### PR TITLE
fix: Windows path compatibility issues preventing CLI initialization

### DIFF
--- a/moai-adk-ts/src/core/installer/template-processor.ts
+++ b/moai-adk-ts/src/core/installer/template-processor.ts
@@ -43,7 +43,8 @@ export class TemplateProcessor {
    * @private
    */
   private tryPackageRelativeTemplates(currentDir: string): string | null {
-    const packageRoot = path.resolve(currentDir, '../../..');
+    // For bundled dist/cli/index.js: dist/cli -> ../.. -> package root
+    const packageRoot = path.resolve(currentDir, '../..');
     const packageTemplates = path.join(packageRoot, 'templates');
 
     if (fs.existsSync(packageTemplates)) {
@@ -67,7 +68,8 @@ export class TemplateProcessor {
    * @private
    */
   private tryDevelopmentTemplates(currentDir: string): string | null {
-    const devTemplates = path.resolve(currentDir, '../../../templates');
+    // For bundled dist/cli/index.js: dist/cli -> ../../templates
+    const devTemplates = path.resolve(currentDir, '../../templates');
 
     if (fs.existsSync(devTemplates)) {
       logger.debug('Found templates in development directory', {

--- a/moai-adk-ts/src/utils/validators/path-validator.ts
+++ b/moai-adk-ts/src/utils/validators/path-validator.ts
@@ -118,9 +118,12 @@ export async function validatePath(
 
 /**
  * Check for dangerous path patterns
+ * Windows drive letters (C:, D:, etc.) are excluded from validation
  */
 function containsDangerousPathPatterns(inputPath: string): boolean {
-  return DANGEROUS_PATH_PATTERNS.some(pattern => pattern.test(inputPath));
+  // Remove Windows drive letter before checking (e.g., "C:\" -> "\")
+  const pathWithoutDrive = inputPath.replace(/^[A-Za-z]:/, '');
+  return DANGEROUS_PATH_PATTERNS.some(pattern => pattern.test(pathWithoutDrive));
 }
 
 /**

--- a/moai-adk-ts/src/utils/version.ts
+++ b/moai-adk-ts/src/utils/version.ts
@@ -8,6 +8,7 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 /**
  * Package information interface
@@ -28,25 +29,17 @@ export interface PackageInfo {
  */
 export function getPackageInfo(): PackageInfo {
   try {
-    // Use import.meta.url to find package root
-    // Note: This is a workaround since we can't use import.meta.url in a regular function
-    // We'll search from current file location or use process.cwd() as fallback
+    // Convert import.meta.url to file path (handles Windows paths correctly)
+    const currentFilePath = fileURLToPath(import.meta.url);
+    const currentDir = path.dirname(currentFilePath);
     let packageJsonPath: string;
 
     // Try to find package root from common locations
+    // For bundled dist/cli/index.js: dist/cli -> ../.. -> package root
     const possibleRoots = [
       // Try from current module (if running from dist/ or src/)
-      path.resolve(
-        new URL('.', import.meta.url).pathname,
-        '..',
-        '..',
-        'package.json'
-      ),
-      path.resolve(
-        new URL('.', import.meta.url).pathname,
-        '..',
-        'package.json'
-      ),
+      path.resolve(currentDir, '..', '..', 'package.json'),
+      path.resolve(currentDir, '..', 'package.json'),
       // Fallback to cwd
       path.resolve(process.cwd(), 'package.json'),
     ];


### PR DESCRIPTION
## 🐛 Problem

On Windows systems, `moai init` command was completely broken with three critical issues:

1. **Path validation error**: `"Path contains dangerous patterns"`
2. **Template installation failure**: No hooks, commands, or agents installed
3. **Version display bug**: Always showing fallback `"0.0.1"` instead of actual version

All features failed, making the CLI unusable on Windows.

## 🔍 Root Causes

All three issues stem from improper Windows path handling:

### 1. Path Validator Bug
**File**: `src/utils/validators/path-validator.ts:122-124`

```typescript
// ❌ BEFORE: Rejects all Windows paths
function containsDangerousPathPatterns(inputPath: string): boolean {
  return DANGEROUS_PATH_PATTERNS.some(pattern => pattern.test(inputPath));
}
```

**Problem**: Pattern `/[<>:"|?*]/` flags the colon in `C:\` as dangerous, rejecting all Windows absolute paths.

```typescript
// ✅ AFTER: Strips drive letter before validation  
function containsDangerousPathPatterns(inputPath: string): boolean {
  const pathWithoutDrive = inputPath.replace(/^[A-Za-z]:/, '');
  return DANGEROUS_PATH_PATTERNS.some(pattern => pattern.test(pathWithoutDrive));
}
```

### 2. Template Path Resolution Bug
**File**: `src/core/installer/template-processor.ts:45-47, 75-77`

```typescript
// ❌ BEFORE: Wrong path depth
const packageRoot = path.resolve(currentDir, '../../..');  // dist/cli -> ../../.. 
const packageTemplates = path.join(packageRoot, 'templates');
// Result: C:\...\moai\templates ❌ (missing moai-adk-ts)
```

**Problem**: Bundled code is in `dist/cli/index.js`, so `../../..` goes too far up.

```typescript
// ✅ AFTER: Correct path depth for bundled structure
const packageRoot = path.resolve(currentDir, '../..');  // dist/cli -> ../..
const packageTemplates = path.join(packageRoot, 'templates'); 
// Result: C:\...\moai\moai-adk-ts\templates ✅
```

### 3. Version Detection Bug  
**File**: `src/utils/version.ts:39-48`

```typescript
// ❌ BEFORE: Broken on Windows
const possibleRoots = [
  path.resolve(
    new URL('.', import.meta.url).pathname,  // Returns /C:/Users/... on Windows
    '..',
    'package.json'
  ),
];
```

**Problem**: On Windows, `URL.pathname` returns `/C:/Users/...` with a leading slash, breaking `path.resolve()`.

```typescript
// ✅ AFTER: Proper cross-platform path conversion
import { fileURLToPath } from 'node:url';

const currentFilePath = fileURLToPath(import.meta.url);  // C:\Users\... (no leading slash)
const currentDir = path.dirname(currentFilePath);
const possibleRoots = [
  path.resolve(currentDir, '..', 'package.json'),
];
```

## 💻 Testing Environment

- **OS**: Windows 11 (Build 26100)  
- **Node.js**: v22.20.0
- **npm**: 11.6.1
- **Shell**: PowerShell
- **Terminal**: Windows Terminal

## ✅ Verification

### Before Fix
```bash
$ moai init .
[ERROR] Path contains dangerous patterns
# No files installed, version shows 0.0.1
```

### After Fix
```bash
$ moai --version
0.2.6  # ✅ Correct version

$ moai init . --yes
✅ Initialization Completed Successfully!
  📄 Files: 35 created
  
# ✅ All installed correctly:
$ ls .claude/hooks/alfred/
policy-block.cjs  pre-write-guard.cjs  session-notice.cjs  tag-enforcer.cjs

$ ls .claude/commands/alfred/
1-spec.md  2-build.md  3-sync.md  8-project.md  9-update.md
```

## 📝 Changes

### Modified Files
1. `src/utils/validators/path-validator.ts` - Strip Windows drive before pattern matching
2. `src/core/installer/template-processor.ts` - Fix relative path depth for bundled code  
3. `src/utils/version.ts` - Use `fileURLToPath()` for Windows compatibility

### Impact
- ✅ **No breaking changes** - Only fixes existing bugs
- ✅ **Cross-platform** - macOS/Linux unaffected  
- ✅ **Minimal scope** - Only utility/helper functions modified

## 🙏 Request

These fixes resolve critical bugs that completely prevented Windows users from using moai-adk CLI. 

**Please consider merging** to enable Windows support in the next release.

---

🤖 **Fixed with Claude Code**  
https://claude.com/claude-code

**Note**: This is a community contribution for bug fixing reference. Feel free to adapt or modify as needed.