### PR TITLE
🏗️ [SPEC-PLUGIN-001/002/003] Claude Code 플러그인 전용 전환

### DIFF
--- a/.moai/specs/SPEC-PLUGIN-001/acceptance.md
+++ b/.moai/specs/SPEC-PLUGIN-001/acceptance.md
@@ -1,0 +1,324 @@
+# SPEC-PLUGIN-001 인수 기준 (Acceptance Criteria)
+
+> **플러그인 구조 검증 시나리오**
+
+---
+
+## 📋 인수 기준 개요
+
+이 문서는 SPEC-PLUGIN-001의 완료 조건을 Given-When-Then 형식으로 정의합니다.
+
+---
+
+## 🧪 테스트 시나리오
+
+### 시나리오 1: 플러그인 매니페스트 검증
+
+**목적**: `plugin.json`이 표준 구조를 따르는지 검증
+
+**Given**:
+- `.claude-plugin/plugin.json` 파일이 존재한다
+- 필수 필드 `name`, `version`이 정의되어 있다
+
+**When**:
+- Claude Code가 플러그인을 로드한다
+
+**Then**:
+- 플러그인이 정상적으로 로드된다
+- `name`이 소문자와 하이픈만 사용한다 (`moai-adk`)
+- `version`이 Semantic Versioning을 따른다 (`0.3.0`)
+- `description`, `author`, `homepage`, `license` 메타데이터가 존재한다
+
+**검증 방법**:
+```bash
+# JSON 구조 검증
+jq -e '.name, .version, .description, .author' .claude-plugin/plugin.json
+
+# name 형식 검증 (소문자, 하이픈만)
+jq -r '.name' .claude-plugin/plugin.json | grep -E '^[a-z-]+$'
+
+# version SemVer 검증
+jq -r '.version' .claude-plugin/plugin.json | grep -E '^\d+\.\d+\.\d+$'
+```
+
+---
+
+### 시나리오 2: 디렉토리 구조 검증
+
+**목적**: 플러그인 표준 디렉토리 구조를 따르는지 검증
+
+**Given**:
+- MoAI-ADK 프로젝트 루트 디렉토리가 존재한다
+
+**When**:
+- 디렉토리 구조를 검사한다
+
+**Then**:
+- `.claude-plugin/` 디렉토리가 존재한다
+- `commands/alfred/` 디렉토리가 존재하고 비어있지 않다
+- `agents/alfred/` 디렉토리가 존재하고 비어있지 않다
+- `hooks/` 디렉토리가 존재하고 `hooks.json`을 포함한다
+- `scripts/` 디렉토리가 존재한다
+- `templates/` 디렉토리가 기존과 동일하게 유지된다
+
+**검증 방법**:
+```bash
+# 필수 디렉토리 존재 확인
+test -d .claude-plugin && echo "✅ .claude-plugin 존재"
+test -d commands/alfred && echo "✅ commands/alfred 존재"
+test -d agents/alfred && echo "✅ agents/alfred 존재"
+test -d hooks && echo "✅ hooks 존재"
+test -d scripts && echo "✅ scripts 존재"
+
+# hooks.json 존재 확인
+test -f hooks/hooks.json && echo "✅ hooks.json 존재"
+
+# commands, agents 디렉토리 비어있지 않은지 확인
+test "$(ls -A commands/alfred)" && echo "✅ commands/alfred 비어있지 않음"
+test "$(ls -A agents/alfred)" && echo "✅ agents/alfred 비어있지 않음"
+```
+
+---
+
+### 시나리오 3: hooks.json 변환 검증
+
+**목적**: hooks.json이 표준 형식을 따르고 `${CLAUDE_PLUGIN_ROOT}`를 사용하는지 검증
+
+**Given**:
+- `hooks/hooks.json` 파일이 존재한다
+
+**When**:
+- hooks.json 내용을 파싱한다
+
+**Then**:
+- `PostToolUse` 후크가 정의되어 있다
+- `PreToolUse` 후크가 정의되어 있다 (선택적)
+- 모든 스크립트 경로가 `${CLAUDE_PLUGIN_ROOT}`를 사용한다
+- `matcher` 필드가 유효한 정규식이다
+
+**검증 방법**:
+```bash
+# PostToolUse 후크 존재 확인
+jq -e '.hooks.PostToolUse' hooks/hooks.json
+
+# ${CLAUDE_PLUGIN_ROOT} 사용 확인
+grep -q '${CLAUDE_PLUGIN_ROOT}' hooks/hooks.json && echo "✅ CLAUDE_PLUGIN_ROOT 사용"
+
+# matcher 필드 검증
+jq -r '.hooks.PostToolUse[].matcher' hooks/hooks.json | grep -E '^[A-Za-z|]+$'
+```
+
+---
+
+### 시나리오 4: 환경변수 경로 참조 검증
+
+**목적**: 모든 내부 파일 참조가 `${CLAUDE_PLUGIN_ROOT}`를 사용하는지 검증
+
+**Given**:
+- `plugin.json`과 `hooks.json`이 존재한다
+
+**When**:
+- 파일 내 경로 참조를 검사한다
+
+**Then**:
+- `plugin.json`의 `commands`, `agents`, `hooks` 경로는 상대 경로(`./`로 시작)를 사용한다
+- `hooks.json`의 스크립트 경로는 `${CLAUDE_PLUGIN_ROOT}`를 사용한다
+- `mcpServers` 정의의 args는 `${CLAUDE_PLUGIN_ROOT}`를 사용한다
+
+**검증 방법**:
+```bash
+# plugin.json 상대 경로 검증
+jq -r '.commands, .agents, .hooks' .claude-plugin/plugin.json | grep -E '^\.\/'
+
+# hooks.json 환경변수 사용 검증
+jq -r '.hooks.PostToolUse[].hooks[].command' hooks/hooks.json | grep -q '${CLAUDE_PLUGIN_ROOT}'
+
+# mcpServers 환경변수 사용 검증
+jq -r '.mcpServers[].args[]' .claude-plugin/plugin.json | grep -q '${CLAUDE_PLUGIN_ROOT}'
+```
+
+---
+
+### 시나리오 5: 플러그인 활성화 검증
+
+**목적**: 플러그인이 Claude Code에서 정상적으로 활성화되는지 검증
+
+**Given**:
+- 플러그인 구조가 완성되어 있다
+- Claude Code가 설치되어 있다
+
+**When**:
+- Claude Code를 시작한다
+
+**Then**:
+- `/alfred:1-spec` 커맨드가 사용 가능하다
+- `/alfred:2-build` 커맨드가 사용 가능하다
+- `/alfred:3-sync` 커맨드가 사용 가능하다
+- `@agent-spec-builder` 에이전트가 호출 가능하다
+- `@agent-code-builder` 에이전트가 호출 가능하다
+
+**검증 방법** (수동):
+```
+1. Claude Code 실행
+2. 프로젝트 디렉토리 열기
+3. `/alfred:1-spec` 입력 후 자동완성 확인
+4. `@agent-spec-builder` 입력 후 에이전트 활성화 확인
+5. 에러 메시지 없이 정상 실행 확인
+```
+
+---
+
+### 시나리오 6: PostToolUse 후크 실행 검증
+
+**목적**: Write/Edit 도구 사용 후 자동 포맷팅이 실행되는지 검증
+
+**Given**:
+- `hooks/hooks.json`에 PostToolUse 후크가 정의되어 있다
+- `scripts/format-code.sh` 스크립트가 실행 가능하다
+
+**When**:
+- Claude Code가 파일을 Write 또는 Edit한다
+
+**Then**:
+- PostToolUse 후크가 트리거된다
+- `format-code.sh` 스크립트가 실행된다
+- 포맷팅이 적용된 파일이 저장된다
+- 에러 발생 시 경고 메시지가 표시되지만 작업은 계속된다
+
+**검증 방법** (수동):
+```
+1. Claude Code에서 "테스트 파일 생성" 요청
+2. 파일 생성 완료 후 로그 확인
+3. PostToolUse 후크 실행 로그 확인
+4. 생성된 파일의 포맷팅 상태 확인
+```
+
+---
+
+## ✅ 완료 조건 (Definition of Done)
+
+### 필수 조건
+
+- [x] `.claude-plugin/plugin.json` 생성 완료
+- [x] `hooks/hooks.json` 생성 완료
+- [x] `scripts/` 디렉토리 및 기본 스크립트 생성
+- [x] 필수 필드 7개 모두 포함 (`name`, `version`, `description`, `author`, `homepage`, `license`, `commands`)
+- [ ] 모든 테스트 시나리오 통과
+- [ ] 플러그인 활성화 성공
+
+### 선택 조건 (권장)
+
+- [ ] `scripts/format-code.sh` 동작 확인
+- [ ] `scripts/validate-spec.sh` 동작 확인
+- [ ] MCP 서버 통합 (선택)
+- [ ] 마이그레이션 가이드 문서 작성
+
+---
+
+## 🧪 품질 게이트
+
+### TRUST 5원칙 검증
+
+#### T - Test First
+- [ ] 플러그인 구조 검증 테스트 작성 (`tests/plugin/structure.test.ts`)
+- [ ] hooks.json 파싱 테스트 작성
+- [ ] 환경변수 경로 검증 테스트 작성
+
+#### R - Readable
+- [ ] `plugin.json` 주석 추가 (JSON 주석 불가 시 README 참조)
+- [ ] `hooks.json` 주석 추가
+- [ ] 디렉토리 구조 다이어그램 작성
+
+#### U - Unified
+- [ ] TypeScript 타입 정의 (`types/plugin.d.ts`)
+- [ ] JSON Schema 검증 (선택)
+
+#### S - Secured
+- [ ] 스크립트 실행 권한 검증 (`chmod +x scripts/*.sh`)
+- [ ] 경로 인젝션 방지
+- [ ] 환경변수 검증
+
+#### T - Trackable
+- [ ] `@SPEC:PLUGIN-001` TAG 부여
+- [ ] `@CODE:PLUGIN-001` TAG 부여
+- [ ] `@TEST:PLUGIN-001` TAG 부여
+- [ ] TAG 체인 무결성 검증
+
+---
+
+## 📊 성능 기준
+
+### 플러그인 로딩 시간
+
+- **목표**: Claude Code 시작 후 1초 내 플러그인 활성화
+- **측정 방법**: Claude Code 로그에서 플러그인 로딩 시간 확인
+
+### 후크 실행 시간
+
+- **목표**: PostToolUse 후크 실행 시간 < 3초
+- **측정 방법**: `time ${CLAUDE_PLUGIN_ROOT}/scripts/format-code.sh`
+
+---
+
+## 🔍 검증 체크리스트
+
+### 자동 검증 (스크립트)
+
+```bash
+#!/bin/bash
+# validate-plugin.sh
+
+echo "🔍 플러그인 구조 검증 시작..."
+
+# 1. 필수 파일 존재 확인
+test -f .claude-plugin/plugin.json || { echo "❌ plugin.json 없음"; exit 1; }
+test -f hooks/hooks.json || { echo "❌ hooks.json 없음"; exit 1; }
+
+# 2. JSON 구조 검증
+jq -e '.name, .version' .claude-plugin/plugin.json > /dev/null || { echo "❌ plugin.json 형식 오류"; exit 1; }
+
+# 3. 환경변수 사용 확인
+grep -q '${CLAUDE_PLUGIN_ROOT}' hooks/hooks.json || { echo "⚠️ CLAUDE_PLUGIN_ROOT 미사용"; }
+
+# 4. 디렉토리 구조 확인
+for dir in commands/alfred agents/alfred hooks scripts; do
+  test -d "$dir" || { echo "❌ $dir 디렉토리 없음"; exit 1; }
+done
+
+echo "✅ 모든 검증 통과"
+```
+
+### 수동 검증 (사용자)
+
+- [ ] Claude Code 실행 및 플러그인 활성화 확인
+- [ ] `/alfred:1-spec` 커맨드 실행 테스트
+- [ ] `@agent-spec-builder` 에이전트 호출 테스트
+- [ ] PostToolUse 후크 실행 확인
+- [ ] 에러 로그 없음 확인
+
+---
+
+## 📝 다음 단계
+
+### TDD 구현 순서
+
+1. **RED**: 테스트 작성
+   - `tests/plugin/structure.test.ts`
+   - `tests/plugin/hooks.test.ts`
+   - `tests/plugin/validation.test.ts`
+
+2. **GREEN**: 최소 구현
+   - `.claude-plugin/plugin.json` 작성
+   - `hooks/hooks.json` 작성
+   - `scripts/format-code.sh` 작성
+
+3. **REFACTOR**: 품질 개선
+   - 스크립트 최적화
+   - 에러 처리 강화
+   - 문서화 완성
+
+---
+
+**작성자**: @Goos
+**작성일**: 2025-10-10
+**참조**: @SPEC:PLUGIN-001, @DOC:PLAN-PLUGIN-001

--- a/.moai/specs/SPEC-PLUGIN-001/plan.md
+++ b/.moai/specs/SPEC-PLUGIN-001/plan.md
@@ -1,0 +1,305 @@
+# SPEC-PLUGIN-001 구현 계획
+
+> **플러그인 구조 설계 및 마이그레이션 전략**
+
+---
+
+## 🎯 구현 목표
+
+1. Claude Code 플러그인 표준 구조 정의
+2. `plugin.json` 매니페스트 설계
+3. `hooks.json` 설정 변환
+4. 기존 템플릿 마이그레이션 계획
+
+---
+
+## 📂 디렉토리 구조 설계
+
+### 최종 구조
+
+```
+MoAI-ADK/
+├── .claude-plugin/              # 플러그인 루트 (새로 추가)
+│   └── plugin.json              # 플러그인 매니페스트
+│
+├── commands/                    # Alfred 커맨드 (기존 위치)
+│   └── alfred/
+│       ├── 1-spec.md
+│       ├── 2-build.md
+│       ├── 3-sync.md
+│       └── ...
+│
+├── agents/                      # 전문 에이전트 (기존 위치)
+│   └── alfred/
+│       ├── spec-builder.md
+│       ├── code-builder.md
+│       └── ...
+│
+├── hooks/                       # 후크 설정 (새로 추가)
+│   └── hooks.json               # PostToolUse, PreToolUse 등
+│
+├── templates/                   # 프로젝트 템플릿 (기존 유지)
+│   └── .moai/
+│       ├── project/
+│       └── memory/
+│
+├── scripts/                     # 자동화 스크립트 (새로 추가)
+│   ├── format-code.sh           # 코드 포맷팅
+│   └── validate-spec.sh         # SPEC 검증
+│
+├── moai-adk-ts/                 # TypeScript 구현 (기존 유지)
+│   ├── src/
+│   └── tests/
+│
+└── .mcp.json                    # MCP 서버 설정 (선택)
+```
+
+### 기존 구조와의 차이점
+
+| 항목 | 기존 | 신규 | 변경 내용 |
+|------|------|------|-----------|
+| 플러그인 루트 | `.claude/` | `.claude-plugin/` | 표준 디렉토리명 |
+| 매니페스트 | `settings.json` | `plugin.json` | 표준 파일명 |
+| 후크 설정 | `settings.json` 내부 | `hooks/hooks.json` | 분리된 파일 |
+| 환경변수 | 없음 | `${CLAUDE_PLUGIN_ROOT}` | 경로 참조 표준화 |
+
+---
+
+## 🔧 plugin.json 매니페스트 설계
+
+### 핵심 필드
+
+```json
+{
+  "name": "moai-adk",
+  "version": "0.3.0",
+  "description": "MoAI Agentic Development Kit - SPEC-First TDD Framework with Alfred SuperAgent",
+  "author": "MoAI (modu.ai)",
+  "homepage": "https://github.com/modu-ai/moai-adk",
+  "license": "MIT",
+
+  "commands": "./commands/alfred",
+  "agents": "./agents/alfred",
+  "hooks": "./hooks/hooks.json",
+
+  "mcpServers": {
+    "moai-adk-server": {
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/moai-adk-ts/dist/mcp-server.js"]
+    }
+  }
+}
+```
+
+### 필드 설명
+
+| 필드 | 타입 | 필수 | 설명 |
+|------|------|------|------|
+| `name` | string | ✅ | 플러그인 고유 ID (소문자, 하이픈) |
+| `version` | string | ✅ | Semantic Version (0.3.0) |
+| `description` | string | ⚠️ | 플러그인 설명 |
+| `author` | string | ⚠️ | 작성자 |
+| `homepage` | string | ⚠️ | 프로젝트 홈페이지 |
+| `license` | string | ⚠️ | 라이선스 (MIT, Apache-2.0 등) |
+| `commands` | string | ⚠️ | 커맨드 디렉토리 상대 경로 |
+| `agents` | string | ⚠️ | 에이전트 디렉토리 상대 경로 |
+| `hooks` | string | ⚠️ | hooks.json 파일 경로 |
+| `mcpServers` | object | ⚠️ | MCP 서버 정의 (선택) |
+
+---
+
+## 🪝 hooks.json 설계
+
+### 기존 settings.json 구조 (참고)
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npm run format"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### 신규 hooks/hooks.json 구조
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/format-code.sh"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/validate-spec.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### 후크 타입 설명
+
+| 후크 타입 | 트리거 시점 | 사용 사례 |
+|----------|-------------|----------|
+| `PreToolUse` | 도구 실행 전 | 파일 검증, 백업, 사전 체크 |
+| `PostToolUse` | 도구 실행 후 | 포맷팅, 린트, TAG 업데이트 |
+
+---
+
+## 🔄 마이그레이션 전략
+
+### 1차 목표: 구조 변경
+
+- ✅ `.claude-plugin/` 디렉토리 생성
+- ✅ `plugin.json` 작성
+- ✅ `hooks/hooks.json` 분리
+- ✅ `scripts/` 디렉토리 추가
+
+### 2차 목표: 호환성 유지
+
+- ✅ 기존 `commands/`, `agents/` 디렉토리 위치 유지
+- ✅ `templates/` 디렉토리 구조 보존
+- ✅ `moai-adk-ts/` 구현 코드 변경 없음
+
+### 3차 목표: 자동화 스크립트
+
+- ✅ `scripts/format-code.sh` - Biome 기반 포맷팅
+- ✅ `scripts/validate-spec.sh` - SPEC 메타데이터 검증
+- ✅ `scripts/sync-tags.sh` - TAG 체인 검증 자동화
+
+---
+
+## 🛠️ 기술적 접근 방법
+
+### 환경변수 활용
+
+**문제점**:
+- 절대 경로 하드코딩 시 플러그인 이식성 저하
+- 사용자별 경로 차이로 인한 호환성 문제
+
+**해결책**:
+- `${CLAUDE_PLUGIN_ROOT}` 환경변수 사용
+- 모든 내부 파일 참조에 이 변수 활용
+
+**예시**:
+```json
+{
+  "command": "${CLAUDE_PLUGIN_ROOT}/scripts/format-code.sh"
+}
+```
+
+### 상대 경로 규칙
+
+**규칙**:
+- 외부 파일 참조: `./`로 시작
+- 내부 파일 참조: `${CLAUDE_PLUGIN_ROOT}` 사용
+
+**예시**:
+```json
+{
+  "commands": "./commands/alfred",
+  "agents": "./agents/alfred"
+}
+```
+
+---
+
+## 🎯 우선순위별 마일스톤
+
+### 1차 마일스톤: 기본 구조 확립
+
+- [ ] `.claude-plugin/plugin.json` 작성
+- [ ] `hooks/hooks.json` 작성
+- [ ] `scripts/` 디렉토리 생성 및 기본 스크립트 추가
+- [ ] 디렉토리 구조 문서화
+
+### 2차 마일스톤: 기능 검증
+
+- [ ] 플러그인 설치 테스트
+- [ ] 커맨드 로딩 검증
+- [ ] 에이전트 활성화 검증
+- [ ] 후크 실행 검증
+
+### 3차 마일스톤: 자동화 강화
+
+- [ ] PostToolUse 후크로 자동 포맷팅
+- [ ] PreToolUse 후크로 SPEC 검증
+- [ ] TAG 체인 자동 검증 스크립트
+
+### 최종 마일스톤: 문서화 및 배포
+
+- [ ] 플러그인 구조 가이드 작성
+- [ ] 마이그레이션 가이드 작성
+- [ ] 배포 체크리스트 작성
+
+---
+
+## ⚠️ 리스크 및 대응 방안
+
+### 리스크 1: 기존 사용자 호환성
+
+**리스크**:
+- 기존 `.claude/settings.json` 사용자가 업데이트 시 설정 유실
+
+**대응**:
+- 마이그레이션 스크립트 제공
+- 자동 감지 및 경고 메시지
+
+### 리스크 2: 환경변수 미지원
+
+**리스크**:
+- 일부 환경에서 `${CLAUDE_PLUGIN_ROOT}` 미지원 가능성
+
+**대응**:
+- Fallback 경로 제공
+- 설치 시 환경변수 검증
+
+### 리스크 3: 성능 저하
+
+**리스크**:
+- 후크 실행으로 인한 도구 사용 지연
+
+**대응**:
+- 비동기 후크 실행
+- 타임아웃 설정 (5초)
+
+---
+
+## 📝 다음 단계
+
+1. **SPEC 승인 후**: `/alfred:2-build SPEC-PLUGIN-001` 실행
+2. **TDD 구현**:
+   - RED: 플러그인 구조 검증 테스트
+   - GREEN: `plugin.json`, `hooks.json` 생성
+   - REFACTOR: 스크립트 최적화
+3. **문서 동기화**: `/alfred:3-sync` 실행
+
+---
+
+**작성자**: @Goos
+**작성일**: 2025-10-10
+**참조**: @SPEC:PLUGIN-001

--- a/.moai/specs/SPEC-PLUGIN-001/spec.md
+++ b/.moai/specs/SPEC-PLUGIN-001/spec.md
@@ -1,0 +1,129 @@
+---
+# 필수 필드 (7개)
+id: PLUGIN-001
+version: 0.0.1
+status: draft
+created: 2025-10-10
+updated: 2025-10-10
+author: @Goos
+priority: high
+
+# 선택 필드 - 분류/메타
+category: refactor
+labels:
+  - claude-code
+  - plugin
+  - architecture
+
+# 선택 필드 - 관계
+depends_on:
+  - STRUCTURE-001
+
+# 선택 필드 - 범위
+scope:
+  packages:
+    - .claude-plugin/
+    - moai-adk-ts/templates/.claude/
+  files:
+    - plugin.json
+    - hooks.json
+---
+
+# @SPEC:PLUGIN-001: Claude Code 플러그인 구조 설계
+
+## HISTORY
+
+### v0.0.1 (2025-10-10)
+- **INITIAL**: Claude Code 플러그인 구조 설계 SPEC 작성
+- **AUTHOR**: @Goos
+- **SCOPE**: 플러그인 디렉토리 구조, 매니페스트 설계, hooks 변환
+- **CONTEXT**: MoAI-ADK를 npm 패키지에서 Claude Code 플러그인 전용으로 전환
+
+---
+
+## 📋 개요
+
+MoAI-ADK를 npm 패키지 기반에서 Claude Code 플러그인 전용 프로젝트로 전환합니다. 기존 CLI 기능을 플러그인 커맨드로 대체하고, 표준 플러그인 디렉토리 구조 및 매니페스트를 설계합니다.
+
+## 🎯 목표
+
+1. Claude Code 플러그인 표준 구조 정의
+2. `.claude-plugin/plugin.json` 매니페스트 설계
+3. `hooks/hooks.json` 변환 (settings.json → hooks.json)
+4. `${CLAUDE_PLUGIN_ROOT}` 환경변수 기반 경로 체계 확립
+5. 기존 템플릿과의 호환성 유지
+
+## 📝 EARS 요구사항
+
+### Ubiquitous Requirements (기본 기능)
+
+1. **플러그인 구조 표준화**
+   - 시스템은 `.claude-plugin/` 디렉토리를 플러그인 루트로 사용해야 한다
+   - 시스템은 `plugin.json` 매니페스트를 필수로 제공해야 한다
+   - 시스템은 `commands/`, `agents/`, `hooks/`, `templates/` 디렉토리 구조를 따라야 한다
+
+2. **매니페스트 필드**
+   - 시스템은 `name`, `version` 필수 필드를 포함해야 한다
+   - 시스템은 `description`, `author`, `homepage`, `license` 메타데이터를 제공해야 한다
+   - 시스템은 `commands`, `agents`, `hooks` 경로를 명시해야 한다
+
+3. **환경변수 사용**
+   - 시스템은 `${CLAUDE_PLUGIN_ROOT}` 변수를 모든 내부 경로 참조에 사용해야 한다
+   - 시스템은 상대 경로는 `./`로 시작하도록 강제해야 한다
+
+### Event-driven Requirements (이벤트 기반)
+
+1. **플러그인 활성화**
+   - WHEN 플러그인이 설치되면, 시스템은 `plugin.json`을 파싱해야 한다
+   - WHEN 플러그인이 활성화되면, 시스템은 `commands/`, `agents/` 디렉토리를 로드해야 한다
+
+2. **후크 실행**
+   - WHEN Write 또는 Edit 도구가 실행되면, 시스템은 PostToolUse 후크를 트리거해야 한다
+   - WHEN 후크 실행이 실패하면, 시스템은 에러 로그를 출력하고 작업을 계속해야 한다
+
+### State-driven Requirements (상태 기반)
+
+1. **개발 모드**
+   - WHILE 개발 모드일 때, 시스템은 상세한 플러그인 로딩 로그를 출력해야 한다
+   - WHILE 디버그 모드일 때, 시스템은 `${CLAUDE_PLUGIN_ROOT}` 경로를 표시해야 한다
+
+2. **활성화 상태**
+   - WHILE 플러그인이 활성화되어 있을 때, 시스템은 `/alfred:*` 커맨드를 제공해야 한다
+   - WHILE 플러그인이 비활성화되어 있을 때, 시스템은 기본 Claude Code 기능만 제공해야 한다
+
+### Optional Features (선택적 기능)
+
+1. **MCP 서버 통합**
+   - WHERE MCP 서버가 정의되어 있으면, 시스템은 `.mcp.json`을 로드할 수 있다
+
+2. **스크립트 자동화**
+   - WHERE `scripts/` 디렉토리가 존재하면, 시스템은 후크에서 스크립트를 실행할 수 있다
+
+### Constraints (제약사항)
+
+1. **경로 규칙**
+   - IF 내부 파일 참조 시, 절대 경로는 `${CLAUDE_PLUGIN_ROOT}`를 사용해야 한다
+   - IF 외부 파일 참조 시, 상대 경로는 `./`로 시작해야 한다
+
+2. **필수 파일**
+   - IF `plugin.json`이 없으면, 시스템은 플러그인 로드를 실패해야 한다
+   - IF `commands/` 또는 `agents/` 디렉토리가 비어있으면, 경고를 표시해야 한다
+
+3. **버전 호환성**
+   - 플러그인 `version`은 Semantic Versioning을 따라야 한다
+   - `name` 필드는 소문자, 하이픈만 사용해야 한다
+
+## 🔗 추적성 (Traceability)
+
+- **@SPEC:PLUGIN-001** → 이 문서
+- **@TEST:PLUGIN-001** → `tests/plugin/structure.test.ts` (예정)
+- **@CODE:PLUGIN-001** → `.claude-plugin/plugin.json` (예정)
+- **@DOC:PLUGIN-001** → `docs/plugin-structure.md` (예정)
+
+---
+
+## 참조
+
+- **Claude Code 플러그인 참조**: https://docs.claude.com/en/docs/claude-code/plugins-reference
+- **관련 SPEC**: @SPEC:STRUCTURE-001
+- **기존 템플릿**: `moai-adk-ts/templates/.claude/`

--- a/.moai/specs/SPEC-PLUGIN-002/acceptance.md
+++ b/.moai/specs/SPEC-PLUGIN-002/acceptance.md
@@ -1,0 +1,390 @@
+# SPEC-PLUGIN-002: 수락 기준
+
+## 📋 개요
+
+본 문서는 `/alfred:8-project` 커맨드 강화 기능의 상세한 수락 기준을 정의합니다.
+
+---
+
+## ✅ Given-When-Then 시나리오
+
+### 시나리오 1: 신규 프로젝트 초기화 (정상 케이스)
+
+**Given**:
+- 사용자가 빈 디렉토리에서 작업 중
+- `.moai/` 디렉토리가 존재하지 않음
+- `${CLAUDE_PLUGIN_ROOT}` 환경변수가 설정되어 있음
+- Node.js가 설치되어 있음
+
+**When**:
+- 사용자가 `/alfred:8-project` 커맨드를 실행
+- Phase 1 분석 후 "진행" 응답
+- 변수 입력:
+  - PROJECT_NAME: "my-awesome-project"
+  - PROJECT_MODE: "team"
+  - PROJECT_DESCRIPTION: "AI-powered development framework"
+  - LOCALE: "ko"
+- Git 초기화: "예"
+
+**Then**:
+- `.moai/` 디렉토리 생성 확인
+- `.moai/config.json` 생성 확인 (렌더링 완료)
+- `.moai/project/product.md`, `structure.md`, `tech.md` 생성 확인
+- `config.json` 내용:
+  ```json
+  {
+    "project": {
+      "name": "my-awesome-project",
+      "mode": "team",
+      "description": "AI-powered development framework",
+      "locale": "ko"
+    }
+  }
+  ```
+- `.git/` 디렉토리 생성 확인 (git init 실행됨)
+- `.gitignore` 파일 생성 확인
+- 완료 메시지 및 다음 단계 안내 표시
+
+---
+
+### 시나리오 2: 기존 프로젝트 갱신 (보존 모드)
+
+**Given**:
+- `.moai/` 디렉토리가 이미 존재
+- `.moai/project/product.md`에 기존 내용이 있음
+- `.moai/config.json`이 있지만 구버전 형식
+
+**When**:
+- 사용자가 `/alfred:8-project` 커맨드를 실행
+- Phase 1 분석 결과: "갱신 모드"
+- "진행" 응답
+
+**Then**:
+- 기존 `product.md` 백업 생성 (예: `product.md.backup-20251010-143022`)
+- 새 `product.md` 생성 (최신 템플릿 적용)
+- 기존 `config.json` 보존 또는 덮어쓰기 확인 프롬프트 표시
+- ⚠️ WARNING 메시지: ".moai/ 디렉토리가 이미 존재합니다 → 갱신 모드로 전환합니다"
+- 완료 메시지: "기존 파일은 백업되었습니다"
+
+---
+
+### 시나리오 3: Node.js 미설치 (대체 전략)
+
+**Given**:
+- Node.js가 설치되지 않음
+- 템플릿 디렉토리에 `config.json.mustache` 존재
+
+**When**:
+- 사용자가 `/alfred:8-project` 커맨드를 실행
+- Phase 1 분석 결과: "Node.js 미설치"
+- "진행" 응답
+
+**Then**:
+- ⚠️ WARNING 메시지: "Node.js가 설치되지 않았습니다 → Mustache 렌더링을 건너뜁니다"
+- 기본값으로 `config.json` 생성:
+  ```json
+  {
+    "project": {
+      "name": "current-directory-name",
+      "mode": "personal",
+      "description": "",
+      "locale": "ko"
+    }
+  }
+  ```
+- ℹ️ INFO 메시지: "수동 렌더링 가이드를 참조하세요"
+- 완료 메시지에 Node.js 설치 권장 포함
+
+---
+
+### 시나리오 4: 템플릿 파일 누락 (에러 케이스)
+
+**Given**:
+- `${CLAUDE_PLUGIN_ROOT}/templates/.moai/config.json.mustache` 파일이 없음
+
+**When**:
+- 사용자가 `/alfred:8-project` 커맨드를 실행
+- Phase 1 분석 수행
+
+**Then**:
+- ❌ CRITICAL 메시지: "필수 템플릿 파일이 없습니다"
+- 에러 메시지:
+  ```
+  ❌ CRITICAL: 필수 템플릿 파일이 없습니다
+    → ${CLAUDE_PLUGIN_ROOT}/templates/.moai/config.json.mustache
+    → 해결: 플러그인을 재설치하거나 템플릿 파일을 수동으로 복사하세요
+  ```
+- 초기화 중단
+- 사용자에게 플러그인 재설치 안내
+
+---
+
+### 시나리오 5: 특수문자 프로젝트명 정규화
+
+**Given**:
+- 사용자가 프로젝트명으로 "My Project (2025)!" 입력
+
+**When**:
+- 변수 수집 단계에서 PROJECT_NAME 입력
+
+**Then**:
+- ⚠️ WARNING 메시지: "프로젝트명에 특수문자가 포함되어 있습니다"
+- 정규화 제안:
+  ```
+  입력: "My Project (2025)!"
+  정규화: "my-project-2025"
+  계속 진행하시겠습니까? (y/n)
+  ```
+- "y" 응답 시 정규화된 이름으로 진행
+- "n" 응답 시 재입력 요청
+
+---
+
+### 시나리오 6: Git 초기화 거부
+
+**Given**:
+- Git이 설치되어 있음
+- 사용자가 Git 초기화를 원하지 않음
+
+**When**:
+- 사용자가 `/alfred:8-project` 커맨드를 실행
+- Git 초기화 프롬프트에서 "아니오" 응답
+
+**Then**:
+- `.git/` 디렉토리 생성되지 않음
+- `.gitignore` 파일 생성되지 않음
+- ℹ️ INFO 메시지: "Git 초기화를 건너뜁니다"
+- 완료 메시지: "나중에 `git init`으로 초기화할 수 있습니다"
+
+---
+
+### 시나리오 7: ${CLAUDE_PLUGIN_ROOT} 미설정 (에러 케이스)
+
+**Given**:
+- `${CLAUDE_PLUGIN_ROOT}` 환경변수가 설정되지 않음
+
+**When**:
+- 사용자가 `/alfred:8-project` 커맨드를 실행
+- Phase 1 환경 분석 수행
+
+**Then**:
+- ❌ CRITICAL 메시지: "플러그인 루트 경로를 찾을 수 없습니다"
+- 에러 메시지:
+  ```
+  ❌ CRITICAL: 플러그인 루트 경로를 찾을 수 없습니다
+    → ${CLAUDE_PLUGIN_ROOT} 환경변수가 설정되지 않았습니다
+    → 해결: Claude Code 플러그인 설치 상태를 확인하세요
+  ```
+- 초기화 중단
+- 사용자에게 플러그인 설치 안내
+
+---
+
+### 시나리오 8: 권한 에러 (.moai/ 생성 실패)
+
+**Given**:
+- 현재 디렉토리에 쓰기 권한이 없음
+
+**When**:
+- 사용자가 `/alfred:8-project` 커맨드를 실행
+- `mkdir -p .moai/` 명령 실행
+
+**Then**:
+- ❌ CRITICAL 메시지: ".moai/ 디렉토리 생성 실패: 권한 거부"
+- 에러 메시지:
+  ```
+  ❌ CRITICAL: .moai/ 디렉토리 생성 실패
+    → 권한 거부 (Permission Denied)
+    → 해결: chmod 755 . 또는 다른 디렉토리에서 실행하세요
+  ```
+- 초기화 중단
+- 권한 확인 명령어 안내: `ls -ld .`
+
+---
+
+### 시나리오 9: render-template.cjs 실행 실패
+
+**Given**:
+- Node.js가 설치되어 있음
+- `scripts/render-template.cjs`가 존재
+- mustache npm 패키지가 설치되지 않음
+
+**When**:
+- Mustache 렌더링 단계 실행
+- `node scripts/render-template.cjs` 실행
+
+**Then**:
+- ❌ CRITICAL 메시지: "템플릿 렌더링 실패"
+- 에러 메시지:
+  ```
+  ❌ CRITICAL: 템플릿 렌더링 실패
+    → Error: Cannot find module 'mustache'
+    → 해결:
+      1. cd ${CLAUDE_PLUGIN_ROOT}
+      2. npm install mustache
+      3. /alfred:8-project 재실행
+  ```
+- 대체 전략: 기본값으로 config.json 생성
+- 수동 렌더링 가이드 제공
+
+---
+
+### 시나리오 10: LOCALE 검증 (엣지 케이스)
+
+**Given**:
+- 사용자가 LOCALE으로 "fr" (프랑스어) 입력
+
+**When**:
+- 변수 수집 단계에서 LOCALE 입력
+
+**Then**:
+- ⚠️ WARNING 메시지: "지원하지 않는 LOCALE 값입니다"
+- 기본값 사용:
+  ```
+  ⚠️ WARNING: 지원하지 않는 LOCALE 값입니다
+    → 입력: "fr"
+    → 지원 언어: ko, en, ja, zh
+    → 기본값 "ko"를 사용합니다
+  ```
+- config.json에 `"locale": "ko"` 저장
+- 완료 메시지: "LOCALE을 나중에 .moai/config.json에서 수정할 수 있습니다"
+
+---
+
+## 🧪 품질 게이트 기준
+
+### 1. 기능 완전성
+
+- [ ] 모든 템플릿 파일이 정상적으로 복사됨
+- [ ] Mustache 렌더링이 성공적으로 완료됨
+- [ ] 변수 치환이 정확하게 수행됨
+- [ ] Git 초기화가 선택적으로 동작함
+- [ ] 에러 케이스가 적절히 처리됨
+
+### 2. 성능 기준
+
+- [ ] 전체 초기화 시간 ≤5초
+- [ ] 템플릿 복사 시간 ≤2초
+- [ ] Mustache 렌더링 시간 ≤1초
+
+### 3. 에러 메시지 품질
+
+- [ ] 모든 에러에 심각도 아이콘 표시 (❌ CRITICAL, ⚠️ WARNING, ℹ️ INFO)
+- [ ] 에러 메시지에 컨텍스트와 해결 방법 포함
+- [ ] 사용자 친화적인 언어 사용
+
+### 4. 추적성
+
+- [ ] 모든 생성 파일에 @TAG 주석 포함
+- [ ] render-template.cjs에 `@CODE:PLUGIN-002:SCRIPT` TAG 포함
+- [ ] 8-project.md에 `@CODE:PLUGIN-002` TAG 포함
+
+### 5. 보안
+
+- [ ] 특수문자 입력 시 정규화 수행
+- [ ] 경로 인젝션 방지 (상대 경로 검증)
+- [ ] 민감 정보 로그 출력 금지
+
+---
+
+## 📊 검증 방법 및 도구
+
+### 자동화 테스트
+
+**테스트 파일**: `tests/commands/project-init.test.ts`
+
+**테스트 프레임워크**: Vitest (TypeScript) 또는 pytest (Python)
+
+**테스트 케이스**:
+```typescript
+describe('@TEST:PLUGIN-002 - /alfred:8-project 커맨드', () => {
+  it('신규 프로젝트 초기화 성공', async () => {
+    // Given: 빈 디렉토리
+    // When: 커맨드 실행
+    // Then: .moai/ 디렉토리 및 config.json 생성 확인
+  });
+
+  it('Mustache 렌더링 정확성', async () => {
+    // Given: config.json.mustache 템플릿
+    // When: 변수 매핑 및 렌더링
+    // Then: 변수 치환 확인
+  });
+
+  it('특수문자 프로젝트명 정규화', async () => {
+    // Given: "My Project (2025)!" 입력
+    // When: 정규화 수행
+    // Then: "my-project-2025" 출력 확인
+  });
+
+  it('Node.js 미설치 시 대체 전략', async () => {
+    // Given: Node.js 미설치 환경 모의
+    // When: 커맨드 실행
+    // Then: 기본값으로 config.json 생성 확인
+  });
+
+  it('템플릿 파일 누락 에러 처리', async () => {
+    // Given: config.json.mustache 삭제
+    // When: 커맨드 실행
+    // Then: ❌ CRITICAL 에러 표시 확인
+  });
+});
+```
+
+### 수동 검증
+
+**체크리스트**:
+- [ ] 신규 프로젝트에서 커맨드 실행 → 모든 파일 생성 확인
+- [ ] 기존 프로젝트에서 커맨드 실행 → 백업 및 보존 확인
+- [ ] Node.js 미설치 환경에서 실행 → 대체 전략 동작 확인
+- [ ] 특수문자 입력 → 정규화 프롬프트 표시 확인
+- [ ] Git 초기화 거부 → .git/ 디렉토리 미생성 확인
+
+---
+
+## 🎯 완료 조건 (Definition of Done)
+
+### 코드 완료
+
+- [ ] render-template.cjs 스크립트 작성 완료
+- [ ] 8-project.md 커맨드 로직 강화 완료
+- [ ] 모든 에러 시나리오 처리 코드 작성 완료
+
+### 테스트 완료
+
+- [ ] 유닛 테스트 커버리지 ≥85%
+- [ ] 통합 테스트 통과 (10개 시나리오 모두)
+- [ ] 수동 검증 체크리스트 완료
+
+### 문서 완료
+
+- [ ] plan.md, acceptance.md 작성 완료
+- [ ] render-template.cjs 스크립트 주석 추가
+- [ ] 8-project.md에 사용 예시 추가
+
+### 품질 검증
+
+- [ ] TRUST 5원칙 준수 확인:
+  - **Test First**: 테스트 커버리지 ≥85%
+  - **Readable**: 함수 ≤50 LOC, 복잡도 ≤10
+  - **Unified**: config.json 형식 일관성
+  - **Secured**: 입력 검증 및 정규화
+  - **Trackable**: @TAG 체인 완전성
+
+### Git 워크플로우
+
+- [ ] 브랜치: `feature/SPEC-PLUGIN-002` 생성
+- [ ] 커밋:
+  - 🔴 RED: render-template.cjs 테스트 작성
+  - 🟢 GREEN: render-template.cjs 구현 완료
+  - ♻️ REFACTOR: 8-project.md 로직 강화
+  - 📝 DOCS: plan.md, acceptance.md 작성
+
+### 동기화
+
+- [ ] `/alfred:3-sync` 실행
+- [ ] TAG 체인 무결성 검증
+- [ ] Living Document 생성 확인
+
+---
+
+_이 문서는 SPEC-PLUGIN-002의 수락 기준으로, `/alfred:2-build SPEC-PLUGIN-002` 완료 후 검증에 사용됩니다._

--- a/.moai/specs/SPEC-PLUGIN-002/plan.md
+++ b/.moai/specs/SPEC-PLUGIN-002/plan.md
@@ -1,0 +1,325 @@
+# SPEC-PLUGIN-002: 구현 계획
+
+## 📋 개요
+
+본 문서는 `/alfred:8-project` 커맨드 강화를 위한 상세한 구현 계획을 정의합니다.
+
+---
+
+## 🎯 우선순위별 마일스톤
+
+### 1차 목표: 기본 템플릿 복사 및 렌더링
+
+- **scripts/render-template.cjs 스크립트 작성**
+  - Mustache 템플릿 렌더링 엔진 구현
+  - 변수 매핑 및 파일 출력 로직
+  - 에러 핸들링 및 로깅
+
+- **Phase 1: 환경 분석 강화**
+  - `.moai/` 디렉토리 존재 여부 확인
+  - `${CLAUDE_PLUGIN_ROOT}` 환경변수 검증
+  - Node.js 설치 여부 확인
+
+- **Phase 2: 템플릿 복사 구현**
+  - `${CLAUDE_PLUGIN_ROOT}/templates/.moai` → `.moai` 복사
+  - Mustache 파일 탐지 및 렌더링 실행
+  - 렌더링 완료 후 `.mustache` 파일 정리
+
+### 2차 목표: Git 초기화 및 .gitignore 생성
+
+- **Git 초기화 프롬프트**
+  - 사용자 확인 메시지 표시
+  - `git init` 실행
+  - `.gitignore` 템플릿 복사 또는 생성
+
+- **프로젝트 문서 생성/갱신**
+  - product.md, structure.md, tech.md 생성
+  - 기존 문서가 있을 경우 보존 전략 적용
+
+### 3차 목표: 에러 처리 및 검증
+
+- **경로 검증**
+  - `${CLAUDE_PLUGIN_ROOT}` 유효성 확인
+  - 템플릿 디렉토리 존재 확인
+  - 쓰기 권한 검증
+
+- **변수 검증**
+  - PROJECT_NAME 정규화 (kebab-case)
+  - PROJECT_MODE 값 검증 (personal|team)
+  - LOCALE 값 검증 (ko|en|ja|zh)
+
+- **롤백 전략**
+  - 초기화 실패 시 부분 복사 파일 정리
+  - 백업 복원 메커니즘 (선택적)
+
+---
+
+## 🛠️ 기술적 접근 방법
+
+### 1. render-template.cjs 스크립트 설계
+
+**파일 경로**: `scripts/render-template.cjs`
+
+**핵심 기능**:
+```javascript
+// 1. 템플릿 파일 읽기
+// 2. Mustache 렌더링
+// 3. 출력 파일 작성
+// 4. 에러 핸들링
+
+const Mustache = require('mustache');
+const fs = require('fs');
+const path = require('path');
+
+function renderTemplate(templatePath, outputPath, variables) {
+  // 템플릿 파일 읽기
+  const template = fs.readFileSync(templatePath, 'utf-8');
+
+  // Mustache 렌더링
+  const rendered = Mustache.render(template, variables);
+
+  // 출력 파일 작성
+  fs.writeFileSync(outputPath, rendered, 'utf-8');
+
+  console.log(`✅ Rendered: ${outputPath}`);
+}
+```
+
+**실행 인터페이스**:
+```bash
+node scripts/render-template.cjs \
+  --template .moai/config.json.mustache \
+  --output .moai/config.json \
+  --var PROJECT_NAME="MoAI-ADK" \
+  --var PROJECT_MODE="team" \
+  --var PROJECT_DESCRIPTION="MoAI Agentic Development Kit" \
+  --var LOCALE="ko"
+```
+
+**의존성**:
+```json
+{
+  "dependencies": {
+    "mustache": "^4.2.0"
+  }
+}
+```
+
+### 2. Mustache 변수 매핑 테이블
+
+| 변수명                  | 기본값           | 설명                        | 예시                    |
+| ----------------------- | ---------------- | --------------------------- | ----------------------- |
+| `{{PROJECT_NAME}}`      | 현재 디렉토리명  | 프로젝트 이름               | "MoAI-ADK"              |
+| `{{PROJECT_MODE}}`      | "personal"       | personal 또는 team          | "team"                  |
+| `{{PROJECT_DESCRIPTION}}` | ""              | 프로젝트 설명 (한 줄)       | "SPEC-First TDD Framework" |
+| `{{LOCALE}}`            | "ko"             | 언어 설정 (ko, en, ja, zh)  | "ko"                    |
+
+**변수 수집 전략**:
+1. 현재 디렉토리명으로 PROJECT_NAME 추론
+2. Git 감지 결과로 PROJECT_MODE 제안 (Git 있으면 team, 없으면 personal)
+3. package.json 또는 README.md에서 PROJECT_DESCRIPTION 추출
+4. 시스템 언어 설정으로 LOCALE 추론
+
+### 3. 커맨드 로직 흐름도
+
+```
+/alfred:8-project 실행
+  ↓
+Phase 1: 환경 분석
+  ├─→ .moai/ 존재 확인
+  ├─→ ${CLAUDE_PLUGIN_ROOT} 검증
+  ├─→ Node.js 설치 확인
+  └─→ Git 설치 확인
+  ↓
+사용자 확인 ("진행", "수정", "중단")
+  ↓
+Phase 2-1: 템플릿 복사
+  ├─→ mkdir -p .moai/project .moai/memory .moai/specs
+  ├─→ cp -r ${CLAUDE_PLUGIN_ROOT}/templates/.moai/* .moai/
+  └─→ 복사 완료 확인
+  ↓
+Phase 2-2: 변수 수집
+  ├─→ PROJECT_NAME 입력/추론
+  ├─→ PROJECT_MODE 선택 (personal/team)
+  ├─→ PROJECT_DESCRIPTION 입력
+  └─→ LOCALE 선택 (ko/en/ja/zh)
+  ↓
+Phase 2-3: Mustache 렌더링
+  ├─→ config.json.mustache → config.json
+  ├─→ CLAUDE.md.mustache → CLAUDE.md (선택적)
+  └─→ .mustache 파일 정리
+  ↓
+Phase 2-4: Git 초기화 (선택적)
+  ├─→ 사용자 확인: "Git 초기화 하시겠습니까?"
+  ├─→ git init (yes일 경우)
+  ├─→ .gitignore 생성/복사
+  └─→ 초기 커밋 (선택적)
+  ↓
+최종 보고
+  ├─→ 생성된 파일 목록 표시
+  ├─→ 다음 단계 안내 (/alfred:1-spec)
+  └─→ 완료 메시지
+```
+
+---
+
+## 🏗️ 아키텍처 설계 방향
+
+### 1. 플러그인 경로 체계
+
+**환경변수 활용**:
+- `${CLAUDE_PLUGIN_ROOT}`: Claude Code가 자동 설정하는 플러그인 루트 경로
+- 예: `/Users/user/.claude/plugins/moai-adk`
+
+**템플릿 디렉토리 구조**:
+```
+${CLAUDE_PLUGIN_ROOT}/
+  templates/
+    .moai/
+      config.json.mustache      # 필수 렌더링 대상
+      CLAUDE.md.mustache        # 선택적 렌더링 대상
+      project/
+        product.md
+        structure.md
+        tech.md
+      memory/
+        development-guide.md
+        spec-metadata.md
+      specs/
+        (빈 디렉토리)
+      reports/
+        (빈 디렉토리)
+```
+
+### 2. 에러 처리 시나리오
+
+**시나리오 1: ${CLAUDE_PLUGIN_ROOT} 미설정**
+```
+❌ CRITICAL: 플러그인 루트 경로를 찾을 수 없습니다
+  → ${CLAUDE_PLUGIN_ROOT} 환경변수가 설정되지 않았습니다
+  → 해결: Claude Code 플러그인 설치 상태를 확인하세요
+```
+
+**시나리오 2: .moai/ 디렉토리 이미 존재**
+```
+⚠️ WARNING: .moai/ 디렉토리가 이미 존재합니다
+  → 갱신 모드로 전환합니다
+  → 기존 product.md, structure.md, tech.md는 보존됩니다
+```
+
+**시나리오 3: Node.js 미설치**
+```
+⚠️ WARNING: Node.js가 설치되지 않았습니다
+  → Mustache 렌더링을 건너뜁니다
+  → 수동 렌더링 가이드:
+    1. Node.js 설치: https://nodejs.org
+    2. npm install mustache
+    3. node scripts/render-template.cjs --help
+```
+
+**시나리오 4: 템플릿 파일 누락**
+```
+❌ CRITICAL: 필수 템플릿 파일이 없습니다
+  → ${CLAUDE_PLUGIN_ROOT}/templates/.moai/config.json.mustache
+  → 해결: 플러그인을 재설치하거나 템플릿 파일을 수동으로 복사하세요
+```
+
+**시나리오 5: 특수문자 프로젝트명**
+```
+⚠️ WARNING: 프로젝트명에 특수문자가 포함되어 있습니다
+  → 입력: "My Project (2025)"
+  → 정규화: "my-project-2025"
+  → 계속 진행하시겠습니까? (y/n)
+```
+
+---
+
+## ⚠️ 리스크 및 대응 방안
+
+### 리스크 1: Claude가 Mustache를 직접 렌더링할 수 없음
+
+**영향도**: High
+**발생 확률**: 확정
+**대응 방안**:
+- render-template.cjs Node.js 스크립트로 렌더링 위임
+- Bash 도구로 `node scripts/render-template.cjs` 실행
+- Node.js 미설치 시 대체 전략: 기본값으로 config.json 생성
+
+### 리스크 2: 템플릿 파일 누락 또는 손상
+
+**영향도**: Medium
+**발생 확률**: Low
+**대응 방안**:
+- Phase 1에서 템플릿 파일 무결성 검증
+- 누락 시 기본 템플릿 문자열로 대체
+- 사용자에게 플러그인 재설치 안내
+
+### 리스크 3: 권한 에러 (.moai/ 디렉토리 생성 실패)
+
+**영향도**: High
+**발생 확률**: Low
+**대응 방안**:
+- `mkdir -p .moai/` 실행 전 쓰기 권한 확인
+- 권한 에러 시 `chmod` 명령어 안내
+- 사용자 홈 디렉토리 대체 경로 제안
+
+### 리스크 4: 기존 파일 덮어쓰기 충돌
+
+**영향도**: Medium
+**발생 확률**: Medium
+**대응 방안**:
+- 기존 파일 존재 시 백업 생성 (예: `config.json.backup-YYYYMMDD-HHMMSS`)
+- 사용자에게 덮어쓰기 여부 확인 프롬프트 표시
+- "Legacy Context" 섹션에 기존 내용 보존
+
+---
+
+## 🔍 의존성
+
+### 내부 의존성
+
+- **@SPEC:PLUGIN-001**: Claude Code 플러그인 구조 설계 (필수)
+- **project-manager 에이전트**: 프로젝트 문서 생성 로직 재사용
+
+### 외부 의존성
+
+- **Node.js**: render-template.cjs 실행 환경
+- **mustache npm 패키지**: 템플릿 렌더링 라이브러리
+- **Git**: 선택적 Git 초기화 기능
+
+---
+
+## 📊 성공 기준
+
+### 기능 테스트
+
+- [ ] 신규 프로젝트에서 `.moai/` 디렉토리 생성 확인
+- [ ] config.json.mustache → config.json 렌더링 성공
+- [ ] 변수 치환 정확성 (PROJECT_NAME, PROJECT_MODE, PROJECT_DESCRIPTION, LOCALE)
+- [ ] Git 초기화 선택적 실행 확인
+- [ ] 에러 시나리오 처리 (Node.js 미설치, 템플릿 누락 등)
+
+### 품질 기준
+
+- [ ] render-template.cjs 스크립트 테스트 커버리지 ≥85%
+- [ ] 에러 메시지 명확성 검증
+- [ ] 커맨드 실행 시간 ≤5초
+
+### 사용성 기준
+
+- [ ] 사용자 입력 최소화 (기본값 제공)
+- [ ] 진행 상태 실시간 표시
+- [ ] 완료 메시지 및 다음 단계 안내 제공
+
+---
+
+## 🚀 다음 단계
+
+1. **render-template.cjs 스크립트 작성** (@CODE:PLUGIN-002:SCRIPT)
+2. **8-project.md 커맨드 로직 강화** (@CODE:PLUGIN-002)
+3. **테스트 케이스 작성** (@TEST:PLUGIN-002)
+4. **문서 동기화** (@DOC:PLUGIN-002)
+
+---
+
+_이 문서는 SPEC-PLUGIN-002의 구현 가이드로, `/alfred:2-build SPEC-PLUGIN-002` 실행 시 참조됩니다._

--- a/.moai/specs/SPEC-PLUGIN-002/spec.md
+++ b/.moai/specs/SPEC-PLUGIN-002/spec.md
@@ -1,0 +1,167 @@
+---
+# 필수 필드 (7개)
+id: PLUGIN-002
+version: 0.0.1
+status: draft
+created: 2025-10-10
+updated: 2025-10-10
+author: @Goos
+priority: high
+
+# 선택 필드 - 분류/메타
+category: feature
+labels:
+  - claude-code
+  - initialization
+  - template
+  - mustache
+
+# 선택 필드 - 관계
+depends_on:
+  - PLUGIN-001
+
+# 선택 필드 - 범위
+scope:
+  packages:
+    - .claude/commands/alfred/
+    - scripts/
+  files:
+    - 8-project.md
+    - render-template.cjs
+---
+
+# @SPEC:PLUGIN-002: /alfred:8-project 커맨드 강화 (init 대체)
+
+## HISTORY
+
+### v0.0.1 (2025-10-10)
+- **INITIAL**: /alfred:8-project 커맨드 강화 SPEC 작성
+- **AUTHOR**: @Goos
+- **SCOPE**: 프로젝트 초기화, 템플릿 복사, Mustache 렌더링, Git 초기화
+- **CONTEXT**: npm 패키지 제거로 인한 moai init CLI 대체 기능 구현
+
+---
+
+## 📋 개요
+
+npm 패키지 제거로 인해 `moai init` CLI가 사라졌으므로, `/alfred:8-project` 커맨드를 강화하여 프로젝트 초기화 기능을 완전히 대체합니다. 템플릿 복사, Mustache 렌더링, Git 초기화를 포함한 완전한 초기화 워크플로우를 제공합니다.
+
+## 🎯 목표
+
+1. **템플릿 복사**: `${CLAUDE_PLUGIN_ROOT}/templates/.moai` → `.moai` 디렉토리 복사
+2. **Mustache 렌더링**: config.json.mustache, CLAUDE.md.mustache 자동 렌더링
+3. **Git 초기화**: 선택적 Git 초기화 및 .gitignore 생성
+4. **헬퍼 스크립트**: scripts/render-template.cjs (Mustache 렌더링 전담)
+5. **변수 수집**: 사용자 입력을 통한 PROJECT_NAME, PROJECT_MODE, PROJECT_DESCRIPTION, LOCALE 수집
+
+## 📝 EARS 요구사항
+
+### Ubiquitous Requirements (기본 기능)
+
+1. **프로젝트 초기화 기능**
+   - 시스템은 `/alfred:8-project` 커맨드를 통해 완전한 프로젝트 초기화를 제공해야 한다
+   - 시스템은 `${CLAUDE_PLUGIN_ROOT}/templates/.moai` 디렉토리의 모든 파일을 복사해야 한다
+   - 시스템은 `.mustache` 확장자 파일을 자동 렌더링해야 한다
+
+2. **템플릿 복사 규칙**
+   - 시스템은 `.moai/` 디렉토리가 이미 존재하는지 확인해야 한다
+   - 시스템은 product.md, structure.md, tech.md를 복사하거나 생성해야 한다
+   - 시스템은 config.json.mustache → config.json 렌더링을 수행해야 한다
+
+3. **Mustache 렌더링**
+   - 시스템은 `scripts/render-template.cjs` Node.js 스크립트를 제공해야 한다
+   - 시스템은 `mustache` npm 패키지를 사용하여 템플릿을 렌더링해야 한다
+   - 시스템은 렌더링된 파일에서 `.mustache` 확장자를 제거해야 한다
+
+4. **변수 매핑**
+   - 시스템은 다음 변수를 지원해야 한다:
+     - `{{PROJECT_NAME}}`: 프로젝트 이름
+     - `{{PROJECT_MODE}}`: personal 또는 team
+     - `{{PROJECT_DESCRIPTION}}`: 프로젝트 설명
+     - `{{LOCALE}}`: 언어 설정 (ko, en, ja, zh)
+
+### Event-driven Requirements (이벤트 기반)
+
+1. **커맨드 실행 흐름**
+   - WHEN 사용자가 `/alfred:8-project`를 실행하면, 시스템은 Phase 1 분석을 시작해야 한다
+   - WHEN `.moai/` 디렉토리가 없으면, 시스템은 신규 초기화 모드로 진행해야 한다
+   - WHEN `.moai/` 디렉토리가 존재하면, 시스템은 갱신 모드로 전환해야 한다
+
+2. **템플릿 렌더링 트리거**
+   - WHEN `.mustache` 파일이 발견되면, 시스템은 render-template.cjs를 실행해야 한다
+   - WHEN 렌더링이 완료되면, 시스템은 원본 `.mustache` 파일을 삭제할 수 있다
+   - WHEN 렌더링이 실패하면, 시스템은 에러 메시지를 표시하고 중단해야 한다
+
+3. **Git 초기화 프롬프트**
+   - WHEN 초기화가 완료되면, 시스템은 Git 초기화 여부를 사용자에게 확인해야 한다
+   - WHEN 사용자가 "예"를 선택하면, 시스템은 `git init` 및 `.gitignore` 생성을 수행해야 한다
+   - WHEN 사용자가 "아니오"를 선택하면, 시스템은 Git 초기화를 건너뛰어야 한다
+
+### State-driven Requirements (상태 기반)
+
+1. **초기화 진행 중**
+   - WHILE 초기화가 진행 중일 때, 시스템은 진행 상태를 표시해야 한다
+   - WHILE 파일 복사 중일 때, 시스템은 복사된 파일 목록을 출력해야 한다
+   - WHILE 렌더링 중일 때, 시스템은 렌더링 대상 파일을 표시해야 한다
+
+2. **사용자 입력 대기**
+   - WHILE 사용자 입력을 대기할 때, 시스템은 기본값을 제안해야 한다
+   - WHILE 변수 수집 중일 때, 시스템은 각 변수의 설명을 제공해야 한다
+
+3. **에러 상태**
+   - WHILE 에러가 발생한 상태일 때, 시스템은 상세한 에러 메시지와 해결 방법을 표시해야 한다
+   - WHILE 권한 에러일 때, 시스템은 필요한 권한 및 명령어를 안내해야 한다
+
+### Optional Features (선택적 기능)
+
+1. **고급 설정**
+   - WHERE 사용자가 고급 설정을 요청하면, 시스템은 추가 변수 입력을 제공할 수 있다
+   - WHERE `.mcp.json`이 템플릿에 존재하면, 시스템은 MCP 서버 설정을 복사할 수 있다
+
+2. **Git 초기화**
+   - WHERE Git이 설치되어 있으면, 시스템은 Git 초기화 옵션을 제공할 수 있다
+   - WHERE .gitignore 템플릿이 존재하면, 시스템은 해당 템플릿을 사용할 수 있다
+
+3. **기존 파일 보존**
+   - WHERE 기존 product.md가 존재하면, 시스템은 백업 후 보존할 수 있다
+   - WHERE 기존 config.json이 존재하면, 시스템은 사용자에게 덮어쓰기 여부를 확인할 수 있다
+
+### Constraints (제약사항)
+
+1. **경로 검증**
+   - IF `${CLAUDE_PLUGIN_ROOT}`가 설정되지 않았으면, 시스템은 에러를 표시하고 중단해야 한다
+   - IF `.moai/` 디렉토리 생성 권한이 없으면, 시스템은 권한 에러를 표시해야 한다
+
+2. **필수 변수 검증**
+   - IF PROJECT_NAME이 비어있으면, 시스템은 기본값(현재 디렉토리명)을 사용해야 한다
+   - IF PROJECT_MODE가 "personal" 또는 "team"이 아니면, 시스템은 에러를 표시해야 한다
+   - IF LOCALE이 지원되지 않는 값이면, 시스템은 기본값 "ko"를 사용해야 한다
+
+3. **템플릿 무결성**
+   - IF config.json.mustache가 없으면, 시스템은 경고를 표시하고 기본 config.json을 생성해야 한다
+   - IF 필수 템플릿 파일이 누락되면, 시스템은 초기화를 중단해야 한다
+
+4. **스크립트 실행 제약**
+   - IF Node.js가 설치되지 않았으면, 시스템은 Mustache 렌더링을 스킵하고 경고를 표시해야 한다
+   - IF render-template.cjs 실행이 실패하면, 시스템은 수동 렌더링 가이드를 제공해야 한다
+
+5. **특수문자 제약**
+   - IF PROJECT_NAME에 공백 또는 특수문자가 포함되면, 시스템은 kebab-case로 정규화해야 한다
+   - IF PROJECT_DESCRIPTION에 개행 문자가 포함되면, 시스템은 공백으로 치환해야 한다
+
+## 🔗 추적성 (Traceability)
+
+- **@SPEC:PLUGIN-002** → 이 문서
+- **@TEST:PLUGIN-002** → `tests/commands/project-init.test.ts` (예정)
+- **@CODE:PLUGIN-002** → `.claude/commands/alfred/8-project.md` (기존, 강화)
+- **@CODE:PLUGIN-002:SCRIPT** → `scripts/render-template.cjs` (예정)
+- **@DOC:PLUGIN-002** → `docs/project-initialization.md` (예정)
+
+---
+
+## 참조
+
+- **관련 SPEC**: @SPEC:PLUGIN-001 (Claude Code 플러그인 구조 설계)
+- **기존 커맨드**: `.claude/commands/alfred/8-project.md`
+- **템플릿 디렉토리**: `${CLAUDE_PLUGIN_ROOT}/templates/.moai/`
+- **Mustache 라이브러리**: https://www.npmjs.com/package/mustache

--- a/.moai/specs/SPEC-PLUGIN-003/acceptance.md
+++ b/.moai/specs/SPEC-PLUGIN-003/acceptance.md
@@ -1,0 +1,408 @@
+# SPEC-PLUGIN-003 수락 기준
+
+## 📋 개요
+
+플러그인 설치 스크립트의 성공 기준을 정의합니다. 모든 시나리오는 Given-When-Then 형식으로 작성하며, 검증 가능한 조건을 명시합니다.
+
+---
+
+## ✅ 인수 기준 (Acceptance Criteria)
+
+### 1. 기본 설치 기능
+
+#### AC-1.1: Git 클론 방식 설치 성공
+**Given**: Git이 설치된 환경
+**When**: `curl -sSL https://moai-adk.dev/install.sh | sh` 실행
+**Then**:
+- `~/.claude/plugins/moai-adk/` 디렉토리 생성됨
+- `plugin.json` 파일이 존재함
+- `commands/`, `agents/` 디렉토리가 존재함
+- 설치 완료 메시지 출력: "✅ MoAI-ADK plugin installed successfully!"
+- 다음 단계 안내 메시지 출력 (Claude Code 재시작)
+
+**검증 방법**:
+```bash
+ls ~/.claude/plugins/moai-adk/plugin.json
+ls -d ~/.claude/plugins/moai-adk/commands
+ls -d ~/.claude/plugins/moai-adk/agents
+```
+
+#### AC-1.2: tar.gz 다운로드 방식 설치 성공
+**Given**: Git이 설치되지 않은 환경
+**When**: `curl -sSL https://moai-adk.dev/install.sh | sh` 실행
+**Then**:
+- GitHub Release API에서 최신 버전 조회됨
+- tar.gz 파일 다운로드 및 압축 해제됨
+- `~/.claude/plugins/moai-adk/plugin.json` 존재함
+- 임시 파일 `/tmp/moai-adk.tar.gz` 삭제됨
+- 설치 완료 메시지 출력
+
+**검증 방법**:
+```bash
+# Git 비활성화 후 테스트
+sudo mv /usr/bin/git /usr/bin/git.bak
+bash install.sh
+sudo mv /usr/bin/git.bak /usr/bin/git
+```
+
+---
+
+### 2. 에러 처리
+
+#### AC-2.1: 네트워크 오류 처리
+**Given**: 네트워크 연결 불가 상태
+**When**: 설치 스크립트 실행
+**Then**:
+- "❌ Error: Cannot reach GitHub API" 에러 메시지 출력
+- 수동 설치 가이드 표시
+- 종료 코드 1 반환
+
+**검증 방법**:
+```bash
+# 네트워크 차단 (macOS 방화벽 또는 iptables)
+./install.sh
+echo $? # 1 출력 확인
+```
+
+#### AC-2.2: 권한 오류 처리
+**Given**: `~/.claude/plugins/` 디렉토리 쓰기 권한 없음
+**When**: 설치 스크립트 실행
+**Then**:
+- "❌ Error: No write permission to ~/.claude/plugins/" 에러 메시지 출력
+- 권한 가이드 표시: `chmod 755 ~/.claude/plugins`
+- 종료 코드 1 반환
+
+**검증 방법**:
+```bash
+chmod 000 ~/.claude/plugins
+./install.sh
+echo $? # 1 출력 확인
+chmod 755 ~/.claude/plugins # 복구
+```
+
+#### AC-2.3: 이미 설치된 경우 덮어쓰기 확인
+**Given**: `~/.claude/plugins/moai-adk/` 디렉토리 이미 존재
+**When**: 설치 스크립트 실행
+**Then**:
+- "⚠️ MoAI-ADK already installed. Overwrite? [y/N]:" 프롬프트 표시
+- 사용자가 'y' 입력 시 → 기존 디렉토리 삭제 후 재설치
+- 사용자가 'N' 입력 시 → "Installation cancelled." 메시지 출력 후 종료
+
+**검증 방법**:
+```bash
+# 이미 설치된 상태 생성
+mkdir -p ~/.claude/plugins/moai-adk
+echo "test" > ~/.claude/plugins/moai-adk/test.txt
+
+# 스크립트 실행 (대화형)
+./install.sh
+# 'N' 입력 → 종료 확인
+# 'y' 입력 → test.txt 삭제 확인
+```
+
+#### AC-2.4: 플러그인 무결성 검증 실패
+**Given**: 다운로드한 파일에 `plugin.json` 없음
+**When**: 설치 검증 단계 실행
+**Then**:
+- "❌ Error: plugin.json not found. Installation may be corrupted." 에러 메시지 출력
+- 재시도 안내 메시지 표시
+- 종료 코드 1 반환
+
+**검증 방법**:
+```bash
+# plugin.json 수동 삭제 후 검증 함수 실행
+rm ~/.claude/plugins/moai-adk/plugin.json
+verify_installation
+echo $? # 1 출력 확인
+```
+
+---
+
+### 3. 크로스 플랫폼 지원
+
+#### AC-3.1: macOS 설치 성공
+**Given**: macOS 환경 (Big Sur 이상)
+**When**: `curl -sSL https://moai-adk.dev/install.sh | sh` 실행
+**Then**:
+- 설치 성공
+- 진행률 메시지 정상 출력
+- `~/.claude/plugins/moai-adk/` 생성됨
+
+**검증 방법**:
+```bash
+uname -s # Darwin 확인
+./install.sh
+ls ~/.claude/plugins/moai-adk/
+```
+
+#### AC-3.2: Linux 설치 성공
+**Given**: Ubuntu 22.04 LTS 환경
+**When**: `curl -sSL https://moai-adk.dev/install.sh | sh` 실행
+**Then**:
+- 설치 성공
+- 진행률 메시지 정상 출력
+- `~/.claude/plugins/moai-adk/` 생성됨
+
+**검증 방법**:
+```bash
+uname -s # Linux 확인
+./install.sh
+ls ~/.claude/plugins/moai-adk/
+```
+
+#### AC-3.3: Windows PowerShell 설치 성공 (선택)
+**Given**: Windows 10/11 + PowerShell 7
+**When**: `irm https://moai-adk.dev/install.ps1 | iex` 실행
+**Then**:
+- 설치 성공
+- 진행률 메시지 정상 출력 (PowerShell 진행률 바)
+- `%USERPROFILE%\.claude\plugins\moai-adk\` 생성됨
+
+**검증 방법**:
+```powershell
+$PSVersionTable.PSVersion # 7.x 확인
+.\install.ps1
+Test-Path "$env:USERPROFILE\.claude\plugins\moai-adk\plugin.json"
+```
+
+---
+
+### 4. 설치 검증
+
+#### AC-4.1: 설치 완료 후 플러그인 구조 확인
+**Given**: 설치 완료 상태
+**When**: 설치 검증 함수 실행
+**Then**:
+- `plugin.json` 존재 확인 통과
+- `commands/`, `agents/` 디렉토리 존재 확인 통과
+- "✅ MoAI-ADK plugin installed successfully!" 메시지 출력
+
+**검증 방법**:
+```bash
+verify_installation
+echo $? # 0 출력 확인
+```
+
+#### AC-4.2: Claude Code 재시작 후 플러그인 인식
+**Given**: 설치 완료 후 Claude Code 재시작
+**When**: `/alfred:8-project` 커맨드 입력
+**Then**:
+- 커맨드가 인식됨 (오류 없음)
+- Alfred SuperAgent 활성화 확인
+
+**검증 방법**:
+```bash
+# Claude Code 재시작 후
+/alfred:8-project
+# "Alfred SuperAgent initialized" 메시지 확인
+```
+
+---
+
+### 5. 사용자 안내 메시지
+
+#### AC-5.1: 설치 진행 메시지 출력
+**Given**: 설치 스크립트 실행 중
+**When**: Git 클론 방식 선택됨
+**Then**:
+- "Git detected. Using git clone method..." 메시지 출력
+- "Cloning MoAI-ADK plugin..." 메시지 출력
+
+**검증 방법**:
+```bash
+./install.sh 2>&1 | grep "Git detected"
+./install.sh 2>&1 | grep "Cloning"
+```
+
+#### AC-5.2: 설치 완료 후 다음 단계 안내
+**Given**: 설치 성공 상태
+**When**: 설치 완료 메시지 출력
+**Then**:
+- "Next steps:" 섹션 표시
+- "1. Restart Claude Code" 안내
+- "2. Verify plugin: ls ~/.claude/plugins/moai-adk" 안내
+- "3. Quick start: /alfred:8-project" 안내
+
+**검증 방법**:
+```bash
+./install.sh 2>&1 | grep "Next steps"
+./install.sh 2>&1 | grep "Restart Claude Code"
+./install.sh 2>&1 | grep "/alfred:8-project"
+```
+
+---
+
+## 🧪 테스트 시나리오 (Given-When-Then)
+
+### 시나리오 1: 정상 설치 (Git 환경)
+**Given**:
+- Git 설치됨 (`which git` 성공)
+- `~/.claude/plugins/` 디렉토리 존재
+- 네트워크 연결 가능
+
+**When**:
+```bash
+curl -sSL https://moai-adk.dev/install.sh | sh
+```
+
+**Then**:
+1. "Git detected. Using git clone method..." 출력
+2. `git clone https://github.com/modu-ai/moai-adk ~/.claude/plugins/moai-adk` 실행
+3. `plugin.json` 존재 확인 통과
+4. "✅ MoAI-ADK plugin installed successfully!" 출력
+5. 종료 코드 0
+
+---
+
+### 시나리오 2: 정상 설치 (Git 미설치)
+**Given**:
+- Git 미설치 (`which git` 실패)
+- curl/wget 설치됨
+- `~/.claude/plugins/` 디렉토리 존재
+- 네트워크 연결 가능
+
+**When**:
+```bash
+curl -sSL https://moai-adk.dev/install.sh | sh
+```
+
+**Then**:
+1. "Git not found. Using tar.gz download method..." 출력
+2. GitHub Release API 호출 (`/repos/modu-ai/moai-adk/releases/latest`)
+3. tar.gz 다운로드 및 압축 해제
+4. 임시 파일 삭제 (`/tmp/moai-adk.tar.gz`)
+5. `plugin.json` 존재 확인 통과
+6. "✅ MoAI-ADK plugin installed successfully!" 출력
+7. 종료 코드 0
+
+---
+
+### 시나리오 3: 네트워크 오류
+**Given**:
+- 네트워크 연결 불가 (GitHub API 접근 실패)
+
+**When**:
+```bash
+./install.sh
+```
+
+**Then**:
+1. "❌ Error: Cannot reach GitHub API" 출력
+2. "→ Check your internet connection" 출력
+3. "→ Manual installation: git clone ..." 수동 가이드 출력
+4. 종료 코드 1
+
+---
+
+### 시나리오 4: 이미 설치된 경우 (덮어쓰기 거부)
+**Given**:
+- `~/.claude/plugins/moai-adk/` 이미 존재
+
+**When**:
+```bash
+./install.sh
+# 프롬프트에서 'N' 입력
+```
+
+**Then**:
+1. "⚠️ MoAI-ADK already installed. Overwrite? [y/N]:" 프롬프트 표시
+2. 사용자 'N' 입력
+3. "Installation cancelled." 출력
+4. 기존 디렉토리 유지 (삭제 안 됨)
+5. 종료 코드 0
+
+---
+
+## 🎯 품질 게이트 기준 (Definition of Done)
+
+### 필수 조건
+
+- [ ] `scripts/install.sh` 파일 생성 및 실행 권한 부여 (`chmod +x`)
+- [ ] Git 클론 방식 정상 작동 (Git 설치 환경)
+- [ ] tar.gz 다운로드 방식 정상 작동 (Git 미설치 환경)
+- [ ] 모든 에러 시나리오 처리 (네트워크, 권한, 무결성)
+- [ ] 설치 검증 통과 (`plugin.json` 존재 확인)
+- [ ] 설치 완료 메시지 및 다음 단계 안내 출력
+- [ ] macOS, Linux 환경에서 테스트 성공
+
+### 선택 조건
+
+- [ ] Windows PowerShell 스크립트 작성 (`scripts/install.ps1`)
+- [ ] PowerShell 환경에서 테스트 성공
+- [ ] 자동화 테스트 스크립트 작성 (`tests/scripts/install.test.sh`)
+- [ ] 설치 가이드 문서 작성 (`docs/installation.md`)
+
+### TRUST 5원칙 준수
+
+- **T**est First:
+  - [ ] `tests/scripts/install.test.sh` 작성
+  - [ ] 모든 에러 시나리오 테스트 케이스 포함
+
+- **R**eadable:
+  - [ ] 스크립트 주석 작성 (각 함수 설명)
+  - [ ] 함수 이름 명확성 (예: `verify_installation()`, `detect_git()`)
+
+- **U**nified:
+  - [ ] 일관된 에러 메시지 형식 (❌, ⚠️, ✅)
+  - [ ] 일관된 함수 네이밍 컨벤션
+
+- **S**ecured:
+  - [ ] 권한 확인 로직 포함
+  - [ ] 임시 파일 안전하게 삭제
+  - [ ] GitHub Release API 응답 검증
+
+- **T**rackable:
+  - [ ] `@CODE:PLUGIN-003` TAG 주석 추가
+  - [ ] `@SPEC:PLUGIN-003` 참조 명시
+
+---
+
+## 📚 검증 방법 및 도구
+
+### 수동 테스트
+```bash
+# 1. Git 환경 테스트
+./install.sh
+
+# 2. Git 미설치 환경 테스트 (Git 임시 비활성화)
+sudo mv /usr/bin/git /usr/bin/git.bak
+./install.sh
+sudo mv /usr/bin/git.bak /usr/bin/git
+
+# 3. 덮어쓰기 테스트
+./install.sh # 'N' 입력
+./install.sh # 'y' 입력
+
+# 4. 권한 오류 테스트
+chmod 000 ~/.claude/plugins
+./install.sh
+chmod 755 ~/.claude/plugins
+```
+
+### 자동화 테스트 (선택)
+```bash
+# tests/scripts/install.test.sh
+bash tests/scripts/install.test.sh
+```
+
+### 설치 검증
+```bash
+# 플러그인 구조 확인
+ls -la ~/.claude/plugins/moai-adk/
+cat ~/.claude/plugins/moai-adk/plugin.json
+
+# Claude Code에서 플러그인 인식 확인
+# Claude Code 재시작 후
+/alfred:8-project
+```
+
+---
+
+## 다음 단계
+
+1. **TDD 구현**: `/alfred:2-build SPEC-PLUGIN-003`
+2. **테스트 실행**: `bash tests/scripts/install.test.sh`
+3. **문서 동기화**: `/alfred:3-sync`
+4. **배포 URL 설정**: `https://moai-adk.dev/install.sh` 호스팅
+
+**완료 조건 달성 시 SPEC-PLUGIN-003 종료** ✅

--- a/.moai/specs/SPEC-PLUGIN-003/plan.md
+++ b/.moai/specs/SPEC-PLUGIN-003/plan.md
@@ -1,0 +1,331 @@
+# SPEC-PLUGIN-003 구현 계획
+
+## 📋 개요
+
+플러그인 설치 스크립트 작성 및 배포 전략을 수립합니다. bash 스크립트를 우선 구현하고, PowerShell 스크립트는 선택적으로 추가합니다.
+
+---
+
+## 🎯 마일스톤 (우선순위 기반)
+
+### 1차 목표: bash 스크립트 기본 구현
+
+**주요 작업**:
+1. `scripts/install.sh` 파일 생성
+2. Git 설치 감지 함수 구현
+3. Git 클론 방식 구현
+4. tar.gz 다운로드 방식 구현 (GitHub Release API)
+5. 설치 검증 함수 구현
+6. 에러 핸들링 및 사용자 안내 메시지
+
+**산출물**:
+- `scripts/install.sh` (실행 가능)
+- 설치 검증 테스트 스크립트
+
+### 2차 목표: 에러 처리 고도화
+
+**주요 작업**:
+1. 네트워크 오류 처리
+2. 권한 오류 처리 (`~/.claude/plugins/` 쓰기 권한)
+3. 이미 설치된 경우 덮어쓰기 확인
+4. 다운로드 실패 시 재시도 로직
+5. 상세한 에러 메시지 템플릿
+
+**산출물**:
+- 에러 처리 가이드 문서
+- 테스트 케이스 (에러 시나리오)
+
+### 3차 목표: 크로스 플랫폼 지원
+
+**주요 작업**:
+1. macOS/Linux 호환성 검증
+2. Windows PowerShell 스크립트 작성 (`scripts/install.ps1`)
+3. OS 자동 감지 및 스크립트 선택
+4. 플랫폼별 진행률 표시 최적화
+
+**산출물**:
+- `scripts/install.ps1` (Windows용)
+- 플랫폼별 테스트 케이스
+
+### 4차 목표: 배포 및 문서화
+
+**주요 작업**:
+1. 설치 스크립트 호스팅 (GitHub Pages 또는 CDN)
+2. `docs/installation.md` 문서 작성
+3. curl 원라이너 URL 설정
+4. Quick Start 가이드에 설치 섹션 추가
+
+**산출물**:
+- 공개 설치 URL: `https://moai-adk.dev/install.sh`
+- 설치 가이드 문서
+
+---
+
+## 🛠️ 기술적 접근 방법
+
+### 1. Git vs tar.gz 선택 알고리즘
+
+```bash
+# install.sh 핵심 로직
+if command -v git &> /dev/null; then
+    echo "Git detected. Using git clone method..."
+    git clone https://github.com/modu-ai/moai-adk ~/.claude/plugins/moai-adk
+else
+    echo "Git not found. Using tar.gz download method..."
+    LATEST_RELEASE=$(curl -s https://api.github.com/repos/modu-ai/moai-adk/releases/latest | grep "tarball_url" | cut -d '"' -f 4)
+    curl -L "$LATEST_RELEASE" -o /tmp/moai-adk.tar.gz
+    mkdir -p ~/.claude/plugins/moai-adk
+    tar -xzf /tmp/moai-adk.tar.gz -C ~/.claude/plugins/moai-adk --strip-components=1
+    rm /tmp/moai-adk.tar.gz
+fi
+```
+
+### 2. GitHub Release API 활용
+
+**API 엔드포인트**:
+```bash
+GET https://api.github.com/repos/modu-ai/moai-adk/releases/latest
+```
+
+**응답 예시** (JSON):
+```json
+{
+  "tag_name": "v0.3.0",
+  "tarball_url": "https://api.github.com/repos/modu-ai/moai-adk/tarball/v0.3.0",
+  "zipball_url": "https://api.github.com/repos/modu-ai/moai-adk/zipball/v0.3.0"
+}
+```
+
+**추출 로직**:
+```bash
+# jq 사용 (선호)
+LATEST_RELEASE=$(curl -s https://api.github.com/repos/modu-ai/moai-adk/releases/latest | jq -r '.tarball_url')
+
+# jq 없을 시 grep/cut 대체
+LATEST_RELEASE=$(curl -s https://api.github.com/repos/modu-ai/moai-adk/releases/latest | grep "tarball_url" | cut -d '"' -f 4)
+```
+
+### 3. 에러 처리 전략
+
+**권한 오류**:
+```bash
+if [ ! -w ~/.claude/plugins ]; then
+    echo "❌ Error: No write permission to ~/.claude/plugins/"
+    echo "  → Run: chmod 755 ~/.claude/plugins"
+    exit 1
+fi
+```
+
+**네트워크 오류**:
+```bash
+if ! curl -s --head https://api.github.com &> /dev/null; then
+    echo "❌ Error: Cannot reach GitHub API"
+    echo "  → Check your internet connection"
+    echo "  → Manual installation: git clone https://github.com/modu-ai/moai-adk ~/.claude/plugins/moai-adk"
+    exit 1
+fi
+```
+
+**이미 설치된 경우**:
+```bash
+if [ -d ~/.claude/plugins/moai-adk ]; then
+    read -p "⚠️ MoAI-ADK already installed. Overwrite? [y/N]: " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        echo "Installation cancelled."
+        exit 0
+    fi
+    rm -rf ~/.claude/plugins/moai-adk
+fi
+```
+
+### 4. 설치 검증 로직
+
+```bash
+# plugin.json 존재 확인
+if [ ! -f ~/.claude/plugins/moai-adk/plugin.json ]; then
+    echo "❌ Error: plugin.json not found. Installation may be corrupted."
+    echo "  → Retry installation or check GitHub repository"
+    exit 1
+fi
+
+# commands/, agents/ 디렉토리 확인
+if [ ! -d ~/.claude/plugins/moai-adk/commands ] || [ ! -d ~/.claude/plugins/moai-adk/agents ]; then
+    echo "⚠️ Warning: plugin structure incomplete. Plugin may not work correctly."
+fi
+
+echo "✅ MoAI-ADK plugin installed successfully!"
+echo ""
+echo "Next steps:"
+echo "  1. Restart Claude Code"
+echo "  2. Verify plugin: ls ~/.claude/plugins/moai-adk"
+echo "  3. Quick start: /alfred:8-project"
+```
+
+### 5. Windows PowerShell 스크립트 (선택)
+
+```powershell
+# install.ps1
+$INSTALL_PATH = "$env:USERPROFILE\.claude\plugins\moai-adk"
+
+if (Get-Command git -ErrorAction SilentlyContinue) {
+    Write-Host "Git detected. Using git clone method..."
+    git clone https://github.com/modu-ai/moai-adk $INSTALL_PATH
+} else {
+    Write-Host "Git not found. Using zip download method..."
+    $LATEST = (Invoke-RestMethod -Uri "https://api.github.com/repos/modu-ai/moai-adk/releases/latest").zipball_url
+    Invoke-WebRequest -Uri $LATEST -OutFile "$env:TEMP\moai-adk.zip"
+    Expand-Archive -Path "$env:TEMP\moai-adk.zip" -DestinationPath $INSTALL_PATH -Force
+    Remove-Item "$env:TEMP\moai-adk.zip"
+}
+
+# 검증
+if (Test-Path "$INSTALL_PATH\plugin.json") {
+    Write-Host "✅ MoAI-ADK plugin installed successfully!"
+} else {
+    Write-Host "❌ Error: Installation failed. plugin.json not found."
+    exit 1
+}
+```
+
+---
+
+## 🏗️ 아키텍처 설계 방향
+
+### 디렉토리 구조
+
+```
+moai-adk/
+├── scripts/
+│   ├── install.sh          # bash 설치 스크립트 (우선)
+│   ├── install.ps1         # PowerShell 스크립트 (선택)
+│   └── uninstall.sh        # 제거 스크립트 (향후)
+├── tests/
+│   └── scripts/
+│       ├── install.test.sh # bash 테스트
+│       └── install.test.ps1 # PowerShell 테스트
+└── docs/
+    └── installation.md     # 설치 가이드 문서
+```
+
+### 설치 스크립트 설계 원칙
+
+1. **멱등성 (Idempotent)**: 여러 번 실행해도 안전
+2. **원자성 (Atomic)**: 설치 실패 시 롤백 또는 정리
+3. **투명성 (Transparent)**: 모든 작업을 사용자에게 명확히 표시
+4. **안전성 (Safe)**: 예외 상황 완벽 처리
+
+---
+
+## ⚠️ 리스크 및 대응 방안
+
+### 리스크 1: GitHub API Rate Limit
+
+**문제**:
+- GitHub API는 비인증 요청 시 60회/시간 제한
+
+**대응**:
+- 에러 메시지에 수동 설치 가이드 포함
+- GitHub Personal Access Token 사용 옵션 추가 (선택)
+
+### 리스크 2: 플러그인 디렉토리 권한
+
+**문제**:
+- `~/.claude/plugins/` 디렉토리 쓰기 권한 없을 수 있음
+
+**대응**:
+- 권한 확인 로직 추가
+- 권한 없을 시 `chmod 755 ~/.claude/plugins` 안내
+
+### 리스크 3: 네트워크 불안정
+
+**문제**:
+- GitHub 다운로드 중 네트워크 끊김
+
+**대응**:
+- 재시도 로직 (최대 3회)
+- 실패 시 수동 설치 가이드 제공
+
+### 리스크 4: 플러그인 구조 변경
+
+**문제**:
+- tar.gz 압축 해제 후 구조가 예상과 다를 수 있음
+
+**대응**:
+- `plugin.json` 존재 확인으로 검증
+- 구조 불일치 시 에러 메시지 출력
+
+---
+
+## 🧪 테스트 전략
+
+### 수동 테스트 시나리오
+
+**정상 케이스**:
+1. Git 설치 환경에서 스크립트 실행
+2. Git 미설치 환경에서 스크립트 실행
+3. 이미 설치된 상태에서 덮어쓰기 선택/거부
+
+**에러 케이스**:
+1. 네트워크 끊김 (GitHub API 접근 불가)
+2. 플러그인 디렉토리 권한 없음
+3. curl/wget 미설치
+4. 다운로드 파일 손상 (plugin.json 없음)
+
+### 자동화 테스트 (선택)
+
+```bash
+# tests/scripts/install.test.sh
+#!/bin/bash
+
+# Mock 환경 설정
+export HOME=/tmp/test-home
+mkdir -p $HOME/.claude/plugins
+
+# 테스트 1: Git 설치 환경
+which git &> /dev/null && echo "✅ Git test passed"
+
+# 테스트 2: tar.gz 다운로드
+# (실제 API 호출 대신 mock 데이터 사용)
+
+# 테스트 3: 설치 검증
+[ -f $HOME/.claude/plugins/moai-adk/plugin.json ] && echo "✅ Verification test passed"
+
+# 정리
+rm -rf $HOME/.claude/plugins
+```
+
+---
+
+## 📚 문서화 요구사항
+
+### installation.md 구성
+
+1. **설치 방법 3가지**:
+   - curl 원라이너 (권장)
+   - Git 클론
+   - 수동 다운로드
+
+2. **문제 해결 가이드**:
+   - 권한 오류 해결
+   - 네트워크 오류 해결
+   - 플러그인 미인식 문제
+
+3. **설치 검증 방법**:
+   - `ls ~/.claude/plugins/moai-adk`
+   - Claude Code 재시작 후 `/alfred:8-project` 실행
+
+---
+
+## 다음 단계
+
+1. **Phase 1**: `scripts/install.sh` 기본 구현 완료
+2. **Phase 2**: 에러 처리 고도화 및 테스트
+3. **Phase 3**: Windows PowerShell 스크립트 추가
+4. **Phase 4**: 문서화 및 배포 URL 설정
+
+**완료 조건**:
+- `scripts/install.sh` 실행 가능
+- 모든 에러 시나리오 처리 완료
+- `docs/installation.md` 문서 작성 완료
+- `/alfred:2-build SPEC-PLUGIN-003` 대기

--- a/.moai/specs/SPEC-PLUGIN-003/spec.md
+++ b/.moai/specs/SPEC-PLUGIN-003/spec.md
@@ -1,0 +1,142 @@
+---
+# 필수 필드 (7개)
+id: PLUGIN-003
+version: 0.0.1
+status: draft
+created: 2025-10-10
+updated: 2025-10-10
+author: @Goos
+priority: medium
+
+# 선택 필드 - 분류/메타
+category: feature
+labels:
+  - installer
+  - shell-script
+  - deployment
+
+# 선택 필드 - 관계 (의존성 그래프)
+depends_on:
+  - PLUGIN-001
+
+# 선택 필드 - 범위 (영향 분석)
+scope:
+  packages:
+    - scripts/
+  files:
+    - install.sh
+    - install.ps1
+---
+
+# @SPEC:PLUGIN-003: 플러그인 설치 스크립트 작성
+
+## HISTORY
+
+### v0.0.1 (2025-10-10)
+- **INITIAL**: 플러그인 설치 스크립트 SPEC 작성
+- **AUTHOR**: @Goos
+- **SCOPE**: curl 원라이너 설치 스크립트, Git/tar.gz 기반 설치, 크로스 플랫폼 지원
+- **CONTEXT**: npm 패키지 제거 후 사용자가 플러그인을 수동 설치할 수 있도록 자동화 스크립트 제공
+
+---
+
+## 📋 개요
+
+MoAI-ADK 플러그인을 간편하게 설치할 수 있는 원라이너 설치 스크립트를 제공합니다. Git 설치 여부에 따라 Git 클론 또는 tar.gz 다운로드 방식을 자동 선택하며, macOS/Linux는 bash 스크립트, Windows는 PowerShell 스크립트로 지원합니다.
+
+## 🎯 목표
+
+1. curl 원라이너 설치 지원 (`curl -sSL https://moai-adk.dev/install.sh | sh`)
+2. Git 설치 감지 및 자동 선택 (Git 클론 vs tar.gz 다운로드)
+3. GitHub Release API 활용 (latest 버전 자동 다운로드)
+4. 설치 경로: `~/.claude/plugins/moai-adk`
+5. 설치 검증 및 사용자 안내 메시지 제공
+6. 크로스 플랫폼 지원 (macOS, Linux, Windows)
+
+## 📝 EARS 요구사항
+
+### Ubiquitous Requirements (기본 기능)
+
+1. **설치 스크립트 제공**
+   - 시스템은 `install.sh` bash 스크립트를 제공해야 한다
+   - 시스템은 Git 설치 여부를 감지해야 한다
+   - 시스템은 설치 경로 `~/.claude/plugins/moai-adk`를 사용해야 한다
+
+2. **설치 방식 선택**
+   - 시스템은 Git 설치 시 `git clone` 방식을 우선 사용해야 한다
+   - 시스템은 Git 미설치 시 tar.gz 다운로드 방식을 대체 사용해야 한다
+   - 시스템은 GitHub Release API를 사용하여 최신 버전을 다운로드해야 한다
+
+3. **설치 완료 메시지**
+   - 시스템은 설치 완료 후 다음 단계를 안내해야 한다
+   - 시스템은 `plugin.json` 존재를 확인해야 한다
+   - 시스템은 Claude Code 재시작을 안내해야 한다
+
+### Event-driven Requirements (이벤트 기반)
+
+1. **Git 감지 시**
+   - WHEN Git이 설치되어 있으면, 시스템은 `git clone https://github.com/modu-ai/moai-adk ~/.claude/plugins/moai-adk` 명령을 실행해야 한다
+
+2. **Git 미설치 시**
+   - WHEN Git이 설치되어 있지 않으면, 시스템은 GitHub Release API를 호출하여 최신 tar.gz를 다운로드해야 한다
+   - WHEN tar.gz 다운로드 완료 시, 시스템은 `~/.claude/plugins/moai-adk`에 압축을 해제해야 한다
+
+3. **네트워크 오류 시**
+   - WHEN GitHub API 요청 실패 시, 시스템은 사용자에게 수동 설치 방법을 안내해야 한다
+   - WHEN 다운로드 실패 시, 시스템은 에러 메시지와 함께 종료해야 한다
+
+4. **이미 설치된 경우**
+   - WHEN `~/.claude/plugins/moai-adk`가 이미 존재하면, 시스템은 덮어쓰기 여부를 확인해야 한다
+   - WHEN 사용자가 덮어쓰기를 거부하면, 시스템은 설치를 중단해야 한다
+
+### State-driven Requirements (상태 기반)
+
+1. **설치 진행 중**
+   - WHILE 설치 진행 중일 때, 시스템은 진행률 메시지를 출력해야 한다
+   - WHILE Git 클론 중일 때, 시스템은 "Cloning MoAI-ADK plugin..." 메시지를 표시해야 한다
+   - WHILE tar.gz 다운로드 중일 때, 시스템은 "Downloading MoAI-ADK plugin..." 메시지를 표시해야 한다
+
+2. **설치 검증 중**
+   - WHILE 설치 검증 중일 때, 시스템은 `plugin.json` 존재를 확인해야 한다
+   - WHILE 설치 검증 중일 때, 시스템은 `commands/`, `agents/` 디렉토리 존재를 확인해야 한다
+
+### Optional Features (선택적 기능)
+
+1. **Windows PowerShell 스크립트**
+   - WHERE Windows 환경이면, 시스템은 `install.ps1` PowerShell 스크립트를 제공할 수 있다
+   - WHERE PowerShell 7+이면, 시스템은 진행률 바를 표시할 수 있다
+
+2. **커스텀 설치 경로**
+   - WHERE 환경변수 `MOAI_INSTALL_PATH`가 설정되어 있으면, 시스템은 해당 경로를 설치 디렉토리로 사용할 수 있다
+
+3. **개발 버전 설치**
+   - WHERE `--dev` 플래그가 전달되면, 시스템은 develop 브랜치를 클론할 수 있다
+
+### Constraints (제약사항)
+
+1. **플러그인 디렉토리 권한**
+   - IF `~/.claude/plugins/` 디렉토리 쓰기 권한이 없으면, 시스템은 설치를 실패하고 권한 가이드를 표시해야 한다
+
+2. **네트워크 연결 필요**
+   - IF 네트워크 연결이 없으면, 시스템은 설치를 실패하고 수동 설치 가이드를 표시해야 한다
+
+3. **필수 도구**
+   - IF curl 또는 wget이 없으면, 시스템은 설치를 실패하고 도구 설치 가이드를 표시해야 한다
+
+4. **플러그인 무결성**
+   - IF 다운로드한 파일에 `plugin.json`이 없으면, 시스템은 설치를 실패하고 재시도를 안내해야 한다
+
+## 🔗 추적성 (Traceability)
+
+- **@SPEC:PLUGIN-003** → 이 문서
+- **@TEST:PLUGIN-003** → `tests/scripts/install.test.sh` (예정)
+- **@CODE:PLUGIN-003** → `scripts/install.sh`, `scripts/install.ps1` (예정)
+- **@DOC:PLUGIN-003** → `docs/installation.md` (예정)
+
+---
+
+## 참조
+
+- **의존 SPEC**: @SPEC:PLUGIN-001
+- **GitHub Release API**: https://docs.github.com/en/rest/releases/releases
+- **Claude Code 플러그인 설치**: https://docs.claude.com/en/docs/claude-code/plugins-installation


### PR DESCRIPTION
## Summary

MoAI-ADK를 npm 패키지에서 Claude Code 플러그인 전용으로 전환하기 위한 3개 SPEC 작성

### SPEC 목록

1. **SPEC-PLUGIN-001**: Claude Code 플러그인 구조 설계
   - `.claude-plugin/plugin.json` 매니페스트 설계
   - `hooks/hooks.json` 변환 로직
   - 디렉토리 구조 정의

2. **SPEC-PLUGIN-002**: /alfred:8-project 커맨드 강화 (init 대체)
   - 템플릿 복사 및 Mustache 렌더링
   - `render-template.cjs` 헬퍼 스크립트
   - Git 초기화 기능

3. **SPEC-PLUGIN-003**: 플러그인 설치 스크립트 작성
   - curl 원라이너 설치 (`install.sh`)
   - Git vs tar.gz 자동 선택
   - 크로스 플랫폼 지원

## Test Plan

- [ ] `/alfred:2-build SPEC-PLUGIN-001` - 플러그인 구조 TDD 구현
- [ ] `/alfred:2-build SPEC-PLUGIN-002` - 8-project 커맨드 강화
- [ ] `/alfred:2-build SPEC-PLUGIN-003` - 설치 스크립트 작성
- [ ] `/alfred:3-sync` - 문서 동기화 및 TAG 체인 검증

## Related Issues

- 관련 이슈: 플러그인 전용 전환 (#TBD)
- 의존성: 없음 (PLUGIN-001은 독립적)

🤖 Generated with [Claude Code](https://claude.com/claude-code)