### PR TITLE
fix(workflow): Support merge commit detection in Release Pipeline

### DIFF
--- a/.github/workflows/moai-release-pipeline.yml
+++ b/.github/workflows/moai-release-pipeline.yml
@@ -29,16 +29,17 @@ jobs:
       - name: 🔍 Detect release commit
         id: detect
         run: |
-          # 마지막 커밋 메시지 확인
+          # 마지막 커밋 메시지 확인 (merge commit 포함)
           LAST_COMMIT=$(git log -1 --pretty=%B)
           echo "최근 커밋: $LAST_COMMIT"
 
           # RELEASE 패턴 감지 (🔖 RELEASE: v0.6.0)
-          if echo "$LAST_COMMIT" | grep -q "^🔖 RELEASE:"; then
+          # 커밋 메시지 어디든 RELEASE 패턴이 있으면 감지 (merge commit 지원)
+          if echo "$LAST_COMMIT" | grep -q "🔖 RELEASE:"; then
             echo "✅ Release 커밋 감지됨"
 
             # 버전 추출 (🔖 RELEASE: v0.6.0 → 0.6.0)
-            VERSION=$(echo "$LAST_COMMIT" | grep -oP 'RELEASE: v\K[0-9]+\.[0-9]+\.[0-9]+' || echo "")
+            VERSION=$(echo "$LAST_COMMIT" | grep -oP 'RELEASE: v\K[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "")
 
             if [ -n "$VERSION" ]; then
               echo "🔖 버전: v$VERSION"


### PR DESCRIPTION
## 문제 해결

Release Pipeline이 GitHub merge commit을 감지하지 못하는 문제를 수정했습니다.

### 원인
- Release Pipeline은 첫 줄이 `^🔖 RELEASE:`로 시작하는 커밋만 감지
- GitHub merge commit의 첫 줄은 "Merge pull request..." 형식
- 따라서 Release 패턴이 PR 설명에 있어도 감지되지 않음

### 해결책
- grep 패턴에서 `^` anchor 제거
- 커밋 메시지 어디든 `🔖 RELEASE:` 패턴이 있으면 감지
- Merge commit 및 일반 commit 모두 지원

### 영향
✅ v0.6.1 Release Pipeline 이제 감지됨
✅ 향후 모든 릴리즈에서 merge commit 지원

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>