### PR TITLE
fix(workflow): GitHub Issues 중복 생성 방지 로직 추가

### DIFF
--- a/.github/workflows/spec-issue-sync.yml
+++ b/.github/workflows/spec-issue-sync.yml
@@ -136,7 +136,37 @@ jobs:
           echo "spec_priority=$spec_priority" >> $GITHUB_OUTPUT
           echo "spec_title=$spec_title" >> $GITHUB_OUTPUT
 
-      - name: Create GitHub Issue
+      - name: Check for existing issue
+        if: steps.spec.outputs.spec_id
+        id: check-issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          spec_id="${{ steps.spec.outputs.spec_id }}"
+
+          echo "=== Checking for existing issue ==="
+          echo "Searching for existing GitHub issue with SPEC-$spec_id..."
+
+          # Search for existing issue with the SPEC ID in the title
+          # Use label filter for efficiency, then search in title
+          existing_issue=$(gh issue list \
+            --label "spec" \
+            --state all \
+            --search "[SPEC-$spec_id]" \
+            --json number,title,state \
+            --jq '.[] | select(.title | contains("[SPEC-'$spec_id']")) | .number' \
+            2>/dev/null | head -1)
+
+          if [ -n "$existing_issue" ]; then
+            echo "✅ Found existing issue: #$existing_issue"
+            echo "issue_exists=true" >> $GITHUB_OUTPUT
+            echo "issue_number=$existing_issue" >> $GITHUB_OUTPUT
+          else
+            echo "📋 No existing issue found for SPEC-$spec_id"
+            echo "issue_exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create or Update GitHub Issue
         if: steps.spec.outputs.spec_id
         id: create-issue
         env:
@@ -148,6 +178,8 @@ jobs:
           spec_status="${{ steps.spec.outputs.spec_status }}"
           spec_priority="${{ steps.spec.outputs.spec_priority }}"
           spec_file="${{ steps.spec.outputs.spec_file }}"
+          issue_exists="${{ steps.check-issue.outputs.issue_exists }}"
+          existing_issue="${{ steps.check-issue.outputs.issue_number }}"
 
           # Read SPEC content (skip YAML frontmatter: 9 lines + 1 blank = 10 lines total)
           # Start reading from line 11
@@ -176,33 +208,47 @@ jobs:
             echo "📝 **Auto-synced**: This issue is automatically synchronized from the SPEC document"
           } > /tmp/issue_body.txt
 
-          echo "📋 Creating GitHub Issue..."
-          echo "  Title: [SPEC-$spec_id] $spec_title (v$spec_version)"
-          echo "  Body file: /tmp/issue_body.txt"
-          wc -l /tmp/issue_body.txt
+          if [ "$issue_exists" = "true" ]; then
+            echo "📝 Updating existing issue #$existing_issue..."
+            echo "  Title: [SPEC-$spec_id] $spec_title (v$spec_version)"
 
-          # Create issue with labels using body-file
-          issue_output=$(gh issue create \
-            --title "[SPEC-$spec_id] $spec_title (v$spec_version)" \
-            --body-file /tmp/issue_body.txt \
-            --label "spec" \
-            --label "planning" \
-            --label "$spec_priority" 2>&1)
+            # Update existing issue with new content
+            gh issue edit "$existing_issue" \
+              --title "[SPEC-$spec_id] $spec_title (v$spec_version)" \
+              --body-file /tmp/issue_body.txt
 
-          echo "$issue_output" | tee /tmp/issue_output.txt
+            issue_num=$existing_issue
+            echo "✅ Updated issue #$issue_num"
+          else
+            echo "📋 Creating new GitHub Issue..."
+            echo "  Title: [SPEC-$spec_id] $spec_title (v$spec_version)"
+            echo "  Body file: /tmp/issue_body.txt"
+            wc -l /tmp/issue_body.txt
 
-          # Extract issue number from output
-          issue_num=$(echo "$issue_output" | grep -oE '/issues/[0-9]+' | grep -oE '[0-9]+' | head -1)
+            # Create issue with labels using body-file
+            issue_output=$(gh issue create \
+              --title "[SPEC-$spec_id] $spec_title (v$spec_version)" \
+              --body-file /tmp/issue_body.txt \
+              --label "spec" \
+              --label "planning" \
+              --label "$spec_priority" 2>&1)
 
-          if [ -z "$issue_num" ]; then
-            echo "⚠️  Could not extract issue number from output"
-            echo "Full output:"
-            cat /tmp/issue_output.txt
-            exit 1
+            echo "$issue_output" | tee /tmp/issue_output.txt
+
+            # Extract issue number from output
+            issue_num=$(echo "$issue_output" | grep -oE '/issues/[0-9]+' | grep -oE '[0-9]+' | head -1)
+
+            if [ -z "$issue_num" ]; then
+              echo "⚠️  Could not extract issue number from output"
+              echo "Full output:"
+              cat /tmp/issue_output.txt
+              exit 1
+            fi
+
+            echo "✅ Created issue #$issue_num"
           fi
 
           echo "issue_number=$issue_num" >> $GITHUB_OUTPUT
-          echo "✅ Created issue #$issue_num"
 
       - name: Add PR comment
         if: steps.create-issue.outputs.issue_number


### PR DESCRIPTION
## 📋 문제 분석

### 근본 원인
`.github/workflows/spec-issue-sync.yml` 워크플로우가 PR의 `opened`와 `synchronize` 이벤트 모두에서 트리거되면서, 매번 새로운 이슈를 생성하고 있습니다.

**증거**:
- PR #88 (14개 커밋) → 6개 이상의 중복 이슈 생성
- Issue #85-91, #93이 모두 동일한 SPEC-UPDATE-REFACTOR-002에 대한 이슈
- Issue #90과 #91이 정확히 같은 초에 생성됨 (race condition)

### 핵심 문제
- 이슈 생성 전에 **중복 확인 로직이 없음**
- 워크플로우가 항상 새 이슈를 생성하기만 함
- SPEC ID가 같은 기존 이슈를 확인하지 않음

---

## ✅ 해결 방법

### 변경 사항
1. **새 단계 추가**: "Check for existing issue" (Lines 139-167)
   - `gh issue list`를 사용하여 SPEC ID가 같은 기존 이슈 검색
   - Label과 title 기반으로 검색

2. **로직 변경**: "Create or Update GitHub Issue" (Lines 169-251)
   - 조건부 처리:
     - 이슈가 **존재하면**: `gh issue edit`로 업데이트
     - 이슈가 **없으면**: `gh issue create`로 새 이슈 생성

### 동작 방식
```
User가 PR 생성 (SPEC 포함)
  ↓
'opened' 이벤트 → workflow 실행 → 이슈 #N 생성
  ↓
User가 커밋 푸시 (SPEC 수정)
  ↓
'synchronize' 이벤트 → workflow 실행 → 기존 이슈 #N 검색 → 업데이트 (중복 아님!)
  ↓
User가 또 커밋 푸시 (SPEC 버전 업데이트)
  ↓
'synchronize' 이벤트 → workflow 실행 → 기존 이슈 #N 검색 → 업데이트
```

### 예상 결과
- **수정 전**: 14개 커밋 PR → 6개 이상의 중복 이슈
- **수정 후**: 14개 커밋 PR → 1개 이슈 (생성 1회, 업데이트 13회)

---

## 🧪 테스트 방법

다음 단계로 테스트 가능:
1. SPEC 파일 변경이 있는 새 PR 생성
2. 여러 번 커밋 푸시
3. GitHub Issues 확인:
   - ✅ 이슈가 1개만 생성되었나?
   - ✅ 각 커밋에서 이슈가 업데이트되었나?
   - ✅ 중복 이슈가 없나?

---

## 📌 관련 이슈

- 7개의 중복 이슈 생성됨: #85, #86, #87, #89, #90, #91, #93
- Root Cause: `spec-issue-sync.yml` workflow의 중복 감지 로직 부재

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>