### PR TITLE
fix: Change PyPI deployment trigger from release event to tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,10 @@
 name: Release & Deploy to PyPI
 
-# 트리거: GitHub Release가 published 상태로 생성되었을 때
+# 트리거: 버전 태그가 푸시되었을 때 (release event의 신뢰성 문제 해결)
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "v*.*.*"
 
 jobs:
   deploy:
@@ -49,5 +50,5 @@ jobs:
           echo "🎉 Release deployment complete!"
           echo ""
           echo "📦 Package: moai-adk"
-          echo "🏷️  Release: ${{ github.event.release.tag_name }}"
-          echo "🔗 PyPI: https://pypi.org/project/moai-adk/${{ github.event.release.tag_name }}/"
+          echo "🏷️  Release: ${{ github.ref }}"
+          echo "🔗 PyPI: https://pypi.org/project/moai-adk/${{ github.ref_name }}/"


### PR DESCRIPTION
## Problem

The release.yml workflow was never being triggered after GitHub releases were created, causing PyPI deployments to fail.

**Root Cause**: GitHub release events have reliability issues when triggered by GitHub Actions. The release.yml workflow uses `on: release.types: [published]` which was never fired.

## Solution

Changed the trigger condition to use tag push instead - this is GitHub's recommended approach for automating releases and is more reliable.

## Changes

- Modified trigger from `on: release.types: [published]` to `on: push.tags: v*.*.*`
- Updated output variables to use `github.ref` and `github.ref_name` instead of release event context

## Impact

Future releases will automatically deploy to PyPI when tags are pushed. No manual intervention needed.

🤖 Generated with Claude Code
Co-Authored-By: Alfred <alfred@mo.ai.kr>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release pipeline configuration to streamline the deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->