### PR TITLE
fix: Remove PATH from environment settings

### DIFF
--- a/src/moai_adk/templates/.claude/settings.json
+++ b/src/moai_adk/templates/.claude/settings.json
@@ -78,7 +78,6 @@
   "outputStyle": "MoAI",
   "cleanupPeriodDays": 30,
   "env": {
-    "PATH": "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$HOME/.local/bin:$HOME/.cargo/bin:/opt/homebrew/bin",
     "MOAI_CONFIG_SOURCE": "sections",
     "ENABLE_TOOL_SEARCH": "1",
     "MAX_THINKING_TOKENS": "31999",


### PR DESCRIPTION
Remove the hardcoded PATH entry from Claude's environment settings.

The hardcoded PATH in `settings.json` overrides the user's system PATH,
causing tool resolution failures on Windows (e.g. pnpm, node not found).
This fix respects the user's existing PATH to ensure cross-OS compatibility.

Refs: #325 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused environment configuration entry.
  * Applied minor formatting improvements to configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->