### PR TITLE
fix(rank): add Claude Code CLI transcript path support

### DIFF
--- a/internal/rank/transcript_test.go
+++ b/internal/rank/transcript_test.go
@@ -1,0 +1,303 @@
+package rank
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestClaudeCodeDir(t *testing.T) {
+	dir, err := claudeCodeDir()
+	if err != nil {
+		t.Fatalf("claudeCodeDir() returned error: %v", err)
+	}
+	if dir == "" {
+		t.Fatal("claudeCodeDir() returned empty string")
+	}
+
+	homeDir, _ := os.UserHomeDir()
+	expected := filepath.Join(homeDir, ".claude")
+	if dir != expected {
+		t.Errorf("claudeCodeDir() = %q, want %q", dir, expected)
+	}
+}
+
+func TestClaudeDesktopConfigDir(t *testing.T) {
+	dir, err := claudeDesktopConfigDir()
+	if err != nil {
+		t.Fatalf("claudeDesktopConfigDir() returned error: %v", err)
+	}
+	if dir == "" {
+		t.Fatal("claudeDesktopConfigDir() returned empty string")
+	}
+}
+
+func TestFindTranscripts_CLIPaths(t *testing.T) {
+	// Set HOME to a temp directory to isolate from the real filesystem.
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	claudeDir := filepath.Join(tempHome, ".claude")
+
+	// Create CLI new format: ~/.claude/projects/<project>/<uuid>.jsonl
+	projectDir := filepath.Join(claudeDir, "projects", "test-project")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cliNewFile := filepath.Join(projectDir, "abc-123-def.jsonl")
+	if err := os.WriteFile(cliNewFile, []byte(`{"type":"test"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create CLI old format: ~/.claude/transcripts/<session>.jsonl
+	transcriptsDir := filepath.Join(claudeDir, "transcripts")
+	if err := os.MkdirAll(transcriptsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cliOldFile := filepath.Join(transcriptsDir, "session-old.jsonl")
+	if err := os.WriteFile(cliOldFile, []byte(`{"type":"test"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	transcripts, err := FindTranscripts()
+	if err != nil {
+		t.Fatalf("FindTranscripts() returned error: %v", err)
+	}
+
+	if len(transcripts) < 2 {
+		t.Fatalf("FindTranscripts() returned %d files, want at least 2", len(transcripts))
+	}
+
+	// Verify both files are found.
+	found := make(map[string]bool)
+	for _, f := range transcripts {
+		found[f] = true
+	}
+
+	if !found[cliNewFile] {
+		t.Errorf("CLI new format file not found: %s", cliNewFile)
+	}
+	if !found[cliOldFile] {
+		t.Errorf("CLI old format file not found: %s", cliOldFile)
+	}
+}
+
+func TestFindTranscripts_MultipleSources(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	claudeDir := filepath.Join(tempHome, ".claude")
+
+	// Create multiple project directories with transcripts.
+	for _, project := range []string{"project-a", "project-b"} {
+		projectDir := filepath.Join(claudeDir, "projects", project)
+		if err := os.MkdirAll(projectDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		file := filepath.Join(projectDir, project+"-session.jsonl")
+		if err := os.WriteFile(file, []byte(`{"type":"test"}`+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	transcripts, err := FindTranscripts()
+	if err != nil {
+		t.Fatalf("FindTranscripts() returned error: %v", err)
+	}
+
+	if len(transcripts) < 2 {
+		t.Fatalf("FindTranscripts() returned %d files, want at least 2", len(transcripts))
+	}
+}
+
+func TestFindTranscripts_EmptyDirectory(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	// No Claude directories at all.
+	transcripts, err := FindTranscripts()
+	if err != nil {
+		t.Fatalf("FindTranscripts() returned error: %v", err)
+	}
+
+	if len(transcripts) != 0 {
+		t.Errorf("FindTranscripts() returned %d files, want 0", len(transcripts))
+	}
+}
+
+func TestFindTranscripts_Deduplication(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	claudeDir := filepath.Join(tempHome, ".claude")
+
+	// Create a single file in one location.
+	projectDir := filepath.Join(claudeDir, "projects", "dedup-project")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	file := filepath.Join(projectDir, "unique-session.jsonl")
+	if err := os.WriteFile(file, []byte(`{"type":"test"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	transcripts, err := FindTranscripts()
+	if err != nil {
+		t.Fatalf("FindTranscripts() returned error: %v", err)
+	}
+
+	// Check no duplicates.
+	seen := make(map[string]int)
+	for _, f := range transcripts {
+		seen[f]++
+	}
+	for f, count := range seen {
+		if count > 1 {
+			t.Errorf("duplicate transcript found: %s (count=%d)", f, count)
+		}
+	}
+}
+
+func TestFindTranscriptForSession_CLIPaths(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	claudeDir := filepath.Join(tempHome, ".claude")
+	sessionID := "test-session-abc123"
+
+	// Create CLI new format with session ID in filename.
+	projectDir := filepath.Join(claudeDir, "projects", "my-project")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	expectedFile := filepath.Join(projectDir, sessionID+".jsonl")
+	if err := os.WriteFile(expectedFile, []byte(`{"type":"test"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result := FindTranscriptForSession(sessionID)
+	if result == "" {
+		t.Fatal("FindTranscriptForSession() returned empty, want match")
+	}
+	if result != expectedFile {
+		t.Errorf("FindTranscriptForSession() = %q, want %q", result, expectedFile)
+	}
+}
+
+func TestFindTranscriptForSession_OldFormat(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	claudeDir := filepath.Join(tempHome, ".claude")
+	sessionID := "old-session-xyz"
+
+	// Create CLI old format: ~/.claude/transcripts/<session>.jsonl
+	transcriptsDir := filepath.Join(claudeDir, "transcripts")
+	if err := os.MkdirAll(transcriptsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	expectedFile := filepath.Join(transcriptsDir, sessionID+".jsonl")
+	if err := os.WriteFile(expectedFile, []byte(`{"type":"test"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result := FindTranscriptForSession(sessionID)
+	if result == "" {
+		t.Fatal("FindTranscriptForSession() returned empty, want match")
+	}
+	if result != expectedFile {
+		t.Errorf("FindTranscriptForSession() = %q, want %q", result, expectedFile)
+	}
+}
+
+func TestFindTranscriptForSession_NotFound(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	result := FindTranscriptForSession("nonexistent-session")
+	if result != "" {
+		t.Errorf("FindTranscriptForSession() = %q, want empty string", result)
+	}
+}
+
+func TestFindTranscriptForSession_PrefersNewFormat(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	claudeDir := filepath.Join(tempHome, ".claude")
+	sessionID := "shared-session"
+
+	// Create both old and new format files.
+	projectDir := filepath.Join(claudeDir, "projects", "pref-project")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	newFile := filepath.Join(projectDir, sessionID+".jsonl")
+	if err := os.WriteFile(newFile, []byte(`{"type":"new"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	transcriptsDir := filepath.Join(claudeDir, "transcripts")
+	if err := os.MkdirAll(transcriptsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	oldFile := filepath.Join(transcriptsDir, sessionID+".jsonl")
+	if err := os.WriteFile(oldFile, []byte(`{"type":"old"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result := FindTranscriptForSession(sessionID)
+	if result == "" {
+		t.Fatal("FindTranscriptForSession() returned empty, want match")
+	}
+
+	// New format (projects) should be preferred over old format (transcripts).
+	if result != newFile {
+		t.Errorf("FindTranscriptForSession() = %q, want new format %q", result, newFile)
+	}
+}
+
+func TestParseTranscript_BasicUsage(t *testing.T) {
+	dir := t.TempDir()
+	transcriptFile := filepath.Join(dir, "test-session.jsonl")
+
+	content := `{"timestamp":"2026-01-01T10:00:00Z","type":"user","message":{}}
+{"timestamp":"2026-01-01T10:00:05Z","type":"assistant","model":"claude-3-opus","message":{"usage":{"input_tokens":100,"output_tokens":50,"cache_creation_input_tokens":10,"cache_read_input_tokens":5}}}
+{"timestamp":"2026-01-01T10:00:10Z","type":"user","message":{}}
+{"timestamp":"2026-01-01T10:00:15Z","type":"assistant","model":"claude-3-opus","message":{"usage":{"input_tokens":200,"output_tokens":100,"cache_creation_input_tokens":20,"cache_read_input_tokens":10}}}
+`
+	if err := os.WriteFile(transcriptFile, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	usage, err := ParseTranscript(transcriptFile)
+	if err != nil {
+		t.Fatalf("ParseTranscript() returned error: %v", err)
+	}
+
+	if usage.InputTokens != 300 {
+		t.Errorf("InputTokens = %d, want 300", usage.InputTokens)
+	}
+	if usage.OutputTokens != 150 {
+		t.Errorf("OutputTokens = %d, want 150", usage.OutputTokens)
+	}
+	if usage.CacheCreationTokens != 30 {
+		t.Errorf("CacheCreationTokens = %d, want 30", usage.CacheCreationTokens)
+	}
+	if usage.CacheReadTokens != 15 {
+		t.Errorf("CacheReadTokens = %d, want 15", usage.CacheReadTokens)
+	}
+	if usage.TurnCount != 2 {
+		t.Errorf("TurnCount = %d, want 2", usage.TurnCount)
+	}
+	if usage.ModelName != "claude-3-opus" {
+		t.Errorf("ModelName = %q, want %q", usage.ModelName, "claude-3-opus")
+	}
+}
+
+func TestParseTranscript_FileNotFound(t *testing.T) {
+	_, err := ParseTranscript("/nonexistent/path/transcript.jsonl")
+	if err == nil {
+		t.Fatal("ParseTranscript() should return error for missing file")
+	}
+}


### PR DESCRIPTION
## Summary

- Fix `FindTranscripts()` and `FindTranscriptForSession()` to search Claude Code CLI paths in addition to Claude Desktop paths
- Add 3-priority search order: CLI new format (`~/.claude/projects/*/*.jsonl`) → CLI old format (`~/.claude/transcripts/*.jsonl`) → Desktop paths (fallback)
- Add deduplication to prevent duplicate transcript entries across sources
- Add 12 comprehensive unit tests with full filesystem isolation

## Root Cause

`claudeConfigDir()` returned Claude Desktop (Electron app) paths only:
- macOS: `~/Library/Application Support/Claude/*/transcripts/*.jsonl`
- Linux: `~/.config/Claude/*/transcripts/*.jsonl`

Claude Code CLI users without Desktop app installed got "No transcripts found" because the CLI stores transcripts at `~/.claude/projects/<project-slug>/*.jsonl`.

## Changes

- **`internal/rank/transcript.go`**: Refactored path detection functions, added `claudeCodeDir()`, `globJSONL()` helper, multi-path search in `FindTranscripts()` and `FindTranscriptForSession()`
- **`internal/rank/transcript_test.go`** (new): 12 tests covering path resolution, CLI path discovery, deduplication, session lookup, priority order, and existing `ParseTranscript` behavior

## Test plan

- [x] All 90 tests pass with `go test -race ./internal/rank/...`
- [x] `go vet` clean
- [x] Tests use `t.TempDir()` and `t.Setenv()` for isolation
- [x] Backward compatible with Claude Desktop users
- [x] Graceful handling of missing directories (returns empty, no error)

Fixes #369

🗿 MoAI <email@mo.ai.kr>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced transcript discovery to search multiple configuration locations with a prioritized order, ensuring transcripts are reliably found across different installation types.
  * Improved deduplication logic to prevent duplicate transcripts from appearing.
  
* **Tests**
  * Added comprehensive unit tests for transcript discovery and parsing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->