### PR TITLE
fix(wizard): reorder language options to fix huh viewport YOffset bug

### DIFF
--- a/internal/cli/wizard/questions.go
+++ b/internal/cli/wizard/questions.go
@@ -27,9 +27,12 @@ func DefaultQuestions(projectRoot string) []Question {
 			Type:        QuestionTypeSelect,
 			Title:       "Select conversation language",
 			Description: "This determines the language Claude will use to communicate with you.",
+			// Default option must be first to avoid huh v0.8.0 viewport YOffset bug:
+			// selectOption() sets viewport.YOffset = selected index unconditionally,
+			// hiding options above the default when all items fit in the viewport.
 			Options: []Option{
-				{Label: "Korean (한국어)", Value: "ko", Desc: "Korean"},
 				{Label: "English", Value: "en", Desc: "English"},
+				{Label: "Korean (한국어)", Value: "ko", Desc: "Korean"},
 				{Label: "Japanese (日本語)", Value: "ja", Desc: "Japanese"},
 				{Label: "Chinese (中文)", Value: "zh", Desc: "Chinese"},
 			},
@@ -151,8 +154,8 @@ func DefaultQuestions(projectRoot string) []Question {
 			Title:       "Select language for Git commits",
 			Description: "Language used for commit messages.",
 			Options: []Option{
-				{Label: "Korean (한국어)", Value: "ko", Desc: "Write commits in Korean"},
 				{Label: "English", Value: "en", Desc: "Write commits in English"},
+				{Label: "Korean (한국어)", Value: "ko", Desc: "Write commits in Korean"},
 				{Label: "Japanese (日本語)", Value: "ja", Desc: "Write commits in Japanese"},
 				{Label: "Chinese (中文)", Value: "zh", Desc: "Write commits in Chinese"},
 			},
@@ -166,8 +169,8 @@ func DefaultQuestions(projectRoot string) []Question {
 			Title:       "Select language for code comments",
 			Description: "Language used for comments in code.",
 			Options: []Option{
-				{Label: "Korean (한국어)", Value: "ko", Desc: "Write comments in Korean"},
 				{Label: "English", Value: "en", Desc: "Write comments in English"},
+				{Label: "Korean (한국어)", Value: "ko", Desc: "Write comments in Korean"},
 				{Label: "Japanese (日本語)", Value: "ja", Desc: "Write comments in Japanese"},
 				{Label: "Chinese (中文)", Value: "zh", Desc: "Write comments in Chinese"},
 			},
@@ -181,8 +184,8 @@ func DefaultQuestions(projectRoot string) []Question {
 			Title:       "Select language for documentation",
 			Description: "Language used for documentation files.",
 			Options: []Option{
-				{Label: "Korean (한국어)", Value: "ko", Desc: "Write docs in Korean"},
 				{Label: "English", Value: "en", Desc: "Write docs in English"},
+				{Label: "Korean (한국어)", Value: "ko", Desc: "Write docs in Korean"},
 				{Label: "Japanese (日本語)", Value: "ja", Desc: "Write docs in Japanese"},
 				{Label: "Chinese (中文)", Value: "zh", Desc: "Write docs in Chinese"},
 			},


### PR DESCRIPTION
## Summary
Fix for language selection showing only 3 of 4 options in `moai update -c` wizard

## Root Cause
The charmbracelet/huh v0.8.0 `selectOption()` unconditionally sets `viewport.YOffset = selected` index. When the default option ("en") was at index 1, the Korean option at index 0 was hidden above the viewport, causing only 3 of 4 language options to be visible.

## Solution
Reordered language option arrays so the default ("en") is at index 0, ensuring `viewport.YOffset=0` keeps all options visible in the viewport regardless of huh's viewport behavior.

## Changes
- Reordered all four language option lists to place English at index 0:
  - locale (conversation language)
  - git_commit_lang (commit message language)
  - code_comment_lang (code comment language)
  - doc_lang (documentation language)

## Testing
Manual verification: All 4 language options now visible in the wizard when running `moai update -c`

## Files Modified
- `internal/cli/wizard/questions.go`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reordered language selection options in the command-line wizard interface. English is now positioned as the default first option, with consistent ordering applied across locale, code, and documentation language preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->