### PR TITLE
fix(windows): platform default and browser URL escaping

### DIFF
--- a/internal/core/project/phase.go
+++ b/internal/core/project/phase.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/modu-ai/moai-adk/pkg/models"
 )
@@ -234,6 +235,11 @@ func applyDetectedDefaults(opts InitOptions, languages []Language, frameworks []
 	// GitMode defaults to "manual"
 	if opts.GitMode == "" {
 		opts.GitMode = "manual"
+	}
+
+	// Platform defaults to current OS ("darwin", "linux", "windows")
+	if opts.Platform == "" {
+		opts.Platform = runtime.GOOS
 	}
 
 	// Output language defaults to "en"

--- a/internal/rank/browser.go
+++ b/internal/rank/browser.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os/exec"
 	"runtime"
+	"strings"
 )
 
 // Browser implements BrowserOpener using platform-specific commands.
@@ -28,7 +29,10 @@ func (b *Browser) Open(url string) error {
 	case "linux":
 		cmd = exec.Command("xdg-open", url)
 	case "windows":
-		cmd = exec.Command("cmd", "/c", "start", url)
+		// Escape & as ^& because cmd.exe interprets & as a command separator.
+		// OAuth callback URLs contain multiple query parameters joined by &.
+		escapedURL := strings.ReplaceAll(url, "&", "^&")
+		cmd = exec.Command("cmd", "/c", "start", escapedURL)
 	default:
 		return fmt.Errorf("unsupported platform: %s", runtime.GOOS)
 	}

--- a/internal/rank/browser_test.go
+++ b/internal/rank/browser_test.go
@@ -1,0 +1,39 @@
+package rank
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBrowserWindowsURLEscaping(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "single ampersand",
+			input: "https://example.com/auth?a=1&b=2",
+			want:  "https://example.com/auth?a=1^&b=2",
+		},
+		{
+			name:  "multiple ampersands",
+			input: "https://example.com/auth?a=1&b=2&c=3",
+			want:  "https://example.com/auth?a=1^&b=2^&c=3",
+		},
+		{
+			name:  "no ampersand",
+			input: "https://example.com/auth?code=abc",
+			want:  "https://example.com/auth?code=abc",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := strings.ReplaceAll(tt.input, "&", "^&")
+			if got != tt.want {
+				t.Errorf("URL escaping = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- **phase.go**: `applyDetectedDefaults()` now sets `Platform = runtime.GOOS` when empty, fixing `moai init` on Windows generating `/bin/bash` in `.mcp.json`
- **browser.go**: Escape `&` as `^&` in URLs before passing to `cmd /c start`, fixing OAuth callback URLs with multiple query parameters on Windows

## Root Cause

- `InitOptions.Platform` was documented as "defaults to runtime.GOOS" but the default was never applied in `applyDetectedDefaults()`
- `cmd.exe` interprets `&` as a command separator, so URLs like `https://...?a=1&b=2` were split into separate commands

## Test Plan

- [x] `TestApplyDetectedDefaults/platform_defaults_to_runtime.GOOS` — verifies Platform is set to a known OS value
- [x] `TestApplyDetectedDefaults/explicit_platform_not_overridden` — verifies explicit Platform is not overridden
- [x] `TestBrowserWindowsURLEscaping` — 3 table-driven subtests: single `&`, multiple `&`, no `&`
- [x] Full test suite passes: `go test -race ./...` (30 packages)

Fixes #405, #406

🗿 MoAI <email@mo.ai.kr>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed URL handling on Windows platforms to properly escape special characters in command-line operations, preventing application launch failures.

* **Improvements**
  * Implemented automatic platform detection that defaults to the current operating system when not explicitly configured, enhancing out-of-box compatibility and reducing setup requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->