### PR TITLE
fix(hook): auto-cleanup GLM settings on SessionEnd

### DIFF
--- a/internal/hook/session_end.go
+++ b/internal/hook/session_end.go
@@ -61,6 +61,16 @@ func (h *sessionEndHandler) Handle(ctx context.Context, input *HookInput) (*Hook
 	// This ensures the lead session returns to Claude after team completion.
 	clearTmuxSessionEnv()
 
+	// Clean up GLM env vars from settings.local.json.
+	// This ensures that if the session ends unexpectedly (error, crash, agent not terminated),
+	// the next session starts with Claude models instead of continuing to use GLM.
+	// Note: We do NOT reset team_mode in llm.yaml - that is intentional config that
+	// should persist across sessions for consistent team mode usage.
+	// We also do NOT remove CLAUDE_CODE_TEAMMATE_DISPLAY - that is a display setting.
+	if input.ProjectDir != "" {
+		cleanupGLMSettings(input.ProjectDir)
+	}
+
 	// SessionEnd hooks return empty JSON {} per Claude Code protocol
 	// Do NOT use hookSpecificOutput for SessionEnd events
 	return &HookOutput{}, nil
@@ -277,5 +287,70 @@ func clearTmuxSessionEnv() {
 		} else {
 			slog.Info("session_end: cleared tmux env", "env", name)
 		}
+	}
+}
+
+// cleanupGLMSettings removes GLM env vars from settings.local.json.
+// This ensures the next session starts with Claude models.
+func cleanupGLMSettings(projectDir string) {
+	settingsPath := filepath.Join(projectDir, ".claude", "settings.local.json")
+
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			slog.Warn("session_end: could not read settings.local.json", "error", err)
+		}
+		return
+	}
+
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		slog.Warn("session_end: could not parse settings.local.json", "error", err)
+		return
+	}
+
+	env, ok := settings["env"].(map[string]any)
+	if !ok {
+		return // No env section
+	}
+
+	// Remove GLM-related env vars only.
+	// We do NOT remove CLAUDE_CODE_TEAMMATE_DISPLAY - that is a tmux display setting
+	// that should persist for future team work sessions.
+	glmVars := []string{
+		"ANTHROPIC_AUTH_TOKEN",
+		"ANTHROPIC_BASE_URL",
+		"ANTHROPIC_DEFAULT_OPUS_MODEL",
+		"ANTHROPIC_DEFAULT_SONNET_MODEL",
+		"ANTHROPIC_DEFAULT_HAIKU_MODEL",
+	}
+
+	changed := false
+	for _, key := range glmVars {
+		if _, exists := env[key]; exists {
+			delete(env, key)
+			changed = true
+		}
+	}
+
+	if !changed {
+		return
+	}
+
+	// Clean up empty env map
+	if len(env) == 0 {
+		delete(settings, "env")
+	}
+
+	newData, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		slog.Warn("session_end: could not marshal settings", "error", err)
+		return
+	}
+
+	if err := os.WriteFile(settingsPath, newData, 0o644); err != nil {
+		slog.Warn("session_end: could not write settings", "error", err)
+	} else {
+		slog.Info("session_end: cleaned up GLM env from settings.local.json")
 	}
 }

--- a/internal/hook/session_end_test.go
+++ b/internal/hook/session_end_test.go
@@ -273,3 +273,139 @@ func TestSessionEndHandler_AlwaysReturnsEmptyOutput(t *testing.T) {
 		t.Errorf("ExitCode should be 0, got %d", got.ExitCode)
 	}
 }
+
+func TestCleanupGLMSettings(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		existingData   map[string]any
+		wantRemoved    []string
+		wantRemaining  []string
+		wantEnvDeleted bool
+	}{
+		{
+			name: "removes GLM env vars but keeps TEAMMATE_DISPLAY",
+			existingData: map[string]any{
+				"env": map[string]any{
+					"ANTHROPIC_AUTH_TOKEN":         "glm-token",
+					"ANTHROPIC_BASE_URL":           "https://glm.example.com",
+					"ANTHROPIC_DEFAULT_OPUS_MODEL":  "glm-5",
+					"ANTHROPIC_DEFAULT_SONNET_MODEL": "glm-4.7",
+					"ANTHROPIC_DEFAULT_HAIKU_MODEL": "glm-4.7-air",
+					"CLAUDE_CODE_TEAMMATE_DISPLAY": "tmux",
+					"OTHER_VAR":                    "keep-me",
+				},
+			},
+			wantRemoved: []string{
+				"ANTHROPIC_AUTH_TOKEN",
+				"ANTHROPIC_BASE_URL",
+				"ANTHROPIC_DEFAULT_OPUS_MODEL",
+				"ANTHROPIC_DEFAULT_SONNET_MODEL",
+				"ANTHROPIC_DEFAULT_HAIKU_MODEL",
+			},
+			wantRemaining:  []string{"OTHER_VAR", "CLAUDE_CODE_TEAMMATE_DISPLAY"},
+			wantEnvDeleted: false, // env still has OTHER_VAR and TEAMMATE_DISPLAY
+		},
+		{
+			name: "removes all GLM vars and deletes env section",
+			existingData: map[string]any{
+				"env": map[string]any{
+					"ANTHROPIC_AUTH_TOKEN": "glm-token",
+					"ANTHROPIC_BASE_URL":   "https://glm.example.com",
+				},
+			},
+			wantRemoved:    []string{"ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_BASE_URL"},
+			wantRemaining:   nil,
+			wantEnvDeleted:  true, // env becomes empty, should be deleted
+		},
+		{
+			name: "no GLM vars - no changes",
+			existingData: map[string]any{
+				"env": map[string]any{
+					"OTHER_VAR": "keep-me",
+				},
+			},
+			wantRemoved:    nil,
+			wantRemaining:  []string{"OTHER_VAR"},
+			wantEnvDeleted: false,
+		},
+		{
+			name:          "no env section - no changes",
+			existingData:  map[string]any{},
+			wantRemoved:   nil,
+			wantRemaining: nil,
+			wantEnvDeleted: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpDir := t.TempDir()
+			claudeDir := filepath.Join(tmpDir, ".claude")
+			if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+				t.Fatalf("setup .claude dir: %v", err)
+			}
+
+			settingsPath := filepath.Join(claudeDir, "settings.local.json")
+			data, err := json.MarshalIndent(tt.existingData, "", "  ")
+			if err != nil {
+				t.Fatalf("marshal settings: %v", err)
+			}
+			if err := os.WriteFile(settingsPath, data, 0o644); err != nil {
+				t.Fatalf("write settings: %v", err)
+			}
+
+			cleanupGLMSettings(tmpDir)
+
+			// Read back and verify
+			resultData, err := os.ReadFile(settingsPath)
+			if err != nil {
+				t.Fatalf("read result settings: %v", err)
+			}
+
+			var result map[string]any
+			if err := json.Unmarshal(resultData, &result); err != nil {
+				t.Fatalf("unmarshal result: %v", err)
+			}
+
+			// Check removed vars
+			env, hasEnv := result["env"].(map[string]any)
+			for _, key := range tt.wantRemoved {
+				if hasEnv {
+					if _, exists := env[key]; exists {
+						t.Errorf("var %q should have been removed", key)
+					}
+				}
+			}
+
+			// Check remaining vars
+			for _, key := range tt.wantRemaining {
+				if !hasEnv {
+					t.Errorf("env section was deleted but %q should remain", key)
+					continue
+				}
+				if _, exists := env[key]; !exists {
+					t.Errorf("var %q should still exist", key)
+				}
+			}
+
+			// Check if env was deleted when empty
+			if tt.wantEnvDeleted {
+				if hasEnv {
+					t.Error("env section should have been deleted when empty")
+				}
+			}
+		})
+	}
+}
+
+func TestCleanupGLMSettings_MissingFile(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	// Don't create settings.local.json - should not panic
+	cleanupGLMSettings(tmpDir)
+}


### PR DESCRIPTION
## Summary

Fixes the issue where GLM environment variables persist after team mode ends unexpectedly.

## Problem

When using `moai cg --team`:
1. GLM env vars are injected (tmux session level + settings.local.json for GLM mode)
2. If the session ends unexpectedly (error, crash, agent not terminated)
3. GLM env vars in settings.local.json are NOT cleaned up
4. **Result**: User continues using GLM instead of Claude

## Solution

Enhanced `SessionEnd` hook to clean up GLM env vars from `settings.local.json`:

### Removes (GLM env vars only)
- `ANTHROPIC_AUTH_TOKEN`
- `ANTHROPIC_BASE_URL`
- `ANTHROPIC_DEFAULT_OPUS_MODEL`
- `ANTHROPIC_DEFAULT_SONNET_MODEL`
- `ANTHROPIC_DEFAULT_HAIKU_MODEL`

### Preserves (intentional config)
- `CLAUDE_CODE_TEAMMATE_DISPLAY` - tmux display setting for future team work
- `team_mode` in llm.yaml - intentional config set via `moai cg` or `moai glm`

## Design Rationale

| Setting | Action | Reason |
|---------|--------|--------|
| GLM env vars | Remove | API keys and model overrides should not persist |
| `CLAUDE_CODE_TEAMMATE_DISPLAY` | Keep | Display setting for consistent tmux behavior |
| `team_mode` (llm.yaml) | Keep | Intentional config for cross-session team mode |

## Changes

| File | Change |
|------|--------|
| `internal/hook/session_end.go` | Added `cleanupGLMSettings()` function |
| `internal/hook/session_end_test.go` | Tests verify correct cleanup behavior |

**Total**: +211 lines

## Test Plan

- [x] `go build ./...` - compilation successful
- [x] `go test ./internal/hook/...` - all tests pass
- [x] Test cases cover:
  - GLM env var removal
  - `CLAUDE_CODE_TEAMMATE_DISPLAY` preservation
  - Missing file handling

## Impact

- GLM API keys are cleaned up on session end
- Team mode display settings persist for convenience
- Users can continue using team mode without reconfiguration

🗿 MoAI <email@mo.ai.kr>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session end cleanup to remove GLM-related environment variables from local project settings, while preserving teammate display and leaving team mode unchanged.

* **Tests**
  * Added tests covering cleanup behavior, including verification of retained settings and safe handling when local settings are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->