### PR TITLE
fix(docs): remove @ references to agent-authoring.md for path frontmatter compliance

### DIFF
--- a/.claude/skills/moai/SKILL.md
+++ b/.claude/skills/moai/SKILL.md
@@ -29,7 +29,7 @@ Rules and constraints governing all workflows are always loaded from these sourc
 - Quality gates, security boundaries: @.claude/rules/moai/core/moai-constitution.md
 - SPEC workflow phases, token budgets: @.claude/rules/moai/workflow/spec-workflow.md
 - Development methodologies (DDD/TDD): @.claude/rules/moai/workflow/workflow-modes.md
-- Agent definitions and creation: @.claude/rules/moai/development/agent-authoring.md
+- Agent definitions: See CLAUDE.md Section 4. For agent creation, use builder-agent subagent.
 - @MX tag rules and protocol: @.claude/rules/moai/workflow/mx-tag-protocol.md
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ researcher, analyst, architect, designer, backend-dev, frontend-dev, tester, qua
 
 Both `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` env var AND `workflow.team.enabled: true` in `.moai/config/sections/workflow.yaml` are required.
 
-For detailed agent descriptions, capabilities, and creation guidelines, see @.claude/rules/moai/development/agent-authoring.md.
+For detailed agent descriptions, see the Agent Catalog section above. For agent creation guidelines, use the builder-agent subagent or see `.claude/rules/moai/development/agent-authoring.md`.
 
 ---
 

--- a/internal/template/templates/.claude/skills/moai/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai/SKILL.md
@@ -29,7 +29,7 @@ Rules and constraints governing all workflows are always loaded from these sourc
 - Quality gates, security boundaries: @.claude/rules/moai/core/moai-constitution.md
 - SPEC workflow phases, token budgets: @.claude/rules/moai/workflow/spec-workflow.md
 - Development methodologies (DDD/TDD): @.claude/rules/moai/workflow/workflow-modes.md
-- Agent definitions and creation: @.claude/rules/moai/development/agent-authoring.md
+- Agent definitions: See CLAUDE.md Section 4. For agent creation, use builder-agent subagent.
 - @MX tag rules and protocol: @.claude/rules/moai/workflow/mx-tag-protocol.md
 
 ---

--- a/internal/template/templates/CLAUDE.md
+++ b/internal/template/templates/CLAUDE.md
@@ -111,7 +111,7 @@ researcher, analyst, architect, designer, backend-dev, frontend-dev, tester, qua
 
 Both `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` env var AND `workflow.team.enabled: true` in `.moai/config/sections/workflow.yaml` are required.
 
-For detailed agent descriptions, capabilities, and creation guidelines, see @.claude/rules/moai/development/agent-authoring.md.
+For detailed agent descriptions, see the Agent Catalog section above. For agent creation guidelines, use the builder-agent subagent or see `.claude/rules/moai/development/agent-authoring.md`.
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes #426 - Removes `@` direct references to `agent-authoring.md` from `CLAUDE.md` and `SKILL.md` to honor the file's `paths: "**/.claude/agents/**"` frontmatter restriction.

## Problem

The `agent-authoring.md` file has `paths: "**/.claude/agents/**"` frontmatter that should restrict loading to agent-creation contexts only. However, direct `@` references in:
- `CLAUDE.md` line 112
- `.claude/skills/moai/SKILL.md` line 32

...were bypassing this restriction, causing the file to load on every session (~2,000-2,800 tokens wasted).

## Solution

Replaced direct `@` references with text descriptions that guide users to:
1. The Agent Catalog section in CLAUDE.md (for descriptions)
2. The `builder-agent` subagent (for creation)

The file remains discoverable via:
- `builder-agent` subagent invocation
- Direct file access

## Changes

- `CLAUDE.md`: Changed `@.claude/rules/moai/development/agent-authoring.md` to text
- `.claude/skills/moai/SKILL.md`: Changed `@` reference to text
- Template files updated in parallel

## Test Plan

- [x] All tests passing (`go test ./...`)
- [x] Build succeeds (`make build`)
- [x] Changes verified in both local and template files

Fixes #426

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Consolidated agent reference guidance across documentation files to direct users to CLAUDE.md Section 4 for agent definitions and to the builder-agent subagent for agent creation assistance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->