### PR TITLE
fix(statusline): goroutine race로 인한 사용량 캐시 미저장 수정

### DIFF
--- a/internal/statusline/usage.go
+++ b/internal/statusline/usage.go
@@ -100,18 +100,17 @@ func (u *usageCollector) CollectUsage(ctx context.Context) (*UsageResult, error)
 		return nil, nil
 	}
 
-	// Update cache (async, continue on failure)
+	// Update cache synchronously. moai statusline runs as a short-lived process,
+	// so async writes race with process exit and may lose data.
 	cache := &usageCacheFile{
 		CachedAt: time.Now().Unix(),
 		Usage5H:  usage5H,
 		Usage7D:  usage7D,
 	}
-	go func() {
-		u.mu.Lock()
-		u.cache = cache
-		u.mu.Unlock()
-		_ = u.saveCache(cache)
-	}()
+	u.mu.Lock()
+	u.cache = cache
+	u.mu.Unlock()
+	_ = u.saveCache(cache)
 
 	return u.toUsageResult(cache), nil
 }


### PR DESCRIPTION
## Summary

- `moai statusline`은 단기(short-lived) 프로세스로 실행됨
- 비동기 goroutine으로 캐시를 저장하면, 프로세스 종료와 경쟁 상태(race condition) 발생
- 캐시가 디스크에 저장되지 않아 매 호출마다 OAuth API를 재요청
- 결과: 429 Rate Limit 발생 + 5H/7D 사용량 바가 갱신되지 않음

### Fix

- `go func() { saveCache() }()` → 동기 `saveCache()` 호출로 변경
- 프로세스 종료 전에 캐시가 항상 디스크에 기록됨

## Changed Files

- `internal/statusline/usage.go`: 비동기 goroutine → 동기 캐시 저장

## Test Plan

- [x] `go test ./internal/statusline/...` (기존 테스트 통과 확인)
- [x] `go vet ./internal/statusline/...` 클린
- [ ] 실제 환경에서 `moai statusline` 실행 후 `~/.moai/cache/usage.json` 갱신 확인

🗿 MoAI <email@mo.ai.kr>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed data consistency issues in cache updates to ensure usage data is properly saved when the process terminates, eliminating potential data loss scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->