### PR TITLE
refactor: translate Korean comments to English

### DIFF
--- a/internal/cli/glm.go
+++ b/internal/cli/glm.go
@@ -188,7 +188,7 @@ func enableTeamMode(cmd *cobra.Command, isHybrid bool) error {
 
 	settingsPath := filepath.Join(root, defs.ClaudeDir, defs.SettingsLocalJSON)
 
-	// 현재 tmux 세션 여부 확인
+	// Check whether we are inside a tmux session
 	inTmux := tmux.NewDetector().InTmuxSession()
 
 	// CG mode requires tmux for pane-level environment isolation.

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -244,7 +244,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 		PrintBanner(version.GetVersion())
 		PrintWelcomeMessage()
 
-		// init.go에서는 locale 없이 실행 (기존 동작 유지)
+		// Run without locale in init.go (preserve existing behavior)
 		result, err := wizard.RunWithDefaults(rootFlag, "")
 		if err != nil {
 			if errors.Is(err, wizard.ErrCancelled) {

--- a/internal/cli/launcher.go
+++ b/internal/cli/launcher.go
@@ -317,7 +317,7 @@ func removeWorktree(projectRoot, worktreeName string) error {
 }
 
 // runGitCommand executes a git command in the given directory.
-// GitManager를 통해 실행하여 타임아웃과 에러 처리를 일관되게 적용한다.
+// Runs via GitManager to apply consistent timeout and error handling.
 func runGitCommand(dir string, args ...string) (string, error) {
 	mgr := gitops.NewGitManager(gitops.ManagerConfig{
 		WorkDir:               dir,
@@ -331,7 +331,7 @@ func runGitCommand(dir string, args ...string) (string, error) {
 		}
 		return "", fmt.Errorf("git %s failed: %s", strings.Join(args, " "), result.Stderr)
 	}
-	// trailing newline 보존을 위해 TrimSpace 하지 않음 (기존 exec.Output() 동작과 동일)
+	// Do not TrimSpace to preserve trailing newline (matches legacy exec.Output() behavior)
 	return result.Stdout + "\n", nil
 }
 

--- a/internal/cli/loop_test.go
+++ b/internal/cli/loop_test.go
@@ -58,7 +58,7 @@ func TestLoopCmd_HasExpectedSubcommands(t *testing.T) {
 	}
 }
 
-// --- noopFeedbackGenerator 테스트 ---
+// --- noopFeedbackGenerator tests ---
 
 func TestNoopFeedbackGenerator_Collect(t *testing.T) {
 	gen := &noopFeedbackGenerator{}
@@ -71,7 +71,7 @@ func TestNoopFeedbackGenerator_Collect(t *testing.T) {
 	}
 }
 
-// --- 커맨드 핸들러 테스트 (의존성 없는 경우) ---
+// --- Command handler tests (when dependencies are nil) ---
 
 func TestRunLoopStart_NilDeps(t *testing.T) {
 	origDeps := deps
@@ -128,7 +128,7 @@ func TestRunLoopCancel_NilDeps(t *testing.T) {
 	}
 }
 
-// --- 실제 LoopController 연결 통합 테스트 ---
+// --- Integration tests with a real LoopController ---
 
 func newTestLoopDeps(t *testing.T) *Dependencies {
 	t.Helper()
@@ -141,7 +141,7 @@ func newTestLoopDeps(t *testing.T) *Dependencies {
 	}
 }
 
-// stubDecisionEngine은 항상 ActionAbort를 반환하는 테스트용 엔진이다.
+// stubDecisionEngine is a test engine that always returns ActionAbort.
 type stubDecisionEngine struct{}
 
 func (e *stubDecisionEngine) Decide(_ context.Context, _ *loop.LoopState, _ *loop.Feedback) (*loop.Decision, error) {
@@ -207,7 +207,7 @@ func TestRunLoopResume_NotPaused(t *testing.T) {
 	}
 }
 
-// TestLoopSubcmds_ArgsValidation는 서브커맨드별 필수 인자 검증 테이블 테스트다.
+// TestLoopSubcmds_ArgsValidation is a table-driven test for required argument validation per subcommand.
 func TestLoopSubcmds_ArgsValidation(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/cli/profile_setup_test.go
+++ b/internal/cli/profile_setup_test.go
@@ -32,7 +32,7 @@ func TestGetProfileText_ThemeFields(t *testing.T) {
 
 // TestGetProfileText_ModeFields verifies that all supported languages
 // include translations for the statusline mode selector fields.
-// REQ-V3-MODE-003: 프로필 위저드는 compact/default/full 이름을 표시한다.
+// REQ-V3-MODE-003: the profile wizard displays compact/default/full names.
 func TestGetProfileText_ModeFields(t *testing.T) {
 	langs := []string{"en", "ko", "ja", "zh"}
 	for _, lang := range langs {
@@ -44,7 +44,7 @@ func TestGetProfileText_ModeFields(t *testing.T) {
 			if text.StatuslineModeDesc == "" {
 				t.Errorf("lang %q: StatuslineModeDesc is empty", lang)
 			}
-			// v3 모드 레이블 검증
+			// Validate v3 mode labels.
 			if text.ModeDefault == "" {
 				t.Errorf("lang %q: ModeDefault is empty", lang)
 			}
@@ -54,7 +54,7 @@ func TestGetProfileText_ModeFields(t *testing.T) {
 			if text.ModeFull == "" {
 				t.Errorf("lang %q: ModeFull is empty", lang)
 			}
-			// 하위 호환성을 위한 deprecated 필드도 검증
+			// Also validate deprecated fields for backward compatibility.
 			if text.ModeVerbose == "" {
 				t.Errorf("lang %q: ModeVerbose is empty", lang)
 			}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -1733,17 +1733,17 @@ func runInitWizard(cmd *cobra.Command, reconfigure bool) error {
 		PrintWelcomeMessage()
 	}
 
-	// REQ-1: language.yaml에서 locale 읽기
+	// REQ-1: Read locale from language.yaml
 	locale := wizard.ReadLocaleFromProject(cwd)
 
-	// REQ-2: 기존 설정에서 사용자명 읽기 (기본값으로 사용)
+	// REQ-2: Read existing usernames from config (used as defaults)
 	existingGitHubUsername := wizard.ReadGitHubUsernameFromConfig(cwd)
 	existingGitLabUsername := wizard.ReadGitLabUsernameFromConfig(cwd)
 
-	// REQ-3: gh CLI 인증 여부 확인
+	// REQ-3: Check gh CLI authentication status
 	ghAuthenticated := wizard.IsGhAuthenticated()
 
-	// 기본 질문 생성 및 기존 값으로 기본값 설정
+	// Build default questions and set existing values as defaults
 	questions := wizard.DefaultQuestions(cwd)
 	if existingGitHubUsername != "" {
 		if q := wizard.QuestionByID(questions, "github_username"); q != nil {
@@ -1755,14 +1755,14 @@ func runInitWizard(cmd *cobra.Command, reconfigure bool) error {
 			q.Default = existingGitLabUsername
 		}
 	}
-	// REQ-3: gh auth 인증된 경우 github_token 질문 스킵
+	// REQ-3: Skip github_token question when gh CLI is authenticated
 	if ghAuthenticated {
 		if q := wizard.QuestionByID(questions, "github_token"); q != nil {
 			q.Condition = func(_ *wizard.WizardResult) bool { return false }
 		}
 	}
 
-	// locale과 커스텀 질문으로 위저드 실행
+	// Run wizard with locale and custom questions
 	result, err := wizard.RunWithLocale(questions, nil, locale)
 	if err != nil {
 		if errors.Is(err, wizard.ErrCancelled) {
@@ -1783,22 +1783,22 @@ func runInitWizard(cmd *cobra.Command, reconfigure bool) error {
 	return nil
 }
 
-// applyWizardConfig는 위저드 결과를 프로젝트 설정 파일에 반영한다.
+// applyWizardConfig applies wizard results to project configuration files.
 func applyWizardConfig(projectRoot string, result *wizard.WizardResult) error {
 	sectionsDir := filepath.Join(projectRoot, defs.MoAIDir, defs.SectionsSubdir)
 
-	// user.yaml: GitHub/GitLab 사용자명·토큰 저장 (REQ-4, REQ-5)
+	// user.yaml: Save GitHub/GitLab username and token (REQ-4, REQ-5)
 	hasUserFields := result.GitHubUsername != "" || result.GitHubToken != "" ||
 		result.GitLabUsername != "" || result.GitLabToken != ""
 	if hasUserFields {
 		userPath := filepath.Join(sectionsDir, defs.UserYAML)
-		// 기존 파일 읽기
+		// Read existing file
 		userData, err := os.ReadFile(userPath)
 		if err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("read user.yaml: %w", err)
 		}
 
-		// YAML 파싱
+		// Parse YAML
 		var user map[string]any
 		if len(userData) > 0 {
 			if err := yaml.Unmarshal(userData, &user); err != nil {
@@ -1808,7 +1808,7 @@ func applyWizardConfig(projectRoot string, result *wizard.WizardResult) error {
 			user = make(map[string]any)
 		}
 
-		// user.user 섹션 확보
+		// Ensure user.user section exists
 		var userConfig map[string]any
 		if existingUser, ok := user["user"].(map[string]any); ok {
 			userConfig = existingUser
@@ -1816,7 +1816,7 @@ func applyWizardConfig(projectRoot string, result *wizard.WizardResult) error {
 			userConfig = make(map[string]any)
 		}
 
-		// GitHub 크레덴셜 저장
+		// Save GitHub credentials
 		if result.GitHubUsername != "" {
 			userConfig["github_username"] = result.GitHubUsername
 		}
@@ -1824,7 +1824,7 @@ func applyWizardConfig(projectRoot string, result *wizard.WizardResult) error {
 			userConfig["github_token"] = result.GitHubToken
 		}
 
-		// GitLab 크레덴셜 저장 (REQ-5)
+		// Save GitLab credentials (REQ-5)
 		if result.GitLabUsername != "" {
 			userConfig["gitlab_username"] = result.GitLabUsername
 		}
@@ -1834,7 +1834,7 @@ func applyWizardConfig(projectRoot string, result *wizard.WizardResult) error {
 
 		user["user"] = userConfig
 
-		// 파일로 저장
+		// Write to file
 		updatedData, err := yaml.Marshal(user)
 		if err != nil {
 			return fmt.Errorf("marshal user.yaml: %w", err)
@@ -1844,7 +1844,7 @@ func applyWizardConfig(projectRoot string, result *wizard.WizardResult) error {
 		}
 	}
 
-	// git-strategy.yaml: Git 모드·프로바이더 저장 (REQ-4)
+	// git-strategy.yaml: Save Git mode and provider (REQ-4)
 	if result.GitMode != "" || result.GitProvider != "" {
 		gitStratPath := filepath.Join(sectionsDir, defs.GitStrategyYAML)
 		gsData, err := os.ReadFile(gitStratPath)
@@ -1861,7 +1861,7 @@ func applyWizardConfig(projectRoot string, result *wizard.WizardResult) error {
 			gs = make(map[string]any)
 		}
 
-		// git_strategy 섹션 확보
+		// Ensure git_strategy section exists
 		var gitStrategy map[string]any
 		if existing, ok := gs["git_strategy"].(map[string]any); ok {
 			gitStrategy = existing
@@ -1876,7 +1876,7 @@ func applyWizardConfig(projectRoot string, result *wizard.WizardResult) error {
 			gitStrategy["provider"] = result.GitProvider
 		}
 
-		// GitLab instance URL 저장 (REQ-5)
+		// Save GitLab instance URL (REQ-5)
 		if result.GitLabInstanceURL != "" {
 			var gitlabSection map[string]any
 			if existing, ok := gitStrategy["gitlab"].(map[string]any); ok {
@@ -1899,7 +1899,7 @@ func applyWizardConfig(projectRoot string, result *wizard.WizardResult) error {
 		}
 	}
 
-	// quality.yaml: 개발 모드 저장 (REQ-4)
+	// quality.yaml: Save development mode (REQ-4)
 	if result.DevelopmentMode != "" {
 		qualityPath := filepath.Join(sectionsDir, defs.QualityYAML)
 		qualityData, err := os.ReadFile(qualityPath)
@@ -1916,7 +1916,7 @@ func applyWizardConfig(projectRoot string, result *wizard.WizardResult) error {
 			quality = make(map[string]any)
 		}
 
-		// constitution 섹션 확보
+		// Ensure constitution section exists
 		var constitution map[string]any
 		if existing, ok := quality["constitution"].(map[string]any); ok {
 			constitution = existing

--- a/internal/cli/wizard/config_helpers.go
+++ b/internal/cli/wizard/config_helpers.go
@@ -8,13 +8,13 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// moaiSectionsDir은 프로젝트 루트 기준 sections 디렉토리 경로를 반환한다.
+// moaiSectionsDir returns the path to the sections directory relative to the project root.
 func moaiSectionsDir(projectRoot string) string {
 	return filepath.Join(projectRoot, ".moai", "config", "sections")
 }
 
-// ReadLocaleFromProject는 language.yaml에서 conversation_language를 읽는다.
-// 파일이 없거나 파싱에 실패하면 빈 문자열을 반환한다.
+// ReadLocaleFromProject reads the conversation_language from language.yaml.
+// Returns an empty string if the file is missing or parsing fails.
 func ReadLocaleFromProject(projectRoot string) string {
 	langPath := filepath.Join(moaiSectionsDir(projectRoot), "language.yaml")
 	data, err := os.ReadFile(langPath)
@@ -36,19 +36,19 @@ func ReadLocaleFromProject(projectRoot string) string {
 	return locale
 }
 
-// ReadGitHubUsernameFromConfig는 user.yaml에서 github_username을 읽는다.
-// 파일이 없거나 값이 없으면 빈 문자열을 반환한다.
+// ReadGitHubUsernameFromConfig reads the github_username from user.yaml.
+// Returns an empty string if the file is missing or the field is absent.
 func ReadGitHubUsernameFromConfig(projectRoot string) string {
 	return readUserField(projectRoot, "github_username")
 }
 
-// ReadGitLabUsernameFromConfig는 user.yaml에서 gitlab_username을 읽는다.
-// 파일이 없거나 값이 없으면 빈 문자열을 반환한다.
+// ReadGitLabUsernameFromConfig reads the gitlab_username from user.yaml.
+// Returns an empty string if the file is missing or the field is absent.
 func ReadGitLabUsernameFromConfig(projectRoot string) string {
 	return readUserField(projectRoot, "gitlab_username")
 }
 
-// readUserField는 user.yaml의 user 섹션에서 특정 필드를 읽는다.
+// readUserField reads a specific field from the user section of user.yaml.
 func readUserField(projectRoot, field string) string {
 	userPath := filepath.Join(moaiSectionsDir(projectRoot), "user.yaml")
 	data, err := os.ReadFile(userPath)
@@ -70,15 +70,15 @@ func readUserField(projectRoot, field string) string {
 	return value
 }
 
-// IsGhAuthenticated는 gh CLI가 인증되어 있는지 확인한다.
-// gh가 없거나 인증되지 않은 경우 false를 반환한다.
+// IsGhAuthenticated checks whether the gh CLI is authenticated.
+// Returns false if gh is not installed or not authenticated.
 func IsGhAuthenticated() bool {
-	// gh CLI 존재 여부 확인
+	// Check whether the gh CLI is available
 	if _, err := exec.LookPath("gh"); err != nil {
 		return false
 	}
 
-	// gh auth status 실행 — 인증된 경우 exit 0
+	// Run gh auth status — exits 0 when authenticated
 	cmd := exec.Command("gh", "auth", "status")
 	err := cmd.Run()
 	return err == nil

--- a/internal/cli/wizard/wizard.go
+++ b/internal/cli/wizard/wizard.go
@@ -9,20 +9,20 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-// Run은 위저드를 실행하여 결과를 반환한다.
-// huh v0.8.x의 YOffset 스크롤 버그를 피하기 위해 각 질문을 독립적인 huh.Form으로 실행한다.
+// Run executes the wizard and returns the result.
+// Each question runs as its own independent huh.Form to avoid the YOffset scroll bug in huh v0.8.x.
 func Run(questions []Question, styles *Styles) (*WizardResult, error) {
 	return RunWithLocale(questions, styles, "")
 }
 
-// RunWithDefaults는 주어진 프로젝트 루트에 대한 기본 질문으로 위저드를 실행한다.
-// locale이 비어 있지 않으면 위저드 UI를 해당 언어로 표시한다.
+// RunWithDefaults runs the wizard with default questions for the given project root.
+// If locale is non-empty, the wizard UI is displayed in that language.
 func RunWithDefaults(projectRoot, locale string) (*WizardResult, error) {
 	questions := DefaultQuestions(projectRoot)
 	return RunWithLocale(questions, nil, locale)
 }
 
-// RunWithLocale은 locale을 초기화하여 위저드를 실행한다.
+// RunWithLocale initializes the locale and runs the wizard.
 func RunWithLocale(questions []Question, styles *Styles, locale string) (*WizardResult, error) {
 	if len(questions) == 0 {
 		return nil, ErrNoQuestions
@@ -35,7 +35,7 @@ func RunWithLocale(questions []Question, styles *Styles, locale string) (*Wizard
 	for i := range questions {
 		q := &questions[i]
 
-		// 조건이 충족되지 않는 질문은 스킵
+		// Skip questions whose condition is not satisfied
 		if q.Condition != nil && !q.Condition(result) {
 			continue
 		}

--- a/internal/cli/wizard/wizard_test.go
+++ b/internal/cli/wizard/wizard_test.go
@@ -786,39 +786,39 @@ func TestRunWithDefaults_CreatesQuestions(t *testing.T) {
 	}
 }
 
-// --- REQ-1: RunWithDefaults locale 파라미터 테스트 ---
+// --- REQ-1: RunWithDefaults locale parameter tests ---
 
 func TestRunWithDefaults_AcceptsLocaleParameter(t *testing.T) {
-	// RunWithDefaults(projectRoot, locale) 시그니처 테스트.
-	// TTY 없이는 실행 불가하므로 컴파일 확인 수준의 테스트.
+	// Tests the RunWithDefaults(projectRoot, locale) signature.
+	// Cannot run without a TTY, so this is a compile-level check only.
 	questions := DefaultQuestions("/tmp/run-defaults-locale-test")
 	if len(questions) == 0 {
 		t.Error("DefaultQuestions should return non-empty")
 	}
-	// locale 파라미터를 받는 새 시그니처 확인:
-	// RunWithDefaults("/tmp/test", "ko") 가 컴파일되어야 함
+	// Verify the new signature that accepts a locale parameter:
+	// RunWithDefaults("/tmp/test", "ko") should compile
 	_ = func() {
-		// 컴파일 타임에만 확인 — TTY 없이 실행 불가
+		// Compile-time check only — cannot run without a TTY
 		// _, _ = RunWithDefaults("/tmp/test", "ko")
 	}
 }
 
-// --- REQ-2: DefaultQuestions 기본값 오버라이드 테스트 ---
+// --- REQ-2: DefaultQuestions default value override tests ---
 
 func TestDefaultQuestions_GitHubUsernameDefaultOverride(t *testing.T) {
-	// DefaultQuestions 결과의 github_username 기본값을 오버라이드할 수 있어야 함
+	// The github_username default in DefaultQuestions result should be overridable.
 	questions := DefaultQuestions("/tmp/test")
 	q := QuestionByID(questions, "github_username")
 	if q == nil {
 		t.Fatal("github_username question not found")
 	}
 
-	// 기존 값은 빈 문자열
+	// Existing value is an empty string
 	if q.Default != "" {
 		t.Errorf("github_username default should be empty initially, got %q", q.Default)
 	}
 
-	// Default 필드 오버라이드 가능 여부 확인
+	// Verify that the Default field can be overridden
 	q.Default = "existing-user"
 	if q.Default != "existing-user" {
 		t.Error("should be able to override Default field")
@@ -832,19 +832,19 @@ func TestDefaultQuestions_GitLabUsernameDefaultOverride(t *testing.T) {
 		t.Fatal("gitlab_username question not found")
 	}
 
-	// 기존 값은 빈 문자열
+	// Existing value is an empty string
 	if q.Default != "" {
 		t.Errorf("gitlab_username default should be empty initially, got %q", q.Default)
 	}
 
-	// Default 필드 오버라이드 가능 여부 확인
+	// Verify that the Default field can be overridden
 	q.Default = "existing-gl-user"
 	if q.Default != "existing-gl-user" {
 		t.Error("should be able to override Default field")
 	}
 }
 
-// --- REQ-3: gh auth 인증 확인 시 github_token 질문 스킵 테스트 ---
+// --- REQ-3: Skip github_token question when gh auth is authenticated tests ---
 
 func TestDefaultQuestions_GitHubTokenCondition(t *testing.T) {
 	questions := DefaultQuestions("/tmp/test")
@@ -853,15 +853,15 @@ func TestDefaultQuestions_GitHubTokenCondition(t *testing.T) {
 		t.Fatal("github_token question not found")
 	}
 
-	// 기본 Condition: github 프로바이더 + personal/team 모드일 때 표시
+	// Default Condition: show when github provider + personal/team mode
 	result := &WizardResult{GitMode: "personal", GitProvider: "github"}
 	if !q.Condition(result) {
 		t.Error("github_token should be visible for github provider + personal mode")
 	}
 
-	// Condition을 오버라이드하여 항상 숨길 수 있어야 함 (gh auth 인증 시)
+	// Condition should be overridable to always hide (when gh auth is authenticated)
 	q.Condition = func(r *WizardResult) bool {
-		return false // gh auth로 인증된 경우 스킵
+		return false // Skip when authenticated via gh auth
 	}
 	if q.Condition(result) {
 		t.Error("overridden condition should return false (skip token question)")
@@ -869,17 +869,17 @@ func TestDefaultQuestions_GitHubTokenCondition(t *testing.T) {
 }
 
 func TestIsGhAuthenticated_ReturnsBoolean(t *testing.T) {
-	// IsGhAuthenticated() 함수가 bool을 반환하는지 확인
-	// gh가 없거나 인증되지 않은 환경에서는 false 반환
+	// Verify that IsGhAuthenticated() returns a bool.
+	// Returns false in environments where gh is not installed or not authenticated.
 	result := IsGhAuthenticated()
-	// bool 타입이어야 함 (true 또는 false)
-	_ = result // 환경에 따라 값이 달라지므로 타입만 확인
+	// Value varies by environment — only check the type
+	_ = result
 }
 
-// --- readLocaleFromProject 헬퍼 함수 테스트 ---
+// --- ReadLocaleFromProject helper function tests ---
 
 func TestReadLocaleFromProject_ReturnsLocale(t *testing.T) {
-	// 임시 디렉토리에 language.yaml 생성
+	// Create language.yaml in a temporary directory
 	tmpDir := t.TempDir()
 	sectionsDir := tmpDir + "/.moai/config/sections"
 	if err := os.MkdirAll(sectionsDir, 0o755); err != nil {
@@ -912,7 +912,7 @@ func TestReadLocaleFromProject_InvalidYAML_ReturnsEmpty(t *testing.T) {
 		t.Fatalf("MkdirAll: %v", err)
 	}
 
-	// 유효하지 않은 YAML
+	// Invalid YAML
 	if err := os.WriteFile(sectionsDir+"/language.yaml", []byte("invalid: [yaml"), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
@@ -930,7 +930,7 @@ func TestReadLocaleFromProject_NoLanguageKey_ReturnsEmpty(t *testing.T) {
 		t.Fatalf("MkdirAll: %v", err)
 	}
 
-	// language 키가 없는 YAML
+	// YAML without the language key
 	if err := os.WriteFile(sectionsDir+"/language.yaml", []byte("other_key: value\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
@@ -941,7 +941,7 @@ func TestReadLocaleFromProject_NoLanguageKey_ReturnsEmpty(t *testing.T) {
 	}
 }
 
-// --- readGitHubUsernameFromConfig 헬퍼 함수 테스트 ---
+// --- ReadGitHubUsernameFromConfig helper function tests ---
 
 func TestReadGitHubUsernameFromConfig_ReturnsUsername(t *testing.T) {
 	tmpDir := t.TempDir()

--- a/internal/cli/wizard_config_test.go
+++ b/internal/cli/wizard_config_test.go
@@ -176,12 +176,12 @@ func TestApplyWizardConfig_AllFieldsPopulated(t *testing.T) {
 	}
 }
 
-// --- REQ-4: applyWizardConfig git-strategy.yaml 저장 테스트 ---
+// --- REQ-4: applyWizardConfig git-strategy.yaml save tests ---
 
 func TestApplyWizardConfig_GitStrategyYAML(t *testing.T) {
 	root := setupSectionsDir(t)
 
-	// git-strategy.yaml 사전 생성
+	// Pre-create git-strategy.yaml
 	sectionsDir := filepath.Join(root, defs.MoAIDir, defs.SectionsSubdir)
 	gitStratPath := filepath.Join(sectionsDir, defs.GitStrategyYAML)
 	existing := "git_strategy:\n  mode: manual\n  provider: github\n"
@@ -232,7 +232,7 @@ func TestApplyWizardConfig_GitStrategyYAML_NoFileCreatedWhenEmpty(t *testing.T) 
 func TestApplyWizardConfig_QualityYAML(t *testing.T) {
 	root := setupSectionsDir(t)
 
-	// quality.yaml 사전 생성
+	// Pre-create quality.yaml
 	sectionsDir := filepath.Join(root, defs.MoAIDir, defs.SectionsSubdir)
 	qualityPath := filepath.Join(sectionsDir, defs.QualityYAML)
 	existing := "constitution:\n  development_mode: tdd\n  enforce_quality: true\n"
@@ -256,7 +256,7 @@ func TestApplyWizardConfig_QualityYAML(t *testing.T) {
 	if constitution["development_mode"] != "ddd" {
 		t.Errorf("constitution.development_mode = %v, want %q", constitution["development_mode"], "ddd")
 	}
-	// 기존 필드 보존 확인
+	// Verify existing fields are preserved
 	if constitution["enforce_quality"] != true {
 		t.Errorf("constitution.enforce_quality should be preserved, got %v", constitution["enforce_quality"])
 	}
@@ -279,7 +279,7 @@ func TestApplyWizardConfig_QualityYAML_NoFileCreatedWhenEmpty(t *testing.T) {
 	}
 }
 
-// --- REQ-5: GitLab 크레덴셜 저장 테스트 ---
+// --- REQ-5: GitLab credential save tests ---
 
 func TestApplyWizardConfig_GitLabCredentials(t *testing.T) {
 	root := setupSectionsDir(t)
@@ -345,7 +345,7 @@ func TestApplyWizardConfig_AllFields(t *testing.T) {
 	root := setupSectionsDir(t)
 	sectionsDir := filepath.Join(root, defs.MoAIDir, defs.SectionsSubdir)
 
-	// 기존 파일들 사전 생성
+	// Pre-create existing files
 	qualityExisting := "constitution:\n  development_mode: tdd\n"
 	if err := os.WriteFile(filepath.Join(sectionsDir, defs.QualityYAML), []byte(qualityExisting), defs.FilePerm); err != nil {
 		t.Fatalf("write quality.yaml: %v", err)
@@ -370,7 +370,7 @@ func TestApplyWizardConfig_AllFields(t *testing.T) {
 		t.Fatalf("applyWizardConfig: %v", err)
 	}
 
-	// user.yaml 검증
+	// Verify user.yaml
 	userParsed := readYAML(t, filepath.Join(sectionsDir, defs.UserYAML))
 	user := userParsed["user"].(map[string]any)
 	if user["github_username"] != "ghuser" {
@@ -386,14 +386,14 @@ func TestApplyWizardConfig_AllFields(t *testing.T) {
 		t.Errorf("gitlab_token = %v, want glpat-tok", user["gitlab_token"])
 	}
 
-	// quality.yaml 검증
+	// Verify quality.yaml
 	qualityParsed := readYAML(t, filepath.Join(sectionsDir, defs.QualityYAML))
 	constitution := qualityParsed["constitution"].(map[string]any)
 	if constitution["development_mode"] != "ddd" {
 		t.Errorf("development_mode = %v, want ddd", constitution["development_mode"])
 	}
 
-	// git-strategy.yaml 검증
+	// Verify git-strategy.yaml
 	gsParsed := readYAML(t, filepath.Join(sectionsDir, defs.GitStrategyYAML))
 	gs := gsParsed["git_strategy"].(map[string]any)
 	if gs["mode"] != "team" {

--- a/internal/core/pathutil_windows.go
+++ b/internal/core/pathutil_windows.go
@@ -8,7 +8,7 @@ import (
 )
 
 // GetLongPathName converts Windows 8.3 short paths to full Unicode paths.
-// This resolves paths like "C:\Users\홍길동~1" back to "C:\Users\홍길동팀장".
+// This resolves paths like "C:\Users\John~1" back to "C:\Users\JohnDoe".
 func GetLongPathName(shortPath string) (string, error) {
 	// Convert to UTF-16
 	ptr, err := syscall.UTF16PtrFromString(shortPath)

--- a/internal/hook/post_tool_astgrep_test.go
+++ b/internal/hook/post_tool_astgrep_test.go
@@ -45,11 +45,11 @@ func TestNewPostToolHandlerWithAstgrep(t *testing.T) {
 func TestPostToolHandler_AstScan_WriteToolWithMatches(t *testing.T) {
 	t.Parallel()
 
-	// 실제 임시 파일 생성 (ScanFile이 파일 존재 여부를 확인하므로)
+	// Create an actual temp file (ScanFile checks for file existence).
 	tmpDir := t.TempDir()
 	tmpFile := filepath.Join(tmpDir, "test.go")
 	if err := os.WriteFile(tmpFile, []byte("package main\n"), 0o644); err != nil {
-		t.Fatalf("임시 파일 생성 실패: %v", err)
+		t.Fatalf("failed to create temp file: %v", err)
 	}
 
 	analyzer := &mockFileAnalyzer{
@@ -73,24 +73,24 @@ func TestPostToolHandler_AstScan_WriteToolWithMatches(t *testing.T) {
 
 	got, err := h.Handle(ctx, input)
 	if err != nil {
-		t.Fatalf("Handle() 오류: %v", err)
+		t.Fatalf("Handle() error: %v", err)
 	}
 	if got == nil || got.Data == nil {
-		t.Fatal("Data가 nil이면 안 됨")
+		t.Fatal("Data must not be nil")
 	}
 
 	var metrics map[string]any
 	if err := json.Unmarshal(got.Data, &metrics); err != nil {
-		t.Fatalf("메트릭 언마샬 실패: %v", err)
+		t.Fatalf("failed to unmarshal metrics: %v", err)
 	}
 
 	astScan, ok := metrics["ast_scan"]
 	if !ok {
-		t.Fatal("metrics에 ast_scan이 없음")
+		t.Fatal("ast_scan not found in metrics")
 	}
 	astMap, ok := astScan.(map[string]any)
 	if !ok {
-		t.Fatalf("ast_scan이 map이 아님: %T", astScan)
+		t.Fatalf("ast_scan is not a map: %T", astScan)
 	}
 	if astMap["matches"] != float64(1) {
 		t.Errorf("matches = %v, want 1", astMap["matches"])
@@ -209,32 +209,32 @@ func TestPostToolHandler_AstScan_TableDriven(t *testing.T) {
 
 			got, err := h.Handle(ctx, input)
 
-			// 관찰 전용: 오류 없이 항상 allow 반환
+			// Observation-only: always returns allow without error.
 			if err != nil {
-				t.Fatalf("Handle() 오류 반환 (관찰 전용이어야 함): %v", err)
+				t.Fatalf("Handle() returned error (must be observation-only): %v", err)
 			}
 			if got == nil {
-				t.Fatal("nil output 반환")
+				t.Fatal("returned nil output")
 			}
 
-			// HookSpecificOutput이 PostToolUse로 설정돼야 함
+			// HookSpecificOutput must be set to PostToolUse.
 			if got.HookSpecificOutput == nil || got.HookSpecificOutput.HookEventName != "PostToolUse" {
-				t.Errorf("HookEventName이 PostToolUse가 아님: %+v", got.HookSpecificOutput)
+				t.Errorf("HookEventName is not PostToolUse: %+v", got.HookSpecificOutput)
 			}
 
-			// ast_scan 메트릭 확인
+			// Verify ast_scan metric.
 			if got.Data != nil {
 				var metrics map[string]any
 				if err := json.Unmarshal(got.Data, &metrics); err != nil {
-					t.Fatalf("메트릭 언마샬 실패: %v", err)
+					t.Fatalf("failed to unmarshal metrics: %v", err)
 				}
 
 				_, hasAstScan := metrics["ast_scan"]
 				if tt.wantAstScan && !hasAstScan {
-					t.Error("ast_scan이 metrics에 있어야 함")
+					t.Error("ast_scan must be present in metrics")
 				}
 				if !tt.wantAstScan && hasAstScan {
-					t.Error("ast_scan이 metrics에 없어야 함")
+					t.Error("ast_scan must not be present in metrics")
 				}
 
 				if tt.wantAstScan && hasAstScan {
@@ -244,7 +244,7 @@ func TestPostToolHandler_AstScan_TableDriven(t *testing.T) {
 					}
 				}
 			} else if tt.wantAstScan {
-				t.Error("Data가 nil인데 ast_scan을 기대함")
+				t.Error("Data is nil but ast_scan was expected")
 			}
 		})
 	}

--- a/internal/lsp/hook/fallback.go
+++ b/internal/lsp/hook/fallback.go
@@ -219,8 +219,8 @@ func (f *fallbackDiagnostics) RunFallback(ctx context.Context, filePath string) 
 }
 
 // runTool executes a single tool and parses its output.
-// 서킷 브레이커가 설정된 경우 외부 도구 실행을 보호한다.
-// 서킷이 열려 있으면 빈 진단을 반환하며 에러를 반환하지 않는다(관찰 전용).
+// If a circuit breaker is configured, it protects external tool execution.
+// When the circuit is open, it returns empty diagnostics without error (observation-only).
 func (f *fallbackDiagnostics) runTool(ctx context.Context, tool FallbackTool, filePath string) ([]Diagnostic, error) {
 	args := make([]string, len(tool.Args))
 	for i, arg := range tool.Args {
@@ -231,7 +231,7 @@ func (f *fallbackDiagnostics) runTool(ctx context.Context, tool FallbackTool, fi
 		}
 	}
 
-	// 서킷 브레이커가 활성화된 경우 외부 도구 실행을 보호한다.
+	// If circuit breaker is active, protect external tool execution.
 	if f.circuitBreaker != nil {
 		var diagnostics []Diagnostic
 		cbErr := f.circuitBreaker.Call(ctx, func() error {

--- a/internal/lsp/hook/fallback_test.go
+++ b/internal/lsp/hook/fallback_test.go
@@ -443,12 +443,12 @@ func TestNewFallbackDiagnosticsWithCircuitBreaker(t *testing.T) {
 	}
 }
 
-// TestFallbackDiagnostics_NilCircuitBreaker verifies behavior is unchanged when circuit breaker is nil.
+// TestFallbackDiagnostics_NilCircuitBreaker verifies that behavior is unchanged when circuit breaker is nil.
 // When circuit breaker is nil, behavior must be identical to the default behavior.
 func TestFallbackDiagnostics_NilCircuitBreaker(t *testing.T) {
 	t.Parallel()
 
-	// Create without circuit breaker
+	// Create without circuit breaker.
 	fb := NewFallbackDiagnostics()
 	if fb.circuitBreaker != nil {
 		t.Fatal("expected nil circuit breaker for default constructor")
@@ -462,18 +462,17 @@ func TestFallbackDiagnostics_NilCircuitBreaker(t *testing.T) {
 }
 
 // TestFallbackDiagnostics_OpenCircuitReturnsEmptyDiagnostics verifies that
-// an open circuit returns empty diagnostics without error.
-// 서킷이 열려 있으면 에러 없이 빈 진단을 반환해야 한다(관찰 전용).
+// an open circuit returns empty diagnostics without error (observation-only).
 func TestFallbackDiagnostics_OpenCircuitReturnsEmptyDiagnostics(t *testing.T) {
 	t.Parallel()
 
-	// 임계값 1로 서킷 브레이커를 생성하여 즉시 열리게 한다.
+	// Create a circuit breaker with threshold 1 so it opens immediately.
 	cb := resilience.NewCircuitBreaker(resilience.CircuitBreakerConfig{
 		Threshold: 1,
 		Timeout:   60 * time.Second,
 	})
 
-	// 서킷을 강제로 오픈 상태로 전환하기 위해 실패를 기록한다.
+	// Record a failure to force the circuit into the open state.
 	failErr := cb.Call(context.Background(), func() error {
 		return context.DeadlineExceeded
 	})
@@ -481,21 +480,21 @@ func TestFallbackDiagnostics_OpenCircuitReturnsEmptyDiagnostics(t *testing.T) {
 		t.Fatal("expected error from first call")
 	}
 
-	// 서킷이 열려 있는지 확인한다.
+	// Verify the circuit is open.
 	if cb.State() != resilience.StateOpen {
 		t.Skipf("circuit not open, state=%s (may need timing adjustment)", cb.State())
 	}
 
 	fb := NewFallbackDiagnosticsWithCircuitBreaker(cb)
 
-	// 실제 파일 경로가 있어야 runTool이 호출된다. 임시 파일 생성.
+	// A real file path is required so that runTool is invoked. Create a temp file.
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "test.go")
 	if err := os.WriteFile(testFile, []byte("package main\n"), 0644); err != nil {
 		t.Fatalf("failed to write test file: %v", err)
 	}
 
-	// go 언어가 가용한 경우에만 실행.
+	// Only run if the go tool is available.
 	if !fb.IsAvailable("go") {
 		t.Skip("go vet not available in test environment")
 	}
@@ -503,7 +502,7 @@ func TestFallbackDiagnostics_OpenCircuitReturnsEmptyDiagnostics(t *testing.T) {
 	ctx := context.Background()
 	diagnostics, err := fb.RunFallback(ctx, testFile)
 
-	// 서킷이 열려 있으면 에러 없이 빈 진단을 반환해야 한다.
+	// When the circuit is open, empty diagnostics must be returned without error.
 	if err != nil {
 		t.Errorf("expected no error when circuit is open, got %v", err)
 	}
@@ -517,7 +516,6 @@ func TestFallbackDiagnostics_OpenCircuitReturnsEmptyDiagnostics(t *testing.T) {
 
 // TestFallbackDiagnostics_ClosedCircuitPassesThrough verifies that
 // a closed circuit allows tool execution to proceed normally.
-// 서킷이 닫혀 있으면 정상 실행을 허용해야 한다.
 func TestFallbackDiagnostics_ClosedCircuitPassesThrough(t *testing.T) {
 	t.Parallel()
 
@@ -528,7 +526,7 @@ func TestFallbackDiagnostics_ClosedCircuitPassesThrough(t *testing.T) {
 
 	fb := NewFallbackDiagnosticsWithCircuitBreaker(cb)
 
-	// 알 수 없는 언어는 서킷 브레이커 유무와 관계없이 에러를 반환한다.
+	// An unknown language always returns an error regardless of circuit breaker state.
 	ctx := context.Background()
 	_, err := fb.RunFallback(ctx, "/path/to/file.unknown")
 

--- a/internal/template/settings_test.go
+++ b/internal/template/settings_test.go
@@ -501,7 +501,7 @@ func TestSettingsTemplateHookEventCount(t *testing.T) {
 		t.Fatal("missing hooks section")
 	}
 
-	const expectedCount = 16 // WorktreeCreate, WorktreeRemove 훅 추가로 14 → 16
+	const expectedCount = 16 // 14 → 16 after adding WorktreeCreate and WorktreeRemove hooks
 	if len(hooks) != expectedCount {
 		t.Errorf("hook event count = %d, want %d; events: %v", len(hooks), expectedCount, hookKeys(hooks))
 	}

--- a/internal/tmux/session_test.go
+++ b/internal/tmux/session_test.go
@@ -454,7 +454,7 @@ func TestSessionManager_InjectEnv_EmptyVars(t *testing.T) {
 
 	mgr := NewSessionManager(WithSessionRunFunc(runner))
 
-	// 빈 맵은 오류 없이 완료되어야 한다
+	// An empty map should complete without error.
 	err := mgr.InjectEnv(context.Background(), map[string]string{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -481,7 +481,7 @@ func TestSessionManager_ClearEnv_Success(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// set-environment -u TEST_KEY 와 set-environment -u OTHER_KEY 호출 확인
+	// Verify set-environment -u TEST_KEY and set-environment -u OTHER_KEY are called.
 	for _, varName := range vars {
 		found := false
 		for _, call := range calls {
@@ -527,7 +527,7 @@ func TestSessionManager_ClearEnv_EmptyVars(t *testing.T) {
 
 	mgr := NewSessionManager(WithSessionRunFunc(runner))
 
-	// 빈 슬라이스는 오류 없이 완료되어야 한다
+	// An empty slice should complete without error.
 	err := mgr.ClearEnv(context.Background(), []string{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
## Summary

- Translate all Korean godoc, inline comments, and test comments to English
- Covers cli, wizard, lsp/hook, core, hook, tmux, and template packages
- Compliance with CLAUDE.local.md coding standards (`code_comments: en`)

## Changed Files (16)

- `internal/cli/wizard/wizard.go`, `config_helpers.go` — godoc translation
- `internal/cli/update.go`, `init.go`, `glm.go`, `launcher.go` — inline comments
- `internal/lsp/hook/fallback.go` — circuit breaker comments
- `internal/core/pathutil_windows.go` — example name (홍길동 → JohnDoe)
- 8 test files — test comments translation

## Test plan

- [x] `go test ./internal/cli/...` — PASS
- [x] `go test ./internal/cli/wizard/...` — PASS
- [x] `go test ./internal/lsp/hook/...` — PASS
- [x] `go test ./internal/hook/...` — PASS
- [x] `go test ./internal/tmux/...` — PASS
- [x] `go test ./internal/template/...` — PASS
- No functional changes — comments only

🗿 MoAI <email@mo.ai.kr>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code comments and documentation for improved clarity across the codebase.

* **Improvements**
  * Enhanced configuration file handling with better locale detection and user field reading.
  * Strengthened test coverage with improved file setup and assertion verification for configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->