### PR TITLE
docs(template): Claude Code 2.1.70-2.1.72 호환성 업데이트

### DIFF
--- a/internal/template/templates/.claude/rules/moai/core/hooks-system.md
+++ b/internal/template/templates/.claude/rules/moai/core/hooks-system.md
@@ -240,6 +240,22 @@ Wrapper scripts are located at:
 - Do not store secrets in hook scripts
 - Agent hooks (type: "agent") have read-only tool access (Read, Grep, Glob)
 
+## Cron Scheduling (v2.1.71+)
+
+Claude Code provides built-in cron scheduling tools for recurring tasks within a session:
+
+| Tool | Purpose |
+|------|---------|
+| CronCreate | Create a recurring scheduled task (interval-based) |
+| CronDelete | Remove a scheduled cron job |
+| CronList | List all active cron jobs in the current session |
+
+These tools complement the `/loop` built-in command for recurring prompts.
+
+Use `CLAUDE_CODE_DISABLE_CRON` environment variable (v2.1.72+) to disable cron jobs mid-session.
+
+Cron jobs are session-scoped and do not persist across sessions.
+
 ## MX Tag Integration with Hooks
 
 PostToolUse hooks can trigger MX tag validation after code modifications:

--- a/internal/template/templates/.claude/rules/moai/core/moai-constitution.md
+++ b/internal/template/templates/.claude/rules/moai/core/moai-constitution.md
@@ -31,6 +31,7 @@ Rules:
 - For sub-agent mode: Launch multiple Agent() calls in a single message for parallel execution
 - For team mode: Use TeamCreate for persistent team coordination, SendMessage for inter-teammate communication
 - Team agents share TaskList for work coordination; sub-agents return results directly
+- Since v2.1.72: Failed Read/WebFetch/Glob calls no longer cancel sibling parallel calls; only Bash errors cascade
 
 ## Output Format
 

--- a/internal/template/templates/.claude/rules/moai/core/settings-management.md
+++ b/internal/template/templates/.claude/rules/moai/core/settings-management.md
@@ -184,6 +184,17 @@ When `workflow.execution_mode` is `auto`, these thresholds determine when team m
 | team.auto_selection.min_files_for_team | 10 | Minimum affected files to trigger team mode |
 | team.auto_selection.min_complexity_score | 7 | Minimum complexity score (1-10) to trigger team mode |
 
+## Environment Variables Reference
+
+Notable environment variables for `.claude/settings.json` env section:
+
+| Variable | Since | Purpose |
+|----------|-------|---------|
+| CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS | v2.1.32 | Enable Agent Teams API |
+| CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS | v2.1.0 | Max tokens for file reads |
+| ENABLE_TOOL_SEARCH | v2.1.70 | Enable deferred tool search with proxy endpoints |
+| CLAUDE_CODE_DISABLE_CRON | v2.1.72 | Disable scheduled cron jobs mid-session |
+
 ## Rules
 
 - Never commit secrets to settings files

--- a/internal/template/templates/.claude/rules/moai/development/model-policy.md
+++ b/internal/template/templates/.claude/rules/moai/development/model-policy.md
@@ -52,6 +52,14 @@ Opus 4.6 supports effort levels that control reasoning depth:
 
 MoAI's --ultrathink flag triggers high effort for the current turn. This aligns with the "ultrathink" keyword behavior in Claude Code.
 
+## Team Agent Model Inheritance (v2.1.72+)
+
+Team agents inherit the leader's model by default when no explicit `model` field is set:
+- If a teammate agent definition has `model: inherit` (or no model field), it uses the leader's model
+- Explicit `model` field in agent definitions overrides inheritance (e.g., `model: haiku`)
+- In CG Mode, tmux session-level GLM env vars take precedence over model inheritance
+- The Agent() tool's `model` parameter also overrides both inheritance and agent definition
+
 ## Rules
 
 - Agent `model` field must be one of: inherit, opus, sonnet, haiku

--- a/internal/template/templates/.claude/rules/moai/workflow/worktree-integration.md
+++ b/internal/template/templates/.claude/rules/moai/workflow/worktree-integration.md
@@ -34,8 +34,22 @@ MoAI-ADK supports two complementary worktree systems for isolated development:
 | **Team Use** | Single agent isolation | Multi-developer collaboration |
 | **State Persistence** | None | SPEC state, progress tracking |
 | **Hook Support** | WorktreeCreate/WorktreeRemove hooks | WorktreeCreate/WorktreeRemove hooks |
+| **Exit Tool** | ExitWorktree (v2.1.72+) | `moai worktree remove` |
 
 ## Claude Code 2.1.50+ Worktree Features
+
+### `ExitWorktree` Tool (v2.1.72+)
+
+Use the ExitWorktree tool to programmatically leave a worktree session and return to the main workspace:
+
+- Available when inside an `EnterWorktree` session or a `claude --worktree` session
+- Useful for user-initiated worktree sessions when the work is complete
+- For agent worktrees (`isolation: worktree`), cleanup is automatic on agent termination -- ExitWorktree is not needed
+
+When to use ExitWorktree:
+- After completing work in a `claude --worktree` session
+- When EnterWorktree was called manually and you want to return to the main workspace
+- NOT needed for agent-spawned worktrees (automatic cleanup handles it)
 
 ### `claude --worktree` (`-w`) Flag
 
@@ -222,5 +236,5 @@ Currently the handlers log worktree creation and removal for session tracking.
 
 ---
 
-Version: 3.0.0 (HARD Rules + Decision Tree)
+Version: 3.1.0 (ExitWorktree + v2.1.72 Compatibility)
 Source: SPEC-WORKTREE-001

--- a/internal/template/templates/.claude/skills/moai/team/plan.md
+++ b/internal/template/templates/.claude/skills/moai/team/plan.md
@@ -185,7 +185,7 @@ AskUserQuestion with options:
 5. TeamDelete to clean up team resources
 6. Log any unresponsive teammates for debugging
 7. Do NOT wait indefinitely for shutdown_response
-8. Execute /clear to free context for next phase
+8. Execute /clear to free context for next phase (Note: since v2.1.72, /clear only clears foreground tasks; background agents are preserved)
 
 **Timeout Rule**: If a teammate does not respond to shutdown_request within 30 seconds, proceed without their confirmation. This prevents the common issue of teammates hanging during cleanup.
 

--- a/internal/template/templates/CLAUDE.md
+++ b/internal/template/templates/CLAUDE.md
@@ -489,7 +489,7 @@ claude --debug "api,hooks"
 claude --debug "mcp"
 ```
 
-Or use the `/debug` command inside a session to inspect current session state, hook execution logs, and tool traces.
+Or use the `/debug` command inside a session to toggle debug logging on/off mid-session (v2.1.71+), inspecting hook execution logs, tool traces, and API interactions in real-time.
 
 ### Common Issues
 
@@ -513,8 +513,8 @@ Large PDFs (>10 pages) return a lightweight reference when @-mentioned. Always s
 
 ---
 
-Version: 13.1.0 (Agent Teams Integration)
-Last Updated: 2026-02-10
+Version: 13.2.0 (Claude Code 2.1.72 Compatibility)
+Last Updated: 2026-03-10
 Language: English
 Core Rule: MoAI is an orchestrator; direct implementation is prohibited
 


### PR DESCRIPTION
## Summary

Claude Code v2.1.70-2.1.72 릴리스 노트를 분석하여 moai-adk-go 템플릿에 필요한 호환성 업데이트를 반영합니다.

### CRITICAL (3건)
- **ExitWorktree 도구**: worktree-integration.md에 ExitWorktree 문서 추가 (v2.1.72+)
- **Cron 스케줄링 도구**: hooks-system.md에 CronCreate/CronDelete/CronList 문서화
- **/debug 명령**: CLAUDE.md에 세션 중 토글 가능 업데이트 (v2.1.71+)

### IMPORTANT (4건)
- **팀 모델 상속**: model-policy.md에 팀 에이전트 리더 모델 상속 문서화 (v2.1.72)
- **/clear 동작 변경**: team/plan.md에 백그라운드 태스크 미종료 노트 (v2.1.72)
- **병렬 도구 안정성**: moai-constitution.md에 Read/WebFetch/Glob 실패 격리 노트 (v2.1.72)
- **환경변수 참조**: settings-management.md에 CLAUDE_CODE_DISABLE_CRON 추가

### 변경 없음
- Go 소스 코드 변경 0건
- 기존 동작에 영향 없는 문서만 업데이트

## Changed Files (7)
- `internal/template/templates/CLAUDE.md`
- `internal/template/templates/.claude/rules/moai/core/hooks-system.md`
- `internal/template/templates/.claude/rules/moai/core/moai-constitution.md`
- `internal/template/templates/.claude/rules/moai/core/settings-management.md`
- `internal/template/templates/.claude/rules/moai/development/model-policy.md`
- `internal/template/templates/.claude/rules/moai/workflow/worktree-integration.md`
- `internal/template/templates/.claude/skills/moai/team/plan.md`

## Test plan
- [x] `make build` 성공
- [x] `go test ./internal/template/...` 통과
- [x] `go vet ./...` 통과
- [ ] `moai update` 로 기존 프로젝트에 템플릿 배포 확인

🗿 MoAI <email@mo.ai.kr>