### PR TITLE
fix(statusline): usage 캐시 저장 goroutine race condition 수정

### DIFF
--- a/internal/statusline/usage.go
+++ b/internal/statusline/usage.go
@@ -100,18 +100,17 @@ func (u *usageCollector) CollectUsage(ctx context.Context) (*UsageResult, error)
 		return nil, nil
 	}
 
-	// Update cache (async, continue on failure)
+	// Update cache synchronously to ensure it is persisted before the CLI process exits.
+	// A goroutine would race against process termination in short-lived commands like "moai statusline".
 	cache := &usageCacheFile{
 		CachedAt: time.Now().Unix(),
 		Usage5H:  usage5H,
 		Usage7D:  usage7D,
 	}
-	go func() {
-		u.mu.Lock()
-		u.cache = cache
-		u.mu.Unlock()
-		_ = u.saveCache(cache)
-	}()
+	u.mu.Lock()
+	u.cache = cache
+	u.mu.Unlock()
+	_ = u.saveCache(cache)
 
 	return u.toUsageResult(cache), nil
 }


### PR DESCRIPTION
## Summary
- statusline의 5H/7D API usage 캐시가 goroutine race condition으로 인해 디스크에 저장되지 않는 버그 수정
- 비동기 `go func()` 캐시 저장을 동기식으로 변경하여 CLI 프로세스 종료 전 캐시 저장 보장

## Root Cause
`CollectUsage()`에서 캐시를 `go func()`로 비동기 저장했으나, `moai statusline`은 단발성 CLI로 출력 후 즉시 종료됨. Go runtime은 main goroutine 종료 시 모든 goroutine을 종료하므로, 캐시 저장 goroutine이 파일 쓰기를 완료하기 전에 프로세스가 종료됨.

### Impact Chain
```
캐시 goroutine 미완료 → 디스크 캐시 미갱신 → 캐시 항상 stale (TTL 5분 초과)
→ 매 statusline 호출마다 API 재요청 → API 429 Rate Limit
→ stale 캐시 fallback → 오래된 5H/7D 데이터 고정 표시
```

## Changes
- `internal/statusline/usage.go`: `go func()` goroutine wrapper 제거, 동기식 캐시 저장으로 변경

## Test Plan
- [x] `go test -race ./internal/statusline/...` PASS (71.9s)
- [x] `go vet ./internal/statusline/...` PASS
- [x] `golangci-lint run ./internal/statusline/...` PASS (0 issues)
- [x] 캐시 히트 경로 동작 검증 완료

🗿 MoAI <email@mo.ai.kr>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced cache persistence mechanism to ensure usage data is reliably saved before the CLI process exits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->