### PR TITLE
fix(template): @ 참조 이중 로딩으로 인한 토큰 낭비 제거

### DIFF
--- a/.claude/skills/moai/SKILL.md
+++ b/.claude/skills/moai/SKILL.md
@@ -25,12 +25,12 @@ argument-hint: "[subcommand] [args] | \"natural language task\""
 
 Rules and constraints governing all workflows are always loaded from these sources. Do NOT duplicate their content here:
 
-- Core identity, orchestration principles, agent catalog: @CLAUDE.md
-- Quality gates, security boundaries: @.claude/rules/moai/core/moai-constitution.md
-- SPEC workflow phases, token budgets: @.claude/rules/moai/workflow/spec-workflow.md
-- Development methodologies (DDD/TDD): @.claude/rules/moai/workflow/workflow-modes.md
+- Core identity, orchestration principles, agent catalog: CLAUDE.md
+- Quality gates, security boundaries: .claude/rules/moai/core/moai-constitution.md
+- SPEC workflow phases, token budgets: .claude/rules/moai/workflow/spec-workflow.md
+- Development methodologies (DDD/TDD): .claude/rules/moai/workflow/workflow-modes.md
 - Agent definitions: See CLAUDE.md Section 4. For agent creation, use builder-agent subagent.
-- @MX tag rules and protocol: @.claude/rules/moai/workflow/mx-tag-protocol.md
+- MX tag rules and protocol: .claude/rules/moai/workflow/mx-tag-protocol.md
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,7 +150,7 @@ MX Tag Types:
 
 For MX protocol details, see .claude/rules/moai/workflow/mx-tag-protocol.md
 
-For team-based parallel execution of these phases, see @.claude/skills/moai/team/plan.md and @.claude/skills/moai/team/run.md.
+For team-based parallel execution of these phases, see .claude/skills/moai/team/plan.md and .claude/skills/moai/team/run.md.
 
 ---
 

--- a/internal/template/templates/.claude/skills/moai/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai/SKILL.md
@@ -25,12 +25,12 @@ argument-hint: "[subcommand] [args] | \"natural language task\""
 
 Rules and constraints governing all workflows are always loaded from these sources. Do NOT duplicate their content here:
 
-- Core identity, orchestration principles, agent catalog: @CLAUDE.md
-- Quality gates, security boundaries: @.claude/rules/moai/core/moai-constitution.md
-- SPEC workflow phases, token budgets: @.claude/rules/moai/workflow/spec-workflow.md
-- Development methodologies (DDD/TDD): @.claude/rules/moai/workflow/workflow-modes.md
+- Core identity, orchestration principles, agent catalog: CLAUDE.md
+- Quality gates, security boundaries: .claude/rules/moai/core/moai-constitution.md
+- SPEC workflow phases, token budgets: .claude/rules/moai/workflow/spec-workflow.md
+- Development methodologies (DDD/TDD): .claude/rules/moai/workflow/workflow-modes.md
 - Agent definitions: See CLAUDE.md Section 4. For agent creation, use builder-agent subagent.
-- @MX tag rules and protocol: @.claude/rules/moai/workflow/mx-tag-protocol.md
+- MX tag rules and protocol: .claude/rules/moai/workflow/mx-tag-protocol.md
 
 ---
 

--- a/internal/template/templates/CLAUDE.md
+++ b/internal/template/templates/CLAUDE.md
@@ -15,7 +15,7 @@ MoAI is the Strategic Orchestrator for Claude Code. All tasks must be delegated 
 - [HARD] Post-Implementation Review: List potential issues and suggest tests after coding (See Section 7)
 - [HARD] Reproduction-First Bug Fix: Write reproduction test before fixing bugs (See Section 7)
 
-Core principles (1-4) are defined in @.claude/rules/moai/core/moai-constitution.md. Development safeguards (5-8) are detailed in Section 7.
+Core principles (1-4) are defined in .claude/rules/moai/core/moai-constitution.md. Development safeguards (5-8) are detailed in Section 7.
 
 ### Recommendations
 
@@ -150,7 +150,7 @@ MX Tag Types:
 
 For MX protocol details, see .claude/rules/moai/workflow/mx-tag-protocol.md
 
-For team-based parallel execution of these phases, see @.claude/skills/moai/team/plan.md and @.claude/skills/moai/team/run.md.
+For team-based parallel execution of these phases, see .claude/skills/moai/team/plan.md and .claude/skills/moai/team/run.md.
 
 ---
 


### PR DESCRIPTION
## Summary

- SKILL.md Authority References 섹션의 불필요한 `@` 파일 참조 5개 제거
- CLAUDE.md의 이중 로딩 `@` 참조 2개 제거 (moai-constitution.md, team plan/run skills)
- `/moai` 호출당 ~18,000 토큰, 대화 시작당 ~3,000 토큰 절감

## Problem

Claude Code의 `@파일경로` 구문은 해당 파일을 강제로 읽어서 컨텍스트에 삽입합니다.
SKILL.md와 CLAUDE.md에서 이미 자동 로딩되는 파일을 `@` 참조로 이중 로딩하고 있었습니다:

| 파일 | 자동 로딩 메커니즘 | `@` 참조 필요? |
|------|-------------------|---------------|
| CLAUDE.md | 프로젝트 인스트럭션 (항상) | 불필요 |
| moai-constitution.md | Rule (paths 없음 → 항상) | 불필요 |
| spec-workflow.md | Rule (조건부) | 라우터에 불필요 |
| workflow-modes.md | Rule (조건부) | 라우터에 불필요 |
| mx-tag-protocol.md | Rule (조건부) | 라우터에 불필요 |
| team/plan.md, team/run.md | Skill (on-demand) | 매 대화 로딩 불필요 |

## Changes

- `CLAUDE.md`: `@.claude/skills/moai/team/{plan,run}.md` → `.claude/skills/moai/team/{plan,run}.md`
- `SKILL.md`: Authority References 섹션의 `@` 접두사 5개 제거
- 동일 변경을 템플릿 소스와 로컬 복사본 모두에 적용

## What's preserved

config yaml 파일의 `@` 참조는 유일한 로드 경로이므로 유지:
- `@.moai/config/config.yaml` (SKILL.md)
- `@.moai/config/sections/{quality,user,language,workflow}.yaml` (CLAUDE.md)

## Test plan

- [x] `make build` 성공
- [x] `go test ./internal/template/...` 통과
- [ ] `/moai plan` 실행 시 불필요한 Read 출력이 사라졌는지 확인

🗿 MoAI <email@mo.ai.kr>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation reference paths to use consistent relative path notation across guidance and specification materials.

* **Chores**
  * Standardized documentation cross-reference formatting for improved consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->