### PR TITLE
refactor(cli): remove statusline preset prompt from profile setup

### DIFF
--- a/internal/cli/profile_setup.go
+++ b/internal/cli/profile_setup.go
@@ -76,27 +76,10 @@ func runProfileSetup(cmd *cobra.Command, args []string) error {
 	if statuslineMode == "" {
 		statuslineMode = "default"
 	}
-	statuslinePreset := existingPrefs.StatuslinePreset
-	if statuslinePreset == "" {
-		statuslinePreset = "full"
-	}
 	statuslineTheme := existingPrefs.StatuslineTheme
 	if statuslineTheme == "" {
 		statuslineTheme = "default"
 	}
-	// Statusline segment toggles
-	segModel := getSegmentDefault(existingPrefs.StatuslineSegments, "model", true)
-	segContext := getSegmentDefault(existingPrefs.StatuslineSegments, "context", true)
-	segOutputStyle := getSegmentDefault(existingPrefs.StatuslineSegments, "output_style", true)
-	segDirectory := getSegmentDefault(existingPrefs.StatuslineSegments, "directory", true)
-	segGitStatus := getSegmentDefault(existingPrefs.StatuslineSegments, "git_status", true)
-	segClaudeVersion := getSegmentDefault(existingPrefs.StatuslineSegments, "claude_version", true)
-	segMoaiVersion := getSegmentDefault(existingPrefs.StatuslineSegments, "moai_version", true)
-	segGitBranch := getSegmentDefault(existingPrefs.StatuslineSegments, "git_branch", true)
-	segSessionTime := getSegmentDefault(existingPrefs.StatuslineSegments, "session_time", true)
-	segUsage5H := getSegmentDefault(existingPrefs.StatuslineSegments, "usage_5h", true)
-	segUsage7D := getSegmentDefault(existingPrefs.StatuslineSegments, "usage_7d", true)
-
 	// ====== Step 1: Language Selection ======
 	langOptions := []huh.Option[string]{
 		huh.NewOption("English", "en"),
@@ -204,34 +187,7 @@ func runProfileSetup(cmd *cobra.Command, args []string) error {
 					huh.NewOption(t.ThemeCatppuccinLatte, "catppuccin-latte"),
 				).
 				Value(&statuslineTheme),
-			huh.NewSelect[string]().
-				Title(t.StatuslineTitle).
-				Description(t.StatuslineDesc).
-				Options(
-					huh.NewOption(t.StatuslineFull, "full"),
-					huh.NewOption(t.StatuslineCompact, "compact"),
-					huh.NewOption(t.StatuslineMinimal, "minimal"),
-					huh.NewOption(t.StatuslineCustom, "custom"),
-				).
-				Value(&statuslinePreset),
 		).Title(t.DisplayTitle),
-
-		// Section 6: Custom Segments — shown only when preset is "custom"
-		huh.NewGroup(
-			huh.NewConfirm().Title(t.SegModel).Value(&segModel),
-			huh.NewConfirm().Title(t.SegContext).Value(&segContext),
-			huh.NewConfirm().Title(t.SegOutputStyle).Value(&segOutputStyle),
-			huh.NewConfirm().Title(t.SegDirectory).Value(&segDirectory),
-			huh.NewConfirm().Title(t.SegGitStatus).Value(&segGitStatus),
-			huh.NewConfirm().Title(t.SegClaudeVersion).Value(&segClaudeVersion),
-			huh.NewConfirm().Title(t.SegMoaiVersion).Value(&segMoaiVersion),
-			huh.NewConfirm().Title(t.SegGitBranch).Value(&segGitBranch),
-			huh.NewConfirm().Title(t.SegSessionTime).Value(&segSessionTime),
-			huh.NewConfirm().Title(t.SegUsage5H).Value(&segUsage5H),
-			huh.NewConfirm().Title(t.SegUsage7D).Value(&segUsage7D),
-		).Title(t.SegmentsTitle).
-			WithHideFunc(func() bool { return statuslinePreset != "custom" }),
-
 	)
 
 	if err := form.Run(); err != nil {
@@ -253,26 +209,8 @@ func runProfileSetup(cmd *cobra.Command, args []string) error {
 		Model:            model,
 		Bypass:           bypass,
 		StatuslineMode:   statuslineMode,
-		StatuslinePreset: statuslinePreset,
-		StatuslineTheme:  statuslineTheme,
-		TeammateDisplay:  "auto",
-	}
-
-	// Only persist segment toggles for custom preset
-	if statuslinePreset == "custom" {
-		prefs.StatuslineSegments = map[string]bool{
-			"model":          segModel,
-			"context":        segContext,
-			"output_style":   segOutputStyle,
-			"directory":      segDirectory,
-			"git_status":     segGitStatus,
-			"claude_version": segClaudeVersion,
-			"moai_version":   segMoaiVersion,
-			"git_branch":     segGitBranch,
-			"session_time":   segSessionTime,
-			"usage_5h":       segUsage5H,
-			"usage_7d":       segUsage7D,
-		}
+		StatuslineTheme: statuslineTheme,
+		TeammateDisplay: "auto",
 	}
 
 	if err := profile.WritePreferences(profileName, prefs); err != nil {
@@ -293,15 +231,4 @@ func runProfileSetup(cmd *cobra.Command, args []string) error {
 		profileName,
 		profile.GetPreferencesPath(profileName))
 	return nil
-}
-
-// getSegmentDefault returns the segment toggle value from the map, or the default.
-func getSegmentDefault(segments map[string]bool, name string, defaultVal bool) bool {
-	if segments == nil {
-		return defaultVal
-	}
-	if val, ok := segments[name]; ok {
-		return val
-	}
-	return defaultVal
 }

--- a/internal/cli/profile_setup_test.go
+++ b/internal/cli/profile_setup_test.go
@@ -64,30 +64,3 @@ func TestGetProfileText_ModeFields(t *testing.T) {
 		})
 	}
 }
-
-// TestGetSegmentDefault verifies the helper handles nil and missing keys correctly.
-func TestGetSegmentDefault(t *testing.T) {
-	tests := []struct {
-		name     string
-		segments map[string]bool
-		key      string
-		def      bool
-		want     bool
-	}{
-		{"nil map returns default true", nil, "model", true, true},
-		{"nil map returns default false", nil, "model", false, false},
-		{"present key returns its value", map[string]bool{"model": false}, "model", true, false},
-		{"missing key returns default", map[string]bool{"context": true}, "model", true, true},
-		{"missing key returns false default", map[string]bool{"context": true}, "model", false, false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := getSegmentDefault(tt.segments, tt.key, tt.def)
-			if got != tt.want {
-				t.Errorf("getSegmentDefault(%v, %q, %v) = %v, want %v",
-					tt.segments, tt.key, tt.def, got, tt.want)
-			}
-		})
-	}
-}

--- a/internal/cli/profile_setup_translations.go
+++ b/internal/cli/profile_setup_translations.go
@@ -54,34 +54,12 @@ type profileSetupText struct {
 	ModeVerbose string // label for mode = "verbose" (deprecated)
 	ModeMinimal string // label for mode = "minimal" (deprecated)
 
-	// Statusline preset selector (segment visibility, shown when mode != minimal)
-	StatuslineTitle   string
-	StatuslineDesc    string
-	StatuslineFull    string
-	StatuslineCompact string
-	StatuslineMinimal string
-	StatuslineCustom  string
-
 	// Statusline theme selector
 	StatuslineThemeTitle string
 	StatuslineThemeDesc  string
 	ThemeDefault         string
 	ThemeCatppuccinMocha string
 	ThemeCatppuccinLatte string
-
-	// Section: Statusline Segments
-	SegmentsTitle    string
-	SegModel         string
-	SegContext       string
-	SegOutputStyle   string
-	SegDirectory     string
-	SegGitStatus     string
-	SegClaudeVersion string
-	SegMoaiVersion   string
-	SegGitBranch     string
-	SegSessionTime   string
-	SegUsage5H       string
-	SegUsage7D       string
 
 	// Messages
 	SetupCancelled string
@@ -126,32 +104,14 @@ var profileSetupTexts = map[string]profileSetupText{
 		ModeDefault:         "Default - 3-line: info, CW/5H/7D bars, dir+git",
 		ModeCompact:         "Compact - 2-line: model+CW bar, git status",
 		ModeFull:            "Full - 5-line: info, CW/5H/7D bars (40-block), dir+git",
-		ModeVerbose:         "Verbose - 3-line detailed view with cost tracking",
-		ModeMinimal:         "Minimal - Model and context only",
-		StatuslineTitle:    "Statusline segment preset",
-		StatuslineDesc:     "Controls which segments are shown in the Claude Code statusline.",
-		StatuslineFull:     "Full - All 8 segments",
-		StatuslineCompact:  "Compact - Model, context, git",
-		StatuslineMinimal:  "Minimal - Model and context only",
-		StatuslineCustom:      "Custom - Choose individual segments",
-		StatuslineThemeTitle:  "Statusline Theme",
-		StatuslineThemeDesc:   "Select a color theme for the statusline.",
-		ThemeDefault:          "Default",
-		ThemeCatppuccinMocha:  "Catppuccin Mocha (dark)",
-		ThemeCatppuccinLatte:  "Catppuccin Latte (light)",
-		SegmentsTitle:         "Statusline Segments",
-		SegModel:           "Show model name",
-		SegContext:         "Show context usage",
-		SegOutputStyle:     "Show output style",
-		SegDirectory:       "Show directory",
-		SegGitStatus:       "Show git status",
-		SegClaudeVersion:   "Show Claude version",
-		SegMoaiVersion:     "Show MoAI version",
-		SegGitBranch:       "Show git branch",
-		SegSessionTime:    "Show session time",
-		SegUsage5H:        "Show 5H API usage bar",
-		SegUsage7D:        "Show 7D API usage bar",
-		SetupCancelled:     "Setup cancelled.",
+		ModeVerbose:        "Verbose - 3-line detailed view with cost tracking",
+		ModeMinimal:        "Minimal - Model and context only",
+		StatuslineThemeTitle: "Statusline Theme",
+		StatuslineThemeDesc:  "Select a color theme for the statusline.",
+		ThemeDefault:         "Default",
+		ThemeCatppuccinMocha: "Catppuccin Mocha (dark)",
+		ThemeCatppuccinLatte: "Catppuccin Latte (light)",
+		SetupCancelled:      "Setup cancelled.",
 		SavedProfile:       "\nSaved profile '%s':\n  Preferences → %s\n",
 	},
 	"ko": {
@@ -190,32 +150,14 @@ var profileSetupTexts = map[string]profileSetupText{
 		ModeDefault:         "Default - 3줄: 정보, CW/5H/7D 바, 디렉토리+git",
 		ModeCompact:         "Compact - 2줄: 모델+CW 바, git 상태",
 		ModeFull:            "Full - 5줄: 정보, CW/5H/7D 바(40블록), 디렉토리+git",
-		ModeVerbose:         "Verbose - 비용 추적이 포함된 3줄 상세 뷰",
-		ModeMinimal:         "Minimal - 모델과 컨텍스트만 표시",
-		StatuslineTitle:    "상태줄 세그먼트 프리셋",
-		StatuslineDesc:     "Claude Code 상태줄에 표시할 세그먼트를 제어합니다.",
-		StatuslineFull:     "Full - 전체 8개 세그먼트",
-		StatuslineCompact:  "Compact - 모델, 컨텍스트, git",
-		StatuslineMinimal:  "Minimal - 모델과 컨텍스트만",
-		StatuslineCustom:      "Custom - 개별 세그먼트 선택",
-		StatuslineThemeTitle:  "Statusline 테마",
-		StatuslineThemeDesc:   "상태줄 색상 테마를 선택하세요.",
-		ThemeDefault:          "기본값",
-		ThemeCatppuccinMocha:  "Catppuccin Mocha (어두운 테마)",
-		ThemeCatppuccinLatte:  "Catppuccin Latte (밝은 테마)",
-		SegmentsTitle:         "상태줄 세그먼트",
-		SegModel:           "모델 이름 표시",
-		SegContext:         "컨텍스트 사용량 표시",
-		SegOutputStyle:     "출력 스타일 표시",
-		SegDirectory:       "디렉토리 표시",
-		SegGitStatus:       "git 상태 표시",
-		SegClaudeVersion:   "Claude 버전 표시",
-		SegMoaiVersion:     "MoAI 버전 표시",
-		SegGitBranch:       "git 브랜치 표시",
-		SegSessionTime:    "세션 시간 표시",
-		SegUsage5H:        "5H API 사용량 바 표시",
-		SegUsage7D:        "7D API 사용량 바 표시",
-		SetupCancelled:     "설정이 취소되었습니다.",
+		ModeVerbose:        "Verbose - 비용 추적이 포함된 3줄 상세 뷰",
+		ModeMinimal:        "Minimal - 모델과 컨텍스트만 표시",
+		StatuslineThemeTitle: "Statusline 테마",
+		StatuslineThemeDesc:  "상태줄 색상 테마를 선택하세요.",
+		ThemeDefault:         "기본값",
+		ThemeCatppuccinMocha: "Catppuccin Mocha (어두운 테마)",
+		ThemeCatppuccinLatte: "Catppuccin Latte (밝은 테마)",
+		SetupCancelled:      "설정이 취소되었습니다.",
 		SavedProfile:       "\n프로필 '%s' 저장 완료:\n  환경설정 → %s\n",
 	},
 	"ja": {
@@ -254,32 +196,14 @@ var profileSetupTexts = map[string]profileSetupText{
 		ModeDefault:         "Default - 3行: 情報、CW/5H/7Dバー、ディレクトリ+git",
 		ModeCompact:         "Compact - 2行: モデル+CWバー、gitステータス",
 		ModeFull:            "Full - 5行: 情報、CW/5H/7Dバー(40ブロック)、ディレクトリ+git",
-		ModeVerbose:         "Verbose - コスト追跡付きの3行詳細表示",
-		ModeMinimal:         "Minimal - モデルとコンテキストのみ",
-		StatuslineTitle:    "ステータスラインセグメントプリセット",
-		StatuslineDesc:     "Claude Codeのステータスラインに表示するセグメントを制御します。",
-		StatuslineFull:     "Full - 全8セグメント",
-		StatuslineCompact:  "Compact - モデル、コンテキスト、git",
-		StatuslineMinimal:  "Minimal - モデルとコンテキストのみ",
-		StatuslineCustom:      "Custom - 個別セグメント選択",
-		StatuslineThemeTitle:  "ステータスラインテーマ",
-		StatuslineThemeDesc:   "ステータスラインのカラーテーマを選択してください。",
-		ThemeDefault:          "デフォルト",
-		ThemeCatppuccinMocha:  "Catppuccin Mocha (ダーク)",
-		ThemeCatppuccinLatte:  "Catppuccin Latte (ライト)",
-		SegmentsTitle:         "ステータスラインセグメント",
-		SegModel:           "モデル名を表示",
-		SegContext:         "コンテキスト使用量を表示",
-		SegOutputStyle:     "出力スタイルを表示",
-		SegDirectory:       "ディレクトリを表示",
-		SegGitStatus:       "gitステータスを表示",
-		SegClaudeVersion:   "Claudeバージョンを表示",
-		SegMoaiVersion:     "MoAIバージョンを表示",
-		SegGitBranch:       "gitブランチを表示",
-		SegSessionTime:    "セッション時間を表示",
-		SegUsage5H:        "5H API使用量バーを表示",
-		SegUsage7D:        "7D API使用量バーを表示",
-		SetupCancelled:     "セットアップがキャンセルされました。",
+		ModeVerbose:        "Verbose - コスト追跡付きの3行詳細表示",
+		ModeMinimal:        "Minimal - モデルとコンテキストのみ",
+		StatuslineThemeTitle: "ステータスラインテーマ",
+		StatuslineThemeDesc:  "ステータスラインのカラーテーマを選択してください。",
+		ThemeDefault:         "デフォルト",
+		ThemeCatppuccinMocha: "Catppuccin Mocha (ダーク)",
+		ThemeCatppuccinLatte: "Catppuccin Latte (ライト)",
+		SetupCancelled:      "セットアップがキャンセルされました。",
 		SavedProfile:       "\nプロファイル '%s' を保存しました:\n  環境設定 → %s\n",
 	},
 	"zh": {
@@ -318,32 +242,14 @@ var profileSetupTexts = map[string]profileSetupText{
 		ModeDefault:         "Default - 3行: 信息、CW/5H/7D栏、目录+git",
 		ModeCompact:         "Compact - 2行: 模型+CW栏、git状态",
 		ModeFull:            "Full - 5行: 信息、CW/5H/7D栏(40块)、目录+git",
-		ModeVerbose:         "Verbose - 含费用追踪的3行详细视图",
-		ModeMinimal:         "Minimal - 仅显示模型和上下文",
-		StatuslineTitle:    "状态栏段预设",
-		StatuslineDesc:     "控制Claude Code状态栏中显示的段。",
-		StatuslineFull:     "Full - 全部8个段",
-		StatuslineCompact:  "Compact - 模型、上下文、git",
-		StatuslineMinimal:  "Minimal - 仅模型和上下文",
-		StatuslineCustom:      "Custom - 选择单个段",
-		StatuslineThemeTitle:  "状态栏主题",
-		StatuslineThemeDesc:   "选择状态栏的颜色主题。",
-		ThemeDefault:          "默认",
-		ThemeCatppuccinMocha:  "Catppuccin Mocha (深色)",
-		ThemeCatppuccinLatte:  "Catppuccin Latte (浅色)",
-		SegmentsTitle:         "状态栏段",
-		SegModel:           "显示模型名称",
-		SegContext:         "显示上下文使用量",
-		SegOutputStyle:     "显示输出样式",
-		SegDirectory:       "显示目录",
-		SegGitStatus:       "显示git状态",
-		SegClaudeVersion:   "显示Claude版本",
-		SegMoaiVersion:     "显示MoAI版本",
-		SegGitBranch:       "显示git分支",
-		SegSessionTime:    "显示会话时间",
-		SegUsage5H:        "显示5H API使用量栏",
-		SegUsage7D:        "显示7D API使用量栏",
-		SetupCancelled:     "设置已取消。",
+		ModeVerbose:        "Verbose - 含费用追踪的3行详细视图",
+		ModeMinimal:        "Minimal - 仅显示模型和上下文",
+		StatuslineThemeTitle: "状态栏主题",
+		StatuslineThemeDesc:  "选择状态栏的颜色主题。",
+		ThemeDefault:         "默认",
+		ThemeCatppuccinMocha: "Catppuccin Mocha (深色)",
+		ThemeCatppuccinLatte: "Catppuccin Latte (浅色)",
+		SetupCancelled:      "设置已取消。",
 		SavedProfile:       "\n配置文件 '%s' 已保存:\n  偏好设置 → %s\n",
 	},
 }


### PR DESCRIPTION
## Summary

Remove the redundant statusline segment preset question from `moai profile setup` wizard. The statusline mode (default/compact/full) already controls both layout and segment visibility, making the preset question redundant.

## Changes

- ✅ Remove preset selector question (full/compact/minimal/custom)
- ✅ Remove custom segment toggles (12 confirm questions)
- ✅ Remove `getSegmentDefault` helper function
- ✅ Remove preset/segment translation strings (en/ko/ja/zh)
- ✅ Remove `TestGetSegmentDefault` test

## Impact

The `statuslineMode` is now the single source of truth for statusline layout. Legacy preset config is still read for migration compatibility.

## Local CI Mirror Results

| Check | Status | Notes |
|-------|--------|-------|
| go vet | ✅ Pass | |
| go test -race | ✅ Pass | Coverage: 90%+ |
| golangci-lint | ✅ Pass | 0 issues |
| build linux/amd64 | ✅ Pass | |
| build linux/arm64 | ✅ Pass | |
| build darwin/amd64 | ✅ Pass | |
| build darwin/arm64 | ✅ Pass | |
| build windows/amd64 | ✅ Pass | |

## Test Plan

- [x] All existing tests pass
- [x] No new lint issues
- [x] Cross-platform builds verified
- [ ] Manual verification of `moai profile setup` workflow

🗿 MoAI <email@mo.ai.kr>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Setup Changes**
  * Simplified the interactive profile setup wizard. Removed statusline segment-level customization and preset selection options from the configuration flow. Individual component toggles are no longer available during setup. Users can still configure overall statusline mode and theme through standard configuration. The setup process now streamlines profile creation by removing granular statusline customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->