### PR TITLE
fix(statusline): 5H/7D 사용량 표시 수정 - OAuth beta 헤더 추가

### DIFF
--- a/internal/statusline/usage.go
+++ b/internal/statusline/usage.go
@@ -41,6 +41,7 @@ type usageCollector struct {
 	failureCooldownMax  time.Duration // Exponential backoff max cooldown (default: 32m)
 	client             *http.Client
 	homeDir            string
+	keychainReaderFn   func() (string, error) // Override for testing
 }
 
 // NewUsageCollector creates a new UsageProvider.
@@ -81,7 +82,11 @@ func (u *usageCollector) CollectUsage(ctx context.Context) (*UsageResult, error)
 	}
 
 	// Cache miss: retrieve OAuth token (REQ-V3-API-010)
-	token := readOAuthToken(u.homeDir, u.readTokenFromKeychain)
+	keychainReader := u.readTokenFromKeychain
+	if u.keychainReaderFn != nil {
+		keychainReader = u.keychainReaderFn
+	}
+	token := readOAuthToken(u.homeDir, keychainReader)
 	if token == "" {
 		slog.Debug("oauth token not found, skipping usage collection")
 		return nil, nil
@@ -434,6 +439,7 @@ func (u *usageCollector) fetchUsageFromHeadersWithURL(ctx context.Context, apiUR
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("anthropic-version", "2023-06-01")
+	req.Header.Set("anthropic-beta", "oauth-2025-04-20")
 
 	resp, err := u.client.Do(req)
 	if err != nil {

--- a/internal/statusline/usage_test.go
+++ b/internal/statusline/usage_test.go
@@ -478,9 +478,20 @@ func TestUsageProvider_CollectUsage_GracefulDegradation(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
-	// No token, no cache
-
-	collector := NewUsageCollector(tmpDir)
+	cachePath := filepath.Join(tmpDir, ".moai", "cache", "usage.json")
+	// No token, no cache — mock keychain to prevent real keychain access
+	collector := &usageCollector{
+		cachePath:           cachePath,
+		ttl:                 5 * time.Minute,
+		failureCooldownBase: 1 * time.Minute,
+		failureCooldownMax:  32 * time.Minute,
+		client:              &http.Client{Timeout: 300 * time.Millisecond},
+		homeDir:             tmpDir,
+	}
+	// Override keychain reader to always fail (no real keychain access)
+	collector.keychainReaderFn = func() (string, error) {
+		return "", fmt.Errorf("no keychain in test")
+	}
 
 	// Should return nil, nil on failure (no error propagation)
 	result, err := collector.CollectUsage(context.Background())


### PR DESCRIPTION
## Summary
- Messages API에 OAuth 토큰으로 인증할 때 `anthropic-beta: oauth-2025-04-20` 헤더가 필수
- 이 헤더 없이는 401 "OAuth authentication is currently not supported" 에러 발생
- 5H/7D 사용량 바가 항상 0%로 표시되던 근본 원인 수정

## Changes
- `fetchUsageFromHeadersWithURL`에 `anthropic-beta: oauth-2025-04-20` 헤더 추가
- `usageCollector`에 `keychainReaderFn` 필드 추가 (테스트에서 실제 키체인 접근 방지)
- `TestUsageProvider_CollectUsage_GracefulDegradation` 테스트 격리 강화

## Root Cause Analysis
1. Haiku probe (Messages API): OAuth 토큰 사용 시 `anthropic-beta` 헤더 없으면 401 반환
2. OAuth usage endpoint (fallback): 지속적 429 Rate Limited (알려진 이슈)
3. 두 경로 모두 실패 → 캐시에 failure 기록 → 사용량 항상 0%

## Verification
```bash
# Before fix: 401 "OAuth authentication is currently not supported"
curl -s https://api.anthropic.com/v1/messages \
  -H "Authorization: Bearer $TOKEN" \
  -H "anthropic-version: 2023-06-01" \
  -d '{"model":"claude-haiku-4-5-20251001","max_tokens":1,"messages":[{"role":"user","content":"h"}]}'

# After fix: 200 OK with rate limit headers
curl -s -D - https://api.anthropic.com/v1/messages \
  -H "Authorization: Bearer $TOKEN" \
  -H "anthropic-version: 2023-06-01" \
  -H "anthropic-beta: oauth-2025-04-20" \
  -d '...' | grep anthropic-ratelimit-unified
# anthropic-ratelimit-unified-5h-utilization: 0.07
# anthropic-ratelimit-unified-7d-utilization: 0.03
```

## Test Plan
- [x] `go test -count=1 ./internal/statusline/` - 전체 통과
- [x] `go test -count=1 ./...` - 전체 프로젝트 통과
- [x] 실제 API 호출로 rate limit 헤더 수신 확인

🗿 MoAI <email@mo.ai.kr>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure to improve coverage for authentication failure handling scenarios with isolated test configurations and mocked behavior.

* **Chores**
  * Updated API request headers for improved service compatibility and integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->