### PR TITLE
fix(template): WSL2 환경에서 Windows 경로 보존 (#495)

### DIFF
--- a/internal/template/settings.go
+++ b/internal/template/settings.go
@@ -90,7 +90,7 @@ func BuildSmartPATH() string {
 			seen[strings.TrimRight(c, "/\\")] = true
 		}
 		for _, entry := range strings.Split(os.Getenv("PATH"), sep) {
-			if isWSL2DrivePath(entry) {
+			if isWSL2DrivePath(entry) && !isUserScopedWindowsPath(entry) {
 				normalized := strings.TrimRight(entry, "/\\")
 				if !seen[normalized] {
 					candidates = append(candidates, entry)
@@ -113,6 +113,31 @@ func isWSL2DrivePath(entry string) bool {
 	}
 	letter := entry[5]
 	return letter >= 'a' && letter <= 'z' && (len(entry) == 6 || entry[6] == '/')
+}
+
+// isUserScopedWindowsPath reports whether a WSL2 drive-mount path points to a
+// per-user Windows directory. Such paths (e.g., /mnt/c/Users/alice/AppData/...)
+// are machine-specific and must not be persisted in settings.json, as they would
+// break portability and partially undo the fix from issue #467.
+//
+// Rejected prefixes (case-insensitive):
+//   - /users/           — Windows user home directories
+//   - /appdata/         — per-user application data
+//   - /documents and settings/ — legacy Windows XP user profiles
+func isUserScopedWindowsPath(entry string) bool {
+	lower := strings.ToLower(entry)
+	// Strip the /mnt/<letter> prefix to check the Windows-relative path.
+	if len(lower) < 7 {
+		return false
+	}
+	// Find the path after /mnt/<letter>, e.g. "/mnt/c/Users/..." → "/users/..."
+	rest := lower[6:] // skip "/mnt/X"
+	for _, segment := range []string{"/users/", "/appdata/", "/documents and settings/"} {
+		if strings.Contains(rest, segment) {
+			return true
+		}
+	}
+	return false
 }
 
 // PathContainsDir checks if a PATH string contains a specific directory entry.

--- a/internal/template/settings_test.go
+++ b/internal/template/settings_test.go
@@ -773,6 +773,12 @@ func TestBuildSmartPATH_WSL2(t *testing.T) {
 			checkNoDup:   "/mnt/c/Windows/System32",
 		},
 		{
+			name:           "user_scoped_paths_excluded",
+			terminalPATH:   "/mnt/c/Windows/System32:/mnt/c/Users/alice/AppData/Local/Programs/bin:/mnt/c/Users/alice/AppData/Roaming/npm",
+			mustContain:    []string{"/mnt/c/Windows/System32"},
+			mustNotContain: []string{"/mnt/c/Users/alice/AppData/Local/Programs/bin", "/mnt/c/Users/alice/AppData/Roaming/npm"},
+		},
+		{
 			name:            "non_wsl2_stable",
 			isStabilityTest: true,
 		},
@@ -824,6 +830,32 @@ func TestBuildSmartPATH_WSL2(t *testing.T) {
 				if count > 1 {
 					t.Errorf("WSL2: %q should appear at most once, found %d times in %q", tc.checkNoDup, count, path)
 				}
+			}
+		})
+	}
+}
+
+// TestIsUserScopedWindowsPath verifies that per-user Windows directories are rejected.
+func TestIsUserScopedWindowsPath(t *testing.T) {
+	tests := []struct {
+		entry string
+		want  bool
+	}{
+		{"/mnt/c/Users/alice/AppData/Local/Programs/bin", true},
+		{"/mnt/c/Users/alice/AppData/Roaming/npm", true},
+		{"/mnt/c/users/bob/appdata/local/bin", true},  // case-insensitive
+		{"/mnt/c/Documents and Settings/alice/bin", true},
+		{"/mnt/c/Windows/System32", false},
+		{"/mnt/c/Windows/System32/WindowsPowerShell/v1.0", false},
+		{"/mnt/d/tools/bin", false},
+		{"/mnt/c/Program Files/Git/bin", false},
+		{"/usr/bin", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.entry, func(t *testing.T) {
+			if got := isUserScopedWindowsPath(tt.entry); got != tt.want {
+				t.Errorf("isUserScopedWindowsPath(%q) = %v, want %v", tt.entry, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

WSL2에서 `moai update` 후 `.claude/settings.json`의 `PATH`가 Windows 경로를 덮어써 `powershell.exe` 등을 실행할 수 없게 되는 버그 수정.

## Root Cause

`BuildSmartPATH()` (`internal/template/settings.go`)가 WSL2 환경에서 `/mnt/c/Windows/System32` 등 Windows 경로를 포함하지 않아, settings.json에 주입된 정적 PATH가 WSL2가 자동 추가한 Windows 경로를 덮어쓰는 문제.

## Changes

- `IsWSL2()` 함수 추가: `WSL_DISTRO_NAME` 환경변수 및 `/proc/version` 패턴으로 WSL2 감지
- `BuildSmartPATH()` 수정: WSL2에서 현재 `PATH`의 `/mnt/...` 경로를 추출해 PATH 끝에 추가 (중복 제거)
- 재현 테스트 5개 추가

## Test Results

All tests pass. Regression tests added:
- `TestIsWSL2_EnvVar`
- `TestBuildSmartPATH_WSL2PreservesWindowsPaths`
- `TestBuildSmartPATH_WSL2_NoDuplicates`
- (and more)

Fixes #495

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added detection for WSL2 environments with improved PATH configuration to properly include Windows drive mount paths.

* **Tests**
  * Added extensive test coverage for WSL2 detection and PATH handling across various environment configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->