### PR TITLE
feat: /moai:github 워크플로우 개선 및 @claude 봇 Opus 설정

### DIFF
--- a/.claude/commands/moai/github.md
+++ b/.claude/commands/moai/github.md
@@ -111,7 +111,7 @@ Before starting analysis, check for existing bot work on each selected issue.
 git ls-remote --heads origin | grep -i "claude/issue-{number}"
 
 # Check for other automated fix branches
-git ls-remote --heads origin | grep -E "(fix|feat|improve)/issue-{number}"
+git ls-remote --heads origin | grep -E "(fix|feat|improve|docs)/issue-{number}"
 
 # Check for PRs referencing this issue
 gh pr list --search "#{number}" --state all --json number,title,headRefName,state,author
@@ -124,6 +124,8 @@ gh pr list --search "#{number}" --state all --json number,title,headRefName,stat
 | Yes | No | - | AskUser: Create PR from bot branch / Redo fix |
 | Yes | Yes | OPEN | AskUser: Review existing PR / Redo fix |
 | Yes | Yes | MERGED | Skip issue (already resolved) |
+| No | Yes | OPEN | AskUser: Review existing PR / Continue work |
+| No | Yes | MERGED | Skip issue (already resolved) |
 | No | No | - | Proceed with normal Phase 2 analysis |
 
 When existing bot work is found, use AskUserQuestion:
@@ -173,6 +175,7 @@ Task(
   team_name: "github-issues-{repo-slug}",
   name: "fixer-{number}",
   mode: "acceptEdits",
+  isolation: "worktree",
   prompt: "Fix GitHub issue #{number} based on analysis findings.
     Analysis: {analyst_findings}
     Affected files: {file_list}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Run Claude Code Review
         id: claude-review
         # C1 Fix: Pinned to commit SHA to prevent supply chain attacks via floating tags.
-        # Tag: v1 | SHA: 1dd74842e568f373608605d9e45c9e854f65f543
+        # SHA: ba7fa4bcf054319261202aef93d71a89112a8d00 (pinned commit, beyond v1 tag)
         uses: anthropics/claude-code-action@ba7fa4bcf054319261202aef93d71a89112a8d00
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,11 @@ on:
   pull_request_review:
     types: [submitted]
 
+# I1 Fix: Added concurrency control to prevent duplicate parallel runs on the same issue/PR.
+concurrency:
+  group: claude-${{ github.event.issue.number || github.event.pull_request.number || github.event.comment.id }}
+  cancel-in-progress: false
+
 jobs:
   claude:
     if: |
@@ -44,7 +49,7 @@ jobs:
       - name: Run Claude Code
         id: claude
         # C1 Fix: Pinned to commit SHA to prevent supply chain attacks via floating tags.
-        # Tag: v1 | SHA: 1dd74842e568f373608605d9e45c9e854f65f543
+        # SHA: ba7fa4bcf054319261202aef93d71a89112a8d00 (pinned commit, beyond v1 tag)
         uses: anthropics/claude-code-action@ba7fa4bcf054319261202aef93d71a89112a8d00
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/internal/template/templates/.claude/commands/moai/github.md
+++ b/internal/template/templates/.claude/commands/moai/github.md
@@ -111,7 +111,7 @@ Before starting analysis, check for existing bot work on each selected issue.
 git ls-remote --heads origin | grep -i "claude/issue-{number}"
 
 # Check for other automated fix branches
-git ls-remote --heads origin | grep -E "(fix|feat|improve)/issue-{number}"
+git ls-remote --heads origin | grep -E "(fix|feat|improve|docs)/issue-{number}"
 
 # Check for PRs referencing this issue
 gh pr list --search "#{number}" --state all --json number,title,headRefName,state,author
@@ -124,6 +124,8 @@ gh pr list --search "#{number}" --state all --json number,title,headRefName,stat
 | Yes | No | - | AskUser: Create PR from bot branch / Redo fix |
 | Yes | Yes | OPEN | AskUser: Review existing PR / Redo fix |
 | Yes | Yes | MERGED | Skip issue (already resolved) |
+| No | Yes | OPEN | AskUser: Review existing PR / Continue work |
+| No | Yes | MERGED | Skip issue (already resolved) |
 | No | No | - | Proceed with normal Phase 2 analysis |
 
 When existing bot work is found, use AskUserQuestion:
@@ -173,6 +175,7 @@ Task(
   team_name: "github-issues-{repo-slug}",
   name: "fixer-{number}",
   mode: "acceptEdits",
+  isolation: "worktree",
   prompt: "Fix GitHub issue #{number} based on analysis findings.
     Analysis: {analyst_findings}
     Affected files: {file_list}


### PR DESCRIPTION
## Summary
- `/moai:github` 지침에 3가지 Critical 개선 사항 추가 (실제 #495, #496 이슈 처리에서 발견된 문제점 해결)
- `@claude` 봇 워크플로우에 Opus 모델 + high effort 설정 추가

## Changes

### /moai:github 지침 개선 (github.md)
- **Issues Phase 1.5: Existing Work Detection** — @claude 봇 기존 브랜치/PR 감지 → 재활용 옵션 제공
- **Bot Review Integration** — CodeRabbit CHANGES_REQUESTED 자동 감지, 피드백 반영, `@coderabbitai resolve` 흐름
- **Auto-Merge Safety Protocol** — mergeStateStatus 사전 검증, BEHIND 자동 해결, `--auto` 모니터링
- **PR Phase 5: Merge** — PR 서브커맨드에도 `--merge` 플래그 추가
- **Multi-PR Merge Orchestration** — 파일 중복 감지 기반 순차 머지

### @claude 봇 워크플로우 설정
- `claude.yml`: `--model opus --effort high --max-turns 20` (deprecated `max_turns` 입력 제거)
- `claude-code-review.yml`: `--model opus --effort high`

## Test plan
- [ ] `/moai:github issues --all` 실행 시 봇 브랜치 감지 동작 확인
- [ ] `/moai:github pr --merge` 실행 시 CodeRabbit 리뷰 상태 확인 동작 검증
- [ ] @claude 멘션 시 Opus 모델 사용 확인 (GitHub Actions 로그)

🗿 MoAI <email@mo.ai.kr>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Made Agent Teams the default collaboration mode; replaced worktree-centric guidance with team-role workflows, multi-perspective PR reviews, per-issue branching, multilingual comment support, pre-execution prerequisites, and stronger auto-merge safety/bot-review guidance.
  * Added flags for team vs sub-agent modes (including tmux support), updated issue/PR phases, and expanded examples and prompts.

* **Chores**
  * Consolidated workflow args into claude_args, set Claude Opus for reviews, added concurrency controls and bounded review turns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->