### PR TITLE
docs: --ultrathink를 --deepthink로 이름 변경

### DIFF
--- a/.claude/agents/moai/builder-agent.md
+++ b/.claude/agents/moai/builder-agent.md
@@ -3,7 +3,7 @@ name: builder-agent
 description: |
   Agent creation specialist. Use PROACTIVELY for creating sub-agents, agent blueprints, and custom agent definitions.
   MUST INVOKE when ANY of these keywords appear in user request:
-  --ultrathink flag: Activate Sequential Thinking MCP for deep analysis of agent design, capability boundaries, and integration patterns.
+  --deepthink flag: Activate Sequential Thinking MCP for deep analysis of agent design, capability boundaries, and integration patterns.
   EN: create agent, new agent, agent blueprint, sub-agent, agent definition, custom agent
   KO: 에이전트생성, 새에이전트, 에이전트블루프린트, 서브에이전트, 에이전트정의, 커스텀에이전트
   JA: エージェント作成, 新エージェント, エージェントブループリント, サブエージェント

--- a/.claude/agents/moai/builder-plugin.md
+++ b/.claude/agents/moai/builder-plugin.md
@@ -3,7 +3,7 @@ name: builder-plugin
 description: |
   Plugin creation specialist. Use PROACTIVELY for Claude Code plugins, marketplace setup, and plugin validation.
   MUST INVOKE when ANY of these keywords appear in user request:
-  --ultrathink flag: Activate Sequential Thinking MCP for deep analysis of plugin architecture, marketplace structure, and plugin validation.
+  --deepthink flag: Activate Sequential Thinking MCP for deep analysis of plugin architecture, marketplace structure, and plugin validation.
   EN: create plugin, plugin, plugin validation, plugin structure, marketplace, new plugin, marketplace creation, marketplace.json, plugin distribution
   KO: 플러그인생성, 플러그인, 플러그인검증, 플러그인구조, 마켓플레이스, 새플러그인, 마켓플레이스 생성, 플러그인 배포
   JA: プラグイン作成, プラグイン, プラグイン検証, プラグイン構造, マーケットプレイス, マーケットプレイス作成, プラグイン配布

--- a/.claude/agents/moai/builder-skill.md
+++ b/.claude/agents/moai/builder-skill.md
@@ -3,7 +3,7 @@ name: builder-skill
 description: |
   Skill creation specialist. Use PROACTIVELY for creating skills, YAML frontmatter design, and knowledge organization.
   MUST INVOKE when ANY of these keywords appear in user request:
-  --ultrathink flag: Activate Sequential Thinking MCP for deep analysis of skill design, knowledge organization, and YAML frontmatter structure.
+  --deepthink flag: Activate Sequential Thinking MCP for deep analysis of skill design, knowledge organization, and YAML frontmatter structure.
   EN: create skill, new skill, skill optimization, knowledge domain, YAML frontmatter
   KO: 스킬생성, 새스킬, 스킬최적화, 지식도메인, YAML프론트매터
   JA: スキル作成, 新スキル, スキル最適化, 知識ドメイン, YAMLフロントマター

--- a/.claude/agents/moai/expert-backend.md
+++ b/.claude/agents/moai/expert-backend.md
@@ -3,7 +3,7 @@ name: expert-backend
 description: |
   Backend architecture and database specialist. Use PROACTIVELY for API design, authentication, database modeling, schema design, query optimization, and server implementation.
   MUST INVOKE when ANY of these keywords appear in user request:
-  --ultrathink flag: Activate Sequential Thinking MCP for deep analysis of backend architecture decisions, database schema design, and API patterns.
+  --deepthink flag: Activate Sequential Thinking MCP for deep analysis of backend architecture decisions, database schema design, and API patterns.
   EN: backend, API, server, authentication, database, REST, GraphQL, microservices, JWT, OAuth, SQL, NoSQL, PostgreSQL, MongoDB, Redis, Oracle, PL/SQL, schema, query, index, data modeling
   KO: 백엔드, API, 서버, 인증, 데이터베이스, RESTful, 마이크로서비스, 토큰, SQL, NoSQL, PostgreSQL, MongoDB, Redis, 오라클, Oracle, PL/SQL, 스키마, 쿼리, 인덱스, 데이터모델링
   JA: バックエンド, API, サーバー, 認証, データベース, マイクロサービス, SQL, NoSQL, PostgreSQL, MongoDB, Redis, Oracle, PL/SQL, スキーマ, クエリ, インデックス

--- a/.claude/agents/moai/expert-debug.md
+++ b/.claude/agents/moai/expert-debug.md
@@ -3,7 +3,7 @@ name: expert-debug
 description: |
   Debugging specialist. Use PROACTIVELY for error diagnosis, bug fixing, exception handling, and troubleshooting.
   MUST INVOKE when ANY of these keywords appear in user request:
-  --ultrathink flag: Activate Sequential Thinking MCP for deep analysis of error patterns, root causes, and debugging strategies.
+  --deepthink flag: Activate Sequential Thinking MCP for deep analysis of error patterns, root causes, and debugging strategies.
   EN: debug, error, bug, exception, crash, troubleshoot, diagnose, fix error
   KO: 디버그, 에러, 버그, 예외, 크래시, 문제해결, 진단, 오류수정
   JA: デバッグ, エラー, バグ, 例外, クラッシュ, トラブルシュート, 診断

--- a/.claude/agents/moai/expert-devops.md
+++ b/.claude/agents/moai/expert-devops.md
@@ -3,7 +3,7 @@ name: expert-devops
 description: |
   DevOps specialist. Use PROACTIVELY for CI/CD, Docker, Kubernetes, deployment, and infrastructure automation.
   MUST INVOKE when ANY of these keywords appear in user request:
-  --ultrathink flag: Activate Sequential Thinking MCP for deep analysis of deployment strategies, CI/CD pipelines, and infrastructure architecture.
+  --deepthink flag: Activate Sequential Thinking MCP for deep analysis of deployment strategies, CI/CD pipelines, and infrastructure architecture.
   EN: DevOps, CI/CD, Docker, Kubernetes, deployment, pipeline, infrastructure, container
   KO: 데브옵스, CI/CD, 도커, 쿠버네티스, 배포, 파이프라인, 인프라, 컨테이너
   JA: DevOps, CI/CD, Docker, Kubernetes, デプロイ, パイプライン, インフラ

--- a/.claude/agents/moai/expert-frontend.md
+++ b/.claude/agents/moai/expert-frontend.md
@@ -3,7 +3,7 @@ name: expert-frontend
 description: |
   Frontend development and UI/UX design specialist. Use PROACTIVELY for React, Vue, Next.js, component design, state management, accessibility, WCAG compliance, and design systems.
   MUST INVOKE when ANY of these keywords appear in user request:
-  --ultrathink flag: Activate Sequential Thinking MCP for deep analysis of component architecture, state management patterns, and UI/UX design decisions.
+  --deepthink flag: Activate Sequential Thinking MCP for deep analysis of component architecture, state management patterns, and UI/UX design decisions.
   EN: frontend, UI, component, React, Vue, Next.js, CSS, responsive, state management, UI/UX, design, accessibility, WCAG, user experience, design system, wireframe
   KO: 프론트엔드, UI, 컴포넌트, 리액트, 뷰, 넥스트, CSS, 반응형, 상태관리, UI/UX, 디자인, 접근성, WCAG, 사용자경험, 디자인시스템, 와이어프레임
   JA: フロントエンド, UI, コンポーネント, リアクト, ビュー, CSS, レスポンシブ, 状態管理, UI/UX, デザイン, アクセシビリティ, WCAG, ユーザー体験, デザインシステム

--- a/.claude/agents/moai/expert-performance.md
+++ b/.claude/agents/moai/expert-performance.md
@@ -3,7 +3,7 @@ name: expert-performance
 description: |
   Performance optimization specialist. Use PROACTIVELY for profiling, benchmarking, memory analysis, and latency optimization.
   MUST INVOKE when ANY of these keywords appear in user request:
-  --ultrathink flag: Activate Sequential Thinking MCP for deep analysis of performance bottlenecks, optimization strategies, and profiling approaches.
+  --deepthink flag: Activate Sequential Thinking MCP for deep analysis of performance bottlenecks, optimization strategies, and profiling approaches.
   EN: performance, profiling, optimization, benchmark, memory, bundle, latency, speed
   KO: 성능, 프로파일링, 최적화, 벤치마크, 메모리, 번들, 지연시간, 속도
   JA: パフォーマンス, プロファイリング, 最適化, ベンチマーク, メモリ, バンドル, レイテンシ

--- a/.claude/agents/moai/expert-refactoring.md
+++ b/.claude/agents/moai/expert-refactoring.md
@@ -3,7 +3,7 @@ name: expert-refactoring
 description: |
   Refactoring specialist. Use PROACTIVELY for codemod, AST-based transformations, API migrations, and large-scale code changes.
   MUST INVOKE when ANY of these keywords appear:
-  --ultrathink flag: Activate Sequential Thinking MCP for deep analysis of refactoring strategies, transformation patterns, and code structure improvements.
+  --deepthink flag: Activate Sequential Thinking MCP for deep analysis of refactoring strategies, transformation patterns, and code structure improvements.
   EN: refactor, restructure, codemod, transform, migrate API, rename across, bulk rename, large-scale change, ast search, structural search
   KO: 리팩토링, 재구조화, 코드모드, 변환, API 마이그레이션, 일괄 변경, 대규모 변경, AST검색, 구조적검색
   JA: リファクタリング, 再構造化, コードモード, 変換, API移行, 一括変更, 大規模変更, AST検索, 構造検索

--- a/.claude/agents/moai/expert-security.md
+++ b/.claude/agents/moai/expert-security.md
@@ -3,7 +3,7 @@ name: expert-security
 description: |
   Security analysis specialist. Use PROACTIVELY for OWASP, vulnerability assessment, XSS, CSRF, and secure code review.
   MUST INVOKE when ANY of these keywords appear in user request:
-  --ultrathink flag: Activate Sequential Thinking MCP for deep analysis of security threats, vulnerability patterns, and OWASP compliance.
+  --deepthink flag: Activate Sequential Thinking MCP for deep analysis of security threats, vulnerability patterns, and OWASP compliance.
   EN: security, vulnerability, OWASP, injection, XSS, CSRF, penetration, audit, threat
   KO: 보안, 취약점, OWASP, 인젝션, XSS, CSRF, 침투, 감사, 위협
   JA: セキュリティ, 脆弱性, OWASP, インジェクション, XSS, CSRF, ペネトレーション, 監査

--- a/.claude/agents/moai/expert-testing.md
+++ b/.claude/agents/moai/expert-testing.md
@@ -3,7 +3,7 @@ name: expert-testing
 description: |
   Testing strategy specialist. Use PROACTIVELY for E2E, integration testing, load testing, coverage, and QA automation.
   MUST INVOKE when ANY of these keywords appear in user request:
-  --ultrathink flag: Activate Sequential Thinking MCP for deep analysis of testing strategies, coverage patterns, and QA automation approaches.
+  --deepthink flag: Activate Sequential Thinking MCP for deep analysis of testing strategies, coverage patterns, and QA automation approaches.
   EN: test strategy, E2E, integration test, load test, test automation, coverage, QA
   KO: 테스트전략, E2E, 통합테스트, 부하테스트, 테스트자동화, 커버리지, QA
   JA: テスト戦略, E2E, 統合テスト, 負荷テスト, テスト自動化, カバレッジ, QA

--- a/.claude/agents/moai/manager-ddd.md
+++ b/.claude/agents/moai/manager-ddd.md
@@ -4,7 +4,7 @@ description: |
   DDD (Domain-Driven Development) implementation specialist. Use for ANALYZE-PRESERVE-IMPROVE
   cycle when working with existing codebases that have minimal test coverage.
   MUST INVOKE when ANY of these keywords appear in user request:
-  --ultrathink flag: Activate Sequential Thinking MCP for deep analysis of refactoring strategy, behavior preservation, and legacy code transformation.
+  --deepthink flag: Activate Sequential Thinking MCP for deep analysis of refactoring strategy, behavior preservation, and legacy code transformation.
   EN: DDD, refactoring, legacy code, behavior preservation, characterization test, domain-driven refactoring
   KO: DDD, 리팩토링, 레거시코드, 동작보존, 특성테스트, 도메인주도리팩토링
   JA: DDD, リファクタリング, レガシーコード, 動作保存, 特性テスト, ドメイン駆動リファクタリング

--- a/.claude/agents/moai/manager-docs.md
+++ b/.claude/agents/moai/manager-docs.md
@@ -3,7 +3,7 @@ name: manager-docs
 description: |
   Documentation specialist. Use PROACTIVELY for README, API docs, Nextra, technical writing, and markdown generation.
   MUST INVOKE when ANY of these keywords appear in user request:
-  --ultrathink flag: Activate Sequential Thinking MCP for deep analysis of documentation structure, content organization, and technical writing strategies.
+  --deepthink flag: Activate Sequential Thinking MCP for deep analysis of documentation structure, content organization, and technical writing strategies.
   EN: documentation, README, API docs, Nextra, markdown, technical writing, docs
   KO: 문서, README, API문서, Nextra, 마크다운, 기술문서, 문서화
   JA: ドキュメント, README, APIドキュメント, Nextra, マークダウン, 技術文書

--- a/.claude/agents/moai/manager-git.md
+++ b/.claude/agents/moai/manager-git.md
@@ -3,7 +3,7 @@ name: manager-git
 description: |
   Git workflow specialist. Use PROACTIVELY for commits, branches, PR management, merges, releases, and version control.
   MUST INVOKE when ANY of these keywords appear in user request:
-  --ultrathink flag: Activate Sequential Thinking MCP for deep analysis of git strategies, branch management, and version control workflows.
+  --deepthink flag: Activate Sequential Thinking MCP for deep analysis of git strategies, branch management, and version control workflows.
   EN: git, commit, push, pull, branch, PR, pull request, merge, release, version control, checkout, rebase, stash
   KO: git, 커밋, 푸시, 풀, 브랜치, PR, 풀리퀘스트, 머지, 릴리즈, 버전관리, 체크아웃, 리베이스
   JA: git, コミット, プッシュ, プル, ブランチ, PR, プルリクエスト, マージ, リリース

--- a/.claude/agents/moai/manager-project.md
+++ b/.claude/agents/moai/manager-project.md
@@ -3,7 +3,7 @@ name: manager-project
 description: |
   Project setup specialist. Use PROACTIVELY for initialization, .moai configuration, scaffolding, and new project creation.
   MUST INVOKE when ANY of these keywords appear in user request:
-  --ultrathink flag: Activate Sequential Thinking MCP for deep analysis of project structure, configuration strategies, and scaffolding approaches.
+  --deepthink flag: Activate Sequential Thinking MCP for deep analysis of project structure, configuration strategies, and scaffolding approaches.
   EN: project setup, initialization, .moai, project configuration, scaffold, new project
   KO: 프로젝트설정, 초기화, .moai, 프로젝트구성, 스캐폴드, 새프로젝트
   JA: プロジェクトセットアップ, 初期化, .moai, プロジェクト構成, スキャフォールド

--- a/.claude/agents/moai/manager-quality.md
+++ b/.claude/agents/moai/manager-quality.md
@@ -3,7 +3,7 @@ name: manager-quality
 description: |
   Code quality specialist. Use PROACTIVELY for TRUST 5 validation, code review, quality gates, and lint compliance.
   MUST INVOKE when ANY of these keywords appear in user request:
-  --ultrathink flag: Activate Sequential Thinking MCP for deep analysis of quality standards, code review strategies, and compliance patterns.
+  --deepthink flag: Activate Sequential Thinking MCP for deep analysis of quality standards, code review strategies, and compliance patterns.
   EN: quality, TRUST 5, code review, compliance, quality gate, lint, code quality
   KO: 품질, TRUST 5, 코드리뷰, 준수, 품질게이트, 린트, 코드품질
   JA: 品質, TRUST 5, コードレビュー, コンプライアンス, 品質ゲート, リント

--- a/.claude/agents/moai/manager-spec.md
+++ b/.claude/agents/moai/manager-spec.md
@@ -3,7 +3,7 @@ name: manager-spec
 description: |
   SPEC creation specialist. Use PROACTIVELY for EARS-format requirements, acceptance criteria, and user story documentation.
   MUST INVOKE when ANY of these keywords appear in user request:
-  --ultrathink flag: Activate Sequential Thinking MCP for deep analysis of requirements, acceptance criteria, and user story design.
+  --deepthink flag: Activate Sequential Thinking MCP for deep analysis of requirements, acceptance criteria, and user story design.
   EN: SPEC, requirement, specification, EARS, acceptance criteria, user story, planning
   KO: SPEC, 요구사항, 명세서, EARS, 인수조건, 유저스토리, 기획
   JA: SPEC, 要件, 仕様書, EARS, 受入基準, ユーザーストーリー

--- a/.claude/agents/moai/manager-strategy.md
+++ b/.claude/agents/moai/manager-strategy.md
@@ -3,7 +3,7 @@ name: manager-strategy
 description: |
   Implementation strategy specialist. Use PROACTIVELY for architecture decisions, technology evaluation, and implementation planning.
   MUST INVOKE when ANY of these keywords appear in user request:
-  --ultrathink flag: Activate Sequential Thinking MCP for deep analysis of architecture decisions, technology selection, and implementation strategies.
+  --deepthink flag: Activate Sequential Thinking MCP for deep analysis of architecture decisions, technology selection, and implementation strategies.
   EN: strategy, implementation plan, architecture decision, technology evaluation, planning
   KO: 전략, 구현계획, 아키텍처결정, 기술평가, 계획
   JA: 戦略, 実装計画, アーキテクチャ決定, 技術評価

--- a/.claude/agents/moai/manager-tdd.md
+++ b/.claude/agents/moai/manager-tdd.md
@@ -4,7 +4,7 @@ description: |
   TDD (Test-Driven Development) implementation specialist. Use for RED-GREEN-REFACTOR
   cycle. Default methodology for new projects and feature development.
   MUST INVOKE when ANY of these keywords appear in user request:
-  --ultrathink flag: Activate Sequential Thinking MCP for deep analysis of test strategy, implementation approach, and coverage optimization.
+  --deepthink flag: Activate Sequential Thinking MCP for deep analysis of test strategy, implementation approach, and coverage optimization.
   EN: TDD, test-driven development, red-green-refactor, test-first, new feature, specification test, greenfield
   KO: TDD, 테스트주도개발, 레드그린리팩터, 테스트우선, 신규기능, 명세테스트, 그린필드
   JA: TDD, テスト駆動開発, レッドグリーンリファクタ, テストファースト, 新機能, 仕様テスト, グリーンフィールド

--- a/.claude/rules/moai/core/settings-management.md
+++ b/.claude/rules/moai/core/settings-management.md
@@ -69,7 +69,7 @@ Example `.mcp.json` configuration:
 - Architecture decisions
 - Technology trade-off analysis
 
-Activate with `--ultrathink` flag for enhanced analysis.
+Activate with `--deepthink` flag for enhanced analysis.
 
 ### MoAI Configuration
 

--- a/.claude/rules/moai/development/model-policy.md
+++ b/.claude/rules/moai/development/model-policy.md
@@ -15,7 +15,7 @@ Agent definition `model` field accepts only these values:
 - haiku: Claude Haiku (fastest, lowest cost)
 
 Current model generation mapping (as of v2.1.69):
-- opus = Opus 4.6 (default effort: medium for Max/Team, use "ultrathink" keyword for high effort)
+- opus = Opus 4.6 (default effort: medium for Max/Team, use "deepthink" keyword for high effort)
 - sonnet = Sonnet 4.6
 - haiku = Haiku 4.5
 
@@ -48,9 +48,9 @@ CG Mode (Claude + GLM) uses environment variable overrides, not model field chan
 Opus 4.6 supports effort levels that control reasoning depth:
 - low: Fastest responses, less thorough
 - medium: Default for Max/Team subscribers (v2.1.68+)
-- high: Deep reasoning, activated by "ultrathink" keyword for one turn
+- high: Deep reasoning, activated by "deepthink" keyword for one turn
 
-MoAI's --ultrathink flag triggers high effort for the current turn. This aligns with the "ultrathink" keyword behavior in Claude Code.
+MoAI's --deepthink flag triggers high effort for the current turn. This aligns with the "deepthink" keyword behavior in Claude Code.
 
 ## Rules
 

--- a/.claude/skills/moai-workflow-thinking/SKILL.md
+++ b/.claude/skills/moai-workflow-thinking/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Sequential Thinking MCP and UltraThink mode for deep analysis, complex
   problem decomposition, and structured reasoning workflows.
   Use when performing multi-step analysis, architecture decisions, technology selection
-  trade-offs, breaking change assessment, or when --ultrathink flag is specified.
+  trade-offs, breaking change assessment, or when --deepthink flag is specified.
   Do NOT use for simple decisions or straightforward implementation tasks.
 license: Apache-2.0
 compatibility: Designed for Claude Code
@@ -24,7 +24,7 @@ progressive_disclosure:
 
 # MoAI Extension: Triggers
 triggers:
-  keywords: ["sequential thinking", "ultrathink", "deep analysis", "complex problem", "architecture decision", "technology selection", "trade-off", "breaking change"]
+  keywords: ["sequential thinking", "deepthink", "deep analysis", "complex problem", "architecture decision", "technology selection", "trade-off", "breaking change"]
   phases:
     - plan
   agents:
@@ -102,12 +102,12 @@ nextThoughtNeeded: false
 
 ## UltraThink Mode
 
-Enhanced analysis mode activated by `--ultrathink` flag.
+Enhanced analysis mode activated by `--deepthink` flag.
 
 **Activation:**
 ```
-"Implement authentication system --ultrathink"
-"Refactor the API layer --ultrathink"
+"Implement authentication system --deepthink"
+"Refactor the API layer --deepthink"
 ```
 
 **Process:**

--- a/.claude/skills/moai/SKILL.md
+++ b/.claude/skills/moai/SKILL.md
@@ -211,7 +211,7 @@ For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/feedback.md
 When this skill is activated, execute the following steps in order:
 
 Step 1 - Parse Arguments:
-Extract subcommand keywords and flags from the Raw User Input. Recognized global flags: --resume [ID], --seq, --ultrathink, --team, --solo. When --ultrathink is detected, activate Sequential Thinking MCP for deep analysis before execution.
+Extract subcommand keywords and flags from the Raw User Input. Recognized global flags: --resume [ID], --seq, --deepthink, --team, --solo. When --deepthink is detected, activate Sequential Thinking MCP for deep analysis before execution.
 
 Step 2 - Route to Workflow:
 Apply the Intent Router (Priority 1 through Priority 4) to determine the target workflow. If ambiguous, use AskUserQuestion to clarify with the user.

--- a/.claude/skills/moai/references/global-flags.md
+++ b/.claude/skills/moai/references/global-flags.md
@@ -107,7 +107,7 @@ Preview mode - show what would be done without making changes.
 
 ## Development Mode Flags
 
-### `--ultrathink`
+### `--deepthink`
 Activate Sequential Thinking MCP for deep analysis.
 
 Used for complex problem analysis, architecture decisions, and technology trade-offs.

--- a/.claude/skills/moai/references/reference.md
+++ b/.claude/skills/moai/references/reference.md
@@ -143,7 +143,7 @@ Propagation Method:
 
 - --resume [ID]: Resume workflow from last checkpoint (SPEC-ID or snapshot ID)
 - --seq: Force sequential execution instead of parallel where applicable
-- --ultrathink: Activate Sequential Thinking MCP for deep analysis before execution
+- --deepthink: Activate Sequential Thinking MCP for deep analysis before execution
 - --team: Force Agent Teams mode for parallel execution
 - --solo: Force sub-agent mode (single agent per phase)
 

--- a/.claude/skills/moai/workflows/project.md
+++ b/.claude/skills/moai/workflows/project.md
@@ -136,7 +136,7 @@ After collection, use the gathered information to generate documentation and pro
 
 [HARD] Delegate codebase analysis to the Explore subagent.
 
-[SOFT] Apply --ultrathink for comprehensive analysis.
+[SOFT] Apply --deepthink for comprehensive analysis.
 
 Analysis Objectives passed to Explore agent:
 

--- a/internal/template/templates/.claude/agents/moai/builder-agent.md
+++ b/internal/template/templates/.claude/agents/moai/builder-agent.md
@@ -3,7 +3,7 @@ name: builder-agent
 description: |
   Agent creation specialist. Use PROACTIVELY for creating sub-agents, agent blueprints, and custom agent definitions.
   MUST INVOKE when ANY of these keywords appear in user request:
-  --ultrathink flag: Activate Sequential Thinking MCP for deep analysis of agent design, capability boundaries, and integration patterns.
+  --deepthink flag: Activate Sequential Thinking MCP for deep analysis of agent design, capability boundaries, and integration patterns.
   EN: create agent, new agent, agent blueprint, sub-agent, agent definition, custom agent
   KO: 에이전트생성, 새에이전트, 에이전트블루프린트, 서브에이전트, 에이전트정의, 커스텀에이전트
   JA: エージェント作成, 新エージェント, エージェントブループリント, サブエージェント

--- a/internal/template/templates/.claude/agents/moai/builder-plugin.md
+++ b/internal/template/templates/.claude/agents/moai/builder-plugin.md
@@ -3,7 +3,7 @@ name: builder-plugin
 description: |
   Plugin creation specialist. Use PROACTIVELY for Claude Code plugins, marketplace setup, and plugin validation.
   MUST INVOKE when ANY of these keywords appear in user request:
-  --ultrathink flag: Activate Sequential Thinking MCP for deep analysis of plugin architecture, marketplace structure, and plugin validation.
+  --deepthink flag: Activate Sequential Thinking MCP for deep analysis of plugin architecture, marketplace structure, and plugin validation.
   EN: create plugin, plugin, plugin validation, plugin structure, marketplace, new plugin, marketplace creation, marketplace.json, plugin distribution
   KO: 플러그인생성, 플러그인, 플러그인검증, 플러그인구조, 마켓플레이스, 새플러그인, 마켓플레이스 생성, 플러그인 배포
   JA: プラグイン作成, プラグイン, プラグイン検証, プラグイン構造, マーケットプレイス, マーケットプレイス作成, プラグイン配布

--- a/internal/template/templates/.claude/agents/moai/builder-skill.md
+++ b/internal/template/templates/.claude/agents/moai/builder-skill.md
@@ -3,7 +3,7 @@ name: builder-skill
 description: |
   Skill creation specialist. Use PROACTIVELY for creating skills, YAML frontmatter design, and knowledge organization.
   MUST INVOKE when ANY of these keywords appear in user request:
-  --ultrathink flag: Activate Sequential Thinking MCP for deep analysis of skill design, knowledge organization, and YAML frontmatter structure.
+  --deepthink flag: Activate Sequential Thinking MCP for deep analysis of skill design, knowledge organization, and YAML frontmatter structure.
   EN: create skill, new skill, skill optimization, knowledge domain, YAML frontmatter
   KO: 스킬생성, 새스킬, 스킬최적화, 지식도메인, YAML프론트매터
   JA: スキル作成, 新スキル, スキル最適化, 知識ドメイン, YAMLフロントマター

--- a/internal/template/templates/.claude/agents/moai/expert-backend.md
+++ b/internal/template/templates/.claude/agents/moai/expert-backend.md
@@ -3,7 +3,7 @@ name: expert-backend
 description: |
   Backend architecture and database specialist. Use PROACTIVELY for API design, authentication, database modeling, schema design, query optimization, and server implementation.
   MUST INVOKE when ANY of these keywords appear in user request:
-  --ultrathink flag: Activate Sequential Thinking MCP for deep analysis of backend architecture decisions, database schema design, and API patterns.
+  --deepthink flag: Activate Sequential Thinking MCP for deep analysis of backend architecture decisions, database schema design, and API patterns.
   EN: backend, API, server, authentication, database, REST, GraphQL, microservices, JWT, OAuth, SQL, NoSQL, PostgreSQL, MongoDB, Redis, Oracle, PL/SQL, schema, query, index, data modeling
   KO: 백엔드, API, 서버, 인증, 데이터베이스, RESTful, 마이크로서비스, 토큰, SQL, NoSQL, PostgreSQL, MongoDB, Redis, 오라클, Oracle, PL/SQL, 스키마, 쿼리, 인덱스, 데이터모델링
   JA: バックエンド, API, サーバー, 認証, データベース, マイクロサービス, SQL, NoSQL, PostgreSQL, MongoDB, Redis, Oracle, PL/SQL, スキーマ, クエリ, インデックス

--- a/internal/template/templates/.claude/agents/moai/expert-debug.md
+++ b/internal/template/templates/.claude/agents/moai/expert-debug.md
@@ -3,7 +3,7 @@ name: expert-debug
 description: |
   Debugging specialist. Use PROACTIVELY for error diagnosis, bug fixing, exception handling, and troubleshooting.
   MUST INVOKE when ANY of these keywords appear in user request:
-  --ultrathink flag: Activate Sequential Thinking MCP for deep analysis of error patterns, root causes, and debugging strategies.
+  --deepthink flag: Activate Sequential Thinking MCP for deep analysis of error patterns, root causes, and debugging strategies.
   EN: debug, error, bug, exception, crash, troubleshoot, diagnose, fix error
   KO: 디버그, 에러, 버그, 예외, 크래시, 문제해결, 진단, 오류수정
   JA: デバッグ, エラー, バグ, 例外, クラッシュ, トラブルシュート, 診断

--- a/internal/template/templates/.claude/agents/moai/expert-devops.md
+++ b/internal/template/templates/.claude/agents/moai/expert-devops.md
@@ -3,7 +3,7 @@ name: expert-devops
 description: |
   DevOps specialist. Use PROACTIVELY for CI/CD, Docker, Kubernetes, deployment, and infrastructure automation.
   MUST INVOKE when ANY of these keywords appear in user request:
-  --ultrathink flag: Activate Sequential Thinking MCP for deep analysis of deployment strategies, CI/CD pipelines, and infrastructure architecture.
+  --deepthink flag: Activate Sequential Thinking MCP for deep analysis of deployment strategies, CI/CD pipelines, and infrastructure architecture.
   EN: DevOps, CI/CD, Docker, Kubernetes, deployment, pipeline, infrastructure, container
   KO: 데브옵스, CI/CD, 도커, 쿠버네티스, 배포, 파이프라인, 인프라, 컨테이너
   JA: DevOps, CI/CD, Docker, Kubernetes, デプロイ, パイプライン, インフラ

--- a/internal/template/templates/.claude/agents/moai/expert-frontend.md
+++ b/internal/template/templates/.claude/agents/moai/expert-frontend.md
@@ -3,7 +3,7 @@ name: expert-frontend
 description: |
   Frontend development and UI/UX design specialist. Use PROACTIVELY for React, Vue, Next.js, component design, state management, accessibility, WCAG compliance, and design systems.
   MUST INVOKE when ANY of these keywords appear in user request:
-  --ultrathink flag: Activate Sequential Thinking MCP for deep analysis of component architecture, state management patterns, and UI/UX design decisions.
+  --deepthink flag: Activate Sequential Thinking MCP for deep analysis of component architecture, state management patterns, and UI/UX design decisions.
   EN: frontend, UI, component, React, Vue, Next.js, CSS, responsive, state management, UI/UX, design, accessibility, WCAG, user experience, design system, wireframe
   KO: 프론트엔드, UI, 컴포넌트, 리액트, 뷰, 넥스트, CSS, 반응형, 상태관리, UI/UX, 디자인, 접근성, WCAG, 사용자경험, 디자인시스템, 와이어프레임
   JA: フロントエンド, UI, コンポーネント, リアクト, ビュー, CSS, レスポンシブ, 状態管理, UI/UX, デザイン, アクセシビリティ, WCAG, ユーザー体験, デザインシステム

--- a/internal/template/templates/.claude/agents/moai/expert-performance.md
+++ b/internal/template/templates/.claude/agents/moai/expert-performance.md
@@ -3,7 +3,7 @@ name: expert-performance
 description: |
   Performance optimization specialist. Use PROACTIVELY for profiling, benchmarking, memory analysis, and latency optimization.
   MUST INVOKE when ANY of these keywords appear in user request:
-  --ultrathink flag: Activate Sequential Thinking MCP for deep analysis of performance bottlenecks, optimization strategies, and profiling approaches.
+  --deepthink flag: Activate Sequential Thinking MCP for deep analysis of performance bottlenecks, optimization strategies, and profiling approaches.
   EN: performance, profiling, optimization, benchmark, memory, bundle, latency, speed
   KO: 성능, 프로파일링, 최적화, 벤치마크, 메모리, 번들, 지연시간, 속도
   JA: パフォーマンス, プロファイリング, 最適化, ベンチマーク, メモリ, バンドル, レイテンシ

--- a/internal/template/templates/.claude/agents/moai/expert-refactoring.md
+++ b/internal/template/templates/.claude/agents/moai/expert-refactoring.md
@@ -3,7 +3,7 @@ name: expert-refactoring
 description: |
   Refactoring specialist. Use PROACTIVELY for codemod, AST-based transformations, API migrations, and large-scale code changes.
   MUST INVOKE when ANY of these keywords appear:
-  --ultrathink flag: Activate Sequential Thinking MCP for deep analysis of refactoring strategies, transformation patterns, and code structure improvements.
+  --deepthink flag: Activate Sequential Thinking MCP for deep analysis of refactoring strategies, transformation patterns, and code structure improvements.
   EN: refactor, restructure, codemod, transform, migrate API, rename across, bulk rename, large-scale change, ast search, structural search
   KO: 리팩토링, 재구조화, 코드모드, 변환, API 마이그레이션, 일괄 변경, 대규모 변경, AST검색, 구조적검색
   JA: リファクタリング, 再構造化, コードモード, 変換, API移行, 一括変更, 大規模変更, AST検索, 構造検索

--- a/internal/template/templates/.claude/agents/moai/expert-security.md
+++ b/internal/template/templates/.claude/agents/moai/expert-security.md
@@ -3,7 +3,7 @@ name: expert-security
 description: |
   Security analysis specialist. Use PROACTIVELY for OWASP, vulnerability assessment, XSS, CSRF, and secure code review.
   MUST INVOKE when ANY of these keywords appear in user request:
-  --ultrathink flag: Activate Sequential Thinking MCP for deep analysis of security threats, vulnerability patterns, and OWASP compliance.
+  --deepthink flag: Activate Sequential Thinking MCP for deep analysis of security threats, vulnerability patterns, and OWASP compliance.
   EN: security, vulnerability, OWASP, injection, XSS, CSRF, penetration, audit, threat
   KO: 보안, 취약점, OWASP, 인젝션, XSS, CSRF, 침투, 감사, 위협
   JA: セキュリティ, 脆弱性, OWASP, インジェクション, XSS, CSRF, ペネトレーション, 監査

--- a/internal/template/templates/.claude/agents/moai/expert-testing.md
+++ b/internal/template/templates/.claude/agents/moai/expert-testing.md
@@ -3,7 +3,7 @@ name: expert-testing
 description: |
   Testing strategy specialist. Use PROACTIVELY for E2E, integration testing, load testing, coverage, and QA automation.
   MUST INVOKE when ANY of these keywords appear in user request:
-  --ultrathink flag: Activate Sequential Thinking MCP for deep analysis of testing strategies, coverage patterns, and QA automation approaches.
+  --deepthink flag: Activate Sequential Thinking MCP for deep analysis of testing strategies, coverage patterns, and QA automation approaches.
   EN: test strategy, E2E, integration test, load test, test automation, coverage, QA
   KO: 테스트전략, E2E, 통합테스트, 부하테스트, 테스트자동화, 커버리지, QA
   JA: テスト戦略, E2E, 統合テスト, 負荷テスト, テスト自動化, カバレッジ, QA

--- a/internal/template/templates/.claude/agents/moai/manager-ddd.md
+++ b/internal/template/templates/.claude/agents/moai/manager-ddd.md
@@ -4,7 +4,7 @@ description: |
   DDD (Domain-Driven Development) implementation specialist. Use for ANALYZE-PRESERVE-IMPROVE
   cycle when working with existing codebases that have minimal test coverage.
   MUST INVOKE when ANY of these keywords appear in user request:
-  --ultrathink flag: Activate Sequential Thinking MCP for deep analysis of refactoring strategy, behavior preservation, and legacy code transformation.
+  --deepthink flag: Activate Sequential Thinking MCP for deep analysis of refactoring strategy, behavior preservation, and legacy code transformation.
   EN: DDD, refactoring, legacy code, behavior preservation, characterization test, domain-driven refactoring
   KO: DDD, 리팩토링, 레거시코드, 동작보존, 특성테스트, 도메인주도리팩토링
   JA: DDD, リファクタリング, レガシーコード, 動作保存, 特性テスト, ドメイン駆動リファクタリング

--- a/internal/template/templates/.claude/agents/moai/manager-docs.md
+++ b/internal/template/templates/.claude/agents/moai/manager-docs.md
@@ -3,7 +3,7 @@ name: manager-docs
 description: |
   Documentation specialist. Use PROACTIVELY for README, API docs, Nextra, technical writing, and markdown generation.
   MUST INVOKE when ANY of these keywords appear in user request:
-  --ultrathink flag: Activate Sequential Thinking MCP for deep analysis of documentation structure, content organization, and technical writing strategies.
+  --deepthink flag: Activate Sequential Thinking MCP for deep analysis of documentation structure, content organization, and technical writing strategies.
   EN: documentation, README, API docs, Nextra, markdown, technical writing, docs
   KO: 문서, README, API문서, Nextra, 마크다운, 기술문서, 문서화
   JA: ドキュメント, README, APIドキュメント, Nextra, マークダウン, 技術文書

--- a/internal/template/templates/.claude/agents/moai/manager-git.md
+++ b/internal/template/templates/.claude/agents/moai/manager-git.md
@@ -3,7 +3,7 @@ name: manager-git
 description: |
   Git workflow specialist. Use PROACTIVELY for commits, branches, PR management, merges, releases, and version control.
   MUST INVOKE when ANY of these keywords appear in user request:
-  --ultrathink flag: Activate Sequential Thinking MCP for deep analysis of git strategies, branch management, and version control workflows.
+  --deepthink flag: Activate Sequential Thinking MCP for deep analysis of git strategies, branch management, and version control workflows.
   EN: git, commit, push, pull, branch, PR, pull request, merge, release, version control, checkout, rebase, stash
   KO: git, 커밋, 푸시, 풀, 브랜치, PR, 풀리퀘스트, 머지, 릴리즈, 버전관리, 체크아웃, 리베이스
   JA: git, コミット, プッシュ, プル, ブランチ, PR, プルリクエスト, マージ, リリース

--- a/internal/template/templates/.claude/agents/moai/manager-project.md
+++ b/internal/template/templates/.claude/agents/moai/manager-project.md
@@ -3,7 +3,7 @@ name: manager-project
 description: |
   Project setup specialist. Use PROACTIVELY for initialization, .moai configuration, scaffolding, and new project creation.
   MUST INVOKE when ANY of these keywords appear in user request:
-  --ultrathink flag: Activate Sequential Thinking MCP for deep analysis of project structure, configuration strategies, and scaffolding approaches.
+  --deepthink flag: Activate Sequential Thinking MCP for deep analysis of project structure, configuration strategies, and scaffolding approaches.
   EN: project setup, initialization, .moai, project configuration, scaffold, new project
   KO: 프로젝트설정, 초기화, .moai, 프로젝트구성, 스캐폴드, 새프로젝트
   JA: プロジェクトセットアップ, 初期化, .moai, プロジェクト構成, スキャフォールド

--- a/internal/template/templates/.claude/agents/moai/manager-quality.md
+++ b/internal/template/templates/.claude/agents/moai/manager-quality.md
@@ -3,7 +3,7 @@ name: manager-quality
 description: |
   Code quality specialist. Use PROACTIVELY for TRUST 5 validation, code review, quality gates, and lint compliance.
   MUST INVOKE when ANY of these keywords appear in user request:
-  --ultrathink flag: Activate Sequential Thinking MCP for deep analysis of quality standards, code review strategies, and compliance patterns.
+  --deepthink flag: Activate Sequential Thinking MCP for deep analysis of quality standards, code review strategies, and compliance patterns.
   EN: quality, TRUST 5, code review, compliance, quality gate, lint, code quality
   KO: 품질, TRUST 5, 코드리뷰, 준수, 품질게이트, 린트, 코드품질
   JA: 品質, TRUST 5, コードレビュー, コンプライアンス, 品質ゲート, リント

--- a/internal/template/templates/.claude/agents/moai/manager-spec.md
+++ b/internal/template/templates/.claude/agents/moai/manager-spec.md
@@ -3,7 +3,7 @@ name: manager-spec
 description: |
   SPEC creation specialist. Use PROACTIVELY for EARS-format requirements, acceptance criteria, and user story documentation.
   MUST INVOKE when ANY of these keywords appear in user request:
-  --ultrathink flag: Activate Sequential Thinking MCP for deep analysis of requirements, acceptance criteria, and user story design.
+  --deepthink flag: Activate Sequential Thinking MCP for deep analysis of requirements, acceptance criteria, and user story design.
   EN: SPEC, requirement, specification, EARS, acceptance criteria, user story, planning
   KO: SPEC, 요구사항, 명세서, EARS, 인수조건, 유저스토리, 기획
   JA: SPEC, 要件, 仕様書, EARS, 受入基準, ユーザーストーリー

--- a/internal/template/templates/.claude/agents/moai/manager-strategy.md
+++ b/internal/template/templates/.claude/agents/moai/manager-strategy.md
@@ -3,7 +3,7 @@ name: manager-strategy
 description: |
   Implementation strategy specialist. Use PROACTIVELY for architecture decisions, technology evaluation, and implementation planning.
   MUST INVOKE when ANY of these keywords appear in user request:
-  --ultrathink flag: Activate Sequential Thinking MCP for deep analysis of architecture decisions, technology selection, and implementation strategies.
+  --deepthink flag: Activate Sequential Thinking MCP for deep analysis of architecture decisions, technology selection, and implementation strategies.
   EN: strategy, implementation plan, architecture decision, technology evaluation, planning
   KO: 전략, 구현계획, 아키텍처결정, 기술평가, 계획
   JA: 戦略, 実装計画, アーキテクチャ決定, 技術評価

--- a/internal/template/templates/.claude/agents/moai/manager-tdd.md
+++ b/internal/template/templates/.claude/agents/moai/manager-tdd.md
@@ -4,7 +4,7 @@ description: |
   TDD (Test-Driven Development) implementation specialist. Use for RED-GREEN-REFACTOR
   cycle. Default methodology for new projects and feature development.
   MUST INVOKE when ANY of these keywords appear in user request:
-  --ultrathink flag: Activate Sequential Thinking MCP for deep analysis of test strategy, implementation approach, and coverage optimization.
+  --deepthink flag: Activate Sequential Thinking MCP for deep analysis of test strategy, implementation approach, and coverage optimization.
   EN: TDD, test-driven development, red-green-refactor, test-first, new feature, specification test, greenfield
   KO: TDD, 테스트주도개발, 레드그린리팩터, 테스트우선, 신규기능, 명세테스트, 그린필드
   JA: TDD, テスト駆動開発, レッドグリーンリファクタ, テストファースト, 新機能, 仕様テスト, グリーンフィールド

--- a/internal/template/templates/.claude/rules/moai/core/settings-management.md
+++ b/internal/template/templates/.claude/rules/moai/core/settings-management.md
@@ -69,7 +69,7 @@ Example `.mcp.json` configuration:
 - Architecture decisions
 - Technology trade-off analysis
 
-Activate with `--ultrathink` flag for enhanced analysis.
+Activate with `--deepthink` flag for enhanced analysis.
 
 ### MoAI Configuration
 

--- a/internal/template/templates/.claude/rules/moai/development/model-policy.md
+++ b/internal/template/templates/.claude/rules/moai/development/model-policy.md
@@ -15,7 +15,7 @@ Agent definition `model` field accepts only these values:
 - haiku: Claude Haiku (fastest, lowest cost)
 
 Current model generation mapping (as of v2.1.69):
-- opus = Opus 4.6 (default effort: medium for Max/Team, use "ultrathink" keyword for high effort)
+- opus = Opus 4.6 (default effort: medium for Max/Team, use "deepthink" keyword for high effort)
 - sonnet = Sonnet 4.6
 - haiku = Haiku 4.5
 
@@ -48,9 +48,9 @@ CG Mode (Claude + GLM) uses environment variable overrides, not model field chan
 Opus 4.6 supports effort levels that control reasoning depth:
 - low: Fastest responses, less thorough
 - medium: Default for Max/Team subscribers (v2.1.68+)
-- high: Deep reasoning, activated by "ultrathink" keyword for one turn
+- high: Deep reasoning, activated by "deepthink" keyword for one turn
 
-MoAI's --ultrathink flag triggers high effort for the current turn. This aligns with the "ultrathink" keyword behavior in Claude Code.
+MoAI's --deepthink flag triggers high effort for the current turn. This aligns with the "deepthink" keyword behavior in Claude Code.
 
 ## Rules
 

--- a/internal/template/templates/.claude/skills/moai-workflow-thinking/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-thinking/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Sequential Thinking MCP and UltraThink mode for deep analysis, complex
   problem decomposition, and structured reasoning workflows.
   Use when performing multi-step analysis, architecture decisions, technology selection
-  trade-offs, breaking change assessment, or when --ultrathink flag is specified.
+  trade-offs, breaking change assessment, or when --deepthink flag is specified.
   Do NOT use for simple decisions or straightforward implementation tasks.
 license: Apache-2.0
 compatibility: Designed for Claude Code
@@ -24,7 +24,7 @@ progressive_disclosure:
 
 # MoAI Extension: Triggers
 triggers:
-  keywords: ["sequential thinking", "ultrathink", "deep analysis", "complex problem", "architecture decision", "technology selection", "trade-off", "breaking change"]
+  keywords: ["sequential thinking", "deepthink", "deep analysis", "complex problem", "architecture decision", "technology selection", "trade-off", "breaking change"]
   phases:
     - plan
   agents:
@@ -102,12 +102,12 @@ nextThoughtNeeded: false
 
 ## UltraThink Mode
 
-Enhanced analysis mode activated by `--ultrathink` flag.
+Enhanced analysis mode activated by `--deepthink` flag.
 
 **Activation:**
 ```
-"Implement authentication system --ultrathink"
-"Refactor the API layer --ultrathink"
+"Implement authentication system --deepthink"
+"Refactor the API layer --deepthink"
 ```
 
 **Process:**

--- a/internal/template/templates/.claude/skills/moai/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai/SKILL.md
@@ -211,7 +211,7 @@ For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/feedback.md
 When this skill is activated, execute the following steps in order:
 
 Step 1 - Parse Arguments:
-Extract subcommand keywords and flags from the Raw User Input. Recognized global flags: --resume [ID], --seq, --ultrathink, --team, --solo. When --ultrathink is detected, activate Sequential Thinking MCP for deep analysis before execution.
+Extract subcommand keywords and flags from the Raw User Input. Recognized global flags: --resume [ID], --seq, --deepthink, --team, --solo. When --deepthink is detected, activate Sequential Thinking MCP for deep analysis before execution.
 
 Step 2 - Route to Workflow:
 Apply the Intent Router (Priority 1 through Priority 4) to determine the target workflow. If ambiguous, use AskUserQuestion to clarify with the user.

--- a/internal/template/templates/.claude/skills/moai/references/reference.md
+++ b/internal/template/templates/.claude/skills/moai/references/reference.md
@@ -143,7 +143,7 @@ Propagation Method:
 
 - --resume [ID]: Resume workflow from last checkpoint (SPEC-ID or snapshot ID)
 - --seq: Force sequential execution instead of parallel where applicable
-- --ultrathink: Activate Sequential Thinking MCP for deep analysis before execution
+- --deepthink: Activate Sequential Thinking MCP for deep analysis before execution
 - --team: Force Agent Teams mode for parallel execution
 - --solo: Force sub-agent mode (single agent per phase)
 

--- a/internal/template/templates/.claude/skills/moai/workflows/project.md
+++ b/internal/template/templates/.claude/skills/moai/workflows/project.md
@@ -136,7 +136,7 @@ After collection, use the gathered information to generate documentation and pro
 
 [HARD] Delegate codebase analysis to the Explore subagent.
 
-[SOFT] Apply --ultrathink for comprehensive analysis.
+[SOFT] Apply --deepthink for comprehensive analysis.
 
 Analysis Objectives passed to Explore agent:
 

--- a/internal/template/templates/CLAUDE.md
+++ b/internal/template/templates/CLAUDE.md
@@ -315,7 +315,7 @@ Resume interrupted agent work using agentId:
 
 MoAI-ADK integrates multiple MCP servers for specialized capabilities:
 
-- **Sequential Thinking**: Complex problem analysis, architecture decisions, technology trade-offs. Activate with `--ultrathink` flag. See Skill("moai-workflow-thinking").
+- **Sequential Thinking**: Complex problem analysis, architecture decisions, technology trade-offs. Activate with `--deepthink` flag. See Skill("moai-workflow-thinking").
 - **Context7**: Up-to-date library documentation lookup via resolve-library-id and get-library-docs.
 - **Pencil**: UI/UX design editing for .pen files (used by expert-frontend and team-designer agents).
 - **claude-in-chrome**: Browser automation for web-based tasks.


### PR DESCRIPTION
## 요약
Claude Code의 `deepthink` 키워드 복원에 따라 모든 관련 문서를 업데이트합니다.

## 변경 사항
- 모든 `--ultrathink` 플래그를 `--deepthink`로 변경
- "ultrathink" 키워드를 "deepthink"로 변경

## 영향 범위
- **87개 파일** 변경
- `.claude/agents/moai/*.md` - 모든 에이전트 정의
- `.claude/skills/moai/*.md` - 모든 스킬 정의
- `.claude/rules/moai/` - 규칙 파일
- `internal/template/templates/` - 템플릿 소스
- `CLAUDE.md` - 메인 실행 지시문

## 주요 변경 내용

### SKILL.md
- 전역 플래그 목록에서 `--ultrathink`를 `--deepthink`로 변경

### model-policy.md
- "deepthink" 키워드로 high effort 활성화 설명 업데이트
- Opus 모델의 deepthink 키워드 동작 설명

### moai-workflow-thinking
- 키워드 트리거 목록에 "deepthink" 추가

## 테스트 상태
- ⚠️ `go test` - `internal/statusline` 패키지 테스트 실패 (GLM 모드 관련 기존 이슈)
- ✅ 본 변경 사항은 **문서만 변경**하므로 Go 코드 동작에 영향 없음

## 확인 항목
- [ ] 모든 `--ultrathink`가 `--deepthink`로 변경되었는지 확인
- [ ] `go build`로 embedded 템플릿 갱신 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Project Documentation Check to verify project documentation exists before core workflows execute.
  * Improved option design with recommended choices and detailed descriptions in user prompts.

* **Chores**
  * Renamed activation flag from `--ultrathink` to `--deepthink` across all workflows and configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->