### PR TITLE
fix(git): worktree fallback 로그 레벨 INFO → DEBUG 변경

### DIFF
--- a/internal/core/git/worktree.go
+++ b/internal/core/git/worktree.go
@@ -30,7 +30,7 @@ func NewWorktreeManager(root string) *worktreeManager {
 // Add creates a new worktree at the given path for the given branch.
 // If the branch does not exist, it is created automatically with -b.
 func (w *worktreeManager) Add(path, branch string) error {
-	w.logger.Info("system git fallback", "operation", "worktree add", "reason", "go-git lacks worktree support")
+	w.logger.Debug("system git fallback", "operation", "worktree add", "reason", "go-git lacks worktree support")
 	w.logger.Debug("adding worktree", "path", path, "branch", branch)
 
 	// Check if path already exists.
@@ -61,7 +61,7 @@ func (w *worktreeManager) Add(path, branch string) error {
 
 // List returns all active worktrees including the main worktree.
 func (w *worktreeManager) List() ([]Worktree, error) {
-	w.logger.Info("system git fallback", "operation", "worktree list", "reason", "go-git lacks worktree support")
+	w.logger.Debug("system git fallback", "operation", "worktree list", "reason", "go-git lacks worktree support")
 	w.logger.Debug("listing worktrees")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -80,7 +80,7 @@ func (w *worktreeManager) List() ([]Worktree, error) {
 // Remove deletes a worktree at the given path.
 // If force is true, the worktree is removed even with uncommitted changes.
 func (w *worktreeManager) Remove(path string, force bool) error {
-	w.logger.Info("system git fallback", "operation", "worktree remove", "reason", "go-git lacks worktree support")
+	w.logger.Debug("system git fallback", "operation", "worktree remove", "reason", "go-git lacks worktree support")
 	w.logger.Debug("removing worktree", "path", path, "force", force)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -110,7 +110,7 @@ func (w *worktreeManager) Remove(path string, force bool) error {
 
 // Prune removes stale worktree references for deleted directories.
 func (w *worktreeManager) Prune() error {
-	w.logger.Info("system git fallback", "operation", "worktree prune", "reason", "go-git lacks worktree support")
+	w.logger.Debug("system git fallback", "operation", "worktree prune", "reason", "go-git lacks worktree support")
 	w.logger.Debug("pruning worktrees")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -127,7 +127,7 @@ func (w *worktreeManager) Prune() error {
 
 // Repair repairs worktree administrative files if they have become corrupted.
 func (w *worktreeManager) Repair() error {
-	w.logger.Info("system git fallback", "operation", "worktree repair", "reason", "go-git lacks worktree support")
+	w.logger.Debug("system git fallback", "operation", "worktree repair", "reason", "go-git lacks worktree support")
 	w.logger.Debug("repairing worktrees")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)


### PR DESCRIPTION
## Summary

- `internal/core/git/worktree.go`에서 워크트리 작업(add/list/remove/prune/repair)의 `"system git fallback"` 로그를 `Info` → `Debug`로 낮춤
- go-git이 워크트리를 네이티브 지원하지 않아 매 작업마다 발생하는 INFO 로그 노이즈 제거
- `--log-level=debug` 플래그 사용 시에만 폴백 메시지 표시

## Test plan

- [x] `go test ./internal/core/git/...` 통과 확인
- [x] 5개 메서드(Add, List, Remove, Prune, Repair) 모두 Debug 레벨로 변경

Closes #521

🗿 MoAI <email@mo.ai.kr>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted internal logging levels for improved system diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->