### PR TITLE
fix(hook): 워크트리 환경에서 발생하는 {} 디렉토리 자동 정리

### DIFF
--- a/internal/hook/session_end.go
+++ b/internal/hook/session_end.go
@@ -622,7 +622,7 @@ func cleanupGLMSettingsLocal(projectDir string) {
 // The cleanup is best-effort: errors are logged with slog.Warn and never returned.
 func cleanupBogusRootDir(projectDir string) {
 	bogusDir := filepath.Join(projectDir, "{}")
-	info, err := os.Stat(bogusDir)
+	info, err := os.Lstat(bogusDir)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			slog.Warn("session_end: could not stat bogus {} directory",
@@ -630,6 +630,9 @@ func cleanupBogusRootDir(projectDir string) {
 				"error", err,
 			)
 		}
+		return
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
 		return
 	}
 	if !info.IsDir() {

--- a/internal/hook/session_end_test.go
+++ b/internal/hook/session_end_test.go
@@ -1013,3 +1013,30 @@ func TestCleanupBogusRootDir_IgnoresFile(t *testing.T) {
 		t.Error("regular file named {} should not have been removed")
 	}
 }
+
+// TestCleanupBogusRootDir_IgnoresSymlink verifies that a symlink named "{}"
+// is not followed or removed (symlink attack prevention).
+func TestCleanupBogusRootDir_IgnoresSymlink(t *testing.T) {
+	t.Parallel()
+
+	projectDir := t.TempDir()
+	realDir := filepath.Join(projectDir, "real-dir")
+	if err := os.Mkdir(realDir, 0o755); err != nil {
+		t.Fatalf("setup: create real dir: %v", err)
+	}
+	symlinkPath := filepath.Join(projectDir, "{}")
+	if err := os.Symlink(realDir, symlinkPath); err != nil {
+		t.Fatalf("setup: create symlink: %v", err)
+	}
+
+	cleanupBogusRootDir(projectDir)
+
+	// The symlink itself must still exist.
+	if _, err := os.Lstat(symlinkPath); os.IsNotExist(err) {
+		t.Error("symlink named {} should not have been removed")
+	}
+	// The symlink target (real directory) must still exist.
+	if _, err := os.Stat(realDir); os.IsNotExist(err) {
+		t.Error("symlink target should not have been removed")
+	}
+}


### PR DESCRIPTION
## Summary

- Claude Code가 워크트리 내에서 `memory: project` 에이전트를 실행할 때 `{project_root}` 템플릿 변수가 치환되지 않아 프로젝트 루트에 `{}` 디렉토리가 생성되는 버그 대응
- `session_end.go`에 `cleanupBogusRootDir()` 함수 추가 — 세션 종료 시 `{}` 디렉토리를 자동 정리
- 테스트 3개 추가: 디렉토리 제거, 미존재 시 no-op, 일반 파일 보존

## Root Cause

Claude Code 내부에서 `{project_root}` 템플릿 변수가 워크트리 컨텍스트에서 치환되지 않아 발생하는 버그. moai 측에서 세션 종료 시 방어적 cleanup으로 대응.

## Test plan

- [x] `TestCleanupBogusRootDir_RemovesDirectory` — 중첩 파일 포함 {} 디렉토리 삭제 확인
- [x] `TestCleanupBogusRootDir_NoDirectory` — 존재하지 않을 때 no-op 확인  
- [x] `TestCleanupBogusRootDir_IgnoresFile` — 일반 파일은 유지 확인
- [x] `go test ./internal/hook/...` 전체 통과

Closes #522

🗿 MoAI <email@mo.ai.kr>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically removes a spurious "{}" directory that may appear at the project root during session cleanup, restoring a clean project state. Removal is best-effort and will not cause session failures; regular files named "{}" are preserved.
* **Tests**
  * Added tests covering removal, no-op when absent, and ignoring non-directory "{}" entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->