### PR TITLE
feat(wizard): moai init/update -c에서 모델 정책 선택 추가

### DIFF
--- a/CLAUDE.local.md
+++ b/CLAUDE.local.md
@@ -876,6 +876,38 @@ go test -run TestCCCmd_Execution ./internal/cli/
 
 ---
 
+---
+
+## 20. Template Path Hardcoding Prevention
+
+### [HARD] Never Use `.HomeDir` or `.GoBinPath` for Fallback Paths in Shell Templates
+
+Shell script templates (`.sh.tmpl`) that need to reference the user's home directory or Go bin path MUST use shell environment variables (`$HOME`) instead of Go template variables (`.HomeDir`, `.GoBinPath`).
+
+**Why**: `.HomeDir` and `.GoBinPath` are resolved at `moai init` time on the host machine and baked into generated scripts as absolute paths (e.g., `/Users/username/go/bin`). When the project is cloned or opened on another OS or by another user, these hardcoded paths silently fail.
+
+**Rule for fallback binary lookups in `.sh.tmpl`:**
+
+```bash
+# WRONG: bakes in macOS absolute path at init time
+if [ -f "{{posixPath .HomeDir}}/go/bin/moai" ]; then
+
+# CORRECT: resolved at runtime per OS/user
+if [ -f "$HOME/go/bin/moai" ]; then
+```
+
+**`.GoBinPath` is still valid** for the primary path injection (the first detected path at `moai init`), because it is the most specific location. But the `$HOME/go/bin` fallback MUST use `$HOME`.
+
+**Checklist when editing any `.sh.tmpl` file:**
+- [ ] Primary path: `{{posixPath .GoBinPath}}/moai` — OK (init-time detection)
+- [ ] Fallback path: `$HOME/go/bin/moai` — MUST use `$HOME`, not `{{posixPath .HomeDir}}/go/bin`
+- [ ] User-local path: `$HOME/.local/bin/moai` — MUST use `$HOME`
+- [ ] After editing template: run `make build` to regenerate embedded files
+
+**`renderer.go` passthrough**: `$HOME` is already in `claudeCodePassthroughTokens`, so the unexpanded token validator will not reject it.
+
+---
+
 **Status**: Active (Local Development)
-**Version**: 1.6.0 (GLM Integration Testing Rules added)
-**Last Updated**: 2026-02-26
+**Version**: 1.7.0 (Template Path Hardcoding Prevention added)
+**Last Updated**: 2026-03-18

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -234,9 +234,8 @@ func runInit(cmd *cobra.Command, args []string) error {
 		if prefs.DocLang != "" {
 			opts.DocLang = prefs.DocLang
 		}
-		if prefs.ModelPolicy != "" {
-			opts.ModelPolicy = prefs.ModelPolicy
-		}
+		// Model policy is now configured per-project via the init wizard.
+		// Profile-level model policy is no longer applied here.
 	}
 
 	if !nonInteractive && isatty.IsTerminal(os.Stdin.Fd()) {
@@ -272,6 +271,9 @@ func runInit(cmd *cobra.Command, args []string) error {
 		}
 		if opts.GitLabInstanceURL == "" {
 			opts.GitLabInstanceURL = result.GitLabInstanceURL
+		}
+		if result.ModelPolicy != "" {
+			opts.ModelPolicy = result.ModelPolicy
 		}
 	}
 

--- a/internal/cli/profile_setup.go
+++ b/internal/cli/profile_setup.go
@@ -65,10 +65,6 @@ func runProfileSetup(cmd *cobra.Command, args []string) error {
 		docLang = "en"
 	}
 
-	modelPolicy := existingPrefs.ModelPolicy
-	if modelPolicy == "" {
-		modelPolicy = "high"
-	}
 	model := existingPrefs.Model
 	bypass := existingPrefs.Bypass
 
@@ -139,17 +135,9 @@ func runProfileSetup(cmd *cobra.Command, args []string) error {
 				Value(&docLang),
 		).Title(t.LanguagesTitle),
 
-		// Section 3: Model Settings (policy + model override)
+		// Section 3: Model Settings (model override + bypass)
+		// Note: model_policy is now configured per-project via moai init / moai update -c.
 		huh.NewGroup(
-			huh.NewSelect[string]().
-				Title(t.ModelPolicyTitle).
-				Description(t.ModelPolicyDesc).
-				Options(
-					huh.NewOption(t.ModelPolicyHigh, "high"),
-					huh.NewOption(t.ModelPolicyMedium, "medium"),
-					huh.NewOption(t.ModelPolicyLow, "low"),
-				).
-				Value(&modelPolicy),
 			huh.NewSelect[string]().
 				Title(t.ModelOverrideTitle).
 				Description(t.ModelOverrideDesc).
@@ -204,7 +192,6 @@ func runProfileSetup(cmd *cobra.Command, args []string) error {
 		GitCommitLang:    gitCommitLang,
 		CodeCommentLang:  codeCommentLang,
 		DocLang:          docLang,
-		ModelPolicy:      modelPolicy,
 		Model:            model,
 		Bypass:           bypass,
 		StatuslineMode:   statuslineMode,

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -644,26 +644,8 @@ func runTemplateSyncWithReporter(cmd *cobra.Command, reporter project.ProgressRe
 
 	_, _ = fmt.Fprintf(out, "\n%s Template sync complete.\n", symSuccess())
 
-	// Show model policy notice when user ran without -c flag
-	configWizard := getBoolFlag(cmd, "config")
-	if !configWizard {
-		boxContent := cliPrimary.Render("Model Policy Configuration") + "\n\n" +
-			"Optimize token usage based on your Claude Code plan:\n" +
-			"  High   - Max $200 plan (opus 23, sonnet 1, haiku 4)\n" +
-			"  Medium - Max $100 plan (opus 4, sonnet 19, haiku 5)\n" +
-			"  Low    - Plus $20 plan (sonnet 12, haiku 16, no opus)\n\n" +
-			"Run: moai update -c"
-		boxStyle := lipgloss.NewStyle().
-			Border(lipgloss.RoundedBorder()).
-			BorderForeground(cliBorder.GetForeground()).
-			Padding(0, 2).
-			MarginLeft(2)
-		_, _ = fmt.Fprintln(out)
-		_, _ = fmt.Fprintln(out, boxStyle.Render(boxContent))
-	}
-
 	_, _ = fmt.Fprintln(out)
-	_, _ = fmt.Fprintln(out, "To reconfigure your project settings, run:")
+	_, _ = fmt.Fprintln(out, "To reconfigure project settings (development mode, git, model policy), run:")
 	_, _ = fmt.Fprintln(out, "   moai update -c")
 
 	// Ensure global settings.json has required env variables
@@ -2028,6 +2010,38 @@ func applyWizardConfig(projectRoot string, result *wizard.WizardResult) error {
 		}
 		if err := os.WriteFile(gitStratPath, updatedData, defs.FilePerm); err != nil {
 			return fmt.Errorf("write git-strategy.yaml: %w", err)
+		}
+	}
+
+	// Apply model policy to agent definition files (project-level, not profile-level)
+	if result.ModelPolicy != "" {
+		policy := template.ModelPolicy(result.ModelPolicy)
+		if template.IsValidModelPolicy(string(policy)) {
+			mgr := manifest.NewManager()
+			if _, err := mgr.Load(projectRoot); err == nil {
+				if err := template.ApplyModelPolicy(projectRoot, policy, mgr); err != nil {
+					return fmt.Errorf("apply model policy: %w", err)
+				}
+			}
+			// Persist model_policy to system.yaml so it survives future updates
+			systemPath := filepath.Join(sectionsDir, defs.SystemYAML)
+			systemData, _ := os.ReadFile(systemPath)
+			var sys map[string]any
+			if len(systemData) > 0 {
+				_ = yaml.Unmarshal(systemData, &sys)
+			}
+			if sys == nil {
+				sys = make(map[string]any)
+			}
+			moaiSection, _ := sys["moai"].(map[string]any)
+			if moaiSection == nil {
+				moaiSection = make(map[string]any)
+			}
+			moaiSection["model_policy"] = string(policy)
+			sys["moai"] = moaiSection
+			if updatedData, err := yaml.Marshal(sys); err == nil {
+				_ = os.WriteFile(systemPath, updatedData, defs.FilePerm)
+			}
 		}
 	}
 

--- a/internal/cli/wizard/questions.go
+++ b/internal/cli/wizard/questions.go
@@ -30,7 +30,21 @@ func DefaultQuestions(projectRoot string) []Question {
 			Default:     defaultProjectName,
 			Required:    true,
 		},
-		// 2. Development Mode
+		// 2. Model Policy
+		{
+			ID:          "model_policy",
+			Type:        QuestionTypeSelect,
+			Title:       "Select model policy",
+			Description: "Controls which Claude model tier is assigned to each agent. Match to your Claude plan.",
+			Options: []Option{
+				{Label: "High (Recommended)", Value: "high", Desc: "Opus for critical agents — Max $200 plan"},
+				{Label: "Medium", Value: "medium", Desc: "Opus for key agents, sonnet for rest — Max $100 plan"},
+				{Label: "Low", Value: "low", Desc: "Sonnet and haiku only — Plus $20 plan"},
+			},
+			Default:  "high",
+			Required: true,
+		},
+		// 3. Development Mode
 		{
 			ID:          "development_mode",
 			Type:        QuestionTypeSelect,

--- a/internal/cli/wizard/questions_test.go
+++ b/internal/cli/wizard/questions_test.go
@@ -50,6 +50,7 @@ func TestQuestionOrder(t *testing.T) {
 
 	expectedIDs := []string{
 		"project_name",
+		"model_policy",
 		"development_mode",
 		"git_mode",
 		"git_provider",
@@ -124,7 +125,7 @@ func TestRemovedQuestionsAbsent(t *testing.T) {
 		"git_commit_lang",
 		"code_comment_lang",
 		"doc_lang",
-		"model_policy",
+		// model_policy intentionally NOT listed here: it was re-added as a project-level question
 		"agent_teams_mode",
 		"max_teammates",
 		"default_model",
@@ -148,6 +149,7 @@ func TestQuestionsAllPresent(t *testing.T) {
 
 	expectedIDs := []string{
 		"project_name",
+		"model_policy",
 		"development_mode",
 		"git_mode",
 		"git_provider",

--- a/internal/cli/wizard/types.go
+++ b/internal/cli/wizard/types.go
@@ -16,6 +16,9 @@ type WizardResult struct {
 	// Development methodology
 	DevelopmentMode string // Development mode: ddd, tdd
 
+	// Model policy (project-level)
+	ModelPolicy string // Token tier: high, medium, low
+
 	// Git settings
 	GitMode           string // Git automation mode: manual, personal, team
 	GitProvider       string // Git provider: "github", "gitlab"

--- a/internal/cli/wizard/wizard.go
+++ b/internal/cli/wizard/wizard.go
@@ -182,6 +182,8 @@ func saveAnswer(id, value string, result *WizardResult, locale *string) {
 	switch id {
 	case "project_name":
 		result.ProjectName = value
+	case "model_policy":
+		result.ModelPolicy = value
 	case "development_mode":
 		result.DevelopmentMode = value
 	case "git_mode":


### PR DESCRIPTION
## 요약

`moai init` 및 `moai update -c` 실행 시 모델 정책(model policy)을 선택할 수 있는 위저드 질문을 추가합니다.

## 변경 내용

- `wizard.DefaultQuestions`에 `model_policy` select 질문 추가 (질문 순서: project_name → model_policy → development_mode → git_mode → ...)
- `WizardResult` 구조체에 `ModelPolicy string` 필드 추가
- `wizard.go:saveAnswer`에 `"model_policy"` case 추가
- `applyWizardConfig`: `ApplyModelPolicy()` 호출 후 `system.yaml`의 `moai.model_policy`에 저장
- `init.go`: 위저드 결과의 `ModelPolicy`를 `opts.ModelPolicy`에 적용 (profile prefs 의존 제거)
- `profile_setup.go`: 모델 정책 select 질문 제거 (프로젝트별 설정으로 이관, 모델 오버라이드/bypass는 유지)
- `CLAUDE.local.md`: 섹션 20 — 템플릿 경로 하드코딩 방지 가이드 추가

## 테스트 계획

- [x] `go build ./...` 통과
- [x] `go test ./...` 전체 통과 (wizard 테스트 기대값 업데이트 포함)
- [ ] `moai init` 실행 후 위저드에서 모델 정책 선택 확인
- [ ] `moai update -c` 실행 후 에이전트 파일 model 필드 변경 확인

Fixes #532

🗿 MoAI <email@mo.ai.kr>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model policy selection is now integrated into the project initialization wizard. Users select from high, medium, or low token tier options during setup.
  * Model policy configuration moved from profile settings to per-project configuration, persisting across updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->