### PR TITLE
fix(template): 생성된 훅/statusline 스크립트의 macOS 하드코딩 경로 수정

### DIFF
--- a/internal/template/templates/.claude/hooks/moai/handle-agent-hook.sh.tmpl
+++ b/internal/template/templates/.claude/hooks/moai/handle-agent-hook.sh.tmpl
@@ -44,8 +44,8 @@ if [ -f "{{posixPath .GoBinPath}}/moai" ]; then
 fi
 
 # Try default ~/go/bin/moai
-if [ -f "{{posixPath .HomeDir}}/go/bin/moai" ]; then
-    exec "{{posixPath .HomeDir}}/go/bin/moai" hook agent "$action" < "$temp_file"
+if [ -f "$HOME/go/bin/moai" ]; then
+    exec "$HOME/go/bin/moai" hook agent "$action" < "$temp_file"
 fi
 
 # Not found - exit silently (Claude Code handles missing hooks gracefully)

--- a/internal/template/templates/.claude/hooks/moai/handle-compact.sh.tmpl
+++ b/internal/template/templates/.claude/hooks/moai/handle-compact.sh.tmpl
@@ -21,8 +21,8 @@ if [ -f "{{posixPath .GoBinPath}}/moai" ]; then
 fi
 
 # Try default ~/go/bin/moai
-if [ -f "{{posixPath .HomeDir}}/go/bin/moai" ]; then
-	exec "{{posixPath .HomeDir}}/go/bin/moai" hook compact < "$temp_file"
+if [ -f "$HOME/go/bin/moai" ]; then
+	exec "$HOME/go/bin/moai" hook compact < "$temp_file"
 fi
 
 # Not found - exit silently (Claude Code handles missing hooks gracefully)

--- a/internal/template/templates/.claude/hooks/moai/handle-notification.sh.tmpl
+++ b/internal/template/templates/.claude/hooks/moai/handle-notification.sh.tmpl
@@ -21,8 +21,8 @@ if [ -f "{{posixPath .GoBinPath}}/moai" ]; then
 fi
 
 # Try default ~/go/bin/moai
-if [ -f "{{posixPath .HomeDir}}/go/bin/moai" ]; then
-	exec "{{posixPath .HomeDir}}/go/bin/moai" hook notification < "$temp_file"
+if [ -f "$HOME/go/bin/moai" ]; then
+	exec "$HOME/go/bin/moai" hook notification < "$temp_file"
 fi
 
 # Not found - exit silently (Claude Code handles missing hooks gracefully)

--- a/internal/template/templates/.claude/hooks/moai/handle-permission-request.sh.tmpl
+++ b/internal/template/templates/.claude/hooks/moai/handle-permission-request.sh.tmpl
@@ -21,8 +21,8 @@ if [ -f "{{posixPath .GoBinPath}}/moai" ]; then
 fi
 
 # Try default ~/go/bin/moai
-if [ -f "{{posixPath .HomeDir}}/go/bin/moai" ]; then
-	exec "{{posixPath .HomeDir}}/go/bin/moai" hook permission-request < "$temp_file"
+if [ -f "$HOME/go/bin/moai" ]; then
+	exec "$HOME/go/bin/moai" hook permission-request < "$temp_file"
 fi
 
 # Not found - exit silently (Claude Code handles missing hooks gracefully)

--- a/internal/template/templates/.claude/hooks/moai/handle-post-tool-failure.sh.tmpl
+++ b/internal/template/templates/.claude/hooks/moai/handle-post-tool-failure.sh.tmpl
@@ -21,8 +21,8 @@ if [ -f "{{posixPath .GoBinPath}}/moai" ]; then
 fi
 
 # Try default ~/go/bin/moai
-if [ -f "{{posixPath .HomeDir}}/go/bin/moai" ]; then
-	exec "{{posixPath .HomeDir}}/go/bin/moai" hook post-tool-failure < "$temp_file"
+if [ -f "$HOME/go/bin/moai" ]; then
+	exec "$HOME/go/bin/moai" hook post-tool-failure < "$temp_file"
 fi
 
 # Not found - exit silently (Claude Code handles missing hooks gracefully)

--- a/internal/template/templates/.claude/hooks/moai/handle-post-tool.sh.tmpl
+++ b/internal/template/templates/.claude/hooks/moai/handle-post-tool.sh.tmpl
@@ -21,8 +21,8 @@ if [ -f "{{posixPath .GoBinPath}}/moai" ]; then
 fi
 
 # Try default ~/go/bin/moai
-if [ -f "{{posixPath .HomeDir}}/go/bin/moai" ]; then
-	exec "{{posixPath .HomeDir}}/go/bin/moai" hook post-tool < "$temp_file"
+if [ -f "$HOME/go/bin/moai" ]; then
+	exec "$HOME/go/bin/moai" hook post-tool < "$temp_file"
 fi
 
 # Not found - exit silently (Claude Code handles missing hooks gracefully)

--- a/internal/template/templates/.claude/hooks/moai/handle-pre-tool.sh.tmpl
+++ b/internal/template/templates/.claude/hooks/moai/handle-pre-tool.sh.tmpl
@@ -21,8 +21,8 @@ if [ -f "{{posixPath .GoBinPath}}/moai" ]; then
 fi
 
 # Try default ~/go/bin/moai
-if [ -f "{{posixPath .HomeDir}}/go/bin/moai" ]; then
-	exec "{{posixPath .HomeDir}}/go/bin/moai" hook pre-tool < "$temp_file"
+if [ -f "$HOME/go/bin/moai" ]; then
+	exec "$HOME/go/bin/moai" hook pre-tool < "$temp_file"
 fi
 
 # Not found - exit silently (Claude Code handles missing hooks gracefully)

--- a/internal/template/templates/.claude/hooks/moai/handle-session-end.sh.tmpl
+++ b/internal/template/templates/.claude/hooks/moai/handle-session-end.sh.tmpl
@@ -21,8 +21,8 @@ if [ -f "{{posixPath .GoBinPath}}/moai" ]; then
 fi
 
 # Try default ~/go/bin/moai
-if [ -f "{{posixPath .HomeDir}}/go/bin/moai" ]; then
-	exec "{{posixPath .HomeDir}}/go/bin/moai" hook session-end < "$temp_file"
+if [ -f "$HOME/go/bin/moai" ]; then
+	exec "$HOME/go/bin/moai" hook session-end < "$temp_file"
 fi
 
 # Not found - exit silently (Claude Code handles missing hooks gracefully)

--- a/internal/template/templates/.claude/hooks/moai/handle-session-start.sh.tmpl
+++ b/internal/template/templates/.claude/hooks/moai/handle-session-start.sh.tmpl
@@ -21,8 +21,8 @@ if [ -f "{{posixPath .GoBinPath}}/moai" ]; then
 fi
 
 # Try default ~/go/bin/moai
-if [ -f "{{posixPath .HomeDir}}/go/bin/moai" ]; then
-	exec "{{posixPath .HomeDir}}/go/bin/moai" hook session-start < "$temp_file"
+if [ -f "$HOME/go/bin/moai" ]; then
+	exec "$HOME/go/bin/moai" hook session-start < "$temp_file"
 fi
 
 # Not found - exit silently (Claude Code handles missing hooks gracefully)

--- a/internal/template/templates/.claude/hooks/moai/handle-stop.sh.tmpl
+++ b/internal/template/templates/.claude/hooks/moai/handle-stop.sh.tmpl
@@ -21,8 +21,8 @@ if [ -f "{{posixPath .GoBinPath}}/moai" ]; then
 fi
 
 # Try default ~/go/bin/moai
-if [ -f "{{posixPath .HomeDir}}/go/bin/moai" ]; then
-	exec "{{posixPath .HomeDir}}/go/bin/moai" hook stop < "$temp_file"
+if [ -f "$HOME/go/bin/moai" ]; then
+	exec "$HOME/go/bin/moai" hook stop < "$temp_file"
 fi
 
 # Not found - exit silently (Claude Code handles missing hooks gracefully)

--- a/internal/template/templates/.claude/hooks/moai/handle-subagent-start.sh.tmpl
+++ b/internal/template/templates/.claude/hooks/moai/handle-subagent-start.sh.tmpl
@@ -21,8 +21,8 @@ if [ -f "{{posixPath .GoBinPath}}/moai" ]; then
 fi
 
 # Try default ~/go/bin/moai
-if [ -f "{{posixPath .HomeDir}}/go/bin/moai" ]; then
-	exec "{{posixPath .HomeDir}}/go/bin/moai" hook subagent-start < "$temp_file"
+if [ -f "$HOME/go/bin/moai" ]; then
+	exec "$HOME/go/bin/moai" hook subagent-start < "$temp_file"
 fi
 
 # Not found - exit silently (Claude Code handles missing hooks gracefully)

--- a/internal/template/templates/.claude/hooks/moai/handle-subagent-stop.sh.tmpl
+++ b/internal/template/templates/.claude/hooks/moai/handle-subagent-stop.sh.tmpl
@@ -21,8 +21,8 @@ if [ -f "{{posixPath .GoBinPath}}/moai" ]; then
 fi
 
 # Try default ~/go/bin/moai
-if [ -f "{{posixPath .HomeDir}}/go/bin/moai" ]; then
-	exec "{{posixPath .HomeDir}}/go/bin/moai" hook subagent-stop < "$temp_file"
+if [ -f "$HOME/go/bin/moai" ]; then
+	exec "$HOME/go/bin/moai" hook subagent-stop < "$temp_file"
 fi
 
 # Not found - exit silently (Claude Code handles missing hooks gracefully)

--- a/internal/template/templates/.claude/hooks/moai/handle-task-completed.sh.tmpl
+++ b/internal/template/templates/.claude/hooks/moai/handle-task-completed.sh.tmpl
@@ -21,8 +21,8 @@ if [ -f "{{posixPath .GoBinPath}}/moai" ]; then
 fi
 
 # Try default ~/go/bin/moai
-if [ -f "{{posixPath .HomeDir}}/go/bin/moai" ]; then
-	exec "{{posixPath .HomeDir}}/go/bin/moai" hook task-completed < "$temp_file"
+if [ -f "$HOME/go/bin/moai" ]; then
+	exec "$HOME/go/bin/moai" hook task-completed < "$temp_file"
 fi
 
 # Not found - exit silently (Claude Code handles missing hooks gracefully)

--- a/internal/template/templates/.claude/hooks/moai/handle-teammate-idle.sh.tmpl
+++ b/internal/template/templates/.claude/hooks/moai/handle-teammate-idle.sh.tmpl
@@ -21,8 +21,8 @@ if [ -f "{{posixPath .GoBinPath}}/moai" ]; then
 fi
 
 # Try default ~/go/bin/moai
-if [ -f "{{posixPath .HomeDir}}/go/bin/moai" ]; then
-	exec "{{posixPath .HomeDir}}/go/bin/moai" hook teammate-idle < "$temp_file"
+if [ -f "$HOME/go/bin/moai" ]; then
+	exec "$HOME/go/bin/moai" hook teammate-idle < "$temp_file"
 fi
 
 # Not found - exit silently (Claude Code handles missing hooks gracefully)

--- a/internal/template/templates/.claude/hooks/moai/handle-user-prompt-submit.sh.tmpl
+++ b/internal/template/templates/.claude/hooks/moai/handle-user-prompt-submit.sh.tmpl
@@ -21,8 +21,8 @@ if [ -f "{{posixPath .GoBinPath}}/moai" ]; then
 fi
 
 # Try default ~/go/bin/moai
-if [ -f "{{posixPath .HomeDir}}/go/bin/moai" ]; then
-	exec "{{posixPath .HomeDir}}/go/bin/moai" hook user-prompt-submit < "$temp_file"
+if [ -f "$HOME/go/bin/moai" ]; then
+	exec "$HOME/go/bin/moai" hook user-prompt-submit < "$temp_file"
 fi
 
 # Not found - exit silently (Claude Code handles missing hooks gracefully)

--- a/internal/template/templates/.claude/hooks/moai/handle-worktree-create.sh.tmpl
+++ b/internal/template/templates/.claude/hooks/moai/handle-worktree-create.sh.tmpl
@@ -21,8 +21,8 @@ if [ -f "{{posixPath .GoBinPath}}/moai" ]; then
 fi
 
 # Try default ~/go/bin/moai
-if [ -f "{{posixPath .HomeDir}}/go/bin/moai" ]; then
-	exec "{{posixPath .HomeDir}}/go/bin/moai" hook worktree-create < "$temp_file"
+if [ -f "$HOME/go/bin/moai" ]; then
+	exec "$HOME/go/bin/moai" hook worktree-create < "$temp_file"
 fi
 
 # Not found - exit silently (Claude Code handles missing hooks gracefully)

--- a/internal/template/templates/.claude/hooks/moai/handle-worktree-remove.sh.tmpl
+++ b/internal/template/templates/.claude/hooks/moai/handle-worktree-remove.sh.tmpl
@@ -21,8 +21,8 @@ if [ -f "{{posixPath .GoBinPath}}/moai" ]; then
 fi
 
 # Try default ~/go/bin/moai
-if [ -f "{{posixPath .HomeDir}}/go/bin/moai" ]; then
-	exec "{{posixPath .HomeDir}}/go/bin/moai" hook worktree-remove < "$temp_file"
+if [ -f "$HOME/go/bin/moai" ]; then
+	exec "$HOME/go/bin/moai" hook worktree-remove < "$temp_file"
 fi
 
 # Not found - exit silently (Claude Code handles missing hooks gracefully)

--- a/internal/template/templates/.moai/status_line.sh.tmpl
+++ b/internal/template/templates/.moai/status_line.sh.tmpl
@@ -27,8 +27,8 @@ if [ -f "{{posixPath .GoBinPath}}/moai" ]; then
 fi
 
 # Try user local bin directory
-if [ -f "{{posixPath .HomeDir}}/.local/bin/moai" ]; then
-	exec "{{posixPath .HomeDir}}/.local/bin/moai" statusline < "$temp_file"
+if [ -f "$HOME/.local/bin/moai" ]; then
+	exec "$HOME/.local/bin/moai" statusline < "$temp_file"
 fi
 
 # Not found - exit silently (Claude Code handles missing statusline gracefully)


### PR DESCRIPTION
## 요약

`moai init` 실행 시점의 macOS 절대 경로(예: `/Users/angeleyes/go/bin`)가 생성된 hook/statusline 스크립트에 bake-in되어, Windows 또는 다른 사용자 환경에서 moai를 찾지 못하고 조용히 실패하는 문제를 수정합니다.

## 근본 원인

`.sh.tmpl` 파일이 `{{posixPath .HomeDir}}` (초기화 시점 절대 경로)를 fallback 바이너리 검색 경로로 사용:
```bash
# 수정 전: macOS 경로 하드코딩
if [ -f "/Users/angeleyes/go/bin/moai" ]; then  

# 수정 후: 런타임 환경변수
if [ -f "$HOME/go/bin/moai" ]; then
```

## 변경 파일

- `handle-*.sh.tmpl` (17개): `{{posixPath .HomeDir}}/go/bin/moai` → `$HOME/go/bin/moai`
- `status_line.sh.tmpl`: `{{posixPath .HomeDir}}/.local/bin/moai` → `$HOME/.local/bin/moai`

**참고:**
- 초기 감지 경로 `{{posixPath .GoBinPath}}` (1순위 fallback)은 init 시점의 정확한 경로이므로 유지
- `$HOME`은 `renderer.go`의 `claudeCodePassthroughTokens`에 이미 등록되어 unexpanded token 검사 통과
- `make build`로 embedded.go 재생성 완료

## 테스트 계획

- [x] `go build ./...` 통과
- [x] `go test ./...` 전체 통과
- [ ] macOS에서 `moai init` 후 생성된 스크립트에 `$HOME/go/bin` 경로 확인
- [ ] Windows(Git Bash)에서 statusline 및 hook 정상 동작 확인

Fixes #531

🗿 MoAI <email@mo.ai.kr>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated binary path resolution across hook templates to use environment variables instead of template-based paths for improved consistency and reliability
  * Enhanced script exit handling to provide explicit success status when hooks are not found

<!-- end of auto-generated comment: release notes by coderabbit.ai -->