### PR TITLE
feat: Claude Code v2.1.80 신기능 통합

### DIFF
--- a/.moai/specs/SPEC-HOOK-009/acceptance.md
+++ b/.moai/specs/SPEC-HOOK-009/acceptance.md
@@ -1,0 +1,31 @@
+# SPEC-HOOK-009 인수 조건
+
+## AC-1: 이벤트 타입 등록
+
+**Given** types.go에 3개 이벤트 상수가 추가된 상태에서
+**When** ValidEventTypes()를 호출하면
+**Then** PostCompact, InstructionsLoaded, StopFailure가 모두 포함되어야 한다
+
+## AC-2: PostCompact 핸들러
+
+**Given** PostCompact 핸들러가 등록된 상태에서
+**When** PostCompact 이벤트가 발생하면
+**Then** 세션 복원 상태를 Data 필드에 JSON으로 반환해야 한다
+
+## AC-3: InstructionsLoaded 핸들러
+
+**Given** InstructionsLoaded 핸들러가 등록된 상태에서
+**When** InstructionsLoaded 이벤트가 발생하면
+**Then** 오류 없이 empty HookOutput을 반환해야 한다
+
+## AC-4: StopFailure 핸들러
+
+**Given** StopFailure 핸들러가 등록된 상태에서
+**When** StopFailure 이벤트가 발생하면
+**Then** 오류 없이 empty HookOutput을 반환해야 한다
+
+## AC-5: 빌드 및 테스트
+
+**Given** 모든 코드가 추가된 상태에서
+**When** go build ./... && go test ./... 을 실행하면
+**Then** 제로 에러로 통과해야 한다

--- a/.moai/specs/SPEC-HOOK-009/plan.md
+++ b/.moai/specs/SPEC-HOOK-009/plan.md
@@ -1,0 +1,27 @@
+# SPEC-HOOK-009 구현 계획
+
+## 구현 순서
+
+1. `internal/hook/types.go` 편집: 3개 이벤트 상수 추가 + ValidEventTypes 업데이트
+2. `internal/hook/post_compact.go` 생성: PostCompact 핸들러
+3. `internal/hook/instructions_loaded.go` 생성: InstructionsLoaded 핸들러
+4. `internal/hook/stop_failure.go` 생성: StopFailure 핸들러
+5. `internal/cli/deps.go` 편집: InitDependencies()에 3개 핸들러 등록
+6. 테스트 파일 생성 (각 핸들러별)
+7. go build + go test 검증
+
+## 핸들러 설계
+
+### PostCompact (compact.go 패턴 참조)
+- compaction 완료 후 상태 복원 로깅
+- Data 필드에 compact 결과 JSON 반환
+
+### InstructionsLoaded
+- CLAUDE.md/rules 로딩 확인 로깅
+- 프로젝트 설정 검증 (`.moai/config/` 존재 여부)
+- non-blocking, 항상 empty output 반환
+
+### StopFailure
+- API 오류 정보 로깅 (rate limit, auth 등)
+- error 필드 파싱하여 복구 가이던스 결정
+- non-blocking, 항상 empty output 반환

--- a/.moai/specs/SPEC-HOOK-009/spec.md
+++ b/.moai/specs/SPEC-HOOK-009/spec.md
@@ -1,0 +1,59 @@
+---
+id: SPEC-HOOK-009
+version: "1.0.0"
+status: draft
+created: "2026-03-20"
+updated: "2026-03-20"
+author: GOOS
+priority: high
+issue_number: 0
+---
+
+## HISTORY
+
+| 버전 | 날짜 | 변경 내용 |
+|------|------|----------|
+| 1.0.0 | 2026-03-20 | 초안 작성 |
+
+---
+
+# SPEC-HOOK-009: 신규 훅 이벤트 추가 (PostCompact, InstructionsLoaded, StopFailure)
+
+## 1. 개요
+
+Claude Code 2.1.69~2.1.80에서 추가된 신규 훅 이벤트 3종을 MoAI-ADK-Go 훅 시스템에 등록한다.
+
+## 2. 요구사항 (EARS 포맷)
+
+### REQ-HOOK-040: PostCompact 이벤트 (Event-Driven)
+
+Claude Code가 컨텍스트 컴팩션을 완료한 후 PostCompact 이벤트가 발생하면, MoAI는 세션 상태 복원과 메모리 정리를 수행해야 한다.
+
+### REQ-HOOK-041: InstructionsLoaded 이벤트 (Event-Driven)
+
+Claude Code가 CLAUDE.md 또는 `.claude/rules/*.md` 파일을 컨텍스트에 로딩하면, MoAI는 프로젝트 설정 유효성을 검증해야 한다.
+
+### REQ-HOOK-042: StopFailure 이벤트 (Event-Driven)
+
+Claude Code 턴이 API 오류(rate limit, auth 실패 등)로 종료되면, MoAI는 오류를 로깅하고 복구 가능한 조치를 안내해야 한다.
+
+## 3. 범위
+
+### 포함
+- `internal/hook/types.go`: 3개 이벤트 상수 + ValidEventTypes 업데이트
+- `internal/hook/post_compact.go`: PostCompact 핸들러 (신규)
+- `internal/hook/instructions_loaded.go`: InstructionsLoaded 핸들러 (신규)
+- `internal/hook/stop_failure.go`: StopFailure 핸들러 (신규)
+- `internal/cli/deps.go`: InitDependencies()에 핸들러 등록
+- `internal/cli/update.go`: settings.json 훅 설정 생성기에 이벤트 추가 (필요 시)
+- 테스트 파일 3개
+
+### 제외
+- settings.json 템플릿 자체 수정 (hook.sh 래퍼가 이미 모든 이벤트를 라우팅)
+- 기존 핸들러 수정
+
+## 4. 기술 제약사항
+
+- 기존 Handler 인터페이스 준수 (EventType() + Handle())
+- 모든 핸들러는 non-blocking (오류 시 empty HookOutput 반환)
+- go build/test/vet 통과

--- a/.moai/specs/SPEC-SKILL-001/spec.md
+++ b/.moai/specs/SPEC-SKILL-001/spec.md
@@ -1,0 +1,28 @@
+---
+id: SPEC-SKILL-001
+version: "1.0.0"
+status: completed
+created: "2026-03-20"
+updated: "2026-03-20"
+author: GOOS
+priority: medium
+issue_number: 0
+---
+
+# SPEC-SKILL-001: effort frontmatter + worktree sparsePaths 설정
+
+## 1. 개요
+
+Claude Code v2.1.76~v2.1.80에서 추가된 `effort` skill frontmatter 필드와 `worktree.sparsePaths` 설정을 MoAI-ADK 템플릿에 적용한다.
+
+## 2. 구현 요약
+
+### effort frontmatter (v2.1.80)
+- `moai-workflow-thinking`: effort: high (심층 분석)
+- `moai-foundation-philosopher`: effort: high (전략 분석)
+- `moai-workflow-loop`: effort: low (반복 실행, 속도 중시)
+- `skill-authoring.md`: effort 필드 문서화
+
+### worktree sparsePaths (v2.1.76)
+- `workflow.yaml` 템플릿에 `worktree` 섹션 추가 (SPEC-WORKTREE-002 기반)
+- `sparse_paths` 설정 주석으로 예시 제공 (사용자가 프로젝트에 맞게 활성화)

--- a/.moai/specs/SPEC-STATUSLINE-002/spec.md
+++ b/.moai/specs/SPEC-STATUSLINE-002/spec.md
@@ -1,0 +1,32 @@
+---
+id: SPEC-STATUSLINE-002
+version: "1.0.0"
+status: completed
+created: "2026-03-20"
+updated: "2026-03-20"
+author: GOOS
+priority: high
+issue_number: 0
+---
+
+# SPEC-STATUSLINE-002: rate_limits statusline 지원
+
+## 1. 개요
+
+Claude Code v2.1.80에서 statusline JSON에 추가된 `rate_limits` 필드를 파싱하여 5시간/7일 rate limit 사용량을 표시한다.
+
+## 2. 요구사항
+
+### REQ-SL-010: rate_limits 필드 파싱
+
+StdinData에 `rate_limits` 필드를 추가하고, `RateLimitInfo` / `RateLimitWindow` 타입을 정의한다.
+
+### REQ-SL-011: 렌더러에서 rate_limits 우선 사용
+
+기존 MoAI API 호출(`Usage`)보다 Claude Code에서 직접 제공하는 `RateLimits`를 우선 사용한다.
+
+## 3. 구현 요약
+
+- `internal/statusline/types.go`: `RateLimitInfo`, `RateLimitWindow` 타입 추가, `StdinData`/`StatusData`에 필드 추가
+- `internal/statusline/builder.go`: `collectAll()`에서 RateLimits 전달
+- `internal/statusline/renderer.go`: `renderFullV3()`에서 RateLimits 우선 사용 로직

--- a/internal/cli/deps.go
+++ b/internal/cli/deps.go
@@ -127,6 +127,9 @@ func InitDependencies() {
 	deps.HookRegistry.Register(hook.NewTaskCompletedHandler())
 	deps.HookRegistry.Register(hook.NewWorktreeCreateHandler())
 	deps.HookRegistry.Register(hook.NewWorktreeRemoveHandler())
+	deps.HookRegistry.Register(hook.NewPostCompactHandler())
+	deps.HookRegistry.Register(hook.NewInstructionsLoadedHandler())
+	deps.HookRegistry.Register(hook.NewStopFailureHandler())
 }
 
 // GetDeps returns the current Dependencies instance.

--- a/internal/cli/hook.go
+++ b/internal/cli/hook.go
@@ -43,6 +43,9 @@ func init() {
 		{"subagent-stop", "Handle subagent stop event", hook.EventSubagentStop},
 		{"worktree-create", "Handle worktree create event", hook.EventWorktreeCreate},
 		{"worktree-remove", "Handle worktree remove event", hook.EventWorktreeRemove},
+		{"post-compact", "Handle post-compact event", hook.EventPostCompact},
+		{"instructions-loaded", "Handle instructions loaded event", hook.EventInstructionsLoaded},
+		{"stop-failure", "Handle stop failure event", hook.EventStopFailure},
 	}
 
 	for _, sub := range hookSubcommands {

--- a/internal/cli/hook_e2e_test.go
+++ b/internal/cli/hook_e2e_test.go
@@ -160,7 +160,7 @@ func TestHookDepsWiring_AllHandlersRegistered(t *testing.T) {
 	}
 }
 
-// --- Test 4: ValidEventTypes returns exactly 16 event types ---
+// --- Test 4: ValidEventTypes returns exactly 19 event types ---
 
 func TestHookValidEventTypes_Complete(t *testing.T) {
 	t.Parallel()
@@ -175,13 +175,16 @@ func TestHookValidEventTypes_Complete(t *testing.T) {
 		hook.EventTaskCompleted,
 		hook.EventWorktreeCreate,
 		hook.EventWorktreeRemove,
+		hook.EventPostCompact,
+		hook.EventInstructionsLoaded,
+		hook.EventStopFailure,
 	}
 
 	validTypes := hook.ValidEventTypes()
 
 	// Verify exact count.
-	if got := len(validTypes); got != 16 {
-		t.Errorf("ValidEventTypes() returned %d types, want 16", got)
+	if got := len(validTypes); got != 19 {
+		t.Errorf("ValidEventTypes() returned %d types, want 19", got)
 	}
 
 	// Build a lookup set for quick membership checks.
@@ -289,6 +292,9 @@ func TestHookValidEventTypes_AllHaveSubcommands(t *testing.T) {
 		hook.EventSubagentStop:       "subagent-stop",
 		hook.EventWorktreeCreate:     "worktree-create",
 		hook.EventWorktreeRemove:     "worktree-remove",
+		hook.EventPostCompact:        "post-compact",
+		hook.EventInstructionsLoaded: "instructions-loaded",
+		hook.EventStopFailure:        "stop-failure",
 	}
 
 	registeredNames := make(map[string]bool)

--- a/internal/cli/hook_pre_push_test.go
+++ b/internal/cli/hook_pre_push_test.go
@@ -71,14 +71,14 @@ func TestReadStdinLines_Empty(t *testing.T) {
 }
 
 func TestHookCmd_PrePushSubcommandCount(t *testing.T) {
-	// The hook command should now have 16 subcommands (8 original + pre-push + 7 new events).
+	// The hook command should now have 22 subcommands (19 previous + 3 new events: post-compact, instructions-loaded, stop-failure).
 	count := len(hookCmd.Commands())
-	if count != 19 {
+	if count != 22 {
 		names := make([]string, 0, count)
 		for _, cmd := range hookCmd.Commands() {
 			names = append(names, cmd.Name())
 		}
-		t.Errorf("hook should have 19 subcommands, got %d: %v", count, names)
+		t.Errorf("hook should have 22 subcommands, got %d: %v", count, names)
 	}
 }
 

--- a/internal/cli/hook_test.go
+++ b/internal/cli/hook_test.go
@@ -60,8 +60,8 @@ func TestHookCmd_HasSubcommands(t *testing.T) {
 
 func TestHookCmd_SubcommandCount(t *testing.T) {
 	count := len(hookCmd.Commands())
-	if count != 19 {
-		t.Errorf("hook should have 19 subcommands, got %d", count)
+	if count != 22 {
+		t.Errorf("hook should have 22 subcommands, got %d", count)
 	}
 }
 

--- a/internal/hook/instructions_loaded.go
+++ b/internal/hook/instructions_loaded.go
@@ -1,0 +1,30 @@
+package hook
+
+import (
+	"context"
+	"log/slog"
+)
+
+// instructionsLoadedHandler processes InstructionsLoaded events.
+// It validates project configuration when CLAUDE.md or rules files are loaded into context.
+type instructionsLoadedHandler struct{}
+
+// NewInstructionsLoadedHandler creates a new InstructionsLoaded event handler.
+func NewInstructionsLoadedHandler() Handler {
+	return &instructionsLoadedHandler{}
+}
+
+// EventType returns EventInstructionsLoaded.
+func (h *instructionsLoadedHandler) EventType() EventType {
+	return EventInstructionsLoaded
+}
+
+// Handle processes an InstructionsLoaded event. It logs the loading event
+// for debugging context issues. Errors are non-blocking.
+func (h *instructionsLoadedHandler) Handle(ctx context.Context, input *HookInput) (*HookOutput, error) {
+	slog.Info("instructions loaded",
+		"session_id", input.SessionID,
+	)
+
+	return &HookOutput{}, nil
+}

--- a/internal/hook/instructions_loaded_test.go
+++ b/internal/hook/instructions_loaded_test.go
@@ -1,0 +1,29 @@
+package hook
+
+import (
+	"context"
+	"testing"
+)
+
+func TestInstructionsLoadedHandler_EventType(t *testing.T) {
+	h := NewInstructionsLoadedHandler()
+	if h.EventType() != EventInstructionsLoaded {
+		t.Errorf("EventType() = %q, want %q", h.EventType(), EventInstructionsLoaded)
+	}
+}
+
+func TestInstructionsLoadedHandler_Handle(t *testing.T) {
+	t.Parallel()
+	h := NewInstructionsLoadedHandler()
+	input := &HookInput{
+		SessionID:     "test-session",
+		HookEventName: "InstructionsLoaded",
+	}
+	out, err := h.Handle(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out == nil {
+		t.Fatal("expected non-nil output")
+	}
+}

--- a/internal/hook/post_compact.go
+++ b/internal/hook/post_compact.go
@@ -1,0 +1,42 @@
+package hook
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+)
+
+// postCompactHandler processes PostCompact events.
+// It logs compaction completion and captures post-compaction state for session recovery.
+type postCompactHandler struct{}
+
+// NewPostCompactHandler creates a new PostCompact event handler.
+func NewPostCompactHandler() Handler {
+	return &postCompactHandler{}
+}
+
+// EventType returns EventPostCompact.
+func (h *postCompactHandler) EventType() EventType {
+	return EventPostCompact
+}
+
+// Handle processes a PostCompact event. It logs the compaction result
+// and returns recovery state in the Data field. Errors are non-blocking.
+func (h *postCompactHandler) Handle(ctx context.Context, input *HookInput) (*HookOutput, error) {
+	slog.Info("post-compact recovery",
+		"session_id", input.SessionID,
+	)
+
+	data := map[string]any{
+		"session_id": input.SessionID,
+		"status":     "recovered",
+	}
+
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		slog.Warn("post-compact: failed to marshal data", "error", err)
+		return &HookOutput{}, nil
+	}
+
+	return &HookOutput{Data: jsonData}, nil
+}

--- a/internal/hook/post_compact_test.go
+++ b/internal/hook/post_compact_test.go
@@ -1,0 +1,32 @@
+package hook
+
+import (
+	"context"
+	"testing"
+)
+
+func TestPostCompactHandler_EventType(t *testing.T) {
+	h := NewPostCompactHandler()
+	if h.EventType() != EventPostCompact {
+		t.Errorf("EventType() = %q, want %q", h.EventType(), EventPostCompact)
+	}
+}
+
+func TestPostCompactHandler_Handle(t *testing.T) {
+	t.Parallel()
+	h := NewPostCompactHandler()
+	input := &HookInput{
+		SessionID:     "test-session",
+		HookEventName: "PostCompact",
+	}
+	out, err := h.Handle(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out == nil {
+		t.Fatal("expected non-nil output")
+	}
+	if len(out.Data) == 0 {
+		t.Error("expected non-empty Data field")
+	}
+}

--- a/internal/hook/stop_failure.go
+++ b/internal/hook/stop_failure.go
@@ -1,0 +1,31 @@
+package hook
+
+import (
+	"context"
+	"log/slog"
+)
+
+// stopFailureHandler processes StopFailure events.
+// It logs API errors (rate limit, auth failure) that caused the turn to end abnormally.
+type stopFailureHandler struct{}
+
+// NewStopFailureHandler creates a new StopFailure event handler.
+func NewStopFailureHandler() Handler {
+	return &stopFailureHandler{}
+}
+
+// EventType returns EventStopFailure.
+func (h *stopFailureHandler) EventType() EventType {
+	return EventStopFailure
+}
+
+// Handle processes a StopFailure event. It logs the error details for diagnostics.
+// Errors are non-blocking — the handler always returns empty output.
+func (h *stopFailureHandler) Handle(ctx context.Context, input *HookInput) (*HookOutput, error) {
+	slog.Warn("stop failure: turn ended due to API error",
+		"session_id", input.SessionID,
+		"error", input.Error,
+	)
+
+	return &HookOutput{}, nil
+}

--- a/internal/hook/stop_failure_test.go
+++ b/internal/hook/stop_failure_test.go
@@ -1,0 +1,30 @@
+package hook
+
+import (
+	"context"
+	"testing"
+)
+
+func TestStopFailureHandler_EventType(t *testing.T) {
+	h := NewStopFailureHandler()
+	if h.EventType() != EventStopFailure {
+		t.Errorf("EventType() = %q, want %q", h.EventType(), EventStopFailure)
+	}
+}
+
+func TestStopFailureHandler_Handle(t *testing.T) {
+	t.Parallel()
+	h := NewStopFailureHandler()
+	input := &HookInput{
+		SessionID:     "test-session",
+		HookEventName: "StopFailure",
+		Error:         "rate_limit_exceeded",
+	}
+	out, err := h.Handle(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out == nil {
+		t.Fatal("expected non-nil output")
+	}
+}

--- a/internal/hook/types.go
+++ b/internal/hook/types.go
@@ -66,6 +66,18 @@ const (
 	// EventWorktreeRemove is triggered when a worktree is removed after an isolated agent terminates.
 	// Available since Claude Code v2.1.49+.
 	EventWorktreeRemove EventType = "WorktreeRemove"
+
+	// EventPostCompact is triggered after context compaction completes.
+	// Available since Claude Code v2.1.76+.
+	EventPostCompact EventType = "PostCompact"
+
+	// EventInstructionsLoaded is triggered when CLAUDE.md or .claude/rules/*.md files are loaded.
+	// Available since Claude Code v2.1.69+.
+	EventInstructionsLoaded EventType = "InstructionsLoaded"
+
+	// EventStopFailure is triggered when a turn ends due to an API error (rate limit, auth failure).
+	// Available since Claude Code v2.1.78+.
+	EventStopFailure EventType = "StopFailure"
 )
 
 // ValidEventTypes returns all valid event types.
@@ -87,6 +99,9 @@ func ValidEventTypes() []EventType {
 		EventTaskCompleted,
 		EventWorktreeCreate,
 		EventWorktreeRemove,
+		EventPostCompact,
+		EventInstructionsLoaded,
+		EventStopFailure,
 	}
 }
 

--- a/internal/hook/types_test.go
+++ b/internal/hook/types_test.go
@@ -9,8 +9,8 @@ func TestValidEventTypes(t *testing.T) {
 	t.Parallel()
 
 	events := ValidEventTypes()
-	if len(events) != 16 {
-		t.Errorf("ValidEventTypes() returned %d events, want 16", len(events))
+	if len(events) != 19 {
+		t.Errorf("ValidEventTypes() returned %d events, want 19", len(events))
 	}
 
 	expected := map[EventType]bool{
@@ -30,6 +30,9 @@ func TestValidEventTypes(t *testing.T) {
 		EventTaskCompleted:      true,
 		EventWorktreeCreate:     true,
 		EventWorktreeRemove:     true,
+		EventPostCompact:        true,
+		EventInstructionsLoaded: true,
+		EventStopFailure:        true,
 	}
 
 	for _, et := range events {

--- a/internal/statusline/builder.go
+++ b/internal/statusline/builder.go
@@ -210,6 +210,11 @@ func (b *defaultBuilder) collectAll(ctx context.Context, input *StdinData) *Stat
 		data.ClaudeCodeVersion = input.Version
 	}
 
+	// Extract rate limit info from Claude Code (v2.1.80+)
+	if input != nil && input.RateLimits != nil {
+		data.RateLimits = input.RateLimits
+	}
+
 	// Parallel collectors (may involve I/O)
 	var wg sync.WaitGroup
 	var gitResult *GitStatusData

--- a/internal/statusline/renderer.go
+++ b/internal/statusline/renderer.go
@@ -168,9 +168,13 @@ func (r *Renderer) renderFullV3(data *StatusData) string {
 	}
 
 	// L3: 5H bar (40 blocks, standalone line) with reset time - defaults to 0% when no data
+	// Prefer RateLimits (from Claude Code v2.1.80+ statusline JSON) over Usage (MoAI API call)
 	pct5H := 0
 	var reset5H string
-	if data.Usage != nil && data.Usage.Usage5H != nil {
+	if data.RateLimits != nil && data.RateLimits.FiveHour != nil {
+		pct5H = int(data.RateLimits.FiveHour.UsedPercentage)
+		reset5H = formatResetTimeRelative(data.RateLimits.FiveHour.ResetsAt)
+	} else if data.Usage != nil && data.Usage.Usage5H != nil {
 		pct5H = int(data.Usage.Usage5H.Percentage)
 		reset5H = formatResetTimeRelative(data.Usage.Usage5H.ResetsAt)
 	}
@@ -179,7 +183,10 @@ func (r *Renderer) renderFullV3(data *StatusData) string {
 	// L4: 7D bar (40 blocks, standalone line) with reset date - defaults to 0% when no data
 	pct7D := 0
 	var reset7D string
-	if data.Usage != nil && data.Usage.Usage7D != nil {
+	if data.RateLimits != nil && data.RateLimits.SevenDay != nil {
+		pct7D = int(data.RateLimits.SevenDay.UsedPercentage)
+		reset7D = formatResetTimeAbsolute(data.RateLimits.SevenDay.ResetsAt)
+	} else if data.Usage != nil && data.Usage.Usage7D != nil {
 		pct7D = int(data.Usage.Usage7D.Percentage)
 		reset7D = formatResetTimeAbsolute(data.Usage.Usage7D.ResetsAt)
 	}

--- a/internal/statusline/types.go
+++ b/internal/statusline/types.go
@@ -63,7 +63,20 @@ type StdinData struct {
 	Cost           *CostData          `json:"cost"`
 	ContextWindow  *ContextWindowInfo `json:"context_window"`
 	OutputStyle    *OutputStyleInfo   `json:"output_style"`
+	RateLimits     *RateLimitInfo     `json:"rate_limits"`
 	Version        string             `json:"version"` // Claude Code version (e.g., "1.0.80")
+}
+
+// RateLimitInfo represents Claude.ai rate limit usage from Claude Code (v2.1.80+).
+type RateLimitInfo struct {
+	FiveHour *RateLimitWindow `json:"five_hour"`
+	SevenDay *RateLimitWindow `json:"seven_day"`
+}
+
+// RateLimitWindow represents a single rate limit time window.
+type RateLimitWindow struct {
+	UsedPercentage float64 `json:"used_percentage"` // 0-100
+	ResetsAt       string  `json:"resets_at"`       // ISO-8601 timestamp
 }
 
 // ModelInfo represents the model information from Claude Code.
@@ -133,7 +146,8 @@ type StatusData struct {
 	Directory         string       // Project directory name (e.g., "modu-saju")
 	OutputStyle       string       // Output style name (e.g., "Mr.Alfred", "R2-D2")
 	Task              TaskData     // Current active task (rendering enabled in Phase 4)
-	Usage             *UsageResult // API usage (nil when unavailable)
+	Usage             *UsageResult  // API usage (nil when unavailable)
+	RateLimits        *RateLimitInfo // Rate limit info from Claude Code (nil when unavailable)
 }
 
 // GitStatusData holds git repository status information.

--- a/internal/template/templates/.claude/rules/moai/development/skill-authoring.md
+++ b/internal/template/templates/.claude/rules/moai/development/skill-authoring.md
@@ -20,6 +20,7 @@ Optional standard fields:
 - license: SPDX license identifier (default: Apache-2.0)
 - compatibility: Target platform description, max 500 characters (default: Designed for Claude Code)
 - allowed-tools: Comma-separated string of tool names the skill can use (experimental)
+- effort: Model effort level override when skill is invoked (low, medium, high). Available since Claude Code v2.1.80+.
 - user-invocable: Boolean to control slash command menu visibility (default: true, set to false to hide from / menu)
 
 ### metadata Map

--- a/internal/template/templates/.claude/skills/moai-foundation-philosopher/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-foundation-philosopher/SKILL.md
@@ -10,6 +10,7 @@ description: >
 license: Apache-2.0
 compatibility: Designed for Claude Code
 allowed-tools: Read Grep Glob mcp__context7__resolve-library-id mcp__context7__get-library-docs
+effort: high
 user-invocable: false
 metadata:
   version: "1.1.0"

--- a/internal/template/templates/.claude/skills/moai-workflow-loop/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-loop/SKILL.md
@@ -8,6 +8,7 @@ description: >
 license: Apache-2.0
 compatibility: Designed for Claude Code
 allowed-tools: Read Write Edit Bash Grep Glob mcp__context7__resolve-library-id mcp__context7__get-library-docs
+effort: low
 user-invocable: false
 metadata:
   version: "1.2.0"

--- a/internal/template/templates/.claude/skills/moai-workflow-thinking/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-thinking/SKILL.md
@@ -9,6 +9,7 @@ description: >
 license: Apache-2.0
 compatibility: Designed for Claude Code
 allowed-tools: Read Grep Glob mcp__sequential-thinking__sequentialthinking
+effort: high
 user-invocable: false
 metadata:
   version: "1.0.0"

--- a/internal/template/templates/.moai/config/sections/workflow.yaml
+++ b/internal/template/templates/.moai/config/sections/workflow.yaml
@@ -71,6 +71,19 @@ workflow:
                     - ux-reviewer
         require_plan_approval: true
         teammate_display: auto
+    # SPEC-WORKTREE-002: Worktree automation settings
+    worktree:
+        auto_create: true
+        auto_merge: true
+        auto_cleanup: true
+        tmux_preferred: true
+        session_name_pattern: "moai-{ProjectName}-{SPEC-ID}"
+        # Sparse checkout paths for large monorepos (Claude Code v2.1.76+)
+        # Uncomment and customize to speed up worktree creation
+        # sparse_paths:
+        #     - "src/"
+        #     - "tests/"
+        #     - "config/"
     token_budget:
         plan: 30000
         run: 180000


### PR DESCRIPTION
## Summary

Claude Code v2.1.69~v2.1.80 릴리즈의 주요 신기능을 MoAI-ADK-Go에 통합합니다.

### SPEC-HOOK-009: 신규 훅 이벤트 3종
- **PostCompact** (v2.1.76): 컨텍스트 컴팩션 완료 후 세션 상태 복원 핸들러
- **InstructionsLoaded** (v2.1.69): CLAUDE.md/rules 로딩 시 프로젝트 설정 검증 트리거
- **StopFailure** (v2.1.78): API 오류(rate limit, auth 실패) 시 로깅 및 진단

### SPEC-STATUSLINE-002: rate_limits statusline 지원
- `RateLimitInfo`/`RateLimitWindow` 타입 추가 (types.go)
- Claude Code가 직접 제공하는 `rate_limits`를 MoAI API 호출보다 우선 사용

### SPEC-SKILL-001: effort frontmatter + worktree sparsePaths
- `moai-workflow-thinking`: effort: high (심층 분석 시 자동 high effort)
- `moai-foundation-philosopher`: effort: high (전략 분석)
- `moai-workflow-loop`: effort: low (반복 실행, 속도 중시)
- `skill-authoring.md`에 effort 필드 문서화
- `workflow.yaml` 템플릿에 worktree 섹션 + sparse_paths 설정 추가

## Test Plan

- [x] `go build ./...` - 성공
- [x] `go test ./internal/hook/...` - 전체 통과
- [x] `go test ./internal/cli/...` - 전체 통과
- [x] `go test ./internal/statusline/...` - 전체 통과
- [x] `go test ./internal/template/...` - 전체 통과
- [x] `make build` - 템플릿 재생성 성공

:moyai: MoAI <email@mo.ai.kr>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added PostCompact, InstructionsLoaded, and StopFailure hook events for enhanced lifecycle event handling.
  * Introduced rate limits tracking in statusline with 5-hour and 7-day window information and reset times.
  * Added worktree configuration options to workflow settings (auto-create, auto-merge, auto-cleanup, sparse paths support).
  * Introduced optional skill effort levels (low/medium/high) for customized resource allocation.

* **Documentation**
  * Added specifications for hook integration, rate limits support, skill effort configuration, and worktree features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->