### PR TITLE
fix(statusline): stdin JSON 파싱 실패 수정 및 rate_limits 활용 개선

### DIFF
--- a/internal/statusline/builder_test.go
+++ b/internal/statusline/builder_test.go
@@ -1056,6 +1056,109 @@ func BenchmarkBuilder_Build(b *testing.B) {
 	}
 }
 
+// TestBuild_OfficialSchema verifies that the exact official Claude Code statusline
+// JSON schema (with integer resets_at) is parsed and rendered correctly.
+//
+// See Issue #549.
+func TestBuild_OfficialSchema(t *testing.T) {
+	t.Setenv("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE", "100")
+
+	builder := New(Options{
+		Mode:    ModeDefault,
+		NoColor: true,
+	})
+
+	// Use the EXACT JSON from the Claude Code official docs
+	officialJSON := `{
+		"model": {"id": "claude-opus-4-6", "display_name": "Opus"},
+		"context_window": {"used_percentage": 25, "context_window_size": 200000},
+		"rate_limits": {
+			"five_hour": {"used_percentage": 23.5, "resets_at": 1738425600},
+			"seven_day": {"used_percentage": 41.2, "resets_at": 1738857600}
+		},
+		"workspace": {"current_dir": "/home/user/project", "project_dir": "/home/user/project"},
+		"version": "1.0.80",
+		"cost": {"total_cost_usd": 0.05}
+	}`
+
+	got, err := builder.Build(context.Background(), strings.NewReader(officialJSON))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Model should appear in the output
+	if !strings.Contains(got, "Opus") {
+		t.Errorf("output should contain model display name 'Opus', got:\n%s", got)
+	}
+
+	// Claude Code version should appear
+	if !strings.Contains(got, "1.0.80") {
+		t.Errorf("output should contain claude version '1.0.80', got:\n%s", got)
+	}
+
+	// Directory should appear
+	if !strings.Contains(got, "project") {
+		t.Errorf("output should contain directory 'project', got:\n%s", got)
+	}
+
+	// Usage bars should appear - 5H and 7D
+	if !strings.Contains(got, "5H:") {
+		t.Errorf("output should contain '5H:' bar, got:\n%s", got)
+	}
+	if !strings.Contains(got, "7D:") {
+		t.Errorf("output should contain '7D:' bar, got:\n%s", got)
+	}
+
+	// 5H percentage should appear (23%)
+	if !strings.Contains(got, "23%") {
+		t.Errorf("output should contain 5H usage '23%%', got:\n%s", got)
+	}
+}
+
+// TestBuild_RateLimitsPreferredOverUsage verifies that in default mode,
+// data.RateLimits (from Claude Code stdin JSON) is preferred over data.Usage
+// (from MoAI API call) for the 5H/7D bars.
+//
+// See Issue #549 Bug 3.
+func TestBuild_RateLimitsPreferredOverUsage(t *testing.T) {
+	t.Setenv("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE", "100")
+
+	// Mock usage provider returns 99% (should be ignored when RateLimits present)
+	mockUsage := &mockUsageProvider{
+		data: &UsageResult{
+			Usage5H: &UsageData{Percentage: 99},
+			Usage7D: &UsageData{Percentage: 88},
+		},
+	}
+
+	builder := New(Options{
+		Mode:          ModeDefault,
+		NoColor:       true,
+		UsageProvider: mockUsage,
+	})
+
+	// JSON with rate_limits at 23% - should take priority over the 99% from UsageProvider
+	inputJSON := `{
+		"rate_limits": {
+			"five_hour": {"used_percentage": 23.5, "resets_at": 1738425600},
+			"seven_day": {"used_percentage": 41.2, "resets_at": 1738857600}
+		}
+	}`
+
+	got, err := builder.Build(context.Background(), strings.NewReader(inputJSON))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// 23% should appear (from RateLimits), not 99% (from Usage)
+	if !strings.Contains(got, "23%") {
+		t.Errorf("output should contain 5H rate limit '23%%' from RateLimits (not 99%% from Usage), got:\n%s", got)
+	}
+	if strings.Contains(got, "99%") {
+		t.Errorf("output should NOT contain '99%%' from Usage when RateLimits is present, got:\n%s", got)
+	}
+}
+
 // TestBuilderSetModeNormalizes verifies SetMode normalizes deprecated mode names.
 // REQ-V3-MODE-004: system always uses ModeDefault, ModeFull constants.
 func TestBuilderSetModeNormalizes(t *testing.T) {

--- a/internal/statusline/renderer.go
+++ b/internal/statusline/renderer.go
@@ -268,19 +268,25 @@ func (r *Renderer) renderBarsInline(data *StatusData, width int) string {
 		segs = append(segs, renderUsageBar("CW:", pct, width, r.noColor))
 	}
 
-	// 5H bar - always shown, defaults to 0% when no data
+	// 5H bar - always shown, defaults to 0% when no data.
+	// Prefer RateLimits (from Claude Code v2.1.80+ statusline JSON) over Usage (MoAI API call).
 	if r.isSegmentEnabled(SegmentUsage5H) {
 		pct5H := 0
-		if data.Usage != nil && data.Usage.Usage5H != nil {
+		if data.RateLimits != nil && data.RateLimits.FiveHour != nil {
+			pct5H = int(data.RateLimits.FiveHour.UsedPercentage)
+		} else if data.Usage != nil && data.Usage.Usage5H != nil {
 			pct5H = int(data.Usage.Usage5H.Percentage)
 		}
 		segs = append(segs, renderUsageBar("5H:", pct5H, width, r.noColor))
 	}
 
-	// 7D bar - always shown, defaults to 0% when no data
+	// 7D bar - always shown, defaults to 0% when no data.
+	// Prefer RateLimits (from Claude Code v2.1.80+ statusline JSON) over Usage (MoAI API call).
 	if r.isSegmentEnabled(SegmentUsage7D) {
 		pct7D := 0
-		if data.Usage != nil && data.Usage.Usage7D != nil {
+		if data.RateLimits != nil && data.RateLimits.SevenDay != nil {
+			pct7D = int(data.RateLimits.SevenDay.UsedPercentage)
+		} else if data.Usage != nil && data.Usage.Usage7D != nil {
 			pct7D = int(data.Usage.Usage7D.Percentage)
 		}
 		segs = append(segs, renderUsageBar("7D:", pct7D, width, r.noColor))
@@ -339,19 +345,13 @@ func renderUsageBarWithReset(label string, pct int, width int, noColor bool, res
 	return fmt.Sprintf("%s (Resets %s)", base, resetStr)
 }
 
-// formatResetTimeRelative formats an ISO 8601 timestamp as relative time "in Xh Ym".
-// Returns empty string on parse failure or if reset is in the past.
-func formatResetTimeRelative(isoTimestamp string) string {
-	if isoTimestamp == "" {
+// formatResetTimeRelative formats a reset time as relative "in Xh Ym".
+// Returns empty string if the reset time is zero, in the past, or unparseable.
+// Accepts either an ISO 8601 string (from UsageData) or Unix epoch int64 (from RateLimitWindow).
+func formatResetTimeRelative(resetTime interface{}) string {
+	t := parseResetTime(resetTime)
+	if t.IsZero() {
 		return ""
-	}
-	t, err := time.Parse(time.RFC3339, isoTimestamp)
-	if err != nil {
-		// Try without timezone
-		t, err = time.Parse("2006-01-02T15:04:05", isoTimestamp)
-		if err != nil {
-			return ""
-		}
 	}
 	remaining := time.Until(t)
 	if remaining <= 0 {
@@ -365,18 +365,13 @@ func formatResetTimeRelative(isoTimestamp string) string {
 	return fmt.Sprintf("in %dm", minutes)
 }
 
-// formatResetTimeAbsolute formats an ISO 8601 timestamp as "Jan 21 at 2pm".
-// Returns empty string on parse failure.
-func formatResetTimeAbsolute(isoTimestamp string) string {
-	if isoTimestamp == "" {
+// formatResetTimeAbsolute formats a reset time as "Jan 21 at 2pm".
+// Returns empty string if the reset time is zero or unparseable.
+// Accepts either an ISO 8601 string (from UsageData) or Unix epoch int64 (from RateLimitWindow).
+func formatResetTimeAbsolute(resetTime interface{}) string {
+	t := parseResetTime(resetTime)
+	if t.IsZero() {
 		return ""
-	}
-	t, err := time.Parse(time.RFC3339, isoTimestamp)
-	if err != nil {
-		t, err = time.Parse("2006-01-02T15:04:05", isoTimestamp)
-		if err != nil {
-			return ""
-		}
 	}
 	// Convert to local time for display
 	t = t.Local()
@@ -390,6 +385,37 @@ func formatResetTimeAbsolute(isoTimestamp string) string {
 		hour12 = 12
 	}
 	return fmt.Sprintf("%s at %d%s", t.Format("Jan 2"), hour12, ampm)
+}
+
+// parseResetTime converts a reset time value to time.Time.
+// Accepts:
+//   - int64: Unix epoch seconds (from Claude Code official statusline schema)
+//   - string: ISO 8601 / RFC 3339 timestamp (from MoAI API UsageData)
+//
+// Returns zero time on failure.
+func parseResetTime(resetTime interface{}) time.Time {
+	switch v := resetTime.(type) {
+	case int64:
+		if v <= 0 {
+			return time.Time{}
+		}
+		return time.Unix(v, 0)
+	case string:
+		if v == "" {
+			return time.Time{}
+		}
+		t, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			// Try without timezone
+			t, err = time.Parse("2006-01-02T15:04:05", v)
+			if err != nil {
+				return time.Time{}
+			}
+		}
+		return t
+	default:
+		return time.Time{}
+	}
 }
 
 // contextPercent returns the context window usage percentage (0~100).

--- a/internal/statusline/types.go
+++ b/internal/statusline/types.go
@@ -6,6 +6,7 @@ package statusline
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 )
 
@@ -74,16 +75,47 @@ type RateLimitInfo struct {
 }
 
 // RateLimitWindow represents a single rate limit time window.
+// The official Claude Code statusline schema sends resets_at as a Unix epoch
+// integer (e.g., 1738425600), not as an ISO-8601 string.
 type RateLimitWindow struct {
 	UsedPercentage float64 `json:"used_percentage"` // 0-100
-	ResetsAt       string  `json:"resets_at"`       // ISO-8601 timestamp
+	ResetsAt       int64   `json:"resets_at"`       // Unix epoch seconds (official schema)
 }
 
 // ModelInfo represents the model information from Claude Code.
+// Claude Code may send this field as either an object or a plain string.
+// Custom UnmarshalJSON handles both formats.
 type ModelInfo struct {
 	ID          string `json:"id"`           // e.g., "claude-opus-4-1"
 	DisplayName string `json:"display_name"` // e.g., "Opus" - use this directly
 	Name        string `json:"name"`         // Legacy field, same as ID
+}
+
+// UnmarshalJSON implements json.Unmarshaler for ModelInfo.
+// It handles both the standard object format and the string shorthand:
+//
+//	Object: {"id": "claude-opus-4-6", "display_name": "Opus"}
+//	String: "claude-opus-4-6"
+//
+// When the string form is received, both ID and Name are set to the string value.
+func (m *ModelInfo) UnmarshalJSON(data []byte) error {
+	// Try string first (some Claude Code versions send model as plain string)
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		m.ID = s
+		m.Name = s
+		m.DisplayName = s
+		return nil
+	}
+
+	// Fall back to object format
+	type modelInfoAlias ModelInfo // prevent infinite recursion
+	var alias modelInfoAlias
+	if err := json.Unmarshal(data, &alias); err != nil {
+		return err
+	}
+	*m = ModelInfo(alias)
+	return nil
 }
 
 // WorkspaceInfo represents the workspace directory information from Claude Code.

--- a/internal/statusline/types_test.go
+++ b/internal/statusline/types_test.go
@@ -1,6 +1,9 @@
 package statusline
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 // TestNormalizeMode verifies backward-compatible mode name normalization.
 // REQ-V3-MODE-001: "minimal" → "default" conversion
@@ -30,5 +33,140 @@ func TestNormalizeMode(t *testing.T) {
 				t.Errorf("NormalizeMode(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestStdinData_UnmarshalJSON_ResetsAtInteger verifies that the official Claude Code
+// statusline JSON schema is parsed correctly. The schema sends resets_at as a Unix
+// epoch integer, but our code previously declared it as string, causing a total
+// parse failure.
+//
+// See Issue #549: https://github.com/modu-ai/moai-adk/issues/549
+func TestStdinData_UnmarshalJSON_ResetsAtInteger(t *testing.T) {
+	input := `{"rate_limits":{"five_hour":{"used_percentage":23.5,"resets_at":1738425600}}}`
+
+	var data StdinData
+	err := json.Unmarshal([]byte(input), &data)
+	if err != nil {
+		t.Fatalf("json.Unmarshal failed (Bug 1: resets_at type mismatch): %v", err)
+	}
+	if data.RateLimits == nil {
+		t.Fatal("data.RateLimits is nil, expected non-nil")
+	}
+	if data.RateLimits.FiveHour == nil {
+		t.Fatal("data.RateLimits.FiveHour is nil, expected non-nil")
+	}
+	if got := data.RateLimits.FiveHour.UsedPercentage; got < 23.4 || got > 23.6 {
+		t.Errorf("UsedPercentage = %v, want ~23.5", got)
+	}
+	if data.RateLimits.FiveHour.ResetsAt != 1738425600 {
+		t.Errorf("ResetsAt = %v, want 1738425600", data.RateLimits.FiveHour.ResetsAt)
+	}
+}
+
+// TestStdinData_UnmarshalJSON_SevenDayResetsAt verifies 7-day rate limit parsing.
+func TestStdinData_UnmarshalJSON_SevenDayResetsAt(t *testing.T) {
+	input := `{"rate_limits":{"seven_day":{"used_percentage":41.2,"resets_at":1738857600}}}`
+
+	var data StdinData
+	if err := json.Unmarshal([]byte(input), &data); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+	if data.RateLimits == nil || data.RateLimits.SevenDay == nil {
+		t.Fatal("data.RateLimits.SevenDay is nil")
+	}
+	if data.RateLimits.SevenDay.ResetsAt != 1738857600 {
+		t.Errorf("ResetsAt = %v, want 1738857600", data.RateLimits.SevenDay.ResetsAt)
+	}
+}
+
+// TestStdinData_UnmarshalJSON_ModelAsString verifies that model field can be parsed
+// as a plain string (not only as an object). Some Claude Code versions send
+// "model": "claude-opus-4-6" instead of "model": {"id": "...", "display_name": "..."}.
+//
+// See Issue #549.
+func TestStdinData_UnmarshalJSON_ModelAsString(t *testing.T) {
+	input := `{"model":"claude-opus-4-6","context_window":{"used_percentage":25}}`
+
+	var data StdinData
+	err := json.Unmarshal([]byte(input), &data)
+	if err != nil {
+		t.Fatalf("json.Unmarshal failed (Bug 2: model as string): %v", err)
+	}
+	if data.Model == nil {
+		t.Fatal("data.Model is nil, expected non-nil")
+	}
+	if data.Model.ID != "claude-opus-4-6" {
+		t.Errorf("Model.ID = %q, want %q", data.Model.ID, "claude-opus-4-6")
+	}
+}
+
+// TestStdinData_UnmarshalJSON_ModelAsObject verifies that model field still works
+// as an object (existing behavior must not break).
+func TestStdinData_UnmarshalJSON_ModelAsObject(t *testing.T) {
+	input := `{"model":{"id":"claude-opus-4-6","display_name":"Opus"}}`
+
+	var data StdinData
+	if err := json.Unmarshal([]byte(input), &data); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+	if data.Model == nil {
+		t.Fatal("data.Model is nil")
+	}
+	if data.Model.ID != "claude-opus-4-6" {
+		t.Errorf("Model.ID = %q, want %q", data.Model.ID, "claude-opus-4-6")
+	}
+	if data.Model.DisplayName != "Opus" {
+		t.Errorf("Model.DisplayName = %q, want %q", data.Model.DisplayName, "Opus")
+	}
+}
+
+// TestStdinData_UnmarshalJSON_OfficialSchema verifies that the exact JSON from
+// the Claude Code official documentation parses correctly.
+func TestStdinData_UnmarshalJSON_OfficialSchema(t *testing.T) {
+	// Exact JSON from https://code.claude.com/docs/en/statusline
+	input := `{
+		"model": {"id": "claude-opus-4-6", "display_name": "Opus"},
+		"context_window": {"used_percentage": 25, "context_window_size": 200000},
+		"rate_limits": {
+			"five_hour": {"used_percentage": 23.5, "resets_at": 1738425600},
+			"seven_day": {"used_percentage": 41.2, "resets_at": 1738857600}
+		},
+		"workspace": {"current_dir": "/home/user/project", "project_dir": "/home/user/project"},
+		"version": "1.0.80",
+		"cost": {"total_cost_usd": 0.05}
+	}`
+
+	var data StdinData
+	if err := json.Unmarshal([]byte(input), &data); err != nil {
+		t.Fatalf("official schema parse failed: %v", err)
+	}
+
+	// Verify all key fields parsed
+	if data.Model == nil || data.Model.ID != "claude-opus-4-6" {
+		t.Errorf("Model not parsed correctly: %+v", data.Model)
+	}
+	if data.ContextWindow == nil {
+		t.Error("ContextWindow is nil")
+	}
+	if data.RateLimits == nil {
+		t.Error("RateLimits is nil")
+	} else {
+		if data.RateLimits.FiveHour == nil {
+			t.Error("RateLimits.FiveHour is nil")
+		} else if data.RateLimits.FiveHour.ResetsAt != 1738425600 {
+			t.Errorf("FiveHour.ResetsAt = %v, want 1738425600", data.RateLimits.FiveHour.ResetsAt)
+		}
+		if data.RateLimits.SevenDay == nil {
+			t.Error("RateLimits.SevenDay is nil")
+		} else if data.RateLimits.SevenDay.ResetsAt != 1738857600 {
+			t.Errorf("SevenDay.ResetsAt = %v, want 1738857600", data.RateLimits.SevenDay.ResetsAt)
+		}
+	}
+	if data.Version != "1.0.80" {
+		t.Errorf("Version = %q, want %q", data.Version, "1.0.80")
+	}
+	if data.Cost == nil || data.Cost.TotalCostUSD != 0.05 {
+		t.Errorf("Cost not parsed correctly: %+v", data.Cost)
 	}
 }


### PR DESCRIPTION
## Summary

- **Bug 1 (CRITICAL)**: `RateLimitWindow.ResetsAt` 타입을 `string` → `int64` (Unix epoch)로 변경. 공식 Claude Code statusline 스키마는 integer를 전송하므로, 기존 `string` 선언이 전체 JSON 파싱을 실패시켜 모든 stdin 데이터(model, context_window, rate_limits 등)가 유실됨
- **Bug 2**: `ModelInfo.UnmarshalJSON` 커스텀 구현으로 `"model": "claude-opus-4-6"` (string) 형식과 `"model": {"id": "...", "display_name": "..."}` (object) 형식 모두 지원
- **Bug 3**: `renderBarsInline()` (default 모드 L2)에서 5H/7D 바를 렌더링할 때 `data.RateLimits` (Claude Code stdin JSON)를 `data.Usage` (MoAI API 호출)보다 우선 사용하도록 수정

## Root Cause

공식 Claude Code 문서(https://code.claude.com/docs/en/statusline)의 JSON 스키마:
```json
"rate_limits": {
    "five_hour": {
        "used_percentage": 23.5,
        "resets_at": 1738425600  ← integer (Unix epoch), not string
    }
}
```

기존 코드: `ResetsAt string` → Go `json.Decode`가 integer를 string 필드에서 만나면 **전체 디코드 실패** 발생.

## Changes

| 파일 | 변경 내용 |
|------|----------|
| `types.go` | `RateLimitWindow.ResetsAt` `string` → `int64`; `ModelInfo.UnmarshalJSON` 추가 |
| `renderer.go` | `formatResetTimeRelative/Absolute`를 `interface{}` 수용으로 변경; `parseResetTime()` 헬퍼 추가; `renderBarsInline` RateLimits 우선 사용 |
| `types_test.go` | Bug 1/2/OfficialSchema 재현 테스트 추가 |
| `builder_test.go` | OfficialSchema E2E 테스트, RateLimits 우선순위 테스트 추가 |

## Test plan

- [x] `TestStdinData_UnmarshalJSON_ResetsAtInteger` - Bug 1 재현 및 수정 확인
- [x] `TestStdinData_UnmarshalJSON_ModelAsString` - Bug 2 재현 및 수정 확인
- [x] `TestStdinData_UnmarshalJSON_OfficialSchema` - 공식 스키마 전체 파싱
- [x] `TestBuild_OfficialSchema` - E2E 통합 테스트
- [x] `TestBuild_RateLimitsPreferredOverUsage` - Bug 3 수정 확인
- [x] `go test -race ./...` - 전체 스위트 통과 (race detector 포함)
- [x] `go vet ./...` - 정적 분석 통과

Fixes #549

🗿 MoAI <email@mo.ai.kr>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Rate limit information now takes precedence over usage metrics in status display when both are available.
  * Enhanced compatibility for multiple timestamp formats in rate limit reset time calculations.
  * Improved flexibility in model information handling.

* **Tests**
  * Significantly expanded test coverage for statusline JSON data parsing and rendering with official schema validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->