### PR TITLE
fix(template): plan.md Phase 3 'WorktreeManager' → 'moai worktree new'

### DIFF
--- a/.claude/skills/moai/workflows/plan.md
+++ b/.claude/skills/moai/workflows/plan.md
@@ -313,7 +313,7 @@ Skipped when: develop_direct workflow, no flags and user chooses "Use current br
 Prerequisite: SPEC files MUST be committed before worktree creation.
 - Stage SPEC files: git add .moai/specs/SPEC-{ID}/
 - Create commit: feat(spec): Add SPEC-{ID} - {title}
-- Create worktree via WorktreeManager with branch feature/SPEC-{ID}
+- Create worktree: `moai worktree new SPEC-{ID}`
 - Display worktree path and navigation instructions
 
 #### Branch Path (--branch flag or user choice)

--- a/internal/template/templates/.claude/skills/moai/workflows/plan.md
+++ b/internal/template/templates/.claude/skills/moai/workflows/plan.md
@@ -313,7 +313,7 @@ Skipped when: develop_direct workflow, no flags and user chooses "Use current br
 Prerequisite: SPEC files MUST be committed before worktree creation.
 - Stage SPEC files: git add .moai/specs/SPEC-{ID}/
 - Create commit: feat(spec): Add SPEC-{ID} - {title}
-- Create worktree via WorktreeManager with branch feature/SPEC-{ID}
+- Create worktree: `moai worktree new SPEC-{ID}`
 - Display worktree path and navigation instructions
 
 #### Branch Path (--branch flag or user choice)


### PR DESCRIPTION
## Summary
- Phase 3 Worktree Path의 모호한 `WorktreeManager` 참조를 명확한 `moai worktree new SPEC-{ID}`로 변경
- 에이전트가 Claude Code의 `EnterWorktree`가 아닌 MoAI worktree를 사용하도록 유도

## Changes
- `.claude/skills/moai/workflows/plan.md` (local copy)
- `internal/template/templates/.claude/skills/moai/workflows/plan.md` (template source)

## Test plan
- [ ] 문서 변경만으로 코드 영향 없음
- [ ] `moai worktree new` 명령어가 정상 동작 확인

Fixes #552

🗿 MoAI <email@mo.ai.kr>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Phase 3 workflow documentation to specify the use of `moai worktree new SPEC-{ID}` command for creating isolated Git worktrees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->