### PR TITLE
fix(template): LSP 템플릿 언어 중립성 — PR #624 후속 수정

### DIFF
--- a/CLAUDE.local.md
+++ b/CLAUDE.local.md
@@ -1004,6 +1004,128 @@ float64(config.DefaultTestCoverageTarget)
 
 ---
 
+## 22. 템플릿 언어 중립성 규칙
+
+### [HARD] 패키지 템플릿은 특정 언어 전용으로 하드코딩 금지
+
+`internal/template/templates/` 하위의 모든 파일은 **범용 패키지로 배포되어 사용자 프로젝트에 적용**되므로, 특정 언어 전용 가정이나 편향을 담으면 안 된다.
+
+moai-adk-go는 Go로 작성된 도구이지만, **도구 자체의 언어와 사용자 프로젝트 언어는 완전히 별개**다. Python 개발자가 `moai init`을 실행하면 그 사람에게 필요한 것은 pylsp이지 gopls가 아니다.
+
+### 허용 vs 금지
+
+| 위치 | 언어 편향 허용? | 이유 |
+|------|-------------|------|
+| **CLAUDE.local.md** | ✅ 허용 | 이 프로젝트(moai-adk-go) 개발자 전용 |
+| **`.moai/config/sections/*.yaml`** (로컬) | ✅ 허용 | 이 프로젝트 자체가 Go |
+| **`.claude/settings.local.json`** | ✅ 허용 | 로컬 세션 전용 |
+| **`internal/template/templates/**/*.tmpl`** | ❌ **금지** | 16개 언어 모두 동등 취급 |
+| **`internal/template/templates/**/*.yaml`** | ❌ **금지** | 사용자 환경 감지 or 중립 |
+| **`internal/template/templates/CLAUDE.md`** | ❌ **금지** | 다국적 언어 중립 |
+| **Go 코드 `internal/`, `pkg/`** | ❌ 금지 | URL/model 상수화 (Section 21) |
+
+### 체크리스트
+
+새 템플릿 파일 추가 또는 수정 시 반드시 확인:
+
+- [ ] 특정 언어 바이너리(gopls, pylsp, rust-analyzer 등)를 "PRIMARY"로 배치하지 않았는가?
+- [ ] 16개 지원 언어(go, python, typescript, javascript, rust, java, kotlin, csharp, ruby, php, elixir, cpp, scala, r, dart, swift)가 동등 수준으로 나열되어 있는가?
+- [ ] 특정 언어만 "enabled: true", 다른 언어는 "planned"/"deferred"로 격하하지 않았는가?
+- [ ] "Primary/Secondary/Tertiary" 분류가 있다면, 언어가 아닌 "기능"(문법 검사, 타입 체크, 린트) 기준인가?
+- [ ] 사용자 환경 감지 로직(project_markers, extension-based)이 포함되어 있는가?
+
+### 16개 지원 언어 목록
+
+Template 파일 작성 시 반드시 16개 모두 동등 처리:
+
+```
+go, python, typescript, javascript, rust, java, kotlin, csharp,
+ruby, php, elixir, cpp, scala, r, dart, swift
+```
+
+이 목록은 `.claude/skills/moai/workflows/sync.md` Phase 0.6.1 "Language Detection" 테이블과 일치해야 하며, 변경 시 두 파일 모두 동기화 필요.
+
+### 사용자 환경 감지 패턴
+
+템플릿은 project marker 파일로 사용자 프로젝트 언어를 감지하여 해당 도구만 활성화해야 한다:
+
+```yaml
+# CORRECT: 16개 언어 동등, project_markers로 자동 감지
+servers:
+  go:
+    project_markers: ["go.mod", "go.sum"]
+    binary: gopls
+  python:
+    project_markers: ["pyproject.toml", "setup.py", "Pipfile", "requirements.txt"]
+    binary: pylsp
+  typescript:
+    project_markers: ["tsconfig.json", "package.json"]
+    binary: typescript-language-server
+  rust:
+    project_markers: ["Cargo.toml"]
+    binary: rust-analyzer
+  # ... (16개 모두 동일 스키마, 동일 우선순위)
+```
+
+```yaml
+# WRONG: Go를 특별 취급
+gopls_bridge:        # ← Go 전용 최상위 섹션
+  enabled: false
+  binary: gopls
+future_servers:      # ← 다른 언어를 "future"로 격하
+  python: { status: "planned" }
+  typescript: { status: "planned" }
+```
+
+### 로컬과 템플릿 분리 원칙
+
+이 프로젝트(moai-adk-go)는 Go로 작성되었지만, **템플릿은 사용자를 위한 것**이지 이 프로젝트를 위한 것이 아니다.
+
+- `internal/template/templates/.moai/config/sections/lsp.yaml.tmpl`: **범용**, 16개 언어 동등
+- `.moai/config/sections/lsp.yaml` (로컬): **moai-adk-go 개발용**, gopls 편향 허용
+
+두 파일의 내용이 달라도 정상이며, 오히려 **같으면 규칙 위반 의심**. 로컬은 이 프로젝트의 실제 개발 필요에 맞게 편향되어야 하고, 템플릿은 사용자 환경에 맞춰 중립이어야 한다.
+
+### 허용되는 언어별 차등 (예외)
+
+다음 경우에만 언어별 차등이 허용된다:
+
+1. **공식 지원 티어**: `.moai/project/tech.md` 또는 `README.md`에 "Tier 1: Go, Python, TS / Tier 2: 나머지" 같은 공식 우선순위가 명시된 경우
+2. **상태가 실제로 다를 때**: 특정 언어 서버가 stable, 다른 언어는 experimental인 경우 (status 필드로 명시)
+3. **기능 제약**: 특정 기능이 특정 언어에서만 동작하는 경우 (드물게)
+
+이 예외들도 반드시 **명시적 문서화**가 필요하며, 암묵적 편향은 허용되지 않는다.
+
+### 검증 방법
+
+새 템플릿 파일 커밋 전 수행:
+
+```bash
+# 1. 템플릿 파일에 언어 이름 등장 횟수 체크
+for lang in go python typescript javascript rust java kotlin csharp ruby php elixir cpp scala r dart swift; do
+  count=$(grep -c "^\s*$lang:" internal/template/templates/path/to/file.tmpl)
+  echo "$lang: $count"
+done
+
+# 2. "PRIMARY" / "gopls" 등 특정 언어 편향 키워드 검색
+grep -i "primary.*gopls\|gopls.*primary" internal/template/templates/**
+
+# 3. 로컬과 템플릿 내용 비교 (동일하면 경고)
+diff .moai/config/sections/lsp.yaml internal/template/templates/.moai/config/sections/lsp.yaml.tmpl
+```
+
+### 역사적 참고
+
+이 규칙은 2026-04-11 세션에서 PR #624가 병합된 직후 발견된 문제에서 비롯되었다:
+- PR #624는 `lsp.yaml.tmpl`을 작성하며 gopls를 "PRIMARY Path C"로 배치
+- Python/TypeScript 등 15개 언어는 "future_servers.status: planned"로 격하
+- Python 개발자가 `moai init` 실행 시 자신에게 필요 없는 Go-biased config를 받게 됨
+- 근본 원인: 이 프로젝트가 Go로 작성되었다는 사실이 무의식 중에 템플릿 설계에 반영됨
+
+**교훈**: 템플릿 파일을 작성할 때 "이 프로젝트가 어떤 언어로 만들어졌는지"를 완전히 잊어버리고, "16개 언어 중 어떤 언어 사용자라도 동등하게 환영받아야 한다"는 관점을 유지해야 한다.
+
+---
+
 **Status**: Active (Local Development)
-**Version**: 1.8.0 (Go 패키지 하드코딩 방지 규칙 추가)
+**Version**: 1.9.0 (템플릿 언어 중립성 규칙 추가)
 **Last Updated**: 2026-04-11

--- a/internal/template/templates/.moai/config/sections/lsp.yaml.tmpl
+++ b/internal/template/templates/.moai/config/sections/lsp.yaml.tmpl
@@ -1,232 +1,340 @@
-# LSP Configuration for MoAI-ADK (Hybrid Strategy — Path C)
+# LSP Configuration for MoAI-ADK
 #
 # ================================================================
-# Architecture Decision Record (ADR)
+# Language Neutrality Policy (CLAUDE.local.md Section 22)
 # ================================================================
-# Chosen after comparative research of opencode, crush, cclsp,
-# plandex-ai, aider, and the Go LSP library landscape (2026).
+# This is a TEMPLATE file deployed to end-user projects via
+# `moai init`. MoAI-ADK supports 16 programming languages, and
+# this file MUST treat all of them as equal first-class citizens.
 #
-# PRIMARY: ast-grep / Tree-sitter for 16-language AST analysis
-#   - Already supported via internal/astgrep/
-#   - See SPEC-ASTG-UPGRADE-001 for the 25-rule library rollout
-#   - Covers all 16 MoAI-supported languages out of the box
+# The author of MoAI-ADK writes Go; users of MoAI-ADK may write
+# ANY of the 16 supported languages. Do NOT encode the author's
+# language preference into this template.
 #
-# SECONDARY: gopls subprocess bridge for Go type-checking
-#   - See SPEC-GOPLS-BRIDGE-001 (planned) for the direct
-#     JSON-RPC stdio client (~200-400 LOC, no external library)
-#   - Go is moai-adk-go's own language, so payback is immediate
-#
-# DEFERRED: Full multi-language LSP client
-#   - SPEC-LSP-CORE-002 will be re-designed with powernap
-#     (charmbracelet/crush's proven library) instead of
-#     go.lsp.dev/jsonrpc2 (pre-v1.0, 3+ years without release)
-#
-# WHY NOT full LSP from day one:
-#   1. ast-grep already covers 16+ languages via Tree-sitter
-#      — re-use don't rebuild (aider / plandex proven pattern)
-#   2. Go LSP Go library landscape is still immature in 2026:
-#      go.lsp.dev/jsonrpc2 is pre-v1.0, tliron/glsp is early
-#      release, sourcegraph/jsonrpc2 is deprecated
-#   3. Charm's powernap (used by crush, 23k+ stars) is the
-#      most battle-tested option but evaluation is pending
-#   4. "Stability > completeness > performance" philosophy
-#      rules out taking on risky dependencies prematurely
-#
-# Research sources:
-#   - C1: sst/opencode LSP deep dive (TS-heavy, lazy init, 20+ langs)
-#   - C2: charmbracelet/crush (Go, powernap, manager-coordinator)
-#   - C3: Broader Go LSP tool survey (plandex=Tree-sitter,
-#         aider=Tree-sitter, sketch=shell-based)
+# Supported languages (all 16 equal, alphabetical):
+#   cpp, csharp, dart, elixir, go, java, javascript, kotlin,
+#   php, python, r, ruby, rust, scala, swift, typescript
 # ================================================================
+#
+# Architecture: MoAI-ADK is an LSP CLIENT + AGGREGATOR
+#   - Spawns existing language server binaries per user's project
+#   - Aggregates diagnostics from all active servers
+#   - Does NOT reimplement per-language analyzers
+#
+# Lazy activation: a language server is only started when a file
+# matching its project_markers is encountered. Users working on a
+# single-language project only pay the cost of that one server.
+#
+# Fallback: ast-grep / Tree-sitter provides AST analysis for all
+# 16 languages via .moai/config/astgrep-rules/. When no LSP
+# binary is available, ast-grep continues to provide quality gates.
+#
+# Research sources (2026-04-11 comparative audit):
+#   - sst/opencode: lazy init, 20+ languages, stdio
+#   - charmbracelet/crush: manager-coordinator + powernap
+#   - ktnyt/cclsp: robust position resolution for AI agents
+#   - plandex-ai/plandex & aider: Tree-sitter fallback pattern
 
 lsp:
-  # ---------------- Path C Primary: gopls bridge ----------------
-  # Go-specific LSP integration via subprocess stdio.
-  # SPEC-GOPLS-BRIDGE-001 will implement direct JSON-RPC 2.0 client
-  # without external library dependency.
+  # Master switch. Flip to true once the runtime LSP client lands
+  # (SPEC-LSP-CORE-002, re-designed with charmbracelet/powernap).
+  enabled: false
+
+  # ---------------- 16 Language Server Matrix ----------------
+  # All 16 MoAI-supported languages, listed alphabetically, with
+  # identical schema. No language receives PRIMARY / SECONDARY /
+  # DEFERRED classification; the user's project_markers decide
+  # which servers actually spawn at runtime.
   #
-  # Lazy spawn: only start gopls on first .go file access
-  # Timeouts: tuned to opencode/crush production values
-  gopls_bridge:
-    # Flip to true when SPEC-GOPLS-BRIDGE-001 lands
-    enabled: false
-
-    binary: gopls
-    args: []
-
-    init_options:
-      staticcheck: true
-      gofumpt: false
-      analyses:
-        unusedparams: true
-        shadow: true
-
-    project_markers:
-      - "go.mod"
-      - "go.sum"
-
-    # Lazy init prevents eager startup of gopls for non-Go sessions
-    lazy_init: true
-
-    # Timeouts based on opencode production tuning research
-    # - diagnostics_debounce_ms: 150 (opencode confirmed empirically)
-    # - initialize_seconds: 30 (extended from 3s per opencode issue #742)
-    # - request_seconds: 5 (standard LSP request timeout)
-    # - shutdown_seconds: 5 (crush graceful shutdown pattern)
-    timeouts:
-      initialize_seconds: 30
-      request_seconds: 5
-      shutdown_seconds: 5
-      diagnostics_debounce_ms: 150
-
-    install_hint: "go install golang.org/x/tools/gopls@latest"
-
-  # ---------------- Path C Primary: ast-grep delegation ----------------
-  # Multi-language analysis delegated to ast-grep / Tree-sitter.
-  # All 16 MoAI-supported languages are covered via ast-grep rules.
-  # See SPEC-ASTG-UPGRADE-001 for the full rule library rollout.
-  delegate_to_astgrep:
-    enabled: true
-    rules_dir: ".moai/config/astgrep-rules"
-
-    # All 16 MoAI-supported languages (ast-grep provides AST parsing
-    # via Tree-sitter for each). This matches the Language Detection
-    # table in .claude/skills/moai/workflows/sync.md Phase 0.6.1.
-    languages:
-      - go
-      - python
-      - typescript
-      - javascript
-      - rust
-      - java
-      - kotlin
-      - csharp
-      - ruby
-      - php
-      - elixir
-      - cpp
-      - scala
-      - r
-      - dart          # Flutter/Dart
-      - swift
-
-  # ---------------- Deferred: Full LSP Server Matrix ----------------
-  # Full multi-language LSP client is planned but deferred.
-  # Listed here for documentation and future implementation.
-  # SPEC-LSP-CORE-002 (re-designed with powernap) will enable this.
-  #
-  # Each entry documents: binary, args, init_options, markers,
-  # install hint, and maturity status.
-  future_servers:
-    python:
-      binary: pylsp
-      fallback_binaries: ["pyright-langserver", "basedpyright-langserver"]
-      status: "planned"
-      install_hint: "pip install python-lsp-server"
-
-    typescript:
-      binary: typescript-language-server
-      args: ["--stdio"]
-      status: "planned"
-      install_hint: "npm install -g typescript-language-server typescript"
-
-    javascript:
-      binary: typescript-language-server
-      args: ["--stdio"]
-      status: "planned"
-      install_hint: "npm install -g typescript-language-server typescript"
-
-    rust:
-      binary: rust-analyzer
-      status: "planned"
-      install_hint: "rustup component add rust-analyzer"
-
-    java:
-      binary: jdtls
-      status: "planned"
-      install_hint: "Install Eclipse JDT Language Server"
-
-    kotlin:
-      binary: kotlin-language-server
-      status: "planned"
-      install_hint: "https://github.com/fwcd/kotlin-language-server"
-
-    csharp:
-      binary: omnisharp
-      args: ["-lsp"]
-      fallback_binaries: ["roslyn-ls"]
-      status: "planned"
-
-    ruby:
-      binary: ruby-lsp
-      fallback_binaries: ["solargraph"]
-      status: "planned"
-      install_hint: "gem install ruby-lsp"
-
-    php:
-      binary: phpactor
-      args: ["language-server"]
-      fallback_binaries: ["intelephense"]
-      status: "planned"
-
-    elixir:
-      binary: elixir-ls
-      fallback_binaries: ["lexical"]
-      status: "planned"
+  # Schema per entry:
+  #   binary               : Primary server executable
+  #   fallback_binaries    : Alternative servers if primary missing
+  #   args                 : Command-line arguments
+  #   init_options         : LSP initializationOptions for the server
+  #   project_markers      : Files that identify this language
+  #                          (LSP client spawns server only when a
+  #                          marker exists in the user's project)
+  #   install_hint         : Human-readable install command
+  #   license_concern      : "open" | "commercial" (user awareness)
+  servers:
 
     cpp:
       binary: clangd
-      status: "planned"
-      install_hint: "Install via LLVM distribution"
+      fallback_binaries: []
+      args: []
+      init_options: {}
+      project_markers:
+        - "CMakeLists.txt"
+        - "compile_commands.json"
+        - "Makefile"
+      install_hint: "Install via LLVM distribution (brew install llvm / apt install clangd)"
+      license_concern: "open"
 
-    scala:
-      binary: metals
-      status: "planned"
-      install_hint: "https://scalameta.org/metals/"
-
-    swift:
-      binary: sourcekit-lsp
-      status: "planned"
-      install_hint: "Bundled with Xcode Command Line Tools"
+    csharp:
+      binary: omnisharp
+      fallback_binaries:
+        - "roslyn-ls"
+      args:
+        - "-lsp"
+      init_options: {}
+      project_markers:
+        - "*.csproj"
+        - "*.sln"
+        - "*.fsproj"
+      install_hint: "Install OmniSharp or Microsoft.CodeAnalysis.LanguageServer"
+      license_concern: "open"
 
     dart:
       binary: dart
-      args: ["language-server", "--protocol=lsp"]
-      status: "planned"
-      install_hint: "Bundled with Dart/Flutter SDK"
+      fallback_binaries: []
+      args:
+        - "language-server"
+        - "--protocol=lsp"
+      init_options: {}
+      project_markers:
+        - "pubspec.yaml"
+        - "pubspec.lock"
+      install_hint: "Install Dart SDK or Flutter SDK (includes dart LSP)"
+      license_concern: "open"
+
+    elixir:
+      binary: elixir-ls
+      fallback_binaries:
+        - "lexical"
+      args: []
+      init_options: {}
+      project_markers:
+        - "mix.exs"
+        - "mix.lock"
+      install_hint: "Install elixir-ls from https://github.com/elixir-lsp/elixir-ls"
+      license_concern: "open"
+
+    go:
+      binary: gopls
+      fallback_binaries: []
+      args: []
+      init_options:
+        staticcheck: true
+      project_markers:
+        - "go.mod"
+        - "go.sum"
+      install_hint: "go install golang.org/x/tools/gopls@latest"
+      license_concern: "open"
+
+    java:
+      binary: jdtls
+      fallback_binaries: []
+      args: []
+      init_options: {}
+      project_markers:
+        - "pom.xml"
+        - "build.gradle"
+        - "build.gradle.kts"
+      install_hint: "Install Eclipse JDT Language Server (jdtls)"
+      license_concern: "open"
+
+    javascript:
+      binary: typescript-language-server
+      fallback_binaries: []
+      args:
+        - "--stdio"
+      init_options: {}
+      project_markers:
+        - "package.json"
+        - "jsconfig.json"
+      install_hint: "npm install -g typescript-language-server typescript"
+      license_concern: "open"
+
+    kotlin:
+      binary: kotlin-language-server
+      fallback_binaries: []
+      args: []
+      init_options: {}
+      project_markers:
+        - "build.gradle.kts"
+        - "build.gradle"
+        - "settings.gradle.kts"
+      install_hint: "Install from https://github.com/fwcd/kotlin-language-server"
+      license_concern: "open"
+
+    php:
+      binary: phpactor
+      fallback_binaries:
+        - "intelephense"
+      args:
+        - "language-server"
+      init_options: {}
+      project_markers:
+        - "composer.json"
+        - "composer.lock"
+      install_hint: "Install phpactor from https://phpactor.readthedocs.io/"
+      license_concern: "open"
+
+    python:
+      binary: pylsp
+      fallback_binaries:
+        - "pyright-langserver"
+        - "basedpyright-langserver"
+      args: []
+      init_options: {}
+      project_markers:
+        - "pyproject.toml"
+        - "setup.py"
+        - "requirements.txt"
+        - "Pipfile"
+      install_hint: "pip install python-lsp-server"
+      license_concern: "open"
 
     r:
       binary: R
-      args: ["--slave", "-e", "languageserver::run()"]
-      status: "planned"
+      fallback_binaries: []
+      args:
+        - "--slave"
+        - "-e"
+        - "languageserver::run()"
+      init_options: {}
+      project_markers:
+        - "DESCRIPTION"
+        - ".Rproj"
+        - "renv.lock"
       install_hint: "install.packages('languageserver') in R"
+      license_concern: "open"
+
+    ruby:
+      binary: ruby-lsp
+      fallback_binaries:
+        - "solargraph"
+      args: []
+      init_options: {}
+      project_markers:
+        - "Gemfile"
+        - ".ruby-version"
+        - "Rakefile"
+      install_hint: "gem install ruby-lsp"
+      license_concern: "open"
+
+    rust:
+      binary: rust-analyzer
+      fallback_binaries: []
+      args: []
+      init_options:
+        checkOnSave:
+          command: "clippy"
+      project_markers:
+        - "Cargo.toml"
+        - "Cargo.lock"
+      install_hint: "rustup component add rust-analyzer"
+      license_concern: "open"
+
+    scala:
+      binary: metals
+      fallback_binaries: []
+      args: []
+      init_options: {}
+      project_markers:
+        - "build.sbt"
+        - "build.sc"
+      install_hint: "Install metals from https://scalameta.org/metals/"
+      license_concern: "open"
+
+    swift:
+      binary: sourcekit-lsp
+      fallback_binaries: []
+      args: []
+      init_options: {}
+      project_markers:
+        - "Package.swift"
+        - "*.xcodeproj"
+        - "*.xcworkspace"
+      install_hint: "Install Xcode Command Line Tools (includes sourcekit-lsp)"
+      license_concern: "open"
+
+    typescript:
+      binary: typescript-language-server
+      fallback_binaries: []
+      args:
+        - "--stdio"
+      init_options: {}
+      project_markers:
+        - "tsconfig.json"
+        - "package.json"
+      install_hint: "npm install -g typescript-language-server typescript"
+      license_concern: "open"
+
+  # ---------------- ast-grep Delegation ----------------
+  # ast-grep / Tree-sitter provides AST analysis for ALL 16 languages.
+  # This is independent of LSP and serves as universal fallback /
+  # supplement. No language is excluded.
+  delegate_to_astgrep:
+    enabled: true
+    rules_dir: ".moai/config/astgrep-rules"
+    languages:
+      - cpp
+      - csharp
+      - dart
+      - elixir
+      - go
+      - java
+      - javascript
+      - kotlin
+      - php
+      - python
+      - r
+      - ruby
+      - rust
+      - scala
+      - swift
+      - typescript
 
   # ---------------- Aggregator Settings ----------------
-  # Consumed by SPEC-LSP-CORE-002 when full LSP client lands.
-  # Currently only affects gopls_bridge via shared timeout values.
+  # Applies equally to all 16 language servers.
+  # Tuned from opencode/crush production research.
   aggregator:
+    # Per-file diagnostic cache time-to-live
     cache_ttl_seconds: 5
+
+    # Maximum simultaneous language server queries
     max_parallel_servers: 16
-    server_startup_timeout_seconds: 10
+
+    # Server startup timeout (first file of a language)
+    server_startup_timeout_seconds: 30
+
+    # Per-request timeout for LSP method calls
     request_timeout_seconds: 5
-    # LSP 3.17+ pull diagnostic model (Biome/Deno pattern)
+
+    # Graceful shutdown timeout
+    shutdown_timeout_seconds: 5
+
+    # Debounce window for diagnostic notifications
+    diagnostics_debounce_ms: 150
+
+    # Use LSP 3.17+ pull diagnostic model
     diagnostic_pull_enabled: true
 
   # ---------------- Discovery Policy ----------------
   # Graceful degradation: missing binaries warn, never error.
-  # Philosophy: "stability > completeness > performance"
+  # Applies equally to all 16 languages.
   discovery:
+    # Actions when a language server binary is not found
+    # Options: warn_and_skip | error | silent_skip
     on_missing: "warn_and_skip"
+
+    # Print install_hint when a server is missing
     auto_install_suggest: true
+
+    # Search order for binaries
     search_paths:
       - "PATH"
       - "node_modules/.bin"
       - ".venv/bin"
       - ".tools/bin"
 
+    # Auto-detect project language via project_markers
+    auto_detect_language: true
+
   # ---------------- Circuit Breaker ----------------
   # Stop trying a failing server after N consecutive failures.
-  # Adopted from opencode/crush production patterns.
+  # Applies equally to all 16 languages.
   circuit_breaker:
     threshold: 3
     open_duration_seconds: 30


### PR DESCRIPTION
## Summary

PR #624 병합 직후 발견된 **템플릿 언어 편향 문제**를 시정합니다. 사용자가 제기한 원칙("로컬은 Go, 패키지는 사용자 환경 중립")을 CLAUDE.local.md에 HARD 규칙으로 명문화하고, PR #624가 배치한 gopls-biased 템플릿을 16개 언어 중립 구조로 재작성합니다.

## Problem

PR #624에서 추가된 `internal/template/templates/.moai/config/sections/lsp.yaml.tmpl`은 다음 구조였음:

```yaml
lsp:
  gopls_bridge:              # ← Go 전용 최상위 섹션
    enabled: false
    binary: gopls
  delegate_to_astgrep:       # ← OK (중립)
    enabled: true
  future_servers:            # ← 15개 언어를 "planned"로 격하
    python: { status: "planned" }
    typescript: { status: "planned" }
    rust: { status: "planned" }
    # ...
```

**영향**:
- Python 개발자가 `moai init` 실행 시 gopls PRIMARY 노이즈 받음
- TypeScript 개발자도 마찬가지
- "Path C" 결정은 moai-adk-go 개발자(Go 작성자)의 선택이지 범용 패키지 사용자의 기본값이 되면 안 됨

**근본 원인**: moai-adk-go가 Go로 작성되었다는 사실이 무의식 중에 템플릿 설계에 반영됨.

## Changes

### Commit A: `docs(local): Section 22 — 템플릿 언어 중립성 규칙 [HARD]`

CLAUDE.local.md에 Section 22 추가:

- **[HARD] 패키지 템플릿은 특정 언어 전용으로 하드코딩 금지**
- 허용/금지 매트릭스 (로컬 vs 템플릿 vs Go 코드)
- 16개 지원 언어 목록 (sync.md Phase 0.6.1과 일치)
- 체크리스트 (PRIMARY 배치 금지, planned/deferred 격하 금지)
- 사용자 환경 감지 패턴 (project_markers 기반)
- 로컬과 템플릿 분리 원칙: "두 파일이 같으면 규칙 위반 의심"
- 예외 (공식 티어, 실제 상태 차이, 기능 제약)
- 검증 방법 (bash 스크립트)
- 역사적 참고 (PR #624 병합 직후 발견)

### Commit B: `fix(template): lsp.yaml.tmpl을 16개 언어 중립 구조로 재작성`

`internal/template/templates/.moai/config/sections/lsp.yaml.tmpl`을 **16개 언어 동등 구조**로 재작성:

```yaml
lsp:
  enabled: false
  servers:
    cpp: { binary: clangd, project_markers: [...] }
    csharp: { binary: omnisharp, ... }
    dart: { ... }
    elixir: { ... }
    go: { binary: gopls, project_markers: ["go.mod", "go.sum"] }
    java: { ... }
    javascript: { binary: typescript-language-server, ... }
    kotlin: { ... }
    php: { ... }
    python: { binary: pylsp, project_markers: ["pyproject.toml", ...] }
    r: { ... }
    ruby: { ... }
    rust: { binary: rust-analyzer, ... }
    scala: { ... }
    swift: { ... }
    typescript: { ... }
  delegate_to_astgrep:
    enabled: true
    languages: [cpp, csharp, dart, ..., typescript]  # 16개 모두
  aggregator: { ... }
  discovery: { auto_detect_language: true, ... }
  circuit_breaker: { ... }
```

**핵심 변경**:
- 16개 언어가 `servers:` 섹션에 **알파벳 순 동등 나열**
- 각 언어 동일 스키마 (binary, fallback_binaries, args, init_options, project_markers, install_hint, license_concern)
- PRIMARY/SECONDARY/DEFERRED 분류 제거
- `gopls_bridge` 같은 언어 특화 최상위 섹션 제거
- project_markers 기반 **lazy activation** (sst/opencode 패턴)
- ast-grep delegation도 16개 언어 모두 나열

### NOT Changed (의도적)

- `.moai/config/sections/lsp.yaml` (로컬): **Go 편향 유지** (gopls_bridge primary)
  - 이유: 이 프로젝트(moai-adk-go) 자체가 Go로 작성됨 → 로컬 편향 허용 (Section 22)
  - 결과: 로컬과 템플릿이 이제 달라짐 → Section 22 원칙 부합

## Files

| 파일 | 변경 | 내용 |
|---|---|---|
| `CLAUDE.local.md` | +123/-1 | Section 22 추가 |
| `internal/template/templates/.moai/config/sections/lsp.yaml.tmpl` | +280/-172 | 16개 언어 중립 재작성 |
| `.moai/config/sections/lsp.yaml` (로컬) | 변경 없음 | Go 편향 유지 (의도적) |

## Verification

### Section 22 체크리스트

- [x] 특정 언어 바이너리를 "PRIMARY"로 배치하지 않음
- [x] 16개 지원 언어가 동등 수준으로 나열됨 (servers 섹션)
- [x] 특정 언어만 "enabled: true"로 설정하지 않음 (모두 lazy)
- [x] "Primary/Secondary/Tertiary" 분류 제거
- [x] project_markers 기반 사용자 환경 감지 포함
- [x] auto_detect_language: true

### 로컬 vs 템플릿 비교

```bash
diff .moai/config/sections/lsp.yaml internal/template/templates/.moai/config/sections/lsp.yaml.tmpl
# 두 파일은 이제 다름 (Section 22 원칙 부합)
```

- 로컬 (`.moai/config/sections/lsp.yaml`): `gopls_bridge` PRIMARY 유지
- 템플릿 (`.tmpl`): 16개 언어 중립 `servers` 섹션

## Test plan

- [x] make build — 통과
- [x] Git commit clean (2 atomic commits)
- [ ] CI: cross-compile + race detector
- [ ] Manual review: Section 22 readable, template neutrality verified

## Impact

- ✅ 모든 언어 사용자가 동등한 품질의 LSP config 받음
- ✅ Section 22 HARD 규칙으로 향후 템플릿 작성 가이드라인 확립
- ✅ 로컬과 템플릿 분리 원칙 명시
- ✅ 사용자 환경 자동 감지 활성화
- ❌ Breaking change 없음 (enabled: false 기본값)

🗿 MoAI <email@mo.ai.kr>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended LSP support to 16 languages with unified configuration structure
  * Added automatic language detection based on project markers

* **Documentation**
  * Added template language neutrality guidelines to ensure consistent multi-language support

* **Chores**
  * Restructured LSP configuration for language-agnostic deployment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->