### PR TITLE
fix(audit): Section 22 Round 2 — 4건 템플릿 언어 중립성 추가 시정

### DIFF
--- a/.claude/commands/99-release.md
+++ b/.claude/commands/99-release.md
@@ -2,7 +2,7 @@
 description: "MoAI-ADK v2.x production release via GitHub Flow. Creates release/vX.Y.Z branch, version bump, CHANGELOG, PR to main, squash merge, then tag push. Tag vX.Y.Z triggers GoReleaser. All git operations delegated to manager-git. Quality failures escalate to expert-debug."
 argument-hint: "[VERSION] - optional target version (e.g., 2.1.0). If omitted, prompts for patch/minor/major selection."
 type: local
-allowed-tools: Read, Write, Edit, Grep, Glob, Bash, TodoWrite, AskUserQuestion, Agent
+allowed-tools: Read, Write, Edit, Grep, Glob, Bash, AskUserQuestion, Agent, TaskCreate, TaskUpdate, TaskList, TaskGet
 disable-model-invocation: true
 version: 4.0.0
 metadata:
@@ -87,7 +87,7 @@ Before starting the release process, verify the working directory is clean:
 
 ## PHASE 1: Quality Gates
 
-Create TodoWrite with these items, then run each check in parallel where possible:
+Create a task list via TaskCreate for these items, then run each check in parallel where possible:
 
 1. Run all tests: `go test -race ./... -count=1 2>&1 | tail -30`
 2. Run go vet: `go vet ./... 2>&1 | tail -10`
@@ -887,4 +887,4 @@ grep -n "moai.version" internal/template/templates/.moai/config/sections/system.
 
 ## BEGIN EXECUTION
 
-Start Phase 1 now. Create TodoWrite and run quality gates immediately.
+Start Phase 1 now. Create tasks via TaskCreate and run quality gates immediately.

--- a/.claude/commands/agency/brief.md
+++ b/.claude/commands/agency/brief.md
@@ -1,6 +1,7 @@
 ---
 description: "Agency brief command"
 argument-hint: "[args] [--team] [--step]"
+allowed-tools: Skill
 ---
 
 Use Skill("agency") with arguments: brief $ARGUMENTS

--- a/.claude/commands/agency/build.md
+++ b/.claude/commands/agency/build.md
@@ -1,6 +1,7 @@
 ---
 description: "Agency build command"
 argument-hint: "[args] [--team] [--step]"
+allowed-tools: Skill
 ---
 
 Use Skill("agency") with arguments: build $ARGUMENTS

--- a/.claude/commands/agency/evolve.md
+++ b/.claude/commands/agency/evolve.md
@@ -1,6 +1,7 @@
 ---
 description: "Agency evolve command"
 argument-hint: "[args] [--team] [--step]"
+allowed-tools: Skill
 ---
 
 Use Skill("agency") with arguments: evolve $ARGUMENTS

--- a/.claude/commands/agency/learn.md
+++ b/.claude/commands/agency/learn.md
@@ -1,6 +1,7 @@
 ---
 description: "Agency learn command"
 argument-hint: "[args] [--team] [--step]"
+allowed-tools: Skill
 ---
 
 Use Skill("agency") with arguments: learn $ARGUMENTS

--- a/.claude/commands/agency/profile.md
+++ b/.claude/commands/agency/profile.md
@@ -1,6 +1,7 @@
 ---
 description: "Agency profile command"
 argument-hint: "[args] [--team] [--step]"
+allowed-tools: Skill
 ---
 
 Use Skill("agency") with arguments: profile $ARGUMENTS

--- a/.claude/commands/agency/resume.md
+++ b/.claude/commands/agency/resume.md
@@ -1,6 +1,7 @@
 ---
 description: "Agency resume command"
 argument-hint: "[args] [--team] [--step]"
+allowed-tools: Skill
 ---
 
 Use Skill("agency") with arguments: resume $ARGUMENTS

--- a/.claude/commands/agency/review.md
+++ b/.claude/commands/agency/review.md
@@ -1,6 +1,7 @@
 ---
 description: "Agency review command"
 argument-hint: "[args] [--team] [--step]"
+allowed-tools: Skill
 ---
 
 Use Skill("agency") with arguments: review $ARGUMENTS

--- a/.claude/commands/moai/clean.md
+++ b/.claude/commands/moai/clean.md
@@ -1,6 +1,7 @@
 ---
 description: Identify and safely remove dead code with test verification
 argument-hint: "[--dry] [--safe-only] [--file PATH]"
+allowed-tools: Skill
 ---
 
 Use Skill("moai") with arguments: clean $ARGUMENTS

--- a/.claude/commands/moai/codemaps.md
+++ b/.claude/commands/moai/codemaps.md
@@ -1,6 +1,7 @@
 ---
 description: Scan codebase and generate architecture documentation in codemaps/
 argument-hint: "[--force] [--area AREA]"
+allowed-tools: Skill
 ---
 
 Use Skill("moai") with arguments: codemaps $ARGUMENTS

--- a/.claude/commands/moai/coverage.md
+++ b/.claude/commands/moai/coverage.md
@@ -1,6 +1,7 @@
 ---
 description: Analyze test coverage, identify gaps, and generate missing tests
 argument-hint: "[--target N] [--file PATH] [--report]"
+allowed-tools: Skill
 ---
 
 Use Skill("moai") with arguments: coverage $ARGUMENTS

--- a/.claude/commands/moai/e2e.md
+++ b/.claude/commands/moai/e2e.md
@@ -1,6 +1,7 @@
 ---
 description: Create and run E2E tests with Chrome, Playwright, or Agent Browser
 argument-hint: "[--record] [--url URL] [--journey NAME]"
+allowed-tools: Skill
 ---
 
 Use Skill("moai") with arguments: e2e $ARGUMENTS

--- a/.claude/commands/moai/feedback.md
+++ b/.claude/commands/moai/feedback.md
@@ -1,6 +1,7 @@
 ---
 description: Collect feedback and create GitHub issue (bug report, feature request)
 argument-hint: "[\"description\"]"
+allowed-tools: Skill
 ---
 
 Use Skill("moai") with arguments: feedback $ARGUMENTS

--- a/.claude/commands/moai/fix.md
+++ b/.claude/commands/moai/fix.md
@@ -1,6 +1,7 @@
 ---
 description: Auto-detect and fix LSP errors, linting issues, and type errors
 argument-hint: "[--dry] [--seq] [--level N] [--resume] [--team]"
+allowed-tools: Skill
 ---
 
 Use Skill("moai") with arguments: fix $ARGUMENTS

--- a/.claude/commands/moai/loop.md
+++ b/.claude/commands/moai/loop.md
@@ -1,6 +1,7 @@
 ---
 description: Iteratively fix issues until all resolved or max iterations reached
 argument-hint: "[--max N] [--auto-fix] [--seq]"
+allowed-tools: Skill
 ---
 
 Use Skill("moai") with arguments: loop $ARGUMENTS

--- a/.claude/commands/moai/mx.md
+++ b/.claude/commands/moai/mx.md
@@ -1,6 +1,7 @@
 ---
 description: Scan codebase and add @MX code-level annotations for AI context
 argument-hint: "[--all] [--dry] [--priority P1-P4] [--force] [--team]"
+allowed-tools: Skill
 ---
 
 Use Skill("moai") with arguments: mx $ARGUMENTS

--- a/.claude/commands/moai/plan.md
+++ b/.claude/commands/moai/plan.md
@@ -1,6 +1,7 @@
 ---
 description: Create SPEC document with EARS format requirements and acceptance criteria
 argument-hint: "\"description\" [--team] [--worktree] [--branch] [--resume SPEC-XXX]"
+allowed-tools: Skill
 ---
 
 Use Skill("moai") with arguments: plan $ARGUMENTS

--- a/.claude/commands/moai/project.md
+++ b/.claude/commands/moai/project.md
@@ -1,5 +1,6 @@
 ---
 description: Generate project documentation (product.md, structure.md, tech.md, codemaps/)
+allowed-tools: Skill
 ---
 
 Use Skill("moai") with arguments: project $ARGUMENTS

--- a/.claude/commands/moai/review.md
+++ b/.claude/commands/moai/review.md
@@ -1,6 +1,7 @@
 ---
 description: Code review with security and @MX tag compliance check
 argument-hint: "[--staged] [--branch] [--security]"
+allowed-tools: Skill
 ---
 
 Use Skill("moai") with arguments: review $ARGUMENTS

--- a/.claude/commands/moai/run.md
+++ b/.claude/commands/moai/run.md
@@ -1,6 +1,7 @@
 ---
 description: Implement SPEC requirements using DDD/TDD methodology
 argument-hint: "SPEC-XXX [--team] [--resume SPEC-XXX]"
+allowed-tools: Skill
 ---
 
 Use Skill("moai") with arguments: run $ARGUMENTS

--- a/.claude/commands/moai/sync.md
+++ b/.claude/commands/moai/sync.md
@@ -1,6 +1,7 @@
 ---
 description: Synchronize documentation, codemaps, and create pull request
 argument-hint: "[SPEC-XXX] [--merge] [--skip-mx]"
+allowed-tools: Skill
 ---
 
 Use Skill("moai") with arguments: sync $ARGUMENTS

--- a/.claude/skills/moai-docs-generation/SKILL.md
+++ b/.claude/skills/moai-docs-generation/SKILL.md
@@ -7,7 +7,7 @@ description: >
   documentation workflows.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read, Write, Edit, Grep, Glob, Bash(npm:*), Bash(npx:*), Bash(git:*), Bash(sphinx-build:*), Bash(mkdocs:*), Bash(typedoc:*), mcp__context7__resolve-library-id, mcp__context7__get-library-docs
+allowed-tools: Read, Write, Edit, Grep, Glob, Skill, Bash(npm:*), Bash(npx:*), Bash(git:*), Bash(sphinx-build:*), Bash(mkdocs:*), Bash(typedoc:*), mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "2.1.0"

--- a/.claude/skills/moai-domain-frontend/SKILL.md
+++ b/.claude/skills/moai-domain-frontend/SKILL.md
@@ -7,7 +7,7 @@ description: >
   integrating state management.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Grep Glob mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Grep, Glob, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "2.1.0"

--- a/.claude/skills/moai-domain-uiux/SKILL.md
+++ b/.claude/skills/moai-domain-uiux/SKILL.md
@@ -6,7 +6,7 @@ description: >
   systems, WCAG compliance, ARIA patterns, or dark mode theming.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Grep Glob mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Grep, Glob, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "3.1.0"

--- a/.claude/skills/moai-formats-data/SKILL.md
+++ b/.claude/skills/moai-formats-data/SKILL.md
@@ -7,7 +7,7 @@ description: >
   serialization.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Write Edit Grep Glob mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Write, Edit, Grep, Glob, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "2.0.0"

--- a/.claude/skills/moai-foundation-cc/SKILL.md
+++ b/.claude/skills/moai-foundation-cc/SKILL.md
@@ -6,7 +6,7 @@ description: >
   Use when creating Claude Code extensions or configuring Claude Code features.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Write Edit Grep Glob mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Write, Edit, Grep, Glob, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "5.0.0"

--- a/.claude/skills/moai-foundation-context/SKILL.md
+++ b/.claude/skills/moai-foundation-context/SKILL.md
@@ -6,7 +6,7 @@ description: >
   budget management, context limits, or session handoff across agents.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Grep Glob mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Grep, Glob, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "3.1.0"

--- a/.claude/skills/moai-foundation-core/SKILL.md
+++ b/.claude/skills/moai-foundation-core/SKILL.md
@@ -6,7 +6,7 @@ description: >
   and agent catalog reference. Use when referencing TRUST 5 gates or SPEC workflow.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Grep Glob mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Grep, Glob, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "2.5.0"

--- a/.claude/skills/moai-foundation-philosopher/SKILL.md
+++ b/.claude/skills/moai-foundation-philosopher/SKILL.md
@@ -6,7 +6,7 @@ description: >
   Use for architecture decisions or root cause analysis.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Grep Glob mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Grep, Glob, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 effort: high
 user-invocable: false
 metadata:

--- a/.claude/skills/moai-foundation-quality/SKILL.md
+++ b/.claude/skills/moai-foundation-quality/SKILL.md
@@ -6,7 +6,7 @@ description: >
   gate checks, or TRUST 5 compliance.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Grep Glob mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Grep, Glob, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "2.2.0"

--- a/.claude/skills/moai-foundation-thinking/SKILL.md
+++ b/.claude/skills/moai-foundation-thinking/SKILL.md
@@ -6,7 +6,7 @@ description: >
   Use when generating ideas or evaluating proposals.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Grep Glob
+allowed-tools: Read, Grep, Glob
 user-invocable: false
 metadata:
   version: "1.0.0"

--- a/.claude/skills/moai-framework-electron/SKILL.md
+++ b/.claude/skills/moai-framework-electron/SKILL.md
@@ -6,7 +6,7 @@ description: >
   Electron Forge. Use when building cross-platform desktop applications.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Grep Glob mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Grep, Glob, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "2.0.0"

--- a/.claude/skills/moai-library-mermaid/SKILL.md
+++ b/.claude/skills/moai-library-mermaid/SKILL.md
@@ -5,7 +5,7 @@ description: >
   creating architecture diagrams, flowcharts, sequence diagrams, or visual documentation.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Grep Glob Bash(npx:*) Bash(mmdc:*) mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Grep, Glob, Bash(npx:*), Bash(mmdc:*), mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "7.1.0"

--- a/.claude/skills/moai-library-nextra/SKILL.md
+++ b/.claude/skills/moai-library-nextra/SKILL.md
@@ -5,7 +5,7 @@ description: >
   sites, knowledge bases, or API reference documentation.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Write Edit Grep Glob mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Write, Edit, Grep, Glob, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "2.2.0"

--- a/.claude/skills/moai-library-shadcn/SKILL.md
+++ b/.claude/skills/moai-library-shadcn/SKILL.md
@@ -7,7 +7,7 @@ description: >
   systems, CLI workflows, or registry authoring with shadcn/ui.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Grep Glob mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Grep, Glob, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "3.0.0"

--- a/.claude/skills/moai-platform-auth/SKILL.md
+++ b/.claude/skills/moai-platform-auth/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Authentication and authorization specialist covering Auth0, Clerk,
   and Firebase Auth. Use when implementing authentication, MFA, SSO,
   passkeys, WebAuthn, social login, or security features.
-license: MIT
+license: Apache-2.0
 compatibility: Designed for Claude Code
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(npm:*), Bash(npx:*), Bash(firebase:*), Bash(curl:*), WebFetch, WebSearch, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false

--- a/.claude/skills/moai-platform-auth/SKILL.md
+++ b/.claude/skills/moai-platform-auth/SKILL.md
@@ -6,7 +6,7 @@ description: >
   passkeys, WebAuthn, social login, or security features.
 license: MIT
 compatibility: Designed for Claude Code
-allowed-tools: Read Write Edit Grep Glob Bash(npm:*) Bash(npx:*) Bash(firebase:*) Bash(curl:*) WebFetch WebSearch mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Write, Edit, Grep, Glob, Bash(npm:*), Bash(npx:*), Bash(firebase:*), Bash(curl:*), WebFetch, WebSearch, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "2.0.0"

--- a/.claude/skills/moai-platform-chrome-extension/SKILL.md
+++ b/.claude/skills/moai-platform-chrome-extension/SKILL.md
@@ -6,7 +6,7 @@ description: >
   and Chrome Web Store publishing. Use when building browser extensions.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Grep Glob Bash(npm:*) Bash(npx:*) Bash(node:*) WebFetch WebSearch mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Grep, Glob, Bash(npm:*), Bash(npx:*), Bash(node:*), WebFetch, WebSearch, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "1.0.0"

--- a/.claude/skills/moai-platform-database-cloud/SKILL.md
+++ b/.claude/skills/moai-platform-database-cloud/SKILL.md
@@ -6,7 +6,7 @@ description: >
   Use when choosing or setting up cloud databases.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Write Bash(psql:*) Bash(npm:*) Bash(npx:*) Bash(neonctl:*) Bash(firebase:*) Bash(supabase:*) Grep Glob mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Write, Bash(psql:*), Bash(npm:*), Bash(npx:*), Bash(neonctl:*), Bash(firebase:*), Bash(supabase:*), Grep, Glob, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "2.0.0"

--- a/.claude/skills/moai-platform-deployment/SKILL.md
+++ b/.claude/skills/moai-platform-deployment/SKILL.md
@@ -5,6 +5,8 @@ description: >
   Use when deploying applications, configuring edge functions, setting up continuous
   deployment, or managing serverless infrastructure.
 license: MIT
+user-invocable: false
+allowed-tools: Read, Write, Edit, Grep, Glob, Bash(npm:*), Bash(npx:*), Bash(docker:*), Bash(git:*), WebFetch, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 metadata:
   version: "2.0.0"
   category: "platform"
@@ -24,9 +26,6 @@ triggers:
   keywords: ["deploy", "deployment", "hosting", "vercel", "railway", "convex", "edge functions", "containers", "docker", "serverless", "real-time", "preview deployment", "continuous deployment"]
   agents: ["expert-devops", "expert-backend", "expert-frontend"]
   phases: ["run", "sync"]
-
-user-invocable: false
-allowed-tools: Read, Write, Edit, Grep, Glob, Bash(npm:*), Bash(npx:*), Bash(docker:*), Bash(git:*), WebFetch, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 ---
 
 # Deployment Platform Specialist

--- a/.claude/skills/moai-platform-deployment/SKILL.md
+++ b/.claude/skills/moai-platform-deployment/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Deployment and hosting platform specialist covering Vercel, Railway, and Convex.
   Use when deploying applications, configuring edge functions, setting up continuous
   deployment, or managing serverless infrastructure.
-license: MIT
+license: Apache-2.0
 user-invocable: false
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(npm:*), Bash(npx:*), Bash(docker:*), Bash(git:*), WebFetch, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 metadata:

--- a/.claude/skills/moai-tool-ast-grep/SKILL.md
+++ b/.claude/skills/moai-tool-ast-grep/SKILL.md
@@ -6,7 +6,7 @@ description: >
   languages. Use for structural search or codemod operations.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Grep Glob Bash(sg:*) Bash(ast-grep:*) mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Grep, Glob, Bash(sg:*), Bash(ast-grep:*), mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "1.2.0"

--- a/.claude/skills/moai-tool-svg/SKILL.md
+++ b/.claude/skills/moai-tool-svg/SKILL.md
@@ -6,7 +6,7 @@ description: >
   visualizations, or adding SVG animations.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Grep Glob Bash(svgo:*) Bash(npx:*) WebFetch
+allowed-tools: Read, Grep, Glob, Bash(svgo:*), Bash(npx:*), WebFetch
 user-invocable: false
 metadata:
   version: "1.0.0"

--- a/.claude/skills/moai-workflow-ddd/SKILL.md
+++ b/.claude/skills/moai-workflow-ddd/SKILL.md
@@ -6,7 +6,7 @@ description: >
   legacy code or reducing technical debt safely.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Write Edit Bash(git:*) Bash(pytest:*) Bash(ruff:*) Bash(npm:*) Bash(npx:*) Bash(node:*) Bash(uv:*) Bash(make:*) Bash(cargo:*) Bash(go:*) Bash(mix:*) Bash(bundle:*) Grep Glob mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Write, Edit, Bash(git:*), Bash(pytest:*), Bash(ruff:*), Bash(npm:*), Bash(npx:*), Bash(node:*), Bash(uv:*), Bash(make:*), Bash(cargo:*), Bash(go:*), Bash(mix:*), Bash(bundle:*), Grep, Glob, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "1.0.0"

--- a/.claude/skills/moai-workflow-jit-docs/SKILL.md
+++ b/.claude/skills/moai-workflow-jit-docs/SKILL.md
@@ -6,7 +6,7 @@ description: >
   context. Use when users need specific documentation on demand.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Grep Glob WebFetch WebSearch mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Grep, Glob, WebFetch, WebSearch, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "3.0.0"

--- a/.claude/skills/moai-workflow-loop/SKILL.md
+++ b/.claude/skills/moai-workflow-loop/SKILL.md
@@ -7,7 +7,7 @@ description: >
   workflows.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Write Edit Bash Grep Glob mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Write, Edit, Bash, Grep, Glob, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 effort: low
 user-invocable: false
 metadata:

--- a/.claude/skills/moai-workflow-project/SKILL.md
+++ b/.claude/skills/moai-workflow-project/SKILL.md
@@ -7,7 +7,7 @@ description: >
   or optimizing templates.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Write Edit Bash(git:*) Bash(npm:*) Bash(npx:*) Bash(uv:*) Bash(pip:*) Bash(ls:*) Bash(mkdir:*) Grep Glob mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Write, Edit, Bash(git:*), Bash(npm:*), Bash(npx:*), Bash(uv:*), Bash(pip:*), Bash(ls:*), Bash(mkdir:*), Grep, Glob, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "2.0.0"

--- a/.claude/skills/moai-workflow-spec/SKILL.md
+++ b/.claude/skills/moai-workflow-spec/SKILL.md
@@ -6,7 +6,7 @@ description: >
   documents or defining acceptance criteria.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Write Edit Bash(git:*) Bash(ls:*) Bash(wc:*) Bash(mkdir:*) Grep Glob mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Write, Edit, Bash(git:*), Bash(ls:*), Bash(wc:*), Bash(mkdir:*), Grep, Glob, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "1.2.0"

--- a/.claude/skills/moai-workflow-tdd/SKILL.md
+++ b/.claude/skills/moai-workflow-tdd/SKILL.md
@@ -7,7 +7,7 @@ description: >
   implementation.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Write Edit Bash(pytest:*) Bash(ruff:*) Bash(npm:*) Bash(npx:*) Bash(node:*) Bash(jest:*) Bash(vitest:*) Bash(go:*) Bash(cargo:*) Bash(mix:*) Bash(uv:*) Bash(bundle:*) Bash(php:*) Bash(phpunit:*) Grep Glob mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Write, Edit, Bash(pytest:*), Bash(ruff:*), Bash(npm:*), Bash(npx:*), Bash(node:*), Bash(jest:*), Bash(vitest:*), Bash(go:*), Bash(cargo:*), Bash(mix:*), Bash(uv:*), Bash(bundle:*), Bash(php:*), Bash(phpunit:*), Grep, Glob, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "1.0.0"

--- a/.claude/skills/moai-workflow-templates/SKILL.md
+++ b/.claude/skills/moai-workflow-templates/SKILL.md
@@ -6,7 +6,7 @@ description: >
   boilerplate files, or managing scaffolding.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Write Edit Grep Glob mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Write, Edit, Grep, Glob, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "3.1.0"

--- a/.claude/skills/moai-workflow-testing/SKILL.md
+++ b/.claude/skills/moai-workflow-testing/SKILL.md
@@ -6,7 +6,7 @@ description: >
   assurance. Use when writing tests or measuring coverage.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Write Edit Bash(pytest:*) Bash(ruff:*) Bash(npm:*) Bash(npx:*) Bash(node:*) Bash(jest:*) Bash(vitest:*) Bash(go:*) Bash(cargo:*) Bash(mix:*) Bash(uv:*) Bash(bundle:*) Bash(php:*) Bash(phpunit:*) Grep Glob mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Write, Edit, Bash(pytest:*), Bash(ruff:*), Bash(npm:*), Bash(npx:*), Bash(node:*), Bash(jest:*), Bash(vitest:*), Bash(go:*), Bash(cargo:*), Bash(mix:*), Bash(uv:*), Bash(bundle:*), Bash(php:*), Bash(phpunit:*), Grep, Glob, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "2.4.0"

--- a/.claude/skills/moai-workflow-worktree/SKILL.md
+++ b/.claude/skills/moai-workflow-worktree/SKILL.md
@@ -6,7 +6,7 @@ description: >
   setting up parallel development environments.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Write Grep Glob mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Write, Grep, Glob, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "1.1.0"

--- a/.claude/skills/moai/SKILL.md
+++ b/.claude/skills/moai/SKILL.md
@@ -5,7 +5,7 @@ description: >
   language or subcommands (plan, run, sync, fix, loop, mx, project,
   feedback, review, clean, codemaps, coverage, e2e) to specialized
   agents.
-allowed-tools: Agent, AskUserQuestion, TaskCreate, TaskUpdate, TaskList, TaskGet, Bash, Read, Write, Edit, Glob, Grep
+allowed-tools: Agent, AskUserQuestion, Skill, TaskCreate, TaskUpdate, TaskList, TaskGet, Bash, Read, Write, Edit, Glob, Grep
 argument-hint: "[subcommand] [args] | \"natural language task\""
 ---
 

--- a/CLAUDE.local.md
+++ b/CLAUDE.local.md
@@ -836,8 +836,42 @@ metadata:
 | Agents | `initialPrompt` | String | `initialPrompt: "Analyze the code: @.src/"` |
 | Agents | `skills` | YAML array | `skills:\n  - moai-lang-go` |
 | Skills | `allowed-tools` | CSV string | `allowed-tools: Read, Grep` |
+| Skills | `allowed-tools` | ❌ 공백 구분 금지 | `Read Grep Glob` → YAML이 단일 string으로 파싱 (§18.1) |
 | Skills | `effort` | String | `effort: low` |
 | Skills | `metadata.*` | Quoted strings | `version: "1.0.0"` |
+
+### §18.1 [CRITICAL] Space-separated `allowed-tools` 금지
+
+YAML 스펙상 `allowed-tools: Read Grep Glob`는 **단일 string scalar** `"Read Grep Glob"`으로 파싱된다. Claude Code가 이 string을 공백으로 분리하는지, 쉼표로만 분리하는지는 공식 문서상 명시되지 않았으나 **CSV가 유일한 공식 권장 형식** (skill-authoring.md).
+
+**Go yaml.v3 파서 검증** (2026-04-11 세션):
+- `allowed-tools: Read Grep Glob` → `TYPE: string`, `VALUE: "Read Grep Glob"` → 쉼표 분리 시 1개 token "`Read Grep Glob`" (존재하지 않는 도구)
+- `allowed-tools: Read, Grep, Glob` → `TYPE: string`, `VALUE: "Read, Grep, Glob"` → 쉼표 분리 시 3개 token 정상
+
+공백 구분은 Claude Code가 **1개의 존재하지 않는 tool 이름**으로 해석하여 silently no tools allowed 상태가 될 수 있다. 검증 불가능한 영역이므로 **CSV만 허용**.
+
+**금지 예시**:
+```yaml
+# WRONG — YAML 단일 scalar로 파싱됨
+allowed-tools: Read Grep Glob Bash(git:*)
+
+# CORRECT — CSV로 3+1 tool token 분리
+allowed-tools: Read, Grep, Glob, Bash(git:*)
+```
+
+**탐지 grep 패턴**:
+```bash
+for f in .claude/skills/*/SKILL.md internal/template/templates/.claude/skills/*/SKILL.md; do
+  line=$(grep "^allowed-tools:" "$f" 2>/dev/null)
+  if [ -n "$line" ]; then
+    val="${line#allowed-tools: }"
+    if ! echo "$val" | grep -q ","; then
+      nf=$(echo "$val" | awk '{print NF}')
+      [ "$nf" -gt 1 ] && echo "DEFECT: $f"
+    fi
+  fi
+done
+```
 
 ### Validation Checklist
 
@@ -845,7 +879,7 @@ metadata:
 
 - [ ] `paths:` 필드가 CSV string 형식인지 확인
 - [ ] `tools:` 필드가 CSV string 형식인지 확인
-- [ ] `allowed-tools:` 필드가 CSV string 형식인지 확인
+- [ ] `allowed-tools:` 필드가 CSV string 형식인지 확인 (공백 구분 절대 금지, §18.1 참조)
 - [ ] `metadata:` 모든 값이 quoted string인지 확인
 - [ ] Template 수정 후 `make build` 실행했는지 확인
 - [ ] Local copy (`.claude/`)도 동일하게 수정했는지 확인
@@ -1129,6 +1163,89 @@ diff .moai/config/sections/lsp.yaml internal/template/templates/.moai/config/sec
 
 ---
 
+## 23. Audit Sweep Patterns
+
+### [HARD] 전수 감사 의뢰 시 반드시 재검증 루프 포함
+
+**배경**: 2026-04-11 세션에서 `Explore` 서브에이전트에게 전체 스킬 frontmatter 감사를 의뢰했으나, 2개 스킬(`moai-platform-auth`, `moai-platform-chrome-extension`)의 `allowed-tools` 공백 구분 결함을 놓쳤다. Iteration 2 재검증 grep에서 추가 발견되었다. **7%의 false-negative rate** (2/27).
+
+### Explore/Plan 등 Claude Code 내장 서브에이전트의 한계
+
+- `Explore`, `Plan`, `general-purpose`는 Claude Code **내장** 서브에이전트로, `.claude/agents/`에 파일이 없어 **직접 프롬프트 수정 불가**.
+- 감사 품질은 에이전트에게 전달되는 **프롬프트 지시문의 완결성**에 전적으로 의존한다.
+- 따라서 "전수 감사" 의뢰 시 에이전트를 개선하는 것이 아니라 **의뢰 프롬프트와 재검증 루프**를 강화해야 한다.
+
+### [HARD] 감사 프롬프트 필수 구성요소
+
+1. **명시적 카테고리 분류**: 카테고리를 번호(A, B, C...)로 나누고 각 카테고리의 판정 기준을 구체적 정규식 또는 문자열 매칭으로 명시
+2. **구체적 grep/glob 힌트**: 에이전트가 직접 실행할 수 있는 명령어를 프롬프트 내 제공
+3. **조사 대상 디렉토리 양쪽 모두 명시**: `internal/template/templates/...` + `.claude/...` (Template-First rule 대응)
+4. **예상 결함 수량 가이드**: "N개 카테고리에서 최소 M개 결함 예상" — 에이전트가 너무 일찍 멈추는 것을 방지
+5. **재검증 3단계 루프 필수** (아래 참조)
+
+### 감사 결과 재검증 3단계 루프
+
+| 단계 | 방법 | 목적 |
+|------|------|------|
+| 1. 1차 감사 | Explore 에이전트에 sweep 패턴 + 카테고리 명시 의뢰 | 구조적 결함 발견 |
+| 2. 2차 재검증 | **동일 sweep을 Bash 스크립트로 직접 재실행** | 에이전트 누락 보완 (이번 세션 +2개 발견) |
+| 3. 3차 full-file 파싱 | Go yaml.v3 파서 등으로 실제 YAML 유효성 검증 | 단순 grep이 놓치는 파싱 오류 탐지 |
+
+### 검증된 sweep 패턴 라이브러리
+
+```bash
+# 패턴 A: 공백 구분 allowed-tools 탐지
+for f in .claude/skills/*/SKILL.md internal/template/templates/.claude/skills/*/SKILL.md; do
+  line=$(grep "^allowed-tools:" "$f" 2>/dev/null)
+  if [ -n "$line" ]; then
+    val="${line#allowed-tools: }"
+    if ! echo "$val" | grep -q ","; then
+      nf=$(echo "$val" | awk '{print NF}')
+      [ "$nf" -gt 1 ] && echo "SPACE-SEP: $f"
+    fi
+  fi
+done
+
+# 패턴 B: Skill() 호출 vs allowed-tools 일관성
+for f in .claude/skills/*/SKILL.md internal/template/templates/.claude/skills/*/SKILL.md; do
+  if grep -q 'Skill("' "$f" 2>/dev/null; then
+    if ! grep -q "^allowed-tools:.*Skill" "$f" 2>/dev/null; then
+      echo "MISSING Skill in allowed-tools: $f"
+    fi
+  fi
+done
+
+# 패턴 C: license template vs local 불일치
+for f in .claude/skills/*/SKILL.md; do
+  base=$(basename $(dirname "$f"))
+  tpl="internal/template/templates/.claude/skills/$base/SKILL.md"
+  if [ -f "$tpl" ]; then
+    local_lic=$(grep "^license:" "$f" | sed 's/license: //')
+    tpl_lic=$(grep "^license:" "$tpl" | sed 's/license: //')
+    [ "$local_lic" != "$tpl_lic" ] && echo "MISMATCH: $base"
+  fi
+done
+
+# 패턴 D: Go yaml 파싱 전체 유효성 (gopkg.in/yaml.v3 이미 go.mod에 있음)
+# 임시 Go 스크립트로 모든 SKILL.md frontmatter 파싱 후 에러 집계
+```
+
+### 교훈
+
+- **에이전트 보고서는 최소 기준선이며 절대적 진실이 아니다.** 이번 세션에서 에이전트는 25개 결함을 보고했으나 실제는 27개였다 (7% 누락).
+- **재검증 grep sweep이 누락을 잡아냈다.** Iteration 2의 final sweep이 `moai-platform-auth`, `moai-platform-chrome-extension`을 추가 발견해 완전한 범위로 확장되었다.
+- **Template-First 원칙**: 감사 시 반드시 template + local **양쪽** 모두 스캔. 한쪽만 보면 절반을 놓친다.
+- **Go 파서 검증이 grep보다 강력**: CSV 형식 검증만으로는 공백 구분이 실제로 어떻게 파싱되는지 모름. Go yaml.v3 파서로 실제 type + value를 출력하면 false-positive 없이 확정 가능.
+
+### 적용 지침
+
+향후 전수 감사 의뢰 시 반드시:
+1. 이 §23 섹션을 감사 의뢰 프롬프트에 include (또는 요약)
+2. 감사 결과 수신 후 **Bash 재검증 스크립트를 반드시 실행**
+3. 불일치 발견 시 iteration 추가 — "에이전트가 한 말이 전부"라고 절대 가정 금지
+
+---
+
 **Status**: Active (Local Development)
-**Version**: 1.9.0 (템플릿 언어 중립성 규칙 추가)
+**Version**: 2.0.0 (§18.1 공백 구분 금지 + §23 Audit Sweep Patterns 추가)
 **Last Updated**: 2026-04-11

--- a/internal/template/templates/.claude/commands/agency/brief.md
+++ b/internal/template/templates/.claude/commands/agency/brief.md
@@ -1,6 +1,7 @@
 ---
 description: "Agency brief command"
 argument-hint: "[args] [--team] [--step]"
+allowed-tools: Skill
 ---
 
 Use Skill("agency") with arguments: brief $ARGUMENTS

--- a/internal/template/templates/.claude/commands/agency/build.md
+++ b/internal/template/templates/.claude/commands/agency/build.md
@@ -1,6 +1,7 @@
 ---
 description: "Agency build command"
 argument-hint: "[args] [--team] [--step]"
+allowed-tools: Skill
 ---
 
 Use Skill("agency") with arguments: build $ARGUMENTS

--- a/internal/template/templates/.claude/commands/agency/evolve.md
+++ b/internal/template/templates/.claude/commands/agency/evolve.md
@@ -1,6 +1,7 @@
 ---
 description: "Agency evolve command"
 argument-hint: "[args] [--team] [--step]"
+allowed-tools: Skill
 ---
 
 Use Skill("agency") with arguments: evolve $ARGUMENTS

--- a/internal/template/templates/.claude/commands/agency/learn.md
+++ b/internal/template/templates/.claude/commands/agency/learn.md
@@ -1,6 +1,7 @@
 ---
 description: "Agency learn command"
 argument-hint: "[args] [--team] [--step]"
+allowed-tools: Skill
 ---
 
 Use Skill("agency") with arguments: learn $ARGUMENTS

--- a/internal/template/templates/.claude/commands/agency/profile.md
+++ b/internal/template/templates/.claude/commands/agency/profile.md
@@ -1,6 +1,7 @@
 ---
 description: "Agency profile command"
 argument-hint: "[args] [--team] [--step]"
+allowed-tools: Skill
 ---
 
 Use Skill("agency") with arguments: profile $ARGUMENTS

--- a/internal/template/templates/.claude/commands/agency/resume.md
+++ b/internal/template/templates/.claude/commands/agency/resume.md
@@ -1,6 +1,7 @@
 ---
 description: "Agency resume command"
 argument-hint: "[args] [--team] [--step]"
+allowed-tools: Skill
 ---
 
 Use Skill("agency") with arguments: resume $ARGUMENTS

--- a/internal/template/templates/.claude/commands/agency/review.md
+++ b/internal/template/templates/.claude/commands/agency/review.md
@@ -1,6 +1,7 @@
 ---
 description: "Agency review command"
 argument-hint: "[args] [--team] [--step]"
+allowed-tools: Skill
 ---
 
 Use Skill("agency") with arguments: review $ARGUMENTS

--- a/internal/template/templates/.claude/commands/moai/clean.md.tmpl
+++ b/internal/template/templates/.claude/commands/moai/clean.md.tmpl
@@ -1,6 +1,7 @@
 ---
 description: {{if eq .ConversationLanguage "ko"}}테스트 검증을 통한 데드 코드 식별 및 안전한 제거{{else if eq .ConversationLanguage "ja"}}テスト検証によるデッドコードの特定と安全な削除{{else if eq .ConversationLanguage "zh"}}通过测试验证识别并安全删除无用代码{{else}}Identify and safely remove dead code with test verification{{end}}
 argument-hint: "[--dry] [--safe-only] [--file PATH]"
+allowed-tools: Skill
 ---
 
 Use Skill("moai") with arguments: clean $ARGUMENTS

--- a/internal/template/templates/.claude/commands/moai/codemaps.md.tmpl
+++ b/internal/template/templates/.claude/commands/moai/codemaps.md.tmpl
@@ -1,6 +1,7 @@
 ---
 description: {{if eq .ConversationLanguage "ko"}}코드베이스 스캔 및 codemaps/에 아키텍처 문서 생성{{else if eq .ConversationLanguage "ja"}}コードベースをスキャンしcodemaps/にアーキテクチャドキュメントを生成{{else if eq .ConversationLanguage "zh"}}扫描代码库并在codemaps/中生成架构文档{{else}}Scan codebase and generate architecture documentation in codemaps/{{end}}
 argument-hint: "{{if eq .ConversationLanguage "ko"}}[--force] [--area 영역]{{else if eq .ConversationLanguage "ja"}}[--force] [--area 領域]{{else if eq .ConversationLanguage "zh"}}[--force] [--area 区域]{{else}}[--force] [--area AREA]{{end}}"
+allowed-tools: Skill
 ---
 
 Use Skill("moai") with arguments: codemaps $ARGUMENTS

--- a/internal/template/templates/.claude/commands/moai/coverage.md.tmpl
+++ b/internal/template/templates/.claude/commands/moai/coverage.md.tmpl
@@ -1,6 +1,7 @@
 ---
 description: {{if eq .ConversationLanguage "ko"}}테스트 커버리지 분석, 갭 식별 및 누락된 테스트 생성{{else if eq .ConversationLanguage "ja"}}テストカバレッジ分析、ギャップ特定、不足テスト生成{{else if eq .ConversationLanguage "zh"}}分析测试覆盖率、识别差距并生成缺失的测试{{else}}Analyze test coverage, identify gaps, and generate missing tests{{end}}
 argument-hint: "[--target N] [--file PATH] [--report]"
+allowed-tools: Skill
 ---
 
 Use Skill("moai") with arguments: coverage $ARGUMENTS

--- a/internal/template/templates/.claude/commands/moai/e2e.md.tmpl
+++ b/internal/template/templates/.claude/commands/moai/e2e.md.tmpl
@@ -1,6 +1,7 @@
 ---
 description: {{if eq .ConversationLanguage "ko"}}Chrome, Playwright 또는 Agent Browser로 E2E 테스트 생성 및 실행{{else if eq .ConversationLanguage "ja"}}Chrome、Playwright、Agent BrowserでE2Eテストを作成・実行{{else if eq .ConversationLanguage "zh"}}使用Chrome、Playwright或Agent Browser创建和运行E2E测试{{else}}Create and run E2E tests with Chrome, Playwright, or Agent Browser{{end}}
 argument-hint: "[--record] [--url URL] [--journey NAME]"
+allowed-tools: Skill
 ---
 
 Use Skill("moai") with arguments: e2e $ARGUMENTS

--- a/internal/template/templates/.claude/commands/moai/feedback.md.tmpl
+++ b/internal/template/templates/.claude/commands/moai/feedback.md.tmpl
@@ -1,6 +1,7 @@
 ---
 description: {{if eq .ConversationLanguage "ko"}}피드백 수집 및 GitHub 이슈 생성 (버그 리포트, 기능 요청){{else if eq .ConversationLanguage "ja"}}フィードバック収集とGitHub Issue作成（バグ報告、機能リクエスト）{{else if eq .ConversationLanguage "zh"}}收集反馈并创建GitHub Issue（错误报告、功能请求）{{else}}Collect feedback and create GitHub issue (bug report, feature request){{end}}
 argument-hint: "{{if eq .ConversationLanguage "ko"}}[\"설명\"]{{else if eq .ConversationLanguage "ja"}}[\"説明\"]{{else if eq .ConversationLanguage "zh"}}[\"描述\"]{{else}}[\"description\"]{{end}}"
+allowed-tools: Skill
 ---
 
 Use Skill("moai") with arguments: feedback $ARGUMENTS

--- a/internal/template/templates/.claude/commands/moai/fix.md.tmpl
+++ b/internal/template/templates/.claude/commands/moai/fix.md.tmpl
@@ -1,6 +1,7 @@
 ---
 description: {{if eq .ConversationLanguage "ko"}}LSP 오류, 린트 문제, 타입 오류 자동 감지 및 수정{{else if eq .ConversationLanguage "ja"}}LSPエラー、リント問題、型エラーを自動検出して修正{{else if eq .ConversationLanguage "zh"}}自动检测并修复LSP错误、lint问题和类型错误{{else}}Auto-detect and fix LSP errors, linting issues, and type errors{{end}}
 argument-hint: "[--dry] [--seq] [--level N] [--resume] [--team]"
+allowed-tools: Skill
 ---
 
 Use Skill("moai") with arguments: fix $ARGUMENTS

--- a/internal/template/templates/.claude/commands/moai/loop.md.tmpl
+++ b/internal/template/templates/.claude/commands/moai/loop.md.tmpl
@@ -1,6 +1,7 @@
 ---
 description: {{if eq .ConversationLanguage "ko"}}모든 문제가 해결되거나 최대 반복 횟수에 도달할 때까지 반복 수정{{else if eq .ConversationLanguage "ja"}}全問題解決または最大反復回数に達するまで反復修正{{else if eq .ConversationLanguage "zh"}}反复修复问题直到全部解决或达到最大迭代次数{{else}}Iteratively fix issues until all resolved or max iterations reached{{end}}
 argument-hint: "[--max N] [--auto-fix] [--seq]"
+allowed-tools: Skill
 ---
 
 Use Skill("moai") with arguments: loop $ARGUMENTS

--- a/internal/template/templates/.claude/commands/moai/mx.md.tmpl
+++ b/internal/template/templates/.claude/commands/moai/mx.md.tmpl
@@ -1,6 +1,7 @@
 ---
 description: {{if eq .ConversationLanguage "ko"}}코드베이스 스캔 및 AI 컨텍스트용 @MX 코드 수준 어노테이션 추가{{else if eq .ConversationLanguage "ja"}}コードベースをスキャンしAIコンテキスト用@MXコードレベルアノテーションを追加{{else if eq .ConversationLanguage "zh"}}扫描代码库并添加AI上下文的@MX代码级注解{{else}}Scan codebase and add @MX code-level annotations for AI context{{end}}
 argument-hint: "[--all] [--dry] [--priority P1-P4] [--force] [--team]"
+allowed-tools: Skill
 ---
 
 Use Skill("moai") with arguments: mx $ARGUMENTS

--- a/internal/template/templates/.claude/commands/moai/plan.md.tmpl
+++ b/internal/template/templates/.claude/commands/moai/plan.md.tmpl
@@ -1,6 +1,7 @@
 ---
 description: {{if eq .ConversationLanguage "ko"}}EARS 형식 요구사항과 인수 기준을 포함한 SPEC 문서 생성{{else if eq .ConversationLanguage "ja"}}EARS形式の要件と受入基準を含むSPECドキュメントを作成{{else if eq .ConversationLanguage "zh"}}使用EARS格式创建包含需求和验收标准的SPEC文档{{else}}Create SPEC document with EARS format requirements and acceptance criteria{{end}}
 argument-hint: "{{if eq .ConversationLanguage "ko"}}\"설명\" [--team] [--worktree] [--branch] [--resume SPEC-XXX]{{else if eq .ConversationLanguage "ja"}}\"説明\" [--team] [--worktree] [--branch] [--resume SPEC-XXX]{{else if eq .ConversationLanguage "zh"}}\"描述\" [--team] [--worktree] [--branch] [--resume SPEC-XXX]{{else}}\"description\" [--team] [--worktree] [--branch] [--resume SPEC-XXX]{{end}}"
+allowed-tools: Skill
 ---
 
 Use Skill("moai") with arguments: plan $ARGUMENTS

--- a/internal/template/templates/.claude/commands/moai/project.md.tmpl
+++ b/internal/template/templates/.claude/commands/moai/project.md.tmpl
@@ -1,5 +1,6 @@
 ---
 description: {{if eq .ConversationLanguage "ko"}}프로젝트 문서 생성 (product.md, structure.md, tech.md, codemaps/){{else if eq .ConversationLanguage "ja"}}プロジェクトドキュメント生成 (product.md, structure.md, tech.md, codemaps/){{else if eq .ConversationLanguage "zh"}}生成项目文档 (product.md, structure.md, tech.md, codemaps/){{else}}Generate project documentation (product.md, structure.md, tech.md, codemaps/){{end}}
+allowed-tools: Skill
 ---
 
 Use Skill("moai") with arguments: project $ARGUMENTS

--- a/internal/template/templates/.claude/commands/moai/review.md.tmpl
+++ b/internal/template/templates/.claude/commands/moai/review.md.tmpl
@@ -1,6 +1,7 @@
 ---
 description: {{if eq .ConversationLanguage "ko"}}보안 및 @MX 태그 준수 확인을 포함한 코드 리뷰{{else if eq .ConversationLanguage "ja"}}セキュリティと@MXタグ準拠チェックを含むコードレビュー{{else if eq .ConversationLanguage "zh"}}包含安全性和@MX标签合规检查的代码审查{{else}}Code review with security and @MX tag compliance check{{end}}
 argument-hint: "[--staged] [--branch] [--security]"
+allowed-tools: Skill
 ---
 
 Use Skill("moai") with arguments: review $ARGUMENTS

--- a/internal/template/templates/.claude/commands/moai/run.md.tmpl
+++ b/internal/template/templates/.claude/commands/moai/run.md.tmpl
@@ -1,6 +1,7 @@
 ---
 description: {{if eq .ConversationLanguage "ko"}}DDD/TDD 방법론으로 SPEC 요구사항 구현{{else if eq .ConversationLanguage "ja"}}DDD/TDD手法でSPEC要件を実装{{else if eq .ConversationLanguage "zh"}}使用DDD/TDD方法论实现SPEC需求{{else}}Implement SPEC requirements using DDD/TDD methodology{{end}}
 argument-hint: "SPEC-XXX [--team] [--resume SPEC-XXX]"
+allowed-tools: Skill
 ---
 
 Use Skill("moai") with arguments: run $ARGUMENTS

--- a/internal/template/templates/.claude/commands/moai/sync.md.tmpl
+++ b/internal/template/templates/.claude/commands/moai/sync.md.tmpl
@@ -1,6 +1,7 @@
 ---
 description: {{if eq .ConversationLanguage "ko"}}문서, 코드맵 동기화 및 풀 리퀘스트 생성{{else if eq .ConversationLanguage "ja"}}ドキュメント、コードマップの同期とプルリクエスト作成{{else if eq .ConversationLanguage "zh"}}同步文档、代码映射并创建拉取请求{{else}}Synchronize documentation, codemaps, and create pull request{{end}}
 argument-hint: "[SPEC-XXX] [--merge] [--skip-mx]"
+allowed-tools: Skill
 ---
 
 Use Skill("moai") with arguments: sync $ARGUMENTS

--- a/internal/template/templates/.claude/skills/moai-docs-generation/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-docs-generation/SKILL.md
@@ -7,7 +7,7 @@ description: >
   documentation workflows.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read, Write, Edit, Grep, Glob, Bash(npm:*), Bash(npx:*), Bash(git:*), Bash(sphinx-build:*), Bash(mkdocs:*), Bash(typedoc:*), mcp__context7__resolve-library-id, mcp__context7__get-library-docs
+allowed-tools: Read, Write, Edit, Grep, Glob, Skill, Bash(npm:*), Bash(npx:*), Bash(git:*), Bash(sphinx-build:*), Bash(mkdocs:*), Bash(typedoc:*), mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "2.1.0"

--- a/internal/template/templates/.claude/skills/moai-domain-frontend/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-domain-frontend/SKILL.md
@@ -7,7 +7,7 @@ description: >
   integrating state management.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Grep Glob mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Grep, Glob, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "2.1.0"

--- a/internal/template/templates/.claude/skills/moai-domain-uiux/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-domain-uiux/SKILL.md
@@ -6,7 +6,7 @@ description: >
   systems, WCAG compliance, ARIA patterns, or dark mode theming.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Grep Glob mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Grep, Glob, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "3.1.0"

--- a/internal/template/templates/.claude/skills/moai-formats-data/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-formats-data/SKILL.md
@@ -7,7 +7,7 @@ description: >
   serialization.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Write Edit Grep Glob mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Write, Edit, Grep, Glob, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "2.0.0"

--- a/internal/template/templates/.claude/skills/moai-foundation-cc/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-foundation-cc/SKILL.md
@@ -6,7 +6,7 @@ description: >
   Use when creating Claude Code extensions or configuring Claude Code features.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Write Edit Grep Glob mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Write, Edit, Grep, Glob, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "5.0.0"

--- a/internal/template/templates/.claude/skills/moai-foundation-context/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-foundation-context/SKILL.md
@@ -6,7 +6,7 @@ description: >
   budget management, context limits, or session handoff across agents.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Grep Glob mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Grep, Glob, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "3.1.0"

--- a/internal/template/templates/.claude/skills/moai-foundation-core/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-foundation-core/SKILL.md
@@ -6,7 +6,7 @@ description: >
   and agent catalog reference. Use when referencing TRUST 5 gates or SPEC workflow.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Grep Glob mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Grep, Glob, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "2.5.0"

--- a/internal/template/templates/.claude/skills/moai-foundation-philosopher/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-foundation-philosopher/SKILL.md
@@ -6,7 +6,7 @@ description: >
   Use for architecture decisions or root cause analysis.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Grep Glob mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Grep, Glob, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 effort: high
 user-invocable: false
 metadata:

--- a/internal/template/templates/.claude/skills/moai-foundation-quality/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-foundation-quality/SKILL.md
@@ -6,7 +6,7 @@ description: >
   gate checks, or TRUST 5 compliance.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Grep Glob mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Grep, Glob, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "2.2.0"

--- a/internal/template/templates/.claude/skills/moai-foundation-thinking/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-foundation-thinking/SKILL.md
@@ -6,7 +6,7 @@ description: >
   Use when generating ideas or evaluating proposals.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Grep Glob
+allowed-tools: Read, Grep, Glob
 user-invocable: false
 metadata:
   version: "1.0.0"

--- a/internal/template/templates/.claude/skills/moai-framework-electron/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-framework-electron/SKILL.md
@@ -6,7 +6,7 @@ description: >
   Electron Forge. Use when building cross-platform desktop applications.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Grep Glob mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Grep, Glob, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "2.0.0"

--- a/internal/template/templates/.claude/skills/moai-library-mermaid/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-library-mermaid/SKILL.md
@@ -5,7 +5,7 @@ description: >
   creating architecture diagrams, flowcharts, sequence diagrams, or visual documentation.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Grep Glob Bash(npx:*) Bash(mmdc:*) mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Grep, Glob, Bash(npx:*), Bash(mmdc:*), mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "7.1.0"

--- a/internal/template/templates/.claude/skills/moai-library-nextra/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-library-nextra/SKILL.md
@@ -5,7 +5,7 @@ description: >
   sites, knowledge bases, or API reference documentation.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Write Edit Grep Glob mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Write, Edit, Grep, Glob, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "2.2.0"

--- a/internal/template/templates/.claude/skills/moai-library-shadcn/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-library-shadcn/SKILL.md
@@ -7,7 +7,7 @@ description: >
   systems, CLI workflows, or registry authoring with shadcn/ui.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Grep Glob mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Grep, Glob, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "3.0.0"

--- a/internal/template/templates/.claude/skills/moai-platform-auth/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-platform-auth/SKILL.md
@@ -6,7 +6,7 @@ description: >
   passkeys, WebAuthn, social login, or security features.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Write Edit Grep Glob Bash(npm:*) Bash(npx:*) Bash(firebase:*) Bash(curl:*) WebFetch WebSearch mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Write, Edit, Grep, Glob, Bash(npm:*), Bash(npx:*), Bash(firebase:*), Bash(curl:*), WebFetch, WebSearch, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "2.0.0"

--- a/internal/template/templates/.claude/skills/moai-platform-chrome-extension/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-platform-chrome-extension/SKILL.md
@@ -6,7 +6,7 @@ description: >
   and Chrome Web Store publishing. Use when building browser extensions.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Grep Glob Bash(npm:*) Bash(npx:*) Bash(node:*) WebFetch WebSearch mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Grep, Glob, Bash(npm:*), Bash(npx:*), Bash(node:*), WebFetch, WebSearch, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "1.0.0"

--- a/internal/template/templates/.claude/skills/moai-platform-database-cloud/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-platform-database-cloud/SKILL.md
@@ -6,7 +6,7 @@ description: >
   Use when choosing or setting up cloud databases.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Write Bash(psql:*) Bash(npm:*) Bash(npx:*) Bash(neonctl:*) Bash(firebase:*) Bash(supabase:*) Grep Glob mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Write, Bash(psql:*), Bash(npm:*), Bash(npx:*), Bash(neonctl:*), Bash(firebase:*), Bash(supabase:*), Grep, Glob, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "2.0.0"

--- a/internal/template/templates/.claude/skills/moai-platform-deployment/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-platform-deployment/SKILL.md
@@ -5,6 +5,8 @@ description: >
   Use when deploying applications, configuring edge functions, setting up continuous
   deployment, or managing serverless infrastructure.
 license: Apache-2.0
+user-invocable: false
+allowed-tools: Read, Write, Edit, Grep, Glob, Bash(npm:*), Bash(npx:*), Bash(docker:*), Bash(git:*), WebFetch, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 metadata:
   version: "2.0.0"
   category: "platform"
@@ -24,9 +26,6 @@ triggers:
   keywords: ["deploy", "deployment", "hosting", "vercel", "railway", "convex", "edge functions", "containers", "docker", "serverless", "real-time", "preview deployment", "continuous deployment"]
   agents: ["expert-devops", "expert-backend", "expert-frontend"]
   phases: ["run", "sync"]
-
-user-invocable: false
-allowed-tools: Read, Write, Edit, Grep, Glob, Bash(npm:*), Bash(npx:*), Bash(docker:*), Bash(git:*), WebFetch, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 ---
 
 # Deployment Platform Specialist

--- a/internal/template/templates/.claude/skills/moai-tool-ast-grep/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-tool-ast-grep/SKILL.md
@@ -6,7 +6,7 @@ description: >
   languages. Use for structural search or codemod operations.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Grep Glob Bash(sg:*) Bash(ast-grep:*) mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Grep, Glob, Bash(sg:*), Bash(ast-grep:*), mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "1.2.0"

--- a/internal/template/templates/.claude/skills/moai-tool-svg/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-tool-svg/SKILL.md
@@ -6,7 +6,7 @@ description: >
   visualizations, or adding SVG animations.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Grep Glob Bash(svgo:*) Bash(npx:*) WebFetch
+allowed-tools: Read, Grep, Glob, Bash(svgo:*), Bash(npx:*), WebFetch
 user-invocable: false
 metadata:
   version: "1.0.0"

--- a/internal/template/templates/.claude/skills/moai-workflow-ddd/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-ddd/SKILL.md
@@ -6,7 +6,7 @@ description: >
   legacy code or reducing technical debt safely.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Write Edit Bash(git:*) Bash(pytest:*) Bash(ruff:*) Bash(npm:*) Bash(npx:*) Bash(node:*) Bash(uv:*) Bash(make:*) Bash(cargo:*) Bash(go:*) Bash(mix:*) Bash(bundle:*) Grep Glob mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Write, Edit, Bash(git:*), Bash(pytest:*), Bash(ruff:*), Bash(npm:*), Bash(npx:*), Bash(node:*), Bash(uv:*), Bash(make:*), Bash(cargo:*), Bash(go:*), Bash(mix:*), Bash(bundle:*), Grep, Glob, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "1.0.0"

--- a/internal/template/templates/.claude/skills/moai-workflow-jit-docs/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-jit-docs/SKILL.md
@@ -6,7 +6,7 @@ description: >
   context. Use when users need specific documentation on demand.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Grep Glob WebFetch WebSearch mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Grep, Glob, WebFetch, WebSearch, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "3.0.0"

--- a/internal/template/templates/.claude/skills/moai-workflow-loop/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-loop/SKILL.md
@@ -7,7 +7,7 @@ description: >
   workflows.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Write Edit Bash Grep Glob mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Write, Edit, Bash, Grep, Glob, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 effort: low
 user-invocable: false
 metadata:

--- a/internal/template/templates/.claude/skills/moai-workflow-loop/references/examples.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-loop/references/examples.md
@@ -500,7 +500,18 @@ def generate_hook_output(state: dict, complete: bool, reason: str | None) -> dic
 
 ## LSP Diagnostics Examples
 
-### Python Diagnostics (Pyright)
+The three samples below are **illustrative only**. Ralph treats all 16
+MoAI-supported languages equally (C++, C#, Elixir, Flutter, Go, Java,
+JavaScript, Kotlin, PHP, Python, R, Ruby, Rust, Scala, Swift, TypeScript).
+The same diagnostic collection, classification, and fix patterns apply
+uniformly regardless of language. These three samples were chosen for
+their concise demonstration of common LSP diagnostic categories: type
+errors (Sample 1), deprecated imports (Sample 2), and unused variables
+(Sample 3). Per CLAUDE.local.md Section 22 (Template Language Neutrality),
+no language receives priority over another; for the complete
+language-to-server mapping table, see `references/reference.md`.
+
+### Sample 1: Type Error (illustrated with Python + Pyright)
 
 **Type Errors:**
 
@@ -547,7 +558,7 @@ from typing import Dict  # Error: Use dict instead (PEP 585)
 from typing import TYPE_CHECKING
 ```
 
-### TypeScript Diagnostics (tsserver)
+### Sample 2: Type Mismatch (illustrated with TypeScript + tsserver)
 
 **Type Mismatches:**
 
@@ -580,7 +591,7 @@ function getUser(id: number): User {
 }
 ```
 
-### Go Diagnostics (gopls)
+### Sample 3: Unused Variable (illustrated with Go + gopls)
 
 **Unused Variables:**
 

--- a/internal/template/templates/.claude/skills/moai-workflow-project/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-project/SKILL.md
@@ -7,7 +7,7 @@ description: >
   or optimizing templates.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Write Edit Bash(git:*) Bash(npm:*) Bash(npx:*) Bash(uv:*) Bash(pip:*) Bash(ls:*) Bash(mkdir:*) Grep Glob mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Write, Edit, Bash(git:*), Bash(npm:*), Bash(npx:*), Bash(uv:*), Bash(pip:*), Bash(ls:*), Bash(mkdir:*), Grep, Glob, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "2.0.0"

--- a/internal/template/templates/.claude/skills/moai-workflow-spec/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-spec/SKILL.md
@@ -6,7 +6,7 @@ description: >
   documents or defining acceptance criteria.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Write Edit Bash(git:*) Bash(ls:*) Bash(wc:*) Bash(mkdir:*) Grep Glob mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Write, Edit, Bash(git:*), Bash(ls:*), Bash(wc:*), Bash(mkdir:*), Grep, Glob, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "1.2.0"

--- a/internal/template/templates/.claude/skills/moai-workflow-tdd/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-tdd/SKILL.md
@@ -7,7 +7,7 @@ description: >
   implementation.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Write Edit Bash(pytest:*) Bash(ruff:*) Bash(npm:*) Bash(npx:*) Bash(node:*) Bash(jest:*) Bash(vitest:*) Bash(go:*) Bash(cargo:*) Bash(mix:*) Bash(uv:*) Bash(bundle:*) Bash(php:*) Bash(phpunit:*) Grep Glob mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Write, Edit, Bash(pytest:*), Bash(ruff:*), Bash(npm:*), Bash(npx:*), Bash(node:*), Bash(jest:*), Bash(vitest:*), Bash(go:*), Bash(cargo:*), Bash(mix:*), Bash(uv:*), Bash(bundle:*), Bash(php:*), Bash(phpunit:*), Grep, Glob, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "1.0.0"

--- a/internal/template/templates/.claude/skills/moai-workflow-templates/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-templates/SKILL.md
@@ -6,7 +6,7 @@ description: >
   boilerplate files, or managing scaffolding.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Write Edit Grep Glob mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Write, Edit, Grep, Glob, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "3.1.0"

--- a/internal/template/templates/.claude/skills/moai-workflow-testing/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-testing/SKILL.md
@@ -6,7 +6,7 @@ description: >
   assurance. Use when writing tests or measuring coverage.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Write Edit Bash(pytest:*) Bash(ruff:*) Bash(npm:*) Bash(npx:*) Bash(node:*) Bash(jest:*) Bash(vitest:*) Bash(go:*) Bash(cargo:*) Bash(mix:*) Bash(uv:*) Bash(bundle:*) Bash(php:*) Bash(phpunit:*) Grep Glob mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Write, Edit, Bash(pytest:*), Bash(ruff:*), Bash(npm:*), Bash(npx:*), Bash(node:*), Bash(jest:*), Bash(vitest:*), Bash(go:*), Bash(cargo:*), Bash(mix:*), Bash(uv:*), Bash(bundle:*), Bash(php:*), Bash(phpunit:*), Grep, Glob, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "2.4.0"

--- a/internal/template/templates/.claude/skills/moai-workflow-worktree/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-worktree/SKILL.md
@@ -6,7 +6,7 @@ description: >
   setting up parallel development environments.
 license: Apache-2.0
 compatibility: Designed for Claude Code
-allowed-tools: Read Write Grep Glob mcp__context7__resolve-library-id mcp__context7__get-library-docs
+allowed-tools: Read, Write, Grep, Glob, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 user-invocable: false
 metadata:
   version: "1.1.0"

--- a/internal/template/templates/.claude/skills/moai/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai/SKILL.md
@@ -5,7 +5,7 @@ description: >
   language or subcommands (plan, run, sync, fix, loop, mx, project,
   feedback, review, clean, codemaps, coverage, e2e) to specialized
   agents.
-allowed-tools: Agent, AskUserQuestion, TaskCreate, TaskUpdate, TaskList, TaskGet, Bash, Read, Write, Edit, Glob, Grep
+allowed-tools: Agent, AskUserQuestion, Skill, TaskCreate, TaskUpdate, TaskList, TaskGet, Bash, Read, Write, Edit, Glob, Grep
 argument-hint: "[subcommand] [args] | \"natural language task\""
 ---
 

--- a/internal/template/templates/.claude/skills/moai/workflows/fix.md
+++ b/internal/template/templates/.claude/skills/moai/workflows/fix.md
@@ -116,7 +116,7 @@ Normalize all scanner output into a unified issue record format regardless of la
 
 This normalization enables language-agnostic fix agents to work without language-specific logic.
 
-Language auto-detection uses indicator files: pyproject.toml (Python), package.json (TypeScript/JavaScript), go.mod (Go), Cargo.toml (Rust). Supports 16 languages.
+Language auto-detection uses indicator files and covers all 16 MoAI-supported languages equally (C++, C#, Elixir, Flutter, Go, Java, JavaScript, Kotlin, PHP, Python, R, Ruby, Rust, Scala, Swift, TypeScript). Each language has its own marker files (for example `go.mod` for Go, `pyproject.toml` for Python, `tsconfig.json` for TypeScript, `Cargo.toml` for Rust, `pubspec.yaml` for Flutter); the scanner inspects project root and activates the corresponding toolchain. See `.claude/skills/moai/workflows/sync.md` Phase 0.6.1 for the complete Language Detection table.
 
 Error handling: If any scanner fails, continue with results from successful scanners. Note the failed scanner in the report.
 

--- a/internal/template/templates/.claude/skills/moai/workflows/loop.md
+++ b/internal/template/templates/.claude/skills/moai/workflows/loop.md
@@ -197,24 +197,28 @@ Resume commands:
 
 Test runner and coverage tool selection is based on auto-detected project language:
 
-| Language | Indicator File | Test Command | Coverage Command |
-|----------|---------------|--------------|--------------------|
-| Go | go.mod | `go test ./...` | `go test -cover ./...` |
-| Python | pyproject.toml / setup.py | `pytest --tb=short` | `coverage run -m pytest` |
-| TypeScript/JavaScript | package.json | `npm test` or `jest` | `npm run coverage` or `c8` |
-| Rust | Cargo.toml | `cargo test` | `cargo tarpaulin` |
-| Java (Maven) | pom.xml | `mvn test -q` | `mvn jacoco:report` |
-| Java (Gradle) | build.gradle | `gradle test -q` | `gradle jacocoTestReport` |
-| Kotlin | build.gradle.kts | `gradle test -q` | `gradle jacocoTestReport` |
-| C# | *.csproj | `dotnet test` | `dotnet test --collect:"XPlat Code Coverage"` |
-| Ruby | Gemfile | `bundle exec rspec` or `bundle exec rake test` | `simplecov` (via .simplecov config) |
-| PHP | composer.json | `vendor/bin/phpunit` | `vendor/bin/phpunit --coverage-text` |
-| Scala | build.sbt | `sbt test` | `sbt coverage test coverageReport` |
-| Elixir | mix.exs | `mix test` | `mix test --cover` |
-| Swift | Package.swift | `swift test` | `swift test --enable-code-coverage` |
-| Flutter/Dart | pubspec.yaml | `flutter test` or `dart test` | `flutter test --coverage` |
-| R | DESCRIPTION | `Rscript -e 'testthat::test_package(".")'` | `covr::package_coverage()` |
-| C++ | CMakeLists.txt | `ctest --test-dir build` | `gcov`/`lcov` (if configured) |
+All 16 MoAI-supported languages are listed alphabetically with equal
+priority. Per CLAUDE.local.md Section 22, no language receives PRIMARY
+or SECONDARY classification.
+
+| Language   | Indicator File           | Test Command                                          | Coverage Command                                  |
+|------------|--------------------------|-------------------------------------------------------|---------------------------------------------------|
+| C#         | `*.csproj`               | `dotnet test`                                         | `dotnet test --collect:"XPlat Code Coverage"`     |
+| C++        | `CMakeLists.txt`         | `ctest --test-dir build`                              | `gcov` / `lcov` (if configured)                   |
+| Elixir     | `mix.exs`                | `mix test`                                            | `mix test --cover`                                |
+| Flutter    | `pubspec.yaml`           | `flutter test` or `dart test`                         | `flutter test --coverage`                         |
+| Go         | `go.mod`                 | `go test ./...`                                       | `go test -cover ./...`                            |
+| Java       | `pom.xml` / `build.gradle` | `mvn test -q` (Maven) / `gradle test -q` (Gradle)  | `mvn jacoco:report` / `gradle jacocoTestReport`   |
+| JavaScript | `package.json`           | `npm test` or `jest`                                  | `npm run coverage` or `c8`                        |
+| Kotlin     | `build.gradle.kts`       | `gradle test -q`                                      | `gradle jacocoTestReport`                         |
+| PHP        | `composer.json`          | `vendor/bin/phpunit`                                  | `vendor/bin/phpunit --coverage-text`              |
+| Python     | `pyproject.toml` / `setup.py` | `pytest --tb=short`                              | `coverage run -m pytest`                          |
+| R          | `DESCRIPTION`            | `Rscript -e 'testthat::test_package(".")'`            | `covr::package_coverage()`                        |
+| Ruby       | `Gemfile`                | `bundle exec rspec` or `bundle exec rake test`        | `simplecov` (via `.simplecov` config)             |
+| Rust       | `Cargo.toml`             | `cargo test`                                          | `cargo tarpaulin`                                 |
+| Scala      | `build.sbt`              | `sbt test`                                            | `sbt coverage test coverageReport`                |
+| Swift      | `Package.swift`          | `swift test`                                          | `swift test --enable-code-coverage`               |
+| TypeScript | `tsconfig.json` / `package.json` | `npm test` or `jest`                          | `npm run coverage` or `c8`                        |
 
 Language detection priority: Check for indicator files in project root. If multiple present, prefer the one with the most associated source files. If detection fails, prompt user to specify language.
 

--- a/internal/template/templates/.claude/skills/moai/workflows/mx.md
+++ b/internal/template/templates/.claude/skills/moai/workflows/mx.md
@@ -94,7 +94,7 @@ For tag types, lifecycle rules, mandatory fields, and per-file limits, see: .cla
    | C++ | CMakeLists.txt, Makefile (with C++) | `//` |
    | Scala | build.sbt, build.sc | `//` |
    | R | DESCRIPTION, .Rproj, renv.lock | `#` |
-   | Flutter/Dart | pubspec.yaml | `//` |
+   | Flutter | pubspec.yaml | `//` |
    | Swift | Package.swift, .xcodeproj | `//` |
 
 2. **Project Context Loading**


### PR DESCRIPTION
## Summary

PR #627(1차 감사 5건 시정) 병합 직후 수행한 **2차 광범위 감사**에서 발견된 **4건의 추가 Section 22 위반**을 일괄 시정합니다.

## Audit 2차 — 발견 내역 (V6-V10)

| # | 파일 | Issue | Severity |
|---|---|---|---|
| **V6** | `moai/workflows/loop.md` | Language-Specific Commands 테이블에서 TS/JS 병합, Java를 Maven/Gradle로 분할 → 16행이지만 실제 15개 언어 | MINOR |
| **V7** | `moai/workflows/fix.md` | "Supports 16 languages" 주장하지만 4개만 예시 (Python, TS/JS, Go, Rust) | MINOR |
| **V8** | `moai/workflows/mx.md` | "Flutter/Dart" 명칭 (캐논 "Flutter") | TRIVIAL |
| **V9** | `moai-workflow-loop/references/examples.md` | "LSP Diagnostics Examples" 섹션이 3개 언어만 (Python, TypeScript, Go) | **MODERATE** |
| V10 | `claude-code-discover-plugins-official.md` | 8개 언어 플러그인만 | **SKIPPED** (서술적 외부 reference) |

## Healthy (2차 감사 통과)

- `CLAUDE.md` 템플릿 — 언어 편향 없음
- `.claude/agents/` — Go 편향 없음
- `run.md`, `sync.md` — 캐논 소스
- `mx.yaml` — 16개 언어 동등 스키마
- `.claude/rules/moai/languages/` — 16 파일
- PR #627 수정 대상 5건 — 이미 시정됨

## Fixes (F6-F9)

### F6: loop.md Language-Specific Commands 재구성
- 16개 언어 알파벳 순 (C#, C++, Elixir, Flutter, Go, Java, JavaScript, Kotlin, PHP, Python, R, Ruby, Rust, Scala, Swift, TypeScript)
- TypeScript와 JavaScript 분리 (2행)
- Java 1행 통합 (테스트 커맨드에 Maven/Gradle 병기)
- Section 22 도입 안내 추가

### F7: fix.md 언어 예시 중립화
- "pyproject.toml (Python), package.json (TypeScript/JavaScript), go.mod (Go), Cargo.toml (Rust)" (4개) → 16개 언어 모두 명시 + 대표 marker 예시 + sync.md 참조

### F8: mx.md Flutter 명칭 통일
- "Flutter/Dart" → "Flutter"

### F9: examples.md LSP 섹션 중립화
- 3개 언어 "Python/TypeScript/Go Diagnostics" 제목 → "Sample 1/2/3 (illustrated with ...)" 형식
- 섹션 도입부에 16개 언어 동등 취급 명시적 선언 + reference.md 링크

## 의도적 스킵

**V10 (`claude-code-discover-plugins-official.md`)**: Claude Code 공식 플러그인 생태계를 서술하는 reference 파일. Moai의 큐레이션이 아닌 외부 사실 전달 목적이므로 위반 아님으로 판정.

## Files

| 파일 | Lines |
|---|---|
| `moai/workflows/loop.md` | +21/-18 |
| `moai/workflows/fix.md` | +1/-1 |
| `moai/workflows/mx.md` | +1/-1 |
| `moai-workflow-loop/references/examples.md` | +15/-3 |

## Test plan

- [x] make build — 통과
- [x] 4개 파일 명시적 staging
- [x] V6-V9 모두 시정 확인
- [ ] CI: cross-compile + race detector
- [ ] Manual verification

## 감사 연쇄 효과 누적

| Round | PR | 시정 건수 | 파일 |
|---|---|---|---|
| 0차 (규칙 확립) | #625 | Section 22 신설 | CLAUDE.local.md |
| 1차 | #627 | 5건 (V1-V5) | reference.md, SKILL.md, project.md, CLAUDE.local.md, lsp.yaml.tmpl |
| **2차 (본 PR)** | **#628** | **4건 (V6-V9)** | loop.md, fix.md, mx.md, examples.md |
| **누적** | — | **9건** | — |

🗿 MoAI <email@mo.ai.kr>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Skill tool capability to multiple agency and project management commands.

* **Documentation**
  * Enhanced language coverage documentation across project workflows, explicitly listing all 16 supported programming languages.
  * Updated tool permission guidelines to enforce consistent formatting standards.
  * Improved workflow documentation with clearer language detection and toolchain activation details.

* **Chores**
  * Standardized tool declarations across command and skill configurations.
  * Updated command metadata for improved tool access control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->