### PR TITLE
fix(statusline): skip usage collector when stdin rate_limits present (#646)

### DIFF
--- a/internal/statusline/builder.go
+++ b/internal/statusline/builder.go
@@ -248,8 +248,11 @@ func (b *defaultBuilder) collectAll(ctx context.Context, input *StdinData) *Stat
 		})
 	}
 
-	// API usage collection (Phase 5, REQ-V3-API-001)
-	if b.usageProvider != nil {
+	// API usage collection (Phase 5, REQ-V3-API-001).
+	// Skip when Claude Code (2.1.80+) already provided rate_limits via stdin:
+	// the blocking Anthropic OAuth API call (5s timeout) caused the statusline to
+	// intermittently exceed Claude Code's render budget and disappear. See issue #646.
+	if b.usageProvider != nil && (input == nil || input.RateLimits == nil) {
 		wg.Go(func() {
 			result, err := b.usageProvider.CollectUsage(ctx)
 			if err != nil {

--- a/internal/statusline/builder_test.go
+++ b/internal/statusline/builder_test.go
@@ -513,11 +513,13 @@ func TestBuilderCollectsTask_FieldExists(t *testing.T) {
 
 // mockUsageProvider implements UsageProvider for testing.
 type mockUsageProvider struct {
-	data *UsageResult
-	err  error
+	data  *UsageResult
+	err   error
+	calls int
 }
 
 func (m *mockUsageProvider) CollectUsage(_ context.Context) (*UsageResult, error) {
+	m.calls++
 	return m.data, m.err
 }
 
@@ -1164,6 +1166,71 @@ func TestBuild_RateLimitsPreferredOverUsage(t *testing.T) {
 	}
 	if strings.Contains(got, "99%") {
 		t.Errorf("output should NOT contain '99%%' from Usage when RateLimits is present, got:\n%s", got)
+	}
+}
+
+// TestBuild_SkipsUsageProviderWhenRateLimitsPresent verifies that when stdin
+// provides rate_limits (Claude Code 2.1.80+), the usage provider (which would
+// perform blocking Anthropic OAuth API calls) is not invoked at all.
+//
+// See Issue #646 — statusline intermittent disappearance caused by 5s HTTP
+// timeout on every usage collector cache miss.
+func TestBuild_SkipsUsageProviderWhenRateLimitsPresent(t *testing.T) {
+	mockUsage := &mockUsageProvider{
+		data: &UsageResult{
+			Usage5H: &UsageData{Percentage: 50},
+			Usage7D: &UsageData{Percentage: 50},
+		},
+	}
+
+	builder := New(Options{
+		Mode:          ModeDefault,
+		NoColor:       true,
+		UsageProvider: mockUsage,
+	})
+
+	inputJSON := `{
+		"rate_limits": {
+			"five_hour": {"used_percentage": 23.5, "resets_at": 1738425600},
+			"seven_day": {"used_percentage": 41.2, "resets_at": 1738857600}
+		}
+	}`
+
+	if _, err := builder.Build(context.Background(), strings.NewReader(inputJSON)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if mockUsage.calls != 0 {
+		t.Errorf("usage provider should not be called when stdin rate_limits is present, got %d calls", mockUsage.calls)
+	}
+}
+
+// TestBuild_CallsUsageProviderWhenRateLimitsAbsent verifies the usage provider
+// is still invoked when stdin does not contain rate_limits (legacy Claude Code
+// or non-Claude-Code harness).
+func TestBuild_CallsUsageProviderWhenRateLimitsAbsent(t *testing.T) {
+	mockUsage := &mockUsageProvider{
+		data: &UsageResult{
+			Usage5H: &UsageData{Percentage: 50},
+			Usage7D: &UsageData{Percentage: 50},
+		},
+	}
+
+	builder := New(Options{
+		Mode:          ModeDefault,
+		NoColor:       true,
+		UsageProvider: mockUsage,
+	})
+
+	// Stdin without rate_limits
+	inputJSON := `{"model": {"id": "claude-opus-4-6"}}`
+
+	if _, err := builder.Build(context.Background(), strings.NewReader(inputJSON)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if mockUsage.calls != 1 {
+		t.Errorf("usage provider should be called exactly once when stdin lacks rate_limits, got %d calls", mockUsage.calls)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `builder.collectAll`에서 stdin JSON에 `rate_limits`가 있으면 `usageProvider`(Anthropic OAuth API 블로킹 호출) 실행을 건너뜀
- 기존 `TestBuild_RateLimitsPreferredOverUsage`는 표시 우선순위만 검증했으나 API 호출 자체는 수행되어 statusline 간헐적 사라짐의 원인이었음
- 회귀 방어를 위해 호출 횟수 검증 테스트 2건 추가

## Root Cause (Issue #646)

`internal/statusline/usage.go:69-73`
- `ttl: 5 * time.Minute` — 캐시 5분
- `http.Client.Timeout: 5 * time.Second` — HTTP 최대 5초 대기

`internal/statusline/builder.go` (before fix)
- Claude Code 2.1.80+가 stdin으로 `rate_limits`를 제공함에도 usageCollector가 독립적으로 병렬 API 호출 수행
- 캐시 TTL 초과 시 매번 Haiku probe(POST /v1/messages) → OAuth usage endpoint(GET) 체인 → 5초 대기 가능
- 결과: statusline 응답 ~900ms 평균, 1.7s 피크 → Claude Code 렌더 예산 초과 → UI에서 사라짐

## Benchmark (before/after, 10 iterations, `/usr/bin/time -p real`)

| # | Before (ms) | After (ms) |
|---|-------------|------------|
| 1 | 973  | 500 (cold) |
| 2 | 1242 | 70 |
| 3 | 986  | 70 |
| 4 | 1834 | 70 |
| 5 | 1066 | 70 |
| 6 | 1090 | 70 |
| 7 | 1019 | 60 |
| 8 | 897  | 70 |
| 9 | 922  | 70 |
| 10| 988  | 70 |
| **avg** | **1002** | **70** (cold 제외) |

약 13배 속도 향상, 네트워크 대기 완전 제거.

## Test Plan

- [x] `go build ./...` PASS
- [x] `go test ./internal/statusline/...` 전체 PASS (신규 2건 포함)
- [x] `go test ./...` 전체 PASS
- [x] `TestBuild_SkipsUsageProviderWhenRateLimitsPresent`: stdin에 `rate_limits` 있을 때 `CollectUsage` 호출 0회 검증
- [x] `TestBuild_CallsUsageProviderWhenRateLimitsAbsent`: 구 Claude Code fallback 경로 회귀 방어
- [x] 실제 설치 후 벤치: 평균 70ms 확인
- [ ] 장기 사용 모니터링 (사라짐 현상 재현되지 않음을 수일간 확인)

## Backwards Compatibility

- stdin에 `rate_limits`가 없는 경우(구 Claude Code <2.1.80, 또는 non-Claude-Code harness) 기존 경로 유지
- API 호출, 캐시, failure cooldown 등 기존 로직 모두 보존
- 공개 API/인터페이스 변경 없음

## Scope

2 files changed, +74/-4. #646 범위 내 최소 변경만 포함.

Fixes #646

🗿 MoAI <email@mo.ai.kr>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized API usage collection to skip unnecessary provider calls when rate limit information is already supplied via stdin, reducing redundant API requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->