### PR TITLE
fix(routing): --team 플래그가 team/*.md 워크플로우를 로드하도록 수정 (#626)

### DIFF
--- a/.claude/skills/moai/SKILL.md
+++ b/.claude/skills/moai/SKILL.md
@@ -107,21 +107,21 @@ Purpose: Create comprehensive specification documents using EARS format with Res
 Phases: Deep Research (research.md) -> SPEC Planning -> Annotation Cycle (1-6 iterations) -> SPEC Creation
 Agents: manager-spec (primary), Explore (research), manager-git (conditional)
 Flags: --worktree, --branch, --resume SPEC-XXX, --team, --no-issue
-For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/plan.md
+For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/plan.md (team mode: ${CLAUDE_SKILL_DIR}/team/plan.md)
 
 ### run - DDD/TDD Implementation
 
 Purpose: Implement SPEC requirements through configured development methodology.
 Agents: manager-strategy, manager-ddd or manager-tdd (per quality.yaml), manager-quality, manager-git
 Flags: --resume SPEC-XXX, --team
-For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/run.md
+For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/run.md (team mode: ${CLAUDE_SKILL_DIR}/team/run.md)
 
 ### sync - Documentation Sync and PR
 
 Purpose: Synchronize documentation with code changes and prepare pull requests.
 Agents: manager-docs (primary), manager-quality, manager-git
 Modes: auto, force, status, project. Flags: --merge, --skip-mx
-For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/sync.md
+For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/sync.md (team mode: ${CLAUDE_SKILL_DIR}/team/sync.md)
 
 ### gate - Pre-Commit Quality Gate
 
@@ -255,7 +255,7 @@ All AskUserQuestion calls throughout MoAI workflows MUST follow these rules:
 - Every option MUST include a detailed description explaining what it does and its implications
 
 Step 3 - Load Workflow Details:
-Read the corresponding workflows/<name>.md file for detailed orchestration instructions.
+If `--team` flag was parsed AND `${CLAUDE_SKILL_DIR}/team/<name>.md` exists for the target subcommand, read the team workflow file instead of the solo workflow. Otherwise read `workflows/<name>.md`. The Quick Reference section above shows both paths for each subcommand that supports team mode.
 
 Step 4 - Read Configuration:
 Load relevant configuration from .moai/config/config.yaml and section files as needed.

--- a/internal/template/templates/.claude/skills/moai/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai/SKILL.md
@@ -107,21 +107,21 @@ Purpose: Create comprehensive specification documents using EARS format with Res
 Phases: Deep Research (research.md) -> SPEC Planning -> Annotation Cycle (1-6 iterations) -> SPEC Creation
 Agents: manager-spec (primary), Explore (research), manager-git (conditional)
 Flags: --worktree, --branch, --resume SPEC-XXX, --team, --no-issue
-For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/plan.md
+For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/plan.md (team mode: ${CLAUDE_SKILL_DIR}/team/plan.md)
 
 ### run - DDD/TDD Implementation
 
 Purpose: Implement SPEC requirements through configured development methodology.
 Agents: manager-strategy, manager-ddd or manager-tdd (per quality.yaml), manager-quality, manager-git
 Flags: --resume SPEC-XXX, --team
-For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/run.md
+For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/run.md (team mode: ${CLAUDE_SKILL_DIR}/team/run.md)
 
 ### sync - Documentation Sync and PR
 
 Purpose: Synchronize documentation with code changes and prepare pull requests.
 Agents: manager-docs (primary), manager-quality, manager-git
 Modes: auto, force, status, project. Flags: --merge, --skip-mx
-For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/sync.md
+For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/sync.md (team mode: ${CLAUDE_SKILL_DIR}/team/sync.md)
 
 ### gate - Pre-Commit Quality Gate
 
@@ -255,7 +255,7 @@ All AskUserQuestion calls throughout MoAI workflows MUST follow these rules:
 - Every option MUST include a detailed description explaining what it does and its implications
 
 Step 3 - Load Workflow Details:
-Read the corresponding workflows/<name>.md file for detailed orchestration instructions.
+If `--team` flag was parsed AND `${CLAUDE_SKILL_DIR}/team/<name>.md` exists for the target subcommand, read the team workflow file instead of the solo workflow. Otherwise read `workflows/<name>.md`. The Quick Reference section above shows both paths for each subcommand that supports team mode.
 
 Step 4 - Read Configuration:
 Load relevant configuration from .moai/config/config.yaml and section files as needed.
@@ -282,3 +282,42 @@ Use AskUserQuestion to present the user with logical next actions based on the c
 
 Version: 2.6.0
 Last Updated: 2026-02-25
+
+<!-- moai:evolvable-start id="rationalizations" -->
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "I will just implement this directly, delegation is overhead" | MoAI is an orchestrator. Direct implementation bypasses the quality gates agents enforce. |
+| "The user's intent is obvious, no need for a Socratic interview" | Ambiguous verbs (clean, fix, improve) almost always produce wrong scope. Rule 5 exists because obvious is often wrong. |
+| "This is a small change, Approach-First is unnecessary" | Small changes still touch files the user cares about. One sentence of approach costs nothing and prevents rework. |
+| "I can run /moai run without a SPEC, it is just a tweak" | Without a SPEC, there is no acceptance criterion to check. Every run without a SPEC silently degrades quality tracking. |
+| "Parallel agents will just race, sequential is safer" | Independent tool calls are explicitly required to run in parallel. Sequentializing them wastes user time. |
+| "I will respond in English since it is technical" | Conversation language is a HARD rule. User-facing output must match the configured language, always. |
+
+<!-- moai:evolvable-end -->
+
+<!-- moai:evolvable-start id="red-flags" -->
+## Red Flags
+
+- MoAI writes code directly instead of delegating to a specialized agent
+- Response in English when conversation_language is not English
+- Multiple independent tool calls executed sequentially in separate messages
+- AskUserQuestion with more than 4 options or containing emoji
+- Agent invocation prompt contains absolute paths to the main project when isolation is worktree
+- /moai run executed without a corresponding SPEC-XXX document
+
+<!-- moai:evolvable-end -->
+
+<!-- moai:evolvable-start id="verification" -->
+## Verification
+
+- [ ] User-facing response language matches conversation_language from language.yaml
+- [ ] Every independent tool call was launched in parallel (one message, multiple tool blocks)
+- [ ] Agent selection trace documents why this agent, not another, was chosen
+- [ ] No XML tags visible in user-facing output
+- [ ] For non-trivial tasks, approach was explained and approved before code changes
+- [ ] SPEC-ID is referenced when /moai run, /moai sync, or /moai fix is invoked
+- [ ] TodoList used to decompose multi-file changes (3+ files)
+
+<!-- moai:evolvable-end -->


### PR DESCRIPTION
## Summary

PR #635에서 분리된 첫 번째 PR. **#626 라우팅 결함 fix만** 포함. astgrep / gopls 구현은 별도 PR로 분리됨.

`.claude/skills/moai/SKILL.md` Step 3에서 `--team` 플래그 파싱 시 `team/<name>.md` 경로를 우선 로드하는 조건 추가. Quick Reference의 plan/run/sync 서브커맨드에 `(team mode: ...)` 경로 명시.

## Changes

- `.claude/skills/moai/SKILL.md` (8 lines)
- `internal/template/templates/.claude/skills/moai/SKILL.md` (47 lines)

총 2 파일, +47/-8.

## Test Plan

- [ ] `/moai run SPEC-XXX --team` 실행 시 `team/run.md` 로드 확인
- [ ] `/moai plan "task" --team` 실행 시 `team/plan.md` 로드 확인
- [ ] `/moai sync --team` 실행 시 `team/sync.md` 로드 확인
- [ ] `--solo` 또는 플래그 없는 경우 기존 `workflows/<name>.md` 로드 확인

## Background — PR #635 Split

원래 PR #635는 #626 fix(routing) + SPEC-ASTG-UPGRADE-001 + SPEC-GOPLS-BRIDGE-001 + 기타가 번들링되어 있어 (107파일 +6028/-911) 3-perspective 리뷰에서 CRITICAL scope creep로 분류됨 (#641 meta 이슈).

본 PR은 그 split의 첫 결과로, **순수 #626 fix만** 포함. 다음 2개 PR이 후속:
- `feat/astgrep-upgrade` (SPEC-ASTG-UPGRADE-001)
- `feat/gopls-bridge` (SPEC-GOPLS-BRIDGE-001)

이로써 #626는 본 PR 머지 시 즉시 종료, #641 meta 이슈는 3개 PR 모두 생성 후 종료.

Fixes #626

🗿 MoAI <email@mo.ai.kr>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for team-mode workflow orchestration selection via `--team` flag

* **Documentation**
  * Enhanced workflow documentation with conditional team-mode file loading
  * Added compliance and verification guidelines to workflow processes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->