### PR TITLE
fix(statusline): GLM 모드 컨텍스트 게이지 1M 오표시 (#653)

### DIFF
--- a/internal/config/envkeys.go
+++ b/internal/config/envkeys.go
@@ -25,6 +25,13 @@ const (
 	// EnvStatuslineMode selects the statusline display mode.
 	EnvStatuslineMode = "MOAI_STATUSLINE_MODE"
 
+	// EnvStatuslineContextSize overrides the context window size used by the
+	// statusline gauge. Useful when the upstream provider reports a context
+	// size that does not match the actual API limit (e.g., GLM models served
+	// behind the Anthropic-compatible endpoint, see issue #653).
+	// Value is parsed as int (tokens). Zero or invalid → fall back to stdin.
+	EnvStatuslineContextSize = "MOAI_STATUSLINE_CONTEXT_SIZE"
+
 	// EnvSkipBinaryUpdate skips binary self-update when set to "1".
 	EnvSkipBinaryUpdate = "MOAI_SKIP_BINARY_UPDATE"
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -80,6 +80,12 @@ type ClaudeTierModels struct {
 type GLMSettings struct {
 	BaseURL string    `yaml:"base_url"`
 	Models  GLMModels `yaml:"models"`
+	// ContextWindows maps GLM model names to their actual context window sizes
+	// (in tokens), overriding the built-in statusline table. Issue #653.
+	// Example entries: {"glm-5.1": 230000, "glm-4.5-air": 128000}.
+	// Takes precedence over the built-in glmContextWindows table in
+	// internal/statusline/memory.go but yields to MOAI_STATUSLINE_CONTEXT_SIZE.
+	ContextWindows map[string]int `yaml:"context_windows,omitempty"`
 }
 
 // GLMModels represents GLM model mappings by performance tier.

--- a/internal/statusline/memory.go
+++ b/internal/statusline/memory.go
@@ -2,10 +2,12 @@ package statusline
 
 import (
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
 	"github.com/modu-ai/moai-adk/internal/config"
+	"gopkg.in/yaml.v3"
 )
 
 // defaultAutoCompactPct is the default auto-compact trigger threshold percentage.
@@ -42,6 +44,59 @@ func getAutoCompactThreshold() int {
 	return defaultAutoCompactPct
 }
 
+// llmYAMLShape is the minimal shape needed to read
+// `llm.glm.context_windows` from .moai/config/sections/llm.yaml. Keeping a
+// local shape here avoids pulling the heavyweight config.Manager into the
+// statusline hot path.
+type llmYAMLShape struct {
+	LLM struct {
+		GLM struct {
+			ContextWindows map[string]int `yaml:"context_windows"`
+		} `yaml:"glm"`
+	} `yaml:"llm"`
+}
+
+// readLLMYAMLContextWindows reads .moai/config/sections/llm.yaml from the
+// closest ancestor directory and returns the user-configured
+// glm.context_windows map. Returns nil on any error (file missing, parse
+// error) so that the caller falls back to built-in defaults. Issue #653.
+func readLLMYAMLContextWindows() map[string]int {
+	dir, err := os.Getwd()
+	if err != nil {
+		return nil
+	}
+	for {
+		path := filepath.Join(dir, ".moai", "config", "sections", "llm.yaml")
+		if data, readErr := os.ReadFile(path); readErr == nil {
+			var shape llmYAMLShape
+			if yaml.Unmarshal(data, &shape) == nil && len(shape.LLM.GLM.ContextWindows) > 0 {
+				return shape.LLM.GLM.ContextWindows
+			}
+			return nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return nil
+		}
+		dir = parent
+	}
+}
+
+// matchContextWindow returns the largest-matching context window entry for
+// the given lowercase model name, or 0 when no entry matches. Longer keys are
+// preferred to avoid "glm-4.5" masking "glm-4.5-air".
+func matchContextWindow(model string, table map[string]int) int {
+	var matched int
+	var matchedSize int
+	for name, size := range table {
+		if strings.Contains(model, strings.ToLower(name)) && len(name) > matched {
+			matched = len(name)
+			matchedSize = size
+		}
+	}
+	return matchedSize
+}
+
 // resolveContextWindowOverride returns a non-zero context window override when
 // the user is running through GLM (or another non-Claude provider) so that the
 // memory gauge reflects the actual provider limit rather than the Claude slot's
@@ -50,8 +105,9 @@ func getAutoCompactThreshold() int {
 //
 // Resolution priority:
 //  1. MOAI_STATUSLINE_CONTEXT_SIZE env (explicit user override)
-//  2. ANTHROPIC_DEFAULT_*_MODEL env contains a known GLM model → glmContextWindows
-//  3. Return 0 (caller falls back to stdin's context_window_size)
+//  2. llm.yaml `glm.context_windows` map (project-level configuration)
+//  3. ANTHROPIC_DEFAULT_*_MODEL env matches built-in glmContextWindows table
+//  4. Return 0 (caller falls back to stdin's context_window_size)
 func resolveContextWindowOverride() int {
 	if v := os.Getenv(config.EnvStatuslineContextSize); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
@@ -59,30 +115,34 @@ func resolveContextWindowOverride() int {
 		}
 	}
 
-	// Check the three Anthropic model env slots; first match wins (any of them
-	// being non-Claude implies a non-Claude provider is active).
 	envSlots := []string{
 		config.EnvAnthropicDefaultOpusModel,
 		config.EnvAnthropicDefaultSonnetModel,
 		config.EnvAnthropicDefaultHaikuModel,
 	}
+
+	// Priority 2: project-level llm.yaml overrides.
+	userTable := readLLMYAMLContextWindows()
+	if len(userTable) > 0 {
+		for _, key := range envSlots {
+			val := strings.ToLower(strings.TrimSpace(os.Getenv(key)))
+			if val == "" || strings.HasPrefix(val, "claude") {
+				continue
+			}
+			if size := matchContextWindow(val, userTable); size > 0 {
+				return size
+			}
+		}
+	}
+
+	// Priority 3: built-in glmContextWindows table.
 	for _, key := range envSlots {
 		val := strings.ToLower(strings.TrimSpace(os.Getenv(key)))
 		if val == "" || strings.HasPrefix(val, "claude") {
 			continue
 		}
-		// Match longest known model name first to avoid "glm-4.5" matching
-		// before "glm-4.5-air".
-		var matched int
-		var matchedSize int
-		for name, size := range glmContextWindows {
-			if strings.Contains(val, name) && len(name) > matched {
-				matched = len(name)
-				matchedSize = size
-			}
-		}
-		if matchedSize > 0 {
-			return matchedSize
+		if size := matchContextWindow(val, glmContextWindows); size > 0 {
+			return size
 		}
 	}
 	return 0

--- a/internal/statusline/memory.go
+++ b/internal/statusline/memory.go
@@ -3,6 +3,7 @@ package statusline
 import (
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/modu-ai/moai-adk/internal/config"
 )
@@ -11,6 +12,24 @@ import (
 // Claude Code triggers auto-compact at approximately 80-85% of the total context window.
 // This can be overridden by the CLAUDE_AUTOCOMPACT_PCT_OVERRIDE environment variable.
 const defaultAutoCompactPct = 85
+
+// glmContextWindows maps known non-Claude (typically GLM-family) model names
+// served via the Anthropic-compatible endpoint to their actual context window
+// sizes in tokens. Claude Code reports `context_window_size` based on the
+// Claude model slot (Opus = 1M, Sonnet/Haiku = 200K), but the underlying GLM
+// model has a different limit. Issue #653.
+//
+// Entries use lowercase substring matching against the resolved model name.
+// Add entries here when a new GLM model ships; users can also override per
+// invocation via MOAI_STATUSLINE_CONTEXT_SIZE.
+var glmContextWindows = map[string]int{
+	"glm-5.1":     200_000, // GLM-5.1 (z.ai) — actual ~230K, leave headroom
+	"glm-5":       128_000,
+	"glm-4.7":     128_000,
+	"glm-4.6":     128_000,
+	"glm-4.5":     128_000,
+	"glm-4.5-air": 128_000,
+}
 
 // getAutoCompactThreshold returns the auto-compact trigger percentage.
 // Reads CLAUDE_AUTOCOMPACT_PCT_OVERRIDE env var if set, otherwise uses default.
@@ -21,6 +40,52 @@ func getAutoCompactThreshold() int {
 		}
 	}
 	return defaultAutoCompactPct
+}
+
+// resolveContextWindowOverride returns a non-zero context window override when
+// the user is running through GLM (or another non-Claude provider) so that the
+// memory gauge reflects the actual provider limit rather than the Claude slot's
+// nominal size. Issue #653 — GLM "opus" slot reported as 1M but real limit is
+// 128-230K depending on the GLM model.
+//
+// Resolution priority:
+//  1. MOAI_STATUSLINE_CONTEXT_SIZE env (explicit user override)
+//  2. ANTHROPIC_DEFAULT_*_MODEL env contains a known GLM model → glmContextWindows
+//  3. Return 0 (caller falls back to stdin's context_window_size)
+func resolveContextWindowOverride() int {
+	if v := os.Getenv(config.EnvStatuslineContextSize); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+
+	// Check the three Anthropic model env slots; first match wins (any of them
+	// being non-Claude implies a non-Claude provider is active).
+	envSlots := []string{
+		config.EnvAnthropicDefaultOpusModel,
+		config.EnvAnthropicDefaultSonnetModel,
+		config.EnvAnthropicDefaultHaikuModel,
+	}
+	for _, key := range envSlots {
+		val := strings.ToLower(strings.TrimSpace(os.Getenv(key)))
+		if val == "" || strings.HasPrefix(val, "claude") {
+			continue
+		}
+		// Match longest known model name first to avoid "glm-4.5" matching
+		// before "glm-4.5-air".
+		var matched int
+		var matchedSize int
+		for name, size := range glmContextWindows {
+			if strings.Contains(val, name) && len(name) > matched {
+				matched = len(name)
+				matchedSize = size
+			}
+		}
+		if matchedSize > 0 {
+			return matchedSize
+		}
+	}
+	return 0
 }
 
 // CollectMemory extracts context window token usage from stdin data.
@@ -39,13 +104,19 @@ func CollectMemory(input *StdinData) *MemoryData {
 
 	ctx := input.ContextWindow
 
-	// Get context window size (default 200K)
+	// Get context window size (default 200K).
+	// GLM/non-Claude providers may have a smaller real limit than the Claude
+	// slot's reported context_window_size — apply override when detected
+	// (issue #653).
 	contextSize := ctx.ContextWindowSize
 	if contextSize <= 0 {
 		contextSize = ctx.Total
 	}
 	if contextSize <= 0 {
 		contextSize = 200000 // Default context window size
+	}
+	if override := resolveContextWindowOverride(); override > 0 {
+		contextSize = override
 	}
 
 	// Scale budget to auto-compact threshold so bar shows 100% at compact point

--- a/internal/statusline/memory_test.go
+++ b/internal/statusline/memory_test.go
@@ -1,6 +1,10 @@
 package statusline
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestCollectMemory(t *testing.T) {
 	// Disable auto-compact scaling for existing tests
@@ -347,5 +351,103 @@ func TestCollectMemory_ExplicitOverride(t *testing.T) {
 	wantBudget := 131072 * 85 / 100
 	if got.TokenBudget != wantBudget {
 		t.Errorf("TokenBudget = %d, want %d (explicit override wins)", got.TokenBudget, wantBudget)
+	}
+}
+
+// TestCollectMemory_LLMYAMLOverride verifies that .moai/config/sections/llm.yaml
+// `glm.context_windows` entries take precedence over the built-in
+// glmContextWindows table when MOAI_STATUSLINE_CONTEXT_SIZE is not set.
+// Priority: env > llm.yaml > built-in table (issue #653).
+func TestCollectMemory_LLMYAMLOverride(t *testing.T) {
+	tempDir := t.TempDir()
+	sectionsDir := filepath.Join(tempDir, ".moai", "config", "sections")
+	if err := os.MkdirAll(sectionsDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	yamlBody := `llm:
+  glm:
+    context_windows:
+      glm-5.1: 230000        # user-configured override (larger than built-in 200K)
+      custom-model: 96000    # previously unknown model
+`
+	if err := os.WriteFile(filepath.Join(sectionsDir, "llm.yaml"), []byte(yamlBody), 0o644); err != nil {
+		t.Fatalf("write llm.yaml: %v", err)
+	}
+	// resolveContextWindowOverride walks from getwd() upward. t.Chdir restores
+	// the original wd at test teardown.
+	t.Chdir(tempDir)
+	t.Setenv("MOAI_STATUSLINE_CONTEXT_SIZE", "")
+	t.Setenv("ANTHROPIC_DEFAULT_SONNET_MODEL", "")
+	t.Setenv("ANTHROPIC_DEFAULT_HAIKU_MODEL", "")
+
+	cases := []struct {
+		name       string
+		glmModel   string
+		wantBudget int
+	}{
+		{
+			name:       "llm.yaml overrides built-in for glm-5.1 (200K→230K)",
+			glmModel:   "glm-5.1",
+			wantBudget: 230_000 * 85 / 100,
+		},
+		{
+			name:       "llm.yaml adds previously unknown custom-model",
+			glmModel:   "custom-model",
+			wantBudget: 96_000 * 85 / 100,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("ANTHROPIC_DEFAULT_OPUS_MODEL", tc.glmModel)
+
+			pct := 50.0
+			input := &StdinData{
+				ContextWindow: &ContextWindowInfo{
+					UsedPercentage:    &pct,
+					ContextWindowSize: 1_000_000,
+				},
+			}
+			got := CollectMemory(input)
+			if got == nil || !got.Available {
+				t.Fatalf("CollectMemory returned unavailable")
+			}
+			if got.TokenBudget != tc.wantBudget {
+				t.Errorf("TokenBudget = %d, want %d", got.TokenBudget, tc.wantBudget)
+			}
+		})
+	}
+}
+
+// TestCollectMemory_EnvOverridesLLMYAML verifies env var wins over llm.yaml.
+func TestCollectMemory_EnvOverridesLLMYAML(t *testing.T) {
+	tempDir := t.TempDir()
+	sectionsDir := filepath.Join(tempDir, ".moai", "config", "sections")
+	_ = os.MkdirAll(sectionsDir, 0o755)
+	yamlBody := `llm:
+  glm:
+    context_windows:
+      glm-5.1: 230000
+`
+	_ = os.WriteFile(filepath.Join(sectionsDir, "llm.yaml"), []byte(yamlBody), 0o644)
+
+	t.Chdir(tempDir)
+	t.Setenv("ANTHROPIC_DEFAULT_OPUS_MODEL", "glm-5.1")
+	t.Setenv("MOAI_STATUSLINE_CONTEXT_SIZE", "65536")
+
+	pct := 50.0
+	input := &StdinData{
+		ContextWindow: &ContextWindowInfo{
+			UsedPercentage:    &pct,
+			ContextWindowSize: 1_000_000,
+		},
+	}
+	got := CollectMemory(input)
+	if got == nil || !got.Available {
+		t.Fatalf("CollectMemory returned unavailable")
+	}
+	wantBudget := 65536 * 85 / 100
+	if got.TokenBudget != wantBudget {
+		t.Errorf("TokenBudget = %d, want %d (env wins over llm.yaml)", got.TokenBudget, wantBudget)
 	}
 }

--- a/internal/statusline/memory_test.go
+++ b/internal/statusline/memory_test.go
@@ -256,3 +256,96 @@ func TestUsagePercent(t *testing.T) {
 		})
 	}
 }
+
+// TestCollectMemory_GLMContextOverride verifies that when a GLM model is
+// active (via ANTHROPIC_DEFAULT_*_MODEL env), the context window size is
+// overridden from the Claude slot's reported value (e.g., 1M) to the actual
+// GLM model's limit. Issue #653.
+func TestCollectMemory_GLMContextOverride(t *testing.T) {
+	pct := 23.0 // near the reported ~23% context-full point on 1M gauge
+
+	cases := []struct {
+		name         string
+		envSlot      string
+		modelName    string
+		reportedSize int
+		wantBudget   int // expected TokenBudget (contextSize * 85 / 100)
+	}{
+		{
+			name:         "glm-5.1 opus slot overrides 1M to 200K",
+			envSlot:      "ANTHROPIC_DEFAULT_OPUS_MODEL",
+			modelName:    "glm-5.1",
+			reportedSize: 1_000_000,
+			wantBudget:   200_000 * 85 / 100,
+		},
+		{
+			name:         "glm-4.5-air haiku slot",
+			envSlot:      "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+			modelName:    "glm-4.5-air",
+			reportedSize: 200_000,
+			wantBudget:   128_000 * 85 / 100,
+		},
+		{
+			name:         "claude model preserves reported size",
+			envSlot:      "ANTHROPIC_DEFAULT_OPUS_MODEL",
+			modelName:    "claude-opus-4-6",
+			reportedSize: 1_000_000,
+			wantBudget:   1_000_000 * 85 / 100,
+		},
+		{
+			name:         "unknown non-claude model falls back to reported",
+			envSlot:      "ANTHROPIC_DEFAULT_SONNET_MODEL",
+			modelName:    "custom-unknown-llm",
+			reportedSize: 200_000,
+			wantBudget:   200_000 * 85 / 100,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Clear all model slots so only tc.envSlot drives detection.
+			t.Setenv("ANTHROPIC_DEFAULT_OPUS_MODEL", "")
+			t.Setenv("ANTHROPIC_DEFAULT_SONNET_MODEL", "")
+			t.Setenv("ANTHROPIC_DEFAULT_HAIKU_MODEL", "")
+			t.Setenv("MOAI_STATUSLINE_CONTEXT_SIZE", "")
+			t.Setenv(tc.envSlot, tc.modelName)
+
+			input := &StdinData{
+				ContextWindow: &ContextWindowInfo{
+					UsedPercentage:    &pct,
+					ContextWindowSize: tc.reportedSize,
+				},
+			}
+			got := CollectMemory(input)
+			if got == nil || !got.Available {
+				t.Fatalf("CollectMemory returned unavailable")
+			}
+			if got.TokenBudget != tc.wantBudget {
+				t.Errorf("TokenBudget = %d, want %d", got.TokenBudget, tc.wantBudget)
+			}
+		})
+	}
+}
+
+// TestCollectMemory_ExplicitOverride verifies that MOAI_STATUSLINE_CONTEXT_SIZE
+// wins over both Claude reported size and GLM auto-detection (issue #653).
+func TestCollectMemory_ExplicitOverride(t *testing.T) {
+	t.Setenv("ANTHROPIC_DEFAULT_OPUS_MODEL", "glm-5.1")
+	t.Setenv("MOAI_STATUSLINE_CONTEXT_SIZE", "131072")
+
+	pct := 50.0
+	input := &StdinData{
+		ContextWindow: &ContextWindowInfo{
+			UsedPercentage:    &pct,
+			ContextWindowSize: 1_000_000,
+		},
+	}
+	got := CollectMemory(input)
+	if got == nil || !got.Available {
+		t.Fatalf("CollectMemory returned unavailable")
+	}
+	wantBudget := 131072 * 85 / 100
+	if got.TokenBudget != wantBudget {
+		t.Errorf("TokenBudget = %d, want %d (explicit override wins)", got.TokenBudget, wantBudget)
+	}
+}

--- a/internal/template/templates/.moai/config/sections/llm.yaml
+++ b/internal/template/templates/.moai/config/sections/llm.yaml
@@ -22,3 +22,15 @@ llm:
       medium: "glm-4.7"       # Balanced performance
       low: "glm-4.5-air"      # Lightweight tasks (Z.ai official default)
 
+    # Optional: override the statusline context window gauge per GLM model
+    # (issue #653). Claude Code reports context_window_size based on the
+    # Claude slot (Opus=1M, Sonnet/Haiku=200K) regardless of provider, so
+    # the statusline over-reports headroom in GLM mode.
+    #
+    # Values are in tokens. Substring match: "glm-5.1" matches "glm-5.1[1m]".
+    # Set MOAI_STATUSLINE_CONTEXT_SIZE env for a one-shot override instead.
+    # context_windows:
+    #   glm-5.1: 230000
+    #   glm-4.7: 128000
+    #   glm-4.5-air: 128000
+


### PR DESCRIPTION
## Summary

GLM 모드 statusline 게이지 1M 오표시 fix. Claude Code debug 로그의 empirical 검증을 거쳐 시나리오 확정 후 수정 + 사용자 제안(llm.yaml) 반영.

## Empirical 검증 (Claude Code debug log)

`/Users/goos/.claude/debug/ef850c76-...txt` 분석 결과:

```
L103: model=glm-5.1[1m] modelSupported=false
L104: [WARN] auto mode disabled: model glm-5.1[1m] does not support auto mode
L380: autocompact: tokens=5250 threshold=967000 effectiveWindow=980000
L459: autocompact: tokens=85835 threshold=967000 effectiveWindow=980000
L257: StatusLine [.moai/status_line.sh] completed with status 0  (× 5회)
```

**확정된 사실**:
1. Claude Code는 GLM 모드에서도 stdin JSON 전송 (statusline 호출됨)
2. `context_window_size`에 Claude Opus 슬롯 값(~1M, `effectiveWindow=980000`) 사용
3. 모델이 GLM임을 인식(`modelSupported=false`)하면서도 슬롯 한도는 1M 유지 → **5배 과대 표시**

**사용자 보고 재검증**: `tokens=85835`에서 bug 상태 게이지 = 8.7%, 실제 GLM-5.1(200K) 기준 = 42.9%. 사용자 "23%에서 context full" 보고는 약 230K 도달 시점(GLM-5.1 실제 한도)과 일치.

## Fix 전략 — 4-tier Priority

| 우선순위 | 소스 | 용도 |
|---|---|---|
| 1 | `MOAI_STATUSLINE_CONTEXT_SIZE` env | 일회성 명시 오버라이드 |
| 2 | **`llm.yaml` `glm.context_windows`** | 프로젝트 설정 (신규) |
| 3 | 내장 `glmContextWindows` 테이블 | 6개 GLM 모델 기본값 |
| 4 | stdin의 `context_window_size` | 기존 동작 (fallback) |

## 변경 파일 (5)

- `internal/statusline/memory.go` +93: 4-tier priority + llm.yaml 로더 + 최장키 매칭
- `internal/statusline/memory_test.go` +140: 테스트 5 시나리오 (llm.yaml 2 + env override 1 + 기존 GLM 4 + explicit 1)
- `internal/config/types.go` +8: `GLMSettings.ContextWindows` 필드
- `internal/config/envkeys.go` +6: `EnvStatuslineContextSize`
- `internal/template/templates/.moai/config/sections/llm.yaml` +12: 주석 예시

## Test Plan

- [x] `go build ./...` PASS
- [x] `golangci-lint run ./...` 0 issues
- [x] 기존 TestCollectMemory 전체 회귀 PASS
- [x] 4-tier priority 검증
- [x] Claude 모델 회귀 방어

## User Workaround

```yaml
# .moai/config/sections/llm.yaml
llm:
  glm:
    context_windows:
      glm-5.1: 230000
      custom-model: 131072
```

또는:
```bash
export MOAI_STATUSLINE_CONTEXT_SIZE=131072
```

Fixes #653

🗿 MoAI <email@mo.ai.kr>
