### PR TITLE
fix(quality): Flutter 프로젝트에서 dart test 대신 flutter test 사용 (#652)

### DIFF
--- a/internal/hook/quality/gate.go
+++ b/internal/hook/quality/gate.go
@@ -162,6 +162,12 @@ var toolchains = []langToolchain{
 		testStep: &gateStep{name: "swift test", binary: "swift", args: []string{"test"}},
 	},
 	// Dart/Flutter: pubspec.yaml
+	// NOTE: Flutter projects are detected dynamically by inspecting pubspec.yaml
+	// content in detectToolchain — Flutter's `package:test` dependency is provided
+	// via `flutter_test` from the SDK, so `dart test` fails ("Could not find
+	// package `test`"). We switch to `flutter test` / `flutter analyze` for
+	// Flutter projects while keeping `dart` for pure Dart CLI projects.
+	// See issue #652.
 	{
 		markerFiles: []string{"pubspec.yaml"},
 		vetSteps:    []gateStep{{name: "dart analyze", binary: "dart", args: []string{"analyze"}}},
@@ -282,17 +288,71 @@ func (g *QualityGate) detectToolchain() *langToolchain {
 				// Glob pattern (e.g., "*.csproj")
 				matches, err := filepath.Glob(filepath.Join(dir, marker))
 				if err == nil && len(matches) > 0 {
-					return &toolchains[i]
+					return resolveDartFlutter(&toolchains[i], dir)
 				}
 			} else {
 				if fileExists(filepath.Join(dir, marker)) {
-					return &toolchains[i]
+					return resolveDartFlutter(&toolchains[i], dir)
 				}
 			}
 		}
 	}
 
 	return nil
+}
+
+// resolveDartFlutter returns a Flutter-specific toolchain variant when the
+// matched Dart toolchain's pubspec.yaml declares a Flutter SDK dependency,
+// and the pure Dart variant otherwise. Flutter projects require
+// `flutter test` / `flutter analyze` because `package:test` is provided
+// transitively via `flutter_test` from the Flutter SDK (issue #652).
+//
+// Non-Dart toolchains are returned unchanged.
+func resolveDartFlutter(tc *langToolchain, dir string) *langToolchain {
+	// Only process toolchain entries whose first marker is pubspec.yaml.
+	if len(tc.markerFiles) == 0 || tc.markerFiles[0] != "pubspec.yaml" {
+		return tc
+	}
+	if !isFlutterProject(filepath.Join(dir, "pubspec.yaml")) {
+		return tc
+	}
+	// Return a new langToolchain with flutter binary substitutions so we do
+	// not mutate the package-level toolchains slice.
+	return &langToolchain{
+		markerFiles: tc.markerFiles,
+		vetSteps:    []gateStep{{name: "flutter analyze", binary: "flutter", args: []string{"analyze"}}},
+		testStep:    &gateStep{name: "flutter test", binary: "flutter", args: []string{"test"}, optional: true},
+	}
+}
+
+// isFlutterProject reports whether the given pubspec.yaml declares the
+// Flutter SDK as a dependency. Detection heuristic:
+//   - "sdk: flutter" substring appears (Dart or Flutter dependency block)
+//   - or "flutter:" top-level section appears (Flutter-specific config)
+//
+// Missing or unreadable files return false (safe fallback to `dart`).
+func isFlutterProject(pubspecPath string) bool {
+	data, err := os.ReadFile(pubspecPath)
+	if err != nil {
+		return false
+	}
+	content := string(data)
+	return strings.Contains(content, "sdk: flutter") ||
+		strings.Contains(content, "sdk:flutter") ||
+		hasFlutterSection(content)
+}
+
+// hasFlutterSection reports whether pubspec content has a top-level
+// `flutter:` section (not a dependency named "flutter").
+func hasFlutterSection(content string) bool {
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimRight(line, " \t")
+		// Top-level section starts at column 0 with "flutter:"
+		if trimmed == "flutter:" {
+			return true
+		}
+	}
+	return false
 }
 
 // executeStep runs a single gate step. Optional steps skip silently when the binary is missing.

--- a/internal/hook/quality/gate_test.go
+++ b/internal/hook/quality/gate_test.go
@@ -379,6 +379,84 @@ func TestQualityGate_detectToolchain(t *testing.T) {
 	}
 }
 
+// TestQualityGate_detectToolchain_Flutter verifies that a pubspec.yaml
+// containing the Flutter SDK dependency resolves to `flutter test` / `flutter
+// analyze` rather than the Dart CLI defaults. See issue #652.
+func TestQualityGate_detectToolchain_Flutter(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name           string
+		pubspec        string
+		wantTestBinary string
+		wantTestArg0   string
+	}{
+		{
+			name: "flutter SDK dependency → flutter test",
+			pubspec: `name: my_app
+dependencies:
+  flutter:
+    sdk: flutter
+`,
+			wantTestBinary: "flutter",
+			wantTestArg0:   "test",
+		},
+		{
+			name: "flutter top-level section → flutter test",
+			pubspec: `name: my_app
+dependencies:
+  cupertino_icons: ^1.0.0
+
+flutter:
+  uses-material-design: true
+`,
+			wantTestBinary: "flutter",
+			wantTestArg0:   "test",
+		},
+		{
+			name: "pure Dart CLI project → dart test",
+			pubspec: `name: my_dart_cli
+dependencies:
+  args: ^2.4.0
+dev_dependencies:
+  test: ^1.24.0
+`,
+			wantTestBinary: "dart",
+			wantTestArg0:   "test",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, "pubspec.yaml"), []byte(tc.pubspec), 0o644); err != nil {
+				t.Fatalf("write pubspec.yaml: %v", err)
+			}
+			g := NewQualityGate(&GateConfig{ProjectDir: dir})
+			tcResolved := g.detectToolchain()
+			if tcResolved == nil {
+				t.Fatalf("detectToolchain returned nil")
+			}
+			if tcResolved.testStep == nil {
+				t.Fatalf("testStep is nil")
+			}
+			if tcResolved.testStep.binary != tc.wantTestBinary {
+				t.Errorf("test binary = %q, want %q", tcResolved.testStep.binary, tc.wantTestBinary)
+			}
+			if len(tcResolved.testStep.args) == 0 || tcResolved.testStep.args[0] != tc.wantTestArg0 {
+				t.Errorf("test args[0] = %v, want %q", tcResolved.testStep.args, tc.wantTestArg0)
+			}
+			// vetSteps 도 flutter 분기인지 확인
+			if len(tcResolved.vetSteps) > 0 && tc.wantTestBinary == "flutter" {
+				if tcResolved.vetSteps[0].binary != "flutter" {
+					t.Errorf("vet binary = %q, want flutter", tcResolved.vetSteps[0].binary)
+				}
+			}
+		})
+	}
+}
+
 func TestQualityGate_detectToolchain_GlobPattern(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Flutter 프로젝트에서 moai 품질 게이트가 `dart test`를 실행하여 "Could not find package `test`" 에러로 commit이 차단되는 문제 fix.

## Root Cause

Flutter 프로젝트는 `package:test`를 `flutter_test`(Flutter SDK 제공)를 통해 간접적으로 사용. `dart test`는 직접 의존성을 요구하므로 항상 실패함.

`internal/hook/quality/gate.go:168`에서 pubspec.yaml 마커 매치 시 `dart test`를 하드코딩, Flutter SDK 의존성 여부를 구분하지 않음.

## Fix

### 1. pubspec.yaml 동적 분석 (internal/hook/quality/gate.go)
- `resolveDartFlutter()` 신규 함수: pubspec.yaml 마커 매치 후 파일 내용 확인
- `isFlutterProject()`: `sdk: flutter` 또는 top-level `flutter:` 섹션 감지
- `hasFlutterSection()`: 최상위 섹션 vs 의존성명 `flutter` 구분
- Flutter 감지 시 `flutter test` + `flutter analyze`로 대체
- Dart CLI 프로젝트는 `dart test` + `dart analyze` 유지 (회귀 없음)

### 2. 테스트 3 시나리오 (internal/hook/quality/gate_test.go)
- flutter SDK dependency → flutter test
- flutter top-level section → flutter test
- pure Dart CLI project → dart test 보존

## Test Plan

- [x] `go build ./...` PASS
- [x] `go test ./internal/hook/quality/...` PASS (신규 3건 + 기존 14건)
- [x] Flutter pubspec (`sdk: flutter`) → flutter binary 선택
- [x] Flutter pubspec (top-level `flutter:`) → flutter binary 선택
- [x] Dart CLI pubspec → dart binary 유지 (회귀 방어)

## Migration / User Impact

Breaking change 없음. 기존 Dart CLI 프로젝트는 동일하게 동작. Flutter 프로젝트는 자동으로 올바른 명령 실행.

Fixes #652

🗿 MoAI <email@mo.ai.kr>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Dart/Flutter project detection: the toolchain resolution now intelligently identifies Flutter projects via configuration inspection and automatically selects the appropriate Flutter tools for analysis and testing. Pure Dart projects continue using Dart tools as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->