### PR TITLE
fix(#642): astgrep filterByLang + binary allowlist + cancel/stderr/YAML fixes

### DIFF
--- a/internal/astgrep/rules.go
+++ b/internal/astgrep/rules.go
@@ -1,7 +1,7 @@
 package astgrep
 
 import (
-	"errors"
+	"bytes"
 	"fmt"
 	"io"
 	"log/slog"
@@ -138,26 +138,36 @@ func (l *RuleLoader) LoadFromDir(dir string) ([]Rule, error) {
 	return allRules, nil
 }
 
-// loadFileSkipOnError loads rules from a single YAML file.
-// Returns partial results on decode errors to allow partial success per file.
+// loadFileSkipOnError는 단일 YAML 파일에서 규칙을 로딩합니다.
+// 멀티 문서 YAML에서 특정 문서 파싱이 실패해도 이후 문서를 계속 로딩합니다 (F5 fix).
+//
+// yaml.v3 Decoder는 파싱 실패 후 상태를 복구하지 않으므로, 파일을 "---" 구분자로
+// 분리하여 각 문서를 독립적으로 파싱하는 방식을 사용합니다.
 func (l *RuleLoader) loadFileSkipOnError(path string) ([]Rule, error) {
-	f, err := os.Open(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("opening rule file %s: %w", path, err)
 	}
-	defer func() { _ = f.Close() }()
+
+	// "---" 구분자로 문서 분리 (멀티 문서 YAML 지원)
+	// 각 문서를 개별적으로 파싱하여 파싱 실패 격리
+	docs := splitYAMLDocs(data)
 
 	var rules []Rule
-	decoder := yaml.NewDecoder(f)
+	var parseErrors int
 
-	for {
+	for i, doc := range docs {
+		trimmed := bytes.TrimSpace(doc)
+		if len(trimmed) == 0 {
+			continue
+		}
+
 		var rule Rule
-		if err := decoder.Decode(&rule); err != nil {
-			if errors.Is(err, io.EOF) {
-				break
-			}
-			slog.Warn("partial decode in rule file", "path", path, "error", err)
-			break
+		if err := yaml.Unmarshal(trimmed, &rule); err != nil {
+			parseErrors++
+			slog.Warn("규칙 파일 문서 파싱 실패, 다음 문서로 진행",
+				"path", path, "doc_index", i, "error", err)
+			continue
 		}
 		if rule.ID == "" {
 			continue
@@ -165,5 +175,34 @@ func (l *RuleLoader) loadFileSkipOnError(path string) ([]Rule, error) {
 		rules = append(rules, rule)
 	}
 
+	if parseErrors > 0 {
+		slog.Warn("규칙 파일에서 파싱 오류 발생",
+			"path", path, "valid_rules", len(rules), "parse_errors", parseErrors)
+	}
+
 	return rules, nil
+}
+
+// splitYAMLDocs는 YAML 멀티 문서 데이터를 "---" 구분자로 분리합니다.
+// 각 문서를 개별 파싱을 위한 독립적인 바이트 슬라이스로 반환합니다.
+func splitYAMLDocs(data []byte) [][]byte {
+	var docs [][]byte
+	// \n--- 또는 파일 시작 --- 로 분리
+	// bytes.Split은 정확히 "---"만 있는 행을 기준으로 분리
+	lines := bytes.Split(data, []byte("\n"))
+	var current [][]byte
+	for _, line := range lines {
+		if bytes.Equal(bytes.TrimSpace(line), []byte("---")) {
+			if len(current) > 0 {
+				docs = append(docs, bytes.Join(current, []byte("\n")))
+			}
+			current = nil
+			continue
+		}
+		current = append(current, line)
+	}
+	if len(current) > 0 {
+		docs = append(docs, bytes.Join(current, []byte("\n")))
+	}
+	return docs
 }

--- a/internal/astgrep/rules_test.go
+++ b/internal/astgrep/rules_test.go
@@ -188,3 +188,52 @@ func TestRules_ReturnsCopy(t *testing.T) {
 		}
 	}
 }
+
+// --- F5 재현 테스트: YAML parse error silent break ---
+
+// TestLoadFromDir_ContinuesAfterMalformedDocument: 멀티 문서 YAML에서 중간에 잘못된 문서가 있어도
+// 이후 유효한 문서를 계속 로딩하는지 검증한다.
+func TestLoadFromDir_ContinuesAfterMalformedDocument(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// doc1: 유효, doc2: 잘못된 YAML, doc3: 유효
+	// yaml.v3 디코더는 문서 간 경계를 --- 로 구분한다.
+	multiDocYAML := `---
+id: rule-first
+language: go
+severity: warning
+message: "첫 번째 규칙"
+pattern: "fmt.Println($X)"
+---
+: 잘못된 yaml 문서 !!invalid
+---
+id: rule-third
+language: python
+severity: error
+message: "세 번째 규칙"
+pattern: "eval($CODE)"
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "mixed.yml"), []byte(multiDocYAML), 0o644); err != nil {
+		t.Fatalf("파일 작성 실패: %v", err)
+	}
+
+	loader := NewRuleLoader()
+	rules, err := loader.LoadFromDir(tmpDir)
+	// 에러는 반환하지 않아야 함 (partial success)
+	if err != nil {
+		t.Fatalf("LoadFromDir() error = %v; 잘못된 문서가 있어도 에러를 반환하면 안 됨", err)
+	}
+
+	// rule-first와 rule-third 모두 로딩되어야 함 (F5 fix 이후)
+	ids := make(map[string]bool)
+	for _, r := range rules {
+		ids[r.ID] = true
+	}
+
+	if !ids["rule-first"] {
+		t.Error("rule-first가 로딩되지 않음 — 첫 번째 유효한 문서가 누락됨")
+	}
+	if !ids["rule-third"] {
+		t.Error("rule-third가 로딩되지 않음 — 잘못된 문서 이후의 유효한 문서가 누락됨 (F5 버그)")
+	}
+}

--- a/internal/astgrep/scanner.go
+++ b/internal/astgrep/scanner.go
@@ -148,16 +148,21 @@ func ValidateBinary(binary string) error {
 		return ErrUntrustedBinary
 	}
 	// bare name: 허용 목록의 고정값만
-	if !filepath.IsAbs(binary) {
+	// filepath.IsAbs는 Windows에서 Unix 스타일 "/usr/bin/sg"를 절대경로로 보지 않으므로
+	// 슬래시/백슬래시 포함 여부로 경로성을 판정해 크로스플랫폼 일관성을 확보한다.
+	looksLikePath := strings.ContainsAny(binary, "/\\") || filepath.IsAbs(binary)
+	if !looksLikePath {
 		if binary == "sg" || binary == "ast-grep" {
 			return nil
 		}
 		return ErrUntrustedBinary
 	}
 	// 절대 경로: 신뢰 prefix 검사 (Clean으로 트래버설 정규화 후)
-	cleaned := filepath.Clean(binary)
+	// Windows와 Unix를 동일하게 다루기 위해 양쪽 모두 ToSlash로 정규화한다.
+	cleaned := filepath.ToSlash(filepath.Clean(binary))
 	for _, p := range trustedBinaryPrefixes() {
-		if strings.HasPrefix(cleaned, p) {
+		prefixSlash := strings.TrimRight(filepath.ToSlash(p), "/")
+		if strings.HasPrefix(cleaned, prefixSlash+"/") || cleaned == prefixSlash {
 			return nil
 		}
 	}

--- a/internal/astgrep/scanner.go
+++ b/internal/astgrep/scanner.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -64,6 +65,11 @@ type Finding struct {
 	Note string `json:"note,omitempty"`
 	// Metadata는 CWE/OWASP 등 추가 메타데이터입니다.
 	Metadata map[string]string `json:"metadata,omitempty"`
+	// Language는 이 finding을 생성한 규칙의 대상 언어입니다.
+	// scanWithRules 경로에서 rule.Language가 주입됩니다.
+	// scanWithConfig 경로에서는 per-finding 언어를 알 수 없으므로 빈 문자열입니다.
+	// --lang 필터는 Language가 빈 finding을 항상 포함합니다 (언어-중립 규칙 허용).
+	Language string `json:"language,omitempty"`
 }
 
 // IsError는 심각도가 error인지 반환합니다.
@@ -99,6 +105,63 @@ func HasErrors(findings []Finding) bool {
 		}
 	}
 	return false
+}
+
+// ErrUntrustedBinary는 신뢰할 수 없는 바이너리 경로가 지정된 경우 반환됩니다.
+var ErrUntrustedBinary = errors.New("astgrep: 신뢰할 수 없는 바이너리 경로")
+
+// trustedBinaryPrefixes는 허용된 절대 경로 prefix 목록을 반환한다.
+func trustedBinaryPrefixes() []string {
+	home, _ := os.UserHomeDir()
+	sep := string(os.PathSeparator)
+	prefixes := []string{
+		"/usr/bin/",
+		"/usr/local/bin/",
+		"/opt/homebrew/bin/",
+	}
+	if home != "" {
+		prefixes = append(prefixes,
+			filepath.Join(home, "go", "bin")+sep,
+			filepath.Join(home, ".local", "bin")+sep,
+			filepath.Join(home, ".cargo", "bin")+sep,
+		)
+	}
+	return prefixes
+}
+
+// ValidateBinary는 sg 바이너리 경로의 안전성을 검사한다.
+// 빈 문자열은 기본값 "sg"로 폴백되므로 허용한다.
+// bare name은 "sg" 또는 "ast-grep"만 허용한다.
+// 절대 경로는 신뢰 prefix 목록에 있어야 한다.
+// 셸 메타문자나 경로 트래버설(..)이 포함되면 ErrUntrustedBinary를 반환한다.
+func ValidateBinary(binary string) error {
+	if binary == "" {
+		// 빈 값은 기본값 "sg"로 폴백됨
+		return nil
+	}
+	// 셸 인젝션 방어: 메타문자 차단
+	if strings.ContainsAny(binary, ";|&`$()<>\n\r") {
+		return ErrUntrustedBinary
+	}
+	// 경로 트래버설 차단
+	if strings.Contains(binary, "..") {
+		return ErrUntrustedBinary
+	}
+	// bare name: 허용 목록의 고정값만
+	if !filepath.IsAbs(binary) {
+		if binary == "sg" || binary == "ast-grep" {
+			return nil
+		}
+		return ErrUntrustedBinary
+	}
+	// 절대 경로: 신뢰 prefix 검사 (Clean으로 트래버설 정규화 후)
+	cleaned := filepath.Clean(binary)
+	for _, p := range trustedBinaryPrefixes() {
+		if strings.HasPrefix(cleaned, p) {
+			return nil
+		}
+	}
+	return ErrUntrustedBinary
 }
 
 // Scanner는 ast-grep 기반의 통합 코드 스캐너입니다.
@@ -153,7 +216,13 @@ func (s *Scanner) isSGAvailable() bool {
 // Scan은 주어진 경로에 대해 모든 규칙을 적용하여 스캔을 수행합니다.
 // sg CLI가 없으면 ([]Finding{}, nil)을 반환합니다 (REQ-ASTG-UPG-012).
 // rules 디렉토리가 비어있거나 존재하지 않으면 ([]Finding{}, nil)을 반환합니다 (REQ-ASTG-UPG-012).
+// SGBinary가 신뢰할 수 없는 경로이면 에러를 반환합니다 (F2 보안 검사).
 func (s *Scanner) Scan(ctx context.Context, path string) ([]Finding, error) {
+	// 바이너리 경로 보안 검증 (F2): 신뢰할 수 없는 경로는 즉시 에러 반환
+	if err := ValidateBinary(s.cfg.SGBinary); err != nil {
+		return []Finding{}, fmt.Errorf("sg 바이너리 검증 실패 (SGBinary=%q): %w", s.cfg.SGBinary, err)
+	}
+
 	// sg CLI가 없으면 warn_and_skip (REQ-ASTG-UPG-012)
 	if !s.isSGAvailable() {
 		slog.Warn("ast-grep (sg) CLI를 찾을 수 없습니다. 스캔을 건너뜁니다.",
@@ -209,10 +278,52 @@ func (s *Scanner) scanWithConfig(ctx context.Context, configPath, path string) (
 	// sg는 발견 시 non-zero exit code를 반환할 수 있으므로 에러를 무시
 	_ = cmd.Run()
 
+	// F4: stderr 내용이 있으면 디버그 로깅 (config 기반 스캔에서는 언어를 알 수 없으므로 에러 전파 생략)
+	if stderr.Len() > 0 {
+		slog.Debug("sg scan stderr (config 기반)", "config", configPath, "stderr", stderr.String())
+	}
+
 	if stdout.Len() == 0 {
 		return []Finding{}, nil
 	}
 
+	return parseSGFindings(stdout.Bytes())
+}
+
+// runSingleRule은 단일 규칙에 대해 sg run을 실행하고 finding을 반환합니다.
+// defer cancel()로 context 누수를 방지합니다 (F3).
+// stderr는 디버그 로깅하고, stdout이 비어있고 stderr가 있으면 에러를 반환합니다 (F4).
+//
+// @MX:WARN: [AUTO] context.WithTimeout을 defer cancel()로 보호 — 이전 구현에서 cancel() 누수 발생
+// @MX:REASON: F3 버그 수정: loop 내 cancel() 미 defer 시 패닉/조기 반환 경로에서 context 누수
+func (s *Scanner) runSingleRule(ctx context.Context, binary string, rule Rule, path string, timeout time.Duration) ([]Finding, error) {
+	scanCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(scanCtx, binary, "run",
+		"--pattern", rule.Pattern,
+		"--lang", rule.Language,
+		"--json",
+		path,
+	)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		// F4: stderr 내용 로깅
+		if stderr.Len() > 0 {
+			slog.Debug("sg run stderr", "rule", rule.ID, "stderr", stderr.String())
+		}
+		// stdout이 비어있고 stderr에 내용이 있으면 실행 실패로 간주
+		if stdout.Len() == 0 && stderr.Len() > 0 {
+			return nil, fmt.Errorf("sg run 실패 (rule %s): %s", rule.ID, stderr.String())
+		}
+	}
+
+	if stdout.Len() == 0 {
+		return nil, nil
+	}
 	return parseSGFindings(stdout.Bytes())
 }
 
@@ -235,31 +346,14 @@ func (s *Scanner) scanWithRules(ctx context.Context, rules []Rule, path string) 
 			continue
 		}
 
-		scanCtx, cancel := context.WithTimeout(ctx, timeout)
-		cmd := exec.CommandContext(scanCtx, binary, "run",
-			"--pattern", rule.Pattern,
-			"--lang", rule.Language,
-			"--json",
-			path,
-		)
-		var stdout bytes.Buffer
-		cmd.Stdout = &stdout
-		_ = cmd.Run()
-		cancel()
-
-		if stdout.Len() == 0 {
-			continue
-		}
-
-		findings, err := parseSGFindings(stdout.Bytes())
+		// F3: runSingleRule에서 defer cancel()로 context 누수 방지
+		findings, err := s.runSingleRule(ctx, binary, rule, path, timeout)
 		if err != nil {
-			slog.Debug("규칙 실행 결과 파싱 실패, 건너뜀",
-				"rule", rule.ID,
-				"error", err)
+			slog.Debug("규칙 실행 실패, 건너뜀", "rule", rule.ID, "error", err)
 			continue
 		}
 
-		// 규칙 메타데이터 주입
+		// 규칙 메타데이터 주입 (F1: Language 필드 포함)
 		for i := range findings {
 			if findings[i].RuleID == "" {
 				findings[i].RuleID = rule.ID
@@ -270,6 +364,8 @@ func (s *Scanner) scanWithRules(ctx context.Context, rules []Rule, path string) 
 			if findings[i].Message == "" {
 				findings[i].Message = rule.Message
 			}
+			// Language는 항상 rule에서 주입 (찾은 파일의 언어가 아닌 규칙 대상 언어)
+			findings[i].Language = rule.Language
 		}
 
 		allFindings = append(allFindings, findings...)

--- a/internal/astgrep/scanner_test.go
+++ b/internal/astgrep/scanner_test.go
@@ -27,18 +27,25 @@ func TestNewScanner_NilConfig(t *testing.T) {
 	}
 }
 
-// TestScanner_SGNotAvailable: sg CLI가 없을 때 (nil, nil) 반환 검증 (AC3)
+// TestScanner_SGNotAvailable: sg CLI가 PATH에 없을 때 (nil, nil) 반환 검증 (AC3)
+// 기본 허용 binary("sg")를 사용하되 실제 PATH에 없는 환경을 시뮬레이션한다.
+// 참고: 비허용 binary name은 F2 보안 검사에서 에러로 차단된다.
 func TestScanner_SGNotAvailable(t *testing.T) {
+	// "sg"는 ValidateBinary를 통과하지만, PATH에 없으면 isSGAvailable이 false를 반환한다.
+	// 이 테스트는 sg가 실제로 없는 환경(PATH에 "sg" 없음)에서만 유의미하다.
+	// sg가 설치된 환경에서는 실제 스캔이 발생할 수 있으므로, 빈 rules 디렉토리로 테스트한다.
+	tmpDir := t.TempDir()
 	cfg := astgrep.DefaultScannerConfig()
-	cfg.SGBinary = "sg-does-not-exist-in-path-12345"
-	s := astgrep.NewScanner(cfg)
+	cfg.SGBinary = "sg" // 허용된 bare name
+	cfg.RulesDir = tmpDir
 
+	s := astgrep.NewScanner(cfg)
 	findings, err := s.Scan(context.Background(), ".")
 	if err != nil {
-		t.Errorf("Scan() error = %v; sg 미존재 시 nil 에러를 반환해야 함", err)
+		t.Errorf("Scan() error = %v; sg 미존재 또는 빈 rules 시 nil 에러를 반환해야 함", err)
 	}
 	if len(findings) != 0 {
-		t.Errorf("Scan() len(findings) = %d; sg 미존재 시 빈 슬라이스를 반환해야 함", len(findings))
+		t.Errorf("Scan() len(findings) = %d; 빈 rules 디렉토리에서 빈 슬라이스를 반환해야 함", len(findings))
 	}
 }
 
@@ -536,4 +543,69 @@ func containsSubstr(s, substr string) bool {
 			}
 			return false
 		}())
+}
+
+// --- F2 재현 테스트: Binary allowlist 부재 ---
+
+// TestValidateBinary_AllowsSg: "sg", "ast-grep" bare name이 허용되는지 검증
+func TestValidateBinary_AllowsSg(t *testing.T) {
+	for _, name := range []string{"sg", "ast-grep"} {
+		if err := astgrep.ValidateBinary(name); err != nil {
+			t.Errorf("ValidateBinary(%q) = %v; 허용된 bare name이어야 함", name, err)
+		}
+	}
+}
+
+// TestValidateBinary_AllowsTrustedPrefix: /usr/local/bin/sg 같은 신뢰 경로가 허용되는지 검증
+func TestValidateBinary_AllowsTrustedPrefix(t *testing.T) {
+	paths := []string{
+		"/usr/bin/sg",
+		"/usr/local/bin/sg",
+		"/opt/homebrew/bin/sg",
+	}
+	for _, p := range paths {
+		if err := astgrep.ValidateBinary(p); err != nil {
+			t.Errorf("ValidateBinary(%q) = %v; 신뢰 경로여야 함", p, err)
+		}
+	}
+}
+
+// TestValidateBinary_RejectsUntrustedPath: /tmp 같은 비신뢰 절대 경로가 거부되는지 검증
+func TestValidateBinary_RejectsUntrustedPath(t *testing.T) {
+	if err := astgrep.ValidateBinary("/tmp/evil/sg"); err == nil {
+		t.Error("ValidateBinary(/tmp/evil/sg) = nil; 비신뢰 경로는 에러를 반환해야 함")
+	}
+}
+
+// TestValidateBinary_RejectsShellMetachars: 셸 메타문자가 포함된 바이너리 경로가 거부되는지 검증
+func TestValidateBinary_RejectsShellMetachars(t *testing.T) {
+	malicious := []string{
+		"sg; rm -rf /",
+		"sg|cat /etc/passwd",
+		"`sg`",
+	}
+	for _, bin := range malicious {
+		if err := astgrep.ValidateBinary(bin); err == nil {
+			t.Errorf("ValidateBinary(%q) = nil; 셸 메타문자는 에러를 반환해야 함", bin)
+		}
+	}
+}
+
+// TestValidateBinary_RejectsTraversal: ..을 포함한 경로 트래버설이 거부되는지 검증
+func TestValidateBinary_RejectsTraversal(t *testing.T) {
+	if err := astgrep.ValidateBinary("/usr/local/bin/../../tmp/sg"); err == nil {
+		t.Error("ValidateBinary(경로 트래버설) = nil; 에러를 반환해야 함")
+	}
+}
+
+// TestScan_RejectsUntrustedBinary: Scan이 신뢰할 수 없는 바이너리 경로로 에러를 반환하는지 검증
+func TestScan_RejectsUntrustedBinary(t *testing.T) {
+	cfg := astgrep.DefaultScannerConfig()
+	cfg.SGBinary = "/tmp/evil/sg"
+	s := astgrep.NewScanner(cfg)
+
+	_, err := s.Scan(context.Background(), ".")
+	if err == nil {
+		t.Error("Scan() with untrusted binary = nil error; 에러를 반환해야 함")
+	}
 }

--- a/internal/cli/astgrep.go
+++ b/internal/cli/astgrep.go
@@ -198,12 +198,23 @@ func detectSGVersion() string {
 }
 
 // filterByLang은 지정된 언어의 규칙에서 발생한 finding만 반환합니다.
-// finding에 language 정보가 없으면 포함합니다.
+// lang이 빈 문자열이면 전체를 반환합니다.
+// finding.Language가 빈 문자열이면 언어-중립 규칙으로 간주하여 항상 포함합니다.
+// 대소문자를 무시합니다.
 func filterByLang(findings []astgrep.Finding, lang string) []astgrep.Finding {
-	// Finding에는 직접적인 language 필드가 없으므로 ruleId 접두사로 추정
-	// 예: "go-*" → Go, "sec-*" → security (언어 중립)
-	// 실제 언어 필터링은 scanner 레벨에서 처리되므로 여기서는 pass-through
-	return findings
+	if lang == "" {
+		return findings
+	}
+	target := strings.ToLower(lang)
+	out := make([]astgrep.Finding, 0, len(findings))
+	for _, f := range findings {
+		fl := strings.ToLower(f.Language)
+		// 언어 정보가 없는 finding은 포함 (언어-중립 규칙 허용)
+		if fl == "" || fl == target {
+			out = append(out, f)
+		}
+	}
+	return out
 }
 
 // filterBySeverity는 지정된 severity 이상의 finding만 반환합니다.

--- a/internal/cli/astgrep_filter_test.go
+++ b/internal/cli/astgrep_filter_test.go
@@ -1,0 +1,58 @@
+package cli
+
+// F1 재현 테스트: filterByLang 미구현 pass-through
+// Finding.Language 필드와 filterByLang 함수를 직접 테스트한다.
+// 패키지 내부 테스트 (package cli)로 작성하여 비공개 함수에 접근한다.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/modu-ai/moai-adk/internal/astgrep"
+)
+
+// TestFilterByLang_KeepsMatchingLanguage: 언어 필터가 일치하는 항목과 언어 정보 없는 항목만 반환하는지 검증
+func TestFilterByLang_KeepsMatchingLanguage(t *testing.T) {
+	findings := []astgrep.Finding{
+		{RuleID: "r1", Language: "go"},
+		{RuleID: "r2", Language: "python"},
+		{RuleID: "r3", Language: ""},
+	}
+	got := filterByLang(findings, "python")
+	// python + 빈 언어 = 2개 반환
+	if len(got) != 2 {
+		t.Errorf("filterByLang(python) len = %d, want 2 (python 항목 + 언어 정보 없는 항목)", len(got))
+	}
+	for _, f := range got {
+		if strings.ToLower(f.Language) != "python" && f.Language != "" {
+			t.Errorf("filterByLang(python)에 잘못된 언어가 포함됨: %q", f.Language)
+		}
+	}
+}
+
+// TestFilterByLang_EmptyLang_ReturnsAll: 언어 필터가 비어있으면 전부 반환하는지 검증
+func TestFilterByLang_EmptyLang_ReturnsAll(t *testing.T) {
+	findings := []astgrep.Finding{
+		{RuleID: "r1", Language: "go"},
+		{RuleID: "r2", Language: "python"},
+		{RuleID: "r3", Language: ""},
+	}
+	got := filterByLang(findings, "")
+	if len(got) != len(findings) {
+		t.Errorf("filterByLang(\"\") len = %d, want %d (전체 반환)", len(got), len(findings))
+	}
+}
+
+// TestFilterByLang_CaseInsensitive: 언어 필터가 대소문자를 무시하는지 검증
+func TestFilterByLang_CaseInsensitive(t *testing.T) {
+	findings := []astgrep.Finding{
+		{RuleID: "r1", Language: "Go"},
+		{RuleID: "r2", Language: "PYTHON"},
+		{RuleID: "r3", Language: ""},
+	}
+	got := filterByLang(findings, "go")
+	// Go (대문자) + 빈 언어 = 2개
+	if len(got) != 2 {
+		t.Errorf("filterByLang(go) 대소문자 무시 테스트: len = %d, want 2", len(got))
+	}
+}

--- a/internal/cli/astgrep_test.go
+++ b/internal/cli/astgrep_test.go
@@ -179,3 +179,4 @@ func TestAstGrepCmd_LangFilter(t *testing.T) {
 		t.Errorf("--lang=go 설정 실패: %v", err)
 	}
 }
+


### PR DESCRIPTION
## Summary

Issue #642의 5개 결함을 TDD(재현 테스트 먼저)로 수정합니다. origin/main 기반 깔끔한 커밋 1개.

- **F1 Perf/UX**: filterByLang pass-through → Finding.Language 필드 + 실제 필터링
- **F2 Security**: sg 바이너리 공급망 주입 → ValidateBinary allowlist
- **F3 Quality**: 루프 내 cancel() 누수 → runSingleRule helper로 defer cancel() 보장
- **F4 Quality**: stderr 캡처 후 미사용 → slog.Debug 로깅 + 오류 전파
- **F5 Security**: YAML 파싱 오류 시 break → --- 구분자 기반 문서 분리로 재구현

이전 #659는 로컬 main 충돌로 대체. 이 PR은 origin/main 기반 clean diff.

## Test plan

- [x] go test ./internal/astgrep/... ./internal/cli/... -race -count=1 PASS
- [x] go test ./... -race -count=1 전체 패키지 PASS
- [x] go vet ./... clean
- [x] 재현 테스트 10개 신규 (수정 전 FAIL → 수정 후 PASS 확인)

Closes #642

🗿 MoAI <email@mo.ai.kr>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Findings now include language information for better categorization.

* **Improvements**
  * Language filter (`--lang`) now actively filters results case-insensitively and preserves language-neutral findings.
  * Rule file parsing now continues after malformed documents, producing partial results instead of failing completely.
  * Added validation of binary paths to prevent untrusted executables from being used.

* **Tests**
  * Added coverage for language filtering, resilient rule parsing, and binary validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->