### PR TITLE
docs(project): structure + tech 문서에 v2.10.3/v2.10.4 변경 반영

### DIFF
--- a/.moai/project/structure.md
+++ b/.moai/project/structure.md
@@ -368,6 +368,56 @@ moai update
 | `rollback.go` | Atomic rollback on failure (keeps previous binary) |
 | `orchestrator.go` | Full update workflow: check → download → merge → replace → verify |
 
+### `internal/lsp/` -- LSP Client Suite (SPEC-LSP-CORE-002 .. MULTI-006, v2.10.3)
+
+Multi-language LSP client foundation based on `github.com/charmbracelet/x/powernap`. Supports 16 languages via project_markers auto-detection.
+
+| Package | Purpose |
+|---------|---------|
+| `internal/lsp/core/` | `Client`, `Manager`, `Document`, Lifecycle State Machine, Capability Negotiation |
+| `internal/lsp/subprocess/` | `Supervisor`, `Launcher` with graceful degradation |
+| `internal/lsp/transport/` | JSON-RPC 2.0 codec via powernap |
+| `internal/lsp/cache/` | TTL cache for diagnostic results (SPEC-LSP-AGG-003) |
+| `internal/lsp/aggregator/` | Parallel diagnostic collection + circuit breaker |
+| `internal/lsp/gopls/` | gopls bridge (SPEC-GOPLS-BRIDGE-001, coexists via `lsp.client_impl` feature flag) |
+| `internal/lsp/config/` | `lsp.yaml` loader with multi-language server matrix |
+| `internal/lsp/hook/` | Phase-aware quality gate (SPEC-LSP-QGATE-004) |
+
+**Feature flag**: `lsp.client_impl` in `.moai/config/sections/lsp.yaml` selects `gopls_bridge` (legacy, Go-only) or `powernap_core` (default, 16 languages).
+
+### `internal/astgrep/` -- Code Quality Scanner (SPEC-ASTG-UPGRADE-001, v2.10.3)
+
+Unified ast-grep (sg CLI) scanner replacing separate quality-gate and PostToolUse hook implementations.
+
+| File | Purpose |
+|------|---------|
+| `scanner.go` | `Scanner.Scan` single entry point (`@MX:ANCHOR`, fan_in >= 3), binary allowlist via `ValidateBinary` |
+| `rules.go` | YAML rule loader with `---` document splitting (malformed docs skipped individually) |
+| `sarif.go` | SARIF 2.1.0 output for GitHub code scanning |
+| `analyzer.go` | Finding aggregation, language filtering, severity ranking |
+
+### `internal/evolution/` -- Skill Evolution System (SPEC-EVO-001, v2.10.4)
+
+Reflective Write Hook infrastructure with 5-layer safety (Frozen Guard / Rate Limiter / Human Oversight).
+
+| File | Purpose |
+|------|---------|
+| `safety.go` | `CheckFrozenGuard` (path traversal / agency constitution / absolute-path rejection), `UpdateRateLimit` with `rateMu` serialization |
+| `learning.go` | `LearningEntry` CRUD with `validateLearningID` regex `^LEARN-\d{8}-\d{3}$` |
+| `graduation.go` | Observation → Heuristic → Rule → Graduated tier progression |
+| `apply.go` | `ApplyProposal` with `merge.ReplaceEvolvableZone` + `filepath.Rel` containment check |
+| `types.go` | Sentinel errors: `ErrFrozenPath`, `ErrRateLimit`, `ErrInvalidLearningID`, `ErrZoneNotFound` |
+
+### `internal/telemetry/` -- Skill Usage Metrics (SPEC-TELEMETRY-001, v2.10.4)
+
+Daily JSONL telemetry with async writer.
+
+| File | Purpose |
+|------|---------|
+| `recorder.go` | Sync `RecordSkillUsage`, `PruneOldFiles` (day-granularity retention) |
+| `async_recorder.go` | `AsyncRecorder` with channel-based single writer, date-keyed file handle cache, `bufio.Writer` (4KB), drop policy on buffer full |
+| `report.go` | Daily/weekly/monthly aggregation, `moai telemetry report` CLI |
+
 ### `internal/template/` -- Template Deployment (Improved)
 
 **Resolves**: 6 template substitution issues (#304, #308, #309, etc.)

--- a/.moai/project/tech.md
+++ b/.moai/project/tech.md
@@ -39,6 +39,28 @@ The module path follows Go conventions with the GitHub organization and reposito
 | Concurrency | goroutines + channels (stdlib) | Go 1.26 | Native concurrent execution for LSP, quality gates, and parallel operations |
 | File Embedding | `embed` (stdlib) | Go 1.26 | Compile-time template embedding into the binary |
 | Context | `context` (stdlib) | Go 1.26 | Cancellation, timeouts, and request-scoped values |
+| LSP Client | `github.com/charmbracelet/x/powernap` | v0.1.3 | Multi-language LSP client foundation (SPEC-LSP-CORE-002). Wraps `sourcegraph/jsonrpc2` with VSCode-compatible codec. Used by `internal/lsp/core/` and `internal/lsp/transport/` |
+| URI Encoding | `net/url` (stdlib) | Go 1.26 | RFC 3986 file:// URI encoding for LSP (`internal/lsp/gopls/uri.go`). Handles space, unicode, Windows drive paths correctly |
+
+### Security Patterns (v2.10.4)
+
+Cross-cutting security patterns established by the 3-perspective review bundle:
+
+| Pattern | Where | Purpose |
+|---------|-------|---------|
+| Path traversal rejection | `internal/evolution/safety.go` | `CheckFrozenGuard` rejects absolute paths (`filepath.IsAbs` + leading `/` for Windows) and `..` components |
+| Binary allowlist | `internal/lsp/gopls/config.go`, `internal/astgrep/scanner.go` | Trusted prefix list (`/usr/bin`, `/usr/local/bin`, `/opt/homebrew/bin`, `$HOME/{go,.local,.cargo}/bin`) + shell metachar rejection (`;&|\`$`) |
+| Cross-platform path normalization | Both above | `filepath.ToSlash` on both sides before HasPrefix comparison (Windows `filepath.Clean` produces backslashes) |
+| ID validation | `internal/evolution/learning.go` | `validateLearningID` regex enforcement prevents path injection via `LearningEntry.ID` |
+
+### Cross-Platform CI Compatibility (v2.10.4)
+
+Established patterns for `Test (windows-latest)` parity:
+
+1. **Path handling**: Use `filepath.ToSlash` for all prefix/equality comparisons. `filepath.IsAbs` returns false for Unix-style `/foo` on Windows — check leading `/` explicitly when Unix-style inputs are expected.
+2. **Test paths**: Use `t.TempDir()` + explicit URI/path conversion helpers. Never hardcode Unix-style test paths that will be compared against OS-generated paths.
+3. **Shell metachar lists**: Do NOT include backslash `\`. Go's `exec.Command` does not invoke a shell, so backslashes in Windows paths are safe and must not be rejected.
+4. **Timing thresholds**: Use generous thresholds (100ms+) with small allowances (5%+) for async operations on Windows CI — scheduler granularity is coarser than Linux/macOS.
 
 ### Language Support
 


### PR DESCRIPTION
## Summary

.moai/project/structure.md와 tech.md에 최근 릴리즈 변경사항을 반영합니다.

### structure.md
신규 모듈 4종 섹션 추가:
- internal/lsp/ (LSP Client Suite, v2.10.3)
- internal/astgrep/ (Code Quality Scanner, v2.10.3)
- internal/evolution/ (Skill Evolution System, v2.10.4)
- internal/telemetry/ (Skill Usage Metrics, v2.10.4)

### tech.md
- Core Dependencies: powernap v0.1.3 + net/url (RFC 3986 file://)
- Security Patterns (v2.10.4): path traversal, binary allowlist, 크로스플랫폼 정규화, ID 검증
- Cross-Platform CI Compatibility: Windows 4가지 패턴 정리

product.md은 변경 없음 (제품 비전 불변).

🗿 MoAI <email@mo.ai.kr>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive internal architectural documentation describing new system components for language server protocol support, code quality scanning, skill evolution capabilities, and telemetry metrics collection.

* **Chores**
  * Updated technical specifications and project structure documentation with cross-platform compatibility guidelines and security patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->