### PR TITLE
fix(#640): GLM team 401 — SessionStart에서 tmux 세션 env 자동 주입

### DIFF
--- a/internal/cli/glm.go
+++ b/internal/cli/glm.go
@@ -289,7 +289,12 @@ func enableTeamMode(cmd *cobra.Command, isHybrid bool) error {
 
 		tmuxStatus := "tmux session: active (env vars injected)"
 		if !inTmux {
-			tmuxStatus = "tmux session: NOT DETECTED (start claude inside tmux for teammates)"
+			tmuxStatus = "Warning: tmux session NOT DETECTED. GLM teammates require tmux for env propagation.\n" +
+				"  Recommended steps:\n" +
+				"    1. tmux new -s moai\n" +
+				"    2. moai glm                # (tmux 안에서 재실행하여 세션 env 설정)\n" +
+				"    3. claude\n" +
+				"    4. /moai --team \"task\""
 		}
 
 		_, _ = fmt.Fprintln(out, renderSuccessCard(

--- a/internal/hook/glm_tmux.go
+++ b/internal/hook/glm_tmux.go
@@ -1,0 +1,131 @@
+package hook
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/modu-ai/moai-adk/internal/tmux"
+)
+
+// glmTmuxKeys는 tmux 세션에 주입할 GLM 관련 환경변수 목록입니다.
+// 새 tmux 팬(팀원)이 GLM API를 사용하려면 이 변수들이 세션 수준에서 설정되어야 합니다.
+var glmTmuxKeys = []string{
+	"ANTHROPIC_AUTH_TOKEN",
+	"ANTHROPIC_BASE_URL",
+	"ANTHROPIC_DEFAULT_OPUS_MODEL",
+	"ANTHROPIC_DEFAULT_SONNET_MODEL",
+	"ANTHROPIC_DEFAULT_HAIKU_MODEL",
+	"CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS",
+	"DISABLE_PROMPT_CACHING",
+	"API_TIMEOUT_MS",
+	"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC",
+}
+
+// buildGLMTmuxEnvVars는 settings.local.json의 env 맵에서 GLM 관련 변수만 추출합니다.
+//
+// 규칙:
+//   - ANTHROPIC_AUTH_TOKEN이 비어 있으면 nil 반환 (주입 불필요)
+//   - glmTmuxKeys에 포함된 키만 결과에 포함됨
+//   - 설정에 없는 키는 결과에 포함되지 않음
+func buildGLMTmuxEnvVars(env map[string]string) map[string]string {
+	if env["ANTHROPIC_AUTH_TOKEN"] == "" {
+		return nil
+	}
+
+	result := make(map[string]string)
+	for _, key := range glmTmuxKeys {
+		if val, ok := env[key]; ok && val != "" {
+			result[key] = val
+		}
+	}
+
+	// ANTHROPIC_AUTH_TOKEN이 있으면 반드시 포함
+	if token := env["ANTHROPIC_AUTH_TOKEN"]; token != "" {
+		result["ANTHROPIC_AUTH_TOKEN"] = token
+	}
+
+	return result
+}
+
+// formatTmuxGLMEnvSummary는 tmux 세션 환경변수 주입 결과 요약 문자열을 반환합니다.
+func formatTmuxGLMEnvSummary(n int) string {
+	return fmt.Sprintf("GLM 팀원을 위해 tmux 세션 환경변수 주입 완료 (%d개 변수)", n)
+}
+
+// ensureTmuxGLMEnv는 SessionStart 훅에서 호출되어, GLM 모드에서 팀원 tmux 팬이
+// ANTHROPIC_AUTH_TOKEN을 상속받을 수 있도록 현재 tmux 세션에 환경변수를 주입합니다.
+//
+// 동작:
+//  1. TMUX 환경변수가 없으면 no-op (tmux 세션 밖)
+//  2. settings.local.json에서 teammateMode가 "tmux"가 아니면 no-op
+//  3. ANTHROPIC_AUTH_TOKEN이 없으면 no-op
+//  4. GLM 관련 환경변수를 tmux set-environment로 현재 세션에 주입
+//
+// 에러 처리: 모든 에러는 경고 로그만 출력하고 빈 문자열을 반환합니다.
+// SessionStart 훅 실패를 절대 일으키지 않습니다.
+//
+// @MX:ANCHOR: [AUTO] SessionStart 훅의 GLM+팀 모드 tmux 환경변수 주입 진입점
+// @MX:REASON: Handle에서 직접 호출되며 session_start_glm_tmux_test.go에서 3개 이상 테스트 케이스가 검증
+func ensureTmuxGLMEnv(projectDir string) string {
+	// 1. tmux 세션 여부 확인
+	if os.Getenv("TMUX") == "" {
+		return ""
+	}
+
+	// 2. settings.local.json 읽기
+	settingsPath := filepath.Join(projectDir, ".claude", "settings.local.json")
+	data, err := os.ReadFile(settingsPath)
+	if err != nil || len(data) == 0 {
+		return ""
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return ""
+	}
+
+	// 3. teammateMode == "tmux" 확인
+	var teammateMode string
+	if v, ok := raw["teammateMode"]; ok {
+		_ = json.Unmarshal(v, &teammateMode)
+	}
+	if teammateMode != "tmux" {
+		return ""
+	}
+
+	// 4. env 맵 추출
+	envRaw, ok := raw["env"]
+	if !ok {
+		return ""
+	}
+	var env map[string]string
+	if err := json.Unmarshal(envRaw, &env); err != nil {
+		return ""
+	}
+
+	// 5. GLM 환경변수 맵 구성 (AUTH_TOKEN 없으면 nil 반환)
+	vars := buildGLMTmuxEnvVars(env)
+	if len(vars) == 0 {
+		return ""
+	}
+
+	// 6. tmux set-environment 실행
+	mgr := tmux.NewSessionManager()
+	if err := mgr.InjectEnv(context.Background(), vars); err != nil {
+		slog.Warn("ensureTmuxGLMEnv: tmux 환경변수 주입 실패",
+			"error", err.Error(),
+			"hint", "tmux 바이너리가 없거나 세션 외부일 수 있음",
+		)
+		return ""
+	}
+
+	summary := formatTmuxGLMEnvSummary(len(vars))
+	slog.Info("ensureTmuxGLMEnv: tmux 세션 GLM 환경변수 주입",
+		"vars", len(vars),
+	)
+	return summary
+}

--- a/internal/hook/session_start.go
+++ b/internal/hook/session_start.go
@@ -84,6 +84,17 @@ func (h *sessionStartHandler) Handle(ctx context.Context, input *HookInput) (*Ho
 		}
 	}
 
+	// GLM 팀 모드에서 팀원 tmux 팬이 ANTHROPIC_AUTH_TOKEN을 상속하도록
+	// 현재 tmux 세션에 GLM 환경변수를 주입합니다.
+	// ensureGLMCredentials가 settings.local.json에 토큰을 기록한 후에 실행해야
+	// 최신 값을 읽을 수 있습니다.
+	if input.ProjectDir != "" {
+		if msg := ensureTmuxGLMEnv(input.ProjectDir); msg != "" {
+			data["tmux_glm_env"] = msg
+			slog.Info("tmux GLM 환경변수 주입", "message", msg)
+		}
+	}
+
 	// Enforce telemetry retention: prune files older than 90 days (SPEC-TELEMETRY-001 R4).
 	// Best-effort: errors are logged and never propagated.
 	if input.ProjectDir != "" {

--- a/internal/hook/session_start_glm_tmux_test.go
+++ b/internal/hook/session_start_glm_tmux_test.go
@@ -1,0 +1,235 @@
+package hook
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestEnsureTmuxGLMEnv_NotInTmux_ReturnsEmpty는 tmux 세션 밖에서 실행 시
+// 함수가 빈 문자열을 반환하는지 검증합니다.
+func TestEnsureTmuxGLMEnv_NotInTmux_ReturnsEmpty(t *testing.T) {
+	// t.Setenv 사용으로 t.Parallel() 불가
+	t.Setenv("TMUX", "") // tmux 세션 밖을 시뮬레이션
+
+	dir := t.TempDir()
+	claudeDir := filepath.Join(dir, ".claude")
+	_ = os.MkdirAll(claudeDir, 0o755)
+	settings := `{"teammateMode":"tmux","env":{"ANTHROPIC_AUTH_TOKEN":"test-token"}}`
+	_ = os.WriteFile(filepath.Join(claudeDir, "settings.local.json"), []byte(settings), 0o644)
+
+	msg := ensureTmuxGLMEnv(dir)
+	if msg != "" {
+		t.Errorf("tmux 밖에서는 빈 문자열이어야 함, got %q", msg)
+	}
+}
+
+// TestEnsureTmuxGLMEnv_NoTeammateModeTmux_ReturnsEmpty는 teammateMode가
+// "tmux"가 아닐 때 빈 문자열을 반환하는지 검증합니다.
+func TestEnsureTmuxGLMEnv_NoTeammateModeTmux_ReturnsEmpty(t *testing.T) {
+	// t.Setenv 사용으로 t.Parallel() 불가
+	t.Setenv("TMUX", "/tmp/fake-tmux,1234,0") // tmux 세션 안을 시뮬레이션
+
+	dir := t.TempDir()
+	claudeDir := filepath.Join(dir, ".claude")
+	_ = os.MkdirAll(claudeDir, 0o755)
+
+	// teammateMode가 없는 경우
+	settings := `{"env":{"ANTHROPIC_AUTH_TOKEN":"test-token"}}`
+	_ = os.WriteFile(filepath.Join(claudeDir, "settings.local.json"), []byte(settings), 0o644)
+
+	msg := ensureTmuxGLMEnv(dir)
+	if msg != "" {
+		t.Errorf("teammateMode가 tmux가 아닐 때 빈 문자열이어야 함 (no key), got %q", msg)
+	}
+
+	// teammateMode가 "auto"인 경우
+	settings2 := `{"teammateMode":"auto","env":{"ANTHROPIC_AUTH_TOKEN":"test-token"}}`
+	_ = os.WriteFile(filepath.Join(claudeDir, "settings.local.json"), []byte(settings2), 0o644)
+
+	msg2 := ensureTmuxGLMEnv(dir)
+	if msg2 != "" {
+		t.Errorf("teammateMode=auto일 때 빈 문자열이어야 함, got %q", msg2)
+	}
+}
+
+// TestEnsureTmuxGLMEnv_NoAuthToken_ReturnsEmpty는 ANTHROPIC_AUTH_TOKEN이 없을 때
+// 빈 문자열을 반환하는지 검증합니다.
+func TestEnsureTmuxGLMEnv_NoAuthToken_ReturnsEmpty(t *testing.T) {
+	// t.Setenv 사용으로 t.Parallel() 불가
+	t.Setenv("TMUX", "/tmp/fake-tmux,1234,0")
+
+	dir := t.TempDir()
+	claudeDir := filepath.Join(dir, ".claude")
+	_ = os.MkdirAll(claudeDir, 0o755)
+
+	// ANTHROPIC_AUTH_TOKEN 없이 teammateMode=tmux
+	settings := `{"teammateMode":"tmux","env":{"ANTHROPIC_BASE_URL":"https://api.z.ai/api/anthropic"}}`
+	_ = os.WriteFile(filepath.Join(claudeDir, "settings.local.json"), []byte(settings), 0o644)
+
+	msg := ensureTmuxGLMEnv(dir)
+	if msg != "" {
+		t.Errorf("AUTH_TOKEN 없을 때 빈 문자열이어야 함, got %q", msg)
+	}
+}
+
+// TestEnsureTmuxGLMEnv_NoSettingsFile_ReturnsEmpty는 settings.local.json이
+// 없을 때 빈 문자열을 반환하는지 검증합니다.
+func TestEnsureTmuxGLMEnv_NoSettingsFile_ReturnsEmpty(t *testing.T) {
+	// t.Setenv 사용으로 t.Parallel() 불가
+	t.Setenv("TMUX", "/tmp/fake-tmux,1234,0")
+
+	dir := t.TempDir()
+	msg := ensureTmuxGLMEnv(dir)
+	if msg != "" {
+		t.Errorf("설정 파일 없을 때 빈 문자열이어야 함, got %q", msg)
+	}
+}
+
+// TestBuildGLMTmuxEnvVars_AllGLMVars는 GLM 환경변수가 모두 있을 때
+// buildGLMTmuxEnvVars가 올바른 맵을 반환하는지 검증합니다.
+func TestBuildGLMTmuxEnvVars_AllGLMVars(t *testing.T) {
+	t.Parallel()
+
+	env := map[string]string{
+		"ANTHROPIC_AUTH_TOKEN":                     "test-glm-token",
+		"ANTHROPIC_BASE_URL":                       "https://api.z.ai/api/anthropic",
+		"ANTHROPIC_DEFAULT_OPUS_MODEL":             "glm-5.1",
+		"ANTHROPIC_DEFAULT_SONNET_MODEL":           "glm-4.7",
+		"ANTHROPIC_DEFAULT_HAIKU_MODEL":            "glm-4.7-flash",
+		"CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS":   "1",
+		"DISABLE_PROMPT_CACHING":                   "1",
+		"API_TIMEOUT_MS":                           "3000000",
+		"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+		"SOME_OTHER_VAR":                           "should-be-ignored",
+	}
+
+	result := buildGLMTmuxEnvVars(env)
+
+	// 반환된 맵에 모든 GLM 관련 변수가 포함되어야 함
+	wantKeys := []string{
+		"ANTHROPIC_AUTH_TOKEN",
+		"ANTHROPIC_BASE_URL",
+		"ANTHROPIC_DEFAULT_OPUS_MODEL",
+		"ANTHROPIC_DEFAULT_SONNET_MODEL",
+		"ANTHROPIC_DEFAULT_HAIKU_MODEL",
+		"CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS",
+		"DISABLE_PROMPT_CACHING",
+		"API_TIMEOUT_MS",
+		"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC",
+	}
+
+	for _, key := range wantKeys {
+		if _, ok := result[key]; !ok {
+			t.Errorf("결과 맵에 %q 키가 없음", key)
+		}
+	}
+
+	// 무관한 변수는 포함되지 않아야 함
+	if _, ok := result["SOME_OTHER_VAR"]; ok {
+		t.Error("무관한 변수 SOME_OTHER_VAR가 포함되면 안 됨")
+	}
+}
+
+// TestBuildGLMTmuxEnvVars_EmptyAuthToken은 AUTH_TOKEN이 없을 때
+// buildGLMTmuxEnvVars가 nil을 반환하는지 검증합니다.
+func TestBuildGLMTmuxEnvVars_EmptyAuthToken(t *testing.T) {
+	t.Parallel()
+
+	// ANTHROPIC_AUTH_TOKEN 없는 경우
+	emptyEnv := map[string]string{
+		"ANTHROPIC_BASE_URL": "https://api.z.ai/api/anthropic",
+	}
+	emptyResult := buildGLMTmuxEnvVars(emptyEnv)
+	if emptyResult != nil {
+		t.Error("AUTH_TOKEN 없을 때 nil이어야 함")
+	}
+
+	// ANTHROPIC_AUTH_TOKEN이 빈 문자열인 경우
+	emptyTokenEnv := map[string]string{
+		"ANTHROPIC_AUTH_TOKEN": "",
+		"ANTHROPIC_BASE_URL":   "https://api.z.ai/api/anthropic",
+	}
+	emptyTokenResult := buildGLMTmuxEnvVars(emptyTokenEnv)
+	if emptyTokenResult != nil {
+		t.Error("빈 AUTH_TOKEN일 때 nil이어야 함")
+	}
+}
+
+// TestEnsureTmuxGLMEnv_HandlesTmuxBinaryMissing은 tmux 바이너리가 없을 때
+// 패닉 없이 빈 문자열을 반환하는지 검증합니다.
+func TestEnsureTmuxGLMEnv_HandlesTmuxBinaryMissing(t *testing.T) {
+	// t.Setenv 사용으로 t.Parallel() 불가
+	t.Setenv("TMUX", "/tmp/fake-tmux,1234,0")
+	t.Setenv("PATH", "/nonexistent-path-for-testing")
+
+	dir := t.TempDir()
+	claudeDir := filepath.Join(dir, ".claude")
+	_ = os.MkdirAll(claudeDir, 0o755)
+
+	settings := map[string]any{
+		"teammateMode": "tmux",
+		"env": map[string]string{
+			"ANTHROPIC_AUTH_TOKEN":                     "test-token",
+			"ANTHROPIC_BASE_URL":                       "https://api.z.ai/api/anthropic",
+			"ANTHROPIC_DEFAULT_OPUS_MODEL":             "glm-5.1",
+			"ANTHROPIC_DEFAULT_SONNET_MODEL":           "glm-4.7",
+			"ANTHROPIC_DEFAULT_HAIKU_MODEL":            "glm-4.7-flash",
+			"CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS":   "1",
+			"DISABLE_PROMPT_CACHING":                   "1",
+		},
+	}
+	data, _ := json.MarshalIndent(settings, "", "  ")
+	_ = os.WriteFile(filepath.Join(claudeDir, "settings.local.json"), data, 0o644)
+
+	// tmux 바이너리 없을 때 패닉 없이 빈 문자열 반환해야 함
+	msg := ensureTmuxGLMEnv(dir)
+	if msg != "" {
+		t.Logf("tmux 바이너리가 없는데 non-empty 반환됨 (PATH 격리 불완전): %q", msg)
+	}
+	// 패닉이 발생하지 않으면 성공
+}
+
+// TestBuildGLMTmuxEnvVars_OnlyPresentVars는 설정 파일에 있는 변수만
+// 결과에 포함되는지 검증합니다 (없는 변수는 포함 안 됨).
+func TestBuildGLMTmuxEnvVars_OnlyPresentVars(t *testing.T) {
+	t.Parallel()
+
+	// 일부 GLM 변수만 있는 경우
+	env := map[string]string{
+		"ANTHROPIC_AUTH_TOKEN": "test-token",
+		"ANTHROPIC_BASE_URL":   "https://api.z.ai/api/anthropic",
+		// 모델명 없음
+	}
+
+	result := buildGLMTmuxEnvVars(env)
+	if result == nil {
+		t.Fatal("AUTH_TOKEN 있을 때 nil이면 안 됨")
+	}
+
+	// AUTH_TOKEN과 BASE_URL은 있어야 함
+	if result["ANTHROPIC_AUTH_TOKEN"] != "test-token" {
+		t.Errorf("AUTH_TOKEN = %q, want %q", result["ANTHROPIC_AUTH_TOKEN"], "test-token")
+	}
+	if result["ANTHROPIC_BASE_URL"] != "https://api.z.ai/api/anthropic" {
+		t.Errorf("BASE_URL = %q, want Z.AI endpoint", result["ANTHROPIC_BASE_URL"])
+	}
+
+	// 설정에 없는 모델 키는 포함되지 않아야 함
+	if _, ok := result["ANTHROPIC_DEFAULT_OPUS_MODEL"]; ok {
+		t.Error("설정에 없는 OPUS_MODEL이 포함되면 안 됨")
+	}
+}
+
+// TestFormatTmuxGLMEnvSummary_ContainsVarCount는 성공 시 반환 문자열에
+// 주입된 변수 수가 포함되는지 검증합니다.
+func TestFormatTmuxGLMEnvSummary_ContainsVarCount(t *testing.T) {
+	t.Parallel()
+
+	summary := formatTmuxGLMEnvSummary(9)
+	if !strings.Contains(summary, "9") {
+		t.Errorf("요약 문자열에 변수 수(9)가 포함되어야 함, got %q", summary)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #640 — `moai glm` + `--team` 조합 시 tmux pane 팀원 401 Unauthorized 에러.

### Root Cause
- `moai glm`이 tmux 세션 env에 `ANTHROPIC_AUTH_TOKEN`을 주입하는 경로는 사용자가 **tmux 안에서** `moai glm`을 실행한 경우에만 동작
- 사용자가 tmux 밖에서 `moai glm` 실행 후 tmux로 옮겨 `claude`를 시작하면 tmux 세션 env는 비어 있고, `--team`이 spawn하는 새 pane 팀원들은 401 에러 발생
- `injectGLMEnvForTeam`이 `settings.local.json`에 env를 쓰지만, 새 tmux pane이 생성될 때 이 값은 자동 전파되지 않음

### Primary Fix: SessionStart 훅 자동 복구 (`internal/hook/glm_tmux.go` 신규)
- `ensureTmuxGLMEnv(projectDir)` 핵심 오케스트레이션
  - TMUX == "" / teammateMode != "tmux" / AUTH_TOKEN 없음 → no-op
  - 조건 통과 시 `tmux.SessionManager.InjectEnv`로 GLM 변수 일괄 주입
  - tmux 바이너리 missing → `slog.Warn` + "" 반환 (세션 abort 금지)
- 주입 대상 변수: `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BASE_URL`, `ANTHROPIC_DEFAULT_*_MODEL`, 호환 플래그 5종
- `session_start.go`의 Handle()에서 `ensureTeammateMode` 직후 호출

### Secondary Fix: `moai glm` 비-tmux 경로 경고 강화
- 기존의 모호한 "tmux session: NOT DETECTED" 문구 → actionable 4단계 권장 절차 안내

## Test plan

- [x] `TestEnsureTmuxGLMEnv_NotInTmux_ReturnsEmpty` — PASS
- [x] `TestEnsureTmuxGLMEnv_NoTeammateModeTmux_ReturnsEmpty` — PASS
- [x] `TestEnsureTmuxGLMEnv_NoAuthToken_ReturnsEmpty` — PASS
- [x] `TestEnsureTmuxGLMEnv_NoSettingsFile_ReturnsEmpty` — PASS
- [x] `TestEnsureTmuxGLMEnv_HandlesTmuxBinaryMissing` — PASS
- [x] `TestBuildGLMTmuxEnvVars_{AllGLMVars,EmptyAuthToken,OnlyPresentVars}` — PASS
- [x] `TestFormatTmuxGLMEnvSummary_ContainsVarCount` — PASS
- [x] `go test ./... -race -count=1` — 전체 패키지 PASS
- [x] `golangci-lint run` — 0 issues

### Limitation
실제 `tmux set-environment` 호출 경로는 CI에 tmux가 없어 단위 테스트로 검증할 수 없습니다. 순수 함수(`buildGLMTmuxEnvVars`, `formatTmuxGLMEnvSummary`)와 guard 경로를 분리하여 커버리지를 확보했고, tmux 바이너리 missing graceful 처리도 검증됨.

Fixes #640

🗿 MoAI <email@mo.ai.kr>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic environment variable propagation for GLM teammates in tmux sessions, enhancing team collaboration capabilities.

* **Improvements**
  * Enhanced error messages with comprehensive step-by-step instructions for setting up GLM in tmux when required for team operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->