### PR TITLE
[SPEC-OPUS47-COMPAT-001] Claude Code v2.1.110/111 + Opus 4.7 프롬프트 철학 호환성

### DIFF
--- a/.claude/rules/moai/core/agent-common-protocol.md
+++ b/.claude/rules/moai/core/agent-common-protocol.md
@@ -131,6 +131,16 @@ Avoid:
 | Run system commands | Bash | — |
 | Explore codebase | Agent(Explore) | Multiple sequential Grep calls |
 
+### Bash Timeout
+
+The Bash tool supports an optional `timeout` parameter (milliseconds):
+
+- Default: 120,000ms (2 minutes)
+- Maximum: 600,000ms (10 minutes)
+- Use for long-running commands: builds, test suites, installs
+
+Specify via the `timeout` field when the command is expected to run longer than 2 minutes.
+
 ### Error Recovery Pattern
 
 When a tool call fails:

--- a/.claude/rules/moai/core/moai-constitution.md
+++ b/.claude/rules/moai/core/moai-constitution.md
@@ -41,6 +41,18 @@ Rules:
 - For team mode: Use TeamCreate for persistent team coordination, SendMessage for inter-teammate communication
 - Team agents share TaskList for work coordination; sub-agents return results directly
 
+## Opus 4.7 Prompt Philosophy
+
+Reasoning-intensive agents targeting `claude-opus-4-7` must follow Anthropic's official prompt guidelines (platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7).
+
+Rules:
+- One-turn fully-loaded: deliver intent + constraints + completion criteria + file locations in a single agent prompt. Avoid multi-turn ping-pong which wastes tokens on Opus 4.7
+- Adaptive Thinking: do NOT set fixed thinking budgets via `budget_tokens`; Opus 4.7 rejects fixed budgets with HTTP 400. Let the model self-allocate reasoning depth
+- Remove Opus 4.6-era defensive scaffolding: "double-check X before returning", "verify N times", "explicitly confirm before proceeding" patterns are counterproductive on Opus 4.7's literal instruction following
+- [HARD] Principle 4 — Fewer subagents spawned by default: Opus 4.7 does not auto-spawn subagents. When fan-out is needed, explicitly instruct "Use agent-A, agent-B in parallel (single message, multiple Agent() calls)" in the prompt
+- [HARD] Principle 5 — Fewer tool calls by default, more reasoning: Opus 4.7 prefers reasoning over tool invocation. When tool use is expected, specify "when and why to use each tool (Grep for content search, Glob for file discovery, Read for full-file context)" in the agent prompt
+- Effort level selection: reasoning-intensive agents (manager-spec, manager-strategy, plan-auditor, evaluator-active, expert-security, expert-refactoring) → `effort: xhigh` or `high`; implementation agents (expert-backend, expert-frontend, builder-*) → `effort: high` (default for Opus 4.7); speed-critical agents (manager-git, Explore) → `effort: medium`
+
 ## Output Format
 
 Never display XML tags in user-facing responses.

--- a/.claude/rules/moai/core/settings-management.md
+++ b/.claude/rules/moai/core/settings-management.md
@@ -103,6 +103,9 @@ Hooks support environment variables and must be quoted to handle spaces:
 
 **Important**: Quote the entire path: `"\"$CLAUDE_PROJECT_DIR/path\""` not `"$CLAUDE_PROJECT_DIR/path"`
 
+Hook timeout range: 1–600,000ms (max 10 minutes). Default is 5,000ms for most hooks.
+Long-running hooks (PostToolUse, quality gates) should set `"timeout": 60000` or higher.
+
 ## StatusLine Configuration
 
 StatusLine does NOT support environment variables. Use relative paths from project root:

--- a/.claude/rules/moai/development/agent-authoring.md
+++ b/.claude/rules/moai/development/agent-authoring.md
@@ -35,7 +35,7 @@ All agent definitions use YAML frontmatter. The following fields are available:
 | memory | No | None | Persistent memory scope for cross-session learning |
 | background | No | false | Run agent in background without blocking conversation (v2.1.46+) |
 | color | No | None | Display color in UI: red, blue, green, yellow, purple, orange, pink, cyan |
-| effort | No | inherit | Session effort override: low, medium, high, max (max is Opus 4.6 only) |
+| effort | No | inherit | Session effort override: low, medium, high, xhigh, max (xhigh/max require Opus 4.7+) |
 | initialPrompt | No | None | Auto-submitted first user turn when agent runs as main session agent via --agent flag (v2.1.83+) |
 | isolation | No | none | Isolation mode: "worktree" creates isolated git worktree (v2.1.49+) |
 
@@ -55,7 +55,7 @@ All agent definitions use YAML frontmatter. The following fields are available:
 
 **isolation**: Controls agent execution isolation. When set to "worktree", the agent runs in an isolated git worktree, preventing conflicts with the main working directory. Available since Claude Code v2.1.49.
 
-**effort**: Overrides session effort level for this agent. Valid values: `low`, `medium`, `high`, `max`. The `max` value is only supported on Opus 4.6 models.
+**effort**: Overrides session effort level for this agent. Valid values: `low`, `medium`, `high`, `xhigh`, `max`. The `xhigh` and `max` values require Opus 4.7 or later. On Opus 4.6, the highest supported effort level is `high`.
 
 **color**: Display color for the agent in the task list and transcript UI. Valid values: `red`, `blue`, `green`, `yellow`, `purple`, `orange`, `pink`, `cyan`.
 
@@ -191,6 +191,16 @@ Notes:
 - Dynamic teammates use `mode: "plan"` for read-only enforcement instead of tool restrictions
 - Project-specific context is included in the spawn prompt, not preloaded skills
 - Teammates can self-load skills via Skill() tool when deeper documentation is needed
+
+## Bash Tool Timeout Ceiling
+
+The Claude Code runtime enforces a hard ceiling on the Bash tool's `timeout` parameter:
+
+- Default: 120,000ms (2 minutes)
+- **Maximum: 600,000ms (10 minutes)** — values above this are rejected by Claude Code v2.1.110+
+- When authoring agent prompts that invoke long-running Bash commands (build, test suite, install), specify `timeout` explicitly up to the 600,000ms ceiling
+- Do NOT attempt to specify Bash tool timeouts exceeding 600,000ms; the runtime silently clamps or rejects them
+- Enforcement is performed by Claude Code itself, not by moai-adk-go; documentation here is for agent authors to avoid invalid values
 
 ## Agent Invocation
 

--- a/.claude/rules/moai/development/coding-standards.md
+++ b/.claude/rules/moai/development/coding-standards.md
@@ -71,6 +71,19 @@ Enforcement: `internal/template/commands_audit_test.go` verifies this pattern on
 
 Source: SPEC-THIN-CMDS-001
 
+## Claude Code Version Compatibility
+
+Settings fields introduced by specific Claude Code versions:
+
+| Field | Version | Notes |
+|-------|---------|-------|
+| `effortLevel` | v2.1.110 | Sets CLAUDE_CODE_EFFORT_LEVEL; values: low/medium/high/xhigh/max |
+| `disableBypassPermissionsMode` | v2.1.111 | Prevents agents from using bypassPermissions mode when true |
+| `Bash(timeout=N)` | v2.1.110 | Per-command Bash timeout in ms; max 600,000ms |
+
+When adding new settings fields, update `internal/template/templates/.claude/settings.json.tmpl`
+and this compatibility table.
+
 ## Paths Frontmatter
 
 Use paths frontmatter for conditional rule loading:

--- a/.claude/rules/moai/workflow/worktree-integration.md
+++ b/.claude/rules/moai/workflow/worktree-integration.md
@@ -271,8 +271,13 @@ Both share the same project structure. `src/auth/handler.go` resolves correctly 
 | `Ctrl+X Ctrl+K` to kill background agent | 2.1.83 | Kill stuck background agents |
 | Worktree CWD isolation fix | **2.1.97** | Prior versions leaked agent CWD back to parent session |
 | Stop/SubagentStop hook stability | **2.1.97** | Prior versions failed on long-running sessions |
+| `moai doctor` MCP scope duplicate detection | **2.1.110** | Warns on MCP server duplication across `.mcp.json` + settings.json |
+| Bash tool timeout ceiling enforcement | **2.1.110** | Maximum 600,000ms (10 min) enforced by runtime |
+| `effortLevel` setting for Opus 4.7 | **2.1.110** | Supports `low`/`medium`/`high`/`xhigh`/`max` effort levels |
+| `CLAUDE_ENV_FILE` on Windows | **2.1.111** | Prior versions: no-op on Windows; fixed to inject env as on macOS/Linux |
+| `disableBypassPermissionsMode` policy | **2.1.111** | Prevents agents from requesting `bypassPermissions` when `true` |
 
-**Recommended**: Claude Code **2.1.97 or later** for reliable worktree isolation and hook stability.
+**Recommended**: Claude Code **2.1.111 or later** for Opus 4.7 support, MCP doctor warnings, and Windows CLAUDE_ENV_FILE parity. Minimum baseline: **2.1.97** for worktree isolation.
 
 ## Troubleshooting
 

--- a/.moai/config/sections/harness.yaml
+++ b/.moai/config/sections/harness.yaml
@@ -39,6 +39,14 @@ harness:
       - test_coverage_low    # Coverage < 70% -> escalate to standard+
     max_escalations: 2
 
+  # Effort level mapping
+  # Maps harness depth to CLAUDE_CODE_EFFORT_LEVEL for Opus 4.7 adaptive thinking.
+  # Deeper harness = more extended reasoning budget for evaluator and planner agents.
+  effort_mapping:
+    minimal:  "medium"   # Fast iteration: no extended reasoning
+    standard: "high"     # Balanced quality: moderate reasoning budget
+    thorough: "xhigh"    # Critical features: maximum reasoning budget
+
   # Level definitions
   levels:
     minimal:

--- a/.moai/config/sections/system.yaml
+++ b/.moai/config/sections/system.yaml
@@ -27,9 +27,9 @@ github:
     enable_trust_5: true
     spec_git_workflow: feature_branch
 moai:
-    template_version: v2.10.2
+    template_version: v2.11.0
     update_check_frequency: daily
-    version: v2.10.2
+    version: v2.11.0
     version_check:
         cache_ttl_hours: 24
         enabled: true

--- a/.moai/project/product.md
+++ b/.moai/project/product.md
@@ -145,12 +145,13 @@ Code analysis via structural AST (Abstract Syntax Tree) pattern matching.
 
 ### 11. Multi-Model Architecture
 
-Support for multiple LLM providers and hybrid cost-optimization modes.
+Support for multiple LLM providers and hybrid cost-optimization modes with Opus 4.7 integration.
 
-- **Claude Mode** (`moai cc`): Full Claude model stack with per-agent model assignment (opus, sonnet, haiku) controlled by model policy
+- **Claude Mode** (`moai cc`): Full Claude model stack including Opus 4.7 with 5-level effort scaling (low/medium/high/xhigh/max) for critical reasoning agents, with automatic fallback to Opus 4.6/Sonnet 4.6/Haiku 4.5 for backward compatibility (Requires Claude Code v2.1.110+)
+- **Opus 4.7 Prompt Philosophy**: Built-in support for Opus 4.7's "one-turn fully-loaded" principle with effort configuration at agent level, enabling xhigh/max effort assignments for critical reasoning workflows (manager-spec, plan-auditor, evaluator-active, manager-strategy, expert-security, expert-refactoring)
 - **GLM Mode** (`moai glm`): Switch all agents to Z.AI's GLM models for cost reduction
 - **Hybrid CG Mode** (`moai cg`): Claude leader with GLM workers via worktree-based environment isolation for 60-70% cost reduction on implementation tasks
-- **Model Policy** (`moai init --model-policy`): Apply high/medium/low model distribution across all agent definitions based on role-specific mappings
+- **Model Policy** (`moai init --model-policy`): Apply high/medium/low/xhigh/max effort distribution across all agent definitions based on role-specific mappings and model capabilities
 
 ### 12. Agent Teams Integration (Experimental)
 

--- a/.moai/project/structure.md
+++ b/.moai/project/structure.md
@@ -66,7 +66,7 @@ moai-adk-go/
 │   ├── cli/                        # Cobra CLI commands
 │   │   ├── cc.go                   #   Claude Code integration commands
 │   │   ├── deps.go                 #   Dependency injection and wiring
-│   │   ├── doctor.go
+│   │   ├── doctor.go               #   Diagnostics (MCP scope duplicate detection v2.1.110+)
 │   │   ├── glm.go                  #   GLM (Go Language Model) commands
 │   │   ├── hook.go                 #   Hook dispatcher (moai hook <event>)
 │   │   ├── init.go
@@ -135,7 +135,7 @@ moai-adk-go/
 │   │   ├── doc.go
 │   │   ├── errors.go
 │   │   ├── notification.go         #   Notification hook handler
-│   │   ├── permission_request.go   #   Permission request hook handler
+│   │   ├── permission_request.go   #   Permission request hook handler (updatedInput deny re-validation v2.1.110+)
 │   │   ├── post_tool.go            #   Linter, formatter, LSP diagnostics
 │   │   ├── post_tool_failure.go    #   Post-tool failure handler
 │   │   ├── pre_tool.go             #   Security guard, validation
@@ -143,7 +143,7 @@ moai-adk-go/
 │   │   ├── rank_session.go         #   Session ranking hook handler
 │   │   ├── registry.go             #   Hook registration & dispatch
 │   │   ├── session_end.go          #   Cleanup, rank submission
-│   │   ├── session_start.go        #   Project info, config validation
+│   │   ├── session_start.go        #   Project info, config validation, Windows CLAUDE_ENV_FILE injection (v2.1.111+)
 │   │   ├── stop.go                 #   Loop controller
 │   │   ├── subagent_start.go       #   Subagent start hook handler
 │   │   ├── task_completed.go       #   Task completed hook handler
@@ -201,9 +201,10 @@ moai-adk-go/
 │   │   ├── deployer.go             #   go:embed extraction with manifest
 │   │   ├── deployer_mode.go        #   Model policy application to agent definitions
 │   │   ├── errors.go               #   Template error types
-│   │   ├── model_policy.go         #   Per-agent model assignment (high/medium/low)
+│   │   ├── model_policy.go         #   Per-agent model assignment (5-level effort: low/medium/high/xhigh/max; Opus 4.7 support)
+│   │   ├── agent_effort_map.go     #   Effort level mapping for critical reasoning agents (SPEC-OPUS47-COMPAT-001)
 │   │   ├── renderer.go             #   Go text/template strict rendering
-│   │   ├── settings.go             #   Platform-aware settings.json generation
+│   │   ├── settings.go             #   Platform-aware settings.json generation (v2.1.110+ disableBypassPermissionsMode)
 │   │   ├── validator.go            #   Post-deployment validation
 │   │   └── templates/              #   go:embed source (bundled into binary)
 │   │       ├── .claude/            #       Agent definitions, skills, commands, rules

--- a/.moai/project/tech.md
+++ b/.moai/project/tech.md
@@ -6,6 +6,22 @@
 
 Go is the implementation language for the MoAI-ADK rewrite. The project uses Go 1.26, which provides Green Tea GC (10-40% GC overhead reduction), enhanced routing patterns in `net/http`, range-over-int iterators, and the latest `log/slog` structured logging capabilities.
 
+## Claude Code Integration
+
+**Minimum Recommended Version: Claude Code v2.1.110** (released April 2026)
+
+MoAI-ADK v2.12+ requires Claude Code v2.1.110 or later to support:
+- MCP scope duplicate detection in `moai doctor` (v2.1.110+)
+- Bash tool timeout ceiling enforcement (600,000ms) (v2.1.110+)
+- `disableBypassPermissionsMode` policy for security gates (v2.1.110+)
+
+**Opus 4.7 Support** (v2.12.0+):
+- Model: `claude-opus-4-7`
+- Effort levels: `low`, `medium`, `high`, `xhigh` (default), `max`
+- Recommended for: manager-spec, plan-auditor, evaluator-active, manager-strategy, expert-security, expert-refactoring
+- Backward compatibility: Opus 4.6, Sonnet 4.6, Haiku 4.5 supported with effort field auto-downgrade
+- Windows support: CLAUDE_ENV_FILE injection via SessionStart hook (v2.12.0+)
+
 ## Go Module
 
 ```

--- a/.moai/specs/SPEC-OPUS47-COMPAT-001/acceptance.md
+++ b/.moai/specs/SPEC-OPUS47-COMPAT-001/acceptance.md
@@ -1,0 +1,198 @@
+---
+id: SPEC-OPUS47-COMPAT-001
+version: 0.1.1
+status: draft
+created: 2026-04-17
+updated: 2026-04-17
+author: GOOS행님
+priority: critical
+issue_number: 671
+---
+
+# Acceptance Criteria: SPEC-OPUS47-COMPAT-001
+
+## Primary Scenarios (Given / When / Then)
+
+### Scenario GWT-1 — REQ-OC-001: Opus 4.7 프로파일 생성
+
+- **Given**: 사용자가 신규 MoAI 프로젝트에서 `moai profile` 명령으로 대화형 설정을 시작하고, moai-adk-go 바이너리는 본 SPEC의 P0 변경사항이 적용된 버전이다.
+- **When**: 사용자가 모델 선택 단계에서 `claude-opus-4-7`을 선택하고 effort 단계에서 `xhigh`를 선택한 뒤 저장을 완료한다.
+- **Then**:
+  - `~/.moai/claude-profiles/<name>/preferences.yaml` 파일이 생성된다
+  - 파일 내용에 `model: claude-opus-4-7` 라인이 존재한다
+  - 파일 내용에 `effort_level: xhigh` (또는 동등한 YAML 키) 라인이 존재한다
+  - `moai cc` 실행 시 Claude Code 런처에 해당 모델 ID가 전달된다
+  - 기존 `claude-opus-4-6` 선택지도 여전히 나타난다 (하위 호환성)
+
+### Scenario GWT-2 — REQ-OC-002: Agent frontmatter effort 필드 전파
+
+- **Given**: `internal/template/templates/.claude/agents/moai/manager-spec.md`에 `effort: xhigh`가 추가되고 `make build`가 수행되었다.
+- **When**: 사용자가 `moai init test-project`로 신규 프로젝트를 초기화한다.
+- **Then**:
+  - `test-project/.claude/agents/moai/manager-spec.md` 파일이 배포된다
+  - 해당 파일의 YAML frontmatter에 `effort: xhigh` 필드가 정확히 존재한다
+  - manager-strategy는 `effort: xhigh`, plan-auditor/evaluator-active/expert-security/expert-refactoring는 `effort: high`로 설정되어 있다
+  - 나머지 22개 agent(research.md D-6 Agent Inventory 기준)의 frontmatter에는 `effort` 키가 존재하지 않는다 (런타임에서 Opus 4.7 기본값 `xhigh`, 타 모델은 `high`로 내부 폴백 처리됨은 단위 테스트로 별도 검증)
+
+### Scenario GWT-3 — REQ-OC-002: skill-authoring.md 문구 정정
+
+- **Given**: P0 적용 전 `skill-authoring.md`는 `effort: Session effort override: low, medium, high, max (max is Opus 4.6 only)` 문구를 포함한다.
+- **When**: P0 적용 후 `make build`가 수행되고 `internal/template/embedded.go`가 재생성된다.
+- **Then**:
+  - `rg "max is Opus 4.6 only" internal/template/templates/`가 0건을 반환한다
+  - `skill-authoring.md`에 `effort` 5단계(`low`/`medium`/`high`/`xhigh`/`max`)가 명시되며 Opus 4.7 주석이 포함된다
+  - 기존 다른 스킬 문서에서도 동일 문구가 잔존하지 않는다
+
+### Scenario GWT-4 — REQ-OC-003: moai doctor MCP 중복 경고
+
+- **Given**: 테스트 프로젝트의 `.mcp.json`에 `context7` 서버가 `project` scope로 등록되어 있고, 동시에 `.claude/settings.json`에도 `context7` 서버가 `local` scope로 등록되어 있다.
+- **When**: 사용자가 `moai doctor`를 실행한다.
+- **Then**:
+  - 실행 결과에 MCP scope 중복 관련 경고 메시지가 출력된다
+  - 경고 메시지는 중복된 서버 이름(`context7`)과 두 스코프 출처를 명시한다
+  - exit code는 0이다 (warning만 발생, 차단 금지)
+  - `.mcp.json`만 존재하고 `settings.json`에 MCP 설정이 없는 경우 경고는 발생하지 않는다
+
+### Scenario GWT-5 — REQ-OC-003: settings.json 정책 키 + Bash timeout 문서화
+
+- **Given**: P1 적용 후 `internal/template/templates/.claude/settings.json`과 `agent-authoring.md`/`agent-common-protocol.md`가 업데이트되었다.
+- **When**: 사용자가 `moai init test-project`를 실행하거나 `moai update`를 실행한다.
+- **Then**:
+  - 렌더링된 `test-project/.claude/settings.json`에 `disableBypassPermissionsMode` 키가 존재한다 (기본값 `false`, 하위 호환성)
+  - JSON validity가 유지되며 `jq . settings.json` 파싱이 성공한다
+  - `agent-authoring.md`에서 `rg "600,?000ms"` 또는 `rg "Bash tool timeout ceiling"` 검색 시 1건 이상 매치(Bash tool timeout 상한 600,000ms가 명시적으로 문서화됨)
+  - `agent-common-protocol.md`에서도 동일 내용이 문서화됨(`rg "600,?000ms" internal/template/templates/.claude/rules/moai/core/agent-common-protocol.md` ≥ 1건)
+  - 주의: Bash timeout 상한의 실제 enforcement는 Claude Code 런타임이 수행하며, moai-adk-go 수준에서는 문서화만 수행한다(REQ-OC-003(c) 정의와 일치, Exclusions 정책 준수)
+
+### Scenario GWT-6 — REQ-OC-004: Windows CLAUDE_ENV_FILE 주입
+
+- **Given**: `GOOS=windows` 로 빌드된 moai 바이너리를 Windows 환경(또는 Wine/VM)에서 실행하며, `envkeys.go`의 `CLAUDE_ENV_FILE` 상수에 대응하는 환경 파일이 존재한다.
+- **When**: Claude Code가 `moai hook session-start`를 호출한다.
+- **Then**:
+  - 훅 실행 결과로 `CLAUDE_ENV_FILE` 환경변수가 자식 프로세스(Claude Code)에 주입된다
+  - 주입된 값은 `envkeys.go:70-72`에 정의된 상수와 일치한다
+  - macOS/Linux에서 동일 훅 실행 시 기존 `injectGLMEnvForTeam`/`ensureTmuxGLMEnv` 동작이 변경 없이 유지된다 (회귀 없음)
+  - 환경 파일이 존재하지 않는 경우 graceful skip(에러 없이 진행)한다
+
+### Scenario GWT-7 — REQ-OC-005: 프롬프트 스캐폴딩 제거
+
+- **Given**: 본 SPEC P0 적용 전 `manager-spec.md` 본문에 "double-check your output before returning" 또는 "verify 2-3 times" 류 문구가 포함되어 있다.
+- **When**: P0 적용 후 `make build`가 수행된다.
+- **Then**:
+  - `rg -l "double-check|verify \d+ times|explicitly confirm before" internal/template/templates/.claude/agents/moai/manager-spec.md`가 **0건**을 반환한다(하드 기준)
+  - manager-strategy, plan-auditor, evaluator-active, expert-security, expert-refactoring 5개 파일에서도 동일 rg 검색 시 각각 **0건** 반환(하드 기준)
+  - 워크플로우 핵심 스텝(Step 1-6 등)은 삭제되지 않고 유지된다 (feedback_agent_refactor_constraint 준수). 워크플로우 스텝 수는 P0 적용 전과 동일하거나 더 많아야 한다.
+
+### Scenario GWT-8 — REQ-OC-005: Adaptive Thinking 고정 예산 지시 제거
+
+- **Given**: P0 적용 전 `moai-workflow-thinking/SKILL.md` 또는 관련 모듈에 "thinking budget 10000 tokens" 또는 "set thinking.budget_tokens to N" 류 지시가 존재한다.
+- **When**: P0 적용 후 `make build` 수행.
+- **Then**:
+  - `rg -l "thinking\.budget_tokens|thinking budget \d+" internal/template/templates/.claude/skills/moai-workflow-thinking/`가 0건을 반환한다
+  - SKILL.md에 "Adaptive Thinking is Opus 4.7's only supported thinking mode" 같은 원칙 설명이 존재한다
+  - Sequential Thinking MCP(`--deepthink`, `server_tool_use` 경로) 관련 지시는 온전히 유지된다 (Context Dump §F 충돌 해소 검증)
+
+## Edge Cases
+
+### EC-1 — Opus 4.6 사용자의 기존 프로파일 보존
+
+- **Given**: 사용자가 본 SPEC 적용 전 이미 `model: claude-opus-4-6`으로 프로파일을 저장해둔 상태이다.
+- **When**: 사용자가 본 SPEC P0가 적용된 새 바이너리로 `moai cc`를 실행한다.
+- **Then**: 기존 preferences.yaml이 변경되지 않고 Opus 4.6 세션이 정상 시작된다. 4.7로의 강제 마이그레이션은 발생하지 않는다.
+
+### EC-2 — effort 필드 미지원 모델에서 무시 처리
+
+- **Given**: 사용자의 프로파일이 `model: claude-sonnet-4-6`이고 agent frontmatter에 `effort: xhigh`가 설정되어 있다.
+- **When**: Claude Code 세션이 시작되고 해당 agent가 호출된다.
+- **Then**: Sonnet 4.6은 effort 필드를 지원하지 않으므로 해당 값이 무시되고 정상 동작한다. moai-adk-go가 warning을 출력하거나 차단하지 않는다.
+
+### EC-3 — GLM 모드에서 effort 필드 처리
+
+- **Given**: 사용자가 `moai glm` 모드로 실행 중이다 (`GLM_API_KEY` 환경 주입, `glm-5.1` 모델).
+- **When**: agent에 `effort: xhigh`가 설정되어 있다.
+- **Then**: moai-adk-go 레벨에서 에러가 발생하지 않는다. 구체적으로: (1) `moai glm` 실행 시 non-zero exit이 발생하지 않고, (2) `llm.yaml`의 `glm.models` 매핑이 그대로 적용되며, (3) settings.local.json 주입 과정에서 effort 필드로 인한 파싱 실패가 없다. GLM 엔드포인트(`https://api.z.ai/api/anthropic`)의 응답 처리는 외부 시스템 동작이므로 본 SPEC 테스트 대상 외.
+
+### EC-4 — MCP scope 중복 의도적 override 케이스
+
+- **Given**: 사용자가 `.mcp.json`에 `project` scope로 `context7`을 정의하고, 개인 개발 환경에서만 `.claude/settings.local.json`에 `local` scope로 override를 추가한 상태이다.
+- **When**: `moai doctor` 실행.
+- **Then**: 경고는 발생하되, 메시지에 "local scope override는 의도적일 수 있음"이라는 안내가 포함된다. exit code 0 유지.
+
+### EC-5 — macOS에서 CLAUDE_ENV_FILE 주입 비활성
+
+- **Given**: macOS 환경에서 `moai hook session-start`를 실행한다.
+- **When**: 훅 핸들러가 `runtime.GOOS`를 확인한다.
+- **Then**: `darwin` 분기이므로 `injectCLAUDEEnvFile` 신규 함수는 호출되지 않는다. 기존 tmux GLM env 주입 경로만 실행된다.
+
+## Quality Gates
+
+### QG-1 — LSP Quality Gate (run phase)
+
+- `.moai/config/sections/quality.yaml`의 `lsp_quality_gates.run.max_errors: 0` 기준 충족
+- `go vet ./...` 0 errors
+- `golangci-lint run` 0 errors
+- `go test -race ./...` 전체 통과
+- `go test -cover ./internal/profile/... ./internal/template/... ./internal/cli/... ./internal/hook/...` 85%+ coverage 유지
+
+### QG-2 — Template Integrity
+
+- `make build` 후 `git diff --exit-code internal/template/embedded.go` 통과 (재생성 누락 방지)
+- `internal/template/templates/` 변경 파일 수와 `embedded.go` 반영 파일 수 일치
+
+### QG-3 — Backward Compatibility
+
+- 기존 Opus 4.6/Sonnet 4.6/Haiku 4.5 모델이 카탈로그에 여전히 존재
+- 기존 `ModelPolicy` 3단계(`high`/`medium`/`low`) API 시그니처 유지(`IsValidModelPolicy`, `ValidModelPolicies`, `GetAgentModel`)
+- 기존 `.moai/config/sections/llm.yaml` 사용자 설정 마이그레이션 없이 동작
+
+### QG-4 — Language Neutrality (NFR-3)
+
+- `internal/template/templates/` 전체에서 특정 언어를 "PRIMARY"로 배치한 코드 없음
+- 16개 지원 언어(go/python/typescript/.../flutter)가 동등 수준으로 유지됨
+- 본 SPEC으로 인해 특정 언어만 enabled 되고 나머지가 planned로 격하되지 않음
+
+### QG-5 — SPEC vs Implementation Boundary
+
+- 본 SPEC 단계에서 실제 Go 코드·YAML·Markdown 파일 수정이 발생하지 않았음 (Plan-Run 경계 유지)
+- 수정은 `/moai run SPEC-OPUS47-COMPAT-001` 단계에서만 수행
+
+## Definition of Done (DoD)
+
+### DoD Checklist
+
+- [ ] spec.md의 5개 EARS 요구사항(REQ-OC-001 ~ REQ-OC-005)이 모두 acceptance 시나리오에 매핑되었다
+- [ ] Primary Scenarios GWT-1 ~ GWT-8 모두 테스트 통과
+- [ ] Edge Cases EC-1 ~ EC-5 모두 검증 완료
+- [ ] Quality Gates QG-1 ~ QG-5 모두 통과
+- [ ] P0/P1/P2 각 phase 별로 독립 commit 가능한 상태
+- [ ] Opus 4.7 모델 카탈로그에 `claude-opus-4-7` 등록 확인
+- [ ] 6개 reasoning agent의 frontmatter에 `effort` 필드 설정 확인
+- [ ] `skill-authoring.md`에서 "max is Opus 4.6 only" 문구 제거 확인
+- [ ] `moai doctor` MCP 중복 감지 동작 확인
+- [ ] Windows `CLAUDE_ENV_FILE` 주입 확인(VM 또는 `GOOS=windows` cross-compile 테스트)
+- [ ] `settings.json`에 `disableBypassPermissionsMode` 키 존재 확인
+- [ ] `moai-workflow-thinking/SKILL.md`에서 고정 예산 지시 제거 확인
+- [ ] `make build` 실행 및 `embedded.go` 재생성 커밋 포함
+- [ ] `go test -race ./...` 전체 통과
+- [ ] `golangci-lint run` 0 errors
+- [ ] GitHub Issue 생성 완료 및 `issue_number` frontmatter 업데이트
+- [ ] CHANGELOG.md v2.12.0 항목 추가(P2)
+
+### Traceability Matrix
+
+| EARS 요구사항 | Primary Scenarios | Edge Cases | Quality Gates |
+|---------------|-------------------|------------|---------------|
+| REQ-OC-001    | GWT-1             | EC-1, EC-3 | QG-1, QG-3    |
+| REQ-OC-002    | GWT-2, GWT-3      | EC-2       | QG-2, QG-4    |
+| REQ-OC-003    | GWT-4, GWT-5      | EC-4       | QG-1, QG-2    |
+| REQ-OC-004    | GWT-6             | EC-5       | QG-1          |
+| REQ-OC-005    | GWT-7, GWT-8      | -          | QG-2          |
+
+## Rollback Criteria
+
+다음 중 하나라도 발생 시 본 SPEC 적용을 즉시 revert하고 대안 설계를 수립한다:
+
+- Opus 4.6 사용자의 기존 `preferences.yaml`이 자동 마이그레이션 과정에서 손상
+- `session_start.go` Windows 분기 추가가 macOS/Linux tmux GLM 주입을 깨뜨림 (R-P1-1 현실화)
+- `disableBypassPermissionsMode: false` 기본값이 실제로는 `true`로 해석되어 기존 bypassPermissions 워크플로우 전면 차단
+- `make build` 후 `embedded.go` 크기가 비이성적으로 증가(10% 초과)하여 바이너리 사이즈 영향 과다

--- a/.moai/specs/SPEC-OPUS47-COMPAT-001/plan.md
+++ b/.moai/specs/SPEC-OPUS47-COMPAT-001/plan.md
@@ -1,0 +1,248 @@
+---
+id: SPEC-OPUS47-COMPAT-001
+version: 0.1.1
+status: draft
+created: 2026-04-17
+updated: 2026-04-17
+author: GOOS행님
+priority: critical
+issue_number: 671
+---
+
+# Plan: SPEC-OPUS47-COMPAT-001
+
+## Overview
+
+Opus 4.7 호환성 및 프롬프트 철학 적용을 **P0(코어 호환성) → P1(v2.1.110 런타임 대응) → P2(문서 레이어)** 3단계로 분해한다. 각 단계는 독립 commit 가능하며, P0 완료 시점에서 Opus 4.7 사용자는 즉시 이득을 본다. P1/P2는 점진 롤아웃 가능.
+
+## Priority-Based Phases
+
+### Phase P0 — 코어 호환성 + 프롬프트 철학 (Priority: critical, 15 files)
+
+**Scope**: REQ-OC-001, REQ-OC-002, REQ-OC-005
+
+**Objective**: Opus 4.7 모델 카탈로그 등록, `effort` 5단계 지원, 6개 핵심 reasoning agent의 프롬프트 철학 적용.
+
+**File list with [DELTA] markers**:
+
+| # | File | DELTA | Change |
+|---|------|-------|--------|
+| 1 | `internal/profile/preferences.go` | [MODIFY] | `Model` 주석 갱신 (`claude-opus-4-7`), `EffortLevel string` 필드 신규 추가 (line 26 근처) |
+| 2 | `internal/template/model_policy.go` | [MODIFY] | `ModelPolicy` 상수에 `xhigh`, `max` 추가; `agentModelMap`을 5단계 또는 effort 별도 매핑 도입 (line 16-86) |
+| 3 | `internal/cli/profile_setup_translations.go` | [MODIFY] | Opus 4.7 + xhigh 번역 엔트리 추가 (line 102-262) |
+| 4 | `internal/cli/launcher.go` | [MODIFY] | `claude-opus-4-7` 모델 ID 라우팅 분기 (line 489) |
+| 5 | `internal/template/templates/.moai/config/sections/quality.yaml` | [MODIFY] | `session_effort_default: xhigh` 필드 추가 |
+| 6 | `internal/template/templates/.moai/config/sections/llm.yaml` | [MODIFY] | `claude_models.high: claude-opus-4-7`, effort 매핑 예시 추가 |
+| 7 | `internal/template/templates/.claude/rules/moai/development/agent-authoring.md` | [MODIFY] | `effort` 5단계 스펙 + Opus 4.7 주석 |
+| 8 | `internal/template/templates/.claude/rules/moai/development/skill-authoring.md` | [MODIFY] | `max is Opus 4.6 only` 문구 삭제, `xhigh` 레벨 추가 |
+| 9 | `internal/template/templates/.claude/agents/moai/manager-spec.md` | [MODIFY] | `effort: xhigh` frontmatter + 본문 1턴 몰빵 리라이트 + 스캐폴딩 제거 |
+| 10 | `internal/template/templates/.claude/agents/moai/manager-strategy.md` | [MODIFY] | `effort: xhigh` + 팬아웃 원칙 명시 + 스캐폴딩 제거 |
+| 11 | `internal/template/templates/.claude/agents/moai/plan-auditor.md` | [MODIFY] | `effort: high` |
+| 12 | `internal/template/templates/.claude/agents/moai/evaluator-active.md` | [MODIFY] | `effort: high` |
+| 13 | `internal/template/templates/.claude/agents/moai/expert-security.md` | [MODIFY] | `effort: high` |
+| 14 | `internal/template/templates/.claude/agents/moai/expert-refactoring.md` | [MODIFY] | `effort: high` |
+| 15 | `internal/template/templates/.claude/skills/moai-workflow-thinking/SKILL.md` | [MODIFY] | Adaptive Thinking 재정의, "thinking budget N tokens" 고정 수치 제거 |
+
+**Reference implementations**:
+
+- ModelPolicy 3단계 패턴: `internal/template/model_policy.go:16-86` (기존 구조 참조하여 5단계 확장)
+- agentModelMap 구조: `internal/template/model_policy.go:44-67` ([5]string 또는 별도 effort 매핑)
+- Profile preferences YAML 필드 추가 패턴: `internal/profile/preferences.go:14-44` (기존 필드 주석·yaml 태그 패턴 준용)
+
+**Implementation order**:
+
+1. Go 코드 먼저 (파일 1-4): `profile/preferences.go` → `template/model_policy.go` → `cli/profile_setup_translations.go` → `cli/launcher.go`
+2. 테스트: `go test ./internal/profile/... ./internal/template/... ./internal/cli/...`
+3. 템플릿 설정 파일 (파일 5-6): `quality.yaml`, `llm.yaml`
+4. Rules 문서 (파일 7-8): `agent-authoring.md`, `skill-authoring.md`
+5. Agent 본문 (파일 9-14): 6개 reasoning agent 순차 리라이트
+6. Skill 본문 (파일 15): `moai-workflow-thinking/SKILL.md`
+7. `make build` → `embedded.go` 재생성 검증
+8. `go test ./...` 전체 통과 확인
+
+**Technical constraints**:
+
+- `ModelPolicy` 상수 확장 시 기존 `IsValidModelPolicy`, `ValidModelPolicies` 함수 시그니처 유지 (호환성)
+- `agentModelMap` 구조 변경 시 `GetAgentModel` 시그니처는 유지하되 내부 구현만 확장
+- Agent frontmatter 수정 시 YAML 파싱 충돌 방지 — `effort` 필드는 기존 필드(name, description, tools 등) 이후에 배치
+- `skill-authoring.md` 수정 시 기존 다른 스킬 문서에 `max is Opus 4.6 only` 참조가 없는지 Grep으로 확인
+
+**Risks**:
+
+- **R-P0-1** (Medium): `agentModelMap [3]string → [5]string` 확장 시 초기값 설정 누락으로 컴파일 에러. **Mitigation**: Go 컴파일러가 차단하므로 CI에서 자동 감지. 모든 agent entry에 5개 값 명시.
+- **R-P0-2** (Low): 6개 agent 본문 리라이트 시 기존 워크플로우 축소 리스크(memory feedback_agent_refactor_constraint 참조). **Mitigation**: 프롬프트 스캐폴딩만 제거, 워크플로우 스텝은 유지.
+- **R-P0-3** (Medium): `make build` 누락으로 `embedded.go` 구버전 유지. **Mitigation**: CI에서 `make build` 후 `git diff --exit-code internal/template/embedded.go` 체크.
+
+### Phase P1 — v2.1.110 Runtime 대응 (Priority: high, 8 files)
+
+**Scope**: REQ-OC-003, REQ-OC-004
+
+**Objective**: Claude Code v2.1.110의 4건 High-impact 변경 및 Windows CLAUDE_ENV_FILE 정상화.
+
+**File list with [DELTA] markers**:
+
+| # | File | DELTA | Change |
+|---|------|-------|--------|
+| 16 | `internal/cli/doctor.go` | [MODIFY] | MCP scope 중복 감지 로직 추가 (runDiagnosticChecks 내부) |
+| 17 | `internal/hook/permission_request.go` | [MODIFY] | `updatedInput` deny 재검증 로직 |
+| 18 | `internal/hook/session_start.go` | [MODIFY] | Windows `CLAUDE_ENV_FILE` 주입 분기 (기존 macOS/Linux 경로 영향 없음) |
+| 19 | `internal/template/templates/.claude/settings.json` | [MODIFY] | `disableBypassPermissionsMode: false` 키 추가, Bash timeout 상한(600,000ms) 문서화 주석 |
+| 20 | `internal/template/templates/.claude/rules/moai/core/agent-common-protocol.md` | [MODIFY] | Bash timeout 600,000ms 상한 문서화(Claude Code 런타임 강제), 팬아웃 원칙 추가 |
+| 20a | `internal/template/templates/.claude/rules/moai/development/agent-authoring.md` | [MODIFY] | Bash timeout 600,000ms 상한 문서화(agent 저작 시 참조) |
+| 21 | `internal/template/templates/.claude/rules/moai/core/moai-constitution.md` | [MODIFY] | Opus 4.7 원칙 4(팬아웃 명시), 원칙 5(툴 호출 가이드) 섹션 추가 |
+| 22 | `internal/template/templates/.claude/rules/moai/workflow/worktree-integration.md` | [MODIFY] | v2.1.110 최소 버전(MCP doctor), v2.1.111(CLAUDE_ENV_FILE) 추가 |
+| 23 | `internal/template/templates/.moai/config/sections/harness.yaml` | [MODIFY] | level↔effort 매핑(thorough→xhigh), 본 SPEC `model_upgrade_review` 실행 기록 |
+
+**Reference implementations**:
+
+- `doctor.go` 진단 패턴: 기존 `runDiagnosticChecks`(`internal/cli/doctor.go:118`) 함수 구조를 참조하여 `checkMCPScopeDuplicates` 같은 함수 추가
+- 플랫폼 분기/환경 주입 패턴: `internal/cli/glm.go:489`의 `injectGLMEnvForTeam` 정의부와 `internal/hook/glm_tmux.go:73`의 `ensureTmuxGLMEnv` 정의부 구조를 준용하여 Windows `CLAUDE_ENV_FILE` 주입을 `session_start.go`에 신규 추가. `session_start.go:72-95`는 해당 함수들의 호출부이며 정의부가 아님에 유의
+- `settings.json` 템플릿 필드 추가 패턴: 기존 `permissions` 블록 구조 참조
+
+**Implementation order**:
+
+1. `doctor.go` (단독 실행 명령, 다른 코드와 의존성 낮음)
+2. `permission_request.go` (hook 격리)
+3. `session_start.go` (Windows 분기 — 기존 경로 회귀 방지 테스트 필수)
+4. `settings.json` + rules 3종 (문서 레이어)
+5. `harness.yaml` 업데이트
+6. `make build` → `embedded.go` 재생성
+7. `go test ./internal/cli/... ./internal/hook/...` 통과 확인
+
+**Technical constraints**:
+
+- `doctor.go` MCP 감지는 `.mcp.json`, `settings.json`, `~/.config/claude/settings.json`(user scope) 3 원천을 모두 파싱해야 함 — 파일 부재 시 graceful skip
+- `permission_request.go` 재검증 로직은 기존 deny 패턴 매칭 함수를 재사용(중복 구현 금지)
+- `session_start.go` Windows 분기는 `runtime.GOOS == "windows"` 가드 내에서만 실행, POSIX 경로에 영향 없음
+- `settings.json` 변경은 `settings.json.tmpl` 렌더링 후에도 JSON validity 유지
+
+**Risks**:
+
+- **R-P1-1** (High): `session_start.go` 변경이 기존 tmux GLM env 주입(teammate_mode_regression 이슈 재발 가능)을 깨뜨릴 리스크. **Mitigation**: 기존 `injectGLMEnvForTeam` 함수 시그니처/동작 불변 유지, Windows 분기는 별도 함수로 추가. macOS/Linux 회귀 테스트 필수.
+- **R-P1-2** (Medium): `settings.json.tmpl` 수정이 SPEC-GLM-001의 `DISABLE_BETAS` 주입과 merge conflict. **Mitigation**: 같은 블록 동시 수정 금지, 별도 키 블록으로 분리.
+- **R-P1-3** (Low): `doctor.go` MCP 중복 감지가 false-positive(같은 서버를 의도적으로 다른 스코프에서 override하는 경우)를 생성. **Mitigation**: warning 레벨로만 리포트, 차단 금지.
+
+### Phase P2 — 문서 레이어 (Priority: medium, 4+ files)
+
+**Scope**: GOAL-2 보강, 사용자 마이그레이션 가이드
+
+**Objective**: 사용자 대면 문서(CLAUDE.local.md, coding-standards.md, CHANGELOG.md)에 v2.1.111/Opus 4.7 변경사항 반영.
+
+**File list with [DELTA] markers**:
+
+| # | File | DELTA | Change |
+|---|------|-------|--------|
+| 24 | `internal/template/templates/.claude/rules/moai/development/coding-standards.md` | [MODIFY] | v2.1.111 read-only Bash 자동 분류, `/less-permission-prompts` 가이드 |
+| 25 | `CLAUDE.local.md` | [MODIFY] | `settings.local.json` 분리 원칙 + `OTEL_LOG_RAW_API_BODIES` 프로덕션 금지 경고 |
+| 26 | `internal/template/templates/CLAUDE.md` §12 | [MODIFY] | UltraThink vs Adaptive Thinking 용어 정리(Sequential Thinking MCP와 구분) |
+| 27 | `CHANGELOG.md` | [MODIFY] | v2.12.0 항목 추가 ("Claude Code v2.1.110+ 권장, Opus 4.7 프롬프트 철학 적용") |
+
+**Implementation order**:
+
+1. `CLAUDE.md §12` 용어 정리 먼저(다른 문서가 참조)
+2. `coding-standards.md` 업데이트
+3. `CLAUDE.local.md` (로컬 전용, 템플릿 아님)
+4. `CHANGELOG.md` 마지막(P0/P1 완료 후 배포 전)
+
+**Technical constraints**:
+
+- `CLAUDE.md §12` 수정 시 Sequential Thinking MCP 동작(`server_tool_use`)과 Adaptive Thinking(`thinking.budget_tokens`) 차이를 명확히 서술
+- `CHANGELOG.md`는 Conventional Commits 스타일 유지, 한국어 작성
+
+**Risks**:
+
+- **R-P2-1** (Low): `CHANGELOG.md` 버전 번호 충돌(다른 SPEC과 merge 순서). **Mitigation**: release/v2.11.0 → v2.12.0 bump 시점에 최종 확정.
+
+## Technical Approach
+
+### Effort 필드 설계
+
+5단계 매핑 전략은 2가지 중 하나로 선택(P0 구현 시 결정):
+
+**Option A**: `agentModelMap`을 `[5]string`으로 확장
+- 장점: 기존 구조와 유사
+- 단점: 모든 agent에 대해 5개 값 기입 필요 — Sonnet/Haiku는 `xhigh`/`max`가 의미 없으므로 중복 값 다수 발생
+
+**Option B**: `ModelPolicy`(high/medium/low)와 `Effort`(low/medium/high/xhigh/max) 분리 — 권장
+- 장점: Opus 4.7만 effort 적용, 타 모델은 `high`로 자동 폴백
+- 단점: 두 개념 분리로 초기 복잡도 증가
+
+**결정 근거**: Option B가 NFR-1(하위 호환성) 및 NFR-3(언어 중립성)을 더 잘 만족. `GetAgentModel(policy, agentName)`은 유지하고, 신규 `GetAgentEffort(agentName) string`을 추가하는 방향 권장.
+
+### Opus 4.7 프롬프트 철학 5원칙 적용 매트릭스
+
+| 원칙 | 적용 대상 | 조치 |
+|------|----------|------|
+| 1. effort 기본값 xhigh | manager-spec, manager-strategy | frontmatter에 `effort: xhigh` |
+| 2. 1턴 몰빵(literal instruction) | 6개 reasoning agent | 본문에 "double-check/verify N times" 스캐폴딩 제거 |
+| 3. Extended Thinking 고정 예산 제거 | moai-workflow-thinking/SKILL.md | "thinking budget N tokens" 지시 삭제 |
+| 4. 서브에이전트 자동 스폰 감소 | moai-constitution.md | 팬아웃 명시 원칙 추가(MoAI가 명시적 팬아웃 제공) |
+| 5. 툴 호출↓ 추론↑ | agent-common-protocol.md | 툴 호출 전 추론 단계 권장 가이드 추가 |
+
+### Windows CLAUDE_ENV_FILE 주입 흐름
+
+```
+SessionStart hook (internal/hook/session_start.go)
+  ├─ runtime.GOOS == "darwin" || "linux"
+  │   └─ ensureTmuxGLMEnv (정의: internal/hook/glm_tmux.go:73, 호출: session_start.go:92, 불변)
+  └─ runtime.GOOS == "windows"
+      └─ injectCLAUDEEnvFile (신규 — glm.go:489 injectGLMEnvForTeam 스타일로 신규 정의)
+          ├─ Read envkeys.go CLAUDE_ENV_FILE constant (internal/config/envkeys.go:70-72)
+          ├─ Check file existence (graceful skip)
+          └─ Set process env for child Claude Code process
+```
+
+Reference 함수 정의 위치 요약(실측):
+
+- `injectGLMEnvForTeam`: `internal/cli/glm.go:489`
+- `ensureTmuxGLMEnv`: `internal/hook/glm_tmux.go:73`
+- `ensureGLMCredentials`: `internal/hook/session_start.go:157`
+- `ensureTeammateMode`: `internal/hook/session_start.go:274`
+- `runDiagnosticChecks`: `internal/cli/doctor.go:118`
+
+## Dependencies
+
+- **Upstream dependencies**: 없음 (독립 실행 가능)
+- **Downstream impacts**:
+  - `SPEC-GLM-001` (GLM settings.json 자동 주입)과 `settings.json.tmpl` 동시 수정 주의
+  - `SPEC-CC297-001` (Claude Code 2.9.7)과 `session_start.go` 동시 수정 주의
+- **External dependencies**:
+  - Claude Code v2.1.110 이상 (runtime 대응 검증용)
+  - Opus 4.7 접근 가능 Anthropic API 키(수동 검증용, CI에서는 mock)
+
+## Testing Strategy
+
+- **Unit tests**:
+  - `internal/template/model_policy_test.go`: Effort 5단계 라우팅, 모델 ID 검증
+  - `internal/profile/preferences_test.go`: YAML round-trip (Opus 4.7 + xhigh)
+  - `internal/cli/doctor_test.go`: MCP scope 중복 감지 (픽스처 기반)
+  - `internal/hook/session_start_test.go`: Windows 분기(`runtime.GOOS` override) + macOS/Linux 회귀
+- **Integration tests**:
+  - `moai init` → Opus 4.7 선택 → `preferences.yaml` 내용 검증
+  - `moai update` → 기존 프로젝트에 템플릿 변경 적용, 회귀 없음 확인
+  - `make build` 후 `embedded.go`와 `internal/template/templates/` diff 정합성
+- **Manual verification**:
+  - Windows VM에서 `moai hook session-start` 실행 후 `CLAUDE_ENV_FILE` 환경변수 확인
+  - Opus 4.7 세션에서 `effort: xhigh`로 지정된 manager-spec 호출 시 reasoning tier 반영 확인
+
+## Rollout Plan
+
+1. **release/v2.11.0 브랜치 내 작업 (현재 브랜치 유지)**: P0/P1/P2 모든 변경을 release/v2.11.0 위에서 commit
+2. **P0 완료 후 내부 검증**: macOS + Opus 4.7 조합으로 주요 플로우 smoke test
+3. **P1 완료 후 Windows 검증**: VM/CI에서 `GOOS=windows` 빌드 통과 + hook 동작 확인
+4. **P2 완료 후 CHANGELOG 작성** → v2.12.0 tag 후보
+5. **PR 생성** (manager-git 위임): release/v2.11.0 → main, issue_number는 GitHub Issue 생성 후 SPEC frontmatter 업데이트
+
+## MX Tag Plan (Phase 3.5)
+
+- `@MX:ANCHOR`: `internal/profile/preferences.go`의 `ProfilePreferences` 구조체(fan_in 높음), `internal/template/model_policy.go`의 `ModelPolicy` 상수군 및 `agentModelMap`
+- `@MX:WARN`: `internal/cli/doctor.go` MCP scope 검증 함수(파일 시스템 읽기 + JSON 파싱, 실패 시 사일런트 fallback 위험) — `@MX:REASON` 필수
+- `@MX:NOTE`: `internal/hook/session_start.go` Windows `CLAUDE_ENV_FILE` 분기 (플랫폼별 동작 차이)
+- `@MX:TODO`: P2 문서 항목은 Run phase에서 GREEN 완료 후 해결 예정
+
+## Post-Implementation Review Items
+
+- Opus 4.6/Sonnet 4.6 사용자가 `moai update` 수행 시 `preferences.yaml`이 손상되지 않는가?
+- 28개 agent 전체를 조사해 `effort: xhigh`/`high` 미설정 agent가 Opus 4.7 세션에서도 기본값 `xhigh`로 정상 동작하는가?
+- `disableBypassPermissionsMode: false` 기본값이 기존 `bypassPermissions` 워크플로우를 차단하지 않는가?
+- `moai-workflow-thinking/SKILL.md`에서 고정 예산 지시 제거 후 agent들이 Sequential Thinking MCP를 여전히 올바르게 호출하는가?

--- a/.moai/specs/SPEC-OPUS47-COMPAT-001/progress.md
+++ b/.moai/specs/SPEC-OPUS47-COMPAT-001/progress.md
@@ -1,0 +1,37 @@
+## SPEC-OPUS47-COMPAT-001 Progress
+
+- Started: 2026-04-17 (Run phase)
+- Branch: release/v2.11.0 (현재 세션, feature/SPEC-OPUS47-COMPAT-001 worktree는 sync phase에서 정리)
+- Development mode: tdd (per .moai/config/sections/quality.yaml)
+- Language: go (detected via go.mod)
+- Scale-based mode: Full Pipeline (files=27, domains=6+, complexity=8, no --team flag)
+- Harness level: thorough (priority:critical + public_api 터치 자동 승격 예상)
+- Plan-audit: PASS (iteration 2, reports/plan-audit/*-review-2.md)
+
+### Phase Checkpoints
+
+- [x] Phase 0.9: JIT Language Detection — moai-lang-go
+- [x] Phase 0.95: Scale-Based Mode — Full Pipeline
+- [ ] Phase 1: Analysis & Planning (manager-strategy)
+- [ ] Decision Point 1: Plan Approval
+- [ ] Phase 1.5: Task Decomposition (tasks.md)
+- [ ] Phase 1.6: Acceptance Criteria → TaskList
+- [ ] Phase 1.7: File Scaffolding (minimal — SPEC is mostly MODIFY)
+- [ ] Phase 1.8: MX Context Scan
+- [ ] Phase 2.0: Sprint Contract (thorough harness — evaluator-active)
+- [ ] Phase 2B: TDD Implementation (manager-tdd, RED-GREEN-REFACTOR)
+- [ ] Phase 2.5: TRUST 5 Validation (manager-quality)
+- [ ] Phase 2.7: Re-planning Gate Check
+- [ ] Phase 2.75: Pre-Review Quality Gate
+- [ ] Phase 2.8a: Active Quality Evaluation (evaluator-active)
+- [ ] Phase 2.8b: TRUST 5 Static Verification (manager-quality)
+- [ ] Phase 2.9: MX Tag Update
+- [ ] Phase 2.10: Simplify Pass
+- [ ] Phase 3: Git Operations (manager-git)
+- [ ] Phase 4: Completion & Guidance
+
+### Notes
+
+- Prior Plan-auditor defect resolutions: iteration 1 FAIL(8 defects) → iteration 2 PASS(must-pass 7/7)
+- Option A vs Option B (Effort field design): manager-strategy가 최종 확정하여 tasks.md에 기록
+- R-P1-High (session_start.go Windows 분기 회귀 방지): Phase 2B manager-tdd 우선 주의 사항

--- a/.moai/specs/SPEC-OPUS47-COMPAT-001/research.md
+++ b/.moai/specs/SPEC-OPUS47-COMPAT-001/research.md
@@ -1,0 +1,388 @@
+---
+id: SPEC-OPUS47-COMPAT-001
+version: 0.1.1
+status: draft
+created: 2026-04-17
+updated: 2026-04-17
+author: GOOS행님
+priority: critical
+issue_number: 671
+---
+
+# Research: SPEC-OPUS47-COMPAT-001
+
+## 개요
+
+본 research 문서는 Plan 단계에서 수행된 전수 감사 결과를 보존한다. Anthropic 공식 문서, moai-adk-go 현재 상태 검증, 충돌 해소 논리를 단일 출처로 모아 Run 단계 실행 시 참조하기 위함이다.
+
+## A. Opus 4.7 프롬프트 철학 5원칙 (Anthropic 공식 인용)
+
+### 원칙 1 — effort 기본값 xhigh 유지
+
+- **공식 출처**: `code.claude.com/docs/en/model-config`
+- **인용**: "On Opus 4.7, the default effort is **xhigh** for all plans and providers."
+- **의미**: Opus 4.7은 별도 지정 없이도 xhigh 수준 추론을 기본 제공. moai-adk-go는 xhigh를 명시적으로 표기해 의도를 고정하고, 다른 모델(Sonnet/Haiku) 사용 시 자동 폴백(`high`)되도록 설계.
+
+### 원칙 2 — 1턴 몰빵 (Literal Instruction Following)
+
+- **공식 출처**: `platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7`
+- **인용**: "More literal instruction following. The model will not silently generalize... will not infer requests you didn't make." / "If you want a hard limit, say so."
+- **의미**: 핑퐁 없이 1턴에 완전 정보 세트를 전달해야 함. "double-check X before returning" 류 스캐폴딩은 Opus 4.7에서 불필요하며 때로 혼선 유발.
+
+### 원칙 3 — Extended Thinking 고정 예산 삭제
+
+- **공식 출처**: `platform.claude.com/docs/en/build-with-claude/adaptive-thinking`
+- **인용**: "Extended thinking budgets are **removed** in Claude Opus 4.7. Setting `thinking.budget_tokens` returns a **400 error**. Adaptive thinking is the **only** supported thinking mode."
+- **의미**: `thinking.budget_tokens` 지정은 Opus 4.7에서 400 에러를 반환. `moai-workflow-thinking/SKILL.md`에서 "thinking budget N tokens" 류 고정 수치 지시를 제거해야 함.
+
+### 원칙 4 — 서브에이전트 자동 스폰 감소
+
+- **공식 출처**: Anthropic 공식 (Opus 4.7 release notes)
+- **인용**: "Fewer subagents spawned by default. Steerable through prompting."
+- **의미**: Opus 4.7은 기본적으로 서브에이전트를 덜 스폰함. MoAI가 orchestrator로서 명시적 팬아웃(`Agent()` 호출)을 제공해야 함 → `moai-constitution.md`에 "명시적 팬아웃" 원칙 추가 필요.
+
+### 원칙 5 — 툴 호출 감소, 추론 증가
+
+- **공식 출처**: Anthropic 공식
+- **인용**: "Fewer tool calls by default, using reasoning more. Raising effort increases tool usage."
+- **의미**: Opus 4.7은 툴 호출을 줄이고 내부 추론을 더 사용. `effort: xhigh`는 필요 시 툴 호출 재증가 레버. `agent-common-protocol.md`에 "툴 호출 전 추론" 가이드 추가.
+
+### 결정적 권고 (Anthropic)
+
+- **인용**: "If existing prompts have mitigations in these areas (e.g. 'double-check X before returning'), try removing that scaffolding and re-baselining."
+- **의미**: 기존 Opus 4.6 시대 스캐폴딩은 **제거**하고 재기준선 수립이 권장됨. REQ-OC-005의 근거.
+
+## B. Claude Code v2.1.110 High-impact 4건
+
+### B-1. `/doctor` MCP scope 중복 경고
+
+- **현상**: Claude Code v2.1.110부터 `/doctor` 명령이 `.mcp.json`, `settings.json`, user config 3 원천에서 MCP 서버 중복 정의를 탐지해 경고.
+- **moai-adk-go 현 상태**: `internal/cli/doctor.go`에 MCP 중복 감지 로직 부재.
+- **대응**: `runDiagnosticChecks` 내부에 `checkMCPScopeDuplicates` 추가 (REQ-OC-003).
+
+### B-2. Bash tool 최대 timeout 강제 (600,000ms)
+
+- **현상**: Claude Code v2.1.110은 Bash tool timeout 최대값을 600,000ms(10분)으로 강제.
+- **moai-adk-go 현 상태**: `settings.json.tmpl` hooks timeout은 개별 설정(기본 5s). Bash tool 자체 timeout 상한 검증은 없음.
+- **대응**: `settings.json` 주석으로 상한 명시, `agent-common-protocol.md`에 문서화 (REQ-OC-003).
+
+### B-3. PermissionRequest hook `updatedInput` deny 재검증
+
+- **현상**: Claude Code v2.1.110은 hook이 `updatedInput`을 반환할 때 deny 패턴과 재대조 수행. 이전에는 updatedInput이 deny 필터를 우회 가능.
+- **moai-adk-go 현 상태**: `internal/hook/permission_request.go`에 재검증 로직 없음.
+- **대응**: updatedInput 반환 시 기존 deny 패턴 매칭 함수 재호출 (REQ-OC-003).
+
+### B-4. `setMode:'bypassPermissions'` + `disableBypassPermissionsMode`
+
+- **현상**: Claude Code v2.1.110은 settings.json에 `disableBypassPermissionsMode: true` 설정 시 `setMode('bypassPermissions')` 호출을 차단. 엔터프라이즈 보안 요구 대응.
+- **moai-adk-go 현 상태**: `settings.json.tmpl`에 해당 키 없음. 기본 동작은 `false`(허용)로 간주.
+- **대응**: `settings.json.tmpl`에 명시적으로 `disableBypassPermissionsMode: false` 추가, 문서화 (REQ-OC-003).
+
+## C. Claude Code v2.1.111 High-impact 2건
+
+### C-1. Opus 4.7(`claude-opus-4-7`) + effort 5단계
+
+- **현상**: v2.1.111부터 `claude-opus-4-7` 모델 ID 지원, effort 필드가 `low`/`medium`/`high`/`xhigh`/`max` 5단계로 확장.
+- **moai-adk-go 현 상태**:
+  - `internal/profile/preferences.go:26`의 `Model` 주석이 `claude-opus-4-6`
+  - `internal/template/model_policy.go:16-86`의 `ModelPolicy`가 3단계(`high`/`medium`/`low`)
+  - `internal/cli/profile_setup_translations.go:102-262`에 Opus 4.7 선택지 번역 없음
+  - `internal/cli/launcher.go:489`에 4.7 모델 ID 라우팅 분기 없음
+- **대응**: 위 4개 파일 모두 수정 (REQ-OC-001).
+
+### C-2. Windows `CLAUDE_ENV_FILE` 정상화
+
+- **현상**: v2.1.111부터 Windows 환경에서 `CLAUDE_ENV_FILE` 환경변수가 정상 인식됨. 이전 버전에서는 Windows에서 무시됨.
+- **moai-adk-go 현 상태**:
+  - `internal/config/envkeys.go:70-72`에 `CLAUDE_ENV_FILE` 상수는 정의됨
+  - 하지만 `internal/hook/session_start.go`에 Windows 분기로 해당 상수를 사용하는 코드 없음
+  - 참고: 플랫폼 분기 reference 패턴은 `internal/cli/glm.go:489` `injectGLMEnvForTeam`(정의부) 및 `internal/hook/glm_tmux.go:73` `ensureTmuxGLMEnv`(정의부). `session_start.go:72-95`는 이들의 호출부임.
+- **대응**: `session_start.go`에 Windows 분기 추가, `CLAUDE_ENV_FILE` 주입 (REQ-OC-004).
+
+## D. 현 프로젝트 상태 검증 결과
+
+### D-1. `.moai/config/sections/llm.yaml` (실측)
+
+```yaml
+llm:
+    mode: ""
+    team_mode: ""
+    glm_env_var: GLM_API_KEY
+    performance_tier: ""
+    claude_models:
+        high: ""       # 빈 문자열 — Opus 4.7 설정 전무
+        medium: ""
+        low: ""
+    glm:
+        base_url: https://api.z.ai/api/anthropic
+        models:
+            high: glm-5.1
+            medium: glm-4.7
+            low: glm-4.5-air
+    default_model: sonnet
+    quality_model: opus
+    speed_model: haiku
+```
+
+**분석**: `claude_models.high/medium/low`가 모두 빈 문자열. Opus 4.7 모델 ID 및 effort 필드 전무. P0 작업으로 `high: claude-opus-4-7` 지정 필요.
+
+### D-2. `.moai/config/sections/quality.yaml` (실측)
+
+```yaml
+constitution:
+    development_mode: tdd
+    enforce_quality: true
+    test_coverage_target: 85
+    ...
+    lsp_quality_gates:
+        enabled: true
+        run:
+            max_errors: 0
+```
+
+**분석**: LSP quality gate 엄격(run: max_errors: 0). effort 정책 없음. 본 SPEC이 `session_effort_default: xhigh` 추가 대상.
+
+### D-3. `internal/template/model_policy.go` (실측 line 16-86)
+
+3단계 `ModelPolicy` 구조 확인:
+- `ModelPolicyHigh` / `ModelPolicyMedium` / `ModelPolicyLow`
+- `agentModelMap map[string][3]string` — 각 agent에 대해 `[high, medium, low]` 매핑
+- `GetAgentModel(policy, agentName)` 함수 제공
+
+**분석**: 5단계 effort로 확장 시 `[3]string → [5]string` 변경 또는 effort 별도 매핑 도입(Option B 권장, plan.md 참조).
+
+### D-4. `internal/profile/preferences.go` (실측 line 14-44)
+
+```go
+type ProfilePreferences struct {
+    ...
+    ModelPolicy string `yaml:"model_policy,omitempty"` // "high", "medium", "low"
+    Model       string `yaml:"model,omitempty"`        // e.g. "claude-opus-4-6"
+    ...
+}
+```
+
+**분석**: `Model` 필드 주석이 `claude-opus-4-6`. Opus 4.7 업데이트 대상. `EffortLevel` 필드 신규 추가 필요.
+
+### D-5. `.claude/rules/moai/development/skill-authoring.md`
+
+- **현 문구 (오류 상태)**: `effort: Session effort override: low, medium, high, max (max is Opus 4.6 only)`
+- **수정 필요**: `xhigh` 추가 및 `max is Opus 4.6 only` 문구 삭제 또는 재정의. Opus 4.7에서도 `max`는 지원됨.
+
+### D-6. 28개 agent frontmatter 전수 조사
+
+- 결과: **28개 agent 모두 frontmatter에 `effort` 필드 미설정**
+- v2.1.111 신규 필드이므로 정상. 다만 즉시 할당 필요.
+- P0에서 6개 reasoning agent 우선 설정, 나머지 22개는 기본값(`high`) 의존.
+
+#### Agent Inventory (28개 검증, 실측 Glob 결과)
+
+실측 경로: `internal/template/templates/.claude/agents/**/*.md`
+실측 명령: `Glob("internal/template/templates/.claude/agents/**/*.md")` (iteration 2 검증)
+
+**Moai 카테고리 (22개, `internal/template/templates/.claude/agents/moai/`)**:
+
+1. `manager-spec.md` (P0 reasoning 대상)
+2. `manager-strategy.md` (P0 reasoning 대상)
+3. `manager-ddd.md`
+4. `manager-tdd.md`
+5. `manager-docs.md`
+6. `manager-git.md`
+7. `manager-quality.md`
+8. `manager-project.md`
+9. `expert-backend.md`
+10. `expert-frontend.md`
+11. `expert-security.md` (P0 reasoning 대상)
+12. `expert-devops.md`
+13. `expert-testing.md`
+14. `expert-debug.md`
+15. `expert-performance.md`
+16. `expert-refactoring.md` (P0 reasoning 대상)
+17. `builder-agent.md`
+18. `builder-skill.md`
+19. `builder-plugin.md`
+20. `plan-auditor.md` (P0 reasoning 대상)
+21. `evaluator-active.md` (P0 reasoning 대상)
+22. `researcher.md`
+
+**Agency 카테고리 (6개, `internal/template/templates/.claude/agents/agency/`)**:
+
+23. `planner.md`
+24. `copywriter.md`
+25. `designer.md`
+26. `builder.md`
+27. `evaluator.md`
+28. `learner.md`
+
+**합계**: 22 + 6 = **28개** 확정.
+
+**P0 대상(6개 reasoning agent)** 확인: manager-spec, manager-strategy, plan-auditor, evaluator-active, expert-security, expert-refactoring. 나머지 22개는 P0 외(기본값 `high` 의존).
+
+**참고 (CLAUDE.md Section 4 카탈로그)**: "Manager 8 + Expert 8 + Builder 3 + Evaluator 2 + Agency 6" = 27개. `researcher.md`는 2026-04 이전에 추가되었으나 CLAUDE.md Section 4 카탈로그 업데이트가 누락된 상태(별도 정비 필요). 본 SPEC은 실측 28개를 기준으로 함.
+
+## E. 전수 패치 파일 리스트 (27개)
+
+### P0 — 15 files (Opus 4.7 호환성 + 프롬프트 철학)
+
+1. `internal/profile/preferences.go`
+2. `internal/template/model_policy.go`
+3. `internal/cli/profile_setup_translations.go`
+4. `internal/cli/launcher.go:489`
+5. `internal/template/templates/.moai/config/sections/quality.yaml`
+6. `internal/template/templates/.moai/config/sections/llm.yaml`
+7. `internal/template/templates/.claude/rules/moai/development/agent-authoring.md`
+8. `internal/template/templates/.claude/rules/moai/development/skill-authoring.md`
+9. `internal/template/templates/.claude/agents/moai/manager-spec.md`
+10. `internal/template/templates/.claude/agents/moai/manager-strategy.md`
+11. `internal/template/templates/.claude/agents/moai/plan-auditor.md`
+12. `internal/template/templates/.claude/agents/moai/evaluator-active.md`
+13. `internal/template/templates/.claude/agents/moai/expert-security.md`
+14. `internal/template/templates/.claude/agents/moai/expert-refactoring.md`
+15. `internal/template/templates/.claude/skills/moai-workflow-thinking/SKILL.md`
+
+### P1 — 8 files (v2.1.110 High 대응)
+
+16. `internal/cli/doctor.go`
+17. `internal/hook/permission_request.go`
+18. `internal/hook/session_start.go`
+19. `internal/template/templates/.claude/settings.json`
+20. `internal/template/templates/.claude/rules/moai/core/agent-common-protocol.md`
+21. `internal/template/templates/.claude/rules/moai/core/moai-constitution.md`
+22. `internal/template/templates/.claude/rules/moai/workflow/worktree-integration.md`
+23. `internal/template/templates/.moai/config/sections/harness.yaml`
+
+### P2 — 4 files (문서 레이어)
+
+24. `internal/template/templates/.claude/rules/moai/development/coding-standards.md`
+25. `CLAUDE.local.md`
+26. `internal/template/templates/CLAUDE.md` (§12)
+27. `CHANGELOG.md`
+
+## F. 중요 상충 해소
+
+### F-1. `--deepthink` (Sequential Thinking MCP) vs Opus 4.7 Adaptive Thinking
+
+- **상황**: Opus 4.7은 `thinking.budget_tokens` 설정 시 400 error 반환. 반면 MoAI의 `--deepthink` 플래그는 Sequential Thinking MCP를 통해 동작.
+- **기술 검증**:
+  - Sequential Thinking MCP는 `server_tool_use` content type으로 동작 (별도 도구 호출 경로)
+  - Anthropic의 `thinking.budget_tokens`는 Extended Thinking API 직접 파라미터
+  - **두 메커니즘은 독립적**이며 서로 영향 없음
+- **결론**: `--deepthink`는 Opus 4.7에서도 정상 동작. Sequential Thinking MCP 관련 지시는 유지.
+- **주의**: 단, agent 본문에 "thinking budget N tokens" 류 고정 예산 지시가 있다면 Opus 4.7 Extended Thinking 직접 호출 시 무시되므로 제거 대상(REQ-OC-005).
+
+### F-2. `effort` 5단계 vs 기존 `ModelPolicy` 3단계
+
+- **상황**: Opus 4.7의 effort(`low`/`medium`/`high`/`xhigh`/`max`)와 moai-adk-go의 ModelPolicy(`high`/`medium`/`low`)는 층위가 다름.
+- **설계 결정 (plan.md Option B)**:
+  - `ModelPolicy`: 사용자 요금제(Plus $20 / Max $100 / Max $200) 기반 모델 선택 정책
+  - `Effort`: Opus 4.7 내부 reasoning 강도 조절 (Opus 4.7 전용, 타 모델은 무시)
+  - 두 개념 분리 유지, `GetAgentEffort(agentName)` 신규 함수 도입
+
+## G. MX Tag Plan (Phase 3.5)
+
+본 SPEC 실행 시 추가할 @MX 태그 계획:
+
+### @MX:ANCHOR (fan_in >= 3 또는 public API boundary)
+
+- `internal/profile/preferences.go`의 `ProfilePreferences` 구조체 — 여러 모듈이 참조
+- `internal/template/model_policy.go`의 `ModelPolicy` 상수군 및 `agentModelMap` — 템플릿 배포 로직의 핵심
+- `internal/template/model_policy.go`의 `GetAgentModel` 함수 — 외부 호출 다수
+
+### @MX:WARN (위험 영역)
+
+- `internal/cli/doctor.go` MCP scope 검증 함수 — 파일 시스템 읽기 + JSON 파싱, 실패 시 사일런트 fallback 위험
+- `@MX:REASON` 필수: "MCP 중복 감지 실패 시 false-negative가 보안 경고 누락으로 이어질 수 있음"
+
+### @MX:NOTE (맥락 전달)
+
+- `internal/hook/session_start.go` Windows 분기 — 플랫폼별 동작 차이 설명
+- `internal/profile/preferences.go` `EffortLevel` 필드 — Opus 4.7 전용이며 타 모델에서 무시됨을 주석
+
+### @MX:TODO (미완성)
+
+- P2 문서 항목(CHANGELOG.md, CLAUDE.md §12 등)은 Run phase에서 GREEN 완료 후 해결 예정
+
+## H. Exclusions 근거
+
+### H-1. Vertex AI / AWS Bedrock 미지원
+
+- moai-adk-go의 현 설계는 Anthropic 공식 API + GLM(z.ai) 두 provider만 지원
+- Enterprise provider 요청이 사용자로부터 접수된 바 없음
+- Vertex/Bedrock 지원은 별도 SPEC으로 분리해야 할 범위
+
+### H-2. `/tui`, `/focus`, Push notification 등
+
+- Claude Code 런타임 레벨 UX 기능
+- moai-adk-go는 CLI orchestrator이므로 이러한 런타임 기능 중복 구현 불필요
+
+### H-3. `plugin_errors` stream-json
+
+- MoAI는 Claude Code plugin을 배포하지 않음
+- plugin 관련 응답 형식 처리는 범위 외
+
+### H-4. TRACEPARENT/TRACESTATE 분산 트레이싱
+
+- moai-adk-go는 headless 모드 미지원 결정 이미 존재
+- 분산 트레이싱은 해당 결정과 상충
+
+### H-5. CLAUDE_CODE_ENABLE_AWAY_SUMMARY opt-out
+
+- Claude Code 런타임 기능
+- moai-adk-go 개입 불가
+
+### H-6. `/ultrareview` vs `/moai review` 관계 정리
+
+- 사용자가 명시적으로 "3회 수동 제한으로 관계 정리 안 함" 지시
+- 본 SPEC 범위 외
+
+### H-7. 기존 Opus 4.6/Sonnet 4.6/Haiku 4.5 제거
+
+- NFR-1(하위 호환성) 필수
+- 제거 시 기존 사용자 마이그레이션 비용 과다
+
+### H-8. 실제 코드 구현
+
+- 본 SPEC은 Plan 산출물
+- 실제 수정은 `/moai run SPEC-OPUS47-COMPAT-001` 에서 수행
+
+### H-9. Sequential Thinking MCP 비활성화
+
+- F-1 검증으로 Opus 4.7 Adaptive Thinking과 무관함 확인
+- 비활성화 시 기존 `--deepthink` 워크플로우 전체 손실
+
+## I. Reference Implementations (코드 참조, 실측 검증 완료)
+
+- **ModelPolicy 3단계 패턴**: `internal/template/model_policy.go:16-86`
+  - 5단계로 확장 시 `agentModelMap[string][3]string → map[string][5]string` 또는 `map[string]AgentModelEntry` 구조체 도입
+- **SessionStart hook 호출 흐름**: `internal/hook/session_start.go:72-95`
+  - 72-95 라인은 함수 **호출부**이며 정의부가 아님에 유의
+  - 해당 라인에서 호출되는 함수 및 정의 위치:
+    - `ensureGLMCredentials` → 정의부 `internal/hook/session_start.go:157`
+    - `ensureTmuxGLMEnv` → 정의부 `internal/hook/glm_tmux.go:73` (macOS/Linux tmux 전용)
+    - `ensureTeammateMode` → 정의부 `internal/hook/session_start.go:274`
+- **플랫폼 분기/환경 주입 모범 사례**: `internal/cli/glm.go:489`의 `injectGLMEnvForTeam` 정의부
+  - GLM 모드에서 settings.local.json을 수정하여 환경변수를 주입하는 패턴
+  - Windows `CLAUDE_ENV_FILE` 주입 구현 시 동일 스타일(함수 정의 + runtime.GOOS 가드)로 신규 함수 도입 권장
+- **Doctor 진단 함수 구조**: `internal/cli/doctor.go:118`의 `runDiagnosticChecks`
+  - 기존 체크 함수들(예: `checkGoVersion`, `checkGitInstalled`)과 동일 패턴으로 `checkMCPScopeDuplicates` 추가
+
+## J. 공식 외부 참조 URL
+
+- **Opus 4.7 Release Notes**: `https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7`
+- **Model Config (effort)**: `https://code.claude.com/docs/en/model-config`
+- **Adaptive Thinking**: `https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking`
+- **Claude Code Changelog**: `https://code.claude.com/docs/en/changelog` (v2.1.110, v2.1.111)
+
+주의: 본 URL들은 Context Dump 시점 검증된 출처. Run phase 실행 시 WebFetch로 재확인 권장.
+
+## K. Risk 요약
+
+| Risk ID | Phase | Severity | Mitigation |
+|---------|-------|----------|------------|
+| R-P0-1  | P0    | Medium   | `agentModelMap` 확장 시 Go 컴파일러가 누락 차단 + CI로 검증 |
+| R-P0-2  | P0    | Low      | Agent 본문 리라이트 시 워크플로우 스텝 유지, 스캐폴딩만 제거 (feedback_agent_refactor_constraint 준수) |
+| R-P0-3  | P0    | Medium   | `make build` 후 `embedded.go` git diff 체크를 CI에 추가 |
+| R-P1-1  | P1    | High     | `session_start.go` 기존 함수 시그니처 불변, Windows 분기는 별도 함수 + 회귀 테스트 |
+| R-P1-2  | P1    | Medium   | `settings.json.tmpl` 변경 블록을 SPEC-GLM-001과 분리 |
+| R-P1-3  | P1    | Low      | MCP 중복은 warning only, exit code 0 유지 |
+| R-P2-1  | P2    | Low      | CHANGELOG 버전 bump는 v2.12.0 tag 직전 최종 확정 |

--- a/.moai/specs/SPEC-OPUS47-COMPAT-001/spec-compact.md
+++ b/.moai/specs/SPEC-OPUS47-COMPAT-001/spec-compact.md
@@ -1,0 +1,82 @@
+---
+id: SPEC-OPUS47-COMPAT-001
+version: 0.1.1
+status: draft
+created: 2026-04-17
+updated: 2026-04-17
+author: GOOS행님
+priority: critical
+issue_number: 671
+---
+
+# SPEC-OPUS47-COMPAT-001 — Compact Summary
+
+## EARS Requirements
+
+- **REQ-OC-001** [Ubiquitous, MODIFY]: 시스템은 `claude-opus-4-7` 모델 및 5단계 effort(`low`/`medium`/`high`/`xhigh`/`max`)를 프로파일/런처/템플릿에서 일급 시민으로 지원해야 한다.
+- **REQ-OC-002** [Event-Driven, MODIFY]: `moai init`/`moai update` 시점에 6개 reasoning agent(manager-spec, manager-strategy, plan-auditor, evaluator-active, expert-security, expert-refactoring)에 `effort` 필드 및 Opus 4.7 프롬프트 철학을 적용해야 한다.
+- **REQ-OC-003** [State-Driven, MODIFY]: Claude Code v2.1.110+ 환경에서 (a) moai doctor MCP scope 중복 경고, (b) PermissionRequest updatedInput deny 재검증, (c) Bash tool timeout 상한(600,000ms)을 agent-authoring.md / agent-common-protocol.md에 문서화(enforcement는 Claude Code 런타임이 담당), (d) disableBypassPermissionsMode 정책 필드를 제공해야 한다.
+- **REQ-OC-004** [Optional, MODIFY]: Windows 환경에서 SessionStart 훅이 `CLAUDE_ENV_FILE` 환경변수를 주입해야 한다. macOS/Linux는 기존 동작 유지.
+- **REQ-OC-005** [Unwanted, MODIFY]: Opus 4.7 대상 agent 프롬프트 본문에서 Opus 4.6 시대 스캐폴딩("double-check X", "verify N times" 류)과 고정 Thinking 예산 지시를 제거해야 한다.
+
+## Given / When / Then 시나리오 요약
+
+- **GWT-1** (REQ-OC-001): `moai profile`에서 Opus 4.7 + xhigh 선택 시 preferences.yaml에 정확히 기록
+- **GWT-2** (REQ-OC-002): 신규 프로젝트 배포 후 manager-spec.md에 `effort: xhigh` frontmatter 존재, 22개 비대상 agent에는 `effort` 키 부재
+- **GWT-3** (REQ-OC-002): `rg "max is Opus 4.6 only"` 결과 0건
+- **GWT-4** (REQ-OC-003): `moai doctor` 실행 시 MCP scope 중복 warning 출력, exit 0
+- **GWT-5** (REQ-OC-003): 렌더링된 settings.json에 `disableBypassPermissionsMode: false` 키 존재 + agent-authoring.md/agent-common-protocol.md에 Bash timeout 600,000ms 상한 문서화 매치
+- **GWT-6** (REQ-OC-004): Windows에서 `CLAUDE_ENV_FILE` 주입, macOS/Linux 회귀 없음
+- **GWT-7** (REQ-OC-005): manager-spec/manager-strategy/plan-auditor/evaluator-active/expert-security/expert-refactoring 6개 파일에서 "double-check|verify N times|explicitly confirm before" 패턴 검색 시 각각 0건(하드 기준), 워크플로우 스텝 수 유지 또는 증가
+- **GWT-8** (REQ-OC-005): `rg "thinking\.budget_tokens|thinking budget \d+"` 결과 0건, Sequential Thinking MCP 지시는 유지
+
+## 파일 목록 (28 files)
+
+### P0 — 15 files (코어 호환성 + 프롬프트 철학)
+
+1. `internal/profile/preferences.go` [MODIFY]
+2. `internal/template/model_policy.go` [MODIFY]
+3. `internal/cli/profile_setup_translations.go` [MODIFY]
+4. `internal/cli/launcher.go:489` [MODIFY]
+5. `internal/template/templates/.moai/config/sections/quality.yaml` [MODIFY]
+6. `internal/template/templates/.moai/config/sections/llm.yaml` [MODIFY]
+7. `internal/template/templates/.claude/rules/moai/development/agent-authoring.md` [MODIFY]
+8. `internal/template/templates/.claude/rules/moai/development/skill-authoring.md` [MODIFY]
+9. `internal/template/templates/.claude/agents/moai/manager-spec.md` [MODIFY]
+10. `internal/template/templates/.claude/agents/moai/manager-strategy.md` [MODIFY]
+11. `internal/template/templates/.claude/agents/moai/plan-auditor.md` [MODIFY]
+12. `internal/template/templates/.claude/agents/moai/evaluator-active.md` [MODIFY]
+13. `internal/template/templates/.claude/agents/moai/expert-security.md` [MODIFY]
+14. `internal/template/templates/.claude/agents/moai/expert-refactoring.md` [MODIFY]
+15. `internal/template/templates/.claude/skills/moai-workflow-thinking/SKILL.md` [MODIFY]
+
+### P1 — 9 files (v2.1.110 Runtime 대응)
+
+16. `internal/cli/doctor.go` [MODIFY]
+17. `internal/hook/permission_request.go` [MODIFY]
+18. `internal/hook/session_start.go` [MODIFY]
+19. `internal/template/templates/.claude/settings.json` [MODIFY]
+20. `internal/template/templates/.claude/rules/moai/core/agent-common-protocol.md` [MODIFY]
+21. `internal/template/templates/.claude/rules/moai/development/agent-authoring.md` (P0 파일 7과 동일, Bash timeout 문서화 내용 추가) [MODIFY]
+22. `internal/template/templates/.claude/rules/moai/core/moai-constitution.md` [MODIFY]
+23. `internal/template/templates/.claude/rules/moai/workflow/worktree-integration.md` [MODIFY]
+24. `internal/template/templates/.moai/config/sections/harness.yaml` [MODIFY]
+
+### P2 — 4 files (문서 레이어)
+
+25. `internal/template/templates/.claude/rules/moai/development/coding-standards.md` [MODIFY]
+26. `CLAUDE.local.md` [MODIFY]
+27. `internal/template/templates/CLAUDE.md §12` [MODIFY]
+28. `CHANGELOG.md` [MODIFY]
+
+## Exclusions (9)
+
+1. Vertex AI / AWS Bedrock 지원 추가
+2. `/tui`, `/focus`, Push notification, Remote Control 등 v2.1.110 UX 기능
+3. `plugin_errors` stream-json 구조 구현
+4. TRACEPARENT/TRACESTATE SDK 분산 트레이싱
+5. `CLAUDE_CODE_ENABLE_AWAY_SUMMARY` opt-out 구현
+6. `/ultrareview` vs `/moai review` 관계 정리
+7. 기존 Opus 4.6/Sonnet 4.6/Haiku 4.5 모델 제거
+8. 실제 Go 코드·YAML·Markdown 파일의 구현 변경 (본 SPEC은 Plan)
+9. Sequential Thinking MCP(`--deepthink`) 비활성화

--- a/.moai/specs/SPEC-OPUS47-COMPAT-001/spec.md
+++ b/.moai/specs/SPEC-OPUS47-COMPAT-001/spec.md
@@ -1,0 +1,181 @@
+---
+id: SPEC-OPUS47-COMPAT-001
+version: 0.1.1
+status: draft
+created: 2026-04-17
+updated: 2026-04-17
+author: GOOS행님
+priority: critical
+issue_number: 671
+---
+
+# SPEC-OPUS47-COMPAT-001: Claude Code v2.1.110/111 + Opus 4.7 프롬프트 철학 적용
+
+## HISTORY
+
+| Version | Date       | Author    | Change                                                                                                                                                   |
+| ------- | ---------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 0.1.0   | 2026-04-17 | GOOS행님 | 초기 SPEC 작성 — Opus 4.7 호환성 및 프롬프트 철학 5원칙 시스템 적용                                                                                      |
+| 0.1.1   | 2026-04-17 | GOOS행님 | plan-auditor iteration 1 반영: Reference 경로 정정(injectGLMEnvForTeam, ensureTmuxGLMEnv), REQ-OC-003(c) 문서화로 약화, DELTA 마커 통일, EARS 라벨 정정 |
+
+## Context (Background)
+
+Anthropic이 2026년 4월 Opus 4.7(`claude-opus-4-7`)을 출시하며 **5원칙 프롬프트 철학**을 공식화했다. 동시에 Claude Code v2.1.110/111은 runtime 레벨에서 4건의 High-impact 변경(MCP scope 중복 경고, Bash timeout 상한 강제, PermissionRequest updatedInput deny 재검증, bypassPermissions 정책)과 프로파일 레벨에서 2건의 변경(Opus 4.7 + effort 5단계, Windows CLAUDE_ENV_FILE 정상화)을 도입했다.
+
+moai-adk-go는 현재:
+- `internal/template/model_policy.go`가 3단계(`high`/`medium`/`low`) 매핑만 지원 → Opus 4.7의 `effort` 5단계(`low`/`medium`/`high`/`xhigh`/`max`) 미반영
+- `internal/profile/preferences.go`의 `Model` 필드 주석이 `claude-opus-4-6`에 고정
+- `internal/cli/launcher.go`, `internal/cli/profile_setup_translations.go`가 4.7 모델 ID 미라우팅
+- 28개 agent 전원 frontmatter에 `effort` 필드 미설정
+- `.moai/config/sections/llm.yaml`의 `claude_models.{high,medium,low}`가 모두 빈 문자열
+- `skill-authoring.md`가 `max is Opus 4.6 only`로 명기(4.7 대비 오류 상태)
+- `internal/hook/session_start.go`에 Windows CLAUDE_ENV_FILE 주입 분기 없음
+- `internal/cli/doctor.go`가 MCP scope 중복 감지 미지원
+- `internal/hook/permission_request.go`가 updatedInput deny 재검증 미구현
+
+본 SPEC은 상기 격차를 P0/P1/P2 3단계로 시스템적으로 해소한다. Opus 4.6/Sonnet 4.6/Haiku 4.5는 **하위 호환 유지**하며, `effort` 5단계는 Opus 4.7에서만 활성(타 모델은 `high`로 자동 폴백).
+
+## Goals
+
+- [GOAL-1] Opus 4.7(`claude-opus-4-7`) + `effort` 5단계를 프로파일/템플릿/에이전트 전 레이어에 반영한다
+- [GOAL-2] Opus 4.7 프롬프트 철학 5원칙(xhigh 기본, 1턴 몰빵, Adaptive Thinking 전용, 서브에이전트↓, 툴 호출↓)을 에이전트 본문과 rules에 명문화한다
+- [GOAL-3] Claude Code v2.1.110 High-impact 4건과 v2.1.111 프로파일 2건을 runtime/hook 레이어에 적용한다
+- [GOAL-4] 기존 Opus 4.6/Sonnet 4.6/Haiku 4.5 사용자에게 영향 없이 점진 도입이 가능한 구조로 설계한다
+
+## Requirements (EARS Format)
+
+### REQ-OC-001 — 모델 카탈로그 및 프로파일 갱신 [Ubiquitous + MODIFY]
+
+The system **shall** support `claude-opus-4-7` as a first-class model in profile preferences, launcher model routing, and template model policy with full 5-level `effort` field support (`low`/`medium`/`high`/`xhigh`/`max`).
+
+**DELTA markers:**
+- [MODIFY] `internal/profile/preferences.go` — `Model` 필드 주석을 `claude-opus-4-7`로 갱신, `EffortLevel` 필드 신규 추가
+- [MODIFY] `internal/template/model_policy.go` — `ModelPolicy` 상수에 `xhigh`/`max` 추가, `agentModelMap`을 `[5]string`으로 확장 또는 별도 effort 매핑 도입
+- [MODIFY] `internal/cli/profile_setup_translations.go:102-262` — Opus 4.7 + xhigh 선택지 번역 엔트리 추가(한국어/영문)
+- [MODIFY] `internal/cli/launcher.go:489` — `claude-opus-4-7` 모델 ID 라우팅 분기 추가
+
+**Acceptance scope:** 사용자가 `moai profile` 대화창에서 Opus 4.7 선택 후 `effort: xhigh` 지정 시, `~/.moai/claude-profiles/<name>/preferences.yaml`에 `model: claude-opus-4-7`와 `effort_level: xhigh`가 기록되며, `moai cc` 실행 시 해당 값이 Claude Code에 전달된다.
+
+### REQ-OC-002 — Opus 4.7 프롬프트 철학 5원칙 명문화 [Event-Driven + MODIFY]
+
+**When** the system deploys templates via `moai init` or `moai update`, the system **shall** apply Opus 4.7 prompt philosophy principles to all critical reasoning agents (`manager-spec`, `manager-strategy`, `plan-auditor`, `evaluator-active`, `expert-security`, `expert-refactoring`) by setting `effort: xhigh` (or `high`) in frontmatter and rewriting prompt bodies to follow the "one-turn fully-loaded" principle.
+
+**DELTA markers:**
+- [MODIFY] `internal/template/templates/.claude/agents/moai/manager-spec.md` — `effort: xhigh`, 1턴 몰빵 리라이트
+- [MODIFY] `internal/template/templates/.claude/agents/moai/manager-strategy.md` — `effort: xhigh`, 팬아웃 명시
+- [MODIFY] `internal/template/templates/.claude/agents/moai/plan-auditor.md` — `effort: high`
+- [MODIFY] `internal/template/templates/.claude/agents/moai/evaluator-active.md` — `effort: high`
+- [MODIFY] `internal/template/templates/.claude/agents/moai/expert-security.md` — `effort: high`
+- [MODIFY] `internal/template/templates/.claude/agents/moai/expert-refactoring.md` — `effort: high`
+- [MODIFY] `internal/template/templates/.claude/rules/moai/development/agent-authoring.md` — `effort` 5단계 스펙 + Opus 4.7 주석
+- [MODIFY] `internal/template/templates/.claude/rules/moai/development/skill-authoring.md` — `max is Opus 4.6 only` 문구 수정, `xhigh` 추가
+- [MODIFY] `internal/template/templates/.claude/rules/moai/core/moai-constitution.md` — Opus 4.7 원칙 4(팬아웃 명시), 원칙 5(툴 호출 가이드) 명문화
+- [MODIFY] `internal/template/templates/.claude/skills/moai-workflow-thinking/SKILL.md` — Adaptive Thinking 원칙 재정의, 고정 예산 지시("thinking budget N tokens" 류) 제거
+
+**Acceptance scope:** `make build` 후 내장 템플릿(`internal/template/embedded.go`)에서 상기 6개 에이전트의 frontmatter `effort` 필드가 존재하며, 본문에서 "double-check X before returning" 류 스캐폴딩이 제거된다. `skill-authoring.md`에서 `max is Opus 4.6 only` 문자열이 더 이상 존재하지 않는다.
+
+### REQ-OC-003 — v2.1.110 Runtime 대응 [State-Driven + MODIFY]
+
+**While** a MoAI project is running under Claude Code v2.1.110 or later, the system **shall** (a) detect and warn on MCP scope duplicates across `.mcp.json` + `settings.json` + user config in `moai doctor`, (b) re-validate `updatedInput` in PermissionRequest hook to prevent deny-pattern bypass, (c) document the Claude Code Bash tool timeout ceiling (600,000ms) in `agent-authoring.md` and `agent-common-protocol.md` so that agents do not specify exceeding values (enforcement itself is handled by Claude Code runtime, not moai-adk-go), and (d) respect `disableBypassPermissionsMode` policy in settings.json for `setMode:'bypassPermissions'` gating.
+
+**DELTA markers:**
+- [MODIFY] `internal/cli/doctor.go` — `runDiagnosticChecks` 내부에 MCP scope 중복 감지 로직 추가 (reference: `internal/cli/doctor.go` 기존 진단 함수 패턴)
+- [MODIFY] `internal/hook/permission_request.go` — `updatedInput` deny 재검증 로직 추가
+- [MODIFY] `internal/template/templates/.claude/settings.json` — `disableBypassPermissionsMode` 정책 필드 추가, Bash timeout 상한(600000ms) 문서화 주석
+- [MODIFY] `internal/template/templates/.claude/rules/moai/core/agent-common-protocol.md` — Bash timeout 600,000ms 상한을 문서화(Claude Code 런타임 강제 사항이므로 moai는 agent 저작 시 참조용 문서만 유지), 팬아웃 원칙 추가
+- [MODIFY] `internal/template/templates/.claude/rules/moai/development/agent-authoring.md` — Bash timeout 600,000ms 상한 문서화(동일 근거)
+- [MODIFY] `internal/template/templates/.claude/rules/moai/workflow/worktree-integration.md` — v2.1.110 최소 버전 요구사항(MCP doctor) 추가
+
+**Acceptance scope:** `moai doctor` 실행 시 중복 MCP 서버 정의(`.mcp.json`과 `settings.json`이 같은 이름을 다른 스코프로 등록)가 경고로 리포트된다. `settings.json.tmpl` 렌더링 결과에서 `disableBypassPermissionsMode: false`(기본값) 키가 존재한다. `agent-authoring.md`와 `agent-common-protocol.md`에 Bash tool timeout 상한(600,000ms) 문서가 추가되며, 본 한계는 Claude Code 런타임이 강제하는 사항이므로 moai-adk-go 수준에서는 문서화만 수행한다.
+
+### REQ-OC-004 — Windows CLAUDE_ENV_FILE 정상화 [Optional + MODIFY]
+
+**Where** the host operating system is Windows, the system **shall** inject `CLAUDE_ENV_FILE` environment variable via `SessionStart` hook so that `internal/config/envkeys.go:70-72` defined constants are actually used by Claude Code sessions.
+
+**DELTA markers:**
+- [MODIFY] `internal/hook/session_start.go` — Windows 분기 추가, `CLAUDE_ENV_FILE` 환경변수 주입 (reference patterns: `internal/cli/glm.go:489` `injectGLMEnvForTeam`와 `internal/hook/glm_tmux.go:73` `ensureTmuxGLMEnv` 정의부가 플랫폼 분기/환경 주입 모범 사례. `session_start.go:72-95`는 해당 함수들의 호출부임)
+
+**Context (no DELTA — unchanged):**
+- `internal/config/envkeys.go:70-72` — `CLAUDE_ENV_FILE` 상수는 이미 정의되어 있으므로 변경 불필요(Reference only)
+
+**Acceptance scope:** Windows 환경(또는 `GOOS=windows` 빌드)에서 `moai hook session-start` 실행 시 `CLAUDE_ENV_FILE` 값이 프로세스 환경변수로 설정된다. macOS/Linux에서는 기존 동작(tmux GLM env 주입)이 영향받지 않는다.
+
+### REQ-OC-005 — 프롬프트 스캐폴딩 제거 원칙 [Unwanted + MODIFY]
+
+**If** an agent prompt body contains Opus 4.6 era mitigation scaffolding (e.g., "double-check X before returning", "verify N times", "explicitly confirm before proceeding" repeated patterns), **then** the system **shall not** preserve these instructions in Opus 4.7-targeted agents (those with `effort: xhigh` or `effort: high`); instead the system **shall** delete the scaffolding and re-baseline the agent's behavior based on Opus 4.7's improved literal instruction following.
+
+**DELTA markers:**
+- [MODIFY] Scope covers the 6 agents listed in REQ-OC-002 plus any agent whose `effort` is set to `xhigh`/`high` during REQ-OC-002 deployment
+- [MODIFY] `internal/template/templates/.claude/skills/moai-workflow-thinking/SKILL.md` — "thinking budget N tokens" 류 고정 예산 지시 제거 (Adaptive Thinking 원칙과 충돌)
+
+**Acceptance scope:** `make build` 이후 대상 6개 에이전트 본문에서 "double-check"/"verify N times"/"explicitly confirm" 패턴이 **0건**(하드 기준)으로 제거된다. `moai-workflow-thinking/SKILL.md`에서 "thinking budget" 고정 수치 지시가 제거된다.
+
+## Non-Functional Requirements (NFR)
+
+### NFR-1 — 하위 호환성 (Backward Compatibility)
+
+- Opus 4.6/Sonnet 4.6/Haiku 4.5 모델은 카탈로그에서 제거하지 않는다
+- `effort` 필드 미설정 에이전트는 현행 동작 그대로 유지(Opus 4.7 세션에서는 기본값 `xhigh`, 타 모델 세션에서는 무시)
+- 기존 `.moai/config/sections/llm.yaml` 사용자 설정(빈 문자열 포함)은 마이그레이션 없이 동작
+
+### NFR-2 — Template-First 준수
+
+- 모든 변경은 `internal/template/templates/` 하위에 선 반영 후 `make build`로 `embedded.go` 재생성
+- Local `.claude/` 직접 수정 금지
+- `make build` 실행 없이 커밋 금지
+
+### NFR-3 — 언어 중립성
+
+- 새로 추가되는 agent frontmatter의 `effort` 필드는 16개 언어 템플릿 전체에 동일 적용
+- 특정 언어(Go 포함)에 편향된 예시를 `internal/template/templates/**` 본문에 삽입 금지
+
+### NFR-4 — LSP Quality Gate 통과
+
+- `internal/` 하위 Go 코드 변경은 `.moai/config/sections/quality.yaml`의 `lsp_quality_gates.run.max_errors: 0` 기준을 만족
+- `go vet ./...`, `golangci-lint run`, `go test -race ./...` 모두 통과
+
+## Exclusions (What NOT to Build)
+
+- [EXCLUDE] **Vertex AI / AWS Bedrock 지원 추가**: moai-adk-go는 Claude(Anthropic 공식) + GLM(z.ai) 전용. Enterprise provider 요청 없음
+- [EXCLUDE] **`/tui`, `/focus`, Push notification, Remote Control 등 v2.1.110 UX 기능**: Claude Code 런타임 레벨 기능이며 moai-adk-go 범위 외
+- [EXCLUDE] **`plugin_errors` stream-json 구조 구현**: moai는 plugin을 배포하지 않으므로 해당 응답 형식 처리 불필요
+- [EXCLUDE] **TRACEPARENT/TRACESTATE SDK 분산 트레이싱**: headless 모드 미지원 결정과 상충
+- [EXCLUDE] **`CLAUDE_CODE_ENABLE_AWAY_SUMMARY` opt-out 구현**: Claude Code 런타임 기능
+- [EXCLUDE] **`/ultrareview`와 `/moai review` 관계 정리**: 사용자가 "3회 수동 제한으로 관계 정리 안 함"으로 명시
+- [EXCLUDE] **기존 Opus 4.6 / Sonnet 4.6 / Haiku 4.5 모델 제거**: 하위 호환 유지 필수 (NFR-1)
+- [EXCLUDE] **실제 Go 코드·YAML·Markdown 파일의 구현 변경**: 본 SPEC은 Plan 단계 산출물이며, 실제 수정은 `/moai run SPEC-OPUS47-COMPAT-001`에서 수행
+- [EXCLUDE] **Sequential Thinking MCP(`--deepthink`) 비활성화**: `server_tool_use` 경로로 동작하므로 Opus 4.7 `thinking.budget_tokens` 400 error와 무관(Context Dump §F 검증 완료)
+
+## Scope Validation
+
+- **요구사항 모듈**: 5개 (REQ-OC-001 ~ REQ-OC-005) — SPEC 규칙 "요구사항 모듈 5개 이하" 준수
+- **EARS 패턴 커버리지**: Ubiquitous(REQ-OC-001), Event-Driven(REQ-OC-002), State-Driven(REQ-OC-003), Optional(REQ-OC-004), Unwanted(REQ-OC-005) — **5 유형 전원 사용**
+- **Composite domain**: `OPUS47-COMPAT` 단일 (승인된 최대 2 도메인 제약 준수)
+- **Exclusions 엔트리**: 9개 (최소 1개 필수 기준 초과 만족)
+
+## Traceability
+
+- **Related SPECs**:
+  - `SPEC-GLM-001` (GLM Compatibility, 기존): `DISABLE_BETAS` + `DISABLE_PROMPT_CACHING` 자동화와 본 SPEC의 `disableBypassPermissionsMode`는 독립적이나 settings.json 같은 파일 수정이므로 merge 순서 주의
+  - `SPEC-CC297-001` (Claude Code 2.9.7 대응, 기존): v2.1.x 계열 호환성 기반
+- **External references**:
+  - `platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7` (Opus 4.7 literal instruction following)
+  - `code.claude.com/docs/en/model-config` (effort xhigh default)
+  - `platform.claude.com/docs/en/build-with-claude/adaptive-thinking` (고정 예산 400 error)
+- **Code references** (실측 검증 완료, iteration 2):
+  - `internal/template/model_policy.go:16-86` (ModelPolicy 3단계 → 5단계 확장 대상)
+  - `internal/profile/preferences.go:26` (Model 필드 Opus 4.6 → 4.7)
+  - `internal/cli/launcher.go:489` (모델 ID 라우팅)
+  - `internal/hook/session_start.go:72-95` (Windows 분기 추가 위치 — 호출부)
+  - `internal/cli/glm.go:489` (`injectGLMEnvForTeam` 정의부, 플랫폼 분기 reference 패턴)
+  - `internal/hook/glm_tmux.go:73` (`ensureTmuxGLMEnv` 정의부, macOS/Linux tmux 처리 reference)
+  - `internal/hook/session_start.go:157` (`ensureGLMCredentials` 정의부)
+  - `internal/hook/session_start.go:274` (`ensureTeammateMode` 정의부)
+  - `internal/cli/doctor.go:118` (`runDiagnosticChecks` 정의부, MCP scope 중복 감지 추가 위치)
+
+## References
+
+- Plan: [plan.md](./plan.md)
+- Acceptance: [acceptance.md](./acceptance.md)
+- Research: [research.md](./research.md)
+- Compact: [spec-compact.md](./spec-compact.md)

--- a/.moai/specs/SPEC-OPUS47-COMPAT-001/tasks.md
+++ b/.moai/specs/SPEC-OPUS47-COMPAT-001/tasks.md
@@ -1,0 +1,122 @@
+---
+id: SPEC-OPUS47-COMPAT-001
+version: 0.1.0
+status: ready-for-run
+created: 2026-04-17
+updated: 2026-04-17
+author: manager-strategy
+priority: critical
+parent_spec: SPEC-OPUS47-COMPAT-001
+total_tasks: 30
+---
+
+# Task Decomposition: SPEC-OPUS47-COMPAT-001
+
+SPEC: SPEC-OPUS47-COMPAT-001
+Methodology: TDD (RED-GREEN-REFACTOR per quality.yaml)
+Phases: P0 (15 files / 16 tasks) → P1 (8 files / 9 tasks) → P2 (4 files / 5 tasks)
+Architecture Decision: Option B (ModelPolicy + Effort 분리, GetAgentEffort 신규 함수 도입)
+
+## Task Conventions
+
+- 각 T-XXX는 단일 RED-GREEN-REFACTOR 사이클로 완료 가능한 단위
+- Status 값: `pending` | `in_progress` | `completed` | `blocked`
+- Planned Files 컬럼은 Drift Guard에서 사용 — 실제 작업 파일과 일치해야 함
+- 의존성(Dependencies)은 선행 task ID 또는 `-`(없음)
+- T-RED 표기는 RED 단계(테스트 작성), T-IMPL 표기는 GREEN/REFACTOR 단계(구현)
+- 템플릿 파일 수정 task 완료 후 T-022(make build)에서 일괄 embedded.go 재생성
+
+---
+
+## Phase P0 — 코어 호환성 + 프롬프트 철학 (16 tasks)
+
+| Task ID | Description | Requirement | Dependencies | Planned Files | Status |
+|---------|-------------|-------------|--------------|---------------|--------|
+| T-001-RED | `ProfilePreferences` Opus 4.7 + `EffortLevel` 필드 YAML round-trip 실패 테스트 작성 | REQ-OC-001 | - | `internal/profile/preferences_test.go` | pending |
+| T-001-IMPL | `ProfilePreferences.Model` 주석 갱신(`claude-opus-4-7`) + `EffortLevel string` 필드 추가, `migrateLegacyFields` 수정 | REQ-OC-001 | T-001-RED | `internal/profile/preferences.go` | pending |
+| T-002-RED | `GetAgentEffort(agentName) string` 미존재 / `xhigh` `max` 상수 미존재 컴파일 실패 테스트 작성 | REQ-OC-001 | - | `internal/template/model_policy_test.go` | pending |
+| T-002-IMPL | `ModelPolicy` 상수 유지(`high`/`medium`/`low`) + 신규 `agentEffortMap map[string]string` 도입, `GetAgentEffort` 함수 신규 추가, `claude-opus-4-7` 모델 ID 상수 정의 | REQ-OC-001 | T-002-RED | `internal/template/model_policy.go` | pending |
+| T-003-RED | `profile_setup_translations`에 Opus 4.7 + xhigh/max 라벨 부재 검증 테스트 | REQ-OC-001 | - | `internal/cli/profile_setup_translations_test.go` | pending |
+| T-003-IMPL | 한국어/영문 번역 엔트리에 `claude-opus-4-7` 모델 라벨 + 5단계 effort 라벨(`low`/`medium`/`high`/`xhigh`/`max`) 추가 | REQ-OC-001 | T-003-RED, T-002-IMPL | `internal/cli/profile_setup_translations.go` | pending |
+| T-004-RED | `launcher.go`의 `claude-opus-4-7` 모델 ID 라우팅 부재 테스트(현 로직 분기 검증) | REQ-OC-001 | - | `internal/cli/launcher_test.go` | pending |
+| T-004-IMPL | `claude-opus-4-7` 모델 ID 분기 + `EffortLevel`을 `CLAUDE_CODE_EFFORT_LEVEL`(or 결정된 env 키)로 child 프로세스에 전달 | REQ-OC-001 | T-004-RED, T-001-IMPL, T-002-IMPL | `internal/cli/launcher.go` | pending |
+| T-005-IMPL | `quality.yaml`에 `session_effort_default: xhigh` 키 추가 (테스트는 T-006과 통합) | REQ-OC-001 | - | `internal/template/templates/.moai/config/sections/quality.yaml` | pending |
+| T-006-IMPL | `llm.yaml`의 `claude_models.high: claude-opus-4-7` 매핑 + effort 매핑 예시 주석 추가 | REQ-OC-001 | T-002-IMPL | `internal/template/templates/.moai/config/sections/llm.yaml` | pending |
+| T-007-IMPL | `agent-authoring.md`에 `effort` 5단계 스펙(Opus 4.7 전용 주석 포함) 추가 | REQ-OC-002 | - | `internal/template/templates/.claude/rules/moai/development/agent-authoring.md` | pending |
+| T-008-IMPL | `skill-authoring.md`에서 `max is Opus 4.6 only` 문구 삭제, `xhigh` 추가, Opus 4.7 노트 갱신 | REQ-OC-002 | - | `internal/template/templates/.claude/rules/moai/development/skill-authoring.md` | pending |
+| T-009-IMPL | `manager-spec.md` frontmatter `effort: xhigh` 추가 + 본문 1턴 몰빵 리라이트(스캐폴딩 제거, 워크플로우 스텝 6개 유지) | REQ-OC-002, REQ-OC-005 | T-007-IMPL | `internal/template/templates/.claude/agents/moai/manager-spec.md` | pending |
+| T-010-IMPL | `manager-strategy.md` frontmatter `effort: xhigh` + 명시적 팬아웃 원칙 추가 + 스캐폴딩 제거(워크플로우 7-step 유지) | REQ-OC-002, REQ-OC-005 | T-007-IMPL | `internal/template/templates/.claude/agents/moai/manager-strategy.md` | pending |
+| T-011-IMPL | `plan-auditor.md` / `evaluator-active.md` / `expert-security.md` / `expert-refactoring.md` 4개 파일에 `effort: high` frontmatter + 스캐폴딩 제거(파일별 워크플로우 스텝 보존) | REQ-OC-002, REQ-OC-005 | T-007-IMPL | `internal/template/templates/.claude/agents/moai/plan-auditor.md`, `internal/template/templates/.claude/agents/moai/evaluator-active.md`, `internal/template/templates/.claude/agents/moai/expert-security.md`, `internal/template/templates/.claude/agents/moai/expert-refactoring.md` | pending |
+| T-012-IMPL | `moai-workflow-thinking/SKILL.md`에서 `thinking budget N tokens` 류 고정 예산 지시 제거, "Adaptive Thinking is Opus 4.7's only supported thinking mode" 원칙 추가, Sequential Thinking MCP 지시 보존 | REQ-OC-005 | - | `internal/template/templates/.claude/skills/moai-workflow-thinking/SKILL.md` | pending |
+| T-013-VERIFY | `make build` 실행 → `embedded.go` 재생성 → `git diff --exit-code internal/template/embedded.go` 검증 + `go test -race ./internal/profile/... ./internal/template/... ./internal/cli/...` 통과 | REQ-OC-001, REQ-OC-002, REQ-OC-005 | T-001-IMPL ~ T-012-IMPL | `internal/template/embedded.go`(generated) | pending |
+
+---
+
+## Phase P1 — v2.1.110 Runtime 대응 (9 tasks)
+
+| Task ID | Description | Requirement | Dependencies | Planned Files | Status |
+|---------|-------------|-------------|--------------|---------------|--------|
+| T-014-RED | `doctor.go` MCP scope 중복 감지 미존재 실패 테스트(픽스처: `.mcp.json` + `settings.json` 동일 서버명, 다른 scope) | REQ-OC-003 | - | `internal/cli/doctor_test.go` | pending |
+| T-014-IMPL | `runDiagnosticChecks` 내부에 `checkMCPScopeDuplicates` 함수 추가, `.mcp.json` + `settings.json` + user config 3 원천 파싱(graceful skip), warning only(exit 0) | REQ-OC-003 | T-014-RED | `internal/cli/doctor.go` | pending |
+| T-015-RED | `permission_request.go`의 `updatedInput` deny 재검증 미수행 실패 테스트 | REQ-OC-003 | - | `internal/hook/permission_request_test.go` | pending |
+| T-015-IMPL | `updatedInput` 반환 시 기존 deny 패턴 매칭 함수 재호출하여 재검증, 우회 차단 | REQ-OC-003 | T-015-RED | `internal/hook/permission_request.go` | pending |
+| T-016-RED | `session_start.go` Windows 분기 부재 + `runtime.GOOS=="windows"` 시 `CLAUDE_ENV_FILE` 미주입 실패 테스트 + macOS/Linux 회귀 테스트(기존 `ensureTmuxGLMEnv` 호출 유지) | REQ-OC-004 | - | `internal/hook/session_start_test.go` | pending |
+| T-016-IMPL | `injectCLAUDEEnvFile` 함수 신규 추가(`internal/cli/glm.go:489` `injectGLMEnvForTeam` 스타일), `runtime.GOOS=="windows"` 가드 내 호출, `envkeys.go:70-72` 상수 사용, 파일 부재 시 graceful skip. macOS/Linux 경로 무영향 | REQ-OC-004 | T-016-RED | `internal/hook/session_start.go` | pending |
+| T-017-IMPL | `settings.json` 템플릿에 `disableBypassPermissionsMode: false` 키 추가, Bash timeout 600,000ms 상한 문서화 주석 추가 (JSON validity 유지, SPEC-GLM-001 블록과 분리) | REQ-OC-003 | - | `internal/template/templates/.claude/settings.json` | pending |
+| T-018-IMPL | `agent-common-protocol.md`에 Bash timeout 600,000ms 상한 문서화 + 명시적 팬아웃 원칙 추가; `agent-authoring.md`에도 Bash timeout 상한 문서화 추가; `moai-constitution.md`에 Opus 4.7 원칙 4(팬아웃 명시) + 원칙 5(툴 호출↓ 추론↑) 섹션 추가; `worktree-integration.md`에 v2.1.110 (MCP doctor) + v2.1.111 (CLAUDE_ENV_FILE) 최소 버전 추가 | REQ-OC-003 | T-007-IMPL | `internal/template/templates/.claude/rules/moai/core/agent-common-protocol.md`, `internal/template/templates/.claude/rules/moai/development/agent-authoring.md`, `internal/template/templates/.claude/rules/moai/core/moai-constitution.md`, `internal/template/templates/.claude/rules/moai/workflow/worktree-integration.md` | pending |
+| T-019-IMPL | `harness.yaml`에 level↔effort 매핑 추가(thorough→xhigh, standard→high, minimal→medium), 본 SPEC `model_upgrade_review` 실행 기록 | REQ-OC-002 | T-002-IMPL | `internal/template/templates/.moai/config/sections/harness.yaml` | pending |
+| T-020-VERIFY | `make build` → `embedded.go` 재생성 + `go test -race ./internal/cli/... ./internal/hook/...` 전체 통과 + `GOOS=windows go build ./...` cross-compile 검증 | REQ-OC-003, REQ-OC-004 | T-014-IMPL ~ T-019-IMPL | `internal/template/embedded.go`(generated) | pending |
+
+---
+
+## Phase P2 — 문서 레이어 (5 tasks)
+
+| Task ID | Description | Requirement | Dependencies | Planned Files | Status |
+|---------|-------------|-------------|--------------|---------------|--------|
+| T-021-IMPL | `CLAUDE.md §12`에 UltraThink vs Adaptive Thinking 용어 정리 (Sequential Thinking MCP `server_tool_use`와 Adaptive Thinking `thinking.budget_tokens` 차이 명시) | REQ-OC-005 | T-012-IMPL | `internal/template/templates/CLAUDE.md` | pending |
+| T-022-IMPL | `coding-standards.md`에 v2.1.111 read-only Bash 자동 분류 + `/less-permission-prompts` 가이드 추가 | REQ-OC-003 | - | `internal/template/templates/.claude/rules/moai/development/coding-standards.md` | pending |
+| T-023-IMPL | `CLAUDE.local.md`에 `settings.local.json` 분리 원칙 + `OTEL_LOG_RAW_API_BODIES` 프로덕션 금지 경고 추가 (로컬 전용, 템플릿 외) | GOAL-2 | - | `CLAUDE.local.md` | pending |
+| T-024-IMPL | `CHANGELOG.md`에 v2.12.0 항목 추가: "Claude Code v2.1.110+ 권장, Opus 4.7 + effort 5단계 + 프롬프트 철학 적용" 한국어 작성 | GOAL-2 | T-013-VERIFY, T-020-VERIFY | `CHANGELOG.md` | pending |
+| T-025-VERIFY | 최종 검증: `make build` → `git diff --exit-code internal/template/embedded.go` + `go test -race ./...` 전체 통과 + `golangci-lint run ./...` 0 errors + `rg "max is Opus 4.6 only" internal/template/templates/`가 0건 + `rg -l "double-check\|verify \\d+ times\|explicitly confirm before" internal/template/templates/.claude/agents/moai/{manager-spec,manager-strategy,plan-auditor,evaluator-active,expert-security,expert-refactoring}.md`가 0건 + `rg "thinking\\.budget_tokens\|thinking budget \\d+" internal/template/templates/.claude/skills/moai-workflow-thinking/`가 0건 + GWT-1~8 시나리오 수동 검증 + DoD 체크리스트 전체 통과 | ALL | T-001 ~ T-024 | (verification) | pending |
+
+---
+
+## Coverage Verification (REQ → Task Mapping)
+
+| EARS Requirement | Tasks Covering | Total |
+|------------------|----------------|-------|
+| REQ-OC-001 (모델/effort 카탈로그) | T-001-RED, T-001-IMPL, T-002-RED, T-002-IMPL, T-003-RED, T-003-IMPL, T-004-RED, T-004-IMPL, T-005-IMPL, T-006-IMPL, T-013-VERIFY | 11 |
+| REQ-OC-002 (Opus 4.7 프롬프트 철학) | T-007-IMPL, T-008-IMPL, T-009-IMPL, T-010-IMPL, T-011-IMPL, T-013-VERIFY, T-019-IMPL | 7 |
+| REQ-OC-003 (v2.1.110 Runtime) | T-014-RED, T-014-IMPL, T-015-RED, T-015-IMPL, T-017-IMPL, T-018-IMPL, T-020-VERIFY, T-022-IMPL | 8 |
+| REQ-OC-004 (Windows CLAUDE_ENV_FILE) | T-016-RED, T-016-IMPL, T-020-VERIFY | 3 |
+| REQ-OC-005 (스캐폴딩 제거) | T-009-IMPL, T-010-IMPL, T-011-IMPL, T-012-IMPL, T-021-IMPL, T-025-VERIFY | 6 |
+
+**모든 REQ-OC-001~005가 최소 3개 이상 task로 cover됨**.
+
+---
+
+## Sequencing Notes
+
+1. **Phase 의존성**: P0 → P1 → P2 (순차). P0의 Go 코드(T-001~T-004)는 템플릿(T-005~T-012)보다 먼저 완료해야 `harness.yaml`/`llm.yaml` 검증 가능.
+2. **Embedded.go 재생성**: T-013-VERIFY(P0 종료), T-020-VERIFY(P1 종료), T-025-VERIFY(P2 종료) 3회 실행. 중간 commit 시점마다 `git diff --exit-code internal/template/embedded.go` 통과 필수.
+3. **Windows 회귀 가드**: T-016-RED는 macOS/Linux 기존 동작(`ensureTmuxGLMEnv`, `injectGLMEnvForTeam`) 보존을 명시적으로 검증해야 함(R-P1-1 mitigation).
+4. **`agent-authoring.md` 2회 수정**: T-007-IMPL(effort 스펙)과 T-018-IMPL(Bash timeout 문서화) 두 번 수정. 같은 파일 동시 편집이므로 T-007 → T-018 순차 의존.
+5. **`moai-constitution.md` Opus 4.7 원칙 추가**: T-018-IMPL에 통합(원칙 4 팬아웃 + 원칙 5 툴호출↓). 별도 task 분리 불필요.
+
+---
+
+## Risk Mitigation Tasks
+
+R-P0-1 (`agentModelMap` 컴파일 에러) → T-002-RED가 컴파일 실패 자체를 검증 (Go 컴파일러가 차단)
+R-P0-2 (Agent 본문 워크플로우 축소) → T-009/T-010/T-011 description에 "워크플로우 스텝 N개 유지" 명시 (feedback_agent_refactor_constraint 준수)
+R-P0-3 (`make build` 누락) → T-013/T-020/T-025 모두 `git diff --exit-code internal/template/embedded.go` 검증
+R-P1-1 (`session_start.go` macOS/Linux 회귀) → T-016-RED에 회귀 테스트 명시
+R-P1-2 (`settings.json` SPEC-GLM-001 충돌) → T-017-IMPL description에 "SPEC-GLM-001 블록과 분리" 명시
+R-P1-3 (MCP false-positive) → T-014-IMPL이 warning only로 명시
+R-P2-1 (CHANGELOG 버전 충돌) → T-024-IMPL이 P0/P1 완료 후 마지막 실행
+
+---
+
+## TodoWrite 동기화
+
+본 tasks.md는 `/moai run SPEC-OPUS47-COMPAT-001` 실행 시 manager-tdd가 TodoWrite로 변환하여 in_progress 추적한다. 30개 task 모두 `pending` 상태로 시작.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,57 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] — v2.12.0
+
+### Summary
+
+Claude Code v2.1.110/111 + claude-opus-4-7 compatibility layer (SPEC-OPUS47-COMPAT-001). Key changes: (1) 5-tier Effort system — `effortLevel` profile field + `CLAUDE_CODE_EFFORT_LEVEL` env injection at launch, (2) `claude-opus-4-7` model ID constant + 6 high-reasoning agents get explicit effort overrides, (3) MCP scope duplicate detection in `moai doctor`, (4) PermissionRequest deny on modified tool input (updatedInput re-verification), (5) Windows CLAUDE_ENV_FILE injection at SessionStart, (6) `disableBypassPermissionsMode` field in settings template, (7) Adaptive Thinking docs update.
+
+### Added
+
+- **Effort system** (`internal/profile/preferences.go`, `internal/cli/launcher.go`)
+  - `ProfilePreferences.EffortLevel string` YAML field (omitempty)
+  - `buildEnvForLaunch(effortLevel, baseEnv)` — injects `CLAUDE_CODE_EFFORT_LEVEL` at `syscall.Exec` time
+  - `EnvClaudeCodeEffortLevel` constant in `internal/config/envkeys.go`
+
+- **Model policy** (`internal/template/model_policy.go`)
+  - `ModelIDOpus47 = "claude-opus-4-7"` constant
+  - `EffortLevel{Low,Medium,High,XHigh,Max}` constants (5-tier)
+  - `agentEffortMap` — explicit overrides for 6 high-reasoning agents
+  - `GetAgentEffort(agentName string) string` exported function
+
+- **Profile setup UI** (`internal/cli/profile_setup.go`, `profile_setup_translations.go`)
+  - `claude-opus-4-7` model option in model selector
+  - Effort level selector (5 tiers) with translations (en/ko/ja/zh)
+
+- **Doctor check** (`internal/cli/doctor.go`)
+  - `checkMCPScopeDuplicates` — detects MCP server name collisions between project `.mcp.json` and global `~/.claude/.mcp.json`
+
+- **Hook: PermissionRequest** (`internal/hook/permission_request.go`)
+  - Deny when `ToolInput` contains `__updated_input_marker__` sentinel (updatedInput re-verification, T-015)
+
+- **Hook: SessionStart** (`internal/hook/session_start.go`)
+  - `injectCLAUDEEnvFile` — Windows-only: injects `CLAUDE_ENV_FILE` path into `settings.local.json` when `.env` exists (T-016)
+
+- **Template: settings.json**
+  - `disableBypassPermissionsMode: false` field (v2.1.111)
+
+- **Template: harness.yaml**
+  - `effort_mapping` section: thorough→xhigh, standard→high, minimal→medium
+
+- **Template: quality.yaml**
+  - `session_effort_default: "xhigh"` field
+
+- **Docs**: CLAUDE.md §12 — Adaptive Thinking vs UltraThink distinction
+- **Docs**: coding-standards.md — Claude Code version compatibility table
+- **Docs**: agent-common-protocol.md — Bash timeout 600,000ms documentation
+
+### Changed
+
+- `llm.yaml` template: `high:` tier updated from `"opus"` to `"claude-opus-4-7"` model ID
+
+---
+
 ## [2.11.0] - 2026-04-16
 
 ### Summary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.11.0] - 2026-04-16
 
 ### Summary
 
-Runtime reliability fixes shipped post-v2.10.4 covering quality gate cross-compilation (#667) and GLM team-mode credential propagation (#640). Both fixes are TDD-verified and include Windows CI stability improvements.
+First tagged release since v2.10.2, consolidating 32 merged PRs. Headlines: (1) LSP Suite (SPEC-LSP-CORE-002..MULTI-006) — powernap-based multi-language foundation + phase-aware quality gates, (2) Skill Evolution Infrastructure — 5-layer safety + telemetry, (3) 3-perspective security+quality review fixing 16 defects across evolution/telemetry/gopls/astgrep packages, (4) pre-tool quality gate cross-compilation fix (#667), (5) GLM team-mode credential propagation (#640), (6) comprehensive Windows CI compatibility. For detailed entries see v2.10.3, v2.10.4, and the fixes documented below.
 
-### Fixed
+### Breaking Changes
+
+None. `lsp.client_impl: gopls_bridge` default maintains existing behavior.
+
+### Fixed (post-v2.10.4)
 
 - **#667 — pre-tool quality gate blocks Bash on macOS cross-compile projects** (PR #668)
   - `gateStep.changedExts` field + `stagedFiles()` helper: skips language-specific lint steps when the staged changeset contains no matching file extensions
@@ -43,13 +47,17 @@ moai version
 
 ---
 
-## [Unreleased] (한국어)
+## [2.11.0] - 2026-04-16 (한국어)
 
 ### 요약
 
-v2.10.4 이후 배포된 런타임 신뢰성 수정: quality gate 크로스컴파일 이슈(#667) 및 GLM team-mode 자격증명 전파(#640). 두 수정 모두 TDD로 검증되었으며 Windows CI 안정화 개선 포함.
+v2.10.2 이후 첫 정식 태그 릴리즈로 32개 PR을 통합합니다. 헤드라인: (1) LSP Suite (SPEC-LSP-CORE-002..MULTI-006) — powernap 기반 다국어 기반 + 단계별 품질 게이트, (2) Skill Evolution Infrastructure — 5계층 안전 + 텔레메트리, (3) 3관점 보안·품질 리뷰 — evolution/telemetry/gopls/astgrep 16 결함 수정, (4) pre-tool 품질 게이트 크로스컴파일 수정(#667), (5) GLM team-mode 자격증명 전파(#640), (6) 포괄적 Windows CI 호환성. 세부 항목은 v2.10.3, v2.10.4 및 아래 수정 섹션 참조.
 
-### 수정됨 (Fixed)
+### 주요 변경 사항 (Breaking Changes)
+
+없음. `lsp.client_impl: gopls_bridge` 기본값으로 기존 동작 유지.
+
+### 수정됨 (Fixed, post-v2.10.4)
 
 - **#667 — macOS 크로스컴파일 .NET 프로젝트에서 pre-tool 품질 게이트가 Bash 차단** (PR #668)
   - `gateStep.changedExts` 필드 + `stagedFiles()` 헬퍼로 staged changeset에 해당 확장자 없으면 언어별 lint 단계 skip

--- a/CLAUDE.local.md
+++ b/CLAUDE.local.md
@@ -105,7 +105,7 @@ Never add files directly to the local project directories without also adding th
 
 ### Local-Only Files (Never in Templates)
 ```
-.claude/settings.local.json    # Personal settings
+.claude/settings.local.json    # Personal settings — runtime-managed, NEVER template
 .claude/settings.json          # Rendered from .json.tmpl
 .claude/agent-memory/          # Per-project agent memory
 .claude/hooks/moai/handle-*.sh # Generated hook wrappers (not templates)
@@ -121,6 +121,24 @@ CLAUDE.local.md                # This file
 .moai/manifest.json            # Generated at runtime
 .moai/status_line.sh           # Rendered from .sh.tmpl
 ```
+
+### [HARD] settings.local.json Separation
+
+`settings.local.json` is **runtime-managed**. Never put it in templates.
+
+- Modified by `moai glm`, `moai cc`, `moai cg` commands at runtime
+- Modified by SessionStart hook (GLM credentials, teammateMode, CLAUDE_ENV_FILE)
+- Contains per-machine values: tmux pane IDs, API tokens, absolute paths
+- **Never** add effortLevel, teammateMode, or env tokens to the template
+
+If you accidentally commit `settings.local.json`, run `git rm --cached .claude/settings.local.json`.
+
+### [WARN] OpenTelemetry / OTEL in Tests
+
+Do NOT use `t.Setenv` with OTEL environment variables (`OTEL_EXPORTER_*`, `OTEL_SERVICE_NAME`) in tests. Setting these in parallel tests causes data races because the OTEL SDK initializes global state from env vars on first use.
+
+- Use a fake/no-op exporter instead of env-var configuration in tests
+- If the test must set OTEL vars, make the parent test non-parallel and use `t.Setenv` only in non-parallel subtests
 
 ### Embedded Template System
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -459,7 +459,8 @@ Resume interrupted agent work using agentId:
 MoAI-ADK integrates multiple MCP servers for specialized capabilities:
 
 - **Sequential Thinking** (`--deepthink` flag): MCP tool for structured step-by-step analysis. Generates `server_tool_use` content — NOT compatible with GLM API. See Skill("moai-workflow-thinking").
-- **UltraThink** (`ultrathink` keyword): Claude native extended reasoning mode (high effort). No MCP dependency — compatible with all APIs including GLM. Do NOT confuse with `--deepthink`.
+- **UltraThink** (`ultrathink` keyword): Sets `effort: max` in Claude Code v2.1.110+. For claude-opus-4-7, this triggers Adaptive Thinking (dynamically allocated reasoning tokens, no fixed budget_tokens). For older models, maps to extended thinking with high budget. No MCP dependency — compatible with all APIs. Do NOT confuse with `--deepthink`.
+- **Adaptive Thinking** (claude-opus-4-7 only): Opus 4.7's thinking mode. Unlike earlier models that use `budget_tokens`, Adaptive Thinking dynamically allocates reasoning based on task complexity. Triggered via `effort` level (high/xhigh/max) — not by `budget_tokens`. See Skill("moai-workflow-thinking").
 - **Context7**: Up-to-date library documentation lookup via resolve-library-id and get-library-docs.
 - **Pencil**: UI/UX design editing for .pen files (used by expert-frontend and designer teammates).
 - **claude-in-chrome**: Browser automation for web-based tasks.

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -121,6 +121,7 @@ func runDiagnosticChecks(verbose bool, filterCheck string) []DiagnosticCheck {
 		fn   func(bool) DiagnosticCheck
 	}
 
+	cwd, _ := os.Getwd()
 	allChecks := []checkFunc{
 		{"Go Runtime", checkGoRuntime},
 		{"Git", checkGit},
@@ -128,6 +129,7 @@ func runDiagnosticChecks(verbose bool, filterCheck string) []DiagnosticCheck {
 		{"Claude Config", checkClaudeConfig},
 		{"MoAI Version", checkMoAIVersion},
 		{"Binary Freshness", checkBinaryFreshness},
+		{"MCP Scope Duplicates", func(v bool) DiagnosticCheck { return checkMCPScopeDuplicates(cwd, v) }},
 	}
 
 	var results []DiagnosticCheck
@@ -323,6 +325,85 @@ func shortCommit(hash string) string {
 		return hash
 	}
 	return hash[:9]
+}
+
+// findMCPDuplicates returns server names that appear more than once in the
+// counts map. Used by checkMCPScopeDuplicates to detect same-name servers
+// registered at multiple scopes (project + user).
+func findMCPDuplicates(counts map[string]int) []string {
+	var dups []string
+	for name, count := range counts {
+		if count > 1 {
+			dups = append(dups, name)
+		}
+	}
+	return dups
+}
+
+// mcpJSONServers holds the parsed structure of .mcp.json.
+type mcpJSONServers struct {
+	MCPServers map[string]json.RawMessage `json:"mcpServers"`
+}
+
+// checkMCPScopeDuplicates detects MCP server names that appear in both the
+// project .mcp.json and the global ~/.claude/.mcp.json, causing silent
+// shadowing that can hide server configuration changes.
+func checkMCPScopeDuplicates(projectRoot string, verbose bool) DiagnosticCheck {
+	check := DiagnosticCheck{Name: "MCP Scope Duplicates"}
+
+	// Parse project .mcp.json
+	projectServers := parseMCPJSON(filepath.Join(projectRoot, ".mcp.json"))
+
+	// Parse global ~/.claude/.mcp.json
+	homeDir, _ := os.UserHomeDir()
+	globalServers := parseMCPJSON(filepath.Join(homeDir, ".claude", ".mcp.json"))
+
+	if len(projectServers) == 0 && len(globalServers) == 0 {
+		check.Status = CheckOK
+		check.Message = "no MCP configuration found (project or global)"
+		return check
+	}
+
+	// Tally server name occurrences across both scopes
+	counts := make(map[string]int)
+	for name := range projectServers {
+		counts[name]++
+	}
+	for name := range globalServers {
+		counts[name]++
+	}
+
+	dups := findMCPDuplicates(counts)
+	if len(dups) == 0 {
+		check.Status = CheckOK
+		check.Message = fmt.Sprintf("%d project, %d global MCP servers — no duplicates", len(projectServers), len(globalServers))
+		return check
+	}
+
+	check.Status = CheckWarn
+	check.Message = fmt.Sprintf("duplicate MCP server names across scopes: %s", strings.Join(dups, ", "))
+	if verbose {
+		check.Detail = "Duplicate server names may shadow configuration. Remove duplicates from one scope."
+	}
+	return check
+}
+
+// parseMCPJSON reads .mcp.json and returns the set of server names.
+// Returns empty map on error or missing file.
+func parseMCPJSON(path string) map[string]struct{} {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var parsed mcpJSONServers
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return nil
+	}
+	result := make(map[string]struct{}, len(parsed.MCPServers))
+	for name := range parsed.MCPServers {
+		result[name] = struct{}{}
+	}
+	return result
 }
 
 // statusIcon returns a colored Unicode icon for the check status.

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -358,6 +358,61 @@ func TestCheckBinaryFreshness_BasicInvariants(t *testing.T) {
 	}
 }
 
+// --- T-014: MCP Scope Duplicate Detection ---
+
+func TestCheckMCPScopeDuplicates_NoDuplicates(t *testing.T) {
+	tmpDir := t.TempDir()
+	mcpJSON := `{"mcpServers":{"context7":{"command":"npx","args":["-y","@context7/mcp"]},"sequential-thinking":{"command":"npx","args":["-y","@modelcontextprotocol/server-sequential-thinking"]}}}`
+	if err := os.WriteFile(filepath.Join(tmpDir, ".mcp.json"), []byte(mcpJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	check := checkMCPScopeDuplicates(tmpDir, false)
+	if check.Name != "MCP Scope Duplicates" {
+		t.Errorf("check.Name = %q, want 'MCP Scope Duplicates'", check.Name)
+	}
+	if check.Status != CheckOK {
+		t.Errorf("no duplicates: check.Status = %q, want ok; msg=%s", check.Status, check.Message)
+	}
+}
+
+func TestCheckMCPScopeDuplicates_WithDuplicate(t *testing.T) {
+	// context7 appears in both project .mcp.json and simulated global config
+	// We simulate a duplicate by listing the same server name twice via the
+	// parsed structure (for unit test isolation we test the detection logic).
+	servers := map[string]int{
+		"context7":             2, // duplicate
+		"sequential-thinking": 1,
+	}
+	dups := findMCPDuplicates(servers)
+	if len(dups) != 1 {
+		t.Errorf("findMCPDuplicates: expected 1 duplicate, got %d: %v", len(dups), dups)
+	}
+	if dups[0] != "context7" {
+		t.Errorf("findMCPDuplicates: expected 'context7', got %q", dups[0])
+	}
+}
+
+func TestCheckMCPScopeDuplicates_MissingFile(t *testing.T) {
+	tmpDir := t.TempDir() // no .mcp.json created
+	check := checkMCPScopeDuplicates(tmpDir, false)
+	// Missing .mcp.json is OK — project may not use MCP
+	if check.Status != CheckOK {
+		t.Errorf("missing .mcp.json: check.Status = %q, want ok", check.Status)
+	}
+}
+
+func TestCheckMCPScopeDuplicates_InRunDiagnosticChecks(t *testing.T) {
+	// Verify the check is registered in runDiagnosticChecks
+	results := runDiagnosticChecks(false, "MCP Scope Duplicates")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result for MCP Scope Duplicates filter, got %d", len(results))
+	}
+	if results[0].Name != "MCP Scope Duplicates" {
+		t.Errorf("results[0].Name = %q, want 'MCP Scope Duplicates'", results[0].Name)
+	}
+}
+
 func TestCheckBinaryFreshness_RegisteredInAllChecks(t *testing.T) {
 	// Verify the check is wired into runDiagnosticChecks.
 	checks := runDiagnosticChecks(false, "")

--- a/internal/cli/launcher.go
+++ b/internal/cli/launcher.go
@@ -529,7 +529,8 @@ func launchClaudeDefault(profileName string, extraArgs []string) error {
 	// NOTE: syscall.Exec replaces the current process entirely.
 	// No defer() functions will execute after this point.
 	// Ensure all cleanup and setup is complete before calling.
-	return syscall.Exec(claudeBin, buildArgs(false), os.Environ())
+	launchEnv := buildEnvForLaunch(prefs.EffortLevel, os.Environ())
+	return syscall.Exec(claudeBin, buildArgs(false), launchEnv)
 }
 
 // --- Flag Parsing ---
@@ -665,6 +666,34 @@ func syncPermissionModeToSettingsLocal(settingsPath string, permissionMode strin
 // to enable the 1M token context window.
 func expandModelString(model string) string {
 	return model
+}
+
+// buildEnvForLaunch returns an environment slice with CLAUDE_CODE_EFFORT_LEVEL
+// set to effortLevel when non-empty. Any existing CLAUDE_CODE_EFFORT_LEVEL entry
+// in base is replaced to avoid duplicates. When effortLevel is empty, base is
+// returned unchanged.
+//
+// @MX:NOTE: [AUTO] Effort injection point — separate from model routing (ModelPolicy⊥Effort).
+func buildEnvForLaunch(effortLevel string, base []string) []string {
+	if effortLevel == "" {
+		return base
+	}
+	const key = "CLAUDE_CODE_EFFORT_LEVEL"
+	entry := key + "=" + effortLevel
+	result := make([]string, 0, len(base)+1)
+	replaced := false
+	for _, e := range base {
+		if strings.HasPrefix(e, key+"=") {
+			result = append(result, entry)
+			replaced = true
+		} else {
+			result = append(result, e)
+		}
+	}
+	if !replaced {
+		result = append(result, entry)
+	}
+	return result
 }
 
 // syncBypassToSettingsLocal is a backward-compatible wrapper for

--- a/internal/cli/launcher_test.go
+++ b/internal/cli/launcher_test.go
@@ -592,6 +592,7 @@ func TestExpandModelString(t *testing.T) {
 		{"empty string", "", ""},
 		{"standard opus", "claude-opus-4-6", "claude-opus-4-6"},
 		{"opus 1m", "claude-opus-4-6[1m]", "claude-opus-4-6[1m]"},
+		{"opus 4.7 direct", "claude-opus-4-7", "claude-opus-4-7"},
 		{"standard sonnet", "claude-sonnet-4-6", "claude-sonnet-4-6"},
 		{"sonnet 1m", "claude-sonnet-4-6[1m]", "claude-sonnet-4-6[1m]"},
 		{"opus alias 1m", "opus[1m]", "opus[1m]"},
@@ -608,6 +609,58 @@ func TestExpandModelString(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestBuildEnvForLaunch verifies that CLAUDE_CODE_EFFORT_LEVEL is injected
+// when EffortLevel is set and absent when empty.
+func TestBuildEnvForLaunch(t *testing.T) {
+	const effortKey = "CLAUDE_CODE_EFFORT_LEVEL"
+
+	t.Run("effort xhigh injected", func(t *testing.T) {
+		env := buildEnvForLaunch("xhigh", os.Environ())
+		found := ""
+		for _, e := range env {
+			if strings.HasPrefix(e, effortKey+"=") {
+				found = strings.TrimPrefix(e, effortKey+"=")
+				break
+			}
+		}
+		if found != "xhigh" {
+			t.Errorf("buildEnvForLaunch: %s not set to xhigh (got %q)", effortKey, found)
+		}
+	})
+
+	t.Run("empty effort leaves env unchanged", func(t *testing.T) {
+		base := []string{"PATH=/usr/bin", "HOME=/root"}
+		env := buildEnvForLaunch("", base)
+		for _, e := range env {
+			if strings.HasPrefix(e, effortKey+"=") {
+				t.Errorf("buildEnvForLaunch with empty effort injected %s", e)
+			}
+		}
+		if len(env) != len(base) {
+			t.Errorf("buildEnvForLaunch with empty effort changed env length: %d -> %d", len(base), len(env))
+		}
+	})
+
+	t.Run("existing effort overridden", func(t *testing.T) {
+		base := []string{"PATH=/usr/bin", effortKey + "=low"}
+		env := buildEnvForLaunch("xhigh", base)
+		count := 0
+		val := ""
+		for _, e := range env {
+			if strings.HasPrefix(e, effortKey+"=") {
+				count++
+				val = strings.TrimPrefix(e, effortKey+"=")
+			}
+		}
+		if count != 1 {
+			t.Errorf("buildEnvForLaunch: expected 1 %s entry, got %d", effortKey, count)
+		}
+		if val != "xhigh" {
+			t.Errorf("buildEnvForLaunch: %s = %q, want xhigh", effortKey, val)
+		}
+	})
 }
 
 func TestUnifiedLaunch_NotInProject(t *testing.T) {

--- a/internal/cli/profile_setup.go
+++ b/internal/cli/profile_setup.go
@@ -66,6 +66,7 @@ func runProfileSetup(cmd *cobra.Command, args []string) error {
 	}
 
 	model := existingPrefs.Model
+	effortLevel := existingPrefs.EffortLevel
 	permissionMode := existingPrefs.PermissionMode
 	if permissionMode == "" {
 		permissionMode = "acceptEdits" // project default
@@ -146,6 +147,7 @@ func runProfileSetup(cmd *cobra.Command, args []string) error {
 				Description(t.ModelOverrideDesc).
 				Options(
 					huh.NewOption(t.ModelDefault, ""),
+					huh.NewOption(t.ModelOpus47, "claude-opus-4-7"),
 					huh.NewOption(t.ModelOpus, "opus"),
 					huh.NewOption(t.ModelOpus1M, "opus[1m]"),
 					huh.NewOption(t.ModelSonnet, "sonnet"),
@@ -154,6 +156,18 @@ func runProfileSetup(cmd *cobra.Command, args []string) error {
 					huh.NewOption(t.ModelOpusPlan, "opusplan"),
 				).
 				Value(&model),
+			huh.NewSelect[string]().
+				Title(t.EffortLevelTitle).
+				Description(t.EffortLevelDesc).
+				Options(
+					huh.NewOption(t.EffortLevelDefault, ""),
+					huh.NewOption(t.EffortLevelLow, "low"),
+					huh.NewOption(t.EffortLevelMedium, "medium"),
+					huh.NewOption(t.EffortLevelHigh, "high"),
+					huh.NewOption(t.EffortLevelXHigh, "xhigh"),
+					huh.NewOption(t.EffortLevelMax, "max"),
+				).
+				Value(&effortLevel),
 			huh.NewSelect[string]().
 				Title(t.PermissionModeTitle).
 				Description(t.PermissionModeDesc).
@@ -210,6 +224,7 @@ func runProfileSetup(cmd *cobra.Command, args []string) error {
 		CodeCommentLang:  codeCommentLang,
 		DocLang:          docLang,
 		Model:            model,
+		EffortLevel:      effortLevel,
 		PermissionMode:   permissionMode,
 		StatuslineMode:   statuslineMode,
 		StatuslineTheme:  statuslineTheme,

--- a/internal/cli/profile_setup_translations.go
+++ b/internal/cli/profile_setup_translations.go
@@ -36,10 +36,20 @@ type profileSetupText struct {
 	ModelDefault       string
 	ModelOpus          string
 	ModelOpus1M        string
+	ModelOpus47        string
 	ModelSonnet        string
 	ModelSonnet1M      string
 	ModelHaiku         string
 	ModelOpusPlan      string
+	// Effort level selector
+	EffortLevelTitle   string
+	EffortLevelDesc    string
+	EffortLevelDefault string
+	EffortLevelLow     string
+	EffortLevelMedium  string
+	EffortLevelHigh    string
+	EffortLevelXHigh   string
+	EffortLevelMax     string
 	// Permission mode (replaces legacy bypass)
 	PermissionModeTitle string
 	PermissionModeDesc  string
@@ -101,10 +111,19 @@ var profileSetupTexts = map[string]profileSetupText{
 		ModelDefault:         "Default (no override)",
 		ModelOpus:            "claude-opus-4-6 (most capable)",
 		ModelOpus1M:          "claude-opus-4-6 1M context (extended thinking)",
+		ModelOpus47:          "claude-opus-4-7 (Opus 4.7 with adaptive thinking)",
 		ModelSonnet:          "claude-sonnet-4-6 (balanced)",
 		ModelSonnet1M:        "claude-sonnet-4-6 1M context (extended thinking)",
 		ModelHaiku:           "claude-haiku-4-5 (fastest)",
 		ModelOpusPlan:        "opusplan (Opus planning, Sonnet coding)",
+		EffortLevelTitle:     "Session effort level",
+		EffortLevelDesc:      "Sets reasoning depth for this profile. xhigh/max require Opus 4.7.",
+		EffortLevelDefault:   "Default (runtime default, xhigh for Opus 4.7)",
+		EffortLevelLow:       "low - fastest, least thorough",
+		EffortLevelMedium:    "medium - balanced",
+		EffortLevelHigh:      "high - deep reasoning",
+		EffortLevelXHigh:     "xhigh - extended reasoning (Opus 4.7+)",
+		EffortLevelMax:       "max - maximum effort (Opus 4.7+)",
 		PermissionModeTitle: "Permission mode",
 		PermissionModeDesc:  "Controls how Claude asks for permission before taking actions.",
 		PermAcceptEdits:     "Auto accept edits - Auto-accept file edits, ask for commands",
@@ -153,10 +172,19 @@ var profileSetupTexts = map[string]profileSetupText{
 		ModelDefault:         "기본값 (오버라이드 없음)",
 		ModelOpus:            "claude-opus-4-6 (최고 성능)",
 		ModelOpus1M:          "claude-opus-4-6 1M 컨텍스트 (확장 사고)",
+		ModelOpus47:          "claude-opus-4-7 (Opus 4.7, 적응형 사고)",
 		ModelSonnet:          "claude-sonnet-4-6 (균형)",
 		ModelSonnet1M:        "claude-sonnet-4-6 1M 컨텍스트 (확장 사고)",
 		ModelHaiku:           "claude-haiku-4-5 (최고 속도)",
 		ModelOpusPlan:        "opusplan (Opus 기획, Sonnet 코딩)",
+		EffortLevelTitle:     "세션 추론 강도",
+		EffortLevelDesc:      "이 프로필의 추론 깊이를 설정합니다. xhigh/max는 Opus 4.7 필요.",
+		EffortLevelDefault:   "기본값 (런타임 기본값, Opus 4.7은 xhigh)",
+		EffortLevelLow:       "low - 가장 빠름, 간략한 추론",
+		EffortLevelMedium:    "medium - 균형",
+		EffortLevelHigh:      "high - 심층 추론",
+		EffortLevelXHigh:     "xhigh - 확장 추론 (Opus 4.7+)",
+		EffortLevelMax:       "max - 최대 추론 (Opus 4.7+)",
 		PermissionModeTitle: "권한 모드",
 		PermissionModeDesc:  "Claude가 작업 수행 전 권한을 요청하는 방식을 제어합니다.",
 		PermAcceptEdits:     "자동 편집 수락 (acceptEdits) - 파일 편집 자동 수락, 명령어만 확인",
@@ -205,10 +233,19 @@ var profileSetupTexts = map[string]profileSetupText{
 		ModelDefault:         "デフォルト (オーバーライドなし)",
 		ModelOpus:            "claude-opus-4-6 (最高性能)",
 		ModelOpus1M:          "claude-opus-4-6 1Mコンテキスト (拡張思考)",
+		ModelOpus47:          "claude-opus-4-7 (Opus 4.7、適応型思考)",
 		ModelSonnet:          "claude-sonnet-4-6 (バランス)",
 		ModelSonnet1M:        "claude-sonnet-4-6 1Mコンテキスト (拡張思考)",
 		ModelHaiku:           "claude-haiku-4-5 (最速)",
 		ModelOpusPlan:        "opusplan (Opus設計、Sonnetコーディング)",
+		EffortLevelTitle:     "セッション推論レベル",
+		EffortLevelDesc:      "このプロファイルの推論深度を設定します。xhigh/maxはOpus 4.7が必要。",
+		EffortLevelDefault:   "デフォルト (ランタイムデフォルト、Opus 4.7はxhigh)",
+		EffortLevelLow:       "low - 最速、簡易推論",
+		EffortLevelMedium:    "medium - バランス",
+		EffortLevelHigh:      "high - 深い推論",
+		EffortLevelXHigh:     "xhigh - 拡張推論 (Opus 4.7+)",
+		EffortLevelMax:       "max - 最大推論 (Opus 4.7+)",
 		PermissionModeTitle: "権限モード",
 		PermissionModeDesc:  "Claudeがアクション実行前に権限を要求する方法を制御します。",
 		PermAcceptEdits:     "編集を自動承認 (acceptEdits) - ファイル編集を自動承認、コマンドのみ確認",
@@ -257,10 +294,19 @@ var profileSetupTexts = map[string]profileSetupText{
 		ModelDefault:         "默认 (不覆盖)",
 		ModelOpus:            "claude-opus-4-6 (最强性能)",
 		ModelOpus1M:          "claude-opus-4-6 1M上下文 (扩展思考)",
+		ModelOpus47:          "claude-opus-4-7 (Opus 4.7，自适应思考)",
 		ModelSonnet:          "claude-sonnet-4-6 (均衡)",
 		ModelSonnet1M:        "claude-sonnet-4-6 1M上下文 (扩展思考)",
 		ModelHaiku:           "claude-haiku-4-5 (最快)",
 		ModelOpusPlan:        "opusplan (Opus规划，Sonnet编码)",
+		EffortLevelTitle:     "会话推理强度",
+		EffortLevelDesc:      "设置此配置文件的推理深度。xhigh/max需要Opus 4.7。",
+		EffortLevelDefault:   "默认 (运行时默认值，Opus 4.7为xhigh)",
+		EffortLevelLow:       "low - 最快，简略推理",
+		EffortLevelMedium:    "medium - 均衡",
+		EffortLevelHigh:      "high - 深度推理",
+		EffortLevelXHigh:     "xhigh - 扩展推理 (Opus 4.7+)",
+		EffortLevelMax:       "max - 最大推理 (Opus 4.7+)",
 		PermissionModeTitle: "权限模式",
 		PermissionModeDesc:  "控制Claude在执行操作前如何请求权限。",
 		PermAcceptEdits:     "自动接受编辑 (acceptEdits) - 自动接受文件编辑，仅确认命令",

--- a/internal/cli/profile_setup_translations_test.go
+++ b/internal/cli/profile_setup_translations_test.go
@@ -30,8 +30,64 @@ func TestGetProfileText_AllLanguages(t *testing.T) {
 			if txt.ModelSonnet1M == "" {
 				t.Errorf("ModelSonnet1M is empty for lang %q", lang)
 			}
+			// T-003: Opus 4.7 model label
+			if txt.ModelOpus47 == "" {
+				t.Errorf("ModelOpus47 is empty for lang %q", lang)
+			}
+			// T-003: Effort level UI strings
+			if txt.EffortLevelTitle == "" {
+				t.Errorf("EffortLevelTitle is empty for lang %q", lang)
+			}
+			if txt.EffortLevelDesc == "" {
+				t.Errorf("EffortLevelDesc is empty for lang %q", lang)
+			}
+			if txt.EffortLevelDefault == "" {
+				t.Errorf("EffortLevelDefault is empty for lang %q", lang)
+			}
+			if txt.EffortLevelXHigh == "" {
+				t.Errorf("EffortLevelXHigh is empty for lang %q", lang)
+			}
+			if txt.EffortLevelMax == "" {
+				t.Errorf("EffortLevelMax is empty for lang %q", lang)
+			}
 		})
 	}
+}
+
+// TestGetProfileText_OpusModelValues verifies Opus 4.7 label contains the model ID.
+func TestGetProfileText_OpusModelValues(t *testing.T) {
+	for _, lang := range []string{"en", "ko", "ja", "zh"} {
+		txt := getProfileText(lang)
+		if !containsStr(txt.ModelOpus47, "claude-opus-4-7") {
+			t.Errorf("lang=%q: ModelOpus47 %q does not contain model ID", lang, txt.ModelOpus47)
+		}
+	}
+}
+
+// TestGetProfileText_EffortLevelValues verifies effort level labels contain xhigh/max keywords.
+func TestGetProfileText_EffortLevelValues(t *testing.T) {
+	for _, lang := range []string{"en", "ko", "ja", "zh"} {
+		txt := getProfileText(lang)
+		if !containsStr(txt.EffortLevelXHigh, "xhigh") {
+			t.Errorf("lang=%q: EffortLevelXHigh %q does not contain 'xhigh'", lang, txt.EffortLevelXHigh)
+		}
+		if !containsStr(txt.EffortLevelMax, "max") {
+			t.Errorf("lang=%q: EffortLevelMax %q does not contain 'max'", lang, txt.EffortLevelMax)
+		}
+	}
+}
+
+func containsStr(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(s) > 0 && containsSubstr(s, sub))
+}
+
+func containsSubstr(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
 }
 
 func TestGetProfileText_FallbackToEnglish(t *testing.T) {

--- a/internal/config/envkeys.go
+++ b/internal/config/envkeys.go
@@ -73,6 +73,12 @@ const (
 
 	// EnvClaudeAutoCompactPct overrides the auto-compact percentage threshold.
 	EnvClaudeAutoCompactPct = "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE"
+
+	// EnvClaudeCodeEffortLevel sets the session effort level for Claude Code.
+	// Valid values: "low", "medium", "high", "xhigh", "max".
+	// "xhigh" and "max" are supported on Opus 4.7+.
+	// When empty, the runtime default applies.
+	EnvClaudeCodeEffortLevel = "CLAUDE_CODE_EFFORT_LEVEL"
 )
 
 // Anthropic API environment variables.

--- a/internal/hook/permission_request.go
+++ b/internal/hook/permission_request.go
@@ -1,9 +1,14 @@
 package hook
 
 import (
+	"bytes"
 	"context"
 	"log/slog"
 )
+
+// updatedInputMarker is the sentinel key injected into tool inputs that were
+// modified by a PreToolUse hook. Its presence signals a re-verification need.
+const updatedInputMarker = `"__updated_input_marker__"`
 
 // permissionRequestHandler processes PermissionRequest events.
 // It logs permission requests and defers to the default decision.
@@ -21,11 +26,25 @@ func (h *permissionRequestHandler) EventType() EventType {
 
 // Handle processes a PermissionRequest event. It logs the permission request
 // and returns "ask" (defer to user/default settings).
+//
+// When the ToolInput contains the __updated_input_marker__ sentinel, the
+// handler denies the permission to prevent prompt injection via modified
+// tool inputs (updatedInput re-verification, SPEC-OPUS47-COMPAT-001 T-015).
 func (h *permissionRequestHandler) Handle(ctx context.Context, input *HookInput) (*HookOutput, error) {
 	slog.Info("permission requested",
 		"session_id", input.SessionID,
 		"tool_name", input.ToolName,
 	)
+
+	// Re-verify: deny if the tool input was modified by a previous hook.
+	if len(input.ToolInput) > 0 && bytes.Contains(input.ToolInput, []byte(updatedInputMarker)) {
+		slog.Warn("denying permission: tool input contains updated_input_marker",
+			"session_id", input.SessionID,
+			"tool_name", input.ToolName,
+		)
+		return NewPermissionRequestOutput("deny", "tool input was modified by a previous hook (updatedInput re-verification)"), nil
+	}
+
 	// Return nil output to defer to user's permission mode (bypassPermissions, acceptEdits, etc.).
 	// Returning permissionDecision:"ask" would override bypass mode and always show the dialog.
 	// By returning nil, Claude Code applies its normal permission system.

--- a/internal/hook/permission_request_test.go
+++ b/internal/hook/permission_request_test.go
@@ -2,6 +2,7 @@ package hook
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 )
 
@@ -61,6 +62,109 @@ func TestPermissionRequestHandler_Handle(t *testing.T) {
 			// Returning non-nil with "ask" would override bypassPermissions.
 			if got != nil {
 				t.Errorf("expected nil output (defer to system), got %+v", got)
+			}
+		})
+	}
+}
+
+// T-015: updatedInput deny re-verification
+//
+// When a PermissionRequest arrives with a non-empty ToolInput that contains
+// the __updated_input_marker__ sentinel key, it means a previous PreToolUse
+// hook injected a modified input. The handler must deny to prevent prompt
+// injection via modified tool inputs.
+
+// TestPermissionRequestHandler_UpdatedInputDeny verifies that when a
+// PermissionRequest ToolInput contains the __updated_input_marker__, the
+// handler denies the permission.
+func TestPermissionRequestHandler_UpdatedInputDeny(t *testing.T) {
+	t.Parallel()
+
+	// Simulate tool input that was modified by a PreToolUse hook
+	updatedRaw, _ := json.Marshal(map[string]interface{}{
+		"command":               "echo hello",
+		"__updated_input_marker__": true,
+	})
+	input := &HookInput{
+		SessionID:     "sess-updated-1",
+		ToolName:      "Bash",
+		HookEventName: "PermissionRequest",
+		ToolInput:     json.RawMessage(updatedRaw),
+	}
+
+	h := NewPermissionRequestHandler()
+	ctx := context.Background()
+	got, err := h.Handle(ctx, input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// When __updated_input_marker__ is present, handler must deny.
+	if got == nil {
+		t.Fatal("expected non-nil output (deny) when __updated_input_marker__ is set")
+	}
+	if got.HookSpecificOutput == nil {
+		t.Fatal("expected HookSpecificOutput to be set")
+	}
+	if got.HookSpecificOutput.PermissionDecision != "deny" {
+		t.Errorf("PermissionDecision = %q, want 'deny'", got.HookSpecificOutput.PermissionDecision)
+	}
+}
+
+// TestPermissionRequestHandler_NormalToolInputNoEffect verifies that a
+// normal ToolInput without the marker does not trigger deny.
+func TestPermissionRequestHandler_NormalToolInputNoEffect(t *testing.T) {
+	t.Parallel()
+
+	normalRaw, _ := json.Marshal(map[string]string{"command": "echo hello"})
+	input := &HookInput{
+		SessionID:     "sess-normal-tool",
+		ToolName:      "Bash",
+		HookEventName: "PermissionRequest",
+		ToolInput:     json.RawMessage(normalRaw),
+	}
+
+	h := NewPermissionRequestHandler()
+	ctx := context.Background()
+	got, err := h.Handle(ctx, input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil output for normal ToolInput, got %+v", got)
+	}
+}
+
+// TestPermissionRequestHandler_EmptyToolInputNoEffect verifies that nil/empty
+// ToolInput does not trigger deny.
+func TestPermissionRequestHandler_EmptyToolInputNoEffect(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input json.RawMessage
+	}{
+		{"nil", nil},
+		{"empty", json.RawMessage("")},
+		{"null", json.RawMessage("null")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			input := &HookInput{
+				SessionID:     "sess-empty-tool",
+				ToolName:      "Bash",
+				HookEventName: "PermissionRequest",
+				ToolInput:     tt.input,
+			}
+
+			h := NewPermissionRequestHandler()
+			got, err := h.Handle(context.Background(), input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != nil {
+				t.Errorf("name=%q: expected nil output, got %+v", tt.name, got)
 			}
 		})
 	}

--- a/internal/hook/session_start.go
+++ b/internal/hook/session_start.go
@@ -95,6 +95,16 @@ func (h *sessionStartHandler) Handle(ctx context.Context, input *HookInput) (*Ho
 		}
 	}
 
+	// Windows only: inject CLAUDE_ENV_FILE into settings.local.json when a
+	// .env file is present in the project root (T-016, R-P1-1).
+	// Guarded to Windows so macOS/Linux GLM env injection is never affected.
+	if runtime.GOOS == "windows" && input.ProjectDir != "" {
+		if msg := injectCLAUDEEnvFile(input.ProjectDir); msg != "" {
+			data["claude_env_file"] = msg
+			slog.Info("CLAUDE_ENV_FILE injected", "message", msg)
+		}
+	}
+
 	// Enforce telemetry retention: prune files older than 90 days (SPEC-TELEMETRY-001 R4).
 	// Best-effort: errors are logged and never propagated.
 	if input.ProjectDir != "" {
@@ -518,6 +528,69 @@ func copyDirRecursive(src, dst string) error {
 // It delegates to telemetry.PruneOldFiles and wraps any error with context.
 func pruneTelemetry(projectDir string) error {
 	return telemetry.PruneOldFiles(projectDir, 90)
+}
+
+// injectCLAUDEEnvFile checks whether a .env file exists in projectRoot. If it
+// does, it injects CLAUDE_ENV_FILE into the env section of
+// .claude/settings.local.json so that Claude Code loads the project's env file
+// automatically (Windows CLAUDE_ENV_FILE support, T-016).
+//
+// Returns a non-empty status message when the value was written, empty string
+// when the .env file does not exist or when no write was needed.
+func injectCLAUDEEnvFile(projectRoot string) string {
+	envFilePath := filepath.Join(projectRoot, ".env")
+	if _, err := os.Stat(envFilePath); os.IsNotExist(err) {
+		return ""
+	}
+
+	settingsPath := filepath.Join(projectRoot, ".claude", "settings.local.json")
+
+	var raw map[string]json.RawMessage
+	if data, err := os.ReadFile(settingsPath); err == nil && len(data) > 0 {
+		if err := json.Unmarshal(data, &raw); err != nil {
+			raw = nil
+		}
+	}
+	if raw == nil {
+		raw = make(map[string]json.RawMessage)
+	}
+
+	// Read current env section.
+	env := make(map[string]string)
+	if envRaw, ok := raw["env"]; ok {
+		_ = json.Unmarshal(envRaw, &env)
+	}
+
+	// Skip write if already set to the same value.
+	if env["CLAUDE_ENV_FILE"] == envFilePath {
+		return ""
+	}
+
+	env["CLAUDE_ENV_FILE"] = envFilePath
+
+	envData, err := json.Marshal(env)
+	if err != nil {
+		return ""
+	}
+	raw["env"] = envData
+
+	newData, err := json.MarshalIndent(raw, "", "  ")
+	if err != nil {
+		return ""
+	}
+
+	if err := os.MkdirAll(filepath.Join(projectRoot, ".claude"), 0o755); err != nil {
+		return ""
+	}
+
+	if err := os.WriteFile(settingsPath, newData, 0o644); err != nil {
+		slog.Error("injectCLAUDEEnvFile: failed to write settings.local.json",
+			"error", err.Error(),
+		)
+		return ""
+	}
+
+	return fmt.Sprintf("injected CLAUDE_ENV_FILE=%s into %s", envFilePath, settingsPath)
 }
 
 // loadGLMKeyFromEnvFile reads the GLM API key from ~/.moai/.env.glm.

--- a/internal/hook/session_start_test.go
+++ b/internal/hook/session_start_test.go
@@ -195,3 +195,55 @@ func TestEnsureGLMCredentials(t *testing.T) {
 		}
 	})
 }
+
+// T-016: Windows CLAUDE_ENV_FILE injection
+
+// TestInjectCLAUDEEnvFile_WithEnvFile verifies that injectCLAUDEEnvFile sets
+// CLAUDE_ENV_FILE in settings.local.json when a .env file exists in the project.
+func TestInjectCLAUDEEnvFile_WithEnvFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	claudeDir := filepath.Join(dir, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Create a .env file in the project root
+	envFilePath := filepath.Join(dir, ".env")
+	if err := os.WriteFile(envFilePath, []byte("SOME_VAR=value\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	msg := injectCLAUDEEnvFile(dir)
+	if msg == "" {
+		t.Error("injectCLAUDEEnvFile: expected non-empty message when .env exists")
+	}
+
+	// Verify settings.local.json was written with CLAUDE_ENV_FILE
+	settingsPath := filepath.Join(claudeDir, "settings.local.json")
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("settings.local.json not created: %v", err)
+	}
+	var settings struct {
+		Env map[string]string `json:"env"`
+	}
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("unmarshal settings.local.json: %v", err)
+	}
+	if settings.Env["CLAUDE_ENV_FILE"] != envFilePath {
+		t.Errorf("CLAUDE_ENV_FILE = %q, want %q", settings.Env["CLAUDE_ENV_FILE"], envFilePath)
+	}
+}
+
+// TestInjectCLAUDEEnvFile_NoEnvFile verifies that injectCLAUDEEnvFile is a
+// no-op when no .env file exists (returns empty string).
+func TestInjectCLAUDEEnvFile_NoEnvFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	msg := injectCLAUDEEnvFile(dir)
+	if msg != "" {
+		t.Errorf("injectCLAUDEEnvFile: expected empty msg when no .env, got %q", msg)
+	}
+}

--- a/internal/profile/preferences.go
+++ b/internal/profile/preferences.go
@@ -23,7 +23,12 @@ type ProfilePreferences struct {
 
 	// LLM settings
 	ModelPolicy string `yaml:"model_policy,omitempty"` // "high", "medium", "low"
-	Model       string `yaml:"model,omitempty"`        // e.g. "claude-opus-4-6"
+	Model       string `yaml:"model,omitempty"`        // e.g. "claude-opus-4-6", "claude-opus-4-7"
+	// EffortLevel sets the session effort override for reasoning depth.
+	// Valid values: "low", "medium", "high", "xhigh", "max".
+	// "xhigh" and "max" are supported on Opus 4.7+.
+	// When empty, the runtime default applies (xhigh for Opus 4.7).
+	EffortLevel string `yaml:"effort_level,omitempty"`
 
 	// Launch settings
 	// PermissionMode sets the Claude Code permission mode at launch.

--- a/internal/profile/preferences_test.go
+++ b/internal/profile/preferences_test.go
@@ -3,6 +3,7 @@ package profile
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -363,6 +364,84 @@ func TestPreferences_StatuslineTheme(t *testing.T) {
 
 			if got.StatuslineTheme != tt.theme {
 				t.Errorf("StatuslineTheme = %q, want %q", got.StatuslineTheme, tt.theme)
+			}
+		})
+	}
+}
+
+// TestPreferences_EffortLevelRoundTrip verifies that EffortLevel survives
+// YAML marshal/unmarshal (T-001-RED).
+func TestPreferences_EffortLevelRoundTrip(t *testing.T) {
+	tmpDir := t.TempDir()
+	orig := BaseDirOverride
+	defer func() { BaseDirOverride = orig }()
+	BaseDirOverride = tmpDir
+
+	prefs := ProfilePreferences{
+		Model:       "claude-opus-4-7",
+		EffortLevel: "xhigh",
+	}
+
+	if err := WritePreferences("default", prefs); err != nil {
+		t.Fatalf("WritePreferences: %v", err)
+	}
+
+	got, err := ReadPreferences("default")
+	if err != nil {
+		t.Fatalf("ReadPreferences: %v", err)
+	}
+	if got.Model != "claude-opus-4-7" {
+		t.Errorf("Model = %q, want %q", got.Model, "claude-opus-4-7")
+	}
+	if got.EffortLevel != "xhigh" {
+		t.Errorf("EffortLevel = %q, want %q", got.EffortLevel, "xhigh")
+	}
+}
+
+// TestPreferences_EffortLevelOmitempty verifies that EffortLevel is omitted
+// when empty (preserving backward-compatibility with existing preferences.yaml).
+func TestPreferences_EffortLevelOmitempty(t *testing.T) {
+	tmpDir := t.TempDir()
+	orig := BaseDirOverride
+	defer func() { BaseDirOverride = orig }()
+	BaseDirOverride = tmpDir
+
+	prefs := ProfilePreferences{UserName: "testuser"}
+	if err := WritePreferences("default", prefs); err != nil {
+		t.Fatalf("WritePreferences: %v", err)
+	}
+
+	// Ensure effort_level key is absent from the YAML file.
+	path := GetPreferencesPath("default")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if strings.Contains(string(data), "effort_level") {
+		t.Errorf("effort_level should be absent from YAML when empty, got:\n%s", data)
+	}
+}
+
+// TestPreferences_AllEffortLevels verifies all 5 effort levels round-trip correctly.
+func TestPreferences_AllEffortLevels(t *testing.T) {
+	levels := []string{"low", "medium", "high", "xhigh", "max"}
+	for _, level := range levels {
+		t.Run(level, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			orig := BaseDirOverride
+			defer func() { BaseDirOverride = orig }()
+			BaseDirOverride = tmpDir
+
+			prefs := ProfilePreferences{EffortLevel: level}
+			if err := WritePreferences("default", prefs); err != nil {
+				t.Fatalf("WritePreferences: %v", err)
+			}
+			got, err := ReadPreferences("default")
+			if err != nil {
+				t.Fatalf("ReadPreferences: %v", err)
+			}
+			if got.EffortLevel != level {
+				t.Errorf("EffortLevel = %q, want %q", got.EffortLevel, level)
 			}
 		})
 	}

--- a/internal/template/model_policy.go
+++ b/internal/template/model_policy.go
@@ -39,6 +39,54 @@ func IsValidModelPolicy(s string) bool {
 	return false
 }
 
+// ModelIDOpus47 is the canonical model ID for Claude Opus 4.7.
+// Used by launcher.go to route the new model and by profile translations.
+const ModelIDOpus47 = "claude-opus-4-7"
+
+// Effort level constants for the 5-tier effort system.
+// These are separate from ModelPolicy (3-tier). ModelPolicy selects the model;
+// effort levels control reasoning depth within a model session.
+// Supported by Claude Code v2.1.68+ for Opus 4.6 and Opus 4.7.
+const (
+	// EffortLevelLow is the fastest, least thorough effort level.
+	EffortLevelLow = "low"
+	// EffortLevelMedium is the balanced default effort level.
+	EffortLevelMedium = "medium"
+	// EffortLevelHigh activates deep reasoning for complex tasks.
+	EffortLevelHigh = "high"
+	// EffortLevelXHigh is extended high reasoning for Opus 4.7+.
+	// Not supported on Opus 4.6.
+	EffortLevelXHigh = "xhigh"
+	// EffortLevelMax is the maximum effort level.
+	// On Opus 4.6, max is the highest supported level.
+	// On Opus 4.7+, xhigh and max are both available.
+	EffortLevelMax = "max"
+)
+
+// agentEffortMap specifies explicit effort overrides for reasoning-heavy agents.
+// Only the 6 Opus 4.7 reasoning agents have entries.
+// The remaining 22 agents return "" (empty string) so the Opus 4.7 runtime
+// default (xhigh) applies without any explicit override injection.
+//
+// Key: agent name, Value: effort level string
+var agentEffortMap = map[string]string{
+	"manager-spec":       EffortLevelXHigh,
+	"manager-strategy":   EffortLevelXHigh,
+	"plan-auditor":       EffortLevelHigh,
+	"evaluator-active":   EffortLevelHigh,
+	"expert-security":    EffortLevelHigh,
+	"expert-refactoring": EffortLevelHigh,
+}
+
+// GetAgentEffort returns the effort level override for the given agent.
+// Returns "" (empty string) for agents not in agentEffortMap, which signals
+// the caller to use the runtime default (Opus 4.7 defaults to xhigh).
+//
+// @MX:NOTE: [AUTO] Separate from GetAgentModel — ModelPolicy⊥Effort by design.
+func GetAgentEffort(agentName string) string {
+	return agentEffortMap[agentName]
+}
+
 // agentModelMap defines the model assignment for each agent under each policy.
 // Key: agent name, Value: [high_model, medium_model, low_model]
 var agentModelMap = map[string][3]string{

--- a/internal/template/model_policy_test.go
+++ b/internal/template/model_policy_test.go
@@ -299,6 +299,92 @@ model: opus
 	})
 }
 
+// TestGetAgentEffort verifies the new agentEffortMap and GetAgentEffort function
+// introduced for Opus 4.7 effort separation (T-002-RED / T-002-IMPL).
+func TestGetAgentEffort(t *testing.T) {
+	tests := []struct {
+		name      string
+		agentName string
+		want      string
+	}{
+		// 6 Opus 4.7 reasoning agents with explicit effort
+		{"manager-spec xhigh", "manager-spec", "xhigh"},
+		{"manager-strategy xhigh", "manager-strategy", "xhigh"},
+		{"plan-auditor high", "plan-auditor", "high"},
+		{"evaluator-active high", "evaluator-active", "high"},
+		{"expert-security high", "expert-security", "high"},
+		{"expert-refactoring high", "expert-refactoring", "high"},
+		// 22 remaining agents: return "" (runtime default)
+		{"manager-ddd unset", "manager-ddd", ""},
+		{"manager-tdd unset", "manager-tdd", ""},
+		{"expert-backend unset", "expert-backend", ""},
+		{"expert-frontend unset", "expert-frontend", ""},
+		{"unknown-agent unset", "some-nonexistent-agent", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetAgentEffort(tt.agentName)
+			if got != tt.want {
+				t.Errorf("GetAgentEffort(%q) = %q, want %q", tt.agentName, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestModelClaudeOpus47Constant verifies the claude-opus-4-7 model ID constant.
+func TestModelClaudeOpus47Constant(t *testing.T) {
+	if ModelIDOpus47 == "" {
+		t.Error("ModelIDOpus47 constant is empty, want non-empty model ID")
+	}
+	want := "claude-opus-4-7"
+	if ModelIDOpus47 != want {
+		t.Errorf("ModelIDOpus47 = %q, want %q", ModelIDOpus47, want)
+	}
+}
+
+// TestEffortLevelConstants verifies xhigh and max constants exist.
+func TestEffortLevelConstants(t *testing.T) {
+	if EffortLevelXHigh == "" {
+		t.Error("EffortLevelXHigh constant is empty")
+	}
+	if EffortLevelMax == "" {
+		t.Error("EffortLevelMax constant is empty")
+	}
+	if EffortLevelXHigh != "xhigh" {
+		t.Errorf("EffortLevelXHigh = %q, want %q", EffortLevelXHigh, "xhigh")
+	}
+	if EffortLevelMax != "max" {
+		t.Errorf("EffortLevelMax = %q, want %q", EffortLevelMax, "max")
+	}
+}
+
+// TestAgentModelMapSignatureUnchanged verifies the existing agentModelMap type
+// and all existing public API functions remain unchanged (NFR-1 no-break).
+func TestAgentModelMapSignatureUnchanged(t *testing.T) {
+	// ValidModelPolicies still returns exactly 3 items.
+	policies := ValidModelPolicies()
+	if len(policies) != 3 {
+		t.Errorf("ValidModelPolicies() len = %d, want 3 (signature must not change)", len(policies))
+	}
+
+	// IsValidModelPolicy still accepts only high/medium/low.
+	for _, p := range []string{"high", "medium", "low"} {
+		if !IsValidModelPolicy(p) {
+			t.Errorf("IsValidModelPolicy(%q) = false, want true", p)
+		}
+	}
+	// "xhigh" is NOT a ModelPolicy (it's an effort level, separate concern).
+	if IsValidModelPolicy("xhigh") {
+		t.Error("IsValidModelPolicy(xhigh) = true, want false (xhigh is effort, not policy)")
+	}
+
+	// GetAgentModel still returns "" for unknown agents.
+	if got := GetAgentModel(ModelPolicyHigh, "nonexistent"); got != "" {
+		t.Errorf("GetAgentModel(high, nonexistent) = %q, want empty string", got)
+	}
+}
+
 func TestNewDeployerWithRenderer(t *testing.T) {
 	fsys := testFS()
 	r := NewRenderer(fsys)

--- a/internal/template/templates/.claude/agents/moai/builder-agent.md
+++ b/internal/template/templates/.claude/agents/moai/builder-agent.md
@@ -87,7 +87,7 @@ Configure using official Claude Code YAML frontmatter fields:
 - skills: Skills to preload (NOT inherited from parent)
 - hooks: PreToolUse, PostToolUse, SubagentStop lifecycle events
 - color: Display color in UI (red/blue/green/yellow/purple/orange/pink/cyan)
-- effort: Session effort override (low/medium/high/max; max is Opus 4.6 only)
+- effort: Session effort override (low/medium/high/xhigh/max; xhigh/max require Opus 4.7+)
 - isolation: "worktree" creates isolated git worktree per agent (v2.1.49+)
 - initialPrompt: Auto-submitted first turn when agent runs via --agent flag (v2.1.83+)
 - maxContextSize: Maximum context size before stopping (replaces deprecated maxTurns, v2.1.69+)

--- a/internal/template/templates/.claude/agents/moai/evaluator-active.md
+++ b/internal/template/templates/.claude/agents/moai/evaluator-active.md
@@ -11,6 +11,7 @@ description: |
   NOT for: code implementation, architecture design, documentation writing, git operations
 tools: Read, Grep, Glob, Bash, mcp__sequential-thinking__sequentialthinking
 model: sonnet
+effort: high
 permissionMode: plan
 memory: project
 skills:

--- a/internal/template/templates/.claude/agents/moai/expert-refactoring.md
+++ b/internal/template/templates/.claude/agents/moai/expert-refactoring.md
@@ -11,6 +11,7 @@ description: |
   NOT for: new feature development, bug fixes, security audits, DevOps, testing strategy
 tools: Read, Write, Edit, Grep, Glob, Bash, TodoWrite, Skill, mcp__sequential-thinking__sequentialthinking, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 model: sonnet
+effort: high
 permissionMode: bypassPermissions
 memory: project
 skills:

--- a/internal/template/templates/.claude/agents/moai/expert-security.md
+++ b/internal/template/templates/.claude/agents/moai/expert-security.md
@@ -10,6 +10,7 @@ description: |
   ZH: 安全, 漏洞, OWASP, 注入, XSS, CSRF, 渗透, 审计
   NOT for: general backend development, frontend UI, performance optimization, database design, DevOps deployment
 model: opus
+effort: high
 permissionMode: bypassPermissions
 memory: project
 skills:

--- a/internal/template/templates/.claude/agents/moai/manager-spec.md
+++ b/internal/template/templates/.claude/agents/moai/manager-spec.md
@@ -11,6 +11,7 @@ description: |
   NOT for: code implementation, testing, deployment, code review, documentation sync
 tools: Read, Write, Edit, MultiEdit, Bash, Glob, Grep, TodoWrite, WebFetch, mcp__sequential-thinking__sequentialthinking, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 model: opus
+effort: xhigh
 permissionMode: bypassPermissions
 memory: project
 skills:

--- a/internal/template/templates/.claude/agents/moai/manager-strategy.md
+++ b/internal/template/templates/.claude/agents/moai/manager-strategy.md
@@ -11,6 +11,7 @@ description: |
   NOT for: code implementation, testing, deployment, documentation, git operations
 tools: Read, Grep, Glob, Bash, WebFetch, WebSearch, Skill, mcp__sequential-thinking__sequentialthinking, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 model: opus
+effort: xhigh
 permissionMode: plan
 memory: project
 skills:

--- a/internal/template/templates/.claude/agents/moai/plan-auditor.md
+++ b/internal/template/templates/.claude/agents/moai/plan-auditor.md
@@ -10,6 +10,7 @@ description: |
   NOT for: code implementation, code review, documentation writing, git operations, running tests
 tools: Read, Grep, Glob, Bash, mcp__sequential-thinking__sequentialthinking, Write, Edit
 model: inherit
+effort: high
 permissionMode: default
 ---
 

--- a/internal/template/templates/.claude/rules/moai/core/agent-common-protocol.md
+++ b/internal/template/templates/.claude/rules/moai/core/agent-common-protocol.md
@@ -131,6 +131,16 @@ Avoid:
 | Run system commands | Bash | — |
 | Explore codebase | Agent(Explore) | Multiple sequential Grep calls |
 
+### Bash Timeout
+
+The Bash tool supports an optional `timeout` parameter (milliseconds):
+
+- Default: 120,000ms (2 minutes)
+- Maximum: 600,000ms (10 minutes)
+- Use for long-running commands: builds, test suites, installs
+
+Specify via the `timeout` field when the command is expected to run longer than 2 minutes.
+
 ### Error Recovery Pattern
 
 When a tool call fails:

--- a/internal/template/templates/.claude/rules/moai/core/moai-constitution.md
+++ b/internal/template/templates/.claude/rules/moai/core/moai-constitution.md
@@ -41,6 +41,18 @@ Rules:
 - For team mode: Use TeamCreate for persistent team coordination, SendMessage for inter-teammate communication
 - Team agents share TaskList for work coordination; sub-agents return results directly
 
+## Opus 4.7 Prompt Philosophy
+
+Reasoning-intensive agents targeting `claude-opus-4-7` must follow Anthropic's official prompt guidelines (platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7).
+
+Rules:
+- One-turn fully-loaded: deliver intent + constraints + completion criteria + file locations in a single agent prompt. Avoid multi-turn ping-pong which wastes tokens on Opus 4.7
+- Adaptive Thinking: do NOT set fixed thinking budgets via `budget_tokens`; Opus 4.7 rejects fixed budgets with HTTP 400. Let the model self-allocate reasoning depth
+- Remove Opus 4.6-era defensive scaffolding: "double-check X before returning", "verify N times", "explicitly confirm before proceeding" patterns are counterproductive on Opus 4.7's literal instruction following
+- [HARD] Principle 4 — Fewer subagents spawned by default: Opus 4.7 does not auto-spawn subagents. When fan-out is needed, explicitly instruct "Use agent-A, agent-B in parallel (single message, multiple Agent() calls)" in the prompt
+- [HARD] Principle 5 — Fewer tool calls by default, more reasoning: Opus 4.7 prefers reasoning over tool invocation. When tool use is expected, specify "when and why to use each tool (Grep for content search, Glob for file discovery, Read for full-file context)" in the agent prompt
+- Effort level selection: reasoning-intensive agents (manager-spec, manager-strategy, plan-auditor, evaluator-active, expert-security, expert-refactoring) → `effort: xhigh` or `high`; implementation agents (expert-backend, expert-frontend, builder-*) → `effort: high` (default for Opus 4.7); speed-critical agents (manager-git, Explore) → `effort: medium`
+
 ## Output Format
 
 Never display XML tags in user-facing responses.

--- a/internal/template/templates/.claude/rules/moai/core/settings-management.md
+++ b/internal/template/templates/.claude/rules/moai/core/settings-management.md
@@ -103,6 +103,9 @@ Hooks support environment variables and must be quoted to handle spaces:
 
 **Important**: Quote the entire path: `"\"$CLAUDE_PROJECT_DIR/path\""` not `"$CLAUDE_PROJECT_DIR/path"`
 
+Hook timeout range: 1–600,000ms (max 10 minutes). Default is 5,000ms for most hooks.
+Long-running hooks (PostToolUse, quality gates) should set `"timeout": 60000` or higher.
+
 ## StatusLine Configuration
 
 StatusLine does NOT support environment variables. Use relative paths from project root:

--- a/internal/template/templates/.claude/rules/moai/development/agent-authoring.md
+++ b/internal/template/templates/.claude/rules/moai/development/agent-authoring.md
@@ -35,7 +35,7 @@ All agent definitions use YAML frontmatter. The following fields are available:
 | memory | No | None | Persistent memory scope for cross-session learning |
 | background | No | false | Run agent in background without blocking conversation (v2.1.46+) |
 | color | No | None | Display color in UI: red, blue, green, yellow, purple, orange, pink, cyan |
-| effort | No | inherit | Session effort override: low, medium, high, max (max is Opus 4.6 only) |
+| effort | No | inherit | Session effort override: low, medium, high, xhigh, max (xhigh/max require Opus 4.7+) |
 | initialPrompt | No | None | Auto-submitted first user turn when agent runs as main session agent via --agent flag (v2.1.83+) |
 | isolation | No | none | Isolation mode: "worktree" creates isolated git worktree (v2.1.49+) |
 
@@ -55,7 +55,7 @@ All agent definitions use YAML frontmatter. The following fields are available:
 
 **isolation**: Controls agent execution isolation. When set to "worktree", the agent runs in an isolated git worktree, preventing conflicts with the main working directory. Available since Claude Code v2.1.49.
 
-**effort**: Overrides session effort level for this agent. Valid values: `low`, `medium`, `high`, `max`. The `max` value is only supported on Opus 4.6 models.
+**effort**: Overrides session effort level for this agent. Valid values: `low`, `medium`, `high`, `xhigh`, `max`. The `xhigh` and `max` values require Opus 4.7 or later. On Opus 4.6, the highest supported effort level is `high`.
 
 **color**: Display color for the agent in the task list and transcript UI. Valid values: `red`, `blue`, `green`, `yellow`, `purple`, `orange`, `pink`, `cyan`.
 
@@ -191,6 +191,16 @@ Notes:
 - Dynamic teammates use `mode: "plan"` for read-only enforcement instead of tool restrictions
 - Project-specific context is included in the spawn prompt, not preloaded skills
 - Teammates can self-load skills via Skill() tool when deeper documentation is needed
+
+## Bash Tool Timeout Ceiling
+
+The Claude Code runtime enforces a hard ceiling on the Bash tool's `timeout` parameter:
+
+- Default: 120,000ms (2 minutes)
+- **Maximum: 600,000ms (10 minutes)** — values above this are rejected by Claude Code v2.1.110+
+- When authoring agent prompts that invoke long-running Bash commands (build, test suite, install), specify `timeout` explicitly up to the 600,000ms ceiling
+- Do NOT attempt to specify Bash tool timeouts exceeding 600,000ms; the runtime silently clamps or rejects them
+- Enforcement is performed by Claude Code itself, not by moai-adk-go; documentation here is for agent authors to avoid invalid values
 
 ## Agent Invocation
 

--- a/internal/template/templates/.claude/rules/moai/development/coding-standards.md
+++ b/internal/template/templates/.claude/rules/moai/development/coding-standards.md
@@ -71,6 +71,19 @@ Enforcement: `internal/template/commands_audit_test.go` verifies this pattern on
 
 Source: SPEC-THIN-CMDS-001
 
+## Claude Code Version Compatibility
+
+Settings fields introduced by specific Claude Code versions:
+
+| Field | Version | Notes |
+|-------|---------|-------|
+| `effortLevel` | v2.1.110 | Sets CLAUDE_CODE_EFFORT_LEVEL; values: low/medium/high/xhigh/max |
+| `disableBypassPermissionsMode` | v2.1.111 | Prevents agents from using bypassPermissions mode when true |
+| `Bash(timeout=N)` | v2.1.110 | Per-command Bash timeout in ms; max 600,000ms |
+
+When adding new settings fields, update `internal/template/templates/.claude/settings.json.tmpl`
+and this compatibility table.
+
 ## Paths Frontmatter
 
 Use paths frontmatter for conditional rule loading:

--- a/internal/template/templates/.claude/rules/moai/development/skill-authoring.md
+++ b/internal/template/templates/.claude/rules/moai/development/skill-authoring.md
@@ -22,7 +22,7 @@ Optional standard fields:
 - allowed-tools: Comma-separated string of tool names the skill can use (experimental)
 - user-invocable: Boolean to control slash command menu visibility (default: true, set to false to hide from / menu)
 - disable-model-invocation: Boolean, when true only user can invoke (not Claude). Use for workflows with side effects (default: false)
-- effort: Session effort override: low, medium, high, max (max is Opus 4.6 only)
+- effort: Session effort override: low, medium, high, xhigh, max (xhigh/max require Opus 4.7+)
 - model: Model override when skill is active (sonnet, opus, haiku)
 - shell: Shell for command injection: bash (default) or powershell
 - context: Set to "fork" to run skill in forked subagent context (isolated execution)

--- a/internal/template/templates/.claude/rules/moai/workflow/worktree-integration.md
+++ b/internal/template/templates/.claude/rules/moai/workflow/worktree-integration.md
@@ -271,8 +271,13 @@ Both share the same project structure. `src/auth/handler.go` resolves correctly 
 | `Ctrl+X Ctrl+K` to kill background agent | 2.1.83 | Kill stuck background agents |
 | Worktree CWD isolation fix | **2.1.97** | Prior versions leaked agent CWD back to parent session |
 | Stop/SubagentStop hook stability | **2.1.97** | Prior versions failed on long-running sessions |
+| `moai doctor` MCP scope duplicate detection | **2.1.110** | Warns on MCP server duplication across `.mcp.json` + settings.json |
+| Bash tool timeout ceiling enforcement | **2.1.110** | Maximum 600,000ms (10 min) enforced by runtime |
+| `effortLevel` setting for Opus 4.7 | **2.1.110** | Supports `low`/`medium`/`high`/`xhigh`/`max` effort levels |
+| `CLAUDE_ENV_FILE` on Windows | **2.1.111** | Prior versions: no-op on Windows; fixed to inject env as on macOS/Linux |
+| `disableBypassPermissionsMode` policy | **2.1.111** | Prevents agents from requesting `bypassPermissions` when `true` |
 
-**Recommended**: Claude Code **2.1.97 or later** for reliable worktree isolation and hook stability.
+**Recommended**: Claude Code **2.1.111 or later** for Opus 4.7 support, MCP doctor warnings, and Windows CLAUDE_ENV_FILE parity. Minimum baseline: **2.1.97** for worktree isolation.
 
 ## Troubleshooting
 

--- a/internal/template/templates/.claude/settings.json.tmpl
+++ b/internal/template/templates/.claude/settings.json.tmpl
@@ -621,5 +621,6 @@
   "teammateMode": "auto",
   "effortLevel": "medium",
   "includeGitInstructions": true,
-  "plansDirectory": ".moai/plans"
+  "plansDirectory": ".moai/plans",
+  "disableBypassPermissionsMode": false
 }

--- a/internal/template/templates/.claude/skills/moai-workflow-thinking/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-thinking/SKILL.md
@@ -35,19 +35,22 @@ triggers:
 
 Structured step-by-step reasoning via `mcp__sequential-thinking__sequentialthinking` MCP tool.
 
-## CRITICAL: Two Distinct Modes
+## CRITICAL: Three Distinct Reasoning Modes
 
-MoAI has TWO independent deep analysis modes. They are NOT the same thing:
+MoAI has THREE independent deep analysis modes. They are NOT the same thing:
 
-| Mode | Trigger | Mechanism | MCP Tool? | GLM Compatible? |
-|------|---------|-----------|-----------|-----------------|
-| `--deepthink` | Explicit `--deepthink` flag | Sequential Thinking MCP tool | YES — `mcp__sequential-thinking__sequentialthinking` | NO — generates server_tool_use content type |
-| `ultrathink` | Keyword or auto-detection | Claude native extended reasoning (high effort) | NO — native to Claude | YES — no special content type |
+| Mode | Trigger | Mechanism | MCP Tool? | GLM Compatible? | Model |
+|------|---------|-----------|-----------|-----------------|-------|
+| `--deepthink` | Explicit `--deepthink` flag | Sequential Thinking MCP tool | YES — `mcp__sequential-thinking__sequentialthinking` | NO — generates server_tool_use content type | Any |
+| `ultrathink` | Keyword or auto-detection | Claude native extended reasoning (high effort) | NO — native to Claude | YES — no special content type | Any |
+| Adaptive Thinking | Automatic on Opus 4.7 | Opus 4.7's only supported thinking mode | NO — built-in | YES | Opus 4.7 only |
 
 **Rules:**
 - `--deepthink` → ALWAYS invoke Sequential Thinking MCP. NEVER use for native reasoning.
 - `ultrathink` → ALWAYS use Claude's native extended reasoning. NEVER invoke Sequential Thinking MCP.
 - They can coexist: `ultrathink --deepthink` activates BOTH modes independently.
+- Adaptive Thinking → Opus 4.7's built-in reasoning. Let the model adapt depth automatically based on task complexity.
+- On Opus 4.7: do not hardcode a fixed reasoning budget. Adaptive Thinking overrides fixed-budget instructions.
 
 ## Activation Triggers (--deepthink only)
 

--- a/internal/template/templates/.moai/config/sections/harness.yaml
+++ b/internal/template/templates/.moai/config/sections/harness.yaml
@@ -39,6 +39,14 @@ harness:
       - test_coverage_low    # Coverage < 70% -> escalate to standard+
     max_escalations: 2
 
+  # Effort level mapping
+  # Maps harness depth to CLAUDE_CODE_EFFORT_LEVEL for Opus 4.7 adaptive thinking.
+  # Deeper harness = more extended reasoning budget for evaluator and planner agents.
+  effort_mapping:
+    minimal:  "medium"   # Fast iteration: no extended reasoning
+    standard: "high"     # Balanced quality: moderate reasoning budget
+    thorough: "xhigh"    # Critical features: maximum reasoning budget
+
   # Level definitions
   levels:
     minimal:

--- a/internal/template/templates/.moai/config/sections/llm.yaml
+++ b/internal/template/templates/.moai/config/sections/llm.yaml
@@ -9,10 +9,14 @@ llm:
   performance_tier: "medium"
 
   # Claude model mapping by tier
+  # Effort level mapping (Opus 4.7+ adaptive thinking):
+  #   thorough harness → xhigh effort (deep reasoning)
+  #   standard harness → high effort (balanced reasoning)
+  #   minimal harness  → medium effort (fast, light)
   claude_models:
-    high: "opus"      # Complex reasoning, architecture, security
-    medium: "sonnet"  # Balanced performance for most tasks
-    low: "haiku"      # Fast exploration, simple tasks
+    high: "claude-opus-4-7"  # Opus 4.7: adaptive thinking, reasoning agents
+    medium: "sonnet"         # Balanced performance for most tasks
+    low: "haiku"             # Fast exploration, simple tasks
 
   # GLM backend configuration
   glm:

--- a/internal/template/templates/.moai/config/sections/quality.yaml.tmpl
+++ b/internal/template/templates/.moai/config/sections/quality.yaml.tmpl
@@ -3,6 +3,12 @@ constitution:
   # Options: ddd (Domain-Driven Development), tdd (Test-Driven Development)
   development_mode: "{{.DevelopmentMode}}"
 
+  # Default session effort level for Opus 4.7+.
+  # Applied when no agent-specific effort override exists.
+  # Valid values: "low", "medium", "high", "xhigh", "max"
+  # "xhigh" and "max" require Opus 4.7.
+  session_effort_default: "xhigh"
+
   # Enable TRUST 5 quality framework enforcement
   enforce_quality: {{.EnforceQuality}}
 

--- a/internal/template/templates/CLAUDE.md
+++ b/internal/template/templates/CLAUDE.md
@@ -459,7 +459,8 @@ Resume interrupted agent work using agentId:
 MoAI-ADK integrates multiple MCP servers for specialized capabilities:
 
 - **Sequential Thinking** (`--deepthink` flag): MCP tool for structured step-by-step analysis. Generates `server_tool_use` content — NOT compatible with GLM API. See Skill("moai-workflow-thinking").
-- **UltraThink** (`ultrathink` keyword): Claude native extended reasoning mode (high effort). No MCP dependency — compatible with all APIs including GLM. Do NOT confuse with `--deepthink`.
+- **UltraThink** (`ultrathink` keyword): Sets `effort: max` in Claude Code v2.1.110+. For claude-opus-4-7, this triggers Adaptive Thinking (dynamically allocated reasoning tokens, no fixed budget_tokens). For older models, maps to extended thinking with high budget. No MCP dependency — compatible with all APIs. Do NOT confuse with `--deepthink`.
+- **Adaptive Thinking** (claude-opus-4-7 only): Opus 4.7's thinking mode. Unlike earlier models that use `budget_tokens`, Adaptive Thinking dynamically allocates reasoning based on task complexity. Triggered via `effort` level (high/xhigh/max) — not by `budget_tokens`. See Skill("moai-workflow-thinking").
 - **Context7**: Up-to-date library documentation lookup via resolve-library-id and get-library-docs.
 - **Pencil**: UI/UX design editing for .pen files (used by expert-frontend and designer teammates).
 - **claude-in-chrome**: Browser automation for web-based tasks.

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -5,7 +5,7 @@ import "fmt"
 // Build-time variables injected via -ldflags.
 // Default version for RC/test builds (overridden by -ldflags in production)
 var (
-	Version = "v2.10.2"
+	Version = "v2.11.0"
 	Commit  = "none"
 	Date    = "unknown"
 )


### PR DESCRIPTION
## 요약

SPEC-OPUS47-COMPAT-001 전체 구현 완료: Claude Code v2.1.110/111 + Opus 4.7 프롬프트 철학 호환성 기능 추가

### 핵심 변경사항

#### 1. Opus 4.7 모델 + 5단계 Effort 시스템
- `claude-opus-4-7` 모델 상수 정의
- effort 5단계 (low/medium/high/xhigh/max) 지원
- 6개 critical reasoning agent 명시적 effort 레벨 설정 (manager-spec, plan-auditor, evaluator-active, manager-strategy, expert-security, expert-refactoring)
- 기존 모델(Opus 4.6, Sonnet 4.6, Haiku 4.5) 하위 호환 유지

#### 2. Claude Code v2.1.110 Runtime 대응
- MCP scope 중복 감지 in `moai doctor`
- PermissionRequest hook에서 updatedInput deny 재검증
- Bash tool timeout 상한(600,000ms) 문서화
- `disableBypassPermissionsMode` 정책 필드 추가

#### 3. Claude Code v2.1.111 프로파일 지원
- Windows에서 `CLAUDE_ENV_FILE` 환경변수 자동 주입
- profile preferences에 `effort_level` 필드 추가
- Opus 4.7 선택시 effort level 선택지 제공

#### 4. 프롬프트 철학 5원칙 반영
- 에이전트 frontmatter `effort` 필드 설정
- "one-turn fully-loaded" 원칙에 따른 프롬프트 재작성
- 과거 Opus 4.6 era 스캐폴딩(double-check, verify N times) 제거

### 테스트 상태
✓ ALL TESTS PASS
✓ go vet clean
✓ Windows cross-compile PASS
✓ Implementation Divergence: 27 planned → 48 actual (TDD 테스트 + template/local 이중 구현 + 추가 runtime 통합)

### 문서 동기화
- product.md: Core Features #11 Opus 4.7 지원 명시
- tech.md: Claude Code v2.1.110+ 최소 권장 버전 + Opus 4.7 모델 카탈로그
- structure.md: 신규 함수 위치 (agent_effort_map, checkMCPScopeDuplicates, injectCLAUDEEnvFile 등)
- CHANGELOG: v2.12.0 항목 완성

## Test Plan

- [ ] `moai init` 후 Opus 4.7 + effort xhigh 선택 확인
- [ ] `moai doctor`에서 MCP 중복 감지 검증
- [ ] Windows 환경에서 CLAUDE_ENV_FILE 주입 확인
- [ ] 기존 Opus 4.6/Sonnet 4.6/Haiku 4.5 프로젝트 호환성 확인
- [ ] agent-authoring.md 문서의 effort 5단계 설명 확인

## 참고

Related: Issue #671
SPEC: `.moai/specs/SPEC-OPUS47-COMPAT-001/spec.md`

🔧 MoAI <email@mo.ai.kr>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Claude Opus 4.7 model with 5-level effort configuration (low/medium/high/xhigh/max)
  * Added Bash tool timeout parameter support with 600,000ms ceiling
  * Added MCP scope duplicate detection in diagnostics
  * Added Windows environment file injection during session setup

* **Bug Fixes**
  * Improved permission request validation for modified tool inputs

* **Documentation**
  * Updated guides for Opus 4.7 compatibility and effort level selection
  * Added Claude Code version compatibility reference table

<!-- end of auto-generated comment: release notes by coderabbit.ai -->