### PR TITLE
fix(lsp): resolve TypeScript (+15 languages) detection failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,10 @@ Two independent workstreams converged in this release:
 
 ### Fixed
 
+**LSP 서버 감지 수정 (#683)**
+- LSP 서버 감지 전체 비활성 문제 수정 (#683): `lsp.yaml` 템플릿 YAML 키를 `binary` → `command`로 수정 (`ServerConfig` YAML 태그와 일치), 16개 언어 전체에 `file_extensions` 추가 (`detectLanguage()` 파일-서버 라우팅 복원)
+- 템플릿 준수 테스트 추가 (`TestTemplate_NoBinaryKey`, `TestTemplate_16LangCommandNonEmpty`, `TestTemplate_16LangFileExtensionsNonEmpty`): 실제 템플릿 파일을 파싱해 스키마 드리프트 재발 방지
+
 **`moai glm` settings.local.json 영구 오염 수정 (#676)**
 - `moai glm` 실행 후 Claude Code 진입 시 context window limit 에러 수정: `applyGLMMode`에서 `injectGLMEnvForTeam()` 호출을 제거하여 `settings.local.json`에 GLM 환경변수(`ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BASE_URL`, `DISABLE_PROMPT_CACHING` 등)가 영구 기록되던 동작 방지. `setGLMEnv()`이 현재 프로세스 env를 설정하면 `syscall.Exec`가 이를 `claude`에 상속하므로 파일 기록은 중복이었으며 세션 종료 후 GLM 모드 잔류를 유발했음.
 - `moai glm` 시작 시 메인 세션 컨텍스트 한도 경고 메시지 추가: `DISABLE_PROMPT_CACHING=1`로 인한 전체 시스템 프롬프트 재전송 (~30-40K 토큰), Z.AI 동시성 한도 (유료 티어 1-3 in-flight), GLM 모델 컨텍스트 윈도우 크기를 안내. Claude 리더 + GLM 팀원 조합이 필요한 경우 `moai cg` 사용 권장.

--- a/internal/lsp/config/template_compliance_test.go
+++ b/internal/lsp/config/template_compliance_test.go
@@ -1,0 +1,99 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/modu-ai/moai-adk/internal/lsp/config"
+)
+
+// templatePath is the path to the real lsp.yaml template file relative to this test package.
+// Used by template compliance tests to detect schema drift early (see issue #683).
+const templateRelPath = "../../../internal/template/templates/.moai/config/sections/lsp.yaml.tmpl"
+
+// TestTemplate_NoBinaryKey is a regression test for issue #683.
+// It ensures the real template never uses "binary:" as a YAML key — the struct only
+// recognises "command:" (ServerConfig.Command yaml:"command"). This test prevents
+// the exact class of schema drift that caused all 16 language servers to silently
+// parse as empty Command strings.
+func TestTemplate_NoBinaryKey(t *testing.T) {
+	t.Parallel()
+
+	absPath, err := filepath.Abs(templateRelPath)
+	if err != nil {
+		t.Fatalf("filepath.Abs: %v", err)
+	}
+	raw, err := os.ReadFile(absPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q): %v — is internal/template/templates/ present?", absPath, err)
+	}
+
+	for i, line := range strings.Split(string(raw), "\n") {
+		trimmed := strings.TrimSpace(line)
+		// Detect bare "binary:" YAML key (not inside a comment or string value).
+		// A comment line starts with "#" after trimming.
+		if strings.HasPrefix(trimmed, "binary:") {
+			t.Errorf("line %d: found forbidden key \"binary:\" — use \"command:\" instead (ServerConfig YAML tag)", i+1)
+		}
+	}
+}
+
+// TestTemplate_16LangCommandNonEmpty verifies the real template file has all 16
+// canonical language servers with a non-empty command field.
+// Parses the template as YAML (no Go template directives in lsp.yaml.tmpl).
+func TestTemplate_16LangCommandNonEmpty(t *testing.T) {
+	t.Parallel()
+
+	absPath, err := filepath.Abs(templateRelPath)
+	if err != nil {
+		t.Fatalf("filepath.Abs: %v", err)
+	}
+
+	cfg, err := config.Load(absPath)
+	if err != nil {
+		t.Fatalf("config.Load(%q): %v", absPath, err)
+	}
+
+	if len(cfg.Servers) < 16 {
+		t.Errorf("template has %d language servers, want >= 16", len(cfg.Servers))
+	}
+
+	for _, lang := range canonicalLanguages {
+		sc, ok := cfg.Servers[lang]
+		if !ok {
+			t.Errorf("template missing language %q", lang)
+			continue
+		}
+		if sc.Command == "" {
+			t.Errorf("language %q: Command is empty — binary: → command: rename missing in template", lang)
+		}
+	}
+}
+
+// TestTemplate_16LangFileExtensionsNonEmpty verifies each language in the real template
+// has at least one file_extensions entry so that detectLanguage() can route files.
+func TestTemplate_16LangFileExtensionsNonEmpty(t *testing.T) {
+	t.Parallel()
+
+	absPath, err := filepath.Abs(templateRelPath)
+	if err != nil {
+		t.Fatalf("filepath.Abs: %v", err)
+	}
+
+	cfg, err := config.Load(absPath)
+	if err != nil {
+		t.Fatalf("config.Load(%q): %v", absPath, err)
+	}
+
+	for _, lang := range canonicalLanguages {
+		sc, ok := cfg.Servers[lang]
+		if !ok {
+			continue // already reported by TestTemplate_16LangCommandNonEmpty
+		}
+		if len(sc.FileExtensions) == 0 {
+			t.Errorf("language %q: FileExtensions is empty — add file_extensions to template", lang)
+		}
+	}
+}

--- a/internal/template/templates/.moai/config/sections/lsp.yaml.tmpl
+++ b/internal/template/templates/.moai/config/sections/lsp.yaml.tmpl
@@ -58,7 +58,7 @@ lsp:
   # which servers actually spawn at runtime.
   #
   # Schema per entry:
-  #   binary               : Primary server executable
+  #   command              : Primary server executable
   #   fallback_binaries    : Alternative servers if primary missing
   #   args                 : Command-line arguments
   #   init_options         : LSP initializationOptions for the server
@@ -70,7 +70,7 @@ lsp:
   servers:
 
     cpp:
-      binary: clangd
+      command: clangd
       fallback_binaries: []
       args: []
       init_options: {}
@@ -79,10 +79,16 @@ lsp:
         - "compile_commands.json"
         - "Makefile"
       install_hint: "Install via LLVM distribution (brew install llvm / apt install clangd)"
+      file_extensions:
+        - ".cpp"
+        - ".cc"
+        - ".cxx"
+        - ".h"
+        - ".hpp"
       license_concern: "open"
 
     csharp:
-      binary: omnisharp
+      command: omnisharp
       fallback_binaries:
         - "roslyn-ls"
       args:
@@ -93,10 +99,12 @@ lsp:
         - "*.sln"
         - "*.fsproj"
       install_hint: "Install OmniSharp or Microsoft.CodeAnalysis.LanguageServer"
+      file_extensions:
+        - ".cs"
       license_concern: "open"
 
     flutter:
-      binary: dart
+      command: dart
       fallback_binaries: []
       args:
         - "language-server"
@@ -106,10 +114,12 @@ lsp:
         - "pubspec.yaml"
         - "pubspec.lock"
       install_hint: "Install Dart SDK or Flutter SDK (dart binary provides language server)"
+      file_extensions:
+        - ".dart"
       license_concern: "open"
 
     elixir:
-      binary: elixir-ls
+      command: elixir-ls
       fallback_binaries:
         - "lexical"
       args: []
@@ -118,10 +128,13 @@ lsp:
         - "mix.exs"
         - "mix.lock"
       install_hint: "Install elixir-ls from https://github.com/elixir-lsp/elixir-ls"
+      file_extensions:
+        - ".ex"
+        - ".exs"
       license_concern: "open"
 
     go:
-      binary: gopls
+      command: gopls
       fallback_binaries: []
       args: []
       init_options:
@@ -130,10 +143,12 @@ lsp:
         - "go.mod"
         - "go.sum"
       install_hint: "go install golang.org/x/tools/gopls@latest"
+      file_extensions:
+        - ".go"
       license_concern: "open"
 
     java:
-      binary: jdtls
+      command: jdtls
       fallback_binaries: []
       args: []
       init_options: {}
@@ -142,10 +157,12 @@ lsp:
         - "build.gradle"
         - "build.gradle.kts"
       install_hint: "Install Eclipse JDT Language Server (jdtls)"
+      file_extensions:
+        - ".java"
       license_concern: "open"
 
     javascript:
-      binary: typescript-language-server
+      command: typescript-language-server
       fallback_binaries: []
       args:
         - "--stdio"
@@ -154,10 +171,14 @@ lsp:
         - "package.json"
         - "jsconfig.json"
       install_hint: "npm install -g typescript-language-server typescript"
+      file_extensions:
+        - ".js"
+        - ".jsx"
+        - ".mjs"
       license_concern: "open"
 
     kotlin:
-      binary: kotlin-language-server
+      command: kotlin-language-server
       fallback_binaries: []
       args: []
       init_options: {}
@@ -166,10 +187,13 @@ lsp:
         - "build.gradle"
         - "settings.gradle.kts"
       install_hint: "Install from https://github.com/fwcd/kotlin-language-server"
+      file_extensions:
+        - ".kt"
+        - ".kts"
       license_concern: "open"
 
     php:
-      binary: phpactor
+      command: phpactor
       fallback_binaries:
         - "intelephense"
       args:
@@ -179,10 +203,12 @@ lsp:
         - "composer.json"
         - "composer.lock"
       install_hint: "Install phpactor from https://phpactor.readthedocs.io/"
+      file_extensions:
+        - ".php"
       license_concern: "open"
 
     python:
-      binary: pylsp
+      command: pylsp
       fallback_binaries:
         - "pyright-langserver"
         - "basedpyright-langserver"
@@ -194,10 +220,12 @@ lsp:
         - "requirements.txt"
         - "Pipfile"
       install_hint: "pip install python-lsp-server"
+      file_extensions:
+        - ".py"
       license_concern: "open"
 
     r:
-      binary: R
+      command: R
       fallback_binaries: []
       args:
         - "--slave"
@@ -209,10 +237,13 @@ lsp:
         - ".Rproj"
         - "renv.lock"
       install_hint: "install.packages('languageserver') in R"
+      file_extensions:
+        - ".R"
+        - ".r"
       license_concern: "open"
 
     ruby:
-      binary: ruby-lsp
+      command: ruby-lsp
       fallback_binaries:
         - "solargraph"
       args: []
@@ -222,10 +253,12 @@ lsp:
         - ".ruby-version"
         - "Rakefile"
       install_hint: "gem install ruby-lsp"
+      file_extensions:
+        - ".rb"
       license_concern: "open"
 
     rust:
-      binary: rust-analyzer
+      command: rust-analyzer
       fallback_binaries: []
       args: []
       init_options:
@@ -235,10 +268,12 @@ lsp:
         - "Cargo.toml"
         - "Cargo.lock"
       install_hint: "rustup component add rust-analyzer"
+      file_extensions:
+        - ".rs"
       license_concern: "open"
 
     scala:
-      binary: metals
+      command: metals
       fallback_binaries: []
       args: []
       init_options: {}
@@ -246,10 +281,13 @@ lsp:
         - "build.sbt"
         - "build.sc"
       install_hint: "Install metals from https://scalameta.org/metals/"
+      file_extensions:
+        - ".scala"
+        - ".sc"
       license_concern: "open"
 
     swift:
-      binary: sourcekit-lsp
+      command: sourcekit-lsp
       fallback_binaries: []
       args: []
       init_options: {}
@@ -258,10 +296,12 @@ lsp:
         - "*.xcodeproj"
         - "*.xcworkspace"
       install_hint: "Install Xcode Command Line Tools (includes sourcekit-lsp)"
+      file_extensions:
+        - ".swift"
       license_concern: "open"
 
     typescript:
-      binary: typescript-language-server
+      command: typescript-language-server
       fallback_binaries: []
       args:
         - "--stdio"
@@ -270,6 +310,9 @@ lsp:
         - "tsconfig.json"
         - "package.json"
       install_hint: "npm install -g typescript-language-server typescript"
+      file_extensions:
+        - ".ts"
+        - ".tsx"
       license_concern: "open"
 
   # ---------------- ast-grep Delegation ----------------


### PR DESCRIPTION
## Summary
- Fix YAML key mismatch in `lsp.yaml` template (`binary:` → `command:`) so `ServerConfig` parses correctly for all 16 language servers
- Add `file_extensions:` for all 16 supported languages so `detectLanguage()` can route files to language servers
- Add 3 template compliance tests to prevent schema drift regression

## Root Cause
- `internal/template/templates/.moai/config/sections/lsp.yaml.tmpl` used `binary:` key for all 16 server entries
- Go struct `ServerConfig` at `internal/lsp/config/types.go:14` only parses `command:` (YAML tag `yaml:"command"`)
- Result: `Command=""` for all 16 servers — `moai lsp doctor` reported every server as missing, `detectLanguage()` always returned no match
- `file_extensions:` field was entirely absent from template, preventing file-to-server routing
- Existing tests used in-memory YAML fixtures with correct keys (`command:` + `file_extensions:`), so CI passed despite the template bug

## Test plan
- [x] `go vet ./...` — clean
- [x] `go test ./internal/lsp/config/... -race -count=1` — all 30 tests PASS including 3 new compliance tests
- [x] `go test ./internal/template/... -race -count=1` — PASS
- [x] `go test ./... -short` — all packages PASS (GLM CLI failures are pre-existing, unrelated to this PR)
- [x] New tests: `TestTemplate_NoBinaryKey`, `TestTemplate_16LangCommandNonEmpty`, `TestTemplate_16LangFileExtensionsNonEmpty` verify the real template file

Fixes #683

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed LSP server detection and routing, restoring language detection for all 16 configured languages.
  * Updated LSP configuration template to ensure each server has a defined command and associated file extensions.

* **Tests**
  * Added template-validation tests to prevent future LSP configuration regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->