### PR TITLE
fix(cli): prevent moai glm from polluting settings.local.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,12 @@ Two independent workstreams converged in this release:
 
 ### Fixed
 
+**`moai glm` settings.local.json 영구 오염 수정 (#676)**
+- `moai glm` 실행 후 Claude Code 진입 시 context window limit 에러 수정: `applyGLMMode`에서 `injectGLMEnvForTeam()` 호출을 제거하여 `settings.local.json`에 GLM 환경변수(`ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BASE_URL`, `DISABLE_PROMPT_CACHING` 등)가 영구 기록되던 동작 방지. `setGLMEnv()`이 현재 프로세스 env를 설정하면 `syscall.Exec`가 이를 `claude`에 상속하므로 파일 기록은 중복이었으며 세션 종료 후 GLM 모드 잔류를 유발했음.
+- `moai glm` 시작 시 메인 세션 컨텍스트 한도 경고 메시지 추가: `DISABLE_PROMPT_CACHING=1`로 인한 전체 시스템 프롬프트 재전송 (~30-40K 토큰), Z.AI 동시성 한도 (유료 티어 1-3 in-flight), GLM 모델 컨텍스트 윈도우 크기를 안내. Claude 리더 + GLM 팀원 조합이 필요한 경우 `moai cg` 사용 권장.
+- `injectGLMEnvForTeam`은 `enableTeamMode()`(`moai --team` 경로)에서만 사용하도록 범위 축소. `applyGLMMode` 호출 제거만 수행, 함수 자체는 유지.
+- 회귀 테스트 추가: `TestApplyGLMMode_NoSettingsLocalPollution`, `TestApplyGLMMode_ProcessEnvIsSet`, `TestGLMCmd_NoSettingsLocalPollution` (기존 `TestGLMCmd_InjectsEnv` 역전).
+
 **Critical Review Findings (this session, post SPEC-DB-SYNC-001 review)**
 - **Hook timeout unit bug** (`c6985e2fe`) — `settings.json.tmpl` PostToolUse `handle-db-schema-change.sh` entry had `"timeout": 30000` (8.3 hours). Claude Code hook timeout is in seconds (range 1-600). Corrected to `30`.
 - **matchGlob path traversal** (`aa29a9316`) — `migrations/../../../etc/passwd.sql` style paths passed `migrations/**/*.sql` prefix match, enabling read of files outside project root in `proposal.json`. Added `filepath.Clean` + `../` escape rejection guard at `HandleDBSchemaSync` entry. 4-case regression test added.

--- a/internal/cli/coverage_test.go
+++ b/internal/cli/coverage_test.go
@@ -655,12 +655,21 @@ func TestRunGLM_WithConfig(t *testing.T) {
 	}
 }
 
-func TestRunGLM_InjectsEnvToSettings(t *testing.T) {
+// TestRunGLM_InjectsEnvToProcess verifies that 'moai glm' injects GLM env vars
+// into the current process (via setGLMEnv), NOT into settings.local.json.
+// The old name was TestRunGLM_InjectsEnvToSettings, which codified the #676 bug.
+// After the fix, GLM env is carried by the current process and inherited by
+// syscall.Exec into `claude`; settings.local.json is left clean.
+// NOTE: does not call t.Parallel() because it modifies process-level env via setGLMEnv.
+func TestRunGLM_InjectsEnvToProcess(t *testing.T) {
 	origDeps := deps
 	defer func() { deps = origDeps }()
 
 	// Set GLM_API_KEY env var
 	t.Setenv("GLM_API_KEY", "test-api-key")
+	// Clear baseline env so assertions are deterministic.
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
+	t.Setenv("ANTHROPIC_BASE_URL", "")
 
 	tmpDir := t.TempDir()
 	setupMinimalConfig(t, tmpDir)
@@ -701,14 +710,20 @@ func TestRunGLM_InjectsEnvToSettings(t *testing.T) {
 		t.Fatalf("runGLM error: %v", err)
 	}
 
-	// Verify settings.local.json was created with GLM env
-	settingsPath := filepath.Join(tmpDir, ".claude", "settings.local.json")
-	data, err := os.ReadFile(settingsPath)
-	if err != nil {
-		t.Fatalf("settings.local.json should be created: %v", err)
+	// GLM env must be in the current process env (inherited by syscall.Exec).
+	if got := os.Getenv("ANTHROPIC_AUTH_TOKEN"); got == "" {
+		t.Error("ANTHROPIC_AUTH_TOKEN must be set in process env after moai glm")
 	}
-	if !strings.Contains(string(data), "ANTHROPIC_AUTH_TOKEN") {
-		t.Error("settings.local.json should contain ANTHROPIC_AUTH_TOKEN")
+	if got := os.Getenv("ANTHROPIC_BASE_URL"); got == "" {
+		t.Error("ANTHROPIC_BASE_URL must be set in process env after moai glm")
+	}
+
+	// settings.local.json must NOT contain GLM env vars (#676 regression guard).
+	settingsPath := filepath.Join(tmpDir, ".claude", "settings.local.json")
+	if data, err := os.ReadFile(settingsPath); err == nil {
+		if strings.Contains(string(data), "ANTHROPIC_AUTH_TOKEN") {
+			t.Error("settings.local.json must NOT contain ANTHROPIC_AUTH_TOKEN (regression: #676)")
+		}
 	}
 }
 

--- a/internal/cli/glm.go
+++ b/internal/cli/glm.go
@@ -136,6 +136,16 @@ func runGLM(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("auto mode is not available with GLM (third-party provider)")
 	}
 
+	// Warn about main-session GLM limitations before launch.
+	// DISABLE_PROMPT_CACHING=1 forces full system prompt re-send per request (~30-40K tokens),
+	// which hits GLM context limits faster than expected. Z.AI concurrency limits (1-3 in-flight
+	// requests per paid tier) are sometimes misreported by Claude Code as "context window limit".
+	_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "WARNING: moai glm uses GLM models for the MAIN SESSION. Known limitations:")
+	_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "  - Main session context window: 128K (glm-4.5-air), 202K (glm-4.7), 204K (glm-5.1)")
+	_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "  - DISABLE_PROMPT_CACHING=1 causes full system prompt re-send per request")
+	_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "  - Z.AI concurrency is limited (1-3 in-flight requests per paid tier)")
+	_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "If you want Claude as leader and GLM for teammates, use 'moai cg' instead.")
+
 	return unifiedLaunch(profileName, "glm", filteredArgs)
 }
 

--- a/internal/cli/glm_model_override_test.go
+++ b/internal/cli/glm_model_override_test.go
@@ -10,12 +10,19 @@ import (
 	"github.com/modu-ai/moai-adk/internal/config"
 )
 
-// TestGLMCmd_AddsModelOverrides verifies that 'moai glm' adds GLM model overrides
-// to settings.local.json. This test addresses the issue where GLM model environment
-// variables (ANTHROPIC_DEFAULT_OPUS_MODEL, etc.) were not being added.
+// TestGLMCmd_AddsModelOverrides verifies that 'moai glm' injects GLM model overrides
+// into the current process env (via setGLMEnv). After the #676 fix, these are no longer
+// written to settings.local.json — the process env is what syscall.Exec inherits into
+// `claude`. settings.local.json must remain clean to prevent GLM mode from leaking
+// into subsequent sessions.
+// NOTE: does not call t.Parallel() because it modifies process-level env via setGLMEnv.
 func TestGLMCmd_AddsModelOverrides(t *testing.T) {
 	// Set GLM_API_KEY env var
 	t.Setenv("GLM_API_KEY", "test-api-key-for-model-override-test")
+	// Baseline: clear the vars we will check so the test is deterministic.
+	t.Setenv("ANTHROPIC_DEFAULT_OPUS_MODEL", "")
+	t.Setenv("ANTHROPIC_DEFAULT_SONNET_MODEL", "")
+	t.Setenv("ANTHROPIC_DEFAULT_HAIKU_MODEL", "")
 
 	// Create temp project
 	tmpDir := t.TempDir()
@@ -56,46 +63,37 @@ func TestGLMCmd_AddsModelOverrides(t *testing.T) {
 		t.Fatalf("moai glm should not error, got: %v", err)
 	}
 
-	// Verify settings.local.json was created with GLM model overrides
+	// GLM model overrides must be in the PROCESS ENV (inherited by syscall.Exec),
+	// NOT in settings.local.json (which would cause persistence pollution, #676).
+	defaults := config.NewDefaultLLMConfig()
+	if got := os.Getenv("ANTHROPIC_DEFAULT_OPUS_MODEL"); got == "" {
+		t.Error("ANTHROPIC_DEFAULT_OPUS_MODEL must be set in process env after moai glm")
+	} else if got != defaults.GLM.Models.High {
+		t.Errorf("ANTHROPIC_DEFAULT_OPUS_MODEL = %q, want %q", got, defaults.GLM.Models.High)
+	}
+	if got := os.Getenv("ANTHROPIC_DEFAULT_SONNET_MODEL"); got == "" {
+		t.Error("ANTHROPIC_DEFAULT_SONNET_MODEL must be set in process env after moai glm")
+	}
+	if got := os.Getenv("ANTHROPIC_DEFAULT_HAIKU_MODEL"); got == "" {
+		t.Error("ANTHROPIC_DEFAULT_HAIKU_MODEL must be set in process env after moai glm")
+	}
+	if got := os.Getenv("ANTHROPIC_AUTH_TOKEN"); got == "" {
+		t.Error("ANTHROPIC_AUTH_TOKEN must be set in process env after moai glm")
+	}
+	if got := os.Getenv("ANTHROPIC_BASE_URL"); got == "" {
+		t.Error("ANTHROPIC_BASE_URL must be set in process env after moai glm")
+	}
+
+	// settings.local.json must NOT contain GLM env vars (#676 regression guard).
 	settingsPath := filepath.Join(claudeDir, "settings.local.json")
-	data, err := os.ReadFile(settingsPath)
-	if err != nil {
-		t.Fatalf("settings.local.json should be created: %v", err)
-	}
-
-	content := string(data)
-
-	// Check for GLM model override environment variables
-	if !strings.Contains(content, "ANTHROPIC_DEFAULT_OPUS_MODEL") {
-		t.Error("settings.local.json should contain ANTHROPIC_DEFAULT_OPUS_MODEL for GLM mode")
-	}
-	if !strings.Contains(content, "ANTHROPIC_DEFAULT_SONNET_MODEL") {
-		t.Error("settings.local.json should contain ANTHROPIC_DEFAULT_SONNET_MODEL for GLM mode")
-	}
-	if !strings.Contains(content, "ANTHROPIC_DEFAULT_HAIKU_MODEL") {
-		t.Error("settings.local.json should contain ANTHROPIC_DEFAULT_HAIKU_MODEL for GLM mode")
-	}
-
-	// Verify the actual model values
-	if !strings.Contains(content, "glm-5.1") {
-		t.Error("settings.local.json should contain glm-5.1 as the Opus model")
-	}
-	if !strings.Contains(content, "glm-4.7") {
-		t.Error("settings.local.json should contain glm-4.7 as the Sonnet model")
-	}
-	if !strings.Contains(content, "glm-4.5-air") {
-		t.Error("settings.local.json should contain glm-4.5-air as the Haiku model")
-	}
-
-	// Also verify base GLM env vars are present
-	if !strings.Contains(content, "ANTHROPIC_AUTH_TOKEN") {
-		t.Error("settings.local.json should contain ANTHROPIC_AUTH_TOKEN")
-	}
-	if !strings.Contains(content, "ANTHROPIC_BASE_URL") {
-		t.Error("settings.local.json should contain ANTHROPIC_BASE_URL")
-	}
-	if !strings.Contains(content, "teammateMode") {
-		t.Error("settings.local.json should contain teammateMode")
+	if data, err := os.ReadFile(settingsPath); err == nil {
+		content := string(data)
+		if strings.Contains(content, "ANTHROPIC_BASE_URL") {
+			t.Error("settings.local.json must NOT contain ANTHROPIC_BASE_URL (regression: #676)")
+		}
+		if strings.Contains(content, "ANTHROPIC_DEFAULT_OPUS_MODEL") {
+			t.Error("settings.local.json must NOT contain ANTHROPIC_DEFAULT_OPUS_MODEL (regression: #676)")
+		}
 	}
 }
 

--- a/internal/cli/glm_test.go
+++ b/internal/cli/glm_test.go
@@ -84,7 +84,14 @@ func TestGLMCmd_NoArgs(t *testing.T) {
 	}
 }
 
-func TestGLMCmd_InjectsEnv(t *testing.T) {
+// TestGLMCmd_NoSettingsLocalPollution verifies that `moai glm` does NOT write
+// GLM env vars to settings.local.json. The previous behavior (injectGLMEnvForTeam
+// in applyGLMMode) caused GLM mode to persist after `moai glm` exited, routing all
+// subsequent `claude` invocations to GLM unexpectedly (#676).
+//
+// setGLMEnv() already injects env into the current process, which syscall.Exec
+// inherits into `claude` — writing to settings.local.json is redundant and harmful.
+func TestGLMCmd_NoSettingsLocalPollution(t *testing.T) {
 	// Set GLM_API_KEY env var
 	t.Setenv("GLM_API_KEY", "test-api-key")
 
@@ -126,22 +133,24 @@ func TestGLMCmd_InjectsEnv(t *testing.T) {
 		t.Fatalf("glm should not error, got: %v", err)
 	}
 
-	// GLM should create settings.local.json with GLM env vars
+	// GLM should NOT write GLM env vars to settings.local.json (#676 fix).
+	// setGLMEnv() injects env into the current process; no file persistence needed.
 	settingsPath := filepath.Join(claudeDir, "settings.local.json")
 	data, err := os.ReadFile(settingsPath)
 	if err != nil {
-		t.Fatalf("settings.local.json should be created: %v", err)
+		// File not created at all — that's acceptable and expected.
+		if !os.IsNotExist(err) {
+			t.Fatalf("unexpected error reading settings.local.json: %v", err)
+		}
+		return
 	}
 
 	content := string(data)
-	if !strings.Contains(content, "ANTHROPIC_AUTH_TOKEN") {
-		t.Error("settings.local.json should contain ANTHROPIC_AUTH_TOKEN")
+	if strings.Contains(content, "ANTHROPIC_BASE_URL") {
+		t.Error("settings.local.json must NOT contain ANTHROPIC_BASE_URL after moai glm (regression: #676 persistence bug)")
 	}
-	if !strings.Contains(content, "ANTHROPIC_BASE_URL") {
-		t.Error("settings.local.json should contain ANTHROPIC_BASE_URL")
-	}
-	if !strings.Contains(content, "teammateMode") {
-		t.Error("settings.local.json should contain teammateMode")
+	if strings.Contains(content, "DISABLE_PROMPT_CACHING") {
+		t.Error("settings.local.json must NOT contain DISABLE_PROMPT_CACHING after moai glm (regression: #676 persistence bug)")
 	}
 }
 

--- a/internal/cli/launcher.go
+++ b/internal/cli/launcher.go
@@ -112,13 +112,15 @@ func applyGLMMode(root, profileName string) error {
 
 	setGLMEnv(glmConfig, apiKey)
 
+	// settings.local.json injection is intentionally omitted here: setGLMEnv()
+	// already sets env for the current process which syscall.Exec inherits into
+	// `claude`. Writing to settings.local.json (as previous behavior) would leak
+	// GLM env to subsequent `claude` invocations after `moai glm` exits.
+	// Tmux team panes still receive env via injectTmuxSessionEnv below (moai cg path).
+	// For persistent settings.local.json injection used by `moai --team`, see enableTeamMode().
+
 	if err := persistTeamMode(root, "glm"); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Warning: failed to persist team mode: %v\n", err)
-	}
-
-	settingsPath := filepath.Join(root, defs.ClaudeDir, defs.SettingsLocalJSON)
-	if err := injectGLMEnvForTeam(settingsPath, glmConfig, apiKey); err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "Warning: failed to inject GLM env into settings: %v\n", err)
 	}
 
 	if tmux.NewDetector().InTmuxSession() {

--- a/internal/cli/launcher_test.go
+++ b/internal/cli/launcher_test.go
@@ -685,3 +685,112 @@ func TestUnifiedLaunch_NotInProject(t *testing.T) {
 		t.Errorf("error should mention 'not in a MoAI project', got: %v", err)
 	}
 }
+
+// TestApplyGLMMode_NoSettingsLocalPollution verifies that applyGLMMode does NOT
+// write GLM env vars to settings.local.json. Regression test for #676.
+//
+// Before the fix, injectGLMEnvForTeam() in applyGLMMode permanently wrote
+// ANTHROPIC_BASE_URL, ANTHROPIC_AUTH_TOKEN, DISABLE_PROMPT_CACHING, etc. to
+// settings.local.json, causing GLM mode to leak into all subsequent `claude`
+// invocations after `moai glm` exited.
+//
+// After the fix, setGLMEnv() sets the current-process env (inherited by
+// syscall.Exec into `claude`), and settings.local.json is left clean.
+// NOTE: does not call t.Parallel() because it modifies process-level env via setGLMEnv.
+func TestApplyGLMMode_NoSettingsLocalPollution(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".moai"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("GLM_API_KEY", "test-glm-key-676")
+
+	origFn := findProjectRootFn
+	findProjectRootFn = func() (string, error) { return tmpDir, nil }
+	defer func() { findProjectRootFn = origFn }()
+
+	origDir, _ := os.Getwd()
+	defer func() { _ = os.Chdir(origDir) }()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	origLaunch := launchClaudeFunc
+	defer func() { launchClaudeFunc = origLaunch }()
+	launchClaudeFunc = func(p string, args []string) error { return nil }
+
+	// Call applyGLMMode directly — this is what unifiedLaunch calls in GLM mode.
+	if err := applyGLMMode(tmpDir, ""); err != nil {
+		t.Fatalf("applyGLMMode() error: %v", err)
+	}
+
+	// settings.local.json must NOT contain GLM env vars after applyGLMMode.
+	settingsPath := filepath.Join(tmpDir, ".claude", "settings.local.json")
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// File not created — correct behavior.
+			return
+		}
+		t.Fatalf("unexpected error reading settings.local.json: %v", err)
+	}
+
+	content := string(data)
+	if strings.Contains(content, "ANTHROPIC_BASE_URL") {
+		t.Error("settings.local.json must NOT contain ANTHROPIC_BASE_URL (regression: #676)")
+	}
+	if strings.Contains(content, "DISABLE_PROMPT_CACHING") {
+		t.Error("settings.local.json must NOT contain DISABLE_PROMPT_CACHING (regression: #676)")
+	}
+	if strings.Contains(content, "ANTHROPIC_AUTH_TOKEN") {
+		t.Error("settings.local.json must NOT contain ANTHROPIC_AUTH_TOKEN (regression: #676)")
+	}
+}
+
+// TestApplyGLMMode_ProcessEnvIsSet verifies that applyGLMMode sets GLM env
+// vars in the current process via setGLMEnv(). The process env is what
+// syscall.Exec inherits into the launched `claude` binary.
+// NOTE: does not call t.Parallel() because it modifies process-level env via setGLMEnv.
+func TestApplyGLMMode_ProcessEnvIsSet(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".moai"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("GLM_API_KEY", "test-glm-key-676-proc")
+	// Ensure a clean baseline for the vars we check.
+	t.Setenv("ANTHROPIC_BASE_URL", "")
+	t.Setenv("DISABLE_PROMPT_CACHING", "")
+
+	origFn := findProjectRootFn
+	findProjectRootFn = func() (string, error) { return tmpDir, nil }
+	defer func() { findProjectRootFn = origFn }()
+
+	origDir, _ := os.Getwd()
+	defer func() { _ = os.Chdir(origDir) }()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	origLaunch := launchClaudeFunc
+	defer func() { launchClaudeFunc = origLaunch }()
+	launchClaudeFunc = func(p string, args []string) error { return nil }
+
+	if err := applyGLMMode(tmpDir, ""); err != nil {
+		t.Fatalf("applyGLMMode() error: %v", err)
+	}
+
+	// Process env must have GLM vars set (inherited by syscall.Exec into claude).
+	if got := os.Getenv("ANTHROPIC_BASE_URL"); got == "" {
+		t.Error("ANTHROPIC_BASE_URL must be set in process env after applyGLMMode")
+	}
+	if got := os.Getenv("DISABLE_PROMPT_CACHING"); got != "1" {
+		t.Errorf("DISABLE_PROMPT_CACHING must be '1' after applyGLMMode, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

- `moai glm` previously wrote GLM env vars (ANTHROPIC_AUTH_TOKEN, ANTHROPIC_BASE_URL, DISABLE_PROMPT_CACHING, teammateMode) permanently to `.claude/settings.local.json`, causing GLM mode to leak into all subsequent `claude` invocations after `moai glm` exited
- `setGLMEnv()` already sets current-process env which `syscall.Exec` inherits into `claude` — the `settings.local.json` write was redundant AND caused persistence pollution
- Startup warning added so users understand `moai glm` uses GLM for the **main session** (high context pressure with DISABLE_PROMPT_CACHING + Z.AI concurrency limits)
- Users who want Claude as leader and GLM for teammates should use `moai cg` instead

## Root Cause

- `applyGLMMode` in `internal/cli/launcher.go` called `injectGLMEnvForTeam(settingsPath, ...)` which wrote env to `.claude/settings.local.json`
- After `moai glm` exited, the file retained the GLM env vars → any later `claude` invocation unexpectedly routed to GLM
- Combined with `DISABLE_PROMPT_CACHING=1` (forces full ~30-40K system prompt per request) and Z.AI concurrency limits (1-3 in-flight), users hit what Claude Code reports as "context window limit" on the very first message
- Reporter's initial hypothesis (that `moai glm` changes `llm.mode`) was verified **false** — only `llm.team_mode` is changed. The real culprit was `settings.local.json` pollution

## Behavior Change

- After `moai glm` exits: `settings.local.json` no longer contains GLM env vars (clean state)
- Main-session GLM routing during `moai glm` itself continues to work via current-process env inherited by `syscall.Exec(claude, ...)`
- Tmux pane env propagation (via `injectTmuxSessionEnv`) is unchanged — `moai cg` team mode unaffected
- `injectGLMEnvForTeam` function is preserved; it is still used by `enableTeamMode()` (`moai --team` path) where persistent settings are appropriate

## Test plan

- [x] `TestApplyGLMMode_NoSettingsLocalPollution` (new): verifies settings.local.json is clean after applyGLMMode
- [x] `TestApplyGLMMode_ProcessEnvIsSet` (new): verifies process env is set correctly by setGLMEnv
- [x] `TestGLMCmd_NoSettingsLocalPollution` (renamed from TestGLMCmd_InjectsEnv, inverted): asserts absence of GLM vars in settings.local.json
- [x] `TestRunGLM_InjectsEnvToProcess` (renamed from TestRunGLM_InjectsEnvToSettings, inverted)
- [x] `TestGLMCmd_AddsModelOverrides` updated to assert process env (not settings.local.json)
- [x] `go vet ./...` clean
- [x] `go test ./internal/cli/... -race -count=1` passes
- [x] Manual: after `moai glm` exit, `.claude/settings.local.json` does not contain ANTHROPIC_BASE_URL

Fixes #676

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed `moai glm` mode corrupting local settings configuration by preventing credential storage in the settings file; GLM environment variables now apply only to the current process.

* **New Features**
  * Added startup warning when running `moai glm` highlighting context window limitations and prompt caching effects, with recommendations for alternative configurations.

* **Tests**
  * Enhanced test coverage for GLM mode environment handling and settings file integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->