### PR TITLE
ci(claude-review): max-turns 10 → 40 to prevent error_max_turns

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -55,7 +55,13 @@ jobs:
           allowed_bots: 'dependabot'
           # Use Opus model with high effort for thorough code reviews.
           # C4 Fix: Added --max-turns to cap runaway executions and control costs.
+          # History:
+          #   C4a: 10 — initial value, hit error_max_turns on multi-file PRs
+          #        (e.g. PR #688 docs 4-language sync, run #24720853092)
+          #   C4b: 10 → 40 — reviews need to read N files across locales.
+          #        Code review is lighter than issue fixing (claude.yml: 80),
+          #        so 40 is a conservative middle ground. Bump to 80 if exceeded.
           claude_args: |
             --model claude-opus-4-7
             --effort high
-            --max-turns 10
+            --max-turns 40


### PR DESCRIPTION
## Summary

PR #688의 `claude-review` check가 `error_max_turns`로 실패했습니다. 10턴 제한은 멀티파일 PR(특히 4개국어 문서 싱크)에서 리뷰를 완료하기에 부족합니다.

## Root Cause

- Run: https://github.com/modu-ai/moai-adk/actions/runs/24720853092/job/72309020124
- PR #688 scope: 4-language docs sync (en/ko/ja/zh × 각 locale당 2+ 파일 = 8+ 파일) + code review가 glossary / style guide 교차 참조 필요
- 10턴으로는 전체 파일을 읽고 리뷰 코멘트를 작성하기까지 도달하지 못함

## Fix

`claude-code-review.yml`의 `--max-turns`를 10 → 40으로 상향.

Sibling workflow `claude.yml`의 프로그레션(#684에서 이미 80까지)과 동일한 로직이며, 코드 리뷰는 이슈 픽스보다 경량(주로 읽기+코멘트)이므로 40을 중간값으로 선택했습니다. 부족하면 후속 PR에서 80으로 상향.

## History alignment

| Workflow | 초기값 | 현재값 | 트리거 |
|---|---|---|---|
| `claude.yml` (issues) | 20 | 80 | #684 (run #24700719267, issue #683) |
| `claude-code-review.yml` (PR) | 10 | 40 (this PR) | PR #688 run #24720853092 |

## Test plan

- [ ] Merge 후 PR #688에 `claude-review` 재실행 (이번 PR의 workflow 업데이트가 반영됨)
- [ ] `error_max_turns` 발생 여부 확인. 발생 시 follow-up PR로 80 상향

Refs: run #24720853092

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code review configuration to improve handling of larger pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->