### PR TITLE
ci(claude-review): max-turns 40 → 80 align with claude.yml

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -59,9 +59,11 @@ jobs:
           #   C4a: 10 — initial value, hit error_max_turns on multi-file PRs
           #        (e.g. PR #688 docs 4-language sync, run #24720853092)
           #   C4b: 10 → 40 — reviews need to read N files across locales.
-          #        Code review is lighter than issue fixing (claude.yml: 80),
-          #        so 40 is a conservative middle ground. Bump to 80 if exceeded.
+          #   C4c: 40 → 80 — align with claude.yml (issue fixes). Code reviews
+          #        on SPEC-level changes frequently exceed 40 turns when the PR
+          #        touches cross-cutting code + tests + docs. 80 matches the
+          #        budget used by the sibling issue-fix workflow.
           claude_args: |
             --model claude-opus-4-7
             --effort high
-            --max-turns 40
+            --max-turns 80


### PR DESCRIPTION
## Summary

PR #692 follow-up. `claude-code-review.yml`의 `--max-turns`를 40 → 80으로 상향하여 sibling workflow `claude.yml`(#684)과 일치시킵니다.

## Rationale

- SPEC-level 변경을 포함한 PR은 code + tests + docs를 교차 참조하는 리뷰가 필요해 40턴을 초과하는 경우가 잦음
- 두 workflow가 동일한 max-turns를 사용하면 향후 상향 조정 시 한 곳만 수정하면 되므로 유지보수 단순화
- `effort: high`에서 리뷰 예산을 동일하게 두는 것이 비용/품질 정합성에 유리

## Changes

- `claude-code-review.yml`: `--max-turns 40` → `--max-turns 80`
- 주석 이력 업데이트 (C4c 항목 추가)

## Test plan

- [ ] Merge 후 PR에 대한 claude-review에서 `error_max_turns` 재발 여부 모니터링
- [ ] 장기 추세상 80턴도 부족하면 effort 또는 scope filtering 재검토

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline configuration to support more comprehensive automated code review processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->