### PR TITLE
ci(claude-review): skip fork PRs to avoid OIDC token failure

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -16,6 +16,12 @@ concurrency:
 
 jobs:
   claude-review:
+    # C5 Fix: Skip fork PRs. GitHub blocks `id-token: write` on cross-repository
+    # PRs for security reasons, causing OIDC token acquisition to fail with
+    # `Unable to get ACTIONS_ID_TOKEN_REQUEST_URL`. Example: PR #690.
+    # Fork PR reviews should be triggered manually via `@claude` on `claude.yml`.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||


### PR DESCRIPTION
## Summary

- Fork(cross-repository) PR에서는 GitHub이 보안상 `id-token: write` 권한을 차단하기 때문에, `anthropics/claude-code-action`이 OIDC 토큰을 받지 못하고 `Unable to get ACTIONS_ID_TOKEN_REQUEST_URL`로 실패한다.
- 결과적으로 모든 fork PR의 `claude-review` 체크가 구조적으로 fail 처리된다 (예: PR #690, fork user `gbrinan`).
- `claude-review` job에 `if: github.event.pull_request.head.repo.full_name == github.repository` 조건을 추가해, fork PR에서는 job 자체를 `skipped`로 표시하도록 수정했다.

## 왜 이 방식인가

| 대안 | 채택 여부 | 이유 |
|------|-----------|------|
| **Skip fork PRs** (이 PR) | ✅ | 안전. `id-token: write`가 실제로 주어지는 내부 PR에서만 job 실행. fail → skipped 전환. |
| `pull_request_target`로 전환 | ❌ | fork의 코드/workflow가 secrets에 접근 가능해 공격 가능. 보안 위험 큼. |
| 아무것도 안 함 | ❌ | 모든 fork PR이 빨간 체크로 표시되어 소음 누적. |

Fork PR의 AI 리뷰가 필요하면 `@claude` 멘션으로 `claude.yml`을 수동 트리거하면 된다.

## Changes

- `.github/workflows/claude-code-review.yml` — `jobs.claude-review`에 `if:` 1줄 추가 + 사유 주석 4줄

## Test plan

- [ ] 이 PR 자체(내부 branch)에서 `claude-review` job이 정상 실행됨을 확인 (skip되지 않음)
- [ ] 머지 이후 새로 열리는 fork PR에서 `claude-review` job이 `skipping`으로 표시됨을 확인 (PR #690 재발 방지)
- [ ] 내부 PR의 기존 flow는 변경 없음

🗿 MoAI <email@mo.ai.kr>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code review workflow security by adding a conditional check to restrict review job execution to pull requests from the same repository, preventing unnecessary runs on external contributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->