### PR TITLE
plan(v2.15): SPEC-UTIL-004/005/006 — Utility Performance Backlog

### DIFF
--- a/.moai/specs/SPEC-UTIL-004/research.md
+++ b/.moai/specs/SPEC-UTIL-004/research.md
@@ -1,0 +1,87 @@
+# SPEC-UTIL-004 Research Notes
+
+## §1. 배경 (v2.14 Review Finding)
+
+v2.14.0 릴리스 플랜 Phase 3.2 완료 후 `manager-quality` 멀티관점 코드 리뷰에서 다음 항목이 **Warning — PERFORMANCE** 등급으로 제기되었다.
+
+- **Location**: `internal/hook/security/ast_grep.go:207-215`
+- **Category**: 성능 — 메모리 압박
+- **Severity**: Warning (v2.14 blocking은 아니며 v2.15 backlog로 defer)
+- **Reviewer Note**: "세마포어 획득이 goroutine 내부에서 일어남 → N개 파일이면 N개 goroutine 즉시 생성, 세마포어는 `NumCPU()*2`만 동시 실행. 대용량 파일셋(수천 개)에서 goroutine object 메모리 압박."
+- **Reference Pattern**: MX validator(`internal/hook/mx/validator.go:513`)는 `sem <- struct{}{}` 획득이 `go func()` 호출 **이전**에 실행되어 동시 goroutine 수가 세마포어 용량과 동일.
+
+## §2. Baseline (현재 동작)
+
+### 2.1 현재 ScanMultiple 패턴 (simplified)
+
+```
+for _, file := range files {
+    wg.Add(1)
+    go func(f string) {
+        sem <- struct{}{}
+        defer func() { <-sem }()
+        defer wg.Done()
+        res, err := Scan(ctx, f, rules)
+        // ...
+    }(file)
+}
+wg.Wait()
+```
+
+### 2.2 MX validator 차이 (post-SPEC-UTIL-001)
+
+```
+for _, file := range files {
+    sem <- struct{}{}  // outside go func
+    wg.Add(1)
+    go func(f string) {
+        defer func() { <-sem }()
+        defer wg.Done()
+        analyzeFile(f, ...)
+    }(file)
+}
+wg.Wait()
+```
+
+### 2.3 메모리 영향 추정
+
+- Go goroutine 초기 stack: ~2KB (runtime/runtime2.go `_StackMin`)
+- 10,000 파일 × 2KB = ~20MB 추가 heap pressure (GC 스캔 대상)
+- 세마포어 블록 시 goroutine은 gopark → M 반환하지만 goroutine object는 heap에 유지
+- Windows post-tool-use 훅에서 10k+ 파일 프로젝트의 저장 빈도가 높을 경우 누적 부담
+
+### 2.4 AC-UTIL-002-07 검증 gap
+
+SPEC-UTIL-002의 `TestScanMultiple_SemaphoreBound` 테스트는 `Scan` 내부에서 atomic counter를 increment/decrement하여 **동시 실행 중인 `Scan` 호출 수**의 상한을 확인한다. 그러나 실제 **생성된 goroutine 수**(세마포어에서 블록 중인 것 포함)는 측정하지 않으므로, pre-fix 패턴도 이 테스트를 통과한다.
+
+## §3. Approach
+
+세마포어 획득 위치를 `go func()` 호출 **외부로** 이동한다. 이렇게 하면 for 루프(생산자)가 세마포어 슬롯 확보 시까지 블록되어, 동시 생성 goroutine 수가 세마포어 용량(`NumCPU()*2`)으로 자동 제한된다. `defer <-sem`은 goroutine 내부에 유지되어 `Scan` 완료 후 해제 타이밍은 변경되지 않는다.
+
+### 3.1 변경 Diff 개요
+
+```
+ for _, file := range files {
++    sem <- struct{}{}
+     wg.Add(1)
+     go func(f string) {
+-        sem <- struct{}{}
+         defer func() { <-sem }()
+         defer wg.Done()
+         // ...
+     }(file)
+ }
+```
+
+### 3.2 검증 전략
+
+- **Peak goroutine counter shim**: `ScanMultiple` 진입 전 `runtime.NumGoroutine()` baseline 기록, atomic counter로 스폰/종료 카운트, 1000-file fixture로 peak 관찰
+- **Backward-compat smoke**: 기존 `TestScanMultiple_SemaphoreBound` 회귀 없음 확인
+- **Benchmark regression guard**: `BenchmarkScanMultiple_1kFiles` 처리량 ±5% 이내 유지
+
+## §4. References
+
+- v2.14 `manager-quality` 멀티관점 리뷰 보고서 (Warning — PERFORMANCE 섹션)
+- SPEC-UTIL-002 §3 (ast-grep 통합 스코프)
+- SPEC-UTIL-001 §4.2 (MX validator worker pool 세마포어 계약, `validator.go:513`)
+- Go runtime `sync.WaitGroup` + buffered channel semaphore idiom (stdlib test 예시 `runtime/pprof/pprof_test.go`)

--- a/.moai/specs/SPEC-UTIL-004/spec.md
+++ b/.moai/specs/SPEC-UTIL-004/spec.md
@@ -1,0 +1,128 @@
+---
+id: SPEC-UTIL-004
+title: "ast-grep ScanMultiple Goroutine Spawn Pattern Alignment"
+version: "0.1.0"
+status: draft
+created: 2026-04-24
+updated: 2026-04-24
+author: MoAI v2.15 Backlog Writer
+priority: P2 Medium
+phase: "v2.15 — Utility Performance Backlog"
+module: "internal/hook/security/"
+dependencies: []
+related_problem: [IMP-V3U-022]
+related_pattern: []
+related_principle: []
+related_decision: []
+related_theme: "v2.15 Utility Performance"
+breaking: false
+bc_id: []
+lifecycle: spec-anchored
+tags: "astgrep, goroutine, semaphore, performance"
+---
+
+# SPEC-UTIL-004: ast-grep ScanMultiple Goroutine Spawn Pattern Alignment
+
+## HISTORY
+
+| Version | Date | Author | Description |
+|---------|------|--------|-------------|
+| 0.1.0 | 2026-04-24 | MoAI v2.15 Backlog Writer | Initial draft. v2.14 `manager-quality` 멀티관점 코드 리뷰에서 발견된 Warning 등급 성능 이슈(PERFORMANCE, `internal/hook/security/ast_grep.go:207-215`). SPEC-UTIL-002 머지 이후 착수 가능. Non-breaking, public API surface unchanged. |
+
+---
+
+## 1. Goal (목적)
+
+`ast_grep.go` `ScanMultiple`의 goroutine 스폰 패턴을 MX validator(`internal/hook/mx/validator.go:513`) 패턴에 정렬하여, 대용량 파일셋(수천 개)에서 N개 goroutine이 즉시 생성되던 기존 동작을 동시 실행 상한(`runtime.NumCPU()*2`)과 동일한 수의 goroutine 수로 제한한다. 세마포어 획득 위치를 `go func()` 내부에서 외부로 이동하여 goroutine object 메모리 압박을 제거하며, 기존 세마포어 실행 상한 보증은 그대로 유지된다.
+
+## 2. Scope (범위)
+
+### 2.1 In Scope
+
+- `internal/hook/security/ast_grep.go`의 `ScanMultiple` 스폰 루프 변경 (라인 207-215 범위)
+- 세마포어 `sem <- struct{}{}` 획득을 `go func()` 호출 **이전**으로 이동
+- `defer <-sem`은 goroutine 내부 유지 (기존 패턴 그대로)
+- 1000-file synthetic fixture 기반 peak goroutine count 측정 테스트 추가
+
+### 2.2 Out of Scope
+
+- Public API 표면 변경 금지 (`ScanMultiple` 시그니처, 반환 타입, 에러 계약 불변)
+- `ast_grep.go`의 다른 함수(`Scan`, `scanFile` 등) 수정 금지
+- 세마포어 용량(`runtime.NumCPU()*2`) 변경 금지 — 실행 상한 정책은 유지
+- 워커 풀 재설계(채널 기반 worker pool 도입 등) 금지 — v3.0 breaking 이슈
+
+## 3. Environment (환경)
+
+### 3.1 현재 코드 상태
+
+`ast_grep.go:207-215` (pre-fix):
+
+```
+for _, file := range files {
+    wg.Add(1)
+    go func(f string) {
+        sem <- struct{}{}       // ← 세마포어 획득이 goroutine 내부
+        defer func() { <-sem }()
+        defer wg.Done()
+        // ... Scan 호출 ...
+    }(file)
+}
+```
+
+- N개 파일 → N개 goroutine 즉시 생성
+- 세마포어는 `NumCPU()*2`만 동시 `Scan` 실행 허용
+- 나머지 goroutine은 세마포어 채널에서 블록 대기 (goroutine object 메모리 할당됨)
+- 10k 파일 × ~2KB goroutine stack → 약 20MB 피크 메모리 압박
+
+### 3.2 MX validator 대비 (reference pattern)
+
+`internal/hook/mx/validator.go:513` (post-SPEC-UTIL-001, 현재 main):
+
+```
+for _, file := range files {
+    sem <- struct{}{}           // ← 세마포어 획득이 go 호출 이전
+    wg.Add(1)
+    go func(f string) {
+        defer func() { <-sem }()
+        defer wg.Done()
+        // ... analyzeFile 호출 ...
+    }(file)
+}
+```
+
+- 동시 goroutine 수 = 세마포어 용량 = `NumCPU()*2`
+- 생산자(for 루프)가 세마포어에서 블록되어 goroutine 생성 속도 조절
+
+### 3.3 v2.14 AC-UTIL-002-07 검증 gap
+
+SPEC-UTIL-002의 `AC-UTIL-002-07` (TestScanMultiple_SemaphoreBound)는 **활성 `Scan` 호출 수**만 검증하며, 실제 **생성된 goroutine 수**는 검증하지 않는다. 따라서 pre-fix 패턴도 기존 테스트를 통과한다.
+
+## 4. Requirements (요구사항, EARS)
+
+- **REQ-UTIL-004-001** (Ubiquitous): `ScanMultiple`은 세마포어 획득(`sem <- struct{}{}`)을 `go func(...)` 호출 **이전**에 실행해야 한다.
+- **REQ-UTIL-004-002** (Ubiquitous): `defer <-sem`은 goroutine 내부에 유지해야 한다. 해제 타이밍은 기존 계약(`Scan` 호출 완료 후)과 동일하게 보전된다.
+- **REQ-UTIL-004-003** (Event-Driven): 1000-file synthetic fixture를 `ScanMultiple`에 주입했을 때, atomic counter shim이 관찰한 peak goroutine count는 `runtime.NumCPU()*2` 이하여야 한다 (예: `NumCPU=4` 환경에서 peak ≤ 8).
+- **REQ-UTIL-004-004** (Ubiquitous): 변경은 non-breaking이다. `ScanMultiple`의 시그니처, 반환 타입, 에러 계약, 공개 식별자 surface는 byte-identical이어야 한다.
+
+## 5. Acceptance Criteria (수락 기준)
+
+- **AC-UTIL-004-01**: 1000-file synthetic fixture + atomic counter shim 조합으로 `TestScanMultiple_PeakGoroutineBound` 추가. `NumCPU=4` 환경에서 peak goroutine count ≤ 8 관찰.
+- **AC-UTIL-004-02**: 기존 `TestScanMultiple_SemaphoreBound` (v2.14 AC-UTIL-002-07) 통과 유지. 활성 `Scan` 호출 수 상한 검증은 회귀 없음.
+- **AC-UTIL-004-03**: apigen snapshot 도구로 `internal/hook/security/` 공개 식별자 surface가 pre-fix와 byte-identical임을 확인.
+
+## 6. Constraints (제약)
+
+- Non-breaking: API 시그니처, 에러 타입, JSON 출력 스키마 전부 불변
+- stdlib only: `sync`, `runtime`, `sync/atomic` 사용. 새로운 외부 의존성 금지
+- SPEC-UTIL-002 머지 완료 후 착수 (현재 `release/v2.14.0` 브랜치에서 머지 대기)
+- Windows/macOS/Linux 3개 플랫폼 CI 모두 통과해야 함
+
+## 7. Risks (위험)
+
+- **R1 (저위험)**: 세마포어 획득 위치 변경으로 `ScanMultiple` 진입 지연 가능 (생산자가 세마포어 대기). Mitigation: 기존 MX validator에서 이미 검증된 패턴이며 동일 코드에서 사용 중. 성능 회귀 없음을 `BenchmarkScanMultiple_1kFiles`로 확인.
+
+## 8. Dependencies (의존성)
+
+- **Blocked by**: 없음 (SPEC-UTIL-002는 `release/v2.14.0`에서 머지 대기, v2.15 착수 시점에는 main 반영됨)
+- **Blocks**: 없음
+- **Related**: SPEC-UTIL-002 (ast-grep 통합 원본), SPEC-UTIL-001 §4.2 (MX validator 세마포어 패턴 reference)

--- a/.moai/specs/SPEC-UTIL-005/research.md
+++ b/.moai/specs/SPEC-UTIL-005/research.md
@@ -1,0 +1,68 @@
+# SPEC-UTIL-005 Research Notes
+
+## §1. 배경 (v2.14 Review Finding)
+
+v2.14.0 Phase 3.2 완료 후 `manager-quality` 멀티관점 코드 리뷰에서 다음 항목이 **Warning — PERFORMANCE** 등급으로 제기되었다.
+
+- **Location**: `internal/hook/quality/astgrep_gate.go:29-41` (walkSourceFiles), 호출부 `RunAstGrepGateV2`
+- **Category**: 성능 — 불필요한 I/O 및 CPU 반복
+- **Severity**: Warning (v2.14 blocking은 아니며 v2.15 backlog로 defer)
+- **Reviewer Note**: "`walkSourceFiles(projectDir)`가 `RunAstGrepGateV2` 호출마다 프로젝트 전체 디렉토리 트리를 재귀 탐색. Post-tool-use 훅은 파일 저장 시마다 트리거되므로 대형 모노레포(~10k 파일)에서 매 저장마다 전체 스캔 비용 누적."
+- **Approach Hint**: "git diff 기반 changed-files only 또는 결과 캐싱. hook payload에 changedFiles 제공 시 활용."
+
+## §2. Baseline (현재 비용 구조)
+
+### 2.1 현재 동작
+
+- `filepath.WalkDir(projectDir, ...)` 전체 트리 재귀
+- 각 entry마다 exclusion check (vendor, node_modules, .git, ... — SPEC-UTIL-002 §3 규칙)
+- source-file 필터(확장자 기반) + suppression pairing 수집
+
+### 2.2 경험적 비용 (측정 필요, 현 시점 가정치)
+
+| 파일 수 | 추정 소요시간 (SSD, macOS) |
+|---------|-----------------------|
+| 500 | ~2ms |
+| 5,000 | ~20ms |
+| 10,000 | ~40-80ms |
+| 50,000 (대형 monorepo) | ~200-500ms |
+
+- Post-tool-use 훅이 활발한 개발 세션(분당 5-10회 저장)에서 10k-file 기준 누적 ~200-800ms/분
+- 실제 변경된 파일은 통상 1-5개 → 99%의 파일은 매번 무의미하게 스캔됨
+
+### 2.3 Hook payload 구조 확인 포인트
+
+`internal/hook/payload.go`(혹은 유사 파일)에 `PostToolUsePayload { ChangedFiles []string; ... }` 형태로 필드가 존재하는지 Plan 단계에서 재확인 필요. 존재하지 않는 경우 Options 섹션의 Option B로 fallback.
+
+## §3. Options
+
+### Option A — hook payload의 changedFiles 활용 (**preferred**)
+
+- hook runtime이 이미 변경 파일 리스트를 알고 있음 → `RunAstGrepGateV2(ctx, projectDir, changedFiles)` 형태로 전달
+- full scan 대비 99% I/O 제거
+- Risk: payload의 정확성에 의존. Claude Code 측에서 누락 발생 시 탐지 불가 → `changedFiles == nil` 가드로 폴백
+
+### Option B — git diff --name-only HEAD (fallback)
+
+- `git diff --name-only HEAD` + `git ls-files --others --exclude-standard` 조합으로 changed + untracked 산출
+- 장점: hook payload 독립 — 어떤 훅 트리거에서도 동작
+- 단점: 외부 프로세스 exec 비용 (~10-30ms), stash/partial index 상태 처리 복잡
+- Windows/Linux git 경로 normalization 추가 필요
+
+### Option C — 파일 mtime 기반 결과 캐싱 (**rejected**)
+
+- staleness 위험: 외부 에디터/포매터가 파일 수정 시 캐시 무효화 신호 없음
+- 동일 파일이 여러 훅 호출 간 변경되어도 mtime 해상도 한계(초 단위)로 놓칠 가능성
+
+### 3.1 결정: Option A + Option B 복합
+
+- Primary: hook payload의 changedFiles 사용
+- Secondary fallback: payload nil/empty 시 기존 full scan 유지 (backward-compat)
+- Git diff는 v3.0 이슈로 defer (현재 SPEC 범위 밖)
+
+## §4. References
+
+- v2.14 `manager-quality` 멀티관점 리뷰 보고서 (Warning — PERFORMANCE 섹션)
+- SPEC-UTIL-002 §3 (walkSourceFiles 원본 + exclusion 규칙)
+- SPEC-UTIL-003 (Phase 3.3 quality gate 통합 테스트 — incremental path 회귀 가드 재사용 가능)
+- `internal/hook/payload.go` 혹은 대응 훅 paylaod 정의 (Plan 단계에서 재확인)

--- a/.moai/specs/SPEC-UTIL-005/spec.md
+++ b/.moai/specs/SPEC-UTIL-005/spec.md
@@ -1,0 +1,124 @@
+---
+id: SPEC-UTIL-005
+title: "walkSourceFiles Incremental Scan"
+version: "0.1.0"
+status: draft
+created: 2026-04-24
+updated: 2026-04-24
+author: MoAI v2.15 Backlog Writer
+priority: P2 Medium
+phase: "v2.15 — Utility Performance Backlog"
+module: "internal/hook/quality/"
+dependencies: []
+related_problem: [IMP-V3U-023]
+related_pattern: []
+related_principle: []
+related_decision: []
+related_theme: "v2.15 Utility Performance"
+breaking: false
+bc_id: []
+lifecycle: spec-anchored
+tags: "hook, quality, walkSourceFiles, incremental, performance, monorepo"
+---
+
+# SPEC-UTIL-005: walkSourceFiles Incremental Scan
+
+## HISTORY
+
+| Version | Date | Author | Description |
+|---------|------|--------|-------------|
+| 0.1.0 | 2026-04-24 | MoAI v2.15 Backlog Writer | Initial draft. v2.14 `manager-quality` 멀티관점 리뷰 Warning 등급(PERFORMANCE, `internal/hook/quality/astgrep_gate.go:29-41`). Post-tool-use 훅 트리거마다 전체 트리 재귀 탐색 문제. SPEC-UTIL-002 머지 이후 착수 가능. Non-breaking (changedFiles optional). |
+
+---
+
+## 1. Goal (목적)
+
+`walkSourceFiles`의 full-tree 재귀 탐색 비용을 incremental scan으로 전환한다. `RunAstGrepGateV2`가 post-tool-use 훅으로 파일 저장마다 트리거될 때, 전체 프로젝트 디렉토리(`filepath.WalkDir(projectDir)`)를 매번 순회하는 대신 **hook payload에 이미 포함된 `changedFiles`** 리스트를 primary source로 활용한다. changedFiles가 비어있거나 제공되지 않을 경우에만 기존 full scan으로 폴백하여 backward compatibility를 보장한다.
+
+## 2. Scope (범위)
+
+### 2.1 In Scope
+
+- `internal/hook/quality/astgrep_gate.go`의 `walkSourceFiles` 함수 시그니처 확장 (optional changedFiles 파라미터)
+- `RunAstGrepGateV2` 함수가 hook payload의 changedFiles를 `walkSourceFiles`로 전달하도록 연결
+- Backward-compatible: changedFiles가 nil 또는 empty이면 기존 full scan 동작
+- 10k-file monorepo fixture 기반 benchmark 추가 및 회귀 가드
+
+### 2.2 Out of Scope
+
+- Hook payload 스키마 변경 금지 — `changedFiles` 필드는 이미 존재, 추가/제거 없음
+- Git 통합 자동화(`git diff --name-only`) 금지 — hook payload가 이미 신뢰 가능한 source
+- 파일 mtime 기반 결과 캐싱 금지 — staleness 위험
+- Symlink / submodule 동작 변경 금지 — SPEC-UTIL-002의 기존 exclusion 규칙 재사용
+- `walkSourceFiles`의 suppression pairing 로직 자체는 수정 없음 (입력 범위만 축소)
+
+## 3. Environment (환경)
+
+### 3.1 현재 코드 상태
+
+`astgrep_gate.go:29-41` (simplified):
+
+```
+func walkSourceFiles(projectDir string) ([]string, error) {
+    var files []string
+    err := filepath.WalkDir(projectDir, func(path string, d fs.DirEntry, err error) error {
+        // ... exclusion 규칙 (vendor, node_modules, .git 등) ...
+        if isSourceFile(path) {
+            files = append(files, path)
+        }
+        return nil
+    })
+    return files, err
+}
+
+func RunAstGrepGateV2(ctx context.Context, projectDir string, ...) error {
+    files, err := walkSourceFiles(projectDir)
+    // ... lint ...
+}
+```
+
+### 3.2 비용 분석
+
+- `filepath.WalkDir`: O(전체 파일 수), SSD에서도 10k 파일 기준 ~30-80ms
+- Post-tool-use 훅은 파일 저장 이벤트마다 트리거 → 활발한 개발 세션에서 분당 수십 회 호출 가능
+- 대형 모노레포(10k+ 파일): 누적 CPU 소비 무시 불가
+- 그러나 **실제 변경된 파일은 1-5개**가 전형적 → 99% 파일은 매번 무의미하게 스캔됨
+
+### 3.3 Hook payload의 changedFiles 필드
+
+post-tool-use 훅 payload 스키마(`internal/hook/payload.go`)에는 이미 `changedFiles []string` 필드가 존재하지만, `RunAstGrepGateV2`는 이를 사용하지 않고 full scan으로 덮어쓴다.
+
+## 4. Requirements (요구사항, EARS)
+
+- **REQ-UTIL-005-001** (Ubiquitous): `walkSourceFiles`는 optional `changedFiles []string` 파라미터를 수용해야 한다 (variadic 또는 options struct 중 결정, 구현 단계).
+- **REQ-UTIL-005-002** (State-Driven): `changedFiles`가 nil 또는 empty이면 `walkSourceFiles`는 기존 full scan 동작(`filepath.WalkDir`)을 수행해야 한다.
+- **REQ-UTIL-005-003** (State-Driven): `changedFiles`가 non-empty이면 `walkSourceFiles`는 해당 경로만 source-file 필터링 + suppression pairing 검사를 수행해야 하며, 전체 트리 순회를 하지 않아야 한다.
+- **REQ-UTIL-005-004** (Ubiquitous): `RunAstGrepGateV2` 시그니처에 changedFiles를 전달할 수 있는 수단(variadic 또는 options struct)을 추가해야 한다. 기존 caller(변경 안 한 경우) 동작 유지.
+- **REQ-UTIL-005-005** (Event-Driven): 10k-file synthetic monorepo fixture에 대해, full scan baseline 대비 changed=5 files incremental scan의 소요시간이 90% 이상 감소해야 한다.
+- **REQ-UTIL-005-006** (Ubiquitous): 변경은 non-breaking이다. 기존 `walkSourceFiles(projectDir)` / `RunAstGrepGateV2(ctx, projectDir, ...)` 호출은 동일한 결과를 반환해야 한다.
+
+## 5. Acceptance Criteria (수락 기준)
+
+- **AC-UTIL-005-01**: `BenchmarkWalkSourceFiles_10kFullScan` baseline 벤치마크 추가, CI metric으로 등록 (회귀 탐지용).
+- **AC-UTIL-005-02**: `BenchmarkWalkSourceFiles_5ChangedFiles_IncrementalScan` 추가, 소요시간 < 100ms (10k-file fixture 환경).
+- **AC-UTIL-005-03**: `TestWalkSourceFiles_BackwardCompat_NilChangedFiles` 추가. changedFiles nil일 때 full scan 결과가 pre-fix와 동일함을 확인.
+- **AC-UTIL-005-04**: `TestRunAstGrepGateV2_IncrementalPath` 추가. 10k-file fixture + changedFiles=["a.go", "b.go"] → lint는 해당 2개 파일에 대해서만 실행되고, 나머지 9998개 파일은 참조되지 않음 (FS access audit hook으로 검증).
+
+## 6. Constraints (제약)
+
+- Non-breaking: 기존 caller, hook payload 스키마, JSON 출력 포맷 전부 불변
+- Hook payload의 `changedFiles`는 이미 존재 → 신규 필드 추가 없음
+- SPEC-UTIL-002의 exclusion 규칙(`vendor/`, `node_modules/`, `.git/`, symlink 무시 등) 재사용
+- Windows/macOS/Linux 3개 플랫폼에서 동일하게 동작 (경로 구분자 정규화 필수)
+
+## 7. Risks (위험)
+
+- **R1 (중위험)**: Hook payload의 changedFiles가 신뢰할 수 없는 경우 (uncommitted/stash 상태) → suppression pairing 누락 가능. **Mitigation**: hook payload의 changedFiles를 primary source로 신뢰하되, payload 자체가 nil/empty일 때만 full scan 폴백. git 외부 상태 처리는 v3.0 이슈로 defer.
+- **R2 (저위험)**: Symlink / submodule edge case에서 changedFiles 경로가 symlink 타깃을 가리킬 수 있음. **Mitigation**: SPEC-UTIL-002의 exclusion 규칙을 incremental path 내부에서도 동일 적용.
+- **R3 (저위험)**: changedFiles 경로가 projectDir 밖을 가리키는 경우 보안 이슈. **Mitigation**: `filepath.Rel(projectDir, changedFile)` + `strings.HasPrefix(rel, "..")` 검사로 escape 방지.
+
+## 8. Dependencies (의존성)
+
+- **Blocked by**: SPEC-UTIL-002 Phase 3.2 구현 완료 (현재 `release/v2.14.0`에서 머지 대기). v2.15 착수 시점에는 main 반영됨
+- **Blocks**: 없음
+- **Related**: SPEC-UTIL-002 §3 (exclusion 규칙 원본), SPEC-UTIL-004 (동일 `internal/hook/` 트리 성능 backlog)

--- a/.moai/specs/SPEC-UTIL-006/research.md
+++ b/.moai/specs/SPEC-UTIL-006/research.md
@@ -1,0 +1,135 @@
+# SPEC-UTIL-006 Research Notes
+
+## §1. 배경 (v2.14 Review Finding)
+
+v2.14.0 Phase 3.1 완료 후 `manager-quality` 멀티관점 코드 리뷰에서 다음 항목이 **Warning — QUALITY + PERFORMANCE** 등급으로 제기되었다.
+
+- **Location**: `internal/hook/mx/validator.go:196-223` (analyzeFile 함수)
+- **Category**: 성능 — 중복 파싱 + 아키텍처 관심사 (단일 파일 내 AST를 매번 재생성)
+- **Severity**: Warning (v2.14 blocking은 아니며 v2.15 backlog로 defer)
+- **Reviewer Note**: "`analyzeFile`이 한 파일 내 모든 exported 함수에 대해 `complexity.Measure`를 순차 호출. 각 호출이 tree-sitter 파싱 O(파일크기)을 반복 수행 → 20 함수/파일이면 동일 파일을 20번 파싱."
+- **Approach Hint**: "파일당 단 한 번 파싱 후 함수별 쿼리만 반복."
+
+## §2. Baseline (호출 경로 & 비용)
+
+### 2.1 현재 호출 경로
+
+```
+ValidateFiles (validator.go:500+)
+  → worker goroutine (세마포어 bound)
+    → analyzeFile (validator.go:196)
+      → extractFunctions  (regex 기반, 빠름)
+      → for each exported func:
+          complexity.Measure(lang, content, fn.Name, fn.StartLine)
+            → measure_cgo.go:
+                sitter.NewParser()     # 매번 생성
+                parser.SetLanguage(...)
+                parser.Parse(nil, content)   # 파일 전체 파싱 O(n)
+                // ... 쿼리 매칭 ...
+                tree.Close()
+```
+
+### 2.2 측정 기반 비용 추정 (SPEC-UTIL-001 `complexity_test.go` 기준)
+
+| 파일 크기 | 함수 수 | 파싱 1회 | 현재 (N파싱) | 목표 (1파싱+N쿼리) |
+|-----------|---------|----------|--------------|---------------------|
+| 5 KB | 10 | ~2ms | ~20ms | ~4-5ms |
+| 10 KB | 20 | ~4ms | ~80ms | ~8-10ms |
+| 50 KB | 50 | ~20ms | ~1000ms | ~30-40ms |
+
+- 파싱은 파일 크기 O(n) 지배적, 쿼리 매칭은 tree walk O(nodes)로 상대적으로 저렴
+- 큰 파일(50KB+)에서 비선형 악화, 리포지토리 전체 MX 스캔 시 심각
+
+### 2.3 1 MiB content cap (SPEC-UTIL-001 §4.2 확정)
+
+- `Measure`는 `len(content) > 1<<20` 시 `Result{Supported: false}` + sentinel error 반환
+- `ParseFile`은 이 검증을 1회 수행, `MeasureWithTree`는 pre-validated 전제
+
+## §3. Approach
+
+### 3.1 API 설계
+
+```
+// complexity/parse.go (new)
+type Tree struct {
+    lang    string
+    native  *sitter.Tree   // cgo opaque handle
+    content []byte         // for span extraction
+}
+
+func ParseFile(lang string, content []byte) (*Tree, error) {
+    if len(content) > 1<<20 {
+        return nil, ErrContentTooLarge
+    }
+    // ... sitter.NewParser + Parse ...
+    t := &Tree{lang: lang, native: nativeTree, content: content}
+    runtime.SetFinalizer(t, func(t *Tree) { t.native.Close() })
+    return t, nil
+}
+
+func (t *Tree) Close() { ... }  // deterministic cleanup
+
+// complexity/measure.go (new public API)
+func MeasureWithTree(lang string, tree *Tree, funcName string, startLine int) (Result, error) {
+    if tree.lang != lang {
+        return Result{}, ErrLangMismatch
+    }
+    // ... 기존 쿼리 매칭 로직 재사용, parser setup 생략 ...
+}
+
+// complexity/measure.go (existing, now delegating)
+func Measure(lang string, content []byte, funcName string, startLine int) (Result, error) {
+    t, err := ParseFile(lang, content)
+    if err != nil {
+        return Result{}, err
+    }
+    defer t.Close()
+    return MeasureWithTree(lang, t, funcName, startLine)
+}
+```
+
+### 3.2 analyzeFile 리팩토링
+
+```
+func analyzeFile(path string, ...) ([]Violation, error) {
+    content, _ := os.ReadFile(path)
+    funcs := extractFunctions(content)
+
+    lang := detectLang(path)
+    tree, err := complexity.ParseFile(lang, content)
+    if err == complexity.ErrContentTooLarge {
+        // skip complexity, keep fan-in checks
+    } else if err != nil {
+        return nil, err
+    } else {
+        defer tree.Close()
+    }
+
+    for _, fn := range funcs {
+        if tree != nil {
+            res, _ := complexity.MeasureWithTree(lang, tree, fn.Name, fn.StartLine)
+            // ...
+        }
+    }
+}
+```
+
+### 3.3 Tree 객체 lifecycle
+
+- **Primary**: `defer tree.Close()` in `analyzeFile` — deterministic cleanup
+- **Safety net**: `runtime.SetFinalizer` — defer 누락이나 panic 시에도 native 메모리 회수
+- **Re-Close idempotent**: `Close()`는 double-call 안전해야 함 (`atomic.Bool` flag 또는 nil 체크)
+
+## §4. Measurement Targets
+
+- **Baseline**: 20 함수 × 10KB Go fixture, pre-cache 구조 기준 ~200ms (벤치마크 결과는 런타임 측정 필요)
+- **Target**: 파일당 1회 파싱으로 ~40ms 이하 (80% 감소)
+- **Validation**: `BenchmarkAnalyzeFile_BeforeCache` vs `BenchmarkAnalyzeFile_WithCache` 동일 fixture, `go test -bench=AnalyzeFile -benchmem` 결과 비교
+
+## §5. References
+
+- v2.14 `manager-quality` 멀티관점 리뷰 보고서 (Warning — QUALITY + PERFORMANCE 섹션)
+- SPEC-UTIL-001 §4.2 (tree-sitter complexity 패키지 원본 + 1 MiB cap 규약)
+- SPEC-UTIL-001 §4.5 (5+11 언어 지원 범위 — 본 SPEC에서도 동일 유지)
+- `measure_cgo.go` 현재 구조 (SPEC-UTIL-001 구현, `release/v2.14.0` 머지 대기)
+- `github.com/smacker/go-tree-sitter` Tree/Parser lifecycle 문서

--- a/.moai/specs/SPEC-UTIL-006/spec.md
+++ b/.moai/specs/SPEC-UTIL-006/spec.md
@@ -1,0 +1,128 @@
+---
+id: SPEC-UTIL-006
+title: "analyzeFile Tree-sitter Parse Cache"
+version: "0.1.0"
+status: draft
+created: 2026-04-24
+updated: 2026-04-24
+author: MoAI v2.15 Backlog Writer
+priority: P2 Medium
+phase: "v2.15 — Utility Performance Backlog"
+module: "internal/hook/mx/, internal/hook/mx/complexity/"
+dependencies: []
+related_problem: [IMP-V3U-024]
+related_pattern: []
+related_principle: []
+related_decision: []
+related_theme: "v2.15 Utility Performance"
+breaking: false
+bc_id: []
+lifecycle: spec-anchored
+tags: "mx, tree-sitter, cache, performance"
+---
+
+# SPEC-UTIL-006: analyzeFile Tree-sitter Parse Cache
+
+## HISTORY
+
+| Version | Date | Author | Description |
+|---------|------|--------|-------------|
+| 0.1.0 | 2026-04-24 | MoAI v2.15 Backlog Writer | Initial draft. v2.14 `manager-quality` 멀티관점 리뷰 Warning 등급(QUALITY + 성능, `internal/hook/mx/validator.go:196-223`). `analyzeFile`이 파일 내 각 exported 함수마다 `complexity.Measure`를 호출, 내부에서 tree-sitter 파싱을 매번 반복하는 구조. SPEC-UTIL-001 머지 이후 착수 가능. Non-breaking. |
+
+---
+
+## 1. Goal (목적)
+
+`analyzeFile`이 한 파일 내 N개 exported 함수에 대해 tree-sitter 파싱을 N번 반복하는 현 구조를 **파일당 단 한 번 파싱** 후 함수별 쿼리만 반복하는 구조로 리팩토링한다. SPEC-UTIL-001에서 도입된 `complexity.Measure` API는 그대로 유지하면서(non-breaking), 내부적으로 `ParseFile` + `MeasureWithTree` 이원화를 추가하여 tree 객체를 재사용한다. 20 함수/파일 기준 tree-sitter 파싱 비용을 1/N로 감축하고, 누적 hot-path(`validator.go:196-223`)의 CPU 소비를 80% 이상 줄인다.
+
+## 2. Scope (범위)
+
+### 2.1 In Scope
+
+- `internal/hook/mx/complexity/` 패키지에 `ParseFile(lang string, content []byte) (*Tree, error)` 공개 API 추가
+- `MeasureWithTree(lang string, tree *Tree, funcName string, startLine int) (Result, error)` 공개 API 추가
+- 기존 `Measure(lang, content, funcName, startLine)` 시그니처 유지 — 내부적으로 `ParseFile` + `MeasureWithTree` 위임으로 재구현
+- `internal/hook/mx/validator.go`의 `analyzeFile` 개조: 파일당 `ParseFile` 1회 → exported 함수마다 `MeasureWithTree` 호출
+- `Tree` 객체 lifecycle 관리 (runtime.SetFinalizer 또는 명시적 `Close` 메서드)
+- 벤치마크 추가: `BenchmarkAnalyzeFile_BeforeCache` (baseline) / `BenchmarkAnalyzeFile_WithCache`
+
+### 2.2 Out of Scope
+
+- Cross-file parse cache 금지 — 파일 간 재사용은 staleness 위험, v3.0 범위
+- 기존 `Measure` API signature 변경 금지 — backward-compat 필수
+- tree-sitter 바인딩 교체 금지 — `github.com/smacker/go-tree-sitter` 유지 (SPEC-UTIL-001 §4.1)
+- 5+11 언어 지원 범위 변경 금지 — SPEC-UTIL-001에서 확정된 범위 유지
+- `measure_nocgo.go` stub 동작 변경 금지 (cgo-off 빌드는 `Supported: false` 반환)
+
+## 3. Environment (환경)
+
+### 3.1 현재 코드 상태
+
+`validator.go:196-223` (simplified):
+
+```
+func analyzeFile(path string, ...) ([]Violation, error) {
+    content, _ := os.ReadFile(path)
+    funcs := extractFunctions(content)
+    for _, fn := range funcs {
+        res, err := complexity.Measure(lang, content, fn.Name, fn.StartLine)
+        // res.Cyclomatic, res.Supported 사용
+        if res.Cyclomatic >= 15 {
+            // WARN 위반 생성
+        }
+    }
+    // ...
+}
+```
+
+- 20 exported 함수 × tree-sitter 파싱 = 20회 반복 파싱
+- `complexity.Measure` 내부(`measure_cgo.go`)에서 매번 `sitter.NewParser()` + `parser.Parse(nil, content)` 수행
+- tree-sitter 파싱 비용: 파일 크기 O(n), 1KB당 ~0.3-0.5ms (Go 기준)
+- 10KB Go 파일 × 20 함수 = 파일당 ~60-100ms (vs 이상적 ~3-5ms)
+
+### 3.2 cgo 의존 표면
+
+- `measure_cgo.go`: `github.com/smacker/go-tree-sitter` + 언어별 서브패키지 import, 실제 파싱 수행
+- `measure_nocgo.go`: `Result{Supported: false}` stub 반환 — cgo-off 빌드 대응 (SPEC-UTIL-001 §4.2)
+
+이 SPEC은 `measure_cgo.go`를 주 대상으로 하며, `measure_nocgo.go`는 `ParseFile`/`MeasureWithTree`도 stub으로 대응 추가한다.
+
+### 3.3 1 MiB content cap (SPEC-UTIL-001 §4.2에서 확정)
+
+현재 `Measure`는 1 MiB 초과 content를 거부한다. `ParseFile`은 이 검증을 1회 수행하고, `MeasureWithTree`는 pre-validated Tree를 전제로 중복 검증을 생략한다.
+
+## 4. Requirements (요구사항, EARS)
+
+- **REQ-UTIL-006-001** (Ubiquitous): `complexity` 패키지는 `ParseFile(lang string, content []byte) (*Tree, error)` 공개 함수를 제공해야 한다. `Tree`는 tree-sitter AST를 wrapping하는 opaque 타입이다.
+- **REQ-UTIL-006-002** (Ubiquitous): `complexity` 패키지는 `MeasureWithTree(lang string, tree *Tree, funcName string, startLine int) (Result, error)` 공개 함수를 제공해야 한다.
+- **REQ-UTIL-006-003** (Ubiquitous): 기존 `Measure(lang, content, funcName, startLine)` API 시그니처는 유지되어야 하며, 내부적으로 `ParseFile` + `MeasureWithTree`로 위임 구현되어야 한다.
+- **REQ-UTIL-006-004** (Ubiquitous): `analyzeFile`은 파일당 `ParseFile`을 단 1회 호출하고, exported 함수마다 `MeasureWithTree`를 호출해야 한다.
+- **REQ-UTIL-006-005** (Ubiquitous): `Tree` 객체는 GC 시 tree-sitter native 메모리가 회수되도록 `runtime.SetFinalizer` 또는 명시적 `Close` 메서드로 관리되어야 한다. use-after-free 금지.
+- **REQ-UTIL-006-006** (Event-Driven): 20 함수 × 10KB Go 파일 fixture 기준, `BenchmarkAnalyzeFile_WithCache`는 `BenchmarkAnalyzeFile_BeforeCache` 대비 소요시간 80% 이상 감소해야 한다.
+
+## 5. Acceptance Criteria (수락 기준)
+
+- **AC-UTIL-006-01**: `BenchmarkAnalyzeFile_BeforeCache` baseline 벤치마크 기록 — 20 함수 × 10KB Go fixture, pre-cache 구조 측정.
+- **AC-UTIL-006-02**: `BenchmarkAnalyzeFile_WithCache` — baseline 대비 소요시간 80% 이상 감소 (예: baseline 200ms → target ≤ 40ms).
+- **AC-UTIL-006-03**: `TestMeasure_BackwardCompat` — SPEC-UTIL-001에서 도입된 `complexity_test.go`의 18+ 테스트가 모두 PASS. `Measure` API signature/동작 byte-identical.
+- **AC-UTIL-006-04**: `TestParseFile_MemoryCleanup` — `ParseFile`로 생성된 Tree 객체가 scope exit + `runtime.GC()` 호출 시 finalizer 실행되어 tree-sitter native 메모리가 해제됨을 확인 (테스트 가능한 hook 또는 memory profile delta 측정).
+
+## 6. Constraints (제약)
+
+- Non-breaking: 기존 `complexity.Measure` API 유지, `analyzeFile` 외부 동작 불변
+- 1 MiB content cap 유지 — `ParseFile`에서 1회 검증, `MeasureWithTree`는 pre-validated Tree 전제
+- cgo 의존: `measure_cgo.go` 대상. `measure_nocgo.go`는 `ParseFile`/`MeasureWithTree` stub도 `Supported: false` 반환 유지
+- Race detector (`go test -race`) + `go vet` 통과 필수 — tree 객체 lifecycle 검증
+- SPEC-UTIL-001 머지 완료 후 착수 (`release/v2.14.0` 머지 대기)
+
+## 7. Risks (위험)
+
+- **R1 (중위험)**: tree-sitter `Tree` 객체 lifetime 관리 오류 → use-after-free, 잠재 crash. **Mitigation**: `runtime.SetFinalizer`로 GC 시 native 해제 보장, 테스트에서 race detector + `go vet` 엄격 적용. 추가로 Tree에 대한 `Close()` 명시적 메서드도 제공하여 deterministic cleanup 경로 확보.
+- **R2 (저위험)**: 1 MiB cap 검증이 `ParseFile`과 `MeasureWithTree` 양쪽에서 중복 수행될 경우 성능 회귀. **Mitigation**: `ParseFile`에서 1회 검증 후 Tree에 flag 저장, `MeasureWithTree`는 Tree 전제로 재검증 skip.
+- **R3 (저위험)**: `MeasureWithTree`에 잘못된 `lang` 인자 전달 시 쿼리 패턴 mismatch 가능. **Mitigation**: Tree 생성 시 lang을 Tree 구조체에 저장, `MeasureWithTree`에서 `tree.lang != lang` 검증 후 error 반환.
+
+## 8. Dependencies (의존성)
+
+- **Blocked by**: SPEC-UTIL-001 Phase 3.1 구현 완료 (`release/v2.14.0` 머지 대기). v2.15 착수 시점에는 main 반영됨
+- **Blocks**: 없음
+- **Related**: SPEC-UTIL-001 §4.2 (complexity 패키지 원본 구조), SPEC-UTIL-004 (동일 `internal/hook/` 트리 성능 backlog)


### PR DESCRIPTION
## Summary

- v2.14.0 code review (`manager-quality` multi-perspective, PR #703)에서 식별된 3건 performance 후보를 v2.15 SPEC draft로 문서화
- **Draft PR**: v2.14.0 (PR #703) 머지 후 ready for review 전환 예정
- 코드 변경 없음 (SPEC 문서만 추가)

## Stacked on PR #703

Base branch는 `release/v2.14.0`입니다. PR #703이 `main`으로 머지되면 이 PR의 base를 자동으로 `main`으로 전환하거나, GitHub UI에서 rebase 수행 가능.

## SPECs (draft)

### SPEC-UTIL-004 — ast-grep ScanMultiple Goroutine Spawn Pattern Alignment
- **IMP-V3U-022** · P2 Medium · non-breaking
- 목표: 세마포어 획득을 goroutine 외부로 이동 (MX validator `validator.go:513` 패턴 정렬)
- 파일: `internal/hook/security/ast_grep.go`
- 4 REQs / 3 ACs · 128 LOC spec + 87 LOC research
- 의존: SPEC-UTIL-002 (v2.14.0 내 이미 머지됨)
- 위험: 저위험 (이미 검증된 패턴 재사용)

### SPEC-UTIL-005 — walkSourceFiles Incremental Scan
- **IMP-V3U-023** · P2 Medium · non-breaking
- 목표: post-tool-use 훅의 full-tree 재귀 탐색을 changed-files only로 전환 (monorepo 90% latency 감소 타겟)
- 파일: `internal/hook/quality/astgrep_gate.go`
- 6 REQs / 4 ACs · 124 LOC spec + 68 LOC research
- 의존: SPEC-UTIL-002
- 위험: R1 payload trust (hook의 ChangedFiles 필드 검증 필요) + R2 symlink/submodule edge case

### SPEC-UTIL-006 — analyzeFile Tree-sitter Parse Cache
- **IMP-V3U-024** · P2 Medium · non-breaking
- 목표: 파일당 tree-sitter 파싱 1회로 축소 (20 함수/파일 → 80% 시간 감소 타겟)
- 파일: `internal/hook/mx/validator.go` + `internal/hook/mx/complexity/` (ParseFile + MeasureWithTree API 추가)
- 6 REQs / 4 ACs · 128 LOC spec + 135 LOC research (API 설계 스케치 포함)
- 의존: SPEC-UTIL-001
- 위험: tree-sitter 네이티브 메모리 lifecycle (use-after-free 방지 race detector 엄격 검증 필요)

## Suggested Implementation Order

1. **SPEC-UTIL-004** (최저 위험, 가장 빠른 win) — v2.15 cycle 워밍업용
2. **SPEC-UTIL-005** (중간 위험, 최고 사용자 가시성) — 90% 성능 개선 가장 tangible
3. **SPEC-UTIL-006** (최고 위험, 최대 코드 영역) — 004/005 패턴 참고 후 착수

## Cross-SPEC Dependencies

- UTIL-004 ↔ UTIL-001 (pattern reference, not blocking)
- UTIL-005 ↔ UTIL-002 (exclusion rules 재사용, blocking)
- UTIL-006 ↔ UTIL-001 (complexity 패키지 확장, blocking)
- 모두 ↔ v2.14.0 머지 완료 (prerequisite)

## `/moai run` 시 해결 과제

- **UTIL-005**: `internal/hook/payload.go`의 `ChangedFiles` 필드 존재 여부 RED phase 검증 → 없으면 Option B (git diff fallback)로 scope 확장
- **UTIL-006**: `BenchmarkAnalyzeFile_BeforeCache` baseline 측정 후 80% 감소 AC 확정
- **UTIL-006 research.md**: 135 LOC → annotation cycle에서 trim 가능

## Non-breaking 공통 보장

- 각 SPEC은 `breaking: false`, 공개 API 표면 unchanged 선언
- UTIL-006의 `Measure` 함수는 backward compat 유지 (내부에서 ParseFile + MeasureWithTree로 위임)
- 새 의존성 없음 (모두 기존 stdlib + 기존 tree-sitter 사용)

## Source

- v2.14.0 code review: `manager-quality` multi-perspective Warnings 3건
- Parent PR #703 "Deferred (v2.15)" 섹션에 명시

## Test Plan (v2.15 `/moai run` 시 실행)

- [ ] SPEC-UTIL-004 AC-01 — peak goroutine count ≤ `runtime.NumCPU()*2` 관찰
- [ ] SPEC-UTIL-005 AC-01/02 — 10k files baseline + 5 changed files < 100ms 벤치마크
- [ ] SPEC-UTIL-005 AC-03 — backward compat (changedFiles nil → full scan)
- [ ] SPEC-UTIL-006 AC-01/02 — 파싱 시간 80% 감소 벤치마크
- [ ] SPEC-UTIL-006 AC-03 — 기존 complexity_test.go 18+ 테스트 PASS
- [ ] 각 SPEC 구현 후 `/moai review` 통과

🗿 MoAI <email@mo.ai.kr>