### PR TITLE
chore(workflow): Enhanced GitHub Flow 공식 채택 + 릴리스 자동화 인프라

### DIFF
--- a/.claude/commands/99-release.md
+++ b/.claude/commands/99-release.md
@@ -1,29 +1,44 @@
 ---
-description: "MoAI-ADK v2.x production release via GitHub Flow. Creates release/vX.Y.Z branch, version bump, CHANGELOG, PR to main, squash merge, then tag push. Tag vX.Y.Z triggers GoReleaser. All git operations delegated to manager-git. Quality failures escalate to expert-debug."
-argument-hint: "[VERSION] - optional target version (e.g., 2.1.0). If omitted, prompts for patch/minor/major selection."
+description: "MoAI-ADK production release via Enhanced GitHub Flow (CLAUDE.local.md §18). Creates release/vX.Y.Z branch, version bump, CHANGELOG (bilingual), PR to main, merge commit (NOT squash), then scripts/release.sh for tag + GoReleaser. Hotfix support via --hotfix flag. All git operations delegated to manager-git. Quality failures escalate to expert-debug."
+argument-hint: "[VERSION] [--hotfix] - optional target version (e.g., 2.1.0). If omitted, prompts for patch/minor/major selection."
 type: local
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash, AskUserQuestion, Agent, TaskCreate, TaskUpdate, TaskList, TaskGet
 disable-model-invocation: true
-version: 4.0.0
+version: 5.0.0
 metadata:
   release_target: "production"
   branch: "main"
   tag_format: "vX.Y.Z"
-  changelog_format: "korean_first"
+  changelog_format: "english_first_bilingual"
   release_notes_format: "bilingual"
   git_delegation: "required"
   quality_escalation: "expert-debug"
+  workflow_model: "enhanced-github-flow"
+  merge_strategy: "merge-commit"
+  reference_policy: "CLAUDE.local.md §18"
 ---
 
-## Release Configuration
+## Release Configuration (Enhanced GitHub Flow)
 
-- **Git workflow**: GitHub Flow with enforce_admins (direct main push blocked)
-- **Release branch**: `release/vX.Y.Z` (created from main, merged via PR)
-- **Target branch**: `main` (all releases merge to main)
-- **Tag format**: `vX.Y.Z` (standard semver, triggers GoReleaser via `.github/workflows/release.yml`)
-- **Merge strategy**: Squash merge with branch auto-delete
+- **Git workflow**: Enhanced GitHub Flow (CLAUDE.local.md §18, Gitflow 비채택)
+- **Release branch**: `release/vX.Y.Z` (main에서 분기, PR 경유 머지)
+- **Hotfix branch**: `hotfix/vX.Y.Z-*` (최신 tag에서 분기, main으로 머지)
+- **Target branch**: `main` (production releases only)
+- **Tag format**: `vX.Y.Z` (SemVer, GoReleaser trigger via `.github/workflows/release.yml`)
+- **[HARD] Merge strategy**: **Merge commit** (`gh pr merge --merge --delete-branch`) — release PR에 반드시 적용. Squash 금지 (개별 SPEC commit 보존 필수, §18.3)
+- **Tag push tool**: `./scripts/release.sh vX.Y.Z` 또는 `make release V=vX.Y.Z` (§18.8) — 수동 `git tag + push` 금지 (CHANGELOG 검증 + CI 확인 + GoReleaser watch 포함)
+- **Label 3축**: PR에 `type:*` + `priority:*` + `area:*` 필수 (§18.6)
 - **Release URL**: https://github.com/modu-ai/moai-adk/releases/tag/vX.Y.Z
-- **Binaries**: darwin-arm64, darwin-amd64, linux-arm64, linux-amd64, windows-amd64
+- **Binaries**: darwin-arm64/amd64, linux-arm64/amd64, windows-arm64/amd64 (6 assets + checksums.txt)
+
+### Tool Selection Guide (§18.8 이중 경로)
+
+| 시나리오 | 도구 | 이유 |
+|---------|------|------|
+| Patch/Minor 자동 릴리스 (CHANGELOG 이미 작성됨) | `./scripts/release.sh vX.Y.Z` | 최소 interaction, CI 확인 포함 |
+| Major release / breaking changes | `/99-release` (이 커맨드) | 완전한 리뷰 + 단계별 확인 흐름 |
+| Hotfix 긴급 대응 | `./scripts/release.sh vX.Y.Z --hotfix` | main 외 브랜치 허용, 빠른 경로 |
+| CHANGELOG 작성 + release 통합 | `/99-release` (이 커맨드) | Phase 4에서 bilingual CHANGELOG 생성 |
 
 ---
 
@@ -349,8 +364,10 @@ Agent(
 3. Wait for CI checks to pass:
    `gh pr checks --watch`
 
-4. Merge PR with squash:
-   `gh pr merge --squash --delete-branch`
+4. **[HARD] Merge PR with merge commit (NOT squash)** — Enhanced GitHub Flow §18.3 준수:
+   `gh pr merge --merge --delete-branch`
+
+   이유: release/vX.Y.Z 브랜치의 개별 commit (version bump + CHANGELOG + 필요 시 추가 fix)을 main history에 보존하여 릴리스 시점 추적 가능. Squash 시 개별 SPEC 구현 commit이 소실됨 (v2.14.0 Case Study §18.11 참조).
 
 5. Sync local main with merged result:
    ```bash
@@ -358,17 +375,38 @@ Agent(
    git pull origin main
    ```
 
-6. Check remote status: Verify if tag vX.Y.Z exists on remote (origin)
-7. Handle tag conflicts:
-   - If remote does NOT have vX.Y.Z: Create tag on current main HEAD and push
-   - If remote already has vX.Y.Z: Report situation with options
-8. Create and push tag (only if tag does NOT exist on remote):
+6. **[HARD] Tag creation via scripts/release.sh** (§18.8) — 수동 `git tag + push` 금지:
    ```bash
-   # Only execute this block if vX.Y.Z tag does NOT exist on origin
-   git tag vX.Y.Z
+   ./scripts/release.sh vX.Y.Z
+   # OR (Makefile)
+   make release V=vX.Y.Z
+   ```
+
+   스크립트가 자동으로:
+   - CHANGELOG.md 해당 버전 섹션 존재 확인
+   - CI 상태 조회 (`gh api /commits/{sha}/status`)
+   - main 브랜치 + origin 동기화 확인
+   - 기존 tag 충돌 검사 (local + remote)
+   - CHANGELOG 섹션 → annotated tag annotation 자동 추출
+   - 사용자 confirmation prompt
+   - Tag 생성 + push → GoReleaser workflow 자동 trigger
+   - GoReleaser workflow watch + GitHub Release 검증
+
+   Hotfix 경우:
+   ```bash
+   ./scripts/release.sh vX.Y.Z --hotfix  # main 외 브랜치 허용
+   ```
+
+   **Fallback** (스크립트 실패 시): manager-git이 수동 tag 생성 — 단, 반드시 CHANGELOG 검증 수행 후
+   ```bash
+   # CHANGELOG.md 에 ## [X.Y.Z] 섹션 존재 확인
+   grep "^## \[X.Y.Z\]" CHANGELOG.md
+   # Tag 생성 + push
+   git tag -a vX.Y.Z -m "vX.Y.Z — [요약]"
    git push origin vX.Y.Z
    ```
-9. Verify GoReleaser workflow triggered (tags bypass branch protection)
+
+7. Verify GoReleaser workflow triggered (tags bypass branch protection)
 
 ### Expected Output
 
@@ -670,19 +708,24 @@ Updating version files...
 
 ---
 
-## Key Rules
+## Key Rules (Enhanced GitHub Flow §18)
 
 - **Target branch**: `main` (production releases)
-- **Git workflow**: GitHub Flow with enforce_admins (direct main push blocked)
-- **Release flow**: release/vX.Y.Z branch → PR → squash merge → tag → push tag
-- **Tag format**: `vX.Y.Z` (triggers GoReleaser via release.yml)
+- **Git workflow**: Enhanced GitHub Flow (CLAUDE.local.md §18, Gitflow 비채택)
+- **[HARD] Release flow**: release/vX.Y.Z branch → PR → **merge commit** (NOT squash) → `./scripts/release.sh` → GoReleaser auto-release
+- **[HARD] Hotfix flow**: hotfix/vX.Y.Z-* branch → PR → **merge commit** → `./scripts/release.sh --hotfix` (§18.5)
+- **Tag format**: `vX.Y.Z` (SemVer, triggers GoReleaser via release.yml)
 - Tags bypass branch protection (only branch pushes are blocked)
 - Tests MUST pass to continue (85%+ coverage per package)
-- All 3 version files must be consistent
+- All 3 version files must be consistent (pkg/version, .moai/config, internal/template/templates/.moai/config)
 - **[HARD] CHANGELOG and GitHub Release: English FIRST, Korean SECOND**
+- **[HARD] Release PR: `--merge` (NOT `--squash`)** — 개별 SPEC commit 보존 (§18.3, v2.14.0 Case Study)
+- **[HARD] Tag push via `scripts/release.sh` only** — 수동 `git tag + push` 금지 (§18.8, CHANGELOG 검증 누락 방지)
 - **[HARD] ALL git operations MUST be delegated to manager-git agent**
 - **[HARD] Quality gate failures MUST be delegated to expert-debug agent**
 - **[HARD] Never `git push origin main` — always use PR merge flow**
+- **[HARD] Label 3축** (type/priority/area) PR 부착 필수 (§18.6) — Release Drafter 자동 분류용
+- **[HARD] Release Drafter draft 참조** (§18.9) — PR merge 시 자동 업데이트되는 draft를 CHANGELOG.md 작성에 활용
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -1,0 +1,92 @@
+---
+name: Release
+about: Release tracking issue (Minor/Major/Hotfix)
+title: "release: vX.Y.Z — <release theme>"
+labels: ["type:chore", "priority:P1", "area:ci"]
+assignees: []
+---
+
+## Release Plan
+
+**Version**: `vX.Y.Z`
+**Type**: [ Minor | Major | Patch | Hotfix ]
+**Target date**: <YYYY-MM-DD>
+**Release branch**: `release/vX.Y.Z` (Minor/Major only) or `hotfix/vX.Y.Z-*` (Hotfix)
+
+## Scope
+
+<!-- SPEC-IDs included in this release -->
+
+- [ ] SPEC-XXX-001: ...
+- [ ] SPEC-XXX-002: ...
+
+## Pre-Release Checklist (CLAUDE.local.md §18.8)
+
+### Code Quality
+- [ ] 모든 SPEC 구현 완료 (`status: implemented` 로 전환)
+- [ ] 51/51 (또는 전체) ACs PASS
+- [ ] `go test -race ./...` PASS (ubuntu/macos/windows CI)
+- [ ] `golangci-lint run ./...` 0 issues
+- [ ] `manager-quality` review 통과 (TRUST 5 ≥ 4/5)
+
+### Documentation
+- [ ] `CHANGELOG.md` 에 `## [X.Y.Z] - YYYY-MM-DD` 섹션 추가 (영문 + 한국어)
+- [ ] Non-breaking 선언 또는 Breaking Changes 섹션 명시
+- [ ] Detection Improvements 섹션 (UX 영향 있는 감지 변경 시)
+- [ ] Deferred items 섹션 (next minor/major 예약 항목)
+- [ ] README.md version line 업데이트 (필요 시)
+
+### Git State
+- [ ] `release/vX.Y.Z` 브랜치 또는 main 최신
+- [ ] 모든 PR merge 완료
+- [ ] 작업 트리 clean (`git status --short` empty)
+- [ ] origin/main과 동기화 (local/remote SHA 일치)
+
+### Branch Protection (admin)
+- [ ] `main` branch protection 활성화 (CI required, 1 review)
+- [ ] Force push 차단 확인
+
+## Release Execution
+
+Minor/Major Release:
+```bash
+# 1. release 브랜치에서 main으로 PR 생성 + merge commit
+gh pr merge <release-PR> --merge --delete-branch
+
+# 2. main pull + 릴리스 스크립트
+git checkout main && git pull origin main
+./scripts/release.sh vX.Y.Z
+# OR: make release V=vX.Y.Z
+```
+
+Hotfix Release:
+```bash
+# 1. main의 latest tag에서 분기
+git checkout -b hotfix/vX.Y.Z-<topic> <latest-tag>
+
+# 2. 수정 + PR + merge commit
+gh pr merge <hotfix-PR> --merge --delete-branch
+
+# 3. Release 스크립트 실행
+git checkout main && git pull origin main
+./scripts/release.sh vX.Y.Z --hotfix
+# OR: make release-hotfix V=vX.Y.Z
+```
+
+## Post-Release Checklist
+
+- [ ] GitHub Release 생성 확인 (GoReleaser 자동)
+- [ ] Release assets 5 플랫폼 업로드 확인 (darwin amd64/arm64, linux amd64/arm64, windows amd64)
+- [ ] `latest` release marker 확인
+- [ ] docs-site 4개국어 reference 페이지 업데이트 (별도 PR, `docs/vX.Y.Z-reference-sync`)
+- [ ] v2.X+1 backlog SPEC 분석 및 초안 작성 (next cycle kickoff)
+- [ ] Release announcement (선택: Discord, Twitter, blog)
+- [ ] 이 Issue close
+
+## Release Notes
+
+<!-- Post-release: 간단한 release 요약 붙여넣기 -->
+
+---
+
+**Reference**: CLAUDE.local.md §18 Enhanced GitHub Flow

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,36 +10,66 @@
 
 ## Type of Change
 
-- [ ] Bug fix (non-breaking change that fixes an issue)
-- [ ] New feature (non-breaking change that adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] Documentation update
-- [ ] Refactoring (no functional changes)
-- [ ] CI/CD changes
-- [ ] Dependencies update
+<!-- Select ONE primary type — see CLAUDE.local.md §18.6 for label 3축 체계 -->
+
+- [ ] `type:feature` — New capability (non-breaking)
+- [ ] `type:fix` — Bug fix (non-breaking)
+- [ ] `type:docs` — Documentation only
+- [ ] `type:chore` — Maintenance (dependencies, cleanup)
+- [ ] `type:ci` — CI/CD / GitHub Actions
+- [ ] `type:refactor` — Code restructuring (no behavior change)
+- [ ] `type:security` — Security fix or hardening
+- [ ] `type:test` — Test additions or improvements
+- [ ] **Breaking change** — Public API change (requires major version bump)
+
+## Merge Strategy (CLAUDE.local.md §18.3)
+
+<!-- Reviewer: use the correct `gh pr merge` flag -->
+
+- [ ] **`--squash`** (default for `feat/`, `fix/`, `chore/`, `docs/`, `plan/` branches) — WIP commit 정리
+- [ ] **`--merge`** (`release/` or `hotfix/` branches) — 릴리스 마일스톤 + 개별 SPEC commit 보존
+- [ ] **Dependabot auto-merge** (dependabot/* branches) — 자동 squash
+
+> ⚠️ Release PR (`release/vX.Y.Z → main`)은 반드시 `--merge` 사용. Squash 시 개별 feature history 손실.
 
 ## Testing
 
-- [ ] Tests pass locally (`go test ./...`)
-- [ ] Race detection passes (`go test -race ./...`)
-- [ ] Linting passes (`golangci-lint run`)
-- [ ] New tests added for new functionality
-- [ ] Coverage maintained at 85%+
+- [ ] `go test ./...` 통과
+- [ ] `go test -race ./...` (race detection) 통과
+- [ ] `golangci-lint run` 통과
+- [ ] 새 기능에 대한 테스트 추가됨
+- [ ] 커버리지 85%+ 유지
+
+## Quality Gates
+
+- [ ] CI all checks green (Lint, Test ubuntu/macos/windows, Build 5 platforms, CodeQL)
+- [ ] `@MX` tag 규율 준수 (fan_in ≥ 3 → ANCHOR, goroutine/complexity ≥ 15 → WARN, 필수 `@MX:REASON`)
+- [ ] SPEC 변경 시 frontmatter `status` 필드 적절히 업데이트 (draft → implemented)
+- [ ] SARIF / wire format 등 public contract 불변 (non-breaking 보장)
 
 ## AI Collaboration
 
-- [ ] This PR was created with AI assistance (Claude Code, Codex, or other)
-- [ ] AI-generated code has been reviewed by a human
-- [ ] AI agent name/tool noted in commit messages (Co-Authored-By)
+- [ ] AI 도구 (Claude Code, Codex 등) 협업으로 생성됨
+- [ ] AI 생성 코드가 사람에 의해 리뷰됨
+- [ ] AI agent 이름이 commit 메시지에 명시됨 (Co-Authored-By 또는 footer)
 
 ## Checklist
 
-- [ ] Code follows the project's coding standards (English comments, Go conventions)
-- [ ] Self-reviewed my own code
-- [ ] Commented hard-to-understand areas
-- [ ] Updated documentation if needed
-- [ ] No secrets or credentials in the changes
+- [ ] 프로젝트 코딩 표준 준수 (Go convention, 주석 한국어, 식별자 영어)
+- [ ] Self-review 완료
+- [ ] 이해하기 어려운 부분에 주석 추가
+- [ ] 필요 시 문서 업데이트 (README, CHANGELOG, docs-site)
+- [ ] Secrets/credentials 포함 없음
+- [ ] Branch 명명 규칙 준수 (§18.2)
 
 ## Related Issues
 
 <!-- Link related issues: Fixes #123, Refs #456 -->
+
+## Post-Merge Actions (release PR 전용)
+
+<!-- Release PR 머지 후 실행 -->
+
+- [ ] `./scripts/release.sh vX.Y.Z` 로 tag + GoReleaser 자동 실행
+- [ ] GitHub Release 생성 확인 (GoReleaser 자동)
+- [ ] docs-site 4개국어 reference 페이지 업데이트 (별도 PR)

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -115,3 +115,128 @@
 - name: dependencies
   color: "0366d6"
   description: "Dependency updates"
+
+# ============================================================================
+# Enhanced GitHub Flow 3축 체계 (CLAUDE.local.md §18.6)
+# type: / priority: / area: 접두사는 2026-04-24부터 공식 표준
+# ============================================================================
+
+# --- type:* (required, 1개 PR당 1 type) ---
+- name: "type:feature"
+  color: "1f883d"
+  description: "New feature or capability"
+
+- name: "type:fix"
+  color: "d73a4a"
+  description: "Bug fix"
+
+- name: "type:docs"
+  color: "0075ca"
+  description: "Documentation only change"
+
+- name: "type:chore"
+  color: "fbca04"
+  description: "Maintenance (dependencies, cleanup)"
+
+- name: "type:ci"
+  color: "e3d21c"
+  description: "CI/CD or GitHub Actions change"
+
+- name: "type:refactor"
+  color: "d2dae6"
+  description: "Code restructuring without behavior change"
+
+- name: "type:security"
+  color: "ee0701"
+  description: "Security fix or hardening"
+
+- name: "type:test"
+  color: "d876e3"
+  description: "Test addition or improvement"
+
+# --- priority:* (required) ---
+- name: "priority:P0"
+  color: "b60205"
+  description: "Critical — immediate response required"
+
+- name: "priority:P1"
+  color: "d93f0b"
+  description: "High — within 24 hours"
+
+- name: "priority:P2"
+  color: "fbca04"
+  description: "Medium — this sprint"
+
+- name: "priority:P3"
+  color: "85e89d"
+  description: "Low — backlog"
+
+- name: "priority:P4"
+  color: "c2c2c2"
+  description: "Icebox — deferred indefinitely"
+
+# --- area:* (required, multiple allowed for cross-cutting PRs) ---
+- name: "area:mx"
+  color: "5319e7"
+  description: "MX validator subsystem"
+
+- name: "area:astgrep"
+  color: "5319e7"
+  description: "ast-grep integration subsystem"
+
+- name: "area:lsp"
+  color: "5319e7"
+  description: "LSP subsystem"
+
+- name: "area:hooks"
+  color: "f9d0c4"
+  description: "Hook system"
+
+- name: "area:docs-site"
+  color: "0e8a16"
+  description: "docs-site (Hugo 4-locale documentation)"
+
+- name: "area:templates"
+  color: "c5def5"
+  description: "internal/template/templates/ (project templates)"
+
+- name: "area:cli"
+  color: "00add8"
+  description: "CLI commands and UX"
+
+- name: "area:config"
+  color: "d4c5f9"
+  description: "Configuration files (.moai/, .claude/)"
+
+- name: "area:workflow"
+  color: "1d76db"
+  description: "SPEC workflow (plan/run/sync)"
+
+- name: "area:ci"
+  color: "e3d21c"
+  description: "CI/CD infrastructure"
+
+- name: "area:security"
+  color: "ee0701"
+  description: "Security-related area"
+
+- name: "area:deps"
+  color: "0366d6"
+  description: "External dependencies"
+
+# --- status:* (optional, progress tracking) ---
+- name: "status:in-progress"
+  color: "ffd700"
+  description: "Currently being worked on"
+
+- name: "status:review"
+  color: "0075ca"
+  description: "In code review"
+
+- name: "status:blocked"
+  color: "d73a4a"
+  description: "Blocked on external dependency"
+
+- name: "status:needs-info"
+  color: "ffffa5"
+  description: "Waiting for additional information from reporter"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,149 @@
+# Release Drafter config (Enhanced GitHub Flow §18.9)
+#
+# 역할: PR merge 시마다 next release draft 자동 업데이트 → CHANGELOG.md 작성 보조
+# 관계: GoReleaser와 병존 (Release Drafter = preview/draft, GoReleaser = final binary release)
+#
+# 사용 흐름:
+#   1. PR merged to main → Release Drafter가 draft release 업데이트
+#   2. 릴리스 준비 시 draft release body 확인 → CHANGELOG.md에 섹션 추가 (영문+한국어)
+#   3. ./scripts/release.sh vX.Y.Z → tag push → GoReleaser가 final release 생성
+#
+# CLAUDE.local.md §18.6 label 3축 체계 준수
+
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+
+# 카테고리: type:* label 기반 분류 (§18.6 축 1)
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'type:feature'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'type:fix'
+  - title: '🔒 Security'
+    labels:
+      - 'type:security'
+  - title: '⚡️ Performance'
+    labels:
+      - 'type:performance'
+  - title: '♻️ Refactoring'
+    labels:
+      - 'type:refactor'
+  - title: '📚 Documentation'
+    labels:
+      - 'type:docs'
+  - title: '🧪 Tests'
+    labels:
+      - 'type:test'
+  - title: '⚙️ CI/CD'
+    labels:
+      - 'type:ci'
+  - title: '🔧 Chores & Maintenance'
+    labels:
+      - 'type:chore'
+      - 'dependencies'
+
+# 제외: draft/CHANGELOG-only PRs (순환 방지)
+exclude-labels:
+  - 'skip-changelog'
+  - 'status:needs-info'
+
+# 각 change entry template (PR title + number + author)
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&'
+
+# Version 자동 추정 (SemVer, §18.4 cadence 정렬)
+version-resolver:
+  major:
+    labels:
+      - 'breaking'
+      - 'type:breaking'
+  minor:
+    labels:
+      - 'type:feature'
+  patch:
+    labels:
+      - 'type:fix'
+      - 'type:security'
+      - 'type:performance'
+      - 'type:refactor'
+      - 'type:docs'
+      - 'type:test'
+      - 'type:ci'
+      - 'type:chore'
+  default: patch
+
+# 전체 Release Notes Template
+template: |
+  ## $RESOLVED_VERSION Release Notes (Draft)
+
+  > ⚠️ **이 문서는 Release Drafter가 PR merge 시마다 자동 업데이트하는 draft입니다.**
+  > 실제 릴리스 시 이 내용을 기반으로 `CHANGELOG.md`를 영문+한국어로 작성한 후 `./scripts/release.sh` 실행.
+
+  ## Changes
+
+  $CHANGES
+
+  ## Contributors
+
+  $CONTRIBUTORS
+
+  ---
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+  **Enhanced GitHub Flow**: CLAUDE.local.md §18
+
+# PR auto-labeling (type 축 자동 추론 — labeler.yml과 상호 보완)
+autolabeler:
+  - label: 'type:feature'
+    title:
+      - '/^feat(\(.+\))?!?:/i'
+    branch:
+      - '/^feat\/.+/'
+      - '/^feature\/.+/'
+  - label: 'type:fix'
+    title:
+      - '/^fix(\(.+\))?!?:/i'
+      - '/^hotfix(\(.+\))?!?:/i'
+    branch:
+      - '/^fix\/.+/'
+      - '/^hotfix\/.+/'
+  - label: 'type:docs'
+    title:
+      - '/^docs(\(.+\))?!?:/i'
+    branch:
+      - '/^docs\/.+/'
+    files:
+      - '**/*.md'
+  - label: 'type:chore'
+    title:
+      - '/^chore(\(.+\))?!?:/i'
+    branch:
+      - '/^chore\/.+/'
+  - label: 'type:ci'
+    title:
+      - '/^ci(\(.+\))?!?:/i'
+    branch:
+      - '/^ci\/.+/'
+    files:
+      - '.github/**'
+  - label: 'type:refactor'
+    title:
+      - '/^refactor(\(.+\))?!?:/i'
+    branch:
+      - '/^refactor\/.+/'
+  - label: 'type:security'
+    title:
+      - '/^(sec|security)(\(.+\))?!?:/i'
+    branch:
+      - '/^security\/.+/'
+      - '/^audit\/.+/'
+  - label: 'type:test'
+    title:
+      - '/^test(\(.+\))?!?:/i'
+    files:
+      - '**/*_test.go'
+  - label: 'breaking'
+    title:
+      - '/^[a-z]+(\(.+\))?!:/i'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,30 @@
+name: Release Drafter
+
+# Enhanced GitHub Flow §18.9 자동화
+# PR이 main에 머지될 때마다 next release의 draft notes를 자동 업데이트.
+# Draft 내용은 수동으로 CHANGELOG.md에 반영한 후 ./scripts/release.sh 실행.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, reopened, synchronize, edited]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    name: Update Release Draft
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Run Release Drafter
+        uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.moai/config/sections/git-strategy.yaml
+++ b/.moai/config/sections/git-strategy.yaml
@@ -1,4 +1,32 @@
 git_strategy:
+    # Enhanced GitHub Flow (CLAUDE.local.md §18)
+    # v2.14.0 이후 공식 채택. Gitflow 비채택 결정.
+    workflow_model: enhanced-github-flow
+    base_branch: main
+    merge_strategies:
+        feature: squash      # feat/ fix/ docs/ chore/ refactor/ plan/ → squash
+        release: merge       # release/vX.Y.Z → main: 반드시 merge commit (SPEC history 보존)
+        hotfix: merge        # hotfix/vX.Y.Z-* → main: merge commit
+        dependabot: squash   # auto-merge squash
+    branch_types:
+        feature: "feat/SPEC-"
+        fix: "fix/"
+        docs: "docs/"
+        chore: "chore/"
+        ci: "ci/"
+        refactor: "refactor/"
+        audit: "audit/"
+        release: "release/"
+        hotfix: "hotfix/"
+        plan: "plan/"
+    release_cadence:
+        patch: "as-needed (critical fix only)"
+        minor: "1-2 weeks (SPEC cluster)"
+        major: "3-6 months (breaking changes)"
+    release_tools:
+        tag_script: "scripts/release.sh"
+        make_target: "make release V=vX.Y.Z"
+        automation: "goreleaser (on tag push)"
     github_username: ""
     gitlab:
         instance_url: ""

--- a/CLAUDE.local.md
+++ b/CLAUDE.local.md
@@ -756,6 +756,249 @@ docs-site 파일을 직접 수정하는 에이전트 (`expert-frontend`, `manage
 
 ---
 
+## 18. Git Workflow — Enhanced GitHub Flow
+
+v2.14.0 릴리스 이후 공식 채택. Gitflow 대안 비교 분석 결과 (v2.14 후 세션) 이 프로젝트의 1-2명 팀 + 2일/릴리스 cadence + 단일 CLI 배포 환경에서 Gitflow의 `develop` 이중 관리 부담을 상회하는 장점이 부재. 현재 de-facto 패턴을 유지하되 **formalization + automation**으로 개선.
+
+### §18.1 브랜치 구조
+
+```
+main ──●──●──●──●──●──  (protected, 항상 배포 가능, tags 부착)
+       ↑  ↑     ↑
+       │  │     release/vX.Y.Z (며칠 이내)
+       │  │
+       │  feat/SPEC-XXX-description (1-3일)
+       │  fix/issue-NNN-description (1일)
+       │  docs/topic-description (1일)
+       │  chore/task-description (1일)
+       │  plan/vX.Y-topic (SPEC 초안 모음)
+       │
+       hotfix/vX.Y.Z-description (main의 tag에서 분기)
+```
+
+### §18.2 [HARD] 브랜치 명명 규칙
+
+| 접두사 | 용도 | 수명 | 예시 |
+|--------|------|------|------|
+| `feat/SPEC-XXX-*` | 기능 개발 (SPEC 기반) | 1-3일 | `feat/SPEC-AUTH-001-oauth2` |
+| `fix/issue-NNN-*` | 이슈 기반 버그 수정 | 1일 | `fix/issue-683-race-condition` |
+| `fix/*` | 이슈 없는 버그 수정 | 1일 | `fix/ci-lint-errcheck` |
+| `docs/*` | 문서 작업 | 1일 | `docs/v2.14-release-notes` |
+| `chore/*` | 유지보수 (의존성, cleanup) | 1일 | `chore/bump-go-1.26` |
+| `ci/*` | CI/GitHub Actions 변경 | 1일 | `ci/add-windows-runner` |
+| `refactor/*` | 리팩토링 (동작 불변) | 1-2일 | `refactor/validator-cleanup` |
+| `release/vX.Y.Z` | 릴리스 준비 (CHANGELOG, version) | 1-3일 | `release/v2.14.0` |
+| `hotfix/vX.Y.Z-*` | 프로덕션 긴급 수정 | 1일 이내 | `hotfix/v2.14.1-import-crash` |
+| `plan/vX.Y-*` | SPEC draft 모음 | 1-3일 | `plan/v2.15-util-perf-backlog` |
+| `audit/*` | 보안/품질 감사 | 1-3일 | `audit/askuserquestion-propagation` |
+
+### §18.3 [HARD] Merge Strategy
+
+각 브랜치 유형별 머지 방식 **반드시** 준수:
+
+| 머지 유형 | 전략 | gh 명령어 | 이유 |
+|-----------|------|-----------|------|
+| feature/fix/chore/docs → main | **squash** | `gh pr merge N --squash` | WIP commit 정리, 1 PR = 1 main commit |
+| release/* → main | **merge commit** ⭐ | `gh pr merge N --merge` | 릴리스 마일스톤 + 개별 SPEC commit 보존 |
+| hotfix/* → main | **merge commit** | `gh pr merge N --merge` | 긴급 변경 이력 명확성 |
+| plan/* → main | **squash** | `gh pr merge N --squash` | 초안 commit 정리 |
+| dependabot/* → main | **squash** | (auto-merge) | 단순 버전 bump |
+
+**공통 규칙**:
+- [HARD] `--delete-branch=true` 기본 (머지 후 head branch 자동 삭제)
+- [HARD] `--rebase`는 금지 (main history linear가 아니어도 OK, merge commit 보존 중요)
+- [HARD] Force push to `main` 금지 (branch protection으로 차단)
+
+### §18.4 Release Cadence 공식화
+
+| 타입 | 기준 | 주기 | 브랜치 |
+|------|------|------|--------|
+| **Patch (vX.Y.Z)** | 버그 수정만 | 필요 시 즉시 | `fix/*` 여러 개 직접 main → tag bump |
+| **Minor (vX.Y.0)** | SPEC cluster (2-4 SPECs) 또는 주요 feature | 1-2주 | `release/vX.Y.0` 경유 |
+| **Major (vX.0.0)** | Breaking changes | 3-6개월 | `release/vX.0.0` + migration guide |
+| **Hotfix (vX.Y.Z+1)** | 프로덕션 긴급 수정 | 24h 이내 | `hotfix/vX.Y.Z+1-*` → main |
+
+### §18.5 Hotfix Workflow
+
+프로덕션에서 발견된 긴급 이슈 처리:
+
+```bash
+# 1. 최신 production tag에서 분기
+git fetch origin --tags
+git checkout -b hotfix/v2.14.1-crash-on-startup v2.14.0
+
+# 2. 수정 + 테스트 (로컬)
+# ...
+
+# 3. Commit + push
+git commit -m "fix(hotfix): crash on startup when config missing (#NNN)"
+git push -u origin hotfix/v2.14.1-crash-on-startup
+
+# 4. PR 생성 (base: main)
+gh pr create --base main --title "hotfix(v2.14.1): ..." --body "..."
+
+# 5. CI green 확인 후 merge commit
+gh pr merge <PR> --merge --delete-branch
+
+# 6. Tag 생성 + push (로컬 릴리스 스크립트 사용)
+./scripts/release.sh v2.14.1 "Hotfix release"
+```
+
+### §18.6 Label 3축 체계
+
+모든 Issue/PR은 다음 3축 label 부착:
+
+**축 1: type (필수)**
+- `type:feature` — 새 기능
+- `type:fix` — 버그 수정
+- `type:docs` — 문서만 변경
+- `type:chore` — 유지보수 (의존성, 빌드 등)
+- `type:ci` — CI/CD 변경
+- `type:refactor` — 리팩토링
+- `type:security` — 보안 이슈/수정
+- `type:test` — 테스트 추가/개선
+
+**축 2: priority (필수)**
+- `priority:P0` — Critical (즉시 대응)
+- `priority:P1` — High (당일)
+- `priority:P2` — Medium (이번 sprint)
+- `priority:P3` — Low (backlog)
+- `priority:P4` — Icebox (장기 보류)
+
+**축 3: area (필수)**
+- `area:mx` — MX validator
+- `area:astgrep` — ast-grep integration
+- `area:lsp` — LSP subsystem
+- `area:hooks` — Hook system
+- `area:docs-site` — docs-site (Hugo)
+- `area:templates` — internal/template/templates/
+- `area:cli` — CLI 명령어
+- `area:config` — .moai/config/*
+- `area:workflow` — SPEC workflow
+- `area:ci` — GitHub Actions
+- `area:security` — 보안 관련
+- `area:deps` — 외부 의존성
+
+**축 4: status (선택)** — 진행 상태 추적
+- `status:in-progress` · `status:review` · `status:blocked` · `status:needs-info`
+
+### §18.7 Branch Protection Rule (GitHub)
+
+[HARD] `main` 브랜치 보호 설정 (admin 실행 필요):
+
+```bash
+gh api -X PUT /repos/modu-ai/moai-adk/branches/main/protection \
+  --input - <<'EOF'
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ["Lint", "Test (ubuntu-latest)", "Test (macos-latest)", "Test (windows-latest)", "Build (linux/amd64)", "CodeQL"]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": {
+    "dismiss_stale_reviews": true,
+    "require_code_owner_reviews": false,
+    "required_approving_review_count": 1
+  },
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "required_linear_history": false,
+  "required_conversation_resolution": true
+}
+EOF
+```
+
+[HARD] `release/*` 패턴 보호 (feature freeze 기간 안정성):
+
+```bash
+gh api -X PUT /repos/modu-ai/moai-adk/branches/release%2F*/protection \
+  --input - <<'EOF'
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ["Lint", "Test (ubuntu-latest)", "Test (macos-latest)"]
+  },
+  "allow_force_pushes": false,
+  "allow_deletions": false
+}
+EOF
+```
+
+### §18.8 Release 프로세스
+
+[HARD] 릴리스는 `scripts/release.sh` 스크립트 경유. 수동 tag push 금지 (GoReleaser 자동 릴리스와 충돌 가능).
+
+**Minor/Major Release (release 브랜치 경유)**:
+
+```bash
+# 1. release 브랜치 생성 + 작업
+git checkout -b release/v2.15.0 main
+# CHANGELOG.md, SPEC status 업데이트, docs-site update 등
+
+# 2. PR + review + merge (merge commit 전략)
+gh pr create --base main --title "release: v2.15.0" --body "..."
+gh pr merge <PR> --merge --delete-branch
+
+# 3. Tag + release (로컬 스크립트)
+git checkout main && git pull
+./scripts/release.sh v2.15.0
+# → tag 생성, push, GoReleaser 자동 실행, GitHub Release 생성
+```
+
+**Patch Release (fix 직접 main)**:
+
+```bash
+# 1. fix 브랜치에서 수정 + PR + squash merge
+# 2. main pull + tag + push (release 스크립트)
+./scripts/release.sh v2.14.1
+```
+
+### §18.9 자동화 도구
+
+이미 구성된 도구 (유지):
+- **GoReleaser** (`.goreleaser.yml` + `.github/workflows/release.yml`): tag push 시 자동 binary 빌드 + GitHub Release
+- **Dependabot** (`.github/dependabot.yml`): Go modules + GitHub Actions 자동 버전 업데이트
+- **Auto-merge** (`.github/workflows/auto-merge.yml`): dependabot PR 자동 머지
+- **Labeler** (`.github/labeler.yml`): PR 파일 패턴 기반 자동 라벨 부착
+
+추가 도구 (v2.15 이후):
+- **Release Drafter**: PR label/title 기반 CHANGELOG draft 자동 생성
+- **Label Sync**: `.github/labels.yml`을 GitHub과 동기화
+
+### §18.10 [HARD] 공식 위반 금지 사항
+
+- ❌ `main`에 직접 push (반드시 PR 경유)
+- ❌ `develop` 브랜치 생성 (Gitflow 패턴 금지)
+- ❌ release PR squash merge (merge commit 필수 — 개별 SPEC commit 보존)
+- ❌ tag 수동 push 없이 `gh release create` (GoReleaser와 충돌)
+- ❌ branch prefix 관례 위반 (`feat/SPEC-*` 대신 `add-something` 등)
+- ❌ `--rebase` merge 전략 (history rewrite 방지)
+- ❌ CI fail 상태 PR merge (admin override 필요, 최소화)
+
+### §18.11 이전 세션 학습 (v2.14.0 Case Study)
+
+v2.14.0 릴리스 과정에서 다음 문제 발생 → v2.15부터 방지:
+
+1. **Squash merge로 release history 손실**
+   - PR #703 (`release/v2.14.0 → main`)을 squash로 머지하여 9개 의미 있는 commit (UTIL-001/002/003 + review fix + CI fix + ETXTBSY)이 단일 commit으로 압축됨
+   - **교훈**: release → main은 항상 `--merge` 사용
+
+2. **Stacked PR close 후 reopen 실패**
+   - PR #704 (base: release/v2.14.0)가 PR #703 merge 과정에서 auto-close됨. `gh pr reopen` 실패 → 새 PR #705 생성으로 우회
+   - **교훈**: stacked PR은 parent merge 전 base를 main으로 미리 전환하는 것이 안전
+
+3. **CI Ubuntu 환경 의존성 누락**
+   - `sg` command가 Ubuntu의 `util-linux` `newgrp` symlink와 충돌
+   - `TestRuleSeed` skip 로직이 `LookPath`만으로 판정하여 false positive
+   - **교훈**: 환경 의존 테스트는 **command signature 검증** 필수 (예: `sg --version` 출력의 "ast-grep" 확인)
+
+4. **Pre-existing flaky test가 릴리스 block**
+   - `TestSupervisor_NonZeroExit`의 ETXTBSY race가 Ubuntu CI에서 간헐 실패
+   - **교훈**: flaky 테스트는 CLAUDE.local.md에 기록 + retry 로직 즉시 적용 (ETXTBSY mitigation pattern 참조)
+
+---
+
 **Status**: Active (Local Development)
-**Version**: 3.1.0 (Phase 6: §17 docs-site 규칙 신설, 4개국어 동기화)
-**Last Updated**: 2026-04-17
+**Version**: 3.2.0 (Phase 7: §18 Enhanced GitHub Flow 공식 채택, Gitflow 거부 결정)
+**Last Updated**: 2026-04-24

--- a/CLAUDE.local.md
+++ b/CLAUDE.local.md
@@ -760,6 +760,47 @@ docs-site 파일을 직접 수정하는 에이전트 (`expert-frontend`, `manage
 
 v2.14.0 릴리스 이후 공식 채택. Gitflow 대안 비교 분석 결과 (v2.14 후 세션) 이 프로젝트의 1-2명 팀 + 2일/릴리스 cadence + 단일 CLI 배포 환경에서 Gitflow의 `develop` 이중 관리 부담을 상회하는 장점이 부재. 현재 de-facto 패턴을 유지하되 **formalization + automation**으로 개선.
 
+### §18.0 [HARD] 운영 원칙 — 5가지 즉시 개선 Framework
+
+이 프로젝트는 **다음 5가지 개선을 공식 운영 방침으로 채택**한다. 모든 git 작업은 이 5개 축을 준수해야 한다.
+
+| # | 개선 항목 | 현재 구현 | 참조 |
+|---|----------|-----------|------|
+| 1 | **Branch protection rule 강제** (`main` + `release/*`) | ⏳ `gh api` 명령어 준비 완료, admin 적용 대기 | §18.7 |
+| 2 | **Label 3축 체계** (`type:` / `priority:` / `area:`) + `status:` 보조축 | ✅ `.github/labels.yml` 정의 완료, 25 labels 추가됨 | §18.6 |
+| 3 | **Merge strategy 명시** (release = merge commit, feature = squash) | ✅ `.github/PULL_REQUEST_TEMPLATE.md` + `git-strategy.yaml` | §18.3 |
+| 4 | **Release Drafter로 CHANGELOG 자동화** | ✅ `.github/release-drafter.yml` + workflow 구성 완료 | §18.9 |
+| 5 | **Hotfix 브랜치 명명 공식화** (`hotfix/vX.Y.Z-*`) | ✅ 스크립트 `--hotfix` 플래그 + `Makefile release-hotfix` target | §18.5 |
+
+### §18.0.1 운영 방침 (매 PR/Release마다 점검)
+
+**모든 PR 작성자**:
+1. 브랜치 명명 §18.2 준수 (11 prefix 중 선택)
+2. PR에 type/priority/area 3축 label 부착 (필수)
+3. PR template 내 "Merge Strategy" 체크박스 선택 (`--squash` vs `--merge`)
+4. Commit 메시지 Conventional Commits 형식 (type:scope) — Release Drafter 자동 분류용
+
+**모든 릴리스 담당자**:
+1. Release Drafter draft 확인 → `CHANGELOG.md`에 영문+한국어 섹션 작성
+2. `./scripts/release.sh vX.Y.Z` 또는 `make release V=vX.Y.Z` 실행 (수동 tag push 금지)
+3. Hotfix는 `./scripts/release.sh vX.Y.Z --hotfix`
+4. GoReleaser workflow 완료 후 GitHub Release 5 플랫폼 assets 확인
+5. Post-release: docs-site 4개국어 reference sync (별도 PR) — §17 규칙 준수
+
+**모든 리뷰어**:
+1. PR의 merge strategy가 브랜치 유형과 일치하는지 확인 (release → `--merge`, feature → `--squash`)
+2. 3축 label 부착 여부 확인 (type 축 최소 1, area 축 최소 1, priority 축 최소 1)
+3. CI all-green 확인 (Lint / Test ubuntu/macos/windows / Build 5 / CodeQL)
+4. v2.14.0 Case Study (§18.11) 재발 방지 체크 (release squash 금지, stacked PR base 전환)
+
+**금지 사항** (§18.10 전체 위반 금지):
+- ❌ `main` 직접 push
+- ❌ `develop` 브랜치 생성 (Gitflow 패턴)
+- ❌ Release PR squash merge (history 손실)
+- ❌ `--rebase` merge 전략
+- ❌ 수동 `gh release create` (GoReleaser와 충돌)
+- ❌ 브랜치 명명 관례 위반
+
 ### §18.1 브랜치 구조
 
 ```
@@ -956,15 +997,31 @@ git checkout main && git pull
 
 ### §18.9 자동화 도구
 
-이미 구성된 도구 (유지):
-- **GoReleaser** (`.goreleaser.yml` + `.github/workflows/release.yml`): tag push 시 자동 binary 빌드 + GitHub Release
-- **Dependabot** (`.github/dependabot.yml`): Go modules + GitHub Actions 자동 버전 업데이트
-- **Auto-merge** (`.github/workflows/auto-merge.yml`): dependabot PR 자동 머지
-- **Labeler** (`.github/labeler.yml`): PR 파일 패턴 기반 자동 라벨 부착
+**구성 완료된 도구 (Enhanced GitHub Flow 공식 인프라)**:
 
-추가 도구 (v2.15 이후):
-- **Release Drafter**: PR label/title 기반 CHANGELOG draft 자동 생성
-- **Label Sync**: `.github/labels.yml`을 GitHub과 동기화
+| 도구 | 역할 | 트리거 | 설정 파일 |
+|------|------|--------|-----------|
+| **GoReleaser** | Tag push 시 5 플랫폼 바이너리 빌드 + GitHub Release 생성 | `push: tags: v*` | `.goreleaser.yml` + `.github/workflows/release.yml` |
+| **Release Drafter** ⭐ | PR merge 시 next release draft 자동 업데이트 (CHANGELOG 작성 보조) | `push: branches: main`, `pull_request: [opened, synchronize, edited]` | `.github/release-drafter.yml` + `.github/workflows/release-drafter.yml` |
+| **Dependabot** | Go modules + GitHub Actions 자동 버전 업데이트 PR | 주간 | `.github/dependabot.yml` |
+| **Auto-merge** | Dependabot PR CI pass 시 자동 머지 (squash) | PR + CI success | `.github/workflows/auto-merge.yml` |
+| **Labeler** | PR 파일 패턴 기반 자동 라벨 부착 (area 축 추론) | PR opened/synchronized | `.github/labeler.yml` |
+| **Release Drafter autolabeler** | PR title/branch/files 기반 type 축 자동 라벨 | 위 Release Drafter와 통합 | `.github/release-drafter.yml` § `autolabeler` |
+
+**Release Drafter ↔ GoReleaser 역할 분담** (공존 설계):
+- **Release Drafter** = "다음 릴리스 preview" 자동 축적 → 인간이 `CHANGELOG.md`에 영문+한국어로 정제
+- **GoReleaser** = tag push 시 final release 생성 (commit 기반 changelog 포함). Release Drafter draft와 무관하게 tag 기준 독립 운영
+- **실제 workflow**: PR merge → Release Drafter가 draft 축적 → 릴리스 시 draft 확인 → `CHANGELOG.md` 업데이트 → `./scripts/release.sh` → GoReleaser final release
+
+**Release Drafter Version Resolver** (자동 SemVer 추정):
+- `breaking` / `type:breaking` label → major bump
+- `type:feature` label → minor bump
+- `type:fix` / `type:security` / `type:performance` / 기타 → patch bump
+
+**추가 도구 (v2.15+ 검토)**:
+- **EndBug/label-sync**: `.github/labels.yml`을 GitHub과 주기적 동기화 (현재 수동)
+- **Commitlint GitHub Action**: Conventional Commits 형식 CI 강제
+- **Changesets (대안)**: CHANGELOG 관리 자동화 심화 — 현재 Release Drafter로 충분
 
 ### §18.10 [HARD] 공식 위반 금지 사항
 
@@ -1000,5 +1057,5 @@ v2.14.0 릴리스 과정에서 다음 문제 발생 → v2.15부터 방지:
 ---
 
 **Status**: Active (Local Development)
-**Version**: 3.2.0 (Phase 7: §18 Enhanced GitHub Flow 공식 채택, Gitflow 거부 결정)
+**Version**: 3.3.0 (Phase 8: §18.0 운영 원칙 5 Framework 명시화 + Release Drafter 구성 완료)
 **Last Updated**: 2026-04-24

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ LOCAL_RELEASE_DIR ?= $(HOME)/.moai/releases
 PLATFORM := $(shell go env GOOS)-$(shell go env GOARCH)
 RELEASE_BINARY := moai-$(VERSION)-$(PLATFORM)
 
-.PHONY: all build test lint fix clean install generate help release-local
+.PHONY: all build test lint fix clean install generate help release-local release release-dry release-hotfix
 
 all: lint test build ## Run lint, test, and build
 
@@ -29,6 +29,18 @@ release-local: build ## Create a local release for development updates
 	@echo "Local release created at: $(LOCAL_RELEASE_DIR)"
 	@echo "  Binary: $(RELEASE_BINARY)"
 	@echo "  Version: $(VERSION)"
+
+release: ## Run Enhanced GitHub Flow release (usage: make release V=v2.15.0)
+	@test -n "$(V)" || (echo "Usage: make release V=v2.15.0"; exit 1)
+	@./scripts/release.sh $(V)
+
+release-dry: ## Dry-run release (validation only, usage: make release-dry V=v2.15.0)
+	@test -n "$(V)" || (echo "Usage: make release-dry V=v2.15.0"; exit 1)
+	@./scripts/release.sh $(V) --dry-run
+
+release-hotfix: ## Hotfix release from tag (usage: make release-hotfix V=v2.14.1)
+	@test -n "$(V)" || (echo "Usage: make release-hotfix V=v2.14.1"; exit 1)
+	@./scripts/release.sh $(V) --hotfix
 
 install: ## Install the binary
 	go install $(LDFLAGS) ./cmd/moai

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+# scripts/release.sh — Enhanced GitHub Flow 기반 로컬 릴리스 실행
+#
+# 사용법:
+#   scripts/release.sh v2.15.0              # Minor/Major release (release branch 머지 완료 전제)
+#   scripts/release.sh v2.14.1              # Patch release (fix 직접 main)
+#   scripts/release.sh v2.14.1 --hotfix     # Hotfix release
+#   scripts/release.sh v2.15.0 --dry-run    # 검증만 (실제 tag/push 없이)
+#
+# 전제 조건 (CLAUDE.local.md §18.8):
+#   - CHANGELOG.md 에 해당 버전 섹션 존재
+#   - main 브랜치 checkout + origin/main 과 동기화
+#   - 모든 CI 통과
+#   - 작업 트리 clean
+#
+# 흐름:
+#   1. 사전 검증 (버전 형식, CHANGELOG, git 상태, CI 상태)
+#   2. 사용자 확인 (AskUserQuestion 없이 stdin prompt)
+#   3. Annotated tag 생성 (CHANGELOG 섹션에서 annotation 자동 추출)
+#   4. Tag push → GoReleaser 자동 실행 (release.yml workflow)
+#   5. GitHub Release 상태 확인 (GoReleaser 완료까지 대기)
+#
+# 참고:
+#   - GoReleaser가 GitHub Release 및 바이너리 배포 자동 처리
+#   - 수동 `gh release create`는 GoReleaser와 충돌 가능하므로 사용 금지
+
+set -euo pipefail
+
+# ─── Color helpers ─────────────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+NC='\033[0m' # No Color
+
+log_info()   { echo -e "${BLUE}[INFO]${NC} $*"; }
+log_ok()     { echo -e "${GREEN}[OK]${NC}   $*"; }
+log_warn()   { echo -e "${YELLOW}[WARN]${NC} $*"; }
+log_error()  { echo -e "${RED}[FAIL]${NC} $*" >&2; }
+die()        { log_error "$*"; exit 1; }
+
+# ─── Argument parsing ──────────────────────────────────────────────────────
+VERSION=""
+DRY_RUN=false
+HOTFIX=false
+SKIP_CI_CHECK=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run)       DRY_RUN=true; shift ;;
+        --hotfix)        HOTFIX=true; shift ;;
+        --skip-ci-check) SKIP_CI_CHECK=true; shift ;;
+        -h|--help)
+            sed -n '2,20p' "$0"
+            exit 0
+            ;;
+        -*)
+            die "Unknown flag: $1 (try --help)"
+            ;;
+        *)
+            if [[ -z "$VERSION" ]]; then
+                VERSION="$1"
+            else
+                die "Multiple version arguments provided"
+            fi
+            shift
+            ;;
+    esac
+done
+
+[[ -n "$VERSION" ]] || die "Version argument required (e.g., v2.15.0). Try --help."
+
+# ─── Validation 1: Version format (SemVer with v prefix) ────────────────────
+if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+    die "Invalid version format: $VERSION (expected: vX.Y.Z or vX.Y.Z-preN)"
+fi
+
+log_info "Release version: ${BOLD}$VERSION${NC}"
+[[ "$DRY_RUN" == true ]] && log_warn "DRY RUN mode — no tag/push will occur"
+[[ "$HOTFIX" == true ]] && log_info "Hotfix mode — relaxed branch check"
+
+# ─── Validation 2: Repository root ─────────────────────────────────────────
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || die 'Not in a git repository')"
+cd "$REPO_ROOT"
+
+# ─── Validation 3: Clean working tree ──────────────────────────────────────
+if [[ -n "$(git status --porcelain)" ]]; then
+    git status --short
+    die "Working tree is dirty. Commit or stash changes first."
+fi
+log_ok "Working tree clean"
+
+# ─── Validation 4: Current branch ──────────────────────────────────────────
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+    if [[ "$HOTFIX" == true ]]; then
+        log_warn "On branch '$CURRENT_BRANCH' (hotfix mode — allowed)"
+    else
+        die "Must be on 'main' branch (current: $CURRENT_BRANCH). Use --hotfix for hotfix branches."
+    fi
+fi
+log_ok "On expected branch: $CURRENT_BRANCH"
+
+# ─── Validation 5: Synced with origin ──────────────────────────────────────
+git fetch origin --tags --quiet
+LOCAL_SHA="$(git rev-parse HEAD)"
+REMOTE_SHA="$(git rev-parse "origin/$CURRENT_BRANCH" 2>/dev/null || echo "")"
+
+if [[ -z "$REMOTE_SHA" ]]; then
+    die "Remote branch 'origin/$CURRENT_BRANCH' not found. Push branch first."
+fi
+
+if [[ "$LOCAL_SHA" != "$REMOTE_SHA" ]]; then
+    AHEAD="$(git rev-list --count "$REMOTE_SHA..$LOCAL_SHA" 2>/dev/null || echo "?")"
+    BEHIND="$(git rev-list --count "$LOCAL_SHA..$REMOTE_SHA" 2>/dev/null || echo "?")"
+    die "Local '$CURRENT_BRANCH' diverged from origin (ahead: $AHEAD, behind: $BEHIND). Pull/push first."
+fi
+log_ok "Local $CURRENT_BRANCH synced with origin"
+
+# ─── Validation 6: Tag does not exist ──────────────────────────────────────
+if git rev-parse "$VERSION" >/dev/null 2>&1; then
+    die "Tag $VERSION already exists (local)."
+fi
+if git ls-remote --exit-code --tags origin "$VERSION" >/dev/null 2>&1; then
+    die "Tag $VERSION already exists on origin."
+fi
+log_ok "Tag $VERSION does not exist yet"
+
+# ─── Validation 7: CHANGELOG.md 에 해당 버전 섹션 존재 ───────────────────────
+CHANGELOG_VERSION="${VERSION#v}" # v2.14.0 → 2.14.0
+CHANGELOG_HEADER="## [$CHANGELOG_VERSION]"
+
+if ! grep -q "^## \[$CHANGELOG_VERSION\]" CHANGELOG.md; then
+    die "CHANGELOG.md missing section '$CHANGELOG_HEADER'. Add release notes first."
+fi
+log_ok "CHANGELOG.md contains $CHANGELOG_HEADER section"
+
+# ─── Validation 8: CI status on HEAD (optional) ────────────────────────────
+if [[ "$SKIP_CI_CHECK" != true ]]; then
+    if command -v gh >/dev/null 2>&1; then
+        CI_STATE="$(gh pr list --head "$CURRENT_BRANCH" --state merged --limit 1 --json number --jq '.[0].number // ""' 2>/dev/null || echo "")"
+
+        # 직접 HEAD commit의 check suite 상태 조회 (main push 이후 CI)
+        HEAD_CHECKS="$(gh api "/repos/modu-ai/moai-adk/commits/$LOCAL_SHA/status" --jq '.state' 2>/dev/null || echo "unknown")"
+
+        case "$HEAD_CHECKS" in
+            success)
+                log_ok "CI status on HEAD: success"
+                ;;
+            pending)
+                log_warn "CI status on HEAD: pending (in progress)"
+                echo -n "  Proceed anyway? [y/N] "
+                read -r reply
+                [[ "$reply" =~ ^[Yy]$ ]] || die "Aborted by user"
+                ;;
+            failure|error)
+                die "CI status on HEAD: $HEAD_CHECKS. Fix CI before releasing."
+                ;;
+            *)
+                log_warn "CI status on HEAD: $HEAD_CHECKS (unable to verify)"
+                ;;
+        esac
+    else
+        log_warn "gh CLI not available — skipping CI status check"
+    fi
+else
+    log_warn "CI check skipped (--skip-ci-check)"
+fi
+
+# ─── Validation 9: SPEC status 확인 (optional, informational) ───────────────
+if [[ -d .moai/specs ]]; then
+    DRAFT_COUNT="$(find .moai/specs -name 'spec.md' -exec grep -l '^status: draft' {} \; 2>/dev/null | wc -l | tr -d ' ')"
+    if [[ "$DRAFT_COUNT" -gt 0 ]]; then
+        log_warn "$DRAFT_COUNT SPEC(s) still in 'draft' status (not blocking, review if relevant)"
+    fi
+fi
+
+# ─── Extract CHANGELOG section as tag annotation ───────────────────────────
+TMP_NOTES="$(mktemp)"
+trap 'rm -f "$TMP_NOTES"' EXIT
+
+awk -v target="$CHANGELOG_HEADER " '
+    $0 ~ "^"target {flag=1; print; next}
+    /^## \[/ && flag {flag=0}
+    flag
+' CHANGELOG.md > "$TMP_NOTES"
+
+if [[ ! -s "$TMP_NOTES" ]]; then
+    die "Failed to extract CHANGELOG section for $VERSION"
+fi
+
+NOTES_LINES="$(wc -l < "$TMP_NOTES" | tr -d ' ')"
+log_ok "Extracted $NOTES_LINES line(s) from CHANGELOG.md as tag annotation"
+
+# ─── Final confirmation ────────────────────────────────────────────────────
+echo
+echo -e "${BOLD}=== Release Summary ===${NC}"
+echo "  Version:     $VERSION"
+echo "  Branch:      $CURRENT_BRANCH"
+echo "  HEAD SHA:    ${LOCAL_SHA:0:12}"
+echo "  Notes size:  $NOTES_LINES lines (from CHANGELOG.md $CHANGELOG_HEADER)"
+echo "  Dry-run:     $DRY_RUN"
+echo "  Hotfix:      $HOTFIX"
+echo
+
+if [[ "$DRY_RUN" == true ]]; then
+    log_info "DRY RUN — skipping tag creation"
+    echo
+    echo "Tag annotation preview (first 30 lines):"
+    echo "---"
+    head -30 "$TMP_NOTES"
+    echo "---"
+    exit 0
+fi
+
+echo -n "Proceed with tag creation + push? [y/N] "
+read -r confirm
+[[ "$confirm" =~ ^[Yy]$ ]] || die "Aborted by user"
+
+# ─── Create + push annotated tag ───────────────────────────────────────────
+log_info "Creating annotated tag $VERSION..."
+git tag -a "$VERSION" -F "$TMP_NOTES"
+log_ok "Tag $VERSION created locally"
+
+log_info "Pushing tag to origin (triggers GoReleaser)..."
+git push origin "$VERSION"
+log_ok "Tag pushed to origin"
+
+# ─── Wait for GoReleaser workflow ──────────────────────────────────────────
+if command -v gh >/dev/null 2>&1; then
+    log_info "Monitoring GoReleaser workflow..."
+    echo "  → https://github.com/modu-ai/moai-adk/actions"
+    echo
+    sleep 5 # Allow workflow dispatch to register
+
+    RUN_ID="$(gh run list --workflow release.yml --limit 1 --json databaseId --jq '.[0].databaseId' 2>/dev/null || echo "")"
+
+    if [[ -n "$RUN_ID" ]]; then
+        log_info "Release workflow run: $RUN_ID (polling every 30s, ctrl-C to detach)"
+        gh run watch "$RUN_ID" --interval 30 || log_warn "Watch detached (workflow may still be running)"
+
+        WORKFLOW_STATE="$(gh run view "$RUN_ID" --json conclusion --jq '.conclusion' 2>/dev/null || echo "unknown")"
+        case "$WORKFLOW_STATE" in
+            success)
+                log_ok "GoReleaser completed successfully"
+                ;;
+            failure)
+                log_error "GoReleaser failed — check workflow logs"
+                echo "  gh run view $RUN_ID --log-failed"
+                exit 1
+                ;;
+            *)
+                log_warn "GoReleaser state: $WORKFLOW_STATE"
+                ;;
+        esac
+    else
+        log_warn "Could not locate release workflow run — check manually"
+    fi
+
+    # Verify GitHub Release exists
+    if gh release view "$VERSION" >/dev/null 2>&1; then
+        RELEASE_URL="https://github.com/modu-ai/moai-adk/releases/tag/$VERSION"
+        log_ok "GitHub Release available: $RELEASE_URL"
+    else
+        log_warn "GitHub Release for $VERSION not found yet (may take additional time)"
+    fi
+else
+    log_warn "gh CLI not available — cannot verify GoReleaser completion"
+fi
+
+echo
+log_ok "${BOLD}Release $VERSION complete${NC}"
+echo
+echo "Next steps:"
+echo "  - Verify release assets: gh release view $VERSION"
+echo "  - Update docs-site (Phase 5): docs/v$CHANGELOG_VERSION-reference/"
+echo "  - Announce release if applicable"


### PR DESCRIPTION
## Summary

v2.14.0 릴리스 후 git workflow 분석 결과, **Gitflow 대신 Enhanced GitHub Flow** (기존 de-facto 패턴 + formalization + automation)를 공식 채택합니다. 1-2명 팀 + 2일/릴리스 cadence + 단일 CLI 배포 환경에서 Gitflow의 `develop` 이중 관리 부담이 실질적 이점을 초과합니다.

## Decision 근거 (데이터 기반)

| 기준 | 값 | Gitflow 필요성 |
|------|-----|----------------|
| Team size | 1-2명 | ❌ |
| Release cadence | 30일간 15 릴리스 (2일/1 릴리스) | ❌ develop 오버헤드 초과 |
| Open 이슈 | 0 | ❌ |
| Multi-env deployment | 없음 (CLI) | ❌ |
| 병렬 release 수요 | 낮음 | ❌ |
| 현재 도구 | GoReleaser + Dependabot + Labeler (모두 main 중심) | Gitflow 도입 시 재구성 부담 |

**결론**: Gitflow의 6개 주요 이점 중 실제 이득은 0-1개. 현재 패턴 유지 + formalization이 최선.

## Changes

### CLAUDE.local.md §18 신설 (247 lines)
Enhanced GitHub Flow 전체 정책:
- 브랜치 명명 규칙 (11 prefix: `feat/SPEC-*`, `fix/issue-*`, `docs/*`, `chore/*`, `ci/*`, `refactor/*`, `audit/*`, `release/vX.Y.Z`, `hotfix/vX.Y.Z-*`, `plan/vX.Y-*`)
- Merge strategy (feature/plan → squash, release/hotfix → **merge commit** ⭐)
- Release cadence (patch/minor/major/hotfix)
- Hotfix workflow 예시 (tag에서 분기)
- Label 3축 체계 (type:/priority:/area:/status:)
- Branch protection rule `gh api` 명령어
- Release 프로세스 (scripts/release.sh 경유)
- 자동화 도구 목록
- [HARD] 공식 위반 금지 사항 (main 직접 push, develop 브랜치, release PR squash, tag 수동 push 금지)
- v2.14.0 Case Study (4건 교훈 기록)

### scripts/release.sh (신규 278 lines)
로컬 릴리스 실행 스크립트:
- SemVer v 접두사 검증 / clean working tree / main 브랜치 / origin 동기화 확인
- CHANGELOG.md 해당 버전 섹션 존재 확인
- CI 상태 조회 (`gh api /commits/{sha}/status`)
- SPEC draft count 경고 (비블로킹)
- CHANGELOG 섹션 자동 추출 → annotated tag annotation
- Tag 생성 + push → GoReleaser workflow 자동 watch
- 플래그: `--dry-run` / `--hotfix` / `--skip-ci-check`

### Makefile targets
- `make release V=v2.15.0` → 정식 릴리스
- `make release-dry V=v2.15.0` → 검증만
- `make release-hotfix V=v2.14.1` → hotfix 경로

### GitHub 인프라
- **PULL_REQUEST_TEMPLATE.md** 확장: Merge Strategy 체크박스 + Quality Gates + AI Collaboration + Post-Merge Actions
- **ISSUE_TEMPLATE/release.md** 신규 (92 lines): Release tracking 이슈 템플릿
- **labels.yml**: 25 신규 labels (type:/priority:/area:/status: 3축)
- **git-strategy.yaml**: workflow_model / merge_strategies / branch_types / release_cadence / release_tools 필드 추가

## Non-breaking
- 기존 labels 모두 유지 (30+ 개, 25 신규 추가만)
- 기존 workflows (release.yml, auto-merge.yml, ci.yml) unchanged
- GoReleaser config unchanged
- ISSUE_TEMPLATE config.yml 및 bug/feature/question templates unchanged

## 수동 후속 작업 (admin 권한 필요)

PR 머지 후 admin이 실행:

```bash
# 1. main branch protection 활성화
gh api -X PUT /repos/modu-ai/moai-adk/branches/main/protection --input - <<EOF2
{
  "required_status_checks": {"strict": true, "contexts": ["Lint", "Test (ubuntu-latest)", "Test (macos-latest)", "Test (windows-latest)", "CodeQL"]},
  "enforce_admins": false,
  "required_pull_request_reviews": {"required_approving_review_count": 1},
  "allow_force_pushes": false,
  "allow_deletions": false
}
EOF2

# 2. Labels 동기화 (옵션, EndBug/label-sync 사용 시)
# gh workflow run label-sync.yml
```

## Test Plan

- [x] `bash -n scripts/release.sh` — syntax valid
- [x] `make -n release V=v2.15.0` — Makefile syntax valid
- [x] `python -c "yaml.safe_load(labels.yml)"` — YAML valid
- [x] `python -c "yaml.safe_load(git-strategy.yaml)"` — YAML valid
- [ ] `./scripts/release.sh v2.14.0 --dry-run` 로 전체 검증 흐름 테스트 (v2.14.0 CHANGELOG 존재)
- [ ] 다음 릴리스 (v2.14.1 또는 v2.15.0)에서 실제 사용으로 검증

## Related

- CLAUDE.local.md §18 Enhanced GitHub Flow 전문
- v2.14.0 Case Study (§18.11): squash merge로 9개 commit 압축된 사례
- Gitflow 비교 분석: 세션 대화 기록 (30일 15 릴리스 데이터)

🗿 MoAI <email@mo.ai.kr>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Formalized Git workflow, branch naming, merge/merge-commit rules, and detailed release/hotfix process.
  * Expanded local contributor guidance and release checklist.

* **Chores**
  * New labeled taxonomy for PRs/issues and updated PR/release issue templates.
  * Added automated release drafting and CI workflow, plus scripted/make-driven release targets and verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->