### PR TITLE
feat(dev-tooling): Makefile dev-sync target + MCP servers default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ LOCAL_RELEASE_DIR ?= $(HOME)/.moai/releases
 PLATFORM := $(shell go env GOOS)-$(shell go env GOARCH)
 RELEASE_BINARY := moai-$(VERSION)-$(PLATFORM)
 
-.PHONY: all build test lint fix clean install generate help release-local release release-dry release-hotfix
+.PHONY: all build test lint fix clean install generate help release-local release release-dry release-hotfix dev-sync
 
 all: lint test build ## Run lint, test, and build
 
@@ -79,6 +79,14 @@ tidy: ## Tidy go modules
 
 run: build ## Build and run
 	./bin/$(BINARY_NAME)
+
+dev-sync: build install ## Build + install + sync templates -> this dev project (.claude/, .moai/)
+	@echo ""
+	@echo "Syncing embedded templates to this dev project (3-way merge preserves local mods)..."
+	moai update --templates-only --yes
+	@echo ""
+	@echo "Sync complete. Run 'git diff' to review template-driven changes."
+	@echo "Note: settings.local.json, CLAUDE.local.md, .moai/specs/, dev-only commands (98-, 99-) are preserved."
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'

--- a/internal/template/templates/.claude/settings.json.tmpl
+++ b/internal/template/templates/.claude/settings.json.tmpl
@@ -617,6 +617,11 @@
     "pr": "\ud83d\uddff MoAI <email@mo.ai.kr>"
   },
   "enableAllProjectMcpServers": false,
+  "enabledMcpjsonServers": [
+    "chrome-devtools",
+    "context7",
+    "sequential-thinking"
+  ],
   "respectGitignore": true,
   "teammateMode": "auto",
   "effortLevel": "medium",


### PR DESCRIPTION
## Summary

V3R3 Phase A 후속 작업 (post-v2.15.0). #710 머지 후 stash로 보존됐던 V3R3 무관 변경분 중 개발 편의 도구 부분만 분리해서 가져옵니다.

## Changes

### `Makefile`
- `dev-sync` target 신규 추가
  - `make dev-sync` 실행 시: `make build && make install && moai update --templates-only --yes`
  - 임베디드 템플릿을 현재 dev project로 동기화 (3-way merge)
  - 보존 대상: `settings.local.json`, `CLAUDE.local.md`, `.moai/specs/`, 98-/99- dev-only 명령
- 기존 `release` / `release-dry` / `release-hotfix` targets (#706)는 그대로 유지

### `internal/template/templates/.claude/settings.json.tmpl`
- `enabledMcpjsonServers` 키 신규 추가:
  - `chrome-devtools`
  - `context7`
  - `sequential-thinking`
- 신규 프로젝트 `moai init` 시 자주 쓰는 MCP 서버 3개를 기본 활성화

## Why

`moai-adk-go` 자체를 dev하면서 templates 변경을 즉시 로컬에 반영하는 편의 명령이 필요했음. v2.15.0 작업 중 stash에 남아 있던 변경분으로, V3R3 SPEC scope 외라 분리 PR로 제출.

MCP 기본 활성화는 신규 프로젝트가 `moai init` 직후 chrome-devtools / context7 / sequential-thinking을 자동 인식하도록 하기 위함. `enableAllProjectMcpServers: false` 정책은 그대로 유지 (whitelist 방식).

## Test plan

- [x] `make help`로 dev-sync target 노출 확인
- [x] `make build` 정상 작동 (v2.14.0 ldflags injection 확인)
- [ ] Local CI mirror (push 후 자동)
- [ ] Reviewer가 dev-sync 직접 실행 시 templates 동기화 확인

## Notes

- 동일 stash에 V3R2 SPEC progress 변경분이 있었으나 본 PR에서 제외 — backup branch `backup/local-pre-v2.15-merge`에 보존됨, 별도 후속 PR로 처리 예정
- BREAKING change 없음 (additive only)

🗿 MoAI <email@mo.ai.kr>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `dev-sync` command that builds, installs, and syncs embedded templates into development projects

* **Chores**
  * Updated template configuration to explicitly enable MCP JSON server support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->