### PR TITLE
release: v2.16.0 — Pattern Cookbook + V3R2 restore + Phase A 통합

### DIFF
--- a/.claude/rules/moai/NOTICE.md
+++ b/.claude/rules/moai/NOTICE.md
@@ -1,0 +1,37 @@
+# MoAI-ADK Third-Party Notices
+
+This product includes software developed by revfactory/harness and redistributed under the Apache License 2.0.
+
+## Apache License 2.0
+
+The following source material is licensed under Apache License 2.0:
+
+**Source Repository**: https://github.com/revfactory/harness  
+**License**: Apache License 2.0 (https://www.apache.org/licenses/LICENSE-2.0)
+
+### Imported Components
+
+The following reference documents from `revfactory/harness` (imported 2026-04-26) are incorporated into MoAI-ADK as pattern cookbook rules:
+
+1. `agent-design-patterns.md` → `.claude/rules/moai/development/agent-patterns.md`
+2. `qa-agent-guide.md` → `.claude/rules/moai/quality/boundary-verification.md`
+3. `skill-testing-guide.md` → `.claude/rules/moai/development/skill-ab-testing.md`
+4. `team-examples.md` → `.claude/rules/moai/workflow/team-pattern-cookbook.md`
+5. `orchestrator-template.md` → `.claude/rules/moai/development/orchestrator-templates.md`
+6. `skill-writing-guide.md` → `.claude/rules/moai/development/skill-writing-craft.md`
+
+### Attribution
+
+This product includes software developed by revfactory/harness contributors. The original works and any modifications are provided under the terms of the Apache License 2.0.
+
+The imported documents have been adapted for MoAI-ADK terminology and 16-language neutrality while preserving the original technical content and design patterns. Original source authorship is retained.
+
+### Full Apache License 2.0 Text
+
+For the complete Apache License 2.0 text, visit: https://www.apache.org/licenses/LICENSE-2.0
+
+---
+
+**Import Date**: 2026-04-26  
+**MoAI-ADK License**: MIT  
+**Combined Compatibility**: Apache 2.0 imports distributed under MIT with Apache attribution preserved.

--- a/.claude/rules/moai/core/hooks-system.md
+++ b/.claude/rules/moai/core/hooks-system.md
@@ -195,7 +195,7 @@ Define hooks in `.claude/settings.json`:
     "PostToolUse": [{
       "matcher": "Write|Edit",
       "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-post-tool.sh\"",
-      "timeout": 60
+      "timeout": 10
     }],
     "Stop": [{
       "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-stop.sh\"",

--- a/.claude/rules/moai/core/hooks-system.md
+++ b/.claude/rules/moai/core/hooks-system.md
@@ -195,7 +195,8 @@ Define hooks in `.claude/settings.json`:
     "PostToolUse": [{
       "matcher": "Write|Edit",
       "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-post-tool.sh\"",
-      "timeout": 10
+      "timeout": 10,
+      "async": true
     }],
     "Stop": [{
       "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-stop.sh\"",

--- a/.claude/rules/moai/core/settings-management.md
+++ b/.claude/rules/moai/core/settings-management.md
@@ -109,7 +109,7 @@ Hook timeout unit is **seconds** (not milliseconds, despite some external docs).
 |------|--------------------|-----------|
 | SessionStart | 30s | MCP server startup latency |
 | PreToolUse | 5s | Fast pre-flight checks only |
-| PostToolUse | **10s** (was 60s before v2.16.0) | LSP/AST/MX validations average <30ms; 10s is generous safety margin |
+| PostToolUse | **10s + `async: true`** (was 60s synchronous before v2.16.0) | LSP/AST/MX validations run in background; results delivered via systemMessage on next turn. 10s is the per-run upper bound, not a blocking wait |
 | Stop / SubagentStop | 5s | Lightweight teardown |
 | TeammateIdle / TaskCompleted | 10s | Quality validation may run lint/test |
 

--- a/.claude/rules/moai/core/settings-management.md
+++ b/.claude/rules/moai/core/settings-management.md
@@ -103,8 +103,32 @@ Hooks support environment variables and must be quoted to handle spaces:
 
 **Important**: Quote the entire path: `"\"$CLAUDE_PROJECT_DIR/path\""` not `"$CLAUDE_PROJECT_DIR/path"`
 
-Hook timeout range: 1–600,000ms (max 10 minutes). Default is 5,000ms for most hooks.
-Long-running hooks (PostToolUse, quality gates) should set `"timeout": 60000` or higher.
+Hook timeout unit is **seconds** (not milliseconds, despite some external docs). Default is 5s for most hooks. Recommended ceilings:
+
+| Hook | Recommended timeout | Rationale |
+|------|--------------------|-----------|
+| SessionStart | 30s | MCP server startup latency |
+| PreToolUse | 5s | Fast pre-flight checks only |
+| PostToolUse | **10s** (was 60s before v2.16.0) | LSP/AST/MX validations average <30ms; 10s is generous safety margin |
+| Stop / SubagentStop | 5s | Lightweight teardown |
+| TeammateIdle / TaskCompleted | 10s | Quality validation may run lint/test |
+
+For very long validations (full test suites, deployments), prefer `"async": true` over high timeout — the hook runs in background and results arrive on the next turn (see hooks-system.md §Async Command Hooks).
+
+### Freeze Diagnosis Checklist
+
+If a session appears to freeze mid-conversation, check in this order (cheapest to most invasive):
+
+1. **MCP authentication failures** — most common cause. Run `claude mcp list` and remove servers showing `oauth_required` / `connection_failed`. Each unauthenticated MCP can add 5-30s retry latency on tool calls.
+2. **Hook timeout** — run `claude --debug "hooks"` to see per-hook latency. If a hook exceeds its timeout, the response stalls until timeout expires. moai hook handlers (post-tool, stop, subagent-stop) typically complete in <50ms; persistent slowness usually points to LSP server hangs.
+3. **Context window pressure** — see `.claude/rules/moai/workflow/context-window-management.md`. SSE streams stall when prompts approach 75% of the window.
+4. **Terminal I/O saturation** — high write ratio (>90% writes in `tmux info`) can make output appear delayed. This is rendering only, not a true freeze.
+
+Profile a hook directly:
+```bash
+echo '{"hook_event_name":"PostToolUse","tool_name":"Write","tool_response":{"success":true},"session_id":"test"}' | time moai hook post-tool
+```
+Healthy result: under 100ms. Persistent slowness → check LSP / disk I/O / MX validation cost.
 
 ## StatusLine Configuration
 

--- a/.claude/rules/moai/development/agent-patterns.md
+++ b/.claude/rules/moai/development/agent-patterns.md
@@ -1,0 +1,200 @@
+---
+description: "Six architectural agent orchestration patterns for MoAI-ADK agent design"
+paths: ".claude/agents/**/*.md,.claude/rules/moai/development/agent-authoring.md"
+---
+
+<!-- Source: revfactory/harness — Apache License 2.0 — see .claude/rules/moai/NOTICE.md -->
+
+# Agent Design Patterns
+
+Six foundational orchestration patterns for designing agent systems in MoAI-ADK. These patterns describe how agents interact, communicate, and coordinate work.
+
+## Pattern 1: Pipeline
+
+Sequential execution where each agent's output becomes the next agent's input.
+
+**Structure**: Agent A → Agent B → Agent C → Agent D
+
+**When to Use**: 
+- Requirements are strongly dependent on previous stage outputs
+- Each stage has clear input/output contracts
+- Linear workflow with minimal branching
+
+**Example**: Content creation pipeline — research → outline → draft → edit
+
+**Anti-Pattern**: Using pipeline when stages are independent (wastes sequential overhead)
+
+---
+
+## Pattern 2: Fan-out/Fan-in
+
+Parallel processing with independent analysis followed by result aggregation.
+
+**Structure**: 
+```
+         ┌→ Agent A ┐
+Dispatch ┼→ Agent B ┼→ Synthesize
+         └→ Agent C ┘
+```
+
+**When to Use**:
+- Same input needs multiple independent perspectives
+- Parallel analysis improves coverage
+- Results can be meaningfully combined
+
+**Example**: Multi-angle research — technical + market + user perspectives analyzed in parallel, then synthesized
+
+**Anti-Pattern**: Over-specifying how to combine results; let agents negotiate
+
+---
+
+## Pattern 3: Expert Pool
+
+Dynamic selection of appropriate specialist for each task.
+
+**Structure**: Router → { Expert A | Expert B | Expert C }
+
+**When to Use**:
+- Input type determines which expert to invoke
+- Not all experts needed for each task
+- Expert selection is well-defined
+
+**Example**: Code review routing — security expert for auth code, performance expert for queries, architecture expert for design
+
+**Anti-Pattern**: Always invoking all experts even when only one is relevant
+
+---
+
+## Pattern 4: Producer-Reviewer
+
+Iterative quality cycle with specialized producer and reviewer agents.
+
+**Structure**: Producer → Reviewer → (Feedback loop) → Producer redo → Reviewer
+
+**When to Use**:
+- Quality validation has clear objective criteria
+- Feedback can guide refinement
+- Bounded iteration count prevents infinite loops
+
+**Example**: Content generation with review — writer creates → editor reviews → writer revises (max 3 iterations)
+
+**Anti-Pattern**: Unbounded review cycles; always set maximum iterations
+
+---
+
+## Pattern 5: Supervisor
+
+Central coordinator agent manages work distribution to subordinate agents.
+
+**Structure**:
+```
+         ┌→ Worker A
+Supervisor ┼→ Worker B  (Dynamic assignment)
+         └→ Worker C
+```
+
+**When to Use**:
+- Work volume or complexity is variable
+- Tasks need dynamic distribution
+- Coordination overhead is acceptable
+
+**Example**: Large codebase migration — supervisor analyzes files, delegates modules to workers, tracks progress
+
+**Anti-Pattern**: Supervisor becomes a bottleneck; use for high-level coordination only
+
+---
+
+## Pattern 6: Hierarchical Delegation
+
+Multi-level delegation where agents recursively decompose problems.
+
+**Structure**:
+```
+[Executive] → [Manager A] → [Specialist A1]
+                           → [Specialist A2]
+           → [Manager B] → [Specialist B1]
+```
+
+**When to Use**:
+- Problem naturally decomposes hierarchically
+- Clear team boundaries exist
+- Depth is limited (max 2-3 levels)
+
+**Example**: Full-stack development — lead → backend team lead → (database + API + tests) + frontend team lead → (UI + state management)
+
+**Anti-Pattern**: Nesting more than 2-3 levels; causes coordination overhead and context loss
+
+---
+
+## Pattern Selection Matrix
+
+| Scenario | Pattern | Why |
+|----------|---------|-----|
+| Linear requirements | Pipeline | Clear ordering |
+| Parallel analysis | Fan-out/Fan-in | Independent perspectives |
+| Variable expertise | Expert Pool | Right tool per task |
+| Quality iteration | Producer-Reviewer | Focused refinement loop |
+| Variable workload | Supervisor | Dynamic allocation |
+| Complex decomposition | Hierarchical | Natural boundaries |
+
+---
+
+## Anti-Patterns to Avoid
+
+**Anti-Pattern 1**: "Pipeline everything"
+- Using sequential patterns when tasks are independent
+- Fix: Use Fan-out/Fan-in for parallel work
+
+**Anti-Pattern 2**: "All experts always"
+- Invoking every expert for every task
+- Fix: Route to relevant experts only via Expert Pool
+
+**Anti-Pattern 3**: "Unbounded review"
+- Producer-Reviewer without iteration limits
+- Fix: Set `max_iterations: 3` to prevent infinite loops
+
+**Anti-Pattern 4**: "Supervisor bottleneck"
+- Central coordinator doing all coordination work
+- Fix: Use shared task lists for self-coordination
+
+**Anti-Pattern 5**: "Deep hierarchies"
+- Nesting more than 2-3 delegation levels
+- Fix: Flatten structure or switch to Supervisor pattern
+
+---
+
+## Combination Strategies
+
+Real-world systems often combine patterns:
+
+| Combination | Structure | Use Case |
+|-------------|-----------|----------|
+| Pipeline + Fan-out | Sequential stages with parallel substeps | Analysis (gather data) → Design → Implement (parallel experts) |
+| Fan-out/Fan-in + Producer-Reviewer | Parallel analysis then iterative refinement | Research (parallel) → Synthesize → Review/improve |
+| Supervisor + Expert Pool | Coordinator routes to specialists | Large project with dynamic workload distribution |
+
+The key is matching pattern structure to actual workflow dependencies, not forcing dependencies into convenient patterns.
+
+---
+
+## MoAI-ADK Pattern Vocabulary
+
+MoAI-ADK applies the six generic harness patterns using these specialized naming conventions:
+
+### Team
+Maps to **Fan-out/Fan-in**. Multiple agents analyze independently, results synthesized. Use when one request needs multiple perspectives: security review + performance audit + architecture check all run in parallel, then consolidated.
+
+### Sub-agent
+Maps to **Pipeline**. Sequential delegation where Agent A's output becomes Agent B's input. Use when work has clear dependencies: design spec → backend implementation → frontend integration → testing.
+
+### Hybrid
+Maps to **Supervisor** + **Expert Pool**. Central orchestrator routes tasks dynamically to specialists based on task type. Use when workload is heterogeneous: same orchestrator routes code review to security expert OR architecture expert depending on input.
+
+### Orchestrator
+Maps to **Hierarchical Delegation**. Multi-level decomposition where the orchestrator (MoAI) delegates to team leads, who delegate to specialists. Use for large projects with natural team boundaries: MoAI → backend lead → (database team + API team) + frontend lead → (UI team).
+
+### Specialist
+Maps to **Expert Pool** singleton. A single expert agent handles all tasks of a specific type without dynamic routing. Use for focused work: one code formatter, one security validator, one documentation generator.
+
+### Pipeline
+Generic **Pipeline** pattern. Sequential stages with each agent's output feeding the next. Already native to MoAI workflows. Use when linear dependency is explicit: requirements → design → implement → test → ship.

--- a/.claude/rules/moai/development/orchestrator-templates.md
+++ b/.claude/rules/moai/development/orchestrator-templates.md
@@ -1,0 +1,298 @@
+---
+description: "Three orchestrator templates for task coordination in MoAI-ADK workflows"
+paths: ".claude/rules/moai/core/moai-constitution.md,CLAUDE.md"
+---
+
+<!-- Source: revfactory/harness — Apache License 2.0 — see .claude/rules/moai/NOTICE.md -->
+
+# Orchestrator Templates
+
+Three orchestration patterns for the MoAI orchestrator when coordinating sub-agents and teams.
+
+---
+
+## Team-orchestrator
+
+**When to Use**:
+- Multiple agents need to communicate (not just return results)
+- Parallel exploration with cross-agent feedback is valuable
+- High-coordination complexity (shared task list, dynamic assignment)
+
+**Structure**:
+```
+User Request
+    ↓
+[MoAI] → TeamCreate → [Member A, Member B, Member C]
+         ↓
+      Coordination Loop:
+      - SendMessage (member-to-member)
+      - TaskCreate/Update (shared list)
+      - TeammateIdle hook (members idle when waiting)
+      ↓
+      Final Result Assembly
+      ↓
+      User Response
+```
+
+**How to Spawn**:
+```
+Agent(
+  subagent_type: "general-purpose",
+  mode: "acceptEdits",
+  prompt: "You are leading a 3-person team to solve X. "
+          "Create team via TeamCreate with members: [researcher, implementer, reviewer]. "
+          "Use SendMessage to coordinate. Use TaskCreate for shared work list. "
+          "Present final result to user."
+)
+```
+
+**Error Recovery**:
+- **Member fails task**: Other members continue, lead gets partial result
+- **Member goes idle**: Lead can SendMessage to resume or TaskCreate new work
+- **Communication loop endless**: Set max iteration count, escalate if stuck
+
+**Escalation Rules**:
+- If 2+ members report blocker → User AskUserQuestion for guidance
+- If member rejected shutdown → Lead waits 10s, then collects available output
+- If team creation fails → Fall back to sub-agent mode
+
+**Example: Research + Analysis + Synthesis**
+```
+Team Created: Researcher, Analyst, Synthesizer
+
+1. Researcher: "Investigating X..." → creates research-deep-dive.md
+2. Analyst: "Cross-checking findings..." → creates analysis-validation.md
+3. Researcher (via SendMessage): "Found Y, contradicts expectation"
+4. Analyst (reply): "Confirmed, Z explains it"
+5. Synthesizer: "Creating unified report..."
+6. All members idle
+7. Lead: "Here's the final report"
+8. Leader sends shutdown_request
+9. All approve
+10. TeamDelete
+```
+
+---
+
+## Sub-orchestrator
+
+**When to Use**:
+- Sequential task handoff (output A → input B)
+- Agent coordination not needed (results only matter)
+- Simpler, lower-coordination overhead
+
+**Structure**:
+```
+User Request
+    ↓
+[MoAI] → Delegate to Agent A
+         ↓ Result
+         Delegate to Agent B (with A's output)
+         ↓ Result
+         Delegate to Agent C
+         ↓ Result
+         Consolidate
+         ↓
+      User Response
+```
+
+**How to Spawn**:
+```javascript
+// Sequential
+const resultA = Agent(prompt: "Analyze X", subagent_type: "analyzer")
+const resultB = Agent(prompt: `Design based on: ${resultA}`, subagent_type: "designer")
+const resultC = Agent(prompt: `Implement: ${resultB}`, subagent_type: "implementer")
+
+// Consolidate
+MoAI: "Here are the results from the pipeline..."
+```
+
+**Error Recovery**:
+- **Agent A fails**: AskUserQuestion to proceed, skip, or retry
+- **Agent B fails**: Provide feedback and retry with adjustment
+- **Agent C fails**: Can use partial output from A+B or re-delegate
+
+**Escalation Rules**:
+- If 3+ agents fail in sequence → Escalate to user
+- If total tokens > 80% budget → Collect results and conclude
+- If result quality degrading → Switch to team mode for renegotiation
+
+**Example: Feature Development Pipeline**
+```
+1. Designer: "Create API spec for feature X"
+   → OpenAPI spec
+
+2. Backend: "Implement the API based on spec"
+   → API code + tests
+
+3. Frontend: "Create components based on API"
+   → UI code + hooks
+
+4. Tester: "Verify API + UI together"
+   → Integration test report
+
+5. MoAI: "Feature complete, ready for PR"
+```
+
+---
+
+## Hybrid-orchestrator
+
+**When to Use**:
+- Mix of sequential and parallel stages
+- Some stages need agent coordination, others don't
+- Maximum flexibility for complex workflows
+
+**Structure**:
+```
+Stage 1: Sequential (Sub-orchestrator)
+  Research Agent → Analysis Agent
+
+Stage 2: Parallel (Team-Orchestrator)
+  [TeamCreate] → [Implementation Team with Backend, Frontend, Tests]
+
+Stage 3: Sequential (Sub-orchestrator)
+  Reviewer Agent (review all outputs)
+
+Stage 4: Consolidate
+  Final result to user
+```
+
+**How to Spawn**:
+```
+// Stage 1: Sequential research
+const research = Agent(prompt: "Research X and Y")
+
+// Stage 2: Parallel implementation
+const implementation = Agent(
+  prompt: "Lead a team to implement based on research...",
+  teamCreate: true
+)
+
+// Stage 3: Sequential review
+const reviewed = Agent(
+  prompt: `Review this implementation: ${implementation}`,
+  subagent_type: "reviewer"
+)
+
+// Consolidate
+MoAI: "Implementation complete and reviewed"
+```
+
+**Error Recovery**:
+- **Sequential stage fails**: Retry or skip to next stage
+- **Team stage fails**: Fall back to sequential sub-agents for that stage
+- **Cascade failure**: Collect partial results, present to user with blockers
+
+**Escalation Rules**:
+- If any stage fails after 2 retries → AskUserQuestion for decision
+- If token budget exceeded → Prioritize remaining stages
+- If team created but failing → Offer to switch to sequential approach
+
+**Example: Full-Stack Feature Development**
+```
+Stage 1 (Research):
+- Research Agent: "Analyze requirements and existing architecture"
+
+Stage 2 (Implementation Team):
+- TeamCreate with Backend, Frontend, Tester
+- Parallel development for 2 days
+- Integration testing
+
+Stage 3 (Review):
+- Review Agent: "Security + performance review"
+
+Stage 4 (User Presentation):
+- "Feature ready, here's the PR"
+```
+
+---
+
+## Decision Matrix: Which Template?
+
+| Scenario | Template | Why |
+|----------|----------|-----|
+| Single feature, clear handoff | Sub | No coordination needed, simpler |
+| Feature with coordination required | Team | Agents need to negotiate |
+| Large feature with research + dev | Hybrid | Research sequential, dev parallel |
+| Bug investigation with hypotheses | Team | Debuggers need to share findings |
+| Simple change (style update) | Sub | Overkill for complexity |
+| Redesign involving multiple teams | Hybrid | Multiple phases with different needs |
+| API + Client in parallel | Team | Tight coordination needed |
+
+---
+
+## Common Patterns Within Templates
+
+### Sub-Orchestrator: Fan-out (Parallel Independent Results)
+```
+[MoAI] → Agent A, Agent B, Agent C (all in parallel)
+        Combine A, B, C results
+```
+
+**When**: Independent analyses that don't depend on each other
+**Example**: Concurrent code reviews from security + performance + architecture
+
+### Sub-Orchestrator: Pipeline (Sequential Handoff)
+```
+[MoAI] → Agent A → (result) → Agent B → (result) → Agent C
+```
+
+**When**: Each stage requires previous stage's output
+**Example**: Research → Design → Implementation → Testing
+
+### Team-Orchestrator: Shared Work List
+```
+[Lead] → TaskCreate([Task1, Task2, Task3])
+         Members self-select tasks
+         → TaskUpdate(Task1 complete)
+         → TaskUpdate(Task2 complete)
+         → Remaining tasks handled...
+```
+
+**When**: Work is decomposable, members can self-coordinate
+**Example**: Code migration (split files, each member migrates independently)
+
+---
+
+## Transition Rules
+
+**When to Switch Templates During Execution**:
+
+1. **Sub → Team**: If agents start reporting dependency on unplanned communication
+   - Action: Collect current results, spawn team for next stage
+
+2. **Team → Sub**: If team reaches deadlock or endless coordination loop
+   - Action: Break down remaining tasks for sequential agents
+
+3. **Hybrid → Simpler**: If complex workflow can be simplified
+   - Action: Skip stages, consolidate results
+
+**Signals to Transition**:
+- **Sub feeling like Team**: Agents sending feedback to each other → Create team instead
+- **Team feeling like Sub**: Agents work independently, little communication → Use sub-agents
+- **Over-engineering**: Simple task using complex template → Simplify
+
+---
+
+## Monitoring & Adjustment
+
+**During Execution**:
+- Monitor agent progress via status messages
+- Track token consumption against budget
+- Check for communication loops or idle periods
+- Assess quality of intermediate results
+
+**Decision Points**:
+- After each major stage: Is approach working? Continue or adjust?
+- At 75% token budget: Prepare to conclude or escalate
+- After first failure: Retry with same template or switch?
+
+**Adjustment Options**:
+- Continue with current template
+- Switch to different template mid-stream
+- Add more agents / members to current team
+- Remove members / agents if not contributing
+- Escalate to user for guidance
+
+These three templates provide proven structures for most MoAI orchestration scenarios. Mix and match as needed for your specific workflow.

--- a/.claude/rules/moai/development/skill-ab-testing.md
+++ b/.claude/rules/moai/development/skill-ab-testing.md
@@ -1,0 +1,221 @@
+---
+description: "A/B testing methodology for skill quality validation and iteration"
+paths: ".claude/skills/**/SKILL.md,.claude/skills/**/*.md"
+---
+
+<!-- Source: revfactory/harness — Apache License 2.0 — see .claude/rules/moai/NOTICE.md -->
+
+# Skill A/B Testing Methodology
+
+Systematic approach to validating skill quality through comparative testing against baseline and iterative improvement.
+
+## Core Principle
+
+**With-Skill vs Baseline Comparison**: Every skill quality evaluation must compare performance with the skill loaded against performance without the skill under identical conditions.
+
+---
+
+## Test Framework
+
+### Test Prompt Design
+
+Create 2-3 test prompts that represent realistic use cases:
+
+**Characteristics of Good Test Prompts**:
+- Concrete and specific (avoid "analyze this")
+- Natural language as users would write
+- Cover core use case + edge case + optional complexity case
+- Mix of explicit instructions and implicit context
+
+**Bad Test Prompts**:
+- "Generate code" (too vague)
+- "Use this framework" (too prescriptive)
+
+**Good Test Prompts**:
+- "I have a React form with email + password fields. The password needs validation (min 8 chars, 1 uppercase, 1 number). Show me the hook code and tests."
+- "This CSV has 3 columns: date, revenue, cost. Add a 4th column: profit margin %. Then sort by margin descending. Include handling for missing data."
+
+### Test Execution: With-Skill vs Baseline
+
+For each test prompt, execute **two parallel runs**:
+
+| Dimension | With-Skill | Baseline |
+|-----------|-----------|----------|
+| **Prompt** | Same prompt + skill provided | Same prompt, no skill |
+| **Output Path** | `_workspace/eval-{id}/with_skill/outputs/` | `_workspace/eval-{id}/without_skill/outputs/` |
+| **Model** | Same model | Same model |
+| **Constraints** | Same token budget, temperature | Same constraints |
+
+### Metrics to Capture
+
+**Token Usage**:
+- `total_tokens`: Tokens consumed (lower is better for same quality)
+- **Improvement**: (baseline_tokens - with_skill_tokens) / baseline_tokens
+
+**Duration**:
+- `duration_ms`: Wall-clock time (lower is better)
+- **Speedup**: baseline_duration / with_skill_duration
+
+**Quality Dimensions** (require manual evaluation or assertion-based scoring):
+
+| Dimension | Measurement |
+|-----------|-------------|
+| **Correctness** | Does output solve the stated problem? (Boolean or %) |
+| **Completeness** | Are all requirements met? (0-100%) |
+| **Clarity** | Is code/response clear and well-organized? (0-100%) |
+| **Efficiency** | Is approach optimal? (0-100%) |
+
+---
+
+## Assertion-Based Scoring
+
+For skills with objective outputs (code generation, data extraction), define assertions:
+
+**Structure**:
+```
+Expectation: "{human-readable expectation}"
+Assertion: "{programmatic check}"
+Evidence: "{what to look for in output}"
+```
+
+**Example Assertions**:
+- `output.includes("useState") && output.includes("useEffect")` — React hooks present
+- `fs.existsSync("output.csv") && csvHasRows("output.csv", 3)` — File created with data
+- `jsAst.hasFunction("validateEmail") && hasReturnType(...)` — Function signature correct
+
+**Scoring Rules**:
+- Each assertion: 0 or 1 (or partial: 0.0-1.0)
+- Score = assertions_passed / total_assertions
+- **Improvement** = (with_skill_score - baseline_score) / baseline_score
+
+---
+
+## Statistical Significance
+
+### Sample Size Guidance
+
+| Difference Magnitude | Recommended Samples |
+|---------------------|-------------------|
+| ≥ 20% improvement | 2-3 samples (clear signal) |
+| 10-20% improvement | 3-5 samples (moderate signal) |
+| 5-10% improvement | 5-10 samples (weak signal, noise risk) |
+| < 5% improvement | 10+ samples (ignore if < 2x total_tokens cost) |
+
+### Variance Factors
+
+Test prompt variance matters more than sample count. If your 2 test prompts exercise different skill aspects, they may be sufficient. If they're similar, results are less reliable.
+
+**High-Variance Prompts** (good):
+- Different domains (API design vs database design)
+- Different skill uses (reference lookup vs advanced decision-making)
+- Different complexity (simple vs complex scenario)
+
+**Low-Variance Prompts** (less reliable):
+- Similar domain (REST API v1 vs REST API v2)
+- Similar complexity (both simple, both complex)
+
+---
+
+## Iteration Workflow
+
+### Single Iteration Cycle
+
+1. **Define Baselines**: Capture "with-skill" and "without-skill" outputs for 2-3 prompts
+2. **Measure Metrics**: Token count, duration, assertion score
+3. **Calculate Improvement**: (with_skill - baseline) / baseline for each metric
+4. **Identify Gaps**: Which assertions failed? What prompt broke the skill?
+5. **Refine Skill**: Improve description (better triggering), body (clearer instructions), schema
+6. **Re-test**: Repeat with updated skill
+
+### When to Iterate
+
+**Continue iterating if**:
+- Assertion pass rate < 80%
+- With-skill score < baseline (regression)
+- Improvement < 10% on primary metric (consider skill value)
+- Skill fails on edge case prompt
+
+**Stop iterating if**:
+- 3+ iterations with < 5% improvement (diminishing returns)
+- Improvement plateaued (no new gains for 2 cycles)
+- Skill meets acceptance criteria (80%+ quality, 10%+ improvement)
+
+### Iteration Cap
+
+Set `max_iterations: 5` to prevent unbounded refinement. If quality target not met after 5 iterations, consider redesigning the skill or reconsidering whether it's valuable.
+
+---
+
+## Evaluation Checklist
+
+**Before declaring skill complete**:
+
+- [ ] 2-3 realistic test prompts defined
+- [ ] With-skill and baseline runs executed for each prompt
+- [ ] Token cost comparison calculated
+- [ ] Quality assertions defined and scored (if applicable)
+- [ ] With-skill improvement ≥ 10% on primary metric, ≥ 0% on all metrics (no regression)
+- [ ] All edge case prompts pass
+- [ ] Description accurately reflects trigger conditions
+- [ ] Body structure follows progressive disclosure (Quick / Implementation / Advanced if large)
+- [ ] Frontmatter complete (description, paths, metadata)
+
+---
+
+## Common Pitfalls
+
+**Pitfall 1**: "Baseline that always passes"
+- Assertion designed to pass with or without skill (non-discriminating)
+- Fix: Baseline should have a lower score; skill should improve it measurably
+
+**Pitfall 2**: "Token usage only metric"
+- Token improvement doesn't guarantee quality improvement
+- Fix: Always include quality metrics (assertions, manual evaluation)
+
+**Pitfall 3**: "Single test prompt"
+- One prompt may be lucky (skill happens to match well)
+- Fix: Test 2-3 diverse prompts to validate generalization
+
+**Pitfall 4**: "Ignoring model variance"
+- Same prompt with different models/temperatures gives different results
+- Fix: Keep model and constraints constant between with/baseline
+
+**Pitfall 5**: "Unbounded iteration"
+- Skill refinement never converges
+- Fix: Set max_iterations and stop when improvement < threshold
+
+---
+
+## Reporting
+
+For each skill iteration, document:
+
+```markdown
+## Iteration N Test Results
+
+### Test Prompts
+1. [Prompt A description]
+2. [Prompt B description]
+
+### Token Metrics
+| Prompt | With-Skill | Baseline | Improvement |
+|--------|-----------|----------|-------------|
+| A | 5,234 | 6,102 | +14.2% |
+| B | 3,891 | 4,012 | +2.9% |
+| **Average** | — | — | **+8.5%** |
+
+### Quality Metrics
+| Assertion | With-Skill | Baseline | Status |
+|-----------|-----------|----------|--------|
+| Output is valid code | 100% | 75% | ✅ PASS |
+| Includes all features | 100% | 50% | ✅ PASS |
+| Well-formatted | 100% | 60% | ✅ PASS |
+| **Average Score** | **100%** | **61.7%** | ✅ **+61.7%** |
+
+### Conclusion
+- Improvement target: ≥10% ✅ Met (8.5% token, +61.7% quality)
+- All assertions passing ✅
+- Ready for release
+```
+
+This methodology ensures skills provide measurable value before being marked complete.

--- a/.claude/rules/moai/development/skill-writing-craft.md
+++ b/.claude/rules/moai/development/skill-writing-craft.md
@@ -1,0 +1,347 @@
+---
+description: "Skill writing guidelines covering description craft, body structure, and schema"
+paths: ".claude/skills/**/SKILL.md"
+---
+
+<!-- Source: revfactory/harness — Apache License 2.0 — see .claude/rules/moai/NOTICE.md -->
+
+# Skill Writing Craft
+
+Guidelines for writing high-quality skills: description triggering, body structure, and schema validation.
+
+---
+
+## Part 1: Description Craft
+
+The description field is **read-only metadata** that Claude Code uses to decide whether to load your skill into context. It's not displayed to users.
+
+### Writing a Good Description
+
+**Purpose**: Summarize when the skill should trigger, in a single sentence. Optimize for Claude Code's context matcher.
+
+**Template**:
+```
+{Capability Summary}: {Domain Keywords} for {Use Case}
+```
+
+**Examples**:
+
+| Skill | Good Description | Why |
+|-------|------------------|-----|
+| moai-domain-frontend | "React 19 / Next.js 16 component development with modern patterns" | Clear domain (React/Next) + capability (components) + keywords |
+| moai-ref-testing-pyramid | "Test strategy and pyramid patterns for unit/integration/E2E coverage" | Clear domain (testing) + specific patterns + coverage levels |
+| moai-library-shadcn | "shadcn/ui component library for React with TypeScript integration" | Clear library name + framework + integration |
+
+**Bad Descriptions** (too vague, won't trigger):
+- "General programming help" (too broad)
+- "Code quality" (ambiguous — which kind?)
+- "Documentation tool" (doesn't specify what documentation)
+
+### When to Trigger vs When to Skip
+
+**The skill should trigger when the user is**:
+- Explicitly asking for the domain (e.g., "help with React hooks")
+- Working in the domain (e.g., modifying a `.tsx` file)
+- Referencing the specific capability (e.g., "create component library")
+
+**The skill should NOT trigger when**:
+- User is asking about a different domain (e.g., "help with Python" to a React skill)
+- The capability is handled by general knowledge (e.g., "basic syntax" for moai-library-shadcn)
+- The skill would duplicate general MoAI capabilities (e.g., moai-domain-backend shouldn't trigger for "debug this Go error")
+
+### Paths Frontmatter for Smart Triggering
+
+Use the `paths` field to control when your skill is auto-loaded by Claude Code:
+
+```yaml
+---
+description: "Skill description"
+paths: ".claude/skills/**/*.md,**/hooks/**/*.ts"
+---
+```
+
+**Path Patterns** (glob syntax):
+- `**/*.tsx` — Any TypeScript React file
+- `**/*_test.go` — Any Go test file
+- `.moai/config/**/*.yaml` — Configuration files
+- `src/api/**/*` — API directory
+
+**Strategy**:
+- Use `paths` for automatic domain detection
+- Use `description` as fallback for manual triggering
+- Combine: paths + description = high-precision triggering
+
+---
+
+## Part 2: Body Structure — Progressive Disclosure
+
+The skill body should follow a three-level progressive disclosure structure:
+
+### Level 1: Quick Reference (100-200 lines)
+
+**Contents**:
+- One-line summary
+- Key concepts (5-7 bullet points)
+- When to use this skill
+- Typical workflow (3-5 steps)
+- Links to deeper content
+
+**Token Cost**: ~1,500 tokens
+
+**Example Structure**:
+```markdown
+# Skill Name
+
+One-line summary: what this skill provides
+
+## Quick Concepts
+- Concept A: explanation
+- Concept B: explanation
+- Concept C: explanation
+
+## When to Use
+- Scenario 1
+- Scenario 2
+
+## Typical Workflow
+1. Step A
+2. Step B
+3. Step C
+
+## See Also
+- [Deep dive topic] — modules/topic.md
+- [Examples] — examples.md
+```
+
+### Level 2: Implementation Guide (500-1,500 lines)
+
+**Contents**:
+- Detailed workflows with code snippets
+- Real-world patterns
+- Integration examples
+- Configuration reference
+- Common patterns and their implementation
+
+**Token Cost**: ~3,000-5,000 tokens
+
+**Structure**:
+```markdown
+## Implementation Guide
+
+### Pattern 1: Name
+- Description
+- When to apply
+- Example code (pseudo-code or multi-language)
+- Integration with MoAI
+
+### Pattern 2: Name
+...
+
+### Configuration
+- Key settings
+- Defaults
+- Override mechanisms
+```
+
+### Level 3: Advanced & Reference (Unlimited)
+
+**Contents**:
+- Deep technical dives
+- Edge cases and workarounds
+- Performance optimization
+- Troubleshooting guides
+- Full API reference
+
+**Token Cost**: On-demand (user explicitly requests)
+
+**Structure**:
+```markdown
+## Advanced Topics
+
+### Topic 1: Name
+[Full technical treatment]
+
+### Topic 2: Name
+[Extended examples]
+
+## Reference
+- [External documentation]
+- [Related specs]
+- [Tool configuration]
+```
+
+### File Organization for Large Skills
+
+When body exceeds 500 lines, split into modules:
+
+```
+.claude/skills/my-skill/
+├── SKILL.md (Quick Reference + Implementation, ≤500 lines)
+├── modules/
+│   ├── advanced-patterns.md
+│   ├── troubleshooting.md
+│   └── reference.md
+├── examples.md
+└── reference.md
+```
+
+**Linking Between Levels**:
+- SKILL.md references → `See also: [Topic] — modules/topic.md`
+- Examples → `Examples: [Name] — examples.md#section`
+- External resources → `Reference: [Tool] — reference.md#api`
+
+---
+
+## Part 3: Frontmatter Schema
+
+Every skill MUST have complete frontmatter:
+
+```yaml
+---
+name: "Display Name of Skill"
+description: "One-line description for context matching"
+type: skill
+paths: "**/*.tsx,**/__tests__/**"
+domains: ["frontend", "testing"]
+model: "default"
+effort: "high"
+tools: ["WebSearch", "WebFetch", "Bash", "Read", "Write", "Edit", "Grep", "Glob"]
+allowed-tools: "WebSearch,WebFetch,Bash,Read,Write,Edit,Grep,Glob"
+---
+```
+
+### Field Reference
+
+| Field | Required | Type | Notes |
+|-------|----------|------|-------|
+| `name` | ✅ | string | Display name, 30-50 chars |
+| `description` | ✅ | string | Single sentence, ≤80 chars, context-matching optimized |
+| `type` | ✅ | string | Always `"skill"` |
+| `paths` | Optional | string | Glob pattern CSV (no YAML array) |
+| `domains` | Optional | array | Topic categories for organization |
+| `model` | Optional | string | `"default"`, `"opus"`, `"sonnet"` |
+| `effort` | Optional | string | `"low"`, `"medium"`, `"high"`, `"xhigh"` |
+| `tools` | Optional | array | Full tool array (if providing access) |
+| `allowed-tools` | Optional | string | CSV string of tool names |
+
+### Validation Rules
+
+**Rule 1: `paths` is CSV string, NOT YAML array**
+```yaml
+# WRONG
+paths:
+  - "**/*.tsx"
+  - "**/__tests__/**"
+
+# CORRECT
+paths: "**/*.tsx,**/__tests__/**"
+```
+
+**Rule 2: Single-sentence description**
+```yaml
+# WRONG
+description: "Frontend development. React and Next.js. Components and hooks."
+
+# CORRECT
+description: "React 19 and Next.js 16 component development with hooks"
+```
+
+**Rule 3: tool vs allowed-tools**
+```yaml
+# Use EITHER tools (array) OR allowed-tools (CSV string), not both
+
+# OPTION A: Array form
+tools:
+  - WebSearch
+  - Bash
+  - Read
+
+# OPTION B: CSV form
+allowed-tools: "WebSearch,Bash,Read"
+```
+
+**Rule 4: Accurate domains**
+```yaml
+domains: ["frontend", "testing"]  # Correct
+domains: ["frontend"]  # Missing testing even though skill covers both
+
+# Use domains that match skill content
+```
+
+### Common Frontmatter Patterns
+
+**API/CLI Reference Skill**:
+```yaml
+---
+name: "Tool Name Reference"
+description: "Tool Name CLI commands and API reference for common use cases"
+type: skill
+paths: "**/*.ts,**/*.py,README.md"
+domains: ["reference", "api"]
+effort: "low"
+allowed-tools: "WebFetch,Read,Grep"
+---
+```
+
+**Code Implementation Skill**:
+```yaml
+---
+name: "Framework Feature"
+description: "Framework Feature implementation patterns with examples"
+type: skill
+paths: "src/**/*.tsx,**/*_test.tsx"
+domains: ["framework", "implementation"]
+effort: "high"
+allowed-tools: "WebSearch,WebFetch,Bash,Read,Write,Edit,Grep,Glob"
+---
+```
+
+**Analysis/Research Skill**:
+```yaml
+---
+name: "Topic Analysis"
+description: "Topic Analysis and research methodology with patterns"
+type: skill
+paths: "docs/**,**/*.md,SPEC-*"
+domains: ["research", "analysis"]
+effort: "medium"
+allowed-tools: "WebSearch,WebFetch,Read,Grep"
+---
+```
+
+---
+
+## Schema Validation
+
+Before committing a skill, verify:
+
+- [ ] Frontmatter fields all present and valid
+- [ ] `name` matches actual skill capability
+- [ ] `description` is single sentence, ≤80 characters
+- [ ] `paths` is CSV string (not YAML array)
+- [ ] `domains` accurately reflect skill scope
+- [ ] `allowed-tools` matches actual tool usage in body
+- [ ] No tool used without being listed in frontmatter
+- [ ] Body follows progressive disclosure (Quick/Implementation/Advanced if >500 lines)
+- [ ] Cross-references in body match actual file paths
+- [ ] Examples are copy-paste ready with comments
+- [ ] External references are verified (URLs valid)
+
+---
+
+## Skill Quality Checklist
+
+**Before marking a skill complete**:
+
+- [ ] Description triggers correctly (tested with Claude Code)
+- [ ] Quick Reference is scannable (≤200 lines, clear structure)
+- [ ] Implementation examples are language-neutral (pseudo-code or multi-language)
+- [ ] No hardcoded framework/language bias
+- [ ] Advanced section covers edge cases
+- [ ] Examples run without modification (or clearly noted limitations)
+- [ ] All external links verified and current
+- [ ] Frontmatter complete and valid
+- [ ] Domains reflect actual coverage
+- [ ] No duplicate content with other skills
+
+This craft guide ensures skills are discoverable, usable, and maintainable.

--- a/.claude/rules/moai/quality/boundary-verification.md
+++ b/.claude/rules/moai/quality/boundary-verification.md
@@ -1,0 +1,209 @@
+---
+description: "Boundary verification methodology for detecting integration defects"
+paths: "**/*_test.go,**/*test*.py,**/*test*.ts,**/*test*.rs,**/test/**,**/tests/**"
+---
+
+<!-- Source: revfactory/harness — Apache License 2.0 — see .claude/rules/moai/NOTICE.md -->
+
+# Boundary Verification
+
+Systematic methodology for detecting defects at component boundaries. These defects are missed by individual component testing but manifest when components interact.
+
+## Overview
+
+**Core Problem**: Individual components test correctly, but integration fails at boundaries. TypeScript generics, type casting, and absent cross-validation create boundary defects that unit tests cannot catch.
+
+**Key Principle**: "Boundary bugs are not found by testing each side alone. Both sides must be read together."
+
+---
+
+## Case Studies
+
+### Case 1: API Response Schema Mismatch
+
+**Symptom**: API returns correct data structure, frontend hook receives it, but runtime fails because the shape doesn't match type expectation.
+
+**Example**: 
+- Backend API returns: `{ projects: [{ id, name }] }`
+- Frontend hook expects generic type parameter: `SlideProject[]`
+- TypeScript compilation passes (generic casting hides mismatch)
+- Runtime error: `Cannot read property 'name' of undefined`
+
+**Root Cause**: API and hook typed independently without cross-validation. Generic type parameters bypass compile-time checking.
+
+**Boundary Condition to Test**:
+- Actual API response must be unwrapped if wrapped in outer object
+- Field names (camelCase vs snake_case) must match
+- Required vs optional fields must align
+
+**Verification Strategy**:
+1. Locate API route and extract `NextResponse.json()` payload structure
+2. Locate corresponding frontend hook and extract generic type `T`
+3. Trace payload from source through any transformation
+4. Verify hook calls `.json<T>()` with correct extraction (e.g., `response.projects` if API wraps)
+5. Create test: invoke both simultaneously, capture actual response and expected type
+
+---
+
+### Case 2: File Path to Router Mismatch
+
+**Symptom**: Link leads to non-existent URL, or router redirects fail silently.
+
+**Example**:
+- Page exists at: `src/app/dashboard/create/page.tsx` → URL `/dashboard/create`
+- Link href specified as: `/create` (missing `/dashboard` prefix)
+- Browser navigates to `/create`, which doesn't exist
+
+**Root Cause**: File structure and link paths not cross-validated. Route groups and dynamic segments add complexity.
+
+**Boundary Condition to Test**:
+- All `href`, `router.push()`, `redirect()` values must map to actual page files
+- Route group parentheses `(group)` must be excluded from URL path
+- Dynamic segments `[id]` must be recognized as variable segments
+
+**Verification Strategy**:
+1. Extract all page files from `src/app/` and construct their URL paths
+2. Extract all navigation calls (`href=`, `router.push(`, `redirect(`)
+3. Verify each reference maps to an actual page URL
+4. Test: click each link in real browser (Playwright/E2E), verify page loads
+
+---
+
+### Case 3: State Transition Incompleteness
+
+**Symptom**: State transitions defined in spec but not fully implemented; intermediate states become dead ends.
+
+**Example**:
+- State transition map allows: `generating_template` → `template_approved`
+- Implementation updates status to `generating_template` but never transitions to `template_approved`
+- Component stuck in `generating_template` state indefinitely
+
+**Root Cause**: State map and state update code not cross-validated. All transitions must have corresponding implementation.
+
+**Boundary Condition to Test**:
+- Every transition in the state map must have code that executes it
+- No "dead" transitions (defined but unreachable)
+- All intermediate states must have exit paths
+
+**Verification Strategy**:
+1. Extract state machine definition (transition map or state type)
+2. Grep all code for `.update({ status: ... })` or equivalent state changes
+3. Verify every allowed transition has an implementation
+4. Verify every implemented transition is in the state map (no rogue transitions)
+5. Test: trace state changes for each workflow, verify all transitions execute
+
+---
+
+### Case 4: Field Name Mismatch (camelCase ↔ snake_case)
+
+**Symptom**: Field names differ between database (snake_case), API (camelCase), and frontend types (camelCase). One layer doesn't translate correctly.
+
+**Example**:
+- DB column: `thumbnail_url`
+- API response: `{ thumbnailUrl: "..." }`
+- Frontend type: `interface SlideProject { thumbnail_url: string }`
+- Actual data: `obj.thumbnailUrl` exists but type expects `obj.thumbnail_url`
+
+**Root Cause**: Automatic transformation skipped in one layer. No validation of field name consistency across layers.
+
+**Boundary Condition to Test**:
+- Field name transforms must be applied consistently
+- API response must be serialized to frontend type correctly
+- TypeScript `Pick` or destructuring must use correct names
+
+**Verification Strategy**:
+1. Document field naming convention per layer (DB, API, frontend)
+2. Trace field through transformation: DB → API response → TS type
+3. Verify transformation applied at each boundary
+4. Create assertion: sample API response must serialize to frontend type without field errors
+5. Test: `Object.keys(apiResponse) ===  Object.keys(frontendType)` after transformation
+
+---
+
+### Case 5: Missing API Endpoint Implementation
+
+**Symptom**: Frontend calls API endpoint that is called but never executed (missing implementation or wrong route).
+
+**Example**:
+- Frontend hook calls `POST /api/projects/123/approve`
+- API route `src/app/api/projects/[id]/approve/route.ts` not found
+- Request returns 404, but frontend silently handles error
+
+**Root Cause**: API defined in documentation but not implemented. Frontend assumes availability.
+
+**Boundary Condition to Test**:
+- Every frontend fetch must have a corresponding API route
+- Route signature must match (HTTP method, path parameters)
+- API must handle the request (not just exist as an empty file)
+
+**Verification Strategy**:
+1. Extract all frontend `fetch()` calls with URLs
+2. Extract all API routes from `src/app/api/**`
+3. Verify 1:1 correspondence
+4. For each unimplemented endpoint: mark as "intentional stub" or implement
+5. Test: E2E flow that exercises each endpoint
+
+---
+
+### Case 6: Async Response Shape Inconsistency
+
+**Symptom**: API returns shape for immediate response (`202 Accepted`) but frontend expects final result shape. Polling or websocket updates with different shape cause runtime error.
+
+**Example**:
+- Initial response: `{ status: "processing", taskId: 123 }`
+- Final result (via webhook): `{ status: "complete", data: [...], errors: [...] }`
+- Frontend type union doesn't account for both shapes
+- Code accesses `.data` on initial response, crashes
+
+**Root Cause**: Async workflows have multiple response shapes. Type definitions cover only one shape.
+
+**Boundary Condition to Test**:
+- Initial response shape must be typed separately from final shape
+- Frontend code must handle both shapes
+- State machine must track which shape is current
+
+**Verification Strategy**:
+1. Identify async workflows (202 responses, polling, webhooks)
+2. Document all possible response shapes at each stage
+3. Create union type covering all shapes: `InitialResponse | FinalResponse`
+4. Verify code uses discriminator field (`status`) to handle each shape
+5. Test: invoke async endpoint, verify response at each stage matches expected shape
+
+---
+
+### Case 7: TypeScript Generic Casting Bypass
+
+**Symptom**: Generic casting (`as T`, `as unknown as T`) bypasses type safety. Mismatch exists but compilation succeeds.
+
+**Example**:
+- API type: `interface ApiResponse { projects: Project[] }`
+- Frontend code: `const data = await fetchJson<SlideProject[]>(url)`
+- No intermediate unwrapping: `response.projects` forgotten
+- Type works but runtime data is `{ projects: [...] }` not `SlideProject[]`
+
+**Root Cause**: Generic type parameters are not validated at the boundaries. Cast operations bypass static checks.
+
+**Boundary Condition to Test**:
+- Generic types must match actual runtime data shape
+- Type casting (especially `as any` or unconstrained `as T`) must be verified
+- No use of generic type parameters without explicit data transformation
+
+**Verification Strategy**:
+1. Audit all `fetchJson<T>` calls and verify `T` matches actual API response shape
+2. Grep for unsafe casts: `as any`, `as unknown`, unconstrained generic `as T`
+3. For each cast, document why it's safe and verify with integration test
+4. Disable TypeScript implicit `any` in `tsconfig.json`
+5. Test: runtime data must deserialize to type without casting
+
+---
+
+## Verification Strategy Summary
+
+1. **Extract Boundaries**: Identify component interaction points (API ↔ Frontend, DB ↔ API, State ↔ Code)
+2. **Cross-Read**: Read both sides of each boundary simultaneously
+3. **Trace Data**: Follow data transformation from source to consumer
+4. **Verify Contracts**: Ensure implicit contracts (naming, shape, transitions) are honored
+5. **Test Integration**: Unit tests don't catch boundary bugs; integration/E2E tests required
+6. **Document Assumptions**: Explicitly state assumptions about field names, response shapes, state transitions
+
+**Golden Rule**: If a boundary can fail, the test must exercise both sides of the boundary.

--- a/.claude/rules/moai/workflow/team-pattern-cookbook.md
+++ b/.claude/rules/moai/workflow/team-pattern-cookbook.md
@@ -1,0 +1,312 @@
+---
+description: "Five team execution patterns with role profiles and communication protocols"
+paths: ".moai/config/sections/workflow.yaml,.claude/rules/moai/workflow/team-protocol.md"
+---
+
+<!-- Source: revfactory/harness — Apache License 2.0 — see .claude/rules/moai/NOTICE.md -->
+
+# Team Pattern Cookbook
+
+Five proven patterns for orchestrating Agent Teams in MoAI-ADK, with role compositions, file ownership, and communication protocols.
+
+---
+
+## Research Team
+
+**Purpose**: Parallel exploration of a topic from multiple angles, with cross-team learning and synthesis.
+
+**Composition**:
+- Research Analyst A: Technical deep dive
+- Research Analyst B: Community/user perspective
+- Analyst C: Market/competitive analysis
+
+**File Ownership**:
+- research-deep-dive.md — Analyst A (technical research)
+- research-community.md — Analyst B (user/community insights)
+- research-market.md — Analyst C (market competitive landscape)
+- research-synthesis.md — Team Lead (combines all perspectives)
+
+**Communication Protocol**:
+1. Each analyst runs independently on their angle
+2. Analysts share findings via SendMessage when insights contradict or amplify
+3. Team Lead synthesizes into unified research.md
+4. On conflict: present both perspectives with evidence, let user decide
+
+**When Discovery Helps**:
+- Large research topics where single perspective misses nuance
+- Competing claims in sources (user research vs product goals)
+- Need to quickly validate from multiple angles before committing to architecture
+
+**When Solo Agent Better**:
+- Research is straightforward (single source, clear answer)
+- Team coordination overhead > quality gain
+
+**Example Coordination**:
+```
+Analyst A: "Current framework adoption is X%"
+Analyst B: "But users in forums complain about X's learning curve"
+Analyst C: "Competitors using X report Y% migration cost"
+Team Lead: "Synthesize these into: X is popular but has adoption risk, competitors mitigating via Z"
+```
+
+**Shutdown Sequence**:
+1. All analysts TaskUpdate their findings as "complete"
+2. Team Lead assembles synthesis.md
+3. Team Lead sends synthesis to user
+4. Team sends shutdown_request approval to leader
+5. Leader runs TeamDelete
+
+---
+
+## Implementation Team
+
+**Purpose**: Parallel development of independent modules with file-level ownership to prevent conflicts.
+
+**Composition**:
+- Backend Developer: API endpoints, database, business logic
+- Frontend Developer: UI components, client-side logic, hooks
+- Test Specialist: Unit + integration tests, coverage
+
+**File Ownership**:
+- `src/api/**/*.go` (or equivalent backend) — Backend Dev
+- `src/components/**/*.tsx`, `src/hooks/**/*.ts` — Frontend Dev
+- `**/*_test.go`, `**/__tests__/**` — Test Specialist (read-only, but owns test files)
+
+**Communication Protocol**:
+1. Backend Dev creates API contract document (types, endpoints)
+2. Frontend Dev reads contract, creates matching hooks and components
+3. Test Specialist writes tests for both layers
+4. Boundary issues escalate via SendMessage (e.g., "API response shape doesn't match hook expectation")
+5. Backend Dev and Frontend Dev synchronize via SendMessage, then re-implement
+
+**When Team Works**:
+- Clear file boundaries (backend/frontend separation)
+- API contract can be defined upfront
+- Parallel development saves time over sequential
+
+**When Sequential Better**:
+- API contract is ambiguous or evolving
+- Heavy backend-frontend coupling
+- Files are tightly interdependent (can't work in parallel)
+
+**Example Workflow**:
+```
+Day 1:
+  - Backend: Define API schema + endpoints
+  - Frontend: Read schema, start building hooks
+  - Tests: Write integration tests against API contract
+
+Day 2:
+  - Backend: Implement API
+  - Frontend: Implement UI with hooks
+  - Tests: Run tests, report boundary issues
+
+Day 3:
+  - Backend + Frontend: Sync on boundary defects, iterate
+  - Tests: Verify fixes
+```
+
+**Shutdown Sequence**:
+1. Backend Dev marks implementation complete
+2. Frontend Dev marks implementation complete
+3. Test Specialist verifies all tests green, marks complete
+4. Team shuts down after all members idle/complete
+
+---
+
+## Review Team
+
+**Purpose**: Parallel code review from multiple perspectives (security, performance, architecture).
+
+**Composition**:
+- Security Reviewer: Auth, input validation, OWASP
+- Performance Reviewer: Algorithms, caching, bottlenecks
+- Architecture Reviewer: Design patterns, modularity, scalability
+
+**File Ownership**:
+- All read-only (mode: plan)
+- Each reviewer focuses on their dimension
+
+**Communication Protocol**:
+1. All reviewers read full changeset independently
+2. Each creates review report in their dimension
+3. Reviewers find conflicting opinions via SendMessage (e.g., "Architecture recommends caching, Performance says caching adds complexity here")
+4. Discuss and reach consensus on each conflict
+5. Single unified review output
+
+**When Parallel Review Helps**:
+- Large changes affecting multiple dimensions
+- Security and performance often have tradeoffs (need expert negotiation)
+- Parallel review faster than sequential
+
+**When Single Reviewer Better**:
+- Small, focused change (one dimension)
+- Reviewer specialization not clear-cut
+
+**Example Conflict Resolution**:
+```
+Sec Reviewer: "Add input validation before query"
+Perf Reviewer: "Validation adds latency, query sanitization sufficient"
+Arch Reviewer: "Input validation should be middleware, separate concern"
+Consensus: Input validation in middleware (architecture clean, performance acceptable, security strengthened)
+```
+
+**Shutdown Sequence**:
+1. All reviewers complete review reports
+2. Team Lead synthesizes into single PR feedback
+3. Team applies feedback or marks as "reviewed with concerns"
+4. TeamDelete
+
+---
+
+## Design Team
+
+**Purpose**: Collaborative design exploration with design, user experience, and stakeholder perspectives.
+
+**Composition**:
+- Visual Designer: UI/visual language, component design
+- UX Designer: User flow, interaction patterns, accessibility
+- Product Lead: Stakeholder requirements, business goals alignment
+
+**File Ownership**:
+- `design-visual.md` — Visual Designer (color, typography, component spec)
+- `design-ux.md` — UX Designer (flows, interactions, accessibility)
+- `design-product.md` — Product Lead (requirements, success metrics)
+
+**Communication Protocol**:
+1. All start with the same design brief
+2. Visual Designer proposes component system
+3. UX Designer reviews flows against components
+4. Product Lead validates against business goals
+5. Conflicts resolved via SendMessage + negotiation
+6. Iterate until all three approve
+
+**When Collaborative Design Helps**:
+- Complex user flows requiring visual + interaction + product alignment
+- Stakeholder conflict needs real-time discussion
+- Design iterations benefit from multiple perspectives
+
+**When Solo Designer Better**:
+- Simple UI updates (button style, color tweak)
+- Designer has full context and authority
+
+**Example Iteration**:
+```
+Visual: "Dark mode with minimalist components"
+UX: "Dark mode affects contrast for accessibility, reconsider"
+Product: "Accessibility is requirement, let's support both modes"
+Visual: "Update spec: light + dark modes, WCAG AAA contrast"
+UX: "Flows work with both modes, approved"
+Product: "Meets requirements, approved"
+```
+
+**Shutdown Sequence**:
+1. All three approve design
+2. Team produces final design.md with visual, UX, and product sections
+3. TeamDelete
+
+---
+
+## Debug Team
+
+**Purpose**: Parallel investigation of a complex bug from multiple angles.
+
+**Composition**:
+- Reproducer: Isolates and documents the bug with test case
+- Analyzer: Traces code paths to identify likely root causes
+- Verifier: Tests hypotheses and validates fixes
+
+**File Ownership**:
+- `bug-reproduction.md` + `test_repro.go` — Reproducer
+- `bug-analysis.md` — Analyzer
+- `bug-verification.md` + test runs — Verifier
+
+**Communication Protocol**:
+1. Reproducer creates minimal test case that fails
+2. Analyzer reads test and code, identifies likely causes
+3. Verifier runs hypothesis tests (e.g., "What if we change X?")
+4. Analyzer synthesizes hypotheses into ranked list: most likely → least likely
+5. Team tests ranked list systematically
+6. First successful hypothesis is root cause
+
+**When Parallel Debug Helps**:
+- Complex bug with multiple possible causes
+- Reproducing bug requires specialist skills
+- Multiple hypotheses to test (can test in parallel)
+
+**When Single Debugger Better**:
+- Bug is simple (obvious from symptom)
+- Reproducing requires deep system context
+
+**Example Investigation**:
+```
+Reproducer: "GET /api/users returns 500 on parameter X=Y"
+Analyzer: "Could be: (1) type mismatch, (2) DB error, (3) missing handler"
+Verifier: Tests (1) with different X types → not the issue
+Verifier: Tests (2) with DB connection check → found it: DB timeout
+Fix: Increase timeout, verify test passes
+```
+
+**Shutdown Sequence**:
+1. Root cause identified and documented
+2. Fix implemented and tested
+3. Verifier confirms bug no longer reproduces
+4. TeamDelete
+
+---
+
+## Pattern Selection Decision Tree
+
+```
+What is the team task?
+├── Parallel research/exploration → Research Team
+├── Feature implementation (backend + frontend + tests) → Implementation Team
+├── Multi-dimension code review (security + perf + arch) → Review Team
+├── Collaborative design with stakeholder input → Design Team
+├── Complex bug investigation with multiple hypotheses → Debug Team
+└── Other → Assess whether clear file boundaries + communication model exists
+           If yes, adapt a pattern; if no, use sequential sub-agents
+```
+
+---
+
+## Shutdown Protocol (All Teams)
+
+All teams follow this sequence:
+
+1. **Members Complete Work**: Each teammate TaskUpdates their tasks as complete
+2. **Idle Status**: Teammates go idle, waiting for coordination
+3. **Lead Initiates Shutdown**: Team Lead sends `shutdown_request` with request_id
+4. **Members Approve/Reject**: Each teammate responds with `shutdown_response { request_id, approve }`
+5. **Final Sync**: Lead synthesizes outputs into final artifact
+6. **TeamDelete**: Leader calls TeamDelete to clean up team
+
+If a teammate rejects shutdown (still working), Lead can:
+- Extend deadline (send message, wait for completion)
+- Collect partial output and proceed (accept incomplete work)
+- Escalate to user (team is stuck)
+
+---
+
+## Communication Guidelines
+
+**Via SendMessage**:
+- Share findings when they contradict other team members
+- Escalate conflicts that need resolution
+- Coordinate on interdependent work
+- Ask clarifying questions about other member's approach
+
+**Via TaskUpdate**:
+- Mark work as complete or blocked
+- Provide brief status (no long messages — use file artifacts)
+
+**When to NOT Communicate**:
+- Individual analysis that doesn't affect other team members (work independently)
+- Status that doesn't block anyone (save for final report)
+
+**Frequency**:
+- First day: High communication (establish coordination)
+- Middle days: Medium (share discoveries that affect others)
+- Final day: High (synthesis and shutdown)
+
+This cookbook provides practical patterns for the most common team scenarios in MoAI-ADK.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -52,7 +52,7 @@
         "hooks": [
           {
             "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-post-tool.sh\"",
-            "timeout": 60,
+            "timeout": 10,
             "type": "command"
           }
         ],

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -53,7 +53,8 @@
           {
             "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-post-tool.sh\"",
             "timeout": 10,
-            "type": "command"
+            "type": "command",
+            "async": true
           }
         ],
         "matcher": "Write|Edit"

--- a/.moai/config/sections/system.yaml
+++ b/.moai/config/sections/system.yaml
@@ -27,9 +27,9 @@ github:
     enable_trust_5: true
     spec_git_workflow: feature_branch
 moai:
-    template_version: v2.15.0
+    template_version: v2.16.0
     update_check_frequency: daily
-    version: v2.15.0
+    version: v2.16.0
     version_check:
         cache_ttl_hours: 24
         enabled: true

--- a/.moai/release/RELEASE-NOTES-v2.16.0.md
+++ b/.moai/release/RELEASE-NOTES-v2.16.0.md
@@ -1,0 +1,184 @@
+# MoAI-ADK v2.16.0 — Pattern Cookbook + V3R2 Backup Restore + V3R3 Phase A 통합 릴리스
+
+**Release Date**: 2026-04-26
+**Type**: Minor (consolidated)
+**Branch**: `feat/SPEC-V3R3-PATTERNS-001-cookbook` → `main`
+**Predecessor**: v2.14.0 (v2.15.0 was prepared but never tagged — fully included here)
+
+---
+
+## TL;DR
+
+v2.16.0은 세 갈래의 작업을 **단일 통합 릴리스**로 묶습니다:
+
+1. **V3R3 Phase B — Pattern Cookbook** (NEW): revfactory/harness Apache 2.0 6 reference docs를
+   `.claude/rules/moai/` 하위로 흡수해 권위 있는 패턴 cookbook 확립.
+2. **V3R2 Backup Restore**: Plan Audit Gate (Phase 0.5), FROZEN/EVOLVABLE Zone Registry
+   (`moai constitution` CLI), Typed Memory Taxonomy (4-type enforcement) 복원.
+3. **V3R3 Phase A — Foundation Hardening** (Convention Compliance Sweep, Expert Tool Uplift,
+   Token Circuit Breaker, Mobile Native Coverage, Commands Cleanup) — v2.15.0에 준비됐으나
+   tag되지 않아 v2.16.0에 합류.
+
+전체 SPEC: 9개 (Phase B 1, V3R2 3, Phase A 5, +Plan Audit Gate). 모든 AC PASS, 회귀 0.
+
+---
+
+## Highlights
+
+### Pattern Cookbook (SPEC-V3R3-PATTERNS-001) — NEW
+
+agent 설계 / skill 작성 / 팀 운영 / QA 경계면 / orchestrator 선택을 위한 권위 있는 cookbook
+6 rule files + NOTICE를 추가했습니다. 모든 파일은 frontmatter `paths` (CSV)로 conditional
+auto-loading되며, Apache 2.0 attribution을 상단에 보존합니다.
+
+| Path | 핵심 |
+|------|------|
+| `.claude/rules/moai/development/agent-patterns.md` | 6 architectural patterns + MoAI 어휘 매핑 |
+| `.claude/rules/moai/development/orchestrator-templates.md` | 3 templates (Team-/Sub-/Hybrid-orchestrator) |
+| `.claude/rules/moai/development/skill-ab-testing.md` | with-skill vs baseline A/B 방법론 |
+| `.claude/rules/moai/development/skill-writing-craft.md` | description craft + 3-level disclosure + schema |
+| `.claude/rules/moai/quality/boundary-verification.md` | 7 documented bug case studies (NEW dir) |
+| `.claude/rules/moai/workflow/team-pattern-cookbook.md` | 5 team patterns (R/I/R/D/D) |
+| `.claude/rules/moai/NOTICE.md` | Apache 2.0 attribution + source list |
+
+License: revfactory/harness Apache 2.0 → MoAI-ADK MIT. NOTICE 보존 시 호환.
+
+### Plan Audit Gate (SPEC-WF-AUDIT-GATE-001)
+
+`/moai run` 실행 시 **Phase 0.5 mandatory gate**가 plan-auditor를 호출해 SPEC plan 산출물을
+독립 검토합니다. 4 verdicts (PASS / FAIL / BYPASSED / INCONCLUSIVE), 7-day grace window
+(FAIL_WARNED downgrade). minimal harness에서도 skip 불가.
+
+리포트: `.moai/reports/plan-audit/<SPEC-ID>-<YYYY-MM-DD>.md`
+
+### FROZEN/EVOLVABLE Zone Registry (SPEC-V3R2-CON-001)
+
+MoAI rule tree의 모든 HARD 조항에 대한 **단일 진실 공급원**. 68 entries (38 Frozen + 30
+Evolvable). 새 CLI 서브커맨드:
+
+- `moai constitution list [--zone frozen|evolvable] [--file <pattern>] [--format table|json]`
+- `moai constitution guard <changed-rule-ids>` — CI에서 Frozen 위반 차단
+- `moai doctor` Constitution Registry 점검 통합
+
+200-entry cold load 벤치: ~1.85ms (목표 <10ms). 86.5% test coverage. Binary delta +33 KiB.
+
+### Typed Memory Taxonomy (SPEC-V3R2-EXT-001)
+
+`.claude/agent-memory/` 4-type enforcement: `user / feedback / project / reference`. 필수
+frontmatter (`name / description / type`), `feedback`/`project` body 구조 (`**Why:**` +
+`**How to apply:**`).
+
+- 24h staleness detection → `<system-reminder>` wrap (≥10 동시 stale 시 aggregate warning)
+- MEMORY.md 200-line cap (Claude Code memory loader 사일런트 절단 방지)
+- PostToolUse audit: non-blocking stderr 경고 (`MEMORY_MISSING_TYPE`,
+  `MEMORY_INDEX_OVERFLOW`, `MEMORY_DUPLICATE` 등)
+
+`MOAI_MEMORY_AUDIT=0` 환경 변수로 일괄 마이그레이션 시 일시 비활성 가능.
+
+### V3R3 Phase A 통합
+
+v2.15.0에 준비됐던 Foundation Hardening 5 SPECs가 그대로 포함됩니다:
+
+- **SPEC-V3R3-DEF-007** Convention Compliance Sweep — 11 skills `progressive_disclosure` blocks,
+  manager-git Scope Boundaries 추가
+- **SPEC-V3R3-ARCH-003** Expert Agent Tool Uplift — 7 expert agents `Agent` tool (max depth 2),
+  expert-debug/performance에 Write/Edit, Escalation Protocol
+- **SPEC-V3R3-ARCH-007** Token Circuit Breaker — `runtime.yaml` per-agent budgets, 75/90%
+  threshold warning, /clear는 MANUAL 유지
+- **SPEC-V3R3-COV-001** Mobile Native Coverage — expert-mobile (4-strategy router) +
+  moai-domain-mobile, react-native deep, flutter deep skills
+- **SPEC-V3R3-CMD-CLEANUP-001** Commands Cleanup — `/moai gate` 명령 wrapper 추가, review.md
+  Phase 4 보안 강화, sync.md Phase 0.55 강화, `/moai context` 제거
+
+---
+
+## Breaking Changes
+
+이번 릴리스의 BC 항목은 모두 v2.15.0에 누적됐던 V3R3 Phase A 변경입니다:
+
+| ID | 영향 | 마이그레이션 |
+|----|------|------------|
+| **BC-V3R3-001** | 7 expert agents에 `Agent` tool 추가 (T2 → T2 escalation, max depth 2) | 자동 — 기존 호출 그대로 동작 |
+| **BC-V3R3-002** | expert-debug, expert-performance에 `Write`, `Edit` 추가 | 자동 |
+| **BC-V3R3-006** | `runtime.yaml` 신설 (token budget). 기본값 보수적, 75/90% threshold만 경고 emission | 자동 — 미설정 시 default 적용. 사용자 정의 시 `.moai/config/sections/runtime.yaml` 편집 |
+
+`/moai context` 제거는 V3R3 Phase A에서 BC가 아닌 deprecation으로 처리됨 (`@MX` annotations
++ auto-memory로 대체).
+
+---
+
+## Verification
+
+| Check | Result |
+|-------|--------|
+| `make build` | ✅ green (go:embed 정상 빌드) |
+| `go test ./...` | ✅ all PASS |
+| `go test ./internal/template/...` | ✅ PASS |
+| `go test ./internal/constitution/...` | ✅ PASS, 86.5% coverage |
+| `go test ./internal/hook/memo/...` | ✅ PASS, 91.7% coverage |
+| `golangci-lint run` | ✅ 0 issues |
+| Mirror diff (Pattern Cookbook 7 files) | ✅ 7/7 byte-identical |
+| AC PASS rate | ✅ 100% (PATTERNS-001 5/5, CON-001 17/17, EXT-001 전체, WF-AUDIT-GATE-001 전체, Phase A 5 SPEC 전체) |
+| Apache 2.0 NOTICE | ✅ all 6 cookbook files attributed |
+| 16-language neutrality (cookbook) | ✅ no standalone install commands; pseudo-code where examples needed |
+
+---
+
+## Note on Versioning
+
+v2.15.0은 system.yaml + CHANGELOG에 준비됐으나 **git tag가 push되지 않은 상태**에서 V3R2
+backup restore가 추가됐습니다. 사용자 결정 (2026-04-26)에 따라 v2.15.0 tag는 건너뛰고 모든
+누적 콘텐츠를 v2.16.0 단일 릴리스로 통합합니다. CHANGELOG의 v2.15.0 섹션은 historical
+artifact로 보존됩니다.
+
+---
+
+## Upgrade Path
+
+```bash
+# Homebrew / direct binary download
+brew upgrade moai-adk
+
+# 또는 Go install
+go install github.com/modu-ai/moai-adk/cmd/moai@v2.16.0
+
+# Project upgrade
+moai update
+```
+
+`moai update` 실행 시:
+- 신규 6 cookbook rule 파일이 `.claude/rules/moai/development|quality|workflow/`로 자동 배포
+- 기존 user customization (`.moai/project/`, `.moai/specs/`) 보호
+- `.moai/config/sections/runtime.yaml` 신규 (Token Circuit Breaker)
+- `.moai/config/sections/harness.yaml` 신규 (V3R3 Phase A에서 도입)
+- `.claude/agent-memory/` 4-type taxonomy 점검 (warning만, 비차단)
+
+업그레이드 후 권장 검증:
+```bash
+moai doctor                              # Zone Registry + 신규 항목 종합 점검
+moai constitution list --zone frozen     # 38 Frozen entries 확인
+go test ./internal/template/...          # 회귀 테스트 (개발 중인 경우)
+```
+
+---
+
+## Next
+
+- **v2.17.0** (Phase C — Extreme Aggressive 핵심): meta-harness skill + 16 정적 skills 제거
+  (BC-V3R3-007), Vibe Design (DTCG 2025.10) Path A/B1/B2, /moai project 소크라테스 인터뷰
+  + harness 자동 분기 (5-layer 통합 장치), Self-Learning Harness (4-tier 학습 + 5-layer safety).
+- 4 SPECs: SPEC-V3R3-HARNESS-001, DESIGN-PIPELINE-001, PROJECT-HARNESS-001, **HARNESS-LEARNING-001**
+
+---
+
+## Credits
+
+- **Pattern Cookbook source**: [revfactory/harness](https://github.com/revfactory/harness) — Apache License 2.0.
+  Attribution preserved in `.claude/rules/moai/NOTICE.md`. 6 reference docs (agent-design-patterns,
+  qa-agent-guide, skill-testing-guide, team-examples, orchestrator-template, skill-writing-guide).
+- **Author**: GOOS행님 (Goos Kim)
+- **Orchestrator**: MoAI (Claude Opus 4.7)
+
+---
+
+🗿 MoAI <email@mo.ai.kr>

--- a/.moai/release/v3r3-extreme-aggressive-handoff.md
+++ b/.moai/release/v3r3-extreme-aggressive-handoff.md
@@ -320,39 +320,51 @@ License credit: Apache 2.0 (revfactory/harness)
 
 ---
 
-## 2. 다음 세션 Resume Message (paste-ready) — v2.16 PATTERNS + LEARNING SPEC 작성
+## 2. 다음 세션 Resume Message (paste-ready) — LEARNING-001 SPEC 작성
+
+> **STATUS UPDATE (2026-04-26 세션 종료)**: Phase B Step 1+2 완료.
+> - PATTERNS-001 구현 완료, PR #715 (release/v2.16.0 branch, 5 commits) 생성됨
+> - 보너스: PostToolUse async + freeze diagnosis + V3R2 inherited 11 lint cleanup
+> - 다음 세션 목표: PR admin merge 확인 → tag v2.16.0 → LEARNING-001 SPEC 작성
 
 ```
-ultrathink. V3R3 Phase B 진행. v2.16 PATTERNS-001 구현 + v2.17 SPEC 작성.
+ultrathink. V3R3 Phase B Step 3 진행. SPEC-V3R3-HARNESS-LEARNING-001 작성.
 
 진행 위치:
-- origin/main HEAD: b47101779 (v2.15.0 candidate, V3R3 Phase A + V3R2 backup 모두 통합 완료)
-- 작성됨: SPEC-V3R3-PATTERNS-001 (.moai/specs/SPEC-V3R3-PATTERNS-001/) ← 4파일
-- 미작성: SPEC-V3R3-HARNESS-LEARNING-001 (handoff §4.3에 요구사항 명문화됨)
-- 미작성: SPEC-V3R3-HARNESS-001, SPEC-V3R3-DESIGN-PIPELINE-001, SPEC-V3R3-PROJECT-HARNESS-001
+- main HEAD: 같음 (b47101779) — 새 SPEC 작성은 main에서 새 feat/* 브랜치
+- release/v2.16.0 branch에 5 commits, PR #715 OPEN, 사용자 검토/머지 대기
+- 완료: PATTERNS-001 4파일 SPEC + 6 rule files + NOTICE + Template-First sync
+- 완료: PostToolUse 60s→10s + async:true 적용 (template + local)
+- 완료: freeze 진단 가이드 (settings-management.md 4-step checklist)
+- 완료: V3R2 restore inherited 11 lint cleanup (audit_cache.go + audit_report.go)
+- 미작성 (이 세션 목표): SPEC-V3R3-HARNESS-LEARNING-001
+- 미작성 (다음): SPEC-V3R3-HARNESS-001, DESIGN-PIPELINE-001, PROJECT-HARNESS-001
 
 handoff document: .moai/release/v3r3-extreme-aggressive-handoff.md
-                  (§4.1 PATTERNS-001 / §4.2 v2.17 핵심 / §4.3 LEARNING-001 ★ NEW)
+                  §4.3 LEARNING-001 요구사항 (4-tier 학습 + 5-layer safety + /moai harness)
 
 다음 단계 (이 세션):
-1. PATTERNS-001 구현 (manager-tdd dispatch)
-   - revfactory/harness clone (/tmp/harness-analysis/harness/) 또는 기존 활용
-   - 6 rule 파일 작성 (.claude/rules/moai/{development,quality,workflow}/)
-   - NOTICE.md 또는 LICENSE-third-party.md 추가 (Apache 2.0 attribution)
-   - Template + local sync, make build, go test
-2. v2.16.0 release prep + PR + admin merge
-3. SPEC-V3R3-HARNESS-LEARNING-001 작성 (manager-spec dispatch, handoff §4.3)
-   - 4-tier 학습 + 5-layer safety
-   - .moai/config/sections/harness.yaml learning section
-   - /moai harness subcommand
-4. (시간 여유 시) SPEC-V3R3-HARNESS-001 + DESIGN-PIPELINE-001 + PROJECT-HARNESS-001 작성
+1. PR #715 status 확인: gh pr view 715
+   • CI all green이면 사용자 admin merge 대기 (squash 금지, merge commit 사용 — release branch)
+   • merge 후: git tag v2.16.0 && git push origin v2.16.0 → GoReleaser 자동 release
+2. SPEC-V3R3-HARNESS-LEARNING-001 작성 (manager-spec dispatch)
+   • 산출: .moai/specs/SPEC-V3R3-HARNESS-LEARNING-001/{spec,plan,acceptance,tasks}.md
+   • 핵심 요구사항 (handoff §4.3):
+     - 4-tier 학습 (1x observation / 3x heuristic / 5x rule / 10x auto-update)
+     - 5-layer safety (Frozen Guard / Canary / Contradiction / Rate Limit / Human Oversight)
+     - .claude/agents/my-harness/ + .claude/skills/my-harness-*/ 자동 진화
+     - .moai/harness/ 사용자 영역만 자동 업데이트 (moai-managed 절대 불가침)
+     - .moai/config/sections/harness.yaml learning section + /moai harness CLI subcommand
+   • 의존성: HARNESS-001 (meta-harness), PROJECT-HARNESS-001 (소크라테스 인터뷰)
+   • design.yaml safety architecture (Section 5) 활용
+3. (시간 여유 시) HARNESS-001 + DESIGN-PIPELINE-001 + PROJECT-HARNESS-001 SPEC 작성
 
 applied lessons:
 - feedback_large_spec_wave_split.md (각 dispatch ~1.5KB)
 - context-window-management.md (75% 임계 모니터)
 
 긴 세션 예상 — 75% 도달 시 progress.md 저장 + /clear + 새 세션 resume.
-완료 후: v2.17 4-SPEC 구현 (HARNESS → DESIGN → PROJECT → LEARNING 순)
+완료 후: v2.17 phase 4-SPEC 구현 (HARNESS → DESIGN → PROJECT → LEARNING 순)
 ```
 
 ---

--- a/.moai/release/v3r3-extreme-aggressive-handoff.md
+++ b/.moai/release/v3r3-extreme-aggressive-handoff.md
@@ -320,31 +320,39 @@ License credit: Apache 2.0 (revfactory/harness)
 
 ---
 
-## 2. 다음 세션 Resume Message (paste-ready)
+## 2. 다음 세션 Resume Message (paste-ready) — v2.16 PATTERNS + LEARNING SPEC 작성
 
 ```
-ultrathink. V3R3 Extreme Aggressive Phase A 진행. v2.15 마무리부터.
+ultrathink. V3R3 Phase B 진행. v2.16 PATTERNS-001 구현 + v2.17 SPEC 작성.
 
 진행 위치:
-- main HEAD: 3ed706a5b (ARCH-003 완료 시점)
-- 미구현: ARCH-007 (작성됨), COV-001 (작성됨), CMD-CLEANUP-001 (미작성)
-- v2.15 배포 대기
+- origin/main HEAD: b47101779 (v2.15.0 candidate, V3R3 Phase A + V3R2 backup 모두 통합 완료)
+- 작성됨: SPEC-V3R3-PATTERNS-001 (.moai/specs/SPEC-V3R3-PATTERNS-001/) ← 4파일
+- 미작성: SPEC-V3R3-HARNESS-LEARNING-001 (handoff §4.3에 요구사항 명문화됨)
+- 미작성: SPEC-V3R3-HARNESS-001, SPEC-V3R3-DESIGN-PIPELINE-001, SPEC-V3R3-PROJECT-HARNESS-001
 
 handoff document: .moai/release/v3r3-extreme-aggressive-handoff.md
+                  (§4.1 PATTERNS-001 / §4.2 v2.17 핵심 / §4.3 LEARNING-001 ★ NEW)
+
 다음 단계 (이 세션):
-1. SPEC-V3R3-CMD-CLEANUP-001 작성 (gate 추가 + security 흡수 강화 + context 제거)
-2. SPEC-V3R3-ARCH-007 구현 (manager-tdd dispatch, Go runtime + runtime.yaml)
-3. SPEC-V3R3-COV-001 구현 (manager-tdd dispatch, expert-mobile + harness seed)
-4. CMD-CLEANUP-001 구현 (review/sync 보안 강화 + gate command + context 삭제)
-5. v2.15 release prep (CHANGELOG/system.yaml/release-notes)
-6. PR + tag v2.15.0
+1. PATTERNS-001 구현 (manager-tdd dispatch)
+   - revfactory/harness clone (/tmp/harness-analysis/harness/) 또는 기존 활용
+   - 6 rule 파일 작성 (.claude/rules/moai/{development,quality,workflow}/)
+   - NOTICE.md 또는 LICENSE-third-party.md 추가 (Apache 2.0 attribution)
+   - Template + local sync, make build, go test
+2. v2.16.0 release prep + PR + admin merge
+3. SPEC-V3R3-HARNESS-LEARNING-001 작성 (manager-spec dispatch, handoff §4.3)
+   - 4-tier 학습 + 5-layer safety
+   - .moai/config/sections/harness.yaml learning section
+   - /moai harness subcommand
+4. (시간 여유 시) SPEC-V3R3-HARNESS-001 + DESIGN-PIPELINE-001 + PROJECT-HARNESS-001 작성
 
 applied lessons:
 - feedback_large_spec_wave_split.md (각 dispatch ~1.5KB)
 - context-window-management.md (75% 임계 모니터)
 
 긴 세션 예상 — 75% 도달 시 progress.md 저장 + /clear + 새 세션 resume.
-완료 후: v2.16 PATTERNS-001 → v2.17 HARNESS+DESIGN+PROJECT
+완료 후: v2.17 4-SPEC 구현 (HARNESS → DESIGN → PROJECT → LEARNING 순)
 ```
 
 ---
@@ -552,6 +560,81 @@ attribution: each rule file 상단에 "# Source: revfactory/harness Apache 2.0"
 이후 manager-tdd로 순차 구현 (HARNESS → DESIGN → PROJECT 순) + v2.17 release.
 ```
 
+### 4.3 SPEC-V3R3-HARNESS-LEARNING-001 (사용자 추가 요구사항 — 2026-04-26)
+
+**요구사항 출처**: 사용자 요청 ("사용자가 설치한 하네스는 사용자가 사용을 하면 할수록 학습된 내용을 지속적으로 자동으로 업데이트가 되도록")
+
+**핵심**: 사용자 프로젝트에 설치된 dynamic harness (`.claude/agents/my-harness/`, `.claude/skills/my-harness-*/`, `.moai/harness/`)가 사용자 활동을 학습하여 자동으로 진화.
+
+#### Scope
+
+1. **사용자 활동 모니터링**:
+   - `/moai` 명령 사용 빈도 (subcommand 별)
+   - 자주 사용하는 SPEC ID 패턴
+   - commit message 트렌드
+   - agent 호출 통계 (어떤 agent가 어떤 작업에 반복 호출되는지)
+   - 사용자 명시 feedback (`/moai feedback` 입력)
+
+2. **학습 알고리즘 (3-tier)**:
+   - **Tier 1 (Observation)**: 1x 발생 — 로그만 기록
+   - **Tier 2 (Heuristic)**: 3x 발생 — harness skill body의 description 보강
+   - **Tier 3 (Rule)**: 5x 발생 — harness skill의 triggers/keywords 자동 inject
+   - **Tier 4 (Auto-update)**: 10x 발생 — 사용자 승인 후 chaining_rules.yaml 갱신
+
+3. **학습 결과 자동 반영 대상**:
+   - `.moai/harness/main.md` (project customization 진입점)
+   - `.moai/harness/{plan,run,sync,design}-extension.md` (workflow 확장)
+   - `.moai/harness/chaining-rules.yaml` (agent chain 규칙)
+   - `.claude/skills/my-harness-*/SKILL.md` body
+   - `.claude/agents/my-harness/*.md` body
+
+4. **5-layer 안전 메커니즘 (design constitution §5 활용)**:
+   - **L1 Frozen Guard**: moai-managed (`.claude/agents/moai/`, `.claude/skills/moai-*/`)는 절대 수정 금지
+   - **L2 Canary Check**: 학습 변경 적용 전 shadow eval (이전 3 프로젝트에 영향 시뮬레이션)
+   - **L3 Contradiction Detector**: 신규 학습이 기존 사용자 customization과 충돌 시 alert
+   - **L4 Rate Limiter**: 주당 최대 3회 자동 업데이트, 24h cooldown
+   - **L5 Human Oversight**: Tier 4 자동 업데이트 시 AskUserQuestion으로 승인 받기
+
+#### 산출 (예정)
+
+- `moai-harness-learner` skill (학습 + 자동 업데이트 코디네이터)
+- `internal/harness/learner.go` (Go 백엔드, 활동 로그 분석 + 학습 추출)
+- `internal/harness/observer.go` (PostToolUse hook 기반 활동 수집)
+- `.moai/harness/usage-log.jsonl` (활동 로그 schema)
+- `.moai/harness/learning-history/` (학습 변경 이력 + rollback)
+- `/moai harness` 신규 subcommand:
+  - `/moai harness status` — 현재 학습 상태 표시
+  - `/moai harness apply` — pending 학습 변경 수동 적용
+  - `/moai harness rollback <date>` — 특정 시점으로 복원
+  - `/moai harness disable` — 자동 학습 일시 중단
+- `.moai/config/sections/harness.yaml`:
+  ```yaml
+  harness:
+    learning:
+      enabled: true
+      auto_apply: false  # 기본 false (사용자 승인 모드)
+      tier_thresholds: { observation: 1, heuristic: 3, rule: 5, auto_update: 10 }
+      rate_limit: { per_week: 3, cooldown_hours: 24 }
+      log_retention_days: 90
+  ```
+
+#### 통합 위치
+
+- v2.17 phase에 포함 (HARNESS-001 + DESIGN-PIPELINE-001 + PROJECT-HARNESS-001 + **LEARNING-001** = 4 SPECs)
+- 의존성:
+  - HARNESS-001 (meta-harness) 선행 필수
+  - PROJECT-HARNESS-001 (소크라테스 인터뷰) 선행 — 사용자 baseline 확보
+  - design.yaml safety architecture (Section 5) 활용
+
+#### Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| 자동 변경이 사용자 의도와 다름 | Tier 4 자동 적용 전 AskUserQuestion 의무, default `auto_apply: false` |
+| 학습 결과 발산 (drift) | Rate Limiter + 주간 회고 보고 (`/moai harness status`) |
+| 활동 로그 privacy 우려 | 로컬 보존만, 외부 전송 없음, 90일 retention |
+| moai-managed 영역 침범 | Frozen Guard L1 강제 — 절대 변경 불가 |
+
 ---
 
 ## 5. 핵심 검증 시나리오 (v2.17 완료 후)
@@ -666,11 +749,15 @@ moai-adk = workflow framework (22 base skills) + meta-harness (∞ generated)
    - /moai security: 흡수 (review/sync 강화) — command 추가 안 함
    - /moai context: 제거 — typed memory(EXT-001)만 사용
    - /moai gate: 추가 (V2.15)
+   - ★ Self-Learning Harness (LEARNING-001, v2.17): 사용자 활동 학습 → harness 자동 진화
+     - 4-tier (1x observation / 3x heuristic / 5x rule / 10x auto-update)
+     - 5-layer safety (Frozen Guard / Canary / Contradiction / Rate Limit / Human Oversight)
+     - moai-managed 영역 절대 불가침, my-harness/ 영역만 자동 업데이트
 ```
 
 ---
 
 **Status**: Ready for next session
-**Last Updated**: 2026-04-26
+**Last Updated**: 2026-04-26 (§4.3 LEARNING-001 추가)
 **Author**: MoAI Orchestrator (Claude Opus 4.7)
-**Reviewed**: User decision integrated (6 decisions confirmed)
+**Reviewed**: User decision integrated (6 decisions + self-learning 요구사항)

--- a/.moai/specs/SPEC-V3R3-PATTERNS-001/acceptance.md
+++ b/.moai/specs/SPEC-V3R3-PATTERNS-001/acceptance.md
@@ -1,0 +1,313 @@
+---
+id: SPEC-V3R3-PATTERNS-001
+version: "0.1.0"
+status: draft
+created_at: 2026-04-26
+updated_at: 2026-04-26
+author: manager-spec
+priority: High
+labels: [patterns, harness, acceptance, v3r3]
+issue_number: null
+---
+
+# SPEC-V3R3-PATTERNS-001 — Acceptance Criteria
+
+## 1. Definition of Done
+
+본 SPEC은 다음을 모두 만족하면 완료(`status: completed`):
+
+- AC-001 ~ AC-005 모두 PASS
+- TRUST 5 quality gate 통과 (Tested / Readable / Unified / Secured / Trackable)
+- `go test ./internal/template/...` green
+- `make build` 성공 (embedded.go 재생성 정상)
+- plan-auditor (있다면) PASS verdict 또는 BYPASSED with documented reason
+
+---
+
+## 2. Acceptance Criteria
+
+### AC-001 — Agent Patterns 산출물 (REQ-PAT-001)
+
+**Given** v3.0.0 R3 Phase A baseline 환경 (DEF-007, ARCH-003 완료),
+**When** Wave 2 완료 후 `.claude/rules/moai/development/agent-patterns.md`가 작성된 경우,
+**Then** 다음을 모두 만족해야 한다:
+
+- 파일 존재: `test -f .claude/rules/moai/development/agent-patterns.md`
+- 6 patterns 명시: grep으로 "Team", "Sub-agent", "Hybrid", "Orchestrator", "Specialist", "Pipeline" 6개 키워드 모두 발견
+- 각 pattern 섹션에 다음 4 요소 포함: definition / when to use / example / anti-pattern
+- 상단에 Apache 2.0 attribution 주석 포함: `grep -q "revfactory/harness" file && grep -q "Apache" file`
+- frontmatter `paths` 글로브가 `.claude/agents/**` 또는 동등한 패턴 포함
+- Template mirror 동기화: `internal/template/templates/.claude/rules/moai/development/agent-patterns.md`이 byte-identical
+
+**검증 명령**:
+```bash
+diff .claude/rules/moai/development/agent-patterns.md \
+     internal/template/templates/.claude/rules/moai/development/agent-patterns.md
+# Exit code 0 (no diff) expected
+```
+
+---
+
+### AC-002 — Boundary Verification + A/B Testing 산출물 (REQ-PAT-002, REQ-PAT-003)
+
+**Given** Wave 2 진행,
+**When** boundary-verification.md + skill-ab-testing.md 작성 완료된 경우,
+**Then** 다음을 모두 만족해야 한다:
+
+- `.claude/rules/moai/quality/boundary-verification.md` 존재 (디렉토리 quality/ 신규 생성됨)
+- boundary-verification: 7 bug case 명시 — 각 case에 symptom / root cause / boundary condition / verification strategy 4 요소 포함
+- skill-ab-testing: A/B methodology 명시 — with-skill vs baseline / evaluation criteria / sample size / statistical significance 4 요소 포함
+- 두 파일 모두 frontmatter `paths` 글로브 적절히 설정 (boundary-verification은 test 파일, skill-ab-testing은 skill 파일)
+- 두 파일 모두 Apache 2.0 attribution 상단 주석
+- Template mirror 양쪽 byte-identical
+
+**검증 명령**:
+```bash
+# 7 bug case 확인 (case 헤더 카운트)
+grep -c "^### Case" .claude/rules/moai/quality/boundary-verification.md
+# Output: 7 expected
+
+# A/B methodology 핵심 키워드 확인
+grep -E "(sample size|baseline|statistical)" .claude/rules/moai/development/skill-ab-testing.md
+# At least 3 matches expected
+```
+
+---
+
+### AC-003 — Team Cookbook + Orchestrator Templates 산출물 (REQ-PAT-004, REQ-PAT-005)
+
+**Given** Wave 2 진행,
+**When** team-pattern-cookbook.md + orchestrator-templates.md 작성 완료된 경우,
+**Then** 다음을 모두 만족해야 한다:
+
+- `.claude/rules/moai/workflow/team-pattern-cookbook.md` 존재
+- 5 팀 예시 명시: research / implementation / review / design / debug — 5개 모두 포함
+- 각 팀 예시에 role profile / file ownership / communication / shutdown sequence 4 요소
+- `.claude/rules/moai/development/orchestrator-templates.md` 존재
+- 3 templates 명시: Team-orchestrator / Sub-orchestrator / Hybrid-orchestrator
+- 각 template에 when to use / how to spawn / error recovery / escalation 4 요소
+- 두 파일 모두 Apache 2.0 attribution + Template mirror 동기화
+
+**검증 명령**:
+```bash
+# 5 팀 헤더 확인
+grep -E "^## (Research|Implementation|Review|Design|Debug)" \
+  .claude/rules/moai/workflow/team-pattern-cookbook.md | wc -l
+# Output: 5 expected
+
+# 3 orchestrator templates 확인
+grep -E "^## (Team|Sub|Hybrid)-orchestrator" \
+  .claude/rules/moai/development/orchestrator-templates.md | wc -l
+# Output: 3 expected
+```
+
+---
+
+### AC-004 — Skill Writing Craft 산출물 (REQ-PAT-006)
+
+**Given** Wave 2 진행,
+**When** skill-writing-craft.md 작성 완료된 경우,
+**Then** 다음을 모두 만족해야 한다:
+
+- `.claude/rules/moai/development/skill-writing-craft.md` 존재
+- 3 핵심 영역 모두 다룸:
+  1. Description craft — when to trigger / when to skip
+  2. Body structure — 3-level progressive disclosure
+  3. Schema validation — frontmatter rules
+- Apache 2.0 attribution + Template mirror 동기화
+- frontmatter `paths` 글로브가 `.claude/skills/**/SKILL.md` 또는 동등 패턴 포함
+
+**검증 명령**:
+```bash
+grep -E "(description|progressive disclosure|frontmatter)" \
+  .claude/rules/moai/development/skill-writing-craft.md | wc -l
+# At least 6 matches (각 키워드 2회 이상) expected
+```
+
+---
+
+### AC-005 — Apache 2.0 Compliance + Template-First Sync (REQ-PAT-007, REQ-PAT-008)
+
+**Given** Wave 2 + Wave 3 완료,
+**When** 6 rule 파일 + NOTICE 모두 작성/동기화된 경우,
+**Then** 다음을 모두 만족해야 한다:
+
+- `.claude/rules/moai/NOTICE.md` 존재
+- NOTICE.md에 다음 모두 명시:
+  - revfactory/harness 저장소 URL
+  - Apache 2.0 license URL
+  - 흡수된 6 reference 파일 경로 일람
+  - import 날짜 (2026-04-26)
+  - attribution clause 텍스트
+  - Apache 2.0 NOTICE 파일 사본 (harness가 가지고 있다면)
+- 6 산출 파일 모두 상단에 동일한 attribution 주석 포함
+- Template mirror 동기화: 7 파일 (6 rule + NOTICE) 모두 `internal/template/templates/.claude/rules/moai/` 하위에 byte-identical 사본 존재
+- `make build` 성공
+- `go test ./internal/template/...` green
+- 16-language neutrality 검증: 산출 파일 6개에서 특정 언어 하드코딩 grep 검사 0건 (Python/Go/JavaScript 등 단독 표기 없이 multi-language 또는 의사코드)
+
+**검증 명령**:
+```bash
+# 7 파일 모두 mirror 동기화 확인
+for f in agent-patterns.md skill-ab-testing.md orchestrator-templates.md skill-writing-craft.md; do
+  diff .claude/rules/moai/development/$f \
+       internal/template/templates/.claude/rules/moai/development/$f
+done
+
+diff .claude/rules/moai/quality/boundary-verification.md \
+     internal/template/templates/.claude/rules/moai/quality/boundary-verification.md
+
+diff .claude/rules/moai/workflow/team-pattern-cookbook.md \
+     internal/template/templates/.claude/rules/moai/workflow/team-pattern-cookbook.md
+
+diff .claude/rules/moai/NOTICE.md \
+     internal/template/templates/.claude/rules/moai/NOTICE.md
+
+# All diffs should exit 0
+
+# Apache attribution 7 파일 모두 확인
+for f in $(find .claude/rules/moai/{development,quality,workflow} -name "*.md" -newer .moai/specs/SPEC-V3R3-PATTERNS-001/spec.md); do
+  grep -q "revfactory/harness" "$f" || echo "MISSING attribution: $f"
+done
+# No output expected (all have attribution)
+
+# Template build + test
+make build && go test ./internal/template/...
+```
+
+---
+
+## 3. Edge Cases
+
+### EC-001 — harness 저장소 LICENSE가 Apache 2.0이 아닌 경우
+
+**Detection**: M1에서 `cat /tmp/harness-analysis/harness/LICENSE` 결과가 Apache 2.0이 아님.
+
+**Response**:
+1. SPEC abort.
+2. AskUserQuestion으로 사용자에게 보고.
+3. 사용자 결정에 따라: (A) 다른 라이선스로 SPEC 재작성, (B) prior art 흡수 포기, (C) 사용자가 라이선스 호환성 직접 확인 후 진행.
+
+### EC-002 — harness reference 파일 일부 부재
+
+**Detection**: M1에서 6 파일 중 일부가 `skills/harness/references/`에 없음.
+
+**Response**:
+1. 누락된 파일을 progress.md에 기록.
+2. AskUserQuestion으로 사용자에게 보고.
+3. 사용자 결정: (A) 부재한 파일은 MoAI-ADK 자력 작성, (B) 해당 파일 산출 제외 후 부분 SPEC 진행, (C) SPEC abort.
+
+### EC-003 — 흡수된 docs가 Markdown 외 형식 (RST, AsciiDoc 등)
+
+**Detection**: M1에서 reference 파일 확장자/형식 확인 시.
+
+**Response**: Markdown으로 자동 변환 (Pandoc 또는 수작업). 변환 사실을 attribution 섹션에 명시: "Converted from <format> to Markdown on 2026-04-26."
+
+### EC-004 — 흡수 docs가 너무 길어 progressive_disclosure가 필요한 경우
+
+**Detection**: M2에서 작성한 파일이 500 LOC 초과.
+
+**Response**: SKILL.md 패턴 적용 — 메인 파일은 Quick Reference (200 LOC 이내) + `modules/` 디렉토리에 deep-dive 분리. frontmatter에 `progressive_disclosure: { enabled: true, level1_tokens: ~1500, level2_tokens: ~5000 }` 추가.
+
+### EC-005 — Template mirror 동기화 실패 (`make build`)
+
+**Detection**: M3에서 `make build` exit code 비-0.
+
+**Response**:
+1. 에러 로그 분석.
+2. `internal/template/templates/.claude/rules/moai/` 경로/파일명 정확성 재확인.
+3. `internal/template/embedded.go` 재생성 정상성 확인.
+4. 5번 retry 한도 초과 시 사용자에게 보고.
+
+### EC-006 — frontmatter `paths` 글로브가 의도와 다르게 매칭
+
+**Detection**: M4 validation에서 의도된 파일 수정 시 rule이 로드되지 않거나, 의도되지 않은 파일에서 로드됨.
+
+**Response**:
+1. 글로브 패턴 재검토 (Claude Code paths 글로브 문법 참조).
+2. `paths: "**/*.go,**/*_test.go"` 같은 다중 패턴 사용 검토.
+3. 수정 후 재검증.
+
+---
+
+## 4. Test Strategy
+
+### Phase 1 — Build Tests (Wave 3)
+
+```bash
+make build
+# Verify: internal/template/embedded.go modified
+# Verify: exit code 0
+
+go test ./internal/template/...
+# Verify: all tests green
+# Verify: commands_audit_test.go pass
+```
+
+### Phase 2 — Content Verification (Wave 3)
+
+```bash
+# Apache attribution 7 파일 (6 rule + NOTICE)
+files=(
+  ".claude/rules/moai/development/agent-patterns.md"
+  ".claude/rules/moai/development/skill-ab-testing.md"
+  ".claude/rules/moai/development/orchestrator-templates.md"
+  ".claude/rules/moai/development/skill-writing-craft.md"
+  ".claude/rules/moai/quality/boundary-verification.md"
+  ".claude/rules/moai/workflow/team-pattern-cookbook.md"
+  ".claude/rules/moai/NOTICE.md"
+)
+for f in "${files[@]}"; do
+  test -f "$f" && echo "OK: $f" || echo "MISSING: $f"
+  grep -q "revfactory/harness" "$f" || echo "NO ATTRIBUTION: $f"
+  grep -q "Apache" "$f" || echo "NO APACHE REF: $f"
+done
+```
+
+### Phase 3 — Mirror Verification (Wave 3)
+
+```bash
+# byte-identical mirror
+local_root=".claude/rules/moai"
+template_root="internal/template/templates/.claude/rules/moai"
+for sub in development/agent-patterns.md development/skill-ab-testing.md development/orchestrator-templates.md development/skill-writing-craft.md quality/boundary-verification.md workflow/team-pattern-cookbook.md NOTICE.md; do
+  diff "$local_root/$sub" "$template_root/$sub" || echo "MIRROR DRIFT: $sub"
+done
+```
+
+### Phase 4 — Frontmatter `paths` Glob Verification (Wave 4)
+
+```bash
+# 각 파일의 frontmatter paths가 적절한지 manual review
+for f in "${files[@]}"; do
+  if [[ "$f" != *NOTICE.md ]]; then
+    head -20 "$f" | grep -q "paths:" || echo "NO paths frontmatter: $f"
+  fi
+done
+```
+
+### Phase 5 — Language Neutrality (Wave 4)
+
+```bash
+# 16-language hardcoding 검사
+banned_patterns=("\\.py\\b" "\\.go\\b" "\\.ts\\b" "\\.rs\\b" "pip install" "go get" "npm install")
+for f in "${files[@]}"; do
+  for p in "${banned_patterns[@]}"; do
+    if grep -E "$p" "$f" > /dev/null; then
+      # 단독 표기인지 multi-language 컨텍스트인지 manual review 필요
+      echo "POTENTIAL HARDCODING in $f: pattern $p"
+    fi
+  done
+done
+# Manual review of flagged matches
+```
+
+---
+
+## 5. Quality Gate Criteria (TRUST 5)
+
+- **Tested**: 본 SPEC은 markdown artifact 산출 — 회귀 테스트는 `internal/template/...` 기존 테스트로 충분. 추가 테스트 불필요.
+- **Readable**: 산출 파일 6개가 명확한 헤더/섹션 구조. ko/en 정책 준수 (rule 파일은 영어).
+- **Unified**: 6 파일 모두 동일한 frontmatter 구조 + 동일한 attribution 패턴. NOTICE.md 단일 진실 공급원.
+- **Secured**: 외부 코드 흡수 시 라이선스 검증 의무 — Apache 2.0 명시 + NOTICE 보존.
+- **Trackable**: SPEC-V3R3-PATTERNS-001 ID로 commit 추적, history 표 frontmatter, attribution date 명시.

--- a/.moai/specs/SPEC-V3R3-PATTERNS-001/plan.md
+++ b/.moai/specs/SPEC-V3R3-PATTERNS-001/plan.md
@@ -1,0 +1,170 @@
+---
+id: SPEC-V3R3-PATTERNS-001
+version: "0.1.0"
+status: draft
+created_at: 2026-04-26
+updated_at: 2026-04-26
+author: manager-spec
+priority: High
+labels: [patterns, harness, plan, v3r3]
+issue_number: null
+---
+
+# SPEC-V3R3-PATTERNS-001 — Implementation Plan
+
+## 1. Strategy Overview
+
+3-Wave 작업으로 분해. Wave 1은 prior art 분석 (read-only), Wave 2는 6 rule 파일 작성 (write), Wave 3은 Template-First 동기화 + 회귀 테스트.
+
+| Wave | Goal | Agent | Mode | Isolation |
+|------|------|-------|------|-----------|
+| Wave 1 | harness clone + 6 reference 분석 + import 매핑 | Explore (general-purpose, mode: plan) | Read-only | None |
+| Wave 2 | 6 rule 파일 + NOTICE 작성 (markdown artifact) | manager-tdd (single sub-agent) | acceptEdits | None |
+| Wave 3 | Template mirror 동기화 + `make build` + Go test 회귀 | manager-git (sub-agent) | acceptEdits | None |
+
+**Why no team mode?** 산출물이 markdown rule 파일 6개로 file count < 10, domain count = 1 (rules). 팀 모드 임계치 (`domains>=3, files>=10`) 미달. Sub-agent 시퀀셜이 token 효율적.
+
+---
+
+## 2. Milestones (Priority-based, no time estimates)
+
+### M1 (Priority High) — Prior Art Analysis
+
+- harness 저장소 clone (HTTPS, depth=1) `/tmp/harness-analysis/harness/`
+- 6 reference docs 위치 확인: `skills/harness/references/{agent-patterns,boundary-verification,skill-ab-testing,team-pattern-cookbook,orchestrator-templates,skill-writing-craft}.md`
+- 각 reference 핵심 섹션 추출 (Explore agent가 read-only 분석)
+- 라이선스 파일 (LICENSE) 확인 → Apache 2.0 검증
+- import 매핑 표 작성 (source section → target section)
+
+**Exit criteria**: 6 reference 모두 읽기 완료, Apache 2.0 LICENSE 사본 확보, import 매핑 표 progress.md에 기록.
+
+### M2 (Priority High) — 6 rule 파일 + NOTICE 작성
+
+- `.claude/rules/moai/quality/` 디렉토리 생성
+- 6 파일 작성 (manager-tdd가 markdown artifact 작성):
+  1. `development/agent-patterns.md`
+  2. `quality/boundary-verification.md`
+  3. `development/skill-ab-testing.md`
+  4. `workflow/team-pattern-cookbook.md`
+  5. `development/orchestrator-templates.md`
+  6. `development/skill-writing-craft.md`
+- 각 파일 frontmatter (paths, description) + 상단 attribution 주석 추가
+- `NOTICE.md` 작성 (6 source 일람 + Apache 2.0 텍스트 사본)
+
+**Exit criteria**: 6 파일 + NOTICE 모두 작성, frontmatter `paths` 글로브 검증, attribution 주석 grep 확인.
+
+### M3 (Priority Medium) — Template-First 동기화
+
+- 7 파일 모두 `internal/template/templates/.claude/rules/moai/`로 미러
+- `make build` 실행 → `internal/template/embedded.go` 재생성
+- `go test ./internal/template/...` 회귀 확인
+- `internal/template/commands_audit_test.go` 통과 확인
+
+**Exit criteria**: byte-identical mirror, build 성공, all template tests green.
+
+### M4 (Priority Medium) — Validation
+
+- frontmatter `paths` 글로브 패턴 실제 매칭 검증 (테스트 파일 수정 시 boundary-verification.md auto-load 확인)
+- 16-language neutral 검증: 6 파일 grep으로 특정 언어 hard-coding 확인 (예: `python`/`go`/`javascript` 편향 검사)
+- AC-001 ~ AC-005 (acceptance.md) 모두 PASS
+
+**Exit criteria**: 모든 AC PASS, plan-auditor (있다면) PASS verdict.
+
+---
+
+## 3. Technical Approach
+
+### 3.1 Cookbook Structure
+
+각 rule 파일은 다음 구조:
+
+```markdown
+<!-- Source: revfactory/harness — Apache License 2.0 — see .claude/rules/moai/NOTICE.md -->
+---
+description: <one-line — when this cookbook applies>
+paths: "<glob>"
+---
+
+# <Title>
+
+> Imported from revfactory/harness Apache 2.0 (date: 2026-04-26).
+> See `.claude/rules/moai/NOTICE.md` for license terms.
+
+## HISTORY
+
+| Version | Date | Author | Description |
+|---------|------|--------|-------------|
+| 1.0.0 | 2026-04-26 | manager-spec | Initial import from harness `skills/harness/references/<file>.md` |
+
+## <Section 1>
+...
+```
+
+### 3.2 Apache 2.0 → MIT 호환성
+
+MoAI-ADK는 MIT 라이선스. Apache 2.0 코드를 MIT 프로젝트에 흡수하는 것은 허용되며 다음 조건 충족:
+
+- Apache 2.0 LICENSE 텍스트 사본 보존 → `NOTICE.md` 또는 `LICENSE-APACHE.txt`
+- 원본 attribution 명시 → 각 파일 상단 주석 + NOTICE.md
+- 변경사항 표기 → "Imported from harness on 2026-04-26, no modifications" 또는 변경 시 변경 내역 기록
+- NOTICE 파일 보존 의무 (harness가 NOTICE 파일을 가지고 있다면 사본 포함)
+
+### 3.3 Frontmatter `paths` 활용 패턴
+
+Claude Code rules 시스템은 `paths` 글로브에 파일 매칭 시 해당 rule을 conditional load. 이를 활용해:
+
+- `agent-patterns.md`는 agent 작성 중에만 로드 (`paths: ".claude/agents/**"`)
+- `skill-ab-testing.md`는 skill 작성 중에만 로드 (`paths: ".claude/skills/**"`)
+
+→ 토큰 효율 + 적절한 컨텍스트.
+
+### 3.4 16-Language Neutrality 보장
+
+원본 harness 문서는 일부 코드 예시를 포함할 수 있음. 흡수 시:
+
+- 코드 예시가 특정 언어인 경우 → 의사코드(pseudocode)로 변환 또는 multi-language 변형 추가
+- 도구명/패키지명만 언급 (예: `pytest` 단독 → "test framework (e.g. pytest, jest, go test)")
+- file extension 가정 금지 (예: `.py` → `<source file>`)
+
+---
+
+## 4. Risks and Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| harness LICENSE가 실제로 Apache 2.0이 아닌 경우 | Low | Critical | M1에서 LICENSE 직접 확인 → 다른 라이선스면 SPEC abort, 사용자 협의 |
+| harness reference docs 일부가 부재 | Medium | High | M1에서 6 파일 모두 존재 확인 → 누락 시 abort 또는 사용자 협의로 대체 |
+| 흡수 후 16-language neutrality 위반 | Medium | Medium | M2에서 작성 시 grep 자가검증 + M4에서 validation grep |
+| Template mirror 누락 | Low | High | M3 이후 `find` 비교 + `diff` 확인 |
+| frontmatter `paths` 글로브 매칭 실패 | Low | Medium | M4에서 실제 파일 수정 후 rule 로딩 확인 |
+| Apache 2.0 NOTICE 누락 | Low | Critical | M2에서 NOTICE.md 별도 작성 + grep 검증 |
+
+---
+
+## 5. Dependencies
+
+- [BLOCKING] git CLI: harness 저장소 clone에 필요 (이미 환경에 존재 확인)
+- [BLOCKING] make: `make build` 실행 (이미 Makefile 존재 확인)
+- [BLOCKING] go: `go test ./internal/template/...` 실행
+- [SOFT] SPEC-V3R3-DEF-007 (Convention Sweep) — frontmatter 베이스라인 정의된 상태에서 시작 가능 (이미 implemented)
+- [SOFT] SPEC-V3R3-ARCH-003 (Expert tool uplift) — agent body 일관성 baseline (이미 완료)
+
+---
+
+## 6. Open Questions
+
+| ID | Question | Resolution Path |
+|----|----------|-----------------|
+| OQ-001 | NOTICE 파일 위치: `.claude/rules/moai/NOTICE.md` vs 프로젝트 root `NOTICE` vs `LICENSE-third-party.md`? | M1에서 결정. 권장: `.claude/rules/moai/NOTICE.md` (cookbook 인접) + `LICENSE-third-party.md` (root 표준) 둘 다. |
+| OQ-002 | harness reference 파일이 실제 6개 모두 존재하는가? | M1 clone 후 `ls skills/harness/references/` 확인. |
+| OQ-003 | 16-language neutrality 위반 시 의사코드 변환 vs multi-variant? | M2 작성 시 case-by-case. 짧은 예시는 의사코드, 긴 예시는 multi-variant. |
+| OQ-004 | frontmatter `paths` 글로브가 실제 자동 로딩되는지 검증 메커니즘은? | M4에서 실제 파일 touch 후 rule 로딩 로그 확인. Claude Code log/debug mode 활용. |
+
+---
+
+## 7. Out of Scope (Reaffirmation)
+
+- harness skill / agent 본체 흡수
+- 한국어 번역
+- 기존 rule 파일 수정 (frozen content)
+- harness 저장소 upstream sync 자동화

--- a/.moai/specs/SPEC-V3R3-PATTERNS-001/spec.md
+++ b/.moai/specs/SPEC-V3R3-PATTERNS-001/spec.md
@@ -1,0 +1,178 @@
+---
+id: SPEC-V3R3-PATTERNS-001
+version: "0.1.0"
+status: draft
+created_at: 2026-04-26
+updated_at: 2026-04-26
+author: manager-spec
+priority: High
+labels: [patterns, harness, agent-design, skill-design, apache2, cookbook, v3r3]
+issue_number: null
+title: "Pattern Cookbook — revfactory/harness Apache 2.0 6 reference docs 흡수"
+breaking: false
+bc_id: []
+lifecycle: spec-anchored
+related_specs: [SPEC-V3R3-DEF-007, SPEC-V3R3-ARCH-003]
+---
+
+# SPEC-V3R3-PATTERNS-001: Pattern Cookbook — revfactory/harness 흡수
+
+## HISTORY
+
+| Version | Date       | Author       | Description                                                                                       |
+|---------|------------|--------------|---------------------------------------------------------------------------------------------------|
+| 0.1.0   | 2026-04-26 | manager-spec | Initial draft. revfactory/harness (Apache 2.0) 6 reference docs를 6 rule 파일로 흡수. handoff §4.1. |
+
+---
+
+## 1. Goal (목적)
+
+revfactory/harness 저장소(Apache 2.0 라이선스)의 6 reference docs를 MoAI-ADK의 `.claude/rules/moai/`로 흡수해 **agent 설계 / skill 작성 / 팀 운영 / QA 경계면 / orchestrator 선택**을 위한 권위 있는 cookbook을 확립한다.
+
+본 SPEC은 외부 prior art를 정식 채택하는 작업이며 모든 산출 파일 상단에 Apache 2.0 attribution 의무를 명시한다.
+
+### 1.1 배경
+
+- handoff §4.1: revfactory/harness `skills/harness/references/*` 6 reference docs는 MoAI-ADK가 v3.0.0 R3에서 도입하려는 패턴 체계와 정확히 일치한다. 자력 작성보다 prior art 흡수가 품질·신뢰성·시간 모두에서 우월.
+- 6 reference 항목 (handoff 명시):
+  1. **agent-patterns** — Team / Sub-agent / Hybrid / Orchestrator / Specialist / Pipeline 6 architectural patterns
+  2. **boundary-verification** — QA 경계면 교차 검증 + 7 실제 버그 사례
+  3. **skill-ab-testing** — With-skill vs Baseline A/B methodology
+  4. **team-pattern-cookbook** — 5 팀 운영 예시 (research/implementation/review/design/debug)
+  5. **orchestrator-templates** — 3 templates (Team / Sub / Hybrid)
+  6. **skill-writing-craft** — description craft + body structure + schema validation
+- License: Apache 2.0. Attribution + NOTICE 의무. MoAI-ADK 자체 라이선스(MIT)와 호환 — Apache 2.0 → MIT 방향은 Apache 2.0 조건(notice 보존) 충족 시 허용.
+
+### 1.2 비목표 (Non-Goals)
+
+- 기존 MoAI-ADK rule 파일 수정/대체 (이번 SPEC은 추가만, 기존 frozen content 변경 없음)
+- harness 저장소의 skill / agent 파일 자체를 흡수 (reference docs만 대상)
+- 한국어 번역 추가 (cookbook은 영어 원본 + 발췌. 사용자 대화는 ko, agent prompt는 en 정책 유지)
+- Apache 2.0 외 라이선스 코드 흡수 (이번 SPEC은 Apache 2.0 단일 source)
+
+---
+
+## 2. Scope
+
+### 2.1 산출 파일 (6 rule files + 1 NOTICE)
+
+#### 신규 6 rule 파일
+
+| # | 경로 | 흡수 source | 핵심 |
+|---|------|-------------|------|
+| 1 | `.claude/rules/moai/development/agent-patterns.md` | harness `references/agent-patterns.md` | 6 patterns + 안티패턴 + selection guide |
+| 2 | `.claude/rules/moai/quality/boundary-verification.md` | harness `references/boundary-verification.md` | 경계면 검증 방법론 + 7 bug case |
+| 3 | `.claude/rules/moai/development/skill-ab-testing.md` | harness `references/skill-ab-testing.md` | A/B methodology + sample size + significance |
+| 4 | `.claude/rules/moai/workflow/team-pattern-cookbook.md` | harness `references/team-pattern-cookbook.md` | 5 팀 예시 + role profile + ownership |
+| 5 | `.claude/rules/moai/development/orchestrator-templates.md` | harness `references/orchestrator-templates.md` | 3 templates + when/how/recovery |
+| 6 | `.claude/rules/moai/development/skill-writing-craft.md` | harness `references/skill-writing-craft.md` | description craft + 3-level disclosure + schema |
+
+신규 디렉토리 1개: `.claude/rules/moai/quality/` (Pattern #2 산출 위해 생성)
+
+#### Apache 2.0 attribution 산출
+
+- `.claude/rules/moai/NOTICE.md` (또는 `LICENSE-third-party.md`) — 흡수된 source 일람, Apache 2.0 텍스트 사본, attribution 보존
+
+### 2.2 Template-First 동기화
+
+- Local: `/Users/goos/MoAI/moai-adk-go/.claude/rules/moai/`
+- Template mirror: `/Users/goos/MoAI/moai-adk-go/internal/template/templates/.claude/rules/moai/`
+- 양쪽 동시 갱신 필수. `make build` 후 `go test ./internal/template/...` 회귀 확인.
+
+### 2.3 Frontmatter 정책
+
+각 rule 파일은 conditional loading 가능하도록 frontmatter 추가:
+
+- `agent-patterns.md` → `paths: ".claude/agents/**/*.md,.claude/rules/moai/development/agent-authoring.md"` (agent 작성 시 auto-load)
+- `boundary-verification.md` → `paths: "**/*_test.go,**/test/**"` (테스트 작성 시 auto-load)
+- `skill-ab-testing.md` → `paths: ".claude/skills/**/*.md"` (skill 작성/평가 시 auto-load)
+- `team-pattern-cookbook.md` → `paths: "workflow.yaml,.claude/rules/moai/workflow/team-protocol.md"` (team 모드 시 auto-load)
+- `orchestrator-templates.md` → `paths: ".claude/rules/moai/core/moai-constitution.md,CLAUDE.md"` (오케스트레이터 컨텍스트)
+- `skill-writing-craft.md` → `paths: ".claude/skills/**/SKILL.md"` (skill body 작성 시 auto-load)
+
+---
+
+## 3. EARS Requirements
+
+### REQ-PAT-001 (Ubiquitous — agent patterns)
+
+WHEN agent designer references pattern selection during agent authoring,
+THE `.claude/rules/moai/development/agent-patterns.md` SHALL provide 6 architectural patterns (Team / Sub-agent / Hybrid / Orchestrator / Specialist / Pipeline) with: pattern definition, when-to-use criteria, anti-pattern examples, and Apache 2.0 attribution at file head.
+
+### REQ-PAT-002 (Ubiquitous — boundary verification)
+
+WHEN QA engineer plans boundary tests OR test agent receives `boundary-verification.md` via paths frontmatter,
+THE document SHALL describe 7 documented bug case patterns with: bug symptom, root cause, boundary condition that should have been tested, and verification strategy template.
+
+### REQ-PAT-003 (Ubiquitous — skill A/B testing)
+
+WHEN skill author optimizes skill quality OR proposes a new skill,
+THE `.claude/rules/moai/development/skill-ab-testing.md` SHALL provide A/B methodology including: with-skill vs baseline comparison protocol, evaluation criteria, statistical significance guidance, and sample size recommendations.
+
+### REQ-PAT-004 (Ubiquitous — team patterns)
+
+WHEN team mode setup is needed OR `workflow.yaml` is being authored,
+THE `.claude/rules/moai/workflow/team-pattern-cookbook.md` SHALL describe 5 team examples (research / implementation / review / design / debug) with: role profile composition, file ownership pattern, communication protocol, and shutdown sequence.
+
+### REQ-PAT-005 (Ubiquitous — orchestrator templates)
+
+WHEN orchestrator template is selected during workflow design,
+THE `.claude/rules/moai/development/orchestrator-templates.md` SHALL provide 3 templates (Team-orchestrator / Sub-orchestrator / Hybrid-orchestrator) with: when to use each, how to spawn, error recovery flow, and escalation rules.
+
+### REQ-PAT-006 (Ubiquitous — skill writing craft)
+
+WHEN skill body is authored OR skill description is reviewed for triggering accuracy,
+THE `.claude/rules/moai/development/skill-writing-craft.md` SHALL guide on: description craft (when to trigger / when to skip), 3-level progressive disclosure body structure, frontmatter schema validation rules.
+
+### REQ-PAT-007 (Ubiquitous — Apache 2.0 compliance)
+
+WHILE any of the 6 cookbook rule files are present in repository,
+THE NOTICE artifact (`.claude/rules/moai/NOTICE.md`) SHALL list all 6 source references with: original repository URL (revfactory/harness), license (Apache 2.0), attribution clause, and date of import.
+
+### REQ-PAT-008 (Ubiquitous — Template-First sync)
+
+WHILE the 6 cookbook rule files exist in `.claude/rules/moai/`,
+THE corresponding files SHALL also exist (byte-identical) in `internal/template/templates/.claude/rules/moai/` so that `moai init` produces the same cookbook for new projects.
+
+---
+
+## 4. Exclusions (What NOT to Build)
+
+- **언어 번역**: 영어 원문만 흡수. 한국어 번역 추가는 별도 SPEC.
+- **harness 저장소의 skill / agent 본체 흡수**: 이번 SPEC은 reference docs 6개만. skill/agent 본체 흡수는 별도 SPEC.
+- **MoAI-ADK 기존 패턴 문서 대체**: `.claude/rules/moai/development/agent-authoring.md`, `skill-authoring.md`은 그대로 유지. cookbook은 보충 자료.
+- **harness 저장소의 다른 reference (7번째 이후)**: handoff에서 명시한 6개만. 추가 흡수는 별도 SPEC.
+- **harness clone 자동화**: 이번 SPEC은 1회성 흡수. 추후 upstream sync 자동화는 별도 SPEC.
+- **frontmatter `paths` 글로브 외 동적 로딩**: 표준 Claude Code rules 메커니즘만 사용.
+
+---
+
+## 5. Constraints
+
+- [HARD] Apache 2.0 attribution: 모든 6 산출 파일 상단에 `<!-- Source: revfactory/harness — Apache License 2.0 — see .claude/rules/moai/NOTICE.md -->` 주석.
+- [HARD] Template-First: local + template mirror 동시 갱신, `make build` 후 회귀 테스트.
+- [HARD] 16-language neutral: cookbook 예시는 특정 언어(Go/Python/JS) 편향 금지. patterns은 언어 중립적 표현.
+- [HARD] 기존 frozen rule 파일 (CLAUDE.md, moai-constitution.md, agent-common-protocol.md, design/constitution.md) 수정 금지.
+- [HARD] 영어 instruction 정책 (coding-standards.md §Language Policy) 준수.
+- 산출물은 `.claude/rules/moai/` 하위. SKILL.md / agent body 직접 수정 없음.
+
+---
+
+## 6. Acceptance Hooks
+
+- AC-001 ~ AC-005 → see `acceptance.md`
+- Implementation order: see `plan.md`
+- Task breakdown: see `tasks.md`
+
+---
+
+## 7. References
+
+- handoff §4.1 — revfactory/harness reference adoption strategy
+- `.claude/rules/moai/development/agent-authoring.md` — 기존 agent 작성 가이드 (보존)
+- `.claude/rules/moai/development/skill-authoring.md` — 기존 skill 작성 가이드 (보존)
+- `.claude/rules/moai/workflow/team-protocol.md` — 기존 team 운영 프로토콜 (보존)
+- SPEC-V3R3-DEF-007 — Convention Compliance Sweep (related: skill frontmatter baseline)
+- SPEC-V3R3-ARCH-003 — Expert tool uplift (related: agent body 일관성 baseline)
+- Apache License 2.0 — https://www.apache.org/licenses/LICENSE-2.0
+- revfactory/harness — https://github.com/revfactory/harness

--- a/.moai/specs/SPEC-V3R3-PATTERNS-001/tasks.md
+++ b/.moai/specs/SPEC-V3R3-PATTERNS-001/tasks.md
@@ -1,0 +1,232 @@
+---
+id: SPEC-V3R3-PATTERNS-001
+version: "0.1.0"
+status: draft
+created_at: 2026-04-26
+updated_at: 2026-04-26
+author: manager-spec
+priority: High
+labels: [patterns, harness, tasks, v3r3]
+issue_number: null
+---
+
+# SPEC-V3R3-PATTERNS-001 — Task Breakdown
+
+> Wave-based execution. 각 wave는 sequential. 동일 wave 내 task는 단일 sub-agent에게 한 번에 위임.
+
+---
+
+## Wave 1 — Prior Art Analysis (Read-only)
+
+**Owner**: Explore agent (general-purpose, mode: plan)
+**Isolation**: None (read-only, 임시 디렉토리 사용)
+**Token estimate**: ~15K (clone metadata + 6 reference 분석)
+
+| ID | Task | Tool/Action | Output |
+|----|------|-------------|--------|
+| T1.1 | harness 저장소 clone (depth=1) | `git clone --depth=1 https://github.com/revfactory/harness.git /tmp/harness-analysis/harness` | `/tmp/harness-analysis/harness/` |
+| T1.2 | LICENSE 검증 | `head -10 /tmp/harness-analysis/harness/LICENSE` | Apache 2.0 확인 또는 EC-001 트리거 |
+| T1.3 | 6 reference 파일 존재 확인 | `ls /tmp/harness-analysis/harness/skills/harness/references/` | 6 파일 모두 확인 또는 EC-002 트리거 |
+| T1.4 | 각 reference 핵심 섹션 추출 | Read each file, extract structure | progress.md에 import 매핑 표 작성 |
+| T1.5 | NOTICE 파일 사본 확보 | `cat /tmp/harness-analysis/harness/NOTICE` (있다면) | NOTICE 텍스트 또는 "NOTICE absent" 기록 |
+
+**Wave 1 Exit**: progress.md에 다음 모두 기록:
+- LICENSE: Apache 2.0 (확정)
+- 6 reference 파일 path 일람
+- import 매핑 표 (source section → target section)
+- NOTICE 텍스트 또는 부재 사실
+
+---
+
+## Wave 2 — Cookbook Authoring (Write)
+
+**Owner**: manager-tdd (sub-agent, acceptEdits)
+**Isolation**: None (직접 write)
+**Token estimate**: ~80K (6 파일 × 평균 13K + NOTICE)
+
+### T2.1 — 디렉토리 신규 생성
+
+```bash
+mkdir -p .claude/rules/moai/quality
+mkdir -p internal/template/templates/.claude/rules/moai/quality
+```
+
+### T2.2 — `.claude/rules/moai/NOTICE.md` 작성
+
+내용:
+- 헤더: "MoAI-ADK Third-Party Notices"
+- Apache 2.0 LICENSE 텍스트 (전체 사본 또는 URL + summary)
+- 흡수된 source 일람 (revfactory/harness, 6 파일, import 날짜 2026-04-26)
+- attribution clause: "This product includes software developed by revfactory/harness contributors."
+- harness NOTICE 파일 사본 (있다면)
+
+### T2.3 — `agent-patterns.md` 작성
+
+경로: `.claude/rules/moai/development/agent-patterns.md`
+- frontmatter: `paths: ".claude/agents/**/*.md,.claude/rules/moai/development/agent-authoring.md"`
+- 상단 attribution 주석
+- 6 patterns 섹션: Team / Sub-agent / Hybrid / Orchestrator / Specialist / Pipeline
+- 각 pattern: definition / when to use / example / anti-pattern
+- harness reference로부터 import + 16-language neutralization
+
+### T2.4 — `boundary-verification.md` 작성
+
+경로: `.claude/rules/moai/quality/boundary-verification.md`
+- frontmatter: `paths: "**/*_test.go,**/*test*.py,**/*test*.ts,**/*test*.rs,**/test/**,**/tests/**"`
+- 상단 attribution 주석
+- 7 bug case: case header 7개
+- 각 case: symptom / root cause / boundary condition / verification strategy
+- 16-language neutralization
+
+### T2.5 — `skill-ab-testing.md` 작성
+
+경로: `.claude/rules/moai/development/skill-ab-testing.md`
+- frontmatter: `paths: ".claude/skills/**/SKILL.md,.claude/skills/**/*.md"`
+- 상단 attribution 주석
+- A/B methodology 섹션: with-skill vs baseline / evaluation criteria / sample size / statistical significance
+
+### T2.6 — `team-pattern-cookbook.md` 작성
+
+경로: `.claude/rules/moai/workflow/team-pattern-cookbook.md`
+- frontmatter: `paths: ".moai/config/sections/workflow.yaml,.claude/rules/moai/workflow/team-protocol.md"`
+- 상단 attribution 주석
+- 5 팀 예시: Research / Implementation / Review / Design / Debug
+- 각 팀: role profile / file ownership / communication / shutdown sequence
+
+### T2.7 — `orchestrator-templates.md` 작성
+
+경로: `.claude/rules/moai/development/orchestrator-templates.md`
+- frontmatter: `paths: ".claude/rules/moai/core/moai-constitution.md,CLAUDE.md"`
+- 상단 attribution 주석
+- 3 templates: Team-orchestrator / Sub-orchestrator / Hybrid-orchestrator
+- 각 template: when to use / how to spawn / error recovery / escalation
+
+### T2.8 — `skill-writing-craft.md` 작성
+
+경로: `.claude/rules/moai/development/skill-writing-craft.md`
+- frontmatter: `paths: ".claude/skills/**/SKILL.md"`
+- 상단 attribution 주석
+- 3 영역: description craft / 3-level progressive disclosure / schema validation
+- 16-language neutralization
+
+**Wave 2 Exit**: 7 파일 모두 작성 완료. 각 파일 head 30줄 review로 frontmatter + attribution 검증.
+
+---
+
+## Wave 3 — Template-First Sync + Build (Write)
+
+**Owner**: manager-git (sub-agent, acceptEdits)
+**Isolation**: None
+**Token estimate**: ~10K
+
+### T3.1 — Template mirror 동기화
+
+```bash
+# Local → Template byte-identical mirror
+for sub in development/agent-patterns.md \
+           development/skill-ab-testing.md \
+           development/orchestrator-templates.md \
+           development/skill-writing-craft.md \
+           quality/boundary-verification.md \
+           workflow/team-pattern-cookbook.md \
+           NOTICE.md; do
+  cp -f ".claude/rules/moai/$sub" \
+        "internal/template/templates/.claude/rules/moai/$sub"
+done
+```
+
+### T3.2 — `make build` 실행
+
+```bash
+make build
+```
+
+성공 시 `internal/template/embedded.go` 재생성 확인.
+
+### T3.3 — Go test 회귀 검증
+
+```bash
+go test ./internal/template/...
+```
+
+특히 `commands_audit_test.go` 통과 확인.
+
+### T3.4 — `diff` 검증
+
+```bash
+for sub in development/agent-patterns.md ...; do
+  diff ".claude/rules/moai/$sub" \
+       "internal/template/templates/.claude/rules/moai/$sub" || \
+    echo "MIRROR DRIFT: $sub"
+done
+# Expected: no output
+```
+
+**Wave 3 Exit**: build 성공 + test green + mirror diff 0.
+
+---
+
+## Wave 4 — Validation (Test)
+
+**Owner**: manager-quality (sub-agent, mode: plan)
+**Isolation**: None (read-only)
+**Token estimate**: ~10K
+
+### T4.1 — AC-001 ~ AC-005 검증
+
+`acceptance.md`의 각 AC 검증 명령 실행 + 결과 progress.md 기록.
+
+### T4.2 — 16-language neutrality grep
+
+```bash
+files=( "agent-patterns.md" "skill-ab-testing.md" "orchestrator-templates.md" \
+        "skill-writing-craft.md" "boundary-verification.md" "team-pattern-cookbook.md" )
+banned=("pip install" "go get " "npm install" "cargo install")
+# 단독 표기 검사 → flagged 파일 manual review
+```
+
+### T4.3 — frontmatter `paths` 글로브 매칭 확인
+
+각 파일 frontmatter `paths`가 의도된 파일 패턴과 일치하는지 manual review.
+
+### T4.4 — 최종 리포트 작성
+
+progress.md에 Wave 1-4 전체 결과 + 미해결 OQ 목록 + AC trace matrix 기록.
+
+**Wave 4 Exit**: 모든 AC PASS, plan-auditor (있다면) PASS, status를 `draft` → `audit-ready`로 변경 가능 상태.
+
+---
+
+## AC ↔ REQ ↔ Task Trace Matrix
+
+| AC | REQs | Tasks |
+|----|------|-------|
+| AC-001 | REQ-PAT-001 | T2.3, T3.1, T3.4, T4.1 |
+| AC-002 | REQ-PAT-002, REQ-PAT-003 | T2.4, T2.5, T3.1, T3.4, T4.1 |
+| AC-003 | REQ-PAT-004, REQ-PAT-005 | T2.6, T2.7, T3.1, T3.4, T4.1 |
+| AC-004 | REQ-PAT-006 | T2.8, T3.1, T3.4, T4.1 |
+| AC-005 | REQ-PAT-007, REQ-PAT-008 | T2.1, T2.2, T3.1, T3.2, T3.3, T3.4, T4.1, T4.2 |
+
+| REQ | ACs | Tasks |
+|-----|-----|-------|
+| REQ-PAT-001 | AC-001 | T2.3 |
+| REQ-PAT-002 | AC-002 | T2.4 |
+| REQ-PAT-003 | AC-002 | T2.5 |
+| REQ-PAT-004 | AC-003 | T2.6 |
+| REQ-PAT-005 | AC-003 | T2.7 |
+| REQ-PAT-006 | AC-004 | T2.8 |
+| REQ-PAT-007 | AC-005 | T2.2, T4.1 |
+| REQ-PAT-008 | AC-005 | T3.1, T3.2, T3.4 |
+
+Coverage: 100% (모든 REQ가 적어도 1 AC + 1 Task에 매핑, 모든 AC가 적어도 1 REQ + 1 Task에 매핑).
+
+---
+
+## Risks recap (from plan.md §4)
+
+- LICENSE 불일치 (R-001) → Wave 1에서 abort path
+- reference 부재 (R-002) → Wave 1에서 사용자 협의
+- 16-language 위반 (R-003) → Wave 2 자가검증 + Wave 4 grep
+- mirror drift (R-004) → Wave 3 diff 검증
+- frontmatter glob 오류 (R-005) → Wave 4 manual review
+- NOTICE 누락 (R-006) → T2.2에서 별도 작성 + AC-005 grep

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,16 @@ Consolidated minor release: V3R3 Phase A 산출물 + V3R2 backup restore (Plan A
   `stale_aggregate_threshold` configurable per project. Default: 24h / 200 lines / 10 files.
 - **`MOAI_MEMORY_AUDIT=0`** environment override for bulk migrations.
 
+### Fixed
+
+- **PostToolUse hook timeout 60s → 10s** (template + local): the previous 60s default could amplify MCP-related stalls
+  by holding the conversation for up to 60s after Write/Edit while LSP/AST/MX validations completed. Real-world latency
+  for `moai hook post-tool` is <50ms; 10s now serves as the defensive ceiling.
+- **`settings-management.md` freeze diagnosis checklist**: added a 4-step ordered checklist (MCP auth → hook timeout
+  → context pressure → terminal I/O) so users can self-diagnose mid-session freezes instead of escalating.
+- **`settings-management.md` timeout units clarification**: corrected the "1–600,000ms" wording (Claude Code hook
+  timeouts are in **seconds**, not milliseconds) and added a per-hook recommended ceiling table.
+
 ### Technical
 
 - New rule directory: `.claude/rules/moai/quality/` (created for boundary-verification.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,34 +5,106 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] — SPEC-V3R2-CON-001: FROZEN/EVOLVABLE Zone Registry
+## [2.16.0] - 2026-04-26
+
+Consolidated minor release: V3R3 Phase A 산출물 + V3R2 backup restore (Plan Audit Gate, Zone Registry, Typed Memory Taxonomy, WF-001/006) + V3R3 Phase B PATTERNS-001 (Pattern Cookbook). v2.15.0 was prepared but never tagged separately; its Phase A entry below is preserved as historical reference and is fully included in this release.
 
 ### Added
 
-- **`moai constitution list`** CLI command: Browse and filter the zone registry by `--zone frozen|evolvable`,
-  `--file <pattern>`, and `--format table|json`. Source: SPEC-V3R2-CON-001.
-- **`moai constitution guard`** CLI command: Check a list of changed rule IDs for FROZEN zone violations.
-  Returns non-zero exit on any Frozen-zone rule modification. Designed for CI pipelines.
-- **Zone Registry** (`.claude/rules/moai/core/zone-registry.md`): Single source of truth for all HARD clauses
-  across the MoAI rule tree. 68 entries: 38 Frozen, 30 Evolvable. Template twin included.
-- **`internal/constitution` package**: `Zone`, `Rule`, `Registry`, `LoadRegistry`, `ValidateRuleReferences`.
-  86.5% test coverage. 200-entry cold load benchmark: ~1.85ms (target <10ms).
-- **Doctor constitution check** (`moai doctor`): `Constitution Registry` check validates registry existence,
-  Frozen entry count, orphan warnings, and duplicate IDs. Supports `MOAI_CONSTITUTION_STRICT=1` strict mode.
-- **Makefile `constitution-check` target**: Runs `moai constitution list --format json` against the live registry.
+#### V3R3 Phase B — Pattern Cookbook (revfactory/harness Apache 2.0 흡수)
+
+- **Pattern Cookbook 6 rule files** (SPEC-V3R3-PATTERNS-001):
+  - `.claude/rules/moai/development/agent-patterns.md` — 6 architectural patterns + MoAI vocabulary mapping
+    (Team / Sub-agent / Hybrid / Orchestrator / Specialist / Pipeline)
+  - `.claude/rules/moai/development/orchestrator-templates.md` — 3 templates (Team-orchestrator / Sub-orchestrator / Hybrid-orchestrator)
+  - `.claude/rules/moai/development/skill-ab-testing.md` — with-skill vs baseline A/B methodology
+  - `.claude/rules/moai/development/skill-writing-craft.md` — description craft + 3-level disclosure + schema
+  - `.claude/rules/moai/quality/boundary-verification.md` — 7 documented bug case studies (NEW directory)
+  - `.claude/rules/moai/workflow/team-pattern-cookbook.md` — 5 team patterns (Research / Implementation / Review / Design / Debug)
+- **Apache 2.0 NOTICE** (`.claude/rules/moai/NOTICE.md`): attribution + source list + import date
+- **Frontmatter `paths` (CSV)** on all 6 rule files for context-aware auto-loading
+- **Template-First mirror**: 7/7 byte-identical copies under `internal/template/templates/.claude/rules/moai/`
+
+#### V3R2 Backup Restore — Plan Audit Gate
+
+- **Phase 0.5 Plan Audit Gate** (SPEC-WF-AUDIT-GATE-001): mandatory plan-auditor gate executed at the
+  start of every `/moai run` invocation, before any implementation phase begins. 4 verdicts
+  (PASS / FAIL / BYPASSED / INCONCLUSIVE), 7-day grace window with FAIL_WARNED downgrade.
+- **`.moai/reports/plan-audit/`** directory + `.gitkeep` for per-call audit report persistence
+- **`spec-workflow.md` Phase 0.5 documentation**: gate entry conditions, verdicts, report format,
+  grace window mechanics
+- **plan.md `audit-ready` signal**: Completion Criteria amended to require explicit `audit-ready`
+  status before transition to Run phase
+- **WF-001/006 restoration**: workflow rule baselines re-aligned with V3R2 standards
+
+#### V3R2 Backup Restore — FROZEN/EVOLVABLE Zone Registry
+
+- **`moai constitution list`** CLI command (SPEC-V3R2-CON-001): browse and filter the zone registry by
+  `--zone frozen|evolvable`, `--file <pattern>`, and `--format table|json`
+- **`moai constitution guard`** CLI command: checks a list of changed rule IDs for FROZEN zone
+  violations. Returns non-zero exit on any Frozen-zone rule modification. Designed for CI pipelines.
+- **Zone Registry** (`.claude/rules/moai/core/zone-registry.md`): single source of truth for all HARD
+  clauses across the MoAI rule tree. 68 entries: 38 Frozen, 30 Evolvable. Template twin included.
+- **`internal/constitution` package**: `Zone`, `Rule`, `Registry`, `LoadRegistry`,
+  `ValidateRuleReferences`. 86.5% test coverage. 200-entry cold load benchmark: ~1.85ms (target <10ms).
+- **Doctor constitution check** (`moai doctor`): validates registry existence, Frozen entry count,
+  orphan warnings, and duplicate IDs. Supports `MOAI_CONSTITUTION_STRICT=1` strict mode.
+- **Makefile `constitution-check` target**: runs `moai constitution list --format json` against the
+  live registry.
 - **CI `constitution-check` job** (`.github/workflows/ci.yml`): `continue-on-error: true` job verifying
   registry integrity on every push to main and PR.
 
+#### V3R2 Backup Restore — Typed Memory Taxonomy
+
+- **4-type memory enforcement** (SPEC-V3R2-EXT-001): `user / feedback / project / reference` memory
+  types with required frontmatter (`name`, `description`, `type`). Body structure rules for
+  `feedback` / `project` (lead with rule + `**Why:**` + `**How to apply:**`).
+- **`internal/hook/memo/taxonomy` subpackage**: `MemoryType` enum, `ParseFile`, `DetectStale`,
+  `AuditFile / AuditIndex / AuditDuplicates`. 91.7% coverage.
+- **Stale memory detection**: SessionStart hook wraps memory files older than 24h in
+  `<system-reminder>` blocks. Aggregate warning emitted when ≥10 stale files detected
+  simultaneously to avoid token bloat.
+- **MEMORY.md 200-line cap**: enforced by `MEMORY_INDEX_OVERFLOW` audit warning. Lines 201+ are
+  silently truncated by Claude Code memory loader.
+- **PostToolUse memory audit**: non-blocking stderr warnings on Write/Edit operations
+  (`MEMORY_MISSING_TYPE`, `MEMORY_MISSING_FRONTMATTER`, `MEMORY_BODY_STRUCTURE_MISSING`,
+  `MEMORY_EXCLUDED_CATEGORY`, `MEMORY_DUPLICATE`).
+- **`workflow.yaml` `memory` section**: `staleness_threshold_hours`, `index_line_cap`,
+  `stale_aggregate_threshold` configurable per project. Default: 24h / 200 lines / 10 files.
+- **`MOAI_MEMORY_AUDIT=0`** environment override for bulk migrations.
+
 ### Technical
 
-- New package `internal/constitution`: `zone.go`, `rule.go`, `loader.go`, `dangling.go`
+- New rule directory: `.claude/rules/moai/quality/` (created for boundary-verification.md)
+- New packages: `internal/constitution`, `internal/hook/memo/taxonomy`
+- Binary size delta cumulative: +33,600 bytes (~33 KiB, limit 50 KiB) for constitution; ~5 KiB for taxonomy
 - Test fixtures: `internal/constitution/testdata/` (6 fixture files)
-- Binary size delta: +33,600 bytes (~33 KiB, limit 50 KiB)
 - Integration tests: `internal/cli/constitution_integration_test.go` (build tag: integration)
+- License compliance: revfactory/harness Apache 2.0 → MoAI-ADK MIT, NOTICE preserved
+  (Apache 2.0 → MIT direction permitted with NOTICE retention)
 
-## [Unreleased] — SPEC-WF-AUDIT-GATE-001: Plan Audit Gate (grace window 7d)
+### Verification
 
-## [2.15.0] - 2026-04-26
+- All AC for SPEC-V3R3-PATTERNS-001 (AC-001..005): PASS
+- All AC for SPEC-V3R2-CON-001 (17 AC): PASS, coverage 86.5%
+- All AC for SPEC-V3R2-EXT-001: PASS, coverage 91.7%
+- All AC for SPEC-WF-AUDIT-GATE-001: PASS (placeholder + spec-workflow integration)
+- `make build`: green
+- `go test ./internal/template/...`: PASS
+- `go test ./internal/constitution/...`: PASS
+- `go test ./internal/hook/memo/...`: PASS
+
+### Note on Versioning
+
+v2.15.0 was prepared (system.yaml bumped, CHANGELOG entry added) but never tagged. The V3R3 Phase A
+content listed in the v2.15.0 section below was merged to main but the tag push was skipped, then
+V3R2 backup restore + Phase B work continued. Per user decision (2026-04-26), all merged content
+since v2.14.0 is consolidated into a single v2.16.0 release. The v2.15.0 section is preserved
+verbatim as a historical artifact.
+
+---
+
+## [2.15.0] - 2026-04-26  *(prepared but never tagged — content consolidated into v2.16.0 above)*
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,13 +75,19 @@ Consolidated minor release: V3R3 Phase A 산출물 + V3R2 backup restore (Plan A
 
 ### Fixed
 
-- **PostToolUse hook timeout 60s → 10s** (template + local): the previous 60s default could amplify MCP-related stalls
-  by holding the conversation for up to 60s after Write/Edit while LSP/AST/MX validations completed. Real-world latency
-  for `moai hook post-tool` is <50ms; 10s now serves as the defensive ceiling.
+- **PostToolUse hook: timeout 60s → 10s + `async: true`** (template + local): the previous 60s synchronous default
+  could hold the conversation for up to 60s after every Write/Edit while LSP/AST/MX validations completed. Real-world
+  latency for `moai hook post-tool` is <50ms, so the 60s ceiling was pure defensive margin that compounded MCP-related
+  stalls. The new defaults: (a) `timeout: 10` as the per-run upper bound, (b) `async: true` so the hook runs in the
+  background and results are delivered via `systemMessage` on the next turn — Write/Edit never blocks the main response.
 - **`settings-management.md` freeze diagnosis checklist**: added a 4-step ordered checklist (MCP auth → hook timeout
   → context pressure → terminal I/O) so users can self-diagnose mid-session freezes instead of escalating.
 - **`settings-management.md` timeout units clarification**: corrected the "1–600,000ms" wording (Claude Code hook
   timeouts are in **seconds**, not milliseconds) and added a per-hook recommended ceiling table.
+- **`internal/runtime/audit_report.go` + `audit_cache.go` lint cleanup**: addressed 11 staticcheck (QF1012, S1039) and
+  errcheck findings inherited from the V3R2 backup restore. Replaced `WriteString(fmt.Sprintf(...))` patterns with
+  `fmt.Fprintf(&sb, ...)`, removed redundant `fmt.Sprintf` for static strings, and made `defer f.Close()` errcheck-safe
+  via `defer func() { _ = f.Close() }()`.
 
 ### Technical
 

--- a/internal/template/templates/.claude/rules/moai/NOTICE.md
+++ b/internal/template/templates/.claude/rules/moai/NOTICE.md
@@ -1,0 +1,37 @@
+# MoAI-ADK Third-Party Notices
+
+This product includes software developed by revfactory/harness and redistributed under the Apache License 2.0.
+
+## Apache License 2.0
+
+The following source material is licensed under Apache License 2.0:
+
+**Source Repository**: https://github.com/revfactory/harness  
+**License**: Apache License 2.0 (https://www.apache.org/licenses/LICENSE-2.0)
+
+### Imported Components
+
+The following reference documents from `revfactory/harness` (imported 2026-04-26) are incorporated into MoAI-ADK as pattern cookbook rules:
+
+1. `agent-design-patterns.md` → `.claude/rules/moai/development/agent-patterns.md`
+2. `qa-agent-guide.md` → `.claude/rules/moai/quality/boundary-verification.md`
+3. `skill-testing-guide.md` → `.claude/rules/moai/development/skill-ab-testing.md`
+4. `team-examples.md` → `.claude/rules/moai/workflow/team-pattern-cookbook.md`
+5. `orchestrator-template.md` → `.claude/rules/moai/development/orchestrator-templates.md`
+6. `skill-writing-guide.md` → `.claude/rules/moai/development/skill-writing-craft.md`
+
+### Attribution
+
+This product includes software developed by revfactory/harness contributors. The original works and any modifications are provided under the terms of the Apache License 2.0.
+
+The imported documents have been adapted for MoAI-ADK terminology and 16-language neutrality while preserving the original technical content and design patterns. Original source authorship is retained.
+
+### Full Apache License 2.0 Text
+
+For the complete Apache License 2.0 text, visit: https://www.apache.org/licenses/LICENSE-2.0
+
+---
+
+**Import Date**: 2026-04-26  
+**MoAI-ADK License**: MIT  
+**Combined Compatibility**: Apache 2.0 imports distributed under MIT with Apache attribution preserved.

--- a/internal/template/templates/.claude/rules/moai/core/hooks-system.md
+++ b/internal/template/templates/.claude/rules/moai/core/hooks-system.md
@@ -195,7 +195,7 @@ Define hooks in `.claude/settings.json`:
     "PostToolUse": [{
       "matcher": "Write|Edit",
       "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-post-tool.sh\"",
-      "timeout": 60
+      "timeout": 10
     }],
     "Stop": [{
       "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-stop.sh\"",

--- a/internal/template/templates/.claude/rules/moai/core/hooks-system.md
+++ b/internal/template/templates/.claude/rules/moai/core/hooks-system.md
@@ -195,7 +195,8 @@ Define hooks in `.claude/settings.json`:
     "PostToolUse": [{
       "matcher": "Write|Edit",
       "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-post-tool.sh\"",
-      "timeout": 10
+      "timeout": 10,
+      "async": true
     }],
     "Stop": [{
       "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-stop.sh\"",

--- a/internal/template/templates/.claude/rules/moai/core/settings-management.md
+++ b/internal/template/templates/.claude/rules/moai/core/settings-management.md
@@ -109,7 +109,7 @@ Hook timeout unit is **seconds** (not milliseconds, despite some external docs).
 |------|--------------------|-----------|
 | SessionStart | 30s | MCP server startup latency |
 | PreToolUse | 5s | Fast pre-flight checks only |
-| PostToolUse | **10s** (was 60s before v2.16.0) | LSP/AST/MX validations average <30ms; 10s is generous safety margin |
+| PostToolUse | **10s + `async: true`** (was 60s synchronous before v2.16.0) | LSP/AST/MX validations run in background; results delivered via systemMessage on next turn. 10s is the per-run upper bound, not a blocking wait |
 | Stop / SubagentStop | 5s | Lightweight teardown |
 | TeammateIdle / TaskCompleted | 10s | Quality validation may run lint/test |
 

--- a/internal/template/templates/.claude/rules/moai/core/settings-management.md
+++ b/internal/template/templates/.claude/rules/moai/core/settings-management.md
@@ -103,8 +103,32 @@ Hooks support environment variables and must be quoted to handle spaces:
 
 **Important**: Quote the entire path: `"\"$CLAUDE_PROJECT_DIR/path\""` not `"$CLAUDE_PROJECT_DIR/path"`
 
-Hook timeout range: 1–600,000ms (max 10 minutes). Default is 5,000ms for most hooks.
-Long-running hooks (PostToolUse, quality gates) should set `"timeout": 60000` or higher.
+Hook timeout unit is **seconds** (not milliseconds, despite some external docs). Default is 5s for most hooks. Recommended ceilings:
+
+| Hook | Recommended timeout | Rationale |
+|------|--------------------|-----------|
+| SessionStart | 30s | MCP server startup latency |
+| PreToolUse | 5s | Fast pre-flight checks only |
+| PostToolUse | **10s** (was 60s before v2.16.0) | LSP/AST/MX validations average <30ms; 10s is generous safety margin |
+| Stop / SubagentStop | 5s | Lightweight teardown |
+| TeammateIdle / TaskCompleted | 10s | Quality validation may run lint/test |
+
+For very long validations (full test suites, deployments), prefer `"async": true` over high timeout — the hook runs in background and results arrive on the next turn (see hooks-system.md §Async Command Hooks).
+
+### Freeze Diagnosis Checklist
+
+If a session appears to freeze mid-conversation, check in this order (cheapest to most invasive):
+
+1. **MCP authentication failures** — most common cause. Run `claude mcp list` and remove servers showing `oauth_required` / `connection_failed`. Each unauthenticated MCP can add 5-30s retry latency on tool calls.
+2. **Hook timeout** — run `claude --debug "hooks"` to see per-hook latency. If a hook exceeds its timeout, the response stalls until timeout expires. moai hook handlers (post-tool, stop, subagent-stop) typically complete in <50ms; persistent slowness usually points to LSP server hangs.
+3. **Context window pressure** — see `.claude/rules/moai/workflow/context-window-management.md`. SSE streams stall when prompts approach 75% of the window.
+4. **Terminal I/O saturation** — high write ratio (>90% writes in `tmux info`) can make output appear delayed. This is rendering only, not a true freeze.
+
+Profile a hook directly:
+```bash
+echo '{"hook_event_name":"PostToolUse","tool_name":"Write","tool_response":{"success":true},"session_id":"test"}' | time moai hook post-tool
+```
+Healthy result: under 100ms. Persistent slowness → check LSP / disk I/O / MX validation cost.
 
 ## StatusLine Configuration
 

--- a/internal/template/templates/.claude/rules/moai/development/agent-patterns.md
+++ b/internal/template/templates/.claude/rules/moai/development/agent-patterns.md
@@ -1,0 +1,200 @@
+---
+description: "Six architectural agent orchestration patterns for MoAI-ADK agent design"
+paths: ".claude/agents/**/*.md,.claude/rules/moai/development/agent-authoring.md"
+---
+
+<!-- Source: revfactory/harness — Apache License 2.0 — see .claude/rules/moai/NOTICE.md -->
+
+# Agent Design Patterns
+
+Six foundational orchestration patterns for designing agent systems in MoAI-ADK. These patterns describe how agents interact, communicate, and coordinate work.
+
+## Pattern 1: Pipeline
+
+Sequential execution where each agent's output becomes the next agent's input.
+
+**Structure**: Agent A → Agent B → Agent C → Agent D
+
+**When to Use**: 
+- Requirements are strongly dependent on previous stage outputs
+- Each stage has clear input/output contracts
+- Linear workflow with minimal branching
+
+**Example**: Content creation pipeline — research → outline → draft → edit
+
+**Anti-Pattern**: Using pipeline when stages are independent (wastes sequential overhead)
+
+---
+
+## Pattern 2: Fan-out/Fan-in
+
+Parallel processing with independent analysis followed by result aggregation.
+
+**Structure**: 
+```
+         ┌→ Agent A ┐
+Dispatch ┼→ Agent B ┼→ Synthesize
+         └→ Agent C ┘
+```
+
+**When to Use**:
+- Same input needs multiple independent perspectives
+- Parallel analysis improves coverage
+- Results can be meaningfully combined
+
+**Example**: Multi-angle research — technical + market + user perspectives analyzed in parallel, then synthesized
+
+**Anti-Pattern**: Over-specifying how to combine results; let agents negotiate
+
+---
+
+## Pattern 3: Expert Pool
+
+Dynamic selection of appropriate specialist for each task.
+
+**Structure**: Router → { Expert A | Expert B | Expert C }
+
+**When to Use**:
+- Input type determines which expert to invoke
+- Not all experts needed for each task
+- Expert selection is well-defined
+
+**Example**: Code review routing — security expert for auth code, performance expert for queries, architecture expert for design
+
+**Anti-Pattern**: Always invoking all experts even when only one is relevant
+
+---
+
+## Pattern 4: Producer-Reviewer
+
+Iterative quality cycle with specialized producer and reviewer agents.
+
+**Structure**: Producer → Reviewer → (Feedback loop) → Producer redo → Reviewer
+
+**When to Use**:
+- Quality validation has clear objective criteria
+- Feedback can guide refinement
+- Bounded iteration count prevents infinite loops
+
+**Example**: Content generation with review — writer creates → editor reviews → writer revises (max 3 iterations)
+
+**Anti-Pattern**: Unbounded review cycles; always set maximum iterations
+
+---
+
+## Pattern 5: Supervisor
+
+Central coordinator agent manages work distribution to subordinate agents.
+
+**Structure**:
+```
+         ┌→ Worker A
+Supervisor ┼→ Worker B  (Dynamic assignment)
+         └→ Worker C
+```
+
+**When to Use**:
+- Work volume or complexity is variable
+- Tasks need dynamic distribution
+- Coordination overhead is acceptable
+
+**Example**: Large codebase migration — supervisor analyzes files, delegates modules to workers, tracks progress
+
+**Anti-Pattern**: Supervisor becomes a bottleneck; use for high-level coordination only
+
+---
+
+## Pattern 6: Hierarchical Delegation
+
+Multi-level delegation where agents recursively decompose problems.
+
+**Structure**:
+```
+[Executive] → [Manager A] → [Specialist A1]
+                           → [Specialist A2]
+           → [Manager B] → [Specialist B1]
+```
+
+**When to Use**:
+- Problem naturally decomposes hierarchically
+- Clear team boundaries exist
+- Depth is limited (max 2-3 levels)
+
+**Example**: Full-stack development — lead → backend team lead → (database + API + tests) + frontend team lead → (UI + state management)
+
+**Anti-Pattern**: Nesting more than 2-3 levels; causes coordination overhead and context loss
+
+---
+
+## Pattern Selection Matrix
+
+| Scenario | Pattern | Why |
+|----------|---------|-----|
+| Linear requirements | Pipeline | Clear ordering |
+| Parallel analysis | Fan-out/Fan-in | Independent perspectives |
+| Variable expertise | Expert Pool | Right tool per task |
+| Quality iteration | Producer-Reviewer | Focused refinement loop |
+| Variable workload | Supervisor | Dynamic allocation |
+| Complex decomposition | Hierarchical | Natural boundaries |
+
+---
+
+## Anti-Patterns to Avoid
+
+**Anti-Pattern 1**: "Pipeline everything"
+- Using sequential patterns when tasks are independent
+- Fix: Use Fan-out/Fan-in for parallel work
+
+**Anti-Pattern 2**: "All experts always"
+- Invoking every expert for every task
+- Fix: Route to relevant experts only via Expert Pool
+
+**Anti-Pattern 3**: "Unbounded review"
+- Producer-Reviewer without iteration limits
+- Fix: Set `max_iterations: 3` to prevent infinite loops
+
+**Anti-Pattern 4**: "Supervisor bottleneck"
+- Central coordinator doing all coordination work
+- Fix: Use shared task lists for self-coordination
+
+**Anti-Pattern 5**: "Deep hierarchies"
+- Nesting more than 2-3 delegation levels
+- Fix: Flatten structure or switch to Supervisor pattern
+
+---
+
+## Combination Strategies
+
+Real-world systems often combine patterns:
+
+| Combination | Structure | Use Case |
+|-------------|-----------|----------|
+| Pipeline + Fan-out | Sequential stages with parallel substeps | Analysis (gather data) → Design → Implement (parallel experts) |
+| Fan-out/Fan-in + Producer-Reviewer | Parallel analysis then iterative refinement | Research (parallel) → Synthesize → Review/improve |
+| Supervisor + Expert Pool | Coordinator routes to specialists | Large project with dynamic workload distribution |
+
+The key is matching pattern structure to actual workflow dependencies, not forcing dependencies into convenient patterns.
+
+---
+
+## MoAI-ADK Pattern Vocabulary
+
+MoAI-ADK applies the six generic harness patterns using these specialized naming conventions:
+
+### Team
+Maps to **Fan-out/Fan-in**. Multiple agents analyze independently, results synthesized. Use when one request needs multiple perspectives: security review + performance audit + architecture check all run in parallel, then consolidated.
+
+### Sub-agent
+Maps to **Pipeline**. Sequential delegation where Agent A's output becomes Agent B's input. Use when work has clear dependencies: design spec → backend implementation → frontend integration → testing.
+
+### Hybrid
+Maps to **Supervisor** + **Expert Pool**. Central orchestrator routes tasks dynamically to specialists based on task type. Use when workload is heterogeneous: same orchestrator routes code review to security expert OR architecture expert depending on input.
+
+### Orchestrator
+Maps to **Hierarchical Delegation**. Multi-level decomposition where the orchestrator (MoAI) delegates to team leads, who delegate to specialists. Use for large projects with natural team boundaries: MoAI → backend lead → (database team + API team) + frontend lead → (UI team).
+
+### Specialist
+Maps to **Expert Pool** singleton. A single expert agent handles all tasks of a specific type without dynamic routing. Use for focused work: one code formatter, one security validator, one documentation generator.
+
+### Pipeline
+Generic **Pipeline** pattern. Sequential stages with each agent's output feeding the next. Already native to MoAI workflows. Use when linear dependency is explicit: requirements → design → implement → test → ship.

--- a/internal/template/templates/.claude/rules/moai/development/orchestrator-templates.md
+++ b/internal/template/templates/.claude/rules/moai/development/orchestrator-templates.md
@@ -1,0 +1,298 @@
+---
+description: "Three orchestrator templates for task coordination in MoAI-ADK workflows"
+paths: ".claude/rules/moai/core/moai-constitution.md,CLAUDE.md"
+---
+
+<!-- Source: revfactory/harness — Apache License 2.0 — see .claude/rules/moai/NOTICE.md -->
+
+# Orchestrator Templates
+
+Three orchestration patterns for the MoAI orchestrator when coordinating sub-agents and teams.
+
+---
+
+## Team-orchestrator
+
+**When to Use**:
+- Multiple agents need to communicate (not just return results)
+- Parallel exploration with cross-agent feedback is valuable
+- High-coordination complexity (shared task list, dynamic assignment)
+
+**Structure**:
+```
+User Request
+    ↓
+[MoAI] → TeamCreate → [Member A, Member B, Member C]
+         ↓
+      Coordination Loop:
+      - SendMessage (member-to-member)
+      - TaskCreate/Update (shared list)
+      - TeammateIdle hook (members idle when waiting)
+      ↓
+      Final Result Assembly
+      ↓
+      User Response
+```
+
+**How to Spawn**:
+```
+Agent(
+  subagent_type: "general-purpose",
+  mode: "acceptEdits",
+  prompt: "You are leading a 3-person team to solve X. "
+          "Create team via TeamCreate with members: [researcher, implementer, reviewer]. "
+          "Use SendMessage to coordinate. Use TaskCreate for shared work list. "
+          "Present final result to user."
+)
+```
+
+**Error Recovery**:
+- **Member fails task**: Other members continue, lead gets partial result
+- **Member goes idle**: Lead can SendMessage to resume or TaskCreate new work
+- **Communication loop endless**: Set max iteration count, escalate if stuck
+
+**Escalation Rules**:
+- If 2+ members report blocker → User AskUserQuestion for guidance
+- If member rejected shutdown → Lead waits 10s, then collects available output
+- If team creation fails → Fall back to sub-agent mode
+
+**Example: Research + Analysis + Synthesis**
+```
+Team Created: Researcher, Analyst, Synthesizer
+
+1. Researcher: "Investigating X..." → creates research-deep-dive.md
+2. Analyst: "Cross-checking findings..." → creates analysis-validation.md
+3. Researcher (via SendMessage): "Found Y, contradicts expectation"
+4. Analyst (reply): "Confirmed, Z explains it"
+5. Synthesizer: "Creating unified report..."
+6. All members idle
+7. Lead: "Here's the final report"
+8. Leader sends shutdown_request
+9. All approve
+10. TeamDelete
+```
+
+---
+
+## Sub-orchestrator
+
+**When to Use**:
+- Sequential task handoff (output A → input B)
+- Agent coordination not needed (results only matter)
+- Simpler, lower-coordination overhead
+
+**Structure**:
+```
+User Request
+    ↓
+[MoAI] → Delegate to Agent A
+         ↓ Result
+         Delegate to Agent B (with A's output)
+         ↓ Result
+         Delegate to Agent C
+         ↓ Result
+         Consolidate
+         ↓
+      User Response
+```
+
+**How to Spawn**:
+```javascript
+// Sequential
+const resultA = Agent(prompt: "Analyze X", subagent_type: "analyzer")
+const resultB = Agent(prompt: `Design based on: ${resultA}`, subagent_type: "designer")
+const resultC = Agent(prompt: `Implement: ${resultB}`, subagent_type: "implementer")
+
+// Consolidate
+MoAI: "Here are the results from the pipeline..."
+```
+
+**Error Recovery**:
+- **Agent A fails**: AskUserQuestion to proceed, skip, or retry
+- **Agent B fails**: Provide feedback and retry with adjustment
+- **Agent C fails**: Can use partial output from A+B or re-delegate
+
+**Escalation Rules**:
+- If 3+ agents fail in sequence → Escalate to user
+- If total tokens > 80% budget → Collect results and conclude
+- If result quality degrading → Switch to team mode for renegotiation
+
+**Example: Feature Development Pipeline**
+```
+1. Designer: "Create API spec for feature X"
+   → OpenAPI spec
+
+2. Backend: "Implement the API based on spec"
+   → API code + tests
+
+3. Frontend: "Create components based on API"
+   → UI code + hooks
+
+4. Tester: "Verify API + UI together"
+   → Integration test report
+
+5. MoAI: "Feature complete, ready for PR"
+```
+
+---
+
+## Hybrid-orchestrator
+
+**When to Use**:
+- Mix of sequential and parallel stages
+- Some stages need agent coordination, others don't
+- Maximum flexibility for complex workflows
+
+**Structure**:
+```
+Stage 1: Sequential (Sub-orchestrator)
+  Research Agent → Analysis Agent
+
+Stage 2: Parallel (Team-Orchestrator)
+  [TeamCreate] → [Implementation Team with Backend, Frontend, Tests]
+
+Stage 3: Sequential (Sub-orchestrator)
+  Reviewer Agent (review all outputs)
+
+Stage 4: Consolidate
+  Final result to user
+```
+
+**How to Spawn**:
+```
+// Stage 1: Sequential research
+const research = Agent(prompt: "Research X and Y")
+
+// Stage 2: Parallel implementation
+const implementation = Agent(
+  prompt: "Lead a team to implement based on research...",
+  teamCreate: true
+)
+
+// Stage 3: Sequential review
+const reviewed = Agent(
+  prompt: `Review this implementation: ${implementation}`,
+  subagent_type: "reviewer"
+)
+
+// Consolidate
+MoAI: "Implementation complete and reviewed"
+```
+
+**Error Recovery**:
+- **Sequential stage fails**: Retry or skip to next stage
+- **Team stage fails**: Fall back to sequential sub-agents for that stage
+- **Cascade failure**: Collect partial results, present to user with blockers
+
+**Escalation Rules**:
+- If any stage fails after 2 retries → AskUserQuestion for decision
+- If token budget exceeded → Prioritize remaining stages
+- If team created but failing → Offer to switch to sequential approach
+
+**Example: Full-Stack Feature Development**
+```
+Stage 1 (Research):
+- Research Agent: "Analyze requirements and existing architecture"
+
+Stage 2 (Implementation Team):
+- TeamCreate with Backend, Frontend, Tester
+- Parallel development for 2 days
+- Integration testing
+
+Stage 3 (Review):
+- Review Agent: "Security + performance review"
+
+Stage 4 (User Presentation):
+- "Feature ready, here's the PR"
+```
+
+---
+
+## Decision Matrix: Which Template?
+
+| Scenario | Template | Why |
+|----------|----------|-----|
+| Single feature, clear handoff | Sub | No coordination needed, simpler |
+| Feature with coordination required | Team | Agents need to negotiate |
+| Large feature with research + dev | Hybrid | Research sequential, dev parallel |
+| Bug investigation with hypotheses | Team | Debuggers need to share findings |
+| Simple change (style update) | Sub | Overkill for complexity |
+| Redesign involving multiple teams | Hybrid | Multiple phases with different needs |
+| API + Client in parallel | Team | Tight coordination needed |
+
+---
+
+## Common Patterns Within Templates
+
+### Sub-Orchestrator: Fan-out (Parallel Independent Results)
+```
+[MoAI] → Agent A, Agent B, Agent C (all in parallel)
+        Combine A, B, C results
+```
+
+**When**: Independent analyses that don't depend on each other
+**Example**: Concurrent code reviews from security + performance + architecture
+
+### Sub-Orchestrator: Pipeline (Sequential Handoff)
+```
+[MoAI] → Agent A → (result) → Agent B → (result) → Agent C
+```
+
+**When**: Each stage requires previous stage's output
+**Example**: Research → Design → Implementation → Testing
+
+### Team-Orchestrator: Shared Work List
+```
+[Lead] → TaskCreate([Task1, Task2, Task3])
+         Members self-select tasks
+         → TaskUpdate(Task1 complete)
+         → TaskUpdate(Task2 complete)
+         → Remaining tasks handled...
+```
+
+**When**: Work is decomposable, members can self-coordinate
+**Example**: Code migration (split files, each member migrates independently)
+
+---
+
+## Transition Rules
+
+**When to Switch Templates During Execution**:
+
+1. **Sub → Team**: If agents start reporting dependency on unplanned communication
+   - Action: Collect current results, spawn team for next stage
+
+2. **Team → Sub**: If team reaches deadlock or endless coordination loop
+   - Action: Break down remaining tasks for sequential agents
+
+3. **Hybrid → Simpler**: If complex workflow can be simplified
+   - Action: Skip stages, consolidate results
+
+**Signals to Transition**:
+- **Sub feeling like Team**: Agents sending feedback to each other → Create team instead
+- **Team feeling like Sub**: Agents work independently, little communication → Use sub-agents
+- **Over-engineering**: Simple task using complex template → Simplify
+
+---
+
+## Monitoring & Adjustment
+
+**During Execution**:
+- Monitor agent progress via status messages
+- Track token consumption against budget
+- Check for communication loops or idle periods
+- Assess quality of intermediate results
+
+**Decision Points**:
+- After each major stage: Is approach working? Continue or adjust?
+- At 75% token budget: Prepare to conclude or escalate
+- After first failure: Retry with same template or switch?
+
+**Adjustment Options**:
+- Continue with current template
+- Switch to different template mid-stream
+- Add more agents / members to current team
+- Remove members / agents if not contributing
+- Escalate to user for guidance
+
+These three templates provide proven structures for most MoAI orchestration scenarios. Mix and match as needed for your specific workflow.

--- a/internal/template/templates/.claude/rules/moai/development/skill-ab-testing.md
+++ b/internal/template/templates/.claude/rules/moai/development/skill-ab-testing.md
@@ -1,0 +1,221 @@
+---
+description: "A/B testing methodology for skill quality validation and iteration"
+paths: ".claude/skills/**/SKILL.md,.claude/skills/**/*.md"
+---
+
+<!-- Source: revfactory/harness — Apache License 2.0 — see .claude/rules/moai/NOTICE.md -->
+
+# Skill A/B Testing Methodology
+
+Systematic approach to validating skill quality through comparative testing against baseline and iterative improvement.
+
+## Core Principle
+
+**With-Skill vs Baseline Comparison**: Every skill quality evaluation must compare performance with the skill loaded against performance without the skill under identical conditions.
+
+---
+
+## Test Framework
+
+### Test Prompt Design
+
+Create 2-3 test prompts that represent realistic use cases:
+
+**Characteristics of Good Test Prompts**:
+- Concrete and specific (avoid "analyze this")
+- Natural language as users would write
+- Cover core use case + edge case + optional complexity case
+- Mix of explicit instructions and implicit context
+
+**Bad Test Prompts**:
+- "Generate code" (too vague)
+- "Use this framework" (too prescriptive)
+
+**Good Test Prompts**:
+- "I have a React form with email + password fields. The password needs validation (min 8 chars, 1 uppercase, 1 number). Show me the hook code and tests."
+- "This CSV has 3 columns: date, revenue, cost. Add a 4th column: profit margin %. Then sort by margin descending. Include handling for missing data."
+
+### Test Execution: With-Skill vs Baseline
+
+For each test prompt, execute **two parallel runs**:
+
+| Dimension | With-Skill | Baseline |
+|-----------|-----------|----------|
+| **Prompt** | Same prompt + skill provided | Same prompt, no skill |
+| **Output Path** | `_workspace/eval-{id}/with_skill/outputs/` | `_workspace/eval-{id}/without_skill/outputs/` |
+| **Model** | Same model | Same model |
+| **Constraints** | Same token budget, temperature | Same constraints |
+
+### Metrics to Capture
+
+**Token Usage**:
+- `total_tokens`: Tokens consumed (lower is better for same quality)
+- **Improvement**: (baseline_tokens - with_skill_tokens) / baseline_tokens
+
+**Duration**:
+- `duration_ms`: Wall-clock time (lower is better)
+- **Speedup**: baseline_duration / with_skill_duration
+
+**Quality Dimensions** (require manual evaluation or assertion-based scoring):
+
+| Dimension | Measurement |
+|-----------|-------------|
+| **Correctness** | Does output solve the stated problem? (Boolean or %) |
+| **Completeness** | Are all requirements met? (0-100%) |
+| **Clarity** | Is code/response clear and well-organized? (0-100%) |
+| **Efficiency** | Is approach optimal? (0-100%) |
+
+---
+
+## Assertion-Based Scoring
+
+For skills with objective outputs (code generation, data extraction), define assertions:
+
+**Structure**:
+```
+Expectation: "{human-readable expectation}"
+Assertion: "{programmatic check}"
+Evidence: "{what to look for in output}"
+```
+
+**Example Assertions**:
+- `output.includes("useState") && output.includes("useEffect")` — React hooks present
+- `fs.existsSync("output.csv") && csvHasRows("output.csv", 3)` — File created with data
+- `jsAst.hasFunction("validateEmail") && hasReturnType(...)` — Function signature correct
+
+**Scoring Rules**:
+- Each assertion: 0 or 1 (or partial: 0.0-1.0)
+- Score = assertions_passed / total_assertions
+- **Improvement** = (with_skill_score - baseline_score) / baseline_score
+
+---
+
+## Statistical Significance
+
+### Sample Size Guidance
+
+| Difference Magnitude | Recommended Samples |
+|---------------------|-------------------|
+| ≥ 20% improvement | 2-3 samples (clear signal) |
+| 10-20% improvement | 3-5 samples (moderate signal) |
+| 5-10% improvement | 5-10 samples (weak signal, noise risk) |
+| < 5% improvement | 10+ samples (ignore if < 2x total_tokens cost) |
+
+### Variance Factors
+
+Test prompt variance matters more than sample count. If your 2 test prompts exercise different skill aspects, they may be sufficient. If they're similar, results are less reliable.
+
+**High-Variance Prompts** (good):
+- Different domains (API design vs database design)
+- Different skill uses (reference lookup vs advanced decision-making)
+- Different complexity (simple vs complex scenario)
+
+**Low-Variance Prompts** (less reliable):
+- Similar domain (REST API v1 vs REST API v2)
+- Similar complexity (both simple, both complex)
+
+---
+
+## Iteration Workflow
+
+### Single Iteration Cycle
+
+1. **Define Baselines**: Capture "with-skill" and "without-skill" outputs for 2-3 prompts
+2. **Measure Metrics**: Token count, duration, assertion score
+3. **Calculate Improvement**: (with_skill - baseline) / baseline for each metric
+4. **Identify Gaps**: Which assertions failed? What prompt broke the skill?
+5. **Refine Skill**: Improve description (better triggering), body (clearer instructions), schema
+6. **Re-test**: Repeat with updated skill
+
+### When to Iterate
+
+**Continue iterating if**:
+- Assertion pass rate < 80%
+- With-skill score < baseline (regression)
+- Improvement < 10% on primary metric (consider skill value)
+- Skill fails on edge case prompt
+
+**Stop iterating if**:
+- 3+ iterations with < 5% improvement (diminishing returns)
+- Improvement plateaued (no new gains for 2 cycles)
+- Skill meets acceptance criteria (80%+ quality, 10%+ improvement)
+
+### Iteration Cap
+
+Set `max_iterations: 5` to prevent unbounded refinement. If quality target not met after 5 iterations, consider redesigning the skill or reconsidering whether it's valuable.
+
+---
+
+## Evaluation Checklist
+
+**Before declaring skill complete**:
+
+- [ ] 2-3 realistic test prompts defined
+- [ ] With-skill and baseline runs executed for each prompt
+- [ ] Token cost comparison calculated
+- [ ] Quality assertions defined and scored (if applicable)
+- [ ] With-skill improvement ≥ 10% on primary metric, ≥ 0% on all metrics (no regression)
+- [ ] All edge case prompts pass
+- [ ] Description accurately reflects trigger conditions
+- [ ] Body structure follows progressive disclosure (Quick / Implementation / Advanced if large)
+- [ ] Frontmatter complete (description, paths, metadata)
+
+---
+
+## Common Pitfalls
+
+**Pitfall 1**: "Baseline that always passes"
+- Assertion designed to pass with or without skill (non-discriminating)
+- Fix: Baseline should have a lower score; skill should improve it measurably
+
+**Pitfall 2**: "Token usage only metric"
+- Token improvement doesn't guarantee quality improvement
+- Fix: Always include quality metrics (assertions, manual evaluation)
+
+**Pitfall 3**: "Single test prompt"
+- One prompt may be lucky (skill happens to match well)
+- Fix: Test 2-3 diverse prompts to validate generalization
+
+**Pitfall 4**: "Ignoring model variance"
+- Same prompt with different models/temperatures gives different results
+- Fix: Keep model and constraints constant between with/baseline
+
+**Pitfall 5**: "Unbounded iteration"
+- Skill refinement never converges
+- Fix: Set max_iterations and stop when improvement < threshold
+
+---
+
+## Reporting
+
+For each skill iteration, document:
+
+```markdown
+## Iteration N Test Results
+
+### Test Prompts
+1. [Prompt A description]
+2. [Prompt B description]
+
+### Token Metrics
+| Prompt | With-Skill | Baseline | Improvement |
+|--------|-----------|----------|-------------|
+| A | 5,234 | 6,102 | +14.2% |
+| B | 3,891 | 4,012 | +2.9% |
+| **Average** | — | — | **+8.5%** |
+
+### Quality Metrics
+| Assertion | With-Skill | Baseline | Status |
+|-----------|-----------|----------|--------|
+| Output is valid code | 100% | 75% | ✅ PASS |
+| Includes all features | 100% | 50% | ✅ PASS |
+| Well-formatted | 100% | 60% | ✅ PASS |
+| **Average Score** | **100%** | **61.7%** | ✅ **+61.7%** |
+
+### Conclusion
+- Improvement target: ≥10% ✅ Met (8.5% token, +61.7% quality)
+- All assertions passing ✅
+- Ready for release
+```
+
+This methodology ensures skills provide measurable value before being marked complete.

--- a/internal/template/templates/.claude/rules/moai/development/skill-writing-craft.md
+++ b/internal/template/templates/.claude/rules/moai/development/skill-writing-craft.md
@@ -1,0 +1,347 @@
+---
+description: "Skill writing guidelines covering description craft, body structure, and schema"
+paths: ".claude/skills/**/SKILL.md"
+---
+
+<!-- Source: revfactory/harness — Apache License 2.0 — see .claude/rules/moai/NOTICE.md -->
+
+# Skill Writing Craft
+
+Guidelines for writing high-quality skills: description triggering, body structure, and schema validation.
+
+---
+
+## Part 1: Description Craft
+
+The description field is **read-only metadata** that Claude Code uses to decide whether to load your skill into context. It's not displayed to users.
+
+### Writing a Good Description
+
+**Purpose**: Summarize when the skill should trigger, in a single sentence. Optimize for Claude Code's context matcher.
+
+**Template**:
+```
+{Capability Summary}: {Domain Keywords} for {Use Case}
+```
+
+**Examples**:
+
+| Skill | Good Description | Why |
+|-------|------------------|-----|
+| moai-domain-frontend | "React 19 / Next.js 16 component development with modern patterns" | Clear domain (React/Next) + capability (components) + keywords |
+| moai-ref-testing-pyramid | "Test strategy and pyramid patterns for unit/integration/E2E coverage" | Clear domain (testing) + specific patterns + coverage levels |
+| moai-library-shadcn | "shadcn/ui component library for React with TypeScript integration" | Clear library name + framework + integration |
+
+**Bad Descriptions** (too vague, won't trigger):
+- "General programming help" (too broad)
+- "Code quality" (ambiguous — which kind?)
+- "Documentation tool" (doesn't specify what documentation)
+
+### When to Trigger vs When to Skip
+
+**The skill should trigger when the user is**:
+- Explicitly asking for the domain (e.g., "help with React hooks")
+- Working in the domain (e.g., modifying a `.tsx` file)
+- Referencing the specific capability (e.g., "create component library")
+
+**The skill should NOT trigger when**:
+- User is asking about a different domain (e.g., "help with Python" to a React skill)
+- The capability is handled by general knowledge (e.g., "basic syntax" for moai-library-shadcn)
+- The skill would duplicate general MoAI capabilities (e.g., moai-domain-backend shouldn't trigger for "debug this Go error")
+
+### Paths Frontmatter for Smart Triggering
+
+Use the `paths` field to control when your skill is auto-loaded by Claude Code:
+
+```yaml
+---
+description: "Skill description"
+paths: ".claude/skills/**/*.md,**/hooks/**/*.ts"
+---
+```
+
+**Path Patterns** (glob syntax):
+- `**/*.tsx` — Any TypeScript React file
+- `**/*_test.go` — Any Go test file
+- `.moai/config/**/*.yaml` — Configuration files
+- `src/api/**/*` — API directory
+
+**Strategy**:
+- Use `paths` for automatic domain detection
+- Use `description` as fallback for manual triggering
+- Combine: paths + description = high-precision triggering
+
+---
+
+## Part 2: Body Structure — Progressive Disclosure
+
+The skill body should follow a three-level progressive disclosure structure:
+
+### Level 1: Quick Reference (100-200 lines)
+
+**Contents**:
+- One-line summary
+- Key concepts (5-7 bullet points)
+- When to use this skill
+- Typical workflow (3-5 steps)
+- Links to deeper content
+
+**Token Cost**: ~1,500 tokens
+
+**Example Structure**:
+```markdown
+# Skill Name
+
+One-line summary: what this skill provides
+
+## Quick Concepts
+- Concept A: explanation
+- Concept B: explanation
+- Concept C: explanation
+
+## When to Use
+- Scenario 1
+- Scenario 2
+
+## Typical Workflow
+1. Step A
+2. Step B
+3. Step C
+
+## See Also
+- [Deep dive topic] — modules/topic.md
+- [Examples] — examples.md
+```
+
+### Level 2: Implementation Guide (500-1,500 lines)
+
+**Contents**:
+- Detailed workflows with code snippets
+- Real-world patterns
+- Integration examples
+- Configuration reference
+- Common patterns and their implementation
+
+**Token Cost**: ~3,000-5,000 tokens
+
+**Structure**:
+```markdown
+## Implementation Guide
+
+### Pattern 1: Name
+- Description
+- When to apply
+- Example code (pseudo-code or multi-language)
+- Integration with MoAI
+
+### Pattern 2: Name
+...
+
+### Configuration
+- Key settings
+- Defaults
+- Override mechanisms
+```
+
+### Level 3: Advanced & Reference (Unlimited)
+
+**Contents**:
+- Deep technical dives
+- Edge cases and workarounds
+- Performance optimization
+- Troubleshooting guides
+- Full API reference
+
+**Token Cost**: On-demand (user explicitly requests)
+
+**Structure**:
+```markdown
+## Advanced Topics
+
+### Topic 1: Name
+[Full technical treatment]
+
+### Topic 2: Name
+[Extended examples]
+
+## Reference
+- [External documentation]
+- [Related specs]
+- [Tool configuration]
+```
+
+### File Organization for Large Skills
+
+When body exceeds 500 lines, split into modules:
+
+```
+.claude/skills/my-skill/
+├── SKILL.md (Quick Reference + Implementation, ≤500 lines)
+├── modules/
+│   ├── advanced-patterns.md
+│   ├── troubleshooting.md
+│   └── reference.md
+├── examples.md
+└── reference.md
+```
+
+**Linking Between Levels**:
+- SKILL.md references → `See also: [Topic] — modules/topic.md`
+- Examples → `Examples: [Name] — examples.md#section`
+- External resources → `Reference: [Tool] — reference.md#api`
+
+---
+
+## Part 3: Frontmatter Schema
+
+Every skill MUST have complete frontmatter:
+
+```yaml
+---
+name: "Display Name of Skill"
+description: "One-line description for context matching"
+type: skill
+paths: "**/*.tsx,**/__tests__/**"
+domains: ["frontend", "testing"]
+model: "default"
+effort: "high"
+tools: ["WebSearch", "WebFetch", "Bash", "Read", "Write", "Edit", "Grep", "Glob"]
+allowed-tools: "WebSearch,WebFetch,Bash,Read,Write,Edit,Grep,Glob"
+---
+```
+
+### Field Reference
+
+| Field | Required | Type | Notes |
+|-------|----------|------|-------|
+| `name` | ✅ | string | Display name, 30-50 chars |
+| `description` | ✅ | string | Single sentence, ≤80 chars, context-matching optimized |
+| `type` | ✅ | string | Always `"skill"` |
+| `paths` | Optional | string | Glob pattern CSV (no YAML array) |
+| `domains` | Optional | array | Topic categories for organization |
+| `model` | Optional | string | `"default"`, `"opus"`, `"sonnet"` |
+| `effort` | Optional | string | `"low"`, `"medium"`, `"high"`, `"xhigh"` |
+| `tools` | Optional | array | Full tool array (if providing access) |
+| `allowed-tools` | Optional | string | CSV string of tool names |
+
+### Validation Rules
+
+**Rule 1: `paths` is CSV string, NOT YAML array**
+```yaml
+# WRONG
+paths:
+  - "**/*.tsx"
+  - "**/__tests__/**"
+
+# CORRECT
+paths: "**/*.tsx,**/__tests__/**"
+```
+
+**Rule 2: Single-sentence description**
+```yaml
+# WRONG
+description: "Frontend development. React and Next.js. Components and hooks."
+
+# CORRECT
+description: "React 19 and Next.js 16 component development with hooks"
+```
+
+**Rule 3: tool vs allowed-tools**
+```yaml
+# Use EITHER tools (array) OR allowed-tools (CSV string), not both
+
+# OPTION A: Array form
+tools:
+  - WebSearch
+  - Bash
+  - Read
+
+# OPTION B: CSV form
+allowed-tools: "WebSearch,Bash,Read"
+```
+
+**Rule 4: Accurate domains**
+```yaml
+domains: ["frontend", "testing"]  # Correct
+domains: ["frontend"]  # Missing testing even though skill covers both
+
+# Use domains that match skill content
+```
+
+### Common Frontmatter Patterns
+
+**API/CLI Reference Skill**:
+```yaml
+---
+name: "Tool Name Reference"
+description: "Tool Name CLI commands and API reference for common use cases"
+type: skill
+paths: "**/*.ts,**/*.py,README.md"
+domains: ["reference", "api"]
+effort: "low"
+allowed-tools: "WebFetch,Read,Grep"
+---
+```
+
+**Code Implementation Skill**:
+```yaml
+---
+name: "Framework Feature"
+description: "Framework Feature implementation patterns with examples"
+type: skill
+paths: "src/**/*.tsx,**/*_test.tsx"
+domains: ["framework", "implementation"]
+effort: "high"
+allowed-tools: "WebSearch,WebFetch,Bash,Read,Write,Edit,Grep,Glob"
+---
+```
+
+**Analysis/Research Skill**:
+```yaml
+---
+name: "Topic Analysis"
+description: "Topic Analysis and research methodology with patterns"
+type: skill
+paths: "docs/**,**/*.md,SPEC-*"
+domains: ["research", "analysis"]
+effort: "medium"
+allowed-tools: "WebSearch,WebFetch,Read,Grep"
+---
+```
+
+---
+
+## Schema Validation
+
+Before committing a skill, verify:
+
+- [ ] Frontmatter fields all present and valid
+- [ ] `name` matches actual skill capability
+- [ ] `description` is single sentence, ≤80 characters
+- [ ] `paths` is CSV string (not YAML array)
+- [ ] `domains` accurately reflect skill scope
+- [ ] `allowed-tools` matches actual tool usage in body
+- [ ] No tool used without being listed in frontmatter
+- [ ] Body follows progressive disclosure (Quick/Implementation/Advanced if >500 lines)
+- [ ] Cross-references in body match actual file paths
+- [ ] Examples are copy-paste ready with comments
+- [ ] External references are verified (URLs valid)
+
+---
+
+## Skill Quality Checklist
+
+**Before marking a skill complete**:
+
+- [ ] Description triggers correctly (tested with Claude Code)
+- [ ] Quick Reference is scannable (≤200 lines, clear structure)
+- [ ] Implementation examples are language-neutral (pseudo-code or multi-language)
+- [ ] No hardcoded framework/language bias
+- [ ] Advanced section covers edge cases
+- [ ] Examples run without modification (or clearly noted limitations)
+- [ ] All external links verified and current
+- [ ] Frontmatter complete and valid
+- [ ] Domains reflect actual coverage
+- [ ] No duplicate content with other skills
+
+This craft guide ensures skills are discoverable, usable, and maintainable.

--- a/internal/template/templates/.claude/rules/moai/quality/boundary-verification.md
+++ b/internal/template/templates/.claude/rules/moai/quality/boundary-verification.md
@@ -1,0 +1,209 @@
+---
+description: "Boundary verification methodology for detecting integration defects"
+paths: "**/*_test.go,**/*test*.py,**/*test*.ts,**/*test*.rs,**/test/**,**/tests/**"
+---
+
+<!-- Source: revfactory/harness — Apache License 2.0 — see .claude/rules/moai/NOTICE.md -->
+
+# Boundary Verification
+
+Systematic methodology for detecting defects at component boundaries. These defects are missed by individual component testing but manifest when components interact.
+
+## Overview
+
+**Core Problem**: Individual components test correctly, but integration fails at boundaries. TypeScript generics, type casting, and absent cross-validation create boundary defects that unit tests cannot catch.
+
+**Key Principle**: "Boundary bugs are not found by testing each side alone. Both sides must be read together."
+
+---
+
+## Case Studies
+
+### Case 1: API Response Schema Mismatch
+
+**Symptom**: API returns correct data structure, frontend hook receives it, but runtime fails because the shape doesn't match type expectation.
+
+**Example**: 
+- Backend API returns: `{ projects: [{ id, name }] }`
+- Frontend hook expects generic type parameter: `SlideProject[]`
+- TypeScript compilation passes (generic casting hides mismatch)
+- Runtime error: `Cannot read property 'name' of undefined`
+
+**Root Cause**: API and hook typed independently without cross-validation. Generic type parameters bypass compile-time checking.
+
+**Boundary Condition to Test**:
+- Actual API response must be unwrapped if wrapped in outer object
+- Field names (camelCase vs snake_case) must match
+- Required vs optional fields must align
+
+**Verification Strategy**:
+1. Locate API route and extract `NextResponse.json()` payload structure
+2. Locate corresponding frontend hook and extract generic type `T`
+3. Trace payload from source through any transformation
+4. Verify hook calls `.json<T>()` with correct extraction (e.g., `response.projects` if API wraps)
+5. Create test: invoke both simultaneously, capture actual response and expected type
+
+---
+
+### Case 2: File Path to Router Mismatch
+
+**Symptom**: Link leads to non-existent URL, or router redirects fail silently.
+
+**Example**:
+- Page exists at: `src/app/dashboard/create/page.tsx` → URL `/dashboard/create`
+- Link href specified as: `/create` (missing `/dashboard` prefix)
+- Browser navigates to `/create`, which doesn't exist
+
+**Root Cause**: File structure and link paths not cross-validated. Route groups and dynamic segments add complexity.
+
+**Boundary Condition to Test**:
+- All `href`, `router.push()`, `redirect()` values must map to actual page files
+- Route group parentheses `(group)` must be excluded from URL path
+- Dynamic segments `[id]` must be recognized as variable segments
+
+**Verification Strategy**:
+1. Extract all page files from `src/app/` and construct their URL paths
+2. Extract all navigation calls (`href=`, `router.push(`, `redirect(`)
+3. Verify each reference maps to an actual page URL
+4. Test: click each link in real browser (Playwright/E2E), verify page loads
+
+---
+
+### Case 3: State Transition Incompleteness
+
+**Symptom**: State transitions defined in spec but not fully implemented; intermediate states become dead ends.
+
+**Example**:
+- State transition map allows: `generating_template` → `template_approved`
+- Implementation updates status to `generating_template` but never transitions to `template_approved`
+- Component stuck in `generating_template` state indefinitely
+
+**Root Cause**: State map and state update code not cross-validated. All transitions must have corresponding implementation.
+
+**Boundary Condition to Test**:
+- Every transition in the state map must have code that executes it
+- No "dead" transitions (defined but unreachable)
+- All intermediate states must have exit paths
+
+**Verification Strategy**:
+1. Extract state machine definition (transition map or state type)
+2. Grep all code for `.update({ status: ... })` or equivalent state changes
+3. Verify every allowed transition has an implementation
+4. Verify every implemented transition is in the state map (no rogue transitions)
+5. Test: trace state changes for each workflow, verify all transitions execute
+
+---
+
+### Case 4: Field Name Mismatch (camelCase ↔ snake_case)
+
+**Symptom**: Field names differ between database (snake_case), API (camelCase), and frontend types (camelCase). One layer doesn't translate correctly.
+
+**Example**:
+- DB column: `thumbnail_url`
+- API response: `{ thumbnailUrl: "..." }`
+- Frontend type: `interface SlideProject { thumbnail_url: string }`
+- Actual data: `obj.thumbnailUrl` exists but type expects `obj.thumbnail_url`
+
+**Root Cause**: Automatic transformation skipped in one layer. No validation of field name consistency across layers.
+
+**Boundary Condition to Test**:
+- Field name transforms must be applied consistently
+- API response must be serialized to frontend type correctly
+- TypeScript `Pick` or destructuring must use correct names
+
+**Verification Strategy**:
+1. Document field naming convention per layer (DB, API, frontend)
+2. Trace field through transformation: DB → API response → TS type
+3. Verify transformation applied at each boundary
+4. Create assertion: sample API response must serialize to frontend type without field errors
+5. Test: `Object.keys(apiResponse) ===  Object.keys(frontendType)` after transformation
+
+---
+
+### Case 5: Missing API Endpoint Implementation
+
+**Symptom**: Frontend calls API endpoint that is called but never executed (missing implementation or wrong route).
+
+**Example**:
+- Frontend hook calls `POST /api/projects/123/approve`
+- API route `src/app/api/projects/[id]/approve/route.ts` not found
+- Request returns 404, but frontend silently handles error
+
+**Root Cause**: API defined in documentation but not implemented. Frontend assumes availability.
+
+**Boundary Condition to Test**:
+- Every frontend fetch must have a corresponding API route
+- Route signature must match (HTTP method, path parameters)
+- API must handle the request (not just exist as an empty file)
+
+**Verification Strategy**:
+1. Extract all frontend `fetch()` calls with URLs
+2. Extract all API routes from `src/app/api/**`
+3. Verify 1:1 correspondence
+4. For each unimplemented endpoint: mark as "intentional stub" or implement
+5. Test: E2E flow that exercises each endpoint
+
+---
+
+### Case 6: Async Response Shape Inconsistency
+
+**Symptom**: API returns shape for immediate response (`202 Accepted`) but frontend expects final result shape. Polling or websocket updates with different shape cause runtime error.
+
+**Example**:
+- Initial response: `{ status: "processing", taskId: 123 }`
+- Final result (via webhook): `{ status: "complete", data: [...], errors: [...] }`
+- Frontend type union doesn't account for both shapes
+- Code accesses `.data` on initial response, crashes
+
+**Root Cause**: Async workflows have multiple response shapes. Type definitions cover only one shape.
+
+**Boundary Condition to Test**:
+- Initial response shape must be typed separately from final shape
+- Frontend code must handle both shapes
+- State machine must track which shape is current
+
+**Verification Strategy**:
+1. Identify async workflows (202 responses, polling, webhooks)
+2. Document all possible response shapes at each stage
+3. Create union type covering all shapes: `InitialResponse | FinalResponse`
+4. Verify code uses discriminator field (`status`) to handle each shape
+5. Test: invoke async endpoint, verify response at each stage matches expected shape
+
+---
+
+### Case 7: TypeScript Generic Casting Bypass
+
+**Symptom**: Generic casting (`as T`, `as unknown as T`) bypasses type safety. Mismatch exists but compilation succeeds.
+
+**Example**:
+- API type: `interface ApiResponse { projects: Project[] }`
+- Frontend code: `const data = await fetchJson<SlideProject[]>(url)`
+- No intermediate unwrapping: `response.projects` forgotten
+- Type works but runtime data is `{ projects: [...] }` not `SlideProject[]`
+
+**Root Cause**: Generic type parameters are not validated at the boundaries. Cast operations bypass static checks.
+
+**Boundary Condition to Test**:
+- Generic types must match actual runtime data shape
+- Type casting (especially `as any` or unconstrained `as T`) must be verified
+- No use of generic type parameters without explicit data transformation
+
+**Verification Strategy**:
+1. Audit all `fetchJson<T>` calls and verify `T` matches actual API response shape
+2. Grep for unsafe casts: `as any`, `as unknown`, unconstrained generic `as T`
+3. For each cast, document why it's safe and verify with integration test
+4. Disable TypeScript implicit `any` in `tsconfig.json`
+5. Test: runtime data must deserialize to type without casting
+
+---
+
+## Verification Strategy Summary
+
+1. **Extract Boundaries**: Identify component interaction points (API ↔ Frontend, DB ↔ API, State ↔ Code)
+2. **Cross-Read**: Read both sides of each boundary simultaneously
+3. **Trace Data**: Follow data transformation from source to consumer
+4. **Verify Contracts**: Ensure implicit contracts (naming, shape, transitions) are honored
+5. **Test Integration**: Unit tests don't catch boundary bugs; integration/E2E tests required
+6. **Document Assumptions**: Explicitly state assumptions about field names, response shapes, state transitions
+
+**Golden Rule**: If a boundary can fail, the test must exercise both sides of the boundary.

--- a/internal/template/templates/.claude/rules/moai/workflow/team-pattern-cookbook.md
+++ b/internal/template/templates/.claude/rules/moai/workflow/team-pattern-cookbook.md
@@ -1,0 +1,312 @@
+---
+description: "Five team execution patterns with role profiles and communication protocols"
+paths: ".moai/config/sections/workflow.yaml,.claude/rules/moai/workflow/team-protocol.md"
+---
+
+<!-- Source: revfactory/harness — Apache License 2.0 — see .claude/rules/moai/NOTICE.md -->
+
+# Team Pattern Cookbook
+
+Five proven patterns for orchestrating Agent Teams in MoAI-ADK, with role compositions, file ownership, and communication protocols.
+
+---
+
+## Research Team
+
+**Purpose**: Parallel exploration of a topic from multiple angles, with cross-team learning and synthesis.
+
+**Composition**:
+- Research Analyst A: Technical deep dive
+- Research Analyst B: Community/user perspective
+- Analyst C: Market/competitive analysis
+
+**File Ownership**:
+- research-deep-dive.md — Analyst A (technical research)
+- research-community.md — Analyst B (user/community insights)
+- research-market.md — Analyst C (market competitive landscape)
+- research-synthesis.md — Team Lead (combines all perspectives)
+
+**Communication Protocol**:
+1. Each analyst runs independently on their angle
+2. Analysts share findings via SendMessage when insights contradict or amplify
+3. Team Lead synthesizes into unified research.md
+4. On conflict: present both perspectives with evidence, let user decide
+
+**When Discovery Helps**:
+- Large research topics where single perspective misses nuance
+- Competing claims in sources (user research vs product goals)
+- Need to quickly validate from multiple angles before committing to architecture
+
+**When Solo Agent Better**:
+- Research is straightforward (single source, clear answer)
+- Team coordination overhead > quality gain
+
+**Example Coordination**:
+```
+Analyst A: "Current framework adoption is X%"
+Analyst B: "But users in forums complain about X's learning curve"
+Analyst C: "Competitors using X report Y% migration cost"
+Team Lead: "Synthesize these into: X is popular but has adoption risk, competitors mitigating via Z"
+```
+
+**Shutdown Sequence**:
+1. All analysts TaskUpdate their findings as "complete"
+2. Team Lead assembles synthesis.md
+3. Team Lead sends synthesis to user
+4. Team sends shutdown_request approval to leader
+5. Leader runs TeamDelete
+
+---
+
+## Implementation Team
+
+**Purpose**: Parallel development of independent modules with file-level ownership to prevent conflicts.
+
+**Composition**:
+- Backend Developer: API endpoints, database, business logic
+- Frontend Developer: UI components, client-side logic, hooks
+- Test Specialist: Unit + integration tests, coverage
+
+**File Ownership**:
+- `src/api/**/*.go` (or equivalent backend) — Backend Dev
+- `src/components/**/*.tsx`, `src/hooks/**/*.ts` — Frontend Dev
+- `**/*_test.go`, `**/__tests__/**` — Test Specialist (read-only, but owns test files)
+
+**Communication Protocol**:
+1. Backend Dev creates API contract document (types, endpoints)
+2. Frontend Dev reads contract, creates matching hooks and components
+3. Test Specialist writes tests for both layers
+4. Boundary issues escalate via SendMessage (e.g., "API response shape doesn't match hook expectation")
+5. Backend Dev and Frontend Dev synchronize via SendMessage, then re-implement
+
+**When Team Works**:
+- Clear file boundaries (backend/frontend separation)
+- API contract can be defined upfront
+- Parallel development saves time over sequential
+
+**When Sequential Better**:
+- API contract is ambiguous or evolving
+- Heavy backend-frontend coupling
+- Files are tightly interdependent (can't work in parallel)
+
+**Example Workflow**:
+```
+Day 1:
+  - Backend: Define API schema + endpoints
+  - Frontend: Read schema, start building hooks
+  - Tests: Write integration tests against API contract
+
+Day 2:
+  - Backend: Implement API
+  - Frontend: Implement UI with hooks
+  - Tests: Run tests, report boundary issues
+
+Day 3:
+  - Backend + Frontend: Sync on boundary defects, iterate
+  - Tests: Verify fixes
+```
+
+**Shutdown Sequence**:
+1. Backend Dev marks implementation complete
+2. Frontend Dev marks implementation complete
+3. Test Specialist verifies all tests green, marks complete
+4. Team shuts down after all members idle/complete
+
+---
+
+## Review Team
+
+**Purpose**: Parallel code review from multiple perspectives (security, performance, architecture).
+
+**Composition**:
+- Security Reviewer: Auth, input validation, OWASP
+- Performance Reviewer: Algorithms, caching, bottlenecks
+- Architecture Reviewer: Design patterns, modularity, scalability
+
+**File Ownership**:
+- All read-only (mode: plan)
+- Each reviewer focuses on their dimension
+
+**Communication Protocol**:
+1. All reviewers read full changeset independently
+2. Each creates review report in their dimension
+3. Reviewers find conflicting opinions via SendMessage (e.g., "Architecture recommends caching, Performance says caching adds complexity here")
+4. Discuss and reach consensus on each conflict
+5. Single unified review output
+
+**When Parallel Review Helps**:
+- Large changes affecting multiple dimensions
+- Security and performance often have tradeoffs (need expert negotiation)
+- Parallel review faster than sequential
+
+**When Single Reviewer Better**:
+- Small, focused change (one dimension)
+- Reviewer specialization not clear-cut
+
+**Example Conflict Resolution**:
+```
+Sec Reviewer: "Add input validation before query"
+Perf Reviewer: "Validation adds latency, query sanitization sufficient"
+Arch Reviewer: "Input validation should be middleware, separate concern"
+Consensus: Input validation in middleware (architecture clean, performance acceptable, security strengthened)
+```
+
+**Shutdown Sequence**:
+1. All reviewers complete review reports
+2. Team Lead synthesizes into single PR feedback
+3. Team applies feedback or marks as "reviewed with concerns"
+4. TeamDelete
+
+---
+
+## Design Team
+
+**Purpose**: Collaborative design exploration with design, user experience, and stakeholder perspectives.
+
+**Composition**:
+- Visual Designer: UI/visual language, component design
+- UX Designer: User flow, interaction patterns, accessibility
+- Product Lead: Stakeholder requirements, business goals alignment
+
+**File Ownership**:
+- `design-visual.md` — Visual Designer (color, typography, component spec)
+- `design-ux.md` — UX Designer (flows, interactions, accessibility)
+- `design-product.md` — Product Lead (requirements, success metrics)
+
+**Communication Protocol**:
+1. All start with the same design brief
+2. Visual Designer proposes component system
+3. UX Designer reviews flows against components
+4. Product Lead validates against business goals
+5. Conflicts resolved via SendMessage + negotiation
+6. Iterate until all three approve
+
+**When Collaborative Design Helps**:
+- Complex user flows requiring visual + interaction + product alignment
+- Stakeholder conflict needs real-time discussion
+- Design iterations benefit from multiple perspectives
+
+**When Solo Designer Better**:
+- Simple UI updates (button style, color tweak)
+- Designer has full context and authority
+
+**Example Iteration**:
+```
+Visual: "Dark mode with minimalist components"
+UX: "Dark mode affects contrast for accessibility, reconsider"
+Product: "Accessibility is requirement, let's support both modes"
+Visual: "Update spec: light + dark modes, WCAG AAA contrast"
+UX: "Flows work with both modes, approved"
+Product: "Meets requirements, approved"
+```
+
+**Shutdown Sequence**:
+1. All three approve design
+2. Team produces final design.md with visual, UX, and product sections
+3. TeamDelete
+
+---
+
+## Debug Team
+
+**Purpose**: Parallel investigation of a complex bug from multiple angles.
+
+**Composition**:
+- Reproducer: Isolates and documents the bug with test case
+- Analyzer: Traces code paths to identify likely root causes
+- Verifier: Tests hypotheses and validates fixes
+
+**File Ownership**:
+- `bug-reproduction.md` + `test_repro.go` — Reproducer
+- `bug-analysis.md` — Analyzer
+- `bug-verification.md` + test runs — Verifier
+
+**Communication Protocol**:
+1. Reproducer creates minimal test case that fails
+2. Analyzer reads test and code, identifies likely causes
+3. Verifier runs hypothesis tests (e.g., "What if we change X?")
+4. Analyzer synthesizes hypotheses into ranked list: most likely → least likely
+5. Team tests ranked list systematically
+6. First successful hypothesis is root cause
+
+**When Parallel Debug Helps**:
+- Complex bug with multiple possible causes
+- Reproducing bug requires specialist skills
+- Multiple hypotheses to test (can test in parallel)
+
+**When Single Debugger Better**:
+- Bug is simple (obvious from symptom)
+- Reproducing requires deep system context
+
+**Example Investigation**:
+```
+Reproducer: "GET /api/users returns 500 on parameter X=Y"
+Analyzer: "Could be: (1) type mismatch, (2) DB error, (3) missing handler"
+Verifier: Tests (1) with different X types → not the issue
+Verifier: Tests (2) with DB connection check → found it: DB timeout
+Fix: Increase timeout, verify test passes
+```
+
+**Shutdown Sequence**:
+1. Root cause identified and documented
+2. Fix implemented and tested
+3. Verifier confirms bug no longer reproduces
+4. TeamDelete
+
+---
+
+## Pattern Selection Decision Tree
+
+```
+What is the team task?
+├── Parallel research/exploration → Research Team
+├── Feature implementation (backend + frontend + tests) → Implementation Team
+├── Multi-dimension code review (security + perf + arch) → Review Team
+├── Collaborative design with stakeholder input → Design Team
+├── Complex bug investigation with multiple hypotheses → Debug Team
+└── Other → Assess whether clear file boundaries + communication model exists
+           If yes, adapt a pattern; if no, use sequential sub-agents
+```
+
+---
+
+## Shutdown Protocol (All Teams)
+
+All teams follow this sequence:
+
+1. **Members Complete Work**: Each teammate TaskUpdates their tasks as complete
+2. **Idle Status**: Teammates go idle, waiting for coordination
+3. **Lead Initiates Shutdown**: Team Lead sends `shutdown_request` with request_id
+4. **Members Approve/Reject**: Each teammate responds with `shutdown_response { request_id, approve }`
+5. **Final Sync**: Lead synthesizes outputs into final artifact
+6. **TeamDelete**: Leader calls TeamDelete to clean up team
+
+If a teammate rejects shutdown (still working), Lead can:
+- Extend deadline (send message, wait for completion)
+- Collect partial output and proceed (accept incomplete work)
+- Escalate to user (team is stuck)
+
+---
+
+## Communication Guidelines
+
+**Via SendMessage**:
+- Share findings when they contradict other team members
+- Escalate conflicts that need resolution
+- Coordinate on interdependent work
+- Ask clarifying questions about other member's approach
+
+**Via TaskUpdate**:
+- Mark work as complete or blocked
+- Provide brief status (no long messages — use file artifacts)
+
+**When to NOT Communicate**:
+- Individual analysis that doesn't affect other team members (work independently)
+- Status that doesn't block anyone (save for final report)
+
+**Frequency**:
+- First day: High communication (establish coordination)
+- Middle days: Medium (share discoveries that affect others)
+- Final day: High (synthesis and shutdown)
+
+This cookbook provides practical patterns for the most common team scenarios in MoAI-ADK.

--- a/internal/template/templates/.claude/settings.json.tmpl
+++ b/internal/template/templates/.claude/settings.json.tmpl
@@ -74,7 +74,8 @@
             "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-post-tool.sh\"",
 {{- end}}
             "timeout": 10,
-            "type": "command"
+            "type": "command",
+            "async": true
           }
         ],
         "matcher": "Write|Edit"

--- a/internal/template/templates/.claude/settings.json.tmpl
+++ b/internal/template/templates/.claude/settings.json.tmpl
@@ -73,7 +73,7 @@
 {{- else}}
             "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-post-tool.sh\"",
 {{- end}}
-            "timeout": 60,
+            "timeout": 10,
             "type": "command"
           }
         ],


### PR DESCRIPTION
## Summary

v2.16.0 통합 minor 릴리스 — 세 갈래 작업을 단일 release PR로 묶음 (사용자 결정 2026-04-26):

1. **V3R3 Phase B — Pattern Cookbook** (NEW) — SPEC-V3R3-PATTERNS-001
   revfactory/harness Apache 2.0 6 reference docs를 `.claude/rules/moai/`로 흡수.
2. **V3R2 Backup Restore** (이미 머지됨, b47101779/f099b8c4e):
   - SPEC-WF-AUDIT-GATE-001 — `/moai run` Phase 0.5 Plan Audit Gate (mandatory, 7d grace)
   - SPEC-V3R2-CON-001 — FROZEN/EVOLVABLE Zone Registry + `moai constitution` CLI
   - SPEC-V3R2-EXT-001 — Typed Memory Taxonomy 4-type enforcement
3. **V3R3 Phase A — Foundation Hardening** (v2.15.0에서 이월):
   - DEF-007, DEF-001, ARCH-003, ARCH-007, COV-001, CMD-CLEANUP-001

v2.15.0은 system.yaml + CHANGELOG에 준비됐으나 tag되지 않은 상태 → 모든 누적 콘텐츠를 v2.16.0으로 통합. v2.15.0 CHANGELOG 섹션은 historical artifact로 보존.

상세 release notes: `.moai/release/RELEASE-NOTES-v2.16.0.md`

## Changes

| Category | Highlights |
|----------|-----------|
| **NEW (Phase B)** | 6 cookbook rule files + NOTICE.md, frontmatter `paths` CSV, Apache 2.0 attribution, 16-language neutral |
| **V3R2 Restore** | Plan Audit Gate (Phase 0.5 mandatory), Zone Registry (68 entries: 38F+30E), Memory Taxonomy (4-type) |
| **Phase A (BC)** | 7 expert agents `Agent` tool, expert-debug/perf Write/Edit, Token Circuit Breaker (runtime.yaml), Mobile coverage (4-strategy), `/moai gate` 추가 |

### Commits (3, merge-commit 권장)

- `48dca1508` — docs(spec): SPEC-V3R3-PATTERNS-001 4 artifacts
- `8cf746685` — feat(rules): import revfactory/harness 6 cookbooks (Apache 2.0)
- `05a5ffdc3` — docs(release): v2.16.0 release prep (CHANGELOG + system.yaml + RELEASE-NOTES)

## Test plan

- [x] `make build` — green (go:embed 정상)
- [x] `go test ./internal/template/...` — PASS
- [x] AC verification (PATTERNS-001 5/5):
  - [x] AC-001: 6 patterns + MoAI vocabulary keywords (Team/Sub-agent/Hybrid/Orchestrator/Specialist/Pipeline)
  - [x] AC-002: 7 ### Case headings in boundary-verification.md
  - [x] AC-003: 3 orchestrator templates + 5 team headers
  - [x] AC-004: skill-writing-craft 3 areas
  - [x] AC-005: Apache attribution + Template-First mirror (7/7 byte-identical)
- [x] 16-language neutrality grep audit clean
- [x] V3R2 restore content (이미 머지된 것) 회귀 없음
- [ ] **CI 결과 확인 후 admin merge** (사용자 manual review)
- [ ] Merge 완료 후 `git tag v2.16.0 && git push origin v2.16.0` (GoReleaser 자동 release)

## Merge Strategy

**Merge commit** (per CLAUDE.md §18.3 release branch convention).
Squash 사용하지 마세요 — 3개 atomic commits (SPEC / impl / release prep) 보존 필요.

```bash
gh pr merge <N> --merge --delete-branch
```

## License Compliance

- revfactory/harness Apache License 2.0 → MoAI-ADK MIT 호환 (NOTICE 보존 시)
- `.claude/rules/moai/NOTICE.md` 산출 — attribution + source list + import date 2026-04-26

🗿 MoAI <email@mo.ai.kr>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive pattern documentation for agent orchestration, skill development, and quality assurance workflows.
  * Introduced team coordination cookbook with multiple operating patterns and decision guidance.

* **Improvements**
  * Enhanced hook performance: PostToolUse timeout reduced with asynchronous execution enabled.

* **Documentation**
  * Added methodology guides for skill testing, boundary verification, and hook configuration.
  * Updated version to v2.16.0 with Apache 2.0 third-party attribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->