### PR TITLE
fix(design-folder): SPEC-V3R3-DESIGN-FOLDER-FIX-001 — reserved collision update path warning 격하

### DIFF
--- a/.claude/rules/moai/design/constitution.md
+++ b/.claude/rules/moai/design/constitution.md
@@ -2,6 +2,7 @@
 
 ## HISTORY
 
+- 2026-04-26 (SPEC-V3R3-DESIGN-FOLDER-FIX-001): §3.2 footnote 추가 — Reserved name violation은 `moai update` (update path)에서 warning + skip, `moai init` (scaffold path)에서 hard error. v3.3.0 → 3.3.1.
 - 2026-04-20 (SPEC-DESIGN-CONST-AMEND-001): Section 3 expanded to tripartite structure (3.1/3.2/3.3). Version 3.2.0 → 3.3.0 (v3.3.0). FROZEN zone extended to cover each subsection individually.
 - 2026-04-20: Relocated from `.claude/rules/agency/constitution.md` (v3.2.0) to `.claude/rules/moai/design/constitution.md` as part of SPEC-AGENCY-ABSORB-001 M1. Original path: `.claude/rules/agency/constitution.md`. No content changes. FROZEN zone and EVOLVABLE zone definitions are preserved verbatim.
 
@@ -76,6 +77,8 @@ Iteration-specific design briefs are stored in `.moai/design/`:
 - [HARD] Reserved file paths (canonical list): `tokens.json`, `components.json`, `assets/`, `import-warnings.json`, `brief/BRIEF-*.md`
 - [HARD] Token budget for auto-loading is bounded by `.moai/config/sections/design.yaml` `design_docs.token_budget`; when the key is absent, the system MUST default to 20000
 - [HARD] Priority order when truncation is needed: spec.md > system.md > research.md > pencil-plan.md
+
+> **Note (SPEC-V3R3-DESIGN-FOLDER-FIX-001):** Reserved name violations during `moai update` (update path) are reported as warnings; the user file is preserved and other templates continue to sync. During `moai init` / scaffold path, reserved name collisions remain hard errors. User data is never modified or deleted in either case.
 
 ### 3.3 Relationship
 
@@ -396,9 +399,9 @@ If a graduated learning causes regression:
 
 ---
 
-Version: 3.3.0
+Version: 3.3.1
 Classification: FROZEN_AMENDMENT
 Original Source: agency/constitution.md v3.2.0
-Last Updated: 2026-04-20
+Last Updated: 2026-04-26
 Relocated: 2026-04-20 (SPEC-AGENCY-ABSORB-001 M1)
 REQ coverage: REQ-CONST-001, REQ-CONST-002, REQ-CONST-003, REQ-CONST-004

--- a/.moai/specs/SPEC-V3R3-DESIGN-FOLDER-FIX-001/acceptance.md
+++ b/.moai/specs/SPEC-V3R3-DESIGN-FOLDER-FIX-001/acceptance.md
@@ -1,0 +1,406 @@
+# SPEC-V3R3-DESIGN-FOLDER-FIX-001 — Acceptance Criteria
+
+## HISTORY
+
+| Version | Date       | Author       | Description |
+|---------|------------|--------------|-------------|
+| 0.1.0   | 2026-04-26 | manager-spec | Initial acceptance criteria. 6 ACs covering update path warning, scaffold strict mode, message content, file preservation. |
+
+---
+
+## 1. Acceptance Criteria Overview
+
+| AC ID    | REQ Coverage                                  | Priority | Test File / Method |
+|----------|------------------------------------------------|----------|---------------------|
+| AC-DFF-01 | REQ-DFF-001, REQ-DFF-002, REQ-DFF-004         | P0       | `TestDesignFolderUpdate_ReservedExact_WarnsButContinues` |
+| AC-DFF-02 | REQ-DFF-001, REQ-DFF-002                      | P0       | `TestDesignFolderUpdate_ReservedGlob_WarnsButContinues` |
+| AC-DFF-03 | REQ-DFF-003, REQ-DFF-008                      | P0       | `TestDesignFolderScaffold_ReservedExact_StillErrors` |
+| AC-DFF-04 | REQ-DFF-005, REQ-DFF-007                      | P1       | `TestDesignFolderUpdate_WarningIncludesGuidance` |
+| AC-DFF-05 | REQ-DFF-006, REQ-DFF-004                      | P0       | `TestDesignFolderUpdate_ReservedNotModified` (강화) |
+| AC-DFF-06 | REQ-DFF-001, REQ-DFF-002                      | P1       | `TestDesignFolderUpdate_MultipleReservedConflicts` |
+
+---
+
+## 2. AC-DFF-01 — Update Path Reserved Exact Warns But Continues
+
+### 2.1 REQ Coverage
+REQ-DFF-001 (Update path warning), REQ-DFF-002 (Other files sync continuation), REQ-DFF-004 (User file preservation)
+
+### 2.2 Given-When-Then
+
+**Given**:
+- `root` 임시 디렉터리에 `.moai/design/` 생성됨
+- `scaffoldDesignDir(root, &warnBuf)`로 templates 정상 deploy됨 (README.md, research.md, system.md, spec.md)
+- 사용자가 `.moai/design/tokens.json`을 내용 `{"primary": "#ff0000"}`로 작성
+- 사용자가 `.moai/design/README.md`를 수정하여 user-edit 마커 추가
+
+**When**:
+- `updateDesignDir(root, &errBuf)` 호출
+
+**Then**:
+- 함수 반환값: `nil` (error 없음)
+- `errBuf`에 "warning" 키워드 포함
+- `errBuf`에 "tokens.json" 키워드 포함
+- `errBuf`에 "preserved" 또는 동등 보존 안내 키워드 포함
+- `.moai/design/tokens.json` 내용 변경 없음 (`{"primary": "#ff0000"}`)
+- `.moai/design/README.md` user-edit 보존됨 (REQ-005 user-edit preservation 정상 동작)
+- `.moai/design/research.md`, `system.md`, `spec.md`는 canonical hash 일치 시 정상 update (또는 user-modified면 보존)
+
+### 2.3 Test Method
+
+```go
+func TestDesignFolderUpdate_ReservedExact_WarnsButContinues(t *testing.T) {
+    t.Parallel()
+    root := t.TempDir()
+    designDir := filepath.Join(root, ".moai", "design")
+    // ... scaffold + create tokens.json + modify README ...
+    var errBuf strings.Builder
+    err := updateDesignDir(root, &errBuf)
+    if err != nil { t.Fatalf("expected nil, got %v", err) }
+    // assert errBuf contains "warning" + "tokens.json" + "preserved"
+    // assert tokens.json unchanged
+    // assert README.md user edit preserved
+}
+```
+
+### 2.4 Pass Criteria
+
+- [ ] 모든 7개 assertion pass
+- [ ] race detection 통과
+- [ ] golangci-lint clean
+
+---
+
+## 3. AC-DFF-02 — Update Path Reserved Glob Warns But Continues
+
+### 3.1 REQ Coverage
+REQ-DFF-001, REQ-DFF-002
+
+### 3.2 Given-When-Then
+
+**Given**:
+- `.moai/design/` scaffold 완료됨
+- `.moai/design/brief/BRIEF-LOCAL.md` 사용자 작성 (내용 "local design brief notes")
+
+**When**:
+- `updateDesignDir(root, &errBuf)` 호출
+
+**Then**:
+- 반환값 `nil`
+- `errBuf`에 "warning" + "BRIEF" + "preserved" 포함
+- `BRIEF-LOCAL.md` 내용 변경 없음
+- 다른 templates (README/research/system/spec) sync 정상 진행
+
+### 3.3 Test Method
+
+```go
+func TestDesignFolderUpdate_ReservedGlob_WarnsButContinues(t *testing.T) {
+    t.Parallel()
+    // ... scaffold + create brief/BRIEF-LOCAL.md ...
+    var errBuf strings.Builder
+    err := updateDesignDir(root, &errBuf)
+    if err != nil { t.Fatalf("expected nil, got %v", err) }
+    // assert warning content + file preservation
+}
+```
+
+### 3.4 Pass Criteria
+
+- [ ] 5개 assertion pass
+
+---
+
+## 4. AC-DFF-03 — Scaffold Path Reserved Still Errors
+
+### 4.1 REQ Coverage
+REQ-DFF-003 (Scaffold path strict mode), REQ-DFF-008 (Path mode dispatch)
+
+### 4.2 Given-When-Then
+
+**Given**:
+- `.moai/design/tokens.json` 사용자 작성 (이론적 신규 프로젝트 케이스)
+- 다른 design files 없음 또는 일부 존재
+
+**When**:
+- `checkReservedCollision(root, &errBuf, true)` 직접 호출 (scaffold strict mode 시뮬레이션)
+
+**Then**:
+- 반환값: error (non-nil)
+- error 메시지에 "reserved filename" + "tokens.json" 포함
+- `errBuf`에 "error: reserved filename: tokens.json" 포함 (warning이 아닌 error 키워드)
+- tokens.json 내용 변경 없음 (REQ-DFF-004 always honored)
+
+### 4.3 Test Method
+
+```go
+func TestDesignFolderScaffold_ReservedExact_StillErrors(t *testing.T) {
+    t.Parallel()
+    root := t.TempDir()
+    designDir := filepath.Join(root, ".moai", "design")
+    os.MkdirAll(designDir, 0o755)
+    os.WriteFile(filepath.Join(designDir, "tokens.json"), []byte(`{"x":1}`), 0o644)
+
+    var errBuf strings.Builder
+    err := checkReservedCollision(root, &errBuf, true) // strict=true
+    if err == nil { t.Fatal("expected error in strict mode") }
+    if !strings.Contains(err.Error(), "reserved filename") {
+        t.Errorf("error must mention reserved filename, got %v", err)
+    }
+    // assert tokens.json unchanged
+}
+```
+
+### 4.4 Pass Criteria
+
+- [ ] 4개 assertion pass
+- [ ] strict mode와 update mode 분리 검증
+
+---
+
+## 5. AC-DFF-04 — Warning Includes Guidance
+
+### 5.1 REQ Coverage
+REQ-DFF-005 (Warning guidance), REQ-DFF-007 (No silent failure)
+
+### 5.2 Given-When-Then
+
+**Given**:
+- `.moai/design/components.json` 사용자 작성
+
+**When**:
+- `updateDesignDir(root, &errBuf)` 호출
+
+**Then**:
+- `errBuf`에 다음 모두 포함:
+  - "warning" 키워드 (silent failure 방지, REQ-DFF-007)
+  - 파일 경로 ("components.json")
+  - "preserved" 또는 보존 안내 키워드
+  - 우회 절차 힌트 ("rename" 또는 "canonical templates" 키워드)
+
+### 5.3 Test Method
+
+```go
+func TestDesignFolderUpdate_WarningIncludesGuidance(t *testing.T) {
+    t.Parallel()
+    root := t.TempDir()
+    designDir := filepath.Join(root, ".moai", "design")
+    os.MkdirAll(designDir, 0o755)
+    os.WriteFile(filepath.Join(designDir, "components.json"), []byte("{}"), 0o644)
+
+    var errBuf strings.Builder
+    err := updateDesignDir(root, &errBuf)
+    if err != nil { t.Fatalf("unexpected error: %v", err) }
+
+    msg := errBuf.String()
+    requiredKeywords := []string{"warning", "components.json", "preserved", "rename"}
+    for _, kw := range requiredKeywords {
+        if !strings.Contains(strings.ToLower(msg), strings.ToLower(kw)) {
+            t.Errorf("warning must contain %q, got: %s", kw, msg)
+        }
+    }
+}
+```
+
+### 5.4 Pass Criteria
+
+- [ ] 모든 4 keyword 포함 확인
+- [ ] 메시지가 빈 문자열이 아님
+
+---
+
+## 6. AC-DFF-05 — Reserved File Not Modified
+
+### 6.1 REQ Coverage
+REQ-DFF-006 (No auto-overwrite), REQ-DFF-004 (User file preservation)
+
+### 6.2 Given-When-Then
+
+**Given**:
+- `.moai/design/components.json` 사용자 작성, 내용 `{"user": "data"}`
+- `.moai/design/import-warnings.json` 사용자 작성, 내용 `{"warning": "test"}`
+
+**When**:
+- `updateDesignDir(root, &errBuf)` 호출
+
+**Then**:
+- 반환값 `nil`
+- 두 파일 모두 내용 변경 없음
+- 두 파일 모두 size 변경 없음 (`os.Stat` 비교)
+- mtime은 변경될 수 있음 (구현 디테일)
+
+### 6.3 Test Method
+
+```go
+func TestDesignFolderUpdate_ReservedNotModified(t *testing.T) {
+    t.Parallel()
+    root := t.TempDir()
+    designDir := filepath.Join(root, ".moai", "design")
+    os.MkdirAll(designDir, 0o755)
+
+    components := []byte(`{"user": "data"}`)
+    imports := []byte(`{"warning": "test"}`)
+    os.WriteFile(filepath.Join(designDir, "components.json"), components, 0o644)
+    os.WriteFile(filepath.Join(designDir, "import-warnings.json"), imports, 0o644)
+
+    var errBuf strings.Builder
+    if err := updateDesignDir(root, &errBuf); err != nil {
+        t.Fatalf("expected nil, got %v", err)
+    }
+
+    // assert byte-identical content for both files
+    got1, _ := os.ReadFile(filepath.Join(designDir, "components.json"))
+    if !bytes.Equal(got1, components) { t.Error("components.json modified") }
+    got2, _ := os.ReadFile(filepath.Join(designDir, "import-warnings.json"))
+    if !bytes.Equal(got2, imports) { t.Error("import-warnings.json modified") }
+}
+```
+
+### 6.4 Pass Criteria
+
+- [ ] 두 파일 모두 byte-identical 보존
+- [ ] 함수 nil 반환
+
+---
+
+## 7. AC-DFF-06 — Multiple Reserved Conflicts
+
+### 7.1 REQ Coverage
+REQ-DFF-001, REQ-DFF-002
+
+### 7.2 Given-When-Then
+
+**Given**:
+- `.moai/design/tokens.json` 사용자 작성
+- `.moai/design/brief/BRIEF-X.md` 사용자 작성
+- `.moai/design/components.json` 사용자 작성
+
+**When**:
+- `updateDesignDir(root, &errBuf)` 호출
+
+**Then**:
+- 반환값 `nil`
+- `errBuf`에 세 파일 이름 모두 포함 ("tokens.json", "BRIEF-X", "components.json")
+- 세 파일 모두 내용 보존
+- 다른 templates (README 등) sync 정상
+
+### 7.3 Test Method
+
+```go
+func TestDesignFolderUpdate_MultipleReservedConflicts(t *testing.T) {
+    t.Parallel()
+    root := t.TempDir()
+    designDir := filepath.Join(root, ".moai", "design")
+    briefDir := filepath.Join(designDir, "brief")
+    os.MkdirAll(briefDir, 0o755)
+
+    files := map[string][]byte{
+        filepath.Join(designDir, "tokens.json"):     []byte(`{"a":1}`),
+        filepath.Join(briefDir, "BRIEF-X.md"):       []byte("brief X"),
+        filepath.Join(designDir, "components.json"): []byte(`[]`),
+    }
+    for path, content := range files {
+        os.WriteFile(path, content, 0o644)
+    }
+
+    var errBuf strings.Builder
+    if err := updateDesignDir(root, &errBuf); err != nil {
+        t.Fatalf("expected nil, got %v", err)
+    }
+
+    msg := errBuf.String()
+    for _, kw := range []string{"tokens.json", "BRIEF-X", "components.json"} {
+        if !strings.Contains(msg, kw) {
+            t.Errorf("warning must mention %q, got: %s", kw, msg)
+        }
+    }
+    // assert all three files preserved
+    for path, want := range files {
+        got, _ := os.ReadFile(path)
+        if !bytes.Equal(got, want) {
+            t.Errorf("%s modified", path)
+        }
+    }
+}
+```
+
+### 7.4 Pass Criteria
+
+- [ ] 세 파일 이름 모두 warning 메시지에 포함
+- [ ] 세 파일 모두 byte-identical 보존
+- [ ] 함수 nil 반환
+
+---
+
+## 8. Edge Cases
+
+### 8.1 errOut == nil
+
+**시나리오**: caller가 `updateDesignDir(root, nil)` 호출
+
+**Expected**: panic 없음. warning은 silent (현재 코드도 동일하게 nil check 있음). 함수는 nil 반환.
+
+**검증**: 단위 테스트 `TestDesignFolderUpdate_NilErrOut`가 panic 없이 통과.
+
+### 8.2 Empty .moai/design/ Directory
+
+**시나리오**: `.moai/design/`은 존재하지만 파일 없음
+
+**Expected**: reserved 충돌 없음 (warning도 출력 안 됨). templates 정상 deploy. nil 반환.
+
+**Existing Coverage**: `TestDesignFolderSkip_EmptyDir`에서 이미 검증됨.
+
+### 8.3 Reserved Match in Subdirectory Outside brief/
+
+**시나리오**: `.moai/design/wireframes/tokens.json` (wireframes는 reserved subdir 아님)
+
+**Expected**: `tokens.json`은 exact match 정책상 `.moai/design/tokens.json`에서만 검사. wireframes/ 하위는 무시. (기존 동작 유지)
+
+**검증**: 신규 테스트 추가 가능하나 본 SPEC 범위 외. 기존 정책 그대로.
+
+---
+
+## 9. Definition of Done
+
+### 9.1 Code
+
+- [ ] `internal/cli/design_folder.go`: `checkReservedCollision` strict 파라미터 추가, `updateDesignDir` 호출 변경
+- [ ] `internal/cli/design_folder_test.go`: 6개 AC 테스트 모두 추가/갱신
+- [ ] 모든 신규/갱신 테스트 GREEN
+
+### 9.2 Documentation
+
+- [ ] `.claude/rules/moai/design/constitution.md` v3.3.1 amendment
+- [ ] `internal/template/templates/.claude/rules/moai/design/constitution.md` mirror
+- [ ] HISTORY entry 추가됨
+
+### 9.3 Quality
+
+- [ ] `go test ./...` 전체 통과
+- [ ] `go test -race ./internal/cli/...` 통과
+- [ ] `golangci-lint run` 0 warnings
+- [ ] `go vet ./...` clean
+- [ ] `make build` 성공
+
+### 9.4 Verification
+
+- [ ] 사용자 보고 시나리오 (`mo.ai.kr/.moai/design/tokens.json`) 수동 재현 → warning + 다른 sync 정상 확인
+- [ ] commit message 한국어 body + Conventional Commits
+
+---
+
+## 10. Quality Gate Mapping
+
+| TRUST Pillar | 검증 |
+|--------------|------|
+| Tested       | 6 ACs, 모든 REQ-DFF-* 커버, race detection 포함 |
+| Readable     | strict bool 파라미터로 의도 명확, warning 메시지 자명 |
+| Unified      | 기존 design_folder.go 코드 스타일 준수, gofmt |
+| Secured      | 사용자 데이터 수정 절대 없음 (REQ-DFF-004/006) |
+| Trackable    | SPEC ID + commit message + HISTORY entry로 traceable |
+
+---
+
+Version: 0.1.0
+Last Updated: 2026-04-26
+REQ coverage: REQ-DFF-001 ~ REQ-DFF-008 (full)
+AC count: 6

--- a/.moai/specs/SPEC-V3R3-DESIGN-FOLDER-FIX-001/plan.md
+++ b/.moai/specs/SPEC-V3R3-DESIGN-FOLDER-FIX-001/plan.md
@@ -1,0 +1,259 @@
+# SPEC-V3R3-DESIGN-FOLDER-FIX-001 — Implementation Plan
+
+## HISTORY
+
+| Version | Date       | Author       | Description |
+|---------|------------|--------------|-------------|
+| 0.1.0   | 2026-04-26 | manager-spec | Initial plan. Single-commit bug fix: design_folder.go warning 격하 + test 갱신 + constitution amendment. |
+
+---
+
+## 1. Implementation Strategy
+
+### 1.1 Approach Selection
+
+**선택**: 단일 commit, TDD 사이클 (RED → GREEN → 검증)
+
+**Rationale**:
+- 변경 범위 좁음 (1 Go 파일 + 1 test 파일 + 1 rule 파일 + 1 template mirror)
+- 의존성 없는 독립 fix
+- Bug fix 본질상 split하면 오히려 reviewer cognitive load 증가
+
+**Alternative 고려 후 거부**:
+- 2-commit split (impl 분리 + constitution 분리): rule 변경이 코드 변경과 의미적으로 결합되어 있어 분리 시 review 흐름 단절
+- 3-commit split (test → impl → docs): TDD 의도는 좋지만 단일 PR cycle 내 간섭 우려
+
+### 1.2 Code Change Pattern (Strict Mode 분기)
+
+**Option A (선택): bool 파라미터 추가**
+```go
+// 시그니처 변경
+func checkReservedCollision(projectRoot string, errOut io.Writer, strict bool) error
+// strict=true → error 반환 (scaffold path)
+// strict=false → warning 출력 후 nil 반환 (update path)
+```
+
+**Option B (거부): 별도 함수 분리**
+- `checkReservedCollisionStrict` + `warnReservedCollision` 두 함수 도입
+- 거부 이유: 호출처가 `updateDesignDir` 1곳뿐. 함수 2개 도입 overkill.
+
+**Option C (거부): caller에서 분기**
+- `checkReservedCollision`은 무조건 발견 list 반환, caller가 error/warning 결정
+- 거부 이유: 시그니처 변경 폭 큼 (반환 타입 `error` → `[]string` + error). 기존 시그니처 보존 우선.
+
+**최종 선택**: Option A — strict bool 파라미터로 명시적 분기.
+
+### 1.3 함수 동작 (수정 후)
+
+```
+checkReservedCollision(projectRoot, errOut, strict bool) error
+├── reserved files 발견 list 수집
+├── if strict == true:
+│     errOut에 "error: reserved filename: ..." 출력
+│     return error (첫 번째 발견)
+├── if strict == false:
+│     errOut에 "warning: reserved filename: ... (preserved; rename to use canonical templates)" 출력
+│     return nil (모든 발견 list warning 후)
+```
+
+**호출 변경**:
+- `updateDesignDir`: `checkReservedCollision(projectRoot, errOut, false)` (warning mode)
+- `scaffoldDesignDir`: 현재는 `checkReservedCollision`을 호출하지 않음. 변경 없음.
+
+**확인 사항**: scaffold path가 reserved 검사를 호출하지 않음 → 신규 프로젝트는 reserved name 위반 가능성 사실상 없음 (template만 deploy). 따라서 REQ-DFF-003은 update path 동작에 의해 자동 보장. 그러나 향후 누가 scaffold 호출 추가할 때를 대비해 strict mode 시그니처를 분리 유지.
+
+---
+
+## 2. Milestones (Priority-Based, No Time Estimates)
+
+### M1 (P0): Test 갱신 (RED Phase)
+
+**Priority**: P0 Critical (TDD 시작점)
+
+**Tasks**:
+1. `internal/cli/design_folder_test.go`:
+   - `TestDesignFolderReservedExact` 수정: error 기대 → warning + nil + 다른 파일 sync 검증
+   - `TestDesignFolderReservedGlob` 수정: 동일 패턴
+   - `TestDesignFolderReservedNotModified` 강화: 파일 보존 + 다른 templates sync 검증 추가
+   - `TestDesignFolderUpdate_WarningIncludesGuidance` 신규: warning 메시지에 "preserved" + 우회 안내 포함
+   - `TestDesignFolderUpdate_MultipleReservedConflicts` 신규: 다중 충돌 케이스
+2. `go test ./internal/cli/... -run TestDesignFolder` 실행 → 전체 RED 확인
+
+**Exit Criteria**: 갱신된 모든 테스트가 명확한 RED 상태 (기존 hard error 동작과 새 expectation 불일치).
+
+### M2 (P0): 구현 (GREEN Phase)
+
+**Priority**: P0 Critical
+
+**Tasks**:
+1. `internal/cli/design_folder.go`:
+   - `checkReservedCollision` 시그니처에 `strict bool` 추가
+   - strict=true: 기존 error 반환 동작 유지
+   - strict=false: 발견 list 누적 → warning 출력 → nil 반환
+   - warning 메시지 포맷: `warning: reserved filename: <path> (preserved; rename to use canonical templates)`
+   - `updateDesignDir`의 호출을 `checkReservedCollision(projectRoot, errOut, false)`로 변경
+   - reserved 충돌 발견된 파일은 update loop에서 skip (canonical hash 비교 대상 외)
+
+**Exit Criteria**:
+- M1의 모든 테스트 GREEN
+- `go vet ./...` clean
+- `golangci-lint run` clean
+- 기존 `TestDesignFolderUserEditPreserved` 등 unrelated 테스트도 모두 통과
+
+### M3 (P1): Documentation Amendment
+
+**Priority**: P1 High
+
+**Tasks**:
+1. `.claude/rules/moai/design/constitution.md`:
+   - HISTORY 최상단에 v3.3.1 entry 추가
+   - §3.2 footnote: "Reserved name violation은 update path에서 warning + skip, scaffold path에서 hard error"
+   - Version footer: 3.3.0 → 3.3.1
+2. `internal/template/templates/.claude/rules/moai/design/constitution.md`:
+   - 동일한 변경 적용 (Template-First HARD 준수)
+3. `make build` 실행 → `internal/template/embedded.go` 재생성
+
+**Exit Criteria**:
+- 두 constitution 파일 byte-identical (template mirror 검증)
+- `make build` 성공
+- diff 검증: `diff .claude/rules/moai/design/constitution.md internal/template/templates/.claude/rules/moai/design/constitution.md` empty
+
+### M4 (P1): Full Test Suite + 검증
+
+**Priority**: P1 High
+
+**Tasks**:
+1. `go test ./...` 전체 통과
+2. `go test -race ./internal/cli/...` 통과
+3. `make build && make install` (로컬 binary 검증)
+4. 수동 검증: `~/MoAI/mo.ai.kr` 또는 임시 프로젝트에서 `moai update` 실행 → tokens.json 존재 시 warning + 다른 파일 sync 정상 확인
+
+**Exit Criteria**: 모든 quality gate green, 사용자 보고 시나리오 재현 후 정상 동작 확인.
+
+---
+
+## 3. Technical Approach
+
+### 3.1 Files Modified
+
+| File | Change Type | LOC Estimate |
+|------|-------------|--------------|
+| `internal/cli/design_folder.go` | Modify | +20/-10 |
+| `internal/cli/design_folder_test.go` | Modify + Add | +80/-30 |
+| `.claude/rules/moai/design/constitution.md` | Modify (HISTORY + footnote + version) | +6/-1 |
+| `internal/template/templates/.claude/rules/moai/design/constitution.md` | Mirror | +6/-1 |
+| `internal/template/embedded.go` | Auto-regenerate via `make build` | (generated) |
+
+총 신규 코드 < 100 LOC. 단일 commit 적합.
+
+### 3.2 Function Signature Changes
+
+**Before**:
+```go
+func checkReservedCollision(projectRoot string, errOut io.Writer) error
+```
+
+**After**:
+```go
+func checkReservedCollision(projectRoot string, errOut io.Writer, strict bool) error
+```
+
+**Caller 변경**:
+- `updateDesignDir`: `checkReservedCollision(projectRoot, errOut, false)` (warning mode, REQ-DFF-001)
+- 다른 caller 없음 (grep 검증 필요)
+
+### 3.3 Update Loop Skip Logic
+
+`updateDesignDir`은 현재 `designTemplateFiles` (README/research/system/spec)만 iterate. reserved files는 `designTemplateFiles`에 없으므로 별도 skip 로직 불필요. **단**, warning 출력 후 다른 template sync는 정상 진행되어야 함을 명시적으로 verify.
+
+### 3.4 Warning Message Format
+
+**English** (default `code_comments` setting):
+```
+warning: reserved filename: tokens.json (preserved; rename to use canonical templates if you want them auto-managed)
+```
+
+**Korean** (when `code_comments: ko`):
+```
+warning: 예약 파일명 충돌: tokens.json (사용자 파일 보존됨; canonical template 사용을 원하면 rename 필요)
+```
+
+**선택**: 단순화를 위해 영어 단일 메시지로 시작 (REQ-DFF-005 충족). i18n은 별도 SPEC 영역.
+
+---
+
+## 4. Risks and Mitigations
+
+| 위험 | 가능성 | 영향 | 완화 |
+|------|--------|------|------|
+| `checkReservedCollision` 시그니처 변경이 다른 caller에 영향 | 낮음 | 중간 | grep으로 caller 전수 검증; 1곳만 발견 시 OK |
+| Constitution amendment HISTORY 누락 | 중간 | 낮음 | review checklist에 추가; M3 exit criteria에 명시 |
+| Template mirror 누락 | 중간 | 높음 | M3 exit criteria diff 검증; pre-commit hook 활용 |
+| 기존 사용자 워크플로우 파괴 (warning이 noise로 인식) | 낮음 | 중간 | warning에 "preserved" 키워드 명시; 사용자가 의도한 동작 명확히 안내 |
+| `errOut`이 nil인 케이스 (silent skip 위험) | 낮음 | 중간 | nil check 추가; nil인 경우 stderr fallback 또는 silent OK 정책 결정 (현재 코드 nil 허용) |
+
+---
+
+## 5. Dependencies and Pre-conditions
+
+### 5.1 Dependencies
+
+- 없음. 독립 fix.
+
+### 5.2 Pre-conditions
+
+- 현재 branch `fix/SPEC-V3R3-DESIGN-FOLDER-FIX-001` 활성
+- `internal/cli/design_folder.go` 및 test 파일 read 권한 확보
+- `make build` 정상 동작
+- `~/.moai/.env.glm` 등 GLM 토큰은 이번 fix와 무관
+
+### 5.3 Post-conditions
+
+- 모든 quality gate green
+- `moai update`가 reserved 충돌 시에도 다른 templates sync 정상 진행
+- v2.15.x patch release candidate (단, release는 별도 SPEC/PR)
+
+---
+
+## 6. Quality Gates
+
+### 6.1 Pre-Commit
+
+- [ ] `go test ./...` 전체 통과
+- [ ] `go test -race ./internal/cli/...` 통과
+- [ ] `golangci-lint run` 0 warnings
+- [ ] `go vet ./...` clean
+- [ ] `make build` 성공 + embedded.go 재생성 확인
+
+### 6.2 Pre-PR
+
+- [ ] template mirror diff empty
+- [ ] constitution.md HISTORY entry 추가됨
+- [ ] commit message 한국어 body + Conventional Commits format
+- [ ] `~/MoAI/mo.ai.kr` 시나리오 수동 재현 완료
+
+### 6.3 Post-Merge
+
+- [ ] CHANGELOG.md v2.15.x entry (별도 release SPEC에서)
+- [ ] User feedback 수집 (다음 release cycle)
+
+---
+
+## 7. Out-of-Band Considerations
+
+### 7.1 i18n (Korean Warning Message)
+
+`code_comments: ko` 설정 시 한국어 warning 메시지 제공은 nice-to-have. 본 SPEC 범위 외. 향후 별도 enhancement SPEC.
+
+### 7.2 Constitution Amendment 승인 절차
+
+design constitution은 FROZEN amendment (SPEC-DESIGN-CONST-AMEND-001 패턴 따름). v3.3.0 → v3.3.1 bump는 footnote 추가 수준 minor amendment. 인간 승인 필요하나 P0 bug fix이므로 PR review 단계에서 일괄 승인 요청.
+
+### 7.3 Release Note Hook
+
+v2.15.1 또는 v2.16.0 release 시 release note에 "moai update가 더 이상 reserved filename 충돌 시 abort하지 않음" 명시 필요. 본 SPEC은 fix만 다루고, release SPEC에서 release note 작성.
+
+---
+
+Version: 0.1.0
+Last Updated: 2026-04-26

--- a/.moai/specs/SPEC-V3R3-DESIGN-FOLDER-FIX-001/spec.md
+++ b/.moai/specs/SPEC-V3R3-DESIGN-FOLDER-FIX-001/spec.md
@@ -1,0 +1,272 @@
+---
+id: SPEC-V3R3-DESIGN-FOLDER-FIX-001
+version: "0.1.0"
+status: draft
+created_at: 2026-04-26
+updated_at: 2026-04-26
+author: manager-spec
+priority: P0
+labels: [design-folder, update-path, bug-fix, reserved-collision, v3r3]
+issue_number: null
+breaking: false
+bc_id: []
+lifecycle: spec-anchored
+depends_on: []
+related_specs: [SPEC-DESIGN-CONST-AMEND-001]
+phase: "v3.0.0 R3 — Phase B — Bug Fix"
+module: "internal/cli/design_folder.go, .claude/rules/moai/design/constitution.md"
+tags: "design-folder, moai-update, reserved-name, bug-fix, v3r3, phase-b"
+related_theme: "Phase B — Update Path Hardening"
+---
+
+# SPEC-V3R3-DESIGN-FOLDER-FIX-001: moai update Reserved Filename Collision — Warning 격하 (Update Path)
+
+## HISTORY
+
+| Version | Date       | Author       | Description |
+|---------|------------|--------------|-------------|
+| 0.1.0   | 2026-04-26 | manager-spec | Initial draft. v2.15.0 user-reported bug: moai update의 hard error로 인한 `.moai/design/tokens.json` 충돌 시 전체 sync 실패. update path만 warning + skip으로 격하. scaffold path는 기존 hard error 유지 (REQ-008). |
+
+---
+
+## 1. Goal (목적)
+
+`moai update` 실행 시 `.moai/design/` 디렉터리의 **reserved filename** (`tokens.json`, `components.json`, `import-warnings.json`, `brief/BRIEF-*.md`) 충돌을 발견할 때 **hard error로 abort 대신 warning 출력 + 해당 파일 skip + 다른 정상 template 파일 sync는 계속 진행**하도록 동작을 격하한다. 신규 프로젝트 init/scaffold 경로는 기존 hard error 동작을 유지하여 신규 사용자 혼란을 방지한다.
+
+### 1.1 배경 (User-Reported Bug)
+
+#### 1.1.1 재현 시나리오
+
+- 환경: `~/MoAI/mo.ai.kr` 프로젝트 (moai-adk v2.15.0+ 사용)
+- 사전 조건: 이전 버전(< v2.15)에서 `.moai/design/tokens.json` 정상 생성됨 (당시 reserved name 정책 부재)
+- 트리거: `moai update` 실행
+- 결과:
+  ```
+  error: reserved filename: tokens.json
+  Error: reserved filename: "tokens.json" collides with reserved name
+  ```
+- 영향: `moai update` 전체가 abort됨. design folder 외 다른 정상 template (예: `.claude/rules/`, `.claude/agents/`) sync도 실행되지 않음.
+
+#### 1.1.2 근본 원인
+
+- v2.15+에서 design constitution §3.2 (SPEC-DESIGN-CONST-AMEND-001)가 도입되며 `.moai/design/` 내 reserved file path 정책 신설
+- `internal/cli/design_folder.go:216 updateDesignDir`의 `checkReservedCollision` 호출이 reserved 충돌을 hard error로 처리 → caller에 error 반환 → moai update 전체 abort
+- 기존 사용자의 valid한 작업 산출물(이전 버전에서 생성된 tokens.json 등)이 신규 정책 위반으로 판정되며 user data preservation 약속 위배
+
+#### 1.1.3 정책 충돌
+
+`moai update`의 핵심 약속 (REQ-005 in SPEC-DESIGN-001):
+- 사용자 파일 보존: SHA-256 hash 비교로 user-modified 파일은 overwrite하지 않음
+
+현재 동작:
+- Reserved 충돌 발견 시 **다른 정상 파일 sync도 막힘** (전체 abort) → 사용자 파일 자체는 그대로 두지만 **template sync 약속 위배**
+
+해결 방향:
+- update path: warning 출력 + 충돌 파일 skip + 다른 templates sync 계속 진행 (return nil)
+- scaffold path: 변경 없음 (신규 프로젝트는 reserved name 거부 유지)
+
+### 1.2 비목표 (Non-Goals)
+
+- 충돌 파일 자체의 수정/삭제: 어떤 경우에도 사용자 데이터를 변경하지 않음
+- scaffold path 동작 변경: REQ-008 (신규 프로젝트 reserved name 거부) 의미 보존
+- Reserved file path canonical list 변경: SPEC-DESIGN-CONST-AMEND-001의 5개 패턴 그대로 유지
+- design constitution §3.2 본문 의미 변경: footnote만 추가 (FROZEN amendment)
+- 자동 rename 또는 migration 로직: 사용자가 직접 처리하도록 안내 메시지 제공
+
+---
+
+## 2. Scope (범위)
+
+### 2.1 In Scope (포함)
+
+1. **`internal/cli/design_folder.go` 수정**:
+   - `checkReservedCollision` 함수 시그니처에 strict 모드 분기 도입 (예: bool 파라미터 또는 별도 함수)
+   - `updateDesignDir`: 충돌 발견 시 warning 출력, 충돌 파일 skip, 다른 templates sync 진행, return nil
+   - `scaffoldDesignDir` (간접): reserved 충돌 검사가 호출되는 경우 strict mode 사용 (현재는 update에서만 호출되지만 시그니처 분리로 명확화)
+2. **`internal/cli/design_folder_test.go` 갱신**:
+   - 기존 `TestDesignFolderReservedExact`: error 기대 → warning + 다른 파일 정상 sync 기대로 수정
+   - 기존 `TestDesignFolderReservedGlob`: 동일 패턴 수정
+   - 기존 `TestDesignFolderReservedNotModified`: 보존 + 다른 파일 update 진행 검증으로 강화
+   - 신규 테스트 `TestDesignFolderScaffold_ReservedExact_StillErrors`: scaffold path는 여전히 error
+   - 신규 테스트 `TestDesignFolderUpdate_WarningIncludesGuidance`: warning 메시지에 우회 절차 포함 검증
+3. **`.claude/rules/moai/design/constitution.md` §3.2 footnote 추가**:
+   - FROZEN amendment HISTORY entry 추가 (v3.3.1로 bump)
+   - Reserved name violation은 update path에서 warning + skip, scaffold path에서 hard error 명시
+4. **Template-First 미러링**:
+   - `internal/template/templates/.claude/rules/moai/design/constitution.md`도 동일하게 수정
+   - `make build`로 embedded.go 재생성
+
+### 2.2 Out of Scope (제외)
+
+- `moai init` (scaffold path) 동작 변경
+- Reserved file path canonical list 추가/제거
+- 자동 마이그레이션 도구 (사용자 수동 rename 안내만)
+- design folder 외 reserved name 정책 (이번 fix는 `.moai/design/`만 대상)
+
+---
+
+## 3. Stakeholders (이해관계자)
+
+- **End Users (mo.ai.kr 등)**: v2.15+ 업데이트 시 기존 작업물 보존 + sync 정상 진행 기대
+- **manager-spec / manager-ddd**: SPEC 작성·구현 주체
+- **expert-backend**: Go 코드 수정 (design_folder.go)
+- **plan-auditor**: bug fix SPEC의 EARS·테스트 커버리지 검증
+- **MoAI 코어 팀**: design constitution v3.3.1 amendment 승인
+
+---
+
+## 4. Requirements (EARS Format)
+
+### 4.1 Event-Driven Requirements
+
+- **REQ-DFF-001 (Update path warning)**: WHEN `moai update`가 `.moai/design/` 내 reserved name 파일 (exact match: tokens.json/components.json/import-warnings.json, glob match: brief/BRIEF-*.md)을 발견 THEN warning 메시지를 errOut에 출력하고 해당 파일 sync를 skip하며 다른 template files sync를 계속 진행
+- **REQ-DFF-002 (Other files sync continuation)**: WHEN reserved 충돌 발견 후 다른 template files (README.md, research.md, system.md, spec.md) sync가 시도됨 THEN 정상 sync 진행 (REQ-005 user-edit preservation은 그대로 적용)
+- **REQ-DFF-003 (Scaffold path strict mode)**: WHEN `moai init` (또는 scaffold path) 신규 프로젝트가 `.moai/design/` 내 reserved name 파일을 발견 THEN hard error 반환 (기존 REQ-008 동작 유지)
+
+### 4.2 Ubiquitous Requirements
+
+- **REQ-DFF-004 (User file preservation)**: 충돌 파일 자체는 어떤 경우에도 수정·삭제되지 않음 — `moai update` warning 후에도 원본 그대로 유지
+- **REQ-DFF-005 (Warning guidance)**: REQ-DFF-001의 warning 메시지에 사용자 우회 절차 안내 포함 ("file preserved; rename to use canonical templates" 또는 한국어 동등 메시지)
+
+### 4.3 Unwanted Behavior Requirements
+
+- **REQ-DFF-006 (No auto-overwrite)**: IF 충돌 파일이 reserved name과 일치 THEN 시스템은 해당 파일을 절대 overwrite하지 않음 (warning 출력 후에도)
+- **REQ-DFF-007 (No silent failure)**: IF reserved 충돌이 발견됨 THEN warning은 반드시 visible하게 출력되어야 함 (silent skip 금지)
+
+### 4.4 State-Driven Requirements
+
+- **REQ-DFF-008 (Path mode dispatch)**: WHILE `checkReservedCollision`이 update mode로 호출됨 THEN warning + nil 반환, WHILE scaffold mode로 호출됨 THEN error 반환 (caller가 명시적으로 mode 지정)
+
+---
+
+## 5. Success Criteria (성공 기준)
+
+### 5.1 Functional
+
+- F-1: `moai update` 실행 시 `.moai/design/tokens.json` 존재 + 다른 파일 정상 → warning 출력, tokens.json 보존, 다른 파일 sync 정상 완료
+- F-2: `moai update` 실행 시 `.moai/design/brief/BRIEF-LOCAL.md` 존재 → warning 출력, BRIEF-LOCAL.md 보존, 다른 파일 sync 정상 완료
+- F-3: `moai init` 실행 시 `.moai/design/tokens.json` 존재 (이론적 케이스, 신규 프로젝트) → hard error 반환 (기존 동작)
+- F-4: warning 메시지에 file path + 우회 절차 안내 포함
+
+### 5.2 Quality
+
+- Q-1: 모든 신규/기존 design_folder 테스트 통과 (`go test ./internal/cli/...`)
+- Q-2: `golangci-lint run`에서 `internal/cli/design_folder.go` 0 warnings
+- Q-3: race detection 통과 (`go test -race ./internal/cli/...`)
+- Q-4: design constitution.md 수정이 internal/template/templates/ mirror에도 동일 적용 (template-first 검증)
+
+### 5.3 Documentation
+
+- D-1: design constitution v3.3.1 HISTORY entry 추가
+- D-2: SPEC-DESIGN-CONST-AMEND-001과의 관계 (reserved name 정책 출처) 명시
+
+---
+
+## 6. Test Scenarios (검증 시나리오)
+
+### 6.1 Update Path — Reserved Exact Match
+
+- **Given**: `.moai/design/tokens.json` 존재 (사용자 데이터 `{"primary": "#000"}`), 다른 templates도 deploy됨
+- **When**: `updateDesignDir(root, errOut)` 호출
+- **Then**:
+  - errOut에 "warning" + "tokens.json" + "preserved" 포함
+  - tokens.json 내용 변경 없음 (`{"primary": "#000"}` 그대로)
+  - 다른 template (README.md 등) update 정상 (canonical hash와 일치하면 overwrite, 사용자 수정본은 보존)
+  - 함수는 nil 반환
+
+### 6.2 Update Path — Reserved Glob Match
+
+- **Given**: `.moai/design/brief/BRIEF-LOCAL.md` 존재
+- **When**: `updateDesignDir` 호출
+- **Then**: warning 출력 + 파일 보존 + 다른 templates sync 정상 + nil 반환
+
+### 6.3 Scaffold Path — Reserved Match (Still Errors)
+
+- **Given**: `.moai/design/tokens.json` 존재 (이론적 신규 프로젝트 케이스)
+- **When**: scaffold path가 strict mode로 `checkReservedCollision` 호출
+- **Then**: error 반환 (REQ-DFF-003) + tokens.json 보존
+
+### 6.4 Update Path — Warning Message Content
+
+- **Given**: `.moai/design/components.json` 존재
+- **When**: `updateDesignDir` 호출, errOut을 buffer로 캡처
+- **Then**: warning에 다음 모두 포함:
+  - 파일 경로 (`components.json` 또는 절대 경로)
+  - "preserved" 또는 "보존" 키워드
+  - 우회 절차 (예: "rename to use canonical templates" 또는 동등 한국어)
+
+### 6.5 Update Path — Multiple Reserved Conflicts
+
+- **Given**: `tokens.json` + `brief/BRIEF-X.md` 동시 존재
+- **When**: `updateDesignDir` 호출
+- **Then**: 두 파일 모두에 대한 warning 출력 + 두 파일 모두 보존 + 다른 templates sync 정상 + nil 반환
+
+---
+
+## 7. Constraints (제약사항)
+
+### 7.1 Technical
+
+- Go 1.23+, `internal/cli/design_folder.go` 변경
+- 기존 함수 시그니처는 가능한 보존 (caller 영향 최소화) — strict mode는 internal 분기 또는 새 함수
+- `errOut io.Writer` 인터페이스는 유지 (warning과 error 모두 동일 writer 사용)
+
+### 7.2 Backward Compatibility
+
+- 기존 모든 design_folder 테스트는 동작 의미가 명확히 변경되는 부분 외에는 그대로 통과해야 함
+- `scaffoldDesignDir` 시그니처 불변
+- `updateDesignDir` 시그니처 불변 (단, 반환 의미가 reserved 충돌 시 nil로 변경)
+
+### 7.3 Template-First (HARD)
+
+- `.claude/rules/moai/design/constitution.md` 수정 시 `internal/template/templates/.claude/rules/moai/design/constitution.md` 동시 수정 필수
+- `make build` 실행 후 `internal/template/embedded.go` 재생성 검증
+
+### 7.4 Quality Gates
+
+- Test coverage ≥ 85% for `design_folder.go`
+- `go vet ./...` clean
+- `golangci-lint run` clean
+
+---
+
+## 8. Exclusions (What NOT to Build)
+
+- **자동 마이그레이션 도구**: 충돌 파일을 자동으로 rename 또는 backup으로 이동하지 않음. 사용자 수동 처리만 안내.
+- **새로운 reserved name 추가**: SPEC-DESIGN-CONST-AMEND-001의 5개 패턴 그대로 유지. 추가 정책 없음.
+- **scaffold path 동작 변경**: 신규 프로젝트는 여전히 reserved name 거부. 일관성 유지.
+- **design folder 외 reserved 정책**: 다른 디렉터리(`.moai/specs/`, `.claude/`)의 reserved name 정책은 이 SPEC의 대상이 아님.
+- **충돌 파일 자체 수정/삭제**: 사용자 데이터는 어떤 경우에도 수정 금지.
+- **회귀 테스트 자동화 인프라**: 본 SPEC은 단위 테스트만 추가. integration test harness는 다른 SPEC.
+
+---
+
+## 9. Acceptance Criteria Mapping
+
+| AC ID    | REQ Coverage                          | 검증 방식 |
+|----------|---------------------------------------|-----------|
+| AC-DFF-01 | REQ-DFF-001, REQ-DFF-002, REQ-DFF-004 | TestDesignFolderUpdate_ReservedExact_WarnsButContinues |
+| AC-DFF-02 | REQ-DFF-001, REQ-DFF-002              | TestDesignFolderUpdate_ReservedGlob_WarnsButContinues |
+| AC-DFF-03 | REQ-DFF-003, REQ-DFF-008              | TestDesignFolderScaffold_ReservedExact_StillErrors |
+| AC-DFF-04 | REQ-DFF-005, REQ-DFF-007              | TestDesignFolderUpdate_WarningIncludesGuidance |
+| AC-DFF-05 | REQ-DFF-006, REQ-DFF-004              | TestDesignFolderUpdate_ReservedNotModified (강화) |
+| AC-DFF-06 | REQ-DFF-001, REQ-DFF-002              | TestDesignFolderUpdate_MultipleReservedConflicts (신규) |
+
+상세 acceptance.md 참조.
+
+---
+
+## 10. References
+
+- SPEC-DESIGN-CONST-AMEND-001: Reserved file path 정책 도입 (출처)
+- SPEC-DESIGN-001: scaffoldDesignDir / updateDesignDir 원본 SPEC
+- `.claude/rules/moai/design/constitution.md` §3.2 — Design Brief execution scope
+- `internal/cli/design_folder.go` — 수정 대상
+- `internal/cli/design_folder_test.go` — 테스트 파일
+
+---
+
+Version: 0.1.0
+Classification: BUG_FIX
+Last Updated: 2026-04-26
+REQ coverage: REQ-DFF-001 ~ REQ-DFF-008

--- a/.moai/specs/SPEC-V3R3-DESIGN-FOLDER-FIX-001/tasks.md
+++ b/.moai/specs/SPEC-V3R3-DESIGN-FOLDER-FIX-001/tasks.md
@@ -1,0 +1,300 @@
+# SPEC-V3R3-DESIGN-FOLDER-FIX-001 — Task Breakdown
+
+## HISTORY
+
+| Version | Date       | Author       | Description |
+|---------|------------|--------------|-------------|
+| 0.1.0   | 2026-04-26 | manager-spec | Initial task list. 9 tasks across 4 milestones. Single-commit bug fix. |
+
+---
+
+## 1. Task Overview
+
+| Task ID  | Milestone | Priority | Owner            | Files Touched | Dependencies |
+|----------|-----------|----------|------------------|----------------|--------------|
+| T-01     | M1        | P0       | manager-tdd      | design_folder_test.go | none |
+| T-02     | M1        | P0       | manager-tdd      | design_folder_test.go | T-01 |
+| T-03     | M1        | P0       | manager-tdd      | design_folder_test.go | T-01 |
+| T-04     | M1        | P1       | manager-tdd      | design_folder_test.go | T-01 |
+| T-05     | M1        | P1       | manager-tdd      | design_folder_test.go | T-01 |
+| T-06     | M2        | P0       | expert-backend   | design_folder.go | T-01..T-05 |
+| T-07     | M3        | P1       | manager-docs     | constitution.md (×2) | T-06 |
+| T-08     | M3        | P1       | expert-backend   | embedded.go via make | T-07 |
+| T-09     | M4        | P0       | manager-quality  | full test suite | T-06, T-08 |
+
+---
+
+## 2. Detailed Tasks
+
+### T-01 (M1, P0) — Update TestDesignFolderReservedExact
+
+**File**: `internal/cli/design_folder_test.go`
+**Owner**: manager-tdd
+
+**Action**:
+- 기존 `TestDesignFolderReservedExact` (line 153~190)을 `TestDesignFolderUpdate_ReservedExact_WarnsButContinues`로 rename
+- expectation 변경:
+  - error 반환 → nil 반환
+  - errBuf에 "error: reserved filename" → "warning" + "tokens.json" + "preserved" 포함
+  - tokens.json 내용 보존 (기존 검증 유지)
+  - 추가: README.md user-edit 보존 검증 (다른 sync 정상 진행 증명)
+
+**Acceptance**: AC-DFF-01
+
+**Exit**:
+- 테스트가 명확한 RED 상태 (현재 hard error 동작과 새 expectation 불일치)
+
+---
+
+### T-02 (M1, P0) — Update TestDesignFolderReservedGlob
+
+**File**: `internal/cli/design_folder_test.go`
+**Owner**: manager-tdd
+
+**Action**:
+- 기존 `TestDesignFolderReservedGlob` (line 194~226)을 `TestDesignFolderUpdate_ReservedGlob_WarnsButContinues`로 rename
+- expectation을 T-01과 동일 패턴으로 변경
+- BRIEF-LOCAL.md 보존 + 다른 templates sync 검증 추가
+
+**Acceptance**: AC-DFF-02
+
+**Exit**: RED 상태 확인
+
+---
+
+### T-03 (M1, P0) — Strengthen TestDesignFolderReservedNotModified
+
+**File**: `internal/cli/design_folder_test.go`
+**Owner**: manager-tdd
+
+**Action**:
+- 기존 `TestDesignFolderReservedNotModified` (line 230~256)을 `TestDesignFolderUpdate_ReservedNotModified`로 rename
+- expectation 강화:
+  - 두 reserved 파일 (components.json + import-warnings.json) 동시 존재
+  - 모두 byte-identical 보존
+  - 함수 nil 반환 (기존 코드는 `_ = updateDesignDir`로 무시했으나 명시적으로 검증)
+
+**Acceptance**: AC-DFF-05
+
+**Exit**: RED 상태 확인
+
+---
+
+### T-04 (M1, P1) — Add TestDesignFolderUpdate_WarningIncludesGuidance
+
+**File**: `internal/cli/design_folder_test.go`
+**Owner**: manager-tdd
+
+**Action**: 신규 테스트 추가
+```go
+func TestDesignFolderUpdate_WarningIncludesGuidance(t *testing.T) {
+    // components.json 작성 → updateDesignDir 호출 → errBuf에 4 keyword 포함 검증
+}
+```
+
+**Required Keywords**: "warning", "components.json", "preserved", "rename"
+
+**Acceptance**: AC-DFF-04
+
+**Exit**: RED 상태 확인 (현재 메시지에 "rename" 없음)
+
+---
+
+### T-05 (M1, P1) — Add TestDesignFolderScaffold_ReservedExact_StillErrors + MultipleConflicts
+
+**File**: `internal/cli/design_folder_test.go`
+**Owner**: manager-tdd
+
+**Action**: 두 개 신규 테스트 추가
+1. `TestDesignFolderScaffold_ReservedExact_StillErrors`: `checkReservedCollision(root, &errBuf, true)` 직접 호출, error 반환 검증
+2. `TestDesignFolderUpdate_MultipleReservedConflicts`: 세 reserved 파일 동시 존재, 모두 warning + 모두 보존
+
+**Acceptance**: AC-DFF-03, AC-DFF-06
+
+**Exit**: 두 테스트 모두 RED (T-05.1: strict 파라미터 미존재로 컴파일 에러; T-05.2: 현재 hard error 동작)
+
+---
+
+### T-06 (M2, P0) — Implement Strict Mode Dispatch
+
+**File**: `internal/cli/design_folder.go`
+**Owner**: expert-backend
+
+**Action**:
+1. `checkReservedCollision` 시그니처 변경:
+   ```go
+   func checkReservedCollision(projectRoot string, errOut io.Writer, strict bool) error
+   ```
+2. 함수 본문 변경:
+   - reserved 파일 발견 list 누적 (append 패턴)
+   - strict == true: 첫 발견 시 즉시 error 반환 + errOut에 "error: reserved filename: ..." 출력 (기존 동작)
+   - strict == false: 모든 발견 list iterate → errOut에 "warning: reserved filename: <path> (preserved; rename to use canonical templates)" 출력 → return nil
+3. `updateDesignDir`의 호출 변경: `checkReservedCollision(projectRoot, errOut, false)`
+4. 시그니처 변경 영향 caller grep 검증: `grep -rn "checkReservedCollision" internal/`
+
+**Acceptance**: M1의 모든 AC GREEN 전환
+
+**Exit**:
+- M1의 6개 테스트 모두 GREEN
+- 기존 `TestDesignFolderUserEditPreserved`, `TestDesignFolderSubdirs` 등 unrelated 테스트 모두 통과
+- `go test ./internal/cli/...` 전체 통과
+- `golangci-lint run` clean
+
+---
+
+### T-07 (M3, P1) — Constitution v3.3.1 Amendment
+
+**Files**:
+- `.claude/rules/moai/design/constitution.md`
+- `internal/template/templates/.claude/rules/moai/design/constitution.md`
+
+**Owner**: manager-docs
+
+**Action**:
+1. HISTORY 최상단에 entry 추가:
+   ```
+   - 2026-04-26 (SPEC-V3R3-DESIGN-FOLDER-FIX-001): §3.2 footnote — Reserved name violation은 update path에서 warning + skip, scaffold path에서 hard error. v3.3.0 → 3.3.1.
+   ```
+2. §3.2 마지막에 footnote 추가:
+   ```
+   > Note: Reserved name violation은 `moai update` (update path)에서는 warning 출력 + 해당 파일 skip + 다른 templates sync 계속 진행. `moai init` (scaffold path)에서는 hard error 반환. 사용자 데이터는 어떤 경우에도 수정·삭제되지 않음.
+   ```
+3. Version footer: `3.3.0` → `3.3.1`
+4. `Last Updated`: `2026-04-20` → `2026-04-26`
+5. 두 파일 byte-identical 검증: `diff .claude/rules/moai/design/constitution.md internal/template/templates/.claude/rules/moai/design/constitution.md` empty
+
+**Acceptance**: D-1, D-2 (spec.md §5.3)
+
+**Exit**: diff empty 확인
+
+---
+
+### T-08 (M3, P1) — Regenerate Embedded Templates
+
+**File**: `internal/template/embedded.go` (auto-generated)
+**Owner**: expert-backend
+
+**Action**:
+1. `make build` 실행
+2. `git diff internal/template/embedded.go` 확인 → constitution.md 변경 반영 확인
+3. `go test ./internal/template/...` 통과 확인 (embedded fs integrity)
+
+**Acceptance**: Q-4 (spec.md §5.2)
+
+**Exit**: build 성공 + embedded.go 갱신 확인
+
+---
+
+### T-09 (M4, P0) — Full Quality Gate Verification
+
+**Owner**: manager-quality
+
+**Action**:
+1. `go test ./...` 전체 통과
+2. `go test -race ./internal/cli/...` 통과
+3. `golangci-lint run` 0 warnings
+4. `go vet ./...` clean
+5. `make install` (로컬 binary 갱신)
+6. 수동 검증 시나리오:
+   - 임시 디렉터리 생성: `mkdir -p /tmp/test-update-fix && cd /tmp/test-update-fix && moai init`
+   - `.moai/design/tokens.json` 작성: `echo '{"primary":"#000"}' > .moai/design/tokens.json`
+   - `moai update` 실행 → warning 출력 확인 + tokens.json 보존 확인 + 다른 design templates sync 확인
+   - 또는 `~/MoAI/mo.ai.kr`에서 직접 재현 (사용자 보고 시나리오)
+
+**Acceptance**: spec.md §5.1 F-1 ~ F-4 + Q-1 ~ Q-4
+
+**Exit**:
+- 모든 quality gate green
+- 사용자 시나리오 수동 재현 정상
+
+---
+
+## 3. Task Dependency Graph
+
+```
+T-01 ──┐
+T-02 ──┤
+T-03 ──┼── T-06 ── T-07 ── T-08 ── T-09
+T-04 ──┤
+T-05 ──┘
+```
+
+- T-01..T-05 는 독립 실행 가능 (병렬). 단, 같은 파일을 수정하므로 순차 권장.
+- T-06은 T-01..T-05의 RED 상태 확인 후 시작.
+- T-07은 T-06 GREEN 확인 후 시작 (코드와 docs 일관성).
+- T-08은 T-07 mirror 동기화 확인 후.
+- T-09는 모든 task 완료 후 final gate.
+
+---
+
+## 4. Commit Strategy
+
+### 4.1 Single Commit (선택)
+
+**Rationale**: 변경 범위 좁고 의존성 강하게 결합. PR review에서 한 번에 검토하는 것이 효율적.
+
+**Commit Message**:
+```
+spec(design-folder): SPEC-V3R3-DESIGN-FOLDER-FIX-001 — reserved collision update path warning 격하
+
+moai update 실행 시 .moai/design/ 내 reserved filename (tokens.json,
+components.json, import-warnings.json, brief/BRIEF-*.md) 충돌 발견 시
+hard error로 abort 대신 warning 출력 + 해당 파일 skip + 다른 templates
+sync 계속 진행하도록 동작 격하.
+
+scaffold path (moai init)는 기존 hard error 동작 유지하여 신규 사용자
+혼란 방지. 사용자 데이터는 어떤 경우에도 수정·삭제되지 않음.
+
+변경 사항:
+- internal/cli/design_folder.go: checkReservedCollision에 strict bool
+  파라미터 추가, updateDesignDir 호출을 strict=false로 변경
+- internal/cli/design_folder_test.go: 6 ACs 커버하는 테스트 추가/갱신
+- .claude/rules/moai/design/constitution.md: v3.3.1 amendment, §3.2
+  footnote 추가
+- internal/template/templates/.claude/rules/moai/design/constitution.md:
+  template-first mirror
+
+User-reported bug: ~/MoAI/mo.ai.kr 프로젝트에서 v2.15+ 업데이트 시
+이전 버전에서 정상 생성된 tokens.json이 reserved name 정책 위반으로
+판정되며 moai update 전체가 abort되던 문제 해결.
+
+Refs: SPEC-DESIGN-CONST-AMEND-001 (reserved name 정책 출처)
+Refs: SPEC-DESIGN-001 (scaffoldDesignDir/updateDesignDir 원본)
+
+🗿 MoAI <email@mo.ai.kr>
+```
+
+### 4.2 Branch / PR
+
+- Branch: `fix/SPEC-V3R3-DESIGN-FOLDER-FIX-001` (현재 활성)
+- PR base: `main`
+- Merge strategy: **squash** (CLAUDE.local.md §18.3 — feature/fix → main = squash)
+- Labels: `type:fix`, `priority:P0`, `area:cli`, `area:templates`
+
+---
+
+## 5. Verification Checklist
+
+### 5.1 Pre-Commit
+- [ ] T-01 ~ T-05 RED 상태 확인 후 T-06 시작
+- [ ] T-06 후 모든 design_folder 테스트 GREEN
+- [ ] T-07 두 constitution 파일 byte-identical
+- [ ] T-08 `make build` 성공 + embedded.go 갱신
+- [ ] T-09 모든 quality gate green
+
+### 5.2 Pre-PR
+- [ ] commit message 한국어 body + Conventional Commits
+- [ ] CHANGELOG.md entry 검토 (별도 release SPEC에서 작성 가능)
+- [ ] 사용자 시나리오 수동 재현 완료
+- [ ] 3축 label 부착 (type/priority/area)
+
+### 5.3 Post-Merge
+- [ ] 다음 release (v2.15.x patch 또는 v2.16.0) release note에 fix 명시
+- [ ] User feedback 모니터링 (다음 release cycle)
+
+---
+
+Version: 0.1.0
+Last Updated: 2026-04-26
+Total Tasks: 9
+Estimated Commits: 1 (single squash merge)

--- a/internal/cli/design_folder.go
+++ b/internal/cli/design_folder.go
@@ -61,18 +61,29 @@ func designDirHasRegularFile(dir string) (bool, error) {
 	return false, nil
 }
 
-// checkReservedCollision returns an error if any existing user file in projectRoot/.moai/design/
-// collides with a reserved filename (exact match or glob match).
-func checkReservedCollision(projectRoot string, errOut io.Writer) error {
+// checkReservedCollision 함수는 projectRoot/.moai/design/ 내 사용자 파일이
+// reserved filename(exact match 또는 glob match)과 충돌하는지 검사한다.
+//
+// strict=true (scaffold path): 첫 번째 충돌 발견 시 error 반환 (기존 동작 유지).
+// strict=false (update path): 모든 충돌에 대해 warning 출력 후 nil 반환.
+//   - 사용자 데이터는 어떤 경우에도 수정·삭제되지 않음 (REQ-DFF-004).
+//   - 충돌 파일을 건너뛰고 다른 templates sync는 계속 진행됨 (REQ-DFF-001/002).
+func checkReservedCollision(projectRoot string, errOut io.Writer, strict bool) error {
 	base := filepath.Join(projectRoot, designDir)
 
 	for _, name := range reservedExact {
 		target := filepath.Join(base, name)
 		if _, err := os.Stat(target); err == nil {
-			if errOut != nil {
-				_, _ = fmt.Fprintf(errOut, "error: reserved filename: %s\n", name)
+			if strict {
+				if errOut != nil {
+					_, _ = fmt.Fprintf(errOut, "error: reserved filename: %s\n", name)
+				}
+				return fmt.Errorf("reserved filename: %q collides with reserved name", name)
 			}
-			return fmt.Errorf("reserved filename: %q collides with reserved name", name)
+			// update path: warning 출력 + 계속 진행 (REQ-DFF-001)
+			if errOut != nil {
+				_, _ = fmt.Fprintf(errOut, "warning: reserved filename: %s (preserved; rename to use canonical templates)\n", name)
+			}
 		}
 	}
 
@@ -87,10 +98,16 @@ func checkReservedCollision(projectRoot string, errOut io.Writer) error {
 				return nil
 			}
 			if matched {
-				if errOut != nil {
-					_, _ = fmt.Fprintf(errOut, "error: reserved filename: %s\n", path)
+				if strict {
+					if errOut != nil {
+						_, _ = fmt.Fprintf(errOut, "error: reserved filename: %s\n", path)
+					}
+					return fmt.Errorf("reserved filename: %q matches reserved pattern %q", path, pattern)
 				}
-				return fmt.Errorf("reserved filename: %q matches reserved pattern %q", path, pattern)
+				// update path: warning 출력 + 계속 진행 (REQ-DFF-001)
+				if errOut != nil {
+					_, _ = fmt.Fprintf(errOut, "warning: reserved filename: %s (preserved; rename to use canonical templates)\n", path)
+				}
 			}
 			return nil
 		})
@@ -209,15 +226,18 @@ func scaffoldDesignDir(projectRoot string, warnOut io.Writer) (bool, error) {
 // Rules:
 //   - REQ-005: Files whose on-disk content differs from the canonical template
 //     (SHA-256 mismatch) are treated as user-modified and are NOT overwritten.
-//   - REQ-008: If any user file collides with a reserved filename, the function
-//     returns a non-zero error and writes "reserved filename" to errOut.
+//   - REQ-DFF-001: Reserved filename collisions emit a warning (not an error) so
+//     other template files continue to sync. The reserved file itself is skipped.
+//   - REQ-DFF-004: Reserved files are never modified or deleted.
 //
-// Returns nil on success, error on reserved filename collision or I/O failure.
+// Returns nil on success or on reserved filename collision.
+// Returns error only on I/O failure.
 func updateDesignDir(projectRoot string, errOut io.Writer) error {
 	base := filepath.Join(projectRoot, designDir)
 
-	// REQ-008: Reject reserved filename collisions before touching anything.
-	if err := checkReservedCollision(projectRoot, errOut); err != nil {
+	// REQ-DFF-001: Warn on reserved filename collisions (strict=false) and continue.
+	// updateDesignDir는 scaffold path와 달리 기존 사용자 데이터를 존중하여 warning만 출력.
+	if err := checkReservedCollision(projectRoot, errOut, false); err != nil {
 		return err
 	}
 

--- a/internal/cli/design_folder_test.go
+++ b/internal/cli/design_folder_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -148,9 +149,10 @@ func TestDesignFolderUserEditPreserved(t *testing.T) {
 	}
 }
 
-// TestDesignFolderReservedExact verifies that updateDesignDir rejects a user file
-// that matches a reserved exact name (e.g. tokens.json) (AC-9, REQ-008).
-func TestDesignFolderReservedExact(t *testing.T) {
+// TestDesignFolderUpdate_ReservedExact_WarnsButContinues verifies that updateDesignDir
+// emits a warning (not an error) when a reserved exact-name file exists, preserves
+// the file, and continues syncing other templates (AC-DFF-01, REQ-DFF-001/002/004).
+func TestDesignFolderUpdate_ReservedExact_WarnsButContinues(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
@@ -165,33 +167,68 @@ func TestDesignFolderReservedExact(t *testing.T) {
 		t.Fatalf("scaffold: %v", err)
 	}
 
-	// User creates a file with reserved exact name
-	if err := os.WriteFile(filepath.Join(designDir, "tokens.json"), []byte("{}"), 0o644); err != nil {
+	// User creates a file with reserved exact name (simulates pre-v2.15 generated artifact)
+	tokensContent := []byte(`{"primary": "#ff0000"}`)
+	if err := os.WriteFile(filepath.Join(designDir, "tokens.json"), tokensContent, 0o644); err != nil {
 		t.Fatalf("write tokens.json: %v", err)
 	}
 
-	var errBuf strings.Builder
-	err := updateDesignDir(root, &errBuf)
-	if err == nil {
-		t.Fatal("updateDesignDir should return error for reserved filename")
+	// User modifies README.md to have a custom edit marker
+	readmePath := filepath.Join(designDir, "README.md")
+	origReadme, err := os.ReadFile(readmePath)
+	if err != nil {
+		t.Fatalf("read README.md: %v", err)
 	}
-	if !strings.Contains(err.Error(), "reserved filename") && !strings.Contains(errBuf.String(), "reserved filename") {
-		t.Errorf("error/stderr must contain 'reserved filename', got: err=%v stderr=%q", err, errBuf.String())
+	userEdit := append(origReadme, []byte("\nUSER EDIT MARKER\n")...)
+	if err := os.WriteFile(readmePath, userEdit, 0o644); err != nil {
+		t.Fatalf("write user README edit: %v", err)
 	}
 
-	// tokens.json must remain unchanged
-	content, readErr := os.ReadFile(filepath.Join(designDir, "tokens.json"))
+	var errBuf strings.Builder
+	err = updateDesignDir(root, &errBuf)
+
+	// AC-DFF-01: function must return nil (not error)
+	if err != nil {
+		t.Fatalf("updateDesignDir must return nil for reserved filename in update path, got: %v", err)
+	}
+
+	msg := errBuf.String()
+	// AC-DFF-01: warning must contain "warning" keyword
+	if !strings.Contains(strings.ToLower(msg), "warning") {
+		t.Errorf("errOut must contain 'warning', got: %q", msg)
+	}
+	// AC-DFF-01: warning must mention the filename
+	if !strings.Contains(msg, "tokens.json") {
+		t.Errorf("errOut must mention 'tokens.json', got: %q", msg)
+	}
+	// AC-DFF-01: warning must include preservation guidance
+	if !strings.Contains(strings.ToLower(msg), "preserved") {
+		t.Errorf("errOut must contain 'preserved', got: %q", msg)
+	}
+
+	// AC-DFF-01: tokens.json content must remain unchanged (user data preservation)
+	gotTokens, readErr := os.ReadFile(filepath.Join(designDir, "tokens.json"))
 	if readErr != nil {
 		t.Fatalf("tokens.json must still exist: %v", readErr)
 	}
-	if string(content) != "{}" {
-		t.Errorf("tokens.json content must not be modified, got %q", content)
+	if !bytes.Equal(gotTokens, tokensContent) {
+		t.Errorf("tokens.json content must not be modified, got %q want %q", gotTokens, tokensContent)
+	}
+
+	// AC-DFF-01: user edit in README.md must be preserved (REQ-005 user-edit preservation)
+	afterReadme, readErr := os.ReadFile(readmePath)
+	if readErr != nil {
+		t.Fatalf("README.md must still exist: %v", readErr)
+	}
+	if !strings.Contains(string(afterReadme), "USER EDIT MARKER") {
+		t.Error("README.md user edit must be preserved after updateDesignDir")
 	}
 }
 
-// TestDesignFolderReservedGlob verifies that updateDesignDir rejects a user file
-// matching the brief/BRIEF-*.md glob pattern (AC-9, REQ-008).
-func TestDesignFolderReservedGlob(t *testing.T) {
+// TestDesignFolderUpdate_ReservedGlob_WarnsButContinues verifies that updateDesignDir
+// emits a warning for brief/BRIEF-*.md glob matches, preserves the file, and continues
+// syncing other templates (AC-DFF-02, REQ-DFF-001/002).
+func TestDesignFolderUpdate_ReservedGlob_WarnsButContinues(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
@@ -206,28 +243,59 @@ func TestDesignFolderReservedGlob(t *testing.T) {
 		t.Fatalf("scaffold: %v", err)
 	}
 
-	// User creates a file matching brief/BRIEF-*.md glob
+	// User creates a file matching the brief/BRIEF-*.md glob pattern
 	briefDir := filepath.Join(designDir, "brief")
 	if err := os.MkdirAll(briefDir, 0o755); err != nil {
 		t.Fatalf("mkdir brief: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(briefDir, "BRIEF-LOCAL.md"), []byte("local brief"), 0o644); err != nil {
+	briefContent := []byte("local design brief notes")
+	if err := os.WriteFile(filepath.Join(briefDir, "BRIEF-LOCAL.md"), briefContent, 0o644); err != nil {
 		t.Fatalf("write BRIEF-LOCAL.md: %v", err)
 	}
 
 	var errBuf strings.Builder
 	err := updateDesignDir(root, &errBuf)
-	if err == nil {
-		t.Fatal("updateDesignDir should return error for reserved glob filename")
+
+	// AC-DFF-02: function must return nil
+	if err != nil {
+		t.Fatalf("updateDesignDir must return nil for reserved glob in update path, got: %v", err)
 	}
-	if !strings.Contains(err.Error(), "reserved filename") && !strings.Contains(errBuf.String(), "reserved filename") {
-		t.Errorf("error/stderr must contain 'reserved filename', got: err=%v stderr=%q", err, errBuf.String())
+
+	msg := errBuf.String()
+	// AC-DFF-02: warning keyword present
+	if !strings.Contains(strings.ToLower(msg), "warning") {
+		t.Errorf("errOut must contain 'warning', got: %q", msg)
+	}
+	// AC-DFF-02: mentions the file (BRIEF appears in path)
+	if !strings.Contains(msg, "BRIEF") {
+		t.Errorf("errOut must mention 'BRIEF', got: %q", msg)
+	}
+	// AC-DFF-02: preservation guidance
+	if !strings.Contains(strings.ToLower(msg), "preserved") {
+		t.Errorf("errOut must contain 'preserved', got: %q", msg)
+	}
+
+	// AC-DFF-02: BRIEF-LOCAL.md content must remain unchanged
+	gotBrief, readErr := os.ReadFile(filepath.Join(briefDir, "BRIEF-LOCAL.md"))
+	if readErr != nil {
+		t.Fatalf("BRIEF-LOCAL.md must still exist: %v", readErr)
+	}
+	if !bytes.Equal(gotBrief, briefContent) {
+		t.Errorf("BRIEF-LOCAL.md content must not be modified, got %q want %q", gotBrief, briefContent)
+	}
+
+	// AC-DFF-02: other templates (research.md, system.md, spec.md) must still be accessible
+	for _, name := range []string{"research.md", "system.md", "spec.md"} {
+		if _, statErr := os.Stat(filepath.Join(designDir, name)); os.IsNotExist(statErr) {
+			t.Errorf("template file %s must still be present after reserved glob warning", name)
+		}
 	}
 }
 
-// TestDesignFolderReservedNotModified verifies that on reserved filename error,
-// the existing user file is not modified (AC-9).
-func TestDesignFolderReservedNotModified(t *testing.T) {
+// TestDesignFolderScaffold_ReservedExact_StillErrors verifies that checkReservedCollision
+// in strict mode (strict=true) still returns an error for reserved exact-name files.
+// This simulates the scaffold path behavior (AC-DFF-03, REQ-DFF-003/008).
+func TestDesignFolderScaffold_ReservedExact_StillErrors(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
@@ -236,22 +304,164 @@ func TestDesignFolderReservedNotModified(t *testing.T) {
 		t.Fatalf("mkdir: %v", err)
 	}
 
-	// Place reserved file with known content
-	reservedContent := `{"user": "data"}`
-	if err := os.WriteFile(filepath.Join(designDir, "components.json"), []byte(reservedContent), 0o644); err != nil {
+	// Create a reserved exact-name file
+	tokensContent := []byte(`{"x":1}`)
+	if err := os.WriteFile(filepath.Join(designDir, "tokens.json"), tokensContent, 0o644); err != nil {
+		t.Fatalf("write tokens.json: %v", err)
+	}
+
+	var errBuf strings.Builder
+	// AC-DFF-03: strict=true must return error (scaffold path behavior)
+	err := checkReservedCollision(root, &errBuf, true)
+	if err == nil {
+		t.Fatal("checkReservedCollision(strict=true) must return error for reserved filename")
+	}
+	// Error message must identify the issue
+	if !strings.Contains(err.Error(), "reserved filename") {
+		t.Errorf("error must mention 'reserved filename', got: %v", err)
+	}
+
+	// AC-DFF-03: tokens.json must remain unchanged (user data preservation always honored)
+	gotTokens, readErr := os.ReadFile(filepath.Join(designDir, "tokens.json"))
+	if readErr != nil {
+		t.Fatalf("tokens.json must still exist: %v", readErr)
+	}
+	if !bytes.Equal(gotTokens, tokensContent) {
+		t.Errorf("tokens.json must not be modified, got %q want %q", gotTokens, tokensContent)
+	}
+}
+
+// TestDesignFolderUpdate_WarningIncludesGuidance verifies that the warning message
+// contains all required guidance keywords for the user to understand the issue
+// (AC-DFF-04, REQ-DFF-005/007).
+func TestDesignFolderUpdate_WarningIncludesGuidance(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	designDir := filepath.Join(root, ".moai", "design")
+	if err := os.MkdirAll(designDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	// Create a reserved exact-name file (components.json)
+	if err := os.WriteFile(filepath.Join(designDir, "components.json"), []byte("{}"), 0o644); err != nil {
 		t.Fatalf("write components.json: %v", err)
 	}
 
 	var errBuf strings.Builder
-	_ = updateDesignDir(root, &errBuf)
+	err := updateDesignDir(root, &errBuf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
-	// Content must remain unchanged
-	content, err := os.ReadFile(filepath.Join(designDir, "components.json"))
+	msg := errBuf.String()
+	// AC-DFF-04: all required keywords must be present
+	requiredKeywords := []string{"warning", "components.json", "preserved", "rename"}
+	for _, kw := range requiredKeywords {
+		if !strings.Contains(strings.ToLower(msg), strings.ToLower(kw)) {
+			t.Errorf("warning must contain %q, got: %s", kw, msg)
+		}
+	}
+	// AC-DFF-04: message must not be empty (REQ-DFF-007 no silent failure)
+	if strings.TrimSpace(msg) == "" {
+		t.Error("warning message must not be empty (silent skip is prohibited)")
+	}
+}
+
+// TestDesignFolderUpdate_ReservedNotModified verifies that reserved files are
+// never modified by updateDesignDir — byte-identical preservation required
+// (AC-DFF-05, REQ-DFF-006/004).
+func TestDesignFolderUpdate_ReservedNotModified(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	designDir := filepath.Join(root, ".moai", "design")
+	if err := os.MkdirAll(designDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	// Create two reserved files with known content
+	components := []byte(`{"user": "data"}`)
+	imports := []byte(`{"warning": "test"}`)
+	if err := os.WriteFile(filepath.Join(designDir, "components.json"), components, 0o644); err != nil {
+		t.Fatalf("write components.json: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(designDir, "import-warnings.json"), imports, 0o644); err != nil {
+		t.Fatalf("write import-warnings.json: %v", err)
+	}
+
+	var errBuf strings.Builder
+	// AC-DFF-05: function must return nil
+	if err := updateDesignDir(root, &errBuf); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+
+	// AC-DFF-05: both files must be byte-identical (no modification)
+	got1, err := os.ReadFile(filepath.Join(designDir, "components.json"))
 	if err != nil {
 		t.Fatalf("read components.json: %v", err)
 	}
-	if string(content) != reservedContent {
-		t.Errorf("components.json was modified, got %q want %q", string(content), reservedContent)
+	if !bytes.Equal(got1, components) {
+		t.Error("components.json was modified — must remain byte-identical")
+	}
+
+	got2, err := os.ReadFile(filepath.Join(designDir, "import-warnings.json"))
+	if err != nil {
+		t.Fatalf("read import-warnings.json: %v", err)
+	}
+	if !bytes.Equal(got2, imports) {
+		t.Error("import-warnings.json was modified — must remain byte-identical")
+	}
+}
+
+// TestDesignFolderUpdate_MultipleReservedConflicts verifies that updateDesignDir
+// emits warnings for all reserved files simultaneously, preserves all files, and
+// continues syncing non-reserved templates (AC-DFF-06, REQ-DFF-001/002).
+func TestDesignFolderUpdate_MultipleReservedConflicts(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	designDir := filepath.Join(root, ".moai", "design")
+	briefDir := filepath.Join(designDir, "brief")
+	if err := os.MkdirAll(briefDir, 0o755); err != nil {
+		t.Fatalf("mkdir brief: %v", err)
+	}
+
+	// Create three reserved files simultaneously
+	reservedFiles := map[string][]byte{
+		filepath.Join(designDir, "tokens.json"):     []byte(`{"a":1}`),
+		filepath.Join(briefDir, "BRIEF-X.md"):       []byte("brief X"),
+		filepath.Join(designDir, "components.json"): []byte(`[]`),
+	}
+	for path, content := range reservedFiles {
+		if err := os.WriteFile(path, content, 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+
+	var errBuf strings.Builder
+	// AC-DFF-06: function must return nil despite multiple conflicts
+	if err := updateDesignDir(root, &errBuf); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+
+	msg := errBuf.String()
+	// AC-DFF-06: all three filenames must appear in warnings
+	for _, kw := range []string{"tokens.json", "BRIEF-X", "components.json"} {
+		if !strings.Contains(msg, kw) {
+			t.Errorf("warning must mention %q, got: %s", kw, msg)
+		}
+	}
+
+	// AC-DFF-06: all three files must be byte-identical (preserved)
+	for path, want := range reservedFiles {
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Errorf("%s was modified — must remain byte-identical", path)
+		}
 	}
 }
 

--- a/internal/template/templates/.claude/rules/moai/design/constitution.md
+++ b/internal/template/templates/.claude/rules/moai/design/constitution.md
@@ -2,6 +2,7 @@
 
 ## HISTORY
 
+- 2026-04-26 (SPEC-V3R3-DESIGN-FOLDER-FIX-001): §3.2 footnote 추가 — Reserved name violation은 `moai update` (update path)에서 warning + skip, `moai init` (scaffold path)에서 hard error. v3.3.0 → 3.3.1.
 - 2026-04-20 (SPEC-DESIGN-CONST-AMEND-001): Section 3 expanded to tripartite structure (3.1/3.2/3.3). Version 3.2.0 → 3.3.0 (v3.3.0). FROZEN zone extended to cover each subsection individually.
 - 2026-04-20: Relocated from `.claude/rules/agency/constitution.md` (v3.2.0) to `.claude/rules/moai/design/constitution.md` as part of SPEC-AGENCY-ABSORB-001 M1. Original path: `.claude/rules/agency/constitution.md`. No content changes. FROZEN zone and EVOLVABLE zone definitions are preserved verbatim.
 
@@ -76,6 +77,8 @@ Iteration-specific design briefs are stored in `.moai/design/`:
 - [HARD] Reserved file paths (canonical list): `tokens.json`, `components.json`, `assets/`, `import-warnings.json`, `brief/BRIEF-*.md`
 - [HARD] Token budget for auto-loading is bounded by `.moai/config/sections/design.yaml` `design_docs.token_budget`; when the key is absent, the system MUST default to 20000
 - [HARD] Priority order when truncation is needed: spec.md > system.md > research.md > pencil-plan.md
+
+> **Note (SPEC-V3R3-DESIGN-FOLDER-FIX-001):** Reserved name violations during `moai update` (update path) are reported as warnings; the user file is preserved and other templates continue to sync. During `moai init` / scaffold path, reserved name collisions remain hard errors. User data is never modified or deleted in either case.
 
 ### 3.3 Relationship
 
@@ -396,9 +399,9 @@ If a graduated learning causes regression:
 
 ---
 
-Version: 3.3.0
+Version: 3.3.1
 Classification: FROZEN_AMENDMENT
 Original Source: agency/constitution.md v3.2.0
-Last Updated: 2026-04-20
+Last Updated: 2026-04-26
 Relocated: 2026-04-20 (SPEC-AGENCY-ABSORB-001 M1)
 REQ coverage: REQ-CONST-001, REQ-CONST-002, REQ-CONST-003, REQ-CONST-004


### PR DESCRIPTION
## Summary

이전 버전(<v2.15)에서 정상 생성된 `.moai/design/tokens.json`이 v2.15+ design constitution §3.2 reserved file paths 정책과 충돌하여 `moai update` 전체가 실패하던 버그 수정.

## Bug Reproduction (사용자 보고)

```bash
$ moai update
Current version: moai-adk v2.15.0
✓ Template version up-to-date. Skipping sync.
error: reserved filename: tokens.json
  Error: .moai/design/ update: reserved filename: "tokens.json" collides with reserved name
Error: reserved filename: "tokens.json" collides with reserved name
```

이전 버전 design import 워크플로우 산출물이 v2.15+ 정책과 충돌 → update 전체 abort.

## 변경 사항

- `internal/cli/design_folder.go`:
  - `checkReservedCollision`에 `strict bool` 파라미터 추가
  - `updateDesignDir`: `strict=false` 호출 → warning + skip + 다른 templates sync 진행
  - `scaffoldDesignDir` 호출 path: `strict=true` 그대로 (신규 프로젝트는 여전히 hard error)
- `internal/cli/design_folder_test.go`: 기존 5개 테스트 갱신 + 신규 6개 AC 테스트 추가 (총 11개 테스트)
- `.claude/rules/moai/design/constitution.md` v3.3.1: HISTORY entry + §3.2 footnote 추가
- `internal/template/templates/.claude/rules/moai/design/constitution.md`: 미러 동기화

## 핵심 원칙

- moai update의 약속: **사용자 파일 보존**. reserved 충돌 발견해도 파일 자체는 보존하고 다른 정상 sync는 계속 진행
- moai init/scaffold (신규 프로젝트): reserved name 충돌은 여전히 hard error (REQ-008 보존)

## Test Plan

- [x] `go test ./internal/cli/ -run TestDesignFolder -v -race` — 11/11 PASS
- [x] `go test ./...` — 회귀 없음
- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./internal/cli/` — 0 issues
- [x] Template-First: constitution.md 양쪽 sync + `make build`

## Manual Verification

```bash
# 사용자 워크플로우 재현
mkdir /tmp/test-update && cd /tmp/test-update
moai init test-project && cd test-project
echo '{"colors": {}}' > .moai/design/tokens.json   # 이전 버전에서 만든 reserved 파일 시뮬레이션
moai update                                          # ★ FAIL → ★ PASS (warning + 다른 파일 sync 정상)
```

## SPEC

- `SPEC-V3R3-DESIGN-FOLDER-FIX-001` — 8 REQs / 6 ACs / AC-REQ matrix 100%
- depends_on: [] (독립적 bug fix)

## Related

- 사용자 보고: ~/MoAI/mo.ai.kr `moai update` 실패
- design constitution §3.2 (v3.3.1로 amendment)
- v2.15.0 신설된 reserved file paths 정책

🗿 MoAI <email@mo.ai.kr>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reserved filename collisions during update now emit warnings and skip the conflicting files while continuing to sync others; user files are preserved unchanged.

* **Documentation**
  * Added and updated specification, plan, acceptance, tasks, and constitution notes documenting update vs init/scaffold collision behavior and version bumped to 3.3.1.

* **Tests**
  * Strengthened tests to verify warning content, byte-identical preservation, multi-conflict warnings, and strict scaffold/init error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->