### PR TITLE
chore(lint): audit_runtime errcheck + staticcheck cleanup (precursor for v2.16.0)

### DIFF
--- a/internal/runtime/audit_cache.go
+++ b/internal/runtime/audit_cache.go
@@ -102,7 +102,8 @@ func (c *InMemoryCache) ComputeHash(specDir string) (string, error) {
 		// Whitespace normalization: collapse runs of whitespace to a single space.
 		normalized := normalizeWhitespace(string(data))
 		// Include filename as separator to prevent hash collisions between files.
-		fmt.Fprintf(h, "%s:%s\n", name, normalized)
+		// hash.Hash.Write never errors per io.Writer contract, so the return value is intentionally discarded.
+		_, _ = fmt.Fprintf(h, "%s:%s\n", name, normalized)
 	}
 
 	return fmt.Sprintf("%x", h.Sum(nil)), nil

--- a/internal/runtime/audit_report.go
+++ b/internal/runtime/audit_report.go
@@ -99,44 +99,44 @@ func (r *FileAuditReporter) AppendRun(specID string, result *AuditResult) error 
 	}
 
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("\n## Audit Run %d\n\n", runNum))
-	sb.WriteString(fmt.Sprintf("- verdict: %s\n", result.Verdict))
+	fmt.Fprintf(&sb, "\n## Audit Run %d\n\n", runNum)
+	fmt.Fprintf(&sb, "- verdict: %s\n", result.Verdict)
 
 	if result.ReportPath != "" {
-		sb.WriteString(fmt.Sprintf("- report_path: %s\n", result.ReportPath))
+		fmt.Fprintf(&sb, "- report_path: %s\n", result.ReportPath)
 	}
 
-	sb.WriteString(fmt.Sprintf("- audit_at: %s\n", result.AuditAt.UTC().Format(time.RFC3339)))
-	sb.WriteString(fmt.Sprintf("- run_trigger: %s\n", trigger))
+	fmt.Fprintf(&sb, "- audit_at: %s\n", result.AuditAt.UTC().Format(time.RFC3339))
+	fmt.Fprintf(&sb, "- run_trigger: %s\n", trigger)
 
 	if result.AuditorVersion != "" {
-		sb.WriteString(fmt.Sprintf("- auditor_version: %s\n", result.AuditorVersion))
+		fmt.Fprintf(&sb, "- auditor_version: %s\n", result.AuditorVersion)
 	}
 
 	if result.CacheHit {
-		sb.WriteString(fmt.Sprintf("- cache_hit: true\n"))
-		sb.WriteString(fmt.Sprintf("- cached_audit_at: %s\n", result.CachedAuditAt.UTC().Format(time.RFC3339)))
+		sb.WriteString("- cache_hit: true\n")
+		fmt.Fprintf(&sb, "- cached_audit_at: %s\n", result.CachedAuditAt.UTC().Format(time.RFC3339))
 	}
 
 	if result.Verdict == VerdictBypassed {
-		sb.WriteString(fmt.Sprintf("- bypass_user: %s\n", result.BypassUser))
-		sb.WriteString(fmt.Sprintf("- bypass_reason: %q\n", bypassReason))
+		fmt.Fprintf(&sb, "- bypass_user: %s\n", result.BypassUser)
+		fmt.Fprintf(&sb, "- bypass_reason: %q\n", bypassReason)
 	}
 
 	if result.InconclusiveAcknowledgedBy != "" {
-		sb.WriteString(fmt.Sprintf("- inconclusive_acknowledged_by: %s\n", result.InconclusiveAcknowledgedBy))
+		fmt.Fprintf(&sb, "- inconclusive_acknowledged_by: %s\n", result.InconclusiveAcknowledgedBy)
 	}
 
 	if result.GraceWindowActive {
-		sb.WriteString(fmt.Sprintf("- grace_window_active: true\n"))
-		sb.WriteString(fmt.Sprintf("- grace_window_remaining_days: %d\n", result.GraceWindowRemainingDays))
+		sb.WriteString("- grace_window_active: true\n")
+		fmt.Fprintf(&sb, "- grace_window_remaining_days: %d\n", result.GraceWindowRemainingDays)
 	}
 
 	f, err := os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
 		return fmt.Errorf("open report file %q: %w", filePath, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	if _, err := f.WriteString(sb.String()); err != nil {
 		return fmt.Errorf("write report: %w", err)
@@ -205,25 +205,25 @@ type ProgressEntry struct {
 // REQ-WAG-003, AC-WAG-03
 func AppendToProgress(progressPath string, result *AuditResult) error {
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("- audit_verdict: %s\n", result.Verdict))
-	sb.WriteString(fmt.Sprintf("- audit_report: %s\n", result.ReportPath))
-	sb.WriteString(fmt.Sprintf("- audit_at: %s\n", result.AuditAt.UTC().Format(time.RFC3339)))
-	sb.WriteString(fmt.Sprintf("- auditor_version: %s\n", result.AuditorVersion))
+	fmt.Fprintf(&sb, "- audit_verdict: %s\n", result.Verdict)
+	fmt.Fprintf(&sb, "- audit_report: %s\n", result.ReportPath)
+	fmt.Fprintf(&sb, "- audit_at: %s\n", result.AuditAt.UTC().Format(time.RFC3339))
+	fmt.Fprintf(&sb, "- auditor_version: %s\n", result.AuditorVersion)
 
 	if result.CacheHit {
 		sb.WriteString("- audit_cache_hit: true\n")
-		sb.WriteString(fmt.Sprintf("- cached_audit_at: %s\n", result.CachedAuditAt.UTC().Format(time.RFC3339)))
+		fmt.Fprintf(&sb, "- cached_audit_at: %s\n", result.CachedAuditAt.UTC().Format(time.RFC3339))
 	}
 
 	if result.InconclusiveAcknowledgedBy != "" {
-		sb.WriteString(fmt.Sprintf("- inconclusive_acknowledged_by: %s\n", result.InconclusiveAcknowledgedBy))
+		fmt.Fprintf(&sb, "- inconclusive_acknowledged_by: %s\n", result.InconclusiveAcknowledgedBy)
 	}
 
 	f, err := os.OpenFile(progressPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
 		return fmt.Errorf("open progress.md %q: %w", progressPath, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	if _, err := f.WriteString(sb.String()); err != nil {
 		return fmt.Errorf("write progress.md: %w", err)


### PR DESCRIPTION
## Summary

V3R2 restore (PR #713)에서 main에 유입된 lint 이슈를 v2.16.0 release (PR #715) 이전에 main에 미리 적용. 진행 중 PR (#716/#717/#718)의 Lint job이 main rebase 후 자동 통과하도록 함.

## 변경 사항

`release/v2.16.0` 브랜치의 commit `f3b8fa378`의 audit_*.go 부분만 추출:

- `internal/runtime/audit_cache.go`: `hash.Hash.Write` 반환값 명시적 무시 (`_, _ =`)
- `internal/runtime/audit_report.go`:
  - 11건 staticcheck QF1012 (`WriteString+fmt.Sprintf` → `fmt.Fprintf` 변환)
  - 2건 staticcheck S1039 (정적 문자열 `fmt.Sprintf` 제거)
  - 2건 errcheck (`defer f.Close()` → `defer func(){ _ = f.Close() }()`)

다른 변경 (PostToolUse async, hooks-system.md, settings, CHANGELOG)은 본 PR에서 제외 — release/v2.16.0 머지 시 함께 들어옴.

## Conflict-free Merge Guarantee

- PR #715 (release/v2.16.0) 머지 시 동일 변경 내용 → no-op merge (GitHub 자동 처리)
- 본 PR이 main에 머지되면 release branch와 main의 audit_*.go 파일은 byte-identical

## Test Plan

- [x] `go vet ./internal/runtime/...` — clean
- [x] `golangci-lint run ./internal/runtime/...` — 0 issues
- [x] `go test ./internal/runtime/` — PASS
- [x] CI Lint job — pass 예상

## Impact (다른 PR 자동 해소)

- PR #716 (LEARNING-001): main rebase 시 Lint job 자동 통과
- PR #717 (Wave 2 SPECs): 동일
- PR #718 (design-folder fix): 동일

## Related

- Refs: PR #715 (release/v2.16.0) commit `f3b8fa378`
- 진행 중 PR Lint failure 해소

🗿 MoAI <email@mo.ai.kr>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements to error handling and string formatting patterns.

* **No user-facing changes** — This release contains only internal code quality enhancements with no impact to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->