### PR TITLE
chore(lang,mx): code_comments en + Wave 1+2 영어화 + @MX:ANCHOR (rebased)

### DIFF
--- a/.moai/config/sections/language.yaml
+++ b/.moai/config/sections/language.yaml
@@ -3,6 +3,6 @@ language:
     conversation_language_name: ko
     agent_prompt_language: en
     git_commit_messages: ko
-    code_comments: ko
+    code_comments: en
     documentation: ko
     error_messages: en

--- a/.moai/release/v3r3-extreme-aggressive-handoff.md
+++ b/.moai/release/v3r3-extreme-aggressive-handoff.md
@@ -671,6 +671,76 @@ moai-adk = workflow framework (22 base skills) + meta-harness (∞ generated)
 ---
 
 **Status**: Ready for next session
-**Last Updated**: 2026-04-26
+**Last Updated**: 2026-04-27
 **Author**: MoAI Orchestrator (Claude Opus 4.7)
 **Reviewed**: User decision integrated (6 decisions confirmed)
+
+---
+
+## 9. 진행 상태 갱신 (2026-04-27 세션 종료 시점)
+
+### 머지된 PR (main HEAD: e65005650)
+
+- **PR #714** (b47101779): V3R2 CON-001 + EXT-001 restore
+- **PR #719** (a14ecfab5): chore(lint) audit_runtime cleanup precursor
+- **PR #718** (e65005650): SPEC-V3R3-DESIGN-FOLDER-FIX-001 reserved collision update path warning 격하
+
+### Open PRs (사용자 admin merge 대기)
+
+- **PR #715**: release/v2.16.0 — Pattern Cookbook + V3R2 restore + Phase A 통합
+  - Windows pre-existing FAIL (#714 머지 패턴과 동일)
+  - merge 전략: `--merge` (release branch)
+- **PR #716**: SPEC-V3R3-HARNESS-LEARNING-001 (Self-Learning Dynamic Harness)
+  - merge 전략: `--squash`
+- **PR #717**: Wave 2 SPECs — HARNESS-001 + DESIGN-PIPELINE-001 + PROJECT-HARNESS-001
+  - 3 SPECs 통합 (34 REQs / 22 ACs / AC-REQ 100%)
+  - merge 전략: `--squash`
+- **PR #720**: chore(lang,mx) — code_comments en + 영어화 Wave 1+2 + @MX:ANCHOR
+  - Wave 1+2 통합 (113 files / +2700/-2670)
+  - 잔존 한국어 3 files (i18n DATA 보존)
+  - CI: Lint/Tests/Builds/CodeQL all PASS, Windows pending
+  - merge 전략: `--squash`
+
+### 권장 머지 순서 (Enhanced GitHub Flow §18.3)
+
+```bash
+# 1. lang/mx (urgent — code_comments 정책 정상화)
+gh pr merge 720 --squash --delete-branch --admin
+
+# 2. SPEC documents (no code, low risk)
+gh pr merge 717 --squash --delete-branch --admin   # Wave 2 SPECs
+gh pr merge 716 --squash --delete-branch --admin   # LEARNING-001
+
+# 3. Release v2.16.0 (merge commit, 마지막)
+gh pr merge 715 --merge --delete-branch --admin
+git checkout main && git pull
+./scripts/release.sh v2.16.0
+```
+
+### v2.17 Implementation 다음 단계 (PR 머지 후)
+
+1. **SPEC-V3R3-HARNESS-001** 구현 (BREAKING, BC-V3R3-007)
+   - meta-harness skill 신설 (revfactory/harness Apache 2.0 흡수)
+   - 16 정적 skills 제거 (domain-{backend,frontend,...} 외 11)
+   - Static/Dynamic namespace 분리 (moai-* / my-harness-*)
+   - moai update 마이그레이터 확장
+2. **SPEC-V3R3-DESIGN-PIPELINE-001** (DTCG 2025.10 + Path A/B1/B2)
+3. **SPEC-V3R3-PROJECT-HARNESS-001** (16Q 인터뷰 + 5-Layer 통합)
+4. **SPEC-V3R3-HARNESS-LEARNING-001** (Self-Learning Dynamic Harness)
+
+manager-tdd 순차 dispatch (depends_on chain 따라). 각 SPEC 4 files (spec/plan/acceptance/tasks)에 implementation 매핑.
+
+### Applied Lessons (이번 세션)
+
+- `feedback_large_spec_wave_split.md` — Wave 2 SPEC 3-way 병렬 dispatch 성공 (각 ~1.5KB)
+- `lessons.md #9` (NEW) — Agent 1M context limit + wave 분할 패턴 (Korean→English 영어화)
+- §18.10 enforcement: main 직접 push 금지 → chore PR 경유 (#719, #720)
+- Auto mode + interrupt 처리: 사용자 결정 명확화 + mixed state 정리
+
+### Verification 시점 (2026-04-27)
+
+- [x] PR #715/716/717: ci_pass 14, Windows pre-existing FAIL
+- [x] PR #720: ci_pass 15, Windows still running
+- [x] main HEAD: e65005650
+- [x] 잔존 한국어 3 files (false positive — i18n DATA / English with Korean references)
+

--- a/internal/astgrep/models.go
+++ b/internal/astgrep/models.go
@@ -76,10 +76,10 @@ type Rule struct {
 	Message  string            `json:"message" yaml:"message"`
 	Pattern  string            `json:"pattern" yaml:"pattern"`
 	Fix      string            `json:"fix,omitempty" yaml:"fix,omitempty"`
-	// Note는 규칙의 교육적 설명입니다. 발견 시 Finding.Note에 전파됩니다.
+	// Note is the educational description of the rule. Propagated to Finding.Note on match.
 	// REQ-UTIL-002-001
 	Note     string            `json:"note,omitempty" yaml:"note,omitempty"`
-	// Metadata는 CWE/OWASP 등 분류 메타데이터입니다. 발견 시 Finding.Metadata에 전파됩니다.
+	// Metadata is classification metadata such as CWE/OWASP. Propagated to Finding.Metadata on match.
 	// REQ-UTIL-002-002
 	Metadata map[string]string `json:"metadata,omitempty" yaml:"metadata,omitempty"`
 }

--- a/internal/astgrep/rules.go
+++ b/internal/astgrep/rules.go
@@ -138,19 +138,21 @@ func (l *RuleLoader) LoadFromDir(dir string) ([]Rule, error) {
 	return allRules, nil
 }
 
-// loadFileSkipOnError는 단일 YAML 파일에서 규칙을 로딩합니다.
-// 멀티 문서 YAML에서 특정 문서 파싱이 실패해도 이후 문서를 계속 로딩합니다 (F5 fix).
+// loadFileSkipOnError loads rules from a single YAML file.
+// Parsing failures in individual documents of a multi-document YAML do not
+// prevent subsequent documents from being loaded (F5 fix).
 //
-// yaml.v3 Decoder는 파싱 실패 후 상태를 복구하지 않으므로, 파일을 "---" 구분자로
-// 분리하여 각 문서를 독립적으로 파싱하는 방식을 사용합니다.
+// Because yaml.v3 Decoder does not recover state after a parse error,
+// the file is split on the "---" separator and each document is parsed
+// independently for failure isolation.
 func (l *RuleLoader) loadFileSkipOnError(path string) ([]Rule, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("opening rule file %s: %w", path, err)
 	}
 
-	// "---" 구분자로 문서 분리 (멀티 문서 YAML 지원)
-	// 각 문서를 개별적으로 파싱하여 파싱 실패 격리
+	// Split documents on the "---" separator (multi-document YAML support).
+	// Each document is parsed independently to isolate parsing failures.
 	docs := splitYAMLDocs(data)
 
 	var rules []Rule
@@ -165,7 +167,7 @@ func (l *RuleLoader) loadFileSkipOnError(path string) ([]Rule, error) {
 		var rule Rule
 		if err := yaml.Unmarshal(trimmed, &rule); err != nil {
 			parseErrors++
-			slog.Warn("규칙 파일 문서 파싱 실패, 다음 문서로 진행",
+			slog.Warn("rule file document parse failed, advancing to next document",
 				"path", path, "doc_index", i, "error", err)
 			continue
 		}
@@ -176,19 +178,19 @@ func (l *RuleLoader) loadFileSkipOnError(path string) ([]Rule, error) {
 	}
 
 	if parseErrors > 0 {
-		slog.Warn("규칙 파일에서 파싱 오류 발생",
+		slog.Warn("parse errors encountered in rule file",
 			"path", path, "valid_rules", len(rules), "parse_errors", parseErrors)
 	}
 
 	return rules, nil
 }
 
-// splitYAMLDocs는 YAML 멀티 문서 데이터를 "---" 구분자로 분리합니다.
-// 각 문서를 개별 파싱을 위한 독립적인 바이트 슬라이스로 반환합니다.
+// splitYAMLDocs splits YAML multi-document data on the "---" separator.
+// Returns each document as an independent byte slice for individual parsing.
 func splitYAMLDocs(data []byte) [][]byte {
 	var docs [][]byte
-	// \n--- 또는 파일 시작 --- 로 분리
-	// bytes.Split은 정확히 "---"만 있는 행을 기준으로 분리
+	// Split on \n--- or a leading --- at the start of the file.
+	// bytes.Split separates on lines that contain exactly "---".
 	lines := bytes.Split(data, []byte("\n"))
 	var current [][]byte
 	for _, line := range lines {

--- a/internal/astgrep/rules_test.go
+++ b/internal/astgrep/rules_test.go
@@ -189,15 +189,16 @@ func TestRules_ReturnsCopy(t *testing.T) {
 	}
 }
 
-// --- F5 재현 테스트: YAML parse error silent break ---
+// --- F5 regression test: YAML parse error silent break ---
 
-// TestLoadFromDir_ContinuesAfterMalformedDocument: 멀티 문서 YAML에서 중간에 잘못된 문서가 있어도
-// 이후 유효한 문서를 계속 로딩하는지 검증한다.
+// TestLoadFromDir_ContinuesAfterMalformedDocument: verifies that even when a malformed
+// document appears in the middle of a multi-document YAML, subsequent valid documents
+// continue to be loaded.
 func TestLoadFromDir_ContinuesAfterMalformedDocument(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	// doc1: 유효, doc2: 잘못된 YAML, doc3: 유효
-	// yaml.v3 디코더는 문서 간 경계를 --- 로 구분한다.
+	// doc1: valid, doc2: malformed YAML, doc3: valid
+	// yaml.v3 decoder separates documents with ---.
 	multiDocYAML := `---
 id: rule-first
 language: go
@@ -214,26 +215,26 @@ message: "세 번째 규칙"
 pattern: "eval($CODE)"
 `
 	if err := os.WriteFile(filepath.Join(tmpDir, "mixed.yml"), []byte(multiDocYAML), 0o644); err != nil {
-		t.Fatalf("파일 작성 실패: %v", err)
+		t.Fatalf("failed to write file: %v", err)
 	}
 
 	loader := NewRuleLoader()
 	rules, err := loader.LoadFromDir(tmpDir)
-	// 에러는 반환하지 않아야 함 (partial success)
+	// must not return an error (partial success)
 	if err != nil {
-		t.Fatalf("LoadFromDir() error = %v; 잘못된 문서가 있어도 에러를 반환하면 안 됨", err)
+		t.Fatalf("LoadFromDir() error = %v; must not return error even with malformed documents", err)
 	}
 
-	// rule-first와 rule-third 모두 로딩되어야 함 (F5 fix 이후)
+	// both rule-first and rule-third must be loaded (after F5 fix)
 	ids := make(map[string]bool)
 	for _, r := range rules {
 		ids[r.ID] = true
 	}
 
 	if !ids["rule-first"] {
-		t.Error("rule-first가 로딩되지 않음 — 첫 번째 유효한 문서가 누락됨")
+		t.Error("rule-first not loaded — first valid document is missing")
 	}
 	if !ids["rule-third"] {
-		t.Error("rule-third가 로딩되지 않음 — 잘못된 문서 이후의 유효한 문서가 누락됨 (F5 버그)")
+		t.Error("rule-third not loaded — valid document after malformed one is missing (F5 bug)")
 	}
 }

--- a/internal/astgrep/sarif.go
+++ b/internal/astgrep/sarif.go
@@ -8,10 +8,10 @@ import (
 	"unicode"
 )
 
-// SARIF 2.1.0 스키마 URL
+// sarifSchema is the SARIF 2.1.0 schema URL.
 const sarifSchema = "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json"
 
-// sarifDocument는 SARIF 2.1.0 최상위 문서입니다.
+// sarifDocument is the SARIF 2.1.0 top-level document.
 // https://docs.oasis-open.org/sarif/sarif/v2.1.0/
 type sarifDocument struct {
 	Schema  string     `json:"$schema"`
@@ -19,65 +19,65 @@ type sarifDocument struct {
 	Runs    []sarifRun `json:"runs"`
 }
 
-// sarifRun은 단일 도구 실행 결과입니다.
+// sarifRun is the result of a single tool execution.
 type sarifRun struct {
 	Tool    sarifTool     `json:"tool"`
 	Results []sarifResult `json:"results"`
 }
 
-// sarifTool은 스캔 도구 정보입니다.
+// sarifTool holds scan tool information.
 type sarifTool struct {
 	Driver sarifDriver `json:"driver"`
 }
 
-// sarifDriver는 도구 드라이버 메타데이터입니다.
+// sarifDriver holds tool driver metadata.
 type sarifDriver struct {
 	Name    string       `json:"name"`
 	Version string       `json:"version"`
 	Rules   []sarifRule  `json:"rules,omitempty"`
 }
 
-// sarifRule은 SARIF 규칙 정의입니다.
+// sarifRule is a SARIF rule definition.
 type sarifRule struct {
 	ID               string            `json:"id"`
 	ShortDescription *sarifMessage     `json:"shortDescription,omitempty"`
 	Properties       map[string]string `json:"properties,omitempty"`
 }
 
-// sarifResult는 단일 발견 결과입니다.
+// sarifResult is a single finding result.
 type sarifResult struct {
 	RuleID     string           `json:"ruleId"`
 	Level      string           `json:"level"`
 	Message    sarifMessage     `json:"message"`
 	Locations  []sarifLocation  `json:"locations"`
-	// Properties는 SARIF 2.1.0 §3.52 property bag입니다.
-	// map[string]any 를 사용하여 기존 string 값과 tags []string을 함께 수용합니다.
-	// REQ-UTIL-002-005/006: owasp/cwe 키가 있으면 external/owasp/* external/cwe/* 태그를 tags에 추가합니다.
+	// Properties is a SARIF 2.1.0 §3.52 property bag.
+	// Uses map[string]any to accommodate both existing string values and tags []string.
+	// REQ-UTIL-002-005/006: when owasp/cwe keys are present, external/owasp/* and external/cwe/* tags are appended to tags.
 	Properties map[string]any `json:"properties,omitempty"`
 }
 
-// sarifMessage는 SARIF 메시지 텍스트입니다.
+// sarifMessage is the SARIF message text.
 type sarifMessage struct {
 	Text string `json:"text"`
 }
 
-// sarifLocation은 코드 위치 정보입니다.
+// sarifLocation holds code location information.
 type sarifLocation struct {
 	PhysicalLocation sarifPhysicalLocation `json:"physicalLocation"`
 }
 
-// sarifPhysicalLocation은 파일 및 영역 정보입니다.
+// sarifPhysicalLocation holds file and region information.
 type sarifPhysicalLocation struct {
 	ArtifactLocation sarifArtifactLocation `json:"artifactLocation"`
 	Region           sarifRegion           `json:"region"`
 }
 
-// sarifArtifactLocation은 파일 URI입니다.
+// sarifArtifactLocation is the file URI.
 type sarifArtifactLocation struct {
 	URI string `json:"uri"`
 }
 
-// sarifRegion은 코드 영역(줄/컬럼)입니다.
+// sarifRegion is the code region (line/column).
 type sarifRegion struct {
 	StartLine   int `json:"startLine"`
 	StartColumn int `json:"startColumn,omitempty"`
@@ -85,17 +85,17 @@ type sarifRegion struct {
 	EndColumn   int `json:"endColumn,omitempty"`
 }
 
-// ToSARIF는 Finding 슬라이스를 SARIF 2.1.0 형식의 JSON으로 변환합니다.
-// REQ-ASTG-UPG-022: SARIF 2.1.0 출력 지원
+// ToSARIF converts a slice of Findings to SARIF 2.1.0 JSON format.
+// REQ-ASTG-UPG-022: SARIF 2.1.0 output support
 //
-// sgVersion은 ast-grep CLI 버전 문자열입니다 (tool.driver.version에 반영).
-// findings가 nil이면 빈 results 배열을 포함한 유효한 SARIF 문서를 반환합니다.
+// sgVersion is the ast-grep CLI version string (reflected in tool.driver.version).
+// When findings is nil, a valid SARIF document with an empty results array is returned.
 func ToSARIF(findings []Finding, sgVersion string) ([]byte, error) {
 	if sgVersion == "" {
 		sgVersion = "unknown"
 	}
 
-	// 규칙 목록 수집 (dedup)
+	// Collect rule list (dedup)
 	ruleSet := make(map[string]sarifRule)
 	for _, f := range findings {
 		if f.RuleID == "" {
@@ -113,10 +113,10 @@ func ToSARIF(findings []Finding, sgVersion string) ([]byte, error) {
 		}
 	}
 
-	// @MX:NOTE: rule ID 기준 오름차순 정렬로 결정적 출력 보장.
-	// Go map 반복 순서가 불확정적이어서 SARIF 출력이 실행마다 달라지면
-	// (1) Snapshot 테스트 불가 (2) GitHub Code Scanning diff 노이즈
-	// (3) CI 재현성 저하 문제가 발생하므로 정렬이 필수. (issue #644)
+	// @MX:NOTE: Sort ascending by rule ID to guarantee deterministic output.
+	// Go map iteration order is non-deterministic, so without sorting the SARIF output
+	// differs between runs: (1) snapshot tests become impossible, (2) GitHub Code Scanning
+	// diffs become noisy, (3) CI reproducibility degrades. Sorting is mandatory. (issue #644)
 	rules := make([]sarifRule, 0, len(ruleSet))
 	for _, r := range ruleSet {
 		rules = append(rules, r)
@@ -125,7 +125,7 @@ func ToSARIF(findings []Finding, sgVersion string) ([]byte, error) {
 		return rules[i].ID < rules[j].ID
 	})
 
-	// results 변환
+	// Convert to results
 	results := make([]sarifResult, 0, len(findings))
 	for _, f := range findings {
 		result := sarifResult{
@@ -149,14 +149,14 @@ func ToSARIF(findings []Finding, sgVersion string) ([]byte, error) {
 			},
 		}
 
-		// 메타데이터를 SARIF properties로 전달 + OWASP/CWE 태그 추가
-		// REQ-UTIL-002-005/006: Metadata에 owasp/cwe 키가 있으면 external/* 태그를 추가합니다.
+		// Pass metadata as SARIF properties and append OWASP/CWE tags.
+		// REQ-UTIL-002-005/006: when owasp/cwe keys are present in Metadata, external/* tags are added.
 		if len(f.Metadata) > 0 {
 			props := make(map[string]any, len(f.Metadata)+1)
 			for k, v := range f.Metadata {
-				props[k] = v // 기존 string 값 보존 (backward compat)
+				props[k] = v // preserve existing string values (backward compat)
 			}
-			// SARIF 2.1.0 §3.52: tags 배열에 external/owasp/* 및 external/cwe/* 항목 추가
+			// SARIF 2.1.0 §3.52: append external/owasp/* and external/cwe/* entries to tags array
 			var tags []string
 			if v, ok := f.Metadata["owasp"]; ok && v != "" {
 				tags = append(tags, "external/owasp/"+sanitizeTagValue(v))
@@ -192,15 +192,15 @@ func ToSARIF(findings []Finding, sgVersion string) ([]byte, error) {
 
 	output, err := json.MarshalIndent(doc, "", "  ")
 	if err != nil {
-		return nil, fmt.Errorf("SARIF 직렬화: %w", err)
+		return nil, fmt.Errorf("SARIF serialization: %w", err)
 	}
 
 	return output, nil
 }
 
-// severityToSARIFLevel은 ast-grep severity를 SARIF level로 변환합니다.
-// SARIF 2.1.0 지원 level: "error", "warning", "note", "none"
-// REQ-ASTG-UPG-022: severity 매핑 (error→error, warning→warning, info→note)
+// severityToSARIFLevel converts an ast-grep severity to a SARIF level.
+// Supported SARIF 2.1.0 levels: "error", "warning", "note", "none"
+// REQ-ASTG-UPG-022: severity mapping (error→error, warning→warning, info→note)
 func severityToSARIFLevel(severity string) string {
 	switch strings.ToLower(severity) {
 	case "error":
@@ -208,24 +208,24 @@ func severityToSARIFLevel(severity string) string {
 	case "warning", "warn":
 		return "warning"
 	default:
-		return "note" // info, hint, "" 모두 note로 매핑
+		return "note" // info, hint, and "" all map to note
 	}
 }
 
-// toFileURI는 파일 경로를 SARIF URI 형식으로 변환합니다.
-// 절대 경로는 file:// 스킴을 붙이지 않고 상대 경로를 그대로 사용합니다.
+// toFileURI converts a file path to the SARIF URI format.
+// Absolute paths are used as-is without adding the file:// scheme.
 func toFileURI(path string) string {
 	if path == "" {
 		return ""
 	}
-	// 이미 URI 형식이면 그대로 반환
+	// Already in URI format — return as-is.
 	if strings.HasPrefix(path, "file://") {
 		return path
 	}
 	return path
 }
 
-// maxInt는 두 정수 중 큰 값을 반환합니다.
+// maxInt returns the larger of two integers.
 func maxInt(a, b int) int {
 	if a > b {
 		return a
@@ -233,14 +233,14 @@ func maxInt(a, b int) int {
 	return b
 }
 
-// sanitizeTagValue는 OWASP/CWE 메타데이터 값을 SARIF tags 항목에 안전한 형태로 변환합니다.
-// 변환 규칙:
-//  1. 소문자 변환
-//  2. 알파벳/숫자 이외의 문자 → 하이픈 치환
-//  3. 연속 하이픈 → 단일 하이픈 축소
-//  4. 선두/말미 하이픈 제거
+// sanitizeTagValue converts an OWASP/CWE metadata value into a form safe
+// for use as a SARIF tags entry. Transformation rules:
+//  1. Convert to lowercase
+//  2. Replace non-alphanumeric characters with hyphens
+//  3. Collapse consecutive hyphens to a single hyphen
+//  4. Strip leading and trailing hyphens
 //
-// 예시: "A03:2021 - Injection" → "a03-2021-injection", "CWE-89" → "cwe-89"
+// Examples: "A03:2021 - Injection" → "a03-2021-injection", "CWE-89" → "cwe-89"
 func sanitizeTagValue(s string) string {
 	var b strings.Builder
 	b.Grow(len(s))
@@ -251,7 +251,7 @@ func sanitizeTagValue(s string) string {
 			b.WriteByte('-')
 		}
 	}
-	// 연속 하이픈 축소
+	// Collapse consecutive hyphens
 	result := b.String()
 	for strings.Contains(result, "--") {
 		result = strings.ReplaceAll(result, "--", "-")

--- a/internal/astgrep/sarif_test.go
+++ b/internal/astgrep/sarif_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/modu-ai/moai-adk/internal/astgrep"
 )
 
-// TestToSARIF_EmptyFindings: findings가 없을 때 유효한 SARIF 문서 생성 검증
+// TestToSARIF_EmptyFindings: verifies that a valid SARIF document is generated when there are no findings
 func TestToSARIF_EmptyFindings(t *testing.T) {
 	output, err := astgrep.ToSARIF(nil, "1.0.0-test")
 	if err != nil {
@@ -19,29 +19,29 @@ func TestToSARIF_EmptyFindings(t *testing.T) {
 
 	var doc map[string]any
 	if err := json.Unmarshal(output, &doc); err != nil {
-		t.Fatalf("SARIF 출력이 유효한 JSON이 아님: %v", err)
+		t.Fatalf("SARIF output is not valid JSON: %v", err)
 	}
 
-	// $schema 필드 검증
+	// validate $schema field
 	schema, ok := doc["$schema"].(string)
 	if !ok || schema == "" {
-		t.Error("SARIF $schema 필드가 없거나 비어있음")
+		t.Error("SARIF $schema field is missing or empty")
 	}
 
-	// version 필드 검증
+	// validate version field
 	version, ok := doc["version"].(string)
 	if !ok || version != "2.1.0" {
 		t.Errorf("SARIF version = %q, want 2.1.0", version)
 	}
 
-	// runs 배열 검증
+	// validate runs array
 	runs, ok := doc["runs"].([]any)
 	if !ok || len(runs) == 0 {
-		t.Fatal("SARIF runs 배열이 없거나 비어있음")
+		t.Fatal("SARIF runs array is missing or empty")
 	}
 }
 
-// TestToSARIF_ToolDriver: tool.driver 필드가 SPEC 요구사항을 만족하는지 검증 (AC5)
+// TestToSARIF_ToolDriver: verifies that tool.driver fields satisfy SPEC requirements (AC5)
 func TestToSARIF_ToolDriver(t *testing.T) {
 	output, err := astgrep.ToSARIF(nil, "0.42.1")
 	if err != nil {
@@ -56,18 +56,18 @@ func TestToSARIF_ToolDriver(t *testing.T) {
 	tool := run["tool"].(map[string]any)
 	driver := tool["driver"].(map[string]any)
 
-	// tool.driver.name이 "moai-ast-grep"이어야 함 (AC5)
+	// tool.driver.name must be "moai-ast-grep" (AC5)
 	if name := driver["name"].(string); name != "moai-ast-grep" {
 		t.Errorf("tool.driver.name = %q, want moai-ast-grep", name)
 	}
 
-	// tool.driver.version이 전달된 버전을 반영해야 함 (AC5)
+	// tool.driver.version must reflect the passed version (AC5)
 	if ver := driver["version"].(string); ver != "0.42.1" {
 		t.Errorf("tool.driver.version = %q, want 0.42.1", ver)
 	}
 }
 
-// TestToSARIF_FindingMapping: Finding이 SARIF result로 올바르게 매핑되는지 검증 (AC5)
+// TestToSARIF_FindingMapping: verifies that Findings are correctly mapped to SARIF results (AC5)
 func TestToSARIF_FindingMapping(t *testing.T) {
 	findings := []astgrep.Finding{
 		{
@@ -99,7 +99,7 @@ func TestToSARIF_FindingMapping(t *testing.T) {
 	run := runs[0].(map[string]any)
 	results, ok := run["results"].([]any)
 	if !ok {
-		t.Fatal("SARIF results 배열이 없음")
+		t.Fatal("SARIF results array is missing")
 	}
 
 	if len(results) != 2 {
@@ -107,7 +107,7 @@ func TestToSARIF_FindingMapping(t *testing.T) {
 	}
 }
 
-// TestToSARIF_SeverityMapping: severity가 SARIF level로 올바르게 매핑되는지 검증 (AC5)
+// TestToSARIF_SeverityMapping: verifies that severity is correctly mapped to SARIF level (AC5)
 func TestToSARIF_SeverityMapping(t *testing.T) {
 	tests := []struct {
 		severity  string
@@ -116,7 +116,7 @@ func TestToSARIF_SeverityMapping(t *testing.T) {
 		{"error", "error"},
 		{"warning", "warning"},
 		{"info", "note"},
-		{"", "note"},  // 빈 문자열 → note (SARIF 기본값)
+		{"", "note"},  // empty string → note (SARIF default)
 	}
 
 	for _, tt := range tests {
@@ -146,7 +146,7 @@ func TestToSARIF_SeverityMapping(t *testing.T) {
 
 			level, ok := result["level"].(string)
 			if !ok {
-				t.Fatalf("SARIF result.level 필드가 없음")
+				t.Fatalf("SARIF result.level field is missing")
 			}
 			if level != tt.wantLevel {
 				t.Errorf("SARIF level = %q, want %q (severity=%q)", level, tt.wantLevel, tt.severity)
@@ -155,7 +155,7 @@ func TestToSARIF_SeverityMapping(t *testing.T) {
 	}
 }
 
-// TestToSARIF_MetadataPreservation: Finding의 메타데이터(CWE/OWASP)가 SARIF에 전달되는지 검증 (AC5)
+// TestToSARIF_MetadataPreservation: verifies that Finding metadata (CWE/OWASP) is passed through to SARIF (AC5)
 func TestToSARIF_MetadataPreservation(t *testing.T) {
 	findings := []astgrep.Finding{
 		{
@@ -176,7 +176,7 @@ func TestToSARIF_MetadataPreservation(t *testing.T) {
 		t.Fatalf("ToSARIF() error = %v", err)
 	}
 
-	// JSON으로 파싱하여 properties 필드 존재 확인
+	// parse as JSON and verify presence of properties field
 	var doc map[string]any
 	_ = json.Unmarshal(output, &doc)
 
@@ -187,21 +187,22 @@ func TestToSARIF_MetadataPreservation(t *testing.T) {
 
 	props, ok := result["properties"].(map[string]any)
 	if !ok {
-		t.Fatal("SARIF result.properties 필드가 없음")
+		t.Fatal("SARIF result.properties field is missing")
 	}
 
 	if cwe, ok := props["cwe"].(string); !ok || cwe == "" {
-		t.Error("SARIF result.properties.cwe 필드가 없거나 비어있음")
+		t.Error("SARIF result.properties.cwe field is missing or empty")
 	}
 }
 
-// TestToSARIF_RulesDeterministicOrder: tool.driver.rules 배열이 rule ID 기준으로
-// 오름차순 정렬되어 실행마다 동일한 순서로 출력되는지 검증.
-// REGRESSION: Go map 반복 순서가 불확정적이어서 SARIF 출력이 실행마다 달라지는
-// 문제(issue #644)를 방지한다. Snapshot 테스트 및 GitHub Code Scanning diff 안정성 확보용.
+// TestToSARIF_RulesDeterministicOrder: verifies that tool.driver.rules array is sorted
+// ascending by rule ID and produces identical output on every run.
+// REGRESSION: prevents the issue (issue #644) where non-deterministic Go map iteration
+// caused SARIF output to vary between runs. Ensures stability for snapshot tests and
+// GitHub Code Scanning diffs.
 func TestToSARIF_RulesDeterministicOrder(t *testing.T) {
-	// 의도적으로 알파벳 역순에 가까운 순서로 입력하여,
-	// map 반복 순서에 의존하면 출력 순서가 불안정해지도록 구성한다.
+	// intentionally provide input in near-reverse-alphabetical order so that
+	// output depending on map iteration order would be unstable.
 	findings := []astgrep.Finding{
 		{RuleID: "zeta-rule", Severity: "warning", Message: "zeta", File: "a.go", Line: 1},
 		{RuleID: "alpha-rule", Severity: "error", Message: "alpha", File: "b.go", Line: 2},
@@ -220,7 +221,7 @@ func TestToSARIF_RulesDeterministicOrder(t *testing.T) {
 		"zeta-rule",
 	}
 
-	// 여러 번 호출해도 항상 동일한 순서여야 한다 (map 반복 비결정성 회피 검증).
+	// must produce identical order on every call (validates avoidance of non-deterministic map iteration).
 	const iterations = 20
 	var firstOutput []byte
 
@@ -233,13 +234,13 @@ func TestToSARIF_RulesDeterministicOrder(t *testing.T) {
 		if i == 0 {
 			firstOutput = output
 		} else if string(output) != string(firstOutput) {
-			t.Fatalf("iteration %d: SARIF 출력이 실행마다 달라짐 (비결정적)\nfirst:\n%s\ngot:\n%s",
+			t.Fatalf("iteration %d: SARIF output differs between runs (non-deterministic)\nfirst:\n%s\ngot:\n%s",
 				i, string(firstOutput), string(output))
 		}
 
 		var doc map[string]any
 		if err := json.Unmarshal(output, &doc); err != nil {
-			t.Fatalf("iteration %d: JSON 파싱 실패: %v", i, err)
+			t.Fatalf("iteration %d: JSON parse failed: %v", i, err)
 		}
 
 		runs := doc["runs"].([]any)
@@ -248,7 +249,7 @@ func TestToSARIF_RulesDeterministicOrder(t *testing.T) {
 		driver := tool["driver"].(map[string]any)
 		rules, ok := driver["rules"].([]any)
 		if !ok {
-			t.Fatalf("iteration %d: tool.driver.rules 배열이 없음", i)
+			t.Fatalf("iteration %d: tool.driver.rules array is missing", i)
 		}
 
 		if len(rules) != len(wantOrder) {
@@ -259,7 +260,7 @@ func TestToSARIF_RulesDeterministicOrder(t *testing.T) {
 			r := rule.(map[string]any)
 			id := r["id"].(string)
 			if id != wantOrder[idx] {
-				t.Errorf("iteration %d: rules[%d].id = %q, want %q (전체 순서가 ID 기준 오름차순이어야 함)",
+				t.Errorf("iteration %d: rules[%d].id = %q, want %q (entire order must be ascending by ID)",
 					i, idx, id, wantOrder[idx])
 			}
 		}
@@ -470,7 +471,7 @@ func TestSARIF_BackwardCompatibility(t *testing.T) {
 	}
 }
 
-// TestToSARIF_RoundTrip: ToSARIF 출력이 유효한 SARIF 2.1.0 스키마를 따르는지 검증
+// TestToSARIF_RoundTrip: verifies that ToSARIF output conforms to valid SARIF 2.1.0 schema
 func TestToSARIF_RoundTrip(t *testing.T) {
 	findings := []astgrep.Finding{
 		{
@@ -497,24 +498,24 @@ func TestToSARIF_RoundTrip(t *testing.T) {
 		t.Fatalf("ToSARIF() error = %v", err)
 	}
 
-	// JSON 파싱 및 재직렬화로 라운드트립 검증
+	// validate round-trip via JSON parse and re-serialization
 	var doc any
 	if err := json.Unmarshal(output, &doc); err != nil {
-		t.Fatalf("ToSARIF() 출력이 유효한 JSON이 아님: %v", err)
+		t.Fatalf("ToSARIF() output is not valid JSON: %v", err)
 	}
 
 	reEncoded, err := json.Marshal(doc)
 	if err != nil {
-		t.Fatalf("재직렬화 실패: %v", err)
+		t.Fatalf("re-serialization failed: %v", err)
 	}
 
 	var redoc map[string]any
 	if err := json.Unmarshal(reEncoded, &redoc); err != nil {
-		t.Fatalf("재파싱 실패: %v", err)
+		t.Fatalf("re-parsing failed: %v", err)
 	}
 
-	// 핵심 필드 재확인
+	// re-verify core fields after round-trip
 	if redoc["version"] != "2.1.0" {
-		t.Errorf("라운드트립 후 version = %v, want 2.1.0", redoc["version"])
+		t.Errorf("version after round-trip = %v, want 2.1.0", redoc["version"])
 	}
 }

--- a/internal/astgrep/scanner.go
+++ b/internal/astgrep/scanner.go
@@ -14,23 +14,23 @@ import (
 	"time"
 )
 
-// ScannerConfig는 통합 Scanner의 설정을 담습니다.
+// ScannerConfig holds configuration for the unified Scanner.
 // REQ-ASTG-UPG-010, REQ-ASTG-UPG-011, REQ-ASTG-UPG-012
 type ScannerConfig struct {
-	// RulesDir는 ast-grep 규칙 디렉토리 경로입니다 (재귀 탐색).
-	// 기본값: ".moai/config/astgrep-rules"
+	// RulesDir is the ast-grep rules directory path (recursive search).
+	// Default: ".moai/config/astgrep-rules"
 	RulesDir string
-	// SGBinary는 sg CLI 바이너리 이름 또는 경로입니다.
-	// 기본값: "sg"
+	// SGBinary is the sg CLI binary name or path.
+	// Default: "sg"
 	SGBinary string
-	// WarnOnlyMode가 true이면 error severity 발견 시에도 차단하지 않습니다.
+	// WarnOnlyMode prevents blocking even when error-severity findings are detected.
 	WarnOnlyMode bool
-	// Timeout은 전체 스캔 타임아웃입니다.
-	// 기본값: 30초
+	// Timeout is the total scan timeout.
+	// Default: 30 seconds
 	Timeout time.Duration
 }
 
-// DefaultScannerConfig는 기본값이 설정된 ScannerConfig를 반환합니다.
+// DefaultScannerConfig returns a ScannerConfig with built-in default values.
 func DefaultScannerConfig() *ScannerConfig {
 	return &ScannerConfig{
 		RulesDir: ".moai/config/astgrep-rules",
@@ -39,56 +39,56 @@ func DefaultScannerConfig() *ScannerConfig {
 	}
 }
 
-// Finding은 ast-grep 스캔의 단일 결과를 나타냅니다.
-// quality gate, post-tool hook, CLI 서브커맨드가 공유하는 표준 타입입니다.
+// Finding represents a single result from an ast-grep scan.
+// It is the canonical shared type used by the quality gate, post-tool hook, and CLI subcommands.
 //
-// @MX:ANCHOR: [AUTO] Finding은 scanner, CLI, hook이 공유하는 표준 데이터 타입
-// @MX:REASON: fan_in >= 3: Scanner.Scan, SARIF 변환기, hook 통합 모두 이 타입을 사용
+// @MX:ANCHOR: [AUTO] Finding is the canonical shared data type for scanner, CLI, and hook
+// @MX:REASON: fan_in >= 3: Scanner.Scan, SARIF converter, and hook integration all use this type
 type Finding struct {
-	// RuleID는 규칙 ID입니다.
+	// RuleID is the rule identifier.
 	RuleID string `json:"ruleId"`
-	// Severity는 심각도입니다: "error", "warning", "info"
+	// Severity is the finding severity: "error", "warning", "info"
 	Severity string `json:"severity"`
-	// Message는 규칙 메시지입니다.
+	// Message is the rule message.
 	Message string `json:"message"`
-	// File은 발견된 파일 경로입니다.
+	// File is the path of the file where the finding was detected.
 	File string `json:"file"`
-	// Line은 1-indexed 줄 번호입니다.
+	// Line is the 1-indexed line number.
 	Line int `json:"line"`
-	// Column은 0-indexed 컬럼 번호입니다.
+	// Column is the 0-indexed column number.
 	Column int `json:"column,omitempty"`
-	// EndLine은 1-indexed 종료 줄 번호입니다.
+	// EndLine is the 1-indexed end line number.
 	EndLine int `json:"endLine,omitempty"`
-	// EndColumn은 종료 컬럼 번호입니다.
+	// EndColumn is the end column number.
 	EndColumn int `json:"endColumn,omitempty"`
-	// Note는 규칙의 추가 설명입니다.
+	// Note is the additional description from the rule.
 	Note string `json:"note,omitempty"`
-	// Metadata는 CWE/OWASP 등 추가 메타데이터입니다.
+	// Metadata is additional metadata such as CWE/OWASP.
 	Metadata map[string]string `json:"metadata,omitempty"`
-	// Language는 이 finding을 생성한 규칙의 대상 언어입니다.
-	// scanWithRules 경로에서 rule.Language가 주입됩니다.
-	// scanWithConfig 경로에서는 per-finding 언어를 알 수 없으므로 빈 문자열입니다.
-	// --lang 필터는 Language가 빈 finding을 항상 포함합니다 (언어-중립 규칙 허용).
+	// Language is the target language of the rule that produced this finding.
+	// Injected from rule.Language via the scanWithRules path.
+	// Empty string in the scanWithConfig path (per-finding language is unknown).
+	// The --lang filter always includes findings with an empty Language (language-neutral rules).
 	Language string `json:"language,omitempty"`
 }
 
-// IsError는 심각도가 error인지 반환합니다.
+// IsError reports whether the severity is "error".
 func (f Finding) IsError() bool {
 	return strings.ToLower(f.Severity) == "error"
 }
 
-// IsWarning은 심각도가 warning인지 반환합니다.
+// IsWarning reports whether the severity is "warning".
 func (f Finding) IsWarning() bool {
 	return strings.ToLower(f.Severity) == "warning"
 }
 
-// IsInfo는 심각도가 info이거나 빈 문자열인지 반환합니다.
+// IsInfo reports whether the severity is "info" or empty string.
 func (f Finding) IsInfo() bool {
 	s := strings.ToLower(f.Severity)
 	return s == "info" || s == ""
 }
 
-// String은 Finding을 사람이 읽기 좋은 형식으로 반환합니다.
+// String returns a human-readable representation of the Finding.
 func (f Finding) String() string {
 	sev := f.Severity
 	if sev == "" {
@@ -97,7 +97,7 @@ func (f Finding) String() string {
 	return fmt.Sprintf("%s:%d: [%s] %s (%s)", f.File, f.Line, f.RuleID, f.Message, sev)
 }
 
-// HasErrors는 findings 슬라이스에 error severity 항목이 있는지 반환합니다.
+// HasErrors reports whether any finding in the slice has error severity.
 func HasErrors(findings []Finding) bool {
 	for _, f := range findings {
 		if f.IsError() {
@@ -107,10 +107,10 @@ func HasErrors(findings []Finding) bool {
 	return false
 }
 
-// ErrUntrustedBinary는 신뢰할 수 없는 바이너리 경로가 지정된 경우 반환됩니다.
-var ErrUntrustedBinary = errors.New("astgrep: 신뢰할 수 없는 바이너리 경로")
+// ErrUntrustedBinary is returned when an untrusted binary path is specified.
+var ErrUntrustedBinary = errors.New("astgrep: untrusted binary path")
 
-// trustedBinaryPrefixes는 허용된 절대 경로 prefix 목록을 반환한다.
+// trustedBinaryPrefixes returns the list of allowed absolute path prefixes.
 func trustedBinaryPrefixes() []string {
 	home, _ := os.UserHomeDir()
 	sep := string(os.PathSeparator)
@@ -129,27 +129,28 @@ func trustedBinaryPrefixes() []string {
 	return prefixes
 }
 
-// ValidateBinary는 sg 바이너리 경로의 안전성을 검사한다.
-// 빈 문자열은 기본값 "sg"로 폴백되므로 허용한다.
-// bare name은 "sg" 또는 "ast-grep"만 허용한다.
-// 절대 경로는 신뢰 prefix 목록에 있어야 한다.
-// 셸 메타문자나 경로 트래버설(..)이 포함되면 ErrUntrustedBinary를 반환한다.
+// ValidateBinary checks the safety of the sg binary path.
+// An empty string is allowed because it falls back to the default "sg".
+// Bare names are restricted to "sg" or "ast-grep".
+// Absolute paths must be in the trusted prefix list.
+// Shell metacharacters or path traversal (..) return ErrUntrustedBinary.
 func ValidateBinary(binary string) error {
 	if binary == "" {
-		// 빈 값은 기본값 "sg"로 폴백됨
+		// Empty value falls back to the default "sg".
 		return nil
 	}
-	// 셸 인젝션 방어: 메타문자 차단
+	// Shell injection defense: block metacharacters.
 	if strings.ContainsAny(binary, ";|&`$()<>\n\r") {
 		return ErrUntrustedBinary
 	}
-	// 경로 트래버설 차단
+	// Block path traversal.
 	if strings.Contains(binary, "..") {
 		return ErrUntrustedBinary
 	}
-	// bare name: 허용 목록의 고정값만
-	// filepath.IsAbs는 Windows에서 Unix 스타일 "/usr/bin/sg"를 절대경로로 보지 않으므로
-	// 슬래시/백슬래시 포함 여부로 경로성을 판정해 크로스플랫폼 일관성을 확보한다.
+	// Bare name: only allow fixed values from the allowlist.
+	// filepath.IsAbs does not treat Unix-style "/usr/bin/sg" as absolute on Windows,
+	// so path-ness is determined by checking for slashes/backslashes to ensure
+	// cross-platform consistency.
 	looksLikePath := strings.ContainsAny(binary, "/\\") || filepath.IsAbs(binary)
 	if !looksLikePath {
 		if binary == "sg" || binary == "ast-grep" {
@@ -157,8 +158,8 @@ func ValidateBinary(binary string) error {
 		}
 		return ErrUntrustedBinary
 	}
-	// 절대 경로: 신뢰 prefix 검사 (Clean으로 트래버설 정규화 후)
-	// Windows와 Unix를 동일하게 다루기 위해 양쪽 모두 ToSlash로 정규화한다.
+	// Absolute path: check trusted prefix list (after normalizing traversal with Clean).
+	// Normalize both sides with ToSlash for consistent Unix/Windows handling.
 	cleaned := filepath.ToSlash(filepath.Clean(binary))
 	for _, p := range trustedBinaryPrefixes() {
 		prefixSlash := strings.TrimRight(filepath.ToSlash(p), "/")
@@ -169,17 +170,17 @@ func ValidateBinary(binary string) error {
 	return ErrUntrustedBinary
 }
 
-// Scanner는 ast-grep 기반의 통합 코드 스캐너입니다.
-// quality gate와 post-tool hook의 분리된 구현을 대체합니다.
+// Scanner is a unified code scanner based on ast-grep.
+// It replaces the separate implementations in the quality gate and post-tool hook.
 //
-// @MX:ANCHOR: [AUTO] Scanner.Scan은 모든 ast-grep 스캔의 단일 진입점
-// @MX:REASON: fan_in >= 3: quality gate hook, PostToolUse hook, CLI subcommand 모두 이 메서드를 호출
+// @MX:ANCHOR: [AUTO] Scanner.Scan is the single entry point for all ast-grep scans
+// @MX:REASON: fan_in >= 3: quality gate hook, PostToolUse hook, and CLI subcommand all call this method
 type Scanner struct {
 	cfg *ScannerConfig
 }
 
-// NewScanner는 주어진 설정으로 새 Scanner를 생성합니다.
-// cfg가 nil이면 DefaultScannerConfig()를 사용합니다.
+// NewScanner creates a new Scanner with the given configuration.
+// If cfg is nil, DefaultScannerConfig() is used.
 func NewScanner(cfg *ScannerConfig) *Scanner {
 	if cfg == nil {
 		cfg = DefaultScannerConfig()
@@ -187,7 +188,7 @@ func NewScanner(cfg *ScannerConfig) *Scanner {
 	return &Scanner{cfg: cfg}
 }
 
-// sgScanMatch는 sg scan --json 출력의 내부 파싱 구조체입니다.
+// sgScanMatch is the internal parsing struct for sg scan --json output.
 type sgScanMatch struct {
 	File     string `json:"file"`
 	Lines    string `json:"lines,omitempty"`
@@ -208,7 +209,7 @@ type sgScanMatch struct {
 	} `json:"range"`
 }
 
-// isSGAvailable은 sg CLI 바이너리가 PATH에 있는지 확인합니다.
+// isSGAvailable reports whether the sg CLI binary is available in PATH.
 func (s *Scanner) isSGAvailable() bool {
 	binary := s.cfg.SGBinary
 	if binary == "" {
@@ -218,25 +219,25 @@ func (s *Scanner) isSGAvailable() bool {
 	return err == nil
 }
 
-// Scan은 주어진 경로에 대해 모든 규칙을 적용하여 스캔을 수행합니다.
-// sg CLI가 없으면 ([]Finding{}, nil)을 반환합니다 (REQ-ASTG-UPG-012).
-// rules 디렉토리가 비어있거나 존재하지 않으면 ([]Finding{}, nil)을 반환합니다 (REQ-ASTG-UPG-012).
-// SGBinary가 신뢰할 수 없는 경로이면 에러를 반환합니다 (F2 보안 검사).
+// Scan runs all rules against the given path.
+// Returns ([]Finding{}, nil) when the sg CLI is not available (REQ-ASTG-UPG-012).
+// Returns ([]Finding{}, nil) when the rules directory is empty or does not exist (REQ-ASTG-UPG-012).
+// Returns an error when SGBinary is an untrusted path (F2 security check).
 func (s *Scanner) Scan(ctx context.Context, path string) ([]Finding, error) {
-	// 바이너리 경로 보안 검증 (F2): 신뢰할 수 없는 경로는 즉시 에러 반환
+	// Binary path security validation (F2): untrusted paths return an error immediately.
 	if err := ValidateBinary(s.cfg.SGBinary); err != nil {
-		return []Finding{}, fmt.Errorf("sg 바이너리 검증 실패 (SGBinary=%q): %w", s.cfg.SGBinary, err)
+		return []Finding{}, fmt.Errorf("sg binary validation failed (SGBinary=%q): %w", s.cfg.SGBinary, err)
 	}
 
-	// sg CLI가 없으면 warn_and_skip (REQ-ASTG-UPG-012)
+	// Warn and skip when the sg CLI is not available (REQ-ASTG-UPG-012).
 	if !s.isSGAvailable() {
-		slog.Warn("ast-grep (sg) CLI를 찾을 수 없습니다. 스캔을 건너뜁니다.",
+		slog.Warn("ast-grep (sg) CLI not found; skipping scan",
 			"binary", s.cfg.SGBinary,
-			"hint", "https://ast-grep.github.io/guide/quick-start.html 에서 설치하세요")
+			"hint", "install from https://ast-grep.github.io/guide/quick-start.html")
 		return []Finding{}, nil
 	}
 
-	// rules 디렉토리가 없으면 빈 결과 반환
+	// Return empty results when the rules directory does not exist
 	if _, err := os.Stat(s.cfg.RulesDir); err != nil {
 		if os.IsNotExist(err) {
 			return []Finding{}, nil
@@ -244,13 +245,13 @@ func (s *Scanner) Scan(ctx context.Context, path string) ([]Finding, error) {
 		return []Finding{}, nil
 	}
 
-	// sgconfig.yml이 있으면 config 기반 스캔 사용
+	// Use config-based scan when sgconfig.yml is present
 	sgconfigPath := filepath.Join(s.cfg.RulesDir, "sgconfig.yml")
 	if _, err := os.Stat(sgconfigPath); err == nil {
 		return s.scanWithConfig(ctx, sgconfigPath, path)
 	}
 
-	// sgconfig.yml이 없으면 재귀적으로 규칙을 로딩하여 스캔
+	// When sgconfig.yml is absent, load rules recursively and scan
 	loader := NewRuleLoader()
 	rules, err := loader.LoadFromDir(s.cfg.RulesDir)
 	if err != nil || len(rules) == 0 {
@@ -260,7 +261,7 @@ func (s *Scanner) Scan(ctx context.Context, path string) ([]Finding, error) {
 	return s.scanWithRules(ctx, rules, path)
 }
 
-// scanWithConfig는 sgconfig.yml을 사용하여 스캔합니다.
+// scanWithConfig scans using an sgconfig.yml file.
 func (s *Scanner) scanWithConfig(ctx context.Context, configPath, path string) ([]Finding, error) {
 	timeout := s.cfg.Timeout
 	if timeout == 0 {
@@ -280,12 +281,12 @@ func (s *Scanner) scanWithConfig(ctx context.Context, configPath, path string) (
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
-	// sg는 발견 시 non-zero exit code를 반환할 수 있으므로 에러를 무시
+	// Ignore the error: sg may return a non-zero exit code when matches are found.
 	_ = cmd.Run()
 
-	// F4: stderr 내용이 있으면 디버그 로깅 (config 기반 스캔에서는 언어를 알 수 없으므로 에러 전파 생략)
+	// F4: debug-log any stderr content (language is unknown in config-based scans, so skip error propagation).
 	if stderr.Len() > 0 {
-		slog.Debug("sg scan stderr (config 기반)", "config", configPath, "stderr", stderr.String())
+		slog.Debug("sg scan stderr (config-based)", "config", configPath, "stderr", stderr.String())
 	}
 
 	if stdout.Len() == 0 {
@@ -295,12 +296,12 @@ func (s *Scanner) scanWithConfig(ctx context.Context, configPath, path string) (
 	return parseSGFindings(stdout.Bytes())
 }
 
-// runSingleRule은 단일 규칙에 대해 sg run을 실행하고 finding을 반환합니다.
-// defer cancel()로 context 누수를 방지합니다 (F3).
-// stderr는 디버그 로깅하고, stdout이 비어있고 stderr가 있으면 에러를 반환합니다 (F4).
+// runSingleRule executes sg run for a single rule and returns the findings.
+// The context is protected with defer cancel() to prevent leaks (F3).
+// stderr is debug-logged; an error is returned when stdout is empty and stderr is non-empty (F4).
 //
-// @MX:WARN: [AUTO] context.WithTimeout을 defer cancel()로 보호 — 이전 구현에서 cancel() 누수 발생
-// @MX:REASON: F3 버그 수정: loop 내 cancel() 미 defer 시 패닉/조기 반환 경로에서 context 누수
+// @MX:WARN: [AUTO] context.WithTimeout guarded by defer cancel() — previous implementation leaked cancel()
+// @MX:REASON: F3 bug fix: without defer, cancel() was leaked on panic/early-return paths inside the loop
 func (s *Scanner) runSingleRule(ctx context.Context, binary string, rule Rule, path string, timeout time.Duration) ([]Finding, error) {
 	scanCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -316,13 +317,13 @@ func (s *Scanner) runSingleRule(ctx context.Context, binary string, rule Rule, p
 	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
-		// F4: stderr 내용 로깅
+		// F4: log stderr content.
 		if stderr.Len() > 0 {
 			slog.Debug("sg run stderr", "rule", rule.ID, "stderr", stderr.String())
 		}
-		// stdout이 비어있고 stderr에 내용이 있으면 실행 실패로 간주
+		// Treat as execution failure when stdout is empty but stderr has content.
 		if stdout.Len() == 0 && stderr.Len() > 0 {
-			return nil, fmt.Errorf("sg run 실패 (rule %s): %s", rule.ID, stderr.String())
+			return nil, fmt.Errorf("sg run failed (rule %s): %s", rule.ID, stderr.String())
 		}
 	}
 
@@ -332,7 +333,7 @@ func (s *Scanner) runSingleRule(ctx context.Context, binary string, rule Rule, p
 	return parseSGFindings(stdout.Bytes())
 }
 
-// scanWithRules는 규칙 목록을 사용하여 개별 스캔합니다.
+// scanWithRules scans the path individually for each rule in the list.
 func (s *Scanner) scanWithRules(ctx context.Context, rules []Rule, path string) ([]Finding, error) {
 	timeout := s.cfg.Timeout
 	if timeout == 0 {
@@ -351,14 +352,14 @@ func (s *Scanner) scanWithRules(ctx context.Context, rules []Rule, path string) 
 			continue
 		}
 
-		// F3: runSingleRule에서 defer cancel()로 context 누수 방지
+		// F3: context leak prevented by defer cancel() inside runSingleRule.
 		findings, err := s.runSingleRule(ctx, binary, rule, path, timeout)
 		if err != nil {
-			slog.Debug("규칙 실행 실패, 건너뜀", "rule", rule.ID, "error", err)
+			slog.Debug("rule execution failed, skipping", "rule", rule.ID, "error", err)
 			continue
 		}
 
-		// 규칙 메타데이터 주입 (F1: Language 필드 포함)
+		// Inject rule metadata (F1: includes Language field).
 		for i := range findings {
 			if findings[i].RuleID == "" {
 				findings[i].RuleID = rule.ID
@@ -369,13 +370,13 @@ func (s *Scanner) scanWithRules(ctx context.Context, rules []Rule, path string) 
 			if findings[i].Message == "" {
 				findings[i].Message = rule.Message
 			}
-			// Language는 항상 rule에서 주입 (찾은 파일의 언어가 아닌 규칙 대상 언어)
+			// Language is always injected from the rule (target language of the rule, not the matched file).
 			findings[i].Language = rule.Language
-			// Note 전파: Finding에 Note가 없으면 Rule.Note에서 복사 (REQ-UTIL-002-003)
+			// Propagate Note: copy from Rule.Note when the Finding has none (REQ-UTIL-002-003).
 			if findings[i].Note == "" {
 				findings[i].Note = rule.Note
 			}
-			// Metadata 전파: Finding에 Metadata가 없으면 Rule.Metadata에서 복사 (REQ-UTIL-002-004)
+			// Propagate Metadata: copy from Rule.Metadata when the Finding has none (REQ-UTIL-002-004).
 			if findings[i].Metadata == nil {
 				findings[i].Metadata = rule.Metadata
 			}
@@ -387,7 +388,7 @@ func (s *Scanner) scanWithRules(ctx context.Context, rules []Rule, path string) 
 	return allFindings, nil
 }
 
-// parseSGFindings는 sg JSON 출력을 Finding 슬라이스로 변환합니다.
+// parseSGFindings converts sg JSON output to a Finding slice.
 func parseSGFindings(output []byte) ([]Finding, error) {
 	trimmed := bytes.TrimSpace(output)
 	if len(trimmed) == 0 {
@@ -396,7 +397,7 @@ func parseSGFindings(output []byte) ([]Finding, error) {
 
 	var matches []sgScanMatch
 	if err := json.Unmarshal(trimmed, &matches); err != nil {
-		return nil, fmt.Errorf("sg 출력 파싱: %w", err)
+		return nil, fmt.Errorf("parse sg output: %w", err)
 	}
 
 	findings := make([]Finding, 0, len(matches))
@@ -406,7 +407,7 @@ func parseSGFindings(output []byte) ([]Finding, error) {
 			Severity:  m.Severity,
 			Message:   m.Message,
 			File:      m.File,
-			Line:      m.Range.Start.Line + 1, // sg는 0-indexed, Finding은 1-indexed
+			Line:      m.Range.Start.Line + 1, // sg uses 0-indexed lines; Finding uses 1-indexed
 			Column:    m.Range.Start.Column,
 			EndLine:   m.Range.End.Line + 1,
 			EndColumn: m.Range.End.Column,

--- a/internal/astgrep/scanner_test.go
+++ b/internal/astgrep/scanner_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/modu-ai/moai-adk/internal/astgrep"
 )
 
-// TestNewScanner_DefaultConfig: 기본 Config로 Scanner 생성이 성공하는지 검증
+// TestNewScanner_DefaultConfig: verifies that Scanner creation succeeds with default Config
 func TestNewScanner_DefaultConfig(t *testing.T) {
 	cfg := astgrep.DefaultScannerConfig()
 	s := astgrep.NewScanner(cfg)
@@ -19,7 +19,7 @@ func TestNewScanner_DefaultConfig(t *testing.T) {
 	}
 }
 
-// TestNewScanner_NilConfig: nil Config 전달 시 패닉 없이 기본값으로 동작하는지 검증
+// TestNewScanner_NilConfig: verifies that passing nil Config falls back to defaults without panicking
 func TestNewScanner_NilConfig(t *testing.T) {
 	s := astgrep.NewScanner(nil)
 	if s == nil {
@@ -27,29 +27,29 @@ func TestNewScanner_NilConfig(t *testing.T) {
 	}
 }
 
-// TestScanner_SGNotAvailable: sg CLI가 PATH에 없을 때 (nil, nil) 반환 검증 (AC3)
-// 기본 허용 binary("sg")를 사용하되 실제 PATH에 없는 환경을 시뮬레이션한다.
-// 참고: 비허용 binary name은 F2 보안 검사에서 에러로 차단된다.
+// TestScanner_SGNotAvailable: verifies that (nil, nil) is returned when sg CLI is not in PATH (AC3)
+// Uses the default allowed binary ("sg") but simulates an environment where it is absent from PATH.
+// Note: disallowed binary names are blocked by the F2 security check with an error.
 func TestScanner_SGNotAvailable(t *testing.T) {
-	// "sg"는 ValidateBinary를 통과하지만, PATH에 없으면 isSGAvailable이 false를 반환한다.
-	// 이 테스트는 sg가 실제로 없는 환경(PATH에 "sg" 없음)에서만 유의미하다.
-	// sg가 설치된 환경에서는 실제 스캔이 발생할 수 있으므로, 빈 rules 디렉토리로 테스트한다.
+	// "sg" passes ValidateBinary, but isSGAvailable returns false when not in PATH.
+	// This test is only meaningful in environments where sg is absent from PATH.
+	// In environments where sg is installed, actual scanning may occur, so we test with an empty rules dir.
 	tmpDir := t.TempDir()
 	cfg := astgrep.DefaultScannerConfig()
-	cfg.SGBinary = "sg" // 허용된 bare name
+	cfg.SGBinary = "sg" // allowed bare name
 	cfg.RulesDir = tmpDir
 
 	s := astgrep.NewScanner(cfg)
 	findings, err := s.Scan(context.Background(), ".")
 	if err != nil {
-		t.Errorf("Scan() error = %v; sg 미존재 또는 빈 rules 시 nil 에러를 반환해야 함", err)
+		t.Errorf("Scan() error = %v; must return nil error when sg is absent or rules dir is empty", err)
 	}
 	if len(findings) != 0 {
-		t.Errorf("Scan() len(findings) = %d; 빈 rules 디렉토리에서 빈 슬라이스를 반환해야 함", len(findings))
+		t.Errorf("Scan() len(findings) = %d; must return empty slice for empty rules directory", len(findings))
 	}
 }
 
-// TestScanner_EmptyRulesDir: 빈 rules 디렉토리일 때 오류 없이 빈 결과 반환 (AC3)
+// TestScanner_EmptyRulesDir: verifies that an empty rules directory returns empty results without error (AC3)
 func TestScanner_EmptyRulesDir(t *testing.T) {
 	tmpDir := t.TempDir()
 	cfg := astgrep.DefaultScannerConfig()
@@ -58,14 +58,14 @@ func TestScanner_EmptyRulesDir(t *testing.T) {
 
 	findings, err := s.Scan(context.Background(), ".")
 	if err != nil {
-		t.Errorf("Scan() error = %v; 빈 rules 디렉토리에서 오류가 발생하면 안 됨", err)
+		t.Errorf("Scan() error = %v; must not return error for empty rules directory", err)
 	}
 	if findings == nil {
-		t.Error("Scan() returned nil findings; 빈 슬라이스를 반환해야 함")
+		t.Error("Scan() returned nil findings; must return empty slice")
 	}
 }
 
-// TestScanner_RulesDirNotExist: rules 디렉토리가 존재하지 않을 때 오류 없이 동작 (AC3)
+// TestScanner_RulesDirNotExist: verifies that a non-existent rules directory operates without error (AC3)
 func TestScanner_RulesDirNotExist(t *testing.T) {
 	cfg := astgrep.DefaultScannerConfig()
 	cfg.RulesDir = "/path/that/does/not/exist/12345"
@@ -73,14 +73,14 @@ func TestScanner_RulesDirNotExist(t *testing.T) {
 
 	findings, err := s.Scan(context.Background(), ".")
 	if err != nil {
-		t.Errorf("Scan() error = %v; 존재하지 않는 rules 디렉토리에서 오류가 발생하면 안 됨", err)
+		t.Errorf("Scan() error = %v; must not return error for non-existent rules directory", err)
 	}
 	if len(findings) != 0 {
-		t.Errorf("Scan() len(findings) = %d; 규칙 없을 때 빈 슬라이스를 반환해야 함", len(findings))
+		t.Errorf("Scan() len(findings) = %d; must return empty slice when no rules exist", len(findings))
 	}
 }
 
-// TestScanner_FindingSeverityClassification: Finding 구조체의 severity 분류 검증
+// TestScanner_FindingSeverityClassification: verifies severity classification of the Finding struct
 func TestScanner_FindingSeverityClassification(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -117,23 +117,23 @@ func TestScanner_FindingSeverityClassification(t *testing.T) {
 	}
 }
 
-// TestRuleLoader_LoadFromDirRecursive: 서브디렉토리를 재귀적으로 로딩하는지 검증 (AC2 - RuleLoader.LoadFromDir)
+// TestRuleLoader_LoadFromDirRecursive: verifies recursive loading of subdirectories (AC2 - RuleLoader.LoadFromDir)
 func TestRuleLoader_LoadFromDirRecursive(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	// go/ 서브디렉토리 생성
+	// create go/ subdirectory
 	goDir := filepath.Join(tmpDir, "go")
 	if err := os.MkdirAll(goDir, 0o755); err != nil {
-		t.Fatalf("서브디렉토리 생성 실패: %v", err)
+		t.Fatalf("failed to create subdirectory: %v", err)
 	}
 
-	// security/ 서브디렉토리 생성
+	// create security/ subdirectory
 	secDir := filepath.Join(tmpDir, "security")
 	if err := os.MkdirAll(secDir, 0o755); err != nil {
-		t.Fatalf("security 서브디렉토리 생성 실패: %v", err)
+		t.Fatalf("failed to create security subdirectory: %v", err)
 	}
 
-	// go/test.yml 생성
+	// create go/test.yml
 	goRuleYAML := `---
 id: test-go-rule
 language: go
@@ -142,10 +142,10 @@ message: "테스트 규칙"
 pattern: "os.Getenv($X)"
 `
 	if err := os.WriteFile(filepath.Join(goDir, "test.yml"), []byte(goRuleYAML), 0o644); err != nil {
-		t.Fatalf("규칙 파일 작성 실패: %v", err)
+		t.Fatalf("failed to write rule file: %v", err)
 	}
 
-	// security/test.yml 생성
+	// create security/test.yml
 	secRuleYAML := `---
 id: test-sec-rule
 language: go
@@ -154,7 +154,7 @@ message: "보안 테스트 규칙"
 pattern: "exec.Command($X)"
 `
 	if err := os.WriteFile(filepath.Join(secDir, "test.yml"), []byte(secRuleYAML), 0o644); err != nil {
-		t.Fatalf("보안 규칙 파일 작성 실패: %v", err)
+		t.Fatalf("failed to write security rule file: %v", err)
 	}
 
 	loader := astgrep.NewRuleLoader()
@@ -164,27 +164,27 @@ pattern: "exec.Command($X)"
 	}
 
 	if len(rules) != 2 {
-		t.Errorf("LoadFromDir() len(rules) = %d, want 2 (서브디렉토리 재귀 로딩 필요)", len(rules))
+		t.Errorf("LoadFromDir() len(rules) = %d, want 2 (recursive subdirectory loading required)", len(rules))
 	}
 
-	// 규칙 ID 검증
+	// verify rule IDs
 	ids := make(map[string]bool)
 	for _, r := range rules {
 		ids[r.ID] = true
 	}
 	if !ids["test-go-rule"] {
-		t.Error("test-go-rule이 로딩되지 않았음")
+		t.Error("test-go-rule was not loaded")
 	}
 	if !ids["test-sec-rule"] {
-		t.Error("test-sec-rule이 로딩되지 않았음")
+		t.Error("test-sec-rule was not loaded")
 	}
 }
 
-// TestRuleLoader_SkipsInvalidYAML: 파싱 실패한 개별 규칙은 건너뛰고 나머지 로딩 (AC3)
+// TestRuleLoader_SkipsInvalidYAML: verifies that individually unparseable rules are skipped and the rest are loaded (AC3)
 func TestRuleLoader_SkipsInvalidYAML(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	// 유효한 규칙 파일
+	// valid rule file
 	validYAML := `---
 id: valid-rule
 language: go
@@ -193,28 +193,28 @@ message: "유효한 규칙"
 pattern: "fmt.Println($X)"
 `
 	if err := os.WriteFile(filepath.Join(tmpDir, "valid.yml"), []byte(validYAML), 0o644); err != nil {
-		t.Fatalf("유효한 규칙 파일 작성 실패: %v", err)
+		t.Fatalf("failed to write valid rule file: %v", err)
 	}
 
-	// 유효하지 않은 YAML 파일 (파싱 불가)
+	// invalid YAML file (unparseable)
 	invalidYAML := `{invalid yaml: [`
 	if err := os.WriteFile(filepath.Join(tmpDir, "invalid.yml"), []byte(invalidYAML), 0o644); err != nil {
-		t.Fatalf("잘못된 규칙 파일 작성 실패: %v", err)
+		t.Fatalf("failed to write invalid rule file: %v", err)
 	}
 
 	loader := astgrep.NewRuleLoader()
-	// 에러를 반환하지 않고 유효한 규칙만 로딩해야 함
+	// must load only valid rules without returning an error
 	rules, err := loader.LoadFromDir(tmpDir)
 	if err != nil {
-		t.Fatalf("LoadFromDir() error = %v; 잘못된 파일은 건너뛰어야 함", err)
+		t.Fatalf("LoadFromDir() error = %v; invalid files must be skipped", err)
 	}
 
 	if len(rules) < 1 {
-		t.Error("유효한 규칙이 최소 1개 이상 로딩되어야 함")
+		t.Error("at least 1 valid rule must be loaded")
 	}
 }
 
-// TestScanner_ScanConfig: Config 필드 설정 검증
+// TestScanner_ScanConfig: verifies Config field settings
 func TestScanner_ScanConfig(t *testing.T) {
 	cfg := &astgrep.ScannerConfig{
 		RulesDir:     "/custom/rules",
@@ -227,19 +227,19 @@ func TestScanner_ScanConfig(t *testing.T) {
 	}
 }
 
-// TestScanner_ContextCancellation: context 취소 시 Scan이 즉시 반환하는지 검증
+// TestScanner_ContextCancellation: verifies that Scan returns immediately when context is cancelled
 func TestScanner_ContextCancellation(t *testing.T) {
 	cfg := astgrep.DefaultScannerConfig()
 	s := astgrep.NewScanner(cfg)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // 즉시 취소
+	cancel() // cancel immediately
 
-	// context가 이미 취소된 상태에서도 패닉 없이 반환해야 함
+	// must return without panicking even when context is already cancelled
 	_, _ = s.Scan(ctx, ".")
 }
 
-// TestFinding_String: Finding.String() 메서드가 사람이 읽기 좋은 형식으로 출력하는지 검증
+// TestFinding_String: verifies that Finding.String() outputs a human-readable format
 func TestFinding_String(t *testing.T) {
 	f := astgrep.Finding{
 		RuleID:   "go-no-raw-getenv",
@@ -253,13 +253,13 @@ func TestFinding_String(t *testing.T) {
 	if got == "" {
 		t.Error("Finding.String() returned empty string")
 	}
-	// 파일명과 줄 번호가 포함되어야 함
+	// must include filename and line number
 	if !containsSubstr(got, "main.go") {
-		t.Errorf("Finding.String() = %q; 파일명을 포함해야 함", got)
+		t.Errorf("Finding.String() = %q; must include filename", got)
 	}
 }
 
-// TestScanner_HasErrors: HasErrors() 메서드가 error severity 여부를 올바르게 판단하는지 검증
+// TestScanner_HasErrors: verifies that HasErrors() correctly determines whether any finding has error severity
 func TestScanner_HasErrors(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -267,19 +267,19 @@ func TestScanner_HasErrors(t *testing.T) {
 		want     bool
 	}{
 		{
-			name:     "빈 findings",
+			name:     "empty findings",
 			findings: nil,
 			want:     false,
 		},
 		{
-			name: "warning만 있는 경우",
+			name: "only warnings",
 			findings: []astgrep.Finding{
 				{RuleID: "r1", Severity: "warning"},
 			},
 			want: false,
 		},
 		{
-			name: "error가 포함된 경우",
+			name: "contains an error",
 			findings: []astgrep.Finding{
 				{RuleID: "r1", Severity: "warning"},
 				{RuleID: "r2", Severity: "error"},
@@ -297,10 +297,10 @@ func TestScanner_HasErrors(t *testing.T) {
 	}
 }
 
-// TestScanner_ScanWithSGAvailable: sg CLI가 있는 경우 실제 스캔 (통합 테스트, sg 없으면 skip)
+// TestScanner_ScanWithSGAvailable: performs actual scan when sg CLI is available (integration test, skip if sg absent)
 func TestScanner_ScanWithSGAvailable(t *testing.T) {
 	if _, err := exec.LookPath("sg"); err != nil {
-		t.Skip("sg CLI가 PATH에 없어 스킵합니다")
+		t.Skip("sg CLI is not in PATH, skipping")
 	}
 
 	tmpDir := t.TempDir()
@@ -319,17 +319,17 @@ func main() {
 `
 	goFile := filepath.Join(tmpDir, "main.go")
 	if err := os.WriteFile(goFile, []byte(goCode), 0o644); err != nil {
-		t.Fatalf("Go 파일 작성 실패: %v", err)
+		t.Fatalf("failed to write Go file: %v", err)
 	}
 
 	rulesDir := filepath.Join(tmpDir, "rules", "go")
 	if err := os.MkdirAll(rulesDir, 0o755); err != nil {
-		t.Fatalf("rules 디렉토리 생성 실패: %v", err)
+		t.Fatalf("failed to create rules directory: %v", err)
 	}
 
 	ruleYAML := "---\nid: test-getenv-rule\nlanguage: go\nseverity: warning\nmessage: \"raw os.Getenv 사용 금지\"\npattern: 'os.Getenv(\"$X\")'\n"
 	if err := os.WriteFile(filepath.Join(rulesDir, "test.yml"), []byte(ruleYAML), 0o644); err != nil {
-		t.Fatalf("규칙 파일 작성 실패: %v", err)
+		t.Fatalf("failed to write rule file: %v", err)
 	}
 
 	cfg := &astgrep.ScannerConfig{
@@ -341,13 +341,13 @@ func main() {
 	if err != nil {
 		t.Fatalf("Scan() error = %v", err)
 	}
-	// sg가 있으면 결과가 슬라이스여야 함 (nil이 아닌)
+	// when sg is available, result must be a slice (not nil)
 	if findings == nil {
 		t.Error("Scan() returned nil with sg available")
 	}
 }
 
-// TestParseSGFindings_EmptyOutput: 빈 출력에 대해 빈 슬라이스 반환 검증
+// TestParseSGFindings_EmptyOutput: verifies that empty output returns an empty slice
 func TestParseSGFindings_EmptyOutput(t *testing.T) {
 	cfg := astgrep.DefaultScannerConfig()
 	cfg.RulesDir = t.TempDir()
@@ -358,11 +358,11 @@ func TestParseSGFindings_EmptyOutput(t *testing.T) {
 		t.Errorf("Scan() error = %v", err)
 	}
 	if findings == nil {
-		t.Error("Scan() returned nil; 빈 슬라이스를 반환해야 함")
+		t.Error("Scan() returned nil; must return empty slice")
 	}
 }
 
-// TestToFileURI_Paths: SARIF URI 변환 검증 (내부 함수 간접 테스트)
+// TestToFileURI_Paths: verifies SARIF URI conversion (indirect test of internal function)
 func TestToFileURI_Paths(t *testing.T) {
 	findings := []astgrep.Finding{
 		{RuleID: "r1", Severity: "warning", Message: "m1", File: "internal/pkg/file.go", Line: 1},
@@ -378,27 +378,27 @@ func TestToFileURI_Paths(t *testing.T) {
 	}
 }
 
-// TestLoadFromDir_PlaceholderDirs: .gitkeep이 있는 플레이스홀더 디렉토리를 처리하는지 검증
+// TestLoadFromDir_PlaceholderDirs: verifies that placeholder directories with .gitkeep are handled correctly
 func TestLoadFromDir_PlaceholderDirs(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	for _, lang := range []string{"python", "typescript", "rust"} {
 		dir := filepath.Join(tmpDir, lang)
 		if err := os.MkdirAll(dir, 0o755); err != nil {
-			t.Fatalf("디렉토리 생성 실패: %v", err)
+			t.Fatalf("failed to create directory: %v", err)
 		}
 		if err := os.WriteFile(filepath.Join(dir, ".gitkeep"), []byte{}, 0o644); err != nil {
-			t.Fatalf(".gitkeep 작성 실패: %v", err)
+			t.Fatalf("failed to write .gitkeep: %v", err)
 		}
 	}
 
 	goDir := filepath.Join(tmpDir, "go")
 	if err := os.MkdirAll(goDir, 0o755); err != nil {
-		t.Fatalf("go 디렉토리 생성 실패: %v", err)
+		t.Fatalf("failed to create go directory: %v", err)
 	}
 	ruleYAML := "---\nid: go-test-rule\nlanguage: go\nseverity: warning\nmessage: \"테스트\"\npattern: \"fmt.Println($X)\"\n"
 	if err := os.WriteFile(filepath.Join(goDir, "test.yml"), []byte(ruleYAML), 0o644); err != nil {
-		t.Fatalf("규칙 파일 작성 실패: %v", err)
+		t.Fatalf("failed to write rule file: %v", err)
 	}
 
 	loader := astgrep.NewRuleLoader()
@@ -408,11 +408,11 @@ func TestLoadFromDir_PlaceholderDirs(t *testing.T) {
 	}
 
 	if len(rules) != 1 {
-		t.Errorf("LoadFromDir() len(rules) = %d, want 1 (.gitkeep 파일은 무시되어야 함)", len(rules))
+		t.Errorf("LoadFromDir() len(rules) = %d, want 1 (.gitkeep files must be ignored)", len(rules))
 	}
 }
 
-// TestHasErrors_MixedSeverities: 다양한 severity가 섞인 슬라이스에서 HasErrors 동작 검증
+// TestHasErrors_MixedSeverities: verifies HasErrors behavior with a slice of mixed severities
 func TestHasErrors_MixedSeverities(t *testing.T) {
 	findings := []astgrep.Finding{
 		{RuleID: "r1", Severity: "info"},
@@ -421,54 +421,54 @@ func TestHasErrors_MixedSeverities(t *testing.T) {
 	}
 
 	if !astgrep.HasErrors(findings) {
-		t.Error("HasErrors() = false; 대소문자 무관하게 error severity를 감지해야 함")
+		t.Error("HasErrors() = false; must detect error severity case-insensitively")
 	}
 }
 
-// TestFinding_IsInfoForHint: hint severity가 IsError/IsWarning에서 false인지 검증
+// TestFinding_IsInfoForHint: verifies that hint severity returns false for IsError/IsWarning
 func TestFinding_IsInfoForHint(t *testing.T) {
 	f := astgrep.Finding{Severity: "hint"}
 	if f.IsError() {
-		t.Error("hint severity가 IsError() = true를 반환했음")
+		t.Error("hint severity returned IsError() = true")
 	}
 	if f.IsWarning() {
-		t.Error("hint severity가 IsWarning() = true를 반환했음")
+		t.Error("hint severity returned IsWarning() = true")
 	}
 }
 
-// TestScanner_ScanWithSGConfig: sgconfig.yml을 사용한 스캔 (sg 없으면 skip)
+// TestScanner_ScanWithSGConfig: scan using sgconfig.yml (skip if sg is absent)
 func TestScanner_ScanWithSGConfig(t *testing.T) {
 	if _, err := exec.LookPath("sg"); err != nil {
-		t.Skip("sg CLI가 PATH에 없어 스킵합니다")
+		t.Skip("sg CLI is not in PATH, skipping")
 	}
 
 	tmpDir := t.TempDir()
 
-	// 대상 파일 생성
+	// create target file
 	goCode := `package main
 import "fmt"
 func main() { fmt.Println("hello") }
 `
 	if err := os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte(goCode), 0o644); err != nil {
-		t.Fatalf("파일 작성 실패: %v", err)
+		t.Fatalf("failed to write file: %v", err)
 	}
 
-	// sgconfig.yml과 rules 디렉토리 생성
+	// create sgconfig.yml and rules directory
 	rulesDir := filepath.Join(tmpDir, "rules")
 	goDir := filepath.Join(rulesDir, "go")
 	if err := os.MkdirAll(goDir, 0o755); err != nil {
-		t.Fatalf("rules 디렉토리 생성 실패: %v", err)
+		t.Fatalf("failed to create rules directory: %v", err)
 	}
 
 	ruleYAML := "---\nid: sgconfig-test-rule\nlanguage: go\nseverity: warning\nmessage: \"fmt.Println 사용\"\npattern: 'fmt.Println($X)'\n"
 	if err := os.WriteFile(filepath.Join(goDir, "test.yml"), []byte(ruleYAML), 0o644); err != nil {
-		t.Fatalf("규칙 파일 작성 실패: %v", err)
+		t.Fatalf("failed to write rule file: %v", err)
 	}
 
-	// sgconfig.yml 생성
+	// create sgconfig.yml
 	sgconfig := "ruleDirs:\n  - go\n"
 	if err := os.WriteFile(filepath.Join(rulesDir, "sgconfig.yml"), []byte(sgconfig), 0o644); err != nil {
-		t.Fatalf("sgconfig.yml 작성 실패: %v", err)
+		t.Fatalf("failed to write sgconfig.yml: %v", err)
 	}
 
 	cfg := &astgrep.ScannerConfig{
@@ -481,13 +481,13 @@ func main() { fmt.Println("hello") }
 		t.Fatalf("Scan() error = %v", err)
 	}
 
-	// sgconfig.yml 경로를 통한 스캔이 성공해야 함 (findings는 sg 동작에 따라 달라짐)
+	// scan via sgconfig.yml path must succeed (findings depend on sg behavior)
 	if findings == nil {
 		t.Error("Scan() with sgconfig.yml returned nil")
 	}
 }
 
-// TestScanner_String_AllSeverities: Finding.String()이 다양한 severity를 출력하는지 검증
+// TestScanner_String_AllSeverities: verifies that Finding.String() outputs various severities
 func TestScanner_String_AllSeverities(t *testing.T) {
 	tests := []struct {
 		severity string
@@ -518,7 +518,7 @@ func TestScanner_String_AllSeverities(t *testing.T) {
 	}
 }
 
-// TestDefaultScannerConfig_Fields: DefaultScannerConfig 기본값 검증
+// TestDefaultScannerConfig_Fields: verifies default values of DefaultScannerConfig
 func TestDefaultScannerConfig_Fields(t *testing.T) {
 	cfg := astgrep.DefaultScannerConfig()
 	if cfg.SGBinary != "sg" {
@@ -532,7 +532,7 @@ func TestDefaultScannerConfig_Fields(t *testing.T) {
 	}
 }
 
-// containsSubstr는 문자열 s에 substr이 포함되어 있는지 확인하는 헬퍼 함수
+// containsSubstr is a helper function that checks whether string s contains substr
 func containsSubstr(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr ||
 		func() bool {
@@ -545,18 +545,18 @@ func containsSubstr(s, substr string) bool {
 		}())
 }
 
-// --- F2 재현 테스트: Binary allowlist 부재 ---
+// --- F2 regression test: Binary allowlist absence ---
 
-// TestValidateBinary_AllowsSg: "sg", "ast-grep" bare name이 허용되는지 검증
+// TestValidateBinary_AllowsSg: verifies that bare names "sg" and "ast-grep" are allowed
 func TestValidateBinary_AllowsSg(t *testing.T) {
 	for _, name := range []string{"sg", "ast-grep"} {
 		if err := astgrep.ValidateBinary(name); err != nil {
-			t.Errorf("ValidateBinary(%q) = %v; 허용된 bare name이어야 함", name, err)
+			t.Errorf("ValidateBinary(%q) = %v; must be an allowed bare name", name, err)
 		}
 	}
 }
 
-// TestValidateBinary_AllowsTrustedPrefix: /usr/local/bin/sg 같은 신뢰 경로가 허용되는지 검증
+// TestValidateBinary_AllowsTrustedPrefix: verifies that trusted paths like /usr/local/bin/sg are allowed
 func TestValidateBinary_AllowsTrustedPrefix(t *testing.T) {
 	paths := []string{
 		"/usr/bin/sg",
@@ -565,19 +565,19 @@ func TestValidateBinary_AllowsTrustedPrefix(t *testing.T) {
 	}
 	for _, p := range paths {
 		if err := astgrep.ValidateBinary(p); err != nil {
-			t.Errorf("ValidateBinary(%q) = %v; 신뢰 경로여야 함", p, err)
+			t.Errorf("ValidateBinary(%q) = %v; must be a trusted path", p, err)
 		}
 	}
 }
 
-// TestValidateBinary_RejectsUntrustedPath: /tmp 같은 비신뢰 절대 경로가 거부되는지 검증
+// TestValidateBinary_RejectsUntrustedPath: verifies that untrusted absolute paths like /tmp are rejected
 func TestValidateBinary_RejectsUntrustedPath(t *testing.T) {
 	if err := astgrep.ValidateBinary("/tmp/evil/sg"); err == nil {
-		t.Error("ValidateBinary(/tmp/evil/sg) = nil; 비신뢰 경로는 에러를 반환해야 함")
+		t.Error("ValidateBinary(/tmp/evil/sg) = nil; untrusted path must return an error")
 	}
 }
 
-// TestValidateBinary_RejectsShellMetachars: 셸 메타문자가 포함된 바이너리 경로가 거부되는지 검증
+// TestValidateBinary_RejectsShellMetachars: verifies that binary paths containing shell metacharacters are rejected
 func TestValidateBinary_RejectsShellMetachars(t *testing.T) {
 	malicious := []string{
 		"sg; rm -rf /",
@@ -586,19 +586,19 @@ func TestValidateBinary_RejectsShellMetachars(t *testing.T) {
 	}
 	for _, bin := range malicious {
 		if err := astgrep.ValidateBinary(bin); err == nil {
-			t.Errorf("ValidateBinary(%q) = nil; 셸 메타문자는 에러를 반환해야 함", bin)
+			t.Errorf("ValidateBinary(%q) = nil; shell metacharacters must return an error", bin)
 		}
 	}
 }
 
-// TestValidateBinary_RejectsTraversal: ..을 포함한 경로 트래버설이 거부되는지 검증
+// TestValidateBinary_RejectsTraversal: verifies that path traversal with .. is rejected
 func TestValidateBinary_RejectsTraversal(t *testing.T) {
 	if err := astgrep.ValidateBinary("/usr/local/bin/../../tmp/sg"); err == nil {
-		t.Error("ValidateBinary(경로 트래버설) = nil; 에러를 반환해야 함")
+		t.Error("ValidateBinary(path traversal) = nil; must return an error")
 	}
 }
 
-// TestScan_RejectsUntrustedBinary: Scan이 신뢰할 수 없는 바이너리 경로로 에러를 반환하는지 검증
+// TestScan_RejectsUntrustedBinary: verifies that Scan returns an error for an untrusted binary path
 func TestScan_RejectsUntrustedBinary(t *testing.T) {
 	cfg := astgrep.DefaultScannerConfig()
 	cfg.SGBinary = "/tmp/evil/sg"
@@ -606,6 +606,6 @@ func TestScan_RejectsUntrustedBinary(t *testing.T) {
 
 	_, err := s.Scan(context.Background(), ".")
 	if err == nil {
-		t.Error("Scan() with untrusted binary = nil error; 에러를 반환해야 함")
+		t.Error("Scan() with untrusted binary = nil error; must return an error")
 	}
 }

--- a/internal/cli/astgrep.go
+++ b/internal/cli/astgrep.go
@@ -15,7 +15,7 @@ import (
 	"github.com/modu-ai/moai-adk/internal/astgrep"
 )
 
-// astGrepFlags는 ast-grep 서브커맨드의 플래그 값을 담습니다.
+// astGrepFlags holds flag values for the ast-grep subcommand.
 type astGrepFlags struct {
 	format   string
 	lang     string
@@ -24,22 +24,22 @@ type astGrepFlags struct {
 	rulesDir string
 }
 
-// NewAstGrepCmd는 `moai ast-grep` Cobra 커맨드를 생성하여 반환합니다.
+// NewAstGrepCmd creates and returns the `moai ast-grep` Cobra command.
 // REQ-ASTG-UPG-020, REQ-ASTG-UPG-021
 func NewAstGrepCmd() *cobra.Command {
 	flags := &astGrepFlags{}
 
 	cmd := &cobra.Command{
 		Use:   "ast-grep [path]",
-		Short: "ast-grep을 사용하여 코드를 스캔합니다",
-		Long: `ast-grep (sg) CLI를 사용하여 지정된 경로에서 코드 품질 및 보안 규칙을 적용합니다.
+		Short: "Scan code using ast-grep",
+		Long: `Applies code quality and security rules to the specified path using the ast-grep (sg) CLI.
 
-지원하는 출력 형식:
-  text   - 사람이 읽을 수 있는 텍스트 (기본값)
-  json   - 기계 판독 가능한 JSON 배열
-  sarif  - SARIF 2.1.0 형식 (GitHub code scanning 업로드용)
+Supported output formats:
+  text   - Human-readable text (default)
+  json   - Machine-readable JSON array
+  sarif  - SARIF 2.1.0 format (for uploading to GitHub code scanning)
 
-예시:
+Examples:
   moai ast-grep ./
   moai ast-grep --format=sarif --lang=go ./internal/
   moai ast-grep --severity=error ./
@@ -56,17 +56,17 @@ func NewAstGrepCmd() *cobra.Command {
 		},
 	}
 
-	// 플래그 등록 (REQ-ASTG-UPG-021)
-	cmd.Flags().StringVar(&flags.format, "format", "text", "출력 형식: text, json, sarif")
-	cmd.Flags().StringVar(&flags.lang, "lang", "", "특정 언어만 스캔 (예: go, python, typescript)")
-	cmd.Flags().StringVar(&flags.severity, "severity", "", "표시할 최소 severity (error, warning, info)")
-	cmd.Flags().BoolVar(&flags.dry, "dry", false, "적용될 규칙 목록만 출력하고 실제 스캔 미실행")
-	cmd.Flags().StringVar(&flags.rulesDir, "rules-dir", ".moai/config/astgrep-rules", "ast-grep 규칙 디렉토리 경로")
+	// Register flags (REQ-ASTG-UPG-021)
+	cmd.Flags().StringVar(&flags.format, "format", "text", "Output format: text, json, sarif")
+	cmd.Flags().StringVar(&flags.lang, "lang", "", "Scan only the specified language (e.g. go, python, typescript)")
+	cmd.Flags().StringVar(&flags.severity, "severity", "", "Minimum severity to display (error, warning, info)")
+	cmd.Flags().BoolVar(&flags.dry, "dry", false, "Print only the list of rules that would be applied without running the actual scan")
+	cmd.Flags().StringVar(&flags.rulesDir, "rules-dir", ".moai/config/astgrep-rules", "ast-grep rules directory path")
 
 	return cmd
 }
 
-// runAstGrep는 ast-grep 스캔을 실행하고 결과를 출력합니다.
+// runAstGrep runs the ast-grep scan and outputs the results.
 func runAstGrep(cmd *cobra.Command, flags *astGrepFlags, path string) error {
 	cfg := &astgrep.ScannerConfig{
 		RulesDir:     flags.rulesDir,
@@ -74,7 +74,7 @@ func runAstGrep(cmd *cobra.Command, flags *astGrepFlags, path string) error {
 		WarnOnlyMode: false,
 	}
 
-	// --dry: 규칙 목록만 출력
+	// --dry: print only the list of rules
 	if flags.dry {
 		return runDryMode(cmd, cfg, flags)
 	}
@@ -87,20 +87,20 @@ func runAstGrep(cmd *cobra.Command, flags *astGrepFlags, path string) error {
 
 	findings, err := scanner.Scan(ctx, path)
 	if err != nil {
-		return fmt.Errorf("ast-grep 스캔: %w", err)
+		return fmt.Errorf("ast-grep scan: %w", err)
 	}
 
-	// --lang 필터 적용
+	// Apply --lang filter.
 	if flags.lang != "" {
 		findings = filterByLang(findings, flags.lang)
 	}
 
-	// --severity 필터 적용
+	// Apply --severity filter.
 	if flags.severity != "" {
 		findings = filterBySeverity(findings, flags.severity)
 	}
 
-	// 출력 형식에 따라 결과 출력
+	// Output results in the selected format.
 	switch strings.ToLower(flags.format) {
 	case "json":
 		return outputJSON(cmd, findings)
@@ -110,7 +110,7 @@ func runAstGrep(cmd *cobra.Command, flags *astGrepFlags, path string) error {
 		outputText(cmd, findings)
 	}
 
-	// error severity 발견 시 exit code 1 (AC4)
+	// exit code 1 when error-severity findings are found (AC4)
 	if astgrep.HasErrors(findings) {
 		os.Exit(1)
 	}
@@ -118,21 +118,21 @@ func runAstGrep(cmd *cobra.Command, flags *astGrepFlags, path string) error {
 	return nil
 }
 
-// runDryMode는 --dry 플래그가 설정된 경우 규칙 목록만 출력합니다.
+// runDryMode prints only the list of rules when the --dry flag is set.
 func runDryMode(cmd *cobra.Command, cfg *astgrep.ScannerConfig, flags *astGrepFlags) error {
 	loader := astgrep.NewRuleLoader()
 	rules, err := loader.LoadFromDir(cfg.RulesDir)
 	if err != nil {
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "rules 디렉토리를 읽을 수 없습니다: %v\n", err)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "cannot read rules directory: %v\n", err)
 		return nil
 	}
 
 	if len(rules) == 0 {
-		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "적용될 규칙이 없습니다.")
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "no rules to apply")
 		return nil
 	}
 
-	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "적용될 규칙 목록 (%d개):\n", len(rules))
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "rules to apply (%d):\n", len(rules))
 	for _, r := range rules {
 		lang := r.Language
 		if lang == "" {
@@ -147,24 +147,24 @@ func runDryMode(cmd *cobra.Command, cfg *astgrep.ScannerConfig, flags *astGrepFl
 	return nil
 }
 
-// outputText는 finding을 텍스트 형식으로 출력합니다.
+// outputText prints findings in text format.
 func outputText(cmd *cobra.Command, findings []astgrep.Finding) {
 	out := cmd.OutOrStdout()
 	if len(findings) == 0 {
-		_, _ = fmt.Fprintln(out, "발견된 항목이 없습니다.")
+		_, _ = fmt.Fprintln(out, "no findings")
 		return
 	}
 
-	_, _ = fmt.Fprintf(out, "발견된 항목 (%d개):\n\n", len(findings))
+	_, _ = fmt.Fprintf(out, "findings (%d):\n\n", len(findings))
 	for _, f := range findings {
 		_, _ = fmt.Fprintln(out, f.String())
 		if f.Note != "" {
-			_, _ = fmt.Fprintf(out, "  메모: %s\n", f.Note)
+			_, _ = fmt.Fprintf(out, "  note: %s\n", f.Note)
 		}
 	}
 }
 
-// outputJSON은 finding을 JSON 배열로 출력합니다.
+// outputJSON prints findings as a JSON array.
 func outputJSON(cmd *cobra.Command, findings []astgrep.Finding) error {
 	if findings == nil {
 		findings = []astgrep.Finding{}
@@ -173,37 +173,37 @@ func outputJSON(cmd *cobra.Command, findings []astgrep.Finding) error {
 	enc := json.NewEncoder(cmd.OutOrStdout())
 	enc.SetIndent("", "  ")
 	if err := enc.Encode(findings); err != nil {
-		return fmt.Errorf("JSON 인코딩: %w", err)
+		return fmt.Errorf("JSON encoding: %w", err)
 	}
 
 	return nil
 }
 
-// outputSARIF는 finding을 SARIF 2.1.0 형식으로 출력합니다.
+// outputSARIF prints findings in SARIF 2.1.0 format.
 func outputSARIF(cmd *cobra.Command, findings []astgrep.Finding) error {
-	// sg 버전 감지 (실패 시 "unknown" 사용)
+	// Detect the sg version (falls back to "unknown" on failure).
 	sgVersion := detectSGVersion()
 
 	output, err := astgrep.ToSARIF(findings, sgVersion)
 	if err != nil {
-		return fmt.Errorf("SARIF 생성: %w", err)
+		return fmt.Errorf("SARIF generation: %w", err)
 	}
 
 	_, err = cmd.OutOrStdout().Write(output)
 	return err
 }
 
-// sgVersionOnce와 sgVersionResult는 detectSGVersion의 sync.Once 캐싱을 위한 패키지 변수입니다.
-// 포인터를 사용하여 테스트에서 새 인스턴스로 교체할 수 있게 합니다 (sync.Once는 복사 불가).
-// REQ-UTIL-002-009: 동일 프로세스 내에서 sg --version은 한 번만 실행됩니다.
+// sgVersionOnce and sgVersionResult are package-level variables for sync.Once caching in detectSGVersion.
+// Using a pointer allows tests to swap in a new instance (sync.Once cannot be copied).
+// REQ-UTIL-002-009: sg --version is executed at most once within the same process.
 var (
 	sgVersionOnce   = new(sync.Once)
 	sgVersionResult string
 )
 
-// sgVersionExec는 sg --version 실행을 담당하는 함수입니다.
-// 테스트에서 교체 가능(injectable)하여 sg 바이너리 없이도 단위 테스트가 가능합니다.
-// REQ-UTIL-002-008: 5초 timeout 내에 sg --version을 실행하여 trimmed stdout을 반환합니다.
+// sgVersionExec is the function responsible for running sg --version.
+// It is injectable and can be replaced in tests, enabling unit tests without the sg binary.
+// REQ-UTIL-002-008: runs sg --version within a 5-second timeout and returns the trimmed stdout.
 var sgVersionExec = func(sgBinary string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -215,9 +215,9 @@ var sgVersionExec = func(sgBinary string) (string, error) {
 	return string(out), nil
 }
 
-// detectSGVersion은 sg --version의 출력을 파싱하여 버전 문자열을 반환합니다.
-// sync.Once를 통해 결과를 캐싱하므로 동일 프로세스 내에서 sg --version은 한 번만 실행됩니다.
-// 오류(바이너리 없음, timeout, 비정상 종료, 빈 출력) 시 "unknown"을 반환합니다.
+// detectSGVersion parses the output of sg --version and returns the version string.
+// Results are cached via sync.Once, so sg --version runs at most once per process.
+// Returns "unknown" on error (binary not found, timeout, abnormal exit, or empty output).
 // REQ-UTIL-002-008, REQ-UTIL-002-009
 func detectSGVersion() string {
 	sgVersionOnce.Do(func() {
@@ -236,13 +236,13 @@ func detectSGVersion() string {
 	return sgVersionResult
 }
 
-// NOTE: sgVersionOnce は *sync.Once (ポインタ型) であることに注意。
-// テストでは新しいインスタンスへのポインタ置き換えにより sync.Once のリセット相当を実現できる。
+// NOTE: sgVersionOnce is a *sync.Once (pointer type).
+// Tests can achieve the equivalent of resetting sync.Once by replacing the pointer with a new instance.
 
-// filterByLang은 지정된 언어의 규칙에서 발생한 finding만 반환합니다.
-// lang이 빈 문자열이면 전체를 반환합니다.
-// finding.Language가 빈 문자열이면 언어-중립 규칙으로 간주하여 항상 포함합니다.
-// 대소문자를 무시합니다.
+// filterByLang returns only findings produced by rules targeting the specified language.
+// Returns all findings when lang is empty.
+// Findings with an empty Language are treated as language-neutral rules and always included.
+// Comparison is case-insensitive.
 func filterByLang(findings []astgrep.Finding, lang string) []astgrep.Finding {
 	if lang == "" {
 		return findings
@@ -251,7 +251,7 @@ func filterByLang(findings []astgrep.Finding, lang string) []astgrep.Finding {
 	out := make([]astgrep.Finding, 0, len(findings))
 	for _, f := range findings {
 		fl := strings.ToLower(f.Language)
-		// 언어 정보가 없는 finding은 포함 (언어-중립 규칙 허용)
+		// Include findings with no language info (language-neutral rules).
 		if fl == "" || fl == target {
 			out = append(out, f)
 		}
@@ -259,7 +259,7 @@ func filterByLang(findings []astgrep.Finding, lang string) []astgrep.Finding {
 	return out
 }
 
-// filterBySeverity는 지정된 severity 이상의 finding만 반환합니다.
+// filterBySeverity returns only findings at or above the specified severity.
 func filterBySeverity(findings []astgrep.Finding, minSeverity string) []astgrep.Finding {
 	var filtered []astgrep.Finding
 	for _, f := range findings {
@@ -272,7 +272,7 @@ func filterBySeverity(findings []astgrep.Finding, minSeverity string) []astgrep.
 			if f.IsError() || f.IsWarning() {
 				filtered = append(filtered, f)
 			}
-		default: // info: 모두 포함
+		default: // info: include all
 			filtered = append(filtered, f)
 		}
 	}

--- a/internal/cli/astgrep_filter_test.go
+++ b/internal/cli/astgrep_filter_test.go
@@ -1,8 +1,8 @@
 package cli
 
-// F1 재현 테스트: filterByLang 미구현 pass-through
-// Finding.Language 필드와 filterByLang 함수를 직접 테스트한다.
-// 패키지 내부 테스트 (package cli)로 작성하여 비공개 함수에 접근한다.
+// F1 reproduction test: filterByLang unimplemented pass-through
+// Tests the Finding.Language field and filterByLang function directly.
+// Written as a package-internal test (package cli) to access unexported functions.
 
 import (
 	"strings"
@@ -11,7 +11,7 @@ import (
 	"github.com/modu-ai/moai-adk/internal/astgrep"
 )
 
-// TestFilterByLang_KeepsMatchingLanguage: 언어 필터가 일치하는 항목과 언어 정보 없는 항목만 반환하는지 검증
+// TestFilterByLang_KeepsMatchingLanguage: verifies that the language filter returns only matching items and items with no language info
 func TestFilterByLang_KeepsMatchingLanguage(t *testing.T) {
 	findings := []astgrep.Finding{
 		{RuleID: "r1", Language: "go"},
@@ -19,18 +19,18 @@ func TestFilterByLang_KeepsMatchingLanguage(t *testing.T) {
 		{RuleID: "r3", Language: ""},
 	}
 	got := filterByLang(findings, "python")
-	// python + 빈 언어 = 2개 반환
+	// python + empty language = 2 returned
 	if len(got) != 2 {
-		t.Errorf("filterByLang(python) len = %d, want 2 (python 항목 + 언어 정보 없는 항목)", len(got))
+		t.Errorf("filterByLang(python) len = %d, want 2 (python item + item with no language info)", len(got))
 	}
 	for _, f := range got {
 		if strings.ToLower(f.Language) != "python" && f.Language != "" {
-			t.Errorf("filterByLang(python)에 잘못된 언어가 포함됨: %q", f.Language)
+			t.Errorf("filterByLang(python) contains unexpected language: %q", f.Language)
 		}
 	}
 }
 
-// TestFilterByLang_EmptyLang_ReturnsAll: 언어 필터가 비어있으면 전부 반환하는지 검증
+// TestFilterByLang_EmptyLang_ReturnsAll: verifies that an empty language filter returns all items
 func TestFilterByLang_EmptyLang_ReturnsAll(t *testing.T) {
 	findings := []astgrep.Finding{
 		{RuleID: "r1", Language: "go"},
@@ -39,11 +39,11 @@ func TestFilterByLang_EmptyLang_ReturnsAll(t *testing.T) {
 	}
 	got := filterByLang(findings, "")
 	if len(got) != len(findings) {
-		t.Errorf("filterByLang(\"\") len = %d, want %d (전체 반환)", len(got), len(findings))
+		t.Errorf("filterByLang(\"\") len = %d, want %d (return all)", len(got), len(findings))
 	}
 }
 
-// TestFilterByLang_CaseInsensitive: 언어 필터가 대소문자를 무시하는지 검증
+// TestFilterByLang_CaseInsensitive: verifies that the language filter is case-insensitive
 func TestFilterByLang_CaseInsensitive(t *testing.T) {
 	findings := []astgrep.Finding{
 		{RuleID: "r1", Language: "Go"},
@@ -51,8 +51,8 @@ func TestFilterByLang_CaseInsensitive(t *testing.T) {
 		{RuleID: "r3", Language: ""},
 	}
 	got := filterByLang(findings, "go")
-	// Go (대문자) + 빈 언어 = 2개
+	// Go (uppercase) + empty language = 2
 	if len(got) != 2 {
-		t.Errorf("filterByLang(go) 대소문자 무시 테스트: len = %d, want 2", len(got))
+		t.Errorf("filterByLang(go) case-insensitive test: len = %d, want 2", len(got))
 	}
 }

--- a/internal/cli/astgrep_test.go
+++ b/internal/cli/astgrep_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/modu-ai/moai-adk/internal/cli"
 )
 
-// TestAstGrepCmd_HelpFlag: --help 플래그가 성공적으로 동작하는지 검증
+// TestAstGrepCmd_HelpFlag: verifies that the --help flag works successfully
 func TestAstGrepCmd_HelpFlag(t *testing.T) {
 	cmd := cli.NewAstGrepCmd()
 	if cmd == nil {
@@ -22,23 +22,23 @@ func TestAstGrepCmd_HelpFlag(t *testing.T) {
 		t.Error("AstGrepCmd.Use is empty")
 	}
 	if !strings.Contains(cmd.Use, "ast-grep") {
-		t.Errorf("AstGrepCmd.Use = %q; 'ast-grep'를 포함해야 함", cmd.Use)
+		t.Errorf("AstGrepCmd.Use = %q; must contain 'ast-grep'", cmd.Use)
 	}
 }
 
-// TestAstGrepCmd_Flags: 모든 필수 플래그가 등록되어 있는지 검증 (AC4)
+// TestAstGrepCmd_Flags: verifies that all required flags are registered (AC4)
 func TestAstGrepCmd_Flags(t *testing.T) {
 	cmd := cli.NewAstGrepCmd()
 
 	requiredFlags := []string{"format", "lang", "severity", "dry"}
 	for _, flag := range requiredFlags {
 		if cmd.Flags().Lookup(flag) == nil {
-			t.Errorf("플래그 --%s가 등록되지 않았음", flag)
+			t.Errorf("flag --%s is not registered", flag)
 		}
 	}
 }
 
-// TestAstGrepCmd_FormatFlag_ValidValues: --format 플래그가 유효한 값만 수락하는지 검증
+// TestAstGrepCmd_FormatFlag_ValidValues: verifies that the --format flag accepts only valid values
 func TestAstGrepCmd_FormatFlag_ValidValues(t *testing.T) {
 	validFormats := []string{"text", "json", "sarif"}
 
@@ -46,31 +46,31 @@ func TestAstGrepCmd_FormatFlag_ValidValues(t *testing.T) {
 		t.Run(format, func(t *testing.T) {
 			cmd := cli.NewAstGrepCmd()
 			if err := cmd.Flags().Set("format", format); err != nil {
-				t.Errorf("--format=%s 설정 실패: %v", format, err)
+				t.Errorf("failed to set --format=%s: %v", format, err)
 			}
 		})
 	}
 }
 
-// TestAstGrepCmd_DryFlag: --dry 플래그가 규칙 목록만 출력하고 스캔 미실행 (AC4)
+// TestAstGrepCmd_DryFlag: verifies that --dry prints only the rule list without running the scan (AC4)
 func TestAstGrepCmd_DryFlag(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	// 간단한 규칙 파일 생성
+	// Create a simple rule file
 	rulesDir := filepath.Join(tmpDir, "rules", "go")
 	if err := os.MkdirAll(rulesDir, 0o755); err != nil {
-		t.Fatalf("rules 디렉토리 생성 실패: %v", err)
+		t.Fatalf("failed to create rules directory: %v", err)
 	}
 
 	ruleYAML := `---
 id: test-dry-rule
 language: go
 severity: warning
-message: "테스트 규칙"
+message: "test rule"
 pattern: "fmt.Println($X)"
 `
 	if err := os.WriteFile(filepath.Join(rulesDir, "test.yml"), []byte(ruleYAML), 0o644); err != nil {
-		t.Fatalf("규칙 파일 작성 실패: %v", err)
+		t.Fatalf("failed to write rule file: %v", err)
 	}
 
 	var buf bytes.Buffer
@@ -79,18 +79,18 @@ pattern: "fmt.Println($X)"
 	cmd.SetErr(&buf)
 
 	if err := cmd.Flags().Set("dry", "true"); err != nil {
-		t.Fatalf("--dry 플래그 설정 실패: %v", err)
+		t.Fatalf("failed to set --dry flag: %v", err)
 	}
 	if err := cmd.Flags().Set("rules-dir", filepath.Join(tmpDir, "rules")); err != nil {
-		t.Fatalf("--rules-dir 플래그 설정 실패: %v", err)
+		t.Fatalf("failed to set --rules-dir flag: %v", err)
 	}
 
-	// --dry 실행은 rules 디렉토리 파일을 나열하고 종료해야 함 (실제 스캔 없음)
-	// 에러 없이 실행되어야 함
+	// --dry execution should list rules directory files and exit (no actual scan)
+	// Should run without error
 	_ = cmd.Execute()
 }
 
-// TestAstGrepCmd_JsonFormat: --format=json 출력이 파싱 가능한 JSON인지 검증 (AC4)
+// TestAstGrepCmd_JsonFormat: verifies that --format=json output is parseable JSON (AC4)
 func TestAstGrepCmd_JsonFormat(t *testing.T) {
 	tmpDir := t.TempDir()
 
@@ -99,12 +99,12 @@ func TestAstGrepCmd_JsonFormat(t *testing.T) {
 	cmd.SetOut(&buf)
 	cmd.SetErr(&buf)
 
-	// sg가 없는 환경에서도 --format=json이 빈 JSON 배열을 반환해야 함
+	// --format=json should return an empty JSON array even in environments without sg
 	if err := cmd.Flags().Set("format", "json"); err != nil {
-		t.Fatalf("--format=json 설정 실패: %v", err)
+		t.Fatalf("failed to set --format=json: %v", err)
 	}
 	if err := cmd.Flags().Set("rules-dir", filepath.Join(tmpDir, "rules")); err != nil {
-		t.Fatalf("--rules-dir 설정 실패: %v", err)
+		t.Fatalf("failed to set --rules-dir: %v", err)
 	}
 
 	cmd.SetArgs([]string{tmpDir})
@@ -112,17 +112,17 @@ func TestAstGrepCmd_JsonFormat(t *testing.T) {
 
 	output := buf.String()
 	if output == "" {
-		t.Skip("출력이 없음 (sg CLI가 없는 환경)")
+		t.Skip("no output (environment without sg CLI)")
 	}
 
-	// JSON으로 파싱 가능한지 확인
+	// Verify it can be parsed as JSON
 	var result any
 	if err := json.Unmarshal([]byte(strings.TrimSpace(output)), &result); err != nil {
-		t.Logf("JSON 파싱 실패 (sg 없는 환경에서는 허용): %v", err)
+		t.Logf("JSON parse failed (allowed in environment without sg): %v", err)
 	}
 }
 
-// TestAstGrepCmd_SarifFormat: --format=sarif 출력이 SARIF 2.1.0 구조를 가지는지 검증 (AC4)
+// TestAstGrepCmd_SarifFormat: verifies that --format=sarif output has SARIF 2.1.0 structure (AC4)
 func TestAstGrepCmd_SarifFormat(t *testing.T) {
 	tmpDir := t.TempDir()
 
@@ -132,10 +132,10 @@ func TestAstGrepCmd_SarifFormat(t *testing.T) {
 	cmd.SetErr(&buf)
 
 	if err := cmd.Flags().Set("format", "sarif"); err != nil {
-		t.Fatalf("--format=sarif 설정 실패: %v", err)
+		t.Fatalf("failed to set --format=sarif: %v", err)
 	}
 	if err := cmd.Flags().Set("rules-dir", filepath.Join(tmpDir, "rules")); err != nil {
-		t.Fatalf("--rules-dir 설정 실패: %v", err)
+		t.Fatalf("failed to set --rules-dir: %v", err)
 	}
 
 	cmd.SetArgs([]string{tmpDir})
@@ -143,40 +143,39 @@ func TestAstGrepCmd_SarifFormat(t *testing.T) {
 
 	output := strings.TrimSpace(buf.String())
 	if output == "" {
-		t.Skip("출력이 없음 (sg CLI가 없는 환경)")
+		t.Skip("no output (environment without sg CLI)")
 	}
 
-	// SARIF version 필드 확인
+	// Verify SARIF version field
 	var doc map[string]any
 	if err := json.Unmarshal([]byte(output), &doc); err != nil {
-		t.Fatalf("SARIF 출력이 유효한 JSON이 아님: %v", err)
+		t.Fatalf("SARIF output is not valid JSON: %v", err)
 	}
 	if doc["version"] != "2.1.0" {
 		t.Errorf("SARIF version = %v, want 2.1.0", doc["version"])
 	}
 }
 
-// TestAstGrepCmd_SeverityFilter: --severity=error 플래그가 필터로 등록되는지 검증 (AC4)
+// TestAstGrepCmd_SeverityFilter: verifies that the --severity=error flag is registered as a filter (AC4)
 func TestAstGrepCmd_SeverityFilter(t *testing.T) {
 	cmd := cli.NewAstGrepCmd()
 
 	if err := cmd.Flags().Set("severity", "error"); err != nil {
-		t.Errorf("--severity=error 설정 실패: %v", err)
+		t.Errorf("failed to set --severity=error: %v", err)
 	}
 
-	// warning도 유효한 값이어야 함
+	// warning should also be a valid value
 	cmd2 := cli.NewAstGrepCmd()
 	if err := cmd2.Flags().Set("severity", "warning"); err != nil {
-		t.Errorf("--severity=warning 설정 실패: %v", err)
+		t.Errorf("failed to set --severity=warning: %v", err)
 	}
 }
 
-// TestAstGrepCmd_LangFilter: --lang 플래그가 등록되고 값을 받는지 검증 (AC4)
+// TestAstGrepCmd_LangFilter: verifies that the --lang flag is registered and accepts values (AC4)
 func TestAstGrepCmd_LangFilter(t *testing.T) {
 	cmd := cli.NewAstGrepCmd()
 
 	if err := cmd.Flags().Set("lang", "go"); err != nil {
-		t.Errorf("--lang=go 설정 실패: %v", err)
+		t.Errorf("failed to set --lang=go: %v", err)
 	}
 }
-

--- a/internal/cli/constitution.go
+++ b/internal/cli/constitution.go
@@ -13,19 +13,19 @@ import (
 	"github.com/modu-ai/moai-adk/internal/constitution"
 )
 
-// constitutionRegistryEnvKey는 registry 경로를 지정하는 환경 변수 이름이다.
+// constitutionRegistryEnvKey is the environment variable name that specifies the registry path.
 const constitutionRegistryEnvKey = "MOAI_CONSTITUTION_REGISTRY"
 
-// constitutionRegistryRelPath는 기본 registry 파일의 프로젝트 상대 경로이다.
+// constitutionRegistryRelPath is the project-relative path to the default registry file.
 const constitutionRegistryRelPath = ".claude/rules/moai/core/zone-registry.md"
 
-// newConstitutionCmd는 `moai constitution` 루트 서브커맨드를 생성한다.
-// research.go 패턴을 따른다.
+// newConstitutionCmd creates the `moai constitution` root subcommand.
+// Follows the research.go pattern.
 func newConstitutionCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "constitution",
 		Short:   "Manage the zone registry (FROZEN/EVOLVABLE zone codification)",
-		Long:    "Zone registry 조회 및 검증 커맨드. SPEC-V3R2-CON-001 구현.",
+		Long:    "Command for querying and validating the zone registry. Implements SPEC-V3R2-CON-001.",
 		GroupID: "tools",
 	}
 	cmd.AddCommand(newConstitutionListCmd())
@@ -33,51 +33,51 @@ func newConstitutionCmd() *cobra.Command {
 	return cmd
 }
 
-// newConstitutionGuardCmd는 `moai constitution guard` 서브커맨드를 생성한다.
-// --violations 플래그로 변경된 rule ID 목록을 받아 FROZEN zone 위반 여부를 반환한다.
-// SPEC-V3R2-CON-001 AC-CON-001-003 구현.
+// newConstitutionGuardCmd creates the `moai constitution guard` subcommand.
+// Receives a list of changed rule IDs via --violations and reports FROZEN zone violations.
+// Implements SPEC-V3R2-CON-001 AC-CON-001-003.
 func newConstitutionGuardCmd() *cobra.Command {
 	var violationsFlag []string
 
 	cmd := &cobra.Command{
 		Use:   "guard",
 		Short: "Check for FROZEN zone violations",
-		Long:  "변경된 rule ID 목록을 받아 Frozen zone 위반 여부를 점검한다. CI 통합에 사용.",
+		Long:  "Receives a list of changed rule IDs and checks for Frozen zone violations. Used for CI integration.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cwd, err := os.Getwd()
 			if err != nil {
-				return fmt.Errorf("working directory 확인 오류: %w", err)
+				return fmt.Errorf("working directory check error: %w", err)
 			}
 			registryPath := resolveRegistryPath(cwd)
 			return runConstitutionGuard(cmd.OutOrStdout(), cmd.ErrOrStderr(), cwd, registryPath, violationsFlag)
 		},
 	}
 
-	cmd.Flags().StringSliceVar(&violationsFlag, "violations", nil, "변경된 rule ID 목록 (쉼표 구분 또는 반복 플래그)")
+	cmd.Flags().StringSliceVar(&violationsFlag, "violations", nil, "List of changed rule IDs (comma-separated or repeated flag)")
 	return cmd
 }
 
-// runConstitutionGuard는 변경된 rule ID 중 Frozen zone 위반을 탐지한다.
-// violations: 변경된 rule ID 목록 (비어있으면 위반 없음으로 처리).
-// 반환값: Frozen zone 위반 시 에러, 없으면 nil.
+// runConstitutionGuard detects Frozen zone violations among the changed rule IDs.
+// violations: list of changed rule IDs (treated as no violations when empty).
+// Returns an error when Frozen zone violations are found, nil otherwise.
 func runConstitutionGuard(w, wWarn io.Writer, projectDir, registryPath string, violations []string) error {
 	reg, err := constitution.LoadRegistry(registryPath, projectDir)
 	if err != nil {
-		return fmt.Errorf("registry 로드 오류 %q: %w", registryPath, err)
+		return fmt.Errorf("registry load error %q: %w", registryPath, err)
 	}
 
-	// orphan 경고 출력 (stderr)
+	// Print orphan warnings to stderr.
 	for _, warn := range reg.Warnings {
-		_, _ = fmt.Fprintf(wWarn, "경고: %s\n", warn)
+		_, _ = fmt.Fprintf(wWarn, "warning: %s\n", warn)
 	}
 
-	// 변경된 ID 중 Frozen zone 위반 탐지
+	// Detect Frozen zone violations among the changed IDs.
 	var frozenViolations []string
 	for _, id := range violations {
 		rule, ok := reg.Get(id)
 		if !ok {
-			// registry에 없는 ID는 dangling ref - 경고만 출력
-			_, _ = fmt.Fprintf(wWarn, "경고: dangling reference %q - registry에 없는 ID\n", id)
+			// ID not in registry is a dangling ref — print warning only.
+			_, _ = fmt.Fprintf(wWarn, "warning: dangling reference %q - ID not found in registry\n", id)
 			continue
 		}
 		if rule.Zone == constitution.ZoneFrozen {
@@ -86,16 +86,16 @@ func runConstitutionGuard(w, wWarn io.Writer, projectDir, registryPath string, v
 	}
 
 	if len(frozenViolations) > 0 {
-		_, _ = fmt.Fprintf(w, "FROZEN zone 위반 탐지 (%d개): %s\n",
+		_, _ = fmt.Fprintf(w, "FROZEN zone violation detected (%d): %s\n",
 			len(frozenViolations), strings.Join(frozenViolations, ", "))
-		return fmt.Errorf("FROZEN zone 위반: %s", strings.Join(frozenViolations, ", "))
+		return fmt.Errorf("FROZEN zone violation: %s", strings.Join(frozenViolations, ", "))
 	}
 
-	_, _ = fmt.Fprintln(w, "constitution guard: OK - Frozen zone 위반 없음")
+	_, _ = fmt.Fprintln(w, "constitution guard: OK - no Frozen zone violations")
 	return nil
 }
 
-// newConstitutionListCmd는 `moai constitution list` 서브커맨드를 생성한다.
+// newConstitutionListCmd creates the `moai constitution list` subcommand.
 func newConstitutionListCmd() *cobra.Command {
 	var zoneFlag string
 	var fileFlag string
@@ -104,11 +104,11 @@ func newConstitutionListCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List zone registry entries",
-		Long:  "zone registry 엔트리를 출력한다. --zone, --file, --format 플래그로 필터링 가능.",
+		Long:  "Prints zone registry entries. Supports filtering with --zone, --file, and --format flags.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cwd, err := os.Getwd()
 			if err != nil {
-				return fmt.Errorf("working directory 확인 오류: %w", err)
+				return fmt.Errorf("working directory check error: %w", err)
 			}
 
 			registryPath := resolveRegistryPath(cwd)
@@ -117,7 +117,7 @@ func newConstitutionListCmd() *cobra.Command {
 			if zoneFlag != "" {
 				z, parseErr := constitution.ParseZone(zoneFlag)
 				if parseErr != nil {
-					return fmt.Errorf("--zone 파싱 오류: %w", parseErr)
+					return fmt.Errorf("--zone parse error: %w", parseErr)
 				}
 				zoneFilter = &z
 			}
@@ -126,15 +126,15 @@ func newConstitutionListCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&zoneFlag, "zone", "", "Zone 필터 (frozen|evolvable)")
-	cmd.Flags().StringVar(&fileFlag, "file", "", "파일 경로 필터 (부분 일치)")
-	cmd.Flags().StringVar(&formatFlag, "format", "table", "출력 형식 (table|json)")
+	cmd.Flags().StringVar(&zoneFlag, "zone", "", "Zone filter (frozen|evolvable)")
+	cmd.Flags().StringVar(&fileFlag, "file", "", "File path filter (partial match)")
+	cmd.Flags().StringVar(&formatFlag, "format", "table", "Output format (table|json)")
 
 	return cmd
 }
 
-// resolveRegistryPath는 우선순위에 따라 registry 파일 경로를 결정한다.
-// 우선순위: MOAI_CONSTITUTION_REGISTRY 환경변수 → CLAUDE_PROJECT_DIR 기준 경로 → cwd 기준 경로.
+// resolveRegistryPath determines the registry file path according to priority.
+// Priority: MOAI_CONSTITUTION_REGISTRY env var → CLAUDE_PROJECT_DIR-relative path → cwd-relative path.
 func resolveRegistryPath(cwd string) string {
 	if envPath := os.Getenv(constitutionRegistryEnvKey); envPath != "" {
 		return envPath
@@ -147,21 +147,21 @@ func resolveRegistryPath(cwd string) string {
 	return filepath.Join(cwd, constitutionRegistryRelPath)
 }
 
-// runConstitutionList는 registry를 로드하고 w에 출력한다.
-// 경고는 wWarn (stderr)에 출력하여 stdout 출력을 오염시키지 않는다.
-// 테스트 친화적 순수 함수.
+// runConstitutionList loads the registry and writes its entries to w.
+// Warnings are written to wWarn (stderr) to avoid polluting stdout output.
+// Pure function, test-friendly.
 func runConstitutionList(w, wWarn io.Writer, projectDir, registryPath string, zoneFilter *constitution.Zone, fileFilter, format string) error {
 	reg, err := constitution.LoadRegistry(registryPath, projectDir)
 	if err != nil {
-		return fmt.Errorf("registry 로드 오류 %q: %w", registryPath, err)
+		return fmt.Errorf("registry load error %q: %w", registryPath, err)
 	}
 
-	// 경고는 stderr(wWarn)에 출력
+	// Write warnings to stderr (wWarn).
 	for _, warn := range reg.Warnings {
-		_, _ = fmt.Fprintf(wWarn, "경고: %s\n", warn)
+		_, _ = fmt.Fprintf(wWarn, "warning: %s\n", warn)
 	}
 
-	// 필터 적용
+	// Apply filters
 	entries := reg.Entries
 	if zoneFilter != nil {
 		entries = reg.FilterByZone(*zoneFilter)
@@ -185,12 +185,12 @@ func runConstitutionList(w, wWarn io.Writer, projectDir, registryPath string, zo
 	}
 }
 
-// constitutionJSONOutput은 JSON 형식 출력 구조체이다.
+// constitutionJSONOutput is the output struct for JSON format.
 type constitutionJSONOutput struct {
 	Entries []constitutionJSONEntry `json:"entries"`
 }
 
-// constitutionJSONEntry는 JSON 직렬화용 엔트리 구조체이다.
+// constitutionJSONEntry is the entry struct for JSON serialization.
 type constitutionJSONEntry struct {
 	ID         string `json:"id"`
 	Zone       string `json:"zone"`
@@ -200,7 +200,7 @@ type constitutionJSONEntry struct {
 	CanaryGate bool   `json:"canary_gate"`
 }
 
-// renderConstitutionJSON은 JSON 형식으로 엔트리를 출력한다.
+// renderConstitutionJSON prints entries in JSON format.
 func renderConstitutionJSON(w io.Writer, entries []constitution.Rule) error {
 	jsonEntries := make([]constitutionJSONEntry, 0, len(entries))
 	for _, e := range entries {
@@ -217,18 +217,18 @@ func renderConstitutionJSON(w io.Writer, entries []constitution.Rule) error {
 	out := constitutionJSONOutput{Entries: jsonEntries}
 	data, err := json.MarshalIndent(out, "", "  ")
 	if err != nil {
-		return fmt.Errorf("JSON 직렬화 오류: %w", err)
+		return fmt.Errorf("JSON serialization error: %w", err)
 	}
 
 	_, _ = fmt.Fprintln(w, string(data))
 	return nil
 }
 
-// renderConstitutionTable은 table 형식으로 엔트리를 출력한다.
-// Clause는 -v 옵션 없이는 40자로 잘린다.
+// renderConstitutionTable prints entries in table format.
+// Clause is truncated to 40 characters unless -v is specified.
 func renderConstitutionTable(w io.Writer, entries []constitution.Rule) {
 	if len(entries) == 0 {
-		_, _ = fmt.Fprintln(w, "엔트리 없음.")
+		_, _ = fmt.Fprintln(w, "no entries")
 		return
 	}
 
@@ -267,5 +267,5 @@ func renderConstitutionTable(w io.Writer, entries []constitution.Rule) {
 		_, _ = fmt.Fprintln(w, line)
 	}
 
-	_, _ = fmt.Fprintf(w, "\n총 %d개 엔트리\n", len(entries))
+	_, _ = fmt.Fprintf(w, "\ntotal %d entries\n", len(entries))
 }

--- a/internal/cli/constitution_guard_test.go
+++ b/internal/cli/constitution_guard_test.go
@@ -9,39 +9,39 @@ import (
 	"testing"
 )
 
-// setupGuardRegistry는 guard 테스트용 임시 registry를 생성한다.
-// projectDir 아래에 CLAUDE.md와 zone-registry.md를 생성한다.
+// setupGuardRegistry creates a temporary registry for guard tests.
+// Creates CLAUDE.md and zone-registry.md under projectDir.
 func setupGuardRegistry(t *testing.T, content string) (projectDir, registryPath string) {
 	t.Helper()
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "CLAUDE.md"), []byte("# Test"), 0o600); err != nil {
-		t.Fatalf("CLAUDE.md 생성 오류: %v", err)
+		t.Fatalf("failed to create CLAUDE.md: %v", err)
 	}
 	regPath := filepath.Join(dir, "zone-registry.md")
 	if err := os.WriteFile(regPath, []byte(content), 0o600); err != nil {
-		t.Fatalf("registry 파일 생성 오류: %v", err)
+		t.Fatalf("failed to create registry file: %v", err)
 	}
 	return dir, regPath
 }
 
-// TestConstitutionGuard_NoViolations는 Frozen zone 변경이 없는 경우 OK를 반환함을 검증한다.
-// AC-CON-001-003 관련.
+// TestConstitutionGuard_NoViolations verifies that OK is returned when there are no Frozen zone changes.
+// Related to AC-CON-001-003.
 func TestConstitutionGuard_NoViolations(t *testing.T) {
 	dir, regPath := setupGuardRegistry(t, validConstitutionRegistryForDoctor)
 
 	var buf bytes.Buffer
 	result := runConstitutionGuard(&buf, io.Discard, dir, regPath, []string{})
 	if result != nil {
-		t.Errorf("위반 없음 시 nil 반환 기대, got: %v", result)
+		t.Errorf("expected nil when no violations, got: %v", result)
 	}
 
 	output := buf.String()
-	if !strings.Contains(output, "OK") && !strings.Contains(output, "no violations") && !strings.Contains(output, "위반") {
-		t.Logf("출력: %s", output)
+	if !strings.Contains(output, "OK") && !strings.Contains(output, "no violations") && !strings.Contains(output, "violation") {
+		t.Logf("output: %s", output)
 	}
 }
 
-// TestConstitutionGuard_RegistryMissing은 registry 없음 시 에러를 반환함을 검증한다.
+// TestConstitutionGuard_RegistryMissing verifies that an error is returned when the registry is absent.
 func TestConstitutionGuard_RegistryMissing(t *testing.T) {
 	dir := t.TempDir()
 	nonExistentPath := filepath.Join(dir, "nonexistent.md")
@@ -49,29 +49,29 @@ func TestConstitutionGuard_RegistryMissing(t *testing.T) {
 	var buf bytes.Buffer
 	result := runConstitutionGuard(&buf, io.Discard, dir, nonExistentPath, []string{})
 	if result == nil {
-		t.Fatal("registry 없음 시 에러를 반환해야 한다")
+		t.Fatal("must return an error when registry is missing")
 	}
 }
 
-// TestConstitutionGuard_DetectsFrozenViolation은 Frozen zone 변경 탐지를 검증한다.
-// AC-CON-001-003 직접 매핑.
+// TestConstitutionGuard_DetectsFrozenViolation verifies detection of Frozen zone changes.
+// Direct mapping to AC-CON-001-003.
 func TestConstitutionGuard_DetectsFrozenViolation(t *testing.T) {
 	dir, regPath := setupGuardRegistry(t, validConstitutionRegistryForDoctor)
 
-	// 위반 목록: Frozen 엔트리 ID를 포함
+	// Violation list: includes a Frozen entry ID
 	violations := []string{"CONST-V3R2-001"}
 	var buf bytes.Buffer
 	result := runConstitutionGuard(&buf, io.Discard, dir, regPath, violations)
 
 	if result == nil {
-		t.Fatal("Frozen 위반 탐지 시 에러를 반환해야 한다")
+		t.Fatal("must return an error when a Frozen violation is detected")
 	}
 	if !strings.Contains(result.Error(), "CONST-V3R2-001") {
-		t.Errorf("에러 메시지에 위반 ID가 포함되어야 한다: %v", result)
+		t.Errorf("error message must contain the violation ID: %v", result)
 	}
 }
 
-// TestConstitutionGuard_EvolvableViolationNotFatal은 Evolvable zone 변경이 에러가 아님을 검증한다.
+// TestConstitutionGuard_EvolvableViolationNotFatal verifies that Evolvable zone changes are not errors.
 func TestConstitutionGuard_EvolvableViolationNotFatal(t *testing.T) {
 	dir, regPath := setupGuardRegistry(t, validConstitutionRegistryForDoctor)
 
@@ -81,11 +81,11 @@ func TestConstitutionGuard_EvolvableViolationNotFatal(t *testing.T) {
 	result := runConstitutionGuard(&buf, io.Discard, dir, regPath, violations)
 
 	if result != nil {
-		t.Errorf("Evolvable zone 변경은 에러가 아니어야 한다: %v", result)
+		t.Errorf("Evolvable zone changes must not be errors: %v", result)
 	}
 }
 
-// TestConstitutionGuard_SubcommandExists는 guard 서브커맨드가 등록되어 있음을 검증한다.
+// TestConstitutionGuard_SubcommandExists verifies that the guard subcommand is registered.
 func TestConstitutionGuard_SubcommandExists(t *testing.T) {
 	constitutionCmd := newConstitutionCmd()
 	var found bool
@@ -96,6 +96,6 @@ func TestConstitutionGuard_SubcommandExists(t *testing.T) {
 		}
 	}
 	if !found {
-		t.Error("constitution guard 서브커맨드가 등록되어 있어야 한다")
+		t.Error("constitution guard subcommand must be registered")
 	}
 }

--- a/internal/cli/constitution_integration_test.go
+++ b/internal/cli/constitution_integration_test.go
@@ -14,19 +14,19 @@ import (
 	"github.com/modu-ai/moai-adk/internal/constitution"
 )
 
-// TestConstitutionList_RealRegistry는 실제 zone-registry.md를 사용한 통합 테스트다.
-// 실제 registry 파일이 존재하는 환경에서만 실행된다.
-// AC-CON-001-001, AC-CON-001-002 관련.
+// TestConstitutionList_RealRegistry is an integration test using the actual zone-registry.md.
+// Runs only in environments where the actual registry file exists.
+// Related to AC-CON-001-001, AC-CON-001-002.
 func TestConstitutionList_RealRegistry(t *testing.T) {
-	// 실제 zone-registry.md 경로 탐색
+	// Find the actual zone-registry.md path
 	registryPath := os.Getenv("MOAI_CONSTITUTION_REGISTRY")
 	if registryPath == "" {
-		// 프로젝트 루트 기준으로 탐색
+		// Search relative to the project root
 		cwd, err := os.Getwd()
 		if err != nil {
-			t.Skipf("cwd 확인 불가: %v", err)
+			t.Skipf("cannot determine cwd: %v", err)
 		}
-		// internal/cli에서 프로젝트 루트까지 상위 이동
+		// Walk up from internal/cli to the project root
 		projectRoot := filepath.Join(cwd, "..", "..")
 		registryPath = filepath.Join(projectRoot, ".claude", "rules", "moai", "core", "zone-registry.md")
 	}
@@ -41,11 +41,11 @@ func TestConstitutionList_RealRegistry(t *testing.T) {
 		var buf bytes.Buffer
 		err := runConstitutionList(&buf, io.Discard, projectDir, registryPath, nil, "", "table")
 		if err != nil {
-			t.Fatalf("runConstitutionList 오류: %v", err)
+			t.Fatalf("runConstitutionList error: %v", err)
 		}
 		output := buf.String()
 		if !strings.Contains(output, "CONST-V3R2-001") {
-			t.Errorf("실제 registry에 CONST-V3R2-001이 포함되어야 한다\n출력: %s", output)
+			t.Errorf("actual registry must contain CONST-V3R2-001\noutput: %s", output)
 		}
 	})
 
@@ -54,11 +54,11 @@ func TestConstitutionList_RealRegistry(t *testing.T) {
 		var buf bytes.Buffer
 		err := runConstitutionList(&buf, io.Discard, projectDir, registryPath, &frozen, "", "table")
 		if err != nil {
-			t.Fatalf("--zone frozen 오류: %v", err)
+			t.Fatalf("--zone frozen error: %v", err)
 		}
 		output := buf.String()
 		if strings.Contains(output, "Evolvable") {
-			t.Errorf("Frozen 필터 결과에 Evolvable이 포함되어서는 안 된다")
+			t.Errorf("Frozen filter result must not contain Evolvable")
 		}
 	})
 
@@ -66,18 +66,18 @@ func TestConstitutionList_RealRegistry(t *testing.T) {
 		var buf bytes.Buffer
 		err := runConstitutionList(&buf, io.Discard, projectDir, registryPath, nil, "", "json")
 		if err != nil {
-			t.Fatalf("--format json 오류: %v", err)
+			t.Fatalf("--format json error: %v", err)
 		}
 		var result struct {
 			Entries []map[string]any `json:"entries"`
 		}
 		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
-			t.Fatalf("JSON 파싱 오류: %v\n출력: %s", err, buf.String())
+			t.Fatalf("JSON parse error: %v\noutput: %s", err, buf.String())
 		}
 		if len(result.Entries) == 0 {
-			t.Error("실제 registry JSON에 entries가 있어야 한다")
+			t.Error("actual registry JSON must have entries")
 		}
-		t.Logf("실제 registry: %d entries", len(result.Entries))
+		t.Logf("actual registry: %d entries", len(result.Entries))
 	})
 
 	t.Run("minimum frozen entries", func(t *testing.T) {
@@ -85,15 +85,15 @@ func TestConstitutionList_RealRegistry(t *testing.T) {
 		var buf bytes.Buffer
 		err := runConstitutionList(&buf, io.Discard, projectDir, registryPath, &frozen, "", "json")
 		if err != nil {
-			t.Fatalf("--zone frozen --format json 오류: %v", err)
+			t.Fatalf("--zone frozen --format json error: %v", err)
 		}
 		var result struct {
 			Entries []map[string]any `json:"entries"`
 		}
 		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
-			t.Fatalf("JSON 파싱 오류: %v", err)
+			t.Fatalf("JSON parse error: %v", err)
 		}
-		// AC-CON-001-006: 최소 7개의 Frozen 불변 조항이 있어야 한다
+		// AC-CON-001-006: must have at least 7 Frozen invariant clauses
 		const minFrozen = 7
 		if len(result.Entries) < minFrozen {
 			t.Errorf("Frozen entries = %d, want >= %d (7 canonical invariants)", len(result.Entries), minFrozen)
@@ -101,13 +101,13 @@ func TestConstitutionList_RealRegistry(t *testing.T) {
 	})
 }
 
-// TestConstitutionGuard_RealRegistry는 실제 registry를 사용한 guard 통합 테스트다.
+// TestConstitutionGuard_RealRegistry is a guard integration test using the actual registry.
 func TestConstitutionGuard_RealRegistry(t *testing.T) {
 	registryPath := os.Getenv("MOAI_CONSTITUTION_REGISTRY")
 	if registryPath == "" {
 		cwd, err := os.Getwd()
 		if err != nil {
-			t.Skipf("cwd 확인 불가: %v", err)
+			t.Skipf("cannot determine cwd: %v", err)
 		}
 		projectRoot := filepath.Join(cwd, "..", "..")
 		registryPath = filepath.Join(projectRoot, ".claude", "rules", "moai", "core", "zone-registry.md")
@@ -123,7 +123,7 @@ func TestConstitutionGuard_RealRegistry(t *testing.T) {
 		var buf bytes.Buffer
 		err := runConstitutionGuard(&buf, io.Discard, projectDir, registryPath, []string{})
 		if err != nil {
-			t.Errorf("위반 없음 시 nil 반환 기대: %v", err)
+			t.Errorf("expected nil when no violations: %v", err)
 		}
 	})
 
@@ -131,7 +131,7 @@ func TestConstitutionGuard_RealRegistry(t *testing.T) {
 		var buf bytes.Buffer
 		err := runConstitutionGuard(&buf, io.Discard, projectDir, registryPath, []string{"CONST-V3R2-001"})
 		if err == nil {
-			t.Error("CONST-V3R2-001 변경은 Frozen zone 위반이므로 에러를 반환해야 한다")
+			t.Error("changing CONST-V3R2-001 is a Frozen zone violation and must return an error")
 		}
 	})
 }

--- a/internal/cli/constitution_test.go
+++ b/internal/cli/constitution_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/modu-ai/moai-adk/internal/constitution"
 )
 
-// sampleRegistryContent는 테스트용 minimal registry 마크다운이다.
+// sampleRegistryContent is a minimal registry markdown for testing.
 const sampleRegistryContent = `# Test Registry
 
 ## Entries
@@ -42,63 +42,63 @@ const sampleRegistryContent = `# Test Registry
 ` + "```" + `
 `
 
-// TestConstitutionListAllEntries는 registry 전체 엔트리 렌더링을 검증한다.
-// AC-CON-001-001 관련.
+// TestConstitutionListAllEntries verifies full entry rendering of the registry.
+// Related to AC-CON-001-001.
 func TestConstitutionListAllEntries(t *testing.T) {
 	dir := t.TempDir()
 	registryPath := filepath.Join(dir, "zone-registry.md")
 	if err := os.WriteFile(registryPath, []byte(sampleRegistryContent), 0o600); err != nil {
-		t.Fatalf("registry 파일 생성 오류: %v", err)
+		t.Fatalf("failed to create registry file: %v", err)
 	}
 
 	var buf bytes.Buffer
 	err := runConstitutionList(&buf, io.Discard, dir, registryPath, nil, "", "table")
 	if err != nil {
-		t.Fatalf("runConstitutionList 오류: %v", err)
+		t.Fatalf("runConstitutionList error: %v", err)
 	}
 
 	output := buf.String()
-	// 모든 3개 엔트리가 출력에 포함되어야 한다
+	// All 3 entries must be present in the output
 	for _, id := range []string{"CONST-V3R2-001", "CONST-V3R2-002", "CONST-V3R2-003"} {
 		if !strings.Contains(output, id) {
-			t.Errorf("출력에 %q가 포함되지 않았다\n출력: %s", id, output)
+			t.Errorf("%q not found in output\noutput: %s", id, output)
 		}
 	}
 }
 
-// TestConstitutionListFilterFrozen은 --zone frozen 필터를 검증한다.
-// AC-CON-001-002 직접 매핑.
+// TestConstitutionListFilterFrozen verifies the --zone frozen filter.
+// Direct mapping to AC-CON-001-002.
 func TestConstitutionListFilterFrozen(t *testing.T) {
 	dir := t.TempDir()
 	registryPath := filepath.Join(dir, "zone-registry.md")
 	if err := os.WriteFile(registryPath, []byte(sampleRegistryContent), 0o600); err != nil {
-		t.Fatalf("registry 파일 생성 오류: %v", err)
+		t.Fatalf("failed to create registry file: %v", err)
 	}
 
 	frozenZone := constitution.ZoneFrozen
 	var buf bytes.Buffer
 	err := runConstitutionList(&buf, io.Discard, dir, registryPath, &frozenZone, "", "table")
 	if err != nil {
-		t.Fatalf("runConstitutionList --zone frozen 오류: %v", err)
+		t.Fatalf("runConstitutionList --zone frozen error: %v", err)
 	}
 
 	output := buf.String()
 
-	// Frozen 엔트리만 포함되어야 한다
+	// Only Frozen entries should be included
 	if !strings.Contains(output, "CONST-V3R2-001") {
-		t.Errorf("출력에 CONST-V3R2-001이 포함되지 않았다")
+		t.Errorf("CONST-V3R2-001 not found in output")
 	}
 	if !strings.Contains(output, "CONST-V3R2-002") {
-		t.Errorf("출력에 CONST-V3R2-002가 포함되지 않았다")
+		t.Errorf("CONST-V3R2-002 not found in output")
 	}
 
-	// Evolvable 엔트리는 제외되어야 한다
+	// Evolvable entries should be excluded
 	if strings.Contains(output, "CONST-V3R2-003") {
-		t.Errorf("출력에 Evolvable 엔트리 CONST-V3R2-003이 포함되어서는 안 된다")
+		t.Errorf("Evolvable entry CONST-V3R2-003 must not be in output")
 	}
 }
 
-// TestConstitutionListFilterByFile은 --file 필터를 검증한다.
+// TestConstitutionListFilterByFile verifies the --file filter.
 func TestConstitutionListFilterByFile(t *testing.T) {
 	dir := t.TempDir()
 	registryPath := filepath.Join(dir, "zone-registry.md")
@@ -124,56 +124,56 @@ func TestConstitutionListFilterByFile(t *testing.T) {
 ` + "```" + `
 `
 	if err := os.WriteFile(registryPath, []byte(content), 0o600); err != nil {
-		t.Fatalf("registry 파일 생성 오류: %v", err)
+		t.Fatalf("failed to create registry file: %v", err)
 	}
 
 	var buf bytes.Buffer
 	err := runConstitutionList(&buf, io.Discard, dir, registryPath, nil, "CLAUDE.md", "table")
 	if err != nil {
-		t.Fatalf("runConstitutionList --file 오류: %v", err)
+		t.Fatalf("runConstitutionList --file error: %v", err)
 	}
 
 	output := buf.String()
 
 	if !strings.Contains(output, "CONST-V3R2-001") {
-		t.Errorf("출력에 CONST-V3R2-001이 포함되지 않았다")
+		t.Errorf("CONST-V3R2-001 not found in output")
 	}
 	if strings.Contains(output, "CONST-V3R2-002") {
-		t.Errorf("출력에 moai-constitution.md 엔트리가 포함되어서는 안 된다")
+		t.Errorf("moai-constitution.md entry must not be in output")
 	}
 }
 
-// TestConstitutionListJSON은 JSON 형식 출력을 검증한다.
+// TestConstitutionListJSON verifies JSON format output.
 func TestConstitutionListJSON(t *testing.T) {
 	dir := t.TempDir()
 	registryPath := filepath.Join(dir, "zone-registry.md")
 	if err := os.WriteFile(registryPath, []byte(sampleRegistryContent), 0o600); err != nil {
-		t.Fatalf("registry 파일 생성 오류: %v", err)
+		t.Fatalf("failed to create registry file: %v", err)
 	}
 
 	var buf bytes.Buffer
 	err := runConstitutionList(&buf, io.Discard, dir, registryPath, nil, "", "json")
 	if err != nil {
-		t.Fatalf("runConstitutionList --format json 오류: %v", err)
+		t.Fatalf("runConstitutionList --format json error: %v", err)
 	}
 
 	output := buf.String()
 
-	// 유효한 JSON이어야 한다
+	// Must be valid JSON
 	var result struct {
 		Entries []map[string]any `json:"entries"`
 	}
 	if err := json.Unmarshal([]byte(output), &result); err != nil {
-		t.Fatalf("JSON 파싱 오류: %v\n출력: %s", err, output)
+		t.Fatalf("JSON parse error: %v\noutput: %s", err, output)
 	}
 
 	if len(result.Entries) != 3 {
-		t.Errorf("JSON entries 수 = %d, want 3", len(result.Entries))
+		t.Errorf("JSON entries count = %d, want 3", len(result.Entries))
 	}
 }
 
-// TestConstitutionListRegistryMissing_FileNotFound는 registry 파일 없음 시 에러를 검증한다.
-// AC-CON-001-013 직접 매핑 (file-missing subtest).
+// TestConstitutionListRegistryMissing_FileNotFound verifies that an error is returned when the registry file is absent.
+// Direct mapping to AC-CON-001-013 (file-missing subtest).
 func TestConstitutionListRegistryMissing_FileNotFound(t *testing.T) {
 	dir := t.TempDir()
 	nonExistentPath := filepath.Join(dir, "nonexistent-registry.md")
@@ -181,12 +181,12 @@ func TestConstitutionListRegistryMissing_FileNotFound(t *testing.T) {
 	var buf bytes.Buffer
 	err := runConstitutionList(&buf, io.Discard, dir, nonExistentPath, nil, "", "table")
 	if err == nil {
-		t.Fatal("존재하지 않는 registry 경로에서 오류를 반환해야 한다")
+		t.Fatal("must return an error for a non-existent registry path")
 	}
 
 	errMsg := err.Error()
 	if !strings.Contains(errMsg, nonExistentPath) {
-		t.Errorf("오류 메시지에 경로 %q가 포함되어야 한다: %v", nonExistentPath, err)
+		t.Errorf("error message must contain path %q: %v", nonExistentPath, err)
 	}
 }
 
@@ -196,7 +196,7 @@ func TestConstitutionListRegistryMissing_FileNotFound(t *testing.T) {
 //
 // Skipped on Windows: os.Chmod(path, 0o000) does not remove read access on
 // Windows because the Windows ACL model does not honor POSIX permission bits
-// in the same way. The test relies on a POSIX permission semantics.
+// in the same way. The test relies on POSIX permission semantics.
 func TestConstitutionListRegistryMissing_PermissionDenied(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("POSIX permission semantics required; skipped on Windows")
@@ -208,12 +208,12 @@ func TestConstitutionListRegistryMissing_PermissionDenied(t *testing.T) {
 	dir := t.TempDir()
 	registryPath := filepath.Join(dir, "zone-registry.md")
 	if err := os.WriteFile(registryPath, []byte(sampleRegistryContent), 0o600); err != nil {
-		t.Fatalf("registry 파일 생성 오류: %v", err)
+		t.Fatalf("failed to create registry file: %v", err)
 	}
 
-	// 권한 제거
+	// Remove permissions
 	if err := os.Chmod(registryPath, 0o000); err != nil {
-		t.Fatalf("chmod 오류: %v", err)
+		t.Fatalf("chmod error: %v", err)
 	}
 	defer func() {
 		_ = os.Chmod(registryPath, 0o600)
@@ -222,6 +222,6 @@ func TestConstitutionListRegistryMissing_PermissionDenied(t *testing.T) {
 	var buf bytes.Buffer
 	err := runConstitutionList(&buf, io.Discard, dir, registryPath, nil, "", "table")
 	if err == nil {
-		t.Fatal("권한 없는 registry 파일에서 오류를 반환해야 한다")
+		t.Fatal("must return an error for a registry file with no permissions")
 	}
 }

--- a/internal/cli/deps.go
+++ b/internal/cli/deps.go
@@ -79,27 +79,27 @@ func InitDependencies() {
 	cwd, _ := os.Getwd()
 
 	// GOPLS-BRIDGE-001: gopls bridge wiring
-	// lsp.yaml에서 gopls 브릿지 설정을 로드하고, 활성화되어 있으면 bridge를 생성한다.
-	// gopls 바이너리가 없거나 설정이 비활성화된 경우 bridge=nil로 fallback한다.
+	// Load gopls bridge config from lsp.yaml; create the bridge when enabled.
+	// Falls back to bridge=nil when the gopls binary is absent or the setting is disabled.
 	lspConfigPath := filepath.Join(cwd, ".moai", "config", "sections", "lsp.yaml")
 	goplsCfg, cfgErr := gopls.LoadConfig(lspConfigPath)
 	var goplsBridge loop.GoplsBridge
 	if cfgErr != nil {
-		slog.Warn("gopls 설정 로드 실패, LSP 진단 비활성화",
+		slog.Warn("gopls config load failed; LSP diagnostics disabled",
 			"path", lspConfigPath,
 			"error", cfgErr,
 		)
 	} else if goplsCfg.Enabled {
-		// context.Background()를 사용한다: bridge는 프로세스 수명 동안 유지된다.
+		// Use context.Background(): the bridge lives for the entire process lifetime.
 		bridge, bridgeErr := gopls.NewBridge(context.Background(), cwd, goplsCfg)
 		if bridgeErr != nil {
-			slog.Warn("gopls bridge 초기화 실패, LSP 진단 비활성화", "error", bridgeErr)
+			slog.Warn("gopls bridge initialization failed; LSP diagnostics disabled", "error", bridgeErr)
 		} else if bridge != nil {
 			goplsBridge = bridge
-			slog.Info("gopls bridge 활성화됨", "binary", goplsCfg.Binary)
+			slog.Info("gopls bridge enabled", "binary", goplsCfg.Binary)
 		}
 	} else {
-		slog.Info("gopls bridge 비활성화됨 (lsp.yaml: enabled=false)")
+		slog.Info("gopls bridge disabled (lsp.yaml: enabled=false)")
 	}
 
 	feedbackGen := loop.NewGoFeedbackGeneratorWithBridge(cwd, goplsBridge)
@@ -131,13 +131,13 @@ func InitDependencies() {
 	})
 
 	// Initialize LSP diagnostics collector and AST analyzer.
-	// GOPLS-BRIDGE-001: gopls bridge가 활성화된 경우 hook 레이어의 LSP 클라이언트는
-	// 여전히 nil이다 — hook/lsp는 별도 통합 경로이며 bridge와 분리되어 있다.
-	// @MX:NOTE: [AUTO] goplsBridge (loop 레이어)와 lsphook LSP 클라이언트(hook 레이어)는
-	// 별개 경로다. 전자는 Feedback.Diagnostics를 채우고, 후자는 PostTool 훅을 담당한다.
+	// GOPLS-BRIDGE-001: when the gopls bridge is active, the hook-layer LSP client
+	// remains nil — hook/lsp is a separate integration path, independent of the bridge.
+	// @MX:NOTE: [AUTO] goplsBridge (loop layer) and lsphook LSP client (hook layer) are
+	// separate paths. The former populates Feedback.Diagnostics; the latter handles the PostTool hook.
 	fallbackDiags := lsphook.NewFallbackDiagnosticsWithCircuitBreaker(lspCircuitBreaker)
 	if goplsBridge == nil {
-		slog.Warn("gopls bridge 비활성화 — quality gates fall back to CLI tools only",
+		slog.Warn("gopls bridge disabled — quality gates fall back to CLI tools only",
 			"impact", "gopls-backed diagnostics are disabled; phase-aware LSP gates bypassed",
 			"fallback", "go vet, go test, golangci-lint, ast-grep",
 			"gopls_bridge_status", "disabled",

--- a/internal/cli/design_folder.go
+++ b/internal/cli/design_folder.go
@@ -61,13 +61,19 @@ func designDirHasRegularFile(dir string) (bool, error) {
 	return false, nil
 }
 
-// checkReservedCollision 함수는 projectRoot/.moai/design/ 내 사용자 파일이
-// reserved filename(exact match 또는 glob match)과 충돌하는지 검사한다.
+// @MX:ANCHOR: [AUTO] checkReservedCollision enforces the SPEC-V3R3-DESIGN-FOLDER-FIX-001 dual-mode invariant
+// @MX:REASON: invariant contract — scaffold path (strict=true) keeps hard error, update path (strict=false) warns and continues; user data is never mutated
+// @MX:SPEC: SPEC-V3R3-DESIGN-FOLDER-FIX-001
 //
-// strict=true (scaffold path): 첫 번째 충돌 발견 시 error 반환 (기존 동작 유지).
-// strict=false (update path): 모든 충돌에 대해 warning 출력 후 nil 반환.
-//   - 사용자 데이터는 어떤 경우에도 수정·삭제되지 않음 (REQ-DFF-004).
-//   - 충돌 파일을 건너뛰고 다른 templates sync는 계속 진행됨 (REQ-DFF-001/002).
+// checkReservedCollision checks whether any user file under projectRoot/.moai/design/
+// collides with a reserved filename (exact match or glob match).
+//
+// strict=true (scaffold path): returns an error on the first collision found (preserves
+// the original behavior).
+// strict=false (update path): emits a warning for each collision and returns nil.
+//   - User data is never modified or deleted in any case (REQ-DFF-004).
+//   - The conflicting file is skipped while other templates continue to sync
+//     (REQ-DFF-001/002).
 func checkReservedCollision(projectRoot string, errOut io.Writer, strict bool) error {
 	base := filepath.Join(projectRoot, designDir)
 
@@ -80,7 +86,7 @@ func checkReservedCollision(projectRoot string, errOut io.Writer, strict bool) e
 				}
 				return fmt.Errorf("reserved filename: %q collides with reserved name", name)
 			}
-			// update path: warning 출력 + 계속 진행 (REQ-DFF-001)
+			// update path: emit warning and continue (REQ-DFF-001)
 			if errOut != nil {
 				_, _ = fmt.Fprintf(errOut, "warning: reserved filename: %s (preserved; rename to use canonical templates)\n", name)
 			}
@@ -104,7 +110,7 @@ func checkReservedCollision(projectRoot string, errOut io.Writer, strict bool) e
 					}
 					return fmt.Errorf("reserved filename: %q matches reserved pattern %q", path, pattern)
 				}
-				// update path: warning 출력 + 계속 진행 (REQ-DFF-001)
+				// update path: emit warning and continue (REQ-DFF-001)
 				if errOut != nil {
 					_, _ = fmt.Fprintf(errOut, "warning: reserved filename: %s (preserved; rename to use canonical templates)\n", path)
 				}
@@ -153,6 +159,10 @@ func loadDesignTemplateFS() (fs.FS, error) {
 	return sub, nil
 }
 
+// @MX:ANCHOR: [AUTO] scaffoldDesignDir is the canonical entry point for `moai init` design folder bootstrap
+// @MX:REASON: invariant contract — empty-dir guard (REQ-010) + reserved-name strict mode prevent corruption of user data on first run
+// @MX:SPEC: SPEC-DESIGN-001
+//
 // scaffoldDesignDir deploys .moai/design/ templates to projectRoot.
 //
 // Returns (true, nil) on successful deployment, (false, nil) when the directory
@@ -221,6 +231,10 @@ func scaffoldDesignDir(projectRoot string, warnOut io.Writer) (bool, error) {
 	return true, nil
 }
 
+// @MX:ANCHOR: [AUTO] updateDesignDir is the canonical entry point for `moai update` design folder sync
+// @MX:REASON: invariant contract — preserves user-modified files via SHA-256 (REQ-005) and never mutates reserved-name collisions (REQ-DFF-004); regression here breaks user data preservation guarantee
+// @MX:SPEC: SPEC-V3R3-DESIGN-FOLDER-FIX-001
+//
 // updateDesignDir syncs .moai/design/ template files during `moai update`.
 //
 // Rules:
@@ -236,7 +250,7 @@ func updateDesignDir(projectRoot string, errOut io.Writer) error {
 	base := filepath.Join(projectRoot, designDir)
 
 	// REQ-DFF-001: Warn on reserved filename collisions (strict=false) and continue.
-	// updateDesignDir는 scaffold path와 달리 기존 사용자 데이터를 존중하여 warning만 출력.
+	// Unlike the scaffold path, updateDesignDir respects existing user data and only emits warnings.
 	if err := checkReservedCollision(projectRoot, errOut, false); err != nil {
 		return err
 	}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -426,19 +426,19 @@ func statusIcon(s CheckStatus) string {
 	}
 }
 
-// constitutionStrictEnvKey는 strict mode를 활성화하는 환경 변수 이름이다.
+// constitutionStrictEnvKey is the environment variable name that activates strict mode.
 const constitutionStrictEnvKey = "MOAI_CONSTITUTION_STRICT"
 
-// checkConstitution은 zone registry 상태를 점검한다.
-// - registry 파일 없음: Warn (선택적 기능)
-// - 로드 오류(중복 ID, 잘못된 YAML 등): Fail
-// - Frozen 엔트리 0개: Warn
-// - orphan 경고 있음 + strictMode: Fail; 아니면 Warn
-// - 정상: OK
+// checkConstitution checks the zone registry state.
+// - registry file missing: Warn (optional feature)
+// - load error (duplicate ID, invalid YAML, etc.): Fail
+// - 0 Frozen entries: Warn
+// - orphan warnings present + strictMode: Fail; otherwise: Warn
+// - healthy: OK
 func checkConstitution(projectDir, registryPath string, verbose, strictMode bool) DiagnosticCheck {
 	check := DiagnosticCheck{Name: "Constitution Registry"}
 
-	// registry 파일 존재 여부 확인
+	// Check whether the registry file exists.
 	if _, err := os.Stat(registryPath); err != nil {
 		check.Status = CheckWarn
 		check.Message = fmt.Sprintf("zone-registry.md not found at %q — run `moai constitution list` to verify", registryPath)
@@ -452,7 +452,7 @@ func checkConstitution(projectDir, registryPath string, verbose, strictMode bool
 		return check
 	}
 
-	// orphan 경고 확인
+	// Check for orphan warnings.
 	if len(reg.Warnings) > 0 && strictMode {
 		check.Status = CheckFail
 		check.Message = fmt.Sprintf("%d orphan/overflow warning(s) detected (strict mode)", len(reg.Warnings))
@@ -462,7 +462,7 @@ func checkConstitution(projectDir, registryPath string, verbose, strictMode bool
 		return check
 	}
 
-	// Frozen 엔트리 수 확인
+	// Check the number of Frozen entries.
 	frozen := reg.FilterByZone(constitution.ZoneFrozen)
 	if len(frozen) == 0 {
 		check.Status = CheckWarn
@@ -470,7 +470,7 @@ func checkConstitution(projectDir, registryPath string, verbose, strictMode bool
 		return check
 	}
 
-	// orphan 경고만 있는 경우 (non-strict)
+	// Only orphan warnings present (non-strict).
 	if len(reg.Warnings) > 0 {
 		check.Status = CheckWarn
 		check.Message = fmt.Sprintf("registry OK (%d entries, %d Frozen), %d orphan/overflow warning(s)",

--- a/internal/cli/doctor_constitution_test.go
+++ b/internal/cli/doctor_constitution_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 )
 
-// validConstitutionRegistryForDoctor는 doctor 테스트용 유효한 registry 내용이다.
-// CLAUDE.md를 참조하므로 테스트 tempDir에 CLAUDE.md를 생성해야 orphan이 발생하지 않는다.
+// validConstitutionRegistryForDoctor is valid registry content for doctor tests.
+// Since it references CLAUDE.md, CLAUDE.md must be created in the test tempDir to avoid orphans.
 const validConstitutionRegistryForDoctor = `# Test Registry
 
 ## Entries
@@ -30,7 +30,7 @@ const validConstitutionRegistryForDoctor = `# Test Registry
 ` + "```" + `
 `
 
-// duplicateIDRegistry는 중복 ID가 있는 registry를 반환한다.
+// duplicateIDRegistryForDoctor is a registry with duplicate IDs.
 const duplicateIDRegistryForDoctor = `# Test Registry
 
 ## Entries
@@ -52,7 +52,7 @@ const duplicateIDRegistryForDoctor = `# Test Registry
 ` + "```" + `
 `
 
-// emptyFrozenRegistryForDoctor는 Frozen 엔트리가 없는 registry를 반환한다.
+// emptyFrozenRegistryForDoctor is a registry with no Frozen entries.
 const emptyFrozenRegistryForDoctor = `# Test Registry
 
 ## Entries
@@ -67,29 +67,29 @@ const emptyFrozenRegistryForDoctor = `# Test Registry
 ` + "```" + `
 `
 
-// TestCheckConstitution_ValidRegistry는 유효한 registry에서 OK를 반환함을 검증한다.
-// AC-CON-001-001 관련.
+// TestCheckConstitution_ValidRegistry verifies that OK is returned for a valid registry.
+// Related to AC-CON-001-001.
 func TestCheckConstitution_ValidRegistry(t *testing.T) {
 	dir := t.TempDir()
 
-	// CLAUDE.md 생성 (파일 존재 확인용)
+	// Create CLAUDE.md (for file existence check)
 	if err := os.WriteFile(filepath.Join(dir, "CLAUDE.md"), []byte("# Test"), 0o600); err != nil {
-		t.Fatalf("CLAUDE.md 생성 오류: %v", err)
+		t.Fatalf("failed to create CLAUDE.md: %v", err)
 	}
 
 	registryPath := filepath.Join(dir, "zone-registry.md")
 	if err := os.WriteFile(registryPath, []byte(validConstitutionRegistryForDoctor), 0o600); err != nil {
-		t.Fatalf("registry 파일 생성 오류: %v", err)
+		t.Fatalf("failed to create registry file: %v", err)
 	}
 
 	check := checkConstitution(dir, registryPath, false, false)
 
 	if check.Status != CheckOK {
-		t.Errorf("유효한 registry에서 Status = %q, want %q\n메시지: %s", check.Status, CheckOK, check.Message)
+		t.Errorf("valid registry Status = %q, want %q\nmessage: %s", check.Status, CheckOK, check.Message)
 	}
 }
 
-// TestCheckConstitution_RegistryMissing는 registry 파일 없음 시 Warn을 반환함을 검증한다.
+// TestCheckConstitution_RegistryMissing verifies that Warn is returned when the registry file is absent.
 func TestCheckConstitution_RegistryMissing(t *testing.T) {
 	dir := t.TempDir()
 	nonExistentPath := filepath.Join(dir, "nonexistent-registry.md")
@@ -97,73 +97,73 @@ func TestCheckConstitution_RegistryMissing(t *testing.T) {
 	check := checkConstitution(dir, nonExistentPath, false, false)
 
 	if check.Status != CheckWarn {
-		t.Errorf("registry 없음 Status = %q, want %q", check.Status, CheckWarn)
+		t.Errorf("missing registry Status = %q, want %q", check.Status, CheckWarn)
 	}
 }
 
-// TestCheckConstitution_DuplicateIDs는 중복 ID registry 시 Fail을 반환함을 검증한다.
+// TestCheckConstitution_DuplicateIDs verifies that Fail is returned for a registry with duplicate IDs.
 func TestCheckConstitution_DuplicateIDs(t *testing.T) {
 	dir := t.TempDir()
 
-	// CLAUDE.md 생성
+	// Create CLAUDE.md
 	if err := os.WriteFile(filepath.Join(dir, "CLAUDE.md"), []byte("# Test"), 0o600); err != nil {
-		t.Fatalf("CLAUDE.md 생성 오류: %v", err)
+		t.Fatalf("failed to create CLAUDE.md: %v", err)
 	}
 
 	registryPath := filepath.Join(dir, "zone-registry.md")
 	if err := os.WriteFile(registryPath, []byte(duplicateIDRegistryForDoctor), 0o600); err != nil {
-		t.Fatalf("registry 파일 생성 오류: %v", err)
+		t.Fatalf("failed to create registry file: %v", err)
 	}
 
 	check := checkConstitution(dir, registryPath, false, false)
 
 	if check.Status != CheckFail {
-		t.Errorf("중복 ID registry Status = %q, want %q\n메시지: %s", check.Status, CheckFail, check.Message)
+		t.Errorf("duplicate ID registry Status = %q, want %q\nmessage: %s", check.Status, CheckFail, check.Message)
 	}
 }
 
-// TestCheckConstitution_EmptyFrozen는 Frozen 엔트리 없음 시 Warn을 반환함을 검증한다.
-// AC-CON-001-006 관련.
+// TestCheckConstitution_EmptyFrozen verifies that Warn is returned when there are no Frozen entries.
+// Related to AC-CON-001-006.
 func TestCheckConstitution_EmptyFrozen(t *testing.T) {
 	dir := t.TempDir()
 
-	// CLAUDE.md 생성
+	// Create CLAUDE.md
 	if err := os.WriteFile(filepath.Join(dir, "CLAUDE.md"), []byte("# Test"), 0o600); err != nil {
-		t.Fatalf("CLAUDE.md 생성 오류: %v", err)
+		t.Fatalf("failed to create CLAUDE.md: %v", err)
 	}
 
 	registryPath := filepath.Join(dir, "zone-registry.md")
 	if err := os.WriteFile(registryPath, []byte(emptyFrozenRegistryForDoctor), 0o600); err != nil {
-		t.Fatalf("registry 파일 생성 오류: %v", err)
+		t.Fatalf("failed to create registry file: %v", err)
 	}
 
 	check := checkConstitution(dir, registryPath, false, false)
 
 	if check.Status != CheckWarn {
-		t.Errorf("empty Frozen Status = %q, want %q\n메시지: %s", check.Status, CheckWarn, check.Message)
+		t.Errorf("empty Frozen Status = %q, want %q\nmessage: %s", check.Status, CheckWarn, check.Message)
 	}
 
 	if !strings.Contains(check.Message, "Frozen") {
-		t.Errorf("경고 메시지에 'Frozen'이 포함되어야 한다: %s", check.Message)
+		t.Errorf("warning message must contain 'Frozen': %s", check.Message)
 	}
 }
 
-// TestCheckConstitution_StrictMode는 MOAI_CONSTITUTION_STRICT=1 시 orphan이 Fail로 처리됨을 검증한다.
-// AC-CON-001-006 관련.
+// TestCheckConstitution_StrictMode verifies that orphans are treated as Fail when MOAI_CONSTITUTION_STRICT=1.
+// Related to AC-CON-001-006.
 func TestCheckConstitution_StrictMode(t *testing.T) {
 	dir := t.TempDir()
-	// CLAUDE.md를 생성하지 않아 orphan 발생 (파일 미존재)
+	// Do not create CLAUDE.md so that an orphan occurs (file not found)
 
 	registryPath := filepath.Join(dir, "zone-registry.md")
 	// sampleRegistryContent uses CLAUDE.md which won't exist in dir
 	if err := os.WriteFile(registryPath, []byte(sampleRegistryContent), 0o600); err != nil {
-		t.Fatalf("registry 파일 생성 오류: %v", err)
+		t.Fatalf("failed to create registry file: %v", err)
 	}
 
-	// strictMode=true, orphan 발생 → Fail
+	// strictMode=true, orphan present → Fail
 	check := checkConstitution(dir, registryPath, false, true)
 
 	if check.Status != CheckFail {
-		t.Errorf("strict mode + orphan Status = %q, want %q\n메시지: %s", check.Status, CheckFail, check.Message)
+		t.Errorf("strict mode + orphan Status = %q, want %q\nmessage: %s", check.Status, CheckFail, check.Message)
 	}
 }

--- a/internal/cli/glm.go
+++ b/internal/cli/glm.go
@@ -308,7 +308,7 @@ func enableTeamMode(cmd *cobra.Command, isHybrid bool) error {
 			tmuxStatus = "Warning: tmux session NOT DETECTED. GLM teammates require tmux for env propagation.\n" +
 				"  Recommended steps:\n" +
 				"    1. tmux new -s moai\n" +
-				"    2. moai glm                # (tmux 안에서 재실행하여 세션 env 설정)\n" +
+				"    2. moai glm                # (re-run inside tmux to configure session env)\n" +
 				"    3. claude\n" +
 				"    4. /moai --team \"task\""
 		}

--- a/internal/cli/profile_setup.go
+++ b/internal/cli/profile_setup.go
@@ -13,21 +13,21 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// 위저드가 제공하는 canonical 값 슬라이스 — huh.NewOption 블록(~line 230)과 반드시 동기화.
+// statuslineModeCanonical holds the canonical values offered by the wizard — must stay in sync with the huh.NewOption block (~line 230).
 // KEEP IN SYNC with huh.NewOption block at ~line 230
 var statuslineModeCanonical = []string{defaultStatuslineMode, "full"}
 
 // KEEP IN SYNC with huh.NewOption block at ~line 240
 var statuslineThemeCanonical = []string{defaultStatuslineTheme, "catppuccin-latte"}
 
-// wizard 기본값 상수.
+// Wizard default constants.
 const (
 	defaultStatuslineMode  = "default"
 	defaultStatuslineTheme = "catppuccin-mocha"
 	defaultPermissionMode  = "acceptEdits"
 )
 
-// isCanonicalStatuslineMode는 s 가 wizard 옵션 슬라이스에 포함된 canonical 값인지 확인한다.
+// isCanonicalStatuslineMode reports whether s is a canonical value in the wizard option slice.
 func isCanonicalStatuslineMode(s string) bool {
 	for _, v := range statuslineModeCanonical {
 		if v == s {
@@ -37,7 +37,7 @@ func isCanonicalStatuslineMode(s string) bool {
 	return false
 }
 
-// isCanonicalStatuslineTheme는 s 가 wizard 옵션 슬라이스에 포함된 canonical 값인지 확인한다.
+// isCanonicalStatuslineTheme reports whether s is a canonical value in the wizard option slice.
 func isCanonicalStatuslineTheme(s string) bool {
 	for _, v := range statuslineThemeCanonical {
 		if v == s {
@@ -47,15 +47,14 @@ func isCanonicalStatuslineTheme(s string) bool {
 	return false
 }
 
-// normalizeStatuslineModeRaw는 statusline 패키지의 NormalizeMode를 호출해
-// 문자열 변환 노이즈를 캡슐화한다.
+// normalizeStatuslineModeRaw calls statusline.NormalizeMode to encapsulate string conversion noise.
 func normalizeStatuslineModeRaw(s string) string {
 	return string(statusline.NormalizeMode(statusline.StatuslineMode(s)))
 }
 
-// normalizeStatuslineMode는 wizard 옵션과 호환되는 mode 값을 반환한다.
-// 이전 statusline 버전의 deprecated 이름을 v3 이름으로 변환하며,
-// 옵션 집합에 없는 값은 "default"로 폴백한다.
+// normalizeStatuslineMode returns a mode value compatible with wizard options.
+// Converts deprecated names from older statusline versions to v3 names,
+// and falls back to "default" for values not present in the option set.
 func normalizeStatuslineMode(mode string) string {
 	if mode == "" {
 		return defaultStatuslineMode
@@ -67,8 +66,9 @@ func normalizeStatuslineMode(mode string) string {
 	return defaultStatuslineMode
 }
 
-// normalizeStatuslineTheme는 wizard 옵션과 호환되는 theme 이름을 반환한다.
-// "default" 등 레거시 값은 "catppuccin-mocha"로 변환해 Select 위젯이 올바르게 선택 항목을 강조한다.
+// normalizeStatuslineTheme returns a theme name compatible with wizard options.
+// Legacy values such as "default" are converted to "catppuccin-mocha" so that the Select
+// widget highlights the correct item.
 func normalizeStatuslineTheme(theme string) string {
 	if isCanonicalStatuslineTheme(theme) {
 		return theme
@@ -76,11 +76,11 @@ func normalizeStatuslineTheme(theme string) string {
 	return defaultStatuslineTheme
 }
 
-// @MX:NOTE: [AUTO] 위저드 v3 마이그레이션 — deprecated Claude 모델 ID를 canonical alias로 정규화.
-// @MX:REASON: 이전 위저드의 "claude-opus-4-7" 옵션 제거 후 기존 prefs 값이 huh.Select 바인딩에서 침묵 소실되는 것을 방지.
+// @MX:NOTE: [AUTO] Wizard v3 migration — normalizes deprecated Claude model IDs to canonical aliases.
+// @MX:REASON: Prevents silent loss of existing prefs values in huh.Select bindings after the "claude-opus-4-7" option was removed from the previous wizard.
 func normalizeModel(m string) string {
 	switch m {
-	// canonical alias 는 그대로 통과
+	// canonical aliases pass through unchanged
 	case "", "opus", "opus[1m]", "sonnet", "sonnet[1m]", "haiku", "opusplan":
 		return m
 	// deprecated full-ID → canonical alias
@@ -95,7 +95,7 @@ func normalizeModel(m string) string {
 	case "claude-haiku-4-5":
 		return "haiku"
 	default:
-		// 알 수 없는 값은 런타임 기본값으로 초기화
+		// Unknown values are reset to the runtime default.
 		return ""
 	}
 }
@@ -119,21 +119,21 @@ func init() {
 	profileCmd.AddCommand(profileSetupCmd)
 }
 
-// runProfileSetup은 인터랙티브 프로필 설정 wizard를 실행한다.
-// 첫 번째 질문은 언어 선택이며, 이후 모든 UI 텍스트는 선택된 언어로 표시된다.
+// runProfileSetup runs the interactive profile configuration wizard.
+// The first question is language selection; all subsequent UI text is displayed in the chosen language.
 func runProfileSetup(cmd *cobra.Command, args []string) error {
 	profileName := "default"
 	if len(args) > 0 {
 		profileName = args[0]
 	}
 
-	// 기존 설정을 기본값으로 로드
+	// Load existing preferences as defaults.
 	existingPrefs, err := profile.ReadPreferences(profileName)
 	if err != nil {
 		return fmt.Errorf("read existing preferences: %w", err)
 	}
 
-	// 기존 설정으로 폼 값 초기화
+	// Initialize form values from existing preferences.
 	userName := existingPrefs.UserName
 
 	convLang := existingPrefs.ConversationLang
@@ -153,7 +153,7 @@ func runProfileSetup(cmd *cobra.Command, args []string) error {
 		docLang = "en"
 	}
 
-	// C-1: deprecated 모델 ID를 canonical alias로 정규화
+	// C-1: normalize deprecated model IDs to canonical aliases
 	model := normalizeModel(existingPrefs.Model)
 	effortLevel := existingPrefs.EffortLevel
 	permissionMode := existingPrefs.PermissionMode
@@ -161,14 +161,14 @@ func runProfileSetup(cmd *cobra.Command, args []string) error {
 		permissionMode = defaultPermissionMode
 	}
 
-	// W-4: 마이그레이션 배너 출력을 위해 raw 값 보존
+	// W-4: preserve raw values for migration banner output
 	rawStatuslineMode := existingPrefs.StatuslineMode
 	rawStatuslineTheme := existingPrefs.StatuslineTheme
 
 	statuslineMode := normalizeStatuslineMode(existingPrefs.StatuslineMode)
 	statuslineTheme := normalizeStatuslineTheme(existingPrefs.StatuslineTheme)
 
-	// ====== Step 1: 언어 선택 ======
+	// ====== Step 1: Language selection ======
 	langOptions := []huh.Option[string]{
 		huh.NewOption("English", "en"),
 		huh.NewOption("Korean (한국어)", "ko"),
@@ -194,12 +194,12 @@ func runProfileSetup(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("wizard error: %w", err)
 	}
 
-	// ====== Step 2: 선택된 언어로 나머지 폼 표시 ======
+	// ====== Step 2: Display remaining forms in the selected language ======
 	t := getProfileText(convLang)
 
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), t.ConfiguringProfile+"\n\n", profileName)
 
-	// W-4: statusline mode/theme 마이그레이션 배너 — 폼 표시 전 출력
+	// W-4: statusline mode/theme migration banner — print before displaying the form
 	if rawStatuslineMode != "" && rawStatuslineMode != statuslineMode {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), t.MigrationNoticeStatuslineMode+"\n", rawStatuslineMode, statuslineMode)
 	}
@@ -208,7 +208,7 @@ func runProfileSetup(cmd *cobra.Command, args []string) error {
 	}
 
 	form := huh.NewForm(
-		// Section 1: 사용자 정보
+		// Section 1: User information
 		huh.NewGroup(
 			huh.NewInput().
 				Title(t.UserNameTitle).
@@ -216,7 +216,7 @@ func runProfileSetup(cmd *cobra.Command, args []string) error {
 				Value(&userName),
 		).Title(t.IdentityTitle),
 
-		// Section 2: 언어 (대화 언어 이후)
+		// Section 2: Languages (after conversation language)
 		huh.NewGroup(
 			huh.NewSelect[string]().
 				Title(t.GitCommitLangTitle).
@@ -235,7 +235,7 @@ func runProfileSetup(cmd *cobra.Command, args []string) error {
 				Value(&docLang),
 		).Title(t.LanguagesTitle),
 
-		// Section 3: 모델 설정 (모델 오버라이드 + 권한 모드)
+		// Section 3: Model settings (model override + permission mode)
 		huh.NewGroup(
 			huh.NewSelect[string]().
 				Title(t.ModelOverrideTitle).
@@ -262,7 +262,7 @@ func runProfileSetup(cmd *cobra.Command, args []string) error {
 					huh.NewOption(t.EffortLevelMax, "max"),
 				).
 				Value(&effortLevel),
-			// S-4: 옵션 순서 — acceptEdits, auto, default, plan, bypass, dontAsk
+			// S-4: option order — acceptEdits, auto, default, plan, bypass, dontAsk
 			huh.NewSelect[string]().
 				Title(t.PermissionModeTitle).
 				Description(t.PermissionModeDesc).
@@ -277,7 +277,7 @@ func runProfileSetup(cmd *cobra.Command, args []string) error {
 				Value(&permissionMode),
 		).Title(t.ModelSettingsTitle),
 
-		// Section 4: 화면 표시 — 모드, 테마
+		// Section 4: Display — mode, theme
 		// KEEP IN SYNC with statuslineModeCanonical at top of file
 		huh.NewGroup(
 			huh.NewSelect[string]().
@@ -308,12 +308,12 @@ func runProfileSetup(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("wizard error: %w", err)
 	}
 
-	// 권한 모드 정규화: "acceptEdits"는 프로젝트 기본값이므로 불필요한 override를 피해 빈 문자열로 저장
+	// Normalize permission mode: "acceptEdits" is the project default, so store empty string to avoid an unnecessary override.
 	if permissionMode == defaultPermissionMode {
 		permissionMode = ""
 	}
 
-	// 설정 저장
+	// Save preferences.
 	prefs := profile.ProfilePreferences{
 		UserName:         userName,
 		ConversationLang: convLang,
@@ -331,9 +331,9 @@ func runProfileSetup(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("save preferences: %w", err)
 	}
 
-	// MoAI 프로젝트 내에 있는 경우 프로젝트 설정에 동기화.
-	// syncedProjectRoot가 설정되면 최종 리포트에 statusline.yaml 경로를 표시해
-	// 사용자가 변경이 적용된 위치를 확인할 수 있다.
+	// When inside a MoAI project, sync preferences to the project configuration.
+	// When syncedProjectRoot is set, the final report shows the statusline.yaml path
+	// so the user can verify where the changes were applied.
 	var syncedProjectRoot string
 	if cwd, err := os.Getwd(); err == nil {
 		moaiDir := filepath.Join(cwd, ".moai")
@@ -350,15 +350,15 @@ func runProfileSetup(cmd *cobra.Command, args []string) error {
 		profileName,
 		profile.GetPreferencesPath(profileName))
 
-	// 사용자가 캡처된 모든 값을 시각적으로 확인할 수 있도록 구조화된 요약 출력.
+	// Print a structured summary so the user can visually confirm all captured values.
 	printProfileSummary(cmd.OutOrStdout(), &t, &prefs, syncedProjectRoot)
 	return nil
 }
 
-// printProfileSummary는 적용된 설정의 다중 라인 요약을 out에 출력한다.
-// 동기화가 실행된 경우 해당 값을 보유한 프로젝트 레벨 YAML 경로도 함께 출력한다.
+// printProfileSummary writes a multi-line summary of the applied settings to out.
+// When sync has been performed, the project-level YAML paths holding the values are also printed.
 func printProfileSummary(out io.Writer, t *profileSetupText, prefs *profile.ProfilePreferences, syncedProjectRoot string) {
-	// S-7: 7개 필드를 단일 Fprintf 호출로 통합
+	// S-7: combine 7 fields into a single Fprintf call
 	_, _ = fmt.Fprintf(out,
 		"%s\n"+
 			"  %s: %s\n"+
@@ -377,14 +377,14 @@ func printProfileSummary(out io.Writer, t *profileSetupText, prefs *profile.Prof
 		valueOrDash(prefs.DocLang),
 		t.SummaryModel, valueOrDefault(prefs.Model, t.SummaryDefault),
 		t.SummaryEffort, valueOrDefault(prefs.EffortLevel, t.SummaryDefault),
-		// S-2: normalize 후 StatuslineMode/Theme 는 항상 non-empty이므로 valueOrDefault 불필요
+		// S-2: StatuslineMode/Theme are always non-empty after normalization, so valueOrDefault is unnecessary
 		t.SummaryPermission, valueOrDefault(prefs.PermissionMode, defaultPermissionMode),
 		t.SummaryStatuslineMode, prefs.StatuslineMode,
 		t.SummaryStatuslineTheme, prefs.StatuslineTheme,
 	)
 
 	if syncedProjectRoot != "" {
-		// S-1: 상대 경로 출력 (syncedProjectRoot == cwd 이므로 상대 경로 하드코딩)
+		// S-1: print relative paths (syncedProjectRoot == cwd, so relative paths are hardcoded)
 		_, _ = fmt.Fprintf(out, "\n%s\n", t.SummarySyncedHeader)
 		_, _ = fmt.Fprintf(out, "  statusline.yaml -> .moai/config/sections/statusline.yaml\n")
 		_, _ = fmt.Fprintf(out, "  language.yaml   -> .moai/config/sections/language.yaml\n")
@@ -393,8 +393,8 @@ func printProfileSummary(out io.Writer, t *profileSetupText, prefs *profile.Prof
 	}
 }
 
-// valueOrDash는 값이 비어 있을 때 "-"를 반환한다.
-// 사용자 이름/언어 등 빈 값이 "설정 안 됨"을 의미하는 필드에 사용한다.
+// valueOrDash returns "-" when v is empty.
+// Used for fields such as user name or language where an empty value means "not set".
 func valueOrDash(v string) string {
 	if v == "" {
 		return "-"
@@ -402,8 +402,8 @@ func valueOrDash(v string) string {
 	return v
 }
 
-// valueOrDefault는 v가 비어 있을 때 fallback을 반환한다.
-// 빈 문자열이 "런타임 기본값 사용"을 의미하는 슬롯에 사용한다.
+// valueOrDefault returns fallback when v is empty.
+// Used for slots where an empty string means "use runtime default".
 func valueOrDefault(v, fallback string) string {
 	if v == "" {
 		return fallback

--- a/internal/cli/profile_setup_normalize_test.go
+++ b/internal/cli/profile_setup_normalize_test.go
@@ -2,7 +2,7 @@ package cli
 
 import "testing"
 
-// TestNormalizeStatuslineMode_Canonical canonical 값이 변경 없이 통과하는지 확인한다.
+// TestNormalizeStatuslineMode_Canonical verifies that canonical values pass through unchanged.
 func TestNormalizeStatuslineMode_Canonical(t *testing.T) {
 	tests := []struct {
 		in, want string
@@ -19,8 +19,8 @@ func TestNormalizeStatuslineMode_Canonical(t *testing.T) {
 	}
 }
 
-// TestNormalizeStatuslineMode_Deprecated deprecated alias가 v3 canonical 값으로 변환되는지 확인한다.
-// minimal/compact → default, verbose → full (statusline.NormalizeMode 동작과 일치).
+// TestNormalizeStatuslineMode_Deprecated verifies that deprecated aliases are converted to v3 canonical values.
+// minimal/compact → default, verbose → full (consistent with statusline.NormalizeMode behavior).
 func TestNormalizeStatuslineMode_Deprecated(t *testing.T) {
 	tests := []struct {
 		in, want string
@@ -38,7 +38,7 @@ func TestNormalizeStatuslineMode_Deprecated(t *testing.T) {
 	}
 }
 
-// TestNormalizeStatuslineMode_EmptyAndUnknown 빈 문자열과 알 수 없는 값이 "default"로 폴백하는지 확인한다.
+// TestNormalizeStatuslineMode_EmptyAndUnknown verifies that empty strings and unknown values fall back to "default".
 func TestNormalizeStatuslineMode_EmptyAndUnknown(t *testing.T) {
 	tests := []struct {
 		in, want string
@@ -56,8 +56,8 @@ func TestNormalizeStatuslineMode_EmptyAndUnknown(t *testing.T) {
 	}
 }
 
-// TestNormalizeStatuslineTheme 유효한 테마는 그대로 통과하고,
-// 알 수 없거나 레거시 "default" 값은 "catppuccin-mocha"로 변환되는지 확인한다.
+// TestNormalizeStatuslineTheme verifies that valid themes pass through unchanged
+// and that unknown or legacy "default" values are converted to "catppuccin-mocha".
 func TestNormalizeStatuslineTheme(t *testing.T) {
 	tests := []struct {
 		in, want string
@@ -77,7 +77,7 @@ func TestNormalizeStatuslineTheme(t *testing.T) {
 	}
 }
 
-// TestNormalizeModel_Canonical canonical alias는 그대로 통과하는지 확인한다.
+// TestNormalizeModel_Canonical verifies that canonical aliases pass through unchanged.
 func TestNormalizeModel_Canonical(t *testing.T) {
 	tests := []struct {
 		in, want string
@@ -99,7 +99,7 @@ func TestNormalizeModel_Canonical(t *testing.T) {
 	}
 }
 
-// TestNormalizeModel_Deprecated deprecated full-ID가 canonical alias로 변환되는지 확인한다.
+// TestNormalizeModel_Deprecated verifies that deprecated full-IDs are converted to canonical aliases.
 func TestNormalizeModel_Deprecated(t *testing.T) {
 	tests := []struct {
 		in, want string
@@ -123,8 +123,8 @@ func TestNormalizeModel_Deprecated(t *testing.T) {
 	}
 }
 
-// TestNormalizeModel_EmptyAndUnknown 빈 문자열은 빈 문자열을 반환하고,
-// 알 수 없는 값은 ""(런타임 기본값)을 반환하는지 확인한다.
+// TestNormalizeModel_EmptyAndUnknown verifies that empty strings return empty strings
+// and unknown values return "" (runtime default).
 func TestNormalizeModel_EmptyAndUnknown(t *testing.T) {
 	tests := []struct {
 		in, want string
@@ -142,7 +142,7 @@ func TestNormalizeModel_EmptyAndUnknown(t *testing.T) {
 	}
 }
 
-// TestValueOrDash 빈 문자열에서 "-"를 반환하는지 확인한다.
+// TestValueOrDash verifies that "-" is returned for empty strings.
 func TestValueOrDash(t *testing.T) {
 	tests := []struct {
 		in, want string
@@ -160,7 +160,7 @@ func TestValueOrDash(t *testing.T) {
 	}
 }
 
-// TestValueOrDefault 빈 문자열에서 fallback을 반환하는지 확인한다.
+// TestValueOrDefault verifies that the fallback is returned for empty strings.
 func TestValueOrDefault(t *testing.T) {
 	tests := []struct {
 		in, fallback, want string

--- a/internal/cli/profile_setup_summary_test.go
+++ b/internal/cli/profile_setup_summary_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/modu-ai/moai-adk/internal/profile"
 )
 
-// makeTestPrefs는 printProfileSummary 테스트용 완전히 채워진 ProfilePreferences를 생성한다.
+// makeTestPrefs creates a fully populated ProfilePreferences for printProfileSummary tests.
 func makeTestPrefs() profile.ProfilePreferences {
 	return profile.ProfilePreferences{
 		UserName:         "Alice",
@@ -24,8 +24,8 @@ func makeTestPrefs() profile.ProfilePreferences {
 	}
 }
 
-// TestPrintProfileSummary_Synced 동기화 성공 시 7개 설정 줄 +
-// "Synced to project config:" 블록과 상대 경로 출력을 검증한다.
+// TestPrintProfileSummary_Synced verifies that on successful sync, 7 setting lines
+// plus the "Synced to project config:" block with a relative path are output.
 func TestPrintProfileSummary_Synced(t *testing.T) {
 	var buf bytes.Buffer
 	prefs := makeTestPrefs()
@@ -35,11 +35,11 @@ func TestPrintProfileSummary_Synced(t *testing.T) {
 
 	output := buf.String()
 
-	// SummaryHeader 확인
+	// Verify SummaryHeader
 	if !strings.Contains(output, "Captured values:") {
 		t.Errorf("expected SummaryHeader 'Captured values:', got:\n%s", output)
 	}
-	// 7개 설정 필드 확인
+	// Verify 7 setting fields
 	for _, want := range []string{
 		"User name",
 		"Languages",
@@ -53,31 +53,31 @@ func TestPrintProfileSummary_Synced(t *testing.T) {
 			t.Errorf("expected field label %q in output:\n%s", want, output)
 		}
 	}
-	// 실제 값 확인
+	// Verify actual values
 	if !strings.Contains(output, "Alice") {
 		t.Errorf("expected UserName 'Alice' in output:\n%s", output)
 	}
 	if !strings.Contains(output, "opus") {
 		t.Errorf("expected model 'opus' in output:\n%s", output)
 	}
-	// 동기화 블록 확인
+	// Verify sync block
 	if !strings.Contains(output, "Synced to project config:") {
 		t.Errorf("expected SummarySyncedHeader in output:\n%s", output)
 	}
-	// S-1: 상대 경로 확인
+	// S-1: Verify relative path
 	if !strings.Contains(output, ".moai/config/sections/statusline.yaml") {
 		t.Errorf("expected relative statusline.yaml path in output:\n%s", output)
 	}
 	if !strings.Contains(output, ".moai/config/sections/language.yaml") {
 		t.Errorf("expected relative language.yaml path in output:\n%s", output)
 	}
-	// 절대 경로가 포함되지 않는지 확인
+	// Verify absolute path is not included
 	if strings.Contains(output, "/some/project/root") {
 		t.Errorf("absolute project root should not appear in output:\n%s", output)
 	}
 }
 
-// TestPrintProfileSummary_Skipped 동기화 미수행 시 중립적인 "No project-level sync" 메시지를 검증한다.
+// TestPrintProfileSummary_Skipped verifies that a neutral "No project-level sync" message is shown when sync is not performed.
 func TestPrintProfileSummary_Skipped(t *testing.T) {
 	var buf bytes.Buffer
 	prefs := makeTestPrefs()
@@ -86,27 +86,27 @@ func TestPrintProfileSummary_Skipped(t *testing.T) {
 	printProfileSummary(&buf, &txt, &prefs, "")
 
 	output := buf.String()
-	// W-5: 중립적 표현 확인
+	// W-5: Verify neutral wording
 	if !strings.Contains(output, "No project-level sync") {
 		t.Errorf("expected neutral skip message, got:\n%s", output)
 	}
-	// 이전 오류성 표현이 없는지 확인
+	// Verify old error-prone wording is absent
 	if strings.Contains(output, "Sync skipped") {
 		t.Errorf("old 'Sync skipped' message should not appear, got:\n%s", output)
 	}
-	// 동기화 블록이 없는지 확인
+	// Verify sync block is absent
 	if strings.Contains(output, "Synced to project config:") {
 		t.Errorf("synced header should not appear when syncedProjectRoot is empty:\n%s", output)
 	}
 }
 
-// TestPrintProfileSummary_EmptyFields 빈 UserName과 언어가 "-"로 렌더링되는지 확인한다.
+// TestPrintProfileSummary_EmptyFields verifies that empty UserName and languages render as "-".
 func TestPrintProfileSummary_EmptyFields(t *testing.T) {
 	var buf bytes.Buffer
 	prefs := profile.ProfilePreferences{
-		// UserName 비움
+		// UserName left empty
 		ConversationLang: "en",
-		// 나머지 언어 필드 비움
+		// remaining language fields left empty
 		StatuslineMode:  "default",
 		StatuslineTheme: "catppuccin-mocha",
 	}
@@ -115,22 +115,22 @@ func TestPrintProfileSummary_EmptyFields(t *testing.T) {
 	printProfileSummary(&buf, &txt, &prefs, "")
 
 	output := buf.String()
-	// 빈 UserName은 "-"로 표시
+	// Empty UserName should display as "-"
 	if !strings.Contains(output, "User name: -") {
 		t.Errorf("empty UserName should render as '-', got:\n%s", output)
 	}
-	// 빈 언어 필드도 "-"로 표시
+	// Empty language fields should also display as "-"
 	if !strings.Contains(output, "-") {
 		t.Errorf("expected dash for empty fields in output:\n%s", output)
 	}
-	// 빈 Model은 "(runtime default)"로 표시
+	// Empty Model should display as "(runtime default)"
 	if !strings.Contains(output, "(runtime default)") {
 		t.Errorf("empty Model should show runtime default, got:\n%s", output)
 	}
 }
 
-// TestPrintProfileSummary_AllLanguages en/ko/ja/zh 각 언어에서 SummaryHeader가
-// 출력에 포함되는지 확인한다.
+// TestPrintProfileSummary_AllLanguages verifies that SummaryHeader is included in output
+// for each of the en/ko/ja/zh languages.
 func TestPrintProfileSummary_AllLanguages(t *testing.T) {
 	prefs := makeTestPrefs()
 	for _, lang := range []string{"en", "ko", "ja", "zh"} {

--- a/internal/cli/profile_setup_translations.go
+++ b/internal/cli/profile_setup_translations.go
@@ -95,7 +95,7 @@ type profileSetupText struct {
 	SummarySyncedHeader    string
 	SummarySyncSkipped     string
 
-	// W-4: statusline 마이그레이션 배너 (이전 값 → 새 값)
+	// W-4: statusline migration banner (previous value → new value)
 	MigrationNoticeStatuslineMode  string
 	MigrationNoticeStatuslineTheme string
 }

--- a/internal/cli/profile_setup_translations_test.go
+++ b/internal/cli/profile_setup_translations_test.go
@@ -110,8 +110,8 @@ func containsSubstr(s, sub string) bool {
 	return false
 }
 
-// TestGetProfileText_PermAutoRuntimeWarning W-3: PermAuto 라벨에 런타임 오류 경고가
-// 포함되어 있는지 언어별로 확인한다.
+// TestGetProfileText_PermAutoRuntimeWarning W-3: verifies that the PermAuto label contains
+// a runtime error warning for each language.
 func TestGetProfileText_PermAutoRuntimeWarning(t *testing.T) {
 	runtimeErrByLang := map[string]string{
 		"en": "Session errors at runtime",
@@ -128,8 +128,8 @@ func TestGetProfileText_PermAutoRuntimeWarning(t *testing.T) {
 	}
 }
 
-// TestGetProfileText_MigrationNoticeFields W-4: MigrationNotice 필드가 4개 언어에서
-// 모두 채워져 있고 %q 형식 동사가 포함되어 있는지 확인한다.
+// TestGetProfileText_MigrationNoticeFields W-4: verifies that MigrationNotice fields are populated
+// in all 4 languages and contain the %q format verb.
 func TestGetProfileText_MigrationNoticeFields(t *testing.T) {
 	for _, lang := range []string{"en", "ko", "ja", "zh"} {
 		txt := getProfileText(lang)
@@ -139,37 +139,37 @@ func TestGetProfileText_MigrationNoticeFields(t *testing.T) {
 		if txt.MigrationNoticeStatuslineTheme == "" {
 			t.Errorf("lang=%q: MigrationNoticeStatuslineTheme is empty", lang)
 		}
-		// %q 형식 동사가 2개 포함되어 있어야 한다 (이전 값, 새 값)
+		// Must contain 2 %q format verbs (old value, new value)
 		if !containsStr(txt.MigrationNoticeStatuslineMode, "%q") {
 			t.Errorf("lang=%q: MigrationNoticeStatuslineMode %q should contain %%q format verb", lang, txt.MigrationNoticeStatuslineMode)
 		}
 	}
 }
 
-// TestGetProfileText_SummarySyncSkippedNeutral W-5: SummarySyncSkipped가
-// 중립적인 표현(프로젝트별 동기화 없음)을 사용하는지 확인한다.
+// TestGetProfileText_SummarySyncSkippedNeutral W-5: verifies that SummarySyncSkipped uses
+// neutral wording (no project-level sync).
 func TestGetProfileText_SummarySyncSkippedNeutral(t *testing.T) {
-	// "Sync skipped" 같은 오류성 표현이 없어야 한다
+	// Must not contain error-prone wording like "Sync skipped"
 	for _, lang := range []string{"en", "ko", "ja", "zh"} {
 		txt := getProfileText(lang)
 		if txt.SummarySyncSkipped == "" {
 			t.Errorf("lang=%q: SummarySyncSkipped is empty", lang)
 		}
 	}
-	// en: 중립 메시지 확인
+	// en: verify neutral message
 	en := getProfileText("en")
 	if !containsStr(en.SummarySyncSkipped, "No project-level sync") {
 		t.Errorf("en SummarySyncSkipped should be neutral, got: %q", en.SummarySyncSkipped)
 	}
-	// ko: 중립 메시지 확인
+	// ko: verify neutral message
 	ko := getProfileText("ko")
 	if !containsStr(ko.SummarySyncSkipped, "프로젝트별 동기화 없음") {
 		t.Errorf("ko SummarySyncSkipped should be neutral, got: %q", ko.SummarySyncSkipped)
 	}
 }
 
-// TestGetProfileText_SummaryHeaderUpdated S-3: ko/ja SummaryHeader가 업데이트된
-// 표현을 사용하는지 확인한다.
+// TestGetProfileText_SummaryHeaderUpdated S-3: verifies that the ko/ja SummaryHeader uses
+// updated wording.
 func TestGetProfileText_SummaryHeaderUpdated(t *testing.T) {
 	ko := getProfileText("ko")
 	if !containsStr(ko.SummaryHeader, "저장된 설정값") {

--- a/internal/constitution/dangling.go
+++ b/internal/constitution/dangling.go
@@ -2,12 +2,12 @@ package constitution
 
 import "fmt"
 
-// ValidateRuleReferences는 refs 슬라이스의 각 Rule ID가 registry에 존재하는지 검증한다.
-// 존재하지 않는 ID에 대해 경고 문자열을 반환한다.
+// ValidateRuleReferences validates that each Rule ID in refs exists in the registry.
+// Returns warning strings for IDs that are not found.
 //
-// REQ-CON-001-041 구현. SPEC-V3R2-SPC-003에서 CLI wiring과 SPEC frontmatter scanning이 추가될 예정.
+// Implements REQ-CON-001-041. CLI wiring and SPEC frontmatter scanning will be added in SPEC-V3R2-SPC-003.
 //
-// @MX:NOTE: [AUTO] SPEC-V3R2-SPC-003에서 CLI wiring 추가 예정
+// @MX:NOTE: [AUTO] CLI wiring to be added in SPEC-V3R2-SPC-003
 // @MX:SPEC: SPEC-V3R2-CON-001 REQ-CON-001-041
 func ValidateRuleReferences(registry *Registry, refs []string) []string {
 	var warnings []string

--- a/internal/constitution/dangling_test.go
+++ b/internal/constitution/dangling_test.go
@@ -7,81 +7,81 @@ import (
 	"github.com/modu-ai/moai-adk/internal/constitution"
 )
 
-// TestValidateRuleReferencesReturnsWarningForUnknownID는 존재하지 않는 ID에 대해
-// 경고 문자열을 반환함을 검증한다.
-// AC-CON-001-011 직접 매핑.
+// TestValidateRuleReferencesReturnsWarningForUnknownID verifies that a warning string
+// is returned for a non-existent ID.
+// Direct mapping to AC-CON-001-011.
 func TestValidateRuleReferencesReturnsWarningForUnknownID(t *testing.T) {
 	t.Parallel()
 
-	// valid_registry.md에는 CONST-V3R2-999가 없다
+	// CONST-V3R2-999 is not in valid_registry.md
 	reg, err := constitution.LoadRegistry(testdataPath("valid_registry.md"), ".")
 	if err != nil {
-		t.Fatalf("LoadRegistry 오류: %v", err)
+		t.Fatalf("LoadRegistry error: %v", err)
 	}
 
 	warnings := constitution.ValidateRuleReferences(reg, []string{"CONST-V3R2-999"})
 
 	if len(warnings) < 1 {
-		t.Fatalf("경고 수 = %d, ≥1이어야 한다", len(warnings))
+		t.Fatalf("warning count = %d, must be >= 1", len(warnings))
 	}
 
 	first := warnings[0]
 	if first == "" {
-		t.Error("첫 번째 경고가 비어 있어서는 안 된다")
+		t.Error("first warning must not be empty")
 	}
 
 	const wantSubstr = "CONST-V3R2-999"
 	if !strings.Contains(first, wantSubstr) {
-		t.Errorf("경고 %q에 %q가 포함되어야 한다", first, wantSubstr)
+		t.Errorf("warning %q must contain %q", first, wantSubstr)
 	}
 }
 
-// TestValidateRuleReferencesNoWarningForKnownID는 존재하는 ID에 대해 경고를 반환하지 않음을 검증한다.
+// TestValidateRuleReferencesNoWarningForKnownID verifies that no warning is returned for an existing ID.
 func TestValidateRuleReferencesNoWarningForKnownID(t *testing.T) {
 	t.Parallel()
 
 	reg, err := constitution.LoadRegistry(testdataPath("valid_registry.md"), ".")
 	if err != nil {
-		t.Fatalf("LoadRegistry 오류: %v", err)
+		t.Fatalf("LoadRegistry error: %v", err)
 	}
 
 	warnings := constitution.ValidateRuleReferences(reg, []string{"CONST-V3R2-001"})
 
 	if len(warnings) != 0 {
-		t.Errorf("존재하는 ID에 대한 경고 수 = %d, 0이어야 한다; 경고: %v", len(warnings), warnings)
+		t.Errorf("warning count for existing ID = %d, must be 0; warnings: %v", len(warnings), warnings)
 	}
 }
 
-// TestValidateRuleReferencesEmptyRefs는 빈 refs 슬라이스에 대해 빈 결과를 반환함을 검증한다.
+// TestValidateRuleReferencesEmptyRefs verifies that an empty result is returned for an empty refs slice.
 func TestValidateRuleReferencesEmptyRefs(t *testing.T) {
 	t.Parallel()
 
 	reg, err := constitution.LoadRegistry(testdataPath("valid_registry.md"), ".")
 	if err != nil {
-		t.Fatalf("LoadRegistry 오류: %v", err)
+		t.Fatalf("LoadRegistry error: %v", err)
 	}
 
 	warnings := constitution.ValidateRuleReferences(reg, []string{})
 
 	if len(warnings) != 0 {
-		t.Errorf("빈 refs에 대한 경고 수 = %d, 0이어야 한다", len(warnings))
+		t.Errorf("warning count for empty refs = %d, must be 0", len(warnings))
 	}
 }
 
-// TestValidateRuleReferencesMixedRefs는 혼합된 refs (존재/비존재)에 대한 동작을 검증한다.
+// TestValidateRuleReferencesMixedRefs verifies behavior for mixed refs (existing and non-existing).
 func TestValidateRuleReferencesMixedRefs(t *testing.T) {
 	t.Parallel()
 
 	reg, err := constitution.LoadRegistry(testdataPath("valid_registry.md"), ".")
 	if err != nil {
-		t.Fatalf("LoadRegistry 오류: %v", err)
+		t.Fatalf("LoadRegistry error: %v", err)
 	}
 
 	refs := []string{"CONST-V3R2-001", "CONST-V3R2-999", "CONST-V3R2-002", "CONST-V3R2-888"}
 	warnings := constitution.ValidateRuleReferences(reg, refs)
 
-	// CONST-V3R2-999와 CONST-V3R2-888이 없으므로 경고 2개
+	// CONST-V3R2-999 and CONST-V3R2-888 are absent, so 2 warnings expected
 	if len(warnings) != 2 {
-		t.Errorf("혼합 refs 경고 수 = %d, want 2; 경고: %v", len(warnings), warnings)
+		t.Errorf("mixed refs warning count = %d, want 2; warnings: %v", len(warnings), warnings)
 	}
 }

--- a/internal/constitution/loader.go
+++ b/internal/constitution/loader.go
@@ -10,27 +10,27 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// designMirrorStart는 design subsystem mirror 엔트리 ID 범위 시작 (051).
+// designMirrorStart is the start of the design subsystem mirror entry ID range (051).
 const designMirrorStart = 51
 
-// designMirrorEnd는 design subsystem mirror 엔트리 ID 범위 끝 (099, 포함).
+// designMirrorEnd is the end of the design subsystem mirror entry ID range (099, inclusive).
 const designMirrorEnd = 99
 
-// designOverflowEnd는 design mirror overflow 범위 끝 (149, 포함).
+// designOverflowEnd is the end of the design mirror overflow range (149, inclusive).
 const designOverflowEnd = 149
 
-// Registry는 로드된 zone registry를 나타낸다.
-// Entries는 전체 엔트리 목록이며, lookup은 ID→인덱스 O(1) 조회를 위한 내부 맵이다.
+// Registry represents the loaded zone registry.
+// Entries is the full list of entries; lookup is an internal map for O(1) ID→index lookup.
 type Registry struct {
-	// Entries는 로드된 Rule 목록이다.
+	// Entries is the list of loaded Rules.
 	Entries []Rule
-	// Warnings는 로드 중 발생한 경고 메시지 목록이다 (orphan, overflow 등).
+	// Warnings is the list of warning messages generated during loading (orphan, overflow, etc.).
 	Warnings []string
-	// lookup은 ID→인덱스 내부 맵 (O(1) Get 지원).
+	// lookup is the internal ID→index map (supports O(1) Get).
 	lookup map[string]int
 }
 
-// Get은 ID로 Rule을 O(1)에 조회한다.
+// Get looks up a Rule by ID in O(1).
 func (r *Registry) Get(id string) (Rule, bool) {
 	if r.lookup == nil {
 		return Rule{}, false
@@ -42,8 +42,8 @@ func (r *Registry) Get(id string) (Rule, bool) {
 	return r.Entries[idx], true
 }
 
-// FilterByZone은 지정된 zone의 Rule 목록을 반환한다.
-// REQ-CON-001-012 지원.
+// FilterByZone returns the list of Rules in the specified zone.
+// Supports REQ-CON-001-012.
 func (r *Registry) FilterByZone(z Zone) []Rule {
 	var result []Rule
 	for _, entry := range r.Entries {
@@ -54,8 +54,8 @@ func (r *Registry) FilterByZone(z Zone) []Rule {
 	return result
 }
 
-// rawEntry는 YAML unmarshal용 내부 구조체이다.
-// Zone 필드를 문자열로 먼저 파싱하기 위해 별도 정의.
+// rawEntry is the internal struct for YAML unmarshalling.
+// Defined separately to parse the Zone field as a string first.
 type rawEntry struct {
 	ID         string `yaml:"id"`
 	Zone       string `yaml:"zone"`
@@ -65,40 +65,40 @@ type rawEntry struct {
 	CanaryGate bool   `yaml:"canary_gate"`
 }
 
-// LoadRegistry는 지정된 경로의 zone registry 마크다운 파일을 로드한다.
+// LoadRegistry loads the zone registry markdown file at the specified path.
 //
-// 파싱 전략 (plan.md §7 OQ1 Decision):
-//  1. 파일에서 첫 번째 ```yaml ... ``` code fence 추출
-//  2. gopkg.in/yaml.v3로 []rawEntry unmarshal
-//  3. Rule 검증: 중복 ID는 fatal error, orphan 파일은 warning + Orphan=true
+// Parsing strategy (plan.md §7 OQ1 Decision):
+//  1. Extract the first ```yaml ... ``` code fence from the file
+//  2. Unmarshal into []rawEntry using gopkg.in/yaml.v3
+//  3. Rule validation: duplicate IDs are a fatal error; orphan files generate a warning + Orphan=true
 //
-// projectDir은 filepath.Clean + scope 제한을 위한 기준 디렉토리.
-// 경로 traversal 방지를 위해 registry 파일 경로를 projectDir 내부로 제한한다.
+// projectDir is the base directory for filepath.Clean and scope restriction.
+// The registry file path is restricted to within projectDir to prevent path traversal.
 func LoadRegistry(path, projectDir string) (*Registry, error) {
-	// 경로 traversal 방지: path를 clean하고 projectDir 범위 내인지 확인
+	// Path traversal prevention: clean the path and verify it is within projectDir scope.
 	cleanPath := filepath.Clean(path)
 	cleanProjectDir := filepath.Clean(projectDir)
 	if filepath.IsAbs(cleanPath) {
-		// 절대 경로인 경우 projectDir 기준으로 상대 경로로 변환하여 scope 확인
+		// For absolute paths, convert to a relative path from projectDir to check scope.
 		rel, err := filepath.Rel(cleanProjectDir, cleanPath)
 		if err == nil && strings.HasPrefix(rel, "..") {
-			return nil, fmt.Errorf("registry 경로 %q가 project dir %q를 벗어난다", path, projectDir)
+			return nil, fmt.Errorf("registry path %q escapes project dir %q", path, projectDir)
 		}
 	}
 
 	data, err := os.ReadFile(cleanPath)
 	if err != nil {
-		return nil, fmt.Errorf("registry 파일 읽기 오류 %q: %w", path, err)
+		return nil, fmt.Errorf("registry file read error %q: %w", path, err)
 	}
 
 	yamlBlock, err := extractYAMLFence(string(data))
 	if err != nil {
-		return nil, fmt.Errorf("YAML code fence 추출 오류: %w", err)
+		return nil, fmt.Errorf("YAML code fence extraction error: %w", err)
 	}
 
 	var raw []rawEntry
 	if err := yaml.Unmarshal([]byte(yamlBlock), &raw); err != nil {
-		return nil, fmt.Errorf("YAML 파싱 오류: %w", err)
+		return nil, fmt.Errorf("YAML parse error: %w", err)
 	}
 
 	reg := &Registry{
@@ -112,7 +112,7 @@ func LoadRegistry(path, projectDir string) (*Registry, error) {
 	for i, re := range raw {
 		z, parseErr := ParseZone(re.Zone)
 		if parseErr != nil {
-			return nil, fmt.Errorf("엔트리 %d (id=%q) zone 파싱 오류: %w", i, re.ID, parseErr)
+			return nil, fmt.Errorf("entry %d (id=%q) zone parse error: %w", i, re.ID, parseErr)
 		}
 
 		rule := Rule{
@@ -124,18 +124,18 @@ func LoadRegistry(path, projectDir string) (*Registry, error) {
 			CanaryGate: re.CanaryGate,
 		}
 
-		// ID 유효성 검증
+		// Validate the ID.
 		if validErr := rule.Validate(); validErr != nil {
-			return nil, fmt.Errorf("엔트리 %d 유효성 오류: %w", i, validErr)
+			return nil, fmt.Errorf("entry %d validation error: %w", i, validErr)
 		}
 
-		// 중복 ID 탐지 (fatal)
+		// Detect duplicate IDs (fatal).
 		if _, exists := reg.lookup[rule.ID]; exists {
-			return nil, fmt.Errorf("중복 ID 탐지: %q", rule.ID)
+			return nil, fmt.Errorf("duplicate ID detected: %q", rule.ID)
 		}
 
-		// orphan 파일 확인: file 경로가 실제로 존재하는지 확인
-		// projectDir 기준으로 상대 경로 해석
+		// Check for orphan files: verify that the file path actually exists.
+		// Relative paths are resolved relative to projectDir.
 		rulePath := rule.File
 		if !filepath.IsAbs(rulePath) {
 			rulePath = filepath.Join(cleanProjectDir, rulePath)
@@ -143,59 +143,59 @@ func LoadRegistry(path, projectDir string) (*Registry, error) {
 		if _, statErr := os.Stat(filepath.Clean(rulePath)); statErr != nil {
 			rule = rule.withOrphan(true)
 			reg.Warnings = append(reg.Warnings,
-				fmt.Sprintf("orphan: 파일 %q를 찾을 수 없다 (rule %s)", rule.File, rule.ID))
+				fmt.Sprintf("orphan: file %q not found (rule %s)", rule.File, rule.ID))
 		}
 
-		// design mirror overflow 탐지 (051-099 범위 초과)
+		// Detect design mirror overflow (exceeds the 051-099 range).
 		idNum := extractIDNumber(rule.ID)
 		if idNum >= designMirrorStart && idNum <= designMirrorEnd {
 			mirrorCount++
 		}
 		if idNum > designMirrorEnd && idNum <= designOverflowEnd {
-			// overflow range 사용 중
+			// Using overflow range.
 			reg.Warnings = append(reg.Warnings,
-				fmt.Sprintf("design mirror overflow: ID %s가 확장 범위(100-149)를 사용하고 있다", rule.ID))
+				fmt.Sprintf("design mirror overflow: ID %s is using the extended range (100-149)", rule.ID))
 		}
 
 		reg.lookup[rule.ID] = len(reg.Entries)
 		reg.Entries = append(reg.Entries, rule)
 	}
 
-	// design mirror 49 slot 초과 감지
+	// Detect when design mirror count exceeds the 49-slot limit.
 	if mirrorCount > designMirrorEnd-designMirrorStart+1 {
 		reg.Warnings = append(reg.Warnings,
-			fmt.Sprintf("design mirror overflow: mirror 엔트리 수 %d가 허용 슬롯 49를 초과한다", mirrorCount))
+			fmt.Sprintf("design mirror overflow: mirror entry count %d exceeds the allowed 49 slots", mirrorCount))
 	}
 
-	// 경고는 reg.Warnings에 저장되어 반환된다.
-	// orphan, overflow 경고는 caller가 reg.Warnings를 통해 확인한다.
-	// REQ-CON-001-040: orphan은 error를 반환하지 않고 Orphan=true 플래그만 설정.
+	// Warnings are stored in reg.Warnings and returned to the caller.
+	// Orphan and overflow warnings are surfaced via reg.Warnings.
+	// REQ-CON-001-040: orphans do not cause an error return; only the Orphan=true flag is set.
 	return reg, nil
 }
 
-// extractYAMLFence는 마크다운 문서에서 첫 번째 ```yaml ... ``` 블록을 추출한다.
+// extractYAMLFence extracts the first ```yaml ... ``` block from a markdown document.
 func extractYAMLFence(content string) (string, error) {
 	const openFence = "```yaml"
 	const closeFence = "```"
 
 	start := strings.Index(content, openFence)
 	if start == -1 {
-		return "", fmt.Errorf("```yaml code fence를 찾을 수 없다")
+		return "", fmt.Errorf("```yaml code fence not found")
 	}
 
-	// openFence 다음 위치
+	// Position immediately after openFence.
 	afterOpen := start + len(openFence)
-	// 닫는 fence 찾기 (openFence 이후에서)
+	// Find the closing fence (starting from after openFence).
 	end := strings.Index(content[afterOpen:], closeFence)
 	if end == -1 {
-		return "", fmt.Errorf("닫는 ``` fence를 찾을 수 없다")
+		return "", fmt.Errorf("closing ``` fence not found")
 	}
 
 	return content[afterOpen : afterOpen+end], nil
 }
 
-// extractIDNumber는 CONST-V3R2-NNN 형식에서 숫자 부분을 추출한다.
-// 파싱 실패 시 -1 반환.
+// extractIDNumber extracts the numeric part from the CONST-V3R2-NNN format.
+// Returns -1 on parse failure.
 func extractIDNumber(id string) int {
 	const prefix = "CONST-V3R2-"
 	if !strings.HasPrefix(id, prefix) {

--- a/internal/constitution/loader_test.go
+++ b/internal/constitution/loader_test.go
@@ -11,237 +11,237 @@ import (
 	"github.com/modu-ai/moai-adk/internal/constitution"
 )
 
-// testdataPath는 testdata 디렉토리의 절대 경로를 반환한다.
+// testdataPath returns the absolute path to the testdata directory.
 func testdataPath(filename string) string {
-	// 이 파일의 디렉토리 기준으로 testdata 경로 구성
+	// Construct testdata path relative to this file's directory
 	return filepath.Join("testdata", filename)
 }
 
-// TestLoadRegistryValidFile은 유효한 registry 파일을 성공적으로 로드함을 검증한다.
+// TestLoadRegistryValidFile verifies that a valid registry file is loaded successfully.
 func TestLoadRegistryValidFile(t *testing.T) {
 	t.Parallel()
 
 	reg, err := constitution.LoadRegistry(testdataPath("valid_registry.md"), ".")
 	if err != nil {
-		t.Fatalf("LoadRegistry 오류: %v", err)
+		t.Fatalf("LoadRegistry error: %v", err)
 	}
 
 	if len(reg.Entries) != 3 {
-		t.Errorf("엔트리 수 = %d, want 3", len(reg.Entries))
+		t.Errorf("entry count = %d, want 3", len(reg.Entries))
 	}
 }
 
-// TestLoadRegistryDuplicateIDsFails는 중복 ID registry 로드 시 오류를 반환함을 검증한다.
+// TestLoadRegistryDuplicateIDsFails verifies that an error is returned when loading a registry with duplicate IDs.
 func TestLoadRegistryDuplicateIDsFails(t *testing.T) {
 	t.Parallel()
 
 	_, err := constitution.LoadRegistry(testdataPath("duplicate_ids.md"), ".")
 	if err == nil {
-		t.Fatal("중복 ID registry 로드가 오류를 반환해야 한다")
+		t.Fatal("loading a duplicate ID registry must return an error")
 	}
 }
 
-// TestLoadRegistryMarksOrphanWithoutPanic은 존재하지 않는 파일 참조 시 panic 없이 Orphan 마킹함을 검증한다.
-// AC-CON-001-007 직접 매핑.
+// TestLoadRegistryMarksOrphanWithoutPanic verifies that orphans are marked without panic
+// when a non-existent file is referenced.
+// Direct mapping to AC-CON-001-007.
 func TestLoadRegistryMarksOrphanWithoutPanic(t *testing.T) {
 	t.Parallel()
 
 	reg, err := constitution.LoadRegistry(testdataPath("orphan_reference.md"), ".")
-	// 오류가 있어도 panic 없이 orphan을 마킹해야 한다
-	// LoadRegistry는 orphan 발생 시 non-nil error를 반환할 수 있다 (warning level)
+	// Must mark orphan without panic, even if an error occurs
+	// LoadRegistry may return a non-nil error on orphan (warning level)
 	_ = err
 
 	if reg == nil {
-		t.Fatal("Registry가 nil이어서는 안 된다")
+		t.Fatal("Registry must not be nil")
 	}
 
-	// orphan 엔트리가 마킹되어야 한다
+	// Orphan entries must be marked
 	var foundOrphan bool
 	for _, entry := range reg.Entries {
 		if entry.File == "this-file-does-not-exist.md" {
 			if !entry.Orphan() {
-				t.Errorf("존재하지 않는 파일 엔트리의 Orphan() = false, true여야 한다")
+				t.Errorf("non-existent file entry Orphan() = false, must be true")
 			}
 			foundOrphan = true
 		}
 	}
 
 	if !foundOrphan {
-		t.Error("orphan 엔트리를 찾을 수 없다")
+		t.Error("could not find orphan entry")
 	}
 
-	// 정상 엔트리도 로드되어야 한다
+	// Normal entries must also be loaded
 	rule, ok := reg.Get("CONST-V3R2-001")
 	if !ok {
-		t.Error("정상 엔트리 CONST-V3R2-001을 찾을 수 없다")
+		t.Error("could not find normal entry CONST-V3R2-001")
 	}
 	if rule.Clause != "SPEC+EARS format" {
 		t.Errorf("CONST-V3R2-001 clause = %q, want %q", rule.Clause, "SPEC+EARS format")
 	}
 }
 
-// TestLoadRegistryMalformedYAML은 잘못된 YAML의 경우 오류를 반환함을 검증한다.
+// TestLoadRegistryMalformedYAML verifies that an error is returned for malformed YAML.
 func TestLoadRegistryMalformedYAML(t *testing.T) {
 	t.Parallel()
 
 	_, err := constitution.LoadRegistry(testdataPath("malformed_yaml.md"), ".")
 	if err == nil {
-		t.Fatal("잘못된 YAML registry 로드가 오류를 반환해야 한다")
+		t.Fatal("loading a malformed YAML registry must return an error")
 	}
 }
 
-// TestLoadRegistryEmptyFrozen은 Frozen 엔트리가 없는 registry를 로드함을 검증한다.
-// FilterByZone(ZoneFrozen)이 빈 slice를 반환해야 한다.
+// TestLoadRegistryEmptyFrozen verifies that a registry with no Frozen entries loads correctly.
+// FilterByZone(ZoneFrozen) must return an empty slice.
 func TestLoadRegistryEmptyFrozen(t *testing.T) {
 	t.Parallel()
 
 	reg, err := constitution.LoadRegistry(testdataPath("empty_frozen.md"), ".")
 	if err != nil {
-		t.Fatalf("LoadRegistry 오류: %v", err)
+		t.Fatalf("LoadRegistry error: %v", err)
 	}
 
 	frozen := reg.FilterByZone(constitution.ZoneFrozen)
 	if len(frozen) != 0 {
-		t.Errorf("Frozen 엔트리 수 = %d, want 0", len(frozen))
+		t.Errorf("Frozen entry count = %d, want 0", len(frozen))
 	}
 }
 
-// TestLoadRegistryOverflowMirror는 51개 design mirror 엔트리가 있는 경우 overflow 감지를 검증한다.
-// AC-CON-001-008 관련.
+// TestLoadRegistryOverflowMirror verifies overflow detection when there are 51 design mirror entries.
+// Related to AC-CON-001-008.
 func TestLoadRegistryOverflowMirror(t *testing.T) {
 	t.Parallel()
 
 	reg, err := constitution.LoadRegistry(testdataPath("overflow_mirror.md"), ".")
-	// overflow mirror가 있어도 panic 없이 로드되어야 한다
+	// Must load without panic even with overflow mirror
 	_ = err
 
 	if reg == nil {
-		t.Fatal("Registry가 nil이어서는 안 된다")
+		t.Fatal("Registry must not be nil")
 	}
 }
 
-// TestRegistryGet은 O(1) 조회가 정확히 작동함을 검증한다.
+// TestRegistryGet verifies that O(1) lookup works correctly.
 func TestRegistryGet(t *testing.T) {
 	t.Parallel()
 
 	reg, err := constitution.LoadRegistry(testdataPath("valid_registry.md"), ".")
 	if err != nil {
-		t.Fatalf("LoadRegistry 오류: %v", err)
+		t.Fatalf("LoadRegistry error: %v", err)
 	}
 
-	// 존재하는 ID
+	// Existing ID
 	rule, ok := reg.Get("CONST-V3R2-001")
 	if !ok {
-		t.Error("CONST-V3R2-001을 찾을 수 없다")
+		t.Error("could not find CONST-V3R2-001")
 	}
 	if rule.Clause != "SPEC+EARS format" {
 		t.Errorf("CONST-V3R2-001 clause = %q, want %q", rule.Clause, "SPEC+EARS format")
 	}
 
-	// 존재하지 않는 ID
+	// Non-existent ID
 	_, ok = reg.Get("CONST-V3R2-999")
 	if ok {
-		t.Error("CONST-V3R2-999가 존재해서는 안 된다")
+		t.Error("CONST-V3R2-999 must not exist")
 	}
 }
 
-// TestRegistryFilterByZone은 Zone 필터링이 정확히 작동함을 검증한다.
-// AC-CON-001-002 관련.
+// TestRegistryFilterByZone verifies that zone filtering works correctly.
+// Related to AC-CON-001-002.
 func TestRegistryFilterByZone(t *testing.T) {
 	t.Parallel()
 
 	reg, err := constitution.LoadRegistry(testdataPath("valid_registry.md"), ".")
 	if err != nil {
-		t.Fatalf("LoadRegistry 오류: %v", err)
+		t.Fatalf("LoadRegistry error: %v", err)
 	}
 
 	frozen := reg.FilterByZone(constitution.ZoneFrozen)
 	if len(frozen) != 2 {
-		t.Errorf("Frozen 엔트리 수 = %d, want 2", len(frozen))
+		t.Errorf("Frozen entry count = %d, want 2", len(frozen))
 	}
 
 	evolvable := reg.FilterByZone(constitution.ZoneEvolvable)
 	if len(evolvable) != 1 {
-		t.Errorf("Evolvable 엔트리 수 = %d, want 1", len(evolvable))
+		t.Errorf("Evolvable entry count = %d, want 1", len(evolvable))
 	}
 }
 
-// TestIDStabilityAppendOnly는 기존 ID가 신규 엔트리 추가 후에도 동일한 clause를 가리킴을 검증한다.
-// AC-CON-001-009 직접 매핑.
+// TestIDStabilityAppendOnly verifies that existing IDs still point to the same clause after new entries are added.
+// Direct mapping to AC-CON-001-009.
 func TestIDStabilityAppendOnly(t *testing.T) {
 	t.Parallel()
 
-	// 초기 registry 로드
+	// Load initial registry
 	reg1, err := constitution.LoadRegistry(testdataPath("valid_registry.md"), ".")
 	if err != nil {
-		t.Fatalf("첫 번째 LoadRegistry 오류: %v", err)
+		t.Fatalf("first LoadRegistry error: %v", err)
 	}
 
 	rule1, ok := reg1.Get("CONST-V3R2-001")
 	if !ok {
-		t.Fatal("CONST-V3R2-001을 찾을 수 없다")
+		t.Fatal("could not find CONST-V3R2-001")
 	}
 
-	// 동일한 파일을 다시 로드해도 같은 clause를 가리켜야 한다
+	// Reloading the same file must still point to the same clause
 	reg2, err := constitution.LoadRegistry(testdataPath("valid_registry.md"), ".")
 	if err != nil {
-		t.Fatalf("두 번째 LoadRegistry 오류: %v", err)
+		t.Fatalf("second LoadRegistry error: %v", err)
 	}
 
 	rule2, ok := reg2.Get("CONST-V3R2-001")
 	if !ok {
-		t.Fatal("두 번째 로드 후 CONST-V3R2-001을 찾을 수 없다")
+		t.Fatal("could not find CONST-V3R2-001 after second load")
 	}
 
 	if rule1.Clause != rule2.Clause {
-		t.Errorf("ID 안정성 실패: 첫 번째=%q, 두 번째=%q", rule1.Clause, rule2.Clause)
+		t.Errorf("ID stability failure: first=%q, second=%q", rule1.Clause, rule2.Clause)
 	}
 }
 
-// TestRegistryEntryHasExactSixFieldsWithCanonicalNames는 로드된 엔트리의 6-field schema를 검증한다.
-// AC-CON-001-017 직접 매핑.
+// TestRegistryEntryHasExactSixFieldsWithCanonicalNames verifies the 6-field schema of loaded entries.
+// Direct mapping to AC-CON-001-017.
 func TestRegistryEntryHasExactSixFieldsWithCanonicalNames(t *testing.T) {
 	t.Parallel()
 
-	// valid_registry.md를 raw YAML로 파싱하여 key set 검증
+	// Parse valid_registry.md as raw YAML to verify key set
 	content, err := os.ReadFile(testdataPath("valid_registry.md"))
 	if err != nil {
-		t.Fatalf("파일 읽기 오류: %v", err)
+		t.Fatalf("file read error: %v", err)
 	}
 
-	// YAML code fence 추출
+	// Extract YAML code fence
 	src := string(content)
 	start := strings.Index(src, "```yaml")
 	end := strings.LastIndex(src, "```")
 	if start == -1 || end == -1 || end <= start {
-		t.Fatal("YAML code fence를 찾을 수 없다")
+		t.Fatal("could not find YAML code fence")
 	}
 	yamlBlock := src[start+7 : end]
 
-	// 첫 번째 엔트리의 key를 raw map으로 파싱하여 확인
-	// 이를 위해 간단한 YAML key 추출 방법 사용
+	// Verify the keys of the first entry using a simple raw map YAML extraction
 	requiredKeys := []string{"id", "zone", "file", "anchor", "clause", "canary_gate"}
 	for _, key := range requiredKeys {
 		if !strings.Contains(yamlBlock, key+":") {
-			t.Errorf("YAML key %q를 찾을 수 없다", key)
+			t.Errorf("YAML key %q not found", key)
 		}
 	}
 }
 
-// TestLoadRegistryFileNotFound는 존재하지 않는 파일 경로의 LoadRegistry 오류를 검증한다.
+// TestLoadRegistryFileNotFound verifies the LoadRegistry error for a non-existent file path.
 func TestLoadRegistryFileNotFound(t *testing.T) {
 	t.Parallel()
 
 	_, err := constitution.LoadRegistry(testdataPath("nonexistent_file.md"), ".")
 	if err == nil {
-		t.Fatal("존재하지 않는 파일 LoadRegistry가 오류를 반환해야 한다")
+		t.Fatal("LoadRegistry for non-existent file must return an error")
 	}
 }
 
-// BenchmarkLoadRegistry200Entries는 200 엔트리 registry의 cold load 성능을 측정한다.
-// AC-CON-001-015 매핑. 목표: <10ms per operation.
+// BenchmarkLoadRegistry200Entries measures cold load performance for a 200-entry registry.
+// AC-CON-001-015 mapping. Target: <10ms per operation.
 func BenchmarkLoadRegistry200Entries(b *testing.B) {
-	// 200 엔트리 임시 파일 생성
+	// Create a temp file with 200 entries
 	tmpDir := b.TempDir()
 	path := filepath.Join(tmpDir, "bench_registry.md")
 
@@ -258,28 +258,27 @@ func BenchmarkLoadRegistry200Entries(b *testing.B) {
 	sb.WriteString("```\n")
 
 	if err := os.WriteFile(path, []byte(sb.String()), 0o600); err != nil {
-		b.Fatalf("벤치마크 파일 생성 오류: %v", err)
+		b.Fatalf("failed to create benchmark file: %v", err)
 	}
 
 	b.ResetTimer()
 	for range b.N {
 		reg, err := constitution.LoadRegistry(path, tmpDir)
 		if err != nil {
-			b.Fatalf("LoadRegistry 오류: %v", err)
+			b.Fatalf("LoadRegistry error: %v", err)
 		}
 		if len(reg.Entries) != 200 {
-			b.Fatalf("엔트리 수 = %d, want 200", len(reg.Entries))
+			b.Fatalf("entry count = %d, want 200", len(reg.Entries))
 		}
 	}
 
-	// 10ms 목표 검증 (벤치마크에서 직접 검증)
+	// Verify 10ms target (single run check within the benchmark)
 	b.StopTimer()
 	const maxDuration = 10 * time.Millisecond
-	// 단순 확인을 위한 단일 실행
 	start := time.Now()
 	_, _ = constitution.LoadRegistry(path, tmpDir)
 	elapsed := time.Since(start)
 	if elapsed > maxDuration {
-		b.Logf("경고: LoadRegistry 200 entries = %v, 목표 %v 초과", elapsed, maxDuration)
+		b.Logf("warning: LoadRegistry 200 entries = %v, exceeds target %v", elapsed, maxDuration)
 	}
 }

--- a/internal/constitution/rule.go
+++ b/internal/constitution/rule.go
@@ -5,65 +5,65 @@ import (
 	"regexp"
 )
 
-// ruleIDPattern은 CONST-V3R2-NNN 형식의 ID를 검증하는 정규표현식 상수이다.
-// NNN은 3자리 이상의 숫자.
+// ruleIDPattern is the regular expression constant that validates IDs in the CONST-V3R2-NNN format.
+// NNN is a numeric string of 3 or more digits.
 const ruleIDPattern = `^CONST-V3R2-\d{3,}$`
 
-// ruleIDRegexp는 컴파일된 ruleIDPattern이다.
+// ruleIDRegexp is the compiled ruleIDPattern.
 var ruleIDRegexp = regexp.MustCompile(ruleIDPattern)
 
-// Rule은 zone registry의 단일 엔트리를 나타낸다.
-// 정확히 6개의 exported 필드를 가지며, yaml.v3 태그로 registry YAML 스키마와 매핑된다.
-// SPEC-V3R2-CON-001 REQ-CON-001-004 직접 구현.
+// Rule represents a single entry in the zone registry.
+// It has exactly 6 exported fields mapped to the registry YAML schema via yaml.v3 tags.
+// Directly implements SPEC-V3R2-CON-001 REQ-CON-001-004.
 //
-// Orphan 필드(unexported)는 loader가 참조 파일 부재 시 내부적으로 설정한다.
-// yaml 태그가 없으므로 registry 파일에는 나타나지 않는다.
+// The orphan field (unexported) is set internally by the loader when the referenced file is absent.
+// It has no yaml tag, so it does not appear in the registry file and is not visible as exported via Go reflect.
 type Rule struct {
-	// ID는 CONST-V3R2-NNN 형식의 고유 식별자이다.
+	// ID is the unique identifier in the CONST-V3R2-NNN format.
 	ID string `yaml:"id"`
-	// Zone은 조항의 zone (Frozen 또는 Evolvable).
+	// Zone is the zone of the clause (Frozen or Evolvable).
 	Zone Zone `yaml:"zone"`
-	// File은 조항이 위치한 규칙 파일 경로이다.
+	// File is the path to the rule file containing the clause.
 	File string `yaml:"file"`
-	// Anchor는 파일 내 위치 앵커 (#섹션명 또는 L라인번호).
+	// Anchor is the in-file location anchor (#section-name or Lline-number).
 	Anchor string `yaml:"anchor"`
-	// Clause는 HARD 조항의 verbatim 텍스트이다.
+	// Clause is the verbatim text of the HARD clause.
 	Clause string `yaml:"clause"`
-	// CanaryGate는 amendment 시 shadow evaluation이 필요한지 여부이다.
-	// Frozen → true, Evolvable → false (기본값).
+	// CanaryGate indicates whether shadow evaluation is required on amendment.
+	// Frozen → true, Evolvable → false (default).
 	CanaryGate bool `yaml:"canary_gate"`
 
-	// orphan은 참조 파일이 디스크에 존재하지 않을 때 loader가 true로 설정한다.
-	// unexported이므로 YAML에 직렬화되지 않으며 Go reflect로도 exported로 보이지 않는다.
+	// orphan is set to true by the loader when the referenced file does not exist on disk.
+	// Unexported, so it is not serialized to YAML and is not visible as exported via Go reflect.
 	orphan bool
 }
 
-// Orphan은 참조 파일이 디스크에 존재하지 않는지 여부를 반환한다.
-// loader가 LoadRegistry 시 파일 존재 확인 후 설정한다.
+// Orphan reports whether the referenced file does not exist on disk.
+// Set by the loader during LoadRegistry after verifying file existence.
 func (r Rule) Orphan() bool {
 	return r.orphan
 }
 
-// withOrphan은 orphan 플래그를 설정한 새 Rule을 반환하는 내부 헬퍼이다.
+// withOrphan is an internal helper that returns a new Rule with the orphan flag set.
 func (r Rule) withOrphan(orphan bool) Rule {
 	r.orphan = orphan
 	return r
 }
 
-// Validate는 Rule의 필수 필드를 검증한다.
-// 빈 필드 또는 잘못된 ID 형식이 있으면 오류를 반환한다.
+// Validate validates the required fields of the Rule.
+// Returns an error when a required field is empty or the ID format is invalid.
 func (r Rule) Validate() error {
 	if r.ID == "" {
-		return fmt.Errorf("rule ID가 비어 있다")
+		return fmt.Errorf("rule ID is empty")
 	}
 	if !ruleIDRegexp.MatchString(r.ID) {
-		return fmt.Errorf("rule ID %q가 패턴 %q에 맞지 않는다", r.ID, ruleIDPattern)
+		return fmt.Errorf("rule ID %q does not match pattern %q", r.ID, ruleIDPattern)
 	}
 	if r.File == "" {
-		return fmt.Errorf("rule %q: File 필드가 비어 있다", r.ID)
+		return fmt.Errorf("rule %q: File field is empty", r.ID)
 	}
 	if r.Clause == "" {
-		return fmt.Errorf("rule %q: Clause 필드가 비어 있다", r.ID)
+		return fmt.Errorf("rule %q: Clause field is empty", r.ID)
 	}
 	return nil
 }

--- a/internal/constitution/rule_test.go
+++ b/internal/constitution/rule_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/modu-ai/moai-adk/internal/constitution"
 )
 
-// TestRuleStructFieldsMatchRegistrySchema는 Rule 구조체가 정확히 6개 exported 필드를 가짐을 검증한다.
-// AC-CON-001-004 직접 매핑.
+// TestRuleStructFieldsMatchRegistrySchema verifies that the Rule struct has exactly 6 exported fields.
+// Direct mapping to AC-CON-001-004.
 func TestRuleStructFieldsMatchRegistrySchema(t *testing.T) {
 	t.Parallel()
 
 	rt := reflect.TypeOf(constitution.Rule{})
 
-	// exported 필드만 카운트
+	// Count exported fields only
 	var exportedFields []string
 	for i := range rt.NumField() {
 		f := rt.Field(i)
@@ -25,18 +25,18 @@ func TestRuleStructFieldsMatchRegistrySchema(t *testing.T) {
 
 	const wantCount = 6
 	if len(exportedFields) != wantCount {
-		t.Errorf("Rule exported 필드 수 = %d, want %d; 필드: %v", len(exportedFields), wantCount, exportedFields)
+		t.Errorf("Rule exported field count = %d, want %d; fields: %v", len(exportedFields), wantCount, exportedFields)
 	}
 
-	// 필드명 순서 및 일치 검증
+	// Verify field names and order
 	wantFields := []string{"ID", "Zone", "File", "Anchor", "Clause", "CanaryGate"}
 	if !reflect.DeepEqual(exportedFields, wantFields) {
-		t.Errorf("Rule exported 필드 = %v, want %v", exportedFields, wantFields)
+		t.Errorf("Rule exported fields = %v, want %v", exportedFields, wantFields)
 	}
 }
 
-// TestRuleStructYAMLTags는 Rule 구조체의 yaml 태그가 registry 스키마와 일치함을 검증한다.
-// AC-CON-001-017 관련.
+// TestRuleStructYAMLTags verifies that the yaml tags on the Rule struct match the registry schema.
+// Related to AC-CON-001-017.
 func TestRuleStructYAMLTags(t *testing.T) {
 	t.Parallel()
 
@@ -54,17 +54,17 @@ func TestRuleStructYAMLTags(t *testing.T) {
 	for fieldName, wantTag := range wantTags {
 		f, ok := rt.FieldByName(fieldName)
 		if !ok {
-			t.Errorf("필드 %q를 찾을 수 없다", fieldName)
+			t.Errorf("field %q not found", fieldName)
 			continue
 		}
 		gotTag := f.Tag.Get("yaml")
 		if gotTag != wantTag {
-			t.Errorf("Rule.%s yaml 태그 = %q, want %q", fieldName, gotTag, wantTag)
+			t.Errorf("Rule.%s yaml tag = %q, want %q", fieldName, gotTag, wantTag)
 		}
 	}
 }
 
-// TestRuleValidateValidRule은 유효한 Rule의 Validate()가 nil을 반환함을 검증한다.
+// TestRuleValidateValidRule verifies that Validate() returns nil for a valid Rule.
 func TestRuleValidateValidRule(t *testing.T) {
 	t.Parallel()
 
@@ -78,11 +78,11 @@ func TestRuleValidateValidRule(t *testing.T) {
 	}
 
 	if err := r.Validate(); err != nil {
-		t.Errorf("유효한 Rule.Validate() = %v, nil이어야 한다", err)
+		t.Errorf("valid Rule.Validate() = %v, must be nil", err)
 	}
 }
 
-// TestRuleValidateEmptyID는 빈 ID의 Validate()가 오류를 반환함을 검증한다.
+// TestRuleValidateEmptyID verifies that Validate() returns an error for an empty ID.
 func TestRuleValidateEmptyID(t *testing.T) {
 	t.Parallel()
 
@@ -95,11 +95,11 @@ func TestRuleValidateEmptyID(t *testing.T) {
 	}
 
 	if err := r.Validate(); err == nil {
-		t.Error("빈 ID Rule.Validate()가 오류를 반환해야 한다")
+		t.Error("Rule.Validate() with empty ID must return an error")
 	}
 }
 
-// TestRuleValidateInvalidIDFormat은 잘못된 ID 형식의 Validate()가 오류를 반환함을 검증한다.
+// TestRuleValidateInvalidIDFormat verifies that Validate() returns an error for an invalid ID format.
 func TestRuleValidateInvalidIDFormat(t *testing.T) {
 	t.Parallel()
 
@@ -124,13 +124,13 @@ func TestRuleValidateInvalidIDFormat(t *testing.T) {
 				Clause: "TRUST 5",
 			}
 			if err := r.Validate(); err == nil {
-				t.Errorf("잘못된 ID %q Rule.Validate()가 오류를 반환해야 한다", tt.id)
+				t.Errorf("Rule.Validate() with invalid ID %q must return an error", tt.id)
 			}
 		})
 	}
 }
 
-// TestRuleValidateEmptyClause는 빈 Clause의 Validate()가 오류를 반환함을 검증한다.
+// TestRuleValidateEmptyClause verifies that Validate() returns an error for an empty Clause.
 func TestRuleValidateEmptyClause(t *testing.T) {
 	t.Parallel()
 
@@ -143,11 +143,11 @@ func TestRuleValidateEmptyClause(t *testing.T) {
 	}
 
 	if err := r.Validate(); err == nil {
-		t.Error("빈 Clause Rule.Validate()가 오류를 반환해야 한다")
+		t.Error("Rule.Validate() with empty Clause must return an error")
 	}
 }
 
-// TestRuleValidateEmptyFile은 빈 File의 Validate()가 오류를 반환함을 검증한다.
+// TestRuleValidateEmptyFile verifies that Validate() returns an error for an empty File.
 func TestRuleValidateEmptyFile(t *testing.T) {
 	t.Parallel()
 
@@ -160,6 +160,6 @@ func TestRuleValidateEmptyFile(t *testing.T) {
 	}
 
 	if err := r.Validate(); err == nil {
-		t.Error("빈 File Rule.Validate()가 오류를 반환해야 한다")
+		t.Error("Rule.Validate() with empty File must return an error")
 	}
 }

--- a/internal/constitution/zone.go
+++ b/internal/constitution/zone.go
@@ -1,6 +1,6 @@
-// Package constitution은 MoAI-ADK 규칙 트리의 FROZEN/EVOLVABLE zone 모델을 구현한다.
-// zone registry를 로드하고 조회하는 API를 제공하며,
-// CLI(moai constitution list)와 doctor 체크에서 공통으로 사용된다.
+// Package constitution implements the FROZEN/EVOLVABLE zone model for the MoAI-ADK rule tree.
+// It provides an API for loading and querying the zone registry,
+// shared by the CLI (moai constitution list) and the doctor check.
 package constitution
 
 import (
@@ -8,20 +8,20 @@ import (
 	"strings"
 )
 
-// Zone은 MoAI-ADK 규칙 조항의 zone을 나타내는 열거형이다.
-// Zone은 uint8 기반으로 구현되어 향후 값 확장 여유 공간을 확보한다.
-// SPEC-V3R2-CON-001 REQ-CON-001-003 직접 구현.
+// Zone is an enumeration representing the zone of a MoAI-ADK rule clause.
+// Zone is uint8-based to leave room for future value expansion.
+// Directly implements SPEC-V3R2-CON-001 REQ-CON-001-003.
 type Zone uint8
 
 const (
-	// ZoneFrozen은 변경 불가 조항 (constitutional invariant)을 나타낸다.
-	// amendment 시 canary shadow evaluation 필수.
+	// ZoneFrozen represents an immutable clause (constitutional invariant).
+	// Canary shadow evaluation is required on amendment.
 	ZoneFrozen Zone = iota // = 0
-	// ZoneEvolvable은 graduation protocol을 통해 진화 가능한 조항을 나타낸다.
+	// ZoneEvolvable represents a clause that can evolve through the graduation protocol.
 	ZoneEvolvable // = 1
 )
 
-// String은 Zone 값의 사람이 읽기 쉬운 문자열 표현을 반환한다.
+// String returns a human-readable string representation of the Zone value.
 func (z Zone) String() string {
 	switch z {
 	case ZoneFrozen:
@@ -33,8 +33,8 @@ func (z Zone) String() string {
 	}
 }
 
-// ParseZone은 문자열을 Zone 값으로 파싱한다.
-// 대소문자를 무시하며, 알 수 없는 값은 오류를 반환한다.
+// ParseZone parses a string into a Zone value.
+// Comparison is case-insensitive; returns an error for unknown values.
 func ParseZone(s string) (Zone, error) {
 	switch strings.ToLower(s) {
 	case "frozen":
@@ -42,6 +42,6 @@ func ParseZone(s string) (Zone, error) {
 	case "evolvable":
 		return ZoneEvolvable, nil
 	default:
-		return 0, fmt.Errorf("알 수 없는 zone 값: %q (허용: Frozen, Evolvable)", s)
+		return 0, fmt.Errorf("unknown zone value: %q (allowed: Frozen, Evolvable)", s)
 	}
 }

--- a/internal/constitution/zone_test.go
+++ b/internal/constitution/zone_test.go
@@ -6,36 +6,36 @@ import (
 	"github.com/modu-ai/moai-adk/internal/constitution"
 )
 
-// TestZoneEnumValuesExactlyTwo는 Zone 타입이 정확히 2개 값만 가짐을 검증한다.
-// AC-CON-001-004 매핑.
+// TestZoneEnumValuesExactlyTwo verifies that the Zone type has exactly 2 values.
+// AC-CON-001-004 mapping.
 func TestZoneEnumValuesExactlyTwo(t *testing.T) {
 	t.Parallel()
 
-	// ZoneFrozen과 ZoneEvolvable이 정의되어 있어야 한다.
+	// ZoneFrozen and ZoneEvolvable must be defined.
 	if constitution.ZoneFrozen == constitution.ZoneEvolvable {
-		t.Fatal("ZoneFrozen과 ZoneEvolvable이 같은 값을 가진다")
+		t.Fatal("ZoneFrozen and ZoneEvolvable have the same value")
 	}
 }
 
-// TestZoneFrozenIsZero는 ZoneFrozen이 iota=0임을 검증한다.
+// TestZoneFrozenIsZero verifies that ZoneFrozen is iota=0.
 func TestZoneFrozenIsZero(t *testing.T) {
 	t.Parallel()
 
 	if constitution.ZoneFrozen != 0 {
-		t.Errorf("ZoneFrozen = %d, 0이어야 한다", constitution.ZoneFrozen)
+		t.Errorf("ZoneFrozen = %d, must be 0", constitution.ZoneFrozen)
 	}
 }
 
-// TestZoneEvolvableIsOne은 ZoneEvolvable이 iota=1임을 검증한다.
+// TestZoneEvolvableIsOne verifies that ZoneEvolvable is iota=1.
 func TestZoneEvolvableIsOne(t *testing.T) {
 	t.Parallel()
 
 	if constitution.ZoneEvolvable != 1 {
-		t.Errorf("ZoneEvolvable = %d, 1이어야 한다", constitution.ZoneEvolvable)
+		t.Errorf("ZoneEvolvable = %d, must be 1", constitution.ZoneEvolvable)
 	}
 }
 
-// TestZoneString은 Zone.String() 메서드의 출력을 검증한다.
+// TestZoneString verifies the output of the Zone.String() method.
 func TestZoneString(t *testing.T) {
 	t.Parallel()
 
@@ -58,7 +58,7 @@ func TestZoneString(t *testing.T) {
 	}
 }
 
-// TestParseZoneValidInputs는 유효한 입력에 대한 ParseZone을 검증한다.
+// TestParseZoneValidInputs verifies ParseZone for valid inputs.
 func TestParseZoneValidInputs(t *testing.T) {
 	t.Parallel()
 
@@ -79,7 +79,7 @@ func TestParseZoneValidInputs(t *testing.T) {
 			t.Parallel()
 			got, err := constitution.ParseZone(tt.input)
 			if err != nil {
-				t.Fatalf("ParseZone(%q) 오류: %v", tt.input, err)
+				t.Fatalf("ParseZone(%q) error: %v", tt.input, err)
 			}
 			if got != tt.want {
 				t.Errorf("ParseZone(%q) = %v, want %v", tt.input, got, tt.want)
@@ -88,7 +88,7 @@ func TestParseZoneValidInputs(t *testing.T) {
 	}
 }
 
-// TestParseZoneInvalidInputs는 알 수 없는 값에 대한 ParseZone 오류 반환을 검증한다.
+// TestParseZoneInvalidInputs verifies that ParseZone returns an error for unknown values.
 func TestParseZoneInvalidInputs(t *testing.T) {
 	t.Parallel()
 
@@ -104,7 +104,7 @@ func TestParseZoneInvalidInputs(t *testing.T) {
 			t.Parallel()
 			_, err := constitution.ParseZone(input)
 			if err == nil {
-				t.Errorf("ParseZone(%q) 오류를 반환해야 하지만 nil을 반환했다", input)
+				t.Errorf("ParseZone(%q) must return an error but returned nil", input)
 			}
 		})
 	}

--- a/internal/evolution/apply.go
+++ b/internal/evolution/apply.go
@@ -28,7 +28,8 @@ func ApplyProposal(projectRoot string, proposal *ProposedChange) error {
 
 	fullPath := filepath.Join(projectRoot, proposal.TargetFile)
 
-	// projectRoot 탈출 시도 검증: 정규화된 경로가 여전히 projectRoot 하위인지 확인
+	// Validate that the path does not escape projectRoot: check that the normalized path
+	// is still under projectRoot.
 	absRoot, err := filepath.Abs(projectRoot)
 	if err != nil {
 		return fmt.Errorf("evolution: resolve project root: %w", err)
@@ -52,15 +53,16 @@ func ApplyProposal(projectRoot string, proposal *ProposedChange) error {
 		return fmt.Errorf("evolution: write backup %s: %w", backupPath, err)
 	}
 
-	// 기존 존 내용을 찾아 추가 내용을 붙인다.
-	// ParseEvolvableZones로 현재 존 내용을 읽은 후 proposal.Addition을 이어 붙이고,
-	// ReplaceEvolvableZone으로 파일 전체 구조(헤더/푸터)를 보존하며 존만 교체한다.
+	// Locate the existing zone content and append the new content.
+	// Read the current zone content with ParseEvolvableZones, append proposal.Addition,
+	// then replace only the zone while preserving the overall file structure (header/footer)
+	// using ReplaceEvolvableZone.
 	zones, parseErr := merge.ParseEvolvableZones(string(original))
 	if parseErr != nil {
 		return fmt.Errorf("evolution: parse evolvable zones: %w", parseErr)
 	}
 
-	// 대상 존 존재 확인 및 기존 내용 추출
+	// Verify the target zone exists and extract its existing content.
 	var existingContent string
 	found := false
 	for _, z := range zones {
@@ -74,15 +76,15 @@ func ApplyProposal(projectRoot string, proposal *ProposedChange) error {
 		return ErrZoneNotFound
 	}
 
-	// 새 존 내용: 기존 내용 + 구분자 + 추가 내용
+	// New zone content: existing content + separator + appended content.
 	newContent := existingContent
 	if newContent != "" && newContent[len(newContent)-1] != '\n' {
 		newContent += "\n"
 	}
 	newContent += proposal.Addition
 
-	// ReplaceEvolvableZone은 파일의 헤더/푸터를 보존하면서 특정 존만 교체한다.
-	// (이전 코드의 MergeEvolvableZones(original, zoneID, newContent) 오용을 수정)
+	// ReplaceEvolvableZone replaces only the specific zone while preserving the file's header/footer.
+	// (Fixes the previous misuse of MergeEvolvableZones(original, zoneID, newContent))
 	updated, err := merge.ReplaceEvolvableZone(string(original), proposal.ZoneID, newContent)
 	if err != nil {
 		return fmt.Errorf("evolution: replace evolvable zone: %w", err)

--- a/internal/evolution/apply_integration_test.go
+++ b/internal/evolution/apply_integration_test.go
@@ -20,9 +20,9 @@ Initial best practice content.
 Footer content that must also be preserved.
 `
 
-// TestApplyProposal_PreservesSurroundingContent는 ApplyProposal이 존 주변의
-// 헤더/푸터 내용을 보존하는지 확인하는 통합 테스트이다.
-// CRITICAL 3: MergeEvolvableZones 오용(파일 파괴) 수정 검증
+// TestApplyProposal_PreservesSurroundingContent is an integration test verifying that
+// ApplyProposal preserves header/footer content surrounding the zone.
+// CRITICAL 3: verifies the fix for MergeEvolvableZones misuse (file destruction)
 func TestApplyProposal_PreservesSurroundingContent(t *testing.T) {
 	t.Parallel()
 
@@ -54,28 +54,28 @@ func TestApplyProposal_PreservesSurroundingContent(t *testing.T) {
 
 	updatedStr := string(updated)
 
-	// 헤더가 보존되어야 함
+	// Header must be preserved
 	if !strings.Contains(updatedStr, "# Skill Header") {
-		t.Error("ApplyProposal: 파일 헤더가 사라짐 (CRITICAL 3 회귀)")
+		t.Error("ApplyProposal: file header disappeared (CRITICAL 3 regression)")
 	}
 
-	// 소개 내용이 보존되어야 함
+	// Introduction content must be preserved
 	if !strings.Contains(updatedStr, "Introduction content that must be preserved.") {
-		t.Error("ApplyProposal: 소개 내용이 사라짐 (CRITICAL 3 회귀)")
+		t.Error("ApplyProposal: introduction content disappeared (CRITICAL 3 regression)")
 	}
 
-	// 푸터가 보존되어야 함
+	// Footer must be preserved
 	if !strings.Contains(updatedStr, "Footer content that must also be preserved.") {
-		t.Error("ApplyProposal: 푸터가 사라짐 (CRITICAL 3 회귀)")
+		t.Error("ApplyProposal: footer disappeared (CRITICAL 3 regression)")
 	}
 
-	// 원본 존 내용이 보존되어야 함
+	// Original zone content must be preserved
 	if !strings.Contains(updatedStr, "Initial best practice content.") {
-		t.Error("ApplyProposal: 원본 존 내용이 사라짐")
+		t.Error("ApplyProposal: original zone content disappeared")
 	}
 
-	// 추가된 내용이 있어야 함
+	// Added content must be present
 	if !strings.Contains(updatedStr, "Always pass context.Context as first argument.") {
-		t.Error("ApplyProposal: 추가된 내용이 없음")
+		t.Error("ApplyProposal: added content not found")
 	}
 }

--- a/internal/evolution/extra_coverage_test.go
+++ b/internal/evolution/extra_coverage_test.go
@@ -30,7 +30,7 @@ func TestUpdateLearning_MissingID(t *testing.T) {
 	projectRoot := t.TempDir()
 	mustInitMoAI(t, projectRoot)
 
-	// 유효한 형식이지만 존재하지 않는 ID
+	// Valid format but non-existent ID
 	err := evolution.UpdateLearning(projectRoot, "LEARN-20260411-999", func(e *evolution.LearningEntry) {
 		e.Observations++
 	})

--- a/internal/evolution/learning.go
+++ b/internal/evolution/learning.go
@@ -13,7 +13,7 @@ import (
 )
 
 // reLearningID matches the canonical learning ID format: LEARN-YYYYMMDD-NNN.
-// 형식 외의 ID는 경로 순회 등 보안 위험이 있으므로 거부한다.
+// IDs outside this format are rejected as they pose security risks such as path traversal.
 var reLearningID = regexp.MustCompile(`^LEARN-\d{8}-\d{3}$`)
 
 // validateLearningID checks that id matches the required LEARN-YYYYMMDD-NNN format.
@@ -38,14 +38,14 @@ func learningFilePath(projectRoot, id string) string {
 // CreateLearning writes a new LearningEntry to disk.
 //
 // Preconditions:
-//   - The entry ID must match LEARN-YYYYMMDD-NNN format (보안: 경로 순회 방지).
+//   - The entry ID must match LEARN-YYYYMMDD-NNN format (security: prevents path traversal).
 //   - The active learning count must be below MaxActiveLearnings.
 //   - The entry ID must not already exist.
 //
 // Returns ErrInvalidLearningID when the ID format is invalid.
 // Returns ErrMaxLearningsReached when the cap is hit.
 func CreateLearning(projectRoot string, entry *LearningEntry) error {
-	// ID 형식 검증: 경로 순회 및 임의 파일 덮어쓰기 방지
+	// Validate ID format: prevents path traversal and arbitrary file overwrites.
 	if err := validateLearningID(entry.ID); err != nil {
 		return err
 	}

--- a/internal/evolution/learning_test.go
+++ b/internal/evolution/learning_test.go
@@ -122,7 +122,7 @@ func TestMaxActiveLearnings_Enforced(t *testing.T) {
 	}
 
 	// One more should fail with ErrMaxLearningsReached.
-	// MaxActiveLearnings는 50이므로 i+1이 001..050 범위이고, 다음은 051
+	// MaxActiveLearnings is 50, so i+1 ranges from 001..050 and the next would be 051
 	extra := sampleEntry("LEARN-20260411-051")
 	err := evolution.CreateLearning(projectRoot, extra)
 	if err == nil {

--- a/internal/evolution/safety.go
+++ b/internal/evolution/safety.go
@@ -22,22 +22,22 @@ var frozenPaths = []string{
 	"CLAUDE.md",
 	".claude/rules/moai/core/moai-constitution.md",
 	".claude/rules/moai/core/agent-common-protocol.md",
-	// Agency fork manifest는 헌법과 동급으로 불변 보호 대상
+	// Agency fork manifest is immutably protected on par with the constitution.
 	".agency/fork-manifest.yaml",
 }
 
 // frozenDirPrefixes contains directory prefixes whose contents are protected.
 var frozenDirPrefixes = []string{
 	".claude/rules/moai/core/",
-	// Agency 헌법 및 관련 규칙 전체 보호 (Agency Constitution §2 FROZEN Zone)
+	// Protect the full Agency constitution and related rules (Agency Constitution §2 FROZEN Zone).
 	".claude/rules/agency/",
 }
 
 // CheckFrozenGuard reports whether targetFile is in the frozen zone.
 //
 // The check covers:
-//   - Absolute paths (항상 거부).
-//   - Paths containing ".." components after filepath.Clean (경로 순회 거부).
+//   - Absolute paths (always rejected).
+//   - Paths containing ".." components after filepath.Clean (path traversal rejected).
 //   - Exact path matches against frozenPaths.
 //   - Files inside frozen directory prefixes.
 //   - Targets with a ":frontmatter" suffix (YAML frontmatter modification).
@@ -47,18 +47,18 @@ func CheckFrozenGuard(targetFile string) error {
 	// Normalise the path separator.
 	target := filepath.ToSlash(strings.TrimSpace(targetFile))
 
-	// 절대 경로는 항상 거부 (예: /etc/passwd, C:\Windows\...)
-	// Windows의 filepath.IsAbs는 "/foo"를 절대경로로 보지 않으므로
-	// Unix 스타일 절대경로(선행 /)와 Windows 스타일(선행 \)을 별도로 검사한다.
+	// Absolute paths are always rejected (e.g. /etc/passwd, C:\Windows\...).
+	// filepath.IsAbs does not treat "/foo" as absolute on Windows, so
+	// Unix-style absolute paths (leading /) and Windows-style (leading \) are checked separately.
 	if filepath.IsAbs(targetFile) ||
 		strings.HasPrefix(targetFile, "/") ||
 		strings.HasPrefix(targetFile, `\`) {
 		return ErrFrozenPath
 	}
 
-	// .. 컴포넌트를 포함한 경로 순회 시도 거부
-	// 원본 경로에 /../ 또는 /.. 종단이 있으면 경로 조작 시도로 판단
-	// filepath.Clean 이전 원본 슬래시 경로에서 직접 검사
+	// Reject path traversal attempts containing ".." components.
+	// If the original slash path contains /../ or ends with /.., treat it as a path manipulation attempt.
+	// Check on the original slash path before applying filepath.Clean.
 	if strings.Contains(target, "/../") ||
 		strings.HasSuffix(target, "/..") ||
 		strings.HasPrefix(target, "../") ||
@@ -66,7 +66,7 @@ func CheckFrozenGuard(targetFile string) error {
 		return ErrFrozenPath
 	}
 
-	// filepath.Clean 후에도 .. 로 시작하면 상위 탈출 시도
+	// If the path still starts with ".." after filepath.Clean, it is an attempt to escape to a parent.
 	cleaned := filepath.ToSlash(filepath.Clean(target))
 	if strings.HasPrefix(cleaned, "../") || cleaned == ".." {
 		return ErrFrozenPath
@@ -105,11 +105,11 @@ func CheckFrozenGuard(targetFile string) error {
 }
 
 // rateMu guards the full Read→mutate→Write sequence in UpdateRateLimit.
-// Read와 Write 사이에 다른 고루틴이 끼어들면 카운터가 손실될 수 있으므로
-// 전체 시퀀스를 단일 락으로 보호한다.
+// Without the lock, another goroutine could interleave between Read and Write,
+// causing the counter to be lost. The entire sequence is protected by a single lock.
 //
-// @MX:WARN: [AUTO] 전역 뮤텍스: 모든 UpdateRateLimit 호출이 직렬화됨
-// @MX:REASON: [AUTO] TOCTOU 경쟁 조건 방지; rate state 파일은 단일 writer 보장이 필요
+// @MX:WARN: [AUTO] Global mutex: all UpdateRateLimit calls are serialized
+// @MX:REASON: [AUTO] Prevents TOCTOU race conditions; the rate state file requires a single writer guarantee
 var rateMu sync.Mutex
 
 // rateStatePath returns the path to the rate-limit state file.
@@ -232,7 +232,7 @@ func CheckFileCooldown(projectRoot, targetFile string) error {
 // it is reset before incrementing.
 //
 // targetFile may be empty to update only the weekly counter.
-// 경쟁 조건 방지를 위해 Read→mutate→Write 전체 시퀀스를 rateMu로 보호한다.
+// The entire Read→mutate→Write sequence is protected by rateMu to prevent race conditions.
 func UpdateRateLimit(projectRoot, targetFile string) error {
 	rateMu.Lock()
 	defer rateMu.Unlock()

--- a/internal/evolution/safety_concurrency_test.go
+++ b/internal/evolution/safety_concurrency_test.go
@@ -9,7 +9,7 @@ import (
 
 // TestUpdateRateLimit_ConcurrentSafety verifies that concurrent calls to
 // UpdateRateLimit do not produce data races and the final count is correct.
-// I2: Read→mutate→Write TOCTOU 경쟁 조건 수정 검증
+// I2: verifies the fix for the Read→mutate→Write TOCTOU race condition
 func TestUpdateRateLimit_ConcurrentSafety(t *testing.T) {
 	t.Parallel()
 

--- a/internal/evolution/security_test.go
+++ b/internal/evolution/security_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/modu-ai/moai-adk/internal/evolution"
 )
 
-// --- CRITICAL 1: CheckFrozenGuard 경로 순회 취약점 재현 테스트 ---
+// --- CRITICAL 1: CheckFrozenGuard path traversal vulnerability reproduction test ---
 
 // TestCheckFrozenGuard_RejectsPathTraversal verifies that CheckFrozenGuard rejects
 // path traversal and absolute path attacks.
@@ -22,27 +22,27 @@ func TestCheckFrozenGuard_RejectsPathTraversal(t *testing.T) {
 		expectBlock bool
 	}{
 		{
-			name:        "../../../etc/passwd 거부",
+			name:        "reject ../../../etc/passwd",
 			targetFile:  "../../../etc/passwd",
 			expectBlock: true,
 		},
 		{
-			name:        ".. 우회 경로 거부",
+			name:        "reject .. bypass path",
 			targetFile:  ".claude/rules/moai/core/../../../CLAUDE.md",
 			expectBlock: true,
 		},
 		{
-			name:        "절대 경로 거부",
+			name:        "reject absolute path",
 			targetFile:  "/etc/passwd",
 			expectBlock: true,
 		},
 		{
-			name:        "유효한 스킬 파일 허용",
+			name:        "allow valid skill file",
 			targetFile:  ".claude/skills/moai-lang-go/SKILL.md",
 			expectBlock: false,
 		},
 		{
-			name:        "./로 시작하는 유효 경로 허용",
+			name:        "allow valid path starting with ./",
 			targetFile:  ".claude/skills/moai-lang-go/SKILL.md",
 			expectBlock: false,
 		},
@@ -54,13 +54,13 @@ func TestCheckFrozenGuard_RejectsPathTraversal(t *testing.T) {
 			t.Parallel()
 			err := evolution.CheckFrozenGuard(tt.targetFile)
 			if tt.expectBlock && err == nil {
-				t.Errorf("CheckFrozenGuard(%q): 차단 예상, 하지만 nil 반환", tt.targetFile)
+				t.Errorf("CheckFrozenGuard(%q): expected block, but returned nil", tt.targetFile)
 			}
 			if !tt.expectBlock && err != nil {
-				t.Errorf("CheckFrozenGuard(%q): 허용 예상, 하지만 오류 반환: %v", tt.targetFile, err)
+				t.Errorf("CheckFrozenGuard(%q): expected allow, but returned error: %v", tt.targetFile, err)
 			}
 			if tt.expectBlock && err != nil && err != evolution.ErrFrozenPath {
-				t.Errorf("CheckFrozenGuard(%q): ErrFrozenPath 예상, 하지만 반환: %v", tt.targetFile, err)
+				t.Errorf("CheckFrozenGuard(%q): expected ErrFrozenPath, but returned: %v", tt.targetFile, err)
 			}
 		})
 	}
@@ -72,11 +72,11 @@ func TestApplyProposal_RejectsProjectRootEscape(t *testing.T) {
 	t.Parallel()
 
 	projectRoot := t.TempDir()
-	// 외부 디렉터리 생성 (프로젝트 루트의 형제)
+	// Create an external directory (sibling of project root)
 	outsideRoot := t.TempDir()
 
-	// outsideRoot 내 파일을 대상으로 하는 상대 경로 계산
-	// filepath.Rel 로 계산하면 ../../tmp/xxx/evil.md 형태
+	// Compute a relative path targeting a file inside outsideRoot
+	// filepath.Rel produces something like ../../tmp/xxx/evil.md
 	rel, err := filepath.Rel(projectRoot, filepath.Join(outsideRoot, "evil.md"))
 	if err != nil {
 		t.Fatalf("filepath.Rel: %v", err)
@@ -90,16 +90,16 @@ func TestApplyProposal_RejectsProjectRootEscape(t *testing.T) {
 
 	applyErr := evolution.ApplyProposal(projectRoot, proposal)
 	if applyErr == nil {
-		t.Error("ApplyProposal: 프로젝트 루트 탈출 시 오류 예상, 하지만 nil 반환")
+		t.Error("ApplyProposal: expected error when escaping project root, but returned nil")
 	}
 
-	// 외부 경로에 파일이 생성되지 않아야 함
+	// No file must be created at the external path
 	if _, statErr := os.Stat(filepath.Join(outsideRoot, "evil.md")); !os.IsNotExist(statErr) {
-		t.Error("ApplyProposal: 프로젝트 루트 외부에 파일이 생성되면 안 됨")
+		t.Error("ApplyProposal: must not create a file outside the project root")
 	}
 }
 
-// --- CRITICAL 2: LearningEntry.ID 경로 순회 취약점 재현 테스트 ---
+// --- CRITICAL 2: LearningEntry.ID path traversal vulnerability reproduction test ---
 
 // TestCreateLearning_RejectsPathTraversalID verifies that CreateLearning rejects
 // IDs that would escape the learnings directory via path traversal.
@@ -109,7 +109,7 @@ func TestCreateLearning_RejectsPathTraversalID(t *testing.T) {
 	projectRoot := t.TempDir()
 	mustInitMoAI(t, projectRoot)
 
-	// 에이전트 파일을 덮어쓸 수 있는 악성 ID
+	// Malicious ID that could overwrite an agent file
 	maliciousID := "../../.claude/agents/evil"
 
 	entry := &evolution.LearningEntry{
@@ -120,16 +120,16 @@ func TestCreateLearning_RejectsPathTraversalID(t *testing.T) {
 
 	err := evolution.CreateLearning(projectRoot, entry)
 	if err == nil {
-		t.Error("CreateLearning: 경로 순회 ID에 오류 예상, 하지만 nil 반환")
+		t.Error("CreateLearning: expected error for path traversal ID, but returned nil")
 	}
 	if err != evolution.ErrInvalidLearningID {
-		t.Errorf("CreateLearning: ErrInvalidLearningID 예상, 하지만 반환: %v", err)
+		t.Errorf("CreateLearning: expected ErrInvalidLearningID, but returned: %v", err)
 	}
 
-	// 순회 경로에 파일이 생성되지 않아야 함
+	// No file must be created at the traversal path
 	escapedPath := filepath.Join(projectRoot, ".moai", "evolution", "learnings", maliciousID+".md")
 	if _, statErr := os.Stat(escapedPath); !os.IsNotExist(statErr) {
-		t.Error("CreateLearning: 경로 순회 ID로 파일이 생성되면 안 됨")
+		t.Error("CreateLearning: must not create a file with a path traversal ID")
 	}
 }
 
@@ -200,7 +200,7 @@ func TestCreateLearning_RejectsInvalidIDFormats(t *testing.T) {
 	}
 }
 
-// --- CRITICAL 4: FrozenGuard Agency 경로 누락 재현 테스트 ---
+// --- CRITICAL 4: FrozenGuard Agency path omission reproduction test ---
 
 // TestCheckFrozenGuard_ProtectsAgencyConstitution verifies that agency constitution
 // files, fork-manifest, and lsp-client.md are blocked.

--- a/internal/hook/dbsync/db_schema_sync.go
+++ b/internal/hook/dbsync/db_schema_sync.go
@@ -182,19 +182,18 @@ func HandleDBSchemaSync(cfg Config) Result {
 	return Result{ExitCode: 0, Decision: DecisionAskUser}
 }
 
-// @MX:NOTE BuildProposal은 파싱된 마이그레이션 내용을 사용자 승인 대기용 Proposal 구조체로
-// 포장한다. JSON 마샬링이 가능한 평면 레이아웃을 유지하여 proposal.json(REQ-009)으로 직접
-// 직렬화될 수 있다.
+// @MX:NOTE BuildProposal wraps the parsed migration content into a Proposal struct awaiting user approval.
+// Maintains a flat JSON-marshalable layout so it can be serialized directly as proposal.json (REQ-009).
 //
-// 입력:
-//   - filePath: 마이그레이션 파일 경로 (Claude Code의 tool_input.file_path 원본)
-//   - parsedContent: parseMigrationStub이 반환한 파싱 결과 문자열
-//     (크기 가드에 걸렸을 경우 빈 문자열이며 Truncated=true 상태)
+// Inputs:
+//   - filePath: migration file path (the original tool_input.file_path from Claude Code)
+//   - parsedContent: the parsing result string returned by parseMigrationStub
+//     (empty string when the size guard was triggered; Truncated=true in that state)
 //
-// 출력:
-//   - Proposal: Decision은 항상 "ask-user"(DecisionAskUser), Timestamp는 UTC RFC3339
+// Output:
+//   - Proposal: Decision is always "ask-user" (DecisionAskUser), Timestamp is UTC RFC3339
 //
-// 부작용: 없음 (순수 함수).
+// Side effects: none (pure function).
 func BuildProposal(filePath, parsedContent string) Proposal {
 	return Proposal{
 		FilePath:      filePath,
@@ -204,17 +203,17 @@ func BuildProposal(filePath, parsedContent string) Proposal {
 	}
 }
 
-// @MX:NOTE MatchesMigrationPattern은 file_path가 DB 마이그레이션 glob 중 하나라도 매칭되는지
-// 확인한다. `**` 와일드카드는 matchGlob이 prefix/suffix 분리 방식으로 처리한다.
+// @MX:NOTE MatchesMigrationPattern checks whether file_path matches any of the DB migration globs.
+// The `**` wildcard is handled by matchGlob using prefix/suffix splitting.
 //
-// 입력:
-//   - filePath: 검사 대상 파일 경로 (호출자 책임으로 filepath.Clean 이후여야 함)
-//   - patterns: db.yaml의 migration_patterns (예: ["prisma/schema.prisma", "migrations/**/*.sql"])
+// Inputs:
+//   - filePath: the file path to check (caller is responsible for applying filepath.Clean first)
+//   - patterns: migration_patterns from db.yaml (e.g., ["prisma/schema.prisma", "migrations/**/*.sql"])
 //
-// 출력:
-//   - bool: 패턴 중 하나라도 매칭되면 true, 전부 미매칭이면 false
+// Output:
+//   - bool: true if any pattern matches, false if none match
 //
-// 부작용: 없음 (순수 함수, 읽기 전용).
+// Side effects: none (pure function, read-only).
 func MatchesMigrationPattern(filePath string, patterns []string) bool {
 	for _, pattern := range patterns {
 		if matchGlob(pattern, filePath) {
@@ -224,19 +223,19 @@ func MatchesMigrationPattern(filePath string, patterns []string) bool {
 	return false
 }
 
-// @MX:NOTE IsExcluded은 재귀 가드(REQ-004) 패턴에 file_path가 매칭되는지 확인한다.
-// DefaultExcludedPatterns(.moai/project/db/**, .moai/cache/**, .moai/logs/**)이 기본
-// 차단 대상이며, 이 경로들의 파일을 훅이 처리하면 schema.md 자동 재작성이 다시 훅을
-// 발동시키는 무한 루프가 발생하므로 반드시 차단된다.
+// @MX:NOTE IsExcluded checks whether file_path matches any of the recursion guard (REQ-004) patterns.
+// DefaultExcludedPatterns (.moai/project/db/**, .moai/cache/**, .moai/logs/**) are the default blocklist;
+// if the hook processes files at these paths, the automatic schema.md rewrite would trigger the hook again,
+// causing an infinite loop — these paths must always be blocked.
 //
-// 입력:
-//   - filePath: 검사 대상 파일 경로
-//   - excluded: 제외 글롭 패턴 목록 (일반적으로 DefaultExcludedPatterns)
+// Inputs:
+//   - filePath: the file path to check
+//   - excluded: list of exclusion glob patterns (typically DefaultExcludedPatterns)
 //
-// 출력:
-//   - bool: 제외 패턴 중 하나라도 매칭되면 true (훅이 exit 0 skip 처리)
+// Output:
+//   - bool: true if any exclusion pattern matches (hook handles as exit 0 skip)
 //
-// 부작용: 없음 (순수 함수, 읽기 전용).
+// Side effects: none (pure function, read-only).
 func IsExcluded(filePath string, excluded []string) bool {
 	for _, pattern := range excluded {
 		if matchGlob(pattern, filePath) {

--- a/internal/hook/dbsync/db_schema_sync.go
+++ b/internal/hook/dbsync/db_schema_sync.go
@@ -322,25 +322,27 @@ func isWithinDebounceWindow(stateFile, filePath string, window time.Duration) bo
 	return state.FilePath == filePath && time.Since(state.Timestamp) < window
 }
 
-// @MX:NOTE CheckDebounce는 동일 filePath가 window 내에 이미 관측되었는지 확인하고,
-// 관측되지 않았다면 stateFile을 원자적으로 갱신한다(임시 파일 + os.Rename, POSIX rename
-// 원자성에 의존). 동일 stateFile을 대상으로 동시에 호출되더라도 정확히 한 호출만
-// debounced=false를 반환한다(REQ-H2-002).
+// @MX:NOTE CheckDebounce verifies whether the same filePath has already been observed inside
+// the window, and atomically updates stateFile if not (temp-file + os.Rename, relying on POSIX
+// rename atomicity). When concurrent callers target the same stateFile, exactly one of them
+// returns debounced=false (REQ-H2-002).
 //
-// 입력:
-//   - stateFile: 디바운스 상태 JSON 파일의 절대 경로 (.moai/cache/db-sync/last-seen.json)
-//   - filePath: PostToolUse 훅이 보고한 마이그레이션 파일 경로
-//   - window: 디바운스 윈도우 (기본 10초; 테스트에서는 50ms 등 짧은 값 사용 가능)
+// Inputs:
+//   - stateFile: absolute path of the debounce-state JSON file (.moai/cache/db-sync/last-seen.json)
+//   - filePath: migration file path reported by the PostToolUse hook
+//   - window: debounce window (default 10s; tests may use shorter values such as 50ms)
 //
-// 출력:
-//   - debounced: true이면 window 내 중복 이벤트 (호출자는 조용히 종료), false면 신규 이벤트
-//   - error: 현재 구현은 항상 nil을 반환한다 (I/O 실패도 안전 기본값 (true, nil)로 흡수;
-//     REQ-H2-003). 미래 시그니처 호환성을 위해 error를 유지한다.
+// Outputs:
+//   - debounced: true means a duplicate event within the window (caller exits silently);
+//     false means a new event.
+//   - error: the current implementation always returns nil (I/O failures are absorbed into
+//     the safe default (true, nil); REQ-H2-003). The error is retained for future signature
+//     compatibility.
 //
-// 부작용:
-//   - stateFile을 temp-file + os.Rename으로 원자적 교체 (정상 경로)
-//   - I/O 실패 시 내부 로그 없음 (공개 API는 logFile 없이 호출됨;
-//     HandleDBSchemaSync 경유 시 checkDebounceWithLog가 ErrorLogFile에 기록)
+// Side effects:
+//   - stateFile is replaced atomically via temp-file + os.Rename (success path)
+//   - On I/O failure the public API logs nothing (it is invoked without logFile;
+//     when called via HandleDBSchemaSync, checkDebounceWithLog records to ErrorLogFile).
 func CheckDebounce(stateFile, filePath string, window time.Duration) (bool, error) {
 	return checkDebounceWithLog(stateFile, filePath, window, "")
 }

--- a/internal/hook/glm_tmux.go
+++ b/internal/hook/glm_tmux.go
@@ -11,8 +11,8 @@ import (
 	"github.com/modu-ai/moai-adk/internal/tmux"
 )
 
-// glmTmuxKeys는 tmux 세션에 주입할 GLM 관련 환경변수 목록입니다.
-// 새 tmux 팬(팀원)이 GLM API를 사용하려면 이 변수들이 세션 수준에서 설정되어야 합니다.
+// glmTmuxKeys is the list of GLM-related environment variables to inject into the tmux session.
+// New tmux panes (teammates) must have these variables set at the session level to use the GLM API.
 var glmTmuxKeys = []string{
 	"ANTHROPIC_AUTH_TOKEN",
 	"ANTHROPIC_BASE_URL",
@@ -25,12 +25,12 @@ var glmTmuxKeys = []string{
 	"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC",
 }
 
-// buildGLMTmuxEnvVars는 settings.local.json의 env 맵에서 GLM 관련 변수만 추출합니다.
+// buildGLMTmuxEnvVars extracts only GLM-related variables from the env map in settings.local.json.
 //
-// 규칙:
-//   - ANTHROPIC_AUTH_TOKEN이 비어 있으면 nil 반환 (주입 불필요)
-//   - glmTmuxKeys에 포함된 키만 결과에 포함됨
-//   - 설정에 없는 키는 결과에 포함되지 않음
+// Rules:
+//   - Returns nil if ANTHROPIC_AUTH_TOKEN is empty (injection not needed)
+//   - Only keys listed in glmTmuxKeys are included in the result
+//   - Keys absent from settings are not included in the result
 func buildGLMTmuxEnvVars(env map[string]string) map[string]string {
 	if env["ANTHROPIC_AUTH_TOKEN"] == "" {
 		return nil
@@ -43,7 +43,7 @@ func buildGLMTmuxEnvVars(env map[string]string) map[string]string {
 		}
 	}
 
-	// ANTHROPIC_AUTH_TOKEN이 있으면 반드시 포함
+	// Always include ANTHROPIC_AUTH_TOKEN if present
 	if token := env["ANTHROPIC_AUTH_TOKEN"]; token != "" {
 		result["ANTHROPIC_AUTH_TOKEN"] = token
 	}
@@ -51,32 +51,32 @@ func buildGLMTmuxEnvVars(env map[string]string) map[string]string {
 	return result
 }
 
-// formatTmuxGLMEnvSummary는 tmux 세션 환경변수 주입 결과 요약 문자열을 반환합니다.
+// formatTmuxGLMEnvSummary returns a summary string for the tmux session environment variable injection result.
 func formatTmuxGLMEnvSummary(n int) string {
-	return fmt.Sprintf("GLM 팀원을 위해 tmux 세션 환경변수 주입 완료 (%d개 변수)", n)
+	return fmt.Sprintf("tmux session environment variables injected for GLM teammates (%d variables)", n)
 }
 
-// ensureTmuxGLMEnv는 SessionStart 훅에서 호출되어, GLM 모드에서 팀원 tmux 팬이
-// ANTHROPIC_AUTH_TOKEN을 상속받을 수 있도록 현재 tmux 세션에 환경변수를 주입합니다.
+// ensureTmuxGLMEnv is called from the SessionStart hook to inject environment variables
+// into the current tmux session so that teammate tmux panes can inherit ANTHROPIC_AUTH_TOKEN in GLM mode.
 //
-// 동작:
-//  1. TMUX 환경변수가 없으면 no-op (tmux 세션 밖)
-//  2. settings.local.json에서 teammateMode가 "tmux"가 아니면 no-op
-//  3. ANTHROPIC_AUTH_TOKEN이 없으면 no-op
-//  4. GLM 관련 환경변수를 tmux set-environment로 현재 세션에 주입
+// Behavior:
+//  1. No-op if TMUX env var is absent (not inside a tmux session)
+//  2. No-op if teammateMode in settings.local.json is not "tmux"
+//  3. No-op if ANTHROPIC_AUTH_TOKEN is absent
+//  4. Inject GLM-related environment variables into the current session via tmux set-environment
 //
-// 에러 처리: 모든 에러는 경고 로그만 출력하고 빈 문자열을 반환합니다.
-// SessionStart 훅 실패를 절대 일으키지 않습니다.
+// Error handling: all errors are only logged as warnings; an empty string is returned.
+// This function must never cause the SessionStart hook to fail.
 //
-// @MX:ANCHOR: [AUTO] SessionStart 훅의 GLM+팀 모드 tmux 환경변수 주입 진입점
-// @MX:REASON: Handle에서 직접 호출되며 session_start_glm_tmux_test.go에서 3개 이상 테스트 케이스가 검증
+// @MX:ANCHOR: [AUTO] Entry point for GLM+team mode tmux environment variable injection in the SessionStart hook
+// @MX:REASON: Called directly from Handle; 3+ test cases in session_start_glm_tmux_test.go verify this
 func ensureTmuxGLMEnv(projectDir string) string {
-	// 1. tmux 세션 여부 확인
+	// 1. Check if inside a tmux session
 	if os.Getenv("TMUX") == "" {
 		return ""
 	}
 
-	// 2. settings.local.json 읽기
+	// 2. Read settings.local.json
 	settingsPath := filepath.Join(projectDir, ".claude", "settings.local.json")
 	data, err := os.ReadFile(settingsPath)
 	if err != nil || len(data) == 0 {
@@ -88,7 +88,7 @@ func ensureTmuxGLMEnv(projectDir string) string {
 		return ""
 	}
 
-	// 3. teammateMode == "tmux" 확인
+	// 3. Verify teammateMode == "tmux"
 	var teammateMode string
 	if v, ok := raw["teammateMode"]; ok {
 		_ = json.Unmarshal(v, &teammateMode)
@@ -97,7 +97,7 @@ func ensureTmuxGLMEnv(projectDir string) string {
 		return ""
 	}
 
-	// 4. env 맵 추출
+	// 4. Extract env map
 	envRaw, ok := raw["env"]
 	if !ok {
 		return ""
@@ -107,24 +107,24 @@ func ensureTmuxGLMEnv(projectDir string) string {
 		return ""
 	}
 
-	// 5. GLM 환경변수 맵 구성 (AUTH_TOKEN 없으면 nil 반환)
+	// 5. Build GLM env var map (returns nil if AUTH_TOKEN is absent)
 	vars := buildGLMTmuxEnvVars(env)
 	if len(vars) == 0 {
 		return ""
 	}
 
-	// 6. tmux set-environment 실행
+	// 6. Run tmux set-environment
 	mgr := tmux.NewSessionManager()
 	if err := mgr.InjectEnv(context.Background(), vars); err != nil {
-		slog.Warn("ensureTmuxGLMEnv: tmux 환경변수 주입 실패",
+		slog.Warn("ensureTmuxGLMEnv: tmux env var injection failed",
 			"error", err.Error(),
-			"hint", "tmux 바이너리가 없거나 세션 외부일 수 있음",
+			"hint", "tmux binary may be missing or running outside a session",
 		)
 		return ""
 	}
 
 	summary := formatTmuxGLMEnvSummary(len(vars))
-	slog.Info("ensureTmuxGLMEnv: tmux 세션 GLM 환경변수 주입",
+	slog.Info("ensureTmuxGLMEnv: GLM env vars injected into tmux session",
 		"vars", len(vars),
 	)
 	return summary

--- a/internal/hook/normalize_test.go
+++ b/internal/hook/normalize_test.go
@@ -451,9 +451,9 @@ func TestReadInput_FlatCamelCase(t *testing.T) {
 			},
 		},
 		{
-			// hook_event_name이 없어도 CLI 명령명에서 유추 가능한 경우에 대비.
-			// 현재는 hook_event_name 필수이므로, reason만 있으면 에러가 맞음.
-			// 이 테스트는 graceful 에러 처리를 확인함.
+			// guards against cases where hook_event_name is absent but inferrable from CLI command name.
+			// currently hook_event_name is required, so having only reason is an expected error.
+			// this test verifies graceful error handling.
 			name:  "SessionEnd with flat camelCase and reason field",
 			input: `{"sessionId":"sess-flat-3","hookEventName":"SessionEnd","cwd":"/tmp","reason":"logout"}`,
 			check: func(t *testing.T, got *HookInput) {

--- a/internal/hook/protocol.go
+++ b/internal/hook/protocol.go
@@ -79,13 +79,13 @@ func validateInput(input *HookInput) error {
 		input.HookEventName = string(EventUserPromptSubmit)
 	}
 
-	// session_id 누락 허용: Claude Code 버전에 따라 일부 이벤트에서 session_id가
-	// 전송되지 않는 경우가 있음. 훅 실행 실패보다 graceful fallback이 바람직함.
+	// Allow missing session_id: some events in certain Claude Code versions do not
+	// send session_id. A graceful fallback is preferable to hook execution failure.
 	if input.SessionID == "" {
 		input.SessionID = "unknown"
 	}
-	// cwd 누락 허용: $CLAUDE_PROJECT_DIR 환경변수로 폴백 가능.
-	// 훅 핸들러에서 cwd가 빈 경우 환경변수를 확인하도록 구현됨.
+	// Allow missing cwd: can fall back to the $CLAUDE_PROJECT_DIR env var.
+	// Hook handlers check the env var when cwd is empty.
 	if input.CWD == "" {
 		if projectDir := os.Getenv("CLAUDE_PROJECT_DIR"); projectDir != "" {
 			input.CWD = projectDir

--- a/internal/hook/protocol_test.go
+++ b/internal/hook/protocol_test.go
@@ -88,7 +88,7 @@ func TestReadInput(t *testing.T) {
 			},
 		},
 		{
-			// session_id 누락 시 "unknown"으로 폴백 (graceful degradation)
+			// when session_id is absent, falls back to "unknown" (graceful degradation)
 			name:    "missing session_id defaults to unknown",
 			input:   `{"cwd": "/tmp", "hook_event_name": "SessionStart"}`,
 			wantErr: false,
@@ -139,7 +139,7 @@ func TestReadInput(t *testing.T) {
 			},
 		},
 		{
-			// cwd 누락 시 $CLAUDE_PROJECT_DIR 폴백 또는 빈 문자열 허용
+			// when cwd is absent, falls back to $CLAUDE_PROJECT_DIR or allows empty string
 			name:    "missing cwd falls back gracefully",
 			input:   `{"session_id": "sess-1", "hook_event_name": "SessionStart"}`,
 			wantErr: false,

--- a/internal/hook/quality/astgrep_gate.go
+++ b/internal/hook/quality/astgrep_gate.go
@@ -15,17 +15,17 @@ import (
 	"github.com/modu-ai/moai-adk/internal/astgrep"
 )
 
-// RunAstGrepGateV2는 통합 Scanner를 사용하여 ast-grep 품질 게이트를 실행합니다.
-// REQ-ASTG-UPG-030: quality gate hook이 통합 Scanner를 호출
-// REQ-UTIL-002-012: 억제 정책 위반이 있으면 (false, formatted-list)를 반환합니다.
-// RunAstGrepGate의 대체 구현으로, 점진적 마이그레이션을 지원합니다.
+// RunAstGrepGateV2 runs the ast-grep quality gate using the unified Scanner.
+// REQ-ASTG-UPG-030: quality gate hook calls the unified Scanner
+// REQ-UTIL-002-012: returns (false, formatted-list) when suppression policy violations are found.
+// Alternative implementation of RunAstGrepGate that supports gradual migration.
 func RunAstGrepGateV2(ctx context.Context, projectDir string, cfg *AstGrepGateConfig) (bool, string) {
 	if cfg == nil || !cfg.Enabled {
 		return true, ""
 	}
 
-	// ── 1. 억제 정책 검사 (sg 독립적, pure-Go) ─────────────────────────────
-	// REQ-UTIL-002-010/011/012: ast-grep-ignore 주석의 @MX:REASON 쌍 검사
+	// ── 1. Suppression policy check (sg-independent, pure-Go) ─────────────────
+	// REQ-UTIL-002-010/011/012: verify @MX:REASON pairing for ast-grep-ignore comments
 	sourceFiles := walkSourceFiles(projectDir)
 	var allViolations []SuppressionViolation
 	for _, fp := range sourceFiles {
@@ -41,7 +41,7 @@ func RunAstGrepGateV2(ctx context.Context, projectDir string, cfg *AstGrepGateCo
 		return false, strings.TrimSpace(sb.String())
 	}
 
-	// ── 2. ast-grep 스캔 (sg CLI 의존) ───────────────────────────────────────
+	// ── 2. ast-grep scan (depends on sg CLI) ─────────────────────────────────
 	rulesDir := filepath.Join(projectDir, cfg.RulesDir)
 	scannerCfg := &astgrep.ScannerConfig{
 		RulesDir:     rulesDir,
@@ -53,7 +53,7 @@ func RunAstGrepGateV2(ctx context.Context, projectDir string, cfg *AstGrepGateCo
 	scanner := astgrep.NewScanner(scannerCfg)
 	findings, err := scanner.Scan(ctx, projectDir)
 	if err != nil {
-		// 스캔 오류 시 통과 (graceful degradation)
+		// Pass on scan error (graceful degradation)
 		return true, ""
 	}
 
@@ -61,7 +61,7 @@ func RunAstGrepGateV2(ctx context.Context, projectDir string, cfg *AstGrepGateCo
 		return true, ""
 	}
 
-	// 결과 포매팅
+	// Format results
 	var sb strings.Builder
 	sb.WriteString("ast-grep domain rule scan results:\n\n")
 	for _, f := range findings {
@@ -70,7 +70,7 @@ func RunAstGrepGateV2(ctx context.Context, projectDir string, cfg *AstGrepGateCo
 	}
 	output := strings.TrimSpace(sb.String())
 
-	// error severity 발견 시 차단 (WarnOnlyMode가 아닌 경우)
+	// Block when error-severity findings are found (unless WarnOnlyMode is enabled)
 	if astgrep.HasErrors(findings) && !cfg.WarnOnlyMode && cfg.BlockOnError {
 		return false, fmt.Sprintf("quality gate failed: ast-grep domain rules\n\n%s", output)
 	}
@@ -120,21 +120,21 @@ type astGrepScanMatch struct {
 
 const astGrepScanTimeout = 30 * time.Second
 
-// SuppressionViolation은 ast-grep-ignore 주석이 @MX:REASON과 쌍을 이루지 않는 경우를 나타냅니다.
+// SuppressionViolation represents a case where an ast-grep-ignore comment is not paired with @MX:REASON.
 // REQ-UTIL-002-010/011
 type SuppressionViolation struct {
-	// Type은 항상 "SUPPRESSION_WITHOUT_REASON"입니다.
+	// Type is always "SUPPRESSION_WITHOUT_REASON".
 	Type    string `json:"type"`
-	// File은 위반이 발생한 파일 경로입니다.
+	// File is the path of the file where the violation occurred.
 	File    string `json:"file"`
-	// Line은 1-indexed 줄 번호입니다.
+	// Line is the 1-indexed line number.
 	Line    int    `json:"line"`
-	// Message는 사람이 읽을 수 있는 오류 메시지입니다.
+	// Message is a human-readable error message.
 	Message string `json:"message"`
 }
 
-// commentPrefix는 파일 확장자에 따라 line comment 접두사를 반환합니다.
-// 지원하지 않는 확장자는 빈 문자열을 반환합니다.
+// commentPrefix returns the line comment prefix for the given file extension.
+// Returns an empty string for unsupported extensions.
 func commentPrefix(filePath string) string {
 	ext := strings.ToLower(filepath.Ext(filePath))
 	switch ext {
@@ -151,11 +151,11 @@ func commentPrefix(filePath string) string {
 	}
 }
 
-// checkSuppressionPairing는 파일을 한 줄씩 검사하여
-// ast-grep-ignore 주석이 인접한 @MX:REASON 주석과 쌍을 이루지 않는 경우를 찾습니다.
+// checkSuppressionPairing inspects a file line by line to find cases where
+// an ast-grep-ignore comment is not paired with an adjacent @MX:REASON comment.
 //
-// 허용 거리: ast-grep-ignore 다음 빈 줄 0~1개 후 @MX:REASON (REQ-UTIL-002-010).
-// 허용 안됨: 비어 있지 않은 다른 주석 또는 코드 행이 사이에 있는 경우 (REQ-UTIL-002-011).
+// Allowed distance: @MX:REASON may appear after 0–1 blank lines following ast-grep-ignore (REQ-UTIL-002-010).
+// Not allowed: any non-empty comment or code line in between (REQ-UTIL-002-011).
 //
 // REQ-UTIL-002-010/011
 func checkSuppressionPairing(filePath string) []SuppressionViolation {
@@ -173,7 +173,7 @@ func checkSuppressionPairing(filePath string) []SuppressionViolation {
 	ignoreMarker := prefix + " ast-grep-ignore"
 	reasonPrefix := prefix + " @MX:REASON"
 
-	// 파일을 행 단위로 읽기
+	// Read file line by line
 	var lines []string
 	sc := bufio.NewScanner(f)
 	for sc.Scan() {
@@ -187,7 +187,7 @@ func checkSuppressionPairing(filePath string) []SuppressionViolation {
 			continue
 		}
 
-		// i번째 줄에서 ast-grep-ignore 발견 (1-indexed: i+1)
+		// ast-grep-ignore found at line i (1-indexed: i+1)
 		found := false
 		blankCount := 0
 
@@ -197,14 +197,14 @@ func checkSuppressionPairing(filePath string) []SuppressionViolation {
 			if nextTrimmed == "" {
 				blankCount++
 				if blankCount > 1 {
-					// 빈 줄 2개 이상: 너무 멀다
+					// More than 1 blank line: too far
 					break
 				}
 				continue
 			}
 
-			// 비어 있지 않은 첫 번째 행 도달
-			// @MX:REASON이 존재하고 이후 텍스트가 비어 있지 않으면 OK
+			// Reached the first non-empty line
+			// OK if @MX:REASON is present and followed by non-empty text
 			if strings.HasPrefix(nextTrimmed, reasonPrefix) {
 				rest := strings.TrimSpace(strings.TrimPrefix(nextTrimmed, reasonPrefix))
 				if rest != "" {
@@ -230,24 +230,24 @@ func checkSuppressionPairing(filePath string) []SuppressionViolation {
 	return violations
 }
 
-// walkSourceFiles는 projectDir 하위의 소스 파일을 재귀 탐색합니다.
-// commentPrefix가 비어 있지 않은 파일만 반환합니다.
-// 억제 정책 검사는 프로덕션 코드에 적용되므로 *_test.go 및 일반적인 제외 경로는 건너뜁니다.
+// walkSourceFiles recursively walks source files under projectDir.
+// Returns only files for which commentPrefix is non-empty.
+// Suppression policy checks apply to production code, so *_test.go and common exclusion paths are skipped.
 func walkSourceFiles(projectDir string) []string {
 	var files []string
 	_ = filepath.WalkDir(projectDir, func(path string, d os.DirEntry, err error) error {
 		if err != nil || d.IsDir() {
 			return nil
 		}
-		// vendor, .git, node_modules 등 제외
+		// Exclude vendor, .git, node_modules, etc.
 		parts := strings.Split(filepath.ToSlash(path), "/")
 		for _, part := range parts {
 			if part == "vendor" || part == ".git" || part == "node_modules" || part == "__pycache__" {
 				return nil
 			}
 		}
-		// *_test.go 파일 제외: 테스트 파일은 ast-grep-ignore를 테스트 픽스처 데이터로
-		// 사용하는 경우가 많으므로 억제 정책 검사에서 제외합니다.
+		// Exclude *_test.go files: test files often use ast-grep-ignore as test fixture data
+		// and should be excluded from suppression policy checks.
 		if strings.HasSuffix(d.Name(), "_test.go") {
 			return nil
 		}

--- a/internal/hook/quality/gate.go
+++ b/internal/hook/quality/gate.go
@@ -31,9 +31,9 @@ type GateConfig struct {
 	// AstGrepGate configures the ast-grep domain rule scan step.
 	// When nil, ast-grep scanning is skipped.
 	AstGrepGate *AstGrepGateConfig
-	// DisabledSteps는 이름으로 특정 단계를 비활성화합니다 (이슈 #667 Fix 3).
-	// 키는 단계 이름(예: "dotnet format"), 값이 false이면 해당 단계를 건너뜁니다.
-	// 예: map[string]bool{"dotnet format": false}
+	// DisabledSteps disables specific steps by name (issue #667 Fix 3).
+	// Keys are step names (e.g., "dotnet format"); a value of false skips that step.
+	// Example: map[string]bool{"dotnet format": false}
 	DisabledSteps map[string]bool
 }
 
@@ -68,10 +68,10 @@ type gateStep struct {
 	args        []string
 	optional    bool     // If true, skip silently when binary is not found.
 	configFiles []string // If non-empty, skip step when none of these files exist in project dir.
-	// changedExts는 이 단계를 실행할 파일 확장자 목록입니다 (이슈 #667 Fix 1).
-	// 비어 있으면 스테이징 파일에 관계없이 항상 실행됩니다.
-	// 비어 있지 않으면 스테이징된 파일 중 이 확장자를 가진 파일이 없을 때 건너뜁니다.
-	// 미래의 무거운 언어별 linter도 이 패턴으로 opt-in할 수 있습니다.
+	// changedExts is the list of file extensions that trigger this step (issue #667 Fix 1).
+	// When empty, the step always runs regardless of staged files.
+	// When non-empty, the step is skipped if no staged file has one of these extensions.
+	// Future heavy language-specific linters can opt-in using this pattern.
 	changedExts []string
 }
 
@@ -139,9 +139,9 @@ var toolchains = []langToolchain{
 		testStep: &gateStep{name: "gradle test", binary: "gradle", args: []string{"test"}, optional: true},
 	},
 	// C#/.NET: *.csproj or *.sln
-	// changedExts: .cs 파일이 스테이징되지 않으면 dotnet format을 건너뜁니다.
-	// Windows 전용 TFM(예: net9.0-windows10.0.22621.0)을 대상으로 하는 프로젝트가
-	// macOS에서 NuGet 복원에 실패하는 문제를 방지합니다 (이슈 #667).
+	// changedExts: skip dotnet format when no .cs file is staged.
+	// Prevents NuGet restore failures on macOS for projects targeting Windows-only TFMs
+	// (e.g., net9.0-windows10.0.22621.0) (issue #667).
 	{
 		markerFiles: []string{"*.csproj", "*.sln"},
 		lintSteps:   []gateStep{{name: "dotnet format", binary: "dotnet", args: []string{"format", "--verify-no-changes"}, optional: true, changedExts: []string{".cs"}}},
@@ -222,10 +222,10 @@ var toolchains = []langToolchain{
 type QualityGate struct {
 	config *GateConfig
 
-	// stagedCache는 Run 호출당 한 번만 git diff --cached 결과를 캐시합니다.
+	// stagedCache caches the git diff --cached result exactly once per Run call.
 	stagedCache        []string
-	stagedCacheReady   bool // 쿼리 완료 여부 (결과가 nil이어도 true)
-	stagedCacheNil     bool // nil 반환(보수적 fallback) 여부
+	stagedCacheReady   bool // true when the query is complete (even if result is nil)
+	stagedCacheNil     bool // true when nil was returned (conservative fallback)
 }
 
 // NewQualityGate creates a QualityGate with the given configuration.
@@ -269,7 +269,7 @@ func (g *QualityGate) Run(ctx context.Context) (bool, string) {
 	}
 
 	// Step 2.5: ast-grep domain rules
-	// ASTG-UPGRADE-001: 통합 Scanner를 사용하는 RunAstGrepGateV2로 전환
+	// ASTG-UPGRADE-001: switched to RunAstGrepGateV2 which uses the unified Scanner
 	if g.config.AstGrepGate != nil && g.config.AstGrepGate.Enabled {
 		projectDir := g.config.ProjectDir
 		if projectDir == "" {
@@ -377,7 +377,7 @@ func hasFlutterSection(content string) bool {
 // Steps with configFiles skip silently when none of the listed config files exist.
 // Steps with changedExts skip silently when no staged file matches any of the listed extensions.
 func (g *QualityGate) executeStep(ctx context.Context, step gateStep, timeout time.Duration) (bool, string) {
-	// Fix 3: DisabledSteps 설정으로 명시적 비활성화
+	// Fix 3: explicitly disable via DisabledSteps configuration
 	if disabled, ok := g.config.DisabledSteps[step.name]; ok && !disabled {
 		return true, ""
 	}
@@ -391,15 +391,15 @@ func (g *QualityGate) executeStep(ctx context.Context, step gateStep, timeout ti
 		return true, ""
 	}
 
-	// Fix 1: 스테이징된 파일 중 changedExts에 해당하는 파일이 없으면 건너뜁니다.
-	// stagedFiles 조회가 실패하거나 git 저장소 밖이면 보수적으로 단계를 실행합니다.
+	// Fix 1: skip when no staged file matches changedExts.
+	// If stagedFiles lookup fails or we are outside a git repository, run the step conservatively.
 	if len(step.changedExts) > 0 {
 		dir := g.config.ProjectDir
 		if dir == "" {
 			dir, _ = os.Getwd()
 		}
 		staged := g.cachedStagedFiles(ctx, dir)
-		// staged가 nil이면 판단 불가 → 보수적으로 실행
+		// If staged is nil, cannot determine — run step conservatively
 		if staged != nil && !hasStagedExt(staged, step.changedExts) {
 			return true, ""
 		}
@@ -408,8 +408,8 @@ func (g *QualityGate) executeStep(ctx context.Context, step gateStep, timeout ti
 	return g.runStep(ctx, step.name, timeout, step.binary, step.args...)
 }
 
-// cachedStagedFiles는 Run 호출당 한 번만 stagedFiles를 조회하고 결과를 캐시합니다.
-// stagedFiles가 nil(보수적 fallback)을 반환한 경우도 캐시합니다.
+// cachedStagedFiles queries stagedFiles exactly once per Run call and caches the result.
+// Also caches when stagedFiles returns nil (conservative fallback).
 func (g *QualityGate) cachedStagedFiles(ctx context.Context, dir string) []string {
 	if !g.stagedCacheReady {
 		files, _ := stagedFiles(ctx, dir)
@@ -423,7 +423,7 @@ func (g *QualityGate) cachedStagedFiles(ctx context.Context, dir string) []strin
 	return g.stagedCache
 }
 
-// hasStagedExt는 staged 목록 중 exts에 포함된 확장자를 가진 파일이 있으면 true를 반환합니다.
+// hasStagedExt returns true if any file in the staged list has an extension in exts.
 func hasStagedExt(staged []string, exts []string) bool {
 	for _, f := range staged {
 		ext := filepath.Ext(f)
@@ -436,26 +436,26 @@ func hasStagedExt(staged []string, exts []string) bool {
 	return false
 }
 
-// stagedFiles는 git diff --cached --name-only를 실행하여 스테이징된 파일 목록을 반환합니다.
-// git 저장소 밖이거나 git 바이너리가 없거나 스테이징된 파일이 없으면 nil을 반환합니다.
-// 오류가 발생해도 nil을 반환하며 (보수적 fallback), 호출자는 nil 시 단계를 실행해야 합니다.
+// stagedFiles runs git diff --cached --name-only and returns the list of staged files.
+// Returns nil when outside a git repository, the git binary is absent, or there are no staged files.
+// Also returns nil on error (conservative fallback); callers must run the step when nil is returned.
 func stagedFiles(ctx context.Context, dir string) ([]string, error) {
-	// git 바이너리 존재 여부 확인
+	// Check whether the git binary exists
 	if _, err := exec.LookPath("git"); err != nil {
-		return nil, nil //nolint:nilerr // 보수적 fallback
+		return nil, nil //nolint:nilerr // conservative fallback
 	}
 
 	cmd := exec.CommandContext(ctx, "git", "diff", "--cached", "--name-only")
 	cmd.Dir = dir
 	out, err := cmd.Output()
 	if err != nil {
-		// git 저장소 밖이거나 명령 실패 → 보수적 fallback
+		// Outside a git repository or command failed — conservative fallback
 		return nil, nil //nolint:nilerr
 	}
 
 	raw := strings.TrimSpace(string(out))
 	if raw == "" {
-		// 스테이징된 파일 없음 → nil 반환 (보수적: 단계 실행)
+		// No staged files — return nil (conservative: run the step)
 		return nil, nil
 	}
 
@@ -516,12 +516,12 @@ func (g *QualityGate) runStep(ctx context.Context, stepName string, timeout time
 		return false, msg
 	}
 
-	// Fix 2: dotnet 단계에서 NuGet 복원 실패(크로스 플랫폼 TFM 불일치)가 감지되면
-	// 경고를 로그하고 통과시킵니다. 다른 linter는 여전히 실패를 전파합니다 (이슈 #667).
+	// Fix 2: when a NuGet restore failure (cross-platform TFM mismatch) is detected in the dotnet step,
+	// log a warning and pass. Other linters still propagate failures (issue #667).
 	if strings.Contains(strings.ToLower(stepName), "dotnet") && isDotnetRestoreFailure(combined) {
-		slog.Warn("dotnet 복원 실패: 크로스 플랫폼 TFM 불일치로 추정하여 건너뜁니다",
+		slog.Warn("dotnet restore failed: assumed cross-platform TFM mismatch, skipping",
 			"step", stepName,
-			"hint", "Windows 전용 TFM이 macOS에서 복원에 실패했을 수 있습니다",
+			"hint", "a Windows-only TFM may have failed to restore on macOS",
 		)
 		return true, ""
 	}
@@ -532,10 +532,10 @@ func (g *QualityGate) runStep(ctx context.Context, stepName string, timeout time
 	return false, fmt.Sprintf("quality gate failed: %s\n\n%s", stepName, output)
 }
 
-// isDotnetRestoreFailure는 stderr/stdout 출력에 NuGet 복원 실패 마커가 포함되어 있는지 확인합니다.
-// Windows 전용 TFM(예: net9.0-windows10.0.22621.0)이 macOS에서 복원에 실패할 때
-// 발생하는 오류 패턴을 감지합니다 (이슈 #667 Fix 2).
-// 이 함수는 dotnet 단계에만 적용됩니다. 다른 linter는 실패를 그대로 전파합니다.
+// isDotnetRestoreFailure checks whether the stderr/stdout output contains NuGet restore failure markers.
+// Detects the error pattern that occurs when a Windows-only TFM (e.g., net9.0-windows10.0.22621.0)
+// fails to restore on macOS (issue #667 Fix 2).
+// This function applies only to the dotnet step; other linters propagate failures as-is.
 func isDotnetRestoreFailure(output string) bool {
 	markers := []string{
 		"Restore operation failed",

--- a/internal/hook/quality/gate_test.go
+++ b/internal/hook/quality/gate_test.go
@@ -449,7 +449,7 @@ dev_dependencies:
 			if len(tcResolved.testStep.args) == 0 || tcResolved.testStep.args[0] != tc.wantTestArg0 {
 				t.Errorf("test args[0] = %v, want %q", tcResolved.testStep.args, tc.wantTestArg0)
 			}
-			// vetSteps 도 flutter 분기인지 확인
+			// Also verify vetSteps are in the flutter branch
 			if len(tcResolved.vetSteps) > 0 && tc.wantTestBinary == "flutter" {
 				if tcResolved.vetSteps[0].binary != "flutter" {
 					t.Errorf("vet binary = %q, want flutter", tcResolved.vetSteps[0].binary)
@@ -499,63 +499,63 @@ func TestQualityGate_Run_UnknownProjectPasses(t *testing.T) {
 }
 
 // TestIsGitCommit covers various command patterns.
-// ─── 이슈 #667: dotnet format 스테이징 파일 필터 및 복원 실패 graceful 처리 ───
+// ─── Issue #667: dotnet format staged file filter and graceful restore-failure handling ───
 
-// TestStagedFiles_OutsideGitRepo는 git 저장소 밖에서 stagedFiles가 nil을 반환하는지 확인합니다.
+// TestStagedFiles_OutsideGitRepo verifies that stagedFiles returns nil outside a git repository.
 func TestStagedFiles_OutsideGitRepo(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir() // git init 없음
+	dir := t.TempDir() // no git init
 
 	got, err := stagedFiles(context.Background(), dir)
-	// 오류가 없어야 하고 nil을 반환해야 합니다 (보수적 fallback).
+	// Must not error and must return nil (conservative fallback).
 	if err != nil {
-		t.Errorf("git 저장소 밖에서 오류가 발생해서는 안 됨: %v", err)
+		t.Errorf("must not error outside a git repository: %v", err)
 	}
 	if got != nil {
-		t.Errorf("git 저장소 밖에서 nil 반환 기대, got: %v", got)
+		t.Errorf("expected nil outside a git repository, got: %v", got)
 	}
 }
 
-// TestStagedFiles_InsideGitRepo는 git 저장소 내에서 스테이징된 파일 목록을 반환하는지 확인합니다.
+// TestStagedFiles_InsideGitRepo verifies that the staged file list is returned inside a git repository.
 func TestStagedFiles_InsideGitRepo(t *testing.T) {
 	t.Parallel()
 
 	skipIfCommandMissing(t, "git")
 
 	dir := t.TempDir()
-	// git 저장소 초기화
+	// Initialize git repository
 	if out, err := runGitCmd(dir, "init"); err != nil {
-		t.Fatalf("git init 실패: %v, out: %s", err, out)
+		t.Fatalf("git init failed: %v, out: %s", err, out)
 	}
 	if out, err := runGitCmd(dir, "config", "user.email", "test@test.com"); err != nil {
-		t.Fatalf("git config 실패: %v, out: %s", err, out)
+		t.Fatalf("git config failed: %v, out: %s", err, out)
 	}
 	if out, err := runGitCmd(dir, "config", "user.name", "Test"); err != nil {
-		t.Fatalf("git config 실패: %v, out: %s", err, out)
+		t.Fatalf("git config failed: %v, out: %s", err, out)
 	}
 
-	// 파일 생성 및 스테이징
+	// Create and stage files
 	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("hello"), 0o644); err != nil {
-		t.Fatalf("파일 생성 실패: %v", err)
+		t.Fatalf("failed to create file: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte("key: val"), 0o644); err != nil {
-		t.Fatalf("파일 생성 실패: %v", err)
+		t.Fatalf("failed to create file: %v", err)
 	}
 	if out, err := runGitCmd(dir, "add", "README.md", "config.yaml"); err != nil {
-		t.Fatalf("git add 실패: %v, out: %s", err, out)
+		t.Fatalf("git add failed: %v, out: %s", err, out)
 	}
 
 	got, err := stagedFiles(context.Background(), dir)
 	if err != nil {
-		t.Fatalf("stagedFiles 오류: %v", err)
+		t.Fatalf("stagedFiles error: %v", err)
 	}
 	if len(got) != 2 {
-		t.Errorf("스테이징된 파일 2개 기대, got: %v", got)
+		t.Errorf("expected 2 staged files, got: %v", got)
 	}
 }
 
-// TestStagedFiles_EmptyStaging은 스테이징된 파일이 없을 때 nil을 반환하는지 확인합니다.
+// TestStagedFiles_EmptyStaging verifies that nil is returned when there are no staged files.
 func TestStagedFiles_EmptyStaging(t *testing.T) {
 	t.Parallel()
 
@@ -563,29 +563,29 @@ func TestStagedFiles_EmptyStaging(t *testing.T) {
 
 	dir := t.TempDir()
 	if out, err := runGitCmd(dir, "init"); err != nil {
-		t.Fatalf("git init 실패: %v, out: %s", err, out)
+		t.Fatalf("git init failed: %v, out: %s", err, out)
 	}
 	if out, err := runGitCmd(dir, "config", "user.email", "test@test.com"); err != nil {
-		t.Fatalf("git config 실패: %v, out: %s", err, out)
+		t.Fatalf("git config failed: %v, out: %s", err, out)
 	}
 	if out, err := runGitCmd(dir, "config", "user.name", "Test"); err != nil {
-		t.Fatalf("git config 실패: %v, out: %s", err, out)
+		t.Fatalf("git config failed: %v, out: %s", err, out)
 	}
 
-	// 스테이징하지 않음
+	// Do not stage any files
 	got, err := stagedFiles(context.Background(), dir)
 	if err != nil {
-		t.Fatalf("stagedFiles 오류: %v", err)
+		t.Fatalf("stagedFiles error: %v", err)
 	}
-	// 빈 스테이징: nil 반환 (보수적 fallback — 단계 실행)
+	// Empty staging: return nil (conservative fallback — run the step)
 	if got != nil {
-		t.Errorf("스테이징된 파일 없을 때 nil 기대, got: %v", got)
+		t.Errorf("expected nil when no staged files, got: %v", got)
 	}
 }
 
-// writeFakeBinary는 임시 디렉터리에 호출 시 지정된 종료 코드로 종료하는
-// 가짜 바이너리 셸 스크립트를 생성하고, 해당 디렉터리 경로를 반환합니다.
-// 테스트에서 PATH를 앞에 삽입하여 실제 바이너리 대신 호출되게 합니다.
+// writeFakeBinary creates a fake binary shell script in a temp directory that exits with the
+// specified exit code when called, and returns the directory path.
+// Prepend the directory to PATH in tests so it is called instead of the real binary.
 func writeFakeBinary(t *testing.T, name string, exitCode int, output string) string {
 	t.Helper()
 	binDir := t.TempDir()
@@ -596,48 +596,48 @@ func writeFakeBinary(t *testing.T, name string, exitCode int, output string) str
 	}
 	content += "exit " + fmt.Sprintf("%d", exitCode) + "\n"
 	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
-		t.Fatalf("가짜 바이너리 생성 실패: %v", err)
+		t.Fatalf("failed to create fake binary: %v", err)
 	}
 	return binDir
 }
 
-// TestQualityGate_SkipsDotnetFormatWhenNoCSharpStaged는 .cs 파일이 스테이징되지 않았을 때
-// dotnet format 단계를 건너뛰는지 검증합니다 (이슈 #667 Fix 1).
-// t.Setenv를 사용하므로 t.Parallel()을 호출하지 않습니다.
+// TestQualityGate_SkipsDotnetFormatWhenNoCSharpStaged verifies that the dotnet format step
+// is skipped when no .cs files are staged (issue #667 Fix 1).
+// Does not call t.Parallel() because it uses t.Setenv.
 func TestQualityGate_SkipsDotnetFormatWhenNoCSharpStaged(t *testing.T) {
 	skipIfCommandMissing(t, "git")
 
 	dir := t.TempDir()
 
-	// git 저장소 초기화
+	// Initialize git repository
 	if out, err := runGitCmd(dir, "init"); err != nil {
-		t.Fatalf("git init 실패: %v, out: %s", err, out)
+		t.Fatalf("git init failed: %v, out: %s", err, out)
 	}
 	if out, err := runGitCmd(dir, "config", "user.email", "test@test.com"); err != nil {
-		t.Fatalf("git config 실패: %v, out: %s", err, out)
+		t.Fatalf("git config failed: %v, out: %s", err, out)
 	}
 	if out, err := runGitCmd(dir, "config", "user.name", "Test"); err != nil {
-		t.Fatalf("git config 실패: %v, out: %s", err, out)
+		t.Fatalf("git config failed: %v, out: %s", err, out)
 	}
 
-	// C# 프로젝트 마커 생성 (.sln 파일로 C# 툴체인 감지)
+	// Create C# project marker (.sln file for C# toolchain detection)
 	if err := os.WriteFile(filepath.Join(dir, "MyApp.sln"), []byte(""), 0o644); err != nil {
-		t.Fatalf("sln 파일 생성 실패: %v", err)
+		t.Fatalf("failed to create sln file: %v", err)
 	}
 
-	// .cs 파일이 아닌 파일만 스테이징 (README.md, config.yaml)
+	// Stage only non-.cs files (README.md, config.yaml)
 	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("docs"), 0o644); err != nil {
-		t.Fatalf("README.md 생성 실패: %v", err)
+		t.Fatalf("failed to create README.md: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte("key: val"), 0o644); err != nil {
-		t.Fatalf("config.yaml 생성 실패: %v", err)
+		t.Fatalf("failed to create config.yaml: %v", err)
 	}
 	if out, err := runGitCmd(dir, "add", "README.md", "config.yaml"); err != nil {
-		t.Fatalf("git add 실패: %v, out: %s", err, out)
+		t.Fatalf("git add failed: %v, out: %s", err, out)
 	}
 
-	// 호출되면 exit 1로 실패하는 가짜 dotnet 바이너리 주입.
-	// changedExts 필터가 올바르게 동작하면 이 바이너리는 절대 실행되지 않아야 합니다.
+	// Inject a fake dotnet binary that fails with exit 1 when called.
+	// If the changedExts filter works correctly, this binary must never be executed.
 	fakeBinDir := writeFakeBinary(t, "dotnet", 1, "Restore operation failed")
 	t.Setenv("PATH", fakeBinDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
@@ -645,7 +645,7 @@ func TestQualityGate_SkipsDotnetFormatWhenNoCSharpStaged(t *testing.T) {
 		name:        "dotnet format",
 		binary:      "dotnet",
 		args:        []string{"format", "--verify-no-changes"},
-		optional:    false, // optional=false: 바이너리가 있으면 반드시 실행
+		optional:    false, // optional=false: must run when binary is present
 		changedExts: []string{".cs"},
 	}
 
@@ -656,20 +656,20 @@ func TestQualityGate_SkipsDotnetFormatWhenNoCSharpStaged(t *testing.T) {
 		LintTimeout: 5 * time.Second,
 	})
 
-	// stagedFiles를 통해 .cs 없음 감지 → dotnet format 건너뜀
+	// No .cs detected via stagedFiles → dotnet format skipped
 	passed, out := g.executeStep(context.Background(), step, 5*time.Second)
 
 	if !passed {
-		t.Errorf("C# 파일이 없을 때 dotnet format 건너뛰어야 합니다 (passed=true 기대), output: %q", out)
+		t.Errorf("dotnet format must be skipped when no C# files are staged (expected passed=true), output: %q", out)
 	}
 }
 
-// TestQualityGate_RunsDotnetFormatWhenCSharpStaged는 .cs 파일이 스테이징되었을 때
-// dotnet format 단계가 실행되는지 검증합니다 (이슈 #667 Fix 1).
-// t.Setenv를 사용하므로 t.Parallel()을 호출하지 않습니다.
+// TestQualityGate_RunsDotnetFormatWhenCSharpStaged verifies that the dotnet format step runs
+// when .cs files are staged (issue #667 Fix 1).
+// Does not call t.Parallel() because it uses t.Setenv.
 func TestQualityGate_RunsDotnetFormatWhenCSharpStaged(t *testing.T) {
-	// Windows는 #!/bin/sh 가짜 바이너리를 exec.Command로 실행할 수 없으므로 스킵.
-	// 실제 dotnet이 설치된 CI에서는 format 실행이 타임아웃으로 실패함.
+	// Skip on Windows: shell-script fake binary is not directly executable via exec.Command.
+	// On CI with real dotnet installed, format execution would fail on timeout.
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping on Windows: shell-script fake binary is not directly executable")
 	}
@@ -677,31 +677,31 @@ func TestQualityGate_RunsDotnetFormatWhenCSharpStaged(t *testing.T) {
 
 	dir := t.TempDir()
 
-	// git 저장소 초기화
+	// Initialize git repository
 	if out, err := runGitCmd(dir, "init"); err != nil {
-		t.Fatalf("git init 실패: %v, out: %s", err, out)
+		t.Fatalf("git init failed: %v, out: %s", err, out)
 	}
 	if out, err := runGitCmd(dir, "config", "user.email", "test@test.com"); err != nil {
-		t.Fatalf("git config 실패: %v, out: %s", err, out)
+		t.Fatalf("git config failed: %v, out: %s", err, out)
 	}
 	if out, err := runGitCmd(dir, "config", "user.name", "Test"); err != nil {
-		t.Fatalf("git config 실패: %v, out: %s", err, out)
+		t.Fatalf("git config failed: %v, out: %s", err, out)
 	}
 
-	// C# 마커 생성
+	// Create C# marker
 	if err := os.WriteFile(filepath.Join(dir, "MyApp.sln"), []byte(""), 0o644); err != nil {
-		t.Fatalf("sln 파일 생성 실패: %v", err)
+		t.Fatalf("failed to create sln file: %v", err)
 	}
 
-	// .cs 파일을 스테이징
+	// Stage a .cs file
 	if err := os.WriteFile(filepath.Join(dir, "Program.cs"), []byte("// C# code"), 0o644); err != nil {
-		t.Fatalf("Program.cs 생성 실패: %v", err)
+		t.Fatalf("failed to create Program.cs: %v", err)
 	}
 	if out, err := runGitCmd(dir, "add", "Program.cs"); err != nil {
-		t.Fatalf("git add 실패: %v, out: %s", err, out)
+		t.Fatalf("git add failed: %v, out: %s", err, out)
 	}
 
-	// 성공(exit 0)하는 가짜 dotnet 주입 — 실제로 호출되어야 합니다.
+	// Inject a fake dotnet that succeeds (exit 0) — it must actually be called.
 	fakeBinDir := writeFakeBinary(t, "dotnet", 0, "")
 	t.Setenv("PATH", fakeBinDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
@@ -720,52 +720,52 @@ func TestQualityGate_RunsDotnetFormatWhenCSharpStaged(t *testing.T) {
 		LintTimeout: 5 * time.Second,
 	})
 
-	// .cs 파일이 스테이징됨 → dotnet format 실행되어야 함 → 가짜 dotnet은 exit 0
+	// .cs file is staged → dotnet format must run → fake dotnet exits 0
 	passed, out := g.executeStep(context.Background(), step, 5*time.Second)
 
 	if !passed {
-		t.Errorf(".cs 파일이 스테이징되었을 때 dotnet format이 통과해야 합니다, output: %q", out)
+		t.Errorf("dotnet format must pass when .cs files are staged, output: %q", out)
 	}
 }
 
-// TestQualityGate_GracefulOnDotnetRestoreFailure는 dotnet 복원 실패 시
-// 게이트가 경고를 로그하고 통과(true, "")를 반환하는지 검증합니다 (이슈 #667 Fix 2).
+// TestQualityGate_GracefulOnDotnetRestoreFailure verifies that the gate logs a warning and returns
+// (true, "") when a dotnet restore failure is detected (issue #667 Fix 2).
 func TestQualityGate_GracefulOnDotnetRestoreFailure(t *testing.T) {
 	t.Parallel()
 
-	// dotnetRestoreFailure 감지 함수를 직접 테스트합니다.
+	// Test the dotnetRestoreFailure detection function directly.
 	cases := []struct {
 		name     string
 		stderr   string
 		wantSkip bool
 	}{
 		{
-			name:     "Restore operation failed 포함",
+			name:     "contains Restore operation failed",
 			stderr:   "Unhandled exception: System.Exception: Restore operation failed.",
 			wantSkip: true,
 		},
 		{
-			name:     "NU1202 오류 코드 포함",
+			name:     "contains NU1202 error code",
 			stderr:   "error NU1202: Package 'foo' 1.0.0 is not compatible with net9.0-windows10.0.22621.0",
 			wantSkip: true,
 		},
 		{
-			name:     "NETSDK1005 오류 포함",
+			name:     "contains NETSDK1005 error",
 			stderr:   "NETSDK1005: Assets file not found",
 			wantSkip: true,
 		},
 		{
-			name:     "not supported on this platform 포함",
+			name:     "contains not supported on this platform",
 			stderr:   "This target framework 'net9.0-windows10.0.22621.0' is not supported on this platform",
 			wantSkip: true,
 		},
 		{
-			name:     "일반 dotnet 포맷 오류 (복원 실패 아님)",
+			name:     "general dotnet format error (not restore failure)",
 			stderr:   "error CS1001: Identifier expected",
 			wantSkip: false,
 		},
 		{
-			name:     "빈 stderr",
+			name:     "empty stderr",
 			stderr:   "",
 			wantSkip: false,
 		},
@@ -782,7 +782,7 @@ func TestQualityGate_GracefulOnDotnetRestoreFailure(t *testing.T) {
 	}
 }
 
-// runGitCmd는 테스트 헬퍼로 주어진 디렉터리에서 git 명령을 실행합니다.
+// runGitCmd is a test helper that runs a git command in the given directory.
 func runGitCmd(dir string, args ...string) (string, error) {
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir

--- a/internal/hook/reflective_write.go
+++ b/internal/hook/reflective_write.go
@@ -252,9 +252,9 @@ func pickEvolvableZone(skillFilePath string) string {
 	return "best-practices"
 }
 
-// deduplicateSummaries는 향후 Reflective Write 확장에서 사용할 헬퍼로 보존한다.
-// 현재 호출 경로는 없으므로 linter unused 경고를 방지하기 위해 주석 처리했다.
-// 복원 시: 본 파일의 블록 주석을 제거하고 호출부를 추가하라.
+// deduplicateSummaries is preserved as a helper for future Reflective Write extensions.
+// Currently there is no call path, so it is commented out to suppress the linter unused warning.
+// To restore: remove the block comment in this file and add a call site.
 /*
 func deduplicateSummaries(summaries []string) string {
 	seen := make(map[string]bool)

--- a/internal/hook/registry_extra_coverage_test.go
+++ b/internal/hook/registry_extra_coverage_test.go
@@ -1,7 +1,7 @@
 package hook
 
-// registry_extra_coverage_test.go: SetTraceWriter, EnableObservability,
-// effectiveDecision, effectiveReason, writeTrace, ensureTraceWriter 커버리지
+// registry_extra_coverage_test.go: coverage for SetTraceWriter, EnableObservability,
+// effectiveDecision, effectiveReason, writeTrace, ensureTraceWriter
 
 import (
 	"context"

--- a/internal/hook/session_end_extra_coverage_test.go
+++ b/internal/hook/session_end_extra_coverage_test.go
@@ -1,7 +1,7 @@
 package hook
 
-// session_end_extra_coverage_test.go: getModifiedGoFiles, cleanupGLMSettingsLocal,
-// NewSessionEndHandlerWithObservability, generateSessionSummary 추가 커버리지
+// session_end_extra_coverage_test.go: additional coverage for getModifiedGoFiles,
+// cleanupGLMSettingsLocal, NewSessionEndHandlerWithObservability, generateSessionSummary
 
 import (
 	"context"

--- a/internal/hook/session_start.go
+++ b/internal/hook/session_start.go
@@ -87,14 +87,14 @@ func (h *sessionStartHandler) Handle(ctx context.Context, input *HookInput) (*Ho
 		}
 	}
 
-	// GLM 팀 모드에서 팀원 tmux 팬이 ANTHROPIC_AUTH_TOKEN을 상속하도록
-	// 현재 tmux 세션에 GLM 환경변수를 주입합니다.
-	// ensureGLMCredentials가 settings.local.json에 토큰을 기록한 후에 실행해야
-	// 최신 값을 읽을 수 있습니다.
+	// Inject GLM environment variables into the current tmux session so that
+	// teammate tmux panes can inherit ANTHROPIC_AUTH_TOKEN in GLM team mode.
+	// Must run after ensureGLMCredentials writes the token to settings.local.json
+	// so the latest value can be read.
 	if input.ProjectDir != "" {
 		if msg := ensureTmuxGLMEnv(input.ProjectDir); msg != "" {
 			data["tmux_glm_env"] = msg
-			slog.Info("tmux GLM 환경변수 주입", "message", msg)
+			slog.Info("tmux GLM env vars injected", "message", msg)
 		}
 	}
 
@@ -444,12 +444,12 @@ func ensureNewSkillSymlinks(projectDir string) int {
 
 		name := entry.Name()
 
-		// 이름 검증: 경로 순회, null 바이트, 슬래시, 백슬래시, 숨김 파일 거부
-		// TOCTOU 완화: ReadDir 결과 이름만 사용하고 직접 경로 조합하지 않음
+		// Validate name: reject path traversal, null bytes, slashes, backslashes, and hidden files
+		// TOCTOU mitigation: use only names from ReadDir results without constructing paths directly
 		if name == "" || name == "." || name == ".." ||
 			strings.ContainsAny(name, "/\\\x00") ||
 			strings.HasPrefix(name, ".") {
-			slog.Warn("ensureNewSkillSymlinks: 잘못된 스킬 이름 건너뜀",
+			slog.Warn("ensureNewSkillSymlinks: skipping invalid skill name",
 				"name", name,
 			)
 			continue

--- a/internal/hook/session_start_glm_tmux_test.go
+++ b/internal/hook/session_start_glm_tmux_test.go
@@ -8,11 +8,11 @@ import (
 	"testing"
 )
 
-// TestEnsureTmuxGLMEnv_NotInTmux_ReturnsEmpty는 tmux 세션 밖에서 실행 시
-// 함수가 빈 문자열을 반환하는지 검증합니다.
+// TestEnsureTmuxGLMEnv_NotInTmux_ReturnsEmpty verifies that the function returns an empty
+// string when executed outside a tmux session.
 func TestEnsureTmuxGLMEnv_NotInTmux_ReturnsEmpty(t *testing.T) {
-	// t.Setenv 사용으로 t.Parallel() 불가
-	t.Setenv("TMUX", "") // tmux 세션 밖을 시뮬레이션
+	// cannot use t.Parallel() due to t.Setenv
+	t.Setenv("TMUX", "") // simulate environment outside a tmux session
 
 	dir := t.TempDir()
 	claudeDir := filepath.Join(dir, ".claude")
@@ -22,74 +22,74 @@ func TestEnsureTmuxGLMEnv_NotInTmux_ReturnsEmpty(t *testing.T) {
 
 	msg := ensureTmuxGLMEnv(dir)
 	if msg != "" {
-		t.Errorf("tmux 밖에서는 빈 문자열이어야 함, got %q", msg)
+		t.Errorf("must return empty string outside tmux, got %q", msg)
 	}
 }
 
-// TestEnsureTmuxGLMEnv_NoTeammateModeTmux_ReturnsEmpty는 teammateMode가
-// "tmux"가 아닐 때 빈 문자열을 반환하는지 검증합니다.
+// TestEnsureTmuxGLMEnv_NoTeammateModeTmux_ReturnsEmpty verifies that the function returns
+// an empty string when teammateMode is not "tmux".
 func TestEnsureTmuxGLMEnv_NoTeammateModeTmux_ReturnsEmpty(t *testing.T) {
-	// t.Setenv 사용으로 t.Parallel() 불가
-	t.Setenv("TMUX", "/tmp/fake-tmux,1234,0") // tmux 세션 안을 시뮬레이션
+	// cannot use t.Parallel() due to t.Setenv
+	t.Setenv("TMUX", "/tmp/fake-tmux,1234,0") // simulate environment inside a tmux session
 
 	dir := t.TempDir()
 	claudeDir := filepath.Join(dir, ".claude")
 	_ = os.MkdirAll(claudeDir, 0o755)
 
-	// teammateMode가 없는 경우
+	// case: teammateMode is absent
 	settings := `{"env":{"ANTHROPIC_AUTH_TOKEN":"test-token"}}`
 	_ = os.WriteFile(filepath.Join(claudeDir, "settings.local.json"), []byte(settings), 0o644)
 
 	msg := ensureTmuxGLMEnv(dir)
 	if msg != "" {
-		t.Errorf("teammateMode가 tmux가 아닐 때 빈 문자열이어야 함 (no key), got %q", msg)
+		t.Errorf("must return empty string when teammateMode is not tmux (no key), got %q", msg)
 	}
 
-	// teammateMode가 "auto"인 경우
+	// case: teammateMode is "auto"
 	settings2 := `{"teammateMode":"auto","env":{"ANTHROPIC_AUTH_TOKEN":"test-token"}}`
 	_ = os.WriteFile(filepath.Join(claudeDir, "settings.local.json"), []byte(settings2), 0o644)
 
 	msg2 := ensureTmuxGLMEnv(dir)
 	if msg2 != "" {
-		t.Errorf("teammateMode=auto일 때 빈 문자열이어야 함, got %q", msg2)
+		t.Errorf("must return empty string when teammateMode=auto, got %q", msg2)
 	}
 }
 
-// TestEnsureTmuxGLMEnv_NoAuthToken_ReturnsEmpty는 ANTHROPIC_AUTH_TOKEN이 없을 때
-// 빈 문자열을 반환하는지 검증합니다.
+// TestEnsureTmuxGLMEnv_NoAuthToken_ReturnsEmpty verifies that the function returns
+// an empty string when ANTHROPIC_AUTH_TOKEN is absent.
 func TestEnsureTmuxGLMEnv_NoAuthToken_ReturnsEmpty(t *testing.T) {
-	// t.Setenv 사용으로 t.Parallel() 불가
+	// cannot use t.Parallel() due to t.Setenv
 	t.Setenv("TMUX", "/tmp/fake-tmux,1234,0")
 
 	dir := t.TempDir()
 	claudeDir := filepath.Join(dir, ".claude")
 	_ = os.MkdirAll(claudeDir, 0o755)
 
-	// ANTHROPIC_AUTH_TOKEN 없이 teammateMode=tmux
+	// teammateMode=tmux without ANTHROPIC_AUTH_TOKEN
 	settings := `{"teammateMode":"tmux","env":{"ANTHROPIC_BASE_URL":"https://api.z.ai/api/anthropic"}}`
 	_ = os.WriteFile(filepath.Join(claudeDir, "settings.local.json"), []byte(settings), 0o644)
 
 	msg := ensureTmuxGLMEnv(dir)
 	if msg != "" {
-		t.Errorf("AUTH_TOKEN 없을 때 빈 문자열이어야 함, got %q", msg)
+		t.Errorf("must return empty string when AUTH_TOKEN is absent, got %q", msg)
 	}
 }
 
-// TestEnsureTmuxGLMEnv_NoSettingsFile_ReturnsEmpty는 settings.local.json이
-// 없을 때 빈 문자열을 반환하는지 검증합니다.
+// TestEnsureTmuxGLMEnv_NoSettingsFile_ReturnsEmpty verifies that the function returns
+// an empty string when settings.local.json is absent.
 func TestEnsureTmuxGLMEnv_NoSettingsFile_ReturnsEmpty(t *testing.T) {
-	// t.Setenv 사용으로 t.Parallel() 불가
+	// cannot use t.Parallel() due to t.Setenv
 	t.Setenv("TMUX", "/tmp/fake-tmux,1234,0")
 
 	dir := t.TempDir()
 	msg := ensureTmuxGLMEnv(dir)
 	if msg != "" {
-		t.Errorf("설정 파일 없을 때 빈 문자열이어야 함, got %q", msg)
+		t.Errorf("must return empty string when settings file is absent, got %q", msg)
 	}
 }
 
-// TestBuildGLMTmuxEnvVars_AllGLMVars는 GLM 환경변수가 모두 있을 때
-// buildGLMTmuxEnvVars가 올바른 맵을 반환하는지 검증합니다.
+// TestBuildGLMTmuxEnvVars_AllGLMVars verifies that buildGLMTmuxEnvVars returns
+// the correct map when all GLM environment variables are present.
 func TestBuildGLMTmuxEnvVars_AllGLMVars(t *testing.T) {
 	t.Parallel()
 
@@ -108,7 +108,7 @@ func TestBuildGLMTmuxEnvVars_AllGLMVars(t *testing.T) {
 
 	result := buildGLMTmuxEnvVars(env)
 
-	// 반환된 맵에 모든 GLM 관련 변수가 포함되어야 함
+	// all GLM-related variables must be present in the returned map
 	wantKeys := []string{
 		"ANTHROPIC_AUTH_TOKEN",
 		"ANTHROPIC_BASE_URL",
@@ -123,45 +123,45 @@ func TestBuildGLMTmuxEnvVars_AllGLMVars(t *testing.T) {
 
 	for _, key := range wantKeys {
 		if _, ok := result[key]; !ok {
-			t.Errorf("결과 맵에 %q 키가 없음", key)
+			t.Errorf("key %q is missing from result map", key)
 		}
 	}
 
-	// 무관한 변수는 포함되지 않아야 함
+	// unrelated variables must not be included
 	if _, ok := result["SOME_OTHER_VAR"]; ok {
-		t.Error("무관한 변수 SOME_OTHER_VAR가 포함되면 안 됨")
+		t.Error("unrelated variable SOME_OTHER_VAR must not be included")
 	}
 }
 
-// TestBuildGLMTmuxEnvVars_EmptyAuthToken은 AUTH_TOKEN이 없을 때
-// buildGLMTmuxEnvVars가 nil을 반환하는지 검증합니다.
+// TestBuildGLMTmuxEnvVars_EmptyAuthToken verifies that buildGLMTmuxEnvVars
+// returns nil when AUTH_TOKEN is absent.
 func TestBuildGLMTmuxEnvVars_EmptyAuthToken(t *testing.T) {
 	t.Parallel()
 
-	// ANTHROPIC_AUTH_TOKEN 없는 경우
+	// case: ANTHROPIC_AUTH_TOKEN is absent
 	emptyEnv := map[string]string{
 		"ANTHROPIC_BASE_URL": "https://api.z.ai/api/anthropic",
 	}
 	emptyResult := buildGLMTmuxEnvVars(emptyEnv)
 	if emptyResult != nil {
-		t.Error("AUTH_TOKEN 없을 때 nil이어야 함")
+		t.Error("must return nil when AUTH_TOKEN is absent")
 	}
 
-	// ANTHROPIC_AUTH_TOKEN이 빈 문자열인 경우
+	// case: ANTHROPIC_AUTH_TOKEN is an empty string
 	emptyTokenEnv := map[string]string{
 		"ANTHROPIC_AUTH_TOKEN": "",
 		"ANTHROPIC_BASE_URL":   "https://api.z.ai/api/anthropic",
 	}
 	emptyTokenResult := buildGLMTmuxEnvVars(emptyTokenEnv)
 	if emptyTokenResult != nil {
-		t.Error("빈 AUTH_TOKEN일 때 nil이어야 함")
+		t.Error("must return nil when AUTH_TOKEN is an empty string")
 	}
 }
 
-// TestEnsureTmuxGLMEnv_HandlesTmuxBinaryMissing은 tmux 바이너리가 없을 때
-// 패닉 없이 빈 문자열을 반환하는지 검증합니다.
+// TestEnsureTmuxGLMEnv_HandlesTmuxBinaryMissing verifies that the function returns
+// an empty string without panicking when the tmux binary is absent.
 func TestEnsureTmuxGLMEnv_HandlesTmuxBinaryMissing(t *testing.T) {
-	// t.Setenv 사용으로 t.Parallel() 불가
+	// cannot use t.Parallel() due to t.Setenv
 	t.Setenv("TMUX", "/tmp/fake-tmux,1234,0")
 	t.Setenv("PATH", "/nonexistent-path-for-testing")
 
@@ -184,32 +184,32 @@ func TestEnsureTmuxGLMEnv_HandlesTmuxBinaryMissing(t *testing.T) {
 	data, _ := json.MarshalIndent(settings, "", "  ")
 	_ = os.WriteFile(filepath.Join(claudeDir, "settings.local.json"), data, 0o644)
 
-	// tmux 바이너리 없을 때 패닉 없이 빈 문자열 반환해야 함
+	// must return empty string without panicking when tmux binary is absent
 	msg := ensureTmuxGLMEnv(dir)
 	if msg != "" {
-		t.Logf("tmux 바이너리가 없는데 non-empty 반환됨 (PATH 격리 불완전): %q", msg)
+		t.Logf("non-empty returned despite missing tmux binary (incomplete PATH isolation): %q", msg)
 	}
-	// 패닉이 발생하지 않으면 성공
+	// success if no panic occurs
 }
 
-// TestBuildGLMTmuxEnvVars_OnlyPresentVars는 설정 파일에 있는 변수만
-// 결과에 포함되는지 검증합니다 (없는 변수는 포함 안 됨).
+// TestBuildGLMTmuxEnvVars_OnlyPresentVars verifies that only variables present in the
+// settings file are included in the result (absent variables are excluded).
 func TestBuildGLMTmuxEnvVars_OnlyPresentVars(t *testing.T) {
 	t.Parallel()
 
-	// 일부 GLM 변수만 있는 경우
+	// only some GLM variables are present
 	env := map[string]string{
 		"ANTHROPIC_AUTH_TOKEN": "test-token",
 		"ANTHROPIC_BASE_URL":   "https://api.z.ai/api/anthropic",
-		// 모델명 없음
+		// model names absent
 	}
 
 	result := buildGLMTmuxEnvVars(env)
 	if result == nil {
-		t.Fatal("AUTH_TOKEN 있을 때 nil이면 안 됨")
+		t.Fatal("must not return nil when AUTH_TOKEN is present")
 	}
 
-	// AUTH_TOKEN과 BASE_URL은 있어야 함
+	// AUTH_TOKEN and BASE_URL must be present
 	if result["ANTHROPIC_AUTH_TOKEN"] != "test-token" {
 		t.Errorf("AUTH_TOKEN = %q, want %q", result["ANTHROPIC_AUTH_TOKEN"], "test-token")
 	}
@@ -217,19 +217,19 @@ func TestBuildGLMTmuxEnvVars_OnlyPresentVars(t *testing.T) {
 		t.Errorf("BASE_URL = %q, want Z.AI endpoint", result["ANTHROPIC_BASE_URL"])
 	}
 
-	// 설정에 없는 모델 키는 포함되지 않아야 함
+	// model keys not in settings must not be included
 	if _, ok := result["ANTHROPIC_DEFAULT_OPUS_MODEL"]; ok {
-		t.Error("설정에 없는 OPUS_MODEL이 포함되면 안 됨")
+		t.Error("OPUS_MODEL not in settings must not be included")
 	}
 }
 
-// TestFormatTmuxGLMEnvSummary_ContainsVarCount는 성공 시 반환 문자열에
-// 주입된 변수 수가 포함되는지 검증합니다.
+// TestFormatTmuxGLMEnvSummary_ContainsVarCount verifies that the returned string
+// contains the number of injected variables on success.
 func TestFormatTmuxGLMEnvSummary_ContainsVarCount(t *testing.T) {
 	t.Parallel()
 
 	summary := formatTmuxGLMEnvSummary(9)
 	if !strings.Contains(summary, "9") {
-		t.Errorf("요약 문자열에 변수 수(9)가 포함되어야 함, got %q", summary)
+		t.Errorf("summary string must contain variable count (9), got %q", summary)
 	}
 }

--- a/internal/hook/session_start_skill_extra_test.go
+++ b/internal/hook/session_start_skill_extra_test.go
@@ -1,9 +1,9 @@
 package hook
 
-// session_start_skill_extra_test.go: ensureNewSkillSymlinks 추가 경로 커버리지
-// - 잘못된 이름(경로 탐색, 숨김 파일, 슬래시 포함)
-// - 기존 디렉터리(Windows 복사본) 건너뜀
-// - getModifiedGoFiles 비어있는 git 출력
+// session_start_skill_extra_test.go: additional path coverage for ensureNewSkillSymlinks
+// - invalid names (path traversal, hidden files, slash-containing)
+// - skipping existing directories (Windows copies)
+// - getModifiedGoFiles with empty git output
 
 import (
 	"os"

--- a/internal/hook/wire_format_freeze_test.go
+++ b/internal/hook/wire_format_freeze_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/modu-ai/moai-adk/internal/hook/quality"
 )
 
-// canonicalHookDiagnostics는 AC-UTIL-003-009의 표준 픽스처를 반환한다.
-// Error / Warning / Information / Hint 각 1개씩 포함한다.
+// canonicalHookDiagnostics returns the canonical fixture for AC-UTIL-003-009.
+// Contains one each of Error, Warning, Information, and Hint.
 func canonicalHookDiagnostics() []lsphook.Diagnostic {
 	return []lsphook.Diagnostic{
 		{
@@ -52,7 +52,7 @@ func canonicalHookDiagnostics() []lsphook.Diagnostic {
 	}
 }
 
-// computeCounts는 픽스처의 SeverityCounts를 계산한다.
+// computeCounts computes the SeverityCounts for the given fixture.
 func computeCounts(diags []lsphook.Diagnostic) lsphook.SeverityCounts {
 	var counts lsphook.SeverityCounts
 	for _, d := range diags {
@@ -72,9 +72,9 @@ func computeCounts(diags []lsphook.Diagnostic) lsphook.SeverityCounts {
 
 // ─── AC-UTIL-003-008 ─────────────────────────────────────────────────────────
 
-// TestHookDiagnosticSeverity_JSONMarshal_StringPreserved는
-// hook.DiagnosticSeverity("error")가 JSON에서 문자열 "error"로 직렬화됨을 확인한다 (AC-UTIL-003-008).
-// wire format 동결: SPEC-UTIL-003 이전과 이후 동일한 JSON 출력이 보장되어야 한다.
+// TestHookDiagnosticSeverity_JSONMarshal_StringPreserved verifies that
+// hook.DiagnosticSeverity("error") serializes to the string "error" in JSON (AC-UTIL-003-008).
+// Wire format freeze: identical JSON output must be guaranteed before and after SPEC-UTIL-003.
 func TestHookDiagnosticSeverity_JSONMarshal_StringPreserved(t *testing.T) {
 	t.Parallel()
 
@@ -122,19 +122,19 @@ func TestHookDiagnosticSeverity_JSONMarshal_StringPreserved(t *testing.T) {
 
 // ─── AC-UTIL-003-009 ─────────────────────────────────────────────────────────
 
-// TestWireFormat_FormatDiagnosticsAsInstructionWithFile_Freeze는
-// 표준 픽스처에 대한 FormatDiagnosticsAsInstructionWithFile 출력이
-// SPEC 적용 전후로 byte-identical임을 확인한다 (AC-UTIL-003-009).
+// TestWireFormat_FormatDiagnosticsAsInstructionWithFile_Freeze verifies that
+// FormatDiagnosticsAsInstructionWithFile output for the canonical fixture is
+// byte-identical before and after SPEC is applied (AC-UTIL-003-009).
 //
-// 동결 검증 방식: 동일 함수를 두 번 호출하여 출력이 항등 (idempotent)임을 검증.
-// SPEC 적용 후 이 테스트는 새 코드와 함께 실행되므로 구현 변경 시 반드시 실패해야 한다.
+// Freeze validation: call the same function twice and verify output is idempotent.
+// After SPEC is applied this test runs with the new code, so it must fail on any implementation change.
 func TestWireFormat_FormatDiagnosticsAsInstructionWithFile_Freeze(t *testing.T) {
 	t.Parallel()
 
 	fixture := canonicalHookDiagnostics()
 	counts := computeCounts(fixture)
 
-	// 에러만 포함 (errors > 0이면 경고는 무시됨)
+	// errors only (when errors > 0, warnings are ignored)
 	got1 := quality.FormatDiagnosticsAsInstructionWithFile("main.go", fixture, counts, false)
 	got2 := quality.FormatDiagnosticsAsInstructionWithFile("main.go", fixture, counts, false)
 
@@ -142,12 +142,12 @@ func TestWireFormat_FormatDiagnosticsAsInstructionWithFile_Freeze(t *testing.T) 
 		t.Error("FormatDiagnosticsAsInstructionWithFile is not idempotent (wire format unstable)")
 	}
 
-	// 출력이 비어있지 않아야 함 (error 진단이 있으므로)
+	// output must not be empty (error diagnostic is present)
 	if got1 == "" {
 		t.Error("FormatDiagnosticsAsInstructionWithFile returned empty string for error diagnostic")
 	}
 
-	// 예상 포맷 요소 확인: 헤더, 파일명, 에러 메시지, 종료 문구
+	// verify expected format elements: header, filename, error message, closing instruction
 	if !strings.Contains(got1, "[Quality Gate]") {
 		t.Errorf("output missing '[Quality Gate]' header: %q", got1)
 	}
@@ -162,9 +162,9 @@ func TestWireFormat_FormatDiagnosticsAsInstructionWithFile_Freeze(t *testing.T) 
 	}
 }
 
-// TestWireFormat_ConvertHookDiagsToLSP_Freeze는 convertHookDiagsToLSP 변환이
-// SPEC 적용 전후로 byte-identical 출력을 생성함을 확인한다 (AC-UTIL-003-009).
-// hook.Diagnostic(string severity) → lsp.Diagnostic(int severity) 변환 경로 동결.
+// TestWireFormat_ConvertHookDiagsToLSP_Freeze verifies that convertHookDiagsToLSP
+// produces byte-identical output before and after SPEC is applied (AC-UTIL-003-009).
+// Freeze for the hook.Diagnostic(string severity) → lsp.Diagnostic(int severity) conversion path.
 func TestWireFormat_ConvertHookDiagsToLSP_Freeze(t *testing.T) {
 	t.Parallel()
 
@@ -186,7 +186,7 @@ func TestWireFormat_ConvertHookDiagsToLSP_Freeze(t *testing.T) {
 		}
 	}
 
-	// severity 변환 정확도: string → int 검증
+	// severity conversion accuracy: string → int validation
 	// SeverityError = "error" → 1, SeverityWarning = "warning" → 2,
 	// SeverityInformation = "information" → 3, SeverityHint = "hint" → 4
 	expected := []int{1, 2, 3, 4}
@@ -197,8 +197,8 @@ func TestWireFormat_ConvertHookDiagsToLSP_Freeze(t *testing.T) {
 	}
 }
 
-// TestHookDiagnostic_JSONRoundTrip는 hook.Diagnostic의 JSON 직렬화/역직렬화가
-// 완전한 데이터 보존을 보장함을 확인한다 (AC-UTIL-003-008 보강).
+// TestHookDiagnostic_JSONRoundTrip verifies that JSON serialization/deserialization of
+// hook.Diagnostic guarantees complete data preservation (reinforces AC-UTIL-003-008).
 func TestHookDiagnostic_JSONRoundTrip(t *testing.T) {
 	t.Parallel()
 

--- a/internal/loop/go_feedback.go
+++ b/internal/loop/go_feedback.go
@@ -16,8 +16,8 @@ import (
 	"github.com/modu-ai/moai-adk/internal/lsp/gopls"
 )
 
-// GoplsBridge는 gopls.Bridge의 GetDiagnostics 메서드를 노출하는 인터페이스다.
-// *gopls.Bridge를 직접 의존하지 않아 테스트에서 mock으로 교체할 수 있다.
+// GoplsBridge is an interface that exposes the GetDiagnostics method of gopls.Bridge.
+// Does not directly depend on *gopls.Bridge, so it can be replaced with a mock in tests.
 // GOPLS-BRIDGE-001: Phase 6 integration
 type GoplsBridge interface {
 	GetDiagnostics(ctx context.Context, path string) ([]gopls.Diagnostic, error)
@@ -32,33 +32,33 @@ type DiagnosticsAggregator interface {
 
 // GoFeedbackGenerator collects feedback by running Go toolchain commands
 // (go test, go vet) and parsing their output. It implements FeedbackGenerator.
-// GOPLS-BRIDGE-001: bridge 필드가 nil이 아니면 LSP 진단도 수집한다.
-// REQ-LL-002: aggregator 필드가 nil이 아니면 Aggregator 기반 lsp.Diagnostic을 수집한다.
+// GOPLS-BRIDGE-001: also collects LSP diagnostics when the bridge field is non-nil.
+// REQ-LL-002: also collects Aggregator-based lsp.Diagnostic when the aggregator field is non-nil.
 type GoFeedbackGenerator struct {
 	projectRoot string
-	bridge      GoplsBridge          // nil이면 gopls 진단 수집 비활성화
-	aggregator  DiagnosticsAggregator // nil이면 Aggregator 진단 수집 비활성화 (REQ-LL-002)
+	bridge      GoplsBridge          // nil disables gopls diagnostic collection
+	aggregator  DiagnosticsAggregator // nil disables Aggregator diagnostic collection (REQ-LL-002)
 }
 
 // NewGoFeedbackGenerator creates a FeedbackGenerator for Go projects.
 // projectRoot is the directory where go test and go vet will be executed.
-// 하위 호환성: bridge는 nil로 설정된다 (LSP 진단 비활성화).
+// Backward compatibility: bridge is set to nil (LSP diagnostic collection disabled).
 func NewGoFeedbackGenerator(projectRoot string) FeedbackGenerator {
 	return &GoFeedbackGenerator{projectRoot: projectRoot, bridge: nil}
 }
 
 // NewGoFeedbackGeneratorWithBridge creates a FeedbackGenerator for Go projects
 // with an optional gopls bridge for LSP diagnostics.
-// GOPLS-BRIDGE-001: bridge가 nil이면 기존 동작(go test + go vet)만 수행한다.
-// bridge가 non-nil이면 LSP 진단도 Feedback.Diagnostics에 추가한다.
+// GOPLS-BRIDGE-001: when bridge is nil, only the existing behavior (go test + go vet) is performed.
+// When bridge is non-nil, LSP diagnostics are also added to Feedback.Diagnostics.
 func NewGoFeedbackGeneratorWithBridge(projectRoot string, bridge GoplsBridge) FeedbackGenerator {
 	return &GoFeedbackGenerator{projectRoot: projectRoot, bridge: bridge}
 }
 
 // NewGoFeedbackGeneratorWithAggregator creates a FeedbackGenerator for Go projects
 // with an optional Aggregator for LSP diagnostics via lsp.Diagnostic.
-// REQ-LL-002: aggregator가 nil이면 기존 동작(go test + go vet)만 수행한다.
-// aggregator가 non-nil이면 lsp.Diagnostic을 Feedback.LSPDiagnostics에 채운다.
+// REQ-LL-002: when aggregator is nil, only the existing behavior (go test + go vet) is performed.
+// When aggregator is non-nil, lsp.Diagnostic is collected into Feedback.LSPDiagnostics.
 func NewGoFeedbackGeneratorWithAggregator(projectRoot string, agg DiagnosticsAggregator) FeedbackGenerator {
 	return &GoFeedbackGenerator{projectRoot: projectRoot, aggregator: agg}
 }
@@ -120,23 +120,23 @@ func (g *GoFeedbackGenerator) Collect(ctx context.Context) (*Feedback, error) {
 
 	fb.Duration = time.Since(start)
 
-	// GOPLS-BRIDGE-001: bridge가 non-nil이면 gopls.Diagnostic을 수집한다.
-	// GetDiagnostics 오류는 무시한다 — bridge 실패가 전체 피드백을 차단해선 안 된다.
+	// GOPLS-BRIDGE-001: when bridge is non-nil, collect gopls.Diagnostic.
+	// Errors from GetDiagnostics are ignored — bridge failures must not block the entire feedback.
 	if g.bridge != nil {
 		diags, err := g.bridge.GetDiagnostics(ctx, g.projectRoot)
 		if err != nil {
-			slog.Warn("gopls 진단 수집 실패, 건너뜀", "error", err)
+			slog.Warn("gopls diagnostic collection failed, skipping", "error", err)
 		} else {
 			fb.Diagnostics = diags
 		}
 	}
 
-	// REQ-LL-002: aggregator가 non-nil이면 lsp.Diagnostic을 수집해 LSPDiagnostics에 채운다.
-	// aggregator 오류는 무시한다 — 진단 실패가 전체 피드백을 차단해선 안 된다.
+	// REQ-LL-002: when aggregator is non-nil, collect lsp.Diagnostic into LSPDiagnostics.
+	// Aggregator errors are ignored — diagnostic failures must not block the entire feedback.
 	if g.aggregator != nil {
 		lspDiags, err := g.aggregator.GetDiagnostics(ctx, g.projectRoot)
 		if err != nil {
-			slog.Warn("aggregator 진단 수집 실패, 건너뜀", "error", err)
+			slog.Warn("aggregator diagnostic collection failed, skipping", "error", err)
 		} else {
 			// Filter to Go-only results: only include diagnostics for .go files.
 			fb.LSPDiagnostics = filterGoOnlyDiagnostics(lspDiags)

--- a/internal/loop/go_feedback_test.go
+++ b/internal/loop/go_feedback_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/modu-ai/moai-adk/internal/lsp/gopls"
 )
 
-// mockBridge는 테스트용 gopls.Bridge 대역이다.
-// GetDiagnostics 호출 결과를 미리 설정할 수 있다.
+// mockBridge is a test double for gopls.Bridge.
+// The result of GetDiagnostics calls can be preconfigured.
 type mockBridge struct {
 	diagnostics []gopls.Diagnostic
 	err         error
@@ -21,22 +21,22 @@ func (m *mockBridge) GetDiagnostics(ctx context.Context, path string) ([]gopls.D
 	return m.diagnostics, m.err
 }
 
-// TestGoFeedbackGenerator_NilBridge는 bridge가 nil일 때 기존 동작이
-// 그대로 유지되는지 검증한다 (하위 호환성).
+// TestGoFeedbackGenerator_NilBridge verifies that the existing behavior is preserved
+// when bridge is nil (backward compatibility).
 func TestGoFeedbackGenerator_NilBridge(t *testing.T) {
 	t.Parallel()
 
 	projectRoot := t.TempDir()
-	// bridge=nil로 생성
+	// Create with bridge=nil
 	gen := NewGoFeedbackGeneratorWithBridge(projectRoot, nil)
 
 	if gen == nil {
-		t.Fatal("NewGoFeedbackGeneratorWithBridge()는 nil을 반환해선 안 된다")
+		t.Fatal("NewGoFeedbackGeneratorWithBridge() must not return nil")
 	}
 }
 
-// TestGoFeedbackGenerator_NilBridgeCollect는 bridge가 nil일 때
-// Collect()가 Diagnostics 필드를 비워두고 정상 반환하는지 검증한다.
+// TestGoFeedbackGenerator_NilBridgeCollect verifies that Collect() leaves the Diagnostics
+// field empty and returns normally when bridge is nil.
 func TestGoFeedbackGenerator_NilBridgeCollect(t *testing.T) {
 	t.Parallel()
 
@@ -48,19 +48,19 @@ func TestGoFeedbackGenerator_NilBridgeCollect(t *testing.T) {
 
 	fb, err := gen.Collect(ctx)
 	if err != nil {
-		t.Fatalf("Collect() 오류 = %v, 기대값: nil", err)
+		t.Fatalf("Collect() error = %v, expected: nil", err)
 	}
 	if fb == nil {
-		t.Fatal("Collect()가 nil Feedback을 반환했다")
+		t.Fatal("Collect() returned nil Feedback")
 	}
-	// bridge가 nil이면 Diagnostics는 nil이어야 한다.
+	// Diagnostics must be nil when bridge is nil.
 	if fb.Diagnostics != nil {
-		t.Errorf("Diagnostics = %v, 기대값: nil (bridge가 nil이므로)", fb.Diagnostics)
+		t.Errorf("Diagnostics = %v, expected: nil (because bridge is nil)", fb.Diagnostics)
 	}
 }
 
-// TestGoFeedbackGenerator_WithBridge_PopulatesDiagnostics는
-// bridge가 있을 때 GetDiagnostics 결과가 Feedback.Diagnostics에 채워지는지 검증한다.
+// TestGoFeedbackGenerator_WithBridge_PopulatesDiagnostics verifies that
+// GetDiagnostics results are populated into Feedback.Diagnostics when bridge is present.
 func TestGoFeedbackGenerator_WithBridge_PopulatesDiagnostics(t *testing.T) {
 	t.Parallel()
 
@@ -86,33 +86,32 @@ func TestGoFeedbackGenerator_WithBridge_PopulatesDiagnostics(t *testing.T) {
 
 	fb, err := gen.Collect(ctx)
 	if err != nil {
-		t.Fatalf("Collect() 오류 = %v, 기대값: nil", err)
+		t.Fatalf("Collect() error = %v, expected: nil", err)
 	}
 	if fb == nil {
-		t.Fatal("Collect()가 nil Feedback을 반환했다")
+		t.Fatal("Collect() returned nil Feedback")
 	}
 
 	if !mock.called {
-		t.Error("bridge.GetDiagnostics()가 호출되지 않았다")
+		t.Error("bridge.GetDiagnostics() was not called")
 	}
 
 	if len(fb.Diagnostics) != len(expectedDiags) {
-		t.Errorf("Diagnostics 수 = %d, 기대값 %d", len(fb.Diagnostics), len(expectedDiags))
+		t.Errorf("Diagnostics count = %d, expected %d", len(fb.Diagnostics), len(expectedDiags))
 	}
 
 	for i, d := range fb.Diagnostics {
 		if d.Severity != expectedDiags[i].Severity {
-			t.Errorf("[%d] Severity = %d, 기대값 %d", i, d.Severity, expectedDiags[i].Severity)
+			t.Errorf("[%d] Severity = %d, expected %d", i, d.Severity, expectedDiags[i].Severity)
 		}
 		if d.Message != expectedDiags[i].Message {
-			t.Errorf("[%d] Message = %q, 기대값 %q", i, d.Message, expectedDiags[i].Message)
+			t.Errorf("[%d] Message = %q, expected %q", i, d.Message, expectedDiags[i].Message)
 		}
 	}
 }
 
-// TestGoFeedbackGenerator_WithBridge_ErrorIsSilent는
-// bridge.GetDiagnostics가 오류를 반환해도 Collect()가 오류 없이
-// 빈 Diagnostics를 반환하는지 검증한다.
+// TestGoFeedbackGenerator_WithBridge_ErrorIsSilent verifies that Collect() returns
+// empty Diagnostics without error even when bridge.GetDiagnostics returns an error.
 func TestGoFeedbackGenerator_WithBridge_ErrorIsSilent(t *testing.T) {
 	t.Parallel()
 
@@ -125,32 +124,32 @@ func TestGoFeedbackGenerator_WithBridge_ErrorIsSilent(t *testing.T) {
 
 	fb, err := gen.Collect(ctx)
 	if err != nil {
-		t.Fatalf("Collect()는 bridge 오류를 상위로 전파해선 안 된다. 오류 = %v", err)
+		t.Fatalf("Collect() must not propagate bridge errors. error = %v", err)
 	}
 	if fb == nil {
-		t.Fatal("Collect()가 nil Feedback을 반환했다")
+		t.Fatal("Collect() returned nil Feedback")
 	}
-	// 오류 시 Diagnostics는 nil이어야 한다 (부분 결과 아님).
+	// On error, Diagnostics must be nil (not a partial result).
 	if len(fb.Diagnostics) != 0 {
-		t.Errorf("bridge 오류 시 Diagnostics는 비어야 함, got %v", fb.Diagnostics)
+		t.Errorf("Diagnostics must be empty on bridge error, got %v", fb.Diagnostics)
 	}
 }
 
-// TestGoFeedbackGenerator_BackwardCompat은 NewGoFeedbackGenerator(기존 시그니처)가
-// 여전히 동작하는지 검증한다 (하위 호환성).
+// TestGoFeedbackGenerator_BackwardCompat verifies that NewGoFeedbackGenerator (original signature)
+// still works (backward compatibility).
 func TestGoFeedbackGenerator_BackwardCompat(t *testing.T) {
 	t.Parallel()
 
 	projectRoot := t.TempDir()
-	// 기존 생성자가 여전히 컴파일되어야 한다.
+	// The original constructor must still compile.
 	gen := NewGoFeedbackGenerator(projectRoot)
 	if gen == nil {
-		t.Fatal("NewGoFeedbackGenerator()는 nil을 반환해선 안 된다")
+		t.Fatal("NewGoFeedbackGenerator() must not return nil")
 	}
 }
 
-// TestGoFeedbackGenerator_WithBridge_EmptyDiagnostics는
-// bridge가 빈 슬라이스를 반환할 때 Diagnostics가 비어있는지 검증한다.
+// TestGoFeedbackGenerator_WithBridge_EmptyDiagnostics verifies that Diagnostics is empty
+// when bridge returns an empty slice.
 func TestGoFeedbackGenerator_WithBridge_EmptyDiagnostics(t *testing.T) {
 	t.Parallel()
 
@@ -163,9 +162,9 @@ func TestGoFeedbackGenerator_WithBridge_EmptyDiagnostics(t *testing.T) {
 
 	fb, err := gen.Collect(ctx)
 	if err != nil {
-		t.Fatalf("Collect() 오류 = %v, 기대값: nil", err)
+		t.Fatalf("Collect() error = %v, expected: nil", err)
 	}
 	if len(fb.Diagnostics) != 0 {
-		t.Errorf("Diagnostics = %v, 기대값: 빈 슬라이스", fb.Diagnostics)
+		t.Errorf("Diagnostics = %v, expected: empty slice", fb.Diagnostics)
 	}
 }

--- a/internal/loop/state.go
+++ b/internal/loop/state.go
@@ -119,14 +119,14 @@ type Feedback struct {
 	Coverage     float64       `json:"coverage"`
 	Duration     time.Duration `json:"duration"`
 	Notes        string        `json:"notes"`
-	// Diagnostics는 gopls 브릿지로 수집한 LSP 진단 목록이다.
-	// GOPLS-BRIDGE-001: bridge가 nil이면 nil을 유지한다 (하위 호환성 보장).
-	// Deprecated: LSPDiagnostics를 사용하라 (REQ-LL-001).
+	// Diagnostics is the list of LSP diagnostics collected via the gopls bridge.
+	// GOPLS-BRIDGE-001: remains nil when bridge is nil (backward compatibility guaranteed).
+	// Deprecated: use LSPDiagnostics instead (REQ-LL-001).
 	Diagnostics []gopls.Diagnostic `json:"diagnostics,omitempty"`
 
-	// LSPDiagnostics는 Aggregator로 수집한 lsp.Diagnostic 목록이다.
-	// REQ-LL-001: Aggregator 기반 진단 수집 결과를 저장한다.
-	// GoFeedbackGenerator가 Aggregator를 통해 채운다 (REQ-LL-002).
+	// LSPDiagnostics is the list of lsp.Diagnostic collected via the Aggregator.
+	// REQ-LL-001: stores the result of Aggregator-based diagnostic collection.
+	// Populated by GoFeedbackGenerator through the Aggregator (REQ-LL-002).
 	LSPDiagnostics []lsp.Diagnostic `json:"lsp_diagnostics,omitempty"`
 }
 

--- a/internal/lsp/aggregator/aggregator.go
+++ b/internal/lsp/aggregator/aggregator.go
@@ -30,7 +30,7 @@ const defaultCBTimeout = 30 * time.Second
 // Manager from SPEC-LSP-CORE-002 satisfies this interface because it exports
 // RouteFor(ctx, path) (core.Client, error).
 //
-// @MX:NOTE: [AUTO] Router interface는 Manager와의 결합 없이 테스트에서 fake를 주입하기 위한 DI 경계
+// @MX:NOTE: [AUTO] Router interface is a DI boundary that allows injecting fakes in tests without coupling to Manager
 type Router interface {
 	RouteFor(ctx context.Context, path string) (core.Client, error)
 }
@@ -39,8 +39,8 @@ type Router interface {
 // servers. It integrates a TTL-based cache, singleflight deduplication, per-language
 // circuit breakers, and per-query timeouts for graceful degradation.
 //
-// @MX:ANCHOR: [AUTO] Aggregator — Ralph, QGATE, LOOP, MCP 등 다수 호출자가 공유하는 진단 수집 핵심 타입
-// @MX:REASON: fan_in >= 3 — Ralph 엔진, Quality Gate, LOOP 커맨드, MCP 브리지가 모두 Aggregator를 통해 진단을 획득함
+// @MX:ANCHOR: [AUTO] Aggregator — core diagnostic collection type shared by Ralph, QGATE, LOOP, MCP and other callers
+// @MX:REASON: fan_in >= 3 — Ralph engine, Quality Gate, LOOP command, and MCP bridge all obtain diagnostics through Aggregator
 type Aggregator struct {
 	router       Router
 	cache        *cache.DiagnosticCache
@@ -87,8 +87,8 @@ func WithCircuitBreakerConfig(cfg resilience.CircuitBreakerConfig) Option {
 
 // NewAggregator constructs a new Aggregator backed by the given router.
 //
-// @MX:ANCHOR: [AUTO] NewAggregator — Aggregator 생성의 유일한 진입점
-// @MX:REASON: fan_in >= 3 — Ralph 엔진, Quality Gate, 통합 테스트, MCP 브리지가 모두 NewAggregator를 호출함
+// @MX:ANCHOR: [AUTO] NewAggregator — sole entry point for constructing an Aggregator
+// @MX:REASON: fan_in >= 3 — Ralph engine, Quality Gate, integration tests, and MCP bridge all call NewAggregator
 func NewAggregator(router Router, opts ...Option) *Aggregator {
 	a := &Aggregator{
 		router:       router,
@@ -132,8 +132,8 @@ func (a *Aggregator) Shutdown(_ context.Context) error {
 // A per-query timeout is applied; on deadline the latest cached value is
 // returned if available, otherwise an empty slice is returned (REQ-AGG-008).
 //
-// @MX:ANCHOR: [AUTO] Aggregator.GetDiagnostics — 진단 수집 핵심 경로
-// @MX:REASON: fan_in >= 3 — Ralph 엔진, Quality Gate, LOOP 커맨드, MCP 브리지가 모두 이 메서드를 통해 진단을 요청함
+// @MX:ANCHOR: [AUTO] Aggregator.GetDiagnostics — core path for collecting diagnostics
+// @MX:REASON: fan_in >= 3 — Ralph engine, Quality Gate, LOOP command, and MCP bridge all request diagnostics through this method
 func (a *Aggregator) GetDiagnostics(ctx context.Context, path string) ([]lsp.Diagnostic, error) {
 	uri := path // v1: use path directly as cache key
 
@@ -240,7 +240,7 @@ func (a *Aggregator) getOrCreateBreaker(lang string) *resilience.CircuitBreaker 
 // detectLanguageFromPath maps common file extensions to language identifiers.
 // This avoids coupling Aggregator to Manager's unexported detectLanguage logic.
 //
-// @MX:NOTE: [AUTO] 확장자 기반 언어 감지 헬퍼 — Manager와의 결합 없이 CircuitBreaker 맵 키를 결정함
+// @MX:NOTE: [AUTO] Extension-based language detection helper — determines the CircuitBreaker map key without coupling to Manager
 func detectLanguageFromPath(path string) string {
 	// Find the last dot in the base name only.
 	base := path

--- a/internal/lsp/cache/cache.go
+++ b/internal/lsp/cache/cache.go
@@ -23,8 +23,8 @@ func WithCleanupInterval(d time.Duration) Option {
 // Entries are keyed by file URI and invalidated when the document version changes
 // or the TTL expires.
 //
-// @MX:ANCHOR: [AUTO] DiagnosticCache — Aggregator, 테스트, Manager가 공유하는 진단 캐시 핵심 타입
-// @MX:REASON: fan_in >= 3 — Aggregator.GetDiagnostics, cache 테스트, Manager 연동 코드가 모두 이 타입을 직접 참조함
+// @MX:ANCHOR: [AUTO] DiagnosticCache — core diagnostic cache type shared by Aggregator, tests, and Manager
+// @MX:REASON: fan_in >= 3 — Aggregator.GetDiagnostics, cache tests, and Manager integration code all reference this type directly
 type DiagnosticCache struct {
 	mu      sync.RWMutex
 	entries map[string]*CacheEntry
@@ -54,8 +54,8 @@ func NewDiagnosticCache(ttl time.Duration, opts ...Option) *DiagnosticCache {
 // Set stores diagnostics for the given URI at the given version.
 // The entry expires after the cache's configured TTL.
 //
-// @MX:ANCHOR: [AUTO] DiagnosticCache.Set — 진단 결과 저장 진입점
-// @MX:REASON: fan_in >= 3 — Aggregator, 캐시 테스트, 통합 테스트가 모두 Set을 호출함
+// @MX:ANCHOR: [AUTO] DiagnosticCache.Set — entry point for storing diagnostic results
+// @MX:REASON: fan_in >= 3 — Aggregator, cache tests, and integration tests all call Set
 func (c *DiagnosticCache) Set(uri string, version int64, diagnostics []lsp.Diagnostic) {
 	copied := make([]lsp.Diagnostic, len(diagnostics))
 	copy(copied, diagnostics)
@@ -86,8 +86,8 @@ func (c *DiagnosticCache) Set(uri string, version int64, diagnostics []lsp.Diagn
 // On a cache hit, a copy of the diagnostics slice is returned to prevent
 // callers from mutating the cached data.
 //
-// @MX:ANCHOR: [AUTO] DiagnosticCache.Get — 캐시 조회 핵심 경로
-// @MX:REASON: fan_in >= 3 — Aggregator.GetDiagnostics, 캐시 테스트, Ralph 엔진이 모두 Get을 통해 결과를 조회함
+// @MX:ANCHOR: [AUTO] DiagnosticCache.Get — core path for cache lookup
+// @MX:REASON: fan_in >= 3 — Aggregator.GetDiagnostics, cache tests, and Ralph engine all retrieve results through Get
 func (c *DiagnosticCache) Get(uri string, version int64) ([]lsp.Diagnostic, bool) {
 	c.mu.RLock()
 	entry, ok := c.entries[uri]
@@ -138,8 +138,8 @@ func (c *DiagnosticCache) Invalidate(uri string) {
 // The goroutine runs until the provided context is cancelled or Stop is called.
 // Calling Start more than once is idempotent.
 //
-// @MX:WARN: [AUTO] Start 고루틴 — cleanupInterval마다 만료 항목을 삭제하는 장기 실행 백그라운드 고루틴
-// @MX:REASON: ctx 취소 없이는 고루틴 누수가 발생함. Start/Stop 쌍 또는 외부 ctx 취소를 반드시 보장해야 함.
+// @MX:WARN: [AUTO] Start goroutine — long-running background goroutine that evicts expired entries every cleanupInterval
+// @MX:REASON: goroutine leak occurs without ctx cancellation. A Start/Stop pair or external ctx cancellation must be guaranteed.
 func (c *DiagnosticCache) Start(ctx context.Context) {
 	c.mu.Lock()
 	if c.cancel != nil {

--- a/internal/lsp/cache/types.go
+++ b/internal/lsp/cache/types.go
@@ -8,8 +8,8 @@ import (
 
 // CacheEntry holds a snapshot of diagnostics for a single file at a specific version.
 //
-// @MX:ANCHOR: [AUTO] CacheEntry — TTL 캐시 항목 타입, DiagnosticCache, Aggregator, 테스트 등 다수 호출자가 직접 참조
-// @MX:REASON: fan_in >= 3 — DiagnosticCache.Set/Get, Aggregator.GetDiagnostics, cache 테스트가 모두 이 타입을 사용함
+// @MX:ANCHOR: [AUTO] CacheEntry — TTL cache entry type referenced directly by DiagnosticCache, Aggregator, tests, and other callers
+// @MX:REASON: fan_in >= 3 — DiagnosticCache.Set/Get, Aggregator.GetDiagnostics, and cache tests all use this type
 type CacheEntry struct {
 	// Diagnostics is the list of diagnostics captured at this version.
 	Diagnostics []lsp.Diagnostic

--- a/internal/lsp/config/loader.go
+++ b/internal/lsp/config/loader.go
@@ -42,7 +42,7 @@ func Load(path string) (*ServersConfig, error) {
 		servers = make(map[string]ServerConfig)
 	}
 
-	// 각 ServerConfig에 Language 필드를 키에서 역주입 (YAML 키 → 구조체)
+	// Back-inject the Language field into each ServerConfig from its map key (YAML key → struct).
 	for lang, sc := range servers {
 		sc.Language = lang
 		servers[lang] = sc

--- a/internal/lsp/config/types.go
+++ b/internal/lsp/config/types.go
@@ -53,8 +53,8 @@ type ServerConfig struct {
 
 // ServersConfig is the root deserialization type for the lsp.servers section.
 // Servers maps language name → ServerConfig.
-// @MX:ANCHOR: [AUTO] ServersConfig 최상위 설정 타입 — Load() 반환값이자 Manager 초기화 인자
-// @MX:REASON: fan_in >= 3 — config.Load 호출자들(Manager, CLI, 테스트)이 이 타입을 모두 참조
+// @MX:ANCHOR: [AUTO] ServersConfig — top-level config type returned by Load() and used as a Manager initialization argument
+// @MX:REASON: fan_in >= 3 — callers of config.Load (Manager, CLI, tests) all reference this type
 type ServersConfig struct {
 	// ClientImpl selects which LSP client implementation handles language
 	// server communication (SPEC-LSP-CORE-002 AC10, REQ-LC-010).

--- a/internal/lsp/config/types_test.go
+++ b/internal/lsp/config/types_test.go
@@ -11,7 +11,7 @@ func TestServerConfig_Defaults(t *testing.T) {
 	t.Parallel()
 
 	var sc config.ServerConfig
-	// 기본값 검증: 비어 있는 ServerConfig은 zero-value여야 함
+	// Verify default: empty ServerConfig must be zero-value
 	if sc.Language != "" {
 		t.Errorf("default Language = %q, want empty", sc.Language)
 	}

--- a/internal/lsp/core/capabilities.go
+++ b/internal/lsp/core/capabilities.go
@@ -58,8 +58,8 @@ func DefaultClientCapabilities() ClientCapabilities {
 	}
 }
 
-// serverCapabilitiesRaw는 initialize 응답에서 파싱하는 내부 타입.
-// 최소한의 필드만 파싱하며 알 수 없는 필드는 무시합니다.
+// serverCapabilitiesRaw is the internal type parsed from the initialize response.
+// Only the minimum required fields are parsed; unknown fields are ignored.
 type serverCapabilitiesRaw struct {
 	TextDocumentSync   any  `json:"textDocumentSync"`
 	ReferencesProvider bool `json:"referencesProvider"`
@@ -114,7 +114,7 @@ func parseTextDocumentSync(v any) int {
 	if v == nil {
 		return 0
 	}
-	// JSON 숫자는 float64로 디코딩됨
+	// JSON numbers are decoded as float64.
 	switch vt := v.(type) {
 	case float64:
 		return int(vt)

--- a/internal/lsp/core/client.go
+++ b/internal/lsp/core/client.go
@@ -17,12 +17,12 @@ import (
 	"github.com/modu-ai/moai-adk/internal/lsp/transport"
 )
 
-// launchFunc은 subprocess.Launcher.Launch와 동일한 시그니처의 함수형 타입.
-// 테스트에서 의존성 주입을 위해 사용합니다.
+// launchFunc is a function type with the same signature as subprocess.Launcher.Launch.
+// Used for dependency injection in tests.
 type launchFunc func(ctx context.Context, cfg config.ServerConfig) (*subprocess.LaunchResult, error)
 
-// transportFactory은 io.ReadWriteCloser를 받아 Transport를 생성하는 함수형 타입.
-// 테스트에서 fakeTransport를 주입하기 위해 사용합니다.
+// transportFactory is a function type that creates a Transport from an io.ReadWriteCloser.
+// Used to inject a fakeTransport in tests.
 type transportFactory func(stream io.ReadWriteCloser) transport.Transport
 
 // supervisorIface abstracts subprocess.Supervisor for testability.
@@ -97,11 +97,11 @@ type client struct {
 	logger          *slog.Logger
 	serverCaps      ServerCapabilities
 
-	// docs는 열린 문서 캐시입니다. T-011 이후 사용됩니다.
+	// docs is the open document cache. Used from T-011 onwards.
 	docs *documentCache
 
-	// diagnostics는 서버가 push한 textDocument/publishDiagnostics 결과를 저장합니다.
-	// T-013 이후 사용됩니다.
+	// diagnostics stores textDocument/publishDiagnostics results pushed by the server.
+	// Used from T-013 onwards.
 	diagnostics   map[string][]lsp.Diagnostic
 	diagnosticsMu sync.RWMutex
 }
@@ -172,11 +172,11 @@ func NewClient(cfg config.ServerConfig, opts ...Option) *client {
 	}
 	c.state = NewStateMachine(c.logger)
 
-	// 기본 launcher: 실제 subprocess.Launcher 사용
+	// Default launcher: use real subprocess.Launcher.
 	defaultLauncher := subprocess.NewLauncher()
 	c.launcher = defaultLauncher.Launch
 
-	// 기본 transport factory: powernap Transport
+	// Default transport factory: powernap Transport.
 	c.trFactory = transport.NewPowernapTransport
 
 	for _, opt := range opts {
@@ -192,10 +192,10 @@ func NewClient(cfg config.ServerConfig, opts ...Option) *client {
 //   - on ErrBinaryNotFound: spawning → shutdown
 //   - on initialize failure: initializing → degraded
 func (c *client) Start(ctx context.Context) error {
-	// subprocess 실행
+	// Spawn the subprocess.
 	result, err := c.launcher(ctx, c.cfg)
 	if err != nil {
-		// ErrBinaryNotFound: warn_and_skip 패턴 (REQ-LC-004)
+		// ErrBinaryNotFound: warn_and_skip pattern (REQ-LC-004).
 		if errors.Is(err, subprocess.ErrBinaryNotFound) {
 			_ = c.state.Transition(StateShutdown)
 			return fmt.Errorf("lsp client start (lang=%s): %w", c.cfg.Language, err)
@@ -204,16 +204,16 @@ func (c *client) Start(ctx context.Context) error {
 		return fmt.Errorf("lsp client start (lang=%s): launch: %w", c.cfg.Language, err)
 	}
 
-	// Supervisor 생성 (Cmd가 nil이면 skip — 테스트 전용 경로)
+	// Create Supervisor (skip when Cmd is nil — test-only path).
 	if result.Cmd != nil {
 		c.supervisor = subprocess.NewSupervisor(result)
 	}
 
-	// stderr drain 고루틴: subprocess stderr 버퍼 deadlock 방지 (REQ-UTIL-003-001, REQ-UTIL-003-002).
-	// result.Stderr가 nil인 경우(테스트 전용 LaunchResult)는 고루틴을 생성하지 않는다.
-	// Supervisor가 subprocess를 종료하면 stderr 파이프가 닫히고 io.Copy가 자연스럽게 반환된다 (C-06).
-	// @MX:WARN: [AUTO] subprocess stderr 드레인 goroutine — context.Context 없이 subprocess stderr 파이프 수명에 바인딩
-	// @MX:REASON: stderr 버퍼 deadlock 방지 목적. Supervisor가 subprocess 종료 시 stderr를 닫으면 io.Copy가 자연 반환되어 goroutine leak 없음 (C-06 보장, REQ-UTIL-003-010 테스트로 128 KiB 버스트 검증).
+	// stderr drain goroutine: prevents subprocess stderr buffer deadlock (REQ-UTIL-003-001, REQ-UTIL-003-002).
+	// No goroutine is started when result.Stderr is nil (test-only LaunchResult).
+	// When Supervisor terminates the subprocess the stderr pipe is closed and io.Copy returns naturally (C-06).
+	// @MX:WARN: [AUTO] subprocess stderr drain goroutine — bound to the subprocess stderr pipe lifetime without a context.Context
+	// @MX:REASON: Purpose is to prevent stderr buffer deadlock. When Supervisor closes stderr on subprocess exit, io.Copy returns naturally with no goroutine leak (C-06 guarantee; validated by REQ-UTIL-003-010 test with 128 KiB burst).
 	if result.Stderr != nil {
 		go func() {
 			io.Copy(io.Discard, result.Stderr) //nolint:errcheck
@@ -221,7 +221,7 @@ func (c *client) Start(ctx context.Context) error {
 		}()
 	}
 
-	// subprocess stdio로 Transport 생성
+	// Create Transport from subprocess stdio.
 	stream := &readWriteCloser{
 		r: result.Stdout,
 		w: result.Stdin,
@@ -229,20 +229,20 @@ func (c *client) Start(ctx context.Context) error {
 	}
 	c.tr = c.trFactory(stream)
 
-	// initializing 상태 전환
+	// Transition to the initializing state.
 	if err := c.state.Transition(StateInitializing); err != nil {
 		c.cleanupTransport()
 		return fmt.Errorf("lsp client start: state transition: %w", err)
 	}
 
-	// LSP initialize 요청 전송
+	// Send the LSP initialize request.
 	if err := c.initialize(ctx); err != nil {
 		_ = c.state.Transition(StateDegraded)
 		return fmt.Errorf("lsp client initialize (lang=%s): %w", c.cfg.Language, err)
 	}
 
-	// publishDiagnostics 핸들러 등록: 서버가 push한 진단 결과를 diagnostics 캐시에 저장합니다.
-	// @MX:NOTE: [AUTO] NotificationRouter를 통해 비동기 publishDiagnostics 알림을 진단 캐시로 라우팅
+	// Register publishDiagnostics handler: stores server-pushed diagnostics in the diagnostics cache.
+	// @MX:NOTE: [AUTO] Routes async publishDiagnostics notifications to the diagnostic cache via NotificationRouter
 	_ = c.router.RegisterPublishDiagnostics(func(uri string, diags []lsp.Diagnostic) error {
 		c.diagnosticsMu.Lock()
 		c.diagnostics[uri] = diags
@@ -251,7 +251,7 @@ func (c *client) Start(ctx context.Context) error {
 	})
 	c.router.Attach(c.tr)
 
-	// ready 상태 전환
+	// Transition to the ready state.
 	if err := c.state.Transition(StateReady); err != nil {
 		return fmt.Errorf("lsp client start: state transition to ready: %w", err)
 	}
@@ -263,8 +263,8 @@ func (c *client) Start(ctx context.Context) error {
 func (c *client) initialize(ctx context.Context) error {
 	caps := DefaultClientCapabilities()
 
-	// rootUri + workspaceFolders: cfg.RootDir이 설정되어 있으면 file:// URI로 변환.
-	// gopls 등 서버는 workspaceFolders를 더 신뢰성 있게 처리하므로 두 필드 모두 전달.
+	// rootUri + workspaceFolders: convert to file:// URI when cfg.RootDir is set.
+	// Servers such as gopls handle workspaceFolders more reliably, so both fields are provided.
 	var rootURI any
 	var workspaceFolders any
 	if c.cfg.RootDir != "" {
@@ -290,8 +290,8 @@ func (c *client) initialize(ctx context.Context) error {
 		return fmt.Errorf("initialize request: %w", err)
 	}
 
-	// LSP 프로토콜: initialize 응답 수신 후 반드시 initialized 알림 전송 (fire-and-forget)
-	// 이 알림 없이는 gopls 등 서버가 workspace를 활성화하지 않음
+	// LSP protocol: the initialized notification MUST be sent after receiving the initialize response (fire-and-forget).
+	// Without this notification, servers such as gopls will not activate the workspace.
 	if notifyErr := c.tr.Notify(ctx, "initialized", map[string]any{}); notifyErr != nil {
 		c.logger.Warn("lsp: initialized notification failed",
 			slog.String("language", c.cfg.Language),
@@ -299,7 +299,7 @@ func (c *client) initialize(ctx context.Context) error {
 		)
 	}
 
-	// サーバーケイパビリティ解析
+	// Parse server capabilities.
 	serverCaps, err := ParseServerCapabilities(result.Capabilities)
 	if err != nil {
 		// Parse failure is non-fatal — degrade gracefully
@@ -318,13 +318,13 @@ func (c *client) initialize(ctx context.Context) error {
 //
 // State transitions: any → shutdown
 func (c *client) Shutdown(ctx context.Context) error {
-	// transport이 없으면 (Start 전 호출) 즉시 shutdown 전환
+	// No transport (called before Start): transition to shutdown immediately.
 	if c.tr == nil {
 		_ = c.state.Transition(StateShutdown)
 		return nil
 	}
 
-	// LSP shutdown 요청 (best-effort: 에러는 로그만)
+	// LSP shutdown request (best-effort: errors are only logged).
 	shutCtx, cancel := context.WithTimeout(ctx, c.shutdownTimeout)
 	defer cancel()
 
@@ -335,10 +335,10 @@ func (c *client) Shutdown(ctx context.Context) error {
 		)
 	}
 
-	// exit 알림 (fire-and-forget)
+	// exit notification (fire-and-forget).
 	_ = c.tr.Notify(ctx, "exit", nil)
 
-	// Supervisor를 통해 프로세스 종료
+	// Terminate the process via Supervisor.
 	if c.supervisor != nil {
 		if err := c.supervisor.Signal(syscall.SIGTERM); err != nil {
 			c.logger.Warn("lsp: SIGTERM failed, sending SIGKILL",
@@ -347,7 +347,7 @@ func (c *client) Shutdown(ctx context.Context) error {
 			)
 			_ = c.supervisor.Kill()
 		} else {
-			// shutdownTimeout 내에 종료되지 않으면 SIGKILL
+			// Send SIGKILL if the process does not exit within shutdownTimeout.
 			killTimer := time.NewTimer(c.shutdownTimeout)
 			defer killTimer.Stop()
 
@@ -357,7 +357,7 @@ func (c *client) Shutdown(ctx context.Context) error {
 			exitCh := c.supervisor.Watch(watchCtx)
 			select {
 			case <-exitCh:
-				// 정상 종료
+				// Clean exit.
 			case <-killTimer.C:
 				_ = c.supervisor.Kill()
 			}

--- a/internal/lsp/core/client_stderr_drain_test.go
+++ b/internal/lsp/core/client_stderr_drain_test.go
@@ -12,10 +12,10 @@ import (
 	"github.com/modu-ai/moai-adk/internal/lsp/transport"
 )
 
-// ─── 테스트 더블 ─────────────────────────────────────────────────────────────
+// ─── Test doubles ─────────────────────────────────────────────────────────────
 
-// stderrSignalingReader는 첫 번째 Read 호출 시 readCh에 신호를 보내는 io.ReadCloser.
-// drain 고루틴이 실제로 stderr를 읽는지 관찰하기 위해 사용한다.
+// stderrSignalingReader is an io.ReadCloser that sends a signal on readCh on the first Read call.
+// Used to observe whether the drain goroutine actually reads from stderr.
 type stderrSignalingReader struct {
 	inner  io.ReadCloser
 	readCh chan struct{}
@@ -39,7 +39,7 @@ func (s *stderrSignalingReader) Read(p []byte) (int, error) {
 
 func (s *stderrSignalingReader) Close() error { return s.inner.Close() }
 
-// nilStderrLauncher는 Stderr가 nil인 LaunchResult를 반환한다 (AC-UTIL-003-002).
+// nilStderrLauncher returns a LaunchResult with Stderr set to nil (AC-UTIL-003-002).
 type nilStderrLauncher struct{}
 
 func (n *nilStderrLauncher) Launch(_ context.Context, _ config.ServerConfig) (*subprocess.LaunchResult, error) {
@@ -49,14 +49,14 @@ func (n *nilStderrLauncher) Launch(_ context.Context, _ config.ServerConfig) (*s
 		// Cmd is nil — Supervisor creation is skipped
 		Stdin:  w1,
 		Stdout: r2,
-		Stderr: nil, // 명시적 nil
+		Stderr: nil, // explicitly nil
 	}, nil
 }
 
-// largeStderrLauncher는 128 KiB + 1 byte를 stderr에 쓰는 고루틴이 내장된 LaunchResult를 반환한다.
-// drain 고루틴 없이는 쓰기 고루틴이 영구 차단되어 deadlock을 유발한다 (AC-UTIL-003-010).
+// largeStderrLauncher returns a LaunchResult with a goroutine that writes 128 KiB + 1 byte to stderr.
+// Without a drain goroutine, the write goroutine blocks permanently causing a deadlock (AC-UTIL-003-010).
 type largeStderrLauncher struct {
-	writeDone chan struct{} // stderr 쓰기가 완료되면 close됨
+	writeDone chan struct{} // closed when the stderr write completes
 }
 
 func newLargeStderrLauncher() *largeStderrLauncher {
@@ -68,14 +68,14 @@ func (l *largeStderrLauncher) Launch(_ context.Context, _ config.ServerConfig) (
 	r2, _ := io.Pipe()
 	stderrR, stderrW := io.Pipe()
 
-	// 128 KiB + 1 byte를 stderr에 쓰는 "subprocess" 시뮬레이션.
-	// io.Pipe는 버퍼가 없으므로 읽는 쪽이 없으면 첫 번째 쓰기에서 차단된다.
-	// drain 고루틴이 있으면 읽어서 쓰기를 완료시키고, writeDone을 닫는다.
+	// Simulate a "subprocess" writing 128 KiB + 1 byte to stderr.
+	// io.Pipe has no buffer, so the first write blocks if nobody reads.
+	// When a drain goroutine is present, it reads and allows the write to complete, then closes writeDone.
 	go func() {
 		defer close(l.writeDone)
 		defer func() { _ = stderrW.Close() }()
 		data := make([]byte, 128*1024+1)
-		// 쓰기 실패는 무시 (파이프가 닫힌 경우)
+		// Ignore write errors (pipe may be closed)
 		_, _ = stderrW.Write(data)
 	}()
 
@@ -87,10 +87,10 @@ func (l *largeStderrLauncher) Launch(_ context.Context, _ config.ServerConfig) (
 	}, nil
 }
 
-// ─── 테스트 ─────────────────────────────────────────────────────────────────
+// ─── Tests ─────────────────────────────────────────────────────────────────
 
-// TestStderrDrain_GoroutineObserved는 result.Stderr가 non-nil일 때
-// drain 고루틴이 실제로 스테이지 stderr를 읽는지 확인한다 (AC-UTIL-003-001).
+// TestStderrDrain_GoroutineObserved verifies that the drain goroutine actually reads
+// from stderr when result.Stderr is non-nil (AC-UTIL-003-001).
 func TestStderrDrain_GoroutineObserved(t *testing.T) {
 	t.Parallel()
 
@@ -120,12 +120,12 @@ func TestStderrDrain_GoroutineObserved(t *testing.T) {
 		t.Fatalf("Start() error = %v, want nil", err)
 	}
 
-	// drain 고루틴이 stderr를 읽을 때까지 최대 2초 대기
-	// goroutine 수 증가 OR 신호 채널을 통해 확인
+	// Wait up to 2 seconds for the drain goroutine to read from stderr.
+	// Verify via goroutine count increase OR signal channel.
 	goroutinesAfter := runtime.NumGoroutine()
 
-	// 고루틴 수가 증가했거나 신호 채널에 신호가 왔음을 확인하기 위해
-	// stderr에 소량의 데이터를 쓰고 readCh 신호를 기다린다.
+	// Write a small amount of data to stderr and wait for the readCh signal
+	// to confirm that the goroutine count increased or the signal channel fired.
 	go func() {
 		defer func() { _ = stderrW.Close() }()
 		stderrW.Write([]byte("drain me")) //nolint:errcheck
@@ -133,14 +133,14 @@ func TestStderrDrain_GoroutineObserved(t *testing.T) {
 
 	select {
 	case <-sigReader.readCh:
-		// drain 고루틴이 실제로 읽었다 — 통과
+		// Drain goroutine actually read — pass
 	case <-time.After(2 * time.Second):
 		t.Errorf("drain goroutine did not read from stderr within 2s (goroutines: %d→%d)",
 			goroutinesBefore, goroutinesAfter)
 	}
 }
 
-// TestStderrDrain_NilGuard는 result.Stderr가 nil일 때 Start가 패닉 없이 완료되는지 확인한다 (AC-UTIL-003-002).
+// TestStderrDrain_NilGuard verifies that Start completes without panic when result.Stderr is nil (AC-UTIL-003-002).
 func TestStderrDrain_NilGuard(t *testing.T) {
 	t.Parallel()
 
@@ -155,15 +155,15 @@ func TestStderrDrain_NilGuard(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	// nil Stderr path — panic이 없어야 한다
+	// nil Stderr path — must not panic
 	err := c.Start(ctx)
 	if err != nil {
 		t.Fatalf("Start() with nil Stderr error = %v, want nil", err)
 	}
 }
 
-// TestStderrDrain_DeadlockPrevention은 subprocess가 128 KiB를 stderr에 쓸 때
-// drain 고루틴이 있으면 5초 내에 완료됨을 확인한다 (AC-UTIL-003-010).
+// TestStderrDrain_DeadlockPrevention verifies that when a subprocess writes 128 KiB to stderr,
+// the drain goroutine allows completion within 5 seconds (AC-UTIL-003-010).
 func TestStderrDrain_DeadlockPrevention(t *testing.T) {
 	t.Parallel()
 
@@ -180,18 +180,18 @@ func TestStderrDrain_DeadlockPrevention(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	// Start는 drain 고루틴을 시작한다. drain 고루틴이 없으면 largeStderrLauncher의
-	// 쓰기 고루틴이 차단되어 writeDone이 닫히지 않는다.
+	// Start launches the drain goroutine. Without it, the largeStderrLauncher's
+	// write goroutine blocks and writeDone is never closed.
 	if err := c.Start(ctx); err != nil {
-		// Start 에러는 허용 (mock 설정에 따라 다름). deadlock이 없는지가 핵심.
+		// Non-nil from Start is allowed (depends on mock setup). The key is: no deadlock.
 		t.Logf("Start() returned non-nil (expected for mock setup): %v", err)
 	}
 
-	// 128 KiB 쓰기 고루틴이 5초 내에 완료되어야 한다.
-	// drain 고루틴 없이는 io.Pipe 첫 쓰기에서 영구 차단됨.
+	// The 128 KiB write goroutine must complete within 5 seconds.
+	// Without a drain goroutine, the first io.Pipe write blocks permanently.
 	select {
 	case <-ll.writeDone:
-		// 정상: drain 고루틴이 stderr를 읽어서 쓰기 고루틴이 완료됨
+		// Normal: drain goroutine read from stderr, allowing the write goroutine to finish
 	case <-ctx.Done():
 		t.Fatal("deadlock: 128 KiB stderr write did not complete within 5s — drain goroutine missing?")
 	}

--- a/internal/lsp/core/client_test.go
+++ b/internal/lsp/core/client_test.go
@@ -21,7 +21,7 @@ import (
 // Test doubles
 // ---------------------------------------------------------------------------
 
-// fakeSupervisor는 실제 subprocess 없이 Shutdown 경로를 테스트하는 supervisor 더블.
+// fakeSupervisor is a supervisor test double that tests the Shutdown path without a real subprocess.
 type fakeSupervisor struct {
 	mu          sync.Mutex
 	signalLog   []os.Signal
@@ -69,8 +69,8 @@ func (f *fakeSupervisor) exitNow() {
 	f.exitCh <- subprocess.ExitEvent{ExitCode: 0}
 }
 
-// fakeLauncher는 실제 서브프로세스를 생성하지 않는 테스트 전용 Launcher.
-// 기본적으로 성공을 반환하며, failWith가 설정된 경우 해당 에러를 반환합니다.
+// fakeLauncher is a test-only Launcher that does not spawn a real subprocess.
+// By default it returns success; if failWith is set, it returns that error instead.
 type fakeLauncher struct {
 	mu       sync.Mutex
 	called   int
@@ -84,7 +84,7 @@ func (f *fakeLauncher) Launch(ctx context.Context, cfg config.ServerConfig) (*su
 	if f.failWith != nil {
 		return nil, f.failWith
 	}
-	// 실제 subprocess 없이 가짜 파이프 반환 (Cmd is nil — Supervisor must handle nil gracefully)
+	// return fake pipes without a real subprocess (Cmd is nil — Supervisor must handle nil gracefully)
 	_, w1 := io.Pipe()
 	r2, _ := io.Pipe()
 	r3, _ := io.Pipe()
@@ -95,7 +95,7 @@ func (f *fakeLauncher) Launch(ctx context.Context, cfg config.ServerConfig) (*su
 	}, nil
 }
 
-// fakeTransport는 실제 JSON-RPC 통신 없이 동작하는 테스트 전용 Transport.
+// fakeTransport is a test-only Transport that operates without real JSON-RPC communication.
 type fakeTransport struct {
 	mu            sync.Mutex
 	callLog       []string
@@ -115,7 +115,7 @@ func newFakeTransport() *fakeTransport {
 	}
 }
 
-// setCallResponse는 특정 method에 대한 응답을 설정합니다.
+// setCallResponse sets the response for a specific method.
 func (f *fakeTransport) setCallResponse(method string, result json.RawMessage, err error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -136,7 +136,7 @@ func (f *fakeTransport) Call(ctx context.Context, method string, params, result 
 		}
 		return nil
 	}
-	// 기본: 성공, result 수정 없음
+	// default: success, result unchanged
 	return nil
 }
 
@@ -180,7 +180,7 @@ func (f *fakeTransport) notifyCount(method string) int {
 	return n
 }
 
-// fakeTransportFactory는 fakeLauncher 이후에 fakeTransport를 반환하는 팩토리.
+// fakeTransportFactory is a factory that returns a fakeTransport after fakeLauncher.
 type fakeTransportFactory struct {
 	tr *fakeTransport
 }
@@ -234,7 +234,7 @@ func TestClient_Start_Success(t *testing.T) {
 	fl := &fakeLauncher{}
 	ft := newFakeTransport()
 
-	// initialize 응답 설정: capabilities 포함
+	// set initialize response: includes capabilities
 	ft.setCallResponse("initialize", json.RawMessage(`{"capabilities":{}}`), nil)
 
 	c := NewClient(cfg,
@@ -377,7 +377,7 @@ func TestClient_Sprint4Methods(t *testing.T) {
 		t.Fatalf("Start: %v", err)
 	}
 
-	// OpenFile은 Sprint 4에서 구현됨 — 에러 없이 성공해야 함
+	// OpenFile is implemented in Sprint 4 — must succeed without error
 	t.Run("OpenFile_Succeeds", func(t *testing.T) {
 		err := c.OpenFile(ctx, "/tmp/foo.go", "package main")
 		if err != nil {
@@ -385,9 +385,9 @@ func TestClient_Sprint4Methods(t *testing.T) {
 		}
 	})
 
-	// GetDiagnostics는 Sprint 4에서 구현됨 — 열린 파일이면 빈 슬라이스 반환
+	// GetDiagnostics is implemented in Sprint 4 — must return empty slice for an open file
 	t.Run("GetDiagnostics_OpenedFile", func(t *testing.T) {
-		// OpenFile로 먼저 파일을 열어야 함
+		// file must be opened with OpenFile first
 		_ = c.OpenFile(ctx, "/tmp/diag.go", "package main")
 		diags, err := c.GetDiagnostics(ctx, "/tmp/diag.go")
 		if err != nil {
@@ -398,7 +398,7 @@ func TestClient_Sprint4Methods(t *testing.T) {
 		}
 	})
 
-	// GetDiagnostics는 열리지 않은 파일에 대해 ErrFileNotOpen 반환
+	// GetDiagnostics returns ErrFileNotOpen for a file that has not been opened
 	t.Run("GetDiagnostics_UnopenedFile", func(t *testing.T) {
 		_, err := c.GetDiagnostics(ctx, "/tmp/notopen.go")
 		if !errors.Is(err, ErrFileNotOpen) {
@@ -406,7 +406,7 @@ func TestClient_Sprint4Methods(t *testing.T) {
 		}
 	})
 
-	// FindReferences는 Sprint 4에서 구현됨 — 서버 capabilities가 없으면 ErrCapabilityUnsupported 반환
+	// FindReferences is implemented in Sprint 4 — must return ErrCapabilityUnsupported when server lacks capability
 	t.Run("FindReferences_NoCapability", func(t *testing.T) {
 		_, err := c.FindReferences(ctx, "/tmp/foo.go", lsp.Position{Line: 0, Character: 0})
 		if !errors.Is(err, ErrCapabilityUnsupported) {
@@ -414,7 +414,7 @@ func TestClient_Sprint4Methods(t *testing.T) {
 		}
 	})
 
-	// GotoDefinition은 Sprint 4에서 구현됨 — 서버 capabilities가 없으면 ErrCapabilityUnsupported 반환
+	// GotoDefinition is implemented in Sprint 4 — must return ErrCapabilityUnsupported when server lacks capability
 	t.Run("GotoDefinition_NoCapability", func(t *testing.T) {
 		_, err := c.GotoDefinition(ctx, "/tmp/foo.go", lsp.Position{Line: 0, Character: 0})
 		if !errors.Is(err, ErrCapabilityUnsupported) {
@@ -455,7 +455,7 @@ func TestClient_Start_TransportClosedOnFailure(t *testing.T) {
 	if err == nil {
 		t.Fatal("Start: expected error on initialize failure, got nil")
 	}
-	// 초기화 실패 시 상태가 degraded 또는 shutdown으로 전환되어야 함
+	// state must transition to degraded or shutdown on initialization failure
 	state := c.State()
 	if state != StateDegraded && state != StateShutdown {
 		t.Errorf("after initialize failure: expected degraded or shutdown, got %q", state)
@@ -508,7 +508,7 @@ func TestWithLogger(t *testing.T) {
 		t.Fatalf("Start: %v", err)
 	}
 
-	// Logger이 적용되었으면 state 전환 시 로그가 기록됨
+	// when WithLogger is applied, log entries must be written on state transitions
 	logged := buf.String()
 	if logged == "" {
 		t.Error("expected log output from WithLogger, got empty")
@@ -525,7 +525,7 @@ func TestReadWriteCloser_Operations(t *testing.T) {
 		closers: []io.Closer{pr, pw},
 	}
 
-	// 쓰기 후 읽기
+	// write then read
 	payload := []byte("hello")
 	go func() {
 		_, _ = rwc.Write(payload)
@@ -540,9 +540,9 @@ func TestReadWriteCloser_Operations(t *testing.T) {
 		t.Errorf("expected %q, got %q", "hello", string(buf[:n]))
 	}
 
-	// Close: 양쪽 파이프 모두 닫힘
+	// Close: both pipes closed
 	if err := rwc.Close(); err != nil {
-		// io.Pipe Close는 이미 닫힌 파이프에 에러를 반환할 수 있음 — 무시
+		// io.Pipe Close may return error for already-closed pipes — ignore
 		_ = err
 	}
 }
@@ -568,7 +568,7 @@ func TestClient_Shutdown_WithSupervisor_GracefulExit(t *testing.T) {
 		t.Fatalf("Start: %v", err)
 	}
 
-	// Supervisor가 즉시 종료하는 시뮬레이션
+	// simulate Supervisor exiting immediately
 	go sv.exitNow()
 
 	if err := c.Shutdown(ctx); err != nil {
@@ -641,7 +641,7 @@ func TestClient_Shutdown_WithCapableServer(t *testing.T) {
 		t.Fatalf("Start: %v", err)
 	}
 
-	// 서버 캐퍼빌리티가 파싱되었는지 확인
+	// verify that server capabilities were parsed
 	if !c.serverCaps.ReferencesProvider {
 		t.Error("expected ReferencesProvider to be true after Start")
 	}

--- a/internal/lsp/core/document.go
+++ b/internal/lsp/core/document.go
@@ -11,7 +11,7 @@ import (
 	"github.com/modu-ai/moai-adk/internal/lsp/transport"
 )
 
-// LSP 문서 동기화 메서드 상수 (하드코딩 방지).
+// LSP document synchronization method constants (prevent hard-coding).
 const (
 	methodDidOpen   = "textDocument/didOpen"
 	methodDidChange = "textDocument/didChange"
@@ -19,7 +19,7 @@ const (
 	methodDidSave   = "textDocument/didSave"
 )
 
-// docEntry는 documentCache의 개별 파일 상태를 나타냅니다.
+// docEntry represents the state of an individual file in the documentCache.
 type docEntry struct {
 	languageID   string
 	version      int32
@@ -27,35 +27,36 @@ type docEntry struct {
 	lastActivity time.Time
 }
 
-// documentCache는 언어 서버에 열린 파일 상태를 추적하여 중복 didOpen 전송을 방지합니다 (REQ-LC-006).
+// documentCache tracks the state of files open in the language server to prevent
+// duplicate didOpen sends (REQ-LC-006).
 //
-// @MX:ANCHOR: [AUTO] documentCache — 모든 문서 동기화 작업의 중앙 상태 저장소
-// @MX:REASON: fan_in >= 3 — openOrChange, reapIdle, didSave, OpenFile, DidSave, Manager 모두 이 구조체를 통해 문서 상태를 관리함
+// @MX:ANCHOR: [AUTO] documentCache — central state store for all document synchronization operations
+// @MX:REASON: fan_in >= 3 — openOrChange, reapIdle, didSave, OpenFile, DidSave, and Manager all manage document state through this struct
 type documentCache struct {
 	mu      sync.RWMutex
 	entries map[string]docEntry
 }
 
-// newDocumentCache는 비어 있는 documentCache를 생성합니다.
+// newDocumentCache creates an empty documentCache.
 func newDocumentCache() *documentCache {
 	return &documentCache{
 		entries: make(map[string]docEntry),
 	}
 }
 
-// openOrChange는 URI에 따라 textDocument/didOpen 또는 textDocument/didChange를 전송합니다.
+// openOrChange sends textDocument/didOpen or textDocument/didChange depending on the URI's state.
 //
-// 규칙:
-//   - 미등록 URI: didOpen (version=1) 전송 후 캐시에 추가
-//   - 등록된 URI + 동일 콘텐츠: lastActivity만 업데이트 (no-op)
-//   - 등록된 URI + 변경된 콘텐츠: didChange (version 증가, 전체 문서 동기화) 전송 후 캐시 업데이트
+// Rules:
+//   - Unregistered URI: send didOpen (version=1) and add to cache.
+//   - Registered URI + same content: update lastActivity only (no-op).
+//   - Registered URI + changed content: send didChange (increment version, full document sync) and update cache.
 func (c *documentCache) openOrChange(ctx context.Context, tr transport.Transport, uri, languageID, content string) error {
 	c.mu.Lock()
 
 	entry, exists := c.entries[uri]
 
 	if !exists {
-		// 신규 파일: didOpen 전송
+		// New file: send didOpen.
 		newEntry := docEntry{
 			languageID:   languageID,
 			version:      1,
@@ -80,14 +81,14 @@ func (c *documentCache) openOrChange(ctx context.Context, tr transport.Transport
 	}
 
 	if entry.content == content {
-		// 동일 콘텐츠: lastActivity만 업데이트 (no-op)
+		// Same content: update lastActivity only (no-op).
 		entry.lastActivity = time.Now()
 		c.entries[uri] = entry
 		c.mu.Unlock()
 		return nil
 	}
 
-	// 콘텐츠 변경: didChange 전송
+	// Content changed: send didChange.
 	newVersion := entry.version + 1
 	entry.version = newVersion
 	entry.content = content
@@ -110,8 +111,8 @@ func (c *documentCache) openOrChange(ctx context.Context, tr transport.Transport
 	return nil
 }
 
-// touch는 URI의 lastActivity 타임스탬프를 현재 시각으로 업데이트합니다.
-// URI가 캐시에 없으면 no-op입니다.
+// touch updates the lastActivity timestamp for the URI to the current time.
+// If the URI is not in the cache, this is a no-op.
 func (c *documentCache) touch(uri string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -121,7 +122,7 @@ func (c *documentCache) touch(uri string) {
 	}
 }
 
-// snapshot은 현재 캐시의 복사본을 반환합니다. idle reaper 등에서 사용합니다.
+// snapshot returns a copy of the current cache. Used by the idle reaper and similar consumers.
 func (c *documentCache) snapshot() map[string]docEntry {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -132,20 +133,20 @@ func (c *documentCache) snapshot() map[string]docEntry {
 	return out
 }
 
-// remove는 URI를 캐시에서 삭제합니다.
+// remove deletes the URI from the cache.
 func (c *documentCache) remove(uri string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	delete(c.entries, uri)
 }
 
-// reapIdle은 idleTimeout을 초과한 항목에 textDocument/didClose를 전송하고 캐시에서 제거합니다 (REQ-LC-022).
-// 에러는 로그하지만 reaping을 중단하지 않습니다.
-// 제거된 항목 수를 반환합니다.
+// reapIdle sends textDocument/didClose for entries that have exceeded idleTimeout and removes them from the cache (REQ-LC-022).
+// Errors are logged but do not stop reaping.
+// Returns the number of entries removed.
 func (c *documentCache) reapIdle(ctx context.Context, tr transport.Transport, idleTimeout time.Duration) int {
 	now := time.Now()
 
-	// 만료된 항목 목록 수집 (락 최소화)
+	// Collect expired entries while holding the read lock (minimize lock duration).
 	c.mu.RLock()
 	var expired []struct {
 		uri        string
@@ -172,7 +173,7 @@ func (c *documentCache) reapIdle(ctx context.Context, tr transport.Transport, id
 				"uri": e.uri,
 			},
 		}
-		// 에러는 무시하고 계속 진행 (REQ-LC-022 요구사항)
+		// Ignore errors and continue (REQ-LC-022 requirement).
 		_ = tr.Notify(ctx, methodDidClose, params)
 		c.remove(e.uri)
 		reaped++
@@ -180,8 +181,8 @@ func (c *documentCache) reapIdle(ctx context.Context, tr transport.Transport, id
 	return reaped
 }
 
-// didSave는 추적 중인 URI에 textDocument/didSave를 전송합니다 (REQ-LC-023).
-// URI가 캐시에 없으면 에러를 반환합니다.
+// didSave sends textDocument/didSave for a tracked URI (REQ-LC-023).
+// Returns an error if the URI is not in the cache.
 func (c *documentCache) didSave(ctx context.Context, tr transport.Transport, uri string) error {
 	c.mu.RLock()
 	entry, ok := c.entries[uri]
@@ -203,22 +204,22 @@ func (c *documentCache) didSave(ctx context.Context, tr transport.Transport, uri
 }
 
 // ---------------------------------------------------------------------------
-// pathToURI — 파일 경로를 LSP URI로 변환
+// pathToURI — convert a file path to an LSP URI
 // ---------------------------------------------------------------------------
 
-// pathToURI는 파일 경로를 LSP file:// URI로 변환합니다.
+// pathToURI converts a file path to an LSP file:// URI.
 //
-// 변환 규칙:
-//   - "file://" 접두어가 있으면 그대로 반환
-//   - 절대 경로: symlink 해제 후 "file://" + 슬래시 표준화된 경로 (macOS /var → /private/var)
-//   - 상대 경로: "file://" + 경로 (as-is)
+// Conversion rules:
+//   - If the path already has a "file://" prefix, return it as-is.
+//   - Absolute path: resolve symlinks, then return "file://" + slash-normalized path (macOS /var → /private/var).
+//   - Relative path: return "file://" + path (as-is).
 func pathToURI(path string) string {
 	if strings.HasPrefix(path, "file://") {
 		return path
 	}
 	if filepath.IsAbs(path) {
-		// symlink 해제: macOS에서 /var/folders → /private/var/folders
-		// 언어 서버가 실제 경로로 반환할 때 URI 불일치를 방지함
+		// Resolve symlinks: on macOS /var/folders → /private/var/folders.
+		// Prevents URI mismatch when the language server returns the real path.
 		if resolved, err := filepath.EvalSymlinks(path); err == nil {
 			path = resolved
 		}
@@ -226,12 +227,12 @@ func pathToURI(path string) string {
 		// Windows: C:\foo\bar.go → file:///C:/foo/bar.go
 		return "file://" + filepath.ToSlash(path)
 	}
-	// 상대 경로: 그대로 반환 (테스트 호환성)
+	// Relative path: return as-is (test compatibility).
 	return "file://" + path
 }
 
-// resolveLanguageID는 ServerConfig.Language에서 LSP languageId를 결정합니다.
-// 알 수 없는 언어는 cfg.Language 그대로를 반환합니다.
+// resolveLanguageID determines the LSP languageId from ServerConfig.Language.
+// Unknown languages are returned unchanged from cfg.Language.
 func resolveLanguageID(language string) string {
 	switch language {
 	case "go":

--- a/internal/lsp/core/document_test.go
+++ b/internal/lsp/core/document_test.go
@@ -16,8 +16,8 @@ import (
 // fakeNotifyTransport — captures Notify calls with params for document sync
 // ---------------------------------------------------------------------------
 
-// fakeNotifyTransport는 Notify 호출을 파라미터 포함하여 기록하는 테스트 전용 Transport.
-// fakeTransport(client_test.go)와 달리 Notify params도 저장합니다.
+// fakeNotifyTransport is a test-only Transport that records Notify calls including params.
+// Unlike fakeTransport (client_test.go), it also stores Notify params.
 type fakeNotifyTransport struct {
 	mu       sync.Mutex
 	notifies []notifyCall
@@ -39,7 +39,7 @@ func (f *fakeNotifyTransport) Call(_ context.Context, method string, _, result a
 	defer f.mu.Unlock()
 	f.callLog = append(f.callLog, method)
 	if result != nil && method == "initialize" {
-		// initialize 응답: capabilities = {}
+		// initialize response: capabilities = {}
 		raw := json.RawMessage(`{"capabilities":{}}`)
 		_ = json.Unmarshal(raw, result)
 	}
@@ -62,7 +62,7 @@ func (f *fakeNotifyTransport) Close() error {
 	return nil
 }
 
-// notifyCount는 해당 method로 Notify가 호출된 횟수를 반환합니다.
+// notifyCount returns the number of times Notify was called with the given method.
 func (f *fakeNotifyTransport) notifyCount(method string) int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -99,7 +99,7 @@ func TestDocumentCache_OpenNew(t *testing.T) {
 		t.Errorf("expected 0 textDocument/didChange, got %d", got)
 	}
 
-	// 버전이 1로 초기화되었는지 확인
+	// verify version is initialized to 1
 	snap := cache.snapshot()
 	entry, ok := snap["file:///foo.go"]
 	if !ok {
@@ -123,17 +123,17 @@ func TestDocumentCache_SameContent(t *testing.T) {
 
 	content := "package main\n"
 	_ = cache.openOrChange(ctx, ft, "file:///bar.go", "go", content)
-	// 같은 내용으로 두 번째 호출
+	// second call with the same content
 	err := cache.openOrChange(ctx, ft, "file:///bar.go", "go", content)
 	if err != nil {
 		t.Fatalf("openOrChange (same content): unexpected error: %v", err)
 	}
 
-	// didOpen은 최초 1회만
+	// didOpen only once (first call)
 	if got := ft.notifyCount(methodDidOpen); got != 1 {
 		t.Errorf("expected 1 textDocument/didOpen total, got %d", got)
 	}
-	// didChange는 0회
+	// didChange 0 times
 	if got := ft.notifyCount(methodDidChange); got != 0 {
 		t.Errorf("expected 0 textDocument/didChange for same content, got %d", got)
 	}
@@ -232,7 +232,7 @@ func TestDocumentCache_ReapIdle_Expired(t *testing.T) {
 
 	_ = cache.openOrChange(ctx, ft, "file:///old.go", "go", "package main")
 
-	// 직접 lastActivity를 과거로 설정
+	// directly set lastActivity to a past time
 	cache.mu.Lock()
 	entry := cache.entries["file:///old.go"]
 	entry.lastActivity = time.Now().Add(-10 * time.Minute)
@@ -262,7 +262,7 @@ func TestDocumentCache_ReapIdle_Active(t *testing.T) {
 	ctx := context.Background()
 
 	_ = cache.openOrChange(ctx, ft, "file:///active.go", "go", "package main")
-	// lastActivity는 방금 전 — idle timeout 5분 이내
+	// lastActivity is just now — within 5-minute idle timeout
 
 	reaped := cache.reapIdle(ctx, ft, 5*time.Minute)
 
@@ -310,7 +310,7 @@ func TestDocumentCache_DidSave_Untracked(t *testing.T) {
 // T-011: Client.OpenFile integration (pathToURI + languageID resolution)
 // ---------------------------------------------------------------------------
 
-// makeNotifyClient는 fakeNotifyTransport를 사용하는 테스트용 클라이언트를 생성합니다.
+// makeNotifyClient creates a test client that uses fakeNotifyTransport.
 func makeNotifyClient(cfg config.ServerConfig, ft *fakeNotifyTransport) *client {
 	return NewClient(cfg,
 		WithLauncherFunc((&fakeLauncher{}).Launch),
@@ -397,7 +397,7 @@ func TestDocumentCache_Touch(t *testing.T) {
 
 	_ = cache.openOrChange(ctx, ft, "file:///touch.go", "go", "package main")
 
-	// 과거 시간으로 강제 설정
+	// force lastActivity to a past time
 	cache.mu.Lock()
 	entry := cache.entries["file:///touch.go"]
 	old := time.Now().Add(-1 * time.Minute)
@@ -436,7 +436,7 @@ func TestClient_DidSave(t *testing.T) {
 		t.Fatalf("Start: %v", err)
 	}
 
-	// 파일을 먼저 열어야 함
+	// file must be opened first
 	_ = c.OpenFile(ctx, "/tmp/save.go", "package main")
 
 	err := c.DidSave(ctx, "/tmp/save.go")

--- a/internal/lsp/core/integration_helpers_test.go
+++ b/internal/lsp/core/integration_helpers_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/modu-ai/moai-adk/internal/lsp/core"
 )
 
-// skipIfBinaryMissing는 cmd 바이너리가 PATH에 없으면 테스트를 건너뜁니다.
+// skipIfBinaryMissing skips the test when the cmd binary is not found in PATH.
 func skipIfBinaryMissing(t *testing.T, cmd string) {
 	t.Helper()
 	if _, err := exec.LookPath(cmd); err != nil {
@@ -23,9 +23,9 @@ func skipIfBinaryMissing(t *testing.T, cmd string) {
 	}
 }
 
-// waitForDiagnostics는 pollInterval 간격으로 GetDiagnostics를 폴링하여
-// minCount 이상의 진단이 반환될 때까지 최대 totalTimeout 동안 대기합니다.
-// totalTimeout 내에 조건이 충족되지 않으면 빈 슬라이스를 반환합니다.
+// waitForDiagnostics polls GetDiagnostics at pollInterval intervals and waits up to totalTimeout
+// until at least minCount diagnostics are returned.
+// Returns an empty slice if the condition is not met within totalTimeout.
 func waitForDiagnostics(
 	ctx context.Context,
 	cl core.Client,
@@ -46,7 +46,7 @@ func waitForDiagnostics(
 		}
 		time.Sleep(pollInterval)
 	}
-	// 마지막으로 한 번 더 시도
+	// One final attempt
 	diags, err := cl.GetDiagnostics(ctx, path)
 	if err == nil {
 		return diags
@@ -54,7 +54,7 @@ func waitForDiagnostics(
 	return nil
 }
 
-// writeTempFile은 dir/name 경로에 content를 쓰고 절대 경로를 반환합니다.
+// writeTempFile writes content to dir/name and returns the absolute path.
 func writeTempFile(t *testing.T, dir, name, content string) string {
 	t.Helper()
 	path := filepath.Join(dir, name)
@@ -68,7 +68,7 @@ func writeTempFile(t *testing.T, dir, name, content string) string {
 	return abs
 }
 
-// assertStateEquals는 Client.State()가 expected와 같은지 확인합니다.
+// assertStateEquals verifies that Client.State() equals expected.
 func assertStateEquals(t *testing.T, cl core.Client, expected core.ClientState) {
 	t.Helper()
 	got := cl.State()
@@ -77,13 +77,13 @@ func assertStateEquals(t *testing.T, cl core.Client, expected core.ClientState) 
 	}
 }
 
-// lspPosition은 0-based line, character를 lsp.Position으로 변환합니다.
+// lspPosition converts 0-based line and character to an lsp.Position.
 func lspPosition(line, character int) lsp.Position {
 	return lsp.Position{Line: line, Character: character}
 }
 
-// writeGoModule은 tmpDir에 go.mod와 main.go를 생성하고 절대 경로를 반환합니다.
-// mainContent가 비어 있으면 기본 main.go를 사용합니다.
+// writeGoModule creates go.mod and main.go in tmpDir and returns their absolute paths.
+// If mainContent is empty, a default main.go is used.
 func writeGoModule(t *testing.T, tmpDir, moduleName, mainContent string) (goModPath, mainGoPath string) {
 	t.Helper()
 
@@ -97,22 +97,22 @@ func writeGoModule(t *testing.T, tmpDir, moduleName, mainContent string) (goModP
 	return goModPath, mainGoPath
 }
 
-// makeGoModuleDir는 gopls가 인식할 수 있는 Go 모듈 임시 디렉토리를 생성합니다.
+// makeGoModuleDir creates a temporary directory under /tmp for a Go module that gopls can recognize.
 //
-// macOS에서 os.TempDir()은 /var/folders/...를 반환하며, Go 도구는 system temp root
-// 내의 go.mod를 무시합니다. 이 함수는 명시적으로 /tmp 아래에 디렉토리를 생성하여
-// gopls가 Go 모듈을 올바르게 인식하도록 합니다.
+// On macOS, os.TempDir() returns /var/folders/..., and Go tools ignore go.mod files within the
+// system temp root. This function explicitly creates the directory under /tmp so gopls
+// correctly recognizes the Go module.
 //
-// t.Cleanup으로 자동 삭제됩니다.
+// Automatically deleted via t.Cleanup.
 func makeGoModuleDir(t *testing.T) string {
 	t.Helper()
-	// /tmp 아래에 생성: macOS system temp root(/var/folders) 우회
+	// Create under /tmp: bypass the macOS system temp root (/var/folders)
 	dir, err := os.MkdirTemp("/tmp", "lsp_integration_*")
 	if err != nil {
 		t.Fatalf("makeGoModuleDir: MkdirTemp: %v", err)
 	}
 	t.Cleanup(func() { os.RemoveAll(dir) })
-	// symlink 해제: gopls가 실제 경로로 URI를 구성하기 때문에 일관성 유지
+	// Resolve symlinks: ensures consistency because gopls constructs URIs from the real path
 	realDir, err := filepath.EvalSymlinks(dir)
 	if err != nil {
 		return dir

--- a/internal/lsp/core/integration_python_test.go
+++ b/internal/lsp/core/integration_python_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/modu-ai/moai-adk/internal/lsp/core"
 )
 
-// pyrightConfig는 pyright-langserver 통합 테스트용 ServerConfig를 반환합니다.
+// pyrightConfig returns the ServerConfig for pyright-langserver integration tests.
 func pyrightConfig() config.ServerConfig {
 	return config.ServerConfig{
 		Language:       "python",
@@ -23,15 +23,15 @@ func pyrightConfig() config.ServerConfig {
 	}
 }
 
-// pyrightConfigWithRoot는 rootDir이 설정된 pyright ServerConfig를 반환합니다.
+// pyrightConfigWithRoot returns a pyright ServerConfig with rootDir set.
 func pyrightConfigWithRoot(rootDir string) config.ServerConfig {
 	cfg := pyrightConfig()
 	cfg.RootDir = rootDir
 	return cfg
 }
 
-// TestIntegration_Pyright_InitializeAndShutdown은 pyright-langserver를 실제로
-// 기동하고 StateReady에 도달한 후 정상적으로 종료되는지 확인합니다.
+// TestIntegration_Pyright_InitializeAndShutdown verifies that pyright-langserver starts,
+// reaches StateReady, and shuts down cleanly.
 func TestIntegration_Pyright_InitializeAndShutdown(t *testing.T) {
 	skipIfBinaryMissing(t, "pyright-langserver")
 
@@ -54,22 +54,22 @@ func TestIntegration_Pyright_InitializeAndShutdown(t *testing.T) {
 	assertStateEquals(t, cl, core.StateShutdown)
 }
 
-// TestIntegration_Pyright_OpenFileAndGetDiagnostics는 pyright-langserver가
-// Python 소스 파일의 타입 오류에 대해 진단을 push하는지 확인합니다.
+// TestIntegration_Pyright_OpenFileAndGetDiagnostics verifies that pyright-langserver pushes
+// diagnostics for type errors in a Python source file.
 //
-// pyright는 초기 분석 시간이 길어 최대 15s 폴링 윈도우를 사용합니다.
+// Pyright has a longer initial analysis time, so a polling window of up to 15s is used.
 func TestIntegration_Pyright_OpenFileAndGetDiagnostics(t *testing.T) {
 	skipIfBinaryMissing(t, "pyright-langserver")
 
 	tmpDir := t.TempDir()
 
-	// 타입 오류가 포함된 Python 파일 생성
-	// pyright는 타입 불일치를 정적으로 감지함
+	// Create a Python file with a type error
+	// pyright statically detects type mismatches
 	pyContent := `x: int = "this is a string"
 `
 	pyPath := writeTempFile(t, tmpDir, "main.py", pyContent)
 
-	// pyproject.toml 생성 (pyright root marker)
+	// Create pyproject.toml (pyright root marker)
 	writeTempFile(t, tmpDir, "pyproject.toml", "[tool.pyright]\n")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -78,8 +78,8 @@ func TestIntegration_Pyright_OpenFileAndGetDiagnostics(t *testing.T) {
 	var cl core.Client
 	var startErr error
 
-	// pyright 기동 재시도 (최대 2회): 첫 번째 기동이 실패하는 경우 대비
-	// RootDir을 tmpDir로 설정하여 pyright에 workspace root 전달
+	// Retry pyright startup (up to 2 times) in case the first attempt fails.
+	// Set RootDir to tmpDir to pass the workspace root to pyright.
 	for attempt := 0; attempt < 2; attempt++ {
 		cl = core.NewClient(pyrightConfigWithRoot(tmpDir))
 		startErr = cl.Start(ctx)
@@ -103,14 +103,14 @@ func TestIntegration_Pyright_OpenFileAndGetDiagnostics(t *testing.T) {
 		t.Fatalf("OpenFile: %v", err)
 	}
 
-	// 진단 폴링: pyright는 gopls보다 느린 분석기 — 최대 15s 대기
+	// Poll for diagnostics: pyright is a slower analyzer than gopls — wait up to 15s
 	diags := waitForDiagnostics(ctx, cl, pyPath, 1, 200*time.Millisecond, 15*time.Second)
 	if len(diags) == 0 {
 		t.Fatal("expected at least 1 diagnostic from pyright for type mismatch, got 0")
 	}
 
-	// 진단 메시지에 타입 오류 관련 키워드가 포함되어 있는지 확인 (case-insensitive)
-	// pyright는 "Expression of type" 혹은 "Cannot assign" 등을 출력함
+	// Verify that at least one diagnostic contains a type-error keyword (case-insensitive)
+	// pyright outputs messages like "Expression of type" or "Cannot assign"
 	typeErrorKeywords := []string{"type", "assign", "str", "int", "expression"}
 	found := false
 outer:

--- a/internal/lsp/core/integration_test.go
+++ b/internal/lsp/core/integration_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/modu-ai/moai-adk/internal/lsp/core"
 )
 
-// goplsConfig는 gopls 통합 테스트에 사용되는 표준 ServerConfig를 반환합니다.
-// rootDir이 비어 있으면 rootUri를 생략합니다.
+// goplsConfig returns the standard ServerConfig used for gopls integration tests.
+// Omits rootUri when rootDir is empty.
 func goplsConfig() config.ServerConfig {
 	return config.ServerConfig{
 		Language:       "go",
@@ -25,16 +25,16 @@ func goplsConfig() config.ServerConfig {
 	}
 }
 
-// goplsConfigWithRoot는 rootDir이 설정된 gopls ServerConfig를 반환합니다.
-// rootDir은 go.mod가 위치한 임시 디렉토리여야 합니다.
+// goplsConfigWithRoot returns a gopls ServerConfig with rootDir set.
+// rootDir must be a temporary directory containing go.mod.
 func goplsConfigWithRoot(rootDir string) config.ServerConfig {
 	cfg := goplsConfig()
 	cfg.RootDir = rootDir
 	return cfg
 }
 
-// TestIntegration_Gopls_InitializeAndShutdown은 gopls를 실제로 기동하고
-// StateReady에 도달한 후 정상적으로 종료되는지 확인합니다 (REQ-LC-010).
+// TestIntegration_Gopls_InitializeAndShutdown verifies that gopls starts, reaches StateReady,
+// and shuts down cleanly (REQ-LC-010).
 func TestIntegration_Gopls_InitializeAndShutdown(t *testing.T) {
 	skipIfBinaryMissing(t, "gopls")
 
@@ -58,23 +58,23 @@ func TestIntegration_Gopls_InitializeAndShutdown(t *testing.T) {
 	}
 	assertStateEquals(t, cl, core.StateShutdown)
 
-	// 고루틴 누수 확인: 종료 후 최대 2개 이내 증가 허용
-	// (runtime 내부 GC 고루틴 등 일시적 변동 허용)
+	// Check for goroutine leaks: allow up to 2 additional goroutines after shutdown
+	// (temporary fluctuation from runtime-internal GC goroutines, etc. is allowed)
 	after := runtime.NumGoroutine()
 	if delta := after - before; delta > 2 {
 		t.Errorf("goroutine leak suspected: before=%d after=%d delta=%d", before, after, delta)
 	}
 }
 
-// TestIntegration_Gopls_OpenFileAndGetDiagnostics는 gopls가 Go 소스 파일의
-// 컴파일 오류에 대해 진단을 push하는지 확인합니다 (REQ-LC-010).
+// TestIntegration_Gopls_OpenFileAndGetDiagnostics verifies that gopls pushes diagnostics
+// for compile errors in a Go source file (REQ-LC-010).
 func TestIntegration_Gopls_OpenFileAndGetDiagnostics(t *testing.T) {
 	skipIfBinaryMissing(t, "gopls")
 
-	// makeGoModuleDir: /tmp 아래에 생성하여 macOS system temp root 제한 우회
+	// makeGoModuleDir: create under /tmp to bypass the macOS system temp root restriction
 	tmpDir := makeGoModuleDir(t)
 
-	// undefined 변수를 참조하는 소스: gopls가 진단을 push해야 함
+	// Source referencing an undefined variable: gopls must push a diagnostic
 	mainContent := `package main
 
 func main() {
@@ -86,7 +86,7 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// RootDir을 tmpDir로 설정: gopls에 rootUri+workspaceFolders를 전달
+	// Set RootDir to tmpDir: passes rootUri+workspaceFolders to gopls
 	cl := core.NewClient(goplsConfigWithRoot(tmpDir))
 
 	if err := cl.Start(ctx); err != nil {
@@ -98,18 +98,18 @@ func main() {
 		_ = cl.Shutdown(shutCtx)
 	})
 
-	// didOpen 전송
+	// Send didOpen
 	if err := cl.OpenFile(ctx, mainGoPath, mainContent); err != nil {
 		t.Fatalf("OpenFile: %v", err)
 	}
 
-	// 진단 폴링: gopls는 비동기로 publishDiagnostics를 push함
+	// Poll for diagnostics: gopls pushes publishDiagnostics asynchronously
 	diags := waitForDiagnostics(ctx, cl, mainGoPath, 1, 100*time.Millisecond, 10*time.Second)
 	if len(diags) == 0 {
 		t.Fatal("expected at least 1 diagnostic from gopls for undefined variable, got 0")
 	}
 
-	// 진단 메시지에 "undefined" 포함 여부 확인 (case-insensitive)
+	// Verify that at least one diagnostic message contains "undefined" (case-insensitive)
 	found := false
 	for _, d := range diags {
 		if strings.Contains(strings.ToLower(d.Message), "undefined") {
@@ -126,14 +126,14 @@ func main() {
 	}
 }
 
-// TestIntegration_Gopls_FindReferences는 gopls가 심볼 참조 위치를 반환하는지
-// 확인합니다 (REQ-LC-010, REQ-LC-002b).
+// TestIntegration_Gopls_FindReferences verifies that gopls returns symbol reference locations
+// (REQ-LC-010, REQ-LC-002b).
 func TestIntegration_Gopls_FindReferences(t *testing.T) {
 	skipIfBinaryMissing(t, "gopls")
 
-	// makeGoModuleDir: /tmp 아래에 생성하여 macOS system temp root 제한 우회
+	// makeGoModuleDir: create under /tmp to bypass the macOS system temp root restriction
 	tmpDir := makeGoModuleDir(t)
-	// foo() 정의 (line 2, 0-indexed) + foo() 호출 (line 5, 0-indexed)
+	// foo() definition (line 2, 0-indexed) + foo() call (line 5, 0-indexed)
 	mainContent := `package main
 
 func foo() {}
@@ -147,7 +147,7 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// RootDir을 tmpDir로 설정: gopls에 rootUri+workspaceFolders를 전달
+	// Set RootDir to tmpDir: passes rootUri+workspaceFolders to gopls
 	cl := core.NewClient(goplsConfigWithRoot(tmpDir))
 	if err := cl.Start(ctx); err != nil {
 		t.Fatalf("Start: %v", err)
@@ -162,13 +162,13 @@ func main() {
 		t.Fatalf("OpenFile: %v", err)
 	}
 
-	// gopls 인덱싱 대기 (didOpen 후 초기 분석 시간 필요)
+	// Wait for gopls indexing (initial analysis time needed after didOpen)
 	time.Sleep(500 * time.Millisecond)
 
-	// foo 정의 위치 (line=2, character=5): "func foo()" 에서 'f' 위치
+	// foo definition location (line=2, character=5): position of 'f' in "func foo()"
 	locs, err := cl.FindReferences(ctx, mainGoPath, lspPosition(2, 5))
 	if err != nil {
-		// ErrCapabilityUnsupported면 gopls 버전 문제 — skip
+		// ErrCapabilityUnsupported means gopls version issue — skip
 		if strings.Contains(err.Error(), "capability") {
 			t.Skipf("gopls does not advertise references capability: %v", err)
 		}
@@ -180,14 +180,14 @@ func main() {
 	}
 }
 
-// TestIntegration_Gopls_GotoDefinition는 gopls가 심볼 정의 위치를 반환하는지
-// 확인합니다 (REQ-LC-010, REQ-LC-002b).
+// TestIntegration_Gopls_GotoDefinition verifies that gopls returns the symbol definition location
+// (REQ-LC-010, REQ-LC-002b).
 func TestIntegration_Gopls_GotoDefinition(t *testing.T) {
 	skipIfBinaryMissing(t, "gopls")
 
-	// makeGoModuleDir: /tmp 아래에 생성하여 macOS system temp root 제한 우회
+	// makeGoModuleDir: create under /tmp to bypass the macOS system temp root restriction
 	tmpDir := makeGoModuleDir(t)
-	// foo() 정의 (line 2) + foo() 호출 (line 5)
+	// foo() definition (line 2) + foo() call (line 5)
 	mainContent := `package main
 
 func foo() {}
@@ -201,7 +201,7 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// RootDir을 tmpDir로 설정: gopls에 rootUri+workspaceFolders를 전달
+	// Set RootDir to tmpDir: passes rootUri+workspaceFolders to gopls
 	cl := core.NewClient(goplsConfigWithRoot(tmpDir))
 	if err := cl.Start(ctx); err != nil {
 		t.Fatalf("Start: %v", err)
@@ -216,10 +216,10 @@ func main() {
 		t.Fatalf("OpenFile: %v", err)
 	}
 
-	// gopls 인덱싱 대기
+	// Wait for gopls indexing
 	time.Sleep(500 * time.Millisecond)
 
-	// foo() 호출 위치 (line=5, character=1): "\tfoo()" 에서 'f' 위치
+	// foo() call location (line=5, character=1): position of 'f' in "\tfoo()"
 	locs, err := cl.GotoDefinition(ctx, mainGoPath, lspPosition(5, 1))
 	if err != nil {
 		if strings.Contains(err.Error(), "capability") {
@@ -232,7 +232,7 @@ func main() {
 		t.Fatal("GotoDefinition: expected at least 1 location, got 0")
 	}
 
-	// 반환된 위치는 정의 라인(line=2)을 포함해야 함
+	// Returned location must include the definition line (line=2)
 	found := false
 	for _, loc := range locs {
 		if loc.Range.Start.Line == 2 {

--- a/internal/lsp/core/integration_typescript_test.go
+++ b/internal/lsp/core/integration_typescript_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/modu-ai/moai-adk/internal/lsp/core"
 )
 
-// tsConfig는 typescript-language-server 통합 테스트용 ServerConfig를 반환합니다.
+// tsConfig returns a ServerConfig for typescript-language-server integration tests.
 func tsConfig() config.ServerConfig {
 	return config.ServerConfig{
 		Language:       "typescript",
@@ -23,10 +23,10 @@ func tsConfig() config.ServerConfig {
 	}
 }
 
-// TestIntegration_TypeScript_InitializeAndShutdown은 typescript-language-server를
-// 실제로 기동하고 StateReady에 도달한 후 정상적으로 종료되는지 확인합니다.
+// TestIntegration_TypeScript_InitializeAndShutdown actually launches
+// typescript-language-server, waits for StateReady, and verifies normal shutdown.
 //
-// typescript-language-server가 PATH에 없으면 Skip됩니다.
+// Skipped if typescript-language-server is not on PATH.
 func TestIntegration_TypeScript_InitializeAndShutdown(t *testing.T) {
 	skipIfBinaryMissing(t, "typescript-language-server")
 
@@ -49,20 +49,21 @@ func TestIntegration_TypeScript_InitializeAndShutdown(t *testing.T) {
 	assertStateEquals(t, cl, core.StateShutdown)
 }
 
-// TestIntegration_TypeScript_OpenFileAndDiagnostics는 typescript-language-server가
-// TypeScript 소스 파일의 타입 오류에 대해 진단을 push하는지 확인합니다.
+// TestIntegration_TypeScript_OpenFileAndDiagnostics verifies that
+// typescript-language-server pushes diagnostics for type errors in a TypeScript
+// source file.
 //
-// typescript-language-server가 PATH에 없으면 Skip됩니다.
+// Skipped if typescript-language-server is not on PATH.
 func TestIntegration_TypeScript_OpenFileAndDiagnostics(t *testing.T) {
 	skipIfBinaryMissing(t, "typescript-language-server")
 
 	tmpDir := t.TempDir()
 
-	// 타입 오류가 있는 TypeScript 파일 생성
+	// Create a TypeScript file with a type error.
 	tsContent := "const x: number = \"string\";\n"
 	tsPath := writeTempFile(t, tmpDir, "main.ts", tsContent)
 
-	// tsconfig.json 생성 (root marker)
+	// Create tsconfig.json (root marker).
 	writeTempFile(t, tmpDir, "tsconfig.json", `{"compilerOptions":{"strict":true}}`+"\n")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -83,13 +84,13 @@ func TestIntegration_TypeScript_OpenFileAndDiagnostics(t *testing.T) {
 		t.Fatalf("OpenFile: %v", err)
 	}
 
-	// 진단 폴링: 최대 10s 대기
+	// Poll for diagnostics: wait up to 10s.
 	diags := waitForDiagnostics(ctx, cl, tsPath, 1, 200*time.Millisecond, 10*time.Second)
 	if len(diags) == 0 {
 		t.Fatal("expected at least 1 diagnostic from typescript-language-server for type mismatch, got 0")
 	}
 
-	// 진단 메시지에 타입 오류 관련 키워드가 포함되어 있는지 확인 (case-insensitive)
+	// Verify the diagnostic message contains type-error keywords (case-insensitive).
 	typeErrorKeywords := []string{"type", "string", "number", "assignable"}
 	found := false
 outer:

--- a/internal/lsp/core/manager.go
+++ b/internal/lsp/core/manager.go
@@ -16,107 +16,107 @@ import (
 	"github.com/modu-ai/moai-adk/internal/lsp/config"
 )
 
-// ErrNoLanguageDetected는 파일 확장자가 설정된 어떤 언어 서버와도 매핑되지 않을 때
-// RouteFor가 반환하는 센티넬 에러입니다.
+// ErrNoLanguageDetected is the sentinel error returned by RouteFor when the file
+// extension does not map to any configured language server.
 //
-// @MX:ANCHOR: [AUTO] ErrNoLanguageDetected — Manager.RouteFor의 공개 센티넬 에러
-// @MX:REASON: fan_in >= 3 — RouteFor, 테스트 어서션, Ralph 엔진, MCP 브리지 등 여러 호출자가 이 센티넬로 분기함
+// @MX:ANCHOR: [AUTO] ErrNoLanguageDetected — public sentinel error for Manager.RouteFor
+// @MX:REASON: fan_in >= 3 — RouteFor, test assertions, Ralph engine, MCP bridge, and other callers all branch on this sentinel
 var ErrNoLanguageDetected = errors.New("lsp: no language server configured for this file type")
 
-// Manager는 여러 언어 서버 Client 인스턴스를 조율하는 타입입니다.
-// 파일 확장자 + 프로젝트 마커 기반으로 요청을 적절한 Client에 라우팅합니다 (REQ-LC-008).
+// Manager coordinates multiple language server Client instances.
+// Routes requests to the appropriate Client based on file extension and project markers (REQ-LC-008).
 //
-// @MX:ANCHOR: [AUTO] Manager — 멀티 언어 LSP 클라이언트 조율자 (REQ-LC-008, REQ-LC-009, REQ-LC-050)
-// @MX:REASON: fan_in >= 3 — Ralph 엔진, Quality Gates, LOOP 커맨드, MCP 브리지가 모두 Manager를 통해 LSP에 접근함
+// @MX:ANCHOR: [AUTO] Manager — multi-language LSP client coordinator (REQ-LC-008, REQ-LC-009, REQ-LC-050)
+// @MX:REASON: fan_in >= 3 — Ralph engine, Quality Gates, LOOP command, and MCP bridge all access LSP through Manager
 type Manager struct {
-	// servers는 언어 이름(예: "go") → ServerConfig 맵입니다.
+	// servers is a map of language name (e.g. "go") → ServerConfig.
 	servers map[string]config.ServerConfig
 
-	// clients는 언어 이름 → Client 맵입니다. lazy-spawned됩니다 (T-016).
+	// clients is a map of language name → Client. Clients are lazy-spawned (T-016).
 	clients map[string]Client
 
-	// mu는 servers, clients, lastActivity 접근을 보호합니다.
+	// mu protects access to servers, clients, and lastActivity.
 	mu sync.Mutex
 
-	// sf는 동시 getOrSpawn 호출을 언어별로 직렬화하는 singleflight 그룹입니다 (REQ-UTIL-003-003).
-	// zero-value로 초기화되며 추가 생성자 호출 없이 즉시 사용 가능합니다.
-	// @MX:NOTE: [AUTO] sf — singleflight.Group; 동일 언어에 대한 중복 clientFactory+Start 호출 방지 (REQ-UTIL-003-004, REQ-UTIL-003-005)
+	// sf is a singleflight group that serializes concurrent getOrSpawn calls per language (REQ-UTIL-003-003).
+	// Initialized as a zero-value and ready to use without an additional constructor call.
+	// @MX:NOTE: [AUTO] sf — singleflight.Group; prevents duplicate clientFactory+Start calls for the same language (REQ-UTIL-003-004, REQ-UTIL-003-005)
 	sf singleflight.Group
 
-	// clientFactory는 테스트에서 DI로 교체 가능한 Client 생성 함수입니다.
-	// 기본값: NewClient
+	// clientFactory is the Client construction function; can be replaced via DI in tests.
+	// Default: NewClient.
 	clientFactory func(config.ServerConfig) Client
 
-	// lastActivity는 언어별 마지막 RouteFor 호출 시각을 추적합니다 (REQ-LC-050).
+	// lastActivity tracks the last RouteFor call time per language (REQ-LC-050).
 	lastActivity map[string]time.Time
 
-	// idleShutdownSeconds는 클라이언트 유휴 종료 기준 초 수입니다.
-	// 0이면 즉시 만료로 처리됩니다.
+	// idleShutdownSeconds is the inactivity threshold in seconds for client shutdown.
+	// A value of 0 is treated as immediately expired.
 	idleShutdownSeconds int
 
-	// reaperInterval은 reaper 고루틴의 tick 간격입니다 (테스트에서 WithReaperInterval로 단축 가능).
+	// reaperInterval is the tick interval of the reaper goroutine (can be shortened via WithReaperInterval in tests).
 	reaperInterval time.Duration
 
-	// logger는 상태 전환 및 생명주기 이벤트 로거입니다.
+	// logger is used for state transitions and lifecycle events.
 	logger *slog.Logger
 
-	// ctx와 cancel은 Manager 내부 고루틴(reaper)의 생명주기를 제어합니다.
+	// ctx and cancel control the lifecycle of Manager's internal goroutine (reaper).
 	ctx    context.Context
 	cancel context.CancelFunc
 
-	// reaperDone은 reaper 고루틴이 완료되었음을 알리는 채널입니다.
+	// reaperDone is a channel that signals when the reaper goroutine has finished.
 	reaperDone chan struct{}
 
-	// statFn은 파일 존재 여부 확인 함수입니다 (테스트에서 DI 가능).
-	// 기본값: os.Stat
+	// statFn is the function used to check file existence (can be injected via DI in tests).
+	// Default: os.Stat.
 	statFn func(string) (os.FileInfo, error)
 }
 
-// ManagerOption은 Manager를 설정하는 함수형 옵션입니다.
+// ManagerOption is a functional option for configuring a Manager.
 type ManagerOption func(*Manager)
 
-// WithClientFactory는 테스트에서 DI로 fake Client를 주입하기 위한 옵션입니다.
+// WithClientFactory is an option for injecting a fake Client via DI in tests.
 func WithClientFactory(f func(config.ServerConfig) Client) ManagerOption {
 	return func(m *Manager) {
 		m.clientFactory = f
 	}
 }
 
-// WithIdleShutdownSeconds는 Manager의 유휴 종료 타임아웃을 설정합니다.
-// 기본값은 REQ-LC-050 기준 600초입니다.
+// WithIdleShutdownSeconds sets the idle shutdown timeout for the Manager.
+// The default is 600 seconds per REQ-LC-050.
 func WithIdleShutdownSeconds(seconds int) ManagerOption {
 	return func(m *Manager) {
 		m.idleShutdownSeconds = seconds
 	}
 }
 
-// WithManagerLogger는 Manager의 로거를 설정합니다.
+// WithManagerLogger sets the logger for the Manager.
 func WithManagerLogger(logger *slog.Logger) ManagerOption {
 	return func(m *Manager) {
 		m.logger = logger
 	}
 }
 
-// WithReaperInterval은 reaper 고루틴의 tick 간격을 설정합니다.
-// 테스트에서 짧은 간격으로 빠른 idle 감지를 테스트할 때 사용합니다.
-// 기본값: 30초.
+// WithReaperInterval sets the tick interval of the reaper goroutine.
+// Used in tests to shorten the interval for fast idle detection.
+// Default: 30 seconds.
 func WithReaperInterval(d time.Duration) ManagerOption {
 	return func(m *Manager) {
 		m.reaperInterval = d
 	}
 }
 
-// defaultReaperInterval은 reaper 기본 tick 간격입니다.
+// defaultReaperInterval is the default tick interval for the reaper.
 const defaultReaperInterval = 30 * time.Second
 
-// defaultIdleShutdownSeconds는 REQ-LC-050 기준 기본 유휴 종료 타임아웃입니다.
+// defaultIdleShutdownSeconds is the default idle shutdown timeout per REQ-LC-050.
 const defaultIdleShutdownSeconds = 600
 
-// NewManager는 ServersConfig를 기반으로 새 Manager를 생성합니다.
-// Start 호출 전까지 reaper 고루틴은 시작되지 않습니다.
+// NewManager creates a new Manager from the given ServersConfig.
+// The reaper goroutine is not started until Start is called.
 //
-// @MX:ANCHOR: [AUTO] NewManager — Manager 생성 팩토리, Manager 사용의 유일한 진입점
-// @MX:REASON: fan_in >= 3 — CLI, 통합 테스트, Ralph 엔진, MCP 브리지가 모두 NewManager를 호출함
+// @MX:ANCHOR: [AUTO] NewManager — Manager factory and sole entry point for constructing a Manager
+// @MX:REASON: fan_in >= 3 — CLI, integration tests, Ralph engine, and MCP bridge all call NewManager
 func NewManager(cfg *config.ServersConfig, opts ...ManagerOption) *Manager {
 	m := &Manager{
 		servers:             make(map[string]config.ServerConfig),
@@ -127,10 +127,10 @@ func NewManager(cfg *config.ServersConfig, opts ...ManagerOption) *Manager {
 		logger:              slog.Default(),
 	}
 
-	// ServersConfig에서 servers 맵 초기화
+	// Initialize the servers map from ServersConfig.
 	if cfg != nil {
 		for lang, sc := range cfg.Servers {
-			// Language 필드가 비어 있으면 맵 키로 채움
+			// Fill Language field from the map key if it is empty.
 			if sc.Language == "" {
 				sc.Language = lang
 			}
@@ -138,11 +138,11 @@ func NewManager(cfg *config.ServersConfig, opts ...ManagerOption) *Manager {
 		}
 	}
 
-	// 기본 clientFactory: NewClient 사용
+	// Default clientFactory: use NewClient.
 	m.clientFactory = func(sc config.ServerConfig) Client {
 		return NewClient(sc)
 	}
-	// 기본 statFn: os.Stat 사용
+	// Default statFn: use os.Stat.
 	m.statFn = os.Stat
 
 	for _, opt := range opts {
@@ -151,28 +151,28 @@ func NewManager(cfg *config.ServersConfig, opts ...ManagerOption) *Manager {
 	return m
 }
 
-// Start는 Manager의 내부 컨텍스트를 초기화하고 reaper 고루틴을 시작합니다.
-// 이 메서드는 Manager를 사용하기 전에 반드시 호출해야 합니다.
+// Start initializes the Manager's internal context and starts the reaper goroutine.
+// This method must be called before using the Manager.
 func (m *Manager) Start(ctx context.Context) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	if m.cancel != nil {
-		// 이미 Start된 경우 no-op
+		// Already started — no-op.
 		return nil
 	}
 
 	m.ctx, m.cancel = context.WithCancel(ctx)
 	m.reaperDone = make(chan struct{})
 
-	// @MX:WARN: [AUTO] reaper 고루틴 — Manager의 생명주기 동안 유휴 클라이언트를 정리하는 장기 실행 백그라운드 고루틴
-	// @MX:REASON: 컨텍스트 취소 없이는 고루틴 누수가 발생할 수 있음. Shutdown에서 반드시 ctx를 취소하고 reaperDone을 기다려야 함.
+	// @MX:WARN: [AUTO] reaper goroutine — long-running background goroutine that cleans up idle clients during the Manager's lifetime
+	// @MX:REASON: goroutine leak may occur without ctx cancellation. Shutdown must cancel ctx and wait for reaperDone.
 	go m.reaper(m.ctx, m.reaperDone)
 	return nil
 }
 
-// Shutdown은 reaper 고루틴을 취소하고 모든 캐시된 Client를 병렬로 종료합니다.
-// 클라이언트 종료 에러는 errors.Join으로 집계됩니다 (REQ-LC-050).
+// Shutdown cancels the reaper goroutine and shuts down all cached Clients in parallel.
+// Client shutdown errors are aggregated via errors.Join (REQ-LC-050).
 func (m *Manager) Shutdown(ctx context.Context) error {
 	m.mu.Lock()
 	if m.cancel != nil {
@@ -181,16 +181,16 @@ func (m *Manager) Shutdown(ctx context.Context) error {
 	reaperDone := m.reaperDone
 	m.mu.Unlock()
 
-	// reaper 고루틴이 완료될 때까지 대기 (ctx 타임아웃 존중)
+	// Wait for the reaper goroutine to finish (respecting ctx timeout).
 	if reaperDone != nil {
 		select {
 		case <-reaperDone:
 		case <-ctx.Done():
-			// ctx 만료 시에도 계속 진행 (best-effort)
+			// Continue even if ctx expires (best-effort).
 		}
 	}
 
-	// 모든 클라이언트를 병렬로 종료
+	// Shut down all clients in parallel.
 	m.mu.Lock()
 	snapshot := make(map[string]Client, len(m.clients))
 	for lang, c := range m.clients {
@@ -222,23 +222,23 @@ func (m *Manager) Shutdown(ctx context.Context) error {
 	return nil
 }
 
-// detectLanguage는 파일 경로의 확장자를 설정된 언어 서버와 매핑합니다.
+// detectLanguage maps the file path extension to a configured language server.
 //
-// 매핑 전략:
-//  1. 파일 확장자가 정확히 1개 언어에 매핑되면 즉시 반환
-//  2. 여러 언어가 같은 확장자를 가지면 프로젝트 마커로 구분:
-//     - 파일 디렉토리부터 루트까지 올라가며 각 언어의 RootMarkers 파일 존재 여부 확인
-//     - 정확히 1개 언어만 마커가 있으면 해당 언어 반환
-//     - 마커로 구분 불가시 후보 언어 중 결정론적으로 첫 번째 반환
-//  3. 확장자 매핑 없으면 (empty, false) 반환
+// Mapping strategy:
+//  1. If the extension maps to exactly one language, return it immediately.
+//  2. If multiple languages share the same extension, disambiguate using project markers:
+//     - Walk up from the file's directory to the root, checking each language's RootMarker files.
+//     - If exactly one language has a matching marker, return that language.
+//     - If markers cannot disambiguate, return the first candidate deterministically.
+//  3. If no extension mapping exists, return ("", false).
 func (m *Manager) detectLanguage(path string) (string, bool) {
 	ext := filepath.Ext(path)
 	if ext == "" {
 		return "", false
 	}
 
-	// 확장자로 후보 언어 수집
-	// 결정론적 순서를 위해 언어 이름 정렬
+	// Collect candidate languages by extension.
+	// Sort language names for deterministic ordering.
 	var candidates []string
 	for lang, sc := range m.servers {
 		for _, fe := range sc.FileExtensions {
@@ -256,25 +256,25 @@ func (m *Manager) detectLanguage(path string) (string, bool) {
 		return candidates[0], true
 	}
 
-	// 결정론적 순서 보장을 위해 정렬
+	// Sort for deterministic ordering.
 	sort.Strings(candidates)
 
-	// 프로젝트 마커로 구분
+	// Disambiguate using project markers.
 	dir := filepath.Dir(path)
 	matched := findLanguageByMarkers(dir, candidates, m.servers, m.statFn)
 	if matched != "" {
 		return matched, true
 	}
 
-	// 마커로 구분 불가: 첫 번째 후보 반환 (결정론적)
+	// Cannot disambiguate via markers: return the first candidate (deterministic).
 	return candidates[0], true
 }
 
-// findLanguageByMarkers는 파일 디렉토리에서 루트까지 올라가며 각 후보 언어의
-// RootMarker 파일이 존재하는지 확인합니다.
-// 정확히 1개 언어만 마커가 있으면 해당 언어를, 없으면 빈 문자열을 반환합니다.
+// findLanguageByMarkers walks up from dir to the filesystem root, checking whether
+// each candidate language's RootMarker files exist.
+// Returns the matched language if exactly one language has a marker, otherwise an empty string.
 func findLanguageByMarkers(dir string, candidates []string, servers map[string]config.ServerConfig, stat func(string) (os.FileInfo, error)) string {
-	// 경로를 따라 올라가며 마커 탐색
+	// Walk up the path searching for markers.
 	for {
 		var matchedLangs []string
 		for _, lang := range candidates {
@@ -292,10 +292,10 @@ func findLanguageByMarkers(dir string, candidates []string, servers map[string]c
 			return matchedLangs[0]
 		}
 
-		// 부모 디렉토리로 이동
+		// Move to the parent directory.
 		parent := filepath.Dir(dir)
 		if parent == dir {
-			// 파일시스템 루트에 도달
+			// Reached the filesystem root.
 			break
 		}
 		dir = parent
@@ -305,13 +305,13 @@ func findLanguageByMarkers(dir string, candidates []string, servers map[string]c
 
 // RouteFor returns the LSP Client responsible for the given file path.
 //
-// 동작:
-//  1. detectLanguage로 언어 결정
-//  2. getOrSpawn으로 Client 획득 (lazy spawn)
-//  3. lastActivity 업데이트
+// Behavior:
+//  1. Determine language via detectLanguage.
+//  2. Obtain Client via getOrSpawn (lazy spawn).
+//  3. Update lastActivity.
 //
-// @MX:ANCHOR: [AUTO] Manager.RouteFor — 파일 경로 기반 LSP 클라이언트 라우팅 핵심 경로
-// @MX:REASON: fan_in >= 3 — Ralph 엔진, Quality Gates, LOOP 커맨드, Aggregator가 모두 RouteFor를 통해 Client를 획득함
+// @MX:ANCHOR: [AUTO] Manager.RouteFor — core path for file-path-based LSP client routing
+// @MX:REASON: fan_in >= 3 — Ralph engine, Quality Gates, LOOP command, and Aggregator all obtain a Client through RouteFor
 func (m *Manager) RouteFor(ctx context.Context, path string) (Client, error) {
 	lang, ok := m.detectLanguage(path)
 	if !ok {
@@ -330,16 +330,16 @@ func (m *Manager) RouteFor(ctx context.Context, path string) (Client, error) {
 	return c, nil
 }
 
-// getOrSpawn은 캐시된 Client를 반환하거나, 없으면 새로 생성합니다.
+// getOrSpawn returns a cached Client or creates a new one if none exists.
 //
-// 동시 안전성 (REQ-UTIL-003-004, REQ-UTIL-003-005, REQ-UTIL-003-006):
-//  1. 빠른 경로: mu 락 하에 캐시를 확인하고 StateShutdown이 아닌 클라이언트가 있으면 즉시 반환.
-//  2. 캐시 미스: singleflight 장벽(m.sf.Do)으로 진입하여 동일 언어에 대한 동시 호출을 직렬화.
-//     - sf.Do 내부에서 재확인(double-check): 다른 goroutine이 이미 완료했을 수 있음.
-//     - clientFactory + c.Start는 sf.Do 내부에서만 실행됨 → 언어당 정확히 1회 보장.
-//     - Start 성공 후에만 캐시에 삽입 → Start 실패 시 캐시 부재로 다음 호출이 재시도 가능.
+// Concurrency safety (REQ-UTIL-003-004, REQ-UTIL-003-005, REQ-UTIL-003-006):
+//  1. Fast path: check the cache under the mu lock and return immediately if a non-shutdown client exists.
+//  2. Cache miss: enter the singleflight barrier (m.sf.Do) to serialize concurrent calls for the same language.
+//     - Double-check inside sf.Do: another goroutine may have already completed.
+//     - clientFactory + c.Start run only inside sf.Do → guaranteed exactly once per language.
+//     - Insert into cache only after a successful Start → allows retry on Start failure (REQ-UTIL-003-006).
 func (m *Manager) getOrSpawn(ctx context.Context, language string) (Client, error) {
-	// 빠른 경로: 준비된 클라이언트가 캐시에 있으면 즉시 반환 (락 → 해제 → 반환)
+	// Fast path: return immediately if a ready client is in the cache (lock → unlock → return).
 	m.mu.Lock()
 	existing, ok := m.clients[language]
 	if ok && existing.State() != StateShutdown {
@@ -348,11 +348,11 @@ func (m *Manager) getOrSpawn(ctx context.Context, language string) (Client, erro
 	}
 	m.mu.Unlock()
 
-	// singleflight 장벽: 동일 언어에 대한 동시 factory+Start 호출을 직렬화 (REQ-UTIL-003-004).
-	// sf.Do는 동일 키에 대해 in-flight 중인 호출이 있으면 모든 대기 호출자가 그 결과를 공유.
-	// 호출 완료 후 키는 자동으로 제거되어 다음 호출은 새로 실행됨 (REQ-UTIL-003-006 재시도 보장).
+	// singleflight barrier: serializes concurrent factory+Start calls for the same language (REQ-UTIL-003-004).
+	// sf.Do shares the result of an in-flight call with all waiting callers for the same key.
+	// After completion the key is automatically removed, so the next call runs fresh (REQ-UTIL-003-006 retry guarantee).
 	v, err, _ := m.sf.Do(language, func() (any, error) {
-		// sf.Do 내부 재확인: 다른 goroutine이 이미 클라이언트를 캐시에 삽입했을 수 있음
+		// Double-check inside sf.Do: another goroutine may have already inserted the client into the cache.
 		m.mu.Lock()
 		existing2, ok2 := m.clients[language]
 		if ok2 && existing2.State() != StateShutdown {
@@ -366,16 +366,16 @@ func (m *Manager) getOrSpawn(ctx context.Context, language string) (Client, erro
 			return nil, fmt.Errorf("lsp manager: no server config for language %q", language)
 		}
 
-		// factory 호출: 언어당 정확히 1회 실행됨 (REQ-UTIL-003-005)
+		// Call factory: runs exactly once per language (REQ-UTIL-003-005).
 		c := m.clientFactory(sc)
 
-		// Start 호출: 락 외부에서 실행 (블로킹 I/O 가능)
+		// Call Start: runs outside the lock (may block on I/O).
 		if err := c.Start(ctx); err != nil {
-			// Start 실패: 캐시에 삽입하지 않음 → 다음 호출 시 재시도 가능 (REQ-UTIL-003-006)
+			// Start failed: do not insert into cache → next call can retry (REQ-UTIL-003-006).
 			return nil, fmt.Errorf("lsp manager: failed to start client for language %q: %w", language, err)
 		}
 
-		// Start 성공 후에만 캐시에 삽입 (REQ-UTIL-003-006)
+		// Insert into cache only after a successful Start (REQ-UTIL-003-006).
 		m.mu.Lock()
 		m.clients[language] = c
 		m.mu.Unlock()
@@ -387,19 +387,19 @@ func (m *Manager) getOrSpawn(ctx context.Context, language string) (Client, erro
 	return v.(Client), nil
 }
 
-// reaper는 일정 간격으로 유휴 클라이언트를 종료하는 백그라운드 고루틴입니다.
+// reaper is the background goroutine that periodically shuts down idle clients.
 //
-// 동작:
-//   - reaperInterval마다 각 언어의 lastActivity를 확인
-//   - time.Since(lastActivity) > idleShutdownSeconds이면 graceful Shutdown
-//   - ctx.Done() 수신 시 reaperDone을 닫고 종료
+// Behavior:
+//   - Every reaperInterval, check lastActivity for each language.
+//   - If time.Since(lastActivity) > idleShutdownSeconds, perform a graceful Shutdown.
+//   - On ctx.Done(), close reaperDone and exit.
 func (m *Manager) reaper(ctx context.Context, done chan struct{}) {
 	defer close(done)
 
 	ticker := time.NewTicker(m.reaperInterval)
 	defer ticker.Stop()
 
-	// shutdownTimeout: 개별 클라이언트 graceful shutdown 시 사용
+	// shutdownTimeout: used for individual client graceful shutdown.
 	const shutdownTimeout = 5 * time.Second
 
 	for {
@@ -412,7 +412,7 @@ func (m *Manager) reaper(ctx context.Context, done chan struct{}) {
 	}
 }
 
-// reapIdleClients는 유휴 타임아웃을 초과한 클라이언트를 찾아 종료합니다.
+// reapIdleClients finds and shuts down clients that have exceeded the idle timeout.
 func (m *Manager) reapIdleClients(ctx context.Context, shutdownTimeout time.Duration) {
 	now := time.Now()
 

--- a/internal/lsp/core/manager_singleflight_test.go
+++ b/internal/lsp/core/manager_singleflight_test.go
@@ -11,17 +11,17 @@ import (
 	"github.com/modu-ai/moai-adk/internal/lsp/config"
 )
 
-// ─── AC-UTIL-003-003: singleflight.Group 필드 존재 확인 ────────────────────
+// ─── AC-UTIL-003-003: verify the singleflight.Group field is present ──────
 
-// TestManager_SingleflightField_Present는 Manager.sf 필드가 존재하고
-// 즉시 Do 호출이 가능한 zero-value 상태임을 확인한다 (AC-UTIL-003-003).
+// TestManager_SingleflightField_Present verifies that the Manager.sf field exists
+// and is in a zero-value ready state where Do can be invoked immediately (AC-UTIL-003-003).
 func TestManager_SingleflightField_Present(t *testing.T) {
 	t.Parallel()
 
 	m := NewManager(makeTestServersConfig())
 
-	// 같은 패키지에서 직접 필드 접근 — 필드가 없으면 컴파일 실패
-	// zero-value 준비 상태 검증: Do 호출이 정상적으로 동작해야 한다
+	// Direct field access from the same package — compile fails if the field is missing.
+	// Verify zero-value readiness: Do invocation must work normally.
 	called := false
 	val, err, shared := m.sf.Do("probe-key", func() (any, error) {
 		called = true
@@ -37,18 +37,18 @@ func TestManager_SingleflightField_Present(t *testing.T) {
 	if val != "result" {
 		t.Errorf("sf.Do value = %v, want 'result'", val)
 	}
-	_ = shared // 공유 여부는 이 테스트에서 검증하지 않음
+	_ = shared // sharing is not verified in this test
 }
 
-// ─── AC-UTIL-003-004: singleflight 장벽 ──────────────────────────────────
+// ─── AC-UTIL-003-004: singleflight barrier ────────────────────────────────
 
-// TestGetOrSpawn_SingleflightBarrier_SecondBlocksUntilFirst는
-// 두 번째 동시 getOrSpawn 호출이 첫 번째 factory 반환까지 차단됨을 확인한다 (AC-UTIL-003-004).
+// TestGetOrSpawn_SingleflightBarrier_SecondBlocksUntilFirst verifies that
+// the second concurrent getOrSpawn call is blocked until the first factory returns (AC-UTIL-003-004).
 func TestGetOrSpawn_SingleflightBarrier_SecondBlocksUntilFirst(t *testing.T) {
 	t.Parallel()
 
 	var factoryCount atomic.Int32
-	// factory가 차단 해제 신호를 받을 때까지 지연됨
+	// factory waits until it receives the unblock signal
 	firstStarted := make(chan struct{})
 	unblock := make(chan struct{})
 
@@ -56,12 +56,12 @@ func TestGetOrSpawn_SingleflightBarrier_SecondBlocksUntilFirst(t *testing.T) {
 		makeTestServersConfig(),
 		WithClientFactory(func(cfg config.ServerConfig) Client {
 			factoryCount.Add(1)
-			// 첫 번째 factory 진입 신호
+			// signal that the first factory entered
 			select {
 			case firstStarted <- struct{}{}:
 			default:
 			}
-			// 차단 해제 신호 대기
+			// wait for the unblock signal
 			<-unblock
 			return &fakeClient{state: StateSpawning}
 		}),
@@ -69,7 +69,7 @@ func TestGetOrSpawn_SingleflightBarrier_SecondBlocksUntilFirst(t *testing.T) {
 
 	ctx := context.Background()
 
-	// 첫 번째 고루틴 시작
+	// Start the first goroutine.
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
@@ -77,14 +77,14 @@ func TestGetOrSpawn_SingleflightBarrier_SecondBlocksUntilFirst(t *testing.T) {
 		_, _ = m.getOrSpawn(ctx, "go")
 	}()
 
-	// factory가 시작될 때까지 대기
+	// Wait until the factory starts.
 	select {
 	case <-firstStarted:
 	case <-time.After(2 * time.Second):
 		t.Fatal("first factory did not start within 2s")
 	}
 
-	// 두 번째 고루틴 시작: factory가 차단 중인 상태에서 getOrSpawn 호출
+	// Start the second goroutine: invoke getOrSpawn while the factory is blocked.
 	done2 := make(chan struct{})
 	wg.Add(1)
 	go func() {
@@ -93,30 +93,30 @@ func TestGetOrSpawn_SingleflightBarrier_SecondBlocksUntilFirst(t *testing.T) {
 		_, _ = m.getOrSpawn(ctx, "go")
 	}()
 
-	// 두 번째 고루틴이 즉시 반환되지 않아야 한다 (sf.Do 차단 중)
+	// The second goroutine must not return immediately (sf.Do is blocking).
 	select {
 	case <-done2:
-		// 두 번째가 즉시 반환되었다 — 빠른 경로(캐시 히트)를 탔을 수 있음.
-		// factory 호출 횟수가 1이면 sf.Do를 통한 공유를 의미하므로 허용한다.
+		// The second caller returned early — it may have taken the fast path (cache hit).
+		// If the factory call count is 1, this means sharing via sf.Do, which is acceptable.
 		t.Logf("second caller returned early (cache hit path) — factory calls: %d", factoryCount.Load())
 	case <-time.After(50 * time.Millisecond):
-		// 예상된 동작: 두 번째 고루틴이 sf.Do 내부에서 차단 중
+		// expected behavior: the second goroutine is blocked inside sf.Do
 	}
 
-	// factory 차단 해제
+	// Release the factory.
 	close(unblock)
 	wg.Wait()
 
-	// factory는 정확히 1번 호출되어야 한다
+	// The factory must have been called exactly once.
 	if got := factoryCount.Load(); got != 1 {
 		t.Errorf("factory called %d times, want 1 (singleflight should deduplicate)", got)
 	}
 }
 
-// ─── AC-UTIL-003-005: 16 goroutine 동시 RouteFor, factory 정확히 1회 ───────
+// ─── AC-UTIL-003-005: 16 concurrent RouteFor goroutines, factory exactly once ───
 
-// TestRouteFor_ExactlyOnce_16ConcurrentCallers는 16개의 동시 RouteFor 호출에서
-// clientFactory가 정확히 1회 호출됨을 확인한다 (AC-UTIL-003-005).
+// TestRouteFor_ExactlyOnce_16ConcurrentCallers verifies that across 16 concurrent
+// RouteFor invocations, clientFactory is called exactly once (AC-UTIL-003-005).
 func TestRouteFor_ExactlyOnce_16ConcurrentCallers(t *testing.T) {
 	t.Parallel()
 
@@ -126,7 +126,7 @@ func TestRouteFor_ExactlyOnce_16ConcurrentCallers(t *testing.T) {
 		makeTestServersConfig(),
 		WithClientFactory(func(cfg config.ServerConfig) Client {
 			factoryCount.Add(1)
-			// 동시성 시나리오를 더 두드러지게 만들기 위해 짧은 지연
+			// Short delay to make the concurrency scenario more pronounced.
 			time.Sleep(5 * time.Millisecond)
 			return &fakeClient{state: StateSpawning}
 		}),
@@ -139,7 +139,7 @@ func TestRouteFor_ExactlyOnce_16ConcurrentCallers(t *testing.T) {
 	ctx := context.Background()
 	var wg sync.WaitGroup
 
-	// 최대한 동시에 시작하기 위한 시작 게이트
+	// Start gate to start all goroutines as concurrently as possible.
 	startGate := make(chan struct{})
 
 	for i := 0; i < N; i++ {
@@ -151,16 +151,16 @@ func TestRouteFor_ExactlyOnce_16ConcurrentCallers(t *testing.T) {
 		}(i)
 	}
 
-	// 모든 고루틴이 준비된 후 동시 시작
+	// Start all goroutines simultaneously after they are ready.
 	close(startGate)
 	wg.Wait()
 
-	// factory는 정확히 1회 호출되어야 한다
+	// The factory must have been called exactly once.
 	if got := factoryCount.Load(); got != 1 {
 		t.Errorf("clientFactory called %d times, want exactly 1", got)
 	}
 
-	// 모든 호출이 에러 없이 완료되어야 한다
+	// All calls must complete without error.
 	for i := 0; i < N; i++ {
 		if errs[i] != nil {
 			t.Errorf("goroutine %d: RouteFor error = %v", i, errs[i])
@@ -170,7 +170,7 @@ func TestRouteFor_ExactlyOnce_16ConcurrentCallers(t *testing.T) {
 		}
 	}
 
-	// 모든 클라이언트가 동일한 포인터여야 한다
+	// All clients must be the same pointer.
 	for i := 1; i < N; i++ {
 		if clients[i] != clients[0] {
 			t.Errorf("goroutine %d: got different client pointer (want same as goroutine 0)", i)
@@ -178,10 +178,10 @@ func TestRouteFor_ExactlyOnce_16ConcurrentCallers(t *testing.T) {
 	}
 }
 
-// ─── AC-UTIL-003-006: Start 실패 시 캐시 부재 및 재시도 확인 ──────────────
+// ─── AC-UTIL-003-006: cache absent and retry on Start failure ─────────────
 
-// TestGetOrSpawn_StartError_CacheAbsentAndRetry는 c.Start 실패 시
-// 캐시에 클라이언트가 남지 않고 다음 호출에서 factory가 다시 호출됨을 확인한다 (AC-UTIL-003-006).
+// TestGetOrSpawn_StartError_CacheAbsentAndRetry verifies that on c.Start failure,
+// no client remains in the cache and the factory is invoked again on the next call (AC-UTIL-003-006).
 func TestGetOrSpawn_StartError_CacheAbsentAndRetry(t *testing.T) {
 	t.Parallel()
 
@@ -198,7 +198,7 @@ func TestGetOrSpawn_StartError_CacheAbsentAndRetry(t *testing.T) {
 
 	ctx := context.Background()
 
-	// 첫 번째 호출: Start 실패 → 에러 반환
+	// First call: Start fails → returns error.
 	c1, err1 := m.getOrSpawn(ctx, "go")
 	if err1 == nil {
 		t.Fatal("first getOrSpawn: expected error, got nil")
@@ -210,7 +210,7 @@ func TestGetOrSpawn_StartError_CacheAbsentAndRetry(t *testing.T) {
 		t.Errorf("first getOrSpawn: error = %v, want to wrap %v", err1, startErr)
 	}
 
-	// 캐시에 클라이언트가 없어야 한다
+	// The cache must not contain the client.
 	m.mu.Lock()
 	_, cacheHit := m.clients["go"]
 	m.mu.Unlock()
@@ -218,21 +218,21 @@ func TestGetOrSpawn_StartError_CacheAbsentAndRetry(t *testing.T) {
 		t.Error("cache should be absent after Start error (REQ-UTIL-003-006)")
 	}
 
-	// 두 번째 호출: factory가 다시 호출되어야 한다 (sf.Do 키가 해제됨)
+	// Second call: the factory must be invoked again (sf.Do key released).
 	_, _ = m.getOrSpawn(ctx, "go")
 	if got := callCount.Load(); got != 2 {
 		t.Errorf("factory called %d times total, want 2 (retry on second call)", got)
 	}
 }
 
-// ─── AC-UTIL-003-011: 경쟁 감지기 — 16 goroutine getOrSpawn ──────────────
+// ─── AC-UTIL-003-011: race detector — 16 goroutines getOrSpawn ────────────
 
-// TestGetOrSpawnConcurrent_RaceDetector는 16개 동시 getOrSpawn 호출에서
-// 데이터 경쟁이 발생하지 않음을 go test -race로 검증한다 (AC-UTIL-003-011).
+// TestGetOrSpawnConcurrent_RaceDetector verifies that 16 concurrent getOrSpawn calls
+// do not produce a data race when run under go test -race (AC-UTIL-003-011).
 //
-// 실행 방법: go test -race -run TestGetOrSpawnConcurrent ./internal/lsp/core/
+// Run with: go test -race -run TestGetOrSpawnConcurrent ./internal/lsp/core/
 func TestGetOrSpawnConcurrent_RaceDetector(t *testing.T) {
-	// t.Parallel()은 -race 단독 실행 시 간섭을 줄이기 위해 의도적으로 생략
+	// t.Parallel() is intentionally omitted to reduce interference when running -race in isolation.
 
 	var spawnCount atomic.Int32
 
@@ -240,7 +240,7 @@ func TestGetOrSpawnConcurrent_RaceDetector(t *testing.T) {
 		makeTestServersConfig(),
 		WithClientFactory(func(cfg config.ServerConfig) Client {
 			spawnCount.Add(1)
-			// 실제 경쟁 조건을 유발할 수 있도록 약간의 지연
+			// Small delay to provoke real race conditions.
 			time.Sleep(2 * time.Millisecond)
 			return &fakeClient{state: StateSpawning}
 		}),
@@ -257,7 +257,7 @@ func TestGetOrSpawnConcurrent_RaceDetector(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			<-startGate
-			// RouteFor는 lastActivity 업데이트도 수행하므로 더 넓은 경쟁 표면을 커버함
+			// RouteFor also updates lastActivity, so it covers a wider race surface.
 			_, _ = m.RouteFor(ctx, "/workspace/main.go")
 		}()
 	}
@@ -265,8 +265,8 @@ func TestGetOrSpawnConcurrent_RaceDetector(t *testing.T) {
 	close(startGate)
 	wg.Wait()
 
-	// 경쟁 감지기가 이 테스트를 통과하면 데이터 경쟁 없음
-	// factory 호출 횟수는 1이어야 함 (singleflight 보장)
+	// If the race detector passes this test, no data race occurred.
+	// The factory call count must be 1 (singleflight guarantee).
 	if got := spawnCount.Load(); got != 1 {
 		t.Errorf("spawnCount = %d, want 1 (singleflight should prevent duplicates)", got)
 	}

--- a/internal/lsp/core/manager_test.go
+++ b/internal/lsp/core/manager_test.go
@@ -18,8 +18,8 @@ import (
 // Test helpers: fakeClient, fakeClientFactory
 // ---------------------------------------------------------------------------
 
-// fakeClient는 테스트용 Client 구현체입니다.
-// 실제 subprocess를 생성하지 않고 동작을 시뮬레이션합니다.
+// fakeClient is a test Client implementation.
+// It simulates behavior without spawning a real subprocess.
 type fakeClient struct {
 	mu           sync.Mutex
 	state        ClientState
@@ -69,8 +69,8 @@ func (f *fakeClient) Capabilities() ServerCapabilities {
 	return ServerCapabilities{}
 }
 
-// fakeClientFactory는 fakeClient를 생성하는 팩토리 함수를 반환합니다.
-// spawnCount로 생성 횟수를 추적합니다.
+// fakeClientFactory returns a factory function that creates fakeClients.
+// It tracks the number of creations via spawnCount.
 func fakeClientFactory(spawnCount *atomic.Int32, clients *[]*fakeClient, mu *sync.Mutex, startErr error) func(config.ServerConfig) Client {
 	return func(cfg config.ServerConfig) Client {
 		spawnCount.Add(1)
@@ -87,7 +87,7 @@ func fakeClientFactory(spawnCount *atomic.Int32, clients *[]*fakeClient, mu *syn
 	}
 }
 
-// makeTestServersConfig는 테스트용 ServersConfig를 생성합니다.
+// makeTestServersConfig creates a ServersConfig for testing.
 func makeTestServersConfig() *config.ServersConfig {
 	return &config.ServersConfig{
 		Servers: map[string]config.ServerConfig{
@@ -117,10 +117,10 @@ func makeTestServersConfig() *config.ServersConfig {
 }
 
 // ---------------------------------------------------------------------------
-// T-015: detectLanguage 테스트
+// T-015: detectLanguage tests
 // ---------------------------------------------------------------------------
 
-// TestDetectLanguage_GoExtension은 .go 파일이 "go" 언어로 감지되는지 테스트합니다.
+// TestDetectLanguage_GoExtension tests that .go files are detected as "go" language.
 func TestDetectLanguage_GoExtension(t *testing.T) {
 	cfg := makeTestServersConfig()
 	m := NewManager(cfg)
@@ -134,7 +134,7 @@ func TestDetectLanguage_GoExtension(t *testing.T) {
 	}
 }
 
-// TestDetectLanguage_PythonExtension은 .py 파일이 "python" 언어로 감지되는지 테스트합니다.
+// TestDetectLanguage_PythonExtension tests that .py files are detected as "python" language.
 func TestDetectLanguage_PythonExtension(t *testing.T) {
 	cfg := makeTestServersConfig()
 	m := NewManager(cfg)
@@ -148,7 +148,7 @@ func TestDetectLanguage_PythonExtension(t *testing.T) {
 	}
 }
 
-// TestDetectLanguage_TypeScriptExtension은 .ts 파일이 "typescript" 언어로 감지되는지 테스트합니다.
+// TestDetectLanguage_TypeScriptExtension tests that .ts files are detected as "typescript" language.
 func TestDetectLanguage_TypeScriptExtension(t *testing.T) {
 	cfg := makeTestServersConfig()
 	m := NewManager(cfg)
@@ -162,7 +162,7 @@ func TestDetectLanguage_TypeScriptExtension(t *testing.T) {
 	}
 }
 
-// TestDetectLanguage_TsxExtension은 .tsx 파일이 "typescript" 언어로 감지되는지 테스트합니다.
+// TestDetectLanguage_TsxExtension tests that .tsx files are detected as "typescript" language.
 func TestDetectLanguage_TsxExtension(t *testing.T) {
 	cfg := makeTestServersConfig()
 	m := NewManager(cfg)
@@ -176,7 +176,7 @@ func TestDetectLanguage_TsxExtension(t *testing.T) {
 	}
 }
 
-// TestDetectLanguage_UnknownExtension은 알 수 없는 확장자에 대해 (empty, false)를 반환하는지 테스트합니다.
+// TestDetectLanguage_UnknownExtension tests that unknown extensions return (empty, false).
 func TestDetectLanguage_UnknownExtension(t *testing.T) {
 	cfg := makeTestServersConfig()
 	m := NewManager(cfg)
@@ -190,7 +190,7 @@ func TestDetectLanguage_UnknownExtension(t *testing.T) {
 	}
 }
 
-// TestDetectLanguage_NoExtension은 확장자가 없는 파일에 대해 (empty, false)를 반환하는지 테스트합니다.
+// TestDetectLanguage_NoExtension tests that files without an extension return (empty, false).
 func TestDetectLanguage_NoExtension(t *testing.T) {
 	cfg := makeTestServersConfig()
 	m := NewManager(cfg)
@@ -204,11 +204,11 @@ func TestDetectLanguage_NoExtension(t *testing.T) {
 	}
 }
 
-// TestDetectLanguage_AmbiguousExtension_ResolvedByMarker는 확장자 중복 시 프로젝트 마커로
-// 언어가 결정되는지 테스트합니다.
-// tsconfig.json이 있는 임시 디렉토리에서 .ts 확장자를 사용합니다.
+// TestDetectLanguage_AmbiguousExtension_ResolvedByMarker tests that language is determined
+// by project markers when multiple languages share the same extension.
+// Uses .ts extension in a temp directory with tsconfig.json.
 func TestDetectLanguage_AmbiguousExtension_ResolvedByMarker(t *testing.T) {
-	// 두 언어가 같은 확장자를 공유하는 설정 구성
+	// configure two languages sharing the same extension
 	cfg := &config.ServersConfig{
 		Servers: map[string]config.ServerConfig{
 			"typescript": {
@@ -226,7 +226,7 @@ func TestDetectLanguage_AmbiguousExtension_ResolvedByMarker(t *testing.T) {
 		},
 	}
 
-	// tsconfig.json이 있는 임시 디렉토리 구성
+	// set up a temp directory with tsconfig.json
 	dir := t.TempDir()
 	tsconfig := filepath.Join(dir, "tsconfig.json")
 	if err := os.WriteFile(tsconfig, []byte("{}"), 0o644); err != nil {
@@ -244,10 +244,10 @@ func TestDetectLanguage_AmbiguousExtension_ResolvedByMarker(t *testing.T) {
 	}
 }
 
-// TestDetectLanguage_AmbiguousExtension_FallsBackToFirstCandidate는
-// 마커가 없을 때 첫 번째 후보 언어(설정 순서 기준)가 선택되는지 테스트합니다.
+// TestDetectLanguage_AmbiguousExtension_FallsBackToFirstCandidate tests that the first
+// candidate language (by config order) is selected when no marker is present.
 func TestDetectLanguage_AmbiguousExtension_FallsBackToFirstCandidate(t *testing.T) {
-	// 명확한 순서를 위해 두 언어가 .ext를 공유하는 설정
+	// two languages sharing .ext for unambiguous ordering
 	cfg := &config.ServersConfig{
 		Servers: map[string]config.ServerConfig{
 			"langA": {
@@ -265,7 +265,7 @@ func TestDetectLanguage_AmbiguousExtension_FallsBackToFirstCandidate(t *testing.
 		},
 	}
 
-	// 마커 파일이 없는 임시 디렉토리
+	// temp directory with no marker files
 	dir := t.TempDir()
 	m := NewManager(cfg)
 	filePath := filepath.Join(dir, "file.ext")
@@ -274,14 +274,14 @@ func TestDetectLanguage_AmbiguousExtension_FallsBackToFirstCandidate(t *testing.
 	if !ok {
 		t.Fatal("expected ok=true for known extension even without markers")
 	}
-	// langA 또는 langB 중 하나여야 함 (결정론적으로 첫 번째)
+	// must be one of langA or langB (deterministically the first)
 	if lang != "langA" && lang != "langB" {
 		t.Fatalf("expected one of langA or langB, got %q", lang)
 	}
 }
 
-// TestRouteFor_NoLanguageDetected는 알 수 없는 파일 확장자로 RouteFor를 호출하면
-// ErrNoLanguageDetected가 반환되는지 테스트합니다.
+// TestRouteFor_NoLanguageDetected tests that ErrNoLanguageDetected is returned
+// when RouteFor is called with an unknown file extension.
 func TestRouteFor_NoLanguageDetected(t *testing.T) {
 	cfg := makeTestServersConfig()
 	var spawnCount atomic.Int32
@@ -299,10 +299,10 @@ func TestRouteFor_NoLanguageDetected(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// T-016: Manager lazy spawn 테스트
+// T-016: Manager lazy spawn tests
 // ---------------------------------------------------------------------------
 
-// TestRouteFor_SpawnsClientOnFirstCall은 RouteFor 최초 호출 시 클라이언트를 생성하는지 테스트합니다.
+// TestRouteFor_SpawnsClientOnFirstCall tests that a client is spawned on the first RouteFor call.
 func TestRouteFor_SpawnsClientOnFirstCall(t *testing.T) {
 	cfg := makeTestServersConfig()
 	var spawnCount atomic.Int32
@@ -322,8 +322,8 @@ func TestRouteFor_SpawnsClientOnFirstCall(t *testing.T) {
 	}
 }
 
-// TestRouteFor_ReturnsSameClientOnSecondCall은 동일 언어로 두 번 RouteFor를 호출해도
-// 팩토리가 한 번만 호출되는지 테스트합니다.
+// TestRouteFor_ReturnsSameClientOnSecondCall tests that the factory is called only once
+// even when RouteFor is called twice for the same language.
 func TestRouteFor_ReturnsSameClientOnSecondCall(t *testing.T) {
 	cfg := makeTestServersConfig()
 	var spawnCount atomic.Int32
@@ -350,8 +350,8 @@ func TestRouteFor_ReturnsSameClientOnSecondCall(t *testing.T) {
 	}
 }
 
-// TestRouteFor_ConcurrentSpawnOnlyOnce는 50개 고루틴이 동일 언어로 RouteFor를 동시에
-// 호출해도 팩토리가 정확히 1번만 호출되는지 테스트합니다.
+// TestRouteFor_ConcurrentSpawnOnlyOnce tests that the factory is called exactly once
+// even when 50 goroutines call RouteFor concurrently for the same language.
 func TestRouteFor_ConcurrentSpawnOnlyOnce(t *testing.T) {
 	cfg := makeTestServersConfig()
 	var spawnCount atomic.Int32
@@ -385,22 +385,22 @@ func TestRouteFor_ConcurrentSpawnOnlyOnce(t *testing.T) {
 	}
 }
 
-// TestRouteFor_SpawnErrorReleasesClient는 Start가 실패하면 클라이언트가 해제되고
-// 다음 호출 시 재시도하는지 테스트합니다.
+// TestRouteFor_SpawnErrorReleasesClient tests that the client is released when Start fails
+// and the next call retries.
 func TestRouteFor_SpawnErrorReleasesClient(t *testing.T) {
 	cfg := makeTestServersConfig()
 
 	startErr := errors.New("fake start error")
 	var callCount atomic.Int32
 
-	// 첫 번째 호출은 실패, 두 번째 호출은 성공하는 팩토리
+	// factory that fails on the first call and succeeds on the second
 	factory := func(sc config.ServerConfig) Client {
 		callCount.Add(1)
 		call := callCount.Load()
 		if call == 1 {
 			return &fakeClient{state: StateSpawning, startErr: startErr}
 		}
-		return &fakeClient{state: StateSpawning} // 두 번째는 성공
+		return &fakeClient{state: StateSpawning} // second call succeeds
 	}
 
 	m := NewManager(cfg, WithClientFactory(factory))
@@ -410,7 +410,7 @@ func TestRouteFor_SpawnErrorReleasesClient(t *testing.T) {
 	}
 	defer m.Shutdown(context.Background()) //nolint:errcheck
 
-	// 첫 번째 호출: Start 실패
+	// first call: Start fails
 	_, err := m.RouteFor(context.Background(), "/path/to/main.go")
 	if err == nil {
 		t.Fatal("expected error from RouteFor with failing client start, got nil")
@@ -419,7 +419,7 @@ func TestRouteFor_SpawnErrorReleasesClient(t *testing.T) {
 		t.Fatalf("expected startErr in chain, got: %v", err)
 	}
 
-	// 두 번째 호출: 성공해야 함 (첫 번째 실패한 클라이언트가 해제됨)
+	// second call: must succeed (failed client from first call is released)
 	_, err2 := m.RouteFor(context.Background(), "/path/to/main.go")
 	if err2 != nil {
 		t.Fatalf("expected second RouteFor to succeed, got: %v", err2)
@@ -429,7 +429,7 @@ func TestRouteFor_SpawnErrorReleasesClient(t *testing.T) {
 	}
 }
 
-// TestRouteFor_UpdatesLastActivity는 RouteFor가 lastActivity를 업데이트하는지 테스트합니다.
+// TestRouteFor_UpdatesLastActivity tests that RouteFor updates lastActivity.
 func TestRouteFor_UpdatesLastActivity(t *testing.T) {
 	cfg := makeTestServersConfig()
 	var spawnCount atomic.Int32
@@ -457,11 +457,11 @@ func TestRouteFor_UpdatesLastActivity(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// T-017: Manager idle shutdown 테스트
+// T-017: Manager idle shutdown tests
 // ---------------------------------------------------------------------------
 
-// TestManager_ReaperShutsDownIdleClient는 유휴 타임아웃 후 클라이언트가 종료되는지 테스트합니다.
-// WithIdleShutdownSeconds(0) + 매우 짧은 reaper 간격을 사용합니다.
+// TestManager_ReaperShutsDownIdleClient tests that a client is shut down after the idle timeout.
+// Uses WithIdleShutdownSeconds(0) + a very short reaper interval.
 func TestManager_ReaperShutsDownIdleClient(t *testing.T) {
 	cfg := makeTestServersConfig()
 
@@ -472,7 +472,7 @@ func TestManager_ReaperShutsDownIdleClient(t *testing.T) {
 	factory := fakeClientFactory(&spawnCount, &clients, &clientsMu, nil)
 	m := NewManager(cfg,
 		WithClientFactory(factory),
-		WithIdleShutdownSeconds(0),         // 0초 = 즉시 만료
+		WithIdleShutdownSeconds(0),         // 0 seconds = expires immediately
 		WithReaperInterval(5*time.Millisecond),
 	)
 
@@ -482,13 +482,13 @@ func TestManager_ReaperShutsDownIdleClient(t *testing.T) {
 	}
 	defer m.Shutdown(ctx) //nolint:errcheck
 
-	// 클라이언트 생성 (RouteFor 호출)
+	// create a client (via RouteFor call)
 	_, err := m.RouteFor(ctx, "/path/to/main.go")
 	if err != nil {
 		t.Fatalf("RouteFor failed: %v", err)
 	}
 
-	// reaper가 idle 클라이언트를 종료할 때까지 대기
+	// wait until reaper shuts down the idle client
 	deadline := time.Now().Add(500 * time.Millisecond)
 	for time.Now().Before(deadline) {
 		clientsMu.Lock()
@@ -501,15 +501,15 @@ func TestManager_ReaperShutsDownIdleClient(t *testing.T) {
 		}
 		clientsMu.Unlock()
 		if count > 0 && shutCalled > 0 {
-			return // 성공
+			return // success
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatal("reaper did not shut down idle client within deadline")
 }
 
-// TestManager_ReaperDoesNotShutdownActiveClient는 활성 클라이언트는 reaper가 종료하지
-// 않는지 테스트합니다.
+// TestManager_ReaperDoesNotShutdownActiveClient tests that the reaper does not
+// shut down an active client.
 func TestManager_ReaperDoesNotShutdownActiveClient(t *testing.T) {
 	cfg := makeTestServersConfig()
 
@@ -520,7 +520,7 @@ func TestManager_ReaperDoesNotShutdownActiveClient(t *testing.T) {
 	factory := fakeClientFactory(&spawnCount, &clients, &clientsMu, nil)
 	m := NewManager(cfg,
 		WithClientFactory(factory),
-		WithIdleShutdownSeconds(60),        // 60초 타임아웃 — 테스트 중에는 만료되지 않음
+		WithIdleShutdownSeconds(60),        // 60-second timeout — will not expire during test
 		WithReaperInterval(5*time.Millisecond),
 	)
 
@@ -535,7 +535,7 @@ func TestManager_ReaperDoesNotShutdownActiveClient(t *testing.T) {
 		t.Fatalf("RouteFor failed: %v", err)
 	}
 
-	// reaper가 몇 번 돌 시간 동안 대기
+	// wait for the reaper to cycle a few times
 	time.Sleep(50 * time.Millisecond)
 
 	clientsMu.Lock()
@@ -547,8 +547,8 @@ func TestManager_ReaperDoesNotShutdownActiveClient(t *testing.T) {
 	}
 }
 
-// TestManager_Shutdown_CancelsReaperPromptly는 Shutdown 호출 시 reaper가 100ms 이내에
-// 종료되는지 테스트합니다.
+// TestManager_Shutdown_CancelsReaperPromptly tests that the reaper terminates within
+// 100ms when Shutdown is called.
 func TestManager_Shutdown_CancelsReaperPromptly(t *testing.T) {
 	cfg := makeTestServersConfig()
 	var spawnCount atomic.Int32
@@ -573,8 +573,8 @@ func TestManager_Shutdown_CancelsReaperPromptly(t *testing.T) {
 	}
 }
 
-// TestManager_Shutdown_AggregatesClientErrors는 클라이언트 종료 시 에러가 집계되어
-// 반환되는지 테스트합니다.
+// TestManager_Shutdown_AggregatesClientErrors tests that errors from client shutdown
+// are aggregated and returned.
 func TestManager_Shutdown_AggregatesClientErrors(t *testing.T) {
 	cfg := makeTestServersConfig()
 
@@ -594,13 +594,13 @@ func TestManager_Shutdown_AggregatesClientErrors(t *testing.T) {
 		t.Fatalf("Manager.Start failed: %v", err)
 	}
 
-	// 클라이언트 생성
+	// create a client
 	_, err := m.RouteFor(ctx, "/path/to/main.go")
 	if err != nil {
 		t.Fatalf("RouteFor failed: %v", err)
 	}
 
-	// Shutdown — 클라이언트 에러가 집계되어야 함
+	// Shutdown — client errors must be aggregated
 	shutErr := m.Shutdown(ctx)
 	if shutErr == nil {
 		t.Fatal("expected Shutdown to return aggregated error, got nil")
@@ -610,7 +610,7 @@ func TestManager_Shutdown_AggregatesClientErrors(t *testing.T) {
 	}
 }
 
-// TestManager_Shutdown_ClearsClientsMap는 Shutdown 후 clients 맵이 비워지는지 테스트합니다.
+// TestManager_Shutdown_ClearsClientsMap tests that the clients map is emptied after Shutdown.
 func TestManager_Shutdown_ClearsClientsMap(t *testing.T) {
 	cfg := makeTestServersConfig()
 	var spawnCount atomic.Int32
@@ -639,15 +639,15 @@ func TestManager_Shutdown_ClearsClientsMap(t *testing.T) {
 	}
 }
 
-// TestErrNoLanguageDetected_Sentinel은 ErrNoLanguageDetected가 errors.Is로 감지 가능한
-// 센티넬인지 테스트합니다.
+// TestErrNoLanguageDetected_Sentinel tests that ErrNoLanguageDetected is a sentinel
+// detectable via errors.Is.
 func TestErrNoLanguageDetected_Sentinel(t *testing.T) {
 	if ErrNoLanguageDetected == nil {
 		t.Fatal("ErrNoLanguageDetected should not be nil")
 	}
 	wrapped := errors.New("outer: " + ErrNoLanguageDetected.Error())
-	// wrapped는 errors.Is로 감지되지 않음 (의도적)
-	// 진짜 sentinel은 직접 비교 가능해야 함
+	// wrapped is not detectable via errors.Is (intentional)
+	// the true sentinel must be directly comparable
 	if !errors.Is(ErrNoLanguageDetected, ErrNoLanguageDetected) {
 		t.Fatal("ErrNoLanguageDetected should be detectable via errors.Is with itself")
 	}

--- a/internal/lsp/core/queries.go
+++ b/internal/lsp/core/queries.go
@@ -9,7 +9,7 @@ import (
 	"github.com/modu-ai/moai-adk/internal/lsp/transport"
 )
 
-// LSP 쿼리 메서드 상수 (하드코딩 방지).
+// LSP query method constants (prevent hard-coding).
 const (
 	methodReferences = "textDocument/references"
 	methodDefinition = "textDocument/definition"
@@ -17,17 +17,17 @@ const (
 
 // GetDiagnostics returns the latest diagnostics for path from the push-model cache (REQ-LC-002b).
 //
-// 동작 방식:
-//   - 서버가 push한 textDocument/publishDiagnostics 알림을 Start()에서 등록한 핸들러가 캐시에 저장
-//   - GetDiagnostics는 해당 캐시에서 즉시 반환 (blocking I/O 없음)
-//   - URI가 문서 캐시에 없으면 ErrFileNotOpen 반환
+// Behavior:
+//   - The handler registered in Start() stores server-pushed textDocument/publishDiagnostics notifications in the cache.
+//   - GetDiagnostics returns immediately from that cache (no blocking I/O).
+//   - Returns ErrFileNotOpen if the URI is not in the document cache.
 //
-// @MX:ANCHOR: [AUTO] GetDiagnostics — LSP 진단 쿼리 공개 API
-// @MX:REASON: fan_in >= 3 — Ralph 엔진, Quality Gates, LOOP 커맨드, Manager, 통합 테스트에서 호출됨
+// @MX:ANCHOR: [AUTO] GetDiagnostics — public API for LSP diagnostic queries
+// @MX:REASON: fan_in >= 3 — called by Ralph engine, Quality Gates, LOOP command, Manager, and integration tests
 func (c *client) GetDiagnostics(_ context.Context, path string) ([]lsp.Diagnostic, error) {
 	uri := pathToURI(path)
 
-	// ErrFileNotOpen: 문서 캐시에 없으면 반환 (REQ-LC-002b 규칙: 호출자가 먼저 OpenFile 해야 함)
+	// ErrFileNotOpen: returned when the URI is not in the document cache (REQ-LC-002b rule: caller must call OpenFile first).
 	snap := c.docs.snapshot()
 	if _, ok := snap[uri]; !ok {
 		return nil, ErrFileNotOpen
@@ -37,7 +37,7 @@ func (c *client) GetDiagnostics(_ context.Context, path string) ([]lsp.Diagnosti
 	diags := c.diagnostics[uri]
 	c.diagnosticsMu.RUnlock()
 
-	// nil slice → empty slice (일관성)
+	// nil slice → empty slice (consistency).
 	if diags == nil {
 		return []lsp.Diagnostic{}, nil
 	}
@@ -48,11 +48,11 @@ func (c *client) GetDiagnostics(_ context.Context, path string) ([]lsp.Diagnosti
 
 // FindReferences returns all reference locations for the symbol at pos in path.
 //
-// 사전 조건 검사:
-//   - serverCaps.Supports("textDocument/references")가 false이면 ErrCapabilityUnsupported 반환
+// Precondition check:
+//   - Returns ErrCapabilityUnsupported if serverCaps.Supports("textDocument/references") is false.
 //
-// @MX:ANCHOR: [AUTO] FindReferences — LSP references 쿼리 공개 API
-// @MX:REASON: fan_in >= 3 — Ralph 엔진, Quality Gates, LOOP 커맨드, 통합 테스트에서 호출됨
+// @MX:ANCHOR: [AUTO] FindReferences — public API for LSP references queries
+// @MX:REASON: fan_in >= 3 — called by Ralph engine, Quality Gates, LOOP command, and integration tests
 func (c *client) FindReferences(ctx context.Context, path string, pos lsp.Position) ([]lsp.Location, error) {
 	if !c.serverCaps.Supports(methodReferences) {
 		return nil, fmt.Errorf("FindReferences: %w", ErrCapabilityUnsupported)
@@ -75,14 +75,14 @@ func (c *client) FindReferences(ctx context.Context, path string, pos lsp.Positi
 
 // GotoDefinition returns definition locations for the symbol at pos in path.
 //
-// 사전 조건 검사:
-//   - serverCaps.Supports("textDocument/definition")가 false이면 ErrCapabilityUnsupported 반환
+// Precondition check:
+//   - Returns ErrCapabilityUnsupported if serverCaps.Supports("textDocument/definition") is false.
 //
-// LSP 응답은 Location, []Location, LocationLink[] 중 하나일 수 있습니다.
-// v1 구현에서는 []Location 또는 단일 Location을 처리합니다 (tolerant decoder).
+// The LSP response may be a Location, []Location, or LocationLink[].
+// The v1 implementation handles []Location or a single Location (tolerant decoder).
 //
-// @MX:ANCHOR: [AUTO] GotoDefinition — LSP definition 쿼리 공개 API
-// @MX:REASON: fan_in >= 3 — Ralph 엔진, Quality Gates, LOOP 커맨드, 통합 테스트에서 호출됨
+// @MX:ANCHOR: [AUTO] GotoDefinition — public API for LSP definition queries
+// @MX:REASON: fan_in >= 3 — called by Ralph engine, Quality Gates, LOOP command, and integration tests
 func (c *client) GotoDefinition(ctx context.Context, path string, pos lsp.Position) ([]lsp.Location, error) {
 	if !c.serverCaps.Supports(methodDefinition) {
 		return nil, fmt.Errorf("GotoDefinition: %w", ErrCapabilityUnsupported)
@@ -102,24 +102,24 @@ func (c *client) GotoDefinition(ctx context.Context, path string, pos lsp.Positi
 	return parseLocations(raw)
 }
 
-// parseLocations는 LSP 응답 raw JSON을 []Location으로 디코딩합니다.
+// parseLocations decodes a raw LSP response JSON into []Location.
 //
-// 처리 전략 (tolerant decoder):
-//  1. 배열 시도: []lsp.Location으로 언마샬
-//  2. 실패 시 단일 객체 시도: lsp.Location으로 언마샬 → []lsp.Location{} 래핑
-//  3. null 응답: 빈 슬라이스 반환
+// Decoding strategy (tolerant decoder):
+//  1. Try array: unmarshal as []lsp.Location.
+//  2. On failure, try single object: unmarshal as lsp.Location → wrap in []lsp.Location{}.
+//  3. null response: return an empty slice.
 func parseLocations(raw json.RawMessage) ([]lsp.Location, error) {
 	if len(raw) == 0 || string(raw) == "null" {
 		return []lsp.Location{}, nil
 	}
 
-	// 배열 먼저 시도
+	// Try array first.
 	var locs []lsp.Location
 	if err := json.Unmarshal(raw, &locs); err == nil {
 		return locs, nil
 	}
 
-	// 단일 객체 시도 (tolerant fallback)
+	// Try single object (tolerant fallback).
 	var single lsp.Location
 	if err := json.Unmarshal(raw, &single); err != nil {
 		return nil, fmt.Errorf("parseLocations: unable to decode as array or single location: %w", err)

--- a/internal/lsp/core/queries_test.go
+++ b/internal/lsp/core/queries_test.go
@@ -18,7 +18,8 @@ import (
 // fakeQueryTransport — supports Call responses + Notify recording + Notification simulation
 // ---------------------------------------------------------------------------
 
-// fakeQueryTransport는 Call 응답과 Notify를 기록하며 OnNotification 핸들러를 지원합니다.
+// fakeQueryTransport records Call responses and Notify calls and supports
+// OnNotification handlers.
 type fakeQueryTransport struct {
 	mu               sync.Mutex
 	callLog          []string
@@ -86,7 +87,7 @@ func (f *fakeQueryTransport) Close() error {
 	return nil
 }
 
-// simulateNotification은 서버가 push 알림을 보내는 것을 시뮬레이션합니다.
+// simulateNotification simulates the server pushing a notification.
 func (f *fakeQueryTransport) simulateNotification(method string, params json.RawMessage) {
 	f.mu.Lock()
 	handler, ok := f.notifHandlers[method]
@@ -116,7 +117,7 @@ func (f *fakeQueryTransport) callCount(method string) int {
 // Helpers
 // ---------------------------------------------------------------------------
 
-// makeQueryClient는 fakeQueryTransport로 시작된 테스트 클라이언트를 반환합니다.
+// makeQueryClient returns a test client constructed with fakeQueryTransport.
 func makeQueryClient(cfg config.ServerConfig, ft *fakeQueryTransport) *client {
 	return NewClient(cfg,
 		WithLauncherFunc((&fakeLauncher{}).Launch),
@@ -126,7 +127,7 @@ func makeQueryClient(cfg config.ServerConfig, ft *fakeQueryTransport) *client {
 	)
 }
 
-// startedQueryClient는 Start까지 완료된 클라이언트를 반환합니다.
+// startedQueryClient returns a client that has completed Start.
 func startedQueryClient(t *testing.T, cfg config.ServerConfig, ft *fakeQueryTransport) *client {
 	t.Helper()
 	c := makeQueryClient(cfg, ft)
@@ -168,12 +169,12 @@ func TestGetDiagnostics_AfterPublishDiagnostics(t *testing.T) {
 	c := startedQueryClient(t, cfg, ft)
 
 	ctx := context.Background()
-	// 파일을 먼저 열어야 함
+	// The file must be opened first.
 	if err := c.OpenFile(ctx, "/tmp/diag.go", "package main"); err != nil {
 		t.Fatalf("OpenFile: %v", err)
 	}
 
-	// 서버가 publishDiagnostics 알림을 보내는 시뮬레이션
+	// Simulate the server sending a publishDiagnostics notification.
 	uri := pathToURI("/tmp/diag.go")
 	diagPayload, _ := json.Marshal(map[string]any{
 		"uri": uri,
@@ -296,7 +297,7 @@ func TestFindReferences_Timeout(t *testing.T) {
 	cfg := config.ServerConfig{Language: "go", Command: "gopls"}
 	c := startedQueryClient(t, cfg, ft)
 
-	// 이미 만료된 컨텍스트
+	// Already-expired context.
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-1*time.Second))
 	defer cancel()
 
@@ -345,7 +346,7 @@ func TestGotoDefinition_SingleObjectResponse(t *testing.T) {
 	ft := newFakeQueryTransport()
 	cfg := config.ServerConfig{Language: "go", Command: "gopls"}
 
-	// 단일 Location 객체 (배열이 아님)
+	// Single Location object (not an array).
 	locJSON, _ := json.Marshal(lsp.Location{
 		URI:   "file:///single.go",
 		Range: lsp.Range{Start: lsp.Position{Line: 3, Character: 2}},

--- a/internal/lsp/core/state.go
+++ b/internal/lsp/core/state.go
@@ -59,7 +59,7 @@ var allowedTransitions = map[ClientState][]ClientState{
 
 // StateMachine manages ClientState transitions with thread-safety and logging.
 //
-// @MX:NOTE: [AUTO] StateMachine.Transition — 상태 전환은 slog.Debug로 기록되어 디버깅 가능
+// @MX:NOTE: [AUTO] StateMachine.Transition — state transitions are logged at slog.Debug for debuggability
 type StateMachine struct {
 	mu      sync.RWMutex
 	current ClientState

--- a/internal/lsp/core/state_test.go
+++ b/internal/lsp/core/state_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-// logBuffer는 slog 출력을 캡처하기 위한 thread-safe 버퍼.
+// logBuffer is a thread-safe buffer for capturing slog output.
 type logBuffer struct {
 	mu  sync.Mutex
 	buf bytes.Buffer
@@ -59,7 +59,7 @@ func TestStateMachine_AllowedTransitions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// 각 테스트는 독립된 StateMachine을 사용
+			// each test uses its own independent StateMachine
 			sm := newStateMachineAt(tt.from, nil)
 			if err := sm.Transition(tt.to); err != nil {
 				t.Errorf("Transition(%q→%q) unexpected error: %v", tt.from, tt.to, err)
@@ -111,7 +111,7 @@ func TestStateMachine_ShutdownTerminal(t *testing.T) {
 	if err := sm.Transition(StateShutdown); err != nil {
 		t.Fatalf("Transition to shutdown: %v", err)
 	}
-	// shutdown 이후 어떤 상태로도 전환 불가
+	// no transition allowed after shutdown
 	for _, next := range []ClientState{StateSpawning, StateInitializing, StateReady, StateDegraded} {
 		err := sm.Transition(next)
 		if err == nil {
@@ -166,7 +166,7 @@ func TestStateMachine_ConcurrentTransitionAndRead(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		// 단일 writer: spawning→initializing
+		// single writer: spawning→initializing
 		_ = sm.Transition(StateInitializing)
 	}()
 

--- a/internal/lsp/gopls/bridge.go
+++ b/internal/lsp/gopls/bridge.go
@@ -1,9 +1,9 @@
 package gopls
 
-// @MX:ANCHOR: [AUTO] Bridge — gopls 서브프로세스 생명주기 및 진단 수집의 핵심 타입
+// @MX:ANCHOR: [AUTO] Bridge — core type for gopls subprocess lifecycle management and diagnostic collection
 // @MX:REASON: fan_in >= 3 (NewBridge, GetDiagnostics, Close, readLoop, initialize)
-// @MX:WARN: [AUTO] readLoop는 goroutine이므로 shutdownCh로 반드시 종료해야 한다
-// @MX:REASON: goroutine 수명이 Bridge.Close()와 결합되며 누수 위험이 있다
+// @MX:WARN: [AUTO] readLoop runs as a goroutine and must be terminated via shutdownCh
+// @MX:REASON: goroutine lifetime is bound to Bridge.Close() and risks leaking
 
 import (
 	"context"
@@ -17,23 +17,23 @@ import (
 	"time"
 )
 
-// circuitBreakerThreshold는 서킷브레이커가 열리기 위한 연속 실패 횟수다.
-// REQ-GB-005 연계: 3회 실패 후 open 상태.
+// circuitBreakerThreshold is the number of consecutive failures required to open the circuit breaker.
+// Related to REQ-GB-005: open state after 3 failures.
 const circuitBreakerThreshold = 3
 
-// circuitBreakerOpenDuration은 서킷브레이커가 open 상태를 유지하는 시간이다.
+// circuitBreakerOpenDuration is the duration the circuit breaker remains in the open state.
 const circuitBreakerOpenDuration = 30 * time.Second
 
-// DiagnosticEvent는 publishDiagnostics 알림을 내부 채널로 전달하는 이벤트다.
+// DiagnosticEvent is the event that delivers publishDiagnostics notifications to the internal channel.
 type DiagnosticEvent struct {
 	URI         string
 	Diagnostics []Diagnostic
 }
 
-// Bridge는 gopls 서브프로세스와의 통신을 관리한다.
-// subprocess 생명주기, LSP 핸드셰이크, 진단 수집을 담당한다.
+// Bridge manages communication with the gopls subprocess.
+// Responsible for subprocess lifecycle, LSP handshake, and diagnostic collection.
 //
-// 모든 공개 메서드는 동시성 안전하다.
+// All public methods are concurrency-safe.
 type Bridge struct {
 	cmd    *exec.Cmd
 	stdin  io.WriteCloser
@@ -42,33 +42,33 @@ type Bridge struct {
 	writer *Writer
 	reader *Reader
 
-	// nextID는 JSON-RPC 요청 ID를 원자적으로 생성한다.
+	// nextID atomically generates JSON-RPC request IDs.
 	nextID atomic.Int64
-	// pendingReg는 진행 중인 요청의 응답 채널을 관리한다.
+	// pendingReg manages response channels for in-flight requests.
 	pendingReg PendingRegistry
 	dispatcher *NotificationDispatcher
 
-	// diagnosticsCh는 publishDiagnostics 알림을 GetDiagnostics에 전달한다.
-	// 버퍼 크기 16: overflow 시 오래된 이벤트를 폐기한다 (plan.md 위험 완화).
+	// diagnosticsCh delivers publishDiagnostics notifications to GetDiagnostics.
+	// Buffer size 16: older events are discarded on overflow (risk mitigation from plan.md).
 	diagnosticsCh chan DiagnosticEvent
 
-	// pendingMu는 pendingDiag 접근을 보호한다.
+	// pendingMu protects access to pendingDiag.
 	pendingMu sync.Mutex
-	// pendingDiag는 collectDiagnostics가 대기 중인 URI 이외의 파일에서 도착한 진단을 저장한다.
-	// 설계 선택: handlePublishDiagnostics는 모든 URI의 최신 진단을 pendingDiag에 저장한다.
-	// collectDiagnostics 진입 시 pendingDiag[uri]를 먼저 확인하고, 비매칭 이벤트도 pendingDiag에 저장한다.
-	// 이를 통해 다른 URI의 진단이 영구 유실되는 F2 결함을 해결한다.
+	// pendingDiag stores diagnostics that arrive for URIs other than the one collectDiagnostics is waiting on.
+	// Design choice: handlePublishDiagnostics stores the latest diagnostics for every URI in pendingDiag.
+	// On entry, collectDiagnostics checks pendingDiag[uri] first; non-matching events are also stored in pendingDiag.
+	// This resolves the F2 defect where diagnostics for other URIs were permanently lost.
 	pendingDiag map[string][]Diagnostic
 
-	// shutdownCh는 readLoop를 종료하는 신호 채널이다.
+	// shutdownCh is the signal channel used to terminate readLoop.
 	shutdownCh chan struct{}
-	// closeOnce는 shutdownCh가 한 번만 닫히도록 보장한다.
+	// closeOnce ensures shutdownCh is closed exactly once.
 	closeOnce sync.Once
 
-	// initialized는 LSP 핸드셰이크 완료 여부다.
+	// initialized indicates whether the LSP handshake has completed.
 	initialized atomic.Bool
 
-	// 서킷브레이커 상태
+	// Circuit breaker state.
 	cbMu          sync.Mutex
 	cbFailures    int
 	cbOpenUntil   time.Time
@@ -76,54 +76,54 @@ type Bridge struct {
 	config *Config
 }
 
-// NewBridge는 gopls 서브프로세스를 생성하고 LSP 핸드셰이크를 수행한 Bridge를 반환한다.
-// gopls 바이너리가 없거나 cfg.Enabled=false이면 (nil, nil)을 반환한다.
+// NewBridge creates a gopls subprocess, performs the LSP handshake, and returns the Bridge.
+// Returns (nil, nil) if the gopls binary is absent or cfg.Enabled=false.
 //
-// REQ-GB-002: gopls 없음 → slog.Warn 후 (nil, nil) 반환.
-// REQ-GB-003: 첫 번째 GetDiagnostics 호출 시가 아니라 명시적으로 호출할 때 초기화한다.
-//             (이 구현에서는 NewBridge 호출 시점에 초기화하고 lazy init은 선택 사항으로 남긴다.)
+// REQ-GB-002: gopls not found → log slog.Warn and return (nil, nil).
+// REQ-GB-003: Initialize on explicit call, not on the first GetDiagnostics call.
+//             (This implementation initializes at NewBridge call time; lazy init is left as an option.)
 func NewBridge(ctx context.Context, projectRoot string, cfg *Config) (*Bridge, error) {
 	if cfg == nil {
 		cfg = DefaultConfig()
 	}
-	// REQ-GB-051: 마스터 스위치가 false이면 nil 반환.
+	// REQ-GB-051: return nil if the master switch is false.
 	if !cfg.Enabled {
 		return nil, nil
 	}
 
-	// F5: 방어적 심층 검증 — LoadConfig를 우회한 직접 Config 주입에도 대응한다.
+	// F5: deep defensive validation — handles direct Config injection that bypasses LoadConfig.
 	if err := validateBinary(cfg.Binary); err != nil {
-		return nil, fmt.Errorf("gopls: NewBridge: 바이너리 검증 실패: %w", err)
+		return nil, fmt.Errorf("gopls: NewBridge: binary validation failed: %w", err)
 	}
 	if err := validateArgs(cfg.Args); err != nil {
-		return nil, fmt.Errorf("gopls: NewBridge: 인수 검증 실패: %w", err)
+		return nil, fmt.Errorf("gopls: NewBridge: argument validation failed: %w", err)
 	}
 
-	// REQ-GB-002: gopls 바이너리 존재 여부 확인.
+	// REQ-GB-002: check whether the gopls binary exists.
 	goplsPath, err := exec.LookPath(cfg.Binary)
 	if err != nil {
-		slog.Warn("gopls 브릿지 비활성화: 바이너리를 찾을 수 없음",
+		slog.Warn("gopls bridge disabled: binary not found",
 			"binary", cfg.Binary,
 			"hint", "go install golang.org/x/tools/gopls@latest",
 		)
 		return nil, nil
 	}
 
-	// gopls 서브프로세스를 시작한다.
+	// Start the gopls subprocess.
 	args := append([]string{"serve"}, cfg.Args...)
 	cmd := exec.CommandContext(ctx, goplsPath, args...)
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
-		return nil, fmt.Errorf("gopls: NewBridge: stdin pipe 생성 실패: %w", err)
+		return nil, fmt.Errorf("gopls: NewBridge: failed to create stdin pipe: %w", err)
 	}
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		return nil, fmt.Errorf("gopls: NewBridge: stdout pipe 생성 실패: %w", err)
+		return nil, fmt.Errorf("gopls: NewBridge: failed to create stdout pipe: %w", err)
 	}
 
 	if err := cmd.Start(); err != nil {
-		return nil, fmt.Errorf("gopls: NewBridge: 서브프로세스 시작 실패: %w", err)
+		return nil, fmt.Errorf("gopls: NewBridge: failed to start subprocess: %w", err)
 	}
 
 	b := &Bridge{
@@ -140,36 +140,36 @@ func NewBridge(ctx context.Context, projectRoot string, cfg *Config) (*Bridge, e
 	b.dispatcher = NewNotificationDispatcher()
 	b.dispatcher.Register("textDocument/publishDiagnostics", b.handlePublishDiagnostics)
 
-	// 읽기 루프를 시작한다.
+	// Start the read loop.
 	go b.readLoop()
 
-	// LSP 핸드셰이크 수행.
+	// Perform the LSP handshake.
 	initCtx, cancel := context.WithTimeout(ctx, cfg.InitTimeout)
 	defer cancel()
 	if err := b.initialize(initCtx, projectRoot); err != nil {
-		// 초기화 실패 시 프로세스를 강제 종료한다.
+		// Force-kill the process on initialization failure.
 		b.forceKill()
-		return nil, fmt.Errorf("gopls: NewBridge: 초기화 실패: %w", err)
+		return nil, fmt.Errorf("gopls: NewBridge: initialization failed: %w", err)
 	}
 
 	return b, nil
 }
 
-// initialize는 LSP 초기화 핸드셰이크를 수행한다.
-// REQ-GB-010, REQ-GB-011, REQ-GB-013 구현.
+// initialize performs the LSP initialization handshake.
+// Implements REQ-GB-010, REQ-GB-011, REQ-GB-013.
 func (b *Bridge) initialize(ctx context.Context, projectRoot string) error {
 	id := b.nextID.Add(1)
 	ch := b.pendingReg.Register(id)
 
-	// rootUri를 RFC 3986 준수 file:// URI로 변환한다.
-	// 직접 문자열 결합은 공백·유니코드·Windows 경로에서 LSP 사양을 위반한다.
+	// Convert rootUri to an RFC 3986-compliant file:// URI.
+	// Direct string concatenation violates the LSP specification for paths with spaces, Unicode, or Windows drive letters.
 	rootURI, err := pathToURI(projectRoot)
 	if err != nil {
 		b.pendingReg.Unregister(id)
-		return fmt.Errorf("gopls: initialize: rootURI 변환 실패: %w", err)
+		return fmt.Errorf("gopls: initialize: rootURI conversion failed: %w", err)
 	}
 
-	// InitOptions 설정.
+	// Configure InitOptions.
 	initOpts := map[string]any{"staticcheck": true}
 	if b.config != nil && len(b.config.InitOptions) > 0 {
 		initOpts = b.config.InitOptions
@@ -190,7 +190,7 @@ func (b *Bridge) initialize(ctx context.Context, projectRoot string) error {
 	paramsJSON, err := json.Marshal(params)
 	if err != nil {
 		b.pendingReg.Unregister(id)
-		return fmt.Errorf("gopls: initialize: params 직렬화 실패: %w", err)
+		return fmt.Errorf("gopls: initialize: params serialization failed: %w", err)
 	}
 
 	req := Request{
@@ -201,57 +201,57 @@ func (b *Bridge) initialize(ctx context.Context, projectRoot string) error {
 	}
 	if err := b.writer.Write(req); err != nil {
 		b.pendingReg.Unregister(id)
-		return fmt.Errorf("gopls: initialize: 요청 전송 실패: %w", err)
+		return fmt.Errorf("gopls: initialize: request send failed: %w", err)
 	}
 
-	// initialize 응답을 기다린다.
+	// Wait for the initialize response.
 	select {
 	case raw, ok := <-ch:
 		if !ok {
-			return fmt.Errorf("gopls: initialize: 응답 채널이 닫혔다")
+			return fmt.Errorf("gopls: initialize: response channel closed")
 		}
 		var resp Response
 		if err := json.Unmarshal(raw, &resp); err != nil {
-			return fmt.Errorf("gopls: initialize: 응답 역직렬화 실패: %w", err)
+			return fmt.Errorf("gopls: initialize: response deserialization failed: %w", err)
 		}
 		if resp.Error != nil {
-			return fmt.Errorf("gopls: initialize: 서버 오류 %d: %s", resp.Error.Code, resp.Error.Message)
+			return fmt.Errorf("gopls: initialize: server error %d: %s", resp.Error.Code, resp.Error.Message)
 		}
 	case <-ctx.Done():
 		b.pendingReg.Unregister(id)
-		return fmt.Errorf("gopls: initialize: 타임아웃: %w", ctx.Err())
+		return fmt.Errorf("gopls: initialize: timeout: %w", ctx.Err())
 	}
 
-	// initialized 알림을 전송한다.
-	// REQ-GB-011: initialize 응답 수신 후 initialized 알림 전송.
+	// Send the initialized notification.
+	// REQ-GB-011: send initialized notification after receiving the initialize response.
 	notif := Notification{
 		JSONRPC: "2.0",
 		Method:  "initialized",
 		Params:  json.RawMessage(`{}`),
 	}
 	if err := b.writer.Write(notif); err != nil {
-		return fmt.Errorf("gopls: initialize: initialized 알림 전송 실패: %w", err)
+		return fmt.Errorf("gopls: initialize: initialized notification send failed: %w", err)
 	}
 
 	b.initialized.Store(true)
 	return nil
 }
 
-// GetDiagnostics는 filePath를 gopls에 열고 publishDiagnostics 알림을 수집하여 반환한다.
-// 서킷브레이커가 열려 있으면 즉시 오류를 반환한다.
+// GetDiagnostics opens filePath in gopls, collects publishDiagnostics notifications, and returns them.
+// Returns an error immediately if the circuit breaker is open.
 //
-// REQ-GB-020, REQ-GB-021, REQ-GB-023 구현.
+// Implements REQ-GB-020, REQ-GB-021, REQ-GB-023.
 func (b *Bridge) GetDiagnostics(ctx context.Context, filePath string) ([]Diagnostic, error) {
-	// 서킷브레이커 확인.
+	// Check the circuit breaker.
 	if err := b.checkCircuitBreaker(); err != nil {
 		return nil, err
 	}
 
-	// didOpen 알림을 전송한다.
-	// RFC 3986 준수 URI로 변환한다. 공백·유니코드·Windows 경로 대응.
+	// Send the didOpen notification.
+	// Convert to an RFC 3986-compliant URI to handle paths with spaces, Unicode, and Windows drive letters.
 	uri, err := pathToURI(filePath)
 	if err != nil {
-		return nil, fmt.Errorf("gopls: GetDiagnostics: URI 변환 실패: %w", err)
+		return nil, fmt.Errorf("gopls: GetDiagnostics: URI conversion failed: %w", err)
 	}
 	params := DidOpenTextDocumentParams{
 		TextDocument: TextDocumentItem{
@@ -263,7 +263,7 @@ func (b *Bridge) GetDiagnostics(ctx context.Context, filePath string) ([]Diagnos
 	}
 	paramsJSON, err := json.Marshal(params)
 	if err != nil {
-		return nil, fmt.Errorf("gopls: GetDiagnostics: params 직렬화 실패: %w", err)
+		return nil, fmt.Errorf("gopls: GetDiagnostics: params serialization failed: %w", err)
 	}
 	notif := Notification{
 		JSONRPC: "2.0",
@@ -272,46 +272,46 @@ func (b *Bridge) GetDiagnostics(ctx context.Context, filePath string) ([]Diagnos
 	}
 	if err := b.writer.Write(notif); err != nil {
 		b.recordFailure()
-		return nil, fmt.Errorf("gopls: GetDiagnostics: didOpen 전송 실패: %w", err)
+		return nil, fmt.Errorf("gopls: GetDiagnostics: didOpen send failed: %w", err)
 	}
 
-	// publishDiagnostics 알림을 디바운스 창 동안 수집한다.
-	// REQ-GB-021: diagnostics_debounce_ms 동안 대기.
+	// Collect publishDiagnostics notifications during the debounce window.
+	// REQ-GB-021: wait for diagnostics_debounce_ms.
 	return b.collectDiagnostics(ctx, uri)
 }
 
-// collectDiagnostics는 diagnosticsCh에서 uri에 해당하는 진단을 수집한다.
-// 전체 타임아웃 ctx 안에서, 마지막 수신 후 debounce 창 동안 추가 이벤트가 없으면 반환한다.
+// collectDiagnostics collects diagnostics for uri from diagnosticsCh.
+// Returns after the debounce window elapses with no additional events, within the overall ctx timeout.
 //
-// F2 수정: 진입 시 pendingDiag[uri]를 먼저 확인하여 이미 도착한 진단을 즉시 사용한다.
-// 대기 중 비매칭 URI 이벤트는 채널에서 소비하되 pendingDiag에 저장하여 후속 호출에서 참조 가능하게 한다.
-// handlePublishDiagnostics도 항상 pendingDiag를 갱신하므로 채널 overflow 시에도 데이터가 보존된다.
+// F2 fix: on entry, check pendingDiag[uri] first to use diagnostics that have already arrived.
+// Non-matching URI events received while waiting are consumed from the channel and stored in pendingDiag for later calls.
+// handlePublishDiagnostics always refreshes pendingDiag, so data is preserved even on channel overflow.
 //
-// @MX:WARN: [AUTO] 채널 기반 debounce 로직 — timer 리셋 경쟁 조건 주의
-// @MX:REASON: timer.Stop()과 timer.Reset() 사이 race를 drain select로 방지한다
+// @MX:WARN: [AUTO] channel-based debounce logic — watch for race conditions around timer reset
+// @MX:REASON: a drain select between timer.Stop() and timer.Reset() prevents the race
 func (b *Bridge) collectDiagnostics(ctx context.Context, uri string) ([]Diagnostic, error) {
 	debounce := b.config.DebounceWindow
 
-	// 진입 시 pendingDiag[uri]를 확인한다.
-	// handlePublishDiagnostics가 이미 해당 URI의 진단을 저장했으면 즉시 사용한다.
+	// Check pendingDiag[uri] on entry.
+	// Use diagnostics already stored by handlePublishDiagnostics immediately.
 	b.pendingMu.Lock()
 	if diags, ok := b.pendingDiag[uri]; ok {
 		delete(b.pendingDiag, uri)
 		b.pendingMu.Unlock()
-		// pendingDiag에 저장된 진단을 초기값으로 설정하고 디바운스 창을 시작한다.
-		// 채널에 추가 이벤트가 올 수 있으므로 debounce를 그대로 수행한다.
+		// Use the stored diagnostics as the initial value and start the debounce window.
+		// Additional events may arrive on the channel, so debounce proceeds as normal.
 		return b.collectWithInitial(ctx, uri, diags, debounce)
 	}
 	b.pendingMu.Unlock()
 
-	// 전체 타임아웃 컨텍스트를 생성한다.
+	// Create the overall timeout context.
 	timeoutCtx, cancel := context.WithTimeout(ctx, b.config.Timeout)
 	defer cancel()
 
-	// 첫 번째 이벤트 대기: 전체 타임아웃까지 기다린다.
-	// 이벤트를 받으면 디바운스 창으로 전환한다.
+	// Wait for the first event up to the overall timeout.
+	// When an event arrives, switch to the debounce window.
 	debounceTimer := time.NewTimer(debounce)
-	debounceTimer.Stop() // 아직 시작하지 않는다.
+	debounceTimer.Stop() // Not started yet.
 	defer debounceTimer.Stop()
 
 	var result []Diagnostic
@@ -321,13 +321,13 @@ func (b *Bridge) collectDiagnostics(ctx context.Context, uri string) ([]Diagnost
 		select {
 		case event := <-b.diagnosticsCh:
 			if event.URI != uri {
-				// 다른 URI 이벤트: pendingDiag에 저장하고 계속 기다린다.
+				// Different URI event: store in pendingDiag and continue waiting.
 				b.pendingMu.Lock()
 				b.pendingDiag[event.URI] = event.Diagnostics
 				b.pendingMu.Unlock()
 				continue
 			}
-			// pendingDiag에서 소비했으므로 중복 저장을 제거한다.
+			// Already consumed from pendingDiag — remove duplicate entry.
 			b.pendingMu.Lock()
 			delete(b.pendingDiag, uri)
 			b.pendingMu.Unlock()
@@ -337,7 +337,7 @@ func (b *Bridge) collectDiagnostics(ctx context.Context, uri string) ([]Diagnost
 				received = true
 				debounceTimer.Reset(debounce)
 			} else {
-				// 추가 이벤트: 디바운스 타이머를 리셋한다.
+				// Additional event: reset the debounce timer.
 				if !debounceTimer.Stop() {
 					select {
 					case <-debounceTimer.C:
@@ -348,27 +348,27 @@ func (b *Bridge) collectDiagnostics(ctx context.Context, uri string) ([]Diagnost
 			}
 
 		case <-debounceTimer.C:
-			// 디바운스 창 내에 추가 이벤트 없음 → 수집 완료.
+			// No additional events within the debounce window → collection complete.
 			b.resetFailures()
 			return result, nil
 
 		case <-timeoutCtx.Done():
 			if received {
-				// 타임아웃이 됐지만 이미 진단을 받았으면 반환한다.
+				// Timed out but diagnostics were already received — return them.
 				b.resetFailures()
 				return result, nil
 			}
 			b.recordFailure()
-			return nil, fmt.Errorf("gopls: GetDiagnostics: 타임아웃")
+			return nil, fmt.Errorf("gopls: GetDiagnostics: timeout")
 
 		case <-b.shutdownCh:
-			return nil, fmt.Errorf("gopls: GetDiagnostics: 브릿지가 종료됐다")
+			return nil, fmt.Errorf("gopls: GetDiagnostics: bridge has been closed")
 		}
 	}
 }
 
-// collectWithInitial은 초기 진단 값을 가진 상태에서 디바운스 창을 수행한다.
-// pendingDiag에서 즉시 진단을 찾았을 때 호출된다.
+// collectWithInitial performs the debounce window starting with an initial set of diagnostics.
+// Called when diagnostics are found immediately in pendingDiag.
 func (b *Bridge) collectWithInitial(ctx context.Context, uri string, initial []Diagnostic, debounce time.Duration) ([]Diagnostic, error) {
 	timeoutCtx, cancel := context.WithTimeout(ctx, b.config.Timeout)
 	defer cancel()
@@ -382,13 +382,13 @@ func (b *Bridge) collectWithInitial(ctx context.Context, uri string, initial []D
 		select {
 		case event := <-b.diagnosticsCh:
 			if event.URI != uri {
-				// 다른 URI 이벤트: pendingDiag에 저장한다.
+				// Different URI event: store in pendingDiag.
 				b.pendingMu.Lock()
 				b.pendingDiag[event.URI] = event.Diagnostics
 				b.pendingMu.Unlock()
 				continue
 			}
-			// 같은 URI의 추가 이벤트: 결과를 갱신하고 타이머를 리셋한다.
+			// Additional event for the same URI: update result and reset the timer.
 			result = event.Diagnostics
 			if !debounceTimer.Stop() {
 				select {
@@ -407,35 +407,35 @@ func (b *Bridge) collectWithInitial(ctx context.Context, uri string, initial []D
 			return result, nil
 
 		case <-b.shutdownCh:
-			return nil, fmt.Errorf("gopls: GetDiagnostics: 브릿지가 종료됐다")
+			return nil, fmt.Errorf("gopls: GetDiagnostics: bridge has been closed")
 		}
 	}
 }
 
-// handlePublishDiagnostics는 publishDiagnostics 알림을 처리하는 핸들러다.
-// NotificationDispatcher에 등록된다.
+// handlePublishDiagnostics is the handler for publishDiagnostics notifications.
+// Registered with the NotificationDispatcher.
 //
-// 모든 URI의 최신 진단을 pendingDiag에 저장하고, 채널에도 non-blocking으로 전달한다.
-// collectDiagnostics는 채널과 pendingDiag를 모두 확인하여 어떤 URI의 진단도 유실하지 않는다.
+// Stores the latest diagnostics for every URI in pendingDiag and delivers them non-blocking to the channel.
+// collectDiagnostics checks both the channel and pendingDiag to ensure no diagnostics are lost for any URI.
 func (b *Bridge) handlePublishDiagnostics(payload json.RawMessage) {
 	var params PublishDiagnosticsParams
 	if err := json.Unmarshal(payload, &params); err != nil {
-		slog.Warn("gopls: publishDiagnostics 역직렬화 실패", "error", err)
+		slog.Warn("gopls: publishDiagnostics deserialization failed", "error", err)
 		return
 	}
 
-	// pendingDiag에 최신 진단을 저장한다 (덮어쓰기).
+	// Store the latest diagnostics in pendingDiag (overwrite).
 	b.pendingMu.Lock()
 	b.pendingDiag[params.URI] = params.Diagnostics
 	b.pendingMu.Unlock()
 
 	event := DiagnosticEvent(params)
-	// non-blocking send: 채널이 가득 차면 가장 오래된 이벤트를 폐기한다.
-	// pendingDiag에 이미 저장했으므로 채널 overflow 시에도 데이터는 보존된다.
+	// Non-blocking send: discard the oldest event if the channel is full.
+	// Data is preserved on channel overflow because it was already stored in pendingDiag.
 	select {
 	case b.diagnosticsCh <- event:
 	default:
-		// 채널이 가득 찼으면 오래된 이벤트 하나를 버리고 새 이벤트를 넣는다.
+		// Channel is full: drop one old event and insert the new one.
 		select {
 		case <-b.diagnosticsCh:
 		default:
@@ -444,35 +444,35 @@ func (b *Bridge) handlePublishDiagnostics(payload json.RawMessage) {
 	}
 }
 
-// Close는 LSP shutdown/exit 시퀀스로 gopls를 정상 종료한다.
-// REQ-GB-004: 5초 타임아웃 후 SIGKILL.
+// Close performs graceful gopls shutdown using the LSP shutdown/exit sequence.
+// REQ-GB-004: SIGKILL after a 5-second timeout.
 //
-// F3 수정: shutdownCh 닫힘 후 stdout을 즉시 닫아 readLoop의 reader.Read() 블록을 해제한다.
-// stdout을 닫으면 bufio.Reader가 EOF를 반환하여 readLoop가 5s 지연 없이 즉시 종료한다.
+// F3 fix: after closing shutdownCh, immediately close stdout to unblock reader.Read() in readLoop.
+// Closing stdout causes bufio.Reader to return EOF, allowing readLoop to exit instantly without a 5s delay.
 //
-// F4 수정: time.After 대신 time.NewTimer + defer Stop을 사용한다.
-// time.After는 done 분기가 먼저 실행되어도 ShutdownTimeout(5s) 동안 goroutine을 잔류시킨다.
-// time.NewTimer + defer Stop은 done 분기 실행 즉시 timer goroutine을 해제한다.
+// F4 fix: use time.NewTimer + defer Stop instead of time.After.
+// time.After retains the goroutine for ShutdownTimeout (5s) even if the done branch runs first.
+// time.NewTimer + defer Stop releases the timer goroutine immediately when the done branch runs.
 func (b *Bridge) Close(ctx context.Context) error {
 	var shutdownErr error
 
-	// initialized 상태일 때만 shutdown 요청을 전송한다.
+	// Only send the shutdown request when initialized.
 	if b.initialized.Load() {
 		shutdownErr = b.sendShutdown(ctx)
 	}
 
-	// readLoop에 종료 신호를 보내고 stdout을 닫아 reader.Read() 블록을 해제한다.
-	// F3: close(shutdownCh) 후 stdout.Close()를 호출해야 readLoop가 즉시 종료된다.
+	// Signal readLoop to stop and close stdout to unblock reader.Read().
+	// F3: stdout.Close() must be called after close(shutdownCh) for readLoop to exit immediately.
 	b.closeOnce.Do(func() {
 		close(b.shutdownCh)
-		// stdout을 닫아 bufio.Reader.Read()가 EOF를 반환하도록 한다.
-		// forceKill은 stdin만 닫으므로 여기서 stdout을 별도로 닫는다.
+		// Close stdout so bufio.Reader.Read() returns EOF.
+		// forceKill only closes stdin, so stdout is closed separately here.
 		if b.stdout != nil {
 			_ = b.stdout.Close()
 		}
 	})
 
-	// 프로세스가 있으면 정상 종료를 기다린다.
+	// Wait for the process to exit cleanly if it exists.
 	if b.cmd != nil {
 		done := make(chan error, 1)
 		go func() {
@@ -480,16 +480,16 @@ func (b *Bridge) Close(ctx context.Context) error {
 		}()
 
 		// F4: time.After → time.NewTimer + defer Stop.
-		// done 분기가 먼저 실행되면 timer goroutine을 즉시 회수한다.
+		// When the done branch runs first, the timer goroutine is released immediately.
 		shutdownTimeout := b.config.ShutdownTimeout
 		timer := time.NewTimer(shutdownTimeout)
 		defer timer.Stop()
 		select {
 		case <-done:
-			// 정상 종료
+			// Clean exit.
 		case <-timer.C:
-			// 타임아웃 시 SIGKILL
-			slog.Warn("gopls: 종료 타임아웃, SIGKILL 전송")
+			// Timeout: send SIGKILL.
+			slog.Warn("gopls: shutdown timeout, sending SIGKILL")
 			b.forceKill()
 		}
 	}
@@ -497,7 +497,7 @@ func (b *Bridge) Close(ctx context.Context) error {
 	return shutdownErr
 }
 
-// sendShutdown은 LSP shutdown 요청 + exit 알림을 전송한다.
+// sendShutdown sends the LSP shutdown request and exit notification.
 func (b *Bridge) sendShutdown(ctx context.Context) error {
 	id := b.nextID.Add(1)
 	ch := b.pendingReg.Register(id)
@@ -510,37 +510,37 @@ func (b *Bridge) sendShutdown(ctx context.Context) error {
 	}
 	if err := b.writer.Write(req); err != nil {
 		b.pendingReg.Unregister(id)
-		return fmt.Errorf("gopls: Close: shutdown 요청 전송 실패: %w", err)
+		return fmt.Errorf("gopls: Close: shutdown request send failed: %w", err)
 	}
 
-	// shutdown 응답을 기다린다.
+	// Wait for the shutdown response.
 	shutdownCtx, cancel := context.WithTimeout(ctx, b.config.ShutdownTimeout)
 	defer cancel()
 	select {
 	case <-ch:
 	case <-shutdownCtx.Done():
 		b.pendingReg.Unregister(id)
-		slog.Warn("gopls: shutdown 응답 타임아웃")
+		slog.Warn("gopls: shutdown response timeout")
 	}
 
-	// exit 알림 전송.
+	// Send the exit notification.
 	exit := Notification{
 		JSONRPC: "2.0",
 		Method:  "exit",
 		Params:  json.RawMessage(`null`),
 	}
 	if err := b.writer.Write(exit); err != nil {
-		return fmt.Errorf("gopls: Close: exit 알림 전송 실패: %w", err)
+		return fmt.Errorf("gopls: Close: exit notification send failed: %w", err)
 	}
 
 	return nil
 }
 
-// readLoop는 gopls stdout에서 메시지를 읽어 pending registry 또는 dispatcher에 라우팅한다.
-// Bridge가 닫힐 때까지 실행된다.
+// readLoop reads messages from gopls stdout and routes them to the pending registry or dispatcher.
+// Runs until the Bridge is closed.
 //
-// @MX:WARN: [AUTO] goroutine — shutdownCh 닫힘 또는 reader EOF에 의해서만 종료된다
-// @MX:REASON: goroutine 수명이 Bridge.Close()와 결합되어 있음
+// @MX:WARN: [AUTO] goroutine — terminated only by shutdownCh closing or reader EOF
+// @MX:REASON: goroutine lifetime is bound to Bridge.Close()
 func (b *Bridge) readLoop() {
 	for {
 		select {
@@ -552,12 +552,12 @@ func (b *Bridge) readLoop() {
 		raw, err := b.reader.Read()
 		if err != nil {
 			if err != io.EOF {
-				slog.Debug("gopls: readLoop 오류 (종료)", "error", err)
+				slog.Debug("gopls: readLoop error (exiting)", "error", err)
 			}
 			return
 		}
 
-		// 메시지를 Response로 파싱하여 id 여부로 라우팅한다.
+		// Parse the message as a Response and route based on whether it has an id.
 		var envelope struct {
 			ID     json.RawMessage `json:"id"`
 			Method string          `json:"method"`
@@ -566,20 +566,20 @@ func (b *Bridge) readLoop() {
 			Params json.RawMessage `json:"params,omitempty"`
 		}
 		if err := json.Unmarshal(raw, &envelope); err != nil {
-			slog.Warn("gopls: 메시지 파싱 실패", "error", err)
+			slog.Warn("gopls: message parsing failed", "error", err)
 			continue
 		}
 
 		isNotification := len(envelope.ID) == 0 || string(envelope.ID) == "null"
 
 		if isNotification && envelope.Method != "" {
-			// 알림: method로 dispatcher에 전달한다.
+			// Notification: forward to dispatcher by method.
 			b.dispatcher.Dispatch(envelope.Method, envelope.Params)
 		} else if !isNotification {
-			// 응답: id를 파싱하여 pending registry에 전달한다.
+			// Response: parse the id and forward to the pending registry.
 			var id int64
 			if err := json.Unmarshal(envelope.ID, &id); err != nil {
-				slog.Warn("gopls: 응답 ID 파싱 실패", "raw_id", string(envelope.ID))
+				slog.Warn("gopls: response ID parsing failed", "raw_id", string(envelope.ID))
 				continue
 			}
 			b.pendingReg.Dispatch(id, raw)
@@ -587,24 +587,24 @@ func (b *Bridge) readLoop() {
 	}
 }
 
-// ─── 서킷브레이커 헬퍼 ────────────────────────────────────────────────────────
+// ─── Circuit breaker helpers ───────────────────────────────────────────────────
 
-// checkCircuitBreaker는 서킷브레이커가 열려 있으면 오류를 반환한다.
+// checkCircuitBreaker returns an error if the circuit breaker is open.
 func (b *Bridge) checkCircuitBreaker() error {
 	b.cbMu.Lock()
 	defer b.cbMu.Unlock()
 	if b.cbFailures >= circuitBreakerThreshold {
 		if time.Now().Before(b.cbOpenUntil) {
-			return fmt.Errorf("gopls: 서킷브레이커 open (연속 %d회 실패, %v 후 재시도 가능)",
+			return fmt.Errorf("gopls: circuit breaker open (%d consecutive failures, retry available in %v)",
 				b.cbFailures, time.Until(b.cbOpenUntil).Round(time.Second))
 		}
-		// open 기간이 지났으면 half-open으로 전환.
+		// Open period has elapsed: transition to half-open.
 		b.cbFailures = 0
 	}
 	return nil
 }
 
-// recordFailure는 실패를 기록하고 임계값 초과 시 서킷브레이커를 연다.
+// recordFailure records a failure and opens the circuit breaker when the threshold is exceeded.
 func (b *Bridge) recordFailure() {
 	b.cbMu.Lock()
 	defer b.cbMu.Unlock()
@@ -614,14 +614,14 @@ func (b *Bridge) recordFailure() {
 	}
 }
 
-// resetFailures는 서킷브레이커 실패 카운트를 초기화한다.
+// resetFailures resets the circuit breaker failure count.
 func (b *Bridge) resetFailures() {
 	b.cbMu.Lock()
 	defer b.cbMu.Unlock()
 	b.cbFailures = 0
 }
 
-// forceKill은 gopls 프로세스를 강제 종료한다.
+// forceKill force-terminates the gopls process.
 func (b *Bridge) forceKill() {
 	if b.cmd != nil && b.cmd.Process != nil {
 		_ = b.cmd.Process.Kill()

--- a/internal/lsp/gopls/bridge_test.go
+++ b/internal/lsp/gopls/bridge_test.go
@@ -13,38 +13,38 @@ import (
 	"time"
 )
 
-// ─── 모의(Mock) gopls 헬퍼 ────────────────────────────────────────────────────
+// ─── Mock gopls helpers ───────────────────────────────────────────────────────
 
-// mockGopls는 pipe 쌍을 이용해 gopls 서버를 시뮬레이션한다.
-// 미리 준비된 JSON-RPC 응답을 순서대로 전송한다.
+// mockGopls simulates a gopls server using paired pipes.
+// It sends pre-prepared JSON-RPC responses in order.
 type mockGopls struct {
-	// clientReader: 브릿지(클라이언트)가 읽는 쪽 → 모의 서버가 쓴다
+	// clientReader: the side the bridge (client) reads from → the mock server writes to it
 	clientReader *io.PipeReader
 	serverWriter *io.PipeWriter
-	// serverReader: 브릿지(클라이언트)가 쓴 메시지를 모의 서버가 읽는다
+	// serverReader: the mock server reads messages written by the bridge (client)
 	serverReader *io.PipeReader
 	clientWriter *io.PipeWriter
 
 	mu       sync.Mutex
-	received []json.RawMessage // 브릿지가 보낸 메시지 기록
+	received []json.RawMessage // record of messages sent by the bridge
 }
 
-// newMockGopls는 pipe 쌍으로 연결된 mockGopls를 생성한다.
+// newMockGopls creates a mockGopls connected by pipe pairs.
 func newMockGopls() *mockGopls {
-	cr, sw := io.Pipe() // 서버→클라이언트 방향
-	sr, cw := io.Pipe() // 클라이언트→서버 방향
+	cr, sw := io.Pipe() // server → client direction
+	sr, cw := io.Pipe() // client → server direction
 	m := &mockGopls{
 		clientReader: cr,
 		serverWriter: sw,
 		serverReader: sr,
 		clientWriter: cw,
 	}
-	// 서버가 보낸 메시지를 비동기로 읽어 received에 저장한다.
+	// Asynchronously read messages sent by the server and store them in received.
 	go m.readLoop()
 	return m
 }
 
-// readLoop는 클라이언트→서버 방향 메시지를 읽어 저장한다.
+// readLoop reads messages in the client → server direction and stores them.
 func (m *mockGopls) readLoop() {
 	r := NewReader(m.serverReader)
 	for {
@@ -58,7 +58,7 @@ func (m *mockGopls) readLoop() {
 	}
 }
 
-// sendResponse는 브릿지에게 id에 대한 result 응답을 전송한다.
+// sendResponse sends a result response for the given id to the bridge.
 func (m *mockGopls) sendResponse(id int64, result any) error {
 	w := NewWriter(m.serverWriter)
 	type response struct {
@@ -69,7 +69,7 @@ func (m *mockGopls) sendResponse(id int64, result any) error {
 	return w.Write(response{JSONRPC: "2.0", ID: id, Result: result})
 }
 
-// sendNotification은 브릿지에게 method 알림을 전송한다.
+// sendNotification sends a notification with the given method to the bridge.
 func (m *mockGopls) sendNotification(method string, params any) error {
 	w := NewWriter(m.serverWriter)
 	type notification struct {
@@ -80,23 +80,23 @@ func (m *mockGopls) sendNotification(method string, params any) error {
 	return w.Write(notification{JSONRPC: "2.0", Method: method, Params: params})
 }
 
-// close는 모의 서버의 pipe를 닫는다.
+// close closes the mock server pipes.
 func (m *mockGopls) close() {
 	_ = m.serverWriter.Close()
 	_ = m.clientWriter.Close()
 }
 
-// receivedCount는 수신된 메시지 수를 반환한다.
+// receivedCount returns the number of received messages.
 func (m *mockGopls) receivedCount() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return len(m.received)
 }
 
-// ─── Bridge 테스트 ─────────────────────────────────────────────────────────────
+// ─── Bridge tests ─────────────────────────────────────────────────────────────
 
-// newTestBridge는 mock I/O를 주입하여 테스트용 Bridge를 생성한다.
-// 실제 gopls 프로세스를 생성하지 않는다.
+// newTestBridge creates a Bridge for testing by injecting mock I/O.
+// It does not spawn an actual gopls process.
 func newTestBridge(mock *mockGopls, cfg *Config) *Bridge {
 	if cfg == nil {
 		cfg = DefaultConfig()
@@ -118,8 +118,8 @@ func newTestBridge(mock *mockGopls, cfg *Config) *Bridge {
 	return b
 }
 
-// TestBridge_InitializeHandshake는 LSP 초기화 핸드셰이크를 검증한다.
-// REQ-GB-010, REQ-GB-011: initialize 요청 → 응답 → initialized 알림 순서.
+// TestBridge_InitializeHandshake verifies the LSP initialization handshake.
+// REQ-GB-010, REQ-GB-011: initialize request → response → initialized notification order.
 func TestBridge_InitializeHandshake(t *testing.T) {
 	mock := newMockGopls()
 	defer mock.close()
@@ -127,13 +127,13 @@ func TestBridge_InitializeHandshake(t *testing.T) {
 	bridge := newTestBridge(mock, nil)
 	go bridge.readLoop()
 
-	// 비동기로 initialize 응답을 전송한다.
+	// Asynchronously send the initialize response.
 	go func() {
-		// 브릿지가 initialize 요청을 보낼 때까지 잠시 대기한다.
+		// Wait briefly until the bridge sends the initialize request.
 		time.Sleep(20 * time.Millisecond)
 		result := InitializeResult{Capabilities: ServerCapabilities{}}
 		if err := mock.sendResponse(1, result); err != nil {
-			t.Errorf("initialize 응답 전송 실패: %v", err)
+			t.Errorf("initialize response send failed: %v", err)
 		}
 	}()
 
@@ -141,18 +141,18 @@ func TestBridge_InitializeHandshake(t *testing.T) {
 	defer cancel()
 
 	if err := bridge.initialize(ctx, "/tmp/test"); err != nil {
-		t.Fatalf("initialize 오류: %v", err)
+		t.Fatalf("initialize error: %v", err)
 	}
 
-	// bridge가 initialize + initialized 두 메시지를 전송했는지 확인한다.
+	// Verify that the bridge sent two messages (initialize + initialized).
 	time.Sleep(50 * time.Millisecond)
 	if mock.receivedCount() < 2 {
-		t.Errorf("수신 메시지 = %d, 최소 2개(initialize + initialized)를 기대했다", mock.receivedCount())
+		t.Errorf("received message count = %d, expected at least 2 (initialize + initialized)", mock.receivedCount())
 	}
 }
 
-// TestBridge_InitializeTimeout은 initialize 타임아웃을 검증한다.
-// REQ-GB-012: 30초 타임아웃 (테스트는 짧게 설정).
+// TestBridge_InitializeTimeout verifies the initialize timeout.
+// REQ-GB-012: 30-second timeout (the test uses a shorter setting).
 func TestBridge_InitializeTimeout(t *testing.T) {
 	mock := newMockGopls()
 	defer mock.close()
@@ -160,18 +160,18 @@ func TestBridge_InitializeTimeout(t *testing.T) {
 	bridge := newTestBridge(mock, nil)
 	go bridge.readLoop()
 
-	// ctx에 짧은 타임아웃을 설정한다. 응답을 보내지 않으면 타임아웃이 발생해야 한다.
+	// Set a short timeout on ctx. If no response is sent, a timeout must occur.
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 
 	err := bridge.initialize(ctx, "/tmp/test")
 	if err == nil {
-		t.Error("타임아웃 시 오류가 반환되지 않았다")
+		t.Error("expected error on timeout, got nil")
 	}
 }
 
-// TestBridge_GetDiagnostics는 diagnostics 수집을 검증한다.
-// REQ-GB-020, REQ-GB-021: didOpen 전송 후 publishDiagnostics 알림 수신.
+// TestBridge_GetDiagnostics verifies diagnostics collection.
+// REQ-GB-020, REQ-GB-021: receive publishDiagnostics notification after sending didOpen.
 func TestBridge_GetDiagnostics(t *testing.T) {
 	mock := newMockGopls()
 	defer mock.close()
@@ -183,18 +183,18 @@ func TestBridge_GetDiagnostics(t *testing.T) {
 	cfg.DebounceWindow = 30 * time.Millisecond
 
 	bridge := newTestBridge(mock, cfg)
-	bridge.initialized.Store(true) // 이미 초기화된 상태로 설정
+	bridge.initialized.Store(true) // mark as already initialized
 	go bridge.readLoop()
 
-	// 플랫폼 독립적 경로/URI 구성: Windows에서는 드라이브 접두사가 붙으므로
-	// pathToURI 결과를 사용해 mock URI와 일치시킨다.
+	// Platform-independent path/URI construction: on Windows the drive prefix is added,
+	// so use the result of pathToURI to match the mock URI.
 	filePath := filepath.Join(t.TempDir(), "main.go")
 	expectedURI, err := pathToURI(filePath)
 	if err != nil {
 		t.Fatalf("pathToURI: %v", err)
 	}
 
-	// 비동기로 publishDiagnostics 알림을 전송한다.
+	// Asynchronously send the publishDiagnostics notification.
 	go func() {
 		time.Sleep(20 * time.Millisecond)
 		params := PublishDiagnosticsParams{
@@ -211,14 +211,14 @@ func TestBridge_GetDiagnostics(t *testing.T) {
 				},
 				{
 					Severity: SeverityWarning,
-					Message:  "SA1001: 사용되지 않는 변수",
+					Message:  "SA1001: unused variable",
 					Source:   "staticcheck",
 					Code:     "SA1001",
 				},
 			},
 		}
 		if err := mock.sendNotification("textDocument/publishDiagnostics", params); err != nil {
-			t.Errorf("publishDiagnostics 전송 실패: %v", err)
+			t.Errorf("publishDiagnostics send failed: %v", err)
 		}
 	}()
 
@@ -227,20 +227,20 @@ func TestBridge_GetDiagnostics(t *testing.T) {
 
 	diags, err := bridge.GetDiagnostics(ctx, filePath)
 	if err != nil {
-		t.Fatalf("GetDiagnostics 오류: %v", err)
+		t.Fatalf("GetDiagnostics error: %v", err)
 	}
 	if len(diags) != 2 {
-		t.Fatalf("진단 개수 = %d, 2를 기대했다", len(diags))
+		t.Fatalf("diagnostic count = %d, expected 2", len(diags))
 	}
 	if diags[0].Severity != SeverityError {
-		t.Errorf("diags[0].Severity = %v, SeverityError를 기대했다", diags[0].Severity)
+		t.Errorf("diags[0].Severity = %v, expected SeverityError", diags[0].Severity)
 	}
 	if diags[1].Source != "staticcheck" {
-		t.Errorf("diags[1].Source = %q, staticcheck를 기대했다", diags[1].Source)
+		t.Errorf("diags[1].Source = %q, expected staticcheck", diags[1].Source)
 	}
 }
 
-// TestBridge_GetDiagnostics_Empty는 진단이 없는 파일에 대해 빈 슬라이스를 반환하는지 검증한다.
+// TestBridge_GetDiagnostics_Empty verifies that an empty slice is returned for a file with no diagnostics.
 func TestBridge_GetDiagnostics_Empty(t *testing.T) {
 	mock := newMockGopls()
 	defer mock.close()
@@ -253,14 +253,14 @@ func TestBridge_GetDiagnostics_Empty(t *testing.T) {
 	bridge.initialized.Store(true)
 	go bridge.readLoop()
 
-	// 플랫폼 독립적 경로/URI 구성.
+	// Platform-independent path/URI construction.
 	filePath := filepath.Join(t.TempDir(), "clean.go")
 	expectedURI, err := pathToURI(filePath)
 	if err != nil {
 		t.Fatalf("pathToURI: %v", err)
 	}
 
-	// 빈 진단 알림을 전송한다.
+	// Send an empty diagnostics notification.
 	go func() {
 		time.Sleep(20 * time.Millisecond)
 		params := PublishDiagnosticsParams{
@@ -268,7 +268,7 @@ func TestBridge_GetDiagnostics_Empty(t *testing.T) {
 			Diagnostics: []Diagnostic{},
 		}
 		if err := mock.sendNotification("textDocument/publishDiagnostics", params); err != nil {
-			t.Errorf("publishDiagnostics 전송 실패: %v", err)
+			t.Errorf("publishDiagnostics send failed: %v", err)
 		}
 	}()
 
@@ -277,21 +277,21 @@ func TestBridge_GetDiagnostics_Empty(t *testing.T) {
 
 	diags, err := bridge.GetDiagnostics(ctx, filePath)
 	if err != nil {
-		t.Fatalf("GetDiagnostics 오류: %v", err)
+		t.Fatalf("GetDiagnostics error: %v", err)
 	}
 	if len(diags) != 0 {
-		t.Errorf("진단 개수 = %d, 0을 기대했다", len(diags))
+		t.Errorf("diagnostic count = %d, expected 0", len(diags))
 	}
 }
 
-// TestBridge_CircuitBreaker는 연속 실패 후 서킷브레이커가 열리는지 검증한다.
-// REQ-GB-005 연계: 3회 연속 실패 → 30초 open 상태.
+// TestBridge_CircuitBreaker verifies that the circuit breaker opens after consecutive failures.
+// Related to REQ-GB-005: 3 consecutive failures → 30-second open state.
 func TestBridge_CircuitBreaker(t *testing.T) {
 	mock := newMockGopls()
 	defer mock.close()
 
 	cfg := DefaultConfig()
-	cfg.Timeout = 30 * time.Millisecond // 빠른 타임아웃
+	cfg.Timeout = 30 * time.Millisecond // fast timeout
 	cfg.DebounceWindow = 5 * time.Millisecond
 
 	bridge := newTestBridge(mock, cfg)
@@ -299,26 +299,26 @@ func TestBridge_CircuitBreaker(t *testing.T) {
 	go bridge.readLoop()
 
 	ctx := context.Background()
-	// 응답 없이 타임아웃 → 3회 반복하면 서킷브레이커가 열린다.
+	// Timeout without response → after 3 iterations the circuit breaker opens.
 	for i := 0; i < circuitBreakerThreshold; i++ {
 		_, _ = bridge.GetDiagnostics(ctx, fmt.Sprintf("/tmp/test/file%d.go", i))
 	}
 
-	// 서킷브레이커가 열렸으면 즉시 반환해야 한다.
+	// If the circuit breaker is open, it should return immediately.
 	start := time.Now()
 	_, err := bridge.GetDiagnostics(ctx, "/tmp/test/new.go")
 	elapsed := time.Since(start)
 	if err == nil {
-		t.Error("서킷브레이커 open 상태에서 오류가 반환되지 않았다")
+		t.Error("expected error while circuit breaker is open, got nil")
 	}
-	// 서킷브레이커는 즉시(20ms 이내) 반환해야 한다.
+	// The circuit breaker should return immediately (within 20ms).
 	if elapsed > 20*time.Millisecond {
-		t.Errorf("서킷브레이커 open 상태에서 너무 오래 걸렸다: %v", elapsed)
+		t.Errorf("took too long while circuit breaker is open: %v", elapsed)
 	}
 }
 
-// TestBridge_GracefulShutdown은 Close가 shutdown/exit 시퀀스를 전송하는지 검증한다.
-// REQ-GB-004: shutdown 요청 + exit 알림.
+// TestBridge_GracefulShutdown verifies that Close sends the shutdown/exit sequence.
+// REQ-GB-004: shutdown request + exit notification.
 func TestBridge_GracefulShutdown(t *testing.T) {
 	mock := newMockGopls()
 	defer mock.close()
@@ -330,12 +330,12 @@ func TestBridge_GracefulShutdown(t *testing.T) {
 	bridge.initialized.Store(true)
 	go bridge.readLoop()
 
-	// shutdown 응답을 비동기로 전송한다.
+	// Asynchronously send the shutdown response.
 	go func() {
 		time.Sleep(20 * time.Millisecond)
-		// shutdown 요청 ID는 bridge가 atomic으로 관리하므로 1이 아닐 수 있다.
-		// bridge.pending에서 첫 번째 ID를 찾아 응답한다.
-		// 단순하게: 응답 ID를 1로 시도한다.
+		// The shutdown request ID is managed atomically by the bridge, so it may not be 1.
+		// Look up the first ID in bridge.pending and respond.
+		// Simpler: try response ID 1.
 		_ = mock.sendResponse(1, nil)
 	}()
 
@@ -343,17 +343,17 @@ func TestBridge_GracefulShutdown(t *testing.T) {
 	defer cancel()
 
 	if err := bridge.Close(ctx); err != nil {
-		t.Fatalf("Close 오류: %v", err)
+		t.Fatalf("Close error: %v", err)
 	}
 
-	// shutdown + exit 메시지를 전송했는지 확인한다.
+	// Verify that shutdown + exit messages were sent.
 	time.Sleep(50 * time.Millisecond)
 	if mock.receivedCount() < 2 {
-		t.Errorf("종료 시 메시지 수 = %d, 최소 2개(shutdown + exit)를 기대했다", mock.receivedCount())
+		t.Errorf("message count on shutdown = %d, expected at least 2 (shutdown + exit)", mock.receivedCount())
 	}
 }
 
-// TestBridge_SendRequest_Concurrent는 동시 요청이 올바르게 처리되는지 검증한다.
+// TestBridge_SendRequest_Concurrent verifies that concurrent requests are handled correctly.
 func TestBridge_SendRequest_Concurrent(t *testing.T) {
 	mock := newMockGopls()
 	defer mock.close()
@@ -366,15 +366,15 @@ func TestBridge_SendRequest_Concurrent(t *testing.T) {
 
 	for i := 0; i < numRequests; i++ {
 		go func(idx int) {
-			// 요청을 등록하고 즉시 응답을 보낸다.
+			// Register the request and immediately send a response.
 			id := bridge.nextID.Add(1)
 			ch := bridge.pendingReg.Register(id)
 
-			// 비동기 응답 전송
+			// Async response transmission.
 			go func() {
 				time.Sleep(10 * time.Millisecond)
 				if err := mock.sendResponse(id, map[string]any{"ok": true}); err != nil {
-					results <- fmt.Errorf("응답 전송 실패: %w", err)
+					results <- fmt.Errorf("response send failed: %w", err)
 					return
 				}
 			}()
@@ -385,20 +385,20 @@ func TestBridge_SendRequest_Concurrent(t *testing.T) {
 			case <-ch:
 				results <- nil
 			case <-ctx.Done():
-				results <- fmt.Errorf("요청 %d 타임아웃", idx)
+				results <- fmt.Errorf("request %d timed out", idx)
 			}
 		}(i)
 	}
 
 	for i := 0; i < numRequests; i++ {
 		if err := <-results; err != nil {
-			t.Errorf("동시 요청 오류: %v", err)
+			t.Errorf("concurrent request error: %v", err)
 		}
 	}
 }
 
-// TestNewBridge_MissingGopls는 gopls 바이너리가 없을 때 (nil, nil)을 반환하는지 검증한다.
-// REQ-GB-002: gopls 없음 → (nil, nil) 반환.
+// TestNewBridge_MissingGopls verifies that (nil, nil) is returned when the gopls binary is missing.
+// REQ-GB-002: gopls missing → return (nil, nil).
 func TestNewBridge_MissingGopls(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.Enabled = true
@@ -407,35 +407,35 @@ func TestNewBridge_MissingGopls(t *testing.T) {
 	ctx := context.Background()
 	b, err := NewBridge(ctx, t.TempDir(), cfg)
 	if err != nil {
-		t.Fatalf("gopls 없음 시 오류가 반환됐다: %v ((nil,nil)을 기대했다)", err)
+		t.Fatalf("error returned when gopls is missing: %v (expected (nil,nil))", err)
 	}
 	if b != nil {
-		t.Error("gopls 없음 시 Bridge가 반환됐다 (nil을 기대했다)")
+		t.Error("Bridge returned when gopls is missing (expected nil)")
 	}
 }
 
-// TestNewBridge_Disabled는 cfg.Enabled=false이면 nil bridge를 반환하는지 검증한다.
-// REQ-GB-051: 비활성화 시 nil을 반환한다.
+// TestNewBridge_Disabled verifies that a nil bridge is returned when cfg.Enabled=false.
+// REQ-GB-051: when disabled, return nil.
 func TestNewBridge_Disabled(t *testing.T) {
 	cfg := DefaultConfig() // Enabled = false
 	ctx := context.Background()
 	b, err := NewBridge(ctx, t.TempDir(), cfg)
 	if err != nil {
-		t.Fatalf("비활성화 시 오류 반환: %v", err)
+		t.Fatalf("error returned when disabled: %v", err)
 	}
 	if b != nil {
-		t.Error("비활성화 시 nil이 아닌 Bridge 반환")
+		t.Error("non-nil Bridge returned when disabled")
 	}
 }
 
-// TestBridge_DiagnosticsChannelOverflow는 diagnostics 채널이 가득 찼을 때
-// 오래된 이벤트를 폐기하고 새 이벤트를 수용하는지 검증한다.
+// TestBridge_DiagnosticsChannelOverflow verifies that when the diagnostics channel is full,
+// older events are discarded and new events are accepted.
 func TestBridge_DiagnosticsChannelOverflow(t *testing.T) {
 	mock := newMockGopls()
 	defer mock.close()
 
 	bridge := newTestBridge(mock, nil)
-	// 채널(크기 16)을 가득 채운다.
+	// Fill the channel (size 16).
 	for i := 0; i < 16; i++ {
 		bridge.diagnosticsCh <- DiagnosticEvent{
 			URI:         fmt.Sprintf("file:///tmp/other%d.go", i),
@@ -443,14 +443,14 @@ func TestBridge_DiagnosticsChannelOverflow(t *testing.T) {
 		}
 	}
 
-	// 채널이 가득 찬 상태에서 새 이벤트를 전송한다 — panic 없이 처리해야 한다.
+	// Send a new event while the channel is full — must be handled without panic.
 	newEvent := DiagnosticEvent{
 		URI:         "file:///tmp/new.go",
 		Diagnostics: []Diagnostic{{Message: "new error"}},
 	}
 	bridge.handlePublishDiagnostics(mustMarshal(t, PublishDiagnosticsParams(newEvent)))
 
-	// 채널에서 이벤트를 드레인하여 새 이벤트가 포함됐는지 확인한다.
+	// Drain events from the channel and verify that the new event is included.
 	found := false
 	for {
 		select {
@@ -464,65 +464,66 @@ func TestBridge_DiagnosticsChannelOverflow(t *testing.T) {
 	}
 done:
 	if !found {
-		t.Error("overflow 처리 후 새 이벤트가 채널에 없다")
+		t.Error("new event missing from channel after overflow handling")
 	}
 }
 
-// mustMarshal은 테스트 헬퍼로 JSON 직렬화에 실패하면 Fatal을 호출한다.
+// mustMarshal is a test helper that calls Fatal if JSON marshalling fails.
 func mustMarshal(t *testing.T, v any) []byte {
 	t.Helper()
 	b, err := json.Marshal(v)
 	if err != nil {
-		t.Fatalf("JSON 직렬화 실패: %v", err)
+		t.Fatalf("JSON marshal failed: %v", err)
 	}
 	return b
 }
 
-// TestReadLoop_ExitsPromptlyOnShutdown은 Close 호출 시 readLoop가 빠르게 종료하는지 검증한다.
-// F3 결함 재현: readLoop가 reader.Read()에 블록된 상태에서 shutdownCh가 닫혀도
-// stdout이 닫히지 않으면 최대 5초(ShutdownTimeout) 동안 goroutine이 잔류한다.
+// TestReadLoop_ExitsPromptlyOnShutdown verifies that readLoop terminates promptly when Close is called.
+// F3 defect reproduction: while readLoop is blocked on reader.Read(), even if shutdownCh is closed,
+// if stdout is not closed, the goroutine lingers for up to 5 seconds (ShutdownTimeout).
 func TestReadLoop_ExitsPromptlyOnShutdown(t *testing.T) {
 	mock := newMockGopls()
-	// mock.close()를 나중에 명시적으로 호출하므로 defer는 사용하지 않는다.
+	// mock.close() is invoked explicitly later, so do not use defer.
 
 	cfg := DefaultConfig()
-	cfg.ShutdownTimeout = 5 * time.Second // F3가 없으면 이 만큼 기다린다
+	cfg.ShutdownTimeout = 5 * time.Second // without F3, this much time elapses
 
 	bridge := newTestBridge(mock, cfg)
 
-	// readLoop를 시작하고 goroutine 종료를 추적한다.
+	// Start readLoop and track goroutine termination.
 	done := make(chan struct{})
 	go func() {
 		bridge.readLoop()
 		close(done)
 	}()
 
-	// readLoop가 reader.Read()에 블록될 시간을 준다.
+	// Give readLoop time to block on reader.Read().
 	time.Sleep(20 * time.Millisecond)
 
-	// shutdownCh를 닫는다 (Close()가 하는 작업).
+	// Close shutdownCh (the action Close() performs).
 	bridge.closeOnce.Do(func() {
 		close(bridge.shutdownCh)
 	})
-	// stdout을 닫아 reader.Read()를 unblock한다 (F3 수정의 핵심).
-	_ = mock.serverWriter.Close() // 클라이언트가 읽는 파이프의 쓰기 측 종료
+	// Close stdout to unblock reader.Read() (the core of the F3 fix).
+	_ = mock.serverWriter.Close() // close the write side of the pipe the client reads from
 
-	// readLoop가 100ms 이내에 종료되어야 한다 (5s 타임아웃보다 훨씬 짧음).
+	// readLoop must terminate within 100ms (much shorter than the 5s timeout).
 	select {
 	case <-done:
-		// 정상: readLoop 종료
+		// Normal: readLoop terminated.
 	case <-time.After(200 * time.Millisecond):
-		t.Error("readLoop가 200ms 이내에 종료되지 않았다 (stdout.Close가 readLoop를 unblock해야 한다)")
+		t.Error("readLoop did not terminate within 200ms (stdout.Close should unblock readLoop)")
 	}
 
 	mock.close()
 }
 
-// TestClose_DoesNotLeakTimer는 Close()의 time.NewTimer가 누수되지 않는지 검증한다.
-// F4 결함 재현: time.After를 사용하면 done 분기가 빠르게 실행되어도 goroutine이 5s 동안 잔류한다.
+// TestClose_DoesNotLeakTimer verifies that the time.NewTimer in Close() does not leak.
+// F4 defect reproduction: when using time.After, even if the done branch executes quickly,
+// the goroutine lingers for 5s.
 func TestClose_DoesNotLeakTimer(t *testing.T) {
-	// 여러 번 Bridge를 생성하고 Close를 호출하여 goroutine 수가 폭발하지 않는지 확인한다.
-	// runtime.NumGoroutine()으로 간접 측정한다.
+	// Create Bridge multiple times and call Close to verify the goroutine count does not blow up.
+	// Measure indirectly via runtime.NumGoroutine().
 	before := countGoroutines()
 
 	const iterations = 20
@@ -534,36 +535,36 @@ func TestClose_DoesNotLeakTimer(t *testing.T) {
 		bridge := newTestBridge(mock, cfg)
 		go bridge.readLoop()
 
-		// shutdown 없이 바로 closeOnce만 실행 (initialized=false이므로 sendShutdown 호출 안 됨).
+		// Run only closeOnce without shutdown (initialized=false so sendShutdown is not invoked).
 		ctx := context.Background()
 		_ = bridge.Close(ctx)
 		mock.close()
 	}
 
-	// goroutine 수가 안정화될 시간을 준다.
+	// Give time for the goroutine count to stabilize.
 	time.Sleep(200 * time.Millisecond)
 	after := countGoroutines()
 
-	// 20번 반복했으나 goroutine 누수는 소수 이내여야 한다.
-	// time.After는 timer goroutine을 ShutdownTimeout(5s) 동안 유지하므로,
-	// F4가 없으면 이 시점에 20개 이상의 goroutine이 잔류할 수 있다.
-	// F4 수정 후에는 timer.Stop()으로 즉시 해제되어 누수가 없어야 한다.
+	// Even with 20 iterations, goroutine leakage must be within a small bound.
+	// time.After keeps the timer goroutine alive for ShutdownTimeout (5s),
+	// so without F4 there could be 20+ residual goroutines at this point.
+	// After the F4 fix, timer.Stop() releases immediately, so there should be no leak.
 	delta := after - before
 	if delta > 5 {
-		t.Errorf("Close 반복 후 goroutine 누수 감지: before=%d, after=%d, delta=%d (5 이하를 기대했다)",
+		t.Errorf("goroutine leak detected after repeated Close: before=%d, after=%d, delta=%d (expected <= 5)",
 			before, after, delta)
 	}
 }
 
-// countGoroutines는 현재 goroutine 수를 반환한다.
+// countGoroutines returns the current goroutine count.
 func countGoroutines() int {
-	// runtime.NumGoroutine()은 현재 실행 중인 goroutine 수를 반환한다.
+	// runtime.NumGoroutine() returns the number of currently running goroutines.
 	return runtime.NumGoroutine()
 }
 
-// TestCollectDiagnostics_PreservesOtherURIEvents는 다른 URI 이벤트가 수집 중 유실되지 않는지 검증한다.
-// F2 결함 재현: collectDiagnostics가 A 파일을 기다리는 동안 B 파일의 진단이 도착하면,
-// 이후 B를 요청했을 때 진단이 반환되어야 한다.
+// TestCollectDiagnostics_PreservesOtherURIEvents verifies that other-URI events are not lost during collection.
+// F2 defect reproduction: while collectDiagnostics is waiting for file A, if diagnostics for file B arrive,
+// then when B is requested afterward the diagnostics must still be returned.
 func TestCollectDiagnostics_PreservesOtherURIEvents(t *testing.T) {
 	mock := newMockGopls()
 	defer mock.close()
@@ -579,48 +580,48 @@ func TestCollectDiagnostics_PreservesOtherURIEvents(t *testing.T) {
 	uriA := "file:///tmp/test/a.go"
 	uriB := "file:///tmp/test/b.go"
 
-	// B 파일의 진단을 먼저 채널에 직접 주입한다 (A를 기다리기 전에).
+	// Inject the diagnostics for file B directly into the channel first (before waiting for A).
 	bridge.diagnosticsCh <- DiagnosticEvent{
 		URI:         uriB,
-		Diagnostics: []Diagnostic{{Message: "B 파일 오류", Severity: SeverityError}},
+		Diagnostics: []Diagnostic{{Message: "B file error", Severity: SeverityError}},
 	}
 
-	// A 파일의 진단을 약간 지연 후 전송한다.
+	// Send the diagnostics for file A after a slight delay.
 	go func() {
 		time.Sleep(20 * time.Millisecond)
 		if err := mock.sendNotification("textDocument/publishDiagnostics", PublishDiagnosticsParams{
 			URI:         uriA,
-			Diagnostics: []Diagnostic{{Message: "A 파일 오류"}},
+			Diagnostics: []Diagnostic{{Message: "A file error"}},
 		}); err != nil {
-			t.Errorf("A 알림 전송 실패: %v", err)
+			t.Errorf("A notification send failed: %v", err)
 		}
 	}()
 
-	// A 파일 수집: 성공해야 한다.
+	// Collect file A: must succeed.
 	ctx := context.Background()
 	diagsA, err := bridge.collectDiagnostics(ctx, uriA)
 	if err != nil {
-		t.Fatalf("collectDiagnostics(A) 오류: %v", err)
+		t.Fatalf("collectDiagnostics(A) error: %v", err)
 	}
-	if len(diagsA) != 1 || diagsA[0].Message != "A 파일 오류" {
-		t.Errorf("collectDiagnostics(A) = %v, 'A 파일 오류' 1개를 기대했다", diagsA)
+	if len(diagsA) != 1 || diagsA[0].Message != "A file error" {
+		t.Errorf("collectDiagnostics(A) = %v, expected one 'A file error' entry", diagsA)
 	}
 
-	// B 파일 수집: pendingDiag에 저장된 이벤트를 반환해야 한다.
+	// Collect file B: should return the event stored in pendingDiag.
 	diagsB, err := bridge.collectDiagnostics(ctx, uriB)
 	if err != nil {
-		t.Fatalf("collectDiagnostics(B) 오류: %v", err)
+		t.Fatalf("collectDiagnostics(B) error: %v", err)
 	}
-	if len(diagsB) != 1 || diagsB[0].Message != "B 파일 오류" {
-		t.Errorf("collectDiagnostics(B) = %v, 'B 파일 오류' 1개를 기대했다 (다른 URI 이벤트 유실)", diagsB)
+	if len(diagsB) != 1 || diagsB[0].Message != "B file error" {
+		t.Errorf("collectDiagnostics(B) = %v, expected one 'B file error' entry (other-URI event lost)", diagsB)
 	}
 }
 
-// TestNewBridge_RealGopls는 실제 gopls 바이너리가 있으면 브릿지를 생성하고 종료한다.
-// gopls가 PATH에 없으면 테스트를 건너뛴다.
+// TestNewBridge_RealGopls creates and shuts down the bridge if a real gopls binary is available.
+// Skips the test if gopls is not on PATH.
 func TestNewBridge_RealGopls(t *testing.T) {
 	if _, err := exec.LookPath("gopls"); err != nil {
-		t.Skip("gopls 바이너리를 찾을 수 없어 테스트를 건너뜁니다")
+		t.Skip("gopls binary not found, skipping test")
 	}
 
 	cfg := DefaultConfig()
@@ -629,7 +630,7 @@ func TestNewBridge_RealGopls(t *testing.T) {
 	cfg.InitTimeout = 15 * time.Second
 	cfg.ShutdownTimeout = 5 * time.Second
 
-	// 임시 디렉토리를 프로젝트 루트로 사용한다.
+	// Use a temporary directory as the project root.
 	projectRoot := t.TempDir()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -637,18 +638,18 @@ func TestNewBridge_RealGopls(t *testing.T) {
 
 	b, err := NewBridge(ctx, projectRoot, cfg)
 	if err != nil {
-		t.Fatalf("NewBridge 오류: %v", err)
+		t.Fatalf("NewBridge error: %v", err)
 	}
 	if b == nil {
-		t.Fatal("NewBridge가 nil을 반환했다")
+		t.Fatal("NewBridge returned nil")
 	}
 	defer func() {
 		closeCtx, closeCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer closeCancel()
 		if err := b.Close(closeCtx); err != nil {
-			t.Logf("Close 오류 (무시): %v", err)
+			t.Logf("Close error (ignored): %v", err)
 		}
 	}()
 
-	t.Log("실제 gopls 브릿지 생성 및 초기화 성공")
+	t.Log("real gopls bridge created and initialized successfully")
 }

--- a/internal/lsp/gopls/config.go
+++ b/internal/lsp/gopls/config.go
@@ -1,7 +1,7 @@
 package gopls
 
-// @MX:ANCHOR: [AUTO] Config 타입 및 로더 — bridge.go, NewBridge에서 의존하는 설정 진입점
-// @MX:REASON: fan_in >= 3 (NewBridge, 테스트, 외부 의존 주입 경로)
+// @MX:ANCHOR: [AUTO] Config type and loader — the settings entry point depended on by bridge.go and NewBridge
+// @MX:REASON: fan_in >= 3 (NewBridge, tests, external dependency injection paths)
 
 import (
 	"errors"
@@ -14,35 +14,35 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// Config는 gopls 브릿지 동작 설정을 담는다.
-// REQ-GB-050: .moai/config/sections/lsp.yaml의 gopls_bridge 섹션에서 로드한다.
-// REQ-GB-022: 타임아웃과 디바운스 창은 lsp.yaml에서 설정 가능하다.
+// Config holds the gopls bridge behavior settings.
+// REQ-GB-050: loaded from the gopls_bridge section of .moai/config/sections/lsp.yaml.
+// REQ-GB-022: timeouts and debounce window are configurable via lsp.yaml.
 type Config struct {
-	// Enabled는 gopls 브릿지 활성화 여부다.
-	// REQ-GB-051: false(기본값)이면 GoFeedbackGenerator는 CLI 전용 경로를 유지한다.
+	// Enabled indicates whether the gopls bridge is active.
+	// REQ-GB-051: when false (default), GoFeedbackGenerator retains the CLI-only path.
 	Enabled bool
-	// Binary는 gopls 실행 파일 경로 또는 이름이다. 기본값: "gopls".
+	// Binary is the gopls executable path or name. Default: "gopls".
 	Binary string
-	// Args는 gopls 서브프로세스에 전달할 추가 인수다.
+	// Args are additional arguments passed to the gopls subprocess.
 	Args []string
-	// InitOptions는 LSP initialize 요청의 initializationOptions다.
-	// REQ-GB-013: staticcheck: true를 포함해야 한다.
+	// InitOptions is the initializationOptions field of the LSP initialize request.
+	// REQ-GB-013: must include staticcheck: true.
 	InitOptions map[string]any
-	// Timeout은 개별 LSP 요청(didOpen, 진단 등)의 타임아웃이다. 기본값: 30s.
-	// REQ-GB-020: didOpen 후 publishDiagnostics 대기 타임아웃.
+	// Timeout is the per-request timeout for individual LSP requests (didOpen, diagnostics, etc.). Default: 30s.
+	// REQ-GB-020: timeout for waiting on publishDiagnostics after didOpen.
 	Timeout time.Duration
-	// InitTimeout은 LSP initialize 핸드셰이크 타임아웃이다.
-	// REQ-GB-012: 초기화 타임아웃 30초.
+	// InitTimeout is the timeout for the LSP initialize handshake.
+	// REQ-GB-012: initialization timeout of 30 seconds.
 	InitTimeout time.Duration
-	// ShutdownTimeout은 graceful shutdown 타임아웃이다.
-	// REQ-GB-004: 5초 타임아웃 후 SIGKILL.
+	// ShutdownTimeout is the graceful shutdown timeout.
+	// REQ-GB-004: SIGKILL after a 5-second timeout.
 	ShutdownTimeout time.Duration
-	// DebounceWindow는 publishDiagnostics 디바운스 창이다.
-	// REQ-GB-021: 기본값 150ms.
+	// DebounceWindow is the publishDiagnostics debounce window.
+	// REQ-GB-021: default 150ms.
 	DebounceWindow time.Duration
 }
 
-// DefaultConfig는 합리적인 기본값으로 채워진 Config를 반환한다.
+// DefaultConfig returns a Config populated with sensible defaults.
 // binary=gopls, timeout=30s, initTimeout=30s, shutdownTimeout=5s, debounce=150ms.
 func DefaultConfig() *Config {
 	return &Config{
@@ -57,8 +57,8 @@ func DefaultConfig() *Config {
 	}
 }
 
-// ─── YAML 파싱용 내부 구조체 ─────────────────────────────────────────────────
-// lsp.yaml의 구조와 1:1 매핑한다.
+// ─── Internal structs for YAML parsing ───────────────────────────────────────
+// 1:1 mapping to the lsp.yaml structure.
 
 type lspYAMLRoot struct {
 	LSP lspYAMLConfig `yaml:"lsp"`
@@ -83,43 +83,43 @@ type timeoutsYAML struct {
 	DiagnosticsDebounceMs  int `yaml:"diagnostics_debounce_ms"`
 }
 
-// LoadConfig는 configPath의 YAML 파일에서 gopls 브릿지 설정을 로드한다.
-// 파일이 없으면 DefaultConfig를 반환한다 (오류 아님).
-// YAML 구문 오류 등 다른 오류는 error를 반환한다.
+// LoadConfig loads the gopls bridge settings from the YAML file at configPath.
+// Returns DefaultConfig when the file does not exist (not an error).
+// All other errors, such as YAML syntax errors, are returned as an error.
 //
-// REQ-GB-050: lsp.yaml에서 설정을 읽는다.
-// REQ-GB-002 연계: gopls 없음과 동일하게 설정 없음도 graceful하게 처리한다.
+// REQ-GB-050: reads settings from lsp.yaml.
+// Related to REQ-GB-002: absence of config is handled gracefully, identical to a missing gopls binary.
 func LoadConfig(configPath string) (*Config, error) {
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			// 파일이 없으면 기본값을 반환한다. 오류가 아니다.
+			// File not found: return defaults. This is not an error.
 			return DefaultConfig(), nil
 		}
-		return nil, fmt.Errorf("gopls: config: 파일 읽기 실패 %q: %w", configPath, err)
+		return nil, fmt.Errorf("gopls: config: file read failed %q: %w", configPath, err)
 	}
 
 	var root lspYAMLRoot
 	if err := yaml.Unmarshal(data, &root); err != nil {
-		return nil, fmt.Errorf("gopls: config: YAML 파싱 실패 %q: %w", configPath, err)
+		return nil, fmt.Errorf("gopls: config: YAML parsing failed %q: %w", configPath, err)
 	}
 
 	cfg := mergeWithDefaults(&root.LSP.GoplsBridge)
 
-	// F5: 바이너리·인수 허용 목록 검사.
-	// lsp.yaml의 binary/args는 외부 편집자가 변조할 수 있는 공급망 공격 벡터다.
+	// F5: binary and argument allowlist check.
+	// The binary/args in lsp.yaml are a supply-chain attack vector that external editors could tamper with.
 	if err := validateBinary(cfg.Binary); err != nil {
-		return nil, fmt.Errorf("gopls: config: 바이너리 검증 실패: %w", err)
+		return nil, fmt.Errorf("gopls: config: binary validation failed: %w", err)
 	}
 	if err := validateArgs(cfg.Args); err != nil {
-		return nil, fmt.Errorf("gopls: config: 인수 검증 실패: %w", err)
+		return nil, fmt.Errorf("gopls: config: argument validation failed: %w", err)
 	}
 
 	return cfg, nil
 }
 
-// mergeWithDefaults는 YAML에서 파싱한 gopls_bridge 설정과 기본값을 병합한다.
-// 0 값인 필드는 기본값으로 채운다.
+// mergeWithDefaults merges the gopls_bridge settings parsed from YAML with the defaults.
+// Fields with zero values are filled with the defaults.
 func mergeWithDefaults(y *goplsBridgeYAML) *Config {
 	def := DefaultConfig()
 	cfg := &Config{
@@ -139,7 +139,7 @@ func mergeWithDefaults(y *goplsBridgeYAML) *Config {
 		cfg.InitOptions = y.InitOptions
 	}
 
-	// 타임아웃: 0이면 기본값 사용
+	// Timeouts: use defaults when the value is 0.
 	cfg.InitTimeout = durationOrDefault(y.Timeouts.InitializeSeconds, 0, def.InitTimeout, time.Second)
 	cfg.Timeout = durationOrDefault(y.Timeouts.RequestSeconds, 0, def.Timeout, time.Second)
 	cfg.ShutdownTimeout = durationOrDefault(y.Timeouts.ShutdownSeconds, 0, def.ShutdownTimeout, time.Second)
@@ -148,7 +148,7 @@ func mergeWithDefaults(y *goplsBridgeYAML) *Config {
 	return cfg
 }
 
-// durationOrDefault는 값이 0이면 defaultVal을 반환하고, 아니면 value * unit을 반환한다.
+// durationOrDefault returns defaultVal when value equals zero, otherwise returns value * unit.
 func durationOrDefault(value, zero int, defaultVal time.Duration, unit time.Duration) time.Duration {
 	if value == zero {
 		return defaultVal
@@ -156,19 +156,19 @@ func durationOrDefault(value, zero int, defaultVal time.Duration, unit time.Dura
 	return time.Duration(value) * unit
 }
 
-// ─── 보안: 바이너리·인수 허용 목록 ──────────────────────────────────────────────
+// ─── Security: binary and argument allowlist ──────────────────────────────────
 //
-// REQ-GB-F5: lsp.yaml의 binary/args는 공급망 공격 벡터다.
-// binary가 신뢰된 경로 이외의 절대 경로를 가리키거나 쉘 메타문자를 포함하면 즉시 거부한다.
+// REQ-GB-F5: binary/args in lsp.yaml are a supply-chain attack vector.
+// Reject immediately if binary points to an absolute path outside trusted paths or contains shell metacharacters.
 
-// ErrUntrustedBinary는 신뢰할 수 없는 바이너리 경로가 지정됐을 때 반환된다.
-var ErrUntrustedBinary = errors.New("gopls: config: 신뢰할 수 없는 바이너리 경로")
+// ErrUntrustedBinary is returned when an untrusted binary path is specified.
+var ErrUntrustedBinary = errors.New("gopls: config: untrusted binary path")
 
-// ErrUnsafeArgs는 쉘 메타문자를 포함하는 인수가 지정됐을 때 반환된다.
-var ErrUnsafeArgs = errors.New("gopls: config: 허용되지 않는 인수 문자")
+// ErrUnsafeArgs is returned when an argument contains shell metacharacters.
+var ErrUnsafeArgs = errors.New("gopls: config: disallowed argument characters")
 
-// trustedPrefixes는 절대 경로 바이너리가 위치해도 되는 신뢰된 디렉토리다.
-// $HOME 기반 경로는 런타임에 확장한다.
+// trustedPrefixes is the set of trusted directories where absolute-path binaries may reside.
+// $HOME-based paths are expanded at runtime.
 var trustedPrefixesStatic = []string{
 	"/usr/bin",
 	"/usr/local/bin",
@@ -176,49 +176,49 @@ var trustedPrefixesStatic = []string{
 	"/opt/local/bin",
 }
 
-// binaryMetachars는 바이너리 이름·경로에 절대 포함되어선 안 되는 문자 집합이다.
-// Windows 경로는 백슬래시를 정상적으로 포함하므로 제외한다.
-// exec.Command는 쉘을 경유하지 않으므로 백슬래시 자체는 인젝션 위험이 없다.
+// binaryMetachars is the set of characters that must never appear in a binary name or path.
+// Windows paths legitimately contain backslashes, so they are excluded.
+// exec.Command does not go through a shell, so backslashes themselves carry no injection risk.
 const binaryMetachars = ";&|`$"
 
-// argMetachars는 인수에 허용되지 않는 쉘 메타문자 집합이다.
+// argMetachars is the set of shell metacharacters disallowed in arguments.
 const argMetachars = ";&|`$\n\r"
 
-// validateBinary는 cfg.Binary가 허용된 바이너리인지 검사한다.
+// validateBinary checks whether cfg.Binary is an allowed binary.
 //
-// 허용 조건:
-//   - bare name(경로 구분자 없음): "gopls" 형태 → 허용 (PATH 탐색에 위임)
-//   - 절대 경로: trustedPrefixes 중 하나로 시작해야 함
+// Allowed conditions:
+//   - Bare name (no path separator): e.g. "gopls" → allowed (delegated to PATH lookup).
+//   - Absolute path: must start with one of the trustedPrefixes.
 //
-// 거부 조건:
-//   - 경로 순회(".." 포함)
-//   - 쉘 메타문자(";", "|", "&", "`", "$", "\") 포함
-//   - 신뢰되지 않은 디렉토리의 절대 경로
+// Rejected conditions:
+//   - Path traversal (contains "..").
+//   - Shell metacharacters (";", "|", "&", "`", "$", "\").
+//   - Absolute path outside a trusted directory.
 func validateBinary(binary string) error {
 	if binary == "" {
-		return fmt.Errorf("%w: 빈 바이너리 이름", ErrUntrustedBinary)
+		return fmt.Errorf("%w: empty binary name", ErrUntrustedBinary)
 	}
 
-	// 쉘 메타문자 검사.
+	// Check for shell metacharacters.
 	if strings.ContainsAny(binary, binaryMetachars) {
-		return fmt.Errorf("%w: 쉘 메타문자 포함 %q", ErrUntrustedBinary, binary)
+		return fmt.Errorf("%w: shell metacharacter in %q", ErrUntrustedBinary, binary)
 	}
 
-	// bare name이면 허용한다 (예: "gopls", "gopls-v0.14").
+	// Bare name is allowed (e.g. "gopls", "gopls-v0.14").
 	if !strings.Contains(binary, string(filepath.Separator)) && !strings.Contains(binary, "/") {
 		return nil
 	}
 
-	// 절대 경로 검사.
-	// 경로 순회("..")를 filepath.Clean으로 해결 후 원본과 비교한다.
+	// Absolute path check.
+	// Resolve path traversal ("..") via filepath.Clean and compare with the original.
 	cleaned := filepath.Clean(binary)
 
-	// ".."를 포함하면 filepath.Clean 전후가 달라진다. 이를 탐지한다.
+	// If ".." is present, filepath.Clean produces a different result. Detect this.
 	if strings.Contains(binary, "..") {
-		return fmt.Errorf("%w: 경로 순회 시도 %q", ErrUntrustedBinary, binary)
+		return fmt.Errorf("%w: path traversal attempt %q", ErrUntrustedBinary, binary)
 	}
 
-	// 신뢰된 접두사 목록 구성: 정적 목록 + $HOME 기반 동적 경로.
+	// Build the trusted prefix list: static list + $HOME-based dynamic paths.
 	prefixes := append([]string(nil), trustedPrefixesStatic...)
 	if home, err := os.UserHomeDir(); err == nil {
 		prefixes = append(prefixes,
@@ -227,9 +227,9 @@ func validateBinary(binary string) error {
 		)
 	}
 
-	// 플랫폼 독립적 비교를 위해 양쪽 모두 forward-slash 정규형으로 변환한다.
-	// 윈도우에서 filepath.Clean은 "/usr/bin/x" → "\usr\bin\x"가 되지만, 비교는
-	// 슬래시 기반으로 수행해 크로스플랫폼 일관성을 유지한다.
+	// Convert both sides to forward-slash canonical form for platform-independent comparison.
+	// On Windows, filepath.Clean turns "/usr/bin/x" into "\usr\bin\x", but the comparison
+	// is slash-based to maintain cross-platform consistency.
 	cleanedSlash := filepath.ToSlash(cleaned)
 	for _, prefix := range prefixes {
 		prefixSlash := filepath.ToSlash(prefix)
@@ -238,19 +238,19 @@ func validateBinary(binary string) error {
 		}
 	}
 
-	return fmt.Errorf("%w: 신뢰된 경로 외부의 바이너리 %q (허용 목록: %v)", ErrUntrustedBinary, binary, prefixes)
+	return fmt.Errorf("%w: binary %q is outside trusted paths (allowlist: %v)", ErrUntrustedBinary, binary, prefixes)
 }
 
-// validateArgs는 gopls에 전달할 추가 인수가 안전한지 검사한다.
+// validateArgs checks whether the additional arguments to be passed to gopls are safe.
 //
-// 거부 조건:
-//   - 쉘 메타문자(";", "|", "&", "`", "$", ">", "<", 개행) 포함
+// Rejected conditions:
+//   - Contains shell metacharacters (";", "|", "&", "`", "$", ">", "<", newline).
 func validateArgs(args []string) error {
-	// 리다이렉션 연산자를 포함한 위험 문자 집합.
+	// Dangerous character set including redirection operators.
 	const dangerousChars = argMetachars + "><"
 	for _, arg := range args {
 		if strings.ContainsAny(arg, dangerousChars) {
-			return fmt.Errorf("%w: 인수 %q에 허용되지 않는 문자가 포함됨", ErrUnsafeArgs, arg)
+			return fmt.Errorf("%w: argument %q contains disallowed characters", ErrUnsafeArgs, arg)
 		}
 	}
 	return nil

--- a/internal/lsp/gopls/config_test.go
+++ b/internal/lsp/gopls/config_test.go
@@ -7,24 +7,24 @@ import (
 	"time"
 )
 
-// TestDefaultConfig는 DefaultConfig가 합리적인 기본값을 반환하는지 검증한다.
+// TestDefaultConfig verifies that DefaultConfig returns reasonable default values.
 func TestDefaultConfig(t *testing.T) {
 	cfg := DefaultConfig()
 	if cfg == nil {
-		t.Fatal("DefaultConfig()가 nil을 반환해서는 안 된다")
+		t.Fatal("DefaultConfig() must not return nil")
 	}
 	if cfg.Binary != "gopls" {
-		t.Errorf("기본 Binary = %q, 원하는 값 = %q", cfg.Binary, "gopls")
+		t.Errorf("default Binary = %q, want %q", cfg.Binary, "gopls")
 	}
 	if cfg.Timeout != 30*time.Second {
-		t.Errorf("기본 Timeout = %v, 원하는 값 = %v", cfg.Timeout, 30*time.Second)
+		t.Errorf("default Timeout = %v, want %v", cfg.Timeout, 30*time.Second)
 	}
 	if cfg.Enabled {
-		t.Error("기본 Enabled는 false여야 한다")
+		t.Error("default Enabled must be false")
 	}
 }
 
-// TestLoadConfig_ValidYAML은 올바른 YAML 파일에서 설정을 로드하는지 검증한다.
+// TestLoadConfig_ValidYAML verifies that config is loaded from a valid YAML file.
 func TestLoadConfig_ValidYAML(t *testing.T) {
 	yaml := `lsp:
     gopls_bridge:
@@ -43,72 +43,72 @@ func TestLoadConfig_ValidYAML(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "lsp.yaml")
 	if err := os.WriteFile(configPath, []byte(yaml), 0644); err != nil {
-		t.Fatalf("테스트 파일 생성 실패: %v", err)
+		t.Fatalf("failed to create test file: %v", err)
 	}
 
 	cfg, err := LoadConfig(configPath)
 	if err != nil {
-		t.Fatalf("LoadConfig 오류: %v", err)
+		t.Fatalf("LoadConfig error: %v", err)
 	}
 	if !cfg.Enabled {
-		t.Error("Enabled = false, true를 기대했다")
+		t.Error("Enabled = false, want true")
 	}
 	if cfg.Binary != "/usr/local/bin/gopls" {
-		t.Errorf("Binary = %q, 원하는 값 = %q", cfg.Binary, "/usr/local/bin/gopls")
+		t.Errorf("Binary = %q, want %q", cfg.Binary, "/usr/local/bin/gopls")
 	}
 	if len(cfg.Args) != 1 || cfg.Args[0] != "-remote=auto" {
-		t.Errorf("Args = %v, 원하는 값 = [-remote=auto]", cfg.Args)
+		t.Errorf("Args = %v, want [-remote=auto]", cfg.Args)
 	}
-	// 타임아웃 검증
+	// validate timeouts
 	if cfg.Timeout != 10*time.Second {
-		t.Errorf("Timeout (request) = %v, 원하는 값 = %v", cfg.Timeout, 10*time.Second)
+		t.Errorf("Timeout (request) = %v, want %v", cfg.Timeout, 10*time.Second)
 	}
 	if cfg.InitTimeout != 60*time.Second {
-		t.Errorf("InitTimeout = %v, 원하는 값 = %v", cfg.InitTimeout, 60*time.Second)
+		t.Errorf("InitTimeout = %v, want %v", cfg.InitTimeout, 60*time.Second)
 	}
 	if cfg.ShutdownTimeout != 10*time.Second {
-		t.Errorf("ShutdownTimeout = %v, 원하는 값 = %v", cfg.ShutdownTimeout, 10*time.Second)
+		t.Errorf("ShutdownTimeout = %v, want %v", cfg.ShutdownTimeout, 10*time.Second)
 	}
 	if cfg.DebounceWindow != 200*time.Millisecond {
-		t.Errorf("DebounceWindow = %v, 원하는 값 = %v", cfg.DebounceWindow, 200*time.Millisecond)
+		t.Errorf("DebounceWindow = %v, want %v", cfg.DebounceWindow, 200*time.Millisecond)
 	}
-	// init_options 검증
+	// validate init_options
 	if v, ok := cfg.InitOptions["staticcheck"]; !ok || v != true {
-		t.Errorf("InitOptions[staticcheck] = %v, true를 기대했다", v)
+		t.Errorf("InitOptions[staticcheck] = %v, want true", v)
 	}
 }
 
-// TestLoadConfig_MissingFile은 파일이 없으면 기본값을 반환하는지 검증한다.
-// REQ-GB-002 대응: 파일 없음은 오류가 아니라 기본값을 반환한다.
+// TestLoadConfig_MissingFile verifies that default values are returned when the file is absent.
+// REQ-GB-002: missing file is not an error; return defaults instead.
 func TestLoadConfig_MissingFile(t *testing.T) {
 	cfg, err := LoadConfig("/nonexistent/path/lsp.yaml")
 	if err != nil {
-		t.Fatalf("파일 없음 시 오류가 반환됐다: %v (기본값을 기대했다)", err)
+		t.Fatalf("missing file returned error: %v (wanted default values)", err)
 	}
 	if cfg == nil {
-		t.Fatal("파일 없음 시 nil이 반환됐다 (기본값을 기대했다)")
+		t.Fatal("missing file returned nil (wanted default values)")
 	}
-	// 기본값 확인
+	// verify defaults
 	if cfg.Binary != "gopls" {
-		t.Errorf("기본 Binary = %q, 원하는 값 = gopls", cfg.Binary)
+		t.Errorf("default Binary = %q, want gopls", cfg.Binary)
 	}
 }
 
-// TestLoadConfig_InvalidYAML은 잘못된 YAML 파일에서 오류를 반환하는지 검증한다.
+// TestLoadConfig_InvalidYAML verifies that an error is returned for an invalid YAML file.
 func TestLoadConfig_InvalidYAML(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "lsp.yaml")
 	if err := os.WriteFile(configPath, []byte("not: valid: yaml: ["), 0644); err != nil {
-		t.Fatalf("테스트 파일 생성 실패: %v", err)
+		t.Fatalf("failed to create test file: %v", err)
 	}
 
 	_, err := LoadConfig(configPath)
 	if err == nil {
-		t.Error("잘못된 YAML에서 오류가 반환되지 않았다")
+		t.Error("invalid YAML did not return an error")
 	}
 }
 
-// TestLoadConfig_PartialYAML은 일부 필드만 지정된 YAML에서 기본값이 채워지는지 검증한다.
+// TestLoadConfig_PartialYAML verifies that default values fill in unspecified fields in a partial YAML.
 func TestLoadConfig_PartialYAML(t *testing.T) {
 	yaml := `lsp:
     gopls_bridge:
@@ -117,43 +117,43 @@ func TestLoadConfig_PartialYAML(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "lsp.yaml")
 	if err := os.WriteFile(configPath, []byte(yaml), 0644); err != nil {
-		t.Fatalf("테스트 파일 생성 실패: %v", err)
+		t.Fatalf("failed to create test file: %v", err)
 	}
 
 	cfg, err := LoadConfig(configPath)
 	if err != nil {
-		t.Fatalf("LoadConfig 오류: %v", err)
+		t.Fatalf("LoadConfig error: %v", err)
 	}
 	if !cfg.Enabled {
-		t.Error("Enabled = false, true를 기대했다")
+		t.Error("Enabled = false, want true")
 	}
-	// 지정하지 않은 필드는 기본값
+	// unspecified fields use defaults
 	if cfg.Binary != "gopls" {
-		t.Errorf("부분 YAML: Binary = %q, 기본값 gopls를 기대했다", cfg.Binary)
+		t.Errorf("partial YAML: Binary = %q, want default gopls", cfg.Binary)
 	}
 	if cfg.Timeout != 30*time.Second {
-		t.Errorf("부분 YAML: Timeout = %v, 기본값 30s를 기대했다", cfg.Timeout)
+		t.Errorf("partial YAML: Timeout = %v, want default 30s", cfg.Timeout)
 	}
 }
 
-// ─── F5: validateBinary / validateArgs 테스트 ────────────────────────────────
+// ─── F5: validateBinary / validateArgs tests ─────────────────────────────────
 
-// TestValidateBinary_AllowsGopls는 bare name "gopls"가 허용되는지 검증한다.
+// TestValidateBinary_AllowsGopls verifies that the bare name "gopls" is allowed.
 func TestValidateBinary_AllowsGopls(t *testing.T) {
 	if err := validateBinary("gopls"); err != nil {
-		t.Errorf("validateBinary(gopls) = %v, nil을 기대했다", err)
+		t.Errorf("validateBinary(gopls) = %v, want nil", err)
 	}
 }
 
-// TestValidateBinary_RejectsUntrustedPath는 신뢰되지 않은 절대 경로를 거부하는지 검증한다.
+// TestValidateBinary_RejectsUntrustedPath verifies that untrusted absolute paths are rejected.
 func TestValidateBinary_RejectsUntrustedPath(t *testing.T) {
 	err := validateBinary("/tmp/evil/gopls")
 	if err == nil {
-		t.Error("validateBinary(/tmp/evil/gopls)이 오류를 반환하지 않았다")
+		t.Error("validateBinary(/tmp/evil/gopls) did not return an error")
 	}
 }
 
-// TestValidateBinary_AllowsTrustedPrefix는 신뢰된 접두사 경로를 허용하는지 검증한다.
+// TestValidateBinary_AllowsTrustedPrefix verifies that trusted prefix paths are allowed.
 func TestValidateBinary_AllowsTrustedPrefix(t *testing.T) {
 	trustedPaths := []string{
 		"/usr/bin/gopls",
@@ -168,20 +168,20 @@ func TestValidateBinary_AllowsTrustedPrefix(t *testing.T) {
 
 	for _, p := range trustedPaths {
 		if err := validateBinary(p); err != nil {
-			t.Errorf("validateBinary(%q) = %v, nil을 기대했다", p, err)
+			t.Errorf("validateBinary(%q) = %v, want nil", p, err)
 		}
 	}
 }
 
-// TestValidateBinary_RejectsTraversal은 경로 순회 시도를 거부하는지 검증한다.
+// TestValidateBinary_RejectsTraversal verifies that path traversal attempts are rejected.
 func TestValidateBinary_RejectsTraversal(t *testing.T) {
 	err := validateBinary("/usr/local/bin/../../../etc/passwd")
 	if err == nil {
-		t.Error("validateBinary(경로 순회)이 오류를 반환하지 않았다")
+		t.Error("validateBinary(path traversal) did not return an error")
 	}
 }
 
-// TestValidateArgs_RejectsShellMetachars는 쉘 메타문자가 포함된 인수를 거부하는지 검증한다.
+// TestValidateArgs_RejectsShellMetachars verifies that args containing shell metacharacters are rejected.
 func TestValidateArgs_RejectsShellMetachars(t *testing.T) {
 	dangerous := []string{
 		"; rm -rf /",
@@ -195,12 +195,12 @@ func TestValidateArgs_RejectsShellMetachars(t *testing.T) {
 	}
 	for _, arg := range dangerous {
 		if err := validateArgs([]string{arg}); err == nil {
-			t.Errorf("validateArgs(%q)이 오류를 반환하지 않았다", arg)
+			t.Errorf("validateArgs(%q) did not return an error", arg)
 		}
 	}
 }
 
-// TestValidateArgs_AllowsSafeArgs는 안전한 인수를 허용하는지 검증한다.
+// TestValidateArgs_AllowsSafeArgs verifies that safe args are allowed.
 func TestValidateArgs_AllowsSafeArgs(t *testing.T) {
 	safe := [][]string{
 		{},
@@ -210,16 +210,16 @@ func TestValidateArgs_AllowsSafeArgs(t *testing.T) {
 	}
 	for _, args := range safe {
 		if err := validateArgs(args); err != nil {
-			t.Errorf("validateArgs(%v) = %v, nil을 기대했다", args, err)
+			t.Errorf("validateArgs(%v) = %v, want nil", args, err)
 		}
 	}
 }
 
-// TestLoadConfig_RealLSPYaml은 실제 .moai/config/sections/lsp.yaml을 로드할 수 있는지 검증한다.
-// 이 파일이 없으면 테스트를 건너뛴다.
+// TestLoadConfig_RealLSPYaml verifies that the real .moai/config/sections/lsp.yaml can be loaded.
+// Skips if the file is not present.
 func TestLoadConfig_RealLSPYaml(t *testing.T) {
-	// 프로젝트 루트에서 실제 파일 경로를 찾는다.
-	// 테스트는 패키지 디렉토리에서 실행되므로 상위 경로로 이동한다.
+	// find the real file path from project root.
+	// tests run from the package directory, so navigate up.
 	candidates := []string{
 		"../../../.moai/config/sections/lsp.yaml",
 		"../../../../.moai/config/sections/lsp.yaml",
@@ -232,18 +232,18 @@ func TestLoadConfig_RealLSPYaml(t *testing.T) {
 		}
 	}
 	if found == "" {
-		t.Skip("실제 lsp.yaml 파일을 찾을 수 없어 테스트를 건너뜁니다")
+		t.Skip("real lsp.yaml not found, skipping test")
 	}
 
 	cfg, err := LoadConfig(found)
 	if err != nil {
-		t.Fatalf("실제 lsp.yaml 로드 오류: %v", err)
+		t.Fatalf("loading real lsp.yaml error: %v", err)
 	}
 	if cfg == nil {
-		t.Fatal("실제 lsp.yaml 로드 결과 nil")
+		t.Fatal("loading real lsp.yaml returned nil")
 	}
-	// 실제 파일에서는 enabled가 false여야 한다 (기본값)
+	// real file should have enabled=false (default)
 	if cfg.Binary != "gopls" {
-		t.Errorf("Binary = %q, gopls를 기대했다", cfg.Binary)
+		t.Errorf("Binary = %q, want gopls", cfg.Binary)
 	}
 }

--- a/internal/lsp/gopls/handler.go
+++ b/internal/lsp/gopls/handler.go
@@ -7,32 +7,32 @@ import (
 
 // ─── PendingRegistry ─────────────────────────────────────────────────────────
 //
-// REQ-GB-033: 요청 id를 키로 응답 채널을 관리하여 요청-응답을 상관시킨다.
+// REQ-GB-033: correlate requests and responses by managing response channels keyed by request id.
 
-// NotificationHandler는 알림 payload를 처리하는 함수 타입이다.
+// NotificationHandler is the function type that processes a notification payload.
 type NotificationHandler func(payload json.RawMessage)
 
-// PendingRegistry는 진행 중인 요청을 추적하는 레지스트리다.
-// sync.Map을 사용하여 동시성 안전한 방식으로 id → 응답 채널을 관리한다.
+// PendingRegistry is a registry that tracks in-flight requests.
+// Uses sync.Map to manage id → response channel mappings in a concurrency-safe manner.
 //
-// @MX:ANCHOR: [AUTO] 요청-응답 상관 핵심 타입. bridge.go의 readLoop, sendRequest에서 사용한다.
-// @MX:REASON: fan_in >= 3 (Register, Dispatch, Unregister 호출 지점)
+// @MX:ANCHOR: [AUTO] Core type for request-response correlation. Used by readLoop and sendRequest in bridge.go.
+// @MX:REASON: fan_in >= 3 (Register, Dispatch, Unregister call sites)
 type PendingRegistry struct {
-	// sync.Map은 map[int64]chan json.RawMessage를 동시성 안전하게 관리한다.
+		// sync.Map manages map[int64]chan json.RawMessage in a concurrency-safe manner.
 	m sync.Map
 }
 
-// Register는 주어진 id에 대한 응답 채널을 생성하고 등록한다.
-// 반환된 채널은 Dispatch가 호출될 때 payload를 수신한다.
+// Register creates and registers a response channel for the given id.
+// The returned channel receives the payload when Dispatch is called.
 func (r *PendingRegistry) Register(id int64) <-chan json.RawMessage {
-	// 버퍼 크기 1: Dispatch가 발신자를 블록하지 않도록 한다.
+	// Buffer size 1: prevents Dispatch from blocking the sender.
 	ch := make(chan json.RawMessage, 1)
 	r.m.Store(id, ch)
 	return ch
 }
 
-// Dispatch는 id에 해당하는 채널에 payload를 전달하고 채널을 레지스트리에서 제거한다.
-// 등록된 id가 없으면 false를 반환한다.
+// Dispatch delivers the payload to the channel for the given id and removes the channel from the registry.
+// Returns false if no channel is registered for the id.
 func (r *PendingRegistry) Dispatch(id int64, payload json.RawMessage) bool {
 	v, ok := r.m.LoadAndDelete(id)
 	if !ok {
@@ -43,47 +43,47 @@ func (r *PendingRegistry) Dispatch(id int64, payload json.RawMessage) bool {
 	return true
 }
 
-// Unregister는 id에 해당하는 채널을 레지스트리에서 제거한다.
-// 타임아웃 등으로 더 이상 응답을 기다리지 않을 때 호출한다.
+// Unregister removes the channel for the given id from the registry.
+// Called when no longer waiting for a response, e.g. on timeout.
 func (r *PendingRegistry) Unregister(id int64) {
 	r.m.Delete(id)
 }
 
 // ─── NotificationDispatcher ──────────────────────────────────────────────────
 //
-// REQ-GB-034: id 없는 메시지(알림)를 등록된 핸들러에 라우팅한다.
+// REQ-GB-034: route messages without an id (notifications) to registered handlers.
 
-// NotificationDispatcher는 LSP 알림을 메서드별로 등록된 핸들러에 라우팅한다.
-// 뮤텍스로 핸들러 맵을 보호한다.
+// NotificationDispatcher routes LSP notifications to handlers registered by method.
+// The handler map is protected by a mutex.
 type NotificationDispatcher struct {
 	mu       sync.RWMutex
 	handlers map[string]NotificationHandler
 }
 
-// NewNotificationDispatcher는 새 NotificationDispatcher를 생성한다.
+// NewNotificationDispatcher creates a new NotificationDispatcher.
 func NewNotificationDispatcher() *NotificationDispatcher {
 	return &NotificationDispatcher{
 		handlers: make(map[string]NotificationHandler),
 	}
 }
 
-// Register는 method에 대한 핸들러를 등록한다.
-// 같은 method에 두 번 등록하면 이전 핸들러를 덮어쓴다.
+// Register registers a handler for the given method.
+// Registering the same method twice overwrites the previous handler.
 func (d *NotificationDispatcher) Register(method string, handler NotificationHandler) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	d.handlers[method] = handler
 }
 
-// Dispatch는 method에 해당하는 핸들러를 동기적으로 호출한다.
-// 등록된 핸들러가 없으면 무시한다(패닉 없음).
+// Dispatch synchronously calls the handler for the given method.
+// Silently ignored (no panic) when no handler is registered.
 func (d *NotificationDispatcher) Dispatch(method string, payload json.RawMessage) {
 	d.mu.RLock()
 	handler, ok := d.handlers[method]
 	d.mu.RUnlock()
 
 	if !ok {
-		// 알 수 없는 알림은 조용히 무시한다.
+		// Unknown notifications are silently ignored.
 		return
 	}
 	handler(payload)

--- a/internal/lsp/gopls/handler_test.go
+++ b/internal/lsp/gopls/handler_test.go
@@ -8,8 +8,8 @@ import (
 	"time"
 )
 
-// TestPendingRegistry_RegisterAndDispatch는 Register로 채널을 등록하고
-// Dispatch로 payload를 전달하는 기본 흐름을 검증한다.
+// TestPendingRegistry_RegisterAndDispatch verifies the basic flow of registering
+// a channel via Register and delivering a payload via Dispatch.
 func TestPendingRegistry_RegisterAndDispatch(t *testing.T) {
 	t.Parallel()
 
@@ -28,24 +28,24 @@ func TestPendingRegistry_RegisterAndDispatch(t *testing.T) {
 			t.Errorf("payload = %s, want %s", got, payload)
 		}
 	case <-time.After(100 * time.Millisecond):
-		t.Fatal("채널에서 payload를 받지 못함")
+		t.Fatal("did not receive payload from channel")
 	}
 }
 
-// TestPendingRegistry_DispatchUnknownID는 등록되지 않은 ID로 Dispatch할 때
-// false를 반환하는지 검증한다.
+// TestPendingRegistry_DispatchUnknownID verifies that Dispatch with an unregistered
+// ID returns false.
 func TestPendingRegistry_DispatchUnknownID(t *testing.T) {
 	t.Parallel()
 
 	r := &PendingRegistry{}
 	dispatched := r.Dispatch(999, json.RawMessage(`{}`))
 	if dispatched {
-		t.Error("알 수 없는 ID로 Dispatch() = true, want false")
+		t.Error("Dispatch() with unknown ID = true, want false")
 	}
 }
 
-// TestPendingRegistry_UnregisterRemovesEntry는 Unregister 후 Dispatch가 false를
-// 반환하는지 검증한다.
+// TestPendingRegistry_UnregisterRemovesEntry verifies that Dispatch returns false
+// after Unregister.
 func TestPendingRegistry_UnregisterRemovesEntry(t *testing.T) {
 	t.Parallel()
 
@@ -55,12 +55,12 @@ func TestPendingRegistry_UnregisterRemovesEntry(t *testing.T) {
 
 	dispatched := r.Dispatch(10, json.RawMessage(`{}`))
 	if dispatched {
-		t.Error("Unregister 후 Dispatch() = true, want false")
+		t.Error("Dispatch() after Unregister = true, want false")
 	}
 }
 
-// TestPendingRegistry_Concurrent는 동시에 여러 고루틴이 Register/Dispatch를 호출할 때
-// 데이터 경쟁 없이 동작하는지 경쟁 감지기로 검증한다.
+// TestPendingRegistry_Concurrent verifies that concurrent goroutines calling
+// Register/Dispatch operate without data races (verified by the race detector).
 func TestPendingRegistry_Concurrent(t *testing.T) {
 	t.Parallel()
 
@@ -70,13 +70,13 @@ func TestPendingRegistry_Concurrent(t *testing.T) {
 	var wg sync.WaitGroup
 	results := make([]json.RawMessage, numRequests)
 
-	// 모든 채널을 먼저 등록한다.
+	// Register all channels first.
 	channels := make([]<-chan json.RawMessage, numRequests)
 	for i := int64(0); i < numRequests; i++ {
 		channels[i] = r.Register(i)
 	}
 
-	// 수신 고루틴들을 먼저 시작한다.
+	// Start receiver goroutines first.
 	for i := 0; i < numRequests; i++ {
 		wg.Add(1)
 		go func(idx int) {
@@ -85,12 +85,12 @@ func TestPendingRegistry_Concurrent(t *testing.T) {
 			case got := <-channels[idx]:
 				results[idx] = got
 			case <-time.After(2 * time.Second):
-				t.Errorf("고루틴 %d: 타임아웃", idx)
+				t.Errorf("goroutine %d: timeout", idx)
 			}
 		}(i)
 	}
 
-	// Dispatch 고루틴들을 동시에 실행한다.
+	// Run Dispatch goroutines concurrently.
 	var dispatchWg sync.WaitGroup
 	for i := int64(0); i < numRequests; i++ {
 		dispatchWg.Add(1)
@@ -104,15 +104,16 @@ func TestPendingRegistry_Concurrent(t *testing.T) {
 	dispatchWg.Wait()
 	wg.Wait()
 
-	// 모든 결과가 수신되었는지 확인한다.
+	// Verify that all results were received.
 	for i, res := range results {
 		if res == nil {
-			t.Errorf("결과 %d가 nil", i)
+			t.Errorf("result %d is nil", i)
 		}
 	}
 }
 
-// TestNotificationDispatcher_Dispatch는 등록된 핸들러가 올바른 메서드로 호출되는지 검증한다.
+// TestNotificationDispatcher_Dispatch verifies that the registered handler is
+// invoked for the correct method.
 func TestNotificationDispatcher_Dispatch(t *testing.T) {
 	t.Parallel()
 
@@ -129,25 +130,25 @@ func TestNotificationDispatcher_Dispatch(t *testing.T) {
 	d.Dispatch("textDocument/publishDiagnostics", payload)
 
 	if !called {
-		t.Fatal("핸들러가 호출되지 않음")
+		t.Fatal("handler was not invoked")
 	}
 	if string(receivedPayload) != string(payload) {
 		t.Errorf("payload = %s, want %s", receivedPayload, payload)
 	}
 }
 
-// TestNotificationDispatcher_UnknownMethod는 등록되지 않은 메서드에 대해
-// 패닉 없이 무시하는지 검증한다.
+// TestNotificationDispatcher_UnknownMethod verifies that an unregistered method
+// is silently ignored without panic.
 func TestNotificationDispatcher_UnknownMethod(t *testing.T) {
 	t.Parallel()
 
 	d := NewNotificationDispatcher()
-	// 패닉이 발생하지 않아야 한다.
+	// Must not panic.
 	d.Dispatch("window/logMessage", json.RawMessage(`{"message":"hello"}`))
 }
 
-// TestNotificationDispatcher_MultipleHandlers는 여러 메서드에 대한 핸들러를
-// 독립적으로 등록하고 호출하는지 검증한다.
+// TestNotificationDispatcher_MultipleHandlers verifies that handlers for
+// different methods are registered and invoked independently.
 func TestNotificationDispatcher_MultipleHandlers(t *testing.T) {
 	t.Parallel()
 
@@ -170,26 +171,27 @@ func TestNotificationDispatcher_MultipleHandlers(t *testing.T) {
 	mu.Lock()
 	defer mu.Unlock()
 	if !called["textDocument/publishDiagnostics"] {
-		t.Error("publishDiagnostics 핸들러가 호출되지 않음")
+		t.Error("publishDiagnostics handler was not invoked")
 	}
 	if !called["window/logMessage"] {
-		t.Error("logMessage 핸들러가 호출되지 않음")
+		t.Error("logMessage handler was not invoked")
 	}
 }
 
-// TestPendingRegistry_Timeout은 Dispatch가 호출되지 않을 때 채널이 블록 상태를
-// 유지하다가 컨텍스트 취소로 타임아웃되는 패턴을 검증한다.
+// TestPendingRegistry_Timeout verifies that the channel remains blocked when
+// Dispatch is not invoked, and that the wait can be terminated by a context
+// cancellation pattern.
 func TestPendingRegistry_Timeout(t *testing.T) {
 	t.Parallel()
 
 	r := &PendingRegistry{}
 	ch := r.Register(99)
 
-	// Dispatch 없이 짧은 타임아웃으로 채널이 블록되는지 확인한다.
+	// Without Dispatch, verify with a short timeout that the channel stays blocked.
 	select {
 	case <-ch:
-		t.Fatal("Dispatch 없이 채널에서 데이터를 받음")
+		t.Fatal("received data from channel without Dispatch")
 	case <-time.After(50 * time.Millisecond):
-		// 예상대로 타임아웃
+		// timed out as expected
 	}
 }

--- a/internal/lsp/gopls/messages.go
+++ b/internal/lsp/gopls/messages.go
@@ -6,13 +6,13 @@ import (
 	lsp "github.com/modu-ai/moai-adk/internal/lsp"
 )
 
-// ─── JSON-RPC 2.0 봉투 타입 ────────────────────────────────────────────────
+// ─── JSON-RPC 2.0 envelope types ─────────────────────────────────────────────
 //
-// REQ-GB-030: LSP 메시지는 Content-Length 헤더로 프레이밍된 JSON-RPC 2.0 형식이다.
-// REQ-GB-033: id 필드로 요청-응답을 상관시킨다.
-// REQ-GB-034: id가 없는 메시지는 알림으로 처리한다.
+// REQ-GB-030: LSP messages use the JSON-RPC 2.0 format framed with Content-Length headers.
+// REQ-GB-033: correlate requests and responses using the id field.
+// REQ-GB-034: messages without an id are treated as notifications.
 
-// Request는 JSON-RPC 2.0 요청 봉투다. 클라이언트가 서버에 보내는 메시지에 사용한다.
+// Request is a JSON-RPC 2.0 request envelope. Used for messages sent from client to server.
 type Request struct {
 	JSONRPC string          `json:"jsonrpc"`
 	ID      int64           `json:"id"`
@@ -20,16 +20,16 @@ type Request struct {
 	Params  json.RawMessage `json:"params,omitempty"`
 }
 
-// Notification은 id 없는 JSON-RPC 2.0 알림 봉투다.
-// 클라이언트가 서버에, 또는 서버가 클라이언트에 단방향으로 보낸다.
+// Notification is a JSON-RPC 2.0 notification envelope without an id.
+// Sent one-way from client to server, or from server to client.
 type Notification struct {
 	JSONRPC string          `json:"jsonrpc"`
 	Method  string          `json:"method"`
 	Params  json.RawMessage `json:"params,omitempty"`
 }
 
-// Response는 서버에서 클라이언트로 오는 JSON-RPC 2.0 응답 봉투다.
-// 응답(id 있음)과 알림(id 없음, Method 있음) 양쪽을 표현한다.
+// Response is the JSON-RPC 2.0 response envelope received from server to client.
+// It represents both responses (with id) and notifications (without id, with Method).
 type Response struct {
 	JSONRPC string          `json:"jsonrpc"`
 	ID      json.RawMessage `json:"id,omitempty"`
@@ -38,132 +38,132 @@ type Response struct {
 	Error   *ResponseError  `json:"error,omitempty"`
 }
 
-// IsNotification은 이 메시지가 알림(id 없음)인지 판별한다.
-// REQ-GB-034: id 필드가 없으면 알림으로 분류한다.
+// IsNotification returns true if this message is a notification (no id).
+// REQ-GB-034: messages without an id field are classified as notifications.
 func (r *Response) IsNotification() bool {
 	return len(r.ID) == 0
 }
 
-// ResponseError는 JSON-RPC 2.0 에러 객체다.
+// ResponseError is a JSON-RPC 2.0 error object.
 type ResponseError struct {
 	Code    int             `json:"code"`
 	Message string          `json:"message"`
 	Data    json.RawMessage `json:"data,omitempty"`
 }
 
-// ─── LSP 초기화 메시지 ─────────────────────────────────────────────────────
+// ─── LSP initialization messages ─────────────────────────────────────────────
 //
-// REQ-GB-010: initialize 요청 params
-// REQ-GB-011: initialized 알림
+// REQ-GB-010: initialize request params
+// REQ-GB-011: initialized notification
 // REQ-GB-013: initializationOptions.staticcheck: true
 
-// InitializeParams는 LSP `initialize` 요청의 파라미터다.
+// InitializeParams holds the parameters for the LSP `initialize` request.
 type InitializeParams struct {
-	// RootURI는 프로젝트 루트 디렉토리의 파일 URI다.
+	// RootURI is the file URI of the project root directory.
 	RootURI string `json:"rootUri"`
-	// ClientCapabilities는 클라이언트가 지원하는 기능 목록이다.
+	// ClientCapabilities lists the features supported by the client.
 	ClientCapabilities ClientCapabilities `json:"capabilities"`
-	// InitializationOptions는 서버별 초기화 옵션이다.
-	// REQ-GB-013: gopls에서 staticcheck를 활성화한다.
+	// InitializationOptions holds server-specific initialization options.
+	// REQ-GB-013: enables staticcheck in gopls.
 	InitializationOptions map[string]any `json:"initializationOptions,omitempty"`
 }
 
-// ClientCapabilities는 클라이언트가 지원하는 기능 집합이다.
+// ClientCapabilities is the set of features supported by the client.
 type ClientCapabilities struct {
 	TextDocument TextDocumentClientCapabilities `json:"textDocument,omitempty"`
 }
 
-// TextDocumentClientCapabilities는 텍스트 문서 관련 클라이언트 기능이다.
+// TextDocumentClientCapabilities holds the client capabilities for text documents.
 type TextDocumentClientCapabilities struct {
 	PublishDiagnostics PublishDiagnosticsClientCapabilities `json:"publishDiagnostics,omitempty"`
 }
 
-// PublishDiagnosticsClientCapabilities는 publishDiagnostics 알림 관련 클라이언트 기능이다.
-// REQ-GB-010: relatedInformation: true를 설정해야 한다.
+// PublishDiagnosticsClientCapabilities holds client capabilities for the publishDiagnostics notification.
+// REQ-GB-010: relatedInformation must be set to true.
 type PublishDiagnosticsClientCapabilities struct {
 	RelatedInformation bool `json:"relatedInformation,omitempty"`
 }
 
-// InitializeResult는 LSP `initialize` 응답의 결과다.
+// InitializeResult holds the result of the LSP `initialize` response.
 type InitializeResult struct {
 	Capabilities ServerCapabilities `json:"capabilities"`
 }
 
-// ServerCapabilities는 gopls 서버가 지원하는 기능 집합이다.
-// 현재는 사용하지 않지만 구조체 역직렬화를 위해 정의한다.
+// ServerCapabilities is the set of features supported by the gopls server.
+// Currently unused but defined for struct deserialization purposes.
 type ServerCapabilities struct{}
 
-// InitializedParams는 LSP `initialized` 알림의 파라미터다. 항상 빈 객체다.
-// REQ-GB-011: initialize 응답 수신 후 전송한다.
+// InitializedParams holds the parameters for the LSP `initialized` notification. Always an empty object.
+// REQ-GB-011: sent after receiving the initialize response.
 type InitializedParams struct{}
 
-// ─── 텍스트 문서 메시지 ────────────────────────────────────────────────────
+// ─── Text document messages ────────────────────────────────────────────────
 
-// DidOpenTextDocumentParams는 LSP `textDocument/didOpen` 알림의 파라미터다.
-// REQ-GB-020: 파일을 열어 diagnostics를 수집한다.
+// DidOpenTextDocumentParams holds the parameters for the LSP `textDocument/didOpen` notification.
+// REQ-GB-020: opens a file to collect diagnostics.
 type DidOpenTextDocumentParams struct {
 	TextDocument TextDocumentItem `json:"textDocument"`
 }
 
-// TextDocumentItem은 LSP 텍스트 문서를 표현한다.
+// TextDocumentItem represents an LSP text document.
 type TextDocumentItem struct {
-	// URI는 문서의 파일 URI다. (예: "file:///workspace/main.go")
+	// URI is the file URI of the document (e.g., "file:///workspace/main.go").
 	URI string `json:"uri"`
-	// LanguageID는 언어 식별자다. Go 파일은 "go"다.
+	// LanguageID is the language identifier. Go files use "go".
 	LanguageID string `json:"languageId"`
-	// Version은 문서 버전 번호다. 1부터 시작한다.
+	// Version is the document version number. Starts at 1.
 	Version int `json:"version"`
-	// Text는 문서의 전체 텍스트 내용이다.
+	// Text is the full text content of the document.
 	Text string `json:"text"`
 }
 
-// ─── 진단 메시지 ──────────────────────────────────────────────────────────
+// ─── Diagnostic messages ──────────────────────────────────────────────────
 //
-// REQ-GB-023: severity, source, code, message, range 필드를 포함해야 한다.
-// REQ-UTIL-003-007: gopls.Diagnostic / Range / Position / DiagnosticSeverity는
-// lsp 패키지 정의의 타입 별칭이다. 단일 출처(single source of truth) 보장.
-// 기존 gopls 호출자는 타입 별칭의 동일성(identity) 의미론으로 수정 없이 컴파일된다.
+// REQ-GB-023: must include severity, source, code, message, and range fields.
+// REQ-UTIL-003-007: gopls.Diagnostic / Range / Position / DiagnosticSeverity are
+// type aliases for the types defined in the lsp package. This guarantees a single source of truth.
+// Existing gopls callers compile without modification due to type alias identity semantics.
 
-// PublishDiagnosticsParams는 `textDocument/publishDiagnostics` 알림의 파라미터다.
+// PublishDiagnosticsParams holds the parameters for the `textDocument/publishDiagnostics` notification.
 type PublishDiagnosticsParams struct {
-	// URI는 이 진단이 속하는 문서의 파일 URI다.
+	// URI is the file URI of the document to which these diagnostics belong.
 	URI string `json:"uri"`
-	// Diagnostics는 이 문서에 대한 진단 목록이다. 빈 슬라이스면 문제 없음을 의미한다.
+	// Diagnostics is the list of diagnostics for this document. An empty slice means no issues.
 	Diagnostics []Diagnostic `json:"diagnostics"`
 }
 
-// Diagnostic은 lsp.Diagnostic의 타입 별칭이다 (REQ-UTIL-003-007).
-// reflect.TypeOf(gopls.Diagnostic{}) == reflect.TypeOf(lsp.Diagnostic{})가 보장된다.
+// Diagnostic is a type alias for lsp.Diagnostic (REQ-UTIL-003-007).
+// Guarantees reflect.TypeOf(gopls.Diagnostic{}) == reflect.TypeOf(lsp.Diagnostic{}).
 type Diagnostic = lsp.Diagnostic
 
-// Range는 lsp.Range의 타입 별칭이다 (REQ-UTIL-003-007).
+// Range is a type alias for lsp.Range (REQ-UTIL-003-007).
 type Range = lsp.Range
 
-// Position은 lsp.Position의 타입 별칭이다 (REQ-UTIL-003-007).
+// Position is a type alias for lsp.Position (REQ-UTIL-003-007).
 type Position = lsp.Position
 
-// DiagnosticSeverity는 lsp.DiagnosticSeverity의 타입 별칭이다 (REQ-UTIL-003-007).
-// LSP 3.17 사양의 DiagnosticSeverity 값과 일치한다 (int 기반, 1=Error, 2=Warning, 3=Info, 4=Hint).
+// DiagnosticSeverity is a type alias for lsp.DiagnosticSeverity (REQ-UTIL-003-007).
+// Matches the DiagnosticSeverity values from LSP 3.17 spec (int-based: 1=Error, 2=Warning, 3=Info, 4=Hint).
 type DiagnosticSeverity = lsp.DiagnosticSeverity
 
 const (
-	// SeverityError는 오류 진단이다 (값: 1).
+	// SeverityError is an error diagnostic (value: 1).
 	SeverityError DiagnosticSeverity = 1
-	// SeverityWarning은 경고 진단이다 (값: 2).
+	// SeverityWarning is a warning diagnostic (value: 2).
 	SeverityWarning DiagnosticSeverity = 2
-	// SeverityInformation은 정보성 진단이다 (값: 3).
-	// 참고: lsp 패키지는 동일 값을 SeverityInfo로 명명한다.
+	// SeverityInformation is an informational diagnostic (value: 3).
+	// Note: the lsp package names the same value SeverityInfo.
 	SeverityInformation DiagnosticSeverity = 3
-	// SeverityHint는 힌트 진단이다 (값: 4).
+	// SeverityHint is a hint diagnostic (value: 4).
 	SeverityHint DiagnosticSeverity = 4
 )
 
-// ─── 종료 메시지 ──────────────────────────────────────────────────────────
+// ─── Shutdown messages ──────────────────────────────────────────────────────
 //
-// REQ-GB-004: shutdown/exit 시퀀스로 gopls를 종료한다.
+// REQ-GB-004: terminates gopls using the shutdown/exit sequence.
 
-// ShutdownParams는 LSP `shutdown` 요청의 파라미터다. 항상 null이다.
+// ShutdownParams holds the parameters for the LSP `shutdown` request. Always null.
 type ShutdownParams struct{}
 
-// ExitParams는 LSP `exit` 알림의 파라미터다. 항상 null이다.
+// ExitParams holds the parameters for the LSP `exit` notification. Always null.
 type ExitParams struct{}

--- a/internal/lsp/gopls/messages_alias_test.go
+++ b/internal/lsp/gopls/messages_alias_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/modu-ai/moai-adk/internal/lsp/gopls"
 )
 
-// TestDiagnosticAlias_TypeIdentity는 gopls.Diagnostic이 lsp.Diagnostic과
-// 동일한 타입임을 reflect.TypeOf로 확인한다 (AC-UTIL-003-007).
+// TestDiagnosticAlias_TypeIdentity verifies via reflect.TypeOf that
+// gopls.Diagnostic and lsp.Diagnostic are the same type (AC-UTIL-003-007).
 func TestDiagnosticAlias_TypeIdentity(t *testing.T) {
 	t.Parallel()
 
@@ -22,8 +22,8 @@ func TestDiagnosticAlias_TypeIdentity(t *testing.T) {
 	}
 }
 
-// TestRangeAlias_TypeIdentity는 gopls.Range가 lsp.Range와
-// 동일한 타입임을 확인한다 (AC-UTIL-003-007).
+// TestRangeAlias_TypeIdentity verifies that gopls.Range and lsp.Range are
+// the same type (AC-UTIL-003-007).
 func TestRangeAlias_TypeIdentity(t *testing.T) {
 	t.Parallel()
 
@@ -32,8 +32,8 @@ func TestRangeAlias_TypeIdentity(t *testing.T) {
 	}
 }
 
-// TestPositionAlias_TypeIdentity는 gopls.Position이 lsp.Position과
-// 동일한 타입임을 확인한다 (AC-UTIL-003-007).
+// TestPositionAlias_TypeIdentity verifies that gopls.Position and lsp.Position
+// are the same type (AC-UTIL-003-007).
 func TestPositionAlias_TypeIdentity(t *testing.T) {
 	t.Parallel()
 
@@ -42,7 +42,7 @@ func TestPositionAlias_TypeIdentity(t *testing.T) {
 	}
 }
 
-// TestSeverityError_Equality는 gopls.SeverityError == lsp.SeverityError를 확인한다 (AC-UTIL-003-007).
+// TestSeverityError_Equality verifies gopls.SeverityError == lsp.SeverityError (AC-UTIL-003-007).
 func TestSeverityError_Equality(t *testing.T) {
 	t.Parallel()
 
@@ -52,19 +52,21 @@ func TestSeverityError_Equality(t *testing.T) {
 	}
 }
 
-// TestDiagnosticAlias_Interoperability는 lsp.Diagnostic 값을 gopls.Diagnostic으로
-// 타입 변환 없이 대입할 수 있음을 컴파일 시점에 검증한다 (AC-UTIL-003-007).
+// TestDiagnosticAlias_Interoperability verifies at compile time that an
+// lsp.Diagnostic value can be assigned to a gopls.Diagnostic without a type
+// conversion (AC-UTIL-003-007).
 func TestDiagnosticAlias_Interoperability(t *testing.T) {
 	t.Parallel()
 
-	// 타입 별칭이면 대입이 컴파일되고 값이 동일해야 함
+	// If aliased, the assignment compiles and the value must be the same.
 	lspDiag := lsp.Diagnostic{
 		Severity: lsp.SeverityError,
 		Message:  "undefined: foo",
 	}
 
-	// 타입 별칭: 추가 변환 없이 대입 가능
-	// ST1023 nolint: 타입 어노테이션이 테스트의 의도(별칭 식별성 대입 증명)
+	// Type alias: assignment without an explicit conversion compiles.
+	// ST1023 nolint: the type annotation is intentional — it documents the test intent
+	// (proving alias identity through the assignment).
 	//nolint:staticcheck // ST1023
 	var goplsDiag gopls.Diagnostic = lspDiag
 	if goplsDiag.Message != lspDiag.Message {

--- a/internal/lsp/gopls/messages_test.go
+++ b/internal/lsp/gopls/messages_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 )
 
-// TestRequestEnvelope_Serialization은 Request 봉투가 JSON-RPC 2.0 규격에 맞게
-// 직렬화되는지 검증한다.
+// TestRequestEnvelope_Serialization verifies that the Request envelope is
+// serialized according to the JSON-RPC 2.0 specification.
 func TestRequestEnvelope_Serialization(t *testing.T) {
 	t.Parallel()
 
@@ -19,12 +19,12 @@ func TestRequestEnvelope_Serialization(t *testing.T) {
 
 	data, err := json.Marshal(req)
 	if err != nil {
-		t.Fatalf("Request 직렬화 실패: %v", err)
+		t.Fatalf("Request marshal failed: %v", err)
 	}
 
 	var got map[string]any
 	if err := json.Unmarshal(data, &got); err != nil {
-		t.Fatalf("역직렬화 실패: %v", err)
+		t.Fatalf("unmarshal failed: %v", err)
 	}
 
 	if got["jsonrpc"] != "2.0" {
@@ -35,8 +35,8 @@ func TestRequestEnvelope_Serialization(t *testing.T) {
 	}
 }
 
-// TestNotificationEnvelope_NoID는 Notification 봉투에 id 필드가 없는지 검증한다.
-// LSP 3.17: notification은 id 필드를 가지지 않는다.
+// TestNotificationEnvelope_NoID verifies that the Notification envelope has no
+// id field. LSP 3.17: notifications do not carry an id.
 func TestNotificationEnvelope_NoID(t *testing.T) {
 	t.Parallel()
 
@@ -48,23 +48,24 @@ func TestNotificationEnvelope_NoID(t *testing.T) {
 
 	data, err := json.Marshal(n)
 	if err != nil {
-		t.Fatalf("Notification 직렬화 실패: %v", err)
+		t.Fatalf("Notification marshal failed: %v", err)
 	}
 
 	var got map[string]any
 	if err := json.Unmarshal(data, &got); err != nil {
-		t.Fatalf("역직렬화 실패: %v", err)
+		t.Fatalf("unmarshal failed: %v", err)
 	}
 
 	if _, ok := got["id"]; ok {
-		t.Error("Notification에 id 필드가 있어서는 안 됨")
+		t.Error("Notification must not contain an id field")
 	}
 	if got["method"] != "initialized" {
 		t.Errorf("method = %v, want initialized", got["method"])
 	}
 }
 
-// TestResponseEnvelope_WithResult는 Response 봉투가 result 필드를 올바르게 갖는지 검증한다.
+// TestResponseEnvelope_WithResult verifies that the Response envelope carries
+// the result field correctly.
 func TestResponseEnvelope_WithResult(t *testing.T) {
 	t.Parallel()
 
@@ -76,20 +77,21 @@ func TestResponseEnvelope_WithResult(t *testing.T) {
 
 	data, err := json.Marshal(resp)
 	if err != nil {
-		t.Fatalf("Response 직렬화 실패: %v", err)
+		t.Fatalf("Response marshal failed: %v", err)
 	}
 
 	var got map[string]any
 	if err := json.Unmarshal(data, &got); err != nil {
-		t.Fatalf("역직렬화 실패: %v", err)
+		t.Fatalf("unmarshal failed: %v", err)
 	}
 
 	if _, ok := got["result"]; !ok {
-		t.Error("Response에 result 필드가 없음")
+		t.Error("Response missing result field")
 	}
 }
 
-// TestResponse_IsNotification은 응답 봉투의 알림 여부를 올바르게 판별하는지 검증한다.
+// TestResponse_IsNotification verifies that the response envelope correctly
+// identifies whether it represents a notification.
 func TestResponse_IsNotification(t *testing.T) {
 	t.Parallel()
 
@@ -99,12 +101,12 @@ func TestResponse_IsNotification(t *testing.T) {
 		wantBool bool
 	}{
 		{
-			name:     "ID 없음 = 알림",
+			name:     "no ID = notification",
 			resp:     Response{JSONRPC: "2.0", Method: "textDocument/publishDiagnostics"},
 			wantBool: true,
 		},
 		{
-			name:     "ID 있음 = 응답",
+			name:     "with ID = response",
 			resp:     Response{JSONRPC: "2.0", ID: json.RawMessage(`1`), Result: json.RawMessage(`{}`)},
 			wantBool: false,
 		},
@@ -121,8 +123,8 @@ func TestResponse_IsNotification(t *testing.T) {
 	}
 }
 
-// TestInitializeParams_Serialization은 InitializeParams가 올바르게 직렬화되는지 검증한다.
-// REQ-GB-010: rootUri와 publishDiagnostics.relatedInformation이 포함되어야 한다.
+// TestInitializeParams_Serialization verifies that InitializeParams serializes correctly.
+// REQ-GB-010: rootUri and publishDiagnostics.relatedInformation must be included.
 func TestInitializeParams_Serialization(t *testing.T) {
 	t.Parallel()
 
@@ -140,12 +142,12 @@ func TestInitializeParams_Serialization(t *testing.T) {
 
 	data, err := json.Marshal(params)
 	if err != nil {
-		t.Fatalf("InitializeParams 직렬화 실패: %v", err)
+		t.Fatalf("InitializeParams marshal failed: %v", err)
 	}
 
 	var got map[string]any
 	if err := json.Unmarshal(data, &got); err != nil {
-		t.Fatalf("역직렬화 실패: %v", err)
+		t.Fatalf("unmarshal failed: %v", err)
 	}
 
 	if got["rootUri"] != "file:///workspace" {
@@ -160,7 +162,8 @@ func TestInitializeParams_Serialization(t *testing.T) {
 	}
 }
 
-// TestDiagnosticSeverity_Values는 DiagnosticSeverity 상수값이 LSP 3.17 규격과 일치하는지 검증한다.
+// TestDiagnosticSeverity_Values verifies that the DiagnosticSeverity constant
+// values match the LSP 3.17 specification.
 func TestDiagnosticSeverity_Values(t *testing.T) {
 	t.Parallel()
 
@@ -181,8 +184,8 @@ func TestDiagnosticSeverity_Values(t *testing.T) {
 	}
 }
 
-// TestPublishDiagnosticsParams_Deserialization은 gopls가 보내는
-// publishDiagnostics 알림의 params를 올바르게 역직렬화하는지 검증한다.
+// TestPublishDiagnosticsParams_Deserialization verifies that the params of the
+// publishDiagnostics notification sent by gopls are deserialized correctly.
 func TestPublishDiagnosticsParams_Deserialization(t *testing.T) {
 	t.Parallel()
 
@@ -203,14 +206,14 @@ func TestPublishDiagnosticsParams_Deserialization(t *testing.T) {
 
 	var params PublishDiagnosticsParams
 	if err := json.Unmarshal([]byte(raw), &params); err != nil {
-		t.Fatalf("역직렬화 실패: %v", err)
+		t.Fatalf("unmarshal failed: %v", err)
 	}
 
 	if params.URI != "file:///workspace/main.go" {
 		t.Errorf("URI = %q, want file:///workspace/main.go", params.URI)
 	}
 	if len(params.Diagnostics) != 1 {
-		t.Fatalf("Diagnostics 개수 = %d, want 1", len(params.Diagnostics))
+		t.Fatalf("Diagnostics count = %d, want 1", len(params.Diagnostics))
 	}
 
 	d := params.Diagnostics[0]
@@ -228,8 +231,8 @@ func TestPublishDiagnosticsParams_Deserialization(t *testing.T) {
 	}
 }
 
-// TestDidOpenTextDocumentParams_Serialization은 didOpen 알림의 params가
-// 올바르게 직렬화되는지 검증한다.
+// TestDidOpenTextDocumentParams_Serialization verifies that the params of the
+// didOpen notification serialize correctly.
 func TestDidOpenTextDocumentParams_Serialization(t *testing.T) {
 	t.Parallel()
 
@@ -244,12 +247,12 @@ func TestDidOpenTextDocumentParams_Serialization(t *testing.T) {
 
 	data, err := json.Marshal(params)
 	if err != nil {
-		t.Fatalf("직렬화 실패: %v", err)
+		t.Fatalf("marshal failed: %v", err)
 	}
 
 	var got DidOpenTextDocumentParams
 	if err := json.Unmarshal(data, &got); err != nil {
-		t.Fatalf("역직렬화 실패: %v", err)
+		t.Fatalf("unmarshal failed: %v", err)
 	}
 
 	if got.TextDocument.URI != "file:///workspace/main.go" {

--- a/internal/lsp/gopls/protocol.go
+++ b/internal/lsp/gopls/protocol.go
@@ -1,6 +1,6 @@
-// Package gopls는 gopls 서브프로세스와 통신하는 자체 구현 LSP 클라이언트를 제공한다.
-// 외부 라이브러리 없이 표준 라이브러리만으로 JSON-RPC 2.0 Content-Length 프레이밍을 구현한다.
-// REQ-GB-060..062: encoding/json, bufio, os/exec, context, sync, log/slog만 사용한다.
+// Package gopls provides a self-implemented LSP client for communicating with the gopls subprocess.
+// Implements JSON-RPC 2.0 Content-Length framing using only the standard library without external dependencies.
+// REQ-GB-060..062: only encoding/json, bufio, os/exec, context, sync, log/slog are used.
 package gopls
 
 import (
@@ -13,78 +13,78 @@ import (
 	"strings"
 )
 
-// Writer는 LSP Content-Length 프레이밍을 적용하여 JSON-RPC 메시지를 기록한다.
-// REQ-GB-030, REQ-GB-032: Content-Length 헤더 형식 `Content-Length: N\r\n\r\n<json>`으로 직렬화한다.
+// Writer writes JSON-RPC messages with LSP Content-Length framing applied.
+// REQ-GB-030, REQ-GB-032: serializes in Content-Length header format `Content-Length: N\r\n\r\n<json>`.
 type Writer struct {
 	w io.Writer
 }
 
-// NewWriter는 주어진 io.Writer를 감싸는 Writer를 생성한다.
+// NewWriter creates a Writer wrapping the given io.Writer.
 func NewWriter(w io.Writer) *Writer {
 	return &Writer{w: w}
 }
 
-// Write는 msg를 JSON으로 직렬화하고 Content-Length 헤더와 함께 기록한다.
-// REQ-GB-032: Content-Length를 계산하고 프레임 전체를 원자적으로 기록한다.
+// Write serializes msg as JSON and writes it with a Content-Length header.
+// REQ-GB-032: computes Content-Length and writes the entire frame atomically.
 func (w *Writer) Write(msg any) error {
 	body, err := json.Marshal(msg)
 	if err != nil {
-		return fmt.Errorf("gopls: write: JSON 직렬화 실패: %w", err)
+		return fmt.Errorf("gopls: write: JSON serialization failed: %w", err)
 	}
 
 	var buf bytes.Buffer
-	// LSP Content-Length 헤더 형식: `Content-Length: N\r\n\r\n`
+	// LSP Content-Length header format: `Content-Length: N\r\n\r\n`
 	fmt.Fprintf(&buf, "Content-Length: %d\r\n\r\n", len(body))
 	buf.Write(body)
 
 	_, err = w.w.Write(buf.Bytes())
 	if err != nil {
-		return fmt.Errorf("gopls: write: 스트림 기록 실패: %w", err)
+		return fmt.Errorf("gopls: write: stream write failed: %w", err)
 	}
 	return nil
 }
 
-// Reader는 LSP Content-Length 프레이밍으로 인코딩된 스트림에서 JSON-RPC 메시지를 읽는다.
-// REQ-GB-031: Content-Length 헤더를 파싱하고 정확히 N바이트를 읽는다.
+// Reader reads JSON-RPC messages from a stream encoded with LSP Content-Length framing.
+// REQ-GB-031: parses the Content-Length header and reads exactly N bytes.
 type Reader struct {
 	r *bufio.Reader
 }
 
-// NewReader는 주어진 io.Reader를 감싸는 Reader를 생성한다.
-// 내부적으로 bufio.Reader를 사용하여 헤더 파싱 성능을 높인다.
+// NewReader creates a Reader wrapping the given io.Reader.
+// Internally uses bufio.Reader to improve header parsing performance.
 func NewReader(r io.Reader) *Reader {
 	return &Reader{r: bufio.NewReader(r)}
 }
 
-// Read는 다음 LSP 메시지를 읽어 JSON 원시 바이트를 반환한다.
-// 스트림이 끝나면 io.EOF를 반환한다.
+// Read reads the next LSP message and returns raw JSON bytes.
+// Returns io.EOF when the stream ends.
 func (r *Reader) Read() (json.RawMessage, error) {
 	length, err := parseHeaders(r.r)
 	if err != nil {
 		return nil, err
 	}
 
-	// 정확히 length 바이트를 읽는다.
+	// Read exactly length bytes.
 	body := make([]byte, length)
 	if _, err := io.ReadFull(r.r, body); err != nil {
-		return nil, fmt.Errorf("gopls: read: 바디 읽기 실패 (선언 길이 %d): %w", length, err)
+		return nil, fmt.Errorf("gopls: read: body read failed (declared length %d): %w", length, err)
 	}
 	return json.RawMessage(body), nil
 }
 
-// parseHeaders는 LSP 헤더 섹션(`\r\n\r\n` 종료)을 파싱하여 Content-Length 값을 반환한다.
-// REQ-GB-031: Content-Length 헤더를 찾을 때까지 줄을 읽고, 이중 CRLF에서 멈춘다.
+// parseHeaders parses the LSP header section (terminated by `\r\n\r\n`) and returns the Content-Length value.
+// REQ-GB-031: reads lines until it finds the Content-Length header, stopping at the double CRLF.
 //
-// 테스트에서도 호출 가능하도록 io.Reader를 받는다. 내부적으로 bufio.Reader로 변환한다.
+// Accepts io.Reader so it can be called from tests. Converts internally to bufio.Reader.
 //
-// 지원 형식:
+// Supported format:
 //
 //	Content-Length: N\r\n
-//	Content-Type: ...\r\n  (선택적, 무시)
+//	Content-Type: ...\r\n  (optional, ignored)
 //	\r\n
 func parseHeaders(r io.Reader) (int, error) {
-	// Reader.Read()는 이미 bufio.Reader를 전달하지만, 테스트에서는 strings.Reader를 전달한다.
-	// bufio.NewReader는 이미 *bufio.Reader인 경우 그대로 반환하지 않으므로 타입 스위치를 사용한다.
+	// Reader.Read() passes a bufio.Reader, but tests may pass a strings.Reader.
+	// bufio.NewReader does not return the existing *bufio.Reader as-is, so use a type switch.
 	var br *bufio.Reader
 	if b, ok := r.(*bufio.Reader); ok {
 		br = b
@@ -98,35 +98,35 @@ func parseHeaders(r io.Reader) (int, error) {
 		line, err := br.ReadString('\n')
 		if err != nil {
 			if err == io.EOF {
-				// EOF이면서 아직 헤더 종료를 못 만났을 때
+				// EOF reached before finding end of headers
 				if line == "" {
 					return 0, io.EOF
 				}
 			} else {
-				return 0, fmt.Errorf("gopls: 헤더 읽기 실패: %w", err)
+				return 0, fmt.Errorf("gopls: header read failed: %w", err)
 			}
 		}
 
-		// CRLF 정규화: \r\n 또는 \n 처리
+		// Normalize CRLF: handle \r\n or \n
 		line = strings.TrimRight(line, "\r\n")
 
-		// 빈 줄 = 헤더 종료 신호
+		// Empty line signals end of headers
 		if line == "" {
 			if contentLength == -1 {
-				return 0, fmt.Errorf("gopls: 헤더에 Content-Length 없음")
+				return 0, fmt.Errorf("gopls: no Content-Length in headers")
 			}
 			return contentLength, nil
 		}
 
-		// Content-Length 헤더만 파싱한다. 다른 헤더(Content-Type 등)는 무시한다.
+		// Parse only the Content-Length header; ignore other headers (Content-Type, etc.).
 		if strings.HasPrefix(line, "Content-Length:") {
 			val := strings.TrimSpace(strings.TrimPrefix(line, "Content-Length:"))
 			n, err := strconv.Atoi(val)
 			if err != nil {
-				return 0, fmt.Errorf("gopls: Content-Length 파싱 실패 %q: %w", val, err)
+				return 0, fmt.Errorf("gopls: Content-Length parse failed %q: %w", val, err)
 			}
 			if n < 0 {
-				return 0, fmt.Errorf("gopls: Content-Length 음수 값: %d", n)
+				return 0, fmt.Errorf("gopls: Content-Length negative value: %d", n)
 			}
 			contentLength = n
 		}

--- a/internal/lsp/gopls/protocol_test.go
+++ b/internal/lsp/gopls/protocol_test.go
@@ -8,8 +8,9 @@ import (
 	"testing"
 )
 
-// TestWriter_Write_RoundTrip는 Writer가 Content-Length 헤더와 함께 JSON을 올바르게
-// 직렬화하고 Reader가 동일한 데이터를 복원하는지 라운드트립 검증한다.
+// TestWriter_Write_RoundTrip verifies that Writer correctly serializes JSON with
+// the Content-Length header and that Reader recovers the same data — a
+// round-trip check.
 func TestWriter_Write_RoundTrip(t *testing.T) {
 	t.Parallel()
 
@@ -19,22 +20,22 @@ func TestWriter_Write_RoundTrip(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:    "단순 객체",
+			name:    "simple object",
 			msg:     map[string]string{"method": "initialize", "jsonrpc": "2.0"},
 			wantErr: false,
 		},
 		{
-			name:    "중첩 구조체",
+			name:    "nested struct",
 			msg:     map[string]any{"id": 1, "params": map[string]string{"rootUri": "file:///tmp"}},
 			wantErr: false,
 		},
 		{
-			name:    "빈 객체",
+			name:    "empty object",
 			msg:     map[string]any{},
 			wantErr: false,
 		},
 		{
-			name:    "유니코드 포함",
+			name:    "with unicode",
 			msg:     map[string]string{"message": "오류: 파일을 찾을 수 없음 — héllo wörld"},
 			wantErr: false,
 		},
@@ -49,26 +50,26 @@ func TestWriter_Write_RoundTrip(t *testing.T) {
 
 			err := w.Write(tt.msg)
 			if (err != nil) != tt.wantErr {
-				t.Fatalf("Write() 에러 = %v, wantErr %v", err, tt.wantErr)
+				t.Fatalf("Write() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if tt.wantErr {
 				return
 			}
 
-			// 작성된 데이터를 Reader로 다시 읽어서 원본과 비교한다.
+			// Read the written data back through Reader and compare with the original.
 			r := NewReader(&buf)
 			raw, err := r.Read()
 			if err != nil {
-				t.Fatalf("Read() 에러 = %v", err)
+				t.Fatalf("Read() error = %v", err)
 			}
 
-			// JSON 역직렬화 후 원본과 비교한다.
+			// Unmarshal JSON and compare with the original.
 			var got any
 			if err := json.Unmarshal(raw, &got); err != nil {
-				t.Fatalf("Unmarshal 에러 = %v", err)
+				t.Fatalf("Unmarshal error = %v", err)
 			}
 
-			// 원본도 JSON 직렬화/역직렬화 후 비교하여 타입 정규화를 맞춘다.
+			// Marshal/unmarshal the original too to normalize types for comparison.
 			orig, _ := json.Marshal(tt.msg)
 			var want any
 			_ = json.Unmarshal(orig, &want)
@@ -76,14 +77,14 @@ func TestWriter_Write_RoundTrip(t *testing.T) {
 			gotJSON, _ := json.Marshal(got)
 			wantJSON, _ := json.Marshal(want)
 			if string(gotJSON) != string(wantJSON) {
-				t.Errorf("라운드트립 불일치:\n got = %s\nwant = %s", gotJSON, wantJSON)
+				t.Errorf("round-trip mismatch:\n got = %s\nwant = %s", gotJSON, wantJSON)
 			}
 		})
 	}
 }
 
-// TestReader_Read_MultipleMessages는 버퍼에 여러 메시지가 연속으로 있을 때
-// 각 메시지를 순서대로 읽는지 검증한다.
+// TestReader_Read_MultipleMessages verifies that when multiple messages are
+// concatenated in a buffer, each one is read in order.
 func TestReader_Read_MultipleMessages(t *testing.T) {
 	t.Parallel()
 
@@ -97,7 +98,7 @@ func TestReader_Read_MultipleMessages(t *testing.T) {
 	w := NewWriter(&buf)
 	for _, m := range msgs {
 		if err := w.Write(m); err != nil {
-			t.Fatalf("Write() 에러 = %v", err)
+			t.Fatalf("Write() error = %v", err)
 		}
 	}
 
@@ -105,22 +106,22 @@ func TestReader_Read_MultipleMessages(t *testing.T) {
 	for i, want := range msgs {
 		raw, err := r.Read()
 		if err != nil {
-			t.Fatalf("메시지 %d Read() 에러 = %v", i, err)
+			t.Fatalf("message %d Read() error = %v", i, err)
 		}
 		var got map[string]any
 		if err := json.Unmarshal(raw, &got); err != nil {
-			t.Fatalf("메시지 %d Unmarshal 에러 = %v", i, err)
+			t.Fatalf("message %d Unmarshal error = %v", i, err)
 		}
 		wantJSON, _ := json.Marshal(want)
 		gotJSON, _ := json.Marshal(got)
 		if string(gotJSON) != string(wantJSON) {
-			t.Errorf("메시지 %d 불일치:\n got = %s\nwant = %s", i, gotJSON, wantJSON)
+			t.Errorf("message %d mismatch:\n got = %s\nwant = %s", i, gotJSON, wantJSON)
 		}
 	}
 }
 
-// TestReader_Read_MalformedHeader는 잘못된 Content-Length 헤더를 파싱할 때
-// 에러를 반환하는지 검증한다.
+// TestReader_Read_MalformedHeader verifies that parsing a malformed
+// Content-Length header returns an error.
 func TestReader_Read_MalformedHeader(t *testing.T) {
 	t.Parallel()
 
@@ -130,22 +131,22 @@ func TestReader_Read_MalformedHeader(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:    "Content-Length 누락",
+			name:    "missing Content-Length",
 			input:   "Content-Type: application/json\r\n\r\n{}",
 			wantErr: true,
 		},
 		{
-			name:    "Content-Length 값이 숫자가 아님",
+			name:    "non-numeric Content-Length",
 			input:   "Content-Length: abc\r\n\r\n{}",
 			wantErr: true,
 		},
 		{
-			name:    "Content-Length가 음수",
+			name:    "negative Content-Length",
 			input:   "Content-Length: -1\r\n\r\n{}",
 			wantErr: true,
 		},
 		{
-			name:    "헤더 구분자 없음",
+			name:    "missing header delimiter",
 			input:   "Content-Length: 2{}",
 			wantErr: true,
 		},
@@ -157,38 +158,39 @@ func TestReader_Read_MalformedHeader(t *testing.T) {
 			r := NewReader(strings.NewReader(tt.input))
 			_, err := r.Read()
 			if (err != nil) != tt.wantErr {
-				t.Errorf("Read() 에러 = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("Read() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}
 }
 
-// TestReader_Read_TruncatedStream는 선언된 Content-Length보다 실제 바디가 짧을 때
-// 에러를 반환하는지 검증한다.
+// TestReader_Read_TruncatedStream verifies that when the actual body is shorter
+// than the declared Content-Length, an error is returned.
 func TestReader_Read_TruncatedStream(t *testing.T) {
 	t.Parallel()
 
-	// Content-Length: 100이지만 실제로는 2바이트만 제공한다.
+	// Content-Length: 100 but only 2 bytes are actually provided.
 	input := "Content-Length: 100\r\n\r\n{}"
 	r := NewReader(strings.NewReader(input))
 	_, err := r.Read()
 	if err == nil {
-		t.Fatal("짧은 스트림에서 에러를 기대했지만 nil 반환")
+		t.Fatal("expected error on truncated stream, got nil")
 	}
 }
 
-// TestReader_Read_EOF는 빈 스트림에서 Read를 호출할 때 io.EOF를 반환하는지 검증한다.
+// TestReader_Read_EOF verifies that calling Read on an empty stream returns io.EOF.
 func TestReader_Read_EOF(t *testing.T) {
 	t.Parallel()
 
 	r := NewReader(strings.NewReader(""))
 	_, err := r.Read()
 	if err != io.EOF && err != io.ErrUnexpectedEOF {
-		t.Errorf("빈 스트림에서 io.EOF 또는 io.ErrUnexpectedEOF를 기대했지만: %v", err)
+		t.Errorf("expected io.EOF or io.ErrUnexpectedEOF for empty stream, got: %v", err)
 	}
 }
 
-// TestParseHeaders_Valid는 올바른 헤더 시퀀스를 파싱하여 Content-Length를 반환하는지 검증한다.
+// TestParseHeaders_Valid verifies that a valid header sequence is parsed and
+// the Content-Length is returned.
 func TestParseHeaders_Valid(t *testing.T) {
 	t.Parallel()
 
@@ -199,19 +201,19 @@ func TestParseHeaders_Valid(t *testing.T) {
 		wantErr    bool
 	}{
 		{
-			name:       "단일 헤더",
+			name:       "single header",
 			input:      "Content-Length: 42\r\n\r\n",
 			wantLength: 42,
 			wantErr:    false,
 		},
 		{
-			name:       "추가 헤더 무시",
+			name:       "ignore extra header",
 			input:      "Content-Length: 7\r\nContent-Type: application/vscode-jsonrpc\r\n\r\n",
 			wantLength: 7,
 			wantErr:    false,
 		},
 		{
-			name:       "공백 있는 Content-Length",
+			name:       "Content-Length with spaces",
 			input:      "Content-Length:  15\r\n\r\n",
 			wantLength: 15,
 			wantErr:    false,
@@ -223,7 +225,7 @@ func TestParseHeaders_Valid(t *testing.T) {
 			t.Parallel()
 			n, err := parseHeaders(strings.NewReader(tt.input))
 			if (err != nil) != tt.wantErr {
-				t.Fatalf("parseHeaders() 에러 = %v, wantErr %v", err, tt.wantErr)
+				t.Fatalf("parseHeaders() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if !tt.wantErr && n != tt.wantLength {
 				t.Errorf("parseHeaders() = %d, want %d", n, tt.wantLength)

--- a/internal/lsp/gopls/public_surface_test.go
+++ b/internal/lsp/gopls/public_surface_test.go
@@ -1,18 +1,19 @@
 package gopls_test
 
-// TestPublicSurface_GoplsPackage는 SPEC-UTIL-003 이후 gopls 패키지의 공개 API 표면이
-// 변경되지 않았음을 컴파일 타임에 확인한다 (AC-UTIL-003-012).
+// TestPublicSurface_GoplsPackage verifies at compile time that the public API
+// surface of the gopls package has not changed since SPEC-UTIL-003 (AC-UTIL-003-012).
 //
-// 이 테스트 파일은 코드를 실행하는 대신 컴파일 가능성을 통해 표면을 잠근다.
-// 아래의 변수/상수/타입 참조가 컴파일되면, 해당 식별자가 여전히 export되어 있다는 증거다.
+// Instead of executing code, this file locks the surface through compilability:
+// if the type/constant/variable references below compile, the corresponding
+// identifiers are still exported.
 
 import (
 	"github.com/modu-ai/moai-adk/internal/lsp/gopls"
 )
 
-// ─── 타입 surface ─────────────────────────────────────────────────────────────
+// ─── Type surface ─────────────────────────────────────────────────────────────
 
-// 컴파일 타임 표면 고정: 아래 타입들이 export되어 있어야 한다.
+// Compile-time surface lock: the following types must remain exported.
 var (
 	_ gopls.Diagnostic         // type alias → lsp.Diagnostic
 	_ gopls.Range              // type alias → lsp.Range
@@ -20,7 +21,7 @@ var (
 	_ gopls.DiagnosticSeverity // type alias → lsp.DiagnosticSeverity
 )
 
-// ─── 상수 surface ─────────────────────────────────────────────────────────────
+// ─── Constant surface ─────────────────────────────────────────────────────────
 
 var (
 	_ = gopls.SeverityError
@@ -29,7 +30,7 @@ var (
 	_ = gopls.SeverityHint
 )
 
-// ─── 기타 메시지 타입 surface ────────────────────────────────────────────────
+// ─── Other message-type surface ───────────────────────────────────────────────
 
 var (
 	_ gopls.Request

--- a/internal/lsp/gopls/uri.go
+++ b/internal/lsp/gopls/uri.go
@@ -8,59 +8,59 @@ import (
 	"strings"
 )
 
-// pathToURI는 로컬 파일 경로를 RFC 3986 준수 file:// URI로 변환한다.
+// pathToURI converts a local file path to an RFC 3986 compliant file:// URI.
 //
-// LSP 사양에 따라 파일 URI는 경로의 공백, 유니코드 문자를 퍼센트 인코딩해야 한다.
-// 직접 "file://" + path 문자열 결합은 다음 케이스에서 실패한다:
-//   - 공백 포함 경로 (/Users/goos/My Project/) — LSP 사양 위반
-//   - 유니코드 경로 (/내 프로젝트/main.go) — didOpen 무음 실패
-//   - Windows 드라이브 경로 (C:\...) — 슬래시 개수 오류
+// Per the LSP spec, file URIs must percent-encode spaces and Unicode characters in the path.
+// Direct string concatenation of "file://" + path fails in these cases:
+//   - Paths with spaces (/Users/goos/My Project/) — LSP spec violation
+//   - Unicode paths (/my-project/main.go) — silent didOpen failure
+//   - Windows drive paths (C:\...) — incorrect number of slashes
 //
-// 변환 규칙:
-//   - 상대 경로는 filepath.Abs로 절대 경로로 변환한다.
-//   - Windows: 백슬래시를 슬래시로 변환하고 /C:/... 형식으로 정규화한다.
+// Conversion rules:
+//   - Relative paths are converted to absolute paths via filepath.Abs.
+//   - Windows: backslashes are converted to slashes and normalized to /C:/... format.
 //   - Unix: /path/to/file → file:///path/to/file
 //
-// @MX:ANCHOR: [AUTO] LSP URI 변환 핵심 헬퍼 — bridge.go의 initialize, GetDiagnostics에서 호출된다
-// @MX:REASON: fan_in >= 3 (initialize, GetDiagnostics, 테스트)
+// @MX:ANCHOR: [AUTO] Core LSP URI conversion helper — called from initialize and GetDiagnostics in bridge.go
+// @MX:REASON: fan_in >= 3 (initialize, GetDiagnostics, tests)
 func pathToURI(absPath string) (string, error) {
 	if absPath == "" {
-		return "", fmt.Errorf("gopls: uri: 빈 경로는 허용되지 않는다")
+		return "", fmt.Errorf("gopls: uri: empty path is not allowed")
 	}
 
-	// 상대 경로를 절대 경로로 변환한다.
+	// Convert relative path to absolute path.
 	abs, err := filepath.Abs(absPath)
 	if err != nil {
-		return "", fmt.Errorf("gopls: uri: 절대 경로 변환 실패 %q: %w", absPath, err)
+		return "", fmt.Errorf("gopls: uri: absolute path conversion failed %q: %w", absPath, err)
 	}
 
-	// filepath.ToSlash로 OS 경로 구분자를 슬래시로 통일한다.
+	// Normalize OS path separators to slashes using filepath.ToSlash.
 	slashed := filepath.ToSlash(abs)
 
-	// Windows 드라이브 경로(C:/...) 처리:
-	// url.URL.String()은 Path가 /C:/...로 시작해야 file:///C:/... 형식을 생성한다.
-	// Unix에서는 abs가 이미 /로 시작하므로 조정 불필요.
+	// Handle Windows drive paths (C:/...):
+	// url.URL.String() requires Path to start with /C:/... to produce the file:///C:/... format.
+	// On Unix, abs already starts with /, so no adjustment is needed.
 	if runtime.GOOS == "windows" && len(slashed) >= 2 && slashed[1] == ':' {
 		// "C:/..." → "/C:/..."
 		slashed = "/" + slashed
 	}
 
-	// url.URL을 사용하여 경로를 퍼센트 인코딩한다.
-	// Scheme만 지정하고 Path는 url.URL이 자동으로 인코딩한다.
+	// Use url.URL to percent-encode the path.
+	// Only Scheme is specified; url.URL encodes Path automatically.
 	u := &url.URL{
 		Scheme: "file",
-		// Host를 빈 문자열로 두면 file:///path 형식이 생성된다.
+		// Leaving Host empty generates the file:///path format.
 		Path: slashed,
 	}
 
-	// url.URL.String()은 "file:///path%20with%20space/main.go" 형식으로 반환한다.
+	// url.URL.String() returns the form "file:///path%20with%20space/main.go".
 	result := u.String()
 
-	// 슬래시 트리플 검증: file:// + /path 는 file:///path가 된다.
-	// url.URL은 Host가 비어있으면 authority를 생략하므로 file:/path 가 될 수 있다.
-	// 명시적으로 file:///를 보장한다.
+	// Verify triple-slash: file:// + /path becomes file:///path.
+	// url.URL may omit the authority when Host is empty, resulting in file:/path.
+	// Explicitly guarantee file:///.
 	if !strings.HasPrefix(result, "file:///") {
-		// file://path → file:///path로 수정
+		// Fix file://path → file:///path
 		if strings.HasPrefix(result, "file://") {
 			result = "file:///" + strings.TrimPrefix(result, "file://")
 		}

--- a/internal/lsp/gopls/uri_test.go
+++ b/internal/lsp/gopls/uri_test.go
@@ -6,82 +6,82 @@ import (
 	"testing"
 )
 
-// TestPathToURI_EncodesSpaces는 경로에 공백이 있을 때 퍼센트 인코딩하는지 검증한다.
+// TestPathToURI_EncodesSpaces verifies that spaces in paths are percent-encoded.
 func TestPathToURI_EncodesSpaces(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		t.Skip("Unix 경로 테스트: Windows에서 건너뜁니다")
+		t.Skip("Unix path test: skipping on Windows")
 	}
 	uri, err := pathToURI("/a b/main.go")
 	if err != nil {
-		t.Fatalf("pathToURI 오류: %v", err)
+		t.Fatalf("pathToURI error: %v", err)
 	}
-	// 공백은 %20으로 인코딩되어야 한다.
+	// spaces must be encoded as %20.
 	if !strings.Contains(uri, "%20") {
-		t.Errorf("pathToURI(%q) = %q, %%20 인코딩을 기대했다", "/a b/main.go", uri)
+		t.Errorf("pathToURI(%q) = %q, want %%20 encoding", "/a b/main.go", uri)
 	}
 	if !strings.HasPrefix(uri, "file:///") {
-		t.Errorf("pathToURI(%q) = %q, file:/// 접두사를 기대했다", "/a b/main.go", uri)
+		t.Errorf("pathToURI(%q) = %q, want file:/// prefix", "/a b/main.go", uri)
 	}
 }
 
-// TestPathToURI_EncodesUnicode는 유니코드 경로를 퍼센트 인코딩하는지 검증한다.
+// TestPathToURI_EncodesUnicode verifies that Unicode paths are percent-encoded.
 func TestPathToURI_EncodesUnicode(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		t.Skip("Unix 경로 테스트: Windows에서 건너뜁니다")
+		t.Skip("Unix path test: skipping on Windows")
 	}
 	uri, err := pathToURI("/내/main.go")
 	if err != nil {
-		t.Fatalf("pathToURI 오류: %v", err)
+		t.Fatalf("pathToURI error: %v", err)
 	}
-	// 유니코드 문자는 퍼센트 인코딩되어야 한다.
+	// Unicode characters must be percent-encoded.
 	if !strings.Contains(uri, "%") {
-		t.Errorf("pathToURI(%q) = %q, 퍼센트 인코딩을 기대했다", "/내/main.go", uri)
+		t.Errorf("pathToURI(%q) = %q, want percent encoding", "/내/main.go", uri)
 	}
 	if !strings.HasPrefix(uri, "file:///") {
-		t.Errorf("pathToURI(%q) = %q, file:/// 접두사를 기대했다", "/내/main.go", uri)
+		t.Errorf("pathToURI(%q) = %q, want file:/// prefix", "/내/main.go", uri)
 	}
 }
 
-// TestPathToURI_WindowsDrive는 Windows 드라이브 경로를 올바르게 처리하는지 검증한다.
-// runtime.GOOS가 windows가 아니어도 로직이 동작해야 하므로 slash 변환 결과를 검증한다.
+// TestPathToURI_WindowsDrive verifies that Windows drive paths are handled correctly.
+// The logic must work correctly on Windows only; skipped on other platforms.
 func TestPathToURI_WindowsDrive(t *testing.T) {
 	if runtime.GOOS != "windows" {
-		t.Skip("Windows 드라이브 경로 테스트: Windows에서만 실행합니다")
+		t.Skip("Windows drive path test: only runs on Windows")
 	}
 	uri, err := pathToURI(`C:\x\main.go`)
 	if err != nil {
-		t.Fatalf("pathToURI 오류: %v", err)
+		t.Fatalf("pathToURI error: %v", err)
 	}
-	// Windows: file:///C:/x/main.go 형식이어야 한다.
+	// Windows: must be in file:///C:/x/main.go format.
 	want := "file:///C:/x/main.go"
 	if uri != want {
-		t.Errorf("pathToURI = %q, %q를 기대했다", uri, want)
+		t.Errorf("pathToURI = %q, want %q", uri, want)
 	}
 }
 
-// TestPathToURI_Idempotent는 동일한 절대 경로를 두 번 변환해도 결과가 같은지 검증한다.
+// TestPathToURI_Idempotent verifies that converting the same absolute path twice yields the same result.
 func TestPathToURI_Idempotent(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		t.Skip("Unix 경로 테스트: Windows에서 건너뜁니다")
+		t.Skip("Unix path test: skipping on Windows")
 	}
 	path := "/usr/local/src/main.go"
 	uri1, err := pathToURI(path)
 	if err != nil {
-		t.Fatalf("pathToURI 오류: %v", err)
+		t.Fatalf("pathToURI error: %v", err)
 	}
 	uri2, err := pathToURI(path)
 	if err != nil {
-		t.Fatalf("pathToURI(2) 오류: %v", err)
+		t.Fatalf("pathToURI(2) error: %v", err)
 	}
 	if uri1 != uri2 {
-		t.Errorf("pathToURI 멱등성 위반: %q != %q", uri1, uri2)
+		t.Errorf("pathToURI idempotency violation: %q != %q", uri1, uri2)
 	}
 }
 
-// TestPathToURI_RejectsEmpty는 빈 경로를 거부하는지 검증한다.
+// TestPathToURI_RejectsEmpty verifies that an empty path is rejected.
 func TestPathToURI_RejectsEmpty(t *testing.T) {
 	_, err := pathToURI("")
 	if err == nil {
-		t.Error("빈 경로에 오류가 반환되지 않았다")
+		t.Error("empty path did not return an error")
 	}
 }

--- a/internal/lsp/subprocess/launcher.go
+++ b/internal/lsp/subprocess/launcher.go
@@ -118,9 +118,9 @@ func (l *Launcher) Launch(ctx context.Context, cfg config.ServerConfig) (*Launch
 	args := make([]string, len(cfg.Args))
 	copy(args, cfg.Args)
 
-	cmd := exec.CommandContext(ctx, binPath, args...) //nolint:gosec // 경로는 위에서 검증됨
+	cmd := exec.CommandContext(ctx, binPath, args...) //nolint:gosec // path is validated above
 
-	// 각 파이프를 독립적으로 생성 (REQ-LC-005 isolation)
+	// Create each pipe independently (REQ-LC-005 isolation)
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		return nil, fmt.Errorf("subprocess.Launch %q: stdin pipe: %w", cfg.Command, err)

--- a/internal/lsp/subprocess/launcher_test.go
+++ b/internal/lsp/subprocess/launcher_test.go
@@ -34,8 +34,8 @@ func writeFakeBinary(t *testing.T, dir, name string) string {
 	}
 	path := filepath.Join(dir, name)
 
-	// 표준 입력을 읽고 아무것도 출력하지 않는 최소 스텁
-	// ETXTBSY 방지: 파일 디스크립터를 write 후 즉시 닫고, 그다음에 chmod
+	// Minimal stub that reads stdin and writes nothing.
+	// ETXTBSY mitigation: close the writer fd before chmod.
 	f, err := os.Create(path)
 	if err != nil {
 		t.Fatalf("writeFakeBinary create: %v", err)
@@ -68,7 +68,7 @@ func TestLauncher_Launch_HappyPath(t *testing.T) {
 
 	cfg := config.ServerConfig{
 		Language: "go",
-		Command:  binPath, // 절대 경로 직접 지정 — PATH 탐색 없이 실행
+		Command:  binPath, // absolute path explicitly; no PATH lookup required
 	}
 
 	l := subprocess.NewLauncher()
@@ -141,7 +141,7 @@ func TestLauncher_Launch_StdioPipesNonNil(t *testing.T) {
 		_ = result.Cmd.Wait()
 	})
 
-	// stdin에 쓰기 시도 — 파이프가 유효하면 에러 없음
+	// Try writing to stdin — if the pipe is valid, no error occurs.
 	if _, err := result.Stdin.Write([]byte("test\n")); err != nil {
 		t.Errorf("Stdin.Write: %v", err)
 	}
@@ -171,7 +171,7 @@ func TestLauncher_Launch_WithArgs(t *testing.T) {
 		_ = result.Cmd.Wait()
 	})
 
-	// 명령행 인자가 정확히 전달됐는지 확인
+	// Verify that the command-line arguments are forwarded correctly.
 	if len(result.Cmd.Args) < 3 {
 		t.Errorf("Cmd.Args = %v, expected binary + 2 args", result.Cmd.Args)
 	}
@@ -212,7 +212,7 @@ func TestLauncher_Launch_EmptyCommand(t *testing.T) {
 	if err == nil {
 		t.Fatal("Launch: expected error for empty command, got nil")
 	}
-	// 에러 메시지에 언어 또는 커맨드 정보가 포함되어야 함
+	// The error message should include language or command information.
 	_ = err
 }
 
@@ -226,7 +226,7 @@ func TestLauncher_Launch_StartFails(t *testing.T) {
 
 	dir := t.TempDir()
 	binPath := dir + "/non-exec"
-	// 실행 권한 없는 파일 작성
+	// Write a file without executable permission.
 	if err := os.WriteFile(binPath, []byte("#!/bin/sh\nexit 0\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
@@ -241,7 +241,7 @@ func TestLauncher_Launch_StartFails(t *testing.T) {
 	if err == nil {
 		t.Fatal("Launch: expected error for non-executable binary, got nil")
 	}
-	// ErrBinaryNotFound가 아닌 다른 에러 (Start 실패)
+	// Expect a different error (Start failure), not ErrBinaryNotFound.
 	if errors.Is(err, subprocess.ErrBinaryNotFound) {
 		t.Errorf("Launch error = ErrBinaryNotFound, want start error")
 	}

--- a/internal/lsp/subprocess/supervisor.go
+++ b/internal/lsp/subprocess/supervisor.go
@@ -34,7 +34,7 @@ type ExitEvent struct {
 //	ch := sv.Watch(ctx)
 //	select {
 //	case ev := <-ch:
-//	    // 서버 비정상 종료 처리 (degraded state)
+//	    // Handle abnormal server termination (degraded state)
 //	}
 //
 // @MX:ANCHOR: [AUTO] Supervisor — subprocess lifecycle monitor used by core.Client and degraded-state handler
@@ -52,13 +52,13 @@ type Supervisor struct {
 // exactly once. Callers MUST NOT call result.Cmd.Wait after this point.
 //
 // @MX:WARN: [AUTO] NewSupervisor starts a goroutine that owns cmd.Wait for the subprocess lifetime
-// @MX:REASON: 표준 입출력 파이프를 닫지 않으면 Wait()이 영구 블록됨 — 호출자는 stdin/stdout/stderr를 먼저 닫아야 함
+// @MX:REASON: Wait() blocks forever if stdio pipes are not closed — callers must close stdin/stdout/stderr first
 func NewSupervisor(result *LaunchResult) *Supervisor {
 	s := &Supervisor{
 		cmd:    result.Cmd,
 		doneCh: make(chan struct{}),
 	}
-	// Wait goroutine: 정확히 한 번만 실행하여 race condition 방지
+	// Wait goroutine: run exactly once to prevent race conditions
 	go func() {
 		err := result.Cmd.Wait()
 		s.exitEv = buildExitEvent(err)
@@ -79,11 +79,11 @@ func (s *Supervisor) Watch(ctx context.Context) <-chan ExitEvent {
 		defer close(ch)
 		select {
 		case <-s.doneCh:
-			// doneCh는 이미 닫혔거나 Wait 완료 시 닫힘
-			// exitEv는 doneCh 닫힌 후에만 읽으므로 race-free
+			// doneCh is already closed or closes when Wait completes
+			// exitEv is read only after doneCh is closed, so this is race-free
 			ch <- s.exitEv
 		case <-ctx.Done():
-			// 컨텍스트 취소: 빈 채널 닫힘으로 호출자에게 알림
+			// Context cancelled: notify caller by closing the empty channel
 		}
 	}()
 
@@ -108,7 +108,7 @@ func buildExitEvent(err error) ExitEvent {
 		return ExitEvent{ExitCode: 0}
 	}
 
-	exitErr, ok := err.(*exec.ExitError) //nolint:errorlint // exec.ExitError은 wrapped되지 않음
+	exitErr, ok := err.(*exec.ExitError) //nolint:errorlint // exec.ExitError is not wrapped
 	if !ok {
 		return ExitEvent{Err: err}
 	}
@@ -116,7 +116,7 @@ func buildExitEvent(err error) ExitEvent {
 	code := exitErr.ExitCode()
 	signaled := false
 
-	// Unix: ProcessState.Sys()는 syscall.WaitStatus
+	// Unix: ProcessState.Sys() returns syscall.WaitStatus
 	if ws, ok := exitErr.Sys().(syscall.WaitStatus); ok {
 		signaled = ws.Signaled()
 	}

--- a/internal/lsp/subprocess/supervisor_test.go
+++ b/internal/lsp/subprocess/supervisor_test.go
@@ -94,7 +94,7 @@ func TestSupervisor_NormalExit(t *testing.T) {
 	t.Parallel()
 
 	result, sv := launchStub(t, "#!/bin/sh\nexit 0\n")
-	// Supervisor가 cmd.Wait()를 소유하므로 테스트에서 직접 Wait 호출 금지
+	// Supervisor owns cmd.Wait(), so do not call Wait directly from the test.
 	t.Cleanup(func() { _ = result.Cmd.Process.Kill() })
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -132,23 +132,23 @@ func TestSupervisor_NonZeroExit(t *testing.T) {
 func TestSupervisor_CtxCancelStopsWatcher(t *testing.T) {
 	t.Parallel()
 
-	// 무한 대기 스크립트
+	// Infinite-wait script.
 	result, sv := launchStub(t, "#!/bin/sh\nsleep 60\n")
 	t.Cleanup(func() {
 		_ = result.Cmd.Process.Kill()
-		// Supervisor가 cmd.Wait()를 소유 — 직접 Wait 호출 금지
+		// Supervisor owns cmd.Wait() — do not call Wait directly.
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
 
 	ch := sv.Watch(ctx)
 
-	// 컨텍스트 취소 → 채널 즉시 닫힘 기대
+	// Context cancel → expect the channel to close immediately.
 	cancel()
 
 	select {
 	case <-ch:
-		// 정상: 채널 닫힘
+		// Normal: channel closed.
 	case <-time.After(2 * time.Second):
 		t.Error("Watch channel did not close after ctx cancel within 2s")
 	}
@@ -173,7 +173,7 @@ func TestSupervisor_Kill(t *testing.T) {
 
 	select {
 	case <-ch:
-		// 정상: 프로세스 종료 후 채널 닫힘
+		// Normal: channel closed after process exit.
 	case <-time.After(3 * time.Second):
 		t.Error("Watch channel did not close after Kill within 3s")
 	}
@@ -184,9 +184,9 @@ func TestSupervisor_Kill(t *testing.T) {
 func TestSupervisor_Signal_SIGTERM(t *testing.T) {
 	t.Parallel()
 
-	// SIGTERM을 받으면 종료하는 스크립트.
-	// /bin/bash 명시: Ubuntu의 /bin/sh는 dash이며 trap 처리 타이밍이 다름.
-	// Watch가 Signal보다 먼저 시작되도록 보장하기 위해 small sleep 추가.
+	// Script that exits when SIGTERM is received.
+	// /bin/bash explicitly: Ubuntu /bin/sh is dash, which has different trap timing.
+	// Add a small sleep to ensure Watch starts before Signal.
 	result, sv := launchStub(t, "#!/bin/bash\ntrap 'exit 0' TERM\nwhile true; do sleep 0.1; done\n")
 	t.Cleanup(func() { _ = result.Cmd.Process.Kill() })
 
@@ -194,7 +194,7 @@ func TestSupervisor_Signal_SIGTERM(t *testing.T) {
 	defer cancel()
 
 	ch := sv.Watch(ctx)
-	// CI 환경에서 subprocess가 trap을 등록할 시간 확보
+	// Give the subprocess time to register the trap in CI environments.
 	time.Sleep(100 * time.Millisecond)
 
 	if err := sv.Signal(syscall.SIGTERM); err != nil {
@@ -203,7 +203,7 @@ func TestSupervisor_Signal_SIGTERM(t *testing.T) {
 
 	select {
 	case ev := <-ch:
-		// SIGTERM으로 정상 종료: ExitCode 0 또는 signal 종료 모두 허용
+		// Normal exit via SIGTERM: ExitCode 0 or signal-based exit are both acceptable.
 		_ = ev
 	case <-time.After(10 * time.Second):
 		t.Error("subprocess did not exit after SIGTERM within 10s")
@@ -221,13 +221,13 @@ func TestSupervisor_Signal_AlreadyDead(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	// 프로세스 종료 대기
+	// Wait for process exit.
 	ch := sv.Watch(ctx)
 	<-ch
 
-	// 이미 종료된 프로세스에 시그널 — 에러 반환, 패닉 없음
+	// Send a signal to an already-dead process — must return an error, not panic.
 	err := sv.Signal(os.Interrupt)
-	// 에러 발생 여부는 OS에 따라 다름 — 패닉 없으면 통과
+	// Whether an error is produced depends on the OS — passing if no panic occurs.
 	_ = err
 }
 
@@ -236,8 +236,8 @@ func TestSupervisor_Signal_AlreadyDead(t *testing.T) {
 func TestSupervisor_MultipleWatchers(t *testing.T) {
 	t.Parallel()
 
-	// 짧은 sleep으로 두 Watch 등록 시간 확보 (CI 환경 고려).
-	// /bin/bash 명시: Ubuntu /bin/sh (dash) vs macOS /bin/sh 차이 회피.
+	// Short sleep to allow time for both Watch registrations (CI environment).
+	// /bin/bash explicitly: avoid Ubuntu /bin/sh (dash) vs macOS /bin/sh differences.
 	result, sv := launchStub(t, "#!/bin/bash\nsleep 0.3\nexit 42\n")
 	t.Cleanup(func() { _ = result.Cmd.Process.Kill() })
 
@@ -275,7 +275,7 @@ func TestSupervisor_ExitEvent_Signaled(t *testing.T) {
 
 	select {
 	case ev := <-ch:
-		// SIGKILL로 강제 종료: Signaled or non-zero exit code
+		// Forced exit via SIGKILL: Signaled or non-zero exit code expected.
 		if !ev.Signaled && ev.ExitCode == 0 && ev.Err == nil {
 			t.Error("ExitEvent after Kill: expected Signaled=true or non-zero ExitCode")
 		}

--- a/internal/lsp/transport/error_transport_test.go
+++ b/internal/lsp/transport/error_transport_test.go
@@ -106,13 +106,13 @@ func TestPnTransport_WithMockConn_OnNotification(t *testing.T) {
 		called = true
 	})
 
-	// 등록된 핸들러가 있어야 함
+	// A handler must be registered.
 	h, ok := mock.handlers["textDocument/publishDiagnostics"]
 	if !ok {
 		t.Fatal("handler not registered in mockRPCConn")
 	}
 
-	// 핸들러 호출 — pnTransport 내부 래퍼가 json.RawMessage를 전달해야 함
+	// Invoke the handler — pnTransport's internal wrapper must forward json.RawMessage.
 	h(context.Background(), "textDocument/publishDiagnostics", json.RawMessage(`{}`))
 	if !called {
 		t.Error("handler was not called after dispatch")
@@ -190,7 +190,7 @@ func TestErrorTransport_AllMethods(t *testing.T) {
 		t.Errorf("Notify error = %v, want %v", err, wantErr)
 	}
 
-	// OnNotification은 empty body — 패닉 없이 호출 가능해야 함
+	// OnNotification has an empty body — must be callable without panic.
 	et.OnNotification("method", nil)
 
 	if err := et.Close(); err != nil {

--- a/internal/lsp/transport/notification.go
+++ b/internal/lsp/transport/notification.go
@@ -56,7 +56,7 @@ func (r *NotificationRouter) Dispatch(method string, params json.RawMessage) err
 	r.mu.RUnlock()
 
 	if !ok {
-		// 미등록 메서드 — 무시 (서버가 클라이언트 범위 밖의 알림을 보낼 수 있음)
+		// Unregistered method — silently ignored (servers may emit notifications beyond our registered set)
 		return nil
 	}
 	return h(params)
@@ -65,8 +65,8 @@ func (r *NotificationRouter) Dispatch(method string, params json.RawMessage) err
 // Attach registers the router's Dispatch as the notification handler for
 // each method in the router on the given Transport.
 //
-// @MX:NOTE: [AUTO] Attach는 Transport.OnNotification을 통해 라우터를 Transport에 연결함
-// 모든 알림이 이 라우터로 집중되므로 Register 후 Attach 호출 순서가 중요함
+// @MX:NOTE: [AUTO] Attach connects the router to a Transport via Transport.OnNotification
+// All notifications are funneled through this router, so the order of Register then Attach matters
 func (r *NotificationRouter) Attach(t Transport) {
 	r.mu.RLock()
 	methods := make([]string, 0, len(r.handlers))
@@ -78,14 +78,14 @@ func (r *NotificationRouter) Attach(t Transport) {
 	for _, method := range methods {
 		m := method // loop variable capture
 		t.OnNotification(m, func(params json.RawMessage) {
-			// 에러는 로깅 레이어에서 처리; Attach는 fire-and-forget
+			// Errors are handled by the logging layer; Attach is fire-and-forget
 			_ = r.Dispatch(m, params)
 		})
 	}
 }
 
 // publishDiagnosticsParams is the JSON payload for textDocument/publishDiagnostics.
-// URI 필드와 Diagnostics 슬라이스는 internal/lsp/models.go의 타입을 재사용함.
+// Reuses the URI field and Diagnostics slice types from internal/lsp/models.go.
 type publishDiagnosticsParams struct {
 	URI         string           `json:"uri"`
 	Diagnostics []lsp.Diagnostic `json:"diagnostics"`
@@ -97,7 +97,7 @@ type publishDiagnosticsParams struct {
 //
 // Uses internal/lsp/models.go types — no duplicate type definitions (REQ-LC-002b).
 //
-// @MX:NOTE: [AUTO] publishDiagnostics 파싱 — internal/lsp.Diagnostic 재사용, 중복 정의 금지
+// @MX:NOTE: [AUTO] publishDiagnostics parsing — reuses internal/lsp.Diagnostic, no duplicate type definitions
 func (r *NotificationRouter) RegisterPublishDiagnostics(
 	callback func(uri string, diags []lsp.Diagnostic) error,
 ) error {

--- a/internal/lsp/transport/notification_test.go
+++ b/internal/lsp/transport/notification_test.go
@@ -61,7 +61,7 @@ func TestNotificationRouter_UnknownMethod_Ignored(t *testing.T) {
 
 	r := transport.NewNotificationRouter()
 
-	// 미등록 메서드 — 에러 없이 무시
+	// unregistered method — silently ignored
 	err := r.Dispatch("$/progress", json.RawMessage(`{}`))
 	if err != nil {
 		t.Errorf("Dispatch unknown method: %v, want nil", err)
@@ -153,7 +153,7 @@ func TestNotificationRouter_Attach_Dispatches(t *testing.T) {
 
 	r.Attach(ft)
 
-	// fakeTransport에 등록된 핸들러 직접 호출로 Attach 통합 검증
+	// verify Attach integration by directly invoking the handler registered on fakeTransport
 	handler, ok := ft.handlers["textDocument/publishDiagnostics"]
 	if !ok {
 		t.Fatal("Attach did not register handler on transport")

--- a/internal/lsp/transport/request.go
+++ b/internal/lsp/transport/request.go
@@ -22,7 +22,7 @@ var ErrRequestTimeout = errors.New("lsp: request timeout")
 //
 //	return WrapCallError(method, uri, lang, transport.Call(...))
 //
-// @MX:NOTE: [AUTO] 에러 래핑 규칙: fmt.Errorf("%w" 패턴 사용 — errors.Is/As 체인 유지
+// @MX:NOTE: [AUTO] Error wrapping rule: use fmt.Errorf("%w" pattern — preserves errors.Is/As chain
 func WrapCallError(method, uri, language string, err error) error {
 	if err == nil {
 		return nil
@@ -55,12 +55,12 @@ func CallWithTimeout(ctx context.Context, t Transport, method string, params, re
 		return nil
 	}
 
-	// 컨텍스트 타임아웃/취소 여부 확인 (REQ-LC-041)
+	// Check for context timeout/cancellation (REQ-LC-041)
 	if isContextErr(ctx, err) {
 		return fmt.Errorf("lsp call %s (lang=%s): %w", method, language, ErrRequestTimeout)
 	}
 
-	// 일반 프로토콜 에러: method + language 컨텍스트 추가
+	// General protocol error: add method + language context
 	return WrapCallError(method, "", language, err)
 }
 

--- a/internal/lsp/transport/request_test.go
+++ b/internal/lsp/transport/request_test.go
@@ -107,7 +107,7 @@ func TestCallWithTimeout_TransportError(t *testing.T) {
 func TestCallWithTimeout_DeadlineExceeded(t *testing.T) {
 	t.Parallel()
 
-	// 절대 완료되지 않는 fake transport — 채널 블로킹
+	// fake transport that never completes — channel blocking
 	blocking := &blockingTransport{}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
@@ -135,7 +135,7 @@ func TestCallWithTimeout_NilCtx(t *testing.T) {
 		}
 	}()
 
-	//nolint:staticcheck // 의도적인 nil context 테스트
+	//nolint:staticcheck // intentional nil context test
 	err := transport.CallWithTimeout(nil, ft, "initialize", nil, nil, "go") //nolint:staticcheck
 	if err == nil {
 		t.Error("CallWithTimeout(nil ctx): expected error, got nil")

--- a/internal/lsp/transport/transport_test.go
+++ b/internal/lsp/transport/transport_test.go
@@ -34,7 +34,7 @@ func (f *fakeTransport) Call(ctx context.Context, method string, params, result 
 		return err
 	}
 	if r, ok := f.callResults[method]; ok && result != nil {
-		// 결과를 JSON 경유로 병합: Call 시그니처는 result any
+		// Merge the result via JSON: Call's signature is `result any`.
 		b, err := json.Marshal(r)
 		if err != nil {
 			return err
@@ -72,7 +72,7 @@ func TestTransport_Interface(t *testing.T) {
 	ft := newFakeTransport()
 	ctx := context.Background()
 
-	// Call은 파라미터를 받아 result에 채워야 함
+	// Call must accept params and populate result.
 	ft.callResults["initialize"] = map[string]any{"serverInfo": "test"}
 	var result map[string]any
 	if err := ft.Call(ctx, "initialize", nil, &result); err != nil {
@@ -82,7 +82,7 @@ func TestTransport_Interface(t *testing.T) {
 		t.Errorf("callCalled = %v, want [initialize]", ft.callCalled)
 	}
 
-	// Notify는 result 없이 notification 전송
+	// Notify sends a notification without a result.
 	if err := ft.Notify(ctx, "initialized", nil); err != nil {
 		t.Errorf("Notify returned unexpected error: %v", err)
 	}
@@ -167,14 +167,14 @@ func TestNewPowernapTransport_CloseOnNil(t *testing.T) {
 
 	tr := transport.NewPowernapTransport(nil)
 
-	// Close은 nil stream이면 에러를 반환하거나 nil을 반환해야 함 — panic 불가
+	// Close must return either an error or nil when the stream is nil — must not panic.
 	defer func() {
 		if r := recover(); r != nil {
 			t.Errorf("Close panicked: %v", r)
 		}
 	}()
 
-	// 패닉 없이 호출 가능해야 함
+	// Must be callable without panicking.
 	_ = tr.Close()
 }
 

--- a/internal/merge/evolvable_zone.go
+++ b/internal/merge/evolvable_zone.go
@@ -251,19 +251,19 @@ func HasEvolvableZones(content string) bool {
 // ReplaceEvolvableZone returns content with the named zone's body replaced by
 // newZoneContent. Returns ErrZoneNotFound if zoneID does not exist.
 //
-// 이 함수는 3-way 병합이 아닌 직접 in-place 교체를 수행한다.
-// evolution Apply 경로에서 사용하도록 설계되었으며, MergeEvolvableZones와 달리
-// base/current/updated 세 버전이 아닌 단일 파일 내 특정 존만 교체한다.
+// This function performs a direct in-place replacement rather than a 3-way merge.
+// Designed for use in the evolution Apply path; unlike MergeEvolvableZones,
+// it replaces only a specific zone within a single file rather than using base/current/updated versions.
 //
-// newZoneContent는 마커 줄을 포함하지 않는 순수 내용이다.
-// 결과물에서 존 시작 마커와 종료 마커 사이에 정확히 한 줄의 공백 없이 삽입된다.
+// newZoneContent is the pure body content without marker lines.
+// It is inserted between the zone start and end markers with no blank lines in the result.
 func ReplaceEvolvableZone(content, zoneID, newZoneContent string) (string, error) {
 	zones, err := ParseEvolvableZones(content)
 	if err != nil {
 		return "", fmt.Errorf("merge: parse zones for replacement: %w", err)
 	}
 
-	// 대상 존 검색
+	// Find the target zone
 	var target *EvolvableZone
 	for i := range zones {
 		if zones[i].ID == zoneID {
@@ -277,12 +277,12 @@ func ReplaceEvolvableZone(content, zoneID, newZoneContent string) (string, error
 
 	lines := strings.Split(content, "\n")
 
-	// target.StartLine: 시작 마커 줄 인덱스 (포함)
-	// target.EndLine: 종료 마커 줄 인덱스 (종료 마커 줄; 내용에는 미포함)
-	before := lines[:target.StartLine+1]    // 시작 마커까지 (포함)
-	after := lines[target.EndLine:]         // 종료 마커부터 (포함)
+	// target.StartLine: start marker line index (inclusive)
+	// target.EndLine: end marker line index (end marker line; not included in content)
+	before := lines[:target.StartLine+1]    // up to and including the start marker
+	after := lines[target.EndLine:]         // from the end marker (inclusive)
 
-	// 새 내용 구성: 마지막에 정확히 하나의 개행 보장
+	// Build new content: guarantee exactly one trailing newline
 	trimmedNew := strings.TrimRight(newZoneContent, "\n")
 
 	var sb strings.Builder

--- a/internal/merge/replace_zone_test.go
+++ b/internal/merge/replace_zone_test.go
@@ -29,28 +29,28 @@ func TestReplaceEvolvableZone_Basic(t *testing.T) {
 		t.Fatalf("ReplaceEvolvableZone: %v", err)
 	}
 
-	// 헤더와 푸터가 보존되어야 함
+	// Header and footer must be preserved.
 	if !strings.Contains(result, "# Header") {
-		t.Error("결과에 헤더가 없음")
+		t.Error("header missing from result")
 	}
 	if !strings.Contains(result, "Introduction paragraph.") {
-		t.Error("결과에 소개 문단이 없음")
+		t.Error("introduction paragraph missing from result")
 	}
 	if !strings.Contains(result, "Footer content.") {
-		t.Error("결과에 푸터가 없음")
+		t.Error("footer missing from result")
 	}
 
-	// 새 존 내용이 포함되어야 함
+	// New zone content must be present.
 	if !strings.Contains(result, "New line 1.") {
-		t.Error("결과에 새 내용이 없음")
+		t.Error("new content missing from result")
 	}
 	if !strings.Contains(result, "New line 3.") {
-		t.Error("결과에 새 내용 3이 없음")
+		t.Error("new content line 3 missing from result")
 	}
 
-	// 원본 존 내용은 없어야 함
+	// Original zone content must be removed.
 	if strings.Contains(result, "Original content") {
-		t.Error("결과에 원본 내용이 남아 있음")
+		t.Error("original content remains in result")
 	}
 }
 
@@ -63,10 +63,10 @@ func TestReplaceEvolvableZone_ErrZoneNotFound(t *testing.T) {
 
 	_, err := ReplaceEvolvableZone(content, "nonexistent-zone", "new content")
 	if err == nil {
-		t.Fatal("ErrZoneNotFound 예상, 하지만 nil 반환")
+		t.Fatal("expected ErrZoneNotFound, got nil")
 	}
 	if err != ErrZoneNotFound {
-		t.Fatalf("ErrZoneNotFound 예상, 하지만 반환: %v", err)
+		t.Fatalf("expected ErrZoneNotFound, got: %v", err)
 	}
 }
 
@@ -87,28 +87,29 @@ func TestReplaceEvolvableZone_Idempotent(t *testing.T) {
 
 	result1, err := ReplaceEvolvableZone(content, "zone1", newContent)
 	if err != nil {
-		t.Fatalf("첫 번째 ReplaceEvolvableZone: %v", err)
+		t.Fatalf("first ReplaceEvolvableZone: %v", err)
 	}
 
 	result2, err := ReplaceEvolvableZone(result1, "zone1", newContent)
 	if err != nil {
-		t.Fatalf("두 번째 ReplaceEvolvableZone: %v", err)
+		t.Fatalf("second ReplaceEvolvableZone: %v", err)
 	}
 
 	if result1 != result2 {
-		t.Errorf("멱등성 실패:\n첫 번째: %q\n두 번째: %q", result1, result2)
+		t.Errorf("idempotency failed:\nfirst: %q\nsecond: %q", result1, result2)
 	}
 }
 
-// TestMergeEvolvableZones_PreservesFileStructure는 apply.go:78의 버그를 재현한다.
-// MergeEvolvableZones를 (file_content, zoneID, newContent)로 잘못 호출했을 때
-// 파일 헤더와 푸터가 사라지는 것을 확인한다.
+// TestMergeEvolvableZones_PreservesFileStructure reproduces the bug at apply.go:78.
+// When MergeEvolvableZones was incorrectly invoked as (file_content, zoneID,
+// newContent), the file header and footer disappeared. This test verifies that.
 //
-// 이 테스트는 ReplaceEvolvableZone으로 수정하기 전 apply.go의 동작을 재현한다.
+// It documents the apply.go behavior before the fix that switched to
+// ReplaceEvolvableZone.
 func TestMergeEvolvableZones_PreservesFileStructure(t *testing.T) {
 	t.Parallel()
 
-	// 헤더, 존, 푸터가 있는 완전한 파일
+	// Complete file with header, zone, and footer.
 	fullFile := strings.Join([]string{
 		"# Skill Header",
 		"",
@@ -123,25 +124,25 @@ func TestMergeEvolvableZones_PreservesFileStructure(t *testing.T) {
 
 	newZoneContent := "Initial best practice content.\n- Always pass context.Context as first argument."
 
-	// ReplaceEvolvableZone으로 올바른 대체 수행
+	// Perform the correct replacement via ReplaceEvolvableZone.
 	result, err := ReplaceEvolvableZone(fullFile, "best-practices", newZoneContent)
 	if err != nil {
 		t.Fatalf("ReplaceEvolvableZone: %v", err)
 	}
 
-	// 헤더와 푸터가 보존되어야 함
+	// Header and footer must be preserved.
 	if !strings.Contains(result, "# Skill Header") {
-		t.Error("헤더가 보존되지 않음")
+		t.Error("header was not preserved")
 	}
 	if !strings.Contains(result, "Introduction content that must be preserved.") {
-		t.Error("소개 내용이 보존되지 않음")
+		t.Error("introduction content was not preserved")
 	}
 	if !strings.Contains(result, "Footer content that must also be preserved.") {
-		t.Error("푸터가 보존되지 않음")
+		t.Error("footer was not preserved")
 	}
 
-	// 새 내용이 포함되어야 함
+	// New content must be present.
 	if !strings.Contains(result, "Always pass context.Context as first argument.") {
-		t.Error("추가된 내용이 없음")
+		t.Error("added content missing")
 	}
 }

--- a/internal/ralph/engine_test.go
+++ b/internal/ralph/engine_test.go
@@ -258,8 +258,8 @@ func TestRalphEngine_Decide(t *testing.T) {
 	}
 }
 
-// TestClassifyFeedback_DiagnosticError는 Diagnostics에 Error 심각도 항목이 있을 때
-// ClassifyFeedback이 ErrorLevelManual을 포함하는지 검증한다.
+// TestClassifyFeedback_DiagnosticError verifies that when Diagnostics contains
+// an Error-severity entry, ClassifyFeedback includes ErrorLevelManual.
 func TestClassifyFeedback_DiagnosticError(t *testing.T) {
 	t.Parallel()
 
@@ -273,15 +273,15 @@ func TestClassifyFeedback_DiagnosticError(t *testing.T) {
 	classified := ClassifyFeedback(fb)
 
 	if len(classified) == 0 {
-		t.Fatal("진단 오류가 있는데 ClassifyFeedback이 빈 슬라이스를 반환했다")
+		t.Fatal("ClassifyFeedback returned empty slice despite a diagnostic error")
 	}
 
 	maxLevel := MaxErrorLevel(classified)
 	if maxLevel < ErrorLevelManual {
-		t.Errorf("MaxErrorLevel = %d, 기대값: >= %d (ErrorLevelManual)", maxLevel, ErrorLevelManual)
+		t.Errorf("MaxErrorLevel = %d, expected >= %d (ErrorLevelManual)", maxLevel, ErrorLevelManual)
 	}
 
-	// 진단 오류 분류 항목이 있어야 한다.
+	// A diagnostic-error classification entry must be present.
 	found := false
 	for _, ce := range classified {
 		if ce.Level == ErrorLevelManual && strings.Contains(ce.Description, "diagnostic") {
@@ -290,12 +290,13 @@ func TestClassifyFeedback_DiagnosticError(t *testing.T) {
 		}
 	}
 	if !found {
-		t.Errorf("진단 오류에 대한 ErrorLevelManual 분류 항목을 찾지 못했다. classified = %v", classified)
+		t.Errorf("could not find an ErrorLevelManual classification entry for the diagnostic error. classified = %v", classified)
 	}
 }
 
-// TestClassifyFeedback_DiagnosticWarning는 Diagnostics에 Warning 심각도 항목만 있을 때
-// ClassifyFeedback이 ErrorLevelLogOnly를 포함하는지 검증한다.
+// TestClassifyFeedback_DiagnosticWarning verifies that when Diagnostics
+// contains only Warning-severity entries, ClassifyFeedback includes
+// ErrorLevelLogOnly.
 func TestClassifyFeedback_DiagnosticWarning(t *testing.T) {
 	t.Parallel()
 
@@ -310,7 +311,7 @@ func TestClassifyFeedback_DiagnosticWarning(t *testing.T) {
 	classified := ClassifyFeedback(fb)
 
 	if len(classified) == 0 {
-		t.Fatal("진단 경고가 있는데 ClassifyFeedback이 빈 슬라이스를 반환했다")
+		t.Fatal("ClassifyFeedback returned empty slice despite a diagnostic warning")
 	}
 
 	found := false
@@ -318,18 +319,18 @@ func TestClassifyFeedback_DiagnosticWarning(t *testing.T) {
 		if ce.Level == ErrorLevelLogOnly && strings.Contains(ce.Description, "diagnostic") {
 			found = true
 			if ce.Count != 2 {
-				t.Errorf("경고 Count = %d, 기대값 2", ce.Count)
+				t.Errorf("warning Count = %d, expected 2", ce.Count)
 			}
 			break
 		}
 	}
 	if !found {
-		t.Errorf("진단 경고에 대한 ErrorLevelLogOnly 분류 항목을 찾지 못했다. classified = %v", classified)
+		t.Errorf("could not find an ErrorLevelLogOnly classification entry for the diagnostic warning. classified = %v", classified)
 	}
 }
 
-// TestClassifyFeedback_DiagnosticMixed는 Error + Warning이 혼재할 때
-// 최종 MaxErrorLevel이 ErrorLevelManual인지 검증한다.
+// TestClassifyFeedback_DiagnosticMixed verifies that when Error + Warning
+// entries coexist, the final MaxErrorLevel is ErrorLevelManual.
 func TestClassifyFeedback_DiagnosticMixed(t *testing.T) {
 	t.Parallel()
 
@@ -345,12 +346,12 @@ func TestClassifyFeedback_DiagnosticMixed(t *testing.T) {
 	maxLevel := MaxErrorLevel(classified)
 
 	if maxLevel < ErrorLevelManual {
-		t.Errorf("MaxErrorLevel = %d, Error+Warning 혼재 시 기대값: >= %d", maxLevel, ErrorLevelManual)
+		t.Errorf("MaxErrorLevel = %d, expected >= %d when Error+Warning coexist", maxLevel, ErrorLevelManual)
 	}
 }
 
-// TestClassifyFeedback_NilDiagnostics는 Diagnostics가 nil일 때
-// 기존 정수 기반 분류가 그대로 동작하는지 검증한다 (fallback 보장).
+// TestClassifyFeedback_NilDiagnostics verifies that when Diagnostics is nil
+// the legacy integer-based classification continues to work (fallback guarantee).
 func TestClassifyFeedback_NilDiagnostics(t *testing.T) {
 	t.Parallel()
 
@@ -363,10 +364,10 @@ func TestClassifyFeedback_NilDiagnostics(t *testing.T) {
 	classified := ClassifyFeedback(fb)
 
 	if len(classified) == 0 {
-		t.Fatal("기존 오류가 있는데 ClassifyFeedback이 빈 슬라이스를 반환했다")
+		t.Fatal("ClassifyFeedback returned empty slice despite legacy errors")
 	}
 
-	// 기존 분류: lint=AutoFix, tests=LogOnly (<=5이므로)
+	// Legacy classification: lint=AutoFix, tests=LogOnly (<= 5).
 	foundLint := false
 	foundTest := false
 	for _, ce := range classified {
@@ -378,28 +379,28 @@ func TestClassifyFeedback_NilDiagnostics(t *testing.T) {
 		}
 	}
 	if !foundLint {
-		t.Errorf("lint 오류 분류를 찾지 못했다. classified = %v", classified)
+		t.Errorf("could not find a lint-error classification. classified = %v", classified)
 	}
 	if !foundTest {
-		t.Errorf("테스트 실패 분류를 찾지 못했다. classified = %v", classified)
+		t.Errorf("could not find a test-failure classification. classified = %v", classified)
 	}
 }
 
-// TestClassifyFeedback_EmptyDiagnostics는 Diagnostics가 빈 슬라이스일 때
-// 추가 분류 항목이 생기지 않는지 검증한다.
+// TestClassifyFeedback_EmptyDiagnostics verifies that no extra classification
+// entries are produced when Diagnostics is an empty slice.
 func TestClassifyFeedback_EmptyDiagnostics(t *testing.T) {
 	t.Parallel()
 
 	fb := &loop.Feedback{
 		BuildSuccess: true,
-		Diagnostics:  []gopls.Diagnostic{}, // 빈 슬라이스
+		Diagnostics:  []gopls.Diagnostic{}, // empty slice
 	}
 
 	classified := ClassifyFeedback(fb)
-	// 빈 진단이면 추가 분류 없음
+	// With empty diagnostics, no diagnostic classification should be added.
 	for _, ce := range classified {
 		if strings.Contains(ce.Description, "diagnostic") {
-			t.Errorf("빈 진단에도 진단 분류 항목이 생성되었다: %v", ce)
+			t.Errorf("a diagnostic classification was produced despite empty diagnostics: %v", ce)
 		}
 	}
 }

--- a/internal/runtime/config.go
+++ b/internal/runtime/config.go
@@ -1,8 +1,8 @@
 // Package runtime provides the Token Circuit Breaker for MoAI-ADK.
 //
 // SPEC-V3R3-ARCH-007: per-agent token budget tracking + stall detection.
-// Warning-first policy (BC-V3R3-006); P5에서 hard-fail로 전환 예정.
-// /clear는 절대 자동 트리거되지 않음 (HARD constraint per MEMORY.md).
+// Warning-first policy (BC-V3R3-006); will switch to hard-fail in P5.
+// /clear is never triggered automatically (HARD constraint per MEMORY.md).
 package runtime
 
 import (

--- a/internal/telemetry/async_recorder.go
+++ b/internal/telemetry/async_recorder.go
@@ -18,11 +18,11 @@ import (
 var ErrRecordDropped = errors.New("telemetry: record dropped (buffer full)")
 
 // AsyncRecorder is a non-blocking telemetry writer.
-// 내부 채널을 통해 단일 writer 고루틴에 레코드를 전달하여
-// 호출자 경로를 블로킹하지 않는다.
+// Delivers records to a single writer goroutine via an internal channel
+// so that the caller path is never blocked.
 //
-// @MX:WARN: [AUTO] 고루틴 + 채널 패턴: goroutine 수명은 Close()로 명시적으로 종료
-// @MX:REASON: [AUTO] 고루틴 누수 방지를 위해 Close() 없이 GC되면 writer 고루틴이 영구 대기
+// @MX:WARN: [AUTO] goroutine + channel pattern: goroutine lifetime is explicitly terminated via Close()
+// @MX:REASON: [AUTO] without Close(), the writer goroutine waits indefinitely when GC'd, causing a goroutine leak
 type AsyncRecorder struct {
 	projectRoot string
 	ch          chan UsageRecord
@@ -31,11 +31,11 @@ type AsyncRecorder struct {
 }
 
 // NewAsyncRecorder creates and starts a new AsyncRecorder.
-// bufSize는 내부 채널 버퍼 크기이다. 버퍼가 꽉 차면 Record()는 ErrRecordDropped를 반환한다.
-// 반환된 AsyncRecorder는 반드시 Close()로 종료해야 한다.
+// bufSize is the internal channel buffer size. When the buffer is full, Record() returns ErrRecordDropped.
+// The returned AsyncRecorder must be terminated with Close().
 //
-// @MX:ANCHOR: [AUTO] NewAsyncRecorder — 비동기 텔레메트리 진입점
-// @MX:REASON: [AUTO] hook/post_tool_metrics.go 등 다수 호출자에서 사용하는 공개 API
+// @MX:ANCHOR: [AUTO] NewAsyncRecorder — async telemetry entry point
+// @MX:REASON: [AUTO] public API used by many callers including hook/post_tool_metrics.go
 func NewAsyncRecorder(projectRoot string, bufSize int) *AsyncRecorder {
 	if bufSize < 1 {
 		bufSize = 256
@@ -51,7 +51,7 @@ func NewAsyncRecorder(projectRoot string, bufSize int) *AsyncRecorder {
 }
 
 // Record enqueues a UsageRecord for asynchronous writing.
-// 버퍼가 꽉 찬 경우 블로킹하지 않고 ErrRecordDropped를 반환한다.
+// Returns ErrRecordDropped without blocking when the buffer is full.
 func (r *AsyncRecorder) Record(rec UsageRecord) error {
 	select {
 	case r.ch <- rec:
@@ -66,8 +66,8 @@ func (r *AsyncRecorder) Record(rec UsageRecord) error {
 }
 
 // Close signals the writer goroutine to flush remaining records and exit.
-// ctx를 통해 최대 대기 시간을 제어한다.
-// Close 이후에는 Record()를 호출하면 안 된다.
+// ctx controls the maximum wait duration.
+// Record() must not be called after Close().
 func (r *AsyncRecorder) Close(ctx context.Context) error {
 	close(r.ch)
 
@@ -94,13 +94,13 @@ func (r *AsyncRecorder) run() {
 	dir := filepath.Join(r.projectRoot, ".moai", "evolution", "telemetry")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		slog.Error("telemetry: async recorder cannot create dir", "err", err)
-		// 디렉터리 생성 실패 시 모든 레코드를 드레인만 하고 종료
+		// Drain all records without writing and exit when directory creation fails
 		for range r.ch {
 		}
 		return
 	}
 
-	// 날짜별 파일 핸들 캐시 (CRITICAL 6: 동일 날짜 파일은 한 번만 open)
+	// Per-day file handle cache (CRITICAL 6: open each day's file only once)
 	var (
 		currentDay string
 		currentFile *os.File
@@ -119,12 +119,12 @@ func (r *AsyncRecorder) run() {
 	}
 	defer flushAndClose()
 
-	// 일정 레코드 수마다 flush (버퍼 누적 방지)
+	// Flush after a certain number of records (prevent buffer accumulation)
 	const flushEvery = 16
 	count := 0
 
 	for rec := range r.ch {
-		// UTC 날짜 키로 날짜 롤오버 감지
+		// Detect day rollover using the UTC date key
 		dayKey := rec.Timestamp.UTC().Format("2006-01-02")
 		if dayKey != currentDay {
 			flushAndClose()
@@ -157,10 +157,10 @@ func (r *AsyncRecorder) run() {
 			}
 		}
 	}
-	// 채널이 닫히면 남은 버퍼를 flush (defer flushAndClose가 처리)
+	// When the channel closes, flush remaining buffer (handled by defer flushAndClose)
 }
 
-// --- 패키지 레벨 싱글턴 ---
+// --- Package-level singleton ---
 
 var (
 	globalRecorder     *AsyncRecorder
@@ -169,9 +169,9 @@ var (
 )
 
 // GetRecorder returns the package-level singleton AsyncRecorder for projectRoot.
-// 첫 호출 시 레코더를 시작한다. projectRoot가 바뀌면 기존 레코더를 닫고 새로 시작한다.
+// Starts the recorder on first call. When projectRoot changes, closes the existing recorder and starts a new one.
 //
-// @MX:NOTE: [AUTO] 싱글턴 패턴: 프로세스당 하나의 writer 고루틴으로 파일 I/O를 집약
+// @MX:NOTE: [AUTO] Singleton pattern: concentrates file I/O into a single writer goroutine per process
 func GetRecorder(projectRoot string) *AsyncRecorder {
 	globalRecorderMu.Lock()
 	defer globalRecorderMu.Unlock()
@@ -180,7 +180,7 @@ func GetRecorder(projectRoot string) *AsyncRecorder {
 		return globalRecorder
 	}
 
-	// projectRoot가 바뀌었거나 아직 초기화되지 않은 경우
+	// projectRoot has changed or not yet initialized
 	if globalRecorder != nil {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()

--- a/internal/telemetry/async_recorder_test.go
+++ b/internal/telemetry/async_recorder_test.go
@@ -16,8 +16,9 @@ import (
 // TestAsyncRecorder_NonBlockingUnderLoad verifies that Record() returns quickly
 // even under heavy parallel load, and that all records are persisted after Close.
 func TestAsyncRecorder_NonBlockingUnderLoad(t *testing.T) {
-	// Windows CI 러너의 고루틴 스케줄러 입도가 Linux/macOS 대비 훨씬 거칠어
-	// latency 기반 검증이 일관되게 실패한다. 비블로킹 불변식은 다른 OS에서 검증.
+	// On Windows CI runners the goroutine scheduler granularity is much coarser
+	// than on Linux/macOS, so latency-based assertions fail consistently.
+	// Verify the non-blocking invariant on other OSes instead.
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping on Windows: scheduler granularity causes flaky latency assertions")
 	}
@@ -52,8 +53,8 @@ func TestAsyncRecorder_NonBlockingUnderLoad(t *testing.T) {
 			start := time.Now()
 			_ = rec.Record(r)
 			elapsed := time.Since(start)
-			// CI 환경(특히 Windows)의 고루틴 스케줄링 지연을 고려해 임계값을 100ms로 설정.
-			// 핵심 불변식: Record()는 디스크 I/O를 기다리지 않고 즉시 반환한다(채널 send 또는 drop).
+			// Threshold set to 100ms to accommodate goroutine scheduling latency in CI (especially Windows).
+			// Core invariant: Record() returns immediately without waiting for disk I/O (channel send or drop).
 			if elapsed > 100*time.Millisecond {
 				slowMu.Lock()
 				slowCalls++
@@ -63,13 +64,13 @@ func TestAsyncRecorder_NonBlockingUnderLoad(t *testing.T) {
 	}
 	wg.Wait()
 
-	// 버퍼 크기보다 많은 레코드이므로 일부는 드롭될 수 있음 - 하지만 블로킹은 없어야 함
-	// 느린 호출이 전체의 5% 이하여야 함(CI 스케줄링 변동 허용)
+	// More records than the buffer size, so some may be dropped — but blocking must not occur.
+	// Slow calls must be <= 5% of total (allows CI scheduling jitter).
 	if slowCalls > numRecords*5/100 {
-		t.Errorf("너무 많은 느린 호출: %d/%d (100ms 초과)", slowCalls, numRecords)
+		t.Errorf("too many slow calls: %d/%d (>100ms)", slowCalls, numRecords)
 	}
 
-	// 모든 레코드가 처리될 때까지 닫기
+	// Close after all records are processed.
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -77,14 +78,14 @@ func TestAsyncRecorder_NonBlockingUnderLoad(t *testing.T) {
 		t.Fatalf("Close: %v", err)
 	}
 
-	// 파일에 일부 레코드가 기록되었는지 확인 (드롭 정책으로 전체가 아닐 수 있음)
+	// Verify that some records were written to file (drop policy may keep less than total).
 	telDir := filepath.Join(dir, ".moai", "evolution", "telemetry")
 	entries, err := os.ReadDir(telDir)
 	if err != nil {
-		t.Fatalf("telemetry 디렉터리 읽기 실패: %v", err)
+		t.Fatalf("read telemetry dir: %v", err)
 	}
 	if len(entries) == 0 {
-		t.Fatal("telemetry 파일이 생성되지 않음")
+		t.Fatal("no telemetry files were created")
 	}
 }
 
@@ -98,10 +99,9 @@ func TestAsyncRecorder_DropPolicyWhenFull(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// 버퍼 크기 1, 소비자를 차단하여 버퍼가 꽉 차도록 함
+	// Buffer size 1; block the consumer so the buffer fills up.
 	rec := NewAsyncRecorder(dir, 1)
-	// 소비자 고루틴을 즉시 멈추기 위해 Close 후에도 테스트
-	// 대신 소비자 없이 채널을 꽉 채우는 방식으로 테스트
+	// Alternatively, fill the channel without a consumer to drive the test.
 
 	ts := time.Date(2026, 4, 15, 10, 0, 0, 0, time.UTC)
 	r := UsageRecord{
@@ -110,8 +110,8 @@ func TestAsyncRecorder_DropPolicyWhenFull(t *testing.T) {
 		Outcome:   OutcomeUnknown,
 	}
 
-	// 여러 번 Record를 호출하여 드롭이 발생하는지 확인
-	// 버퍼가 1이므로 처음 몇 번 이후에는 드롭되어야 함
+	// Call Record many times and verify that drops occur.
+	// Buffer is 1, so after the first few calls drops must happen.
 	var dropped int
 	for i := 0; i < 100; i++ {
 		err := rec.Record(r)
@@ -124,9 +124,9 @@ func TestAsyncRecorder_DropPolicyWhenFull(t *testing.T) {
 	defer cancel()
 	_ = rec.Close(ctx)
 
-	// 드롭이 발생했어야 함 (버퍼 1이므로)
-	// 소비자가 빠르면 드롭이 적을 수 있으므로 느슨하게 검증
-	t.Logf("드롭된 레코드: %d/100", dropped)
+	// Drops must have occurred (because buffer is 1).
+	// If the consumer is fast, dropped count may be small — verify loosely.
+	t.Logf("dropped records: %d/100", dropped)
 }
 
 // TestAsyncRecorder_ReusesFileHandle verifies that the async recorder does not
@@ -141,7 +141,7 @@ func TestAsyncRecorder_ReusesFileHandle(t *testing.T) {
 
 	rec := NewAsyncRecorder(dir, 500)
 
-	// 같은 날짜로 100개 레코드 기록
+	// Record 100 entries with the same date.
 	ts := time.Date(2026, 4, 15, 10, 0, 0, 0, time.UTC)
 	for i := 0; i < 100; i++ {
 		r := UsageRecord{
@@ -161,12 +161,12 @@ func TestAsyncRecorder_ReusesFileHandle(t *testing.T) {
 		t.Fatalf("Close: %v", err)
 	}
 
-	// 파일에 100개 레코드가 모두 기록되었는지 확인
+	// Verify that all 100 records were written to the file.
 	telDir := filepath.Join(dir, ".moai", "evolution", "telemetry")
 	path := filepath.Join(telDir, "usage-2026-04-15.jsonl")
 	f, err := os.Open(path)
 	if err != nil {
-		t.Fatalf("파일 열기 실패: %v", err)
+		t.Fatalf("open file: %v", err)
 	}
 	defer func() { _ = f.Close() }()
 
@@ -179,12 +179,12 @@ func TestAsyncRecorder_ReusesFileHandle(t *testing.T) {
 		}
 		var rec UsageRecord
 		if err := json.Unmarshal([]byte(line), &rec); err != nil {
-			t.Errorf("유효하지 않은 JSON at line %d: %v", count+1, err)
+			t.Errorf("invalid JSON at line %d: %v", count+1, err)
 		}
 		count++
 	}
 
 	if count != 100 {
-		t.Errorf("기대 100개 레코드, 실제 %d개", count)
+		t.Errorf("expected 100 records, got %d", count)
 	}
 }

--- a/internal/template/settings_test.go
+++ b/internal/template/settings_test.go
@@ -934,7 +934,7 @@ func TestIsWSL2_ProcVersionFallback_NonWSL(t *testing.T) {
 	}
 }
 
-// --- SPEC-DB-SYNC-RELOC-001: db-schema-change PostToolUse 훅이 제거되었음을 검증 ---
+// --- SPEC-DB-SYNC-RELOC-001: verify db-schema-change PostToolUse hook is removed ---
 
 // TestRender_DbSchemaChangeHook_Removed verifies that SPEC-DB-SYNC-RELOC-001
 // has relocated the per-edit PostToolUse hook for `handle-db-schema-change.sh`


### PR DESCRIPTION
## Summary

PR #720 supersede. main에 PR #721 (windows fix) 머지 후 rebase + conflict resolve. lang/mx + Wave 1+2 영어화 + @MX:ANCHOR + handoff doc 갱신 통합.

CLAUDE.local.md §3 (Go-Specific: All code, comments, godoc in English) 준수를 위한 대규모 정비.

## Changes (113 files / +2700/-2670)

### 1. Configuration
- `.moai/config/sections/language.yaml`: `code_comments: ko → en`

### 2. Go Comments Translation (Wave 1 + Wave 2)
- internal/{astgrep,cli,constitution,evolution,hook,loop,merge,runtime,template,telemetry,lsp/*,ralph}/ Go files (production + tests)
- pkg/models/{doc,lang}.go
- 한국어 주석/godoc/test message → 영어
- i18n DATA 보존 (translations.go map 값, i18n/templates.go template 본문)

### 3. @MX:ANCHOR (design_folder.go)
SPEC-V3R3-DESIGN-FOLDER-FIX-001 invariant 보호 (3개 함수)

### 4. Conflict Resolution
- internal/cli/constitution_test.go: PR #721 Windows skip + lang/mx 영어 godoc 통합

### 5. handoff document update
- .moai/release/v3r3-extreme-aggressive-handoff.md §9 진행 상태 갱신

## Verification

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/cli/ ./internal/hook/ ./internal/lsp/... -count=1 -short`: PASS

## Remaining Korean (intentional, preserved permanently)

- internal/i18n/templates.go (i18n template DATA)
- pkg/models/doc.go (godoc example: "Korean (한국어)")
- internal/hook/pre_tool_test.go (English comment referencing Korean test data)

## Closes

- PR #720 (force-push permission denied; rebased to new branch)

## Refs

- PR #721 (windows CI stabilize) — merged in main
- handoff: .moai/release/v3r3-extreme-aggressive-handoff.md §9

🗿 MoAI <email@mo.ai.kr>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Localized all user-facing text, error messages, help documentation, and configuration descriptions from Korean to English across the application for improved consistency and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->