### PR TITLE
fix(ci): Actions 효율 hotfix — concurrency 추가 + release-drafter 트리거 정리

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -10,6 +10,11 @@ permissions:
   contents: write
   pull-requests: write
 
+# Auto-merge — PR별 mutex, in-flight cancel 시 race condition 위험
+concurrency:
+  group: auto-merge-${{ github.event.workflow_run.pull_requests[0].number || github.run_id }}
+  cancel-in-progress: false
+
 jobs:
   auto-merge:
     # CI가 성공한 경우에만 실행

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,6 +9,10 @@ on:
     # Weekly scan: Monday at 06:00 UTC
     - cron: "0 6 * * 1"
 
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze (Go)

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,10 +9,14 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, reopened, synchronize, edited]
+    types: [opened, reopened, synchronize]
 
 permissions:
   contents: read
+
+concurrency:
+  group: release-drafter-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   update_release_draft:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,11 @@ permissions:
   contents: write
   packages: write
 
+# Release publish — cancel-in-progress: false (tag publish + GoReleaser cancel 시 partial release 위험)
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release:
     name: Release


### PR DESCRIPTION
## Summary

modu-ai org 5 레포 일괄 점검 마지막 PR. PUBLIC repo로 비용 zero이지만 9569 runs 누적으로 효율 개선 가치 큼.

## 변경

| 파일 | concurrency | cancel-in-progress | 근거 |
|---|---|---|---|
| auto-merge.yml | ✓ | **false** | PR 단위 mutex, race condition 방지 |
| codeql.yml | ✓ | true | 마지막 commit 결과만 의미 |
| release-drafter.yml | ✓ | true | + 'edited' 트리거 제거 (PR body는 release-drafter 미사용) |
| release.yml | ✓ | **false** | GoReleaser tag publish 안전 |

## 미변경

| 파일 | 이유 |
|---|---|
| ci.yml | 이미 concurrency 설정됨 |
| claude-code-review.yml | 이미 concurrency 설정됨 |
| claude.yml | 이미 concurrency 설정됨 |
| review-quality-gate.yml | 이미 concurrency 설정됨 |
| test-install.yml | 이미 concurrency 설정됨 |
| community.yml | schedule + welcome + labeler — cancel 부적절 |

## Test Plan

- [ ] CI 통과
- [ ] auto-merge race condition 없음 확인
- [ ] CodeQL 빠른 연속 push 시 마지막만 실행
- [ ] release.yml은 tag push 시 GoReleaser 정상 완주

🗿 MoAI <namgoos@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configurations to add concurrency management across automated merge, code analysis, and release processes.
  * Refined event filtering in the release draft workflow to optimize trigger conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->