### PR TITLE
feat(spec): SPEC-STATUS-AUTO-001 — SPEC status auto-update system

### DIFF
--- a/.claude/hooks/moai/handle-spec-status.sh
+++ b/.claude/hooks/moai/handle-spec-status.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Hook wrapper for SPEC status auto-update
+# Triggered by PostToolUse event after git commit
+
+INPUT=$(cat)
+moai hook spec-status <<< "$INPUT"

--- a/.claude/skills/moai/workflows/sync.md
+++ b/.claude/skills/moai/workflows/sync.md
@@ -706,6 +706,12 @@ Update SPEC status based on lifecycle level and implementation completeness:
 - Level 2 (spec-anchored): Set status to "completed" if all requirements met, or "in-progress" if partial. Schedule next review based on quarterly maintenance policy.
 - Level 3 (spec-as-source): Set status based on implementation-SPEC alignment. Flag discrepancies for resolution.
 
+**Implementation** (SPEC-STATUS-AUTO-001 REQ-4):
+```bash
+moai spec status <SPEC-ID> completed
+```
+Failure to update status does not block the sync workflow (warning only).
+
 Record version changes, status transitions, and divergence summary. Include in sync report.
 
 #### Step 2.4.1: GitHub Issue Status Sync

--- a/.moai/specs/SPEC-STATUS-AUTO-001/progress.md
+++ b/.moai/specs/SPEC-STATUS-AUTO-001/progress.md
@@ -1,0 +1,13 @@
+## SPEC-STATUS-AUTO-001 Progress
+
+- Started: 2026-04-27T10:00:00Z
+- Harness: standard (auto-detected: file_count > 3, spec_type=feature)
+- Development Mode: tdd (quality.yaml)
+- Phase 0.9: Language=Go (moai-lang-go)
+- Phase 0.95: Standard Mode (6 files, 1 domain)
+- plan_artifact_hash: 6d96a8fabe28a193c0bc8631912158a2b58351320f72eecab639a6ce7aab7d09
+- Phase 0.5 complete: audit_verdict=FAIL_WARNED (grace window D-5)
+- audit_report: .moai/reports/plan-audit/SPEC-STATUS-AUTO-001-review-1.md
+- audit_at: 2026-04-27T10:02:00Z
+- auditor_version: plan-auditor
+- defects: 8 critical, 3 major, 4 minor (must-pass: REQ numbering, EARS ACs, frontmatter fields)

--- a/.moai/specs/SPEC-STATUS-AUTO-001/spec.md
+++ b/.moai/specs/SPEC-STATUS-AUTO-001/spec.md
@@ -1,0 +1,161 @@
+---
+id: SPEC-STATUS-AUTO-001
+version: "1.0.0"
+status: draft
+created: "2026-04-27"
+updated: "2026-04-27"
+author: GOOS
+priority: P1
+labels: [spec-status, automation, hooks, cli, sync-workflow]
+---
+
+# SPEC-STATUS-AUTO-001: SPEC Status Auto-Update System
+
+## Problem Statement
+
+SPEC documents in `.moai/specs/` track lifecycle status (`draft` → `planned` → `implemented` → `completed`), but status updates are purely manual. When a SPEC's implementation is merged to main, the SPEC frontmatter is often left at `draft` or `planned` indefinitely. 15 SPECs were found in this exact state during audit on 2026-04-27.
+
+Root causes:
+1. No code exists to modify SPEC frontmatter status
+2. `/moai sync` Step 2.4 documents status updates but has no implementation
+3. SPEC metadata formats are fragmented (6 variants: YAML, Markdown list, table, Korean fields)
+4. No trigger mechanism to detect when a SPEC should transition
+
+## Requirements (EARS Format)
+
+### REQ-1: SPEC Status Updater Library (Priority: P0)
+
+**WHEN** `spec.UpdateStatus(specID, newStatus)` is called, **THE SYSTEM SHALL** locate `.moai/specs/<specID>/spec.md`, detect its metadata format (YAML frontmatter, Markdown list, or table), update the status field to `newStatus`, and preserve all other content unchanged.
+
+**Acceptance Criteria:**
+- AC-1.1: Supports all 6 format variants:
+  - YAML `status:` (Format A, B)
+  - Markdown `- **Status**: X` (Format D)
+  - Markdown table `| 상태 | X |` or `| Status | X |` (Format E)
+  - Adds YAML frontmatter block if none exists (Format F)
+- AC-1.2: Validated status values: `draft`, `planned`, `in-progress`, `implemented`, `completed`, `superseded`
+- AC-1.3: Returns error if spec.md file not found or status value invalid
+- AC-1.4: Does not modify any content outside the status field
+- AC-1.5: Unit test coverage >= 90% for all format parsers
+
+### REQ-2: CLI Command (Priority: P0)
+
+**WHEN** `moai spec status <SPEC-ID> <status>` is invoked, **THE SYSTEM SHALL** call the updater library and report success or failure.
+
+**Acceptance Criteria:**
+- AC-2.1: Command registered under `moai spec` parent command
+- AC-2.2: Validates SPEC-ID exists in `.moai/specs/` before attempting update
+- AC-2.3: Prints human-readable confirmation: `SPEC-XXX status updated: draft → completed`
+- AC-2.4: Supports `--dry-run` flag to preview change without writing
+- AC-2.5: Supports `--list` flag to show all SPECs and their current status
+
+### REQ-3: Commit-Based Auto-Detection (L1) (Priority: P1)
+
+**WHEN** a git commit message contains a pattern matching `SPEC-[A-Z0-9]+-[0-9]+`, **THE SYSTEM SHALL** extract the SPEC-ID(s) and automatically update their status to `implemented`.
+
+**Acceptance Criteria:**
+- AC-3.1: Implemented as `internal/hook/spec_status.go` hook handler
+- AC-3.2: Triggered by `PostToolUse` event when tool is `Bash` and command matches `git commit`
+- AC-3.3: Parses commit message from `git log -1 --format=%s`
+- AC-3.4: Extracts all unique SPEC-XXX patterns from the message
+- AC-3.5: For each SPEC-ID found, calls `spec.UpdateStatus(specID, "implemented")`
+- AC-3.6: Logs updated SPECs to stderr (non-blocking — hook exit code always 0)
+- AC-3.7: Gracefully skips if `.moai/specs/` directory does not exist
+
+### REQ-4: Sync Workflow Integration (L2) (Priority: P1)
+
+**WHEN** `/moai sync` completes documentation synchronization, **THE SYSTEM SHALL** update the synced SPEC status to `completed`.
+
+**Acceptance Criteria:**
+- AC-4.1: sync.md Phase 2.4 invokes `moai spec status <SPEC-ID> completed`
+- AC-4.2: Status update occurs after documentation sync succeeds
+- AC-4.3: Failure to update status does not block the sync workflow (warning only)
+- AC-4.4: Logs the status transition in sync output
+
+### REQ-5: Batch Status Command (Priority: P2)
+
+**WHEN** `moai spec status --sync-git` is invoked, **THE SYSTEM SHALL** cross-reference all SPECs in `.moai/specs/` against git log on main and update statuses where implementation commits exist.
+
+**Acceptance Criteria:**
+- AC-5.1: Scans `git log main --oneline --no-merges` for SPEC-XXX patterns
+- AC-5.2: For each SPEC found in commits but not marked `completed`/`implemented`, updates status
+- AC-5.3: Reports a summary: `Updated N SPECs, skipped M (already completed), K not found`
+- AC-5.4: Requires `--confirm` flag (or `--yes` for non-interactive) before writing changes
+
+## Technical Approach
+
+### Package Structure
+
+```
+internal/spec/
+  status.go         # UpdateStatus(), ParseStatus(), Format detection
+  status_test.go    # Unit tests for all 6 format parsers
+
+internal/hook/
+  spec_status.go    # L1 hook handler (PostToolUse)
+
+internal/cli/
+  spec.go           # `moai spec` parent command
+  spec_status.go    # `moai spec status` subcommand
+```
+
+### Format Detection Algorithm
+
+```
+1. Read first 30 lines of spec.md
+2. If contains "---" delimiter → YAML frontmatter
+   a. Parse YAML, look for "status:" key
+   b. If no "status:" key → add it
+3. Else if contains "| 상태 |" or "| Status |" → Table format
+   a. Replace status value in table row
+4. Else if contains "- **Status**:" → Markdown list format
+   a. Replace status value in list item
+5. Else → Prepend YAML frontmatter block with status field
+```
+
+### Hook Registration
+
+In `settings.json` hooks:
+```json
+{
+  "PostToolUse": [{
+    "matcher": "Bash",
+    "hooks": [{
+      "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-spec-status.sh\"",
+      "timeout": 5
+    }]
+  }]
+}
+```
+
+Hook wrapper script reads stdin JSON, checks if bash command was `git commit`, then calls `moai spec status --auto-commit`.
+
+## Scope
+
+### In Scope
+- SPEC status updater library with multi-format support
+- CLI command `moai spec status`
+- L1 PostToolUse hook for commit-based detection
+- L2 sync workflow integration
+- Batch sync-git command
+
+### Out of Scope
+- L3 PR merge detection via GitHub Actions (future SPEC)
+- SPEC lifecycle state machine enforcement (validation only)
+- Web UI for SPEC status management
+- Automatic archiving of completed SPECs
+
+## Dependencies
+
+- Existing `internal/cli/` command structure (cobra)
+- Existing `internal/hook/` hook handler pattern
+- `.moai/specs/` directory structure (convention)
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| YAML frontmatter parsing fragile | Use simple line-based regex, not full YAML parser |
+| Hook timeout on large commit messages | 5s timeout, process only first line |
+| Race condition on concurrent edits | SPEC files are single-writer (one session at a time) |
+| False positive SPEC pattern in commit body | Only match conventional commit title (first line) |

--- a/.moai/specs/SPEC-STATUS-AUTO-001/spec.md
+++ b/.moai/specs/SPEC-STATUS-AUTO-001/spec.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-STATUS-AUTO-001
 version: "1.0.0"
-status: draft
+status: implemented
 created: "2026-04-27"
 updated: "2026-04-27"
 author: GOOS

--- a/.moai/specs/SPEC-STATUS-AUTO-001/tasks.md
+++ b/.moai/specs/SPEC-STATUS-AUTO-001/tasks.md
@@ -1,0 +1,14 @@
+## Task Decomposition
+SPEC: SPEC-STATUS-AUTO-001
+
+| Task ID | Description | Requirement | Dependencies | Planned Files | Status |
+|---------|-------------|-------------|--------------|---------------|--------|
+| T-001 | YAML frontmatter status update (Format A/B) | REQ-1 | - | internal/spec/status.go, internal/spec/status_test.go | pending |
+| T-002 | Markdown list status update (Format D) | REQ-1 | T-001 | internal/spec/status.go | pending |
+| T-003 | Table status update (Format E, KR/EN) | REQ-1 | T-001 | internal/spec/status.go | pending |
+| T-004 | YAML frontmatter prepend (Format F) | REQ-1 | T-001 | internal/spec/status.go | pending |
+| T-005 | ParseStatus + validation | REQ-1 | T-001 | internal/spec/status.go | pending |
+| T-006 | CLI: moai spec status + --dry-run + --list | REQ-2 | T-005 | internal/cli/spec.go, internal/cli/spec_status.go, internal/cli/root.go | pending |
+| T-007 | PostToolUse hook handler + wrapper script | REQ-3 | T-005 | internal/hook/spec_status.go, .claude/hooks/moai/handle-spec-status.sh | pending |
+| T-008 | Sync workflow integration | REQ-4 | T-006 | .claude/skills/moai/workflows/sync.md | pending |
+| T-009 | Batch --sync-git command | REQ-5 | T-005 | internal/cli/spec_status.go | pending |

--- a/internal/cli/hook.go
+++ b/internal/cli/hook.go
@@ -106,6 +106,15 @@ func init() {
 	}
 	dbSchemaSyncCmd.Flags().String("file", "", "File path from PostToolUse hook stdin")
 	hookCmd.AddCommand(dbSchemaSyncCmd)
+
+	// Add "spec-status" subcommand (SPEC-STATUS-AUTO-001)
+	specStatusCmd := &cobra.Command{
+		Use:   "spec-status",
+		Short: "Auto-update SPEC status on git commit",
+		Long:  "Extract SPEC-IDs from git commit messages and update their status to 'implemented'. Called from handle-spec-status.sh.",
+		RunE:  runSpecStatus,
+	}
+	hookCmd.AddCommand(specStatusCmd)
 }
 
 // @MX:ANCHOR: [AUTO] runHookEvent is the central dispatcher for all Claude Code hook events
@@ -292,6 +301,39 @@ func runDBSchemaSync(cmd *cobra.Command, _ []string) error {
 
 	// Always exit 0 (non-blocking, REQ-011)
 	_ = result.ExitCode
+	return nil
+}
+
+// runSpecStatus handles the spec-status hook subcommand.
+// It reads hook input from stdin and dispatches to the spec status handler.
+func runSpecStatus(cmd *cobra.Command, _ []string) error {
+	if deps == nil || deps.HookProtocol == nil || deps.HookRegistry == nil {
+		return fmt.Errorf("hook system not initialized")
+	}
+
+	// Read hook input from stdin
+	input, err := deps.HookProtocol.ReadInput(os.Stdin)
+	if err != nil {
+		return fmt.Errorf("read hook input: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Second)
+	defer cancel()
+
+	// Create spec status handler and execute
+	handler := hook.NewSpecStatusHandler()
+	output, err := handler.Handle(ctx, input)
+	if err != nil {
+		// Log but don't fail - hook is non-blocking
+		_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "spec-status: error:", err)
+		return nil
+	}
+
+	if writeErr := deps.HookProtocol.WriteOutput(cmd.OutOrStdout(), output); writeErr != nil {
+		_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "spec-status: write output:", writeErr)
+	}
+
+	// Always exit 0 (non-blocking)
 	return nil
 }
 

--- a/internal/cli/hook_e2e_test.go
+++ b/internal/cli/hook_e2e_test.go
@@ -344,6 +344,7 @@ func TestHookValidEventTypes_AllHaveSubcommands(t *testing.T) {
 		"pre-push":         true,
 		"db-schema-sync":   true, // SPEC-DB-SYNC-001: domain hook, not a Claude Code event
 		"harness-observe":  true, // SPEC-V3R3-HARNESS-LEARNING-001: domain hook, not a Claude Code event
+			"spec-status":      true, // SPEC-STATUS-AUTO-001: domain hook, not a Claude Code event
 	}
 
 	for _, cmd := range hookCmd.Commands() {

--- a/internal/cli/hook_pre_push_test.go
+++ b/internal/cli/hook_pre_push_test.go
@@ -73,8 +73,8 @@ func TestReadStdinLines_Empty(t *testing.T) {
 func TestHookCmd_PrePushSubcommandCount(t *testing.T) {
 	// The hook command should now have 31 subcommands (30 previous + 1 new: db-schema-sync, SPEC-DB-SYNC-001).
 	count := len(hookCmd.Commands())
-	// 31 previous + 1 new: harness-observe (SPEC-V3R3-HARNESS-LEARNING-001)
-	if count != 32 {
+	// 32 previous + 1 new: spec-status (SPEC-STATUS-AUTO-001)
+	if count != 33 {
 		names := make([]string, 0, count)
 		for _, cmd := range hookCmd.Commands() {
 			names = append(names, cmd.Name())

--- a/internal/cli/hook_test.go
+++ b/internal/cli/hook_test.go
@@ -60,9 +60,9 @@ func TestHookCmd_HasSubcommands(t *testing.T) {
 
 func TestHookCmd_SubcommandCount(t *testing.T) {
 	count := len(hookCmd.Commands())
-	// 31 previous + 1 new: harness-observe (SPEC-V3R3-HARNESS-LEARNING-001 T-P1-03)
-	if count != 32 {
-		t.Errorf("hook should have 32 subcommands, got %d", count)
+	// 32 previous + 1 new: spec-status (SPEC-STATUS-AUTO-001)
+	if count != 33 {
+		t.Errorf("hook should have 33 subcommands, got %d", count)
 	}
 }
 

--- a/internal/cli/spec.go
+++ b/internal/cli/spec.go
@@ -1,0 +1,27 @@
+package cli
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// newSpecCmd creates the 'moai spec' parent command
+func newSpecCmd() *cobra.Command {
+	specCmd := &cobra.Command{
+		Use:   "spec",
+		Short: "Manage SPEC documents",
+		Long:  `Manage SPEC documents in .moai/specs/ directory.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+		GroupID: "tools",
+	}
+
+	// Add subcommands
+	specCmd.AddCommand(newSpecStatusCmd())
+
+	return specCmd
+}
+
+func init() {
+	rootCmd.AddCommand(newSpecCmd())
+}

--- a/internal/cli/spec_status.go
+++ b/internal/cli/spec_status.go
@@ -3,17 +3,25 @@ package cli
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/modu-ai/moai-adk/internal/spec"
 )
 
+// specIDPattern matches SPEC-XXX patterns in git commit messages
+var specIDPattern = regexp.MustCompile(`SPEC-[A-Z0-9-]+-[0-9]+`)
+
 // newSpecStatusCmd creates the 'moai spec status' subcommand
 func newSpecStatusCmd() *cobra.Command {
 	var dryRun bool
 	var listAll bool
+	var syncGit bool
+	var syncConfirm bool
+	var syncYes bool
 
 	cmd := &cobra.Command{
 		Use:   "status <SPEC-ID> <new-status>",
@@ -23,8 +31,14 @@ func newSpecStatusCmd() *cobra.Command {
 Examples:
   moai spec status SPEC-XXX completed        # Update status
   moai spec status SPEC-XXX completed --dry-run  # Preview change
-  moai spec status --list                    # List all SPECs`,
+  moai spec status --list                    # List all SPECs
+  moai spec status --sync-git                # Sync from git log
+  moai spec status --sync-git --yes          # Non-interactive sync`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if syncGit {
+				return syncGitSpecStatuses(cmd, syncYes)
+			}
+
 			// Handle --list flag
 			if listAll {
 				return listAllSpecs(cmd)
@@ -44,6 +58,9 @@ Examples:
 
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Preview change without writing")
 	cmd.Flags().BoolVar(&listAll, "list", false, "List all SPECs and their status")
+	cmd.Flags().BoolVar(&syncGit, "sync-git", false, "Sync SPEC statuses from git log on main")
+	cmd.Flags().BoolVar(&syncConfirm, "confirm", false, "Confirm sync-git changes interactively")
+	cmd.Flags().BoolVar(&syncYes, "yes", false, "Non-interactive mode for sync-git (auto-confirm)")
 
 	return cmd
 }
@@ -131,4 +148,97 @@ func listAllSpecs(cmd *cobra.Command) error {
 	}
 
 	return nil
+}
+
+// syncGitSpecStatuses scans git log on main for SPEC-XXX patterns and updates statuses.
+// REQ-5 of SPEC-STATUS-AUTO-001.
+func syncGitSpecStatuses(cmd *cobra.Command, autoConfirm bool) error {
+	projectRoot, err := findProjectRootFn()
+	if err != nil {
+		return fmt.Errorf("failed to find project root: %w", err)
+	}
+
+	specIDsFromGit, err := getSPECIDsFromGitLog()
+	if err != nil {
+		return fmt.Errorf("failed to scan git log: %w", err)
+	}
+
+	if len(specIDsFromGit) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "No SPEC-IDs found in git log.")
+		return nil
+	}
+
+	specsDir := filepath.Join(projectRoot, ".moai", "specs")
+	updated := 0
+	skipped := 0
+	notFound := 0
+
+	for _, specID := range specIDsFromGit {
+		specDir := filepath.Join(specsDir, specID)
+
+		if _, err := os.Stat(filepath.Join(specDir, "spec.md")); os.IsNotExist(err) {
+			fmt.Fprintf(cmd.OutOrStdout(), "  skipped %s: not found in .moai/specs/\n", specID)
+			notFound++
+			continue
+		}
+
+		currentStatus := "unknown"
+		if s, err := spec.ParseStatus(specDir); err == nil {
+			currentStatus = s
+		}
+
+		if currentStatus == "completed" || currentStatus == "implemented" {
+			fmt.Fprintf(cmd.OutOrStdout(), "  skipped %s: already %s\n", specID, currentStatus)
+			skipped++
+			continue
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), "  %s: %s → implemented\n", specID, currentStatus)
+
+		if !autoConfirm {
+			fmt.Fprintf(cmd.OutOrStdout(), "    Apply? [y/N]: ")
+			var response string
+			fmt.Scanln(&response)
+			if strings.ToLower(response) != "y" {
+				fmt.Fprintf(cmd.OutOrStdout(), "    skipped %s\n", specID)
+				skipped++
+				continue
+			}
+		}
+
+		if err := spec.UpdateStatus(specDir, "implemented"); err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "  error updating %s: %v\n", specID, err)
+			continue
+		}
+		updated++
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "\nSummary: updated %d, skipped %d (already done), %d not found\n", updated, skipped, notFound)
+	return nil
+}
+
+// getSPECIDsFromGitLog scans git log on main for SPEC-XXX patterns.
+func getSPECIDsFromGitLog() ([]string, error) {
+	branch := "main"
+	if _, err := exec.Command("git", "rev-parse", "--verify", "main").Output(); err != nil {
+		branch = "master"
+	}
+
+	out, err := exec.Command("git", "log", branch, "--oneline", "--no-merges").Output()
+	if err != nil {
+		return nil, fmt.Errorf("git log failed: %w", err)
+	}
+
+	matches := specIDPattern.FindAllString(string(out), -1)
+
+	seen := make(map[string]bool)
+	var result []string
+	for _, m := range matches {
+		if !seen[m] {
+			seen[m] = true
+			result = append(result, m)
+		}
+	}
+
+	return result, nil
 }

--- a/internal/cli/spec_status.go
+++ b/internal/cli/spec_status.go
@@ -1,0 +1,134 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/modu-ai/moai-adk/internal/spec"
+)
+
+// newSpecStatusCmd creates the 'moai spec status' subcommand
+func newSpecStatusCmd() *cobra.Command {
+	var dryRun bool
+	var listAll bool
+
+	cmd := &cobra.Command{
+		Use:   "status <SPEC-ID> <new-status>",
+		Short: "Update or list SPEC document statuses",
+		Long: `Update the status field in a SPEC document, or list all SPECs.
+
+Examples:
+  moai spec status SPEC-XXX completed        # Update status
+  moai spec status SPEC-XXX completed --dry-run  # Preview change
+  moai spec status --list                    # List all SPECs`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Handle --list flag
+			if listAll {
+				return listAllSpecs(cmd)
+			}
+
+			// Require SPEC-ID and new-status arguments
+			if len(args) < 2 {
+				return cmd.Help()
+			}
+
+			specID := args[0]
+			newStatus := args[1]
+
+			return updateSpecStatus(cmd, specID, newStatus, dryRun)
+		},
+	}
+
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Preview change without writing")
+	cmd.Flags().BoolVar(&listAll, "list", false, "List all SPECs and their status")
+
+	return cmd
+}
+
+// updateSpecStatus updates the status of a SPEC document
+func updateSpecStatus(cmd *cobra.Command, specID, newStatus string, dryRun bool) error {
+	// Find project root
+	projectRoot, err := findProjectRootFn()
+	if err != nil {
+		return fmt.Errorf("failed to find project root: %w", err)
+	}
+
+	// Locate SPEC directory
+	specDir := filepath.Join(projectRoot, ".moai", "specs", specID)
+
+	// Get current status for display
+	oldStatus := "unknown"
+	if content, err := spec.ParseStatus(specDir); err == nil {
+		oldStatus = content
+	}
+
+	// Dry run: just show what would change
+	if dryRun {
+		fmt.Fprintf(cmd.OutOrStdout(), "Would update: %s status %s → %s\n", specID, oldStatus, newStatus)
+		return nil
+	}
+
+	// Perform update
+	if err := spec.UpdateStatus(specDir, newStatus); err != nil {
+		return fmt.Errorf("Error: %w", err)
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "%s status updated: %s → %s\n", specID, oldStatus, newStatus)
+	return nil
+}
+
+// listAllSpecs lists all SPECs and their current status
+func listAllSpecs(cmd *cobra.Command) error {
+	projectRoot, err := findProjectRootFn()
+	if err != nil {
+		return fmt.Errorf("failed to find project root: %w", err)
+	}
+
+	specsDir := filepath.Join(projectRoot, ".moai", "specs")
+
+	// Check if directory exists
+	if _, err := os.Stat(specsDir); os.IsNotExist(err) {
+		fmt.Fprintf(cmd.OutOrStdout(), "No SPECs directory found at %s\n", specsDir)
+		return nil
+	}
+
+	// Read all subdirectories
+	entries, err := os.ReadDir(specsDir)
+	if err != nil {
+		return fmt.Errorf("failed to read specs directory: %w", err)
+	}
+
+	// Print header
+	fmt.Fprintf(cmd.OutOrStdout(), "%-30s %-15s %s\n", "SPEC-ID", "Status", "Modified")
+	fmt.Fprintln(cmd.OutOrStdout(), strings.Repeat("-", 80))
+
+	// List each SPEC
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		specID := entry.Name()
+		specDir := filepath.Join(specsDir, specID)
+
+		// Parse status
+		status := "unknown"
+		if s, err := spec.ParseStatus(specDir); err == nil {
+			status = s
+		}
+
+		// Get modification time
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		modTime := info.ModTime().Format("2006-01-02 15:04")
+
+		fmt.Fprintf(cmd.OutOrStdout(), "%-30s %-15s %s\n", specID, status, modTime)
+	}
+
+	return nil
+}

--- a/internal/cli/spec_status_test.go
+++ b/internal/cli/spec_status_test.go
@@ -1,0 +1,201 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestSpecStatusCommand tests the basic command structure
+func TestSpecStatusCommand(t *testing.T) {
+	cmd := newSpecCmd()
+
+	if cmd.Use != "spec" {
+		t.Errorf("expected command Use 'spec', got %q", cmd.Use)
+	}
+
+	if cmd.Short == "" {
+		t.Error("expected command Short to be set")
+	}
+}
+
+// TestSpecStatusUpdate tests updating a SPEC status via CLI
+func TestSpecStatusUpdate(t *testing.T) {
+	tmpDir := t.TempDir()
+	specDir := filepath.Join(tmpDir, ".moai", "specs", "SPEC-CLI-TEST-001")
+	if err := os.MkdirAll(specDir, 0755); err != nil {
+		t.Fatalf("failed to create spec dir: %v", err)
+	}
+
+	specPath := filepath.Join(specDir, "spec.md")
+	content := `---
+id: SPEC-CLI-TEST-001
+status: draft
+---
+# Test SPEC
+`
+	if err := os.WriteFile(specPath, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write spec file: %v", err)
+	}
+
+	// Override project root for test
+	oldFindProjectRootFn := findProjectRootFn
+	defer func() { findProjectRootFn = oldFindProjectRootFn }()
+	findProjectRootFn = func() (string, error) {
+		return tmpDir, nil
+	}
+
+	// Execute command
+	cmd := newSpecStatusCmd()
+	cmd.SetArgs([]string{"SPEC-CLI-TEST-001", "completed"})
+	output := &strings.Builder{}
+	cmd.SetOut(output)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("command execution failed: %v", err)
+	}
+
+	outputStr := output.String()
+	if !strings.Contains(outputStr, "status updated") {
+		t.Errorf("expected output to contain 'status updated', got: %s", outputStr)
+	}
+
+	// Verify the file was updated
+	updatedContent, err := os.ReadFile(specPath)
+	if err != nil {
+		t.Fatalf("failed to read updated spec: %v", err)
+	}
+
+	if !strings.Contains(string(updatedContent), "status: completed") {
+		t.Error("status was not updated in file")
+	}
+}
+
+// TestSpecStatusDryRun tests the --dry-run flag
+func TestSpecStatusDryRun(t *testing.T) {
+	tmpDir := t.TempDir()
+	specDir := filepath.Join(tmpDir, ".moai", "specs", "SPEC-DRYRUN-001")
+	if err := os.MkdirAll(specDir, 0755); err != nil {
+		t.Fatalf("failed to create spec dir: %v", err)
+	}
+
+	specPath := filepath.Join(specDir, "spec.md")
+	content := `---
+status: draft
+---
+`
+	if err := os.WriteFile(specPath, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write spec file: %v", err)
+	}
+
+	oldFindProjectRootFn := findProjectRootFn
+	defer func() { findProjectRootFn = oldFindProjectRootFn }()
+	findProjectRootFn = func() (string, error) {
+		return tmpDir, nil
+	}
+
+	cmd := newSpecStatusCmd()
+	cmd.SetArgs([]string{"SPEC-DRYRUN-001", "completed", "--dry-run"})
+	output := &strings.Builder{}
+	cmd.SetOut(output)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("command execution failed: %v", err)
+	}
+
+	// File should NOT be modified
+	originalContent, err := os.ReadFile(specPath)
+	if err != nil {
+		t.Fatalf("failed to read spec: %v", err)
+	}
+
+	if strings.Contains(string(originalContent), "status: completed") {
+		t.Error("file was modified during dry-run")
+	}
+
+	outputStr := output.String()
+	if !strings.Contains(outputStr, "Would update") {
+		t.Errorf("expected dry-run output, got: %s", outputStr)
+	}
+}
+
+// TestSpecStatusList tests the --list flag
+func TestSpecStatusList(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create multiple SPECs
+	for i := 1; i <= 3; i++ {
+		specDir := filepath.Join(tmpDir, ".moai", "specs", fmt.Sprintf("SPEC-LIST-%03d", i))
+		if err := os.MkdirAll(specDir, 0755); err != nil {
+			t.Fatalf("failed to create spec dir: %v", err)
+		}
+
+		status := "draft"
+		if i == 2 {
+			status = "completed"
+		}
+
+		specPath := filepath.Join(specDir, "spec.md")
+		content := fmt.Sprintf("---\nstatus: %s\n---\n", status)
+		if err := os.WriteFile(specPath, []byte(content), 0644); err != nil {
+			t.Fatalf("failed to write spec file: %v", err)
+		}
+	}
+
+	oldFindProjectRootFn := findProjectRootFn
+	defer func() { findProjectRootFn = oldFindProjectRootFn }()
+	findProjectRootFn = func() (string, error) {
+		return tmpDir, nil
+	}
+
+	cmd := newSpecStatusCmd()
+	cmd.SetArgs([]string{"--list"})
+	output := &strings.Builder{}
+	cmd.SetOut(output)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("command execution failed: %v", err)
+	}
+
+	outputStr := output.String()
+	if !strings.Contains(outputStr, "SPEC-LIST-001") {
+		t.Error("output should contain SPEC-LIST-001")
+	}
+	if !strings.Contains(outputStr, "SPEC-LIST-002") {
+		t.Error("output should contain SPEC-LIST-002")
+	}
+	if !strings.Contains(outputStr, "draft") {
+		t.Error("output should contain draft status")
+	}
+	if !strings.Contains(outputStr, "completed") {
+		t.Error("output should contain completed status")
+	}
+}
+
+// TestSpecStatusNotFound tests error handling for non-existent SPEC
+func TestSpecStatusNotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	oldFindProjectRootFn := findProjectRootFn
+	defer func() { findProjectRootFn = oldFindProjectRootFn }()
+	findProjectRootFn = func() (string, error) {
+		return tmpDir, nil
+	}
+
+	cmd := newSpecStatusCmd()
+	cmd.SetArgs([]string{"SPEC-NONEXISTENT", "completed"})
+	output := &strings.Builder{}
+	cmd.SetOut(output)
+	cmd.SetErr(output)
+
+	if err := cmd.Execute(); err == nil {
+		t.Error("command should return error for non-existent SPEC")
+	}
+
+	outputStr := output.String()
+	if !strings.Contains(outputStr, "not found") && !strings.Contains(outputStr, "Error") {
+		t.Errorf("expected error message, got: %s", outputStr)
+	}
+}

--- a/internal/hook/spec_status.go
+++ b/internal/hook/spec_status.go
@@ -1,0 +1,124 @@
+package hook
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"regexp"
+	"strings"
+
+	"github.com/modu-ai/moai-adk/internal/spec"
+)
+
+// specStatusHandler processes PostToolUse events to auto-update SPEC status on git commits.
+// It implements REQ-3 of SPEC-STATUS-AUTO-001.
+type specStatusHandler struct{}
+
+// NewSpecStatusHandler creates a new spec status hook handler.
+func NewSpecStatusHandler() Handler {
+	return &specStatusHandler{}
+}
+
+// EventType returns EventPostToolUse.
+func (h *specStatusHandler) EventType() EventType {
+	return EventPostToolUse
+}
+
+// Handle processes a PostToolUse event. It checks if the tool was a git commit,
+// extracts SPEC-IDs from the commit message, and updates their status to "implemented".
+// Errors are non-blocking - the handler always returns success.
+func (h *specStatusHandler) Handle(ctx context.Context, input *HookInput) (*HookOutput, error) {
+	projectDir := resolveProjectDir(input)
+
+	// Parse hook input data
+	var data struct {
+		ToolName string `json:"tool_name"`
+		Command  string `json:"command"`
+	}
+	if input.Data != nil {
+		if err := json.Unmarshal(input.Data, &data); err != nil {
+			slog.Debug("spec-status: failed to unmarshal hook data", "error", err)
+			return &HookOutput{}, nil
+		}
+	}
+
+	// Only process git commit commands
+	if !isGitCommitCommand(data.Command) {
+		return &HookOutput{}, nil
+	}
+
+	// Extract commit message (simulate "git log -1 --format=%s")
+	commitMsg := extractCommitMessage(data.Command)
+	if commitMsg == "" {
+		return &HookOutput{}, nil
+	}
+
+	// Extract SPEC-IDs from commit message
+	specIDs := extractSPECIDs(commitMsg)
+	if len(specIDs) == 0 {
+		return &HookOutput{}, nil
+	}
+
+	// Update each SPEC status
+	updatedCount := 0
+	for _, specID := range specIDs {
+		specDir := projectDir + "/.moai/specs/" + specID
+		if err := spec.UpdateStatus(specDir, "implemented"); err != nil {
+			// Log but don't fail - SPEC might not exist or already be implemented
+			slog.Debug("spec-status: failed to update", "spec", specID, "error", err)
+			continue
+		}
+		slog.Info("spec-status: updated", "spec", specID, "status", "implemented")
+		updatedCount++
+	}
+
+	// Build response data
+	responseData := map[string]any{
+		"updated_count": updatedCount,
+		"spec_ids":      specIDs,
+	}
+	rawData, _ := json.Marshal(responseData)
+
+	return &HookOutput{Data: rawData}, nil
+}
+
+// isGitCommitCommand checks if a command is a git commit.
+func isGitCommitCommand(command string) bool {
+	// Simple heuristic: command contains "git" and "commit"
+	return strings.Contains(command, "git") && strings.Contains(command, "commit")
+}
+
+// extractCommitMessage extracts the commit message from a git commit command.
+// It looks for -m flags or --message flags.
+func extractCommitMessage(command string) string {
+	// Look for -m "message" or --message "message"
+	re := regexp.MustCompile(`(?:-m|--message)\s+['"]([^'"]+)['"]`)
+	matches := re.FindStringSubmatch(command)
+	if len(matches) > 1 {
+		return matches[1]
+	}
+
+	// Fallback: return empty string
+	return ""
+}
+
+// extractSPECIDs extracts all SPEC-XXX patterns from a commit message.
+// Pattern: SPEC-[A-Z0-9]+-[0-9]+ (e.g., SPEC-STATUS-AUTO-001, SPEC-V3R2-CON-001)
+func extractSPECIDs(commitMsg string) []string {
+	// Pattern matches SPEC- followed by alphanumeric chars and dashes, ending with -digits
+	// Examples: SPEC-TEST-001, SPEC-STATUS-AUTO-001, SPEC-V3R2-CON-001
+	re := regexp.MustCompile(`SPEC-[A-Z0-9-]+-[0-9]+`)
+	matches := re.FindAllString(commitMsg, -1)
+
+	// Deduplicate while preserving order
+	seen := make(map[string]bool)
+	var result []string
+	for _, match := range matches {
+		if !seen[match] {
+			seen[match] = true
+			result = append(result, match)
+		}
+	}
+
+	return result
+}

--- a/internal/hook/spec_status_test.go
+++ b/internal/hook/spec_status_test.go
@@ -1,0 +1,258 @@
+package hook
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/modu-ai/moai-adk/internal/spec"
+)
+
+// TestSpecStatusHandler_PostToolUse tests the hook handler triggers on git commit
+func TestSpecStatusHandler_PostToolUse(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create test SPECs
+	for i := 1; i <= 2; i++ {
+		specDir := filepath.Join(tmpDir, ".moai", "specs", fmt.Sprintf("SPEC-HOOK-%03d", i))
+		if err := os.MkdirAll(specDir, 0755); err != nil {
+			t.Fatalf("failed to create spec dir: %v", err)
+		}
+
+		specPath := filepath.Join(specDir, "spec.md")
+		content := fmt.Sprintf("---\nstatus: draft\n---\n# Test SPEC %d\n", i)
+		if err := os.WriteFile(specPath, []byte(content), 0644); err != nil {
+			t.Fatalf("failed to write spec file: %v", err)
+		}
+	}
+
+	handler := NewSpecStatusHandler()
+
+	// Simulate PostToolUse event for git commit
+	commitMsg := "feat(SPEC-HOOK-001): Implement feature"
+	input := &HookInput{
+		SessionID:     "test-session",
+		ProjectDir:   tmpDir,
+		HookEventName: "PostToolUse",
+		Data:         buildHookData("Bash", "git commit -m '"+commitMsg+"'"),
+	}
+
+	ctx := context.Background()
+	output, err := handler.Handle(ctx, input)
+
+	if err != nil {
+		t.Fatalf("Handle() returned error: %v", err)
+	}
+
+	// Hook should always succeed (non-blocking)
+	if output == nil {
+		t.Fatal("expected non-nil output")
+	}
+
+	// Verify SPEC-HOOK-001 status was updated
+	specDir := filepath.Join(tmpDir, ".moai", "specs", "SPEC-HOOK-001")
+	status, err := spec.ParseStatus(specDir)
+	if err != nil {
+		t.Fatalf("failed to parse status: %v", err)
+	}
+
+	if status != "implemented" {
+		t.Errorf("expected status 'implemented', got %q", status)
+	}
+
+	// SPEC-HOOK-002 should remain unchanged (not in commit message)
+	specDir2 := filepath.Join(tmpDir, ".moai", "specs", "SPEC-HOOK-002")
+	status2, _ := spec.ParseStatus(specDir2)
+	if status2 == "implemented" {
+		t.Error("SPEC-HOOK-002 should not be updated")
+	}
+}
+
+// TestSpecStatusHandler_MultipleSPECs tests extracting multiple SPEC-IDs from commit
+func TestSpecStatusHandler_MultipleSPECs(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create test SPECs
+	specIDs := []string{"SPEC-MULTI-001", "SPEC-MULTI-002", "SPEC-MULTI-003"}
+	for _, specID := range specIDs {
+		specDir := filepath.Join(tmpDir, ".moai", "specs", specID)
+		if err := os.MkdirAll(specDir, 0755); err != nil {
+			t.Fatalf("failed to create spec dir: %v", err)
+		}
+
+		specPath := filepath.Join(specDir, "spec.md")
+		content := "---\nstatus: draft\n---\n"
+		if err := os.WriteFile(specPath, []byte(content), 0644); err != nil {
+			t.Fatalf("failed to write spec file: %v", err)
+		}
+	}
+
+	handler := NewSpecStatusHandler()
+
+	// Commit message with multiple SPEC-IDs
+	commitMsg := "feat(SPEC-MULTI-001, SPEC-MULTI-002): Implement features"
+	input := &HookInput{
+		SessionID:     "test-session",
+		ProjectDir:   tmpDir,
+		HookEventName: "PostToolUse",
+		Data:         buildHookData("Bash", "git commit -m '"+commitMsg+"'"),
+	}
+
+	ctx := context.Background()
+	_, err := handler.Handle(ctx, input)
+	if err != nil {
+		t.Fatalf("Handle() returned error: %v", err)
+	}
+
+	// Verify both SPECs were updated
+	for i := 1; i <= 2; i++ {
+		specDir := filepath.Join(tmpDir, ".moai", "specs", fmt.Sprintf("SPEC-MULTI-%03d", i))
+		status, err := spec.ParseStatus(specDir)
+		if err != nil {
+			t.Fatalf("failed to parse status: %v", err)
+		}
+
+		if status != "implemented" {
+			t.Errorf("SPEC-MULTI-%03d: expected status 'implemented', got %q", i, status)
+		}
+	}
+
+	// SPEC-MULTI-003 should remain draft
+	specDir3 := filepath.Join(tmpDir, ".moai", "specs", "SPEC-MULTI-003")
+	status3, _ := spec.ParseStatus(specDir3)
+	if status3 != "draft" {
+		t.Errorf("SPEC-MULTI-003: expected status 'draft', got %q", status3)
+	}
+}
+
+// TestSpecStatusHandler_NonGitCommand tests that non-git commands are ignored
+func TestSpecStatusHandler_NonGitCommand(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	specDir := filepath.Join(tmpDir, ".moai", "specs", "SPEC-NGIT-001")
+	if err := os.MkdirAll(specDir, 0755); err != nil {
+		t.Fatalf("failed to create spec dir: %v", err)
+	}
+
+	specPath := filepath.Join(specDir, "spec.md")
+	content := "---\nstatus: draft\n---\n"
+	if err := os.WriteFile(specPath, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write spec file: %v", err)
+	}
+
+	handler := NewSpecStatusHandler()
+
+	input := &HookInput{
+		SessionID:     "test-session",
+		ProjectDir:   tmpDir,
+		HookEventName: "PostToolUse",
+		Data:         buildHookData("Bash", "go test ./..."),
+	}
+
+	ctx := context.Background()
+	_, err := handler.Handle(ctx, input)
+	if err != nil {
+		t.Fatalf("Handle() returned error: %v", err)
+	}
+
+	// Status should remain unchanged
+	status, _ := spec.ParseStatus(specDir)
+	if status != "draft" {
+		t.Errorf("expected status 'draft', got %q", status)
+	}
+}
+
+// TestSpecStatusHandler_NoSpecsDirectory tests graceful handling when .moai/specs doesn't exist
+func TestSpecStatusHandler_NoSpecsDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	// Don't create .moai/specs
+
+	handler := NewSpecStatusHandler()
+
+	input := &HookInput{
+		SessionID:     "test-session",
+		ProjectDir:   tmpDir,
+		HookEventName: "PostToolUse",
+		Data:         buildHookData("Bash", "git commit -m 'feat(SPEC-NOEXIST-001): test'"),
+	}
+
+	ctx := context.Background()
+	output, err := handler.Handle(ctx, input)
+
+	// Should not error (non-blocking)
+	if err != nil {
+		t.Fatalf("Handle() should not error: %v", err)
+	}
+
+	if output == nil {
+		t.Fatal("expected non-nil output")
+	}
+}
+
+// TestExtractSPECIDs tests the SPEC-ID extraction pattern
+func TestExtractSPECIDs(t *testing.T) {
+	tests := []struct {
+		name     string
+		commitMsg string
+		expected []string
+	}{
+		{
+			name:     "single SPEC",
+			commitMsg: "feat(SPEC-TEST-001): Implement feature",
+			expected: []string{"SPEC-TEST-001"},
+		},
+		{
+			name:     "multiple SPECs",
+			commitMsg: "feat(SPEC-TEST-001, SPEC-AUTH-002): Implement features",
+			expected: []string{"SPEC-TEST-001", "SPEC-AUTH-002"},
+		},
+		{
+			name:     "SPEC with dash in name",
+			commitMsg: "feat(SPEC-V3R2-CON-001): Add constitution",
+			expected: []string{"SPEC-V3R2-CON-001"},
+		},
+		{
+			name:     "no SPEC patterns",
+			commitMsg: "feat: add some feature",
+			expected: nil,
+		},
+		{
+			name:     "conventional commit without SPEC",
+			commitMsg: "fix(auth): handle edge case",
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			found := extractSPECIDs(tt.commitMsg)
+
+			if len(found) != len(tt.expected) {
+				t.Errorf("expected %d SPEC-IDs, got %d", len(tt.expected), len(found))
+			}
+
+			for i, expected := range tt.expected {
+				if i >= len(found) {
+					t.Errorf("missing expected SPEC-ID: %s", expected)
+					continue
+				}
+				if found[i] != expected {
+					t.Errorf("expected %q at index %d, got %q", expected, i, found[i])
+				}
+			}
+		})
+	}
+}
+
+// buildHookData creates JSON data for HookInput.Data
+func buildHookData(toolName, command string) json.RawMessage {
+	data := map[string]any{
+		"tool_name": toolName,
+		"command":   command,
+	}
+	raw, _ := json.Marshal(data)
+	return raw
+}

--- a/internal/spec/status.go
+++ b/internal/spec/status.go
@@ -1,0 +1,323 @@
+package spec
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+)
+
+// ValidStatuses defines all allowed status values
+var ValidStatuses = []string{
+	"draft",
+	"planned",
+	"in-progress",
+	"implemented",
+	"completed",
+	"superseded",
+}
+
+// IsValidStatus checks if a status value is valid
+func IsValidStatus(status string) bool {
+	return slices.Contains(ValidStatuses, status)
+}
+
+// UpdateStatus updates the status field in a SPEC document
+// specDir is the directory containing spec.md (e.g., ".moai/specs/SPEC-XXX")
+func UpdateStatus(specDir, newStatus string) error {
+	// Validate status
+	if !IsValidStatus(newStatus) {
+		return fmt.Errorf("invalid status: %q", newStatus)
+	}
+
+	// Locate spec.md
+	specPath := filepath.Join(specDir, "spec.md")
+	if _, err := os.Stat(specPath); os.IsNotExist(err) {
+		return fmt.Errorf("spec.md not found in %s", specDir)
+	}
+
+	// Read the file
+	content, err := os.ReadFile(specPath)
+	if err != nil {
+		return fmt.Errorf("failed to read spec.md: %w", err)
+	}
+
+	// Detect format and update status
+	updated, err := updateStatusInContent(string(content), newStatus)
+	if err != nil {
+		return err
+	}
+
+	// Write back
+	if err := os.WriteFile(specPath, []byte(updated), 0644); err != nil {
+		return fmt.Errorf("failed to write spec.md: %w", err)
+	}
+
+	return nil
+}
+
+// ParseStatus extracts the current status from a SPEC document
+func ParseStatus(specDir string) (string, error) {
+	specPath := filepath.Join(specDir, "spec.md")
+	content, err := os.ReadFile(specPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read spec.md: %w", err)
+	}
+
+	return parseStatusFromContent(string(content))
+}
+
+// updateStatusInContent detects format and updates status field
+func updateStatusInContent(content, newStatus string) (string, error) {
+	lines := strings.Split(content, "\n")
+
+	// Read first 30 lines for format detection
+	sampleLines := lines
+	if len(sampleLines) > 30 {
+		sampleLines = sampleLines[:30]
+	}
+	sample := strings.Join(sampleLines, "\n")
+
+	// Format detection (order matters: check more specific patterns first)
+	if strings.Contains(sample, "| 상태 |") || strings.Contains(sample, "| Status |") {
+		// Table format (Format E) - check before YAML since tables may have ---
+		return updateStatusInTable(lines, newStatus)
+	}
+
+	if strings.Contains(sample, "- **Status**:") || strings.Contains(sample, "- **상태**:") {
+		// Markdown list format (Format D)
+		return updateStatusInMarkdownList(lines, newStatus)
+	}
+
+	if strings.Contains(sample, "---") {
+		// YAML frontmatter (Format A/B)
+		return updateStatusInYAML(lines, newStatus)
+	}
+
+	// No frontmatter - add YAML frontmatter (Format F)
+	return addYAMLFrontmatter(content, newStatus)
+}
+
+// updateStatusInYAML updates status in YAML frontmatter
+func updateStatusInYAML(lines []string, newStatus string) (string, error) {
+	inFrontmatter := false
+	statusLineIdx := -1
+	lastFrontmatterFieldIdx := -1
+
+	for i, line := range lines {
+		if strings.TrimSpace(line) == "---" {
+			if !inFrontmatter {
+				inFrontmatter = true
+			} else {
+				// End of frontmatter
+				break
+			}
+			continue
+		}
+
+		if inFrontmatter {
+			if strings.HasPrefix(line, "status:") {
+				statusLineIdx = i
+			}
+			// Track the last field line (before the closing ---)
+			if strings.Contains(line, ":") && !strings.HasPrefix(line, "#") {
+				lastFrontmatterFieldIdx = i
+			}
+		}
+	}
+
+	// Update existing status line
+	if statusLineIdx >= 0 {
+		lines[statusLineIdx] = fmt.Sprintf("status: %s", newStatus)
+		return strings.Join(lines, "\n"), nil
+	}
+
+	// Fallback: return original content on error
+	originalContent := strings.Join(lines, "\n")
+
+	// Add status field after last frontmatter field
+	if lastFrontmatterFieldIdx >= 0 {
+		// Insert after last field
+		newLines := make([]string, len(lines)+1)
+		copy(newLines, lines[:lastFrontmatterFieldIdx+1])
+		newLines[lastFrontmatterFieldIdx+1] = fmt.Sprintf("status: %s", newStatus)
+		copy(newLines[lastFrontmatterFieldIdx+2:], lines[lastFrontmatterFieldIdx+1:])
+		return strings.Join(newLines, "\n"), nil
+	}
+
+	// No fields found - add status at start of frontmatter
+	for i, line := range lines {
+		if strings.TrimSpace(line) == "---" {
+			newLines := make([]string, len(lines)+1)
+			copy(newLines, lines[:i+1])
+			newLines[i+1] = fmt.Sprintf("status: %s", newStatus)
+			copy(newLines[i+2:], lines[i+1:])
+			return strings.Join(newLines, "\n"), nil
+		}
+	}
+
+	return originalContent, fmt.Errorf("could not find YAML frontmatter")
+}
+
+// updateStatusInTable updates status in table format
+func updateStatusInTable(lines []string, newStatus string) (string, error) {
+	originalContent := strings.Join(lines, "\n")
+
+	for i, line := range lines {
+		// Match Korean table: | 상태 | value |
+		if strings.Contains(line, "| 상태 |") {
+			parts := strings.Split(line, "|")
+			if len(parts) >= 3 {
+				// Replace the value after "상태"
+				for j, part := range parts {
+					if strings.TrimSpace(part) == "상태" && j+1 < len(parts) {
+						parts[j+1] = " " + newStatus + " "
+						lines[i] = strings.Join(parts, "|")
+						return strings.Join(lines, "\n"), nil
+					}
+				}
+			}
+		}
+
+		// Match English table: | Status | value |
+		if strings.Contains(line, "| Status |") {
+			parts := strings.Split(line, "|")
+			if len(parts) >= 3 {
+				for j, part := range parts {
+					if strings.TrimSpace(part) == "Status" && j+1 < len(parts) {
+						parts[j+1] = " " + newStatus + " "
+						lines[i] = strings.Join(parts, "|")
+						return strings.Join(lines, "\n"), nil
+					}
+				}
+			}
+		}
+	}
+
+	return originalContent, fmt.Errorf("could not find status in table")
+}
+
+// updateStatusInMarkdownList updates status in Markdown list format
+func updateStatusInMarkdownList(lines []string, newStatus string) (string, error) {
+	originalContent := strings.Join(lines, "\n")
+
+	for i, line := range lines {
+		if strings.HasPrefix(line, "- **Status**:") || strings.HasPrefix(line, "- **상태**:") {
+			lines[i] = strings.TrimRight(line, "\r")
+			// Replace the value after the colon
+			parts := strings.SplitN(line, ":", 2)
+			if len(parts) == 2 {
+				lines[i] = fmt.Sprintf("%s: %s", parts[0], newStatus)
+			}
+			return strings.Join(lines, "\n"), nil
+		}
+	}
+
+	return originalContent, fmt.Errorf("could not find status in Markdown list")
+}
+
+// addYAMLFrontmatter adds YAML frontmatter with status field
+func addYAMLFrontmatter(content, newStatus string) (string, error) {
+	frontmatter := fmt.Sprintf("---\nstatus: %s\n---\n", newStatus)
+	return frontmatter + content, nil
+}
+
+// parseStatusFromContent extracts status from content
+func parseStatusFromContent(content string) (string, error) {
+	lines := strings.Split(content, "\n")
+
+	// Read first 30 lines
+	sampleLines := lines
+	if len(sampleLines) > 30 {
+		sampleLines = sampleLines[:30]
+	}
+	sample := strings.Join(sampleLines, "\n")
+
+	// Try table format first (most specific pattern)
+	if strings.Contains(sample, "| 상태 |") || strings.Contains(sample, "| Status |") {
+		if status, found := parseStatusFromTable(lines); found {
+			return status, nil
+		}
+	}
+
+	// Try Markdown list format
+	if strings.Contains(sample, "- **Status**:") || strings.Contains(sample, "- **상태**:") {
+		if status, found := parseStatusFromMarkdownList(lines); found {
+			return status, nil
+		}
+	}
+
+	// Try YAML frontmatter
+	if strings.Contains(sample, "---") {
+		if status, found := parseStatusFromYAML(lines); found {
+			return status, nil
+		}
+	}
+
+	return "", fmt.Errorf("could not parse status from spec.md")
+}
+
+// parseStatusFromYAML extracts status from YAML frontmatter
+func parseStatusFromYAML(lines []string) (string, bool) {
+	inFrontmatter := false
+
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "---" {
+			if !inFrontmatter {
+				inFrontmatter = true
+			} else {
+				break
+			}
+			continue
+		}
+
+		if inFrontmatter && strings.HasPrefix(line, "status:") {
+			parts := strings.SplitN(line, ":", 2)
+			if len(parts) == 2 {
+				return strings.TrimSpace(parts[1]), true
+			}
+		}
+	}
+
+	return "", false
+}
+
+// parseStatusFromTable extracts status from table format
+func parseStatusFromTable(lines []string) (string, bool) {
+	reStatus := regexp.MustCompile(`\|\s*Status\s*\|\s*([^\||]+)\s*\|`)
+	reSangtae := regexp.MustCompile(`\|\s*상태\s*\|\s*([^\||]+)\s*\|`)
+
+	for _, line := range lines {
+		// Try English first
+		if matches := reStatus.FindStringSubmatch(line); len(matches) > 1 {
+			return strings.TrimSpace(matches[1]), true
+		}
+
+		// Try Korean
+		if matches := reSangtae.FindStringSubmatch(line); len(matches) > 1 {
+			return strings.TrimSpace(matches[1]), true
+		}
+	}
+
+	return "", false
+}
+
+// parseStatusFromMarkdownList extracts status from Markdown list format
+func parseStatusFromMarkdownList(lines []string) (string, bool) {
+	reStatus := regexp.MustCompile(`-\s*\*\*Status\*\*:\s*(.+)`)
+	reSangtae := regexp.MustCompile(`-\s*\*\*상태\*\*:\s*(.+)`)
+
+	for _, line := range lines {
+		if matches := reStatus.FindStringSubmatch(line); len(matches) > 1 {
+			return strings.TrimSpace(matches[1]), true
+		}
+
+		if matches := reSangtae.FindStringSubmatch(line); len(matches) > 1 {
+			return strings.TrimSpace(matches[1]), true
+		}
+	}
+
+	return "", false
+}

--- a/internal/spec/status_test.go
+++ b/internal/spec/status_test.go
@@ -1,0 +1,483 @@
+package spec
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestValidStatuses verifies that all valid status values are defined
+func TestValidStatuses(t *testing.T) {
+	validStatuses := []string{
+		"draft",
+		"planned",
+		"in-progress",
+		"implemented",
+		"completed",
+		"superseded",
+	}
+
+	for _, status := range validStatuses {
+		if !IsValidStatus(status) {
+			t.Errorf("IsValidStatus(%q) = false, want true", status)
+		}
+	}
+
+	// Test invalid status
+	if IsValidStatus("invalid") {
+		t.Error("IsValidStatus(\"invalid\") = true, want false")
+	}
+}
+
+// TestUpdateStatus_YAMLFormat tests updating status in YAML frontmatter (Format A/B)
+func TestUpdateStatus_YAMLFormat(t *testing.T) {
+	tmpDir := t.TempDir()
+	specDir := filepath.Join(tmpDir, ".moai", "specs", "SPEC-TEST-001")
+	if err := os.MkdirAll(specDir, 0755); err != nil {
+		t.Fatalf("failed to create spec dir: %v", err)
+	}
+
+	specPath := filepath.Join(specDir, "spec.md")
+	originalContent := `---
+id: SPEC-TEST-001
+version: "1.0.0"
+status: draft
+created: "2026-04-27"
+---
+
+# Test SPEC
+
+This is a test SPEC document.
+`
+	if err := os.WriteFile(specPath, []byte(originalContent), 0644); err != nil {
+		t.Fatalf("failed to write spec file: %v", err)
+	}
+
+	// Test updating status
+	if err := UpdateStatus(specDir, "completed"); err != nil {
+		t.Fatalf("UpdateStatus failed: %v", err)
+	}
+
+	// Verify the update
+	updatedContent, err := os.ReadFile(specPath)
+	if err != nil {
+		t.Fatalf("failed to read updated spec file: %v", err)
+	}
+
+	content := string(updatedContent)
+	if !strings.Contains(content, "status: completed") {
+		t.Errorf("status not updated to completed, got:\n%s", content)
+	}
+
+	// Verify other content is preserved
+	if !strings.Contains(content, "id: SPEC-TEST-001") {
+		t.Error("id field not preserved")
+	}
+	if !strings.Contains(content, "# Test SPEC") {
+		t.Error("content after frontmatter not preserved")
+	}
+}
+
+// TestUpdateStatus_YAMLNoStatus tests adding status to YAML frontmatter when missing
+func TestUpdateStatus_YAMLNoStatus(t *testing.T) {
+	tmpDir := t.TempDir()
+	specDir := filepath.Join(tmpDir, ".moai", "specs", "SPEC-TEST-002")
+	if err := os.MkdirAll(specDir, 0755); err != nil {
+		t.Fatalf("failed to create spec dir: %v", err)
+	}
+
+	specPath := filepath.Join(specDir, "spec.md")
+	originalContent := `---
+id: SPEC-TEST-002
+version: "1.0.0"
+created: "2026-04-27"
+---
+
+# Test SPEC
+`
+	if err := os.WriteFile(specPath, []byte(originalContent), 0644); err != nil {
+		t.Fatalf("failed to write spec file: %v", err)
+	}
+
+	if err := UpdateStatus(specDir, "planned"); err != nil {
+		t.Fatalf("UpdateStatus failed: %v", err)
+	}
+
+	updatedContent, err := os.ReadFile(specPath)
+	if err != nil {
+		t.Fatalf("failed to read updated spec file: %v", err)
+	}
+
+	content := string(updatedContent)
+	if !strings.Contains(content, "status: planned") {
+		t.Errorf("status not added, got:\n%s", content)
+	}
+}
+
+// TestUpdateStatus_MarkdownListFormat tests updating status in Markdown list format (Format D)
+func TestUpdateStatus_MarkdownListFormat(t *testing.T) {
+	tmpDir := t.TempDir()
+	specDir := filepath.Join(tmpDir, ".moai", "specs", "SPEC-TEST-003")
+	if err := os.MkdirAll(specDir, 0755); err != nil {
+		t.Fatalf("failed to create spec dir: %v", err)
+	}
+
+	specPath := filepath.Join(specDir, "spec.md")
+	originalContent := `# Test SPEC
+
+- **Status**: draft
+- **Author**: GOOS
+- **Priority**: P1
+`
+	if err := os.WriteFile(specPath, []byte(originalContent), 0644); err != nil {
+		t.Fatalf("failed to write spec file: %v", err)
+	}
+
+	if err := UpdateStatus(specDir, "implemented"); err != nil {
+		t.Fatalf("UpdateStatus failed: %v", err)
+	}
+
+	updatedContent, err := os.ReadFile(specPath)
+	if err != nil {
+		t.Fatalf("failed to read updated spec file: %v", err)
+	}
+
+	content := string(updatedContent)
+	if !strings.Contains(content, "- **Status**: implemented") {
+		t.Errorf("status not updated in Markdown list, got:\n%s", content)
+	}
+	if !strings.Contains(content, "- **Author**: GOOS") {
+		t.Error("other list items not preserved")
+	}
+}
+
+// TestUpdateStatus_TableFormatKorean tests updating status in Korean table format (Format E)
+func TestUpdateStatus_TableFormatKorean(t *testing.T) {
+	tmpDir := t.TempDir()
+	specDir := filepath.Join(tmpDir, ".moai", "specs", "SPEC-TEST-004")
+	if err := os.MkdirAll(specDir, 0755); err != nil {
+		t.Fatalf("failed to create spec dir: %v", err)
+	}
+
+	specPath := filepath.Join(specDir, "spec.md")
+	originalContent := `# Test SPEC
+
+| 항목 | 값 |
+|------|-----|
+| 상태 | draft |
+| 우선순위 | P1 |
+`
+	if err := os.WriteFile(specPath, []byte(originalContent), 0644); err != nil {
+		t.Fatalf("failed to write spec file: %v", err)
+	}
+
+	if err := UpdateStatus(specDir, "completed"); err != nil {
+		t.Fatalf("UpdateStatus failed: %v", err)
+	}
+
+	updatedContent, err := os.ReadFile(specPath)
+	if err != nil {
+		t.Fatalf("failed to read updated spec file: %v", err)
+	}
+
+	content := string(updatedContent)
+	if !strings.Contains(content, "| 상태 | completed |") {
+		t.Errorf("status not updated in Korean table, got:\n%s", content)
+	}
+}
+
+// TestUpdateStatus_TableFormatEnglish tests updating status in English table format (Format E)
+func TestUpdateStatus_TableFormatEnglish(t *testing.T) {
+	tmpDir := t.TempDir()
+	specDir := filepath.Join(tmpDir, ".moai", "specs", "SPEC-TEST-005")
+	if err := os.MkdirAll(specDir, 0755); err != nil {
+		t.Fatalf("failed to create spec dir: %v", err)
+	}
+
+	specPath := filepath.Join(specDir, "spec.md")
+	originalContent := `# Test SPEC
+
+| Field | Value |
+|-------|-------|
+| Status | draft |
+| Priority | P1 |
+`
+	if err := os.WriteFile(specPath, []byte(originalContent), 0644); err != nil {
+		t.Fatalf("failed to write spec file: %v", err)
+	}
+
+	if err := UpdateStatus(specDir, "in-progress"); err != nil {
+		t.Fatalf("UpdateStatus failed: %v", err)
+	}
+
+	updatedContent, err := os.ReadFile(specPath)
+	if err != nil {
+		t.Fatalf("failed to read updated spec file: %v", err)
+	}
+
+	content := string(updatedContent)
+	if !strings.Contains(content, "| Status | in-progress |") {
+		t.Errorf("status not updated in English table, got:\n%s", content)
+	}
+}
+
+// TestUpdateStatus_NoFrontmatter tests adding YAML frontmatter when none exists (Format F)
+func TestUpdateStatus_NoFrontmatter(t *testing.T) {
+	tmpDir := t.TempDir()
+	specDir := filepath.Join(tmpDir, ".moai", "specs", "SPEC-TEST-006")
+	if err := os.MkdirAll(specDir, 0755); err != nil {
+		t.Fatalf("failed to create spec dir: %v", err)
+	}
+
+	specPath := filepath.Join(specDir, "spec.md")
+	originalContent := `# Test SPEC
+
+This SPEC has no frontmatter.
+`
+	if err := os.WriteFile(specPath, []byte(originalContent), 0644); err != nil {
+		t.Fatalf("failed to write spec file: %v", err)
+	}
+
+	if err := UpdateStatus(specDir, "draft"); err != nil {
+		t.Fatalf("UpdateStatus failed: %v", err)
+	}
+
+	updatedContent, err := os.ReadFile(specPath)
+	if err != nil {
+		t.Fatalf("failed to read updated spec file: %v", err)
+	}
+
+	content := string(updatedContent)
+	if !strings.Contains(content, "---") {
+		t.Error("YAML frontmatter delimiters not added")
+	}
+	if !strings.Contains(content, "status: draft") {
+		t.Error("status not added to new frontmatter")
+	}
+	if !strings.Contains(content, "# Test SPEC") {
+		t.Error("original content not preserved after frontmatter")
+	}
+}
+
+// TestUpdateStatus_SpecNotFound tests error handling when spec.md doesn't exist
+func TestUpdateStatus_SpecNotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	specDir := filepath.Join(tmpDir, ".moai", "specs", "SPEC-NONEXISTENT")
+	// Don't create the file
+
+	err := UpdateStatus(specDir, "completed")
+	if err == nil {
+		t.Error("UpdateStatus should return error when spec.md not found")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error message should mention 'not found', got: %v", err)
+	}
+}
+
+// TestUpdateStatus_InvalidStatus tests error handling for invalid status values
+func TestUpdateStatus_InvalidStatus(t *testing.T) {
+	tmpDir := t.TempDir()
+	specDir := filepath.Join(tmpDir, ".moai", "specs", "SPEC-TEST-007")
+	if err := os.MkdirAll(specDir, 0755); err != nil {
+		t.Fatalf("failed to create spec dir: %v", err)
+	}
+
+	specPath := filepath.Join(specDir, "spec.md")
+	originalContent := `---
+id: SPEC-TEST-007
+status: draft
+---
+`
+	if err := os.WriteFile(specPath, []byte(originalContent), 0644); err != nil {
+		t.Fatalf("failed to write spec file: %v", err)
+	}
+
+	err := UpdateStatus(specDir, "invalid-status")
+	if err == nil {
+		t.Error("UpdateStatus should return error for invalid status")
+	}
+}
+
+// TestParseStatus_YAMLFormat tests reading status from YAML frontmatter
+func TestParseStatus_YAMLFormat(t *testing.T) {
+	tmpDir := t.TempDir()
+	specDir := filepath.Join(tmpDir, ".moai", "specs", "SPEC-TEST-008")
+	if err := os.MkdirAll(specDir, 0755); err != nil {
+		t.Fatalf("failed to create spec dir: %v", err)
+	}
+
+	specPath := filepath.Join(specDir, "spec.md")
+	content := `---
+id: SPEC-TEST-008
+status: implemented
+---
+# Test
+`
+	if err := os.WriteFile(specPath, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write spec file: %v", err)
+	}
+
+	status, err := ParseStatus(specDir)
+	if err != nil {
+		t.Fatalf("ParseStatus failed: %v", err)
+	}
+	if status != "implemented" {
+		t.Errorf("ParseStatus = %q, want %q", status, "implemented")
+	}
+}
+
+// TestParseStatus_MarkdownListFormat tests reading status from Markdown list
+func TestParseStatus_MarkdownListFormat(t *testing.T) {
+	tmpDir := t.TempDir()
+	specDir := filepath.Join(tmpDir, ".moai", "specs", "SPEC-TEST-009")
+	if err := os.MkdirAll(specDir, 0755); err != nil {
+		t.Fatalf("failed to create spec dir: %v", err)
+	}
+
+	specPath := filepath.Join(specDir, "spec.md")
+	content := `# Test
+
+- **Status**: completed
+- **Author**: GOOS
+`
+	if err := os.WriteFile(specPath, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write spec file: %v", err)
+	}
+
+	status, err := ParseStatus(specDir)
+	if err != nil {
+		t.Fatalf("ParseStatus failed: %v", err)
+	}
+	if status != "completed" {
+		t.Errorf("ParseStatus = %q, want %q", status, "completed")
+	}
+}
+
+// TestParseStatus_TableFormat tests reading status from table format
+func TestParseStatus_TableFormat(t *testing.T) {
+	tmpDir := t.TempDir()
+	specDir := filepath.Join(tmpDir, ".moai", "specs", "SPEC-TEST-010")
+	if err := os.MkdirAll(specDir, 0755); err != nil {
+		t.Fatalf("failed to create spec dir: %v", err)
+	}
+
+	specPath := filepath.Join(specDir, "spec.md")
+	content := `# Test
+
+| 상태 | draft |
+| 우선순위 | P1 |
+`
+	if err := os.WriteFile(specPath, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write spec file: %v", err)
+	}
+
+	status, err := ParseStatus(specDir)
+	if err != nil {
+		t.Fatalf("ParseStatus failed: %v", err)
+	}
+	if status != "draft" {
+		t.Errorf("ParseStatus = %q, want %q", status, "draft")
+	}
+}
+
+// TestUpdateStatus_EmptyFrontmatter tests adding status to empty YAML frontmatter
+func TestUpdateStatus_EmptyFrontmatter(t *testing.T) {
+	tmpDir := t.TempDir()
+	specDir := filepath.Join(tmpDir, ".moai", "specs", "SPEC-TEST-011")
+	if err := os.MkdirAll(specDir, 0755); err != nil {
+		t.Fatalf("failed to create spec dir: %v", err)
+	}
+
+	specPath := filepath.Join(specDir, "spec.md")
+	content := `---
+---
+# No fields
+`
+	if err := os.WriteFile(specPath, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write spec file: %v", err)
+	}
+
+	if err := UpdateStatus(specDir, "draft"); err != nil {
+		t.Fatalf("UpdateStatus failed: %v", err)
+	}
+
+	updated, _ := os.ReadFile(specPath)
+	if !strings.Contains(string(updated), "status: draft") {
+		t.Errorf("status not added to empty frontmatter, got:\n%s", string(updated))
+	}
+}
+
+// TestUpdateStatus_KoreanMarkdownList tests updating status in Korean Markdown list
+func TestUpdateStatus_KoreanMarkdownList(t *testing.T) {
+	tmpDir := t.TempDir()
+	specDir := filepath.Join(tmpDir, ".moai", "specs", "SPEC-TEST-012")
+	if err := os.MkdirAll(specDir, 0755); err != nil {
+		t.Fatalf("failed to create spec dir: %v", err)
+	}
+
+	specPath := filepath.Join(specDir, "spec.md")
+	content := `# Test
+
+- **상태**: draft
+- **작성자**: GOOS
+`
+	if err := os.WriteFile(specPath, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write spec file: %v", err)
+	}
+
+	if err := UpdateStatus(specDir, "planned"); err != nil {
+		t.Fatalf("UpdateStatus failed: %v", err)
+	}
+
+	updated, _ := os.ReadFile(specPath)
+	if !strings.Contains(string(updated), "- **상태**: planned") {
+		t.Errorf("Korean markdown list status not updated, got:\n%s", string(updated))
+	}
+}
+
+// TestParseStatus_NoStatus tests ParseStatus when no status field exists
+func TestParseStatus_NoStatus(t *testing.T) {
+	tmpDir := t.TempDir()
+	specDir := filepath.Join(tmpDir, ".moai", "specs", "SPEC-TEST-013")
+	if err := os.MkdirAll(specDir, 0755); err != nil {
+		t.Fatalf("failed to create spec dir: %v", err)
+	}
+
+	specPath := filepath.Join(specDir, "spec.md")
+	content := `# Plain document
+
+No status anywhere.
+`
+	if err := os.WriteFile(specPath, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write spec file: %v", err)
+	}
+
+	_, err := ParseStatus(specDir)
+	if err == nil {
+		t.Error("ParseStatus should return error when no status found")
+	}
+}
+
+// TestSpecIDPattern tests the SPEC-ID extraction regex pattern
+func TestSpecIDPattern(t *testing.T) {
+	// This test documents the expected pattern
+	// Pattern: SPEC-[A-Z0-9]+-[0-9]+
+	validPatterns := []string{
+		"SPEC-STATUS-AUTO-001",
+		"SPEC-TEST-123",
+		"SPEC-AUTH-001",
+		"SPEC-V3R2-CON-001",
+	}
+
+	// The actual extraction will be tested in the hook handler tests
+	// This just documents the expected pattern format
+	for _, pattern := range validPatterns {
+		if len(pattern) < 5 {
+			t.Errorf("pattern %q too short", pattern)
+		}
+		if !strings.HasPrefix(pattern, "SPEC-") {
+			t.Errorf("pattern %q doesn't start with SPEC-", pattern)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- **REQ-1**: SPEC status updater library supporting 6 format variants (YAML frontmatter, Markdown list, Korean/English tables, YAML prepend)
- **REQ-2**: `moai spec status` CLI command with `--dry-run`, `--list`, and `--sync-git` flags
- **REQ-3**: PostToolUse hook auto-detecting git commits with SPEC-ID patterns and updating status to `implemented`
- **REQ-4**: sync.md Step 2.4 integration — calls `moai spec status <SPEC-ID> completed` after sync
- **REQ-5**: `moai spec status --sync-git --yes` batch command cross-referencing git log on main

## Test plan

- [x] 16 unit tests for spec status library (89.1% coverage)
- [x] 5 CLI command tests (dry-run, list, update, not-found)
- [x] 5 hook handler tests (PostToolUse, multiple SPECs, non-git, extraction)
- [x] `go vet ./internal/spec/... ./internal/hook/... ./internal/cli/...` passes
- [x] All new tests pass, 4 pre-existing failures (template parser TTY) unrelated

🤖 MoAI <email@mo.ai.kr>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New CLI for viewing/updating SPEC status (list, dry-run, interactive/batch confirm, sync options) and a non-blocking git-hook that updates SPECs from commit messages.
  * Sync integration marks synced SPECs completed.

* **Documentation**
  * New spec, progress, tasks, and workflow guidance for automated SPEC status handling.

* **Tests**
  * Added unit and end-to-end tests for status parsing, CLI behavior, and hook processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->