### PR TITLE
fix(glm): MOAI_STATUSLINE_CONTEXT_SIZE를 GLM 모델별로 자동 주입 (#742)

### DIFF
--- a/internal/cli/glm.go
+++ b/internal/cli/glm.go
@@ -7,10 +7,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/modu-ai/moai-adk/internal/config"
 	"github.com/modu-ai/moai-adk/internal/defs"
+	"github.com/modu-ai/moai-adk/internal/statusline"
 	"github.com/modu-ai/moai-adk/internal/tmux"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -346,6 +348,11 @@ func enableTeamMode(cmd *cobra.Command, isHybrid bool) error {
 }
 
 // injectTmuxSessionEnv sets GLM environment variables at the tmux session level.
+//
+// Issue #742: Pre-computes MOAI_STATUSLINE_CONTEXT_SIZE from the High slot
+// (Opus equivalent) so the Claude Code statusline reflects the real GLM model
+// context window (128K/200K/etc.) instead of the Claude slot's nominal size
+// (1M for the Opus slot).
 func injectTmuxSessionEnv(glmConfig *GLMConfigFromYAML, apiKey string) error {
 	if isTestEnvironment() {
 		return nil
@@ -365,6 +372,12 @@ func injectTmuxSessionEnv(glmConfig *GLMConfigFromYAML, apiKey string) error {
 		"DISABLE_PROMPT_CACHING":                    "1",
 		"API_TIMEOUT_MS":                            "3000000",
 		"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+	}
+
+	// Issue #742: Map the High slot model to its real context window so
+	// statusline gauge reflects GLM limits, not Claude's Opus slot 1M nominal.
+	if size := statusline.ResolveGLMContextWindow(glmConfig.Models.High); size > 0 {
+		vars[config.EnvStatuslineContextSize] = strconv.Itoa(size)
 	}
 
 	mgr := tmux.NewSessionManager()
@@ -398,6 +411,8 @@ func clearTmuxSessionEnv() error {
 		"DISABLE_PROMPT_CACHING",
 		"API_TIMEOUT_MS",
 		"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC",
+		// Issue #742: clear GLM context-size hint when leaving GLM mode
+		config.EnvStatuslineContextSize,
 	}
 
 	mgr := tmux.NewSessionManager()
@@ -533,6 +548,14 @@ func injectGLMEnvForTeam(settingsPath string, glmConfig *GLMConfigFromYAML, apiK
 	settings.Env["DISABLE_PROMPT_CACHING"] = "1"
 	settings.Env["API_TIMEOUT_MS"] = "3000000"
 	settings.Env["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] = "1"
+	// Issue #742: pre-compute statusline context size from the High slot
+	// (Opus equivalent) so SessionStart hook propagates it via tmux env.
+	if size := statusline.ResolveGLMContextWindow(glmConfig.Models.High); size > 0 {
+		settings.Env[config.EnvStatuslineContextSize] = strconv.Itoa(size)
+	} else {
+		// Clean up stale value from a prior session that resolved a known model.
+		delete(settings.Env, config.EnvStatuslineContextSize)
+	}
 
 	// Force tmux display mode: GLM team mode uses tmux for env var inheritance.
 	// "auto" can fall back to inline mode, causing teammates to lose GLM env vars (#468).

--- a/internal/cli/glm_test.go
+++ b/internal/cli/glm_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -450,5 +451,153 @@ func TestMaskAPIKey(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("maskAPIKey(%q) = %q, want %q", tt.key, got, tt.want)
 		}
+	}
+}
+
+// TestInjectGLMEnvForTeam_StatuslineContextSize verifies Issue #742:
+// when the GLM High slot maps to a known context window, the function persists
+// MOAI_STATUSLINE_CONTEXT_SIZE in settings.local.json so the SessionStart hook
+// can later propagate it through tmux env to the statusline.
+func TestInjectGLMEnvForTeam_StatuslineContextSize(t *testing.T) {
+	cases := []struct {
+		name      string
+		highModel string
+		wantSize  string // "" means key should be absent
+	}{
+		{"glm-5.1 maps to 200K", "glm-5.1", "200000"},
+		{"glm-4.6 maps to 128K", "glm-4.6", "128000"},
+		{"glm-4.5-air maps to 128K (longest match)", "glm-4.5-air", "128000"},
+		{"unknown model omits the hint", "totally-unknown-model", ""},
+		{"claude prefix omits the hint (not GLM)", "claude-opus-4.7", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			claudeDir := filepath.Join(tmpDir, ".claude")
+			if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			settingsPath := filepath.Join(claudeDir, "settings.local.json")
+
+			glmCfg := &GLMConfigFromYAML{
+				BaseURL: "https://api.z.ai",
+				EnvVar:  "TEST_KEY",
+			}
+			glmCfg.Models.High = tc.highModel
+			glmCfg.Models.Medium = "ignored"
+			glmCfg.Models.Low = "ignored"
+
+			if err := injectGLMEnvForTeam(settingsPath, glmCfg, "test-api-key"); err != nil {
+				t.Fatalf("injectGLMEnvForTeam error: %v", err)
+			}
+
+			data, err := os.ReadFile(settingsPath)
+			if err != nil {
+				t.Fatalf("read settings: %v", err)
+			}
+			var settings SettingsLocal
+			if err := json.Unmarshal(data, &settings); err != nil {
+				t.Fatalf("parse settings: %v", err)
+			}
+
+			got, present := settings.Env["MOAI_STATUSLINE_CONTEXT_SIZE"]
+			if tc.wantSize == "" {
+				if present {
+					t.Errorf("MOAI_STATUSLINE_CONTEXT_SIZE present=%q for unknown model %q (expected absent)",
+						got, tc.highModel)
+				}
+				return
+			}
+			if !present {
+				t.Errorf("MOAI_STATUSLINE_CONTEXT_SIZE absent for known model %q (expected %q)",
+					tc.highModel, tc.wantSize)
+			}
+			if got != tc.wantSize {
+				t.Errorf("MOAI_STATUSLINE_CONTEXT_SIZE = %q, want %q", got, tc.wantSize)
+			}
+		})
+	}
+}
+
+// TestInjectGLMEnvForTeam_StatuslineContextSize_StaleCleanup verifies that
+// switching the High slot from a known model to an unknown model removes the
+// previously injected MOAI_STATUSLINE_CONTEXT_SIZE so the stale value is not
+// propagated to a different GLM model.
+func TestInjectGLMEnvForTeam_StatuslineContextSize_StaleCleanup(t *testing.T) {
+	tmpDir := t.TempDir()
+	claudeDir := filepath.Join(tmpDir, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	settingsPath := filepath.Join(claudeDir, "settings.local.json")
+
+	cfg := &GLMConfigFromYAML{BaseURL: "https://api.z.ai", EnvVar: "TEST_KEY"}
+
+	// First call: glm-5.1 -> 200000 written.
+	cfg.Models.High = "glm-5.1"
+	cfg.Models.Medium = "ignored"
+	cfg.Models.Low = "ignored"
+	if err := injectGLMEnvForTeam(settingsPath, cfg, "key1"); err != nil {
+		t.Fatalf("first inject: %v", err)
+	}
+
+	// Second call with an unknown model: stale 200000 must be cleared.
+	cfg.Models.High = "unknown-future-model"
+	if err := injectGLMEnvForTeam(settingsPath, cfg, "key2"); err != nil {
+		t.Fatalf("second inject: %v", err)
+	}
+
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+	var settings SettingsLocal
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("parse settings: %v", err)
+	}
+	if v, present := settings.Env["MOAI_STATUSLINE_CONTEXT_SIZE"]; present {
+		t.Errorf("stale MOAI_STATUSLINE_CONTEXT_SIZE = %q after switch to unknown model (expected absent)", v)
+	}
+}
+
+// TestRemoveGLMEnv_DropsStatuslineContextSize verifies that switching from GLM
+// mode back to Claude mode (moai cc) clears the GLM-specific context size hint.
+func TestRemoveGLMEnv_DropsStatuslineContextSize(t *testing.T) {
+	tmpDir := t.TempDir()
+	claudeDir := filepath.Join(tmpDir, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	settingsPath := filepath.Join(claudeDir, "settings.local.json")
+
+	// Seed settings.local.json with a GLM payload that includes the hint.
+	seed := map[string]any{
+		"env": map[string]string{
+			"ANTHROPIC_AUTH_TOKEN":         "glm-key",
+			"ANTHROPIC_BASE_URL":           "https://api.z.ai",
+			"ANTHROPIC_DEFAULT_OPUS_MODEL": "glm-5.1",
+			"MOAI_STATUSLINE_CONTEXT_SIZE": "200000",
+		},
+	}
+	seedData, _ := json.MarshalIndent(seed, "", "  ")
+	if err := os.WriteFile(settingsPath, seedData, 0o600); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+
+	if err := removeGLMEnv(settingsPath); err != nil {
+		t.Fatalf("removeGLMEnv error: %v", err)
+	}
+
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("read after remove: %v", err)
+	}
+	var settings SettingsLocal
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("parse after remove: %v", err)
+	}
+	if v, present := settings.Env["MOAI_STATUSLINE_CONTEXT_SIZE"]; present {
+		t.Errorf("removeGLMEnv left MOAI_STATUSLINE_CONTEXT_SIZE = %q (expected absent)", v)
 	}
 }

--- a/internal/cli/launcher.go
+++ b/internal/cli/launcher.go
@@ -243,6 +243,9 @@ func removeGLMEnv(settingsPath string) error {
 		delete(settings.Env, "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC")
 		// Remove teammate display env var override (CG/GLM set this)
 		delete(settings.Env, "CLAUDE_CODE_TEAMMATE_DISPLAY")
+		// Issue #742: drop GLM context-size hint when leaving GLM mode so the
+		// statusline reverts to the Claude slot's nominal size.
+		delete(settings.Env, "MOAI_STATUSLINE_CONTEXT_SIZE")
 
 		if len(settings.Env) == 0 {
 			settings.Env = nil

--- a/internal/hook/glm_tmux.go
+++ b/internal/hook/glm_tmux.go
@@ -13,6 +13,10 @@ import (
 
 // glmTmuxKeys is the list of GLM-related environment variables to inject into the tmux session.
 // New tmux panes (teammates) must have these variables set at the session level to use the GLM API.
+//
+// Issue #742: MOAI_STATUSLINE_CONTEXT_SIZE is included so the Claude Code
+// statusline reflects the real GLM model context window (128K/200K/etc.)
+// instead of the Claude slot's nominal size (1M for the Opus slot).
 var glmTmuxKeys = []string{
 	"ANTHROPIC_AUTH_TOKEN",
 	"ANTHROPIC_BASE_URL",
@@ -23,6 +27,7 @@ var glmTmuxKeys = []string{
 	"DISABLE_PROMPT_CACHING",
 	"API_TIMEOUT_MS",
 	"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC",
+	"MOAI_STATUSLINE_CONTEXT_SIZE",
 }
 
 // buildGLMTmuxEnvVars extracts only GLM-related variables from the env map in settings.local.json.

--- a/internal/statusline/memory.go
+++ b/internal/statusline/memory.go
@@ -97,6 +97,33 @@ func matchContextWindow(model string, table map[string]int) int {
 	return matchedSize
 }
 
+// ResolveGLMContextWindow returns the context window size in tokens for the
+// given GLM model name, or 0 if no match is found. The lookup honors
+// project-level overrides in `.moai/config/sections/llm.yaml`
+// (`glm.context_windows` map) before falling back to the built-in
+// `glmContextWindows` table.
+//
+// This is the single source of truth used by `moai cg` / `moai glm` to
+// pre-compute MOAI_STATUSLINE_CONTEXT_SIZE for tmux session env injection
+// (Issue #742). It is exported so callers outside the statusline package can
+// resolve a model's context window without reimplementing the lookup priority.
+func ResolveGLMContextWindow(model string) int {
+	val := strings.ToLower(strings.TrimSpace(model))
+	if val == "" || strings.HasPrefix(val, "claude") {
+		return 0
+	}
+
+	// Priority 1: project-level llm.yaml overrides.
+	if userTable := readLLMYAMLContextWindows(); len(userTable) > 0 {
+		if size := matchContextWindow(val, userTable); size > 0 {
+			return size
+		}
+	}
+
+	// Priority 2: built-in glmContextWindows table.
+	return matchContextWindow(val, glmContextWindows)
+}
+
 // resolveContextWindowOverride returns a non-zero context window override when
 // the user is running through GLM (or another non-Claude provider) so that the
 // memory gauge reflects the actual provider limit rather than the Claude slot's

--- a/internal/statusline/memory_test.go
+++ b/internal/statusline/memory_test.go
@@ -451,3 +451,67 @@ func TestCollectMemory_EnvOverridesLLMYAML(t *testing.T) {
 		t.Errorf("TokenBudget = %d, want %d (env wins over llm.yaml)", got.TokenBudget, wantBudget)
 	}
 }
+
+// TestResolveGLMContextWindow verifies the public helper used by
+// internal/cli/glm.go (Issue #742) to pre-compute context size for tmux env
+// injection. Lookup priority: llm.yaml override -> built-in glmContextWindows.
+func TestResolveGLMContextWindow(t *testing.T) {
+	t.Run("built-in table match", func(t *testing.T) {
+		// Use a tempDir without llm.yaml so the built-in table is consulted.
+		t.Chdir(t.TempDir())
+
+		cases := []struct {
+			name     string
+			model    string
+			wantSize int
+		}{
+			{"glm-5.1 substring match (longest wins)", "glm-5.1", 200_000},
+			{"glm-4.5-air longest match wins over glm-4.5", "glm-4.5-air", 128_000},
+			{"glm-4.5 fallback when no -air suffix", "glm-4.5", 128_000},
+			{"glm-4.6 known model", "glm-4.6", 128_000},
+			{"empty input returns 0", "", 0},
+			{"claude prefix returns 0 (not GLM)", "claude-sonnet-4.6", 0},
+			{"unknown model returns 0", "completely-unknown", 0},
+			{"case insensitive", "GLM-5.1", 200_000},
+			{"trims whitespace", "  glm-5.1  ", 200_000},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				got := ResolveGLMContextWindow(tc.model)
+				if got != tc.wantSize {
+					t.Errorf("ResolveGLMContextWindow(%q) = %d, want %d", tc.model, got, tc.wantSize)
+				}
+			})
+		}
+	})
+
+	t.Run("llm.yaml override wins over built-in", func(t *testing.T) {
+		tempDir := t.TempDir()
+		sectionsDir := filepath.Join(tempDir, ".moai", "config", "sections")
+		if err := os.MkdirAll(sectionsDir, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		yamlBody := `llm:
+  glm:
+    context_windows:
+      glm-5.1: 230000
+      custom-private: 96000
+`
+		if err := os.WriteFile(filepath.Join(sectionsDir, "llm.yaml"), []byte(yamlBody), 0o644); err != nil {
+			t.Fatalf("write llm.yaml: %v", err)
+		}
+		t.Chdir(tempDir)
+
+		if got := ResolveGLMContextWindow("glm-5.1"); got != 230_000 {
+			t.Errorf("ResolveGLMContextWindow(glm-5.1) with override = %d, want 230000", got)
+		}
+		if got := ResolveGLMContextWindow("custom-private"); got != 96_000 {
+			t.Errorf("ResolveGLMContextWindow(custom-private) = %d, want 96000", got)
+		}
+		// Models not in override but in built-in table still resolve.
+		if got := ResolveGLMContextWindow("glm-4.5"); got != 128_000 {
+			t.Errorf("ResolveGLMContextWindow(glm-4.5) = %d, want 128000 (built-in fallback)", got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Closes #742. `moai glm`/`moai cg` 실행 시 GLM 모델별 실제 context window를 statusline에 정확히 반영하도록 `MOAI_STATUSLINE_CONTEXT_SIZE`를 자동 주입한다.

### Before / After

```
# Before
/context → glm-5.1[1m] → 115.5k/1m tokens (12%)   ← Opus 1M 기준 (잘못됨)

# After
/context → glm-5.1 → 115.5k/200k tokens (58%)     ← GLM-5.1 실제 200K (정확)
```

## Implementation

### 1. Single source of truth for GLM model → context size mapping

`internal/statusline/memory.go`에 `ResolveGLMContextWindow(model string) int` 공개 헬퍼 추가. 우선순위:

1. `.moai/config/sections/llm.yaml` `glm.context_windows` (프로젝트 오버라이드)
2. Built-in `glmContextWindows` 테이블 (glm-5.1 200K / glm-4.7 128K / glm-4.5-air 128K 등)

### 2. tmux 세션 env 주입 (직접 + 간접 경로 모두 커버)

| 경로 | 함수 | 변경 |
|------|------|------|
| 직접 (moai glm/cg 진입) | `injectTmuxSessionEnv` | `tmux set-environment`에 SIZE 포함 |
| 간접 (settings.local.json 영구 저장) | `injectGLMEnvForTeam` | env 맵에 SIZE 저장 + unknown 모델 전환 시 stale 값 자동 정리 |
| SessionStart 훅 (재진입 시 propagate) | `glmTmuxKeys` (hook/glm_tmux.go) | SIZE를 propagation 키 목록에 추가 |
| GLM 종료 (moai cc) | `clearTmuxSessionEnv` + `removeGLMEnv` | tmux env + settings에서 SIZE 제거 |

### 3. Resolution priority (statusline 측 기존 로직)

`MOAI_STATUSLINE_CONTEXT_SIZE` env는 이미 statusline의 최우선순위 (`memory.go:111-116`). 따라서 본 PR이 주입한 값이 즉시 statusline에 반영된다.

## Test Plan

- [x] `go test ./internal/statusline/` PASS — 기존 9 케이스 + 신규 9 케이스 (TestResolveGLMContextWindow, TestCollectMemory_*)
- [x] `go test ./internal/cli/` PASS — 기존 + 신규 3개 (StatuslineContextSize / StaleCleanup / RemoveGLMEnv_Drops)
- [x] `go test ./internal/hook/` PASS — glmTmuxKeys propagation 검증 통과
- [x] `go test -race -count=1 ./internal/cli/ ./internal/statusline/ ./internal/hook/` 전체 PASS
- [x] `golangci-lint run` 0 issues
- [x] `go build ./...` clean
- [x] `go vet ./...` clean

## Acceptance Criteria

- [x] `glm-5.1` → 200000 자동 주입
- [x] `glm-4.5-air` → 128000 (longest match: -air suffix 우선)
- [x] `glm-4.7` → 128000
- [x] Unknown 모델 → SIZE 미주입 (stdin fallback 유지)
- [x] `claude-*` 모델 → SIZE 미주입 (GLM 아님)
- [x] 모델 변경 시 stale 값 자동 정리
- [x] `moai cc` 전환 시 SIZE 제거 (Claude 슬롯 nominal 복귀)

## Merge Strategy

- [x] Squash merge (per §18.3, fix/* → main)
- [x] Branch deletion on merge

## Files Changed

| File | LOC delta | Role |
|------|-----------|------|
| `internal/statusline/memory.go` | +28 | `ResolveGLMContextWindow` exported helper |
| `internal/statusline/memory_test.go` | +63 | TestResolveGLMContextWindow (built-in + override) |
| `internal/cli/glm.go` | +20 | injectTmuxSessionEnv + injectGLMEnvForTeam SIZE 주입 |
| `internal/cli/glm_test.go` | +137 | 3 신규 테스트 (StatuslineContextSize family) |
| `internal/cli/launcher.go` | +3 | removeGLMEnv에서 SIZE 삭제 |
| `internal/hook/glm_tmux.go` | +5 | glmTmuxKeys에 SIZE 추가 |

Total: 6 files, +271 / -0 (additions only)

## Diagnosed in this session

- statusline_debug.log stdin JSON 분석으로 `exceeds_200k_tokens`, `effort.level`, `rate_limits.*` 등 메타데이터가 이미 stdin에 존재함을 확인 (Issue #751로 별도 처리)
- `MOAI_STATUSLINE_CONTEXT_SIZE` 인프라는 90% 완성되어 있었고, 누락된 건 `moai glm` 시점의 자동 주입 (본 PR이 해결)

🗿 MoAI <email@mo.ai.kr>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed stale context window settings from being retained when switching between GLM and Claude models.

* **Chores**
  * Improved environment variable management for GLM model context window sizes in team mode and tmux sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->