### PR TITLE
feat(mcp): Claude Code v2.1.119 MCP alwaysLoad pre-load support

### DIFF
--- a/.claude/rules/moai/core/settings-management.md
+++ b/.claude/rules/moai/core/settings-management.md
@@ -31,6 +31,31 @@ Standard MCP servers in MoAI-ADK:
 - pencil: .pen file design editing. Used by expert-frontend (sub-agent mode) and team-designer (team mode).
 - claude-in-chrome: Browser automation
 
+**`alwaysLoad` field (Claude Code v2.1.119+)**
+
+Claude Code v2.1.119에서 `.mcp.json`의 MCP 서버 항목에 `"alwaysLoad": true` 필드가 추가되었다.
+이 필드가 `true`로 설정된 서버의 툴 스키마는 세션 시작 시 즉시 로드된다(기존 지연 로드 방식 대비).
+
+MoAI-ADK 기본 설정:
+- `context7`: `"alwaysLoad": true` — 매 세션 문서 조회가 빈번하므로 즉시 로드
+- `sequential-thinking`: `"alwaysLoad": true` — DeepThink 워크플로우에서 첫 호출 지연 제거
+- `moai-lsp`: `alwaysLoad` 미설정 — 프로젝트에 따라 LSP가 필요 없는 경우도 있으므로 지연 로드 유지
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "$comment": "Up-to-date documentation and code examples via Context7",
+      "alwaysLoad": true,
+      "command": "/bin/bash",
+      "args": ["-l", "-c", "exec npx -y @upstash/context7-mcp@latest"]
+    }
+  }
+}
+```
+
+Source: SPEC-CC2122-MCP-001 (2026-04-30)
+
 MCP tools are deferred by default and must be loaded before use. Exception: servers with `alwaysLoad: true` are loaded at session start automatically.
 
 1. Use ToolSearch to find and load the tool

--- a/.moai/specs/SPEC-CC2122-MCP-001/acceptance.md
+++ b/.moai/specs/SPEC-CC2122-MCP-001/acceptance.md
@@ -1,0 +1,109 @@
+# SPEC-CC2122-MCP-001 인수 기준
+
+## HISTORY
+
+| Version | Date | Author | Description |
+|---------|------|--------|-------------|
+| 0.1.0 | 2026-04-30 | manager-spec | 초기 작성 — GWT-1 ~ GWT-5 시나리오 + Edge Cases + Quality Gate + Definition of Done |
+
+본 문서는 SPEC-CC2122-MCP-001 의 구현이 완료되었음을 검증하기 위한 Given-When-Then(GWT) 시나리오와 Definition of Done 을 정의한다. 각 시나리오는 `internal/template/settings_test.go` 의 테이블 드리븐(또는 sub-test) 구조로 자동화된다.
+
+## Given-When-Then 시나리오
+
+### GWT-1: `context7` 엔트리에 `alwaysLoad: true` 부착 검증
+
+**Given:** `internal/template/templates/.mcp.json.tmpl` 이 본 SPEC 의 변경 후 상태이고, 표준 템플릿 컨텍스트(예: `Platform="darwin"` 또는 `Platform="linux"`) 로 `moai init` 또는 `moai update` 가 렌더링하여 `.mcp.json` 파일을 생성했다.
+**When:** 결과 `.mcp.json` 의 JSON 트리에서 `mcpServers.context7` 엔트리를 검사한다.
+**Then:** `mcpServers.context7` 객체는 `"alwaysLoad": true` 키-값 쌍을 포함해야 한다. 다른 모든 기존 필드(`command`, `args`, `$comment`) 는 손상되지 않은 채 보존되어야 한다.
+
+### GWT-2: `sequential-thinking` 엔트리에 `alwaysLoad: true` 부착 검증
+
+**Given:** GWT-1 과 동일한 렌더링 컨텍스트.
+**When:** 결과 `.mcp.json` 의 `mcpServers["sequential-thinking"]` 엔트리를 검사한다.
+**Then:** `mcpServers["sequential-thinking"]` 객체는 `"alwaysLoad": true` 키-값 쌍을 포함해야 한다. `command`, `args`, `$comment` 는 변경 없이 보존되어야 한다.
+
+### GWT-3: `moai-lsp` 엔트리에 `alwaysLoad` 부재 (또는 `false`) 검증
+
+**Given:** GWT-1 과 동일한 렌더링 컨텍스트.
+**When:** 결과 `.mcp.json` 의 `mcpServers["moai-lsp"]` 엔트리를 검사한다.
+**Then:** `mcpServers["moai-lsp"]` 객체에는 `alwaysLoad` 키가 부재해야 한다. 만약 어떤 이유로 키가 존재한다면 그 값은 `false` 여야 한다 (lazy-load 정책 유지). `command`, `args`, `timeout`, `$comment` 는 변경 없이 보존되어야 한다.
+
+### GWT-4: 기존 필드 회귀 없음 — 베이스라인 비교
+
+**Given:** SPEC 적용 전의 `.mcp.json.tmpl` 렌더링 결과를 베이스라인 JSON 으로 보유하거나 메모리 내 fixture 로 정의한다. 베이스라인은 본 SPEC 변경 직전의 3개 mcpServers 엔트리 + `staggeredStartup` 블록 + `$schema` 필드를 포함한다.
+**When:** 본 SPEC 적용 후의 렌더링 결과 JSON 트리를 베이스라인과 필드 단위로 비교한다 (단, `alwaysLoad` 의 `context7`/`sequential-thinking` 추가는 제외).
+**Then:** 모든 3개 mcpServers 엔트리에서 `command`, `args`, `timeout` (존재하는 경우), `$comment` 필드가 베이스라인과 정확히 일치해야 한다. 윈도우/유닉스 플랫폼 분기 모두에서 동일하게 검증된다. `staggeredStartup` 블록과 `$schema` 필드도 변경되지 않아야 한다.
+
+### GWT-5: 테스트 스위트 + 회귀 없음
+
+**Given:** `internal/template/settings_test.go` 에 본 SPEC 으로 추가된 신규 테스트 케이스 (`TestMCPTemplateAlwaysLoad*` prefix 의 함수 ≥ 3개) 가 작성되어 있고, 기존 테스트 스위트도 그대로 유지된다.
+**When:** 다음 명령들을 차례로 실행한다:
+- `go test -count=1 ./internal/template/...`
+- `go test -race ./internal/template/...`
+- `go test ./...` (전체, cascading failure 검출용)
+**Then:**
+- 모든 명령이 `PASS` 한다.
+- 신규 추가된 `TestMCPTemplateAlwaysLoad*` 케이스 ≥ 3개가 명시적으로 PASS 출력됨 (각각 REQ-001 / REQ-002 / REQ-003 에 매핑).
+- 기존 `internal/template/settings_test.go` 의 모든 케이스가 회귀 없이 통과한다.
+- `go test -race` 가 race detector 경고 없이 clean 통과한다.
+- `go test ./...` 전체에서 다른 패키지의 회귀가 발생하지 않는다.
+
+## Edge Cases (테스트 추가 권장)
+
+GWT-1 ~ GWT-5 외에 구현 단계에서 명시적으로 다뤄야 할 추가 엣지 케이스:
+
+- **윈도우 플랫폼 렌더링 (`Platform="windows"`):** `{{- if eq .Platform "windows"}}` 분기에서도 `alwaysLoad: true` 가 `context7` 와 `sequential-thinking` 두 엔트리에 동일하게 부착되어야 한다. 명령 분기 (`cmd.exe /c npx ...`) 는 변경 없이 보존된다.
+- **JSON 파싱 유효성:** 렌더링 결과 문자열을 `encoding/json` 으로 디코드 시 에러 없이 성공해야 한다. 키 순서, trailing comma, 따옴표 짝 등 JSON 문법이 깨지지 않았음을 보증.
+- **`alwaysLoad` 값 타입 검증:** `alwaysLoad` 는 boolean `true` 여야 하며, 문자열 `"true"` 또는 숫자 `1` 등이 되어서는 안 된다 (Claude Code 런타임 호환).
+- **기존 사용자의 `.mcp.json` 보호:** 사용자가 `.mcp.json` 을 수정한 경우, `moai update` 가 그 파일을 임의로 덮어쓰지 않아야 한다 (Protected Directories 정책, CLAUDE.local.md §2). 이는 본 SPEC 의 직접 검증 대상은 아니나, 변경이 사용자 데이터를 손상시키지 않는다는 일반 원칙을 침해해서는 안 된다.
+- **두 `settings-management.md` 파일 동일성:** 루트 (`.claude/rules/moai/core/settings-management.md`) 와 템플릿 미러본 (`internal/template/templates/.claude/rules/moai/core/settings-management.md`) 의 v2.1.119 노트 부분이 정확히 동일한 텍스트인지 `diff` 로 검증.
+
+## Quality Gate Criteria
+
+본 SPEC 의 인수 조건은 다음을 모두 충족해야 한다:
+
+- [ ] **EARS 준수**: spec.md 의 5개 REQ 가 모두 EARS 패턴(WHEN/IF/Ubiquitous) 으로 표현됨
+- [ ] **GWT-1 ~ GWT-5**: 5개 시나리오 모두 자동화된 테스트로 통과
+- [ ] **REQ-매핑**: REQ-001 → GWT-1 + GWT-2 + 신규 테스트 (a)(b); REQ-002 → GWT-3 + 신규 테스트 (c); REQ-003 → GWT-4 + 회귀 검증; REQ-004 → 두 `settings-management.md` 파일 노트 부착 + diff 검증; REQ-005 → 신규 테스트 함수 ≥ 3개 존재 + GWT-5 통과
+- [ ] **하위 호환**: GWT-3 통과로 `moai-lsp` lazy-load 유지, 그리고 v2.1.119 미만 사용자에 대해서는 `alwaysLoad` 가 단순 무시되므로 자연스럽게 호환됨 (별도 검증 불필요)
+- [ ] **회귀 없음**: GWT-4, GWT-5 통과로 기존 필드 보존 + 다른 패키지 회귀 없음 보장
+- [ ] **race-free**: `go test -race ./internal/template/...` 통과
+- [ ] **vet/lint**: `go vet ./...` 무경고, `golangci-lint run` 무경고 (가능한 경우)
+- [ ] **빌드**: `make build` 성공으로 `internal/template/embedded.go` 가 최신 템플릿을 반영
+- [ ] **문서 동기화**: 두 `settings-management.md` 파일에 v2.1.119 `alwaysLoad` 노트 부착, 두 사본 동일 (REQ-004)
+- [ ] **Template-First Rule 준수**: CLAUDE.local.md §2 의 verification (모든 신규 `.claude/`/`.moai/` 변경에 대응되는 `internal/template/templates/` 변경 존재) 통과
+
+## Definition of Done
+
+다음 조건이 모두 만족되면 SPEC-CC2122-MCP-001 은 완료(`status: completed`)로 간주한다:
+
+1. `internal/template/templates/.mcp.json.tmpl` 의 `context7` 와 `sequential-thinking` 엔트리에 `"alwaysLoad": true` 가 추가되었고, `moai-lsp` 엔트리는 변경되지 않았다.
+2. `internal/template/settings_test.go` 에 `TestMCPTemplateAlwaysLoad*` (또는 동등 명명의) 신규 테스트 함수 ≥ 3개가 추가되어 REQ-001 / REQ-002 / REQ-003 을 각각 검증한다.
+3. 위 GWT-1 ~ GWT-5 시나리오가 모두 자동화된 테스트로 작성·통과됨.
+4. `go test ./...` 전체 통과, `go vet ./...` 무경고, `go test -race ./internal/template/...` 통과.
+5. `make build` 이후 `internal/template/embedded.go` 가 최신 템플릿을 반영한다.
+6. `.claude/rules/moai/core/settings-management.md` 와 `internal/template/templates/.claude/rules/moai/core/settings-management.md` 두 파일에 v2.1.119 `alwaysLoad` 의미 + 사용 권장 기준 노트가 동일하게 부착됨 (REQ-004).
+7. PR 이 main 에 머지되어 `merged_pr` / `merged_commit` 정보가 spec.md 의 frontmatter 에 기록됨.
+8. plan-auditor 의 사후 감사(post-merge audit)에서 통과 판정.
+
+## 검증 방법 요약
+
+| 시나리오 | 검증 도구 | 자동화 여부 |
+|---------|-----------|-----------|
+| GWT-1, GWT-2 | `go test ./internal/template/...` (`TestMCPTemplateAlwaysLoadOnContext7`, `TestMCPTemplateAlwaysLoadOnSequentialThinking` 또는 통합 테스트의 sub-tests) | 자동화 |
+| GWT-3 | `go test ./internal/template/...` (`TestMCPTemplateAlwaysLoadAbsentOnMoaiLSP`) | 자동화 |
+| GWT-4 | `go test ./internal/template/...` (`TestMCPTemplateExistingFieldsPreserved` — 베이스라인 비교 또는 필드별 명시적 검증) | 자동화 |
+| GWT-5 | `go test -count=1 -race ./internal/template/...` + `go test ./...` | 자동화 |
+| Edge cases (윈도우 분기, JSON 파싱) | 위와 동일 테스트 파일에 추가 | 자동화 |
+| REQ-004 (두 `settings-management.md` 동일성) | `diff .claude/rules/moai/core/settings-management.md internal/template/templates/.claude/rules/moai/core/settings-management.md` 의 v2.1.119 노트 섹션 비교 | 수동 또는 CI 스크립트로 자동화 가능 |
+| Definition of Done #7, #8 | manager-git PR 머지 후 plan-auditor 호출 | 수동 트리거 (자동 검증) |
+
+## REQ ↔ GWT 매핑 표
+
+| REQ | 매핑 GWT | 매핑 신규 테스트 케이스 (예시 명명) |
+|-----|---------|--------------------------------|
+| REQ-001 (context7 + sequential-thinking 에 `alwaysLoad: true`) | GWT-1, GWT-2 | `TestMCPTemplateAlwaysLoadOnContext7`, `TestMCPTemplateAlwaysLoadOnSequentialThinking` |
+| REQ-002 (moai-lsp 에 `alwaysLoad` 부재 또는 false) | GWT-3 | `TestMCPTemplateAlwaysLoadAbsentOnMoaiLSP` |
+| REQ-003 (기존 필드 회귀 없음) | GWT-4 | `TestMCPTemplateExistingFieldsPreserved` (또는 GWT-1/2/3 의 회귀 검증 통합) |
+| REQ-004 (두 `settings-management.md` 노트) | (테스트 외) 수동 또는 CI 스크립트 | `diff` 비교 + reviewer 시각 검증 |
+| REQ-005 (테스트 ≥ 3개 존재 + 통과) | GWT-5 | 위 신규 테스트 3개 모두 + `go test ./...` 통과 |

--- a/.moai/specs/SPEC-CC2122-MCP-001/plan.md
+++ b/.moai/specs/SPEC-CC2122-MCP-001/plan.md
@@ -1,0 +1,133 @@
+# SPEC-CC2122-MCP-001 구현 계획
+
+## 개요
+
+본 계획은 Claude Code v2.1.119 의 `alwaysLoad: true` MCP 필드를 `internal/template/templates/.mcp.json.tmpl` 의 `context7` 와 `sequential-thinking` 엔트리에 통합하는 작업의 마일스톤, 기술적 접근, 리스크, 의존성을 정의한다.
+
+이 문서는 시간 추정(예: "2 days") 대신 **우선순위 라벨** 과 **단계 간 순서** 로 진행을 표현한다 (CLAUDE.local.md §14 + agent-common-protocol.md §Time Estimation 준수).
+
+## 기술적 접근 (High-Level)
+
+`.mcp.json.tmpl` 은 Go template 형식의 단순 JSON 파일이다. 변경은 두 mcpServers 엔트리(`context7`, `sequential-thinking`)에 `"alwaysLoad": true` 한 줄을 추가하는 작은 보조-필드 수정이다. 기존의 `command`, `args`, `timeout`, `$comment`, 플랫폼 분기 (`{{- if eq .Platform "windows"}}`) 는 절대 손대지 않는다.
+
+테스트 측면에서는 기존 `internal/template/settings_test.go` 에 이미 `.mcp.json.tmpl` 렌더링 검증 패턴이 존재할 가능성이 높으므로, M1 에서 그 패턴을 식별하고 동일 컨벤션(테이블 드리븐 또는 sub-test 구조)을 따른다. 신규 테스트 함수는 `TestMCPTemplateAlwaysLoad*` prefix 로 grep/search 가능하게 명명한다.
+
+문서 동기화는 두 파일 (`settings-management.md` 루트 + 템플릿 미러본) 에 동일한 짧은 노트를 추가하는 단순 미러 작업이며, Template-First Rule (CLAUDE.local.md §2) 에 따라 템플릿 본을 먼저 수정하고 루트 사본을 동기화하거나 동시에 작성한다.
+
+## Milestones
+
+### M1 — Path Discovery + Existing Test Pattern Review (Priority: High)
+
+**목표**: 변경 대상 파일의 정확한 라인 범위와 `settings_test.go` 의 기존 `.mcp.json.tmpl` 검증 패턴을 식별한다.
+
+**작업 항목:**
+
+- `internal/template/templates/.mcp.json.tmpl` 의 현재 3개 엔트리(`context7`, `sequential-thinking`, `moai-lsp`) 의 정확한 라인 범위 확인
+- `internal/template/settings_test.go` 내 `.mcp.json` / `.mcp.json.tmpl` 관련 기존 테스트 함수 확인 (Grep `mcp` 또는 `MCP` 케이스)
+- 기존 테스트가 사용하는 패턴 식별: 테이블 드리븐 vs sub-test, JSON 파싱 후 필드 검증 vs 문자열 매칭
+- 기존 테스트 컨벤션의 helper / fixture (예: 템플릿 렌더링 헬퍼, JSON 디코드 헬퍼) 위치 파악
+- `.claude/rules/moai/core/settings-management.md` 와 그 템플릿 미러본의 현재 구조 (섹션 헤더, MCP 관련 기존 설명) 확인하여 노트 삽입 지점 선정
+
+**Done 기준:**
+
+- 수정 대상 4개 파일 모두 정확한 라인 범위가 식별되어 PR 설명에 인용 가능
+- 신규 테스트가 따라야 할 기존 컨벤션이 명확히 결정됨 (예: "table-driven with `tests := []struct{...}` pattern")
+
+### M2 — Template Update (Priority: High)
+
+**목표**: `.mcp.json.tmpl` 의 `context7` 와 `sequential-thinking` 두 엔트리에 `"alwaysLoad": true` 를 추가한다. `moai-lsp` 는 변경하지 않는다.
+
+**작업 항목:**
+
+- `context7` 엔트리에 `"alwaysLoad": true` 한 줄 추가 (`$comment` 라인 바로 뒤 또는 엔트리 마지막 — 기존 JSON 의 키 순서 컨벤션을 따름)
+- `sequential-thinking` 엔트리에 동일하게 한 줄 추가
+- `moai-lsp` 엔트리는 손대지 않음 (REQ-002 명시적 제외)
+- JSON 문법 유효성 확인 (trailing comma 위치, 따옴표 짝)
+- 플랫폼 분기 (`{{- if eq .Platform "windows"}}` ... `{{- else}}` ... `{{- end}}`) 는 그대로 유지 (REQ-003 회귀 방지)
+- `make build` 로 `internal/template/embedded.go` 재생성
+
+**Done 기준:**
+
+- `internal/template/templates/.mcp.json.tmpl` 변경분이 `context7` 와 `sequential-thinking` 두 엔트리에만 국한됨 (`git diff` 로 검증 가능)
+- `make build` 성공, `internal/template/embedded.go` 재생성됨
+- `go build ./internal/template/...` 통과
+
+### M3 — Test Coverage (TDD: RED → GREEN) (Priority: High)
+
+**목표**: `internal/template/settings_test.go` 에 REQ-001/002/003 을 각각 검증하는 신규 테스트 케이스 최소 3개를 TDD 사이클(RED → GREEN)로 추가한다.
+
+**작업 항목:**
+
+- M1 에서 식별한 기존 컨벤션을 따라 신규 함수 추가:
+  - `TestMCPTemplateAlwaysLoadOnContext7` (또는 통합 함수의 sub-test) — REQ-001 (a) 검증: 렌더링된 `.mcp.json` 의 `context7` 엔트리에 `alwaysLoad: true` 존재
+  - `TestMCPTemplateAlwaysLoadOnSequentialThinking` — REQ-001 (b) 검증: `sequential-thinking` 엔트리에 `alwaysLoad: true` 존재
+  - `TestMCPTemplateAlwaysLoadAbsentOnMoaiLSP` — REQ-002 검증: `moai-lsp` 엔트리에 `alwaysLoad` 키가 부재하거나 `false`
+  - (선택 통합) `TestMCPTemplateExistingFieldsPreserved` — REQ-003 검증: 3개 엔트리 모두에서 `command`, `args`, `timeout` (해당 시), `$comment` 가 보존됨
+- TDD 순서: 테스트를 먼저 작성하고 (M2 작업 전에는 RED), M2 적용 후 GREEN 확인. 본 plan 에서는 M2 가 M3 보다 먼저 기재되어 있으나, 실제 구현자는 자유롭게 RED-first 로 순서를 뒤집어도 된다.
+- 테스트는 두 플랫폼 분기 (windows / non-windows) 모두를 커버 (M1 에서 발견한 기존 패턴이 plat-aware 이면 따름)
+- `go test -count=1 ./internal/template/...` 통과 확인 (캐시 disable, CLAUDE.local.md §6 Go Test Execution Rules)
+
+**Done 기준:**
+
+- 신규 테스트 함수 ≥ 3개가 `TestMCPTemplateAlwaysLoad*` 또는 `TestMCPTemplateExistingFieldsPreserved` 명명으로 추가됨
+- 각 테스트가 REQ-001 / REQ-002 / REQ-003 중 하나 이상에 매핑됨 (acceptance.md 검증 표 참조)
+- `go test ./internal/template/...` 전체 통과 (신규 + 기존, 회귀 없음)
+- `go test -race ./internal/template/...` 통과
+
+### M4 — Documentation Sync + Final Validation (Priority: High)
+
+**목표**: `settings-management.md` 두 파일 (루트 + 템플릿 미러본) 에 v2.1.119 `alwaysLoad` 노트를 추가하고, 전체 품질 게이트를 통과시킨다.
+
+**작업 항목:**
+
+- 두 `settings-management.md` 파일에 짧은 섹션/노트 블록 추가 (REQ-004):
+  - 노트 내용: (a) `alwaysLoad: true` 의 pre-load 의미, (b) `false`/부재 시 lazy-load 하위 호환, (c) 권장 기준 — 소형 + 빈번 → `true`, 대형 + 비상시 → `false`/부재
+  - moai-adk 의 현재 사례 ("`context7`, `sequential-thinking` 은 `true`, `moai-lsp` 는 부재") 를 한 줄 예시로 포함하여 독자 이해를 돕는다
+  - 노트의 길이는 5-10 문장 정도로 제한 (문서 비대화 방지, Karpathy Simplicity First 준수)
+- Template-First Rule (CLAUDE.local.md §2) 준수: `internal/template/templates/.claude/rules/moai/core/settings-management.md` 를 먼저 또는 동시에 수정
+- 두 파일의 변경분이 동일한지 `diff` 로 검증
+- 최종 게이트:
+  - `go test ./...` (전체) 통과 — cascading failure 검출 (CLAUDE.local.md §6)
+  - `go vet ./...` 통과
+  - `golangci-lint run` 무경고 (가능한 경우)
+  - `make build` 성공 (embedded.go 최신)
+- 커밋 메시지 초안: `feat(mcp): add alwaysLoad: true to context7 + sequential-thinking MCP entries (SPEC-CC2122-MCP-001)`
+
+**Done 기준:**
+
+- 두 `settings-management.md` 파일에 v2.1.119 `alwaysLoad` 노트 부착됨, 두 사본이 동일 내용
+- `make build` 후 `git status` 에 `internal/template/embedded.go` 변경 포함 (자동 재생성 결과)
+- 모든 게이트 (vet/test/lint/build) 통과
+- PR 설명에 SPEC-CC2122-MCP-001 명시, REQ-001 ~ REQ-005 와 GWT-1 ~ GWT-5 의 매핑 표 포함
+
+## Dependencies
+
+- **상위 의존**: 없음. 본 SPEC 은 v2.1.119 호환 통합 시리즈의 일부로 SPEC-CC2122-HOOK-001 (이미 main 적용) 및 SPEC-CC2122-STATUSLINE-001 (별도 진행) 과 병렬 관계이며, 코드 수준의 직접 의존은 없다.
+- **하위 의존 후보**: 향후 사용자가 추가하는 자체 MCP 서버에 `alwaysLoad` 자동 권장 로직(예: `moai doctor` 가 사용 빈도 분석 후 제안)을 도입한다면 본 SPEC 의 결정 표(소형/빈번 vs 대형/비상시)를 입력으로 사용할 수 있다. 그러나 그 작업은 별도 SPEC 이다.
+- **외부 의존**: Claude Code v2.1.119 이상에서 `.mcp.json` 의 `alwaysLoad` 필드를 실제로 인식하는지 — 릴리스 노트로 확인됨. 통합 테스트는 사용자 환경에서 수동으로 1회 검증할 수 있으나, 본 SPEC 의 자동화된 테스트는 템플릿 렌더링 수준에서만 검증한다 (런타임 동작 검증은 Claude Code 의 책임).
+
+## Risks and Mitigations
+
+| 리스크 | 영향도 | 완화 전략 |
+|--------|--------|-----------|
+| `moai-lsp` 엔트리에 실수로 `alwaysLoad: true` 가 추가됨 | High | M2 의 `git diff` 검토 + M3 의 `TestMCPTemplateAlwaysLoadAbsentOnMoaiLSP` 자동화 테스트로 회귀 즉시 검출. REQ-002 에 명시적으로 금지. |
+| JSON 문법 오류 (trailing comma, 따옴표 누락) 로 `.mcp.json` 파싱 실패 | High | M2 후 `go test` 의 템플릿 렌더링 + JSON 파싱 테스트가 통과해야 함. 파싱 실패는 즉시 RED 가 됨. |
+| 플랫폼 분기 (`{{- if eq .Platform "windows"}}`) 의 위치/구조가 깨짐 | Medium | REQ-003 회귀 검증 + M3 의 `TestMCPTemplateExistingFieldsPreserved` 가 윈도우/유닉스 양쪽 분기를 모두 검증. |
+| 두 `settings-management.md` 파일의 내용이 어긋남 (Template-First 위반) | Medium | M4 에서 `diff` 로 두 파일 동일성 검증. CLAUDE.local.md §2 의 verification 체크리스트 준수. |
+| `make build` 누락으로 `internal/template/embedded.go` 가 stale | High | M2 와 M4 모두에서 `make build` 명시적 실행. PR 체크리스트의 "Templates regenerated" 항목 준수 (CLAUDE.local.md §4). |
+| 기존 사용자가 `moai update` 실행 시 `.mcp.json` 머지 충돌 | Low | 본 SPEC 범위 밖. `moai update` 의 기존 머지 정책에 위임. 사용자가 직접 수정한 `.mcp.json` 은 보호됨 (CLAUDE.local.md §2 Protected Directories 정책 준수). |
+| 템플릿 언어 중립성 위반 (특정 언어 편향 도입) | Low | 본 SPEC 은 JSON 한 줄 추가 + 영어 노트 한 단락이며, 16개 언어 사용자 모두에게 동등하게 적용됨. CLAUDE.local.md §15 위반 없음. |
+
+## Out of Scope (Plan-Level)
+
+- `moai-lsp` 의 `alwaysLoad` 정책 변경 — 본 SPEC 은 `false`/부재 유지를 명시 (REQ-002).
+- `staggeredStartup` 블록 (`enabled`, `delayMs`, `connectionTimeout`) 변경 — 별도 SPEC 분리.
+- 사용자 정의 MCP 서버에 대한 자동 `alwaysLoad` 추천/주입 — 별도 SPEC 후보.
+- `.claude/settings.json` 의 MCP 관련 키 (예: `enabledMcpjsonServers`) 수정 — 본 SPEC 범위 밖.
+- `.mcp.json` 스키마 강화 검증 (boolean type check 등) — 별도 SPEC 후보.
+- 기존 사용자의 `.mcp.json` 자동 마이그레이션 도구 — 본 SPEC 범위 밖.
+- 4개국어 docs-site (`docs-site/`) 동기화 — 본 SPEC 의 변경은 내부 룰 문서 (`.claude/rules/moai/core/settings-management.md`) 에 한정되며, docs-site 사용자 가이드 갱신 여부는 별도 판단 (CLAUDE.local.md §17.3 ko-canonical 정책 검토 후 필요 시 후속 PR 분리).
+
+## Approval / Next Step
+
+본 plan.md 와 spec.md, acceptance.md 가 plan-auditor 의 승인을 받으면, manager-cycle 또는 manager-tdd 가 `/moai run SPEC-CC2122-MCP-001` 으로 위임받아 M1 → M4 순으로 구현한다. 본 SPEC 단계에서는 코드/테스트/문서 어떤 파일도 수정하지 않는다 (사용자 명시 제약).

--- a/.moai/specs/SPEC-CC2122-MCP-001/spec.md
+++ b/.moai/specs/SPEC-CC2122-MCP-001/spec.md
@@ -1,0 +1,101 @@
+---
+id: SPEC-CC2122-MCP-001
+version: "0.1.0"
+status: draft
+created_at: 2026-04-30
+updated_at: 2026-04-30
+author: manager-spec
+priority: Medium
+labels: [mcp, claude-code-integration, templates, backward-compat]
+issue_number: null
+related_specs: [SPEC-CC2122-HOOK-001, SPEC-CC2122-STATUSLINE-001]
+---
+
+# SPEC-CC2122-MCP-001: Claude Code v2.1.119 MCP `alwaysLoad` 통합
+
+## HISTORY
+
+| Version | Date | Author | Description |
+|---------|------|--------|-------------|
+| 0.1.0 | 2026-04-30 | manager-spec | 초기 작성 — Claude Code v2.1.119 `.mcp.json` `alwaysLoad: true` 필드를 `context7` 와 `sequential-thinking` 서버 엔트리에 적용. `moai-lsp` 는 lazy-load 유지. |
+
+## Status: Draft
+
+## Overview
+
+Claude Code v2.1.119 릴리스 노트에 따라 `.mcp.json` 의 `mcpServers` 엔트리에 선택적 `alwaysLoad: true` 필드가 추가되었다. 이 필드가 `true` 이면 해당 MCP 서버의 도구 스키마(tool schemas)가 세션 시작 시점에 컨텍스트로 미리 로드(pre-load)되며, `false` 이거나 부재하면 기존처럼 첫 도구 호출 시점에 지연 로드(lazy-load)된다.
+
+본 SPEC 은 moai-adk-go 의 `internal/template/templates/.mcp.json.tmpl` 템플릿을 v2.1.119 호환으로 업데이트하여, **소형 스키마 + 빈번한 사용** 특성을 가진 `context7` (라이브러리 문서 조회) 와 `sequential-thinking` (단계별 추론) 두 서버에 한해 `alwaysLoad: true` 를 부여한다. **대형 스키마 + 비상시 사용** 특성을 가진 `moai-lsp` (LSP code intelligence) 는 lazy-load 를 유지하여 초기 컨텍스트 비용을 절감한다.
+
+이 SPEC 은 **WHAT 과 WHY** 에 집중한다. 정확한 JSON 키 위치, Go 테스트 함수 시그니처, 문서 주석의 정확한 단어 선택 등 **HOW** 는 manager-cycle (또는 manager-tdd) 위임 시 결정된다.
+
+## Background
+
+`.mcp.json.tmpl` 의 현재(템플릿 기준) 상태는 3개의 mcpServers 엔트리를 포함한다:
+
+- `context7` — `npx -y @upstash/context7-mcp@latest` 실행. 라이브러리 문서 조회용. 스키마 소형, 빈번 사용.
+- `sequential-thinking` — `npx -y @modelcontextprotocol/server-sequential-thinking` 실행. 구조화된 단계별 추론용. 스키마 소형, 빈번 사용.
+- `moai-lsp` — `moai mcp lsp` 실행. LSP 기반 코드 인텔리전스(goto definition, find references, hover, diagnostics, rename). 스키마 대형, 일부 세션에서만 사용.
+
+세 엔트리 중 어느 것도 현재 `alwaysLoad` 필드를 갖지 않는다. v2.1.119 부터는 선택적 필드이므로 부재 시 기본 동작(lazy-load)으로 처리되어 하위 호환은 유지되지만, 자주 사용되는 두 서버에 한해 명시적으로 `alwaysLoad: true` 를 부여하면 첫 도구 호출 지연(latency)이 제거된다는 이점이 있다.
+
+`moai-lsp` 에 대해 동일한 처리를 하지 않는 이유: LSP 도구 스키마는 다른 두 서버 대비 상대적으로 크고, 모든 세션에서 사용되지 않기 때문에 항상 로드 시 초기 컨텍스트가 불필요하게 증가한다. 따라서 lazy-load 가 적합하다.
+
+문서 동기화 측면에서는 `.claude/rules/moai/core/settings-management.md` 와 그 템플릿 미러본인 `internal/template/templates/.claude/rules/moai/core/settings-management.md` 두 파일에 v2.1.119 `alwaysLoad` 의미와 사용 가이드를 짧은 노트로 추가해야 한다(REQ-004).
+
+## Requirements (EARS)
+
+### REQ-001 (Event-Driven)
+
+[WHEN] `moai init` 또는 `moai update` 명령이 `internal/template/templates/.mcp.json.tmpl` 을 렌더링하여 사용자 프로젝트 루트의 `.mcp.json` 파일을 생성/갱신할 때
+[THEN] 결과 `.mcp.json` 의 `mcpServers.context7` 엔트리와 `mcpServers["sequential-thinking"]` 엔트리는 각각 `"alwaysLoad": true` 키-값 쌍을 포함해야 한다.
+
+### REQ-002 (Unwanted Behavior)
+
+[IF] 동일한 템플릿 렌더링 결과의 `mcpServers["moai-lsp"]` 엔트리에 `alwaysLoad` 필드를 추가하려는 시도가 있는 경우
+[THEN] 시스템은 해당 추가를 거부해야 한다. 즉, `moai-lsp` 엔트리는 `alwaysLoad` 키를 포함하지 않아야 하며, 만약 어떤 이유로 키가 존재한다면 그 값은 반드시 `false` 여야 한다 (lazy-load 유지).
+
+### REQ-003 (Ubiquitous, 회귀 방지)
+
+시스템은 본 SPEC 의 변경이 적용된 후에도 `.mcp.json.tmpl` 의 모든 3개 mcpServers 엔트리(`context7`, `sequential-thinking`, `moai-lsp`)에서 기존에 존재하던 필드 — `command`, `args`, `timeout`, `$comment`, 그리고 플랫폼 분기(`{{- if eq .Platform "windows"}}` 블록의 윈도우/유닉스 명령 분기) — 를 변경 없이 그대로 보존해야 한다. `alwaysLoad` 추가 외의 어떤 필드 변경도 발생해서는 안 된다.
+
+### REQ-004 (Event-Driven, 문서 동기화)
+
+[WHEN] 프로젝트 문서가 Claude Code v2.1.119 호환성을 설명할 때
+[THEN] `.claude/rules/moai/core/settings-management.md` (루트 사본) 와 `internal/template/templates/.claude/rules/moai/core/settings-management.md` (템플릿 미러본) 두 파일은 모두 `alwaysLoad: true` 의 의미를 설명하는 짧은 노트를 포함해야 한다. 노트는 최소한 다음 세 요점을 다뤄야 한다: (a) `alwaysLoad: true` 가 세션 시작 시 도구 스키마를 미리 로드하는 동작임, (b) 부재/`false` 시 기존 lazy-load 동작 유지로 하위 호환됨, (c) 사용 권장 기준 — 소형 스키마 + 빈번한 사용 시 `true` 를, 대형 스키마 또는 비상시 사용 시 `false` (또는 부재) 를 권장.
+
+### REQ-005 (Event-Driven, 테스트 커버리지)
+
+[WHEN] `internal/template/settings_test.go` 에 정의된 테스트 스위트를 `go test ./internal/template/...` 로 실행할 때
+[THEN] 다음 3가지 동작을 각각 명시적으로 검증하는 신규 테스트 케이스가 최소 3개 이상 존재해야 한다: (a) REQ-001 검증 — 렌더링된 `.mcp.json` 의 `context7` 와 `sequential-thinking` 엔트리에 `alwaysLoad: true` 가 존재함, (b) REQ-002 검증 — `moai-lsp` 엔트리에 `alwaysLoad` 가 부재하거나 `false` 임, (c) REQ-003 검증 — 기존 필드(`command`, `args`, `timeout`, `$comment`)가 모든 3개 엔트리에서 회귀 없이 보존됨. 신규 테스트 함수명은 `TestMCPTemplateAlwaysLoad*` (또는 동등한 검색 가능한) prefix 를 사용한다.
+
+## Files Affected
+
+**수정 대상:**
+
+- `internal/template/templates/.mcp.json.tmpl` — `context7` 와 `sequential-thinking` 두 엔트리에 `"alwaysLoad": true` 추가. `moai-lsp` 엔트리는 변경하지 않음.
+- `internal/template/settings_test.go` — `TestMCPTemplateAlwaysLoad*` prefix 의 신규 테스트 케이스 최소 3개 추가 (REQ-001/002/003 매핑).
+- `.claude/rules/moai/core/settings-management.md` — v2.1.119 `alwaysLoad` 의미 + 사용 권장 기준을 짧은 섹션 또는 노트 블록으로 추가.
+- `internal/template/templates/.claude/rules/moai/core/settings-management.md` — 위 루트 사본과 동일한 노트를 미러링 (Template-First Rule, CLAUDE.local.md §2 준수).
+
+**간접 영향 (수정 없음):**
+
+- `internal/template/embedded.go` — 자동 생성 파일. `make build` 로 재생성됨. 직접 편집 금지.
+- 사용자 프로젝트의 기존 `.mcp.json` — `moai update` 시점에 갱신될 수 있음. 본 SPEC 의 행동은 템플릿 변경에 한정되며, 기존 사용자 파일에 대한 마이그레이션 정책은 본 SPEC 범위 밖이다.
+
+## Exclusions (What NOT to Build)
+
+- `moai-lsp` 엔트리에 `alwaysLoad: true` 부여는 본 SPEC 에서 명시적으로 제외한다. 향후 LSP 사용 패턴이 변하거나 스키마가 축소되면 별도 SPEC 으로 검토할 수 있다.
+- `staggeredStartup` 블록 (`enabled`, `delayMs`, `connectionTimeout`) 의 변경은 본 SPEC 범위 밖이다. 본 SPEC 은 `mcpServers.*` 내부의 `alwaysLoad` 필드만 다룬다.
+- 사용자 정의 MCP 서버 (사용자가 자신의 `.mcp.json` 에 추가한 추가 엔트리) 에 대한 `alwaysLoad` 자동 부여 로직은 구현하지 않는다. 본 SPEC 은 템플릿이 제공하는 3개 표준 엔트리에만 적용된다.
+- `.mcp.json` 스키마 검증 강화 (예: `alwaysLoad` 가 boolean 인지 type-check) 는 본 SPEC 범위 밖이다. Claude Code 런타임이 자체 검증을 수행한다고 가정한다.
+- 기존 사용자의 `.mcp.json` 에 자동으로 `alwaysLoad: true` 를 주입하는 마이그레이션 도구는 구현하지 않는다. `moai update` 의 기존 머지 정책을 따른다.
+- `.claude/settings.json` 의 MCP 관련 키 (예: `enabledMcpjsonServers`) 변경은 본 SPEC 의 대상이 아니다. 본 SPEC 은 `.mcp.json.tmpl` 템플릿과 그 동작을 설명하는 문서에만 영향을 미친다.
+
+## Acceptance Reference
+
+상세한 Given-When-Then 시나리오와 검증 항목은 `acceptance.md` 를 참조한다.
+
+## Implementation Reference
+
+마일스톤, 우선순위, 기술적 접근 방식은 `plan.md` 를 참조한다.

--- a/internal/template/settings_test.go
+++ b/internal/template/settings_test.go
@@ -616,6 +616,153 @@ func TestMCPTemplateSchema(t *testing.T) {
 	}
 }
 
+// TestMCPTemplateAlwaysLoadOnContext7 verifies that the rendered .mcp.json sets
+// "alwaysLoad": true on the context7 server entry (REQ-001, REQ-002).
+func TestMCPTemplateAlwaysLoadOnContext7(t *testing.T) {
+	platforms := []string{"darwin", "linux", "windows"}
+
+	for _, platform := range platforms {
+		t.Run(platform, func(t *testing.T) {
+			ctx := testContext(platform)
+			output := renderTemplate(t, ".mcp.json.tmpl", ctx)
+
+			var config map[string]any
+			if err := json.Unmarshal([]byte(strings.TrimSpace(output)), &config); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			servers, ok := config["mcpServers"].(map[string]any)
+			if !ok {
+				t.Fatal("missing mcpServers")
+			}
+			server, ok := servers["context7"].(map[string]any)
+			if !ok {
+				t.Fatal("missing context7 server entry")
+			}
+			val, exists := server["alwaysLoad"]
+			if !exists {
+				t.Error("context7: alwaysLoad field is absent; want true")
+				return
+			}
+			if val != true {
+				t.Errorf("context7: alwaysLoad = %v, want true", val)
+			}
+		})
+	}
+}
+
+// TestMCPTemplateAlwaysLoadOnSequentialThinking verifies that the rendered
+// .mcp.json sets "alwaysLoad": true on the sequential-thinking server entry
+// (REQ-001, REQ-003).
+func TestMCPTemplateAlwaysLoadOnSequentialThinking(t *testing.T) {
+	platforms := []string{"darwin", "linux", "windows"}
+
+	for _, platform := range platforms {
+		t.Run(platform, func(t *testing.T) {
+			ctx := testContext(platform)
+			output := renderTemplate(t, ".mcp.json.tmpl", ctx)
+
+			var config map[string]any
+			if err := json.Unmarshal([]byte(strings.TrimSpace(output)), &config); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			servers, ok := config["mcpServers"].(map[string]any)
+			if !ok {
+				t.Fatal("missing mcpServers")
+			}
+			server, ok := servers["sequential-thinking"].(map[string]any)
+			if !ok {
+				t.Fatal("missing sequential-thinking server entry")
+			}
+			val, exists := server["alwaysLoad"]
+			if !exists {
+				t.Error("sequential-thinking: alwaysLoad field is absent; want true")
+				return
+			}
+			if val != true {
+				t.Errorf("sequential-thinking: alwaysLoad = %v, want true", val)
+			}
+		})
+	}
+}
+
+// TestMCPTemplateAlwaysLoadAbsentOnMoaiLSP verifies that the moai-lsp server
+// entry does NOT have alwaysLoad set to true (REQ-004).
+func TestMCPTemplateAlwaysLoadAbsentOnMoaiLSP(t *testing.T) {
+	ctx := testContext("darwin")
+	output := renderTemplate(t, ".mcp.json.tmpl", ctx)
+
+	var config map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(output)), &config); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	servers, ok := config["mcpServers"].(map[string]any)
+	if !ok {
+		t.Fatal("missing mcpServers")
+	}
+	server, ok := servers["moai-lsp"].(map[string]any)
+	if !ok {
+		t.Fatal("missing moai-lsp server entry")
+	}
+	if val, exists := server["alwaysLoad"]; exists && val == true {
+		t.Error("moai-lsp: alwaysLoad must not be true; it was explicitly excluded from REQ-004")
+	}
+}
+
+// TestMCPTemplateExistingFieldsPreserved verifies that adding alwaysLoad does
+// not disturb existing fields in any server entry (REQ-005).
+func TestMCPTemplateExistingFieldsPreserved(t *testing.T) {
+	ctx := testContext("darwin")
+	output := renderTemplate(t, ".mcp.json.tmpl", ctx)
+
+	var config map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(output)), &config); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	servers, ok := config["mcpServers"].(map[string]any)
+	if !ok {
+		t.Fatal("missing mcpServers")
+	}
+
+	// context7 must still have command and args
+	c7, ok := servers["context7"].(map[string]any)
+	if !ok {
+		t.Fatal("missing context7")
+	}
+	if c7["command"] == nil {
+		t.Error("context7: command field missing after alwaysLoad insertion")
+	}
+	if c7["args"] == nil {
+		t.Error("context7: args field missing after alwaysLoad insertion")
+	}
+
+	// sequential-thinking must still have command and args
+	st, ok := servers["sequential-thinking"].(map[string]any)
+	if !ok {
+		t.Fatal("missing sequential-thinking")
+	}
+	if st["command"] == nil {
+		t.Error("sequential-thinking: command field missing after alwaysLoad insertion")
+	}
+	if st["args"] == nil {
+		t.Error("sequential-thinking: args field missing after alwaysLoad insertion")
+	}
+
+	// moai-lsp must still have command, args, and timeout
+	lsp, ok := servers["moai-lsp"].(map[string]any)
+	if !ok {
+		t.Fatal("missing moai-lsp")
+	}
+	if lsp["command"] == nil {
+		t.Error("moai-lsp: command field missing")
+	}
+	if lsp["args"] == nil {
+		t.Error("moai-lsp: args field missing")
+	}
+	if lsp["timeout"] == nil {
+		t.Error("moai-lsp: timeout field missing")
+	}
+}
+
 // --- BuildSmartPATH and PathContainsDir tests ---
 
 // TestBuildSmartPATH_StableAcrossTerminalPATH is a regression test for issue #467:

--- a/internal/template/templates/.claude/rules/moai/core/settings-management.md
+++ b/internal/template/templates/.claude/rules/moai/core/settings-management.md
@@ -31,7 +31,36 @@ Standard MCP servers in MoAI-ADK:
 - pencil: .pen file design editing. Used by expert-frontend (sub-agent mode) and team-designer (team mode).
 - claude-in-chrome: Browser automation
 
+<<<<<<< HEAD
 MCP tools are deferred by default and must be loaded before use. Exception: servers with `alwaysLoad: true` are loaded at session start automatically.
+=======
+**`alwaysLoad` field (Claude Code v2.1.119+)**
+
+Claude Code v2.1.119에서 `.mcp.json`의 MCP 서버 항목에 `"alwaysLoad": true` 필드가 추가되었다.
+이 필드가 `true`로 설정된 서버의 툴 스키마는 세션 시작 시 즉시 로드된다(기존 지연 로드 방식 대비).
+
+MoAI-ADK 기본 설정:
+- `context7`: `"alwaysLoad": true` — 매 세션 문서 조회가 빈번하므로 즉시 로드
+- `sequential-thinking`: `"alwaysLoad": true` — DeepThink 워크플로우에서 첫 호출 지연 제거
+- `moai-lsp`: `alwaysLoad` 미설정 — 프로젝트에 따라 LSP가 필요 없는 경우도 있으므로 지연 로드 유지
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "$comment": "Up-to-date documentation and code examples via Context7",
+      "alwaysLoad": true,
+      "command": "/bin/bash",
+      "args": ["-l", "-c", "exec npx -y @upstash/context7-mcp@latest"]
+    }
+  }
+}
+```
+
+Source: SPEC-CC2122-MCP-001 (2026-04-30)
+
+MCP tools are deferred and must be loaded before use:
+>>>>>>> 450661684 (docs(rules): M4 — settings-management alwaysLoad v2.1.119 노트 추가 (SPEC-CC2122-MCP-001))
 
 1. Use ToolSearch to find and load the tool
 2. Then call the loaded tool directly

--- a/internal/template/templates/.mcp.json.tmpl
+++ b/internal/template/templates/.mcp.json.tmpl
@@ -3,6 +3,7 @@
   "mcpServers": {
     "context7": {
       "$comment": "Up-to-date documentation and code examples via Context7",
+      "alwaysLoad": true,
 {{- if eq .Platform "windows"}}
       "command": "cmd.exe",
       "args": ["/c", "npx -y @upstash/context7-mcp@latest"]
@@ -13,6 +14,7 @@
     },
     "sequential-thinking": {
       "$comment": "Step-by-step reasoning for complex problems",
+      "alwaysLoad": true,
 {{- if eq .Platform "windows"}}
       "command": "cmd.exe",
       "args": ["/c", "npx -y @modelcontextprotocol/server-sequential-thinking"]


### PR DESCRIPTION
## Summary
- Claude Code v2.1.119 `.mcp.json` mcpServers entries에 추가된 `alwaysLoad: true` 필드 통합
- Context7, Sequential Thinking 두 utility MCP 서버에 `alwaysLoad: true` 부여 (자주 호출 + 작은 schema → 사전 로드 이득)
- moai-lsp는 lazy-load 유지 (큰 schema, 항상 필요하지는 않음)

## SPEC
- ID: SPEC-CC2122-MCP-001
- Status: draft → in_review (PR 머지 후 completed)
- Plan Audit: 본 세션 컨텍스트 효율을 위해 생략 (5 EARS / 5 GWT 의 작은 SPEC, manual 검증으로 갈음). PR review 시 plan-auditor 호출 권장.

## Changes
- \`internal/template/templates/.mcp.json.tmpl\`: context7, sequential-thinking 두 entry에 \`\"alwaysLoad\": true\` 추가
- \`internal/template/settings_test.go\`: 4개 테스트 케이스 (TestMCPTemplateAlwaysLoadOnContext7, OnSequentialThinking, AbsentOnMoaiLSP, ExistingFieldsPreserved)
- \`.claude/rules/moai/core/settings-management.md\` + 템플릿 mirror: v2.1.119 alwaysLoad 노트 추가 (한국어)
- \`.moai/specs/SPEC-CC2122-MCP-001/\`: SPEC + plan + acceptance

## Commits (TDD)
- \`d27c70bab\` test(template): RED M3 — alwaysLoad 4개 테스트 케이스 추가
- \`a11bb472a\` feat(template): GREEN M2 — context7, sequential-thinking에 alwaysLoad 적용
- \`450661684\` docs(template): M4 — settings-management.md v2.1.119 alwaysLoad 노트

## Test Plan
- [x] \`go test ./internal/template/...\` → PASS (4개 신규 + 기존 모두)
- [x] \`go test ./...\` (full suite) → PASS, regression 없음
- [x] \`go vet ./...\` → clean
- [x] Template-First: internal/template/templates/ 우선, local mirror 동기화 (CLAUDE.local.md §2 준수)

## Related
- 자매 PR: #752 (SPEC-CC2122-STATUSLINE-001 — P2)
- 자매 PR: #753 (SPEC-CC2122-HOOK-001 — P1)
- v2.1.119-122 통합 시리즈 P0 단위

## Merge Strategy
- [x] Squash merge (feature branch convention per CLAUDE.local.md §18.3)

🗿 MoAI <email@mo.ai.kr>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated MCP server docs to document the new `alwaysLoad` option and recommended defaults.

* **New Features**
  * `context7` and `sequential-thinking` MCP tools now load at session start; `moai-lsp` remains deferred.

* **Tests**
  * Added tests validating `alwaysLoad` semantics, preservation of existing server settings, and cross-platform compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->