### PR TITLE
chore(ci): label-sync workflow 추가 — labels.yml → repo 동기화

### DIFF
--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -1,0 +1,51 @@
+# Label Sync Workflow
+#
+# Synchronizes .github/labels.yml to the GitHub repository labels.
+# Triggers:
+#   - Manual: workflow_dispatch (admin-initiated, dry-run support)
+#   - Automatic: push to main when .github/labels.yml or this workflow file changes
+#
+# Reference: CLAUDE.local.md §18.6 (3축 라벨 체계)
+# Source of truth: .github/labels.yml
+
+name: Label Sync
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Preview changes without applying (true/false)"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "true"
+          - "false"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/labels.yml"
+      - ".github/workflows/label-sync.yml"
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
+jobs:
+  sync:
+    name: Sync repository labels from labels.yml
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Sync labels
+        uses: EndBug/label-sync@v2
+        with:
+          config-file: .github/labels.yml
+          # delete-other-labels: false — preserve labels not in labels.yml (e.g., bot-managed labels)
+          # request-options: see https://github.com/EndBug/label-sync for advanced behavior
+          dry-run: ${{ github.event.inputs.dry_run || 'false' }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

`.github/labels.yml`에 §18.6 3축 라벨 체계(`type:*` / `priority:P*` / `area:*`)가 이미 완전 정의되어 있으나 GitHub repo에는 sync되지 않은 상태입니다. 그 결과 최근 PR들(#757 등)에 `area:lsp` / `priority:P1` 같은 라벨 부착이 \"label not found\" 오류로 실패했습니다.

## Solution

EndBug/label-sync@v2 기반 workflow 추가:

- **workflow_dispatch**: 수동 트리거 (dry-run 옵션 포함, admin이 의도적으로 실행)
- **push to main**: `.github/labels.yml` 변경 시 자동 sync
- **delete-other-labels: false**: bot이 관리하는 라벨(예: `coderabbit`)은 보존

## Post-merge action (admin 필요)

1. main 머지 후 Actions 탭에서 \"Label Sync\" workflow 실행 (또는 dry-run 먼저 검증)
2. 약 30개 라벨이 새로 생성됨:
   - `type:*` 8개 (feature, fix, docs, chore, ci, refactor, security, test)
   - `priority:P*` 5개 (P0~P4)
   - `area:*` 12개 (mx, astgrep, lsp, hooks, docs-site, templates, cli, config, workflow, ci, security, deps)
   - `status:*` 4개 (in-progress, review, blocked, needs-info)

## Verification

PR 자체는 workflow 파일만 추가하므로 CI 위험 거의 없음. 단 머지 후 첫 push 트리거가 정상 동작하는지 확인 필요.

## Test plan

- [x] Workflow YAML 문법 검증 (push 시 GitHub Actions parser 자동 검증)
- [ ] 머지 후 admin이 dry-run 실행 → 30개 라벨 추가 예정 확인
- [ ] 실제 sync 실행 → 라벨 활성화
- [ ] 후속 PR(#757, #758 등)에 3축 라벨 부착 가능 확인

## Merge Strategy

- type:chore · area:ci
- Squash merge (단일 workflow 추가)

🗿 MoAI <email@mo.ai.kr>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced an automated workflow for synchronizing GitHub issue and pull request labels from configuration files. The workflow can be manually triggered with a dry-run preview mode to review label changes before applying them, or automatically runs whenever label configuration is updated. This ensures consistent label management across your repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->