### PR TITLE
feat(hook): yaml config + agents disallowedTools 정적 linter (SPEC-CC2122-HOOK-002)

### DIFF
--- a/.moai/specs/SPEC-CC2122-HOOK-002/spec.md
+++ b/.moai/specs/SPEC-CC2122-HOOK-002/spec.md
@@ -1,0 +1,85 @@
+# SPEC-CC2122-HOOK-002: HOOK-001 Follow-up (REQ-007 + REQ-008)
+
+## Status: DRAFT
+
+## Overview
+
+SPEC-CC2122-HOOK-001 의 follow-up. 다음 두 요구사항을 완성한다:
+
+1. **REQ-007** (yaml config read): `slow_hook_threshold_ms` 임계값을 hardcoded 5000ms 가 아닌 `.moai/config/sections/observability.yaml` 의 `observability.hook_metrics.slow_hook_threshold_ms` 에서 읽도록 한다.
+2. **REQ-008** (CG Mode disallowedTools regression guard): 에이전트 frontmatter `disallowedTools:` 가 현실적으로 유효한 형식을 갖추고 있는지 정적으로 검증한다. 실제 `claude --print` 실행은 dev 프로젝트의 GLM 통합 테스트 금지 정책(CLAUDE.local.md §13)에 따라 별도 manual 검증으로 분리한다.
+
+## Requirements
+
+### REQ-CC2122-HOOK-002-001 (REQ-007 implementation)
+
+[WHEN] `writeHookMetric` 가 호출되고 `.moai/config/sections/observability.yaml` 가 존재하며 `observability.hook_metrics.slow_hook_threshold_ms` 가 양의 정수로 정의되어 있을 때
+[THEN] 시스템은 해당 값을 임계값으로 사용해야 한다 (hardcoded 5000ms 보다 우선)
+
+### REQ-CC2122-HOOK-002-002
+
+[WHEN] `.moai/config/sections/observability.yaml` 가 부재하거나 yaml 파싱이 실패하거나 키가 누락된 경우
+[THEN] 시스템은 hardcoded 기본값 5000ms 로 fallback 해야 하며 panic 또는 stderr 출력 없이 정상 동작해야 한다
+
+### REQ-CC2122-HOOK-002-003
+
+[WHEN] yaml 의 `slow_hook_threshold_ms` 값이 0 이하 또는 비-숫자형인 경우
+[THEN] 시스템은 hardcoded 기본값 5000ms 로 fallback 해야 한다 (의도적 invalid value 보호)
+
+### REQ-CC2122-HOOK-002-004 (REQ-008 static linter)
+
+[WHEN] `internal/template/templates/.claude/agents/**/*.md` 의 frontmatter 가 파싱될 때
+[THEN] 모든 에이전트 정의는 다음 두 조건 중 하나를 충족해야 한다:
+- `tools:` 만 정의 (allowlist 모드)
+- `disallowedTools:` 만 정의 (denylist 모드)
+- 동시 정의 금지 (mutual exclusion, claude-code v2.1.119+ 사양)
+
+### REQ-CC2122-HOOK-002-005
+
+[WHEN] `disallowedTools:` 가 정의되어 있을 때
+[THEN] 값은 CSV 문자열 형식(공백 구분 금지) 이어야 한다 (CLAUDE.local.md §12 규칙)
+
+### REQ-CC2122-HOOK-002-006
+
+[WHEN] CI 또는 로컬에서 `go test ./internal/...` 가 실행될 때
+[THEN] 위 정적 검증은 단위 테스트로 자동 실행되어야 한다 (수동 step 불요)
+
+## Out of Scope
+
+- **실제 `claude --print` 동시 실행 회귀 테스트**: dev 프로젝트의 GLM 통합 테스트 금지 정책(§13). 별도 manual smoke test 스크립트(`scripts/manual-cg-disallowed-test.sh`)로 분리하거나 CI 별도 job 으로 향후 처리.
+- **observability.yaml 의 다른 필드(retention_days, max_file_size_mb 등) yaml read**: 현재 hook 메트릭 코드 외 사용처가 없으므로 불필요. SPEC-OBS 별 SPEC 으로 분리 가능.
+- **runtime config hot-reload**: 매 hook 호출마다 yaml 재읽기 — 단순화를 위해 채택 (sync.Once 캐싱 없음). 성능 영향 없음(파일 크기 < 1KB).
+
+## Acceptance Criteria
+
+- AC-001: `internal/hook/post_tool_duration.go` 가 `loadSlowHookThreshold(projectRoot string) int64` helper 를 호출하여 yaml 우선, fallback default 동작
+- AC-002: `loadSlowHookThreshold` 단위 테스트 4건 (file present + valid / file absent / file malformed / invalid value)
+- AC-003: 기존 `post_tool_duration_test.go` 의 4건 회귀 테스트 모두 PASS (default 5000ms 동작 보존)
+- AC-004: `internal/template/templates/.claude/agents/` validator 단위 테스트 추가, 모든 agent .md 파일 frontmatter 검증
+- AC-005: `go test ./internal/hook/... ./internal/template/...` 단일 명령으로 새 테스트 모두 실행
+
+## Files Affected
+
+**수정:**
+- `internal/hook/post_tool_duration.go` (loadSlowHookThreshold helper 추가, writeHookMetric 통합)
+
+**신규:**
+- `internal/hook/post_tool_duration_threshold_test.go` (yaml read 단위 테스트)
+- `internal/template/agents_frontmatter_test.go` (REQ-008 정적 linter, 새 테스트 파일)
+- `scripts/manual-cg-disallowed-test.sh` (선택 — manual smoke test 스크립트)
+
+**무수정 (검증):**
+- `internal/template/templates/.moai/config/sections/observability.yaml` (이미 정의됨)
+- `internal/hook/types.go` (HookInput 변경 없음)
+
+## Methodology
+
+TDD (RED-GREEN-REFACTOR) — REQ-007 yaml read 는 테스트 우선 작성. REQ-008 static linter 는 단순한 표 기반 검증이라 테스트가 곧 명세.
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| yaml parse 실패가 panic 으로 전파 | Low | recover() 또는 명시적 error swallow + default fallback |
+| agent frontmatter 검증이 기존 agent 파일에서 fail | Medium | 검증 추가 전 1회 audit 후 위반 케이스 사전 수정 |
+| Manual smoke test 가 실제로 수행되지 않음 | Medium | 스크립트 + README 가이드만 제공, CI 강제 안 함 (follow-up) |

--- a/internal/hook/post_tool_duration.go
+++ b/internal/hook/post_tool_duration.go
@@ -6,14 +6,62 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"gopkg.in/yaml.v3"
 )
 
-// slowHookThresholdMs는 메트릭 기록을 트리거하는 기본 임계값(밀리초)이다.
-// REQ-CC2122-HOOK-001-004
-const slowHookThresholdMs = 5000
+// defaultSlowHookThresholdMs는 yaml 설정이 없거나 invalid 일 때 사용되는
+// 기본 임계값(밀리초)이다.
+// REQ-CC2122-HOOK-001-004 (default), REQ-CC2122-HOOK-002-002 (fallback)
+const defaultSlowHookThresholdMs int64 = 5000
 
 // hookMetricsRelPath는 프로젝트 루트에서 메트릭 파일까지의 상대 경로이다.
 const hookMetricsRelPath = ".moai/observability/hook-metrics.jsonl"
+
+// observabilityConfigRelPath는 yaml 설정 파일의 프로젝트 루트 기준 상대 경로이다.
+const observabilityConfigRelPath = ".moai/config/sections/observability.yaml"
+
+// observabilityConfig는 observability.yaml 의 hook_metrics 섹션 구조이다.
+// 다른 필드(trace_dir, retention_days 등)는 본 helper의 관심사가 아니므로 무시된다.
+type observabilityConfig struct {
+	Observability struct {
+		HookMetrics struct {
+			SlowHookThresholdMs int64 `yaml:"slow_hook_threshold_ms"`
+		} `yaml:"hook_metrics"`
+	} `yaml:"observability"`
+}
+
+// loadSlowHookThreshold는 .moai/config/sections/observability.yaml 에서
+// observability.hook_metrics.slow_hook_threshold_ms 를 읽어 반환한다.
+//
+// 다음 경우 모두 defaultSlowHookThresholdMs (5000ms) 로 fallback 한다:
+//   - 파일 부재
+//   - yaml 파싱 실패
+//   - 키 누락
+//   - 0 이하의 invalid 값
+//
+// REQ-CC2122-HOOK-002-001 (yaml 우선), REQ-CC2122-HOOK-002-002 (fallback),
+// REQ-CC2122-HOOK-002-003 (invalid value 보호)
+//
+// 호출 빈도가 낮고 (slow hook 발생 시에만) 파일 크기가 작아서 (< 1KB)
+// 캐싱 없이 매 호출 시 yaml 을 다시 읽어도 성능 영향이 없다.
+func loadSlowHookThreshold(projectRoot string) int64 {
+	if projectRoot == "" {
+		return defaultSlowHookThresholdMs
+	}
+	data, err := os.ReadFile(filepath.Join(projectRoot, observabilityConfigRelPath))
+	if err != nil {
+		return defaultSlowHookThresholdMs
+	}
+	var cfg observabilityConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return defaultSlowHookThresholdMs
+	}
+	if cfg.Observability.HookMetrics.SlowHookThresholdMs <= 0 {
+		return defaultSlowHookThresholdMs
+	}
+	return cfg.Observability.HookMetrics.SlowHookThresholdMs
+}
 
 // hookDurationEntry는 hook-metrics.jsonl에 기록되는 JSON 라인 구조이다.
 // REQ-CC2122-HOOK-001-002
@@ -52,13 +100,16 @@ func extractDurationMs(input *HookInput) float64 {
 // 존재할 때 hook-metrics.jsonl에 1줄을 원자적으로 추가한다.
 // 디렉토리 부재 시 조용히 건너뛴다 (exit 0 보장).
 // REQ-CC2122-HOOK-001-002, REQ-CC2122-HOOK-001-003, REQ-CC2122-HOOK-001-004
+// REQ-CC2122-HOOK-002-001: 임계값은 observability.yaml 우선, default fallback
 func writeHookMetric(input *HookInput, hookName, outcome string) {
+	projectRoot := resolveProjectRoot(input)
+
+	threshold := loadSlowHookThreshold(projectRoot)
 	durationMs := extractDurationMs(input)
-	if durationMs <= slowHookThresholdMs {
+	if durationMs <= float64(threshold) {
 		return
 	}
 
-	projectRoot := resolveProjectRoot(input)
 	if projectRoot == "" {
 		return
 	}

--- a/internal/hook/post_tool_duration_threshold_test.go
+++ b/internal/hook/post_tool_duration_threshold_test.go
@@ -1,0 +1,190 @@
+package hook
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// @MX:NOTE: [AUTO] post_tool_duration_threshold_test.go — REQ-CC2122-HOOK-002 yaml read
+// @MX:SPEC: SPEC-CC2122-HOOK-002 REQ-001/002/003
+
+// writeObservabilityYAML는 테스트용 observability.yaml을 작성한다.
+func writeObservabilityYAML(t *testing.T, projectRoot, content string) {
+	t.Helper()
+	dir := filepath.Join(projectRoot, ".moai", "config", "sections")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("config 디렉토리 생성 실패: %v", err)
+	}
+	path := filepath.Join(dir, "observability.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("observability.yaml 작성 실패: %v", err)
+	}
+}
+
+// TestLoadSlowHookThreshold_Default는 yaml 파일이 부재할 때 default(5000ms)를 반환하는지 검증한다.
+// REQ-CC2122-HOOK-002-002
+func TestLoadSlowHookThreshold_Default(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	got := loadSlowHookThreshold(dir)
+	if got != defaultSlowHookThresholdMs {
+		t.Errorf("loadSlowHookThreshold = %d, want %d (default)", got, defaultSlowHookThresholdMs)
+	}
+}
+
+// TestLoadSlowHookThreshold_CustomValue는 yaml 에 정의된 양의 정수를 우선 반환하는지 검증한다.
+// REQ-CC2122-HOOK-002-001
+func TestLoadSlowHookThreshold_CustomValue(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeObservabilityYAML(t, dir, `
+observability:
+  enabled: true
+  hook_metrics:
+    slow_hook_threshold_ms: 7500
+    output_path: .moai/observability/hook-metrics.jsonl
+`)
+
+	got := loadSlowHookThreshold(dir)
+	if got != 7500 {
+		t.Errorf("loadSlowHookThreshold = %d, want 7500", got)
+	}
+}
+
+// TestLoadSlowHookThreshold_MalformedYAML는 yaml 파싱 실패 시 default 로 fallback 하는지 검증한다.
+// REQ-CC2122-HOOK-002-002
+func TestLoadSlowHookThreshold_MalformedYAML(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeObservabilityYAML(t, dir, "this: is: not: valid: yaml: ::")
+
+	got := loadSlowHookThreshold(dir)
+	if got != defaultSlowHookThresholdMs {
+		t.Errorf("loadSlowHookThreshold = %d, want %d (default fallback for malformed yaml)", got, defaultSlowHookThresholdMs)
+	}
+}
+
+// TestLoadSlowHookThreshold_InvalidValue는 0 이하 또는 음수 값일 때 default 로 fallback 하는지 검증한다.
+// REQ-CC2122-HOOK-002-003
+func TestLoadSlowHookThreshold_InvalidValue(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		content string
+	}{
+		{
+			name: "zero",
+			content: `
+observability:
+  hook_metrics:
+    slow_hook_threshold_ms: 0
+`,
+		},
+		{
+			name: "negative",
+			content: `
+observability:
+  hook_metrics:
+    slow_hook_threshold_ms: -100
+`,
+		},
+		{
+			name: "missing_key",
+			content: `
+observability:
+  hook_metrics:
+    output_path: .moai/observability/hook-metrics.jsonl
+`,
+		},
+		{
+			name: "empty_file",
+			content: ``,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			writeObservabilityYAML(t, dir, tc.content)
+
+			got := loadSlowHookThreshold(dir)
+			if got != defaultSlowHookThresholdMs {
+				t.Errorf("loadSlowHookThreshold = %d, want %d (default fallback)", got, defaultSlowHookThresholdMs)
+			}
+		})
+	}
+}
+
+// TestLoadSlowHookThreshold_EmptyProjectRoot는 projectRoot가 빈 문자열일 때 default를 반환하는지 검증한다.
+func TestLoadSlowHookThreshold_EmptyProjectRoot(t *testing.T) {
+	t.Parallel()
+
+	got := loadSlowHookThreshold("")
+	if got != defaultSlowHookThresholdMs {
+		t.Errorf("loadSlowHookThreshold(\"\") = %d, want %d", got, defaultSlowHookThresholdMs)
+	}
+}
+
+// TestPostToolDuration_HonorsCustomThreshold는 yaml 에 정의된 임계값(2000ms)이
+// hardcoded default(5000ms)보다 우선 적용되는지 통합 검증한다.
+// duration_ms=3000 일 때:
+//   - default(5000) 기준: skip
+//   - custom(2000) 기준: write
+// 따라서 yaml read가 정상 동작하면 메트릭이 기록되어야 한다.
+// REQ-CC2122-HOOK-002-001 (E2E 검증)
+func TestPostToolDuration_HonorsCustomThreshold(t *testing.T) {
+	dir := t.TempDir()
+
+	obsDir := filepath.Join(dir, ".moai", "observability")
+	if err := os.MkdirAll(obsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// custom threshold = 2000ms (default보다 낮음)
+	writeObservabilityYAML(t, dir, `
+observability:
+  enabled: true
+  hook_metrics:
+    slow_hook_threshold_ms: 2000
+    output_path: .moai/observability/hook-metrics.jsonl
+`)
+
+	t.Setenv("CLAUDE_PROJECT_DIR", dir)
+
+	// 3000ms: default 5000 기준 skip, custom 2000 기준 write
+	raw, _ := json.Marshal(map[string]any{"success": true, "duration_ms": int64(3000)})
+	input := &HookInput{
+		SessionID:     "sess-custom-threshold-001",
+		ToolName:      "Bash",
+		HookEventName: "PostToolUse",
+		CWD:           dir,
+		ToolResponse:  raw,
+	}
+
+	h := NewPostToolHandler()
+	out, err := h.Handle(context.Background(), input)
+	if err != nil {
+		t.Fatalf("Handle 에러: %v", err)
+	}
+	if out == nil {
+		t.Fatal("Handle nil 반환")
+	}
+
+	metricsPath := filepath.Join(obsDir, "hook-metrics.jsonl")
+	if _, err := os.Stat(metricsPath); os.IsNotExist(err) {
+		t.Fatal("custom threshold(2000ms)이 적용되지 않음 — duration_ms=3000 이지만 메트릭 미기록")
+	}
+
+	entries := readMetricsJSONL(t, metricsPath)
+	if len(entries) != 1 {
+		t.Fatalf("메트릭 엔트리 수 = %d, want 1 (custom threshold 적용 시 기록되어야 함)", len(entries))
+	}
+	if entries[0].DurationMs != 3000 {
+		t.Errorf("duration_ms = %v, want 3000", entries[0].DurationMs)
+	}
+}

--- a/internal/template/agents_frontmatter_test.go
+++ b/internal/template/agents_frontmatter_test.go
@@ -1,0 +1,183 @@
+package template
+
+import (
+	"fmt"
+	"io/fs"
+	"strings"
+	"testing"
+)
+
+// @MX:NOTE: [AUTO] agents_frontmatter_test.go — REQ-CC2122-HOOK-002 정적 linter
+// @MX:SPEC: SPEC-CC2122-HOOK-002 REQ-004/005/006
+//
+// 이 테스트는 .claude/agents/**/*.md 의 frontmatter 가 다음 규칙을 준수하는지
+// 정적으로 검증한다:
+//   1. tools 와 disallowedTools 는 mutually exclusive (claude-code v2.1.119+ 사양)
+//   2. disallowedTools 가 정의된 경우 CSV 문자열 형식이어야 함 (공백 구분 금지)
+//   3. tools 가 정의된 경우 CSV 문자열 형식이어야 함 (CLAUDE.local.md §12)
+//
+// 실제 `claude --print` 회귀 테스트는 GLM 통합 테스트 정책(CLAUDE.local.md §13)
+// 으로 별도 manual 검증 분리.
+
+// validateToolsCSVFormat는 tools 또는 disallowedTools 필드 값이 CSV 형식인지 검증한다.
+// 빈 값은 허용 (필드 부재로 간주).
+// YAML 배열 syntax([...]) 는 금지.
+// 공백만으로 분리된 다중 토큰은 금지 (콤마 분리 필수).
+//
+// 반환: 위반 시 에러 메시지, 정상 시 빈 문자열.
+func validateToolsCSVFormat(field, value string) string {
+	if value == "" {
+		return ""
+	}
+
+	trimmed := strings.TrimSpace(value)
+
+	// YAML 배열 syntax 금지: "[A, B, C]" 형태는 frontmatter parser 가 그대로 문자열로 캡처함.
+	if strings.HasPrefix(trimmed, "[") {
+		return fmt.Sprintf("%s 값이 YAML 배열 syntax 로 시작함 (CSV 문자열 필수): %q", field, value)
+	}
+
+	// 콤마 없이 공백 구분된 다중 토큰은 위반 (예: "Read Write Edit").
+	// 단일 토큰(예: "Read")은 허용.
+	hasComma := strings.Contains(trimmed, ",")
+	hasMultipleTokens := len(strings.Fields(trimmed)) > 1
+	if hasMultipleTokens && !hasComma {
+		return fmt.Sprintf("%s 값이 공백 구분으로 보임 (CSV 형식 필수, 콤마 분리): %q", field, value)
+	}
+
+	return ""
+}
+
+// collectAgentFiles는 embedded templates 에서 .claude/agents/ 하위 모든 .md 파일을 수집한다.
+func collectAgentFiles(t *testing.T) []string {
+	t.Helper()
+
+	fsys, err := EmbeddedTemplates()
+	if err != nil {
+		t.Fatalf("EmbeddedTemplates() error: %v", err)
+	}
+
+	var agentFiles []string
+	walkErr := fs.WalkDir(fsys, ".claude/agents", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if strings.HasSuffix(path, ".md") || strings.HasSuffix(path, ".md.tmpl") {
+			agentFiles = append(agentFiles, path)
+		}
+		return nil
+	})
+	if walkErr != nil {
+		t.Fatalf("WalkDir error: %v", walkErr)
+	}
+
+	if len(agentFiles) == 0 {
+		t.Fatal("no agent files found under .claude/agents/")
+	}
+	return agentFiles
+}
+
+// TestAgentsFrontmatter_ToolsDisallowedMutualExclusion verifies that no agent
+// definition declares both `tools:` and `disallowedTools:` simultaneously.
+// REQ-CC2122-HOOK-002-004
+func TestAgentsFrontmatter_ToolsDisallowedMutualExclusion(t *testing.T) {
+	t.Parallel()
+
+	fsys, err := EmbeddedTemplates()
+	if err != nil {
+		t.Fatalf("EmbeddedTemplates() error: %v", err)
+	}
+
+	for _, path := range collectAgentFiles(t) {
+		t.Run(path, func(t *testing.T) {
+			data, readErr := fs.ReadFile(fsys, path)
+			if readErr != nil {
+				t.Fatalf("ReadFile(%q) error: %v", path, readErr)
+			}
+
+			fm, _, parseErr := parseFrontmatterAndBody(string(data))
+			if parseErr != "" {
+				t.Fatalf("frontmatter 파싱 실패: %s", parseErr)
+			}
+
+			_, hasTools := fm["tools"]
+			_, hasDisallowed := fm["disallowedTools"]
+
+			if hasTools && hasDisallowed {
+				t.Errorf("REQ-CC2122-HOOK-002-004 위반: tools 와 disallowedTools 가 동시 정의됨. claude-code v2.1.119+ 에서는 mutually exclusive 이어야 함.")
+			}
+		})
+	}
+}
+
+// TestAgentsFrontmatter_ToolsCSVFormat verifies that `tools:` and `disallowedTools:`
+// values follow CSV format (no whitespace-only separator, no array syntax).
+// REQ-CC2122-HOOK-002-005
+func TestAgentsFrontmatter_ToolsCSVFormat(t *testing.T) {
+	t.Parallel()
+
+	fsys, err := EmbeddedTemplates()
+	if err != nil {
+		t.Fatalf("EmbeddedTemplates() error: %v", err)
+	}
+
+	for _, path := range collectAgentFiles(t) {
+		t.Run(path, func(t *testing.T) {
+			data, readErr := fs.ReadFile(fsys, path)
+			if readErr != nil {
+				t.Fatalf("ReadFile(%q) error: %v", path, readErr)
+			}
+
+			fm, _, parseErr := parseFrontmatterAndBody(string(data))
+			if parseErr != "" {
+				t.Fatalf("frontmatter 파싱 실패: %s", parseErr)
+			}
+
+			if msg := validateToolsCSVFormat("tools", fm["tools"]); msg != "" {
+				t.Errorf("REQ-CC2122-HOOK-002-005 위반: %s", msg)
+			}
+			if msg := validateToolsCSVFormat("disallowedTools", fm["disallowedTools"]); msg != "" {
+				t.Errorf("REQ-CC2122-HOOK-002-005 위반: %s", msg)
+			}
+		})
+	}
+}
+
+// TestValidateToolsCSVFormat_Cases는 validateToolsCSVFormat 헬퍼 자체가 정확히
+// 동작하는지 단위 검증한다. 향후 frontmatter validator 가 강화될 때 회귀 방지 목적.
+// REQ-CC2122-HOOK-002-006
+func TestValidateToolsCSVFormat_Cases(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		field     string
+		value     string
+		wantFails bool
+	}{
+		{name: "empty", field: "tools", value: "", wantFails: false},
+		{name: "single_tool", field: "tools", value: "Read", wantFails: false},
+		{name: "csv_with_space", field: "tools", value: "Read, Write, Edit", wantFails: false},
+		{name: "csv_no_space", field: "disallowedTools", value: "Bash,Write", wantFails: false},
+		{name: "long_csv", field: "tools", value: "Read, Write, Edit, Grep, Glob, Bash, TodoWrite, Skill, mcp__sequential-thinking__sequentialthinking", wantFails: false},
+		{name: "yaml_array", field: "tools", value: "[Read, Write]", wantFails: true},
+		{name: "yaml_array_with_space", field: "tools", value: "[ Read, Write ]", wantFails: true},
+		{name: "space_separated", field: "tools", value: "Read Write Edit", wantFails: true},
+		{name: "two_tokens_space", field: "disallowedTools", value: "Bash Write", wantFails: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			msg := validateToolsCSVFormat(tc.field, tc.value)
+			gotFails := msg != ""
+			if gotFails != tc.wantFails {
+				t.Errorf("validateToolsCSVFormat(%q, %q) gotFails=%v (msg=%q), want %v",
+					tc.field, tc.value, gotFails, msg, tc.wantFails)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

SPEC-CC2122-HOOK-001 의 follow-up REQ-007/008 을 완성합니다.

### REQ-007 — `slow_hook_threshold_ms` yaml read

기존 hardcoded `5000ms` 임계값을 `.moai/config/sections/observability.yaml` 의 `observability.hook_metrics.slow_hook_threshold_ms` 에서 읽도록 변경.

- 새 helper: `loadSlowHookThreshold(projectRoot string) int64`
- 우선순위: yaml 값 > hardcoded default(5000ms)
- Fallback 조건: 파일 부재 / 파싱 실패 / 0 이하 invalid 값 → default
- 캐싱 없음 (파일 < 1KB, slow hook 호출 빈도 낮음)

### REQ-008 — CG Mode disallowedTools 정적 linter

claude-code v2.1.119+ 에서 `claude --print` 가 에이전트 frontmatter `disallowedTools:` 를 준수하게 됨에 따른 회귀 방지.

- 23개 agent .md 파일을 정적 검증:
  1. `tools:` 와 `disallowedTools:` 동시 정의 금지 (mutually exclusive)
  2. 값은 CSV 문자열 형식 필수 (YAML 배열 `[A, B]` 또는 공백 구분 `A B C` 금지)
- 실제 `claude --print` 통합 테스트는 dev 프로젝트 GLM 정책(CLAUDE.local.md §13) 으로 분리

## Files Changed

| File | Change |
|------|--------|
| `internal/hook/post_tool_duration.go` | `loadSlowHookThreshold` helper 추가, `writeHookMetric` 통합 |
| `internal/hook/post_tool_duration_threshold_test.go` | REQ-007 테스트 6건 (신규) |
| `internal/template/agents_frontmatter_test.go` | REQ-008 정적 linter + self-test (신규) |
| `.moai/specs/SPEC-CC2122-HOOK-002/spec.md` | EARS 6건 + AC 5건 + 영향 분석 (신규) |

## Test plan

- [x] `TestLoadSlowHookThreshold_*` 6/6 PASS (default / custom / malformed / invalid / empty / E2E)
- [x] `TestAgentsFrontmatter_*` 46/46 PASS (23 agent × 2 검증)
- [x] `TestValidateToolsCSVFormat_Cases` 9/9 PASS
- [x] 기존 hook + template 회귀 모두 PASS
- [x] `golangci-lint run ./internal/hook/... ./internal/template/...` — 0 issues

## Out of Scope

- 실제 `claude --print` 동시 실행 회귀 테스트 → dev 프로젝트 GLM 정책으로 별도 manual 분리
- `observability.yaml` 의 다른 필드(retention_days 등) yaml read → 사용처 없음, SPEC-OBS 별도 SPEC 으로 분리 가능
- runtime hot-reload → 매 호출 재읽기로 충분 (성능 영향 없음)

## Merge Strategy

- type:feature · area:hooks · priority:P2
- Squash merge (단일 feature 브랜치)

🗿 MoAI <email@mo.ai.kr>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Hook metrics slow operation threshold is now configurable through the observability configuration file, with automatic fallback to sensible defaults when configuration is missing or malformed.

* **Validation**
  * Agent tool configurations now validated for correct formatting and to prevent conflicting tool and disallowed-tools declarations in the same agent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->