### PR TITLE
fix(lsp): ETXTBSY hotfix — TestMain eager 초기화 (SPEC-LSP-FLAKY-002)

### DIFF
--- a/.moai/specs/SPEC-LSP-FLAKY-002/spec.md
+++ b/.moai/specs/SPEC-LSP-FLAKY-002/spec.md
@@ -1,0 +1,85 @@
+# SPEC-LSP-FLAKY-002: LSP Launcher ETXTBSY Eager Initialization Hotfix
+
+## Status: DRAFT
+
+## Overview
+
+SPEC-LSP-FLAKY-001 (PR #757) 머지 후에도 Ubuntu CI 에서 동일한 ETXTBSY flake 가 PR #758 에서 재발했다:
+
+```
+launcher_test.go:37: Launch returned unexpected error: subprocess.Launch
+"/tmp/moai-lsp-subprocess-test-1440849762/shared-fake-lsp": start: fork/exec
+/tmp/moai-lsp-subprocess-test-1440849762/shared-fake-lsp: text file busy
+```
+
+## Root Cause Analysis (정정)
+
+SPEC-001 의 진단이 부분적으로 틀렸다. 실제 race 는 다음과 같다:
+
+1. SPEC-001 의 `sharedBinaryPath` 는 `sync.OnceValues` 로 **lazy** 초기화됨
+2. 따라서 첫 테스트 goroutine 이 `t.Parallel()` 진입 후에 binary write 를 시작함
+3. 같은 패키지의 `supervisor_test.go` 도 t.Parallel() 로 자체 fake binary 를 동시에 작성하고 cmd.Start() 를 호출함
+4. supervisor goroutine 이 fork() 할 때, launcher 의 `OnceValues` 안에서 열린 writer fd (`shared-fake-lsp` 의 writer) 가 supervisor 의 fork 자식에게 inherit 됨
+5. supervisor 자식이 자기 binary 를 exec 하기 전 짧은 윈도우에 launcher 의 다른 goroutine 이 `cmd.Start(shared-fake-lsp)` 를 호출
+6. 커널이 inode 를 검사: shared-fake-lsp 가 누군가 (supervisor fork 자식) 에게 writer 로 열려 있음 → ETXTBSY
+
+핵심: O_CLOEXEC 는 exec 시점에만 fd 를 닫는데, **fork 와 exec 사이의 윈도우** 는 닫지 못한다. 그 윈도우가 ETXTBSY race 의 본질이다.
+
+## Solution Strategy (수정)
+
+**Eager initialization in TestMain**: lazy `sync.OnceValues` 를 제거하고, `TestMain` 의 `m.Run()` 호출 *이전* 에 binary 를 작성한다.
+
+이 시점에는:
+- 어떤 `t.Parallel()` goroutine 도 시작되지 않음
+- 따라서 어떤 fork() 도 발생할 수 없음
+- 따라서 어떤 자식 프로세스도 writer fd 를 inherit 할 수 없음
+
+`m.Run()` 진입 시점에는 모든 writer fd 가 이미 닫힌 상태이므로 race window 자체가 존재하지 않는다.
+
+## Requirements
+
+### REQ-LSP-FLAKY-002-001
+
+[WHEN] `internal/lsp/subprocess` 패키지의 테스트 프로세스가 시작될 때
+[THEN] `TestMain` 은 `m.Run()` 호출 전에 fake LSP stub binary 를 패키지 전역 경로에 1회 작성하고, 모든 writer fd 를 닫아야 한다
+
+### REQ-LSP-FLAKY-002-002
+
+[WHEN] `sharedFakeBinaryPath(t)` 가 임의의 t.Parallel() 테스트에서 호출될 때
+[THEN] 함수는 `pkgSharedBinaryPath` 변수의 값을 즉시 반환하며 어떤 file write 도 발생하지 않아야 한다
+
+### REQ-LSP-FLAKY-002-003
+
+[WHEN] `m.Run()` 이 진입한 이후 어떤 테스트 goroutine 도 `shared-fake-lsp` 에 write 하지 않아야 한다 (read+exec only)
+
+### REQ-LSP-FLAKY-002-004
+
+[WHEN] CI Ubuntu race detector 단계가 5회 연속 실행될 때
+[THEN] launcher 패키지 테스트가 모두 green 이어야 하며 어떤 ETXTBSY 실패도 발생하지 않아야 한다
+
+## Files Affected
+
+**수정:**
+- `internal/lsp/subprocess/launcher_main_test.go` (sync.OnceValues 제거, eager init 도입)
+
+**무수정 (검증):**
+- `internal/lsp/subprocess/launcher_test.go` (호출 시그니처 동일, 변경 불요)
+- `internal/lsp/subprocess/launcher.go`
+- `internal/lsp/subprocess/supervisor.go`
+- `internal/lsp/subprocess/supervisor_test.go`
+
+## Acceptance Criteria
+
+- AC-001: `launcher_main_test.go` 에서 `sync.OnceValues` 제거, `TestMain` 이 `m.Run()` 전에 binary 작성
+- AC-002: `pkgSharedBinaryPath` 패키지 변수가 m.Run() 진입 시점에 절대 경로로 초기화되어 있음
+- AC-003: 로컬 `go test -race -count=20 ./internal/lsp/subprocess/...` 20회 연속 PASS
+- AC-004: PR CI Ubuntu race detector 5회 연속 PASS
+
+## Out of Scope
+
+- supervisor_test.go 의 `writeFakeBinaryContent` 자체적으로는 race 를 유발하지 않음 (각자 고유 file 작성). 단, 그들이 launcher binary 의 writer fd 를 inherit 할 수 있는 race window 만 차단하면 충분.
+- `internal/lsp/subprocess/launcher.go` production 코드는 무수정.
+
+## Why SPEC-001 was incomplete
+
+SPEC-001 은 "shared file 사용 시 file write 가 1회만 발생하므로 race 없음" 으로 추론했으나, lazy 초기화 패턴 자체가 race window 였다. 본 SPEC-002 는 eager 초기화로 race window 를 제거한다.

--- a/internal/lsp/subprocess/launcher_main_test.go
+++ b/internal/lsp/subprocess/launcher_main_test.go
@@ -1,19 +1,26 @@
 package subprocess_test
 
 // @MX:NOTE: [AUTO] TestMain — 패키지 전역 공유 fake binary 초기화 진입점
-// @MX:SPEC: SPEC-LSP-FLAKY-001
+// @MX:SPEC: SPEC-LSP-FLAKY-001, SPEC-LSP-FLAKY-002
 //
 // 이 파일은 패키지 테스트 프로세스의 진입점인 TestMain을 정의한다.
-// TestMain에서 공유 fake binary를 단 1회만 생성하고 os.RemoveAll로 정리한다.
-// 이로써 t.Parallel() 테스트들이 동시에 실행되는 중에는 어떤 fake binary 파일
-// 쓰기도 발생하지 않아 Linux fork-exec ETXTBSY race가 근본적으로 제거된다.
+// TestMain에서 공유 fake binary를 m.Run() 호출 *전*에 작성하고 모든 writer fd가
+// 닫힌 후에만 t.Parallel() 테스트들이 시작된다. 이로써 Linux fork-exec ETXTBSY
+// race가 근본 제거된다.
+//
+// History:
+// - SPEC-LSP-FLAKY-001 (1차 시도): sync.OnceValues lazy 초기화. supervisor_test
+//   goroutine 이 t.Parallel() 중 fork 할 때 launcher OnceValues 의 writer fd 를
+//   잠시 inherit 하는 race 가 잔존하여 Ubuntu CI 에서 여전히 flake 발생.
+// - SPEC-LSP-FLAKY-002 (현재): TestMain 에서 eager 작성. m.Run() 진입 시점에
+//   writer fd 가 이미 닫혀 있으므로 어떤 t.Parallel() goroutine 의 fork 도
+//   shared binary 의 writer fd 를 inherit 할 수 없다.
 
 import (
 	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
-	"sync"
 	"testing"
 )
 
@@ -21,44 +28,16 @@ import (
 // 테스트 프로세스 종료 시 os.RemoveAll로 정리된다.
 var pkgTempDir string
 
-// sharedBinaryPath는 sync.OnceValues를 통해 패키지 전역 fake binary를
-// 정확히 1회만 생성하고 그 경로를 반환한다.
+// pkgSharedBinaryPath는 TestMain이 m.Run() 호출 전에 작성한 공유 fake LSP stub
+// 바이너리의 절대 경로이다. Windows 에서는 빈 문자열 (호출자가 t.Skip 처리).
 //
-// @MX:NOTE: [AUTO] sharedBinaryPath — ETXTBSY race 제거를 위한 공유 바이너리 경로
-// @MX:SPEC: SPEC-LSP-FLAKY-001 REQ-LSP-FLAKY-001-001, REQ-LSP-FLAKY-001-002
+// @MX:ANCHOR: [AUTO] pkgSharedBinaryPath — ETXTBSY race 제거를 위한 공유 바이너리 경로
+// @MX:REASON: fan_in >= 3 — TestLauncher_Launch_HappyPath, _StdioPipesNonNil, _WithArgs 가 모두 참조
+// @MX:SPEC: SPEC-LSP-FLAKY-002 REQ-001
 //
-// 핵심 불변: 이 함수가 반환한 경로의 파일은 테스트 실행 중 절대 재작성되지 않는다.
+// 핵심 불변: TestMain 종료 후 이 경로의 파일은 절대 재작성되지 않는다.
 // 모든 호출자는 read+exec 전용으로 사용해야 하며, 파일 내용을 변경해서는 안 된다.
-var sharedBinaryPath = sync.OnceValues(func() (string, error) {
-	if runtime.GOOS == "windows" {
-		// Windows는 shell script stub을 지원하지 않으므로 빈 경로를 반환.
-		// 호출자(sharedFakeBinaryPath)에서 t.Skip()으로 처리한다.
-		return "", nil
-	}
-	path := filepath.Join(pkgTempDir, "shared-fake-lsp")
-
-	// ETXTBSY mitigation 시퀀스: Create → Write → Sync → Close → Chmod 순서 준수.
-	// fork/exec 전에 모든 writer fd가 닫혀 있음을 보장한다.
-	f, err := os.Create(path)
-	if err != nil {
-		return "", fmt.Errorf("sharedBinaryPath create: %w", err)
-	}
-	if _, err := f.Write([]byte("#!/bin/sh\ncat\n")); err != nil {
-		_ = f.Close()
-		return "", fmt.Errorf("sharedBinaryPath write: %w", err)
-	}
-	if err := f.Sync(); err != nil {
-		_ = f.Close()
-		return "", fmt.Errorf("sharedBinaryPath sync: %w", err)
-	}
-	if err := f.Close(); err != nil {
-		return "", fmt.Errorf("sharedBinaryPath close: %w", err)
-	}
-	if err := os.Chmod(path, 0o755); err != nil {
-		return "", fmt.Errorf("sharedBinaryPath chmod: %w", err)
-	}
-	return path, nil
-})
+var pkgSharedBinaryPath string
 
 // sharedFakeBinaryPath는 패키지 전역 공유 fake LSP stub 바이너리 경로를 반환한다.
 //
@@ -66,25 +45,65 @@ var sharedBinaryPath = sync.OnceValues(func() (string, error) {
 //   - 바이너리를 read+exec 전용으로 사용하는 테스트에서만 호출한다.
 //   - 바이너리 내용이나 권한을 수정하는 테스트는 반드시 writeFakeBinary를 사용한다.
 //
-// @MX:SPEC: SPEC-LSP-FLAKY-001 REQ-LSP-FLAKY-001-001
+// @MX:SPEC: SPEC-LSP-FLAKY-002 REQ-001
 func sharedFakeBinaryPath(t *testing.T) string {
 	t.Helper()
 	if runtime.GOOS == "windows" {
 		t.Skip("shell script stub은 Windows에서 지원되지 않음")
 	}
-	path, err := sharedBinaryPath()
-	if err != nil {
-		t.Fatalf("공유 fake binary 초기화 실패: %v", err)
+	if pkgSharedBinaryPath == "" {
+		t.Fatal("pkgSharedBinaryPath 가 초기화되지 않음 (TestMain 에서 setup 실패)")
 	}
-	return path
+	return pkgSharedBinaryPath
+}
+
+// buildSharedBinary는 TestMain 단계에서 fake LSP stub 바이너리를 작성한다.
+// 작성 순서: Create → Write → Sync → Close → Chmod.
+// 반환 시점에 모든 writer fd 가 닫혀 있음을 보장한다.
+//
+// 이 함수는 m.Run() 호출 *전* 에만 호출되어야 하며, 어떤 t.Parallel() goroutine
+// 도 시작되지 않은 상태에서 실행된다. 따라서 fork-exec ETXTBSY race 가 발생
+// 할 수 없다.
+func buildSharedBinary(dir string) (string, error) {
+	if runtime.GOOS == "windows" {
+		// Windows 에서는 shell script stub 을 지원하지 않음. 호출자가 t.Skip 처리.
+		return "", nil
+	}
+	path := filepath.Join(dir, "shared-fake-lsp")
+
+	f, err := os.Create(path)
+	if err != nil {
+		return "", fmt.Errorf("buildSharedBinary create: %w", err)
+	}
+	if _, err := f.Write([]byte("#!/bin/sh\ncat\n")); err != nil {
+		_ = f.Close()
+		return "", fmt.Errorf("buildSharedBinary write: %w", err)
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return "", fmt.Errorf("buildSharedBinary sync: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return "", fmt.Errorf("buildSharedBinary close: %w", err)
+	}
+	if err := os.Chmod(path, 0o755); err != nil {
+		return "", fmt.Errorf("buildSharedBinary chmod: %w", err)
+	}
+	return path, nil
 }
 
 // TestMain은 패키지 테스트 프로세스의 진입점이다.
-// 패키지 전역 임시 디렉터리를 생성하고 모든 테스트 완료 후 정리한다.
-// 공유 fake binary는 sharedBinaryPath (sync.OnceValues)에 의해 최초 요청 시 생성된다.
+//
+// 책임:
+//  1. 패키지 전역 임시 디렉터리 생성
+//  2. 공유 fake binary 작성 (m.Run() 진입 전, t.Parallel() 시작 전)
+//  3. m.Run() 으로 모든 테스트 실행 (writer fd 가 이미 닫힌 상태)
+//  4. 임시 디렉터리 정리
+//
+// 핵심 설계 원칙: m.Run() 호출 전에 모든 binary 작성이 완료되어 writer fd 가
+// 닫혀 있어야 한다. 그래야 t.Parallel() 테스트들이 동시에 fork-exec 를 호출해도
+// 어떤 자식 프로세스도 shared-fake-lsp 의 writer fd 를 inherit 할 수 없다.
 func TestMain(m *testing.M) {
-	// 패키지 전역 임시 디렉터리 생성.
-	// t.TempDir()은 *testing.T가 필요하므로 TestMain에서는 os.MkdirTemp를 사용한다.
 	dir, err := os.MkdirTemp("", "moai-lsp-subprocess-test-*")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "TestMain: 임시 디렉터리 생성 실패: %v\n", err)
@@ -92,11 +111,19 @@ func TestMain(m *testing.M) {
 	}
 	pkgTempDir = dir
 
-	// 모든 테스트 실행.
+	// CRITICAL: m.Run() 호출 *전* 에 binary 를 eager 하게 작성한다.
+	// 이 시점에는 t.Parallel() goroutine 이 아직 시작되지 않았으므로 fork-exec
+	// ETXTBSY race 가 발생할 수 없다.
+	binPath, err := buildSharedBinary(dir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "TestMain: 공유 fake binary 작성 실패: %v\n", err)
+		_ = os.RemoveAll(dir)
+		os.Exit(1)
+	}
+	pkgSharedBinaryPath = binPath
+
 	code := m.Run()
 
-	// 임시 디렉터리 정리 (공유 fake binary 포함).
 	_ = os.RemoveAll(pkgTempDir)
-
 	os.Exit(code)
 }


### PR DESCRIPTION
## Summary

SPEC-LSP-FLAKY-001 (PR #757) 머지 직후 PR #758 의 Ubuntu CI 에서 동일한 ETXTBSY flake 가 재발했습니다. 진단을 정정하고 hotfix 합니다.

## Real Root Cause (SPEC-001 정정)

SPEC-001 은 \"shared file 1회 작성이면 race 없음\" 으로 추론했으나 **lazy 초기화 패턴 자체가 race window** 였습니다.

```
1. sync.OnceValues lazy → 첫 t.Parallel() 테스트가 진입한 후에 write 시작
2. supervisor_test 도 동시에 t.Parallel() 로 자체 binary write + cmd.Start()
3. supervisor goroutine 의 fork() 가 launcher OnceValues 의 writer fd 를 자식에 inherit
4. 자식이 exec() 하기 전 짧은 윈도우에 launcher 의 다른 goroutine 이 cmd.Start(shared-fake-lsp) 호출
5. 커널이 inode 검사 → shared-fake-lsp 가 supervisor 자식에게 writer 로 열려 있음 → ETXTBSY
```

`O_CLOEXEC` 는 **exec 시점에만** fd 를 닫고, fork↔exec 사이의 윈도우는 닫지 못합니다.

## Fix

`TestMain` 의 `m.Run()` 호출 **전에** binary 를 eager 하게 작성합니다. 이 시점에는 어떤 `t.Parallel()` goroutine 도 시작되지 않았으므로 fork 가 발생할 수 없습니다.

| Before (SPEC-001) | After (SPEC-002) |
|-------------------|------------------|
| `sync.OnceValues` lazy init | `TestMain` eager init before `m.Run()` |
| 첫 테스트 진입 시 write 시작 | `m.Run()` 진입 시 이미 모든 fd 닫힘 |
| supervisor fork 가 race window 유발 가능 | race window 자체가 존재하지 않음 |

## Files Changed

| File | Change |
|------|--------|
| `internal/lsp/subprocess/launcher_main_test.go` | `sync.OnceValues` 제거, `buildSharedBinary` helper + `TestMain` 에서 m.Run() 전 호출 |
| `.moai/specs/SPEC-LSP-FLAKY-002/spec.md` | EARS 4건 + AC 4건 + 진단 정정 (신규) |

`launcher_test.go` 는 호출 시그니처(`sharedFakeBinaryPath(t)`) 가 동일하여 변경 불요.

## Verification

- [x] `go test -race -count=20 ./internal/lsp/subprocess/...` — 20회 연속 PASS (macOS local)
- [x] `go vet` — clean
- [x] `golangci-lint run` — 0 issues
- [ ] CI Ubuntu race detector — race window 자체가 제거되었으므로 결정론적 PASS 예상

## Production Code Untouched

```
internal/lsp/subprocess/launcher.go         | 0
internal/lsp/subprocess/supervisor.go       | 0
internal/lsp/subprocess/supervisor_test.go  | 0
```

## Merge Strategy

- type:fix · area:lsp · priority:P1 (블로킹 follow-up CI)
- Squash merge

🗿 MoAI <email@mo.ai.kr>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Fixed intermittent test failures in language server protocol subprocess initialization through improved test setup sequencing
  * Enhanced test stability and reduced flaky failures during parallel test execution and repeated CI runs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->