### PR TITLE
fix(runner): version checker time-dependent test flakiness — Clock injection

### DIFF
--- a/internal/github/runner/version.go
+++ b/internal/github/runner/version.go
@@ -69,19 +69,48 @@ var mockReleaseData = map[string]string{
 	"2.698.0": "2026-03-28", // 30일 전
 }
 
+// Clock은 현재 시각 조회를 추상화합니다 (테스트 시 결정적 시간 주입용).
+// Clock abstracts current-time retrieval, enabling deterministic time injection in tests.
+type Clock interface {
+	Now() time.Time
+}
+
+// RealClock은 실제 시스템 시각을 반환합니다.
+// RealClock returns actual system time.
+type RealClock struct{}
+
+// Now는 현재 시각을 반환합니다.
+func (RealClock) Now() time.Time { return time.Now() }
+
 // VersionChecker는 runner 버전을 확인합니다.
 // VersionChecker checks runner version against latest.
 type VersionChecker struct {
 	ghRunnerDir string
 	ghClient    GitHubClient
+	clock       Clock
 }
 
-// NewVersionChecker는 새로운 VersionChecker 인스턴스를 생성합니다.
-// NewVersionChecker creates a new VersionChecker instance.
+// NewVersionChecker는 새로운 VersionChecker 인스턴스를 생성합니다 (실제 시각 사용).
+// NewVersionChecker creates a new VersionChecker instance with real system clock.
 func NewVersionChecker(ghRunnerDir string, ghClient GitHubClient) *VersionChecker {
 	return &VersionChecker{
 		ghRunnerDir: ghRunnerDir,
 		ghClient:    ghClient,
+		clock:       RealClock{},
+	}
+}
+
+// NewVersionCheckerWithClock은 사용자 지정 Clock으로 VersionChecker를 생성합니다 (테스트 전용).
+// NewVersionCheckerWithClock creates a VersionChecker with a custom Clock (for tests).
+// nil clock is normalized to RealClock for safety.
+func NewVersionCheckerWithClock(ghRunnerDir string, ghClient GitHubClient, clock Clock) *VersionChecker {
+	if clock == nil {
+		clock = RealClock{}
+	}
+	return &VersionChecker{
+		ghRunnerDir: ghRunnerDir,
+		ghClient:    ghClient,
+		clock:       clock,
 	}
 }
 
@@ -106,12 +135,13 @@ func (v *VersionChecker) CheckVersion(ctx context.Context) (*CheckResult, error)
 	}
 
 	// 3. 릴리즈 날짜 계산 (테스트용 mock 데이터)
+	now := v.clock.Now()
 	publishedDate, ok := mockReleaseData[installed]
 	if !ok {
-		publishedDate = time.Now().Format("2006-01-02")
+		publishedDate = now.Format("2006-01-02")
 	}
 	parsed, _ := time.Parse("2006-01-02", publishedDate)
-	daysOld := calculateDaysOld(parsed, time.Now())
+	daysOld := calculateDaysOld(parsed, now)
 
 	// 4. 상태 결정
 	var status VersionCheckStatus

--- a/internal/github/runner/version_test.go
+++ b/internal/github/runner/version_test.go
@@ -8,6 +8,21 @@ import (
 	"time"
 )
 
+// fixedTestNow는 시간 종속적 버전 검증 테스트의 결정적 기준 시각입니다.
+// fixedTestNow is the deterministic reference time for time-sensitive version tests.
+// Choice rationale: 2026-04-27 makes mockReleaseData entries hit threshold boundaries:
+//   - 2.700.0 (2026-04-17) -> 10 days (OK)
+//   - 2.699.0 (2026-04-02) -> 25 days (WARN)
+//   - 2.698.0 (2026-03-28) -> 30 days (FAIL)
+var fixedTestNow = time.Date(2026, 4, 27, 0, 0, 0, 0, time.UTC)
+
+// fakeClock는 테스트용 결정적 Clock 구현입니다.
+// fakeClock is a deterministic Clock implementation for tests.
+type fakeClock struct{ now time.Time }
+
+// Now는 고정된 시각을 반환합니다.
+func (f fakeClock) Now() time.Time { return f.now }
+
 // MockGitHubClient는 테스트용 GitHubClient 인터페이스 구현입니다.
 // MockGitHubClient is a test implementation of GitHubClient interface.
 type MockGitHubClient struct {
@@ -47,7 +62,7 @@ func TestVersionChecker_CheckVersion_OK(t *testing.T) {
 		},
 	}
 
-	checker := NewVersionChecker("/tmp/actions-runner", mockClient)
+	checker := NewVersionCheckerWithClock("/tmp/actions-runner", mockClient, fakeClock{now: fixedTestNow})
 
 	result, err := checker.CheckVersion(context.Background())
 	if err != nil {
@@ -58,9 +73,8 @@ func TestVersionChecker_CheckVersion_OK(t *testing.T) {
 		t.Errorf("Expected VersionCheckOK, got %s", result.Status)
 	}
 
-	// daysOld는 time.Now() 기준이므로 mockReleaseData 날짜(2026-04-17)와의
-	// 실제 차이를 계산하여 검증
-	wantDays := calculateDaysOld(parseDate("2026-04-17"), time.Now())
+	// fixedTestNow(2026-04-27) - mockReleaseData["2.700.0"](2026-04-17) = 10 days
+	wantDays := calculateDaysOld(parseDate("2026-04-17"), fixedTestNow)
 	if result.DaysOld != wantDays {
 		t.Errorf("Expected %d days old, got %d", wantDays, result.DaysOld)
 	}
@@ -79,7 +93,7 @@ func TestVersionChecker_CheckVersion_Warn25(t *testing.T) {
 		},
 	}
 
-	checker := NewVersionChecker("/tmp/actions-runner", mockClient)
+	checker := NewVersionCheckerWithClock("/tmp/actions-runner", mockClient, fakeClock{now: fixedTestNow})
 
 	result, err := checker.CheckVersion(context.Background())
 	if err != nil {
@@ -90,7 +104,8 @@ func TestVersionChecker_CheckVersion_Warn25(t *testing.T) {
 		t.Errorf("Expected VersionCheckWarn (25 days), got %s", result.Status)
 	}
 
-	wantDays := calculateDaysOld(parseDate("2026-04-02"), time.Now())
+	// fixedTestNow(2026-04-27) - mockReleaseData["2.699.0"](2026-04-02) = 25 days
+	wantDays := calculateDaysOld(parseDate("2026-04-02"), fixedTestNow)
 	if result.DaysOld != wantDays {
 		t.Errorf("Expected %d days old, got %d", wantDays, result.DaysOld)
 	}
@@ -109,7 +124,7 @@ func TestVersionChecker_CheckVersion_Fail30(t *testing.T) {
 		},
 	}
 
-	checker := NewVersionChecker("/tmp/actions-runner", mockClient)
+	checker := NewVersionCheckerWithClock("/tmp/actions-runner", mockClient, fakeClock{now: fixedTestNow})
 
 	result, err := checker.CheckVersion(context.Background())
 	if err != nil {
@@ -120,7 +135,8 @@ func TestVersionChecker_CheckVersion_Fail30(t *testing.T) {
 		t.Errorf("Expected VersionCheckFail (30 days), got %s", result.Status)
 	}
 
-	wantDays := calculateDaysOld(parseDate("2026-03-28"), time.Now())
+	// fixedTestNow(2026-04-27) - mockReleaseData["2.698.0"](2026-03-28) = 30 days
+	wantDays := calculateDaysOld(parseDate("2026-03-28"), fixedTestNow)
 	if result.DaysOld != wantDays {
 		t.Errorf("Expected %d days old, got %d", wantDays, result.DaysOld)
 	}


### PR DESCRIPTION
## Summary

`TestVersionChecker_CheckVersion_Warn25` 시간 종속적 결함이 모든 PR을 차단하던 회귀를 hotfix로 해소. **PR #764 (SPEC-V3R3-UPDATE-CLEANUP-001) 머지를 위한 선행 작업**입니다.

## 결함 분석

`internal/github/runner/version.go`:
- `mockReleaseData` (line 65-70): 절대 날짜 문자열 보유 (`"2.699.0": "2026-04-02"` 등)
- `CheckVersion()` (line 114): `time.Now()` 직접 호출하여 days 계산
- 임계값: 25일 (WARN), 30일 (FAIL)

2026-04-02 → 2026-05-04 = **32일** 경과 → \`status = VersionCheckFail\` 분기. 그러나 테스트 expectation은 \`VersionCheckWarn (25 days)\` → 결정적 실패.

```
--- FAIL: TestVersionChecker_CheckVersion_Warn25 (0.00s)
    version_test.go:90: Expected VersionCheckWarn (25 days), got FAIL
FAIL    github.com/modu-ai/moai-adk/internal/github/runner    15.605s
```

CI에서 모든 신규 PR을 차단하던 사전 결함입니다 (PR #764에서 발견).

## 해결 — Clock 의존성 주입

Additive 변경, no breaking change:

1. \`Clock interface { Now() time.Time }\` + \`RealClock\` 구현 추가
2. \`VersionChecker.clock\` 필드 추가 (default RealClock)
3. \`NewVersionCheckerWithClock(dir, client, clock)\` 신규 생성자
4. 기존 \`NewVersionChecker(dir, client)\`는 RealClock 자동 주입 (호환성 유지)
5. \`CheckVersion()\` 내부 \`time.Now()\` 2개 호출 → \`v.clock.Now()\`

테스트:
- \`fakeClock\` 타입 + \`fixedTestNow = 2026-04-27 UTC\` 추가
- 2026-04-27 기준으로 mockReleaseData 항목이 정확히 10/25/30일 경계에 위치
- OK / Warn25 / Fail30 3개 테스트가 결정적 시각 주입
- NotInstalled / FetchError 테스트는 시간 비종속, 변경 없음

## 검증

\`\`\`
$ go vet ./internal/github/runner/...
(pass)

$ go test -count=1 -race ./internal/github/runner/...
ok  github.com/modu-ai/moai-adk/internal/github/runner  17.038s

=== RUN   TestVersionChecker_CheckVersion_OK         --- PASS
=== RUN   TestVersionChecker_CheckVersion_Warn25     --- PASS  ← 회귀 fix 검증
=== RUN   TestVersionChecker_CheckVersion_Fail30     --- PASS
=== RUN   TestVersionChecker_CheckVersion_NotInstalled --- PASS
=== RUN   TestVersionChecker_CheckVersion_FetchError --- PASS
=== RUN   TestVersionChecker_CalculateDaysOld        --- PASS
\`\`\`

## Test Plan

- [x] go vet pass
- [x] go test -race local pass (17s)
- [ ] CI Lint pass
- [ ] CI Test (ubuntu/macos/windows) pass
- [ ] CI Build (5 platforms) pass
- [ ] CI CodeQL pass

## Scope

이 PR은 hotfix only — `internal/github/runner/version.go` + `version_test.go` 2개 파일, +58/-12 lines. 다른 production 동작에 영향 없음.

## Blocked PRs (이 PR 머지 후 자동 해소)

- #764 SPEC-V3R3-UPDATE-CLEANUP-001 (이 hotfix 머지 후 sync + CI 재실행 필요)

## Follow-up (별도 SPEC)

장기적으로 \`mockReleaseData\`를 production 코드에서 제거하고 실제 GitHub Release API 호출(\`FileSystemGitHubClient.GetLatestRelease\` 구현)로 대체 권장 (현재 file의 line 64 TODO).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved version checking to use an injected time source, enabling more reliable and deterministic behavior. Version checking functionality remains unchanged for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->