### PR TITLE
docs(spec): SPEC-GLM-MCP-001 plan — Z.AI 공식 MCP 서버 통합

### DIFF
--- a/.moai/reports/devops/glm-cache-control-validation-2026-05-01.md
+++ b/.moai/reports/devops/glm-cache-control-validation-2026-05-01.md
@@ -1,0 +1,360 @@
+# GLM cache_control 호환성 검증 보고서
+
+**작성일**: 2026-05-01  
+**작성자**: expert-devops (조사 전용, 코드 변경 없음)  
+**조사 방법**: WebFetch + WebSearch (라이브 API 호출 없음)
+
+---
+
+## 1. 요약 (Executive Summary)
+
+- Z.AI 공식 문서(`docs.z.ai`) 어디에도 `cache_control`, `prompt-caching-2024-07-31` 베타 헤더, `anthropic-beta` 지원 여부에 대한 명시적 설명이 없다. 지원도 미지원도 공식 문서화되지 않은 상태다.
+- LiteLLM Issue #19923(2026-01-28)에서 Z.AI / GLM 모델에 `cache_control` 필드가 전송 시 **자동으로 제거(strip)** 되는 버그가 확인됐다. 이는 오픈소스 게이트웨이 레이어의 문제이나, Z.AI 프록시 자체의 동작 방식을 간접적으로 암시한다.
+- Claude Code `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1`은 신규 베타 플래그 추가 시 **반복적으로 우회되는** 구조적 취약점을 가진다. 2026년 2월(Issue #22893), 3월(Issue #30926), 4월(Issue #49648)에 연속 회귀 발생.
+- `cache_read_input_tokens` / `cache_creation_input_tokens`을 Z.AI 엔드포인트에서 실측한 공개 사례가 **존재하지 않는다**. 캐싱이 실제로 동작하는지 확인된 바 없다.
+- **권장 정책**: 현행 유지(옵션 A). 단, `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS` 우회 회귀에 대응하는 모니터링을 추가할 것.
+
+---
+
+## 2. 현재 코드 상태
+
+### 2.1 `DISABLE_PROMPT_CACHING=1` 주입 위치
+
+| 파일 | 줄 번호(근사) | 함수/컨텍스트 | 역할 |
+|------|------------|-------------|------|
+| `internal/cli/glm.go` | 176 | `setGLMEnv()` | `moai glm` 실행 시 프로세스 env 주입 |
+| `internal/cli/glm.go` | 372 | `injectTmuxSessionEnv()` | tmux 세션 레벨 env 주입 (GLM 팀 모드) |
+| `internal/cli/glm.go` | 548 | `injectGLMEnvForTeam()` | settings.local.json 에 팀 모드 주입 |
+| `internal/cli/glm.go` | 827 | `buildGLMEnvVars()` | env 맵 생성 헬퍼 (공통 참조 소스) |
+| `internal/cli/glm.go` | 872 | `injectGLMEnv()` | settings.local.json 에 직접 주입 |
+| `internal/hook/session_start.go` | 245–246 | `ensureGLMCompatibilityFlags()` | SessionStart 훅에서 누락 시 보완 주입 |
+
+> **참고**: `glm.go:142–147` 코드 주석에 주입 이유 명시:  
+> `DISABLE_PROMPT_CACHING=1` → 프롬프트 캐싱 미지원으로 인한 전체 시스템 프롬프트 재전송(~30-40K 토큰/요청) → GLM 컨텍스트 소진 가속
+
+### 2.2 `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1` 주입 위치
+
+동일 6개 위치에서 `DISABLE_PROMPT_CACHING`과 항상 쌍으로 주입된다. `internal/github/auth/glm.go:35–36`에서는 GitHub Actions CI용으로 `DISABLE_BETAS=true`라는 별도 변수명으로도 등록된다.
+
+### 2.3 회귀 가드 위치
+
+| 파일 | 줄 번호(근사) | 테스트 내용 |
+|------|------------|-----------|
+| `internal/cli/launcher_test.go` | 745–746 | `moai cc` 전환 후 settings.local.json에 `DISABLE_PROMPT_CACHING` 잔류 금지 (Issue #676) |
+| `internal/cli/glm_test.go` | 153–154 | `moai glm` 종료 후 settings.local.json에 `DISABLE_PROMPT_CACHING` 잔류 금지 (Issue #676) |
+
+두 테스트 모두 **잔류(leak) 방지** 목적이며, 주입 자체의 정확성을 검증하지는 않는다.
+
+### 2.4 `moai cc` 전환 시 정리 로직
+
+`internal/cli/launcher.go:235–243`: `moai cc` 실행 시 settings.local.json에서 다음 키를 `delete()` 처리한다.
+
+```
+ANTHROPIC_BASE_URL
+ANTHROPIC_DEFAULT_{HAIKU,SONNET,OPUS}_MODEL
+CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS
+DISABLE_PROMPT_CACHING
+API_TIMEOUT_MS
+CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC
+```
+
+tmux 세션 환경도 `clearTmuxSessionEnv()`(`glm.go:392–419`)에서 동일하게 정리된다.
+
+---
+
+## 3. Z.AI 공식 문서 분석
+
+### 3.1 FAQ (`https://docs.z.ai/devpack/faq`)
+
+`cache_control`, `anthropic-beta`, `prompt-caching`, `experimental_betas`, `Error 1214` 등의 키워드에 대한 **언급이 전혀 없다**. 문서 내용은 GLM Coding Plan 구독 정보, 모델 설정, 쿼터 관리, MCP 도구에 국한된다.
+
+지원 모델 목록: GLM-5.1, GLM-5-Turbo, GLM-4.7, GLM-4.5-Air.
+
+### 3.2 Quick Start (`https://docs.z.ai/devpack/quick-start`)
+
+**엔드포인트 URL**:
+- Coding API: `https://api.z.ai/api/coding/paas/v4`
+- General API: `https://api.z.ai/api/paas/v4`
+- **Anthropic 호환**: `https://api.z.ai/api/anthropic`
+
+**환경변수 계약**:
+
+```
+ANTHROPIC_AUTH_TOKEN = <Z.AI API Key>
+ANTHROPIC_BASE_URL   = https://api.z.ai/api/anthropic
+API_TIMEOUT_MS       = 3000000 (선택, 기본 제공 값 예시)
+```
+
+**캐싱 관련 언급**: 없음.  
+**베타 헤더 관련 언급**: 없음.  
+**제한사항**: GLM Coding Plan은 Claude Code, Roo Code, Cline 등 공식 지원 도구 내 사용으로 엄격 제한.
+
+### 3.3 Claude Code 통합 가이드 (`https://docs.z.ai/devpack/tool/claude`)
+
+**지원 환경변수**:
+
+| 변수명 | 용도 |
+|--------|------|
+| `ANTHROPIC_AUTH_TOKEN` | Z.AI API 키 |
+| `ANTHROPIC_BASE_URL` | `https://api.z.ai/api/anthropic` |
+| `API_TIMEOUT_MS` | `3000000` (5000분 타임아웃) |
+| `ANTHROPIC_DEFAULT_OPUS_MODEL` | `GLM-4.7` 또는 `glm-5.1` (프리미엄) |
+| `ANTHROPIC_DEFAULT_SONNET_MODEL` | `GLM-4.7` 또는 `glm-5-turbo` (프리미엄) |
+| `ANTHROPIC_DEFAULT_HAIKU_MODEL` | `GLM-4.5-Air` |
+
+**캐싱 관련 언급**: 없음.  
+**베타 헤더 관련 언급**: 없음.  
+**알려진 이슈**: usage 데이터 포맷 불일치로 비용/토큰 카운트 표시 오류 가능. macOS 권한 이슈. Windows 미지원(부분적).
+
+> **결론**: Z.AI 공식 문서 3개 페이지 모두 `cache_control`, `anthropic-beta`, 또는 프롬프트 캐싱에 대해 **어떠한 언급도 없다**. 지원 여부에 대한 공식 입장이 존재하지 않는다.
+
+---
+
+## 4. Community Evidence
+
+### 4.1 `cache_control` 스트리핑 버그 (LiteLLM, 2026-01-28)
+
+**출처**: [BerriAI/litellm Issue #19923](https://github.com/BerriAI/litellm/issues/19923)  
+**날짜**: 2026-01-28  
+**내용**: GLM/ZAI 모델에 대한 `cache_control` 및 `thinking/reasoning` 파라미터가 정상 작동하지 않는다. 근본 원인은 `ZAIChatConfig`가 `OpenAIGPTConfig`를 상속하며, `transform_request()`에서 `remove_cache_control_flag_from_messages_and_tools()`를 호출하기 때문이다. 즉, **`cache_control` 필드가 요청에서 제거된 상태로 Z.AI로 전송**된다. 제안된 수정사항: `ZAIChatConfig`에서 해당 메서드를 오버라이드하여 GLM 모델은 `cache_control`을 제거하지 않도록.
+
+**의미**: LiteLLM 게이트웨이 레이어의 버그이나, Z.AI 엔드포인트가 `cache_control`을 어떻게 처리하는지(또는 처리하지 않는지)에 대한 커뮤니티 내 혼란이 존재함을 확인.
+
+### 4.2 GLM-5 캐싱 지원 요청 (openclaw, 2026-02-23)
+
+**출처**: [openclaw/openclaw Issue #24497](https://github.com/openclaw/openclaw/issues/24497)  
+**날짜**: 2026-02-23  
+**내용**: `contextPruning` with `mode: "cache-ttl"` 기능이 ZAI/GLM-5를 지원하지 않음을 버그로 보고. GLM-5 네이티브 캐싱은 `$0.20/M` (표준 대비 1/5 가격)으로 지원된다고 주장. `isCacheTtlEligibleProvider()` 함수의 하드코딩된 검사가 `"zai"`를 포함하지 않아 캐싱이 무음으로 비활성화됨.
+
+**중요 구분**: 이 이슈에서 말하는 "GLM-5 네이티브 캐싱"은 Z.AI의 자체 캐싱 메커니즘을 가리키는 것으로 보이며, Anthropic의 `cache_control: { type: "ephemeral" }` 방식과 동일한지는 **미확인**.
+
+### 4.3 Cerebras `zai-glm-4.7` 프롬프트 캐싱 활성화 요청 (Roo-Code, 2026-01-10)
+
+**출처**: [RooCodeInc/Roo-Code Issue #10601](https://github.com/RooCodeInc/Roo-Code/issues/10601)  
+**날짜**: 2026-01-10  
+**내용**: Cerebras에서 제공하는 `zai-glm-4.7` 모델(Z.AI의 GLM-4.7과 동일 모델 가중치, 다른 인프라)에 대해 프롬프트 캐싱이 비활성화 상태. Cerebras 공식 문서는 지원 명시. `supportsPromptCaching = true`로 수정 요청.
+
+**중요 구분**: 이 이슈는 Cerebras 인프라에서 실행되는 GLM-4.7에 관한 것이며, `api.z.ai/api/anthropic` 엔드포인트와 **직접 관련 없음**. 단, 동일 모델 가중치를 기반으로 캐싱 지원 가능성을 시사한다.
+
+### 4.4 `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS` 구조적 취약점
+
+**출처**: 복수의 anthropics/claude-code GitHub 이슈
+
+| 이슈 | 날짜 | 내용 |
+|------|------|------|
+| [Issue #22893](https://github.com/anthropics/claude-code/issues/22893) | 2026-02-xx | `advanced-tool-use-2025-11-20` 베타 플래그가 `DISABLE_EXPERIMENTAL_BETAS=1`에도 불구 전송됨 |
+| [Issue #30926](https://github.com/anthropics/claude-code/issues/30926) | 2026-03-xx | v2.1.69에서 `advanced-tool-use-2025-11-20` 도입. 프록시 설정 시 `firstParty`로 감지되어 비호환 플래그 전송 |
+| [Issue #20031](https://github.com/anthropics/claude-code/issues/20031) | 2026-01-xx | `DISABLE_EXPERIMENTAL_BETAS=1` 설정에도 `?beta=true` 쿼리 파라미터 잔류 |
+| [Issue #49648](https://github.com/anthropics/claude-code/issues/49648) | 2026-04-xx | v2.1.112에서 `claude-code-20250219`, `interleaved-thinking-2025-05-14` 등 베타 플래그가 Bedrock에 전송되어 400 오류 |
+
+**패턴**: Claude Code 신규 베타 플래그 추가 시 `DISABLE_EXPERIMENTAL_BETAS` 게이팅이 누락되는 패턴이 반복된다. v2.1.101에서 한 번 수정됐으나 이후에도 회귀가 지속됐다.
+
+### 4.5 Error 1214 관련
+
+공개 GitHub 이슈나 블로그에서 Z.AI + Error 1214 조합에 대한 문서화된 최신 사례를 발견하지 못했다. memory 파일(`glm_compatibility.md`, 30일 이상 경과)의 기록은 최신 상태를 반영하지 않을 수 있다 — **현재 재현 가능 여부 불명확**.
+
+### 4.6 `cache_read_input_tokens` 실측 사례
+
+**결론**: `api.z.ai/api/anthropic` 엔드포인트에서 `cache_read_input_tokens` 또는 `cache_creation_input_tokens`이 0이 아닌 값으로 반환됐다는 공개 보고가 **없다**. 캐싱이 실제로 동작함을 경험적으로 확인한 사례가 존재하지 않는다.
+
+---
+
+## 5. 모델별 호환성 매트릭스
+
+| 모델 | beta headers 허용 | cache_control 처리 | Anthropic 캐싱 실측 | 비고 |
+|------|-----------------|-------------------|-------------------|------|
+| GLM-5.1 | 미확인 (문서 없음) | 미확인 | 없음 | Z.AI 최고 성능 모델 |
+| GLM-5-Turbo | 미확인 | 미확인 | 없음 | — |
+| GLM-4.7 | 30일 전 기록: 베타 헤더 허용 가능 (stale) | 미확인 | 없음 | Cerebras 동명 모델은 캐싱 지원 명시 (다른 인프라) |
+| GLM-4.6 | 미확인 | 미확인 | 없음 | 200K ctx, 에이전트/도구 특화 |
+| GLM-4.5-Air | 미확인 | 미확인 | 없음 | 저가 Haiku 슬롯 |
+
+**출처 주기**:
+- Z.AI 공식 문서 (2026-05-01 조회): 캐싱/베타 헤더 언급 없음
+- [openclaw #24497](https://github.com/openclaw/openclaw/issues/24497): GLM-5 네이티브 캐싱 가격 언급 (Z.AI 자체 캐싱, 2026-02-23)
+- [LiteLLM #19923](https://github.com/BerriAI/litellm/issues/19923): cache_control 스트리핑 확인 (2026-01-28)
+- Memory `glm_compatibility.md` (stale, ~30일 전): GLM-5.1 베타 헤더 거부, GLM-4.7 무관
+
+> **GLM-5.1 vs GLM-4.7 차이**: 30일 전 메모리에 GLM-5.1은 `anthropic-beta` 헤더를 거부하고 GLM-4.7은 영향 없었다는 기록이 있으나, Z.AI 엔드포인트의 펌웨어/프록시 업데이트로 현재 상태는 다를 수 있다. **stale 데이터로 취급**.
+
+---
+
+## 6. 검증 절차 (실 API 키 사용 시)
+
+아래는 실제 Z.AI API 키 보유자가 수행할 수 있는 검증 절차 의사코드다.
+
+### 6.1 단계 1: 베타 헤더 수용 여부 확인
+
+```bash
+# anthropic-beta 헤더를 포함한 최소 요청
+curl -X POST https://api.z.ai/api/anthropic/v1/messages \
+  -H "x-api-key: $ZAI_API_KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "anthropic-beta: prompt-caching-2024-07-31" \
+  -H "content-type: application/json" \
+  -d '{"model":"glm-4.7","max_tokens":10,"messages":[{"role":"user","content":"hi"}]}'
+# 확인 사항: HTTP 400 (헤더 거부) vs 200 (수용 또는 무시)
+# 오류 메시지에 "invalid beta" 또는 "unexpected beta" 포함 여부 확인
+```
+
+### 6.2 단계 2: cache_control ephemeral 전송 후 usage 확인
+
+```bash
+# system 프롬프트에 cache_control 마킹
+curl -X POST https://api.z.ai/api/anthropic/v1/messages \
+  -H "x-api-key: $ZAI_API_KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "content-type: application/json" \
+  -d '{
+    "model": "glm-4.7",
+    "max_tokens": 10,
+    "system": [
+      {
+        "type": "text",
+        "text": "You are a helpful assistant. '"$(python3 -c 'print("x"*2048)')"'",
+        "cache_control": {"type": "ephemeral"}
+      }
+    ],
+    "messages": [{"role": "user", "content": "hi"}]
+  }'
+# 응답 usage 필드 확인:
+# "usage": {
+#   "input_tokens": NNN,
+#   "cache_creation_input_tokens": 0,  <-- 0이면 캐싱 안 됨
+#   "cache_read_input_tokens": 0       <-- 0이면 캐시 히트 없음
+# }
+```
+
+### 6.3 단계 3: 두 번째 요청으로 cache_read 확인
+
+동일 요청을 반복하여 `cache_read_input_tokens > 0`인지 확인한다. 동일 시스템 프롬프트가 5분 TTL 내에 재사용되면 캐시 히트가 발생해야 한다(Anthropic 네이티브 기준).
+
+### 6.4 응답 usage 객체 확인 필드
+
+```json
+{
+  "usage": {
+    "input_tokens":                   <-- 비캐시 입력 토큰
+    "cache_creation_input_tokens":    <-- 0이면 캐싱 미지원 또는 최솟값 미달
+    "cache_read_input_tokens":        <-- 0이면 캐시 히트 없음
+    "output_tokens":                  <-- 정상
+    "cache_write_input_tokens":       <-- 일부 SDK에서 사용하는 별칭
+  }
+}
+```
+
+`cache_creation_input_tokens`과 `cache_read_input_tokens`이 모두 `0`이거나 응답 JSON에 **존재하지 않으면** Z.AI 엔드포인트가 캐싱을 처리하지 않는다고 판단한다.
+
+---
+
+## 7. 권장 정책
+
+### 옵션 A: 현행 유지 (권장)
+
+두 플래그(`DISABLE_PROMPT_CACHING=1`, `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1`)를 모든 `moai glm` 경로에서 유지한다.
+
+**근거**:
+1. Z.AI 공식 문서에 캐싱 지원이 명시되지 않았다. 지원 의사를 확인할 수 없다.
+2. `cache_read_input_tokens` 실측 사례가 공개적으로 없다. 캐싱이 동작한다는 증거가 없다.
+3. LiteLLM 오픈소스 생태계에서도 Z.AI/GLM에 `cache_control`을 전송하면 스트리핑하거나 무시하는 동작이 관측됐다(Issue #19923).
+4. `DISABLE_EXPERIMENTAL_BETAS`가 효과적으로 동작하지 않는 회귀 패턴이 2026년 내 3회 관측됐다. GLM 사용자 입장에서 베타 헤더 전송은 Z.AI의 미구현 기능을 호출하는 것으로, 오류 또는 정의되지 않은 동작으로 이어진다.
+5. `DISABLE_PROMPT_CACHING=1`의 주된 이유(전체 시스템 프롬프트 재전송 → 컨텍스트 소진)는 캐싱 지원 여부와 무관하게 유효하다. 캐싱이 지원되지 않는 한 이 플래그는 올바른 보호 역할을 한다.
+
+**한계**: `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS` 우회 회귀가 반복되므로, Claude Code 신규 버전 업데이트 시 베타 헤더 전송 여부를 주기적으로 확인해야 한다.
+
+---
+
+### 옵션 B: opt-in 환경변수 (`MOAI_GLM_ENABLE_CACHING=1`)
+
+사용자가 실 API로 §6 절차를 직접 확인한 후 선택적으로 캐싱을 활성화하는 경로를 제공한다.
+
+**구현 예시**:
+```go
+// setGLMEnv 내에서
+if os.Getenv("MOAI_GLM_ENABLE_CACHING") != "1" {
+    _ = os.Setenv("DISABLE_PROMPT_CACHING", "1")
+}
+```
+
+**장점**: 실제로 Z.AI가 캐싱을 지원하는 것이 확인되면 전환 비용 없이 활성화 가능.  
+**단점**: 검증 절차 없이 활성화하면 오류 또는 비용 증가 위험. 현재 공개 증거 없음.
+
+현재 시점에서는 **대기** 권고. Z.AI 측의 공식 문서화 또는 커뮤니티 실측 보고가 나왔을 때 검토.
+
+---
+
+### 옵션 C: 모델별 분기
+
+GLM-4.7은 베타 헤더에 덜 민감하다는 30일 전 기록을 근거로 모델별로 분기한다.
+
+**장점**: 이론적으로 일부 모델에서 캐싱 시도 가능.  
+**단점**:
+1. 30일 전 메모리는 stale이다. Z.AI 프록시 업데이트로 현재 동작이 달라졌을 수 있다.
+2. 캐싱이 실제로 동작한다는 확인이 없으므로 모델별 분기는 위험 대비 이득이 불명확하다.
+3. `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS` 우회 회귀 패턴으로 인해 특정 모델에서 베타 헤더를 허용해도 Claude Code 자체에서 예상치 않은 베타 플래그를 전송할 수 있다.
+
+현재 시점에서 **권장하지 않음**.
+
+---
+
+### 권장 결론
+
+**옵션 A 유지**. 근거가 불충분한 상태에서 현행 보호 플래그를 변경하는 것은 정의되지 않은 동작으로 이어질 가능성이 높다.
+
+**SPEC-GLM-001 amendment 필요 여부**: 이 보고서의 조사 결과를 `SPEC-GLM-001` 코드 주석(`glm.go:142–147`) 에 보강하는 것은 고려할 수 있다. 그러나 플래그 제거나 opt-in 로직 추가는 §8의 open question이 해소된 후에 별도 SPEC으로 진행할 것을 권장한다.
+
+---
+
+## 8. Open Questions
+
+이 보고서에서 검증되지 않은 항목 및 사용자가 실 API로 확인해야 할 항목:
+
+1. **[검증 필요] Z.AI가 `cache_control: { type: "ephemeral" }` 필드를 수신하면 어떻게 처리하는가?**  
+   - 무시(silently ignore)하는가, 오류를 반환하는가, 아니면 실제로 캐싱하는가?  
+   - 확인 방법: §6.2 단계 수행 후 응답 usage 필드 확인.
+
+2. **[검증 필요] Z.AI가 `anthropic-beta: prompt-caching-2024-07-31` 헤더를 수신하면 400 오류를 반환하는가?**  
+   - 30일 전 GLM-5.1에서는 Error 1214/400이 발생했다는 기록이 있으나 stale.  
+   - 확인 방법: §6.1 단계 수행.
+
+3. **[검증 필요] Z.AI의 "GLM-5 네이티브 캐싱"(openclaw #24497에서 언급)이 Anthropic `cache_control` 방식과 동일한 메커니즘인가, 아니면 자체 컨텍스트 캐싱인가?**  
+   - Z.AI 공식 문서나 Zhipu AI 개발자 문서에서 확인 필요.
+
+4. **[검증 필요] Claude Code v2.1.119–121 이후 `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1` 설정 시 `advanced-tool-use-2025-11-20` 베타 플래그가 실제로 억제되는가?**  
+   - 최신 CC 버전(현재 v2.1.119–122 기준) + Z.AI 엔드포인트 조합에서 서버 측 거부 오류 발생 여부 확인.
+
+5. **[검증 필요] `DISABLE_PROMPT_CACHING=1` 없이 `moai glm`을 실행할 경우 컨텍스트 소진이 얼마나 빨리 발생하는가?**  
+   - glm.go 주석의 "30-40K 토큰/요청" 추정치가 현재 모델(GLM-5.1, GLM-5-Turbo)에서도 동일하게 적용되는지 확인.
+
+6. **[검증 필요] Z.AI의 Anthropic 호환 엔드포인트가 Anthropic의 공식 메시지 API 변경(베타 헤더 불필요 → `cache_control` 자동 처리)을 반영하는가?**  
+   - Anthropic은 `prompt-caching-2024-07-31` 베타 헤더 없이도 `cache_control` 필드만으로 캐싱 동작함을 공식화했다. Z.AI 프록시가 이를 패스스루하는지 확인 필요.
+
+---
+
+## 9. References
+
+| 출처 | URL | 날짜 |
+|------|-----|------|
+| Z.AI 개발자 문서 FAQ | https://docs.z.ai/devpack/faq | 2026-05-01 조회 |
+| Z.AI 빠른 시작 | https://docs.z.ai/devpack/quick-start | 2026-05-01 조회 |
+| Z.AI Claude Code 통합 가이드 | https://docs.z.ai/devpack/tool/claude | 2026-05-01 조회 |
+| LiteLLM Issue #19923: GLM cache_control 스트리핑 버그 | https://github.com/BerriAI/litellm/issues/19923 | 2026-01-28 |
+| openclaw Issue #24497: ZAI GLM-5 cache-ttl 지원 요청 | https://github.com/openclaw/openclaw/issues/24497 | 2026-02-23 |
+| Roo-Code Issue #10601: zai-glm-4.7 캐싱 활성화 요청 | https://github.com/RooCodeInc/Roo-Code/issues/10601 | 2026-01-10 |
+| anthropics/claude-code Issue #22893: DISABLE_BETAS 미동작 | https://github.com/anthropics/claude-code/issues/22893 | 2026-02 |
+| anthropics/claude-code Issue #30926: v2.1.69 beta 플래그 회귀 | https://github.com/anthropics/claude-code/issues/30926 | 2026-03 |
+| anthropics/claude-code Issue #20031: beta=true 쿼리 파라미터 잔류 | https://github.com/anthropics/claude-code/issues/20031 | 2026-01 |
+| anthropics/claude-code Issue #49648: Bedrock Opus 4.7 beta 거부 | https://github.com/anthropics/claude-code/issues/49648 | 2026-04 |
+| APIyi: Claude Code 환경변수 가이드 | https://help.apiyi.com/en/claude-code-environment-variables-complete-guide-en.html | — |
+| Anthropic 공식 프롬프트 캐싱 문서 | https://platform.claude.com/docs/en/build-with-claude/prompt-caching | — |
+| moai-adk-go 소스: glm.go | internal/cli/glm.go:142–177, 370–384, 546–548, 826–829, 870–873 | — |
+| moai-adk-go 소스: session_start.go | internal/hook/session_start.go:238–246 | — |
+| moai-adk-go 소스: launcher.go | internal/cli/launcher.go:235–243 | — |
+| moai-adk-go 소스: auth/glm.go | internal/github/auth/glm.go:34–39 | — |
+| moai-adk-go 테스트: launcher_test.go | internal/cli/launcher_test.go:745–746 | — |
+| moai-adk-go 테스트: glm_test.go | internal/cli/glm_test.go:153–154 | — |
+
+---
+
+*이 보고서는 코드 변경을 포함하지 않으며, 조사 전용입니다.*  
+*공개 출처 검색 기준일: 2026-05-01*

--- a/.moai/specs/SPEC-GLM-MCP-001/acceptance.md
+++ b/.moai/specs/SPEC-GLM-MCP-001/acceptance.md
@@ -1,0 +1,288 @@
+# SPEC-GLM-MCP-001 인수 기준
+
+## HISTORY
+
+| Version | Date | Author | Description |
+|---------|------|--------|-------------|
+| 0.1.0 | 2026-05-01 | manager-spec | 초기 작성 — REQ-GMC-001 ~ 010 별 GWT 시나리오 (총 22개), Edge Cases, Quality Gate, Definition of Done |
+
+본 문서는 SPEC-GLM-MCP-001 의 구현이 완료되었음을 검증하기 위한 Given-When-Then(GWT) 시나리오와 Definition of Done 을 정의한다. 각 시나리오는 `internal/cli/glm_test.go` 또는 `internal/cli/glm_tools_test.go` 의 테이블 드리븐 / sub-test 구조로 자동화된다.
+
+본 acceptance.md 는 **single source of truth** 이며, spec.md 의 "Acceptance Summary" 섹션은 본 파일의 간단 요약일 뿐이다. SPEC-CI-MULTI-LLM-001 audit defect D5 ("acceptance defer to external file" anti-pattern) 를 회피하기 위해 본 파일에 모든 시나리오를 명시적으로 작성한다.
+
+## REQ ↔ GWT 매핑 표
+
+| REQ | 매핑 GWT | 핵심 검증 대상 |
+|-----|---------|---------------|
+| REQ-GMC-001 (Ubiquitous, subcommand 존재 + idempotent) | GWT-1, GWT-2 | `tools enable/disable` subcommand 라우팅 + 반복 호출 안전성 |
+| REQ-GMC-002 (Ubiquitous, SPEC-GLM-001 호환) | GWT-3 | DISABLE_BETAS / DISABLE_PROMPT_CACHING 정책 보존 |
+| REQ-GMC-003 (Event-Driven, enable 전체 경로) | GWT-4, GWT-5 | `~/.claude.json` 에 정확한 엔트리 추가 + 사용자 안내 출력 |
+| REQ-GMC-004 (Event-Driven, disable) | GWT-6, GWT-7 | 엔트리 제거 + 다른 엔트리 보존 |
+| REQ-GMC-005 (Event-Driven, 백업) | GWT-8, GWT-9 | 백업 파일 생성 + idempotent skip 시 백업 생략 |
+| REQ-GMC-006 (Event-Driven, 기존 엔트리 처리) | GWT-10, GWT-11 | 토큰 일치 시 idempotent skip + 토큰 불일치 시 `--force` 안내 |
+| REQ-GMC-007 (State-Driven, 토큰 부재) | GWT-12 | 토큰 부재 시 enable 거부 + 가이드 출력 |
+| REQ-GMC-008 (Optional, project scope) | GWT-13 | `--scope project` 시 `.mcp.json` 에 기록 |
+| REQ-GMC-009 (Unwanted, Node.js 부재/구버전) | GWT-14, GWT-15 | 부재/구버전 시 graceful fail + `~/.claude.json` 변경 없음 |
+| REQ-GMC-010 (Unwanted, 사용자 정의 엔트리 보존) | GWT-16, GWT-17 | enable/disable 모두에서 다른 mcpServers 엔트리 보존 |
+| Edge Cases | GWT-18 ~ GWT-22 | 모드 전환, atomic write, JSON 파싱, locale, 명령 인자 검증 |
+
+## Given-When-Then 시나리오
+
+### GWT-1: `tools enable` subcommand 라우팅 + idempotent
+
+**Given:** 사용자가 정상 환경 (Node.js >= 22, GLM_AUTH_TOKEN 설정됨, `~/.claude.json` 의 mcpServers 에 zai-mcp-server 부재) 에 있다.
+**When:** `moai glm tools enable vision` 을 실행한다. 이어서 동일 명령을 두 번째로 실행한다.
+**Then:**
+- 첫 실행: 종료 코드 0, `~/.claude.json` 의 `mcpServers.zai-mcp-server` 엔트리 추가
+- 두 번째 실행: 종료 코드 0, "이미 활성화됨" 메시지, `~/.claude.json` 내용 변경 없음 (idempotent skip)
+
+### GWT-2: `tools disable` subcommand 라우팅 + idempotent
+
+**Given:** GWT-1 의 첫 실행 직후 상태 (zai-mcp-server 엔트리 존재).
+**When:** `moai glm tools disable all` 을 실행한다. 이어서 동일 명령을 두 번째로 실행한다.
+**Then:**
+- 첫 실행: 종료 코드 0, zai-mcp-server 엔트리 제거됨
+- 두 번째 실행: 종료 코드 0, "활성화된 zai-mcp-server 엔트리 없음" 메시지, `~/.claude.json` 변경 없음 (idempotent skip)
+
+### GWT-3: SPEC-GLM-001 호환성 (REQ-GMC-002)
+
+**Given:** 사용자가 `moai glm` 모드에서 작업 중이며, settings.local.json 에 `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1` 와 `DISABLE_PROMPT_CACHING=1` 가 SPEC-GLM-001 에 의해 설정되어 있다.
+**When:** `moai glm tools enable all` 을 실행하고, 그 후 `moai cc` 로 모드 전환 후 `moai glm` 으로 다시 전환한다.
+**Then:**
+- `moai glm tools enable` 동작은 settings.local.json 의 env 키들을 *변경하지 않음*
+- `moai cc` → `moai glm` 모드 전환 후에도 SPEC-GLM-001 의 정책이 정상 작동 (기존 회귀 테스트 통과)
+- zai-mcp-server 엔트리는 모드 전환 영향을 받지 않음 (사용자 명시 disable 까지 유지)
+
+### GWT-4: enable 의 전체 경로 — 엔트리 정확성 (REQ-GMC-003)
+
+**Given:** Node.js v22.5.0 설치됨, `~/.moai/.env.glm` 에 `GLM_AUTH_TOKEN=test-glm-key-abc123`, `~/.claude.json` 에 zai-mcp-server 부재.
+**When:** `moai glm tools enable vision` 을 실행한다.
+**Then:** `~/.claude.json` 의 `mcpServers.zai-mcp-server` 엔트리는 정확히 다음을 포함:
+- `command: "npx"`
+- `args: ["-y", "@z_ai/mcp-server@latest"]`
+- `env.Z_AI_API_KEY: "test-glm-key-abc123"`
+- `env.Z_AI_MODE: "ZAI"`
+
+JSON 파싱 후 위 4개 필드가 모두 검증되어야 한다. 다른 필드 (timeout 등) 는 본 SPEC 범위 밖이므로 포함 여부 무관.
+
+### GWT-5: enable 의 사용자 안내 출력 (REQ-GMC-003)
+
+**Given:** GWT-4 와 동일.
+**When:** `moai glm tools enable all` 을 실행한다.
+**Then:** stdout 에 다음 정보가 모두 포함됨:
+- 활성화된 도구 목록 (Vision / Web Search / Web Reader)
+- "Pro 플랜 ($9/월) 이상 필요" 또는 동등한 plan tier 안내
+- "Claude Code 재시작 필요" 안내
+- 비활성화 명령 (`moai glm tools disable all`) 안내
+
+### GWT-6: disable 의 엔트리 제거 (REQ-GMC-004)
+
+**Given:** `~/.claude.json` 의 mcpServers 에 zai-mcp-server 엔트리가 존재함.
+**When:** `moai glm tools disable all` 을 실행한다.
+**Then:** `~/.claude.json` 의 mcpServers 객체에서 zai-mcp-server 키가 제거되고, mcpServers 객체 자체는 (다른 엔트리가 없으면) 빈 객체로 유지되거나, 다른 엔트리가 있으면 그대로 보존됨.
+
+### GWT-7: disable 후 다른 mcpServers 엔트리 보존 (REQ-GMC-004)
+
+**Given:** `~/.claude.json` 의 mcpServers 에 다음 4개 엔트리 존재: `context7`, `sequential-thinking`, `moai-lsp`, `zai-mcp-server`.
+**When:** `moai glm tools disable all` 을 실행한다.
+**Then:** mcpServers 객체에 정확히 3개 엔트리 (`context7`, `sequential-thinking`, `moai-lsp`) 만 남고, 각 엔트리의 `command`, `args`, `env`, `timeout`, `$comment` 등 모든 필드가 변경 없이 보존됨.
+
+### GWT-8: 백업 파일 생성 (REQ-GMC-005)
+
+**Given:** `~/.claude.json` 의 mcpServers 에 zai-mcp-server 부재, Node.js + 토큰 정상.
+**When:** `moai glm tools enable vision` 을 실행하고, 명령 종료 후 `~/.claude.json` 동일 디렉토리를 검사한다.
+**Then:** `~/.claude.json.bak-<ISO timestamp>` 패턴의 백업 파일이 정확히 1개 생성됨. 백업 내용은 명령 실행 *직전* 상태의 `~/.claude.json` 와 동일.
+
+### GWT-9: idempotent skip 시 백업 생략 (REQ-GMC-005)
+
+**Given:** `~/.claude.json` 에 zai-mcp-server 엔트리가 이미 존재하고 토큰이 일치함 (GWT-1 의 두 번째 실행 시나리오).
+**When:** `moai glm tools enable vision` 을 실행한다.
+**Then:** `~/.claude.json.bak-*` 패턴의 백업 파일이 *생성되지 않음* (idempotent skip 은 변경이 없으므로 백업 불필요).
+
+### GWT-10: 기존 엔트리 + 토큰 일치 → idempotent skip (REQ-GMC-006 (a))
+
+**Given:** `~/.claude.json` 에 zai-mcp-server 엔트리가 이미 존재하며, `env.Z_AI_API_KEY` 가 `~/.moai/.env.glm` 의 `GLM_AUTH_TOKEN` 과 동일.
+**When:** `moai glm tools enable all` 을 실행한다.
+**Then:**
+- 종료 코드 0
+- "이미 활성화됨" 메시지 출력
+- `~/.claude.json` 변경 없음 (mtime 변경 없음 또는 동일 내용)
+
+### GWT-11: 기존 엔트리 + 토큰 불일치 → `--force` 안내 (REQ-GMC-006 (b))
+
+**Given:** `~/.claude.json` 에 zai-mcp-server 엔트리가 존재하며, `env.Z_AI_API_KEY` 가 `~/.moai/.env.glm` 의 `GLM_AUTH_TOKEN` 과 *다름*.
+**When:** `moai glm tools enable all` 을 실행한다 (--force 없이).
+**Then:**
+- 종료 코드 비-0
+- 차이 요약 출력 (예: "기존: TOKEN_A...XYZ, 새 토큰: TOKEN_B...ABC")
+- "덮어쓰려면 --force 사용" 안내 출력
+- `~/.claude.json` 변경 없음 (사용자 데이터 보호)
+
+### GWT-12: 토큰 부재 → enable 거부 (REQ-GMC-007)
+
+**Given:** `~/.moai/.env.glm` 파일이 존재하지 않거나 `GLM_AUTH_TOKEN` 이 빈 문자열.
+**When:** `moai glm tools enable vision` 을 실행한다.
+**Then:**
+- 종료 코드 비-0
+- "GLM 토큰 미설정" 에러 메시지
+- 토큰 등록 가이드 (`moai github auth glm <token>` 또는 동등한 명령) 출력
+- `~/.claude.json` 변경 없음 (어떤 엔트리도 추가/수정되지 않음)
+
+### GWT-13: `--scope project` 옵션 (REQ-GMC-008)
+
+**Given:** Node.js + 토큰 정상, 프로젝트 루트 (`pwd`) 에 `.mcp.json` 부재.
+**When:** `moai glm tools enable vision --scope project` 을 실행한다.
+**Then:**
+- 프로젝트 루트의 `.mcp.json` 에 `mcpServers.zai-mcp-server` 엔트리가 생성됨 (GWT-4 와 동일한 4개 필드 포함)
+- `~/.claude.json` 의 mcpServers 는 *변경되지 않음* (user scope 미터치)
+
+### GWT-14: Node.js 부재 (REQ-GMC-009)
+
+**Given:** PATH 에 `node` 명령이 없음 (`exec.LookPath("node")` 가 에러 반환).
+**When:** `moai glm tools enable all` 을 실행한다.
+**Then:**
+- 종료 코드 비-0
+- "Node.js not found" 에러 메시지
+- 최소 요구 버전 (`>= v22.0.0`) 안내
+- 설치 가이드 (예: `https://nodejs.org/` 또는 nvm 권장) 출력
+- `~/.claude.json` 변경 없음
+
+### GWT-15: Node.js 구버전 (REQ-GMC-009)
+
+**Given:** PATH 에 `node` 가 존재하나 버전이 `v18.20.4` (< v22.0.0).
+**When:** `moai glm tools enable vision` 을 실행한다.
+**Then:**
+- 종료 코드 비-0
+- 감지된 버전 (`v18.20.4`) + 최소 요구 버전 (`>= v22.0.0`) 출력
+- 업그레이드 가이드 출력
+- `~/.claude.json` 변경 없음
+
+### GWT-16: 사용자 정의 엔트리 보존 — enable (REQ-GMC-010)
+
+**Given:** `~/.claude.json` 의 mcpServers 에 사용자 정의 엔트리 `my-custom-server` (사용자가 직접 추가) + `context7`, `sequential-thinking` 가 존재. zai-mcp-server 부재.
+**When:** `moai glm tools enable vision` 을 실행한다.
+**Then:**
+- mcpServers 객체에 4개 엔트리: `my-custom-server`, `context7`, `sequential-thinking`, `zai-mcp-server`
+- `my-custom-server`, `context7`, `sequential-thinking` 의 모든 필드 (`command`, `args`, `env`, etc.) 가 변경 없이 *완전히* 보존됨
+- 새 엔트리 `zai-mcp-server` 만 추가됨
+
+### GWT-17: 사용자 정의 엔트리 보존 — disable (REQ-GMC-010)
+
+**Given:** `~/.claude.json` 의 mcpServers 에 `my-custom-server`, `context7`, `zai-mcp-server` 3개 존재.
+**When:** `moai glm tools disable all` 을 실행한다.
+**Then:**
+- mcpServers 객체에 정확히 2개 엔트리: `my-custom-server`, `context7`
+- `my-custom-server` 와 `context7` 의 모든 필드가 변경 없이 보존됨
+- `zai-mcp-server` 만 제거됨
+
+## Edge Cases (자동화 테스트 권장)
+
+### GWT-18: 모드 전환 후 zai-mcp-server 엔트리 유지 (R5 검증)
+
+**Given:** `moai glm tools enable all` 으로 zai-mcp-server 활성화된 상태.
+**When:** `moai cc` 로 모드 전환 → 작업 → `moai glm` 으로 재전환.
+**Then:** `~/.claude.json` 의 mcpServers.zai-mcp-server 엔트리가 모든 모드 전환 후에도 *그대로 유지됨* (사용자 명시 `disable` 까지 유지). EX-4 정책 검증.
+
+### GWT-19: atomic write 실패 시 복구 (R7 검증)
+
+**Given:** `~/.claude.json` 이 존재하고, 디스크 풀 또는 권한 문제로 atomic write 가 실패하는 시뮬레이션 (테스트에서는 mock).
+**When:** `moai glm tools enable vision` 을 실행한다.
+**Then:**
+- 종료 코드 비-0
+- 명확한 에러 메시지 출력 (디스크 풀 또는 권한 문제)
+- `~/.claude.json` 의 *원본 내용* 이 손상 없이 보존됨 (atomic rename 의 atomicity 보장)
+- 백업 파일 (`~/.claude.json.bak-*`) 이 존재하면 사용자에게 복구 가이드 출력
+
+### GWT-20: JSON 파싱 유효성
+
+**Given:** `moai glm tools enable all` 실행 후 결과 `~/.claude.json`.
+**When:** 결과 파일을 `encoding/json` 으로 디코드한다.
+**Then:** 파싱이 에러 없이 성공. JSON 문법 (trailing comma, 따옴표 짝, 키 중복 없음) 이 유효.
+
+### GWT-21: locale 출력 언어 (i18n)
+
+**Given:** `.moai/config/sections/language.yaml` 의 `conversation_language: ko` (현재 프로젝트 설정).
+**When:** `moai glm tools enable vision` 을 실행하여 stdout 메시지를 캡처한다.
+**Then:**
+- 사용자 안내 메시지 (`"Vision 활성화됨"`, `"Pro 플랜 권장"`, `"Claude Code 재시작 필요"`) 가 한국어로 출력됨
+- 에러 메시지 (errno, exec error 등) 는 영어 그대로 (CLAUDE.local.md §language policy 준수)
+
+### GWT-22: 명령 인자 검증
+
+**Given:** 사용자가 잘못된 인자로 명령 실행.
+**When:**
+- (a) `moai glm tools enable foo` (도구명 오타)
+- (b) `moai glm tools enable` (인자 없음)
+- (c) `moai glm tools enable vision websearch` (옵션 2개 동시)
+**Then:**
+- (a): "알 수 없는 도구명: foo. 지원: vision, websearch, webreader, all" 에러 + 사용법 출력
+- (b): 사용법 출력 + 종료 코드 비-0 (또는 기본값으로 `all` 적용 — 결정은 M3 에서, 어느 쪽이든 일관)
+- (c): "한 번에 하나의 도구명만 또는 'all' 사용" 에러 + 사용법 출력 (또는 v0.1 에서는 모두 enable 처리 — 결정은 M3)
+
+## 성능 게이트
+
+| 메트릭 | 기준 | 측정 방법 |
+|--------|------|-----------|
+| `moai glm tools enable` 명령 지연 | < 5초 (npx 첫 다운로드 제외) | 테스트에서 `time` 측정 |
+| `moai glm tools disable` 명령 지연 | < 1초 | 테스트에서 `time` 측정 |
+| `~/.claude.json` 파일 크기 증가 | < 500 bytes 추가 (단일 zai-mcp-server 엔트리) | 백업 파일과 신규 파일 크기 비교 |
+| atomic write race window | 0 (POSIX rename atomicity 보장) | OS 가 보장, 테스트 불요 |
+
+> **Note**: npx 첫 다운로드 (~5MB `@z_ai/mcp-server` 패키지) 는 사용자가 실제로 도구를 *호출* 할 때 발생하며, `moai glm tools enable` 자체에서는 발생하지 않음 (Claude Code 의 lazy MCP loading 정책 + SPEC-CC2122-MCP-001 의 alwaysLoad=false 기본값에 의해).
+
+## 품질 게이트 기준
+
+본 SPEC 의 인수 조건은 다음을 모두 충족해야 한다:
+
+- [ ] **EARS 준수**: spec.md 의 10개 REQ-GMC-001 ~ 010 이 모두 EARS 패턴으로 표현됨 (Ubiquitous 2 + Event-Driven 4 + State-Driven 1 + Optional 1 + Unwanted 2)
+- [ ] **GWT-1 ~ GWT-22**: 모든 시나리오가 자동화된 테스트로 통과 (manual 검증 가능 케이스는 수동 + 가이드)
+- [ ] **REQ ↔ GWT 매핑**: 본 acceptance.md 상단 매핑 표의 모든 REQ 가 ≥ 1개 GWT 로 검증됨
+- [ ] **하위 호환**: GWT-3 (SPEC-GLM-001 호환성) + GWT-7, GWT-16, GWT-17 (다른 mcpServers 엔트리 보존) 통과
+- [ ] **회귀 없음**: 기존 `internal/cli/glm_test.go` 의 모든 테스트 + 다른 패키지 테스트 통과 (`go test ./...`)
+- [ ] **race-free**: `go test -race ./internal/cli/...` 통과
+- [ ] **vet/lint**: `go vet ./...` 무경고, `golangci-lint run` 무경고 (가능한 경우)
+- [ ] **빌드**: `make build` 성공으로 `internal/template/embedded.go` 가 최신 템플릿 반영
+- [ ] **테스트 커버리지**: 신규 패키지 (`internal/cli/glm_tools.go` 또는 `internal/integration/zaimcp/`) ≥ 85% 라인 커버리지 (CLAUDE.local.md §6 Coverage Targets)
+- [ ] **문서 동기화**: 두 `settings-management.md` 파일 (템플릿 + 루트 미러본) 에 Z.AI MCP 노트 부착, 두 사본 동일 내용 (Template-First Rule, CLAUDE.local.md §2)
+- [ ] **CHANGELOG.md** 에 v0.1 항목 추가
+- [ ] **16개 언어 중립성**: CLAUDE.local.md §15 verification 통과
+
+## Definition of Done
+
+다음 조건이 모두 만족되면 SPEC-GLM-MCP-001 은 완료(`status: completed`)로 간주한다:
+
+1. `moai glm tools enable [vision|websearch|webreader|all]` subcommand 가 작동하며 REQ-GMC-001 ~ 010 을 모두 충족.
+2. `moai glm tools disable [vision|websearch|webreader|all]` subcommand 가 작동하며 다른 mcpServers 엔트리를 손상하지 않음.
+3. `~/.moai/.env.glm` 의 `GLM_AUTH_TOKEN` 이 자동 재사용되어 사용자가 토큰을 재입력하지 않음.
+4. Node.js < v22 환경에서 graceful fail + `~/.claude.json` 무변경.
+5. 기존 zai-mcp-server 엔트리가 사용자 정의 토큰을 가질 때 `--force` 안내로 데이터 보호.
+6. GWT-1 ~ GWT-22 시나리오가 모두 자동화된 테스트로 작성·통과됨 (수동 검증 케이스는 명시적으로 수동임을 표시).
+7. `go test ./...` 전체 통과, `go vet ./...` 무경고, `go test -race ./internal/cli/...` 통과.
+8. `make build` 이후 `internal/template/embedded.go` 가 최신 템플릿 반영.
+9. `internal/template/templates/.claude/rules/moai/core/settings-management.md` 와 `.claude/rules/moai/core/settings-management.md` 두 파일에 Z.AI MCP 통합 노트 + `moai glm tools` 사용 가이드가 동일하게 부착됨.
+10. CHANGELOG.md 에 v0.1 항목 추가.
+11. PR 이 main 에 머지되어 `merged_pr` / `merged_commit` 정보가 spec.md frontmatter 에 기록됨.
+12. plan-auditor 의 사후 감사(post-merge audit)에서 통과 판정.
+13. 사용자 수동 통합 검증 (가능한 경우): `moai glm tools enable all` → Claude Code 재시작 → Vision MCP 도구 호출 → `moai glm tools disable all` → 엔트리 제거 확인.
+
+## 검증 방법 요약
+
+| 시나리오 그룹 | 검증 도구 | 자동화 여부 |
+|--------------|-----------|-----------|
+| GWT-1 ~ GWT-2 (subcommand idempotent) | `go test ./internal/cli/...` (`TestGLMToolsEnableIdempotent`, `TestGLMToolsDisableIdempotent`) | 자동화 |
+| GWT-3 (SPEC-GLM-001 호환) | 기존 GLM 회귀 테스트 + 신규 sub-test | 자동화 |
+| GWT-4 ~ GWT-5 (enable 정확성) | 신규 테스트 + JSON 디코드 후 필드 검증 | 자동화 |
+| GWT-6 ~ GWT-7 (disable + 보존) | 신규 테스트 + 다중 엔트리 fixture | 자동화 |
+| GWT-8 ~ GWT-9 (백업 정책) | 신규 테스트 + `t.TempDir()` 격리 | 자동화 |
+| GWT-10 ~ GWT-11 (기존 엔트리 처리) | 신규 테스트 + 토큰 mock | 자동화 |
+| GWT-12 (토큰 부재) | 신규 테스트 + `~/.moai/.env.glm` mock | 자동화 |
+| GWT-13 (`--scope project`) | 신규 테스트 + 프로젝트 루트 mock | 자동화 |
+| GWT-14 ~ GWT-15 (Node.js 부재/구버전) | 신규 테스트 + PATH mock + 버전 출력 mock | 자동화 |
+| GWT-16 ~ GWT-17 (사용자 정의 엔트리 보존) | 신규 테스트 + 다중 mcpServers fixture | 자동화 |
+| GWT-18 (모드 전환) | 통합 테스트 또는 수동 검증 (CLAUDE.local.md §13 GLM Integration Testing 정책 — dev 프로젝트에서 실행 금지, `/tmp/test-project` 사용) | 부분 자동화 |
+| GWT-19 (atomic write 실패) | 신규 테스트 + write error mock | 자동화 |
+| GWT-20 (JSON 파싱 유효성) | 신규 테스트 + `encoding/json` 검증 | 자동화 |
+| GWT-21 (locale 출력) | 신규 테스트 + language.yaml mock | 자동화 |
+| GWT-22 (인자 검증) | 신규 테스트 + 명령 인자 변형 | 자동화 |
+| Definition of Done #11, #12 | manager-git PR 머지 후 plan-auditor 호출 | 수동 트리거 (자동 검증) |
+| Definition of Done #13 | 사용자 수동 검증 (실제 Z.AI 토큰 + 실제 Claude Code 세션 필요) | 수동 |

--- a/.moai/specs/SPEC-GLM-MCP-001/plan.md
+++ b/.moai/specs/SPEC-GLM-MCP-001/plan.md
@@ -1,0 +1,214 @@
+# SPEC-GLM-MCP-001 구현 계획
+
+## HISTORY
+
+| Version | Date | Author | Description |
+|---------|------|--------|-------------|
+| 0.1.0 | 2026-05-01 | manager-spec | 초기 작성 — 5개 마일스톤, 5개 리스크 카탈로그, 6개 OQ 결정 표 |
+
+## 개요
+
+본 계획은 SPEC-GLM-MCP-001 의 구현 — `moai glm tools enable|disable [vision|websearch|webreader|all]` subcommand 를 통해 Z.AI 의 공식 `@z_ai/mcp-server` 패키지를 Claude Code MCP 서버로 등록 — 의 마일스톤, 기술적 접근, 리스크, 의존성을 정의한다.
+
+본 문서는 시간 추정 (예: "2 days") 대신 **우선순위 라벨** 과 **단계 간 순서** 로 진행을 표현한다 (CLAUDE.local.md §14 + agent-common-protocol.md §Time Estimation 준수).
+
+## 기술적 접근 (High-Level)
+
+핵심 구현은 다음 4 컴포넌트로 구성된다:
+
+1. **명령 라우터 확장** — `internal/cli/glm.go` 또는 신규 `internal/cli/glm_tools.go` 에 `tools` subcommand 추가. cobra 또는 기존 명령 디스패치 패턴을 따름.
+2. **Node.js 버전 검증** — `exec.LookPath("node")` + `exec.Command("node", "--version")` 으로 최소 v22.0.0 검증. 부재/구버전 시 graceful fail.
+3. **JSON 머지 로직** — `~/.claude.json` (또는 `.mcp.json` for project scope) 을 안전하게 read → unmarshal → mcpServers 키만 부분 갱신 → marshal → 백업 후 atomic write. 다른 MCP 엔트리 (`context7`, `sequential-thinking`, `moai-lsp`, 사용자 정의) 는 절대 손대지 않음.
+4. **토큰 재사용** — 기존 `loadGLMKey()` 헬퍼 (`~/.moai/.env.glm` 의 `GLM_AUTH_TOKEN`) 를 재사용하여 사용자가 토큰을 재입력하지 않도록 함. 토큰 부재 시 친절한 안내.
+
+테스트 측면에서는 기존 `internal/cli/glm_test.go` 의 패턴 (table-driven, t.TempDir() 격리, `loadGLMKey()` 모킹) 을 따른다. 신규 테스트 함수는 `TestGLMToolsEnable*`, `TestGLMToolsDisable*` prefix 로 grep/search 가능하게 명명한다.
+
+문서 동기화는 `internal/template/templates/.claude/rules/moai/core/settings-management.md` (템플릿) 와 `.claude/rules/moai/core/settings-management.md` (루트 미러본) 두 파일에 동일한 짧은 노트를 추가하는 단순 미러 작업이며, Template-First Rule (CLAUDE.local.md §2) 에 따라 템플릿 본을 먼저 수정한다.
+
+## Open Questions Resolution
+
+research.md §7 의 6개 OQ 에 대한 plan-stage 결정:
+
+| OQ | 결정 | 근거 |
+|----|------|------|
+| OQ-1 (별도 vs `all`) | **둘 다 지원** — `tools enable [vision\|websearch\|webreader\|all]` | 사용자 통제권 ↑, 단순성 미세 손실은 허용 |
+| OQ-2 (user vs project scope) | **user scope 기본**, `--scope project` 옵션 | Z.AI 공식 가이드 일관 + 다중 프로젝트 사용자 편의 |
+| OQ-3 (기존 엔트리 처리) | **idempotent skip (토큰 일치)** + **`--force` 안내 (토큰 불일치)** | R1 위험 완화 + 사용자 데이터 보호 |
+| OQ-4 (Lite 플랜 처리) | **경고 출력 + 진행** (사전 검증 API 비싸거나 불안정 가능) | EX-2 와 일관, 런타임 에러는 Z.AI 가 반환 |
+| OQ-5 (Mainland China v0.1?) | **제외 (EX-1)**, v0.2 로 연기 | 단순화 + 검증 부담 감소 |
+| OQ-6 (sample test 자동 실행) | **v0.1 에서 제외 (EX-6)**, 향후 `--test` 플래그 | 첫 실행 ~10s 지연 회피 |
+
+## Milestones
+
+### M1 — Path Discovery + Existing Pattern Review (Priority: High)
+
+**목표**: 변경 대상 파일의 정확한 경로/라인 범위 식별, `internal/cli/glm.go` 의 기존 명령 디스패치 패턴 + `internal/cli/glm_test.go` 의 기존 테스트 패턴 식별.
+
+**작업 항목:**
+
+- `internal/cli/glm.go` 의 명령 라우팅 (cobra 등) 패턴 확인
+- `internal/cli/github_auth.go` 의 `moai github auth glm` subcommand 구조 분석 (참조 패턴)
+- `internal/cli/glm.go:loadGLMKey()` (또는 동등 함수) 의 정확한 위치, 시그니처, 테스트 헬퍼 확인
+- `internal/cli/glm_test.go` 의 기존 케이스가 사용하는 테스트 컨벤션 식별: t.TempDir() 사용 여부, HOME 디렉토리 모킹 방식, JSON fixture 위치
+- `~/.claude.json` 의 표준 구조 (`mcpServers` 객체 + 사용자 정의 엔트리 보존 정책) 사례 확인 (SPEC-CC2122-MCP-001 참조)
+- `.claude/rules/moai/core/settings-management.md` 와 그 템플릿 미러본의 현재 구조 (섹션 헤더, MCP 관련 기존 설명) 확인하여 노트 삽입 지점 선정
+
+**Done 기준:**
+
+- 수정 대상 파일 모두 정확한 경로/라인 범위가 식별되어 PR 설명에 인용 가능
+- 신규 테스트가 따라야 할 기존 컨벤션이 명확히 결정됨
+- 기존 `loadGLMKey()` 재사용 가능성 / 보강 필요성 판단
+
+### M2 — JSON Merge Helper + Node.js Version Detection (Priority: High)
+
+**목표**: `~/.claude.json` 의 안전 머지 로직 + Node.js 버전 검증 헬퍼를 패키지로 분리하여 재사용성 + 테스트 용이성 확보.
+
+**작업 항목:**
+
+- 신규 헬퍼 (위치: `internal/cli/glm_tools.go` 또는 `internal/integration/zaimcp/`):
+  - `mergeMCPServer(configPath string, name string, entry MCPEntry) error` — atomic write + 백업
+  - `removeMCPServer(configPath string, name string) error` — 부분 제거, 다른 엔트리 보존
+  - `detectNodeVersion() (semver.Version, error)` — node `--version` 파싱
+- 백업 정책: `~/.claude.json.bak-<ISO timestamp>` 생성 (REQ-GMC-005). idempotent skip 시 백업 생략
+- atomic write: 임시 파일 → `os.Rename` 패턴 (POSIX atomic guarantee)
+- 사용자 정의 엔트리 보존 검증: 기존 `mcpServers` 의 모든 키 중 `zai-mcp-server` 외에는 변경하지 않음 (REQ-GMC-010)
+- TDD 사이클: 헬퍼 테스트 먼저 작성 (RED) → 구현 (GREEN)
+
+**Done 기준:**
+
+- 신규 헬퍼 함수가 `internal/cli/...` 또는 `internal/integration/zaimcp/...` 에 추가됨
+- 헬퍼별 unit test 가 `t.TempDir()` 격리로 작성됨
+- 사용자 정의 MCP 엔트리 보존 검증 테스트 (REQ-GMC-010 매핑) 통과
+- Node.js 버전 검증의 3가지 케이스 (정상, 부재, 구버전) 테스트 통과
+
+### M3 — Subcommand Routing + Token Reuse Integration (Priority: High)
+
+**목표**: `moai glm tools enable|disable [도구명]` subcommand 를 명령 라우터에 추가하고, M2 의 헬퍼 + 기존 `loadGLMKey()` 를 통합한다.
+
+**작업 항목:**
+
+- `glm tools enable` 명령:
+  - Step 1: `loadGLMKey()` 호출 → 토큰 부재 시 REQ-GMC-007 에러 메시지 + exit code 비-0
+  - Step 2: `detectNodeVersion()` 호출 → < v22 시 REQ-GMC-009 에러 메시지 + exit code 비-0
+  - Step 3: 기존 `~/.claude.json` 읽고 `zai-mcp-server` 엔트리 검사 → REQ-GMC-006 (a) idempotent skip 또는 (b) `--force` 안내
+  - Step 4: `mergeMCPServer()` 호출 → 백업 + atomic write
+  - Step 5: 활성화된 도구 목록 + Pro 플랜 권장 + Claude Code 재시작 안내 출력
+- `glm tools disable` 명령:
+  - Step 1: `~/.claude.json` 읽기
+  - Step 2: `removeMCPServer()` 호출
+  - Step 3: 제거된 도구 목록 출력
+- `--scope project` 옵션 처리: configPath 를 `.mcp.json` (project root) 으로 전환 (REQ-GMC-008)
+- 부분 도구 비활성화 모델 결정: v0.1 에서는 `vision|websearch|webreader|all` 모두 동일하게 zai-mcp-server 엔트리 전체를 추가/제거 (단순성). 도구별 활성/비활성 토글은 v0.2 후보
+- TDD: 명령 통합 테스트 (`TestGLMToolsEnable*`, `TestGLMToolsDisable*` prefix)
+
+**Done 기준:**
+
+- `moai glm tools enable vision` / `moai glm tools enable all` 이 정상 작동
+- `moai glm tools disable all` 이 정상 작동, 다른 MCP 엔트리 보존 (REQ-GMC-010)
+- `--scope project` 옵션이 `.mcp.json` 에 기록 (REQ-GMC-008)
+- 명령 통합 테스트 ≥ 6개 추가 (각 REQ-GMC-003 ~ 010 매핑)
+- `go test -count=1 -race ./internal/cli/...` 통과
+
+### M4 — Documentation Sync (Priority: Medium)
+
+**목표**: `settings-management.md` 두 파일 (템플릿 + 루트 미러본) 에 Z.AI MCP 통합 노트 + `moai glm tools` 사용 가이드를 추가한다.
+
+**작업 항목:**
+
+- `internal/template/templates/.claude/rules/moai/core/settings-management.md` 에 노트 추가 (Template-First Rule, CLAUDE.local.md §2):
+  - Z.AI MCP 통합의 의미 (Vision / Web Search / Web Reader)
+  - `moai glm tools enable [도구명]` / `moai glm tools disable [도구명]` 사용법
+  - Node.js >= v22 + GLM_AUTH_TOKEN 사전 조건
+  - Pro 플랜 권장 (Vision / WebSearch)
+  - SPEC-CC2122-MCP-001 (`alwaysLoad`) 와의 관계 — zai-mcp-server 는 lazy-load 권장 (스키마 크기 미상, 사용 빈도 미상이므로 conservative default)
+- `.claude/rules/moai/core/settings-management.md` 에 동일한 노트 미러링
+- 두 파일의 변경분이 동일한지 `diff` 로 검증
+- CHANGELOG.md 에 v0.1 항목 추가 (사용자 알림)
+
+**Done 기준:**
+
+- 두 `settings-management.md` 파일에 Z.AI MCP 노트 부착됨, 두 사본 동일 내용
+- CHANGELOG.md 에 SPEC-GLM-MCP-001 항목 추가
+- 16개 언어 중립성 위반 없음 (CLAUDE.local.md §15) — `internal/template/templates/` 변경분이 특정 언어 편향이 없는지 확인
+
+### M5 — Final Quality Gates + Pre-merge Validation (Priority: High)
+
+**목표**: 모든 품질 게이트 통과 + plan-auditor 사후 감사 준비.
+
+**작업 항목:**
+
+- `go test ./...` (전체) 통과 — cascading failure 검출 (CLAUDE.local.md §6)
+- `go test -race ./...` 통과 — concurrency 안전성
+- `go vet ./...` 무경고
+- `golangci-lint run` 무경고 (가능한 경우)
+- `make build` 성공 + `internal/template/embedded.go` 가 최신 템플릿 반영
+- 통합 검증 (수동, GLM 토큰 보유 시):
+  - `moai glm tools enable all` 실행 → `~/.claude.json` 내용 검증
+  - Claude Code 재시작 → MCP 도구 호출 시도 (Vision OCR ping)
+  - `moai glm tools disable all` 실행 → 엔트리 제거 검증
+  - `moai cc` 모드 전환 후에도 엔트리 유지 확인 (R5 매핑)
+- 커밋 메시지 초안: `feat(glm): add 'moai glm tools enable/disable' for Z.AI MCP integration (SPEC-GLM-MCP-001)`
+
+**Done 기준:**
+
+- 모든 자동화 게이트 (vet/test/lint/build) 통과
+- 수동 통합 검증 (가능한 경우) 성공
+- PR 설명에 SPEC-GLM-MCP-001 명시, REQ ↔ GWT 매핑 표 포함
+- plan-auditor 의 사전 감사(`/moai run` Phase 0.5) 통과 준비
+
+## Dependencies
+
+- **상위 의존**: SPEC-GLM-001 (호환성 자동화) — 이미 `completed`. 본 SPEC 은 SPEC-GLM-001 의 환경변수 정책 위에서 작동.
+- **하위 의존 후보**:
+  - v0.2: Mainland China (`Z_AI_MODE=ZHIPU`) 지원 SPEC
+  - v0.2: 도구별 부분 enable/disable 모델 (Vision 만 활성, WebSearch 비활성)
+  - v0.2: GLM Coding Plan 등급 사전 검증 (Pro vs Lite)
+- **외부 의존**:
+  - `@z_ai/mcp-server >= v0.1.2` 가 npm 에 publish 되어 있어야 함 — 이미 확인됨
+  - Claude Code 가 `~/.claude.json` 의 `mcpServers` 키를 인식해야 함 — 공식 메커니즘
+  - Node.js >= v22.0.0 가 사용자 환경에 설치되어 있어야 함 — REQ-GMC-009 에 의해 검증됨
+
+## Risks and Mitigations
+
+| ID | 리스크 | 영향도 | 완화 전략 | REQ 매핑 |
+|----|--------|--------|-----------|----------|
+| R1 | 사용자 `~/.claude.json` 에 이미 `zai-mcp-server` 엔트리 존재 → 덮어쓰기 vs 보존 | High | REQ-GMC-006 (a) idempotent skip, (b) `--force` 안내 + 차이 요약. M3 에서 차이 검사 테스트 작성 | REQ-GMC-006 |
+| R2 | 사용자 GLM Coding Plan Lite ($3) 보유 → Vision MCP 호출 시 401/403 | Medium | enable 시 명확한 경고 출력 ("Pro 플랜 이상 필요"). 런타임 에러는 Z.AI 응답 그대로 노출 (EX-2). 추후 v0.2 에서 사전 API 검증 검토 | EX-2 |
+| R3 | Node.js < 22 → `npx @z_ai/mcp-server` 실패 | High | M2 의 `detectNodeVersion()` 로 사전 검증. 부재/구버전 시 REQ-GMC-009 에 따라 graceful fail + 설치 가이드 출력 | REQ-GMC-009 |
+| R4 | `~/.claude.json` (user scope) vs `.mcp.json` (project scope) 결정 모호 | Medium | OQ-2 결정: user scope 기본, `--scope project` 옵트인 (REQ-GMC-008). Z.AI 공식 가이드와 일관 | REQ-GMC-008 |
+| R5 | `moai cc` ↔ `moai glm` 모드 전환 시 MCP 설정 영향 (회귀 가능성) | Medium | EX-4 결정: 모드 전환 시 자동 enable/disable 하지 *않음*. 단순성 + 예측 가능성 우선. M5 수동 통합 검증으로 모드 전환 후 엔트리 유지 확인 | EX-4 |
+| R6 | 사용자 정의 MCP 엔트리 (`context7`, `sequential-thinking`, `moai-lsp`, 또는 사용자 추가) 손상 | High | REQ-GMC-010 명시적 보존. M2 의 `mergeMCPServer()` / `removeMCPServer()` 가 다른 엔트리 변경 금지. 회귀 검증 테스트 필수 | REQ-GMC-010 |
+| R7 | atomic write 실패 (디스크 풀, 권한 문제) → `~/.claude.json` 손상 | High | M2 에서 백업 생성 (`~/.claude.json.bak-<ts>`) + atomic rename. 실패 시 명확한 복구 가이드 출력 | REQ-GMC-005 |
+| R8 | `make build` 누락으로 `internal/template/embedded.go` 가 stale | Medium | M5 에서 `make build` 명시적 실행. PR 체크리스트 (CLAUDE.local.md §4) 준수 | M5 |
+| R9 | 16개 언어 중립성 위반 (특정 언어 편향 도입) | Low | 본 SPEC 은 영어 도움말 메시지 + 한국어 사용자 메시지. `internal/template/templates/` 의 변경분은 영어 + 16개 언어 동등 사례. CLAUDE.local.md §15 verify | CLAUDE.local.md §15 |
+
+## Out of Scope (Plan-Level)
+
+- Mainland China 엔드포인트 지원 (EX-1, v0.2 후보)
+- GLM 플랜 등급 사전 API 검증 (EX-2)
+- 다른 MCP 엔트리 (`context7`, `sequential-thinking`, `moai-lsp`) 정책 변경 (EX-3)
+- 모드 전환 시 자동 enable/disable (EX-4)
+- `~/.claude.json` 스키마 강화 검증 (EX-5)
+- 사전 sample test 자동 실행 (EX-6)
+- 도구별 부분 enable/disable 모델 (v0.2 후보)
+- 4개국어 docs-site (`docs-site/`) 동기화 — 본 SPEC 의 변경은 내부 룰 문서 (`.claude/rules/moai/core/settings-management.md`) 에 한정. 공식 사용자 가이드 갱신 여부는 별도 판단 (CLAUDE.local.md §17.3 ko-canonical 정책 검토 후 필요 시 후속 PR 분리)
+
+## 16개 언어 중립성 검증 체크리스트
+
+본 SPEC 의 변경이 CLAUDE.local.md §15 (Template Language Neutrality) 를 위반하지 않는지 확인:
+
+- [ ] `internal/template/templates/.claude/rules/moai/core/settings-management.md` 의 노트가 특정 언어를 PRIMARY 로 배치하지 않음
+- [ ] 16개 언어 (go/python/typescript/javascript/rust/java/kotlin/csharp/ruby/php/elixir/cpp/scala/r/flutter/swift) 가 동등 수준
+- [ ] Node.js 22 prerequisite 는 *Z.AI MCP 패키지 실행* 의 외부 요구사항이며, 사용자 프로젝트 언어 선택과 무관함을 노트에 명시
+- [ ] 본 통합은 *moai-adk-go 의 내부 CLI 기능* 이며, 16개 언어 사용자 모두에게 동일하게 작동
+
+## Approval / Next Step
+
+본 plan.md 와 spec.md, acceptance.md 가 plan-auditor 의 승인을 받으면, manager-cycle 또는 manager-tdd 가 `/moai run SPEC-GLM-MCP-001` 으로 위임받아 M1 → M5 순으로 구현한다. 본 SPEC 단계에서는 코드/테스트/문서 어떤 파일도 수정하지 않는다 (사용자 명시 제약).
+
+manager-cycle 위임 시 권장 순서:
+1. M1 (path discovery)
+2. M2 (helpers, TDD RED → GREEN)
+3. M3 (subcommand routing, TDD)
+4. M4 (docs sync)
+5. M5 (quality gates + plan-auditor pre-flight)

--- a/.moai/specs/SPEC-GLM-MCP-001/progress.md
+++ b/.moai/specs/SPEC-GLM-MCP-001/progress.md
@@ -1,0 +1,86 @@
+---
+spec_id: SPEC-GLM-MCP-001
+created: 2026-05-01
+updated: 2026-05-01
+plan_complete_at: 2026-05-01T14:18:00+09:00
+plan_status: audit-ready
+phase: plan
+harness_level: standard
+development_mode: tdd
+---
+
+# SPEC-GLM-MCP-001 — Progress
+
+## Phase 1: Plan (Complete)
+
+### Background
+
+3개 작업 묶음 중 Task C 산출물:
+- Task B: `.moai/reports/devops/glm-cache-control-validation-2026-05-01.md` (현행 caching 정책 유지 권장)
+- Task C: 본 SPEC (Z.AI Vision/WebSearch/WebReader MCP 통합)
+- Task A: SPEC-CI-MULTI-LLM-001 별도 세션 (grace window D-1 임박)
+
+### Socratic Interview Skip
+
+기술 키워드 5+ 충족 → Phase 0.3 Clarity Eval 자동 skip. 확인 키워드: Z.AI, GLM, Vision MCP, web_search, web reader, @z_ai/mcp-server, claude mcp add, MCP server.
+
+### Artifacts
+
+| File | Size | Status |
+|------|------|--------|
+| `research.md` | 11.9 KB | audit-ready |
+| `spec.md` | 13.7 KB | audit-ready |
+| `plan.md` | 15.4 KB | audit-ready |
+| `acceptance.md` | 19.3 KB | audit-ready (22 GWT) |
+| `spec-compact.md` | 6.4 KB | auto-extracted |
+
+### REQ Summary
+
+- 총 10건 (REQ-GMC-001 ~ REQ-GMC-010)
+- EARS 분포: Ubiquitous=2, Event-Driven=4, State-Driven=1, Optional=1, Unwanted=2
+- 통합 옵션 권장: Option 2 (`moai glm tools enable|disable [vision|websearch|webreader|all]`)
+
+### Plan Audit
+
+- audit_verdict: **PASS**
+- audit_score: **0.91** (Clarity 0.90 / Completeness 0.95 / Testability 0.90 / Traceability 0.95)
+- audit_report: `.moai/reports/plan-audit/SPEC-GLM-MCP-001-review-1.md`
+- audit_at: 2026-05-01T14:14:00+09:00
+- MP defects: 0 (MP-1/2/3 PASS, MP-4 N/A — internal CLI scope)
+- minor refinements: 3건 (D1~D3, 비차단)
+- iteration: 1/3
+
+### Plan-stage Constraints Verified
+
+- [x] YAML frontmatter 9 canonical fields (no `created`/`updated`/`spec_id`/`title` aliases)
+- [x] EARS distribution table 정확성 (D6 회피)
+- [x] acceptance.md 디스크 작성 (D5 anti-pattern 회피)
+- [x] Exclusions 섹션 ≥1 entry (EX-1 Mainland China v0.2 연기 등)
+- [x] 모든 REQ에 ≥1 acceptance criterion (traceability 100%)
+- [x] 16-language neutrality 무관 (internal CLI feature, templates/.claude/ 미수정)
+
+## Phase 2: Run (Pending)
+
+Trigger: `/moai run SPEC-GLM-MCP-001` (별도 세션 권장 — context 격리)
+
+Pre-flight:
+- Plan-Auditor PASS 확인됨 (Phase 0.5 audit gate 자동 통과)
+- Methodology: TDD (RED-GREEN-REFACTOR, quality.yaml `development_mode: tdd`)
+- Min coverage per commit: 80%
+
+Milestone plan (plan.md §M1~M5):
+- M1: CLI skeleton (`moai glm tools` 서브커맨드 트리)
+- M2: Node.js prerequisite + GLM_AUTH_TOKEN 재사용
+- M3: settings/`.claude.json` writer (mcpServers 주입)
+- M4: enable/disable/status idempotent 동작
+- M5: 회귀 가드 (mode-switch glm↔cc↔cg 무영향)
+
+## Phase 3: Sync (Pending)
+
+Trigger: `/moai sync SPEC-GLM-MCP-001` (M5 완료 후)
+
+Sub-tasks:
+- Run-stage MX 태깅 검증
+- CHANGELOG.md entry
+- docs-site 4-locale 가이드 (ko/en/ja/zh) — `moai glm tools` 사용법
+- Conventional commits + PR 생성

--- a/.moai/specs/SPEC-GLM-MCP-001/research.md
+++ b/.moai/specs/SPEC-GLM-MCP-001/research.md
@@ -1,0 +1,201 @@
+# SPEC-GLM-MCP-001 Research Artifact (Phase 0.5)
+
+## HISTORY
+
+| Version | Date | Author | Description |
+|---------|------|--------|-------------|
+| 0.1.0 | 2026-05-01 | manager-spec | 초기 작성 — Z.AI MCP 서버 통합 deep research, 3개 통합 옵션 분석, integration point 매핑, 위험 카탈로그 |
+
+## 연구 목표
+
+`moai glm` 모드에서 사용자가 Claude Code 내부에서 Z.AI 의 공식 MCP 서버 3종(Vision, Web Search, Web Reader) 에 접근할 수 있도록 통합하는 방안을 연구한다. 본 연구는 코드 수정을 수반하지 않는 plan-stage 산출물이며, manager-cycle 위임 시점의 의사결정 근거를 제공한다.
+
+연구 범위:
+- Z.AI 공식 MCP 패키지 (`@z_ai/mcp-server`) 의 능력, 가격, 환경 요구사항 식별
+- Claude Code 의 공식 MCP 등록 메커니즘 검토
+- moai-adk-go 의 기존 GLM 통합 지점 (`internal/cli/glm.go`, settings 템플릿) 매핑
+- 3가지 통합 옵션의 장단점 비교 + 권장안 도출
+- 핵심 위험 카탈로그 (R1 ~ R5)
+
+## 1. Z.AI 공식 MCP 서버 사실 카탈로그
+
+WebSearch (2026-04-26) 로 확인된 사실. 본 SPEC 작성 시점에서는 추가 WebFetch 호출 없이 이 카탈로그를 인용한다.
+
+### 1.1 패키지 정보
+
+- npm 패키지: `@z_ai/mcp-server`
+- 최소 버전: `>= v0.1.2` (GLM-4.6V Vision 능력 포함)
+- 실행 방식: `npx -y @z_ai/mcp-server@latest`
+- Node.js 전제: `>= v22.0.0`
+
+### 1.2 노출 도구 (3종)
+
+| MCP 서버 | 능력 | 사용 사례 |
+|----------|------|-----------|
+| Vision | GLM-4.6V 이미지 분석, OCR, UI 분석, 다이어그램 이해 | 스크린샷 분석, 문서 OCR, 디자인 검토 |
+| Web Search | 최신 기술 문서, API 변경, OSS 업데이트 검색 | 최근 라이브러리 변경 확인, 보안 권고 검색 |
+| Web Reader | 웹페이지 본문 + 구조화된 메타데이터 추출 | 블로그/문서/공지 본문 가져오기 |
+
+### 1.3 가격 / 플랜 등급
+
+- **Lite ($3/월)**: GLM 코어만 (Vision, Web Search 미포함)
+- **Pro ($9/월) 이상**: Vision + Web Search 활성화
+
+### 1.4 리전 모드
+
+| 환경변수 | 값 | 엔드포인트 |
+|---------|-----|------------|
+| `Z_AI_MODE` | `ZAI` | 국제 (https://api.z.ai) |
+| `Z_AI_MODE` | `ZHIPU` | Mainland China (https://open.bigmodel.cn/api/anthropic) |
+
+### 1.5 공식 등록 명령
+
+Claude Code 네이티브 CLI 방식:
+
+```bash
+claude mcp add -s user zai-mcp-server \
+  --env Z_AI_API_KEY=<key> Z_AI_MODE=ZAI \
+  -- npx -y "@z_ai/mcp-server@latest"
+```
+
+수동 `~/.claude.json` 의 `mcpServers` 엔트리 추가도 가능. `command: "npx"`, `args: ["-y", "@z_ai/mcp-server"]`, `env: {Z_AI_API_KEY: ..., Z_AI_MODE: ...}` 구조.
+
+### 1.6 출처 검증
+
+- 공식 문서: `https://docs.z.ai/devpack/mcp/vision-mcp-server` (필요 시 WebFetch 1회 한도)
+- 본 연구는 사전 로드된 사실(WebSearch 2026-04-26) 인용. 추가 외부 호출 없이 SPEC 작성 가능.
+
+## 2. moai-adk-go 기존 통합 지점
+
+본 SPEC 의 변경은 통합 지점을 *참조*하지만 *수정하지 않는다* (사용자 명시 제약). 통합 지점 식별은 manager-cycle 위임 시 정확한 라인 범위를 활용하기 위함이다.
+
+### 2.1 GLM 환경 주입 코드
+
+| 파일 | 라인 (대략) | 역할 |
+|-----|------------|------|
+| `internal/cli/glm.go` | 167 (`setGLMEnv`) | 프로세스 env 주입 (ANTHROPIC_BASE_URL, AUTH_TOKEN, DISABLE_BETAS, DISABLE_PROMPT_CACHING) |
+| `internal/cli/glm.go` | 372 / 548 / 827 / 872 | settings.json env writer (cc / glm / cg 모드 전환별) |
+| `internal/cli/launcher.go` | 241 | `moai cc` 전환 시 DISABLE_PROMPT_CACHING 제거 |
+| `internal/hook/session_start.go` | 245 | SessionStart 자동 감지 |
+| `internal/template/templates/.claude/settings.json.tmpl` | 전역 | settings 템플릿 (env 블록 포함) |
+
+### 2.2 GLM 토큰 저장소
+
+- `~/.moai/.env.glm` 의 `GLM_AUTH_TOKEN` 키
+- `loadGLMKey()` 함수가 파일을 읽어 `setGLMEnv()` 와 `injectTmuxSessionEnv()` 가 사용
+- `moai github auth glm <token>` 패턴이 이미 존재 — 본 SPEC 의 옵션 2(opt-in subcommand) 와 일관된 UX 모델
+
+### 2.3 SPEC-GLM-001 과의 관계
+
+- SPEC-GLM-001 (`completed`) 은 호환성 자동화: `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1` + `DISABLE_PROMPT_CACHING=1` 자동 주입/제거
+- 본 SPEC 은 SPEC-GLM-001 위에 *MCP 서버 등록* 기능을 추가하며, 캐싱/베타 헤더 정책을 변경하지 않는다
+- 이를 통해 Task B(in-flight cache_control 검토) 와 충돌하지 않음을 보장
+
+## 3. 통합 옵션 비교
+
+### 3.1 옵션 1 — Auto-inject
+
+`moai glm setup` 또는 `moai glm` 자체가 `~/.claude.json` 또는 settings.json 에 `mcpServers.zai-mcp-server` 를 자동 추가한다.
+
+**장점:**
+- 사용자 마찰 0 — `moai glm` 한 번만 실행
+- 신규 사용자 온보딩 시간 단축
+
+**단점:**
+- 침습적 — 사용자의 기존 `~/.claude.json` MCP 설정과 충돌 가능
+- 사용자가 Vision/WebSearch 를 원하지 않는 경우에도 강제 주입
+- 옵트아웃 메커니즘 별도 필요
+- 명시적 동의 부재 — settings.json 의 신뢰 모델을 위반할 수 있음
+
+### 3.2 옵션 2 — Opt-in Subcommand (권장)
+
+`moai glm tools enable <vision|websearch|webreader|all>` 신규 subcommand 가 사용자 요청 시 동일 설정을 작성. 대응 `moai glm tools disable <...>` 로 제거.
+
+**장점:**
+- 명시적 동의 — 사용자가 직접 활성화 요청
+- idempotent — 반복 호출 안전
+- reversible — disable 명령으로 깔끔하게 제거 가능
+- 기존 패턴 (`moai github auth glm <token>`) 과 일관됨
+- Lite/Pro 플랜 검증 + 친절한 에러 메시지를 한 곳에서 수행 가능
+- 사용자의 기존 MCP 설정과 충돌 시 명확한 시각적 경고 가능
+
+**단점:**
+- 추가 단계 1회 필요 (한 번만 실행하면 영구)
+- subcommand parser/route 확장 코드 필요
+
+### 3.3 옵션 3 — Documentation Guide
+
+README + CLAUDE.md 에 가이드 섹션을 추가하고 코드 변경은 하지 않음. 사용자가 직접 `claude mcp add ...` 실행.
+
+**장점:**
+- 코드 표면 0 — 충돌 위험 없음
+- 가장 보수적
+
+**단점:**
+- 사용자 마찰 큼 — 문서 읽고 명령어 복사/붙여넣기
+- GLM 토큰 재입력 부담 (`~/.moai/.env.glm` 활용 불가)
+- 통합 추적 불가 (몇 명이 실제로 사용하는지 측정 불가)
+- moai-adk-go 의 다른 통합 (`moai github auth glm`) 과 일관되지 않음
+
+### 3.4 권장: 옵션 2
+
+근거:
+1. 기존 moai-adk-go 패턴 (`moai github auth glm`, `moai cc/glm/cg`) 과 동일한 명시적 사용자 의도 모델
+2. 안전성 — 사용자가 자신의 MCP 설정을 통제
+3. 가역성 — 활성화 시 disable 도 함께 제공하면 사용자 신뢰도 ↑
+4. 토큰 재사용 — 기존 `~/.moai/.env.glm` `GLM_AUTH_TOKEN` 을 자동 활용하여 중복 입력 회피
+5. 플랜 검증 — Pro 플랜 미보유 시 Vision/WebSearch 활성화 거부 + 명확한 안내
+
+## 4. 위험 카탈로그
+
+| ID | 위험 | 영향도 | 완화 전략 |
+|----|------|--------|-----------|
+| R1 | 사용자 `~/.claude.json` 에 이미 `zai-mcp-server` 엔트리 존재 — 덮어쓰기 vs 보존 | High | `tools enable` 시 기존 엔트리 감지 → AskUserQuestion(orchestrator) 또는 명시적 `--force` 플래그 요구. 옵션 2 의 명시적 UX 가 이 결정을 자연스럽게 해결 |
+| R2 | 사용자가 GLM Coding Plan Lite ($3) 보유 — Vision MCP 호출 시 401/403 | Medium | enable 명령에서 사전 플랜 검증(가능한 경우 API ping) 또는 enable 시 "Pro 플랜 필요" 명시. 런타임 에러는 Z.AI 가 반환하므로 본 SPEC 은 *명확한 에러 메시지 가이드*만 제공 |
+| R3 | Node.js < 22 — `npx @z_ai/mcp-server` 실패 | High | enable 명령 진입 시 `node --version` 체크. 부재/구버전 시 graceful fail + 설치 가이드 출력 |
+| R4 | `~/.claude.json` (user scope) vs `.mcp.json` (project scope) 결정 | Medium | Z.AI 공식 가이드 따라 `-s user` (사용자 전역) 권장. 본 SPEC 의 enable 명령은 user scope 기본, `--scope project` 플래그로 옵트인 가능 |
+| R5 | `moai cc` ↔ `moai glm` 모드 전환 시 MCP 설정 영향 | Medium | MCP 설정은 모드 독립적 — 한 번 enable 하면 cc 모드에서도 도구가 노출됨. 단, Z.AI API key 가 필요하므로 cc 모드에서는 호출 시 401 반환 가능. 본 SPEC 은 모드별 자동 enable/disable 을 *하지 않는다* (사용자가 명시적으로 disable 해야 함) — 이것이 가장 단순하고 예측 가능한 동작 |
+
+## 5. 16개 언어 중립성
+
+본 통합은 moai-adk-go 의 *내부 CLI 기능* 이며 `internal/template/templates/` 의 사용자 프로젝트 템플릿을 변경하지 않는다. 따라서 16개 언어 중립성 정책 (CLAUDE.local.md §15) 의 직접적 검증 대상이 아니다.
+
+다만 enable 명령의 도움말/에러 메시지가 *한국어 사용자만* 또는 *영어 사용자만* 우대하지 않도록 i18n 컨벤션 (오류 영어, 사용자 메시지 conversation_language) 을 따른다.
+
+## 6. 캐싱 / cache_control 정책 영향
+
+SPEC-GLM-001 의 `DISABLE_PROMPT_CACHING=1` 정책은 본 SPEC 변경의 영향을 받지 않는다.
+
+근거:
+- MCP 서버는 *Claude Code 의 도구 호출 경로* 를 통해 작동
+- prompt caching 은 *Anthropic API 의 인풋 토큰 캐싱* 을 제어
+- MCP 서버 등록(`mcpServers` JSON 추가) 은 환경변수 또는 헤더에 영향을 주지 않음
+- 따라서 Task B (in-flight cache_control 검토) 와 직교적
+
+## 7. Open Questions (Plan-Stage Resolution Required)
+
+| OQ | 질문 | 제안 답변 |
+|----|------|----------|
+| OQ-1 | Vision/WebSearch/WebReader 를 별도 enable 가능 vs `all` 만 지원? | 별도 + `all` 둘 다 지원. 사용자가 Vision 만 원하는 경우(Pro 플랜 가입은 했으나 WebSearch 데이터 사용 우려) 를 배려 |
+| OQ-2 | enable 결과를 `~/.claude.json` (user scope) vs `.mcp.json` (project scope) 어디에 기록? | 기본 user scope (`~/.claude.json`), `--scope project` 옵션 제공 |
+| OQ-3 | 기존 zai-mcp-server 엔트리 감지 시 동작? | (a) 사용자 토큰 일치 시 idempotent skip, (b) 토큰 다른 경우 에러 + `--force` 안내 |
+| OQ-4 | Lite 플랜 사용자가 vision/websearch enable 시 동작? | 경고 출력 + enable 진행 (사전 검증 API 가 없거나 비싸면). 런타임 401 시 Z.AI 응답 그대로 노출 |
+| OQ-5 | Mainland China (`Z_AI_MODE=ZHIPU`) 를 v0.1 에서 지원? | **제외 (v0.2 로 연기)**. v0.1 은 `Z_AI_MODE=ZAI` 국제 엔드포인트만 지원 |
+| OQ-6 | enable 시 sample test (Vision OCR ping 등) 자동 실행? | 옵트인 (`--test`) — 기본 비활성. test 가 npm 다운로드를 트리거하므로 첫 실행 ~10s 지연 발생 가능 |
+
+OQ-5 는 spec.md 의 Exclusions (EX-1) 으로 명시 분리. 그 외 OQ 는 plan.md 의 결정 표로 추적.
+
+## 8. References
+
+- Z.AI 공식 MCP 문서: https://docs.z.ai/devpack/mcp/vision-mcp-server (필요 시 WebFetch 1회 한도)
+- Claude Code MCP 가이드: `claude mcp add --help`
+- `.moai/specs/SPEC-GLM-001/spec.md` — 베이스 GLM 호환성
+- `.moai/specs/SPEC-CC2122-MCP-001/spec.md` — `.mcp.json.tmpl` 변경 패턴 (구조 참조)
+- `.moai/specs/SPEC-LSPMCP-001/spec.md` — moai-lsp MCP 통합 패턴 (구조 참조)
+- `internal/cli/glm.go` — 환경 주입 진입점 (직접 수정하지 않음)
+- `internal/cli/github_auth.go` — `moai github auth glm <token>` 패턴 참조
+- CLAUDE.local.md §13 (GLM Integration Testing), §15 (Template Language Neutrality)
+
+## 9. 결론
+
+옵션 2 (opt-in `moai glm tools enable/disable`) 가 이 프로젝트의 기존 패턴, 안전성, 가역성, 사용자 신뢰 모델 모두에서 우월하다. 본 결정은 spec.md 의 REQ 분배에 반영되며, plan.md 의 마일스톤 M1 ~ M4 가 해당 옵션을 구현 가이드로 사용한다.

--- a/.moai/specs/SPEC-GLM-MCP-001/spec-compact.md
+++ b/.moai/specs/SPEC-GLM-MCP-001/spec-compact.md
@@ -1,0 +1,103 @@
+# SPEC-GLM-MCP-001 Compact Reference
+
+> **Purpose**: Run-phase token-efficient extract of REQs + critical ACs only.
+> **Token savings**: ~30% vs full spec.md + acceptance.md.
+> **Single source of truth**: `spec.md`, `plan.md`, `acceptance.md`. This file is a derived projection.
+
+## Identity
+
+- ID: SPEC-GLM-MCP-001
+- Domain: GLM-MCP
+- Status: draft
+- Priority: Medium
+- Recommended option: **Opt-in subcommand** (`moai glm tools enable|disable`)
+
+## EARS Distribution
+
+| Pattern | Count | REQ IDs |
+|---------|-------|---------|
+| Ubiquitous | 2 | 001, 002 |
+| Event-Driven | 4 | 003, 004, 005, 006 |
+| State-Driven | 1 | 007 |
+| Optional | 1 | 008 |
+| Unwanted | 2 | 009, 010 |
+| **Total** | **10** | — |
+
+## Requirements (Compact)
+
+- **REQ-GMC-001** (Ubiquitous): `moai glm tools enable|disable [vision|websearch|webreader|all]` subcommand exists and is idempotent.
+- **REQ-GMC-002** (Ubiquitous): No conflict with SPEC-GLM-001 (`DISABLE_BETAS=1`, `DISABLE_PROMPT_CACHING=1`). MCP registration is orthogonal to env var policy.
+- **REQ-GMC-003** (Event-Driven): WHEN `enable` runs AND Node>=22 AND `GLM_AUTH_TOKEN` set → write `mcpServers.zai-mcp-server` to `~/.claude.json` with `command: "npx"`, `args: ["-y", "@z_ai/mcp-server@latest"]`, `env.Z_AI_API_KEY: <token>`, `env.Z_AI_MODE: "ZAI"`. Print activated tools + Pro plan + Claude Code restart guidance.
+- **REQ-GMC-004** (Event-Driven): WHEN `disable` runs → remove `zai-mcp-server` entry; preserve all other mcpServers entries; print removed tools.
+- **REQ-GMC-005** (Event-Driven): WHEN `enable`/`disable` runs → backup `~/.claude.json` to `~/.claude.json.bak-<ISO ts>` before modification. Skip backup on idempotent skip (no change).
+- **REQ-GMC-006** (Event-Driven): WHEN `enable` runs AND existing `zai-mcp-server` entry present → (a) idempotent skip if token matches, (b) refuse + show `--force` guidance if token differs (R1 mitigation, no overwrite).
+- **REQ-GMC-007** (State-Driven): WHILE `GLM_AUTH_TOKEN` absent or empty → reject `enable`; output token-registration guide (`moai github auth glm <token>` or equivalent).
+- **REQ-GMC-008** (Optional): WHERE `--scope project` flag present → write to project-root `.mcp.json` instead of `~/.claude.json` (default user scope).
+- **REQ-GMC-009** (Unwanted): IF `node` absent OR version < v22.0.0 → graceful fail with detected version + min requirement + install guidance; non-zero exit; `~/.claude.json` unchanged.
+- **REQ-GMC-010** (Unwanted): IF user-defined or third-party `mcpServers` entries present → enable/disable MUST NOT modify them. Scope limited to `mcpServers.zai-mcp-server` key only.
+
+## Critical Acceptance Criteria (Compact)
+
+(Full GWT scenarios in `acceptance.md`. Below: 10 must-pass scenarios.)
+
+| ID | Scenario | Expected Result |
+|----|----------|-----------------|
+| GWT-1 | `enable vision` twice → second run is no-op | First run creates entry; second run idempotent skip |
+| GWT-3 | `moai cc` ↔ `moai glm` mode switch after enable | SPEC-GLM-001 env policy preserved; zai-mcp-server entry retained |
+| GWT-4 | `enable vision` from clean state | `~/.claude.json` `mcpServers.zai-mcp-server` has 4 fields exactly |
+| GWT-7 | `disable all` with 3 other mcpServers entries | Only zai-mcp-server removed; other 3 preserved verbatim |
+| GWT-8 | `enable vision` from clean state | `~/.claude.json.bak-<ts>` created with pre-modification contents |
+| GWT-11 | `enable` with existing entry but mismatched token | Non-zero exit; `--force` guidance; `~/.claude.json` unchanged |
+| GWT-12 | `enable vision` with no `GLM_AUTH_TOKEN` | Non-zero exit; token registration guide; `~/.claude.json` unchanged |
+| GWT-13 | `enable vision --scope project` | `.mcp.json` (project root) written; `~/.claude.json` untouched |
+| GWT-14 | `enable all` with `node` absent on PATH | Non-zero exit; install guidance; `~/.claude.json` unchanged |
+| GWT-16 | `enable vision` with user-defined `my-custom-server` entry | `my-custom-server` preserved verbatim; new `zai-mcp-server` added |
+
+## Quality Gates (Compact)
+
+- All 10 REQs covered by ≥1 GWT scenario each
+- `go test ./...` passes (no regression)
+- `go test -race ./internal/cli/...` passes
+- `go vet ./...` zero warnings
+- New package coverage ≥85%
+- Both `settings-management.md` files (template + root mirror) updated and identical
+- `make build` regenerates `internal/template/embedded.go`
+- 16-language neutrality preserved (CLAUDE.local.md §15)
+
+## Exclusions
+
+1. **EX-1**: Mainland China (`Z_AI_MODE=ZHIPU`) deferred to v0.2
+2. **EX-2**: GLM plan tier (Lite vs Pro) pre-validation skipped — runtime 401 surfaces from Z.AI directly
+3. **EX-3**: Other mcpServers entries (`context7`, `sequential-thinking`, `moai-lsp`) policies unchanged
+4. **EX-4**: Mode switch (`cc` ↔ `glm` ↔ `cg`) does NOT auto enable/disable zai-mcp-server (explicit user command only)
+5. **EX-5**: `~/.claude.json` schema strict validation deferred (Claude Code runtime validates)
+6. **EX-6**: Pre-flight sample test (Vision OCR ping) deferred to optional `--test` flag in v0.2
+
+## Risk-to-REQ Mapping (Compact)
+
+| Risk | Mitigation REQ |
+|------|----------------|
+| R1: Existing entry overwrite | REQ-GMC-006 (`--force` guard) |
+| R2: Lite plan user, Vision 401 | EX-2 (clear messaging, no pre-check) |
+| R3: Node.js < 22 | REQ-GMC-009 (graceful fail) |
+| R4: User vs project scope | REQ-GMC-008 (`--scope project` opt-in) |
+| R5: Mode switch corruption | EX-4 (no auto-toggle) |
+| R6: Other mcpServers damage | REQ-GMC-010 (scope limited to one key) |
+| R7: Atomic write failure | REQ-GMC-005 (backup before write) |
+
+## Files Affected (Anticipated)
+
+- `internal/cli/glm_tools.go` (new) or `internal/cli/glm.go` (extension)
+- `internal/cli/glm_tools_test.go` (new)
+- `internal/template/templates/.claude/rules/moai/core/settings-management.md` (template)
+- `.claude/rules/moai/core/settings-management.md` (mirror)
+- `CHANGELOG.md`
+
+## Plan Audit Readiness
+
+- ✓ 9-field frontmatter canonical schema (`id`, `version`, `status`, `created_at`, `updated_at`, `author`, `priority`, `labels`, `issue_number`)
+- ✓ EARS distribution table accurate (Section 3.0): 2+4+1+1+2 = 10
+- ✓ Exclusions section ≥1 entry (6 entries)
+- ✓ acceptance.md self-contained (no external defer, D5 anti-pattern avoided)
+- ✓ research.md present (Phase 0.5 deep research)
+- ✓ Risks ≥1 with mitigation strategies (R1~R7)

--- a/.moai/specs/SPEC-GLM-MCP-001/spec.md
+++ b/.moai/specs/SPEC-GLM-MCP-001/spec.md
@@ -1,0 +1,204 @@
+---
+id: SPEC-GLM-MCP-001
+version: "0.1.0"
+status: draft
+created_at: 2026-05-01
+updated_at: 2026-05-01
+author: manager-spec
+priority: Medium
+labels: [glm, mcp, vision, websearch, integration, enhancement]
+issue_number: 756
+related_specs: [SPEC-GLM-001, SPEC-CC2122-MCP-001, SPEC-LSPMCP-001]
+---
+
+# SPEC-GLM-MCP-001: Z.AI 공식 MCP 서버 통합 (Vision + Web Search + Web Reader)
+
+## HISTORY
+
+| Version | Date | Author | Description |
+|---------|------|--------|-------------|
+| 0.1.0 | 2026-05-01 | manager-spec | 초기 작성 — Z.AI `@z_ai/mcp-server` 통합. Opt-in subcommand (`moai glm tools enable/disable`) 권장. Mainland China (Z_AI_MODE=ZHIPU) 는 v0.2 로 연기. |
+
+## Status: Draft
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| SPEC ID | SPEC-GLM-MCP-001 |
+| Domain | GLM-MCP |
+| Number | 001 |
+| Lifecycle Level | spec-anchored |
+| Recommended Integration Option | Option 2 (Opt-in subcommand) |
+| Token Reuse Source | `~/.moai/.env.glm` `GLM_AUTH_TOKEN` |
+| Node.js Prerequisite | `>= v22.0.0` |
+| Z.AI Package Min Version | `@z_ai/mcp-server >= v0.1.2` |
+| Z.AI Plan Tier (Vision/WebSearch) | Pro ($9/월) 이상 |
+| Default MCP Scope | user (`~/.claude.json`) |
+| Z_AI_MODE Default | `ZAI` (국제) |
+
+## Overview
+
+Z.AI 의 공식 MCP 서버 패키지(`@z_ai/mcp-server`) 는 GLM-4.6V Vision (이미지 인식, OCR), Web Search (최신 기술 문서 검색), Web Reader (웹페이지 본문/메타데이터 추출) 세 도구를 Claude Code 내부에서 노출한다. 본 SPEC 은 `moai glm` 모드를 사용하는 사용자가 위 도구들을 *명시적이고 가역적으로* 활성화할 수 있도록 신규 subcommand `moai glm tools enable|disable [vision|websearch|webreader|all]` 를 도입한다.
+
+본 SPEC 은 SPEC-GLM-001 (호환성 자동화: `DISABLE_BETAS=1` + `DISABLE_PROMPT_CACHING=1`) 위에 *MCP 서버 등록* 레이어를 추가한다. 캐싱/베타 정책은 변경하지 않으며, 모드 전환 (`moai cc` ↔ `moai glm` ↔ `moai cg`) 의 기존 의미를 보존한다.
+
+본 SPEC 은 **WHAT 과 WHY** 에 집중한다. 정확한 Go 함수 시그니처, 패키지 구조, 명령 라우팅 코드는 manager-cycle 위임 시 결정한다.
+
+## Background
+
+연구 산출물 `research.md` 에 정리된 사실 카탈로그를 요약하면:
+- Z.AI 가 공식 npm 패키지 `@z_ai/mcp-server` (`>= v0.1.2`) 를 통해 3개 도구를 MCP 인터페이스로 노출
+- 공식 등록 명령: `claude mcp add -s user zai-mcp-server --env Z_AI_API_KEY=<key> Z_AI_MODE=ZAI -- npx -y "@z_ai/mcp-server@latest"`
+- moai-adk-go 의 기존 패턴 `moai github auth glm <token>` 와 동일한 명시적 사용자 의도 모델이 안전성 + 가역성 + 사용자 신뢰 측면에서 우월함
+
+3가지 통합 옵션 (Auto-inject / Opt-in subcommand / Documentation guide) 중 **Opt-in subcommand** 가 권장됨 (research.md §3.4 참조). Auto-inject 는 사용자 동의 없이 침습적이고, Documentation guide 는 마찰이 크고 token 재사용을 활용하지 못한다.
+
+## 3.0 EARS 분배표
+
+| 패턴 | 갯수 | REQ ID |
+|------|------|--------|
+| Ubiquitous | 2 | REQ-GMC-001, REQ-GMC-002 |
+| Event-Driven | 4 | REQ-GMC-003, REQ-GMC-004, REQ-GMC-005, REQ-GMC-006 |
+| State-Driven | 1 | REQ-GMC-007 |
+| Optional | 1 | REQ-GMC-008 |
+| Unwanted | 2 | REQ-GMC-009, REQ-GMC-010 |
+| **합계** | **10** | — |
+
+## Requirements (EARS Format)
+
+### REQ-GMC-001 (Ubiquitous)
+
+시스템은 신규 subcommand `moai glm tools` 를 제공해야 한다. 이 subcommand 는 최소 두 가지 동작 모드를 가진다: `enable [vision|websearch|webreader|all]` 와 `disable [vision|websearch|webreader|all]`. 두 동작 모드 모두 idempotent 해야 한다 — 동일 인자로 반복 호출해도 결과가 동일하고 부수 효과가 누적되지 않아야 한다.
+
+### REQ-GMC-002 (Ubiquitous)
+
+시스템은 본 SPEC 에 의해 도입된 어떤 동작도 SPEC-GLM-001 의 호환성 자동화 (`CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1` + `DISABLE_PROMPT_CACHING=1` 의 mode 별 inject/strip) 의미와 충돌하지 않도록 보장해야 한다. 즉, MCP 등록은 환경변수 정책과 직교적이며, `moai cc/glm/cg` 모드 전환은 기존 정책을 그대로 유지한다.
+
+### REQ-GMC-003 (Event-Driven)
+
+[WHEN] 사용자가 `moai glm tools enable vision` 또는 `moai glm tools enable all` 을 실행하고
+[AND] 시스템 PATH 에 Node.js `>= v22.0.0` 가 존재하고
+[AND] `~/.moai/.env.glm` 에 유효한 `GLM_AUTH_TOKEN` 이 존재할 때
+[THEN] 시스템은 `~/.claude.json` (user scope) 의 `mcpServers` 객체에 `zai-mcp-server` 엔트리를 추가해야 하며, 그 엔트리는 다음을 포함해야 한다:
+- `command: "npx"`
+- `args: ["-y", "@z_ai/mcp-server@latest"]`
+- `env.Z_AI_API_KEY`: `~/.moai/.env.glm` 의 `GLM_AUTH_TOKEN` 값
+- `env.Z_AI_MODE`: `ZAI` (기본값)
+
+[AND] 시스템은 사용자에게 활성화된 도구 목록(Vision / Web Search / Web Reader) + 사용 안내(Pro 플랜 권장 + Claude Code 재시작 필요) 를 출력해야 한다.
+
+### REQ-GMC-004 (Event-Driven)
+
+[WHEN] 사용자가 `moai glm tools disable [도구명|all]` 을 실행할 때
+[THEN] 시스템은 `~/.claude.json` 의 `mcpServers.zai-mcp-server` 엔트리를 제거해야 한다 (또는 도구별 부분 disable 모델을 도입하는 경우 해당 도구만 비활성화). 제거 후 `mcpServers` 객체가 비면 빈 객체로 유지하고 다른 사용자 정의 MCP 엔트리는 절대 손대지 않는다.
+
+[AND] 시스템은 제거된 도구 목록을 사용자에게 출력해야 한다.
+
+### REQ-GMC-005 (Event-Driven)
+
+[WHEN] 사용자가 `moai glm tools enable` 또는 `moai glm tools disable` 을 실행할 때
+[THEN] 시스템은 `~/.claude.json` 파일을 수정하기 전에 안전 백업을 동일 디렉토리에 `~/.claude.json.bak-<ISO timestamp>` 로 저장해야 한다. 단, 동일 명령의 idempotent skip (변경 없음) 의 경우에는 백업을 생성하지 않아도 된다.
+
+### REQ-GMC-006 (Event-Driven)
+
+[WHEN] 사용자가 `moai glm tools enable` 을 실행하고
+[AND] `~/.claude.json` 의 `mcpServers.zai-mcp-server` 엔트리가 이미 존재할 때
+[THEN] 시스템은 다음을 검사해야 한다:
+- (a) 기존 엔트리의 `env.Z_AI_API_KEY` 가 현재 `~/.moai/.env.glm` 의 `GLM_AUTH_TOKEN` 과 동일하면 idempotent skip 처리하고 "이미 활성화됨" 메시지를 출력한다.
+- (b) 토큰이 다르거나 다른 필드가 사용자 정의 변경된 경우, 시스템은 *덮어쓰지 말고* `--force` 플래그 안내 + 차이 요약을 출력한 후 종료해야 한다 (R1 위험 완화).
+
+### REQ-GMC-007 (State-Driven)
+
+[WHILE] `~/.moai/.env.glm` 의 `GLM_AUTH_TOKEN` 이 존재하지 않거나 빈 문자열인 동안
+[THEN] 시스템은 `moai glm tools enable` 명령을 거부해야 하며, 사용자에게 `moai github auth glm <token>` 또는 동등한 토큰 등록 명령으로 먼저 토큰을 설정하도록 안내 메시지를 출력해야 한다 (한 번에 한 가지 액션만 요구).
+
+### REQ-GMC-008 (Optional)
+
+[WHERE] 사용자가 `moai glm tools enable --scope project` 옵션을 명시한 경우
+[THEN] 시스템은 user scope 인 `~/.claude.json` 대신 프로젝트 루트의 `.mcp.json` 에 `zai-mcp-server` 엔트리를 추가해야 한다. 이 옵션이 부재하면 기본은 user scope 이다 (Z.AI 공식 가이드와 일관).
+
+### REQ-GMC-009 (Unwanted Behavior)
+
+[IF] `node --version` 실행이 실패하거나 결과가 `v22.0.0` 미만인 경우
+[THEN] 시스템은 `moai glm tools enable` 을 즉시 중단하고 다음을 출력해야 한다:
+- 감지된 Node.js 버전 (또는 "not found")
+- 최소 요구 버전 (`>= v22.0.0`)
+- 설치 가이드 링크 또는 권장 설치 명령
+
+[AND] 종료 코드는 비-0 이어야 하며, `~/.claude.json` 은 *어떤 변경도 없이* 유지되어야 한다.
+
+### REQ-GMC-010 (Unwanted Behavior)
+
+[IF] `~/.claude.json` 에 본 SPEC 이 도입한 `zai-mcp-server` 엔트리 외의 사용자 정의 `mcpServers` 엔트리가 존재하는 경우
+[THEN] 시스템은 `enable` / `disable` 동작 중 어떤 경우에도 사용자 정의 엔트리를 변경/이동/삭제해서는 안 된다. 본 SPEC 의 변경 범위는 `mcpServers.zai-mcp-server` 키 하나에 한정된다.
+
+## Specifications (HOW — 간략)
+
+본 섹션은 *구현 단계로 위임될 결정* 의 윤곽만 제공한다. 정확한 함수명, 패키지 경로, JSON 직렬화 방식은 plan.md 와 manager-cycle 위임 시점에 확정된다.
+
+- 신규 명령 라우팅: `internal/cli/glm.go` (또는 분리된 `glm_tools.go`) 에 `glmToolsCommand` 추가
+- JSON 머지 로직: 기존 `~/.claude.json` 을 안전하게 읽고, 사용자 정의 엔트리 보존하면서 `zai-mcp-server` 만 갱신
+- 토큰 조회: 기존 `loadGLMKey()` 헬퍼 재사용 (research.md §2.2)
+- Node.js 버전 검증: `exec.LookPath("node")` + `node --version` 출력 파싱
+- 출력 메시지: conversation_language 정책 (영어 에러, 사용자 메시지 ko)
+- 패키지 위치 후보: `internal/cli/glm_tools.go` 또는 `internal/integration/zaimcp/`
+
+## Files Affected (Anticipated, Plan-Stage Only)
+
+본 SPEC 은 코드를 수정하지 않으나, manager-cycle 위임 시 다음 파일이 영향을 받을 것으로 예측된다 (plan.md 에서 정확한 라인 범위 결정):
+
+**예상 신규 / 수정:**
+
+- `internal/cli/glm.go` 또는 `internal/cli/glm_tools.go` — `tools enable|disable` 명령 추가
+- `internal/cli/glm_test.go` 또는 `internal/cli/glm_tools_test.go` — 신규 테스트 케이스
+- `internal/template/templates/.claude/rules/moai/core/settings-management.md` — Z.AI MCP 통합 노트 추가 (Template-First Rule, CLAUDE.local.md §2)
+- `.claude/rules/moai/core/settings-management.md` — 위 미러본
+- `CHANGELOG.md` — v0.1 항목 추가
+
+**간접 영향 (수정 없음, 정책 검증):**
+
+- `internal/cli/launcher.go` — mode 전환 로직, 본 SPEC 변경 없음
+- `internal/hook/session_start.go` — SessionStart 자동 감지, 본 SPEC 변경 없음
+- `internal/template/templates/.claude/settings.json.tmpl` — settings 템플릿, 본 SPEC 변경 없음 (R5 검증 대상)
+
+## Exclusions (What NOT to Build)
+
+- **EX-1**: Mainland China 엔드포인트 (`Z_AI_MODE=ZHIPU`, `https://open.bigmodel.cn/api/anthropic`) 지원은 본 SPEC v0.1 에서 명시적으로 제외하며 v0.2 로 연기한다. 본 SPEC 의 enable 명령은 `Z_AI_MODE=ZAI` (국제) 만 설정한다. 향후 `--region zhipu` 플래그 추가는 별도 SPEC 으로 다룬다.
+- **EX-2**: 사용자 GLM Coding Plan 등급 (Lite vs Pro) 의 사전 API 검증은 구현하지 않는다. enable 시 단순 경고("Vision 과 Web Search 는 Pro 플랜 이상 필요") 를 출력하고 활성화는 진행한다. 런타임 401/403 응답은 Z.AI 가 반환하므로 본 SPEC 은 *명확한 가이드* 만 제공한다.
+- **EX-3**: 기존 사용자 `.mcp.json` (project scope) 또는 `~/.claude.json` (user scope) 의 구조 변경 또는 다른 MCP 엔트리(`context7`, `sequential-thinking`, `moai-lsp`) 에 대한 정책 변경은 본 SPEC 범위 밖이다.
+- **EX-4**: `moai cc` ↔ `moai glm` ↔ `moai cg` 모드 전환 시 자동으로 zai-mcp-server 엔트리를 enable/disable 하는 로직은 *구현하지 않는다*. 본 SPEC 의 enable/disable 은 사용자 명시적 명령에 의해서만 동작한다 (R5 결정, 단순성 원칙).
+- **EX-5**: `~/.claude.json` 스키마 검증 강화 (예: `alwaysLoad` 또는 다른 필드의 type-check) 는 본 SPEC 범위 밖이다. SPEC-CC2122-MCP-001 의 결정과 동일하게 Claude Code 런타임이 자체 검증한다고 가정.
+- **EX-6**: 사전 sample test (Vision OCR ping 등) 자동 실행은 v0.1 에서 제외한다 (research.md OQ-6). 향후 `--test` 옵트인 플래그로 검토 가능.
+
+## Risks Reference
+
+상세 위험 분석 (R1~R5) 과 완화 전략은 `plan.md` §Risks 와 `research.md` §4 를 참조한다.
+
+## Acceptance Reference
+
+상세 Given-When-Then 시나리오, edge cases, 품질 게이트 기준, Definition of Done 은 `acceptance.md` 를 참조한다. 본 spec.md 는 acceptance criteria 를 *간단 요약* 만 제공하며, 구체적 시나리오는 acceptance.md 가 single source of truth 이다.
+
+### Acceptance Summary (간단 요약)
+
+- 사용자가 `moai glm tools enable vision` 실행 시 Vision MCP 가 Claude Code 에 노출되어야 함
+- `moai glm tools disable all` 실행 시 zai-mcp-server 엔트리가 제거되어야 하며 다른 MCP 엔트리는 보존됨
+- Node.js < 22 인 환경에서 enable 명령은 graceful fail 해야 함
+- `GLM_AUTH_TOKEN` 부재 시 enable 명령은 토큰 등록 가이드를 출력 후 종료해야 함
+- 모드 전환 (`moai cc` ↔ `moai glm`) 후에도 zai-mcp-server 엔트리는 사용자 명시 disable 까지 유지되어야 함
+
+## Implementation Reference
+
+마일스톤, 우선순위, 기술적 접근 방식, 위험 완화는 `plan.md` 를 참조한다.
+
+## References
+
+- Z.AI 공식 MCP 문서: https://docs.z.ai/devpack/mcp/vision-mcp-server
+- `.moai/specs/SPEC-GLM-MCP-001/research.md` — 본 SPEC 의 deep research 산출물
+- `.moai/specs/SPEC-GLM-001/spec.md` — 베이스 GLM 호환성 자동화
+- `.moai/specs/SPEC-CC2122-MCP-001/spec.md` — `.mcp.json.tmpl` 변경 패턴 참조
+- `.moai/specs/SPEC-LSPMCP-001/spec.md` — moai-lsp MCP 통합 패턴 참조
+- CLAUDE.local.md §13 (GLM Integration Testing 정책)
+- CLAUDE.local.md §15 (Template Language Neutrality)
+- `internal/cli/glm.go` — GLM 환경 주입 진입점 (참조만, 본 SPEC 단계에서 수정 없음)
+- `internal/cli/github_auth.go` — `moai github auth glm` 패턴 참조


### PR DESCRIPTION
## Summary

SPEC-GLM-MCP-001 plan + Z.AI cache_control 호환성 검증 보고서.

Z.AI Vision/WebSearch/WebReader MCP 서버(@z_ai/mcp-server)를 \`moai glm\` 모드에 통합하는 plan-stage 산출물. plan-only PR (implementation 별도 SPEC).

## 산출물

### SPEC-GLM-MCP-001 plan 4종 (8 files / 새로 추가)

- spec.md (13.7 KB) — 10 REQ-GMC-001~010, EARS U=2/E=4/S=1/O=1/Un=2
- plan.md (15.4 KB) — M1-M5 + R1-R7 위험 매핑
- acceptance.md (19.3 KB) — 22 GWT scenarios (모든 REQ 커버)
- research.md (11.9 KB) — Phase 0.5 deep research
- spec-compact.md (6.4 KB) — Run phase token saver
- progress.md — audit-ready signal

### Z.AI cache_control 호환성 검증 보고서

- \`.moai/reports/devops/glm-cache-control-validation-2026-05-01.md\` (360 LOC)
- 결론: 현행 정책 유지 (DISABLE_PROMPT_CACHING + DISABLE_BETAS) — caching 활성화 전 실 API 검증 필요

## 권장 통합 옵션

Option 2: \`moai glm tools enable|disable\` 서브커맨드 추가 (Vision/WebSearch/WebReader 토글)

## Plan-Audit Verdict

PASS, score 0.91, MP 0 defects.

## Test Plan

- [x] plan-auditor PASS
- [ ] PR review
- [ ] CI all-green
- [ ] Admin merge

## Stale Base 안내

⚠️ Branch base = \`71dfd3e65\` (꽤 이전 commit). GitHub PR view는 base...head로 정확 diff 표시. Merge 시 conflict 발생하면 rebase 진행. 의도 변경: **8 files only** (SPEC docs 7 + report 1).

## Note

- v2.14 이후 audit (2026-05-04 세션)에서 발견된 PR 미생성 작업물. push 완료 후 정상화.
- 사용자 hybrid SPEC scoping 작업과 별개 작업으로 진행 (관련 SPEC은 추후 dependency 명시).

🗿 MoAI <email@mo.ai.kr>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive specifications and acceptance criteria for the upcoming `moai glm tools enable|disable` command integration.
  * Documented implementation roadmap for Z.AI MCP server integration with Claude Code, enabling access to Vision, Web Search, and Web Reader capabilities.
  * Included research findings, quality gates, and testing requirements for planned feature delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->