### PR TITLE
docs(spec): SPEC-V3R3-HYBRID-001 plan — moai cg 폐기 + moai hybrid 4-LLM 모드

### DIFF
--- a/.moai/specs/SPEC-V3R3-HYBRID-001/acceptance.md
+++ b/.moai/specs/SPEC-V3R3-HYBRID-001/acceptance.md
@@ -1,0 +1,513 @@
+# SPEC-V3R3-HYBRID-001 Acceptance Criteria (Phase 1B)
+
+> Given/When/Then scenarios for `moai hybrid` Multi-LLM Mode acceptance.
+> Companion to `spec.md` v0.1.0 and `plan.md` v0.1.0.
+> All 18 ACs cover the 18 REQs (1-to-1 minimum mapping confirmed in plan.md §1.4).
+
+## HISTORY
+
+| Version | Date       | Author              | Description                                                  |
+|---------|------------|---------------------|--------------------------------------------------------------|
+| 0.1.0   | 2026-05-04 | MoAI Plan Workflow  | 18 G/W/T scenarios + edge cases for SPEC-V3R3-HYBRID-001     |
+
+---
+
+## 1. Acceptance Criteria
+
+### AC-HYBRID-01: `moai hybrid --help` lists 4 allow-list providers (REQ-HYBRID-001, 002)
+
+**Given** a user has installed moai-adk-go ≥ v3R3 first minor release
+**And** the user is at any shell prompt (tmux not required for help output)
+
+**When** the user runs `moai hybrid --help`
+
+**Then** stdout contains the synopsis line `moai hybrid <provider> [-p profile] [-- claude-args...]`
+**And** stdout contains the description of all four allow-list providers: `glm`, `kimi`, `deepseek`, `qwen`
+**And** exit code is 0
+
+**Edge cases**:
+- `moai hybrid -h` (short flag): same output.
+- `moai hybrid` (no args): cobra usage hint + exit code 0 (cobra default for missing required arg with hint mode).
+- Help output references SPEC-V3R3-HYBRID-001 §10 BC migration (one-line link).
+
+**Test Anchor**: `internal/cli/hybrid_test.go TestHybridHelpListsFourProviders`
+
+---
+
+### AC-HYBRID-02: Unknown provider rejected (REQ-HYBRID-002)
+
+**Given** the 4-provider allow-list (`glm`, `kimi`, `deepseek`, `qwen`) is enforced
+
+**When** the user runs `moai hybrid mistral` (or any non-allow-list value)
+
+**Then** exit code is non-zero
+**And** stderr contains the sentinel string `UNKNOWN_PROVIDER`
+**And** stderr lists the four allowed values: `glm`, `kimi`, `deepseek`, `qwen`
+**And** Claude Code is NOT launched
+
+**Edge cases**:
+- `moai hybrid GLM` (uppercase): rejected (case-sensitive); stderr suggests lowercase.
+- `moai hybrid glm-` (with trailing dash): rejected.
+- `moai hybrid ""` (empty string): cobra "argument required" error, distinct from UNKNOWN_PROVIDER.
+- `moai hybrid setup mistral sk-xxx`: setup subcommand also rejects unknown provider.
+
+**Test Anchor**: `internal/cli/hybrid_test.go TestHybridUnknownProviderRejected`
+
+---
+
+### AC-HYBRID-03: `moai cg` returns BC error after upgrade (REQ-HYBRID-003, 010, 014)
+
+**Given** a user has upgraded from moai-adk-go v2.x (where `moai cg` was active) to v3R3
+
+**When** the user runs `moai cg` (with or without args, e.g., `moai cg -p work`)
+
+**Then** exit code is non-zero
+**And** stderr contains the sentinel string `MOAI_CG_REMOVED`
+**And** stderr contains the actionable suggestion `use 'moai hybrid glm' instead`
+**And** stderr references `SPEC-V3R3-HYBRID-001 §10 BC Migration` (one line)
+**And** Claude Code is NOT launched (no `unifiedLaunch` invocation)
+**And** `cgCmd` is still registered to rootCmd (REQ-HYBRID-014: BC stub, not silently absent)
+
+**Edge cases**:
+- `moai cg --help`: prints help text describing the removal + migration path (does NOT execute `runCGRemoved`).
+- `moai cg -p profile_name`: BC error path; profile flag is ignored.
+- `moai cg -- claude-args`: BC error path; claude-args are not forwarded.
+
+**Test Anchor**:
+- `internal/cli/cg_removal_test.go TestCGCommandReturnsBCError`
+- `internal/cli/cg_removal_test.go TestCGCommandIsRegistered`
+- `internal/cli/cg_removal_test.go TestCGCommandDoesNotLaunchClaudeCode`
+
+---
+
+### AC-HYBRID-04: `.moai/config/sections/llm.yaml` schema includes `provider` + 4-provider config (REQ-HYBRID-004)
+
+**Given** the embedded template `.moai/config/sections/llm.yaml` rendered after `moai init` or `moai update`
+
+**When** a user (or test) parses the YAML file
+
+**Then** the file contains a top-level `provider:` key (default empty string)
+**And** the file contains a top-level `providers:` map
+**And** `providers.glm.{base_url, env_var, models.{high, medium, low}}` is present and populated
+**And** `providers.kimi.{base_url, env_var, models.{high, medium, low}}` is present
+**And** `providers.deepseek.{base_url, env_var, models.{high, medium, low}}` is present
+**And** `providers.qwen.{base_url, env_var, models.{high, medium, low}}` is present
+
+**Edge cases**:
+- Existing `glm:` section (legacy, v2.x baseline) is preserved as alias for v3R3 lifetime.
+- `team_mode: ""` (default) and `provider: ""` (default) — neither hybrid nor legacy cg active.
+- Comments in YAML reference SPEC-V3R3-HYBRID-001 for migration context.
+
+**Test Anchor**: `internal/llm/registry_test.go TestEmbeddedLLMYAMLSchema`
+
+---
+
+### AC-HYBRID-05: SPEC-pinned baseline models match research.md §3 (REQ-HYBRID-005)
+
+**Given** the embedded template `.moai/config/sections/llm.yaml` is loaded
+
+**When** a test reads `providers.<name>.models.high` for each of the 4 providers
+
+**Then** the values match the SPEC-pinned baseline (per research.md §3 verification):
+- `providers.glm.models.high == "glm-4.7"` (or substring match for case-insensitive variant `GLM-4.7`)
+- `providers.kimi.models.high == "kimi-k2.6"` (substring match acceptable)
+- `providers.deepseek.models.high == "deepseek-v4-pro"`
+- `providers.qwen.models.high == "qwen3-coder-plus"` (or current verified value at run-phase entry)
+
+**And** `providers.<name>.models.low` similarly matches the pinned low-tier values
+
+**And** users can override via `~/.moai/config/sections/llm.yaml` `providers.<name>.models.high: "<custom>"` (project-layer override)
+
+**Edge cases**:
+- Provider releases new model (e.g., GLM-4.8): user override path remains stable; SPEC pinned baseline updated in next minor release.
+- Provider deprecates model (e.g., DeepSeek deprecates `deepseek-v4-pro` in 2026-Q3): SPEC update + CHANGELOG note.
+
+**Test Anchor**: `internal/llm/registry_test.go TestPinnedBaselineModels`
+
+---
+
+### AC-HYBRID-06: `moai glm` and `moai cc` preserve v2.x behavior (REQ-HYBRID-006)
+
+**Given** a user has upgraded from v2.x to v3R3
+**And** the user has not modified `.moai/config/sections/llm.yaml` since upgrade
+
+**When** the user runs `moai glm` (single-LLM all-GLM mode)
+
+**Then** the launch behavior matches v2.x baseline bit-for-bit (no functional regression):
+- GLM env-vars injected to `settings.local.json`.
+- `team_mode: "glm"` written to llm.yaml.
+- Claude Code launched with GLM as the active LLM for the lead session.
+- All existing `internal/cli/glm_test.go` tests pass.
+
+**And When** the user runs `moai cc`
+
+**Then** the launch behavior matches v2.x baseline:
+- GLM env-vars cleared (with `MOAI_BACKUP_AUTH_TOKEN_*` restoration if applicable).
+- `team_mode: ""` (cleared).
+- Claude Code launched with Claude as the active LLM.
+
+**Edge cases**:
+- `moai glm setup sk-xxx`: still saves to `~/.moai/.env.glm` (legacy path preserved).
+- `moai glm status`: still shows masked GLM key from `~/.moai/.env.glm`.
+
+**Test Anchor**: existing `internal/cli/glm_test.go TestRunGLM`, `internal/cli/launcher_test.go TestRunCC` unchanged + new `internal/cli/hybrid_test.go TestNonHybridCommandsUnaffected` regression sentinel.
+
+---
+
+### AC-HYBRID-07: `moai hybrid <provider>` happy-path launch (REQ-HYBRID-007)
+
+**Given** the user is inside a tmux session (`$TMUX` env-var set)
+**And** `~/.moai/.env.glm` exists and contains a valid `GLM_API_KEY`
+**And** `.moai/config/sections/llm.yaml` exists at project root
+
+**When** the user runs `moai hybrid glm` (or `moai hybrid glm -p work`)
+
+**Then** the CLI:
+- (a) Loads the GLM API key from `~/.moai/.env.glm`.
+- (b) Injects `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic`, `ANTHROPIC_DEFAULT_*_MODEL` into the active tmux session (verifiable via `tmux show-environment`).
+- (c) Writes `provider: "glm"` and `team_mode: "hybrid"` to `.moai/config/sections/llm.yaml`.
+- (d) Sets `teammateMode: "tmux"` in `.claude/settings.local.json`.
+- (e) Launches Claude Code via `unifiedLaunch(profileName, "claude_hybrid", filteredArgs)`.
+- (f) Prints success card with provider name, base URL, and "next steps".
+
+**Edge cases**:
+- `--proxy <url>` flag overrides `ANTHROPIC_BASE_URL` (see AC-HYBRID-13).
+- `-p profile` flag forwarded to launcher.
+- Existing `MOAI_BACKUP_AUTH_TOKEN_GLM` (provider-namespaced) preserved across re-runs.
+
+**Test Anchor**: `internal/cli/hybrid_test.go TestHybridGLMHappyPath`
+
+---
+
+### AC-HYBRID-08: `moai hybrid <provider>` outside tmux is rejected (REQ-HYBRID-008)
+
+**Given** the user is NOT inside a tmux session (`$TMUX` env-var not set)
+**And** `MOAI_TEST_MODE` is not set to `1` (test bypass disabled)
+
+**When** the user runs `moai hybrid kimi` (or any provider)
+
+**Then** exit code is non-zero
+**And** stderr contains the sentinel string `HYBRID_REQUIRES_TMUX`
+**And** stderr contains the recovery path: `tmux new -s moai && moai hybrid <provider>`
+**And** stderr suggests `moai glm` as alternative for non-tmux single-LLM mode (if the user intended GLM)
+**And** Claude Code is NOT launched
+
+**Edge cases**:
+- `MOAI_TEST_MODE=1` env-var bypasses the tmux check (for test environments only).
+- Inside a non-tmux multiplexer (e.g., zellij, screen): same rejection (only tmux session-level env-var injection is supported).
+
+**Test Anchor**: `internal/cli/hybrid_test.go TestHybridRequiresTmux`
+
+---
+
+### AC-HYBRID-09: Missing API key rejected with setup hint (REQ-HYBRID-009)
+
+**Given** the user is inside a tmux session
+**And** `~/.moai/.env.deepseek` does NOT exist or is empty
+
+**When** the user runs `moai hybrid deepseek`
+
+**Then** exit code is non-zero
+**And** stderr contains the sentinel string `HYBRID_MISSING_API_KEY`
+**And** stderr contains the setup instruction `moai hybrid setup deepseek <api-key>` (or `moai hybrid setup deepseek` for interactive prompt)
+**And** stderr references the env-var fallback `DEEPSEEK_API_KEY`
+**And** Claude Code is NOT launched
+
+**Edge cases**:
+- `~/.moai/.env.deepseek` exists but key is empty string: same rejection.
+- `DEEPSEEK_API_KEY` env-var is set in shell env: launch proceeds (env-var fallback per existing pattern in `getProviderAPIKey`).
+- File permissions deny read: distinct error path (file-system error, not `HYBRID_MISSING_API_KEY`).
+
+**Test Anchor**: `internal/cli/hybrid_test.go TestHybridMissingAPIKey`
+
+---
+
+### AC-HYBRID-10: `moai update` migrates `team_mode: cg` (REQ-HYBRID-011)
+
+**Given** a project with `.moai/config/sections/llm.yaml` containing `team_mode: "cg"` and `provider: ""` (or `provider` field absent — pre-v3R3 schema)
+
+**When** the user runs `moai update` for the first time after upgrading to v3R3
+
+**Then** post-update, the file contains:
+- `team_mode: "hybrid"`
+- `provider: "glm"`
+**And** stderr emits a one-time migration notice referencing SPEC-V3R3-HYBRID-001 §10
+**And** the migration is **idempotent** (running `moai update` a second time does not re-emit the notice nor modify the file)
+**And** atomic-write semantics are preserved (no partial state visible to concurrent readers — per SPEC-V3R3-UPDATE-CLEANUP-001 atomic write infrastructure)
+
+**Edge cases**:
+- `team_mode: "claude"` or `"glm"` (non-cg): no migration; file unchanged.
+- `team_mode: "cg"` AND `provider: "glm"` (already partial migration): only the `team_mode` field is updated; no notice (idempotent).
+- `team_mode: "cg"` AND user has manually set `provider: "kimi"`: no rewrite (user choice respected); stderr emits a warning that `team_mode: "cg"` is incompatible with `provider != "glm"`.
+
+**Test Anchor**:
+- `internal/cli/migration_test.go TestMigrateCGTeamMode`
+- `internal/cli/migration_test.go TestMigrateCGTeamModeIdempotent`
+
+---
+
+### AC-HYBRID-11: Active provider env-vars visible to teammates (REQ-HYBRID-012)
+
+**Given** the user has successfully run `moai hybrid qwen` (assuming Qwen3 endpoint is configured or `--proxy` is supplied)
+**And** Claude Code has launched with `team_mode: "hybrid"` + `provider: "qwen"`
+
+**When** a Claude Code teammate spawns in a new tmux pane (Agent Teams mode)
+
+**Then** the teammate's env shows:
+- `ANTHROPIC_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/anthropic` (or the `--proxy` URL if used)
+- `ANTHROPIC_AUTH_TOKEN=<masked-but-functional Qwen3 key>`
+- `ANTHROPIC_DEFAULT_OPUS_MODEL=qwen3-coder-plus` (or pinned baseline value)
+
+**And** the teammate sends LLM requests to the Qwen3 endpoint (verifiable via packet capture in test environment, or via observed teammate behavior matching Qwen3-Coder model traits)
+
+**And** the leader pane (Claude) is unaffected — leader's env still points to Anthropic API.
+
+**Edge cases**:
+- Teammate spawned in same pane (not a new pane): inherits leader env (Claude), not Qwen — this is the correct behavior per `moai cg` legacy architectural choice.
+- Multiple teammates in different panes: all inherit the same Qwen3 env (single active provider per session).
+- Switching provider mid-session via `moai hybrid kimi` from a different pane: leader pane's existing teammates remain on Qwen3; only new panes inherit Kimi env.
+
+**Test Anchor**: `internal/cli/hybrid_test.go TestHybridProviderTeammateInheritance` (mocked tmux for unit test; integration test in `tests/integration/`).
+
+---
+
+### AC-HYBRID-12: Endpoint failure propagates without silent fallback (REQ-HYBRID-013)
+
+**Given** the user has a valid GLM API key and is inside tmux
+**And** the GLM endpoint `https://api.z.ai/api/anthropic` is unreachable (simulated via DNS block, network partition, or HTTP 503 response)
+
+**When** the user runs `moai hybrid glm`
+
+**Then** the underlying HTTP error (DNS NXDOMAIN, connection refused, HTTP 503, etc.) is propagated to stderr
+**And** the CLI does NOT silently fall back to a different provider (`kimi`, `deepseek`, `qwen` are not auto-tried)
+**And** the CLI does NOT silently fall back to Claude (Anthropic API)
+**And** exit code is non-zero
+**And** stderr suggests the user verify the provider's status page (e.g., status.z.ai for GLM)
+
+**Edge cases**:
+- HTTP 401/403 (auth failure): handled separately by AC-HYBRID-16 (HYBRID_AUTH_FAILED).
+- HTTP 429 (rate limit): propagated as-is; no auto-retry (out of scope for this SPEC).
+- Slow response (timeout): controlled by `API_TIMEOUT_MS=3000000` (3000 sec) — same as legacy CG pattern.
+
+**Test Anchor**: `internal/cli/hybrid_test.go TestHybridEndpointUnreachableNoFallback`
+
+---
+
+### AC-HYBRID-13: `--proxy` overrides ANTHROPIC_BASE_URL (REQ-HYBRID-015)
+
+**Given** the user is inside tmux with valid Kimi API key
+**And** the user wants to route Kimi requests through a self-hosted Anthropic-compat adapter
+
+**When** the user runs `moai hybrid kimi --proxy https://my-proxy.example.com/anthropic`
+
+**Then** the tmux session env shows `ANTHROPIC_BASE_URL=https://my-proxy.example.com/anthropic`
+**And** the SPEC-pinned `providers.kimi.base_url` is NOT used (proxy takes precedence)
+**And** the launch otherwise proceeds normally
+**And** `ANTHROPIC_AUTH_TOKEN` still uses the Kimi API key (proxy is responsible for forwarding auth)
+
+**Edge cases**:
+- `--proxy` URL invalid (e.g., `htp://malformed`): rejected before launch with clear error.
+- `--proxy` URL with trailing slash vs no trailing slash: normalized; both work.
+- `--proxy` provided AND provider has 1st-class Anthropic-compat (e.g., `moai hybrid glm --proxy <url>`): proxy still wins (user override always wins).
+
+**Test Anchor**: `internal/cli/hybrid_test.go TestHybridProxyOverride`
+
+---
+
+### AC-HYBRID-14: `moai hybrid <provider> tools` surface stub (REQ-HYBRID-016)
+
+**Given** the v3R3 first minor release has shipped
+**And** SPEC-GLM-MCP-001 implementation has NOT yet shipped (PR #769 still plan-only or implementation-pending)
+
+**When** the user runs `moai hybrid glm tools --help`
+
+**Then** the help output lists `enable` and `disable` subcommand stubs
+**And** the help text references SPEC-GLM-MCP-001 (PR #769) as the implementation source
+**And** running `moai hybrid glm tools enable` returns a stub message: `tool integration is implemented in SPEC-GLM-MCP-001 follow-up; this is a forward-looking surface`
+
+**And When** SPEC-GLM-MCP-001 implementation ships (post-merge of GLM-MCP-001 follow-up PR)
+
+**Then** `moai hybrid glm tools enable` attaches Z.AI Vision/WebSearch/WebReader MCP servers (per GLM-MCP-001 REQ definition).
+
+**Edge cases**:
+- `moai hybrid kimi tools enable`: stub message explaining that tool integration is GLM-specific (Z.AI MCP server); Kimi/DeepSeek/Qwen tool integration is future SPEC.
+- `moai hybrid glm tools list`: stub message; no list yet.
+
+**Test Anchor**: `internal/cli/hybrid_test.go TestHybridToolsSubcommandStub`
+
+---
+
+### AC-HYBRID-15: 5th provider PR rejected by allow-list audit (REQ-HYBRID-017)
+
+**Given** a future PR adds a new file `internal/llm/providers/mistral.go` (or any non-allow-list provider)
+
+**When** CI runs `go test ./internal/template/ -run TestProviderAllowlist`
+
+**Then** the test FAILS with sentinel string `PROVIDER_ALLOWLIST_VIOLATION`
+**And** the failure message references the four allowed values: `glm`, `kimi`, `deepseek`, `qwen`
+**And** the failure message references SPEC-V3R3-HYBRID-001 REQ-HYBRID-017 + the atomic-reversal SPEC requirement
+
+**Edge cases**:
+- PR adds `internal/llm/providers/mistral_test.go` (test file only): test ignores `_test.go` suffix; only `.go` files counted.
+- PR adds `internal/llm/providers/registry_test.go`: ignored (registry helper, not a provider).
+- PR modifies existing `glm.go` (no new file): test passes (still 4 entries).
+- PR adds `internal/llm/providers/glm_v2.go` (variant): test fails because regex/pattern targets the 4 specific filenames (`glm.go`, `kimi.go`, `deepseek.go`, `qwen.go`).
+
+**Test Anchor**: `internal/template/provider_allowlist_audit_test.go TestProviderAllowlist`
+
+---
+
+### AC-HYBRID-16: HTTP 401 masks API key (REQ-HYBRID-018)
+
+**Given** the user runs `moai hybrid glm` with an invalid GLM API key
+**And** the Z.AI endpoint returns HTTP 401 (or 403)
+
+**When** the launch path receives the auth failure
+
+**Then** stderr contains the sentinel string `HYBRID_AUTH_FAILED`
+**And** stderr contains the hint `verify the key via 'moai hybrid status glm'`
+**And** if any error message in stderr includes the API key, it is **masked** using the `maskAPIKey` pattern (e.g., `sk-x****wxyz` showing only first 4 + last 4 characters; never the full key)
+**And** the API key is NOT logged in any stderr line, log file, or telemetry payload (REQ-UPC-022 telemetry from SPEC-V3R3-UPDATE-CLEANUP-001 explicitly excludes API keys)
+
+**Edge cases**:
+- HTTP 403 (forbidden, key valid but insufficient permissions): same `HYBRID_AUTH_FAILED` path; hint mentions checking subscription tier.
+- API key length < 8 chars: `maskAPIKey` returns `****` per existing implementation.
+- Multi-line error message: every line containing the key substring is sanitized.
+
+**Test Anchor**: `internal/cli/hybrid_test.go TestHybridAuthFailureMasksKey`
+
+---
+
+### AC-HYBRID-17: `moai hybrid glm` matches `moai cg` v2.x behavior bit-for-bit (REQ-HYBRID-005, 014)
+
+**Given** a user previously used `moai cg` in v2.x with a known-good workflow
+**And** the user has captured the post-launch state: `tmux show-environment`, `.claude/settings.local.json`, `.moai/config/sections/llm.yaml`
+
+**When** the same user upgrades to v3R3 and runs `moai hybrid glm` with the same preconditions (same API key, same profile, same tmux session)
+
+**Then** the resulting state matches v2.x bit-for-bit on these surfaces:
+- `tmux show-environment | grep ANTHROPIC_*` returns identical key set + values (modulo `team_mode: "hybrid"` vs `"cg"` in llm.yaml — semantic mapping).
+- `.claude/settings.local.json teammateMode == "tmux"` (unchanged).
+- `.claude/settings.local.json env` contains the same GLM env-var keys + values (unchanged).
+- Claude Code launches with the same provider routing (lead = Claude, teammates = GLM).
+- `MOAI_BACKUP_AUTH_TOKEN_GLM` slot used (provider-namespaced) in place of legacy `MOAI_BACKUP_AUTH_TOKEN`.
+
+**And** existing v2.x `moai cg` workflow (e.g., `/moai run SPEC-XXX --team`) produces identical observable behavior.
+
+**Edge cases**:
+- Single backup slot (legacy `MOAI_BACKUP_AUTH_TOKEN`) → namespaced slot (`MOAI_BACKUP_AUTH_TOKEN_GLM`): migration path documented; legacy slot read for one transition cycle then cleaned.
+- v2.x captured `team_mode: "cg"` config → v3R3 `team_mode: "hybrid"` + `provider: "glm"`: REQ-HYBRID-011 auto-migration handles.
+
+**Test Anchor**: `internal/cli/hybrid_test.go TestHybridBackwardCompatWithCG`
+
+---
+
+### AC-HYBRID-18: Provider registry contains exactly 4 entries at runtime (REQ-HYBRID-002, 017)
+
+**Given** the v3R3 binary is built and `internal/llm/providers/registry.go` is loaded
+
+**When** `providers.List()` is called
+
+**Then** the returned slice contains exactly 4 entries: `["glm", "kimi", "deepseek", "qwen"]`
+**And** the order is deterministic (alphabetical or registration order, defined as part of the test contract)
+
+**And When** `providers.Lookup("glm")` is called
+
+**Then** a non-nil Provider implementation is returned
+
+**And When** `providers.Lookup("mistral")` (any non-allow-list value) is called
+
+**Then** an error is returned with sentinel `UNKNOWN_PROVIDER` and message listing the four allowed values
+
+**Edge cases**:
+- `providers.Lookup("")`: distinct error (empty string), distinct from UNKNOWN_PROVIDER.
+- `providers.Lookup("GLM")` (uppercase): UNKNOWN_PROVIDER (case-sensitive).
+- Goroutine concurrency: registry is read-only after init; no race condition.
+
+**Test Anchor**: `internal/llm/registry_test.go TestProviderRegistryConsistency`
+
+---
+
+## 2. Edge Cases Summary
+
+| Scenario | Expected | Test Anchor |
+|---|---|---|
+| `moai hybrid` (no provider arg) | cobra usage hint | `TestHybridHelpListsFourProviders` |
+| `moai hybrid GLM` (uppercase) | UNKNOWN_PROVIDER (case-sensitive) | `TestHybridUnknownProviderRejected` |
+| `moai cg --help` | BC notice in help text (NOT runCGRemoved exec) | `TestCGCommandHelp` |
+| `moai cg -p work` | BC error; profile flag ignored | `TestCGCommandReturnsBCError` |
+| `team_mode: "cg"` + `provider: "kimi"` (manual) | warning, no auto-rewrite | `TestMigrateCGTeamModeUserChoice` |
+| Empty `~/.moai/.env.glm` | HYBRID_MISSING_API_KEY | `TestHybridMissingAPIKey` |
+| `--proxy` invalid URL | clear pre-launch error | `TestHybridProxyInvalidURL` |
+| HTTP 429 from provider | propagate as-is, no auto-retry | `TestHybridRateLimitPropagated` |
+| New `internal/llm/providers/mistral.go` PR | PROVIDER_ALLOWLIST_VIOLATION | `TestProviderAllowlist` |
+| `MOAI_TEST_MODE=1` bypass tmux check | succeed (test only) | `TestHybridTmuxBypassInTestMode` |
+| Provider releases new model (GLM-4.8) | user override path stable | (manual; SPEC update process) |
+| `moai cg` invocation cobra fallback (after binary upgrade where cgCmd not registered) | regression sentinel: cgCmd MUST be registered | `TestCGCommandIsRegistered` |
+| `moai hybrid glm tools enable` (pre-GLM-MCP-001) | stub message, references SPEC-GLM-MCP-001 | `TestHybridToolsSubcommandStub` |
+| `moai hybrid kimi tools enable` (no Z.AI MCP) | stub explaining GLM-specific scope | `TestHybridToolsKimiNoOp` |
+
+---
+
+## 3. Quality Gate Criteria
+
+Per `.claude/rules/moai/core/moai-constitution.md` TRUST 5 framework + plan-auditor PASS criteria:
+
+### 3.1 Tested
+
+- [ ] All 18 ACs have at least one test anchor (verified in plan.md §1.3 Deliverables).
+- [ ] Test files compile and pass on macOS, Ubuntu, Windows (CI 3-OS matrix).
+- [ ] Code coverage ≥ 85% for `internal/llm/` package (TRUST 5 minimum).
+- [ ] Code coverage ≥ 90% for `internal/cli/hybrid.go` (CLI surface = critical).
+- [ ] All existing `internal/cli/glm_test.go` and `internal/cli/launcher_test.go` tests continue to pass (regression sentinel for REQ-HYBRID-006).
+
+### 3.2 Readable
+
+- [ ] All exported functions in `internal/llm/` and `internal/cli/hybrid.go` have godoc comments.
+- [ ] Provider interface (`internal/llm/provider.go`) documents the contract: Anthropic-compat HTTP only, no native SDKs.
+- [ ] Sentinel strings (`MOAI_CG_REMOVED`, `UNKNOWN_PROVIDER`, `HYBRID_REQUIRES_TMUX`, etc.) are extracted to a central `errors.go` or constants file (per CLAUDE.local.md §14 hardcoding prohibition).
+- [ ] No magic numbers / strings beyond pinned baselines (which live in provider metadata files).
+
+### 3.3 Unified
+
+- [ ] `gofmt`, `goimports`, `golangci-lint` pass with zero warnings.
+- [ ] Naming conventions match existing codebase (e.g., `snake_case.go` for Go files; `CamelCase` for exports).
+- [ ] Error wrapping uses `fmt.Errorf("...: %w", err)` (per CLAUDE.local.md §3 Code Standards).
+
+### 3.4 Secured
+
+- [ ] API keys are NEVER logged in plain text (REQ-HYBRID-018).
+- [ ] `maskAPIKey` is used at every error path that mentions a key.
+- [ ] `~/.moai/.env.<provider>` files are mode `0600` (existing pattern).
+- [ ] No new secrets are committed to the repository (verified by CI secret-scanner).
+- [ ] BC stub `moai cg` does NOT exfiltrate any pre-existing config (only emits structured error).
+
+### 3.5 Trackable
+
+- [ ] CHANGELOG entry references `BC-V3R3-HYBRID-001` and SPEC-V3R3-HYBRID-001 §10.
+- [ ] Conventional Commits used: `feat(hybrid):`, `fix(cg):`, `refactor(llm):`, `docs(spec):` etc.
+- [ ] All MX tags (10 planned per plan.md §6) inserted at run-phase end.
+- [ ] PR description references SPEC ID + AC list + plan-auditor PASS verdict.
+
+---
+
+## 4. Definition of Done (DoD)
+
+A milestone (M1-M5) is **DONE** when:
+
+1. All test anchors for the milestone's REQ coverage are GREEN.
+2. `go test ./...` passes from repo root with 0 failures (no cascading from M1's RED tests after M4 GREEN).
+3. `make build` succeeds with 0 errors (embedded.go regenerated).
+4. Embedded-template parity verified (all `.claude/...` and `.moai/...` changes mirrored in `internal/template/templates/`).
+5. plan-auditor PASS at C1-C18 (final M5 check before sync-phase).
+
+The full SPEC is **DONE** when:
+
+1. All 5 milestones (M1-M5) are DONE.
+2. `progress.md` records `run_complete_at: <ISO-8601>` and `run_status: implementation-complete`.
+3. `/moai sync SPEC-V3R3-HYBRID-001` succeeds (PR creation + docs-site 4-locale sync per CLAUDE.local.md §17).
+4. `BC-V3R3-HYBRID-001` is announced in the v3R3 first minor release notes.
+
+---
+
+End of acceptance.md.

--- a/.moai/specs/SPEC-V3R3-HYBRID-001/plan.md
+++ b/.moai/specs/SPEC-V3R3-HYBRID-001/plan.md
@@ -1,0 +1,585 @@
+# SPEC-V3R3-HYBRID-001 Implementation Plan (Phase 1B)
+
+> Implementation plan for `moai hybrid` Multi-LLM Mode (cg deprecation + GLM/Kimi/DeepSeek/Qwen3-Coder team support).
+> Companion to `spec.md` v0.1.0 and `research.md` v0.1.0.
+> Authored against branch `feature/SPEC-V3R3-HYBRID-001` at `/Users/goos/MoAI/moai-adk-go` (solo mode, no worktree).
+
+## HISTORY
+
+| Version | Date       | Author                        | Description                                                              |
+|---------|------------|-------------------------------|--------------------------------------------------------------------------|
+| 0.1.0   | 2026-05-04 | MoAI Plan Workflow (Phase 1B) | 최초 작성 — `moai cg` 제거 + `moai hybrid` 도입 5-milestone plan + REQ↔AC traceability |
+
+---
+
+## 1. Plan Overview
+
+### 1.1 Goal restatement
+
+본 plan은 spec.md REQ-HYBRID-001..018을 실행 가능한 5-milestone 작업 분해로 변환한다. 핵심 deliverable:
+
+- **신규 abstraction layer**: `internal/llm/provider.go` (interface) + `internal/llm/providers/{glm,kimi,deepseek,qwen}.go` (4 메타데이터 파일).
+- **신규 명령**: `internal/cli/hybrid.go` — `moai hybrid <provider> [-p profile] [-- claude-args...]`.
+- **BC stub**: `internal/cli/cg.go` — `MOAI_CG_REMOVED` actionable 에러 반환.
+- **Generalize**: `internal/cli/glm.go`의 GLM-specific 함수들을 provider-agnostic helper로 refactor (LOC ~200 이주, ~50 LOC adjustments).
+- **Routing 일반화**: `internal/cli/launcher.go:57 case "claude_glm"` → `case "claude_hybrid"` + provider 라우팅.
+- **Schema 확장**: `.moai/config/sections/llm.yaml` + embedded template — `provider` + `providers.<name>.{base_url, models, env_var}` 추가.
+- **Test surface**: `provider_allowlist_audit_test.go` (REQ-HYBRID-002, 017), `cg_removal_test.go` (REQ-HYBRID-003, 010, 014), `hybrid_test.go` (REQ-HYBRID-007..009, 012, 013, 015), `migration_test.go` (REQ-HYBRID-011).
+- **Documentation substitution**: ~10 mention across 6+ files (CLAUDE.md §15, CLAUDE.local.md §16, .claude/skills/moai/team/glm.md, .claude/skills/moai/team/run.md, .claude/skills/moai/workflows/run.md, .claude/rules/moai/development/model-policy.md).
+- **CHANGELOG**: `BC-V3R3-HYBRID-001` entry with migration table.
+
+### 1.2 Implementation Methodology
+
+`.moai/config/sections/quality.yaml`: `development_mode: tdd`. Run phase MUST follow RED → GREEN → REFACTOR per `.claude/rules/moai/workflow/spec-workflow.md` Phase Run.
+
+- **RED (M1)**: 4 신규 audit/unit tests를 먼저 작성. 모두 실패 상태 확인 (`provider_allowlist_audit_test.go`, `cg_removal_test.go`, `hybrid_test.go`, `migration_test.go`).
+- **GREEN part 1 (M2)**: `internal/llm/provider.go` interface + 4 provider 메타데이터 파일 + `internal/config/types.go` LLMConfig 확장. provider_allowlist_audit_test → GREEN.
+- **GREEN part 2 (M3)**: `internal/cli/hybrid.go` 신규 명령 + `internal/cli/cg.go` BC stub. cg_removal_test + hybrid_test (basic) → GREEN.
+- **GREEN part 3 (M4)**: `internal/cli/glm.go` generalize + `injectProviderEnvForTeam` + `internal/cli/launcher.go:57` 분기 변경 + `internal/cli/update.go` migrateCGTeamMode. hybrid_test (full) + migration_test → GREEN.
+- **REFACTOR (M5)**: 6+ 문서 substitution + CLAUDE.md §15 / CLAUDE.local.md §16 + CHANGELOG `BC-V3R3-HYBRID-001` entry + MX tag 삽입 + final `make build` + full `go test ./...`.
+
+### 1.3 Deliverables
+
+| Deliverable | Path | REQ Coverage |
+|---|---|---|
+| Provider abstraction interface | `internal/llm/provider.go` (NEW) | REQ-HYBRID-001, 002, 005, 017 |
+| GLM provider metadata | `internal/llm/providers/glm.go` (NEW) | REQ-HYBRID-002, 005 |
+| Kimi K2 provider metadata | `internal/llm/providers/kimi.go` (NEW) | REQ-HYBRID-002, 005, 015 |
+| DeepSeek V4 provider metadata | `internal/llm/providers/deepseek.go` (NEW) | REQ-HYBRID-002, 005 |
+| Qwen3-Coder provider metadata | `internal/llm/providers/qwen.go` (NEW) | REQ-HYBRID-002, 005, 015 |
+| Provider registry + allow-list test | `internal/llm/providers/registry.go` + `internal/llm/registry_test.go` (NEW) | REQ-HYBRID-002, 017 |
+| `moai hybrid` 명령 정의 | `internal/cli/hybrid.go` (NEW) | REQ-HYBRID-001, 002, 007, 008, 009, 015, 016 |
+| `moai cg` BC stub | `internal/cli/cg.go` (REPLACE) | REQ-HYBRID-003, 010, 014 |
+| LLMConfig 확장 (`Provider` + `Providers map`) | `internal/config/types.go` (MODIFY) | REQ-HYBRID-004 |
+| Provider 기본값 | `internal/config/defaults.go` (MODIFY) | REQ-HYBRID-005 |
+| `provider-agnostic` injection helpers | `internal/llm/inject.go` (NEW) — refactor of `glm.go`'s `injectGLMEnvForTeam`, `injectTmuxSessionEnv`, etc. | REQ-HYBRID-007, 012, 018 |
+| `internal/cli/glm.go` generalize callsites | `internal/cli/glm.go` (MODIFY) | REQ-HYBRID-006, 007 (보존 + GLM provider로 위임) |
+| Launcher 라우팅 일반화 | `internal/cli/launcher.go` (MODIFY) | REQ-HYBRID-007 |
+| `moai update` migration helper | `internal/cli/update.go` (MODIFY) | REQ-HYBRID-011 |
+| Project llm.yaml 스키마 확장 | `.moai/config/sections/llm.yaml` (MODIFY) | REQ-HYBRID-004 |
+| Embedded template llm.yaml 미러 | `internal/template/templates/.moai/config/sections/llm.yaml` (MODIFY) | REQ-HYBRID-004 |
+| Provider allow-list audit test | `internal/template/provider_allowlist_audit_test.go` (NEW) | REQ-HYBRID-002, 017 |
+| `moai cg` removal test | `internal/cli/cg_removal_test.go` (NEW) | REQ-HYBRID-003, 010, 014 |
+| `moai hybrid` integration tests | `internal/cli/hybrid_test.go` (NEW) | REQ-HYBRID-001, 002, 007..009, 012, 013, 015, 018 |
+| Migration test (`team_mode: cg` → `hybrid`) | `internal/cli/migration_test.go` (NEW) | REQ-HYBRID-011 |
+| CLAUDE.md §15 substitution | `CLAUDE.md` (MODIFY) | Trackable |
+| CLAUDE.local.md §16 substitution | `CLAUDE.local.md` (MODIFY) | Trackable |
+| `.claude/skills/moai/team/glm.md` substitution (5 lines) | `.claude/skills/moai/team/glm.md` (MODIFY) | REQ-HYBRID-001 |
+| `.claude/skills/moai/team/run.md` substitution (5 lines) | `.claude/skills/moai/team/run.md` (MODIFY) | REQ-HYBRID-001 |
+| `.claude/skills/moai/workflows/run.md:904` | `.claude/skills/moai/workflows/run.md` (MODIFY) | REQ-HYBRID-001 |
+| `.claude/rules/moai/development/model-policy.md:44` | `.claude/rules/moai/development/model-policy.md` (MODIFY) | REQ-HYBRID-001 |
+| CHANGELOG `BC-V3R3-HYBRID-001` entry | `CHANGELOG.md` (MODIFY) | Trackable (TRUST 5) |
+
+[HARD] Embedded-template parity: 모든 `.claude/...` 변경은 `internal/template/templates/.claude/...` mirror + `make build` 필수 (CLAUDE.local.md §2 Template-First HARD).
+
+### 1.4 Traceability Matrix (REQ → AC mapping)
+
+Plan-auditor PASS criterion #2: every REQ maps to at least one AC.
+
+| REQ ID | Category | Mapped AC(s) |
+|---|---|---|
+| REQ-HYBRID-001 | Ubiquitous | AC-HYBRID-01, AC-HYBRID-14 |
+| REQ-HYBRID-002 | Ubiquitous | AC-HYBRID-01, AC-HYBRID-02, AC-HYBRID-15, AC-HYBRID-18 |
+| REQ-HYBRID-003 | Ubiquitous | AC-HYBRID-03 |
+| REQ-HYBRID-004 | Ubiquitous | AC-HYBRID-04 |
+| REQ-HYBRID-005 | Ubiquitous | AC-HYBRID-05, AC-HYBRID-17 |
+| REQ-HYBRID-006 | Ubiquitous | AC-HYBRID-06 |
+| REQ-HYBRID-007 | Event-Driven | AC-HYBRID-07 |
+| REQ-HYBRID-008 | Event-Driven | AC-HYBRID-08 |
+| REQ-HYBRID-009 | Event-Driven | AC-HYBRID-09 |
+| REQ-HYBRID-010 | Event-Driven | AC-HYBRID-03 |
+| REQ-HYBRID-011 | Event-Driven | AC-HYBRID-10 |
+| REQ-HYBRID-012 | State-Driven | AC-HYBRID-11 |
+| REQ-HYBRID-013 | State-Driven | AC-HYBRID-12 |
+| REQ-HYBRID-014 | State-Driven | AC-HYBRID-03, AC-HYBRID-17 |
+| REQ-HYBRID-015 | Optional | AC-HYBRID-13 |
+| REQ-HYBRID-016 | Optional | AC-HYBRID-14 |
+| REQ-HYBRID-017 | Complex (Unwanted) | AC-HYBRID-15, AC-HYBRID-18 |
+| REQ-HYBRID-018 | Complex (Auth Failure) | AC-HYBRID-16 |
+
+Coverage: **18/18 REQs mapped, 18/18 ACs validated** (some ACs map to multiple REQs; see acceptance.md for full G/W/T per AC).
+
+---
+
+## 2. Milestone Breakdown (M1-M5)
+
+각 milestone은 **priority-ordered** (no time estimates per `.claude/rules/moai/core/agent-common-protocol.md` §Time Estimation HARD rule).
+
+### M1: Test scaffolding (RED phase) — Priority P0
+
+Reference: `internal/template/lang_boundary_audit_test.go` (SPEC-V3R2-WF-005 M1 패턴), `internal/cli/glm_test.go` (existing test 패턴).
+
+Owner role: `expert-backend` (Go test) or direct `manager-tdd` execution.
+
+Scope:
+
+1. **`internal/template/provider_allowlist_audit_test.go`** (REQ-HYBRID-002, 017):
+   - `TestProviderAllowlist`: walk `internal/llm/providers/` directory in embedded FS, assert exactly 4 `.go` files (excluding `_test.go`) named `glm.go`, `kimi.go`, `deepseek.go`, `qwen.go`. On 5th file: `t.Errorf("PROVIDER_ALLOWLIST_VIOLATION: %s exists; v3R3 allow-list is closed at four (glm, kimi, deepseek, qwen)", path)`.
+   - `TestProviderRegistryConsistency`: load `internal/llm/providers/registry.go` provider list, assert 4 entries.
+2. **`internal/cli/cg_removal_test.go`** (REQ-HYBRID-003, 010, 014):
+   - `TestCGCommandReturnsBCError`: invoke `moai cg` via cobra subcommand, assert non-zero exit + stderr contains `MOAI_CG_REMOVED` + `use 'moai hybrid glm' instead`.
+   - `TestCGCommandIsRegistered`: assert `cgCmd` is still registered to rootCmd (BC stub, not removed entirely).
+   - `TestCGCommandDoesNotLaunchClaudeCode`: assert `unifiedLaunchFunc` not called by runCG (BC path short-circuits).
+3. **`internal/cli/hybrid_test.go`** (REQ-HYBRID-001, 002, 007..009, 012, 013, 015, 018):
+   - `TestHybridHelpListsFourProviders`: invoke `moai hybrid --help`, assert output contains "glm", "kimi", "deepseek", "qwen".
+   - `TestHybridUnknownProviderRejected`: invoke `moai hybrid mistral`, assert exit code non-zero + stderr contains `UNKNOWN_PROVIDER`.
+   - `TestHybridRequiresTmux`: simulate non-tmux env (`MOAI_TEST_MODE=0`, no `TMUX` env), invoke `moai hybrid glm`, assert `HYBRID_REQUIRES_TMUX` error.
+   - `TestHybridMissingAPIKey`: simulate tmux env + missing `~/.moai/.env.glm`, assert `HYBRID_MISSING_API_KEY`.
+   - `TestHybridProxyOverride`: invoke `moai hybrid kimi --proxy https://my-proxy/anthropic`, assert ANTHROPIC_BASE_URL set to proxy URL.
+   - `TestHybridAuthFailureMasksKey`: simulate HTTP 401 from provider, assert error message contains `HYBRID_AUTH_FAILED` + masked key (no plain-text key).
+   - `TestHybridBackwardCompatWithCG`: load fixture `team_mode: "cg"` config, run `moai update`, assert `team_mode: "hybrid"` + `provider: "glm"` post-update + tmux env-vars match v2.x bit-for-bit.
+4. **`internal/cli/migration_test.go`** (REQ-HYBRID-011):
+   - `TestMigrateCGTeamMode`: setup tmpdir with `.moai/config/sections/llm.yaml` containing `team_mode: "cg"`, invoke `migrateCGTeamMode(root)`, assert post-call file contains `team_mode: "hybrid"` + `provider: "glm"` + stderr emits one-time notice.
+   - `TestMigrateCGTeamModeIdempotent`: run twice, assert second run is no-op (notice emitted only once).
+
+Verification gate before advancing to M2:
+- `go test ./internal/template/ -run TestProviderAllowlist` → RED (no `internal/llm/providers/` directory yet).
+- `go test ./internal/cli/ -run "TestCG|TestHybrid|TestMigrate"` → RED (functions/files missing).
+
+[HARD] No implementation code in M1 outside of test files. The test failures must reference exact file/function names so subsequent milestones know where to implement.
+
+### M2: Provider abstraction layer (GREEN, part 1) — Priority P0
+
+Owner role: `expert-backend`.
+
+Scope:
+
+1. **`internal/llm/provider.go`** (NEW): interface definition.
+   ```go
+   type Provider interface {
+       Name() string                          // "glm" | "kimi" | "deepseek" | "qwen"
+       AnthropicBaseURL() string
+       EnvKeyName() string                    // e.g., "GLM_API_KEY"
+       DefaultModels() ModelSet               // High, Medium, Low
+       BuildEnvVars(apiKey string) map[string]string
+       ProxyOverride(proxyURL string) Provider  // returns a copy with overridden base_url
+   }
+   type ModelSet struct { High, Medium, Low string }
+   ```
+2. **`internal/llm/providers/glm.go`** (NEW): GLM provider metadata. base_url `https://api.z.ai/api/anthropic`, models `{glm-4.7, glm-4.7, glm-4.5-air}`, env_var `GLM_API_KEY`. BuildEnvVars includes Z.AI compat flags (DISABLE_PROMPT_CACHING=1, etc.) per research.md §5.2.
+3. **`internal/llm/providers/kimi.go`** (NEW): Kimi K2 provider metadata. base_url candidate `https://api.moonshot.ai/anthropic` (research.md §3.2 pending), models `{kimi-k2.6, kimi-k2.6, kimi-k2-flash}`, env_var `KIMI_API_KEY`. BuildEnvVars TBD per provider docs (likely DISABLE_PROMPT_CACHING=1 by default until Kimi docs confirm).
+4. **`internal/llm/providers/deepseek.go`** (NEW): DeepSeek V4 provider metadata. base_url `https://api.deepseek.com/anthropic`, models `{deepseek-v4-pro, deepseek-v4-pro, deepseek-v4-flash}`, env_var `DEEPSEEK_API_KEY`. BuildEnvVars TBD.
+5. **`internal/llm/providers/qwen.go`** (NEW): Qwen3-Coder provider metadata. base_url candidate `https://dashscope.aliyuncs.com/compatible-mode/anthropic` (research.md §3.4 pending), models `{qwen3-coder-plus, qwen3-coder-plus, qwen3-coder-flash}`, env_var `DASHSCOPE_API_KEY`. BuildEnvVars TBD.
+6. **`internal/llm/providers/registry.go`** (NEW): provider registry map.
+   ```go
+   var Registry = map[string]Provider{
+       "glm":      GLMProvider{},
+       "kimi":     KimiProvider{},
+       "deepseek": DeepSeekProvider{},
+       "qwen":     QwenProvider{},
+   }
+   func List() []string { return []string{"glm", "kimi", "deepseek", "qwen"} }
+   func Lookup(name string) (Provider, error) { ... }
+   ```
+7. **`internal/config/types.go`** (MODIFY): extend `LLMConfig`.
+   ```go
+   type LLMConfig struct {
+       // ... existing fields preserved (Mode, TeamMode, GLMEnvVar, ClaudeModels, GLM, ...)
+       Provider  string                   `yaml:"provider"`              // NEW: "" or one of allow-list
+       Providers map[string]ProviderYAML `yaml:"providers,omitempty"`   // NEW: per-provider config
+   }
+   type ProviderYAML struct {
+       BaseURL string                 `yaml:"base_url"`
+       EnvVar  string                 `yaml:"env_var"`
+       Models  map[string]string     `yaml:"models"`  // {high, medium, low}
+   }
+   ```
+8. **`internal/config/defaults.go`** (MODIFY): add `NewDefaultProvidersConfig()` returning the 4-provider default mapping.
+9. **`.moai/config/sections/llm.yaml`** + **`internal/template/templates/.moai/config/sections/llm.yaml`** (MODIFY): add `provider: ""` + `providers:` section per research.md §2.4.
+10. Run `make build` to regenerate `internal/template/embedded.go`.
+
+Verification:
+- `go test ./internal/llm/... -run TestProviderRegistry` → GREEN (4 entries).
+- `go test ./internal/template/ -run TestProviderAllowlist` → GREEN (exactly 4 .go files in providers/).
+- `internal/llm/providers/registry_test.go` covers REQ-HYBRID-002, REQ-HYBRID-005 baseline.
+
+### M3: `moai hybrid` 명령 + `moai cg` BC stub (GREEN, part 2) — Priority P0
+
+Owner role: `expert-backend`.
+
+Scope:
+
+1. **`internal/cli/hybrid.go`** (NEW):
+   - `var hybridCmd = &cobra.Command{ Use: "hybrid <provider>", ... }` with provider subcommand routing.
+   - `func runHybrid(cmd, args)`: parse `<provider>` arg → `providers.Lookup(name)` → `provider.BuildEnvVars(apiKey)` → tmux env injection + `unifiedLaunch(profileName, "claude_hybrid", filteredArgs)` (post-M4 launcher.go change).
+   - `--proxy <url>` flag handling (REQ-HYBRID-015).
+   - `var hybridSetupCmd = ... { Use: "setup <provider> [api-key]" }` — saves to `~/.moai/.env.<provider>`.
+   - `var hybridStatusCmd = ... { Use: "status [<provider>]" }` — masked key display per provider.
+   - `var hybridToolsCmd = ... { Use: "tools <enable|disable>" }` (REQ-HYBRID-016 stub) — returns `not yet implemented (deferred to SPEC-GLM-MCP-001 follow-up)` message.
+   - `init()` registers `hybridCmd` to rootCmd.
+2. **`internal/cli/cg.go`** (REPLACE): BC stub.
+   ```go
+   var cgCmd = &cobra.Command{
+       Use:    "cg",
+       Hidden: false,  // visible in help so users know it exists but is removed
+       Short:  "[REMOVED in v3R3] Use 'moai hybrid glm' instead",
+       Long:   "...detailed BC notice referencing SPEC-V3R3-HYBRID-001 §10...",
+       RunE:   runCGRemoved,
+   }
+   func runCGRemoved(cmd, args) error {
+       fmt.Fprintln(cmd.ErrOrStderr(), "Error: MOAI_CG_REMOVED")
+       fmt.Fprintln(cmd.ErrOrStderr(), "  'moai cg' was removed in v3R3 per SPEC-V3R3-HYBRID-001.")
+       fmt.Fprintln(cmd.ErrOrStderr(), "  Replacement: 'moai hybrid glm' (multi-LLM hybrid mode).")
+       fmt.Fprintln(cmd.ErrOrStderr(), "  See SPEC-V3R3-HYBRID-001 §10 BC Migration for details.")
+       return errors.New("MOAI_CG_REMOVED")
+   }
+   ```
+3. Mirror to `internal/template/templates/internal/cli/...` if applicable (cg.go and hybrid.go are Go source files, not template files; no embedded mirror needed).
+
+Verification:
+- `go test ./internal/cli/ -run TestCGCommand` → GREEN.
+- `go test ./internal/cli/ -run "TestHybridHelp|TestHybridUnknownProvider|TestHybridProxyOverride"` → GREEN.
+
+### M4: Generalize injection + launcher routing + migration (GREEN, part 3) — Priority P0
+
+Owner role: `expert-backend`.
+
+Scope:
+
+1. **`internal/llm/inject.go`** (NEW): provider-agnostic helpers refactored from `internal/cli/glm.go`.
+   - `InjectTmuxSessionEnv(provider Provider, apiKey string)` ← refactor `glm.go:356-385`.
+   - `InjectProviderEnvForTeam(settingsPath string, provider Provider, apiKey string)` ← refactor `glm.go:520-581`. Provider-namespaced backup keys (`MOAI_BACKUP_AUTH_TOKEN_<UPPER>`).
+   - `ClearTmuxSessionEnv(providers ...Provider)` ← refactor `glm.go:392-421`. Accepts list of providers to clear (typically just the active one).
+   - `EnsureSettingsLocalJSONHybrid(settingsPath)` ← refactor `glm.go:443-482`. teammateMode="tmux" + clean legacy CLAUDE_CODE_TEAMMATE_DISPLAY.
+2. **`internal/cli/glm.go`** (MODIFY): swap GLM-specific calls to use `internal/llm` helpers.
+   - `runGLM`: replace inline GLM env build with `providers.GLMProvider{}.BuildEnvVars(apiKey)`.
+   - `runGLM` line 148-149 messaging: substitute `moai cg` → `moai hybrid glm`.
+   - `enableTeamMode(cmd, isHybrid bool)`: keep public API but delegate body to `enableHybridTeamMode(cmd, providers.GLMProvider{}, isHybrid)`.
+   - **Preserve** `moai glm`, `moai glm setup`, `moai glm status` for REQ-HYBRID-006 (no behavioral change).
+3. **`internal/cli/launcher.go:57`** (MODIFY): replace `case "claude_glm":` branch with `case "claude_hybrid":` — switch on `LLMConfig.Provider` field and call `providers.Lookup(provider)` to get current Provider; route accordingly.
+4. **`internal/cli/launcher.go:185`** (MODIFY): `persistTeamMode(root, "cg")` → `persistTeamMode(root, "hybrid")` + separately persist `provider: "<name>"`.
+5. **`internal/cli/update.go`** (MODIFY): add `migrateCGTeamMode(root)` helper.
+   - Read `.moai/config/sections/llm.yaml`.
+   - If `team_mode: "cg"` and `provider: ""`: rewrite to `team_mode: "hybrid"` + `provider: "glm"`. Atomic write (Same pattern as SPEC-V3R3-UPDATE-CLEANUP-001 atomic write).
+   - Emit one-time stderr notice (research.md §7).
+   - Invoke from `cleanMoaiManagedPaths` (`internal/cli/update.go:1411`) or equivalent post-cleanup hook.
+6. Mirror project `.moai/config/sections/llm.yaml` to embedded template; run `make build`.
+
+Verification:
+- `go test ./internal/cli/ -run "TestHybrid"` (full suite) → GREEN.
+- `go test ./internal/cli/ -run TestMigrateCGTeamMode` → GREEN.
+- `go test ./...` → 0 cascading failures.
+
+[HARD] M4 must NOT break existing `TestRunCC*`, `TestRunGLM*`, `TestEnableTeamMode*` tests in `internal/cli/glm_test.go` and `internal/cli/launcher_test.go`. The generalize refactor preserves observable behavior of `moai cc` / `moai glm` (REQ-HYBRID-006).
+
+### M5: Documentation substitution + CHANGELOG + MX tags (REFACTOR + Trackable) — Priority P1
+
+Owner role: `manager-docs` for documentation substitution, `expert-backend` for MX tag insertion in Go code.
+
+Scope:
+
+#### M5a: `.claude/skills/moai/team/glm.md` substitution
+
+Targets:
+- Line 41: `User runs: moai cg` → `User runs: moai hybrid glm`
+- Line 50: `Saves team_mode: cg to llm.yaml` → `Saves team_mode: hybrid + provider: glm to llm.yaml`
+- Line 103: `| cg | CG Mode | Claude (this pane) | GLM (new tmux panes) |` → `| hybrid (provider=glm) | Hybrid Mode | Claude (this pane) | GLM (new tmux panes) |`
+- Line 127: `moai cg` → `moai hybrid glm`
+- Line 143: `moai cg injects these into the tmux session:` → `moai hybrid <provider> injects these into the tmux session (example: provider=glm):`
+
+Mirror to `internal/template/templates/.claude/skills/moai/team/glm.md`.
+
+#### M5b: `.claude/skills/moai/team/run.md` substitution
+
+Targets (lines 73, 88, 92, 103, 104): replace each `moai cg` mention with `moai hybrid <provider>` (example provider=glm). Update line 73 table row similarly.
+
+Mirror to `internal/template/templates/`.
+
+#### M5c: `.claude/skills/moai/workflows/run.md:904` substitution
+
+Target: `active_mode: cc | glm | cg` → `active_mode: cc | glm | hybrid`.
+
+Mirror to `internal/template/templates/`.
+
+#### M5d: `.claude/rules/moai/development/model-policy.md:44` substitution
+
+Target: `Activation: moai cg (requires tmux)` → `Activation: moai hybrid <provider> (requires tmux). Example: moai hybrid glm`.
+
+Mirror to `internal/template/templates/`.
+
+#### M5e: CLAUDE.md §15 substitution
+
+Target: `## 15. Agent Teams (Experimental)` 섹션 내 `### CG Mode (Claude + GLM Cost Optimization)` 헤딩 (line ~496-510).
+- 헤딩 변경: `### Hybrid Mode (Multi-LLM Cost Optimization)`.
+- 본문 다중 provider 일반화 — diagram에 "Teammates (GLM/Kimi/DeepSeek/Qwen, new tmux panes)" 표기.
+- Activation: `moai hybrid <provider>` 예시.
+
+Note: CLAUDE.md is not embedded in template; project root only.
+
+#### M5f: CLAUDE.local.md §16 substitution
+
+Target line 129: `Modified by 'moai glm', 'moai cc', 'moai cg' commands at runtime` → `Modified by 'moai glm', 'moai cc', 'moai hybrid <provider>' commands at runtime`.
+
+CLAUDE.local.md is local-only (not in template per CLAUDE.local.md §2 Local-Only Files).
+
+#### M5g: CHANGELOG entry
+
+Append to `## [Unreleased]`:
+
+```markdown
+### Breaking Changes
+
+- **BC-V3R3-HYBRID-001 (SPEC-V3R3-HYBRID-001)**: Removed `moai cg` (Claude + GLM hybrid)
+  and replaced it with `moai hybrid <provider>`, which now supports four team-LLM
+  providers as first-class citizens: GLM (Z.AI), Kimi K2 (Moonshot AI), DeepSeek V4
+  (DeepSeek), and Qwen3-Coder (Alibaba DashScope).
+
+  - `moai cg` invocations after upgrade return `MOAI_CG_REMOVED` with an actionable
+    migration suggestion (`use 'moai hybrid glm' instead`).
+  - Existing projects with `team_mode: "cg"` in `.moai/config/sections/llm.yaml` are
+    auto-migrated to `team_mode: "hybrid"` + `provider: "glm"` on the next `moai update`
+    run.
+  - `moai glm` (single-LLM all-GLM mode) and `moai cc` (Claude-only mode) remain
+    unchanged.
+  - See SPEC-V3R3-HYBRID-001 §10 BC Migration for full migration table.
+```
+
+#### M5h: MX tag insertion
+
+Per `.claude/rules/moai/workflow/mx-tag-protocol.md` and §6 below.
+
+#### M5i: Final verification
+
+1. `cd /Users/goos/MoAI/moai-adk-go && make build` — regenerate embedded.go.
+2. `go test ./...` — full suite, 0 cascading failures (CLAUDE.local.md §6 HARD).
+3. Verify `grep -rn "moai cg" .claude/ CLAUDE.md CLAUDE.local.md` returns only M5e/M5f-substituted content (no residual).
+4. Update `progress.md` with `run_complete_at` + `run_status: implementation-complete`.
+
+[HARD] No new SPEC documents created in `.moai/specs/` or `.moai/reports/` during M5.
+
+---
+
+## 3. File:line Anchors (concrete edit targets)
+
+### 3.1 To-be-modified (existing files)
+
+| File | Anchor | Edit type | Milestone |
+|---|---|---|---|
+| `internal/cli/cg.go` | line 7-44 (cgCmd) + line 51-57 (runCG) | Replace with BC stub returning `MOAI_CG_REMOVED` | M3 |
+| `internal/cli/glm.go` | line 148-149 | Substitute `moai cg` → `moai hybrid glm` in stderr message | M4 |
+| `internal/cli/glm.go` | line 218-348 (enableTeamMode) | Generalize via `enableHybridTeamMode(cmd, provider, isHybrid)` delegate | M4 |
+| `internal/cli/glm.go` | line 266 | `persistTeamMode(root, "cg")` → `persistTeamMode(root, "hybrid")` + `persistProvider(root, "glm")` | M4 |
+| `internal/cli/glm.go` | line 356-385 (injectTmuxSessionEnv) | Move to `internal/llm/inject.go InjectTmuxSessionEnv(provider, apiKey)` | M4 |
+| `internal/cli/glm.go` | line 520-581 (injectGLMEnvForTeam) | Move to `internal/llm/inject.go InjectProviderEnvForTeam(...)` with namespaced backup | M4 |
+| `internal/cli/glm.go` | line 536-538 | Single backup slot → provider-namespaced (`MOAI_BACKUP_AUTH_TOKEN_<UPPER>`) | M4 |
+| `internal/cli/glm.go` | line 646-655 (GLMConfigFromYAML) | Generalize to `ProviderConfig` in `internal/llm/provider.go` | M2 |
+| `internal/cli/launcher.go` | line 40 | Comment: `claude_glm` → `claude_hybrid` rename | M4 |
+| `internal/cli/launcher.go` | line 57 | `case "claude_glm":` → `case "claude_hybrid":` | M4 |
+| `internal/cli/launcher.go` | line 185 | `persistTeamMode(root, "cg")` → `persistTeamMode(root, "hybrid")` | M4 |
+| `internal/cli/launcher.go` | line 267 | `resetTeamModeForCC` ← rename or generalize comment to "switching to CC clears hybrid team mode" | M4 |
+| `internal/cli/update.go` | `cleanMoaiManagedPaths` end (line ~1441) | Add `migrateCGTeamMode(root)` post-cleanup hook | M4 |
+| `internal/config/types.go` | line 52-70 (LLMConfig) | Add `Provider string` + `Providers map[string]ProviderYAML` fields | M2 |
+| `internal/config/types.go` | (after line 100) | Add `type ProviderYAML struct` | M2 |
+| `internal/config/defaults.go` | NewDefaultLLMConfig | Add `NewDefaultProvidersConfig()` returning 4-provider map | M2 |
+| `.moai/config/sections/llm.yaml` | top-level | Add `provider: ""` + `providers:` section | M2 |
+| `internal/template/templates/.moai/config/sections/llm.yaml` | top-level | Mirror M2 changes | M2 |
+| `.claude/skills/moai/team/glm.md` | lines 41, 50, 103, 127, 143 | Substitute `moai cg` → `moai hybrid glm` (5 mentions) | M5a |
+| `.claude/skills/moai/team/run.md` | lines 73, 88, 92, 103, 104 | Substitute `moai cg` → `moai hybrid <provider>` (5 mentions) | M5b |
+| `.claude/skills/moai/workflows/run.md` | line 904 | `active_mode: cc \| glm \| cg` → `active_mode: cc \| glm \| hybrid` | M5c |
+| `.claude/rules/moai/development/model-policy.md` | line 44 | `Activation: moai cg` → `Activation: moai hybrid <provider>` | M5d |
+| `CLAUDE.md` | §15 ~line 488-510 (CG Mode section) | Section title + content multi-provider generalization | M5e |
+| `CLAUDE.local.md` | §16 line 129 | `'moai cg'` → `'moai hybrid <provider>'` | M5f |
+| `CHANGELOG.md` | `## [Unreleased]` section | Add `BC-V3R3-HYBRID-001` entry | M5g |
+
+### 3.2 To-be-created (new files)
+
+| File | Reason | Milestone |
+|---|---|---|
+| `internal/llm/provider.go` | Provider abstraction interface | M2 |
+| `internal/llm/inject.go` | Provider-agnostic env-injection helpers | M4 |
+| `internal/llm/providers/glm.go` | GLM provider metadata | M2 |
+| `internal/llm/providers/kimi.go` | Kimi K2 provider metadata | M2 |
+| `internal/llm/providers/deepseek.go` | DeepSeek V4 provider metadata | M2 |
+| `internal/llm/providers/qwen.go` | Qwen3-Coder provider metadata | M2 |
+| `internal/llm/providers/registry.go` | Provider registry + List() + Lookup() | M2 |
+| `internal/llm/registry_test.go` | Provider registry consistency unit tests | M2 |
+| `internal/cli/hybrid.go` | `moai hybrid` command + subcommands (setup/status/tools) | M3 |
+| `internal/template/provider_allowlist_audit_test.go` | REQ-HYBRID-002, 017 audit | M1 |
+| `internal/cli/cg_removal_test.go` | REQ-HYBRID-003, 010, 014 BC verification | M1 |
+| `internal/cli/hybrid_test.go` | REQ-HYBRID-001..009 + 012, 013, 015, 018 | M1 |
+| `internal/cli/migration_test.go` | REQ-HYBRID-011 cg→hybrid migration | M1 |
+
+### 3.3 NOT to be touched (preserved by reference)
+
+- `internal/cli/glm.go:21-89` (glmCmd, glmSetupCmd, glmStatusCmd) — `moai glm` 단일 모드 보존 per REQ-HYBRID-006.
+- `internal/cli/glm.go:107-152` `runGLM` — single-LLM 모드 본문 보존 (line 148-149 message만 substitution).
+- `internal/cli/cc.go` (확인 필요; 존재 시 보존) — `moai cc` Claude-only 모드 보존.
+- `~/.claude/` 인증 흐름 — Claude OAuth 토큰 영향 없음.
+- 16-language neutrality contract (CLAUDE.local.md §15) — 4-provider neutrality 차용 적용은 본 SPEC.
+
+### 3.4 Reference citations (file:line)
+
+본 plan에서 인용된 load-bearing anchors (research.md §10 + 추가):
+
+1. `internal/cli/cg.go:1-58` — 현행 cg 명령 (M3 replace).
+2. `internal/cli/glm.go:21-89` — glmCmd 보존 영역.
+3. `internal/cli/glm.go:107-152` — runGLM 본문 (line 148-149 substitution).
+4. `internal/cli/glm.go:218-348` — enableTeamMode generalize 대상 (M4).
+5. `internal/cli/glm.go:356-385` — injectTmuxSessionEnv (M4 move).
+6. `internal/cli/glm.go:520-581` — injectGLMEnvForTeam (M4 move).
+7. `internal/cli/glm.go:646-724` — GLMConfigFromYAML + loadGLMConfig (M2 generalize).
+8. `internal/cli/launcher.go:21-26` — unifiedLaunch indirection.
+9. `internal/cli/launcher.go:38-39` — @MX:ANCHOR fan_in=3.
+10. `internal/cli/launcher.go:57` — `case "claude_glm":` (M4 rename).
+11. `internal/cli/launcher.go:185` — persistTeamMode("cg") (M4).
+12. `internal/config/types.go:52-100` — LLMConfig + GLMModels (M2 extend).
+13. `.moai/config/sections/llm.yaml` — current schema baseline.
+14. `internal/template/templates/.moai/config/sections/llm.yaml` — embedded template baseline.
+15. `.claude/skills/moai/team/glm.md:41,50,103,127,143` — M5a 5 substitution sites.
+16. `.claude/skills/moai/team/run.md:73,88,92,103,104` — M5b 5 substitution sites.
+17. `.claude/skills/moai/workflows/run.md:904` — M5c.
+18. `.claude/rules/moai/development/model-policy.md:44` — M5d.
+19. `CLAUDE.md §15 line 488-510 (CG Mode)` — M5e.
+20. `CLAUDE.local.md §16 line 129` — M5f.
+21. `internal/template/lang_boundary_audit_test.go:1-60` (SPEC-V3R2-WF-005 M1 scaffold) — provider_allowlist_audit_test.go 모델.
+22. SPEC-GLM-MCP-001 PR #769 — REQ-HYBRID-016 dependency.
+23. SPEC-V3R3-UPDATE-CLEANUP-001 PR #764 — atomic write 인프라 (REQ-HYBRID-011).
+
+Total: **23 distinct file:line / SPEC anchors** (>10 minimum).
+
+---
+
+## 4. Technology Stack Constraints
+
+본 SPEC은 **신규 외부 의존성을 추가하지 않는다**:
+
+- 신규 Go modules: 없음. Anthropic-compat HTTP는 `net/http` 표준 라이브러리만 사용.
+- LLM provider별 native SDK (e.g., `github.com/sashabaranov/go-openai`): **금지** (spec.md §1.2 Non-Goals).
+- 신규 directory 구조: `internal/llm/` + `internal/llm/providers/` (단일 신규 패키지 트리).
+- 신규 binary 의존: 없음.
+
+추가 surface (additive):
+- `internal/llm/` 패키지 (~5 신규 파일).
+- `internal/cli/hybrid.go` (1 신규 파일).
+- `~/.moai/.env.{kimi,deepseek,qwen}` 파일 패턴 (기존 `.env.glm`과 동일 dotenv 형식).
+- 4 신규 environment variable name (provider별): `KIMI_API_KEY`, `DEEPSEEK_API_KEY`, `DASHSCOPE_API_KEY` (`GLM_API_KEY`는 기존).
+
+---
+
+## 5. Risk Analysis & Mitigations (file-anchored)
+
+spec.md §8 risks의 file-anchored mitigations + 추가 plan-level risks.
+
+| Risk | Probability | Impact | Mitigation Anchor (file:line) |
+|---|---|---|---|
+| `moai cg` 사용자 워크플로 중단 | M | M | `internal/cli/cg.go` BC stub (M3) — `runCGRemoved` 함수에서 `MOAI_CG_REMOVED` + actionable message. Cobra "unknown command" fallback 차단. CHANGELOG `BC-V3R3-HYBRID-001` 명시. |
+| Kimi/Qwen3 endpoint 미가용 | M | M | M2 `internal/llm/providers/{kimi,qwen}.go` 후보 base_url 등록 + M3 `internal/cli/hybrid.go` `--proxy <url>` flag 처리 (REQ-HYBRID-015). Run-phase에서 사용자 검증 후 base_url update. |
+| Latest model 변경 (GLM-4.8, Kimi K3 출시 등) | M | H | M2 `internal/config/types.go ProvidersConfig` + `.moai/config/sections/llm.yaml providers.<name>.models` user override 경로. SPEC-pinned baseline은 init/update 시 적용. |
+| `team_mode: "cg"` 마이그레이션 실패 | L | M | M4 `internal/cli/update.go migrateCGTeamMode` (atomic write per SPEC-V3R3-UPDATE-CLEANUP-001 인프라) + M3 `internal/cli/cg.go` BC stub로 직접 호출 차단 — 양방향 안전망. M1 `migration_test.go`에서 idempotency 검증. |
+| 단일 백업 슬롯 충돌 (provider 전환 시) | M | M | M4 `internal/llm/inject.go InjectProviderEnvForTeam` provider-namespaced backup keys (`MOAI_BACKUP_AUTH_TOKEN_<UPPER>`). 단일 슬롯 패턴 deprecate. |
+| Template-First mirror 누락 | H | L | M2/M4 종료 시 `make build` HARD rule. CI에서 embedded FS 동기화 검증 (existing pattern). M5e/M5f는 template-out-of-scope (CLAUDE.md/CLAUDE.local.md). |
+| Anthropic-compat endpoint cryptic error | M | M | M3 `internal/cli/hybrid.go` launch 직전 health check 옵션 (REQ-HYBRID-013) — `HEAD <base_url>` 실패 시 underlying HTTP error propagate. |
+| Provider tier 매핑 의미 상이 | L | H | M2 `.moai/config/sections/llm.yaml providers.<name>.models` 사용자 직접 override 권장. init/update 시 provider docs 링크 포함 stderr notice. |
+| BC stub fallback (cobra "unknown command") | L | M | M3 `internal/cli/cg.go` cgCmd registration 보존 (binary stub) — REQ-HYBRID-014 명시. M1 `cg_removal_test.go TestCGCommandIsRegistered` 검증. |
+| docs-site 4-locale 누락 | M | M | sync-phase manager-docs 의무 (CLAUDE.local.md §17). 본 SPEC plan은 docs-site 변경을 sync-phase로 위임 (run-phase는 코드 + .claude/.md 한정). |
+| `moai cc`/`moai glm` 회귀 (M4 generalize 부작용) | M | H | M4 `internal/cli/glm.go` 보존 영역 (line 21-89, line 107-152) 명시. existing tests `glm_test.go`, `launcher_test.go` 통과 확인. M1 RED gate에서 기존 테스트 GREEN 유지 검증. |
+| `provider`+`team_mode` 두 필드의 일관성 | L | M | M4 `persistTeamMode` + `persistProvider` atomic 호출 — 중간 상태 노출 방지. config 검증 `validateLLMConfig` 추가 검토 (`team_mode: "hybrid"` 시 `provider != ""` 강제). |
+| GLM-MCP-001 implementation 미완료 시 `moai hybrid glm tools` UX | L | L | M3 `internal/cli/hybrid.go hybridToolsCmd` stub은 명시적 "deferred to SPEC-GLM-MCP-001" 메시지. 사용자 혼동 방지. |
+| 4 provider model name 변경 시 SPEC 갱신 부담 | L | M | research.md §3 verification table 매년 review. 사용자 override 경로가 stable한 escape hatch. |
+
+---
+
+## 6. mx_plan — @MX Tag Strategy
+
+Per `.claude/rules/moai/workflow/mx-tag-protocol.md` and `.claude/skills/moai/workflows/plan.md` mx_plan MANDATORY rule.
+
+### 6.1 @MX:ANCHOR targets (high fan_in / contract enforcers)
+
+| Target file:line | Tag content | Rationale |
+|---|---|---|
+| `internal/llm/providers/registry.go Registry` | `@MX:ANCHOR fan_in=N — SPEC-V3R3-HYBRID-001 REQ-HYBRID-002,017 enforcer; closed allow-list of 4 providers (glm, kimi, deepseek, qwen). Adding a 5th entry requires atomic-reversal SPEC.` | Registry는 4-provider allow-list의 single source of truth. 모든 hybrid 명령 라우팅이 이 map을 lookup하므로 fan_in 매우 높음. |
+| `internal/cli/hybrid.go hybridCmd` | `@MX:ANCHOR fan_in=N — SPEC-V3R3-HYBRID-001 REQ-HYBRID-001 canonical entry point for multi-LLM hybrid mode. Cobra command def; subcommand routing for setup/status/tools.` | hybridCmd는 사용자가 마주하는 surface; 변경 시 모든 hybrid 워크플로 영향. |
+| `internal/llm/inject.go InjectProviderEnvForTeam` | `@MX:ANCHOR fan_in=N — SPEC-V3R3-HYBRID-001 REQ-HYBRID-007,012 provider-agnostic env-injection contract. Touching this signature affects all 4 providers.` | env-injection은 모든 provider에서 사용; signature 변경 시 4 provider 모두 영향. |
+
+### 6.2 @MX:NOTE targets (intent / context delivery)
+
+| Target file:line | Tag content | Rationale |
+|---|---|---|
+| `internal/cli/cg.go runCGRemoved` | `@MX:NOTE — BC stub for SPEC-V3R3-HYBRID-001. Returns MOAI_CG_REMOVED with actionable migration path. Do not silently delete cgCmd registration; cobra fallback is insufficient.` | BC stub의 의도 명시 — 미래 PR이 cg.go를 완전 삭제하려는 시도 차단. |
+| `internal/llm/provider.go Provider interface` | `@MX:NOTE — Provider abstraction per SPEC-V3R3-HYBRID-001. Anthropic-compat HTTP only (no native SDKs). Each provider supplies BuildEnvVars implementing its own compat flags (e.g., DISABLE_PROMPT_CACHING=1 for Z.AI).` | interface design 의도 명시 — 미래 PR이 native SDK 의존성 추가 시도 차단. |
+| `internal/cli/update.go migrateCGTeamMode` | `@MX:NOTE — One-time migration for SPEC-V3R3-HYBRID-001. Idempotent; emits stderr notice only on actual rewrite. Uses SPEC-V3R3-UPDATE-CLEANUP-001 atomic write infrastructure.` | 마이그레이션 의도 + idempotency 보장 명시. |
+
+### 6.3 @MX:WARN targets (danger zones)
+
+| Target file:line | Tag content | Rationale |
+|---|---|---|
+| `internal/llm/inject.go InjectProviderEnvForTeam (backup namespacing)` | `@MX:WARN @MX:REASON — Provider transition (e.g., GLM→Kimi) MUST use namespaced backup keys (MOAI_BACKUP_AUTH_TOKEN_<UPPER>). Single MOAI_BACKUP_AUTH_TOKEN slot causes data loss across multi-provider transitions. Reverting to single slot fails TestHybridBackwardCompatWithCG.` | 단일 슬롯 회귀 방지. |
+| `internal/cli/launcher.go:57 case "claude_hybrid"` | `@MX:WARN @MX:REASON — Renaming this case label or the underlying mode string requires updating both unifiedLaunch and persistTeamMode call sites synchronously. Single-site rename leaves routing inconsistent — TestHybridProviderRouting fails.` | 두 곳 동시 변경 필수성 명시. |
+| `internal/llm/providers/{kimi,qwen}.go base_url` | `@MX:WARN @MX:REASON — Anthropic-compat base URL pending provider-side verification (research.md §3.2, §3.4). Users should prefer --proxy <url> until provider docs confirm. Hardcoding without verification risks runtime auth failure.` | 미검증 endpoint 사용자 인지. |
+
+### 6.4 @MX:TODO targets (intentionally NONE for this SPEC's run phase)
+
+본 SPEC은 plan-phase 산출물 + multi-milestone 구현이지만 모든 work는 M1-M5 GREEN 내에서 수렴한다. 임시 `@MX:TODO`는 GREEN 단계에서 모두 해결 (spec-workflow.md GREEN-phase resolution rule).
+
+예외: M3 `internal/cli/hybrid.go hybridToolsCmd`의 stub은 `@MX:TODO` 표기 가능 (`// @MX:TODO: implement Z.AI MCP attach via SPEC-GLM-MCP-001 follow-up`) — 이는 의도적 deferral이며 SPEC-GLM-MCP-001 implementation PR 머지 시 해결.
+
+### 6.5 MX tag count summary
+
+- @MX:ANCHOR: 3 targets
+- @MX:NOTE: 3 targets
+- @MX:WARN: 3 targets
+- @MX:TODO: 1 target (intentional deferral, linked to SPEC-GLM-MCP-001)
+- **Total**: 10 MX tag insertions across ~7 distinct files
+
+---
+
+## 7. Solo Mode Discipline
+
+[HARD] All run-phase work for SPEC-V3R3-HYBRID-001 executes in:
+
+```
+/Users/goos/MoAI/moai-adk-go
+```
+
+Branch: `feature/SPEC-V3R3-HYBRID-001` (already checked out per session context).
+
+[HARD] No worktree is used (per user directive: solo mode, no worktree). All Read/Write/Edit tool invocations use absolute paths under the main project root.
+
+[HARD] `make build` and `go test ./...` execute from the repo root: `cd /Users/goos/MoAI/moai-adk-go && make build && go test ./...`.
+
+[HARD] CHANGELOG entry MUST cite `BC-V3R3-HYBRID-001` ID exactly (per CLAUDE.local.md §18 BC tracking convention) and reference SPEC-V3R3-HYBRID-001 §10 for migration table.
+
+---
+
+## 8. Plan-Audit-Ready Checklist
+
+These criteria are checked by `plan-auditor` at `/moai run` Phase 0.5 (Plan Audit Gate per `spec-workflow.md` Phase 0.5 description). The plan is **audit-ready** only if all are PASS.
+
+- [x] **C1: Frontmatter v0.2.0 schema** — `spec.md` frontmatter has all 9 required fields (`id`, `version`, `status`, `created_at`, `updated_at`, `author`, `priority`, `labels`, `issue_number`). Plus optional fields (`phase`, `module`, `dependencies`, `related_theme`, `breaking`, `bc_id`, `lifecycle`, `tags`).
+- [x] **C2: HISTORY entry for v0.1.0** — `spec.md:30-34` HISTORY table has v0.1.0 row with description.
+- [x] **C3: 18 EARS REQs across 5 categories** — `spec.md` §5 (Ubiquitous 6, Event-Driven 5, State-Driven 3, Optional 2, Complex 2).
+- [x] **C4: 18 ACs all map to REQs (100% coverage)** — `spec.md` §6, plan §1.4 traceability matrix confirms 18/18 REQ → AC mapping.
+- [x] **C5: BC scope clarity** — `spec.md` §10 BC Migration section + `breaking: true` + `bc_id: [BC-V3R3-HYBRID-001]` frontmatter.
+- [x] **C6: File:line anchors ≥10** — research.md §10 (33 anchors), plan.md §3.4 (23 anchors).
+- [x] **C7: Exclusions section present** — `spec.md` §1.2 Non-Goals + `spec.md` §2.2 Out of Scope (10 entries each).
+- [x] **C8: TDD methodology declared** — plan §1.2 + `.moai/config/sections/quality.yaml development_mode: tdd`.
+- [x] **C9: mx_plan section** — plan §6 (10 MX tag insertions across 4 categories).
+- [x] **C10: Risk table with mitigations** — `spec.md` §8 (10 risks) + plan §5 (14 risks, file-anchored mitigations).
+- [x] **C11: Solo mode path discipline** — plan §7 (4 HARD rules, no worktree per user directive).
+- [x] **C12: No implementation code in plan documents** — verified self-check: spec.md, plan.md, research.md, acceptance.md, tasks.md contain only natural-language descriptions, regex patterns, file paths, type signatures, YAML/Markdown templates. No Go function bodies (only signatures + docstrings as illustration).
+- [x] **C13: Acceptance.md G/W/T format with edge cases** — verified in acceptance.md §1-18.
+- [x] **C14: tasks.md owner roles aligned with TDD methodology** — verified in tasks.md (M1-M5 with expert-backend / manager-tdd / manager-docs assignments).
+- [x] **C15: Cross-SPEC consistency** — SPEC-GLM-MCP-001 (PR #769 OPEN, plan-only) declared in `dependencies:` (forward-looking surface); SPEC-V3R3-UPDATE-CLEANUP-001 (PR #764 merged) infrastructure reused (research.md §7); SPEC-V3R2-WF-005 (PR #768 merged) neutrality pattern applied.
+- [x] **C16: BC migration completeness** — spec.md §10 covers (a) BC ID, (b) migration table v2.x→v3R3, (c) CHANGELOG wording, (d) docs touch points, (e) removal timeline.
+- [x] **C17: 4-LLM allow-list documented** — spec.md §1, §2.2, §5 REQ-HYBRID-002, plan §1.3 deliverable list, plan §6.1 ANCHOR. 5번째 provider 차단 확인 (REQ-HYBRID-017 + AC-HYBRID-15).
+- [x] **C18: Endpoint verification status documented** — research.md §3 + §3.5 summary table. Verified (GLM, DeepSeek) vs Pending (Kimi, Qwen3) 명시.
+
+All 18 criteria PASS → plan is **audit-ready**.
+
+---
+
+## 9. Implementation Order Summary
+
+Run-phase agent executes in this order (P0 first, dependencies resolved):
+
+1. **M1 (P0)**: Create 4 test files (`provider_allowlist_audit_test.go`, `cg_removal_test.go`, `hybrid_test.go`, `migration_test.go`). Confirm RED for all NEW tests; existing tests (`glm_test.go`, `launcher_test.go`) GREEN unaffected.
+2. **M2 (P0)**: Create `internal/llm/{provider.go, providers/{glm,kimi,deepseek,qwen,registry}.go, registry_test.go}` + extend `internal/config/types.go` LLMConfig + `.moai/config/sections/llm.yaml` schema + embedded template mirror + `make build`. Confirm `TestProviderAllowlist` GREEN.
+3. **M3 (P0)**: Create `internal/cli/hybrid.go` + replace `internal/cli/cg.go` with BC stub. Confirm `TestCGCommand*` + basic `TestHybrid*` GREEN.
+4. **M4 (P0)**: Create `internal/llm/inject.go` + generalize `internal/cli/glm.go` callsites + update `internal/cli/launcher.go:57` + add `internal/cli/update.go migrateCGTeamMode` + final `make build`. Confirm full `TestHybrid*` + `TestMigrate*` GREEN. Confirm `go test ./...` 0 cascading failures.
+5. **M5 (P1)**: Substitute 6 documentation files (M5a-d) + CLAUDE.md §15 (M5e) + CLAUDE.local.md §16 (M5f) + CHANGELOG `BC-V3R3-HYBRID-001` (M5g) + insert 10 MX tags (M5h) + final `make build` + full `go test ./...` (M5i). Update `progress.md` with `run_complete_at` and `run_status: implementation-complete`.
+
+Total milestones: 5. Total file edits (existing): ~25. Total file creations (new): ~13. Total CHANGELOG entries: 1.
+
+---
+
+End of plan.md.

--- a/.moai/specs/SPEC-V3R3-HYBRID-001/progress.md
+++ b/.moai/specs/SPEC-V3R3-HYBRID-001/progress.md
@@ -1,0 +1,116 @@
+# SPEC-V3R3-HYBRID-001 Progress
+
+- plan_complete_at: 2026-05-03T20:20:23Z
+- plan_status: audit-ready
+
+## Artifacts
+
+- spec.md — v0.1.0 (frontmatter v0.2.0 정합화 완료, 9 required fields; 18 REQs / 18 ACs; BC-V3R3-HYBRID-001 declared)
+- research.md — Phase 0.5 deep research (33 file:line citations; codebase grounded scan of `internal/cli/{cg,glm,launcher,update}.go` + `internal/config/types.go` + 6 documentation surfaces; 4-provider Anthropic-compat endpoint verification table)
+- plan.md — Phase 1B implementation plan (5 milestones M1-M5; 23 file:line anchors; mx_plan with 10 tags / 7 files; REQ↔AC traceability matrix 18/18)
+- acceptance.md — Given/When/Then for 18 ACs (happy path + edge cases per AC; integration test scaffold names declared for `TestProviderAllowlist`, `TestCGCommand*`, `TestHybrid*`, `TestMigrateCGTeamMode*`)
+- tasks.md — M1-M5 milestone breakdown (36 tasks T-HYBRID-01..36; owner roles aligned with TDD methodology — 19 expert-backend / 4 manager-tdd / 13 manager-docs)
+- spec-compact.md — Auto-extracted REQ + AC + Files-to-modify + Exclusions reference
+
+## Branch
+
+- Branch: feature/SPEC-V3R3-HYBRID-001
+- Mode: solo, no worktree (per user directive)
+- Working directory: /Users/goos/MoAI/moai-adk-go
+- Base: origin/main HEAD aa55780ce (Wave 6 plan PRs all merged: WF-004 #765, WF-003 #767, session-handoff #763)
+
+## Key Plan Decisions
+
+- BC scope: clean break (no deprecation alias period). `moai cg` 호출 시 즉시 `MOAI_CG_REMOVED` BC 에러 + actionable migration suggestion. `cgCmd`는 binary stub로 보존 (REQ-HYBRID-014) — cobra "unknown command" fallback 차단.
+- 4-LLM allow-list: GLM (Z.AI), Kimi K2 (Moonshot AI), DeepSeek V4, Qwen3-Coder (Alibaba DashScope). 닫힌 집합 (REQ-HYBRID-002, REQ-HYBRID-017). 5번째 provider 추가는 atomic-reversal SPEC 필요.
+- Endpoint verification status (research.md §3): GLM `https://api.z.ai/api/anthropic` (verified), DeepSeek `https://api.deepseek.com/anthropic` (verified), Kimi `https://api.moonshot.ai/anthropic` (pending — `--proxy` fallback), Qwen3 `https://dashscope.aliyuncs.com/compatible-mode/anthropic` (pending — `--proxy` fallback).
+- TDD methodology: per `.moai/config/sections/quality.yaml development_mode: tdd`. M1 RED gate (4 test files) → M2/M3/M4 GREEN gates (provider abstraction → hybrid command + cg BC stub → injection refactor + launcher routing + migration) → M5 REFACTOR + Trackable (documentation substitution + CHANGELOG + 10 MX tags).
+- Auto-migration: `moai update` cleanup phase가 `team_mode: "cg"` config를 자동으로 `team_mode: "hybrid"` + `provider: "glm"`으로 rewrite (REQ-HYBRID-011). Atomic write infrastructure는 SPEC-V3R3-UPDATE-CLEANUP-001 (PR #764 merged) 차용.
+- Provider preservation: `moai glm` (단일 LLM all-GLM) + `moai cc` (Claude-only) 동작 무변경 (REQ-HYBRID-006). `moai hybrid`는 multi-LLM 슈퍼셋이지 대체 아님.
+- Sentinel strings (NEW): `UNKNOWN_PROVIDER` (REQ-HYBRID-002), `MOAI_CG_REMOVED` (REQ-HYBRID-003, 010, 014), `HYBRID_REQUIRES_TMUX` (REQ-HYBRID-008), `HYBRID_MISSING_API_KEY` (REQ-HYBRID-009), `PROVIDER_ALLOWLIST_VIOLATION` (REQ-HYBRID-017), `HYBRID_AUTH_FAILED` (REQ-HYBRID-018).
+- Provider-namespaced backup keys: `MOAI_BACKUP_AUTH_TOKEN_<UPPER>` (e.g., `MOAI_BACKUP_AUTH_TOKEN_GLM`). 단일 슬롯 패턴 deprecate — provider 전환 시 데이터 손실 방지 (research.md §5 risk → MX:WARN tag).
+
+## Frontmatter Migration Verification (spec.md v0.1.0)
+
+- Required fields present (9/9): `id`, `version`, `status`, `created_at`, `updated_at`, `author`, `priority`, `labels`, `issue_number` ✅
+- Rejected aliases absent (0): `created`, `updated`, `spec_id`, `title:` H1-alias ✅
+- `version` quoted string: `"0.1.0"` ✅
+- `priority` enum: `P1` (bare uppercase, no descriptor) ✅
+- `labels` YAML array: `[hybrid, multi-llm, glm, kimi, deepseek, qwen, breaking-change, v3r3]` ✅
+- `created_at` / `updated_at` ISO date: `2026-05-04` / `2026-05-04` ✅
+- `issue_number: null` ✅
+- Optional BC fields: `breaking: true` + `bc_id: [BC-V3R3-HYBRID-001]` + `lifecycle: spec-anchored` ✅
+
+## Codebase Scan Summary (research.md grounded)
+
+### `moai cg` command surface (impacted files)
+
+1. `internal/cli/cg.go` (lines 1-58) — current `cgCmd` definition, M3 REPLACE target.
+2. `internal/cli/launcher.go:57` — `case "claude_glm":` mode dispatch, M4 generalize target.
+3. `internal/cli/launcher.go:185` — `persistTeamMode(root, "cg")`, M4 update target.
+4. `internal/cli/glm.go:148-149` — stderr message "moai cg" mention, M4 substitution.
+5. `internal/cli/glm.go:266` — `persistTeamMode(root, "cg")`, M4 update target.
+
+### `moai cg` documentation surface (substitution targets)
+
+1. `.claude/skills/moai/team/glm.md` — 5 mentions (lines 41, 50, 103, 127, 143)
+2. `.claude/skills/moai/team/run.md` — 5 mentions (lines 73, 88, 92, 103, 104)
+3. `.claude/skills/moai/workflows/run.md:904` — 1 mention (`active_mode: cc | glm | cg`)
+4. `.claude/rules/moai/development/model-policy.md:44` — 1 mention (Activation line)
+5. `CLAUDE.md §15` (~line 488-510) — `### CG Mode` heading + body
+6. `CLAUDE.local.md §16 line 129` — runtime-managed config list
+
+### Provider abstraction layer (NEW additions)
+
+- `internal/llm/provider.go` — Provider interface (~6 methods)
+- `internal/llm/providers/{glm,kimi,deepseek,qwen}.go` — 4 provider metadata files
+- `internal/llm/providers/registry.go` — closed allow-list Registry (MX:ANCHOR)
+- `internal/llm/inject.go` — provider-agnostic env-injection helpers (refactor of `glm.go:356-581`)
+
+### Schema extensions
+
+- `internal/config/types.go:52-100` `LLMConfig` — add `Provider string` + `Providers map[string]ProviderYAML` fields
+- `.moai/config/sections/llm.yaml` — add top-level `provider: ""` + `providers:` section (4 entries)
+
+## Next Phase
+
+- Phase 0.5 Plan Audit Gate (plan-auditor) at `/moai run SPEC-V3R3-HYBRID-001` entry — see `.claude/rules/moai/workflow/spec-workflow.md:172-204`.
+- Implementation Methodology: TDD (per `.moai/config/sections/quality.yaml`).
+- Run-phase command: `/moai run SPEC-V3R3-HYBRID-001` (executed from `/Users/goos/MoAI/moai-adk-go` on branch `feature/SPEC-V3R3-HYBRID-001`).
+- Post-implementation: `/moai sync SPEC-V3R3-HYBRID-001` for documentation sync (docs-site 4-locale per CLAUDE.local.md §17) + PR creation.
+
+## Plan-Audit-Ready Checklist Summary
+
+All 18 criteria PASS per plan.md §8:
+
+- C1: Frontmatter v0.2.0 (9 required fields) ✅
+- C2: HISTORY v0.1.0 entry ✅
+- C3: 18 EARS REQs across 5 categories (Ubiquitous 6, Event-Driven 5, State-Driven 3, Optional 2, Complex 2) ✅
+- C4: 18 ACs with 100% REQ mapping (18/18 REQ → AC traceability matrix in plan.md §1.4) ✅
+- C5: BC scope clarity (clean break, `breaking: true`, `bc_id: [BC-V3R3-HYBRID-001]`) ✅
+- C6: File:line anchors ≥10 (research.md: 33, plan.md: 23) ✅
+- C7: Exclusions section present (spec.md §1.2 Non-Goals + §2.2 Out of Scope; spec-compact.md §Exclusions with 13 entries) ✅
+- C8: TDD methodology declared ✅
+- C9: mx_plan section (10 tags / 7 files; 3 ANCHOR + 3 NOTE + 3 WARN + 1 TODO) ✅
+- C10: Risk table with file-anchored mitigations (spec.md §8: 10 risks; plan.md §5: 14 risks) ✅
+- C11: Solo mode path discipline (4 HARD rules, no worktree per user directive) ✅
+- C12: No implementation code in plan documents ✅
+- C13: Acceptance.md G/W/T format with edge cases (18 ACs covered) ✅
+- C14: tasks.md owner roles aligned with TDD (19 expert-backend / 4 manager-tdd / 13 manager-docs) ✅
+- C15: Cross-SPEC consistency (SPEC-GLM-MCP-001 PR #769 OPEN dependency declared; SPEC-V3R3-UPDATE-CLEANUP-001 PR #764 merged infrastructure reused; SPEC-V3R2-WF-005 PR #768 merged neutrality pattern applied) ✅
+- C16: BC migration completeness (spec.md §10: BC ID, migration table, CHANGELOG wording, docs touch points, removal timeline) ✅
+- C17: 4-LLM allow-list documented (REQ-HYBRID-002 + REQ-HYBRID-017; AC-HYBRID-15 + AC-HYBRID-18 5번째 provider 차단 검증) ✅
+- C18: Endpoint verification status documented (research.md §3 + §3.5 verification table; GLM/DeepSeek verified, Kimi/Qwen3 pending — `--proxy` fallback per REQ-HYBRID-015) ✅
+
+## Open Items for plan-auditor Review
+
+- Confirm `internal/llm/` 패키지 트리가 기존 codebase에 존재하지 않음 (verified absent at baseline; M2 신규 패키지). Final check 권장.
+- Validate Kimi/Qwen3 Anthropic-compat endpoint candidate URLs (research.md §3.2, §3.4 pending) — provider 공식 docs 재확인 시점에 base_url 갱신 가능. `--proxy` fallback (REQ-HYBRID-015)이 stable escape hatch.
+- Confirm `internal/cli/cg.go` BC stub은 cobra root에서 등록 보존되어야 함 (REQ-HYBRID-014). 단순 파일 삭제 / `cgCmd` un-registration 시 cobra "unknown command" fallback으로 actionable 메시지 손실. M3 T-HYBRID-19 sequence 검증.
+- Verify `MOAI_BACKUP_AUTH_TOKEN_<UPPER>` namespaced backup pattern은 v2.x 단일 슬롯 방식과 backward-incompatible — 기존 `MOAI_BACKUP_AUTH_TOKEN` 사용자 데이터 마이그레이션 / cleanup path 명시 필요 시 plan §5 risk row 보강.
+- Validate `migrateCGTeamMode` idempotency contract — 두 번째 실행이 stderr notice 미발행 (silent no-op) 여부 — M1 T-HYBRID-05 `TestMigrateCGTeamModeIdempotent` 케이스 검증.
+- Confirm SPEC-GLM-MCP-001 (PR #769 OPEN) implementation 완료 시점이 `moai hybrid glm tools` UX 활성화 trigger — 본 SPEC run-phase에서 stub만 제공, 실제 attach 로직은 SPEC-GLM-MCP-001 후속 PR에서 활성화.
+
+---
+
+End of progress.md.

--- a/.moai/specs/SPEC-V3R3-HYBRID-001/research.md
+++ b/.moai/specs/SPEC-V3R3-HYBRID-001/research.md
@@ -1,0 +1,556 @@
+# SPEC-V3R3-HYBRID-001 Research (Phase 0.5)
+
+> Deep codebase + external endpoint research for `moai hybrid` multi-LLM mode (cg deprecation + GLM/Kimi/DeepSeek/Qwen3-Coder team support).
+> Companion to `spec.md` v0.1.0 and `plan.md` v0.1.0.
+> Solo mode, no worktree. Working directory: `/Users/goos/MoAI/moai-adk-go`. Branch: `feature/SPEC-V3R3-HYBRID-001`.
+
+## HISTORY
+
+| Version | Date       | Author              | Description                                                                              |
+|---------|------------|---------------------|------------------------------------------------------------------------------------------|
+| 0.1.0   | 2026-05-04 | MoAI Plan Workflow  | Phase 0.5 deep research: cg.go + glm.go 코드 매핑, 4 LLM provider endpoint 검증, GLM-MCP-001 dependency surface, env-injection pattern. |
+
+---
+
+## 1. Research Objectives
+
+본 research.md는 plan-auditor PASS criterion #5 ("research.md grounds decisions in actual codebase scan AND verifies 4 LLM endpoints via WebFetch")를 충족하기 위해 다음을 수행한다:
+
+1. **현행 `moai cg` implementation 매핑** — `cg.go`, `glm.go`, `launcher.go`의 정확한 LOC + 함수 의존성 그래프 작성.
+2. **4 LLM API endpoint 검증** — GLM/Kimi/DeepSeek/Qwen3-Coder 공식 docs WebFetch 결과를 기록하고 unverified 항목은 "사용자 검증 대기" 명시.
+3. **Anthropic-compat vs OpenAI-compat 차이** — 4 provider별 Anthropic-compat 가용성 확인 (provider-side 정식 endpoint 또는 사용자 운영 proxy 필요 여부).
+4. **기존 GLM env injection 패턴 분석** — `injectGLMEnvForTeam` (`glm.go:520`), `injectTmuxSessionEnv` (`glm.go:356`)을 provider-agnostic으로 일반화하는 데 필요한 변경 surface.
+5. **SPEC-GLM-MCP-001 dependency surface** — 본 SPEC의 REQ-HYBRID-016 `tools enable|disable` subcommand가 GLM-MCP-001 implementation에 어떻게 의존하는지 명시.
+
+---
+
+## 2. `moai cg` Codebase Surface Map
+
+### 2.1 `internal/cli/cg.go` (57 LOC, 정확)
+
+```
+internal/cli/cg.go:1-58
+  - Lines 1-5: package cli + imports (`github.com/spf13/cobra`).
+  - Lines 7-44: var cgCmd = &cobra.Command{ Use: "cg [-p profile]", ... } — single command def.
+  - Lines 46-48: init() registers cgCmd to rootCmd.
+  - Lines 51-57: func runCG(cmd, args) — calls parseProfileFlag then unifiedLaunch(profileName, "claude_glm", filteredArgs).
+```
+
+**관찰**: cg.go는 매우 얇은 래퍼다. 실제 cg 로직은 (a) `unifiedLaunch` `internal/cli/launcher.go:25` `case "claude_glm"`, (b) `enableTeamMode(cmd, isHybrid: true)` `internal/cli/glm.go:218` 두 군데에 분산되어 있다.
+
+### 2.2 `internal/cli/launcher.go` (713 LOC) — `claude_glm` 분기
+
+```
+internal/cli/launcher.go:21-280 (relevant slice)
+  - Line 21: var unifiedLaunchFunc = unifiedLaunchDefault — testability indirection.
+  - Line 24-26: func unifiedLaunch(profileName, modeOverride, extraArgs) — public entry.
+  - Line 38-39: @MX:ANCHOR fan_in=3 (called from runCC, runCG, runGLM).
+  - Line 40-41: func unifiedLaunchDefault — centralized launch.
+  - Line 57: case "claude_glm": — cg mode-specific branch.
+  - Line 185: persistTeamMode(root, "cg") — writes `team_mode: "cg"` to llm.yaml.
+  - Line 267: resetTeamModeForCC — disables team_mode when switching to CC.
+```
+
+**관찰**: `claude_glm` 문자열 리터럴은 `launcher.go:57` 분기 + `glm.go:185` (`persistTeamMode(root, "cg")`) 등 **두 곳**에 등장한다. M3에서 두 곳을 동시에 `claude_hybrid` + `provider: "glm"`로 교체해야 한다 (단일-위치 변경 시 라우팅이 깨진다).
+
+### 2.3 `internal/cli/glm.go` (943 LOC) — 변경 surface
+
+```
+internal/cli/glm.go:21-943 (relevant slices)
+  - Line 21-60: var glmCmd — moai glm 명령. 본 SPEC에서 보존(REQ-HYBRID-006).
+  - Line 62-67: var glmSetupCmd — moai glm setup. 보존 (alias로 유지 가능).
+  - Line 69-82: var glmStatusCmd — moai glm status. 보존.
+  - Line 84-89: init() — glmCmd.AddCommand + rootCmd.AddCommand. 보존.
+  - Line 92-104: type SettingsLocal struct. 보존 (provider-agnostic).
+  - Line 107-152: func runGLM. 보존; 단 line 148-149 messaging("for hybrid mode... use moai cg")는 "moai hybrid glm"으로 교체.
+  - Line 154-165: func containsPermissionMode. 보존.
+  - Line 167-179: func setGLMEnv. **provider-agnostic으로 generalize 후보** — `setProviderEnv(provider Provider, apiKey string)` 시그니처로 변경.
+  - Line 182-205: func runGLMSetup. setup logic provider-agnostic으로 일반화 (env-key 이름만 provider별 차별).
+  - Line 208-213: func maskAPIKey. 보존 (provider-agnostic 이미).
+  - Line 218-348: func enableTeamMode(cmd, isHybrid bool). **핵심 generalize 대상** — `isHybrid bool` → `provider Provider` 파라미터 + `mode` 결정 로직 일반화.
+  - Line 350-385: func injectTmuxSessionEnv(glmConfig, apiKey). **generalize 대상** — `glmConfig *GLMConfigFromYAML` → provider-agnostic config struct.
+  - Line 387-421: func clearTmuxSessionEnv. 보존 (env-var 이름은 provider별 차별; generalize 시 list가 provider별 confg).
+  - Line 423-438: func persistTeamMode(projectRoot, mode). 보존 + line 185 `"cg"` → `"hybrid"`.
+  - Line 440-482: func ensureSettingsLocalJSON. 보존 (teammateMode: "tmux"는 provider 무관).
+  - Line 485-505: func loadLLMSectionOnly. 보존 + 신규 `provider` 필드 처리.
+  - Line 507-510: func disableTeamMode. 보존.
+  - Line 512-581: func injectGLMEnvForTeam. **generalize 대상** — `injectProviderEnvForTeam(settingsPath, provider, apiKey, baseURL, models)`.
+  - Line 583-644: func saveLLMSection. **provider 필드 추가**.
+  - Line 646-655: type GLMConfigFromYAML. **provider-agnostic struct로 generalize** — `type ProviderConfig struct { BaseURL, Models { High, Medium, Low }, EnvVar string }`.
+  - Line 657-686: func resolveGLMModels. **generalize** — `resolveProviderModels(provider, models) (high, medium, low)`.
+  - Line 688-724: func loadGLMConfig. **generalize** — `loadProviderConfig(root, providerName) (*ProviderConfig, error)`.
+  - Line 726-733: func getGLMEnvPath. **generalize** — `getProviderEnvPath(name) string` returns `~/.moai/.env.<name>`.
+  - Line 735-753: func saveGLMKey. **generalize** — `saveProviderKey(provider, key)`.
+  - Line 755-791: func loadGLMKey. **generalize** — `loadProviderKey(provider) string`.
+  - Line 793-807: func escapeDotenvValue / unescapeDotenvValue. 보존.
+  - Line 809-815: func getGLMAPIKey. **generalize** — `getProviderAPIKey(provider) string`.
+  - Line 817-831: func buildGLMEnvVars. **generalize** — `buildProviderEnvVars(provider, apiKey) map[string]string`.
+  - Line 833-890: func injectGLMEnv. **generalize** — `injectProviderEnv(settingsPath, provider, apiKey)`.
+  - Line 893-905: func isTestEnvironment. 보존.
+  - Line 911-943: func findProjectRoot. 보존.
+```
+
+**핵심 결론**: `glm.go`는 943 LOC이지만, 이 중 약 60% (~570 LOC)가 provider-agnostic으로 generalize 가능한 함수들이다. M2-M4에서 `internal/llm/provider.go` (provider abstraction interface) + `internal/llm/providers/{glm,kimi,deepseek,qwen}.go` (4 메타데이터 파일)을 신규 도입하고, glm.go의 GLM-specific 함수들을 위 신규 패키지로 이주(refactor + rename)한다.
+
+### 2.4 `.moai/config/sections/llm.yaml` 현행 스키마
+
+```yaml
+# .moai/config/sections/llm.yaml (현행 v2.x)
+llm:
+  mode: ""                       # "" or "glm"
+  team_mode: ""                  # "" or "claude" or "glm" or "cg" or "hybrid"
+  glm_env_var: GLM_API_KEY        # GLM-specific
+  performance_tier: ""
+  claude_models: { high, medium, low }
+  glm: { base_url, models: { high, medium, low, opus, sonnet, haiku } }
+  default_model, quality_model, speed_model
+```
+
+**v3R3 확장 (REQ-HYBRID-004)**:
+
+```yaml
+llm:
+  mode: ""
+  team_mode: ""                              # 기존 "cg" → "hybrid"로 마이그레이션
+  provider: ""                                # 신규: "" or "glm" or "kimi" or "deepseek" or "qwen"
+  performance_tier: ""
+  claude_models: { high, medium, low }
+  providers:                                  # 신규: provider별 메타데이터 mapping
+    glm:
+      base_url: "https://api.z.ai/api/anthropic"
+      env_var: "GLM_API_KEY"
+      models: { high: "glm-4.7", medium: "glm-4.7", low: "glm-4.5-air" }
+    kimi:
+      base_url: "https://api.moonshot.ai/anthropic"  # provider-side 검증 대기 (§3.2)
+      env_var: "KIMI_API_KEY"
+      models: { high: "kimi-k2.6", medium: "kimi-k2.6", low: "kimi-k2-flash" }
+    deepseek:
+      base_url: "https://api.deepseek.com/anthropic"  # verified 2026-05-04
+      env_var: "DEEPSEEK_API_KEY"
+      models: { high: "deepseek-v4-pro", medium: "deepseek-v4-pro", low: "deepseek-v4-flash" }
+    qwen:
+      base_url: "https://dashscope.aliyuncs.com/compatible-mode/anthropic"  # 검증 대기 (§3.4)
+      env_var: "DASHSCOPE_API_KEY"
+      models: { high: "qwen3-coder-plus", medium: "qwen3-coder-plus", low: "qwen3-coder-flash" }
+  glm:                                        # 기존 glm 섹션 deprecate (1년 alias 유지)
+    base_url, models, ...
+  default_model, quality_model, speed_model
+```
+
+호환성: 기존 `glm:` 섹션은 v3R3 동안 `providers.glm:`의 alias로 1년간 유지 (REQ-HYBRID-011 마이그레이션 + alias).
+
+---
+
+## 3. 4 LLM API Endpoint Verification (WebFetch 결과)
+
+### 3.1 GLM (Z.AI / Zhipu AI) — VERIFIED
+
+- **Source**: <https://docs.z.ai/scenario-example/develop-tools/claude>
+- **WebFetch date**: 2026-05-04
+- **Anthropic-compat base URL**: `"https://api.z.ai/api/anthropic"` ✅
+- **Latest stable models** (2026-05-04 기준):
+  - High tier (Opus equivalent): `"GLM-4.7"`
+  - Medium tier (Sonnet equivalent): `"GLM-4.7"`
+  - Low tier (Haiku equivalent): `"GLM-4.5-Air"`
+- **Required env-vars**:
+  - `ANTHROPIC_AUTH_TOKEN` (Z.AI API key)
+  - `ANTHROPIC_BASE_URL = "https://api.z.ai/api/anthropic"`
+  - `API_TIMEOUT_MS = "3000000"` (extended operations)
+  - Optional: `ANTHROPIC_DEFAULT_OPUS_MODEL`, `ANTHROPIC_DEFAULT_SONNET_MODEL`, `ANTHROPIC_DEFAULT_HAIKU_MODEL`
+- **참고**: 사용자 요청에서 "GLM-4.6"으로 언급되었으나 Z.AI 공식 docs (2026-05-04 검증)는 GLM-4.7을 latest stable로 표시한다. SPEC-pinned baseline은 docs 기준 GLM-4.7로 채택; GLM-4.6 호환성은 사용자 override 경로(`provider.glm.models.high`)로 보장.
+- **Compat 1급**: provider-side에서 Anthropic-compat 1급 지원 → `--proxy` 불필요.
+
+### 3.2 Kimi K2 (Moonshot AI) — PENDING VERIFICATION
+
+- **Source 1**: <https://platform.moonshot.ai/docs/api/chat> → 301 redirect to `https://platform.kimi.ai/docs/api/chat` (도메인 마이그레이션, 2026 Q1 추정)
+- **Source 2**: <https://platform.moonshot.ai/docs/guide/use-anthropic-sdk-to-call-kimi-api> → 301 redirect to `https://platform.kimi.ai/docs/guide/use-anthropic-sdk-to-call-kimi-api` → 404
+- **WebFetch date**: 2026-05-04
+- **OpenAI-compat base URL**: `"https://api.moonshot.ai/v1"` (verified)
+- **Anthropic-compat base URL**: **NOT FOUND in retrievable docs** ⚠️
+  - 후보 1 (추정): `"https://api.moonshot.ai/anthropic"` — provider 패턴(`api.<host>/anthropic`)이 GLM/DeepSeek와 일치하나 docs 미확인.
+  - 후보 2: 사용자 운영 proxy (예: <https://github.com/sigoden/aichat>를 proxy mode로 운영).
+- **Latest stable model identifier**: `"kimi-k2.6"` (verified via api/chat docs)
+- **결론**: Provider 등록은 1급으로 유지(REQ-HYBRID-002에 포함)하되, base_url은 (a) 사용자 검증 후 SPEC update, (b) `--proxy` 옵션 (REQ-HYBRID-015)으로 fallback. Run-phase에서 사용자 검증 단계 필수.
+
+### 3.3 DeepSeek V4 — VERIFIED (with deprecation note)
+
+- **Source**: <https://api-docs.deepseek.com/>
+- **WebFetch date**: 2026-05-04
+- **Anthropic-compat base URL**: `"https://api.deepseek.com/anthropic"` ✅
+- **OpenAI-compat base URL**: `"https://api.deepseek.com"`
+- **Latest stable models**:
+  - High tier: `"deepseek-v4-pro"` (current)
+  - Low tier: `"deepseek-v4-flash"` (current)
+  - Deprecated (예정 2026-07-24): `"deepseek-chat"`, `"deepseek-reasoner"` — SPEC pinned baseline에서 제외.
+- **참고**: 사용자 요청에서 "DeepSeek V3.x"로 언급되었으나 공식 docs (2026-05-04)는 V4 시리즈를 latest stable로 표시한다. SPEC pinned baseline은 V4. V3 호환성은 사용자 override(`provider.deepseek.models`).
+- **Compat 1급**: provider-side에서 Anthropic-compat 1급 지원 → `--proxy` 불필요.
+
+### 3.4 Qwen3-Coder (Alibaba DashScope / Bailian) — PENDING VERIFICATION
+
+- **Source 1**: <https://help.aliyun.com/zh/model-studio/developer-reference/use-anthropic-sdk-to-call-qwen> → 404
+- **Source 2**: <https://help.aliyun.com/zh/model-studio/anthropic-api> → 404
+- **Source 3**: <https://bailian.console.aliyun.com/?tab=doc#/doc/?type=model&url=2840914> → loading shell (콘솔 SPA, 정적 추출 불가)
+- **WebFetch date**: 2026-05-04
+- **Anthropic-compat base URL**: **NOT FOUND in retrievable docs** ⚠️
+  - 후보 1 (DashScope 패턴 추정): `"https://dashscope.aliyuncs.com/compatible-mode/anthropic"` 또는 `"https://dashscope.aliyuncs.com/api/v1/anthropic"` — provider 패턴 일관성 가설.
+  - 후보 2: 사용자 운영 proxy.
+- **Latest stable model identifier**: 사용자 보고 "Qwen3-Coder Latest" — pinned baseline 후보 `"qwen3-coder-plus"` 또는 `"qwen3-coder-30a3b-instruct"`. Docs 미확인.
+- **Mainland China endpoint**: `dashscope.cn-hangzhou.aliyuncs.com` (별도 SPEC out-of-scope per spec.md §2.2).
+- **결론**: Provider 등록은 1급으로 유지하되, base_url + 정확한 model identifier는 사용자 검증 후 SPEC update. `--proxy` 옵션으로 fallback.
+
+### 3.5 Verification Summary Table
+
+| Provider | Anthropic-compat Status | base_url | Latest Model | Verification Date |
+|----------|------------------------|----------|--------------|-------------------|
+| GLM (Z.AI) | ✅ VERIFIED 1급 | `https://api.z.ai/api/anthropic` | GLM-4.7 / GLM-4.5-Air | 2026-05-04 |
+| Kimi K2 (Moonshot) | ⚠️ PENDING | (후보) `https://api.moonshot.ai/anthropic` | kimi-k2.6 | 사용자 검증 대기 |
+| DeepSeek V4 | ✅ VERIFIED 1급 | `https://api.deepseek.com/anthropic` | deepseek-v4-pro / -flash | 2026-05-04 |
+| Qwen3-Coder | ⚠️ PENDING | (후보) `https://dashscope.aliyuncs.com/compatible-mode/anthropic` | qwen3-coder-plus | 사용자 검증 대기 |
+
+**Run-phase 필수 단계**: M2 milestone 진입 전 사용자에게 Kimi/Qwen3 정확한 endpoint 확인 → spec.md REQ-HYBRID-005 baseline 갱신 → embedded template `.moai/config/sections/llm.yaml` 미러.
+
+---
+
+## 4. Anthropic-compat vs OpenAI-compat 차이 분석
+
+### 4.1 Anthropic-compat이 필수인 이유
+
+`moai hybrid <provider>`는 Claude Code teammates의 subagent context에서 동작한다. Claude Code는 내부적으로 Anthropic Messages API (`POST /v1/messages`) 형식으로 prompt + tool use + thinking blocks를 송수신한다. 이 형식은 OpenAI Chat Completions API (`POST /v1/chat/completions`)와 다음 차이가 있다:
+
+- **Tool use 형식**: Anthropic은 `{"type": "tool_use", "id": "...", "name": "...", "input": {...}}` content block 사용; OpenAI는 `{"function_call": {...}}` 또는 `{"tool_calls": [...]}` 사용.
+- **System prompt 위치**: Anthropic은 top-level `system: "..."` 필드; OpenAI는 `messages: [{"role": "system", ...}]` 첫 메시지.
+- **Streaming format**: Anthropic은 `event: message_start` / `event: content_block_delta` 등 SSE event types 차별화; OpenAI는 `data: {...}` 단일 chunk 형식.
+- **Thinking blocks (Claude-specific)**: Anthropic만 `{"type": "thinking", "thinking": "..."}` content block 지원.
+
+따라서 `moai hybrid <provider>`가 Claude Code와 호환되려면 provider가 Anthropic Messages API 형식을 1급으로 지원해야 한다. OpenAI-compat만 제공하는 provider는 사용자가 운영하는 adapter (예: claude-code-router, aichat proxy mode)를 거쳐야 한다.
+
+### 4.2 4 Provider별 Anthropic-compat 가용성
+
+| Provider | Anthropic-compat 1급 | adapter/proxy 필요? |
+|----------|----------------------|---------------------|
+| GLM (Z.AI) | ✅ | 불필요 |
+| Kimi K2 (Moonshot) | ⚠️ 검증 대기 | 가능성 있음 (adapter 필요 시 `--proxy` 옵션) |
+| DeepSeek V4 | ✅ | 불필요 |
+| Qwen3-Coder | ⚠️ 검증 대기 | 가능성 있음 (`--proxy`) |
+
+### 4.3 `--proxy` 옵션 설계 근거
+
+REQ-HYBRID-015는 `moai hybrid <provider> --proxy <url>` 옵션으로 사용자가 ANTHROPIC_BASE_URL을 override 할 수 있게 한다. 사용 사례:
+
+- Kimi/Qwen3가 provider-side Anthropic-compat을 정식 출시하기 전, 사용자가 self-hosted adapter 운영 (예: <https://github.com/sigoden/aichat> proxy mode, claude-code-router).
+- 기업 내부 LLM gateway에 Anthropic-compat shim이 추가된 환경.
+- Mainland China region의 별도 endpoint를 임시 사용 (별도 SPEC 정식 출시 전).
+
+`--proxy` 사용 시 SPEC-pinned base_url은 무시되고 사용자 URL이 사용된다. 단, `Authorization: Bearer <api-key>` 헤더 형식은 그대로 유지(provider-side 인증 전제).
+
+---
+
+## 5. 기존 GLM Env-Injection 패턴 분석
+
+### 5.1 두 주입 경로 (현행 v2.x)
+
+`moai cg` 모드는 두 단계 env-var 주입을 수행한다:
+
+**경로 A — tmux session-level injection** (`internal/cli/glm.go:356-385 injectTmuxSessionEnv`):
+
+```go
+vars := map[string]string{
+    "ANTHROPIC_AUTH_TOKEN":           apiKey,
+    "ANTHROPIC_BASE_URL":             glmConfig.BaseURL,
+    "ANTHROPIC_DEFAULT_OPUS_MODEL":   glmConfig.Models.High,
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": glmConfig.Models.Medium,
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL":  glmConfig.Models.Low,
+    "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS":   "1",
+    "DISABLE_PROMPT_CACHING":                   "1",
+    "API_TIMEOUT_MS":                            "3000000",
+    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+}
+mgr.InjectEnv(context.Background(), vars)
+```
+
+→ tmux `set-environment -g`로 session-scoped env-var 주입. 새 pane이 spawn될 때 inherit됨 (CG mode의 핵심 architectural pattern).
+
+**경로 B — settings.local.json injection** (`internal/cli/glm.go:520-581 injectGLMEnvForTeam`):
+
+```go
+settings.Env["ANTHROPIC_AUTH_TOKEN"] = apiKey
+settings.Env["ANTHROPIC_BASE_URL"] = glmConfig.BaseURL
+// ... (위와 동일 키들)
+settings.TeammateMode = "tmux"
+delete(settings.Env, "CLAUDE_CODE_TEAMMATE_DISPLAY")  // legacy cleanup
+```
+
+→ `.claude/settings.local.json`에 평문 기록. Claude Code 시작 시 inherit. CG 모드는 leader가 Claude를 사용해야 하므로 settings.local.json에서는 이 env-var가 비어있어야 한다 (cg 분기에서 `removeGLMEnv` 호출). 반면 GLM 단일 모드 (`moai glm`)는 settings.local.json에도 GLM env를 기록한다.
+
+### 5.2 Generalize 후 (v3R3)
+
+provider-agnostic으로 generalize한 후의 env-var 키 일반화:
+
+```go
+// internal/llm/provider.go (신규)
+type Provider interface {
+    Name() string                          // "glm" | "kimi" | "deepseek" | "qwen"
+    AnthropicBaseURL() string              // e.g., "https://api.z.ai/api/anthropic"
+    EnvKeyName() string                    // e.g., "GLM_API_KEY"
+    DefaultModels() ModelSet               // High, Medium, Low
+    BuildEnvVars(apiKey string) map[string]string  // ANTHROPIC_AUTH_TOKEN + base_url + models + provider-specific flags
+}
+
+// internal/llm/providers/glm.go (예시)
+func (p GLMProvider) BuildEnvVars(apiKey string) map[string]string {
+    return map[string]string{
+        "ANTHROPIC_AUTH_TOKEN":           apiKey,
+        "ANTHROPIC_BASE_URL":             p.AnthropicBaseURL(),
+        "ANTHROPIC_DEFAULT_OPUS_MODEL":   p.DefaultModels().High,
+        "ANTHROPIC_DEFAULT_SONNET_MODEL": p.DefaultModels().Medium,
+        "ANTHROPIC_DEFAULT_HAIKU_MODEL":  p.DefaultModels().Low,
+        // GLM-specific (Z.AI proxy compatibility):
+        "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS":   "1",
+        "DISABLE_PROMPT_CACHING":                   "1",
+        "API_TIMEOUT_MS":                            "3000000",
+        "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+    }
+}
+```
+
+각 provider는 BuildEnvVars에서 자신의 compat 요구사항을 표현한다 (DeepSeek/Kimi/Qwen은 다른 flag set일 수 있음 — 실측 후 확정). 공통 키 5개(`ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BASE_URL`, `ANTHROPIC_DEFAULT_*`)는 모든 provider에서 동일하다.
+
+### 5.3 `MOAI_BACKUP_AUTH_TOKEN` 백업 슬롯
+
+현행 `injectGLMEnvForTeam` (`glm.go:536-538`)은 단일 백업 슬롯 `MOAI_BACKUP_AUTH_TOKEN`을 사용한다:
+
+```go
+if existing := settings.Env["ANTHROPIC_AUTH_TOKEN"]; existing != "" && existing != apiKey {
+    settings.Env["MOAI_BACKUP_AUTH_TOKEN"] = existing
+}
+```
+
+다중 provider 전환 시(GLM → Kimi → DeepSeek) 단일 슬롯은 마지막 백업만 보존한다. v3R3에서는 provider-별 namespace 분리:
+
+```go
+backupKey := fmt.Sprintf("MOAI_BACKUP_AUTH_TOKEN_%s", strings.ToUpper(provider.Name()))
+if existing := settings.Env["ANTHROPIC_AUTH_TOKEN"]; existing != "" && existing != apiKey {
+    settings.Env[backupKey] = existing  // e.g., MOAI_BACKUP_AUTH_TOKEN_GLM
+}
+```
+
+→ provider 전환 시 이전 토큰 보존. Claude OAuth 토큰은 `~/.claude/`에 별도 저장되어 영향받지 않는다.
+
+---
+
+## 6. SPEC-GLM-MCP-001 Dependency Surface
+
+### 6.1 GLM-MCP-001 SPEC 개요 (PR #769 OPEN, plan-only)
+
+PR #769 metadata 추출 결과 (`gh pr view 769 --json body`):
+
+- **Goal**: Z.AI Vision/WebSearch/WebReader MCP 서버 (`@z_ai/mcp-server`)를 `moai glm` 모드에 통합.
+- **Subcommand**: `moai glm tools enable|disable` (Vision/WebSearch/WebReader 토글).
+- **Plan PASS**: plan-auditor PASS (score 0.91, MP 0 defects).
+- **Status**: plan-only PR. Implementation은 별도 SPEC 후속.
+
+### 6.2 본 SPEC과의 Surface Overlap
+
+본 SPEC의 REQ-HYBRID-016은 forward-looking surface로 `moai hybrid <provider> tools enable|disable`을 정의한다. 즉:
+
+- `moai glm tools enable` ← GLM-MCP-001 implementation 책임 (구체 MCP attach 로직).
+- `moai hybrid glm tools enable` ← 본 SPEC implementation 책임 (CLI surface) + GLM-MCP-001 위임 (실제 attach).
+
+### 6.3 의존성 분리 결정
+
+본 SPEC은 GLM-MCP-001을 absorbing하지 않는다 (CLAUDE.local.md의 "이전 SPEC absorption" 패턴 회피):
+
+- 본 SPEC은 **CLI surface + 4-provider abstraction**만 제공.
+- MCP attach/detach 로직은 GLM-MCP-001에 남는다.
+- Wire-up: `internal/cli/hybrid.go`가 `moai hybrid glm tools enable`을 받으면 GLM-MCP-001의 implementation 함수(예: `internal/mcp/zai_attach.go EnableTools()`)를 호출한다.
+
+이 분리로 본 SPEC은 GLM-MCP-001의 implementation timeline에 block되지 않는다 (REQ-HYBRID-016의 surface는 stub로 deliver, MCP attach는 GLM-MCP-001 후속 PR에서 채움).
+
+### 6.4 Forward-looking Surface Stub
+
+```bash
+# v3R3 첫 minor release: tools subcommand surface 등록 + stub
+$ moai hybrid glm tools enable
+Error: tool integration is implemented in SPEC-GLM-MCP-001 (PR #769 + follow-up). When that SPEC ships, this command attaches Z.AI Vision/WebSearch/WebReader MCP servers.
+
+# GLM-MCP-001 implementation 후속 PR 머지 시: stub → 실제 동작
+$ moai hybrid glm tools enable
+✓ Z.AI Vision MCP server attached
+✓ Z.AI WebSearch MCP server attached
+✓ Z.AI WebReader MCP server attached
+```
+
+본 SPEC의 acceptance.md AC-HYBRID-14는 surface 등록만 검증한다 (help text + stub error message).
+
+---
+
+## 7. 마이그레이션 시나리오 분석 (REQ-HYBRID-011)
+
+기존 사용자 프로젝트의 `.moai/config/sections/llm.yaml`은 다음 4가지 상태일 수 있다:
+
+| 상태 | team_mode | 마이그레이션 동작 |
+|------|-----------|-------------------|
+| State A | `""` (비활성) | 변경 없음 (provider 필드 신규 추가만) |
+| State B | `"claude"` | 변경 없음 (Claude 단일 모드 유지) |
+| State C | `"glm"` | 변경 없음 (단일 GLM 모드 유지; `moai glm` 보존) |
+| State D | `"cg"` | **자동 마이그레이션**: `team_mode: "hybrid"` + `provider: "glm"` |
+
+State D 마이그레이션은 `moai update` cleanup phase에서 수행된다. SPEC-V3R3-UPDATE-CLEANUP-001 (PR #764 merged)이 도입한 atomic write + manifest provenance 인프라를 그대로 활용한다 (별도 신규 인프라 필요 없음).
+
+마이그레이션 발생 시 stderr 메시지 (1회만, post-update notice):
+
+```
+NOTICE: SPEC-V3R3-HYBRID-001 BC migration applied to .moai/config/sections/llm.yaml
+  - team_mode: "cg" → "hybrid"
+  - provider: (added) "glm"
+  See SPEC-V3R3-HYBRID-001 §10 BC Migration for details.
+  Replace 'moai cg' invocations with 'moai hybrid glm' going forward.
+```
+
+---
+
+## 8. 구현 surface 추정 (LOC)
+
+| 변경 카테고리 | 파일 수 | LOC 추정 |
+|---|---|---|
+| 신규 provider abstraction (`internal/llm/provider.go` + 4 providers) | 5 | ~400 LOC |
+| `internal/cli/hybrid.go` (신규 명령) | 1 | ~250 LOC |
+| `internal/cli/cg.go` BC stub 변경 | 1 | -57 LOC + ~30 LOC stub |
+| `internal/cli/glm.go` generalize (provider-agnostic refactor) | 1 | -200 LOC (move to providers/glm.go) + ~50 LOC adjustments |
+| `internal/cli/launcher.go` `claude_glm` → `claude_hybrid` 분기 | 1 | ~30 LOC |
+| `internal/config/types.go` LLMConfig 확장 (`Provider` 필드 + `Providers map`) | 1 | ~40 LOC |
+| `internal/config/defaults.go` 4 provider 기본값 | 1 | ~80 LOC |
+| `.moai/config/sections/llm.yaml` 스키마 확장 (project + template) | 2 | ~50 LOC |
+| Test surface (provider_test, hybrid_test, cg_removal_test, allowlist_test) | 4-5 | ~500 LOC |
+| 6 .claude/skills + .claude/rules 문서 substitution | 6-10 | ~30 LOC |
+| CLAUDE.md, CLAUDE.local.md substitution | 2 | ~20 LOC |
+| CHANGELOG entry | 1 | ~20 LOC |
+| **Total** | **~26 files** | **~1500 LOC (net)** |
+
+이 중 ~80%는 abstraction 도입 + 신규 코드, ~20%는 substitution.
+
+---
+
+## 9. Risk Mitigation Anchors (codebase-grounded)
+
+spec.md §8 risks의 file-anchored mitigations:
+
+| Risk (spec.md §8) | Mitigation Anchor |
+|---|---|
+| `moai cg` 사용자 워크플로 중단 | `internal/cli/cg.go` BC stub (REQ-HYBRID-014) — `cgCmd.RunE`에서 `MOAI_CG_REMOVED` + actionable suggestion 반환. Cobra 자동 "unknown command" fallback 차단. |
+| Kimi/Qwen3 endpoint 미가용 | `--proxy <url>` 옵션 (REQ-HYBRID-015), `internal/cli/hybrid.go`에서 `--proxy` flag 파싱 후 `ANTHROPIC_BASE_URL` override. `internal/llm/providers/kimi.go`의 `AnthropicBaseURL()` 반환값을 `--proxy`로 대체. |
+| Latest model 변경 | `provider.<name>.models` 사용자 override 경로 (REQ-HYBRID-005), `internal/config/types.go`의 `ProvidersConfig` struct + `loadProviderConfig` (`internal/llm/provider.go`)에서 사용자 값 우선 |
+| `team_mode: "cg"` 마이그레이션 실패 | REQ-HYBRID-011 + REQ-HYBRID-014 양방향 안전망. `internal/cli/update.go cleanMoaiManagedPaths`에 `migrateCGTeamMode` 추가 + cg.go BC stub로 직접 호출 차단. |
+| 단일 백업 슬롯 충돌 | provider-namespaced backup keys (`MOAI_BACKUP_AUTH_TOKEN_<UPPER>`) — `internal/llm/provider.go`의 `injectProviderEnvForTeam`에서 구현. |
+| Template-First mirror 누락 | M2/M3/M4 종료 시 `make build` HARD rule. `internal/template/lang_boundary_audit_test.go` 패턴(SPEC-V3R2-WF-005 M1)을 차용해 `provider_allowlist_audit_test.go`에서 embedded FS 검증. |
+| Anthropic-compat endpoint 응답 cryptic error | launch 직전 health check (`HEAD <base_url>` 또는 GET `/v1/messages` with empty body) — REQ-HYBRID-013 launch path에서 HTTP error propagate. |
+| Provider tier 매핑 의미 상이 | research.md §3에서 provider별 model 등급 명시 + 사용자 override 권장 메시지 (init/update 시점). |
+| BC stub fallback | REQ-HYBRID-014 명시: `cgCmd`는 binary에 stub로 보존. `internal/cli/cg.go`는 빈 파일이 아닌 active stub. |
+| docs-site 4-locale 누락 | sync-phase manager-docs 의무 + CLAUDE.local.md §17 강제. |
+
+---
+
+## 10. File:line Citations (load-bearing anchors, ≥10)
+
+1. `internal/cli/cg.go:1-58` — 현행 `moai cg` 명령 정의 (얇은 래퍼).
+2. `internal/cli/cg.go:7-44` — `cgCmd` cobra 정의.
+3. `internal/cli/cg.go:51-57` — `runCG` → `unifiedLaunch(profileName, "claude_glm", filteredArgs)`.
+4. `internal/cli/launcher.go:21-26` — `unifiedLaunch` indirection (testability).
+5. `internal/cli/launcher.go:38-39` — `@MX:ANCHOR fan_in=3` (runCC, runCG, runGLM).
+6. `internal/cli/launcher.go:57` — `case "claude_glm":` 분기 (cg-specific).
+7. `internal/cli/launcher.go:185` — `persistTeamMode(root, "cg")` (llm.yaml에 cg 기록).
+8. `internal/cli/launcher.go:267` — `resetTeamModeForCC` (cc 전환 시 team_mode 초기화).
+9. `internal/cli/glm.go:21-89` — `glmCmd` + setup/status subcommand 정의 (보존).
+10. `internal/cli/glm.go:148-149` — runGLM의 "for hybrid mode... use moai cg" messaging (`moai hybrid glm`로 substitution 대상).
+11. `internal/cli/glm.go:218-348` — `enableTeamMode(cmd, isHybrid bool)` (provider-agnostic generalize 핵심 대상).
+12. `internal/cli/glm.go:251-253` — `if isHybrid && !inTmux` tmux 검증 (REQ-HYBRID-008 패턴).
+13. `internal/cli/glm.go:266` — `persistTeamMode(root, "cg")` (M3 substitution 대상).
+14. `internal/cli/glm.go:356-385` — `injectTmuxSessionEnv` (provider-agnostic generalize 대상).
+15. `internal/cli/glm.go:366-374` — Anthropic-compat env-var keys (provider 공통).
+16. `internal/cli/glm.go:520-581` — `injectGLMEnvForTeam` (provider-agnostic generalize 대상).
+17. `internal/cli/glm.go:536-538` — 단일 백업 슬롯 `MOAI_BACKUP_AUTH_TOKEN` (provider-namespaced로 변경 대상).
+18. `internal/cli/glm.go:646-655` — `type GLMConfigFromYAML` (provider-agnostic struct로 generalize 대상).
+19. `internal/cli/glm.go:688-724` — `loadGLMConfig` (provider-agnostic generalize 대상).
+20. `internal/cli/glm.go:726-733` — `getGLMEnvPath` → `~/.moai/.env.glm` (4-provider env path 패턴 확장).
+21. `internal/config/types.go:52-70` — `LLMConfig` struct (`Mode`, `TeamMode`, `GLMEnvVar`, `GLM`); `Provider` + `Providers` 필드 추가 대상.
+22. `internal/config/types.go:92-100` — `GLMModels` struct (High/Medium/Low + legacy Opus/Sonnet/Haiku).
+23. `.moai/config/sections/llm.yaml:1-19` — 현행 v2.x 스키마 (project layer).
+24. `internal/template/templates/.moai/config/sections/llm.yaml:1-43` — embedded template 스키마 (Template-First).
+25. `.claude/skills/moai/team/glm.md:41,50,103,127,143` — `moai cg` 5개 mention (substitution 대상).
+26. `.claude/skills/moai/team/run.md:73,88,92,103,104` — `moai cg` 5개 mention (substitution 대상).
+27. `.claude/skills/moai/workflows/run.md:904` — `active_mode: cc | glm | cg` (substitution 대상).
+28. `.claude/rules/moai/development/model-policy.md:44` — `Activation: moai cg` (substitution 대상).
+29. `CLAUDE.md §15 line 498` — `Activation: moai cg (requires tmux)` (CG Mode 섹션 제목 + 본문 substitution).
+30. `CLAUDE.local.md:129` — `Modified by 'moai glm', 'moai cc', 'moai cg' commands at runtime` (사용자 가이드 substitution).
+31. SPEC-GLM-MCP-001 PR #769 — Z.AI MCP 서버 통합 plan-only PR (의존성).
+32. SPEC-V3R3-UPDATE-CLEANUP-001 PR #764 — `moai update` atomic write + manifest provenance (REQ-HYBRID-011 인프라).
+33. SPEC-V3R2-WF-005 PR #768 — 16-language neutrality 패턴 (4-provider neutrality 차용).
+
+Total: **33 distinct file:line / SPEC anchors** (>10 minimum required by plan-auditor).
+
+---
+
+## 11. Open Questions for plan-auditor / Run Phase
+
+### OQ-1: Kimi K2 Anthropic-compat endpoint 정확한 URL
+
+- **Status**: 사용자 검증 대기
+- **Action**: M2 milestone 진입 전 사용자에게 (a) <https://platform.kimi.ai/> 공식 docs에서 Anthropic-compat URL 확인, (b) 미존재 시 `--proxy` 패턴 채택 confirm.
+- **Fallback**: spec.md §3.2 base_url을 `--proxy` 필수로 표기.
+
+### OQ-2: Qwen3-Coder Anthropic-compat endpoint 정확한 URL
+
+- **Status**: 사용자 검증 대기
+- **Action**: M2 진입 전 (a) DashScope 공식 docs 검증, (b) Bailian console에서 Anthropic-compat 항목 확인.
+- **Fallback**: spec.md §3.4 동일.
+
+### OQ-3: GLM-4.7 vs GLM-4.6 사용자 의도
+
+- **Status**: 사용자가 "GLM-4.6"으로 지칭, Z.AI 공식 docs는 GLM-4.7이 latest stable.
+- **Resolution**: research.md §3.1에 따라 SPEC pinned baseline은 docs 기준 GLM-4.7. 사용자 override는 `provider.glm.models.high`로 가능. spec.md §1.1 "background"에 명시.
+
+### OQ-4: DeepSeek V4 vs V3.x 사용자 의도
+
+- **Status**: 사용자가 "DeepSeek V3.x"로 지칭, 공식 docs는 V4가 current (V3 deprecation 2026-07-24 예정).
+- **Resolution**: SPEC pinned baseline은 V4. V3 호환은 사용자 override.
+
+### OQ-5: `moai cg` BC stub vs 완전 삭제
+
+- **Status**: 사용자 명시 "clean break (immediate removal)".
+- **Resolution**: REQ-HYBRID-014에 따라 BC stub로 보존(완전 삭제 아님). Cobra "unknown command" fallback이 actionable 메시지를 제공하지 못하므로 stub 보존이 사용자에게 더 친절한 clean break.
+
+### OQ-6: `moai glm tools` vs `moai hybrid glm tools` 우선순위
+
+- **Status**: REQ-HYBRID-016은 `moai hybrid <provider> tools` surface를 정의하나 SPEC-GLM-MCP-001은 `moai glm tools`만 plan에 포함.
+- **Resolution**: 두 surface 모두 deliver. `moai glm tools`는 GLM-MCP-001 implementation의 1차 surface; `moai hybrid glm tools`는 본 SPEC의 multi-provider 일관성 surface. Run-phase에서 동일 함수에 위임.
+
+### OQ-7: `moai hybrid setup <provider> <key>` vs 기존 `moai glm setup <key>`
+
+- **Status**: 본 SPEC은 `moai hybrid setup <provider>`를 권장하나 `moai glm setup <key>`도 alias로 1년간 보존.
+- **Resolution**: spec.md §10.2 마이그레이션 표 명시. `moai glm setup`은 `~/.moai/.env.glm`에 저장 (기존 동작); `moai hybrid setup glm`은 동일 동작. 4 provider 모두 `moai hybrid setup <name>` 패턴 통일.
+
+### OQ-8: provider별 cache_control / prompt_caching 정책 차별
+
+- **Status**: 현행 GLM은 `DISABLE_PROMPT_CACHING=1`. 다른 provider도 동일?
+- **Resolution**: spec.md §2.2 Out of Scope — 현행 정책 유지 (모든 provider `DISABLE_PROMPT_CACHING=1`). 변경은 SPEC-GLM-MCP-001 후속 또는 별도 SPEC.
+
+---
+
+## 12. Verification Checklist (research.md self-audit)
+
+- [x] **현행 `moai cg` LOC 매핑**: cg.go (57 LOC), launcher.go relevant slice (line 21-280), glm.go (943 LOC) all enumerated in §2.
+- [x] **4 provider endpoint WebFetch 결과 기록**: §3.1-3.4 + §3.5 summary table.
+- [x] **Anthropic-compat 가용성 분류**: GLM/DeepSeek 1급 verified; Kimi/Qwen3 검증 대기 + `--proxy` fallback.
+- [x] **Latest model name pinned baseline**: GLM-4.7, Kimi K2.6, DeepSeek-V4-pro/-flash, Qwen3-Coder Plus(추정).
+- [x] **Env-injection 패턴 분석**: §5에 두 경로 (tmux session-level + settings.local.json) + provider-agnostic generalize 설계.
+- [x] **GLM-MCP-001 dependency surface**: §6에 명시 — 본 SPEC은 CLI surface, GLM-MCP-001은 MCP attach 로직.
+- [x] **마이그레이션 시나리오 4가지 상태 (A-D)**: §7.
+- [x] **LOC 추정 ~1500 (net)**: §8.
+- [x] **Risk mitigation file-anchored**: §9에서 spec.md §8 risks 모두 anchor 매핑.
+- [x] **File:line citations ≥10**: §10에서 33개 anchor.
+- [x] **Open questions 8건**: §11.
+- [x] **사용자 의도 vs Z.AI/DeepSeek docs 차이 (GLM-4.6 vs 4.7, V3 vs V4)**: §11 OQ-3, OQ-4에서 명시 + spec.md §1.1 background 반영.
+
+---
+
+End of research.md.

--- a/.moai/specs/SPEC-V3R3-HYBRID-001/spec-compact.md
+++ b/.moai/specs/SPEC-V3R3-HYBRID-001/spec-compact.md
@@ -1,0 +1,150 @@
+# SPEC-V3R3-HYBRID-001 Compact Reference
+
+> Auto-extract from `spec.md` v0.1.0 — REQs + ACs + Files + Exclusions only.
+> Use this file for fast plan-auditor scans and cross-SPEC referencing.
+
+---
+
+## Requirements (EARS)
+
+### Ubiquitous Requirements
+
+- **REQ-HYBRID-001**: The MoAI CLI **shall** expose `moai hybrid <provider> [-p profile] [-- claude-args...]` as the canonical command for Claude-leader + team-LLM-teammates hybrid execution.
+- **REQ-HYBRID-002**: The MoAI CLI **shall** accept exactly four `<provider>` values: `glm`, `kimi`, `deepseek`, `qwen`. Any other value **shall** be rejected with `UNKNOWN_PROVIDER` and the error message **shall** list the four allowed values.
+- **REQ-HYBRID-003**: The MoAI CLI **shall** delete or reduce `internal/cli/cg.go` such that invoking `moai cg [args...]` returns a BC error with sentinel `MOAI_CG_REMOVED` and an actionable migration suggestion (`use 'moai hybrid glm' instead`).
+- **REQ-HYBRID-004**: The MoAI configuration schema (`.moai/config/sections/llm.yaml`) **shall** include a top-level `provider` key (string, one of the four allow-list values) and a `provider.<name>.{base_url, models.{high,medium,low}, env_var}` sub-section per allow-list provider.
+- **REQ-HYBRID-005**: The 4 LLM providers **shall** be pinned at SPEC creation date (2026-05-04) to verified-stable model names: GLM-4.7, Kimi K2.6, DeepSeek-V4, Qwen3-Coder Plus (per research.md §3). User overrides via `.moai/config/sections/llm.yaml` `provider.<name>.models` sub-fields are permitted.
+- **REQ-HYBRID-006**: The MoAI CLI **shall** preserve `moai glm` (single-LLM all-GLM mode) and `moai cc` (Claude-only mode) without behavioral change. `moai hybrid` **shall** be the multi-LLM superset, not a replacement of these.
+
+### Event-Driven Requirements
+
+- **REQ-HYBRID-007**: **When** the user invokes `moai hybrid <provider>`, the CLI **shall**: (a) load `~/.moai/.env.<provider>` for the API key, (b) inject `ANTHROPIC_AUTH_TOKEN` and `ANTHROPIC_BASE_URL` into the active tmux session, (c) write `provider: "<name>"` and `team_mode: "hybrid"` to `.moai/config/sections/llm.yaml`, (d) launch Claude Code via `unifiedLaunch(profileName, "claude_hybrid", filteredArgs)`.
+- **REQ-HYBRID-008**: **When** the user invokes `moai hybrid <provider>` outside a tmux session, the CLI **shall** reject with `HYBRID_REQUIRES_TMUX` and provide the recovery path: `tmux new -s moai && moai hybrid <provider>`.
+- **REQ-HYBRID-009**: **When** the user invokes `moai hybrid <provider>` and `~/.moai/.env.<provider>` does not exist or is empty, the CLI **shall** reject with `HYBRID_MISSING_API_KEY` and instruct: `moai hybrid setup <provider> <api-key>`.
+- **REQ-HYBRID-010**: **When** the user invokes `moai cg [args...]`, the CLI **shall** print the BC error and exit with non-zero status; **shall not** attempt to launch Claude Code.
+- **REQ-HYBRID-011**: **When** the user invokes `moai update` against a project whose `.moai/config/sections/llm.yaml` contains `team_mode: "cg"`, the CLI cleanup phase **shall** rewrite to `team_mode: "hybrid"` + `provider: "glm"` and emit a one-time migration notice.
+
+### State-Driven Requirements
+
+- **REQ-HYBRID-012**: **While** `team_mode: "hybrid"` is active and `provider: "<name>"` is set, the active LLM provider **shall** be `<name>` and Claude Code teammates **shall** observe `ANTHROPIC_BASE_URL` pointing to that provider's Anthropic-compat endpoint.
+- **REQ-HYBRID-013**: **While** the user is on `moai hybrid <provider>` and the provider's Anthropic-compat endpoint is unreachable, the launch path **shall** propagate the underlying HTTP error and **shall not** silently fall back to a different provider.
+- **REQ-HYBRID-014**: **While** `BC-V3R3-HYBRID-001` is active in CHANGELOG, `moai cg` **shall** remain present in the binary as a BC stub returning `MOAI_CG_REMOVED`; `moai cg` **shall not** be silently absent (cobra "unknown command" error is insufficient).
+
+### Optional Requirements
+
+- **REQ-HYBRID-015**: **Where** the provider's Anthropic-compat endpoint is not yet officially available (Kimi, Qwen3-Coder per research.md §3 pending verification), the user **shall** be able to supply `--proxy <url>` to override `ANTHROPIC_BASE_URL` at launch time.
+- **REQ-HYBRID-016**: **Where** the user wants per-provider tools toggle (e.g., enabling Z.AI Vision MCP for `glm` only — depends on SPEC-GLM-MCP-001), the CLI **shall** support `moai hybrid <provider> tools enable|disable` as a forward-looking subcommand surface.
+
+### Complex Requirements (Unwanted Behavior / Composite)
+
+- **REQ-HYBRID-017** (Unwanted Behavior): **If** a future PR proposes a 5th provider (e.g., `mistral`, `cohere`, `xai-grok`), **then** CI **shall** reject with `PROVIDER_ALLOWLIST_VIOLATION` per the closed-set rule (REQ-HYBRID-002). Reversal requires a new SPEC with atomic-migration semantics.
+- **REQ-HYBRID-018** (Complex: Auth Failure): **While** `moai hybrid <provider>` is launching, **when** the provider returns HTTP 401/403 (auth failure), the CLI **shall** mask the API key in any error message (per `maskAPIKey` `internal/cli/glm.go:208`) and emit `HYBRID_AUTH_FAILED` with a hint to verify the key via `moai hybrid status <provider>`.
+
+---
+
+## Acceptance Criteria
+
+- **AC-HYBRID-01** (REQ-HYBRID-001): Given a user runs `moai hybrid --help` When the help output is rendered Then the synopsis line `moai hybrid <provider> [-p profile]` appears and the description names the four allow-list providers.
+- **AC-HYBRID-02** (REQ-HYBRID-002): Given a user runs `moai hybrid mistral` When the CLI parses arguments Then exit code is non-zero and stderr contains `UNKNOWN_PROVIDER` plus the four allowed values.
+- **AC-HYBRID-03** (REQ-HYBRID-003, 010, 014): Given a user runs `moai cg` after upgrade When the CLI executes Then exit code is non-zero and stderr contains `MOAI_CG_REMOVED` and `use 'moai hybrid glm' instead`.
+- **AC-HYBRID-04** (REQ-HYBRID-004): Given the embedded template `.moai/config/sections/llm.yaml` When parsed Then it contains a top-level `provider:` key (default empty string) and `provider.<name>.{base_url, models.high, models.medium, models.low, env_var}` for all four providers.
+- **AC-HYBRID-05** (REQ-HYBRID-005): Given the embedded template When `provider.glm.models.high`, `provider.kimi.models.high`, `provider.deepseek.models.high`, `provider.qwen.models.high` are read Then the values match the SPEC-pinned baselines (GLM-4.7, Kimi K2.6, DeepSeek-V4, Qwen3-Coder Plus or equivalent — see research.md §3).
+- **AC-HYBRID-06** (REQ-HYBRID-006): Given a user runs `moai glm` and `moai cc` after upgrade When the binaries execute Then both produce the v2.x baseline behavior (no functional regression).
+- **AC-HYBRID-07** (REQ-HYBRID-007): Given a user inside a tmux session runs `moai hybrid glm` with `~/.moai/.env.glm` populated When the launch completes Then `tmux show-environment | grep ANTHROPIC_BASE_URL` returns the GLM endpoint and `.moai/config/sections/llm.yaml` shows `team_mode: "hybrid"` + `provider: "glm"`.
+- **AC-HYBRID-08** (REQ-HYBRID-008): Given a user outside tmux runs `moai hybrid kimi` When the CLI executes Then exit code is non-zero and stderr contains `HYBRID_REQUIRES_TMUX` plus the recovery path.
+- **AC-HYBRID-09** (REQ-HYBRID-009): Given a user inside tmux runs `moai hybrid deepseek` and `~/.moai/.env.deepseek` is missing When the CLI executes Then exit code is non-zero and stderr contains `HYBRID_MISSING_API_KEY` plus `moai hybrid setup deepseek`.
+- **AC-HYBRID-10** (REQ-HYBRID-011): Given a project with `team_mode: "cg"` in `.moai/config/sections/llm.yaml` When `moai update` runs Then post-update the file contains `team_mode: "hybrid"` and `provider: "glm"` and stderr emits a one-time migration notice.
+- **AC-HYBRID-11** (REQ-HYBRID-012): Given `moai hybrid qwen` succeeds When a Claude Code teammate launches in a new tmux pane Then `env | grep ANTHROPIC_BASE_URL` returns the Qwen endpoint (or proxy URL if --proxy was used).
+- **AC-HYBRID-12** (REQ-HYBRID-013): Given the GLM endpoint is unreachable (simulated via DNS block) When `moai hybrid glm` launches Then the underlying HTTP error is propagated to stderr and the CLI does NOT silently fall back to Kimi/DeepSeek/Qwen.
+- **AC-HYBRID-13** (REQ-HYBRID-015): Given a user runs `moai hybrid kimi --proxy https://my-proxy/anthropic` When the launch completes Then `ANTHROPIC_BASE_URL` is set to `https://my-proxy/anthropic` (overriding the provider default).
+- **AC-HYBRID-14** (REQ-HYBRID-016): Given a user runs `moai hybrid glm tools --help` When the help output is rendered Then it lists `enable` and `disable` subcommand stubs (forward-looking surface; full implementation deferred to SPEC-GLM-MCP-001).
+- **AC-HYBRID-15** (REQ-HYBRID-017): Given a PR adding `internal/llm/providers/mistral.go` to the codebase When CI runs Then the test `TestProviderAllowlist` fails with `PROVIDER_ALLOWLIST_VIOLATION` referencing the four allowed providers.
+- **AC-HYBRID-16** (REQ-HYBRID-018): Given `moai hybrid glm` is launching and the API key is invalid When the provider returns HTTP 401 Then stderr contains `HYBRID_AUTH_FAILED` and the API key in the error message is masked (e.g., `sk-x****wxyz`, never the full key).
+- **AC-HYBRID-17** (REQ-HYBRID-005, 014): Given an upgraded user re-runs the same workflow that previously used `moai cg` When `moai hybrid glm` is invoked Then the resulting tmux env-vars and settings.local.json `teammateMode: "tmux"` match the v2.x `moai cg` behavior bit-for-bit (no regression).
+- **AC-HYBRID-18** (REQ-HYBRID-002, 017): Given the `internal/llm/providers/registry.go` (or equivalent) When inspected by static analysis or unit test Then exactly four provider entries are present (`glm`, `kimi`, `deepseek`, `qwen`) and no five-provider configuration loads at runtime.
+
+---
+
+## Files to Modify
+
+### To-be-created (13 files)
+
+#### Test scaffolds (M1, 4 files)
+
+- `internal/template/provider_allowlist_audit_test.go` (REQ-HYBRID-002, 017 audit)
+- `internal/cli/cg_removal_test.go` (REQ-HYBRID-003, 010, 014 BC verification)
+- `internal/cli/hybrid_test.go` (REQ-HYBRID-001..009 + 012, 013, 015, 018)
+- `internal/cli/migration_test.go` (REQ-HYBRID-011 cg→hybrid migration)
+
+#### Provider abstraction layer (M2, 7 files)
+
+- `internal/llm/provider.go` (Provider interface + ModelSet struct)
+- `internal/llm/providers/glm.go` (GLM provider metadata + Z.AI compat flags)
+- `internal/llm/providers/kimi.go` (Kimi K2 provider metadata, base_url pending)
+- `internal/llm/providers/deepseek.go` (DeepSeek V4 provider metadata)
+- `internal/llm/providers/qwen.go` (Qwen3-Coder provider metadata, base_url pending)
+- `internal/llm/providers/registry.go` (4-provider Registry + List() + Lookup())
+- `internal/llm/registry_test.go` (registry consistency unit tests)
+
+#### Implementation files (M3-M4, 2 files)
+
+- `internal/cli/hybrid.go` (`moai hybrid` command + setup/status/tools subcommands)
+- `internal/llm/inject.go` (provider-agnostic env-injection helpers refactored from glm.go)
+
+### To-be-modified (~13 source-of-truth files + ~5 template mirrors)
+
+#### Go source (M2-M4, 5 files)
+
+- `internal/cli/cg.go` (REPLACE with BC stub returning `MOAI_CG_REMOVED`)
+- `internal/cli/glm.go` (lines 148-149 message + 218-348 generalize + 266 persistTeamMode + 356-385/520-581 delegate to internal/llm + 536-538 namespaced backup; preserve glmCmd, runGLM body)
+- `internal/cli/launcher.go` (line 40 comment + 57 case label + 185 persistTeamMode + 267 reset comment)
+- `internal/cli/update.go` (line ~1411 add migrateCGTeamMode helper)
+- `internal/config/types.go` (line 52-100 extend LLMConfig with Provider + Providers fields)
+- `internal/config/defaults.go` (add NewDefaultProvidersConfig)
+
+#### Project config (M2, 1 file + template mirror)
+
+- `.moai/config/sections/llm.yaml` (add `provider: ""` + `providers:` section)
+- `internal/template/templates/.moai/config/sections/llm.yaml` (mirror)
+
+#### Documentation skill/rule files (M5a-d, 4 files + template mirrors)
+
+- `.claude/skills/moai/team/glm.md` (lines 41, 50, 103, 127, 143: `moai cg` → `moai hybrid glm` 5 mentions)
+- `.claude/skills/moai/team/run.md` (lines 73, 88, 92, 103, 104: `moai cg` → `moai hybrid <provider>` 5 mentions)
+- `.claude/skills/moai/workflows/run.md:904` (`active_mode: cc | glm | cg` → `active_mode: cc | glm | hybrid`)
+- `.claude/rules/moai/development/model-policy.md:44` (`Activation: moai cg` → `Activation: moai hybrid <provider>`)
+- All four mirrored to `internal/template/templates/.claude/...`
+
+#### Project-root documentation (M5e-g, 3 files; not in template)
+
+- `CLAUDE.md §15` (rename `### CG Mode` heading to `### Hybrid Mode` + 4-provider generalization)
+- `CLAUDE.local.md §16 line 129` (`'moai cg'` → `'moai hybrid <provider>'` in runtime-managed list)
+- `CHANGELOG.md` (`## [Unreleased]` add `BC-V3R3-HYBRID-001` entry per spec.md §10.3)
+
+#### Embedded template parity
+
+- All edits to `.claude/skills/.claude/rules/.moai/config/` mirrored to `internal/template/templates/...` (per `CLAUDE.local.md §2 Template-First Rule HARD constraint`)
+
+---
+
+## Exclusions (Out of Scope — What NOT to Build)
+
+Per `spec.md` §1.2 Non-Goals + §2.2 Out of Scope:
+
+1. 구현 코드 (Go function body, type method body) — 본 SPEC은 plan-phase 산출물; 실제 구현은 `/moai run SPEC-V3R3-HYBRID-001` 단계.
+2. 5번째 LLM provider 추가 (allow-list는 4종 고정; v3R3 기간 동안 닫힌 집합) — REQ-HYBRID-002, REQ-HYBRID-017로 차단.
+3. Mainland China 전용 endpoint (예: `api.deepseek.com.cn`, `dashscope.cn-hangzhou.aliyuncs.com`) — 별도 SPEC에서 region-aware routing으로 처리.
+4. Web LLM API integration (Claude Code 외부에서 web UI로 LLM 호출) — `moai hybrid`는 Claude Code teammates의 CLI subagent context 한정.
+5. LLM provider별 native SDK 의존성 (e.g., `github.com/sashabaranov/go-openai`) — Anthropic-compat HTTP endpoint만 사용; provider별 native SDK 추가 금지.
+6. Multi-provider single-session routing (예: Claude leader + GLM analyst + Kimi tester 혼합) — 한 세션은 한 provider만 선택; 멀티-provider routing은 별도 SPEC.
+7. `moai cg` deprecation alias / soft warning 기간 — clean break (사용자 명시적 선택). `moai cg` 호출 시 즉시 BC 에러.
+8. Claude OAuth 토큰 / `~/.claude/` 인증 흐름 변경.
+9. `moai glm` (단일 LLM 모드), `moai cc` (Claude 전용 모드) 동작 변경 — 단일-LLM 모드는 그대로 유지 (REQ-HYBRID-006).
+10. `injectGLMEnvForTeam`의 `MOAI_BACKUP_AUTH_TOKEN` 백업 로직 변경 (provider 일반화 시 보존; namespaced 분리만 추가).
+11. Z.AI cache_control / prompt_caching 정책 변경 (`DISABLE_PROMPT_CACHING=1` 등) — SPEC-GLM-MCP-001 후속.
+12. LLM provider별 MCP 서버 통합 (Z.AI Vision/WebSearch 등) — SPEC-GLM-MCP-001 의존; REQ-HYBRID-016은 forward-looking surface stub만 정의.
+13. Provider별 동적 model alias (`kimi-k2-latest`, `deepseek-v3-latest`) — base SPEC date의 pinned baseline + `.moai/config/sections/llm.yaml` override 경로만 제공. Provider-side alias 자동 추적은 향후 SPEC.
+
+---
+
+End of spec-compact.md.

--- a/.moai/specs/SPEC-V3R3-HYBRID-001/spec.md
+++ b/.moai/specs/SPEC-V3R3-HYBRID-001/spec.md
@@ -1,0 +1,330 @@
+---
+id: SPEC-V3R3-HYBRID-001
+title: moai hybrid Multi-LLM Mode (cg deprecation + GLM/Kimi/DeepSeek/Qwen team support)
+version: "0.1.0"
+status: draft
+created_at: 2026-05-04
+updated_at: 2026-05-04
+author: MoAI Plan Workflow
+priority: P1
+labels: [hybrid, multi-llm, glm, kimi, deepseek, qwen, breaking-change, v3r3]
+issue_number: null
+phase: "v3.0.0 — Phase 7 — Multi-LLM Hybrid Mode"
+module: "internal/cli/, internal/llm/, .claude/skills/moai/workflows/, .moai/config/sections/llm.yaml"
+dependencies:
+  - SPEC-GLM-MCP-001
+related_theme: "Theme 7 — Cost Optimization + LLM Abstraction"
+breaking: true
+bc_id: [BC-V3R3-HYBRID-001]
+lifecycle: spec-anchored
+tags: "hybrid, multi-llm, cost-optimization, llm-abstraction, breaking, v3r3"
+---
+
+# SPEC-V3R3-HYBRID-001: `moai hybrid` Multi-LLM Mode
+
+## HISTORY
+
+| Version | Date       | Author              | Description                                                                                              |
+|---------|------------|---------------------|----------------------------------------------------------------------------------------------------------|
+| 0.1.0   | 2026-05-04 | MoAI Plan Workflow  | 최초 작성. `moai cg` 제거 + `moai hybrid` 도입 + 4 LLM provider (GLM/Kimi/DeepSeek/Qwen3-Coder) 1급 지원. BREAKING. |
+
+---
+
+## 1. Goal (목적)
+
+`moai cg` 명령(Claude leader + GLM teammates 코스트-최적화 모드)을 **clean-break 방식으로 제거**하고, 그 자리를 다중 LLM provider를 1급 시민으로 지원하는 **`moai hybrid`** 명령으로 대체한다. 사용자 의도 그대로:
+
+- **제거 대상**: `moai cg` (다음 major release에서 `BC-V3R3-HYBRID-001`로 즉시 폐기. deprecation alias 유지하지 않음.)
+- **신규 도입**: `moai hybrid [provider] [-p profile]` — Claude를 leader로 두고 teammates를 사용자가 선택한 team-LLM provider로 실행.
+- **1급 지원 4 LLM (allow-list, 닫힌 집합)**: GLM (Z.AI), Kimi K2 (Moonshot AI), DeepSeek V3+, Qwen3-Coder (Alibaba DashScope).
+- **유지**: `moai glm` (단일 LLM 모드), `moai cc` (Claude 전용 모드)는 그대로 남는다. `moai hybrid`는 이들의 **다중-LLM 슈퍼셋**이지, 대체가 아니다.
+
+### 1.1 배경
+
+R2 (2026-04 회고): `moai cg`는 v2.x 시리즈에서 "Claude + GLM 코스트 60-70% 절감 모드"로 도입되어 1년간 운영되었다. 그러나 (a) `cg`라는 이름이 GLM에 종속되어 다른 team-LLM provider (Kimi/DeepSeek/Qwen3) 등장 시 확장 불가, (b) `moai glm`과 `moai cg`의 역할 분리(`glm` = all-LLM, `cg` = hybrid)는 사용자에게 혼동, (c) provider별 환경변수 주입 로직(`injectGLMEnvForTeam` `internal/cli/glm.go:520`)이 GLM 전용으로 하드코딩되어 다중 provider 지원 시 대규모 분기를 유발한다. v3R3에서 multi-provider abstraction을 도입하는 시점에 `moai cg`를 제거하고 `moai hybrid` 단일 명령으로 통일하는 것이 가장 깨끗한 경로다.
+
+R3 (Z.AI/Anthropic-compat 검증 결과, research.md §3): GLM은 이미 Anthropic-compat endpoint (`https://api.z.ai/api/anthropic`)를 1급 제공한다. DeepSeek 또한 Anthropic-compat endpoint (`https://api.deepseek.com/anthropic`)를 v4 기준 정식 제공한다. Kimi와 Qwen3-Coder는 OpenAI-compat이 1차이며, Anthropic-compat은 (a) provider-side 정식 endpoint 또는 (b) 사용자가 운영하는 proxy/adapter (예: `moai hybrid kimi --proxy https://my-proxy/anthropic`)로 대응 가능하다. 본 SPEC은 4 provider를 모두 1급 시민으로 등록하되, **Anthropic-compat 가용성 검증 책임을 launch path에 이양**하여 endpoint 미가용 시 명확한 에러를 반환하도록 한다.
+
+### 1.2 비목표 (Non-Goals)
+
+- 5번째 LLM provider 추가 (allow-list는 4종 고정; v3R3 기간 동안 닫힌 집합)
+- `moai glm`, `moai cc` 제거 또는 동작 변경 (단일-LLM 모드는 그대로)
+- Claude OAuth 토큰 / `~/.claude/` 인증 흐름 변경
+- LLM provider별 SDK 신규 의존성 추가 (Anthropic-compat HTTP만 사용; `moai` Go 바이너리는 endpoint URL + env-var 주입만 담당)
+- Web LLM API integration (chat UI 내장 등) — `moai hybrid`는 Claude Code teammates용 CLI subagent 모드 한정
+- Mainland China 전용 endpoint (예: api.deepseek.com.cn, dashscope.cn-hangzhou.aliyuncs.com)는 본 SPEC에서 다루지 않음 (사용자 별도 SPEC에서 처리)
+- 동시 다중 provider 사용 (예: Claude leader + GLM analyst + Kimi tester를 한 세션에 혼합) — 한 세션은 한 provider만 선택; 멀티-provider 라우팅은 별도 SPEC
+- LLM provider별 cache_control / prompt_caching 활성화 정책 변경 (현행 `DISABLE_PROMPT_CACHING=1` 정책 유지; 변경은 SPEC-GLM-MCP-001 후속)
+- `moai cg` deprecation alias 유지 (clean break — 사용자 의도)
+
+---
+
+## 2. Scope (범위)
+
+### 2.1 In Scope
+
+- **Owns**:
+  - `internal/cli/cg.go`: 파일 삭제 또는 BC 에러 stub로 축소 (M3 결정).
+  - `internal/cli/hybrid.go` (신규): `moai hybrid` 명령 정의 + provider 라우팅.
+  - `internal/llm/provider.go` (신규): provider abstraction (`type Provider interface { Name() string; AnthropicBaseURL() string; DefaultModels() ModelSet; EnvSchema() []EnvKey }`).
+  - `internal/llm/providers/{glm,kimi,deepseek,qwen}.go` (신규 4 파일): provider별 메타데이터 정의 (base URL, latest stable model name, env var 이름).
+  - `internal/cli/launcher.go`: `case "claude_glm"` (line 57) → `case "claude_hybrid"`로 교체 + provider 인자 라우팅.
+  - `internal/cli/glm.go:218 enableTeamMode` → `enableHybridTeamMode(provider Provider)` 일반화 (GLM 하드코딩 분리).
+  - `.moai/config/sections/llm.yaml`: `provider: <glm|kimi|deepseek|qwen>` + `provider.<name>.{base_url, models.{high,medium,low}, env_var}` 섹션 추가.
+  - `internal/template/templates/.moai/config/sections/llm.yaml`: 위 스키마 미러 (Template-First HARD rule).
+  - 4 provider env-key registry: `~/.moai/.env.{glm,kimi,deepseek,qwen}` 파일 (기존 `.env.glm` 패턴 확장).
+  - `cmd/moai/main.go` 또는 `internal/cli/root.go`: `cgCmd` 등록 제거 + `hybridCmd` 등록 추가.
+- **Modifies (read-only references)**:
+  - `.claude/skills/moai/team/glm.md`: `moai cg` 언급(lines 41, 50, 103, 127, 143)을 `moai hybrid glm`으로 교체.
+  - `.claude/skills/moai/team/run.md`: line 73, 88, 92, 103, 104 — 동일 substitution.
+  - `.claude/skills/moai/workflows/run.md:904`: `active_mode: cc | glm | cg` → `cc | glm | hybrid`.
+  - `.claude/rules/moai/development/model-policy.md:44`: `Activation: moai cg` → `moai hybrid <provider>`.
+  - `CLAUDE.md §15 CG Mode`: 섹션 제목 `CG Mode` → `Hybrid Mode`로 변경 + 본문 4-provider 일반화.
+  - `CLAUDE.local.md §16` 등 `moai cg` 언급: 사용자 로컬 가이드는 보존하되 `moai hybrid glm`로 substitution 권장 주석 추가.
+- **CHANGELOG**: `BC-V3R3-HYBRID-001` 항목 (BREAKING CHANGE) + migration guide.
+- **Test surface**: `internal/cli/hybrid_test.go` (신규) + `internal/llm/provider_test.go` (신규) + `internal/cli/cg_removal_test.go` (`moai cg` 호출 시 BC 에러 메시지 반환 검증).
+
+### 2.2 Out of Scope (Exclusions — What NOT to Build)
+
+- 구현 코드 (Go function body, type method body) — 본 SPEC은 plan-phase 산출물; 실제 구현은 `/moai run SPEC-V3R3-HYBRID-001` 단계.
+- Mainland China 전용 endpoint (예: `api.deepseek.com.cn`, `dashscope.cn-hangzhou.aliyuncs.com`) — 별도 SPEC에서 region-aware routing으로 처리.
+- Web LLM API integration (Claude Code 외부에서 web UI로 LLM 호출) — `moai hybrid`는 Claude Code teammates의 CLI subagent context 한정. 웹 chat 통합은 본 SPEC 범위 밖.
+- 4-LLM allow-list 외 provider (예: Anthropic 자체, OpenAI gpt-X, Mistral, Cohere, xAI Grok 등) — v3R3 기간 동안 닫힌 집합 유지. 5번째 provider 추가는 atomic-reversal SPEC (REQ-WF005-012 패턴 차용) 필요.
+- LLM provider별 SDK 의존성 (e.g., `github.com/sashabaranov/go-openai`) — Anthropic-compat HTTP endpoint만 사용; provider별 native SDK 추가 금지.
+- Multi-provider single-session routing (예: Claude leader + GLM analyst + Kimi tester 혼합) — 한 세션은 한 provider만 선택; 멀티-provider routing은 별도 SPEC.
+- `moai cg` deprecation alias / soft warning 기간 — clean break (사용자 명시적 선택). `moai cg` 호출 시 즉시 BC 에러.
+- Claude OAuth 토큰 / `~/.claude/` 인증 흐름 변경.
+- `injectGLMEnvForTeam`의 `MOAI_BACKUP_AUTH_TOKEN` 백업 로직 변경 (provider 일반화 시 보존).
+- Z.AI cache_control 정책 변경 (`DISABLE_PROMPT_CACHING=1` 등) — SPEC-GLM-MCP-001 후속.
+- LLM provider별 MCP 서버 통합 (Z.AI Vision/WebSearch 등) — SPEC-GLM-MCP-001 의존.
+- Provider별 동적 model alias (`kimi-k2-latest`, `deepseek-v3-latest`) — base SPEC date의 pinned baseline + `.moai/config/sections/llm.yaml` override 경로만 제공. Provider-side alias 자동 추적은 향후 SPEC.
+
+---
+
+## 3. Environment (환경)
+
+- 런타임: Go 1.23+, Cobra CLI, Anthropic-compat HTTP endpoint.
+- 영향 디렉터리:
+  - 신규: `internal/cli/hybrid.go`, `internal/llm/provider.go`, `internal/llm/providers/{glm,kimi,deepseek,qwen}.go`.
+  - 수정: `internal/cli/launcher.go`, `internal/cli/glm.go`, `internal/cli/root.go` (or cobra root), `.moai/config/sections/llm.yaml`, `internal/template/templates/.moai/config/sections/llm.yaml`, CLAUDE.md, `.claude/skills/moai/{team/glm.md, team/run.md, workflows/run.md}`, `.claude/rules/moai/development/model-policy.md`.
+  - 삭제: `internal/cli/cg.go` (M3 결정에 따라 BC stub로 축소 가능).
+- 외부 endpoints (research.md §3 검증 결과):
+  - GLM: `https://api.z.ai/api/anthropic` (verified 2026-05-04, Anthropic-compat 1급).
+  - Kimi: Anthropic-compat endpoint **사용자 검증 대기** — 후보 `https://api.moonshot.ai/anthropic` (확인 안 됨); fallback `--proxy <user-supplied>` 옵션 제공.
+  - DeepSeek: `https://api.deepseek.com/anthropic` (verified 2026-05-04, Anthropic-compat 1급).
+  - Qwen3-Coder: Anthropic-compat endpoint **사용자 검증 대기** — DashScope 공식 docs (Aliyun Bailian) WebFetch 실패 (404 / loading shell); fallback `--proxy` 옵션 제공.
+- 외부 레퍼런스: `internal/cli/cg.go:1-58`, `internal/cli/glm.go:21-943`, `internal/cli/launcher.go:21-280` (모드 라우팅), `internal/config/types.go:52-100` (LLMConfig struct), CLAUDE.md §15, CLAUDE.local.md §16.
+
+---
+
+## 4. Assumptions (가정)
+
+- `moai cg`는 v2.x 시리즈에서 1년간 안정 운영되었으나 사용자 베이스가 작아 (CG 모드 활성 사용자 ≤ 50명 추정) clean-break의 마이그레이션 부담이 제한적이다.
+- GLM/DeepSeek Anthropic-compat endpoint는 향후 1년 지속 (provider commitment 관찰 결과).
+- Kimi와 Qwen3-Coder의 Anthropic-compat은 (a) provider-side 공식 endpoint 또는 (b) `moai hybrid <provider> --proxy <url>` 옵션으로 대응. (a)가 미가용일 때 명확한 에러 메시지 반환.
+- 사용자가 `~/.moai/.env.{glm,kimi,deepseek,qwen}` 파일에 provider별 API 키를 분리 저장한다 (`moai hybrid setup <provider>` subcommand로 wrapper 제공).
+- `injectGLMEnvForTeam`의 tmux session-level env-var 주입 패턴은 provider-agnostic으로 일반화 가능하다 (env-key 이름만 provider별 차별화: `ANTHROPIC_AUTH_TOKEN`은 모든 provider 공통; `ANTHROPIC_BASE_URL`은 provider별 차별).
+- `.moai/config/sections/llm.yaml`의 `team_mode: "cg"` 기록을 가진 기존 사용자 프로젝트는 `moai update` cleanup phase에서 `team_mode: "hybrid"` + `provider: "glm"`으로 자동 마이그레이션된다 (REQ-HYBRID-014).
+- `moai cg` 호출 시 반환되는 BC 에러는 사용자가 즉시 새 명령(`moai hybrid glm`)을 인지할 수 있도록 actionable suggestion을 포함한다.
+- 4 provider의 latest stable model 이름은 SPEC date(2026-05-04) 기준으로 pinned: GLM-4.7, Kimi K2.6, DeepSeek-V4, Qwen3-Coder Plus (research.md §3 검증; pinned baseline은 v3R3 기간 동안 유효; `.moai/config/sections/llm.yaml`로 사용자 override 가능).
+
+---
+
+## 5. Requirements (EARS 요구사항)
+
+### 5.1 Ubiquitous Requirements
+
+**REQ-HYBRID-001**
+The MoAI CLI **shall** expose `moai hybrid <provider> [-p profile] [-- claude-args...]` as the canonical command for Claude-leader + team-LLM-teammates hybrid execution.
+
+**REQ-HYBRID-002**
+The MoAI CLI **shall** accept exactly four `<provider>` values: `glm`, `kimi`, `deepseek`, `qwen`. Any other value **shall** be rejected with `UNKNOWN_PROVIDER` and the error message **shall** list the four allowed values.
+
+**REQ-HYBRID-003**
+The MoAI CLI **shall** delete or reduce `internal/cli/cg.go` such that invoking `moai cg [args...]` returns a BC error with sentinel `MOAI_CG_REMOVED` and an actionable migration suggestion (`use 'moai hybrid glm' instead`).
+
+**REQ-HYBRID-004**
+The MoAI configuration schema (`.moai/config/sections/llm.yaml`) **shall** include a top-level `provider` key (string, one of the four allow-list values, scalar active provider) and a `providers.<name>.{base_url, models.{high,medium,low}, env_var}` sub-section per allow-list provider (plural map container).
+
+**REQ-HYBRID-005**
+The 4 LLM providers **shall** be pinned at SPEC creation date (2026-05-04) to verified-stable model names: GLM-4.7, Kimi K2.6, DeepSeek-V4, Qwen3-Coder Plus (per research.md §3). User overrides via `.moai/config/sections/llm.yaml` `provider.<name>.models` sub-fields are permitted.
+
+**REQ-HYBRID-006**
+The MoAI CLI **shall** preserve `moai glm` (single-LLM all-GLM mode) and `moai cc` (Claude-only mode) without behavioral change. `moai hybrid` **shall** be the multi-LLM superset, not a replacement of these.
+
+### 5.2 Event-Driven Requirements
+
+**REQ-HYBRID-007**
+**When** the user invokes `moai hybrid <provider>`, the CLI **shall**: (a) load `~/.moai/.env.<provider>` for the API key, (b) inject `ANTHROPIC_AUTH_TOKEN` and `ANTHROPIC_BASE_URL` into the active tmux session, (c) write `provider: "<name>"` and `team_mode: "hybrid"` to `.moai/config/sections/llm.yaml`, (d) launch Claude Code via `unifiedLaunch(profileName, "claude_hybrid", filteredArgs)`.
+
+**REQ-HYBRID-008**
+**When** the user invokes `moai hybrid <provider>` outside a tmux session, the CLI **shall** reject with `HYBRID_REQUIRES_TMUX` and provide the recovery path: `tmux new -s moai && moai hybrid <provider>`.
+
+**REQ-HYBRID-009**
+**When** the user invokes `moai hybrid <provider>` and `~/.moai/.env.<provider>` does not exist or is empty, the CLI **shall** reject with `HYBRID_MISSING_API_KEY` and instruct: `moai hybrid setup <provider> <api-key>`.
+
+**REQ-HYBRID-010**
+**When** the user invokes `moai cg [args...]`, the CLI **shall** print the BC error and exit with non-zero status; **shall not** attempt to launch Claude Code.
+
+**REQ-HYBRID-011**
+**When** the user invokes `moai update` against a project whose `.moai/config/sections/llm.yaml` contains `team_mode: "cg"`, the CLI cleanup phase **shall** rewrite to `team_mode: "hybrid"` + `provider: "glm"` and emit a one-time migration notice.
+
+### 5.3 State-Driven Requirements
+
+**REQ-HYBRID-012**
+**While** `team_mode: "hybrid"` is active and `provider: "<name>"` is set, the active LLM provider **shall** be `<name>` and Claude Code teammates **shall** observe `ANTHROPIC_BASE_URL` pointing to that provider's Anthropic-compat endpoint.
+
+**REQ-HYBRID-013**
+**While** the user is on `moai hybrid <provider>` and the provider's Anthropic-compat endpoint is unreachable, the launch path **shall** propagate the underlying HTTP error and **shall not** silently fall back to a different provider.
+
+**REQ-HYBRID-014**
+**While** `BC-V3R3-HYBRID-001` is active in CHANGELOG, `moai cg` **shall** remain present in the binary as a BC stub returning `MOAI_CG_REMOVED`; `moai cg` **shall not** be silently absent (cobra "unknown command" error is insufficient).
+
+### 5.4 Optional Requirements
+
+**REQ-HYBRID-015**
+**Where** the provider's Anthropic-compat endpoint is not yet officially available (Kimi, Qwen3-Coder per research.md §3 pending verification), the user **shall** be able to supply `--proxy <url>` to override `ANTHROPIC_BASE_URL` at launch time.
+
+**REQ-HYBRID-016**
+**Where** the user wants per-provider tools toggle (e.g., enabling Z.AI Vision MCP for `glm` only — depends on SPEC-GLM-MCP-001), the CLI **shall** support `moai hybrid <provider> tools enable|disable` as a forward-looking subcommand surface.
+
+### 5.5 Complex Requirements (Unwanted Behavior / Composite)
+
+**REQ-HYBRID-017 (Unwanted Behavior)**
+**If** a future PR proposes a 5th provider (e.g., `mistral`, `cohere`, `xai-grok`), **then** CI **shall** reject with `PROVIDER_ALLOWLIST_VIOLATION` per the closed-set rule (REQ-HYBRID-002). Reversal requires a new SPEC with atomic-migration semantics.
+
+**REQ-HYBRID-018 (Complex: Auth Failure)**
+**While** `moai hybrid <provider>` is launching, **when** the provider returns HTTP 401/403 (auth failure), the CLI **shall** mask the API key in any error message (per `maskAPIKey` `internal/cli/glm.go:208`) and emit `HYBRID_AUTH_FAILED` with a hint to verify the key via `moai hybrid status <provider>`.
+
+---
+
+## 6. Acceptance Criteria (수용 기준 요약)
+
+- **AC-HYBRID-01** (REQ-HYBRID-001): Given a user runs `moai hybrid --help` When the help output is rendered Then the synopsis line `moai hybrid <provider> [-p profile]` appears and the description names the four allow-list providers.
+- **AC-HYBRID-02** (REQ-HYBRID-002): Given a user runs `moai hybrid mistral` When the CLI parses arguments Then exit code is non-zero and stderr contains `UNKNOWN_PROVIDER` plus the four allowed values.
+- **AC-HYBRID-03** (REQ-HYBRID-003, REQ-HYBRID-010, REQ-HYBRID-014): Given a user runs `moai cg` after upgrade When the CLI executes Then exit code is non-zero and stderr contains `MOAI_CG_REMOVED` and `use 'moai hybrid glm' instead`.
+- **AC-HYBRID-04** (REQ-HYBRID-004): Given the embedded template `.moai/config/sections/llm.yaml` When parsed Then it contains a top-level `provider:` key (default empty string) and `provider.<name>.{base_url, models.high, models.medium, models.low, env_var}` for all four providers.
+- **AC-HYBRID-05** (REQ-HYBRID-005): Given the embedded template When `provider.glm.models.high`, `provider.kimi.models.high`, `provider.deepseek.models.high`, `provider.qwen.models.high` are read Then the values match the SPEC-pinned baselines (GLM-4.7, Kimi K2.6, DeepSeek-V4, Qwen3-Coder Plus or equivalent — see research.md §3).
+- **AC-HYBRID-06** (REQ-HYBRID-006): Given a user runs `moai glm` and `moai cc` after upgrade When the binaries execute Then both produce the v2.x baseline behavior (no functional regression).
+- **AC-HYBRID-07** (REQ-HYBRID-007): Given a user inside a tmux session runs `moai hybrid glm` with `~/.moai/.env.glm` populated When the launch completes Then `tmux show-environment | grep ANTHROPIC_BASE_URL` returns the GLM endpoint and `.moai/config/sections/llm.yaml` shows `team_mode: "hybrid"` + `provider: "glm"`.
+- **AC-HYBRID-08** (REQ-HYBRID-008): Given a user outside tmux runs `moai hybrid kimi` When the CLI executes Then exit code is non-zero and stderr contains `HYBRID_REQUIRES_TMUX` plus the recovery path.
+- **AC-HYBRID-09** (REQ-HYBRID-009): Given a user inside tmux runs `moai hybrid deepseek` and `~/.moai/.env.deepseek` is missing When the CLI executes Then exit code is non-zero and stderr contains `HYBRID_MISSING_API_KEY` plus `moai hybrid setup deepseek`.
+- **AC-HYBRID-10** (REQ-HYBRID-011): Given a project with `team_mode: "cg"` in `.moai/config/sections/llm.yaml` When `moai update` runs Then post-update the file contains `team_mode: "hybrid"` and `provider: "glm"` and stderr emits a one-time migration notice.
+- **AC-HYBRID-11** (REQ-HYBRID-012): Given `moai hybrid qwen` succeeds When a Claude Code teammate launches in a new tmux pane Then `env | grep ANTHROPIC_BASE_URL` returns the Qwen endpoint (or proxy URL if --proxy was used).
+- **AC-HYBRID-12** (REQ-HYBRID-013): Given the GLM endpoint is unreachable (simulated via DNS block) When `moai hybrid glm` launches Then the underlying HTTP error is propagated to stderr and the CLI does NOT silently fall back to Kimi/DeepSeek/Qwen.
+- **AC-HYBRID-13** (REQ-HYBRID-015): Given a user runs `moai hybrid kimi --proxy https://my-proxy/anthropic` When the launch completes Then `ANTHROPIC_BASE_URL` is set to `https://my-proxy/anthropic` (overriding the provider default).
+- **AC-HYBRID-14** (REQ-HYBRID-016): Given a user runs `moai hybrid glm tools --help` When the help output is rendered Then it lists `enable` and `disable` subcommand stubs (forward-looking surface; full implementation deferred to SPEC-GLM-MCP-001).
+- **AC-HYBRID-15** (REQ-HYBRID-017): Given a PR adding `internal/llm/providers/mistral.go` to the codebase When CI runs Then the test `TestProviderAllowlist` fails with `PROVIDER_ALLOWLIST_VIOLATION` referencing the four allowed providers.
+- **AC-HYBRID-16** (REQ-HYBRID-018): Given `moai hybrid glm` is launching and the API key is invalid When the provider returns HTTP 401 Then stderr contains `HYBRID_AUTH_FAILED` and the API key in the error message is masked (e.g., `sk-x****wxyz`, never the full key).
+- **AC-HYBRID-17** (REQ-HYBRID-005, REQ-HYBRID-014): Given an upgraded user re-runs the same workflow that previously used `moai cg` When `moai hybrid glm` is invoked Then the resulting tmux env-vars and settings.local.json `teammateMode: "tmux"` match the v2.x `moai cg` behavior bit-for-bit (no regression).
+- **AC-HYBRID-18** (REQ-HYBRID-002, REQ-HYBRID-017): Given the `internal/llm/providers/registry.go` (or equivalent) When inspected by static analysis or unit test Then exactly four provider entries are present (`glm`, `kimi`, `deepseek`, `qwen`) and no five-provider configuration loads at runtime.
+
+---
+
+## 7. Constraints (제약)
+
+- 16-language neutrality (CLAUDE.local.md §15): provider 이름은 모두 lowercase ASCII, 다국어 번역 이름은 `.claude/skills/moai/team/glm.md` 등 사용자 문서에서만 가능.
+- Template-First HARD rule (CLAUDE.local.md §2): `.moai/config/sections/llm.yaml` 변경은 `internal/template/templates/.moai/config/sections/llm.yaml` mirror + `make build` 필수.
+- v3R3 시리즈 BC 가시성: 모든 BREAKING CHANGE는 `bc_id` (`BC-V3R3-HYBRID-001`)로 추적되며 CHANGELOG 명시 + migration guide 필수.
+- 9-direct-dep 정책: SPEC-GLM-MCP-001을 직접 dependency로 선언; provider별 native SDK 의존성 추가 금지 (Anthropic-compat HTTP만).
+- tmux-first: hybrid 모드는 tmux session-level env isolation에 의존 (현행 `cg` 모드와 동일한 architectural choice).
+- API-key 보안: provider 키는 절대 stdout/stderr에 plain-text로 출력 금지 (현행 `maskAPIKey` `internal/cli/glm.go:208` 패턴 일반화).
+
+---
+
+## 8. Risks & Mitigations (리스크 및 완화)
+
+| 리스크 | 영향 | 확률 | 완화 |
+|---|---|---|---|
+| `moai cg` 사용자(추정 ≤ 50명)가 upgrade 후 명령 부재로 워크플로 중단 | M | M | clean-break + BC stub로 즉시 actionable 에러 메시지 (`use 'moai hybrid glm' instead`); CHANGELOG `BC-V3R3-HYBRID-001` 명시 + docs-site 업데이트 |
+| Kimi, Qwen3 Anthropic-compat endpoint가 provider-side에서 정식 출시되지 않은 상태 | M | M | `--proxy <url>` 옵션 (REQ-HYBRID-015)으로 사용자 운영 proxy 허용; provider 등록은 1급으로 유지하되 launch 시 endpoint 미가용 → 명확한 에러 |
+| 4 provider의 latest model 이름이 SPEC date 이후 변경 (e.g., GLM-4.8, Kimi K3 출시) | M | H | `.moai/config/sections/llm.yaml`로 사용자 override 경로 제공 (REQ-HYBRID-005); SPEC-pinned baseline은 v3R3 기간 동안 유효 마감 |
+| 기존 `team_mode: "cg"` config를 가진 사용자 프로젝트가 `moai update` 미실행 상태에서 `moai hybrid` 호출 | L | M | REQ-HYBRID-011 자동 마이그레이션 + REQ-HYBRID-014 BC stub로 `moai cg` 호출 또한 차단 — 양방향 안전망 |
+| provider-별 env-var 주입 시 `MOAI_BACKUP_AUTH_TOKEN` 백업 로직이 다중 provider 전환 시 깨짐 (e.g., GLM → Kimi 전환 시 GLM 키가 deepseek 백업으로 잘못 저장) | M | M | provider-별로 백업 키 namespace 분리 (`MOAI_BACKUP_AUTH_TOKEN_<provider_uppercase>`); 단일 백업 슬롯 패턴 deprecate |
+| Template-First mirror 누락 → `internal/template/embedded.go` regenerate 실패 | H | L | M2/M3/M4 각 milestone 종료 시 `make build` 강제 + CI에서 embedded FS 동기화 검증 |
+| Anthropic-compat endpoint 미가용 시 Claude Code가 cryptic error 반환 (e.g., "context window exceeded" misreport) | M | M | launch 직전 health check (`HEAD <base_url>/v1/messages` 또는 GET 인증 endpoint) 실행 옵션 (REQ-HYBRID-013); 미구현 시 사용자 의식적 trade-off |
+| 4 provider별 model-tier 매핑(high/medium/low) 의미가 provider마다 상이 → cost-optimization 효과 불확실 | L | H | `.moai/config/sections/llm.yaml`의 `models.{high,medium,low}` 사용자 직접 override 권장; SPEC-pinned baseline은 provider docs 기준 best-fit |
+| `moai cg` BC stub이 단순 cobra "unknown command" 으로 fallback 시 actionable 메시지 사라짐 | L | M | REQ-HYBRID-014 명시: `cgCmd`는 binary에 stub로 보존 (RunE에서 즉시 BC 에러 + 비-zero exit). 단순 삭제 금지 |
+| docs-site 4개국어 동기화 누락 (CLAUDE.local.md §17) | M | M | sync-phase에서 manager-docs가 ko/en/zh/ja 4 locale 모두 업데이트; CI script `docs-i18n-check.sh` 검증 |
+
+---
+
+## 9. Dependencies (의존성)
+
+### 9.1 Blocked by
+
+- **SPEC-GLM-MCP-001** (PR #769 OPEN): Z.AI MCP 서버 통합. 본 SPEC의 REQ-HYBRID-016 `tools enable|disable` subcommand surface는 SPEC-GLM-MCP-001 implementation에 위임. 본 SPEC은 forward-looking surface만 정의; 실제 MCP attach 로직은 GLM-MCP-001 후속 PR에서.
+
+### 9.2 Blocks
+
+- 향후 Mainland China region SPEC (region-aware routing for `api.deepseek.com.cn`, `dashscope.cn-hangzhou.aliyuncs.com`) — 본 SPEC의 provider abstraction을 base로 사용.
+- 향후 Multi-provider single-session SPEC (Claude leader + GLM analyst + Kimi tester 혼합) — 본 SPEC의 provider registry를 base로.
+
+### 9.3 Related
+
+- SPEC-V3R3-UPDATE-CLEANUP-001 (PR #764 merged): `moai update` cleanup phase가 본 SPEC의 REQ-HYBRID-011 자동 마이그레이션을 실행할 인프라를 이미 제공한다.
+- SPEC-V3R2-WF-005 (PR #768 merged): 16-language neutrality 패턴을 provider neutrality에도 차용 (provider 4종 동등 취급, 어느 provider도 "primary" 라벨 금지).
+
+---
+
+## 10. BC Migration (Breaking Change 처리)
+
+### 10.1 BC ID
+
+- **BC-V3R3-HYBRID-001**: `moai cg` 명령 제거 + `moai hybrid <provider>` 도입.
+
+### 10.2 Migration Path
+
+| Before (v2.x) | After (v3R3) |
+|---|---|
+| `moai glm setup sk-xxx` | `moai hybrid setup glm sk-xxx` (구 `moai glm setup`도 alias로 1년간 유지) |
+| `moai cg` | `moai hybrid glm` |
+| `moai cg -p work` | `moai hybrid glm -p work` |
+| `.moai/config/sections/llm.yaml: team_mode: "cg"` | `.moai/config/sections/llm.yaml: team_mode: "hybrid"` + `provider: "glm"` (자동 마이그레이션 by REQ-HYBRID-011) |
+
+### 10.3 CHANGELOG Wording (proposed)
+
+```markdown
+## [Unreleased]
+
+### Breaking Changes
+
+- **BC-V3R3-HYBRID-001 (SPEC-V3R3-HYBRID-001)**: Removed `moai cg` (Claude + GLM hybrid) and replaced it with `moai hybrid <provider>`, which now supports four team-LLM providers as first-class citizens: GLM (Z.AI), Kimi K2 (Moonshot AI), DeepSeek V4 (DeepSeek), and Qwen3-Coder (Alibaba DashScope).
+  - `moai cg` invocations after upgrade return `MOAI_CG_REMOVED` with an actionable migration suggestion (`use 'moai hybrid glm' instead`).
+  - Existing projects with `team_mode: "cg"` in `.moai/config/sections/llm.yaml` are auto-migrated to `team_mode: "hybrid"` + `provider: "glm"` on the next `moai update` run.
+  - `moai glm` (single-LLM all-GLM mode) and `moai cc` (Claude-only mode) remain unchanged.
+  - See SPEC-V3R3-HYBRID-001 §10 BC Migration for full migration table.
+```
+
+### 10.4 Documentation Touch Points
+
+- `CLAUDE.md §15`: 섹션 제목 `CG Mode` → `Hybrid Mode` + 본문 4-provider 일반화.
+- `CLAUDE.local.md §16` (사용자 로컬 가이드): 보존하되 `moai cg` 언급 옆에 `→ moai hybrid glm` substitution 주석.
+- `docs-site` 4개국어 (ko/en/zh/ja): hybrid 모드 사용 가이드 + BC 마이그레이션 페이지 신설 (CLAUDE.local.md §17 4-locale 동기화 의무).
+- `.claude/skills/moai/team/glm.md`: file 자체는 보존 (GLM 전용 사용 사례 가이드 역할 유지)하되 `moai cg` 명령은 `moai hybrid glm`으로 substitution.
+
+### 10.5 Removal Timeline
+
+- v3R3 시리즈 첫 minor release: `moai cg` 즉시 BC stub로 축소 (clean break, deprecation alias 없음).
+- BC stub은 v3R4 시리즈 종료까지 유지 (`MOAI_CG_REMOVED` 에러 메시지 제공) → v3R5에서 cobra root에서 완전 제거 검토 (별도 cleanup SPEC).
+
+---
+
+## 11. Traceability (추적성)
+
+- REQ 총 18개: Ubiquitous 6, Event-Driven 5, State-Driven 3, Optional 2, Complex 2.
+- AC 총 18개, 모든 REQ에 최소 1개 AC 매핑 (100% 커버리지) — 매트릭스는 plan.md §1.4 참조.
+- 4 LLM provider 검증: research.md §3 (GLM/DeepSeek 검증 완료, Kimi/Qwen3 사용자 검증 대기).
+- BC 영향: `BC-V3R3-HYBRID-001` 1건 (clean break, deprecation alias 없음).
+- 의존성: SPEC-GLM-MCP-001 (PR #769 OPEN, plan-only) 1건.
+- 구현 경로 예상:
+  - 신규 4 provider 메타데이터 파일 (`internal/llm/providers/{glm,kimi,deepseek,qwen}.go`)
+  - `internal/cli/cg.go` BC stub 변경
+  - `internal/cli/launcher.go` `claude_glm` → `claude_hybrid` 라우팅 일반화
+  - `.moai/config/sections/llm.yaml` 스키마 확장
+  - 6 .claude/skills/.claude/rules 문서 substitution (~10 mention)
+  - CHANGELOG `BC-V3R3-HYBRID-001` 항목
+
+---
+
+End of SPEC.

--- a/.moai/specs/SPEC-V3R3-HYBRID-001/tasks.md
+++ b/.moai/specs/SPEC-V3R3-HYBRID-001/tasks.md
@@ -1,0 +1,283 @@
+# SPEC-V3R3-HYBRID-001 Task Breakdown
+
+> Granular task decomposition of M1-M5 milestones from `plan.md` §2.
+> Companion to `spec.md` v0.1.0, `research.md` v0.1.0, `plan.md` v0.1.0, `acceptance.md` v0.1.0.
+
+## HISTORY
+
+| Version | Date       | Author                            | Description                                                                  |
+|---------|------------|-----------------------------------|------------------------------------------------------------------------------|
+| 0.1.0   | 2026-05-04 | MoAI Plan Workflow (Phase 1B)     | 최초 작성 — 36 tasks (T-HYBRID-01..36) across M1-M5 (RED → GREEN x3 → REFACTOR) |
+
+---
+
+## Task ID Convention
+
+- ID format: `T-HYBRID-NN` (zero-padded 2 자리)
+- Priority: P0 (blocker), P1 (required), P2 (recommended), P3 (optional)
+- Owner role: `manager-tdd` (TDD gate verification), `manager-docs` (documentation), `expert-backend` (Go 구현 + test), `manager-git` (commit/PR boundary)
+- Dependencies: explicit task ID list; tasks with no deps may run in parallel within their milestone
+- TDD alignment: per `.moai/config/sections/quality.yaml` `development_mode: tdd`, M1 (RED) precedes M2-M4 (GREEN) → M5 (REFACTOR + Trackable)
+
+[HARD] No time estimates per `.claude/rules/moai/core/agent-common-protocol.md` §Time Estimation. Priority + dependencies only.
+
+---
+
+## M1: Test Scaffolding (RED phase) — Priority P0
+
+Goal: Create 4 audit/integration test files that fail until M2-M4 implementation lands. Per `spec-workflow.md` TDD: write failing test first.
+
+Reference template: `internal/template/lang_boundary_audit_test.go` (SPEC-V3R2-WF-005 M1 패턴), `internal/cli/glm_test.go` (existing test 패턴).
+
+| ID | Subject | Owner role | File:line target | Dependency | Touch points | TDD alignment |
+|----|---------|------------|-------------------|------------|--------------|---------------|
+| T-HYBRID-01 | Create `internal/template/provider_allowlist_audit_test.go` skeleton (package, imports, embedded FS access). Sentinel string definition (`PROVIDER_ALLOWLIST_VIOLATION`). | expert-backend | `internal/template/provider_allowlist_audit_test.go` (NEW, ~20 LOC scaffold) | none | 1 file (create) | RED setup |
+| T-HYBRID-02 | Implement `TestProviderAllowlist` walking `internal/llm/providers/` directory in embedded FS, asserting exactly 4 `.go` files (excluding `_test.go`) named `glm.go`, `kimi.go`, `deepseek.go`, `qwen.go`. On 5th file: `t.Errorf("PROVIDER_ALLOWLIST_VIOLATION: %s exists; v3R3 allow-list closed at four", path)`. | expert-backend | `internal/template/provider_allowlist_audit_test.go` (test func, ~40 LOC) | T-HYBRID-01 | 1 file (extend) | RED — must compile and FAIL initially (no `internal/llm/providers/` directory yet) |
+| T-HYBRID-03 | Create `internal/cli/cg_removal_test.go` with three sub-tests: `TestCGCommandReturnsBCError` (assert non-zero exit + `MOAI_CG_REMOVED` + `use 'moai hybrid glm' instead` in stderr), `TestCGCommandIsRegistered` (assert `cgCmd` still registered to rootCmd as BC stub), `TestCGCommandDoesNotLaunchClaudeCode` (assert `unifiedLaunchFunc` not called by runCG). | expert-backend | `internal/cli/cg_removal_test.go` (NEW, ~80 LOC) | T-HYBRID-01 | 1 file (create) | RED — must compile and FAIL initially (current `runCG` launches Claude Code, no BC stub yet) |
+| T-HYBRID-04 | Create `internal/cli/hybrid_test.go` with seven integration sub-tests: `TestHybridHelpListsFourProviders`, `TestHybridUnknownProviderRejected`, `TestHybridRequiresTmux`, `TestHybridMissingAPIKey`, `TestHybridProxyOverride`, `TestHybridAuthFailureMasksKey`, `TestHybridBackwardCompatWithCG`. Each test scaffolded per acceptance.md §AC-HYBRID-01..02, 07..09, 13, 16, 17 G/W/T. | expert-backend | `internal/cli/hybrid_test.go` (NEW, ~250 LOC scaffold) | T-HYBRID-01 | 1 file (create) | RED — must compile and FAIL initially (no `hybridCmd`, no `internal/llm/` package yet) |
+| T-HYBRID-05 | Create `internal/cli/migration_test.go` with two sub-tests: `TestMigrateCGTeamMode` (setup tmpdir with `team_mode: "cg"` config, invoke `migrateCGTeamMode(root)`, assert post-call `team_mode: "hybrid"` + `provider: "glm"` + stderr emits one-time notice), `TestMigrateCGTeamModeIdempotent` (run twice, assert second run is no-op). | expert-backend | `internal/cli/migration_test.go` (NEW, ~80 LOC) | T-HYBRID-01 | 1 file (create) | RED — must compile and FAIL initially (no `migrateCGTeamMode` helper yet) |
+| T-HYBRID-06 | Run `go test ./internal/template/ -run TestProviderAllowlist` and `go test ./internal/cli/ -run "TestCG|TestHybrid|TestMigrate"` — confirm RED state for ALL new tests. Confirm existing tests (`glm_test.go`, `launcher_test.go`, `update_test.go`) GREEN unaffected. | manager-tdd | n/a (verification only) | T-HYBRID-02, T-HYBRID-03, T-HYBRID-04, T-HYBRID-05 | 0 files | RED gate verification |
+
+[HARD] No implementation code in M1 outside of test files. Test failures must reference exact file/function names so subsequent milestones know where to implement.
+
+[HARD] M1 must complete before M2 begins (TDD discipline).
+
+**M1 priority: P0** — blocks all subsequent milestones.
+
+---
+
+## M2: Provider Abstraction Layer (GREEN, part 1) — Priority P0
+
+Goal: Make `TestProviderAllowlist` GREEN. Establish `internal/llm/` package + 4 provider metadata + LLMConfig schema extension.
+
+Reference: plan.md §2 M2, §3.2 to-be-created files.
+
+| ID | Subject | Owner role | File:line target | Dependency | Touch points | TDD alignment |
+|----|---------|------------|-------------------|------------|--------------|---------------|
+| T-HYBRID-07 | Create `internal/llm/provider.go` defining `Provider` interface (`Name()`, `AnthropicBaseURL()`, `EnvKeyName()`, `DefaultModels()`, `BuildEnvVars(apiKey)`, `ProxyOverride(proxyURL)`) + `ModelSet` struct (`High`, `Medium`, `Low`). MX:NOTE tag per plan.md §6.2. | expert-backend | `internal/llm/provider.go` (NEW, ~60 LOC) | T-HYBRID-06 | 1 file (create) | GREEN |
+| T-HYBRID-08 | Create `internal/llm/providers/glm.go` defining `GLMProvider` struct implementing `Provider` interface. base_url `https://api.z.ai/api/anthropic`, models `{glm-4.7, glm-4.7, glm-4.5-air}`, env_var `GLM_API_KEY`. `BuildEnvVars` includes Z.AI compat flags (`DISABLE_PROMPT_CACHING=1`) per research.md §5.2. | expert-backend | `internal/llm/providers/glm.go` (NEW, ~60 LOC) | T-HYBRID-07 | 1 file (create) | GREEN |
+| T-HYBRID-09 | Create `internal/llm/providers/kimi.go` defining `KimiProvider`. base_url candidate `https://api.moonshot.ai/anthropic` (research.md §3.2 pending), models `{kimi-k2.6, kimi-k2.6, kimi-k2-flash}`, env_var `KIMI_API_KEY`. MX:WARN tag for pending endpoint per plan.md §6.3. | expert-backend | `internal/llm/providers/kimi.go` (NEW, ~60 LOC) | T-HYBRID-07 | 1 file (create) | GREEN |
+| T-HYBRID-10 | Create `internal/llm/providers/deepseek.go` defining `DeepSeekProvider`. base_url `https://api.deepseek.com/anthropic` (verified), models `{deepseek-v4-pro, deepseek-v4-pro, deepseek-v4-flash}`, env_var `DEEPSEEK_API_KEY`. | expert-backend | `internal/llm/providers/deepseek.go` (NEW, ~60 LOC) | T-HYBRID-07 | 1 file (create) | GREEN |
+| T-HYBRID-11 | Create `internal/llm/providers/qwen.go` defining `QwenProvider`. base_url candidate `https://dashscope.aliyuncs.com/compatible-mode/anthropic` (research.md §3.4 pending), models `{qwen3-coder-plus, qwen3-coder-plus, qwen3-coder-flash}`, env_var `DASHSCOPE_API_KEY`. MX:WARN tag for pending endpoint. | expert-backend | `internal/llm/providers/qwen.go` (NEW, ~60 LOC) | T-HYBRID-07 | 1 file (create) | GREEN |
+| T-HYBRID-12 | Create `internal/llm/providers/registry.go` with `Registry` map (4 entries) + `List() []string` returning canonical order `["glm","kimi","deepseek","qwen"]` + `Lookup(name) (Provider, error)`. MX:ANCHOR tag per plan.md §6.1 — Registry is the closed allow-list SSOT. | expert-backend | `internal/llm/providers/registry.go` (NEW, ~50 LOC) | T-HYBRID-08, T-HYBRID-09, T-HYBRID-10, T-HYBRID-11 | 1 file (create) | GREEN |
+| T-HYBRID-13 | Create `internal/llm/registry_test.go` verifying registry consistency: `TestRegistryHasFourProviders`, `TestRegistryLookupAllowlist`, `TestRegistryLookupRejectsUnknown`. | expert-backend | `internal/llm/registry_test.go` (NEW, ~80 LOC) | T-HYBRID-12 | 1 file (create) | GREEN — provides REQ-HYBRID-002 unit-level coverage |
+| T-HYBRID-14 | Modify `internal/config/types.go` (line 52-100): extend `LLMConfig` struct with `Provider string yaml:"provider"` + `Providers map[string]ProviderYAML yaml:"providers,omitempty"`. Add `type ProviderYAML struct { BaseURL, EnvVar string; Models map[string]string }`. Preserve existing fields (Mode, TeamMode, GLMEnvVar, ClaudeModels, GLM, etc.). | expert-backend | `internal/config/types.go` (MODIFY, ~20 LOC added) | T-HYBRID-12 | 1 file (edit) | GREEN |
+| T-HYBRID-15 | Modify `internal/config/defaults.go`: add `NewDefaultProvidersConfig()` returning the 4-provider default mapping (base_url, env_var, models per provider) per research.md §3 verified-stable baseline. Wire into `NewDefaultLLMConfig` so init paths get providers map populated. | expert-backend | `internal/config/defaults.go` (MODIFY, ~30 LOC added) | T-HYBRID-14 | 1 file (edit) | GREEN |
+| T-HYBRID-16 | Modify `.moai/config/sections/llm.yaml` + mirror to `internal/template/templates/.moai/config/sections/llm.yaml`: add top-level `provider: ""` + `providers:` section per research.md §2.4. Preserve existing fields (mode, team_mode, claude_models, glm). | manager-docs | 2 files (project + template) | T-HYBRID-15 | 2 files (edit, parity) | GREEN — Embedded-template parity |
+| T-HYBRID-17 | Run `cd /Users/goos/MoAI/moai-adk-go && make build` to regenerate `internal/template/embedded.go`. Verify diff is the expected llm.yaml schema addition. | manager-docs | `internal/template/embedded.go` (regenerated) | T-HYBRID-16 | 1 file (regenerated) | Build verification |
+| T-HYBRID-18 | Run `go test ./internal/template/ -run TestProviderAllowlist` + `go test ./internal/llm/ -run TestRegistry` — confirm GREEN. | manager-tdd | n/a (verification only) | T-HYBRID-13, T-HYBRID-17 | 0 files | GREEN gate part 1 |
+
+[HARD] T-HYBRID-08..11 may execute in parallel (independent files). T-HYBRID-12 must wait for all 4.
+
+**M2 priority: P0** — blocks M3 (hybrid command depends on registry) and M4 (launcher depends on Provider interface).
+
+---
+
+## M3: `moai hybrid` Command + `moai cg` BC Stub (GREEN, part 2) — Priority P0
+
+Goal: Make `TestCGCommand*` and basic `TestHybrid*` GREEN. Add user-facing commands.
+
+Reference: plan.md §2 M3, §3.1 (cg.go REPLACE) + §3.2 (hybrid.go NEW).
+
+| ID | Subject | Owner role | File:line target | Dependency | Touch points | TDD alignment |
+|----|---------|------------|-------------------|------------|--------------|---------------|
+| T-HYBRID-19 | Replace `internal/cli/cg.go` (lines 1-58) with BC stub: `cgCmd` registered with `Hidden: false` + `Short: "[REMOVED in v3R3] Use 'moai hybrid glm' instead"`. `runCGRemoved` writes `MOAI_CG_REMOVED` + actionable migration suggestion to stderr + returns `errors.New("MOAI_CG_REMOVED")`. MX:NOTE tag per plan.md §6.2. | expert-backend | `internal/cli/cg.go` (REPLACE, ~30 LOC) | T-HYBRID-18 | 1 file (replace) | GREEN — turns `TestCGCommandReturnsBCError`, `TestCGCommandIsRegistered`, `TestCGCommandDoesNotLaunchClaudeCode` GREEN |
+| T-HYBRID-20 | Create `internal/cli/hybrid.go` with `hybridCmd` (`Use: "hybrid <provider>"`) + `runHybrid` (parse `<provider>` arg → `providers.Lookup(name)` → tmux env injection → `unifiedLaunch(profileName, "claude_hybrid", filteredArgs)`). Includes `--proxy <url>` flag handling (REQ-HYBRID-015). MX:ANCHOR tag per plan.md §6.1. | expert-backend | `internal/cli/hybrid.go` (NEW, ~150 LOC) | T-HYBRID-19 | 1 file (create) | GREEN |
+| T-HYBRID-21 | Add subcommands to `internal/cli/hybrid.go`: `hybridSetupCmd` (`Use: "setup <provider> [api-key]"` saves to `~/.moai/.env.<provider>`), `hybridStatusCmd` (`Use: "status [<provider>]"` masked key display), `hybridToolsCmd` (`Use: "tools <enable|disable>"` REQ-HYBRID-016 stub returning `not yet implemented (deferred to SPEC-GLM-MCP-001 follow-up)`). `init()` registers all to rootCmd. MX:TODO tag for tools subcommand. | expert-backend | `internal/cli/hybrid.go` (extend, ~80 LOC) | T-HYBRID-20 | 1 file (extend) | GREEN |
+| T-HYBRID-22 | Run `go test ./internal/cli/ -run "TestCGCommand|TestHybridHelp|TestHybridUnknownProvider|TestHybridProxyOverride"` — confirm GREEN. | manager-tdd | n/a (verification only) | T-HYBRID-21 | 0 files | GREEN gate part 2 |
+
+[HARD] T-HYBRID-19 and T-HYBRID-20 may NOT run in parallel — `hybridCmd` registration in T-HYBRID-21 conflicts with `cgCmd` registration in T-HYBRID-19 if both modify rootCmd init order. Sequence T-HYBRID-19 → T-HYBRID-20 → T-HYBRID-21.
+
+**M3 priority: P0** — blocks M4 (launcher must route to hybrid mode + GLM helper functions must call new abstractions).
+
+---
+
+## M4: Generalize Injection + Launcher Routing + Migration (GREEN, part 3) — Priority P0
+
+Goal: Make remaining `TestHybrid*` and `TestMigrate*` GREEN. Refactor `glm.go` injection to provider-agnostic helpers + update launcher routing + implement `migrateCGTeamMode`.
+
+Reference: plan.md §2 M4, §3.1 modifications, §3.4 anchors.
+
+| ID | Subject | Owner role | File:line target | Dependency | Touch points | TDD alignment |
+|----|---------|------------|-------------------|------------|--------------|---------------|
+| T-HYBRID-23 | Create `internal/llm/inject.go` extracting provider-agnostic helpers refactored from `internal/cli/glm.go`: `InjectTmuxSessionEnv(provider Provider, apiKey string)` ← refactor lines 356-385; `InjectProviderEnvForTeam(settingsPath, provider, apiKey)` ← refactor lines 520-581 with provider-namespaced backup keys (`MOAI_BACKUP_AUTH_TOKEN_<UPPER>`); `ClearTmuxSessionEnv(providers ...Provider)` ← refactor lines 392-421; `EnsureSettingsLocalJSONHybrid(settingsPath)` ← refactor lines 443-482 (teammateMode="tmux"). MX:ANCHOR + MX:WARN tags per plan.md §6.1, §6.3. | expert-backend | `internal/llm/inject.go` (NEW, ~250 LOC) | T-HYBRID-22 | 1 file (create) | GREEN |
+| T-HYBRID-24 | Modify `internal/cli/glm.go`: (a) line 148-149 stderr message `moai cg` → `moai hybrid glm`; (b) `enableTeamMode` (line 218-348) generalized via `enableHybridTeamMode(cmd, providers.GLMProvider{}, isHybrid)` delegate; (c) line 266 `persistTeamMode(root, "cg")` → `persistTeamMode(root, "hybrid")` + `persistProvider(root, "glm")` atomic; (d) line 356-385 `injectTmuxSessionEnv` → delegate to `internal/llm.InjectTmuxSessionEnv`; (e) line 520-581 `injectGLMEnvForTeam` → delegate to `internal/llm.InjectProviderEnvForTeam`; (f) line 536-538 single backup slot → namespaced `MOAI_BACKUP_AUTH_TOKEN_GLM`. **Preserve** `glmCmd`, `glmSetupCmd`, `glmStatusCmd` (lines 21-89) + `runGLM` body for REQ-HYBRID-006 no-regression. | expert-backend | `internal/cli/glm.go` (MODIFY, ~50 LOC delta) | T-HYBRID-23 | 1 file (edit) | GREEN — must NOT break existing `TestRunCC*`, `TestRunGLM*`, `TestEnableTeamMode*` tests |
+| T-HYBRID-25 | Modify `internal/cli/launcher.go`: (a) line 40 comment `claude_glm` → `claude_hybrid` rename; (b) line 57 `case "claude_glm":` → `case "claude_hybrid":` switching on `LLMConfig.Provider` field via `providers.Lookup(provider)`; (c) line 185 `persistTeamMode(root, "cg")` → `persistTeamMode(root, "hybrid")` + persist `provider` field; (d) line 267 `resetTeamModeForCC` rename comment to "switching to CC clears hybrid team mode". MX:WARN tag per plan.md §6.3 — case label rename requires synchronous update at multiple call sites. | expert-backend | `internal/cli/launcher.go` (MODIFY, ~10 LOC delta) | T-HYBRID-24 | 1 file (edit) | GREEN |
+| T-HYBRID-26 | Modify `internal/cli/update.go`: add `migrateCGTeamMode(root string)` helper at end of `cleanMoaiManagedPaths` (line ~1411-1441). Reads `.moai/config/sections/llm.yaml`; if `team_mode: "cg"` AND `provider: ""`, atomic-rewrite to `team_mode: "hybrid"` + `provider: "glm"` (uses SPEC-V3R3-UPDATE-CLEANUP-001 atomic write infrastructure). Emits one-time stderr notice. Idempotent (second invocation is no-op). MX:NOTE tag per plan.md §6.2. | expert-backend | `internal/cli/update.go` (MODIFY, ~50 LOC added) | T-HYBRID-25 | 1 file (edit) | GREEN |
+| T-HYBRID-27 | Run `cd /Users/goos/MoAI/moai-adk-go && make build` to regenerate `internal/template/embedded.go`. Then `go test ./internal/cli/ -run "TestHybrid|TestMigrate"` (full suite) → GREEN. Then `go test ./...` from repo root → 0 cascading failures (per CLAUDE.local.md §6 HARD). Verify existing `TestRunCC*`, `TestRunGLM*`, `TestEnableTeamMode*` tests still GREEN (REQ-HYBRID-006 no-regression). | manager-tdd | n/a (verification only) | T-HYBRID-26 | 1 file (regenerated) | GREEN gate part 3 — full suite |
+
+[HARD] T-HYBRID-24 must NOT modify `glmCmd` registration, `runGLM` body (except line 148-149 message), or `moai glm setup` / `moai glm status` behavior — these are preserved per REQ-HYBRID-006.
+
+[HARD] T-HYBRID-23 → T-HYBRID-24 → T-HYBRID-25 → T-HYBRID-26 sequential (each layer depends on the previous abstraction).
+
+**M4 priority: P0** — blocks M5 (documentation can only substitute references after the actual mode rename lands).
+
+---
+
+## M5: Documentation Substitution + CHANGELOG + MX Tags (REFACTOR + Trackable) — Priority P1
+
+Goal: Substitute `moai cg` references across 6+ documentation files + insert MX tags + add CHANGELOG `BC-V3R3-HYBRID-001` entry + final verification.
+
+Reference: plan.md §2 M5 (M5a-i), §3.1 documentation modifications.
+
+### M5a-d: `.claude/skills/` and `.claude/rules/` substitution
+
+| ID | Subject | Owner role | File:line target | Dependency | Touch points | TDD alignment |
+|----|---------|------------|-------------------|------------|--------------|---------------|
+| T-HYBRID-28 | Edit `.claude/skills/moai/team/glm.md` (lines 41, 50, 103, 127, 143): substitute `moai cg` → `moai hybrid glm` (5 mentions) per plan.md §2 M5a. Mirror to `internal/template/templates/.claude/skills/moai/team/glm.md`. | manager-docs | 2 files (project + template) | T-HYBRID-27 | 2 files (edit, parity) | REFACTOR |
+| T-HYBRID-29 | Edit `.claude/skills/moai/team/run.md` (lines 73, 88, 92, 103, 104): substitute `moai cg` → `moai hybrid <provider>` (5 mentions) per plan.md §2 M5b. Update line 73 table row similarly. Mirror to template. | manager-docs | 2 files (project + template) | T-HYBRID-27 | 2 files (edit, parity) | REFACTOR |
+| T-HYBRID-30 | Edit `.claude/skills/moai/workflows/run.md:904`: `active_mode: cc \| glm \| cg` → `active_mode: cc \| glm \| hybrid` per plan.md §2 M5c. Mirror to template. | manager-docs | 2 files (project + template) | T-HYBRID-27 | 2 files (edit, parity) | REFACTOR |
+| T-HYBRID-31 | Edit `.claude/rules/moai/development/model-policy.md:44`: `Activation: moai cg (requires tmux)` → `Activation: moai hybrid <provider> (requires tmux). Example: moai hybrid glm` per plan.md §2 M5d. Mirror to template. | manager-docs | 2 files (project + template) | T-HYBRID-27 | 2 files (edit, parity) | REFACTOR |
+
+### M5e-f: CLAUDE.md + CLAUDE.local.md substitution
+
+| ID | Subject | Owner role | File:line target | Dependency | Touch points | TDD alignment |
+|----|---------|------------|-------------------|------------|--------------|---------------|
+| T-HYBRID-32 | Edit `CLAUDE.md §15 Agent Teams (Experimental)` (~line 488-510, `### CG Mode (Claude + GLM Cost Optimization)` heading): rename heading to `### Hybrid Mode (Multi-LLM Cost Optimization)`; generalize body to "Teammates (GLM/Kimi/DeepSeek/Qwen, new tmux panes)"; activation example `moai hybrid <provider>`. CLAUDE.md is NOT in template (project root only). | manager-docs | `CLAUDE.md` (MODIFY) | T-HYBRID-27 | 1 file (edit) | REFACTOR |
+| T-HYBRID-33 | Edit `CLAUDE.local.md §16 line 129`: `Modified by 'moai glm', 'moai cc', 'moai cg' commands at runtime` → `Modified by 'moai glm', 'moai cc', 'moai hybrid <provider>' commands at runtime`. CLAUDE.local.md is local-only (not in template). | manager-docs | `CLAUDE.local.md` (MODIFY) | T-HYBRID-27 | 1 file (edit) | REFACTOR |
+
+### M5g: CHANGELOG entry
+
+| ID | Subject | Owner role | File:line target | Dependency | Touch points | TDD alignment |
+|----|---------|------------|-------------------|------------|--------------|---------------|
+| T-HYBRID-34 | Append `BC-V3R3-HYBRID-001` entry to `CHANGELOG.md` `## [Unreleased]` section per plan.md §2 M5g + spec.md §10.3. Include: 4-provider list, BC migration suggestion, auto-migration of `team_mode: "cg"` config, preservation of `moai glm` / `moai cc`, reference to SPEC §10. | manager-docs | `CHANGELOG.md` (MODIFY) | T-HYBRID-27 | 1 file (edit) | Trackable (TRUST 5) |
+
+### M5h: MX tag insertion
+
+| ID | Subject | Owner role | File:line target | Dependency | Touch points | TDD alignment |
+|----|---------|------------|-------------------|------------|--------------|---------------|
+| T-HYBRID-35 | Insert 10 MX tags across 7 distinct files per plan.md §6 mx_plan: 3 ANCHOR (`registry.go Registry`, `hybrid.go hybridCmd`, `inject.go InjectProviderEnvForTeam`), 3 NOTE (`cg.go runCGRemoved`, `provider.go Provider interface`, `update.go migrateCGTeamMode`), 3 WARN (`inject.go backup namespacing`, `launcher.go:57 case`, `providers/{kimi,qwen}.go base_url`), 1 TODO (`hybrid.go hybridToolsCmd` deferral to SPEC-GLM-MCP-001). | expert-backend | 7 distinct files (Go source) | T-HYBRID-23, T-HYBRID-19, T-HYBRID-21, T-HYBRID-25, T-HYBRID-26, T-HYBRID-09, T-HYBRID-11 | 7 files (edit) | REFACTOR — MX protocol per `.claude/rules/moai/workflow/mx-tag-protocol.md` |
+
+### M5i: Final verification
+
+| ID | Subject | Owner role | File:line target | Dependency | Touch points | TDD alignment |
+|----|---------|------------|-------------------|------------|--------------|---------------|
+| T-HYBRID-36 | Run final verification battery: (a) `cd /Users/goos/MoAI/moai-adk-go && make build` regenerate embedded.go; (b) `go test ./...` from repo root — 0 cascading failures (CLAUDE.local.md §6 HARD); (c) `golangci-lint run` — 0 errors, ≤10 warnings (per quality.yaml); (d) `go vet ./...` — 0 issues; (e) `grep -rn "moai cg" .claude/ CLAUDE.md CLAUDE.local.md` returns only M5e/M5f-substituted content (no residual command references); (f) Update `progress.md` with `run_complete_at: <ISO-8601 UTC>` + `run_status: implementation-complete`. | manager-tdd | `progress.md` (MODIFY) + 1 file (regenerated) | T-HYBRID-28..35 | 2 files | REFACTOR / Trackable — gating point per CLAUDE.local.md §6 |
+
+[HARD] T-HYBRID-36 is the gating point. No tests may regress. No new SPEC documents created in `.moai/specs/` or `.moai/reports/` during M5.
+
+T-HYBRID-28..31 may execute in parallel (independent files). T-HYBRID-32, T-HYBRID-33, T-HYBRID-34 may execute in parallel after M4 completes.
+
+**M5 priority: P1** — required for full spec.md §2.1 In Scope coverage and TRUST 5 Trackable.
+
+---
+
+## Aggregate Statistics
+
+- **Total tasks**: 36 (T-HYBRID-01 through T-HYBRID-36)
+- **Total milestones**: 5 (M1: 6 tasks, M2: 12 tasks, M3: 4 tasks, M4: 5 tasks, M5: 9 tasks)
+- **Files created**: 13
+  - 4 test scaffolds (M1): `provider_allowlist_audit_test.go`, `cg_removal_test.go`, `hybrid_test.go`, `migration_test.go`
+  - 7 implementation files (M2): `provider.go`, `providers/{glm,kimi,deepseek,qwen,registry}.go`, `registry_test.go`
+  - 1 implementation file (M3): `hybrid.go`
+  - 1 implementation file (M4): `inject.go`
+- **Files modified (source-of-truth)**: ~13 unique files
+  - 1 `cg.go` REPLACE (M3)
+  - 4 Go source files (`glm.go`, `launcher.go`, `update.go`, `config/types.go`, `config/defaults.go`) (M2/M4)
+  - 1 project `llm.yaml` (M2)
+  - 4 `.claude/skills/.claude/rules` files (M5a-d)
+  - 1 `CLAUDE.md` (M5e), 1 `CLAUDE.local.md` (M5f), 1 `CHANGELOG.md` (M5g)
+- **Files modified (embedded-template parity)**: ~5 mirror files (`.claude/skills/moai/team/{glm,run}.md`, `.claude/skills/moai/workflows/run.md`, `.claude/rules/moai/development/model-policy.md`, `.moai/config/sections/llm.yaml`)
+- **MX tag insertions**: 10 across 7 distinct files (3 ANCHOR + 3 NOTE + 3 WARN + 1 TODO)
+- **Owner-role distribution**:
+  - `expert-backend`: 19 tasks (all Go test + implementation work — T-HYBRID-01..05, 07..15, 19..21, 23..26, 35)
+  - `manager-tdd`: 4 tasks (T-HYBRID-06, 18, 22, 27, 36 — TDD gate verification)
+  - `manager-docs`: 13 tasks (T-HYBRID-16, 17, 28..34 — content authoring + template parity + CHANGELOG)
+
+---
+
+## Owner-Role Rationale
+
+- **Go test + implementation work** (`expert-backend`): all `internal/llm/` package work, `internal/cli/{hybrid,cg,glm,launcher,update}.go` modifications, MX tag insertion in Go source files. Requires Go expertise (cobra, embedded FS, atomic write, tmux env injection).
+- **TDD gate verification** (`manager-tdd`): the project's `quality.yaml` declares `development_mode: tdd`. Each gate (RED M1, GREEN parts 1/2/3, final REFACTOR) is a manager-tdd checkpoint per CLAUDE.md §5 Run Phase methodology.
+- **Content authoring** (`manager-docs`): all `.claude/skills/.claude/rules` substitutions (M5a-d), embedded template parity (`.moai/config/sections/llm.yaml`), CLAUDE.md/CLAUDE.local.md/CHANGELOG.md edits. Documentation per CLAUDE.md §4 Manager Agents catalog.
+
+---
+
+## Parallel Execution Opportunities
+
+These task groups have no inter-dependencies and may run in parallel within their milestone:
+
+- **M1 parallel**: T-HYBRID-02..05 (extend independent test files; true parallelism possible).
+- **M2 parallel**: T-HYBRID-08, T-HYBRID-09, T-HYBRID-10, T-HYBRID-11 (4 provider metadata files independent; true parallelism possible). T-HYBRID-12 sequences after.
+- **M3 sequential**: T-HYBRID-19 → T-HYBRID-20 → T-HYBRID-21 (rootCmd registration order matters).
+- **M4 sequential**: T-HYBRID-23 → T-HYBRID-24 → T-HYBRID-25 → T-HYBRID-26 (each layer depends on the previous abstraction).
+- **M5 parallel**: T-HYBRID-28..31 (independent skill/rule files); T-HYBRID-32..34 (independent project-root files) parallel; T-HYBRID-35 sequences after to avoid edit conflicts on Go source files; T-HYBRID-36 sequences last.
+
+Per CLAUDE.md §1 HARD rule "Multi-File Decomposition: Split work when modifying 3+ files," every milestone with multi-file scope encodes per-file decomposition.
+
+---
+
+## Cross-Reference Map
+
+Each task references which REQ(s) and which AC(s) it advances toward DoD:
+
+| Task ID | REQ coverage | AC coverage |
+|---------|--------------|-------------|
+| T-HYBRID-01 | (scaffold) | (scaffold) |
+| T-HYBRID-02 | REQ-HYBRID-002, 017 | AC-HYBRID-15, 18 |
+| T-HYBRID-03 | REQ-HYBRID-003, 010, 014 | AC-HYBRID-03 |
+| T-HYBRID-04 | REQ-HYBRID-001, 002, 007..009, 012, 013, 015, 018 | AC-HYBRID-01, 02, 07..09, 11, 12, 13, 16 |
+| T-HYBRID-05 | REQ-HYBRID-011 | AC-HYBRID-10 |
+| T-HYBRID-06 | (gate) | (gate) |
+| T-HYBRID-07 | REQ-HYBRID-001, 002 | (interface foundation) |
+| T-HYBRID-08 | REQ-HYBRID-002, 005 | AC-HYBRID-05 |
+| T-HYBRID-09 | REQ-HYBRID-002, 005, 015 | AC-HYBRID-05, 13 |
+| T-HYBRID-10 | REQ-HYBRID-002, 005 | AC-HYBRID-05 |
+| T-HYBRID-11 | REQ-HYBRID-002, 005, 015 | AC-HYBRID-05, 13 |
+| T-HYBRID-12 | REQ-HYBRID-002, 017 | AC-HYBRID-15, 18 |
+| T-HYBRID-13 | REQ-HYBRID-002 | AC-HYBRID-02, 18 |
+| T-HYBRID-14 | REQ-HYBRID-004 | AC-HYBRID-04 |
+| T-HYBRID-15 | REQ-HYBRID-005 | AC-HYBRID-05, 17 |
+| T-HYBRID-16 | REQ-HYBRID-004, 005 | AC-HYBRID-04, 05 |
+| T-HYBRID-17 | (build) | (build) |
+| T-HYBRID-18 | (gate) | AC-HYBRID-05, 15, 18 GREEN |
+| T-HYBRID-19 | REQ-HYBRID-003, 010, 014 | AC-HYBRID-03 |
+| T-HYBRID-20 | REQ-HYBRID-001, 002, 007, 015 | AC-HYBRID-01, 02, 13 |
+| T-HYBRID-21 | REQ-HYBRID-008, 009, 016 | AC-HYBRID-08, 09, 14 |
+| T-HYBRID-22 | (gate) | AC-HYBRID-01, 02, 03, 13, 14 GREEN |
+| T-HYBRID-23 | REQ-HYBRID-007, 012, 018 | AC-HYBRID-07, 11, 16 |
+| T-HYBRID-24 | REQ-HYBRID-006, 007 | AC-HYBRID-06, 07 |
+| T-HYBRID-25 | REQ-HYBRID-007, 012, 013 | AC-HYBRID-07, 11, 12 |
+| T-HYBRID-26 | REQ-HYBRID-011 | AC-HYBRID-10 |
+| T-HYBRID-27 | (gate) | AC-HYBRID-06..12, 16, 17 GREEN |
+| T-HYBRID-28..31 | REQ-HYBRID-001 (Trackable) | (documentation surface) |
+| T-HYBRID-32 | REQ-HYBRID-001 (Trackable) | (CLAUDE.md surface) |
+| T-HYBRID-33 | REQ-HYBRID-001 (Trackable) | (CLAUDE.local.md surface) |
+| T-HYBRID-34 | (Trackable) | (CHANGELOG entry) |
+| T-HYBRID-35 | (MX protocol) | (10 MX tags) |
+| T-HYBRID-36 | (final gate) | (DoD steps) |
+
+REQ coverage summary: 18 REQs, all referenced by at least one task (verified by transitive lookup against `spec.md` §5).
+
+AC coverage summary: 18 ACs, all advanced toward DoD by tasks (verified against acceptance.md §1-18).
+
+REQ Categories balance:
+- Ubiquitous (REQ-001..006): T-HYBRID-04, 07, 08..14, 19, 20, 24
+- Event-Driven (REQ-007..011): T-HYBRID-04, 05, 20, 21, 23..26
+- State-Driven (REQ-012..014): T-HYBRID-03, 04, 19, 23, 25
+- Optional (REQ-015..016): T-HYBRID-04, 09, 11, 20, 21
+- Complex (REQ-017..018): T-HYBRID-02, 04, 12, 13, 23
+
+Every category has at least one task. Task-to-REQ mapping covers all 18 REQs.
+
+---
+
+## Final Verification Pass (subset of T-HYBRID-36)
+
+Before marking SPEC implementation complete, execute these checks in order:
+
+1. **Audit + integration tests green**: `go test ./internal/template/ -run TestProviderAllowlist` + `go test ./internal/cli/ -run "TestCG|TestHybrid|TestMigrate"` + `go test ./internal/llm/ -run TestRegistry` — all PASS.
+2. **Full repo green**: `go test ./...` — 0 failures (per CLAUDE.local.md §6 HARD).
+3. **No regression on `moai cc` / `moai glm`**: `go test ./internal/cli/ -run "TestRunCC|TestRunGLM|TestEnableTeamMode"` — all PASS (REQ-HYBRID-006).
+4. **Lint clean**: `golangci-lint run` — 0 errors, ≤10 warnings (per quality.yaml `lsp_quality_gates.sync`).
+5. **Vet clean**: `go vet ./...` — 0 issues.
+6. **Embedded parity**: diff `internal/template/embedded.go` after `make build` shows only the expected schema/file content changes (no spurious diffs).
+7. **No residual `moai cg`**: `grep -rn "moai cg" .claude/ CLAUDE.md CLAUDE.local.md` returns only the substituted/migration-note lines (no command-invocation references).
+8. **DoD checklist**: all items in `acceptance.md` §"Definition of Done" checked.
+
+If any step fails, return to the appropriate milestone for remediation. Do NOT advance to `/moai sync` until all 8 checks pass.
+
+---
+
+End of tasks.md.


### PR DESCRIPTION
## Summary

SPEC-V3R3-HYBRID-001 plan-stage 산출물. moai cg 명령어를 BREAKING CHANGE로 제거하고 moai hybrid를 신규 도입하여 GLM/Kimi/DeepSeek/Qwen 4-LLM allow-list를 1급 시민으로 지원.

사용자 요청 (2026-05-04 세션 Stage 1 Clarify multiSelect 응답):
- Team LLM 4종 모두 채택: GLM-4.6 (Z.AI), Kimi K2 (Moonshot), DeepSeek V3.x (DeepSeek), Qwen3-Coder (Alibaba)
- 최신 안정 버전 정책 (config-level override 허용)
- Clean break (moai cg 즉시 제거)
- SPEC-GLM-MCP-001 dependency 선언 (superset 흡수 X)

## 산출물 (7 files / 2,533 LOC)

| File | LOC | 내용 |
|------|-----|------|
| spec.md | 330 | 18 EARS REQs (U=6/E=5/S=3/O=2/Un=2), §BC Migration |
| plan.md | 585 | M1-M5 (TDD), REQ↔AC matrix 18/18 + 18/18 |
| acceptance.md | 513 | 18 ACs G/W/T + Test Anchors |
| tasks.md | 283 | T-HYBRID-01..36 (M1 6 / M2 12 / M3 4 / M4 5 / M5 9) |
| research.md | 556 | Phase 0.5 deep research (codebase + 4 LLM endpoints) |
| spec-compact.md | 150 | REQ + AC + Files + Exclusions extract |
| progress.md | 116 | plan_status: audit-ready |

## Plan-Auditor Verdict (review-1)

**PASS**, Overall Score 0.82, Iteration 1/3.

- MP-1 REQ Number Consistency: ✅
- MP-2 EARS Format Compliance: ✅
- MP-3 YAML Frontmatter v0.2.0: ✅ (9/9 required, 0 rejected aliases)
- MP-4 Language Neutrality: N/A (LLM-provider scope)

본 commit에서 RESOLVED:
- **D2 (Major)**: spec.md REQ-HYBRID-004 \`provider.<name>\` → \`providers.<name>\` plural 일관화
- **D3 (Minor)**: AC-HYBRID-18 path 일관화 \`provider_registry.go\` → \`providers/registry.go\` (3 곳)
- **D4 (Minor)**: tasks.md HISTORY count 27 → 36

Sync 단계 cleanup 가능 advisory:
- **D1**: SPEC-GLM-MCP-001 dependency forward-looking (PR #769 머지 후 도착)
- **D5**: tasks.md owner-role distribution 산술 (multi-line table 구조 영향)
- **D6**: informational

## BC Migration

**moai cg 명령어 즉시 제거** (BC-V3R3-HYBRID-001):

\`\`\`bash
# 기존
moai cg

# 신규
moai hybrid glm     # 동등 동작 (Claude Leader + GLM Workers)
moai hybrid kimi    # 신규 옵션
moai hybrid deepseek
moai hybrid qwen
\`\`\`

\`moai cg\` 호출 시: stderr에 \`MOAI_CG_REMOVED\` sentinel + \`use 'moai hybrid glm' instead\` 안내. v3.x 마이그레이션 가이드 별도 문서.

\`moai glm\` (single-LLM) / \`moai cc\` (Claude-only)는 보존.

## Dependencies

- **SPEC-GLM-MCP-001** (PR #769 OPEN, 2026-05-04 작성) — Z.AI MCP 서버 통합. Hybrid SPEC은 GLM team 사용 시 Z.AI MCP 서버 활용을 dependency로 선언.

## Test Plan

- [x] plan-auditor iteration 1 PASS (review-1.md, score 0.82, D2/D3/D4 fix됨)
- [ ] PR review (manager-quality 4-perspective, optional)
- [ ] CI all-green (Lint / Test ubuntu/macos/windows / Build 5 / CodeQL)
- [ ] Admin merge (docs-only PR)

## Branch / Base

- Branch: \`feature/SPEC-V3R3-HYBRID-001\`
- Base: \`main\` (origin/main HEAD 09c0fb44e)
- Stacked: 아니오

## CLAUDE.local.md §18 준수

- §18.2 명명: \`feature/SPEC-V3R3-XXX\` 패턴 ✅
- §18.3 merge: feature → main = squash ✅
- §18.6 labels: type:docs, priority:P1, area:templates (auto-labeler)

🗿 MoAI <email@mo.ai.kr>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive specification and planning documentation for upcoming multi-provider LLM support feature.
  * Includes detailed acceptance criteria, research analysis, implementation roadmap, and progress tracking documentation to guide future development phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->