### PR TITLE
docs(spec): SPEC-V3R3-BRAIN-001 plan + audit PASS (iter 3)

### DIFF
--- a/.moai/specs/SPEC-V3R3-BRAIN-001/acceptance.md
+++ b/.moai/specs/SPEC-V3R3-BRAIN-001/acceptance.md
@@ -1,0 +1,338 @@
+---
+id: SPEC-V3R3-BRAIN-001
+version: "0.1.0"
+status: draft
+created_at: 2026-05-04
+updated_at: 2026-05-04
+author: MoAI Plan Workflow
+priority: P1
+labels: [brain, ideation, workflow, handoff, claude-design, v3r3, acceptance]
+issue_number: null
+phase: "v3.0.0 — Phase 8 — Brain Workflow Introduction"
+breaking: false
+harness: standard
+---
+
+# Acceptance Criteria: SPEC-V3R3-BRAIN-001
+
+This document defines the Given-When-Then scenarios that verify SPEC-V3R3-BRAIN-001 is correctly implemented. Each scenario maps to one or more EARS requirements (REQ-BRAIN-001..012).
+
+---
+
+## Scenario 1: Happy Path — Complete 7-Phase Execution
+
+**Maps to**: REQ-BRAIN-001, REQ-BRAIN-005, REQ-BRAIN-009
+
+**Given**:
+- A fresh project with `.moai/brain/` directory present (created by `moai init`)
+- `.moai/project/brand/brand-voice.md` exists with non-empty content
+- No prior IDEA-NNN directories exist
+
+**When**:
+- User invokes `/moai brain "I want to build a habit-tracking mobile app for senior citizens"`
+
+**Then**:
+- The system creates `.moai/brain/IDEA-001/` directory
+- Phase 1 Discovery executes: AskUserQuestion is called at least once with ToolSearch preload (verified via debug log)
+- Phase 2 Diverge produces 5-15 divergent concepts (in-memory, not persisted as standalone file)
+- Phase 3 Research produces `.moai/brain/IDEA-001/research.md` with at least 3 cited sources from WebSearch and at least 1 from Context7 (parallel call evidence in tool-use stream)
+- Phase 4 Converge produces `.moai/brain/IDEA-001/ideation.md` containing a "Lean Canvas" section with all 9 blocks (Problem, Customer Segments, Unique Value Proposition, Solution, Channels, Revenue Streams, Cost Structure, Key Metrics, Unfair Advantage)
+- Phase 5 Critical Evaluation appends an "Evaluation Report" section to `ideation.md`
+- Phase 6 Proposal produces `.moai/brain/IDEA-001/proposal.md` containing a `### SPEC Decomposition Candidates` heading followed by 2-10 bullet entries matching grammar `- SPEC-{DOMAIN}-{NUM}: {scope}`
+- Phase 7 Handoff produces all 5 files under `.moai/brain/IDEA-001/claude-design-handoff/`: `prompt.md`, `context.md`, `references.md`, `acceptance.md`, `checklist.md`
+- `prompt.md` contains 5 sections: Goal, References, Brand Voice, Acceptance, Out-of-scope
+- `prompt.md` contains NO MoAI-specific tokens (no `SPEC-`, no `.moai/`, no `manager-`)
+- After Phase 7, AskUserQuestion is invoked with 3 options (a) proceed to project (Recommended), (b) review manually, (c) regenerate
+- The workflow exits cleanly with status code 0
+
+**Verification commands**:
+```bash
+ls .moai/brain/IDEA-001/
+test -f .moai/brain/IDEA-001/research.md
+test -f .moai/brain/IDEA-001/ideation.md
+test -f .moai/brain/IDEA-001/proposal.md
+test -d .moai/brain/IDEA-001/claude-design-handoff/
+ls .moai/brain/IDEA-001/claude-design-handoff/ | wc -l   # expect 5
+grep -q "### SPEC Decomposition Candidates" .moai/brain/IDEA-001/proposal.md
+grep -E "^- SPEC-[A-Z][A-Z0-9]+-[0-9]{3}: " .moai/brain/IDEA-001/proposal.md | wc -l   # expect 2-10
+grep -q "Lean Canvas" .moai/brain/IDEA-001/ideation.md
+grep -v "SPEC-\|\.moai/\|manager-" .moai/brain/IDEA-001/claude-design-handoff/prompt.md  # exit 0 means no matches
+```
+
+---
+
+## Scenario 2: Brand Context Absent — Graceful Default-Voice Fallback
+
+**Maps to**: REQ-BRAIN-006
+
+**Given**:
+- A fresh project with `.moai/brain/` directory present
+- `.moai/project/brand/` directory does NOT exist (or `brand-voice.md` is missing)
+- No prior IDEA-NNN directories exist
+
+**When**:
+- User invokes `/moai brain "I want a developer productivity dashboard"`
+- User completes Phases 1-6 normally
+
+**Then**:
+- Phase 7 Handoff produces all 5 files under `.moai/brain/IDEA-001/claude-design-handoff/`
+- `claude-design-handoff/prompt.md` contains a section header "Brand Voice (default — please customize)"
+- `claude-design-handoff/context.md` contains a placeholder warning at the top: a clearly visible note instructing the user to populate `.moai/project/brand/brand-voice.md` and regenerate, OR to manually edit the prompt before pasting into claude.com Design
+- The workflow exits with status code 0 (graceful, not error)
+- Before Phase 7, AskUserQuestion offers user the option to run brand interview first (option) or accept default (option) — Recommended option is "accept default and continue" to keep workflow short
+
+**Verification commands**:
+```bash
+grep -q "Brand Voice (default — please customize)" .moai/brain/IDEA-001/claude-design-handoff/prompt.md
+grep -qi "brand-voice.md" .moai/brain/IDEA-001/claude-design-handoff/context.md
+test ! -d .moai/project/brand/   # confirm absent precondition
+```
+
+---
+
+## Scenario 3: Research Phase — WebSearch Failure Handled Gracefully
+
+**Maps to**: REQ-BRAIN-003
+
+**Given**:
+- A fresh project with `.moai/brain/` directory present
+- WebSearch tool is unavailable or returns network error (simulate via test harness)
+- Context7 MCP is available
+
+**When**:
+- User invokes `/moai brain "I want a code review automation tool"`
+- Phase 3 Research executes
+
+**Then**:
+- The system attempts WebSearch and Context7 in parallel (single-message tool calls)
+- WebSearch returns error or empty results
+- Context7 returns valid documentation
+- The system does NOT abort Phase 3 — it produces `.moai/brain/IDEA-001/research.md` with:
+  - A "Sources" section listing all successfully-fetched sources (Context7 results)
+  - A "Research Limitations" section noting that WebSearch was unavailable
+- The workflow continues to Phase 4 (Converge) without crash
+- The workflow exits with status code 0
+
+**Verification commands**:
+```bash
+test -f .moai/brain/IDEA-001/research.md
+grep -qi "research limitations\|websearch.*unavailable\|websearch.*failed" .moai/brain/IDEA-001/research.md
+test -f .moai/brain/IDEA-001/ideation.md   # Phase 4 still executed
+test -f .moai/brain/IDEA-001/proposal.md   # Phase 6 still executed
+```
+
+---
+
+## Scenario 4: SPEC Decomposition List Parseable by `/moai plan --from-brain`
+
+**Maps to**: REQ-BRAIN-004, REQ-BRAIN-007 (downstream integration)
+
+**Given**:
+- A completed brain workflow has produced `.moai/brain/IDEA-001/proposal.md`
+- The proposal.md contains a `### SPEC Decomposition Candidates` section with the following entries:
+  ```
+  - SPEC-AUTH-001: User authentication and session management
+  - SPEC-API-001: REST API for habit CRUD operations
+  - SPEC-NOTIF-001: Push notification subsystem
+  ```
+- `/moai project --from-brain IDEA-001` has been run, producing `product.md`/`structure.md`/`tech.md`
+
+**When**:
+- User invokes `/moai plan` (no arguments)
+
+**Then**:
+- The plan workflow detects `.moai/brain/IDEA-001/proposal.md` exists
+- The plan workflow parses the "SPEC Decomposition Candidates" section using the documented grammar
+- AskUserQuestion is invoked with the 3 candidate SPECs as options (plus an "other / custom" option)
+- The Recommended option is the first candidate (SPEC-AUTH-001) per AskUserQuestion convention
+- User selects one candidate
+- The plan workflow proceeds to generate `.moai/specs/SPEC-AUTH-001/{spec.md, plan.md, acceptance.md}` populated with brain-derived context (proposal scope copied as preliminary requirements)
+- No errors thrown for the parser regardless of bullet-list whitespace variations
+
+**Edge case extension**:
+- If proposal.md contains a malformed entry like `- AUTH-001: missing prefix` (not matching grammar), the plan workflow surfaces it as a WARNING (not error) in the output and excludes it from the AskUserQuestion options.
+
+**Verification commands**:
+```bash
+# After /moai plan execution:
+test -d .moai/specs/SPEC-AUTH-001/
+grep -q "habit\|authentication" .moai/specs/SPEC-AUTH-001/spec.md   # brain context propagated
+# Parser robustness test:
+echo "- AUTH-001: malformed" >> .moai/brain/IDEA-001/proposal.md
+# Re-run /moai plan; expect warning in output, no error
+```
+
+---
+
+## Scenario 5: Language Neutrality — Tech-Stack-Agnostic Output
+
+**Maps to**: REQ-BRAIN-008, REQ-BRAIN-011
+
+**Given**:
+- A fresh project with `.moai/brain/` directory present
+- No `.moai/project/tech.md` exists yet (so no tech-stack precedent)
+
+**When**:
+- User invokes `/moai brain "I want to build a Python data pipeline tool for ETL workflows"`
+- The user's idea explicitly mentions "Python"
+
+**Then**:
+- Phase 1 Discovery clarifies the idea WITHOUT asking "which Python web framework" or similar tech-stack-specific questions — questions focus on user persona, problem space, success metrics
+- Phase 3 Research includes general ETL ecosystem references but does NOT prioritize Python-specific tools over alternatives — at least 2 of the cited sources discuss tools written in non-Python languages (e.g., dbt, Apache NiFi, Talend, Pentaho)
+- Phase 6 `proposal.md` does NOT contain phrases like "FastAPI", "Django", "Flask", "Pandas", "Airflow", "PySpark", or any specific Python library/framework name in the requirements section. The "Solution" block of Lean Canvas describes capabilities (e.g., "high-throughput ETL transformation engine") not implementations (e.g., "Pandas-based engine")
+- The "SPEC Decomposition Candidates" section uses neutral SPEC IDs (e.g., `SPEC-PIPELINE-001`, `SPEC-API-001`) — NOT Python-specific (e.g., `SPEC-FASTAPI-001`)
+- Phase 7 `prompt.md` does NOT mention any specific frontend or backend technology
+- The user can subsequently choose any of the 16 supported MoAI-ADK languages (go, python, typescript, javascript, rust, java, kotlin, csharp, ruby, php, elixir, cpp, scala, r, flutter, swift) at the `/moai project` or `/moai plan` stage without conflict
+
+**Verification commands**:
+```bash
+# Tech-stack mention probe (should produce zero matches in proposal.md):
+grep -iE "fastapi|django|flask|pandas|airflow|pyspark|numpy|sqlalchemy" .moai/brain/IDEA-001/proposal.md | wc -l   # expect 0
+# Or only in "User mentioned" / "Original idea" verbatim quote section if echoed:
+grep -iE "fastapi|django|flask" .moai/brain/IDEA-001/proposal.md
+# If matches, verify they're inside a "Original Idea (verbatim)" block, not in requirements/solution sections
+# SPEC-decomposition language-neutral check:
+grep -E "^- SPEC-(FASTAPI|DJANGO|FLASK|PANDAS|PYSPARK)-" .moai/brain/IDEA-001/proposal.md   # expect 0 matches
+# Handoff prompt language-neutral check:
+grep -iE "fastapi|django|flask|react|vue|angular|svelte" .moai/brain/IDEA-001/claude-design-handoff/prompt.md | wc -l   # expect 0
+```
+
+---
+
+## Scenario 6: AskUserQuestion Enforcement — No Prose Questions
+
+**Maps to**: REQ-BRAIN-012
+
+**Given**:
+- A fresh project
+- Debug logging enabled (capture tool-use stream)
+
+**When**:
+- User invokes `/moai brain "I have a vague idea about productivity tools"`
+- The idea is intentionally vague (clarity score ≤ 3) to trigger Discovery rounds
+
+**Then**:
+- Phase 1 Discovery is triggered
+- Every question directed at the user is invoked via `AskUserQuestion` tool call
+- Each `AskUserQuestion` call is preceded by `ToolSearch(query: "select:AskUserQuestion")` in the same turn (deferred-tool preload)
+- The agent's output text body contains NO interrogative prose ending in `?` (no "What do you think?", "Which approach do you prefer?", "Should we proceed?")
+- All option labels in AskUserQuestion calls are in the user's `conversation_language` (Korean, per `.moai/config/sections/language.yaml`)
+- The first option of each AskUserQuestion has `(권장)` suffix (Korean) or `(Recommended)` (English)
+- Each AskUserQuestion has at most 4 questions, each with at most 4 options
+- After max 5 rounds (REQ-BRAIN-002 cap), Discovery terminates and proceeds to Phase 2
+
+**Verification approach**:
+```bash
+# Inspect debug log for tool-use stream:
+grep -E "AskUserQuestion|ToolSearch" .claude/logs/session-*.log | head -20
+# Verify ToolSearch immediately precedes each AskUserQuestion (within same turn)
+# Verify no orchestrator output contains a free-form prose question:
+# (manual review of session transcript — should not see any "?-ending" sentence in agent prose addressed to user)
+```
+
+---
+
+## Edge Cases
+
+### Edge Case 1: Multiple IDEAs in Same Project
+
+**Given**: `.moai/brain/IDEA-001/` and `.moai/brain/IDEA-002/` already exist
+
+**When**: User runs `/moai brain "third idea"`
+
+**Then**: System creates `.moai/brain/IDEA-003/` (auto-increment from max existing)
+
+### Edge Case 2: Mid-Workflow Interrupt
+
+**Given**: Phase 3 Research is in progress, partial `research.md` written
+
+**When**: User cancels (Ctrl+C or session closes)
+
+**Then**:
+- `.moai/brain/IDEA-001/` directory exists with partial files
+- Re-running `/moai brain "<same idea>"` SHOULD prompt user via AskUserQuestion: (a) resume from last completed phase (Recommended), (b) restart from Phase 1, (c) abort
+- Resume option uses existing files; restart option creates IDEA-002
+
+### Edge Case 3: User Rejects All Phase 7 Options
+
+**Given**: REQ-BRAIN-009 AskUserQuestion at Phase 7 exit
+
+**When**: User selects option (c) "regenerate handoff package with adjustments"
+
+**Then**:
+- AskUserQuestion follow-up asks what to adjust (brand voice, references, acceptance criteria)
+- Phase 7 re-executes with user-specified adjustments
+- All 5 handoff files are overwritten
+- After regeneration, REQ-BRAIN-009 AskUserQuestion is re-invoked
+
+### Edge Case 4: proposal.md Decomposition Section Empty
+
+**Given**: For very small ideas, proposal.md contains 0-1 SPEC candidates instead of 2-10
+
+**When**: Phase 6 generates proposal.md
+
+**Then**:
+- If 0 candidates: Phase 6 emits a warning in the output and includes a "SPEC Decomposition Candidates: TBD — idea may be too small for SPEC-driven workflow, consider direct `/moai plan` instead" placeholder section
+- If 1 candidate: Acceptable, no warning
+- The grammar `- SPEC-{DOMAIN}-{NUM}: {scope}` is enforced for any candidates present
+
+### Edge Case 5: Concurrent `/moai brain` Invocations
+
+**Given**: User somehow invokes `/moai brain` twice in parallel sessions
+
+**When**: Both sessions try to create IDEA-NNN directory
+
+**Then**:
+- Out of scope for this SPEC's testing — concurrency-safety of IDEA-NNN auto-increment is documented as a known limitation
+- v0.2 may add file lock; for v0.1, document in proposal.md output that concurrent invocations are not supported
+
+---
+
+## Definition of Done (Acceptance-Level)
+
+For this SPEC to be considered DONE, ALL of the following must hold:
+
+- [ ] All 6 numbered scenarios above pass (Scenario 1-6)
+- [ ] All 5 edge cases produce expected behavior (manual verification or test cases)
+- [ ] All 12 EARS requirements (REQ-BRAIN-001..012) traced to at least one scenario
+- [ ] Frontmatter validation: 9 required fields present in all 4 plan artifacts (research.md, spec.md, plan.md, acceptance.md)
+- [ ] `created_at` and `updated_at` are `2026-05-04` (NOT `created` / `updated`)
+- [ ] `labels` is YAML array (not comma-separated string)
+- [ ] `version` is quoted string (`"0.1.0"`, not `0.1`)
+- [ ] `priority` is `P1` (uppercase P-prefix accepted enum)
+- [ ] No implementation code in spec.md, plan.md, acceptance.md (only WHAT/WHY/HOW-AT-PLAN-LEVEL)
+
+---
+
+## EARS Requirement Coverage Matrix
+
+| Requirement | Type | Scenario(s) Covering | Priority |
+|-------------|------|---------------------|----------|
+| REQ-BRAIN-001 | Event-Driven | #1 | P1 |
+| REQ-BRAIN-002 | Event-Driven | #6 (5-round cap) | P1 |
+| REQ-BRAIN-003 | Event-Driven | #1, #3 | P1 |
+| REQ-BRAIN-004 | Event-Driven | #1, #4 | P1 |
+| REQ-BRAIN-005 | Event-Driven | #1 (no MoAI tokens check) | P1 |
+| REQ-BRAIN-006 | Optional | #1 (with brand), #2 (without brand) | P2 |
+| REQ-BRAIN-007 | Event-Driven | #4 (downstream) | P1 |
+| REQ-BRAIN-008 | Ubiquitous | #5 | P1 |
+| REQ-BRAIN-009 | Event-Driven | #1, edge case #3 | P1 |
+| REQ-BRAIN-010 | Unwanted | #1 (no auto-project) | P1 |
+| REQ-BRAIN-011 | Unwanted | #5 | P1 |
+| REQ-BRAIN-012 | Unwanted | #6 | P1 |
+
+All 12 requirements covered by at least one scenario.
+
+---
+
+## References
+
+- `spec.md` (sibling) — EARS requirements, file deliverables, exclusions
+- `plan.md` (sibling) — implementation phases, risk analysis, MX tag plan
+- `research.md` (sibling) — codebase context, decisions, risk surface
+- `.claude/rules/moai/core/askuser-protocol.md` — AskUserQuestion + ToolSearch enforcement (Scenario 6)
+- `.claude/rules/moai/development/coding-standards.md` — frontmatter schema validation
+
+---
+
+**Status**: audit-ready

--- a/.moai/specs/SPEC-V3R3-BRAIN-001/plan.md
+++ b/.moai/specs/SPEC-V3R3-BRAIN-001/plan.md
@@ -1,0 +1,434 @@
+---
+id: SPEC-V3R3-BRAIN-001
+version: "0.1.0"
+status: draft
+created_at: 2026-05-04
+updated_at: 2026-05-04
+author: MoAI Plan Workflow
+priority: P1
+labels: [brain, ideation, workflow, handoff, claude-design, v3r3, plan]
+issue_number: null
+phase: "v3.0.0 — Phase 8 — Brain Workflow Introduction"
+module: "internal/cli/, .claude/skills/moai/workflows/, .claude/skills/moai-domain-ideation/, .claude/skills/moai-domain-research/, .claude/skills/moai-domain-design-handoff/, .claude/agents/manager-brain.md, .claude/commands/moai-brain.md, .moai/brain/"
+breaking: false
+harness: standard
+---
+
+# Plan: SPEC-V3R3-BRAIN-001 — `/moai brain` Implementation Plan
+
+## 1. Strategy Overview
+
+This SPEC introduces a brand-new pre-spec ideation workflow. The implementation strategy follows the Template-First discipline mandated by `CLAUDE.local.md` §2: every artifact under `.claude/`, `.moai/` is added to `internal/template/templates/` first, then regenerated via `make build`, then exposed locally.
+
+**Approach**: Skill-first build order, then agent, then CLI binding, then integration patches, then tests. Skills can be developed in isolation against the foundation primitives without depending on the agent/CLI being ready.
+
+**Reuse strategy**: The brain workflow is a composition over `moai-foundation-thinking`. New `moai-domain-*` skills are thin orchestrators that delegate phase-specific logic to the foundation. This minimizes new-code risk and aligns with the constitutional principle "Reuse over re-invention" (CLAUDE.md §1).
+
+---
+
+## 2. Implementation Phases
+
+### Phase A1: Foundation Skills (Domain Skills)
+
+**Files**: deliverables #2, #3, #4 (3 new skills under `.claude/skills/moai-domain-*/`)
+**Dependencies**: None (only `moai-foundation-thinking` which already exists)
+**Estimated LOC**: ~1,200 markdown
+
+Tasks:
+1. Create `.claude/skills/moai-domain-ideation/SKILL.md` — thin orchestrator for Diverge → Cluster → Converge pipeline. Delegates 90% to `moai-foundation-thinking/modules/diverge-converge.md`. Adds Lean Canvas section assembly logic (Problem / Customer / UVP / Solution / Channels / Revenue / Cost / Metrics / Unfair Advantage). Adds "SPEC Decomposition Candidates" assembler with grammar `- SPEC-{DOMAIN}-{NUM}: {scope}`.
+2. Create `.claude/skills/moai-domain-research/SKILL.md` — patterns for parallel WebSearch + Context7 + market scan. Documents Anthropic's parallel-tool-call convention. Includes failure-graceful pattern (REQ-BRAIN-003 partial-failure tolerance).
+3. Create `.claude/skills/moai-domain-design-handoff/SKILL.md` — Claude Design prompt template (5-section: Goal / References / Brand Voice / Acceptance / Out-of-scope). Documents brand-absent fallback per REQ-BRAIN-006.
+4. Mirror all 3 skills to `internal/template/templates/.claude/skills/moai-domain-*/SKILL.md`.
+
+**Verification**: Skills are valid markdown with proper frontmatter. No runtime testing required at this phase — skills are loaded lazily.
+
+### Phase A2: Workflow Orchestration Skill
+
+**Files**: deliverable #1 (`.claude/skills/moai/workflows/brain.md`)
+**Dependencies**: Phase A1 complete (skills must exist before workflow references them)
+**Estimated LOC**: ~600 markdown
+
+Tasks:
+1. Create `.claude/skills/moai/workflows/brain.md` with the 7-phase contract:
+   - Phase 1 Discovery (uses `moai-foundation-thinking/modules/deep-questioning.md` + AskUserQuestion)
+   - Phase 2 Diverge (uses `moai-domain-ideation`)
+   - Phase 3 Research (uses `moai-domain-research`)
+   - Phase 4 Converge (uses `moai-domain-ideation`)
+   - Phase 5 Critical Evaluation (uses `moai-foundation-thinking/modules/critical-evaluation.md` + `first-principles.md`)
+   - Phase 6 Proposal (uses `moai-domain-ideation` for SPEC decomposition)
+   - Phase 7 Handoff (uses `moai-domain-design-handoff`)
+2. Document IDEA-NNN auto-increment logic (scan `.moai/brain/IDEA-*` directories, take max + 1).
+3. Document brand-context detection (`.moai/project/brand/brand-voice.md` existence check).
+4. Document REQ-BRAIN-009 next-action AskUserQuestion (with options a/b/c).
+5. Mirror to `internal/template/templates/.claude/skills/moai/workflows/brain.md`.
+
+**Verification**: Manual review of phase contracts; cross-reference REQ-BRAIN-001..012 against workflow steps.
+
+### Phase A3: Workflow Router Patch
+
+**Files**: deliverable #5 (`.claude/skills/moai/SKILL.md` patch)
+**Dependencies**: Phase A2 complete (workflow file must exist before router references it)
+**Estimated LOC**: ~30 markdown
+
+Tasks:
+1. Add `brain` to subcommand router section in `.claude/skills/moai/SKILL.md`. Match the existing pattern used for `plan`, `run`, `sync`, etc.
+2. Add "Priority 1 routing" entry: `/moai brain "<idea>"` → load `workflows/brain.md`.
+3. Mirror to template.
+
+**Verification**: Manual diff review against existing subcommand entries.
+
+### Phase A4: Agent Definition
+
+**Files**: deliverable #6 (`.claude/agents/manager-brain.md`)
+**Dependencies**: Phase A2 complete
+**Estimated LOC**: ~250 markdown
+
+Tasks:
+1. Create `.claude/agents/manager-brain.md` following the `manager-spec.md` pattern.
+2. Frontmatter: `name`, `description`, `model: opus`, `tools: Read, Write, Edit, Glob, Grep, Bash, WebSearch, WebFetch, ToolSearch, AskUserQuestion, mcp__context7__*`.
+3. Body: workflow phases 1-7 prose, delegation patterns, blocker-report contract for missing inputs.
+4. Mirror to `internal/template/templates/.claude/agents/manager-brain.md`.
+
+**Verification**: `internal/template/agents_audit_test.go` (existing test) verifies agent frontmatter and body structure on next `make build`.
+
+### Phase A5: Command Wrappers
+
+**Files**: deliverables #7, #8 (`.claude/commands/moai-brain.md` NEW, `.claude/commands/moai.md` PATCH)
+**Dependencies**: Phase A2, A4 complete
+**Estimated LOC**: #7 ≤80 lines (≤20 LOC body); #8 patch ~10 lines
+
+Tasks:
+1. Create `.claude/commands/moai-brain.md`:
+   - Frontmatter per Thin Command Pattern (`description`, `argument-hint`, `allowed-tools` CSV, `model`).
+   - Body: ≤20 LOC, single instruction "Use the moai workflow brain skill to execute /moai brain with arguments: {{args}}".
+2. Patch `.claude/commands/moai.md` to add `brain` to recognized subcommands list.
+3. Mirror both to template.
+
+**Verification**: `internal/template/commands_audit_test.go` extended (deliverable #17) checks Thin Command Pattern compliance.
+
+### Phase A6: Output Directory Templates
+
+**Files**: deliverables #11, #12
+**Dependencies**: None
+**Estimated LOC**: ~250 markdown total (5 example files × ~50 lines)
+
+Tasks:
+1. Create `internal/template/templates/.moai/brain/.gitkeep` (zero bytes).
+2. Create `internal/template/templates/.moai/brain/IDEA-EXAMPLE/`:
+   - `research.md` (worked example: market research for hypothetical SaaS)
+   - `ideation.md` (worked example: Lean Canvas filled in)
+   - `proposal.md` (worked example: 3 SPEC decomposition candidates)
+   - `claude-design-handoff/prompt.md` (worked example: paste-ready prompt)
+   - `claude-design-handoff/context.md`, `references.md`, `acceptance.md`, `checklist.md` (worked stubs)
+3. Examples MUST follow REQ-BRAIN-008 (16-language neutrality) — example proposal does not name a specific tech stack.
+
+**Verification**: `moai init` in `/tmp/test-project` produces `.moai/brain/IDEA-EXAMPLE/` directory with all 8 files.
+
+### Phase A7: Go CLI Entry
+
+**Files**: deliverables #9, #10
+**Dependencies**: Phase A2 (slash command must exist for delegation)
+**Estimated LOC**: brain.go ~150 LOC; root.go patch ~10 LOC
+
+Tasks:
+1. Create `internal/cli/brain.go` with cobra command `brainCmd`:
+   - Use: `brain "<idea>"`
+   - Short: "Run the /moai brain ideation workflow"
+   - Run: prints user-facing instruction "Run `/moai brain \"<idea>\"` in Claude Code chat — `moai brain` is a CLI hint, the actual workflow runs in Claude Code session."
+   - Optional: `--instructions-only` flag to print 7-phase contract without spawning.
+2. Patch `internal/cli/root.go` to register `brainCmd`.
+3. Follow §1 CLI vs slash boundary in `CLAUDE.local.md`: terminal `moai brain` is informational; the workflow IS a slash command.
+
+**Verification**: `go build ./...` succeeds; `moai brain --help` prints expected text.
+
+### Phase A8: Workflow Integration Patches
+
+**Files**: deliverables #13, #14, #15
+**Dependencies**: Phase A2 complete (brain workflow output format defined)
+**Estimated LOC**: project.md +80, plan.md +100, design.md +40
+
+Tasks:
+1. Patch `.claude/skills/moai/workflows/project.md`:
+   - Add CLI flag `--from-brain IDEA-XXX`.
+   - When flag present, load `.moai/brain/IDEA-XXX/proposal.md` and prepend its content to the product/structure/tech generation prompt.
+   - Document precedence: `proposal.md` (primary) > codebase scan (secondary).
+2. Patch `.claude/skills/moai/workflows/plan.md`:
+   - Detect `.moai/brain/IDEA-*/proposal.md` existence on `/moai plan` invocation.
+   - Parse "SPEC Decomposition Candidates" section using grammar `- SPEC-{DOMAIN}-{NUM}: {scope}`.
+   - Surface candidates to user via AskUserQuestion (recommendation field) — never auto-create SPECs.
+   - Defensive parser: warn (not error) on grammar drift.
+3. Patch `.claude/skills/moai/workflows/design.md`:
+   - When `--path A` and no `--bundle` arg, scan `.moai/brain/IDEA-*/claude-design-handoff/` for candidate bundles.
+   - Suggest detected bundles via AskUserQuestion.
+4. Mirror all 3 patches to template.
+
+**Verification**: Manual workflow trace for each integration point.
+
+### Phase A9: Tests
+
+**Files**: deliverables #16, #17
+**Dependencies**: Phases A1-A8 complete
+**Estimated LOC**: brain_test.go ~200 LOC; commands_audit_test.go extension ~50 LOC
+
+Tasks:
+1. Create `internal/cli/brain_test.go`:
+   - Table-driven tests for `brainCmd.Run` with various args.
+   - `t.TempDir()` isolation per `CLAUDE.local.md` §6.
+   - Test `--help` output structure.
+   - Test `--instructions-only` flag.
+   - Test missing args error message.
+2. Extend `internal/template/commands_audit_test.go`:
+   - Add `moai-brain.md` to the list of commands verified for Thin Command Pattern.
+   - Verify body LOC ≤20.
+   - Verify frontmatter completeness.
+3. Run full test suite: `go test ./... -race -count=1`.
+
+**Verification**: All tests pass; coverage for `brain.go` ≥85%.
+
+---
+
+## 3. Risk Analysis
+
+### Risk 1: Phase 7 Prompt Quality (HIGH)
+
+**Description**: A poorly-templated `prompt.md` produces Claude Design output missing the user's brand voice or feature scope, requiring manual editing — defeating REQ-BRAIN-005's "paste-ready" promise.
+
+**Probability**: Medium (template quality is the only variable; user testing will surface gaps quickly)
+**Impact**: High (user friction on the headline feature)
+
+**Mitigation**:
+- Template includes self-review checklist before final write.
+- Phase 7 acceptance gate: AskUserQuestion confirms user reviewed handoff package before workflow exit.
+- IDEA-EXAMPLE/ template ships with worked example so users see expected output shape.
+- `--regenerate` flag (REQ-BRAIN-009 option c) allows iteration without re-running phases 1-6.
+- Acceptance scenario #1 verifies all 5 handoff files are produced with required structure.
+
+### Risk 2: Brand Context Absent (MEDIUM)
+
+**Description**: First-time projects without `.moai/project/brand/` populated produce generic-voice prompts. REQ-BRAIN-006 specifies brand integration but does not define absent-fallback.
+
+**Probability**: High (brand interview is opt-in)
+**Impact**: Medium (workflow still completes; output quality reduced)
+
+**Mitigation**:
+- When brand context absent, Phase 7 emits "Brand Voice (default — please customize)" section with placeholder warning.
+- AskUserQuestion offers user the option to run brand interview before Phase 7 (or accept default).
+- Acceptance scenario #2 verifies graceful fallback.
+
+### Risk 3: Claude.com Design External Dependency (MEDIUM)
+
+**Description**: Claude Design product UX changes break prompt template assumptions; the workflow has no direct integration test with claude.com.
+
+**Probability**: Low (Claude Design is stable per Anthropic roadmap)
+**Impact**: Medium (workflow output stale, requires template update)
+
+**Mitigation**:
+- prompt.md template designed as human-readable instructions, not machine-formatted — robust to UX changes.
+- references.md and acceptance.md are static design-quality artifacts independent of Claude Design's UI.
+- This SPEC's acceptance scenario #1 stops at "handoff package generated" — does not require Claude Design execution.
+- Long-term: `references/claude-design-prompt-best-practices.md` reference doc tracks Anthropic's published guidance.
+
+### Risk 4: Self-Bootstrap Order Pressure (LOW)
+
+**Description**: Pressure to start SPEC-V3R3-WEB-001 before BRAIN ships could lead to brain workflow being designed around web-specific assumptions, breaking generality.
+
+**Probability**: Low (SPEC sequencing is enforced by dependency declaration)
+**Impact**: High if it occurs (REQ-BRAIN-008 violation, generality lost)
+
+**Mitigation**:
+- This SPEC explicitly lists "Web UI for brain" in Out-of-Scope §7.
+- REQ-BRAIN-008 (16-language neutrality) is testable at acceptance — see scenario #5.
+- IDEA-EXAMPLE/ ships with non-web-specific worked example.
+
+### Risk 5: SPEC Decomposition Format Drift (LOW)
+
+**Description**: proposal.md's "SPEC Decomposition Candidates" section format diverges from what `/moai plan --from-brain` expects.
+
+**Probability**: Low (template fixes the grammar)
+**Impact**: Low (defensive parser surfaces warnings)
+
+**Mitigation**:
+- proposal.md template fixes section grammar: `### SPEC Decomposition Candidates` heading + bullet list `- SPEC-{DOMAIN}-{NUM}: {scope}`.
+- plan.md patch implements defensive parser: surfaces non-conforming entries as warnings, never errors.
+- Acceptance scenario #4 verifies parseability.
+
+---
+
+## 4. Task Decomposition (Granular)
+
+| Task ID | Phase | Description | Deliverables | Priority | Status |
+|---------|-------|-------------|--------------|----------|--------|
+| T-A1.1 | A1 | Create moai-domain-ideation skill | #2 | P1 | pending |
+| T-A1.2 | A1 | Create moai-domain-research skill | #3 | P1 | pending |
+| T-A1.3 | A1 | Create moai-domain-design-handoff skill | #4 | P1 | pending |
+| T-A1.4 | A1 | Mirror domain skills to template | (mirrors of #2/3/4) | P1 | pending |
+| T-A2.1 | A2 | Create workflows/brain.md (7-phase contract) | #1 | P1 | pending |
+| T-A2.2 | A2 | Mirror brain.md to template | (mirror of #1) | P1 | pending |
+| T-A3.1 | A3 | Patch moai/SKILL.md router for `brain` subcommand | #5 | P1 | pending |
+| T-A4.1 | A4 | Create manager-brain agent | #6 | P1 | pending |
+| T-A5.1 | A5 | Create moai-brain.md command (Thin Pattern) | #7 | P1 | pending |
+| T-A5.2 | A5 | Patch commands/moai.md subcommand list | #8 | P1 | pending |
+| T-A6.1 | A6 | Create .moai/brain/.gitkeep template | #11 | P1 | pending |
+| T-A6.2 | A6 | Create IDEA-EXAMPLE/ worked example (8 files) | #12 | P2 | pending |
+| T-A7.1 | A7 | Create internal/cli/brain.go | #9 | P1 | pending |
+| T-A7.2 | A7 | Patch internal/cli/root.go (register brainCmd) | #10 | P1 | pending |
+| T-A8.1 | A8 | Patch project.md (--from-brain flag) | #13 | P1 | pending |
+| T-A8.2 | A8 | Patch plan.md (decomposition parser) | #14 | P1 | pending |
+| T-A8.3 | A8 | Patch design.md (bundle auto-detect) | #15 | P2 | pending |
+| T-A9.1 | A9 | Create internal/cli/brain_test.go | #16 | P1 | pending |
+| T-A9.2 | A9 | Extend commands_audit_test.go | #17 | P1 | pending |
+| T-A9.3 | A9 | Run full test suite + lint | (verification) | P1 | pending |
+| T-A9.4 | A9 | `make build` (regenerate embedded templates) | (verification) | P1 | pending |
+
+**Total tasks**: 21
+**Sequential ordering**: A1 → A2 → A3 → A4 → A5 → A6 → A7 → A8 → A9 (later phases may parallelize within their bounds)
+
+---
+
+## 5. Reference Implementations
+
+| Pattern | Reference | Used For |
+|---------|-----------|----------|
+| Thin Command Pattern | `.claude/commands/moai/plan.md` (existing) | deliverable #7 |
+| Workflow Orchestration | `.claude/skills/moai/workflows/plan.md` (existing) | deliverable #1 |
+| Manager Agent Definition | `.claude/agents/moai/manager-spec.md` (existing) | deliverable #6 |
+| Domain Skill Structure | `.claude/skills/moai-domain-backend/` (existing) | deliverables #2, #3, #4 |
+| AskUserQuestion + ToolSearch Preload | `.claude/rules/moai/core/askuser-protocol.md` | Phase 1 Discovery, Phase 6, Phase 7 |
+| Template-First Discipline | `internal/template/templates/.moai/specs/` (existing) | deliverables #11, #12 |
+| Cobra Command Registration | `internal/cli/plan.go` + `root.go` (existing) | deliverables #9, #10 |
+| Commands Audit Test | `internal/template/commands_audit_test.go` (existing) | deliverable #17 |
+
+---
+
+## 6. MX Tag Plan
+
+Per `.claude/rules/moai/workflow/mx-tag-protocol.md`, the following MX tags will be added during the run phase:
+
+### @MX:NOTE (Context delivery)
+
+- `internal/cli/brain.go` — explain why this is a thin CLI wrapper (delegation to slash command).
+- `.claude/skills/moai/workflows/brain.md` — explain the 7-phase contract and its derivation from `moai-foundation-thinking`.
+
+### @MX:WARN (Danger zone)
+
+- `.claude/skills/moai/workflows/brain.md` — Phase 7 prompt template generation. **Reason**: Output is paste-ready into external system (claude.com); changes affect user trust. @MX:REASON required for any template modification.
+- `internal/cli/brain.go` — argument parsing. **Reason**: User-facing CLI; error messages must be helpful (16-language neutrality applies to error messages too).
+
+### @MX:ANCHOR (Invariant contract)
+
+- `.claude/skills/moai-domain-design-handoff/SKILL.md` — `prompt.md` template structure (5 sections: Goal / References / Brand Voice / Acceptance / Out-of-scope). **High fan-in**: consumed by every brain workflow execution.
+- `.claude/skills/moai-domain-ideation/SKILL.md` — "SPEC Decomposition Candidates" section grammar. **High fan-in**: consumed by `/moai plan --from-brain` patch.
+
+### @MX:TODO (Incomplete work — resolved in run phase)
+
+- `internal/template/templates/.moai/brain/IDEA-EXAMPLE/` — initial example may be domain-specific; should be replaced with a more generic example based on user feedback in v0.2. (Resolution: keep current, document as "subject to v0.2 refinement" comment.)
+
+---
+
+## 7. Estimated LOC
+
+| Component | LOC | Confidence |
+|-----------|-----|------------|
+| `.claude/skills/moai/workflows/brain.md` | ~600 | High |
+| `moai-domain-ideation/SKILL.md` | ~400 | High |
+| `moai-domain-research/SKILL.md` | ~350 | Medium |
+| `moai-domain-design-handoff/SKILL.md` | ~450 | Medium |
+| `manager-brain.md` | ~250 | High |
+| `moai-brain.md` (Thin Command) | ~80 | High |
+| `moai.md` patch | ~10 | High |
+| `moai/SKILL.md` patch (router) | ~30 | High |
+| `internal/cli/brain.go` | ~150 | High |
+| `internal/cli/root.go` patch | ~10 | High |
+| IDEA-EXAMPLE/ (8 files × ~50) | ~250 | Medium |
+| `project.md` patch | ~80 | High |
+| `plan.md` patch | ~100 | Medium |
+| `design.md` patch | ~40 | High |
+| `brain_test.go` | ~200 | High |
+| `commands_audit_test.go` extension | ~50 | High |
+| **Total** | **~3,050** | Medium-High |
+
+---
+
+## 8. Build & Quality Gates
+
+### 8.1 Build Steps (executed in Phase A9)
+
+1. `make build` — regenerate `internal/template/embedded.go` from `internal/template/templates/`
+2. `go test ./... -race -count=1` — full test suite, no caching
+3. `golangci-lint run ./...` — zero warnings target
+4. `go vet ./...` — static analysis
+5. Manual smoke test: `./moai brain --help` produces expected output
+
+### 8.2 plan-auditor Gate
+
+This SPEC has `harness: standard`. plan-auditor (independent skeptical assessor) is auto-engaged at Phase 2.3 of `/moai plan` workflow. Audit checklist:
+
+- [ ] Frontmatter 9 required fields present in spec.md
+- [ ] EARS requirements use proper keywords (WHEN/WHILE/WHERE/IF/SHALL)
+- [ ] Acceptance scenarios in Given-When-Then format (5+ scenarios)
+- [ ] Out-of-Scope section non-empty (10 entries in this SPEC)
+- [ ] Risk analysis covers minimum 3 risks (this SPEC: 5 risks)
+- [ ] Reuse inventory present (this SPEC: research §5)
+- [ ] No implementation code in spec.md (only WHAT/WHY)
+- [ ] No time estimates in plan.md (priority labels only — verified above)
+- [ ] Cross-references to existing skills/agents validated (this SPEC: research §1)
+- [ ] 16-language neutrality verified (REQ-BRAIN-008)
+
+### 8.3 Run-Phase Quality Gates (LSP-based, per CLAUDE.md §6)
+
+- Zero LSP errors
+- Zero type errors
+- Zero lint errors (`golangci-lint`)
+- Test coverage ≥85% for `internal/cli/brain.go`
+
+---
+
+## 9. Sequencing Strategy (Run Phase Recommendation)
+
+**Recommended execution mode**: `sequential` (single-developer, single-branch).
+
+**Rationale**:
+- 21 tasks but strong dependency chain (A1 → A2 → A3 → ...)
+- File ownership concentrated in `.claude/skills/` (3 new skills) and `internal/cli/` (1 new file + 1 patch) — no parallel write conflict potential
+- Tests in Phase A9 verify all earlier phases — running A1-A8 in parallel risks broken intermediate state
+- Worktree isolation NOT required (single SPEC, no cross-SPEC dependency)
+
+**Alternative**: If pressure to ship faster, Phase A1's 3 domain skills can be developed in parallel (independent files, no cross-references between them at draft time). All other phases must remain sequential.
+
+---
+
+## 10. Cross-Reference Validation
+
+Validation that this plan aligns with the SPEC requirements:
+
+| REQ | Verified by Phase |
+|-----|-------------------|
+| REQ-BRAIN-001 (7-phase execution) | Phase A2 (workflows/brain.md) |
+| REQ-BRAIN-002 (Discovery rounds ≤5) | Phase A2 + Phase A4 (manager-brain) |
+| REQ-BRAIN-003 (parallel research) | Phase A1.2 (moai-domain-research) |
+| REQ-BRAIN-004 (SPEC decomposition list) | Phase A1.1 (moai-domain-ideation) + Phase A8.2 (plan.md patch) |
+| REQ-BRAIN-005 (paste-ready prompt) | Phase A1.3 (moai-domain-design-handoff) |
+| REQ-BRAIN-006 (brand integration) | Phase A1.3 + Phase A2 (brand-detect logic) |
+| REQ-BRAIN-007 (--from-brain flag) | Phase A8.1 (project.md patch) |
+| REQ-BRAIN-008 (16-language neutrality) | Phase A6.2 (IDEA-EXAMPLE) + acceptance scenario #5 |
+| REQ-BRAIN-009 (next-action AskUserQuestion) | Phase A2 (workflow Phase 7 exit) |
+| REQ-BRAIN-010 (no auto-project) | Phase A2 (negative invariant in workflow) |
+| REQ-BRAIN-011 (no tech-stack in proposal) | Phase A1.1 (ideation skill rule) + acceptance scenario #5 |
+| REQ-BRAIN-012 (AskUserQuestion enforcement) | Phase A2 + Phase A4 (agent ban on prose questions) |
+
+All 12 requirements traced to implementation phases.
+
+---
+
+## 11. References
+
+- `research.md` (sibling) — codebase context, decisions, risk surface
+- `spec.md` (sibling) — EARS requirements, file deliverables, exclusions
+- `acceptance.md` (sibling) — Given-When-Then scenarios
+- `.claude/rules/moai/development/coding-standards.md` — Thin Command Pattern, frontmatter schema
+- `.claude/rules/moai/workflow/mx-tag-protocol.md` — MX tag types and reasoning
+- `CLAUDE.local.md` §2 (Template-First), §6 (Test Isolation), §16 (Self-check)
+
+---
+
+**Status**: audit-ready (post plan-auditor PASS at Phase 2.3)

--- a/.moai/specs/SPEC-V3R3-BRAIN-001/progress.md
+++ b/.moai/specs/SPEC-V3R3-BRAIN-001/progress.md
@@ -1,0 +1,151 @@
+---
+spec_id: SPEC-V3R3-BRAIN-001
+artifact: progress
+phase: plan
+updated_at: 2026-05-04
+---
+
+# Progress: SPEC-V3R3-BRAIN-001
+
+Tracking the lifecycle of `/moai brain` — Idea-to-Item Workflow with Claude Design Handoff Package.
+
+---
+
+## Plan Phase
+
+- plan_started_at: 2026-05-04T07:25:00+09:00
+- plan_complete_at: 2026-05-04T07:33:00+09:00
+- plan_status: audit-ready
+
+### Plan Artifacts Produced
+
+| File | Status | Lines (approx) |
+|------|--------|----------------|
+| `research.md` | created | ~270 |
+| `spec.md` | created | ~310 |
+| `plan.md` | created | ~370 |
+| `acceptance.md` | created | ~360 |
+| `spec-compact.md` | created | ~110 |
+| `progress.md` | created (this file) | — |
+
+### Frontmatter Validation Status
+
+All 6 plan artifacts (post-iteration-1 revision):
+
+- spec.md: 9 required fields ✓ (id, version, status, created_at, updated_at, author, priority, labels, issue_number)
+- plan.md: 9 required fields ✓
+- acceptance.md: 9 required fields ✓
+- research.md: minimal frontmatter ✓ (spec_id, artifact, version, created_at, author, status) — added in iteration 1
+- progress.md: minimal frontmatter ✓ (spec_id, artifact, phase, updated_at) — added in iteration 1
+- spec-compact.md: minimal frontmatter ✓ (spec_id, artifact, version, source, created_at, updated_at) — added in iteration 1
+- All canonical-schema artifacts use `created_at`/`updated_at` (NOT `created`/`updated`)
+- All use `labels: [...]` YAML array (NOT comma-separated string)
+- All use `version: "0.1.0"` (quoted string, NOT unquoted float)
+- All use `priority: P1` (uppercase P-prefix accepted enum)
+- All use `created_at: 2026-05-04` and `updated_at: 2026-05-04`
+- `id` matches regex `^SPEC-[A-Z][A-Z0-9]+-[0-9]{3}$` (SPEC-V3R3-BRAIN-001) ✓
+
+### EARS Requirements Count
+
+12 requirements total (REQ-BRAIN-001..012):
+- 7 Event-Driven (001, 002, 003, 004, 005, 007, 009)
+- 0 State-Driven
+- 1 Optional (006)
+- 1 Ubiquitous (008)
+- 3 Unwanted (010, 011, 012)
+
+### Acceptance Scenarios Count
+
+6 numbered scenarios + 5 edge cases = 11 total verification points.
+
+All 12 EARS requirements traced to at least one scenario (coverage matrix in acceptance.md).
+
+### Deliverables Count
+
+17 deliverables (10 NEW + 7 PATCH):
+- Skills: 5 (4 NEW: #1, #2, #3, #4 + 1 PATCH: #5)
+- Agents: 1 NEW (#6)
+- Commands: 2 (1 NEW: #7 + 1 PATCH: #8)
+- Go CLI: 2 (1 NEW: #9 + 1 PATCH: #10)
+- Templates: 2 NEW (#11, #12 — #12 is a directory containing 8 sub-files; deliverable count anchors on the directory entry)
+- Workflow patches: 3 PATCH (#13, #14, #15)
+- Tests: 2 (1 NEW: #16 + 1 PATCH: #17)
+
+NEW set: #1, #2, #3, #4, #6, #7, #9, #11, #12, #16 (10)
+PATCH set: #5, #8, #10, #13, #14, #15, #17 (7)
+
+### Out-of-Scope Entries
+
+10 explicit exclusions in spec.md §7 (satisfies [HARD] "at least one exclusion entry" rule).
+
+---
+
+## Run Phase
+
+- run_started_at: (pending)
+- run_complete_at: (pending)
+- run_status: pending
+
+---
+
+## Sync Phase
+
+- sync_started_at: (pending)
+- sync_complete_at: (pending)
+- sync_status: pending
+
+---
+
+## Notes
+
+- Self-bootstrap pattern: SPEC-V3R3-WEB-001 (web dashboard) cannot start until this SPEC is merged. After merge, the web SPEC will be ideated USING `/moai brain` as the canonical proof-of-concept.
+- Reuse-heavy: 90% of brain workflow's logic comes from `moai-foundation-thinking` (already exists). New domain skills are thin orchestrators.
+- Phase 7 (Claude Design Handoff) was added per user correction during fourth Socratic round of plan-spawn discussion. Originally missing, now first-class with 5-file deliverable structure.
+- 16-language neutrality is testable at acceptance — see scenario #5.
+
+---
+
+## Revision Log
+
+### Iteration 1 (2026-05-04)
+
+- revision_iteration: 1
+- revision_completed_at: 2026-05-04T08:15:00+09:00
+- defects_resolved: 7 (1 blocker, 2 majors, 4 minors)
+
+Defects addressed (per `.moai/reports/plan-audit/SPEC-V3R3-BRAIN-001-review-1.md`):
+
+| # | Severity | Description | Status |
+|---|----------|-------------|--------|
+| 1 | blocker | REQ-BRAIN-002 broken cross-reference to non-existent "plan.md Phase 0.3 algorithm" | RESOLVED — replaced with canonical reference to `.claude/skills/moai/workflows/plan.md` Phase 0.3 + inline score-to-rounds mapping |
+| 2 | major | NEW/PATCH file count mismatch ("13+4" vs actual "10+7") | RESOLVED — corrected to 10 NEW + 7 PATCH across spec.md §5, spec-compact.md, progress.md |
+| 3 | major | Deliverable #12 IDEA-EXAMPLE/ specificity (8 sub-files unaccounted) | RESOLVED — 8 sub-files explicitly enumerated under deliverable #12 in spec.md §5.5; deliverable count anchored on directory entry (17 total preserved) |
+| 4 | minor | EARS classification mislabel for REQ-BRAIN-002/004/005 (labelled State-Driven, actually Event-Driven) | RESOLVED — relabeled to Event-Driven in spec.md §4.1/§4.2 + spec-compact.md table; progress.md EARS count recomputed (7 Event-Driven, 0 State-Driven) |
+| 5 | minor | research.md missing YAML frontmatter | RESOLVED — added minimal frontmatter (spec_id, artifact, version, created_at, author, status) |
+| 6 | minor | progress.md and spec-compact.md missing YAML frontmatter | RESOLVED — added minimal frontmatter to both |
+| 7 | minor | spec-compact.md L8 used legacy `Created:`/`Updated:` body labels | RESOLVED — replaced with canonical `created_at:`/`updated_at:` |
+
+### Iteration 2 (2026-05-04)
+
+- revision_iteration: 2
+- revision_completed_at: 2026-05-04T08:35:00+09:00
+- defects_resolved: 1 (1 fresh major from review-2.md FD-1) + 1 spillover (acceptance.md trace matrix label sync)
+
+Defects addressed (per `.moai/reports/plan-audit/SPEC-V3R3-BRAIN-001-review-2.md`):
+
+| # | Severity | Description | Status |
+|---|----------|-------------|--------|
+| FD-1 | major | REQ-BRAIN-002 trigger ("clarity ≤ 3 → up to 5 rounds") contradicted iteration-1 inline mapping ("1-3 → 0 rounds") inherited from plan.md Phase 0.3 — same input range yielded opposite behaviors | RESOLVED — REQ-BRAIN-002 rewritten with brain-specific inverted mapping (1-3 → up to 5 rounds, 4-6 → up to 3 rounds, 7-10 → up to 1 round) + explicit rationale that brain's ideation-depth purpose inverts plan-workflow's requirements-speed purpose. Trigger and mapping now agree on every input. |
+| spillover | minor | acceptance.md §EARS Requirement Coverage Matrix still labelled REQ-BRAIN-002/004/005 as State-Driven (iteration-1 defect #4 propagation gap, flagged by manager-spec but not auto-fixed due to scope guard) | RESOLVED — orchestrator directly synced trace matrix labels to Event-Driven (single-line edit, no semantic change to scenarios). |
+
+### Iteration 3 — Plan Audit PASS (2026-05-04)
+
+- audit_iteration: 3
+- audit_completed_at: 2026-05-04T08:50:00+09:00
+- verdict: PASS
+- report: `.moai/reports/plan-audit/SPEC-V3R3-BRAIN-001-review-3.md`
+- structural_soundness: confirmed (mechanical refinement only, no rework)
+- iteration-1 regression check: 7/7 still resolved
+- iteration-2 FD-1: resolved
+- fresh_defects: 0
+- ready_for_run: true

--- a/.moai/specs/SPEC-V3R3-BRAIN-001/research.md
+++ b/.moai/specs/SPEC-V3R3-BRAIN-001/research.md
@@ -1,0 +1,310 @@
+---
+spec_id: SPEC-V3R3-BRAIN-001
+artifact: research
+version: "0.1.0"
+created_at: 2026-05-04
+author: MoAI Plan Workflow
+status: pre-spec research
+---
+
+# Research: SPEC-V3R3-BRAIN-001 — `/moai brain` Idea-to-Item Workflow
+
+**Date**: 2026-05-04
+**Author**: MoAI Plan Workflow
+**Status**: pre-spec research
+
+---
+
+## 1. Codebase Context
+
+### 1.1 Existing Thinking Foundation (reuse target)
+
+**Skill**: `.claude/skills/moai-foundation-thinking/SKILL.md` (16,470 bytes)
+
+The skill consolidates three integrated frameworks already used across MoAI:
+
+| Framework | Module Path | Reused By |
+|-----------|-------------|-----------|
+| Diverge-Converge (5-phase: Requirements → Diverge 20-50 → Cluster → Converge → Document) | `modules/diverge-converge.md` | manager-strategy, team-reader analyst |
+| Critical Evaluation (7-step: Restate → Evidence → Fallacies → Assumptions → Alternatives → Contradictions → Burden) | `modules/critical-evaluation.md` | manager-strategy, plan-auditor |
+| Deep Questioning (6-layer progressive inquiry) | `modules/deep-questioning.md` | manager-spec, manager-strategy |
+| First Principles (5-phase: Audit → Decompose → Generate → Trade-off → Bias Check) | `modules/first-principles.md` | manager-strategy |
+| Sequential Thinking MCP | (`--deepthink` flag) | Architecture decisions |
+
+**Key finding**: The brain workflow's Phase 2 (Diverge), Phase 4 (Converge), Phase 5 (Critical Evaluation), and Discovery Phase 1 (Deep Questioning) are **direct compositions** over `moai-foundation-thinking` — no new ideation logic is required at the framework layer. The new `moai-domain-ideation` skill is a thin orchestrator that invokes the foundation skill and adds artifact-shaping (Lean Canvas section assembly, SPEC-decomposition list extraction).
+
+### 1.2 Existing Design Workflow (path A target)
+
+**Skill**: `.claude/skills/moai-workflow-design-import/SKILL.md`
+**Workflow**: `.claude/skills/moai/workflows/design.md`
+
+`/moai design --path A --bundle <path>` already accepts a Claude Design handoff bundle and writes machine-generated artifacts to `.moai/design/`. The brain workflow's Phase 7 produces a bundle compatible with this existing import path:
+
+```
+.moai/brain/IDEA-001/claude-design-handoff/   ← brain Phase 7 output (this SPEC)
+        │
+        ▼ user external action (claude.com Design)
+        │
+.moai/design/                                  ← existing import workflow output
+```
+
+**Implication**: Phase 7 emits a directory shape that `moai-workflow-design-import` can ingest after the user's external claude.com Design execution. No changes to the import skill are required for this SPEC, only an additive bundle-resolution helper in `design.md` (deliverable #15) that auto-detects `.moai/brain/IDEA-XXX/claude-design-handoff/` as a candidate bundle source.
+
+### 1.3 Existing Project Workflow (downstream consumer)
+
+**Workflow**: `.claude/skills/moai/workflows/project.md` (46,614 bytes)
+**Agent**: `.claude/agents/moai/manager-project.md`
+
+`/moai project` currently generates `product.md`, `structure.md`, `tech.md` based on:
+1. User natural language input
+2. Existing codebase scanning (Glob, Grep)
+3. Optional brand context from `.moai/project/brand/`
+
+This SPEC adds a fourth, highest-priority input source: `.moai/brain/IDEA-XXX/proposal.md` consumed via the new `--from-brain IDEA-XXX` flag (deliverable #13). When present, proposal.md becomes the primary source of truth for product scope; codebase scanning becomes secondary corroboration.
+
+**Boundary**: brain output does NOT replace project output. They are sequential phases:
+- brain = WHO/WHY (vision, market, user, decomposition candidates)
+- project = WHAT (product/structure/tech docs grounded in brain proposal)
+
+### 1.4 Existing Plan Workflow (downstream consumer)
+
+**Workflow**: `.claude/skills/moai/workflows/plan.md` (36,153 bytes)
+**Agent**: `.claude/agents/moai/manager-spec.md`
+
+`/moai plan` currently accepts a free-form description and produces a single SPEC. The patch in deliverable #14 makes plan aware of `proposal.md`'s "SPEC Decomposition Candidates" section: when a user runs `/moai plan SPEC-XXX-001` (or no SPEC ID at all) within a project that has `.moai/brain/IDEA-XXX/proposal.md`, plan can pre-populate candidate suggestions from the proposal's decomposition list.
+
+**Constraint**: This is **suggestion only** — the user retains full control over which SPECs to commit to. plan.md's existing AskUserQuestion confirmation gate is preserved.
+
+### 1.5 Workflow Router
+
+**Skill**: `.claude/skills/moai/SKILL.md`
+**Command**: `.claude/commands/moai/moai.md`
+
+Subcommand routing currently recognizes: `plan`, `run`, `sync`, `design`, `db`, `project`, `fix`, `loop`, `mx`, `feedback`, `review`, `clean`, `codemaps`, `coverage`, `e2e`. Adding `brain` to this router (deliverable #5 + #8) follows the established pattern — the router parses the first positional arg, dispatches to `.claude/skills/moai/workflows/brain.md`, and surfaces no other behavioral change.
+
+### 1.6 Agent Catalog
+
+**Existing managers** (`.claude/agents/moai/manager-*.md`):
+- manager-spec, manager-ddd, manager-docs, manager-git, manager-project, manager-strategy
+- manager-quality, manager-tdd (planned)
+
+**Pattern observation**: Each manager owns one workflow phase. `manager-brain` (deliverable #6) extends this pattern, owning phases 1-7 of the brain workflow. It delegates to:
+- `moai-foundation-thinking` (Phase 1 Discovery, Phase 2 Diverge, Phase 4 Converge, Phase 5 Critical Eval)
+- `moai-domain-research` (Phase 3 Research) — new skill in this SPEC
+- `moai-domain-ideation` (artifact assembly, Lean Canvas, decomposition list) — new skill in this SPEC
+- `moai-domain-design-handoff` (Phase 7) — new skill in this SPEC
+
+### 1.7 Template-First Discipline
+
+[HARD] Every new file under `.claude/`, `.moai/` MUST also exist in `internal/template/templates/`.
+
+The 17 deliverables include `internal/template/templates/.moai/brain/.gitkeep` and a worked example directory `IDEA-EXAMPLE/` so newly scaffolded projects (`moai init`) include the brain output directory. Skills, agents, and commands all have template mirrors.
+
+### 1.8 Thin Command Pattern
+
+**Rule** (coding-standards.md): Command body under 20 LOC, delegate to skill via "Use the {skill} skill to execute {workflow}".
+
+Deliverable #7 (`.claude/commands/moai-brain.md`) follows this pattern. The rich workflow logic lives in `.claude/skills/moai/workflows/brain.md` (deliverable #1, ~600 lines).
+
+---
+
+## 2. Anthropic / External Best-Practice References
+
+### 2.1 Ideation-to-Spec Pipelines
+
+**Pattern (industry-standard)**: Lean Canvas (Ash Maurya, 2010) and Business Model Canvas (Osterwalder) are the de facto ideation-to-proposal artifacts in startup methodology. Both decompose vague ideas into 9 testable blocks: Problem, Customer Segments, Unique Value Proposition, Solution, Channels, Revenue Streams, Cost Structure, Key Metrics, Unfair Advantage. The brain workflow's Phase 4 (Converge → ideation.md with Lean Canvas) adopts this canonical format.
+
+**Source**: https://leanstack.com/lean-canvas (publicly documented)
+
+**Adaptation**: For software-development context (MoAI's domain), the brain workflow weights "Problem" + "Customer Segments" + "Solution" + "Key Metrics" most heavily. Revenue/Cost blocks remain present but are deferred when the product is internal tooling.
+
+### 2.2 First Principles Decomposition (Phase 5 Critical Evaluation)
+
+**Pattern**: Elon Musk's first-principles methodology (popularized via SpaceX/Tesla decisions) breaks problems to fundamental truths rather than reasoning by analogy. `moai-foundation-thinking/modules/first-principles.md` already encodes this as a 5-phase process. Phase 5 of the brain workflow invokes this module on the ideation.md candidates surfaced in Phase 4.
+
+### 2.3 Claude Design Handoff Best Practices
+
+**Source**: Anthropic's Claude Design product documentation (https://claude.com/product/claude-design — publicly accessible)
+
+**Key practices** the Phase 7 prompt template adopts:
+1. **Concrete reference URLs**: paste URLs to existing sites that exemplify desired feel/aesthetic — Claude Design is multimodal and will consume the visuals.
+2. **Explicit acceptance criteria**: state non-negotiable design quality gates (WCAG AA, mobile-first responsive breakpoints, brand color hex codes).
+3. **Brand voice section**: paste the brand voice excerpts directly into the prompt — Claude Design does not have access to `.moai/project/brand/`.
+4. **Out-of-scope list**: explicitly state what is NOT to be designed (e.g., "do not design admin/internal pages", "do not include illustrations beyond hero").
+5. **Tech-stack neutral**: do NOT specify React vs Vue — Claude Design produces design artifacts (Figma-equivalent), not code. Tech stack is decided downstream in `/moai design --path A`.
+
+**Implication for prompt.md template**: 5-section structure (Goal, References, Brand Voice, Acceptance, Out-of-scope) maps directly onto these 5 best practices. The handoff package's `references.md` and `acceptance.md` files are extracted-out versions of sections 2 and 4 to enable per-section regeneration if the user wants to iterate.
+
+### 2.4 Parallel Tool-Call Best Practice
+
+**Source**: Anthropic's Claude documentation on tool use — https://docs.anthropic.com/en/docs/build-with-claude/tool-use
+
+When multiple independent tool calls are needed, issuing them in a single message (multiple `<tool_use>` blocks) is documented as 50-70% faster than sequential calls. REQ-BRAIN-003 mandates this for Phase 3 Research (parallel WebSearch + Context7).
+
+### 2.5 Socratic Interview / Round Limits
+
+**Source**: AskUserQuestion protocol (this project's `.claude/rules/moai/core/askuser-protocol.md`)
+
+- Maximum 4 questions per AskUserQuestion call (Claude Code hard limit)
+- Maximum 4 options per question
+- First option must carry `(권장)` / `(Recommended)` suffix
+- Free-form prose questions prohibited
+
+REQ-BRAIN-002 inherits these limits. Phase 1 Discovery is bounded to 5 rounds × 4 questions = max 20 clarifying questions. Practice (referenced in §3.3 below) suggests 1-2 rounds typically achieves 100% intent clarity for ideation-stage requests, so 5 is a safe upper bound.
+
+---
+
+## 3. Decisions Locked by Conversation Rounds
+
+The fourth Socratic round (referenced in user's spec spawn prompt) locked these design decisions:
+
+### 3.1 Workflow Position
+
+`brain` is a NEW upstream phase BEFORE `project`. Order:
+```
+brain (once) → [user external claude.com Design] → design (path A) → project (once) → plan (per SPEC) → run → sync
+```
+
+`brain` and `project` are run-once artifacts; `plan/run/sync` repeat per SPEC.
+
+### 3.2 Output Format
+
+Markdown only (decision in user's spawn prompt §"Out of Scope"). No JSON canvas, no YAML proposal. Rationale: human review velocity > machine parsing — proposal.md is read by humans before consumed by `/moai project --from-brain`. The decomposition list inside proposal.md is the only machine-parsed section, and uses a simple bullet-list grammar.
+
+### 3.3 Discovery Round Cap
+
+Max 5 rounds (REQ-BRAIN-002). User decision: ideation-stage requests rarely exceed 2-3 rounds in practice; 5 is a safety ceiling, not a target.
+
+### 3.4 Phase 7 Mandatory Inclusion
+
+Phase 7 (Claude Design Handoff Package) is NOT optional. User correction during the fourth round: "you forgot Claude Design handoff — that's the whole point of the workflow". This SPEC treats the handoff package as a first-class deliverable with its own 5-file structure (prompt.md / context.md / references.md / acceptance.md / checklist.md).
+
+### 3.5 Tech-Stack Agnostic Output (16-language neutrality)
+
+REQ-BRAIN-008 enforces that brain artifacts do not assume a specific programming language or framework. Even if the user's idea mentions "Python web app", the proposal.md should describe the proposal at the product level (not "FastAPI + PostgreSQL"). Tech selection is deferred to `/moai project` and `/moai plan`.
+
+### 3.6 Self-Bootstrap (Web SPEC will use Brain)
+
+The Web dashboard SPEC (SPEC-V3R3-WEB-001) will be ideated USING the brain workflow once this SPEC ships. This is the canonical proof-of-concept. Note: this dependency direction means SPEC-V3R3-WEB-001 cannot start until SPEC-V3R3-BRAIN-001 is merged.
+
+---
+
+## 4. Risk Surface
+
+### 4.1 Phase 7 Prompt Quality Risk (HIGH)
+
+**Risk**: A poorly-templated prompt.md produces a Claude Design output that misses the user's brand voice or feature scope, requiring manual editing — defeating the "paste-ready" promise of REQ-BRAIN-005.
+
+**Mitigation**:
+- prompt.md template includes a self-review checklist before final write (manager-brain validates structure presence)
+- Phase 7 acceptance gate: AskUserQuestion confirms user reviewed handoff package before workflow exit
+- IDEA-EXAMPLE/ template ships with a worked example so users see the expected output shape
+- `--regenerate` flag (REQ-BRAIN-009 option c) allows iteration without re-running phases 1-6
+
+### 4.2 Brand Context Absent (MEDIUM)
+
+**Risk**: First-time projects without `.moai/project/brand/` populated produce generic-voice prompts. REQ-BRAIN-006 specifies brand integration but does not define the absent-fallback.
+
+**Mitigation**:
+- When brand context absent, Phase 7 emits a "Brand Voice (default — please customize)" section with a placeholder warning
+- AskUserQuestion offers user the option to run brand interview before Phase 7 (or accept default)
+- acceptance.md scenario #2 verifies graceful fallback (covered in this SPEC's acceptance.md)
+
+### 4.3 Claude.com Design External Dependency (MEDIUM)
+
+**Risk**: Claude Design product UX changes break the prompt template assumptions; the workflow has no direct integration test with claude.com.
+
+**Mitigation**:
+- prompt.md template is designed to be human-readable instructions, not machine-formatted — robust to UX changes
+- references.md and acceptance.md are static design-quality artifacts independent of Claude Design's UI
+- This SPEC's acceptance scenario #1 stops at "handoff package generated" — does not require Claude Design execution
+
+### 4.4 Self-Bootstrap Order (LOW)
+
+**Risk**: Pressure to start SPEC-V3R3-WEB-001 before BRAIN ships could lead to brain workflow being designed around web-specific assumptions, breaking generality.
+
+**Mitigation**:
+- This SPEC explicitly lists "Web UI for brain" in Out-of-Scope (web SPEC depends on brain, not vice versa)
+- REQ-BRAIN-008 (16-language neutrality) is testable at acceptance — see scenario #5
+
+### 4.5 SPEC Decomposition Format Drift (LOW)
+
+**Risk**: proposal.md's "SPEC Decomposition Candidates" section format diverges from what `/moai plan --from-brain` expects.
+
+**Mitigation**:
+- proposal.md template fixes the section grammar: `### SPEC Decomposition Candidates` heading + bullet list `- SPEC-XXX-NNN: <one-line scope>`
+- plan.md patch (deliverable #14) implements a defensive parser that surfaces non-conforming entries as warnings, never errors
+- Acceptance scenario #4 verifies parseability
+
+---
+
+## 5. Reuse Inventory
+
+| Asset | Status | Used By |
+|-------|--------|---------|
+| moai-foundation-thinking (Diverge-Converge) | exists | brain Phase 2, 4 |
+| moai-foundation-thinking (Critical Evaluation) | exists | brain Phase 5 |
+| moai-foundation-thinking (Deep Questioning) | exists | brain Phase 1 Discovery |
+| moai-foundation-thinking (First Principles) | exists | brain Phase 5 (alongside Critical Eval) |
+| moai-workflow-design-import | exists | downstream consumer of Phase 7 output |
+| moai-workflow-spec | exists | downstream consumer of proposal.md |
+| moai-workflow-project | exists | downstream consumer (--from-brain flag patch) |
+| AskUserQuestion + ToolSearch protocol | exists | Phase 1 Discovery, Phase 6 confirmation, Phase 7 next-action |
+| MoAI thin command pattern | exists | deliverable #7 conformance |
+| Template-First scaffold pattern | exists | deliverable #11, #12 |
+
+**No new infrastructure is required**. The 17 deliverables are pure compositions over existing primitives.
+
+---
+
+## 6. Estimated Effort
+
+| Component | LOC | Confidence |
+|-----------|-----|------------|
+| `.claude/skills/moai/workflows/brain.md` (orchestration) | ~600 | High |
+| `moai-domain-ideation/SKILL.md` (Lean Canvas + decomposition assembly) | ~400 | High |
+| `moai-domain-research/SKILL.md` (parallel WebSearch + Context7) | ~350 | Medium |
+| `moai-domain-design-handoff/SKILL.md` (prompt template) | ~450 | Medium |
+| `manager-brain.md` (agent definition) | ~250 | High |
+| `moai-brain.md` (thin command, ≤20 LOC body + frontmatter) | ~80 | High |
+| `moai.md` patch (subcommand router) | ~30 | High |
+| `internal/cli/brain.go` (Go entry) | ~150 | High |
+| `internal/cli/root.go` patch | ~10 | High |
+| `internal/template/templates/.moai/brain/IDEA-EXAMPLE/` (5 files × ~50 lines) | ~250 | Medium |
+| `project.md` patch (--from-brain flag) | ~80 | High |
+| `plan.md` patch (decomposition parser) | ~100 | Medium |
+| `design.md` patch (bundle auto-detect) | ~40 | High |
+| `internal/cli/brain_test.go` | ~200 | High |
+| `internal/template/commands_audit_test.go` extension | ~50 | High |
+| **Total** | **~3,040** | Medium-High |
+
+(Plan-spawn estimate of ~2,400 was a floor; this SPEC adds explicit research and handoff sub-skills which lift the realistic estimate. Both estimates within the same order of magnitude — no SPEC-split needed.)
+
+---
+
+## 7. Open Questions Resolved by This Research
+
+1. **Q**: Does brain replace `/moai plan` ideation? **A**: No. plan retains its current ideation hooks; brain is upstream-only. (decision §3.1)
+2. **Q**: Is JSON output supported? **A**: No, markdown only. (decision §3.2)
+3. **Q**: Can users skip Phase 7? **A**: No, mandatory per user correction. (decision §3.4)
+4. **Q**: Should brain auto-trigger `/moai project`? **A**: No, AskUserQuestion offers it as REQ-BRAIN-009 option (a) — user controls. (decision §3.6 + REQ-BRAIN-009)
+5. **Q**: How is brand context absence handled? **A**: Default-voice fallback with user customization prompt. (mitigation §4.2)
+
+---
+
+## 8. References
+
+- `.claude/skills/moai-foundation-thinking/SKILL.md` (Diverge-Converge, Critical Evaluation, Deep Questioning, First Principles)
+- `.claude/skills/moai-workflow-design-import/SKILL.md` (downstream import path)
+- `.claude/skills/moai/workflows/project.md` (downstream project consumer)
+- `.claude/skills/moai/workflows/plan.md` (downstream plan consumer)
+- `.claude/skills/moai/workflows/design.md` (path A integration)
+- `.claude/rules/moai/core/askuser-protocol.md` (Socratic interview rules)
+- `.claude/rules/moai/development/coding-standards.md` (Thin Command Pattern, frontmatter schema)
+- Lean Canvas (Ash Maurya, 2010) — https://leanstack.com/lean-canvas
+- Anthropic Claude Design product documentation — https://claude.com/product/claude-design
+- Anthropic tool-use parallel-call documentation — https://docs.anthropic.com/en/docs/build-with-claude/tool-use
+
+---
+
+**Status**: Research complete. Spec.md / plan.md / acceptance.md follow.

--- a/.moai/specs/SPEC-V3R3-BRAIN-001/spec-compact.md
+++ b/.moai/specs/SPEC-V3R3-BRAIN-001/spec-compact.md
@@ -1,0 +1,125 @@
+---
+spec_id: SPEC-V3R3-BRAIN-001
+artifact: spec-compact
+version: "0.1.0"
+source: spec.md
+created_at: 2026-05-04
+updated_at: 2026-05-04
+---
+
+# SPEC-V3R3-BRAIN-001 — Compact Summary
+
+**Title**: `/moai brain` — Idea-to-Item Workflow with Claude Design Handoff Package
+**Priority**: P1
+**Status**: draft
+**Phase**: v3.0.0 — Phase 8 — Brain Workflow Introduction
+**Author**: MoAI Plan Workflow
+**created_at**: 2026-05-04 | **updated_at**: 2026-05-04
+**Harness**: standard
+
+---
+
+## Goal (1 sentence)
+
+Introduce a pre-spec ideation workflow `/moai brain` that converts vague user ideas into validated product proposals with SPEC decomposition candidates AND a paste-ready Claude Design handoff package.
+
+## Workflow Position
+
+```
+brain (NEW, once) → [external claude.com Design] → design (path A) → project (once) → plan (per SPEC) → run → sync
+```
+
+## 7 Phases
+
+1. Discovery — Socratic interview (clarity score ≤ 3 triggers up to 5 rounds)
+2. Diverge — 5-15 angle variations (reuses moai-foundation-thinking)
+3. Research — parallel WebSearch + Context7 → research.md
+4. Converge — Lean Canvas → ideation.md
+5. Critical Evaluation — First Principles + Critical Eval (appended to ideation.md)
+6. Proposal — proposal.md with "SPEC Decomposition Candidates" section
+7. Handoff — claude-design-handoff/ (5 files: prompt/context/references/acceptance/checklist)
+
+## Output Layout
+
+```
+.moai/brain/IDEA-NNN/
+├── research.md
+├── ideation.md
+├── proposal.md
+└── claude-design-handoff/{prompt, context, references, acceptance, checklist}.md
+```
+
+## EARS Requirements (12 total)
+
+| ID | Type | Summary |
+|----|------|---------|
+| REQ-BRAIN-001 | Event-Driven | 7 phases execute sequentially |
+| REQ-BRAIN-002 | Event-Driven | ≤5 Discovery rounds when clarity ≤ 3 |
+| REQ-BRAIN-003 | Event-Driven | Parallel WebSearch + Context7 in single message |
+| REQ-BRAIN-004 | Event-Driven | proposal.md "SPEC Decomposition Candidates" section, 2-10 entries |
+| REQ-BRAIN-005 | Event-Driven | prompt.md is paste-ready (no MoAI tokens) |
+| REQ-BRAIN-006 | Optional | Brand voice integrated when present |
+| REQ-BRAIN-007 | Event-Driven | `/moai project --from-brain` consumes proposal.md |
+| REQ-BRAIN-008 | Ubiquitous | 16-language neutrality |
+| REQ-BRAIN-009 | Event-Driven | Phase 7 exit AskUserQuestion (3 options) |
+| REQ-BRAIN-010 | Unwanted | NO auto-execution of /moai project |
+| REQ-BRAIN-011 | Unwanted | NO tech-stack in proposal.md |
+| REQ-BRAIN-012 | Unwanted | NO prose questions (AskUserQuestion only) |
+
+## Files (17 deliverables = 10 NEW + 7 PATCH)
+
+> Deliverable #12 is a directory containing 8 worked-example sub-files; deliverable count anchors on the directory entry.
+
+**Skills (5)**: workflows/brain.md (NEW), moai-domain-ideation (NEW), moai-domain-research (NEW), moai-domain-design-handoff (NEW), moai/SKILL.md (PATCH)
+**Agents (1)**: manager-brain.md (NEW)
+**Commands (2)**: moai-brain.md (NEW, Thin Pattern), commands/moai.md (PATCH)
+**Go CLI (2)**: internal/cli/brain.go (NEW), root.go (PATCH)
+**Templates (2)**: .moai/brain/.gitkeep (NEW), IDEA-EXAMPLE/ (NEW directory; 8 sub-files)
+**Workflow Patches (3)**: project.md (PATCH, --from-brain), plan.md (PATCH, decomposition parser), design.md (PATCH, bundle auto-detect)
+**Tests (2)**: internal/cli/brain_test.go (NEW), commands_audit_test.go (PATCH)
+
+NEW set: #1, #2, #3, #4, #6, #7, #9, #11, #12, #16 (10)
+PATCH set: #5, #8, #10, #13, #14, #15, #17 (7)
+
+## Reuse Inventory
+
+- moai-foundation-thinking: Diverge-Converge, Critical Evaluation, Deep Questioning, First Principles
+- moai-workflow-design-import: downstream consumer of Phase 7 output
+- AskUserQuestion + ToolSearch protocol
+- MoAI Thin Command Pattern, Template-First scaffold
+
+**No new infrastructure required** — pure composition over existing primitives.
+
+## Risk Top 3
+
+1. Phase 7 prompt quality (HIGH) — mitigated by self-review + IDEA-EXAMPLE + --regenerate
+2. Brand absent (MEDIUM) — mitigated by default-voice fallback + AskUserQuestion offer
+3. Claude.com Design external (MEDIUM) — mitigated by human-readable template, not machine-parsed
+
+## Estimated LOC
+
+~3,050 (skills/agent ~2,180 + Go CLI ~410 + tests ~250 + examples/patches ~210)
+
+## Out of Scope
+
+Web UI for brain (separate SPEC-V3R3-WEB-001), automated claude.com execution, brain v0.2 extensions (Persona, Competitor Matrix, GAN loop), multi-IDEA orchestration, replacing /moai plan, JSON output, non-software ideas, 4-locale docs (deferred to /moai sync).
+
+## Dependencies
+
+- Upstream: NONE (all foundation skills exist)
+- Downstream: SPEC-V3R3-WEB-001 (will be self-bootstrapped using brain)
+
+## Acceptance Scenarios
+
+1. Happy path — full 7 phases (REQ-BRAIN-001/005/009)
+2. Brand absent — graceful default-voice (REQ-BRAIN-006)
+3. WebSearch failure — partial-result tolerance (REQ-BRAIN-003)
+4. proposal.md decomposition parseable by /moai plan (REQ-BRAIN-004/007)
+5. Language neutrality — Python idea → tech-agnostic proposal (REQ-BRAIN-008/011)
+6. AskUserQuestion enforcement — no prose questions (REQ-BRAIN-012)
+
+Plus 5 edge cases (multi-IDEA, mid-workflow interrupt, Phase 7 regenerate, empty decomposition, concurrent invocations).
+
+---
+
+**See**: research.md, spec.md, plan.md, acceptance.md

--- a/.moai/specs/SPEC-V3R3-BRAIN-001/spec.md
+++ b/.moai/specs/SPEC-V3R3-BRAIN-001/spec.md
@@ -1,0 +1,315 @@
+---
+id: SPEC-V3R3-BRAIN-001
+version: "0.1.0"
+status: draft
+created_at: 2026-05-04
+updated_at: 2026-05-04
+author: MoAI Plan Workflow
+priority: P1
+labels: [brain, ideation, workflow, handoff, claude-design, v3r3]
+issue_number: null
+phase: "v3.0.0 — Phase 8 — Brain Workflow Introduction"
+module: "internal/cli/, .claude/skills/moai/workflows/, .claude/skills/moai-domain-ideation/, .claude/skills/moai-domain-research/, .claude/skills/moai-domain-design-handoff/, .claude/agents/manager-brain.md, .claude/commands/moai-brain.md, .moai/brain/"
+dependencies: []
+related_specs: [SPEC-V3R3-WEB-001]
+breaking: false
+bc_id: []
+lifecycle: spec-anchored
+tags: "brain, ideation, workflow, handoff, claude-design, v3r3"
+harness: standard
+---
+
+# SPEC-V3R3-BRAIN-001: `/moai brain` — Idea-to-Item Workflow with Claude Design Handoff Package
+
+## HISTORY
+
+| Version | Date       | Author | Description |
+|---------|------------|--------|-------------|
+| 0.1.0   | 2026-05-04 | MoAI Plan Workflow | Initial SPEC — `/moai brain` pre-spec ideation workflow with 7 phases producing proposal.md + Claude Design handoff package. Self-bootstrap pattern: SPEC-V3R3-WEB-001 will be ideated USING this workflow once shipped. |
+
+---
+
+## 1. Goal
+
+Introduce a brand-new pre-spec ideation workflow `/moai brain` that converts vague user ideas into validated product proposals AND produces a ready-to-use Claude Design handoff package. The workflow is the missing upstream phase that converts "I have a fuzzy idea" into "I have a concrete product proposal with SPEC decomposition candidates AND a paste-ready prompt for claude.com Design".
+
+### 1.1 Workflow Chain (post-shipping)
+
+```
+/moai brain "idea"
+    ↓ produces
+.moai/brain/IDEA-XXX/{research.md, ideation.md, proposal.md, claude-design-handoff/}
+
+[USER EXTERNAL ACTION: paste handoff package into claude.com Design]
+
+/moai design --path A --bundle <claude-design-output>   (existing, reused)
+/moai project --from-brain IDEA-XXX                     (proposal.md → product/structure/tech.md)
+/moai plan SPEC-XXX-NNN                                  (per SPEC, may pre-populate from proposal.md decomposition)
+[Run Gate: worktree | sequential | parallel]
+/moai run SPEC-XXX-NNN
+/moai sync
+```
+
+### 1.2 Cardinality
+
+| Phase | Cardinality | Reason |
+|-------|-------------|--------|
+| brain | once per project | Vision is set once; if vision changes, run brain again with new IDEA-NNN |
+| project | once per project | Product/structure/tech docs are project-scoped, refreshed on major changes |
+| plan / run / sync | per SPEC (many) | SPECs are the unit of work — brain emits 2-10 candidates per IDEA |
+
+---
+
+## 2. Phase Structure
+
+The brain workflow comprises 7 phases. Phases 1-6 produce the product proposal; Phase 7 produces the Claude Design handoff package.
+
+| Phase | Purpose | Inputs | Outputs |
+|-------|---------|--------|---------|
+| 1. Discovery | Socratic interview to clarify vague idea | User input | clarified_intent (in-memory JSON) |
+| 2. Diverge | Reuse `moai-foundation-thinking` Diverge-Converge — generate 5-15 angle variations | clarified_intent | divergent_concepts list (in-memory) |
+| 3. Research | Parallel WebSearch + Context7 + market scan via `moai-domain-research` skill | divergent_concepts | `research.md` |
+| 4. Converge | Reduce to 1-3 viable concepts; build Lean Canvas section | research.md + divergent_concepts | `ideation.md` (with Lean Canvas) |
+| 5. Critical Evaluation | First Principles + Critical Evaluation from `moai-foundation-thinking` | ideation.md | evaluation_report inline in `ideation.md` |
+| 6. Proposal | Final product proposal with SPEC decomposition candidate list | ideation.md + evaluation | `proposal.md` |
+| 7. Claude Design Handoff Package | Generate paste-ready prompt + curated references + acceptance criteria for claude.com Design | proposal.md + brand context (if exists) | `claude-design-handoff/{prompt.md, context.md, references.md, acceptance.md, checklist.md}` |
+
+---
+
+## 3. Output Directory Layout
+
+```
+.moai/brain/
+└── IDEA-001/                              ← auto-incremented per project
+    ├── research.md                         ← Phase 3 output: market/tech research
+    ├── ideation.md                         ← Phase 4-5 output: Lean Canvas + critical eval
+    ├── proposal.md                         ← Phase 6 output: final proposal + SPEC decomposition
+    └── claude-design-handoff/              ← Phase 7 output (5 files)
+        ├── prompt.md                       ← paste-ready prompt for claude.com Design
+        ├── context.md                      ← brand voice + Lean Canvas summary
+        ├── references.md                   ← curated reference sites/screenshots
+        ├── acceptance.md                   ← design quality criteria (WCAG, brand consistency)
+        └── checklist.md                    ← 5-step user external action guide
+```
+
+IDEA-NNN auto-increments. Multiple IDEAs per project are permitted but conventionally one is used.
+
+---
+
+## 4. EARS Requirements
+
+### 4.1 Workflow Execution
+
+**REQ-BRAIN-001** (Event-Driven, Mandatory):
+WHEN user invokes `/moai brain "<idea>"`, THE system SHALL execute Phase 1-7 sequentially, producing all artifacts under `.moai/brain/IDEA-XXX/`.
+
+**REQ-BRAIN-002** (Event-Driven, Mandatory):
+WHEN the user idea has a low clarity score, THE Discovery phase SHALL conduct Socratic interview rounds via AskUserQuestion before proceeding to Diverge, using the canonical 5-dimension clarity-scoring algorithm defined in `.claude/skills/moai/workflows/plan.md` Phase 0.3 for the score itself, but applying the brain-specific score-to-rounds mapping below (which inverts plan-workflow's mapping because brain's purpose is ideation depth, not requirements speed): score 1-3 → up to 5 rounds (high ambiguity needs deep clarification), score 4-6 → up to 3 rounds, score 7-10 → up to 1 round (verify intent only). Maximum 5 rounds total to comply with AskUserQuestion practical limits.
+
+**REQ-BRAIN-003** (Event-Driven, Mandatory):
+WHEN Phase 3 Research executes, THE system SHALL invoke WebSearch and Context7 MCP in parallel (single message, multiple tool calls) and produce `research.md` with all sources cited.
+
+### 4.2 Artifact Contracts
+
+**REQ-BRAIN-004** (Event-Driven, Mandatory):
+WHEN Phase 6 Proposal is generated, `proposal.md` SHALL include a "SPEC Decomposition Candidates" section listing 2-10 candidate SPEC IDs with one-line scope each, using grammar `- SPEC-{DOMAIN}-{NUM}: {scope}`.
+
+**REQ-BRAIN-005** (Event-Driven, Mandatory):
+WHEN Phase 7 Handoff is generated, `claude-design-handoff/prompt.md` SHALL be paste-ready (no MoAI-specific tokens, no internal SPEC IDs) so user can copy-paste into claude.com Design without editing.
+
+**REQ-BRAIN-006** (Optional, Conditional):
+WHERE `.moai/project/brand/` exists with `brand-voice.md`, Phase 7 SHALL incorporate brand voice into `prompt.md` and `context.md`.
+
+### 4.3 Downstream Integration
+
+**REQ-BRAIN-007** (Event-Driven, Mandatory):
+WHEN `/moai project --from-brain IDEA-XXX` is invoked AFTER brain completes, THE project workflow SHALL load `proposal.md` and use it as primary input for `product.md`/`structure.md`/`tech.md` generation, treating user codebase as secondary corroboration.
+
+### 4.4 Constraints
+
+**REQ-BRAIN-008** (Ubiquitous, Mandatory):
+THE brain workflow SHALL be language-neutral — neither prompt templates nor research patterns SHALL favor specific tech stack or programming language. The 16 languages supported by MoAI-ADK (go, python, typescript, javascript, rust, java, kotlin, csharp, ruby, php, elixir, cpp, scala, r, flutter, swift) are equally valid output targets.
+
+**REQ-BRAIN-009** (Event-Driven, Mandatory):
+WHEN brain completes Phase 7 successfully, THE system SHALL emit AskUserQuestion offering: (a) proceed to `/moai project --from-brain IDEA-XXX` (Recommended), (b) review artifacts manually first, (c) regenerate handoff package with adjustments.
+
+### 4.5 Negative Requirements (Unwanted Behavior)
+
+**REQ-BRAIN-010** (Unwanted, Mandatory):
+THE system SHALL NOT auto-execute `/moai project` after brain completes — user explicit choice via REQ-BRAIN-009 AskUserQuestion is required.
+
+**REQ-BRAIN-011** (Unwanted, Mandatory):
+THE Phase 6 proposal.md SHALL NOT specify implementation language or framework versions — tech selection is deferred to `/moai project` and `/moai plan`.
+
+**REQ-BRAIN-012** (Unwanted, Mandatory):
+THE Phase 1 Discovery SHALL NOT use free-form prose questions — all clarification questions MUST go through AskUserQuestion with ToolSearch preload (per `.claude/rules/moai/core/askuser-protocol.md`).
+
+---
+
+## 5. Files to Create / Modify
+
+**Total: 17 deliverables (10 NEW + 7 PATCH)**
+
+> Deliverable count anchors at 17 logical entries. Deliverable #12 is a single template directory whose 8 sub-files (enumerated in §5.5) are components of that one deliverable. Actual file-system artifact count = 16 single-file entries (#1–#11, #13–#17) + 8 sub-files of #12 = 24 files. Audit accounting uses the deliverable count (17).
+
+### 5.1 Skills (5)
+
+| # | Path | Type | Purpose |
+|---|------|------|---------|
+| 1 | `.claude/skills/moai/workflows/brain.md` | NEW (~600 LOC) | Workflow orchestration; phase contract; AskUserQuestion sequences |
+| 2 | `.claude/skills/moai-domain-ideation/SKILL.md` | NEW (~400 LOC) | Diverge/Converge/Lean Canvas patterns (thin orchestrator over `moai-foundation-thinking`) |
+| 3 | `.claude/skills/moai-domain-research/SKILL.md` | NEW (~350 LOC) | WebSearch/Context7/market-scan parallel patterns |
+| 4 | `.claude/skills/moai-domain-design-handoff/SKILL.md` | NEW (~450 LOC) | Claude Design prompt template + brand voice integration |
+| 5 | `.claude/skills/moai/SKILL.md` | PATCH | Add `brain` to subcommand router (Priority 1 routing) |
+
+### 5.2 Agents (1)
+
+| # | Path | Type | Purpose |
+|---|------|------|---------|
+| 6 | `.claude/agents/manager-brain.md` | NEW (~250 LOC) | Brain workflow coordinator; delegates to ideation/research/handoff skills |
+
+### 5.3 Commands (2)
+
+| # | Path | Type | Purpose |
+|---|------|------|---------|
+| 7 | `.claude/commands/moai-brain.md` | NEW (Thin Command, ≤20 LOC body) | `/moai:brain` slash command wrapper |
+| 8 | `.claude/commands/moai.md` | PATCH | Recognize `brain` as subcommand of `/moai` |
+
+### 5.4 Go CLI (2)
+
+| # | Path | Type | Purpose |
+|---|------|------|---------|
+| 9 | `internal/cli/brain.go` | NEW (~150 LOC) | `moai brain` terminal command (delegates to slash by spawning Claude Code session OR prints instructions) |
+| 10 | `internal/cli/root.go` | PATCH | Register `brainCmd` with cobra root |
+
+### 5.5 Output Directory Templates (2)
+
+| # | Path | Type | Purpose |
+|---|------|------|---------|
+| 11 | `internal/template/templates/.moai/brain/.gitkeep` | NEW | Ensure dir exists in scaffolded projects |
+| 12 | `internal/template/templates/.moai/brain/IDEA-EXAMPLE/` (directory; contains 8 sub-files enumerated below) | NEW | Worked example handoff package for user reference |
+
+Sub-files of deliverable #12 (each ~50 LOC, all NEW; per `plan.md` §A6.2):
+
+| Sub-path | Purpose |
+|----------|---------|
+| `IDEA-EXAMPLE/research.md` | Worked example: market research for hypothetical SaaS |
+| `IDEA-EXAMPLE/ideation.md` | Worked example: Lean Canvas filled in |
+| `IDEA-EXAMPLE/proposal.md` | Worked example: 3 SPEC decomposition candidates |
+| `IDEA-EXAMPLE/claude-design-handoff/prompt.md` | Worked example: paste-ready Claude Design prompt |
+| `IDEA-EXAMPLE/claude-design-handoff/context.md` | Worked stub: brand voice + Lean Canvas summary |
+| `IDEA-EXAMPLE/claude-design-handoff/references.md` | Worked stub: curated reference URLs/screenshots |
+| `IDEA-EXAMPLE/claude-design-handoff/acceptance.md` | Worked stub: design quality criteria |
+| `IDEA-EXAMPLE/claude-design-handoff/checklist.md` | Worked stub: 5-step user external-action guide |
+
+### 5.6 Workflow Integration Patches (3)
+
+| # | Path | Type | Purpose |
+|---|------|------|---------|
+| 13 | `.claude/skills/moai/workflows/project.md` | PATCH | Accept `--from-brain IDEA-XXX` flag; consume proposal.md when generating product/structure/tech.md |
+| 14 | `.claude/skills/moai/workflows/plan.md` | PATCH | When proposal.md detected, pre-populate SPEC candidates from decomposition list |
+| 15 | `.claude/skills/moai/workflows/design.md` | PATCH | Auto-detect `.moai/brain/IDEA-XXX/claude-design-handoff/` as path A bundle source |
+
+### 5.7 Tests (2)
+
+| # | Path | Type | Purpose |
+|---|------|------|---------|
+| 16 | `internal/cli/brain_test.go` | NEW (~200 LOC) | Unit tests for brain CLI command |
+| 17 | `internal/template/commands_audit_test.go` | PATCH | Verify new `moai-brain.md` matches Thin Command Pattern |
+
+### 5.8 Documentation (deferred to `/moai sync`)
+
+NOT in this SPEC's deliverables — flagged for follow-up sync:
+- `docs-site/content/{ko,en,ja,zh}/v3/workflows/brain.md` (4-locale)
+
+---
+
+## 6. Constraints
+
+[HARD] **16-language neutrality** (REQ-BRAIN-008): Phase 3 research must not auto-suggest specific tech stacks. Even if user mentions "Python", proposal.md describes the proposal at the product level.
+
+[HARD] **Template-First**: Every new file under `.claude/`, `.moai/` MUST also exist in `internal/template/templates/`. (Deliverables #11, #12 enforce this for the brain output directory.)
+
+[HARD] **Thin Command Pattern**: `moai-brain.md` body under 20 LOC (per `.claude/rules/moai/development/coding-standards.md`).
+
+[HARD] **Frontmatter 9-field canonical schema** for spec.md: `id`, `version`, `status`, `created_at`, `updated_at`, `author`, `priority`, `labels`, `issue_number`. NEVER `created`/`updated` (legacy, rejected).
+
+[HARD] **Reuse over re-invention**: `moai-foundation-thinking` provides Diverge/Converge/First Principles/Critical Eval. The new ideation skill is a thin orchestrator, NOT a re-implementation.
+
+[HARD] **Parallel execution** (REQ-BRAIN-003): Phase 3 research MUST issue WebSearch + Context7 calls in a single message (multiple tool blocks), not sequentially.
+
+[HARD] **AskUserQuestion enforcement** (REQ-BRAIN-012): All user-facing decision points (Discovery rounds, Phase 6 confirmation, Phase 7 next-action) use AskUserQuestion with ToolSearch preload. Prose questions ending with `?` are prohibited.
+
+[HARD] **harness level: standard**: plan-auditor auto-engaged at Phase 2.3 of `/moai plan` workflow.
+
+---
+
+## 7. Out of Scope (Exclusions — What NOT to Build)
+
+The following are explicitly excluded from THIS SPEC's deliverables:
+
+1. **Web UI for brain**: `moai web` browser dashboard is a SEPARATE SPEC (SPEC-V3R3-WEB-001) that depends on this one. The web SPEC will itself be ideated using this brain workflow (self-bootstrap pattern).
+2. **Automated execution of claude.com Design**: User manual external action remains. The handoff package is paste-ready; the actual claude.com Design execution is a human step.
+3. **Phase extensions for v0.2**: User Persona Generator, Competitor Matrix, GAN-loop refinement of proposal — deferred to brain v0.2.
+4. **Multi-IDEA orchestration**: Parallel ideation across many IDEA-NNN simultaneously — out of scope, single-IDEA workflow only.
+5. **Replacing `/moai plan` ideation hooks**: plan.md retains its current ideation behavior. The brain SPEC is upstream-only and additive.
+6. **Auto-execution of `/moai plan` after `/moai project`**: User explicitly controls when to enter plan phase.
+7. **Alternative IDEA file formats**: Only markdown — no JSON canvas, no YAML proposal.
+8. **Brain GAN loop**: Iterative quality refinement of proposal.md via evaluator-active — deferred to brain v0.2.
+9. **Brain output for non-software ideas**: brain is scoped to software/product ideation. Non-software brainstorming (e.g., business strategy without software component) is out of scope.
+10. **4-locale documentation in this SPEC**: docs-site updates deferred to `/moai sync` after merge.
+
+---
+
+## 8. Acceptance Criteria
+
+See `acceptance.md` for full Given-When-Then scenarios. Minimum 5 scenarios required:
+
+1. Happy path — vague idea → 7 phases → all artifacts produced (REQ-BRAIN-001)
+2. Brand context absent — Phase 7 graceful default-voice fallback (REQ-BRAIN-006)
+3. Research phase — WebSearch failure handled gracefully (REQ-BRAIN-003)
+4. SPEC decomposition list parseable by `/moai plan --from-brain` (REQ-BRAIN-004)
+5. Language neutrality — Python-mentioning idea produces tech-stack-agnostic proposal (REQ-BRAIN-008)
+
+---
+
+## 9. Definition of Done
+
+- [ ] All 17 files created/patched per §5
+- [ ] All 12 EARS requirements (REQ-BRAIN-001..012) verified via acceptance scenarios
+- [ ] Frontmatter validation: 9 required fields present; `created_at`/`updated_at` (NOT `created`/`updated`); labels is YAML array
+- [ ] `make build` completes successfully (embedded templates regenerated)
+- [ ] `go test ./internal/cli/...` passes including `brain_test.go`
+- [ ] `go test ./internal/template/...` passes including extended `commands_audit_test.go`
+- [ ] `golangci-lint run ./...` zero warnings
+- [ ] plan-auditor PASS on Phase 2.3 of `/moai plan SPEC-V3R3-BRAIN-001`
+- [ ] PR merged to main; no follow-up regressions in `/moai run`, `/moai sync`, `/moai project`, `/moai plan` (smoke tests)
+- [ ] IDEA-EXAMPLE/ template verified to scaffold correctly via `moai init` → `ls .moai/brain/`
+
+---
+
+## 10. Dependencies and Sequencing
+
+**Upstream dependencies**: None. All foundation skills (`moai-foundation-thinking`, `moai-workflow-design-import`) already exist.
+
+**Downstream blockers** (this SPEC unblocks):
+- SPEC-V3R3-WEB-001 (Web dashboard SPEC) — will be ideated using brain workflow once shipped (self-bootstrap proof-of-concept)
+- Future ideation-stage SPECs across all v3 phases
+
+**Parallel SPECs**: None — this is a single-domain SPEC with no shared file ownership conflicts.
+
+---
+
+## 11. References
+
+- `research.md` (this SPEC's siblings) — codebase context, Anthropic best practices, decision log
+- `plan.md` (this SPEC's siblings) — implementation phases, risk analysis, MX tag plan
+- `acceptance.md` (this SPEC's siblings) — 5+ Given-When-Then scenarios
+- `.claude/rules/moai/development/coding-standards.md` — Thin Command Pattern, frontmatter schema
+- `.claude/rules/moai/core/askuser-protocol.md` — Socratic interview rules
+- Lean Canvas (Ash Maurya, 2010) — https://leanstack.com/lean-canvas
+- Anthropic Claude Design — https://claude.com/product/claude-design
+
+---
+
+**Status**: draft (audit-ready post-plan-auditor PASS)


### PR DESCRIPTION
## Summary

`/moai brain` 신규 upstream 워크플로우 SPEC 작성. 아이디어 → 검증된 product proposal + Claude Design 핸드오프 패키지 자동 생성.

워크플로우 체인: `brain → project → plan → run → sync` (brain·project는 프로젝트당 1회).

## SPEC Artifacts

- `.moai/specs/SPEC-V3R3-BRAIN-001/spec.md` — 12 EARS, 17 deliverables (10 NEW + 7 PATCH)
- `.moai/specs/SPEC-V3R3-BRAIN-001/plan.md` — Phase A1-A9 task decomposition, ~3,050 LOC
- `.moai/specs/SPEC-V3R3-BRAIN-001/acceptance.md` — 6 G/W/T scenarios + 5 edge cases
- `.moai/specs/SPEC-V3R3-BRAIN-001/research.md` — moai-foundation-thinking 재사용 분석
- `.moai/specs/SPEC-V3R3-BRAIN-001/spec-compact.md` — Run phase 토큰 절감용
- `.moai/specs/SPEC-V3R3-BRAIN-001/progress.md` — plan/audit phase tracking

## Phase Structure

| Phase | Purpose |
|-------|---------|
| 1. Discovery | Socratic interview (clarity score 기반 1-5 rounds) |
| 2. Diverge | moai-foundation-thinking Diverge-Converge |
| 3. Research | WebSearch + Context7 병렬 자료조사 |
| 4. Converge | Lean Canvas 작성 |
| 5. Critical Evaluation | First Principles + Critical Evaluation |
| 6. Proposal | proposal.md + SPEC decomposition candidates |
| 7. Claude Design Handoff | claude.com 위임용 5-file 패키지 (prompt/context/references/acceptance/checklist) |

## Plan Audit

- iteration 1: FAIL (7 defects)
- iteration 2: FAIL (FD-1 fresh)
- **iteration 3: PASS** ← merge ready

## Test plan

- [ ] manager-spec/builder-skill로 brain workflow skill 작성 (Phase A1)
- [ ] manager-brain agent 정의 (Phase A2)
- [ ] moai-domain-{ideation,research,design-handoff} 3 skills 작성 (Phase A1 동시)
- [ ] Go CLI `moai brain` 추가 + 라우터 통합 (Phase A3)
- [ ] /moai:brain wrapper command (Phase A4)
- [ ] project.md / plan.md / design.md 통합 패치 (Phase A5)
- [ ] Brain 자체 검증 — `/moai brain "테스트 아이디어"` E2E (Phase A6)
- [ ] Self-bootstrap — Brain으로 SPEC-V3R3-WEB-001 ideate (Phase B)

## Self-Bootstrap

본 SPEC 머지 후 `/moai run SPEC-V3R3-BRAIN-001`로 brain 워크플로우 구현 → 완성된 brain으로 SPEC-V3R3-WEB-001 (web 대시보드) ideate → web SPEC 작성/구현.

🗿 MoAI <email@mo.ai.kr>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added specification documentation for the new `/moai brain` ideation workflow, which guides users through a 7-phase process to convert vague ideas into structured product proposals with Claude Design handoff packages. Includes acceptance criteria, implementation plan, research guidelines, and progress tracking for feature rollout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->