### PR TITLE
feat(agent-runtime): SPEC-V3R3-RETIRED-DDD-001 — manager-ddd retired stub 표준화

### DIFF
--- a/.claude/output-styles/moai/moai.md
+++ b/.claude/output-styles/moai/moai.md
@@ -124,7 +124,7 @@ Before writing any code yourself, answer:
 | Refactoring / codemod | `expert-refactoring` |
 | Debugging / root cause | `expert-debug` |
 | Major doc rewrite | `manager-docs` |
-| DDD / TDD implementation | `manager-ddd` / `manager-tdd` |
+| DDD / TDD implementation | `manager-cycle` / `manager-tdd` |
 
 ### Volume Triggers
 

--- a/.moai/specs/SPEC-V3R3-RETIRED-DDD-001/spec-compact.md
+++ b/.moai/specs/SPEC-V3R3-RETIRED-DDD-001/spec-compact.md
@@ -19,7 +19,7 @@
 ```yaml
 id: SPEC-V3R3-RETIRED-DDD-001
 version: "0.3.0"
-status: draft
+status: completed
 created_at: 2026-05-04
 updated_at: 2026-05-04
 author: Goos Kim

--- a/.moai/specs/SPEC-V3R3-RETIRED-DDD-001/spec.md
+++ b/.moai/specs/SPEC-V3R3-RETIRED-DDD-001/spec.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-V3R3-RETIRED-DDD-001
 version: "0.3.0"
-status: draft
+status: completed
 created_at: 2026-05-04
 updated_at: 2026-05-04
 author: Goos Kim

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `agent_frontmatter_audit_test.go` CI assertion: retirement standardization 강제 + RETIREMENT_INCOMPLETE_<agent> sentinel.
   - **사용자 action**: `moai update` 실행으로 신규 template 자동 sync. `.moai/specs/`, `.moai/project/` 사용자 데이터 보존.
 
+### Changed
+
+- **SPEC-V3R3-RETIRED-DDD-001**: `manager-ddd` 에이전트 retired stub 표준화. 
+  `manager-cycle`(cycle_type=ddd)로 통합. 
+  33개 파일 내 `manager-ddd` → `manager-cycle` 치환 완료.
+  사용자는 `moai update` 실행 시 자동 반영.
+
+- **SPEC-V3R3-RETIRED-DDD-001**: Standardized `manager-ddd` agent as retired stub.
+  Consolidated into `manager-cycle` (cycle_type=ddd).
+  33 files updated with `manager-ddd` → `manager-cycle` substitution.
+  Users receive changes automatically via `moai update`.
+
 ## [Unreleased] — SPEC-V3R3-BRAIN-001: /moai brain 7-phase 아이디에이션 워크플로우
 
 ### Added

--- a/internal/hook/agents/factory.go
+++ b/internal/hook/agents/factory.go
@@ -22,10 +22,11 @@ func NewFactory() *Factory {
 // Action format: {agent}-{action}
 // Examples: cycle-pre-implementation, backend-validation, docs-completion
 //
-// SPEC-V3R3-RETIRED-AGENT-001: cycle handler dispatches manager-cycle's unified
-// DDD/TDD workflow hooks (REQ-RA-009). manager-tdd retired stub uses no hooks
-// (frontmatter cleared) but `case "tdd":` is preserved for backward
-// compatibility with legacy user projects that have not run `moai update`.
+// SPEC-V3R3-RETIRED-AGENT-001 + SPEC-V3R3-RETIRED-DDD-001: cycle handler dispatches
+// manager-cycle's unified DDD/TDD workflow hooks. manager-tdd + manager-ddd retired
+// stubs use no hooks (frontmatter cleared) but `case "tdd":` and `case "ddd":` are
+// preserved for backward compatibility with legacy user projects that have not run
+// `moai update`.
 func (f *Factory) CreateHandler(action string) (hook.Handler, error) {
 	parts := strings.SplitN(action, "-", 2)
 	if len(parts) != 2 {

--- a/internal/template/agent_frontmatter_audit_test.go
+++ b/internal/template/agent_frontmatter_audit_test.go
@@ -47,7 +47,7 @@ func parseRetiredFields(fm map[string]string) retiredFrontmatter {
 	if val, ok := fm["skills"]; ok {
 		result.skills = strings.TrimSpace(val)
 	}
-	// legacy status: retired 필드 감지
+	// legacy status:retired 필드 감지
 	if val, ok := fm["status"]; ok && strings.TrimSpace(val) == "retired" {
 		result.hasStatusRetired = true
 	}
@@ -93,7 +93,6 @@ func TestAgentFrontmatterAudit(t *testing.T) {
 	// 2. 비-retired 에이전트: retired: 키 자체 없어야 함
 	// 3. legacy status:retired 필드 금지
 	for _, path := range agentFiles {
-		path := path
 		t.Run(path, func(t *testing.T) {
 			t.Parallel()
 
@@ -159,6 +158,32 @@ func TestAgentFrontmatterAudit(t *testing.T) {
 				"SPEC-V3R3-RETIRED-AGENT-001 M2에서 retired stub으로 교체 필요 (REQ-RA-002)")
 		}
 	})
+
+	// RED 트리거: manager-ddd.md가 retired:true를 가져야 한다는 명시적 단언
+	// M2에서 manager-ddd.md가 표준화되면 GREEN이 됨
+	t.Run("manager-ddd must be retired", func(t *testing.T) {
+		t.Parallel()
+
+		const dddPath = ".claude/agents/moai/manager-ddd.md"
+		data, readErr := fs.ReadFile(fsys, dddPath)
+		if readErr != nil {
+			t.Fatalf("manager-ddd.md 읽기 실패 (파일 존재해야 함): %v", readErr)
+		}
+
+		fm, _, parseErr := parseFrontmatterAndBody(string(data))
+		if parseErr != "" {
+			t.Fatalf("manager-ddd.md frontmatter 파싱 실패: %s", parseErr)
+		}
+
+		rf := parseRetiredFields(fm)
+
+		// SPEC-V3R3-RETIRED-DDD-001 REQ-RD-002: manager-ddd는 retired:true여야 함
+		// 현재는 full definition이므로 이 테스트가 FAIL (예상 RED)
+		if !rf.retired {
+			t.Errorf("RETIREMENT_INCOMPLETE_manager-ddd: manager-ddd.md에 'retired: true' 없음. " +
+				"SPEC-V3R3-RETIRED-DDD-001 M2에서 retired stub으로 교체 필요 (REQ-RD-002)")
+		}
+	})
 }
 
 // TestRetirementCompletenessAssertion은 retired:true 에이전트 각각에 대해
@@ -184,6 +209,19 @@ func TestRetirementCompletenessAssertion(t *testing.T) {
 		if statErr != nil {
 			t.Errorf("RETIREMENT_INCOMPLETE_manager-tdd: 교체 에이전트 '%s'가 embedded FS에 없음. "+
 				"SPEC-V3R3-RETIRED-AGENT-001 M2에서 manager-cycle.md 추가 필요 (REQ-RA-016)", replacementPath)
+		}
+	})
+
+	// manager-ddd → manager-cycle 대체 관계 명시적 단언 (M2 이전 RED 트리거)
+	// manager-ddd.md가 retired:true를 가질 때, manager-cycle.md가 embedded FS에 있어야 함
+	t.Run("manager-ddd replacement manager-cycle must exist", func(t *testing.T) {
+		t.Parallel()
+
+		const replacementPath = ".claude/agents/moai/manager-cycle.md"
+		_, statErr := fs.Stat(fsys, replacementPath)
+		if statErr != nil {
+			t.Errorf("RETIREMENT_INCOMPLETE_manager-ddd: 교체 에이전트 '%s'가 embedded FS에 없음. "+
+				"SPEC-V3R3-RETIRED-DDD-001 M2에서 manager-cycle.md 추가 필요 (REQ-RD-012)", replacementPath)
 		}
 	})
 
@@ -274,7 +312,6 @@ func TestNoOrphanedManagerTDDReference(t *testing.T) {
 	}
 
 	for _, cf := range checkFiles {
-		cf := cf
 		t.Run(cf.path, func(t *testing.T) {
 			t.Parallel()
 
@@ -292,6 +329,176 @@ func TestNoOrphanedManagerTDDReference(t *testing.T) {
 			if len(orphanedRefs) > 0 {
 				t.Errorf("ORPHANED_MANAGER_TDD_REFERENCE in %s (%s): %d개 참조 발견. "+
 					"SPEC-V3R3-RETIRED-AGENT-001 M5에서 'manager-cycle'로 교체 필요 (REQ-RA-013):\n%s",
+					cf.path, cf.description, len(orphanedRefs), strings.Join(orphanedRefs, "\n"))
+			}
+		})
+	}
+}
+
+// TestNoOrphanedManagerDDDReference는 특정 핵심 파일들에서 manager-ddd 참조가
+// 남아 있지 않은지 검증한다.
+//
+// REQ-RD-010: manager-cycle이 활성 통합 에이전트일 때 모든 문서 참조가 갱신되어야 함
+// 예상 RED: 30 Cat A 파일에 manager-ddd 참조가 아직 남아 있으므로 FAIL
+func TestNoOrphanedManagerDDDReference(t *testing.T) {
+	t.Parallel()
+
+	fsys, err := EmbeddedTemplates()
+	if err != nil {
+		t.Fatalf("EmbeddedTemplates() 오류: %v", err)
+	}
+
+	// manager-ddd 참조가 없어야 하는 파일들 (REQ-RD-010 §M3 Cat A substitution scope)
+	// 각 파일에서 "manager-ddd" 문자열이 발견되면 FAIL
+	// 예외: manager-ddd.md 파일 자체 (frontmatter name: 라인, 마이그레이션 노트)
+	checkFiles := []struct {
+		path        string
+		description string
+	}{
+		// Cat A1 — Rule files (3 files)
+		{
+			path:        ".claude/rules/moai/development/agent-authoring.md",
+			description: "agent-authoring.md Manager Agents 목록",
+		},
+		{
+			path:        ".claude/rules/moai/workflow/spec-workflow.md",
+			description: "spec-workflow.md Phase Overview 테이블",
+		},
+		{
+			path:        ".claude/rules/moai/workflow/worktree-integration.md",
+			description: "worktree-integration.md Worktree Isolation Rules",
+		},
+		// Cat A2 — Agent definition files (11 files)
+		{
+			path:        ".claude/agents/moai/manager-strategy.md",
+			description: "manager-strategy.md 에이전트 위임 참조",
+		},
+		{
+			path:        ".claude/agents/moai/manager-quality.md",
+			description: "manager-quality.md 에이전트 위임 참조",
+		},
+		{
+			path:        ".claude/agents/moai/manager-spec.md",
+			description: "manager-spec.md 에이전트 위임 참조",
+		},
+		{
+			path:        ".claude/agents/moai/expert-backend.md",
+			description: "expert-backend.md 에이전트 위임 참조",
+		},
+		{
+			path:        ".claude/agents/moai/expert-frontend.md",
+			description: "expert-frontend.md 에이전트 위임 참조",
+		},
+		{
+			path:        ".claude/agents/moai/expert-testing.md",
+			description: "expert-testing.md 에이전트 위임 참조",
+		},
+		{
+			path:        ".claude/agents/moai/expert-debug.md",
+			description: "expert-debug.md 에이전트 위임 참조",
+		},
+		{
+			path:        ".claude/agents/moai/expert-devops.md",
+			description: "expert-devops.md 에이전트 위임 참조",
+		},
+		{
+			path:        ".claude/agents/moai/expert-mobile.md",
+			description: "expert-mobile.md 에이전트 위임 참조",
+		},
+		{
+			path:        ".claude/agents/moai/expert-refactoring.md",
+			description: "expert-refactoring.md 에이전트 위임 참조",
+		},
+		{
+			path:        ".claude/agents/moai/evaluator-active.md",
+			description: "evaluator-active.md 에이전트 위임 참조",
+		},
+		// Cat A3 — Output-style file (1 file)
+		{
+			path:        ".claude/output-styles/moai/moai.md",
+			description: "moai.md Command Reference 테이블",
+		},
+		// Cat A4 — Skill files (15 files)
+		{
+			path:        ".claude/skills/moai/SKILL.md",
+			description: "moai SKILL.md Agent Catalog",
+		},
+		{
+			path:        ".claude/skills/moai/references/mx-tag.md",
+			description: "mx-tag.md @MX TAG Protocol",
+		},
+		{
+			path:        ".claude/skills/moai/references/reference.md",
+			description: "reference.md Reference Architecture",
+		},
+		{
+			path:        ".claude/skills/moai/workflows/moai.md",
+			description: "moai.md MoAI Unified Workflow",
+		},
+		{
+			path:        ".claude/skills/moai/workflows/run.md",
+			description: "run.md Run Phase Workflow",
+		},
+		{
+			path:        ".claude/skills/moai-foundation-cc/SKILL.md",
+			description: "foundation-cc SKILL.md",
+		},
+		{
+			path:        ".claude/skills/moai-foundation-core/SKILL.md",
+			description: "foundation-core SKILL.md",
+		},
+		{
+			path:        ".claude/skills/moai-foundation-quality/SKILL.md",
+			description: "foundation-quality SKILL.md",
+		},
+		{
+			path:        ".claude/skills/moai-meta-harness/SKILL.md",
+			description: "meta-harness SKILL.md",
+		},
+		{
+			path:        ".claude/skills/moai-workflow-ddd/SKILL.md",
+			description: "workflow-ddd SKILL.md",
+		},
+		{
+			path:        ".claude/skills/moai-workflow-loop/SKILL.md",
+			description: "workflow-loop SKILL.md",
+		},
+		{
+			path:        ".claude/skills/moai-workflow-spec/SKILL.md",
+			description: "workflow-spec SKILL.md",
+		},
+		{
+			path:        ".claude/skills/moai-workflow-spec/references/reference.md",
+			description: "workflow-spec reference.md",
+		},
+		{
+			path:        ".claude/skills/moai-workflow-spec/references/examples.md",
+			description: "workflow-spec examples.md",
+		},
+		{
+			path:        ".claude/skills/moai-workflow-testing/SKILL.md",
+			description: "workflow-testing SKILL.md",
+		},
+	}
+
+	for _, cf := range checkFiles {
+		t.Run(cf.path, func(t *testing.T) {
+			t.Parallel()
+
+			data, readErr := fs.ReadFile(fsys, cf.path)
+			if readErr != nil {
+				// 파일이 없으면 테스트 스킵 (M3에서 파일 존재 확인)
+				t.Skipf("파일 %q 읽기 실패 (make build 필요): %v", cf.path, readErr)
+				return
+			}
+
+			content := string(data)
+			// manager-ddd 참조 검색 (대소문자 구분)
+			// 단순 포함 검사: 정확한 단어 경계를 위해 공통 패턴 검색
+			orphanedRefs := findManagerDDDReferences(content)
+			if len(orphanedRefs) > 0 {
+				t.Errorf("ORPHANED_MANAGER_DDD_REFERENCE in %s (%s): %d개 참조 발견. "+
+					"SPEC-V3R3-RETIRED-DDD-001 M3에서 'manager-cycle'로 교체 필요 (REQ-RD-010):\n%s",
 					cf.path, cf.description, len(orphanedRefs), strings.Join(orphanedRefs, "\n"))
 			}
 		})
@@ -324,6 +531,33 @@ func findManagerTDDReferences(content string) []string {
 		// 허용 예외: 마이그레이션 노트 (# deprecated, # 이전 이름, <!-- , [DEPRECATED 등)
 		trimmed := strings.TrimSpace(line)
 		if strings.HasPrefix(trimmed, "name: manager-tdd") {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "#") && strings.Contains(strings.ToLower(trimmed), "deprecated") {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "<!--") {
+			continue
+		}
+		refs = append(refs, fmt.Sprintf("  L%d: %s", i+1, trimmed))
+	}
+	return refs
+}
+
+// findManagerDDDReferences는 콘텐츠에서 manager-ddd 관련 참조를 찾아 반환한다.
+// frontmatter의 name: 라인 및 마이그레이션 노트는 허용한다.
+func findManagerDDDReferences(content string) []string {
+	var refs []string
+	lines := strings.Split(content, "\n")
+	for i, line := range lines {
+		// manager-ddd 참조 검색
+		if !strings.Contains(line, "manager-ddd") {
+			continue
+		}
+		// 허용 예외: frontmatter name 필드 (manager-ddd.md 자체의 name: manager-ddd)
+		// 허용 예외: 마이그레이션 노트 (# deprecated, # 이전 이름, <!-- , [DEPRECATED 등)
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "name: manager-ddd") {
 			continue
 		}
 		if strings.HasPrefix(trimmed, "#") && strings.Contains(strings.ToLower(trimmed), "deprecated") {

--- a/internal/template/templates/.claude/agents/moai/evaluator-active.md
+++ b/internal/template/templates/.claude/agents/moai/evaluator-active.md
@@ -91,7 +91,7 @@ The "Evaluation Dimensions" table above reflects the built-in default profile. W
 ## Sprint Contract Negotiation (Phase 2.0, thorough only)
 
 When invoked for contract negotiation before implementation:
-1. Review implementation plan from manager-ddd/tdd
+1. Review implementation plan from manager-cycle/tdd
 2. Identify missing edge cases, untested scenarios, security gaps
 3. Produce contract.md with agreed Done criteria and hard thresholds
 4. Maximum 2 negotiation rounds

--- a/internal/template/templates/.claude/agents/moai/expert-backend.md
+++ b/internal/template/templates/.claude/agents/moai/expert-backend.md
@@ -59,7 +59,7 @@ OUT OF SCOPE: Frontend implementation (expert-frontend), DevOps deployment (expe
 - Frontend work: Delegate to expert-frontend
 - Security audit: Delegate to expert-security
 - DevOps deployment: Delegate to expert-devops
-- DDD implementation: Delegate to manager-ddd
+- DDD implementation: Delegate to manager-cycle
 
 ## Framework Detection
 
@@ -116,7 +116,7 @@ Create `.moai/docs/backend-architecture-{SPEC-ID}.md` with framework, DB, endpoi
 
 - expert-frontend: API contract (OpenAPI/GraphQL), error format, CORS config
 - expert-devops: Health checks, env vars, migrations, CI/CD
-- manager-ddd: Test structure, mock strategy, coverage requirements
+- manager-cycle: Test structure, mock strategy, coverage requirements
 
 ## @MX Tag Obligations
 

--- a/internal/template/templates/.claude/agents/moai/expert-debug.md
+++ b/internal/template/templates/.claude/agents/moai/expert-debug.md
@@ -56,7 +56,7 @@ IN SCOPE:
 - Error pattern matching and impact assessment
 
 OUT OF SCOPE:
-- Code implementation (delegate to manager-ddd)
+- Code implementation (delegate to manager-cycle)
 - Code quality verification (delegate to manager-quality)
 - Git operations (delegate to manager-git)
 - Documentation updates (delegate to manager-docs)
@@ -87,7 +87,7 @@ OUT OF SCOPE:
 
 ## Delegation Rules
 
-- **Runtime Errors**: Delegate to manager-ddd (requires DDD cycle with testing)
+- **Runtime Errors**: Delegate to manager-cycle (requires DDD cycle with testing)
 - **Code Quality Issues**: Delegate to manager-quality (TRUST verification)
 - **Git Issues**: Delegate to manager-git (repository operations)
 - **Complex Multi-Error**: Recommend running `/moai fix` or `/moai loop`

--- a/internal/template/templates/.claude/agents/moai/expert-devops.md
+++ b/internal/template/templates/.claude/agents/moai/expert-devops.md
@@ -56,7 +56,7 @@ OUT OF SCOPE: Application code (expert-backend/frontend), security audits (exper
 
 - Backend readiness: Coordinate with expert-backend (health checks, startup commands, env vars)
 - Frontend deployment: Coordinate with expert-frontend (build strategy, env vars)
-- Test execution: Coordinate with manager-ddd (CI/CD test integration)
+- Test execution: Coordinate with manager-cycle (CI/CD test integration)
 
 ## Platform Detection
 
@@ -111,7 +111,7 @@ Platform comparison: Railway ($5-50/mo, auto DB, zero-config), Vercel (Free-$20/
 
 - expert-backend: Health endpoint, startup/shutdown commands, env vars, migrations
 - expert-frontend: Deployment platform, API URL config, CORS settings
-- manager-ddd: CI/CD test execution, coverage enforcement
+- manager-cycle: CI/CD test execution, coverage enforcement
 
 ## Success Criteria
 

--- a/internal/template/templates/.claude/agents/moai/expert-frontend.md
+++ b/internal/template/templates/.claude/agents/moai/expert-frontend.md
@@ -116,7 +116,7 @@ Create `.moai/docs/frontend-architecture-{SPEC-ID}.md` with component hierarchy,
 
 - expert-backend: API contract (OpenAPI/GraphQL), auth flow, CORS
 - expert-devops: Deployment platform (Vercel, Netlify), env vars, build strategy
-- manager-ddd: Component test structure, mock strategy (MSW), coverage
+- manager-cycle: Component test structure, mock strategy (MSW), coverage
 
 ## DTCG Validator Integration
 

--- a/internal/template/templates/.claude/agents/moai/expert-mobile.md
+++ b/internal/template/templates/.claude/agents/moai/expert-mobile.md
@@ -102,7 +102,7 @@ Key technologies: Dart, Flutter SDK, Provider/Riverpod/BLoC, go_router, Dio, Pla
 - Backend API design: Delegate to expert-backend
 - Security audit: Delegate to expert-security
 - DevOps deployment: Delegate to expert-devops
-- DDD implementation: Delegate to manager-ddd
+- DDD implementation: Delegate to manager-cycle
 
 ## Escalation Protocol
 

--- a/internal/template/templates/.claude/agents/moai/expert-refactoring.md
+++ b/internal/template/templates/.claude/agents/moai/expert-refactoring.md
@@ -51,7 +51,7 @@ OUT OF SCOPE:
 ## Delegation Protocol
 
 - Errors after refactoring: Delegate to expert-debug
-- Tests after refactoring: Delegate to manager-ddd
+- Tests after refactoring: Delegate to manager-cycle
 - Quality validation: Delegate to manager-quality
 - Security pattern review: Delegate to expert-security
 

--- a/internal/template/templates/.claude/agents/moai/expert-testing.md
+++ b/internal/template/templates/.claude/agents/moai/expert-testing.md
@@ -52,11 +52,11 @@ Design comprehensive test strategies and implement test automation covering unit
 
 IN SCOPE: Test strategy design, framework selection, E2E/integration test implementation, test data management, coverage analysis, flaky test remediation.
 
-OUT OF SCOPE: Unit test implementation (manager-ddd), load test execution (expert-performance), security testing (expert-security), production deployment (expert-devops).
+OUT OF SCOPE: Unit test implementation (manager-cycle), load test execution (expert-performance), security testing (expert-security), production deployment (expert-devops).
 
 ## Delegation Protocol
 
-- Unit test implementation: Delegate to manager-ddd
+- Unit test implementation: Delegate to manager-cycle
 - Load test execution: Delegate to expert-performance
 - Security testing: Delegate to expert-security
 - Backend implementation: Delegate to expert-backend
@@ -95,7 +95,7 @@ Create `.moai/docs/test-strategy-{SPEC-ID}.md` with pyramid, frameworks, critica
 
 ### Step 6: Coordinate with Team
 
-- manager-ddd: Unit test patterns, mock strategy, coverage targets
+- manager-cycle: Unit test patterns, mock strategy, coverage targets
 - expert-backend: API integration tests, contract testing, DB fixtures
 - expert-frontend: Component tests, E2E user flows, visual regression
 - expert-devops: CI/CD pipeline integration, test environment provisioning

--- a/internal/template/templates/.claude/agents/moai/manager-ddd.md
+++ b/internal/template/templates/.claude/agents/moai/manager-ddd.md
@@ -1,162 +1,39 @@
 ---
 name: manager-ddd
 description: |
-  DDD (Domain-Driven Development) implementation specialist. Use for ANALYZE-PRESERVE-IMPROVE
-  cycle when working with existing codebases that have minimal test coverage.
-  MUST INVOKE when ANY of these keywords appear in user request:
-  --deepthink flag: Activate Sequential Thinking MCP for deep analysis of refactoring strategy, behavior preservation, and legacy code transformation.
-  EN: DDD, refactoring, legacy code, behavior preservation, characterization test, domain-driven refactoring
-  KO: DDD, 리팩토링, 레거시코드, 동작보존, 특성테스트, 도메인주도리팩토링
-  JA: DDD, リファクタリング, レガシーコード, 動作保存, 特性テスト, ドメイン駆動リファクタリング
-  ZH: DDD, 重构, 遗留代码, 行为保存, 特性测试, 领域驱动重构
-  NOT for: greenfield development (use TDD), deployment, documentation, git operations, security audits
-tools: Read, Write, Edit, MultiEdit, Bash, Grep, Glob, TodoWrite, Skill, mcp__sequential-thinking__sequentialthinking, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
-model: sonnet
-permissionMode: bypassPermissions
-memory: project
-skills:
-  - moai-foundation-core
-  - moai-workflow-ddd
-  - moai-workflow-testing
-hooks:
-  PreToolUse:
-    - matcher: "Write|Edit|MultiEdit"
-      hooks:
-        - type: command
-          command: "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-agent-hook.sh\" ddd-pre-transformation"
-          timeout: 5
-  PostToolUse:
-    - matcher: "Write|Edit|MultiEdit"
-      hooks:
-        - type: command
-          command: "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-agent-hook.sh\" ddd-post-transformation"
-          timeout: 10
-  SubagentStop:
-    - hooks:
-        - type: command
-          command: "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-agent-hook.sh\" ddd-completion"
-          timeout: 10
+  Retired (SPEC-V3R3-RETIRED-DDD-001) — use manager-cycle with cycle_type=ddd.
+  This agent has been consolidated into the unified manager-cycle agent.
+  See manager-cycle.md for the active replacement.
+retired: true
+retired_replacement: manager-cycle
+retired_param_hint: "cycle_type=ddd"
+tools: []
+skills: []
 ---
 
-# DDD Implementer
+# manager-ddd — Retired Agent
 
-## Primary Mission
+This agent has been retired as part of SPEC-V3R3-RETIRED-DDD-001 (following SPEC-V3R3-RETIRED-AGENT-001).
 
-Execute ANALYZE-PRESERVE-IMPROVE DDD cycles for behavior-preserving code refactoring with characterization test creation.
+## Replacement
 
-**When to use**: Selected when `development_mode: ddd` in quality.yaml. Best for existing codebases with minimal test coverage (< 10%). For projects with sufficient coverage, use `manager-cycle` with `cycle_type=tdd`.
+Use **manager-cycle** with `cycle_type=ddd` instead.
 
-## Behavioral Contract (SEMAP)
+## Migration Guide
 
-**Preconditions**: SPEC document exists with approved status. Implementation plan approved. Target files identified.
+| Old Invocation | New Invocation |
+|----------------|----------------|
+| `Use the manager-ddd subagent to implement the feature` | `Use the manager-cycle subagent with cycle_type=ddd to implement the feature` |
+| `manager-ddd: run ANALYZE-PRESERVE-IMPROVE cycle` | `manager-cycle: run DDD cycle (cycle_type=ddd)` |
 
-**Postconditions**: All existing tests still pass. New characterization tests cover modified paths. Coverage >= 85% on modified files. No new lint/type errors.
+## Why This Change
 
-**Invariants**: Existing test suite never broken during any cycle. Each ANALYZE-PRESERVE-IMPROVE cycle is atomic and reversible.
+The `manager-ddd` agent has been consolidated into the `manager-cycle` agent, which supports DDD (ANALYZE-PRESERVE-IMPROVE) cycles through the `cycle_type` parameter. This unification:
 
-**Forbidden**: Deleting/modifying existing tests without SPEC requirement. Introducing global mutable state. Skipping characterization tests. Modifying files outside SPEC scope.
+- Eliminates duplication between the two agents
+- Provides a single entry point for all implementation cycles
+- Enables future cycle types without additional agent proliferation
 
-## Scope Boundaries
+## Active Agent
 
-IN SCOPE: DDD cycle (ANALYZE-PRESERVE-IMPROVE), characterization tests, structural refactoring, AST-based transformation, behavior preservation verification, technical debt reduction.
-
-OUT OF SCOPE: New feature development from scratch (use manager-cycle with cycle_type=tdd), SPEC creation (manager-spec), security audits (expert-security), performance optimization (expert-performance).
-
-## Delegation Protocol
-
-- SPEC unclear: Delegate to manager-spec
-- Security concerns: Delegate to expert-security
-- Performance issues: Delegate to expert-performance
-- Quality validation: Delegate to manager-quality
-
-## Execution Workflow
-
-### STEP 1: Confirm Refactoring Plan
-
-- Read SPEC document, extract refactoring scope, targets, preservation requirements, success criteria
-- Read existing code and test files, assess current coverage
-
-### STEP 1.5: Detect Project Scale
-
-- Count test files and source lines (exclude vendor, node_modules, generated)
-- LARGE_SCALE: test files > 500 OR source lines > 50,000
-- LARGE_SCALE → targeted test execution in PRESERVE/IMPROVE phases
-- Standard → full test suite execution
-- STEP 5 Final Verification ALWAYS runs full suite regardless of scale
-
-### STEP 2: ANALYZE Phase
-
-- Use AST-grep to analyze import patterns, dependencies, module boundaries
-- Calculate coupling metrics: Ca (afferent), Ce (efferent), I = Ce/(Ca+Ce)
-- Detect code smells: god classes, feature envy, long methods, duplicates
-- Prioritize refactoring targets by impact and risk
-
-### STEP 3: PRESERVE Phase
-
-- Verify existing tests pass (100% pass rate required)
-- Create characterization tests for uncovered code paths (capture what IS, not what SHOULD BE)
-- Name tests: `test_characterize_[component]_[scenario]`
-- Create behavior snapshots for complex outputs
-- Verify safety net: all tests pass including new characterization tests
-
-### STEP 3.5: LSP Baseline Capture
-
-- Capture LSP diagnostics (errors, warnings, type errors, lint errors)
-- Store baseline for regression detection during IMPROVE phase
-
-### STEP 4: IMPROVE Phase
-
-For each transformation:
-1. **Make Single Change**: One atomic structural change, AST-grep for multi-file transforms
-2. **LSP Verification**: Check for regression (errors > baseline → REVERT immediately)
-3. **Verify Behavior**: Run tests (targeted for LARGE_SCALE, full for standard). Any failure → REVERT
-4. **Check Completion**: LSP errors == 0, no regression, iteration limit (max 100), stale detection (5 iterations)
-5. **Record Progress**: Document transformation, update metrics, update TodoWrite
-
-### STEP 5: Complete and Report
-
-- Run COMPLETE test suite (always full, regardless of LARGE_SCALE)
-  - Memory guard: If enabled and memory low, run in module-level batches
-- Verify all behavior snapshots match
-- Compare before/after coupling metrics
-- Generate DDD completion report
-- Commit changes, update SPEC status
-
-## Ralph-Style LSP Integration
-
-- Baseline capture at ANALYZE phase start via diagnostics
-- Regression detection after each transformation (error count comparison)
-- Completion markers: all tests passing, LSP errors == 0, type errors == 0, coverage met
-- Loop prevention: max 100 iterations, stale detection after 5 no-progress iterations
-
-## Checkpoint and Resume
-
-- Checkpoint after every transformation to `.moai/state/checkpoints/ddd/`
-- Auto-checkpoint on memory pressure
-- Resume from any checkpoint with `--resume latest`
-- Adaptive context trimming to prevent memory overflow
-
-## @MX Tag Obligations
-
-During ANALYZE and IMPROVE phases, maintain @MX tags:
-
-- ANALYZE: Scan for functions meeting ANCHOR criteria (fan_in >= 3) and WARN criteria (goroutines, complexity >= 15). Add missing tags.
-- PRESERVE: Do not remove existing @MX tags during characterization test creation.
-- IMPROVE: Update @MX:ANCHOR if fan_in changes after refactoring. Remove @MX:WARN if dangerous pattern is eliminated. Add @MX:NOTE for discovered business rules.
-
-Tag format: `// @MX:TYPE: [AUTO] description` (use language-appropriate comment syntax).
-All ANCHOR and WARN tags MUST include a `@MX:REASON` sub-line.
-Respect per-file limits: max 3 ANCHOR, 5 WARN, 10 NOTE, 5 TODO.
-
-## DDD vs TDD Decision Guide
-
-- Code already exists with defined behavior? → DDD
-- Creating new functionality from scratch? → TDD
-- Goal is structure improvement, not feature addition? → DDD
-
-## Common Refactoring Patterns
-
-- **Extract Method**: Long methods, duplicated code → identify candidates, test callers, extract
-- **Extract Class**: Multiple responsibilities → identify clusters, test public methods, delegate
-- **Move Method**: Feature envy → identify misplaced methods, test behavior, move atomically
-- **Rename**: Unclear names → use AST-grep rewrite for safe multi-file rename
+See `.claude/agents/moai/manager-cycle.md` for the full agent definition.

--- a/internal/template/templates/.claude/agents/moai/manager-quality.md
+++ b/internal/template/templates/.claude/agents/moai/manager-quality.md
@@ -61,7 +61,7 @@ IN SCOPE:
 - TAG chain verification
 
 OUT OF SCOPE:
-- Code implementation (delegate to manager-ddd or expert-debug)
+- Code implementation (delegate to manager-cycle or expert-debug)
 - Git operations (delegate to manager-git)
 - Documentation generation (delegate to manager-docs)
 
@@ -104,12 +104,12 @@ Classification: PASS (all items) / WARNING (non-compliance with recommendations)
 
 ## Context Propagation
 
-**Input** (from manager-ddd): Implemented file list, test results, coverage report, DDD cycle status, SPEC requirements.
+**Input** (from manager-cycle): Implemented file list, test results, coverage report, DDD cycle status, SPEC requirements.
 
 **Output** (to manager-git): Quality verdict (PASS/WARNING/CRITICAL), TRUST 5 assessment, coverage confirmation, commit approval status.
 
 ## Delegation Protocol
 
-- Code modifications: Delegate to manager-ddd or expert-debug
+- Code modifications: Delegate to manager-cycle or expert-debug
 - Git operations: Delegate to manager-git
 - Debugging: Delegate to expert-debug

--- a/internal/template/templates/.claude/agents/moai/manager-spec.md
+++ b/internal/template/templates/.claude/agents/moai/manager-spec.md
@@ -55,7 +55,7 @@ Generate EARS-style SPEC documents for implementation planning. Translates busin
 
 IN SCOPE: SPEC creation, EARS specifications, acceptance criteria, implementation planning, expert consultation recommendations.
 
-OUT OF SCOPE: Code implementation (manager-ddd/tdd), Git operations (manager-git), documentation sync (manager-docs).
+OUT OF SCOPE: Code implementation (manager-cycle/tdd), Git operations (manager-git), documentation sync (manager-docs).
 
 ## SPEC Scope Boundaries (What/Why vs How)
 

--- a/internal/template/templates/.claude/agents/moai/manager-strategy.md
+++ b/internal/template/templates/.claude/agents/moai/manager-strategy.md
@@ -133,7 +133,7 @@ Dependency order when multiple: backend → frontend → devops.
 ### Step 7: Wait for Approval and Handover
 
 - Present plan to user, wait for approval
-- On approval: hand TAG chain, library versions, key decisions, task list to manager-ddd/tdd
+- On approval: hand TAG chain, library versions, key decisions, task list to manager-cycle/tdd
 
 ## Context Propagation
 

--- a/internal/template/templates/.claude/hooks/moai/handle-agent-hook.sh.tmpl
+++ b/internal/template/templates/.claude/hooks/moai/handle-agent-hook.sh.tmpl
@@ -16,6 +16,10 @@
 #   - debug-verification, debug-completion
 #   - devops-verification, devops-completion
 
+# @MX:NOTE: manager-ddd is retired per SPEC-V3R3-RETIRED-DDD-001.
+# ddd-* action references are preserved for backward compat with pre-update user projects.
+# Active manager-cycle uses cycle-* actions (cycle-pre-implementation, etc.).
+
 set -e
 
 # Get action from first argument (use lowercase to avoid template token detection)

--- a/internal/template/templates/.claude/output-styles/moai/moai.md
+++ b/internal/template/templates/.claude/output-styles/moai/moai.md
@@ -124,7 +124,7 @@ Before writing any code yourself, answer:
 | Refactoring / codemod | `expert-refactoring` |
 | Debugging / root cause | `expert-debug` |
 | Major doc rewrite | `manager-docs` |
-| DDD / TDD implementation | `manager-ddd` / `manager-tdd` |
+| DDD / TDD implementation | `manager-cycle` / `manager-tdd` |
 
 ### Volume Triggers
 

--- a/internal/template/templates/.claude/rules/moai/core/agent-hooks.md
+++ b/internal/template/templates/.claude/rules/moai/core/agent-hooks.md
@@ -56,6 +56,10 @@ Actions follow the naming pattern `{agent}-{phase}`:
 | manager-spec | - | - | spec-completion |
 | manager-docs | - | docs-verification | docs-completion |
 
+<!-- @MX:NOTE: manager-ddd retired (SPEC-V3R3-RETIRED-DDD-001), action set
+     preserved here for backward compat with pre-update user projects.
+     Active manager-cycle uses cycle-* actions. See manager-cycle.md. -->
+
 Note: Dynamic team teammates (spawned via `Agent(subagent_type: "general-purpose")`) do not use agent-scoped hooks. Quality enforcement for teammates uses global TeammateIdle and TaskCompleted hooks in settings.json.
 
 ## Hook Command Interface

--- a/internal/template/templates/.claude/rules/moai/development/agent-authoring.md
+++ b/internal/template/templates/.claude/rules/moai/development/agent-authoring.md
@@ -101,7 +101,6 @@ The `memory` field enables cross-session learning for agents. Three scope levels
 Coordinate workflows and multi-step processes:
 
 - manager-spec: SPEC document creation
-- manager-ddd: DDD implementation cycle
 - manager-cycle: Unified DDD/TDD implementation cycle
 - manager-docs: Documentation generation
 - manager-quality: Quality gates validation

--- a/internal/template/templates/.claude/rules/moai/workflow/spec-workflow.md
+++ b/internal/template/templates/.claude/rules/moai/workflow/spec-workflow.md
@@ -216,7 +216,7 @@ When team mode is enabled (workflow.team.enabled and AGENT_TEAMS env), phases ca
 | Phase | Sub-agent Mode | Team Mode | Condition |
 |-------|---------------|-----------|-----------|
 | Plan | manager-spec (single) | Dynamic teammates: researcher + analyst + architect (parallel, general-purpose) | Complexity >= threshold |
-| Run | manager-ddd/tdd (sequential) | Dynamic teammates: backend-dev + frontend-dev + tester (parallel, general-purpose) | Domains >= 3 or files >= 10 |
+| Run | manager-cycle (sequential) | Dynamic teammates: backend-dev + frontend-dev + tester (parallel, general-purpose) | Domains >= 3 or files >= 10 |
 | Sync | manager-docs (single) | manager-docs (always sub-agent) | N/A |
 
 All teammates are spawned dynamically via `Agent(subagent_type: "general-purpose")` with runtime overrides from `workflow.yaml` role profiles. No static team agent definitions are used. See `.claude/skills/moai/team/run.md` for complete orchestration.

--- a/internal/template/templates/.claude/rules/moai/workflow/worktree-integration.md
+++ b/internal/template/templates/.claude/rules/moai/workflow/worktree-integration.md
@@ -132,7 +132,7 @@ Is this a one-shot sub-agent task?
 
 - [HARD] Implementation teammates in team mode (role_profiles: implementer, tester, designer) MUST use `isolation: "worktree"` when spawned via Agent()
 - [HARD] Read-only teammates (role_profiles: researcher, analyst, reviewer) MUST NOT use `isolation: "worktree"` — their `mode: "plan"` already prevents writes
-- [HARD] One-shot sub-agents that write files (expert-backend, expert-frontend, manager-ddd, manager-tdd) SHOULD use `isolation: "worktree"` when making cross-file changes
+- [HARD] One-shot sub-agents that write files (expert-backend, expert-frontend, manager-cycle) SHOULD use `isolation: "worktree"` when making cross-file changes
 - [HARD] GitHub workflow agents (fixer agents in /moai github issues) MUST use `isolation: "worktree"` for branch isolation
 
 ### When to Use Which

--- a/internal/template/templates/.claude/skills/moai-foundation-cc/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-foundation-cc/SKILL.md
@@ -212,7 +212,7 @@ Phase 4 Commit: Descriptive messages, logical groupings, clean history
 ### Essential Sub-agents
 
 - spec-builder: EARS specifications
-- manager-ddd: DDD execution
+- manager-cycle: DDD execution
 - expert-security: Security analysis
 - expert-backend: API development
 - expert-frontend: UI implementation

--- a/internal/template/templates/.claude/skills/moai-foundation-core/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-foundation-core/SKILL.md
@@ -29,7 +29,7 @@ triggers:
   keywords: ["trust-5", "spec-first", "ddd", "delegation", "agent", "token", "progressive disclosure", "modular", "workflow", "orchestration", "quality gate", "spec", "ears format", "context window", "token budget", "token limit", "session state", "/clear", "context management", "multi-agent handoff", "session persistence", "context", "session", "budget", "optimization", "handoff", "state", "memory", "multi-agent"]
   agents:
     - "manager-spec"
-    - "manager-ddd"
+    - "manager-cycle"
     - "manager-strategy"
     - "manager-quality"
     - "builder-agent"

--- a/internal/template/templates/.claude/skills/moai-foundation-quality/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-foundation-quality/SKILL.md
@@ -28,7 +28,7 @@ triggers:
   keywords: ["quality", "testing", "test", "validation", "trust-5", "best practice", "code review", "linting", "coverage", "pytest", "security", "ci/cd", "quality gate", "proactive", "code smell", "technical debt", "refactoring"]
   agents:
     - "manager-quality"
-    - "manager-ddd"
+    - "manager-cycle"
     - "expert-testing"
     - "expert-security"
     - "expert-refactoring"

--- a/internal/template/templates/.claude/skills/moai-meta-harness/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-meta-harness/SKILL.md
@@ -152,7 +152,7 @@ This skill fills the skeleton with domain-specific content:
 
 1. Generate agent definitions (`.claude/agents/my-harness/*.md`) referencing
    existing MoAI agents: `manager-spec`, `manager-strategy`, `manager-tdd`,
-   `manager-ddd`, `manager-quality`, `manager-docs`, `manager-git`,
+   `manager-cycle`, `manager-quality`, `manager-docs`, `manager-git`,
    `expert-backend`, `expert-frontend`, `expert-debug`, `expert-testing`,
    `expert-security`, `expert-refactoring`, `expert-performance`, `expert-devops`,
    `expert-mobile`, `builder-agent`, `builder-skill`, `builder-plugin`,
@@ -212,7 +212,7 @@ referenced below are static MoAI agents — no new agents are introduced.
 
 **Workflow Managers**
 
-- `manager-ddd` — DDD-flavored harness workflow templates
+- `manager-cycle` — DDD-flavored harness workflow templates
 - `manager-tdd` — TDD-flavored harness workflow templates
 - `manager-quality` — Quality gate configuration in generated harnesses
 - `manager-docs` — Documentation generation patterns

--- a/internal/template/templates/.claude/skills/moai-workflow-ddd/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-ddd/SKILL.md
@@ -17,7 +17,7 @@ metadata:
   tags: "workflow, refactoring, ddd, domain-driven, behavior-preservation, ast-grep, characterization-tests"
   author: "MoAI-ADK Team"
   context: "fork"
-  agent: "manager-ddd"
+  agent: "manager-cycle"
   related-skills: "moai-tool-ast-grep, moai-workflow-testing, moai-foundation-quality"
 ---
 

--- a/internal/template/templates/.claude/skills/moai-workflow-loop/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-loop/SKILL.md
@@ -150,7 +150,7 @@ Skills:
 
 Agents:
 
-- manager-ddd: DDD implementation
+- manager-cycle: DDD implementation
 - manager-quality: Quality validation
 - expert-debug: Complex debugging
 

--- a/internal/template/templates/.claude/skills/moai-workflow-spec/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-spec/SKILL.md
@@ -220,7 +220,7 @@ PLAN Phase (/moai:1-plan):
 
 RUN Phase (/moai:2-run):
 
-- manager-ddd agent loads SPEC document
+- manager-cycle agent loads SPEC document
 - ANALYZE-PRESERVE-IMPROVE DDD cycle execution
 - moai-workflow-testing skill reference for test patterns
 - Domain Expert agent delegation (expert-backend, expert-frontend, etc.)
@@ -353,7 +353,7 @@ Validation Checklist:
 - moai-workflow-project: Project initialization and configuration
 - moai-workflow-worktree: Git Worktree management for parallel development
 - manager-spec: SPEC creation and requirement analysis agent
-- manager-ddd: DDD implementation based on SPEC requirements
+- manager-cycle: DDD implementation based on SPEC requirements
 - manager-quality: TRUST 5 quality validation and gate enforcement
 
 ### Integration Examples

--- a/internal/template/templates/.claude/skills/moai-workflow-spec/references/examples.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-spec/references/examples.md
@@ -14,7 +14,7 @@ This document provides complete, production-ready SPEC examples for common devel
 Created: 2025-12-07
 Status: Planned
 Priority: High
-Assigned: manager-ddd
+Assigned: manager-cycle
 Related SPECs: SPEC-002 (User Registration)
 Epic: EPIC-AUTH
 Estimated Effort: 8 hours
@@ -331,7 +331,7 @@ RATE_LIMIT_MAX_REQUESTS=10
 Created: 2025-12-07
 Status: Planned
 Priority: High
-Assigned: manager-ddd
+Assigned: manager-cycle
 Related SPECs: SPEC-003 (Order Management), SPEC-006 (Refund System)
 Epic: EPIC-PAYMENT
 Estimated Effort: 16 hours

--- a/internal/template/templates/.claude/skills/moai-workflow-spec/references/reference.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-spec/references/reference.md
@@ -16,7 +16,7 @@ This document provides comprehensive reference information for SPEC workflow man
 Created: YYYY-MM-DD
 Status: Planned
 Priority: Medium
-Assigned: manager-ddd
+Assigned: manager-cycle
 
 ## Description
 [Brief description of the feature]
@@ -67,7 +67,7 @@ Business:
 Created: YYYY-MM-DD
 Status: Planned
 Priority: High
-Assigned: manager-ddd
+Assigned: manager-cycle
 Related SPECs: SPEC-YYY, SPEC-ZZZ
 
 ## Description
@@ -269,7 +269,7 @@ Technical:
 - Low: Enhancement or optional feature
 
 **Assigned Agents**:
-- manager-ddd: DDD-based implementation
+- manager-cycle: DDD-based implementation
 - manager-spec: SPEC refinement and updates
 - expert-backend: Backend-specific features
 - expert-frontend: Frontend-specific features
@@ -530,7 +530,7 @@ manager-spec creates SPEC-001
     ↓
 /moai:2-run SPEC-001
     ↓
-manager-ddd implements with ANALYZE-PRESERVE-IMPROVE
+manager-cycle implements with ANALYZE-PRESERVE-IMPROVE
     ↓
 /moai:3-sync SPEC-001
     ↓

--- a/internal/template/templates/.claude/skills/moai-workflow-testing/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-testing/SKILL.md
@@ -17,7 +17,7 @@ metadata:
   tags: "workflow, ddd, testing, debugging, performance, quality, review, pr-review"
   author: "MoAI-ADK Team"
   context: "fork"
-  agent: "manager-ddd"
+  agent: "manager-cycle"
 
 # MoAI Extension: Progressive Disclosure
 progressive_disclosure:
@@ -29,7 +29,7 @@ progressive_disclosure:
 triggers:
   keywords: ["DDD", "domain-driven development", "characterization tests", "behavior preservation", "debugging", "performance optimization", "code review", "PR review", "quality assurance", "testing", "CI/CD", "TRUST 5"]
   phases: ["run", "sync"]
-  agents: ["manager-ddd", "expert-testing", "expert-debug", "expert-performance", "manager-quality"]
+  agents: ["manager-cycle", "expert-testing", "expert-debug", "expert-performance", "manager-quality"]
 ---
 
 # Development Workflow Specialist

--- a/internal/template/templates/.claude/skills/moai/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai/SKILL.md
@@ -114,7 +114,7 @@ For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/plan.md (team mod
 ### run - DDD/TDD Implementation
 
 Purpose: Implement SPEC requirements through configured development methodology.
-Agents: manager-strategy, manager-ddd or manager-tdd (per quality.yaml), manager-quality, manager-git
+Agents: manager-strategy, manager-cycle or manager-tdd (per quality.yaml), manager-quality, manager-git
 Flags: --resume SPEC-XXX, --team
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/run.md (team mode: ${CLAUDE_SKILL_DIR}/team/run.md)
 
@@ -216,7 +216,7 @@ For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/db.md
 
 Purpose: Full autonomous research -> plan -> annotate -> run -> sync pipeline.
 Phases: Parallel Exploration (research.md) -> SPEC Generation -> Annotation Cycle -> Implementation -> Sync
-Agents: Explore, manager-spec, manager-ddd/tdd, manager-quality, manager-docs, manager-git
+Agents: Explore, manager-spec, manager-cycle/tdd, manager-quality, manager-docs, manager-git
 Flags: --loop, --max N, --branch, --pr, --resume SPEC-XXX, --team, --solo, --no-issue
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/moai.md
 

--- a/internal/template/templates/.claude/skills/moai/references/mx-tag.md
+++ b/internal/template/templates/.claude/skills/moai/references/mx-tag.md
@@ -3,7 +3,7 @@ name: moai-workflow-mx-tag
 description: >
   @MX TAG annotation protocol reference for AI agent code context delivery.
   Provides detailed tag syntax grammar, fan-in analysis method, agent report
-  format, and edge case handling. Used by manager-ddd and manager-tdd agents.
+  format, and edge case handling. Used by manager-cycle and manager-tdd agents.
 user-invocable: false
 metadata:
   version: "2.5.0"
@@ -21,7 +21,7 @@ progressive_disclosure:
 # MoAI Extension: Triggers
 triggers:
   keywords: ["mx", "tag", "annotation", "anchor", "invariant", "context"]
-  agents: ["manager-ddd", "manager-tdd", "manager-quality"]
+  agents: ["manager-cycle", "manager-tdd", "manager-quality"]
   phases: ["run"]
 ---
 

--- a/internal/template/templates/.claude/skills/moai/references/reference.md
+++ b/internal/template/templates/.claude/skills/moai/references/reference.md
@@ -22,7 +22,7 @@ progressive_disclosure:
 # MoAI Extension: Triggers
 triggers:
   keywords: ["reference", "pattern", "flag", "config", "resume", "legacy", "mapping"]
-  agents: ["manager-spec", "manager-ddd", "manager-tdd", "manager-docs", "manager-quality", "manager-git"]
+  agents: ["manager-spec", "manager-cycle", "manager-tdd", "manager-docs", "manager-quality", "manager-git"]
   phases: ["plan", "run", "sync"]
 ---
 

--- a/internal/template/templates/.claude/skills/moai/workflows/moai.md
+++ b/internal/template/templates/.claude/skills/moai/workflows/moai.md
@@ -75,7 +75,7 @@ constitution:
 
 **Agent Selection**:
 - **TDD cycle**: `manager-tdd` subagent (RED-GREEN-REFACTOR)
-- **DDD cycle**: `manager-ddd` subagent (ANALYZE-PRESERVE-IMPROVE)
+- **DDD cycle**: `manager-cycle` subagent (ANALYZE-PRESERVE-IMPROVE)
 
 For methodology details, see: .claude/rules/moai/workflow/spec-workflow.md (Run Phase section)
 
@@ -145,7 +145,7 @@ This iterative refinement catches architectural misunderstandings before impleme
 [HARD] Methodology selection based on `.moai/config/sections/quality.yaml`:
 
 - **development_mode: tdd** (default): Use `manager-tdd` (RED-GREEN-REFACTOR)
-- **development_mode: ddd**: Use `manager-ddd` (ANALYZE-PRESERVE-IMPROVE)
+- **development_mode: ddd**: Use `manager-cycle` (ANALYZE-PRESERVE-IMPROVE)
 
 Expert agent selection (for domain-specific work):
 - Backend logic: expert-backend subagent
@@ -236,7 +236,7 @@ Mode selection:
 13. **Phase 2 (Run)**: Route based on Gate result (execution_mode parameter)
    - worktree: Already running in isolated tmux+worktree session (Gate handled transition)
    - team: Read ${CLAUDE_SKILL_DIR}/team/run.md and follow team orchestration
-   - sub-agent: manager-tdd or manager-ddd (per quality.yaml development_mode)
+   - sub-agent: manager-tdd or manager-cycle (per quality.yaml development_mode)
    - Harness level determines phase skipping and evaluator involvement
 14. **Phase 3 (Sync)**: Always manager-docs sub-agent (sync phase never uses team mode)
 15. Terminate with completion marker

--- a/internal/template/templates/.claude/skills/moai/workflows/run.md
+++ b/internal/template/templates/.claude/skills/moai/workflows/run.md
@@ -2,7 +2,7 @@
 name: moai-workflow-run
 description: >
   DDD/TDD implementation workflow for SPEC requirements. Second step
-  of the Plan-Run-Sync workflow. Routes to manager-ddd or manager-tdd based
+  of the Plan-Run-Sync workflow. Routes to manager-cycle or manager-tdd based
   on quality.yaml development_mode setting.
 user-invocable: false
 metadata:
@@ -21,7 +21,7 @@ progressive_disclosure:
 # MoAI Extension: Triggers
 triggers:
   keywords: ["run", "implement", "build", "create", "develop", "code"]
-  agents: ["manager-ddd", "manager-tdd", "manager-strategy", "manager-quality", "manager-git"]
+  agents: ["manager-cycle", "manager-tdd", "manager-strategy", "manager-quality", "manager-git"]
   phases: ["run"]
 ---
 
@@ -537,7 +537,7 @@ See .claude/rules/moai/workflow/mx-tag-protocol.md for tag type definitions.
 Before Phase 2, determine the development methodology by reading `.moai/config/sections/quality.yaml`:
 
 **If development_mode is "ddd":**
-- Route all tasks to manager-ddd subagent
+- Route all tasks to manager-cycle subagent
 - Use ANALYZE-PRESERVE-IMPROVE cycle (see @spec-workflow.md for details)
 
 **If development_mode is "tdd":**
@@ -596,11 +596,11 @@ If no delta markers are present in the SPEC, delta processing is silently skippe
 
 ### Phase 2: Implementation (Mode-Dependent)
 
-**[HARD] Worktree Prompt Construction**: When spawning implementation agents (manager-ddd, manager-tdd) with `isolation: "worktree"`, the orchestrator MUST construct prompts using project-root-relative paths only. Do NOT embed the current working directory path in the agent prompt. See "Worktree Path Rules [HARD]" section above.
+**[HARD] Worktree Prompt Construction**: When spawning implementation agents (manager-cycle, manager-tdd) with `isolation: "worktree"`, the orchestrator MUST construct prompts using project-root-relative paths only. Do NOT embed the current working directory path in the agent prompt. See "Worktree Path Rules [HARD]" section above.
 
 #### Phase 2A: DDD Implementation (for ddd mode)
 
-Agent: manager-ddd subagent
+Agent: manager-cycle subagent
 
 Input: Approved execution plan from Phase 1 plus task decomposition from Phase 1.5. Include `.moai/project/structure.md` and `.moai/project/tech.md` as onboarding context in the agent prompt so the implementation agent understands the project's architecture conventions before writing code.
 
@@ -616,7 +616,7 @@ Output: files_modified list, characterization_tests_created list, test_results (
 
 Implementation Divergence Tracking:
 
-The manager-ddd subagent must track deviations from the original SPEC plan during implementation:
+The manager-cycle subagent must track deviations from the original SPEC plan during implementation:
 
 - planned_files: Files listed in plan.md that were expected to be created or modified
 - actual_files: Files actually created or modified during the DDD cycle
@@ -980,7 +980,7 @@ All of the following must be verified:
 - Phase 0.95: SPEC has 8 files, 2 domains → Standard Mode selected
 - Phase 1: manager-strategy creates execution plan with 5 tasks
 - Decision Point: User approves plan
-- Phase 2: Implementation via manager-ddd (DDD mode)
+- Phase 2: Implementation via manager-cycle (DDD mode)
 - Phase 2.5: TRUST 5 validation passes
 - Phase 3: Commits created on feature branch
 


### PR DESCRIPTION
## Summary
- manager-ddd 에이전트를 manager-cycle로 통합하는 retired stub 표준화 (predecessor SPEC-V3R3-RETIRED-AGENT-001 패턴 적용)
- 38파일 수정: Cat A (30파일 manager-ddd→manager-cycle 치환) + Cat B (3파일 보존) + Cat C (2파일 @MX:NOTE annotation) + live sync (2파일) + CHANGELOG
- TDD 사이클 완료: M1 RED → M2-M4 GREEN → M5 REFACTOR, 71/71 테스트 통과, golangci-lint clean

## Test plan
- [x] `go test ./internal/template/...` — 71/71 PASS
- [x] `golangci-lint run` — 0 issues
- [x] `make build` — 성공
- [x] Cat A orphan reference test — 30파일 모두 PASS
- [x] factory.go backward compat 유지 — `case "ddd":` 보존
- [x] 잔여 manager-ddd 참조: 정확히 5파일 (3 Cat B + 2 Cat C, 설계 의도대로)

Closes #778

🗿 MoAI <email@mo.ai.kr>