### PR TITLE
fix(ci): Release Drafter pull_request 트리거 제거 — 8 PR 노이즈 batch 해결

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -8,10 +8,9 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [opened, reopened, synchronize]
-  # Manual trigger 옵션. Draft 가 stale 상태이거나 target_commitish 가 손상된 경우
-  # admin 이 직접 재실행할 수 있도록 workflow_dispatch 를 추가한다.
+  # pull_request 트리거 제거 (2026-05): GitHub Releases API 가 PR ref(refs/pull/N/merge)를
+  # target_commitish 로 받지 못하므로 모든 PR check 가 빨간 X 노이즈로 남는 문제 발생.
+  # main push 시에만 draft 갱신; PR 단계에서 preview 가 필요하면 workflow_dispatch 사용.
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

8개 OPEN PR 모두에서 발생하던 Release Drafter 빨간 X 노이즈를 단일 워크플로우 수정으로 일괄 해결.

## Root Cause

```
Validation Failed: {"resource":"Release","code":"invalid","field":"target_commitish"}
targetCommitish: refs/pull/785/merge
```

Release Drafter v7이 PR 트리거 시 `refs/pull/N/merge`를 target_commitish로 사용하지만, GitHub Releases API는 branch/tag/SHA만 허용. 모든 PR check 실패.

## Change

`.github/workflows/release-drafter.yml`:
- `on.pull_request` 블록 제거
- `push: branches: main` 만 유지 (정상 사용 패턴)
- `workflow_dispatch` 유지 (admin 수동 재실행 경로)

## Impact

- ✅ 8/8 OPEN PR의 Release Drafter 노이즈 즉시 제거 (next push부터)
- ✅ main 머지 시에만 release draft 갱신 (의도한 동작)
- ✅ Release Drafter는 main branch protection의 required check가 아니므로 머지 영향 없음
- ✅ PR 단계 preview 가 필요한 경우 `gh workflow run release-drafter.yml` 수동 실행 가능

## Test Plan

- [x] 로컬 YAML 문법 검증 (Edit 도구 자체 검증)
- [ ] PR 머지 후 다른 PR push 시 Release Drafter check 미발생 확인
- [ ] main push 시에만 release draft 정상 갱신 확인

## References

- memory: feedback_ci_aux_workflow_failures (claude-review + Release Drafter org quota 비차단 분류)
- 진단 로그: gh run view 25385665551 (PR #785, target_commitish invalid 에러)

🗿 MoAI <email@mo.ai.kr>