### PR TITLE
chore(workflow): Block 0 cwd anchoring for --worktree paste-ready resume

### DIFF
--- a/.claude/rules/moai/workflow/session-handoff.md
+++ b/.claude/rules/moai/workflow/session-handoff.md
@@ -145,6 +145,82 @@ applied lessons: project_<wave>_<spec>_<status> (PR <previous-PR-number> 머지 
 - Multiple memory entries for the same context without `[SUPERSEDED by ...]` markers — index pollution; next session cannot identify the canonical entry.
 - Forcing the format on trivial tasks (typo fix, single config edit) — pollutes memory with noise.
 
+## Worktree-Anchored Resume Pattern
+
+[HARD] When the SPEC was initialized via `/moai plan --worktree` (creating a SPEC worktree at `~/.moai/worktrees/<project>/<spec-or-name>/`), the resume message MUST include **Block 0 (cwd anchoring)** prepended before the standard 6-block structure. Without Block 0, the next session starts in main project cwd by default, breaking SPEC worktree isolation expectations.
+
+### Why Block 0 is required
+
+The standard 6-block format implicitly assumes the next session inherits the previous session's cwd (main project). With `--worktree`, SPEC artifacts and `Agent(isolation: "worktree")` base expectations live in a **different cwd** (the worktree path). If the user pastes a resume into a Claude Code session that starts in main project cwd:
+
+- `Agent(isolation: "worktree")` base = main project HEAD ≠ worktree HEAD → lessons #13 (--team + SPEC worktree base mismatch)
+- Bash commands and file operations target main project → lessons #12 (수동 worktree isolation 위배) anti-pattern
+- Build/test results come from the wrong tree
+
+Block 0 forces the user to start a NEW terminal session **inside** the worktree, anchoring main session cwd before any orchestrator action.
+
+### Block 0 Format
+
+Block 0 is **prepended** before Block 1 in the canonical 6-block format:
+
+```
+[New Terminal — START IN WORKTREE]
+$ cd <worktree-absolute-path>
+$ <session-launcher>
+   └─ Claude Code session starts here (cwd = worktree)
+```
+
+Where `<session-launcher>` is one of:
+
+| Launcher | When to use |
+|---|---|
+| `claude` | Default Claude Code session (Anthropic API) |
+| `moai cc` | Claude with optional profile (`-p <name>`) — recommended for normal SPEC work |
+| `moai cc --bypass` | Bypass permissions (sandbox/isolated environments only) |
+| `moai cg` | CG mode: Claude leader + GLM teammates (requires `tmux new-session` first) |
+| `moai glm` | GLM-only backend (Z.AI proxy, cost-optimized) |
+
+For `--team` execution, the session-launcher SHOULD be `moai cg` inside an explicit `tmux new-session -s <name>` so that teammate spawn via `tmux split-window` inherits worktree cwd + tmux session env.
+
+### Updated Block 4 (preconditions)
+
+When Block 0 is present, the **first precondition (0)** verifies the user's compliance:
+
+```
+0) git rev-parse --show-toplevel → <worktree-path> (★ critical pre-check)
+```
+
+If verification 0) fails (output ≠ worktree path), the next session MUST stop and instruct the user to restart inside the worktree. No orchestrator action proceeds until cwd matches.
+
+### Single-Session vs Multi-Session Decision
+
+Block 0 is REQUIRED only when SPEC was initialized with `--worktree`. For SPECs initialized with `--branch` (or no flag), the standard 6-block structure suffices because main session cwd already follows the branch — `Agent(isolation: "worktree")` base aligns naturally.
+
+[HARD] If `--worktree` was used and the user is NOT comfortable with multi-terminal/multi-session workflow, the orchestrator SHOULD recommend `--branch` for the next SPEC. Forcing Block 0 onto a single-session user is friction without benefit. See lessons #14 for the single-session vs multi-session decision rationale.
+
+### Verified Example (with Block 0)
+
+```
+[New Terminal — START IN WORKTREE]
+$ cd /Users/goos/.moai/worktrees/moai-adk/SPEC-V3R3-CI-AUTONOMY-001
+$ tmux new-session -s moai-ci-autonomy
+$ moai cg
+   └─ Claude Code session starts here (cwd = worktree)
+
+ultrathink. SPEC-V3R3-CI-AUTONOMY-001 Wave 3 (T3 auto-fix loop) 진입.
+applied lessons: project_ciaut_wave2_complete, lessons #12 #13 #14, lessons #9 wave-split.
+
+전제 검증:
+0) git rev-parse --show-toplevel → /Users/goos/.moai/worktrees/moai-adk/SPEC-V3R3-CI-AUTONOMY-001 (★ critical)
+1) git branch --show-current → feat/SPEC-V3R3-CI-AUTONOMY-001-wave-3
+2) gh pr view 788 → MERGED
+3) ls .moai/specs/SPEC-V3R3-CI-AUTONOMY-001/ → 8 files
+
+실행: /moai run SPEC-V3R3-CI-AUTONOMY-001 --team
+
+머지 후: Wave 4 → Wave 5 → Wave 6 → Wave 7
+```
+
 ## Cross-references
 
 - `.claude/rules/moai/workflow/context-window-management.md` — 75% threshold detection heuristics, broader long-horizon session continuity policy
@@ -152,8 +228,10 @@ applied lessons: project_<wave>_<spec>_<status> (PR <previous-PR-number> 머지 
 - `.claude/rules/moai/core/moai-constitution.md` §Lessons Protocol — auto-memory write rules and `[SUPERSEDED by ...]` convention
 - CLAUDE.md §11 (Error Handling) — token-limit recovery flow
 - `feedback_large_spec_wave_split.md` (auto-memory) — wave-split rationale that often precedes a session handoff
+- lessons #14 (auto-memory) — `--worktree` paste-ready Block 0 강제 rationale + single-session/multi-session decision
+- lessons #12, #13 (auto-memory) — worktree isolation discipline + --team base mismatch context
 
 ---
 
-Source: 2026-05-01 SPEC-V3R2-WF-002 session evidence (verified 6-block format)
+Source: 2026-05-01 SPEC-V3R2-WF-002 session evidence (verified 6-block format) + 2026-05-06 SPEC-V3R3-CI-AUTONOMY-001 Wave 2 (Block 0 addition)
 Status: HARD operational rule, applies to all multi-phase MoAI workflows

--- a/.claude/skills/moai/workflows/plan.md
+++ b/.claude/skills/moai/workflows/plan.md
@@ -650,6 +650,35 @@ Prerequisite: SPEC files MUST be committed before worktree creation.
 - Create worktree: `moai worktree new SPEC-{ID}`
 - Display worktree path and navigation instructions
 
+##### Worktree-Anchored Resume Output [HARD]
+
+When `--worktree` is used, the plan-phase output MUST include a paste-ready resume message with **Block 0 (cwd anchoring)** prepended before the standard 6-block structure. This anchors the user to start the next session inside the worktree, preventing main-cwd drift.
+
+Block 0 format (prepended before Block 1):
+
+```
+[New Terminal — START IN WORKTREE]
+$ cd <worktree-absolute-path>
+$ <session-launcher>            # claude | moai cc | moai cg | moai glm
+   └─ Claude Code session starts here (cwd = worktree)
+```
+
+Block 4 (preconditions) MUST include `0)` as the first item:
+
+```
+0) git rev-parse --show-toplevel → <worktree-path> (★ critical pre-check)
+```
+
+Recommended session-launcher per execution mode:
+
+- `--team` → `tmux new-session -s moai-<spec> && moai cg` (teammate spawn via tmux split-window inherits worktree cwd + tmux session env)
+- single-session → `moai cc` (or `claude`) directly inside worktree
+- GLM-only → `moai glm`
+
+[HARD] Single-session corollary: If the user is NOT comfortable with multi-terminal/multi-session workflow, recommend converting to `--branch` next time. `--worktree` only realizes its isolation value when the user actually starts a separate session inside the worktree path. Forcing Block 0 onto a single-session user is friction without benefit.
+
+See `.claude/rules/moai/workflow/session-handoff.md` "Worktree-Anchored Resume Pattern" for the canonical Block 0 specification and lessons #14 for the failure-mode rationale.
+
 #### Branch Path (--branch flag or user choice)
 
 Agent: manager-git subagent

--- a/internal/template/templates/.claude/rules/moai/workflow/session-handoff.md
+++ b/internal/template/templates/.claude/rules/moai/workflow/session-handoff.md
@@ -145,6 +145,82 @@ applied lessons: project_<wave>_<spec>_<status> (PR <previous-PR-number> 머지 
 - Multiple memory entries for the same context without `[SUPERSEDED by ...]` markers — index pollution; next session cannot identify the canonical entry.
 - Forcing the format on trivial tasks (typo fix, single config edit) — pollutes memory with noise.
 
+## Worktree-Anchored Resume Pattern
+
+[HARD] When the SPEC was initialized via `/moai plan --worktree` (creating a SPEC worktree at `~/.moai/worktrees/<project>/<spec-or-name>/`), the resume message MUST include **Block 0 (cwd anchoring)** prepended before the standard 6-block structure. Without Block 0, the next session starts in main project cwd by default, breaking SPEC worktree isolation expectations.
+
+### Why Block 0 is required
+
+The standard 6-block format implicitly assumes the next session inherits the previous session's cwd (main project). With `--worktree`, SPEC artifacts and `Agent(isolation: "worktree")` base expectations live in a **different cwd** (the worktree path). If the user pastes a resume into a Claude Code session that starts in main project cwd:
+
+- `Agent(isolation: "worktree")` base = main project HEAD ≠ worktree HEAD → lessons #13 (--team + SPEC worktree base mismatch)
+- Bash commands and file operations target main project → lessons #12 (수동 worktree isolation 위배) anti-pattern
+- Build/test results come from the wrong tree
+
+Block 0 forces the user to start a NEW terminal session **inside** the worktree, anchoring main session cwd before any orchestrator action.
+
+### Block 0 Format
+
+Block 0 is **prepended** before Block 1 in the canonical 6-block format:
+
+```
+[New Terminal — START IN WORKTREE]
+$ cd <worktree-absolute-path>
+$ <session-launcher>
+   └─ Claude Code session starts here (cwd = worktree)
+```
+
+Where `<session-launcher>` is one of:
+
+| Launcher | When to use |
+|---|---|
+| `claude` | Default Claude Code session (Anthropic API) |
+| `moai cc` | Claude with optional profile (`-p <name>`) — recommended for normal SPEC work |
+| `moai cc --bypass` | Bypass permissions (sandbox/isolated environments only) |
+| `moai cg` | CG mode: Claude leader + GLM teammates (requires `tmux new-session` first) |
+| `moai glm` | GLM-only backend (Z.AI proxy, cost-optimized) |
+
+For `--team` execution, the session-launcher SHOULD be `moai cg` inside an explicit `tmux new-session -s <name>` so that teammate spawn via `tmux split-window` inherits worktree cwd + tmux session env.
+
+### Updated Block 4 (preconditions)
+
+When Block 0 is present, the **first precondition (0)** verifies the user's compliance:
+
+```
+0) git rev-parse --show-toplevel → <worktree-path> (★ critical pre-check)
+```
+
+If verification 0) fails (output ≠ worktree path), the next session MUST stop and instruct the user to restart inside the worktree. No orchestrator action proceeds until cwd matches.
+
+### Single-Session vs Multi-Session Decision
+
+Block 0 is REQUIRED only when SPEC was initialized with `--worktree`. For SPECs initialized with `--branch` (or no flag), the standard 6-block structure suffices because main session cwd already follows the branch — `Agent(isolation: "worktree")` base aligns naturally.
+
+[HARD] If `--worktree` was used and the user is NOT comfortable with multi-terminal/multi-session workflow, the orchestrator SHOULD recommend `--branch` for the next SPEC. Forcing Block 0 onto a single-session user is friction without benefit. See lessons #14 for the single-session vs multi-session decision rationale.
+
+### Verified Example (with Block 0)
+
+```
+[New Terminal — START IN WORKTREE]
+$ cd /Users/goos/.moai/worktrees/moai-adk/SPEC-V3R3-CI-AUTONOMY-001
+$ tmux new-session -s moai-ci-autonomy
+$ moai cg
+   └─ Claude Code session starts here (cwd = worktree)
+
+ultrathink. SPEC-V3R3-CI-AUTONOMY-001 Wave 3 (T3 auto-fix loop) 진입.
+applied lessons: project_ciaut_wave2_complete, lessons #12 #13 #14, lessons #9 wave-split.
+
+전제 검증:
+0) git rev-parse --show-toplevel → /Users/goos/.moai/worktrees/moai-adk/SPEC-V3R3-CI-AUTONOMY-001 (★ critical)
+1) git branch --show-current → feat/SPEC-V3R3-CI-AUTONOMY-001-wave-3
+2) gh pr view 788 → MERGED
+3) ls .moai/specs/SPEC-V3R3-CI-AUTONOMY-001/ → 8 files
+
+실행: /moai run SPEC-V3R3-CI-AUTONOMY-001 --team
+
+머지 후: Wave 4 → Wave 5 → Wave 6 → Wave 7
+```
+
 ## Cross-references
 
 - `.claude/rules/moai/workflow/context-window-management.md` — 75% threshold detection heuristics, broader long-horizon session continuity policy
@@ -152,8 +228,10 @@ applied lessons: project_<wave>_<spec>_<status> (PR <previous-PR-number> 머지 
 - `.claude/rules/moai/core/moai-constitution.md` §Lessons Protocol — auto-memory write rules and `[SUPERSEDED by ...]` convention
 - CLAUDE.md §11 (Error Handling) — token-limit recovery flow
 - `feedback_large_spec_wave_split.md` (auto-memory) — wave-split rationale that often precedes a session handoff
+- lessons #14 (auto-memory) — `--worktree` paste-ready Block 0 강제 rationale + single-session/multi-session decision
+- lessons #12, #13 (auto-memory) — worktree isolation discipline + --team base mismatch context
 
 ---
 
-Source: 2026-05-01 SPEC-V3R2-WF-002 session evidence (verified 6-block format)
+Source: 2026-05-01 SPEC-V3R2-WF-002 session evidence (verified 6-block format) + 2026-05-06 SPEC-V3R3-CI-AUTONOMY-001 Wave 2 (Block 0 addition)
 Status: HARD operational rule, applies to all multi-phase MoAI workflows

--- a/internal/template/templates/.claude/skills/moai/workflows/plan.md
+++ b/internal/template/templates/.claude/skills/moai/workflows/plan.md
@@ -650,6 +650,35 @@ Prerequisite: SPEC files MUST be committed before worktree creation.
 - Create worktree: `moai worktree new SPEC-{ID}`
 - Display worktree path and navigation instructions
 
+##### Worktree-Anchored Resume Output [HARD]
+
+When `--worktree` is used, the plan-phase output MUST include a paste-ready resume message with **Block 0 (cwd anchoring)** prepended before the standard 6-block structure. This anchors the user to start the next session inside the worktree, preventing main-cwd drift.
+
+Block 0 format (prepended before Block 1):
+
+```
+[New Terminal — START IN WORKTREE]
+$ cd <worktree-absolute-path>
+$ <session-launcher>            # claude | moai cc | moai cg | moai glm
+   └─ Claude Code session starts here (cwd = worktree)
+```
+
+Block 4 (preconditions) MUST include `0)` as the first item:
+
+```
+0) git rev-parse --show-toplevel → <worktree-path> (★ critical pre-check)
+```
+
+Recommended session-launcher per execution mode:
+
+- `--team` → `tmux new-session -s moai-<spec> && moai cg` (teammate spawn via tmux split-window inherits worktree cwd + tmux session env)
+- single-session → `moai cc` (or `claude`) directly inside worktree
+- GLM-only → `moai glm`
+
+[HARD] Single-session corollary: If the user is NOT comfortable with multi-terminal/multi-session workflow, recommend converting to `--branch` next time. `--worktree` only realizes its isolation value when the user actually starts a separate session inside the worktree path. Forcing Block 0 onto a single-session user is friction without benefit.
+
+See `.claude/rules/moai/workflow/session-handoff.md` "Worktree-Anchored Resume Pattern" for the canonical Block 0 specification and lessons #14 for the failure-mode rationale.
+
 #### Branch Path (--branch flag or user choice)
 
 Agent: manager-git subagent


### PR DESCRIPTION
## Summary

Closes architecture mismatch between \`--worktree\` flag (multi-session intent) and Claude Code single-session reality identified during SPEC-V3R3-CI-AUTONOMY-001 Wave 2 (PR #788).

User explicit critique (2026-05-06):
> "터미널에서 moai worktree를 사용하지 않는 이상 claude code 내에서 사용이 어렵다면 --worktree 옵션은 의미가 없지 않나?"

This PR adopts **Option B** (paste-ready 강제) from the architecture decision matrix.

## Problem

\`--worktree\` flag was effectively no-op for single Claude Code session users:
- main session cwd remained on main project; SPEC worktree was a parallel directory
- \`Agent(isolation: "worktree")\` base = main HEAD ≠ worktree HEAD (lessons #13)
- Bash cd workaround required (lessons #12 anti-pattern)
- Build/test results came from wrong tree

## Solution: Block 0 (cwd anchoring)

When SPEC is initialized via \`/moai plan --worktree\`, paste-ready resume MUST include Block 0 prepended before standard 6-block format:

\`\`\`
[New Terminal — START IN WORKTREE]
$ cd <worktree-absolute-path>
$ <session-launcher>            # claude | moai cc | moai cg | moai glm
   └─ Claude Code session starts here (cwd = worktree)

ultrathink. ... (Block 1 onward)

전제 검증:
0) git rev-parse --show-toplevel → <worktree-path> (★ critical pre-check)
1) ... (other preconditions)
\`\`\`

Block 0 forces user to start NEW terminal session inside worktree, anchoring main cwd before any orchestrator action.

## Single-Session Corollary

If user is NOT comfortable with multi-terminal/multi-session workflow, recommend \`--branch\` for next SPEC. main cwd auto-follows branch, isolation naturally aligned.

## Changes

- \`.claude/rules/moai/workflow/session-handoff.md\`: New "Worktree-Anchored Resume Pattern" section + verified example
- \`.claude/skills/moai/workflows/plan.md\`: \`--worktree\` path mandates Block 0 + recommends \`--branch\` for single-session
- Template-First mirror under \`internal/template/templates/\`
- \`make build\`: PASS (embedded.go regenerated automatically via go:embed)

## References

- lessons #14 (auto-memory) — \`--worktree\` paste-ready Block 0 강제 rationale + single/multi-session decision
- lessons #12, #13 — original anti-pattern context
- SPEC-V3R3-CI-AUTONOMY-001 Wave 2 PR #788 — incident

## Test plan

- [ ] Required CI green: Lint / Test (ubuntu/macos/windows) / Build / CodeQL
- [ ] template-first parity: \`diff -q\` 0 between \`.claude/\` and \`internal/template/templates/.claude/\` for both files
- [ ] Future Wave 3 entry validates Block 0 format (post-merge live test)

🗿 MoAI <email@mo.ai.kr>