### PR TITLE
fix(bodp): anchor audit trail to git repo root, not os.Getwd()

### DIFF
--- a/internal/cli/worktree/new.go
+++ b/internal/cli/worktree/new.go
@@ -35,6 +35,19 @@ var getProjectNameFunc = func() string { return detectProjectName(".") }
 // Overridable in tests.
 var isTmuxAvailableFunc = IsTmuxAvailable
 
+// gitRepoRootFunc returns the absolute path of the git repository root via
+// `git rev-parse --show-toplevel`. Overridable in tests to avoid cwd leak:
+// BODP audit trail must always anchor on git root, never os.Getwd(), because
+// test processes run with cwd=package-dir which differs from the repo root.
+//
+// @MX:NOTE BODP audit trail 경로 버그 수정 (SPEC-V3R3-CI-AUTONOMY-001 Wave 7):
+// os.Getwd()는 테스트 실행 시 패키지 디렉터리를 반환하여 audit trail이
+// internal/cli/worktree/.moai/... 에 누수됨. 이 var로 테스트가 tempDir 주입 가능.
+var gitRepoRootFunc = func() (string, error) {
+	out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	return strings.TrimSpace(string(out)), err
+}
+
 // legacyWorktreeDir is the project-local worktrees path checked for migration warnings.
 // Overridable in tests.
 var legacyWorktreeDir = filepath.Join(".", ".moai", "worktrees")
@@ -117,7 +130,16 @@ func runNew(cmd *cobra.Command, args []string) error {
 
 	// BODP audit trail (W7-T04 reused). Failures are non-fatal — surface a
 	// warning but keep the worktree creation result.
-	if err := writeWorktreeAuditTrail(specID, branchName, effectiveBase, wtPath); err != nil {
+	//
+	// gitRepoRootFunc is used instead of os.Getwd() to ensure audit trail is
+	// always written under the git repository root, not the process cwd (which
+	// diverges during test execution to the package directory).
+	repoRoot, rootErr := gitRepoRootFunc()
+	if rootErr != nil {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: cannot determine repo root for audit trail: %v\n", rootErr)
+		repoRoot = "." // non-fatal fallback
+	}
+	if err := writeWorktreeAuditTrail(repoRoot, specID, branchName, effectiveBase); err != nil {
 		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: BODP audit trail write failed: %v\n", err)
 	}
 
@@ -176,23 +198,24 @@ func determineBase(baseFlag string, fromCurrent bool) string {
 // creation. The CLI path never prompts the user (orchestrator-only HARD), so
 // UserChoice mirrors the recommendation.
 //
+// repoRoot MUST be the git repository root returned by gitRepoRootFunc, NOT
+// os.Getwd(). The two diverge during test execution: Go runs tests with
+// cwd=package-dir, which would leak audit trail files into
+// internal/cli/worktree/.moai/branches/decisions/ instead of the repo root.
+//
 // @MX:NOTE CLI path은 사용자 프롬프트 호출 절대 금지 — agent-common-protocol
 // §User Interaction Boundary HARD (orchestrator-only). BODP signal collection
 // 은 audit trail 목적 (decision input은 사용자가 plan/worktree 직접 선택).
-func writeWorktreeAuditTrail(specID, branchName, base, _ string) error {
+func writeWorktreeAuditTrail(repoRoot, specID, branchName, base string) error {
 	currentBranch, _ := gitWorktreeCmd("rev-parse", "--abbrev-ref", "HEAD")
 	currentBranch = strings.TrimSpace(currentBranch)
-	cwd, err := os.Getwd()
-	if err != nil {
-		return fmt.Errorf("getwd: %w", err)
-	}
 	decision, _ := bodp.Check(bodp.CheckInput{
 		CurrentBranch: currentBranch,
 		NewSpecID:     specID,
-		RepoRoot:      cwd,
+		RepoRoot:      repoRoot,
 		EntryPoint:    bodp.EntryWorktreeCLI,
 	})
-	return bodp.WriteDecision(cwd, bodp.AuditEntry{
+	return bodp.WriteDecision(repoRoot, bodp.AuditEntry{
 		Timestamp:     time.Now().UTC(),
 		EntryPoint:    bodp.EntryWorktreeCLI,
 		CurrentBranch: currentBranch,

--- a/internal/cli/worktree/new_test.go
+++ b/internal/cli/worktree/new_test.go
@@ -376,22 +376,28 @@ func TestRunNew_WithTmuxFlag_TmuxAvailable(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Arrange
+			// Arrange: isolate cwd and gitRepoRootFunc to prevent BODP audit
+			// trail from leaking into the package directory.
+			// See: BODP audit trail cwd leak fix (SPEC-V3R3-CI-AUTONOMY-001 Wave 7).
 			tempDir := t.TempDir()
+			t.Chdir(tempDir)
 
 			// Set up mock functions
 			oldUserHomeDirFunc := userHomeDirFunc
 			oldGetProjectNameFunc := getProjectNameFunc
 			oldIsTmuxAvailableFunc := isTmuxAvailableFunc
+			oldGitRepoRoot := gitRepoRootFunc
 			defer func() {
 				userHomeDirFunc = oldUserHomeDirFunc
 				getProjectNameFunc = oldGetProjectNameFunc
 				isTmuxAvailableFunc = oldIsTmuxAvailableFunc
+				gitRepoRootFunc = oldGitRepoRoot
 			}()
 
 			userHomeDirFunc = func() (string, error) { return tempDir, nil }
 			getProjectNameFunc = func() string { return "test-project" }
 			isTmuxAvailableFunc = func() bool { return tt.tmuxAvailable }
+			gitRepoRootFunc = func() (string, error) { return tempDir, nil }
 
 			mockProvider, cleanup := setupMockProvider(t)
 			defer cleanup()
@@ -436,22 +442,28 @@ func TestRunNew_TmuxNotAvailable_GracefulDegradation(t *testing.T) {
 	// This test verifies that when --tmux flag is set but tmux is unavailable,
 	// worktree is still created and manual instructions are printed
 
-	// Arrange
+	// Arrange: isolate cwd and gitRepoRootFunc to prevent BODP audit trail
+	// from leaking into the package directory.
+	// See: BODP audit trail cwd leak fix (SPEC-V3R3-CI-AUTONOMY-001 Wave 7).
 	tempDir := t.TempDir()
+	t.Chdir(tempDir)
 	specID := "SPEC-TEST-001"
 
 	oldUserHomeDirFunc := userHomeDirFunc
 	oldGetProjectNameFunc := getProjectNameFunc
 	oldIsTmuxAvailableFunc := isTmuxAvailableFunc
+	oldGitRepoRoot := gitRepoRootFunc
 	defer func() {
 		userHomeDirFunc = oldUserHomeDirFunc
 		getProjectNameFunc = oldGetProjectNameFunc
 		isTmuxAvailableFunc = oldIsTmuxAvailableFunc
+		gitRepoRootFunc = oldGitRepoRoot
 	}()
 
 	userHomeDirFunc = func() (string, error) { return tempDir, nil }
 	getProjectNameFunc = func() string { return "test-project" }
 	isTmuxAvailableFunc = func() bool { return false } // tmux unavailable
+	gitRepoRootFunc = func() (string, error) { return tempDir, nil }
 
 	mockProvider, cleanup := setupMockProvider(t)
 	defer cleanup()

--- a/internal/cli/worktree/subcommands_test.go
+++ b/internal/cli/worktree/subcommands_test.go
@@ -66,8 +66,19 @@ func (m *mockWorktreeManager) Root() string {
 // --- Tests for runNew ---
 
 func TestRunNew_Success(t *testing.T) {
+	// Isolate cwd and gitRepoRootFunc so that writeWorktreeAuditTrail does not
+	// leak audit trail files into the package directory.
+	// See: BODP audit trail cwd leak fix (SPEC-V3R3-CI-AUTONOMY-001 Wave 7).
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
 	origProvider := WorktreeProvider
-	defer func() { WorktreeProvider = origProvider }()
+	origGitRepoRoot := gitRepoRootFunc
+	defer func() {
+		WorktreeProvider = origProvider
+		gitRepoRootFunc = origGitRepoRoot
+	}()
+	gitRepoRootFunc = func() (string, error) { return tmpDir, nil }
 
 	var capturedPath, capturedBranch string
 	WorktreeProvider = &mockWorktreeManager{
@@ -108,8 +119,18 @@ func TestRunNew_Success(t *testing.T) {
 }
 
 func TestRunNew_AddError(t *testing.T) {
+	// Isolate cwd and gitRepoRootFunc to prevent audit trail from leaking
+	// into the package directory when runNew is invoked with a failing Add.
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
 	origProvider := WorktreeProvider
-	defer func() { WorktreeProvider = origProvider }()
+	origGitRepoRoot := gitRepoRootFunc
+	defer func() {
+		WorktreeProvider = origProvider
+		gitRepoRootFunc = origGitRepoRoot
+	}()
+	gitRepoRootFunc = func() (string, error) { return tmpDir, nil }
 
 	WorktreeProvider = &mockWorktreeManager{
 		addFunc: func(_, _ string) error {


### PR DESCRIPTION
## Summary

Anchor BODP CLI audit trail writes to the git repository root via `git rev-parse --show-toplevel` (overridable in tests), replacing the previous `os.Getwd()` call which leaked audit trail files into the package directory during test execution. Follow-up to PR #794 (SPEC-V3R3-CI-AUTONOMY-001 Wave 7 T8 BODP).

## Background

PR #794 introduced the BODP CLI audit trail in `internal/cli/worktree/new.go`. The leak was diagnosed after auto-merge: 5 audit trail files were written to `internal/cli/worktree/.moai/branches/decisions/` (package dir) instead of the repo root during `go test ./internal/cli/worktree/...`.

Diagnostic report: `.moai/reports/expert-debug/bodp-audit-trail-leak-2026-05-09.md` (staged in upcoming `/moai sync` for SPEC closure).

## Root Cause

`writeWorktreeAuditTrail()` used `os.Getwd()` as the `repoRoot` argument to `bodp.WriteDecision()`. Go test processes run with cwd = package directory, so audit trail files landed in the wrong location. Violates CLAUDE.local.md §6 Test Isolation for 4 tests:

- `TestRunNew_Success` (subcommands_test.go:68)
- `TestRunNew_AddError` (subcommands_test.go:110)
- `TestRunNew_WithTmuxFlag_TmuxAvailable` (new_test.go:342)
- `TestRunNew_TmuxNotAvailable_GracefulDegradation` (new_test.go:434)

`TestNew_AuditTrailWritten` (new_test.go:588) was unaffected because it already called `t.Chdir(tempDir)`.

## Fix

1. **\`gitRepoRootFunc\` var** (\`new.go\`) — wraps \`exec.Command(\"git\", \"rev-parse\", \"--show-toplevel\")\`, overridable in tests.
2. **\`writeWorktreeAuditTrail()\` signature change** — accept \`repoRoot\` explicitly: \`(specID, branchName, base, _)\` → \`(repoRoot, specID, branchName, base)\`.
3. **\`runNew()\` caller** — invokes \`gitRepoRootFunc()\` with non-fatal \`\".\"\` fallback + stderr warning on error.
4. **4 tests updated** — \`t.Chdir(t.TempDir())\` + \`gitRepoRootFunc\` mock + \`defer\` restore.

## Verification

- \`go test -count=1 ./internal/cli/worktree/... ./internal/bodp/...\`: PASS (8.668s + 0.239s)
- \`go test -race -count=1 ./internal/cli/worktree/... ./internal/bodp/...\`: PASS (9.408s + 1.703s)
- \`go vet ./...\`: PASS
- \`go build ./...\`: PASS
- Leak repro: \`rm -rf internal/cli/worktree/.moai/ && go test -count=1 ./internal/cli/worktree/...\` → \`internal/cli/worktree/.moai/\` does not exist after run

## Test Plan

- [ ] CI: Lint + Test (ubuntu/macos/windows) + Build (5 platforms) + CodeQL all green
- [ ] Local repro: \`rm -rf internal/cli/worktree/.moai/ && go test -count=1 ./internal/cli/worktree/... && ls internal/cli/worktree/.moai/ 2>/dev/null && echo LEAKING || echo CLEAN\` → CLEAN
- [ ] Post-merge: \`make build && make install\` → \`moai worktree new test-x\` audit trail at \`\$REPO_ROOT/.moai/branches/decisions/test-x.md\`, not package dir

## Related

- PR #794 (Wave 7 T8 BODP) — original SPEC introducing the leak
- SPEC-V3R3-CI-AUTONOMY-001 — closure pending in upcoming \`/moai sync\`
- CLAUDE.local.md §6 Test Isolation, §18.12 BODP

## Labels

type:fix, priority:P1, area:bodp, area:cli

🗿 MoAI <email@mo.ai.kr>