### PR TITLE
fix(ci): align docs-i18n-check main push to warn-only (Phase 1)

### DIFF
--- a/.github/workflows/docs-i18n-check.yml
+++ b/.github/workflows/docs-i18n-check.yml
@@ -63,8 +63,10 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "strict=${{ inputs.strict }}" >> "$GITHUB_OUTPUT"
           elif [[ "${{ github.event_name }}" == "push" ]]; then
-            # push to main: strict (blocks regressions after baseline is cleared)
-            echo "strict=true" >> "$GITHUB_OUTPUT"
+            # push to main: warn-only during Phase 1 rollout (matches PR behavior).
+            # Flip to strict after the baseline 35 drifts are cleared (Phase 2)
+            # via SPEC-V3R3-DOCS-PARITY-001 or equivalent — see CLAUDE.local.md §17.3.
+            echo "strict=false" >> "$GITHUB_OUTPUT"
           else
             # PRs: warn-only during Phase 1 rollout
             echo "strict=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- main push에서 docs-i18n-check가 strict=true로 동작하여 status badge가 fail로 표시되었던 이슈 수정
- main push도 PR과 동일하게 strict=false (warn-only) — Phase 1 rollout 일관성 확보
- `continue-on-error: true`라 머지 차단은 원래 없었지만 운영상 false-alarm 제거

## Why

- PR #799 admin merge 직후 main push에서 docs-i18n-check가 fail 표시되어 사용자 주의가 분산됨
- workflow header(`# ADVISORY ONLY — NOT BLOCKING`)와 main push strict 동작이 inconsistent
- baseline 35 drifts는 별도 SPEC(예: `SPEC-V3R3-DOCS-PARITY-001`)으로 4-locale 동기화 wave 진행 후 strict 전환

## Scope

- 1 file, +4/-2: `.github/workflows/docs-i18n-check.yml`
- workflow_dispatch는 `inputs.strict` 그대로 (수동 strict 검증 유지)
- PR 동작 변경 없음 (이미 strict=false)

## Test plan

- [ ] CI: 본 PR의 docs-i18n-check job이 warn-only mode로 실행되는지 확인 (PR 동작 변경 없음 확인)
- [ ] Merge 후: main push trigger 시 strict=false 적용 확인 (status badge green)
- [ ] workflow_dispatch로 strict=true 수동 실행 시 종전 동작 유지 확인

## References

- CLAUDE.local.md §17.3 (4-locale documentation parity)
- SPEC-DOCS-SITE-001 AC-G3-03 (Phase 1/Phase 2 rollout intent)
- M1 closure 후 follow-up Track #2

🗿 MoAI <email@mo.ai.kr>