### PR TITLE
fix(worktree): isolate t.Chdir in RunNew tests to prevent BODP audit trail leak

### DIFF
--- a/internal/cli/worktree/subcommands_test.go
+++ b/internal/cli/worktree/subcommands_test.go
@@ -1274,6 +1274,9 @@ func TestRunNew_SpecID(t *testing.T) {
 	userHomeDirFunc = func() (string, error) { return fakeHomeDir, nil }
 	getProjectNameFunc = func() string { return "test-project" }
 	legacyWorktreeDir = t.TempDir() // empty dir → no legacy warning
+	// Isolate cwd so the BODP audit trail does not leak into the real repo
+	// root (gitRepoRootFunc falls back to "." which becomes this tempDir).
+	t.Chdir(t.TempDir())
 
 	var capturedPath, capturedBranch string
 	WorktreeProvider = &mockWorktreeManager{
@@ -1327,6 +1330,8 @@ func TestRunNew_DefaultPath(t *testing.T) {
 	userHomeDirFunc = func() (string, error) { return fakeHomeDir, nil }
 	getProjectNameFunc = func() string { return "test-project" }
 	legacyWorktreeDir = t.TempDir() // empty dir → no legacy warning
+	// Isolate cwd so the BODP audit trail does not leak into the real repo root.
+	t.Chdir(t.TempDir())
 
 	tests := []struct {
 		name     string
@@ -2034,6 +2039,8 @@ func TestRunNew_LegacyWarning(t *testing.T) {
 		t.Fatal(err)
 	}
 	legacyWorktreeDir = legacyDir
+	// Isolate cwd so the BODP audit trail does not leak into the real repo root.
+	t.Chdir(t.TempDir())
 
 	WorktreeProvider = &mockWorktreeManager{
 		addFunc: func(_, _ string) error { return nil },
@@ -2076,6 +2083,8 @@ func TestRunNew_NoLegacyWarning_EmptyDir(t *testing.T) {
 	userHomeDirFunc = func() (string, error) { return fakeHomeDir, nil }
 	getProjectNameFunc = func() string { return "test-project" }
 	legacyWorktreeDir = t.TempDir() // empty dir → no warning
+	// Isolate cwd so the BODP audit trail does not leak into the real repo root.
+	t.Chdir(t.TempDir())
 
 	WorktreeProvider = &mockWorktreeManager{
 		addFunc: func(_, _ string) error { return nil },


### PR DESCRIPTION
## Summary

- 4개 worktree 테스트가 `t.Chdir`를 호출하지 않아 BODP audit trail fixture 4종을 실제 git repo root에 누출하던 회귀를 수정
- PR #795 (production 측 `gitRepoRootFunc` 도입)의 follow-up. 진단 리포트 §Fix Proposal "방안 B — test 측 t.Chdir" 적용
- 누수 0건 확인 (`go test -race ./internal/cli/worktree/`)

## Why

- PR #795 머지 후에도 `internal/cli/worktree/` 테스트 실행 시 `.moai/branches/decisions/`에 4개 fixture(`feature-SPEC-AUTH-001.md`, `feature-SPEC-UI-042.md`, `feature-x.md`, `fix-something.md`)가 반복 누출되었음
- M1 PR #799 작업 중 working tree 오염으로 발견. cleanup 후 `go test ./...` 재실행 시 동일 누수 재발 → bisect로 4개 테스트 식별

## Bisect 결과 (누수 테스트)

| 테스트 | 누수 fixture |
|--------|--------------|
| `TestRunNew_SpecID` | `feature-SPEC-AUTH-001.md` |
| `TestRunNew_DefaultPath` | 4 fixture (subtest 4개 모두) |
| `TestRunNew_LegacyWarning` | `feature-SPEC-AUTH-001.md` |
| `TestRunNew_NoLegacyWarning_EmptyDir` | 방어적 추가 (fix와 동일 패턴) |

## Fix

각 테스트의 `fakeHomeDir := t.TempDir()` 설정 직후 `t.Chdir(t.TempDir())` 추가 (4 곳, +9 LOC).

`gitRepoRootFunc`은 `git rev-parse --show-toplevel` 호출 → tempDir이 git repo 아니므로 실패 → fallback `repoRoot = "."` → 결과적으로 audit trail은 tempDir에만 남고 테스트 종료 시 자동 cleanup.

## Test plan

- [ ] `go test -count=1 -race ./internal/cli/worktree/` PASS
- [ ] 테스트 실행 후 `ls .moai/branches/decisions/*.md` 결과 0건 (이전엔 6개)
- [ ] 전체 `./...` 회귀 없음
- [ ] CI 3 OS Test PASS

## References

- PR #795 (방안 A — production 측 fix)
- 진단 리포트: `.moai/reports/expert-debug/bodp-audit-trail-leak-2026-05-09.md` (gitignored, 로컬 디버깅용)
- M1 closure 후 follow-up Track #1

🗿 MoAI <email@mo.ai.kr>