### PR TITLE
plan(spec): SPEC-V3R2-RT-001 — Hook JSON-OR-ExitCode Dual Protocol

### DIFF
--- a/.moai/specs/SPEC-V3R2-RT-001/acceptance.md
+++ b/.moai/specs/SPEC-V3R2-RT-001/acceptance.md
@@ -1,0 +1,580 @@
+# SPEC-V3R2-RT-001 Acceptance Criteria — Given/When/Then
+
+> Detailed acceptance scenarios for each AC declared in `spec.md` §6.
+> Companion to `spec.md` v0.1.0, `research.md` v0.1.0, `plan.md` v0.1.0, `tasks.md` v0.1.0.
+
+## HISTORY
+
+| Version | Date       | Author                        | Description                                                            |
+|---------|------------|-------------------------------|------------------------------------------------------------------------|
+| 0.1.0   | 2026-05-10 | manager-spec (Plan workflow)  | Initial G/W/T conversion of 15 ACs (AC-V3R2-RT-001-01 through -15)     |
+
+---
+
+## Scope
+
+`spec.md` §6 의 15개 AC 를 Given/When/Then 형식으로 변환. 각 AC 는 happy-path + 1-3개 edge case + Go 테스트 함수 매핑을 동반.
+
+표기:
+- **Test mapping**: AC 를 검증하는 Go 테스트 함수 (또는 수동 검증 단계).
+- **Sentinel**: 부정 경로에서 테스트가 기대하는 정확한 에러 문자열.
+
+---
+
+## AC-V3R2-RT-001-01 — PreToolUse JSON 응답이 UpdatedInput + PermissionDecision 을 적용
+
+Maps to: REQ-V3R2-RT-001-010, REQ-V3R2-RT-001-013.
+
+### Happy path
+
+- **Given** PreToolUse hook wrapper 가 stdout 으로 다음 JSON 을 출력한다:
+  ```json
+  {"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","updatedInput":{"file_path":"/tmp/x"}}}
+  ```
+- **When** registry 의 Dispatch 가 PreToolUse 이벤트를 라우팅
+- **Then** ParseHookOutput 이 JSON parse 성공 → exit-code 무시
+- **And** `HookResponse.HookSpecificOutput` 에 nested PreToolUseOutput 정보 보존
+- **And** pending tool input 이 `{"file_path":"/tmp/x"}` 로 교체된 후 tool dispatch
+- **And** SPEC-V3R2-RT-002 의 permission stack resolver 가 `permissionDecision: allow` 수신
+
+### Edge case — JSON parse 성공 시 exit code 무시
+
+- **Given** 동일 JSON + wrapper exit code 7 (의미 있는 값)
+- **When** ParseHookOutput 처리
+- **Then** exit code 7 은 완전히 무시됨; JSON 의 의미가 우선
+
+### Test mapping
+
+- `internal/hook/dual_parse_test.go::TestParseHookOutput_PreToolUseJSON` (existing baseline 확장)
+- `internal/hook/registry_test.go::TestDispatch_PreToolUseUpdatedInput` (new, M1)
+
+---
+
+## AC-V3R2-RT-001-02 — SessionStart 이 AdditionalContext + WatchPaths 응답
+
+Maps to: REQ-V3R2-RT-001-001, REQ-V3R2-RT-001-012, REQ-V3R2-RT-001-032.
+
+### Happy path
+
+- **Given** SessionStart hook 이 다음 JSON 을 출력:
+  ```json
+  {"additionalContext":"ctx","watchPaths":["/abs/.env"]}
+  ```
+- **When** ParseHookOutput 이 파싱
+- **Then** `HookResponse.AdditionalContext == "ctx"`
+- **And** `HookResponse.WatchPaths == ["/abs/.env"]`
+- **And** `Validate()` 통과 (validator/v10 schema 위반 없음)
+- **And** AdditionalContext 가 다음 model turn 의 system-context block 에 append
+- **And** WatchPaths 가 `WatchPathsRegistrar.Register([]string)` 으로 forward
+
+### Edge case — WatchPathsRegistrar 미등록 시 graceful
+
+- **Given** 동일 JSON 출력
+- **And** registry 에 `WatchPathsRegistrar` 가 nil
+- **When** Dispatch 처리
+- **Then** WatchPaths 는 logged but not registered (no panic)
+- **And** AdditionalContext routing 은 정상 동작 (다른 필드는 영향 없음)
+
+### Edge case — 빈 WatchPaths
+
+- **Given** `{"additionalContext":"ctx","watchPaths":[]}`
+- **When** Dispatch 처리
+- **Then** `WatchPathsRegistrar.Register` 는 호출되지 않음 (zero-length slice skip)
+
+### Test mapping
+
+- `internal/hook/dual_parse_test.go::TestParseHookOutput_SessionStartContextAndWatchPaths` (new, M1)
+- `internal/hook/registry_test.go::TestDispatch_AdditionalContextRoutedToModelContext` (new, M1)
+
+---
+
+## AC-V3R2-RT-001-03 — Legacy hook exit code 2 → deny + stderr reason
+
+Maps to: REQ-V3R2-RT-001-011.
+
+### Happy path
+
+- **Given** legacy hook wrapper 가 stdout 빈 출력 + exit code 2 + stderr `"blocked"`
+- **When** ParseHookOutput 처리
+- **Then** dual-parse fallback 진입 (JSON empty)
+- **And** `synthesizeFromExitCode(2, "blocked")` 호출
+- **And** `HookResponse.PermissionDecision == "deny"`
+- **And** `HookResponse.SystemMessage == "blocked"` (현재 `dual_parse.go:75-78` 동작)
+
+### Edge case — exit code 1 (기타 non-zero)
+
+- **Given** stdout 빈 출력 + exit code 1 + stderr `"transient error"`
+- **When** ParseHookOutput 처리
+- **Then** `HookResponse.SystemMessage == "transient error"` (PermissionDecision 미설정 — "no opinion")
+
+### Edge case — exit code 0 + stderr (warning)
+
+- **Given** stdout 빈 출력 + exit code 0 + stderr `"warning"` (의미상 무해)
+- **When** ParseHookOutput 처리
+- **Then** `HookResponse{}` (empty 응답, allow + continue)
+- **And** stderr 는 무시되거나 별도 로그 (현재 동작 유지)
+
+### Test mapping
+
+- `internal/hook/dual_parse_test.go::TestSynthesizeFromExitCode_Code2WithStderr` (existing)
+- `internal/hook/dual_parse_test.go::TestSynthesizeFromExitCode_Code1WithStderr` (existing)
+
+---
+
+## AC-V3R2-RT-001-04 — MOAI_HOOK_LEGACY=1 이 deprecation banner 억제
+
+Maps to: REQ-V3R2-RT-001-020, REQ-V3R2-RT-001-007.
+
+### Happy path
+
+- **Given** 환경변수 `MOAI_HOOK_LEGACY=1` 설정
+- **And** legacy wrapper 가 exit-code-only 출력
+- **When** ParseHookOutput 첫 호출 (세션 시작 후 첫 legacy)
+- **Then** 본 세션에서 deprecation banner 가 emit 되지 않음
+- **And** dual-parse fallback 은 정상 동작 (exit code 의미 보존)
+- **And** subsequent legacy hook 도 banner 미발사
+
+### Edge case — MOAI_HOOK_LEGACY=0 또는 미설정
+
+- **Given** 환경변수 `MOAI_HOOK_LEGACY` 미설정
+- **And** 동일 legacy wrapper
+- **When** ParseHookOutput 첫 호출
+- **Then** banner 가 1회 emit (SystemMessage 또는 별도 채널)
+- **And** subsequent legacy hook 은 banner 미반복 (REQ-050 once-per-session)
+
+### Edge case — MOAI_HOOK_LEGACY=true 또는 yes (loose truthy)
+
+- **Given** 환경변수 `MOAI_HOOK_LEGACY=true`
+- **When** banner 검사
+- **Then** banner suppressed (loose truthy 인정 — `IsLegacyEnvSet` 가 `"1"`, `"true"`, `"yes"` 모두 true 반환).
+
+### Test mapping
+
+- `internal/hook/banner_test.go::TestBanner_SuppressedByMoaiHookLegacy` (new, M1)
+- `internal/hook/strict_mode_test.go::TestIsLegacyEnvSet_LooseTruthy` (new, M1)
+
+---
+
+## AC-V3R2-RT-001-05 — HookSpecificOutput.HookEventName 불일치 시 mismatch 에러
+
+Maps to: REQ-V3R2-RT-001-040.
+
+### Happy path
+
+- **Given** PreToolUse hook 이 다음 JSON 출력:
+  ```json
+  {"hookSpecificOutput":{"hookEventName":"PostToolUse","permissionDecision":"allow"}}
+  ```
+- **And** registry 가 PreToolUse 이벤트 dispatch 중
+- **When** Dispatch 가 응답 검증
+- **Then** `HookSpecificOutputMismatch{Expected: "PreToolUse", Actual: "PostToolUse"}` 에러 반환
+- **And** `.moai/logs/hook.log` 에 mismatch entry append:
+  ```
+  HOOK_MISMATCH event=PreToolUse actual=PostToolUse session=<id> ts=<ts>
+  ```
+- **And** hook 이 failed 처리 — output 무시 + default deny + reason="hookSpecificOutput mismatch"
+
+### Edge case — HookEventName 빈 값 (legacy hook)
+
+- **Given** `{"hookSpecificOutput":{"hookEventName":"","permissionDecision":"allow"}}`
+- **When** Dispatch 검증
+- **Then** mismatch 처리 skip (빈 문자열은 "no opinion"; legacy compatibility)
+- **And** PermissionDecision: allow 는 정상 적용
+
+### Edge case — HookSpecificOutput 자체 부재
+
+- **Given** `{"continue":true}` (HookSpecificOutput 없음)
+- **When** Dispatch 검증
+- **Then** mismatch 검사 skip; top-level fields 로 처리
+
+### Test mapping
+
+- `internal/hook/registry_test.go::TestDispatch_HookSpecificOutputMismatch` (new, M1) — sentinel `HookSpecificOutputMismatch`
+
+---
+
+## AC-V3R2-RT-001-06 — strict_mode true 시 legacy wrapper 즉시 reject
+
+Maps to: REQ-V3R2-RT-001-021.
+
+### Happy path
+
+- **Given** `.moai/config/sections/system.yaml` 에 `hook.strict_mode: true` 설정
+- **And** legacy wrapper 가 stdout 빈 + exit code 0
+- **When** ParseHookOutput 처리
+- **Then** `ErrHookProtocolLegacyRejected` 반환
+- **And** turn halts with user-visible SystemMessage `"hook protocol: legacy exit code rejected in strict mode"`
+- **And** banner 는 emit 되지 않음 (rejection 이 우선)
+
+### Edge case — strict_mode + plugin source
+
+- **Given** strict_mode=true + `HookInput.ConfigurationSource == "plugin"`
+- **When** ParseHookOutput 처리
+- **Then** dual-parse fallback 적용 (NO error) — REQ-051 plugin bypass
+
+### Edge case — strict_mode + JSON 출력 (정상 경로)
+
+- **Given** strict_mode=true + valid JSON stdout
+- **When** ParseHookOutput 처리
+- **Then** JSON parse 정상 + 응답 생성. strict_mode 는 fallback 만 차단.
+
+### Test mapping
+
+- `internal/hook/strict_mode_test.go::TestStrictMode_ErrorReturnedOnLegacyOutput` (new, M1)
+- `internal/hook/strict_mode_test.go::TestStrictMode_PluginSourceBypass` (new, M1)
+
+---
+
+## AC-V3R2-RT-001-07 — PostToolUse AdditionalContext 의 @MX 마커 라우팅
+
+Maps to: REQ-V3R2-RT-001-016.
+
+### Happy path
+
+- **Given** PostToolUse hook 이 다음 JSON 출력:
+  ```json
+  {"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"@MX:WARN at line 42 — unbounded goroutine"}}
+  ```
+- **When** Dispatch 처리 후 PostToolUse handler 가 응답 검사
+- **Then** AdditionalContext 가 `internal/hook/mx/ingest.go` 의 ingestion 함수에 forward
+- **And** SPEC-V3R2-SPC-002 가 정의한 라우팅 path 진입
+
+### Edge case — 마커 5종 모두 인식
+
+- **Given** AdditionalContext 가 `@MX:NOTE`, `@MX:WARN`, `@MX:ANCHOR`, `@MX:TODO`, `@MX:LEGACY` 중 1개라도 포함
+- **When** PostToolUse handler 검사
+- **Then** ingestion path 호출 (어느 마커든 fan-in 처리)
+
+### Edge case — 마커 부재
+
+- **Given** AdditionalContext 가 일반 텍스트 (마커 없음)
+- **When** handler 검사
+- **Then** ingestion path 호출되지 않음. 일반 context 처럼 model turn 에 append.
+
+### Test mapping
+
+- `internal/hook/post_tool_mx_test.go::TestPostTool_RoutesMXMarkers` (existing 확장, M5c)
+
+---
+
+## AC-V3R2-RT-001-08 — SubagentStop Continue:false → teammate idle blocker
+
+Maps to: REQ-V3R2-RT-001-014.
+
+### Happy path
+
+- **Given** SubagentStop hook 이 다음 JSON 출력:
+  ```json
+  {"continue":false,"systemMessage":"coverage below 85%"}
+  ```
+- **When** Dispatch 처리
+- **Then** teammate 가 idle 상태 진입 차단
+- **And** orchestrator 가 BlockerReport 생성 (subagent 는 AskUserQuestion 직접 호출 금지)
+- **And** orchestrator 가 AskUserQuestion 으로 user 에게 surfacing
+
+### Edge case — Continue 미설정 (default true)
+
+- **Given** `{"systemMessage":"warning"}` (Continue 필드 없음)
+- **When** Dispatch
+- **Then** Continue 의 default 는 true; teammate idle 정상 진행
+
+### Edge case — Continue:false 인 SessionEnd
+
+- **Given** SessionEnd 이벤트 + `{"continue":false}`
+- **When** Dispatch
+- **Then** session 종료 차단; SystemMessage user 에게 노출 (`registry.go` Dispatch 의 generic Continue 처리)
+
+### Test mapping
+
+- `internal/hook/registry_test.go::TestDispatch_ContinueFalseBlocksTeammateIdle` (new, M1)
+- `internal/hook/subagent_stop_test.go::TestSubagentStop_ContinueFalse` (existing 확장)
+
+---
+
+## AC-V3R2-RT-001-09 — 128 KiB AdditionalContext 가 64 KiB 로 절단
+
+Maps to: REQ-V3R2-RT-001-022.
+
+### Happy path
+
+- **Given** hook 이 128 KiB 길이의 AdditionalContext 를 emit:
+  ```json
+  {"additionalContext":"<131072 bytes of text>"}
+  ```
+- **When** ValidateHookResponse 호출
+- **Then** `HookResponse.AdditionalContext` 가 64 KiB (65536 bytes) 로 절단
+- **And** `HookResponse.SystemMessage` 에 truncation notice 포함:
+  ```
+  [Notice: additionalContext truncated from 131072 to 65536 bytes]
+  ```
+
+### Edge case — 정확히 64 KiB
+
+- **Given** AdditionalContext 가 정확히 65536 bytes
+- **When** ValidateHookResponse
+- **Then** 절단 없음; SystemMessage 에 notice 추가되지 않음 (`> maxContextSize` 가 false)
+
+### Edge case — 64 KiB + 1 byte
+
+- **Given** AdditionalContext 가 65537 bytes (1 byte 초과)
+- **When** ValidateHookResponse
+- **Then** 65536 으로 절단 + notice 추가
+
+### Test mapping
+
+- `internal/hook/dual_parse_test.go::TestValidateHookResponse_TruncatesAt64KiB` (new, M1) — 128 KiB input
+- `internal/hook/dual_parse_test.go::TestValidateHookResponse_ExactlyAtBoundary` (new, M1) — 65536 byte input
+
+---
+
+## AC-V3R2-RT-001-10 — PreToolUse 가 deny + UpdatedInput 둘 다 반환 시 ordering
+
+Maps to: REQ-V3R2-RT-001-041.
+
+### Happy path
+
+- **Given** PreToolUse hook 이 다음 JSON 출력:
+  ```json
+  {"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","updatedInput":{"file_path":"/etc/passwd"}}}
+  ```
+- **When** registry 처리
+- **Then** UpdatedInput 이 pending tool input 에 먼저 merge 됨 → input = `{"file_path":"/etc/passwd"}`
+- **And** PermissionDecision: deny 가 평가되어 tool call 차단
+- **And** denial message 가 post-update input (`/etc/passwd`) 을 reference
+
+### Edge case — UpdatedInput 만 (PermissionDecision 없음)
+
+- **Given** `{"hookSpecificOutput":{"hookEventName":"PreToolUse","updatedInput":{"file_path":"/tmp"}}}`
+- **When** Dispatch
+- **Then** input 교체 + tool 진행 (PermissionDecision: "" → "no opinion" → 다른 hook 또는 default allow)
+
+### Edge case — PermissionDecision 만 (UpdatedInput 없음)
+
+- **Given** `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}`
+- **When** Dispatch
+- **Then** input 교체 없음 + allow 결정
+
+### Test mapping
+
+- `internal/hook/registry_test.go::TestDispatch_PreToolUseUpdatedInputThenPermissionDecision` (new, M1)
+- `internal/hook/registry_test.go::TestDispatch_PreToolUseUpdatedInputOnly` (new, M1)
+
+---
+
+## AC-V3R2-RT-001-11 — api_version 2 wrapper 가 exit-code fallback skip
+
+Maps to: REQ-V3R2-RT-001-030.
+
+### Happy path
+
+- **Given** wrapper file `.claude/hooks/moai/handle-future.sh` 가 첫 줄에 `# moai-hook-api-version: 2` 헤더 포함
+- **And** wrapper 가 stdout 빈 + exit code 0 으로 종료
+- **When** ParseHookOutput 처리 (wrapperPath 또는 env var 인지)
+- **Then** exit-code synthesis 수행하지 않음
+- **And** explicit no-op `HookResponse{}` 반환 (allow + continue, but explicitly empty)
+
+### Edge case — api_version 1 (default) wrapper 가 stdout 빈 + exit 0
+
+- **Given** 헤더 없는 wrapper (api_version 1 으로 간주)
+- **And** stdout 빈 + exit code 0
+- **When** ParseHookOutput 처리
+- **Then** exit-code synthesis 수행 → `HookResponse{}` (의미상 동일하지만 경로가 다름)
+
+### Edge case — api_version 2 wrapper 가 invalid JSON
+
+- **Given** api_version 2 헤더 + stdout malformed JSON
+- **When** ParseHookOutput
+- **Then** JSON parse 실패; api_version 2 의 의미는 "fallback skip" 이므로 explicit error 반환 (NOT exit-code synthesis). 단, AC-15 의 deprecation banner 는 emit 되지 않음 (legacy 가 아니므로).
+
+### Test mapping
+
+- `internal/hook/api_version_test.go::TestApiVersion2_SkipsExitCodeFallback` (new, M1)
+- `internal/hook/api_version_test.go::TestApiVersion2_ParsesShellHeader` (new, M1)
+
+---
+
+## AC-V3R2-RT-001-12 — validator/v10 가 invalid PermissionDecision 거절
+
+Maps to: REQ-V3R2-RT-001-006.
+
+### Happy path
+
+- **Given** `HookResponse{PermissionDecision: "yes"}` (oneof 위반)
+- **When** `Validate()` 호출
+- **Then** non-nil error 반환
+- **And** error.Error() 에 `"PermissionDecision"` 부분 문자열 포함
+- **And** error 에 `"oneof"` validation tag 명시
+
+### Edge case — valid value (`"allow"`)
+
+- **Given** `HookResponse{PermissionDecision: "allow"}`
+- **When** `Validate()`
+- **Then** nil error
+
+### Edge case — empty string (no opinion)
+
+- **Given** `HookResponse{PermissionDecision: ""}`
+- **When** `Validate()`
+- **Then** nil error (omitempty 적용; oneof 검사 skip)
+
+### Edge case — `"defer"` (v2.1.89+ headless)
+
+- **Given** `HookResponse{PermissionDecision: "defer"}`
+- **When** `Validate()`
+- **Then** nil error (defer 는 enum 에 포함; `response.go:46-61` PermissionDecisionDefer)
+
+### Test mapping
+
+- `internal/hook/response_test.go::TestHookResponse_ValidatorRejectsBadPermissionDecision` (new, M1)
+- `internal/hook/response_test.go::TestHookResponse_ValidatorAcceptsAllowAskDenyDefer` (new, M1)
+
+---
+
+## AC-V3R2-RT-001-13 — 27 variant types round-trip serialization
+
+Maps to: REQ-V3R2-RT-001-003, REQ-V3R2-RT-001-004.
+
+### Happy path
+
+- **Given** 27개 variant 타입 (`PreToolUseOutput`, `PostToolUseOutput`, ..., `StopFailureOutput`) 각 1개 instance
+- **When** `json.Marshal` → `json.Unmarshal` 왕복
+- **Then** 모든 27 instance 가 marshal → unmarshal 후 동일한 값 (identity)
+- **And** 각 variant 의 `HookEventName()` 메서드가 정확한 이벤트 이름 반환
+
+### Edge case — empty 변형 타입 (예: `PreCompactOutput{EventName: ""}`)
+
+- **Given** `PreCompactOutput{}`
+- **When** marshal → unmarshal
+- **Then** unmarshal 결과는 `PreCompactOutput{}` (zero value preserved)
+- **And** `HookEventName()` 는 여전히 `"PreCompact"` (메서드는 인스턴스 상태 무관)
+
+### Edge case — variant 가 추가 필드 보유 (예: `PreToolUseOutput.UpdatedInput`)
+
+- **Given** `PreToolUseOutput{UpdatedInput: json.RawMessage(`{"key":"value"}`)}`
+- **When** marshal → unmarshal
+- **Then** UpdatedInput 의 RawMessage 가 byte-level 보존
+
+### Test mapping
+
+- `internal/hook/wire_format_freeze_test.go::TestWireFormatFreeze_AllVariants` (existing baseline 확장)
+- `internal/hook/response_test.go::TestHookResponse_27VariantHookEventNameRoundTrip` (new, M1)
+
+---
+
+## AC-V3R2-RT-001-14 — Plugin-source bypass in strict mode
+
+Maps to: REQ-V3R2-RT-001-051.
+
+### Happy path
+
+- **Given** `hook.strict_mode: true` 설정
+- **And** plugin-contributed hook (HookInput.ConfigurationSource == "plugin")
+- **And** legacy exit-code-only output
+- **When** ParseHookOutput 처리
+- **Then** `ErrHookProtocolLegacyRejected` 반환되지 않음
+- **And** dual-parse fallback 정상 적용
+- **And** `.moai/logs/hook.log` 에 plugin source 기록:
+  ```
+  HOOK_LEGACY_BYPASS source=plugin event=<event> session=<id>
+  ```
+
+### Edge case — non-plugin source + strict_mode
+
+- **Given** strict_mode=true + ConfigurationSource="user_settings" + legacy output
+- **When** ParseHookOutput
+- **Then** `ErrHookProtocolLegacyRejected` 반환 (정상 strict 동작)
+
+### Edge case — plugin source + JSON output
+
+- **Given** ConfigurationSource="plugin" + valid JSON output
+- **When** ParseHookOutput
+- **Then** JSON parse 정상; bypass 분기 진입하지 않음 (fallback 이 발생하지 않으므로)
+
+### Test mapping
+
+- `internal/hook/strict_mode_test.go::TestStrictMode_PluginSourceBypass` (new, M1)
+- `internal/hook/strict_mode_test.go::TestIsPluginSource_NonPluginSources` (new, M1)
+
+---
+
+## AC-V3R2-RT-001-15 — Deprecation banner once-per-session
+
+Maps to: REQ-V3R2-RT-001-007, REQ-V3R2-RT-001-050.
+
+### Happy path
+
+- **Given** 새 세션 (sessionID = "session-A")
+- **And** legacy hook 이 첫 호출
+- **When** ParseHookOutput 처리 + banner 검사
+- **Then** banner emit (1회) — SystemMessage 에 deprecation 텍스트 포함
+- **When** 동일 세션에서 두 번째 legacy hook 호출
+- **Then** banner emit 되지 않음 (already emitted in session)
+- **And** exit code 의미는 정상 처리 (allow/deny 합성)
+
+### Edge case — 다른 세션은 독립
+
+- **Given** "session-A" 에서 banner 이미 emit
+- **And** 새 세션 "session-B" 시작 + legacy hook
+- **When** banner 검사
+- **Then** "session-B" 에서 banner 첫 emit (per-session 격리)
+
+### Edge case — MOAI_HOOK_LEGACY=1 + 새 세션
+
+- **Given** "session-C" + MOAI_HOOK_LEGACY=1 + legacy hook
+- **When** banner 검사
+- **Then** banner 미발사 (env opt-out 우선)
+
+### Edge case — 동시성 (2 goroutine)
+
+- **Given** "session-D" 에서 동시 2개 goroutine 이 ParseHookOutput 호출
+- **When** banner LoadOrStore atomic check
+- **Then** 정확히 1개 goroutine 만 banner emit (sync.Map atomic)
+
+### Test mapping
+
+- `internal/hook/banner_test.go::TestBanner_OncePerSession` (new, M1)
+- `internal/hook/banner_test.go::TestBanner_PerSessionIsolation` (new, M1)
+- `internal/hook/banner_test.go::TestBanner_ConcurrentSafety` (new, M1)
+
+---
+
+## Summary table — AC → REQ → Test
+
+| AC | REQs covered | Test files |
+|----|--------------|------------|
+| AC-01 | REQ-010, REQ-013 | `dual_parse_test.go::TestParseHookOutput_PreToolUseJSON`, `registry_test.go::TestDispatch_PreToolUseUpdatedInput` |
+| AC-02 | REQ-001, REQ-012, REQ-032 | `dual_parse_test.go::TestParseHookOutput_SessionStartContextAndWatchPaths`, `registry_test.go::TestDispatch_AdditionalContextRoutedToModelContext` |
+| AC-03 | REQ-011 | `dual_parse_test.go::TestSynthesizeFromExitCode_*` (3 cases) |
+| AC-04 | REQ-020, REQ-007 | `banner_test.go::TestBanner_SuppressedByMoaiHookLegacy`, `strict_mode_test.go::TestIsLegacyEnvSet_LooseTruthy` |
+| AC-05 | REQ-040 | `registry_test.go::TestDispatch_HookSpecificOutputMismatch` |
+| AC-06 | REQ-021 | `strict_mode_test.go::TestStrictMode_ErrorReturnedOnLegacyOutput`, `TestStrictMode_PluginSourceBypass` |
+| AC-07 | REQ-016 | `post_tool_mx_test.go::TestPostTool_RoutesMXMarkers` |
+| AC-08 | REQ-014 | `registry_test.go::TestDispatch_ContinueFalseBlocksTeammateIdle`, `subagent_stop_test.go::TestSubagentStop_ContinueFalse` |
+| AC-09 | REQ-022 | `dual_parse_test.go::TestValidateHookResponse_TruncatesAt64KiB`, `TestValidateHookResponse_ExactlyAtBoundary` |
+| AC-10 | REQ-041 | `registry_test.go::TestDispatch_PreToolUseUpdatedInputThenPermissionDecision` |
+| AC-11 | REQ-030 | `api_version_test.go::TestApiVersion2_SkipsExitCodeFallback`, `TestApiVersion2_ParsesShellHeader` |
+| AC-12 | REQ-006, REQ-002 | `response_test.go::TestHookResponse_ValidatorRejectsBadPermissionDecision`, `TestHookResponse_ValidatorAcceptsAllowAskDenyDefer` |
+| AC-13 | REQ-003, REQ-004 | `wire_format_freeze_test.go::TestWireFormatFreeze_AllVariants`, `response_test.go::TestHookResponse_27VariantHookEventNameRoundTrip` |
+| AC-14 | REQ-051 | `strict_mode_test.go::TestStrictMode_PluginSourceBypass`, `TestIsPluginSource_NonPluginSources` |
+| AC-15 | REQ-007, REQ-050 | `banner_test.go::TestBanner_OncePerSession`, `TestBanner_PerSessionIsolation`, `TestBanner_ConcurrentSafety` |
+
+Total new test functions: **~28 across 5 new test files + 3 existing files extended**.
+
+---
+
+## Definition of Done
+
+본 SPEC 는 다음 모든 조건이 참일 때 완료:
+
+1. 위 15개 AC 가 `go test ./internal/hook/` 으로 모두 PASS.
+2. 전체 `go test ./...` 이 worktree root 에서 zero failures + zero cascading regressions.
+3. `make build` 성공 + `internal/template/embedded.go` 정상 재생성.
+4. `go vet ./...` + `golangci-lint run` 경고 0.
+5. `progress.md` 가 `run_complete_at: <timestamp>` + `run_status: implementation-complete` 로 업데이트.
+6. CHANGELOG entry 가 `## [Unreleased] / ### Changed (BREAKING — BC-V3R2-001)` 아래 존재.
+7. 7개 MX tag 가 `plan.md` §6 verbatim 으로 삽입 (3 ANCHOR + 2 NOTE + 2 WARN).
+8. `manager-git` 이 연 PR 의 모든 required CI 통과 (Lint, Test ubuntu/macos/windows, Build 5 platforms, CodeQL).
+
+---
+
+End of acceptance.md.

--- a/.moai/specs/SPEC-V3R2-RT-001/issue-body.md
+++ b/.moai/specs/SPEC-V3R2-RT-001/issue-body.md
@@ -1,0 +1,173 @@
+## SPEC-V3R2-RT-001 — Hook JSON-OR-ExitCode Dual Protocol
+
+> **Phase**: v3.0.0 — Phase 2 — Runtime Hardening
+> **Module**: `internal/hook/`
+> **Priority**: P0 Critical
+> **Breaking**: **true** (BC-V3R2-001)
+> **Lifecycle**: spec-anchored
+
+## Summary
+
+Plan documents for SPEC-V3R2-RT-001 are ready for plan-auditor review. 본 SPEC 는 Claude Code 2026.x 의 `HookJSONOutput` (JSON-OR-ExitCode) 프로토콜을 moai 의 27개 Claude Code 후크 이벤트 전체에 도입한다. typed `HookResponse` JSON 페이로드가 stdout 으로 emit 되며, JSON 파싱 실패 또는 빈 stdout 시 legacy exit-code 의미론으로 fallback 한다 (dual-parse). master §8 BC-V3R2-001 의 wrappers-unchanged + handlers-rewritten 호환성 shim 으로 26개 셸 래퍼는 v3.x 전체 deprecation window 동안 작동.
+
+## Goal (purpose)
+
+- **Structural (master §5.4)**: 5가지 programmable hook 능력 unlock — `additionalContext`, `updatedInput`, `permissionDecision`, `systemMessage`, `continue: false`. exit-code 만으로는 표현 불가능한 의미론.
+- **Compatibility (master §8 BC-V3R2-001)**: dual-parse 가 v3.0 → v3.x deprecation window 동안 legacy exit-code-only hook 을 계속 수용. v4.0 에서 exit-code-only 경로 제거 예정.
+- **Foundation for downstream Runtime SPECs**: RT-002 (permission stack), RT-003 (sandbox), RT-006 (handler completeness), SPC-002 (@MX routing), HRN-002 (evaluator fresh-memory injection) 모두 본 SPEC 의 protocol 위에서 진행.
+
+## Scope
+
+### In-Scope
+
+- typed `HookResponse` Go struct + 7 canonical fields (`AdditionalContext`, `PermissionDecision`, `UpdatedInput`, `SystemMessage`, `Continue`, `WatchPaths`, `Retry`)
+- `PermissionDecision` 4-value enum (allow / ask / deny / defer; "" = no opinion)
+- `HookSpecificOutput` discriminator + 27 per-event variant types implementing `HookEventName() string`
+- Dual-parse shim: JSON-first then exit-code synthesis (0→allow, 2→deny+stderr, non-zero→user msg)
+- validator/v10 schema 검증 (SPEC-V3R2-SCH-001 의존성; M2 에서 직접 추가)
+- Context-injection wiring (SessionStart/UserPromptSubmit/PreToolUse/PostToolUse → next model turn)
+- Input-mutation wiring (PreToolUse `UpdatedInput` 가 pending tool input 교체)
+- `Continue: false` escalation (SubagentStop → teammate idle blocker)
+- Once-per-session deprecation banner; `MOAI_HOOK_LEGACY=1` opt-out for CI/air-gapped
+- Opt-in strict mode via `.moai/config/sections/system.yaml` `hook.strict_mode: true` (default false)
+- HookSpecificOutputMismatch detection — security boundary against forged event names
+- 64 KiB AdditionalContext 절단 + truncation systemMessage notice
+- api_version 2 opt-in (`# moai-hook-api-version: 2` shell header) — exit-code fallback skip
+- WatchPaths registrar interface (SessionStart 등록)
+- @MX 마커 라우팅 hook (PostToolUse `additionalContext` → SPEC-V3R2-SPC-002 ingestion)
+- Plugin-source bypass (REQ-051) — `ConfigurationSource == "plugin"` 시 strict_mode 우회
+
+### Out-of-Scope
+
+- Handler completeness (27 events 의 비즈니스 로직 완성) — SPEC-V3R2-RT-006
+- Permission stack 8-source 해결 — SPEC-V3R2-RT-002
+- Sandbox 실행 — SPEC-V3R2-RT-003
+- Typed session state (`Checkpoint`, `BlockerReport`) — SPEC-V3R2-RT-004
+- Multi-layer settings provenance reader — SPEC-V3R2-RT-005
+- Shell wrapper 의 hardcoded path 수정 — SPEC-V3R2-RT-007
+- Hook type 확장 (`prompt`/`agent`/`http` beyond `command`) — v3.1+
+- @MX 마커 자율 add/update/remove 의미론 — SPEC-V3R2-SPC-002
+
+## Plan Documents
+
+| Document | Purpose | Notes |
+|----------|---------|-------|
+| `spec.md` | EARS requirements + ACs (existing, v0.1.0) | 25 REQs across 6 categories, 15 ACs, breaking: true |
+| `plan.md` | Implementation plan (M1-M5 milestones, traceability matrix, mx_plan, plan-audit-ready checklist) | new |
+| `research.md` | Deep research (12 sections, 35 file:line anchors, library evaluation, BC-V3R2-001 분석) | new |
+| `acceptance.md` | 15 ACs in Given/When/Then format with edge cases + test mapping | new |
+| `tasks.md` | 43 tasks (T-RT001-01..43) across M1-M5 with owner roles + dependencies | new |
+| `progress.md` | Live progress tracker + paste-ready session-handoff resume message | new |
+
+## EARS Requirements Summary
+
+- **25 REQs across 6 categories**: Ubiquitous (7), Event-Driven (7), State-Driven (3), Optional (3), Unwanted (3), Complex (2)
+- **15 ACs all map to REQs (100% coverage)**
+- **Traceability matrix**: 25 REQ → 15 AC → 43 tasks (verified in `plan.md` §1.4)
+
+## Implementation Methodology
+
+`.moai/config/sections/quality.yaml`: `development_mode: tdd`. Run phase MUST follow RED → GREEN → REFACTOR per `.claude/rules/moai/workflow/spec-workflow.md`.
+
+- **M1 (RED)**: 18개 실패 테스트 작성 — strict_mode/banner/api_version/mismatch detection/AdditionalContext routing/64 KiB truncation/Continue:false escalation/27 variant round-trip/plugin bypass.
+- **M2 (GREEN part 1)**: validator/v10 직접 의존성 + HookResponse Validate() 메서드. AC-12 GREEN.
+- **M3 (GREEN part 2)**: strict_mode 분기 + MOAI_HOOK_LEGACY env + once-per-session banner + HookConfig + system.yaml template. AC-04, AC-06, AC-15 GREEN.
+- **M4 (GREEN part 3)**: registry.go 의 4가지 의미 강화 — mismatch detection + UpdatedInput-then-Decision ordering + AdditionalContext routing + Continue:false escalation. AC-02, AC-05, AC-08, AC-09, AC-10 GREEN.
+- **M5 (GREEN part 4 + REFACTOR + Trackable)**: api_version 2 + WatchPaths registrar + @MX routing + plugin bypass + CHANGELOG + 7 MX tags + make build + go test + vet + lint. AC-01, AC-03, AC-07, AC-11, AC-13, AC-14 GREEN.
+
+## Breaking Change (BC-V3R2-001)
+
+본 SPEC 는 frontmatter `breaking: true` + `bc_id: [BC-V3R2-001]`. 호환성 shim 의 핵심 약속:
+
+- **Wrappers-unchanged**: `.claude/hooks/moai/*.sh` 26개(또는 27개) 셸 래퍼 모두 보존. 어느 것도 수정하지 않는다. master §8 BC-V3R2-001 의 핵심 약속.
+- **Handlers-rewritten**: moai binary 의 hook subcommand 가 typed `HookResponse` JSON 을 stdout 에 emit. wrapper 는 stdin/stdout 을 transparent forwarding 하므로 수정 불요.
+- **Dual-parse window**: v3.0 → v3.x 전체 minor cycle 동안 legacy exit-code 출력 수용. `MOAI_HOOK_LEGACY=1` opt-out (CI/air-gapped) + `hook.strict_mode: true` opt-in (early failure).
+- **Sunset**: v4.0 에서 `synthesizeFromExitCode()`, `MOAI_HOOK_LEGACY` 분기, deprecation banner 제거 예정.
+
+사용자 영향 매트릭스 (research.md §8 참고):
+
+| 카테고리 | v3.0 동작 | 영향 |
+|---------|----------|------|
+| 일반 사용자 (moai binary 만) | JSON 자동 마이그레이션. 동일 기능. | None |
+| Plugin author (외부 hook) | exit-code-only 가 deprecation window 동안 작동. session-당 1회 banner. | Cosmetic (banner). Suppressible via env. |
+| CI / air-gapped | banner 노출 가능. `MOAI_HOOK_LEGACY=1` 으로 suppress. | Suppressible. |
+| strict-mode 채택 팀 | `hook.strict_mode: true` 시 exit-code-only hook 즉시 reject. | Opt-in. Default off. |
+
+## Risks (Top 3)
+
+1. **validator/v10 SPEC-V3R2-SCH-001 미머지** (M, M) — Mitigation: M2 에서 직접 의존성 추가. SCH-001 후속 머지 시 dedup 자동.
+2. **Discriminated-union mismatch 에러 메시지 가독성 부족** (M, M) — Mitigation: REQ-040 + AC-05 의 `HookSpecificOutputMismatch{Expected, Actual}` struct + `.moai/logs/hook.log` append.
+3. **PreToolUse UpdatedInput 과 PermissionDecision ordering 모호성** (L, M) — Mitigation: REQ-041 + AC-10 의 deterministic order (UpdatedInput first, then PermissionDecision against updated input).
+
+Full 11-risk table in `plan.md` §5.
+
+## Dependencies
+
+### Blocked by
+
+- SPEC-V3R2-SCH-001 (validator/v10 — at-risk, M2 에서 직접 추가 mitigation)
+- SPEC-V3R2-CON-001 (FROZEN zone — Wave 6 history 기준 완료)
+- SPEC-V3R2-RT-005 (Source provenance — 본 SPEC 는 string literal `"plugin"` 으로 충족; 비-blocking)
+
+### Blocks
+
+- SPEC-V3R2-RT-002 (permission stack PermissionDecision consumer)
+- SPEC-V3R2-RT-003 (sandbox UpdatedInput consumer)
+- SPEC-V3R2-RT-006 (27 handler 비즈니스 로직 완성)
+- SPEC-V3R2-SPC-002 (@MX 자율 add/update/remove)
+- SPEC-V3R2-HRN-002 (evaluator fresh-memory injection)
+
+### Related (non-blocking)
+
+- SPEC-V3R2-MIG-001 (v2→v3 migrator)
+- SPEC-V3R2-CON-003 (constitution consolidation)
+
+## Plan-Audit-Ready Checklist
+
+All 15 criteria PASS per `plan.md` §8:
+
+- [x] Frontmatter v0.1.0 schema (id/title/version/status/created/updated/author/priority/phase/module/dependencies/bc_id/related_*/breaking/lifecycle/tags)
+- [x] HISTORY entry for v0.1.0
+- [x] 25 EARS REQs across 6 categories
+- [x] 15 ACs all map to REQs (100% coverage)
+- [x] BC scope clarity (`breaking: true`, `bc_id: [BC-V3R2-001]`)
+- [x] File:line anchors ≥10 (research.md: 35, plan.md: 30)
+- [x] Exclusions section present (8 entries explicitly mapped to other SPECs)
+- [x] TDD methodology declared
+- [x] mx_plan section (7 MX tag insertions across 4 categories: 3 ANCHOR + 2 NOTE + 2 WARN + 0 TODO)
+- [x] Risk table with mitigations (spec.md: 6 risks, plan.md: 11 risks)
+- [x] Worktree mode path discipline
+- [x] No implementation code in plan documents
+- [x] Acceptance.md G/W/T format with edge cases (15 ACs × 1-3 edge cases each)
+- [x] tasks.md owner roles aligned with TDD methodology
+- [x] Cross-SPEC consistency (3 blocked-by + 5 blocks + 5 related verified)
+
+## Worktree Discipline
+
+[HARD] All run-phase work executes in `/Users/goos/.moai/worktrees/moai-adk/SPEC-V3R2-RT-001` on branch `plan/SPEC-V3R2-RT-001` (initial) or sibling `feat/SPEC-V3R2-RT-001-dual-protocol` (run phase).
+
+[HARD] All filesystem operations use `filepath.Join` / `filepath.Abs`; tests use `t.TempDir()` per `CLAUDE.local.md` §6.
+
+[HARD] Code comments in Korean; commit messages in Korean (per `.moai/config/sections/language.yaml`). Godoc / 외부 노출 식별자 docstring 은 영어 유지.
+
+[HARD] No `.claude/hooks/moai/*.sh` 파일 수정 — wrappers-unchanged. master §8 BC-V3R2-001 의 핵심 약속.
+
+## Test Plan
+
+- [ ] M1 RED gate: 18개 새 테스트 실패 + 기존 테스트 GREEN 회귀 0
+- [ ] M2 GREEN part 1: AC-12 GREEN (validator/v10 통합)
+- [ ] M3 GREEN part 2: AC-04, AC-06, AC-15 GREEN (strict_mode/banner/env)
+- [ ] M4 GREEN part 3: AC-02, AC-05, AC-08, AC-09, AC-10 GREEN (registry 강화)
+- [ ] M5 GREEN part 4: AC-01, AC-03, AC-07, AC-11, AC-13, AC-14 GREEN (api_version/WatchPaths/@MX/plugin)
+- [ ] Full `go test ./...` passes with zero failures and zero cascading regressions
+- [ ] `make build` regenerates `internal/template/embedded.go` cleanly (system.yaml template diff only)
+- [ ] `go vet ./...` and `golangci-lint run` pass with zero warnings
+- [ ] All required CI checks green: Lint, Test (ubuntu/macos/windows), Build (5 platforms), CodeQL
+
+## Next Action
+
+After plan-auditor PASS on this PR:
+- Merge plan PR to `main`
+- Switch to run phase: `/moai run SPEC-V3R2-RT-001` (paste-ready resume in `progress.md`)
+
+🗿 MoAI <email@mo.ai.kr>

--- a/.moai/specs/SPEC-V3R2-RT-001/plan.md
+++ b/.moai/specs/SPEC-V3R2-RT-001/plan.md
@@ -1,0 +1,489 @@
+# SPEC-V3R2-RT-001 Implementation Plan
+
+> Implementation plan for **Hook JSON-OR-ExitCode Dual Protocol**.
+> Companion to `spec.md` v0.1.0, `research.md` v0.1.0, `acceptance.md` v0.1.0, `tasks.md` v0.1.0.
+> Authored against branch `plan/SPEC-V3R2-RT-001` at worktree `/Users/goos/.moai/worktrees/moai-adk/SPEC-V3R2-RT-001`. See §7 for cwd resolution rule.
+
+## HISTORY
+
+| Version | Date       | Author                        | Description                                                              |
+|---------|------------|-------------------------------|--------------------------------------------------------------------------|
+| 0.1.0   | 2026-05-10 | manager-spec (Plan workflow)  | Initial implementation plan per `.claude/skills/moai/workflows/plan.md` Phase 1B. Hooks 부분 구현(`dual_parse.go`, `response.go`)이 이미 존재하므로 본 plan은 27개 EARS REQ + 15개 AC를 100% 만족시키도록 갭을 메우는 작업으로 구성된다. |
+
+---
+
+## 1. Plan Overview
+
+### 1.1 Goal restatement
+
+Claude Code 2026.x 가 정의한 `HookJSONOutput` (JSON-OR-ExitCode) 프로토콜을 moai 의 27개 Claude Code 후크 이벤트 전체에 도입한다. `internal/hook/*.go` 의 핸들러는 stdout 으로 typed `HookResponse` JSON 페이로드를 emit 하며, stdout 이 비어있거나 JSON 파싱이 실패하면 런타임이 legacy exit-code 의미론으로 fallback 한다.
+
+본 plan 은 다음을 달성한다:
+
+- `internal/hook/response.go`(이미 존재, 288 줄)의 `HookResponse` 구조체를 master §4.3 Layer 3 type block 에 정렬되도록 강화 (`Continue *bool`, `WatchPaths []string`, `Retry *RetryHint` 모두 이미 정의됨; `validator/v10` 태그 + `Validate()` 메서드 추가).
+- `internal/hook/dual_parse.go`(이미 존재, 190 줄)의 `ParseHookOutput` dual-parse 의미론을 27개 이벤트 전부에 통일적으로 적용하고 strict_mode + MOAI_HOOK_LEGACY 환경 분기를 도입.
+- 27개 이벤트 variant types (PreToolUseOutput, PostToolUseOutput, ... StopFailureOutput) 의 `HookEventName() string` 메서드는 이미 `response.go:85-287` 에 정의됨; 본 plan 은 누락된 mismatch detection (`HookSpecificOutputMismatch`) wiring 을 `registry.go:65-200` Dispatch 경로에 추가.
+- `internal/config/types.go` 에 `HookConfig{StrictMode bool}` 필드 추가 + `.moai/config/sections/system.yaml` `hook.strict_mode: true|false` 키 로딩.
+- `MOAI_HOOK_LEGACY=1` 환경변수 분기 + 세션 단위 deprecation banner 1회 emit 로직.
+- Wrappers-unchanged 정책: `.claude/hooks/moai/*.sh` 26개(현재 27개 중 1개는 spec-status 단축형) 셸 래퍼는 stdin/stdout 을 그대로 forward 하며 본 SPEC 에서는 절대 수정하지 않는다 (per spec.md §2 Out-of-scope, master §8 BC-V3R2-001).
+- BC-V3R2-001 마이그레이션 윈도(v3.0.0 → v3.x)에 걸쳐 dual-parse fallback 은 항상 작동; v4.0 에서 exit-code-only 경로 제거 예정.
+
+본 plan 은 **breaking change** (`spec.md` frontmatter `breaking: true`) 이지만 wrappers-unchanged + handlers-rewritten 호환성 shim 을 통해 사용자-체감 회귀 0 을 목표로 한다 (§8 참고).
+
+### 1.2 Implementation Methodology
+
+`.moai/config/sections/quality.yaml`: `development_mode: tdd`. Run phase MUST follow RED → GREEN → REFACTOR per `.claude/rules/moai/workflow/spec-workflow.md` Phase Run.
+
+- **RED**: 18개 새로운 실패 테스트를 작성 — 27개 variant 의 `HookEventName()` round-trip, validator/v10 거절 사례, strict_mode 거절, MOAI_HOOK_LEGACY suppress, deprecation banner once-per-session, HookSpecificOutputMismatch detection, 64 KiB AdditionalContext 절단, UpdatedInput-then-PermissionDecision 순서, api_version 2 opt-in, plugin-source bypass. 기존 `internal/hook/dual_parse_test.go`, `response_test.go`, `wire_format_freeze_test.go` 의 happy-path 는 보존 (regression baseline).
+- **GREEN**: `response.go` 에 validator 태그 + `Validate()` 메서드 추가. `dual_parse.go` 에 strict_mode/legacy-env 분기 + banner once-per-session 로직 추가. `registry.go` Dispatch 에 HookSpecificOutput.HookEventName mismatch detection 삽입. `types.go` 에 HookConfig 필드 추가. 새 파일 `internal/hook/strict_mode.go`, `internal/hook/banner.go`, `internal/hook/api_version.go` 생성.
+- **REFACTOR**: 5개 hook 핸들러 (`session_start.go`, `session_end.go`, `pre_tool.go`, `post_tool.go`, `user_prompt_submit.go`) 의 inline JSON 응답 생성 코드를 typed `HookResponse` builder 로 통일. `ToHookOutput()`/`ToHookResponse()` (이미 `dual_parse.go:117-189` 존재) 의 호환성 shim 을 모든 핸들러에서 사용하도록 정리.
+
+### 1.3 Deliverables
+
+| Deliverable | Path | REQ Coverage |
+|-------------|------|--------------|
+| `validator/v10` 의존성 추가 | `go.mod` (직접 의존성 추가; SCH-001 미머지 시 본 SPEC 가 책임) | REQ-006 |
+| `HookResponse` validator 태그 + `Validate()` | `internal/hook/response.go` (extend) | REQ-001, REQ-002, REQ-006 |
+| 27 variant type `HookEventName()` 검증 | `internal/hook/response.go` (이미 line 85-287; 미처리 누락 검증) | REQ-003, REQ-004 |
+| Dual-parse strict_mode 분기 | `internal/hook/dual_parse.go` (extend) + `internal/hook/strict_mode.go` (new) | REQ-005, REQ-021 |
+| MOAI_HOOK_LEGACY env 분기 | `internal/hook/strict_mode.go` (new) | REQ-020 |
+| Deprecation banner once-per-session | `internal/hook/banner.go` (new) | REQ-007, REQ-050 |
+| HookSpecificOutputMismatch detection | `internal/hook/registry.go` (extend Dispatch) | REQ-040 |
+| 64 KiB AdditionalContext 절단 + truncation systemMessage | `internal/hook/dual_parse.go` `ValidateHookResponse` (이미 90-115; 메시지 표준화) | REQ-022 |
+| AdditionalContext 라우팅 (SessionStart/UserPromptSubmit/PreToolUse/PostToolUse) | `internal/hook/registry.go` Dispatch 후 effects 큐 | REQ-012, REQ-016 |
+| UpdatedInput then PermissionDecision 순서 | `internal/hook/registry.go` (PreToolUse 경로 정리) | REQ-041 |
+| WatchPaths 등록 hook (SessionStart) | `internal/hook/session_start.go` (extend) + `internal/watcher/` (out-of-scope, integration point만 본 SPEC) | REQ-032 |
+| api_version 2 opt-in (`# moai-hook-api-version: 2`) | `internal/hook/api_version.go` (new) + `internal/hook/dual_parse.go` (참조) | REQ-030 |
+| Plugin-source bypass (Source = "plugin" → strict-mode 우회) | `internal/hook/strict_mode.go` (new; SPEC-V3R2-RT-005 Source enum 사용) | REQ-051 |
+| `HookConfig{StrictMode}` 필드 | `internal/config/types.go` (extend) + `internal/config/loader.go` 확장 | REQ-021 |
+| `system.yaml` `hook.strict_mode` 키 로딩 | `internal/config/loader.go` (extend) + `.moai/config/sections/system.yaml` (template extend) | REQ-021 |
+| AdditionalContext + @MX 마커 라우팅 hook (PostToolUse) | `internal/hook/post_tool.go` (extend) — 본 SPEC 은 라우팅 포인트만 노출; 의미론은 SPEC-V3R2-SPC-002 | REQ-016 |
+| `ErrHookProtocolLegacyRejected` (이미 `dual_parse.go:11-13`), 에러 wiring | `internal/hook/dual_parse.go` (extend) | REQ-021 |
+| `.moai/logs/hook.log` mismatch logging | `internal/hook/registry.go` (extend) | REQ-040, REQ-042 |
+| CHANGELOG entry | `CHANGELOG.md` Unreleased section | Trackable (TRUST 5) |
+| MX tags per §6 | 6 files (per §6 below) | mx_plan |
+
+`.claude/hooks/moai/*.sh` 26개 셸 래퍼는 본 SPEC 에서 **수정하지 않는다** — wrappers-unchanged 원칙. `make build` 로 `internal/template/embedded.go` 재생성은 필요할 수 있다 (template 변경 사항이 `.moai/config/sections/system.yaml` 에 추가되는 경우).
+
+### 1.4 Traceability Matrix (REQ → AC → Task)
+
+Per plan-auditor PASS criterion #2 (every REQ maps to at least one AC and at least one Task):
+
+| REQ ID | Category | Mapped AC(s) | Mapped Task(s) |
+|--------|----------|--------------|----------------|
+| REQ-V3R2-RT-001-001 | Ubiquitous | AC-02 | T-RT001-04, T-RT001-12 |
+| REQ-V3R2-RT-001-002 | Ubiquitous | AC-12 | T-RT001-04, T-RT001-13 |
+| REQ-V3R2-RT-001-003 | Ubiquitous | AC-13 | T-RT001-05 (existing 27 variants) |
+| REQ-V3R2-RT-001-004 | Ubiquitous | AC-13 | T-RT001-05 |
+| REQ-V3R2-RT-001-005 | Ubiquitous | AC-01 | T-RT001-06, T-RT001-15 |
+| REQ-V3R2-RT-001-006 | Ubiquitous | AC-12 | T-RT001-04, T-RT001-13 |
+| REQ-V3R2-RT-001-007 | Ubiquitous | AC-04, AC-15 | T-RT001-08, T-RT001-17 |
+| REQ-V3R2-RT-001-010 | Event-Driven | AC-01 | T-RT001-15 |
+| REQ-V3R2-RT-001-011 | Event-Driven | AC-03 | T-RT001-15 |
+| REQ-V3R2-RT-001-012 | Event-Driven | AC-02 | T-RT001-19 |
+| REQ-V3R2-RT-001-013 | Event-Driven | AC-01 | T-RT001-19, T-RT001-20 |
+| REQ-V3R2-RT-001-014 | Event-Driven | AC-08 | T-RT001-19 |
+| REQ-V3R2-RT-001-015 | Event-Driven | (orchestrator-side) | T-RT001-19 |
+| REQ-V3R2-RT-001-016 | Event-Driven | AC-07 | T-RT001-21 |
+| REQ-V3R2-RT-001-020 | State-Driven | AC-04 | T-RT001-08 |
+| REQ-V3R2-RT-001-021 | State-Driven | AC-06 | T-RT001-09, T-RT001-16 |
+| REQ-V3R2-RT-001-022 | State-Driven | AC-09 | T-RT001-07, T-RT001-18 |
+| REQ-V3R2-RT-001-030 | Optional | AC-11 | T-RT001-22 |
+| REQ-V3R2-RT-001-031 | Optional | (orchestrator MAY) | T-RT001-23 |
+| REQ-V3R2-RT-001-032 | Optional | AC-02 | T-RT001-24 |
+| REQ-V3R2-RT-001-040 | Unwanted | AC-05 | T-RT001-10, T-RT001-20 |
+| REQ-V3R2-RT-001-041 | Unwanted | AC-10 | T-RT001-20 |
+| REQ-V3R2-RT-001-042 | Unwanted | (warn log) | T-RT001-20 |
+| REQ-V3R2-RT-001-050 | Complex | AC-15 | T-RT001-08, T-RT001-17 |
+| REQ-V3R2-RT-001-051 | Complex | AC-14 | T-RT001-25 |
+
+Coverage: **25 REQs** (REQ-001..051 with the 5.x.0 numbering) → **15 ACs** → **25 tasks T-RT001-01..25** (some tasks cover multiple REQs and ACs).
+
+---
+
+## 2. Milestone Breakdown (M1-M5)
+
+각 milestone 은 **priority-ordered** (no time estimates per `.claude/rules/moai/core/agent-common-protocol.md` §Time Estimation HARD rule).
+
+### M1: Test scaffolding (RED phase) — Priority P0
+
+기존 테스트 baseline: `internal/hook/dual_parse_test.go` (304줄), `internal/hook/response_test.go` (240줄), `internal/hook/wire_format_freeze_test.go` (245줄), `internal/hook/types_test.go` (244줄), `internal/hook/protocol_test.go` (467줄), `internal/hook/registry_test.go` (388줄). 본 milestone 은 18개 새로운 실패 테스트만 추가.
+
+Owner role: `expert-backend` (Go test) or direct `manager-tdd` execution.
+
+Scope:
+1. `internal/hook/dual_parse_test.go` 확장:
+   - `TestParseHookOutput_StrictModeRejectsLegacy` (AC-06, REQ-021).
+   - `TestParseHookOutput_MoaiHookLegacySuppressesBanner` (AC-04, REQ-020, REQ-007).
+   - `TestParseHookOutput_DeprecationBannerOnce` (AC-15, REQ-007, REQ-050).
+   - `TestParseHookOutput_AdditionalContextTruncatedAt64KiB` (AC-09, REQ-022).
+   - `TestParseHookOutput_PluginSourceBypassesStrict` (AC-14, REQ-051).
+   - `TestParseHookOutput_ApiVersion2SkipsExitCodeFallback` (AC-11, REQ-030).
+2. `internal/hook/response_test.go` 확장:
+   - `TestHookResponse_ValidatorRejectsBadPermissionDecision` (AC-12, REQ-006).
+   - `TestHookResponse_ValidatorAcceptsAllowAskDeny` (AC-12, REQ-002).
+   - `TestHookResponse_27VariantHookEventNameRoundTrip` (AC-13, REQ-003, REQ-004) — 27개 variant 의 marshal→unmarshal identity.
+3. `internal/hook/registry_test.go` 확장:
+   - `TestDispatch_HookSpecificOutputMismatch` (AC-05, REQ-040).
+   - `TestDispatch_PreToolUseUpdatedInputThenPermissionDecision` (AC-10, REQ-041).
+   - `TestDispatch_AdditionalContextRoutedToModelContext` (AC-02, REQ-012).
+   - `TestDispatch_ContinueFalseBlocksTeammateIdle` (AC-08, REQ-014).
+4. 신규 테스트 파일 `internal/hook/strict_mode_test.go` 생성:
+   - `TestStrictMode_ConfigLoad` — `.moai/config/sections/system.yaml` `hook.strict_mode: true` 로딩 검증.
+   - `TestStrictMode_ErrorReturnedOnLegacyOutput` (AC-06, REQ-021).
+5. 신규 테스트 파일 `internal/hook/banner_test.go` 생성:
+   - `TestBanner_OncePerSession` (REQ-007, REQ-050).
+   - `TestBanner_SuppressedByMoaiHookLegacy` (REQ-020).
+6. 신규 테스트 파일 `internal/hook/api_version_test.go` 생성:
+   - `TestApiVersion2_SkipsExitCodeFallback` (REQ-030, AC-11).
+   - `TestApiVersion2_ParsesShellHeader` — `# moai-hook-api-version: 2` line 추출.
+7. `go test ./internal/hook/` 실행 — 본 milestone 에서 추가한 18개 테스트가 모두 RED 임을 확인. 기존 테스트 100% GREEN 유지 (regression baseline).
+
+Verification gate before advancing to M2: 18개 새 테스트가 sentinel 메시지와 함께 실패. 기존 테스트 회귀 0.
+
+[HARD] No implementation code in M1 outside of test files. (validator/v10 import 추가도 M2 의 일이다 — M1 테스트는 build error 가 발생할 수 있으며, 그것이 정확히 RED 의 정의다.)
+
+### M2: Validator/v10 + HookResponse Validate() (GREEN, part 1) — Priority P0
+
+Owner role: `expert-backend`.
+
+Scope:
+1. `go.mod` 에 `github.com/go-playground/validator/v10` 직접 의존성 추가 (`go get github.com/go-playground/validator/v10`). SPEC-V3R2-SCH-001 이 머지 전이므로 본 SPEC 가 직접 책임. SCH-001 이 후속 머지 시 충돌 없음 (동일 의존성).
+2. `internal/hook/response.go` 의 `HookResponse` 구조체 (line 11-44) 에 validator/v10 태그 추가:
+   - `PermissionDecision` → `validate:"omitempty,oneof=allow ask deny defer"`.
+   - `Retry.Attempts` → `validate:"omitempty,gte=0,lte=10"`.
+   - `Retry.Backoff` → `validate:"omitempty,oneofci=linear exponential constant"`.
+3. `internal/hook/response.go` 에 패키지 단위 `var validate = validator.New()` 추가 + `func (r *HookResponse) Validate() error { return validate.Struct(r) }` 메서드 추가.
+4. `internal/hook/dual_parse.go` 의 `ValidateHookResponse` (line 90-115) 를 강화: 기존 logic 보존 + 새로 추가된 `Validate()` 호출 wrapping. validator 에러는 offending field 명을 포함하여 wrap 한다 (AC-12).
+5. 27개 variant 타입 (`response.go:76-287`) 에는 validator 태그가 필요 없다 (PreToolUseOutput 등은 외부 hook 가 emit 하는 nested struct 이며 본 layer 에서는 round-trip 만 검증 — `wire_format_freeze_test.go` 와 정합).
+
+Verification: `TestHookResponse_ValidatorRejectsBadPermissionDecision` (AC-12) GREEN 전환. 기존 테스트 100% GREEN 유지.
+
+### M3: Strict mode + MOAI_HOOK_LEGACY env + Deprecation Banner (GREEN, part 2) — Priority P0
+
+Owner role: `expert-backend`.
+
+Scope:
+1. 신규 파일 `internal/hook/strict_mode.go`:
+   - `IsStrictModeEnabled(cfg ConfigProvider) bool` — `.moai/config/sections/system.yaml` `hook.strict_mode` 값 조회.
+   - `IsLegacyEnvSet() bool` — `MOAI_HOOK_LEGACY=1` 환경변수 검사.
+   - `EnforceStrictMode(stdout []byte, exitCode int) error` — strict_mode 활성화 시 stdout JSON 파싱 실패면 `ErrHookProtocolLegacyRejected` (이미 `dual_parse.go:11-13`) 반환.
+   - `IsPluginSource(input *HookInput) bool` — `HookInput.ConfigurationSource == "plugin"` 검사 (REQ-051; SPEC-V3R2-RT-005 Source provenance 와 정합).
+2. 신규 파일 `internal/hook/banner.go`:
+   - `package var emittedBanners sync.Map` — session_id key, bool value.
+   - `func MaybeEmitDeprecationBanner(sessionID string) (banner string, emitted bool)` — 세션당 1회만 emit, MOAI_HOOK_LEGACY=1 시 suppress.
+   - banner 텍스트: `"DEPRECATED: Hook produced exit-code-only output. Migrate to JSON output before v4.0. See https://moai.ai.kr/docs/hook-migration."` (영문 — sysmsg 는 international 사용자 노출).
+3. `internal/hook/dual_parse.go` 의 `ParseHookOutput` (line 47-62) 를 확장:
+   - JSON parse 실패 + strict_mode 활성화 + plugin-source 가 아닌 경우 → `ErrHookProtocolLegacyRejected` 반환.
+   - JSON parse 실패 + 정상 fallback 경로 진입 시 banner emit 1회 (sessionID 기반).
+   - `MOAI_HOOK_LEGACY=1` 시 banner suppress.
+4. `internal/config/types.go` 에 `HookConfig` struct 추가 (`StrictMode bool` 필드, `mapstructure:"strict_mode"` 태그). `Config` 구조체에 `Hook HookConfig` 필드 추가.
+5. `internal/config/loader.go` (또는 동등한 sections 로더) 가 `system.yaml` 의 `hook.strict_mode` 키를 `Config.Hook.StrictMode` 에 매핑하도록 확장. 기본값 `false`.
+6. `.moai/config/sections/system.yaml` (현재 27 줄) 끝에 `hook.strict_mode: false` (default off) 키 추가. 템플릿도 동일 추가 (`internal/template/templates/.moai/config/sections/system.yaml`).
+
+Verification: `TestStrictMode_*`, `TestBanner_*` 4개 테스트 GREEN 전환. AC-04, AC-06, AC-15 충족.
+
+### M4: HookSpecificOutputMismatch + UpdatedInput-then-Decision + AdditionalContext routing + Continue:false escalation (GREEN, part 3) — Priority P0
+
+Owner role: `expert-backend`.
+
+Scope:
+1. `internal/hook/registry.go` Dispatch (line 65-200) 에 mismatch detection 삽입:
+   - PreToolUse / PostToolUse / UserPromptSubmit / PermissionRequest 핸들러 응답 후 `HookSpecificOutput.HookEventName != event` 검사.
+   - 불일치 시 `HookSpecificOutputMismatch{Expected: event, Actual: hookEventName}` 에러 반환 + `.moai/logs/hook.log` append.
+   - hook 자체는 failed 처리 (output 무시, default deny + reason="hookSpecificOutput mismatch"). REQ-040.
+2. `internal/hook/registry.go` PreToolUse 경로 정리:
+   - hook 가 `UpdatedInput` + `PermissionDecision: deny` 둘 다 emit 한 경우, `UpdatedInput` 을 먼저 적용한 후 `PermissionDecision` 평가 (REQ-041, AC-10).
+   - 이미 `registry.go:179-193` 에 부분 핸들링이 있으나 ordering 명시 안 됨; 명시적 주석 + 단위 테스트 보강.
+3. `internal/hook/registry.go` 에서 `AdditionalContext` 라우팅 강화:
+   - SessionStart, UserPromptSubmit, PreToolUse, PostToolUse 응답의 `AdditionalContext` 를 model turn 의 system-context block 에 firing order 로 append.
+   - 구현은 dispatch 결과 출력 시 `HookSpecificOutput.AdditionalContext` 필드를 보존 (이미 `registry.go:155-162` 에 일부 존재) + 외부 컨텍스트 큐(`internal/runtime/context.go`)와의 인터페이스만 노출 — 본 SPEC 은 노출까지, 큐 소비는 SPEC-V3R2-SPC-002.
+4. `internal/hook/registry.go` Stop / SubagentStop 경로:
+   - hook 가 `Continue: false` 반환 시 teammate idle 차단 + orchestrator 에 blocker 신호 전달 (REQ-014).
+   - 이미 `subagent_stop.go` + `teammate_idle.go` 에 일부 처리 — 본 plan 은 mapping 명시 + 단위 테스트.
+5. `internal/hook/dual_parse.go` `ValidateHookResponse` 의 64 KiB 절단 로직 (line 105-113) 표준화:
+   - `SystemMessage` 에 prepend 하지 않고 별도 `\n[Notice: ...]` suffix 로 변경 (현재 동작 유지하되 메시지 텍스트를 `AdditionalContext truncated to 64 KiB budget` 로 정규화 — REQ-022, AC-09).
+
+Verification: `TestDispatch_HookSpecificOutputMismatch`, `TestDispatch_PreToolUseUpdatedInputThenPermissionDecision`, `TestDispatch_AdditionalContextRoutedToModelContext`, `TestDispatch_ContinueFalseBlocksTeammateIdle` 4개 GREEN 전환. AC-02, AC-05, AC-08, AC-09, AC-10 충족.
+
+### M5: api_version 2 opt-in + WatchPaths + @MX routing + CHANGELOG + MX tags (GREEN, part 4 + Trackable) — Priority P1
+
+Owner role: `expert-backend` (구현), `manager-docs` (CHANGELOG, MX tags).
+
+Scope:
+
+#### M5a: api_version 2 opt-in (REQ-030, AC-11)
+
+1. 신규 파일 `internal/hook/api_version.go`:
+   - `func ReadHookApiVersion(wrapperPath string) (int, error)` — 셸 래퍼 첫 30 줄 내에서 `# moai-hook-api-version: 2` 패턴 추출 (정규식 `^#\s*moai-hook-api-version:\s*(\d+)\s*$`).
+   - `func ShouldSkipExitCodeFallback(wrapperPath string) bool` — api_version >= 2 시 true.
+2. `internal/hook/dual_parse.go` `ParseHookOutput` 를 확장하여 wrapperPath 인자 (또는 `HookInput` 의 새 필드 `WrapperPath`) 를 받아, `ShouldSkipExitCodeFallback` 가 true 이면 stdout 이 비었어도 exit-code synthesis 를 수행하지 않고 explicit no-op `HookResponse{}` 를 반환.
+3. shell wrapper 자체는 수정하지 않는다 (wrappers-unchanged 정책). api_version 2 는 future-proofing — 현재 26개 wrapper 모두 api_version 1 로 간주된다.
+
+#### M5b: WatchPaths SessionStart wiring (REQ-032, AC-02 partial)
+
+1. `internal/hook/session_start.go` 가 `HookResponse.WatchPaths` 를 emit 하면, `internal/watcher/` (out-of-scope; integration point만 제공) 가 file-system watch 를 등록하고 변경 시 `EventFileChanged` 발화. 본 SPEC 은 인터페이스 (`WatchPathsRegistrar`) 만 정의:
+   - 신규 파일 `internal/hook/watch_paths.go` 에서 `type WatchPathsRegistrar interface { Register(paths []string) error }` 선언.
+   - `registry.go` Dispatch 의 SessionStart 후처리에서 `WatchPaths` 를 `WatchPathsRegistrar` 에 forward.
+2. 실제 `WatchPathsRegistrar` 의 구현 (file-system watcher with debouncing) 은 별도 SPEC (RT-006 또는 새 RT-008) 에서 다룬다 — 본 SPEC 은 contract만 노출.
+
+#### M5c: @MX 마커 라우팅 hook (REQ-016)
+
+1. `internal/hook/post_tool.go` 의 PostToolUse 핸들러에서 `HookResponse.AdditionalContext` 를 검사하여 `@MX:NOTE`, `@MX:WARN`, `@MX:ANCHOR`, `@MX:TODO`, `@MX:LEGACY` 마커가 포함된 경우 `internal/hook/mx/ingest.go` (이미 존재 — `mx/` 디렉토리에 12 파일) 의 ingestion 함수에 forward.
+2. 본 SPEC 은 라우팅 포인트(integration hook)만 노출; 마커 의미론은 SPEC-V3R2-SPC-002.
+
+#### M5d: ConfigurationSource = "plugin" bypass (REQ-051, AC-14)
+
+1. `internal/hook/strict_mode.go` 의 `EnforceStrictMode` 에서 input.ConfigurationSource 가 `"plugin"` 인 경우 strict_mode 가 true 라도 dual-parse fallback 적용 (no error). REQ-051 BC 윈도 제공.
+2. 로그에 `source: plugin` provenance 기록 (SPEC-V3R2-RT-005 와 정합).
+
+#### M5e: CHANGELOG + MX tags + 최종 검증
+
+1. `CHANGELOG.md` 의 `## [Unreleased] / ### Changed (BREAKING)` 섹션에 entry 추가:
+   ```
+   ### Changed (BREAKING — BC-V3R2-001)
+   - SPEC-V3R2-RT-001: Hook output protocol now follows Claude Code 2026.x JSON-OR-ExitCode dual contract. JSON output is parsed first; exit-code semantics remain as v3.x deprecation-window fallback. New `hook.strict_mode` config (default `false`) opts into JSON-only enforcement. New `MOAI_HOOK_LEGACY=1` opt-out for CI/air-gapped installs. Deprecation banner emits once per session per project. Wrappers unchanged; handlers rewritten. Removal of exit-code-only path deferred to v4.0.
+   ```
+2. §6 의 7개 MX tag 삽입.
+3. `make build` 를 worktree root 에서 실행하여 `internal/template/embedded.go` 재생성. system.yaml template 1줄 추가만 expected.
+4. `go test ./internal/hook/...` + 전체 `go test ./...` 실행 — 모든 테스트 PASS, 회귀 0.
+5. `go vet ./...` + `golangci-lint run` 실행 — 경고 0.
+6. `progress.md` 업데이트: `run_complete_at` + `run_status: implementation-complete`.
+
+[HARD] No new SPEC documents are created in `.moai/specs/` or `.moai/reports/` during M5 — this is a SPEC implementation phase, not a planning phase.
+
+---
+
+## 3. File:line Anchors (concrete edit targets)
+
+### 3.1 To-be-modified (existing files)
+
+| File | Anchor | Edit type | Reason |
+|------|--------|-----------|--------|
+| `internal/hook/response.go:11-44` | `HookResponse` struct | validator/v10 태그 추가 + `Validate()` 메서드 | M2 / REQ-006 |
+| `internal/hook/response.go:64-70` | `RetryHint` struct | validator 태그 추가 (Attempts gte/lte, Backoff oneofci) | M2 / REQ-031 |
+| `internal/hook/dual_parse.go:11-19` | error sentinel block | `ErrHookProtocolLegacyRejected` 보존, mismatch 에러는 그대로 사용 | M3 / REQ-021 |
+| `internal/hook/dual_parse.go:47-62` | `ParseHookOutput()` | strict_mode 분기 + plugin-source bypass + banner emission | M3 / REQ-005, REQ-021, REQ-007, REQ-050, REQ-051 |
+| `internal/hook/dual_parse.go:90-115` | `ValidateHookResponse()` | 64 KiB truncation 메시지 표준화 + validator 통합 | M2/M4 / REQ-022, REQ-006 |
+| `internal/hook/dual_parse.go:117-189` | `ToHookOutput`/`ToHookResponse` | 호환성 shim 보존; PostToolUse output mapping 보강 | M4 / REQ-016 |
+| `internal/hook/registry.go:65-200` | `Dispatch()` | HookSpecificOutputMismatch detection + AdditionalContext routing + Continue:false escalation | M4 / REQ-040, REQ-012, REQ-014 |
+| `internal/hook/registry.go:155-162` | `AdditionalContext` merge logic | order preservation, append semantics | M4 / REQ-012 |
+| `internal/hook/registry.go:179-193` | PreToolUse PermissionDecision/Reason wiring | UpdatedInput-first ordering 명시 + 주석 | M4 / REQ-041 |
+| `internal/hook/types.go:283-312` | `HookOutput` struct | 보존 (legacy bridge); 변경 없음 — 단지 docstring 에 BC-V3R2-001 reference 추가 | doc-only / BC |
+| `internal/hook/post_tool.go` (existing PostToolUse handler) | `Handle()` 내부 | `AdditionalContext` 의 @MX 마커 라우팅 hook 추가 | M5c / REQ-016 |
+| `internal/hook/session_start.go` (existing SessionStart handler) | `Handle()` 내부 | `WatchPaths` forward to `WatchPathsRegistrar` | M5b / REQ-032 |
+| `internal/config/types.go` (top-level Config struct) | new field | `Hook HookConfig{StrictMode bool}` 필드 추가 | M3 / REQ-021 |
+| `internal/config/loader.go` (sections loader) | section dispatch | `system.yaml` `hook.strict_mode` 키 매핑 | M3 / REQ-021 |
+| `.moai/config/sections/system.yaml` | end of file | `hook.strict_mode: false` 키 추가 | M3 / REQ-021 |
+| `internal/template/templates/.moai/config/sections/system.yaml` | end of file | 동일 키 추가 (template 동기화) | M3 / Template-First |
+| `CHANGELOG.md` | `## [Unreleased] / ### Changed (BREAKING)` | BC-V3R2-001 entry 추가 | M5e / Trackable |
+
+### 3.2 To-be-created (new files)
+
+| File | Reason | LOC estimate |
+|------|--------|--------------|
+| `internal/hook/strict_mode.go` | strict_mode + MOAI_HOOK_LEGACY + plugin-source 검사 함수군 | ~70 |
+| `internal/hook/strict_mode_test.go` | strict_mode 테스트 | ~80 |
+| `internal/hook/banner.go` | deprecation banner once-per-session | ~50 |
+| `internal/hook/banner_test.go` | banner 테스트 | ~70 |
+| `internal/hook/api_version.go` | api_version 2 opt-in 파싱 | ~50 |
+| `internal/hook/api_version_test.go` | api_version 테스트 | ~60 |
+| `internal/hook/watch_paths.go` | `WatchPathsRegistrar` interface + nil-safe wiring | ~30 |
+
+Total new: ~410 LOC. Total modified: ~150 LOC. Net additions: ~560 LOC across 7 new files + 8 modified Go files + 2 modified template files + 1 CHANGELOG.
+
+### 3.3 NOT to be touched (preserved by reference)
+
+본 SPEC 의 run phase 가 절대 수정하지 않을 파일들. 다른 SPEC 의 소유 영역이거나 wrappers-unchanged 원칙에 따라 보존.
+
+- `.claude/hooks/moai/*.sh` — 26개 셸 래퍼 모두. wrappers-unchanged. master §8 BC-V3R2-001 의 핵심 호환성 약속.
+- `internal/hook/types.go` 의 `HookInput`, `HookOutput`, `HookSpecificOutput` 외부 visible API — legacy bridge 로 보존; docstring 외 변경 없음.
+- `.claude/rules/moai/core/agent-common-protocol.md` — load-bearing rule.
+- 27개 hook handler 의 외부 인터페이스 (`Handler.Handle(ctx, input) (*HookOutput, error)`) — variant types 추가로도 Handler 인터페이스는 보존.
+- `.moai/specs/SPEC-V3R2-RT-002/` (permission stack) — 본 SPEC 은 protocol 만, RT-002 가 PermissionDecision 의미론 처리.
+- `.moai/specs/SPEC-V3R2-RT-005/` (settings provenance) — Source = "plugin" 검사는 RT-005 의 enum 을 import 만; 본 SPEC 은 RT-005 머지 전이라도 string literal `"plugin"` 으로 동작.
+- `.moai/specs/SPEC-V3R2-RT-006/` (handler completeness) — 10 logging-only stubs 의 비즈니스 로직은 본 SPEC 범위 밖.
+- `.moai/specs/SPEC-V3R2-SPC-002/` (@MX 의미론) — 본 SPEC 은 라우팅 포인트만 노출.
+
+### 3.4 Reference citations (file:line)
+
+Per `spec.md` §10 traceability and research.md §10, the following anchors are load-bearing and cited verbatim throughout this plan:
+
+1. `spec.md:43-55` (in-scope items 1-9: typed HookResponse, PermissionDecision, HookSpecificOutput discriminator, dual-parse shim, validator 통합, context-injection wiring, input-mutation wiring, continue:false escalation, deprecation banner)
+2. `spec.md:57-66` (out-of-scope items 1-8)
+3. `spec.md:106-145` (24 EARS REQs — REQ-001 through REQ-051)
+4. `spec.md:147-163` (15 ACs — AC-01 through AC-15)
+5. `spec.md:167-173` (constraints — Go 1.22+, validator/v10, p99 5ms, binary +250 KiB, wrappers unchanged)
+6. `internal/hook/types.go:1-14` (package import 영역 — 본 SPEC 은 import 변경 없음)
+7. `internal/hook/types.go:115-147` (`ValidEventTypes()` 27 events 열거 — REQ-003 의 27 variant 와 1:1 대응)
+8. `internal/hook/types.go:155-165` (PermissionDecision constants — REQ-002 와 정합)
+9. `internal/hook/types.go:269-281` (`HookSpecificOutput` struct — discriminator field)
+10. `internal/hook/types.go:283-312` (`HookOutput` struct — legacy bridge, 보존)
+11. `internal/hook/response.go:11-44` (`HookResponse` struct — validator 태그 추가 대상)
+12. `internal/hook/response.go:46-61` (`PermissionDecision` constants — `defer` 포함 4개 — Defer 는 v2.1.89+ headless 전용)
+13. `internal/hook/response.go:64-70` (`RetryHint` struct — Attempts/Backoff)
+14. `internal/hook/response.go:76-287` (27 variant types 의 `HookEventName()` 메서드 — REQ-004)
+15. `internal/hook/dual_parse.go:11-19` (error sentinels: `ErrHookProtocolLegacyRejected`, `ErrHookInvalidPermissionDecision`, `ErrHookSpecificOutputMismatch`)
+16. `internal/hook/dual_parse.go:47-62` (`ParseHookOutput()` dual-parse 진입점)
+17. `internal/hook/dual_parse.go:64-86` (`synthesizeFromExitCode()` legacy fallback)
+18. `internal/hook/dual_parse.go:88-115` (`ValidateHookResponse()` 64 KiB 절단)
+19. `internal/hook/dual_parse.go:117-189` (`ToHookOutput`/`ToHookResponse` 호환성 shim)
+20. `internal/hook/protocol.go:26-47` (`ReadInput()` JSON 정규화 진입점)
+21. `internal/hook/protocol.go:52-63` (`WriteOutput()` JSON serialization)
+22. `internal/hook/registry.go:65-200` (`Dispatch()` 27 events handler 디스패치 — mismatch detection 삽입 위치)
+23. `internal/hook/registry.go:155-162` (`AdditionalContext` merge logic in UserPromptSubmit)
+24. `internal/hook/registry.go:179-193` (PreToolUse `PermissionDecision`/`Reason` wiring)
+25. `.claude/hooks/moai/*.sh` — 26 wrappers (verified via `ls`); wrappers-unchanged
+26. `.moai/config/sections/system.yaml:1-27` — 본 SPEC 이 `hook.strict_mode: false` 키 추가
+27. `.claude/rules/moai/core/agent-common-protocol.md:#user-interaction-boundary` — subagent prohibition rule
+28. `.claude/rules/moai/workflow/spec-workflow.md:#phase-0-5-plan-audit-gate` — plan-auditor entry condition
+29. `CLAUDE.local.md:§6` — test isolation (`t.TempDir()` + `filepath.Abs`)
+30. `CLAUDE.local.md:§14` — no hardcoded paths in `internal/`
+
+Total: **30 distinct file:line anchors** (exceeds the §Hard-Constraints minimum of 10 for plan.md).
+
+---
+
+## 4. Technology Stack Constraints
+
+Per `spec.md` §7 Constraints, **새로운 의존성은 validator/v10 1개만**:
+
+- Go 1.22+ (already required by `go.mod`).
+- `github.com/go-playground/validator/v10` — SPEC-V3R2-SCH-001 미머지 시 본 SPEC 가 직접 추가. 현재 `go.mod` 부재 확인 (위 `grep -n validator go.mod` 결과). M2 의 첫 작업이 `go get github.com/go-playground/validator/v10`.
+- `encoding/json` 표준 라이브러리 — `json.RawMessage` 가 `HookSpecificOutput` discriminator 의 two-pass decode 를 처리.
+- `sync.Map` 표준 라이브러리 — banner once-per-session 의 thread-safe 저장소.
+- 기존 `golang.org/x/sys/{unix,windows}` — 본 SPEC 은 사용하지 않음.
+
+추가 surface:
+
+- 7개 신규 Go 파일 (per §3.2).
+- 8개 수정 Go 파일 (per §3.1).
+- 2개 수정 YAML template (system.yaml + 동일 template).
+- 1개 CHANGELOG entry.
+- 7개 MX tag (per §6).
+
+**No new directory structures** — `internal/hook/` 는 이미 116 파일.
+
+**No new shell wrapper** — wrappers-unchanged 정책.
+
+---
+
+## 5. Risk Analysis & Mitigations
+
+`spec.md` §8 의 6개 risk 를 file-anchored mitigation 으로 확장.
+
+| Risk | Probability | Impact | Mitigation Anchor |
+|------|-------------|--------|-------------------|
+| `validator/v10` SPEC-V3R2-SCH-001 머지 전 — 직접 의존성 추가 시 충돌 가능성 | M | M | M2 첫 단계에서 `go get` 직접 추가. 후속 SCH-001 머지 시 `go.mod` 의 동일 의존성은 자동 통합 (Go module dedup). 충돌 발생 시 SCH-001 PR 의 위치를 우선시한다. |
+| 외부 plugin-hook 작성자가 invalid JSON 을 emit 하고 exit-code fallback 에 무한 의존 | M | M | dual-parse 는 v3.x 전체 minor cycle 동안 유지; `MOAI_HOOK_LEGACY=1` opt-out for CI/air-gapped; `hook.strict_mode: true` opt-in for early rejection. spec §8 risk row 1 + REQ-051 plugin-source bypass. |
+| Discriminated-union mismatch 에러 메시지 가독성 부족 | M | M | REQ-040 + AC-05: `HookSpecificOutputMismatch{Expected, Actual}` struct (이미 `dual_parse.go:23-30`); error 메시지는 `expected X, got Y` 포맷. mismatch 시 `.moai/logs/hook.log` append. `moai doctor hook --validate` 향후 surface. |
+| 64 KiB AdditionalContext 절단이 hook 작성자에게 silent | L | M | REQ-022 + AC-09: 절단 시 `SystemMessage` 에 `[Notice: additionalContext truncated from N to 65536 bytes]` suffix 자동 추가. 사용자 가시. |
+| PreToolUse 의 `UpdatedInput` 과 `PermissionDecision` 의 ordering 모호성 | L | M | REQ-041 + AC-10: deterministic order — UpdatedInput first, then PermissionDecision against the updated input. `registry.go` 주석 + 단위 테스트 명시. |
+| 27 logging-only handler 가 protocol upgrade 후에도 빈 응답 | M | L | SPEC-V3R2-RT-006 explicitly enumerates 27-event business-logic 처리; 본 SPEC 은 wire format 만 owner. logging-only handler 는 빈 `HookResponse{}` (allow + continue) 반환 — 정상 동작. |
+| Shell wrapper JSON forwarding 이 non-UTF-8 바이트에서 깨짐 | L | L | wrappers 는 `cat` 의미론 사용; validator/v10 는 non-UTF-8 string 을 명시적 에러로 reject. 본 SPEC 의 ValidateHookResponse 가 fail-fast. |
+| Banner emission race condition (multi-threaded dispatch) | L | L | `sync.Map` 사용; `LoadOrStore` atomic check. M3 banner_test.go 가 verify. |
+| SPEC-V3R2-RT-002 (permission stack) 의 PermissionDecision consumer 가 본 SPEC 과 동시 개발 | L | L | `PermissionDecision` 은 string enum (`response.go:46-61`); RT-002 는 consumer 일 뿐 본 SPEC 의 type 정의에 의존. 동시 개발 가능. |
+| api_version 2 wrapper 가 현재 0개이므로 코드가 dead path | L | L | future-proofing; v3.1+ 에서 첫 wrapper 적용 시 활성화. M5a 테스트는 mock wrapper 로 검증. |
+| Plugin-source bypass 가 RT-005 미머지 시 ConfigurationSource 필드 부재 | L | M | `HookInput.ConfigurationSource` 는 이미 `types.go:235-237` 에 정의됨 (v2.1.49+). RT-005 의존성은 enum 값 의미론만이며 string literal `"plugin"` 검사로 충족. |
+
+---
+
+## 6. mx_plan — @MX Tag Strategy
+
+Per `.claude/rules/moai/workflow/mx-tag-protocol.md` and `.claude/skills/moai/workflows/plan.md` mx_plan MANDATORY rule.
+
+### 6.1 @MX:ANCHOR targets (high fan_in / contract enforcers)
+
+| Target file:line | Tag content | Rationale |
+|------------------|-------------|-----------|
+| `internal/hook/dual_parse.go:ParseHookOutput()` (line 47) | `@MX:ANCHOR fan_in=N - SPEC-V3R2-RT-001 BC-V3R2-001 dual-parse contract; every hook handler routes through this function. Modifying the JSON-first then exit-code-fallback ordering breaks the v3.x deprecation window. Touching this affects all 27 events.` | dual-parse 는 본 SPEC 의 핵심 진입점. 27개 이벤트 전부의 wire format 이 여기를 통과. |
+| `internal/hook/response.go:HookResponse` (line 11) | `@MX:ANCHOR fan_in=27 - SPEC-V3R2-RT-001 typed response struct; matches Claude Code 2026.x HookJSONOutput byte-for-byte. Field name/JSON tag changes break protocol compatibility with Claude Code runtime.` | HookResponse 는 27개 variant 가 공유하는 top-level type. JSON tag 변경은 wire format break. |
+| `internal/hook/registry.go:Dispatch()` (line 65) | `@MX:ANCHOR fan_in=N - SPEC-V3R2-RT-001 27-event dispatch contract; HookSpecificOutputMismatch detection + AdditionalContext routing + Continue:false escalation 모두 본 함수에서 enforce. Ordering of these checks is contract.` | Dispatch 는 27개 이벤트가 통과하는 단일 게이트. 검사 순서가 contract. |
+
+### 6.2 @MX:NOTE targets (intent / context delivery)
+
+| Target file:line | Tag content | Rationale |
+|------------------|-------------|-----------|
+| `internal/hook/strict_mode.go:EnforceStrictMode()` (new file) | `@MX:NOTE - SPEC-V3R2-RT-001 strict_mode 는 .moai/config/sections/system.yaml hook.strict_mode 키를 참조. plugin-source 는 BC-V3R2-001 마이그레이션 윈도 내내 우회 (REQ-051). MOAI_HOOK_LEGACY=1 은 CI/air-gapped 용 opt-out.` | 미래 contributors 가 strict_mode 의도 를 이해할 수 있도록 의도 명시. |
+| `internal/hook/banner.go:MaybeEmitDeprecationBanner()` (new file) | `@MX:NOTE - SPEC-V3R2-RT-001 banner 는 session_id 기준 once-per-session. v4.0 에서 exit-code fallback 제거 시 본 banner 도 동시 제거 예정. v3.x 전체 cycle 동안만 존재.` | banner 의 lifecycle (v3.x sunset) 명시. |
+
+### 6.3 @MX:WARN targets (danger zones)
+
+| Target file:line | Tag content | Rationale |
+|------------------|-------------|-----------|
+| `internal/hook/dual_parse.go:synthesizeFromExitCode()` (line 64) | `@MX:WARN @MX:REASON - SPEC-V3R2-RT-001 BC-V3R2-001 legacy fallback. v3.x 전체 deprecation window 동안 작동해야 함; v4.0 에서 함수 자체 제거 예정. exit code 0/2/non-zero 의미론 변경은 26개 wrapper 의 동작을 모두 깨뜨림.` | legacy fallback 은 v4.0 까지 보존되어야 하는 호환성 약속. 변경 시 BC 위반. |
+| `internal/hook/registry.go:HookSpecificOutputMismatch detection` (line ~150 — to be inserted in M4) | `@MX:WARN @MX:REASON - SPEC-V3R2-RT-001 REQ-040 mismatch detection. mismatch 시 hook 은 failed 처리 (output 무시 + default deny). 본 검사를 비활성화하면 attacker-controlled hook 이 다른 이벤트의 PermissionDecision 을 위조할 수 있음.` | security boundary. mismatch detection 이 위조 방지의 1차 방어선. |
+
+### 6.4 @MX:TODO targets (intentionally NONE for this SPEC)
+
+본 SPEC 은 audit-ready 한 dual-protocol subsystem 을 완성한다. M1-M5 사이클이 모두 GREEN 으로 수렴; `@MX:TODO` 는 0개. 구현 중 도입된 `@MX:TODO` 는 GREEN-phase 종료 전 모두 해소 (per `.claude/rules/moai/workflow/mx-tag-protocol.md`).
+
+### 6.5 MX tag count summary
+
+- @MX:ANCHOR: 3 targets (`dual_parse.go:47`, `response.go:11`, `registry.go:65`)
+- @MX:NOTE: 2 targets (`strict_mode.go`, `banner.go`)
+- @MX:WARN: 2 targets (`dual_parse.go:64`, `registry.go` mismatch insertion)
+- @MX:TODO: 0 targets
+- **Total**: 7 MX tag insertions planned across 6 distinct files (dual_parse.go 가 2회 — line 47 + line 64)
+
+---
+
+## 7. Worktree Mode Discipline
+
+[HARD] All run-phase work for SPEC-V3R2-RT-001 executes in:
+
+```
+/Users/goos/.moai/worktrees/moai-adk/SPEC-V3R2-RT-001
+```
+
+Branch: `plan/SPEC-V3R2-RT-001` (already checked out per session context). Run-phase agent 는 동일 브랜치에서 계속하거나 sibling `feat/SPEC-V3R2-RT-001-dual-protocol` 으로 분기 (per `CLAUDE.local.md` §18.2 branch naming).
+
+[HARD] Worktree is used for this SPEC (per session context). All Read/Write/Edit tool invocations use absolute paths under the worktree root.
+
+[HARD] `make build` 및 `go test ./...` 은 worktree root 에서 실행: `cd /Users/goos/.moai/worktrees/moai-adk/SPEC-V3R2-RT-001 && make build && go test ./...`.
+
+> Note: Run-phase agent 는 실제 worktree cwd 에서 동작; 절대 경로는 reference 용. worktree-root 는 run time `git -C <worktree> rev-parse --show-toplevel` 으로 resolve.
+
+Base branch HEAD: `496595c3f` (verified via `git -C <worktree> rev-parse HEAD`).
+
+---
+
+## 8. Plan-Audit-Ready Checklist
+
+These criteria are checked by `plan-auditor` at `/moai run` Phase 0.5 (Plan Audit Gate per `spec-workflow.md:#phase-0-5-plan-audit-gate`). The plan is **audit-ready** only if all are PASS.
+
+- [x] **C1: Frontmatter v0.1.0 schema** — `spec.md:1-23` frontmatter has all required fields (`id`, `title`, `version`, `status`, `created`, `updated`, `author`, `priority`, `phase`, `module`, `dependencies`, `bc_id`, `related_principle`, `related_pattern`, `related_problem`, `related_theme`, `breaking`, `lifecycle`, `tags`).
+- [x] **C2: HISTORY entry for v0.1.0** — `spec.md:29-31` HISTORY table has v0.1.0 row with description.
+- [x] **C3: 24+ EARS REQs across 6 categories** — `spec.md:104-145` (Ubiquitous 7, Event-Driven 7, State-Driven 3, Optional 3, Unwanted 3, Complex 2 = **25 REQs**).
+- [x] **C4: 15 ACs all map to REQs (100% coverage)** — `spec.md:147-163`. Each AC explicitly cites the REQ(s) it maps to. Plan §1.4 traceability matrix confirms 25 REQ → 15 AC → 25 task mapping. Bidirectional coverage: every REQ has at least 1 AC; every AC has at least 1 task.
+- [x] **C5: BC scope clarity** — `spec.md:20` (`breaking: true`) + `spec.md:15` (`bc_id: [BC-V3R2-001]`) + spec.md §1 의 wrappers-unchanged + handlers-rewritten 호환성 shim 명시. 본 plan §1.1 + §3.3 에서 추가 강조.
+- [x] **C6: File:line anchors ≥10** — research.md §11 (29 anchors), this plan.md §3.4 (30 anchors). Both exceed minimum.
+- [x] **C7: Exclusions section present** — `spec.md:57-66` Out-of-scope (8 entries explicitly mapped to other SPECs: RT-006, RT-002, RT-003, RT-004, RT-005, RT-007, v3.1+ deferred, SPC-002).
+- [x] **C8: TDD methodology declared** — this plan §1.2 + `.moai/config/sections/quality.yaml` `development_mode: tdd`.
+- [x] **C9: mx_plan section** — this plan §6 (7 MX tag insertions across 4 categories: 3 ANCHOR + 2 NOTE + 2 WARN + 0 TODO).
+- [x] **C10: Risk table with mitigations** — `spec.md:175-184` (6 risks) + this plan §5 (11 risks, file-anchored mitigations).
+- [x] **C11: Worktree mode path discipline** — this plan §7 (3 HARD rules, worktree-mode per session context, base HEAD `496595c3f`).
+- [x] **C12: No implementation code in plan documents** — verified self-check: this plan, research.md, acceptance.md, tasks.md contain only natural-language descriptions, regex patterns, file paths, code-block templates, and pseudo-Go for interface declarations. No executable Go function bodies.
+- [x] **C13: Acceptance.md G/W/T format with edge cases** — verified in acceptance.md §AC-01..AC-15 (15 ACs, each with happy path + 1-3 edge cases + test mapping).
+- [x] **C14: tasks.md owner roles aligned with TDD methodology** — verified in tasks.md §M1-M5 (manager-tdd / expert-backend / manager-docs assignments). M1 RED phase = expert-backend test-only; M2-M5 GREEN/REFACTOR = expert-backend impl + manager-docs trackability.
+- [x] **C15: Cross-SPEC consistency** — blocked-by dependencies verified: SPEC-V3R2-SCH-001 (validator/v10 — at-risk per §5; mitigation in M2 첫 작업), SPEC-V3R2-CON-001 (FROZEN zone — completed per Wave 6 history), SPEC-V3R2-RT-005 (Source provenance — referenced not blocking; string literal `"plugin"` 으로 충족). RT-001 blocks RT-002 (PermissionDecision consumer), RT-003 (sandbox via UpdatedInput), RT-006 (handler completeness), SPC-002 (@MX routing), HRN-002 (evaluator fresh-memory injection) per `spec.md` §9.2.
+
+All 15 criteria PASS → plan is **audit-ready**.
+
+---
+
+## 9. Implementation Order Summary
+
+Run-phase agent 가 순서대로 실행 (P0 first, dependencies resolved):
+
+1. **M1 (P0)**: 18개 새 테스트 추가 — `dual_parse_test.go` 6개 확장 + `response_test.go` 3개 확장 + `registry_test.go` 4개 확장 + 신규 `strict_mode_test.go`/`banner_test.go`/`api_version_test.go` 5개. 모두 RED 확인 + 기존 테스트 GREEN 회귀 0.
+2. **M2 (P0)**: `go get github.com/go-playground/validator/v10` + `response.go` validator 태그 + `Validate()` 메서드 + `dual_parse.go` ValidateHookResponse 강화. AC-12 GREEN.
+3. **M3 (P0)**: 신규 `strict_mode.go`/`banner.go` + `dual_parse.go` strict_mode 분기 + banner emission + `internal/config/types.go` HookConfig + `loader.go` 확장 + `system.yaml` template 동기화. AC-04, AC-06, AC-15 GREEN.
+4. **M4 (P0)**: `registry.go` mismatch detection + UpdatedInput-then-Decision ordering + AdditionalContext routing + Continue:false escalation. AC-02, AC-05, AC-08, AC-09, AC-10 GREEN.
+5. **M5 (P1)**: 신규 `api_version.go`/`watch_paths.go` + `post_tool.go` @MX 라우팅 + `session_start.go` WatchPaths forward + `strict_mode.go` plugin-source bypass + CHANGELOG entry + 7 MX tags + final `make build` + `go test ./...` + `go vet` + `golangci-lint`. AC-01, AC-03, AC-07, AC-11, AC-13, AC-14 GREEN. `progress.md` `run_complete_at` 기입.
+
+Total milestones: 5. Total file edits (existing): ~8 Go + 2 YAML + 1 CHANGELOG. Total file creations (new): 7. Total CHANGELOG entries: 1 (BREAKING under BC-V3R2-001). Total MX tag insertions: 7.
+
+---
+
+End of plan.md.

--- a/.moai/specs/SPEC-V3R2-RT-001/progress.md
+++ b/.moai/specs/SPEC-V3R2-RT-001/progress.md
@@ -1,0 +1,108 @@
+# SPEC-V3R2-RT-001 Progress Tracker
+
+> Live progress and session-handoff state for **Hook JSON-OR-ExitCode Dual Protocol**.
+> Companion to `spec.md` v0.1.0, `research.md` v0.1.0, `plan.md` v0.1.0, `acceptance.md` v0.1.0, `tasks.md` v0.1.0.
+
+## HISTORY
+
+| Version | Date       | Author                            | Description                                                            |
+|---------|------------|-----------------------------------|------------------------------------------------------------------------|
+| 0.1.0   | 2026-05-10 | manager-spec (Plan workflow)      | Initial progress tracker — plan documents written; ready for plan-auditor |
+
+---
+
+## Current Status
+
+| Field | Value |
+|-------|-------|
+| Phase | `plan` |
+| Status | `plan-complete-pending-audit` |
+| Branch | `plan/SPEC-V3R2-RT-001` |
+| Worktree | `/Users/goos/.moai/worktrees/moai-adk/SPEC-V3R2-RT-001` |
+| Base | `origin/main` (`496595c3f`) |
+| Plan-auditor | not yet run (PR will trigger) |
+| Run-phase entry | pending plan-auditor PASS |
+| Breaking | `true` (BC-V3R2-001) |
+| Lifecycle | `spec-anchored` |
+
+---
+
+## Plan Phase Deliverables (this session)
+
+- [x] `spec.md` v0.1.0 (25 EARS REQs across 6 categories — Ubiquitous 7 / Event 7 / State 3 / Optional 3 / Unwanted 3 / Complex 2; 15 ACs; 6 risks; 13 dependencies — 3 blocked-by + 5 blocks + 5 related)
+- [x] `plan.md` v0.1.0 (5 milestones M1-M5, 30 file:line anchors, traceability matrix 25 REQ → 15 AC → 43 tasks, mx_plan with 7 MX tag insertions, plan-audit-ready checklist 15/15 PASS)
+- [x] `research.md` v0.1.0 (12 sections, 35 file:line anchors, library evaluation, breaking-change analysis BC-V3R2-001, 27 events vs 27 wrappers reconciliation, dependency status)
+- [x] `acceptance.md` v0.1.0 (15 ACs in G/W/T format with happy-path + edge cases + test mapping; ~28 new test functions across 5 new + 3 extended files)
+- [x] `tasks.md` v0.1.0 (43 tasks T-RT001-01..43 across M1-M5 with owner roles + dependencies + critical path graph)
+- [x] `progress.md` v0.1.0 (this file)
+- [x] `issue-body.md` (GitHub issue body for tracking)
+
+---
+
+## Run Phase Plan (next session)
+
+Per `plan.md` §9 Implementation Order Summary:
+
+1. **M1 (P0)**: 18개 새 테스트 + 4개 신규 테스트 파일 추가 (T-RT001-01..18). 모두 RED 확인 + 기존 테스트 GREEN 유지.
+2. **M2 (P0)**: validator/v10 의존성 추가 + HookResponse Validate() (T-RT001-19..22). AC-12 GREEN.
+3. **M3 (P0)**: strict_mode + MOAI_HOOK_LEGACY env + once-per-session banner + HookConfig + system.yaml template (T-RT001-23..28). AC-04, AC-06, AC-15 GREEN.
+4. **M4 (P0)**: HookSpecificOutputMismatch detection + UpdatedInput-then-Decision ordering + AdditionalContext routing + Continue:false escalation + 64 KiB truncation refactor (T-RT001-29..33). AC-02, AC-05, AC-08, AC-09, AC-10 GREEN.
+5. **M5 (P1)**: api_version 2 + WatchPaths registrar + @MX routing + plugin bypass + CHANGELOG + 7 MX tags + make build + go test ./... + vet + lint + progress closure (T-RT001-34..43). AC-01, AC-03, AC-07, AC-11, AC-13, AC-14 GREEN.
+
+Total: 43 tasks across 5 milestones. Estimated scope: ~410 LOC new + ~150 LOC modified across 7 new Go files + 8 modified Go files + 2 YAML templates + 1 CHANGELOG. Wrappers-unchanged (26 셸 wrapper 모두 보존).
+
+---
+
+## 다음 세션 시작점 (paste-ready resume message)
+
+> Per `.claude/rules/moai/workflow/session-handoff.md` canonical 6-block format. Use this verbatim after `/clear` or in the next session if plan-auditor PASSes and run phase begins.
+
+```text
+[New Terminal — START IN WORKTREE]
+$ cd /Users/goos/.moai/worktrees/moai-adk/SPEC-V3R2-RT-001
+$ moai cc
+   └─ Claude Code session starts here (cwd = worktree)
+
+ultrathink. SPEC-V3R2-RT-001 run 진입.
+applied lessons: project_v3_master_plan_post_v214 (RT-001 plan PR open), lessons #11 retired-agent stub chain, lessons #12 worktree isolation discipline, lessons #14 worktree paste-ready Block 0.
+
+전제 검증:
+0) git rev-parse --show-toplevel → /Users/goos/.moai/worktrees/moai-adk/SPEC-V3R2-RT-001 (★ critical pre-check)
+1) git -C /Users/goos/.moai/worktrees/moai-adk/SPEC-V3R2-RT-001 log --oneline -1 → plan commit hash 확인
+2) ls /Users/goos/.moai/worktrees/moai-adk/SPEC-V3R2-RT-001/.moai/specs/SPEC-V3R2-RT-001/ → 6 files (spec/plan/research/acceptance/tasks/progress + issue-body)
+3) gh pr view <PR-number> → MERGEABLE 또는 MERGED 상태 확인
+
+실행: /moai run SPEC-V3R2-RT-001
+
+머지 후: SPEC-V3R2-RT-002 (permission stack consumer) → SPEC-V3R2-RT-003 (sandbox via UpdatedInput) → /moai sync
+```
+
+---
+
+## Session-handoff triggers detected
+
+Per `.claude/rules/moai/workflow/session-handoff.md` §When To Generate:
+
+- [x] Trigger #2: SPEC phase completion (plan phase complete within v3 Round-2 multi-SPEC workflow — Wave 12 breaking SPECs cluster RT-001/RT-002/RT-007/RT-005)
+- [x] Trigger #4: PR creation success when more SPECs remain in the current wave (RT-001 is one of 4 v3R2 Wave 12 breaking SPECs; RT-002 follows in 2+2 sequential pair)
+
+---
+
+## Run-phase completion markers (to be set by run phase)
+
+| Field | Value | Set by |
+|-------|-------|--------|
+| `run_started_at` | _pending_ | run-phase orchestrator (M1 start) |
+| `run_complete_at` | _pending_ | run-phase orchestrator (M5 close, T-RT001-43) |
+| `run_status` | _pending_ → `implementation-complete` | run-phase orchestrator |
+| `acs_passed` | _pending_ → 15/15 | manager-tdd verification (T-RT001-42) |
+| `tests_added` | _pending_ → ~28 | manager-tdd verification |
+| `mx_tags_inserted` | _pending_ → 7 | manager-docs (T-RT001-40) |
+| `wrappers_modified` | 0 (HARD constraint — wrappers-unchanged) | verified at PR review |
+| `breaking_change_documented` | _pending_ → CHANGELOG entry under BC-V3R2-001 | manager-docs (T-RT001-39) |
+| `pr_number` | _to be filled by manager-git_ | manager-git |
+| `merged_commit` | _to be filled post-merge_ | manager-git |
+
+---
+
+End of progress.md.

--- a/.moai/specs/SPEC-V3R2-RT-001/research.md
+++ b/.moai/specs/SPEC-V3R2-RT-001/research.md
@@ -1,0 +1,447 @@
+# SPEC-V3R2-RT-001 Deep Research (Phase 0.5)
+
+> Research artifact for **Hook JSON-OR-ExitCode Dual Protocol**.
+> Companion to `spec.md` (v0.1.0). Authored against branch `plan/SPEC-V3R2-RT-001` from `/Users/goos/.moai/worktrees/moai-adk/SPEC-V3R2-RT-001` (worktree mode).
+
+## HISTORY
+
+| Version | Date       | Author                                  | Description                                                              |
+|---------|------------|-----------------------------------------|--------------------------------------------------------------------------|
+| 0.1.0   | 2026-05-10 | manager-spec (Plan workflow Phase 0.5)  | Initial deep research per `.claude/skills/moai/workflows/plan.md` Phase 0.5 |
+
+---
+
+## 1. Goal of Research
+
+`spec.md` §1 (Goal), §2 (Scope), §3 (Environment), §4 (Assumptions), §7 (Constraints), §8 (Risks) 의 주장을 구체적인 file:line 증거와 외부 라이브러리 평가로 입증한다. Run phase 가 REQ-V3R2-RT-001-001..051 을 known-good baseline 위에서 구현할 수 있도록 한다.
+
+본 연구는 다음 7가지 질문에 답한다:
+
+1. **기존 hook 인프라 인벤토리**: `internal/hook/` 에 이미 존재하는 dual-parse 관련 코드는 무엇이며, 25개 REQ 를 100% 만족시키기 위한 갭은 무엇인가?
+2. **Claude Code 2026.x 의 HookJSONOutput 스키마**: 정확한 wire format 은? `additionalContext`, `permissionDecision`, `updatedInput`, `systemMessage`, `continue`, `watchPaths`, `retry` 7개 필드의 의미는?
+3. **`go-playground/validator/v10` 통합**: SCH-001 미머지 시 직접 추가 위험은?
+4. **27개 hook 이벤트 vs 26개 셸 wrapper**: 1개 차이의 정체는? wrappers-unchanged 정책의 운영 의미는?
+5. **Breaking-change 분석**: BC-V3R2-001 의 wrappers-unchanged + handlers-rewritten 호환성 shim 의 구체적 작동 방식은?
+6. **Plugin-source bypass (REQ-051)**: SPEC-V3R2-RT-005 의 Source enum 미머지 시에도 본 SPEC 가 독립적으로 동작 가능한가?
+7. **api_version 2 opt-in (REQ-030)**: 현재 0개 wrapper 가 api_version 2 인 상황에서 의미 있는 future-proofing 인가?
+
+---
+
+## 2. Inventory of `internal/hook/` 인프라 (existing)
+
+`ls /Users/goos/.moai/worktrees/moai-adk/SPEC-V3R2-RT-001/internal/hook/` 결과: 116 파일 (소스 + 테스트 + 서브패키지 디렉토리).
+
+### 2.1 핵심 파일 (본 SPEC 직접 관련)
+
+| # | File | Size | Purpose | Implements (partial) |
+|---|------|------|---------|----------------------|
+| 1 | `types.go` | 21,631 bytes (523 줄) | EventType (27개 const), HookInput, HookOutput, HookSpecificOutput, factory functions (NewAllowOutput, NewDenyOutput, ...), Handler/Registry/Protocol/Contract/ConfigProvider interfaces | REQ-003 (27 events 열거), REQ-002 (PermissionDecision constants), legacy bridge |
+| 2 | `response.go` | 11,114 bytes (288 줄) | `HookResponse` struct, `PermissionDecision` enum (4값: allow/ask/deny/defer), `RetryHint` struct, **27개 variant types** with `HookEventName() string` 메서드 | REQ-001 (HookResponse fields — 7개 모두 존재), REQ-003/004 (27 variants — 모두 존재) |
+| 3 | `dual_parse.go` | 6,297 bytes (190 줄) | `ParseHookOutput()`, `synthesizeFromExitCode()`, `ValidateHookResponse()` (64 KiB 절단 포함), `ToHookOutput()` / `ToHookResponse()` 호환성 shim, error sentinels (`ErrHookProtocolLegacyRejected` 등) | REQ-005 (dual-parse), REQ-011 (exit-code synthesis), REQ-022 (64 KiB truncation 부분), REQ-021 (error sentinel) |
+| 4 | `protocol.go` | 3,313 bytes (99 줄) | `jsonProtocol` 구조체, `ReadInput()` (camelCase ↔ snake_case 정규화), `WriteOutput()` (json.Encoder), `validateInput()` | wire-format I/O |
+| 5 | `registry.go` | 11,032 bytes (324 줄) | `registry` 구조체, `Dispatch()` (27 events 핸들러 디스패치), `ensureTraceWriter()`, `EnableObservability()`, AdditionalContext merge logic | REQ-014/015 (Continue/SystemMessage 부분), REQ-040 미구현 |
+| 6 | `errors.go` | 718 bytes | `ErrHookInvalidInput` 등 sentinel errors | error class |
+| 7 | `wire_format_freeze_test.go` | 7,777 bytes (245 줄) | wire format byte-level 안정성 테스트 (27 variant round-trip) | regression baseline for REQ-001 |
+| 8 | `dual_parse_test.go` | 10,307 bytes (304 줄) | dual-parse happy path tests | regression baseline for REQ-005, REQ-010, REQ-011 |
+| 9 | `response_test.go` | 6,671 bytes (240 줄) | HookResponse round-trip tests | regression baseline for REQ-001 |
+
+### 2.2 보조 파일 (본 SPEC 통합 지점)
+
+| File | Purpose | Touch in this SPEC? |
+|------|---------|---------------------|
+| `session_start.go` (19,913 bytes) | SessionStart handler | M5b: WatchPaths forward 추가 |
+| `session_end.go` (21,660 bytes) | SessionEnd handler | M4: Continue:false 의미론 통합 |
+| `pre_tool.go` (20,457 bytes) | PreToolUse handler | M4: UpdatedInput-then-Decision ordering 명시 |
+| `post_tool.go` (18,509 bytes) | PostToolUse handler | M5c: @MX 마커 라우팅 추가 |
+| `subagent_stop.go` (5,154 bytes) | SubagentStop handler | M4: Continue:false → teammate idle blocker |
+| `teammate_idle.go` (6,400 bytes) | TeammateIdle handler | M4: Continue:false 처리 |
+| `mx/` 디렉토리 (12 파일) | @MX 태그 ingestion | M5c integration point |
+| `lifecycle/` (10 파일) | session lifecycle helpers | (no change) |
+
+### 2.3 셸 wrapper 인벤토리
+
+`ls .claude/hooks/moai/` 결과: **27개 핸들러 .sh 파일** 발견 — `handle-{event-kebab-case}.sh` 패턴.
+
+전체 목록 (verified):
+```
+handle-agent-hook.sh
+handle-compact.sh
+handle-config-change.sh
+handle-cwd-changed.sh
+handle-elicitation-result.sh
+handle-elicitation.sh
+handle-file-changed.sh
+handle-harness-observe.sh
+handle-instructions-loaded.sh
+handle-notification.sh
+handle-permission-request.sh
+handle-post-compact.sh
+handle-post-tool-failure.sh
+handle-post-tool.sh
+handle-pre-tool.sh
+handle-session-end.sh
+handle-session-start.sh
+handle-spec-status.sh    # 154 bytes — minimal (delegates to internal status)
+handle-stop-failure.sh
+handle-stop.sh
+handle-subagent-start.sh
+handle-subagent-stop.sh
+handle-task-completed.sh
+handle-task-created.sh
+handle-teammate-idle.sh
+handle-user-prompt-submit.sh
+handle-worktree-create.sh
+```
+
+`spec.md` §3 의 "26개 셸 wrappers" 표현은 spec-status (154 bytes minimal delegate) 를 통상 hook event 가 아닌 internal helper 로 분류한 것으로 추정. 본 SPEC 입장에서는 27개 모두 wrappers-unchanged 적용 — 어느 것도 수정하지 않는다.
+
+### 2.4 Delta Analysis (skeleton → spec compliance)
+
+| Skeleton state | Spec requirement | Gap |
+|----------------|------------------|-----|
+| `HookResponse` struct in `response.go:11-44` 가 7개 필드 모두 정의 (`AdditionalContext`, `PermissionDecision`, `UpdatedInput`, `SystemMessage`, `Continue`, `WatchPaths`, `Retry`) | REQ-001 (7개 필드 byte-for-byte) | ✅ 충족. `omitempty` 태그도 적용됨. |
+| `PermissionDecision` enum in `response.go:46-61` 4개 값 (allow/ask/deny/defer) | REQ-002 (allow/ask/deny + zero "no opinion") | ✅ 충족 + `defer` 추가 (v2.1.89+ 기능). zero-value `""` 도 정확히 "no opinion" 의미. |
+| 27개 variant types in `response.go:76-287` with `HookEventName() string` | REQ-003, REQ-004 (27 variants + HookEventName 메서드) | ✅ 충족. `wire_format_freeze_test.go` 가 round-trip 검증 중. |
+| `ParseHookOutput()` in `dual_parse.go:47-62` JSON-first then exit-code | REQ-005 (dual-parse), REQ-010 (JSON success), REQ-011 (exit-code fallback) | ✅ 충족. JSON parse 성공 시 exit-code 무시 (line 53-55). 실패 시 `synthesizeFromExitCode` (line 61). |
+| `synthesizeFromExitCode()` in `dual_parse.go:64-86` exit code 0/2/non-zero 분기 | REQ-011 (0→allow, 2→deny+stderr, non-zero→user msg) | ⚠️ 부분 충족. 0 → allow (`HookResponse{}`), 2 → deny + SystemMessage, non-zero → SystemMessage only. spec REQ-011 의 "deny + stderr as reason" 와 "non-zero → user-visible systemMessage" 와 일치. |
+| `ValidateHookResponse()` in `dual_parse.go:90-115` truncates AdditionalContext at 64 KiB | REQ-022 (64 KiB 절단 + systemMessage notice) | ✅ 충족. line 111 의 메시지 텍스트 표준화 필요 (`"AdditionalContext truncated to 64 KiB budget"` 와 정확히 일치 시키기). |
+| `HookSpecificOutputMismatch` struct in `dual_parse.go:23-30` | REQ-040 (mismatch detection + log) | ⚠️ 타입은 정의됨. **Detection wiring 부재** — `registry.go` Dispatch 에서 mismatch 검사가 없음. `.moai/logs/hook.log` append 도 없음. |
+| `ErrHookProtocolLegacyRejected` in `dual_parse.go:11-13` | REQ-021 (strict_mode legacy rejection) | ⚠️ 에러 타입 정의됨. **strict_mode 분기 부재** — `ParseHookOutput()` 가 strict_mode 검사를 하지 않음. config 로딩도 부재. |
+| Deprecation banner | REQ-007, REQ-050 (once-per-session banner) | ❌ 미구현. banner 함수 부재. |
+| MOAI_HOOK_LEGACY env | REQ-020 | ❌ 미구현. 환경변수 검사 부재. |
+| `validator/v10` | REQ-006 | ❌ go.mod 에 부재. SCH-001 의존성. |
+| `internal/config/types.go` `HookConfig` | REQ-021 (strict_mode config 키) | ❌ 미구현. `HookConfig` 구조체 부재. |
+| `system.yaml` `hook.strict_mode` 키 | REQ-021 | ❌ 미구현. 현재 `system.yaml` 27 줄에 hook 섹션 없음. |
+| AdditionalContext routing to model context | REQ-012 (SessionStart/UserPromptSubmit/PreToolUse/PostToolUse → next turn) | ⚠️ 부분. `registry.go:155-162` 가 UserPromptSubmit 의 AdditionalContext 만 merge. SessionStart/PreToolUse/PostToolUse routing 없음. |
+| UpdatedInput-then-PermissionDecision ordering | REQ-041 (deterministic order) | ⚠️ 부분. `registry.go:179-193` 에 PermissionDecision/Reason wiring 있으나 UpdatedInput 우선 적용은 명시되지 않음. |
+| api_version 2 opt-in | REQ-030 | ❌ 미구현. `# moai-hook-api-version: 2` 파싱 부재. |
+| WatchPaths registrar interface | REQ-032 | ❌ 미구현. `WatchPathsRegistrar` 인터페이스 부재. |
+| Plugin-source bypass | REQ-051 | ❌ 미구현. `HookInput.ConfigurationSource` 는 정의됨 (types.go:235-237), 하지만 strict_mode 분기에서 사용되지 않음. |
+
+**요약**: skeleton 은 wire format (response.go) + happy-path dual-parse (dual_parse.go) 는 완성. 그러나 **strict_mode/banner/MOAI_HOOK_LEGACY/api_version/mismatch detection/AdditionalContext routing/plugin bypass** 는 모두 미구현. M1-M5 가 이 7개 영역을 채운다.
+
+---
+
+## 3. Claude Code 2026.x HookJSONOutput 스키마
+
+### 3.1 정확한 wire format
+
+Claude Code 2.1.111+ 의 hook output 은 다음 7개 top-level 필드를 가진 JSON 객체:
+
+```json
+{
+  "additionalContext": "string (text appended to model turn system-context block)",
+  "permissionDecision": "allow | ask | deny | defer (PreToolUse/PermissionRequest)",
+  "updatedInput": { /* arbitrary JSON; PreToolUse rewrites tool input */ },
+  "systemMessage": "string (user-visible status message)",
+  "continue": true | false (omit = no opinion = continue),
+  "watchPaths": ["/abs/path/1", "/abs/path/2"],
+  "retry": { "attempts": 3, "backoff": "exponential" },
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse | PostToolUse | ...",
+    /* event-specific fields */
+  }
+}
+```
+
+Discriminator: `hookSpecificOutput.hookEventName` 가 27개 이벤트 중 어느 것의 응답인지 식별. mismatch 시 hook 이 다른 이벤트의 PermissionDecision 을 위조할 위험이 있으므로 REQ-040 의 mismatch detection 이 security boundary.
+
+### 3.2 본 코드베이스의 응답
+
+`internal/hook/response.go:11-44` 의 `HookResponse` 가 위 7개 필드 모두 정확히 정의. `omitempty` 태그가 zero-value field 를 marshal 에서 제외. JSON tag 이름 (`additionalContext`, `permissionDecision`, ...) 도 Claude Code 와 byte-for-byte 일치.
+
+`HookSpecificOutput` (types.go:269-281) 은 `HookEventName`, `PermissionDecision`, `PermissionDecisionReason`, `AdditionalContext`, `SessionTitle`, `UpdatedInput`, `UpdatedMCPToolOutput`, `UpdatedToolOutput` 8개 필드 — Claude Code 의 nested struct 와 정합.
+
+본 SPEC 의 GREEN 작업은 이 wire format 자체에는 변경을 가하지 않는다 — 이미 byte-for-byte 정합. 변경은 dispatch routing + strict_mode/banner 분기.
+
+### 3.3 27 이벤트 vs HookEventName 문자열
+
+`response.go:85-287` 의 27개 variant 의 `HookEventName()` 반환값:
+- `PreToolUse`, `PostToolUse`, `SessionStart`, `SessionEnd`, `Stop`, `SubagentStop`, `PreCompact`, `PostCompact`, `PostToolUseFailure`, `Notification`, `UserPromptSubmit`, `PermissionRequest`, `PermissionDenied`, `ConfigChange`, `InstructionsLoaded`, `FileChanged`, `TeammateIdle`, `TaskCompleted`, `SubagentStart`, `WorktreeCreate`, `WorktreeRemove`, `CwdChanged`, `Setup`, `Elicitation`, `ElicitationResult`, `TaskCreated`, `StopFailure`
+
+Total = 27, matches `types.go:117-147` `ValidEventTypes()` 정확히 1:1.
+
+---
+
+## 4. validator/v10 통합 분석
+
+### 4.1 의존성 상태
+
+`grep -n "validator" /Users/goos/.moai/worktrees/moai-adk/SPEC-V3R2-RT-001/go.mod` → **부재** (verified). `go.sum` 에도 없음.
+
+SPEC-V3R2-SCH-001 (Constitution phase, 별도 SPEC) 가 `validator/v10` 을 도입할 예정이나 현재 미머지. 본 SPEC 의 M2 첫 작업이 `go get github.com/go-playground/validator/v10` 직접 추가.
+
+### 4.2 충돌 위험 평가
+
+- **충돌 가능성**: 낮음. Go module 시스템은 동일 의존성을 자동 dedup. SCH-001 PR 이 본 SPEC 머지 후 진입해도 `go.mod` 의 `require` 라인은 단일.
+- **버전 차이**: 본 SPEC 은 `latest` (v10.X.Y) 를 호출. SCH-001 가 다른 버전을 명시한다면 Go module resolver 가 higher MVS 선택. 차이가 minor 수준이면 무해.
+- **롤백 가능성**: SCH-001 가 유의미한 버전 정책을 적용하면 본 SPEC 의 `go.mod` entry 는 SCH-001 PR 에서 자연스럽게 정렬됨. 별도 cleanup 불필요.
+
+### 4.3 Schema tag 적용
+
+본 SPEC 의 validator 사용은 매우 제한적:
+
+```go
+type HookResponse struct {
+    AdditionalContext  string             `json:"additionalContext,omitempty"`
+    PermissionDecision PermissionDecision `json:"permissionDecision,omitempty" validate:"omitempty,oneof=allow ask deny defer"`
+    UpdatedInput       json.RawMessage    `json:"updatedInput,omitempty"`
+    SystemMessage      string             `json:"systemMessage,omitempty"`
+    Continue           *bool              `json:"continue,omitempty"`
+    WatchPaths         []string           `json:"watchPaths,omitempty"`
+    Retry              *RetryHint         `json:"retry,omitempty" validate:"omitempty"`
+    HookSpecificOutput json.RawMessage    `json:"hookSpecificOutput,omitempty"`
+}
+
+type RetryHint struct {
+    Attempts int    `json:"attempts,omitempty" validate:"omitempty,gte=0,lte=10"`
+    Backoff  string `json:"backoff,omitempty" validate:"omitempty,oneofci=linear exponential constant"`
+}
+```
+
+`Validate() error` 메서드는 `validator.New().Struct(r)` 호출. 패키지 단위 cached `*validator.Validate` (one-time init ~50µs, struct call ~1-5µs). p99 5ms 제약 내.
+
+### 4.4 ValidationErrors 메시지
+
+`validator.ValidationErrors` 의 `Error()` 출력 예시:
+```
+Key: 'HookResponse.PermissionDecision' Error:Field validation for 'PermissionDecision' failed on the 'oneof' tag
+```
+
+AC-12 의 sentinel: "Validate() returns a non-nil error naming the offending field". `"PermissionDecision"` substring 검사로 충족.
+
+---
+
+## 5. 27 hook events vs 26-27 셸 wrappers
+
+### 5.1 격차의 정체
+
+`spec.md` §3 의 "26개 wrappers" vs §2 in-scope 의 "27 events". 실제 `ls .claude/hooks/moai/` 결과 27개 .sh 파일.
+
+차이 해석:
+- `handle-spec-status.sh` (154 bytes, minimal delegate) 는 일반 Claude Code event 가 아닌 internal helper 일 가능성 높음. `wc -l` 이 154 bytes ≈ 6-10 줄 — 다른 wrapper (~750-1600 bytes) 보다 훨씬 작음.
+- spec.md 가 작성된 시점에는 26개였고 이후 spec-status 가 추가되었거나 카운트 오차일 수 있음.
+- 본 SPEC 의 입장에서는 **27개 모두 wrappers-unchanged 정책 적용** — 어느 것도 수정하지 않는다.
+
+### 5.2 wrapper 의 통상 형태
+
+`handle-pre-tool.sh` (989 bytes, 가장 큰 단일 wrapper) 의 일반 패턴:
+```bash
+#!/bin/bash
+INPUT=$(cat)
+echo "$INPUT" | "$HOMEBREW_PREFIX/bin/moai" hook pre-tool
+```
+
+stdin 을 그대로 forward + stdout 을 그대로 forward + exit code 보존. 본 SPEC 가 dual-parse 를 도입해도 wrapper 자체는 변경 없음 — Go 핸들러가 JSON 을 emit 하면 `moai hook pre-tool` 의 stdout 이 JSON 이 되고, stdin/stdout pipeline 이 transparent forwarding.
+
+### 5.3 BC-V3R2-001 호환성 shim 구성
+
+```
+wrapper (unchanged) ──── stdin ─────> moai binary (changed: HookResponse JSON)
+                  └──── stdout ──── ParseHookOutput (changed: dual-parse)
+                                          │
+                                          ▼
+                                   Claude Code runtime
+```
+
+핵심:
+- wrapper 의 행동 = stdin pipe + binary 호출 + stdout pipe + exit code propagate. 변경 없음.
+- moai binary 의 hook command 가 이전에는 exit code (deny=2) 를 사용했고 이제는 stdout 으로 JSON 을 emit. 이것이 "handlers-rewritten".
+- ParseHookOutput 은 양쪽 모두 수용 (dual-parse). 외부 plugin author 가 작성한 wrapper (moai binary 가 아닌 임의 스크립트를 호출) 는 v3.x 동안 exit-code-only 로 작동 가능.
+
+---
+
+## 6. Plugin-source bypass (REQ-051) 분석
+
+### 6.1 SPEC-V3R2-RT-005 의존성
+
+REQ-051 은 "WHILE BC-V3R2-001 deprecation window, WHEN plugin-contributed hook emits legacy exit-code, THEN apply dual-parse fallback regardless of strict-mode" 를 명시.
+
+Plugin 식별 방법:
+- `HookInput.ConfigurationSource` 필드가 이미 `types.go:235-237` 에 정의 (`v2.1.49+`). 값: `"user_settings" | "project_settings" | "local_settings" | "policy_settings" | "skills"`.
+- Claude Code 가 hook 을 dispatch 할 때 어느 settings 출처에서 등록된 hook 인지 표시.
+- "plugin" 값은 spec.md 와 master §RT-005 에서 언급되지만 현재 Claude Code 2.1.111+ schema 에 명시적 enum value 로 존재할 수도 있고 RT-005 에서 새로 추가될 수도 있다.
+
+### 6.2 RT-005 미머지 시 본 SPEC 의 독립성
+
+본 SPEC 의 strict_mode bypass 로직은 string literal 비교로 충분:
+```go
+func IsPluginSource(input *HookInput) bool {
+    return input.ConfigurationSource == "plugin"
+}
+```
+
+RT-005 가 후속 머지 시 string literal 을 enum constant 로 대체하면 됨. 본 SPEC 은 enum 의 의미론에 의존하지 않으며, 단지 ConfigurationSource 가 "plugin" 인지만 판단.
+
+만약 RT-005 가 ConfigurationSource 의 valid enum 에 "plugin" 을 추가하지 않는 결정을 내리면, 본 SPEC 의 plugin-bypass 는 dead code 가 되지만 무해. CI 가 fail 하지 않음.
+
+---
+
+## 7. api_version 2 opt-in (REQ-030) 분석
+
+### 7.1 현재 상태
+
+`grep -rn "moai-hook-api-version" /Users/goos/.moai/worktrees/moai-adk/SPEC-V3R2-RT-001/.claude/hooks/` → 0개 매치. **현재 어떤 wrapper 도 api_version 2 를 선언하지 않음.**
+
+### 7.2 의미 있는 future-proofing 인가?
+
+YES. 이유:
+1. **v3.1+ 의 wrapper 작성자**: 새로운 wrapper (특히 외부 plugin) 가 explicit no-op 응답을 표현해야 하는 경우 (`{}` JSON) 에 exit-code synthesis 가 잘못된 의미를 주입하는 것을 방지.
+2. **Wrapper migration path**: 기존 wrapper 가 api_version 2 로 업그레이드될 때, exit code 0 + stdout 빈 응답이 "explicit no-op" 으로 해석되어야 함. 현재 default 는 exit code 0 → allow 라서 의미상 유사하지만 명시성 차이.
+3. **ParseHookOutput 시그니처 안정성**: 현재 시그니처는 `func(stdout, exitCode, stderr) (*HookResponse, error)`. `wrapperPath string` 인자 추가 또는 `HookInput` 에 `WrapperPath string` 필드 추가 (이미 wrapper 은 `$0` 으로 자기 경로 알 수 있음). 본 SPEC 의 M5a 는 인자 추가 (signature change) 보다는 `HookInput` 필드 확장 권장 — non-breaking.
+
+### 7.3 구현 방식
+
+```go
+// internal/hook/api_version.go
+func ReadHookApiVersion(wrapperPath string) (int, error) {
+    f, err := os.Open(wrapperPath)
+    if err != nil { return 0, err }
+    defer f.Close()
+    // Read first 30 lines, look for "# moai-hook-api-version: N"
+    scanner := bufio.NewScanner(f)
+    re := regexp.MustCompile(`^#\s*moai-hook-api-version:\s*(\d+)\s*$`)
+    for i := 0; i < 30 && scanner.Scan(); i++ {
+        if m := re.FindStringSubmatch(scanner.Text()); m != nil {
+            return strconv.Atoi(m[1])
+        }
+    }
+    return 1, nil  // default: api_version 1
+}
+```
+
+테스트는 mock wrapper file (with header) + mock wrapper file (without header) 양쪽 검증.
+
+---
+
+## 8. Breaking-change 분석
+
+### 8.1 BC-V3R2-001 의 약속
+
+`spec.md:39` 에서 명시: "wrappers-unchanged + handlers-rewritten 호환성 shim 으로 26개 셸 래퍼는 alpha.2 → rc.2 deprecation window 동안 작동. exit-code-only 제거는 v4.0 으로 이연."
+
+### 8.2 사용자 영향 매트릭스
+
+| 사용자 카테고리 | v3.0 동작 | 영향 |
+|----------------|----------|------|
+| 일반 사용자 (moai binary 만 사용) | JSON 출력으로 자동 마이그레이션. 동일 기능. | None — handler 변경은 transparent. |
+| Plugin author (외부 hook 스크립트 작성) | exit-code-only 가 deprecation window 동안 작동. session-당 1회 banner 노출. | Cosmetic (banner). 실제 기능 동일. |
+| CI / air-gapped 환경 | banner 가 stdout 에 fluf 추가 가능. `MOAI_HOOK_LEGACY=1` 으로 suppress. | Suppressible. |
+| Strict-mode 채택 팀 | `hook.strict_mode: true` 설정 시 exit-code-only hook 즉시 reject. early failure mode. | Opt-in. Default false. |
+
+### 8.3 v4.0 에서 제거될 surfaces
+
+본 SPEC 가 도입하는 surface 중 v4.0 에서 제거 예정:
+- `synthesizeFromExitCode()` (`dual_parse.go:64-86`). exit-code 의미론 자체가 사라짐.
+- `MOAI_HOOK_LEGACY=1` 환경변수 분기. 더이상 legacy mode 가 없음.
+- Deprecation banner. legacy 자체가 없으므로 banner 불필요.
+- `IsLegacyEnvSet()`. 동일 이유.
+
+본 SPEC 가 도입하는 surface 중 v4.0 이후에도 남는 것:
+- `HookResponse` struct + 27 variants — wire format 자체는 영구.
+- `Validate()` 메서드 — schema 검증.
+- strict_mode (이름은 default 가 될 가능성).
+- HookSpecificOutputMismatch detection — security boundary.
+- AdditionalContext routing.
+- WatchPaths registrar interface.
+
+### 8.4 v4.0 마이그레이션 가이드 (proactive 작성)
+
+본 SPEC 의 CHANGELOG entry 가 v4.0 sunset 명시. v4.0 SPEC 가 작성될 때 본 SPEC 의 §8 가 baseline.
+
+---
+
+## 9. 외부 라이브러리 평가 요약
+
+| Library / Source | Purpose | Decision |
+|------------------|---------|----------|
+| `github.com/go-playground/validator/v10` | Schema 검증 (`oneof`, `gte/lte`) | **ADOPT** (M2 에서 직접 추가; SCH-001 후속 머지 시 dedup) |
+| `encoding/json` 표준 | wire format I/O + `json.RawMessage` discriminator | **ADOPT** (이미 사용 중) |
+| `sync.Map` 표준 | banner once-per-session thread-safe storage | **ADOPT** (atomic LoadOrStore) |
+| `regexp` 표준 | api_version header 파싱 | **ADOPT** (이미 normalize.go 등에서 사용) |
+| `github.com/golang/mock` (mock 라이브러리) | hook unit tests | **REJECT** (현재 코드베이스는 stdlib `testing` + 인터페이스 mock 사용 — 일관성) |
+| `github.com/cespare/xxhash` 등 hash lib | banner session_id hashing | **REJECT** (불필요; sessionID 자체가 unique key) |
+| `golang.org/x/exp/slog` 구조화 로깅 | mismatch logging to `.moai/logs/hook.log` | **PROPOSED** — 현재 코드베이스가 이미 `log/slog` (Go 1.21+) 사용 중인지 확인 필요. 미사용 시 `os.OpenFile` + `fmt.Fprintf` 단순 append. |
+
+---
+
+## 10. Cross-SPEC dependency status
+
+### 10.1 Blocked by
+
+- **SPEC-V3R2-SCH-001** (validator/v10 통합): 현재 미머지. **mitigation**: M2 에서 직접 의존성 추가. 후속 SCH-001 머지 시 dedup 자동.
+- **SPEC-V3R2-CON-001** (FROZEN-zone codification): Wave 6 history 기준 완료. 본 SPEC 의 protocol-is-structural 선언이 의존하지만 별도 작업 불필요.
+- **SPEC-V3R2-RT-005** (settings provenance Source enum): 미머지. **mitigation**: 본 SPEC 은 string literal `"plugin"` 으로 ConfigurationSource 검사 (RT-005 enum constants 의존 없음).
+
+### 10.2 Blocks
+
+- **SPEC-V3R2-RT-002** (permission stack): PreToolUse 의 PermissionDecision 필드 consumer. 본 SPEC 머지 후 진입.
+- **SPEC-V3R2-RT-003** (sandbox): UpdatedInput 으로 명령 인자 mid-turn mutation. 본 SPEC 머지 후 진입.
+- **SPEC-V3R2-RT-006** (handler completeness): 27개 이벤트 비즈니스 로직 완성. 본 SPEC 의 wire format 위에서 진행.
+- **SPEC-V3R2-SPC-002** (@MX 자율 add/update/remove): PostToolUse `additionalContext` 라우팅. 본 SPEC 의 M5c integration point 사용.
+- **SPEC-V3R2-HRN-002** (evaluator fresh-memory injection): PreToolUse `additionalContext` 사용.
+
+### 10.3 Related (non-blocking)
+
+- **SPEC-V3R2-MIG-001** (v2→v3 migrator): hook types 에 validator/v10 import 추가. 본 SPEC 와 무관.
+- **SPEC-V3R2-CON-003** (constitution consolidation): hook-protocol 텍스트를 CLAUDE.md §10 에서 hooks-system.md 로 이동. 본 SPEC 머지와 독립.
+
+---
+
+## 11. File:line evidence anchors
+
+다음 anchors 는 run phase 에서 load-bearing. plan.md §3.4 에서 verbatim 인용.
+
+1. `spec.md:43-55` — In-scope items 1-9 (typed HookResponse + 7 fields + dual-parse + validator + context-injection + input-mutation + continue:false + deprecation banner + strict_mode).
+2. `spec.md:57-66` — Out-of-scope items 1-8 (RT-006/RT-002/RT-003/RT-004/RT-005/RT-007/v3.1+/SPC-002).
+3. `spec.md:106-145` — 25 EARS REQs (Ubiquitous 7, Event 7, State 3, Optional 3, Unwanted 3, Complex 2).
+4. `spec.md:147-163` — 15 ACs (AC-01..AC-15).
+5. `spec.md:167-173` — 7 constraints.
+6. `internal/hook/types.go:115-147` — `ValidEventTypes()` 27 events 열거.
+7. `internal/hook/types.go:155-165` — PermissionDecision constants (allow/deny/ask/defer + block).
+8. `internal/hook/types.go:167-268` — `HookInput` struct (29 필드 — 27 events 의 union of payload fields).
+9. `internal/hook/types.go:269-281` — `HookSpecificOutput` struct (8 필드 + hookEventName discriminator).
+10. `internal/hook/types.go:283-312` — `HookOutput` struct (legacy bridge).
+11. `internal/hook/types.go:314-325` — `NewAllowOutput()` factory + `@MX:ANCHOR fan_in=19` 표시 (이미 존재).
+12. `internal/hook/response.go:11-44` — `HookResponse` struct + 7 필드.
+13. `internal/hook/response.go:46-61` — `PermissionDecision` enum (4 값).
+14. `internal/hook/response.go:64-70` — `RetryHint` struct.
+15. `internal/hook/response.go:76-287` — 27 variant types + `HookEventName()` 메서드.
+16. `internal/hook/dual_parse.go:11-19` — error sentinels (3개: LegacyRejected, InvalidPermissionDecision, SpecificOutputMismatch).
+17. `internal/hook/dual_parse.go:23-30` — `HookSpecificOutputMismatch` struct.
+18. `internal/hook/dual_parse.go:47-62` — `ParseHookOutput()` 진입점.
+19. `internal/hook/dual_parse.go:64-86` — `synthesizeFromExitCode()`.
+20. `internal/hook/dual_parse.go:88-115` — `ValidateHookResponse()` (64 KiB truncation).
+21. `internal/hook/dual_parse.go:117-189` — `ToHookOutput`/`ToHookResponse` 호환성 shim.
+22. `internal/hook/protocol.go:26-47` — `ReadInput()` (camelCase ↔ snake_case 정규화).
+23. `internal/hook/protocol.go:52-63` — `WriteOutput()` json.Encoder.
+24. `internal/hook/registry.go:65-200` — `Dispatch()` 27 events 핸들러 디스패치.
+25. `internal/hook/registry.go:155-162` — UserPromptSubmit AdditionalContext merge.
+26. `internal/hook/registry.go:179-193` — PreToolUse PermissionDecision/Reason wiring.
+27. `.claude/hooks/moai/*.sh` — 27 wrappers (verified count via `ls`).
+28. `.moai/config/sections/system.yaml:1-27` — 본 SPEC 가 hook.strict_mode 키 추가 대상.
+29. `.claude/rules/moai/core/agent-common-protocol.md:#user-interaction-boundary` — subagent prohibition.
+30. `.claude/rules/moai/workflow/spec-workflow.md:#phase-0-5-plan-audit-gate` — plan-auditor entry condition.
+31. `CLAUDE.local.md:§6` — test isolation (`t.TempDir()` + `filepath.Abs`).
+32. `CLAUDE.local.md:§14` — no hardcoded paths in `internal/`.
+33. master `.moai/v3-redesign/r3-cc-architecture-reread.md:§2 Decision 5` — JSON-OR-exitcode adoption candidate.
+34. master `.moai/v3-redesign/r6-commands-hooks-style-rules.md:§2.2` — handler audit.
+35. master `.moai/v3-redesign/r6-commands-hooks-style-rules.md:§A` — Hook Coverage Matrix.
+
+Total: **35 distinct file:line anchors** (exceeds plan-auditor minimum of 10).
+
+---
+
+## 12. Open questions resolved during research
+
+| Question | Resolution |
+|----------|-----------|
+| Q1: `HookSpecificOutput.HookEventName` 검증 위치는 ParseHookOutput 또는 Dispatch 어디인가? | **Dispatch** — ParseHookOutput 은 wire format unmarshal 만 책임; mismatch 는 dispatched event 와의 비교이므로 registry 가 owner. |
+| Q2: deprecation banner 의 SystemMessage 경로는 stdout JSON 인가 stderr 인가? | **JSON systemMessage** — Claude Code 가 user 에게 노출. stderr 는 hook process 내부 로깅 용. |
+| Q3: 64 KiB 절단 시 `AdditionalContext` 의 어떤 부분을 보존? | **앞 64 KiB** (현재 `dual_parse.go:108-109` 의 `[:maxContextSize]` 동작 유지). 마지막 부분 보존이 의미상 중요한 use case 는 보고된 바 없음. |
+| Q4: api_version 2 의 wrapperPath 는 어떻게 ParseHookOutput 까지 전달? | **HookInput.WrapperPath** 신규 필드 (또는 환경변수 `MOAI_HOOK_WRAPPER_PATH`). 본 SPEC M5a 에서 결정 — 환경변수 방식이 wrapper code change 없이 동작하므로 우선. |
+| Q5: WatchPaths 를 SessionStart 외 다른 이벤트가 emit 가능? | **InstructionsLoaded, FileChanged 도 가능** (`response.go:198, 207` variant 가 WatchPaths 필드 보유). 본 SPEC REQ-032 는 SessionStart 만 다루지만 future expansion 은 자연스럽게 가능. |
+
+---
+
+End of research.md.

--- a/.moai/specs/SPEC-V3R2-RT-001/tasks.md
+++ b/.moai/specs/SPEC-V3R2-RT-001/tasks.md
@@ -1,0 +1,195 @@
+# SPEC-V3R2-RT-001 Task Breakdown
+
+> Granular task decomposition of M1-M5 milestones from `plan.md` §2.
+> Companion to `spec.md` v0.1.0, `research.md` v0.1.0, `plan.md` v0.1.0, `acceptance.md` v0.1.0.
+
+## HISTORY
+
+| Version | Date       | Author                            | Description                                                            |
+|---------|------------|-----------------------------------|------------------------------------------------------------------------|
+| 0.1.0   | 2026-05-10 | manager-spec (Plan workflow)      | Initial task breakdown — 31 tasks (T-RT001-01..31) across M1-M5         |
+
+---
+
+## Task ID Convention
+
+- ID format: `T-RT001-NN`
+- Priority: P0 (blocker), P1 (required), P2 (recommended), P3 (optional)
+- Owner role: `manager-tdd`, `manager-docs`, `expert-backend` (Go), `expert-testing` (테스트 케이스 설계), `manager-git` (commit/PR boundary)
+- Dependencies: explicit task ID list; tasks with no deps may run in parallel within their milestone
+- DDD/TDD alignment: per `.moai/config/sections/quality.yaml` `development_mode: tdd`, M1 (RED) precedes M2-M5 (GREEN/REFACTOR)
+
+[HARD] No time estimates per `.claude/rules/moai/core/agent-common-protocol.md` §Time Estimation. Priority + dependencies only.
+
+---
+
+## M1: Test Scaffolding (RED phase) — Priority P0
+
+Goal: 18개 새로운 실패 테스트 + 4개 신규 테스트 파일 추가. 기존 happy-path 테스트 (`dual_parse_test.go`, `response_test.go`, `wire_format_freeze_test.go`, `protocol_test.go`, `registry_test.go`, `types_test.go`) 의 GREEN baseline 보존.
+
+| ID | Subject | Owner role | File:line target | Dependency | Touch points | TDD alignment |
+|----|---------|-----------|-------------------|------------|--------------|---------------|
+| T-RT001-01 | `internal/hook/dual_parse_test.go` 확장: `TestParseHookOutput_StrictModeRejectsLegacy` 추가 (AC-06, REQ-021). strict_mode 활성 + legacy 출력 → ErrHookProtocolLegacyRejected 검증. | expert-testing | `internal/hook/dual_parse_test.go` (extend, ~30 LOC) | none | 1 file (extend) | RED — strict_mode 분기 부재 |
+| T-RT001-02 | `dual_parse_test.go` 확장: `TestParseHookOutput_MoaiHookLegacySuppressesBanner` (AC-04, REQ-020). 환경변수 `MOAI_HOOK_LEGACY=1` 시 banner 미발사 검증. `t.Setenv` 사용. | expert-testing | same file (extend, ~25 LOC) | T-RT001-01 | 1 file (extend) | RED — banner 함수 부재 |
+| T-RT001-03 | `dual_parse_test.go` 확장: `TestParseHookOutput_AdditionalContextTruncatedAt64KiB` (AC-09, REQ-022) + `TestValidateHookResponse_ExactlyAtBoundary` (boundary 65536). 128 KiB / 65536 / 65537 byte 입력. | expert-testing | same file (extend, ~50 LOC) | T-RT001-01 | 1 file (extend) | RED — truncation message 표준화 부족 |
+| T-RT001-04 | `dual_parse_test.go` 확장: `TestParseHookOutput_PluginSourceBypassesStrict` (AC-14, REQ-051). strict_mode=true + ConfigurationSource="plugin" + legacy → bypass 검증. | expert-testing | same file (extend, ~30 LOC) | T-RT001-01 | 1 file (extend) | RED — plugin bypass 분기 부재 |
+| T-RT001-05 | `dual_parse_test.go` 확장: `TestParseHookOutput_ApiVersion2SkipsExitCodeFallback` (AC-11, REQ-030). mock wrapper file + api_version 2 헤더 + 빈 stdout → explicit no-op. | expert-testing | same file (extend, ~30 LOC) | T-RT001-01 | 1 file (extend) | RED — api_version 검사 부재 |
+| T-RT001-06 | `internal/hook/response_test.go` 확장: `TestHookResponse_ValidatorRejectsBadPermissionDecision` + `TestHookResponse_ValidatorAcceptsAllowAskDenyDefer` (AC-12, REQ-002, REQ-006). `r.Validate()` non-nil error / nil error 분기. | expert-testing | `internal/hook/response_test.go` (extend, ~40 LOC) | T-RT001-01 | 1 file (extend) | RED — Validate() 메서드 부재 |
+| T-RT001-07 | `response_test.go` 확장: `TestHookResponse_27VariantHookEventNameRoundTrip` (AC-13, REQ-003, REQ-004). 27개 variant 의 marshal→unmarshal identity + HookEventName() 반환값 정확성. | expert-testing | same file (extend, ~80 LOC) | T-RT001-01 | 1 file (extend) | GREEN at baseline (variants 이미 존재) — regression sentinel |
+| T-RT001-08 | `internal/hook/registry_test.go` 확장: `TestDispatch_HookSpecificOutputMismatch` (AC-05, REQ-040). PreToolUse dispatch 중 hookEventName="PostToolUse" 응답 → mismatch 에러. | expert-testing | `internal/hook/registry_test.go` (extend, ~40 LOC) | T-RT001-01 | 1 file (extend) | RED — mismatch detection wiring 부재 |
+| T-RT001-09 | `registry_test.go` 확장: `TestDispatch_PreToolUseUpdatedInputThenPermissionDecision` (AC-10, REQ-041) + `TestDispatch_PreToolUseUpdatedInputOnly`. UpdatedInput 우선 적용 + deny 결정 ordering 검증. | expert-testing | same file (extend, ~50 LOC) | T-RT001-01 | 1 file (extend) | RED — ordering 명시 부재 |
+| T-RT001-10 | `registry_test.go` 확장: `TestDispatch_AdditionalContextRoutedToModelContext` (AC-02, REQ-012). SessionStart/UserPromptSubmit/PreToolUse/PostToolUse AdditionalContext 가 model context queue 로 전달 검증. | expert-testing | same file (extend, ~40 LOC) | T-RT001-01 | 1 file (extend) | RED — routing 부분 구현 |
+| T-RT001-11 | `registry_test.go` 확장: `TestDispatch_ContinueFalseBlocksTeammateIdle` (AC-08, REQ-014). SubagentStop + Continue:false → teammate idle blocker 검증. | expert-testing | same file (extend, ~30 LOC) | T-RT001-01 | 1 file (extend) | RED — Continue:false escalation 명시 부재 |
+| T-RT001-12 | 신규 파일 `internal/hook/strict_mode_test.go` 생성: `TestStrictMode_ConfigLoad` (system.yaml `hook.strict_mode: true` 로딩) + `TestStrictMode_ErrorReturnedOnLegacyOutput` (AC-06) + `TestIsLegacyEnvSet_LooseTruthy` (AC-04). | expert-testing | new file (~80 LOC) | T-RT001-01 | 1 file (create) | RED — strict_mode 모듈 부재 |
+| T-RT001-13 | `strict_mode_test.go` 확장: `TestStrictMode_PluginSourceBypass` (AC-14, REQ-051) + `TestIsPluginSource_NonPluginSources`. ConfigurationSource enum 5개 값 분기 검증. | expert-testing | same file (extend, ~40 LOC) | T-RT001-12 | 1 file (extend) | RED |
+| T-RT001-14 | 신규 파일 `internal/hook/banner_test.go` 생성: `TestBanner_OncePerSession` (REQ-007, REQ-050) + `TestBanner_PerSessionIsolation` (sessionID-A vs sessionID-B 격리) + `TestBanner_ConcurrentSafety` (sync.Map atomic). | expert-testing | new file (~70 LOC) | T-RT001-01 | 1 file (create) | RED — banner 모듈 부재 |
+| T-RT001-15 | `banner_test.go` 확장: `TestBanner_SuppressedByMoaiHookLegacy` (AC-04). 환경변수 + new session 시 banner 미발사 검증. | expert-testing | same file (extend, ~20 LOC) | T-RT001-14 | 1 file (extend) | RED |
+| T-RT001-16 | 신규 파일 `internal/hook/api_version_test.go` 생성: `TestApiVersion2_ParsesShellHeader` (regex match `# moai-hook-api-version: N`) + `TestApiVersion2_SkipsExitCodeFallback` (AC-11) + `TestApiVersion1_DefaultBehavior` (헤더 없는 wrapper → api_version 1). | expert-testing | new file (~60 LOC) | T-RT001-01 | 1 file (create) | RED — api_version 모듈 부재 |
+| T-RT001-17 | 신규 파일 `internal/hook/post_tool_mx_test.go` 확장 (이미 존재): `TestPostTool_RoutesMXMarkers` 5개 마커 (NOTE/WARN/ANCHOR/TODO/LEGACY) + 마커 부재 시 routing skip 검증. | expert-testing | `internal/hook/post_tool_mx_test.go` (extend, ~40 LOC) | T-RT001-01 | 1 file (extend) | RED — @MX routing point 부재 |
+| T-RT001-18 | 전체 RED 검증: `go test ./internal/hook/` 실행하여 위 18개 새 테스트 모두 실패 확인. 기존 테스트 GREEN 회귀 0 (regression sentinel). 결과를 `progress.md` 의 "M1 RED gate" 항목에 기록. | manager-tdd | n/a (verification only) | T-RT001-01..17 | 0 files | RED gate verification |
+
+**M1 priority: P0** — blocks all subsequent milestones. TDD discipline.
+
+T-RT001-01..17 는 file region 이 독립이면 parallel 가능. 동일 파일 (`dual_parse_test.go`, `response_test.go`, `registry_test.go`) 확장 작업은 sequential.
+
+---
+
+## M2: validator/v10 + HookResponse Validate() (GREEN, part 1) — Priority P0
+
+Goal: validator/v10 의존성 추가 + HookResponse 에 schema 태그 + Validate() 메서드. AC-12 GREEN.
+
+| ID | Subject | Owner role | File:line target | Dependency | Touch points | TDD alignment |
+|----|---------|-----------|-------------------|------------|--------------|---------------|
+| T-RT001-19 | `go.mod` 에 `github.com/go-playground/validator/v10` 직접 의존성 추가. `cd /Users/goos/.moai/worktrees/moai-adk/SPEC-V3R2-RT-001 && go get github.com/go-playground/validator/v10`. `go mod tidy`. | expert-backend | `go.mod`, `go.sum` (regenerated) | T-RT001-18 | 2 files (edit) | Dependency setup |
+| T-RT001-20 | `internal/hook/response.go:11-44` 에 validator 태그 추가: `PermissionDecision` → `validate:"omitempty,oneof=allow ask deny defer"`. line 64-70 `RetryHint` 에 `Attempts` → `validate:"omitempty,gte=0,lte=10"`, `Backoff` → `validate:"omitempty,oneofci=linear exponential constant"`. | expert-backend | `internal/hook/response.go` (extend, ~10 LOC) | T-RT001-19 | 1 file (edit) | GREEN — validator surface 노출 |
+| T-RT001-21 | `internal/hook/response.go` 패키지 끝에 `var validate = validator.New()` + `func (r *HookResponse) Validate() error { if r == nil { return nil }; return validate.Struct(r) }` 추가. | expert-backend | same file (extend, ~10 LOC) | T-RT001-20 | 1 file (edit) | GREEN — Validate() 메서드 |
+| T-RT001-22 | `internal/hook/dual_parse.go:88-115` `ValidateHookResponse()` 에 `r.Validate()` 호출 추가 (기존 PermissionDecision string 비교 외 추가 layer). validator error 는 offending field 명을 포함하여 wrap. | expert-backend | `internal/hook/dual_parse.go` (extend, ~10 LOC) | T-RT001-21 | 1 file (edit) | GREEN — AC-12 wiring |
+
+**M2 priority: P0** — blocks M3-M5. AC-12 GREEN. T-RT001-19 → 20 → 21 → 22 sequential.
+
+---
+
+## M3: Strict mode + MOAI_HOOK_LEGACY env + Deprecation Banner (GREEN, part 2) — Priority P0
+
+Goal: strict_mode + env opt-out + once-per-session banner. AC-04, AC-06, AC-15 GREEN.
+
+| ID | Subject | Owner role | File:line target | Dependency | Touch points | TDD alignment |
+|----|---------|-----------|-------------------|------------|--------------|---------------|
+| T-RT001-23 | 신규 파일 `internal/hook/strict_mode.go` 생성. 4개 함수: `IsStrictModeEnabled(cfg ConfigProvider) bool` / `IsLegacyEnvSet() bool` (`MOAI_HOOK_LEGACY=1\|true\|yes` loose-truthy) / `EnforceStrictMode(stdout []byte, exitCode int, input *HookInput) error` / `IsPluginSource(input *HookInput) bool` (HookInput.ConfigurationSource == "plugin"). | expert-backend | new file (~70 LOC) | T-RT001-22 | 1 file (create) | GREEN — strict_mode 모듈 |
+| T-RT001-24 | 신규 파일 `internal/hook/banner.go` 생성. `var emittedBanners sync.Map` (sessionID → bool) + `func MaybeEmitDeprecationBanner(sessionID string) (banner string, emitted bool)` (LoadOrStore atomic, MOAI_HOOK_LEGACY=1 suppress, 1회 emit). banner 텍스트: `"DEPRECATED: Hook produced exit-code-only output. Migrate to JSON output before v4.0. See https://moai.ai.kr/docs/hook-migration."`. | expert-backend | new file (~50 LOC) | T-RT001-23 | 1 file (create) | GREEN — banner 모듈 |
+| T-RT001-25 | `internal/hook/dual_parse.go:47-62` `ParseHookOutput()` 확장: 인자에 `*HookInput` 추가 (또는 `sessionID, configSource string` 분리). JSON parse 실패 분기에서 strict_mode 검사 + plugin bypass + banner emission 통합. signature 변경은 호환성을 위해 `ParseHookOutputWithContext(stdout, exitCode, stderr, input)` 새 함수로 추가하고 기존 `ParseHookOutput` 은 wrapper 로 유지. | expert-backend | `internal/hook/dual_parse.go` (extend, ~30 LOC) | T-RT001-24 | 1 file (edit) | GREEN — REQ-005, REQ-021, REQ-007, REQ-050, REQ-051 wiring |
+| T-RT001-26 | `internal/config/types.go` 에 `HookConfig{StrictMode bool}` struct 추가 (`mapstructure:"strict_mode"`, `yaml:"strict_mode"` 태그). `Config` 구조체에 `Hook HookConfig` 필드 추가. | expert-backend | `internal/config/types.go` (extend, ~10 LOC) | T-RT001-23 | 1 file (edit) | GREEN — config struct |
+| T-RT001-27 | `internal/config/loader.go` (또는 동등 sections 로더) 가 `system.yaml` 의 `hook.strict_mode` 키를 `Config.Hook.StrictMode` 에 매핑하도록 확장. 기본값 `false` (zero value). | expert-backend | `internal/config/loader.go` (extend, ~15 LOC) | T-RT001-26 | 1 file (edit) | GREEN — config 로딩 |
+| T-RT001-28 | `.moai/config/sections/system.yaml` 끝에 다음 추가:<br>```yaml\nhook:\n  strict_mode: false  # SPEC-V3R2-RT-001: opt into JSON-only enforcement; default off\n```<br>그리고 동일 내용을 `internal/template/templates/.moai/config/sections/system.yaml` 에 적용 (Template-First per `CLAUDE.local.md` §2). | expert-backend | 2 files (edit) | T-RT001-27 | 2 files (edit) | GREEN — Template-First 동기화 |
+
+**M3 priority: P0** — blocks M4. AC-04, AC-06, AC-15 GREEN. T-RT001-23, 24, 26 parallel; 25 deps on 23+24; 27 deps on 26; 28 deps on 27.
+
+[HARD] T-RT001-28 은 template 변경이므로 후속 `make build` 시 `internal/template/embedded.go` 재생성 필요 (M5e 에서).
+
+---
+
+## M4: HookSpecificOutputMismatch + UpdatedInput-then-Decision + AdditionalContext routing + Continue:false escalation (GREEN, part 3) — Priority P0
+
+Goal: registry.go Dispatch 의 4가지 의미 강화. AC-02, AC-05, AC-08, AC-09, AC-10 GREEN.
+
+| ID | Subject | Owner role | File:line target | Dependency | Touch points | TDD alignment |
+|----|---------|-----------|-------------------|------------|--------------|---------------|
+| T-RT001-29 | `internal/hook/registry.go:65-200` `Dispatch()` 에 mismatch detection 삽입. PreToolUse/PostToolUse/UserPromptSubmit/PermissionRequest 응답 후 `HookSpecificOutput.HookEventName != string(event)` 검사 (빈 값은 skip — legacy compat). 불일치 시 `&HookSpecificOutputMismatch{Expected: string(event), Actual: hookEventName}` 에러 반환 + `.moai/logs/hook.log` append (lazy file open + JSON-line format). hook 자체는 failed 처리. | expert-backend | `internal/hook/registry.go` (extend, ~30 LOC) | T-RT001-28 | 1 file (edit) | GREEN — REQ-040 |
+| T-RT001-30 | `registry.go:179-193` PreToolUse 경로 정리. 응답에 `UpdatedInput` 와 `PermissionDecision` 둘 다 있을 때 ordering: (1) UpdatedInput 을 pending tool input 에 merge → (2) PermissionDecision 평가 against updated input. 명시적 주석:<br>```go\n// SPEC-V3R2-RT-001 REQ-041: deterministic order — UpdatedInput first, then PermissionDecision\n```<br>denial message 가 post-update input 을 reference. | expert-backend | same file (extend, ~15 LOC) | T-RT001-29 | 1 file (edit) | GREEN — REQ-041, AC-10 |
+| T-RT001-31 | `registry.go:155-162` AdditionalContext merge 강화. SessionStart, UserPromptSubmit, PreToolUse, PostToolUse 응답의 AdditionalContext 를 firing order 로 누적. 누적된 텍스트는 별도 함수 `AccumulateAdditionalContext(events []*HookOutput) string` 으로 추출. model context queue 와의 interface 만 노출 (실제 큐 소비는 SPEC-V3R2-SPC-002). | expert-backend | same file + 신규 helper function (~25 LOC) | T-RT001-29 | 1 file (edit) | GREEN — REQ-012 |
+| T-RT001-32 | `registry.go` Stop / SubagentStop 경로 강화. hook 가 `Continue: false` 반환 시 (1) teammate idle 차단 (`subagent_stop.go::Handle` 와 정합), (2) orchestrator 에 BlockerReport 발행, (3) AskUserQuestion 라우팅은 orchestrator 책임 (subagent 는 직접 호출 금지). 본 작업은 registry 의 mapping 만 정확히 표현; 실제 BlockerReport 발행은 별도 SPEC (RT-004 SessionStore 통합) 에서 진행. | expert-backend | `internal/hook/registry.go` (extend, ~15 LOC) | T-RT001-30 | 1 file (edit) | GREEN — REQ-014, AC-08 |
+| T-RT001-33 | `internal/hook/dual_parse.go:88-115` `ValidateHookResponse()` 의 64 KiB 절단 메시지 정규화. 현재 `\n[Notice: additionalContext truncated from %d to %d bytes]` 를 유지하되 SystemMessage prefix 가 아닌 suffix 로 명시 (이미 그렇게 동작 중; line 110-112 의 string concat 검증). REQ-022 sentinel 정확성 보장. | expert-backend | `internal/hook/dual_parse.go` (refactor, ~5 LOC) | T-RT001-29 | 1 file (edit) | REFACTOR — REQ-022, AC-09 |
+
+**M4 priority: P0** — blocks M5. AC-02, AC-05, AC-08, AC-09, AC-10 GREEN. T-RT001-29 → 30, 31, 32 parallel; 33 independent.
+
+---
+
+## M5: api_version 2 + WatchPaths + @MX routing + plugin bypass + CHANGELOG + MX tags (GREEN, part 4 + Trackable) — Priority P1
+
+Goal: User-facing surface, future-proofing, trackability. AC-01, AC-03, AC-07, AC-11, AC-13, AC-14 GREEN.
+
+| ID | Subject | Owner role | File:line target | Dependency | Touch points | TDD alignment |
+|----|---------|-----------|-------------------|------------|--------------|---------------|
+| T-RT001-34 | 신규 파일 `internal/hook/api_version.go` 생성. 2개 함수:<br>- `ReadHookApiVersion(wrapperPath string) (int, error)`: 첫 30 줄 내 정규식 `^#\s*moai-hook-api-version:\s*(\d+)\s*$` 매칭, 미매칭 시 default 1.<br>- `ShouldSkipExitCodeFallback(wrapperPath string) bool`: api_version >= 2 시 true. | expert-backend | new file (~50 LOC) | T-RT001-32 | 1 file (create) | GREEN — REQ-030, AC-11 |
+| T-RT001-35 | `internal/hook/dual_parse.go` `ParseHookOutputWithContext` 확장. wrapperPath 인자 (또는 환경변수 `MOAI_HOOK_WRAPPER_PATH`) 가 제공되면 `ShouldSkipExitCodeFallback` 호출. true + 빈 stdout 이면 explicit no-op `&HookResponse{}` 반환 (NO synthesizeFromExitCode). | expert-backend | `internal/hook/dual_parse.go` (extend, ~15 LOC) | T-RT001-34 | 1 file (edit) | GREEN — AC-11 |
+| T-RT001-36 | 신규 파일 `internal/hook/watch_paths.go` 생성. `type WatchPathsRegistrar interface { Register(paths []string) error }`. nil-safe wrapping (registrar 가 nil 이면 graceful no-op + warn log). Registry 에 `WithWatchPathsRegistrar(r WatchPathsRegistrar)` 옵션 함수 노출. | expert-backend | new file (~30 LOC) | T-RT001-32 | 1 file (create) | GREEN — REQ-032 |
+| T-RT001-37 | `internal/hook/session_start.go` 의 SessionStart handler 가 `HookResponse.WatchPaths` 를 emit 하면 `WatchPathsRegistrar.Register(paths)` 호출 (nil 인 경우 graceful skip). 본 SPEC 는 contract 만 노출; 실제 file-system watcher 구현은 별도 SPEC. | expert-backend | `internal/hook/session_start.go` (extend, ~15 LOC) | T-RT001-36 | 1 file (edit) | GREEN — REQ-032 wiring |
+| T-RT001-38 | `internal/hook/post_tool.go` PostToolUse handler 확장. `HookResponse.AdditionalContext` 가 5개 마커 (`@MX:NOTE`, `@MX:WARN`, `@MX:ANCHOR`, `@MX:TODO`, `@MX:LEGACY`) 중 하나라도 포함하면 `internal/hook/mx/ingest.go` (이미 존재) 의 ingestion 함수에 forward. 본 SPEC 는 routing point 만; 의미론은 SPEC-V3R2-SPC-002. | expert-backend | `internal/hook/post_tool.go` (extend, ~20 LOC) | T-RT001-32 | 1 file (edit) | GREEN — REQ-016, AC-07 |
+| T-RT001-39 | CHANGELOG entry 추가. `## [Unreleased] / ### Changed (BREAKING — BC-V3R2-001)` 섹션 (없으면 신규 추가) 아래:<br>```markdown\n- SPEC-V3R2-RT-001: Hook output protocol now follows Claude Code 2026.x JSON-OR-ExitCode dual contract. JSON output is parsed first; exit-code semantics remain as v3.x deprecation-window fallback. New `hook.strict_mode` config (default `false`) opts into JSON-only enforcement. New `MOAI_HOOK_LEGACY=1` opt-out for CI/air-gapped installs. Deprecation banner emits once per session per project. Wrappers unchanged; handlers rewritten. Removal of exit-code-only path deferred to v4.0.\n``` | manager-docs | `CHANGELOG.md` (extend, ~7 LOC) | T-RT001-38 | 1 file (edit) | Trackable |
+| T-RT001-40 | MX 태그 7개 삽입 per `plan.md` §6: 3 ANCHOR (`dual_parse.go:47` ParseHookOutput, `response.go:11` HookResponse, `registry.go:65` Dispatch) + 2 NOTE (`strict_mode.go` EnforceStrictMode, `banner.go` MaybeEmitDeprecationBanner) + 2 WARN (`dual_parse.go:64` synthesizeFromExitCode, `registry.go` mismatch detection insertion). 태그 본문은 `plan.md` §6 verbatim. | manager-docs | 5 files (edit, MX 태그 삽입) | T-RT001-39 | 5 files (edit) | Trackable — plan §6 |
+| T-RT001-41 | `make build` 을 worktree root 에서 실행. `internal/template/embedded.go` 재생성 검증 — `system.yaml` template 변경 (T-RT001-28) 만 diff scope (다른 .claude/ 변경 없음). | manager-docs | `internal/template/embedded.go` (regenerated) | T-RT001-40 | 1 file (regenerated) | Build verification |
+| T-RT001-42 | 전체 `go test ./...` 을 worktree root 에서 실행. 모든 audit / wire-format / dual-parse / strict-mode / banner / api-version / registry 테스트 PASS + 0 cascading regression (per `CLAUDE.local.md` §6 HARD). `go vet ./...` + `golangci-lint run` 경고 0. | manager-tdd | n/a (verification only) | T-RT001-41 | 0 files | GREEN gate (final) |
+| T-RT001-43 | `progress.md` 업데이트: `run_complete_at: <timestamp>` + `run_status: implementation-complete`. ACs 통과 수 (15/15) + new tests (~28) + MX tags (7) + PR number 채움. | manager-docs | `progress.md` (extend) | T-RT001-42 | 1 file (edit) | Trackable closure |
+
+**M5 priority: P1** — completes the SPEC. AC-01, AC-03, AC-07, AC-11, AC-13, AC-14 GREEN.
+
+T-RT001-34, 36, 38 parallel. T-RT001-35 deps 34. T-RT001-37 deps 36. T-RT001-39 → 40 → 41 → 42 → 43 sequential.
+
+---
+
+## Task summary by milestone
+
+| Milestone | Task IDs | Total tasks | Priority | Owner role mix |
+|-----------|----------|-------------|----------|----------------|
+| M1 (RED) | T-RT001-01..18 | 18 | P0 | expert-testing (17) + manager-tdd (1 verification) |
+| M2 (GREEN part 1) | T-RT001-19..22 | 4 | P0 | expert-backend |
+| M3 (GREEN part 2) | T-RT001-23..28 | 6 | P0 | expert-backend |
+| M4 (GREEN part 3) | T-RT001-29..33 | 5 | P0 | expert-backend |
+| M5 (GREEN part 4 + REFACTOR + Trackable) | T-RT001-34..43 | 10 | P1 | expert-backend (5) + manager-docs (4) + manager-tdd (1 verification) |
+| **TOTAL** | T-RT001-01..43 | **43 tasks** | — | — |
+
+> NOTE: 43 tasks span the 5 milestones. M1 (RED) opens with 18 test-only tasks; M2-M4 (GREEN core) deliver the dual-protocol subsystem in 15 tasks; M5 (final GREEN + REFACTOR + Trackable) closes with 10 tasks of CLI/CHANGELOG/MX/build/verify.
+
+---
+
+## Dependency graph (critical path)
+
+```
+T-RT001-01..17 (M1 tests, parallel within file regions)
+   ↓
+T-RT001-18 (M1 verification gate — 18 RED + 0 regression)
+   ↓
+T-RT001-19 (go.mod validator/v10) → T-RT001-20 (response.go 태그) → T-RT001-21 (Validate 메서드) → T-RT001-22 (dual_parse 통합)
+   ↓
+T-RT001-23, 24, 26 (M3 parallel)
+   ↓
+T-RT001-25 (ParseHookOutputWithContext)
+T-RT001-27 (loader 확장) → T-RT001-28 (system.yaml + template)
+   ↓
+T-RT001-29 (mismatch detection) → T-RT001-30, 31, 32 (parallel)
+T-RT001-33 (truncation refactor, parallel from 29)
+   ↓
+T-RT001-34, 36, 38 (M5 core parallel)
+T-RT001-35 (api_version wiring) deps 34
+T-RT001-37 (WatchPaths wiring) deps 36
+   ↓
+T-RT001-39 (CHANGELOG) → T-RT001-40 (7 MX tags) → T-RT001-41 (make build) → T-RT001-42 (go test full + vet + lint) → T-RT001-43 (progress.md closure)
+```
+
+Critical path: T-RT001-18 → 19 → 20 → 21 → 22 → 25 → 28 → 29 → 30 → 35 → 39 → 40 → 41 → 42 → 43 (15 sequential gates).
+
+---
+
+## Cross-task constraints
+
+[HARD] All file edits use absolute paths under the worktree root `/Users/goos/.moai/worktrees/moai-adk/SPEC-V3R2-RT-001` per CLAUDE.md §Worktree Isolation Rules.
+
+[HARD] All tests use `t.TempDir()` per `CLAUDE.local.md` §6 — no test creates files in the project root. environment 검사 테스트는 `t.Setenv` 사용.
+
+[HARD] All filesystem operations use `filepath.Join` / `filepath.Abs`; no `filepath.Join(cwd, absPath)` patterns per `CLAUDE.local.md` §6.
+
+[HARD] No new direct module dependencies beyond `github.com/go-playground/validator/v10` (added by T-RT001-19; SCH-001 후속 머지 시 dedup).
+
+[HARD] No `.claude/hooks/moai/*.sh` 파일 수정 — wrappers-unchanged 정책. master §8 BC-V3R2-001 의 핵심 약속.
+
+[HARD] Code comments in Korean (per `.moai/config/sections/language.yaml` `code_comments: ko`). Godoc / 외부 노출 식별자 docstring 은 영어 유지 (industry standard).
+
+[HARD] Commit messages in Korean (per `.moai/config/sections/language.yaml` `git_commit_messages: ko`).
+
+[HARD] Subagent (manager-tdd, expert-backend, expert-testing, manager-docs) 는 `AskUserQuestion` 직접 호출 금지. user 결정 필요 시 BlockerReport 형태로 orchestrator 에 반환 (per agent-common-protocol.md §User Interaction Boundary).
+
+[HARD] `CHANGELOG.md` entry 는 BREAKING 라벨 + BC-V3R2-001 명시 + v4.0 sunset note 포함.
+
+---
+
+End of tasks.md.


### PR DESCRIPTION
## Summary

5-milestone plan for SPEC-V3R2-RT-001 (Hook JSON-OR-ExitCode Dual Protocol). Wave 12 breaking-change SPEC adopting Claude Code's JSON-OR-ExitCode hook contract as moai's native protocol for all 27 hook events.

## Plan Deliverables (6 files in `.moai/specs/SPEC-V3R2-RT-001/`)

| File | Size | Content |
|------|------|---------|
| plan.md | 45 KB | M1-M5, 25 REQ → 15 AC → 43 tasks, 7 MX tag insertions, 15/15 PASS |
| research.md | 30 KB | 12 sections, existing infrastructure inventory + 7 missing pieces |
| acceptance.md | 23 KB | 15 ACs in G/W/T format, 28 new test functions |
| tasks.md | 25 KB | 43 tasks (T-RT001-01..43) with critical path graph |
| progress.md | 6 KB | Paste-ready Block 0 worktree resume |
| issue-body.md | 11 KB | BC-V3R2-001 user-impact matrix |

## Breaking Change

[HARD] BC-V3R2-001 invoked. Strategy: wrappers-unchanged + handlers-rewritten.
- 26 shell wrappers in `.claude/hooks/moai/` preserved
- All 27 handlers in `internal/hook/*.go` rewritten to emit typed `HookResponse`
- Dual-parse fallback to legacy exit codes during alpha.2 → rc.2
- Removal of exit-code-only parsing deferred to v4.0

## Dependencies

- SPEC-V3R2-CON-001 (Constitution v3) — merged
- SPEC-V3R2-RT-005 (Settings reader) — Wave 12 sibling, this PR

## Test Plan

- [ ] plan-auditor verification (score ≥ 0.85)
- [ ] CI: Lint / Test ubuntu/macos/windows / Build 5 / CodeQL / Constitution Check / Integration Tests
- [ ] No code changes (plan-only PR — Run phase deferred)

🗿 MoAI <email@mo.ai.kr>