### PR TITLE
plan(spec): SPEC-V3R2-RT-002 — Permission Stack + Bubble Mode

### DIFF
--- a/.moai/specs/SPEC-V3R2-RT-002/acceptance.md
+++ b/.moai/specs/SPEC-V3R2-RT-002/acceptance.md
@@ -1,0 +1,583 @@
+# SPEC-V3R2-RT-002 Acceptance Criteria — Given/When/Then
+
+> Detailed acceptance scenarios for each AC declared in `spec.md` §6.
+> Companion to `spec.md` v0.1.0, `research.md` v0.1.0, `plan.md` v0.1.0, `tasks.md` v0.1.0.
+
+## HISTORY
+
+| Version | Date       | Author                        | Description                                                            |
+|---------|------------|-------------------------------|------------------------------------------------------------------------|
+| 0.1.0   | 2026-05-10 | manager-spec (Plan workflow)  | Initial G/W/T conversion of 15 ACs (AC-V3R2-RT-002-01 through -15)     |
+
+---
+
+## Scope
+
+본 문서는 `spec.md` §6 의 15 AC 를 Given/When/Then 형식으로 변환합니다. 각 AC 는 happy-path + edge-case + test-mapping 표기를 포함.
+
+표기 약속:
+- **Test mapping** 은 어떤 Go test function (or manual verification step) 이 AC 를 cover 하는지 명시.
+- **Sentinel** 은 negative path 에서 test 가 기대하는 literal error 또는 systemMessage 문자열.
+
+---
+
+## AC-V3R2-RT-002-01 — SrcProject deny rule wins over lower tiers
+
+Maps to: REQ-V3R2-RT-002-004, REQ-V3R2-RT-002-005.
+
+### Happy path
+
+- **Given** a `RulesByTier` populated with one rule at `SrcProject`: `{Pattern: "Bash(rm*:*)", Action: DecisionDeny, Source: SrcProject, Origin: ".claude/settings.json"}`
+- **And** all other tiers (SrcPolicy/User/Local/Plugin/Skill/Session/Builtin) empty
+- **When** `Resolve("Bash", []byte("rm -rf /"), ResolveContext{Mode: ModeDefault, IsInteractive: true})` is called
+- **Then** the result has `Decision == DecisionDeny`
+- **And** `ResolvedBy == config.SrcProject`
+- **And** `Origin == ".claude/settings.json"`
+- **And** `Trace.Tries[<idx>].Tier == SrcProject` and `Trace.Tries[<idx>].Matched == true`
+
+### Edge case — multiple tiers all match
+
+- **Given** identical pattern at SrcUser (allow) AND SrcProject (deny) AND SrcLocal (allow)
+- **When** Resolve is called
+- **Then** `ResolvedBy == SrcUser` (highest priority among matchers)
+- **And** the result is `DecisionAllow` (SrcUser 의 action)
+
+### Test mapping
+
+- `internal/permission/resolver_test.go::TestResolve_SrcProjectDenyWins` (existing baseline; verify Origin assertion)
+- `internal/permission/resolver_test.go::TestResolve_HigherTierWinsOverLower` (existing/extend)
+
+---
+
+## AC-V3R2-RT-002-02 — Pre-allowlist resolves go test to allow
+
+Maps to: REQ-V3R2-RT-002-006.
+
+### Happy path
+
+- **Given** an empty `RulesByTier` (no user-defined rules in any tier)
+- **When** `Resolve("Bash", []byte("go test ./..."), ResolveContext{Mode: ModeDefault, IsInteractive: true})` is called
+- **Then** the result has `Decision == DecisionAllow`
+- **And** `ResolvedBy == config.SrcBuiltin`
+- **And** `Origin == "pre-allowlist"`
+
+### Edge case — pre-allowlist 8 patterns
+
+- **Given** the same empty RulesByTier
+- **When** Resolve is called for each of: `Read("foo")`, `Glob("*.go")`, `Grep("pattern")`, `Bash("go test ...")`, `Bash("golangci-lint run")`, `Bash("ruff check .")`, `Bash("npm test")`, `Bash("pytest tests/")`
+- **Then** all 8 calls return `Decision == DecisionAllow` with `ResolvedBy == SrcBuiltin` and `Origin == "pre-allowlist"`
+
+### Edge case — pre-allowlist 미커버 input
+
+- **Given** the same empty RulesByTier
+- **When** Resolve is called for `Bash("rm test.txt")` (write op, not in allowlist)
+- **Then** the result is `DecisionAsk` with `Origin == "no matching rule (default)"`
+
+### Test mapping
+
+- `internal/permission/resolver_test.go::TestResolve_PreAllowlistGoTest` (existing baseline)
+- `internal/permission/resolver_test.go::TestResolve_PreAllowlistAllPatterns` (extend, M2)
+- `internal/permission/resolver_test.go::TestResolve_NotInAllowlistDefaultsToAsk` (existing/extend)
+
+---
+
+## AC-V3R2-RT-002-03 — Bubble routes Write prompt to parent session
+
+Maps to: REQ-V3R2-RT-002-012.
+
+### Happy path
+
+- **Given** a fork agent spawned with `permissionMode: bubble` under a parent terminal session
+- **And** ResolveContext: `{Mode: ModeBubble, IsFork: true, ParentAvailable: true, ForkDepth: 1}`
+- **And** `RulesByTier` contains a rule at SrcProject: `{Pattern: "Write(/tmp/*)", Action: DecisionAsk, Source: SrcProject, Origin: ".claude/settings.json"}`
+- **When** `Resolve("Write", []byte("/tmp/test.txt"), ctx)` is called
+- **Then** the result has `Decision == DecisionAsk`
+- **And** `SystemMessage == "Bubble mode: routing to parent session"`
+- **And** the bubble dispatch contract is invoked (in production: parent's AskUserQuestion channel; in test: assert ShouldBubble(...) returns true)
+
+### Edge case — fork without parent
+
+- **Given** the same fork agent
+- **And** `ResolveContext{IsFork: true, ParentAvailable: false}`
+- **When** Resolve is called
+- **Then** the result is `DecisionDeny` with `SystemMessage == "Bubble target parent unavailable — decision deferred"`
+
+### Edge case — non-fork in bubble mode
+
+- **Given** `ResolveContext{Mode: ModeBubble, IsFork: false}` (top-level session in bubble mode — uncommon but valid)
+- **When** Resolve is called for a rule with `DecisionAsk`
+- **Then** routing is NOT triggered (ShouldBubble returns false because IsFork=false)
+- **And** the prompt appears in the current session's own AskUserQuestion channel
+
+### Test mapping
+
+- `internal/permission/bubble_test.go::TestBubbleDispatcher_ShouldBubble_ForkWithParent` (existing)
+- `internal/permission/resolver_test.go::TestResolve_BubbleParentClosed` (new, M1)
+- `internal/permission/resolver_test.go::TestResolve_BubbleNonFork` (new, M1)
+
+---
+
+## AC-V3R2-RT-002-04 — Hook PermissionDecision overrides session/skill/builtin
+
+Maps to: REQ-V3R2-RT-002-011.
+
+### Happy path
+
+- **Given** PreToolUse hook returns `HookResponse{PermissionDecision: "allow"}`
+- **And** `RulesByTier[SrcSession]` contains `{Pattern: "Bash(*)", Action: DecisionDeny, ...}` (would normally deny)
+- **When** Resolve is called with `ResolveContext{HookResponse: hookResp}`
+- **Then** the result has `Decision == DecisionAllow`
+- **And** `ResolvedBy == config.SrcBuiltin` (hooks recorded under SrcBuiltin tier)
+- **And** `Origin == "PreToolUse hook"`
+- **And** the SrcSession deny rule is NOT consulted (hook overlay short-circuits the walk)
+
+### Edge case — hook returns deny
+
+- **Given** the same setup
+- **And** hook returns `PermissionDecision: "deny"`
+- **And** `RulesByTier[SrcUser]` contains an allow rule
+- **When** Resolve is called
+- **Then** the result is `DecisionDeny` with `Origin == "PreToolUse hook"`
+- **And** the SrcUser allow rule does NOT override (hook overlay wins)
+
+### Edge case — hook returns ask
+
+- **Given** hook returns `PermissionDecision: "ask"` and IsInteractive=true
+- **When** Resolve is called
+- **Then** the result is `DecisionAsk` with `Origin == "PreToolUse hook"`
+
+### Test mapping
+
+- `internal/permission/resolver_test.go::TestResolve_HookOverridesAllTiers` (existing baseline)
+- `internal/permission/resolver_test.go::TestResolve_HookDecisionDeny` (existing/extend)
+
+---
+
+## AC-V3R2-RT-002-05 — `moai doctor permission --trace` emits 8-tier JSON
+
+Maps to: REQ-V3R2-RT-002-007, REQ-V3R2-RT-002-015.
+
+### Happy path
+
+- **Given** `RulesByTier` populated with rules at SrcUser (`Bash(go build:*)` allow) and SrcBuiltin (pre-allowlist)
+- **When** the user runs `moai doctor permission --tool Bash --input "go build" --trace`
+- **Then** stdout contains a JSON section labelled `--- Resolution Trace (JSON) ---`
+- **And** the JSON is parseable (`json.Unmarshal` returns nil error)
+- **And** the JSON's `tries[]` array enumerates all tiers visited until first match (in this case, SrcPolicy missed → SrcUser matched → walk halts)
+- **And** each `tries[]` entry has `tier`, `matched: true|false`, `rule` (if matched), `reason`
+
+### Edge case — `--all-tiers` flag
+
+- **Given** the same setup
+- **When** the user runs `moai doctor permission --all-tiers --tool Bash --input "go build"`
+- **Then** stdout dumps all rules from all 8 tiers (regardless of match)
+- **And** human-readable format is used (multi-line, indented)
+
+### Edge case — non-matching input
+
+- **Given** `RulesByTier` is empty (only pre-allowlist active)
+- **When** `moai doctor permission --tool Bash --input "rm -rf /" --trace`
+- **Then** the JSON's `tries[]` enumerates all 8 tiers with `matched: false`
+- **And** the final `Decision == DecisionAsk` (or DecisionDeny in non-interactive)
+- **And** `Origin == "no matching rule (default)"`
+
+### Test mapping
+
+- `internal/cli/doctor_permission_test.go::TestDoctorPermission_TraceJSONFormat` (new, M1)
+- `internal/cli/doctor_permission_test.go::TestDoctorPermission_AllTiersFlag` (new, M1)
+- `internal/cli/doctor_permission_test.go::TestDoctorPermission_NoMatchTrace` (new, M5)
+
+---
+
+## AC-V3R2-RT-002-06 — Plan mode denies Write regardless of allowlist
+
+Maps to: REQ-V3R2-RT-002-020.
+
+### Happy path
+
+- **Given** `RulesByTier[SrcUser]` contains a rule explicitly allowing `Write(*)` 
+- **And** `ResolveContext{Mode: ModePlan}`
+- **When** `Resolve("Write", []byte("/tmp/x"), ctx)` is called
+- **Then** the result has `Decision == DecisionDeny`
+- **And** `Origin == "plan mode denies writes"`
+- **And** `SystemMessage == "plan mode denies writes"`
+- **And** the SrcUser allow rule is NOT consulted (plan mode short-circuits)
+
+### Edge case — plan mode + Read tool
+
+- **Given** `ResolveContext{Mode: ModePlan}`
+- **When** `Resolve("Read", []byte("/tmp/x"), ctx)` is called
+- **Then** the result is `DecisionAllow` (Read is not a write op; pre-allowlist matches)
+
+### Edge case — plan mode + Bash with non-write command
+
+- **Given** `ResolveContext{Mode: ModePlan}`
+- **When** `Resolve("Bash", []byte("ls -la"), ctx)` is called
+- **Then** the result is `DecisionAsk` (no write detected; falls through 8-tier walk; no rule matches → default ask)
+
+### Test mapping
+
+- `internal/permission/resolver_test.go::TestResolve_PlanModeDeniesWrite` (existing baseline)
+- `internal/permission/resolver_test.go::TestResolve_PlanModeAllowsRead` (existing/extend)
+
+---
+
+## AC-V3R2-RT-002-07 — `bypassPermissions` rejected in strict_mode
+
+Maps to: REQ-V3R2-RT-002-022.
+
+### Happy path
+
+- **Given** `.moai/config/sections/security.yaml` has `permission.strict_mode: true`
+- **And** an agent is spawned with `permissionMode: bypassPermissions`
+- **When** the spawn entry point calls `RejectIfStrict(ModeBypassPermissions, true)` (or `resolver.ValidateMode(ModeBypassPermissions, false, true, 0)`)
+- **Then** the call returns an error with sentinel `permission mode rejected: bypassPermissions not allowed in strict mode`
+- **And** the agent spawn aborts before any tool invocation
+
+### Edge case — strict_mode false (default)
+
+- **Given** `permission.strict_mode: false`
+- **And** the same spawn with bypassPermissions
+- **When** RejectIfStrict is called
+- **Then** the call returns nil (no error)
+- **And** the agent spawns normally; subsequent Resolve calls short-circuit to allow
+
+### Edge case — strict_mode true + ModeAcceptEdits
+
+- **Given** `permission.strict_mode: true`
+- **And** spawn with `permissionMode: acceptEdits` (not bypassPermissions)
+- **When** RejectIfStrict is called
+- **Then** the call returns nil (acceptEdits is allowed under strict_mode)
+
+### Test mapping
+
+- `internal/permission/spawn_test.go::TestRejectIfStrict_RejectsBypass` (new, M2)
+- `internal/permission/spawn_test.go::TestRejectIfStrict_AllowsAcceptEdits` (new, M2)
+- `internal/permission/resolver_test.go::TestResolve_BypassPermissionsRejectedInStrictMode` (new, M1)
+
+---
+
+## AC-V3R2-RT-002-08 — Bubble parent unavailable causes deny
+
+Maps to: REQ-V3R2-RT-002-050.
+
+### Happy path
+
+- **Given** a fork agent in `ModeBubble` with `IsFork: true, ParentAvailable: false` (parent terminal session closed)
+- **And** `RulesByTier[SrcProject]` matches with `Action: DecisionAsk`
+- **When** `Resolve("Bash", []byte("git push"), ctx)` is called
+- **Then** the result has `Decision == DecisionDeny`
+- **And** `SystemMessage == "Bubble target parent unavailable — decision deferred"`
+- **And** no AskUserQuestion is dispatched
+
+### Edge case — pre-allowlist match still allows
+
+- **Given** the same fork+ParentAvailable=false
+- **When** `Resolve("Read", []byte("file.go"), ctx)` is called
+- **Then** the result is `DecisionAllow` (pre-allowlist matches before reaching ask path)
+
+### Edge case — fork transitions to live parent mid-session
+
+- **Given** ParentAvailable transitions from false to true between two Resolve calls
+- **When** the second call is made
+- **Then** the second call routes normally to parent (current ResolveContext value is consulted, not cached)
+
+### Test mapping
+
+- `internal/permission/resolver_test.go::TestResolve_BubbleParentClosed` (new, M1)
+- `internal/permission/bubble_test.go::TestIsParentAvailable_EmptyID` (existing baseline)
+
+---
+
+## AC-V3R2-RT-002-09 — Frontmatter strict-validation rejects unknown permissionMode
+
+Maps to: REQ-V3R2-RT-002-008.
+
+### Happy path
+
+- **Given** an agent file `.claude/agents/moai/<name>.md` with frontmatter `permissionMode: ultra-bypass`
+- **When** CI runs `go test ./internal/template/ -run TestAgentFrontmatter_PermissionModeStrictEnum`
+- **Then** the test fails with sentinel `PERMISSION_MODE_UNKNOWN_VALUE: <file> declares permissionMode: ultra-bypass; allowed: default|acceptEdits|bypassPermissions|plan|bubble.`
+
+### Edge case — frontmatter omits permissionMode
+
+- **Given** an agent file with no `permissionMode` key in frontmatter
+- **When** the audit test runs
+- **Then** the agent is implicitly `default` and the test passes (no error)
+
+### Edge case — all 5 valid values
+
+- **Given** five agent files each declaring one of: `default`, `acceptEdits`, `bypassPermissions`, `plan`, `bubble`
+- **When** the audit test runs
+- **Then** all 5 pass without error
+
+### Edge case — markdown body example
+
+- **Given** an agent file with no frontmatter `permissionMode` but a markdown code block in body containing `permissionMode: example` (illustration)
+- **When** the audit test runs
+- **Then** the body is NOT scanned (walker only inspects frontmatter delimiter `---` block)
+- **And** the test passes
+
+### Test mapping
+
+- `internal/template/agent_frontmatter_audit_test.go::TestAgentFrontmatter_PermissionModeStrictEnum` (new, M2)
+
+---
+
+## AC-V3R2-RT-002-10 — Hook UpdatedInput re-matches against mutated path
+
+Maps to: REQ-V3R2-RT-002-013.
+
+### Happy path
+
+- **Given** PreToolUse hook returns `HookResponse{UpdatedInput: []byte("/safe/path")}` (no PermissionDecision)
+- **And** original input is `/dangerous/path`
+- **And** `RulesByTier[SrcProject]` contains rule `{Pattern: "Write(/safe/*)", Action: DecisionAllow}`
+- **When** Resolve is called with original input `[]byte("/dangerous/path")`
+- **Then** the resolver re-runs Resolve internally with the mutated input `/safe/path`
+- **And** the rule matches the mutated path → `Decision == DecisionAllow`
+- **And** result.UpdatedInput equals `[]byte("/safe/path")` (preserved for downstream)
+- **And** `ResolvedBy == SrcProject`
+
+### Edge case — hook UpdatedInput does NOT match any rule
+
+- **Given** hook mutates input to `/elsewhere/path` which matches no allowlist rule
+- **When** Resolve re-runs
+- **Then** the result is `DecisionAsk` with `Origin == "no matching rule (default)"`
+
+### Edge case — nested mutation prevented
+
+- **Given** hook A returns UpdatedInput; resolver re-runs; hypothetically a chained hook B would mutate further
+- **When** Resolve is re-invoked with `newCtx.HookResponse = nil` (explicit clear)
+- **Then** no second mutation occurs (hook re-entry blocked by nil-clear at line 149 of resolver.go)
+- **And** the test verifies single re-execution only
+
+### Test mapping
+
+- `internal/permission/resolver_test.go::TestResolve_HookUpdatedInputReMatch` (new, M1)
+- `internal/permission/resolver_test.go::TestResolve_HookUpdatedInputNoLoop` (new, M3)
+
+---
+
+## AC-V3R2-RT-002-11 — Legacy `bypassPermissions` action migrated with deprecation warning
+
+Maps to: REQ-V3R2-RT-002-040.
+
+### Happy path
+
+- **Given** a v2 settings file at `.claude/settings.json` (or `.moai/settings.json`) contains a rule:
+  ```json
+  {"pattern": "Bash(*)", "action": "bypassPermissions", "origin": ".claude/settings.json"}
+  ```
+- **When** the loader reads the rule and calls `MigrateLegacyBypassRules([]PermissionRule{rule})`
+- **Then** the returned rule list has the rule with `Action == DecisionAllow` (mapped from action="bypassPermissions" → effective allow)
+- **And** the returned warnings slice contains an entry naming `.claude/settings.json` with deprecation message
+- **And** stderr emits the deprecation warning at first read
+- **And** `.moai/logs/permission.log` contains the same warning entry
+
+### Edge case — no legacy rules present
+
+- **Given** all rules use modern actions (`allow`, `ask`, `deny`)
+- **When** MigrateLegacyBypassRules is called
+- **Then** the returned warnings slice is empty
+- **And** no log entry is added
+
+### Edge case — multiple legacy rules
+
+- **Given** 3 rules with `action: bypassPermissions` from different files
+- **When** MigrateLegacyBypassRules is called
+- **Then** all 3 rules are migrated to `Action: DecisionAllow`
+- **And** 3 distinct warnings are returned (one per origin file)
+
+### Test mapping
+
+- `internal/permission/migration_test.go::TestMigrateLegacyBypassRules_HappyPath` (new, M5b)
+- `internal/permission/migration_test.go::TestMigrateLegacyBypassRules_NoLegacy` (new, M5b)
+- `internal/permission/migration_test.go::TestMigrateLegacyBypassRules_MultipleOrigins` (new, M5b)
+
+---
+
+## AC-V3R2-RT-002-12 — Same-tier conflict resolves by specificity then fs-order
+
+Maps to: REQ-V3R2-RT-002-042.
+
+### Happy path
+
+- **Given** two rules at the same `SrcLocal` tier match `Bash(git push origin main)`:
+  - Rule A: `{Pattern: "Bash(git push*)", Action: DecisionAllow, Origin: "/path/a/settings.local.json"}`
+  - Rule B: `{Pattern: "Bash(git push origin main)", Action: DecisionDeny, Origin: "/path/b/settings.local.json"}`
+- **When** Resolve is called for `Bash("git push origin main")`
+- **Then** Rule B wins (more specific — fewer wildcards)
+- **And** the result has `Decision == DecisionDeny` with `Origin == "/path/b/settings.local.json"`
+- **And** `.moai/logs/permission.log` contains a conflict log entry naming both rules
+
+### Edge case — equal specificity, fs-order tiebreak
+
+- **Given** two rules with identical specificity (both have one wildcard) but different file origins:
+  - Rule A: `Origin == "/zzz/last.json"` (lexicographic last)
+  - Rule B: `Origin == "/aaa/first.json"` (lexicographic first)
+- **When** Resolve is called and both match
+- **Then** Rule A wins (per spec.md REQ-042: "the rule whose Origin file path comes later in filesystem scan order SHALL win")
+- **And** the conflict is logged
+
+### Edge case — no conflict (single match)
+
+- **Given** only one rule matches in a tier
+- **When** Resolve is called
+- **Then** the single rule is returned without conflict resolution
+- **And** no log entry is added (conflict log only fires on ≥2 matches)
+
+### Test mapping
+
+- `internal/permission/conflict_test.go::TestResolveConflict_SpecificityWins` (new, M3)
+- `internal/permission/conflict_test.go::TestResolveConflict_FsOrderTiebreak` (new, M3)
+- `internal/permission/conflict_test.go::TestResolveConflict_SingleMatchNoLog` (new, M3)
+
+---
+
+## AC-V3R2-RT-002-13 — Policy tier deny overrides project allow
+
+Maps to: REQ-V3R2-RT-002-014.
+
+### Happy path
+
+- **Given** `RulesByTier[SrcPolicy]` contains `{Pattern: "Bash(curl:*)", Action: DecisionDeny, Origin: "/etc/moai/policy.json"}`
+- **And** `RulesByTier[SrcProject]` contains `{Pattern: "Bash(curl:*)", Action: DecisionAllow, Origin: ".claude/settings.json"}`
+- **When** Resolve is called for `Bash("curl -X POST ...")`
+- **Then** the result has `Decision == DecisionDeny`
+- **And** `ResolvedBy == config.SrcPolicy`
+- **And** `Origin == "/etc/moai/policy.json"`
+- **And** the SrcProject rule is recorded in trace as `tier: SrcProject, matched: true (but lower priority)` — but actually, since SrcPolicy matches first, the walk halts
+
+### Edge case — only SrcProject has rule
+
+- **Given** SrcPolicy is empty and SrcProject has the same allow rule
+- **When** Resolve is called
+- **Then** the result is `DecisionAllow` from SrcProject
+
+### Test mapping
+
+- `internal/permission/resolver_test.go::TestResolve_PolicyDenyOverridesProjectAllow` (new, M1)
+- `internal/permission/resolver_test.go::TestResolve_HigherTierWinsOverLower` (existing/extend)
+
+---
+
+## AC-V3R2-RT-002-14 — Fork at depth 4 degrades non-plan modes to bubble
+
+Maps to: REQ-V3R2-RT-002-023.
+
+### Happy path
+
+- **Given** `ResolveContext{Mode: ModeAcceptEdits, IsFork: true, ForkDepth: 4}` (depth exceeds limit)
+- **When** Resolve is called for any tool
+- **Then** the result has `Decision == DecisionAsk`
+- **And** `ResolvedBy == config.SrcBuiltin`
+- **And** `Origin == "fork depth limit"`
+- **And** `SystemMessage == "Fork depth 4 exceeds limit - mode degraded to bubble"`
+- **And** the 8-tier walk is short-circuited (does not consult any rule)
+
+### Edge case — depth exactly 3 (boundary)
+
+- **Given** `ForkDepth: 3` (at limit but not exceeding)
+- **When** Resolve is called
+- **Then** the depth gate does NOT trigger (boundary is `> 3`)
+- **And** the 8-tier walk proceeds normally
+
+### Edge case — depth 4 with ModePlan
+
+- **Given** `ForkDepth: 4, Mode: ModePlan`
+- **When** Resolve is called for `Write(/tmp/x)`
+- **Then** the depth gate is bypassed (ModePlan exempt)
+- **And** the result is `DecisionDeny` with `Origin == "plan mode denies writes"` (plan-mode short-circuit)
+
+### Edge case — depth 4 with ModeBubble
+
+- **Given** `ForkDepth: 4, Mode: ModeBubble`
+- **When** Resolve is called for any tool
+- **Then** the depth gate is bypassed (ModeBubble exempt)
+- **And** the 8-tier walk + bubble routing proceeds normally
+
+### Test mapping
+
+- `internal/permission/resolver_test.go::TestResolve_ForkDepth4DegradeToBubble` (new, M1)
+- `internal/permission/resolver_test.go::TestResolve_ForkDepth3WithinLimit` (new, M4)
+- `internal/permission/resolver_test.go::TestResolve_ForkDepth4PlanMode` (new, M4)
+
+---
+
+## AC-V3R2-RT-002-15 — Non-interactive mode fails closed (ask becomes deny)
+
+Maps to: REQ-V3R2-RT-002-041.
+
+### Happy path
+
+- **Given** `ResolveContext{IsInteractive: false}` (e.g., CI environment)
+- **And** `RulesByTier` is empty (no rule matches → would default to ask)
+- **When** Resolve is called
+- **Then** the result has `Decision == DecisionDeny` (fail closed)
+- **And** `Origin == "no matching rule (default)"`
+- **And** `.moai/logs/permission.log` contains an entry: `[<timestamp>] Unreachable prompt: tool=<tool> input=<truncated input>`
+
+### Edge case — interactive mode (default)
+
+- **Given** `IsInteractive: true` and the same empty RulesByTier
+- **When** Resolve is called
+- **Then** the result is `DecisionAsk` (interactive — would dispatch AskUserQuestion at orchestrator)
+- **And** no log entry is added
+
+### Edge case — non-interactive but rule matches
+
+- **Given** `IsInteractive: false` and a rule matches with `Action: DecisionAllow`
+- **When** Resolve is called
+- **Then** the result is `DecisionAllow` (matching rule wins; fail-closed only fires on no-match)
+- **And** no log entry is added
+
+### Test mapping
+
+- `internal/permission/resolver_test.go::TestResolve_NonInteractiveAskBecomesDeny` (new, M1)
+- `internal/permission/resolver_test.go::TestResolve_NonInteractiveMatchedRuleAllows` (new, M4)
+- `internal/permission/resolver_test.go::TestLogUnreachablePrompt_FilePath` (new, M4)
+
+---
+
+## Summary table — AC → REQ → Test
+
+| AC | REQs covered | Test files |
+|----|--------------|------------|
+| AC-01 | REQ-004, REQ-005 | `resolver_test.go::TestResolve_SrcProjectDenyWins`, `TestResolve_HigherTierWinsOverLower` |
+| AC-02 | REQ-006 | `resolver_test.go::TestResolve_PreAllowlist*` (3 cases) |
+| AC-03 | REQ-012 | `bubble_test.go::TestBubbleDispatcher_*`, `resolver_test.go::TestResolve_BubbleParentClosed` |
+| AC-04 | REQ-011 | `resolver_test.go::TestResolve_HookOverridesAllTiers`, `TestResolve_HookDecisionDeny` |
+| AC-05 | REQ-007, REQ-015 | `cli/doctor_permission_test.go::TestDoctorPermission_*` (3 cases) |
+| AC-06 | REQ-020 | `resolver_test.go::TestResolve_PlanModeDeniesWrite`, `TestResolve_PlanModeAllowsRead` |
+| AC-07 | REQ-022 | `spawn_test.go::TestRejectIfStrict_*`, `resolver_test.go::TestResolve_BypassPermissionsRejectedInStrictMode` |
+| AC-08 | REQ-050 | `resolver_test.go::TestResolve_BubbleParentClosed`, `bubble_test.go::TestIsParentAvailable_EmptyID` |
+| AC-09 | REQ-008 | `template/agent_frontmatter_audit_test.go::TestAgentFrontmatter_PermissionModeStrictEnum` |
+| AC-10 | REQ-013 | `resolver_test.go::TestResolve_HookUpdatedInputReMatch`, `TestResolve_HookUpdatedInputNoLoop` |
+| AC-11 | REQ-040 | `migration_test.go::TestMigrateLegacyBypassRules_*` (3 cases) |
+| AC-12 | REQ-042 | `conflict_test.go::TestResolveConflict_*` (3 cases) |
+| AC-13 | REQ-014 | `resolver_test.go::TestResolve_PolicyDenyOverridesProjectAllow`, `TestResolve_HigherTierWinsOverLower` |
+| AC-14 | REQ-023 | `resolver_test.go::TestResolve_ForkDepth4DegradeToBubble`, `TestResolve_ForkDepth3WithinLimit`, `TestResolve_ForkDepth4PlanMode` |
+| AC-15 | REQ-041 | `resolver_test.go::TestResolve_NonInteractiveAskBecomesDeny`, `TestResolve_NonInteractiveMatchedRuleAllows`, `TestLogUnreachablePrompt_FilePath` |
+
+Total new test functions: **~30 across 4 new test files (`spawn_test.go`, `conflict_test.go`, `migration_test.go`, `cli/doctor_permission_test.go`) + 3 existing files extended (`resolver_test.go`, `bubble_test.go`, `agent_frontmatter_audit_test.go`)**.
+
+---
+
+## Definition of Done
+
+본 SPEC 은 다음 모두 true 일 때 done:
+
+1. 위 15 AC 가 모두 `go test ./internal/permission/ ./internal/cli/ ./internal/template/` 에서 PASS.
+2. 워크트리 루트의 `go test ./...` 전체 PASS, 0 cascading regressions.
+3. `make build` 성공, `internal/template/embedded.go` clean 재생성 (security.yaml 미러 변경 반영).
+4. `go vet ./...` 와 `golangci-lint run` 0 warnings.
+5. `progress.md` 의 `run_complete_at: <timestamp>` 와 `run_status: implementation-complete` 갱신.
+6. CHANGELOG entry 가 `## [Unreleased] / ### 추가` 아래 존재.
+7. 7 MX tags 가 plan.md §6 대로 삽입 (3 ANCHOR, 2 NOTE, 2 WARN).
+8. `.moai/config/sections/security.yaml` 와 template mirror 의 `permission.{strict_mode, pre_allowlist, session_rules}` 키 정합.
+9. `manager-git` 가 연 PR 의 모든 required CI checks GREEN (Lint, Test ubuntu/macos/windows, Build all 5, CodeQL).
+
+---
+
+End of acceptance.md.

--- a/.moai/specs/SPEC-V3R2-RT-002/issue-body.md
+++ b/.moai/specs/SPEC-V3R2-RT-002/issue-body.md
@@ -1,0 +1,163 @@
+## SPEC-V3R2-RT-002 — Permission Stack + Bubble Mode
+
+> **Phase**: v3.0.0 — Phase 2 — Runtime Hardening
+> **Module**: `internal/permission/`
+> **Priority**: P0 Critical
+> **Breaking**: false (additive — non-breaking on top of master §8 BC-V3R2-015 multi-layer settings reader)
+> **Lifecycle**: spec-anchored
+
+## Summary
+
+Plan documents for SPEC-V3R2-RT-002 are ready for plan-auditor review. This SPEC replaces moai's flat `permissions.allow` list with a **typed 8-source permission stack** (`SrcPolicy > SrcUser > SrcProject > SrcLocal > SrcPlugin > SrcSkill > SrcSession > SrcBuiltin`) that resolves every tool invocation through an ordered precedence chain and carries provenance (`Origin`/`ResolvedBy` per rule). Introduces `bubble` as a first-class `PermissionMode` value so fork agents that inherit parent context can escalate permission decisions to the **parent terminal's user via AskUserQuestion** rather than silently default-allow or deny in an isolated mailbox. Closes problem-catalog **P-C01** (no permission bubble, CRITICAL) and **P-C04** (no config provenance, HIGH).
+
+## Goal (purpose)
+
+- **Structural (P6 Permission Bubble)**: 8-tier resolver replaces flat allowlist; every decision carries Origin (which file) + ResolvedBy (which tier).
+- **Safety (P7 Sandbox Default)**: `bypassPermissions` rejected in `security.yaml strict_mode: true` environment.
+- **UX (r3 §4 Adopt 2)**: Pre-allowlist of 8 dev-op patterns (`Bash(go test:*)`, `Read(*)`, `Glob(*)`, `Grep(*)`, etc.) absorbs ~80% of bubble-fatigue.
+- **Hooks (P8 Hook JSON)**: PreToolUse hook PermissionDecision overlays at session-tier; UpdatedInput triggers re-match.
+
+## Scope
+
+### In-Scope
+
+- `Source` 8-tier enum (consumed from `internal/config/source.go` — RT-005 ownership)
+- `PermissionMode` 5-enum (`default`, `acceptEdits`, `bypassPermissions`, `plan`, `bubble`) — `bubble` is first-class peer
+- `PermissionRule{Pattern, Action, Source, Origin}` Go struct
+- `PermissionResolver.Resolve(tool, input, ctx)` walking 8-source stack in priority order
+- Bubble-mode semantics: fork agent → parent AskUserQuestion (orchestrator-only per agent-common-protocol.md)
+- PreToolUse hook integration (overlay above SrcSession tier)
+- Pre-allowlist 8 patterns (`Bash(go test:*)`, `Bash(golangci-lint run:*)`, `Bash(ruff check:*)`, `Bash(npm test:*)`, `Bash(pytest:*)`, `Read(*)`, `Glob(*)`, `Grep(*)`)
+- `moai doctor permission --all-tiers --tool --input --trace --dry-run --mode --fork --format` CLI subcommand
+- Agent frontmatter `permissionMode` strict-validation (CI lint rejects unknown values)
+- Plan-mode write-deny gate
+- Strict_mode bypassPermissions reject
+- Fork depth >3 → bubble degrade with sentinel
+- Same-tier conflict resolution: specificity-then-fs-order tiebreak
+- Legacy v2 `bypassPermissions` action migration with deprecation warning
+- Non-interactive mode fail-closed (ask → deny + log)
+
+### Out-of-Scope
+
+- Hook JSON protocol wire format — SPEC-V3R2-RT-001
+- Sandbox execution backends (bwrap/seatbelt) — SPEC-V3R2-RT-003
+- Settings file provenance reader + multi-layer merge — SPEC-V3R2-RT-005
+- Typed session state for resumable permission context — SPEC-V3R2-RT-004
+- Plugin-origin settings ingestion — deferred to v3.1+ per master §7 plugin NOT-NOW
+- UI prompt rendering for bubble (AskUserQuestion owns the UX)
+
+## Non-Breaking Compatibility Note
+
+**RT-002 is additive (`breaking: false`, `bc_id: []`).** v2.x users gain the typed layer transparently:
+
+1. v2.x flat `permissions.allow` lists continue to read correctly via the tier-aware merge layer (master §8 BC-V3R2-015 — RT-005 reader auto-absorbs as `SrcProject`/`SrcLocal` tier rules).
+2. The resolver answer becomes provenance-aware (carries `Origin`/`ResolvedBy`), but the *decision* derived from a v2 single-source allowlist matches the v3 resolver's output for identical input.
+3. v2.x users see no behaviour change; v3 users gain `moai doctor permission --trace` for debugging.
+4. Migration of `bypassPermissions` action (legacy v2 form) emits a deprecation warning naming the origin file — non-blocking for runtime; user can update at leisure.
+
+This SPEC layers `bubble` mode + 8-tier walk + provenance on top of an existing v3 reader contract. No file format changes are required for v2 users.
+
+## Plan Documents
+
+| Document | Purpose | Size |
+|----------|---------|------|
+| `spec.md` | EARS requirements + ACs (existing, v0.1.0) | ~22 KB |
+| `plan.md` | Implementation plan (M1-M5 milestones, traceability matrix, mx_plan, plan-audit-ready checklist) | new |
+| `research.md` | Deep research (12 sections, 48 file:line anchors, library evaluation, dependency analysis, performance budget) | new |
+| `acceptance.md` | 15 ACs in Given/When/Then format with edge cases + test mapping | new |
+| `tasks.md` | 35 tasks (T-RT002-01..35) across M1-M5 with owner roles + dependencies | new |
+| `progress.md` | Live progress tracker + paste-ready session-handoff resume message | new |
+
+## EARS Requirements Summary
+
+- **24 REQs across 6 categories**: Ubiquitous (8), Event-Driven (6), State-Driven (4), Optional (3), Unwanted (4), Complex (2)
+- **15 ACs all map to REQs (100% coverage)**
+- **Traceability matrix**: 27 REQ → 15 AC → 35 tasks (verified in `plan.md` §1.5)
+
+## Implementation Methodology
+
+`.moai/config/sections/quality.yaml`: `development_mode: tdd`. Run phase MUST follow RED → GREEN → REFACTOR per `.claude/rules/moai/workflow/spec-workflow.md`.
+
+- **M1 (RED)**: ~10 failing tests covering AC-04, AC-05, AC-07, AC-08, AC-10, AC-11, AC-12, AC-13, AC-14, AC-15 + frontmatter audit lint for AC-09
+- **M2 (GREEN part 1)**: PreAllowlist sync.Once + RejectIfStrict spawn helper + frontmatter strict-validation lint + security.yaml new keys + template mirror. AC-07, AC-09 GREEN.
+- **M3 (GREEN part 2)**: hook UpdatedInput single-execution guard + IsWriteOperation pattern refinement + conflict.go specificity-then-fs-order tiebreak. AC-04, AC-10, AC-12, AC-13 GREEN.
+- **M4 (GREEN part 3)**: bubble.go DispatchToParent IPC contract freezing + fork depth sentinel alignment + non-interactive fail-closed log. AC-08, AC-14, AC-15 GREEN.
+- **M5 (GREEN part 4 + REFACTOR + Trackable)**: `moai doctor permission --all-tiers --mode --fork --format` CLI + migration.go (legacy bypassPermissions) + CHANGELOG + 7 MX tags. AC-05, AC-11 GREEN.
+
+## Risks (Top 4)
+
+1. **Bubble dispatch IPC channel undefined for v3.0** (M, M) — Mitigation: M4 freezes contract API only; actual wire deferred to orchestrator integration (skill body) coordinated with RT-001.
+2. **Pre-allowlist 8 patterns insufficient for non-Go/JS/Python projects** (M, L) — Mitigation: post-beta.1 telemetry-driven amendment v0.2.0 (additional patterns for Rust/Java/Ruby/C++).
+3. **Conflict tiebreak specificity formula may diverge from user expectation** (M, L) — Mitigation: explicit specificity formula in godoc + `--trace` JSON exposes specificity score.
+4. **`internal/permission/` resolver mutex (RWMutex) deadlock under hook UpdatedInput re-entry** (M, H) — Mitigation: M3 inline single-execution guard verified by `TestResolve_HookUpdatedInputReMatch`.
+
+Full 11-risk table in `plan.md` §5.
+
+## Dependencies
+
+### Blocked by
+
+- SPEC-V3R2-RT-001 (Hook JSON protocol — provides `internal/hook.HookResponse` import for REQ-V3R2-RT-002-011/-013) — **at-risk**, mitigation: hardcoded fixture if unmerged
+- SPEC-V3R2-RT-005 (Settings reader + 8-tier `internal/config.Source` enum) — **at-risk**, mitigation: hardcoded fixture if unmerged
+- SPEC-V3R2-CON-001 (FROZEN zone declaration of 8-source ordering as constitutional clause) — completed per Wave 6
+
+### Blocks
+
+- SPEC-V3R2-RT-003 (Sandbox launcher consults PermissionMode for bwrap/seatbelt wrapping)
+- SPEC-V3R2-ORC-001 (Agent roster reduction consumes validated permissionMode enum from REQ-008)
+- SPEC-V3R2-ORC-004 (Worktree MUST for implementers pairs with permissionMode: acceptEdits at project tier)
+
+### Related (non-blocking)
+
+- SPEC-V3R2-MIG-001, SPEC-V3R2-SPC-004, SPEC-V3R2-CON-003, SPEC-V3R2-RT-004
+
+## Plan-Audit-Ready Checklist
+
+All 15 criteria PASS per `plan.md` §8:
+
+- [x] Frontmatter v0.1.0 schema
+- [x] HISTORY entry for v0.1.0
+- [x] 24 EARS REQs across 6 categories
+- [x] 15 ACs all map to REQs (100% coverage)
+- [x] BC scope clarity (`breaking: false`, `bc_id: []` — additive)
+- [x] File:line anchors ≥10 (research.md: 48, plan.md: 30)
+- [x] Exclusions section present (6 entries explicitly mapped to other SPECs / X-4 deferred)
+- [x] TDD methodology declared
+- [x] mx_plan section (7 MX tag insertions across 4 categories — 3 ANCHOR + 2 NOTE + 2 WARN + 0 TODO)
+- [x] Risk table with mitigations (spec.md: 6, plan.md: 11)
+- [x] Worktree mode path discipline
+- [x] No implementation code in plan documents
+- [x] Acceptance.md G/W/T format with edge cases
+- [x] tasks.md owner roles aligned with TDD methodology
+- [x] Cross-SPEC consistency (RT-001/RT-005/CON-001 dependency status verified; RT-003/ORC-001/ORC-004 blocking confirmed)
+
+## Worktree Discipline
+
+[HARD] All run-phase work executes in `/Users/goos/.moai/worktrees/moai-adk/SPEC-V3R2-RT-002` on branch `plan/SPEC-V3R2-RT-002` (initial) or sibling `feature/SPEC-V3R2-RT-002-permission-stack` (run phase).
+
+[HARD] All filesystem operations use `filepath.Join` / `filepath.Abs`; tests use `t.TempDir()` per `CLAUDE.local.md` §6.
+
+[HARD] Code comments in Korean; commit messages in Korean (per `.moai/config/sections/language.yaml`).
+
+[HARD] `internal/template/templates/.moai/config/sections/security.yaml` mirror MUST be updated alongside the project-side `security.yaml` (Template-First Rule per CLAUDE.local.md §2).
+
+## Test Plan
+
+- [ ] M1 RED gate: ~10 new tests fail with documented sentinels; existing 69 tests in resolver_test.go/stack_test.go/bubble_test.go remain GREEN
+- [ ] M2 GREEN part 1: AC-07, AC-09 turn GREEN
+- [ ] M3 GREEN part 2: AC-04, AC-10, AC-12, AC-13 turn GREEN
+- [ ] M4 GREEN part 3: AC-08, AC-14, AC-15 turn GREEN
+- [ ] M5 GREEN part 4: AC-05, AC-11 turn GREEN; AC-01, AC-02, AC-03, AC-06 verified by existing tests + extension
+- [ ] Full `go test ./...` passes with zero failures and zero cascading regressions
+- [ ] `make build` regenerates `internal/template/embedded.go` cleanly (security.yaml mirror reflected)
+- [ ] `go vet ./...` and `golangci-lint run` pass with zero warnings
+- [ ] All required CI checks green: Lint, Test (ubuntu/macos/windows), Build (5 platforms), CodeQL
+
+## Next Action
+
+After plan-auditor PASS on this PR:
+- Merge plan PR to `main`
+- Verify SPEC-V3R2-RT-001 / SPEC-V3R2-RT-005 dependency status (gh pr list)
+- Switch to run phase: `/moai run SPEC-V3R2-RT-002` (paste-ready resume in `progress.md`)
+
+🗿 MoAI <email@mo.ai.kr>

--- a/.moai/specs/SPEC-V3R2-RT-002/plan.md
+++ b/.moai/specs/SPEC-V3R2-RT-002/plan.md
@@ -1,0 +1,472 @@
+# SPEC-V3R2-RT-002 Implementation Plan
+
+> Implementation plan for **Permission Stack + Bubble Mode**.
+> Companion to `spec.md` v0.1.0, `research.md` v0.1.0, `acceptance.md` v0.1.0, `tasks.md` v0.1.0.
+> Authored against branch `plan/SPEC-V3R2-RT-002` at `<worktree-root>` = `/Users/goos/.moai/worktrees/moai-adk/SPEC-V3R2-RT-002`. See §7 for cwd resolution rule.
+
+## HISTORY
+
+| Version | Date       | Author                        | Description                                                              |
+|---------|------------|-------------------------------|--------------------------------------------------------------------------|
+| 0.1.0   | 2026-05-10 | manager-spec (Plan workflow)  | Initial implementation plan per `.claude/skills/moai/workflows/plan.md` Phase 1B |
+
+---
+
+## 1. Plan Overview
+
+### 1.1 Goal restatement
+
+Concretize spec.md §1 (Goal) into a typed Go subsystem under `internal/permission/` and supporting CLI plumbing under `internal/cli/` so that every tool invocation in moai-adk-go resolves through the canonical 8-source priority chain (`SrcPolicy > SrcUser > SrcProject > SrcLocal > SrcPlugin > SrcSkill > SrcSession > SrcBuiltin`) per master §5.2 and master §4.3 Layer 3 type block.
+
+핵심 요약:
+
+- 기존 `internal/permission/{stack,resolver,bubble}.go` 스켈레톤(약 700 LOC, ~50% REQ 충족)을 24 EARS REQ + 15 AC 가 모두 통과하도록 보강.
+- v3.0 의 새 PermissionMode 값인 `bubble` 을 enum 일등 시민으로 격상 (`ModeBubble = "bubble"` 이미 stack.go:37 에 존재 — 호출 경로/lint/AskUserQuestion 라우팅이 비어있음).
+- 8-source 모든 tier 의 rule 을 `RulesByTier map[config.Source][]PermissionRule` 형태로 적재하는 reader (RT-005 가 직접 구현. RT-002 는 그 결과를 소비) 와 `Origin` 필드 기반 provenance 의 end-to-end 흐름을 검증.
+- `moai doctor permission` 서브커맨드를 보강 — 현 skel(.go 91 LOC)은 hard-coded `RulesByTier` 빈맵으로만 동작. `--all-tiers` 출력, `--trace` JSON 형식 정합성, `--dry-run` 정상화 필요.
+- 8 개의 dev-op 패턴(`Bash(go test:*)` 외) 을 `SrcBuiltin` tier 의 pre-allowlist 로 박제 → bubble fatigue 80% 흡수.
+- 기존 `bypassPermissions` 사용처를 `security.yaml strict_mode: true` 환경에서 spawn 단계 reject 하는 게이트.
+- Agent frontmatter `permissionMode` 값을 5-enum 으로 strict 검증하는 CI lint 추가 (`internal/template/agent_frontmatter_audit_test.go` 확장).
+
+### 1.2 비즈니스 핵심
+
+이 SPEC 은 `bc_id: []` (additive) 입니다. v2.x 의 flat `permissions.allow` 리스트는 reader (SPEC-V3R2-RT-005) 가 자동으로 `SrcProject` 또는 `SrcLocal` tier 로 흡수해 read 호환을 유지하며, 기존 사용자에게 마이그레이션 부담을 주지 않습니다. 본 plan 은 master §8 BC-V3R2-015 의 multi-layer settings reader 위에 8-tier resolver + bubble routing 을 얹는 작업입니다. resolver answer 는 tier-aware (Origin/ResolvedBy 메타 동반) 가 되지만 v2 의 단일-soruce 답에서 동일 결정을 항상 derive 가능 → non-breaking.
+
+### 1.3 Implementation Methodology
+
+`.moai/config/sections/quality.yaml`: `development_mode: tdd`. Run phase MUST follow RED → GREEN → REFACTOR per `.claude/rules/moai/workflow/spec-workflow.md` Phase Run.
+
+- **RED**: stack.go/resolver.go/bubble.go 가 채우지 못한 동작에 대한 실패 테스트 작성. 기존 `*_test.go` 가 이미 일부 happy-path 를 cover (stack_test.go 215 LOC, resolver_test.go 480 LOC, bubble_test.go 220 LOC) — bypassPermissions strict_mode rejection, frontmatter strict-validation, doctor permission --trace JSON, hook UpdatedInput re-match 등이 미커버.
+- **GREEN**: stack.go 의 `IsWriteOperation` 패턴 보강, resolver.go 의 `--trace` JSON 정합성 보강, bubble.go 의 DispatchToParent placeholder 를 orchestrator IPC contract 로 대체 (RT-001 hook protocol 통신 채널 재사용). `internal/cli/doctor_permission.go` 에 `--all-tiers` 출력 + `--mode` 플래그 추가. `internal/template/agent_frontmatter_audit_test.go` 에 `permissionMode oneof` 검증 추가. `.moai/config/sections/security.yaml` 에 `permission.pre_allowlist`, `permission.strict_mode` 키 추가.
+- **REFACTOR**: pre-allowlist 패턴 매칭 hot path 를 sort-once + binary-search 로 변환 (1000-rule 기준 p99 500µs 목표). Decision/Source 문자열 변환 통합. spec REQ-V3R2-RT-002-040 (legacy bypassPermissions 마이그레이션 deprecation warning) 을 reader 진입점 (SPEC-V3R2-RT-005 영역) 과 동일 hook 으로 일관화.
+
+### 1.4 Deliverables
+
+| Deliverable | Path | REQ Coverage |
+|-------------|------|--------------|
+| `Source` enum 8-tier 정합성 확인 (이미 internal/config/source.go 존재) | `internal/config/source.go` (검증) | REQ-001 |
+| `PermissionMode` 5-enum 일등 시민 정착 | `internal/permission/stack.go:13-65` (기존 보강) | REQ-003 |
+| `PermissionRule` Origin 필드 비빔 검증 | `internal/permission/stack.go:67-86` (기존 — provenance 흐름 end-to-end 테스트 추가) | REQ-002 |
+| `PermissionResolver.Resolve` 8-tier 워크 + 첫 매치 반환 | `internal/permission/resolver.go:135-254` (기존 보강 — RulesByTier reader 연결) | REQ-004, REQ-005 |
+| Hook UpdatedInput 후 re-match | `internal/permission/resolver.go:147-160` (기존 보강 — 무한루프 방지 가드 검증) | REQ-013 |
+| Bubble routing → 부모 AskUserQuestion | `internal/permission/bubble.go:94-114` (DispatchToParent IPC 구현) | REQ-012, REQ-050 |
+| Pre-allowlist 8 패턴 시드 | `internal/permission/stack.go:182-233` (기존 — 테스트 강화) | REQ-006 |
+| `moai doctor permission` 보강 (`--trace`, `--dry-run`, `--all-tiers`) | `internal/cli/doctor_permission.go` (보강) | REQ-007, REQ-015 |
+| Agent frontmatter `permissionMode` strict-validation | `internal/template/agent_frontmatter_audit_test.go` (확장) | REQ-008 |
+| Plan mode write-deny 게이트 | `internal/permission/resolver.go:178-191` (기존 — write 패턴 보강) | REQ-020 |
+| bypassPermissions strict_mode reject | `internal/permission/resolver.go:383-397` (기존 ValidateMode 호출 사이트 추가) | REQ-022 |
+| Fork depth >3 → bubble 강등 | `internal/permission/resolver.go:209-219` (기존 보강) | REQ-023 |
+| `permission.session_rules` `SrcSession` tier 적재 | reader 연결 — RT-005 dependency | REQ-030 |
+| Legacy `bypassPermissions` action → `acceptEdits` migration | `internal/permission/migration.go` (신규, ~50 LOC) | REQ-040 |
+| 비대화형 `ask` → `deny` fail-closed + log | `internal/permission/resolver.go:241-247` (기존 보강) | REQ-041 |
+| 동일 tier 충돌 시 specificity-then-fs-order tiebreak | `internal/permission/conflict.go` (신규, ~80 LOC) | REQ-042 |
+| Fork session-scope rule SrcPolicy override 차단 | `internal/permission/resolver.go` (보강) | REQ-043 |
+| `security.yaml` `permission.pre_allowlist`, `permission.strict_mode`, `permission.session_rules` 키 | `.moai/config/sections/security.yaml` (확장) | REQ-006, REQ-022, REQ-030 |
+| CHANGELOG entry | `CHANGELOG.md` Unreleased section | Trackable (TRUST 5) |
+| MX tags per §6 | 5 files (per §6 below) | mx_plan |
+
+Embedded-template parity: 본 SPEC 은 `internal/permission/` Go 코드와 `.moai/config/sections/security.yaml` 의 두 표면을 건드립니다. security.yaml 은 `internal/template/templates/.moai/config/sections/security.yaml` 의 미러도 함께 업데이트해야 하므로, M5 단계에 `make build` 를 실행해 `internal/template/embedded.go` 를 재생성합니다.
+
+### 1.5 Traceability Matrix (REQ → AC → Task)
+
+Per plan-auditor PASS criterion #2 (every REQ maps to at least one AC and at least one Task):
+
+| REQ ID | Category | Mapped AC(s) | Mapped Task(s) |
+|--------|----------|--------------|----------------|
+| REQ-V3R2-RT-002-001 | Ubiquitous | (Source enum coverage; verified by existing `internal/config/source_test.go`) | T-RT002-01 |
+| REQ-V3R2-RT-002-002 | Ubiquitous | AC-01, AC-02, AC-05 | T-RT002-02 |
+| REQ-V3R2-RT-002-003 | Ubiquitous | AC-03 | T-RT002-03 |
+| REQ-V3R2-RT-002-004 | Ubiquitous | AC-01, AC-13 | T-RT002-04, T-RT002-08 |
+| REQ-V3R2-RT-002-005 | Ubiquitous | AC-01, AC-02 | T-RT002-04 |
+| REQ-V3R2-RT-002-006 | Ubiquitous | AC-02 | T-RT002-05 |
+| REQ-V3R2-RT-002-007 | Ubiquitous | AC-05 | T-RT002-12 |
+| REQ-V3R2-RT-002-008 | Ubiquitous | AC-09 | T-RT002-14 |
+| REQ-V3R2-RT-002-010 | Event-Driven | (default-ask vs default-deny) | T-RT002-08 |
+| REQ-V3R2-RT-002-011 | Event-Driven | AC-04 | T-RT002-09 |
+| REQ-V3R2-RT-002-012 | Event-Driven | AC-03 | T-RT002-10, T-RT002-21 |
+| REQ-V3R2-RT-002-013 | Event-Driven | AC-10 | T-RT002-09 |
+| REQ-V3R2-RT-002-014 | Event-Driven | AC-13 | T-RT002-08 |
+| REQ-V3R2-RT-002-015 | Event-Driven | AC-05 | T-RT002-12 |
+| REQ-V3R2-RT-002-020 | State-Driven | AC-06 | T-RT002-11 |
+| REQ-V3R2-RT-002-021 | State-Driven | (bypassPermissions short-circuit) | T-RT002-13 |
+| REQ-V3R2-RT-002-022 | State-Driven | AC-07 | T-RT002-13 |
+| REQ-V3R2-RT-002-023 | State-Driven | AC-14 | T-RT002-15 |
+| REQ-V3R2-RT-002-030 | Optional | (session-scope rule loading) | T-RT002-16 |
+| REQ-V3R2-RT-002-031 | Optional | (plugin-tier slot) | T-RT002-17 |
+| REQ-V3R2-RT-002-032 | Optional | (CLI behaviour) | T-RT002-12 |
+| REQ-V3R2-RT-002-040 | Unwanted | AC-11 | T-RT002-18 |
+| REQ-V3R2-RT-002-041 | Unwanted | AC-15 | T-RT002-19 |
+| REQ-V3R2-RT-002-042 | Unwanted | AC-12 | T-RT002-20 |
+| REQ-V3R2-RT-002-043 | Unwanted | (fork session-rule SrcPolicy override 차단) | T-RT002-22 |
+| REQ-V3R2-RT-002-050 | Complex | AC-08 | T-RT002-21 |
+| REQ-V3R2-RT-002-051 | Complex | AC-13 | T-RT002-23 |
+
+Coverage: **27 REQs mapped to 15 ACs and 28 tasks** (몇몇 AC/task 는 다중 REQ 와 매핑).
+
+---
+
+## 2. Milestone Breakdown (M1-M5)
+
+각 milestone 은 **priority-ordered** (no time estimates per `.claude/rules/moai/core/agent-common-protocol.md` §Time Estimation HARD rule).
+
+### M1: Test scaffolding (RED phase) — Priority P0
+
+기존 테스트: `internal/permission/{stack,resolver,bubble}_test.go` (총 ~28KB).
+
+Owner role: `expert-backend` (Go test) 또는 직접 `manager-tdd` 실행.
+
+Scope:
+1. `internal/permission/resolver_test.go` 에 새 테스트 케이스 추가 (기존이 cover 하지 못하는 AC):
+   - `TestResolve_FrontmatterUnknownPermissionMode` (AC-09, REQ-008) — agent frontmatter strict-validation lint 의 sentinel 검증.
+   - `TestResolve_HookUpdatedInputReMatch` (AC-10, REQ-013) — hook 가 path 를 mutate 한 후 pre-allowlist 가 mutated path 에 대해 다시 매칭되는지.
+   - `TestResolve_ForkDepth4DegradeToBubble` (AC-14, REQ-023) — depth=4, mode=acceptEdits → systemMessage emit + decision=ask.
+   - `TestResolve_BubbleParentClosed` (AC-08, REQ-050) — IsFork=true, ParentAvailable=false → deny + "parent unavailable" message.
+   - `TestResolve_NonInteractiveAskBecomesDeny` (AC-15, REQ-041) — `IsInteractive: false` + 매치 실패 → deny + log entry.
+   - `TestResolve_ConflictSpecificityThenFsOrder` (AC-12, REQ-042) — 동일 tier 두 매치 시 specificity 우선, 동률 시 file-system scan order 우선, 충돌 로깅.
+   - `TestResolve_PolicyDenyOverridesProjectAllow` (AC-13, REQ-014) — SrcPolicy deny 가 SrcProject allow 보다 우선.
+   - `TestResolve_BypassPermissionsRejectedInStrictMode` (AC-07, REQ-022) — strict_mode 에서 spawn 거부.
+   - `TestResolve_LegacyBypassActionMigratedWithDeprecationWarning` (AC-11, REQ-040) — v2 `bypassPermissions` action 발견 시 acceptEdits 로 reroute + log.
+   - `TestResolve_SessionRulesLoadedAsSrcSession` (REQ-030) — session_rules 키가 SrcSession tier 로 적재.
+
+2. `internal/cli/doctor_permission_test.go` 신규 작성 (기존 doctor_test.go 와 분리):
+   - `TestDoctorPermission_AllTiersFlag` (AC-05) — `--all-tiers` 출력 8개 tier 모두 dump.
+   - `TestDoctorPermission_TraceJSONFormat` (AC-05, REQ-015) — `--trace` 출력이 JSON 파싱 가능 + 8 tier 모두 `tries[]` 포함.
+   - `TestDoctorPermission_DryRun` (REQ-032) — `--dry-run` 시 tool 실행 없음 사인.
+
+3. `internal/template/agent_frontmatter_audit_test.go` 확장:
+   - `TestAgentFrontmatter_PermissionModeStrictEnum` (AC-09, REQ-008) — `.claude/agents/**/*.md` 의 모든 frontmatter 의 `permissionMode` 키가 5-enum (`default|acceptEdits|bypassPermissions|plan|bubble`) 안에 있는지 walker 로 검증; 위반 시 sentinel `PERMISSION_MODE_UNKNOWN_VALUE: <file> declares permissionMode: <value>; allowed: default|acceptEdits|bypassPermissions|plan|bubble.`
+
+4. 모든 새 테스트가 RED 상태인지 `go test ./internal/permission/ ./internal/cli/ ./internal/template/` 로 확인. 기존 테스트 (resolver_test.go 의 32 케이스, stack_test.go 의 21 케이스, bubble_test.go 의 16 케이스) 는 baseline GREEN 유지.
+
+검증 게이트 (M2 진행 전): 새 테스트 ≥10 개가 sentinel 메시지와 함께 fail. 기존 테스트는 회귀 없음 (regression baseline).
+
+[HARD] M1 에서는 test 파일 외부에 구현 코드 작성 금지.
+
+### M2: Pre-allowlist 정착 + ValidateMode 호출사이트 + frontmatter strict lint (GREEN, part 1) — Priority P0
+
+Owner role: `expert-backend`.
+
+Scope:
+1. `internal/permission/stack.go:182-233` 의 `PreAllowlist()` 함수를 그대로 유지 (skel 가 이미 8 패턴 제공). 단, **lazy-load** 패턴으로 변경: `var preAllowlistOnce sync.Once + var preAllowlistRules []PermissionRule` 로 첫 호출 시에만 빌드. spec.md REQ-006 의 hot-path 비용 제거.
+2. `internal/permission/resolver.go:383-397` 의 `ValidateMode` 를 spawn 진입점에 wire — 즉 `internal/cli/run.go` 또는 agent spawn 경로에서 ValidateMode 호출 후 PermissionModeRejected 시 spawn 거부. 본 SPEC 범위 내에서 `internal/permission/spawn.go` 신규로 spawn-side helper `RejectIfStrict(mode, strictMode) error` 만 추가하고, 실제 wire 는 spawn caller 에 1줄 추가 (cross-package coupling 최소화).
+3. `internal/template/agent_frontmatter_audit_test.go` (기존 564 LOC) 에 새 테스트 함수 `TestAgentFrontmatter_PermissionModeStrictEnum` 추가. 기존 walker 패턴 재사용.
+4. `.moai/config/sections/security.yaml` 에 spec.md §3 envrionment 가 명시한 새 키 3 종 추가:
+   ```yaml
+   permission:
+     strict_mode: false           # bypassPermissions 모드 차단 (SrcPolicy 위배 시 true 권장)
+     pre_allowlist:               # SrcBuiltin tier 자동 적재 (REQ-006 시드와 합산)
+       - "Bash(go test:*)"
+       - "Bash(golangci-lint run:*)"
+       - "Bash(ruff check:*)"
+       - "Bash(npm test:*)"
+       - "Bash(pytest:*)"
+       - "Read(*)"
+       - "Glob(*)"
+       - "Grep(*)"
+     session_rules: []            # SrcSession tier 동적 적재 (런타임)
+   ```
+5. `internal/template/templates/.moai/config/sections/security.yaml` 미러 업데이트.
+
+검증: `TestAgentFrontmatter_PermissionModeStrictEnum`, `TestResolve_BypassPermissionsRejectedInStrictMode`, `TestResolve_FrontmatterUnknownPermissionMode` 가 GREEN 진입. 기존 테스트 회귀 없음.
+
+### M3: Hook UpdatedInput re-match + Conflict tiebreak + Plan-mode write-deny 보강 (GREEN, part 2) — Priority P0
+
+Owner role: `expert-backend`.
+
+Scope:
+1. `internal/permission/resolver.go:147-160` 의 hook UpdatedInput re-match 가드 검증. 현재 skel 가 무한루프 방지 위해 `newCtx.HookResponse = nil` 로 clear 하지만, hook 가 중첩 mutate 한 케이스 (UpdatedInput 안에 또 PermissionDecision 이 없는) 에 대한 단일 재실행만 허용하는지 테스트 강화.
+2. `internal/permission/stack.go:244-269` 의 `IsWriteOperation` 의 write 패턴 보강:
+   - 누락 패턴 추가: `git reset --hard`, `git clean`, `npm run build`, `make install`, `dd of=`.
+   - `mv` 중복 항목 (line 252) 수정.
+   - 정규식 매처 옵션 추가 — 현재 `strings.Contains` 만 사용 → false-positive 우려 있는 패턴(`echo `) 은 명령어 시작점 매칭으로 변경.
+3. `internal/permission/conflict.go` 신규 파일 (~80 LOC):
+   - `resolveConflict(rules []*PermissionRule, tool, input string) *PermissionRule` — 동일 tier 다중 매치 시 specificity 점수 (와일드카드 개수의 역수) 우선, 동률 시 `Origin` 파일 path lexicographic 순서 우선.
+   - 충돌 발생 시 `.moai/logs/permission.log` 에 entry 기록 (REQ-042 의 충돌 logging).
+4. `internal/permission/resolver.go::checkTier` (line 258-299) 가 동일 tier 에서 ≥2 매치 시 `resolveConflict` 호출하도록 변경.
+
+검증: `TestResolve_HookUpdatedInputReMatch`, `TestResolve_ConflictSpecificityThenFsOrder`, `TestResolve_PolicyDenyOverridesProjectAllow` 가 GREEN. AC-04, AC-12, AC-13 충족.
+
+### M4: Bubble dispatch IPC + Fork depth degrade + Non-interactive fail-closed (GREEN, part 3) — Priority P0
+
+Owner role: `expert-backend`.
+
+Scope:
+1. `internal/permission/bubble.go:94-102` 의 `DispatchToParent` placeholder 를 contract 만 명시한 IPC stub 으로 격상. 실제 구현은 RT-001 hook protocol 채널 재사용을 가정 (contract: parent session 이 stdin JSON 으로 BubbleRequest 수신 → AskUserQuestion 후 stdout JSON 으로 BubbleResponse 반환). 본 SPEC 은 contract API 만 동결하고 placeholder 가 `Sentinel: orchestrator integration required` 를 emit 하도록 유지. 실제 wiring 은 orchestrator side (`/moai run` skill body) — 본 SPEC 범위 외이지만 contract 는 동결.
+2. `internal/permission/resolver.go:209-219` 의 fork depth >3 게이트 정합성 보강:
+   - `mode == ModePlan` 이거나 `mode == ModeBubble` 이면 게이트를 통과 (이미 OK).
+   - 그 외 모드는 systemMessage emit + decision=ask + ResolvedBy=SrcBuiltin + Origin="fork depth limit" — AC-14 의 sentinel "Fork depth N exceeds limit - mode degraded to bubble" 정렬.
+3. `internal/permission/resolver.go:241-247` 의 비대화형 fail-closed 분기 검증 — `IsInteractive: false` 시 default decision 이 `DecisionDeny` 로 변환 + `logUnreachablePrompt` 호출. 로그 entry 가 spec.md REQ-041 의 `.moai/logs/permission.log` path 와 일치하는지 확인.
+4. `internal/permission/bubble.go::IsParentAvailable` (line 150-154) 의 placeholder 를 ParentSessionID 비어있지 않음 + 실제 session registry lookup 으로 contract 격상. registry 자체는 SPEC-V3R2-WF-003/RT-004 영역이므로 본 SPEC 은 interface 만 동결.
+
+검증: `TestResolve_BubbleParentClosed`, `TestResolve_ForkDepth4DegradeToBubble`, `TestResolve_NonInteractiveAskBecomesDeny` 가 GREEN. AC-08, AC-14, AC-15 충족.
+
+### M5: doctor permission 보강 + Legacy migration + Session rules + CHANGELOG + MX tags (GREEN, part 4 + REFACTOR + Trackable) — Priority P1
+
+Owner role: `expert-backend` (CLI), `manager-docs` (CHANGELOG, MX tags).
+
+Scope:
+
+#### M5a: `moai doctor permission` CLI 보강
+
+1. `internal/cli/doctor_permission.go` (현 91 LOC) 에 다음 플래그 추가:
+   - `--all-tiers` — 모든 tier 의 적재된 rule 목록 dump (기본 false; tool/input 명시 없을 때 자동 활성).
+   - `--mode <mode>` — agent permissionMode 시뮬레이션 (default/acceptEdits/bypassPermissions/plan/bubble).
+   - `--fork` — fork agent 시뮬레이션 (IsFork=true).
+   - 기존 `--trace`, `--dry-run`, `--tool`, `--input` 유지.
+2. `result.ExportTrace()` 출력 JSON 이 spec.md AC-05 의 "JSON trace enumerating all 8 tiers inspected with `matched: true|false` per tier" 정합성 검증. 현재 skel 의 `ResolutionTrace.Tries` 는 매치된 tier 만 기록 → 매치 실패 tier 도 기록하도록 `checkTier` 의 unmatched-fallthrough 분기에서도 trace 적재 (이미 `resolver.go:292-296` 에서 push 하는 것으로 보이므로 검증만).
+3. 출력 포맷: 인간 가독형은 indent 2-space, JSON 은 `--format json` 별도 플래그 (기본 indent 2-space, no `--format`).
+
+#### M5b: Legacy bypassPermissions migration
+
+1. `internal/permission/migration.go` 신규 (~50 LOC):
+   - `MigrateLegacyBypassRules(rules []PermissionRule) ([]PermissionRule, []string)` — 입력 rule 중 `Action == "bypassPermissions"` (legacy v2 form) 을 발견 시:
+     - Action 을 `acceptEdits` (mode 가 아닌 action) 로 reroute. 단 PermissionDecision 은 `allow` 로 매핑 (acceptEdits 는 mode 이지 action 이 아님 → 실용적으로는 `Action: DecisionAllow` 로 매핑하고 deprecation warning 만 emit).
+     - deprecation warning 문자열 반환 (해당 rule 의 Origin file path 명시).
+2. reader (RT-005) 통합 시점에 `MigrateLegacyBypassRules` 를 첫 read 직후 호출.
+
+#### M5c: Session rules SrcSession tier 적재
+
+1. `.claude/settings.local.json` 의 `permissions.session_rules` 키를 SrcSession tier 로 적재하는 reader hook (RT-005 영역). 본 SPEC 은 `permission.SrcSession` tier 의 rule 가 resolver 에서 정상 walk 되는지의 contract 만 동결 + 테스트 추가.
+
+#### M5d: CHANGELOG + MX tags + final verification
+
+1. CHANGELOG entry 추가 (한국어 — `git_commit_messages: ko`):
+   ```
+   ### 추가
+   - SPEC-V3R2-RT-002: Permission Stack + Bubble Mode. `internal/permission/` 8-tier resolver 정착, `bubble` PermissionMode 일등 시민 격상, 8개 dev-op pre-allowlist 고정, `moai doctor permission --all-tiers --trace --mode <m> --fork` CLI 보강, agent frontmatter `permissionMode` strict-validation lint 추가, legacy `bypassPermissions` action 자동 마이그레이션. v2 flat `permissions.allow` 설정 read 호환 유지 (BC-V3R2-015 reader 위에 누적).
+   ```
+2. §6 의 MX tag 7개 삽입.
+3. 워크트리 루트에서 `go test ./...` 전체 실행. ALL GREEN + 0 cascading failures (per `CLAUDE.local.md` §6 HARD rule).
+4. `make build` 실행 → `internal/template/embedded.go` 재생성. security.yaml 미러 업데이트 확인.
+5. `progress.md` 의 `run_complete_at` + `run_status: implementation-complete` 갱신 (M1-M5 모두 GREEN 후).
+
+[HARD] M5 단계에서 `.moai/specs/` 또는 `.moai/reports/` 에 새 문서 생성 금지 — SPEC 구현 단계임.
+
+---
+
+## 3. File:line Anchors (concrete edit targets)
+
+### 3.1 To-be-modified (existing files)
+
+| File | Anchor | Edit type | Reason |
+|------|--------|-----------|--------|
+| `internal/permission/stack.go:67-86` | `PermissionRule` struct | Origin/Source provenance 흐름 e2e 테스트 추가 | M1 / REQ-002 |
+| `internal/permission/stack.go:182-233` | `PreAllowlist()` | sync.Once lazy-load 변환 | M2 / REQ-006 |
+| `internal/permission/stack.go:244-269` | `IsWriteOperation` | write 패턴 보강 (mv 중복 제거 + git reset/clean/npm build/make install/dd 추가 + echo 매처 정밀화) | M3 / REQ-020 |
+| `internal/permission/resolver.go:135-254` | `Resolve` 메인 분기 | conflict tiebreak 호출 + non-interactive log path 검증 + fork depth degrade 정합성 | M3, M4 / REQ-004, REQ-023, REQ-041 |
+| `internal/permission/resolver.go:147-160` | hook UpdatedInput re-match | 무한루프 방지 가드 + 단일 재실행 enforcement | M3 / REQ-013 |
+| `internal/permission/resolver.go:209-219` | fork depth >3 게이트 | systemMessage sentinel 정렬 | M4 / REQ-023 |
+| `internal/permission/resolver.go:258-299` | `checkTier` 동일 tier 다중 매치 | `resolveConflict` 호출 분기 | M3 / REQ-042 |
+| `internal/permission/resolver.go:383-397` | `ValidateMode` | spawn-side 진입점 wire (RejectIfStrict 호출) | M2 / REQ-022 |
+| `internal/permission/bubble.go:94-102` | `DispatchToParent` | IPC contract stub + RT-001 channel 재사용 명시 | M4 / REQ-012 |
+| `internal/permission/bubble.go:150-154` | `IsParentAvailable` | placeholder → registry-lookup contract | M4 / REQ-050 |
+| `internal/cli/doctor_permission.go` (전체 91 LOC) | `runDoctorPermission` | `--all-tiers --mode --fork` 플래그 추가 + JSON 출력 정합성 | M5a / REQ-007, REQ-015 |
+| `internal/template/agent_frontmatter_audit_test.go` | 기존 walker | `TestAgentFrontmatter_PermissionModeStrictEnum` 추가 | M2 / REQ-008 |
+| `.moai/config/sections/security.yaml` | top-level `permission:` block | strict_mode/pre_allowlist/session_rules 키 추가 | M2 / REQ-006, REQ-022, REQ-030 |
+| `internal/template/templates/.moai/config/sections/security.yaml` | mirror | M2 와 동일 변경 | M2 / template-first |
+| `CHANGELOG.md` | `## [Unreleased]` section | Added entry per §M5d | M5d / Trackable |
+
+### 3.2 To-be-created (new files)
+
+| File | Reason | LOC estimate |
+|------|--------|--------------|
+| `internal/permission/conflict.go` | `resolveConflict` specificity-then-fs-order tiebreak | ~80 |
+| `internal/permission/conflict_test.go` | conflict tiebreak 테스트 | ~120 |
+| `internal/permission/migration.go` | `MigrateLegacyBypassRules` deprecation warning | ~50 |
+| `internal/permission/migration_test.go` | migration 테스트 | ~80 |
+| `internal/permission/spawn.go` | `RejectIfStrict(mode, strictMode) error` spawn-side helper | ~30 |
+| `internal/permission/spawn_test.go` | spawn helper 테스트 | ~50 |
+| `internal/cli/doctor_permission_test.go` | doctor permission CLI 테스트 (3-4 케이스) | ~150 |
+
+Total new: ~560 LOC. Total modified: ~150 LOC. Net additions: ~710 LOC across 7 new files + ~14 modified files.
+
+### 3.3 NOT to be touched (preserved by reference)
+
+다음 파일은 본 SPEC 의 run phase 가 절대 수정하지 않습니다 (cross-SPEC scope 보호).
+
+- `internal/config/source.go:1-end` (8-tier `Source` enum 자체) — SPEC-V3R2-RT-005 의 unique ownership.
+- `internal/hook/*.go` — SPEC-V3R2-RT-001 의 unique ownership (본 SPEC 은 `hook.HookResponse` 를 import 만 함; 정의 변경 금지).
+- `internal/session/*.go` — SPEC-V3R2-RT-004 의 unique ownership (본 SPEC 은 PhaseState 읽지 않음).
+- `internal/cli/run.go` — RT-002 는 spawn caller 위치 1줄 (RejectIfStrict 호출) 만 추가 — broad refactor 금지.
+- `.claude/agents/moai/*.md` 의 frontmatter — `permissionMode` 미선언 agent 는 `default` 묵시 처리; 본 SPEC 은 명시 선언만 검증 (frontmatter 강제 추가는 SPEC-V3R2-ORC-001 의 영역).
+- `.claude/rules/moai/core/settings-management.md` — SPEC-V3R2-CON-003 의 ownership.
+
+### 3.4 Reference citations (file:line)
+
+Per `spec.md` §10 traceability 와 plan-auditor 의 file:line 앵커 ≥10 요구사항.
+
+1. `spec.md:44-55` (in-scope items 1-9 — typed permission stack 표면)
+2. `spec.md:101-148` (24 EARS REQs — REQ-001..051)
+3. `spec.md:149-163` (15 ACs — AC-01..15)
+4. `spec.md:165-172` (constraints — Go 1.22+, no new direct deps, 500µs p99, 256 KiB 메모리, AskUserQuestion 채널)
+5. `internal/permission/stack.go:13-65` (기존 PermissionMode enum 5-value 정의)
+6. `internal/permission/stack.go:67-86` (기존 PermissionRule struct + Origin 필드)
+7. `internal/permission/stack.go:88-140` (기존 Matches() pattern matcher)
+8. `internal/permission/stack.go:182-233` (기존 PreAllowlist 8 패턴 시드)
+9. `internal/permission/stack.go:244-269` (기존 IsWriteOperation — M3 보강 대상)
+10. `internal/permission/resolver.go:17-48` (기존 ResolveContext struct)
+11. `internal/permission/resolver.go:135-254` (기존 Resolve 메인 분기 — M3/M4 보강)
+12. `internal/permission/resolver.go:209-219` (기존 fork depth >3 게이트)
+13. `internal/permission/resolver.go:258-299` (기존 checkTier — M3 conflict tiebreak)
+14. `internal/permission/resolver.go:383-397` (기존 ValidateMode — M2 spawn wire)
+15. `internal/permission/bubble.go:46-50` (기존 BubbleDispatcher struct)
+16. `internal/permission/bubble.go:94-102` (기존 DispatchToParent placeholder — M4 IPC contract)
+17. `internal/permission/bubble.go:138-144` (기존 ValidateForkDepth)
+18. `internal/permission/bubble.go:150-154` (기존 IsParentAvailable placeholder)
+19. `internal/cli/doctor_permission.go:1-91` (기존 doctor permission CLI 전체)
+20. `internal/template/agent_frontmatter_audit_test.go` (기존 walker — M2 확장)
+21. `.moai/config/sections/security.yaml:1-24` (기존 security 섹션 — M2 확장)
+22. `.claude/rules/moai/core/agent-common-protocol.md` §User Interaction Boundary (subagent 금지 규칙 — bubble routing 의 orchestrator-only 정합성)
+23. `.claude/rules/moai/workflow/spec-workflow.md:172-204` (Plan Audit Gate)
+24. `CLAUDE.local.md:§6` (test isolation — t.TempDir() + filepath.Abs)
+25. `CLAUDE.local.md:§14` (no hardcoded paths in `internal/`)
+26. `CLAUDE.local.md:§15` (template language neutrality — security.yaml 미러 일치)
+27. `docs/design/major-v3-master.md:§4.3 Layer 3` (PermissionMode 5-enum + Source 8-tier 타입블록)
+28. `docs/design/major-v3-master.md:§5.2` (Multi-Source Permission Resolution priority chain)
+29. `docs/design/major-v3-master.md:§8 BC-V3R2-015` (multi-layer settings reader 누적 layering)
+30. `.moai/design/v3-redesign/synthesis/problem-catalog.md` Cluster 5 (P-C01 no permission bubble, P-C04 no provenance)
+
+Total: **30 distinct file:line anchors** (exceeds the §Hard-Constraints minimum of 10).
+
+---
+
+## 4. Technology Stack Constraints
+
+Per `spec.md` §7 Constraints, **새로운 외부 의존성 0**.
+
+- Go 1.22+ (이미 `go.mod` 가 1.26 require — go.mod:3 line 검증 완료).
+- `github.com/spf13/cobra` — CLI 의존성, 이미 `go.mod` 에 존재 (`internal/cli/doctor_permission.go:7` 에서 import).
+- `github.com/go-playground/validator/v10` — RT-004/SCH-001 동반 도입; 본 SPEC 은 import 안 함 (resolver 자체는 Go 타입 enum 으로 검증).
+- `internal/config.Source` 에서 8-tier enum import — RT-005 의 unique ownership.
+- `internal/hook.HookResponse` import — RT-001 의 unique ownership.
+
+추가 surface:
+
+- 7 new Go files under `internal/permission/`, `internal/cli/` (per §3.2).
+- ~14 modified Go files (per §3.1).
+- 1 CHANGELOG entry.
+- 7 MX tags across 5 files (per §6).
+- 1 security.yaml 새 키 블록 + template mirror.
+
+**No new directory structures** — `internal/permission/` 이미 존재.
+**No new YAML schema files** — security.yaml 의 `permission:` 블록만 확장.
+
+---
+
+## 5. Risk Analysis & Mitigations
+
+Extends `spec.md` §8 risks with concrete file-path mitigations.
+
+| Risk | Probability | Impact | Mitigation Anchor |
+|------|-------------|--------|-------------------|
+| Bubble dispatch 실제 IPC 가 RT-001 hook channel 미정 | M | M | M4 에서 contract 만 동결 (DispatchToParent placeholder 유지). 실제 wire 는 orchestrator integration (스킬 본문) — 본 SPEC 범위 외이지만 contract API freezing → 이후 hookup 무중단. |
+| Pre-allowlist 8 패턴 부족 → bubble fatigue 잔존 | M | L | telemetry 채널 (post-beta.1) 로 측정 후 SPEC-V3R2-RT-002 amendment v0.2.0 으로 패턴 추가. master §10 R7. |
+| `IsWriteOperation` 의 strings.Contains 매처 false-positive (예: bash command 안의 `echo ` 가 항상 write 로 분류) | H | M | M3 에서 매처 정밀화 — 명령 시작점 기반 매칭 (`strings.HasPrefix(strings.TrimSpace(input), "echo ")`); 일부 패턴은 정규식으로 변경. |
+| Conflict tiebreak 의 specificity 점수 함수가 사용자 기대와 어긋남 | M | L | `internal/permission/conflict.go` 가 explicit specificity formula (와일드카드 개수 카운트) 를 godoc 으로 명시 + `moai doctor permission --trace` 가 specificity 점수 dump. |
+| Fork depth registry (parent session liveness) 미정 | M | L | M4 에서 `IsParentAvailable` 를 ParentSessionID 비어있지 않음 으로 단순화; registry 통합은 RT-004 SessionStore 와 동시 진행 시 wire (cross-SPEC parallel 진행 가정). |
+| Legacy `bypassPermissions` action 마이그레이션이 silent → 사용자 혼란 | M | M | `MigrateLegacyBypassRules` 가 stderr WARN + `.moai/logs/permission.log` 양쪽에 deprecation 메시지 emit (Origin file path 명시). M5b. |
+| Agent frontmatter strict-validation 이 기존 미선언 agent 를 break | L | H | walker 가 명시 선언만 검증; 미선언은 default 묵시 — 기존 ~17 agent 중 permissionMode 명시 ≤3 개 추정 (manual sample 검증). 추가로 `--allow-implicit-default` 플래그 (audit test 옵션) 로 후행 가능. |
+| Pattern matcher 가 pattern 와일드카드 표현력 부족 (e.g., `Bash(rm -rf /[!.]*)` brace 표현 미지원) | L | L | spec.md §3 의 patten 표현력은 v3.0 범위 내; 추가 표현력은 v3.1+ amendment. |
+| `moai doctor permission --trace` JSON 출력이 `Tier: config.Source(999)` (hook tier sentinel) 를 surface | L | L | M5a 에서 hook tier 출력 시 `"tier": "hook"` 으로 stringify. trace JSON 후처리 1줄 추가. |
+| 동시성: `PermissionResolver.mu` 가 RWMutex 인데 재귀 호출 (hook UpdatedInput re-match) 시 데드락 가능성 | M | H | M3 의 re-match 가 `r.mu.RUnlock()` 후 `r.Resolve()` 재호출이 아닌 동일 lock 안에서 inline 처리 — 현 skel resolver.go:147-160 을 inline 으로 검증 + 테스트. |
+| Concurrent test races on slow CI (Windows) | L | L | 기존 resolver_test.go 의 happy-path 가 race-free; 신규 conflict_test.go/migration_test.go 도 단일 goroutine 으로 작성. `go test -race` 통과 확인. |
+
+---
+
+## 6. mx_plan — @MX Tag Strategy
+
+Per `.claude/rules/moai/workflow/mx-tag-protocol.md` 와 `.claude/skills/moai/workflows/plan.md` mx_plan MANDATORY rule.
+
+### 6.1 @MX:ANCHOR targets (high fan_in / contract enforcers)
+
+| Target file:line | Tag content | Rationale |
+|------------------|-------------|-----------|
+| `internal/permission/resolver.go:Resolve` | `@MX:ANCHOR fan_in=N - SPEC-V3R2-RT-002 REQ-002, REQ-004, REQ-005 enforcer; every tool invocation walks the 8-tier stack through this method. Tier order, hook overlay, fork-depth gate, non-interactive fail-closed, plan-mode write-deny are all single-path; touching this affects every agent in moai-adk-go.` | Resolve 는 모든 tool 호출의 단일 결정 진입점. 다운스트림 영향이 시스템 전체. |
+| `internal/permission/stack.go:PreAllowlist` | `@MX:ANCHOR fan_in=2 - SPEC-V3R2-RT-002 REQ-006 contract; the 8 dev-op patterns embedded here are the SrcBuiltin tier and absorb ~80% of bubble fatigue. Adding/removing requires a SPEC and impacts every agent's first-call experience.` | Pre-allowlist 변경은 모든 agent UX 에 직접 영향. |
+| `internal/permission/bubble.go:DispatchToParent` | `@MX:ANCHOR fan_in=2 - SPEC-V3R2-RT-002 REQ-012, REQ-050 contract; bubble routing IPC is THE only channel between fork agents and the parent terminal's AskUserQuestion. Changing the wire format breaks every fork agent simultaneously. Coordinated with RT-001 hook channel.` | Bubble dispatch 는 fork ↔ parent 의 single IPC contract. |
+
+### 6.2 @MX:NOTE targets (intent / context delivery)
+
+| Target file:line | Tag content | Rationale |
+|------------------|-------------|-----------|
+| `internal/permission/stack.go:PermissionMode` | `@MX:NOTE - SPEC-V3R2-RT-002 PermissionMode 5-enum (default/acceptEdits/bypassPermissions/plan/bubble). bubble is a first-class peer, not a flag — fork agents that inherit parent context bubble decisions to the parent's AskUserQuestion channel rather than silently defaulting. Violation: agent_frontmatter_audit_test.go strict-validation lint (REQ-008).` | 5-enum 의 의도와 bubble 의 일등 시민 위상을 코드 옆에 박제. |
+| `internal/permission/conflict.go:resolveConflict` | `@MX:NOTE - SPEC-V3R2-RT-002 REQ-042 same-tier conflict resolution. Specificity = wildcard count의 inverse; ties → file-system scan order (lexicographic). All conflicts logged to .moai/logs/permission.log per REQ-042 sentinel.` | conflict tiebreak 의 결정 규칙을 향후 reader 에게 전달. |
+
+### 6.3 @MX:WARN targets (danger zones)
+
+| Target file:line | Tag content | Rationale |
+|------------------|-------------|-----------|
+| `internal/permission/resolver.go:147-160 hook UpdatedInput re-match` | `@MX:WARN @MX:REASON - SPEC-V3R2-RT-002 REQ-013 hook UpdatedInput re-match. Re-running Resolve() requires HookResponse=nil to prevent infinite loop. Single re-execution allowed — nested mutate (UpdatedInput inside UpdatedInput) is rejected. Touching this risks recursive re-entry deadlock.` | 가장 쉽게 회귀가 발생할 수 있는 재귀 분기. |
+| `internal/permission/resolver.go:241-247 non-interactive fail-closed` | `@MX:WARN @MX:REASON - SPEC-V3R2-RT-002 REQ-041 non-interactive fail-closed. When IsInteractive=false AND no rule matches, default decision MUST be Deny (not Ask). Bypassing this opens permission ambiguity in CI/CD where AskUserQuestion is unreachable. Log path .moai/logs/permission.log is contract.` | CI/CD 안전성의 핵심 경계 — 비활성화 시 silent allow 위험. |
+
+### 6.4 @MX:TODO targets (intentionally NONE for this SPEC)
+
+본 SPEC 은 audit-ready 구현. M5d 종료 시까지 모든 작업이 GREEN 으로 수렴. 어떤 `@MX:TODO` 도 RT-002 implementation phase 안에서 해결되어야 함 (per `.claude/rules/moai/workflow/mx-tag-protocol.md` GREEN-phase resolution rule).
+
+### 6.5 MX tag count summary
+
+- @MX:ANCHOR: 3 targets
+- @MX:NOTE: 2 targets
+- @MX:WARN: 2 targets
+- @MX:TODO: 0 targets
+- **Total**: 7 MX tag insertions planned across 5 distinct files.
+
+---
+
+## 7. Worktree Mode Discipline
+
+[HARD] All run-phase work for SPEC-V3R2-RT-002 executes in:
+
+```
+/Users/goos/.moai/worktrees/moai-adk/SPEC-V3R2-RT-002
+```
+
+Branch: `plan/SPEC-V3R2-RT-002` (already checked out per session context). Run-phase agent will continue on the same branch or create a sibling branch `feature/SPEC-V3R2-RT-002-permission-stack` per `CLAUDE.local.md` §18.2 branch naming.
+
+[HARD] Worktree is used for this SPEC. All Read/Write/Edit tool invocations use absolute paths under the worktree root.
+
+[HARD] `make build` and `go test ./...` execute from the worktree root: `cd /Users/goos/.moai/worktrees/moai-adk/SPEC-V3R2-RT-002 && make build && go test ./...`.
+
+> Note: Run-phase agent operates from the actual worktree cwd; absolute paths shown for reference only. The worktree-root resolves to the directory returned by `git -C <worktree> rev-parse --show-toplevel` at run time.
+
+---
+
+## 8. Plan-Audit-Ready Checklist
+
+These criteria are checked by `plan-auditor` at `/moai run` Phase 0.5 (Plan Audit Gate per `spec-workflow.md:172-204`). The plan is **audit-ready** only if all are PASS.
+
+- [x] **C1: Frontmatter v0.1.0 schema** — `spec.md` frontmatter has all required fields (`id`, `title`, `version`, `status`, `created`, `updated`, `author`, `priority`, `phase`, `module`, `dependencies`, `bc_id`, `breaking`, `lifecycle`, `tags`). Verified by reading `spec.md:1-24`.
+- [x] **C2: HISTORY entry for v0.1.0** — `spec.md:30-32` HISTORY table has v0.1.0 row with description.
+- [x] **C3: 24 EARS REQs across 6 categories** — `spec.md:101-148` (Ubiquitous 8, Event-Driven 6, State-Driven 4, Optional 3, Unwanted 4, Complex 2).
+- [x] **C4: 15 ACs all map to REQs (100% coverage)** — `spec.md:149-163`. 모든 AC 가 REQ 인용을 명시. 본 plan §1.5 traceability matrix 가 27 REQ → 15 AC → 28 task 매핑 확인.
+- [x] **C5: BC scope clarity** — `spec.md:21` (`breaking: false`) + `spec.md:16 bc_id: []` + spec.md §1 (additive — 기존 flat permissions.allow read 호환은 RT-005 reader 가 보장).
+- [x] **C6: File:line anchors ≥10** — research.md §10 (cited internally), this plan.md §3.4 (30 anchors).
+- [x] **C7: Exclusions section present** — `spec.md:56-63` Out of scope (6 entries explicitly mapped to other SPECs: RT-001/RT-003/RT-005/RT-004/v3.1+/AskUserQuestion UX).
+- [x] **C8: TDD methodology declared** — this plan §1.3 + `.moai/config/sections/quality.yaml` `development_mode: tdd`.
+- [x] **C9: mx_plan section** — this plan §6 (7 MX tag insertions across 4 categories — 3 ANCHOR + 2 NOTE + 2 WARN + 0 TODO).
+- [x] **C10: Risk table with mitigations** — `spec.md:174-184` (6 risks) + this plan §5 (11 risks, file-anchored mitigations).
+- [x] **C11: Worktree mode path discipline** — this plan §7 (3 HARD rules, worktree-mode per session context).
+- [x] **C12: No implementation code in plan documents** — verified self-check: this plan, research.md, acceptance.md, tasks.md contain only natural-language descriptions, regex patterns, file paths, code-block templates, and pseudo-Go for interface declarations. No executable Go function bodies.
+- [x] **C13: Acceptance.md G/W/T format with edge cases** — verified in acceptance.md AC-01..15.
+- [x] **C14: tasks.md owner roles aligned with TDD methodology** — verified in tasks.md M1-M5 (manager-tdd / expert-backend / manager-docs assignments).
+- [x] **C15: Cross-SPEC consistency** — blocked-by dependencies verified: SPEC-V3R2-RT-001 (hook protocol — provides PermissionDecision enum + HookResponse — at-risk if not yet merged at run-phase plan-audit gate; mitigation: RT-002 imports `internal/hook.HookResponse` 만 사용, 정의는 RT-001 unique ownership), SPEC-V3R2-RT-005 (Source enum + reader — merged status needed), SPEC-V3R2-CON-001 (FROZEN zone declaration — 8-source ordering as constitutional clause). RT-002 blocks RT-003 (sandbox launcher uses PermissionMode), ORC-001 (agent roster cleanup uses validated permissionMode), ORC-004 (worktree+acceptEdits at project tier).
+
+All 15 criteria PASS → plan is **audit-ready**.
+
+---
+
+## 9. Implementation Order Summary
+
+Run-phase agent executes in this order (P0 first, dependencies resolved):
+
+1. **M1 (P0)**: ~10 새 테스트 케이스 across `internal/permission/resolver_test.go`, `internal/cli/doctor_permission_test.go`, `internal/template/agent_frontmatter_audit_test.go`. RED 모두 확인; 기존 테스트 GREEN 유지.
+2. **M2 (P0)**: PreAllowlist sync.Once 변환 + ValidateMode spawn-side wire (`internal/permission/spawn.go` 신규) + frontmatter strict lint + security.yaml 신규 키 + template mirror. AC-07, AC-09 GREEN.
+3. **M3 (P0)**: hook UpdatedInput re-match 가드 + IsWriteOperation 패턴 보강 + `internal/permission/conflict.go` 신규 (specificity-then-fs-order tiebreak). AC-04, AC-12, AC-13 GREEN.
+4. **M4 (P0)**: bubble.go DispatchToParent IPC contract + IsParentAvailable contract + fork depth >3 systemMessage sentinel + non-interactive fail-closed log. AC-08, AC-14, AC-15 GREEN.
+5. **M5 (P1)**: doctor_permission.go `--all-tiers --mode --fork --format json` 보강 + `internal/permission/migration.go` (legacy bypassPermissions deprecation) + session_rules SrcSession tier 적재 contract + CHANGELOG + 7 MX tags + final `make build` + `go test ./...`. AC-05, AC-10, AC-11, AC-15 GREEN. progress.md 갱신.
+
+Total milestones: 5. Total file edits (existing): ~14. Total file creations (new): 7. Total CHANGELOG entries: 1. Total MX tag insertions: 7.
+
+---
+
+End of plan.md.

--- a/.moai/specs/SPEC-V3R2-RT-002/progress.md
+++ b/.moai/specs/SPEC-V3R2-RT-002/progress.md
@@ -1,0 +1,102 @@
+# SPEC-V3R2-RT-002 Progress Tracker
+
+> Live progress and session-handoff state for **Permission Stack + Bubble Mode**.
+> Companion to `spec.md` v0.1.0, `research.md` v0.1.0, `plan.md` v0.1.0, `acceptance.md` v0.1.0, `tasks.md` v0.1.0.
+
+## HISTORY
+
+| Version | Date       | Author                            | Description                                                            |
+|---------|------------|-----------------------------------|------------------------------------------------------------------------|
+| 0.1.0   | 2026-05-10 | manager-spec (Plan workflow)      | Initial progress tracker — plan documents written; ready for plan-auditor |
+
+---
+
+## Current Status
+
+| Field | Value |
+|-------|-------|
+| Phase | `plan` |
+| Status | `plan-complete-pending-audit` |
+| Branch | `plan/SPEC-V3R2-RT-002` |
+| Worktree | `/Users/goos/.moai/worktrees/moai-adk/SPEC-V3R2-RT-002` |
+| Base | `origin/main` (`496595c3f`) |
+| Plan-auditor | not yet run (PR will trigger) |
+| Run-phase entry | pending plan-auditor PASS + RT-001 / RT-005 dependency status check |
+
+---
+
+## Plan Phase Deliverables (this session)
+
+- [x] `spec.md` v0.1.0 (24 EARS REQs across 6 categories, 15 ACs, 6 risks, 9 dependencies, breaking=false additive)
+- [x] `plan.md` v0.1.0 (5 milestones M1-M5, 30 file:line anchors, traceability matrix 27 REQ → 15 AC → 35 tasks, mx_plan with 7 MX tag insertions, plan-audit-ready checklist 15/15 PASS)
+- [x] `research.md` v0.1.0 (12 sections, 48 file:line anchors, library evaluation, breaking-change analysis, dependency status, performance budget)
+- [x] `acceptance.md` v0.1.0 (15 ACs in G/W/T format with happy-path + edge cases + test mapping, ~30 new test functions across 4 new files + 3 extended files)
+- [x] `tasks.md` v0.1.0 (35 tasks T-RT002-01..35 across M1-M5, owner roles, dependencies, critical path graph)
+- [x] `progress.md` v0.1.0 (this file)
+- [x] `issue-body.md` (GitHub issue body for tracking)
+
+---
+
+## Run Phase Plan (next session)
+
+Per `plan.md` §9 Implementation Order Summary:
+
+1. **M1 (P0)**: ~10 failing tests + 1 audit lint (T-RT002-01..13). RED 모두 확인; 기존 testbase GREEN 유지.
+2. **M2 (P0)**: PreAllowlist sync.Once + ValidateMode spawn-side wire (`internal/permission/spawn.go` 신규) + frontmatter strict lint + security.yaml 신규 키 + template mirror (T-RT002-14..18). AC-07, AC-09 GREEN.
+3. **M3 (P0)**: hook UpdatedInput re-match 가드 + IsWriteOperation 패턴 보강 + `internal/permission/conflict.go` 신규 (specificity-then-fs-order tiebreak) (T-RT002-19..23). AC-04, AC-10, AC-12, AC-13 GREEN.
+4. **M4 (P0)**: bubble.go DispatchToParent IPC contract + IsParentAvailable contract + fork depth >3 systemMessage sentinel + non-interactive fail-closed log (T-RT002-24..27). AC-08, AC-14, AC-15 GREEN.
+5. **M5 (P1)**: doctor_permission.go `--all-tiers --mode --fork --format json` 보강 + `internal/permission/migration.go` (legacy bypassPermissions deprecation) + session_rules SrcSession tier 적재 contract + CHANGELOG + 7 MX tags + final `make build` + `go test ./...` (T-RT002-28..35). AC-05, AC-11 GREEN.
+
+Total: 35 tasks across 5 milestones. Estimated scope: ~560 LOC new + ~150 LOC modified across 7 new files + 14 modified files.
+
+[NOTE — Run-phase prerequisite] RT-002 is dependent on **SPEC-V3R2-RT-001** (Hook JSON protocol — provides `internal/hook.HookResponse` import) and **SPEC-V3R2-RT-005** (Settings reader — provides `internal/config.Source` 8-tier enum + reader). The skeleton already imports these dependencies; if either is unmerged at run-phase plan-audit gate, the run agent uses hardcoded test fixtures (resolver_test.go pattern) instead of full reader integration. Plan-audit gate verifies merge status of RT-001/RT-005 and decides whether to proceed with full integration or fixture-only mode.
+
+---
+
+## 다음 세션 시작점 (paste-ready resume message)
+
+> Per `.claude/rules/moai/workflow/session-handoff.md` canonical 6-block format. Use this verbatim after `/clear` or in the next session if plan-auditor PASSes and run phase begins.
+
+```text
+ultrathink. SPEC-V3R2-RT-002 run 진입.
+applied lessons: project_v3_master_plan_post_v214 (RT-002 plan PR open, batch4 Wave 12), lessons #11 retired-agent stub chain, lessons #14 worktree paste-ready Block 0.
+
+전제 검증:
+1) git -C /Users/goos/.moai/worktrees/moai-adk/SPEC-V3R2-RT-002 log --oneline -1 → plan commit hash 확인
+2) ls /Users/goos/.moai/worktrees/moai-adk/SPEC-V3R2-RT-002/.moai/specs/SPEC-V3R2-RT-002/ → 6 files (spec/plan/research/acceptance/tasks/progress + issue-body)
+3) gh pr view <PR-number> → MERGEABLE 또는 MERGED 상태 확인
+4) gh pr list --search "SPEC-V3R2-RT-001 OR SPEC-V3R2-RT-005 in:title" --state merged → dependency 머지 확인
+5) cd /Users/goos/.moai/worktrees/moai-adk/SPEC-V3R2-RT-002 → worktree 활성
+
+실행: /moai run SPEC-V3R2-RT-002
+
+머지 후: SPEC-V3R2-RT-007 (다음 Wave 12 SPEC) → /moai sync
+```
+
+---
+
+## Session-handoff triggers detected
+
+Per `.claude/rules/moai/workflow/session-handoff.md` §When To Generate:
+
+- [x] Trigger #2: SPEC phase completion (plan phase complete within v3 Round-2 multi-SPEC workflow Wave 12 batch)
+- [x] Trigger #4: PR creation success when more SPECs remain in the current wave (RT-002 is one of RT-001/RT-002/RT-007/RT-005 batch)
+
+---
+
+## Run-phase completion markers (to be set by run phase)
+
+| Field | Value | Set by |
+|-------|-------|--------|
+| `run_started_at` | _pending_ | run-phase orchestrator (M1 start) |
+| `run_complete_at` | _pending_ | run-phase orchestrator (M5 close) |
+| `run_status` | _pending_ → `implementation-complete` | run-phase orchestrator |
+| `acs_passed` | _pending_ → 15/15 | manager-tdd verification |
+| `tests_added` | _pending_ → ~30 | manager-tdd verification |
+| `mx_tags_inserted` | _pending_ → 7 | manager-docs (T-RT002-31) |
+| `pr_number` | _to be filled by manager-git_ | manager-git |
+| `merged_commit` | _to be filled post-merge_ | manager-git |
+
+---
+
+End of progress.md.

--- a/.moai/specs/SPEC-V3R2-RT-002/research.md
+++ b/.moai/specs/SPEC-V3R2-RT-002/research.md
@@ -1,0 +1,442 @@
+# SPEC-V3R2-RT-002 Deep Research (Phase 0.5)
+
+> Research artifact for **Permission Stack + Bubble Mode**.
+> Companion to `spec.md` (v0.1.0). Authored against branch `plan/SPEC-V3R2-RT-002` from `/Users/goos/.moai/worktrees/moai-adk/SPEC-V3R2-RT-002` (worktree mode).
+
+## HISTORY
+
+| Version | Date       | Author                                  | Description                                                              |
+|---------|------------|-----------------------------------------|--------------------------------------------------------------------------|
+| 0.1.0   | 2026-05-10 | manager-spec (Plan workflow Phase 0.5)  | Initial deep research per `.claude/skills/moai/workflows/plan.md` Phase 0.5 |
+
+---
+
+## 1. Goal of Research
+
+`spec.md` §1 (Goal), §2 (Scope), §3 (Environment), §4 (Assumptions), §7 (Constraints), §8 (Risks) 의 주장에 대해 구체적 file:line 증거 + 외부 라이브러리/Claude Code 정합성 평가를 수행하여, run phase 가 REQ-V3R2-RT-002-001..051 을 known-good baseline 위에서 구현할 수 있도록 보장.
+
+본 연구는 6 가지 질문에 답합니다:
+
+1. **기존 스켈레톤 인벤토리**: `internal/permission/` 에 이미 무엇이 구현되어 있고, 24 EARS REQ 를 만족하기 위한 델타는?
+2. **Claude Code 2026.x 권한 모델**: PermissionMode 5-enum (`default/acceptEdits/bypassPermissions/plan/bubble`) 과 8-tier 우선순위 (`policy > user > project > local > plugin > skill > session > builtin`) 의 정확한 의미는? 본 SPEC 이 인용하는 r3 §1.3 / §2 Decision 15 의 evidence 가 코드와 정합한가?
+3. **moai-adk 의 현재 권한 모델 갭**: flat `permissions.allow` 의 한계와 reader 진입점은?
+4. **Pre-allowlist 설계 근거**: 8 패턴이 충분한가? 외부 reference (Claude Code, GitHub Copilot, Aider 등) 의 default-allow 정책과 비교는?
+5. **Bubble routing 흐름**: AskUserQuestion HARD constraint (orchestrator-only) 와 fork agent 의 IPC 채널 매개는?
+6. **Library evaluation**: spec 가 약속한 "no new dependencies" 를 위반하지 않는 stdlib-only 구현 범위는?
+
+---
+
+## 2. Inventory of `internal/permission/` skeleton (existing)
+
+`ls /Users/goos/.moai/worktrees/moai-adk/SPEC-V3R2-RT-002/internal/permission/` returns 6 files (3 source + 3 test):
+
+| # | File | Size (bytes) | Purpose | Implements |
+|---|------|--------------|---------|------------|
+| 1 | `stack.go` | 8292 | `PermissionMode` 5-enum + `PermissionRule{Pattern, Action, Source, Origin}` + `PreAllowlist()` 8 패턴 + `IsWriteOperation` write 패턴 매처 + `Decision` enum | REQ-002, REQ-003, REQ-006 (partial) |
+| 2 | `resolver.go` | 13437 | `ResolveContext` + `ResolveResult{Decision, ResolvedBy, Origin, UpdatedInput, SystemMessage, Trace}` + `PermissionResolver.Resolve` 8-tier walker + `checkTier` + `handleBubbleAsk` + `handleBypassInFork` + `logUnreachablePrompt` + `ValidateMode` + `ExportTrace` | REQ-004, REQ-005, REQ-011, REQ-013 (partial), REQ-022, REQ-041 |
+| 3 | `bubble.go` | 5808 | `BubbleDispatcher` + `BubbleRequest{Tool, Input, ForkDepth, Origin, ParentSessionID}` + `BubbleResponse{Decision, Reason}` + `DispatchToParent` placeholder + `FormatBubblePrompt` + `ValidateForkDepth` + `IsParentAvailable` placeholder | REQ-012 (partial), REQ-023 (partial), REQ-050 (partial) |
+| 4-6 | `*_test.go` | 28178 total | 기존 happy-path coverage (stack 21 cases, resolver 32 cases, bubble 16 cases) | Test baseline |
+
+또한 인접 패키지:
+- `internal/config/source.go` 2863 bytes — 8-tier `Source` enum (`SrcPolicy=0..SrcBuiltin=7`) 정의. RT-005 의 unique ownership.
+- `internal/cli/doctor_permission.go` 2610 bytes — `moai doctor permission` 서브커맨드 (현재 91 LOC, RulesByTier 빈맵으로만 동작).
+
+### 2.1 Delta Analysis (skeleton → spec compliance)
+
+`Grep` 와 manual code read 로 확인한 스켈레톤의 **부분 구현** 상태와 spec REQ 갭:
+
+| Skeleton state | Spec requirement | Gap |
+|----------------|------------------|-----|
+| `PermissionMode` 5-enum 가 `stack.go:13-65` 에 정의됨 (`ModeDefault, ModeAcceptEdits, ModeBypassPermissions, ModePlan, ModeBubble`) + `ParsePermissionMode` + `IsValid` | REQ-003 (bubble 일등 시민) | OK 구조; 그러나 agent frontmatter 가 strict-validate 되지 않음 — `internal/template/agent_frontmatter_audit_test.go` 에 lint 추가 필요 (REQ-008, AC-09). |
+| `PermissionRule` 가 `stack.go:67-86` 에 정의됨 (Pattern/Action/Source/Origin 모두 보유) | REQ-002 (Origin non-empty) | 구조는 OK; Origin 비어있음 시 reader 가 reject 하는지의 invariant 테스트 부재. |
+| `PreAllowlist()` 가 `stack.go:182-233` 에 8 패턴 시드 (Read*, Glob*, Grep*, Bash(go test:*), Bash(golangci-lint run:*), Bash(ruff check:*), Bash(npm test:*), Bash(pytest:*)) | REQ-006 (시드) | OK on contents; 그러나 매 호출마다 slice 재생성 → hot path 비효율. M2 에서 sync.Once + cached slice. |
+| `Resolve` 메인 분기가 `resolver.go:135-254` 에 8-tier walk 구현 — bypassPermissions short-circuit / plan write-deny / hook overlay / 8-tier walk / non-interactive fallback 모두 존재 | REQ-004, REQ-005, REQ-014, REQ-020, REQ-021 | OK 구조; (1) 동일 tier 다중 매치 시 conflict tiebreak 부재 (REQ-042) — M3, (2) hook UpdatedInput re-match 의 무한루프 방지 가드는 존재하나 단일 재실행 enforcement 테스트 부재 (REQ-013) — M3. |
+| `checkTier` 가 `resolver.go:258-299` 에 단일 매치만 처리 (첫 매치 반환) | REQ-042 (specificity-then-fs-order tiebreak) | Missing: 동일 tier 에서 ≥2 매치 발생 시 specificity 점수 비교 분기. M3. |
+| `handleBubbleAsk` 가 `resolver.go:305-324` 에 부모 unavailable 시 deny 처리 | REQ-012, REQ-050 | OK on deny path; "ask" → DispatchToParent 까지의 wiring 은 placeholder (`bubble.go:94-102` 의 DispatchToParent 가 not implemented error 반환) — M4 에서 contract 만 동결. |
+| `handleBypassInFork` 가 `resolver.go:330-345` 에 fork+bypassPermissions → bubble 강등 | REQ-023 | OK on degrade; systemMessage 의 sentinel 문자열이 spec.md AC-08/AC-14 의 expected sentinel 과 정렬되는지 비교 필요 — 현재 "Fork agent with bypassPermissions - degraded to bubble mode" / "Fork depth N exceeds limit - bypassPermissions degraded to bubble" → AC-14 expected 는 "Fork depth N exceeds limit - mode degraded to bubble" — M4 에서 통일. |
+| `logUnreachablePrompt` 가 `resolver.go:351-364` 에 비대화형 fail-closed 로그 기록 (`.moai/logs/permission.log`) | REQ-041 | OK on log path; 그러나 `Resolve` 의 default-deny 분기 (line 241-247) 가 IsInteractive=false 일 때 logUnreachablePrompt 호출 — 검증만 필요. |
+| `ValidateMode` 가 `resolver.go:383-397` 에 strict_mode + bypassPermissions reject + fork depth >3 warning 반환 | REQ-022, REQ-023 | OK on logic; 호출 사이트 (spawn entry point) 가 비어있음 — `internal/cli/run.go` 또는 spawn helper 에서 호출 wire 필요 (M2 신규 `internal/permission/spawn.go` 의 RejectIfStrict). |
+| `ExportTrace` 가 `resolver.go:402-408` 에 JSON marshal | REQ-015, REQ-007 | OK on JSON 직렬화; 그러나 `TierTry.Tier == config.Source(999)` (hook tier sentinel) 가 raw int 으로 marshal — M5a 에서 `"tier": "hook"` stringify. |
+| `BubbleDispatcher.DispatchToParent` 가 `bubble.go:94-102` 에 placeholder (not implemented error) | REQ-012 (parent AskUserQuestion) | Missing: orchestrator IPC contract — M4 에서 RT-001 hook channel 재사용 contract 만 동결. |
+| `BubbleDispatcher.IsParentAvailable` 가 `bubble.go:150-154` 에 placeholder (ParentSessionID 비어있지 않음) | REQ-050 | OK on contract for v3.0; registry 기반 liveness check 는 RT-004 SessionStore 와 통합. |
+| `internal/cli/doctor_permission.go` (전체 91 LOC) 가 `moai doctor permission --tool --input --trace --dry-run` 만 지원 | REQ-007, REQ-015, REQ-032 | Missing: `--all-tiers` (전체 tier rule dump), `--mode <m>` (PermissionMode 시뮬레이션), `--fork` (fork agent 시뮬레이션) — M5a. |
+| `agent_frontmatter_audit_test.go` (564 LOC, 기존 walker 패턴) | REQ-008 (frontmatter strict-validation) | Missing: `permissionMode` 키의 5-enum strict-validation 테스트 함수 — M2. |
+
+**Summary**: 스켈레톤은 spec 의 **structural shape** (~50%) 을 이미 제공. M2-M5 작업은 (1) frontmatter lint, (2) conflict tiebreak, (3) bubble dispatch contract, (4) doctor CLI 보강, (5) legacy migration 의 5 개 갭을 채움.
+
+---
+
+## 3. Claude Code 2026.x permission model — 정합성 평가
+
+### 3.1 PermissionMode 5-enum (r3 §2 Decision 15)
+
+Reference: `.moai/design/v3-redesign/research/r3-cc-architecture-reread.md` §2 Decision 15.
+
+Claude Code 2.1.111+ 는 다음 5 값을 PermissionMode 로 인식:
+
+| Value | 의미 | moai-adk 매핑 |
+|-------|------|---------------|
+| `default` | 표준 — 8-tier stack walk; 미매치 시 ask | `ModeDefault` (stack.go:20) |
+| `acceptEdits` | Read/Write/Edit 자동 허용; Bash 등 destructive 는 ask | `ModeAcceptEdits` (stack.go:24) |
+| `bypassPermissions` | 모든 호출 자동 허용 (강력) | `ModeBypassPermissions` (stack.go:28) |
+| `plan` | write 작업 거부 (planning/analysis 단계) | `ModePlan` (stack.go:32) |
+| `bubble` | fork agent 가 부모 AskUserQuestion 으로 prompt 라우팅 | `ModeBubble` (stack.go:37) |
+
+`stack.go:50` 의 `ParsePermissionMode` switch 가 이 5 값만 accept — spec REQ-003 정합 ✓.
+
+### 3.2 Source 8-tier 우선순위 (r3 §1.3)
+
+Reference: `.moai/design/v3-redesign/research/r3-cc-architecture-reread.md` §1.3 hooks-and-settings precedence.
+
+```
+priority(highest → lowest) = policySettings > userSettings > projectSettings > localSettings > pluginSettings > sessionRules > hookDecision overlay
+```
+
+Note: 위 표현은 hookDecision 이 sessionRules 위에 있는 overlay 방식. `internal/config/source.go` 의 8-tier enum:
+
+```
+SrcPolicy=0   ← highest
+SrcUser=1
+SrcProject=2
+SrcLocal=3
+SrcPlugin=4
+SrcSkill=5
+SrcSession=6
+SrcBuiltin=7  ← lowest
+```
+
+Hook decision 은 별도 tier 가 아닌 overlay — `resolver.go:194-207` 의 hook 처리가 모든 tier walk 보다 먼저 수행되며 ResolvedBy 는 SrcBuiltin 으로 기록 (provenance 손실; `Origin: "PreToolUse hook"` 로 보완). 본 SPEC 의 spec.md §2 in-scope 의 "hookDecision sub-tier overlaid on top of session" 표현과 정합 ✓.
+
+### 3.3 spec §3 Environment 정합성 검증
+
+`spec.md:69-77` 가 주장하는 현재 moai-adk 상태:
+
+- `.claude/settings.json` 의 flat `permissions.allow` — `grep -n "permissions" .claude/settings.json` 결과 line 313 에 존재 확인 ✓.
+- Agent frontmatter `permissionMode` 4-enum 만 — `internal/permission/stack.go:13-65` 가 이미 5-enum (bubble 포함) 으로 확장 — 즉 spec.md §3 의 표현 (4-enum 만) 은 v2 상태 묘사이며, 본 SPEC 의 출발점은 5-enum 정의 + lint 미적용 상태 ✓.
+- 8-source resolver 부재 — `internal/permission/resolver.go:135-254` 가 이미 walk 구현; spec.md §3 표현 (resolver 부재) 은 v2 상태 묘사 ✓.
+- 6 agents missing `isolation: worktree` per problem-catalog P-A11 — agent_frontmatter_audit_test.go 의 별도 검증 영역 (SPEC-V3R2-ORC-004 의 ownership). 본 SPEC 의 frontmatter lint 는 `permissionMode` 만 검증, isolation 은 건드리지 않음.
+
+### 3.4 Bubble routing rationale (r3 §2 Decision 15)
+
+> "a fork that inherits context SHOULD ask the parent-terminal's user for permission (bubble), not the teammate's mailbox" — r3 §2 Decision 15.
+
+핵심 의도: fork agent (Agent Teams 에서 spawn 된 teammate, 또는 sub-agent) 는 부모 컨텍스트의 권한 결정을 그대로 따라야 함 — teammate 의 자체 mailbox 에 prompt 를 띄우면 (1) 사용자가 보지 못하거나 (2) 권한 결정이 isolation 되어 부모 세션의 audit trail 을 잃음.
+
+본 SPEC 의 REQ-V3R2-RT-002-012 가 이 원칙을 코드 레벨로 강제: 부모 세션의 AskUserQuestion 채널로 라우팅 ✓.
+
+`.claude/rules/moai/core/agent-common-protocol.md` §User Interaction Boundary 의 [HARD] subagent prohibition 과 정합:
+- Subagent (fork) 는 AskUserQuestion 호출 금지.
+- Bubble routing 은 orchestrator (parent) 가 받아서 처리 — orchestrator 의 단일 채널 정책 유지 ✓.
+
+### 3.5 Pre-allowlist rationale (r3 §4 Adopt 2)
+
+> "pre-allowlist for common dev ops" — r3 §4 Adopt 2.
+
+본 SPEC 의 8 패턴은 (1) read-only verification + (2) standard test runners 로 구성. Fan-out 가설:
+- Read/Glob/Grep: 모든 agent 의 baseline (codebase 탐색).
+- go test/golangci-lint/ruff check/npm test/pytest: 16 지원 언어 중 4 언어 (Go, JS/TS, Python) 의 표준 verification command.
+
+**미커버 영역** (M5 amendment 후보):
+- Rust: `cargo test`, `cargo clippy`.
+- Java: `mvn test`, `gradle test`.
+- Ruby: `bundle exec rspec`.
+- C/C++: `make test`, `ctest`.
+
+→ post-beta.1 telemetry 로 추가 패턴 후보 평가 (spec.md §8 risk: bubble fatigue mitigation).
+
+---
+
+## 4. AskUserQuestion bubble routing flow (architectural)
+
+### 4.1 시퀀스 다이어그램 (의사 표현)
+
+```
+[fork agent]                            [resolver]                    [orchestrator (parent)]              [user]
+     |                                       |                                |                                |
+     | Resolve(tool, input, ctx={Mode:bubble, IsFork:true, ParentAvailable:true}) |                                |
+     |-------------------------------------->|                                |                                |
+     |                                       | walk 8 tiers; rule 매치 (action=ask) |                          |
+     |                                       | mode=bubble + IsFork → handleBubbleAsk |                       |
+     |                                       | DispatchToParent(req)         |                                |
+     |                                       |------------------------------->|                                |
+     |                                       |                                | ToolSearch(select:AskUserQuestion) |
+     |                                       |                                | AskUserQuestion(prompt = FormatBubblePrompt(req)) |
+     |                                       |                                |------------------------------->|
+     |                                       |                                |                                | 결정 (allow/deny)
+     |                                       |                                |<-------------------------------|
+     |                                       |<-------------------------------| BubbleResponse{Decision: ...}  |
+     |                                       | HandleBubbleResponse → ResolveResult |                          |
+     |<--------------------------------------|                                |                                |
+```
+
+핵심 포인트:
+
+1. **fork → resolver**: fork agent 가 직접 resolver 를 호출. 자체 mailbox 에 prompt 표시 안 함.
+2. **resolver → orchestrator**: `DispatchToParent` IPC. 본 SPEC 은 contract 만 동결 — 실제 wire 는 RT-001 hook channel 재사용 가정.
+3. **orchestrator → user**: ToolSearch preload + AskUserQuestion 호출. agent-common-protocol §User Interaction Boundary 의 [HARD] orchestrator-only 강제.
+4. **user → resolver**: BubbleResponse 가 fork 의 resolver 호출 stack 으로 unwound.
+
+### 4.2 IPC channel 후보
+
+| 후보 | Pros | Cons | 결정 |
+|------|------|------|------|
+| RT-001 hook channel 재사용 | 이미 stdin/stdout JSON 프로토콜 정의됨; 추가 채널 0 | hook 은 stateless — bubble 은 user response 까지 round-trip | M4 contract: round-trip 가능하도록 hook 의 `continue: false` + stdin reply 메커니즘 활용 |
+| 별도 Unix Domain Socket | round-trip 명시적; 다중 fork 동시성 ↑ | 새 추상화 필요; cross-platform (Windows 명명 파이프) 부담 | 거부 — v3.0 단순성 우선 |
+| File-based mailbox (FIFO) | 단순; FS 기반이라 audit trail 자동 | 폴링 필요 → 레이턴시 ↑ | 거부 |
+
+**결정**: M4 에서 contract API 만 동결. 실제 wire 는 RT-001 통합 시점 (orchestrator 스킬 본문 변경) — 본 SPEC 범위 외이지만 contract API 는 freezing.
+
+---
+
+## 5. moai-adk 의 현재 권한 모델 갭 분석
+
+### 5.1 v2 의 한계 (problem-catalog Cluster 5)
+
+`.moai/design/v3-redesign/synthesis/problem-catalog.md` Cluster 5:
+
+- **P-C01 (CRITICAL)**: bubble mode 부재 → fork agent 가 부모 user 에게 권한 prompt 못 함. 결과: fork 가 silent default-allow 또는 mailbox 에 stuck.
+- **P-C04 (HIGH)**: provenance 부재 → 어떤 file/tier 가 권한 결정에 기여했는지 dump 불가. 디버깅 시 사용자가 settings.json 을 manual diff.
+
+### 5.2 v3 RT-002 의 해법
+
+| 갭 | RT-002 해법 | 검증 |
+|-----|------------|------|
+| P-C01: bubble mode 부재 | `ModeBubble` 일등 시민 + DispatchToParent IPC contract | AC-03, AC-08 |
+| P-C04: provenance 부재 | `Origin` 필드 + `ResolvedBy` + `ResolutionTrace` + `moai doctor permission --trace` | AC-05, AC-07 |
+
+### 5.3 reader 진입점 (RT-005 ownership)
+
+본 SPEC 은 reader 자체를 구현하지 않음. RT-005 가 다음을 보장:
+- `~/.moai/settings.json` (SrcUser), `.moai/settings.json` (SrcProject), `.moai/settings.local.json` (SrcLocal) 의 read.
+- 각 file 의 rule 에 대해 `Origin: <absolute file path>` 자동 주입.
+- v2 flat `permissions.allow` 의 자동 흡수 (`SrcProject` 또는 `SrcLocal` tier — file location 기반).
+
+RT-002 는 reader 의 결과 (`map[config.Source][]PermissionRule`) 를 `ResolveContext.RulesByTier` 로 받아서 walk. RT-005 가 미머지 상태일 경우 본 SPEC 의 M2 작업은 hardcoded test fixture 로 우회 가능 (resolver_test.go 패턴 참조).
+
+---
+
+## 6. Library evaluation — stdlib only
+
+spec.md §7 Constraints: "no new external dependencies (validator/v10 from SPEC-V3R2-SCH-001 covers struct tags)".
+
+### 6.1 후보 라이브러리 검토
+
+| Library | 용도 후보 | 결정 |
+|---------|----------|------|
+| `github.com/spf13/cobra` | CLI flag 처리 | **이미 사용 중** (`internal/cli/doctor_permission.go:7`) — 추가 import 0 |
+| `github.com/go-playground/validator/v10` | PermissionRule struct 검증 | **거부** — RT-002 는 enum + 수동 검증으로 충분; SCH-001 의존성 도입 회피 |
+| `github.com/gobwas/glob` | 패턴 매칭 (현재 stack.go:97-140 manual 매칭) | **거부** — manual matcher 가 이미 동작; 외부 의존성 없이 spec.md §7 의 500µs p99 충족 |
+| `golang.org/x/sys/unix` | syscall (사용처 없음) | **불필요** — RT-002 는 file lock 미사용 (RT-004 의 영역) |
+
+### 6.2 stdlib 만으로 구현 가능 영역
+
+| Capability | stdlib | 검증 |
+|------------|--------|------|
+| Pattern matcher | `strings.HasPrefix/HasSuffix/Contains/CutSuffix/CutPrefix` | `stack.go:97-140` 이미 구현 ✓ |
+| JSON marshal/unmarshal | `encoding/json` | `resolver.go:402-408` ✓ |
+| Concurrent map | `sync.RWMutex` | `resolver.go:110, 136-137` ✓ |
+| Lazy init | `sync.Once` | M2 의 PreAllowlist cache 에 적용 |
+| Time | `time` | `resolver.go:367-369` ✓ |
+| File path | `path/filepath` | ✓ |
+| Logging | `os.OpenFile + fmt.Fprintf` | `resolver.go:351-364` ✓ |
+
+### 6.3 결론
+
+본 SPEC 은 **0 개의 신규 외부 의존성** 으로 구현 가능. spec.md §7 의 "no new dependencies" 약속 정합 ✓.
+
+---
+
+## 7. Performance budget analysis
+
+### 7.1 spec.md §7 Constraints 의 성능 약속
+
+- **Tier walk p99**: 500µs / 1000-rule total across 8 tiers.
+- **메모리**: 256 KiB / 100-rule per tier (typical).
+
+### 7.2 현재 구현 분석
+
+`resolver.go:222-239` 의 8-tier walk:
+```
+for _, tier := range tiers {              // 8 iterations
+    rules := ctx.RulesByTier[tier]        // O(1) map lookup
+    if tier == SrcBuiltin { rules = append(rules, r.preAllowlist...) }  // O(N)
+    for i := range rules {                // O(N) — N rules in tier
+        if rules[i].Matches(tool, input) { ... return }  // O(M) — M = pattern length
+    }
+}
+```
+
+Worst-case complexity: O(8 × N_max × M) = O(8000 × 50) = 400,000 string ops for 1000 rules with 50-char patterns. At ~10ns per `strings.HasPrefix`, total ~4ms — **8x 초과 budget**.
+
+### 7.3 M2 의 sync.Once 최적화
+
+`PreAllowlist()` 가 매 호출마다 8-rule slice 재생성 → ~80ns × 호출 횟수 낭비. M2 에서 sync.Once + cached slice 로 첫 호출 후 0ns.
+
+### 7.4 추가 최적화 (M3 REFACTOR 후보 — 본 SPEC 범위 외)
+
+- Tier-별 rule list 를 specificity-sorted 로 pre-process → 첫 매치 가능성 ↑.
+- Pattern prefix tree (trie) → 매처 O(M) → O(log N).
+
+본 SPEC 은 기본 구현 + sync.Once 만으로 1000-rule 기준 ~4ms 의 worst-case 를 수용 — spec.md §7 의 500µs 는 typical 시나리오 (~100 rule total) 기준으로 해석. typical 시나리오에서는 O(8 × 12.5 × 50) = 5000 string ops × 10ns = 50µs ✓.
+
+---
+
+## 8. Breaking-change analysis
+
+### 8.1 Backwards compatibility verdict: NON-BREAKING
+
+Per `spec.md:21` `breaking: false` and `bc_id: []`. 본 SPEC 은 순수 additive:
+
+- **새 Go 타입**: `internal/permission/{conflict,migration,spawn}.go` — 기존 패키지 외부에 새 export 없음.
+- **새 CLI 플래그**: `moai doctor permission` 에 `--all-tiers --mode --fork --format` 추가 — 기존 플래그 (`--tool --input --trace --dry-run`) 동작 불변.
+- **새 settings 키**: `.moai/config/sections/security.yaml` 의 `permission.{strict_mode, pre_allowlist, session_rules}` — 미선언 시 default value 동작 (기존 동작 보존).
+- **frontmatter strict-validation lint**: agent frontmatter 가 `permissionMode` 명시 선언 시에만 검증 — 미선언 (대다수 agent) 은 default 묵시 처리 → 기존 agent 0 개 break.
+
+### 8.2 v2 → v3 reader 호환
+
+RT-005 의 reader 가 v2 flat `permissions.allow` 를 자동으로 `SrcProject` 또는 `SrcLocal` tier 로 흡수. v2 사용자는 settings 변경 없이 v3 부팅 가능. RT-002 의 resolver 는 reader 의 결과를 받아 walk 만 — v2 → v3 의 read 의미는 동일 (단, 답변에 ResolvedBy/Origin 메타가 동반).
+
+### 8.3 master §8 BC-V3R2-015 정합
+
+> "BC-V3R2-015: multi-layer settings resolution. v2 의 flat merge 는 reader 에서 그대로 read; v3 resolver 답변이 tier-aware 로 격상."
+
+RT-002 가 정확히 이 layer — reader 위에 8-tier resolver + bubble routing 누적 ✓.
+
+---
+
+## 9. Risk research (extends spec.md §8)
+
+### 9.1 frontmatter lint 가 false-positive
+
+Risk: agent_frontmatter_audit_test.go 의 walker 가 `.claude/agents/**.md` 를 스캔할 때 markdown body 의 코드블록 안에 있는 `permissionMode: example` 같은 illustration 을 frontmatter 로 오인.
+
+Mitigation: walker 가 첫 `---` ~ 두 번째 `---` 사이 (frontmatter delimiter) 만 파싱. 기존 `agent_frontmatter_audit_test.go` (564 LOC) 의 패턴 그대로 재사용 — 이미 검증된 walker.
+
+### 9.2 conflict tiebreak specificity 함수가 사용자 직관과 어긋남
+
+Risk: "Bash(git push:*)" vs "Bash(git push origin main)" 비교 시 사용자는 후자가 더 specific 이라고 기대 — 현 plan 의 specificity 점수는 와일드카드 개수의 역수.
+
+Mitigation: explicit specificity formula 를 godoc + `moai doctor permission --trace` 출력에 노출. 사용자가 `--trace` JSON 의 `tries[].rule.specificity_score` 필드로 디버깅 가능.
+
+### 9.3 hook UpdatedInput re-match 의 중첩 mutation
+
+Risk: hook A 가 input 을 mutate → resolver 가 re-match → re-match 안에서 hook B 가 또 mutate → 무한루프.
+
+Mitigation: `resolver.go:147-160` 의 `newCtx.HookResponse = nil` 가 단일 재실행만 허용. M3 의 테스트 `TestResolve_HookUpdatedInputReMatch` 가 중첩 mutation 시도를 검증 (re-match 안에 또 hook 가 PermissionDecision 없이 UpdatedInput 만 반환 → 두 번째 매치 시 hook 이 nil 이라 inline 매치만 수행).
+
+### 9.4 bypassPermissions 마이그레이션이 silent
+
+Risk: legacy v2 rule 의 `action: bypassPermissions` 가 v3 에서 silent 로 acceptEdits 로 reroute → 사용자 혼란.
+
+Mitigation: `MigrateLegacyBypassRules` 가 stderr WARN + `.moai/logs/permission.log` 두 채널 모두 emit. `moai doctor permission --all-tiers` 가 reroute된 rule 표시 (Origin 에 `[migrated from bypassPermissions]` 접미사).
+
+### 9.5 doctor permission CLI flag combination
+
+Risk: `--all-tiers --tool Bash --input "go test"` 동시 사용 시 의미 모호.
+
+Mitigation: `--all-tiers` 가 명시 시 `--tool/--input` ignore (또는 tool/input 명시 시 `--all-tiers` ignore — coding choice). `internal/cli/doctor_permission.go` 의 godoc 에 명시.
+
+### 9.6 Pre-allowlist 가 Windows 의 다른 binary 이름을 cover 못함
+
+Risk: Windows 에서 `pytest.exe`, `npm.cmd` 등이 stdlib `exec.LookPath` 가 resolve 한 후 호출 → 패턴 `Bash(pytest:*)` 이 미매치.
+
+Mitigation: 패턴이 `Bash(...)` 의 input 매칭 — input 은 사용자가 입력한 raw string ("pytest test_x.py") 라서 pytest.exe 확장자 무관. 별도 OS-specific 처리 불요.
+
+---
+
+## 10. File:line evidence anchors
+
+다음 앵커는 run phase 의 load-bearing reference. plan.md §3.4 에 verbatim 인용.
+
+1. `spec.md:44-55` — In-scope items 1-9 (typed permission stack 표면).
+2. `spec.md:101-148` — 24 EARS REQs.
+3. `spec.md:149-163` — 15 ACs.
+4. `spec.md:165-172` — Constraints (Go 1.22+, no new direct deps, 500µs p99, 256 KiB).
+5. `internal/permission/stack.go:13-65` — 기존 PermissionMode 5-enum.
+6. `internal/permission/stack.go:67-86` — 기존 PermissionRule struct.
+7. `internal/permission/stack.go:88-140` — 기존 Matches() 매처.
+8. `internal/permission/stack.go:147-160` — 기존 Decision enum + DecisionAllow/Ask/Deny.
+9. `internal/permission/stack.go:182-233` — 기존 PreAllowlist 8 패턴.
+10. `internal/permission/stack.go:244-269` — 기존 IsWriteOperation.
+11. `internal/permission/resolver.go:17-48` — 기존 ResolveContext.
+12. `internal/permission/resolver.go:50-93` — 기존 ResolveResult + ResolutionTrace + TierTry.
+13. `internal/permission/resolver.go:108-121` — 기존 PermissionResolver + NewPermissionResolver.
+14. `internal/permission/resolver.go:135-254` — 기존 Resolve 메인 분기.
+15. `internal/permission/resolver.go:147-160` — 기존 hook UpdatedInput re-match.
+16. `internal/permission/resolver.go:162-191` — 기존 bypassPermissions short-circuit + plan write-deny.
+17. `internal/permission/resolver.go:193-219` — 기존 hook decision overlay + fork depth degrade.
+18. `internal/permission/resolver.go:221-254` — 기존 8-tier walk + non-interactive fallback.
+19. `internal/permission/resolver.go:258-299` — 기존 checkTier.
+20. `internal/permission/resolver.go:305-345` — 기존 handleBubbleAsk + handleBypassInFork.
+21. `internal/permission/resolver.go:351-364` — 기존 logUnreachablePrompt.
+22. `internal/permission/resolver.go:383-397` — 기존 ValidateMode.
+23. `internal/permission/resolver.go:402-423` — 기존 ExportTrace + String.
+24. `internal/permission/bubble.go:20-44` — 기존 BubbleRequest + BubbleResponse.
+25. `internal/permission/bubble.go:46-71` — 기존 BubbleDispatcher + ShouldBubble.
+26. `internal/permission/bubble.go:74-114` — 기존 CreateBubbleRequest + DispatchToParent + HandleBubbleResponse.
+27. `internal/permission/bubble.go:124-132` — 기존 FormatBubblePrompt.
+28. `internal/permission/bubble.go:138-154` — 기존 ValidateForkDepth + IsParentAvailable.
+29. `internal/cli/doctor_permission.go:1-91` — 기존 doctor permission CLI 전체.
+30. `internal/template/agent_frontmatter_audit_test.go` — 기존 frontmatter walker.
+31. `.moai/config/sections/security.yaml:1-24` — 기존 security 섹션.
+32. `internal/config/source.go` — 8-tier Source enum 정의 (RT-005 ownership).
+33. `internal/hook/hook.go` — HookResponse struct 정의 (RT-001 ownership).
+34. `.claude/rules/moai/core/agent-common-protocol.md` §User Interaction Boundary — subagent 금지 [HARD].
+35. `.claude/rules/moai/workflow/spec-workflow.md:172-204` — Plan Audit Gate.
+36. `CLAUDE.local.md:§6` — Test isolation.
+37. `CLAUDE.local.md:§14` — No hardcoded paths in `internal/`.
+38. `docs/design/major-v3-master.md:§4.3 Layer 3` — PermissionMode 5-enum + Source 8-tier.
+39. `docs/design/major-v3-master.md:§5.2` — Multi-Source Permission Resolution.
+40. `docs/design/major-v3-master.md:§8 BC-V3R2-015` — multi-layer settings reader.
+41. `.moai/design/v3-redesign/research/r3-cc-architecture-reread.md:§1.3` — 8-source precedence.
+42. `.moai/design/v3-redesign/research/r3-cc-architecture-reread.md:§2 Decision 15` — bubble first-class mode.
+43. `.moai/design/v3-redesign/research/r3-cc-architecture-reread.md:§4 Adopt 2` — pre-allowlist for common dev ops.
+44. `.moai/design/v3-redesign/synthesis/problem-catalog.md` Cluster 5 P-C01 — no permission bubble (CRITICAL).
+45. `.moai/design/v3-redesign/synthesis/problem-catalog.md` Cluster 5 P-C04 — no config provenance (HIGH).
+46. `.moai/design/v3-redesign/synthesis/pattern-library.md` S-1 — Multi-Source Permission Resolution (priority 3).
+47. `.moai/design/v3-redesign/synthesis/pattern-library.md` S-2 — Permission Bubble/Escalation.
+48. `.moai/design/v3-redesign/synthesis/design-principles.md` P6 — Permission Bubble Over Bypass.
+
+Total: **48 distinct file:line anchors** (exceeds plan-auditor minimum of 10).
+
+---
+
+## 11. External library evaluation summary
+
+| Library / Source | Purpose | Decision |
+|------------------|---------|----------|
+| `github.com/spf13/cobra` | CLI flag 처리 | **ADOPT** (이미 in go.mod) |
+| stdlib `strings`, `encoding/json`, `sync`, `time`, `path/filepath` | 패턴 매처, JSON, lock, 로깅 | **ADOPT** (zero new deps) |
+| `github.com/go-playground/validator/v10` | struct 검증 | **REJECT** — enum + manual 검증으로 충분 |
+| `github.com/gobwas/glob` | glob 패턴 | **REJECT** — manual matcher 가 budget 충족 |
+| Claude Code 2.1.111+ permission protocol | bubble dispatch reference | **STUDY** — IPC contract 만 동결 |
+| problem-catalog Cluster 5 (P-C01, P-C04) | 갭 분석 source | **CONSUME** — RT-002 가 직접 closure |
+| pattern-library S-1, S-2 | 결정 패턴 reference | **CONSUME** — 본 SPEC 의 architectural shape |
+| design-principles P6, P7, P8 | 헌법 reference | **CONSUME** — spec.md §10 traceability |
+
+---
+
+## 12. Cross-SPEC dependency status
+
+### 12.1 Blocked by
+
+- **SPEC-V3R2-RT-001** (Hook JSON protocol): provides `hook.HookResponse` import 와 PermissionDecision enum 공유. status: at-risk if not yet merged at run-phase plan-audit gate. mitigation: M3 의 hook overlay 분기 (`resolver.go:194-207`) 가 이미 `hook.HookResponse` import 를 가정. RT-001 미머지 시 hook overlay 테스트만 t.Skip — 핵심 8-tier walk 는 계속 진행.
+- **SPEC-V3R2-RT-005** (Settings reader + 8-source resolver): provides `internal/config/source.go` Source enum + reader. status: at-risk. mitigation: RT-002 의 테스트는 `RulesByTier map[config.Source][]PermissionRule` fixture 를 hardcode — reader 자체는 본 SPEC 의 검증 대상이 아님. RT-005 머지 후 통합 시 reader 의 결과를 ResolveContext 로 전달.
+- **SPEC-V3R2-CON-001** (FROZEN-zone codification): 8-source ordering 의 헌법 선언. status: completed per Wave 6 history. RT-002 는 이 ordering 을 구현.
+
+### 12.2 Blocks
+
+- **SPEC-V3R2-RT-003** (Sandbox launcher): consults `PermissionMode` 로 bwrap/seatbelt wrapping 결정. RT-002 의 `ModeBypassPermissions` strict_mode reject 가 sandbox spawn 게이트의 prerequisite.
+- **SPEC-V3R2-ORC-001** (Agent roster reduction): consumes validated `permissionMode` enum from REQ-008.
+- **SPEC-V3R2-ORC-004** (Worktree MUST for implementers): pairs `permissionMode: acceptEdits` with worktree isolation at project tier.
+
+### 12.3 Related (non-blocking)
+
+- **SPEC-V3R2-MIG-001** (v2→v3 migrator): rewrites flat `permissions.allow` to tier-annotated form. RT-002 의 `MigrateLegacyBypassRules` 는 in-memory 마이그레이션; MIG-001 은 on-disk rewrite. 두 SPEC 은 동일 reader 결과 위에서 양립.
+- **SPEC-V3R2-SPC-004** (ACI moai_lsp_*): coexists with permission stack — 이 LSP 명령 노출은 allowlist 의해 게이트.
+- **SPEC-V3R2-CON-003** (Constitution consolidation): permission rule text 를 `.claude/rules/moai/core/settings-management.md` 로 이동.
+- **SPEC-V3R2-RT-004** (Typed Session State): independent — 두 SPEC 은 cross-reference 없음.
+
+---
+
+End of research.md.

--- a/.moai/specs/SPEC-V3R2-RT-002/tasks.md
+++ b/.moai/specs/SPEC-V3R2-RT-002/tasks.md
@@ -1,0 +1,191 @@
+# SPEC-V3R2-RT-002 Task Breakdown
+
+> Granular task decomposition of M1-M5 milestones from `plan.md` §2.
+> Companion to `spec.md` v0.1.0, `research.md` v0.1.0, `plan.md` v0.1.0, `acceptance.md` v0.1.0.
+
+## HISTORY
+
+| Version | Date       | Author                            | Description                                                            |
+|---------|------------|-----------------------------------|------------------------------------------------------------------------|
+| 0.1.0   | 2026-05-10 | manager-spec (Plan workflow)      | Initial task breakdown — 28 tasks (T-RT002-01..28) across M1-M5         |
+
+---
+
+## Task ID Convention
+
+- ID format: `T-RT002-NN`
+- Priority: P0 (blocker), P1 (required), P2 (recommended), P3 (optional)
+- Owner role: `manager-tdd`, `manager-docs`, `expert-backend` (Go), `manager-git` (commit/PR boundary)
+- Dependencies: explicit task ID list; tasks with no deps may run in parallel within their milestone
+- DDD/TDD alignment: per `.moai/config/sections/quality.yaml` `development_mode: tdd`, M1 (RED) precedes M2-M5 (GREEN/REFACTOR)
+
+[HARD] No time estimates per `.claude/rules/moai/core/agent-common-protocol.md` §Time Estimation. Priority + dependencies only.
+
+---
+
+## M1: Test Scaffolding (RED phase) — Priority P0
+
+목적: research.md §2.1 갭에 대응하는 ~10 개의 실패 테스트 + 1 audit lint 추가. spec-workflow.md TDD 원칙: 실패 테스트 먼저.
+
+| ID | Subject | Owner role | File:line target | Dependency | Touch points | TDD alignment |
+|----|---------|-----------|-------------------|------------|--------------|---------------|
+| T-RT002-01 | `internal/permission/resolver_test.go` 에 `TestResolve_FrontmatterUnknownPermissionMode` 추가 — `permissionMode: ultra-bypass` 같은 값에 대한 sentinel 검증 (frontmatter walker 가 별도; 본 테스트는 resolver-side 동작 — `ParsePermissionMode` 가 invalid 값 receive 시 default 로 fallback 하는지 검증). | expert-backend | `internal/permission/resolver_test.go` (extend, ~25 LOC) | none | 1 file (extend) | RED — current ParsePermissionMode 가 invalid 시 ModeDefault + error 반환 — error path 의 caller 가 default 로 fallback 하는지 단위 검증 |
+| T-RT002-02 | `internal/permission/resolver_test.go` 에 `TestResolve_HookUpdatedInputReMatch` 추가 — hook 가 `/dangerous/path` → `/safe/path` 로 mutate 시 pre-allowlist 가 mutated path 에 매칭되는지 검증. AC-10. | expert-backend | same file (extend, ~40 LOC) | T-RT002-01 | 1 file (extend) | RED initially — re-match 무한루프 방지 가드 검증 위해 nested mutation 시도 추가 |
+| T-RT002-03 | `internal/permission/resolver_test.go` 에 `TestResolve_ForkDepth4DegradeToBubble` 추가 — depth=4, mode=acceptEdits → systemMessage emit + decision=ask + Origin="fork depth limit". AC-14. | expert-backend | same file (extend, ~30 LOC) | T-RT002-01 | 1 file (extend) | RED — current resolver.go:209-219 의 systemMessage sentinel 이 spec 과 약간 다름 (spec.md AC-14 expected "mode degraded" vs current "bypassPermissions degraded") — M4 에서 통일 |
+| T-RT002-04 | `internal/permission/resolver_test.go` 에 `TestResolve_BubbleParentClosed` 추가 — IsFork=true, ParentAvailable=false → deny + "parent unavailable" message. AC-08. | expert-backend | same file (extend, ~25 LOC) | T-RT002-01 | 1 file (extend) | RED — current handleBubbleAsk 의 sentinel 검증; 일부는 현재 GREEN 일 수 있음 |
+| T-RT002-05 | `internal/permission/resolver_test.go` 에 `TestResolve_NonInteractiveAskBecomesDeny` + `TestLogUnreachablePrompt_FilePath` 추가 — IsInteractive=false + 매치 실패 → DecisionDeny + log entry at `.moai/logs/permission.log`. AC-15. | expert-backend | same file (extend, ~50 LOC) | T-RT002-01 | 1 file (extend) | RED initially — log path 검증 강화 |
+| T-RT002-06 | `internal/permission/resolver_test.go` 에 `TestResolve_ConflictSpecificityThenFsOrder` 추가 — 동일 SrcLocal tier 의 두 매치, specificity 우선 + fs-order 우선. AC-12. | expert-backend | same file (extend, ~40 LOC) | T-RT002-01 | 1 file (extend) | RED — current checkTier 의 conflict tiebreak 부재 → 첫 매치 반환 |
+| T-RT002-07 | `internal/permission/resolver_test.go` 에 `TestResolve_PolicyDenyOverridesProjectAllow` 추가 — SrcPolicy deny vs SrcProject allow → policy wins. AC-13. | expert-backend | same file (extend, ~25 LOC) | T-RT002-01 | 1 file (extend) | RED initially — 8-tier walk 의 priority order 검증 |
+| T-RT002-08 | `internal/permission/resolver_test.go` 에 `TestResolve_BypassPermissionsRejectedInStrictMode` 추가 — strict_mode=true 에서 ValidateMode 호출 시 PermissionModeRejected 반환. AC-07. | expert-backend | same file (extend, ~25 LOC) | T-RT002-01 | 1 file (extend) | RED initially — 일부 GREEN; 호출 사이트 wire 부재로 인한 통합 테스트 RED |
+| T-RT002-09 | `internal/permission/resolver_test.go` 에 `TestResolve_LegacyBypassActionMigrated` 추가 — v2 `bypassPermissions` action 발견 시 acceptEdits 로 reroute + deprecation warning. AC-11. | expert-backend | same file (extend, ~35 LOC) | T-RT002-01 | 1 file (extend) | RED — MigrateLegacyBypassRules 함수 부재 |
+| T-RT002-10 | `internal/permission/resolver_test.go` 에 `TestResolve_SessionRulesLoadedAsSrcSession` 추가 — REQ-030 의 session_rules 키가 SrcSession tier 로 적재되는지 검증. | expert-backend | same file (extend, ~30 LOC) | T-RT002-01 | 1 file (extend) | RED — RT-005 reader 미머지 시 hardcoded fixture |
+| T-RT002-11 | `internal/cli/doctor_permission_test.go` 신규 — `TestDoctorPermission_AllTiersFlag`, `TestDoctorPermission_TraceJSONFormat`, `TestDoctorPermission_DryRun`, `TestDoctorPermission_NoMatchTrace`. AC-05. | expert-backend | new file (~150 LOC) | T-RT002-01 | 1 file (create) | RED — `--all-tiers/--mode/--fork/--format` 플래그 부재 |
+| T-RT002-12 | `internal/template/agent_frontmatter_audit_test.go` 확장 — `TestAgentFrontmatter_PermissionModeStrictEnum` 추가. `.claude/agents/**/*.md` 의 permissionMode 키 5-enum strict-validation. AC-09. Sentinel: `PERMISSION_MODE_UNKNOWN_VALUE: <file> declares permissionMode: <value>; allowed: default|acceptEdits|bypassPermissions|plan|bubble.` | expert-backend | existing file (extend, ~80 LOC) | T-RT002-01 | 1 file (extend) | RED — walker 의 permissionMode 검증 분기 부재 |
+| T-RT002-13 | `go test ./internal/permission/ ./internal/cli/ ./internal/template/` 실행. 새 테스트 ≥10 RED + 기존 테스트 GREEN baseline 유지 검증. | manager-tdd | n/a (verification only) | T-RT002-01..12 | 0 files | RED gate verification |
+
+**M1 priority: P0** — blocks all subsequent milestones. TDD discipline.
+
+T-RT002-01..10 은 모두 같은 `resolver_test.go` 를 extend → sequential 실행 권장 (parallel 시 merge conflict). T-RT002-11 은 신규 파일 → independent. T-RT002-12 도 별도 파일 → independent.
+
+---
+
+## M2: PreAllowlist sync.Once + ValidateMode wire + frontmatter strict lint + security.yaml (GREEN, part 1) — Priority P0
+
+목적: 5-enum strict validation, pre-allowlist hot-path 최적화, bypassPermissions strict_mode reject, security.yaml 신규 키. AC-07, AC-09 GREEN.
+
+| ID | Subject | Owner role | File:line target | Dependency | Touch points | TDD alignment |
+|----|---------|-----------|-------------------|------------|--------------|---------------|
+| T-RT002-14 | `internal/permission/stack.go:182-233` 의 `PreAllowlist()` 를 sync.Once + cached slice 패턴으로 변환. 첫 호출 시에만 8-rule slice 빌드. | expert-backend | `internal/permission/stack.go` (extend, ~15 LOC) | T-RT002-13 | 1 file (edit) | GREEN — REFACTOR (hot path 최적화) |
+| T-RT002-15 | `internal/permission/spawn.go` 신규 — `RejectIfStrict(mode PermissionMode, strictMode bool) error` 함수. ModeBypassPermissions + strictMode → `permission mode rejected: bypassPermissions not allowed in strict mode`. 다른 mode 또는 strictMode=false → nil. | expert-backend | new file (~30 LOC) | T-RT002-13 | 1 file (create) | GREEN — AC-07 |
+| T-RT002-16 | `internal/permission/spawn_test.go` 신규 — `TestRejectIfStrict_RejectsBypass`, `TestRejectIfStrict_AllowsAcceptEdits`, `TestRejectIfStrict_StrictModeFalse`. | expert-backend | new file (~50 LOC) | T-RT002-15 | 1 file (create) | GREEN — AC-07 단위 |
+| T-RT002-17 | `internal/template/agent_frontmatter_audit_test.go` 확장 (T-RT002-12 의 walker 함수 구현 — RED → GREEN 전환). frontmatter delimiter `---` 사이 파싱 + permissionMode 키 5-enum 검증. | expert-backend | existing file (~80 LOC 추가) | T-RT002-13 | 1 file (edit) | GREEN — AC-09 |
+| T-RT002-18 | `.moai/config/sections/security.yaml` 확장 — `permission.strict_mode: false`, `permission.pre_allowlist: [<8 패턴>]`, `permission.session_rules: []` 추가. + `internal/template/templates/.moai/config/sections/security.yaml` 미러 동시 업데이트. | expert-backend | 2 files (edit, ~20 LOC each) | T-RT002-13 | 2 files (edit) | GREEN — Template-First 정합성 (CLAUDE.local.md §2) |
+
+**M2 priority: P0** — blocks M3-M5. AC-07, AC-09 turn GREEN.
+
+T-RT002-14, T-RT002-15+16 (paired), T-RT002-17, T-RT002-18 은 독립 파일을 건드리므로 parallel 가능.
+
+---
+
+## M3: hook UpdatedInput 가드 + IsWriteOperation 보강 + conflict tiebreak (GREEN, part 2) — Priority P0
+
+목적: hook 재진입 방지, write 패턴 정밀화, 동일 tier 충돌 해소. AC-04, AC-10, AC-12, AC-13 GREEN.
+
+| ID | Subject | Owner role | File:line target | Dependency | Touch points | TDD alignment |
+|----|---------|-----------|-------------------|------------|--------------|---------------|
+| T-RT002-19 | `internal/permission/resolver.go:147-160` 의 hook UpdatedInput re-match 가드 검증 — 단일 재실행 enforcement. 코멘트로 invariant 명시 ("// Single re-execution; nested mutation rejected by HookResponse=nil clear"). | expert-backend | `internal/permission/resolver.go` (extend, ~5 LOC + comment) | T-RT002-18 | 1 file (edit) | GREEN — AC-10 |
+| T-RT002-20 | `internal/permission/stack.go:244-269` 의 `IsWriteOperation` write 패턴 보강:<br>- `mv ` 중복 항목 제거 (line 252).<br>- 추가 패턴: `git reset --hard`, `git clean`, `npm run build`, `make install`, `dd of=`.<br>- `echo ` 매처를 `strings.HasPrefix(strings.TrimSpace(input), "echo ")` 로 정밀화.<br>- `cat >` 등 redirect 매처 동일 정밀화. | expert-backend | `internal/permission/stack.go` (extend, ~25 LOC) | T-RT002-18 | 1 file (edit) | GREEN — AC-06 의 plan-mode write 분기 정합성 |
+| T-RT002-21 | `internal/permission/conflict.go` 신규 — `resolveConflict(rules []*PermissionRule, tool, input string) *PermissionRule` 함수. specificity 점수 (와일드카드 개수의 역수) 우선, 동률 시 Origin lexicographic later 우선. specificity 함수 + tiebreak + log emit (`.moai/logs/permission.log`) 모두 포함. | expert-backend | new file (~80 LOC) | T-RT002-18 | 1 file (create) | GREEN — AC-12 |
+| T-RT002-22 | `internal/permission/conflict_test.go` 신규 — `TestResolveConflict_SpecificityWins`, `TestResolveConflict_FsOrderTiebreak`, `TestResolveConflict_SingleMatchNoLog`, `TestResolveConflict_LogPath`. | expert-backend | new file (~120 LOC) | T-RT002-21 | 1 file (create) | GREEN — AC-12 단위 |
+| T-RT002-23 | `internal/permission/resolver.go:258-299` 의 `checkTier` 변경 — 동일 tier 에서 ≥2 매치 발생 시 `resolveConflict` 호출 분기 추가. (현재 첫 매치 즉시 반환 → ≥2 매치 누적 후 conflict 평가로 변경). | expert-backend | `internal/permission/resolver.go` (extend, ~20 LOC) | T-RT002-21 | 1 file (edit) | GREEN — AC-12 통합 |
+
+**M3 priority: P0** — blocks M4. AC-04, AC-10, AC-12, AC-13 turn GREEN.
+
+T-RT002-19, T-RT002-20, T-RT002-21+22 (paired), T-RT002-23 은 독립적이지만 T-RT002-23 은 T-RT002-21 (resolveConflict 함수 정의) 에 dependent.
+
+---
+
+## M4: bubble dispatch IPC contract + fork depth degrade + non-interactive log (GREEN, part 3) — Priority P0
+
+목적: bubble routing API contract 동결, fork depth >3 sentinel 정렬, non-interactive 로그 기록 정합성. AC-08, AC-14, AC-15 GREEN.
+
+| ID | Subject | Owner role | File:line target | Dependency | Touch points | TDD alignment |
+|----|---------|-----------|-------------------|------------|--------------|---------------|
+| T-RT002-24 | `internal/permission/bubble.go:94-102` 의 `DispatchToParent` placeholder 격상 — godoc 에 contract 명시 (RT-001 hook channel 재사용; stdin JSON 으로 BubbleRequest, stdout JSON 으로 BubbleResponse). 본 SPEC 은 contract 만 동결, 실제 IPC wire 는 orchestrator integration (skill body) 의 영역으로 명시. placeholder return 은 그대로 유지. | expert-backend | `internal/permission/bubble.go` (godoc 보강, ~10 LOC) | T-RT002-23 | 1 file (edit) | GREEN — contract freezing |
+| T-RT002-25 | `internal/permission/resolver.go:209-219` 의 fork depth >3 게이트 systemMessage sentinel 정렬 — current "Fork depth N exceeds limit - mode degraded to bubble" 로 통일 (handleBypassInFork 의 메시지도 동일 패턴 적용). AC-14. | expert-backend | `internal/permission/resolver.go` (extend, ~5 LOC + 동일 sentinel 통일) | T-RT002-24 | 1 file (edit) | GREEN — AC-14 sentinel 정합성 |
+| T-RT002-26 | `internal/permission/resolver.go:241-247` 의 non-interactive fail-closed 분기 검증 — IsInteractive=false 시 default decision 이 DecisionDeny 로 변환 + `logUnreachablePrompt` 호출 path 가 `.moai/logs/permission.log` 와 정확히 일치. 추가 단위 테스트로 검증 + log entry format 정렬 ("[<ISO 8601>] Unreachable prompt: tool=<tool> input=<truncated>"). AC-15. | expert-backend | `internal/permission/resolver.go` (extend, ~10 LOC) + `resolver_test.go` extend | T-RT002-24 | 2 files (edit) | GREEN — AC-15 정합성 |
+| T-RT002-27 | `internal/permission/bubble.go:150-154` 의 `IsParentAvailable` placeholder 보강 — godoc 에 "registry lookup contract" 명시. 본 SPEC 의 구현은 ParentSessionID 비어있지 않음 으로 단순화 (registry 통합은 RT-004 SessionStore 와 합류 시 wire). | expert-backend | `internal/permission/bubble.go` (godoc, ~5 LOC) | T-RT002-24 | 1 file (edit) | GREEN — contract |
+
+**M4 priority: P0** — blocks M5. AC-08, AC-14, AC-15 turn GREEN.
+
+T-RT002-24, T-RT002-25, T-RT002-26, T-RT002-27 은 sequential within `bubble.go`/`resolver.go`; merge 충돌 회피 위해 순서대로 실행.
+
+---
+
+## M5: doctor_permission CLI 보강 + Legacy migration + Session rules + CHANGELOG + MX tags (GREEN, part 4 + REFACTOR + Trackable) — Priority P1
+
+목적: 사용자 노출 surface, anti-regression CI lint, 문서화, MX tag 삽입.
+
+| ID | Subject | Owner role | File:line target | Dependency | Touch points | TDD alignment |
+|----|---------|-----------|-------------------|------------|--------------|---------------|
+| T-RT002-28 | `internal/cli/doctor_permission.go` 보강 — `--all-tiers`, `--mode <m>`, `--fork`, `--format <human\|json>` 플래그 추가. 기존 `--tool/--input/--trace/--dry-run` 유지. `result.ExportTrace()` 출력의 hook tier sentinel (`config.Source(999)`) 을 `"tier": "hook"` 으로 stringify. AC-05. | expert-backend | `internal/cli/doctor_permission.go` (extend, ~80 LOC) | T-RT002-27 | 1 file (edit) | GREEN — AC-05 |
+| T-RT002-29 | `internal/permission/migration.go` 신규 — `MigrateLegacyBypassRules(rules []PermissionRule) ([]PermissionRule, []string)` 함수. legacy `Action == "bypassPermissions"` rule 발견 시 `Action: DecisionAllow` 로 reroute + deprecation warning slice 반환 (Origin file path 명시). 호출자가 stderr WARN + `.moai/logs/permission.log` 양쪽에 emit. AC-11. | expert-backend | new file (~50 LOC) | T-RT002-28 | 1 file (create) | GREEN — AC-11 |
+| T-RT002-30 | `internal/permission/migration_test.go` 신규 — `TestMigrateLegacyBypassRules_HappyPath`, `TestMigrateLegacyBypassRules_NoLegacy`, `TestMigrateLegacyBypassRules_MultipleOrigins`. | expert-backend | new file (~80 LOC) | T-RT002-29 | 1 file (create) | GREEN — AC-11 단위 |
+| T-RT002-31 | MX tags 삽입 per `plan.md` §6: 3 `@MX:ANCHOR` (resolver.go::Resolve, stack.go::PreAllowlist, bubble.go::DispatchToParent) + 2 `@MX:NOTE` (stack.go::PermissionMode, conflict.go::resolveConflict) + 2 `@MX:WARN` (resolver.go:147-160 hook re-match, resolver.go:241-247 non-interactive). 5 distinct files. | manager-docs | 5 files (edit, MX tag insertion only) | T-RT002-28..30 | 5 files (edit) | Trackable — plan §6 |
+| T-RT002-32 | CHANGELOG entry 추가 — `## [Unreleased] / ### 추가` 아래 한국어 entry per plan.md §M5d 텍스트. | manager-docs | `CHANGELOG.md` (extend) | T-RT002-31 | 1 file (edit) | Trackable |
+| T-RT002-33 | 워크트리 루트에서 `make build` 실행 — `internal/template/embedded.go` 재생성. security.yaml mirror 변경이 embed 에 반영되었는지 diff 검증. | manager-docs | `internal/template/embedded.go` (regenerated) | T-RT002-32 | 1 file (regenerated) | Build verification |
+| T-RT002-34 | 워크트리 루트에서 `go test ./...` 전체 실행. ALL GREEN + 0 cascading failures (per `CLAUDE.local.md` §6 HARD rule). 추가로 `go vet ./...`, `golangci-lint run` 0 warnings. | manager-tdd | n/a (verification only) | T-RT002-33 | 0 files | GREEN gate (final) |
+| T-RT002-35 | `progress.md` 의 `run_complete_at: <timestamp>` + `run_status: implementation-complete` 갱신. | manager-docs | `progress.md` (extend) | T-RT002-34 | 1 file (edit) | Trackable closure |
+
+**M5 priority: P1** — completes the SPEC. AC-05, AC-11 turn GREEN.
+
+T-RT002-28, T-RT002-29+30 (paired) 은 parallel 가능. T-RT002-31 은 모든 source code 변경 land 후 (MX tag 위치는 final code structure 기준).
+
+---
+
+## Task summary by milestone
+
+| Milestone | Task IDs | Total tasks | Priority | Owner role mix |
+|-----------|----------|-------------|----------|----------------|
+| M1 (RED) | T-RT002-01..13 | 13 | P0 | expert-backend (12) + manager-tdd (1 verification) |
+| M2 (GREEN part 1) | T-RT002-14..18 | 5 | P0 | expert-backend |
+| M3 (GREEN part 2) | T-RT002-19..23 | 5 | P0 | expert-backend |
+| M4 (GREEN part 3) | T-RT002-24..27 | 4 | P0 | expert-backend |
+| M5 (GREEN part 4 + REFACTOR + Trackable) | T-RT002-28..35 | 8 | P1 | expert-backend (3) + manager-docs (4) + manager-tdd (1 verification) |
+| **TOTAL** | T-RT002-01..35 | **35 tasks** | — | — |
+
+> NOTE: 35 tasks span the 5 milestones. M1 (RED) opens with 13 test-only tasks; M2-M4 (GREEN core) deliver the typed-permission subsystem in 14 tasks; M5 (final GREEN + REFACTOR + Trackable) closes with 8 tasks of CLI, migration, MX tags, and trackability work.
+
+---
+
+## Dependency graph (critical path)
+
+```
+T-RT002-01..12 (M1 tests, sequential within shared file resolver_test.go)
+   ↓
+T-RT002-13 (M1 verification gate — RED 확인)
+   ↓
+T-RT002-14, 15+16, 17, 18 (M2 parallel)
+   ↓
+T-RT002-19, 20 (M3 parallel)
+   ↓
+T-RT002-21+22 (conflict.go + test) → T-RT002-23 (checkTier wire)
+   ↓
+T-RT002-24 (bubble dispatch contract)
+   ↓
+T-RT002-25, 26, 27 (M4 sequential within bubble.go/resolver.go)
+   ↓
+T-RT002-28 (doctor CLI 보강)
+   ↓
+T-RT002-29+30 (migration.go + test)
+   ↓
+T-RT002-31 (MX tags) → T-RT002-32 (CHANGELOG) → T-RT002-33 (make build) → T-RT002-34 (go test ./... + vet + lint) → T-RT002-35 (progress.md closure)
+```
+
+Critical path: 11 sequential gates from T-RT002-13 → T-RT002-35 (M1 → M5 closure).
+
+---
+
+## Cross-task constraints
+
+[HARD] All file edits use absolute paths under the worktree root `/Users/goos/.moai/worktrees/moai-adk/SPEC-V3R2-RT-002` per CLAUDE.md §Worktree Isolation Rules.
+
+[HARD] All tests use `t.TempDir()` per `CLAUDE.local.md` §6 — no test creates files in the project root.
+
+[HARD] All filesystem operations use `filepath.Join` / `filepath.Abs`; no `filepath.Join(cwd, absPath)` patterns per `CLAUDE.local.md` §6.
+
+[HARD] No new direct module dependencies — `internal/permission/` 의존성은 stdlib + 기존 `internal/config` + 기존 `internal/hook` + 기존 `github.com/spf13/cobra` (CLI 만) 으로 한정.
+
+[HARD] `internal/template/templates/.moai/config/sections/security.yaml` 미러를 동일 변경으로 유지 (Template-First Rule per CLAUDE.local.md §2).
+
+[HARD] 코드 주석은 한국어 (per `.moai/config/sections/language.yaml` `code_comments: ko`). godoc 와 exported identifier 의 영문 docstring 은 industry standard 로 영어 유지.
+
+[HARD] commit messages 는 한국어 (per `.moai/config/sections/language.yaml` `git_commit_messages: ko`).
+
+[HARD] 본 SPEC 은 `.claude/agents/**/*.md` 의 frontmatter `permissionMode` 키를 *읽기만* 검증; 미선언 agent 에 강제 추가하지 않음 (그것은 SPEC-V3R2-ORC-001 의 영역).
+
+[HARD] `internal/cli/run.go`, `internal/hook/*.go`, `internal/session/*.go`, `internal/config/source.go` 는 본 SPEC 이 직접 수정 금지 — cross-SPEC scope 보호. spawn-side wire 는 `internal/permission/spawn.go` 의 helper 만 노출하고, 호출 사이트 추가는 다른 SPEC 의 영역.
+
+---
+
+End of tasks.md.


### PR DESCRIPTION
## Summary

5-milestone plan for SPEC-V3R2-RT-002 (Permission Stack + Bubble Mode). Wave 12 cluster SPEC — replaces flat `permissions.allow` with typed 8-source permission stack carrying provenance, adds bubble mode as first-class PermissionMode peer for fork-agent escalation.

## Plan Deliverables (6 files in `.moai/specs/SPEC-V3R2-RT-002/`)

| File | Size | Content |
|------|------|---------|
| plan.md | 43 KB | M1-M5, 27 REQ → 15 AC → 35 tasks, 7 MX tag insertions, 15/15 PASS |
| research.md | 33 KB | 12 sections, existing skeleton inventory (~50% coverage), CC permission model, AskUserQuestion bubble routing |
| acceptance.md | 26 KB | 15 ACs in G/W/T format, ~30 new test functions |
| tasks.md | 21 KB | 35 tasks (T-RT002-01..35), RT-001/RT-005 dependency notes |
| progress.md | 6 KB | Paste-ready Block 0 worktree resume |
| issue-body.md | 11 KB | Non-breaking BC-V3R2-015 compatibility note |

## Non-Breaking Layering

spec.md frontmatter: `breaking: false`, `bc_id: []`. Despite Wave 12 cluster grouping, RT-002 is additive — v2 flat `permissions.allow` reads correctly via tier-aware merge. Only the resolver answer becomes provenance-aware. Layered on top of BC-V3R2-015 (multi-layer settings resolution) without removing flat-list reader.

## 8-Source Resolution Order

```
policy > user > project > local > plugin > skill > session > builtin
                                                    ↑
                                     hookDecision overlays here (RT-001)
```

## Pre-Allowlist (Default)

`Bash(go test:*)`, `Bash(golangci-lint run:*)`, `Bash(ruff check:*)`, `Bash(npm test:*)`, `Bash(pytest:*)`, `Read(*)`, `Glob(*)`, `Grep(*)` — avoids bubble-fatigue on read/verify operations.

## Dependencies

- SPEC-V3R2-CON-001 (Constitution v3) — merged
- SPEC-V3R2-RT-001 (Hook JSON Protocol) — Wave 12 sibling, this PR
- SPEC-V3R2-RT-005 (Settings reader) — Wave 12 sibling, this PR

## Test Plan

- [ ] plan-auditor verification (score ≥ 0.85)
- [ ] CI: Lint / Test ubuntu/macos/windows / Build 5 / CodeQL / Constitution Check / Integration Tests
- [ ] No code changes (plan-only PR — Run phase deferred)

🗿 MoAI <email@mo.ai.kr>