### PR TITLE
docs(workflow): SPEC Phase Discipline 표준화 — plan-in-main, worktree-for-run-and-sync

### DIFF
--- a/.claude/rules/moai/workflow/spec-workflow.md
+++ b/.claude/rules/moai/workflow/spec-workflow.md
@@ -11,10 +11,34 @@ MoAI's three-phase development workflow with token budget management.
 | Phase | Command | Agent | Token Budget | Purpose |
 |-------|---------|-------|--------------|---------|
 | Plan | /moai plan | manager-spec | 30K | Create SPEC document |
-| Run | /moai run | manager-ddd/tdd (per quality.yaml) | 180K | DDD/TDD implementation |
+| Run | /moai run | manager-cycle (per quality.yaml development_mode) | 180K | DDD/TDD implementation |
 | Sync | /moai sync | manager-docs | 40K | Documentation sync |
 
 <!-- @MX:ANCHOR fan_in=10 - Subcommand classification single source of truth; cross-referenced by 10 workflow skills (5 multi-agent + 5 utility). Changes here affect all workflow contracts. -->
+
+## SPEC Phase Discipline
+
+[HARD] Every MoAI SPEC follows this 4-step lifecycle. Each step has a fixed location (main checkout vs SPEC worktree), branch convention, and PR merge strategy.
+
+| Step | Location        | Command                                                                 | Branch                                       | PR strategy | Lifecycle event              |
+|------|-----------------|-------------------------------------------------------------------------|----------------------------------------------|-------------|------------------------------|
+| 1    | main checkout   | `/moai plan SPEC-XXX`                                                   | `plan/SPEC-XXX`                              | squash      | plan PR merged into main     |
+| 2    | SPEC worktree   | `moai worktree new SPEC-XXX --base origin/main` then `/moai run SPEC-XXX` | `feat/SPEC-XXX`                              | squash      | run PR merged into main      |
+| 3    | SPEC worktree   | `/moai sync SPEC-XXX` (same worktree as Step 2)                         | `sync/SPEC-XXX` (or `chore/SPEC-XXX-sync`)   | squash      | sync PR merged into main     |
+| 4    | host checkout   | `moai worktree done SPEC-XXX`                                           | n/a                                          | n/a         | worktree disposed            |
+
+[HARD] Step ordering rules:
+- Step 1 (plan) MUST execute in main checkout. NO worktree at this step. Plan artifacts are markdown only — no code conflict — and main-authored plans enable cross-SPEC reference for plan-auditor and parallel SPEC scoping.
+- Step 2 (run) MUST create a fresh worktree from the plan-merged main HEAD (`--base origin/main`). The worktree base alignment is a precondition for `Agent(isolation: "worktree")` correctness (see lessons #13).
+- Step 3 (sync) MUST reuse the SAME worktree as Step 2. Sync rotates codemap / MX / docs in the run-modified tree; spawning a fresh worktree at sync would lose run-state context.
+- Step 4 (cleanup) MUST happen ONLY after BOTH run AND sync PRs are merged. Premature `moai worktree done` between run-merge and sync-merge breaks Step 3.
+
+[HARD] Anti-patterns:
+- Creating a worktree for plan (Step 1). Plan-in-worktree forces a base rebase after plan PR merge and prevents parallel SPEC plan visibility.
+- Stacking plan + run in the same worktree. Once the plan PR merges, the worktree base becomes stale; subsequent run work either rebases (extra cost) or proceeds against a stale tree (correctness risk).
+- Disposing the worktree after run merge but before sync merge. Sync re-enters the tree with codemap / MX / docs writes; the host checkout cannot stand in for a disposed worktree.
+
+Cross-reference: see `.claude/rules/moai/workflow/worktree-integration.md` § SPEC-to-Worktree Mapping for per-step worktree applicability and decision tree.
 
 ## Subcommand Classification (Pipeline vs Multi-Agent)
 
@@ -85,6 +109,8 @@ See `spec.md` §1.2 (Non-Goals) — they are deferred to a future SPEC.
 
 ## Plan Phase
 
+[HARD] Execute in main checkout. NO worktree at this step. See § SPEC Phase Discipline (Step 1).
+
 Create comprehensive specification using EARS format.
 
 Sub-phases:
@@ -107,6 +133,8 @@ Output:
 
 ## Run Phase
 
+[HARD] Execute in a fresh SPEC worktree created at run start: `moai worktree new SPEC-XXX --base origin/main`. See § SPEC Phase Discipline (Step 2).
+
 Implement specification using configured development methodology.
 
 Token Strategy:
@@ -118,7 +146,7 @@ Development Methodology (configured in quality.yaml development_mode):
 
 ### DDD Mode — ANALYZE-PRESERVE-IMPROVE
 
-Best for existing projects with < 10% test coverage. Uses manager-ddd agent.
+Best for existing projects with < 10% test coverage. Uses manager-cycle agent with cycle_type=ddd.
 
 **ANALYZE**: Read existing code, map domain boundaries, identify side effects and implicit contracts.
 **PRESERVE**: Write characterization tests capturing current behavior. Create behavior snapshots for regression detection.
@@ -126,7 +154,7 @@ Best for existing projects with < 10% test coverage. Uses manager-ddd agent.
 
 ### TDD Mode — RED-GREEN-REFACTOR (default)
 
-Best for all development work, new projects, and brownfield with 10%+ coverage. Uses manager-tdd agent.
+Best for all development work, new projects, and brownfield with 10%+ coverage. Uses manager-cycle agent with cycle_type=tdd.
 
 **RED**: Write a failing test describing desired behavior. Verify it fails. One test at a time.
 **GREEN**: Write simplest implementation that passes. No premature optimization.
@@ -182,7 +210,7 @@ Triggers:
 - Agent explicitly reports inability to meet a SPEC requirement
 
 Communication path:
-- Implementation agent (manager-ddd/tdd) detects trigger condition
+- Implementation agent (manager-cycle) detects trigger condition
 - Agent returns structured stagnation report to MoAI (agents cannot call AskUserQuestion)
 - MoAI presents gap analysis to user via AskUserQuestion with options:
   - Continue with current approach (minor adjustments needed)
@@ -198,6 +226,8 @@ Detection method:
 Integration: Referenced by run.md Phase 2.7 and loop.md iteration checks
 
 ## Sync Phase
+
+[HARD] Continue in the SAME SPEC worktree as run. Do NOT create a new worktree. See § SPEC Phase Discipline (Step 3).
 
 Generate documentation and prepare for deployment.
 
@@ -233,9 +263,9 @@ Progressive Disclosure:
 ## Phase Transitions
 
 Plan to Run:
-- Trigger: SPEC document approved (annotation cycle completed, user confirmed "Proceed")
-- Pre-condition: plan.md records `plan_complete_at` + `plan_status: audit-ready` in progress.md
-- Action: Execute /clear, then /moai run SPEC-XXX
+- Trigger: Plan PR merged into main (squash) AND SPEC document approved (annotation cycle completed, user confirmed "Proceed")
+- Pre-condition: plan.md records `plan_complete_at` + `plan_status: audit-ready` in progress.md; plan PR is in MERGED state
+- Action: Execute /clear, then `moai worktree new SPEC-XXX --base origin/main`, then `/moai run SPEC-XXX` inside the worktree
 - Gate: `/moai run` Phase 0.5 (Plan Audit Gate) executes automatically before any implementation.
   See "Phase 0.5: Plan Audit Gate" section below for details.
 
@@ -273,8 +303,14 @@ not blocking. After grace window expires, FAIL verdicts block Phase 1 unconditio
 Grace window start: `.moai/state/audit-gate-merge-at.txt` (ISO-8601 timestamp).
 
 Run to Sync:
-- Trigger: Implementation complete, tests passing
-- Action: Execute /moai sync SPEC-XXX
+- Trigger: Run PR merged into main, tests passing
+- Action: Execute `/moai sync SPEC-XXX` in the SAME worktree as run (do NOT create a new worktree)
+
+Sync to Cleanup:
+- Trigger: Sync PR merged into main
+- Pre-condition: BOTH run PR AND sync PR are in MERGED state (verify via `gh pr view <PR>`)
+- Action: `moai worktree done SPEC-XXX` (executed from host checkout, not from inside the worktree)
+- See § SPEC Phase Discipline (Step 4)
 
 ## Agent Teams Variant
 
@@ -285,7 +321,7 @@ When team mode is enabled (workflow.team.enabled and AGENT_TEAMS env), phases ca
 | Phase | Sub-agent Mode | Team Mode | Condition |
 |-------|---------------|-----------|-----------|
 | Plan | manager-spec (single) | Dynamic teammates: researcher + analyst + architect (parallel, general-purpose) | Complexity >= threshold |
-| Run | manager-ddd/tdd (sequential) | Dynamic teammates: backend-dev + frontend-dev + tester (parallel, general-purpose) | Domains >= 3 or files >= 10 |
+| Run | manager-cycle (sequential) | Dynamic teammates: backend-dev + frontend-dev + tester (parallel, general-purpose) | Domains >= 3 or files >= 10 |
 | Sync | manager-docs (single) | manager-docs (always sub-agent) | N/A |
 
 All teammates are spawned dynamically via `Agent(subagent_type: "general-purpose")` with runtime overrides from `workflow.yaml` role profiles. No static team agent definitions are used. See `.claude/skills/moai/team/run.md` for complete orchestration.

--- a/.claude/rules/moai/workflow/worktree-integration.md
+++ b/.claude/rules/moai/workflow/worktree-integration.md
@@ -132,7 +132,7 @@ Is this a one-shot sub-agent task?
 
 - [HARD] Implementation teammates in team mode (role_profiles: implementer, tester, designer) MUST use `isolation: "worktree"` when spawned via Agent()
 - [HARD] Read-only teammates (role_profiles: researcher, analyst, reviewer) MUST NOT use `isolation: "worktree"` — their `mode: "plan"` already prevents writes
-- [HARD] One-shot sub-agents that write files (expert-backend, expert-frontend, manager-ddd, manager-tdd) SHOULD use `isolation: "worktree"` when making cross-file changes
+- [HARD] One-shot sub-agents that write files (expert-backend, expert-frontend, manager-develop) SHOULD use `isolation: "worktree"` when making cross-file changes
 - [HARD] GitHub workflow agents (fixer agents in /moai github issues) MUST use `isolation: "worktree"` for branch isolation
 
 ### When to Use Which
@@ -290,11 +290,16 @@ Both share the same project structure. `src/auth/handler.go` resolves correctly 
 
 ## SPEC-to-Worktree Mapping
 
-| SPEC Phase | Worktree Type | Location |
-|------------|--------------|----------|
-| Plan | Claude Native | `.claude/worktrees/` (ephemeral) |
-| Run | MoAI | `~/.moai/worktrees/{Project}/{SPEC}/` |
-| Sync | MoAI | Same as Run phase |
+[HARD] Per-step worktree applicability is governed by `.claude/rules/moai/workflow/spec-workflow.md` § SPEC Phase Discipline (canonical source). This table summarizes the mapping for quick reference; on conflict, spec-workflow.md wins.
+
+| Step | Phase   | Worktree?                | Location                              | Lifecycle event              |
+|------|---------|--------------------------|---------------------------------------|------------------------------|
+| 1    | Plan    | **NO** (main checkout)   | n/a — `plan/SPEC-XXX` branch on main  | plan PR merged               |
+| 2    | Run     | **YES** (MoAI worktree)  | `~/.moai/worktrees/{project}/{SPEC}/` | run PR merged                |
+| 3    | Sync    | **YES** — same as Step 2 | same path as Step 2 (do NOT recreate) | sync PR merged               |
+| 4    | Cleanup | n/a                      | host checkout                         | `moai worktree done SPEC-XXX` |
+
+[HARD] Disposal contract: `moai worktree done SPEC-XXX` MUST run only after BOTH run PR AND sync PR are merged. Premature disposal between Step 2 merge and Step 3 merge breaks Sync.
 
 ## Team Protocol
 

--- a/internal/template/templates/.claude/rules/moai/workflow/spec-workflow.md
+++ b/internal/template/templates/.claude/rules/moai/workflow/spec-workflow.md
@@ -16,6 +16,30 @@ MoAI's three-phase development workflow with token budget management.
 
 <!-- @MX:ANCHOR fan_in=10 - Subcommand classification single source of truth; cross-referenced by 10 workflow skills (5 multi-agent + 5 utility). Changes here affect all workflow contracts. -->
 
+## SPEC Phase Discipline
+
+[HARD] Every MoAI SPEC follows this 4-step lifecycle. Each step has a fixed location (main checkout vs SPEC worktree), branch convention, and PR merge strategy.
+
+| Step | Location        | Command                                                                 | Branch                                       | PR strategy | Lifecycle event              |
+|------|-----------------|-------------------------------------------------------------------------|----------------------------------------------|-------------|------------------------------|
+| 1    | main checkout   | `/moai plan SPEC-XXX`                                                   | `plan/SPEC-XXX`                              | squash      | plan PR merged into main     |
+| 2    | SPEC worktree   | `moai worktree new SPEC-XXX --base origin/main` then `/moai run SPEC-XXX` | `feat/SPEC-XXX`                              | squash      | run PR merged into main      |
+| 3    | SPEC worktree   | `/moai sync SPEC-XXX` (same worktree as Step 2)                         | `sync/SPEC-XXX` (or `chore/SPEC-XXX-sync`)   | squash      | sync PR merged into main     |
+| 4    | host checkout   | `moai worktree done SPEC-XXX`                                           | n/a                                          | n/a         | worktree disposed            |
+
+[HARD] Step ordering rules:
+- Step 1 (plan) MUST execute in main checkout. NO worktree at this step. Plan artifacts are markdown only — no code conflict — and main-authored plans enable cross-SPEC reference for plan-auditor and parallel SPEC scoping.
+- Step 2 (run) MUST create a fresh worktree from the plan-merged main HEAD (`--base origin/main`). The worktree base alignment is a precondition for `Agent(isolation: "worktree")` correctness (see lessons #13).
+- Step 3 (sync) MUST reuse the SAME worktree as Step 2. Sync rotates codemap / MX / docs in the run-modified tree; spawning a fresh worktree at sync would lose run-state context.
+- Step 4 (cleanup) MUST happen ONLY after BOTH run AND sync PRs are merged. Premature `moai worktree done` between run-merge and sync-merge breaks Step 3.
+
+[HARD] Anti-patterns:
+- Creating a worktree for plan (Step 1). Plan-in-worktree forces a base rebase after plan PR merge and prevents parallel SPEC plan visibility.
+- Stacking plan + run in the same worktree. Once the plan PR merges, the worktree base becomes stale; subsequent run work either rebases (extra cost) or proceeds against a stale tree (correctness risk).
+- Disposing the worktree after run merge but before sync merge. Sync re-enters the tree with codemap / MX / docs writes; the host checkout cannot stand in for a disposed worktree.
+
+Cross-reference: see `.claude/rules/moai/workflow/worktree-integration.md` § SPEC-to-Worktree Mapping for per-step worktree applicability and decision tree.
+
 ## Subcommand Classification (Pipeline vs Multi-Agent)
 
 Source: SPEC-V3R2-WF-004. Each MoAI subcommand is classified along the
@@ -85,6 +109,8 @@ See `spec.md` §1.2 (Non-Goals) — they are deferred to a future SPEC.
 
 ## Plan Phase
 
+[HARD] Execute in main checkout. NO worktree at this step. See § SPEC Phase Discipline (Step 1).
+
 Create comprehensive specification using EARS format.
 
 Sub-phases:
@@ -106,6 +132,8 @@ Output:
 - Technical approach
 
 ## Run Phase
+
+[HARD] Execute in a fresh SPEC worktree created at run start: `moai worktree new SPEC-XXX --base origin/main`. See § SPEC Phase Discipline (Step 2).
 
 Implement specification using configured development methodology.
 
@@ -199,6 +227,8 @@ Integration: Referenced by run.md Phase 2.7 and loop.md iteration checks
 
 ## Sync Phase
 
+[HARD] Continue in the SAME SPEC worktree as run. Do NOT create a new worktree. See § SPEC Phase Discipline (Step 3).
+
 Generate documentation and prepare for deployment.
 
 Token Strategy:
@@ -233,9 +263,9 @@ Progressive Disclosure:
 ## Phase Transitions
 
 Plan to Run:
-- Trigger: SPEC document approved (annotation cycle completed, user confirmed "Proceed")
-- Pre-condition: plan.md records `plan_complete_at` + `plan_status: audit-ready` in progress.md
-- Action: Execute /clear, then /moai run SPEC-XXX
+- Trigger: Plan PR merged into main (squash) AND SPEC document approved (annotation cycle completed, user confirmed "Proceed")
+- Pre-condition: plan.md records `plan_complete_at` + `plan_status: audit-ready` in progress.md; plan PR is in MERGED state
+- Action: Execute /clear, then `moai worktree new SPEC-XXX --base origin/main`, then `/moai run SPEC-XXX` inside the worktree
 - Gate: `/moai run` Phase 0.5 (Plan Audit Gate) executes automatically before any implementation.
   See "Phase 0.5: Plan Audit Gate" section below for details.
 
@@ -273,8 +303,14 @@ not blocking. After grace window expires, FAIL verdicts block Phase 1 unconditio
 Grace window start: `.moai/state/audit-gate-merge-at.txt` (ISO-8601 timestamp).
 
 Run to Sync:
-- Trigger: Implementation complete, tests passing
-- Action: Execute /moai sync SPEC-XXX
+- Trigger: Run PR merged into main, tests passing
+- Action: Execute `/moai sync SPEC-XXX` in the SAME worktree as run (do NOT create a new worktree)
+
+Sync to Cleanup:
+- Trigger: Sync PR merged into main
+- Pre-condition: BOTH run PR AND sync PR are in MERGED state (verify via `gh pr view <PR>`)
+- Action: `moai worktree done SPEC-XXX` (executed from host checkout, not from inside the worktree)
+- See § SPEC Phase Discipline (Step 4)
 
 ## Agent Teams Variant
 

--- a/internal/template/templates/.claude/rules/moai/workflow/worktree-integration.md
+++ b/internal/template/templates/.claude/rules/moai/workflow/worktree-integration.md
@@ -290,11 +290,16 @@ Both share the same project structure. `src/auth/handler.go` resolves correctly 
 
 ## SPEC-to-Worktree Mapping
 
-| SPEC Phase | Worktree Type | Location |
-|------------|--------------|----------|
-| Plan | Claude Native | `.claude/worktrees/` (ephemeral) |
-| Run | MoAI | `~/.moai/worktrees/{Project}/{SPEC}/` |
-| Sync | MoAI | Same as Run phase |
+[HARD] Per-step worktree applicability is governed by `.claude/rules/moai/workflow/spec-workflow.md` § SPEC Phase Discipline (canonical source). This table summarizes the mapping for quick reference; on conflict, spec-workflow.md wins.
+
+| Step | Phase   | Worktree?                | Location                              | Lifecycle event              |
+|------|---------|--------------------------|---------------------------------------|------------------------------|
+| 1    | Plan    | **NO** (main checkout)   | n/a — `plan/SPEC-XXX` branch on main  | plan PR merged               |
+| 2    | Run     | **YES** (MoAI worktree)  | `~/.moai/worktrees/{project}/{SPEC}/` | run PR merged                |
+| 3    | Sync    | **YES** — same as Step 2 | same path as Step 2 (do NOT recreate) | sync PR merged               |
+| 4    | Cleanup | n/a                      | host checkout                         | `moai worktree done SPEC-XXX` |
+
+[HARD] Disposal contract: `moai worktree done SPEC-XXX` MUST run only after BOTH run PR AND sync PR are merged. Premature disposal between Step 2 merge and Step 3 merge breaks Sync.
 
 ## Team Protocol
 


### PR DESCRIPTION
## Summary

- spec-workflow.md에 SPEC Phase Discipline 신설 (canonical 4-step lifecycle 표준)
- Plan/Run/Sync Phase 본문 + transitions에 [HARD] location/branch/cleanup 표기
- worktree-integration.md SPEC-to-Worktree Mapping 표 정정 (Step 1 NO worktree)

## 표준 4-step lifecycle

| Step | Location | 명령 | 브랜치 | 머지 |
|------|----------|------|--------|------|
| 1 plan | main checkout | \`/moai plan SPEC-XXX\` | \`plan/SPEC-XXX\` | squash |
| 2 run | SPEC worktree | \`moai worktree new --base origin/main\` + \`/moai run\` | \`feat/SPEC-XXX\` | squash |
| 3 sync | SPEC worktree (same as Step 2) | \`/moai sync SPEC-XXX\` | \`sync/SPEC-XXX\` | squash |
| 4 cleanup | host checkout | \`moai worktree done SPEC-XXX\` (run+sync 모두 머지 후) | n/a | n/a |

## 근거

- **lessons #13 회피**: --team + worktree base 불일치를 plan PR 머지 후 fresh worktree 분기로 차단
- **plan-auditor cross-SPEC 가시성**: plan PR을 main에 squash merge 하면 plan-auditor가 여러 SPEC을 동시에 보면서 cross-reference 가능
- **worktree base rebase 비용 제거**: plan PR 머지 시 worktree가 plan-merged HEAD 기준으로 fresh 분기되므로 rebase 불필요
- **사용자 토론** (2026-05-10): RT-001/002/004/ORC-002/SPC-001 plan PR이 결과적으로 옵션 A 표준에 부합한 사실 확인 후 명문화 결정

## 영향 범위

- 향후 모든 SPEC plan은 main checkout에서 작성 (RT-005/RT-007부터 적용)
- 기존 머지된 plan PR(RT-001/RT-002/RT-004/ORC-002/SPC-001)은 결과 동일, 표준 위반 없음
- worktree-integration.md SPEC-to-Worktree Mapping 표는 spec-workflow.md를 canonical source로 cross-reference

## Test plan

- [x] make build로 embedded 재생성 (4 files diff identical between template and local)
- [ ] CI Constitution Check 통과 확인
- [ ] CI Lint 통과 확인 (markdown lint)

🗿 MoAI <email@mo.ai.kr>