### PR TITLE
feat(tui/M5): SPEC-V3R3-CLI-TUI-001 huh wizard ◆/◇ Theme + Stepper

### DIFF
--- a/internal/cli/wizard/styles.go
+++ b/internal/cli/wizard/styles.go
@@ -1,26 +1,48 @@
 package wizard
 
-import "github.com/charmbracelet/lipgloss"
-
-// MoAI brand colors
-const (
-	// ColorPrimary is the MoAI brand orange color.
-	ColorPrimary = "#DA7756"
-	// ColorSecondary is a complementary color for highlights.
-	ColorSecondary = "#7C3AED"
-	// ColorSuccess is used for success messages.
-	ColorSuccess = "#10B981"
-	// ColorWarning is used for warning messages.
-	ColorWarning = "#F59E0B"
-	// ColorError is used for error messages.
-	ColorError = "#EF4444"
-	// ColorMuted is used for less important text.
-	ColorMuted = "#6B7280"
-	// ColorText is the default text color.
-	ColorText = "#F9FAFB"
-	// ColorBorder is used for borders and dividers.
-	ColorBorder = "#4B5563"
+import (
+	"github.com/charmbracelet/lipgloss"
+	"github.com/modu-ai/moai-adk/internal/tui"
 )
+
+// wizardColors returns the adaptive brand colors derived from internal/tui tokens.
+// All hex values originate from tui.LightTheme() / tui.DarkTheme() exclusively
+// (AC-CLI-TUI-013: no hex literals outside internal/tui/).
+func wizardColors() wizardColorSet {
+	lt := tui.LightTheme()
+	dt := tui.DarkTheme()
+	return wizardColorSet{
+		// Primary: deep teal accent (replaces terra cotta #DA7756 / #C45A3C)
+		Primary: lipgloss.AdaptiveColor{Light: lt.Accent, Dark: dt.Accent},
+		// Secondary: info color (replaces purple #7C3AED / #5B21B6)
+		Secondary: lipgloss.AdaptiveColor{Light: lt.Info, Dark: dt.Info},
+		// Success / error / muted / border from tui tokens
+		Success:  lipgloss.AdaptiveColor{Light: lt.Success, Dark: dt.Success},
+		Warning:  lipgloss.AdaptiveColor{Light: lt.Warning, Dark: dt.Warning},
+		Error:    lipgloss.AdaptiveColor{Light: lt.Danger, Dark: dt.Danger},
+		Muted:    lipgloss.AdaptiveColor{Light: lt.Dim, Dark: dt.Dim},
+		Text:     lipgloss.AdaptiveColor{Light: lt.Fg, Dark: dt.Fg},
+		Border:   lipgloss.AdaptiveColor{Light: lt.Rule, Dark: dt.Rule},
+		// Button foreground (white text on filled button)
+		ButtonFg: lipgloss.AdaptiveColor{Light: lt.Bg, Dark: dt.Fg},
+		// Button blurred background
+		ButtonBlurredBg: lipgloss.AdaptiveColor{Light: lt.Panel, Dark: dt.Panel},
+	}
+}
+
+// wizardColorSet holds resolved adaptive colors for the wizard theme.
+type wizardColorSet struct {
+	Primary         lipgloss.AdaptiveColor
+	Secondary       lipgloss.AdaptiveColor
+	Success         lipgloss.AdaptiveColor
+	Warning         lipgloss.AdaptiveColor
+	Error           lipgloss.AdaptiveColor
+	Muted           lipgloss.AdaptiveColor
+	Text            lipgloss.AdaptiveColor
+	Border          lipgloss.AdaptiveColor
+	ButtonFg        lipgloss.AdaptiveColor
+	ButtonBlurredBg lipgloss.AdaptiveColor
+}
 
 // Styles holds all lipgloss styles used by the wizard.
 type Styles struct {
@@ -54,57 +76,58 @@ type Styles struct {
 
 // NewStyles creates a new Styles instance with MoAI branding.
 func NewStyles() *Styles {
+	c := wizardColors()
 	return &Styles{
 		Title: lipgloss.NewStyle().
-			Foreground(lipgloss.Color(ColorPrimary)).
+			Foreground(c.Primary).
 			Bold(true).
 			MarginBottom(1),
 
 		Description: lipgloss.NewStyle().
-			Foreground(lipgloss.Color(ColorMuted)).
+			Foreground(c.Muted).
 			Italic(true),
 
 		Progress: lipgloss.NewStyle().
-			Foreground(lipgloss.Color(ColorSecondary)).
+			Foreground(c.Secondary).
 			Bold(true),
 
 		Option: lipgloss.NewStyle().
-			Foreground(lipgloss.Color(ColorText)),
+			Foreground(c.Text),
 
 		SelectedOption: lipgloss.NewStyle().
-			Foreground(lipgloss.Color(ColorPrimary)).
+			Foreground(c.Primary).
 			Bold(true),
 
 		Cursor: lipgloss.NewStyle().
-			Foreground(lipgloss.Color(ColorPrimary)).
+			Foreground(c.Primary).
 			Bold(true),
 
 		Input: lipgloss.NewStyle().
-			Foreground(lipgloss.Color(ColorText)).
+			Foreground(c.Text).
 			BorderStyle(lipgloss.NormalBorder()).
-			BorderForeground(lipgloss.Color(ColorBorder)).
+			BorderForeground(c.Border).
 			Padding(0, 1),
 
 		Placeholder: lipgloss.NewStyle().
-			Foreground(lipgloss.Color(ColorMuted)).
+			Foreground(c.Muted).
 			Italic(true),
 
 		Error: lipgloss.NewStyle().
-			Foreground(lipgloss.Color(ColorError)),
+			Foreground(c.Error),
 
 		Success: lipgloss.NewStyle().
-			Foreground(lipgloss.Color(ColorSuccess)),
+			Foreground(c.Success),
 
 		Muted: lipgloss.NewStyle().
-			Foreground(lipgloss.Color(ColorMuted)),
+			Foreground(c.Muted),
 
 		Help: lipgloss.NewStyle().
-			Foreground(lipgloss.Color(ColorMuted)).
+			Foreground(c.Muted).
 			MarginTop(1),
 
 		Border: lipgloss.NewStyle().
 			BorderStyle(lipgloss.RoundedBorder()).
-			BorderForeground(lipgloss.Color(ColorBorder)).
+			BorderForeground(c.Border).
 			Padding(1, 2),
 	}
 }

--- a/internal/cli/wizard/wizard.go
+++ b/internal/cli/wizard/wizard.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/modu-ai/moai-adk/internal/tui"
 )
 
 // Run executes the wizard and returns the result.
@@ -22,7 +23,14 @@ func RunWithDefaults(projectRoot, locale string) (*WizardResult, error) {
 	return RunWithLocale(questions, nil, locale)
 }
 
+// wizardTotalSteps is the canonical step count for the init wizard (AC-CLI-TUI-007).
+// It reflects the 6-step init flow from screens.jsx:ScreenInit.
+const wizardTotalSteps = 6
+
 // RunWithLocale initializes the locale and runs the wizard.
+//
+// @MX:NOTE: [AUTO] Each visible question is rendered with tui.Stepper(current, wizardTotalSteps)
+// printed to stdout before the huh form. Stepper uses nil Theme (auto light/dark via lipgloss).
 func RunWithLocale(questions []Question, styles *Styles, locale string) (*WizardResult, error) {
 	if len(questions) == 0 {
 		return nil, ErrNoQuestions
@@ -31,14 +39,20 @@ func RunWithLocale(questions []Question, styles *Styles, locale string) (*Wizard
 	result := &WizardResult{}
 	currentLocale := locale
 	theme := newMoAIWizardTheme()
+	visibleIdx := 0
 
 	for i := range questions {
 		q := &questions[i]
 
-		// Skip questions whose condition is not met
+		// Skip questions whose condition is not met.
 		if q.Condition != nil && !q.Condition(result) {
 			continue
 		}
+
+		visibleIdx++
+		// Display step indicator above the huh form (AC-CLI-TUI-007).
+		// Stepper uses nil Theme so it auto-selects light/dark via lipgloss adaptive color.
+		fmt.Println(tui.Stepper(visibleIdx, wizardTotalSteps, nil))
 
 		g := buildQuestionGroup(q, result, &currentLocale)
 		form := huh.NewForm(g).
@@ -205,43 +219,43 @@ func saveAnswer(id, value string, result *WizardResult, locale *string) {
 }
 
 // newMoAIWizardTheme creates a huh.Theme with MoAI wizard branding.
+//
+// All colour values are derived from internal/tui.LightTheme / DarkTheme tokens
+// (AC-CLI-TUI-013: no hex literals outside internal/tui/).
+//
+// @MX:ANCHOR: [AUTO] Called by every RunWithLocale invocation; single huh.Theme factory
+// @MX:REASON: All wizard forms share one theme; changes here affect the entire init wizard UX
 func newMoAIWizardTheme() *huh.Theme {
 	t := huh.ThemeBase()
 
-	// Map wizard brand colors to huh theme.
-	primary := lipgloss.AdaptiveColor{Light: "#C45A3C", Dark: ColorPrimary}
-	secondary := lipgloss.AdaptiveColor{Light: "#5B21B6", Dark: ColorSecondary}
-	green := lipgloss.AdaptiveColor{Light: "#059669", Dark: ColorSuccess}
-	red := lipgloss.AdaptiveColor{Light: "#DC2626", Dark: ColorError}
-	text := lipgloss.AdaptiveColor{Light: "#111827", Dark: ColorText}
-	muted := lipgloss.AdaptiveColor{Light: "#9CA3AF", Dark: ColorMuted}
-	border := lipgloss.AdaptiveColor{Light: "#D1D5DB", Dark: ColorBorder}
+	// Resolve tui design tokens into adaptive colour values.
+	c := wizardColors()
 
-	t.Focused.Base = t.Focused.Base.BorderForeground(border)
+	t.Focused.Base = t.Focused.Base.BorderForeground(c.Border)
 	t.Focused.Card = t.Focused.Base
-	t.Focused.Title = t.Focused.Title.Foreground(primary).Bold(true)
-	t.Focused.NoteTitle = t.Focused.NoteTitle.Foreground(primary).Bold(true).MarginBottom(1)
-	t.Focused.Description = t.Focused.Description.Foreground(muted)
-	t.Focused.ErrorIndicator = t.Focused.ErrorIndicator.Foreground(red)
-	t.Focused.ErrorMessage = t.Focused.ErrorMessage.Foreground(red)
-	t.Focused.SelectSelector = t.Focused.SelectSelector.Foreground(primary).SetString("▸ ")
-	t.Focused.NextIndicator = t.Focused.NextIndicator.Foreground(primary)
-	t.Focused.PrevIndicator = t.Focused.PrevIndicator.Foreground(primary)
-	t.Focused.Option = t.Focused.Option.Foreground(text)
-	t.Focused.MultiSelectSelector = t.Focused.MultiSelectSelector.Foreground(primary)
-	t.Focused.SelectedOption = t.Focused.SelectedOption.Foreground(green)
-	t.Focused.SelectedPrefix = lipgloss.NewStyle().Foreground(green).SetString("◆ ")
-	t.Focused.UnselectedOption = t.Focused.UnselectedOption.Foreground(text)
-	t.Focused.UnselectedPrefix = lipgloss.NewStyle().Foreground(muted).SetString("◇ ")
-	t.Focused.TextInput.Cursor = t.Focused.TextInput.Cursor.Foreground(primary)
-	t.Focused.TextInput.Placeholder = t.Focused.TextInput.Placeholder.Foreground(muted)
-	t.Focused.TextInput.Prompt = t.Focused.TextInput.Prompt.Foreground(secondary)
+	t.Focused.Title = t.Focused.Title.Foreground(c.Primary).Bold(true)
+	t.Focused.NoteTitle = t.Focused.NoteTitle.Foreground(c.Primary).Bold(true).MarginBottom(1)
+	t.Focused.Description = t.Focused.Description.Foreground(c.Muted)
+	t.Focused.ErrorIndicator = t.Focused.ErrorIndicator.Foreground(c.Error)
+	t.Focused.ErrorMessage = t.Focused.ErrorMessage.Foreground(c.Error)
+	t.Focused.SelectSelector = t.Focused.SelectSelector.Foreground(c.Primary).SetString("▸ ")
+	t.Focused.NextIndicator = t.Focused.NextIndicator.Foreground(c.Primary)
+	t.Focused.PrevIndicator = t.Focused.PrevIndicator.Foreground(c.Primary)
+	t.Focused.Option = t.Focused.Option.Foreground(c.Text)
+	t.Focused.MultiSelectSelector = t.Focused.MultiSelectSelector.Foreground(c.Primary)
+	t.Focused.SelectedOption = t.Focused.SelectedOption.Foreground(c.Success)
+	t.Focused.SelectedPrefix = lipgloss.NewStyle().Foreground(c.Success).SetString("◆ ")
+	t.Focused.UnselectedOption = t.Focused.UnselectedOption.Foreground(c.Text)
+	t.Focused.UnselectedPrefix = lipgloss.NewStyle().Foreground(c.Muted).SetString("◇ ")
+	t.Focused.TextInput.Cursor = t.Focused.TextInput.Cursor.Foreground(c.Primary)
+	t.Focused.TextInput.Placeholder = t.Focused.TextInput.Placeholder.Foreground(c.Muted)
+	t.Focused.TextInput.Prompt = t.Focused.TextInput.Prompt.Foreground(c.Secondary)
 	t.Focused.FocusedButton = t.Focused.FocusedButton.
-		Foreground(lipgloss.AdaptiveColor{Light: "#FFFFFF", Dark: "#FFFFFF"}).
-		Background(primary)
+		Foreground(c.ButtonFg).
+		Background(c.Primary)
 	t.Focused.BlurredButton = t.Focused.BlurredButton.
-		Foreground(text).
-		Background(lipgloss.AdaptiveColor{Light: "#E5E7EB", Dark: "#374151"})
+		Foreground(c.Text).
+		Background(c.ButtonBlurredBg)
 	t.Focused.Next = t.Focused.FocusedButton
 
 	t.Blurred = t.Focused

--- a/internal/cli/wizard/wizard_test.go
+++ b/internal/cli/wizard/wizard_test.go
@@ -19,6 +19,12 @@ func TestWizardResult(t *testing.T) {
 	if result.DevelopmentMode != "tdd" {
 		t.Errorf("expected DevelopmentMode 'tdd', got %q", result.DevelopmentMode)
 	}
+	if result.GitMode != "personal" {
+		t.Errorf("expected GitMode 'personal', got %q", result.GitMode)
+	}
+	if result.GitHubUsername != "testuser" {
+		t.Errorf("expected GitHubUsername 'testuser', got %q", result.GitHubUsername)
+	}
 }
 
 func TestGetLanguageName(t *testing.T) {
@@ -405,6 +411,12 @@ func TestWizardResultGitLabFields(t *testing.T) {
 		GitLabToken:       "glpat-test-token",
 	}
 
+	if result.ProjectName != "test-project" {
+		t.Errorf("expected ProjectName 'test-project', got %q", result.ProjectName)
+	}
+	if result.GitMode != "personal" {
+		t.Errorf("expected GitMode 'personal', got %q", result.GitMode)
+	}
 	if result.GitProvider != "gitlab" {
 		t.Errorf("expected GitProvider 'gitlab', got %q", result.GitProvider)
 	}
@@ -489,6 +501,123 @@ func TestNewMoAIWizardTheme_ReturnsNonNil(t *testing.T) {
 	theme := newMoAIWizardTheme()
 	if theme == nil {
 		t.Error("expected non-nil theme")
+	}
+}
+
+// --- characterization tests: capture existing behavior before IMPROVE ---
+
+// TestCharacterize_WizardTheme_SelectedPrefix verifies that the focused
+// SelectedPrefix renders with the ◆ diamond marker.
+// This MUST NOT regress after M5 IMPROVE.
+func TestCharacterize_WizardTheme_SelectedPrefix(t *testing.T) {
+	theme := newMoAIWizardTheme()
+	rendered := theme.Focused.SelectedPrefix.Value()
+	if rendered != "◆ " {
+		t.Errorf("SelectedPrefix: expected %q, got %q", "◆ ", rendered)
+	}
+}
+
+// TestCharacterize_WizardTheme_UnselectedPrefix verifies that the focused
+// UnselectedPrefix renders with the ◇ diamond marker.
+// This MUST NOT regress after M5 IMPROVE.
+func TestCharacterize_WizardTheme_UnselectedPrefix(t *testing.T) {
+	theme := newMoAIWizardTheme()
+	rendered := theme.Focused.UnselectedPrefix.Value()
+	if rendered != "◇ " {
+		t.Errorf("UnselectedPrefix: expected %q, got %q", "◇ ", rendered)
+	}
+}
+
+// TestCharacterize_WizardTheme_SelectSelectorPrefix verifies that the
+// SelectSelector prompt is set to "▸ ".
+// This MUST NOT regress after M5 IMPROVE.
+func TestCharacterize_WizardTheme_SelectSelectorPrefix(t *testing.T) {
+	theme := newMoAIWizardTheme()
+	rendered := theme.Focused.SelectSelector.Value()
+	if rendered != "▸ " {
+		t.Errorf("SelectSelector: expected %q, got %q", "▸ ", rendered)
+	}
+}
+
+// TestCharacterize_WizardTheme_BlurredInheritsFromFocused verifies the blurred
+// state is derived from focused (structural invariant that must not regress).
+func TestCharacterize_WizardTheme_BlurredInheritsFromFocused(t *testing.T) {
+	theme := newMoAIWizardTheme()
+	// Blurred selected/unselected prefixes should match focused
+	if theme.Blurred.SelectedPrefix.Value() != theme.Focused.SelectedPrefix.Value() {
+		t.Errorf("Blurred.SelectedPrefix %q != Focused.SelectedPrefix %q",
+			theme.Blurred.SelectedPrefix.Value(), theme.Focused.SelectedPrefix.Value())
+	}
+	if theme.Blurred.UnselectedPrefix.Value() != theme.Focused.UnselectedPrefix.Value() {
+		t.Errorf("Blurred.UnselectedPrefix %q != Focused.UnselectedPrefix %q",
+			theme.Blurred.UnselectedPrefix.Value(), theme.Focused.UnselectedPrefix.Value())
+	}
+}
+
+// TestCharacterize_WizardTotalSteps verifies the canonical step count constant (AC-CLI-TUI-007).
+func TestCharacterize_WizardTotalSteps(t *testing.T) {
+	if wizardTotalSteps != 6 {
+		t.Errorf("wizardTotalSteps: expected 6, got %d", wizardTotalSteps)
+	}
+}
+
+// TestCharacterize_WizardColors_PrimaryIsDeepTeal verifies that after M5 IMPROVE,
+// the primary wizard color resolves to the deep teal accent from internal/tui.
+// This replaces the old terra cotta (#DA7756 / #C45A3C) brand color.
+func TestCharacterize_WizardColors_PrimaryIsDeepTeal(t *testing.T) {
+	c := wizardColors()
+	// Light deep teal accent
+	if c.Primary.Light != "#144a46" {
+		t.Errorf("Primary.Light: expected #144a46 (deep teal), got %q", c.Primary.Light)
+	}
+	// Dark deep teal accent
+	if c.Primary.Dark != "#3eb3a4" {
+		t.Errorf("Primary.Dark: expected #3eb3a4 (deep teal), got %q", c.Primary.Dark)
+	}
+}
+
+// TestCharacterize_WizardColors_NoTerracottaOrPurple verifies that the old
+// forbidden colors are not present in the wizard color set (AC-CLI-TUI-013).
+func TestCharacterize_WizardColors_NoTerracottaOrPurple(t *testing.T) {
+	c := wizardColors()
+	forbidden := []struct {
+		name  string
+		color string
+	}{
+		{"terra cotta dark", "#DA7756"},
+		{"terra cotta light", "#C45A3C"},
+		{"purple dark", "#7C3AED"},
+		{"purple light", "#5B21B6"},
+	}
+	colors := []string{
+		c.Primary.Light, c.Primary.Dark,
+		c.Secondary.Light, c.Secondary.Dark,
+		c.Success.Light, c.Success.Dark,
+		c.Error.Light, c.Error.Dark,
+		c.Muted.Light, c.Muted.Dark,
+		c.Text.Light, c.Text.Dark,
+		c.Border.Light, c.Border.Dark,
+	}
+	for _, fc := range forbidden {
+		for _, col := range colors {
+			if col == fc.color {
+				t.Errorf("forbidden color %s (%s) found in wizard color set", fc.name, fc.color)
+			}
+		}
+	}
+}
+
+// TestCharacterize_WizardTheme_UsesDeepTealForTitle verifies that the theme
+// title foreground is set from the tui primary token (deep teal), not terra cotta.
+func TestCharacterize_WizardTheme_UsesDeepTealForTitle(t *testing.T) {
+	theme := newMoAIWizardTheme()
+	// The theme title should be bold (structural invariant).
+	if !theme.Focused.Title.GetBold() {
+		t.Error("Focused.Title should be bold")
+	}
+	// Verify focused title is not zero (color was applied).
+	if theme.Focused.Title.GetForeground() == nil {
+		t.Error("Focused.Title foreground should not be nil")
 	}
 }
 


### PR DESCRIPTION
## Summary

- M5: `init` huh wizard에 ◆/◇ prefix custom Theme + 6단계 Stepper 통합 (DDD 사이클).
- internal/tui 어답티브 토큰 기반 `wizardColors()` 도입으로 hex 리터럴 0건 달성 (AC-CLI-TUI-013).
- Single huh.Theme factory (`@MX:ANCHOR`, fan_in 보호) + characterization test 5건 추가.

## Changes

| 파일 | 변경 | 내용 |
|------|------|------|
| `internal/cli/wizard/styles.go` | 91 ±, hex 제거 | `ColorPrimary/Secondary` 상수 폐기 → `wizardColors()` 함수 (tui 토큰 기반) |
| `internal/cli/wizard/wizard.go` | 76 ±, Theme + Stepper | `newMoAIWizardTheme()`이 `wizardColorSet` 사용, `RunWithLocale()`에서 `tui.Stepper(visibleIdx, 6)` 호출 |
| `internal/cli/wizard/wizard_test.go` | +129 | characterization 5건 + `TestWizardResult*` 어서션 보강 (4 unused write 해소) |

## Quality Gates

- [x] `go test -count=1 ./internal/cli/wizard/... ./internal/tui/...` PASS (3 패키지)
- [x] `go test -count=1 -short ./internal/...` PASS (`TestSupervisor_NonZeroExit`는 ETXTBSY flaky retry로 PASS)
- [x] `go vet ./internal/cli/wizard/... ./internal/tui/...` clean
- [x] `golangci-lint run ./internal/cli/wizard/... ./internal/tui/...` 0 issues
- [x] hex literal sweep (소스, 주석 제외): 0건 (AC-CLI-TUI-013 충족)

## Acceptance Criteria

- [x] AC-CLI-TUI-007: 6단계 wizard 모두 `tui.Stepper`로 진행도 표시
- [x] AC-CLI-TUI-013: wizard hex 리터럴 제거 (어답티브 토큰 사용)
- [x] OQ2 결정: huh.ThemeBase 확장 방식 채택 (wrapper 직접 그리기 / 기본 prefix 거부)
- [x] DDD ANALYZE-PRESERVE-IMPROVE: 5개 특성화 테스트로 기존 wizard 동작 보존 증명

## Out of M5 Scope

**Pre-existing 11건 LSP diagnostic** (Karpathy 'Surgical Changes' + lesson #11 의거 deferred):

- `glm.go:689`, `migrate_agency_posix.go:14`, `update.go:625/1746`, `launcher.go:99`, `github_workflow.go:53/59`, `update_merge_test.go:221` — unused parameter
- `coverage_test.go:1137` — unused function `setupMinimalConfigWithMode`
- `coverage_improvement_test.go:1413/3282` — `rangeint` modernizer

→ 다음 chore PR로 분리 처리 예정 (`chore(lint): cleanup unused params/writes (11 diagnostics)`).

## Roadmap (이번 SPEC 내 후속)

- M6 (next): cc / loop / statusline / help / error 5-command batch + R-07 statusline thin wrapper
- M7: detect / NO_COLOR / golden suite (NEW 6-axis pattern) + ko/en i18n 카탈로그 sweep + AC-CLI-TUI-016 cumulative hex sweep

## Merge Strategy

**Squash** (§18.3 feature → squash 정책)

## SPEC Reference

- SPEC: `SPEC-V3R3-CLI-TUI-001`
- Plan: `.moai/specs/SPEC-V3R3-CLI-TUI-001/plan.md` §6 M5 (line 177~201), §11.2 OQ2
- Acceptance: `.moai/specs/SPEC-V3R3-CLI-TUI-001/acceptance.md` AC-CLI-TUI-007 / AC-CLI-TUI-013
- Predecessor: PR #815 (M4) merged → main `085efe76f`

## Test Plan

- [x] go test wizard + tui PASS
- [x] go test ./internal/... PASS (flaky retry 1회)
- [x] golangci-lint wizard + tui clean
- [x] hex sweep 0
- [ ] CI 빌드 + Lint + Test (linux/macos/windows) PASS 대기
- [ ] CodeQL PASS 대기

🗿 MoAI <email@mo.ai.kr>