### PR TITLE
chore(workflow): --worktree plan 전용 강제 + --base main 옵션 명시

### DIFF
--- a/.claude/rules/moai/development/branch-origin-protocol.md
+++ b/.claude/rules/moai/development/branch-origin-protocol.md
@@ -28,7 +28,8 @@ All three paths consume `internal/bodp.Check()` and `internal/bodp.WriteDecision
 ## HARD Rules
 
 - [HARD] CLI path (`moai worktree new`) MUST NOT invoke `AskUserQuestion` — see `agent-common-protocol.md` § User Interaction Boundary. Static check: `internal/cli/worktree/new_test.go` `TestNew_NoAskUserQuestion`.
-- [HARD] Default base for `moai worktree new` is `origin/main` (from `internal/bodp.DefaultBase`). The legacy default `"main"` is replaced.
+- [HARD] Default base for `moai worktree new` is `origin/main` (from `internal/bodp.DefaultBase`). Rationale: team-safe — auto-fetches latest from remote, preventing stale local main from contaminating new worktrees when teammates have merged PRs the user hasn't pulled. The legacy default `"main"` was replaced for this reason.
+- [HARD] `--base main` is the explicit opt-in for solo workflows where the user has committed locally to main without pushing. Use this when `git log main` shows commits the user wants in the new worktree's parent that may not yet be on `origin/main`.
 - [HARD] `--base` and `--from-current` are mutually exclusive flags on `moai worktree new`.
 - [HARD] Every BODP decision (skill or CLI) MUST be persisted to `.moai/branches/decisions/<normalized-branch>.md` via `bodp.WriteDecision`. Failure is non-fatal; absence of the file is the diagnostic signal for the off-protocol reminder.
 - [HARD] Skill body BODP gate MUST follow the askuser-protocol Socratic structure: `(권장)` first, ≤4 options, conversation_language match, "Other" auto-appended.

--- a/.claude/skills/moai/SKILL.md
+++ b/.claude/skills/moai/SKILL.md
@@ -247,6 +247,33 @@ Extract subcommand keywords and flags from the Raw User Input. Recognized global
 - `ultrathink` keyword detected → Activate Claude's native extended reasoning (high effort mode). Do NOT invoke Sequential Thinking MCP. This is native Claude behavior with no MCP dependency.
 - Both can coexist: `ultrathink --deepthink` activates BOTH independently.
 
+Step 1.5 - Flag-Subcommand Compatibility Validation:
+[HARD] After parsing the subcommand and flags (Step 1), validate flag-subcommand compatibility BEFORE routing. If a forbidden combination is detected, STOP all further processing and output an error in the user's conversation_language. Do NOT proceed to Step 2.
+
+Forbidden flag-subcommand combinations:
+
+| Flag | Allowed subcommands | Forbidden subcommands |
+|------|---------------------|------------------------|
+| `--worktree` | `plan`, default (autonomous) | `run`, `sync` |
+| `--branch` | `plan`, default (autonomous) | `run`, `sync` |
+
+Rationale: `--worktree` (and `--branch`) provision the workspace at SPEC initialization. `/moai plan` is the sole entry point that creates the worktree/branch. `/moai run` and `/moai sync` MUST operate within the worktree/branch already established during `plan`. Re-creating during run/sync corrupts the SPEC lifecycle and is rejected at the router level.
+
+Error message template (Korean conversation_language; substitute the actual flag and subcommand):
+```
+에러: --worktree 플래그는 /moai plan 전용입니다.
+/moai run 과 /moai sync 는 plan 단계에서 생성된 기존 worktree/branch를 재사용합니다.
+
+올바른 사용법:
+  /moai plan SPEC-XXX --worktree    (worktree 생성)
+  /moai run SPEC-XXX                (기존 worktree/branch 재사용)
+  /moai sync SPEC-XXX               (기존 worktree/branch 재사용)
+
+다시 실행하려면 --worktree 플래그를 제거한 형태로 호출하세요.
+```
+
+For English (`en` conversation_language), translate the message; the structure remains identical.
+
 Step 2 - Route to Workflow:
 Apply the Intent Router (Priority 1 through Priority 4) to determine the target workflow. If ambiguous, use AskUserQuestion to clarify with the user.
 

--- a/internal/cli/worktree/new.go
+++ b/internal/cli/worktree/new.go
@@ -60,12 +60,27 @@ func newNewCmd() *cobra.Command {
 If the branch does not exist, it is created automatically.
 
 SPEC-ID patterns (e.g., SPEC-AUTH-001) are automatically converted
-to branch names using the feature/ prefix convention.`,
+to branch names using the feature/ prefix convention.
+
+Base branch selection (mutually exclusive):
+  --base origin/main    Default. Fetches latest from remote before checkout.
+                        Team-safe: includes any teammate-merged PRs even if
+                        local main has not been pulled yet.
+  --base main           Use local main ref. Includes local-only commits that
+                        are not yet on the remote. Use this when you have
+                        committed directly to main locally and want them
+                        in the new worktree's parent.
+  --from-current        Use current HEAD as base (any branch). Skips
+                        'git fetch origin main' entirely.
+
+For solo development with local-only commits, prefer --base main.
+For team workflows where origin is the source of truth, the default
+origin/main is safer because it always reflects the latest merged state.`,
 		Args: cobra.ExactArgs(1),
 		RunE: runNew,
 	}
 	cmd.Flags().String("path", "", "Custom path for the worktree (default: .moai/worktrees/<SPEC-ID> for SPEC IDs, ../<branch-name> otherwise)")
-	cmd.Flags().String("base", bodp.DefaultBase, "Base branch to create the worktree from (default origin/main per BODP)")
+	cmd.Flags().String("base", bodp.DefaultBase, "Base branch (default origin/main, auto-fetched). Use --base main for local-only commits, --from-current for current HEAD.")
 	cmd.Flags().Bool("from-current", false, "Use current HEAD as the worktree base (skips `git fetch origin main`)")
 	cmd.Flags().Bool("tmux", false, "Create a tmux session after worktree creation")
 	return cmd

--- a/internal/template/templates/.claude/rules/moai/development/branch-origin-protocol.md
+++ b/internal/template/templates/.claude/rules/moai/development/branch-origin-protocol.md
@@ -28,7 +28,8 @@ All three paths consume `internal/bodp.Check()` and `internal/bodp.WriteDecision
 ## HARD Rules
 
 - [HARD] CLI path (`moai worktree new`) MUST NOT invoke `AskUserQuestion` — see `agent-common-protocol.md` § User Interaction Boundary. Static check: `internal/cli/worktree/new_test.go` `TestNew_NoAskUserQuestion`.
-- [HARD] Default base for `moai worktree new` is `origin/main` (from `internal/bodp.DefaultBase`). The legacy default `"main"` is replaced.
+- [HARD] Default base for `moai worktree new` is `origin/main` (from `internal/bodp.DefaultBase`). Rationale: team-safe — auto-fetches latest from remote, preventing stale local main from contaminating new worktrees when teammates have merged PRs the user hasn't pulled. The legacy default `"main"` was replaced for this reason.
+- [HARD] `--base main` is the explicit opt-in for solo workflows where the user has committed locally to main without pushing. Use this when `git log main` shows commits the user wants in the new worktree's parent that may not yet be on `origin/main`.
 - [HARD] `--base` and `--from-current` are mutually exclusive flags on `moai worktree new`.
 - [HARD] Every BODP decision (skill or CLI) MUST be persisted to `.moai/branches/decisions/<normalized-branch>.md` via `bodp.WriteDecision`. Failure is non-fatal; absence of the file is the diagnostic signal for the off-protocol reminder.
 - [HARD] Skill body BODP gate MUST follow the askuser-protocol Socratic structure: `(권장)` first, ≤4 options, conversation_language match, "Other" auto-appended.

--- a/internal/template/templates/.claude/skills/moai/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai/SKILL.md
@@ -247,6 +247,33 @@ Extract subcommand keywords and flags from the Raw User Input. Recognized global
 - `ultrathink` keyword detected → Activate Claude's native extended reasoning (high effort mode). Do NOT invoke Sequential Thinking MCP. This is native Claude behavior with no MCP dependency.
 - Both can coexist: `ultrathink --deepthink` activates BOTH independently.
 
+Step 1.5 - Flag-Subcommand Compatibility Validation:
+[HARD] After parsing the subcommand and flags (Step 1), validate flag-subcommand compatibility BEFORE routing. If a forbidden combination is detected, STOP all further processing and output an error in the user's conversation_language. Do NOT proceed to Step 2.
+
+Forbidden flag-subcommand combinations:
+
+| Flag | Allowed subcommands | Forbidden subcommands |
+|------|---------------------|------------------------|
+| `--worktree` | `plan`, default (autonomous) | `run`, `sync` |
+| `--branch` | `plan`, default (autonomous) | `run`, `sync` |
+
+Rationale: `--worktree` (and `--branch`) provision the workspace at SPEC initialization. `/moai plan` is the sole entry point that creates the worktree/branch. `/moai run` and `/moai sync` MUST operate within the worktree/branch already established during `plan`. Re-creating during run/sync corrupts the SPEC lifecycle and is rejected at the router level.
+
+Error message template (Korean conversation_language; substitute the actual flag and subcommand):
+```
+에러: --worktree 플래그는 /moai plan 전용입니다.
+/moai run 과 /moai sync 는 plan 단계에서 생성된 기존 worktree/branch를 재사용합니다.
+
+올바른 사용법:
+  /moai plan SPEC-XXX --worktree    (worktree 생성)
+  /moai run SPEC-XXX                (기존 worktree/branch 재사용)
+  /moai sync SPEC-XXX               (기존 worktree/branch 재사용)
+
+다시 실행하려면 --worktree 플래그를 제거한 형태로 호출하세요.
+```
+
+For English (`en` conversation_language), translate the message; the structure remains identical.
+
 Step 2 - Route to Workflow:
 Apply the Intent Router (Priority 1 through Priority 4) to determine the target workflow. If ambiguous, use AskUserQuestion to clarify with the user.
 


### PR DESCRIPTION
## Summary

두 가지 worktree 관련 워크플로우 routing/UX 개선.

### Task A — `--worktree` plan-only 강제 (router-level)

- `/moai run SPEC-XXX --worktree`가 silently 무시되던 문제 해결
- moai SKILL.md에 Step 1.5 (Flag-Subcommand Compatibility Validation) 추가
- `--worktree`/`--branch`가 `run`/`sync`에 사용되면 즉시 에러 출력 + 라우팅 중단
- 한국어 에러 메시지 + 올바른 사용법 가이드

### Task B — `moai worktree new --base` UX 개선 (디폴트 유지)

- BODP Wave 7의 `origin/main` 디폴트 유지 (팀 안전 — 자동 fetch로 stale main 방지)
- `--base main` 옵션이 솔로 워크플로우 (로컬 직접 커밋) 시나리오에 적합함을 help text에 명시
- `branch-origin-protocol.md` HARD 규칙 보강: rationale + `--base main` opt-in 명시

## Files Changed (5)

- `.claude/skills/moai/SKILL.md` — Step 1.5 추가
- `.claude/rules/moai/development/branch-origin-protocol.md` — HARD 규칙 rationale 보강
- `internal/cli/worktree/new.go` — Long description + --base flag help
- `internal/template/templates/.claude/skills/moai/SKILL.md` — mirror
- `internal/template/templates/.claude/rules/moai/development/branch-origin-protocol.md` — mirror

## Verification

- [x] `go vet ./internal/cli/worktree/...` PASS
- [x] `go test ./internal/bodp/... ./internal/cli/worktree/...` PASS
- [x] live ↔ template diff (branch-origin-protocol.md): identical
- [x] live ↔ template diff (SKILL.md): Step 1.5 동기화 (manager-ddd↔manager-develop는 pre-existing 별도 divergence, 본 PR 범위 외)

## Test Plan

- [ ] CI 16/16 PASS (Lint + Test ubuntu/macos/windows + Build 5)
- [ ] Reviewer가 Step 1.5 에러 메시지 명확성 검토
- [ ] 사용자가 `moai worktree new --help` 출력에서 base 옵션 차이를 즉시 이해

## Related

- BODP HARD 규칙 (origin/main 디폴트) 유지 — 팀 안전성 우선
- 솔로 시나리오는 `--base main` 명시적 opt-in으로 cover

🗿 MoAI <email@mo.ai.kr>