### PR TITLE
plan(spec): SPEC-V3R2-SPC-002 — @MX TAG v2 hook JSON integration + sidecar index

### DIFF
--- a/.moai/specs/SPEC-V3R2-SPC-002/acceptance.md
+++ b/.moai/specs/SPEC-V3R2-SPC-002/acceptance.md
@@ -1,0 +1,701 @@
+# SPEC-V3R2-SPC-002 Acceptance Criteria
+
+> Detailed Given-When-Then scenarios and verification evidence for **@MX TAG v2 with hook JSON integration and sidecar index**.
+> Companion to `spec.md` v0.1.0, `plan.md` v0.1.0, `research.md` v0.1.0, `tasks.md` v0.1.0.
+
+## HISTORY
+
+| Version | Date | Author | Description |
+|---------|------|--------|-------------|
+| 0.1.0   | 2026-05-10 | manager-spec (Plan workflow Phase 1B) | Initial acceptance.md. 15 AC scenarios mapped 1:1 to spec.md §6 AC-SPC-002-01..15. Each AC includes Given/When/Then + measurable evidence + REQ traceback + tasks.md task IDs. Performance budgets: 2s full-scan / 100ms incremental. |
+
+---
+
+## 1. AC Coverage Map
+
+| AC ID | Spec §6 statement | Mapped REQs | Mapped tasks | Evidence type |
+|---|---|---|---|---|
+| AC-SPC-002-01 | Tag struct extracted from `// @MX:NOTE` line | REQ-001, REQ-002, REQ-005 | T-SPC002-15 | Go unit test (existing scanner_test.go regression + new fixture) |
+| AC-SPC-002-02 | `--full` produces sidecar with N entries + `schema_version: 2` | REQ-003, REQ-008, REQ-013 | T-SPC002-04, T-SPC002-12 | Sidecar JSON parse + count |
+| AC-SPC-002-03 | Atomic write — interrupted process leaves sidecar valid or empty | REQ-004 | T-SPC002-12 | Concurrent goroutine fixture |
+| AC-SPC-002-04 | PostToolUse Edit triggers HookOutput with mxTags + additionalContext | REQ-010, REQ-011 | T-SPC002-01, T-SPC002-02, T-SPC002-03 | Handler unit test |
+| AC-SPC-002-05 | `@MX:WARN` without sibling REASON → MissingReasonForWarn warning | REQ-006, REQ-040 | T-SPC002-09 | Scanner warnings list |
+| AC-SPC-002-06 | Two `@MX:ANCHOR` with same ID → DuplicateAnchorID error + refuse write | REQ-007, REQ-021 | T-SPC002-10 | Scanner error + Manager refuse |
+| AC-SPC-002-07 | Stale tag (≤ 7 days) preserved in sidecar | REQ-014 | T-SPC002-13 | Sidecar entry lookup |
+| AC-SPC-002-08 | Stale tag (8+ days) archived to mx-archive.json | REQ-020 | T-SPC002-14 | Archive file content check |
+| AC-SPC-002-09 | Corrupt sidecar → empty + repair suggestion | REQ-022 | T-SPC002-11 | Stderr capture + Load() return |
+| AC-SPC-002-10 | mx.yaml `ignore: ["vendor/"]` excludes vendor/ paths | REQ-030 | T-SPC002-08 | Scanner result filter check |
+| AC-SPC-002-11 | `MOAI_MX_HOOK_SILENT=1` empties additionalContext | REQ-031 | T-SPC002-07 | Handler output assertion |
+| AC-SPC-002-12 | `--json` dumps current sidecar to stdout | REQ-032 | T-SPC002-05 | CLI stdout JSON parse |
+| AC-SPC-002-13 | Wrong hookEventName + mxTags → HookSpecificOutputMismatch | REQ-041 | T-SPC002-16 | Validator error type assertion |
+| AC-SPC-002-14 | `--anchor-audit` flags fan_in < 3 anchor as low-value | REQ-042 | T-SPC002-06 | Audit report content check |
+| AC-SPC-002-15 | All 16 supported languages produce tags in sidecar | REQ-005 | T-SPC002-15 | Per-language fixture sweep |
+
+---
+
+## 2. Acceptance Criteria
+
+### AC-SPC-002-01: Tag struct extraction
+
+**REQ traceback**: REQ-SPC-002-001 (inline syntax FROZEN preserved), REQ-SPC-002-002 (Tag struct definition), REQ-SPC-002-005 (16-language scanner)
+
+**Mapped tasks**: T-SPC002-15 (16-language fixture)
+
+**Given** a Go source file `/tmp/test.go` containing the line `// @MX:NOTE explains why handler forks` at line 12
+**When** the TagScanner scans the file via `scanner.ScanFile("/tmp/test.go")`
+**Then** the scanner MUST return exactly one Tag struct with the following field values:
+- `Kind == MXNote` (TagKind enum value)
+- `File == "/tmp/test.go"` (absolute path)
+- `Line == 12` (1-based line number)
+- `Body == "explains why handler forks"` (text after `@MX:NOTE`)
+- `Reason == ""` (NOTE has no required reason)
+- `AnchorID == ""` (NOTE has no AnchorID)
+- `CreatedBy == "human"` (default when no agent-specific marker)
+- `LastSeenAt` within 1 second of `time.Now()`
+
+**Verification command**:
+```bash
+cd /Users/goos/MoAI/moai-adk-go
+go test ./internal/mx/ -run TestScanner_AllSixteenLanguages -v
+```
+
+**Test fixture** (excerpt from `internal/mx/scanner_test.go`):
+```go
+func TestScanner_NoteTagBasic(t *testing.T) {
+    tmpDir := t.TempDir()
+    filePath := filepath.Join(tmpDir, "test.go")
+    content := []byte("package foo\n// @MX:NOTE explains why handler forks\nfunc Bar() {}\n")
+    require.NoError(t, os.WriteFile(filePath, content, 0644))
+
+    scanner := NewScanner()
+    tags, err := scanner.ScanFile(filePath)
+    require.NoError(t, err)
+    require.Len(t, tags, 1)
+    require.Equal(t, MXNote, tags[0].Kind)
+    require.Equal(t, 2, tags[0].Line)
+    require.Equal(t, "explains why handler forks", tags[0].Body)
+}
+```
+
+**Expected**: PASS (existing scanner already implements this — fixture validates ongoing correctness).
+
+---
+
+### AC-SPC-002-02: Full scan produces correct sidecar
+
+**REQ traceback**: REQ-SPC-002-003 (sidecar at `.moai/state/mx-index.json`), REQ-SPC-002-008 (`schema_version: 2`), REQ-SPC-002-013 (`--full` rescans entire project)
+
+**Mapped tasks**: T-SPC002-04 (`--full` flag), T-SPC002-12 (atomic write fixture)
+
+**Given** a project tree at `/tmp/proj/` containing exactly 42 `@MX:` tags distributed across 15 source files in 5 different languages (go, py, rs, ts, java)
+**When** an operator runs `cd /tmp/proj && moai mx --full`
+**Then** the file `/tmp/proj/.moai/state/mx-index.json` MUST exist
+**And** it MUST be valid JSON
+**And** it MUST contain a top-level field `schema_version` equal to integer `2`
+**And** it MUST contain a top-level field `tags` with exactly 42 entries
+**And** each entry MUST have all 8 Tag fields populated correctly
+
+**Verification command**:
+```bash
+cd /tmp/proj
+moai mx --full
+jq '.schema_version' .moai/state/mx-index.json
+# Expected: 2
+jq '.tags | length' .moai/state/mx-index.json
+# Expected: 42
+```
+
+**Test fixture**: `internal/cli/mx_test.go` `TestMxCmd_FullFlag_RebuildsSidecar` (T-SPC002-04). Synthesizes 42-tag fixture under `t.TempDir()` and asserts JSON output.
+
+---
+
+### AC-SPC-002-03: Atomic write semantics
+
+**REQ traceback**: REQ-SPC-002-004 (atomic temp+rename)
+
+**Mapped tasks**: T-SPC002-12 (concurrent fixture)
+
+**Given** a sidecar Manager is performing `Manager.Write(sidecar)` with a 2MB payload
+**And** a separate goroutine is repeatedly calling `Manager.Load()` 1000 times
+**When** the 1000 reads complete
+**Then** every read MUST return either:
+- a valid Sidecar struct (well-formed JSON, parseable), OR
+- an error indicating file does not exist (during temp file phase)
+
+**And** ZERO reads MUST return partial/truncated JSON (parse failure on partial file)
+
+**Verification command**:
+```bash
+go test ./internal/mx/ -run TestSidecar_AtomicWrite_NoPartialReads -race -count=10 -v
+```
+
+**Test fixture** (excerpt — `internal/mx/sidecar_test.go`):
+```go
+func TestSidecar_AtomicWrite_NoPartialReads(t *testing.T) {
+    tmpDir := t.TempDir()
+    mgr := NewManager(tmpDir)
+    largePayload := generateLargeSidecar(10000) // 10K tags ≈ 5MB
+
+    var wg sync.WaitGroup
+    var partialReads int32
+    wg.Add(2)
+
+    // Writer goroutine
+    go func() {
+        defer wg.Done()
+        for i := 0; i < 100; i++ {
+            require.NoError(t, mgr.Write(largePayload))
+        }
+    }()
+
+    // Reader goroutine
+    go func() {
+        defer wg.Done()
+        for i := 0; i < 1000; i++ {
+            sc, err := mgr.Load()
+            if err == nil && sc.SchemaVersion != SchemaVersion {
+                atomic.AddInt32(&partialReads, 1)
+            }
+        }
+    }()
+
+    wg.Wait()
+    require.Equal(t, int32(0), partialReads, "no partial reads expected")
+}
+```
+
+**Expected**: PASS under `-race` flag.
+
+---
+
+### AC-SPC-002-04: PostToolUse triggers mxTags emission
+
+**REQ traceback**: REQ-SPC-002-010 (PostToolUse re-scan), REQ-SPC-002-011 (HookResponse with mxTags + additionalContext)
+
+**Mapped tasks**: T-SPC002-01 (handler), T-SPC002-02 (MxTags field), T-SPC002-03 (additionalContext format)
+
+**Given** a Python file `/tmp/proj/foo.py` is edited via Claude's Edit tool, adding the line `# @MX:WARN missing timeout on requests.get`
+**And** the PostToolUse hook fires with `tool_name == "Edit"` and `tool_input.file_path == "/tmp/proj/foo.py"`
+**When** the post_tool_mx handler processes the event
+**Then** the returned `HookOutput` MUST satisfy:
+- `HookOutput.HookSpecificOutput != nil`
+- `HookOutput.HookSpecificOutput.HookEventName == "PostToolUse"`
+- `HookOutput.HookSpecificOutput.AdditionalContext != ""` (contains substring "missing timeout on requests.get" AND the line number)
+- `HookOutput.HookSpecificOutput.MxTags` is a non-empty `[]mx.Tag` slice
+- `MxTags[0].Kind == MXWarn`
+- `MxTags[0].File == "/tmp/proj/foo.py"`
+- `MxTags[0].Body == "missing timeout on requests.get"`
+
+**Verification command**:
+```bash
+go test ./internal/hook/ -run TestPostToolUseHandler_EmitsMxTags -v
+```
+
+**Test fixture** (excerpt — `internal/hook/post_tool_mx_test.go`):
+```go
+func TestPostToolUseHandler_EmitsMxTags(t *testing.T) {
+    tmpDir := t.TempDir()
+    pyFile := filepath.Join(tmpDir, "foo.py")
+    require.NoError(t, os.WriteFile(pyFile, []byte("# @MX:WARN missing timeout on requests.get\nimport requests\n"), 0644))
+
+    h := NewPostToolMxHandler()
+    input := &HookInput{
+        SessionID:     "test-001",
+        Cwd:           tmpDir,
+        HookEventName: "PostToolUse",
+        ToolName:      "Edit",
+        ToolInput:     json.RawMessage(`{"file_path":"` + pyFile + `"}`),
+    }
+    output, err := h.Handle(context.Background(), input)
+    require.NoError(t, err)
+    require.NotNil(t, output.HookSpecificOutput)
+    require.Equal(t, "PostToolUse", output.HookSpecificOutput.HookEventName)
+    require.Contains(t, output.HookSpecificOutput.AdditionalContext, "missing timeout")
+    require.Len(t, output.HookSpecificOutput.MxTags, 1)
+    require.Equal(t, mx.MXWarn, output.HookSpecificOutput.MxTags[0].Kind)
+}
+```
+
+**Expected**: PASS.
+
+---
+
+### AC-SPC-002-05: MissingReasonForWarn warning
+
+**REQ traceback**: REQ-SPC-002-006 (WARN requires sibling REASON), REQ-SPC-002-040 (3-line lookahead)
+
+**Mapped tasks**: T-SPC002-09 (lookahead fixture)
+
+**Given** a Go file with `// @MX:WARN bug here` at line 5 and no `@MX:REASON` within lines 6, 7, or 8
+**When** the Scanner scans the file
+**Then** the Scanner's `Warnings()` slice MUST contain exactly 1 entry
+**And** the entry MUST contain the substring `MissingReasonForWarn`
+**And** the entry MUST contain the file path AND line number `:5`
+
+**Edge case**: REASON at line 9 (4 lines after WARN) MUST still trigger the warning (3-line lookahead is exclusive).
+
+**Verification command**:
+```bash
+go test ./internal/mx/ -run TestScanner_MissingReasonForWarn_3LineLookahead -v
+```
+
+**Test fixture**:
+```go
+func TestScanner_MissingReasonForWarn_3LineLookahead(t *testing.T) {
+    tmpDir := t.TempDir()
+    filePath := filepath.Join(tmpDir, "warn.go")
+    content := []byte(`package foo
+// @MX:WARN bug here
+func Bar() {
+    println("foo")
+    println("bar")
+    println("baz")
+}
+`)
+    require.NoError(t, os.WriteFile(filePath, content, 0644))
+
+    scanner := NewScanner()
+    _, err := scanner.ScanFile(filePath)
+    require.NoError(t, err)
+    require.Len(t, scanner.Warnings(), 1)
+    require.Contains(t, scanner.Warnings()[0], "MissingReasonForWarn")
+    require.Contains(t, scanner.Warnings()[0], ":2") // line 2 of the test file
+}
+```
+
+**Expected**: PASS.
+
+---
+
+### AC-SPC-002-06: DuplicateAnchorID refuse-write
+
+**REQ traceback**: REQ-SPC-002-007 (uniqueness), REQ-SPC-002-021 (refuse write)
+
+**Mapped tasks**: T-SPC002-10 (duplicate fixture)
+
+**Given** two source files `/tmp/proj/a.go` and `/tmp/proj/b.go`, each containing `// @MX:ANCHOR auth-handler-v1\n// @MX:REASON test`
+**When** the Scanner runs `ScanDirectory("/tmp/proj")` and the result is passed to `Manager.Write()`
+**Then** the Scanner's `Errors()` slice MUST contain a `DuplicateAnchorID` entry naming both file:line pairs (`a.go:1` and `b.go:1`)
+**And** the `Manager.Write` call MUST refuse to write the sidecar (return error)
+**And** the file `.moai/state/mx-index.json` MUST remain unchanged (or absent if this is the first scan)
+
+**Verification command**:
+```bash
+go test ./internal/mx/ -run TestScanner_DuplicateAnchorID_RefuseWrite -v
+```
+
+**Test fixture**:
+```go
+func TestScanner_DuplicateAnchorID_RefuseWrite(t *testing.T) {
+    tmpDir := t.TempDir()
+    aPath := filepath.Join(tmpDir, "a.go")
+    bPath := filepath.Join(tmpDir, "b.go")
+    body := []byte("package foo\n// @MX:ANCHOR auth-handler-v1\n// @MX:REASON test\n")
+    require.NoError(t, os.WriteFile(aPath, body, 0644))
+    require.NoError(t, os.WriteFile(bPath, body, 0644))
+
+    scanner := NewScanner()
+    tags, err := scanner.ScanDirectory(tmpDir)
+    require.NoError(t, err) // scan itself succeeds
+    require.Len(t, scanner.Errors(), 1)
+    require.Contains(t, scanner.Errors()[0], "DuplicateAnchorID")
+    require.Contains(t, scanner.Errors()[0], "a.go")
+    require.Contains(t, scanner.Errors()[0], "b.go")
+
+    mgr := NewManager(filepath.Join(tmpDir, ".moai/state"))
+    err = mgr.Write(&Sidecar{SchemaVersion: SchemaVersion, Tags: tags})
+    // depending on implementation, write may succeed but Manager has tag dedup logic;
+    // alternative: scanner returns error before Write.
+    // Plan binding: scanner errors short-circuit Manager.Write at the CLI/handler call site.
+    _ = err
+}
+```
+
+**Expected**: PASS.
+
+---
+
+### AC-SPC-002-07: 7-day stale tag preservation
+
+**REQ traceback**: REQ-SPC-002-014 (LastSeenAt preserved if not found within 7 days)
+
+**Mapped tasks**: T-SPC002-13 (6-day fixture)
+
+**Given** the existing sidecar contains a Tag with `LastSeenAt = now - 6 days` and a body that is no longer present in the current source tree
+**When** `Manager.UpdateFile()` (or `--full`) runs and does not find this Tag
+**Then** the Tag MUST remain in the sidecar
+**And** its `LastSeenAt` MUST NOT change (preserved from prior scan)
+
+**Verification command**:
+```bash
+go test ./internal/mx/ -run TestSidecar_StaleNotYetArchived_7Days -v
+```
+
+**Test fixture**:
+```go
+func TestSidecar_StaleNotYetArchived_7Days(t *testing.T) {
+    tmpDir := t.TempDir()
+    mgr := NewManager(tmpDir)
+    sixDaysAgo := time.Now().Add(-6 * 24 * time.Hour)
+
+    initial := &Sidecar{
+        SchemaVersion: SchemaVersion,
+        Tags: []Tag{
+            {Kind: MXNote, File: "removed.go", Line: 10, Body: "old", LastSeenAt: sixDaysAgo},
+        },
+    }
+    require.NoError(t, mgr.Write(initial))
+
+    // Run full scan against empty project — tag is "missing"
+    sidecar, err := mgr.RebuildFromScan(tmpDir, []Tag{})
+    require.NoError(t, err)
+
+    require.Len(t, sidecar.Tags, 1)
+    require.Equal(t, sixDaysAgo.Unix(), sidecar.Tags[0].LastSeenAt.Unix())
+}
+```
+
+**Expected**: PASS.
+
+---
+
+### AC-SPC-002-08: 8-day stale archive sweep
+
+**REQ traceback**: REQ-SPC-002-020 (8+ days → archive)
+
+**Mapped tasks**: T-SPC002-14 (8-day archive fixture)
+
+**Given** the existing sidecar contains a Tag with `LastSeenAt = now - 8 days` and a body no longer present in source
+**When** `--full` runs (which triggers archive sweep)
+**Then** the Tag MUST be removed from `.moai/state/mx-index.json`
+**And** the Tag MUST be appended to `.moai/state/mx-archive.json`
+**And** the archive's `archived_at` MUST be within 1 second of `time.Now()`
+
+**Verification command**:
+```bash
+go test ./internal/mx/ -run TestSidecar_StaleArchived_8Days -v
+```
+
+**Test fixture**:
+```go
+func TestSidecar_StaleArchived_8Days(t *testing.T) {
+    tmpDir := t.TempDir()
+    mgr := NewManager(tmpDir)
+    eightDaysAgo := time.Now().Add(-8 * 24 * time.Hour)
+
+    initial := &Sidecar{
+        SchemaVersion: SchemaVersion,
+        Tags: []Tag{
+            {Kind: MXNote, File: "removed.go", Line: 10, Body: "old", LastSeenAt: eightDaysAgo},
+        },
+    }
+    require.NoError(t, mgr.Write(initial))
+
+    sidecar, err := mgr.RebuildFromScan(tmpDir, []Tag{})
+    require.NoError(t, err)
+    require.Len(t, sidecar.Tags, 0) // archived
+
+    archiveData, err := os.ReadFile(filepath.Join(tmpDir, "mx-archive.json"))
+    require.NoError(t, err)
+    var archive Archive
+    require.NoError(t, json.Unmarshal(archiveData, &archive))
+    require.Len(t, archive.ArchivedTags, 1)
+}
+```
+
+**Expected**: PASS.
+
+---
+
+### AC-SPC-002-09: Corrupt sidecar repair suggestion
+
+**REQ traceback**: REQ-SPC-002-022
+
+**Mapped tasks**: T-SPC002-11
+
+**Given** the file `.moai/state/mx-index.json` exists with content `{"schema_version": 2, "tags": [INVALID JSON`
+**When** an operator runs `moai mx` (any subcommand) which loads the sidecar
+**Then** the command MUST NOT crash
+**And** the in-memory sidecar MUST be empty (`SchemaVersion: 2, Tags: []`)
+**And** stderr MUST contain the substring `WARNING: sidecar corrupt` and `/moai mx --full`
+
+**Verification command**:
+```bash
+echo '{"schema_version": 2, "tags": [INVALID' > /tmp/proj/.moai/state/mx-index.json
+moai mx 2>&1 | grep "WARNING: sidecar corrupt"
+# Expected: 1 match
+```
+
+**Test fixture**: `internal/mx/sidecar_test.go` `TestSidecar_CorruptJSON_RepairSuggestion`.
+
+**Expected**: PASS.
+
+---
+
+### AC-SPC-002-10: mx.yaml ignore patterns
+
+**REQ traceback**: REQ-SPC-002-030
+
+**Mapped tasks**: T-SPC002-08 (Scanner ignore wire-up)
+
+**Given** `.moai/config/sections/mx.yaml` contains:
+```yaml
+mx:
+  ignore:
+    - "vendor/**"
+    - "dist/**"
+```
+**And** the project has an @MX tag in `vendor/foo.go` and another in `src/bar.go`
+**When** an operator runs `moai mx --full`
+**Then** the resulting sidecar MUST contain ONLY the `src/bar.go` tag
+**And** MUST NOT contain any tag from `vendor/`
+
+**Verification command**:
+```bash
+cd /tmp/proj
+moai mx --full
+jq '[.tags[] | .file] | map(test("vendor/")) | any' .moai/state/mx-index.json
+# Expected: false
+```
+
+**Test fixture**: `internal/mx/scanner_test.go` `TestScanner_RespectsMxYamlIgnore`.
+
+**Expected**: PASS.
+
+---
+
+### AC-SPC-002-11: MOAI_MX_HOOK_SILENT env
+
+**REQ traceback**: REQ-SPC-002-031
+
+**Mapped tasks**: T-SPC002-07
+
+**Given** the env var `MOAI_MX_HOOK_SILENT=1` is set
+**When** PostToolUse handler processes a file edit that adds a new `@MX:NOTE`
+**Then** the returned `HookOutput.HookSpecificOutput.AdditionalContext` MUST be empty (`""`)
+**But** `HookOutput.HookSpecificOutput.MxTags` MUST still be populated (structured data is unaffected)
+**And** the sidecar MUST be updated normally
+
+**Verification command**:
+```bash
+go test ./internal/hook/ -run TestPostToolUseHandler_HookSilentEnv -v
+```
+
+**Test fixture**:
+```go
+func TestPostToolUseHandler_HookSilentEnv(t *testing.T) {
+    t.Setenv("MOAI_MX_HOOK_SILENT", "1")
+    // ... (similar setup as AC-04 fixture)
+    output, err := h.Handle(context.Background(), input)
+    require.NoError(t, err)
+    require.Equal(t, "", output.HookSpecificOutput.AdditionalContext)
+    require.NotEmpty(t, output.HookSpecificOutput.MxTags) // structured data preserved
+}
+```
+
+**Expected**: PASS.
+
+---
+
+### AC-SPC-002-12: `/moai mx --json` stdout dump
+
+**REQ traceback**: REQ-SPC-002-032
+
+**Mapped tasks**: T-SPC002-05
+
+**Given** a sidecar at `.moai/state/mx-index.json` exists with content
+**When** an operator runs `moai mx --json`
+**Then** stdout MUST receive byte-for-byte the content of the sidecar file (or a re-marshalled equivalent JSON)
+**And** stdout MUST be valid JSON parseable into `Sidecar` struct
+**And** exit code MUST be 0
+
+**Verification command**:
+```bash
+moai mx --json | jq '.schema_version'
+# Expected: 2
+```
+
+**Test fixture**: `internal/cli/mx_test.go` `TestMxCmd_JsonFlag_DumpsSidecar`.
+
+**Expected**: PASS.
+
+---
+
+### AC-SPC-002-13: HookSpecificOutput mismatch error
+
+**REQ traceback**: REQ-SPC-002-041
+
+**Mapped tasks**: T-SPC002-16
+
+**Given** a HookOutput is being constructed with `hookSpecificOutput.hookEventName == "PreToolUse"` and `hookSpecificOutput.mxTags` is non-empty
+**When** the hook protocol validator inspects the output
+**Then** the validator MUST reject the output with error type `HookSpecificOutputMismatch`
+**And** the error message MUST mention both the actual hookEventName ("PreToolUse") and the expected ("PostToolUse")
+
+**Verification command**:
+```bash
+go test ./internal/hook/ -run TestPostToolUseHandler_HookSpecificOutputMismatch -v
+```
+
+**Test fixture**:
+```go
+func TestHookOutput_MxTagsRequiresPostToolUseEvent(t *testing.T) {
+    output := &HookOutput{
+        HookSpecificOutput: &HookSpecificOutput{
+            HookEventName: "PreToolUse", // wrong
+            MxTags:        []mx.Tag{{Kind: mx.MXNote}},
+        },
+    }
+    err := ValidateMxTagsConsistency(output)
+    require.ErrorIs(t, err, ErrHookSpecificOutputMismatch)
+}
+```
+
+**Expected**: PASS.
+
+---
+
+### AC-SPC-002-14: `--anchor-audit` flags low fan_in
+
+**REQ traceback**: REQ-SPC-002-042
+
+**Mapped tasks**: T-SPC002-06 (anchor-audit)
+
+**Given** the sidecar contains an `MXAnchor` Tag with `AnchorID == "rare-spot"` and SPC-004 fan_in computation returns 1 caller
+**When** an operator runs `moai mx --anchor-audit`
+**Then** the audit report (stdout) MUST list `rare-spot` with fan_in 1
+**And** the report MUST NOT list any anchor with fan_in ≥ 3
+**And** exit code MUST be 0 (audit is informational, not failure)
+
+**Verification command**:
+```bash
+moai mx --anchor-audit | grep "rare-spot.*1"
+# Expected: 1 match
+```
+
+**Test fixture**: `internal/mx/anchor_audit_test.go` `TestRunAnchorAudit_LowFanInReported`.
+
+**Expected**: PASS.
+
+---
+
+### AC-SPC-002-15: 16-language scanner coverage
+
+**REQ traceback**: REQ-SPC-002-005 (16-language support)
+
+**Mapped tasks**: T-SPC002-15
+
+**Given** a test fixture directory contains 16 source files, one per supported language (go, py, ts, js, rs, java, kt, cs, rb, php, ex, cpp, scala, R, dart, swift), each with at least one `@MX:NOTE` tag
+**When** the Scanner runs `ScanDirectory()` on the fixture
+**Then** the result MUST contain exactly 16 Tag records (one per file)
+**And** every Tag MUST have `Kind == MXNote`
+**And** every Tag's File field MUST point to the correct fixture file
+
+**Verification command**:
+```bash
+go test ./internal/mx/ -run TestScanner_AllSixteenLanguages -v
+```
+
+**Test fixture** (excerpt):
+```go
+func TestScanner_AllSixteenLanguages(t *testing.T) {
+    tmpDir := t.TempDir()
+    languages := map[string]string{
+        "test.go":    "// @MX:NOTE go test\n",
+        "test.py":    "# @MX:NOTE python test\n",
+        "test.ts":    "// @MX:NOTE ts test\n",
+        "test.js":    "// @MX:NOTE js test\n",
+        "test.rs":    "// @MX:NOTE rust test\n",
+        "test.java":  "// @MX:NOTE java test\n",
+        "test.kt":    "// @MX:NOTE kotlin test\n",
+        "test.cs":    "// @MX:NOTE csharp test\n",
+        "test.rb":    "# @MX:NOTE ruby test\n",
+        "test.php":   "// @MX:NOTE php test\n",
+        "test.ex":    "# @MX:NOTE elixir test\n",
+        "test.cpp":   "// @MX:NOTE cpp test\n",
+        "test.scala": "// @MX:NOTE scala test\n",
+        "test.R":     "# @MX:NOTE r test\n",
+        "test.dart":  "// @MX:NOTE flutter test\n",
+        "test.swift": "// @MX:NOTE swift test\n",
+    }
+    for name, content := range languages {
+        require.NoError(t, os.WriteFile(filepath.Join(tmpDir, name), []byte(content), 0644))
+    }
+
+    scanner := NewScanner()
+    tags, err := scanner.ScanDirectory(tmpDir)
+    require.NoError(t, err)
+    require.Len(t, tags, 16, "all 16 supported languages should produce a tag")
+}
+```
+
+**Expected**: PASS. Exactly 16 tags returned (one per language).
+
+---
+
+## 3. Performance Acceptance
+
+Per spec §7 Constraints:
+
+| Performance criterion | Target | Verification |
+|----------------------|--------|--------------|
+| Full-scan budget | ≤ 2s for 10,000-file fixture | Benchmark `go test -bench BenchmarkFullScan10K ./internal/mx/` (optional, advisory) |
+| Incremental update budget | ≤ 100ms per file | T-SPC002-12 fixture timing assertion |
+| Sidecar file size | ≤ 5MB for 10,000 tags | `ls -la mx-index.json` check after benchmark fixture |
+| No new third-party dependency | Go stdlib only | `go mod why` should show no new top-level deps from this SPEC |
+
+---
+
+## 4. Definition of Done
+
+The SPEC is considered DONE when:
+
+- [ ] All 15 ACs (AC-SPC-002-01 through AC-SPC-002-15) verified
+- [ ] All 22 REQs (REQ-SPC-002-001..008, 010..014, 020..022, 030..032, 040..042) traced to ≥1 task per plan §1.5
+- [ ] All 22 tasks (T-SPC002-01..22 per tasks.md) marked complete
+- [ ] `go test -race -count=1 ./...` PASS (no regressions)
+- [ ] `golangci-lint run` clean
+- [ ] `make build` regenerates `internal/template/embedded.go` correctly
+- [ ] Coverage ≥ 85% per modified package
+- [ ] Template parity verified via `diff -r` (no template change expected)
+- [ ] CHANGELOG entry written in Unreleased section
+- [ ] @MX tags applied per plan §6 (6 tags)
+- [ ] Run PR squash-merged into main
+- [ ] Sync PR squash-merged into main
+- [ ] Worktree disposed via `moai worktree done SPEC-V3R2-SPC-002`
+- [ ] Manual end-to-end smoke test: real Claude session edit a Go file, observe `mxTags` in PostToolUse hook stdout, verify `.moai/state/mx-index.json` updates
+
+---
+
+## 5. Quality Gate Criteria
+
+Per `.moai/config/sections/quality.yaml`:
+
+| Criterion | Target | Verification |
+|-----------|--------|--------------|
+| Tested | All new functions covered | `go test -cover ./internal/{hook,mx,cli}/` ≥ 85% |
+| Readable | English code + ko inline comments | `golangci-lint run` clean |
+| Unified | Style + import order | `gofmt -l ./internal/` empty |
+| Secured | No new attack surface | PostToolUse handler is read-only on source + write-only on `.moai/state/`; no shell injection |
+| Trackable | All commits + CHANGELOG | git log inspection + CHANGELOG diff |
+
+---
+
+## 6. Risk-based AC Prioritization
+
+| AC | Priority | Why |
+|---|---|---|
+| AC-01, AC-02, AC-04 | P0 | Core: tag struct + sidecar contract + PostToolUse emission |
+| AC-03, AC-12 | P0 | Atomic write + JSON dump (RT-001 protocol contract) |
+| AC-05, AC-06, AC-08, AC-15 | P0 | Scanner correctness + 16-lang coverage (regression prevention) |
+| AC-07 | P1 | Stale-tag preservation edge case |
+| AC-09, AC-13 | P1 | Repair semantics + protocol mismatch |
+| AC-10, AC-11 | P1 | mx.yaml ignore + silent env (CI ergonomics) |
+| AC-14 | P2 | Anchor audit (advisory, fan_in based) |
+
+---
+
+End of acceptance.
+
+Version: 0.1.0
+Status: Acceptance artifact for SPEC-V3R2-SPC-002

--- a/.moai/specs/SPEC-V3R2-SPC-002/issue-body.md
+++ b/.moai/specs/SPEC-V3R2-SPC-002/issue-body.md
@@ -1,0 +1,151 @@
+# SPEC-V3R2-SPC-002 — @MX TAG v2 with hook JSON integration and sidecar index (Plan PR)
+
+> Step 1 plan-in-main per `.claude/rules/moai/workflow/spec-workflow.md` § SPEC Phase Discipline.
+> Branch: `plan/SPEC-V3R2-SPC-002` · Base: `origin/main` HEAD `fcb486c87` · Merge strategy: squash.
+
+## Summary
+
+Layer two additive capabilities on top of the FROZEN inline @MX TAG protocol (mx-tag-protocol.md, CONST-V3R2-003):
+
+1. **Machine-readable JSON sidecar** at `.moai/state/mx-index.json` (`schema_version: 2`, atomic temp+rename writes) that materializes every @MX TAG as a structured Tag record (Kind/File/Line/Body/Reason/AnchorID/CreatedBy/LastSeenAt). Enables tool consumption (SPC-004 resolver, evaluator-active, codemaps) without re-scanning source on every query.
+
+2. **PostToolUse hook integration** via SPEC-V3R2-RT-001's JSON dual-protocol — the new `post_tool_mx` handler emits `additionalContext` (human-readable summary) and `hookSpecificOutput.mxTags` (structured Tag array) into the model turn, AND atomically updates the sidecar.
+
+The inline source-code convention `// @MX:KIND text` stays FROZEN. The sidecar is a **view** — never the source of truth.
+
+This PR contains **plan artifacts only** (research / plan / acceptance / tasks / progress / issue-body). No code or hook changes ship in this PR — those land in the run PR (`feat/SPEC-V3R2-SPC-002`) after this plan PR squash-merges into `main`.
+
+## Why this matters
+
+- **Sidecar enables tooling at scale**: SPC-004 resolver query (already merged, PR #746) reads the sidecar. Without atomic write semantics + schema_version pinning, resolver consumers face partial-read crashes. This SPEC formalizes the contract.
+- **PostToolUse integration closes the agent feedback loop**: Today, Claude edits a file with `@MX:WARN goroutine leak` and the warning vanishes into the file system. With this SPEC, the next model turn sees the WARN injected into context AND consumers (evaluator-active per HRN-003) see the structured tag.
+- **80% of the code already exists**: Wave 3 PR #741 (`3f0933550`) merged `internal/mx/` package skeleton (tag.go, scanner.go, sidecar.go, comment_prefixes.go, resolver.go). SPC-004 PR #746 (`68795dbe3`) added resolver_query.go, fanin.go, danger_category.go, spec_association.go. **Run-phase scope is gap-closure, not from-scratch build** — see plan §1.2.
+
+## Plan-phase deliverables (this PR)
+
+- `spec.md` (already on main; no change)
+- `research.md` — 30 evidence anchors, 9 OQ resolutions, cross-SPEC boundary survey for CON-001 / RT-001 / SPC-004 / HRN-003 / WF-005, gap inventory G-01..G-08.
+- `plan.md` — 6 milestones (M1..M6), 22 tasks, 22 REQ → 15 AC → 22 Task traceability matrix; 6 @MX tags planned; risk mitigation cross-referenced to spec §8.
+- `acceptance.md` — 15 ACs in Given/When/Then form with verification commands, test fixtures (Go), and Definition of Done.
+- `tasks.md` — 22 tasks with REQ/AC traceback, dependency graph, SPC-004 reuse plan.
+- `progress.md` — milestone tracker shell + AC status + risk watch.
+- `issue-body.md` — this file.
+
+## Run-phase scope (next PR after this plan PR merges)
+
+After plan PR squash-merge:
+
+1. `moai worktree new SPEC-V3R2-SPC-002 --base origin/main` (Step 2 spec-workflow).
+2. `/moai run SPEC-V3R2-SPC-002` invokes Phase 0.5 plan-audit gate.
+3. **M1 — PostToolUse handler + types (P0)**:
+   - New `internal/hook/post_tool_mx.go` (~150 LOC) handler emitting `mxTags` + `additionalContext`.
+   - Add `MxTags []mx.Tag` field to `HookSpecificOutput` in `internal/hook/types.go`.
+   - 16-language regression fixture in `internal/mx/scanner_test.go`.
+4. **M2 — `/moai mx` flag dispatcher (P0)**:
+   - `--full` (rescan + rebuild + archive sweep)
+   - `--index-only` (silent — CI 친화)
+   - `--json` (dump current sidecar to stdout)
+   - `--anchor-audit` (low fan_in anchor reporter)
+5. **M3 — silent env + mx.yaml ignore (P1)**:
+   - `MOAI_MX_HOOK_SILENT=1` empties additionalContext but preserves MxTags + sidecar
+   - mx.yaml `ignore:` patterns wire-up to Scanner
+6. **M4 — Scanner correctness fixtures (P1)**:
+   - MissingReasonForWarn 3-line lookahead
+   - DuplicateAnchorID refuse-write
+   - Corrupt sidecar repair suggestion
+   - HookSpecificOutput mismatch validator
+7. **M5 — Archive sweep + atomic verify (P1)**:
+   - 7-day stale preservation
+   - 8-day archive sweep
+   - Atomic write race fixture (`-race -count=10`)
+8. **M6 — Verification (P0)**:
+   - Full test suite + lint + build + CHANGELOG + @MX tags + smoke test
+
+Estimated artifacts: 5 new Go source files + 5 new test files + 4 modified Go files + CHANGELOG = **~1,250 LOC delta** (production ~480 + test ~770).
+
+## Acknowledged discrepancies (from plan §1.2.1)
+
+1. **80% of code already exists.** Wave 3 PR #741 (`3f0933550`) merged the `internal/mx/` skeleton; SPC-004 PR #746 (`68795dbe3`) added resolver/fanin/danger. Run-phase task count reflects gap-closure not from-scratch build. Sync-phase HISTORY in spec.md should reconcile §1 "introduces" → "completes".
+
+2. **REQ-006 vs REQ-040 unification.** Both REQs describe the same code path (Scanner WARN → 3-line lookahead for REASON). tasks.md treats as single task (T-SPC002-09).
+
+3. **MxTags field vs additionalContext embed.** OQ-1 (research §7) chose new `HookSpecificOutput.MxTags` field (omitempty) over JSON embed in additionalContext. Rationale: protocol-level structured emission consistent with RT-001 dual-protocol intent.
+
+4. **schema_version: 2 preservation.** SPC-004 already consumes the sidecar schema. New fields MUST be omitempty; no field semantic changes.
+
+5. **`internal/hook/file_changed.go:supportedExtensions` drift with `comment_prefixes.go`** is acknowledged advisory; integration deferred to WF-005 16-language enum SoT SPEC.
+
+## FROZEN preservation guarantee
+
+The inline @MX TAG syntax defined in `.claude/rules/moai/workflow/mx-tag-protocol.md` is FROZEN per zone-registry.md `CONST-V3R2-003`. This SPEC adds NO new tag kinds, NO sub-line modifications, NO syntax variants. Every change lives in:
+
+- `internal/hook/post_tool_mx.go` (new handler)
+- `internal/hook/types.go` (new MxTags field)
+- `internal/cli/mx.go` (new flags)
+- `internal/mx/{config,integration,anchor_audit}.go` (new helpers)
+- `internal/mx/scanner_test.go`, `internal/mx/sidecar_test.go` (new fixtures)
+
+Zero changes to `.claude/rules/moai/workflow/mx-tag-protocol.md`. Zero changes to existing inline syntax in agent files.
+
+## Plan-auditor target
+
+- **PASS verdict** ≥ 0.85 first iteration.
+- 22 REQs (REQ-SPC-002-001..008, 010..014, 020..022, 030..032, 040..042) traced to ≥1 AC and ≥1 task per plan §1.5 traceability matrix.
+- 15 ACs each with Given/When/Then + verification command + REQ traceback.
+- 30 evidence anchors in research.md (counted [E-01]..[E-30]).
+- 9 OQ resolutions in research §7.
+- §1.2.1 explicitly addresses 5 known plan-vs-spec discrepancies.
+- 6 @MX tags planned (1 ANCHOR + 2 WARN + 3 NOTE) — covers all 3 of {ANCHOR, WARN, NOTE} types.
+- Worktree-base alignment per Step 2 (`moai worktree new --base origin/main`) called out (plan §10).
+- Parallel SPEC isolation: only `internal/hook/`, `internal/cli/`, `internal/mx/`, `CHANGELOG.md`. No `.claude/` tree changes expected.
+
+## File-level scope (run-phase)
+
+| Layer | Files |
+|---|---|
+| Hook handler | `internal/hook/post_tool_mx.go` (new), `internal/hook/types.go` (modified) |
+| CLI surface | `internal/cli/mx.go` (extended) |
+| MX package | `internal/mx/config.go` (new), `internal/mx/integration.go` (new), `internal/mx/anchor_audit.go` (new), `internal/mx/sidecar.go` (extended) |
+| Test fixtures | 5 new test files + extensions to existing scanner_test.go, sidecar_test.go |
+| Build | `make build` (regenerates `internal/template/embedded.go` defensively; no template diff expected) |
+| Trackability | `CHANGELOG.md` Unreleased entry, 6 @MX tags |
+
+## Test plan
+
+- [ ] M1 RED tests: PostToolUse handler emission (T-SPC002-01..03), MxTags field marshalling (T-SPC002-02), 16-lang fixture (T-SPC002-15) — all FAIL initially
+- [ ] M1 GREEN: handler implementation lands → all 4 GREEN
+- [ ] M2 RED: `--full` / `--json` / `--anchor-audit` CLI tests FAIL initially
+- [ ] M2 GREEN: flag dispatcher + helpers land → all GREEN
+- [ ] M3 RED: silent env + mx.yaml ignore tests FAIL
+- [ ] M3 GREEN: env + config loader land → GREEN
+- [ ] M4 RED: 4 correctness fixtures (MissingReason/Duplicate/Corrupt/Mismatch) FAIL where logic is missing
+- [ ] M4 GREEN: refinements + sentinel errors land → GREEN
+- [ ] M5 RED: atomic + stale + archive fixtures FAIL initially (especially `-race -count=10`)
+- [ ] M5 GREEN: archive sweep + race-safe writes land → GREEN
+- [ ] M6 final: `go test -race -count=1 ./...` PASS, `golangci-lint run` clean, `make build` exit 0, end-to-end smoke test verified
+
+## Dependencies
+
+| SPEC | Status | Role |
+|---|---|---|
+| SPEC-V3R2-CON-001 (FROZEN/EVOLVABLE) | merged (assumed) | Blocks (consumed); CONST-V3R2-003 enforces FROZEN inline syntax |
+| SPEC-V3R2-RT-001 (JSON hook protocol) | merged (assumed; types.go implementation in main) | Blocks (consumed); HookSpecificOutput dual-protocol substrate |
+| SPEC-V3R2-SPC-004 (resolver query API) | **merged** (PR #746, `68795dbe3`) | Co-resident; this SPEC must preserve schema_version: 2 backward-compat |
+| SPEC-V3R2-HRN-003 (evaluator MX scoring) | in-flight | Downstream consumer (may use sidecar at scoring time) |
+| SPEC-V3R2-WF-005 (16-language enum SoT) | in-flight | Downstream (advisory drift detection only) |
+
+## References
+
+- `.claude/rules/moai/workflow/mx-tag-protocol.md` (FROZEN inline syntax — read-only reference)
+- `.claude/rules/moai/core/zone-registry.md` `CONST-V3R2-003`
+- `internal/mx/{tag,scanner,sidecar,resolver,comment_prefixes,fanin,danger_category,spec_association,resolver_query}.go` (existing implementation)
+- `internal/hook/types.go` (RT-001 dual-protocol surface)
+- `internal/hook/file_changed.go` (existing FileChanged MX integration)
+- `internal/cli/mx.go` + `internal/cli/mx_query.go` (existing CLI surface)
+- `.moai/config/sections/mx.yaml` (config target for ignore patterns + hook budget)
+- spec.md §1 (Goal), §2 (Scope), §5 (REQ), §6 (AC), §7 (Constraints), §8 (Risks)
+- design-principles.md §P8 (Hook JSON Protocol); pattern-library.md §T-1 / §T-5 (ACI + dual-protocol patterns)
+
+---
+
+🗿 MoAI <email@mo.ai.kr>

--- a/.moai/specs/SPEC-V3R2-SPC-002/plan.md
+++ b/.moai/specs/SPEC-V3R2-SPC-002/plan.md
@@ -1,0 +1,623 @@
+# SPEC-V3R2-SPC-002 Implementation Plan
+
+> Implementation plan for **@MX TAG v2 with hook JSON integration and sidecar index**.
+> Companion to `spec.md` v0.1.0, `research.md` v0.1.0, `acceptance.md` v0.1.0, `tasks.md` v0.1.0.
+> Authored on branch `plan/SPEC-V3R2-SPC-002` (Step 1 plan-in-main; base `origin/main` HEAD `fcb486c87`).
+> Run phase will execute on a fresh worktree `feat/SPEC-V3R2-SPC-002` per `.claude/rules/moai/workflow/spec-workflow.md` § SPEC Phase Discipline Step 2.
+
+## HISTORY
+
+| Version | Date | Author | Description |
+|---------|------|--------|-------------|
+| 0.1.0   | 2026-05-10 | manager-spec (Plan workflow Phase 1B) | Initial implementation plan. Scope: PostToolUse hook integration (G-01/G-02), `/moai mx` flag extensions (G-03), `MOAI_MX_HOOK_SILENT` env handling (G-04), mx.yaml `ignore:` wire-up (G-05), MissingReasonForWarn + DuplicateAnchorID emission tests (G-06/G-07), anchor-audit reporter (G-08). Existing `internal/mx/` package (Wave 3 PR #741 + SPC-004 PR #746) provides 80% of the code surface. |
+
+---
+
+## 1. Plan Overview
+
+### 1.1 Goal restatement
+
+`spec.md` §1 의 핵심 목표를 milestone 분해:
+
+> Layer two additive capabilities on top of the FROZEN inline @MX TAG protocol (mx-tag-protocol.md, CONST-V3R2-003): (1) machine-readable JSON sidecar at `.moai/state/mx-index.json` with `schema_version: 2` and atomic temp+rename writes, (2) PostToolUse hook integration emitting `additionalContext` (human-readable summary) + `hookSpecificOutput.mxTags` (structured Tag array). Inline source-code convention stays FROZEN; sidecar is a view, never the source of truth.
+
+### 1.2 Current State Audit (research.md §2 cross-reference)
+
+`internal/mx/` 패키지는 이미 main 에 머지되어 있다 (research.md [E-02] commit `3f0933550`, [E-03] commit `68795dbe3`). 본 SPEC 의 구현 진척도:
+
+| 영역 | 상태 | Evidence |
+|------|------|----------|
+| `Tag` struct + 5-kind enum | ✅ 구현 | research [E-04], [E-05] |
+| `Sidecar` + `schema_version: 2` | ✅ 구현 | research [E-06] |
+| Atomic temp+rename write | ✅ 구현 | research [E-07] |
+| 16-언어 comment-prefix lookup | ✅ 구현 | research [E-08], [E-26] |
+| AnchorID 중복 추적 (Scanner 내부) | ✅ 구현 | research [E-09] |
+| `IsStale()` 7-일 TTL | ✅ 구현 | research [E-10] |
+| `Manager.UpdateFile` API | ✅ 구현 | research [E-12] |
+| **PostToolUse handler 의 mxTags emission** (G-01) | ❌ 격차 | research [E-13] |
+| **`HookSpecificOutput.MxTags` 필드** (G-02) | ❌ 격차 | research [E-14] |
+| **`/moai mx` 의 `--full` / `--index-only` / `--json` / `--anchor-audit` flags** (G-03) | ❌ 격차 | research [E-15], [E-22] |
+| **`MOAI_MX_HOOK_SILENT` env** (G-04) | ❌ 격차 | (G-01 의존) |
+| **mx.yaml `ignore:` wire-up** (G-05) | ❌ 격차 | research [E-16] |
+| **MissingReasonForWarn 명시 fixture** (G-06) | ⚠ 부분 (Scanner 로직 존재, fixture 부재) | spec §5.1 REQ-006 + §5.5 REQ-040 |
+| **DuplicateAnchorID write-refuse 명시 검증** (G-07) | ⚠ 부분 | spec §5.3 REQ-021 |
+| **anchor-audit fan_in < 3 reporter** (G-08) | ❌ 격차 | research [E-15] |
+
+Net actionable scope (Run-phase): **8 격차 해소** + 정합성 검증 (template parity, race detector, coverage ≥ 85%).
+
+### 1.2.1 Acknowledged Discrepancies
+
+본 plan 이 spec.md 와 의도적으로 다르게 처리하는 부분 (research evidence 기반):
+
+- **Spec §1 은 본 SPEC 이 "introduces" 하는 것처럼 서술하나, 실제로는 80% 가 이미 main 에 존재** — Wave 3 PR #741 (`3f0933550`, 2026-04-XX) 가 spec.md 의 §2.1 "In Scope" 첫 4개 bullet 을 모두 구현. SPC-004 PR #746 가 resolver / fan_in / danger_category / spec_association 을 추가. 본 plan 의 milestone 은 따라서 "build" 가 아니라 **"integrate + close gaps"** 로 reframe 됨. Sync-phase HISTORY 에서 spec.md §1 "introduces" 표현을 "completes" 로 reconcile 권장.
+- **spec §5.1 REQ-006 vs §5.5 REQ-040 의 의도적 분리** — 두 REQ 모두 같은 코드 경로 (Scanner 의 WARN 검출 후 3-라인 lookahead) 로 충족된다. tasks.md 는 단일 task 로 묶음.
+- **`HookSpecificOutput.MxTags` 필드 vs `additionalContext` 임베드** — research §7 OQ-1 결정에 따라 `MxTags` 필드 신규 추가. `additionalContext` 는 human-readable summary 만 담음. spec §5.2 REQ-011 verbatim 과 일치.
+- **Schema version 변경 금지** — SPC-004 가 이미 sidecar schema 를 소비 중 (PR #746 머지). 본 SPEC 의 모든 변경은 schema_version: 2 backward-compatible 이어야 한다. 새 필드는 omitempty 로 추가, 기존 필드 의미 변경 금지.
+- **`internal/hook/file_changed.go:supportedExtensions` 와 `internal/mx/comment_prefixes.go` 의 drift 통합** — 본 plan 은 이를 advisory 격차 (`G-extra`) 로 분류하며 sync 통합은 별도 SPEC (혹은 WF-005 16-language enum SPEC) 로 위임. tasks.md 에서는 drift detection 테스트만 추가 (T-SPC002-15).
+
+### 1.3 Implementation Methodology
+
+`.moai/config/sections/quality.yaml`: `development_mode: tdd`. Run phase MUST follow RED → GREEN → REFACTOR per `.claude/rules/moai/workflow/spec-workflow.md` § Run Phase.
+
+- **RED**: 8개 격차 영역마다 새 RED test fixture 추가:
+  - `TestPostToolUseHandler_EmitsMxTags` (G-01) — synthetic Edit on a Go file with new `@MX:NOTE`; expects HookOutput with `MxTags` populated.
+  - `TestHookSpecificOutput_MxTagsField` (G-02) — JSON marshalling test that `mxTags` appears in JSON when populated.
+  - `TestMxCmd_FullFlag_RebuildsSidecar` (G-03/full) — end-to-end CLI test.
+  - `TestMxCmd_IndexOnlyFlag` (G-03/index-only) — silent mode CLI test.
+  - `TestMxCmd_JsonFlag_DumpsSidecar` (G-03/json) — stdout JSON dump test.
+  - `TestMxCmd_AnchorAuditFlag_ReportsLowFanIn` (G-08) — audit reporter test.
+  - `TestPostToolUseHandler_HookSilentEnv` (G-04) — env var disables additionalContext.
+  - `TestScanner_RespectsMxYamlIgnore` (G-05) — ignore patterns wire-up.
+  - `TestScanner_MissingReasonForWarn_3LineLookahead` (G-06) — explicit fixture.
+  - `TestScanner_DuplicateAnchorID_RefuseWrite` (G-07) — explicit fixture.
+  - `TestPostToolUseHandler_HookSpecificOutputMismatch` (REQ-041) — wrong hookEventName rejection.
+  - `TestSidecar_AtomicWrite_NoPartialReads` (REQ-004 강화) — concurrent read during write fixture.
+  - `TestSidecar_StaleArchiveSweep_8Days` (REQ-020) — explicit 8-day fixture.
+  - `TestComment_AllSixteenLanguages` (REQ-005, AC-15) — single fixture per language.
+
+- **GREEN**: 각 RED test 를 GREEN 으로 전환하기 위한 production code 추가/수정:
+  - `internal/hook/post_tool_mx.go` 신규: PostToolUse 핸들러의 MX scan + sidecar update + mxTags emission.
+  - `internal/hook/types.go` 수정: `HookSpecificOutput` 에 `MxTags []mx.Tag` 필드 추가 (omitempty).
+  - `internal/cli/mx.go` 확장: 4개 flag (`--full`, `--index-only`, `--json`, `--anchor-audit`) 추가 + RunE 분기.
+  - `internal/mx/scanner.go` 보강: mx.yaml ignore 패턴 wire-up (`SetIgnorePatterns` 호출 site 추가).
+  - `internal/mx/sidecar.go` 보강: archive sweep 로직 호출 (`--full` path 에서 trigger).
+  - `internal/mx/anchor_audit.go` 신규: low-value anchor 리포터.
+
+- **REFACTOR**: 공유 logic 추출:
+  - `internal/mx/config.go` 신규: mx.yaml load + 기본값 (ignore patterns, hook.max_additional_context_bytes).
+  - PostToolUse handler 와 FileChanged handler 의 공통 scan-then-update 경로를 `internal/mx/integration.go` 의 helper 로 통합.
+  - `@MX:NOTE` 태그로 결정 사유 명시.
+
+### 1.4 Deliverables
+
+| Deliverable | Path | REQ Coverage |
+|-------------|------|--------------|
+| PostToolUse MX handler | `internal/hook/post_tool_mx.go` (신규 ~150 LOC) | REQ-010, REQ-011, REQ-012, REQ-031, REQ-041 |
+| `HookSpecificOutput.MxTags` field | `internal/hook/types.go` (+5 LOC) | REQ-011 |
+| `/moai mx` flag extensions | `internal/cli/mx.go` (현 30 LOC → ~150 LOC) | REQ-013, REQ-030, REQ-032, REQ-042 |
+| mx.yaml config loader | `internal/mx/config.go` (신규 ~80 LOC) | REQ-030, REQ-031 |
+| Anchor audit reporter | `internal/mx/anchor_audit.go` (신규 ~80 LOC) | REQ-042 |
+| Scan-update integration helper | `internal/mx/integration.go` (신규 ~60 LOC) | REQ-010, REQ-012 |
+| Archive sweep on `--full` | `internal/mx/sidecar.go` 확장 (+30 LOC) | REQ-014, REQ-020 |
+| 14 신규 RED tests | `internal/hook/post_tool_mx_test.go`, `internal/cli/mx_test.go`, `internal/mx/scanner_test.go`, `internal/mx/sidecar_test.go`, `internal/mx/anchor_audit_test.go` (+~600 LOC) | T-SPC002-01..14 |
+| Template parity for hook + CLI changes | `internal/template/templates/.claude/hooks/moai/handle-post-tool.sh` 검증 (likely no change) + `internal/template/embedded.go` regenerate via `make build` | TRUST 5 Trackable |
+| CHANGELOG entry | `CHANGELOG.md` Unreleased | TRUST 5 Trackable |
+| MX tags per §6 | 6 files (per §6 below) | mx_plan |
+
+Embedded-template parity는 **applicable** (`make build` 후 `internal/template/embedded.go` 재생성). 그러나 본 SPEC 의 변경은 모두 `internal/` Go 코드이고 template 자산은 거의 변경되지 않음 (handle-post-tool.sh wrapper 는 `moai hook post-tool` 호출로 binary 위임, 실제 로직은 Go 측). 검증: `diff -r .claude/ internal/template/templates/.claude/` 변경 0 line 기대.
+
+### 1.5 Traceability Matrix (REQ → AC → Task)
+
+Per plan-auditor PASS criterion #2 (every REQ maps to at least one AC and at least one Task). Built **after** tasks.md was finalized; each row references actual T-SPC002-NN IDs.
+
+| REQ ID | Category | Mapped AC(s) | Mapped Task(s) |
+|--------|----------|--------------|----------------|
+| REQ-SPC-002-001 | Ubiquitous (inline syntax FROZEN preserved) | (no AC; invariant tested via existing SPC-004 tests + T-SPC002-15 16-lang fixture) | T-SPC002-15 16-language fixture (verifies all 5 kinds across 16 langs) |
+| REQ-SPC-002-002 | Ubiquitous (Tag struct definition) | AC-01 | T-SPC002-15 (existing tag.go covers; new fixture exercises) |
+| REQ-SPC-002-003 | Ubiquitous (sidecar at `.moai/state/mx-index.json`) | AC-02 | T-SPC002-04 (mx --full path), T-SPC002-12 (atomic write fixture) |
+| REQ-SPC-002-004 | Ubiquitous (atomic temp+rename) | AC-03 | T-SPC002-12 (concurrent read fixture) |
+| REQ-SPC-002-005 | Ubiquitous (16-language scanner support) | AC-15 | T-SPC002-15 (per-lang fixture) |
+| REQ-SPC-002-006 | Ubiquitous (`@MX:WARN` requires sibling `@MX:REASON`) | AC-05 | T-SPC002-09 (MissingReasonForWarn fixture) |
+| REQ-SPC-002-007 | Ubiquitous (AnchorID uniqueness) | AC-06 | T-SPC002-10 (DuplicateAnchorID fixture) |
+| REQ-SPC-002-008 | Ubiquitous (`schema_version: 2`) | AC-02 | T-SPC002-04 (CLI full path), T-SPC002-12 |
+| REQ-SPC-002-010 | Event-driven (PostToolUse re-scan + delta detect) | AC-04 | T-SPC002-01 (PostToolUse handler) |
+| REQ-SPC-002-011 | Event-driven (HookResponse with mxTags + additionalContext) | AC-04 | T-SPC002-01, T-SPC002-02 (MxTags field), T-SPC002-03 (handler emission) |
+| REQ-SPC-002-012 | Event-driven (sidecar atomic update on PostToolUse) | AC-04 | T-SPC002-01, T-SPC002-12 |
+| REQ-SPC-002-013 | Event-driven (`/moai mx --full` rescan) | AC-02 | T-SPC002-04 (--full flag) |
+| REQ-SPC-002-014 | Event-driven (LastSeenAt preservation when not found within 7d) | AC-07 | T-SPC002-13 (stale not yet archived fixture) |
+| REQ-SPC-002-020 | State-driven (8-day stale → archive) | AC-08 | T-SPC002-14 (archive sweep fixture) |
+| REQ-SPC-002-021 | State-driven (DuplicateAnchorID refuse write) | AC-06 | T-SPC002-10 |
+| REQ-SPC-002-022 | State-driven (corrupt sidecar repair suggestion) | AC-09 | T-SPC002-11 (corrupt sidecar fixture) |
+| REQ-SPC-002-030 | Optional (mx.yaml ignore patterns) | AC-10 | T-SPC002-08 (Scanner ignore wire-up) |
+| REQ-SPC-002-031 | Optional (`MOAI_MX_HOOK_SILENT` env) | AC-11 | T-SPC002-07 (silent env fixture) |
+| REQ-SPC-002-032 | Optional (`/moai mx --json` stdout dump) | AC-12 | T-SPC002-05 (--json flag) |
+| REQ-SPC-002-040 | Complex (3-line lookahead for REASON) | AC-05 | T-SPC002-09 |
+| REQ-SPC-002-041 | Complex (HookSpecificOutputMismatch on wrong hookEventName) | AC-13 | T-SPC002-03 (handler validates hookEventName) |
+| REQ-SPC-002-042 | Complex (anchor-audit low fan_in candidate) | AC-14 | T-SPC002-06 (--anchor-audit flag) |
+
+Coverage: **22 unique REQs (001..008, 010..014, 020..022, 030..032, 040..042) → 15 ACs (AC-01..AC-15) → 16 tasks (T-SPC002-01..16)**. AC-01 maps to existing scanner code; verification via T-SPC002-15 fixture.
+
+→ All REQ IDs from spec §5 are mapped. AC-01..AC-15 from spec §6 are mapped.
+
+---
+
+## 2. Milestone Breakdown (M1-M6)
+
+각 milestone 은 **priority-ordered** (no time estimates per `.claude/rules/moai/core/agent-common-protocol.md` § Time Estimation HARD rule).
+
+### M1: PostToolUse handler 신설 + HookSpecificOutput 확장 (G-01/G-02) — Priority P0
+
+Owner role: `expert-backend` (Go hook system + JSON protocol).
+
+Tasks:
+- T-SPC002-01: 신규 `internal/hook/post_tool_mx.go` 생성. 핸들러 인터페이스: PostToolUse event 의 `tool_name in {Write, Edit}` AND `tool_input.file_path` 가 `comment_prefixes.go` 의 supported ext 인 경우, `mx.NewScanner().ScanFile(filePath)` 호출 → `Manager.UpdateFile(filePath, newTags)` 호출 → 결과로 `HookOutput` 구성.
+- T-SPC002-02: `internal/hook/types.go` 수정. `HookSpecificOutput` 구조체에 `MxTags []mx.Tag` field 추가 (`json:"mxTags,omitempty"`). 기존 PostToolUse 출력과 backward-compatible (omitempty).
+- T-SPC002-03: PostToolUse handler 의 `additionalContext` 구성. Format: `"@MX:WARN at file.go:42: goroutine leak (no Done() signal)"` (한 줄당 한 태그). spec §1 의 예시 verbatim.
+- T-SPC002-15: 16-언어 fixture — `internal/mx/scanner_test.go` 에 `TestScanner_AllSixteenLanguages` 추가. fixture: 16개 임시 파일 (각 언어별 1개 `@MX:NOTE`). 기대: 16개 Tag 모두 추출.
+
+RED 검증: `TestPostToolUseHandler_EmitsMxTags` + `TestHookSpecificOutput_MxTagsField` FAIL on `go test ./internal/hook/ ./internal/mx/` (handler 미구현 + field 부재).
+
+GREEN 검증: 두 test PASS. existing PostToolUse tests (post_tool_astgrep_test.go 등) still PASS — backward compatibility.
+
+### M2: `/moai mx` flag 확장 (G-03) — Priority P0
+
+Owner role: `expert-backend` (CLI subcommand).
+
+Tasks:
+- T-SPC002-04: `internal/cli/mx.go` 확장. parent command 의 `RunE` 를 4-flag dispatcher 로 전환:
+  - `--full`: 전체 rescan + sidecar rebuild + archive sweep + console summary.
+  - `--index-only`: full path 와 동일 + (no console output) — CI 친화.
+  - `--json`: 현 sidecar 를 stdout 으로 dump.
+  - `--anchor-audit`: fan_in < 3 anchor 리포트 (M5 에서 wire).
+  - 충돌 검증: 두 flag 동시 지정 시 error.
+- T-SPC002-05: `--json` 구현. `internal/mx/sidecar.go` 의 `Manager.Load()` 호출 → `json.MarshalIndent` → `os.Stdout.Write`.
+- T-SPC002-06: `--anchor-audit` 구현 placeholder — M5 에서 본격 wire. 임시 출력 "audit not yet wired" 로 RED test 통과.
+
+RED 검증: 4개 RunE 분기 test 모두 FAIL.
+
+GREEN 검증: 4개 모두 PASS. `moai mx query` (SPC-004) subcommand still works (regression).
+
+### M3: PostToolUse silent mode + mx.yaml ignore wire-up (G-04/G-05) — Priority P1
+
+Owner role: `expert-backend` + `expert-devops` (env var convention).
+
+Tasks:
+- T-SPC002-07: PostToolUse handler 가 `os.Getenv("MOAI_MX_HOOK_SILENT") == "1"` 검사. true 면 sidecar 갱신은 수행하되 `additionalContext` 는 비움 (`""`). `MxTags` 필드는 그대로 emit (구조화 데이터는 silent 와 무관 — CI 가 읽을 수 있도록).
+- T-SPC002-08: `internal/mx/config.go` 신규. mx.yaml 의 `ignore:` 키 (없으면 기본값) load. `SetIgnorePatterns` 를 PostToolUse handler + CLI `--full` path 모두에서 호출.
+
+RED 검증: `TestPostToolUseHandler_HookSilentEnv` + `TestScanner_RespectsMxYamlIgnore` FAIL.
+
+GREEN 검증: 두 test PASS. CI 환경 (`MOAI_MX_HOOK_SILENT=1` 가 settings.json 에 미리 주입된) 에서 model-turn 토큰 절약 실증.
+
+### M4: Scanner 검증 fixture (G-06/G-07/REQ-040/REQ-041/REQ-022) — Priority P1
+
+Owner role: `expert-backend`.
+
+Tasks:
+- T-SPC002-09: `TestScanner_MissingReasonForWarn_3LineLookahead` 추가. fixture: Go 파일 with `// @MX:WARN bug here` 후 다음 3-라인 안에 `@MX:REASON` 없음. 기대: Scanner.warnings 에 1건 (file:line + 메시지 "MissingReasonForWarn").
+- T-SPC002-10: `TestScanner_DuplicateAnchorID_RefuseWrite` 추가. fixture: 두 파일에 `// @MX:ANCHOR auth-handler-v1` 동시 존재. 기대: ScanDirectory 가 `DuplicateAnchorID` 에러 반환, Manager.Write 거부.
+- T-SPC002-11: `TestSidecar_CorruptJSON_RepairSuggestion` 추가. fixture: `.moai/state/mx-index.json` 에 깨진 JSON 작성 후 `Manager.Load()` 호출. 기대: 빈 sidecar 반환 + stderr 에 repair suggestion (`"WARNING: sidecar corrupt"` 포함).
+- T-SPC002-16: `TestPostToolUseHandler_HookSpecificOutputMismatch` 추가. fixture: handler 가 PreToolUse event 수신 시 mxTags emission 거부. 기대: error `HookSpecificOutputMismatch`.
+
+RED 검증: 4 tests FAIL.
+
+GREEN 검증: 4 PASS.
+
+### M5: Archive sweep + Anchor audit (G-08/REQ-014/REQ-020) — Priority P1
+
+Owner role: `expert-backend`.
+
+Tasks:
+- T-SPC002-12: `TestSidecar_AtomicWrite_NoPartialReads` 추가. fixture: writer goroutine 이 sidecar 에 큰 페이로드 write 하는 동안 reader goroutine 들이 반복 read. 기대: 모든 read 가 valid JSON (parse 성공) 또는 file-not-exist (writer 가 temp 단계).
+- T-SPC002-13: `TestSidecar_StaleNotYetArchived_7Days` 추가. fixture: tag with `LastSeenAt: now - 6days`, scan 결과 not found. 기대: tag 가 sidecar 에 보존됨.
+- T-SPC002-14: `TestSidecar_StaleArchived_8Days` 추가. fixture: tag with `LastSeenAt: now - 8days`, scan 결과 not found. 기대: tag 가 sidecar 에서 제거 + `mx-archive.json` 에 추가.
+- T-SPC002-06 (continued): `--anchor-audit` 본격 wire. `internal/mx/anchor_audit.go` 신규. logic: `Manager.GetAllTags()` → MXAnchor only filter → `fanin.Count(anchorID)` (SPC-004 의 fanin.go 재사용) → fan_in < 3 만 수집 → markdown 표 stdout 출력.
+
+RED 검증: 3 sidecar test + anchor-audit test FAIL.
+
+GREEN 검증: 4 PASS.
+
+### M6: Verification gates + audit consolidation — Priority P0
+
+Owner role: `manager-cycle` + `manager-quality`.
+
+Tasks:
+- T-SPC002-17: 전체 테스트 스위트 — `go test -race -count=1 ./...` PASS, 0 회귀.
+- T-SPC002-18: `golangci-lint run` clean.
+- T-SPC002-19: `make build` exits 0; `internal/template/embedded.go` 재생성.
+- T-SPC002-20: `CHANGELOG.md` Unreleased 업데이트:
+  - "feat(mx/SPEC-V3R2-SPC-002): PostToolUse hook MX tag integration with structured mxTags emission"
+  - "feat(mx/SPEC-V3R2-SPC-002): /moai mx --full / --index-only / --json / --anchor-audit flags"
+  - "feat(mx/SPEC-V3R2-SPC-002): mx.yaml ignore patterns wire-up + MOAI_MX_HOOK_SILENT env handling"
+  - "feat(mx/SPEC-V3R2-SPC-002): 7-day stale tag archive sweep on full scan"
+- T-SPC002-21: @MX 태그 적용 per §6.
+- T-SPC002-22: 수동 검증 — 임시 Go file 에 `@MX:NOTE` 추가 후 `claude` 세션에서 Edit 호출, settings.json 의 PostToolUse hook 가 실제로 mxTags 를 emit 하는지 stdout 캡처.
+
+Verification gate: All AC-SPC-002-01 through AC-SPC-002-15 verified per acceptance.md.
+
+---
+
+## 3. File-Level Modification Map
+
+### 3.1 Files modified (existing)
+
+| File | Lines added/changed | Purpose |
+|------|---------------------|---------|
+| `internal/hook/types.go` | +5 LOC | `HookSpecificOutput.MxTags` field 추가 |
+| `internal/cli/mx.go` | +120 LOC | 4-flag dispatcher + RunE 분기 |
+| `internal/mx/scanner.go` | +20 LOC | `MissingReasonForWarn` warning emission 보강 (이미 일부 존재) |
+| `internal/mx/sidecar.go` | +30 LOC | Archive sweep on full-scan path |
+| `CHANGELOG.md` | +4 lines | Unreleased entry |
+
+### 3.2 Files created (new)
+
+| File | LOC (approx) | Purpose |
+|------|--------------|---------|
+| `internal/hook/post_tool_mx.go` | ~150 | PostToolUse MX 핸들러 |
+| `internal/hook/post_tool_mx_test.go` | ~250 | 4 RED tests for handler (G-01/G-02/G-04/REQ-041) |
+| `internal/mx/config.go` | ~80 | mx.yaml load + 기본값 |
+| `internal/mx/integration.go` | ~60 | Scan-update helper (PostToolUse + FileChanged 공유) |
+| `internal/mx/anchor_audit.go` | ~80 | Low fan_in anchor reporter |
+| `internal/mx/anchor_audit_test.go` | ~80 | T-SPC002-06 fixture |
+| `internal/cli/mx_test.go` | ~150 | 4 flag tests (T-SPC002-04..06) |
+| `internal/mx/scanner_test_g06_g07.go` (or extend `scanner_test.go`) | ~120 | T-SPC002-09, T-SPC002-10, T-SPC002-15 |
+| `internal/mx/sidecar_test_g08.go` (or extend `sidecar_test.go`) | ~150 | T-SPC002-11, T-SPC002-12, T-SPC002-13, T-SPC002-14 |
+
+### 3.3 Files removed
+
+None.
+
+### 3.4 Files NOT modified (out-of-scope)
+
+- `.claude/rules/moai/workflow/mx-tag-protocol.md` — FROZEN per CONST-V3R2-003.
+- `internal/mx/tag.go` — already complete (Wave 3).
+- `internal/mx/comment_prefixes.go` — 16-언어 매핑 이미 완전.
+- `internal/mx/resolver_query.go` / `fanin.go` / `danger_category.go` / `spec_association.go` — SPC-004 territory.
+- `internal/hook/file_changed.go` — 별도 path; FileChanged event 는 본 SPEC scope 아님 (PostToolUse 에 집중). 단 helper 함수 (`internal/mx/integration.go`) 를 통한 공유는 acceptable.
+- `.claude/hooks/moai/handle-post-tool.sh` — 단순 wrapper; binary 위임 구조 변경 없음.
+
+---
+
+## 4. Technical Approach
+
+### 4.1 PostToolUse handler 의 dispatch 로직
+
+```go
+// internal/hook/post_tool_mx.go (신규)
+func (h *postToolMxHandler) Handle(ctx context.Context, input *HookInput) (*HookOutput, error) {
+    // 1. Filter: only Write/Edit tools matter
+    if input.ToolName != "Write" && input.ToolName != "Edit" {
+        return &HookOutput{}, nil
+    }
+
+    // 2. Filter: only supported file extensions
+    filePath := extractFilePath(input.ToolInput)
+    ext := strings.ToLower(filepath.Ext(filePath))
+    if mx.GetCommentPrefix(ext) == "" {
+        return &HookOutput{}, nil
+    }
+
+    // 3. Scan file for current tags
+    scanner := mx.NewScanner()
+    cfg, _ := mx.LoadConfig(input.Cwd) // mx.yaml ignore patterns
+    scanner.SetIgnorePatterns(cfg.IgnorePatterns)
+    tags, err := scanner.ScanFile(filePath)
+    if err != nil {
+        return &HookOutput{}, nil // graceful degradation
+    }
+
+    // 4. Update sidecar
+    stateDir := filepath.Join(input.Cwd, ".moai/state")
+    mgr := mx.NewManager(stateDir)
+    if _, err := mgr.UpdateFile(filePath, tags); err != nil {
+        slog.Warn("sidecar update failed", "err", err)
+        return &HookOutput{}, nil
+    }
+
+    // 5. Build response — silent mode handling
+    silent := os.Getenv("MOAI_MX_HOOK_SILENT") == "1"
+    var additionalContext string
+    if !silent {
+        additionalContext = formatTagsForContext(tags)
+    }
+
+    return &HookOutput{
+        HookSpecificOutput: &HookSpecificOutput{
+            HookEventName:     "PostToolUse",
+            AdditionalContext: additionalContext,
+            MxTags:            tags, // structured field — always populated
+        },
+    }, nil
+}
+```
+
+### 4.2 `HookSpecificOutput.MxTags` 필드 위치
+
+```go
+// internal/hook/types.go (수정)
+type HookSpecificOutput struct {
+    HookEventName            string          `json:"hookEventName,omitempty"`
+    PermissionDecision       string          `json:"permissionDecision,omitempty"`
+    PermissionDecisionReason string          `json:"permissionDecisionReason,omitempty"`
+    AdditionalContext        string          `json:"additionalContext,omitempty"`
+    SessionTitle             string          `json:"sessionTitle,omitempty"`
+    UpdatedInput             json.RawMessage `json:"updatedInput,omitempty"`
+    UpdatedMCPToolOutput     string          `json:"updatedMCPToolOutput,omitempty"`
+    UpdatedToolOutput        string          `json:"updatedToolOutput,omitempty"`
+    MxTags                   []mx.Tag        `json:"mxTags,omitempty"` // SPEC-V3R2-SPC-002 신규
+}
+```
+
+Cyclic import 회피: `internal/hook` 가 `internal/mx` 를 import (`internal/mx` 가 `internal/hook` 을 import 하지 않음). 현재 `internal/hook/file_changed.go` 가 이미 `internal/mx` import 중이므로 cycle 없음.
+
+### 4.3 `/moai mx` flag dispatcher
+
+```go
+// internal/cli/mx.go (확장)
+func newMxCmd() *cobra.Command {
+    var (
+        fullFlag       bool
+        indexOnlyFlag  bool
+        jsonFlag       bool
+        anchorAuditFlag bool
+    )
+    cmd := &cobra.Command{
+        Use:   "mx",
+        Short: "@MX TAG 관리 도구",
+        RunE: func(cmd *cobra.Command, args []string) error {
+            // 충돌 검증
+            count := boolToInt(fullFlag) + boolToInt(indexOnlyFlag) + boolToInt(jsonFlag) + boolToInt(anchorAuditFlag)
+            if count > 1 {
+                return fmt.Errorf("flags --full, --index-only, --json, --anchor-audit are mutually exclusive")
+            }
+            switch {
+            case fullFlag:
+                return runMxFull(cmd, false /* console output */)
+            case indexOnlyFlag:
+                return runMxFull(cmd, true /* silent */)
+            case jsonFlag:
+                return runMxJsonDump(cmd)
+            case anchorAuditFlag:
+                return runMxAnchorAudit(cmd)
+            default:
+                return cmd.Help()
+            }
+        },
+    }
+    cmd.Flags().BoolVar(&fullFlag, "full", false, "전체 rescan + sidecar rebuild + archive sweep")
+    cmd.Flags().BoolVar(&indexOnlyFlag, "index-only", false, "전체 rescan (silent — CI 친화)")
+    cmd.Flags().BoolVar(&jsonFlag, "json", false, "현 sidecar 를 stdout 으로 dump")
+    cmd.Flags().BoolVar(&anchorAuditFlag, "anchor-audit", false, "fan_in < 3 anchor 리포트")
+    cmd.AddCommand(newMxQueryCmd()) // SPC-004 — 보존
+    return cmd
+}
+```
+
+### 4.4 mx.yaml config loader
+
+```go
+// internal/mx/config.go (신규)
+type Config struct {
+    IgnorePatterns                []string
+    HookMaxAdditionalContextBytes int
+}
+
+func LoadConfig(projectRoot string) (*Config, error) {
+    path := filepath.Join(projectRoot, ".moai/config/sections/mx.yaml")
+    data, err := os.ReadFile(path)
+    if err != nil {
+        if os.IsNotExist(err) {
+            return defaultConfig(), nil
+        }
+        return nil, err
+    }
+    var raw map[string]interface{}
+    if err := yaml.Unmarshal(data, &raw); err != nil {
+        return defaultConfig(), nil // graceful
+    }
+    // Extract ignore: patterns + hook.max_additional_context_bytes
+    return parseConfig(raw), nil
+}
+
+func defaultConfig() *Config {
+    return &Config{
+        IgnorePatterns: []string{
+            "vendor/**", "node_modules/**", "dist/**", ".git/**",
+            "**/*_generated.go", "**/mock_*.go",
+        },
+        HookMaxAdditionalContextBytes: 4096,
+    }
+}
+```
+
+### 4.5 Anchor audit reporter
+
+```go
+// internal/mx/anchor_audit.go (신규)
+type AnchorAuditEntry struct {
+    AnchorID string
+    File     string
+    Line     int
+    FanIn    int
+}
+
+func RunAnchorAudit(mgr *Manager, threshold int) ([]AnchorAuditEntry, error) {
+    sidecar, err := mgr.Load()
+    if err != nil {
+        return nil, err
+    }
+    var lowValue []AnchorAuditEntry
+    for _, tag := range sidecar.Tags {
+        if tag.Kind != MXAnchor {
+            continue
+        }
+        fanIn := CountFanIn(tag.AnchorID, sidecar.Tags) // SPC-004 fanin.go reuse
+        if fanIn < threshold {
+            lowValue = append(lowValue, AnchorAuditEntry{
+                AnchorID: tag.AnchorID, File: tag.File, Line: tag.Line, FanIn: fanIn,
+            })
+        }
+    }
+    return lowValue, nil
+}
+```
+
+### 4.6 Performance budget
+
+Spec §7 의 budget:
+
+| Budget | 충족 전략 |
+|--------|-----------|
+| Full-scan ≤ 2s for 10K files | Scanner 의 prefix-table approach (no AST). 측정: T-SPC002-12 의 후속으로 benchmark test 추가 (optional) |
+| Incremental update ≤ 100ms per file | UpdateFile 은 단일 파일 in-memory map 갱신 + 단일 sidecar write. 5KB sidecar write < 1ms; 100ms 여유 충분 |
+| Sidecar size ≤ 5MB for 10K tags | 평균 ~500 bytes/tag (JSON-encoded). 10K tags = 5MB upper bound; 실제 평균 < 300 bytes 이므로 여유 |
+| Atomic write no partial reads | T-SPC002-12 fixture |
+
+### 4.7 Backward compatibility
+
+- `HookSpecificOutput.MxTags` 는 omitempty — 기존 PostToolUse 출력 (astgrep, duration 등) 에 영향 없음.
+- `/moai mx` parent command 의 default RunE (no flag) 는 Help() 출력으로 유지 — 기존 SPC-004 의 `mx query` subcommand 에 영향 없음.
+- Schema version 2 유지 — SPC-004 의 mx_query 가 sidecar 를 read 하는 path 에 break 없음.
+- mx.yaml 기존 키 (`comment_syntax`, `discovery`, `auto_tag`) 유지; `ignore:` 는 신규 키.
+
+### 4.8 Cross-platform behavior
+
+- `os.Rename` atomic 보장: POSIX 표준. Windows 도 같은 보장 (NTFS).
+- `MOAI_MX_HOOK_SILENT` env: cross-platform.
+- `internal/mx/comment_prefixes.go` 의 확장자 매핑 은 case-insensitive (이미 `strings.ToLower(ext)` 처리).
+
+---
+
+## 5. Quality Gates
+
+Per `.moai/config/sections/quality.yaml`:
+
+| Gate | Requirement | Verification command |
+|------|-------------|-----------------------|
+| Coverage | ≥ 85% per modified file | `go test -cover ./internal/hook/ ./internal/mx/ ./internal/cli/` |
+| Race | `go test -race ./...` clean | `go test -race -count=1 ./...` |
+| Lint | golangci-lint clean | `golangci-lint run` |
+| Build | embedded.go regenerated | `make build` |
+| Template parity | `diff -r` byte-identical | `diff -r .claude/ internal/template/templates/.claude/` |
+| Sidecar contract | schema_version: 2 보존 | T-SPC002-12 fixture |
+| MX | @MX tags applied per §6 | manual (post-implementation review) |
+
+---
+
+## 6. @MX Tag Plan (mx_plan)
+
+Apply per `.claude/rules/moai/workflow/mx-tag-protocol.md`. Language: ko (per `code_comments: ko`). Note: 본 plan 자체는 plan markdown 이므로 @MX 태그를 추가하지 않음 (이는 source code 대상). 아래 표는 run-phase 에서 Go 코드에 추가될 태그.
+
+| File | Tag | Reason |
+|------|-----|--------|
+| `internal/hook/post_tool_mx.go:Handle` | `@MX:ANCHOR @MX:REASON: SPEC-V3R2-SPC-002 의 PostToolUse MX 통합 진입점; sidecar 갱신 + mxTags emission 의 단일 책임 — fan_in ≥ 3 (PostToolUse hook dispatcher + FileChanged shared path + 향후 SessionEnd MX validation)` | invariant contract + high fan_in |
+| `internal/hook/types.go:HookSpecificOutput.MxTags` | `@MX:NOTE: SPEC-V3R2-SPC-002 신규 필드; omitempty 로 기존 출력 backward-compatible; consumers (evaluator-active, ralph engine) 가 직렬화된 Tag 배열을 직접 소비` | new field rationale |
+| `internal/mx/config.go:LoadConfig` | `@MX:NOTE: mx.yaml 부재 시 graceful degradation (defaultConfig); CI 환경 isolation 보장 — config 미존재가 lint break 가 되지 않음` | non-obvious behavior |
+| `internal/mx/anchor_audit.go:RunAnchorAudit` | `@MX:NOTE: SPC-004 fanin.go 의 CountFanIn 재사용; threshold 3 은 spec §5.5 REQ-042 에서 유래 — hardcoded 가 의도적 (config 의 evolution 표면 분리)` | cross-SPEC dependency note |
+| `internal/cli/mx.go:newMxCmd` | `@MX:WARN @MX:REASON: 4-flag mutual exclusion; 사용자가 두 flag 동시 지정 시 silent ambiguity 위험 — 명시적 error 반환으로 회피. 향후 flag 추가 시 카운트 로직 갱신 의무` | mutability hazard |
+| `internal/mx/sidecar.go:archiveSweep` (신규 helper) | `@MX:WARN @MX:REASON: archive 후 원본 sidecar 에서 entry 제거하므로 partial failure 위험 — archive write 성공 후에만 sidecar rewrite (two-phase). archive write 실패 시 sidecar 무변경 (idempotent retry 가능)` | failure-recovery semantic |
+
+---
+
+## 7. Risk Mitigation Plan (spec §8 risks → run-phase tasks)
+
+| spec §8 risk | Mitigation in run-phase |
+|--------------|--------------------------|
+| Row 1 — Sidecar drift from source truth | T-SPC002-04 (`/moai mx --full`) 가 언제든 rebuild; CI guard 잠재 추가 (out-of-scope) |
+| Row 2 — Cross-language parser 엣지 케이스 | T-SPC002-15 16-언어 fixture; v3.1 에서 escape-aware refinement (out-of-scope) |
+| Row 3 — PostToolUse JSON 토큰 폭증 | mx.yaml `hook.max_additional_context_bytes` (T-SPC002-08); MOAI_MX_HOOK_SILENT (T-SPC002-07) |
+| Row 4 — Stale 태그 7-일 TTL 위반 | T-SPC002-13 + T-SPC002-14 fixtures; archive 는 `--full` path 에서 트리거 (research §7 OQ-3) |
+| Row 5 — Duplicate AnchorID block | T-SPC002-10 fixture; Scanner 가 명시 에러 + Manager refuse-write |
+| Row 6 — Binary size growth | prefix-table approach (no per-language parsers); risk 사실상 해소 |
+
+추가 mitigation:
+- **OOQ — `internal/hook/file_changed.go` 와 PostToolUse 의 sidecar race**: sidecar Manager 가 이미 `sync.RWMutex` 보유 (research [E-21]). 추가 작업 불필요.
+- **OOQ — handler 가 PostToolUseFailure 에서 동작?**: spec 미명시. plan 결정: PostToolUse 만 처리. PostToolUseFailure 는 별도 핸들러가 처리. `internal/hook/post_tool_mx.go` 의 `EventType()` 는 `EventPostToolUse` 만 반환.
+
+---
+
+## 8. Dependencies (status as of `fcb486c87`)
+
+### 8.1 Blocking (consumed)
+
+- ✅ **SPEC-V3R2-CON-001** (FROZEN/EVOLVABLE codification) — assumed merged; CONST-V3R2-003 가 mx-tag-protocol.md 를 FROZEN 으로 등록.
+- ✅ **SPEC-V3R2-RT-001** (JSON hook protocol) — `internal/hook/types.go` 가 RT-001 의 dual-protocol 구현 보유 (research [E-14]).
+
+### 8.2 Blocked by (none active)
+
+All blockers are merged or adjacent. RT-001 의 protocol 표면 변경이 본 SPEC 의 기간 내에 발생하면 plan 재조정 필요.
+
+### 8.3 Blocks (downstream consumers)
+
+- **SPEC-V3R2-SPC-004** (resolver query API) — **이미 머지** (PR #746). 본 SPEC 이 sidecar contract 를 변경하지 않음 (schema_version: 2 유지) 으로 SPC-004 의 read path 에 영향 없음.
+- **SPEC-V3R2-HRN-003** (evaluator MX 점수) — downstream; 본 SPEC 의 sidecar 가 publish 되면 score 계산에 사용 가능.
+- **SPEC-V3R2-WF-005** (16-언어 enum SoT) — comment_prefixes.go drift detection 은 advisory (out-of-scope).
+
+---
+
+## 9. Verification Plan
+
+### 9.1 Pre-merge verification (run-phase end)
+
+- [ ] All 22 tasks (T-SPC002-01..22) complete per tasks.md (M3 의 13 sub-task 별도 카운트)
+- [ ] All 15 ACs (AC-SPC-002-01..15) verified per acceptance.md
+- [ ] `go test -race -count=1 ./...` PASS (no regressions)
+- [ ] `golangci-lint run` clean
+- [ ] `make build` regenerates `internal/template/embedded.go` correctly
+- [ ] Coverage `go test -cover ./internal/{hook,mx,cli}/` ≥ 85% per package
+- [ ] `diff -r .claude/ internal/template/templates/.claude/` byte-identical (no template change expected)
+- [ ] CHANGELOG entry written in Unreleased section
+- [ ] @MX tags applied per §6 (6 tags)
+- [ ] Manual end-to-end smoke test: edit a Go file via `claude` session, observe `mxTags` in PostToolUse hook stdout
+
+### 9.2 Plan-auditor target
+
+- [ ] All 22 unique REQs mapped in §1.5 traceability matrix
+- [ ] All 15 ACs mapped to ≥1 task
+- [ ] No orphan tasks (every task supports ≥1 REQ)
+- [ ] research.md evidence anchors cited (≥30 per plan-audit mandate)
+- [ ] §1.2.1 explicitly addresses spec/plan discrepancies (Wave 3 prior implementation, REQ-006/REQ-040 unification, MxTags vs additionalContext)
+- [ ] FROZEN clause CONST-V3R2-003 explicitly preserved (inline syntax untouched)
+- [ ] Schema_version 변경 금지 명시
+- [ ] Worktree-base alignment per Step 2 (run-phase) called out (§10 below)
+- [ ] §6 mx_plan covers ≥3 of {ANCHOR, WARN, NOTE} types (covered: 1 ANCHOR + 2 WARN + 3 NOTE = 모두 3)
+- [ ] No time estimates (P0/P1 priority labels only)
+- [ ] Parallel SPEC isolation: only `internal/hook/`, `internal/cli/`, `internal/mx/`, `CHANGELOG.md`. .claude/ 트리 미변경.
+
+### 9.3 Plan-auditor risk areas (front-loaded mitigations)
+
+- **Risk: Wave 3 가 이미 80% 구현 → REQ-001..008 이 redundant 처럼 보임** → §1.2.1 acknowledged; sync-phase HISTORY 에서 spec.md "introduces" → "completes" reconcile. plan 의 task 는 격차 8개 (G-01..G-08) 에 집중.
+- **Risk: SPC-004 가 이미 main 에 있는데 본 SPEC 의 schema 변경이 break 가능** → schema_version: 2 보존 서약 + 새 필드는 omitempty + T-SPC002-12 atomic write fixture.
+- **Risk: PostToolUse hook 토큰 폭증 (model context bloat)** → MOAI_MX_HOOK_SILENT env (T-SPC002-07) + mx.yaml `hook.max_additional_context_bytes` (T-SPC002-08).
+- **Risk: PostToolUse handler 가 모든 Write/Edit 에 동작 → CI 환경에서 noise** → MOAI_MX_HOOK_SILENT=1 을 settings.local.json 의 CI variant 에 미리 주입; spec §5.4 REQ-031 verbatim.
+- **Risk: PostToolUse handler 가 cyclic deadlock (Manager.UpdateFile mutex 와 PostToolUse 동시 발화)** → sidecar Manager 가 RWMutex 보유; sidecar 는 single-writer model (PostToolUse handler + `--full` CLI 가 동일 mutex 공유).
+- **Risk: `fcb486c87` baseline drift if main advances during plan PR review** → run-phase 가 명시적으로 `origin/main` 에서 rebase (Step 2 `moai worktree new --base origin/main`).
+- **Risk: `internal/hook/post_tool_mx.go` 와 기존 PostToolUse handler (`post_tool_astgrep`, `post_tool_duration`) 충돌** → Go hook 시스템은 EventType-based dispatch + multiple handlers chain; handler 등록 order 는 settings.json hook config 가 결정. 본 SPEC 의 handler 는 별도 등록 entry (e.g. settings.json `PostToolUse[1]`) — 기존 handler 영향 없음.
+
+### 9.4 Rollback plan (if SPC-004 discovers schema gap)
+
+만약 run-phase 후 SPC-004 가 sidecar schema 의 새로 발견된 gap (예: anchor_id 의 namespace 충돌) 을 보고하면:
+1. `MxTags` 필드 emission 만 비활성화 (`HookSpecificOutput.MxTags = nil` 강제) — RT-001 protocol 호환성 유지.
+2. Sidecar write 는 계속 (consumer 영향 없음).
+3. Hotfix SPEC 으로 schema_version: 3 도입 + migrate.
+
+---
+
+## 10. Run-Phase Entry Conditions
+
+After plan PR squash-merged into main:
+
+1. `git checkout main && git pull` (host checkout).
+2. `moai worktree new SPEC-V3R2-SPC-002 --base origin/main` per Step 2 spec-workflow.md.
+3. `cd ~/.moai/worktrees/moai-adk/SPEC-V3R2-SPC-002`.
+4. `git rev-parse --show-toplevel` should output the worktree path (Block 0 verification per session-handoff.md).
+5. `git rev-parse HEAD` should match plan-merge commit SHA on main.
+6. Verify `internal/mx/` 패키지 무결성: `go test ./internal/mx/...` — 기존 SPC-004 tests still PASS.
+7. `/moai run SPEC-V3R2-SPC-002` invokes Phase 0.5 plan-audit gate, then proceeds to M1.
+
+---
+
+Version: 0.1.0
+Status: Plan artifact for SPEC-V3R2-SPC-002
+Run-phase methodology: TDD (per `.moai/config/sections/quality.yaml` `development_mode: tdd`)
+Estimated artifacts: 5 new Go source files + 5 new test files + 4 modified Go files + CHANGELOG = ~1,250 LOC delta (production ~480 + test ~770)

--- a/.moai/specs/SPEC-V3R2-SPC-002/progress.md
+++ b/.moai/specs/SPEC-V3R2-SPC-002/progress.md
@@ -1,0 +1,162 @@
+# SPEC-V3R2-SPC-002 Progress Tracker
+
+> Phase tracker shell for **@MX TAG v2 with hook JSON integration and sidecar index**.
+> Updated by run-phase agents during M1..M6 execution.
+
+## HISTORY
+
+| Version | Date | Author | Description |
+|---------|------|--------|-------------|
+| 0.1.0   | 2026-05-10 | manager-spec (Plan workflow Phase 1B) | Initial progress.md shell. plan_complete_at populated post-PR-merge. plan_status: audit-ready. |
+
+---
+
+## 1. Phase Status
+
+| Phase   | Status       | Started     | Completed | Notes |
+|---------|--------------|-------------|-----------|-------|
+| Plan    | in-progress  | 2026-05-10  | (TBD)     | plan/SPEC-V3R2-SPC-002 branch open; PR pending squash-merge |
+| Run     | pending      | -           | -         | Awaits plan PR merge + worktree setup |
+| Sync    | pending      | -           | -         | Awaits run PR merge |
+| Cleanup | pending      | -           | -         | Awaits sync PR merge |
+
+Plan-phase status fields:
+- `plan_complete_at`: (set when plan PR merged into main)
+- `plan_status`: draft → **audit-ready** → audited → merged
+
+---
+
+## 2. Plan Phase Checkpoints
+
+- [x] spec.md authored (already present at HEAD `fcb486c87`)
+- [x] research.md authored (Phase 1A — 30 evidence anchors)
+- [x] plan.md authored (Phase 1B — 6 milestones, 22 tasks, 22 REQs traced)
+- [x] acceptance.md authored (15 ACs with Given/When/Then)
+- [x] tasks.md authored (22 tasks across M1..M6)
+- [x] progress.md shell authored
+- [x] issue-body.md authored (PR body draft)
+- [ ] plan-auditor PASS verdict (target ≥ 0.85 first iteration)
+- [ ] plan PR squash-merged into main
+- [ ] plan_complete_at + plan_status = audit-ready persisted
+
+---
+
+## 3. Milestone Tracker (Run Phase)
+
+### M1: PostToolUse handler + types — Priority P0
+
+- [ ] T-SPC002-01: post_tool_mx.go handler (4 sub-tests)
+- [ ] T-SPC002-02: HookSpecificOutput.MxTags field
+- [ ] T-SPC002-03: formatTagsForContext + budget cap (3 sub-tests)
+- [ ] T-SPC002-15: 16-language fixture
+
+Verification gate: `go test ./internal/hook/ ./internal/mx/ -run "TestPostToolUseHandler|TestHookSpecificOutput_MxTagsField|TestScanner_AllSixteenLanguages"` → all PASS.
+
+### M2: `/moai mx` flag dispatcher — Priority P0
+
+- [ ] T-SPC002-04: `--full` flag (3 sub-tests)
+- [ ] T-SPC002-05: `--json` flag (2 sub-tests)
+- [ ] T-SPC002-06: `--anchor-audit` flag scaffold (3 sub-tests; full wire in M5)
+
+Verification gate: `go test ./internal/cli/ -run TestMxCmd` → all PASS.
+
+### M3: silent env + mx.yaml ignore — Priority P1
+
+- [ ] T-SPC002-07: MOAI_MX_HOOK_SILENT env (3 sub-tests)
+- [ ] T-SPC002-08: mx.yaml config loader + Scanner ignore wire-up (4 sub-tests)
+
+Verification gate: `go test ./internal/hook/ ./internal/mx/ -run "TestPostToolUseHandler_HookSilent|TestLoadConfig|TestScanner_RespectsMxYaml"` → all PASS.
+
+### M4: Scanner correctness fixtures — Priority P1
+
+- [ ] T-SPC002-09: MissingReasonForWarn 3-line lookahead (3 sub-tests)
+- [ ] T-SPC002-10: DuplicateAnchorID refuse-write (2 sub-tests)
+- [ ] T-SPC002-11: Corrupt sidecar repair suggestion (2 sub-tests)
+- [ ] T-SPC002-16: HookSpecificOutput mismatch validator (3 sub-tests)
+
+Verification gate: `go test ./internal/mx/ ./internal/hook/ -run "TestScanner_MissingReason|TestScanner_DuplicateAnchor|TestSidecar_Corrupt|TestHookOutput_MxTagsWith"` → all PASS.
+
+### M5: Archive sweep + atomic verify — Priority P1
+
+- [ ] T-SPC002-12: Atomic write no-partial-reads (race fixture)
+- [ ] T-SPC002-13: 7-day stale preservation
+- [ ] T-SPC002-14: 8-day stale archive sweep (2 sub-tests)
+- [ ] T-SPC002-06 (continued): anchor-audit fully wired with fanin.CountFanIn
+
+Verification gate: `go test ./internal/mx/ -run "TestSidecar_Atomic|TestSidecar_Stale|TestRunAnchorAudit" -race -count=10` → all PASS.
+
+### M6: Verification + audit — Priority P0
+
+- [ ] T-SPC002-17: `go test -race -count=1 ./...` PASS
+- [ ] T-SPC002-18: `golangci-lint run` clean
+- [ ] T-SPC002-19: `make build` exits 0; embedded.go regenerated; `diff -r` clean
+- [ ] T-SPC002-20: CHANGELOG.md updated (4 entries)
+- [ ] T-SPC002-21: @MX tags applied per plan §6 (6 tags)
+- [ ] T-SPC002-22: end-to-end smoke test (real claude session)
+
+Verification gate: All AC-SPC-002-01..15 verified per acceptance.md.
+
+---
+
+## 4. AC Status Tracker
+
+| AC ID | Status | Verified by | Verified at |
+|---|---|---|---|
+| AC-01 | pending | T-SPC002-15 | (TBD) |
+| AC-02 | pending | T-SPC002-04, T-SPC002-12 | (TBD) |
+| AC-03 | pending | T-SPC002-12 | (TBD) |
+| AC-04 | pending | T-SPC002-01..03 | (TBD) |
+| AC-05 | pending | T-SPC002-09 | (TBD) |
+| AC-06 | pending | T-SPC002-10 | (TBD) |
+| AC-07 | pending | T-SPC002-13 | (TBD) |
+| AC-08 | pending | T-SPC002-14 | (TBD) |
+| AC-09 | pending | T-SPC002-11 | (TBD) |
+| AC-10 | pending | T-SPC002-08 | (TBD) |
+| AC-11 | pending | T-SPC002-07 | (TBD) |
+| AC-12 | pending | T-SPC002-05 | (TBD) |
+| AC-13 | pending | T-SPC002-16 | (TBD) |
+| AC-14 | pending | T-SPC002-06 | (TBD) |
+| AC-15 | pending | T-SPC002-15 | (TBD) |
+
+---
+
+## 5. Iteration Tracker (Re-planning Gate)
+
+Per `.claude/rules/moai/workflow/spec-workflow.md` § Re-planning Gate, append per-iteration acceptance criteria completion count + error count delta to detect stagnation (3+ iterations no AC progress → trigger AskUserQuestion gap analysis).
+
+| Iteration | Date | AC completed | Error delta | Notes |
+|---|---|---|---|---|
+| (TBD)     | (TBD) | 0/15        | 0           | First run-phase iteration baseline |
+
+---
+
+## 6. Risk Watch
+
+Per spec §8 + plan §7 + research §7:
+
+| Risk | Status | Mitigation |
+|---|---|---|
+| Wave 3 already implemented 80% — REQ redundancy concern | MITIGATED | plan §1.2.1 acknowledged; sync HISTORY reconcile |
+| SPC-004 schema break risk | MITIGATED | schema_version: 2 preserved; new fields omitempty only |
+| PostToolUse handler crashes Claude session | MONITORED | T-SPC002-01 graceful no-op + race detector (T-SPC002-12) |
+| Token budget overflow | MITIGATED | T-SPC002-03 (budget cap) + T-SPC002-07 (silent env) |
+| Atomic write race | MITIGATED | sidecar Manager has sync.RWMutex (research [E-21]) + T-SPC002-12 fixture |
+| Cross-language fixture drift | MITIGATED | T-SPC002-15 16-lang regression guard |
+| HookSpecificOutput mismatch | MITIGATED | T-SPC002-16 validator + sentinel error |
+
+---
+
+## 7. Notes
+
+- Run-phase methodology: TDD per `.moai/config/sections/quality.yaml` `development_mode: tdd`.
+- Worktree base: `origin/main` HEAD `fcb486c87` (plan-phase author baseline).
+- Template-first discipline: this SPEC touches `internal/` Go code only; no template asset changes expected. `make build` regenerates `embedded.go` for safety.
+- Estimated artifacts: 5 new Go source files + 5 new test files + 4 modified Go files + CHANGELOG = ~1,250 LOC delta (production ~480 + test ~770).
+- 80% of code surface already merged via Wave 3 PR #741 (`3f0933550`) + SPC-004 PR #746 (`68795dbe3`); this SPEC closes 8 격차 (G-01..G-08) per research.md §10.
+
+---
+
+End of progress.
+
+Version: 0.1.0
+Status: Progress shell for SPEC-V3R2-SPC-002

--- a/.moai/specs/SPEC-V3R2-SPC-002/research.md
+++ b/.moai/specs/SPEC-V3R2-SPC-002/research.md
@@ -1,0 +1,440 @@
+# SPEC-V3R2-SPC-002 Research
+
+> Research artifact for **@MX TAG v2 with hook JSON integration and sidecar index**.
+> Companion to `spec.md` v0.1.0, `plan.md` v0.1.0, `acceptance.md` v0.1.0, `tasks.md` v0.1.0.
+
+## HISTORY
+
+| Version | Date       | Author                          | Description |
+|---------|------------|---------------------------------|-------------|
+| 0.1.0   | 2026-05-10 | manager-spec (Plan workflow Phase 1A) | Initial research on existing `internal/mx/` scaffolding (already merged via SPEC-V3R2 Wave 3 + SPC-004), inline @MX TAG protocol FROZEN status, PostToolUse hook integration gap, 16-language comment prefix coverage, and downstream blocker survey for SPC-004 + HRN-003 consumers. |
+
+---
+
+## 1. Research Scope and Method
+
+### 1.1 Scope
+
+본 research 는 다음 10개 축에 대한 plan-phase 의사결정 근거를 수집한다:
+
+1. **현행 `internal/mx/` 패키지 상태** — `tag.go` / `scanner.go` / `sidecar.go` / `resolver.go` / `comment_prefixes.go` / `fanin.go` / `danger_category.go` / `spec_association.go` / `resolver_query.go` 가 어느 SPEC 까지 구현되어 있는지 SHA-anchored 인벤토리.
+2. **Inline @MX TAG protocol 의 FROZEN 경계** — `.claude/rules/moai/workflow/mx-tag-protocol.md` 의 5-kind enum (NOTE / WARN / ANCHOR / TODO / LEGACY), `@MX:REASON` 의무, 자율 agent add/update/remove 권한 — 이 SPEC 이 손대지 않을 표면.
+3. **PostToolUse hook JSON protocol** — `internal/hook/types.go` 의 `HookOutput` / `HookSpecificOutput` 구조; `additionalContext` 필드와 `hookSpecificOutput.hookEventName` 의무; `mxTags` 구조화 필드 도입 가능성.
+4. **`/moai mx` CLI 현재 surface** — `internal/cli/mx.go` parent + `mx_query.go` (SPC-004 query subcommand) 가 무엇을 노출하고 있고 SPC-002 가 추가해야 하는 sub-flags (`--full` / `--index-only` / `--json` / `--anchor-audit`) 의 격차.
+5. **16-language comment-prefix 매트릭스** — `internal/mx/comment_prefixes.go` 의 현 매핑 vs CLAUDE.local.md §15 canonical 16-언어 enum (go, python, typescript, javascript, rust, java, kotlin, csharp, ruby, php, elixir, cpp, scala, r, flutter, swift) vs SPEC §3.
+6. **Atomic JSON write 패턴** — repo 전반의 `os.Rename` 사용 사례 (config/manager.go, manifest/manifest.go, runtime/persist.go). `internal/mx/sidecar.go` 의 `writeWithoutLock` 가 이 표준에 부합하는지 검증.
+7. **`PostToolUse` 핸들러의 MX 진입점** — `internal/hook/file_changed.go` 가 이미 `mx.NewScanner()` 를 호출하는 사실; PostToolUse vs FileChanged event-type 분리 + sidecar 갱신 누락 영역.
+8. **Stale-tag retention 정책** — sidecar Tag 의 `LastSeenAt` + `IsStale()` 메서드; 7-일 TTL 의 archive 경로 (`mx-archive.json`) 구현 상태.
+9. **AnchorID 충돌 검출** — Scanner 의 `anchorIDs map[string]string` 추적; duplicate 감지 시 `DuplicateAnchorID` 에러 emission 여부.
+10. **Downstream consumers** — SPC-004 (resolver query) 는 이미 main 에 있음 (PR #746 머지 commit `68795dbe3`). HRN-003 (evaluator) 는 sidecar 를 score 입력으로 소비할 예정이나 이 SPEC 의 책임은 아님.
+
+### 1.2 Method
+
+- **Static analysis**: `internal/mx/*.go` 와 `internal/hook/*.go` 직접 read; existing `@MX:ANCHOR` / `@MX:REASON` 태그 인벤토리.
+- **CLI surface probe**: `internal/cli/mx.go` 와 `internal/cli/mx_query.go` 의 cobra subcommand 트리 검사.
+- **Git history**: `git log --oneline -- internal/mx/` 로 SPC-002 / SPC-004 / Wave 3 commit 흐름 재구성.
+- **Cross-SPEC reference**: SPEC-V3R2-RT-001 (JSON hook protocol), SPEC-V3R2-CON-001 (FROZEN zone registry), SPEC-V3R2-SPC-004 (resolver query — already merged), SPEC-V3R2-HRN-003 (evaluator — downstream).
+- **Constitution reference**: zone-registry.md `CONST-V3R2-003` (mx-tag-protocol.md FROZEN clause id).
+- **Evidence anchoring**: 각 finding 은 file:line 또는 commit SHA 를 인용. 추정 금지.
+
+### 1.3 Evidence Anchor Inventory
+
+본 research 는 plan-auditor PASS 기준 (#4 ≥ 30 evidence anchors) 충족을 목표로 한다. 인용은 [E-NN] 으로 표기하고 §6 에서 합산.
+
+---
+
+## 2. Current-State Inventory (HEAD `fcb486c87`)
+
+### 2.1 `internal/mx/` 패키지 인벤토리
+
+`internal/mx/` 는 이미 다음 9개 파일을 포함한다 (HEAD `fcb486c87` 기준):
+
+| File | LOC (approx) | 책임 | SPEC 출처 |
+|------|--------------|------|-----------|
+| `tag.go` | ~70 | `TagKind` enum (5개) + `Tag` struct (8 fields) + `IsStale()` | SPC-002 본 SPEC |
+| `scanner.go` | ~280 | `Scanner` 구조체 + `ScanFile` / `ScanDirectory` + `@MX:` line 파서 + AnchorID 중복 추적 | SPC-002 본 SPEC |
+| `sidecar.go` | ~230 | `Sidecar` struct (`schema_version: 2`) + `Manager` (load/write/UpdateFile) + atomic temp+rename | SPC-002 본 SPEC |
+| `comment_prefixes.go` | ~70 | 16-언어 line-comment prefix lookup (`.go`→`//`, `.py`→`#`, ...) | SPC-002 본 SPEC |
+| `resolver.go` | ~50 | `Resolver.ResolveAnchor` (placeholder for SPC-004) | SPC-002 본 SPEC |
+| `resolver_query.go` | ~390 | SPC-004 implementation: query API + filters (kind / file / spec / danger) | SPC-004 (merged PR #746) |
+| `fanin.go` | ~100 | SPC-004 fan_in 카운팅 | SPC-004 |
+| `danger_category.go` | ~95 | SPC-004 WARN→category 매핑 | SPC-004 |
+| `spec_association.go` | ~65 | SPC-004 SPEC↔Tag 연관 | SPC-004 |
+
+Evidence anchor [E-01]: `ls -la internal/mx/` 출력 — 9 source + 9 test 파일 = 18 파일 (2026-05-10).
+Evidence anchor [E-02]: `git log --oneline -- internal/mx/` 출력 — `3f0933550 feat(v3r2): Wave 3 — Permission Stack, MX TAG v2, Hook Handler, Constitution Pipeline (#741)` 가 SPC-002 의 핵심 골격을 도입한 commit.
+Evidence anchor [E-03]: `git log --oneline` 출력 — `68795dbe3 feat(mx): SPEC-V3R2-SPC-004 — @MX anchor resolver query API + moai mx query CLI (#746)` 가 SPC-004 머지 commit (resolver_query.go / fanin.go / danger_category.go / spec_association.go 추가).
+
+### 2.2 SPC-002 본 SPEC 의 구현 진척도
+
+Wave 3 PR #741 머지로 인해 본 SPEC 의 대부분 in-scope 영역이 이미 코드 상에 존재한다. **본 plan-phase 의 임무는 빌드가 아니라 격차 확인 + PostToolUse 통합 + CLI flag 확장 + 테스트 커버리지 확정**이다.
+
+이미 구현된 항목 (✅ 완료):
+- `Tag` Go struct + `TagKind` enum (`tag.go`) — Evidence [E-04]: `internal/mx/tag.go:8-26` 5-kind enum 정의 (`MXNote`, `MXWarn`, `MXAnchor`, `MXTodo`, `MXLegacy`).
+- `Tag` 8 fields (Kind / File / Line / Body / Reason / AnchorID / CreatedBy / LastSeenAt) — Evidence [E-05]: `internal/mx/tag.go:29-54`.
+- `Sidecar` struct + `schema_version: 2` 상수 — Evidence [E-06]: `internal/mx/sidecar.go:11-30`. `SchemaVersion = 2` 명시.
+- Atomic temp+rename write — Evidence [E-07]: `internal/mx/sidecar.go:108-125` `writeWithoutLock` 구현, `os.WriteFile(tempPath)` → `os.Rename(tempPath, sidecarPath)` 패턴.
+- 16-언어 comment-prefix lookup — Evidence [E-08]: `internal/mx/comment_prefixes.go:5-65`.
+- AnchorID 중복 추적 (Scanner 내부) — Evidence [E-09]: `internal/mx/scanner.go:13-19` `anchorIDs map[string]string` field.
+- `IsStale()` 7-일 TTL 검사 — Evidence [E-10]: `internal/mx/tag.go:56-62` `IsStale()` method, `7*24` hours.
+- `mx-archive.json` 경로 상수 — Evidence [E-11]: `internal/mx/sidecar.go:18` `ArchiveFileName = "mx-archive.json"`.
+- `Manager.UpdateFile` (PostToolUse incremental update API) — Evidence [E-12]: `internal/mx/sidecar.go:148+` `UpdateFile(filePath, newTags)` method.
+
+격차 / 미구현 (❌ 본 SPEC 의 run-phase scope):
+- **G-01**: PostToolUse 핸들러에서 `mxTags` 구조화 필드를 emit 하는 경로가 없다. 현재는 `internal/hook/file_changed.go` (FileChanged event) 가 `mx.NewScanner` 만 호출. PostToolUse handler 자체가 `Manager.UpdateFile` + `additionalContext` emission 을 수행하지 않음. Evidence [E-13]: `grep -n "mx\." internal/hook/post_tool*.go` → empty.
+- **G-02**: `HookSpecificOutput` 에 `mxTags` 필드가 없다. 현재 필드는 `HookEventName`, `PermissionDecision`, `PermissionDecisionReason`, `AdditionalContext`, `SessionTitle`, `UpdatedInput`, `UpdatedMCPToolOutput`, `UpdatedToolOutput` — 8개. Evidence [E-14]: `internal/hook/types.go:270-281`.
+- **G-03**: `/moai mx` 의 sub-flags 확장 부재. 현재 `internal/cli/mx.go` 는 parent command + `mx query` subcommand (SPC-004) 만 등록. `--full` / `--index-only` / `--json` / `--anchor-audit` flag 없음. Evidence [E-15]: `internal/cli/mx.go:1-30` 전체 30 LOC.
+- **G-04**: `MOAI_MX_HOOK_SILENT` 환경 변수 처리 부재. PostToolUse 핸들러 자체가 미구현이므로 silent 모드 분기도 없음.
+- **G-05**: `mx.yaml` `ignore:` 패턴이 Scanner 에 fed-in 되지 않음. `Scanner.SetIgnorePatterns` 메서드는 존재하나 (Evidence [E-16]: `internal/mx/scanner.go:31-33`), 실제 호출 site (CLI 명령 또는 hook) 가 mx.yaml 을 읽어 주입하는 로직이 없음.
+- **G-06**: `MissingReasonForWarn` warning emission 검증 부족. Scanner 가 `@MX:WARN` 다음 3-라인 내 `@MX:REASON` 부재를 어떻게 처리하는지 명시적 테스트 fixture 부재 (REQ-SPC-002-006 + REQ-SPC-002-040 검증 필요).
+- **G-07**: `DuplicateAnchorID` 처리 — 현재 `anchorIDs` map 은 추적만 하고 있으며 `RefuseToWrite` 시멘틱이 sidecar Manager 에 연결되어 있는지 명시 검증 부재 (REQ-SPC-002-007 + REQ-SPC-002-021).
+- **G-08**: `--anchor-audit` 의 fan_in < 3 low-value anchor 후보 리포트 (REQ-SPC-002-042). SPC-004 의 `fanin.go` 가 fan_in 계산은 하나, audit 형태의 CLI 출력이 별도로 wire-up 되어 있지 않음.
+
+### 2.3 Inline @MX TAG protocol — FROZEN
+
+`.claude/rules/moai/workflow/mx-tag-protocol.md` 는 zone-registry.md `CONST-V3R2-003` 으로 등록된 FROZEN clause:
+
+> `clause: "@MX TAG protocol"`, `canary_gate: true`, `anchor: "#mx-tag-types"`
+
+Evidence anchor [E-17]: `.claude/rules/moai/core/zone-registry.md:48-53` CONST-V3R2-003 entry verbatim.
+
+본 SPEC 은 inline 표면 (e.g. `// @MX:NOTE text`) 의 **추가, 삭제, 변경 모두 금지**한다. SPC-002 의 모든 변경은 sidecar (machine-readable view) + hook integration (PostToolUse) + CLI surface 에 한정된다. spec.md §1 + §2.2 + §7 Constraints 모두 동일한 invariant 강조.
+
+### 2.4 PostToolUse hook 의 현재 구조
+
+`internal/hook/post_tool*.go` 파일 5개 (`post_tool*.go` + tests):
+
+```
+internal/hook/post_tool_astgrep_test.go
+internal/hook/post_tool_duration_test.go
+internal/hook/post_tool_duration_threshold_test.go
+internal/hook/post_tool_failure_test.go
+```
+
+핸들러 로직: `internal/hook/post_tool*.go` 본체에서 `HookSpecificOutput.HookEventName == "PostToolUse"` 출력 시 다음 패턴을 사용한다 (Evidence anchor [E-18]: `internal/hook/types.go:387-396` `NewPostToolOutput(context string)`):
+
+```go
+return &HookOutput{
+    HookSpecificOutput: &HookSpecificOutput{
+        HookEventName:     "PostToolUse",
+        AdditionalContext: context,
+    },
+}
+```
+
+본 SPEC 의 G-01/G-02 격차 해결 시 이 패턴을 확장해야 한다 (`mxTags` 필드 추가).
+
+Evidence anchor [E-19]: `internal/hook/post_tool_astgrep_test.go:218-220` 가 이미 `HookSpecificOutput.HookEventName != "PostToolUse"` validation 을 수행 — 즉 dual-emit 시 hookEventName mismatch 검증은 기존 패턴에서 차용 가능 (REQ-SPC-002-041 의 `HookSpecificOutputMismatch` 와 같은 카테고리).
+
+### 2.5 `FileChanged` 와 `PostToolUse` 의 분리
+
+`internal/hook/file_changed.go` 는 이미 MX scanner 를 호출 (Evidence [E-20]: `internal/hook/file_changed.go:77` `scanner := mx.NewScanner()`). 그러나 FileChanged event 는 외부 file system change (e.g. git pull, IDE save) 시 발화하는 반면, PostToolUse 는 Claude 의 Write/Edit tool 결과 발화한다.
+
+본 SPEC 의 REQ-SPC-002-010 은 **PostToolUse** 발화 시 sidecar 갱신 + `additionalContext` emission 을 요구하며, 이는 FileChanged 의 기존 MX scan 과 별개의 코드 경로다. 두 경로가 모두 sidecar Manager 에 수렴해야 하며 race condition 방지 (sidecar manager 의 `sync.RWMutex`) 는 이미 구현되어 있음 — Evidence [E-21]: `internal/mx/sidecar.go:46` `mu sync.RWMutex`.
+
+### 2.6 `/moai mx` CLI 현재 surface
+
+`internal/cli/mx.go` 전체 30 LOC. parent command 만 등록 + SPC-004 의 query subcommand 만 add. Subcommand 트리:
+
+```
+moai mx                                    (parent — Help() 출력)
+moai mx query [--kind ... --spec ... ]     (SPC-004)
+```
+
+본 SPEC 의 격차 (G-03):
+- `moai mx --full` (전체 rescan + sidecar rebuild)
+- `moai mx --index-only` (sidecar 만 재생성, no console output)
+- `moai mx --json` (sidecar 를 stdout 으로 dump — REQ-SPC-002-032)
+- `moai mx --anchor-audit` (fan_in < 3 anchors 리포트 — REQ-SPC-002-042)
+
+이들은 parent `moai mx` 의 cobra Run/RunE 에 flag 로 추가하거나 subcommand (`moai mx full`, `moai mx audit`) 로 분리할 수 있음. plan-phase 결정: **flag 형태로 parent command 에 추가** (CLI 호환성 + sub-tree 분기 최소화). spec §6 AC-12 가 `/moai mx --json` 형식을 명시하므로 flag 형식이 SPEC-fidelity 우선.
+
+Evidence anchor [E-22]: spec.md §5.4 REQ-SPC-002-032 + AC-SPC-002-12 verbatim "When `/moai mx --json` is invoked, ..." — flag 형태로 명시.
+
+---
+
+## 3. Inline @MX TAG Protocol Boundary (FROZEN reference)
+
+### 3.1 5-kind enum 의 의미
+
+`tag.go` (E-04) 의 5-kind enum 은 mx-tag-protocol.md 의 inline syntax 와 1:1 대응:
+
+| TagKind | inline syntax | sub-line 의무 | when |
+|---------|---------------|---------------|------|
+| `MXNote` | `// @MX:NOTE text` | (없음) | context / intent delivery |
+| `MXWarn` | `// @MX:WARN text` | `@MX:REASON` 의무 | danger zone (goroutine leak, complexity ≥15, ...) |
+| `MXAnchor` | `// @MX:ANCHOR text` | `@MX:REASON` 의무 | invariant contract (fan_in ≥ 3) |
+| `MXTodo` | `// @MX:TODO text` | (없음) | incomplete work |
+| `MXLegacy` | `// @MX:LEGACY text` | (없음) | code without SPEC coverage |
+
+Evidence [E-23]: mx-tag-protocol.md "Tag Types:" 섹션 verbatim — 5-kind 와 sub-line 의무.
+
+### 3.2 본 SPEC 의 입장 (FROZEN preservation)
+
+REQ-SPC-002-001 "The system SHALL preserve the inline @MX TAG syntax defined in `.claude/rules/moai/workflow/mx-tag-protocol.md` verbatim; no changes to on-disk form" 는 다음을 의미:
+
+- `// @MX:NOTE` / `// @MX:WARN` / `// @MX:ANCHOR` / `// @MX:TODO` / `// @MX:LEGACY` 의 5-kind 표면 유지.
+- `@MX:REASON` 의무 보존 (WARN + ANCHOR 모두; spec §5.1 REQ-006 은 WARN 만 명시하지만 mx-tag-protocol.md 는 ANCHOR 도 reason 의무로 정의).
+- `@MX:SPEC` / `@MX:LEGACY` / `@MX:REASON` / `@MX:TEST` / `@MX:PRIORITY` 5개 sub-key 표면 유지.
+- 자율 agent add/update/remove 권한 보존 (mx-tag-protocol.md FROZEN clause).
+
+본 SPEC 은 위 모두에 대해 **read-only 관찰자** + **persisted view 생성자** 로 동작.
+
+Evidence [E-24]: zone-registry.md CONST-V3R2-003 `canary_gate: true` — graduation protocol 통과 없이는 변경 금지.
+
+### 3.3 Note: WARN sub-line 검증 정책
+
+Spec §5.1 REQ-006 "Every `@MX:WARN` tag SHALL have a sibling `@MX:REASON` sub-line; absence SHALL be flagged as a scanner warning" 와 §5.5 REQ-040 "WHILE scanning a file AND a line contains both `@MX:WARN` and no sibling `@MX:REASON` within the next 3 lines, THEN the scanner SHALL emit `MissingReasonForWarn` warning (not error — reason is authored progressively)" 는 의도적으로 분리되어 있음:
+
+- REQ-006: 의무는 명시되어 있다 (semantic).
+- REQ-040: emission 은 warning (not error) — agent 가 점진적으로 reason 을 작성할 수 있는 진화 경로 보존.
+
+Plan-phase 결정: REQ-006 은 REQ-040 의 약화된 형식이며 두 REQ 모두 같은 코드 경로 (Scanner 의 WARN 검출 후 3-라인 lookahead) 로 충족된다. tasks.md 에서는 단일 task (`Scanner.checkMissingReasonForWarn`) 로 묶어 처리.
+
+---
+
+## 4. Atomic JSON Write Patterns (repo 표준)
+
+`os.Rename` 기반 atomic write 는 repo 전반에 다음 site 들에서 사용 중:
+
+| File:Line | 용도 |
+|-----------|------|
+| `internal/config/manager.go:401` | config YAML atomic write |
+| `internal/manifest/manifest.go:234` | manifest.json atomic write |
+| `internal/runtime/persist.go:17` | runtime state JSON |
+| `internal/mx/sidecar.go:124` | **본 SPEC 의 sidecar atomic write** |
+| `internal/update/updater.go:133` | binary swap |
+| `internal/core/project/validator.go:227` | .moai backup rename |
+
+Evidence [E-25]: `grep -rn "os.Rename" --include="*.go" internal/` — 14건 (테스트 제외 시 8건).
+
+표준 패턴 (`internal/manifest/manifest.go:230-235`):
+
+```go
+tmpName := path + ".tmp"
+if err := os.WriteFile(tmpName, data, 0644); err != nil {
+    return fmt.Errorf("write temp: %w", err)
+}
+return os.Rename(tmpName, path)
+```
+
+`internal/mx/sidecar.go` 의 `writeWithoutLock` 은 이 패턴을 충실히 따름 (E-07). 추가 안전 장치로 rename 실패 시 temp file cleanup (`_ = os.Remove(tempPath)`) 도 포함되어 있음.
+
+REQ-SPC-002-004 "atomically written (temp-file + rename) to prevent partial reads" 는 이미 충족 — run-phase 에서는 검증 + 테스트 fixture 추가만 수행.
+
+---
+
+## 5. 16-Language Comment-Prefix Coverage
+
+CLAUDE.local.md §15 의 canonical 16-언어:
+
+`go, python, typescript, javascript, rust, java, kotlin, csharp, ruby, php, elixir, cpp, scala, r, flutter, swift`
+
+`internal/mx/comment_prefixes.go` 매핑 (E-08):
+
+| 언어 | 확장자 | prefix | 매핑 존재? |
+|------|--------|--------|------------|
+| go | `.go` | `//` | ✅ |
+| python | `.py` | `#` | ✅ |
+| typescript | `.ts` | `//` | ✅ |
+| javascript | `.js`, `.mjs` | `//` | ✅ |
+| rust | `.rs` | `//` | ✅ |
+| java | `.java` | `//` | ✅ |
+| kotlin | `.kt` | `//` | ✅ |
+| csharp | `.cs` | `//` | ✅ |
+| ruby | `.rb` | `#` | ✅ |
+| php | `.php` | `//` | ✅ |
+| elixir | `.ex`, `.exs` | `#` | ✅ |
+| cpp | `.cpp`, `.hpp`, `.cc`, `.cxx` | `//` | ✅ |
+| scala | `.scala` | `//` | ✅ |
+| r | `.R`, `.r` | `#` | ✅ |
+| flutter (Dart) | `.dart` | `//` | ✅ |
+| swift | `.swift` | `//` | ✅ |
+
+16/16 모두 매핑됨. spec §5.1 REQ-005 + AC-15 충족 가능.
+
+Evidence [E-26]: `internal/mx/comment_prefixes.go:5-65` — 16개 언어 모두 lookup map 등록.
+
+격차: `internal/hook/file_changed.go:14-37` 의 `supportedExtensions` map 은 `comment_prefixes.go` 와 별도 정의되어 있어 drift 가능성 존재. plan-phase 결정: run-phase 에서 두 source 를 통합하거나 drift detection 테스트 추가 (tasks.md T-SPC002-15).
+
+Evidence [E-27]: `internal/hook/file_changed.go:14-37` `supportedExtensions` map 별도 정의 — 21 extensions, comment_prefixes 와 약간 다름 (예: `.h` 는 file_changed 만 가짐).
+
+---
+
+## 6. Cross-SPEC Boundary Survey
+
+### 6.1 SPEC-V3R2-CON-001 (FROZEN/EVOLVABLE codification)
+
+상태: 가정 머지 (spec.md §9.1 Blocked-by). zone-registry.md `CONST-V3R2-003` 가 mx-tag-protocol.md 를 FROZEN 으로 등록 — 본 SPEC 의 inline 표면 보존 의무를 강제.
+
+Evidence [E-28]: `.claude/rules/moai/core/zone-registry.md` CONST-V3R2-003 entry.
+
+### 6.2 SPEC-V3R2-RT-001 (JSON hook protocol)
+
+상태: spec.md §9.1 의 prerequisite. RT-001 이 `HookOutput` / `HookSpecificOutput` JSON dual-protocol 을 정의 — 본 SPEC 의 REQ-010/011/012 가 이 protocol 위에 `mxTags` payload 를 얹는다.
+
+`internal/hook/types.go:285-302` (E-14, E-18) 가 RT-001 의 구체화. 본 SPEC 은 `HookSpecificOutput` 에 `MxTags []mx.Tag` field 를 추가하거나, 또는 protocol-neutral 방식으로 `AdditionalContext` 에 직렬화 텍스트만 emit 하고 sidecar update 는 별도 호출하는 두 가지 옵션 가능.
+
+Plan-phase 결정 (OQ-1 below): **`HookSpecificOutput` 에 `MxTags` 필드 추가** — 구조화 emission 을 protocol level 에 일급 객체로 표현하여 RT-001 의 dual-protocol 정신과 일치.
+
+Evidence [E-29]: spec §5.2 REQ-011 "the handler SHALL emit a HookResponse JSON with `additionalContext` (human-readable summary) and `hookSpecificOutput.mxTags` (structured array of Tag records)" — both surfaces 명시.
+
+### 6.3 SPEC-V3R2-SPC-004 (resolver query API)
+
+상태: **이미 머지** (PR #746, commit `68795dbe3`, 2026-04-30). `internal/mx/resolver_query.go` + `internal/cli/mx_query.go` 추가됨.
+
+본 SPEC 과의 관계: SPC-004 가 sidecar (`internal/mx/sidecar.go`) 를 read-only 소비. 본 SPEC 이 sidecar 의 schema_version + write 의무를 책임.
+
+영향: SPC-002 가 sidecar 의 schema 를 변경 (예: 새 필드 추가) 하면 SPC-004 의 query 결과 schema 도 변경됨. plan-phase 결정: schema_version 을 변경하지 않는다 — 모든 본 SPEC scope 의 변경은 schema_version: 2 호환.
+
+Evidence [E-30]: `internal/cli/mx_query.go:95` `mgr := mx.NewManager(stateDir)` — SPC-004 가 sidecar Manager 의 read API (`GetAllTags`) 에 의존.
+
+### 6.4 SPEC-V3R2-HRN-003 (evaluator MX 점수)
+
+상태: in-flight (downstream 미정). 본 SPEC 이 sidecar 를 publish 하면 evaluator-active 가 score 계산에 사용 가능. 본 SPEC 은 evaluator 가 sidecar 를 어떻게 소비하는지 결정하지 않음 — HRN-003 의 스코프.
+
+영향: 없음 (one-way produce).
+
+### 6.5 SPEC-V3R2-WF-005 (16-language neutrality)
+
+상태: in-flight. WF-005 가 16-언어 enum 의 single source of truth 를 정의하면 `internal/mx/comment_prefixes.go` 와 `internal/hook/file_changed.go:supportedExtensions` 모두 그 enum 을 참조해야 한다. 본 SPEC 은 16-언어 매핑이 이미 존재함을 보장 (§5) — drift detection 만 책임.
+
+---
+
+## 7. Decision Log (Plan-Phase Open Questions Resolved)
+
+### OQ-1: PostToolUse 의 `mxTags` 를 어디에 직렬화할 것인가?
+
+**Decision**: `HookSpecificOutput` 구조체에 `MxTags []mx.Tag` 필드 신규 추가 + JSON omitempty.
+
+**Rationale**: (1) RT-001 이 정의한 dual-protocol (top-level decision + hookSpecificOutput) 정신과 일치. (2) `additionalContext` 에 JSON 을 임베드하는 방식은 escape 문제와 사이즈 폭증 위험. (3) 추가 필드는 omitempty 이므로 기존 PostToolUse 출력에 영향 없음 (backward-compatible).
+
+대안 (기각): `additionalContext` 에 JSON 직렬화 임베드 — 가독성 ↓, parsing fragility ↑.
+
+**검증**: spec.md REQ-011 + AC-04 를 동시 충족.
+
+### OQ-2: PostToolUse handler 의 sidecar update 는 sync 인가 async 인가?
+
+**Decision**: sync (blocking) — REQ-SPC-002-012 "the sidecar index SHALL be atomically updated" 을 만족하기 위해 PostToolUse handler 가 응답 전 sidecar Manager.UpdateFile 호출 완료 보장.
+
+**Rationale**: REQ-CON 인 atomic 보장 + race-free (sidecar Manager 가 sync.RWMutex 보유 — E-21). sync 의 latency 비용은 spec §7 budget 100ms 이내 (UpdateFile 은 in-memory map 갱신 + 단일 파일 write — typical < 5ms).
+
+### OQ-3: Stale-tag retention 의 archive 는 누가 트리거하나?
+
+**Decision**: `/moai mx --full` 실행 시 (full scan) Manager.UpdateFile 의 후처리에서 trigger. PostToolUse incremental update 는 archive 를 트리거하지 않음 (전체 view 가 없으므로 stale 판정 불가).
+
+**Rationale**: REQ-SPC-002-014 + REQ-020 모두 "during a full scan" + "WHILE LastSeenAt is older than 7 days AND the tag is not found in the current scan" 의 두 조건이 합쳐졌을 때만 archive — full scan path 가 자연스러운 트리거 지점.
+
+### OQ-4: `MOAI_MX_HOOK_SILENT=1` 동작 범위는?
+
+**Decision**: PostToolUse handler 만 영향. sidecar update 는 항상 발생, `additionalContext` 만 비움 (REQ-SPC-002-031 verbatim).
+
+**Rationale**: spec §5.4 verbatim. CI 환경에서 sidecar 정합성은 유지하되 model-turn 에 노이즈 주입 방지.
+
+### OQ-5: `--full` vs `--index-only` 의 차이는?
+
+**Decision**:
+- `--full`: 전체 rescan + sidecar rebuild + console summary (count of tags) + archive sweep.
+- `--index-only`: 전체 rescan + sidecar rebuild + (no console output) + archive sweep. CI/automation 용.
+
+둘 다 archive sweep 트리거 (OQ-3 결정과 일관).
+
+### OQ-6: `--anchor-audit` 의 출력 형태?
+
+**Decision**: stdout 으로 markdown 표 (Agent / AnchorID / fan_in / file:line) 출력. fan_in < 3 인 anchor 만 포함. exit code 0 (audit 결과는 informational, fail 아님).
+
+**Rationale**: REQ-SPC-002-042 verbatim "low-value anchor candidate (not removed automatically; reviewer decides)".
+
+### OQ-7: `mx.yaml` 의 `ignore:` 패턴 형식?
+
+**Decision**: gitignore-style 글로브 패턴 (예: `vendor/`, `*.pb.go`). 기본값 `["vendor/", "node_modules/", "dist/", ".git/", "**/*_generated.go", "**/mock_*.go"]`. mx.yaml 의 기존 `comment_syntax`, `discovery` 등 다른 keys 와 sibling.
+
+**Rationale**: gitignore 표면은 사용자 친화적이고 Go `path/filepath.Match` 로 충분 구현 가능.
+
+### OQ-8: AnchorID 충돌 검출 시 동작?
+
+**Decision**: Scanner 가 `DuplicateAnchorID` 에러 emit + `Manager.Write` refuse (sidecar 갱신 거부). 사용자가 충돌 해결 후 재실행해야 한다. PostToolUse 시 충돌이 발생하면 단일 파일만 거부 (전체 sidecar 무효화 회피).
+
+**Rationale**: spec §5.3 REQ-021 "scanner SHALL emit `DuplicateAnchorID` error naming both file:line pairs and refuse to write the index".
+
+### OQ-9: corrupt sidecar 처리 시 사용자 통지?
+
+**Decision**: stderr 로 "WARNING: sidecar corrupt at ..., rebuilding via /moai mx --full" repair suggestion 출력 + 빈 sidecar 로 진행. 다음 `--full` 호출 시 자동 복구.
+
+**Rationale**: spec §5.3 REQ-022 "treat it as empty and emit a repair suggestion; the next full scan rebuilds it".
+
+---
+
+## 8. Risk Survey (cross-referenced from spec §8)
+
+| Risk | Evidence anchor | Mitigation reference (plan §x) |
+|------|------------------|--------------------------------|
+| Sidecar drift from source truth | E-12 (UpdateFile API), E-25 (atomic write) | plan §M3 PostToolUse integration + `/moai mx --verify` advisory; CI guard 잠재 추가 |
+| Cross-language comment parser 엣지 케이스 (nested comments, string literals) | E-08 (16-언어 매핑) | plan §M4 per-language fixture; escape-aware refinement deferred to v3.1 |
+| PostToolUse JSON 토큰 폭증 | E-14 (HookSpecificOutput) | mx.yaml `hook.max_additional_context_bytes` cap (spec §8 row 3 mitigation) |
+| Stale 태그가 7-일 TTL 넘김 | E-10 (IsStale), E-11 (mx-archive.json) | plan §M3 archive sweep on `--full` |
+| Duplicate AnchorID block | E-09 (anchorIDs map) | plan §M2 + §6 AC-06 fixture; Scanner refuses write |
+| Binary size growth from 16-language parsers | E-08 (prefix-table) | prefix-table 접근 (no per-language AST) — risk 사실상 해소 |
+| FileChanged 와 PostToolUse race | E-21 (sync.RWMutex) | sidecar Manager 가 이미 mutex 보호; 추가 작업 불필요 |
+
+---
+
+## 9. Cross-Reference Summary
+
+External references:
+- mx-tag-protocol.md (FROZEN inline syntax)
+- Anthropic hook protocol: claude-code v2.1.59+ `hookSpecificOutput.hookEventName` 의무
+
+Internal file:line anchors:
+- spec.md §1 / §2 / §5 / §6
+- plan.md §1 / §M1-M6 / §4 (mx_plan)
+- tasks.md §M1-M6
+- acceptance.md (15 ACs)
+- `.claude/rules/moai/workflow/mx-tag-protocol.md` 5-kind enum
+- `.claude/rules/moai/core/zone-registry.md` CONST-V3R2-003
+- `internal/mx/{tag,scanner,sidecar,resolver,comment_prefixes,fanin,danger_category,spec_association,resolver_query}.go`
+- `internal/hook/{types.go,file_changed.go,protocol.go,post_tool_*.go}`
+- `internal/cli/{mx,mx_query}.go`
+- `.moai/config/sections/mx.yaml`
+
+Cross-SPEC references:
+- SPEC-V3R2-CON-001 (FROZEN classification — consumed)
+- SPEC-V3R2-RT-001 (JSON hook protocol — prerequisite, consumed)
+- SPEC-V3R2-SPC-004 (resolver query — already merged)
+- SPEC-V3R2-HRN-003 (evaluator scoring — downstream)
+- SPEC-V3R2-WF-005 (16-언어 enum — downstream)
+
+Total evidence anchors: **30** ([E-01]..[E-30]). Plan-auditor PASS criterion #4 (≥30) 충족.
+
+---
+
+## 10. Conclusions and Plan-Phase Recommendations
+
+1. **본 SPEC 의 80% 는 이미 main 에 코드로 존재**. Wave 3 PR #741 commit `3f0933550` 가 tag.go / scanner.go / sidecar.go / comment_prefixes.go / resolver.go 를 모두 머지함. SPC-004 PR #746 가 fanin / danger_category / spec_association / resolver_query 를 추가.
+
+2. **Run-phase 의 임무는 빌드가 아니라 격차 해소 + 통합 + 테스트 커버리지**:
+   - G-01: PostToolUse handler 신규 작성 (sidecar UpdateFile 호출 + mxTags emission).
+   - G-02: `HookSpecificOutput.MxTags` 필드 추가.
+   - G-03: `/moai mx` parent command 에 `--full` / `--index-only` / `--json` / `--anchor-audit` flag 추가.
+   - G-04: `MOAI_MX_HOOK_SILENT` env 처리.
+   - G-05: mx.yaml `ignore:` 패턴 wire-up.
+   - G-06: MissingReasonForWarn 명시 fixture.
+   - G-07: DuplicateAnchorID write-refuse 명시 검증.
+   - G-08: anchor-audit fan_in < 3 리포트.
+
+3. **FROZEN 표면 무결**: mx-tag-protocol.md 의 inline 표면을 손대지 않는다. 모든 변경은 sidecar / hook / CLI 표면.
+
+4. **schema_version: 2 호환**: SPC-004 이미 본 schema 를 read 중이므로 schema 변경 금지. 추가 필드는 omitempty.
+
+5. **16-언어 coverage 이미 충족**: comment_prefixes.go 가 16/16 매핑 보유. WF-005 와의 drift detection 은 advisory.
+
+6. **Cross-package consistency**: `internal/hook/file_changed.go` 의 supportedExtensions map 과 `internal/mx/comment_prefixes.go` 의 통합은 nice-to-have (drift 위험 LOW; spec out-of-scope).
+
+7. **Performance budget 충족 가능**: spec §7 의 2s full-scan / 100ms incremental 은 prefix-table 접근법으로 충분 — Scanner 가 AST parse 없이 line-comment regex 만 수행.
+
+8. **테스트 인프라 존재**: `internal/mx/*_test.go` 9개 파일 (총 ~1700+ LOC test code) 이 이미 tag/scanner/sidecar/resolver 의 RED-GREEN-REFACTOR cycle 을 수행 완료. run-phase 는 차이 영역 (PostToolUse handler + CLI flag) 의 새 fixture 만 추가.
+
+End of research.
+
+Version: 0.1.0
+Status: Research artifact for SPEC-V3R2-SPC-002 (Plan workflow Phase 1A)

--- a/.moai/specs/SPEC-V3R2-SPC-002/tasks.md
+++ b/.moai/specs/SPEC-V3R2-SPC-002/tasks.md
@@ -1,0 +1,669 @@
+# SPEC-V3R2-SPC-002 Task List
+
+> Implementation task list for **@MX TAG v2 with hook JSON integration and sidecar index**.
+> Companion to `spec.md` v0.1.0, `plan.md` v0.1.0, `research.md` v0.1.0, `acceptance.md` v0.1.0.
+
+## HISTORY
+
+| Version | Date | Author | Description |
+|---------|------|--------|-------------|
+| 0.1.0   | 2026-05-10 | manager-spec (Plan workflow Phase 1B) | Initial task list. 22 tasks (T-SPC002-01..22) grouped into 6 milestones (M1..M6), priorities P0/P1/P2. Wave-split: tasks fit within ~22 entries — no wave-split needed (under feedback_large_spec_wave_split.md 30-task threshold). |
+
+---
+
+## 1. Task Overview
+
+| Milestone | Phase | Tasks | Priority | REQ Coverage |
+|---|---|---|---|---|
+| M1: PostToolUse handler + types | RED → GREEN | T-SPC002-01..03, T-SPC002-15 | P0 | REQ-001, REQ-002, REQ-005, REQ-010, REQ-011, REQ-012 |
+| M2: `/moai mx` flag dispatcher | RED → GREEN | T-SPC002-04..06 | P0 | REQ-013, REQ-032, REQ-042 |
+| M3: silent env + mx.yaml ignore | RED → GREEN | T-SPC002-07, T-SPC002-08 | P1 | REQ-030, REQ-031 |
+| M4: Scanner correctness fixtures | RED → GREEN | T-SPC002-09..11, T-SPC002-16 | P1 | REQ-006, REQ-007, REQ-021, REQ-022, REQ-040, REQ-041 |
+| M5: Archive sweep + atomic verify | RED → GREEN | T-SPC002-12..14 | P1 | REQ-004, REQ-014, REQ-020 |
+| M6: Verification + audit | VERIFY | T-SPC002-17..22 | P0 | (cross-cutting) |
+
+Total: **22 tasks**. Below 30-task threshold → no wave-split required (per `feedback_large_spec_wave_split.md`).
+
+---
+
+## 2. Tasks by Milestone
+
+### Milestone 1: PostToolUse handler + HookSpecificOutput.MxTags field — Priority P0
+
+#### T-SPC002-01: Create internal/hook/post_tool_mx.go
+
+**REQ traceback**: REQ-SPC-002-010, REQ-SPC-002-011, REQ-SPC-002-012
+
+**AC traceback**: AC-04
+
+**Goal**: Create new PostToolUse handler under `internal/hook/post_tool_mx.go` that:
+1. Filters for `tool_name in {Write, Edit}`.
+2. Filters for supported file extensions (via `mx.GetCommentPrefix(ext) != ""`).
+3. Calls `mx.NewScanner().ScanFile(filePath)` then `Manager.UpdateFile(filePath, tags)`.
+4. Returns HookOutput with `HookSpecificOutput.HookEventName = "PostToolUse"`, `AdditionalContext = formatTagsForContext(tags)`, `MxTags = tags`.
+5. Handles silent mode via `os.Getenv("MOAI_MX_HOOK_SILENT")` (T-SPC002-07 dependency).
+
+**Files**:
+- `internal/hook/post_tool_mx.go` (new ~150 LOC)
+- `internal/hook/post_tool_mx_test.go` (new ~250 LOC)
+
+**Sub-tasks**:
+- Define `postToolMxHandler` struct + `NewPostToolMxHandler()` constructor
+- Implement `EventType()` returning `EventPostToolUse`
+- Implement `Handle(ctx, input)` per logic above
+- Add helper `formatTagsForContext(tags) string` (one tag per line: `@MX:KIND at file.go:N: body`)
+- Add helper `extractFilePath(rawInput)` to parse tool_input JSON for file_path
+- Register handler in `internal/hook/registry.go` (or appropriate dispatch site)
+- Test: `TestPostToolUseHandler_EmitsMxTags` (Python file with `# @MX:WARN`)
+- Test: `TestPostToolUseHandler_NonEditTool` (tool_name = "Read" → empty output)
+- Test: `TestPostToolUseHandler_UnsupportedExt` (.txt → empty output)
+- Test: `TestPostToolUseHandler_HandlerEventTypeIsPostToolUse`
+
+**Acceptance**:
+- [ ] Handler returns valid HookOutput for Edit/Write events
+- [ ] Non-Write/Edit tools produce empty output (graceful no-op)
+- [ ] Unsupported extensions produce empty output
+- [ ] All 4 sub-tests PASS
+
+**Dependencies**: T-SPC002-02 (MxTags field must exist)
+
+---
+
+#### T-SPC002-02: Add HookSpecificOutput.MxTags field
+
+**REQ traceback**: REQ-SPC-002-011
+
+**AC traceback**: AC-04
+
+**Goal**: Add `MxTags []mx.Tag` field to `HookSpecificOutput` struct in `internal/hook/types.go`.
+
+**Files**:
+- `internal/hook/types.go` (+5 LOC)
+
+**Sub-tasks**:
+- Import `internal/mx` package (verify no cyclic import)
+- Add field `MxTags []mx.Tag \`json:"mxTags,omitempty"\``
+- Verify existing JSON marshalling tests in `protocol_test.go` still PASS (backward compatibility)
+- Add test `TestHookSpecificOutput_MxTagsField_JSONMarshal` (verifies JSON output has `mxTags` key when populated, absent when empty)
+
+**Acceptance**:
+- [ ] Field added with omitempty tag
+- [ ] No cyclic import errors (`go vet`)
+- [ ] Existing tests still PASS
+- [ ] JSON marshalling test PASS
+
+**Dependencies**: None (independent struct edit)
+
+---
+
+#### T-SPC002-03: AdditionalContext format + helper
+
+**REQ traceback**: REQ-SPC-002-011 (human-readable summary), REQ-SPC-002-031 (silent mode skip)
+
+**AC traceback**: AC-04, AC-11
+
+**Goal**: Implement `formatTagsForContext(tags []mx.Tag) string` in `post_tool_mx.go`. Format: one tag per line.
+
+Format spec:
+```
+@MX:WARN at foo.go:42: missing timeout on requests.get
+@MX:NOTE at foo.go:17: explains why handler forks
+```
+
+Cap at `mx.yaml` `hook.max_additional_context_bytes` (default 4096) — truncate with "... (N more tags)" suffix.
+
+**Files**:
+- `internal/hook/post_tool_mx.go` (function added)
+
+**Sub-tasks**:
+- Implement formatTagsForContext
+- Apply byte cap from config
+- Test: `TestFormatTagsForContext_BasicFormat`
+- Test: `TestFormatTagsForContext_BudgetCap`
+- Test: `TestFormatTagsForContext_EmptyTagsReturnsEmpty`
+
+**Acceptance**:
+- [ ] Format matches spec example
+- [ ] Byte cap enforced
+- [ ] 3 sub-tests PASS
+
+**Dependencies**: T-SPC002-08 (mx.yaml config loader)
+
+---
+
+#### T-SPC002-15: 16-language scanner fixture
+
+**REQ traceback**: REQ-SPC-002-005
+
+**AC traceback**: AC-15
+
+**Goal**: Add `TestScanner_AllSixteenLanguages` fixture in `internal/mx/scanner_test.go` that creates 16 files (one per language) and asserts 16 tags found.
+
+**Files**:
+- `internal/mx/scanner_test.go` (+~80 LOC)
+
+**Sub-tasks**:
+- Create test that synthesizes 16 source files in `t.TempDir()`
+- Assert `scanner.ScanDirectory(tmpDir)` returns exactly 16 Tag records
+- Verify each Tag has correct `Kind == MXNote` and File field
+
+**Acceptance**:
+- [ ] All 16 supported languages produce exactly 1 tag each
+- [ ] Test PASS
+
+**Dependencies**: None (existing scanner already supports 16 langs per research [E-26])
+
+---
+
+### Milestone 2: `/moai mx` flag dispatcher — Priority P0
+
+#### T-SPC002-04: `--full` flag implementation
+
+**REQ traceback**: REQ-SPC-002-013, REQ-SPC-002-003
+
+**AC traceback**: AC-02
+
+**Goal**: Add `--full` flag to `internal/cli/mx.go` that triggers full project rescan + sidecar rebuild + archive sweep.
+
+**Files**:
+- `internal/cli/mx.go` (parent command extension, +~50 LOC)
+- `internal/cli/mx_test.go` (new ~80 LOC)
+
+**Sub-tasks**:
+- Add `BoolVar` for `--full` flag
+- Implement `runMxFull(cmd, silent bool)` helper
+- Walk project tree from `cwd`, scan all supported files via Scanner.ScanDirectory
+- Apply mx.yaml ignore patterns
+- Call `Manager.RebuildFromScan(allTags)` (new method or repurpose UpdateAll)
+- Trigger archive sweep at end
+- Test: `TestMxCmd_FullFlag_RebuildsSidecar` (42-tag fixture)
+- Test: `TestMxCmd_FullFlag_RespectsIgnore`
+- Test: `TestMxCmd_FullFlag_TriggersArchiveSweep` (works with T-SPC002-14)
+
+**Acceptance**:
+- [ ] `--full` produces sidecar with all current tags
+- [ ] Console summary printed (count of tags, files scanned)
+- [ ] Archive sweep triggered (stale entries moved)
+- [ ] 3 sub-tests PASS
+
+**Dependencies**: T-SPC002-08 (mx.yaml ignore wire-up), T-SPC002-14 (archive sweep)
+
+---
+
+#### T-SPC002-05: `--json` flag implementation
+
+**REQ traceback**: REQ-SPC-002-032
+
+**AC traceback**: AC-12
+
+**Goal**: Add `--json` flag that prints current sidecar contents to stdout.
+
+**Files**:
+- `internal/cli/mx.go` (+~20 LOC)
+
+**Sub-tasks**:
+- Add `BoolVar` for `--json`
+- Implement `runMxJsonDump(cmd)`: `Manager.Load()` → `json.MarshalIndent` → `os.Stdout.Write`
+- Handle missing sidecar (output empty `{"schema_version":2,"tags":[]}` + repair suggestion to stderr)
+- Test: `TestMxCmd_JsonFlag_DumpsSidecar`
+- Test: `TestMxCmd_JsonFlag_MissingSidecarOk` (no sidecar → empty schema)
+
+**Acceptance**:
+- [ ] stdout receives valid JSON
+- [ ] Schema version = 2
+- [ ] Exit code 0
+- [ ] 2 sub-tests PASS
+
+**Dependencies**: None
+
+---
+
+#### T-SPC002-06: `--anchor-audit` flag scaffold + wire
+
+**REQ traceback**: REQ-SPC-002-042
+
+**AC traceback**: AC-14
+
+**Goal**: Add `--anchor-audit` flag that lists MXAnchor tags with fan_in < 3.
+
+**Files**:
+- `internal/cli/mx.go` (+~30 LOC)
+- `internal/mx/anchor_audit.go` (new ~80 LOC)
+- `internal/mx/anchor_audit_test.go` (new ~80 LOC)
+
+**Sub-tasks**:
+- Add `BoolVar` for `--anchor-audit`
+- Implement `runMxAnchorAudit(cmd)`:
+  1. Load sidecar via `Manager.Load()`
+  2. Filter to MXAnchor tags
+  3. For each anchor: compute fan_in via SPC-004 `fanin.CountFanIn(anchorID, allTags)`
+  4. Filter fan_in < 3
+  5. Print markdown table to stdout: `| AnchorID | File | Line | FanIn |`
+- Implement `RunAnchorAudit(mgr, threshold)` in `anchor_audit.go`
+- Test: `TestRunAnchorAudit_LowFanInReported`
+- Test: `TestRunAnchorAudit_HighFanInExcluded`
+- Test: `TestMxCmd_AnchorAuditFlag_OutputFormat`
+
+**Acceptance**:
+- [ ] Audit lists only fan_in < 3 anchors
+- [ ] Markdown table format
+- [ ] Exit code 0
+- [ ] 3 sub-tests PASS
+
+**Dependencies**: T-SPC002-04 (mx command structure), SPC-004 fanin.go (already merged)
+
+---
+
+### Milestone 3: silent env + mx.yaml ignore — Priority P1
+
+#### T-SPC002-07: MOAI_MX_HOOK_SILENT env handling
+
+**REQ traceback**: REQ-SPC-002-031
+
+**AC traceback**: AC-11
+
+**Goal**: PostToolUse handler reads `MOAI_MX_HOOK_SILENT=1` and skips `additionalContext` (sidecar still updated, MxTags still emitted).
+
+**Files**:
+- `internal/hook/post_tool_mx.go` (env check in Handle method, +5 LOC)
+- `internal/hook/post_tool_mx_test.go` (+~40 LOC)
+
+**Sub-tasks**:
+- Add `silent := os.Getenv("MOAI_MX_HOOK_SILENT") == "1"` check
+- Conditionally skip formatTagsForContext call
+- Test: `TestPostToolUseHandler_HookSilentEnv`
+- Test: `TestPostToolUseHandler_HookSilentEnv_StillUpdatesSidecar`
+- Test: `TestPostToolUseHandler_HookSilentEnv_StillEmitsMxTagsField`
+
+**Acceptance**:
+- [ ] AdditionalContext empty when silent=1
+- [ ] Sidecar still updated
+- [ ] MxTags structured field still populated
+- [ ] 3 sub-tests PASS
+
+**Dependencies**: T-SPC002-01
+
+---
+
+#### T-SPC002-08: mx.yaml config loader + ignore wire-up
+
+**REQ traceback**: REQ-SPC-002-030
+
+**AC traceback**: AC-10
+
+**Goal**: Create `internal/mx/config.go` to load mx.yaml and provide ignore patterns. Wire into Scanner.
+
+**Files**:
+- `internal/mx/config.go` (new ~80 LOC)
+- `internal/mx/config_test.go` (new ~60 LOC)
+
+**Sub-tasks**:
+- Define `Config` struct (`IgnorePatterns []string`, `HookMaxAdditionalContextBytes int`)
+- Implement `LoadConfig(projectRoot string) (*Config, error)`:
+  - Read `.moai/config/sections/mx.yaml`
+  - Parse YAML, extract `ignore:` and `hook.max_additional_context_bytes`
+  - Return defaults on missing file (graceful)
+- Implement `defaultConfig() *Config`:
+  - Default ignore: `["vendor/**", "node_modules/**", "dist/**", ".git/**", "**/*_generated.go", "**/mock_*.go"]`
+  - Default budget: 4096 bytes
+- Wire into Scanner via `scanner.SetIgnorePatterns(cfg.IgnorePatterns)` at all call sites (PostToolUse handler + `--full` CLI)
+- Test: `TestLoadConfig_FromFile`
+- Test: `TestLoadConfig_MissingFileReturnsDefault`
+- Test: `TestLoadConfig_InvalidYamlReturnsDefault`
+- Test: `TestScanner_RespectsMxYamlIgnore`
+
+**Acceptance**:
+- [ ] mx.yaml ignore patterns honored
+- [ ] Default fallback works
+- [ ] Invalid YAML graceful
+- [ ] 4 sub-tests PASS
+
+**Dependencies**: None
+
+---
+
+### Milestone 4: Scanner correctness fixtures — Priority P1
+
+#### T-SPC002-09: MissingReasonForWarn 3-line lookahead fixture
+
+**REQ traceback**: REQ-SPC-002-006, REQ-SPC-002-040
+
+**AC traceback**: AC-05
+
+**Goal**: Add explicit fixture verifying Scanner emits `MissingReasonForWarn` warning when `@MX:WARN` lacks REASON within 3 lines.
+
+**Files**:
+- `internal/mx/scanner_test.go` (+~50 LOC)
+- (potentially) `internal/mx/scanner.go` (logic refinement if absent, +~10 LOC)
+
+**Sub-tasks**:
+- Verify Scanner already implements 3-line lookahead (research [E-09]); add logic if missing
+- Test: `TestScanner_MissingReasonForWarn_3LineLookahead` (REASON missing → warning emitted)
+- Test: `TestScanner_WarnWithReasonAtLine2_NoWarning` (REASON 2 lines after WARN → no warning)
+- Test: `TestScanner_WarnWithReasonAtLine4_WarningEmitted` (REASON 4 lines after WARN → warning emitted, lookahead is 3)
+
+**Acceptance**:
+- [ ] Warning emission verified for 0/4+ line distance
+- [ ] No warning for 1-3 line distance
+- [ ] 3 sub-tests PASS
+
+**Dependencies**: None (logic already exists per research)
+
+---
+
+#### T-SPC002-10: DuplicateAnchorID refuse-write fixture
+
+**REQ traceback**: REQ-SPC-002-007, REQ-SPC-002-021
+
+**AC traceback**: AC-06
+
+**Goal**: Verify Scanner detects duplicate AnchorID and Manager refuses sidecar write.
+
+**Files**:
+- `internal/mx/scanner_test.go` (+~50 LOC)
+
+**Sub-tasks**:
+- Test: `TestScanner_DuplicateAnchorID_NamesBothFiles` (two files with same AnchorID → error contains both)
+- Test: `TestScanner_DuplicateAnchorID_RefuseWrite` (Manager.Write rejected when scanner has duplicates)
+
+**Acceptance**:
+- [ ] Duplicate AnchorID detected
+- [ ] Both file:line pairs in error message
+- [ ] Manager.Write refused
+- [ ] 2 sub-tests PASS
+
+**Dependencies**: None
+
+---
+
+#### T-SPC002-11: Corrupt sidecar repair suggestion fixture
+
+**REQ traceback**: REQ-SPC-002-022
+
+**AC traceback**: AC-09
+
+**Goal**: Verify Manager.Load handles corrupt JSON gracefully + emits repair suggestion.
+
+**Files**:
+- `internal/mx/sidecar_test.go` (+~40 LOC)
+
+**Sub-tasks**:
+- Test: `TestSidecar_CorruptJSON_ReturnsEmpty` (corrupt file → empty Sidecar)
+- Test: `TestSidecar_CorruptJSON_StderrSuggestion` (capture stderr, assert "WARNING: sidecar corrupt")
+
+**Acceptance**:
+- [ ] Empty sidecar returned (no crash)
+- [ ] Stderr contains repair suggestion
+- [ ] 2 sub-tests PASS
+
+**Dependencies**: None
+
+---
+
+#### T-SPC002-16: HookSpecificOutput mismatch validation
+
+**REQ traceback**: REQ-SPC-002-041
+
+**AC traceback**: AC-13
+
+**Goal**: Verify validator rejects mxTags with wrong hookEventName.
+
+**Files**:
+- `internal/hook/types.go` (+15 LOC for ValidateMxTagsConsistency function)
+- `internal/hook/types_test.go` (+~30 LOC)
+
+**Sub-tasks**:
+- Add `ValidateMxTagsConsistency(output *HookOutput) error`:
+  - If `MxTags != nil && HookEventName != "PostToolUse"` → return ErrHookSpecificOutputMismatch
+- Define `ErrHookSpecificOutputMismatch` sentinel error
+- Test: `TestHookOutput_MxTagsWithPreToolUse_Rejected`
+- Test: `TestHookOutput_MxTagsWithPostToolUse_Accepted`
+- Test: `TestHookOutput_NoMxTags_AnyEventOk`
+
+**Acceptance**:
+- [ ] Validator rejects mismatched events
+- [ ] Validator accepts correct PostToolUse + MxTags combo
+- [ ] 3 sub-tests PASS
+
+**Dependencies**: T-SPC002-02 (MxTags field exists)
+
+---
+
+### Milestone 5: Archive sweep + atomic write verification — Priority P1
+
+#### T-SPC002-12: Atomic write no-partial-reads fixture
+
+**REQ traceback**: REQ-SPC-002-004
+
+**AC traceback**: AC-03
+
+**Goal**: Stress-test concurrent reads during writes, assert no partial reads.
+
+**Files**:
+- `internal/mx/sidecar_test.go` (+~70 LOC)
+
+**Sub-tasks**:
+- Generate 5MB sidecar payload (10K tags)
+- Test: `TestSidecar_AtomicWrite_NoPartialReads` (writer + 1000 readers, 0 partial reads)
+- Run with `-race` flag
+
+**Acceptance**:
+- [ ] 0 partial reads
+- [ ] No data race
+- [ ] PASS under `-race -count=10`
+
+**Dependencies**: None
+
+---
+
+#### T-SPC002-13: 7-day stale tag preservation fixture
+
+**REQ traceback**: REQ-SPC-002-014
+
+**AC traceback**: AC-07
+
+**Goal**: Verify stale tag (LastSeenAt = 6 days ago, missing from current scan) is preserved in sidecar.
+
+**Files**:
+- `internal/mx/sidecar_test.go` (+~50 LOC)
+
+**Sub-tasks**:
+- Test: `TestSidecar_StaleNotYetArchived_7Days`
+- Verify LastSeenAt timestamp not mutated
+
+**Acceptance**:
+- [ ] Tag remains in sidecar
+- [ ] LastSeenAt unchanged
+- [ ] PASS
+
+**Dependencies**: None
+
+---
+
+#### T-SPC002-14: 8-day stale archive sweep fixture
+
+**REQ traceback**: REQ-SPC-002-020
+
+**AC traceback**: AC-08
+
+**Goal**: Verify 8-day stale tag is moved to mx-archive.json on full scan.
+
+**Files**:
+- `internal/mx/sidecar_test.go` (+~60 LOC)
+- `internal/mx/sidecar.go` (archive sweep helper, +~30 LOC)
+
+**Sub-tasks**:
+- Implement `archiveSweep()` helper in sidecar.go (called from RebuildFromScan path)
+- Logic: for each tag in current sidecar, if `IsStale()` AND not in current scan → move to mx-archive.json
+- Test: `TestSidecar_StaleArchived_8Days`
+- Test: `TestSidecar_ArchiveSweep_TwoPhase` (verify archive write succeeds before sidecar rewrite — partial-failure idempotency)
+
+**Acceptance**:
+- [ ] Stale tag removed from sidecar
+- [ ] Stale tag appended to archive
+- [ ] Two-phase write (archive first, sidecar second) verified
+- [ ] 2 sub-tests PASS
+
+**Dependencies**: T-SPC002-04 (--full path triggers sweep)
+
+---
+
+### Milestone 6: Verification + audit — Priority P0
+
+#### T-SPC002-17: Full test suite
+
+**REQ traceback**: (cross-cutting)
+
+**Goal**: `go test -race -count=1 ./...` PASS.
+
+**Acceptance**: 0 regressions; existing SPC-004 tests still PASS.
+
+**Dependencies**: M1-M5 complete.
+
+---
+
+#### T-SPC002-18: Linter
+
+**Goal**: `golangci-lint run` clean.
+
+---
+
+#### T-SPC002-19: Build verification
+
+**Goal**: `make build` exits 0; `internal/template/embedded.go` regenerated correctly. `diff -r .claude/ internal/template/templates/.claude/` shows 0 changes (no template assets touched by this SPEC).
+
+---
+
+#### T-SPC002-20: CHANGELOG
+
+**Goal**: Add 4 bullet entries to CHANGELOG.md Unreleased section per plan §M6-T20.
+
+---
+
+#### T-SPC002-21: @MX tags
+
+**Goal**: Apply 6 @MX tags per plan §6 (1 ANCHOR + 2 WARN + 3 NOTE).
+
+---
+
+#### T-SPC002-22: End-to-end smoke test
+
+**Goal**: Manual verification — open `claude` session, edit a Go file via Edit tool, confirm:
+1. PostToolUse hook fires
+2. stdout contains `mxTags` JSON field
+3. `.moai/state/mx-index.json` is updated atomically
+4. `MOAI_MX_HOOK_SILENT=1` correctly empties additionalContext
+
+**Acceptance**: All 4 observations confirmed.
+
+**Dependencies**: M1-M5 + T-SPC002-17 PASS.
+
+---
+
+## 3. Task Dependency Graph
+
+```
+T-02 (MxTags field)
+  ↓
+T-01 (post_tool_mx.go handler) ← T-08 (config loader)
+  ↓                                ↓
+T-03 (formatTagsForContext)    T-15 (16-lang fixture)
+  ↓
+T-07 (MOAI_MX_HOOK_SILENT)     ↓
+                                T-04 (--full flag) ← T-14 (archive sweep)
+                                  ↓
+                                T-05 (--json flag)
+                                T-06 (--anchor-audit)
+
+T-09 (MissingReasonForWarn)
+T-10 (DuplicateAnchorID)
+T-11 (corrupt sidecar)
+T-12 (atomic write race)
+T-13 (7-day stale preservation)
+T-16 (HookSpecificOutputMismatch) ← T-02
+
+T-17 (full test) → T-18 (lint) → T-19 (build) → T-20 (CHANGELOG) → T-21 (MX tags) → T-22 (smoke test)
+```
+
+Parallelizable groups:
+- M1 tasks (T-01..03, T-15): mostly independent after T-02
+- M4 tasks (T-09..11, T-16): all independent (different test files)
+- M5 tasks (T-12..14): independent
+
+---
+
+## 4. Dependency Resolution
+
+### 4.1 SPC-004 status (already merged)
+
+PR #746 (commit `68795dbe3`) merged 2026-04-30. `internal/mx/resolver_query.go`, `fanin.go`, `danger_category.go`, `spec_association.go` exist on main. Tasks T-SPC002-06 (anchor-audit) reuse `fanin.CountFanIn` from this code.
+
+If somehow the SPC-004 code was reverted between plan-PR merge and run-PR start, T-SPC002-06 fallback: implement minimal CountFanIn locally in anchor_audit.go (count of MXAnchor tags referencing the same AnchorID — simple O(n²)). Plan binding: this fallback is documented but NOT expected since SPC-004 is in main HEAD `fcb486c87`.
+
+### 4.2 Wave 3 PR #741 status
+
+Commit `3f0933550` (2026-04-XX) merged tag.go, scanner.go, sidecar.go, comment_prefixes.go, resolver.go. These are the foundation of this SPEC and assumed present.
+
+If somehow reverted: full re-implementation required (>3,000 LOC). Recovery path: file-level re-port from PR #741 diff + this SPEC's add-on.
+
+### 4.3 SPEC-V3R2-RT-001 status
+
+`internal/hook/types.go` already implements RT-001 protocol (research [E-14]). T-SPC002-02 extends `HookSpecificOutput` with one new omitempty field — backward-compatible.
+
+### 4.4 SPEC-V3R2-WF-005 (16-language enum)
+
+Out-of-scope but advisory. `internal/mx/comment_prefixes.go` and `internal/hook/file_changed.go:supportedExtensions` have minor drift (research [E-27]). T-SPC002-15 16-lang fixture catches future divergence; integration into a single SoT is deferred to WF-005.
+
+---
+
+## 5. Effort Estimates (priority labels only, no time)
+
+Per `.claude/rules/moai/core/agent-common-protocol.md` § Time Estimation HARD rule, all tasks use priority labels; no time estimates.
+
+| Task category | Priority | Notes |
+|---|---|---|
+| M1, M2, M6 (core path) | P0 | Critical — handler + CLI + verification |
+| M3, M4 (correctness fixtures) | P1 | Required but defer-acceptable |
+| M5 (archive + race) | P1 | Required for spec §7 budget assertion |
+| (none) | P2 | No P2 tasks in this SPEC |
+
+---
+
+## 6. Test Coverage Goal
+
+Per `.moai/config/sections/quality.yaml` `coverage_target: 85`:
+
+| Package | Pre-SPEC LOC | Post-SPEC LOC | Coverage target |
+|---|---|---|---|
+| `internal/hook/` | ~9000 | ~9400 | ≥ 85% (mostly new handler test coverage) |
+| `internal/mx/` | ~3000 | ~3300 | ≥ 85% (new config + anchor_audit) |
+| `internal/cli/` | ~very large | +~150 | ≥ 85% on mx.go new flag dispatcher |
+
+---
+
+## 7. Risk-based Task Prioritization
+
+| Risk | Mitigation task |
+|---|---|
+| PostToolUse handler crashes Claude session | T-SPC002-01 graceful no-op + T-SPC002-17 race detector |
+| Sidecar drift from source truth | T-SPC002-04 (--full rebuild) + T-SPC002-22 smoke test |
+| Token budget overflow | T-SPC002-03 (formatTagsForContext budget cap) + T-SPC002-07 (silent env) |
+| Atomic write race | T-SPC002-12 (concurrent fixture, -race -count=10) |
+| Stale tag never archived | T-SPC002-14 (8-day fixture) |
+| Cross-language fixture drift | T-SPC002-15 (16-lang fixture as regression guard) |
+| HookSpecificOutput mismatch | T-SPC002-16 (validator + sentinel error) |
+
+---
+
+## 8. Wave-Split Assessment
+
+Per `feedback_large_spec_wave_split.md`: SPECs with 30+ tasks should be wave-split.
+
+This SPEC has **22 tasks**. Below threshold → no wave-split needed. Single delegation prompt per task during Run phase is acceptable (~1.5KB each).
+
+---
+
+End of tasks.
+
+Version: 0.1.0
+Status: Tasks artifact for SPEC-V3R2-SPC-002


### PR DESCRIPTION
## Summary

v3 Master Plan **Sprint/Wave 14 Phase 2 (1/2)**. Plan-in-main per `spec-workflow.md` Step 1 + doctrine #822.

Authors 6 plan artifacts for SPEC-V3R2-SPC-002 (@MX TAG v2 — sidecar index + PostToolUse hook JSON integration). 15 ACs / 22 tasks / EARS coverage 22 unique REQs traced 1:1 to ACs.

## Reframing — gap closure (not from scratch)

Wave 3 prior implementation reframes scope:
- `internal/mx/` package (tag.go, scanner.go, sidecar.go, comment_prefixes.go, resolver.go) shipped via PR #741 commit `3f0933550`
- SPC-004 PR #746 (`68795dbe3`) added resolver_query.go / fanin.go / danger_category.go / spec_association.go

Plan §1.2.1 reframes M1-M5 as **8 격차 G-01..G-08** for run-phase implementation. Sync-phase HISTORY entry will reconcile spec.md §1 "introduces" → "completes". Same pattern as Phase 1 ORC-004 (LR-05/LR-09 already in main → run-phase scope 축소).

## Plan structure

6 milestones (P0/P1):
- M1 PostToolUse handler + types — P0
- M2 `/moai mx` flag dispatcher (--full / --index-only / --json / --anchor-audit) — P0
- M3 silent env (`MOAI_MX_HOOK_SILENT`) + mx.yaml ignore — P1
- M4 Scanner correctness fixtures (16-language) — P1
- M5 Archive sweep + atomic verify — P1
- M6 Verification — P0

22 tasks (T-SPC002-01..22), under wave-split threshold (30+).

## Open questions (for plan-auditor / run-phase)

- **Q1** Reframing acceptance — gap-closure vs from-scratch. Plan §1.2.1 chooses gap-closure with sync-phase reconciliation.
- **Q2** `MxTags` field placement — chose structured `HookSpecificOutput.MxTags []mx.Tag` (omitempty) over `additionalContext` JSON embed for RT-001 protocol consistency.
- **Q3** `internal/hook/file_changed.go:supportedExtensions` vs `internal/mx/comment_prefixes.go` enum drift — defer integration to SPEC-V3R2-WF-005 (16-language SoT).
- **Q4** `schema_version: 2` preservation contract — all new fields must be omitempty; no semantic changes to existing fields. Run-phase rollback path documented in plan §9.4.

## Test plan

- [ ] CI required gates green (Lint / Test 3-OS / Build / CodeQL)
- [ ] plan-auditor verdict (run-phase 진입 시 자동 트리거)
- [ ] Run-phase will validate 8 G-### against existing internal/mx/ implementation

## Dependencies

- Blocks: SPEC-V3R2-SPC-004 (resolver consumes sidecar)
- Blocked by: SPEC-V3R2-CON-001 (zone registry, merged), SPEC-V3R2-RT-001 (JSON hook protocol, merged)

🗿 MoAI <email@mo.ai.kr>