### PR TITLE
plan(spec): SPEC-V3R2-SPC-004 — @MX anchor resolver query API

### DIFF
--- a/.moai/specs/SPEC-V3R2-SPC-004/acceptance.md
+++ b/.moai/specs/SPEC-V3R2-SPC-004/acceptance.md
@@ -1,0 +1,518 @@
+# SPEC-V3R2-SPC-004 Acceptance Criteria
+
+> Detailed Given-When-Then scenarios and verification evidence for **@MX anchor resolver (query by SPEC ID, fan_in, danger category)**.
+> Companion to `spec.md` v0.1.0, `plan.md` v0.1.0, `research.md` v0.1.0, `tasks.md` v0.1.0.
+
+## HISTORY
+
+| Version | Date       | Author                                         | Description |
+|---------|------------|------------------------------------------------|-------------|
+| 0.1.0   | 2026-05-10 | manager-spec (Plan workflow Phase 1B)          | Initial acceptance.md. 15 AC scenarios mapped 1:1 to spec.md §6 AC-SPC-004-01..15. Each AC includes Given/When/Then + measurable evidence + REQ traceback + tasks.md task IDs. Performance budgets: <100ms 1K tags / <2s 50 anchors with LSP. Note: 15 ACs are **largely covered by existing tests** in `internal/mx/resolver_query_test.go` and `internal/cli/mx_query_test.go` (PR #746 commit `68795dbe3`); this artifact preserves their G/W/T form and adds the gap-closure (G-01..G-08) verification fixtures. |
+
+---
+
+## 1. AC Coverage Map
+
+| AC ID | Spec §6 statement | Mapped REQs | Mapped tasks | Existing test? | Evidence type |
+|---|---|---|---|---|---|
+| AC-SPC-004-01 | `--spec X --kind anchor` returns only ANCHOR for SPEC X | REQ-001, REQ-006, REQ-010 | T-SPC004-04, T-SPC004-05, T-SPC004-12 | YES (`TestResolver_AC1_SpecAndKindFilter`) | Resolver Go API + CLI assertion |
+| AC-SPC-004-02 | `--fan-in-min 3 --kind anchor` returns 3-tier subset | REQ-011 | T-SPC004-01, T-SPC004-02 | YES (`TestResolver_AC2_FanInMinFilter`) | LSP + textual counter |
+| AC-SPC-004-03 | `--danger concurrency` matches WARN with REASON pattern | REQ-012 | T-SPC004-03 | YES (`TestResolver_AC3_DangerCategoryFilter`) | DangerCategoryMatcher |
+| AC-SPC-004-04 | sidecar absent → SidecarUnavailable + suggest `/moai mx --full` | REQ-013 | T-SPC004-09 | PARTIAL (covered in CLI test; stderr format fixture added) | stderr capture |
+| AC-SPC-004-05 | `--format json` (default) → valid JSON array per REQ-005 schema | REQ-004, REQ-005 | T-SPC004-15 | YES (`TestResolver_AC5_JSONOutputSchema`) | JSON schema validation |
+| AC-SPC-004-06 | `--format table` → human-readable columnar | REQ-004 | (existing) | YES (`TestMxQueryCmd_AC6_TableFormat`) | stdout column check |
+| AC-SPC-004-07 | no LSP for Python → results with `fan_in_method: "textual"` annotation | REQ-020 | T-SPC004-01, T-SPC004-02 | YES (`TestResolver_AC7_TextualFallbackAnnotation`) | TagResult.FanInMethod |
+| AC-SPC-004-08 | 10K tags + no `--limit` → at most 100 entries + TruncationNotice | REQ-007, REQ-021 | T-SPC004-13 | YES (`TestResolver_AC8_PaginationAndTruncation`) | result count + TruncationNotice |
+| AC-SPC-004-09 | `MOAI_MX_QUERY_STRICT=1` + no LSP → exit non-zero + LSPRequired | REQ-030 | T-SPC004-02 | PARTIAL (sentinel error in tests; LSP-detect path 신규) | exit code + error type |
+| AC-SPC-004-10 | `--format markdown` → markdown table | REQ-031 | (existing) | YES (`TestMxQueryCmd_AC10_MarkdownFormat`) | stdout markdown structure |
+| AC-SPC-004-11 | ANCHOR in test fixture → references from other test files excluded | REQ-040 | T-SPC004-07, T-SPC004-08 | YES (`TestResolver_AC11_TestFileExclusion`) | fan_in count diff |
+| AC-SPC-004-12 | zero match → `[]` exit 0 | REQ-041 | (existing) | YES (`TestResolver_AC12_EmptyResult`) | stdout + exit code |
+| AC-SPC-004-13 | invalid `--kind nonexistent` → exit 2 + InvalidQuery | REQ-041 | T-SPC004-06 | YES (`TestResolver_AC13_InvalidQuery`) | exit code + stderr |
+| AC-SPC-004-14 | combined `--spec X --kind anchor --fan-in-min 3` AND-composed | REQ-042 | (existing) | YES (`TestResolver_AC14_CombinedFilters`) | filter composition |
+| AC-SPC-004-15 | tag body `ANCHOR for SPEC-AUTH-001` → `spec_associations` includes "SPEC-AUTH-001" | REQ-006 | T-SPC004-04, T-SPC004-05 | YES (`TestResolver_AC15_BodyBasedSpecAssociation`) | SpecAssociator regex |
+
+→ All 15 ACs traceable. 11 of 15 already covered by PR #746 existing tests (research §2.2 + grep evidence); 4 are PARTIAL/NEW (AC-04 stderr fixture, AC-09 LSP-detect, AC-11 test_paths glob, AC-13 danger 분기 추가).
+
+---
+
+## 2. Acceptance Criteria
+
+### AC-SPC-004-01: `--spec X --kind anchor` returns only ANCHOR tags for SPEC X
+
+**REQ traceback**: REQ-SPC-004-001 (CLI subcommand), REQ-SPC-004-006 (SPEC association), REQ-SPC-004-010 (Event-driven combined filter)
+
+**Mapped tasks**: T-SPC004-04 (LoadSpecModules), T-SPC004-05 (SpecAssociator wire), T-SPC004-12 (CLI wire)
+
+**Given** a sidecar at `.moai/state/mx-index.json` containing 20 tags distributed across 2 SPECs: 10 tags associated with `SPEC-X-001` (5 ANCHOR + 5 NOTE) and 10 tags with `SPEC-Y-002` (5 ANCHOR + 5 WARN)
+**And** SPEC-X-001's `module:` frontmatter lists `internal/x/`
+**And** SPEC-Y-002's `module:` frontmatter lists `internal/y/`
+**And** all SPEC-X tags' file paths fall under `internal/x/`; all SPEC-Y tags under `internal/y/`
+**When** an operator runs `moai mx query --spec SPEC-X-001 --kind anchor --format json`
+**Then** stdout MUST contain a JSON array with exactly 5 entries
+**And** each entry MUST have `kind == "ANCHOR"`
+**And** each entry's `spec_associations` MUST contain `"SPEC-X-001"`
+**And** no entry MUST have `spec_associations` containing `"SPEC-Y-002"`
+**And** exit status MUST be 0
+
+**Verification command**:
+```bash
+cd /tmp/proj
+moai mx query --spec SPEC-X-001 --kind anchor --format json | jq 'length'
+# Expected: 5
+moai mx query --spec SPEC-X-001 --kind anchor --format json | jq '.[].kind' | sort -u
+# Expected: "ANCHOR"
+```
+
+**Test fixture**: `internal/mx/resolver_query_test.go` `TestResolver_AC1_SpecAndKindFilter` (already exists per `grep "AC-SPC-004-01"` at line 54). Fixture builds 20-tag sidecar under `t.TempDir()`, instantiates `SpecAssociator` with module map `{"SPEC-X-001": ["internal/x/"], "SPEC-Y-002": ["internal/y/"]}`, asserts result.
+
+**Expected**: PASS (existing fixture covers Resolver Go API; T-SPC004-04 + T-SPC004-05 add CLI wire-up so end-to-end CLI test PASS).
+
+---
+
+### AC-SPC-004-02: `--fan-in-min 3 --kind anchor` returns subset
+
+**REQ traceback**: REQ-SPC-004-011 (Event-driven fan-in filter)
+
+**Mapped tasks**: T-SPC004-01 (LSPFanInCounter struct), T-SPC004-02 (LSPFanInCounter tests)
+
+**Given** a sidecar with 5 ANCHOR tags whose computed fan_in values are 1, 2, 3, 5, 10 (computed via either LSP or textual counter)
+**When** an operator runs `moai mx query --fan-in-min 3 --kind anchor`
+**Then** the result MUST contain exactly 3 entries (fan_in 3, 5, 10)
+**And** the entries MUST be ordered by file path (consistent ordering)
+**And** each entry's `fan_in` field MUST be ≥ 3
+**And** each entry's `fan_in_method` MUST be either `"lsp"` or `"textual"`
+
+**Verification command**:
+```bash
+moai mx query --fan-in-min 3 --kind anchor --format json | jq 'length'
+# Expected: 3
+moai mx query --fan-in-min 3 --kind anchor --format json | jq '.[].fan_in' | sort -n
+# Expected: 3 5 10
+```
+
+**Test fixture**: `internal/mx/resolver_query_test.go` `TestResolver_AC2_FanInMinFilter` (already exists per `grep "AC-SPC-004-02"` at line 106). T-SPC004-01 신규: `internal/mx/fanin_lsp_test.go` adds LSP mock for the same fan_in values.
+
+**Expected**: PASS.
+
+---
+
+### AC-SPC-004-03: `--danger concurrency` matches WARN with REASON pattern
+
+**REQ traceback**: REQ-SPC-004-012 (danger category)
+
+**Mapped tasks**: T-SPC004-03 (LoadDangerConfig + user wire)
+
+**Given** the sidecar contains a WARN tag with `Reason == "goroutine leak on panic"`
+**And** `mx.yaml` `danger_categories:` either is unset (DefaultDangerCategories used) OR maps `"goroutine leak"` → `concurrency`
+**When** an operator runs `moai mx query --danger concurrency`
+**Then** the result MUST include that WARN tag
+**And** the entry's `danger_category` MUST be `"concurrency"`
+
+**Verification command**:
+```bash
+moai mx query --danger concurrency --format json | jq '.[] | select(.danger_category == "concurrency")' | jq -s 'length'
+# Expected: ≥ 1
+```
+
+**Test fixture**: `internal/mx/resolver_query_test.go` `TestResolver_AC3_DangerCategoryFilter` (already exists at line 145). T-SPC004-03 신규: `TestLoadDangerConfig_UserCustomCategories` verifies user-defined patterns.
+
+**Expected**: PASS.
+
+---
+
+### AC-SPC-004-04: sidecar absent → SidecarUnavailable + suggest `/moai mx --full`
+
+**REQ traceback**: REQ-SPC-004-013 (Event-driven sidecar absent)
+
+**Mapped tasks**: T-SPC004-09 (stderr format fixture)
+
+**Given** `.moai/state/mx-index.json` does not exist (project freshly initialized or sidecar deleted)
+**When** an operator runs `moai mx query --kind anchor`
+**Then** the command MUST exit with non-zero status (current implementation: exit 1 from cobra RunE error)
+**And** stderr MUST contain the substring `SidecarUnavailable`
+**And** stderr MUST contain the substring `/moai mx --full`
+
+**Verification command**:
+```bash
+rm -f /tmp/proj/.moai/state/mx-index.json
+moai mx query --kind anchor 2>&1 1>/dev/null | grep -E "SidecarUnavailable.*moai mx --full"
+# Expected: 1 match line
+```
+
+**Test fixture**: `internal/cli/mx_query_test.go` `TestMxQueryCmd_AC4_SidecarUnavailable` (already exists at line 89). T-SPC004-09 신규: explicit `TestSidecarUnavailable_StderrFormat` asserts both substrings present in single stderr capture.
+
+**Expected**: PASS.
+
+---
+
+### AC-SPC-004-05: `--format json` (default) → valid JSON array per REQ-005 schema
+
+**REQ traceback**: REQ-SPC-004-004 (default format), REQ-SPC-004-005 (JSON schema 11 fields)
+
+**Mapped tasks**: T-SPC004-15 (16-language sweep verifies schema)
+
+**Given** the sidecar contains valid tags
+**When** an operator runs `moai mx query` (no `--format` flag, defaults to JSON)
+**Then** stdout MUST be a valid JSON document (parseable by `jq`)
+**And** the document MUST be a JSON array (top-level `[`...`]`)
+**And** each array entry MUST contain at minimum the fields: `kind`, `file`, `line`, `body`, `created_by`, `last_seen_at`, `spec_associations`
+**And** ANCHOR entries MAY have `fan_in` and `fan_in_method`
+**And** WARN entries MAY have `danger_category`
+**And** all entries with `reason` populated MUST surface it; absent → field absent (omitempty)
+
+**Verification command**:
+```bash
+moai mx query | jq 'type'
+# Expected: "array"
+moai mx query | jq '.[0] | keys' | jq 'sort'
+# Expected: array containing "body", "created_by", "file", "kind", "last_seen_at", "line", "spec_associations"
+```
+
+**Test fixture**: `internal/mx/resolver_query_test.go` `TestResolver_AC5_JSONOutputSchema` (already exists at line 212).
+
+**Expected**: PASS.
+
+---
+
+### AC-SPC-004-06: `--format table` → human-readable columnar
+
+**REQ traceback**: REQ-SPC-004-004 (table format)
+
+**Mapped tasks**: (existing — covered by `TestResolver_AC6_TableFormat`)
+
+**Given** the sidecar contains tags
+**When** an operator runs `moai mx query --format table`
+**Then** stdout MUST contain a header line with columns: `KIND`, `FILE`, `LINE`, `BODY`
+**And** stdout MUST contain a separator line (dashes)
+**And** stdout MUST contain at least one data row
+**And** each row MUST be space-padded to align columns
+
+**Verification command**:
+```bash
+moai mx query --format table | head -3
+# Expected first line containing "KIND" and "FILE"
+moai mx query --format table | grep -c "^-"
+# Expected: ≥ 1 (separator line)
+```
+
+**Test fixture**: `internal/mx/resolver_query_test.go` `TestResolver_AC6_TableFormat` (already exists at line 155 + line 507 secondary).
+
+**Expected**: PASS.
+
+---
+
+### AC-SPC-004-07: no LSP for Python → `fan_in_method: "textual"` annotation
+
+**REQ traceback**: REQ-SPC-004-020 (State-driven LSP unavailable)
+
+**Mapped tasks**: T-SPC004-01 (LSPFanInCounter), T-SPC004-02 (LSPFanInCounter tests with no-LSP path)
+
+**Given** a Python project with `@MX:ANCHOR py-anchor-001` in a `.py` file
+**And** no Python LSP server (pylsp / pyright) is running on the host
+**And** `MOAI_MX_QUERY_STRICT` is unset (or `"0"`)
+**When** an operator runs `moai mx query --fan-in-min 1 --file-prefix internal/py/ --format json`
+**Then** the result MUST contain ANCHOR entries from `internal/py/`
+**And** each entry's `fan_in_method` MUST be `"textual"` (not `"lsp"`)
+**And** exit status MUST be 0 (graceful fallback)
+
+**Verification command**:
+```bash
+moai mx query --fan-in-min 1 --file-prefix internal/py/ --format json | jq '.[].fan_in_method' | sort -u
+# Expected: "textual"
+```
+
+**Test fixture**: `internal/mx/resolver_query_test.go` `TestResolver_AC7_TextualFallbackAnnotation` (already exists at line 285). T-SPC004-01 + T-SPC004-02 신규: `TestLSPFanInCounter_NoSymbolMatch` verifies fallback behavior with mock client returning empty workspace/symbol response.
+
+**Expected**: PASS.
+
+---
+
+### AC-SPC-004-08: 10K tags + no `--limit` → at most 100 entries + TruncationNotice
+
+**REQ traceback**: REQ-SPC-004-007 (default limit 100), REQ-SPC-004-021 (TruncationNotice header)
+
+**Mapped tasks**: T-SPC004-13 (benchmark verifies pagination)
+
+**Given** the sidecar contains exactly 10,000 tags (any kinds)
+**When** an operator runs `moai mx query` (no `--limit` flag)
+**Then** stdout MUST contain a JSON array with exactly 100 entries (default limit)
+**And** stderr MUST contain the substring `TruncationNotice`
+**And** stderr MUST report the total count (10000) and truncated count (100)
+**And** exit status MUST be 0
+
+**Verification command**:
+```bash
+# Generate 10K-tag sidecar via test helper
+moai mx query | jq 'length'
+# Expected: 100
+moai mx query 2>&1 1>/dev/null | grep -c "TruncationNotice"
+# Expected: 1
+```
+
+**Test fixture**: `internal/mx/resolver_query_test.go` `TestResolver_AC8_PaginationAndTruncation` (already exists at line 254 + line 643 secondary). T-SPC004-13 신규: benchmark `BenchmarkResolver_Resolve_1KTags` measures perf at limit boundary.
+
+**Expected**: PASS.
+
+---
+
+### AC-SPC-004-09: `MOAI_MX_QUERY_STRICT=1` + no LSP → exit non-zero + LSPRequired
+
+**REQ traceback**: REQ-SPC-004-030 (Optional strict mode)
+
+**Mapped tasks**: T-SPC004-02 (LSP-detect path)
+
+**Given** `MOAI_MX_QUERY_STRICT=1` env var is set
+**And** no LSP server is running for the target language(s)
+**When** an operator runs `moai mx query --fan-in-min 3 --kind anchor`
+**Then** the command MUST exit with non-zero status
+**And** stderr MUST contain the substring `LSPRequired` (case-sensitive)
+**And** the error MUST mention the language (or `"any"` if multi-language project)
+
+**Verification command**:
+```bash
+MOAI_MX_QUERY_STRICT=1 moai mx query --fan-in-min 3 --kind anchor; echo $?
+# Expected: non-zero exit code
+MOAI_MX_QUERY_STRICT=1 moai mx query --fan-in-min 3 --kind anchor 2>&1 | grep -c LSPRequired
+# Expected: ≥ 1
+```
+
+**Test fixture**: `internal/mx/resolver_query_test.go` `TestResolver_AC9_StrictModeNoLSP` (already exists at line 314). T-SPC004-02 신규: `TestLSPFanInCounter_StrictModeUnavailable` adds explicit availability-check fixture (replaces current unconditional `LSPRequired` return).
+
+**Expected**: PASS.
+
+---
+
+### AC-SPC-004-10: `--format markdown` → markdown table
+
+**REQ traceback**: REQ-SPC-004-031 (Optional markdown format)
+
+**Mapped tasks**: (existing — covered by `TestResolver_AC10_MarkdownFormat`)
+
+**Given** the sidecar contains tags
+**When** an operator runs `moai mx query --format markdown`
+**Then** stdout MUST contain a markdown table header line `| Kind | File | Line | Body | FanIn | Danger | SPECs |`
+**And** stdout MUST contain a markdown separator line `|------|...`
+**And** stdout MUST contain ≥1 data row formatted as `| ... |`
+**And** if TruncationNotice applies, stdout MUST start with a blockquote `> **TruncationNotice**: showing N of M total results.`
+
+**Verification command**:
+```bash
+moai mx query --format markdown | grep -E "^\| Kind \| File "
+# Expected: 1 match
+```
+
+**Test fixture**: `internal/mx/resolver_query_test.go` `TestResolver_AC10_MarkdownFormat` (already exists at line 189 + line 485 secondary).
+
+**Expected**: PASS.
+
+---
+
+### AC-SPC-004-11: ANCHOR in test fixture → references from other test files excluded
+
+**REQ traceback**: REQ-SPC-004-040 (Complex test exclusion)
+
+**Mapped tasks**: T-SPC004-07 (isTestFile glob), T-SPC004-08 (test_paths user wire)
+
+**Given** an ANCHOR `auth-handler-anchor-001` in `internal/auth/handler.go` line 42
+**And** the same anchor_id appears in `internal/auth/handler_test.go` (3 references) and `tests/integration/auth_test.go` (2 references) and `internal/auth/other.go` (1 reference)
+**And** `mx.yaml` either has default `test_paths` OR sets `test_paths: ["**/integration/**"]`
+**When** an operator runs `moai mx query --spec ... --kind anchor --fan-in-min 1` (no `--include-tests`)
+**Then** the result for `auth-handler-anchor-001` MUST have `fan_in == 1` (only `other.go` reference; both test files excluded)
+**When** the same operator runs with `--include-tests`
+**Then** the result MUST have `fan_in == 6` (all references included)
+
+**Verification command**:
+```bash
+moai mx query --kind anchor --fan-in-min 1 --format json | jq '.[] | select(.anchor_id == "auth-handler-anchor-001") | .fan_in'
+# Expected: 1
+moai mx query --kind anchor --fan-in-min 1 --include-tests --format json | jq '.[] | select(.anchor_id == "auth-handler-anchor-001") | .fan_in'
+# Expected: 6
+```
+
+**Test fixture**: `internal/mx/resolver_query_test.go` `TestResolver_AC11_TestFileExclusion` (already exists at line 342). T-SPC004-07 + T-SPC004-08 신규: `TestIsTestFile_UserPattern_IntegrationDir` + `TestTextualFanInCounter_RespectsUserTestPaths` verify user glob wire-up.
+
+**Expected**: PASS.
+
+---
+
+### AC-SPC-004-12: zero match → `[]` exit 0
+
+**REQ traceback**: REQ-SPC-004-041 (Complex empty result)
+
+**Mapped tasks**: (existing)
+
+**Given** the sidecar exists but contains no ANCHOR tags
+**When** an operator runs `moai mx query --kind anchor`
+**Then** stdout MUST be the literal string `[]\n` (or `[]` followed by newline)
+**And** exit status MUST be 0
+**And** stderr MUST be empty (or only whitespace)
+
+**Verification command**:
+```bash
+moai mx query --kind anchor | tr -d '\n'; echo
+# Expected: []
+moai mx query --kind anchor; echo "exit=$?"
+# Expected: exit=0
+```
+
+**Test fixture**: `internal/mx/resolver_query_test.go` `TestResolver_AC12_EmptyResult` (already exists at line 370).
+
+**Expected**: PASS.
+
+---
+
+### AC-SPC-004-13: invalid `--kind nonexistent` → exit 2 + InvalidQuery
+
+**REQ traceback**: REQ-SPC-004-041 (Complex invalid filter)
+
+**Mapped tasks**: T-SPC004-06 (validateQuery danger 분기 추가; danger 검증도 같은 경로)
+
+**Given** the operator passes an invalid value to a typed flag (e.g. `--kind frobnicate` or, post-G-02, `--danger frobnicate`)
+**When** an operator runs `moai mx query --kind frobnicate`
+**Then** the command MUST exit with status 2 (per spec §5.5 REQ-041)
+**And** stderr MUST contain the substring `InvalidQuery`
+**And** stderr MUST mention the offending field name and value
+**And** stderr MUST list the allowed values for that field
+
+**Verification command**:
+```bash
+moai mx query --kind frobnicate; echo $?
+# Expected exit: 2
+moai mx query --kind frobnicate 2>&1 | grep -E "InvalidQuery.*kind.*frobnicate"
+# Expected: 1 match
+moai mx query --kind frobnicate 2>&1 | grep -E "allowed.*note.*warn.*anchor"
+# Expected: 1 match
+```
+
+**Test fixture**: `internal/mx/resolver_query_test.go` `TestResolver_AC13_InvalidQuery_Kind` (already exists at line 674) + `internal/cli/mx_query_test.go` `TestMxQueryCmd_AC13_InvalidKind` (line 66). T-SPC004-06 신규: `TestValidateQuery_UnknownDanger_InvalidQueryError` extends to danger field.
+
+**Note**: Current CLI implementation may exit with 1 (cobra RunE non-nil error). Spec §5.5 REQ-041 requires exit 2; T-SPC004-06 verifies this. Discrepancy: existing test verifies error type but not exit code 2 specifically — gap-closure verifies exit code.
+
+**Expected**: PASS (after T-SPC004-06 ensures exit code 2 vs existing exit code 1).
+
+---
+
+### AC-SPC-004-14: combined filters AND-composed
+
+**REQ traceback**: REQ-SPC-004-042 (Complex multi-filter AND)
+
+**Mapped tasks**: (existing)
+
+**Given** the sidecar contains tags such that:
+- 8 ANCHOR tags total
+- 5 of those are associated with `SPEC-X-001`
+- 3 of those 5 have fan_in ≥ 3
+**When** an operator runs `moai mx query --spec SPEC-X-001 --kind anchor --fan-in-min 3`
+**Then** the result MUST contain exactly 3 entries
+**And** every entry MUST satisfy ALL three filters:
+- `kind == "ANCHOR"`
+- `spec_associations` contains `"SPEC-X-001"`
+- `fan_in >= 3`
+
+**Verification command**:
+```bash
+moai mx query --spec SPEC-X-001 --kind anchor --fan-in-min 3 --format json | jq 'length'
+# Expected: 3
+moai mx query --spec SPEC-X-001 --kind anchor --fan-in-min 3 --format json | jq '.[] | (.kind == "ANCHOR" and (.spec_associations | index("SPEC-X-001")) and (.fan_in >= 3))' | sort -u
+# Expected: true
+```
+
+**Test fixture**: `internal/mx/resolver_query_test.go` `TestResolver_AC14_CombinedFilters` (already exists at line 400).
+
+**Expected**: PASS.
+
+---
+
+### AC-SPC-004-15: tag body `ANCHOR for SPEC-AUTH-001` → spec_associations includes "SPEC-AUTH-001"
+
+**REQ traceback**: REQ-SPC-004-006 (b) (body-based SPEC association)
+
+**Mapped tasks**: T-SPC004-04, T-SPC004-05 (LoadSpecModules + SpecAssociator wire); 16-language sweep T-SPC004-15
+
+**Given** a tag with `Body == "ANCHOR for SPEC-AUTH-001 handler"` in any source file
+**And** `SPEC-AUTH-001` may or may not have a `module:` frontmatter entry pointing to this file
+**When** an operator runs `moai mx query --format json` (no SPEC filter)
+**Then** the result entry corresponding to that tag MUST have `spec_associations` containing the string `"SPEC-AUTH-001"`
+
+**Verification command**:
+```bash
+moai mx query --format json | jq '.[] | select(.body | contains("SPEC-AUTH-001")) | .spec_associations'
+# Expected: array containing "SPEC-AUTH-001"
+```
+
+**Test fixture**: `internal/mx/resolver_query_test.go` `TestResolver_AC15_BodyBasedSpecAssociation` (already exists at line 449). 16-language sweep T-SPC004-15 verifies body-based association works in all 16 supported languages.
+
+**Expected**: PASS.
+
+---
+
+## 3. Performance Acceptance
+
+Per spec §7 Constraints:
+
+| Performance criterion | Target | Verification | Notes |
+|----------------------|--------|--------------|-------|
+| Resolver Resolve() — 1K tags, no fan_in | <100ms per call | `BenchmarkResolver_Resolve_1KTags` (T-SPC004-13) | Advisory; CI does not enforce |
+| Resolver Resolve() — 50 ANCHOR + LSP fan_in | <2s per call | `BenchmarkResolver_Resolve_50AnchorsLSP` (T-SPC004-13) | Advisory; uses mock LSP client |
+| CLI response size cap | 10MB JSON | (bounded by `--limit` default 100 + max 10000) | implicit; no separate test |
+| 16-language coverage | All 16 languages parse + associate | T-SPC004-15 16-lang sweep | Validates resolver layer (SPC-002 validates scanner) |
+
+---
+
+## 4. Definition of Done
+
+The SPEC is considered DONE when:
+
+- [ ] All 15 ACs (AC-SPC-004-01 through AC-SPC-004-15) verified
+- [ ] All 18 REQs (REQ-SPC-004-001..007, 010..013, 020..021, 030..031, 040..042) traced to ≥1 task per plan §1.5
+- [ ] All 20 tasks (T-SPC004-01..20 per tasks.md) marked complete
+- [ ] `go test -race -count=1 ./...` PASS (no regressions)
+- [ ] `golangci-lint run` clean
+- [ ] `make build` regenerates `internal/template/embedded.go` correctly
+- [ ] Coverage ≥ 85% per modified package (`internal/mx/`, `internal/cli/`)
+- [ ] Template parity verified via `diff -r .claude/ internal/template/templates/.claude/` (no template change expected)
+- [ ] CHANGELOG entry written in Unreleased section (4 entries per plan §M6)
+- [ ] @MX tags applied per plan §6 (6 tags: 1 ANCHOR + 2 WARN + 3 NOTE)
+- [ ] Run PR squash-merged into main
+- [ ] Sync PR squash-merged into main
+- [ ] Worktree disposed via `moai worktree done SPEC-V3R2-SPC-004`
+- [ ] Manual end-to-end verification: real project with gopls running, `moai mx query --kind anchor --fan-in-min 1` returns ≥1 entry with `fan_in_method: "lsp"`
+
+---
+
+## 5. Quality Gate Criteria
+
+Per `.moai/config/sections/quality.yaml`:
+
+| Criterion | Target | Verification |
+|-----------|--------|--------------|
+| Tested | All new functions covered | `go test -cover ./internal/mx/ ./internal/cli/` ≥ 85% |
+| Readable | English code + ko inline comments (per language.yaml) | `golangci-lint run` clean |
+| Unified | Style + import order | `gofmt -l ./internal/` empty |
+| Secured | No new attack surface | LSP path is read-only on source (no exec); spec_loader is yaml-parse on `.moai/specs/` (read-only) |
+| Trackable | All commits + CHANGELOG | git log inspection + CHANGELOG diff |
+
+---
+
+## 6. Risk-based AC Prioritization
+
+| AC | Priority | Why |
+|---|---|---|
+| AC-01, AC-02, AC-03 | P0 | Core: SPEC + kind + fan_in + danger filters (most consumed by callers) |
+| AC-05, AC-12 | P0 | JSON contract (REQ-005 schema) + empty result handling — tooling depends on it |
+| AC-08 | P0 | Pagination + TruncationNotice (output size safeguard) |
+| AC-04 | P0 | SidecarUnavailable graceful failure (CLI UX) |
+| AC-07 | P1 | LSP fallback annotation (fan_in correctness signal) |
+| AC-09 | P1 | Strict mode (CI ergonomics) |
+| AC-13 | P1 | InvalidQuery exit 2 (script integration) |
+| AC-14 | P1 | AND composition (compositional semantics) |
+| AC-15 | P1 | Body-based association (regex correctness) |
+| AC-06, AC-10 | P2 | Alternative output formats (less common path) |
+| AC-11 | P2 | test fixture exclusion (ergonomics) |
+
+---
+
+End of acceptance.
+
+Version: 0.1.0
+Status: Acceptance artifact for SPEC-V3R2-SPC-004

--- a/.moai/specs/SPEC-V3R2-SPC-004/issue-body.md
+++ b/.moai/specs/SPEC-V3R2-SPC-004/issue-body.md
@@ -1,0 +1,161 @@
+# SPEC-V3R2-SPC-004 — @MX anchor resolver (query by SPEC ID, fan_in, danger category) (Plan PR)
+
+> Step 1 plan-in-main per `.claude/rules/moai/workflow/spec-workflow.md` § SPEC Phase Discipline.
+> Branch: `plan/SPEC-V3R2-SPC-004` · Base: `origin/main` HEAD `73742e3ee` · Merge strategy: squash.
+
+## Summary
+
+Expose a structured query API over the @MX TAG sidecar index (SPEC-V3R2-SPC-002) as an ACI-shaped tool: `moai mx query`. Callers can filter tags by SPEC ID, by Kind (NOTE/WARN/ANCHOR/TODO/LEGACY), by fan_in threshold (high-callsite anchors for invariant enforcement), by danger category (WARN-tagged items whose REASON sub-line matches safety-critical patterns), and by file path prefix.
+
+Output format is JSON (primary) for tool consumption and a human-readable table (secondary) for terminal inspection. This same API is consumed by codemaps generation, evaluator-active scoring hints, and the /moai review phase.
+
+This PR contains **plan artifacts only** (research / plan / acceptance / tasks / progress / issue-body). No code or hook changes ship in this PR — those land in the run PR (`feat/SPEC-V3R2-SPC-004`) after this plan PR squash-merges into `main`.
+
+## Why this matters
+
+- **Resolver completes the T-1 ACI priority-1 pattern**: pattern-library.md §T-1 names `moai_locate_mx_anchor` as the strongest single-leverage ACI command. Together with SPC-002 (sidecar) and SPC-001 (`/moai mx index --json`), this SPEC forms the 6-command suite per design-principles.md §P2 "Interface Design Over Tool Count".
+- **Downstream consumers depend on it**: codemaps generation needs per-module anchor count; evaluator-active (HRN-003) needs danger_category distribution as a harness signal; `/moai review` needs structured query into the @MX layer.
+- **90%+ of the code already exists**: SPC-004 PR #746 (`68795dbe3`, 2026-04-30) merged `internal/mx/{resolver_query,fanin,danger_category,spec_association}.go` with all 10 CLI flags, 11-field JSON schema, 3 sentinel errors, JSON/table/markdown formatters, AND-composed multi-filter, and 15 AC fixtures. **Run-phase scope is gap-closure (LSP integration + user config wire-up + 16-language sweep), not from-scratch build** — see plan §1.2.
+
+## Plan-phase deliverables (this PR)
+
+- `spec.md` (already on main; no change)
+- `research.md` — 45 evidence anchors, 9 OQ resolutions, cross-SPEC boundary survey for SPC-002 / LSP-CORE-002 / HRN-003 / RT-001, gap inventory G-01..G-08, danger_categories default mapping survey, 16-lang LSP availability matrix.
+- `plan.md` — 6 milestones (M1..M6), 20 tasks, 18 REQ → 15 AC → 20 Task traceability matrix; 6 @MX tags planned; risk mitigation cross-referenced to spec §8.
+- `acceptance.md` — 15 ACs in Given/When/Then form with verification commands, test fixture references (11 of 15 already in `internal/mx/resolver_query_test.go` and `internal/cli/mx_query_test.go`), and Definition of Done.
+- `tasks.md` — 20 tasks with REQ/AC traceback, dependency graph, SPC-002 reuse plan; no wave-split required (under 30-task threshold).
+- `progress.md` — milestone tracker shell + AC status + risk watch.
+- `issue-body.md` — this file.
+
+## Run-phase scope (next PR after this plan PR merges)
+
+After plan PR squash-merge:
+
+1. `moai worktree new SPEC-V3R2-SPC-004 --base origin/main` (Step 2 spec-workflow).
+2. `/moai run SPEC-V3R2-SPC-004` invokes Phase 0.5 plan-audit gate.
+3. **M1 — LSP `find-references` integration (G-01) (P0)**:
+   - New `internal/mx/fanin_lsp.go` (~150 LOC) with `LSPFanInCounter` (powernap-backed).
+   - 4 RED tests (`internal/mx/fanin_lsp_test.go` ~250 LOC).
+   - `Resolver.Resolve` strictMode 분기 강화 (LSP availability detect; replaces current unconditional `LSPRequired` return).
+4. **M2 — `mx.yaml` `danger_categories:` user wire-up (G-02) (P1)**:
+   - `LoadDangerConfig()` helper in `internal/mx/danger_category.go`.
+   - `validateQuery()` extended to validate `--danger` value against known categories.
+   - CLI exit code 2 fix on `*InvalidQueryError` (currently exits 1).
+5. **M3 — `.moai/specs/*/spec.md` `module:` 자동 로드 (G-03) (P1)**:
+   - New `internal/mx/spec_loader.go` (~80 LOC) — yaml frontmatter parse, supports both string + array module formats.
+   - SpecAssociator path-based association activated (currently inactive due to empty map).
+6. **M4 — `Resolver.ResolveAnchorCallsites()` API parity (G-04) (P1)**:
+   - New `internal/mx/callsite.go` with Callsite struct.
+   - Additive `Resolver.ResolveAnchorCallsites(ctx, anchorID, projectRoot, includeTests) ([]Callsite, error)`.
+   - Existing `ResolveAnchor(anchorID) (Tag, error)` preserved (backward-compat).
+7. **M5 — test_paths glob (G-05) + stderr verify (G-06) (P1)**:
+   - `isTestFile` extended with user `mx.yaml test_paths:` glob patterns.
+   - Explicit `TestSidecarUnavailable_StderrFormat` fixture verifies both substrings present.
+8. **M6 — Verification (P0)**:
+   - CLI wire-up (LoadDangerConfig + LoadSpecModules + LSP detect).
+   - 16-language sweep (G-08) verifying resolver layer across all 16 supported languages.
+   - Performance benchmark fixtures (G-07; advisory).
+   - Full test suite + lint + build + CHANGELOG + 6 @MX tags + manual smoke test.
+
+Estimated artifacts: 7 new Go source files + extensions to 4 existing test files + 5 modified Go files + CHANGELOG = **~1,400 LOC delta** (production ~480 + test ~920).
+
+## Acknowledged discrepancies (from plan §1.2.1)
+
+1. **90%+ of code already exists.** SPC-004 PR #746 (`68795dbe3`) merged the resolver query API + CLI subcommand + 4 of 5 fan_in / danger / spec_association / pagination subsystems. Run-phase task count reflects gap-closure not from-scratch build. Sync-phase HISTORY in spec.md should reconcile §1 "Expose ... API" → "complete the API to spec parity (LSP integration + user config wire-up + 16-language coverage)".
+
+2. **`Resolver.ResolveAnchor(anchorID) []Callsite` signature gap.** Spec verbatim is `[]Callsite`; current implementation returns `(Tag, error)`. Two APIs have different semantics — plan-phase decision: existing `ResolveAnchor` preserved + new `ResolveAnchorCallsites()` added (additive, backward-compat). G-04 closes the gap.
+
+3. **JSON output envelope.** Spec §5.3 REQ-021 "TruncationNotice in the output header" interpretable as stdout envelope, but current CLI emits stdout=`[]TagResult` slice + stderr=TruncationNotice. Plan-phase decision (research §9 OQ-5): preserve existing format for backward-compat. Go API exposes envelope (`QueryResult`); CLI keeps slice-only stdout.
+
+4. **`--danger` enum validation gap.** Current `validateQuery()` only enum-checks `Kind` (research [E-15]); `--danger` accepts arbitrary strings (silent empty result). Plan-phase decision (research §9 OQ-4): extend `validateQuery` with `DangerCategoryMatcher.ValidateCategory()` call → `InvalidQueryError` on unknown category. Empty `--danger` (no filter) skips validation.
+
+5. **LSP availability detection.** Current strictMode 분기 (research [E-21]) returns unconditional `LSPRequired` (todo "(no LSP client)"). G-01 replaces with powernap server discovery result. Backward-compat: strictMode unset → no behavior change.
+
+6. **Performance budget verification format.** Spec §7 of <100ms / <2s is machine-dependent; CI does not enforce. Plan-phase decision (research §9 OQ-7): benchmark fixtures (`go test -bench`) for regression detection; absolute value assertion is advisory.
+
+## SPC-002 schema invariant guarantee
+
+This SPEC is a read-only consumer of the SPC-002 sidecar (`.moai/state/mx-index.json`). All changes:
+
+- Read sidecar via `mx.Manager.Load()` (existing API).
+- Iterate `sidecar.Tags` (read-only).
+- Apply filters in-memory.
+- Compute fan_in via separate counter (no sidecar mutation).
+
+Zero changes to:
+- `internal/mx/sidecar.go`
+- `internal/mx/scanner.go`
+- `internal/mx/tag.go`
+- `internal/mx/comment_prefixes.go`
+- `.claude/rules/moai/workflow/mx-tag-protocol.md` (FROZEN per CONST-V3R2-003)
+
+`SchemaVersion = 2` invariant preserved per SPC-002 plan §1.4.
+
+## File-level scope (run-phase)
+
+| Layer | Files |
+|---|---|
+| LSP integration | `internal/mx/fanin_lsp.go` (new), `internal/mx/fanin_lsp_test.go` (new) |
+| Config loaders | `internal/mx/danger_category.go` (extended), `internal/mx/spec_loader.go` (new) |
+| API parity | `internal/mx/callsite.go` (new), `internal/mx/resolver.go` (extended) |
+| Validation | `internal/mx/resolver_query.go` (extended) |
+| Test exclusion glob | `internal/mx/fanin.go` (extended) |
+| CLI wire-up | `internal/cli/mx_query.go` (extended) |
+| Test fixtures | 3 new test files (fanin_lsp_test.go, spec_loader_test.go, resolver_callsites_test.go) + extensions to 4 existing test files |
+| Performance | `internal/mx/resolver_query_bench_test.go` (new, advisory) |
+| Build | `make build` (regenerates `internal/template/embedded.go` defensively; no template diff expected) |
+| Trackability | `CHANGELOG.md` Unreleased entry, 6 @MX tags |
+
+## Test plan
+
+- [ ] M1 RED tests: LSPFanInCounter 4 sub-tests + strictMode 강화 → all FAIL initially
+- [ ] M1 GREEN: LSPFanInCounter implementation + Resolve strictMode 분기 → all GREEN
+- [ ] M2 RED: LoadDangerConfig 4 sub-tests + validateQuery danger 분기 → all FAIL
+- [ ] M2 GREEN: helper + validation extension → all GREEN
+- [ ] M3 RED: spec_loader 5 sub-tests + SpecAssociator integration → all FAIL
+- [ ] M3 GREEN: helper land → all GREEN
+- [ ] M4 RED: Callsite struct + ResolveAnchorCallsites 4 sub-tests → all FAIL
+- [ ] M4 GREEN: additive method lands → all GREEN; existing ResolveAnchor unchanged
+- [ ] M5 RED: isTestFile glob 3 sub-tests + stderr fixture → all FAIL
+- [ ] M5 GREEN: helper + integration → all GREEN
+- [ ] M6 final: 16-lang sweep PASS, benchmarks compile, `go test -race -count=1 ./...` PASS, `golangci-lint run` clean, `make build` exit 0, end-to-end manual verification (real gopls)
+
+## Dependencies
+
+| SPEC | Status | Role |
+|---|---|---|
+| SPEC-V3R2-SPC-002 (sidecar contract) | merged (plan PR #836 at `73742e3ee`; sidecar code at PR #741 commit `3f0933550`) | Blocks (consumed); read-only sidecar reader; schema_version: 2 invariant preserved |
+| SPEC-LSP-CORE-002 (LSP client via powernap) | merged (assumed; `internal/lsp/core/client.go` present) | Blocks (consumed); G-01 LSP-backed counter dependency |
+| SPEC-V3R2-HRN-003 (evaluator MX scoring) | in-flight | Downstream consumer (danger_category distribution as harness signal) |
+| codemaps generation tools | in-flight | Downstream consumer (per-module anchor count via Resolver.Resolve) |
+| pattern-library.md §T-1 priority 1 | design pattern source | Establishes "ACI 6-command suite" including this SPEC |
+
+## Plan-auditor target
+
+- **PASS verdict** ≥ 0.85 first iteration.
+- 18 REQs (REQ-SPC-004-001..007, 010..013, 020..021, 030..031, 040..042) traced to ≥1 AC and ≥1 task per plan §1.5 traceability matrix.
+- 15 ACs each with Given/When/Then + verification command + REQ traceback.
+- 45 evidence anchors in research.md (counted [E-01]..[E-45]).
+- 9 OQ resolutions in research §9.
+- §1.2.1 explicitly addresses 6 known plan-vs-spec discrepancies (90%+ already implemented; ResolveAnchor signature; JSON envelope; danger 검증 gap; LSP detect; benchmark format).
+- 6 @MX tags planned (1 ANCHOR + 2 WARN + 3 NOTE) — covers all 3 of {ANCHOR, WARN, NOTE} types.
+- Worktree-base alignment per Step 2 (`moai worktree new --base origin/main`) called out (plan §10).
+- Parallel SPEC isolation: only `internal/mx/`, `internal/cli/`, `CHANGELOG.md`. No `.claude/` tree changes expected.
+- SPC-002 schema_version: 2 invariant preservation 명시 (plan §1.2.1 + plan §3.5).
+
+## References
+
+- `.claude/rules/moai/workflow/mx-tag-protocol.md` (FROZEN inline syntax — read-only reference)
+- `.claude/rules/moai/core/zone-registry.md` `CONST-V3R2-003`
+- `internal/mx/{tag,scanner,sidecar,resolver,resolver_query,fanin,danger_category,spec_association,comment_prefixes}.go` (existing implementation; PR #741 + PR #746)
+- `internal/mx/{resolver_query_test,fanin_test,danger_category_test,spec_association_test}.go` (existing test fixtures with verbatim AC-SPC-004-NN annotations)
+- `internal/cli/{mx,mx_query,mx_query_test}.go` (existing CLI surface)
+- `internal/lsp/core/{client,capabilities,document}.go` (powernap LSP client — G-01 dependency)
+- `.moai/config/sections/mx.yaml` (config target for danger_categories + test_paths)
+- spec.md §1 (Goal), §2 (Scope), §3 (Environment), §4 (Assumptions), §5 (REQ), §6 (AC), §7 (Constraints), §8 (Risks), §9 (Dependencies), §10 (Traceability)
+- design-principles.md §P2 (Interface Design Over Tool Count); pattern-library.md §T-1 priority 1
+- master-v3 §7.3 (ACI command list including `moai_locate_mx_anchor`)
+
+---
+
+🗿 MoAI <email@mo.ai.kr>

--- a/.moai/specs/SPEC-V3R2-SPC-004/plan.md
+++ b/.moai/specs/SPEC-V3R2-SPC-004/plan.md
@@ -1,0 +1,793 @@
+# SPEC-V3R2-SPC-004 Implementation Plan
+
+> Implementation plan for **@MX anchor resolver (query by SPEC ID, fan_in, danger category)**.
+> Companion to `spec.md` v0.1.0, `research.md` v0.1.0, `acceptance.md` v0.1.0, `tasks.md` v0.1.0.
+> Authored on branch `plan/SPEC-V3R2-SPC-004` (Step 1 plan-in-main; base `origin/main` HEAD `73742e3ee`).
+> Run phase will execute on a fresh worktree `feat/SPEC-V3R2-SPC-004` per `.claude/rules/moai/workflow/spec-workflow.md` § SPEC Phase Discipline Step 2.
+
+## HISTORY
+
+| Version | Date       | Author                                            | Description |
+|---------|------------|---------------------------------------------------|-------------|
+| 0.1.0   | 2026-05-10 | manager-spec (Plan workflow Phase 1B)             | Initial implementation plan. Scope: LSP `find-references` integration via powernap (G-01), `mx.yaml` `danger_categories:` 사용자 wire-up (G-02), `.moai/specs/*/spec.md` `module:` frontmatter 자동 로드 + `SpecAssociator` 주입 (G-03), `Resolver.ResolveAnchorCallsites()` API parity (G-04), `mx.yaml test_paths:` 패턴 wire-up (G-05), stderr format verification (G-06), performance benchmark (G-07), 16-언어 sweep (G-08). Existing `internal/mx/{resolver_query,fanin,danger_category,spec_association}.go` (PR #746 commit `68795dbe3`) provides 90%+ of the code surface. |
+
+---
+
+## 1. Plan Overview
+
+### 1.1 Goal restatement
+
+`spec.md` §1 의 핵심 목표를 milestone 분해:
+
+> Expose a structured query API over the @MX TAG sidecar index (SPEC-V3R2-SPC-002) as an ACI-shaped tool: `moai mx query`. Callers can filter tags by SPEC ID, by Kind (NOTE/WARN/ANCHOR/TODO/LEGACY), by fan_in threshold, by danger category, and by file path prefix. Output format is JSON (primary) for tool consumption and a human-readable table (secondary) for terminal inspection. This same API is consumed by codemaps generation, evaluator-active scoring hints, and the /moai review phase.
+
+### 1.2 Current State Audit (research.md §2 cross-reference)
+
+`internal/mx/` 패키지의 SPC-004 표면은 이미 main 에 머지되어 있다 (research.md [E-02], [E-03] commit `68795dbe3`, PR #746). 본 SPEC 의 구현 진척도:
+
+| 영역 | 상태 | Evidence |
+|------|------|----------|
+| `Query` struct + 10 filter 필드 | ✅ 구현 | research [E-04] |
+| `Resolver.Resolve(query) (QueryResult, error)` | ✅ 구현 | research [E-05] |
+| `Resolver.ResolveAnchor(anchorID) (Tag, error)` | ⚠ Signature 부분 일치 | research [E-13] (단일 Tag — spec verbatim 은 `[]Callsite`) |
+| `TextualFanInCounter` + `isTestFile` | ✅ 구현 | research [E-07], [E-08] |
+| `DangerCategoryMatcher` + 4 default 카테고리 | ✅ 구현 | research [E-09], [E-10] |
+| `SpecAssociator` (path + body 합성) | ✅ 구현 | research [E-11], [E-12] |
+| `validateQuery()` + 3 sentinel error | ✅ 구현 | research [E-15] |
+| Pagination (default 100, max 10000) + offset | ✅ 구현 | research [E-06], [E-16] |
+| JSON / table / markdown output | ✅ 구현 | research [E-17], [E-18], [E-19] |
+| CLI `moai mx query` 10-flag | ✅ 구현 | research [E-20], [E-31] |
+| `MOAI_MX_QUERY_STRICT=1` env 분기 | ✅ 구현 | research [E-21] |
+| `--include-tests` flag | ✅ 구현 | research [E-22] |
+| AND-composed multi-filter | ✅ 구현 | research [E-23] |
+| **LSP-backed `LSPFanInCounter`** (G-01) | ❌ 격차 | research §2.3 G-01 |
+| **`mx.yaml` `danger_categories:` user wire-up** (G-02) | ⚠ 부분 (yaml 태그 정의; load 로직 부재) | research [E-24] |
+| **`.moai/specs/*/spec.md` `module:` 자동 로드 → `SpecAssociator`** (G-03) | ❌ 격차 | research §5.1 |
+| **`Resolver.ResolveAnchorCallsites()` API parity** (G-04) | ❌ 격차 (additive, backward-compat) | research §2.3 G-04 |
+| **`mx.yaml test_paths:` glob 패턴 wire-up** (G-05) | ⚠ 부분 (TestPaths field 정의; `isTestFile` 미사용) | research [E-09] line 18, [E-08] |
+| **stderr message format 회귀 방지 fixture** (G-06) | ⚠ 부분 (substring 일치; explicit fixture 부재) | research [E-25] |
+| **Performance benchmark fixture** (G-07) | ❌ 격차 | research §10 row 7 |
+| **16-언어 sweep test** (G-08) | ❌ 격차 | research §2.3 G-08 |
+
+Net actionable scope (Run-phase): **8 격차 해소** (G-01..G-08) + 정합성 검증 (template parity unaffected, race detector clean, coverage ≥ 85%).
+
+### 1.2.1 Acknowledged Discrepancies
+
+본 plan 이 spec.md 와 의도적으로 다르게 처리하는 부분 (research evidence 기반):
+
+- **Spec §1 은 본 SPEC 이 "Expose a structured query API ..." 하는 것처럼 서술하나, 실제로는 90%+ 가 이미 main 에 존재** — SPC-004 PR #746 commit `68795dbe3` (2026-04-30) 가 spec.md §2.1 "In Scope" 의 모든 bullet (CLI subcommand, Go API, fan_in via fallback, danger category, JSON output, pagination, SPEC association) 을 구현 완료. 본 plan 의 milestone 은 따라서 "build" 가 아니라 **"complete API to spec parity + integrate LSP + wire user config"** 로 reframe 됨. Sync-phase HISTORY 에서 spec.md §1 "Expose ... API" 표현을 "complete the API to spec parity (LSP integration + user config wire-up + 16-language coverage)" 로 reconcile 권장.
+
+- **`Resolver.ResolveAnchor(anchorID) []Callsite` signature 격차** — 현 `ResolveAnchor` 는 `(Tag, error)` 반환 (research [E-13]). spec §1 + §5 의 verbatim 은 `[]Callsite` (multi-callsite enumeration). 두 API 는 의미가 다르다 — 전자는 "anchor 위치 조회", 후자는 "anchor 의 모든 caller 위치 enumeration". plan-phase 결정 (research §9 OQ-9): existing `ResolveAnchor` 보존 + 신규 `ResolveAnchorCallsites(ctx, anchorID, projectRoot, includeTests) ([]Callsite, error)` 추가 (additive). spec.md sync HISTORY 에서 두 메서드 의도 차이 명시 권장.
+
+- **JSON 출력 envelope 차이** — spec §5.3 REQ-021 "TruncationNotice in the output header" 는 stdout envelope 으로 해석 가능하나, 현 CLI 는 stdout = `[]TagResult` slice + stderr = TruncationNotice 메시지 (research [E-39], [E-40]). plan-phase 결정 (research §9 OQ-5): backward-compat 위해 현 형식 유지. Go API 의 `QueryResult` 는 envelope (Tags / TruncationNotice / TotalCount) 노출 — programmatic caller 충족.
+
+- **`--danger` 미정의 카테고리 검증 격차** — 현 `validateQuery()` 는 `Kind` 만 enum-check (research [E-15]); `--danger` 임의 string 허용. plan-phase 결정 (research §9 OQ-4): G-02 의 일부로 `validateQuery()` 에 `DangerCategoryMatcher.ValidateCategory()` 호출 추가. Empty `--danger` (no filter) 는 검증 skip. spec §5.5 REQ-041 의 invalid query 범주에 포함.
+
+- **LSP availability detection** — 현재 (research [E-21]) strictMode 분기는 무조건 `LSPRequired` 반환 (todo "(no LSP client)"). G-01 의 일부로 powernap server discovery 결과를 검출 로직으로 대체. strictMode 에서 LSP available 시 `LSPFanInCounter` 사용; unavailable 시 `LSPRequiredError`.
+
+- **Performance budget verification 형식** — spec §7 의 <100ms / <2s 는 machine-dependent; CI 강제 X. plan-phase 결정 (research §9 OQ-7): benchmark fixture (`go test -bench`) 추가, 회귀 detect 용도. 절대값 assertion 은 advisory.
+
+### 1.3 Implementation Methodology
+
+`.moai/config/sections/quality.yaml`: `development_mode: tdd`. Run phase MUST follow RED → GREEN → REFACTOR per `.claude/rules/moai/workflow/spec-workflow.md` § Run Phase.
+
+- **RED**: 8개 격차 영역마다 새 RED test fixture 추가:
+  - `TestLSPFanInCounter_Count` (G-01) — powernap mock 으로 LSP textDocument/references 응답 → fan_in N. textual fallback 비교.
+  - `TestLoadDangerConfig_UserCustomCategories` (G-02) — mx.yaml 에 사용자 정의 카테고리 → matcher 가 user pattern 매칭.
+  - `TestValidateQuery_UnknownDanger_InvalidQueryError` (G-02) — `--danger frobnicate` (미정의) → `InvalidQueryError`.
+  - `TestLoadSpecModules_FromFrontmatter` (G-03) — `.moai/specs/SPEC-X/spec.md` frontmatter 의 `module:` → map[specID][]modulePath.
+  - `TestSpecAssociator_PathBased_FromLoader` (G-03) — loader 결과 → SpecAssociator 가 path-prefix 매칭으로 SPEC ID 반환.
+  - `TestResolver_ResolveAnchorCallsites` (G-04) — anchor_id → []Callsite (file/line/method).
+  - `TestIsTestFile_RespectsTestPathsConfig` (G-05) — mx.yaml test_paths: `["**/integration/**"]` → `tag.File = "integration/foo.go"` 가 test 로 분류.
+  - `TestSidecarUnavailable_StderrFormat` (G-06) — sidecar 부재 시 stderr 가 정확히 "SidecarUnavailable" + "/moai mx --full" 둘 다 포함.
+  - `BenchmarkResolver_Resolve_1KTags` (G-07) — 1K tag fixture 에 대한 b.N iteration 측정.
+  - `BenchmarkResolver_Resolve_50AnchorsLSP` (G-07) — 50 ANCHOR + LSP-backed counter (mock) 측정.
+  - `TestResolver_AllSixteenLanguages` (G-08) — 16개 언어 fixture에서 fan_in / SPEC association 동작.
+
+- **GREEN**: 각 RED test 를 GREEN 으로 전환하기 위한 production code 추가/수정:
+  - `internal/mx/fanin_lsp.go` 신규: `LSPFanInCounter` struct 구현 (powernap client 의존). FanInCounter 인터페이스 (research [E-07]) 구현.
+  - `internal/mx/danger_category.go` 보강: `LoadDangerConfig(projectRoot string) (DangerCategoryConfig, error)` 헬퍼 추가.
+  - `internal/mx/resolver_query.go` 수정: `validateQuery()` 에 danger 검증 분기 추가.
+  - `internal/mx/spec_loader.go` 신규: `LoadSpecModules(projectRoot string) (map[string][]string, error)` 헬퍼.
+  - `internal/mx/resolver.go` 수정: `ResolveAnchorCallsites()` 메서드 추가 (additive). `Callsite` struct 정의 (`internal/mx/callsite.go` 또는 같은 파일).
+  - `internal/mx/fanin.go` 수정: `isTestFile()` 가 user-configured glob patterns 을 받도록 변경 (또는 `isTestFileWithPatterns(file, patterns []string) bool` helper 신설).
+  - `internal/cli/mx_query.go` 확장: `LoadDangerConfig` + `LoadSpecModules` 호출 → `query.dangerMatcher` / `query.specAssociator` 주입. LSP availability detect → `query.fanInCounter` 분기.
+
+- **REFACTOR**: 공유 logic 추출:
+  - `internal/mx/config.go` (SPC-002 의 잠재 신규 파일과 충돌 우려 — research §11 cross-ref 참조; SPC-002 plan §1.4 의 `internal/mx/config.go` 와 별도 파일로 분리. 본 SPEC 은 `internal/mx/spec_loader.go` 와 `internal/mx/danger_category.go` 의 `LoadDangerConfig()` 만 추가).
+  - `@MX:NOTE` 태그로 결정 사유 명시 (plan §6).
+
+### 1.4 Deliverables
+
+| Deliverable | Path | REQ Coverage |
+|-------------|------|--------------|
+| LSPFanInCounter (powernap-backed) | `internal/mx/fanin_lsp.go` (신규 ~150 LOC) | REQ-003, REQ-020, REQ-030 |
+| `LoadDangerConfig` helper | `internal/mx/danger_category.go` (+30 LOC) | REQ-001 (`--danger`), REQ-012 |
+| `LoadSpecModules` helper | `internal/mx/spec_loader.go` (신규 ~80 LOC) | REQ-006 (a) |
+| `Callsite` struct + `Resolver.ResolveAnchorCallsites()` | `internal/mx/callsite.go` (신규 ~30 LOC) + `internal/mx/resolver.go` (+50 LOC) | REQ-002, REQ-003 |
+| `isTestFile` glob 패턴 wire-up | `internal/mx/fanin.go` (+30 LOC) | REQ-040 |
+| `validateQuery` danger 검증 분기 | `internal/mx/resolver_query.go` (+20 LOC) | REQ-041 |
+| CLI wire-up (config + LSP detect) | `internal/cli/mx_query.go` (+60 LOC) | REQ-001, REQ-006, REQ-012, REQ-013, REQ-030 |
+| 11 신규 RED tests | `internal/mx/fanin_lsp_test.go`, `internal/mx/spec_loader_test.go`, `internal/mx/resolver_test.go` (확장), `internal/mx/danger_category_test.go` (확장), `internal/mx/fanin_test.go` (확장) (+~700 LOC) | T-SPC004-01..11 |
+| 16-언어 sweep fixture | `internal/mx/resolver_query_test.go` (확장 ~150 LOC) | REQ-001 + 16-lang neutrality |
+| Benchmark fixtures (advisory) | `internal/mx/resolver_query_bench_test.go` (신규 ~80 LOC) | spec §7 budget |
+| Template parity check | `make build` regenerates `internal/template/embedded.go` | TRUST 5 Trackable |
+| CHANGELOG entry | `CHANGELOG.md` Unreleased | TRUST 5 Trackable |
+| MX tags per §6 | 6 tags (per §6 below) | mx_plan |
+
+Embedded-template parity는 **applicable** (`make build` 후 `internal/template/embedded.go` 재생성). 그러나 본 SPEC 의 변경은 모두 `internal/` Go 코드이고 template 자산 변경 없음. 검증: `diff -r .claude/ internal/template/templates/.claude/` 변경 0 line 기대.
+
+### 1.5 Traceability Matrix (REQ → AC → Task)
+
+Per plan-auditor PASS criterion #2 (every REQ maps to at least one AC and at least one Task). Built **after** tasks.md was finalized; each row references actual T-SPC004-NN IDs.
+
+| REQ ID | Category | Mapped AC(s) | Mapped Task(s) |
+|--------|----------|--------------|----------------|
+| REQ-SPC-004-001 | Ubiquitous (CLI subcommand + 10 flags) | AC-01..AC-15 (cross-cutting) | T-SPC004-12 (CLI wire-up); existing CLI tests |
+| REQ-SPC-004-002 | Ubiquitous (Go API `Resolver.Resolve()`) | AC-05 | T-SPC004-12 (existing Resolve covers; G-04 adds Callsites) |
+| REQ-SPC-004-003 | Ubiquitous (LSP-first + ast-grep/textual fallback) | AC-07 | T-SPC004-01, T-SPC004-02 (LSPFanInCounter) |
+| REQ-SPC-004-004 | Ubiquitous (default JSON + `--format table`) | AC-05, AC-06 | (existing); AC-15 16-lang sweep regression |
+| REQ-SPC-004-005 | Ubiquitous (JSON 11-field schema) | AC-05 | (existing); T-SPC004-15 sweep verifies schema |
+| REQ-SPC-004-006 | Ubiquitous (SPEC association: path + body) | AC-01, AC-15 | T-SPC004-04, T-SPC004-05 (LoadSpecModules + SpecAssociator wire) |
+| REQ-SPC-004-007 | Ubiquitous (pagination default 100/max 10000) | AC-08 | (existing); T-SPC004-13 benchmark verifies |
+| REQ-SPC-004-010 | Event-driven (`--spec X --kind anchor`) | AC-01 | T-SPC004-04, T-SPC004-05 + existing |
+| REQ-SPC-004-011 | Event-driven (`--fan-in-min 3 --kind anchor`) | AC-02 | T-SPC004-01, T-SPC004-02 + existing |
+| REQ-SPC-004-012 | Event-driven (`--danger concurrency`) | AC-03 | T-SPC004-03 (LoadDangerConfig wire) + existing |
+| REQ-SPC-004-013 | Event-driven (sidecar absent → SidecarUnavailable) | AC-04 | T-SPC004-09 (stderr format fixture) + existing |
+| REQ-SPC-004-020 | State-driven (no LSP → textual + annotation) | AC-07 | T-SPC004-01, T-SPC004-02 |
+| REQ-SPC-004-021 | State-driven (10K+ tags → auto limit + TruncationNotice) | AC-08 | (existing); T-SPC004-13 benchmark |
+| REQ-SPC-004-030 | Optional (`MOAI_MX_QUERY_STRICT=1` → fail no LSP) | AC-09 | T-SPC004-02 (LSP-backed strictMode 분기) |
+| REQ-SPC-004-031 | Optional (`--format markdown`) | AC-10 | (existing); T-SPC004-15 16-lang regression |
+| REQ-SPC-004-040 | Complex (test fixture excluded; `--include-tests` override) | AC-11 | T-SPC004-07, T-SPC004-08 (test_paths glob wire) + existing |
+| REQ-SPC-004-041 | Complex (zero match → `[]` exit 0; invalid filter → InvalidQuery exit 2) | AC-12, AC-13 | T-SPC004-06 (validateQuery danger 분기) + existing |
+| REQ-SPC-004-042 | Complex (multi-filter AND-composed) | AC-14 | (existing covers; T-SPC004-15 16-lang verifies) |
+
+Coverage: **18 unique REQs (001..007, 010..013, 020..021, 030..031, 040..042) → 15 ACs (AC-01..AC-15) → 15 tasks (T-SPC004-01..15)**. AC-01..AC-15 from spec §6 are mapped.
+
+→ All REQ IDs from spec §5 are mapped.
+
+---
+
+## 2. Milestone Breakdown (M1-M6)
+
+각 milestone 은 **priority-ordered** (no time estimates per `.claude/rules/moai/core/agent-common-protocol.md` § Time Estimation HARD rule).
+
+### M1: LSP `find-references` 통합 (G-01) — Priority P0
+
+Owner role: `expert-backend` (Go LSP client + concurrent dispatch).
+
+Tasks:
+- T-SPC004-01: 신규 `internal/mx/fanin_lsp.go` 생성. `LSPFanInCounter` struct: `Client` (powernap interface), `ProjectRoot` field. `Count(ctx, tag, projectRoot, excludeTests)` 구현 — workspace/symbol query (anchor_id) → first match → textDocument/references → result count (excludeTests 적용).
+- T-SPC004-02: 신규 `internal/mx/fanin_lsp_test.go`. powernap client mock (`type mockLSPClient struct{}`) 으로 RED tests:
+  - `TestLSPFanInCounter_BasicCount` — symbol 매칭 + 3 references → fan_in = 3, method = "lsp".
+  - `TestLSPFanInCounter_NoSymbolMatch` — workspace/symbol 0 결과 → fan_in = 0, method = "lsp" (또는 textual fallback decision; OQ-2 결정 = textual fallback + annotation).
+  - `TestLSPFanInCounter_StrictModeUnavailable` — `MOAI_MX_QUERY_STRICT=1` + LSP unavailable → `LSPRequiredError`.
+  - `TestLSPFanInCounter_ExcludeTests` — references 결과 중 _test.go → 제외.
+
+RED 검증: `TestLSPFanInCounter_*` FAIL on `go test ./internal/mx/` (LSPFanInCounter 미구현).
+
+GREEN 검증: 4 test PASS. existing `TestTextualFanInCounter_*` (research [E-07]) still PASS — interface compat.
+
+### M2: `mx.yaml` `danger_categories:` user wire-up + validateQuery 강화 (G-02) — Priority P1
+
+Owner role: `expert-backend` (Go yaml unmarshal + CLI wire).
+
+Tasks:
+- T-SPC004-03: `internal/mx/danger_category.go` 보강. `LoadDangerConfig(projectRoot string) (DangerCategoryConfig, error)` 추가:
+  - mx.yaml 부재 → `DangerCategoryConfig{}` (graceful → DefaultDangerCategories).
+  - parse error → graceful + log warning.
+  - 정상 → user-defined Categories + TestPaths 반환.
+- T-SPC004-06: `internal/mx/resolver_query.go` 의 `validateQuery()` 에 분기 추가:
+  - `query.Danger != ""` 일 때 `dangerMatcher.ValidateCategory(query.Danger)` false → `InvalidQueryError{Field: "danger", Value: query.Danger, Message: "...allowed: " + KnownCategories()}`.
+  - 단 `validateQuery` 시점에 dangerMatcher 가 nil 일 수 있음 — 그 경우 default matcher 로 검증.
+
+신규 RED tests:
+- `TestLoadDangerConfig_UserCustomCategories` (T-SPC004-03 RED) — mx.yaml 에 `danger_categories: { critical: ["unwrap()", "panic()"] }` → matcher 가 "unwrap()" 매칭.
+- `TestLoadDangerConfig_FileMissing_DefaultUsed` (T-SPC004-03 RED) — mx.yaml 부재 → DefaultDangerCategories 사용.
+- `TestValidateQuery_UnknownDanger_InvalidQueryError` (T-SPC004-06 RED) — `--danger frobnicate` → exit 2.
+
+RED 검증: 3 test FAIL.
+
+GREEN 검증: 3 PASS. existing `validateQuery` test (kind validation) still PASS.
+
+### M3: `.moai/specs/*/spec.md` `module:` 자동 로드 + SpecAssociator 주입 (G-03) — Priority P1
+
+Owner role: `expert-backend` (yaml frontmatter parse + filesystem walk).
+
+Tasks:
+- T-SPC004-04: 신규 `internal/mx/spec_loader.go`. `LoadSpecModules(projectRoot string) (map[string][]string, error)` 구현:
+  - `.moai/specs/*/spec.md` glob 순회 (sort 보장).
+  - 각 file 의 yaml frontmatter (`---` ... `---` 사이) parse.
+  - `id` field → SPEC ID, `module` field → string (쉼표 split + TrimSpace) 또는 `[]string` (yaml array — type assertion 분기).
+  - 결과 map 반환. spec.md 부재 시 빈 map.
+- T-SPC004-05: 신규 `internal/mx/spec_loader_test.go`. RED tests:
+  - `TestLoadSpecModules_StringFormat` — `module: "internal/mx/, cmd/moai/"` → `map["SPEC-X"] = ["internal/mx/", "cmd/moai/"]`.
+  - `TestLoadSpecModules_ArrayFormat` — `module: [internal/foo/, internal/bar/]` → 동일 결과.
+  - `TestLoadSpecModules_EmptyModule` — `module: ""` → `map["SPEC-X"] = []`.
+  - `TestLoadSpecModules_NoSpecsDir` — `.moai/specs/` 부재 → empty map.
+  - `TestSpecAssociator_PathBased_FromLoader` — loader 결과 → SpecAssociator 의 path-prefix 매칭 동작.
+
+RED 검증: 5 test FAIL.
+
+GREEN 검증: 5 PASS. existing `SpecAssociator_BodyBased` test (research [E-12]) still PASS.
+
+### M4: `Resolver.ResolveAnchorCallsites()` API parity (G-04) — Priority P1
+
+Owner role: `expert-backend` (additive API).
+
+Tasks:
+- T-SPC004-10: 신규 `internal/mx/callsite.go`. `Callsite` struct 정의:
+  ```go
+  type Callsite struct {
+      File   string `json:"file"`
+      Line   int    `json:"line"`
+      Column int    `json:"column,omitempty"`
+      Method string `json:"method"` // "lsp" or "textual"
+  }
+  ```
+- T-SPC004-11: `internal/mx/resolver.go` 수정. `Resolver.ResolveAnchorCallsites(ctx, anchorID, projectRoot, includeTests) ([]Callsite, error)` 메서드 추가:
+  - LSP available 시 LSPFanInCounter 의 underlying client 호출 → `Location[]` → `Callsite[]` 변환.
+  - LSP unavailable 시 TextualFanInCounter 와 같은 walk + line-grep 하되 hit 마다 `Callsite{File, Line, Method: "textual"}` 추가.
+  - existing `ResolveAnchor` 보존 (no signature change).
+- 신규 RED tests:
+  - `TestResolver_ResolveAnchorCallsites_LSP` — LSP mock → 3 callsites 반환.
+  - `TestResolver_ResolveAnchorCallsites_TextualFallback` — LSP unavailable → walk-based 결과.
+  - `TestResolver_ResolveAnchor_BackwardCompat` — 기존 `ResolveAnchor(anchorID)` (Tag, error) 변경 없음.
+
+RED 검증: 3 test FAIL (Callsite struct + ResolveAnchorCallsites 미구현).
+
+GREEN 검증: 3 PASS. existing `TestResolver_ResolveAnchor*` test (research [E-13]) still PASS.
+
+### M5: `mx.yaml test_paths:` glob 패턴 wire-up (G-05) + stderr verification (G-06) — Priority P1
+
+Owner role: `expert-backend`.
+
+Tasks:
+- T-SPC004-07: `internal/mx/fanin.go` 의 `isTestFile()` 변경 또는 `isTestFileWithPatterns(file string, userPatterns []string) bool` 신설. user pattern (glob) 가 매칭하면 true; hard-coded fallback (`_test.go`, `tests`, `fixtures`, `testdata`) 도 유지.
+- T-SPC004-08: 신규 RED tests:
+  - `TestIsTestFile_UserPattern_IntegrationDir` — patterns `["**/integration/**"]` + file `internal/foo/integration/bar.go` → true.
+  - `TestIsTestFile_UserPattern_NoMatch_FallbackHardcoded` — patterns `["**/integration/**"]` + file `internal/foo/foo_test.go` → true (hard-coded `_test.go` 매칭).
+  - `TestTextualFanInCounter_RespectsUserTestPaths` — counter 가 LoadDangerConfig 의 TestPaths 받아 적용.
+- T-SPC004-09: 신규 `TestSidecarUnavailable_StderrFormat` (G-06):
+  - sidecar 부재 + `moai mx query` 실행 → stderr 가 substring `SidecarUnavailable` AND `/moai mx --full` 둘 다 포함.
+  - `internal/cli/mx_query_test.go` 확장.
+
+RED 검증: 4 test FAIL (사용자 pattern 미적용).
+
+GREEN 검증: 4 PASS. existing `isTestFile` test (research [E-08]) still PASS.
+
+### M6: 16-언어 sweep (G-08) + Performance benchmark (G-07) + Verification — Priority P0
+
+Owner role: `manager-cycle` + `manager-quality`.
+
+Tasks:
+- T-SPC004-15: 신규 `TestResolver_AllSixteenLanguages` (G-08):
+  - `t.TempDir()` 안에 16개 source file 생성 (go / python / typescript / javascript / rust / java / kotlin / csharp / ruby / php / elixir / cpp / scala / r / flutter / swift), 각 1개 `@MX:NOTE` + 1개 `@MX:ANCHOR` (anchor_id 고유, e.g. `anchor-go-001`, `anchor-py-001` ...).
+  - sidecar 생성 후 resolver 가 16 language 모든 tag 추출.
+  - `--kind anchor` filter → 16 anchors 반환.
+  - fan_in textual mode + cross-file callsite (anchor_id 가 다른 파일에서 참조됨) → fan_in = N (configurable).
+  - SPEC association: tag body 에 `SPEC-V3R2-X-001` 명시 → `spec_associations` 에 포함.
+- T-SPC004-13: 신규 `internal/mx/resolver_query_bench_test.go`:
+  - `BenchmarkResolver_Resolve_1KTags` — 1000 tag fixture, no fan_in computation. spec §7: <100ms.
+  - `BenchmarkResolver_Resolve_50AnchorsLSP` — 50 ANCHOR + LSP mock. spec §7: <2s.
+  - 두 benchmark 모두 advisory; CI 강제 X.
+- T-SPC004-14: 전체 테스트 스위트 — `go test -race -count=1 ./...` PASS, 0 회귀.
+- T-SPC004-16: `golangci-lint run` clean.
+- T-SPC004-17: `make build` exits 0; `internal/template/embedded.go` 재생성.
+- T-SPC004-18: `CHANGELOG.md` Unreleased 업데이트:
+  - "feat(mx/SPEC-V3R2-SPC-004): LSP `find-references` integration via powernap (LSP-backed `LSPFanInCounter`)"
+  - "feat(mx/SPEC-V3R2-SPC-004): `mx.yaml` `danger_categories:` + `test_paths:` user wire-up"
+  - "feat(mx/SPEC-V3R2-SPC-004): `.moai/specs/*/spec.md` `module:` frontmatter 자동 로드 + `SpecAssociator` 주입"
+  - "feat(mx/SPEC-V3R2-SPC-004): `Resolver.ResolveAnchorCallsites()` API parity (additive)"
+- T-SPC004-19: @MX 태그 적용 per §6.
+- T-SPC004-20: 수동 검증 — 임시 Go file 에 `@MX:ANCHOR` 추가 후 `moai mx query --kind anchor --fan-in-min 1` 실행, LSP-backed result 와 textual result 비교.
+
+Verification gate: All AC-SPC-004-01 through AC-SPC-004-15 verified per acceptance.md.
+
+---
+
+## 3. File-Level Modification Map
+
+### 3.1 Files modified (existing)
+
+| File | Lines added/changed | Purpose |
+|------|---------------------|---------|
+| `internal/mx/danger_category.go` | +30 LOC | `LoadDangerConfig()` helper |
+| `internal/mx/resolver_query.go` | +20 LOC | `validateQuery()` danger 분기 |
+| `internal/mx/resolver.go` | +50 LOC | `ResolveAnchorCallsites()` 신규 메서드 |
+| `internal/mx/fanin.go` | +30 LOC | `isTestFileWithPatterns()` user glob 적용 |
+| `internal/cli/mx_query.go` | +60 LOC | `LoadDangerConfig` + `LoadSpecModules` 호출 + LSP detect 분기 |
+| `CHANGELOG.md` | +4 lines | Unreleased entry |
+
+### 3.2 Files created (new)
+
+| File | LOC (approx) | Purpose |
+|------|--------------|---------|
+| `internal/mx/fanin_lsp.go` | ~150 | `LSPFanInCounter` (powernap-backed) |
+| `internal/mx/fanin_lsp_test.go` | ~250 | T-SPC004-01, T-SPC004-02 RED tests |
+| `internal/mx/spec_loader.go` | ~80 | `LoadSpecModules()` helper |
+| `internal/mx/spec_loader_test.go` | ~200 | T-SPC004-04, T-SPC004-05 RED tests (5 cases) |
+| `internal/mx/callsite.go` | ~30 | `Callsite` struct + JSON tags |
+| `internal/mx/resolver_callsites_test.go` | ~150 | T-SPC004-10, T-SPC004-11 RED tests (3 cases) |
+| `internal/mx/resolver_query_bench_test.go` | ~80 | T-SPC004-13 advisory benchmarks |
+
+### 3.3 Files extended (existing test files)
+
+| File | LOC (added) | Purpose |
+|------|-------------|---------|
+| `internal/mx/danger_category_test.go` | +120 | T-SPC004-03 RED tests (LoadDangerConfig + UnknownDanger) |
+| `internal/mx/fanin_test.go` | +100 | T-SPC004-07, T-SPC004-08 RED tests (user test_paths) |
+| `internal/cli/mx_query_test.go` | +60 | T-SPC004-09 RED test (stderr format) |
+| `internal/mx/resolver_query_test.go` | +200 | T-SPC004-15 16-language sweep + T-SPC004-06 validateQuery danger |
+
+### 3.4 Files removed
+
+None.
+
+### 3.5 Files NOT modified (out-of-scope)
+
+- `.claude/rules/moai/workflow/mx-tag-protocol.md` — FROZEN per CONST-V3R2-003.
+- `internal/mx/sidecar.go` — SPC-002 territory (read-only consume from this SPEC).
+- `internal/mx/scanner.go` — SPC-002 territory (no scanner change needed).
+- `internal/mx/tag.go` — schema 변경 금지 (SPC-002 schema_version: 2 invariant).
+- `internal/mx/comment_prefixes.go` — already complete (16-lang lookup).
+- `internal/hook/post_tool_*.go` — SPC-002 territory.
+- `internal/cli/mx.go` — parent command, SPC-002 의 G-03 격차 영역.
+- `cmd/moai/main.go` — root command, 변경 불필요.
+
+---
+
+## 4. Technical Approach
+
+### 4.1 LSPFanInCounter 의 powernap 호출 흐름
+
+```go
+// internal/mx/fanin_lsp.go (신규)
+package mx
+
+import (
+    "context"
+    "strings"
+
+    "github.com/modu-ai/moai-adk/internal/lsp/core"
+)
+
+// LSPFanInCounter is a FanInCounter that uses LSP textDocument/references
+// to count anchor references. Falls back to TextualFanInCounter when LSP
+// is unavailable for the target language.
+//
+// @MX:ANCHOR LSPFanInCounter — LSP-first fan_in measurement
+// @MX:REASON: 본 SPEC 의 spec §5.2 REQ-003 의 LSP-first 정책 단일 진입점;
+//             callers: CLI mx_query.go, ResolveAnchorCallsites, codemaps generator
+type LSPFanInCounter struct {
+    Client      *core.Client // powernap LSP client
+    ProjectRoot string
+    Fallback    FanInCounter // typically *TextualFanInCounter
+}
+
+func (c *LSPFanInCounter) Count(ctx context.Context, tag Tag, projectRoot string, excludeTests bool) (int, string, error) {
+    if tag.AnchorID == "" {
+        return 0, "lsp", nil
+    }
+    if c.Client == nil || !c.Client.IsAvailable(ctx, langFor(tag.File)) {
+        if c.Fallback != nil {
+            return c.Fallback.Count(ctx, tag, projectRoot, excludeTests)
+        }
+        return 0, "textual", nil
+    }
+    // workspace/symbol query
+    syms, err := c.Client.WorkspaceSymbol(ctx, tag.AnchorID)
+    if err != nil || len(syms) == 0 {
+        if c.Fallback != nil {
+            return c.Fallback.Count(ctx, tag, projectRoot, excludeTests)
+        }
+        return 0, "lsp", nil
+    }
+    // textDocument/references on first match
+    locs, err := c.Client.References(ctx, syms[0].Location, false /* includeDeclaration */)
+    if err != nil {
+        if c.Fallback != nil {
+            return c.Fallback.Count(ctx, tag, projectRoot, excludeTests)
+        }
+        return 0, "lsp", err
+    }
+    count := 0
+    for _, loc := range locs {
+        if excludeTests && isTestPath(loc.URI) {
+            continue
+        }
+        count++
+    }
+    return count, "lsp", nil
+}
+
+func langFor(file string) string {
+    // mapping ext → LSP language id
+    // delegated to internal/mx/comment_prefixes.go pattern (read-only)
+    ext := strings.ToLower(filepath.Ext(file))
+    return langIDForExt(ext) // helper in same package
+}
+```
+
+powernap API (`core.Client.WorkspaceSymbol` / `core.Client.References`) 가 안정 표면이라 가정. 실 구현 시 powernap signature 에 맞게 조정 (research §3.1 cross-ref).
+
+### 4.2 strictMode 분기
+
+```go
+// internal/mx/resolver_query.go (수정 — research [E-21] 강화)
+strictMode := os.Getenv("MOAI_MX_QUERY_STRICT") == "1"
+needsFanIn := query.FanInMin > 0
+if strictMode && needsFanIn {
+    if lspCounter, ok := fanInCounter.(*LSPFanInCounter); ok {
+        if lspCounter.Client == nil || !lspCounter.Client.IsAnyServerAvailable(context.Background()) {
+            return QueryResult{}, &LSPRequiredError{Language: "any"}
+        }
+    } else {
+        return QueryResult{}, &LSPRequiredError{Language: "any"}
+    }
+}
+```
+
+기존 (E-21) 의 unconditional `LSPRequired` 반환을 LSP availability 검출 결과로 대체. Backward-compat: strictMode unset 일 때는 동작 변경 없음.
+
+### 4.3 LoadSpecModules helper
+
+```go
+// internal/mx/spec_loader.go (신규)
+package mx
+
+import (
+    "fmt"
+    "os"
+    "path/filepath"
+    "strings"
+
+    "gopkg.in/yaml.v3"
+)
+
+// LoadSpecModules walks .moai/specs/*/spec.md and extracts the `module:`
+// frontmatter field for each SPEC. Used by the SpecAssociator to perform
+// path-based association (REQ-SPC-004-006 (a)).
+//
+// Supported `module:` formats:
+//   - String:    module: "internal/mx/, cmd/moai/"
+//   - Array:     module: [internal/mx/, cmd/moai/]
+//
+// Empty / missing `module:` → empty []string for that SPEC ID.
+// Missing .moai/specs/ → empty map (graceful).
+func LoadSpecModules(projectRoot string) (map[string][]string, error) {
+    specsDir := filepath.Join(projectRoot, ".moai/specs")
+    entries, err := os.ReadDir(specsDir)
+    if err != nil {
+        if os.IsNotExist(err) {
+            return map[string][]string{}, nil
+        }
+        return nil, fmt.Errorf("read specs dir: %w", err)
+    }
+    result := map[string][]string{}
+    for _, entry := range entries {
+        if !entry.IsDir() {
+            continue
+        }
+        specPath := filepath.Join(specsDir, entry.Name(), "spec.md")
+        data, err := os.ReadFile(specPath)
+        if err != nil {
+            continue // graceful skip
+        }
+        front := extractFrontmatter(data)
+        if front == nil {
+            continue
+        }
+        var meta struct {
+            ID     string      `yaml:"id"`
+            Module interface{} `yaml:"module"` // string or []string
+        }
+        if err := yaml.Unmarshal(front, &meta); err != nil {
+            continue
+        }
+        if meta.ID == "" {
+            meta.ID = entry.Name() // fallback to dir name
+        }
+        result[meta.ID] = parseModuleField(meta.Module)
+    }
+    return result, nil
+}
+
+func parseModuleField(v interface{}) []string {
+    switch m := v.(type) {
+    case string:
+        if m == "" {
+            return []string{}
+        }
+        parts := strings.Split(m, ",")
+        out := make([]string, 0, len(parts))
+        for _, p := range parts {
+            if t := strings.TrimSpace(p); t != "" {
+                out = append(out, t)
+            }
+        }
+        return out
+    case []interface{}:
+        out := make([]string, 0, len(m))
+        for _, item := range m {
+            if s, ok := item.(string); ok {
+                if t := strings.TrimSpace(s); t != "" {
+                    out = append(out, t)
+                }
+            }
+        }
+        return out
+    default:
+        return []string{}
+    }
+}
+
+// extractFrontmatter returns the bytes between the first two "---" lines,
+// or nil if no frontmatter is found.
+func extractFrontmatter(data []byte) []byte {
+    // implementation: first --- on line 1, find second ---, return between
+    // ... (omitted for brevity)
+}
+```
+
+### 4.4 LoadDangerConfig helper
+
+```go
+// internal/mx/danger_category.go (수정 — append helper)
+func LoadDangerConfig(projectRoot string) (DangerCategoryConfig, error) {
+    path := filepath.Join(projectRoot, ".moai/config/sections/mx.yaml")
+    data, err := os.ReadFile(path)
+    if err != nil {
+        if os.IsNotExist(err) {
+            return DangerCategoryConfig{}, nil // graceful → DefaultDangerCategories
+        }
+        return DangerCategoryConfig{}, err
+    }
+    var cfg DangerCategoryConfig
+    if err := yaml.Unmarshal(data, &cfg); err != nil {
+        return DangerCategoryConfig{}, nil // graceful (log warning)
+    }
+    return cfg, nil
+}
+```
+
+### 4.5 isTestFile glob 패턴 wire-up
+
+```go
+// internal/mx/fanin.go (수정)
+func isTestFileWithPatterns(filePath string, userPatterns []string) bool {
+    // hard-coded fallback (preserve existing behavior)
+    if isTestFile(filePath) {
+        return true
+    }
+    // user-defined glob patterns (gitignore-style)
+    for _, pattern := range userPatterns {
+        if match, _ := doublestar.PathMatch(pattern, filePath); match {
+            return true
+        }
+    }
+    return false
+}
+```
+
+doublestar 라이브러리는 이미 repo 의 go.mod 에 있을 가능성 — 검증 후 부재 시 `path/filepath.Match` 의 single-star 패턴만 지원 (간소화).
+
+### 4.6 Callsite struct + ResolveAnchorCallsites
+
+```go
+// internal/mx/callsite.go (신규)
+package mx
+
+type Callsite struct {
+    File   string `json:"file"`
+    Line   int    `json:"line"`
+    Column int    `json:"column,omitempty"`
+    Method string `json:"method"` // "lsp" or "textual"
+}
+
+// internal/mx/resolver.go (수정 — additive method)
+func (r *Resolver) ResolveAnchorCallsites(ctx context.Context, anchorID, projectRoot string, includeTests bool) ([]Callsite, error) {
+    tag, err := r.ResolveAnchor(anchorID)
+    if err != nil {
+        return nil, err
+    }
+    counter := r.fanInCounter()
+    if lspCounter, ok := counter.(*LSPFanInCounter); ok && lspCounter.Client != nil {
+        // LSP path
+        return resolveCallsitesViaLSP(ctx, lspCounter, tag, projectRoot, includeTests)
+    }
+    // textual fallback
+    return resolveCallsitesViaTextual(tag, projectRoot, includeTests)
+}
+```
+
+`r.fanInCounter()` 는 Resolver 에 새 필드 (`fanInCounter FanInCounter` private field) + getter 추가.
+
+### 4.7 Performance budget verification 형식
+
+```go
+// internal/mx/resolver_query_bench_test.go (신규)
+func BenchmarkResolver_Resolve_1KTags(b *testing.B) {
+    tmpDir := b.TempDir()
+    mgr := NewManager(tmpDir)
+    sidecar := generateBenchmarkSidecar(1000, 0 /* no anchors with fan_in */)
+    if err := mgr.Write(sidecar); err != nil {
+        b.Fatal(err)
+    }
+    resolver := NewResolver(mgr)
+
+    b.ResetTimer()
+    for i := 0; i < b.N; i++ {
+        _, err := resolver.Resolve(Query{Limit: 100})
+        if err != nil {
+            b.Fatal(err)
+        }
+    }
+    // Advisory: <100ms per op (spec §7)
+}
+
+func BenchmarkResolver_Resolve_50AnchorsLSP(b *testing.B) {
+    // 50 ANCHOR fixture + LSP mock counter
+    // Advisory: <2s per op
+}
+```
+
+### 4.8 Backward compatibility
+
+- `Resolver.ResolveAnchor(anchorID) (Tag, error)` — signature 보존 (G-04 는 additive `ResolveAnchorCallsites`).
+- `TextualFanInCounter` — 변경 없음. `LSPFanInCounter` 가 신규 인터페이스 구현체로 추가.
+- `DangerCategoryMatcher` — `NewDangerCategoryMatcher(cfg)` 가 cfg.Categories 비어있으면 DefaultDangerCategories 사용 (existing 동작 유지).
+- `validateQuery()` — danger 분기 추가 (existing kind 분기 보존).
+- CLI 의 stdout 출력 형식 (slice-only JSON) — 변경 없음 (OQ-5 결정).
+- sidecar schema_version: 2 — 변경 금지 (SPC-002 invariant).
+
+### 4.9 Cross-platform behavior
+
+- `os.ReadDir` / `os.ReadFile` — cross-platform.
+- `filepath.Match` / `doublestar.PathMatch` — case-sensitive on Linux/Mac, case-insensitive on Windows (acceptable; user 가 패턴 작성 시 인지).
+- `MOAI_MX_QUERY_STRICT` env — cross-platform.
+- powernap LSP client — Windows 에서 일부 LSP server (예: rust-analyzer) 가 다른 binary path 가질 수 있음 (powernap 측 책임).
+
+---
+
+## 5. Quality Gates
+
+Per `.moai/config/sections/quality.yaml`:
+
+| Gate | Requirement | Verification command |
+|------|-------------|-----------------------|
+| Coverage | ≥ 85% per modified file | `go test -cover ./internal/mx/ ./internal/cli/` |
+| Race | `go test -race ./...` clean | `go test -race -count=1 ./...` |
+| Lint | golangci-lint clean | `golangci-lint run` |
+| Build | embedded.go regenerated | `make build` |
+| Template parity | `diff -r` byte-identical | `diff -r .claude/ internal/template/templates/.claude/` |
+| Sidecar contract | schema_version: 2 보존 (SPC-002 invariant) | T-SPC004-15 16-lang sweep verifies sidecar Load OK |
+| Performance budget | benchmark advisory | `go test -bench BenchmarkResolver_Resolve ./internal/mx/` |
+| MX | @MX tags applied per §6 | manual (post-implementation review) |
+
+---
+
+## 6. @MX Tag Plan (mx_plan)
+
+Apply per `.claude/rules/moai/workflow/mx-tag-protocol.md`. Language: en (per `code_comments: ko` — 한국어, 단 MX tag 본문은 영문 per `feedback_mx_tag_language.md`). 본 plan 자체는 plan markdown 이므로 @MX 태그를 추가하지 않음 (이는 source code 대상). 아래 표는 run-phase 에서 Go 코드에 추가될 태그 (`code_comments: ko` per language.yaml — single-line MX tag is in English by convention).
+
+| File | Tag | Reason |
+|------|-----|--------|
+| `internal/mx/fanin_lsp.go:LSPFanInCounter.Count` | `@MX:ANCHOR @MX:REASON: SPEC-V3R2-SPC-004 의 LSP-first fan_in 단일 진입점; fan_in ≥ 3 (CLI mx_query.go + ResolveAnchorCallsites + future codemaps generator)` | invariant contract + high fan_in |
+| `internal/mx/fanin_lsp.go:LSPFanInCounter` (struct) | `@MX:NOTE: powernap client 의존; `Fallback` 필드 nil 시 LSP 실패가 silent 0-count 으로 transitionm — caller 가 strictMode 분기로 명시 처리해야 함` | non-obvious behavior |
+| `internal/mx/spec_loader.go:LoadSpecModules` | `@MX:NOTE: spec.md frontmatter 의 module 필드는 string 또는 []string 양쪽 형식 허용; runtime type assertion 으로 분기. 추가 형식 (예: nested map) 은 silent ignore — graceful degradation 정책` | parsing 분기 사유 |
+| `internal/mx/danger_category.go:LoadDangerConfig` | `@MX:NOTE: mx.yaml 부재 시 graceful — DefaultDangerCategories 사용; CI 환경 isolation 보장 (config 부재가 lint break 가 아님)` | graceful fallback rationale |
+| `internal/mx/resolver_query.go:validateQuery` (수정 영역) | `@MX:WARN @MX:REASON: --danger 검증 시 dangerMatcher nil 가능성 — default matcher 로 fallback. 호출자가 dangerMatcher 를 항상 주입한다고 가정하는 invariant 위반 시 silent allow` | mutability hazard |
+| `internal/mx/resolver.go:ResolveAnchorCallsites` | `@MX:WARN @MX:REASON: LSP 실패 시 textual fallback 으로 단일 anchor 가 두 가지 fan_in_method 결과를 반환 가능 — caller 가 method 필드를 inspect 하지 않으면 결과 의미가 모호. 명시적 method 필드로 해결` | API surface hazard |
+
+---
+
+## 7. Risk Mitigation Plan (spec §8 risks → run-phase tasks)
+
+| spec §8 risk | Mitigation in run-phase |
+|--------------|--------------------------|
+| Row 1 — Fan_in false positives (textual matches) | T-SPC004-01 LSP-first; T-SPC004-02 method annotation; doc 명시 |
+| Row 2 — `danger_categories:` patterns over-match | T-SPC004-03 user customizable; T-SPC004-06 InvalidQuery 검증; defaults conservative (4 카테고리만) |
+| Row 3 — SPEC association heuristic misses tags | T-SPC004-04, T-SPC004-05 path-based wire; body-based always works (research [E-12]); `--spec none` 잠재 추가 (out-of-scope, advisory) |
+| Row 4 — Output size blows up | already mitigated (--limit default 100, max 10000 — research [E-06]); T-SPC004-13 benchmark verifies pagination |
+| Row 5 — Resolver bypasses SPC-002 freshness | sidecar age check 잠재 추가 (out-of-scope; SPC-002 plan §7 OQ 와 cross-ref) |
+
+추가 mitigation:
+- **OOQ — LSP server 가 16-언어 중 일부에서 부재** (R 등): T-SPC004-01 의 fallback 분기로 silent textual transition + annotation.
+- **OOQ — workspace/symbol query 가 anchor_id 매칭 실패**: G-01 의 fallback 분기 (LSP → textual).
+- **OOQ — spec.md frontmatter 의 module 필드가 nested 형식**: T-SPC004-04 의 graceful skip (`default: []string{}`).
+- **OOQ — TextualFanInCounter 의 filepath.Walk 가 50 anchor × 10K-file 시 O(N²)**: T-SPC004-13 benchmark 가 회귀 detect; advisory cache 도입은 v3.1.
+
+---
+
+## 8. Dependencies (status as of `73742e3ee`)
+
+### 8.1 Blocking (consumed)
+
+- ✅ **SPEC-V3R2-SPC-002** (sidecar contract) — plan PR #836 머지; sidecar 구현은 PR #741 commit `3f0933550` 에서 완료. schema_version: 2 invariant 가정.
+- ✅ **SPEC-LSP-CORE-002** (LSP client via powernap) — assumed merged; `internal/lsp/core/client.go` 가 powernap-based client 노출.
+
+### 8.2 Blocked by (none active)
+
+All blockers are merged or assumed merged. powernap API 변경 시 plan 재조정 필요.
+
+### 8.3 Blocks (downstream consumers)
+
+- **codemaps generation tools** — per-module anchor count 를 본 SPEC 의 `Resolver.Resolve(query)` 로 조회 가능.
+- **SPEC-V3R2-HRN-003** (evaluator MX scoring) — danger_category distribution 을 harness signal 로 사용 가능.
+- **`/moai review` phase** — 잠재 consumer.
+
+---
+
+## 9. Verification Plan
+
+### 9.1 Pre-merge verification (run-phase end)
+
+- [ ] All 20 tasks (T-SPC004-01..20) complete per tasks.md
+- [ ] All 15 ACs (AC-SPC-004-01..15) verified per acceptance.md
+- [ ] `go test -race -count=1 ./...` PASS (no regressions)
+- [ ] `golangci-lint run` clean
+- [ ] `make build` regenerates `internal/template/embedded.go` correctly
+- [ ] Coverage `go test -cover ./internal/mx/ ./internal/cli/` ≥ 85% per package
+- [ ] `diff -r .claude/ internal/template/templates/.claude/` byte-identical (no template change expected)
+- [ ] CHANGELOG entry written in Unreleased section
+- [ ] @MX tags applied per §6 (6 tags)
+- [ ] Manual verification: `moai mx query --kind anchor --fan-in-min 1` against real project, verify LSP path 동작 (gopls available)
+
+### 9.2 Plan-auditor target
+
+- [ ] All 18 unique REQs mapped in §1.5 traceability matrix
+- [ ] All 15 ACs mapped to ≥1 task
+- [ ] No orphan tasks (every task supports ≥1 REQ)
+- [ ] research.md evidence anchors cited (≥30 per plan-audit mandate; current: 45)
+- [ ] §1.2.1 explicitly addresses spec/plan discrepancies (90%+ already implemented; ResolveAnchor signature; JSON envelope; danger 검증 격차; LSP detect; benchmark 형식)
+- [ ] FROZEN clause CONST-V3R2-003 explicitly preserved (mx-tag-protocol.md untouched)
+- [ ] Sidecar schema_version: 2 invariant 보존 명시
+- [ ] Worktree-base alignment per Step 2 (run-phase) called out (§10 below)
+- [ ] §6 mx_plan covers ≥3 of {ANCHOR, WARN, NOTE} types (covered: 1 ANCHOR + 2 WARN + 3 NOTE = 모두 3)
+- [ ] No time estimates (P0/P1 priority labels only)
+- [ ] Parallel SPEC isolation: only `internal/mx/`, `internal/cli/`, `CHANGELOG.md`. .claude/ tree 미변경.
+
+### 9.3 Plan-auditor risk areas (front-loaded mitigations)
+
+- **Risk: SPC-004 가 이미 90%+ 구현 → REQ-001..007 이 redundant 처럼 보임** → §1.2.1 acknowledged; sync-phase HISTORY 에서 spec.md "Expose ... API" → "complete the API to spec parity" reconcile. plan 의 task 는 격차 8개 (G-01..G-08) 에 집중.
+- **Risk: SPC-002 가 schema 를 변경하면 본 SPEC break 가능** → SPC-002 plan §1.4 의 schema_version: 2 invariant 보존 서약 cross-ref. sidecar Load 호환성은 본 SPEC 의 책임.
+- **Risk: powernap API 변경** → assumption (research §8.2). 변경 시 `LSPFanInCounter` 의 client signature 만 조정.
+- **Risk: 16-언어 LSP server 가 사용자 환경에서 일부 부재** → fallback 정책 (G-01 OQ-1). silent textual transition + annotation으로 graceful.
+- **Risk: spec.md `Resolver.ResolveAnchor(anchorID) []Callsite` verbatim 과 현 구현 mismatch** → §1.2.1 acknowledged; G-04 가 additive 로 해결.
+- **Risk: `73742e3ee` baseline drift if main advances during plan PR review** → run-phase 가 명시적으로 `origin/main` 에서 rebase (Step 2 `moai worktree new --base origin/main`).
+- **Risk: G-01 LSP 통합이 powernap 의 안정 API 가 없는 경우 stuck** → research §3.1 의 powernap reference 가 가정. plan 진입 전 powernap signature 검증 필요. 위험 LOW (이미 다른 hook 에서 사용 중).
+- **Risk: T-SPC004-15 의 16-language fixture 가 LSP 비의존이라 G-01 검증 부족** → T-SPC004-01 + T-SPC004-02 의 LSP mock test 가 직교 검증.
+
+### 9.4 Rollback plan (if LSP integration causes regressions)
+
+만약 run-phase 후 LSP 통합 (G-01) 이 unforeseen regressions 을 일으키면:
+1. CLI 의 LSP detect 분기를 unconditional `TextualFanInCounter` 로 fallback (한 줄 변경).
+2. `LSPFanInCounter` 코드는 보존 (`internal/mx/fanin_lsp.go` deleted X — 단 사용 site 비활성화).
+3. Hotfix SPEC 으로 LSP path 점진 재활성화.
+
+만약 G-03 의 SpecAssociator wire-up 이 false-positive (잘못된 SPEC 매칭) 을 양산하면:
+1. CLI 가 `LoadSpecModules` 호출을 skip → empty map 으로 SpecAssociator 초기화.
+2. body-based association (REQ-006 (b)) 만 동작 — existing 동작과 동일 (research [E-12]).
+
+---
+
+## 10. Run-Phase Entry Conditions
+
+After plan PR squash-merged into main:
+
+1. `git checkout main && git pull` (host checkout).
+2. `moai worktree new SPEC-V3R2-SPC-004 --base origin/main` per Step 2 spec-workflow.md.
+3. `cd ~/.moai/worktrees/moai-adk/SPEC-V3R2-SPC-004`.
+4. `git rev-parse --show-toplevel` should output the worktree path (Block 0 verification per session-handoff.md).
+5. `git rev-parse HEAD` should match plan-merge commit SHA on main.
+6. Verify SPC-002 sidecar contract 무결성: `go test ./internal/mx/...` — 기존 SPC-002 + SPC-004 tests still PASS.
+7. Verify powernap LSP client 가용: `go test ./internal/lsp/core/...` PASS.
+8. `/moai run SPEC-V3R2-SPC-004` invokes Phase 0.5 plan-audit gate, then proceeds to M1.
+
+---
+
+Version: 0.1.0
+Status: Plan artifact for SPEC-V3R2-SPC-004
+Run-phase methodology: TDD (per `.moai/config/sections/quality.yaml` `development_mode: tdd`)
+Estimated artifacts: 7 new Go source files + extensions to 4 existing test files + 5 modified Go files + CHANGELOG = ~1,400 LOC delta (production ~480 + test ~920)

--- a/.moai/specs/SPEC-V3R2-SPC-004/progress.md
+++ b/.moai/specs/SPEC-V3R2-SPC-004/progress.md
@@ -1,0 +1,161 @@
+# SPEC-V3R2-SPC-004 Progress Tracker
+
+> Phase tracker shell for **@MX anchor resolver (query by SPEC ID, fan_in, danger category)**.
+> Updated by run-phase agents during M1..M6 execution.
+
+## HISTORY
+
+| Version | Date       | Author                                    | Description |
+|---------|------------|-------------------------------------------|-------------|
+| 0.1.0   | 2026-05-10 | manager-spec (Plan workflow Phase 1B)     | Initial progress.md shell. plan_complete_at populated post-PR-merge. plan_status: audit-ready. |
+
+---
+
+## 1. Phase Status
+
+| Phase   | Status       | Started     | Completed | Notes |
+|---------|--------------|-------------|-----------|-------|
+| Plan    | in-progress  | 2026-05-10  | (TBD)     | plan/SPEC-V3R2-SPC-004 branch open; PR pending squash-merge |
+| Run     | pending      | -           | -         | Awaits plan PR merge + worktree setup |
+| Sync    | pending      | -           | -         | Awaits run PR merge |
+| Cleanup | pending      | -           | -         | Awaits sync PR merge |
+
+Plan-phase status fields:
+- `plan_complete_at`: (set when plan PR merged into main)
+- `plan_status`: draft → **audit-ready** → audited → merged
+
+---
+
+## 2. Plan Phase Checkpoints
+
+- [x] spec.md authored (already present at HEAD `73742e3ee`)
+- [x] research.md authored (Phase 1A — 45 evidence anchors)
+- [x] plan.md authored (Phase 1B — 6 milestones, 20 tasks, 18 REQs traced)
+- [x] acceptance.md authored (15 ACs with Given/When/Then; 11 covered by existing tests)
+- [x] tasks.md authored (20 tasks across M1..M6, no wave-split required)
+- [x] progress.md shell authored
+- [x] issue-body.md authored (PR body draft)
+- [ ] plan-auditor PASS verdict (target ≥ 0.85 first iteration)
+- [ ] plan PR squash-merged into main
+- [ ] plan_complete_at + plan_status = audit-ready persisted
+
+---
+
+## 3. Milestone Tracker (Run Phase)
+
+### M1: LSP `find-references` 통합 (G-01) — Priority P0
+
+- [ ] T-SPC004-01: LSPFanInCounter struct + interface implementation
+- [ ] T-SPC004-02: LSPFanInCounter RED tests (4 sub-tests) + strictMode 강화
+
+Verification gate: `go test ./internal/mx/ -run "TestLSPFanInCounter|TestResolver_AC9_StrictMode"` → all PASS.
+
+### M2: `mx.yaml` `danger_categories:` user wire-up (G-02) — Priority P1
+
+- [ ] T-SPC004-03: LoadDangerConfig helper + 4 RED tests
+- [ ] T-SPC004-06: validateQuery danger 분기 + CLI exit-2 fixture
+
+Verification gate: `go test ./internal/mx/ ./internal/cli/ -run "TestLoadDangerConfig|TestValidateQuery_UnknownDanger|TestMxQueryCmd_AC13_DangerInvalid"` → all PASS.
+
+### M3: `.moai/specs/*/spec.md` `module:` 자동 로드 (G-03) — Priority P1
+
+- [ ] T-SPC004-04: spec_loader.go LoadSpecModules helper
+- [ ] T-SPC004-05: spec_loader RED tests (5 cases) + SpecAssociator integration
+
+Verification gate: `go test ./internal/mx/ -run "TestLoadSpecModules|TestSpecAssociator_PathBased_FromLoader"` → all PASS.
+
+### M4: `Resolver.ResolveAnchorCallsites()` API parity (G-04) — Priority P1
+
+- [ ] T-SPC004-10: Callsite struct + helpers
+- [ ] T-SPC004-11: ResolveAnchorCallsites + 4 RED tests (LSP/textual/exclude-tests/backward-compat)
+
+Verification gate: `go test ./internal/mx/ -run "TestResolver_ResolveAnchorCallsites|TestResolver_ResolveAnchor_BackwardCompat"` → all PASS.
+
+### M5: test_paths glob (G-05) + stderr verify (G-06) — Priority P1
+
+- [ ] T-SPC004-07: isTestFile glob 패턴 wire-up + TextualFanInCounter 확장
+- [ ] T-SPC004-08: isTestFile RED tests (3 sub-tests) + integration
+- [ ] T-SPC004-09: stderr format regression fixture (G-06)
+
+Verification gate: `go test ./internal/mx/ ./internal/cli/ -run "TestIsTestFile_UserPattern|TestTextualFanInCounter_RespectsUserTestPaths|TestSidecarUnavailable_StderrFormat"` → all PASS.
+
+### M6: 16-언어 sweep (G-08) + benchmark (G-07) + verification — Priority P0
+
+- [ ] T-SPC004-12: CLI wire-up — LoadDangerConfig + LoadSpecModules + LSP detect
+- [ ] T-SPC004-13: Performance benchmark fixtures (advisory)
+- [ ] T-SPC004-15: 16-language sweep test
+- [ ] T-SPC004-14: `go test -race -count=1 ./...` PASS
+- [ ] T-SPC004-16: `golangci-lint run` clean
+- [ ] T-SPC004-17: `make build` exits 0; embedded.go regenerated; `diff -r` clean
+- [ ] T-SPC004-18: CHANGELOG.md updated (4 entries)
+- [ ] T-SPC004-19: @MX tags applied per plan §6 (6 tags)
+- [ ] T-SPC004-20: end-to-end manual verification (real LSP + project)
+
+Verification gate: All AC-SPC-004-01..15 verified per acceptance.md.
+
+---
+
+## 4. AC Status Tracker
+
+| AC ID | Status | Verified by | Existing test? | Verified at |
+|---|---|---|---|---|
+| AC-01 | pending | T-SPC004-04, T-SPC004-05, T-SPC004-12 | YES | (TBD) |
+| AC-02 | pending | T-SPC004-01, T-SPC004-02 | YES | (TBD) |
+| AC-03 | pending | T-SPC004-03, T-SPC004-12 | YES | (TBD) |
+| AC-04 | pending | T-SPC004-09, T-SPC004-12 | PARTIAL → fixture added | (TBD) |
+| AC-05 | pending | T-SPC004-15 (sweep) | YES | (TBD) |
+| AC-06 | pending | (existing) | YES | (TBD) |
+| AC-07 | pending | T-SPC004-01, T-SPC004-02 | YES | (TBD) |
+| AC-08 | pending | T-SPC004-13 | YES | (TBD) |
+| AC-09 | pending | T-SPC004-02 (LSP-detect path) | PARTIAL → strictMode 강화 | (TBD) |
+| AC-10 | pending | (existing) | YES | (TBD) |
+| AC-11 | pending | T-SPC004-07, T-SPC004-08 | YES → user_paths added | (TBD) |
+| AC-12 | pending | (existing) | YES | (TBD) |
+| AC-13 | pending | T-SPC004-06 (exit code 2) | PARTIAL → exit code fix | (TBD) |
+| AC-14 | pending | (existing) | YES | (TBD) |
+| AC-15 | pending | T-SPC004-04, T-SPC004-05, T-SPC004-15 | YES → 16-lang sweep extended | (TBD) |
+
+---
+
+## 5. Iteration Tracker (Re-planning Gate)
+
+Per `.claude/rules/moai/workflow/spec-workflow.md` § Re-planning Gate, append per-iteration acceptance criteria completion count + error count delta to detect stagnation (3+ iterations no AC progress → trigger AskUserQuestion gap analysis).
+
+| Iteration | Date | AC completed | Error delta | Notes |
+|---|---|---|---|---|
+| (TBD)     | (TBD) | 0/15        | 0           | First run-phase iteration baseline |
+
+---
+
+## 6. Risk Watch
+
+Per spec §8 + plan §7 + research §10:
+
+| Risk | Status | Mitigation |
+|---|---|---|
+| SPC-004 already implemented 90%+ — REQ redundancy concern | MITIGATED | plan §1.2.1 acknowledged; sync HISTORY reconcile (Expose → complete to parity) |
+| SPC-002 schema break risk | MITIGATED | schema_version: 2 preserved; no sidecar field added by this SPEC; read-only consumer |
+| LSP server unavailable for 16-lang on user host | MITIGATED | Silent fallback to TextualFanInCounter + annotation; strictMode opt-in |
+| `Resolver.ResolveAnchor()` signature mismatch with spec.md | MITIGATED | G-04 additive `ResolveAnchorCallsites()`; existing API unchanged |
+| Performance regression on 50-anchor LSP path | MONITORED | T-SPC004-13 advisory benchmark |
+| isTestFile user pattern over-match | MITIGATED | hard-coded fallback preserved; user pattern is additive |
+| `validateQuery` dangerMatcher nil panic | MITIGATED | T-SPC004-06 default matcher fallback inside validateQuery |
+| spec_loader.go yaml parse failure | MITIGATED | graceful skip per file (T-SPC004-04); empty map on missing dir |
+
+---
+
+## 7. Notes
+
+- Run-phase methodology: TDD per `.moai/config/sections/quality.yaml` `development_mode: tdd`.
+- Worktree base: `origin/main` HEAD `73742e3ee` (plan-phase author baseline; SPC-002 plan PR #836 merge commit).
+- Template-first discipline: this SPEC touches `internal/` Go code only; no template asset changes expected. `make build` regenerates `embedded.go` for safety.
+- Estimated artifacts: 7 new Go source files + extensions to 4 existing test files + 5 modified Go files + CHANGELOG = ~1,400 LOC delta (production ~480 + test ~920).
+- 90%+ of code surface already merged via SPC-004 PR #746 (`68795dbe3`); this SPEC closes 8 격차 (G-01..G-08) per research.md §12.
+- 11 of 15 ACs already covered by existing tests; 4 are PARTIAL/NEW (AC-04 stderr fixture, AC-09 LSP-detect, AC-11 test_paths glob, AC-13 exit code 2).
+
+---
+
+End of progress.
+
+Version: 0.1.0
+Status: Progress shell for SPEC-V3R2-SPC-004

--- a/.moai/specs/SPEC-V3R2-SPC-004/research.md
+++ b/.moai/specs/SPEC-V3R2-SPC-004/research.md
@@ -1,0 +1,554 @@
+# SPEC-V3R2-SPC-004 Research
+
+> Research artifact for **@MX anchor resolver (query by SPEC ID, fan_in, danger category)**.
+> Companion to `spec.md` v0.1.0, `plan.md` v0.1.0, `acceptance.md` v0.1.0, `tasks.md` v0.1.0.
+
+## HISTORY
+
+| Version | Date       | Author                                       | Description |
+|---------|------------|----------------------------------------------|-------------|
+| 0.1.0   | 2026-05-10 | manager-spec (Plan workflow Phase 1A)        | Initial research on existing `internal/mx/{resolver_query,fanin,danger_category,spec_association}.go` (already merged via SPC-004 PR #746 / commit `68795dbe3`), CLI `moai mx query` subcommand current surface, LSP `find-references` integration boundary via powernap, ast-grep / textual fallback policy, SPEC association heuristic distribution across `.moai/specs/*/spec.md` `module:` frontmatter. SPC-002 sidecar contract (PR #836 plan-only at `73742e3ee`; sidecar code from PR #741 commit `3f0933550`) is the consumed dependency. |
+
+---
+
+## 1. Research Scope and Method
+
+### 1.1 Scope
+
+본 research 는 다음 10개 축에 대한 plan-phase 의사결정 근거를 수집한다:
+
+1. **현행 `internal/mx/` 패키지의 SPC-004 표면** — `resolver_query.go` / `fanin.go` / `danger_category.go` / `spec_association.go` / `resolver.go` 가 spec.md §5 의 어떤 REQ 를 어느 정도까지 충족하고 있는지 SHA-anchored inventory.
+2. **`moai mx query` CLI subcommand 현재 surface** — `internal/cli/mx_query.go` 의 cobra subcommand 정의 + 10개 flag (`--spec`, `--kind`, `--fan-in-min`, `--danger`, `--file-prefix`, `--since`, `--limit`, `--offset`, `--format`, `--include-tests`) 가 spec §2.1 verbatim 과 일치하는지.
+3. **SPC-002 sidecar 의존 contract** — `internal/mx/sidecar.go` 의 `Sidecar` struct 와 `Manager.Load()` API 가 resolver 의 read-only 입력으로 어떻게 소비되는지. SPC-002 plan PR #836 (commit `73742e3ee`) 의 schema_version: 2 invariant 보존 의무.
+4. **LSP `find-references` 통합 경로** — `internal/lsp/core/client.go` 의 textDocument/references 호출 가능성; 16-언어 중 어느 언어가 powernap 에서 LSP server 를 가지고 있는지; spec §5.2 REQ-003 의 LSP 우선 + textual fallback 정책.
+5. **ast-grep / textual fallback** — `internal/astgrep/scanner.go` 가 fan_in 측정용으로 사용 가능한지; `TextualFanInCounter` 의 false-positive 위험.
+6. **SPEC association 휴리스틱** — `.moai/specs/*/spec.md` frontmatter 의 `module:` 필드 분포; tag body 의 `SPEC-[A-Z0-9-]+` regex 패턴 매칭 fidelity (spec §5.1 REQ-006 (a)/(b) 분기).
+7. **danger_categories mapping** — `mx.yaml` 의 `danger_categories:` 키 default 값 (concurrency / resource-leak / cleanup / security) 분포; 사용자 정의 패턴 확장 경로.
+8. **Pagination + limit truncation** — `--limit` 기본 100 / 최대 10000 정책; `TruncationNotice` emission 시점 + offset 처리.
+9. **Output format triple** — JSON (default) / table / markdown 의 schema 차이; spec §5.1 REQ-005 verbatim 8-필드 schema (kind / file / line / body / reason / anchor_id / created_by / last_seen_at + ANCHOR-only fan_in + WARN-only danger_category + spec_associations).
+10. **Downstream consumer survey** — codemaps generation / evaluator-active scoring (HRN-003) / `/moai review` phase 가 resolver API 를 어떻게 소비할지.
+
+### 1.2 Method
+
+- **Static analysis**: `internal/mx/{resolver_query,fanin,danger_category,spec_association,resolver}.go` 직접 read; existing `@MX:ANCHOR` / `@MX:WARN` 태그 인벤토리.
+- **CLI surface probe**: `internal/cli/mx_query.go` 의 cobra subcommand 트리 + flag 정의 검사.
+- **Test fixture audit**: `internal/mx/resolver_query_test.go` (~30KB) + `internal/cli/mx_query_test.go` 의 AC-SPC-004-NN 매핑 verbatim grep.
+- **Git history**: `git log --oneline -- internal/mx/resolver_query.go internal/mx/fanin.go internal/mx/danger_category.go internal/mx/spec_association.go cmd/moai/mx.go internal/cli/mx*.go` 로 SPC-004 commit 흐름 재구성.
+- **Cross-SPEC reference**: SPEC-V3R2-SPC-002 (sidecar contract — plan PR #836 머지), SPEC-LSP-CORE-002 (LSP client via powernap), SPEC-V3R2-HRN-003 (evaluator scoring — downstream).
+- **Pattern source**: `.moai/design/v3-redesign/synthesis/pattern-library.md` §T-1 priority 1 (ACI strongest single leverage), `design-principles.md` §P2 (Interface Design Over Tool Count).
+- **Evidence anchoring**: 각 finding 은 file:line 또는 commit SHA 를 인용. 추정 금지.
+
+### 1.3 Evidence Anchor Inventory
+
+본 research 는 plan-auditor PASS 기준 (#4 ≥ 30 evidence anchors) 충족을 목표로 한다. 인용은 [E-NN] 으로 표기하고 §11 에서 합산.
+
+---
+
+## 2. Current-State Inventory (HEAD `73742e3ee`)
+
+### 2.1 `internal/mx/` SPC-004 영역 인벤토리
+
+`internal/mx/` 는 18개 파일 (9 source + 9 test) 을 포함한다 (HEAD `73742e3ee` 기준). 그 중 SPC-004 가 도입한 4개 source + 4개 test:
+
+| File | LOC (approx) | 책임 | Evidence anchor |
+|------|--------------|------|-----------------|
+| `resolver_query.go` | 407 | `Query` struct + `TagResult` schema + `QueryResult` (with TruncationNotice/TotalCount) + `Resolver.Resolve()` filter composition + `applyFilters()` AND logic + `FormatTable()` / `FormatMarkdown()` + 3 sentinel errors (`SidecarUnavailableError`, `LSPRequiredError`, `InvalidQueryError`) + `validateQuery()` + `resolveLimit()` | [E-04], [E-05], [E-06] |
+| `fanin.go` | 118 | `FanInCounter` interface (Count signature with `excludeTests` bool) + `TextualFanInCounter` struct (filepath.Walk + line-grep) + `isTestFile()` (suffix `_test.go` + path part `tests`/`fixtures`/`testdata`) | [E-07], [E-08] |
+| `danger_category.go` | 100 | `DangerCategoryConfig` (yaml-tagged) + `DangerCategoryMatcher.Match()` / `CategoryOf()` / `ValidateCategory()` / `KnownCategories()` + `DefaultDangerCategories` (4 categories: concurrency / resource-leak / cleanup / security) | [E-09], [E-10] |
+| `spec_association.go` | 76 | `SpecAssociator` (specID → []modulePath map) + `Associate()` (path-prefix + body regex 합성) + `ExtractSpecIDs()` (regex `SPEC-[A-Z0-9][A-Z0-9-]*`) + `isFileUnderModules()` | [E-11], [E-12] |
+| `resolver.go` | 87 | `Resolver` 구조체 + `NewResolver(*Manager)` + `ResolveAnchor()` / `ResolveAll()` / `ListAnchors()` / `AuditLowFanIn()` (placeholder) | [E-13], [E-14] |
+
+Evidence anchor [E-01]: `ls -la internal/mx/` 출력 — 18 파일 (2026-05-10).
+Evidence anchor [E-02]: `git log --oneline -- internal/mx/resolver_query.go internal/mx/fanin.go internal/mx/danger_category.go internal/mx/spec_association.go` 출력 → `68795dbe3 feat(mx): SPEC-V3R2-SPC-004 — @MX anchor resolver query API + moai mx query CLI (#746)` + `9ce15872b feat(mx): SPEC-V3R2-SPC-004 GREEN` + `ff887abcd test(mx): SPEC-V3R2-SPC-004 RED — Resolver.Resolve query API + 15 AC tests` + `e97ebf1ed refactor(mx): SPEC-V3R2-SPC-004 REFACTOR — golangci-lint 수정 + godoc 개선` + `fe0901cdc chore(i18n): translate Korean comments to English (batch B) (#783)`.
+Evidence anchor [E-03]: SPC-004 PR #746 가 ff887abcd → 9ce15872b → e97ebf1ed → 68795dbe3 의 4-commit RED → GREEN → REFACTOR → MERGE 시퀀스로 구현되었다.
+
+### 2.2 SPC-004 본 SPEC 의 구현 진척도
+
+SPC-004 PR #746 (`68795dbe3`, 2026-04-30) 머지로 인해 본 SPEC 의 in-scope 영역 (spec §2.1) 이 사실상 완전히 코드 상에 존재한다. 본 plan-phase 의 임무는 빌드가 아니라 **격차 확인 + AC parity 검증 + 문서/테스트 강화**다.
+
+이미 구현된 항목 (✅ 완료):
+
+- `Query` struct + 10 filter 필드 — Evidence [E-04]: `internal/mx/resolver_query.go:11-51` (SpecID / Kind / FanInMin / Danger / FilePrefix / Since / Limit / Offset / IncludeTests + 내부 필드 fanInCounter / dangerMatcher / specAssociator / projectRoot).
+- `Resolver.Resolve(query) (QueryResult, error)` Go API — Evidence [E-05]: `internal/mx/resolver_query.go:159-263` 전체 함수.
+- `Resolver.ResolveAnchor(anchorID)` API — Evidence [E-13]: `internal/mx/resolver.go:26-36`. spec §1 verbatim "Resolver.ResolveAnchor(anchorID) []Callsite" 와 비교: 현 구현은 `(Tag, error)` 단일 반환 — `[]Callsite` 분배는 부재 (G-04 참조).
+- `TextualFanInCounter` (LSP unavailable fallback) — Evidence [E-07]: `internal/mx/fanin.go:24-99`. `Count()` 가 `(int, "textual", error)` 반환.
+- `DangerCategoryMatcher` 4개 default 카테고리 — Evidence [E-09]: `internal/mx/danger_category.go:21-40`.
+- `SpecAssociator` path-prefix + body regex 합성 — Evidence [E-11]: `internal/mx/spec_association.go:25-46`.
+- `validateQuery()` + `InvalidQueryError` — Evidence [E-15]: `internal/mx/resolver_query.go:265-275` + 4-error sentinel (Sidecar / LSP / InvalidQuery).
+- Pagination (`--limit` default 100 / max 10000, `--offset` default 0) — Evidence [E-06]: `internal/mx/resolver_query.go:53-57` + `resolveLimit()` at line 149-157 + offset slicing at line 235-249.
+- `TruncationNotice` emission when totalCount > limit+offset — Evidence [E-16]: `internal/mx/resolver_query.go:256` `truncationNotice := totalCount > limit+offset`.
+- JSON output schema 11-필드 — Evidence [E-17]: `internal/mx/resolver_query.go:61-85` `TagResult` struct (kind / file / line / body / reason / anchor_id / created_by / last_seen_at / fan_in / fan_in_method / danger_category / spec_associations).
+- `FormatMarkdown()` markdown table — Evidence [E-18]: `internal/mx/resolver_query.go:345-368`.
+- `FormatTable()` columnar — Evidence [E-19]: `internal/mx/resolver_query.go:370-398`.
+- CLI `moai mx query` subcommand — Evidence [E-20]: `internal/cli/mx_query.go:1-184` 전체 file. 10 flag 모두 cobra Flags() 등록 (lines 172-181).
+- `MOAI_MX_QUERY_STRICT=1` env 처리 — Evidence [E-21]: `internal/mx/resolver_query.go:195-202`. strictMode + needsFanIn → `LSPRequiredError`.
+- `IncludeTests` bool flag → `excludeTests = !query.IncludeTests` 전달 — Evidence [E-22]: `internal/mx/resolver_query.go:216`.
+- AND-composed multi-filter — Evidence [E-23]: `internal/mx/resolver_query.go:278-340` `applyFilters()` 가 모든 filter 를 순차 evaluate; 한 단계라도 fail 시 `(TagResult{}, false)` 반환.
+
+격차 / 보강 영역 (본 SPEC 의 run-phase scope — 아래 §2.3 G-NN):
+
+### 2.3 격차 인벤토리 (G-01..G-08)
+
+| ID | Gap | Spec 출처 | Current state | Action category |
+|----|-----|-----------|---------------|-----------------|
+| **G-01** | LSP `find-references` integration via powernap (LSP-first, textual fallback) | spec §2.1 + §5.2 REQ-003 + §5.3 REQ-020 | ❌ 부재. `FanInCounter` 인터페이스만 정의 (E-07); LSP-backed 구현체 없음. CLI 가 `TextualFanInCounter` 만 사용 (E-22). spec §5.2 REQ-003 "shall compute fan_in for `@MX:ANCHOR` tags using LSP `find-references` when an LSP server is available" 미충족 | New `LSPFanInCounter` |
+| **G-02** | `mx.yaml` `danger_categories:` 의 사용자 정의 로드 wire-up | spec §3 + §5.1 REQ-001 (`--danger <category>`) | ⚠ 부분. `DangerCategoryConfig` yaml 태그는 정의 (E-09); 그러나 CLI / Resolver 호출 site 가 mx.yaml 을 read 해서 `NewDangerCategoryMatcher(cfg)` 에 주입하지 않음. 항상 `DefaultDangerCategories` 만 사용 — Evidence [E-24]: `internal/cli/mx_query.go` 어디에도 `LoadConfig` / `yaml.Unmarshal(mx.yaml)` 없음 | New `mx.LoadDangerConfig()` + CLI wire |
+| **G-03** | SPEC `module:` 필드 자동 로드 + `SpecAssociator` 주입 | spec §5.1 REQ-006 (a) "tag's file path falls under a module listed in the SPEC's `module:` frontmatter" | ❌ 부재. `SpecAssociator` 는 `map[string][]string` 받지만 (E-11), CLI 가 `.moai/specs/*/spec.md` 의 frontmatter 를 read 해서 map 을 구성하는 로직 없음. CLI 가 항상 `NewSpecAssociator(map[string][]string{})` (E-23 lines 184-187 inside Resolve, 단 그것도 fallback) — 결국 path-based association 이 동작하지 않음 | New `mx.LoadSpecModules()` + CLI wire |
+| **G-04** | `Resolver.ResolveAnchor(anchorID) []Callsite` API parity | spec §2.1 + §5.1 (signature) | ⚠ Signature mismatch. 현 `ResolveAnchor` 는 `(Tag, error)` 반환 (E-13); spec verbatim 은 `[]Callsite` (multi-callsite enumeration). G-01 의 LSP 통합 후 `ResolveAnchorCallsites()` 신규 메서드 추가 권장 (기존 API 보존, additive) | New `Resolver.ResolveAnchorCallsites()` (additive) |
+| **G-05** | `--include-tests` 의 한 단계 더 — `mx.yaml test_paths:` 사용자 정의 패턴 | spec §5.5 REQ-040 + DangerCategoryConfig.TestPaths field | ⚠ 부분. `DangerCategoryConfig.TestPaths` field 는 정의 (E-09 line 18); 그러나 현 `isTestFile()` 는 hard-coded `_test.go` / `tests` / `fixtures` / `testdata` 만 검사 (E-08 lines 31-45). 사용자 정의 패턴 무시 | Wire `cfg.TestPaths` 를 `isTestFile()` 에 주입 |
+| **G-06** | `SidecarUnavailableError` 발생 시 stderr 메시지 형식 검증 | spec §5.2 REQ-013 + AC-04 | ⚠ 부분. CLI 가 stderr 에 `"SidecarUnavailable: sidecar index does not exist — run '/moai mx --full' to rebuild index\n"` 출력 (E-25: `internal/cli/mx_query.go:99-103`); spec verbatim 은 "suggests `/moai mx --full`" — substring 일치 OK. AC-04 fixture 가 stderr capture 검증 필요 | Verify (test fixture 보강) |
+| **G-07** | Performance budget 검증 — <100ms 1K tags / <2s with LSP for 50 anchors | spec §7 Constraints | ⚠ 미검증. benchmark fixture 부재. `TextualFanInCounter` 의 `filepath.Walk` 가 매 ANCHOR 마다 전체 트리 재순회 — 50 anchor × 10K-file repo 시 50 × O(N) (성능 risk). LSP-backed 가 도입되면 단일 LSP 호출로 측정 가능 | Add benchmark + advisory budget assertion |
+| **G-08** | 16-언어 fixture sweep — 모든 언어에서 fan_in / SPEC association 동작 검증 | spec §1 (16-language neutrality) + master-v3 §7.3 | ❌ 부재. 현 test 가 Go fixture 위주. `comment_prefixes.go` 가 16-lang 매핑은 보장하나 (SPC-002 res §5), resolver 의 fan_in / SPEC association 이 16 언어 전반에서 작동하는지 sweep test 없음 | New `TestResolver_AllSixteenLanguages` |
+
+Net actionable scope (Run-phase): **8 격차 해소** (G-01 ~ G-08) + 정합성 검증 (race detector clean, coverage ≥ 85%, AC-15 sweep).
+
+### 2.4 SPC-002 sidecar contract 의존
+
+본 SPEC 은 SPC-002 (PR #836 plan-only at `73742e3ee`; 실제 sidecar 구현은 PR #741 commit `3f0933550` Wave 3) 의 sidecar 를 read-only 로 소비한다. 의존 표면:
+
+| Sidecar 표면 | Resolver 사용 site | Evidence |
+|-------------|-------------------|----------|
+| `Sidecar` struct (`SchemaVersion: 2`, `Tags []Tag`, `ScannedAt time.Time`) | `r.manager.Load()` → `sidecar.Tags` iteration | [E-26]: `internal/mx/sidecar.go:23-33` + `resolver_query.go:174-177` |
+| `SidecarFileName = "mx-index.json"` 상수 | `os.Stat(sidecarPath)` → `SidecarUnavailable` 분기 | [E-27]: `internal/mx/sidecar.go:16-17` + `resolver_query.go:169-172` |
+| `Manager.Load()` API | atomic read with sync.RWMutex | [E-28]: `internal/mx/sidecar.go:131-136` |
+| `Tag.Key()` (file:Kind:line) | (현재 미사용; 향후 dedup 가능) | [E-29]: `internal/mx/tag.go:65-67` |
+| `Tag.IsStale()` 7-day TTL | (현재 미사용; resolver 는 stale 무시 가능) | (advisory; spec §2.2 Out-of-scope) |
+
+본 SPEC 의 `mxTags` field / sidecar schema 변경 권한 없음. SPC-002 의 schema_version: 2 invariant 보존 의무 (SPC-002 plan §1.2.1 + plan §10).
+
+Evidence [E-30]: SPC-002 plan §1.2.1 verbatim — "Schema version 변경 금지 — SPC-004 가 이미 sidecar schema 를 소비 중 (PR #746 머지). 본 SPEC 의 모든 변경은 schema_version: 2 backward-compatible 이어야 한다."
+
+### 2.5 CLI `moai mx query` subcommand 현재 surface
+
+`internal/cli/mx_query.go` 전체 184 LOC. 10 flag 등록:
+
+```
+moai mx query --spec <SPEC-ID> --kind <note|warn|anchor|todo|legacy>
+              --fan-in-min <N> --danger <category> --file-prefix <path>
+              --since <RFC3339> --limit <N> --offset <N>
+              --format <json|table|markdown> --include-tests
+```
+
+cobra Use: "query"; Short: "Query @MX tag sidecar index"; Long: 4-line example block (E-20 lines 32-40).
+
+`moai mx` parent 명령은 SPC-002 의 G-03 격차 (4-flag dispatcher: `--full` / `--index-only` / `--json` / `--anchor-audit`) 가 아직 main 에 없음 (SPC-002 plan PR #836 plan-only 머지). 본 SPEC 의 CLI surface 는 `moai mx query` subcommand 에 한정.
+
+Evidence [E-31]: `internal/cli/mx.go:1-28` parent command 30 LOC; `cmd.AddCommand(newMxQueryCmd())` 만 호출 (line 21).
+
+---
+
+## 3. LSP `find-references` Integration Boundary
+
+### 3.1 powernap LSP client 표면
+
+`internal/lsp/core/client.go` 가 powernap 을 통해 LSP server 와 통신. 16-언어 중 다음이 표준 LSP server 를 가진다 (모든 환경에서 사용 가능 보장은 아님 — 사용자 환경 의존):
+
+| 언어 | LSP server | LSP available 가정 |
+|------|-----------|---------------------|
+| go | `gopls` | YES (대부분 환경) |
+| python | `pylsp` / `pyright` | YES |
+| typescript | `typescript-language-server` | YES |
+| javascript | `typescript-language-server` | YES |
+| rust | `rust-analyzer` | YES |
+| java | `jdtls` / `eclipse.jdt.ls` | YES (heavy startup) |
+| kotlin | `kotlin-language-server` | YES (slow) |
+| csharp | `omnisharp-roslyn` | YES |
+| ruby | `solargraph` | YES |
+| php | `intelephense` | YES |
+| elixir | `elixir-ls` | YES |
+| cpp | `clangd` | YES |
+| scala | `metals` | YES (heavy) |
+| r | `r-languageserver` | OPTIONAL (often unavailable) |
+| flutter (Dart) | `dart` LSP | YES |
+| swift | `sourcekit-lsp` | YES (macOS only typically) |
+
+본 SPEC 의 plan-phase 결정: LSP availability 는 **runtime-detected** (powernap 의 server discovery). 부재 시 silently fallback to `TextualFanInCounter` + annotate `fan_in_method: "textual"` (REQ-SPC-004-020).
+
+Evidence [E-32]: `ls internal/lsp/core/` 출력 — capabilities.go / client.go / document.go 등 12 file. `client.go` 는 15KB, gopls 와의 동기/비동기 호출 추상화.
+
+### 3.2 textDocument/references LSP method
+
+LSP 표준 `textDocument/references` request:
+- params: `{textDocument: {uri}, position: {line, character}, context: {includeDeclaration: false}}`
+- response: `Location[]` array (URI + range)
+
+본 SPEC 의 fan_in 측정 시:
+1. `@MX:ANCHOR` 가 부착된 함수의 위치를 알아야 함. 현 `Tag` struct 는 `(File, Line)` 만 가짐 — anchor 가 위치한 line 의 다음 함수 declaration 을 찾아 그 symbol 의 references 호출. 이는 추가 작업.
+2. 단순화: anchor_id 자체를 symbol name 으로 가정하고 LSP `workspace/symbol` query → 첫 번째 결과의 references 호출.
+
+plan-phase 결정 (OQ-2 below): **단순 경로 채택** — anchor_id 를 symbol query 로 사용. 부정확한 경우 textual fallback annotate. spec §4 가정 "Callsite count for ANCHOR fan_in is precise within 10% of ground truth" 와 일치.
+
+Evidence [E-33]: spec.md §4 Assumption 4 verbatim "Callsite count for ANCHOR fan_in is precise within 10% of ground truth; occasional false positives/negatives acceptable".
+
+### 3.3 strictMode behavior
+
+`MOAI_MX_QUERY_STRICT=1` env 가 set 되고 LSP 가 unavailable 하면 `LSPRequiredError` 반환 (REQ-SPC-004-030). 현재 구현 (E-21) 은 이 분기를 가지나, **LSP availability 검출 로직이 부재** — strictMode 에서는 무조건 `LSPRequired` 반환 (line 195-202 의 todo "(no LSP client)"). G-01 LSP 통합 시 이 분기를 powernap server discovery 결과로 대체.
+
+---
+
+## 4. ast-grep / Textual Fallback
+
+### 4.1 ast-grep 가용성
+
+`internal/astgrep/scanner.go` 13KB + `analyzer.go` 15KB + `rules.go` 5.5KB — astgrep 는 SARIF 분석 + rule-based scanning 용도로 사용되나, fan_in 측정용 일반 symbol search 는 아직 wire-up 되어 있지 않음. spec §5.2 REQ-003 "ast-grep or textual search" 의 "ast-grep" 옵션은 plan-phase 에서 다음 결정을 요구:
+
+- **Option A (채택)**: textual fallback 만 구현 (G-01 의 LSP 통합이 주요 경로). ast-grep 통합은 v3.1 deferred.
+- **Option B (기각)**: ast-grep 의 generic pattern (예: `kind: identifier, regex: "^${ANCHOR_ID}$"`) 로 구조화된 references search.
+
+이유: ast-grep 는 syntax-aware (tree-sitter) 라 false-positive 가 textual 보다 낮으나, anchor_id 가 변수명이 아닌 경우 (예: 자유로운 ID `auth-handler-v1` with hyphen) tree-sitter identifier 노드 매칭이 어려움. textual + LSP 조합으로 충분.
+
+Evidence [E-34]: `internal/astgrep/scanner.go` 의 사용 사례는 SARIF 출력 + lint rule 실행에 한정 — fan_in 통계 사용처 없음.
+
+### 4.2 TextualFanInCounter false-positive 관리
+
+현 `TextualFanInCounter.Count()` (E-07):
+- `filepath.Walk(projectRoot)` 로 모든 file 순회.
+- `vendor` / `node_modules` / `.git` 디렉토리 스킵.
+- target file 자체 제외.
+- excludeTests=true 시 `isTestFile()` 매칭 파일 제외.
+- 각 파일에 대해 `bufio.Scanner` 로 라인 단위 검사, `strings.Contains(line, anchorID)` true 시 count++.
+
+False-positive 위험:
+- `anchorID = "auth"` 같은 짧은 ID: 임의의 strings/comments 에서 substring 매칭.
+- 권장: `auth-handler-v1` 처럼 hyphenated ID 사용 (현 사용 패턴).
+
+본 SPEC 의 plan-phase 결정: false-positive 위험은 spec §4 가정 (10% margin) 으로 수용; LSP 우선 정책으로 minimize. textual annotation `fan_in_method: "textual"` 으로 caller 가 noise 인지 가능.
+
+Evidence [E-35]: `internal/mx/fanin.go:101-117` `countReferencesInFile` — 단순 substring contains. Word-boundary 검사 없음.
+
+### 4.3 isTestFile 확장 가능성
+
+현재 hard-coded path parts: `tests` / `fixtures` / `testdata` (E-08). `mx.yaml` `test_paths:` 사용자 정의 패턴 (E-09 line 18) 이 정의되어 있으나 wire-up 부재 (G-05). plan-phase 결정: G-05 에서 wire-up + glob 패턴 지원 (`path/filepath.Match`).
+
+---
+
+## 5. SPEC Association 휴리스틱
+
+### 5.1 Path-based association (REQ-006 (a))
+
+`SpecAssociator.Associate()` (E-11):
+1. 각 SPEC ID 마다 등록된 module path 리스트 순회.
+2. `isFileUnderModules(tag.File, modulePaths)` → `strings.HasPrefix` 매칭.
+3. 매칭 시 SPEC ID 를 result 에 추가.
+
+**문제**: CLI 가 SPEC frontmatter 를 read 해서 `map[string][]string` 을 구성하는 로직이 없음 (G-03). 현재 모든 호출 site 가 `NewSpecAssociator(map[string][]string{})` (empty map) 사용 — path-based association 항상 disabled.
+
+### 5.2 Body-based association (REQ-006 (b))
+
+`ExtractSpecIDs()` (E-12): regex `SPEC-[A-Z0-9][A-Z0-9-]*` 로 tag body 에서 SPEC ID 직접 추출. 동작 OK.
+
+### 5.3 SPEC frontmatter `module:` 필드 분포
+
+`.moai/specs/*/spec.md` 의 `module:` 필드 sample (현 SPEC 본인 포함):
+
+```
+SPEC-V3R2-SPC-004: module: "internal/mx/resolver.go, cmd/moai/mx.go"
+SPEC-V3R2-SPC-002: module: (frontmatter 부재 또는 다른 형식 — 검증 필요)
+SPEC-V3R2-ORC-003: module: ".claude/agents/*"
+SPEC-V3R2-ORC-004: module: ".claude/rules/moai/workflow/*"
+```
+
+본 SPEC 의 module 필드 verbatim: `"internal/mx/resolver.go, cmd/moai/mx.go"` — 쉼표 구분 string. parsing 시 `strings.Split(",")` + `strings.TrimSpace` 필요.
+
+Evidence [E-36]: spec.md frontmatter line 11 `module: "internal/mx/resolver.go, cmd/moai/mx.go"`.
+
+### 5.4 plan-phase 결정 (OQ-3 below)
+
+**G-03 wire-up 표면**:
+1. CLI 가 `internal/spec/loader.go` 같은 helper 를 호출 (없으면 신규 작성) 해서 `.moai/specs/*/spec.md` 의 frontmatter 를 yaml unmarshal.
+2. `module:` 필드를 쉼표로 split 해서 `[]string` 으로 정규화.
+3. `map[specID][]modulePath` 구성하여 `NewSpecAssociator(map)` 에 전달.
+4. Resolver.Resolve() 호출 site 이전에 1회 실행 (cache; cold-start <100ms).
+
+대안 (기각): SPC-002 sidecar 에 spec_associations 를 미리 계산해서 저장 — schema_version 변경 위험.
+
+---
+
+## 6. danger_categories Mapping
+
+### 6.1 Default 4 categories (E-10)
+
+```go
+var DefaultDangerCategories = map[string][]string{
+    "concurrency":   {"goroutine leak", "unbounded channel", "race condition"},
+    "resource-leak": {"missing Close", "fd leak"},
+    "cleanup":       {"defer missing", "Close not called"},
+    "security":      {"hardcoded credential", "sql injection", "xss"},
+}
+```
+
+Default 매핑이 conservative (낮은 false-positive). 사용자 정의 확장은 `mx.yaml` `danger_categories:` 키.
+
+### 6.2 사용자 정의 wire-up (G-02)
+
+Spec §2.1 + §3 verbatim: `.moai/config/sections/mx.yaml` `danger_categories:` 가 pattern→category map 제공. 현재 (E-24) wire-up 부재. G-02 에서 추가:
+
+```go
+// New helper in internal/mx/danger_category.go
+func LoadDangerConfig(projectRoot string) (DangerCategoryConfig, error) {
+    path := filepath.Join(projectRoot, ".moai/config/sections/mx.yaml")
+    data, err := os.ReadFile(path)
+    if err != nil {
+        if os.IsNotExist(err) {
+            return DangerCategoryConfig{}, nil // graceful → DefaultDangerCategories
+        }
+        return DangerCategoryConfig{}, err
+    }
+    var cfg DangerCategoryConfig
+    if err := yaml.Unmarshal(data, &cfg); err != nil {
+        return DangerCategoryConfig{}, nil // graceful
+    }
+    return cfg, nil
+}
+```
+
+CLI wire: `cfg, _ := mx.LoadDangerConfig(projectRoot)` → `query.dangerMatcher = mx.NewDangerCategoryMatcher(cfg)`.
+
+Evidence [E-37]: `internal/mx/danger_category.go:14-18` `DangerCategoryConfig` 가 yaml-tagged (이미 unmarshal 가능 형태).
+
+### 6.3 `--danger` flag 의 enum validation
+
+현재 (E-15) `validateQuery()` 는 `Kind` 만 enum-check. `--danger` 값은 임의 string 허용 — 미정의 카테고리 입력 시 silent empty result. plan-phase 결정 (OQ-4 below): `--danger` 도 `DangerCategoryMatcher.ValidateCategory()` 로 검증; 미정의 카테고리는 `InvalidQueryError` 반환.
+
+Evidence [E-38]: `internal/mx/danger_category.go:87-90` `ValidateCategory()` 메서드 정의.
+
+---
+
+## 7. Pagination + Output Format
+
+### 7.1 pagination 정책 (E-06 + E-16)
+
+- `--limit` default 100, max 10000, `resolveLimit()` 에서 clamp.
+- `--offset` default 0; negative → 0; `>= len(matched)` → 빈 슬라이스.
+- `TruncationNotice = totalCount > limit + offset` (단순 boolean — 추가 정보 없음).
+
+spec §5.3 REQ-021 verbatim: "WHILE the project contains 10,000+ tags, the resolver SHALL apply `--limit` defaults automatically and emit a `TruncationNotice` in the output header." → 충족.
+
+### 7.2 Output format triple
+
+| Format | Default? | Implementation | Evidence |
+|--------|----------|---------------|----------|
+| json | YES | CLI `json.MarshalIndent(result.Tags, "", " ")` + stderr TruncationNotice | E-39: `internal/cli/mx_query.go:152-164` |
+| table | NO | `mx.FormatTable(result)` — KIND/FILE/LINE/BODY 4-column, "(결과 없음)" empty handler | E-19 + E-40: `internal/cli/mx_query.go:147` |
+| markdown | NO | `mx.FormatMarkdown(result)` — Kind/File/Line/Body/FanIn/Danger/SPECs 7-column | E-18 + E-41: `internal/cli/mx_query.go:150` |
+
+JSON dump 시 `result.Tags` (slice only) 가 stdout, `TruncationNotice` 는 stderr — spec §5.3 REQ-021 "output header" 와 약간 격차 (stderr 가 header 위치는 아님). plan-phase 결정 (OQ-5 below): JSON 출력에 envelope (`{"tags": [...], "truncation_notice": bool, "total_count": N}`) 추가는 backward-incompatible 변경 — 현 형식 유지, stderr 유지. spec §5.3 REQ-021 의 "output header" 는 stderr 로 해석 가능 (CLI semantic).
+
+Evidence [E-42]: `internal/mx/resolver_query.go:88-95` `QueryResult` 가 이미 envelope (`Tags / TruncationNotice / TotalCount`) — Go API 측면에서는 envelope 존재. CLI 가 backward-compat 위해 slice-only 출력 선택.
+
+### 7.3 Empty result handling (REQ-041)
+
+Spec §5.5 REQ-041: "IF a query matches zero tags, THEN the resolver SHALL emit an empty JSON array (not null) and exit with status 0".
+
+현 구현 (E-22 line 252-254):
+```go
+if paginated == nil {
+    paginated = []TagResult{}
+}
+```
+
+→ Go API 는 non-nil empty slice 보장. CLI marshal 시 `json.MarshalIndent([]TagResult{})` → `"[]"` (non-null). 충족.
+
+---
+
+## 8. Cross-SPEC Boundary Survey
+
+### 8.1 SPEC-V3R2-SPC-002 (sidecar contract)
+
+**상태**: plan PR #836 머지 (commit `73742e3ee`, 2026-05-10). 실제 sidecar 구현은 **이미** Wave 3 PR #741 commit `3f0933550` 에 머지되어 있음. SPC-002 plan-phase 는 8 격차 (G-01..G-08) 의 hook integration / CLI flag / archive sweep 을 run-phase 에서 추가 예정.
+
+**본 SPEC 과의 관계**: SPC-002 sidecar 의 read-only consumer. schema_version: 2 invariant 보존 의무.
+
+**영향**: SPC-002 run-phase 에서 sidecar 에 새 필드 추가 (omitempty) 는 본 SPEC 의 Resolve API 에 영향 없음 (existing fields parse). 단, SPC-002 가 schema_version 을 3 으로 올리면 본 SPEC 의 `Manager.Load()` 가 호환성 처리 필요 — plan-phase 결정: SPC-002 schema_version: 2 freeze 가정.
+
+Evidence [E-43]: SPC-002 plan §1.2 "Schema_version 변경 금지 — SPC-004 가 이미 sidecar schema 를 소비 중" verbatim.
+
+### 8.2 SPEC-LSP-CORE-002 (LSP client)
+
+**상태**: assumed merged (powernap-based LSP client 는 `internal/lsp/core/` 에 존재; E-32). LSP server discovery + `textDocument/references` request 는 powernap API 통해 호출 가능.
+
+**본 SPEC 과의 관계**: G-01 의 dependency. LSP-backed `LSPFanInCounter` 구현체가 powernap client 를 호출.
+
+**영향**: powernap API 변경 시 본 SPEC 의 `LSPFanInCounter` 도 영향. plan-phase 결정: powernap 의 안정 API (`Client.References(uri, position)`) 가정.
+
+### 8.3 SPEC-V3R2-HRN-003 (evaluator MX scoring)
+
+**상태**: in-flight (downstream). 본 SPEC 의 resolver API 가 main 에 있음을 전제로 evaluator-active 가 score 계산에 사용 가능.
+
+**영향**: 없음 (one-way produce). 단, evaluator 가 호출하는 query 패턴 (예: `--kind warn --danger security` 등) 이 정착되면 본 SPEC 의 performance budget 검증 우선 순위 ↑.
+
+Evidence [E-44]: spec.md §9.2 Blocks "Evaluator-active scoring (may use danger_category distribution as a harness signal per SPEC-V3R2-HRN-003)".
+
+### 8.4 codemaps generation (downstream)
+
+**상태**: in-flight. `/moai codemaps` 가 per-module anchor count 를 본 SPEC 의 `Resolver.Resolve(query)` 로 조회 가능.
+
+**영향**: 없음 (one-way produce). codemaps 의 호출 패턴은 `--kind anchor --file-prefix <module>` — 현 구현 충족.
+
+### 8.5 pattern-library.md §T-1 priority 1
+
+**상태**: design pattern source. "ACI strongest single leverage pattern" 으로 본 SPEC + SPC-002 + SPC-001 (`/moai mx index --json`) 등을 묶어 6-command suite 로 정의.
+
+**본 SPEC 의 위치**: T-1 priority 1 의 핵심 query command. design-principles.md §P2 "Interface Design Over Tool Count" 와 일치.
+
+Evidence [E-45]: spec.md §10 Traceability "Patterns: T-1 ACI (pattern-library.md §T-1 priority 1 — "6 commands" including `moai_locate_mx_anchor`)".
+
+---
+
+## 9. Decision Log (Plan-Phase Open Questions Resolved)
+
+### OQ-1: G-01 의 LSP-backed fan_in 구현 위치는?
+
+**Decision**: 신규 `internal/mx/fanin_lsp.go` 파일에 `LSPFanInCounter` struct 추가. `FanInCounter` 인터페이스 (E-07) 구현. CLI 가 powernap availability 검출 후 `LSPFanInCounter` (available) 또는 `TextualFanInCounter` (fallback) 선택.
+
+**Rationale**: 인터페이스 분리로 textual / LSP 두 구현체 공존; CLI 의 `query.fanInCounter` 필드에 주입; existing test suite 의 mock 도 가능.
+
+**대안 (기각)**: `TextualFanInCounter` 안에 LSP 분기 — interface segregation 원칙 위배.
+
+### OQ-2: LSP `find-references` symbol resolution 정확도는?
+
+**Decision**: anchor_id 를 `workspace/symbol` query 로 사용. 결과의 첫 번째 매치를 symbol 위치로 가정 → `textDocument/references` 호출. 매치 0건 시 textual fallback + annotate `fan_in_method: "textual"`.
+
+**Rationale**: 단순 경로 우선; spec §4 가정 (10% margin) 수용.
+
+**대안 (기각)**: anchor 가 부착된 line 의 다음 함수 declaration 을 AST 로 찾기 — 추가 tree-sitter 의존성, 본 SPEC scope 초과.
+
+### OQ-3: G-03 의 SPEC frontmatter 로드 helper 위치는?
+
+**Decision**: 신규 `internal/mx/spec_loader.go` (또는 `spec_modules_loader.go`) 에 `LoadSpecModules(projectRoot string) (map[string][]string, error)` 추가. CLI 가 1회 호출, 결과를 `NewSpecAssociator(map)` 에 전달.
+
+**Rationale**: SPC association 의 path-based path 를 주 로직 모듈에 격리; testability ↑ (mock map 주입 가능).
+
+**파싱 형식**: spec.md frontmatter 의 `module:` 값은 string. `strings.Split(",")` + `strings.TrimSpace()` → `[]string`. yaml array 형식 (`module: [path1, path2]`) 도 가능 — yaml.Unmarshal 시 type assertion 으로 양쪽 지원.
+
+### OQ-4: `--danger` 미정의 카테고리 입력 시 동작?
+
+**Decision**: `validateQuery()` 에 `--danger` 검증 추가. `DangerCategoryMatcher.ValidateCategory(query.Danger)` false 시 `InvalidQueryError{Field: "danger", Value: query.Danger, Message: "...allowed: " + strings.Join(matcher.KnownCategories(), ", ")}`.
+
+**Rationale**: spec §5.5 REQ-041 verbatim "if the query's filter values are syntactically invalid, exit status is 2 with `InvalidQuery` error" — semantic enum violation 도 invalid query 범주.
+
+**Edge case**: empty `--danger` (no filter) 는 검증 skip. user-defined category 추가는 mx.yaml 수정 필요.
+
+### OQ-5: JSON 출력 envelope 변경 여부?
+
+**Decision**: 변경 없음. CLI 의 stdout 은 `[]TagResult` slice 직렬화 유지; TruncationNotice 는 stderr. Go API 의 `QueryResult` envelope 는 그대로 노출 (직접 호출자용).
+
+**Rationale**: backward-compatibility (이미 PR #746 merge 후 tooling 이 의존 가능); spec §5.3 REQ-021 "output header" 의 stderr 해석은 CLI semantic 측면에서 acceptable.
+
+**대안 (기각)**: stdout 에 envelope JSON (`{"tags": [...], "truncation_notice": bool}`) 추가 — breaking change.
+
+### OQ-6: G-05 의 `mx.yaml test_paths:` 패턴 형식?
+
+**Decision**: gitignore-style glob (예: `tests/**`, `**/fixtures/`, `**/*_test.go`). `path/filepath.Match` 또는 `doublestar.PathMatch` 사용. 각 패턴은 `tag.File` 의 project-relative path 와 매칭.
+
+**Rationale**: gitignore 표면이 사용자 친화적; existing `internal/mx/scanner.go` 의 ignore 패턴과 일관성.
+
+### OQ-7: G-07 의 performance budget 검증 형식?
+
+**Decision**: benchmark fixture 추가 (`BenchmarkResolver_Resolve_1KTags`) — go test -bench. spec §7 의 <100ms / <2s 는 advisory; CI 에서 강제하지 않음 (machine-dependent). 단 benchmark 가 RED → GREEN 사이클에서 회귀 detect 용도.
+
+**Rationale**: machine variance; CI runner 별 런타임 차이.
+
+### OQ-8: G-08 의 16-언어 fixture 형식?
+
+**Decision**: SPC-002 의 16-language fixture 패턴 차용. `t.TempDir()` 안에 16개 source file 생성, 각 1개 `@MX:NOTE` + 1개 `@MX:ANCHOR` (anchor_id 고유). resolver 가 16 language 모든 파일에서 tag 추출 + fan_in 계산 (textual mode) + SPEC association (path-based + body-based) 동작 검증.
+
+**Rationale**: SPC-002 의 SPC-002 plan §M1 T-SPC002-15 와 일관성; 16-language neutrality는 본 SPEC 의 spec §1 "16-language neutrality" 와 매핑.
+
+### OQ-9: `Resolver.ResolveAnchorCallsites()` 신규 메서드 signature?
+
+**Decision**:
+```go
+// Callsite represents a single reference site for an anchor.
+type Callsite struct {
+    File   string `json:"file"`
+    Line   int    `json:"line"`
+    Column int    `json:"column,omitempty"`
+    Method string `json:"method"` // "lsp" or "textual"
+}
+
+func (r *Resolver) ResolveAnchorCallsites(ctx context.Context, anchorID string, projectRoot string, includeTests bool) ([]Callsite, error)
+```
+
+기존 `ResolveAnchor(anchorID) (Tag, error)` 보존 (additive). spec §1 의 "Resolver.ResolveAnchor(anchorID) []Callsite" verbatim 은 본 새 메서드로 매칭 (이름 추가 — backward compat).
+
+**Rationale**: existing API consumer 보호. callsite enumeration 은 G-01 LSP 통합과 자연스럽게 결합.
+
+---
+
+## 10. Risk Survey (cross-referenced from spec §8)
+
+| Risk | Evidence anchor | Mitigation reference (plan §x) |
+|------|-----------------|--------------------------------|
+| Fan_in false positives (textual matches in strings/comments) | E-35 (substring contains), E-33 (10% margin assumption) | plan §M1 LSP-first counter; annotate `fan_in_method: textual` when fallback |
+| `danger_categories:` patterns over-match | E-10 (default 4-category) | plan §M2 user-customizable via mx.yaml; OQ-4 validation; defaults conservative |
+| SPEC association heuristic misses tags in unrelated files | E-11 + E-12 (path-prefix + body regex) | plan §M3 path-based wire-up (G-03); body-based always works; `--spec none` (advisory) |
+| Output size blows up on `--fan-in-min 0` + no `--limit` | E-06 (default 100), E-16 (TruncationNotice) | already mitigated by default limits |
+| Resolver usage bypasses SPC-002 freshness | E-26 (sidecar Load), E-43 (SPC-002 schema invariant) | sidecar age check 잠재 추가 (plan §M5; advisory) |
+| LSP server unavailability silently breaks fan_in | E-21 (strictMode + fallback), OQ-1 | plan §M1 strictMode 분기 + textual annotation |
+| Performance — 50 anchors × 10K-file repo | E-07 (filepath.Walk per anchor) | plan §M5 LSP single-call; TextualFanInCounter cache 잠재 추가 (advisory) |
+
+---
+
+## 11. Cross-Reference Summary
+
+External references:
+- LSP specification 3.17 textDocument/references
+- powernap LSP client (`internal/lsp/core/`)
+- SPC-002 sidecar contract (PR #836 plan / PR #741 implementation)
+- SPC-004 implementation PR #746 commit `68795dbe3`
+
+Internal file:line anchors:
+- spec.md §1 (Goal), §2 (Scope), §3 (Environment), §4 (Assumptions), §5 (REQ), §6 (AC), §7 (Constraints), §8 (Risks), §9 (Dependencies), §10 (Traceability)
+- plan.md §1 / §M1-M6 / §6 (mx_plan)
+- tasks.md §M1-M6
+- acceptance.md (15 ACs)
+- `internal/mx/{resolver,resolver_query,fanin,danger_category,spec_association,sidecar,tag,scanner,comment_prefixes}.go`
+- `internal/mx/{resolver_query_test,fanin_test,danger_category_test,spec_association_test}.go`
+- `internal/cli/{mx,mx_query,mx_query_test}.go`
+- `internal/lsp/core/{client,capabilities,document}.go` (powernap)
+- `internal/astgrep/{scanner,analyzer,rules}.go` (advisory; not used by SPC-004)
+- `.moai/config/sections/mx.yaml` (config target for danger_categories + test_paths)
+
+Cross-SPEC references:
+- SPEC-V3R2-SPC-002 (sidecar contract — consumed; plan PR #836 merged at `73742e3ee`)
+- SPEC-LSP-CORE-002 (LSP client via powernap — consumed)
+- SPEC-V3R2-HRN-003 (evaluator MX scoring — downstream)
+- SPEC-V3R2-RT-001 (JSON hook protocol — adjacent; not consumed by resolver)
+- pattern-library.md §T-1 priority 1 (ACI design pattern source)
+- design-principles.md §P2 (Interface Design Over Tool Count)
+
+Total evidence anchors: **45** ([E-01]..[E-45]). Plan-auditor PASS criterion #4 (≥30) 충족 + 여유.
+
+---
+
+## 12. Conclusions and Plan-Phase Recommendations
+
+1. **본 SPEC 의 핵심 표면은 이미 main 에 코드로 존재**. SPC-004 PR #746 commit `68795dbe3` 가 `Resolver.Resolve()`, 10-flag CLI, `TextualFanInCounter`, `DangerCategoryMatcher`, `SpecAssociator`, 3개 sentinel error, JSON/table/markdown formatter 모두 구현 완료. 15 AC (AC-SPC-004-01..15) 가 existing test suite 에서 verbatim 매핑되어 PASS 중.
+
+2. **Run-phase 의 임무는 빌드가 아니라 격차 해소 + LSP 통합 + 사용자 정의 wire-up**:
+   - G-01: LSP `find-references` 통합 (powernap-backed `LSPFanInCounter`).
+   - G-02: `mx.yaml` `danger_categories:` 사용자 정의 wire-up.
+   - G-03: `.moai/specs/*/spec.md` `module:` frontmatter 자동 로드 → `SpecAssociator` 주입.
+   - G-04: `Resolver.ResolveAnchorCallsites()` API parity (additive).
+   - G-05: `mx.yaml test_paths:` 패턴 wire-up to `isTestFile()`.
+   - G-06: stderr message format verification (test 보강).
+   - G-07: performance benchmark fixture.
+   - G-08: 16-언어 sweep fixture.
+
+3. **SPC-002 schema invariant 보존**: schema_version: 2 변경 금지. 본 SPEC 의 모든 변경은 read-only on sidecar.
+
+4. **LSP availability 가 runtime detect**: powernap 의 server discovery 결과로 분기. 부재 시 textual fallback + annotation. strictMode 에서는 LSPRequiredError.
+
+5. **15 AC 모두 existing test 커버**: AC-SPC-004-01..15 이 `internal/mx/resolver_query_test.go` 와 `internal/cli/mx_query_test.go` 에 verbatim 명시. 본 SPEC 의 run-phase 는 격차 영역 (G-01..G-08) 의 새 fixture 만 추가.
+
+6. **Performance budget 검증은 advisory**: spec §7 의 <100ms / <2s 는 machine-dependent; CI 강제 X. benchmark fixture 가 회귀 detect 용도.
+
+7. **16-언어 neutrality 는 SPC-002 가 보장**: `comment_prefixes.go` 가 16 lang 매핑 보유. 본 SPEC 의 sweep test 는 resolver-side 검증 (filepath.Walk 가 16 lang 파일 모두 발견; SPEC association 동작; fan_in textual mode 동작).
+
+8. **테스트 인프라 존재**: `internal/mx/resolver_query_test.go` 30KB + `internal/cli/mx_query_test.go` 가 이미 15 AC 매핑. run-phase 는 G-01..G-08 의 새 fixture 만 추가 (~6 새 test functions).
+
+End of research.
+
+Version: 0.1.0
+Status: Research artifact for SPEC-V3R2-SPC-004 (Plan workflow Phase 1A)

--- a/.moai/specs/SPEC-V3R2-SPC-004/tasks.md
+++ b/.moai/specs/SPEC-V3R2-SPC-004/tasks.md
@@ -1,0 +1,634 @@
+# SPEC-V3R2-SPC-004 Task List
+
+> Implementation task list for **@MX anchor resolver (query by SPEC ID, fan_in, danger category)**.
+> Companion to `spec.md` v0.1.0, `plan.md` v0.1.0, `research.md` v0.1.0, `acceptance.md` v0.1.0.
+
+## HISTORY
+
+| Version | Date       | Author                                    | Description |
+|---------|------------|-------------------------------------------|-------------|
+| 0.1.0   | 2026-05-10 | manager-spec (Plan workflow Phase 1B)     | Initial task list. 20 tasks (T-SPC004-01..20) grouped into 6 milestones (M1..M6), priorities P0/P1. Wave-split: tasks fit within ~20 entries — no wave-split needed (under feedback_large_spec_wave_split.md 30-task threshold). |
+
+---
+
+## 1. Task Overview
+
+| Milestone | Phase | Tasks | Priority | REQ Coverage |
+|---|---|---|---|---|
+| M1: LSP `find-references` integration (G-01) | RED → GREEN | T-SPC004-01, T-SPC004-02 | P0 | REQ-003, REQ-011, REQ-020, REQ-030 |
+| M2: `mx.yaml` `danger_categories:` user wire-up + validateQuery 강화 (G-02) | RED → GREEN | T-SPC004-03, T-SPC004-06 | P1 | REQ-001 (`--danger`), REQ-012, REQ-041 |
+| M3: `.moai/specs/*/spec.md` `module:` 자동 로드 (G-03) | RED → GREEN | T-SPC004-04, T-SPC004-05 | P1 | REQ-006, REQ-010 |
+| M4: `Resolver.ResolveAnchorCallsites()` API parity (G-04) | RED → GREEN | T-SPC004-10, T-SPC004-11 | P1 | REQ-002, REQ-003 |
+| M5: test_paths glob (G-05) + stderr verify (G-06) | RED → GREEN | T-SPC004-07, T-SPC004-08, T-SPC004-09 | P1 | REQ-013, REQ-040 |
+| M6: 16-언어 sweep (G-08) + benchmark (G-07) + verify | VERIFY | T-SPC004-12..20 | P0 | (cross-cutting) |
+
+Total: **20 tasks**. Below 30-task threshold → no wave-split required (per `feedback_large_spec_wave_split.md`).
+
+---
+
+## 2. Tasks by Milestone
+
+### Milestone 1: LSP `find-references` 통합 (G-01) — Priority P0
+
+#### T-SPC004-01: Create `internal/mx/fanin_lsp.go` with LSPFanInCounter
+
+**REQ traceback**: REQ-SPC-004-003 (LSP-first), REQ-SPC-004-020 (textual fallback annotation)
+
+**AC traceback**: AC-02, AC-07
+
+**Goal**: Create new `LSPFanInCounter` struct implementing the `FanInCounter` interface (existing `internal/mx/fanin.go` line 13-18). Uses powernap LSP client for `workspace/symbol` + `textDocument/references` queries. Falls back to `TextualFanInCounter` when LSP server unavailable for the target language.
+
+**Files**:
+- `internal/mx/fanin_lsp.go` (new ~150 LOC)
+
+**Sub-tasks**:
+- Define `LSPFanInCounter` struct: `Client *core.Client` (powernap), `ProjectRoot string`, `Fallback FanInCounter`
+- Implement `Count(ctx, tag, projectRoot, excludeTests) (int, string, error)` per plan §4.1 pseudocode
+- Add `langFor(file string) string` helper (extension → LSP language id; reuse comment_prefixes lookup pattern but for LSP language identifier strings)
+- Add `isTestPath(uri string) bool` helper (URI → file path → call existing `isTestFile`; M5 추후 extension)
+- Mock-friendly: `Client` is interface (or pointer to powernap struct that has interface methods); test injects `*mockLSPClient`
+- Returns (count, "lsp", nil) on success; (count, "textual", nil) on Fallback path; (0, "lsp", err) on hard failure with no fallback
+
+**Acceptance**:
+- [ ] Compiles cleanly (`go build ./internal/mx/`)
+- [ ] No cyclic import (verify `go vet ./...`)
+- [ ] `LSPFanInCounter` satisfies `FanInCounter` interface (compile-time assertion `var _ FanInCounter = (*LSPFanInCounter)(nil)`)
+
+**Dependencies**: powernap `core.Client` exposed (research §3.1)
+
+---
+
+#### T-SPC004-02: LSPFanInCounter RED tests + strictMode wire-up
+
+**REQ traceback**: REQ-SPC-004-003, REQ-SPC-004-020, REQ-SPC-004-030
+
+**AC traceback**: AC-02, AC-07, AC-09
+
+**Goal**: Add RED tests for `LSPFanInCounter` covering:
+1. Basic LSP-backed count (workspace/symbol → references → count)
+2. No symbol match → fallback path (textual annotation)
+3. Strict mode + LSP unavailable → `LSPRequiredError`
+4. Test file exclusion (excludeTests=true)
+
+Also: wire up `internal/mx/resolver_query.go` strictMode 분기 (research [E-21] line 195-202) to actually check LSP availability via the injected counter (currently returns unconditional `LSPRequired` — this is a real bug today).
+
+**Files**:
+- `internal/mx/fanin_lsp_test.go` (new ~250 LOC)
+- `internal/mx/resolver_query.go` (modified +20 LOC for strictMode 강화)
+
+**Sub-tasks**:
+- Mock `core.Client`-shaped interface (or use a small internal interface `LSPClient` extracted from powernap surface used by counter)
+- `TestLSPFanInCounter_BasicCount`: mock `WorkspaceSymbol` returns 1 symbol; mock `References` returns 3 locations → assert `(3, "lsp", nil)`
+- `TestLSPFanInCounter_NoSymbolMatch_FallbackToTextual`: mock returns empty WorkspaceSymbol; counter has Fallback=*TextualFanInCounter → assert annotation = "textual"
+- `TestLSPFanInCounter_StrictModeUnavailable`: `MOAI_MX_QUERY_STRICT=1` set via `t.Setenv` (note: parallel-safe — see CLAUDE.local.md §6 OTEL caveat is OTEL-specific, env via t.Setenv on this var is OK), Client.IsAvailable returns false → Resolve returns `*LSPRequiredError`
+- `TestLSPFanInCounter_ExcludeTests`: References returns 5 locations of which 2 are `_test.go` → `excludeTests=true` returns count=3
+- Modify `Resolver.Resolve` strictMode 분기 to call `lspCounter.Client.IsAnyServerAvailable(ctx)` (or equivalent) before returning `LSPRequiredError`
+
+**Acceptance**:
+- [ ] 4 LSPFanInCounter tests PASS
+- [ ] AC-09 fixture (`TestResolver_AC9_StrictModeNoLSP` existing) still PASS with new strictMode logic
+- [ ] No regression in existing `TestTextualFanInCounter_*` tests (research [E-07])
+
+**Dependencies**: T-SPC004-01
+
+---
+
+### Milestone 2: `mx.yaml` `danger_categories:` user wire-up + validateQuery 강화 (G-02) — Priority P1
+
+#### T-SPC004-03: Add LoadDangerConfig helper + RED tests
+
+**REQ traceback**: REQ-SPC-004-001 (`--danger`), REQ-SPC-004-012
+
+**AC traceback**: AC-03
+
+**Goal**: Add `LoadDangerConfig(projectRoot string) (DangerCategoryConfig, error)` to `internal/mx/danger_category.go` (research §6.2 pseudocode). Reads `.moai/config/sections/mx.yaml`, returns `DangerCategoryConfig{}` on file-missing (graceful), graceful skip on parse error. CLI wire-up call site: `internal/cli/mx_query.go` (T-SPC004-12).
+
+**Files**:
+- `internal/mx/danger_category.go` (modified +30 LOC)
+- `internal/mx/danger_category_test.go` (extended +120 LOC)
+
+**Sub-tasks**:
+- Implement `LoadDangerConfig(projectRoot string) (DangerCategoryConfig, error)`
+- `TestLoadDangerConfig_FileMissing_DefaultUsed`: mx.yaml 부재 → returned cfg.Categories empty → `NewDangerCategoryMatcher(cfg)` falls back to DefaultDangerCategories
+- `TestLoadDangerConfig_UserCustomCategories`: mx.yaml with `danger_categories: {critical: ["unwrap()", "panic()"]}` → matcher.Match("function calls unwrap()", "critical") returns true
+- `TestLoadDangerConfig_ParseError_GracefulFallback`: malformed yaml → no panic, returns empty cfg
+- `TestLoadDangerConfig_RespectsTestPaths`: `test_paths: ["**/integration/**"]` → cfg.TestPaths populated correctly
+
+**Acceptance**:
+- [ ] 4 sub-tests PASS
+- [ ] Existing `TestDangerCategoryMatcher_*` tests still PASS
+- [ ] `golangci-lint` clean
+
+**Dependencies**: None (independent helper)
+
+---
+
+#### T-SPC004-06: validateQuery danger 분기 + RED test
+
+**REQ traceback**: REQ-SPC-004-041
+
+**AC traceback**: AC-13
+
+**Goal**: Extend `validateQuery()` in `internal/mx/resolver_query.go` (research [E-15] line 265-275) to validate `query.Danger`. If user passes `--danger frobnicate` (not in known categories), return `*InvalidQueryError`. CLI converts to exit code 2.
+
+**Files**:
+- `internal/mx/resolver_query.go` (modified +20 LOC inside `validateQuery`)
+- `internal/mx/resolver_query_test.go` (extended +60 LOC for new test)
+- `internal/cli/mx_query.go` (modified +10 LOC to ensure exit code 2 on `*InvalidQueryError`)
+- `internal/cli/mx_query_test.go` (extended +40 LOC for CLI exit-2 assertion)
+
+**Sub-tasks**:
+- In `validateQuery(query Query) error`: if `query.Danger != ""`, check `query.dangerMatcher.ValidateCategory(query.Danger)`; if false, return `&InvalidQueryError{Field: "danger", Value: query.Danger, Message: "allowed: " + strings.Join(matcher.KnownCategories(), ", ")}`
+- Handle dangerMatcher nil: instantiate default matcher for validation purposes only
+- `TestValidateQuery_UnknownDanger_InvalidQueryError` (Go API level)
+- `TestMxQueryCmd_AC13_DangerInvalid_Exit2` (CLI level — ensure exit code is exactly 2, not 1)
+- Update CLI `RunE` to map `*InvalidQueryError` to `cobra.SilenceErrors=true` + `os.Exit(2)` path (verify cobra mechanics)
+
+**Acceptance**:
+- [ ] Both new tests PASS
+- [ ] Existing AC-13 fixture (`TestResolver_AC13_InvalidQuery_Kind` line 674) still PASS — kind validation unchanged
+- [ ] CLI exit code is 2 on InvalidQuery (not 1)
+
+**Dependencies**: T-SPC004-03 (DangerCategoryMatcher loaded via LoadDangerConfig)
+
+---
+
+### Milestone 3: `.moai/specs/*/spec.md` `module:` 자동 로드 (G-03) — Priority P1
+
+#### T-SPC004-04: Create `internal/mx/spec_loader.go` with LoadSpecModules
+
+**REQ traceback**: REQ-SPC-004-006 (a)
+
+**AC traceback**: AC-01, AC-15
+
+**Goal**: New file `internal/mx/spec_loader.go` per plan §4.3 pseudocode. Walks `.moai/specs/*/spec.md`, parses yaml frontmatter, extracts `id` + `module` fields, returns `map[specID][]modulePath`. Supports both string format (`module: "a, b"`) and array format (`module: [a, b]`).
+
+**Files**:
+- `internal/mx/spec_loader.go` (new ~80 LOC)
+
+**Sub-tasks**:
+- Implement `LoadSpecModules(projectRoot string) (map[string][]string, error)`
+- Implement `extractFrontmatter(data []byte) []byte` helper (find `---` ... `---` block)
+- Implement `parseModuleField(v interface{}) []string` (string vs []interface{} branch)
+- Use `gopkg.in/yaml.v3` (verify in go.mod; fallback to v2 if needed)
+- Graceful: missing dir → empty map, missing spec.md → skip, parse error → skip
+- `id` fallback: if frontmatter missing `id`, use directory name
+
+**Acceptance**:
+- [ ] Compiles cleanly
+- [ ] No new top-level go.mod dependency (yaml.v3 likely already present; verify)
+- [ ] `go vet` clean
+
+**Dependencies**: None
+
+---
+
+#### T-SPC004-05: spec_loader RED tests + SpecAssociator wire integration
+
+**REQ traceback**: REQ-SPC-004-006
+
+**AC traceback**: AC-01, AC-15
+
+**Goal**: Add 5 RED tests for `LoadSpecModules` and 1 integration test verifying that `SpecAssociator` populated by loader correctly performs path-based association.
+
+**Files**:
+- `internal/mx/spec_loader_test.go` (new ~200 LOC)
+
+**Sub-tasks**:
+- `TestLoadSpecModules_StringFormat`: synthesize `t.TempDir()/.moai/specs/SPEC-X-001/spec.md` with `module: "internal/mx/, cmd/moai/"` → assert `result["SPEC-X-001"] == ["internal/mx/", "cmd/moai/"]`
+- `TestLoadSpecModules_ArrayFormat`: yaml array `module: [internal/foo/, internal/bar/]` → same expected
+- `TestLoadSpecModules_EmptyModule`: `module: ""` or absent → `result["SPEC-X-001"] == []`
+- `TestLoadSpecModules_NoSpecsDir`: no `.moai/specs/` → empty map, no error
+- `TestLoadSpecModules_MultipleSpecs`: 3 specs → 3-entry map
+- `TestSpecAssociator_PathBased_FromLoader` (integration): build SpecAssociator from loader output → tag with file `internal/mx/foo.go` → Associate returns `["SPEC-X-001"]`
+
+**Acceptance**:
+- [ ] 6 sub-tests PASS
+- [ ] Existing `TestSpecAssociator_*` tests (research [E-12]) still PASS
+
+**Dependencies**: T-SPC004-04
+
+---
+
+### Milestone 4: `Resolver.ResolveAnchorCallsites()` API parity (G-04) — Priority P1
+
+#### T-SPC004-10: Create `internal/mx/callsite.go` with Callsite struct
+
+**REQ traceback**: REQ-SPC-004-002, REQ-SPC-004-003
+
+**AC traceback**: (additive — supports AC-02 and downstream consumer needs)
+
+**Goal**: New file `internal/mx/callsite.go` defining the `Callsite` struct (research §9 OQ-9). 30 LOC including JSON tags and small helper.
+
+**Files**:
+- `internal/mx/callsite.go` (new ~30 LOC)
+
+**Sub-tasks**:
+- Define `Callsite` struct with fields: `File string`, `Line int`, `Column int (omitempty)`, `Method string` ("lsp" or "textual")
+- Add `String() string` method for log/debug output
+- Add `IsTestFile() bool` method delegating to `isTestFile(c.File)`
+
+**Acceptance**:
+- [ ] Compiles cleanly
+- [ ] JSON marshal produces expected schema
+
+**Dependencies**: None
+
+---
+
+#### T-SPC004-11: Add Resolver.ResolveAnchorCallsites + RED tests
+
+**REQ traceback**: REQ-SPC-004-002, REQ-SPC-004-003
+
+**AC traceback**: (additive)
+
+**Goal**: Add `ResolveAnchorCallsites(ctx, anchorID, projectRoot, includeTests) ([]Callsite, error)` method to `Resolver` (existing `internal/mx/resolver.go`). Existing `ResolveAnchor(anchorID) (Tag, error)` preserved unchanged.
+
+**Files**:
+- `internal/mx/resolver.go` (modified +50 LOC)
+- `internal/mx/resolver_callsites_test.go` (new ~150 LOC)
+
+**Sub-tasks**:
+- Add private `fanInCounter FanInCounter` field to `Resolver` + setter `WithFanInCounter(c FanInCounter) *Resolver` (builder pattern)
+- Implement `ResolveAnchorCallsites`: lookup tag via existing `ResolveAnchor` → if LSP counter available, call LSP path; else textual walk
+- LSP path: invoke `LSPFanInCounter.Client.WorkspaceSymbol` + `References` → convert `Location[]` to `[]Callsite`
+- Textual path: filepath.Walk + line-grep, on hit append `Callsite{File, Line, Method: "textual"}`
+- `TestResolver_ResolveAnchorCallsites_LSP`: mock LSP client returns 3 locations → 3 Callsites
+- `TestResolver_ResolveAnchorCallsites_TextualFallback`: no LSP → walk-based 3 callsites with method="textual"
+- `TestResolver_ResolveAnchorCallsites_ExcludeTests`: includeTests=false → test files excluded
+- `TestResolver_ResolveAnchor_BackwardCompat`: existing API signature unchanged (compile-time check `var _ func(string) (Tag, error) = (*Resolver).ResolveAnchor`)
+
+**Acceptance**:
+- [ ] 4 sub-tests PASS
+- [ ] Existing `TestResolver_ResolveAnchor_*` (research [E-13]) still PASS
+- [ ] No signature change on `ResolveAnchor` (compile-time)
+
+**Dependencies**: T-SPC004-10 (Callsite struct), T-SPC004-01 (LSPFanInCounter for LSP path test)
+
+---
+
+### Milestone 5: test_paths glob (G-05) + stderr verify (G-06) — Priority P1
+
+#### T-SPC004-07: isTestFile glob 패턴 wire-up
+
+**REQ traceback**: REQ-SPC-004-040
+
+**AC traceback**: AC-11
+
+**Goal**: Extend `isTestFile()` (research [E-08]) to also accept user-defined glob patterns from `mx.yaml` `test_paths:`. Implement `isTestFileWithPatterns(filePath string, userPatterns []string) bool` helper. Existing `isTestFile` callers continue to use hard-coded fallback.
+
+**Files**:
+- `internal/mx/fanin.go` (modified +30 LOC)
+
+**Sub-tasks**:
+- Add helper function `isTestFileWithPatterns(filePath string, userPatterns []string) bool` — first check existing `isTestFile`, then iterate userPatterns calling `path/filepath.Match` (or `doublestar.PathMatch` if available in go.mod)
+- Verify go.mod for `github.com/bmatcuk/doublestar` or similar — if absent, use `filepath.Match` (single-star) for v0.1.0 simplicity
+- Refactor `TextualFanInCounter.Count` to accept user test_paths via constructor: `NewTextualFanInCounter(projectRoot string, testPaths []string)` — backward compat: existing `&TextualFanInCounter{}` still works (testPaths nil → fallback hard-coded only)
+
+**Acceptance**:
+- [ ] Compiles cleanly
+- [ ] Existing `TestTextualFanInCounter_*` tests still PASS (backward compat)
+
+**Dependencies**: None
+
+---
+
+#### T-SPC004-08: isTestFile glob RED tests + integration
+
+**REQ traceback**: REQ-SPC-004-040
+
+**AC traceback**: AC-11
+
+**Goal**: Add 3 RED tests for new helper + integration with TextualFanInCounter.
+
+**Files**:
+- `internal/mx/fanin_test.go` (extended +100 LOC)
+
+**Sub-tasks**:
+- `TestIsTestFile_UserPattern_IntegrationDir`: patterns=`["**/integration/**"]` + file=`internal/foo/integration/bar.go` → true
+- `TestIsTestFile_UserPattern_NoMatch_FallbackHardcoded`: patterns=`["**/integration/**"]` + file=`internal/foo/foo_test.go` → true (hard-coded `_test.go` matches)
+- `TestTextualFanInCounter_RespectsUserTestPaths`: build counter with `testPaths=["**/integration/**"]`, anchor referenced in `internal/foo.go` (1) + `internal/integration/foo_int.go` (1); excludeTests=true → count=1 (integration excluded)
+
+**Acceptance**:
+- [ ] 3 sub-tests PASS
+- [ ] Existing `isTestFile` tests still PASS
+
+**Dependencies**: T-SPC004-07
+
+---
+
+#### T-SPC004-09: stderr format regression fixture (G-06)
+
+**REQ traceback**: REQ-SPC-004-013
+
+**AC traceback**: AC-04
+
+**Goal**: Add explicit fixture asserting that `SidecarUnavailable` stderr message contains BOTH the substring `SidecarUnavailable` AND `/moai mx --full`. Closes the AC-04 verification gap (current test asserts substring only individually, not jointly).
+
+**Files**:
+- `internal/cli/mx_query_test.go` (extended +60 LOC)
+
+**Sub-tasks**:
+- `TestSidecarUnavailable_StderrFormat`: setup `t.TempDir()` project without `.moai/state/mx-index.json`; cd into it; invoke cobra cmd; capture stderr buffer; assert both substrings present in single capture
+- Edge case: assert exact format `SidecarUnavailable: ... /moai mx --full` (per `internal/cli/mx_query.go:99-103` current emission); allow forward compatibility via substring match
+
+**Acceptance**:
+- [ ] Test PASS
+- [ ] Existing `TestMxQueryCmd_AC4_SidecarUnavailable` (line 89) still PASS
+
+**Dependencies**: None (CLI side)
+
+---
+
+### Milestone 6: 16-언어 sweep (G-08) + Performance benchmark (G-07) + verification — Priority P0
+
+#### T-SPC004-12: CLI wire-up — LoadDangerConfig + LoadSpecModules + LSP detect
+
+**REQ traceback**: REQ-SPC-004-001, REQ-SPC-004-006, REQ-SPC-004-012, REQ-SPC-004-013, REQ-SPC-004-030
+
+**AC traceback**: AC-01, AC-03, AC-09 (cross-cutting)
+
+**Goal**: Modify `internal/cli/mx_query.go` `RunE` to:
+1. Call `mx.LoadDangerConfig(projectRoot)` → instantiate `DangerCategoryMatcher` and inject into Query
+2. Call `mx.LoadSpecModules(projectRoot)` → instantiate `SpecAssociator` and inject into Query
+3. Detect LSP availability (powernap server discovery) → choose `LSPFanInCounter` or `TextualFanInCounter`
+4. Wire results into `Resolver.Resolve(query)`
+
+**Files**:
+- `internal/cli/mx_query.go` (modified +60 LOC)
+
+**Sub-tasks**:
+- Add helpers: `loadResolverDeps(projectRoot string) (*mx.DangerCategoryMatcher, *mx.SpecAssociator, mx.FanInCounter, error)`
+- LSP detect: call `core.NewClientFromEnv()` (or whatever powernap exposes); on error → fallback `&mx.TextualFanInCounter{ProjectRoot: projectRoot}`
+- Inject all three into `mx.Query` (extend Query struct exposure or use builder methods on Resolver)
+- Verify CLI tests still pass
+
+**Acceptance**:
+- [ ] CLI compiles cleanly
+- [ ] All 4 P0 ACs (01, 03, 04, 05, 08, 12) still PASS
+- [ ] Manual end-to-end: `moai mx query --kind anchor` against this project returns ≥1 entry
+
+**Dependencies**: T-SPC004-01 (LSPFanInCounter), T-SPC004-03 (LoadDangerConfig), T-SPC004-04 (LoadSpecModules)
+
+---
+
+#### T-SPC004-13: Performance benchmark fixtures (G-07)
+
+**REQ traceback**: spec §7 Constraints (advisory)
+
+**AC traceback**: AC-08 (pagination)
+
+**Goal**: Add benchmark functions for performance regression detection. Advisory only (CI does not enforce thresholds).
+
+**Files**:
+- `internal/mx/resolver_query_bench_test.go` (new ~80 LOC)
+
+**Sub-tasks**:
+- `BenchmarkResolver_Resolve_1KTags`: generate 1000-tag sidecar fixture, b.N iterations of `Resolve(Query{Limit: 100})`. Spec §7 target: <100ms per op (advisory)
+- `BenchmarkResolver_Resolve_50AnchorsLSP`: 50 ANCHOR + LSP mock. Spec §7 target: <2s per op (advisory)
+- `BenchmarkSpecAssociator_Associate_1KSpecs`: scaling check on path-based association (informational)
+- Use `testing.B.ReportMetric` for ns/op + custom metrics
+
+**Acceptance**:
+- [ ] Benchmarks compile cleanly (`go test -bench Benchmark ./internal/mx/ -run='^$'`)
+- [ ] Benchmarks complete without error (no assertions; advisory only)
+
+**Dependencies**: T-SPC004-01 (LSP mock for second benchmark)
+
+---
+
+#### T-SPC004-15: 16-language sweep test (G-08)
+
+**REQ traceback**: REQ-SPC-004-001, spec §1 (16-language neutrality)
+
+**AC traceback**: AC-15 (extends to all 16 languages)
+
+**Goal**: Add `TestResolver_AllSixteenLanguages` per plan §M6 description. Verifies resolver layer (filepath.Walk + SPEC association + fan_in textual mode) works across all 16 supported languages.
+
+**Files**:
+- `internal/mx/resolver_query_test.go` (extended +200 LOC)
+
+**Sub-tasks**:
+- `t.TempDir()` with 16 source files (one per language: go, py, ts, js, rs, java, kt, cs, rb, php, ex, cpp, scala, R, dart, swift)
+- Each file contains 1 `@MX:NOTE` + 1 `@MX:ANCHOR` (anchor_id unique per language: `anchor-go-001`, `anchor-py-001`, ...)
+- Each anchor's `tag.Body` contains explicit `SPEC-LANG-001` body reference (16 different SPEC IDs)
+- Build sidecar via Scanner → Manager.Write
+- Run `Resolver.Resolve(Query{Kind: MXAnchor})` → assert 16 entries
+- Run `Resolver.Resolve(Query{Kind: MXAnchor, FanInMin: 1})` with TextualFanInCounter → assert all 16 have fan_in≥0 (textual scan finds the anchor_id reference in own file at minimum 0; if cross-references seeded, ≥1)
+- Verify each entry's `spec_associations` contains the body-referenced SPEC ID
+
+**Acceptance**:
+- [ ] Test PASS
+- [ ] All 16 languages produce results
+- [ ] Existing AC-15 fixture (`TestResolver_AC15_BodyBasedSpecAssociation` line 449) still PASS
+
+**Dependencies**: SPC-002 Scanner + comment_prefixes (already merged)
+
+---
+
+#### T-SPC004-14: Full test suite + race detector
+
+**REQ traceback**: TRUST 5 Tested
+
+**AC traceback**: All 15 ACs
+
+**Goal**: Run full test suite under race detector with count=1 to disable caching. Zero regressions allowed.
+
+**Sub-tasks**:
+- `go test -race -count=1 ./...` → exit 0
+- If failure: diagnose root cause, fix, re-run
+
+**Acceptance**:
+- [ ] All tests PASS under `-race -count=1`
+- [ ] No flaky tests introduced
+
+**Dependencies**: All other tasks complete
+
+---
+
+#### T-SPC004-16: Lint clean
+
+**REQ traceback**: TRUST 5 Readable
+
+**AC traceback**: (cross-cutting)
+
+**Goal**: `golangci-lint run` produces no warnings on touched files.
+
+**Sub-tasks**:
+- Run `golangci-lint run`
+- Fix any new warnings (especially `errcheck`, `gosec`, `unused`)
+- Ensure new functions have godoc comments per `.claude/rules/moai/languages/go.md` MUST list
+
+**Acceptance**:
+- [ ] `golangci-lint run` exit 0
+- [ ] All exported new symbols have godoc
+
+**Dependencies**: All other tasks complete
+
+---
+
+#### T-SPC004-17: Build + embedded.go regenerate
+
+**REQ traceback**: CLAUDE.local.md §2 Template-First
+
+**AC traceback**: (cross-cutting)
+
+**Goal**: `make build` regenerates `internal/template/embedded.go`. Verify `diff -r .claude/ internal/template/templates/.claude/` is byte-identical (no template change expected for this SPEC since changes are in `internal/`).
+
+**Sub-tasks**:
+- `make build` → exit 0
+- `diff -r .claude/ internal/template/templates/.claude/` → empty output (or only intentional differences from settings.local.json)
+- Verify CLAUDE.local.md §2 Template-First rule respected (no new files in `.claude/` without template counterpart)
+
+**Acceptance**:
+- [ ] `make build` succeeds
+- [ ] Template parity verified
+
+**Dependencies**: All other tasks complete
+
+---
+
+#### T-SPC004-18: CHANGELOG entry
+
+**REQ traceback**: TRUST 5 Trackable
+
+**AC traceback**: (cross-cutting)
+
+**Goal**: Add 4 entries to `CHANGELOG.md` under `## Unreleased` section per plan §M6.
+
+**Sub-tasks**:
+- Append:
+  - `feat(mx/SPEC-V3R2-SPC-004): LSP find-references integration via powernap (LSPFanInCounter)`
+  - `feat(mx/SPEC-V3R2-SPC-004): mx.yaml danger_categories: + test_paths: user wire-up`
+  - `feat(mx/SPEC-V3R2-SPC-004): .moai/specs/*/spec.md module: frontmatter auto-load + SpecAssociator injection`
+  - `feat(mx/SPEC-V3R2-SPC-004): Resolver.ResolveAnchorCallsites() API parity (additive)`
+
+**Acceptance**:
+- [ ] CHANGELOG diff visible in PR
+- [ ] Entries follow Conventional Commits style
+
+**Dependencies**: None
+
+---
+
+#### T-SPC004-19: @MX tags applied
+
+**REQ traceback**: spec §10 Traceability + plan §6
+
+**AC traceback**: (cross-cutting)
+
+**Goal**: Apply 6 @MX tags per plan §6 (mx_plan): 1 ANCHOR + 2 WARN + 3 NOTE.
+
+**Sub-tasks**:
+- Add tags listed in plan §6 to:
+  - `internal/mx/fanin_lsp.go:LSPFanInCounter.Count` → `@MX:ANCHOR` + `@MX:REASON`
+  - `internal/mx/fanin_lsp.go:LSPFanInCounter` (struct) → `@MX:NOTE`
+  - `internal/mx/spec_loader.go:LoadSpecModules` → `@MX:NOTE`
+  - `internal/mx/danger_category.go:LoadDangerConfig` → `@MX:NOTE`
+  - `internal/mx/resolver_query.go:validateQuery` → `@MX:WARN` + `@MX:REASON`
+  - `internal/mx/resolver.go:ResolveAnchorCallsites` → `@MX:WARN` + `@MX:REASON`
+- Verify via `moai mx query --kind anchor --file-prefix internal/mx/fanin_lsp.go` shows ≥1 entry post-implementation
+
+**Acceptance**:
+- [ ] 6 tags present in source
+- [ ] Each WARN tag has sibling `@MX:REASON` (per mx-tag-protocol.md)
+- [ ] ANCHOR tag has fan_in justification
+
+**Dependencies**: All implementation tasks complete
+
+---
+
+#### T-SPC004-20: Manual end-to-end verification
+
+**REQ traceback**: spec §6 (Acceptance) + plan §9.1
+
+**AC traceback**: (smoke test)
+
+**Goal**: Run `moai mx query` against the moai-adk-go project itself and verify results are sensible.
+
+**Sub-tasks**:
+- Build local binary: `make install`
+- `moai mx query --kind anchor --fan-in-min 1 --format json | jq 'length'` → expect ≥1 result
+- Verify at least one entry has `fan_in_method: "lsp"` (gopls running)
+- `moai mx query --danger concurrency --format table` → expect human-readable table
+- `moai mx query --spec SPEC-V3R2-SPC-004 --kind anchor` → expect entries from `internal/mx/` if @MX tags applied (T-SPC004-19)
+- Verify `MOAI_MX_QUERY_STRICT=1 moai mx query --fan-in-min 1` succeeds when LSP is available
+
+**Acceptance**:
+- [ ] All 4 manual verifications pass
+- [ ] Performance is subjectively responsive (<2s for project's tag set)
+
+**Dependencies**: All other tasks complete
+
+---
+
+## 3. Task Dependency Graph
+
+```
+T-SPC004-01 (LSPFanInCounter)
+  ├── T-SPC004-02 (LSP RED tests + strictMode)
+  ├── T-SPC004-11 (ResolveAnchorCallsites — LSP path)
+  └── T-SPC004-12 (CLI wire — LSP detect)
+
+T-SPC004-03 (LoadDangerConfig)
+  └── T-SPC004-06 (validateQuery danger 분기)
+      └── T-SPC004-12 (CLI wire — danger config)
+
+T-SPC004-04 (LoadSpecModules)
+  ├── T-SPC004-05 (spec_loader RED tests + integration)
+  └── T-SPC004-12 (CLI wire — SpecAssociator)
+
+T-SPC004-07 (isTestFile glob helper)
+  └── T-SPC004-08 (isTestFile RED tests)
+
+T-SPC004-10 (Callsite struct)
+  └── T-SPC004-11 (ResolveAnchorCallsites)
+
+T-SPC004-09 (stderr fixture) — independent
+
+T-SPC004-13 (benchmarks) — depends on T-SPC004-01 for LSP mock
+T-SPC004-15 (16-lang sweep) — depends on T-SPC004-04, T-SPC004-05
+
+Verification (no inter-deps among these but order matters):
+  T-SPC004-14 (full suite -race) → T-SPC004-16 (lint) → T-SPC004-17 (build) → T-SPC004-18 (CHANGELOG) → T-SPC004-19 (MX tags) → T-SPC004-20 (manual verify)
+```
+
+Critical path: T-SPC004-01 → T-SPC004-02 → T-SPC004-12 → T-SPC004-15 → T-SPC004-14 → T-SPC004-20.
+
+Parallelizable: M2 (T-03/06), M3 (T-04/05), M5 (T-07/08/09) can run in parallel after M1 LSP scaffolding. M4 (T-10/11) depends on M1 LSP for one test path.
+
+---
+
+## 4. SPC-002 Reuse Plan
+
+본 SPEC 은 SPC-002 의 다음 표면을 read-only consume:
+
+| SPC-002 표면 | SPC-004 사용 site |
+|-------------|-------------------|
+| `mx.Manager` (sidecar I/O) | `Resolver.Resolve` 가 `r.manager.Load()` 호출 (existing) |
+| `mx.Sidecar` struct + schema_version 2 | JSON unmarshal 시 schema check (existing) |
+| `mx.Tag` struct (8 fields) | `applyFilters` + `TagResult` 생성 (existing) |
+| `mx.SidecarFileName` 상수 | os.Stat for SidecarUnavailable detection (existing) |
+| `mx.NewScanner()` + `comment_prefixes.go` | T-SPC004-15 16-lang sweep 가 source file 스캔 시 사용 |
+| `mx.MXNote/MXWarn/MXAnchor/MXTodo/MXLegacy` 상수 | `validKinds` map (existing) + new tests |
+
+본 SPEC 의 sidecar 변경은 0건. SPC-002 의 schema_version: 2 invariant 보존 의무 (plan §1.2.1).
+
+---
+
+## 5. Wave-Split Decision
+
+**Total tasks**: 20.
+**Threshold**: 30 (per `feedback_large_spec_wave_split.md`).
+**Decision**: **No wave-split**. Single PR for run-phase covering all 6 milestones.
+
+Rationale: Total task count is 20 (well below 30-task threshold). Critical path involves M1 → M3 → M6, with parallelizable branches in M2/M3/M5. Estimated ~1,400 LOC delta is within single-PR review capacity.
+
+Risk if wave-split forced: M4 (Callsites API) artificial split would orphan G-04 across PRs. M1 (LSP) scaffolding split would orphan G-01 LSP-backed counter from its consumers (G-04, M6 sweep).
+
+---
+
+End of tasks.
+
+Version: 0.1.0
+Status: Task list for SPEC-V3R2-SPC-004


### PR DESCRIPTION
## Summary

v3 Master Plan **Sprint/Wave 14 Phase 2 (2/2)**. Sibling of SPC-002 (#836). Plan-in-main per `spec-workflow.md` Step 1 + doctrine #822.

Authors 6 plan artifacts for SPEC-V3R2-SPC-004 (`moai mx query` resolver — filter tags by SPEC, kind, fan_in, danger category, file prefix). 15 ACs / 20 tasks / 18 unique REQs traced 1:1 to ACs.

## Reframing — gap closure (90% already merged)

SPC-004 PR #746 commit `68795dbe3` already shipped:
- `resolver_query.go`, `fanin.go`, `danger_category.go`, `spec_association.go`
- 10-flag CLI surface (`--spec`, `--kind`, `--fan-in-min`, `--danger`, `--file-prefix`, `--since`, `--limit`, `--offset`, `--format`, `--include-tests`)
- 11-field JSON schema, 3 sentinel errors

Plan §1.2.1 reframes M1-M5 as **8 격차 G-01..G-08** for run-phase:
- G-01 LSP-backed fan_in via powernap (`internal/mx/fanin_lsp.go` new)
- G-02 danger_categories config schema + validation
- G-03 SPEC frontmatter loader (`internal/mx/spec_loader.go` new)
- G-04 ResolveAnchorCallsites API parity
- G-05 test_paths glob (gitignore-style)
- G-06 stderr TruncationNotice verify
- G-07 performance benchmark (advisory, not CI-enforced)
- G-08 16-language sweep fixture parity with SPC-002

## Plan structure

6 milestones (P0/P1):
- M1 LSP integration — P0
- M2 danger config — P1
- M3 spec loader — P1
- M4 callsite API parity — P1
- M5 test_paths glob + stderr verify — P1
- M6 16-lang sweep + benchmark + verification — P0

20 tasks (T-SPC004-01..20), under wave-split threshold (30+).

## Pre-existing test coverage

11 of 15 ACs grep-verified at `internal/mx/resolver_query_test.go` lines 54/106/145/179/212/254/285/314/342/370/400/449/485/507/643/674. Run-phase gap-closure adds 4 missing ACs (G-### derived) + tightens existing.

## Open questions (run-phase risks)

- **OQ powernap API signature** — verify `Client.WorkspaceSymbol` / `Client.References` / `Client.IsAvailable` stable surface before G-01 implementation. LOW risk (powernap already used in repo).
- **OQ doublestar library** — T-SPC004-07 falls back to `path/filepath.Match` (single-star) if doublestar unavailable in `go.mod`; double-star glob (`**`) limitation noted.
- **OQ cobra exit code 2** — exact mechanism (`cmd.SilenceErrors` + post-RunE hook vs `main.go ExecuteC` analysis) deferred to run-phase first cycle.

## Test plan

- [ ] CI required gates green (Lint / Test 3-OS / Build / CodeQL)
- [ ] plan-auditor verdict (run-phase 진입 시 자동 트리거)
- [ ] Run-phase validates 8 G-### against existing internal/mx/ + adds 4 missing AC fixtures

## Dependencies

- Blocked by: **SPEC-V3R2-SPC-002** (sidecar — plan PR #836 just merged at `73742e3ee`; impl PR #741 commit `3f0933550`)
- Blocks: codemaps generation tools, evaluator-active scoring (HRN-003)

🗿 MoAI <email@mo.ai.kr>