### PR TITLE
plan(spec): SPEC-V3R3-STATUSLINE-FALLBACK-001 — moai statusline stdin fallback 강화

### DIFF
--- a/.moai/specs/SPEC-V3R3-STATUSLINE-FALLBACK-001/acceptance.md
+++ b/.moai/specs/SPEC-V3R3-STATUSLINE-FALLBACK-001/acceptance.md
@@ -1,0 +1,128 @@
+---
+id: SPEC-V3R3-STATUSLINE-FALLBACK-001
+version: "0.2.0"
+status: draft
+created_at: 2026-05-10
+updated_at: 2026-05-10
+author: GOOS행님
+priority: High
+labels: [statusline, fallback, cli]
+issue_number: null
+---
+
+# Acceptance Criteria: SPEC-V3R3-STATUSLINE-FALLBACK-001
+
+## 1. Core Scenarios
+
+### AC-SF-001: Empty stdin Fallback
+
+**When** `parseStdin()`이 `nil`을 반환하면, `moai statusline` **shall** project directory name(`os.Getwd()`의 basename), git branch(filesystem 기반), MoAI-ADK version, rate limits 정보(API usage collector 경유)를 포함한 statusline을 출력한다.
+
+**Verification**: `echo "" | moai statusline` — 출력에 project name과 version 포함 확인.
+
+### AC-SF-002: `{}` Empty JSON Fallback
+
+**When** stdin으로 `{}`이 전달되어 `parseStdin()`이 빈 `StdinData` 구조체를 반환하면, `moai statusline` **shall** 모든 필드 zero-value 상태에서도 fallback이 정상 동작하여 project directory name(`os.Getwd()` basename)과 model name(env/cache fallback 시도)을 표시한다.
+
+**Verification**: `echo '{}' | moai statusline` — crash 없이 정상 3-line 형식 출력.
+
+### AC-SF-003: Model Name Env Fallback
+
+**When** stdin JSON에 `model` 필드가 없고 환경변수 `MOAI_LAST_MODEL`이 `"claude-opus-4-7-20250514"`로 설정되어 있으면, `moai statusline` **shall** statusline에 `"Opus 4.7"`을 표시한다.
+
+**Verification**: `echo '{}' | MOAI_LAST_MODEL=claude-opus-4-7-20250514 moai statusline` — 출력에 "Opus 4.7" 포함.
+
+### AC-SF-004: Model Name Cache Fallback
+
+**When** stdin JSON에 `model` 필드가 없고 `MOAI_LAST_MODEL` env도 없으며 `~/.moai/state/last-model.txt` 파일에 `"claude-sonnet-4-20250514"`가 저장되어 있으면, `moai statusline` **shall** statusline에 `"Sonnet 4"`를 표시한다.
+
+**Verification**: cache file 생성 후 `echo '{}' | moai statusline` — 출력에 "Sonnet 4" 포함.
+
+### AC-SF-005: Model Name Cache Write
+
+**When** stdin JSON에 유효한 model 정보(`{"model": {"display_name": "Opus"}}`)가 포함되어 `CollectMetrics()`가 model name을 추출하면, `moai statusline` **shall** `~/.moai/state/last-model.txt`에 `"Opus"`를 원자적으로 저장한다.
+
+**Verification**: 정상 stdin 전달 후 cache file 내용 확인.
+
+### AC-SF-006: Cwd Guard — Deleted Directory
+
+**When** process의 현재 working directory가 삭제된 directory일 때, `moai statusline` **shall** working directory를 `$HOME`으로 전환하고 project directory name을 `~`로 표시하며 crash 없이 정상 statusline을 출력한다.
+
+**Verification**: 테스트에서 임시 dir 생성 → `os.Chdir()` → dir 삭제 → `Build()` 호출 → 정상 출력 확인.
+
+### AC-SF-007: Sandbox Cwd Priority
+
+**When** stdin JSON의 `cwd`가 `/sandbox/project`이고 process의 `os.Getwd()`가 `/home/user/project`일 때, `extractProjectDirectory()` **shall** stdin의 `cwd` 값을 우선하여 `/sandbox/project`의 basename을 표시한다.
+
+**Verification**: unit test에서 stdin `cwd`와 `os.Getwd()`를 다르게 설정 후 basename 확인.
+
+### AC-SF-008: Happy Path Regression
+
+**Event-driven**: **When** 정상 stdin JSON(모든 필드 포함)이 전달되면, `moai statusline` **shall** 기존과 동일한 3-line statusline을 출력한다. 출력 diff가 발생하지 않아야 한다.
+
+**Verification**: 기존 golden test 통과.
+
+## 2. Edge Case Scenarios
+
+### EC-SF-001: `null` JSON Literal
+
+**When** stdin으로 `null` literal이 전달되면, `moai statusline` **shall** `parseStdin()`이 `nil`을 반환하고 모든 fallback이 정상 동작한다.
+
+**Verification**: `echo 'null' | moai statusline` — 정상 출력.
+
+### EC-SF-002: Cache File Directory 없음
+
+**When** `~/.moai/state/` directory가 존재하지 않을 때 `WriteModelCache()`가 호출되면, `moai statusline` **shall** directory를 자동 생성하고 cache file을 정상 작성한다.
+
+**Verification**: `t.TempDir()` 환경에서 cache write → file 존재 확인.
+
+### EC-SF-003: Cache File Write 실패
+
+**When** cache directory에 write 권한이 없을 때, `WriteModelCache()` **shall** error를 silent ignore하고 statusline 출력에 영향이 없다.
+
+**Verification**: readonly dir에서 `WriteModelCache()` — error 무시 확인.
+
+### EC-SF-004: `MOAI_LAST_MODEL` 빈 문자열
+
+**When** 환경변수 `MOAI_LAST_MODEL`이 빈 문자열(`""`)로 설정되어 있으면, `moai statusline` **shall** 빈 문자열을 유효하지 않은 것으로 간주하고 cache file fallback으로 진행한다.
+
+**Verification**: `echo '{}' | MOAI_LAST_MODEL="" moai statusline` 동작 확인.
+
+### EC-SF-005: Cache File Corrupted
+
+**When** `~/.moai/state/last-model.txt`에 빈 내용이나 binary data가 있으면, `ReadModelCache()` **shall** 빈 문자열을 반환하고 model name은 미표시된다.
+
+**Verification**: corrupt file로 unit test — crash 없음 확인.
+
+## 3. Quality Gates
+
+### AC-SF-QG-001: 테스트 커버리지
+
+- `internal/statusline/` 패키지 coverage >= 85%
+- `internal/cli/statusline.go` coverage >= 85%
+- Race detector: `go test -race ./internal/statusline/... ./internal/cli/...` 통과
+
+### AC-SF-QG-002: Lint
+
+- `golangci-lint run ./internal/statusline/... ./internal/cli/...` zero errors
+- `go vet ./internal/statusline/... ./internal/cli/...` zero errors
+
+### AC-SF-QG-003: 성능
+
+- Empty stdin fallback path의 추가 latency < 1ms (env read + getcwd + file read)
+- 기존 happy path latency 변화 없음 (측정 가능한 regression 없음)
+
+### AC-SF-QG-004: Cross-Platform
+
+- macOS: `os.Getwd()` 정상 동작
+- Linux: 동일
+- Windows: path separator 차이 고려 (`filepath.Base` 사용으로 이미 대응)
+
+## 4. Definition of Done
+
+- [ ] AC-SF-001 ~ AC-SF-008 모두 통과
+- [ ] EC-SF-001 ~ EC-SF-005 모두 통과
+- [ ] AC-SF-QG-001 ~ AC-SF-QG-004 모두 통과
+- [ ] `go test -race ./internal/statusline/... ./internal/cli/...` 통과
+- [ ] 기존 statusline golden test 모두 통과 (regression 없음)
+- [ ] MX tags 5개 이상 적용 (plan.md §5 참조)

--- a/.moai/specs/SPEC-V3R3-STATUSLINE-FALLBACK-001/plan.md
+++ b/.moai/specs/SPEC-V3R3-STATUSLINE-FALLBACK-001/plan.md
@@ -1,0 +1,130 @@
+---
+id: SPEC-V3R3-STATUSLINE-FALLBACK-001
+version: "0.1.0"
+status: draft
+created_at: 2026-05-10
+updated_at: 2026-05-10
+author: GOOS행님
+priority: High
+labels: [statusline, fallback, cli]
+issue_number: null
+---
+
+# Implementation Plan: SPEC-V3R3-STATUSLINE-FALLBACK-001
+
+## 1. Milestone 분해
+
+### M1: Cwd Guard + Project Directory Fallback (P0)
+
+**목표**: `runStatusline()` 시작 부분에 cwd guard 추가, `extractProjectDirectory()` getcwd fallback 구현
+
+**변경 파일**:
+- `internal/cli/statusline.go` — `runStatusline()` 함수 시작 부분에 `os.Getwd()` 검증 추가
+  - `os.Getwd()` 실패 또는 존재하지 않는 directory → `os.Chdir(os.Getenv("HOME"))` 또는 `os.UserHomeDir()`
+  - cwd guard 성공/실패 여부를 `statusline.Options`에 전달 (예: `CwdFallback bool` 또는 별도 flag)
+- `internal/statusline/builder.go` — `extractProjectDirectory()` 수정
+  - 기존 3-level 우선순위 유지
+  - 새로운 4번째 fallback: `os.Getwd()` → `filepath.Base()`
+- `internal/cli/statusline_test.go` — cwd guard 테스트 (t.TempDir() + 삭제 시나리오)
+
+**테스트 전략**:
+- `TestCwdGuard_DeletedDirectory` — 임시 dir 생성 후 삭제 → HOME fallback 확인
+- `TestExtractProjectDirectory_GetwdFallback` — nil input → getcwd basename 확인
+- `TestExtractProjectDirectory_SandboxCwdPriority` — stdin cwd ≠ getcwd → stdin 우선
+
+**MX Tag 대상**:
+- `internal/cli/statusline.go`: `@MX:ANCHOR` on `runStatusline` (public entry point, fan_in >= 3)
+- `internal/statusline/builder.go`: `@MX:NOTE` on `extractProjectDirectory` (fallback chain 설명)
+
+### M2: Model Name Fallback Chain (P0)
+
+**목표**: stdin model 누락 시 env/cache fallback 구현, 정상 수신 시 cache write
+
+**변경 파일**:
+- `internal/statusline/model_cache.go` (신규)
+  - `ReadModelCache(homeDir string) string` — `~/.moai/state/last-model.txt` 읽기
+  - `WriteModelCache(homeDir, modelName string) error` — 원자적 쓰기 (temp + rename)
+  - 부모 directory 자동 생성 (`os.MkdirAll`)
+- `internal/statusline/metrics.go` — `CollectMetrics()` 수정
+  - `input.Model == nil` 또는 model name 비어있을 때 fallback chain:
+    1. `os.Getenv("MOAI_LAST_MODEL")` 조회
+    2. `ReadModelCache(homeDir)` 조회
+    3. 둘 다 없으면 `Available: false` (기존 동작)
+  - 정상 model 수신 시 `WriteModelCache()` 호출 (goroutine 없이 동기식)
+- `internal/statusline/builder.go` — `New()` 옵션에 `HomeDir` 전달 이미 됨 (기존 `usageProvider`용)
+  - `collectAll()`에서 `CollectMetrics(input)` 호출 시 `homeDir` 전달 방식 변경 필요
+  - `CollectMetrics` signature 변경: `CollectMetrics(input *StdinData, homeDir string) *MetricsData`
+- `internal/statusline/metrics_test.go` — fallback chain 테스트
+
+**테스트 전략**:
+- `TestCollectMetrics_NilInput_EnvFallback` — env var 설정 → model name 확인
+- `TestCollectMetrics_NilInput_CacheFallback` — cache file 생성 → model name 확인
+- `TestCollectMetrics_NilInput_NoFallback` — env/cache 모두 없음 → Available: false
+- `TestCollectMetrics_ValidInput_CacheWrite` — 정상 stdin → cache file 생성 확인
+- `TestWriteModelCache_AtomicReplace` — 기존 파일 원자적 교체 확인
+- `TestWriteModelCache_DirCreation` — 부모 dir 없음 → 자동 생성 확인
+
+**MX Tag 대상**:
+- `internal/statusline/model_cache.go`: `@MX:ANCHOR` on `ReadModelCache`/`WriteModelCache`
+- `internal/statusline/metrics.go`: `@MX:NOTE` on `CollectMetrics` (fallback chain 설명)
+
+### M3: Builder Fallback 통합 + Template 정리 (P1/P2)
+
+**목표**: `collectAll()` nil input 시 모든 fallback이 올바르게 동작하는지 통합 테스트, template 선택적 정리
+
+**변경 파일**:
+- `internal/statusline/builder.go` — `collectAll()` 수정
+  - `input == nil`일 때 `os.Getwd()`로 directory fallback
+  - `CollectMetrics`에 `homeDir` 전달
+- `internal/statusline/builder_test.go` (신규 또는 확장)
+  - `TestCollectAll_NilInput` — 모든 collector nil 동작 검증
+  - `TestCollectAll_PartialInput` — 일부 필드만 있는 JSON
+  - `TestCollectAll_EmptyJSON` — `{}` 입력
+  - `TestCollectAll_NullJSON` — `null` 입력
+  - `TestBuild_DeletedCwdFallback` — cwd 삭제 → HOME fallback + project name `~`
+- `internal/template/templates/.moai/status_line.sh.tmpl` — cwd guard 제거 (선택)
+  - Go binary가 cwd guard를 수행하므로 shell-level guard는 중복
+  - 단, 기존 배포된 wrapper와의 호환성을 위해 즉시 제거하지 않고 deprecation comment 추가도 고려
+
+**테스트 전략**:
+- 위 builder_test.go 테스트 케이스
+- `TestBuild_OutputFormat` — nil/partial/normal stdin 모두 3-line 형식 준수 확인
+- Race detector: `go test -race ./internal/statusline/...`
+
+**MX Tag 대상**:
+- `internal/statusline/builder.go`: `@MX:ANCHOR` on `Build` (core pipeline, fan_in >= 5)
+
+## 2. 기술 제약
+
+| 제약 | 근거 |
+|------|------|
+| Zero-regression | 기존 happy path 성능/출력 변경 금지 |
+| 표준 라이브러리만 사용 | 외부 dependency 도입 금지 |
+| 동기식 fallback | env read, getcwd, file read 모두 마이크로초 단위 — goroutine 불필요 |
+| Race-safe cache write | Build 파이프라인 내에서 순차 실행 |
+| t.TempDir() 필수 | 테스트 임시 파일은 모두 `/tmp` 하위 |
+
+## 3. 위험 분석
+
+| 위험 | 확률 | 영향 | 완화 방안 |
+|------|------|------|-----------|
+| Cache file write race (동시 moai statusline 프로세스) | 낮음 | 낮음 (마지막 write 승리, data 손실 없음) | Atomic rename으로 corruption 방지 |
+| HOME env var 미설정 (CI 등) | 낮음 | 중간 | `os.UserHomeDir()` fallback 사용 |
+| `os.Getwd()` 성공했으나 실제로 삭제된 dir인 경우 | 극히 낮음 | 중간 | `os.Stat()`으로 존재 확인 후 Chdir |
+| CollectMetrics signature 변경으로 인한 기존 테스트 break | 중간 | 낮음 | 기존 호출부 모두 업데이트 |
+
+## 4. 의존성
+
+- M1과 M2는 독립적 — 병렬 개발 가능
+- M3는 M1, M2 완료 후 통합
+- Template 변경(M3의 선택 부분)은 `make build` 필요
+
+## 5. MX Tag 요약
+
+| 파일 | Tag Type | 대상 |
+|------|----------|------|
+| `internal/cli/statusline.go` | `@MX:ANCHOR` | `runStatusline` |
+| `internal/statusline/builder.go` | `@MX:ANCHOR` | `Build`, `collectAll` |
+| `internal/statusline/builder.go` | `@MX:NOTE` | `extractProjectDirectory` |
+| `internal/statusline/metrics.go` | `@MX:NOTE` | `CollectMetrics` |
+| `internal/statusline/model_cache.go` | `@MX:ANCHOR` | `ReadModelCache`, `WriteModelCache` |

--- a/.moai/specs/SPEC-V3R3-STATUSLINE-FALLBACK-001/progress.md
+++ b/.moai/specs/SPEC-V3R3-STATUSLINE-FALLBACK-001/progress.md
@@ -1,0 +1,53 @@
+---
+id: SPEC-V3R3-STATUSLINE-FALLBACK-001
+version: "0.1.0"
+status: draft
+created_at: 2026-05-10
+updated_at: 2026-05-10
+author: GOOS행님
+priority: High
+labels: [statusline, fallback, cli]
+issue_number: null
+---
+
+# Progress: SPEC-V3R3-STATUSLINE-FALLBACK-001
+
+## 현재 상태
+
+| 항목 | 상태 |
+|------|------|
+| Research | 완료 (`research.md`) |
+| Spec | 완료 (`spec.md` v0.1.0) |
+| Plan | 완료 (`plan.md` v0.1.0) |
+| Acceptance | 완료 (`acceptance.md` v0.1.0) |
+| Plan Audit | PASS (0.88, iter 2) |
+| M1: Cwd Guard + Directory Fallback | 미시작 |
+| M2: Model Name Fallback Chain | 미시작 |
+| M3: 통합 테스트 + Template 정리 | 미시작 |
+
+## Milestone 추적
+
+### M1: Cwd Guard + Project Directory Fallback
+- [ ] `internal/cli/statusline.go` cwd guard 구현
+- [ ] `internal/statusline/builder.go` `extractProjectDirectory()` getcwd fallback
+- [ ] 단위 테스트 작성
+- [ ] Race detector 통과
+
+### M2: Model Name Fallback Chain
+- [ ] `internal/statusline/model_cache.go` 신규 파일 작성
+- [ ] `internal/statusline/metrics.go` fallback chain 구현
+- [ ] `CollectMetrics` signature 변경 + 기존 호출부 업데이트
+- [ ] 단위 테스트 작성
+- [ ] Race detector 통과
+
+### M3: 통합 테스트 + Template 정리
+- [ ] `internal/statusline/builder_test.go` 통합 테스트
+- [ ] 모든 stdin variant (empty / `{}` / `null` / partial / normal) 테스트
+- [ ] `status_line.sh.tmpl` deprecation comment (선택)
+- [ ] `make build` template 반영
+- [ ] MX tags 적용
+
+## 메모
+
+- OQ-1 (settings.json statusLine 소멸): 본 SPEC에서 defer. 별도 investigation 필요.
+- OQ-2 (git worktree branch mismatch): 확인 후 별도 SPEC 권장. 본 SPEC scope 외.

--- a/.moai/specs/SPEC-V3R3-STATUSLINE-FALLBACK-001/research.md
+++ b/.moai/specs/SPEC-V3R3-STATUSLINE-FALLBACK-001/research.md
@@ -1,0 +1,157 @@
+# Research: SPEC-V3R3-STATUSLINE-FALLBACK-001
+
+## Statusline Architecture
+
+### Call Chain
+
+```
+settings.json statusLine.command → bash .moai/status_line.sh → moai statusline (Go binary)
+                                                               ↓
+                                                         readStdinWithTimeout()
+                                                               ↓
+                                                         statusline.New(opts).Build(ctx, stdinData)
+                                                               ↓
+                                                         parseStdin(r) → *StdinData (nil on error)
+                                                               ↓
+                                                         collectAll(ctx, input) → *StatusData
+                                                               ↓
+                                                         renderer.Render(data, mode) → string
+```
+
+### Key Files
+
+| File | Purpose | Lines |
+|------|---------|-------|
+| `internal/cli/statusline.go` | CLI entry point, stdin reading, config loading | 169 |
+| `internal/statusline/builder.go` | Build pipeline: parseStdin → collectAll → Render | 315 |
+| `internal/statusline/renderer.go` | 3-line/5-line layout rendering | 537 |
+| `internal/statusline/types.go` | StdinData JSON schema, type definitions | 315 |
+| `internal/statusline/metrics.go` | Model/cost extraction from stdin | 193 |
+| `internal/statusline/memory.go` | Context window extraction + GLM context window override | 286 |
+| `internal/template/templates/.moai/status_line.sh.tmpl` | Shell wrapper (stdin relay to Go binary) | 36 |
+
+### StdinData JSON Schema (types.go:57-71)
+
+```go
+type StdinData struct {
+    HookEventName  string             `json:"hook_event_name"`
+    SessionID      string             `json:"session_id"`
+    TranscriptPath string             `json:"transcript_path"`
+    CWD            string             `json:"cwd"`        // Legacy
+    Model          *ModelInfo         `json:"model"`       // Can be object or string
+    Workspace      *WorkspaceInfo     `json:"workspace"`
+    Cost           *CostData          `json:"cost"`
+    ContextWindow  *ContextWindowInfo `json:"context_window"`
+    OutputStyle    *OutputStyleInfo   `json:"output_style"`
+    RateLimits     *RateLimitInfo     `json:"rate_limits"`
+    Effort         *EffortInfo        `json:"effort"`
+    Thinking       *ThinkingInfo      `json:"thinking"`
+    Version        string             `json:"version"`
+}
+```
+
+## Current Fallback Behavior Analysis
+
+### parseStdin() — builder.go:166-179
+
+When stdin is empty, `{}`, `null`, or invalid JSON:
+- `json.Decoder.Decode(&input)` returns error → `slog.Debug(...)` → returns `nil`
+- No data is preserved; entire stdin is discarded
+
+### collectAll() — builder.go:183-288 with `input == nil`
+
+| Collector | With nil input | Result |
+|-----------|---------------|--------|
+| `CollectMemory(nil)` | `input == nil \|\| input.ContextWindow == nil` | `{Available: false}` — no CW bar |
+| `CollectMetrics(nil)` | `input == nil` | `{Available: false}` — no model name |
+| `CollectTask()` | No stdin dependency | Works — shows active task |
+| `extractProjectDirectory(nil)` | `input == nil` | `""` — no directory shown |
+| Worktree extraction | `input == nil` | `""` — no WT indicator |
+| OutputStyle | `input == nil` | `""` — no output style |
+| ClaudeCodeVersion | `input == nil` | `""` — no CC version |
+| RateLimits | `input == nil` | `nil` — falls through to Usage API call |
+| Effort/Thinking | `input == nil` | `nil` — no effort display |
+| **Git collector** | Independent (filesystem) | **Works** — branch, status |
+| **Version collector** | Independent (config) | **Works** — MoAI version |
+
+### Summary: What breaks on empty stdin
+
+- **Model name**: Missing entirely — most impactful user-visible gap
+- **Project directory**: Missing — `renderDirGitLine` shows only branch
+- **Context window bar**: Not shown — `Available: false`
+- **Rate limits**: Missing — triggers blocking API call (5s timeout) which causes statusline disappearance
+- **Claude Code version**: Missing
+- **Output style**: Missing
+- **Worktree indicator**: Missing
+- **Effort/Thinking**: Missing
+
+### What still works on empty stdin
+
+- Git branch + ahead/behind
+- Git status (staged/modified/untracked)
+- MoAI-ADK version
+- Active task display
+
+## Shell Wrapper (status_line.sh.tmpl)
+
+The shell wrapper:
+1. Creates temp file, reads stdin into it
+2. Sources GLM env vars
+3. Tries `moai` in PATH, then hardcoded Go bin path, then `$HOME/.local/bin/moai`
+4. Passes temp file as stdin to `moai statusline`
+
+**Problem**: The cwd guard (from stash@{0}) was added to the *local* `.moai/status_line.sh` but NOT to the template. The template has NO cwd guard. This means:
+- Template-generated statusline scripts have no cwd protection
+- The cwd guard needs to move into the Go binary itself
+
+## Test Coverage Gaps
+
+### Existing tests (internal/cli/statusline_test.go)
+- Command registration (exists, hidden, subcommand)
+- `renderSimpleFallback()` — returns "moai"
+- `loadSegmentConfig()` — YAML parsing
+- `loadStatuslineFileConfig()` — YAML parsing
+
+### Missing tests
+- **parseStdin with empty reader** — what happens with `io.MultiReader()`
+- **parseStdin with `{}`** — empty JSON object
+- **parseStdin with `null`** — null literal
+- **parseStdin with partial JSON** — e.g., `{"model": null}`
+- **collectAll with nil input** — verify each collector's nil behavior
+- **CWD-based fallback for project directory** — `getcwd()` when no workspace
+- **Model name fallback** — env var or cache file
+- **Renderer with partial StatusData** — which segments show/hide
+
+### Existing tests in internal/statusline/
+- `renderer_test.go`, `gradient_test.go`, `update_test.go`, `metrics_test.go` — cover rendering logic
+
+## Recommendations for SPEC Scope
+
+### In Scope (REQ-1 to REQ-4)
+
+1. **REQ-1**: Empty/null stdin → fallback project directory from `os.Getwd()`, git branch from filesystem
+2. **REQ-2**: Model name fallback via env var `MOAI_LAST_MODEL` or cache file `~/.moai/state/last-model.txt`
+3. **REQ-3**: `Workspace.CurrentDir` fallback to `os.Getwd()` (already partially works via git collector)
+4. **REQ-4**: Cwd guard in Go binary (absorb from shell wrapper)
+
+### Out of Scope
+
+- Settings.json `statusLine` key persistence (OQ-1 — requires SessionStart hook investigation)
+- Branch output mismatch (OQ-2 — requires git worktree caching investigation)
+- UI redesign of statusline layout
+- New display modes
+
+### Risk Assessment
+
+- **Low risk**: Changes are additive fallbacks; existing happy path untouched
+- **Test surface**: All fallback paths can be tested with nil/empty StdinData
+- **Concurrency**: No new goroutines; git collector already thread-safe
+- **Performance**: Fallbacks are instant (env var read, getcwd) — no I/O added to hot path
+
+### Files to Modify
+
+1. `internal/statusline/builder.go` — `parseStdin()` nil handling, `collectAll()` fallback logic
+2. `internal/cli/statusline.go` — cwd guard before stdin read
+3. `internal/statusline/metrics.go` — model name fallback (env/cache)
+4. `internal/statusline/builder_test.go` — new test cases for nil/partial input
+5. `internal/template/templates/.moai/status_line.sh.tmpl` — simplify (cwd guard absorbed by Go)

--- a/.moai/specs/SPEC-V3R3-STATUSLINE-FALLBACK-001/spec-compact.md
+++ b/.moai/specs/SPEC-V3R3-STATUSLINE-FALLBACK-001/spec-compact.md
@@ -1,0 +1,48 @@
+---
+id: SPEC-V3R3-STATUSLINE-FALLBACK-001
+version: "0.1.0"
+status: draft
+created_at: 2026-05-10
+updated_at: 2026-05-10
+author: GOOS행님
+priority: High
+labels: [statusline, fallback, cli]
+issue_number: null
+---
+
+# SPEC-V3R3-STATUSLINE-FALLBACK-001 (Compact)
+
+## Requirements
+
+### REQ-SF-001: Empty/Partial stdin Fallback
+stdin JSON empty / `{}` / `null` / partial → project name(getcwd), git branch(filesystem), version(config), rate limits(API) 표시
+
+### REQ-SF-002: Model Name Fallback
+stdin model 누락 → `MOAI_LAST_MODEL` env → `~/.moai/state/last-model.txt` cache → 미표시. 정상 수신 시 cache write (atomic rename).
+
+### REQ-SF-003: Workspace Directory Fallback
+stdin workspace 없음 → `os.Getwd()` basename. stdin `cwd` ≠ `getcwd` 시 stdin 우선.
+
+### REQ-SF-004: Cwd Guard Go Binary 흡수
+`os.Getwd()` 실패/삭제 dir → `$HOME` Chdir → project name `~`. Shell wrapper cwd guard 제거 가능.
+
+### REQ-SF-005: Cache File Write 안정성
+부모 dir 자동 생성, atomic rename, write 실패 시 silent ignore.
+
+## Acceptance Criteria (Key)
+
+| ID | 시나리오 | 검증 |
+|----|----------|------|
+| AC-SF-001 | Empty stdin → project name + version 표시 | `echo "" \| moai statusline` |
+| AC-SF-003 | `MOAI_LAST_MODEL` env → model name 표시 | env 설정 후 실행 |
+| AC-SF-004 | Cache file → model name 표시 | file 생성 후 실행 |
+| AC-SF-005 | 정상 stdin → cache file 생성 | file 내용 확인 |
+| AC-SF-006 | Deleted cwd → HOME fallback + `~` | t.TempDir() 삭제 테스트 |
+| AC-SF-008 | 정상 stdin → 기존 출력 무변경 | golden test 통과 |
+
+## Exclusions
+
+- settings.json `statusLine` key 소멸 원인 조사
+- Git worktree branch 출력 불일치 수정
+- Statusline UI 재설계
+- 새로운 display mode

--- a/.moai/specs/SPEC-V3R3-STATUSLINE-FALLBACK-001/spec.md
+++ b/.moai/specs/SPEC-V3R3-STATUSLINE-FALLBACK-001/spec.md
@@ -1,0 +1,116 @@
+---
+id: SPEC-V3R3-STATUSLINE-FALLBACK-001
+version: "0.1.0"
+status: draft
+created_at: 2026-05-10
+updated_at: 2026-05-10
+author: GOOS행님
+priority: High
+labels: [statusline, fallback, cli]
+issue_number: null
+---
+
+# SPEC-V3R3-STATUSLINE-FALLBACK-001: moai statusline Go 바이너리 stdin fallback 강화
+
+## HISTORY
+
+| 날짜 | 버전 | 작성자 | 변경 내용 |
+|------|------|--------|-----------|
+| 2026-05-10 | 0.1.0 | GOOS행님 | 최초 작성 — research.md 기반 4개 REQ 정의 |
+
+## 1. 개요
+
+### 1.1 배경
+
+`moai statusline` 명령은 Claude Code가 stdin으로 전달하는 JSON 데이터를 파싱하여 3-line statusline을 출력하는 Go 바이너리이다. 현재 stdin JSON이 empty / `{}` / `null` / partial인 경우 `parseStdin()`이 `nil`을 반환하고, `collectAll()`은 다수의 critical segment를 누락한 채 렌더링한다.
+
+특히 model name, project directory, rate limits가 누락되면 statusline은 사실상 무의미한 출력만 남게 된다. 이 SPEC은 stdin 데이터 유무와 무관하게 항상 완전한 statusline을 출력하도록 fallback 체인을 강화한다.
+
+### 1.2 목표
+
+- stdin JSON이 없거나 불완전해도 모든 핵심 정보가 표시되는 statusline 보장
+- Shell wrapper(`status_line.sh`)의 cwd guard를 Go 바이너리로 흡수
+- Model name fallback chain 구현 (stdin → env → cache file)
+- 기존 happy path 영향 최소화 (zero-regression 원칙)
+
+### 1.3 비목표 (Exclusions)
+
+- **EXCL-1**: `settings.json`의 `statusLine` key mid-session 소멸 원인 조사 — 별도 investigation 필요
+- **EXCL-2**: Git worktree caching으로 인한 branch 출력 불일치 수정 — 확인 후 별도 SPEC 권장
+- **EXCL-3**: Statusline layout/UI 재설계
+- **EXCL-4**: 새로운 display mode 추가
+
+## 2. 요구사항
+
+### 2.1 REQ-SF-001: Empty/Partial stdin Fallback
+
+**Event-driven**: **When** stdin JSON이 empty string, `{}`, `null`, 또는 필드 누락 partial JSON인 경우, `moai statusline` **shall** project name, git branch, MoAI version, rate limits를 표시한다.
+
+**When** `parseStdin()`이 `nil`을 반환하면, `moai statusline` **shall** 다음 fallback 체인을 수행한다:
+
+| 데이터 | Fallback 순서 (우선순위 높음 → 낮음) |
+|--------|--------------------------------------|
+| Project directory | stdin `workspace.project_dir` → stdin `workspace.current_dir` → stdin `cwd` → `os.Getwd()` basename |
+| Git branch | filesystem git collector (기존 동작 유지) |
+| MoAI version | config file auto-detect (기존 동작 유지) |
+| Rate limits | stdin `rate_limits` → API usage collector (기존 동작 유지) |
+
+### 2.2 REQ-SF-002: Model Name Fallback
+
+**When** stdin JSON의 `model` 필드가 `null`이거나 존재하지 않으면, `moai statusline` **shall** 다음 fallback 체인으로 model name을 결정한다:
+
+1. 환경변수 `MOAI_LAST_MODEL` 조회
+2. Cache file `~/.moai/state/last-model.txt` 읽기
+3. 둘 다 없으면 model name 미표시 (기존 동작과 동일)
+
+**When** 정상 stdin JSON에 model 정보가 포함되어 있으면, `moai statusline` **shall** 해당 model name을 cache file(`~/.moai/state/last-model.txt`)에 기록한다. 이는 후속 empty stdin 호출 시 fallback 데이터로 활용된다.
+
+### 2.3 REQ-SF-003: Workspace Directory Fallback
+
+**When** stdin JSON에 `workspace` 필드가 없거나 `workspace.current_dir`과 `workspace.project_dir`이 모두 비어있으면, `moai statusline` **shall** `os.Getwd()`의 basename을 project directory로 표시한다.
+
+**If** stdin JSON의 `cwd` 값이 process의 `os.Getwd()`와 다르면 (sandbox 환경 등), `moai statusline` **shall** stdin의 `cwd` 값을 우선 사용한다.
+
+### 2.4 REQ-SF-004: Cwd Guard Go Binary 흡수
+
+**When** process의 현재 working directory(`os.Getwd()`)가 존재하지 않는 directory인 경우 (deleted directory), `moai statusline` **shall** 다음 동작을 수행한다:
+
+1. `$HOME`을 fallback working directory로 설정 (`os.Chdir`)
+2. Project directory name을 `~`로 표시
+3. Git collector는 working directory 기반이므로 자연스럽게 비활성화 (기존 nil 동작 유지)
+
+**When** cwd guard가 Go binary에서 정상 수행되면, shell-level cwd guard는 redundant하게 된다. Template 변경(`status_line.sh.tmpl` 내 cwd guard 제거)은 선택사항이며 기존 wrapper와의 호환성을 유지해야 한다.
+
+### 2.5 REQ-SF-005: Cache File Write 안정성
+
+**When** model name cache file(`~/.moai/state/last-model.txt`)을 작성할 때, `moai statusline` **shall** 다음을 보장한다:
+
+- 부모 directory(`~/.moai/state/`)가 없으면 생성 (mode 0755)
+- 기존 파일이 있으면 원자적 교체 (write to temp + rename)
+- Write 실패 시 silent ignore (statusline 출력에 영향 없음)
+
+## 3. 기술 접근
+
+### 3.1 수정 파일
+
+| 파일 | 변경 내용 | 우선순위 |
+|------|-----------|----------|
+| `internal/statusline/builder.go` | `collectAll()` fallback 로직, `extractProjectDirectory()` getcwd fallback | P0 |
+| `internal/cli/statusline.go` | `runStatusline()` 시작 부분 cwd guard 추가 | P0 |
+| `internal/statusline/metrics.go` | `CollectMetrics()` model name fallback (env + cache) | P0 |
+| `internal/statusline/model_cache.go` (신규) | Cache file read/write 유틸리티 | P0 |
+| `internal/statusline/builder_test.go` | nil/partial stdin 테스트 케이스 | P1 |
+| `internal/template/templates/.moai/status_line.sh.tmpl` | cwd guard 제거 (선택) | P2 |
+
+### 3.2 아키텍처 제약
+
+- **Zero-regression**: 기존 happy path (정상 stdin JSON)의 동작, 성능, 출력 변경 금지
+- **No new goroutines**: Fallback 로직은 동기식 (env read, getcwd, file read 모두 마이크로초 단위)
+- **No new dependencies**: 표준 라이브러리만 사용
+- **Race-safe**: Cache file write는 sequential (Build 파이프라인 내)
+
+## 4. 관련 문서
+
+- Research: `.moai/specs/SPEC-V3R3-STATUSLINE-FALLBACK-001/research.md`
+- 기존 SPEC: SPEC-V3R3-CLI-TUI-001 (M7 이후 statusline fallback scoping 메모)
+- Memory: `project_statusline_disappearance_fix.md` (statusline 자주 사라짐 3 root cause 진단)


### PR DESCRIPTION
## Summary
- `moai statusline` Go 바이너리의 stdin JSON empty/partial/null 시 모든 핵심 segment(model name, project dir, rate limits) 누락 문제 해결 계획
- 3 milestone: M1 cwd guard + directory fallback, M2 model name env+cache fallback chain, M3 통합 테스트 + template 정리
- 5 REQ (SF-001~005), 8 AC + 5 EC + 4 QG, plan-auditor PASS 0.88 (iter 2)

## SPEC Artifacts (6 files)
| File | Content |
|------|---------|
| `research.md` | Codebase analysis (stdin parsing, builder, metrics) |
| `spec.md` | 5 EARS format requirements |
| `plan.md` | 3 milestone implementation plan |
| `acceptance.md` | 8 AC + 5 EC + 4 QG (EARS format) |
| `progress.md` | Milestone tracking |
| `spec-compact.md` | Compact reference |

## Test Plan
- [x] plan-auditor iteration 1: REVISE 0.72 (4 defects)
- [x] plan-auditor iteration 2: PASS 0.88 (all defects resolved)
- [ ] Admin merge (squash) per plan-in-main doctrine

## Merge Strategy
- [x] Squash merge (`--squash`) per §18.3 plan → main rule

🗿 MoAI <email@mo.ai.kr>