### PR TITLE
docs(sync): v3 SPEC 상태 갱신 — ORC-001/005, RT-005, BRAIN-001

### DIFF
--- a/.moai/specs/SPEC-V3R2-ORC-001/spec.md
+++ b/.moai/specs/SPEC-V3R2-ORC-001/spec.md
@@ -2,9 +2,9 @@
 id: SPEC-V3R2-ORC-001
 title: "Agent roster consolidation (22 → 17)"
 version: "0.1.1"
-status: draft
+status: implemented
 created: 2026-04-23
-updated: 2026-04-23
+updated: 2026-05-10
 author: GOOS
 priority: P0 Critical
 phase: "v3.0.0 — Phase 3 — Agent Cleanup"

--- a/.moai/specs/SPEC-V3R2-ORC-005/spec.md
+++ b/.moai/specs/SPEC-V3R2-ORC-005/spec.md
@@ -2,9 +2,9 @@
 id: SPEC-V3R2-ORC-005
 title: "Dynamic Team Generation Formalization + Mailbox Protocol v2"
 version: "0.1.0"
-status: draft
+status: implemented
 created: 2026-04-23
-updated: 2026-04-23
+updated: 2026-05-10
 author: GOOS
 priority: P1 High
 phase: "v3.0.0 — Phase 6 — Multi-Mode Workflow"

--- a/.moai/specs/SPEC-V3R2-RT-005/spec.md
+++ b/.moai/specs/SPEC-V3R2-RT-005/spec.md
@@ -2,7 +2,7 @@
 id: SPEC-V3R2-RT-005
 title: "Multi-Layer Settings Resolution with Provenance Tags"
 version: "0.1.1"
-status: draft
+status: implemented
 created: 2026-04-23
 updated: 2026-05-10
 author: GOOS

--- a/.moai/specs/SPEC-V3R3-BRAIN-001/spec.md
+++ b/.moai/specs/SPEC-V3R3-BRAIN-001/spec.md
@@ -1,9 +1,9 @@
 ---
 id: SPEC-V3R3-BRAIN-001
 version: "0.1.0"
-status: draft
+status: implemented
 created_at: 2026-05-04
-updated_at: 2026-05-04
+updated_at: 2026-05-10
 author: MoAI Plan Workflow
 priority: P1
 labels: [brain, ideation, workflow, handoff, claude-design, v3r3]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] — SPEC-V3R2-ORC-001: Agent Roster Consolidation (22 → 17)
+
+### Added
+
+- **SPEC-V3R2-ORC-001**: 에이전트 카탈로그 22개에서 17개로 통합. manager-cycle → manager-develop(DDD/TDD 통합), agency 에이전트 6개 흡수(copywriter → moai-domain-copywriting skill, designer → moai-domain-brand-design skill), plan-auditor/evaluator-active 독립 유지. ORC-002~005 선행 작업. PR #843.
+
+### English
+
+- **SPEC-V3R2-ORC-001**: Agent catalog consolidation from 22 to 17 agents. manager-cycle → manager-develop (DDD/TDD unified), 6 agency agents absorbed into skills (copywriter → moai-domain-copywriting, designer → moai-domain-brand-design), plan-auditor/evaluator-active retained as independent. Prerequisite for ORC-002~005. PR #843.
+
+## [Unreleased] — SPEC-V3R2-ORC-005: Dynamic Team Generation Formalization
+
+### Added
+
+- **SPEC-V3R2-ORC-005**: Agent Teams 동적 생성 공식화. 정적 team-* 에이전트 파일 삭제, `Agent(subagent_type: "general-purpose")` + workflow.yaml role_profiles로 런타임 생성. Mailbox Protocol v2, file ownership 전략, tmux pane lifecycle 관리. PR #743.
+
+### English
+
+- **SPEC-V3R2-ORC-005**: Dynamic Agent Teams generation formalization. Removed static team-* agent files; spawn via `Agent(subagent_type: "general-purpose")` with workflow.yaml role profiles at runtime. Mailbox Protocol v2, file ownership strategy, tmux pane lifecycle management. PR #743.
+
 ## [Unreleased] — SPEC-V3R3-STATUSLINE-FALLBACK-001: Statusline Stdin Fallback
 
 ### Added


### PR DESCRIPTION
## Summary

- ORC-001, ORC-005, RT-005, BRAIN-001 spec.md `status: draft` → `implemented` 갱신 (run 이미 머지됨)
- CHANGELOG에 ORC-001 (agent roster #843), ORC-005 (team formalization #743) 항목 추가

## Context

v3 Plan Batch 6 종료 후 sync 패스. Sprint 11 진입 전 완료된 SPEC들의 spec.md 상태를 정리.

## Test plan

- [ ] `grep "status: implemented" .moai/specs/SPEC-V3R2-ORC-001/spec.md` → 정상
- [ ] `grep "status: implemented" .moai/specs/SPEC-V3R2-RT-005/spec.md` → 정상
- [ ] CHANGELOG에 ORC-001, ORC-005 항목 존재 확인

🗿 MoAI <email@mo.ai.kr>