### PR TITLE
fix(template): SPEC-V3R2-ORC-001 post-merge AC-06 + stale refs

### DIFF
--- a/.claude/agents/moai/expert-devops.md
+++ b/.claude/agents/moai/expert-devops.md
@@ -50,7 +50,7 @@ Design and implement CI/CD pipelines, infrastructure as code, and production dep
 
 IN SCOPE: CI/CD pipeline design, containerization, deployment strategy, infrastructure automation, secrets management, monitoring/health checks.
 
-OUT OF SCOPE: Application code (expert-backend/frontend), security audits (expert-security), performance profiling (expert-performance), testing strategy (expert-testing).
+OUT OF SCOPE: Application code (expert-backend/frontend), security audits (expert-security), performance profiling (expert-performance), testing strategy (manager-cycle).
 
 ## Delegation Protocol
 

--- a/.claude/agents/moai/expert-mobile.md
+++ b/.claude/agents/moai/expert-mobile.md
@@ -118,14 +118,14 @@ Anti-pattern: silent absorption of out-of-scope work. Maintain Scope Discipline 
 
 ## Harness Era: Sub-Skill Generation
 
-This agent does NOT bundle full iOS/Android/RN/Flutter sub-skills inline. Instead, use `builder-skill` to dynamically generate deep sub-skills when the project requires them:
+This agent does NOT bundle full iOS/Android/RN/Flutter sub-skills inline. Instead, use `builder-platform` (artifact_type=skill) to dynamically generate deep sub-skills when the project requires them:
 
 ```
 # Generate iOS-specific deep skill
-Use the builder-skill subagent to create moai-framework-ios with SwiftUI, UIKit, Core Data patterns.
+Use the builder-platform subagent (artifact_type=skill) to create moai-framework-ios with SwiftUI, UIKit, Core Data patterns.
 
 # Generate Flutter deep skill
-Use the builder-skill subagent to create moai-framework-flutter-deep with Riverpod, go_router, Dio, Platform Channels.
+Use the builder-platform subagent (artifact_type=skill) to create moai-framework-flutter-deep with Riverpod, go_router, Dio, Platform Channels.
 ```
 
 This keeps `expert-mobile` lean and allows harness-generated skills to be tailored to project-specific iOS/Android/RN/Flutter versions and patterns.

--- a/.claude/agents/moai/expert-refactoring.md
+++ b/.claude/agents/moai/expert-refactoring.md
@@ -50,7 +50,7 @@ OUT OF SCOPE:
 
 ## Delegation Protocol
 
-- Errors after refactoring: Delegate to expert-debug
+- Errors after refactoring: Delegate to manager-quality (diagnostic-mode)
 - Tests after refactoring: Delegate to manager-develop
 - Quality validation: Delegate to manager-quality
 - Security pattern review: Delegate to expert-security

--- a/.claude/agents/moai/expert-security.md
+++ b/.claude/agents/moai/expert-security.md
@@ -53,7 +53,7 @@ OUT OF SCOPE:
 - Server-side security fixes: Delegate to expert-backend
 - Client-side security fixes (XSS, CSP): Delegate to expert-frontend
 - AST-grep pattern-based fixes: Delegate to expert-refactoring
-- Security test cases: Delegate to expert-testing
+- Security test cases: Delegate to manager-cycle (cycle_type=tdd)
 - Infrastructure hardening: Delegate to expert-devops
 
 ## Security Review Process
@@ -94,7 +94,7 @@ OUT OF SCOPE:
 
 ### Phase 3: Verification
 
-- Coordinate security test cases with expert-testing
+- Coordinate security test cases with manager-cycle (cycle_type=tdd)
 - Re-run AST-grep security scan after fixes
 - Confirm all vulnerabilities resolved, no regressions introduced
 

--- a/.claude/agents/moai/expert-testing.md
+++ b/.claude/agents/moai/expert-testing.md
@@ -6,8 +6,9 @@ description: |
   Load test execution belongs in expert-performance with --deepthink load-test.
   See manager-cycle.md and expert-performance.md for the active replacements.
 retired: true
-retired_replacement: "manager-cycle | expert-performance"
-retired_param_hint: "strategy: manager-cycle cycle_type=tdd; load: expert-performance --deepthink load-test"
+retired_replacement: "manager-cycle"
+retired_replacement_alt: "expert-performance"
+retired_param_hint: "strategy: cycle_type=tdd; load: use expert-performance --deepthink load-test"
 tools: []
 skills: []
 ---

--- a/.claude/agents/moai/manager-brain.md
+++ b/.claude/agents/moai/manager-brain.md
@@ -5,7 +5,7 @@ description: |
   validated product proposals with SPEC decomposition candidates and Claude Design handoff package.
   Executes 7-phase pipeline: Discovery, Diverge, Research, Converge, Critical Evaluation, Proposal, Handoff.
   MUST INVOKE when: /moai brain, ideation request, pre-spec exploration, "help me think through this idea"
-  NOT for: code implementation (manager-tdd/ddd), SPEC creation (manager-spec), documentation (manager-docs)
+  NOT for: code implementation (manager-cycle), SPEC creation (manager-spec), documentation (manager-docs)
 tools: Read, Write, Edit, Glob, Grep, Bash, WebSearch, WebFetch, ToolSearch, AskUserQuestion, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 model: opus
 effort: xhigh
@@ -28,7 +28,7 @@ Execute the `/moai brain` 7-phase ideation workflow: Discovery, Diverge, Researc
 
 IN SCOPE: 7-phase brain workflow execution, IDEA-NNN directory management, AskUserQuestion Socratic interview, parallel research execution, Lean Canvas assembly, SPEC decomposition list generation, Claude Design handoff package assembly.
 
-OUT OF SCOPE: SPEC creation (manager-spec), code implementation (manager-tdd/ddd), documentation sync (manager-docs), Git operations (manager-git).
+OUT OF SCOPE: SPEC creation (manager-spec), code implementation (manager-cycle), documentation sync (manager-docs), Git operations (manager-git).
 
 ## Pre-Execution Setup
 

--- a/.claude/skills/moai-foundation-core/SKILL.md
+++ b/.claude/skills/moai-foundation-core/SKILL.md
@@ -29,11 +29,10 @@ triggers:
   keywords: ["trust-5", "spec-first", "ddd", "delegation", "agent", "token", "progressive disclosure", "modular", "workflow", "orchestration", "quality gate", "spec", "ears format", "context window", "token budget", "token limit", "session state", "/clear", "context management", "multi-agent handoff", "session persistence", "context", "session", "budget", "optimization", "handoff", "state", "memory", "multi-agent"]
   agents:
     - "manager-spec"
-    - "manager-ddd"
+    - "manager-cycle"
     - "manager-strategy"
     - "manager-quality"
-    - "builder-agent"
-    - "builder-skill"
+    - "builder-platform"
     - "manager-docs"
     - "manager-project"
   phases:

--- a/.claude/skills/moai/SKILL.md
+++ b/.claude/skills/moai/SKILL.md
@@ -28,7 +28,7 @@ Rules and constraints governing all workflows are always loaded from these sourc
 - Quality gates, security boundaries: .claude/rules/moai/core/moai-constitution.md
 - SPEC workflow phases, token budgets: .claude/rules/moai/workflow/spec-workflow.md
 - Development methodologies (DDD/TDD): .claude/rules/moai/workflow/spec-workflow.md (Run Phase section)
-- Agent definitions: See CLAUDE.md Section 4. For agent creation, use builder-agent subagent.
+- Agent definitions: See CLAUDE.md Section 4. For agent creation, use builder-platform subagent (artifact_type=agent).
 - @MX tag rules and protocol: .claude/rules/moai/workflow/mx-tag-protocol.md
 
 ---
@@ -114,7 +114,7 @@ For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/plan.md (team mod
 ### run - DDD/TDD Implementation
 
 Purpose: Implement SPEC requirements through configured development methodology.
-Agents: manager-strategy, manager-ddd or manager-tdd (per quality.yaml), manager-quality, manager-git
+Agents: manager-strategy, manager-cycle (cycle_type=ddd|tdd per quality.yaml), manager-quality, manager-git
 Flags: --resume SPEC-XXX, --team
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/run.md (team mode: ${CLAUDE_SKILL_DIR}/team/run.md)
 
@@ -143,14 +143,14 @@ For detailed orchestration: Read /Users/goos/MoAI/moai-adk-go/.claude/skills/moa
 ### fix - Auto-Fix Errors
 
 Purpose: Autonomously detect and fix LSP errors, linting issues, and type errors.
-Agents: expert-debug (diagnosis), expert-backend/expert-frontend (fixes)
+Agents: manager-quality (diagnostic-mode), expert-backend/expert-frontend (fixes)
 Flags: --dry, --sequential, --level N, --resume, --team
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/fix.md
 
 ### loop - Iterative Auto-Fix
 
 Purpose: Repeatedly fix issues until completion marker detected or max iterations reached.
-Agents: expert-debug, expert-backend, expert-frontend, expert-testing
+Agents: manager-quality (diagnostic-mode), expert-backend, expert-frontend, manager-cycle
 Flags: --max N, --auto-fix, --seq
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/loop.md
 
@@ -171,7 +171,7 @@ For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/review.md (team m
 ### clean - Dead Code Removal
 
 Purpose: Identify and safely remove unused code with test verification.
-Agents: expert-refactoring, expert-testing
+Agents: expert-refactoring, manager-cycle
 Flags: --dry, --safe-only, --file PATH
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/clean.md
 
@@ -185,14 +185,14 @@ For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/codemaps.md
 ### coverage - Test Coverage Analysis
 
 Purpose: Analyze test coverage gaps and generate missing tests.
-Agents: expert-testing
+Agents: manager-cycle (cycle_type=tdd)
 Flags: --target N, --file PATH, --report
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/coverage.md
 
 ### e2e - End-to-End Testing
 
 Purpose: Create and run E2E tests using Chrome, Playwright, or Agent Browser.
-Agents: expert-testing, expert-frontend
+Agents: manager-cycle (cycle_type=tdd), expert-frontend
 Flags: --record, --url URL, --journey NAME
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/e2e.md
 
@@ -216,7 +216,7 @@ For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/db.md
 
 Purpose: Full autonomous research -> plan -> annotate -> run -> sync pipeline.
 Phases: Parallel Exploration (research.md) -> SPEC Generation -> Annotation Cycle -> Implementation -> Sync
-Agents: Explore, manager-spec, manager-ddd/tdd, manager-quality, manager-docs, manager-git
+Agents: Explore, manager-spec, manager-cycle, manager-quality, manager-docs, manager-git
 Flags: --loop, --max N, --branch, --pr, --resume SPEC-XXX, --team, --solo, --no-issue
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/moai.md
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ Route request based on command type:
 Execute using explicit agent invocation:
 
 - "Use the expert-backend subagent to develop the API"
-- "Use the manager-ddd subagent to implement with DDD approach"
+- "Use the manager-cycle subagent with cycle_type=ddd to implement with DDD approach"
 - "Use the Explore subagent to analyze the codebase structure"
 
 ### Phase 4: Report
@@ -103,17 +103,17 @@ For detailed design rules, see .claude/rules/moai/design/constitution.md
 4. Workflow coordination needed? Use the manager-[workflow] subagent
 5. Complex multi-step tasks? Use the manager-strategy subagent
 
-### Manager Agents (8)
+### Manager Agents (7)
 
-spec, ddd, tdd, docs, quality, project, strategy, git
+spec, cycle, docs, quality, project, strategy, git
 
-### Expert Agents (8)
+### Expert Agents (6)
 
-backend, frontend, security, devops, performance, debug, testing, refactoring
+backend, frontend, security, devops, performance, refactoring
 
-### Builder Agents (3)
+### Builder Agents (1)
 
-agent, skill, plugin
+platform (artifact_type: agent|skill|plugin|command|hook|mcp-server|lsp-server)
 
 ### Evaluator Agents (2)
 
@@ -133,7 +133,7 @@ Role profiles (in `workflow.yaml`): researcher, analyst, architect, implementer,
 
 Requires: `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` env var AND `workflow.team.enabled: true` in workflow.yaml.
 
-For detailed agent descriptions, see the Agent Catalog section above. For agent creation guidelines, use the builder-agent subagent or see `.claude/rules/moai/development/agent-authoring.md`.
+For detailed agent descriptions, see the Agent Catalog section above. For agent creation guidelines, use the builder-platform subagent (artifact_type=agent) or see `.claude/rules/moai/development/agent-authoring.md`.
 
 ---
 
@@ -144,7 +144,7 @@ MoAI uses DDD and TDD as its development methodologies, selected via quality.yam
 ### MoAI Command Flow
 
 - /moai plan "description" → manager-spec subagent
-- /moai run SPEC-XXX → manager-ddd or manager-tdd subagent (per quality.yaml development_mode)
+- /moai run SPEC-XXX → manager-cycle subagent (cycle_type=ddd|tdd per quality.yaml development_mode)
 - /moai sync SPEC-XXX → manager-docs subagent
 
 For detailed workflow specifications, see .claude/rules/moai/workflow/spec-workflow.md
@@ -375,7 +375,7 @@ For anti-hallucination policy, see .claude/rules/moai/core/moai-constitution.md
 
 ### Error Recovery
 
-- Agent execution errors: Use expert-debug subagent
+- Agent execution errors: Use manager-quality subagent (diagnostic-mode)
 - Token limit errors: Execute /clear, then guide user to resume
 - Permission errors: Review settings.json manually
 - Integration errors: Use expert-devops subagent


### PR DESCRIPTION
## Summary

- **AC-06 PASS**: template↔local 6 agent files 동기화 (expert-devops, expert-mobile, expert-refactoring, expert-security, expert-testing, manager-brain) — 이전 M4 sweep에서 local copy가 누락된 post-R5 name 변경분
- **CLAUDE.md**: Agent Catalog 카운트 정정 (Manager 8→7, Expert 8→6, Builder 3→1) + 신규 에이전트명 반영
- **Skills**: moai-foundation-core/SKILL.md + moai/SKILL.md 스탈 참조 11건 교체

## Files Changed (9)

| File | Change |
|------|--------|
| `.claude/agents/moai/expert-devops.md` | `expert-testing` → `manager-cycle` |
| `.claude/agents/moai/expert-mobile.md` | `builder-skill` → `builder-platform (artifact_type=skill)` (3 lines) |
| `.claude/agents/moai/expert-refactoring.md` | `expert-debug` → `manager-quality (diagnostic-mode)` |
| `.claude/agents/moai/expert-security.md` | `expert-testing` → `manager-cycle (cycle_type=tdd)` (2 lines) |
| `.claude/agents/moai/expert-testing.md` | stub schema 정규화 (`retired_replacement_alt` 필드 분리) |
| `.claude/agents/moai/manager-brain.md` | `manager-tdd/ddd` → `manager-cycle` (2 lines) |
| `CLAUDE.md` | Agent Catalog 카운트 + 5개 스탈 참조 교체 |
| `.claude/skills/moai-foundation-core/SKILL.md` | `manager-ddd`, `builder-agent`, `builder-skill` → 신규명 |
| `.claude/skills/moai/SKILL.md` | 8개 스탈 참조 교체 |

## Root Cause

ORC-001 M4 downstream sweep이 template만 갱신하고 local `.claude/` 파일들을 누락. `make build`가 embedded.go만 재생성하므로 수동 복사 필요.

## Test plan

- [x] `diff -r internal/template/templates/.claude/agents/moai/ .claude/agents/moai/` → 출력 없음 (AC-06 PASS)
- [x] `grep -r "manager-ddd\|manager-tdd\|builder-agent\|expert-debug\|expert-testing" CLAUDE.md` → 없음
- [x] 동일 grep 검사 moai-foundation-core/SKILL.md + moai/SKILL.md → 없음

🗿 MoAI <email@mo.ai.kr>