### PR TITLE
refactor(agents): manager-cycle→manager-develop + builder-platform→builder-harness

### DIFF
--- a/.claude/agents/moai/builder-agent.md
+++ b/.claude/agents/moai/builder-agent.md
@@ -1,11 +1,11 @@
 ---
 name: builder-agent
 description: |
-  Retired (SPEC-V3R2-ORC-001) — use builder-platform with artifact_type=agent.
-  This agent has been consolidated into the unified builder-platform agent.
-  See builder-platform.md for the active replacement.
+  Retired (SPEC-V3R2-ORC-001) — use builder-harness with artifact_type=agent.
+  This agent has been consolidated into the unified builder-harness agent.
+  See builder-harness.md for the active replacement.
 retired: true
-retired_replacement: builder-platform
+retired_replacement: builder-harness
 retired_param_hint: "artifact_type=agent"
 tools: []
 skills: []
@@ -19,15 +19,15 @@ This agent has been retired as part of SPEC-V3R2-ORC-001 (Agent roster consolida
 
 ## Replacement
 
-Use **builder-platform** with `artifact_type=agent` instead.
+Use **builder-harness** with `artifact_type=agent` instead.
 
 ## Migration Guide
 
 | Old Invocation | New Invocation |
 |----------------|----------------|
-| `Use the builder-agent subagent to create an agent` | `Use the builder-platform subagent with artifact_type=agent to create an agent` |
-| `builder-agent: design a custom agent` | `builder-platform: design a custom agent (artifact_type=agent)` |
+| `Use the builder-agent subagent to create an agent` | `Use the builder-harness subagent with artifact_type=agent to create an agent` |
+| `builder-agent: design a custom agent` | `builder-harness: design a custom agent (artifact_type=agent)` |
 
 ## Active Agent
 
-See `.claude/agents/moai/builder-platform.md` for the full agent definition.
+See `.claude/agents/moai/builder-harness.md` for the full agent definition.

--- a/.claude/agents/moai/builder-harness.md
+++ b/.claude/agents/moai/builder-harness.md
@@ -1,5 +1,5 @@
 ---
-name: builder-platform
+name: builder-harness
 description: |
   Unified artifact creation specialist. Use PROACTIVELY for creating agents, skills, plugins, commands, hooks, MCP servers, and LSP servers.
   MUST INVOKE when ANY of these keywords appear in user request:
@@ -54,14 +54,14 @@ This agent consolidates three previously separate builder agents.
 
 | Old Usage | New Usage |
 |-----------|-----------|
-| Use `builder-agent` subagent | Use `builder-platform` subagent with `artifact_type=agent` |
-| Use `builder-skill` subagent | Use `builder-platform` subagent with `artifact_type=skill` |
-| Use `builder-plugin` subagent | Use `builder-platform` subagent with `artifact_type=plugin` |
+| Use `builder-agent` subagent | Use `builder-harness` subagent with `artifact_type=agent` |
+| Use `builder-skill` subagent | Use `builder-harness` subagent with `artifact_type=skill` |
+| Use `builder-plugin` subagent | Use `builder-harness` subagent with `artifact_type=plugin` |
 
 **Deprecated agents** (retired stubs still present for compatibility):
-- `builder-agent` → replaced by `builder-platform` with `artifact_type=agent`
-- `builder-skill` → replaced by `builder-platform` with `artifact_type=skill`
-- `builder-plugin` → replaced by `builder-platform` with `artifact_type=plugin`
+- `builder-agent` → replaced by `builder-harness` with `artifact_type=agent`
+- `builder-skill` → replaced by `builder-harness` with `artifact_type=skill`
+- `builder-plugin` → replaced by `builder-harness` with `artifact_type=plugin`
 
 ## Scope Boundaries
 
@@ -75,7 +75,7 @@ IN SCOPE:
 OUT OF SCOPE:
 - Implementing actual business logic: Delegate to expert agents
 - Code implementation within artifacts: Delegate to expert-backend/expert-frontend
-- Running tests: Delegate to manager-cycle with cycle_type=tdd
+- Running tests: Delegate to manager-develop with cycle_type=tdd
 
 ## Workflow
 

--- a/.claude/agents/moai/builder-plugin.md
+++ b/.claude/agents/moai/builder-plugin.md
@@ -1,11 +1,11 @@
 ---
 name: builder-plugin
 description: |
-  Retired (SPEC-V3R2-ORC-001) — use builder-platform with artifact_type=plugin.
-  This agent has been consolidated into the unified builder-platform agent.
-  See builder-platform.md for the active replacement.
+  Retired (SPEC-V3R2-ORC-001) — use builder-harness with artifact_type=plugin.
+  This agent has been consolidated into the unified builder-harness agent.
+  See builder-harness.md for the active replacement.
 retired: true
-retired_replacement: builder-platform
+retired_replacement: builder-harness
 retired_param_hint: "artifact_type=plugin"
 tools: []
 skills: []
@@ -19,15 +19,15 @@ This agent has been retired as part of SPEC-V3R2-ORC-001 (Agent roster consolida
 
 ## Replacement
 
-Use **builder-platform** with `artifact_type=plugin` instead.
+Use **builder-harness** with `artifact_type=plugin` instead.
 
 ## Migration Guide
 
 | Old Invocation | New Invocation |
 |----------------|----------------|
-| `Use the builder-plugin subagent to create a plugin` | `Use the builder-platform subagent with artifact_type=plugin to create a plugin` |
-| `builder-plugin: build a marketplace plugin` | `builder-platform: build a marketplace plugin (artifact_type=plugin)` |
+| `Use the builder-plugin subagent to create a plugin` | `Use the builder-harness subagent with artifact_type=plugin to create a plugin` |
+| `builder-plugin: build a marketplace plugin` | `builder-harness: build a marketplace plugin (artifact_type=plugin)` |
 
 ## Active Agent
 
-See `.claude/agents/moai/builder-platform.md` for the full agent definition.
+See `.claude/agents/moai/builder-harness.md` for the full agent definition.

--- a/.claude/agents/moai/builder-skill.md
+++ b/.claude/agents/moai/builder-skill.md
@@ -1,11 +1,11 @@
 ---
 name: builder-skill
 description: |
-  Retired (SPEC-V3R2-ORC-001) — use builder-platform with artifact_type=skill.
-  This agent has been consolidated into the unified builder-platform agent.
-  See builder-platform.md for the active replacement.
+  Retired (SPEC-V3R2-ORC-001) — use builder-harness with artifact_type=skill.
+  This agent has been consolidated into the unified builder-harness agent.
+  See builder-harness.md for the active replacement.
 retired: true
-retired_replacement: builder-platform
+retired_replacement: builder-harness
 retired_param_hint: "artifact_type=skill"
 tools: []
 skills: []
@@ -19,15 +19,15 @@ This agent has been retired as part of SPEC-V3R2-ORC-001 (Agent roster consolida
 
 ## Replacement
 
-Use **builder-platform** with `artifact_type=skill` instead.
+Use **builder-harness** with `artifact_type=skill` instead.
 
 ## Migration Guide
 
 | Old Invocation | New Invocation |
 |----------------|----------------|
-| `Use the builder-skill subagent to create a skill` | `Use the builder-platform subagent with artifact_type=skill to create a skill` |
-| `builder-skill: design a knowledge skill` | `builder-platform: design a knowledge skill (artifact_type=skill)` |
+| `Use the builder-skill subagent to create a skill` | `Use the builder-harness subagent with artifact_type=skill to create a skill` |
+| `builder-skill: design a knowledge skill` | `builder-harness: design a knowledge skill (artifact_type=skill)` |
 
 ## Active Agent
 
-See `.claude/agents/moai/builder-platform.md` for the full agent definition.
+See `.claude/agents/moai/builder-harness.md` for the full agent definition.

--- a/.claude/agents/moai/expert-backend.md
+++ b/.claude/agents/moai/expert-backend.md
@@ -61,7 +61,7 @@ OUT OF SCOPE: Frontend implementation (expert-frontend), DevOps deployment (expe
 - Frontend work: Delegate to expert-frontend
 - Security audit: Delegate to expert-security
 - DevOps deployment: Delegate to expert-devops
-- DDD implementation: Delegate to manager-cycle (cycle_type=ddd)
+- DDD implementation: Delegate to manager-develop (cycle_type=ddd)
 
 ## Framework Detection
 
@@ -118,7 +118,7 @@ Create `.moai/docs/backend-architecture-{SPEC-ID}.md` with framework, DB, endpoi
 
 - expert-frontend: API contract (OpenAPI/GraphQL), error format, CORS config
 - expert-devops: Health checks, env vars, migrations, CI/CD
-- manager-cycle: Test structure, mock strategy, coverage requirements
+- manager-develop: Test structure, mock strategy, coverage requirements
 
 ## @MX Tag Obligations
 

--- a/.claude/agents/moai/expert-devops.md
+++ b/.claude/agents/moai/expert-devops.md
@@ -50,7 +50,7 @@ Design and implement CI/CD pipelines, infrastructure as code, and production dep
 
 IN SCOPE: CI/CD pipeline design, containerization, deployment strategy, infrastructure automation, secrets management, monitoring/health checks.
 
-OUT OF SCOPE: Application code (expert-backend/frontend), security audits (expert-security), performance profiling (expert-performance), testing strategy (manager-cycle).
+OUT OF SCOPE: Application code (expert-backend/frontend), security audits (expert-security), performance profiling (expert-performance), testing strategy (manager-develop).
 
 ## Delegation Protocol
 

--- a/.claude/agents/moai/expert-mobile.md
+++ b/.claude/agents/moai/expert-mobile.md
@@ -118,14 +118,14 @@ Anti-pattern: silent absorption of out-of-scope work. Maintain Scope Discipline 
 
 ## Harness Era: Sub-Skill Generation
 
-This agent does NOT bundle full iOS/Android/RN/Flutter sub-skills inline. Instead, use `builder-platform` (artifact_type=skill) to dynamically generate deep sub-skills when the project requires them:
+This agent does NOT bundle full iOS/Android/RN/Flutter sub-skills inline. Instead, use `builder-harness` (artifact_type=skill) to dynamically generate deep sub-skills when the project requires them:
 
 ```
 # Generate iOS-specific deep skill
-Use the builder-platform subagent (artifact_type=skill) to create moai-framework-ios with SwiftUI, UIKit, Core Data patterns.
+Use the builder-harness subagent (artifact_type=skill) to create moai-framework-ios with SwiftUI, UIKit, Core Data patterns.
 
 # Generate Flutter deep skill
-Use the builder-platform subagent (artifact_type=skill) to create moai-framework-flutter-deep with Riverpod, go_router, Dio, Platform Channels.
+Use the builder-harness subagent (artifact_type=skill) to create moai-framework-flutter-deep with Riverpod, go_router, Dio, Platform Channels.
 ```
 
 This keeps `expert-mobile` lean and allows harness-generated skills to be tailored to project-specific iOS/Android/RN/Flutter versions and patterns.

--- a/.claude/agents/moai/expert-performance.md
+++ b/.claude/agents/moai/expert-performance.md
@@ -55,7 +55,7 @@ OUT OF SCOPE:
 - Actual implementation of optimizations (delegate to expert-backend/expert-frontend)
 - Security audits (delegate to expert-security)
 - Infrastructure provisioning (delegate to expert-devops)
-- Unit test strategy design (delegate to manager-cycle cycle_type=tdd)
+- Unit test strategy design (delegate to manager-develop cycle_type=tdd)
 
 ## Delegation Protocol
 

--- a/.claude/agents/moai/expert-security.md
+++ b/.claude/agents/moai/expert-security.md
@@ -53,7 +53,7 @@ OUT OF SCOPE:
 - Server-side security fixes: Delegate to expert-backend
 - Client-side security fixes (XSS, CSP): Delegate to expert-frontend
 - AST-grep pattern-based fixes: Delegate to expert-refactoring
-- Security test cases: Delegate to manager-cycle (cycle_type=tdd)
+- Security test cases: Delegate to manager-develop (cycle_type=tdd)
 - Infrastructure hardening: Delegate to expert-devops
 
 ## Security Review Process
@@ -94,7 +94,7 @@ OUT OF SCOPE:
 
 ### Phase 3: Verification
 
-- Coordinate security test cases with manager-cycle (cycle_type=tdd)
+- Coordinate security test cases with manager-develop (cycle_type=tdd)
 - Re-run AST-grep security scan after fixes
 - Confirm all vulnerabilities resolved, no regressions introduced
 

--- a/.claude/agents/moai/expert-testing.md
+++ b/.claude/agents/moai/expert-testing.md
@@ -1,12 +1,12 @@
 ---
 name: expert-testing
 description: |
-  Retired (SPEC-V3R2-ORC-001) — split across manager-cycle (test strategy) and expert-performance (load testing).
-  Test strategy design belongs in manager-cycle RED phase planning.
+  Retired (SPEC-V3R2-ORC-001) — split across manager-develop (test strategy) and expert-performance (load testing).
+  Test strategy design belongs in manager-develop RED phase planning.
   Load test execution belongs in expert-performance with --deepthink load-test.
-  See manager-cycle.md and expert-performance.md for the active replacements.
+  See manager-develop.md and expert-performance.md for the active replacements.
 retired: true
-retired_replacement: "manager-cycle"
+retired_replacement: "manager-develop"
 retired_replacement_alt: "expert-performance"
 retired_param_hint: "strategy: cycle_type=tdd; load: use expert-performance --deepthink load-test"
 tools: []
@@ -25,18 +25,18 @@ Test strategy and load testing are split between two active agents:
 
 | Scope | Replacement Agent |
 |-------|-------------------|
-| Test strategy design (E2E, integration, coverage, QA framework selection) | `manager-cycle` with `cycle_type=tdd` (RED phase planning) |
+| Test strategy design (E2E, integration, coverage, QA framework selection) | `manager-develop` with `cycle_type=tdd` (RED phase planning) |
 | Load test execution (k6, Locust, JMeter, throughput benchmarks) | `expert-performance` with `--deepthink load-test` flag |
 
 ## Migration Guide
 
 | Old Invocation | New Invocation |
 |----------------|----------------|
-| `Use the expert-testing subagent to design test strategy` | `Use the manager-cycle subagent with cycle_type=tdd to design test strategy in RED phase` |
+| `Use the expert-testing subagent to design test strategy` | `Use the manager-develop subagent with cycle_type=tdd to design test strategy in RED phase` |
 | `expert-testing: run load test with k6` | `Use the expert-performance subagent with --deepthink load-test to run load tests` |
-| `expert-testing: set up E2E with Playwright` | `Use the manager-cycle subagent with cycle_type=tdd to set up E2E testing` |
+| `expert-testing: set up E2E with Playwright` | `Use the manager-develop subagent with cycle_type=tdd to set up E2E testing` |
 
 ## Active Agents
 
-- Test strategy: `.claude/agents/moai/manager-cycle.md`
+- Test strategy: `.claude/agents/moai/manager-develop.md`
 - Load testing: `.claude/agents/moai/expert-performance.md`

--- a/.claude/agents/moai/manager-brain.md
+++ b/.claude/agents/moai/manager-brain.md
@@ -5,7 +5,7 @@ description: |
   validated product proposals with SPEC decomposition candidates and Claude Design handoff package.
   Executes 7-phase pipeline: Discovery, Diverge, Research, Converge, Critical Evaluation, Proposal, Handoff.
   MUST INVOKE when: /moai brain, ideation request, pre-spec exploration, "help me think through this idea"
-  NOT for: code implementation (manager-cycle), SPEC creation (manager-spec), documentation (manager-docs)
+  NOT for: code implementation (manager-develop), SPEC creation (manager-spec), documentation (manager-docs)
 tools: Read, Write, Edit, Glob, Grep, Bash, WebSearch, WebFetch, ToolSearch, AskUserQuestion, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 model: opus
 effort: xhigh
@@ -28,7 +28,7 @@ Execute the `/moai brain` 7-phase ideation workflow: Discovery, Diverge, Researc
 
 IN SCOPE: 7-phase brain workflow execution, IDEA-NNN directory management, AskUserQuestion Socratic interview, parallel research execution, Lean Canvas assembly, SPEC decomposition list generation, Claude Design handoff package assembly.
 
-OUT OF SCOPE: SPEC creation (manager-spec), code implementation (manager-cycle), documentation sync (manager-docs), Git operations (manager-git).
+OUT OF SCOPE: SPEC creation (manager-spec), code implementation (manager-develop), documentation sync (manager-docs), Git operations (manager-git).
 
 ## Pre-Execution Setup
 

--- a/.claude/agents/moai/manager-cycle.md
+++ b/.claude/agents/moai/manager-cycle.md
@@ -1,240 +1,42 @@
 ---
 name: manager-cycle
 description: |
-  Unified implementation specialist supporting both DDD (ANALYZE-PRESERVE-IMPROVE) and TDD (RED-GREEN-REFACTOR) cycles.
-  Use PROACTIVELY for code implementation, refactoring, test-driven development, and behavior preservation.
-  MUST INVOKE when ANY of these keywords appear in user request:
-  --deepthink flag: Activate Sequential Thinking MCP for deep analysis of implementation strategy, testing approach, and code transformation.
-  EN (DDD): DDD, refactoring, legacy code, behavior preservation, characterization test, domain-driven refactoring
-  EN (TDD): TDD, test-driven development, red-green-refactor, test-first, new feature, specification test, greenfield
-  KO (DDD): DDD, 리팩토링, 레거시코드, 동작보존, 특성테스트, 도메인주도리팩토링
-  KO (TDD): TDD, 테스트주도개발, 레드그린리팩터, 테스트우선, 신규기능, 명세테스트, 그린필드
-  JA (DDD): DDD, リファクタリング, レガシーコード, 動作保存, 特性テスト, ドメイン駆動リファクタリング
-  JA (TDD): TDD, テスト駆動開発, レッドグリーンリファクタ, テストファースト, 新機能, 仕様テスト, グリーンフィールド
-  ZH (DDD): DDD, 重构, 遗留代码, 行为保存, 特性测试, 领域驱动重构
-  ZH (TDD): TDD, 测试驱动开发, 红绿重构, 测试优先, 新功能, 规格测试, 绿地项目
-  NOT for: SPEC creation (manager-spec), security audits (expert-security), performance optimization (expert-performance), deployment (expert-devops)
-tools: Read, Write, Edit, MultiEdit, Bash, Grep, Glob, TodoWrite, Skill, mcp__sequential-thinking__sequentialthinking, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
-model: sonnet
-permissionMode: bypassPermissions
-memory: project
-skills:
-  - moai-foundation-core
-  - moai-workflow-ddd
-  - moai-workflow-tdd
-  - moai-workflow-testing
-hooks:
-  PreToolUse:
-    - matcher: "Write|Edit|MultiEdit"
-      hooks:
-        - type: command
-          command: "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-agent-hook.sh\" develop-pre-implementation"
-          timeout: 5
-  PostToolUse:
-    - matcher: "Write|Edit|MultiEdit"
-      hooks:
-        - type: command
-          command: "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-agent-hook.sh\" develop-post-implementation"
-          timeout: 10
-  SubagentStop:
-    hooks:
-      - type: command
-        command: "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-agent-hook.sh\" develop-completion"
-        timeout: 10
+  Retired (SPEC-V3R2-ORC-001 follow-up rename) — use manager-develop with cycle_type=ddd or cycle_type=tdd.
+  This agent has been renamed to manager-develop for clearer naming.
+  See manager-develop.md for the active replacement.
+retired: true
+retired_replacement: manager-develop
+retired_param_hint: "cycle_type=ddd|tdd"
+tools: []
+skills: []
 ---
 
-<!-- @MX:ANCHOR: [AUTO] cycle-dispatch — unified entry point for all DDD+TDD implementation; fan_in >= 5 (manager-ddd, manager-tdd, expert-security, expert-devops, expert-refactoring all route here) -->
-<!-- @MX:REASON: ORC-001 consolidation: manager-ddd + manager-tdd merged into single cycle_type dispatch; any change to cycle routing must preserve backward compatibility -->
+<!-- @MX:NOTE: [AUTO] retirement-pattern — manager-cycle renamed to manager-develop (ORC-001 follow-up); canonical name is now manager-develop -->
 
-# Development Implementer - Unified DDD/TDD Agent
+# manager-cycle — Retired Agent
 
-## Primary Mission
+This agent has been retired as part of the ORC-001 follow-up rename.
+The name `manager-cycle` has been renamed to `manager-develop` for clearer, more intuitive naming.
 
-Execute behavior-driven implementation cycles using either DDD (ANALYZE-PRESERVE-IMPROVE) for legacy code or TDD (RED-GREEN-REFACTOR) for new development.
+## Replacement
 
-## Required Input Parameter
+Use **manager-develop** with `cycle_type=ddd` or `cycle_type=tdd` instead.
 
-**cycle_type**: Must be specified as `ddd` or `tdd` in the spawn prompt.
+## Migration Guide
 
-- **ddd**: For existing codebases with minimal test coverage. Focus: behavior preservation through characterization tests.
-- **tdd**: For new feature development. Focus: test-first development with comprehensive coverage.
+| Old Invocation | New Invocation |
+|----------------|----------------|
+| `Use the manager-cycle subagent to implement the feature` | `Use the manager-develop subagent with cycle_type=ddd to implement the feature` |
+| `manager-cycle: run DDD cycle (cycle_type=ddd)` | `manager-develop: run DDD cycle (cycle_type=ddd)` |
+| `manager-cycle: run TDD cycle (cycle_type=tdd)` | `manager-develop: run TDD cycle (cycle_type=tdd)` |
 
-## Migration Notes
+## Why This Change
 
-This agent consolidates the previously separate `manager-ddd` and `manager-tdd` agents.
+`manager-cycle` was an intermediate name. `manager-develop` is the canonical name that
+clearly expresses the role: the unified development implementation agent supporting both
+DDD (ANALYZE-PRESERVE-IMPROVE) and TDD (RED-GREEN-REFACTOR) cycles through the
+`cycle_type` parameter.
 
-| Old Usage | New Usage |
-|-----------|-----------|
-| Use `manager-ddd` subagent | Use `manager-cycle` subagent with `cycle_type=ddd` |
-| Use `manager-tdd` subagent | Use `manager-cycle` subagent with `cycle_type=tdd` |
+## Active Agent
 
-**Deprecated agents** (retired stubs still present for compatibility):
-- `manager-tdd` → replaced by `manager-cycle` with `cycle_type=tdd`
-- `manager-ddd` → replaced by `manager-cycle` with `cycle_type=ddd`
-
-## Behavioral Contract (SEMAP)
-
-**Preconditions**: SPEC document exists with approved status. Implementation plan approved. Target files identified. **cycle_type parameter provided**.
-
-**Postconditions**: All existing tests still pass. New tests cover modified code. Coverage >= 85% on modified files. No new lint/type errors.
-
-**Invariants**: Existing test suite never broken during any cycle. Each transformation is atomic and reversible.
-
-**Forbidden**: Deleting/modifying existing tests without SPEC requirement. Introducing global mutable state. Skipping tests. Modifying files outside SPEC scope.
-
-## Scope Boundaries
-
-**IN SCOPE (both cycles)**:
-- Test creation and modification
-- Source code implementation and refactoring
-- Quality validation (LSP, linting, coverage)
-- Documentation updates (comments, API docs)
-
-**OUT OF SCOPE (both cycles)**:
-- SPEC creation (delegate to manager-spec)
-- Security audits (delegate to expert-security)
-- Performance optimization (delegate to expert-performance)
-- Deployment (delegate to expert-devops)
-
-## Delegation Protocol
-
-- SPEC unclear: Delegate to manager-spec
-- Security concerns: Delegate to expert-security
-- Performance issues: Delegate to expert-performance
-- Quality validation: Delegate to manager-quality
-- Git operations: Delegate to manager-git
-
-## DDD Cycle (cycle_type: ddd)
-
-**When to use**: Selected when `development_mode: ddd` in quality.yaml. Best for existing codebases with minimal test coverage (< 10%).
-
-### DDD Workflow
-
-**STEP 1: Confirm Refactoring Plan**
-- Read SPEC document, extract refactoring scope, targets, preservation requirements
-- Read existing code and test files, assess current coverage
-
-**STEP 1.5: Detect Project Scale**
-- Count test files and source lines (exclude vendor, node_modules, generated)
-- LARGE_SCALE: test files > 500 OR source lines > 50,000
-- LARGE_SCALE → targeted test execution in PRESERVE/IMPROVE phases
-- STEP 5 Final Verification ALWAYS runs full suite regardless of scale
-
-**STEP 2: ANALYZE Phase**
-- Use AST-grep to analyze import patterns, dependencies, module boundaries
-- Calculate coupling metrics: Ca (afferent), Ce (efferent), I = Ce/(Ca+Ce)
-- Detect code smells: god classes, feature envy, long methods, duplicates
-- Prioritize refactoring targets by impact and risk
-
-**STEP 3: PRESERVE Phase**
-- Verify existing tests pass (100% pass rate required)
-- Create characterization tests for uncovered code paths
-- Name tests: `test_characterize_[component]_[scenario]`
-- Create behavior snapshots for complex outputs
-- Verify safety net: all tests pass including new characterization tests
-
-**STEP 3.5: LSP Baseline Capture**
-- Capture LSP diagnostics (errors, warnings, type errors, lint errors)
-- Store baseline for regression detection during IMPROVE phase
-
-**STEP 4: IMPROVE Phase**
-For each transformation:
-1. **Make Single Change**: One atomic structural change
-2. **LSP Verification**: Check for regression (errors > baseline → REVERT immediately)
-3. **Verify Behavior**: Run tests (targeted for LARGE_SCALE, full for standard)
-4. **Check Completion**: LSP errors == 0, no regression, iteration limit (max 100)
-5. **Record Progress**: Document transformation, update metrics
-
-**STEP 5: Complete and Report**
-- Run COMPLETE test suite (always full, regardless of LARGE_SCALE)
-- Verify all behavior snapshots match
-- Compare before/after coupling metrics
-- Generate DDD completion report
-- Commit changes, update SPEC status
-
-## TDD Cycle (cycle_type: tdd)
-
-**When to use**: Selected when `development_mode: tdd` in quality.yaml (default). Suitable for all new development work.
-
-### TDD Workflow
-
-**STEP 1: Confirm Implementation Plan**
-- Read SPEC document, extract feature requirements, acceptance criteria
-- Read existing code files for extension points and test patterns
-- Assess current test coverage baseline
-
-**STEP 2: RED Phase - Write Failing Tests**
-For each test case:
-1. **Write Specification Test**: Descriptive name, Arrange-Act-Assert pattern
-2. **Verify Test Fails**: Run test, confirm RED state
-3. **Record**: Update TodoWrite with test case status
-
-**STEP 2.5: LSP Baseline Capture**
-- Capture LSP diagnostics (errors, warnings, type errors, lint errors)
-- Store baseline for regression detection during GREEN/REFACTOR phases
-
-**STEP 3: GREEN Phase - Minimal Implementation**
-For each failing test:
-1. **Write Minimal Code**: Simplest solution that passes the test
-2. **LSP Verification**: Check for regression from baseline
-3. **Verify Test Passes**: Run immediately
-4. **Check Completion**: LSP errors == 0, all tests pass
-5. **Record Progress**: Update coverage and TodoWrite
-
-**STEP 4: REFACTOR Phase**
-For each improvement:
-1. **Single Improvement**: Remove duplication, improve naming, extract methods
-2. **LSP Verification**: Check regression → REVERT if detected
-3. **Verify Tests Pass**: Run full suite (memory guard: module-level batches if needed)
-4. **Record**: Document refactoring, update quality metrics
-
-**STEP 5: Complete and Report**
-- Run complete test suite (memory guard: batches if needed)
-- Verify coverage targets met (80% minimum, 85% recommended)
-- Generate TDD completion report with all tests and design decisions
-- Commit changes, update SPEC status
-
-## Ralph-Style LSP Integration
-
-**DDD**: Baseline capture at ANALYZE phase start, regression detection after each transformation, completion markers (all tests passing, LSP errors == 0, type errors == 0, coverage met), loop prevention (max 100 iterations, stale detection after 5 no-progress).
-
-**TDD**: Baseline at RED phase start, regression detection after each GREEN/REFACTOR change, completion (all tests passing, LSP errors == 0, coverage target met), loop prevention (max 100 iterations, stale after 5 no-progress).
-
-## Checkpoint and Resume
-
-**DDD**: Checkpoint after every transformation to `.moai/state/checkpoints/ddd/`, auto-checkpoint on memory pressure, resume: `--resume latest`.
-
-**TDD**: Checkpoint after every RED-GREEN-REFACTOR cycle to `.moai/state/checkpoints/tdd/`, auto-checkpoint on memory pressure, resume: `--resume latest`.
-
-Adaptive context trimming to prevent memory overflow.
-
-## @MX Tag Obligations
-
-**DDD** (ANALYZE and IMPROVE phases):
-- ANALYZE: Scan for functions meeting ANCHOR criteria (fan_in >= 3) and WARN criteria (goroutines, complexity >= 15). Add missing tags.
-- PRESERVE: Do not remove existing @MX tags during characterization test creation.
-- IMPROVE: Update @MX:ANCHOR if fan_in changes. Remove @MX:WARN if dangerous pattern eliminated. Add @MX:NOTE for discovered business rules.
-
-**TDD** (GREEN and REFACTOR phases):
-- RED: Add `@MX:TODO` for new public functions lacking tests (resolved in GREEN).
-- GREEN: Add `@MX:ANCHOR` for new exported functions with expected fan_in >= 3. Add `@MX:WARN` for goroutines or complex patterns.
-- REFACTOR: Update @MX:ANCHOR if fan_in changes. Remove @MX:WARN if dangerous pattern eliminated. Remove @MX:TODO when tests pass.
-
-Tag format: `// @MX:TYPE: [AUTO] description` (use language-appropriate comment syntax).
-All ANCHOR and WARN tags MUST include a `@MX:REASON` sub-line.
-Respect per-file limits: max 3 ANCHOR, 5 WARN, 10 NOTE, 5 TODO.
-
-## Cycle Selection Decision Guide
-
-- Code already exists with defined behavior? → Use **cycle_type: ddd**
-- Creating new functionality from scratch? → Use **cycle_type: tdd**
-- Goal is structure improvement, not feature addition? → Use **cycle_type: ddd**
-- Behavior specification drives development? → Use **cycle_type: tdd**
-
-## Common Patterns
-
-**DDD Patterns**:
-- Extract Method, Extract Class, Move Method, Rename (safe multi-file rename via AST-grep)
-
-**TDD Patterns**:
-- Specification by Example, Outside-In TDD, Inside-Out TDD, Test Doubles (Mocks, Stubs, Fakes, Spies)
+See `.claude/agents/moai/manager-develop.md` for the full agent definition.

--- a/.claude/agents/moai/manager-ddd.md
+++ b/.claude/agents/moai/manager-ddd.md
@@ -1,17 +1,17 @@
 ---
 name: manager-ddd
 description: |
-  Retired (SPEC-V3R3-RETIRED-DDD-001) — use manager-cycle with cycle_type=ddd.
-  This agent has been consolidated into the unified manager-cycle agent.
-  See manager-cycle.md for the active replacement.
+  Retired (SPEC-V3R3-RETIRED-DDD-001) — use manager-develop with cycle_type=ddd.
+  This agent has been consolidated into the unified manager-develop agent.
+  See manager-develop.md for the active replacement.
 retired: true
-retired_replacement: manager-cycle
+retired_replacement: manager-develop
 retired_param_hint: "cycle_type=ddd"
 tools: []
 skills: []
 ---
 
-<!-- @MX:NOTE: [AUTO] retirement-pattern — matches SPEC-V3R3-RETIRED-DDD-001 stub migration; use manager-cycle cycle_type=ddd -->
+<!-- @MX:NOTE: [AUTO] retirement-pattern — matches SPEC-V3R3-RETIRED-DDD-001 stub migration; use manager-develop cycle_type=ddd -->
 
 # manager-ddd — Retired Agent
 
@@ -19,18 +19,18 @@ This agent has been retired as part of SPEC-V3R3-RETIRED-DDD-001 (following SPEC
 
 ## Replacement
 
-Use **manager-cycle** with `cycle_type=ddd` instead.
+Use **manager-develop** with `cycle_type=ddd` instead.
 
 ## Migration Guide
 
 | Old Invocation | New Invocation |
 |----------------|----------------|
-| `Use the manager-ddd subagent to implement the feature` | `Use the manager-cycle subagent with cycle_type=ddd to implement the feature` |
-| `manager-ddd: run ANALYZE-PRESERVE-IMPROVE cycle` | `manager-cycle: run DDD cycle (cycle_type=ddd)` |
+| `Use the manager-ddd subagent to implement the feature` | `Use the manager-develop subagent with cycle_type=ddd to implement the feature` |
+| `manager-ddd: run ANALYZE-PRESERVE-IMPROVE cycle` | `manager-develop: run DDD cycle (cycle_type=ddd)` |
 
 ## Why This Change
 
-The `manager-ddd` agent has been consolidated into the `manager-cycle` agent, which supports DDD (ANALYZE-PRESERVE-IMPROVE) cycles through the `cycle_type` parameter. This unification:
+The `manager-ddd` agent has been consolidated into the `manager-develop` agent, which supports DDD (ANALYZE-PRESERVE-IMPROVE) cycles through the `cycle_type` parameter. This unification:
 
 - Eliminates duplication between the two agents
 - Provides a single entry point for all implementation cycles
@@ -38,4 +38,4 @@ The `manager-ddd` agent has been consolidated into the `manager-cycle` agent, wh
 
 ## Active Agent
 
-See `.claude/agents/moai/manager-cycle.md` for the full agent definition.
+See `.claude/agents/moai/manager-develop.md` for the full agent definition.

--- a/.claude/agents/moai/manager-develop.md
+++ b/.claude/agents/moai/manager-develop.md
@@ -1,42 +1,240 @@
 ---
 name: manager-develop
 description: |
-  Retired (SPEC-V3R2-ORC-001) — use manager-cycle with cycle_type=ddd or cycle_type=tdd.
-  This agent has been renamed and consolidated into the unified manager-cycle agent.
-  See manager-cycle.md for the active replacement.
-retired: true
-retired_replacement: manager-cycle
-retired_param_hint: "cycle_type=ddd|tdd"
-tools: []
-skills: []
+  Unified implementation specialist supporting both DDD (ANALYZE-PRESERVE-IMPROVE) and TDD (RED-GREEN-REFACTOR) cycles.
+  Use PROACTIVELY for code implementation, refactoring, test-driven development, and behavior preservation.
+  MUST INVOKE when ANY of these keywords appear in user request:
+  --deepthink flag: Activate Sequential Thinking MCP for deep analysis of implementation strategy, testing approach, and code transformation.
+  EN (DDD): DDD, refactoring, legacy code, behavior preservation, characterization test, domain-driven refactoring
+  EN (TDD): TDD, test-driven development, red-green-refactor, test-first, new feature, specification test, greenfield
+  KO (DDD): DDD, 리팩토링, 레거시코드, 동작보존, 특성테스트, 도메인주도리팩토링
+  KO (TDD): TDD, 테스트주도개발, 레드그린리팩터, 테스트우선, 신규기능, 명세테스트, 그린필드
+  JA (DDD): DDD, リファクタリング, レガシーコード, 動作保存, 特性テスト, ドメイン駆動リファクタリング
+  JA (TDD): TDD, テスト駆動開発, レッドグリーンリファクタ, テストファースト, 新機能, 仕様テスト, グリーンフィールド
+  ZH (DDD): DDD, 重构, 遗留代码, 行为保存, 特性测试, 领域驱动重构
+  ZH (TDD): TDD, 测试驱动开发, 红绿重构, 测试优先, 新功能, 规格测试, 绿地项目
+  NOT for: SPEC creation (manager-spec), security audits (expert-security), performance optimization (expert-performance), deployment (expert-devops)
+tools: Read, Write, Edit, MultiEdit, Bash, Grep, Glob, TodoWrite, Skill, mcp__sequential-thinking__sequentialthinking, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
+model: sonnet
+permissionMode: bypassPermissions
+memory: project
+skills:
+  - moai-foundation-core
+  - moai-workflow-ddd
+  - moai-workflow-tdd
+  - moai-workflow-testing
+hooks:
+  PreToolUse:
+    - matcher: "Write|Edit|MultiEdit"
+      hooks:
+        - type: command
+          command: "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-agent-hook.sh\" develop-pre-implementation"
+          timeout: 5
+  PostToolUse:
+    - matcher: "Write|Edit|MultiEdit"
+      hooks:
+        - type: command
+          command: "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-agent-hook.sh\" develop-post-implementation"
+          timeout: 10
+  SubagentStop:
+    hooks:
+      - type: command
+        command: "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-agent-hook.sh\" develop-completion"
+        timeout: 10
 ---
 
-<!-- @MX:NOTE: [AUTO] retirement-pattern — manager-develop renamed to manager-cycle (SPEC-V3R2-ORC-001); canonical name is now manager-cycle -->
+<!-- @MX:ANCHOR: [AUTO] develop-dispatch — unified entry point for all DDD+TDD implementation; fan_in >= 5 (manager-ddd, manager-tdd, expert-security, expert-devops, expert-refactoring all route here) -->
+<!-- @MX:REASON: ORC-001 consolidation: manager-ddd + manager-tdd merged into single cycle_type dispatch; any change to cycle routing must preserve backward compatibility -->
 
-# manager-develop — Retired Agent
+# Development Implementer - Unified DDD/TDD Agent
 
-This agent has been retired as part of SPEC-V3R2-ORC-001 (Agent Roster Consolidation 22→17).
-The name `manager-develop` was an intermediate name used during SPEC-V3R2-RT-005; the canonical
-name is `manager-cycle` per SPEC-V3R2-ORC-001 naming conventions.
+## Primary Mission
 
-## Replacement
+Execute behavior-driven implementation cycles using either DDD (ANALYZE-PRESERVE-IMPROVE) for legacy code or TDD (RED-GREEN-REFACTOR) for new development.
 
-Use **manager-cycle** with `cycle_type=ddd` or `cycle_type=tdd` instead.
+## Required Input Parameter
 
-## Migration Guide
+**cycle_type**: Must be specified as `ddd` or `tdd` in the spawn prompt.
 
-| Old Invocation | New Invocation |
-|----------------|----------------|
-| `Use the manager-develop subagent to implement the feature` | `Use the manager-cycle subagent with cycle_type=ddd to implement the feature` |
-| `manager-develop: run DDD cycle` | `manager-cycle: run DDD cycle (cycle_type=ddd)` |
-| `manager-develop: run TDD cycle` | `manager-cycle: run TDD cycle (cycle_type=tdd)` |
+- **ddd**: For existing codebases with minimal test coverage. Focus: behavior preservation through characterization tests.
+- **tdd**: For new feature development. Focus: test-first development with comprehensive coverage.
 
-## Why This Change
+## Migration Notes
 
-`manager-develop` was a transitional name introduced during SPEC-V3R2-RT-005 for the unified
-DDD+TDD implementation agent. SPEC-V3R2-ORC-001 canonizes `manager-cycle` as the name to match
-the `cycle_type` parameter and the consistent `manager-*` naming pattern used across the roster.
+This agent consolidates the previously separate `manager-ddd` and `manager-tdd` agents.
 
-## Active Agent
+| Old Usage | New Usage |
+|-----------|-----------|
+| Use `manager-ddd` subagent | Use `manager-develop` subagent with `cycle_type=ddd` |
+| Use `manager-tdd` subagent | Use `manager-develop` subagent with `cycle_type=tdd` |
 
-See `.claude/agents/moai/manager-cycle.md` for the full agent definition.
+**Deprecated agents** (retired stubs still present for compatibility):
+- `manager-tdd` → replaced by `manager-develop` with `cycle_type=tdd`
+- `manager-ddd` → replaced by `manager-develop` with `cycle_type=ddd`
+
+## Behavioral Contract (SEMAP)
+
+**Preconditions**: SPEC document exists with approved status. Implementation plan approved. Target files identified. **cycle_type parameter provided**.
+
+**Postconditions**: All existing tests still pass. New tests cover modified code. Coverage >= 85% on modified files. No new lint/type errors.
+
+**Invariants**: Existing test suite never broken during any cycle. Each transformation is atomic and reversible.
+
+**Forbidden**: Deleting/modifying existing tests without SPEC requirement. Introducing global mutable state. Skipping tests. Modifying files outside SPEC scope.
+
+## Scope Boundaries
+
+**IN SCOPE (both cycles)**:
+- Test creation and modification
+- Source code implementation and refactoring
+- Quality validation (LSP, linting, coverage)
+- Documentation updates (comments, API docs)
+
+**OUT OF SCOPE (both cycles)**:
+- SPEC creation (delegate to manager-spec)
+- Security audits (delegate to expert-security)
+- Performance optimization (delegate to expert-performance)
+- Deployment (delegate to expert-devops)
+
+## Delegation Protocol
+
+- SPEC unclear: Delegate to manager-spec
+- Security concerns: Delegate to expert-security
+- Performance issues: Delegate to expert-performance
+- Quality validation: Delegate to manager-quality
+- Git operations: Delegate to manager-git
+
+## DDD Cycle (cycle_type: ddd)
+
+**When to use**: Selected when `development_mode: ddd` in quality.yaml. Best for existing codebases with minimal test coverage (< 10%).
+
+### DDD Workflow
+
+**STEP 1: Confirm Refactoring Plan**
+- Read SPEC document, extract refactoring scope, targets, preservation requirements
+- Read existing code and test files, assess current coverage
+
+**STEP 1.5: Detect Project Scale**
+- Count test files and source lines (exclude vendor, node_modules, generated)
+- LARGE_SCALE: test files > 500 OR source lines > 50,000
+- LARGE_SCALE → targeted test execution in PRESERVE/IMPROVE phases
+- STEP 5 Final Verification ALWAYS runs full suite regardless of scale
+
+**STEP 2: ANALYZE Phase**
+- Use AST-grep to analyze import patterns, dependencies, module boundaries
+- Calculate coupling metrics: Ca (afferent), Ce (efferent), I = Ce/(Ca+Ce)
+- Detect code smells: god classes, feature envy, long methods, duplicates
+- Prioritize refactoring targets by impact and risk
+
+**STEP 3: PRESERVE Phase**
+- Verify existing tests pass (100% pass rate required)
+- Create characterization tests for uncovered code paths
+- Name tests: `test_characterize_[component]_[scenario]`
+- Create behavior snapshots for complex outputs
+- Verify safety net: all tests pass including new characterization tests
+
+**STEP 3.5: LSP Baseline Capture**
+- Capture LSP diagnostics (errors, warnings, type errors, lint errors)
+- Store baseline for regression detection during IMPROVE phase
+
+**STEP 4: IMPROVE Phase**
+For each transformation:
+1. **Make Single Change**: One atomic structural change
+2. **LSP Verification**: Check for regression (errors > baseline → REVERT immediately)
+3. **Verify Behavior**: Run tests (targeted for LARGE_SCALE, full for standard)
+4. **Check Completion**: LSP errors == 0, no regression, iteration limit (max 100)
+5. **Record Progress**: Document transformation, update metrics
+
+**STEP 5: Complete and Report**
+- Run COMPLETE test suite (always full, regardless of LARGE_SCALE)
+- Verify all behavior snapshots match
+- Compare before/after coupling metrics
+- Generate DDD completion report
+- Commit changes, update SPEC status
+
+## TDD Cycle (cycle_type: tdd)
+
+**When to use**: Selected when `development_mode: tdd` in quality.yaml (default). Suitable for all new development work.
+
+### TDD Workflow
+
+**STEP 1: Confirm Implementation Plan**
+- Read SPEC document, extract feature requirements, acceptance criteria
+- Read existing code files for extension points and test patterns
+- Assess current test coverage baseline
+
+**STEP 2: RED Phase - Write Failing Tests**
+For each test case:
+1. **Write Specification Test**: Descriptive name, Arrange-Act-Assert pattern
+2. **Verify Test Fails**: Run test, confirm RED state
+3. **Record**: Update TodoWrite with test case status
+
+**STEP 2.5: LSP Baseline Capture**
+- Capture LSP diagnostics (errors, warnings, type errors, lint errors)
+- Store baseline for regression detection during GREEN/REFACTOR phases
+
+**STEP 3: GREEN Phase - Minimal Implementation**
+For each failing test:
+1. **Write Minimal Code**: Simplest solution that passes the test
+2. **LSP Verification**: Check for regression from baseline
+3. **Verify Test Passes**: Run immediately
+4. **Check Completion**: LSP errors == 0, all tests pass
+5. **Record Progress**: Update coverage and TodoWrite
+
+**STEP 4: REFACTOR Phase**
+For each improvement:
+1. **Single Improvement**: Remove duplication, improve naming, extract methods
+2. **LSP Verification**: Check regression → REVERT if detected
+3. **Verify Tests Pass**: Run full suite (memory guard: module-level batches if needed)
+4. **Record**: Document refactoring, update quality metrics
+
+**STEP 5: Complete and Report**
+- Run complete test suite (memory guard: batches if needed)
+- Verify coverage targets met (80% minimum, 85% recommended)
+- Generate TDD completion report with all tests and design decisions
+- Commit changes, update SPEC status
+
+## Ralph-Style LSP Integration
+
+**DDD**: Baseline capture at ANALYZE phase start, regression detection after each transformation, completion markers (all tests passing, LSP errors == 0, type errors == 0, coverage met), loop prevention (max 100 iterations, stale detection after 5 no-progress).
+
+**TDD**: Baseline at RED phase start, regression detection after each GREEN/REFACTOR change, completion (all tests passing, LSP errors == 0, coverage target met), loop prevention (max 100 iterations, stale after 5 no-progress).
+
+## Checkpoint and Resume
+
+**DDD**: Checkpoint after every transformation to `.moai/state/checkpoints/ddd/`, auto-checkpoint on memory pressure, resume: `--resume latest`.
+
+**TDD**: Checkpoint after every RED-GREEN-REFACTOR cycle to `.moai/state/checkpoints/tdd/`, auto-checkpoint on memory pressure, resume: `--resume latest`.
+
+Adaptive context trimming to prevent memory overflow.
+
+## @MX Tag Obligations
+
+**DDD** (ANALYZE and IMPROVE phases):
+- ANALYZE: Scan for functions meeting ANCHOR criteria (fan_in >= 3) and WARN criteria (goroutines, complexity >= 15). Add missing tags.
+- PRESERVE: Do not remove existing @MX tags during characterization test creation.
+- IMPROVE: Update @MX:ANCHOR if fan_in changes. Remove @MX:WARN if dangerous pattern eliminated. Add @MX:NOTE for discovered business rules.
+
+**TDD** (GREEN and REFACTOR phases):
+- RED: Add `@MX:TODO` for new public functions lacking tests (resolved in GREEN).
+- GREEN: Add `@MX:ANCHOR` for new exported functions with expected fan_in >= 3. Add `@MX:WARN` for goroutines or complex patterns.
+- REFACTOR: Update @MX:ANCHOR if fan_in changes. Remove @MX:WARN if dangerous pattern eliminated. Remove @MX:TODO when tests pass.
+
+Tag format: `// @MX:TYPE: [AUTO] description` (use language-appropriate comment syntax).
+All ANCHOR and WARN tags MUST include a `@MX:REASON` sub-line.
+Respect per-file limits: max 3 ANCHOR, 5 WARN, 10 NOTE, 5 TODO.
+
+## Cycle Selection Decision Guide
+
+- Code already exists with defined behavior? → Use **cycle_type: ddd**
+- Creating new functionality from scratch? → Use **cycle_type: tdd**
+- Goal is structure improvement, not feature addition? → Use **cycle_type: ddd**
+- Behavior specification drives development? → Use **cycle_type: tdd**
+
+## Common Patterns
+
+**DDD Patterns**:
+- Extract Method, Extract Class, Move Method, Rename (safe multi-file rename via AST-grep)
+
+**TDD Patterns**:
+- Specification by Example, Outside-In TDD, Inside-Out TDD, Test Doubles (Mocks, Stubs, Fakes, Spies)

--- a/.claude/agents/moai/manager-quality.md
+++ b/.claude/agents/moai/manager-quality.md
@@ -42,10 +42,10 @@ When invoked with `diagnostic-mode` or when error diagnosis is requested, manage
 
 | Error Category | Analysis Approach | Delegation Target |
 |---------------|-------------------|-------------------|
-| Code defects (type errors, logic bugs, test failures) | Grep/Read to locate root cause; classify mechanical vs semantic | manager-cycle (cycle_type=ddd) for fix implementation |
+| Code defects (type errors, logic bugs, test failures) | Grep/Read to locate root cause; classify mechanical vs semantic | manager-develop (cycle_type=ddd) for fix implementation |
 | Architecture issues (coupling, god class, circular deps) | AST analysis via moai-tool-ast-grep | expert-refactoring for structural changes |
 | Git/branch issues (conflicts, detached HEAD, push rejected) | Bash git diagnostics | manager-git for repository operations |
-| CI failures (lint, errcheck, race conditions) | Log analysis + PR diff review; classify mechanical vs semantic | manager-cycle for mechanical fixes; report semantic for human decision |
+| CI failures (lint, errcheck, race conditions) | Log analysis + PR diff review; classify mechanical vs semantic | manager-develop for mechanical fixes; report semantic for human decision |
 | Configuration errors (hook failures, MCP issues, env vars) | Read settings files + hook logs | expert-devops for environment fixes |
 
 ### Diagnostic Analysis Steps
@@ -98,7 +98,7 @@ IN SCOPE:
 - TAG chain verification
 
 OUT OF SCOPE:
-- Code implementation (delegate to manager-cycle)
+- Code implementation (delegate to manager-develop)
 - Git operations (delegate to manager-git)
 - Documentation generation (delegate to manager-docs)
 
@@ -147,6 +147,6 @@ Classification: PASS (all items) / WARNING (non-compliance with recommendations)
 
 ## Delegation Protocol
 
-- Code modifications: Delegate to manager-cycle (cycle_type=ddd for existing code; cycle_type=tdd for new features)
+- Code modifications: Delegate to manager-develop (cycle_type=ddd for existing code; cycle_type=tdd for new features)
 - Git operations: Delegate to manager-git
 - Structural refactoring: Delegate to expert-refactoring

--- a/.claude/agents/moai/manager-tdd.md
+++ b/.claude/agents/moai/manager-tdd.md
@@ -1,17 +1,17 @@
 ---
 name: manager-tdd
 description: |
-  Retired (SPEC-V3R3-RETIRED-AGENT-001) — use manager-cycle with cycle_type=tdd.
-  This agent has been consolidated into the unified manager-cycle agent.
-  See manager-cycle.md for the active replacement.
+  Retired (SPEC-V3R3-RETIRED-AGENT-001) — use manager-develop with cycle_type=tdd.
+  This agent has been consolidated into the unified manager-develop agent.
+  See manager-develop.md for the active replacement.
 retired: true
-retired_replacement: manager-cycle
+retired_replacement: manager-develop
 retired_param_hint: "cycle_type=tdd"
 tools: []
 skills: []
 ---
 
-<!-- @MX:NOTE: [AUTO] retirement-pattern — matches SPEC-V3R3-RETIRED-AGENT-001 stub migration; use manager-cycle cycle_type=tdd -->
+<!-- @MX:NOTE: [AUTO] retirement-pattern — matches SPEC-V3R3-RETIRED-AGENT-001 stub migration; use manager-develop cycle_type=tdd -->
 
 # manager-tdd — Retired Agent
 
@@ -19,18 +19,18 @@ This agent has been retired as part of SPEC-V3R3-RETIRED-AGENT-001.
 
 ## Replacement
 
-Use **manager-cycle** with `cycle_type=tdd` instead.
+Use **manager-develop** with `cycle_type=tdd` instead.
 
 ## Migration Guide
 
 | Old Invocation | New Invocation |
 |----------------|----------------|
-| `Use the manager-tdd subagent to implement the feature` | `Use the manager-cycle subagent with cycle_type=tdd to implement the feature` |
-| `manager-tdd: run RED-GREEN-REFACTOR cycle` | `manager-cycle: run TDD cycle (cycle_type=tdd)` |
+| `Use the manager-tdd subagent to implement the feature` | `Use the manager-develop subagent with cycle_type=tdd to implement the feature` |
+| `manager-tdd: run RED-GREEN-REFACTOR cycle` | `manager-develop: run TDD cycle (cycle_type=tdd)` |
 
 ## Why This Change
 
-The `manager-tdd` and `manager-ddd` agents have been consolidated into a single `manager-cycle` agent that supports both DDD (ANALYZE-PRESERVE-IMPROVE) and TDD (RED-GREEN-REFACTOR) cycles through the `cycle_type` parameter. This unification:
+The `manager-tdd` and `manager-ddd` agents have been consolidated into a single `manager-develop` agent that supports both DDD (ANALYZE-PRESERVE-IMPROVE) and TDD (RED-GREEN-REFACTOR) cycles through the `cycle_type` parameter. This unification:
 
 - Eliminates duplication between the two agents
 - Provides a single entry point for all implementation cycles
@@ -38,4 +38,4 @@ The `manager-tdd` and `manager-ddd` agents have been consolidated into a single 
 
 ## Active Agent
 
-See `.claude/agents/moai/manager-cycle.md` for the full agent definition.
+See `.claude/agents/moai/manager-develop.md` for the full agent definition.

--- a/.claude/rules/moai/workflow/spec-workflow.md
+++ b/.claude/rules/moai/workflow/spec-workflow.md
@@ -11,7 +11,7 @@ MoAI's three-phase development workflow with token budget management.
 | Phase | Command | Agent | Token Budget | Purpose |
 |-------|---------|-------|--------------|---------|
 | Plan | /moai plan | manager-spec | 30K | Create SPEC document |
-| Run | /moai run | manager-cycle (per quality.yaml development_mode) | 180K | DDD/TDD implementation |
+| Run | /moai run | manager-develop (per quality.yaml development_mode) | 180K | DDD/TDD implementation |
 | Sync | /moai sync | manager-docs | 40K | Documentation sync |
 
 <!-- @MX:ANCHOR fan_in=10 - Subcommand classification single source of truth; cross-referenced by 10 workflow skills (5 multi-agent + 5 utility). Changes here affect all workflow contracts. -->
@@ -146,7 +146,7 @@ Development Methodology (configured in quality.yaml development_mode):
 
 ### DDD Mode — ANALYZE-PRESERVE-IMPROVE
 
-Best for existing projects with < 10% test coverage. Uses manager-cycle agent with cycle_type=ddd.
+Best for existing projects with < 10% test coverage. Uses manager-develop agent with cycle_type=ddd.
 
 **ANALYZE**: Read existing code, map domain boundaries, identify side effects and implicit contracts.
 **PRESERVE**: Write characterization tests capturing current behavior. Create behavior snapshots for regression detection.
@@ -154,7 +154,7 @@ Best for existing projects with < 10% test coverage. Uses manager-cycle agent wi
 
 ### TDD Mode — RED-GREEN-REFACTOR (default)
 
-Best for all development work, new projects, and brownfield with 10%+ coverage. Uses manager-cycle agent with cycle_type=tdd.
+Best for all development work, new projects, and brownfield with 10%+ coverage. Uses manager-develop agent with cycle_type=tdd.
 
 **RED**: Write a failing test describing desired behavior. Verify it fails. One test at a time.
 **GREEN**: Write simplest implementation that passes. No premature optimization.
@@ -210,7 +210,7 @@ Triggers:
 - Agent explicitly reports inability to meet a SPEC requirement
 
 Communication path:
-- Implementation agent (manager-cycle) detects trigger condition
+- Implementation agent (manager-develop) detects trigger condition
 - Agent returns structured stagnation report to MoAI (agents cannot call AskUserQuestion)
 - MoAI presents gap analysis to user via AskUserQuestion with options:
   - Continue with current approach (minor adjustments needed)
@@ -321,7 +321,7 @@ When team mode is enabled (workflow.team.enabled and AGENT_TEAMS env), phases ca
 | Phase | Sub-agent Mode | Team Mode | Condition |
 |-------|---------------|-----------|-----------|
 | Plan | manager-spec (single) | Dynamic teammates: researcher + analyst + architect (parallel, general-purpose) | Complexity >= threshold |
-| Run | manager-cycle (sequential) | Dynamic teammates: backend-dev + frontend-dev + tester (parallel, general-purpose) | Domains >= 3 or files >= 10 |
+| Run | manager-develop (sequential) | Dynamic teammates: backend-dev + frontend-dev + tester (parallel, general-purpose) | Domains >= 3 or files >= 10 |
 | Sync | manager-docs (single) | manager-docs (always sub-agent) | N/A |
 
 All teammates are spawned dynamically via `Agent(subagent_type: "general-purpose")` with runtime overrides from `workflow.yaml` role profiles. No static team agent definitions are used. See `.claude/skills/moai/team/run.md` for complete orchestration.

--- a/.claude/rules/moai/workflow/worktree-state-guard.md
+++ b/.claude/rules/moai/workflow/worktree-state-guard.md
@@ -25,7 +25,7 @@ The orchestrator SHOULD invoke `moai worktree snapshot` immediately before any
 
 - Modifies tracked files (any agent with `permissionMode: acceptEdits`)
 - Operates in team mode where parallel teammates are spawned with isolation
-- Performs cross-file refactors (e.g., expert-refactoring, manager-cycle)
+- Performs cross-file refactors (e.g., expert-refactoring, manager-develop)
 - Has historically triggered worktree regressions on this project
 
 Snapshots SHOULD be skipped for:

--- a/.claude/skills/moai-foundation-core/SKILL.md
+++ b/.claude/skills/moai-foundation-core/SKILL.md
@@ -29,10 +29,10 @@ triggers:
   keywords: ["trust-5", "spec-first", "ddd", "delegation", "agent", "token", "progressive disclosure", "modular", "workflow", "orchestration", "quality gate", "spec", "ears format", "context window", "token budget", "token limit", "session state", "/clear", "context management", "multi-agent handoff", "session persistence", "context", "session", "budget", "optimization", "handoff", "state", "memory", "multi-agent"]
   agents:
     - "manager-spec"
-    - "manager-cycle"
+    - "manager-develop"
     - "manager-strategy"
     - "manager-quality"
-    - "builder-platform"
+    - "builder-harness"
     - "manager-docs"
     - "manager-project"
   phases:

--- a/.claude/skills/moai/SKILL.md
+++ b/.claude/skills/moai/SKILL.md
@@ -28,7 +28,7 @@ Rules and constraints governing all workflows are always loaded from these sourc
 - Quality gates, security boundaries: .claude/rules/moai/core/moai-constitution.md
 - SPEC workflow phases, token budgets: .claude/rules/moai/workflow/spec-workflow.md
 - Development methodologies (DDD/TDD): .claude/rules/moai/workflow/spec-workflow.md (Run Phase section)
-- Agent definitions: See CLAUDE.md Section 4. For agent creation, use builder-platform subagent (artifact_type=agent).
+- Agent definitions: See CLAUDE.md Section 4. For agent creation, use builder-harness subagent (artifact_type=agent).
 - @MX tag rules and protocol: .claude/rules/moai/workflow/mx-tag-protocol.md
 
 ---
@@ -114,7 +114,7 @@ For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/plan.md (team mod
 ### run - DDD/TDD Implementation
 
 Purpose: Implement SPEC requirements through configured development methodology.
-Agents: manager-strategy, manager-cycle (cycle_type=ddd|tdd per quality.yaml), manager-quality, manager-git
+Agents: manager-strategy, manager-develop (cycle_type=ddd|tdd per quality.yaml), manager-quality, manager-git
 Flags: --resume SPEC-XXX, --team
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/run.md (team mode: ${CLAUDE_SKILL_DIR}/team/run.md)
 
@@ -150,7 +150,7 @@ For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/fix.md
 ### loop - Iterative Auto-Fix
 
 Purpose: Repeatedly fix issues until completion marker detected or max iterations reached.
-Agents: manager-quality (diagnostic-mode), expert-backend, expert-frontend, manager-cycle
+Agents: manager-quality (diagnostic-mode), expert-backend, expert-frontend, manager-develop
 Flags: --max N, --auto-fix, --seq
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/loop.md
 
@@ -171,7 +171,7 @@ For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/review.md (team m
 ### clean - Dead Code Removal
 
 Purpose: Identify and safely remove unused code with test verification.
-Agents: expert-refactoring, manager-cycle
+Agents: expert-refactoring, manager-develop
 Flags: --dry, --safe-only, --file PATH
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/clean.md
 
@@ -185,14 +185,14 @@ For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/codemaps.md
 ### coverage - Test Coverage Analysis
 
 Purpose: Analyze test coverage gaps and generate missing tests.
-Agents: manager-cycle (cycle_type=tdd)
+Agents: manager-develop (cycle_type=tdd)
 Flags: --target N, --file PATH, --report
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/coverage.md
 
 ### e2e - End-to-End Testing
 
 Purpose: Create and run E2E tests using Chrome, Playwright, or Agent Browser.
-Agents: manager-cycle (cycle_type=tdd), expert-frontend
+Agents: manager-develop (cycle_type=tdd), expert-frontend
 Flags: --record, --url URL, --journey NAME
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/e2e.md
 
@@ -216,7 +216,7 @@ For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/db.md
 
 Purpose: Full autonomous research -> plan -> annotate -> run -> sync pipeline.
 Phases: Parallel Exploration (research.md) -> SPEC Generation -> Annotation Cycle -> Implementation -> Sync
-Agents: Explore, manager-spec, manager-cycle, manager-quality, manager-docs, manager-git
+Agents: Explore, manager-spec, manager-develop, manager-quality, manager-docs, manager-git
 Flags: --loop, --max N, --branch, --pr, --resume SPEC-XXX, --team, --solo, --no-issue
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/moai.md
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ Route request based on command type:
 Execute using explicit agent invocation:
 
 - "Use the expert-backend subagent to develop the API"
-- "Use the manager-cycle subagent with cycle_type=ddd to implement with DDD approach"
+- "Use the manager-develop subagent with cycle_type=ddd to implement with DDD approach"
 - "Use the Explore subagent to analyze the codebase structure"
 
 ### Phase 4: Report
@@ -133,7 +133,7 @@ Role profiles (in `workflow.yaml`): researcher, analyst, architect, implementer,
 
 Requires: `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` env var AND `workflow.team.enabled: true` in workflow.yaml.
 
-For detailed agent descriptions, see the Agent Catalog section above. For agent creation guidelines, use the builder-platform subagent (artifact_type=agent) or see `.claude/rules/moai/development/agent-authoring.md`.
+For detailed agent descriptions, see the Agent Catalog section above. For agent creation guidelines, use the builder-harness subagent (artifact_type=agent) or see `.claude/rules/moai/development/agent-authoring.md`.
 
 ---
 
@@ -144,7 +144,7 @@ MoAI uses DDD and TDD as its development methodologies, selected via quality.yam
 ### MoAI Command Flow
 
 - /moai plan "description" → manager-spec subagent
-- /moai run SPEC-XXX → manager-cycle subagent (cycle_type=ddd|tdd per quality.yaml development_mode)
+- /moai run SPEC-XXX → manager-develop subagent (cycle_type=ddd|tdd per quality.yaml development_mode)
 - /moai sync SPEC-XXX → manager-docs subagent
 
 For detailed workflow specifications, see .claude/rules/moai/workflow/spec-workflow.md

--- a/internal/cli/agent_lint.go
+++ b/internal/cli/agent_lint.go
@@ -469,7 +469,7 @@ func checkMissingIsolation(file string, fm AgentFrontmatter) []LintViolation {
 
 	// Write-heavy standalone agents that require isolation: worktree (SPEC-V3R2-ORC-004)
 	writeHeavyAgents := []string{
-		"manager-cycle", "expert-backend", "expert-frontend",
+		"manager-develop", "expert-backend", "expert-frontend",
 		"expert-refactoring", "researcher",
 	}
 

--- a/internal/cli/agent_lint_test.go
+++ b/internal/cli/agent_lint_test.go
@@ -291,8 +291,8 @@ func TestCheckMissingIsolation(t *testing.T) {
 			wantCount: 1,
 		},
 		{
-			name:      "write-heavy manager-cycle without worktree",
-			agentName: "manager-cycle",
+			name:      "write-heavy manager-develop without worktree",
+			agentName: "manager-develop",
 			isolation: "",
 			wantCount: 1,
 		},

--- a/internal/cli/launcher_worktree_validation_test.go
+++ b/internal/cli/launcher_worktree_validation_test.go
@@ -62,7 +62,7 @@ func TestValidateWorktreeReturn_AcceptsValidPath(t *testing.T) {
 		WorktreeBranch: "feat/SPEC-V3R3-RETIRED-AGENT-001",
 		IsolationMode:  "worktree",
 	}
-	err := validateWorktreeReturn(result, "worktree", "manager-cycle")
+	err := validateWorktreeReturn(result, "worktree", "manager-develop")
 	if err != nil {
 		t.Errorf("유효한 worktreePath에 대해 오류가 반환되면 안 됨: %v", err)
 	}
@@ -79,7 +79,7 @@ func TestValidateWorktreeReturn_SkipsWhenIsolationNotWorktree(t *testing.T) {
 			WorktreePath:  "", // 빈 경로
 			IsolationMode: mode,
 		}
-		err := validateWorktreeReturn(result, mode, "manager-cycle")
+		err := validateWorktreeReturn(result, mode, "manager-develop")
 		if err != nil {
 			t.Errorf("isolation=%q + 빈 WorktreePath에 오류 반환됨 (스킵해야 함): %v", mode, err)
 		}
@@ -140,7 +140,7 @@ func TestPathTemplateRejectsNonStringValue(t *testing.T) {
 		patterns := []string{"{}", "[object Object]", "null", "undefined"}
 		for _, p := range patterns {
 			r := &worktreeReturn{WorktreePath: p, IsolationMode: "worktree"}
-			err := validateWorktreeReturn(r, "worktree", "manager-cycle")
+			err := validateWorktreeReturn(r, "worktree", "manager-develop")
 			if err == nil {
 				t.Errorf("worktreePath=%q should trigger WORKTREE_PATH_INVALID, got nil", p)
 				continue

--- a/internal/hook/agents/cycle_handler.go
+++ b/internal/hook/agents/cycle_handler.go
@@ -1,5 +1,6 @@
-// cycle_handler.go: manager-cycle unified DDD/TDD lifecycle hook handling.
-// SPEC-V3R3-RETIRED-AGENT-001 D-EVAL-01 fix: added `case "cycle":` to factory dispatch.
+// cycle_handler.go: manager-develop unified DDD/TDD lifecycle hook handling.
+// Originally manager-cycle (SPEC-V3R3-RETIRED-AGENT-001); renamed to manager-develop
+// per ORC-001 follow-up rename.
 // REQ-RA-009 acceptance criterion (factory dispatch).
 package agents
 
@@ -9,24 +10,24 @@ import (
 "github.com/modu-ai/moai-adk/internal/hook"
 )
 
-// @MX:NOTE: [AUTO] cycleHandler is the unified DDD/TDD agent (manager-cycle) lifecycle hook dispatcher.
-// Maps cycle-pre-implementation / cycle-post-implementation / cycle-completion actions to
+// @MX:NOTE: [AUTO] developHandler is the unified DDD/TDD agent (manager-develop) lifecycle hook dispatcher.
+// Maps develop-pre-implementation / develop-post-implementation / develop-completion actions to
 // PreToolUse / PostToolUse / SubagentStop events. Currently pass-through (default allow);
-// subsequent SPEC can add cycle-specific validation (e.g., RED phase test existence enforcement).
+// subsequent SPEC can add develop-specific validation (e.g., RED phase test existence enforcement).
 //
-// cycleHandler handles unified DDD/TDD workflow hooks for the manager-cycle agent.
-// SPEC-V3R2-ORC-001 retirement decision integrated manager-tdd / manager-ddd with manager-cycle,
-// and this handler processes cycle-* actions.
-type cycleHandler struct {
+// developHandler handles unified DDD/TDD workflow hooks for the manager-develop agent.
+// Originally manager-cycle (SPEC-V3R2-ORC-001); ORC-001 follow-up rename changed canonical
+// name to manager-develop. This handler processes develop-* actions.
+type developHandler struct {
 baseHandler
 }
 
-// NewCycleHandler creates a manager-cycle handler for the given action.
+// NewDevelopHandler creates a manager-develop handler for the given action.
 // Actions: pre-implementation, post-implementation, completion
 //
 // SubagentStart is also handled by agentStartHandler in internal/hook/subagent_start.go
 // (REQ-RA-007 retired-rejection guard).
-func NewCycleHandler(action string) hook.Handler {
+func NewDevelopHandler(action string) hook.Handler {
 event := hook.EventPreToolUse
 switch action {
 case "post-implementation":
@@ -35,24 +36,30 @@ case "completion":
 event = hook.EventSubagentStop
 }
 
-return &cycleHandler{
+return &developHandler{
 baseHandler: baseHandler{
 action: action,
 event: event,
-agent: "cycle",
+agent: "develop",
 },
 }
 }
 
-// Handle handles cycle workflow hooks.
-// Currently pass-through (default allow). Subsequent SPEC can add cycle-specific validation.
-func (h *cycleHandler) Handle(ctx context.Context, input *hook.HookInput) (*hook.HookOutput, error) {
+// NewCycleHandler is a backward-compatibility alias for NewDevelopHandler.
+// Preserved for factory dispatch backward compat (legacy "cycle" case in factory.go).
+func NewCycleHandler(action string) hook.Handler {
+return NewDevelopHandler(action)
+}
+
+// Handle handles develop workflow hooks.
+// Currently pass-through (default allow). Subsequent SPEC can add develop-specific validation.
+func (h *developHandler) Handle(ctx context.Context, input *hook.HookInput) (*hook.HookOutput, error) {
 // pre-implementation: RED/ANALYZE phase pre-validation
 // post-implementation: GREEN/PRESERVE/IMPROVE/REFACTOR phase verification
-// completion: cycle workflow completion report
+// completion: develop workflow completion report
 return hook.NewAllowOutput(), nil
 }
 
-func (h *cycleHandler) EventType() hook.EventType {
+func (h *developHandler) EventType() hook.EventType {
 return h.event
 }

--- a/internal/hook/agents/factory.go
+++ b/internal/hook/agents/factory.go
@@ -16,17 +16,17 @@ func NewFactory() *Factory {
 	return &Factory{}
 }
 
-// @MX:NOTE: [AUTO] Switch branch that creates one of 11 handler types based on the agent name. Add a new case here when adding a new agent.
-// Supported agents: ddd, tdd (legacy retired stub compat), cycle, backend, frontend, testing, debug, devops, quality, spec, docs
+// @MX:NOTE: [AUTO] Switch branch that creates one of 12 handler types based on the agent name. Add a new case here when adding a new agent.
+// Supported agents: ddd, tdd (legacy retired stub compat), develop, cycle (backward compat alias for develop), backend, frontend, testing, debug, devops, quality, spec, docs
 // CreateHandler creates a handler for the given agent action.
 // Action format: {agent}-{action}
-// Examples: cycle-pre-implementation, backend-validation, docs-completion
+// Examples: develop-pre-implementation, backend-validation, docs-completion
 //
-// SPEC-V3R3-RETIRED-AGENT-001 + SPEC-V3R3-RETIRED-DDD-001: cycle handler dispatches
-// manager-cycle's unified DDD/TDD workflow hooks. manager-tdd + manager-ddd retired
+// SPEC-V3R3-RETIRED-AGENT-001 + SPEC-V3R3-RETIRED-DDD-001: develop handler dispatches
+// manager-develop's unified DDD/TDD workflow hooks. manager-tdd + manager-ddd retired
 // stubs use no hooks (frontmatter cleared) but `case "tdd":` and `case "ddd":` are
 // preserved for backward compatibility with legacy user projects that have not run
-// `moai update`.
+// `moai update`. `case "cycle":` is preserved for backward compat with pre-rename projects.
 func (f *Factory) CreateHandler(action string) (hook.Handler, error) {
 	parts := strings.SplitN(action, "-", 2)
 	if len(parts) != 2 {
@@ -41,8 +41,11 @@ func (f *Factory) CreateHandler(action string) (hook.Handler, error) {
 		return NewDDDHandler(act), nil
 	case "tdd":
 		return NewTDDHandler(act), nil
+	case "develop":
+		return NewDevelopHandler(act), nil
 	case "cycle":
-		return NewCycleHandler(act), nil
+		// Backward compat alias for develop (pre-rename projects)
+		return NewDevelopHandler(act), nil
 	case "backend":
 		return NewBackendHandler(act), nil
 	case "frontend":

--- a/internal/hook/agents/factory_test.go
+++ b/internal/hook/agents/factory_test.go
@@ -33,7 +33,12 @@ func TestFactory_CreateHandler_ValidActions(t *testing.T) {
 		{"tdd-post-implementation", hook.EventPostToolUse},
 		{"tdd-completion", hook.EventSubagentStop},
 
-		// Cycle handler actions (manager-cycle unified DDD/TDD, SPEC-V3R3-RETIRED-AGENT-001)
+		// Develop handler actions (manager-develop unified DDD/TDD, ORC-001 follow-up rename)
+		{"develop-pre-implementation", hook.EventPreToolUse},
+		{"develop-post-implementation", hook.EventPostToolUse},
+		{"develop-completion", hook.EventSubagentStop},
+
+		// Cycle handler actions (backward compat alias for develop, pre-rename projects)
 		{"cycle-pre-implementation", hook.EventPreToolUse},
 		{"cycle-post-implementation", hook.EventPostToolUse},
 		{"cycle-completion", hook.EventSubagentStop},
@@ -175,6 +180,60 @@ func TestFactory_CreateHandler_HandleReturnsAllowOutput(t *testing.T) {
 			}
 			if output == nil {
 				t.Fatalf("Handle() for %q returned nil output", action)
+			}
+		})
+	}
+}
+
+func TestDevelopHandler_ActionBranches(t *testing.T) {
+	t.Parallel()
+
+	// Develop handler has a switch statement on action; exercise every branch.
+	actions := []string{
+		"pre-implementation",
+		"post-implementation",
+		"completion",
+		"unknown-develop-action", // default branch
+	}
+
+	ctx := context.Background()
+
+	for _, action := range actions {
+		t.Run(action, func(t *testing.T) {
+			t.Parallel()
+
+			h := NewDevelopHandler(action)
+			output, err := h.Handle(ctx, &hook.HookInput{})
+			if err != nil {
+				t.Fatalf("DevelopHandler.Handle(%q) error: %v", action, err)
+			}
+			if output == nil {
+				t.Fatalf("DevelopHandler.Handle(%q) returned nil output", action)
+			}
+		})
+	}
+}
+
+func TestDevelopHandler_EventTypes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		action    string
+		wantEvent hook.EventType
+	}{
+		{"pre-implementation", hook.EventPreToolUse},
+		{"post-implementation", hook.EventPostToolUse},
+		{"completion", hook.EventSubagentStop},
+		{"unknown", hook.EventPreToolUse}, // default
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.action, func(t *testing.T) {
+			t.Parallel()
+
+			h := NewDevelopHandler(tt.action)
+			if got := h.EventType(); got != tt.wantEvent {
+				t.Errorf("NewDevelopHandler(%q).EventType() = %q, want %q", tt.action, got, tt.wantEvent)
 			}
 		})
 	}

--- a/internal/template/builder_skill_path_test.go
+++ b/internal/template/builder_skill_path_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-// TestBuilderSkillPathStructure verifies that the builder-platform agent instructions
+// TestBuilderSkillPathStructure verifies that the builder-harness agent instructions
 // explicitly enforce the correct skill file path structure.
 //
 // Regression test for: https://github.com/modu-ai/moai-adk/issues/443
@@ -19,7 +19,7 @@ import (
 //
 //	.claude/skills/moai-library-pykrx/SKILL.md  (CORRECT)
 //
-// SPEC-V3R2-ORC-001: builder-skill.md retired; guidance now lives in builder-platform.md.
+// SPEC-V3R2-ORC-001: builder-skill.md retired; guidance now lives in builder-harness.md.
 func TestBuilderSkillPathStructure(t *testing.T) {
 	t.Parallel()
 
@@ -29,8 +29,8 @@ func TestBuilderSkillPathStructure(t *testing.T) {
 	}
 
 	// builder-skill.md is a retired stub (SPEC-V3R2-ORC-001); skill authoring
-	// guidance has moved to builder-platform.md (artifact_type=skill workflow).
-	const agentPath = ".claude/agents/moai/builder-platform.md"
+	// guidance has moved to builder-harness.md (artifact_type=skill workflow).
+	const agentPath = ".claude/agents/moai/builder-harness.md"
 
 	data, err := fs.ReadFile(fsys, agentPath)
 	if err != nil {

--- a/internal/template/manager_develop_present_test.go
+++ b/internal/template/manager_develop_present_test.go
@@ -1,10 +1,12 @@
-// manager_develop_present_test.go: verifies that manager-develop.md exists in the embedded FS.
+// manager_develop_present_test.go: verifies that manager-develop.md exists in the embedded FS
+// as the active unified DDD/TDD implementation agent.
 // REQ-RA-003 mapping.
 //
-// Originally (SPEC-V3R2-RT-005 M1-M2): verified manager-develop.md is a full active agent.
-// Updated (SPEC-V3R2-ORC-001 M5): manager-develop was a transitional name; ORC-001
-// canonizes manager-cycle as the unified DDD/TDD agent name and retires manager-develop.
-// Tests now verify the retirement stub pattern (consistent with TestRetirementCompletenessAssertion).
+// History:
+//   SPEC-V3R2-RT-005 M1-M2: manager-develop.md was a full active agent (transitional name).
+//   SPEC-V3R2-ORC-001 M5: renamed to manager-cycle; manager-develop became a retired stub.
+//   ORC-001 follow-up rename: manager-develop restored as the canonical active agent name;
+//   manager-cycle is now the retired stub.
 package template
 
 import (
@@ -12,12 +14,12 @@ import (
 	"testing"
 )
 
-// TestManagerDevelopRetiredStubPresent verifies that manager-develop.md exists in the
-// embedded FS as a properly formed retirement stub.
+// TestManagerDevelopActiveAgentPresent verifies that manager-develop.md exists in the
+// embedded FS as a properly formed active agent definition.
 //
-// SPEC-V3R2-ORC-001: manager-develop (transitional name from RT-005) was retired in favor
-// of the canonical manager-cycle name. The stub must be present for backward compatibility.
-func TestManagerDevelopRetiredStubPresent(t *testing.T) {
+// ORC-001 follow-up rename: manager-develop is the canonical active unified DDD/TDD agent.
+// manager-cycle is now a retired stub pointing to manager-develop.
+func TestManagerDevelopActiveAgentPresent(t *testing.T) {
 	t.Parallel()
 
 	fsys, err := EmbeddedTemplates()
@@ -31,15 +33,16 @@ func TestManagerDevelopRetiredStubPresent(t *testing.T) {
 	_, statErr := fs.Stat(fsys, managerDevelopPath)
 	if statErr != nil {
 		t.Fatalf("manager-develop.md not found in embedded FS. "+
-			"Retirement stub must be present for backward compatibility (SPEC-V3R2-ORC-001): %v", statErr)
+			"Active agent must be present (ORC-001 follow-up rename): %v", statErr)
 	}
 }
 
-// TestManagerDevelopIsRetiredStub verifies that manager-develop.md's frontmatter
-// correctly identifies it as a retired stub pointing to manager-cycle.
+// TestManagerDevelopIsActiveAgent verifies that manager-develop.md's frontmatter
+// correctly identifies it as the active agent (not a retired stub).
 //
-// SPEC-V3R2-ORC-001: manager-develop must have retired: true and retired_replacement: manager-cycle.
-func TestManagerDevelopIsRetiredStub(t *testing.T) {
+// ORC-001 follow-up rename: manager-develop must NOT have retired: true and must
+// have the correct name field, tools, and hooks.
+func TestManagerDevelopIsActiveAgent(t *testing.T) {
 	t.Parallel()
 
 	fsys, err := EmbeddedTemplates()
@@ -59,30 +62,74 @@ func TestManagerDevelopIsRetiredStub(t *testing.T) {
 		t.Fatalf("manager-develop.md frontmatter parse error: %s", parseErr)
 	}
 
+	// retired: field must NOT be present (or must be false)
+	if retiredVal, hasRetired := fm["retired"]; hasRetired && retiredVal == "true" {
+		t.Error("manager-develop.md must NOT have 'retired: true' — it is the active agent (ORC-001 follow-up rename)")
+	}
+
+	// name field must match
+	if name, ok := fm["name"]; !ok {
+		t.Error("manager-develop.md must have a 'name' frontmatter field")
+	} else if name != "manager-develop" {
+		t.Errorf("manager-develop.md name field must be 'manager-develop', got: %q", name)
+	}
+
+	// tools must be non-empty (active agent has tools)
+	tools, hasTools := fm["tools"]
+	if !hasTools || tools == "" || tools == "[]" {
+		t.Error("manager-develop.md active agent must have a non-empty tools list")
+	}
+}
+
+// TestManagerCycleIsRetiredStub verifies that manager-cycle.md's frontmatter
+// correctly identifies it as a retired stub pointing to manager-develop.
+//
+// ORC-001 follow-up rename: manager-cycle must have retired: true and
+// retired_replacement: manager-develop.
+func TestManagerCycleIsRetiredStub(t *testing.T) {
+	t.Parallel()
+
+	fsys, err := EmbeddedTemplates()
+	if err != nil {
+		t.Fatalf("EmbeddedTemplates() error: %v", err)
+	}
+
+	const managerCyclePath = ".claude/agents/moai/manager-cycle.md"
+
+	data, readErr := fs.ReadFile(fsys, managerCyclePath)
+	if readErr != nil {
+		t.Fatalf("failed to read manager-cycle.md: %v", readErr)
+	}
+
+	fm, _, parseErr := parseFrontmatterAndBody(string(data))
+	if parseErr != "" {
+		t.Fatalf("manager-cycle.md frontmatter parse error: %s", parseErr)
+	}
+
 	// retired: field must be present with value "true"
 	retiredVal, hasRetired := fm["retired"]
 	if !hasRetired {
-		t.Error("manager-develop.md must have 'retired: true' frontmatter field (SPEC-V3R2-ORC-001)")
+		t.Error("manager-cycle.md must have 'retired: true' frontmatter field (ORC-001 follow-up rename)")
 	} else if retiredVal != "true" {
-		t.Errorf("manager-develop.md retired field must be 'true', got: %q", retiredVal)
+		t.Errorf("manager-cycle.md retired field must be 'true', got: %q", retiredVal)
 	}
 
-	// retired_replacement must point to manager-cycle
+	// retired_replacement must point to manager-develop
 	replacement, hasReplacement := fm["retired_replacement"]
 	if !hasReplacement {
-		t.Error("manager-develop.md must have 'retired_replacement' frontmatter field")
-	} else if replacement != "manager-cycle" {
-		t.Errorf("manager-develop.md retired_replacement must be 'manager-cycle', got: %q", replacement)
+		t.Error("manager-cycle.md must have 'retired_replacement' frontmatter field")
+	} else if replacement != "manager-develop" {
+		t.Errorf("manager-cycle.md retired_replacement must be 'manager-develop', got: %q", replacement)
 	}
 
 	// tools must be empty
 	tools, hasTools := fm["tools"]
 	if hasTools && tools != "" && tools != "[]" {
-		t.Errorf("manager-develop.md retired stub must have empty tools list, got: %q", tools)
+		t.Errorf("manager-cycle.md retired stub must have empty tools list, got: %q", tools)
 	}
 
 	// name field must match
-	if name, ok := fm["name"]; ok && name != "manager-develop" {
-		t.Errorf("manager-develop.md name field must be 'manager-develop', got: %q", name)
+	if name, ok := fm["name"]; ok && name != "manager-cycle" {
+		t.Errorf("manager-cycle.md name field must be 'manager-cycle', got: %q", name)
 	}
 }

--- a/internal/template/templates/.claude/agents/moai/builder-agent.md
+++ b/internal/template/templates/.claude/agents/moai/builder-agent.md
@@ -1,11 +1,11 @@
 ---
 name: builder-agent
 description: |
-  Retired (SPEC-V3R2-ORC-001) — use builder-platform with artifact_type=agent.
-  This agent has been consolidated into the unified builder-platform agent.
-  See builder-platform.md for the active replacement.
+  Retired (SPEC-V3R2-ORC-001) — use builder-harness with artifact_type=agent.
+  This agent has been consolidated into the unified builder-harness agent.
+  See builder-harness.md for the active replacement.
 retired: true
-retired_replacement: builder-platform
+retired_replacement: builder-harness
 retired_param_hint: "artifact_type=agent"
 tools: []
 skills: []
@@ -19,15 +19,15 @@ This agent has been retired as part of SPEC-V3R2-ORC-001 (Agent roster consolida
 
 ## Replacement
 
-Use **builder-platform** with `artifact_type=agent` instead.
+Use **builder-harness** with `artifact_type=agent` instead.
 
 ## Migration Guide
 
 | Old Invocation | New Invocation |
 |----------------|----------------|
-| `Use the builder-agent subagent to create an agent` | `Use the builder-platform subagent with artifact_type=agent to create an agent` |
-| `builder-agent: design a custom agent` | `builder-platform: design a custom agent (artifact_type=agent)` |
+| `Use the builder-agent subagent to create an agent` | `Use the builder-harness subagent with artifact_type=agent to create an agent` |
+| `builder-agent: design a custom agent` | `builder-harness: design a custom agent (artifact_type=agent)` |
 
 ## Active Agent
 
-See `.claude/agents/moai/builder-platform.md` for the full agent definition.
+See `.claude/agents/moai/builder-harness.md` for the full agent definition.

--- a/internal/template/templates/.claude/agents/moai/builder-harness.md
+++ b/internal/template/templates/.claude/agents/moai/builder-harness.md
@@ -1,5 +1,5 @@
 ---
-name: builder-platform
+name: builder-harness
 description: |
   Unified artifact creation specialist. Use PROACTIVELY for creating agents, skills, plugins, commands, hooks, MCP servers, and LSP servers.
   MUST INVOKE when ANY of these keywords appear in user request:
@@ -54,14 +54,14 @@ This agent consolidates three previously separate builder agents.
 
 | Old Usage | New Usage |
 |-----------|-----------|
-| Use `builder-agent` subagent | Use `builder-platform` subagent with `artifact_type=agent` |
-| Use `builder-skill` subagent | Use `builder-platform` subagent with `artifact_type=skill` |
-| Use `builder-plugin` subagent | Use `builder-platform` subagent with `artifact_type=plugin` |
+| Use `builder-agent` subagent | Use `builder-harness` subagent with `artifact_type=agent` |
+| Use `builder-skill` subagent | Use `builder-harness` subagent with `artifact_type=skill` |
+| Use `builder-plugin` subagent | Use `builder-harness` subagent with `artifact_type=plugin` |
 
 **Deprecated agents** (retired stubs still present for compatibility):
-- `builder-agent` → replaced by `builder-platform` with `artifact_type=agent`
-- `builder-skill` → replaced by `builder-platform` with `artifact_type=skill`
-- `builder-plugin` → replaced by `builder-platform` with `artifact_type=plugin`
+- `builder-agent` → replaced by `builder-harness` with `artifact_type=agent`
+- `builder-skill` → replaced by `builder-harness` with `artifact_type=skill`
+- `builder-plugin` → replaced by `builder-harness` with `artifact_type=plugin`
 
 ## Scope Boundaries
 
@@ -75,7 +75,7 @@ IN SCOPE:
 OUT OF SCOPE:
 - Implementing actual business logic: Delegate to expert agents
 - Code implementation within artifacts: Delegate to expert-backend/expert-frontend
-- Running tests: Delegate to manager-cycle with cycle_type=tdd
+- Running tests: Delegate to manager-develop with cycle_type=tdd
 
 ## Workflow
 

--- a/internal/template/templates/.claude/agents/moai/builder-plugin.md
+++ b/internal/template/templates/.claude/agents/moai/builder-plugin.md
@@ -1,11 +1,11 @@
 ---
 name: builder-plugin
 description: |
-  Retired (SPEC-V3R2-ORC-001) — use builder-platform with artifact_type=plugin.
-  This agent has been consolidated into the unified builder-platform agent.
-  See builder-platform.md for the active replacement.
+  Retired (SPEC-V3R2-ORC-001) — use builder-harness with artifact_type=plugin.
+  This agent has been consolidated into the unified builder-harness agent.
+  See builder-harness.md for the active replacement.
 retired: true
-retired_replacement: builder-platform
+retired_replacement: builder-harness
 retired_param_hint: "artifact_type=plugin"
 tools: []
 skills: []
@@ -19,15 +19,15 @@ This agent has been retired as part of SPEC-V3R2-ORC-001 (Agent roster consolida
 
 ## Replacement
 
-Use **builder-platform** with `artifact_type=plugin` instead.
+Use **builder-harness** with `artifact_type=plugin` instead.
 
 ## Migration Guide
 
 | Old Invocation | New Invocation |
 |----------------|----------------|
-| `Use the builder-plugin subagent to create a plugin` | `Use the builder-platform subagent with artifact_type=plugin to create a plugin` |
-| `builder-plugin: build a marketplace plugin` | `builder-platform: build a marketplace plugin (artifact_type=plugin)` |
+| `Use the builder-plugin subagent to create a plugin` | `Use the builder-harness subagent with artifact_type=plugin to create a plugin` |
+| `builder-plugin: build a marketplace plugin` | `builder-harness: build a marketplace plugin (artifact_type=plugin)` |
 
 ## Active Agent
 
-See `.claude/agents/moai/builder-platform.md` for the full agent definition.
+See `.claude/agents/moai/builder-harness.md` for the full agent definition.

--- a/internal/template/templates/.claude/agents/moai/builder-skill.md
+++ b/internal/template/templates/.claude/agents/moai/builder-skill.md
@@ -1,11 +1,11 @@
 ---
 name: builder-skill
 description: |
-  Retired (SPEC-V3R2-ORC-001) — use builder-platform with artifact_type=skill.
-  This agent has been consolidated into the unified builder-platform agent.
-  See builder-platform.md for the active replacement.
+  Retired (SPEC-V3R2-ORC-001) — use builder-harness with artifact_type=skill.
+  This agent has been consolidated into the unified builder-harness agent.
+  See builder-harness.md for the active replacement.
 retired: true
-retired_replacement: builder-platform
+retired_replacement: builder-harness
 retired_param_hint: "artifact_type=skill"
 tools: []
 skills: []
@@ -19,15 +19,15 @@ This agent has been retired as part of SPEC-V3R2-ORC-001 (Agent roster consolida
 
 ## Replacement
 
-Use **builder-platform** with `artifact_type=skill` instead.
+Use **builder-harness** with `artifact_type=skill` instead.
 
 ## Migration Guide
 
 | Old Invocation | New Invocation |
 |----------------|----------------|
-| `Use the builder-skill subagent to create a skill` | `Use the builder-platform subagent with artifact_type=skill to create a skill` |
-| `builder-skill: design a knowledge skill` | `builder-platform: design a knowledge skill (artifact_type=skill)` |
+| `Use the builder-skill subagent to create a skill` | `Use the builder-harness subagent with artifact_type=skill to create a skill` |
+| `builder-skill: design a knowledge skill` | `builder-harness: design a knowledge skill (artifact_type=skill)` |
 
 ## Active Agent
 
-See `.claude/agents/moai/builder-platform.md` for the full agent definition.
+See `.claude/agents/moai/builder-harness.md` for the full agent definition.

--- a/internal/template/templates/.claude/agents/moai/expert-backend.md
+++ b/internal/template/templates/.claude/agents/moai/expert-backend.md
@@ -61,7 +61,7 @@ OUT OF SCOPE: Frontend implementation (expert-frontend), DevOps deployment (expe
 - Frontend work: Delegate to expert-frontend
 - Security audit: Delegate to expert-security
 - DevOps deployment: Delegate to expert-devops
-- DDD implementation: Delegate to manager-cycle (cycle_type=ddd)
+- DDD implementation: Delegate to manager-develop (cycle_type=ddd)
 
 ## Framework Detection
 
@@ -118,7 +118,7 @@ Create `.moai/docs/backend-architecture-{SPEC-ID}.md` with framework, DB, endpoi
 
 - expert-frontend: API contract (OpenAPI/GraphQL), error format, CORS config
 - expert-devops: Health checks, env vars, migrations, CI/CD
-- manager-cycle: Test structure, mock strategy, coverage requirements
+- manager-develop: Test structure, mock strategy, coverage requirements
 
 ## @MX Tag Obligations
 

--- a/internal/template/templates/.claude/agents/moai/expert-devops.md
+++ b/internal/template/templates/.claude/agents/moai/expert-devops.md
@@ -50,7 +50,7 @@ Design and implement CI/CD pipelines, infrastructure as code, and production dep
 
 IN SCOPE: CI/CD pipeline design, containerization, deployment strategy, infrastructure automation, secrets management, monitoring/health checks.
 
-OUT OF SCOPE: Application code (expert-backend/frontend), security audits (expert-security), performance profiling (expert-performance), testing strategy (manager-cycle).
+OUT OF SCOPE: Application code (expert-backend/frontend), security audits (expert-security), performance profiling (expert-performance), testing strategy (manager-develop).
 
 ## Delegation Protocol
 

--- a/internal/template/templates/.claude/agents/moai/expert-mobile.md
+++ b/internal/template/templates/.claude/agents/moai/expert-mobile.md
@@ -118,14 +118,14 @@ Anti-pattern: silent absorption of out-of-scope work. Maintain Scope Discipline 
 
 ## Harness Era: Sub-Skill Generation
 
-This agent does NOT bundle full iOS/Android/RN/Flutter sub-skills inline. Instead, use `builder-platform` (artifact_type=skill) to dynamically generate deep sub-skills when the project requires them:
+This agent does NOT bundle full iOS/Android/RN/Flutter sub-skills inline. Instead, use `builder-harness` (artifact_type=skill) to dynamically generate deep sub-skills when the project requires them:
 
 ```
 # Generate iOS-specific deep skill
-Use the builder-platform subagent (artifact_type=skill) to create moai-framework-ios with SwiftUI, UIKit, Core Data patterns.
+Use the builder-harness subagent (artifact_type=skill) to create moai-framework-ios with SwiftUI, UIKit, Core Data patterns.
 
 # Generate Flutter deep skill
-Use the builder-platform subagent (artifact_type=skill) to create moai-framework-flutter-deep with Riverpod, go_router, Dio, Platform Channels.
+Use the builder-harness subagent (artifact_type=skill) to create moai-framework-flutter-deep with Riverpod, go_router, Dio, Platform Channels.
 ```
 
 This keeps `expert-mobile` lean and allows harness-generated skills to be tailored to project-specific iOS/Android/RN/Flutter versions and patterns.

--- a/internal/template/templates/.claude/agents/moai/expert-performance.md
+++ b/internal/template/templates/.claude/agents/moai/expert-performance.md
@@ -55,7 +55,7 @@ OUT OF SCOPE:
 - Actual implementation of optimizations (delegate to expert-backend/expert-frontend)
 - Security audits (delegate to expert-security)
 - Infrastructure provisioning (delegate to expert-devops)
-- Unit test strategy design (delegate to manager-cycle cycle_type=tdd)
+- Unit test strategy design (delegate to manager-develop cycle_type=tdd)
 
 ## Delegation Protocol
 

--- a/internal/template/templates/.claude/agents/moai/expert-security.md
+++ b/internal/template/templates/.claude/agents/moai/expert-security.md
@@ -53,7 +53,7 @@ OUT OF SCOPE:
 - Server-side security fixes: Delegate to expert-backend
 - Client-side security fixes (XSS, CSP): Delegate to expert-frontend
 - AST-grep pattern-based fixes: Delegate to expert-refactoring
-- Security test cases: Delegate to manager-cycle (cycle_type=tdd)
+- Security test cases: Delegate to manager-develop (cycle_type=tdd)
 - Infrastructure hardening: Delegate to expert-devops
 
 ## Security Review Process
@@ -94,7 +94,7 @@ OUT OF SCOPE:
 
 ### Phase 3: Verification
 
-- Coordinate security test cases with manager-cycle (cycle_type=tdd)
+- Coordinate security test cases with manager-develop (cycle_type=tdd)
 - Re-run AST-grep security scan after fixes
 - Confirm all vulnerabilities resolved, no regressions introduced
 

--- a/internal/template/templates/.claude/agents/moai/expert-testing.md
+++ b/internal/template/templates/.claude/agents/moai/expert-testing.md
@@ -1,12 +1,12 @@
 ---
 name: expert-testing
 description: |
-  Retired (SPEC-V3R2-ORC-001) — split across manager-cycle (test strategy) and expert-performance (load testing).
-  Test strategy design belongs in manager-cycle RED phase planning.
+  Retired (SPEC-V3R2-ORC-001) — split across manager-develop (test strategy) and expert-performance (load testing).
+  Test strategy design belongs in manager-develop RED phase planning.
   Load test execution belongs in expert-performance with --deepthink load-test.
-  See manager-cycle.md and expert-performance.md for the active replacements.
+  See manager-develop.md and expert-performance.md for the active replacements.
 retired: true
-retired_replacement: "manager-cycle"
+retired_replacement: "manager-develop"
 retired_replacement_alt: "expert-performance"
 retired_param_hint: "strategy: cycle_type=tdd; load: use expert-performance --deepthink load-test"
 tools: []
@@ -25,18 +25,18 @@ Test strategy and load testing are split between two active agents:
 
 | Scope | Replacement Agent |
 |-------|-------------------|
-| Test strategy design (E2E, integration, coverage, QA framework selection) | `manager-cycle` with `cycle_type=tdd` (RED phase planning) |
+| Test strategy design (E2E, integration, coverage, QA framework selection) | `manager-develop` with `cycle_type=tdd` (RED phase planning) |
 | Load test execution (k6, Locust, JMeter, throughput benchmarks) | `expert-performance` with `--deepthink load-test` flag |
 
 ## Migration Guide
 
 | Old Invocation | New Invocation |
 |----------------|----------------|
-| `Use the expert-testing subagent to design test strategy` | `Use the manager-cycle subagent with cycle_type=tdd to design test strategy in RED phase` |
+| `Use the expert-testing subagent to design test strategy` | `Use the manager-develop subagent with cycle_type=tdd to design test strategy in RED phase` |
 | `expert-testing: run load test with k6` | `Use the expert-performance subagent with --deepthink load-test to run load tests` |
-| `expert-testing: set up E2E with Playwright` | `Use the manager-cycle subagent with cycle_type=tdd to set up E2E testing` |
+| `expert-testing: set up E2E with Playwright` | `Use the manager-develop subagent with cycle_type=tdd to set up E2E testing` |
 
 ## Active Agents
 
-- Test strategy: `.claude/agents/moai/manager-cycle.md`
+- Test strategy: `.claude/agents/moai/manager-develop.md`
 - Load testing: `.claude/agents/moai/expert-performance.md`

--- a/internal/template/templates/.claude/agents/moai/manager-brain.md
+++ b/internal/template/templates/.claude/agents/moai/manager-brain.md
@@ -5,7 +5,7 @@ description: |
   validated product proposals with SPEC decomposition candidates and Claude Design handoff package.
   Executes 7-phase pipeline: Discovery, Diverge, Research, Converge, Critical Evaluation, Proposal, Handoff.
   MUST INVOKE when: /moai brain, ideation request, pre-spec exploration, "help me think through this idea"
-  NOT for: code implementation (manager-cycle), SPEC creation (manager-spec), documentation (manager-docs)
+  NOT for: code implementation (manager-develop), SPEC creation (manager-spec), documentation (manager-docs)
 tools: Read, Write, Edit, Glob, Grep, Bash, WebSearch, WebFetch, ToolSearch, AskUserQuestion, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 model: opus
 effort: xhigh
@@ -28,7 +28,7 @@ Execute the `/moai brain` 7-phase ideation workflow: Discovery, Diverge, Researc
 
 IN SCOPE: 7-phase brain workflow execution, IDEA-NNN directory management, AskUserQuestion Socratic interview, parallel research execution, Lean Canvas assembly, SPEC decomposition list generation, Claude Design handoff package assembly.
 
-OUT OF SCOPE: SPEC creation (manager-spec), code implementation (manager-cycle), documentation sync (manager-docs), Git operations (manager-git).
+OUT OF SCOPE: SPEC creation (manager-spec), code implementation (manager-develop), documentation sync (manager-docs), Git operations (manager-git).
 
 ## Pre-Execution Setup
 

--- a/internal/template/templates/.claude/agents/moai/manager-cycle.md
+++ b/internal/template/templates/.claude/agents/moai/manager-cycle.md
@@ -1,240 +1,42 @@
 ---
 name: manager-cycle
 description: |
-  Unified implementation specialist supporting both DDD (ANALYZE-PRESERVE-IMPROVE) and TDD (RED-GREEN-REFACTOR) cycles.
-  Use PROACTIVELY for code implementation, refactoring, test-driven development, and behavior preservation.
-  MUST INVOKE when ANY of these keywords appear in user request:
-  --deepthink flag: Activate Sequential Thinking MCP for deep analysis of implementation strategy, testing approach, and code transformation.
-  EN (DDD): DDD, refactoring, legacy code, behavior preservation, characterization test, domain-driven refactoring
-  EN (TDD): TDD, test-driven development, red-green-refactor, test-first, new feature, specification test, greenfield
-  KO (DDD): DDD, 리팩토링, 레거시코드, 동작보존, 특성테스트, 도메인주도리팩토링
-  KO (TDD): TDD, 테스트주도개발, 레드그린리팩터, 테스트우선, 신규기능, 명세테스트, 그린필드
-  JA (DDD): DDD, リファクタリング, レガシーコード, 動作保存, 特性テスト, ドメイン駆動リファクタリング
-  JA (TDD): TDD, テスト駆動開発, レッドグリーンリファクタ, テストファースト, 新機能, 仕様テスト, グリーンフィールド
-  ZH (DDD): DDD, 重构, 遗留代码, 行为保存, 特性测试, 领域驱动重构
-  ZH (TDD): TDD, 测试驱动开发, 红绿重构, 测试优先, 新功能, 规格测试, 绿地项目
-  NOT for: SPEC creation (manager-spec), security audits (expert-security), performance optimization (expert-performance), deployment (expert-devops)
-tools: Read, Write, Edit, MultiEdit, Bash, Grep, Glob, TodoWrite, Skill, mcp__sequential-thinking__sequentialthinking, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
-model: sonnet
-permissionMode: bypassPermissions
-memory: project
-skills:
-  - moai-foundation-core
-  - moai-workflow-ddd
-  - moai-workflow-tdd
-  - moai-workflow-testing
-hooks:
-  PreToolUse:
-    - matcher: "Write|Edit|MultiEdit"
-      hooks:
-        - type: command
-          command: "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-agent-hook.sh\" develop-pre-implementation"
-          timeout: 5
-  PostToolUse:
-    - matcher: "Write|Edit|MultiEdit"
-      hooks:
-        - type: command
-          command: "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-agent-hook.sh\" develop-post-implementation"
-          timeout: 10
-  SubagentStop:
-    hooks:
-      - type: command
-        command: "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-agent-hook.sh\" develop-completion"
-        timeout: 10
+  Retired (SPEC-V3R2-ORC-001 follow-up rename) — use manager-develop with cycle_type=ddd or cycle_type=tdd.
+  This agent has been renamed to manager-develop for clearer naming.
+  See manager-develop.md for the active replacement.
+retired: true
+retired_replacement: manager-develop
+retired_param_hint: "cycle_type=ddd|tdd"
+tools: []
+skills: []
 ---
 
-<!-- @MX:ANCHOR: [AUTO] cycle-dispatch — unified entry point for all DDD+TDD implementation; fan_in >= 5 (manager-ddd, manager-tdd, expert-security, expert-devops, expert-refactoring all route here) -->
-<!-- @MX:REASON: ORC-001 consolidation: manager-ddd + manager-tdd merged into single cycle_type dispatch; any change to cycle routing must preserve backward compatibility -->
+<!-- @MX:NOTE: [AUTO] retirement-pattern — manager-cycle renamed to manager-develop (ORC-001 follow-up); canonical name is now manager-develop -->
 
-# Development Implementer - Unified DDD/TDD Agent
+# manager-cycle — Retired Agent
 
-## Primary Mission
+This agent has been retired as part of the ORC-001 follow-up rename.
+The name `manager-cycle` has been renamed to `manager-develop` for clearer, more intuitive naming.
 
-Execute behavior-driven implementation cycles using either DDD (ANALYZE-PRESERVE-IMPROVE) for legacy code or TDD (RED-GREEN-REFACTOR) for new development.
+## Replacement
 
-## Required Input Parameter
+Use **manager-develop** with `cycle_type=ddd` or `cycle_type=tdd` instead.
 
-**cycle_type**: Must be specified as `ddd` or `tdd` in the spawn prompt.
+## Migration Guide
 
-- **ddd**: For existing codebases with minimal test coverage. Focus: behavior preservation through characterization tests.
-- **tdd**: For new feature development. Focus: test-first development with comprehensive coverage.
+| Old Invocation | New Invocation |
+|----------------|----------------|
+| `Use the manager-cycle subagent to implement the feature` | `Use the manager-develop subagent with cycle_type=ddd to implement the feature` |
+| `manager-cycle: run DDD cycle (cycle_type=ddd)` | `manager-develop: run DDD cycle (cycle_type=ddd)` |
+| `manager-cycle: run TDD cycle (cycle_type=tdd)` | `manager-develop: run TDD cycle (cycle_type=tdd)` |
 
-## Migration Notes
+## Why This Change
 
-This agent consolidates the previously separate `manager-ddd` and `manager-tdd` agents.
+`manager-cycle` was an intermediate name. `manager-develop` is the canonical name that
+clearly expresses the role: the unified development implementation agent supporting both
+DDD (ANALYZE-PRESERVE-IMPROVE) and TDD (RED-GREEN-REFACTOR) cycles through the
+`cycle_type` parameter.
 
-| Old Usage | New Usage |
-|-----------|-----------|
-| Use `manager-ddd` subagent | Use `manager-cycle` subagent with `cycle_type=ddd` |
-| Use `manager-tdd` subagent | Use `manager-cycle` subagent with `cycle_type=tdd` |
+## Active Agent
 
-**Deprecated agents** (retired stubs still present for compatibility):
-- `manager-tdd` → replaced by `manager-cycle` with `cycle_type=tdd`
-- `manager-ddd` → replaced by `manager-cycle` with `cycle_type=ddd`
-
-## Behavioral Contract (SEMAP)
-
-**Preconditions**: SPEC document exists with approved status. Implementation plan approved. Target files identified. **cycle_type parameter provided**.
-
-**Postconditions**: All existing tests still pass. New tests cover modified code. Coverage >= 85% on modified files. No new lint/type errors.
-
-**Invariants**: Existing test suite never broken during any cycle. Each transformation is atomic and reversible.
-
-**Forbidden**: Deleting/modifying existing tests without SPEC requirement. Introducing global mutable state. Skipping tests. Modifying files outside SPEC scope.
-
-## Scope Boundaries
-
-**IN SCOPE (both cycles)**:
-- Test creation and modification
-- Source code implementation and refactoring
-- Quality validation (LSP, linting, coverage)
-- Documentation updates (comments, API docs)
-
-**OUT OF SCOPE (both cycles)**:
-- SPEC creation (delegate to manager-spec)
-- Security audits (delegate to expert-security)
-- Performance optimization (delegate to expert-performance)
-- Deployment (delegate to expert-devops)
-
-## Delegation Protocol
-
-- SPEC unclear: Delegate to manager-spec
-- Security concerns: Delegate to expert-security
-- Performance issues: Delegate to expert-performance
-- Quality validation: Delegate to manager-quality
-- Git operations: Delegate to manager-git
-
-## DDD Cycle (cycle_type: ddd)
-
-**When to use**: Selected when `development_mode: ddd` in quality.yaml. Best for existing codebases with minimal test coverage (< 10%).
-
-### DDD Workflow
-
-**STEP 1: Confirm Refactoring Plan**
-- Read SPEC document, extract refactoring scope, targets, preservation requirements
-- Read existing code and test files, assess current coverage
-
-**STEP 1.5: Detect Project Scale**
-- Count test files and source lines (exclude vendor, node_modules, generated)
-- LARGE_SCALE: test files > 500 OR source lines > 50,000
-- LARGE_SCALE → targeted test execution in PRESERVE/IMPROVE phases
-- STEP 5 Final Verification ALWAYS runs full suite regardless of scale
-
-**STEP 2: ANALYZE Phase**
-- Use AST-grep to analyze import patterns, dependencies, module boundaries
-- Calculate coupling metrics: Ca (afferent), Ce (efferent), I = Ce/(Ca+Ce)
-- Detect code smells: god classes, feature envy, long methods, duplicates
-- Prioritize refactoring targets by impact and risk
-
-**STEP 3: PRESERVE Phase**
-- Verify existing tests pass (100% pass rate required)
-- Create characterization tests for uncovered code paths
-- Name tests: `test_characterize_[component]_[scenario]`
-- Create behavior snapshots for complex outputs
-- Verify safety net: all tests pass including new characterization tests
-
-**STEP 3.5: LSP Baseline Capture**
-- Capture LSP diagnostics (errors, warnings, type errors, lint errors)
-- Store baseline for regression detection during IMPROVE phase
-
-**STEP 4: IMPROVE Phase**
-For each transformation:
-1. **Make Single Change**: One atomic structural change
-2. **LSP Verification**: Check for regression (errors > baseline → REVERT immediately)
-3. **Verify Behavior**: Run tests (targeted for LARGE_SCALE, full for standard)
-4. **Check Completion**: LSP errors == 0, no regression, iteration limit (max 100)
-5. **Record Progress**: Document transformation, update metrics
-
-**STEP 5: Complete and Report**
-- Run COMPLETE test suite (always full, regardless of LARGE_SCALE)
-- Verify all behavior snapshots match
-- Compare before/after coupling metrics
-- Generate DDD completion report
-- Commit changes, update SPEC status
-
-## TDD Cycle (cycle_type: tdd)
-
-**When to use**: Selected when `development_mode: tdd` in quality.yaml (default). Suitable for all new development work.
-
-### TDD Workflow
-
-**STEP 1: Confirm Implementation Plan**
-- Read SPEC document, extract feature requirements, acceptance criteria
-- Read existing code files for extension points and test patterns
-- Assess current test coverage baseline
-
-**STEP 2: RED Phase - Write Failing Tests**
-For each test case:
-1. **Write Specification Test**: Descriptive name, Arrange-Act-Assert pattern
-2. **Verify Test Fails**: Run test, confirm RED state
-3. **Record**: Update TodoWrite with test case status
-
-**STEP 2.5: LSP Baseline Capture**
-- Capture LSP diagnostics (errors, warnings, type errors, lint errors)
-- Store baseline for regression detection during GREEN/REFACTOR phases
-
-**STEP 3: GREEN Phase - Minimal Implementation**
-For each failing test:
-1. **Write Minimal Code**: Simplest solution that passes the test
-2. **LSP Verification**: Check for regression from baseline
-3. **Verify Test Passes**: Run immediately
-4. **Check Completion**: LSP errors == 0, all tests pass
-5. **Record Progress**: Update coverage and TodoWrite
-
-**STEP 4: REFACTOR Phase**
-For each improvement:
-1. **Single Improvement**: Remove duplication, improve naming, extract methods
-2. **LSP Verification**: Check regression → REVERT if detected
-3. **Verify Tests Pass**: Run full suite (memory guard: module-level batches if needed)
-4. **Record**: Document refactoring, update quality metrics
-
-**STEP 5: Complete and Report**
-- Run complete test suite (memory guard: batches if needed)
-- Verify coverage targets met (80% minimum, 85% recommended)
-- Generate TDD completion report with all tests and design decisions
-- Commit changes, update SPEC status
-
-## Ralph-Style LSP Integration
-
-**DDD**: Baseline capture at ANALYZE phase start, regression detection after each transformation, completion markers (all tests passing, LSP errors == 0, type errors == 0, coverage met), loop prevention (max 100 iterations, stale detection after 5 no-progress).
-
-**TDD**: Baseline at RED phase start, regression detection after each GREEN/REFACTOR change, completion (all tests passing, LSP errors == 0, coverage target met), loop prevention (max 100 iterations, stale after 5 no-progress).
-
-## Checkpoint and Resume
-
-**DDD**: Checkpoint after every transformation to `.moai/state/checkpoints/ddd/`, auto-checkpoint on memory pressure, resume: `--resume latest`.
-
-**TDD**: Checkpoint after every RED-GREEN-REFACTOR cycle to `.moai/state/checkpoints/tdd/`, auto-checkpoint on memory pressure, resume: `--resume latest`.
-
-Adaptive context trimming to prevent memory overflow.
-
-## @MX Tag Obligations
-
-**DDD** (ANALYZE and IMPROVE phases):
-- ANALYZE: Scan for functions meeting ANCHOR criteria (fan_in >= 3) and WARN criteria (goroutines, complexity >= 15). Add missing tags.
-- PRESERVE: Do not remove existing @MX tags during characterization test creation.
-- IMPROVE: Update @MX:ANCHOR if fan_in changes. Remove @MX:WARN if dangerous pattern eliminated. Add @MX:NOTE for discovered business rules.
-
-**TDD** (GREEN and REFACTOR phases):
-- RED: Add `@MX:TODO` for new public functions lacking tests (resolved in GREEN).
-- GREEN: Add `@MX:ANCHOR` for new exported functions with expected fan_in >= 3. Add `@MX:WARN` for goroutines or complex patterns.
-- REFACTOR: Update @MX:ANCHOR if fan_in changes. Remove @MX:WARN if dangerous pattern eliminated. Remove @MX:TODO when tests pass.
-
-Tag format: `// @MX:TYPE: [AUTO] description` (use language-appropriate comment syntax).
-All ANCHOR and WARN tags MUST include a `@MX:REASON` sub-line.
-Respect per-file limits: max 3 ANCHOR, 5 WARN, 10 NOTE, 5 TODO.
-
-## Cycle Selection Decision Guide
-
-- Code already exists with defined behavior? → Use **cycle_type: ddd**
-- Creating new functionality from scratch? → Use **cycle_type: tdd**
-- Goal is structure improvement, not feature addition? → Use **cycle_type: ddd**
-- Behavior specification drives development? → Use **cycle_type: tdd**
-
-## Common Patterns
-
-**DDD Patterns**:
-- Extract Method, Extract Class, Move Method, Rename (safe multi-file rename via AST-grep)
-
-**TDD Patterns**:
-- Specification by Example, Outside-In TDD, Inside-Out TDD, Test Doubles (Mocks, Stubs, Fakes, Spies)
+See `.claude/agents/moai/manager-develop.md` for the full agent definition.

--- a/internal/template/templates/.claude/agents/moai/manager-ddd.md
+++ b/internal/template/templates/.claude/agents/moai/manager-ddd.md
@@ -1,17 +1,17 @@
 ---
 name: manager-ddd
 description: |
-  Retired (SPEC-V3R3-RETIRED-DDD-001) — use manager-cycle with cycle_type=ddd.
-  This agent has been consolidated into the unified manager-cycle agent.
-  See manager-cycle.md for the active replacement.
+  Retired (SPEC-V3R3-RETIRED-DDD-001) — use manager-develop with cycle_type=ddd.
+  This agent has been consolidated into the unified manager-develop agent.
+  See manager-develop.md for the active replacement.
 retired: true
-retired_replacement: manager-cycle
+retired_replacement: manager-develop
 retired_param_hint: "cycle_type=ddd"
 tools: []
 skills: []
 ---
 
-<!-- @MX:NOTE: [AUTO] retirement-pattern — matches SPEC-V3R3-RETIRED-DDD-001 stub migration; use manager-cycle cycle_type=ddd -->
+<!-- @MX:NOTE: [AUTO] retirement-pattern — matches SPEC-V3R3-RETIRED-DDD-001 stub migration; use manager-develop cycle_type=ddd -->
 
 # manager-ddd — Retired Agent
 
@@ -19,18 +19,18 @@ This agent has been retired as part of SPEC-V3R3-RETIRED-DDD-001 (following SPEC
 
 ## Replacement
 
-Use **manager-cycle** with `cycle_type=ddd` instead.
+Use **manager-develop** with `cycle_type=ddd` instead.
 
 ## Migration Guide
 
 | Old Invocation | New Invocation |
 |----------------|----------------|
-| `Use the manager-ddd subagent to implement the feature` | `Use the manager-cycle subagent with cycle_type=ddd to implement the feature` |
-| `manager-ddd: run ANALYZE-PRESERVE-IMPROVE cycle` | `manager-cycle: run DDD cycle (cycle_type=ddd)` |
+| `Use the manager-ddd subagent to implement the feature` | `Use the manager-develop subagent with cycle_type=ddd to implement the feature` |
+| `manager-ddd: run ANALYZE-PRESERVE-IMPROVE cycle` | `manager-develop: run DDD cycle (cycle_type=ddd)` |
 
 ## Why This Change
 
-The `manager-ddd` agent has been consolidated into the `manager-cycle` agent, which supports DDD (ANALYZE-PRESERVE-IMPROVE) cycles through the `cycle_type` parameter. This unification:
+The `manager-ddd` agent has been consolidated into the `manager-develop` agent, which supports DDD (ANALYZE-PRESERVE-IMPROVE) cycles through the `cycle_type` parameter. This unification:
 
 - Eliminates duplication between the two agents
 - Provides a single entry point for all implementation cycles
@@ -38,4 +38,4 @@ The `manager-ddd` agent has been consolidated into the `manager-cycle` agent, wh
 
 ## Active Agent
 
-See `.claude/agents/moai/manager-cycle.md` for the full agent definition.
+See `.claude/agents/moai/manager-develop.md` for the full agent definition.

--- a/internal/template/templates/.claude/agents/moai/manager-develop.md
+++ b/internal/template/templates/.claude/agents/moai/manager-develop.md
@@ -1,42 +1,240 @@
 ---
 name: manager-develop
 description: |
-  Retired (SPEC-V3R2-ORC-001) — use manager-cycle with cycle_type=ddd or cycle_type=tdd.
-  This agent has been renamed and consolidated into the unified manager-cycle agent.
-  See manager-cycle.md for the active replacement.
-retired: true
-retired_replacement: manager-cycle
-retired_param_hint: "cycle_type=ddd|tdd"
-tools: []
-skills: []
+  Unified implementation specialist supporting both DDD (ANALYZE-PRESERVE-IMPROVE) and TDD (RED-GREEN-REFACTOR) cycles.
+  Use PROACTIVELY for code implementation, refactoring, test-driven development, and behavior preservation.
+  MUST INVOKE when ANY of these keywords appear in user request:
+  --deepthink flag: Activate Sequential Thinking MCP for deep analysis of implementation strategy, testing approach, and code transformation.
+  EN (DDD): DDD, refactoring, legacy code, behavior preservation, characterization test, domain-driven refactoring
+  EN (TDD): TDD, test-driven development, red-green-refactor, test-first, new feature, specification test, greenfield
+  KO (DDD): DDD, 리팩토링, 레거시코드, 동작보존, 특성테스트, 도메인주도리팩토링
+  KO (TDD): TDD, 테스트주도개발, 레드그린리팩터, 테스트우선, 신규기능, 명세테스트, 그린필드
+  JA (DDD): DDD, リファクタリング, レガシーコード, 動作保存, 特性テスト, ドメイン駆動リファクタリング
+  JA (TDD): TDD, テスト駆動開発, レッドグリーンリファクタ, テストファースト, 新機能, 仕様テスト, グリーンフィールド
+  ZH (DDD): DDD, 重构, 遗留代码, 行为保存, 特性测试, 领域驱动重构
+  ZH (TDD): TDD, 测试驱动开发, 红绿重构, 测试优先, 新功能, 规格测试, 绿地项目
+  NOT for: SPEC creation (manager-spec), security audits (expert-security), performance optimization (expert-performance), deployment (expert-devops)
+tools: Read, Write, Edit, MultiEdit, Bash, Grep, Glob, TodoWrite, Skill, mcp__sequential-thinking__sequentialthinking, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
+model: sonnet
+permissionMode: bypassPermissions
+memory: project
+skills:
+  - moai-foundation-core
+  - moai-workflow-ddd
+  - moai-workflow-tdd
+  - moai-workflow-testing
+hooks:
+  PreToolUse:
+    - matcher: "Write|Edit|MultiEdit"
+      hooks:
+        - type: command
+          command: "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-agent-hook.sh\" develop-pre-implementation"
+          timeout: 5
+  PostToolUse:
+    - matcher: "Write|Edit|MultiEdit"
+      hooks:
+        - type: command
+          command: "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-agent-hook.sh\" develop-post-implementation"
+          timeout: 10
+  SubagentStop:
+    hooks:
+      - type: command
+        command: "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-agent-hook.sh\" develop-completion"
+        timeout: 10
 ---
 
-<!-- @MX:NOTE: [AUTO] retirement-pattern — manager-develop renamed to manager-cycle (SPEC-V3R2-ORC-001); canonical name is now manager-cycle -->
+<!-- @MX:ANCHOR: [AUTO] develop-dispatch — unified entry point for all DDD+TDD implementation; fan_in >= 5 (manager-ddd, manager-tdd, expert-security, expert-devops, expert-refactoring all route here) -->
+<!-- @MX:REASON: ORC-001 consolidation: manager-ddd + manager-tdd merged into single cycle_type dispatch; any change to cycle routing must preserve backward compatibility -->
 
-# manager-develop — Retired Agent
+# Development Implementer - Unified DDD/TDD Agent
 
-This agent has been retired as part of SPEC-V3R2-ORC-001 (Agent Roster Consolidation 22→17).
-The name `manager-develop` was an intermediate name used during SPEC-V3R2-RT-005; the canonical
-name is `manager-cycle` per SPEC-V3R2-ORC-001 naming conventions.
+## Primary Mission
 
-## Replacement
+Execute behavior-driven implementation cycles using either DDD (ANALYZE-PRESERVE-IMPROVE) for legacy code or TDD (RED-GREEN-REFACTOR) for new development.
 
-Use **manager-cycle** with `cycle_type=ddd` or `cycle_type=tdd` instead.
+## Required Input Parameter
 
-## Migration Guide
+**cycle_type**: Must be specified as `ddd` or `tdd` in the spawn prompt.
 
-| Old Invocation | New Invocation |
-|----------------|----------------|
-| `Use the manager-develop subagent to implement the feature` | `Use the manager-cycle subagent with cycle_type=ddd to implement the feature` |
-| `manager-develop: run DDD cycle` | `manager-cycle: run DDD cycle (cycle_type=ddd)` |
-| `manager-develop: run TDD cycle` | `manager-cycle: run TDD cycle (cycle_type=tdd)` |
+- **ddd**: For existing codebases with minimal test coverage. Focus: behavior preservation through characterization tests.
+- **tdd**: For new feature development. Focus: test-first development with comprehensive coverage.
 
-## Why This Change
+## Migration Notes
 
-`manager-develop` was a transitional name introduced during SPEC-V3R2-RT-005 for the unified
-DDD+TDD implementation agent. SPEC-V3R2-ORC-001 canonizes `manager-cycle` as the name to match
-the `cycle_type` parameter and the consistent `manager-*` naming pattern used across the roster.
+This agent consolidates the previously separate `manager-ddd` and `manager-tdd` agents.
 
-## Active Agent
+| Old Usage | New Usage |
+|-----------|-----------|
+| Use `manager-ddd` subagent | Use `manager-develop` subagent with `cycle_type=ddd` |
+| Use `manager-tdd` subagent | Use `manager-develop` subagent with `cycle_type=tdd` |
 
-See `.claude/agents/moai/manager-cycle.md` for the full agent definition.
+**Deprecated agents** (retired stubs still present for compatibility):
+- `manager-tdd` → replaced by `manager-develop` with `cycle_type=tdd`
+- `manager-ddd` → replaced by `manager-develop` with `cycle_type=ddd`
+
+## Behavioral Contract (SEMAP)
+
+**Preconditions**: SPEC document exists with approved status. Implementation plan approved. Target files identified. **cycle_type parameter provided**.
+
+**Postconditions**: All existing tests still pass. New tests cover modified code. Coverage >= 85% on modified files. No new lint/type errors.
+
+**Invariants**: Existing test suite never broken during any cycle. Each transformation is atomic and reversible.
+
+**Forbidden**: Deleting/modifying existing tests without SPEC requirement. Introducing global mutable state. Skipping tests. Modifying files outside SPEC scope.
+
+## Scope Boundaries
+
+**IN SCOPE (both cycles)**:
+- Test creation and modification
+- Source code implementation and refactoring
+- Quality validation (LSP, linting, coverage)
+- Documentation updates (comments, API docs)
+
+**OUT OF SCOPE (both cycles)**:
+- SPEC creation (delegate to manager-spec)
+- Security audits (delegate to expert-security)
+- Performance optimization (delegate to expert-performance)
+- Deployment (delegate to expert-devops)
+
+## Delegation Protocol
+
+- SPEC unclear: Delegate to manager-spec
+- Security concerns: Delegate to expert-security
+- Performance issues: Delegate to expert-performance
+- Quality validation: Delegate to manager-quality
+- Git operations: Delegate to manager-git
+
+## DDD Cycle (cycle_type: ddd)
+
+**When to use**: Selected when `development_mode: ddd` in quality.yaml. Best for existing codebases with minimal test coverage (< 10%).
+
+### DDD Workflow
+
+**STEP 1: Confirm Refactoring Plan**
+- Read SPEC document, extract refactoring scope, targets, preservation requirements
+- Read existing code and test files, assess current coverage
+
+**STEP 1.5: Detect Project Scale**
+- Count test files and source lines (exclude vendor, node_modules, generated)
+- LARGE_SCALE: test files > 500 OR source lines > 50,000
+- LARGE_SCALE → targeted test execution in PRESERVE/IMPROVE phases
+- STEP 5 Final Verification ALWAYS runs full suite regardless of scale
+
+**STEP 2: ANALYZE Phase**
+- Use AST-grep to analyze import patterns, dependencies, module boundaries
+- Calculate coupling metrics: Ca (afferent), Ce (efferent), I = Ce/(Ca+Ce)
+- Detect code smells: god classes, feature envy, long methods, duplicates
+- Prioritize refactoring targets by impact and risk
+
+**STEP 3: PRESERVE Phase**
+- Verify existing tests pass (100% pass rate required)
+- Create characterization tests for uncovered code paths
+- Name tests: `test_characterize_[component]_[scenario]`
+- Create behavior snapshots for complex outputs
+- Verify safety net: all tests pass including new characterization tests
+
+**STEP 3.5: LSP Baseline Capture**
+- Capture LSP diagnostics (errors, warnings, type errors, lint errors)
+- Store baseline for regression detection during IMPROVE phase
+
+**STEP 4: IMPROVE Phase**
+For each transformation:
+1. **Make Single Change**: One atomic structural change
+2. **LSP Verification**: Check for regression (errors > baseline → REVERT immediately)
+3. **Verify Behavior**: Run tests (targeted for LARGE_SCALE, full for standard)
+4. **Check Completion**: LSP errors == 0, no regression, iteration limit (max 100)
+5. **Record Progress**: Document transformation, update metrics
+
+**STEP 5: Complete and Report**
+- Run COMPLETE test suite (always full, regardless of LARGE_SCALE)
+- Verify all behavior snapshots match
+- Compare before/after coupling metrics
+- Generate DDD completion report
+- Commit changes, update SPEC status
+
+## TDD Cycle (cycle_type: tdd)
+
+**When to use**: Selected when `development_mode: tdd` in quality.yaml (default). Suitable for all new development work.
+
+### TDD Workflow
+
+**STEP 1: Confirm Implementation Plan**
+- Read SPEC document, extract feature requirements, acceptance criteria
+- Read existing code files for extension points and test patterns
+- Assess current test coverage baseline
+
+**STEP 2: RED Phase - Write Failing Tests**
+For each test case:
+1. **Write Specification Test**: Descriptive name, Arrange-Act-Assert pattern
+2. **Verify Test Fails**: Run test, confirm RED state
+3. **Record**: Update TodoWrite with test case status
+
+**STEP 2.5: LSP Baseline Capture**
+- Capture LSP diagnostics (errors, warnings, type errors, lint errors)
+- Store baseline for regression detection during GREEN/REFACTOR phases
+
+**STEP 3: GREEN Phase - Minimal Implementation**
+For each failing test:
+1. **Write Minimal Code**: Simplest solution that passes the test
+2. **LSP Verification**: Check for regression from baseline
+3. **Verify Test Passes**: Run immediately
+4. **Check Completion**: LSP errors == 0, all tests pass
+5. **Record Progress**: Update coverage and TodoWrite
+
+**STEP 4: REFACTOR Phase**
+For each improvement:
+1. **Single Improvement**: Remove duplication, improve naming, extract methods
+2. **LSP Verification**: Check regression → REVERT if detected
+3. **Verify Tests Pass**: Run full suite (memory guard: module-level batches if needed)
+4. **Record**: Document refactoring, update quality metrics
+
+**STEP 5: Complete and Report**
+- Run complete test suite (memory guard: batches if needed)
+- Verify coverage targets met (80% minimum, 85% recommended)
+- Generate TDD completion report with all tests and design decisions
+- Commit changes, update SPEC status
+
+## Ralph-Style LSP Integration
+
+**DDD**: Baseline capture at ANALYZE phase start, regression detection after each transformation, completion markers (all tests passing, LSP errors == 0, type errors == 0, coverage met), loop prevention (max 100 iterations, stale detection after 5 no-progress).
+
+**TDD**: Baseline at RED phase start, regression detection after each GREEN/REFACTOR change, completion (all tests passing, LSP errors == 0, coverage target met), loop prevention (max 100 iterations, stale after 5 no-progress).
+
+## Checkpoint and Resume
+
+**DDD**: Checkpoint after every transformation to `.moai/state/checkpoints/ddd/`, auto-checkpoint on memory pressure, resume: `--resume latest`.
+
+**TDD**: Checkpoint after every RED-GREEN-REFACTOR cycle to `.moai/state/checkpoints/tdd/`, auto-checkpoint on memory pressure, resume: `--resume latest`.
+
+Adaptive context trimming to prevent memory overflow.
+
+## @MX Tag Obligations
+
+**DDD** (ANALYZE and IMPROVE phases):
+- ANALYZE: Scan for functions meeting ANCHOR criteria (fan_in >= 3) and WARN criteria (goroutines, complexity >= 15). Add missing tags.
+- PRESERVE: Do not remove existing @MX tags during characterization test creation.
+- IMPROVE: Update @MX:ANCHOR if fan_in changes. Remove @MX:WARN if dangerous pattern eliminated. Add @MX:NOTE for discovered business rules.
+
+**TDD** (GREEN and REFACTOR phases):
+- RED: Add `@MX:TODO` for new public functions lacking tests (resolved in GREEN).
+- GREEN: Add `@MX:ANCHOR` for new exported functions with expected fan_in >= 3. Add `@MX:WARN` for goroutines or complex patterns.
+- REFACTOR: Update @MX:ANCHOR if fan_in changes. Remove @MX:WARN if dangerous pattern eliminated. Remove @MX:TODO when tests pass.
+
+Tag format: `// @MX:TYPE: [AUTO] description` (use language-appropriate comment syntax).
+All ANCHOR and WARN tags MUST include a `@MX:REASON` sub-line.
+Respect per-file limits: max 3 ANCHOR, 5 WARN, 10 NOTE, 5 TODO.
+
+## Cycle Selection Decision Guide
+
+- Code already exists with defined behavior? → Use **cycle_type: ddd**
+- Creating new functionality from scratch? → Use **cycle_type: tdd**
+- Goal is structure improvement, not feature addition? → Use **cycle_type: ddd**
+- Behavior specification drives development? → Use **cycle_type: tdd**
+
+## Common Patterns
+
+**DDD Patterns**:
+- Extract Method, Extract Class, Move Method, Rename (safe multi-file rename via AST-grep)
+
+**TDD Patterns**:
+- Specification by Example, Outside-In TDD, Inside-Out TDD, Test Doubles (Mocks, Stubs, Fakes, Spies)

--- a/internal/template/templates/.claude/agents/moai/manager-quality.md
+++ b/internal/template/templates/.claude/agents/moai/manager-quality.md
@@ -42,10 +42,10 @@ When invoked with `diagnostic-mode` or when error diagnosis is requested, manage
 
 | Error Category | Analysis Approach | Delegation Target |
 |---------------|-------------------|-------------------|
-| Code defects (type errors, logic bugs, test failures) | Grep/Read to locate root cause; classify mechanical vs semantic | manager-cycle (cycle_type=ddd) for fix implementation |
+| Code defects (type errors, logic bugs, test failures) | Grep/Read to locate root cause; classify mechanical vs semantic | manager-develop (cycle_type=ddd) for fix implementation |
 | Architecture issues (coupling, god class, circular deps) | AST analysis via moai-tool-ast-grep | expert-refactoring for structural changes |
 | Git/branch issues (conflicts, detached HEAD, push rejected) | Bash git diagnostics | manager-git for repository operations |
-| CI failures (lint, errcheck, race conditions) | Log analysis + PR diff review; classify mechanical vs semantic | manager-cycle for mechanical fixes; report semantic for human decision |
+| CI failures (lint, errcheck, race conditions) | Log analysis + PR diff review; classify mechanical vs semantic | manager-develop for mechanical fixes; report semantic for human decision |
 | Configuration errors (hook failures, MCP issues, env vars) | Read settings files + hook logs | expert-devops for environment fixes |
 
 ### Diagnostic Analysis Steps
@@ -98,7 +98,7 @@ IN SCOPE:
 - TAG chain verification
 
 OUT OF SCOPE:
-- Code implementation (delegate to manager-cycle)
+- Code implementation (delegate to manager-develop)
 - Git operations (delegate to manager-git)
 - Documentation generation (delegate to manager-docs)
 
@@ -147,6 +147,6 @@ Classification: PASS (all items) / WARNING (non-compliance with recommendations)
 
 ## Delegation Protocol
 
-- Code modifications: Delegate to manager-cycle (cycle_type=ddd for existing code; cycle_type=tdd for new features)
+- Code modifications: Delegate to manager-develop (cycle_type=ddd for existing code; cycle_type=tdd for new features)
 - Git operations: Delegate to manager-git
 - Structural refactoring: Delegate to expert-refactoring

--- a/internal/template/templates/.claude/agents/moai/manager-tdd.md
+++ b/internal/template/templates/.claude/agents/moai/manager-tdd.md
@@ -1,17 +1,17 @@
 ---
 name: manager-tdd
 description: |
-  Retired (SPEC-V3R3-RETIRED-AGENT-001) — use manager-cycle with cycle_type=tdd.
-  This agent has been consolidated into the unified manager-cycle agent.
-  See manager-cycle.md for the active replacement.
+  Retired (SPEC-V3R3-RETIRED-AGENT-001) — use manager-develop with cycle_type=tdd.
+  This agent has been consolidated into the unified manager-develop agent.
+  See manager-develop.md for the active replacement.
 retired: true
-retired_replacement: manager-cycle
+retired_replacement: manager-develop
 retired_param_hint: "cycle_type=tdd"
 tools: []
 skills: []
 ---
 
-<!-- @MX:NOTE: [AUTO] retirement-pattern — matches SPEC-V3R3-RETIRED-AGENT-001 stub migration; use manager-cycle cycle_type=tdd -->
+<!-- @MX:NOTE: [AUTO] retirement-pattern — matches SPEC-V3R3-RETIRED-AGENT-001 stub migration; use manager-develop cycle_type=tdd -->
 
 # manager-tdd — Retired Agent
 
@@ -19,18 +19,18 @@ This agent has been retired as part of SPEC-V3R3-RETIRED-AGENT-001.
 
 ## Replacement
 
-Use **manager-cycle** with `cycle_type=tdd` instead.
+Use **manager-develop** with `cycle_type=tdd` instead.
 
 ## Migration Guide
 
 | Old Invocation | New Invocation |
 |----------------|----------------|
-| `Use the manager-tdd subagent to implement the feature` | `Use the manager-cycle subagent with cycle_type=tdd to implement the feature` |
-| `manager-tdd: run RED-GREEN-REFACTOR cycle` | `manager-cycle: run TDD cycle (cycle_type=tdd)` |
+| `Use the manager-tdd subagent to implement the feature` | `Use the manager-develop subagent with cycle_type=tdd to implement the feature` |
+| `manager-tdd: run RED-GREEN-REFACTOR cycle` | `manager-develop: run TDD cycle (cycle_type=tdd)` |
 
 ## Why This Change
 
-The `manager-tdd` and `manager-ddd` agents have been consolidated into a single `manager-cycle` agent that supports both DDD (ANALYZE-PRESERVE-IMPROVE) and TDD (RED-GREEN-REFACTOR) cycles through the `cycle_type` parameter. This unification:
+The `manager-tdd` and `manager-ddd` agents have been consolidated into a single `manager-develop` agent that supports both DDD (ANALYZE-PRESERVE-IMPROVE) and TDD (RED-GREEN-REFACTOR) cycles through the `cycle_type` parameter. This unification:
 
 - Eliminates duplication between the two agents
 - Provides a single entry point for all implementation cycles
@@ -38,4 +38,4 @@ The `manager-tdd` and `manager-ddd` agents have been consolidated into a single 
 
 ## Active Agent
 
-See `.claude/agents/moai/manager-cycle.md` for the full agent definition.
+See `.claude/agents/moai/manager-develop.md` for the full agent definition.

--- a/internal/template/templates/.claude/hooks/moai/handle-agent-hook.sh.tmpl
+++ b/internal/template/templates/.claude/hooks/moai/handle-agent-hook.sh.tmpl
@@ -18,7 +18,7 @@
 
 # @MX:NOTE: manager-ddd is retired per SPEC-V3R3-RETIRED-DDD-001.
 # ddd-* action references are preserved for backward compat with pre-update user projects.
-# Active manager-cycle uses cycle-* actions (cycle-pre-implementation, etc.).
+# Active manager-develop uses cycle-* actions (cycle-pre-implementation, etc.).
 
 set -e
 

--- a/internal/template/templates/.claude/rules/moai/core/agent-hooks.md
+++ b/internal/template/templates/.claude/rules/moai/core/agent-hooks.md
@@ -45,7 +45,7 @@ Actions follow the naming pattern `{agent}-{phase}`:
 
 | Agent | PreToolUse | PostToolUse | SubagentStop |
 |-------|-----------|------------|-------------|
-| manager-cycle | cycle-pre-transformation | cycle-post-transformation | cycle-completion |
+| manager-develop | cycle-pre-transformation | cycle-post-transformation | cycle-completion |
 | manager-develop | develop-pre-implementation | develop-post-implementation | develop-completion |
 | expert-backend | backend-validation | backend-verification | - |
 | expert-frontend | frontend-validation | frontend-verification | - |
@@ -55,10 +55,10 @@ Actions follow the naming pattern `{agent}-{phase}`:
 | manager-docs | - | docs-verification | docs-completion |
 
 <!-- @MX:NOTE: manager-ddd/manager-tdd retired (SPEC-V3R3-RETIRED-DDD-001 + ORC-001),
-     consolidated into manager-cycle. expert-debug absorbed by manager-quality (diagnostic-mode).
-     expert-testing absorbed by manager-cycle (cycle_type=tdd) + expert-performance.
+     consolidated into manager-develop. expert-debug absorbed by manager-quality (diagnostic-mode).
+     expert-testing absorbed by manager-develop (cycle_type=tdd) + expert-performance.
      Legacy hook actions (ddd-*, testing-*, debug-*) preserved in handler for backward compat
-     with pre-update user projects. See manager-cycle.md. -->
+     with pre-update user projects. See manager-develop.md. -->
 
 Note: Dynamic team teammates (spawned via `Agent(subagent_type: "general-purpose")`) do not use agent-scoped hooks. Quality enforcement for teammates uses global TeammateIdle and TaskCompleted hooks in settings.json.
 
@@ -80,7 +80,7 @@ stdin JSON structure:
   "toolInput": null,
   "toolOutput": null,
   "session": { "id": "sess-123", "cwd": "/path/to/project", "projectDir": "/path/to/project" },
-  "data": { "agent": "manager-cycle", "action": "cycle-completion" }
+  "data": { "agent": "manager-develop", "action": "cycle-completion" }
 }
 ```
 

--- a/internal/template/templates/.claude/rules/moai/development/agent-authoring.md
+++ b/internal/template/templates/.claude/rules/moai/development/agent-authoring.md
@@ -101,7 +101,7 @@ The `memory` field enables cross-session learning for agents. Three scope levels
 Coordinate workflows and multi-step processes:
 
 - manager-spec: SPEC document creation
-- manager-cycle: Unified DDD/TDD implementation (cycle_type=ddd|tdd; consolidated from retired agents)
+- manager-develop: Unified DDD/TDD implementation (cycle_type=ddd|tdd; consolidated from retired agents)
 - manager-docs: Documentation generation
 - manager-quality: Quality gates validation + diagnostic sub-mode (replaces expert-debug)
 - manager-project: Project configuration
@@ -120,16 +120,16 @@ Domain-specific implementation:
 - expert-refactoring: Code refactoring
 
 <!-- @MX:NOTE: expert-debug absorbed by manager-quality (diagnostic-mode, SPEC-V3R2-ORC-001).
-              expert-testing absorbed by manager-cycle (cycle_type=tdd) + expert-performance. -->
+              expert-testing absorbed by manager-develop (cycle_type=tdd) + expert-performance. -->
 
 ### Builder Agents (1)
 
 Create new MoAI components:
 
-- builder-platform: New agents, skills, plugins, commands, hooks, MCP/LSP servers (use artifact_type param)
+- builder-harness: New agents, skills, plugins, commands, hooks, MCP/LSP servers (use artifact_type param)
 
-<!-- @MX:NOTE: builder-agent/builder-skill/builder-plugin consolidated into builder-platform (SPEC-V3R2-ORC-001).
-              Use builder-platform with artifact_type=agent|skill|plugin|command|hook|mcp-server|lsp-server. -->
+<!-- @MX:NOTE: builder-agent/builder-skill/builder-plugin consolidated into builder-harness (SPEC-V3R2-ORC-001).
+              Use builder-harness with artifact_type=agent|skill|plugin|command|hook|mcp-server|lsp-server. -->
 
 ### Dynamic Team Generation (Experimental)
 

--- a/internal/template/templates/.claude/rules/moai/workflow/spec-workflow.md
+++ b/internal/template/templates/.claude/rules/moai/workflow/spec-workflow.md
@@ -11,7 +11,7 @@ MoAI's three-phase development workflow with token budget management.
 | Phase | Command | Agent | Token Budget | Purpose |
 |-------|---------|-------|--------------|---------|
 | Plan | /moai plan | manager-spec | 30K | Create SPEC document |
-| Run | /moai run | manager-cycle (per quality.yaml development_mode) | 180K | DDD/TDD implementation |
+| Run | /moai run | manager-develop (per quality.yaml development_mode) | 180K | DDD/TDD implementation |
 | Sync | /moai sync | manager-docs | 40K | Documentation sync |
 
 <!-- @MX:ANCHOR fan_in=10 - Subcommand classification single source of truth; cross-referenced by 10 workflow skills (5 multi-agent + 5 utility). Changes here affect all workflow contracts. -->
@@ -146,7 +146,7 @@ Development Methodology (configured in quality.yaml development_mode):
 
 ### DDD Mode — ANALYZE-PRESERVE-IMPROVE
 
-Best for existing projects with < 10% test coverage. Uses manager-cycle agent with cycle_type=ddd.
+Best for existing projects with < 10% test coverage. Uses manager-develop agent with cycle_type=ddd.
 
 **ANALYZE**: Read existing code, map domain boundaries, identify side effects and implicit contracts.
 **PRESERVE**: Write characterization tests capturing current behavior. Create behavior snapshots for regression detection.
@@ -154,7 +154,7 @@ Best for existing projects with < 10% test coverage. Uses manager-cycle agent wi
 
 ### TDD Mode — RED-GREEN-REFACTOR (default)
 
-Best for all development work, new projects, and brownfield with 10%+ coverage. Uses manager-cycle agent with cycle_type=tdd.
+Best for all development work, new projects, and brownfield with 10%+ coverage. Uses manager-develop agent with cycle_type=tdd.
 
 **RED**: Write a failing test describing desired behavior. Verify it fails. One test at a time.
 **GREEN**: Write simplest implementation that passes. No premature optimization.
@@ -210,7 +210,7 @@ Triggers:
 - Agent explicitly reports inability to meet a SPEC requirement
 
 Communication path:
-- Implementation agent (manager-cycle) detects trigger condition
+- Implementation agent (manager-develop) detects trigger condition
 - Agent returns structured stagnation report to MoAI (agents cannot call AskUserQuestion)
 - MoAI presents gap analysis to user via AskUserQuestion with options:
   - Continue with current approach (minor adjustments needed)
@@ -321,7 +321,7 @@ When team mode is enabled (workflow.team.enabled and AGENT_TEAMS env), phases ca
 | Phase | Sub-agent Mode | Team Mode | Condition |
 |-------|---------------|-----------|-----------|
 | Plan | manager-spec (single) | Dynamic teammates: researcher + analyst + architect (parallel, general-purpose) | Complexity >= threshold |
-| Run | manager-cycle (sequential) | Dynamic teammates: backend-dev + frontend-dev + tester (parallel, general-purpose) | Domains >= 3 or files >= 10 |
+| Run | manager-develop (sequential) | Dynamic teammates: backend-dev + frontend-dev + tester (parallel, general-purpose) | Domains >= 3 or files >= 10 |
 | Sync | manager-docs (single) | manager-docs (always sub-agent) | N/A |
 
 All teammates are spawned dynamically via `Agent(subagent_type: "general-purpose")` with runtime overrides from `workflow.yaml` role profiles. No static team agent definitions are used. See `.claude/skills/moai/team/run.md` for complete orchestration.

--- a/internal/template/templates/.claude/rules/moai/workflow/worktree-state-guard.md
+++ b/internal/template/templates/.claude/rules/moai/workflow/worktree-state-guard.md
@@ -25,7 +25,7 @@ The orchestrator SHOULD invoke `moai worktree snapshot` immediately before any
 
 - Modifies tracked files (any agent with `permissionMode: acceptEdits`)
 - Operates in team mode where parallel teammates are spawned with isolation
-- Performs cross-file refactors (e.g., expert-refactoring, manager-cycle)
+- Performs cross-file refactors (e.g., expert-refactoring, manager-develop)
 - Has historically triggered worktree regressions on this project
 
 Snapshots SHOULD be skipped for:

--- a/internal/template/templates/.claude/skills/moai-foundation-cc/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-foundation-cc/SKILL.md
@@ -27,9 +27,9 @@ progressive_disclosure:
 triggers:
   keywords: ["skill", "agent", "plugin", "slash command", "hook", "sandbox", "headless", "memory", "settings", "claude code", "sub-agent", "agent pattern", "orchestration", "delegation"]
   agents:
-    - "builder-platform"
-    - "builder-platform"
-    - "builder-platform"
+    - "builder-harness"
+    - "builder-harness"
+    - "builder-harness"
   phases:
     - "plan"
     - "run"

--- a/internal/template/templates/.claude/skills/moai-foundation-core/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-foundation-core/SKILL.md
@@ -32,7 +32,7 @@ triggers:
     - "manager-develop"
     - "manager-strategy"
     - "manager-quality"
-    - "builder-platform"
+    - "builder-harness"
     - "manager-docs"
     - "manager-project"
   phases:

--- a/internal/template/templates/.claude/skills/moai-foundation-quality/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-foundation-quality/SKILL.md
@@ -28,8 +28,8 @@ triggers:
   keywords: ["quality", "testing", "test", "validation", "trust-5", "best practice", "code review", "linting", "coverage", "pytest", "security", "ci/cd", "quality gate", "proactive", "code smell", "technical debt", "refactoring"]
   agents:
     - "manager-quality"
-    - "manager-cycle"
-    - "manager-cycle"
+    - "manager-develop"
+    - "manager-develop"
     - "expert-security"
     - "expert-refactoring"
   phases:

--- a/internal/template/templates/.claude/skills/moai-meta-harness/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-meta-harness/SKILL.md
@@ -144,18 +144,18 @@ This skill (`moai-meta-harness`) generates the harness skeleton:
 3. Write extension files: `.moai/harness/agents.md`, `.moai/harness/skills.md`
 4. Create agent definition stubs in `.claude/agents/my-harness/`
 
-Agents involved: `builder-platform` for artifact generation.
+Agents involved: `builder-harness` for artifact generation.
 
 #### Phase 5 — Customization
 
 This skill fills the skeleton with domain-specific content:
 
 1. Generate agent definitions (`.claude/agents/my-harness/*.md`) referencing
-   existing MoAI agents: `manager-spec`, `manager-strategy`, `manager-cycle`,
+   existing MoAI agents: `manager-spec`, `manager-strategy`, `manager-develop`,
    `manager-quality`, `manager-docs`, `manager-git`,
    `expert-backend`, `expert-frontend`,
    `expert-security`, `expert-refactoring`, `expert-performance`, `expert-devops`,
-   `expert-mobile`, `builder-platform`,
+   `expert-mobile`, `builder-harness`,
    `evaluator-active`, `plan-auditor`.
 2. Generate domain skills (`.claude/skills/my-harness-*/SKILL.md`) following
    the skill-authoring.md schema with `my-harness-*` prefix.
@@ -199,21 +199,21 @@ referenced below are static MoAI agents — no new agents are introduced.
 - `expert-mobile` — Mobile domain harness templates
 - `expert-devops` — DevOps/platform domain harness templates
 - `expert-security` — Security review of generated permissions
-- `manager-cycle` — Test harness pattern generation
+- `manager-develop` — Test harness pattern generation
 - `manager-quality` — Quality gates + diagnostic patterns
 - `expert-refactoring` — Refactoring workflow patterns
 - `expert-performance` — Performance profiling patterns
 
 **Builders**
 
-- `builder-platform` (artifact_type=agent) — Generates `.claude/agents/my-harness/*.md` content
-- `builder-platform` (artifact_type=skill) — Generates `.claude/skills/my-harness-*/SKILL.md` content
-- `builder-platform` (artifact_type=plugin) — Optional plugin bundling of generated artifacts
+- `builder-harness` (artifact_type=agent) — Generates `.claude/agents/my-harness/*.md` content
+- `builder-harness` (artifact_type=skill) — Generates `.claude/skills/my-harness-*/SKILL.md` content
+- `builder-harness` (artifact_type=plugin) — Optional plugin bundling of generated artifacts
 
 **Workflow Managers**
 
-- `manager-cycle` (cycle_type=ddd) — DDD-flavored harness workflow templates
-- `manager-cycle` (cycle_type=tdd) — TDD-flavored harness workflow templates
+- `manager-develop` (cycle_type=ddd) — DDD-flavored harness workflow templates
+- `manager-develop` (cycle_type=tdd) — TDD-flavored harness workflow templates
 - `manager-quality` — Quality gate configuration in generated harnesses
 - `manager-docs` — Documentation generation patterns
 - `manager-git` — Git workflow patterns for generated harnesses
@@ -335,7 +335,7 @@ The following capabilities are explicitly NOT implemented by this skill:
 - `moai-foundation-cc` — Claude Code skill/agent authoring standards
 - `manager-spec` — Conducts Discovery and Synthesis phases
 - `evaluator-active` — Sprint Contract evaluation in Phase 6
-- `builder-platform` — Artifact generation helpers
+- `builder-harness` — Artifact generation helpers
 
 ---
 

--- a/internal/template/templates/.claude/skills/moai-ref-testing-pyramid/skill.md
+++ b/internal/template/templates/.claude/skills/moai-ref-testing-pyramid/skill.md
@@ -2,7 +2,7 @@
 name: moai-ref-testing-pyramid
 description: >
   Test pyramid strategy, coverage targets, test patterns, and quality metrics
-  reference. Agent-extending skill that amplifies manager-cycle and manager-quality
+  reference. Agent-extending skill that amplifies manager-develop and manager-quality
   expertise with production-grade testing patterns.
   NOT for: production code implementation, architecture design, DevOps, security audits.
 user-invocable: false
@@ -12,7 +12,7 @@ metadata:
   status: "active"
   updated: "2026-03-30"
   tags: "testing, pyramid, coverage, tdd, patterns, reference"
-  agent: "manager-cycle"
+  agent: "manager-develop"
 
 # MoAI Extension: Progressive Disclosure
 progressive_disclosure:
@@ -23,7 +23,7 @@ progressive_disclosure:
 # MoAI Extension: Triggers
 triggers:
   keywords: ["test", "coverage", "tdd", "unit test", "integration", "e2e"]
-  agents: ["manager-cycle", "manager-quality"]
+  agents: ["manager-develop", "manager-quality"]
   phases: ["run"]
 ---
 
@@ -31,8 +31,8 @@ triggers:
 
 ## Target Agents
 
-- `manager-cycle` - Primary: applies patterns during test creation and coverage analysis
-- `manager-cycle` - Secondary: applies during RED-GREEN-REFACTOR cycles
+- `manager-develop` - Primary: applies patterns during test creation and coverage analysis
+- `manager-develop` - Secondary: applies during RED-GREEN-REFACTOR cycles
 
 ## Test Pyramid Ratios
 

--- a/internal/template/templates/.claude/skills/moai-workflow-ddd/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-ddd/SKILL.md
@@ -17,7 +17,7 @@ metadata:
   tags: "workflow, refactoring, ddd, domain-driven, behavior-preservation, ast-grep, characterization-tests"
   author: "MoAI-ADK Team"
   context: "fork"
-  agent: "manager-cycle"
+  agent: "manager-develop"
   related-skills: "moai-tool-ast-grep, moai-workflow-testing, moai-foundation-quality"
 ---
 

--- a/internal/template/templates/.claude/skills/moai-workflow-loop/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-loop/SKILL.md
@@ -150,7 +150,7 @@ Skills:
 
 Agents:
 
-- manager-cycle: DDD implementation
+- manager-develop: DDD implementation
 - manager-quality: Quality validation
 - manager-quality: Complex debugging
 

--- a/internal/template/templates/.claude/skills/moai-workflow-project/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-project/SKILL.md
@@ -28,7 +28,7 @@ progressive_disclosure:
 triggers:
   keywords: ["project setup", "initialization", "project initialization", "project configuration", "project documentation", "multilingual", "language initialization", "template", "boilerplate", "scaffolding", "code template", "feedback template", "docs", "documentation", "API reference", "docs generation", "Sphinx", "MkDocs", "TypeDoc", "OpenAPI", "jit docs", "just in time docs", "project template", "GitHub issue", "template optimization", "how to", "implement", "best practices", "technology guide", "framework documentation"]
   phases: ["plan", "run", "sync"]
-  agents: ["manager-project", "manager-docs", "builder-platform", "manager-spec", "expert-backend", "expert-frontend"]
+  agents: ["manager-project", "manager-docs", "builder-harness", "manager-spec", "expert-backend", "expert-frontend"]
 ---
 
 # MoAI Workflow Project - Integrated Project Management System

--- a/internal/template/templates/.claude/skills/moai-workflow-spec/references/examples.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-spec/references/examples.md
@@ -14,7 +14,7 @@ This document provides complete, production-ready SPEC examples for common devel
 Created: 2025-12-07
 Status: Planned
 Priority: High
-Assigned: manager-cycle
+Assigned: manager-develop
 Related SPECs: SPEC-002 (User Registration)
 Epic: EPIC-AUTH
 Estimated Effort: 8 hours
@@ -331,7 +331,7 @@ RATE_LIMIT_MAX_REQUESTS=10
 Created: 2025-12-07
 Status: Planned
 Priority: High
-Assigned: manager-cycle
+Assigned: manager-develop
 Related SPECs: SPEC-003 (Order Management), SPEC-006 (Refund System)
 Epic: EPIC-PAYMENT
 Estimated Effort: 16 hours

--- a/internal/template/templates/.claude/skills/moai-workflow-spec/references/reference.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-spec/references/reference.md
@@ -16,7 +16,7 @@ This document provides comprehensive reference information for SPEC workflow man
 Created: YYYY-MM-DD
 Status: Planned
 Priority: Medium
-Assigned: manager-cycle
+Assigned: manager-develop
 
 ## Description
 [Brief description of the feature]
@@ -67,7 +67,7 @@ Business:
 Created: YYYY-MM-DD
 Status: Planned
 Priority: High
-Assigned: manager-cycle
+Assigned: manager-develop
 Related SPECs: SPEC-YYY, SPEC-ZZZ
 
 ## Description
@@ -269,7 +269,7 @@ Technical:
 - Low: Enhancement or optional feature
 
 **Assigned Agents**:
-- manager-cycle: DDD-based implementation
+- manager-develop: DDD-based implementation
 - manager-spec: SPEC refinement and updates
 - expert-backend: Backend-specific features
 - expert-frontend: Frontend-specific features
@@ -530,7 +530,7 @@ manager-spec creates SPEC-001
     ↓
 /moai:2-run SPEC-001
     ↓
-manager-cycle implements with ANALYZE-PRESERVE-IMPROVE
+manager-develop implements with ANALYZE-PRESERVE-IMPROVE
     ↓
 /moai:3-sync SPEC-001
     ↓

--- a/internal/template/templates/.claude/skills/moai-workflow-tdd/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-tdd/SKILL.md
@@ -18,7 +18,7 @@ metadata:
   tags: "workflow, tdd, test-driven, red-green-refactor, test-first"
   author: "MoAI-ADK Team"
   context: "fork"
-  agent: "manager-cycle"
+  agent: "manager-develop"
   related-skills: "moai-workflow-ddd, moai-workflow-testing, moai-foundation-quality"
 
 # MoAI Extension: Progressive Disclosure
@@ -31,7 +31,7 @@ progressive_disclosure:
 triggers:
   keywords: ["TDD", "test-driven development", "red-green-refactor", "test-first", "new feature", "greenfield"]
   phases: ["run"]
-  agents: ["manager-cycle", "expert-backend", "expert-frontend"]
+  agents: ["manager-develop", "expert-backend", "expert-frontend"]
 ---
 
 # Test-Driven Development (TDD) Workflow
@@ -192,7 +192,7 @@ After each refactoring step:
 
 ### Standard TDD Session
 
-When executing TDD through manager-cycle:
+When executing TDD through manager-develop:
 
 Step 1 - Understand Requirements:
 

--- a/internal/template/templates/.claude/skills/moai-workflow-testing/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-testing/SKILL.md
@@ -17,7 +17,7 @@ metadata:
   tags: "workflow, ddd, testing, debugging, performance, quality, review, pr-review"
   author: "MoAI-ADK Team"
   context: "fork"
-  agent: "manager-cycle"
+  agent: "manager-develop"
 
 # MoAI Extension: Progressive Disclosure
 progressive_disclosure:
@@ -29,7 +29,7 @@ progressive_disclosure:
 triggers:
   keywords: ["DDD", "domain-driven development", "characterization tests", "behavior preservation", "debugging", "performance optimization", "code review", "PR review", "quality assurance", "testing", "CI/CD", "TRUST 5"]
   phases: ["run", "sync"]
-  agents: ["manager-cycle", "manager-quality", "expert-performance"]
+  agents: ["manager-develop", "manager-quality", "expert-performance"]
 ---
 
 # Development Workflow Specialist

--- a/internal/template/templates/.claude/skills/moai/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai/SKILL.md
@@ -28,7 +28,7 @@ Rules and constraints governing all workflows are always loaded from these sourc
 - Quality gates, security boundaries: .claude/rules/moai/core/moai-constitution.md
 - SPEC workflow phases, token budgets: .claude/rules/moai/workflow/spec-workflow.md
 - Development methodologies (DDD/TDD): .claude/rules/moai/workflow/spec-workflow.md (Run Phase section)
-- Agent definitions: See CLAUDE.md Section 4. For agent creation, use builder-platform subagent.
+- Agent definitions: See CLAUDE.md Section 4. For agent creation, use builder-harness subagent.
 - @MX tag rules and protocol: .claude/rules/moai/workflow/mx-tag-protocol.md
 
 ---
@@ -114,7 +114,7 @@ For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/plan.md (team mod
 ### run - DDD/TDD Implementation
 
 Purpose: Implement SPEC requirements through configured development methodology.
-Agents: manager-strategy, manager-cycle (cycle_type=ddd|tdd per quality.yaml), manager-quality, manager-git
+Agents: manager-strategy, manager-develop (cycle_type=ddd|tdd per quality.yaml), manager-quality, manager-git
 Flags: --resume SPEC-XXX, --team
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/run.md (team mode: ${CLAUDE_SKILL_DIR}/team/run.md)
 
@@ -150,7 +150,7 @@ For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/fix.md
 ### loop - Iterative Auto-Fix
 
 Purpose: Repeatedly fix issues until completion marker detected or max iterations reached.
-Agents: manager-quality, expert-backend, expert-frontend, manager-cycle
+Agents: manager-quality, expert-backend, expert-frontend, manager-develop
 Flags: --max N, --auto-fix, --seq
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/loop.md
 
@@ -171,7 +171,7 @@ For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/review.md (team m
 ### clean - Dead Code Removal
 
 Purpose: Identify and safely remove unused code with test verification.
-Agents: expert-refactoring, manager-cycle
+Agents: expert-refactoring, manager-develop
 Flags: --dry, --safe-only, --file PATH
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/clean.md
 
@@ -185,14 +185,14 @@ For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/codemaps.md
 ### coverage - Test Coverage Analysis
 
 Purpose: Analyze test coverage gaps and generate missing tests.
-Agents: manager-cycle
+Agents: manager-develop
 Flags: --target N, --file PATH, --report
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/coverage.md
 
 ### e2e - End-to-End Testing
 
 Purpose: Create and run E2E tests using Chrome, Playwright, or Agent Browser.
-Agents: manager-cycle, expert-frontend
+Agents: manager-develop, expert-frontend
 Flags: --record, --url URL, --journey NAME
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/e2e.md
 
@@ -216,7 +216,7 @@ For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/db.md
 
 Purpose: Full autonomous research -> plan -> annotate -> run -> sync pipeline.
 Phases: Parallel Exploration (research.md) -> SPEC Generation -> Annotation Cycle -> Implementation -> Sync
-Agents: Explore, manager-spec, manager-cycle, manager-quality, manager-docs, manager-git
+Agents: Explore, manager-spec, manager-develop, manager-quality, manager-docs, manager-git
 Flags: --loop, --max N, --branch, --pr, --resume SPEC-XXX, --team, --solo, --no-issue
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/moai.md
 

--- a/internal/template/templates/.claude/skills/moai/references/mx-tag.md
+++ b/internal/template/templates/.claude/skills/moai/references/mx-tag.md
@@ -3,7 +3,7 @@ name: moai-workflow-mx-tag
 description: >
   @MX TAG annotation protocol reference for AI agent code context delivery.
   Provides detailed tag syntax grammar, fan-in analysis method, agent report
-  format, and edge case handling. Used by manager-cycle and manager-quality agents.
+  format, and edge case handling. Used by manager-develop and manager-quality agents.
 user-invocable: false
 metadata:
   version: "2.5.0"
@@ -21,7 +21,7 @@ progressive_disclosure:
 # MoAI Extension: Triggers
 triggers:
   keywords: ["mx", "tag", "annotation", "anchor", "invariant", "context"]
-  agents: ["manager-cycle", "manager-quality"]
+  agents: ["manager-develop", "manager-quality"]
   phases: ["run"]
 ---
 

--- a/internal/template/templates/.claude/skills/moai/references/reference.md
+++ b/internal/template/templates/.claude/skills/moai/references/reference.md
@@ -22,7 +22,7 @@ progressive_disclosure:
 # MoAI Extension: Triggers
 triggers:
   keywords: ["reference", "pattern", "flag", "config", "resume", "legacy", "mapping"]
-  agents: ["manager-spec", "manager-cycle", "manager-docs", "manager-quality", "manager-git"]
+  agents: ["manager-spec", "manager-develop", "manager-docs", "manager-quality", "manager-git"]
   phases: ["plan", "run", "sync"]
 ---
 

--- a/internal/template/templates/.claude/skills/moai/workflows/clean.md
+++ b/internal/template/templates/.claude/skills/moai/workflows/clean.md
@@ -22,7 +22,7 @@ progressive_disclosure:
 # MoAI Extension: Triggers
 triggers:
   keywords: ["clean", "dead code", "unused code", "dead-code", "remove unused"]
-  agents: ["expert-refactoring", "manager-cycle"]
+  agents: ["expert-refactoring", "manager-develop"]
   phases: ["clean"]
 ---
 
@@ -168,7 +168,7 @@ Safety Measures:
 
 ## Phase 5: Test Verification
 
-[HARD] Delegate test verification to the manager-cycle subagent.
+[HARD] Delegate test verification to the manager-develop subagent.
 
 After removals:
 - Run full test suite: `go test -race ./...` (Go) or equivalent
@@ -233,7 +233,7 @@ Next Steps (AskUserQuestion):
 - Phase 2: expert-refactoring subagent (usage graph analysis)
 - Phase 3: MoAI orchestrator (user approval via AskUserQuestion)
 - Phase 4: expert-refactoring subagent (safe removal)
-- Phase 5: manager-cycle subagent (test verification)
+- Phase 5: manager-develop subagent (test verification)
 - Phase 5.5: MoAI orchestrator or expert-refactoring (MX tag cleanup)
 
 ## Execution Summary
@@ -246,7 +246,7 @@ Next Steps (AskUserQuestion):
 6. If --dry: Display analysis results and exit
 7. Present removal plan to user via AskUserQuestion
 8. Delegate safe removal to expert-refactoring subagent
-9. Delegate test verification to manager-cycle subagent
+9. Delegate test verification to manager-develop subagent
 10. Clean up @MX tags for removed code (Phase 5.5)
 11. TaskCreate/TaskUpdate for all candidates
 12. Report results with next step options

--- a/internal/template/templates/.claude/skills/moai/workflows/coverage.md
+++ b/internal/template/templates/.claude/skills/moai/workflows/coverage.md
@@ -22,7 +22,7 @@ progressive_disclosure:
 # MoAI Extension: Triggers
 triggers:
   keywords: ["coverage", "test coverage", "coverage gap", "missing tests", "coverage target"]
-  agents: ["manager-cycle"]
+  agents: ["manager-develop"]
   phases: ["coverage"]
 ---
 
@@ -49,7 +49,7 @@ This subcommand is classified as **Agentless fixed-pipeline** per SPEC-V3R2-WF-0
 It executes a deterministic 3-phase contract: **localize → repair → validate**.
 
 - **Phase mapping**: localize ← Phase 1+2; repair ← Phase 3; validate ← Phase 4
-- **No LLM-driven control flow**: Agent() invocations exist for executor delegation within phases (e.g., `manager-cycle` for measurement) but never select the next phase.
+- **No LLM-driven control flow**: Agent() invocations exist for executor delegation within phases (e.g., `manager-develop` for measurement) but never select the next phase.
 - **No-op exit**: When the localize phase finds zero targets, the pipeline exits with status `no-op` and exit code 0, skipping repair and validate.
 - **Fail-fast**: When repair encounters an unresolvable error, the pipeline terminates and reports the error. There is no multi-agent fallback.
 - **`--mode` flag handling**: Any `--mode` flag passed to this subcommand is ignored. The system logs `MODE_FLAG_IGNORED_FOR_UTILITY` at info level and proceeds with the fixed pipeline.
@@ -59,7 +59,7 @@ See [Subcommand Classification matrix](../../rules/moai/workflow/spec-workflow.m
 
 ## Phase 1: Coverage Measurement
 
-[HARD] Delegate coverage measurement to the manager-cycle subagent.
+[HARD] Delegate coverage measurement to the manager-develop subagent.
 
 Language-specific coverage tools:
 
@@ -80,7 +80,7 @@ Expected Output:
 
 ## Phase 2: Gap Analysis
 
-[HARD] Delegate gap analysis to the manager-cycle subagent.
+[HARD] Delegate gap analysis to the manager-develop subagent.
 
 Pre-Analysis MX Tag Scan:
 
@@ -129,7 +129,7 @@ Gap Report Structure:
 
 If --report flag: Skip this phase. Display gap report and exit.
 
-[HARD] Delegate test generation to the manager-cycle subagent.
+[HARD] Delegate test generation to the manager-develop subagent.
 
 Test Generation Strategy (based on quality.yaml development_mode):
 
@@ -201,20 +201,20 @@ Next Steps (AskUserQuestion):
 
 ## Agent Chain Summary
 
-- Phase 1-2: manager-cycle subagent (measurement and analysis)
-- Phase 3: manager-cycle subagent (test generation)
-- Phase 4: manager-cycle subagent (verification)
+- Phase 1-2: manager-develop subagent (measurement and analysis)
+- Phase 3: manager-develop subagent (test generation)
+- Phase 4: manager-develop subagent (verification)
 - Phase 5: MoAI orchestrator (report and user interaction)
 
 ## Execution Summary
 
 1. Parse arguments (extract flags: --target, --file, --report, --package, --uncovered, --critical)
 2. Read coverage target from quality.yaml if --target not specified
-3. Delegate coverage measurement to manager-cycle subagent
+3. Delegate coverage measurement to manager-develop subagent
 4. Scan target files for @MX tags (Pre-Analysis MX Tag Scan)
-5. Delegate gap analysis to manager-cycle subagent (with MX context)
+5. Delegate gap analysis to manager-develop subagent (with MX context)
 6. If --report: Display gap report and exit
-7. Delegate test generation to manager-cycle subagent
+7. Delegate test generation to manager-develop subagent
 8. Verify tests pass and re-measure coverage
 9. TaskCreate/TaskUpdate for all gaps and generated tests
 10. Report results with next step options

--- a/internal/template/templates/.claude/skills/moai/workflows/e2e.md
+++ b/internal/template/templates/.claude/skills/moai/workflows/e2e.md
@@ -22,7 +22,7 @@ progressive_disclosure:
 # MoAI Extension: Triggers
 triggers:
   keywords: ["e2e", "end-to-end", "e2e test", "browser test", "playwright", "agent-browser", "user journey"]
-  agents: ["manager-cycle", "expert-frontend"]
+  agents: ["manager-develop", "expert-frontend"]
   phases: ["e2e"]
 ---
 
@@ -96,7 +96,7 @@ Detection results are used to mark availability status in AskUserQuestion option
 
 ### Step 0.1: Tool Detection
 
-[HARD] Delegate tool detection to the manager-cycle subagent.
+[HARD] Delegate tool detection to the manager-develop subagent.
 
 Detection commands (run in parallel):
 - Agent Browser: `npx agent-browser --version 2>/dev/null || echo "not-installed"`
@@ -176,7 +176,7 @@ For Playwright best practices and patterns, reference: Skill("moai-workflow-test
 
 ## Phase 1: Journey Mapping
 
-[HARD] Delegate journey mapping to the manager-cycle subagent.
+[HARD] Delegate journey mapping to the manager-develop subagent.
 
 If --journey flag: Load the specified journey definition and skip to Phase 2.
 
@@ -208,7 +208,7 @@ Steps:
 
 ## Phase 2: Test Script Creation
 
-[HARD] Delegate test script creation to the manager-cycle subagent.
+[HARD] Delegate test script creation to the manager-develop subagent.
 
 ### Playwright CLI Mode
 
@@ -245,7 +245,7 @@ No test script files generated. Instead, create journey step definitions as stru
 
 ## Phase 3: Test Execution
 
-[HARD] Delegate test execution to the manager-cycle subagent (or expert-frontend for Chrome MCP).
+[HARD] Delegate test execution to the manager-develop subagent (or expert-frontend for Chrome MCP).
 
 ### Playwright CLI Execution
 
@@ -428,11 +428,11 @@ Next Steps (AskUserQuestion):
 
 ## Agent Chain Summary
 
-- Phase 0: manager-cycle subagent (tool detection and installation)
-- Phase 1: manager-cycle subagent (journey mapping)
-- Phase 2: manager-cycle subagent (test script creation)
-- Phase 3: manager-cycle or expert-frontend subagent (test execution). For Chrome DevTools MCP performance baselines and Lighthouse audits, delegate to expert-performance subagent.
-- Phase 4: expert-frontend subagent (GIF recording via Chrome MCP / Chrome DevTools MCP screenshot sequences) or manager-cycle (Playwright/Agent Browser traces)
+- Phase 0: manager-develop subagent (tool detection and installation)
+- Phase 1: manager-develop subagent (journey mapping)
+- Phase 2: manager-develop subagent (test script creation)
+- Phase 3: manager-develop or expert-frontend subagent (test execution). For Chrome DevTools MCP performance baselines and Lighthouse audits, delegate to expert-performance subagent.
+- Phase 4: expert-frontend subagent (GIF recording via Chrome MCP / Chrome DevTools MCP screenshot sequences) or manager-develop (Playwright/Agent Browser traces)
 - Phase 5: MoAI orchestrator (report and user interaction)
 
 ## Execution Summary
@@ -440,10 +440,10 @@ Next Steps (AskUserQuestion):
 1. Parse arguments (extract flags: --tool, --record, --url, --journey, --headless, --browser, --timeout, --retry)
 2. Phase 0: Detect available tools, always prompt user with recommendation, install if needed
 3. If --journey: Load specific journey, skip to Phase 2
-4. Phase 1: Delegate journey mapping to manager-cycle subagent
+4. Phase 1: Delegate journey mapping to manager-develop subagent
 5. Present journey options to user via AskUserQuestion
-6. Phase 2: Delegate test script creation to manager-cycle subagent
-7. Phase 3: Delegate test execution to manager-cycle/expert-frontend subagent
+6. Phase 2: Delegate test script creation to manager-develop subagent
+7. Phase 3: Delegate test execution to manager-develop/expert-frontend subagent
 8. Phase 4: If --record, capture recordings via selected tool's mechanism
 9. TaskCreate/TaskUpdate for all journeys
 10. Phase 5: Report results with next step options

--- a/internal/template/templates/.claude/skills/moai/workflows/loop.md
+++ b/internal/template/templates/.claude/skills/moai/workflows/loop.md
@@ -22,7 +22,7 @@ progressive_disclosure:
 # MoAI Extension: Triggers
 triggers:
   keywords: ["loop", "iterate", "repeat", "until done", "keep fixing", "all errors"]
-  agents: ["manager-quality", "expert-backend", "expert-frontend", "manager-cycle"]
+  agents: ["manager-quality", "expert-backend", "expert-frontend", "manager-develop"]
   phases: ["loop"]
 ---
 
@@ -120,7 +120,7 @@ Step 6 - Fix Execution:
 Agent selection by issue type:
 - Type errors, logic bugs: manager-quality subagent
 - Import/module issues: expert-backend or expert-frontend subagent
-- Test failures: manager-cycle subagent
+- Test failures: manager-develop subagent
 - Security issues: expert-security subagent
 - Performance issues: expert-performance subagent
 

--- a/internal/template/templates/.claude/skills/moai/workflows/moai.md
+++ b/internal/template/templates/.claude/skills/moai/workflows/moai.md
@@ -74,8 +74,8 @@ constitution:
 *DDD adapts for greenfield (ANALYZE requirements -> PRESERVE with spec tests -> IMPROVE)
 
 **Agent Selection**:
-- **TDD cycle**: `manager-cycle` subagent (RED-GREEN-REFACTOR)
-- **DDD cycle**: `manager-cycle` subagent (ANALYZE-PRESERVE-IMPROVE)
+- **TDD cycle**: `manager-develop` subagent (RED-GREEN-REFACTOR)
+- **DDD cycle**: `manager-develop` subagent (ANALYZE-PRESERVE-IMPROVE)
 
 For methodology details, see: .claude/rules/moai/workflow/spec-workflow.md (Run Phase section)
 
@@ -144,13 +144,13 @@ This iterative refinement catches architectural misunderstandings before impleme
 
 [HARD] Methodology selection based on `.moai/config/sections/quality.yaml`:
 
-- **development_mode: tdd** (default): Use `manager-cycle` (RED-GREEN-REFACTOR)
-- **development_mode: ddd**: Use `manager-cycle` (ANALYZE-PRESERVE-IMPROVE)
+- **development_mode: tdd** (default): Use `manager-develop` (RED-GREEN-REFACTOR)
+- **development_mode: ddd**: Use `manager-develop` (ANALYZE-PRESERVE-IMPROVE)
 
 Expert agent selection (for domain-specific work):
 - Backend logic: expert-backend subagent
 - Frontend components: expert-frontend subagent
-- Test creation: manager-cycle subagent
+- Test creation: manager-develop subagent
 - Bug fixing: manager-quality subagent
 - Refactoring: expert-refactoring subagent
 - Security fixes: expert-security subagent
@@ -236,7 +236,7 @@ Mode selection:
 13. **Phase 2 (Run)**: Route based on Gate result (execution_mode parameter)
    - worktree: Already running in isolated tmux+worktree session (Gate handled transition)
    - team: Read ${CLAUDE_SKILL_DIR}/team/run.md and follow team orchestration
-   - sub-agent: manager-cycle (cycle_type=ddd or tdd, per quality.yaml development_mode)
+   - sub-agent: manager-develop (cycle_type=ddd or tdd, per quality.yaml development_mode)
    - Harness level determines phase skipping and evaluator involvement
 14. **Phase 3 (Sync)**: Always manager-docs sub-agent (sync phase never uses team mode)
 15. Terminate with completion marker

--- a/internal/template/templates/.claude/skills/moai/workflows/run.md
+++ b/internal/template/templates/.claude/skills/moai/workflows/run.md
@@ -2,7 +2,7 @@
 name: moai-workflow-run
 description: >
   DDD/TDD implementation workflow for SPEC requirements. Second step
-  of the Plan-Run-Sync workflow. Routes to manager-cycle based
+  of the Plan-Run-Sync workflow. Routes to manager-develop based
   on quality.yaml development_mode setting.
 user-invocable: false
 metadata:
@@ -21,7 +21,7 @@ progressive_disclosure:
 # MoAI Extension: Triggers
 triggers:
   keywords: ["run", "implement", "build", "create", "develop", "code"]
-  agents: ["manager-cycle", "manager-strategy", "manager-quality", "manager-git"]
+  agents: ["manager-develop", "manager-strategy", "manager-quality", "manager-git"]
   phases: ["run"]
 ---
 
@@ -425,8 +425,8 @@ Mode Selection Rules:
 
 | Request Pattern | Detection Criteria | Execution Mode | Agents |
 |----------------|-------------------|---------------|--------|
-| Bug fix / error fix | SPEC scope ≤ 3 files, single domain | **Fix Mode** | manager-quality + manager-cycle |
-| Single endpoint / function | SPEC scope ≤ 5 files, single domain | **Focused Mode** | relevant expert + manager-cycle |
+| Bug fix / error fix | SPEC scope ≤ 3 files, single domain | **Fix Mode** | manager-quality + manager-develop |
+| Single endpoint / function | SPEC scope ≤ 5 files, single domain | **Focused Mode** | relevant expert + manager-develop |
 | Feature across 1 domain | SPEC scope 5-10 files, single domain | **Standard Mode** | manager-strategy + relevant expert + manager-quality |
 | Multi-domain feature | SPEC scope ≥ 10 files OR ≥ 3 domains | **Full Pipeline** | All agents (strategy + backend + frontend + testing + quality + docs) |
 | Large cross-cutting change | complexity score ≥ 7 AND --team flag | **Team Mode** | 3-4 parallel teammates |
@@ -596,11 +596,11 @@ See .claude/rules/moai/workflow/mx-tag-protocol.md for tag type definitions.
 Before Phase 2, determine the development methodology by reading `.moai/config/sections/quality.yaml`:
 
 **If development_mode is "ddd":**
-- Route all tasks to manager-cycle subagent
+- Route all tasks to manager-develop subagent
 - Use ANALYZE-PRESERVE-IMPROVE cycle (see @spec-workflow.md for details)
 
 **If development_mode is "tdd":**
-- Route all tasks to manager-cycle subagent
+- Route all tasks to manager-develop subagent
 - Use RED-GREEN-REFACTOR cycle (see @spec-workflow.md for details)
 
 ### Phase 2.0: Sprint Contract Negotiation
@@ -655,11 +655,11 @@ If no delta markers are present in the SPEC, delta processing is silently skippe
 
 ### Phase 2: Implementation (Mode-Dependent)
 
-**[HARD] Worktree Prompt Construction**: When spawning implementation agents (manager-cycle) with `isolation: "worktree"`, the orchestrator MUST construct prompts using project-root-relative paths only. Do NOT embed the current working directory path in the agent prompt. See "Worktree Path Rules [HARD]" section above.
+**[HARD] Worktree Prompt Construction**: When spawning implementation agents (manager-develop) with `isolation: "worktree"`, the orchestrator MUST construct prompts using project-root-relative paths only. Do NOT embed the current working directory path in the agent prompt. See "Worktree Path Rules [HARD]" section above.
 
 #### Phase 2A: DDD Implementation (for ddd mode)
 
-Agent: manager-cycle subagent
+Agent: manager-develop subagent
 
 Input: Approved execution plan from Phase 1 plus task decomposition from Phase 1.5. Include `.moai/project/structure.md` and `.moai/project/tech.md` as onboarding context in the agent prompt so the implementation agent understands the project's architecture conventions before writing code.
 
@@ -675,7 +675,7 @@ Output: files_modified list, characterization_tests_created list, test_results (
 
 Implementation Divergence Tracking:
 
-The manager-cycle subagent must track deviations from the original SPEC plan during implementation:
+The manager-develop subagent must track deviations from the original SPEC plan during implementation:
 
 - planned_files: Files listed in plan.md that were expected to be created or modified
 - actual_files: Files actually created or modified during the DDD cycle
@@ -703,7 +703,7 @@ After each DDD IMPROVE cycle completion, compare planned vs actual:
 
 #### Phase 2B: TDD Implementation (for tdd mode)
 
-Agent: manager-cycle subagent
+Agent: manager-develop subagent
 
 Input: Approved execution plan from Phase 1 plus task decomposition from Phase 1.5. Include `.moai/project/structure.md` and `.moai/project/tech.md` as onboarding context in the agent prompt so the implementation agent understands the project's architecture conventions before writing code.
 
@@ -718,7 +718,7 @@ Output: files_created list, specification_tests_created list, test_results (all 
 
 Implementation Divergence Tracking:
 
-The manager-cycle subagent must track deviations from the original SPEC plan during implementation:
+The manager-develop subagent must track deviations from the original SPEC plan during implementation:
 
 - planned_files: Files listed in plan.md that were expected to be created
 - actual_files: Files actually created during the TDD cycle
@@ -1039,7 +1039,7 @@ All of the following must be verified:
 - Phase 0.95: SPEC has 8 files, 2 domains → Standard Mode selected
 - Phase 1: manager-strategy creates execution plan with 5 tasks
 - Decision Point: User approves plan
-- Phase 2: Implementation via manager-cycle (DDD mode)
+- Phase 2: Implementation via manager-develop (DDD mode)
 - Phase 2.5: TRUST 5 validation passes
 - Phase 3: Commits created on feature branch
 
@@ -1047,7 +1047,7 @@ All of the following must be verified:
 **Prompt**: "/moai run SPEC-BUG-042" (bug fix SPEC, 2 files affected)
 **Expected Result**:
 - Phase 0.95: SPEC has 2 files, 1 domain → Fix Mode selected
-- Directly spawns manager-quality + manager-cycle
+- Directly spawns manager-quality + manager-develop
 - Minimal overhead, fast execution
 - Quality validation still runs
 

--- a/internal/template/templates/.claude/skills/moai/workflows/sync.md
+++ b/internal/template/templates/.claude/skills/moai/workflows/sync.md
@@ -478,7 +478,7 @@ Purpose: Measure test coverage, identify gaps, and generate missing tests to mee
 
 #### Step 0.7.1: Coverage Measurement
 
-Agent: manager-cycle subagent
+Agent: manager-develop subagent
 
 Measure current coverage using language-specific tools:
 - Go: `go test -coverprofile=coverage.out -covermode=atomic ./...` then `go tool cover -func=coverage.out`
@@ -490,7 +490,7 @@ Output: Overall coverage percentage, per-file coverage, per-function data.
 
 #### Step 0.7.2: Gap Analysis
 
-Agent: manager-cycle subagent
+Agent: manager-develop subagent
 
 Identify files below the coverage target (from quality.yaml test_coverage_target, default 85%).
 
@@ -502,7 +502,7 @@ Prioritize gaps by risk:
 
 #### Step 0.7.3: Test Generation
 
-Agent: manager-cycle subagent
+Agent: manager-develop subagent
 
 Generate missing tests for P1 and P2 gaps:
 - Follow development_mode for test style (TDD: table-driven tests, DDD: characterization tests)

--- a/internal/template/templates/CLAUDE.md
+++ b/internal/template/templates/CLAUDE.md
@@ -133,7 +133,7 @@ Role profiles (in `workflow.yaml`): researcher, analyst, architect, implementer,
 
 Requires: `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` env var AND `workflow.team.enabled: true` in workflow.yaml.
 
-For detailed agent descriptions, see the Agent Catalog section above. For agent creation guidelines, use the builder-platform subagent or see `.claude/rules/moai/development/agent-authoring.md`.
+For detailed agent descriptions, see the Agent Catalog section above. For agent creation guidelines, use the builder-harness subagent or see `.claude/rules/moai/development/agent-authoring.md`.
 
 ---
 


### PR DESCRIPTION
## Summary

- `manager-cycle` → `manager-develop` (active agent: plan/run/sync 사이클의 run 단계 담당)
- `builder-platform` → `builder-harness` (active agent: harness 네임스페이스 artifact 생성 전문)
- `manager-cycle` 기존 slot은 retired stub으로 전환 (`retired_replacement: manager-develop`)
- 73개 파일: templates + local `.claude/` + Go 소스 (`cycle_handler.go` → `developHandler`, `factory.go` alias 추가)

## Rationale

- `manager-develop`: 네이밍 대칭 — manager-**spec**(plan) / manager-**develop**(run) / manager-**docs**(sync)
- `builder-harness`: `moai-meta-harness` skill Phase 4-5에서 builder-harness를 호출하는 구조 → harness 네임스페이스와 일관성, sub-namespace 충돌 없음

## Test plan

- [x] `go test ./internal/template/` — `TestBuilderSkillPath`, `TestManagerDevelopPresent` PASS
- [x] `go test ./internal/hook/agents/` — `TestDevelopHandler_*`, `TestCycleHandler_BackwardCompat` PASS
- [x] `go test ./internal/hook/` — `TestHookWrapper_*` PASS (make install 후)
- [x] `go test ./internal/...` — 전체 PASS (FAIL 없음)
- [x] AC-06: `diff -r internal/template/templates/.claude/agents/moai/ .claude/agents/moai/` → 출력 없음

🗿 MoAI <email@mo.ai.kr>