### PR TITLE
plan(catalog): SPEC-V3R4-CATALOG-001 3-tier catalog manifest

### DIFF
--- a/.moai/brain/IDEA-003/claude-design-handoff/acceptance.md
+++ b/.moai/brain/IDEA-003/claude-design-handoff/acceptance.md
@@ -1,0 +1,76 @@
+# Acceptance — Review Completion Criteria
+
+## Definition of Done
+
+검토자의 review는 다음을 모두 충족할 때 완료됩니다:
+
+### 1. 4-Dimension Scoring (필수)
+
+각 1-5점으로 명시:
+
+- [ ] **Architecture soundness** — 3-tier 구조의 정합성
+- [ ] **Migration safety** — moai update 안전성 설계
+- [ ] **User friction** — 신규/기존 사용자 경험 영향
+- [ ] **Implementation risk** — SPEC 분해 및 위험 격리
+
+### 2. Verdict 명시 (필수)
+
+다음 중 하나:
+
+- `APPROVE` — 7개 SPEC 모두 그대로 `/moai plan` 진입
+- `APPROVE WITH CONDITIONS` — 조건부 승인 (조건 명시 필요)
+- `REJECT` — 거부 (재설계 영역 명시 필요)
+
+### 3. Concerns & Suggestions (필수)
+
+- [ ] Top 3 Concerns — 식별된 가장 큰 위험
+- [ ] Top 3 Suggestions — 개선 제안
+
+### 4. Conditions (APPROVE WITH CONDITIONS 시만)
+
+조건부 승인 시:
+
+- [ ] 각 조건이 verifiable (검증 가능) 인가
+- [ ] 각 조건이 SPEC 분해에 mappable (어느 SPEC에 추가 요구사항인가)
+
+### 5. Evidence-based (필수)
+
+- [ ] 모든 주장에 근거 (references.md 인용 또는 외부 자료)
+- [ ] 추측 표현 ("아마", "그럴 수 있다") 최소화
+- [ ] 정량적 표현 우선 (예: "context budget 1% = 10K tokens" 같은 수치)
+
+### 6. Constitutional Compliance Check (필수)
+
+검토자는 다음 헌법 준수 여부도 평가:
+
+- [ ] AskUserQuestion 독점 (산문 질문 없음) — proposal 자체가 위반하는지
+- [ ] 16-language neutrality 위배 (특정 언어 우대)
+- [ ] Template-First 원칙 위배 (template 외부 자산 추가)
+- [ ] HARD rule 충돌 (있다면 명시)
+
+## Out of Scope
+
+검토자는 다음을 평가할 필요 없음:
+
+- ❌ Go 코드 구현 디테일 (구현은 후속 SPEC)
+- ❌ 정확한 manifest YAML 스키마 (SPEC-V3R4-CATALOG-001에서 결정)
+- ❌ UI/UX 디자인 (이 제안은 internal architecture)
+- ❌ 4개국어 docs 번역 (SPEC-V3R4-CATALOG-007 산출)
+
+## Output Length
+
+- 본문: 1,500-3,000 단어 권장
+- 최대: 5,000 단어
+- 핵심에 집중. 장황한 도입부는 생략.
+
+## Language
+
+- [HARD] 한국어 작성 (사용자 conversation_language = ko)
+- 기술 용어 (skill, plugin, marketplace, manifest 등) 은 원어 유지
+- 코드/명령어 (`moai pack add`) 는 monospace
+
+## Tone
+
+- 직설적이고 비판적 (sycophancy 금지)
+- 구체적 (vague 비판 금지)
+- 정량적 우선 (수치 제시 가능 시 반드시 수치)

--- a/.moai/brain/IDEA-003/claude-design-handoff/checklist.md
+++ b/.moai/brain/IDEA-003/claude-design-handoff/checklist.md
@@ -1,0 +1,127 @@
+# Checklist — Reviewer Walkthrough
+
+## How to Use This Bundle
+
+이 5-file 번들 (prompt + context + references + acceptance + checklist) 은 외부 claude.com 세션 또는 독립 검토자에게 그대로 paste하여 사용합니다. 검토자는 이 checklist 순서로 진행하세요.
+
+## Step 1: Bundle 읽기 순서
+
+다음 순서로 읽으세요:
+
+1. [ ] **prompt.md** — Role + Task + Output format 이해 (3분)
+2. [ ] **context.md** — 배경 + 사용자 답변 + Solution Summary 흡수 (5분)
+3. [ ] **references.md** — 외부 출처 + MoAI internal references 위치 (2분)
+4. [ ] **acceptance.md** — Definition of Done 확인 (2분)
+5. [ ] **checklist.md** (이 파일) — 검토 순서 가이드 (2분)
+
+소요 시간 합계: ~15분 (읽기)
+
+## Step 2: 사전 자료 학습
+
+다음을 가능한 한 학습 (실제 URL 방문 또는 검색):
+
+- [ ] Anthropic 공식 plugin docs — marketplace 스키마, scope, security model
+- [ ] Hugo update guide — drift detection 패턴
+- [ ] Cookiecutter `cruft` — 3-way merge 메커니즘 (외부 검색 필요)
+- [ ] MoAI-ADK README + CLAUDE.md (가능 시)
+
+소요 시간: ~30분
+
+## Step 3: ideation.md + proposal.md 정밀 검토
+
+핵심 산출물 2개를 읽고 검토:
+
+- [ ] `.moai/brain/IDEA-003/ideation.md` — Lean Canvas 9블록 + Critical Evaluation Section 5
+- [ ] `.moai/brain/IDEA-003/proposal.md` — 7개 SPEC 분해 + 권장 실행 순서
+
+소요 시간: ~20분
+
+## Step 4: 4-Dimension Scoring
+
+각 차원 1-5점 평가. 점수 근거 필수 기록.
+
+### Architecture Soundness
+
+- [ ] 3-tier 구조가 Anthropic plugin scope (marketplace/user/project) 와 정합한가?
+- [ ] manifest 스키마 (SPEC-V3R4-CATALOG-001) 가 단일 진실 공급원으로 충분한가?
+- [ ] 더 단순한 대안이 있는가? (예: 2-tier로 충분?)
+- [ ] 더 복잡한 대안이 정당화되는가? (예: 4-tier)
+
+### Migration Safety
+
+- [ ] cruft-style drift detection이 모든 시나리오를 커버하는가?
+  - [ ] 사용자가 코어 직접 수정
+  - [ ] 사용자가 새 자산 추가
+  - [ ] 코어에서 자산 제거됨 (사용 중)
+  - [ ] 옵션 팩 install 후 코어 업데이트
+  - [ ] harness-generated 자산과 코어 충돌
+- [ ] Snapshot rollback이 부분 실패 시에도 동작하는가?
+- [ ] Audit log이 디버깅에 충분한가?
+- [ ] **빠진 시나리오** 식별 (가장 중요)
+
+### User Friction
+
+- [ ] 신규 사용자 (moai init) 가 첫 `/moai brain` 호출 시 모든 필요 skill 보유?
+- [ ] 기존 사용자 (moai update) 의 마이그레이션 안내가 명확한가?
+- [ ] `moai pack add` 명령의 발견성 (discoverability) 은 충분한가?
+- [ ] harness opt-out 인터뷰가 신규 사용자에게 직관적인가?
+
+### Implementation Risk
+
+- [ ] SPEC-V3R4-CATALOG-004 (moai update 안전 동기화) 의 위험 격리 전략은 적절한가?
+- [ ] Wave 순서 (001 → 002 → 003+005 → 004 → 006+007) 가 위험 흐름과 맞는가?
+- [ ] evaluator-active strict mode 적용 SPEC 식별이 적절한가?
+- [ ] 통합 테스트 coverage 계획이 충분한가?
+
+## Step 5: Constitutional Compliance
+
+- [ ] AskUserQuestion 독점 위반 없음 확인
+- [ ] 16-language neutrality 유지 확인
+- [ ] Template-First 원칙 위반 없음 확인
+- [ ] 다른 HARD rule 충돌 검사
+
+## Step 6: Top 3 Concerns + Top 3 Suggestions
+
+가장 중요한 비판 3개와 개선 제안 3개를 명시.
+
+각 항목 형식:
+```
+[Concern N] [구체적 문제]
+- 근거: [references.md 인용 또는 외부 자료]
+- 영향: [어떤 SPEC / 어떤 사용자에게]
+- 권장: [조치 방향]
+```
+
+## Step 7: Verdict 결정
+
+다음 중 하나 선택 + 근거 기록:
+
+- **APPROVE** — 7개 SPEC 모두 `/moai plan` 진입 가능
+- **APPROVE WITH CONDITIONS** — 다음 조건 충족 시 진입 가능:
+  - [ ] 조건 1: ___
+  - [ ] 조건 2: ___
+  - [ ] 조건 3: ___
+- **REJECT** — 다음 영역 재설계 필요:
+  - [ ] 영역 1: ___
+  - [ ] 영역 2: ___
+
+## Step 8: Output 작성
+
+acceptance.md 의 Output Format 섹션에 따라 markdown 작성. 한국어. 1,500-3,000 단어.
+
+## Step 9: Self-Check
+
+제출 전:
+
+- [ ] 4-dimension 점수 모두 기재 (1-5)
+- [ ] Verdict 명시
+- [ ] Top 3 Concerns + Top 3 Suggestions 모두 기재
+- [ ] 모든 주장에 근거 (references.md 인용 또는 외부 자료)
+- [ ] 정량적 표현 우선 사용
+- [ ] sycophantic 표현 ("훌륭한 제안입니다") 제거
+- [ ] vague 표현 ("아마도", "그럴 수 있다") 최소화
+- [ ] 한국어 + 기술 용어 원어 유지
+
+## 검토 완료 후
+
+이 review를 MoAI 오케스트레이터에게 반환합니다. 오케스트레이터는 review 결과를 사용자에게 보고하고 `/moai plan SPEC-V3R4-CATALOG-001` 실행 여부를 AskUserQuestion으로 확인합니다.

--- a/.moai/brain/IDEA-003/claude-design-handoff/context.md
+++ b/.moai/brain/IDEA-003/claude-design-handoff/context.md
@@ -1,0 +1,78 @@
+# Context — MoAI-ADK Catalog Slimming Proposal
+
+## Background
+
+MoAI-ADK는 Claude Code 위에서 SPEC-First DDD/TDD 워크플로우를 제공하는 오픈소스 메타 시스템입니다. 현재 v2.x 운영 중이며 다음 마이너 릴리스 (v2.20 또는 v3.0) 에서 카탈로그 구조 변경을 계획하고 있습니다.
+
+### 현재 상태 (2026-05-12 기준)
+
+- **Skills**: 36개 (foundation 4 / workflow 13 / domain 11 / platform 3 / framework 1 / meta 1 / ref 4)
+- **Agents**: 29개 (manager-* 8 / expert-* 9 / builder-* 4 / evaluator-active / plan-auditor / researcher / claude-code-guide / manager-brain)
+- **Harness 인프라**: 이미 존재 (`moai-meta-harness`, `moai-harness-learner`, `builder-harness`)
+- **Anthropic plugin marketplace**: 2026 표준 인프라 (이미 공식 도입됨)
+- **Context budget**: Opus 4.7 1M context의 1% = 10K tokens가 skill description 예산
+
+### 문제 정의
+
+1. **모든 36 skills + 29 agents가 `moai init` 시 deploy** — 사용 안 하는 자산도 모두 (예: Chrome-extension 프로젝트가 아닌데 `moai-platform-chrome-extension` 로드)
+2. **Context budget overflow 위험** — 사용자가 marketplace plugin 추가 시 즉시 1% 한도 초과 → MoAI 자체 skill description 일부 drop → trigger 정확도 저하
+3. **Harness 인프라 미활용** — `moai-meta-harness`가 프로젝트별 동적 skill/agent 생성 능력을 이미 갖췄지만, 정적 deploy가 이를 대체
+4. **`moai update` 위험 증가** — 카탈로그가 클수록 update 시 충돌과 사용자 변경 손실 가능성 증가
+
+## User Answers (Phase 1 Discovery)
+
+`/moai brain` 워크플로우 Phase 1 Discovery 라운드에서 사용자가 4가지 핵심 결정에 답변:
+
+| 질문 | 답변 |
+|------|------|
+| 코어 분류 기준 | Workflow + Foundation 필수만 (~18개) |
+| harness 위상 | `/moai project`에서 자동 제안, opt-out |
+| 정리 범위 | skills + agents 둘 다 정리 |
+| 마이그레이션 | Non-breaking 신규 설치 + **`moai update` 시 기존 프로젝트도 안전하게 catalog 동기화 (재설계 필요)** |
+
+사용자의 추가 요구: "문제가 없도록 다시 설계해서 보고" — `moai update` 안전성이 최우선 제약.
+
+## Proposed Solution Summary
+
+**"3-tier Catalog + cruft-style Safe Sync"**
+
+```
+Tier 1 — Core (always deployed)         : 18 skills + 15 agents
+Tier 2 — Optional Packs (opt-in)        : moai pack add <name>
+Tier 3 — Harness-Generated (per-project): /moai project 인터뷰 opt-out
+```
+
+Safety: `moai update --catalog-sync` 가 snapshot → drift 감지 → 3-way merge → 사용자 확인 → rollback 인프라로 구성.
+
+## Constitutional Constraints (HARD)
+
+검토자가 인지해야 할 MoAI 헌법 (변경 불가):
+
+- **AskUserQuestion 독점**: 모든 user-facing 질문은 AskUserQuestion 경유 (산문 질문 금지)
+- **16개 언어 중립성**: `internal/template/templates/` 는 16개 프로그래밍 언어 동등 취급
+- **Template-First**: 모든 신규 자산은 먼저 `internal/template/templates/` 에 추가
+- **No tech-stack assumptions in brain**: proposal은 능력 (capability) 만 기술, 구현은 후속 SPEC
+- **PR-based migration**: 모든 변경은 Conventional Commits + PR 경유, force push 금지
+
+## SPEC Decomposition (proposal.md 참조)
+
+7개 SPEC으로 분해:
+- SPEC-V3R4-CATALOG-001: manifest 스키마
+- SPEC-V3R4-CATALOG-002: 디렉토리 재배치
+- SPEC-V3R4-CATALOG-003: moai pack 명령
+- SPEC-V3R4-CATALOG-004: moai update 안전 동기화 ⚠️ **highest risk**
+- SPEC-V3R4-CATALOG-005: /moai project 인터뷰 확장
+- SPEC-V3R4-CATALOG-006: moai doctor catalog
+- SPEC-V3R4-CATALOG-007: 마이그레이션 docs 4개국어
+
+권장 실행 순서: Wave 1 (001+002) → Wave 2 (003+005) → Wave 3 (004) → Wave 4 (006+007)
+
+## Why This Matters
+
+이 결정은 **MoAI-ADK가 Claude Code 생태계 표준에 정렬되어 장기적으로 확장 가능한 distribution architecture로 전환**하는 분기점입니다. 잘못된 결정 시:
+
+- 사용자 손실 (moai update 충돌)
+- 카탈로그 분할로 인한 유지보수 부담 증가 (마이그레이션 미흡)
+- 코어가 너무 좁아 신규 사용자 첫 사용 마찰 증가
+
+이를 방지하기 위한 독립 review를 요청합니다.

--- a/.moai/brain/IDEA-003/claude-design-handoff/prompt.md
+++ b/.moai/brain/IDEA-003/claude-design-handoff/prompt.md
@@ -1,0 +1,77 @@
+# Architecture Review Request — MoAI-ADK Catalog Slimming
+
+> Paste-ready prompt for external review session (claude.com Design / Claude.ai)
+> Context: 이 prompt는 MoAI-ADK 카탈로그 정리 제안 (IDEA-003) 을 독립 reviewer에게 검토 요청할 때 그대로 붙여넣을 수 있도록 작성되었습니다.
+
+---
+
+## Role
+
+당신은 Claude Code 생태계와 plugin marketplace 아키텍처에 정통한 시니어 시스템 아키텍트입니다. 오픈소스 개발 도구의 distribution, 사용자 마이그레이션 안전성, context budget 최적화에 대한 깊은 이해를 가지고 있습니다.
+
+## Task
+
+다음 제안 (MoAI-ADK Catalog Slimming, 3-tier 구조 + cruft-style safe sync) 을 독립적으로 검토하고, 다음 4개 차원에서 평가를 제공해 주세요:
+
+1. **Architecture soundness** — 3-tier 분류 (core / optional-pack / harness-generated) 가 Anthropic 공식 plugin marketplace 패턴과 정합하는가? 더 나은 대안이 있는가?
+2. **Migration safety** — `moai update --catalog-sync` 의 cruft-style drift detection + 3-way merge + snapshot rollback 설계가 데이터 손실을 방지하기에 충분한가? 빠진 시나리오가 있는가?
+3. **User friction** — 코어를 36 → 18 skills로 줄였을 때 신규 사용자가 마주칠 첫 마찰 (예: `/moai brain` 호출 시 필요 skill 누락) 이 있는가?
+4. **Implementation risk** — 7개 SPEC 분해 (특히 SPEC-V3R4-CATALOG-004 안전 동기화) 중 가장 큰 위험은? 격리 전략은 적절한가?
+
+## Inputs
+
+1. **context.md** — 배경 + 현재 상태 + 사용자 답변 4개 (Phase 1 Discovery)
+2. **references.md** — Phase 3 Research 외부 출처 (Anthropic plugin docs, cruft 모델 등)
+3. **acceptance.md** — 합격 기준 (review 완료의 정의)
+4. **checklist.md** — 검토자가 따라갈 순서
+
+이 4개 파일을 함께 첨부합니다. 모두 읽고 통합 review를 작성해 주세요.
+
+## Constraints
+
+- 추측이 아닌 근거 기반. `references.md` 출처 또는 외부 자료를 인용
+- 비판은 직접적이고 정량적으로 (예: "context budget 1% = 10K tokens는 18개 skill로 보장된다" 같은 수치)
+- 한국어로 작성 (사용자 conversation_language)
+- 5,000 단어 이내. 핵심만.
+
+## Output Format
+
+```markdown
+# Review — MoAI-ADK Catalog Slimming (IDEA-003)
+
+## Verdict
+[APPROVE / APPROVE WITH CONDITIONS / REJECT]
+
+## Architecture Soundness (1-5점)
+[점수 및 근거]
+
+## Migration Safety (1-5점)
+[점수 및 근거, 빠진 시나리오 식별]
+
+## User Friction (1-5점)
+[점수 및 근거]
+
+## Implementation Risk (1-5점)
+[점수 및 근거, 격리 전략 평가]
+
+## Top 3 Concerns
+1. ...
+2. ...
+3. ...
+
+## Top 3 Suggestions
+1. ...
+2. ...
+3. ...
+
+## Conditions for Approval (if conditional)
+- ...
+```
+
+## Brand Voice Note
+
+이 프로젝트의 brand-voice.md 는 현재 `_TBD_` 상태입니다. 기본 voice (concise, direct, technical) 로 작성해 주세요. 마케팅 톤 (예: "혁신적", "최첨단") 은 피해 주세요.
+
+---
+
+**Begin review now.**

--- a/.moai/brain/IDEA-003/claude-design-handoff/references.md
+++ b/.moai/brain/IDEA-003/claude-design-handoff/references.md
@@ -1,0 +1,78 @@
+# References — External Sources for IDEA-003 Review
+
+## Anthropic Official Documentation (2026 Stable)
+
+### Claude Code Plugins & Marketplace
+
+- [Discover and install prebuilt plugins through marketplaces — Claude Code Docs](https://code.claude.com/docs/en/discover-plugins)
+- [Extend Claude with skills — Claude Code Docs](https://code.claude.com/docs/en/skills)
+- [Agent Skills — Claude API Docs](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview)
+- [Plugins for Claude Code and Cowork — Anthropic](https://claude.com/plugins)
+
+### Official Repositories
+
+- [anthropics/claude-plugins-official](https://github.com/anthropics/claude-plugins-official) — 13개 공식 plugin 카탈로그
+- [anthropics/skills](https://github.com/anthropics/skills/) — Public agent skills repository (Apache 2.0)
+- [claude-plugins-official/.claude-plugin/marketplace.json](https://github.com/anthropics/claude-plugins-official/blob/main/.claude-plugin/marketplace.json) — marketplace.json schema 예시
+
+### Community Marketplace Aggregators
+
+- [claudemarketplaces.com](https://claudemarketplaces.com/) — 4,200+ skills, 770+ MCP servers, 2,500+ marketplaces 추적
+- [DeepWiki — Claude Code Plugin Marketplace & Discovery](https://deepwiki.com/anthropics/claude-code/4.1-plugin-marketplace-and-discovery)
+
+### Guide Articles (검증된 2026 콘텐츠)
+
+- [Claude Code Plugins: A 2026 Guide — Nimbalyst](https://nimbalyst.com/blog/claude-code-plugins-guide/)
+- [Claude Code Plugins vs Skills — What's the Difference? (2026)](https://www.agensi.io/learn/claude-code-plugins-vs-skills-explained)
+- [Claude Code Plugin Marketplace: Complete Guide (2026)](https://www.agensi.io/learn/claude-code-plugin-marketplace-guide)
+- [Install Anthropic Marketplace Plugins in Claude Code — systemprompt.io](https://systemprompt.io/guides/getting-started-anthropic-marketplace)
+
+## Scaffolding & Template Update Patterns
+
+### 검증된 Drift Detection 모델
+
+- [Hugo Blox — Update guide (drift handling, override preservation)](https://bootstrap.hugoblox.com/hugo-tutorials/update/) — "remove overrides → compare upstream → re-apply" 패턴
+- [Brian Coords — WP/Woo Plugin Scaffolding in 2026](https://www.briancoords.com/my-wp-woo-plugin-scaffolding-in-2026/) — AI agent 기반 scaffold 진화
+- [DevOps School — Template Scaffolding (Feb 2026)](https://www.devopsschool.nl/template-scaffolding/) — PR-based migration 패턴
+
+### Backstage Software Catalog (Spotify 오픈소스)
+
+- [Authorizing scaffolder tasks, parameters, steps, and actions — Backstage Docs](https://backstage.io/docs/features/software-templates/authorizing-scaffolder-template-details/) — 권한/idempotency 패턴
+- [Backstage scaffolder template composability — Issue #15241](https://github.com/backstage/backstage/issues/15241) — 템플릿 합성성 토론
+- [Top Backstage Plugins for Infrastructure Automation (2026 Edition)](https://stackgen.com/blog/top-backstage-plugins-for-infrastructure-automation-2026-edition)
+
+### 참고 도구 (search 결과 미직접 포함, 검토자가 추가 참조)
+
+- **Cookiecutter `cruft`** — https://github.com/cruft/cruft — 템플릿 drift 자동 감지 + 사용자 override 보존하며 upstream merge. 이 제안의 영감 모델.
+- **Yeoman** — https://yeoman.io/ — generator-based scaffold update flow
+- **Copier** — https://copier.readthedocs.io/ — modern template update with versioning
+
+## MoAI-ADK Internal References (검토에 필수)
+
+### Constitution & Rules
+
+- `.claude/rules/moai/core/moai-constitution.md` — TRUST 5 + AskUserQuestion 규칙
+- `.claude/rules/moai/development/skill-authoring.md` — Skill YAML frontmatter 스키마
+- `.claude/rules/moai/development/coding-standards.md` — Template-First, thin command 패턴
+- `.claude/rules/moai/design/constitution.md` — Frozen vs Evolvable zone 정책 (이 제안의 안전성 모델 영감)
+
+### Existing Harness Infrastructure
+
+- `.claude/skills/moai-meta-harness/SKILL.md` — 7-Phase harness workflow (Apache 2.0 from revfactory/harness)
+- `.claude/skills/moai-harness-learner/SKILL.md` — Tier 4 진화 메커니즘
+- `.claude/agents/moai/builder-harness.md` — Unified artifact factory (agents/skills/plugins/commands/hooks/MCP/LSP)
+
+### CLAUDE.local.md (Local Development Guide)
+
+- §2 Protected Directories — `.claude/`, `.moai/project/`, `.moai/specs/` 보호 규칙
+- §15 16-language Neutrality — `internal/template/templates/` 언어 중립성 강제
+- §18 Enhanced GitHub Flow — branch/merge/release 표준
+
+## How to Use This References File
+
+검토자는:
+
+1. 먼저 Anthropic 공식 plugin docs (상단 4개 URL) 을 읽어 marketplace/scope 이해
+2. Hugo update + DevOps School template scaffolding 패턴으로 drift detection 모범 사례 확인
+3. `cruft` 모델을 별도 검색하여 3-way merge + version pinning 메커니즘 학습
+4. MoAI internal references는 제안의 제약사항 (constitutional, 16-lang 등) 이해를 위해 참조

--- a/.moai/brain/IDEA-003/ideation.md
+++ b/.moai/brain/IDEA-003/ideation.md
@@ -1,0 +1,293 @@
+# IDEA-003 Ideation — 3-Tier Catalog + Safe Update Sync
+
+> Generated: 2026-05-12 · Phase 4 (Converge) + Phase 5 (Critical Evaluation) of `/moai brain`
+
+## Converged Concept
+
+**"Lean Core + Opt-in Packs + Harness Auto-Gen + cruft-style Safe Sync"**
+
+moai-adk의 skill/agent 카탈로그를 3-tier 구조로 재편한다:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Tier 1 — Core (always deployed)                            │
+│  • Workflow-* 13 + Foundation-* 4 + moai 1 = 18 skills      │
+│  • manager-* 8 + evaluator-active + plan-auditor +           │
+│    핵심 expert-* (backend/frontend/security/refactoring/    │
+│    performance) + builder-harness = ~15 agents              │
+│  • moai init / moai update 시 항상 동기화                    │
+└─────────────────────────────────────────────────────────────┘
+                            │
+                            ▼
+┌─────────────────────────────────────────────────────────────┐
+│  Tier 2 — Optional Packs (opt-in install)                   │
+│  • moai pack add backend / frontend / mobile / chrome-ext / │
+│    auth / deployment / design (brand+copywriting+handoff)   │
+│  • Anthropic marketplace 표준 활용 (/.claude/plugins/)       │
+│  • moai update 시 install된 pack만 동기화                    │
+└─────────────────────────────────────────────────────────────┘
+                            │
+                            ▼
+┌─────────────────────────────────────────────────────────────┐
+│  Tier 3 — Harness-Generated (project-local)                 │
+│  • my-harness-* skills, .claude/agents/my-harness/*         │
+│  • /moai project 인터뷰에서 자동 제안 (opt-out)              │
+│  • moai update 시 절대 보존 (frozen zone)                    │
+└─────────────────────────────────────────────────────────────┘
+
+                  ╔═══════════════════════════════╗
+                  ║  Safety: moai update --sync   ║
+                  ║  (cruft-style drift detection) ║
+                  ╚═══════════════════════════════╝
+```
+
+## Lean Canvas (9 blocks)
+
+### 1. Problem
+
+신규 moai-adk 설치 시 모든 36 skills + 29 agents가 deploy되어:
+
+- **Context budget 압박**: Anthropic의 skill description budget = context window 1%. Opus 4.7 1M의 1% = 10K tokens. 사용자가 marketplace plugin 추가 시 즉시 overflow → MoAI 자체 skill의 trigger 정확도 저하
+- **사용 안 하는 자산 노이즈**: Chrome-extension, Electron, mobile 등 도메인 미사용 프로젝트도 모두 deploy됨
+- **harness 인프라 미활용**: 동적 skill/agent 생성 능력이 이미 있는데도 정적 deploy
+- **moai update 위험**: 카탈로그가 비대해질수록 update 시 사용자 변경 손실 위험 증가
+
+### 2. Customer Segments
+
+- **(주) 신규 moai-adk 설치자**: `moai init`으로 새 프로젝트 시작하는 모든 개발자
+- **(주) 기존 프로젝트 maintainer**: 이미 moai-adk를 도입한 프로젝트의 owner — `moai update` 안전성이 최우선
+- **(부) MoAI core contributor**: 카탈로그를 유지보수하는 사람 — 코어/팩 경계가 명확해야 추가/제거 결정 가능
+
+### 3. Unique Value Proposition
+
+**"Lean by Default, Grow by Choice — moai update에서 0 손실 보장"**
+
+- 기본 설치 = 코어 18 skills + 15 agents (현재 대비 -50%)
+- 도메인 팩은 `moai pack add` 1줄 명령으로 추가
+- harness가 프로젝트 인터뷰로 맞춤 자산 자동 생성
+- `moai update`는 cruft-style drift 감지 + 사용자 확인 + 자동 백업 → 데이터 손실 0
+
+### 4. Solution
+
+#### 4.1 카탈로그 재배치 (코드 변경)
+
+`internal/template/templates/.claude/skills/` 구조:
+
+```
+.claude/skills/
+├── moai/                          # 코어 (always)
+├── moai-foundation-{cc,core,quality,thinking}/  # 코어 4개
+├── moai-workflow-*/               # 코어 13개 (워크플로우 진입)
+├── moai-meta-harness/             # 코어 (harness 엔진 자체)
+├── moai-harness-learner/          # 코어 (Tier 4 진화)
+└── # 옵션 팩은 별도 디렉토리로 이동:
+    # internal/template/packs/
+    #   ├── backend/.claude/skills/moai-domain-backend/
+    #   ├── frontend/.claude/skills/moai-domain-frontend/
+    #   │                            moai-domain-database/
+    #   │                            moai-ref-react-patterns/
+    #   ├── mobile/
+    #   ├── chrome-extension/
+    #   ├── auth/
+    #   ├── deployment/
+    #   └── design/.claude/skills/moai-domain-{brand-design,copywriting,design-handoff}/
+    #                              moai-design-system/
+    #                              moai-workflow-{design-context,design-import,gan-loop}/
+```
+
+`internal/template/templates/.claude/agents/moai/` 구조:
+
+```
+agents/moai/
+├── builder-harness.md             # 코어 (모든 builder 통합)
+├── manager-*.md                   # 코어 8개
+├── evaluator-active.md            # 코어
+├── plan-auditor.md                # 코어
+├── expert-{backend,frontend,security,refactoring,performance}.md  # 코어 5개
+└── # 옵션:
+    # internal/template/packs/<pack>/.claude/agents/moai/
+    #   expert-{mobile,devops,testing,debug}.md
+    #   manager-brain.md (brain workflow 사용자만)
+    #   researcher.md (research-heavy 프로젝트)
+    #   claude-code-guide.md
+```
+
+#### 4.2 `moai pack` 명령어 (신규)
+
+```
+moai pack add <name>      # 팩 install → .claude/skills/+agents/에 카피
+moai pack add backend frontend design   # 다중 install
+moai pack remove <name>   # 팩 uninstall (사용 중이면 경고)
+moai pack list            # 설치된 팩 목록
+moai pack available       # 설치 가능한 팩 목록 (built-in + marketplace)
+```
+
+#### 4.3 `moai update --catalog-sync` 안전 동기화
+
+cruft 모델 기반:
+
+1. **Snapshot**: 현재 `.claude/` 와 `.moai/config/`를 `.moai/cache/catalog-snapshot-{timestamp}/`에 백업
+2. **Compute drift**:
+   - 코어 자산의 사용자 직접 수정 감지 (hash 비교)
+   - 사용자 추가 자산 (`my-harness-*`, 사용자 custom skill/agent) 식별
+   - 코어에서 제거된 자산이 어디서 사용 중인지 grep 분석
+3. **Plan**: drift 보고서 + 동기화 plan을 AskUserQuestion으로 표시
+   - "코어 자산 N개 업데이트 (사용자 수정 M개 발견 — 어떻게 처리?)"
+   - "옵션 팩 P개 자동 동기화"
+   - "사용자 추가 자산 Q개 절대 보존"
+4. **Apply**: 사용자 승인 후 적용. 실패 시 snapshot으로 rollback
+5. **Audit**: `.moai/cache/catalog-sync-{timestamp}.log` 에 모든 변경 기록
+
+#### 4.4 `/moai project` harness opt-out 자동 제안
+
+`/moai project` Socratic 인터뷰 끝부분에 추가:
+
+```
+ToolSearch(query: "select:AskUserQuestion")
+AskUserQuestion({
+  question: "프로젝트 도메인에 맞는 맞춤 스킬/에이전트를 harness로 생성하시겠습니까?",
+  options: [
+    { label: "예 (권장)", description: "moai-meta-harness가 인터뷰 결과 기반으로 my-harness-* skills + .claude/agents/my-harness/* 생성. 도메인 특화 안내가 즉시 동작." },
+    { label: "아니오, 기본 코어만 사용", description: "코어 18 skills만 사용. 필요 시 나중에 `moai pack add` 또는 `/moai harness` 수동 호출 가능." },
+    { label: "팩만 install, harness는 생략", description: "프로젝트 유형 기반 도메인 팩만 install (예: backend). 동적 생성 없음." }
+  ]
+})
+```
+
+기본값 = "예". 거부 시 코어만, 또는 팩 선택만.
+
+### 5. Channels
+
+- `moai init <project>` — 신규 프로젝트는 코어만 deploy + 인터뷰 시작
+- `moai update [--catalog-sync]` — 기존 프로젝트 안전 동기화
+- `moai pack {add|remove|list|available}` — 신규 명령어
+- `/moai project` — harness opt-out 자동 제안 (기존 명령 확장)
+- `/moai harness` — 수동 harness 실행 (기존 entry point 유지)
+- `moai doctor catalog` — 카탈로그 상태 + budget 진단 (기존 doctor 확장)
+
+### 6. Revenue Streams
+
+N/A (오픈소스 MIT license).
+
+### 7. Cost Structure
+
+| 항목 | 영향 |
+|------|------|
+| 코드 변경 (`internal/template/`) | 큼 — pack 디렉토리 신설 + deploy 로직 분기 |
+| `moai pack` 명령 추가 | 중 — 신규 CLI subtree (≈200-300 LOC) |
+| `moai update --catalog-sync` 재설계 | **매우 큼** — drift 감지, 백업, rollback, AskUserQuestion 흐름 모두 신규. 가장 위험 영역. |
+| `/moai project` 인터뷰 확장 | 작 — AskUserQuestion 한 라운드 추가 |
+| 마이그레이션 가이드 + CHANGELOG | 중 — 4개국어 docs-site sync (§17 규칙) |
+| 테스트 (특히 update 안전성) | 매우 큼 — drift 모든 시나리오 (수정/추가/삭제 교차) |
+
+### 8. Key Metrics
+
+1. **코어 크기**: 36 → 18 skills (-50%), 29 → 15 agents (-48%)
+2. **신규 설치 후 첫 /moai brain 호출 컨텍스트**: 사용 안 하는 skill description으로 인한 노이즈 감소 (정량 측정 — A/B testing pattern from `.claude/rules/moai/development/skill-ab-testing.md`)
+3. **`moai update` 사용자 보고 손실 사례**: 0 (절대 목표)
+4. **harness 활성화율**: opt-out 비율 < 20% (사용자가 harness 가치 인식)
+5. **pack 평균 설치 수**: 신규 프로젝트당 2-3개 (over-installation 방지)
+
+### 9. Unfair Advantage
+
+- **Anthropic 공식 plugin marketplace 표준 위에 얹음** — 자체 메커니즘 발명 비용 0, cross-tool 호환 (Cursor, Gemini CLI 등)도 보너스
+- **harness가 이미 동작** — `moai-meta-harness` + `builder-harness` + `moai-harness-learner` 인프라 완성. 정리만 하면 즉시 이점
+- **cruft / Backstage PR-based migration 패턴이 검증된 표준** — 안전성 설계의 invariant가 명확
+
+---
+
+## Phase 5: Critical Evaluation
+
+### 5.1 Adversarial Evaluation
+
+#### 비판 1: "코어 18개도 너무 크지 않은가?"
+
+대안 — 코어를 더 줄여 foundation 4개 + moai 1개 = 5개만.
+
+**반론**:
+- Workflow-* 13개는 `/moai plan`, `/moai run`, `/moai sync` 등 모든 핵심 명령의 진입점. 이걸 코어에서 제외하면 `/moai plan` 호출 시 즉시 fail 또는 추가 install 마찰 발생.
+- Anthropic 공식 marketplace의 13개 plugin도 같은 패턴 (workflow 진입은 코어).
+- `moai-meta-harness` 와 `moai-harness-learner` 가 코어에 있어야 사용자가 "harness 사용하시겠습니까?" 인터뷰를 처음부터 받음.
+
+→ 18개가 **함수적 최소(functional minimum)**. 5개로 줄이면 첫 사용 마찰이 큼.
+
+#### 비판 2: "사용자가 코어 자산을 직접 수정했다면 `moai update`가 어떻게 처리?"
+
+이게 **가장 위험한 시나리오**. 사용자가 `.claude/skills/moai-workflow-plan/SKILL.md`를 직접 편집하여 자기 사용 패턴에 맞춤. moai update가 이를 overwrite하면 손실.
+
+**대응 (cruft 모델 적용)**:
+1. moai update 시 코어 자산마다 hash 계산 → 이전 배포 시 hash와 비교
+2. hash가 다르면 = 사용자 수정 → **3-way merge 시도** (이전 / 현재 사용자 / 신규 upstream)
+3. merge 충돌 시 사용자에게 AskUserQuestion으로 옵션 제시:
+   - "사용자 버전 유지 (upstream 무시)" — 안전, 그러나 신규 기능 누락
+   - "Upstream 적용 (사용자 변경 백업 후 덮어쓰기)" — 신규 기능 흭득, 백업으로 복구 가능
+   - "수동 merge 도우미 표시" — diff 출력 후 사용자가 직접 결정
+4. 모든 사용자 수정은 `.moai/cache/user-overrides/{path}` 에 영구 백업 (deletion 없음)
+
+#### 비판 3: "harness가 잘못된 skill을 생성하면?"
+
+`moai-meta-harness`의 출력 품질은 인터뷰 답변에 의존. 사용자가 모호하게 답하면 부정확한 skill 생성 가능.
+
+**대응**:
+- harness 생성 자산은 `.claude/skills/my-harness-*/` 로 명확히 격리 → 삭제 쉬움
+- `moai harness rollback` 명령으로 즉시 복구 가능 (기존 `moai harness rollback <date>` 인프라 활용)
+- 생성 후 사용자에게 즉시 review AskUserQuestion (현재 `moai-harness-learner`의 Tier 4 패턴과 동일)
+
+#### 비판 4: "옵션 팩이 진정 도움이 되는가, 아니면 노이즈?"
+
+사용자가 backend 프로젝트를 시작했다고 가정. 자동으로 `moai pack add backend` 제안 → 5개 skill 추가. 그러나 진짜 필요한 건 1-2개 일 수 있음.
+
+**대응**:
+- 팩 단위로 묶는 대신 **개별 skill install 도 허용**: `moai skill add moai-domain-backend`
+- 팩은 "추천 묶음", 개별 skill은 "정밀 install"
+- /doctor catalog 명령이 6개월간 한 번도 trigger되지 않은 skill을 "유휴(idle)" 표시 → uninstall 제안
+
+#### 비판 5: "왜 Anthropic 공식 marketplace에 그냥 publish하지 않는가?"
+
+대안 — MoAI 자체 carteralog 없이 Anthropic marketplace에 plugin으로만 publish.
+
+**반론**:
+- MoAI는 **단일 통합 워크플로우 (plan-run-sync, brain, design)** 를 제공하는 메타 시스템. 코어 skills이 서로를 참조하고 의존성이 강함. 개별 plugin으로 분해하면 의존성 그래프가 복잡해짐.
+- 그러나 옵션 팩은 marketplace에 publish 가능: `moai-pack-backend` 등을 marketplace plugin으로 만들면 cross-tool 호환 + 자동 update 이점 흭득.
+
+→ **하이브리드**: 코어는 moai-adk가 직접 배포 (현재 방식 유지), 옵션 팩은 marketplace publish 검토 (Phase 후속 작업).
+
+### 5.2 First Principles Decomposition
+
+**질문: skill이 무엇인가, 본질적으로?**
+
+→ Skill = Claude의 context에 로드되는 instruction set. 그 본질은 "trigger 조건이 충족되면 Claude의 행동을 특정 방향으로 유도하는 텍스트".
+
+**원자 단위로 분해**:
+1. **Trigger** (keywords/agents/phases/paths) → Claude가 언제 이걸 사용해야 하는지
+2. **Description** (frontmatter) → context budget을 차지, trigger 매칭에 사용됨
+3. **Body** (SKILL.md 본문) → trigger 활성화 시 실제로 로드되는 지침
+4. **References** (bundled files) → on-demand로 Claude가 fetch
+
+**도출되는 invariant**:
+- Skill의 **존재 자체가 비용** (description은 항상 budget 차지)
+- Skill의 **활용은 trigger 매칭률에 의존**
+- 결론: **사용 빈도가 낮은 skill일수록 존재 비용 > 활용 가치** → 제거하거나 lazy install
+
+이 invariant가 코어 분류의 객관적 기준:
+- 코어 = 모든 사용자가 거의 항상 사용 (workflow 진입)
+- 옵션 = 도메인별 일부 사용자만 사용 (backend skill은 backend 프로젝트만)
+- harness-generated = 특정 프로젝트에서만 사용
+
+**숨겨진 가정 검증**:
+- 가정 A: "사용자는 자기 도메인을 알고 적절히 install할 능력이 있다" — 위험. 일부 사용자는 모호함. → harness 자동 제안이 안전망.
+- 가정 B: "moai update는 자주 실행된다" — 불확실. → update가 드물게 실행될수록 catalog drift가 누적되어 안전 동기화의 가치 큼.
+- 가정 C: "Anthropic marketplace는 안정적" — 검증 필요. 베타 기능일 가능성. → MoAI는 marketplace 미사용 fallback도 유지해야 함.
+
+### 5.3 Evaluation Summary
+
+| 측면 | 평가 | 보완 |
+|------|------|------|
+| 컨셉 일관성 | 강함 (3-tier가 Anthropic plugin scope와 매칭) | — |
+| 사용자 마찰 | 보통 (harness 자동 제안으로 완화) | — |
+| 구현 난이도 | 높음 (특히 moai update 재설계) | Phase 6의 SPEC 분해로 위험 격리 |
+| 실패 시나리오 | 식별됨 (5가지 비판 + 4가지 대응) | — |
+| 가역성 | 강함 (rollback, snapshot, opt-in 구조) | — |
+| 기존 사용자 영향 | 0 (moai update의 hash diff + 사용자 확인 + 백업) | 대규모 통합 테스트 필요 |
+
+**최종 판단**: 컨셉은 견고. 위험은 `moai update --catalog-sync` 한 곳에 집중되어 있어 SPEC 분해 시 이 영역에 evaluator-active와 통합 테스트를 집중 배치하면 관리 가능.

--- a/.moai/brain/IDEA-003/proposal.md
+++ b/.moai/brain/IDEA-003/proposal.md
@@ -1,0 +1,115 @@
+# IDEA-003 Proposal — Catalog Slimming + Harness-First Distribution
+
+> Generated: 2026-05-12 · Phase 6 of `/moai brain` workflow
+> Primary input: ideation.md · Market grounding: research.md
+
+## Executive Summary
+
+moai-adk의 skill/agent 카탈로그를 3-tier 구조 (Core / Optional Packs / Harness-Generated) 로 재편하고, `moai update`를 cruft-style drift detection 기반 안전 동기화로 재설계한다. 기존 사용자의 손실 0을 절대 목표로 한다.
+
+핵심 산출물:
+- **코어 카탈로그 슬림화** (36 skills → 18 skills, 29 agents → 15 agents, 약 -50%)
+- **옵션 팩 시스템** (`moai pack add <name>`)
+- **harness auto-trigger** (`/moai project` 인터뷰 끝에서 opt-out 제안)
+- **안전 동기화** (`moai update` 가 drift 감지 + 백업 + 사용자 확인 + 자동 rollback)
+
+## Capability Scope (NOT Implementation)
+
+> [HARD] 이 섹션은 능력 (capability) 만 기술. 구현 세부 (Go 코드, 라이브러리 선택 등) 는 후속 SPEC에서 결정. (REQ-BRAIN-011 준수)
+
+### Capability 1: 카탈로그를 명시적 3-tier로 분류한다
+
+- 모든 skill과 agent는 `core` / `optional-pack:<name>` / `harness-generated` 중 정확히 하나의 tier에 속한다
+- tier 정보는 카탈로그 manifest 파일에 선언적으로 기록된다 (`internal/template/catalog.yaml` 형식 등 후속 결정)
+- `moai init`은 기본적으로 core만 deploy
+- `moai update`는 manifest를 기준으로 사용자 환경과의 drift를 계산
+
+### Capability 2: 옵션 팩을 사용자 명령으로 추가/제거할 수 있다
+
+- 신규 명령 `moai pack {add|remove|list|available}`
+- 팩은 "skills + agents + rules + commands" 의 묶음 (Anthropic plugin과 동등한 단위)
+- 초기 팩 후보: backend, frontend, mobile, chrome-extension, auth, deployment, design, devops, testing
+- 팩 install 시 의존 관계 자동 해결 (예: design 팩은 frontend 팩을 권장)
+
+### Capability 3: `/moai project`가 harness 활성화를 자동 제안한다
+
+- 인터뷰 끝에서 AskUserQuestion으로 harness opt-out 선택지 제시 (3 옵션: "예 권장" / "코어만" / "팩만 install")
+- 기본값은 "예". 거부 시 코어만 또는 사용자가 선택한 팩만 install
+- harness 실행 결과는 `.claude/skills/my-harness-*` 와 `.claude/agents/my-harness/` 에 격리
+
+### Capability 4: `moai update`가 catalog drift를 안전하게 동기화한다
+
+- 실행 시 자동 snapshot (`.moai/cache/catalog-snapshot-<timestamp>/`)
+- Drift 카테고리:
+  - **Core 자산의 사용자 직접 수정**: hash 비교로 감지
+  - **사용자 추가 자산** (my-harness-*, custom skill): 절대 보존
+  - **코어에서 제거된 자산**: 사용처 grep 후 사용 중이면 경고
+  - **신규 코어 자산**: 자동 추가
+  - **옵션 팩의 upstream 변경**: install된 팩만 동기화
+- 모든 변경은 AskUserQuestion으로 사용자 승인
+- 적용 실패 시 snapshot으로 자동 rollback
+- Audit log: `.moai/cache/catalog-sync-<timestamp>.log`
+
+### Capability 5: 카탈로그 상태를 진단할 수 있다
+
+- 신규 명령 `moai doctor catalog` (또는 기존 `moai doctor` 확장)
+- 출력: tier별 install 자산 수, context budget 사용량, idle skill (6개월+ 미사용) 목록, drift 여부
+
+### Capability 6: 마이그레이션 문서를 4개국어로 제공한다
+
+- CHANGELOG에 breaking-vs-non-breaking 명시
+- docs-site에 마이그레이션 가이드 (ko/en/ja/zh 4개국어, §17 docs-site 규칙 준수)
+- `moai update`의 첫 실행 시 마이그레이션 안내 출력
+
+## SPEC Decomposition Candidates
+
+> [HARD] 후속 `/moai plan` 워크플로우의 입력. 각 항목은 단일 SPEC ID로 진행 가능한 응집된 scope.
+
+- SPEC-V3R4-CATALOG-001: 3-tier manifest 스키마 정의 + 현재 36 skills / 29 agents의 tier 분류 lock-in (코어/옵션-팩별/harness-gen). 산출: `internal/template/catalog.yaml`, 분류 테이블, lang_boundary_audit_test 와 동급의 `catalog_tier_audit_test.go`
+- SPEC-V3R4-CATALOG-002: 카탈로그 디렉토리 재배치 — `internal/template/templates/.claude/skills/` 와 `agents/`를 코어/팩별 디렉토리로 분리 (`internal/template/packs/<pack>/`). 기존 build 파이프라인 (`make build`) 호환 유지. Go embed 패스 + deploy 로직 분기 반영
+- SPEC-V3R4-CATALOG-003: `moai pack` CLI 명령 (add/remove/list/available) — manifest 기반 install + 의존성 해결 + 충돌 감지. 단위 테스트 + integration 테스트 (`/tmp/test-project` 환경)
+- SPEC-V3R4-CATALOG-004: `moai update --catalog-sync` 안전 동기화 — cruft-style drift detection, 3-way merge, snapshot 백업, AskUserQuestion 흐름, rollback, audit log. **가장 위험**. evaluator-active strict mode + 광범위 시나리오 통합 테스트 필수
+- SPEC-V3R4-CATALOG-005: `/moai project` 인터뷰 확장 — harness opt-out AskUserQuestion 추가, 거부 시 팩 install fallback. 기존 `manager-project` agent + project workflow skill 업데이트
+- SPEC-V3R4-CATALOG-006: `moai doctor catalog` 진단 명령 — tier별 카운트 + context budget 표시 + idle skill 감지 (사용 빈도 추적 hook 검토). README에 사용법 추가
+- SPEC-V3R4-CATALOG-007: 마이그레이션 docs + CHANGELOG + 4개국어 docs-site sync — `adk.mo.ai.kr/migration/v3r4-catalog/` (4개 locale) + 영문/한국어 CHANGELOG + `moai update` 첫 실행 시 인라인 안내
+
+### 권장 실행 순서
+
+```
+Wave 1 (Foundation)
+  ├─ SPEC-V3R4-CATALOG-001 (manifest 스키마)
+  └─ SPEC-V3R4-CATALOG-002 (디렉토리 재배치)
+         │
+Wave 2 (Distribution)
+  ├─ SPEC-V3R4-CATALOG-003 (moai pack)
+  └─ SPEC-V3R4-CATALOG-005 (/moai project 인터뷰)
+         │
+Wave 3 (Safety — 가장 위험)
+  └─ SPEC-V3R4-CATALOG-004 (moai update 안전 동기화)
+         │
+Wave 4 (Polish)
+  ├─ SPEC-V3R4-CATALOG-006 (moai doctor catalog)
+  └─ SPEC-V3R4-CATALOG-007 (마이그레이션 docs 4개국어)
+```
+
+## Acceptance — Brain Phase Exit
+
+이 proposal이 후속 `/moai plan` 워크플로우 입력으로 전달되어야 할 조건:
+
+- [x] Lean Canvas 9 블록 작성
+- [x] 5가지 비판 + 대응 (Phase 5)
+- [x] First Principles 분해
+- [x] 7개 SPEC 후보가 `SPEC-V3R4-CATALOG-NNN` 그래마 준수
+- [x] Tech-stack 가정 없음 (capability만 기술)
+- [x] 가장 위험한 영역 식별 (SPEC-V3R4-CATALOG-004)
+
+## Open Questions for `/moai plan` Phase
+
+다음 결정은 SPEC 작성 시 (`/moai plan SPEC-V3R4-CATALOG-001`) 다룬다:
+
+1. catalog.yaml의 정확한 스키마 (tier, dependencies, conflicts, recommended_with)
+2. 팩 dependency resolution 알고리즘 (linear vs DAG)
+3. moai update의 3-way merge 알고리즘 선택 (git merge-file 호출 vs 자체 구현)
+4. opt-in과 opt-out 비율 측정 telemetry 여부 (privacy 정책 충돌 검토)
+5. Anthropic marketplace publishing 여부 (별도 SPEC으로 분리 가능)
+6. 기존 사용자의 `manager-brain.md`, `expert-mobile.md`, `expert-devops.md` 등을 어느 팩에 넣을지 최종 매핑

--- a/.moai/brain/IDEA-003/research.md
+++ b/.moai/brain/IDEA-003/research.md
@@ -1,0 +1,86 @@
+# IDEA-003 Research — Skill/Agent Catalog 정리 방안
+
+> Generated: 2026-05-12 · Phase 3 of `/moai brain` workflow
+
+## Topic
+
+moai-adk 기본 설치 시 36개 skills + 29개 agents 전체 deploy 대신, 코어만 deploy하고 `moai-meta-harness`가 프로젝트별 필요 자산을 동적 생성하는 구조로 전환. 핵심 제약: **`moai update` 실행 시 기존 프로젝트도 catalog가 안전하게 동기화되어야 함** (사용자 손실 0).
+
+## Key Findings
+
+### Finding 1: Anthropic 공식 Plugin Marketplace는 2026년 표준 인프라
+
+Claude Code는 **plugin** (배포 단위, skills + agents + hooks + MCP 묶음) 과 **skill** (단일 instruction set) 을 명확히 분리했고, 공식 marketplace (`anthropics/claude-plugins-official` repo, 13개 공식 plugin)를 운영합니다. `/plugin marketplace add` 로 GitHub/Git/local/URL 어디서든 marketplace 추가 가능하며 auto-update 옵션 존재.
+
+- Plugin scopes: **marketplace** (built-in) / **user** (`~/.claude/plugins/`) / **project** (`.claude/plugins/`)
+- Plugin trust dialog로 보안 보장
+- Auto-update 후 `/reload-plugins` 알림
+- Cross-tool: SKILL.md는 Cursor, Gemini CLI, Codex CLI, Antigravity IDE에서도 동작 (Agent Skills open standard)
+
+**Implication**: MoAI의 core/optional/harness-generated 3-tier는 이미 Anthropic의 marketplace/user/project scope와 1:1 대응합니다. 별도 메커니즘 발명할 필요 없이 표준 위에 얹습니다.
+
+### Finding 2: Context Budget 1% 룰 = 코어 슬림화의 결정적 정당화
+
+> "Skill descriptions are loaded into context so Claude knows what's available. All skill names are always included, but if you have many skills, descriptions are shortened to fit the character budget. The budget scales at 1% of the model's context window. When it overflows, descriptions for the skills you invoke least are dropped first."
+
+**계산** (Opus 4.7 1M context):
+- 1M × 1% = 10,000 tokens가 skill description 예산
+- 현재 MoAI 36개 skills × 평균 250자 (≈ 70 tokens) = ~2,500 tokens — 아직은 OK
+- 그러나 사용자가 marketplace에서 추가 plugin install 시 즉시 overflow → MoAI 자체 skill의 description이 drop 가능
+- 코어 18개로 줄이면 모든 description이 풀 텍스트로 유지됨 → **trigger 정확도 향상**
+
+`/doctor` 명령으로 budget 상태 확인 가능 (Anthropic 공식 진단 도구).
+
+### Finding 3: Drift Detection은 cruft / Hugo 모델이 검증된 표준
+
+`moai update`의 catalog 동기화 안전성 패턴:
+
+1. **Hugo theme 패턴**: override 파일을 임시 제거 → upstream 비교 → 사용자 결정 후 재적용
+2. **Cookiecutter `cruft`**: 템플릿 변경 자동 drift 감지, 사용자 override 보존하며 upstream 변경 merge
+3. **DevOps School PR-based migration**: 템플릿 변경 → bot이 PR 자동 생성 → 소유자 review → CI 검증 → deploy. 감사 흔적(audit trail) 완전 보존
+4. **Backstage Scaffolder**: 권한/검증/idempotency 분리. 동일 scaffold 반복 실행 corruption 0
+
+**Idempotent + Traceable**은 모든 모던 scaffolding 도구의 공통 invariant.
+
+### Finding 4: Curated Bundles 패턴이 1,234-skill 시대의 표준
+
+3rd-party marketplace는 1,234개 skill을 다 install하지 말고 role-based bundle (예: "Web Wizard" = frontend-design + api-design-principles + lint-and-validate + create-pr) 로 분류해 제공. **사용자는 본인 역할/도메인만 install**.
+
+MoAI에 적용: 코어 18개 + "백엔드 팩", "프런트엔드 팩", "디자인 팩" 등 도메인 팩을 marketplace 형태로. harness가 프로젝트 인터뷰 결과로 적절한 팩을 자동 install.
+
+### Finding 5: Built-in Skills는 이미 존재
+
+`/simplify`, `/batch`, `/debug`, `/loop`, `/claude-api` 등이 Claude Code 기본 번들. 즉 Claude Code 자체가 minimal core + plugin install 모델로 동작 중. MoAI도 이 패턴을 따르면 사용자에게 친숙.
+
+## Implications for MoAI
+
+| 발견 | MoAI 의사결정 영향 |
+|------|-------------------|
+| Anthropic plugin marketplace 존재 | 자체 메커니즘 발명 X. 표준 plugin scopes 활용 |
+| Context budget 1% 룰 | 코어 18개 슬림화는 **성능 최적화이자 trigger 정확도 보장** |
+| cruft drift detection | `moai update --catalog-sync` 는 cruft 모델로 구현 (자동 감지 + 사용자 확인 + 백업) |
+| Curated bundles | "moai pack add backend" 같은 도메인 팩 도입 검토 |
+| /doctor budget 진단 | `moai doctor` 또는 `moai catalog status` 명령에 budget 표시 추가 |
+
+## Limitations of Research
+
+- **cargo-generate, cruft, Yeoman 업데이트 메커니즘 구체 동작 미확인** (검색 결과는 패턴 수준). Phase 5 Critical Evaluation에서 추가 확인 또는 implementation 시 정밀 조사 필요.
+- **Anthropic plugin marketplace의 dependency resolution 동작** (한 plugin이 다른 plugin 요구 시) 미확인. MoAI가 marketplace 출판 시 영향 가능.
+- **Plugin trust dialog의 UX**가 매번 뜨는지, 한 번만인지 확인 필요 (사용자 마찰).
+
+## Sources
+
+- [Anthropic — Discover and install prebuilt plugins through marketplaces (Claude Code Docs)](https://code.claude.com/docs/en/discover-plugins)
+- [Anthropic — Extend Claude with skills (Claude Code Docs)](https://code.claude.com/docs/en/skills)
+- [Anthropic — Agent Skills API Docs](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview)
+- [anthropics/claude-plugins-official — Official plugin marketplace repo](https://github.com/anthropics/claude-plugins-official)
+- [anthropics/skills — Public agent skills repository](https://github.com/anthropics/skills/)
+- [DeepWiki — Claude Code Plugin Marketplace & Discovery](https://deepwiki.com/anthropics/claude-code/4.1-plugin-marketplace-and-discovery)
+- [agensi.io — Claude Code Plugins vs Skills (2026)](https://www.agensi.io/learn/claude-code-plugins-vs-skills-explained)
+- [agensi.io — Claude Code Plugin Marketplace Complete Guide (2026)](https://www.agensi.io/learn/claude-code-plugin-marketplace-guide)
+- [Nimbalyst — Claude Code Plugins: A 2026 Guide](https://nimbalyst.com/blog/claude-code-plugins-guide/)
+- [systemprompt.io — Install Anthropic Marketplace Plugins in Claude Code](https://systemprompt.io/guides/getting-started-anthropic-marketplace)
+- [Brian Coords — WP/Woo Plugin Scaffolding in 2026](https://www.briancoords.com/my-wp-woo-plugin-scaffolding-in-2026/)
+- [DevOps School — Template Scaffolding Meaning, Examples, Use Cases (Feb 2026)](https://www.devopsschool.nl/template-scaffolding/)
+- [Hugo Blox — Update guide (drift handling)](https://bootstrap.hugoblox.com/hugo-tutorials/update/)
+- [Backstage Software Catalog — Scaffolder Authorization](https://backstage.io/docs/features/software-templates/authorizing-scaffolder-template-details/)

--- a/.moai/specs/SPEC-V3R4-CATALOG-001/acceptance.md
+++ b/.moai/specs/SPEC-V3R4-CATALOG-001/acceptance.md
@@ -1,0 +1,181 @@
+# Acceptance Criteria — SPEC-V3R4-CATALOG-001
+
+> **v0.2.0 (plan-auditor iter 1 FAIL 0.72 → 11 defects 반영)**: 카운트 통일 (37 skills + 28 agents = 65 entries), Scenario 6/7 신규 (D6 untracked REQ → AC mapping 보강), Scenario 5 매핑에 REQ-027 추가 (D2), Scenario 4 vacuously-true 명확화 (D4), Quality Gates self-referential plan-auditor 제거 (D10).
+
+Given-When-Then scenarios for the 3-tier catalog manifest. Scenarios derived from EARS Requirements in `spec.md`. Edge cases derived from `research.md` §"Risks & Constraints".
+
+> **Catalog Entry 정의 (spec.md §Overview 와 일관성)**: "Catalog entry" 는 `internal/template/templates/.claude/skills/` 바로 아래 top-level 디렉토리 1개 (**37개**) 또는 `internal/template/templates/.claude/agents/moai/` 바로 아래 `.md` 파일 1개 (**28개**) 를 의미한다. `moai/` 컨테이너는 단일 logical skill 로 취급. **총 65 entries**.
+
+## Scenario 1: Manifest contains all 37 skills + 28 agents with valid tier classification
+
+**Given** the codebase has **37 top-level skill directories** under `internal/template/templates/.claude/skills/` (each containing `SKILL.md` or `skill.md` for legacy reference skills) and **28 agent markdown files** under `internal/template/templates/.claude/agents/moai/` (verified in `research.md` §"Architecture Analysis" + disk verification by `find ... -maxdepth 1 -mindepth 1 -type d | wc -l` = 37 / `find ... -name '*.md' | wc -l` = 28),
+
+**When** the audit test `TestAllSkillsInCatalog` AND `TestAllAgentsInCatalog` execute against the embedded FS,
+
+**Then** every skill directory MUST appear exactly once in `catalog.yaml` under one of three sections (`catalog.core.skills`, `catalog.optional_packs.<pack>.skills`, `catalog.harness_generated.skills`), AND every agent file MUST similarly appear exactly once. Each entry MUST have a `tier` field whose value matches the regex `^(core|optional-pack:[a-z][a-z0-9-]{1,30}|harness-generated)$`. Each entry MUST also have a `path` field (REQ-009) identifying its relative location under `templates/`. Missing entries MUST cause test failure with sentinel `CATALOG_ENTRY_MISSING: <relative-path>`. Invalid tier values MUST cause failure with sentinel `CATALOG_TIER_INVALID: <entry> tier=<value>`. The audit suite as a whole (REQ-014, REQ-015, REQ-016) MUST exist as `internal/template/catalog_tier_audit_test.go`.
+
+> Maps: REQ-CATALOG-001-005, REQ-CATALOG-001-006, REQ-CATALOG-001-009, REQ-CATALOG-001-014, REQ-CATALOG-001-015, REQ-CATALOG-001-016, REQ-CATALOG-001-019.
+
+## Scenario 2: Hash field enables drift detection (foundation for SPEC-004)
+
+**Given** an existing project deployed manifest version `1.0.0` with skill `moai-workflow-spec` recorded as `hash: "abc123...def"` (sha256, 64 lowercase hex chars),
+
+**When** moai-adk-go releases a future manifest version `1.1.0` where the same skill has `hash: "789xyz...456"` (upstream content changed),
+
+**Then** the manifest schema MUST allow SPEC-V3R4-CATALOG-004 (`moai update --catalog-sync`) to detect `"abc123..." != "789xyz..."` as a drift signal. The hash field MUST be the sha256 digest of the normalized source file content (LF line endings, trailing whitespace trimmed, no other transformations). The audit test `TestManifestHashStability` MUST verify that:
+
+- Each entry's `hash` matches regex `^[0-9a-f]{64}$` (sentinel `CATALOG_HASH_INVALID: <entry>` on mismatch).
+- Re-computing the hash on the same source content yields the same value (golden test; sentinel `CATALOG_HASH_UNSTABLE` on instability — required for cross-platform CI Windows/macOS/Linux).
+
+Hash algorithm is **sha256** (selected via OQ6 권장안). The manifest also MUST record `version: "1.0.0"` per entry to provide a semver-based fallback signal when hash collisions or content-equivalent re-encoding occurs.
+
+> Maps: REQ-CATALOG-001-007, REQ-CATALOG-001-008, REQ-CATALOG-001-020, REQ-CATALOG-001-022, REQ-CATALOG-001-023.
+>
+> **User constraint reflection**: 사용자 추가 제약 ("moai update 손실 0") 의 foundation. 본 SPEC 단독으로는 drift 비교 / 사용자 확인 / 자동 백업을 수행하지 않으나, SPEC-V3R4-CATALOG-004 가 본 hash + version 필드를 입력으로 사용하여 안전 동기화 구현.
+
+## Scenario 3: Pack dependency graph is acyclic (DAG invariant)
+
+**Given** the manifest declares the following pack dependencies (example, final assignment in M2):
+- pack `design` declares `depends_on: [frontend]`
+- pack `frontend` declares `depends_on: []`
+- pack `deployment` declares `depends_on: [backend]`
+- pack `backend` declares `depends_on: []`
+
+**When** the audit test `TestPackDependencyDAG` runs DFS-based cycle detection over the declared `depends_on` graph,
+
+**Then** the test MUST pass when the graph is a linear DAG (no back-edge in DFS). If a future contributor introduces `pack frontend: depends_on: [design]` (creating cycle `design → frontend → design`), the audit MUST fail with sentinel `PACK_DEPENDENCY_CYCLE: design <-> frontend` and the CI build MUST block the merge.
+
+> Maps: REQ-CATALOG-001-010, REQ-CATALOG-001-018.
+
+## Scenario 4: Workflow Trigger Coverage — vacuously true at v1 (D4 권장 수정 반영)
+
+**Given** the current `internal/template/templates/.claude/skills/moai/workflows/` directory contains **20 flat `.md` files** (e.g., `plan.md`, `run.md`, `sync.md`, `brain.md`, `clean.md`, `codemaps.md`, `coverage.md`, `db.md`, `design.md`, `e2e.md`, `feedback.md`, `fix.md`, `gate.md`, `github.md`, `loop.md`, `moai.md`, `mx.md`, `project.md`, `review.md`, `security.md`) — NOT subdirectories with `SKILL.md`. Empirical disk check: `grep -r 'required-skills' .claude/skills/moai/workflows/` → **0 matches** (no workflow currently declares `metadata.required-skills` frontmatter),
+
+**When** the audit test `TestWorkflowTriggerCoverage` parses each workflow `.md` file's frontmatter,
+
+**Then** the audit MUST behave as follows per REQ-021's conditional structure:
+- If a workflow's frontmatter declares `metadata.required-skills` (list of skill names), the audit MUST resolve each listed skill against the catalog AND verify the skill's `tier` is either `core` OR `optional-pack:<name>` where the pack is explicitly declared in the workflow's `metadata.required-packs` field, emitting sentinel `WORKFLOW_UNCOVERED: <workflow> requires <skill>` on violation.
+- If a workflow's frontmatter has no `metadata.required-skills` key, the audit MUST pass vacuously (conditional REQ not triggered).
+- At v1 manifest milestone, **all 20 workflows are vacuously true** (none declare the key). Audit GREEN.
+- Future SPEC retrofit (post-CATALOG-007) MAY add `metadata.required-skills` to specific workflows; the test then activates substantive verification automatically without code change.
+
+This treatment is consistent with REQ-021's Event-Driven (conditional) EARS pattern.
+
+> Maps: REQ-CATALOG-001-021.
+>
+> **Note**: This scenario guards against future regression where a contributor moves a heretofore-core skill into `optional-pack:*`, silently breaking a workflow that depended on it. The audit will catch this at CI time once `metadata.required-skills` is retrofitted into workflows. v1 establishes the conditional check infrastructure without breaking the current flat-md layout.
+
+## Scenario 5: Schema validation rejects malformed entries
+
+**Given** a contributor manually edits `catalog.yaml` to introduce (a) an invalid entry with `tier: "invalid-tier-name"` AND `hash: "shorthash"` (not 64 hex chars), AND (b) a tier change on an existing entry without corresponding SPEC ID amendment reference in the PR description, AND (c) a hypothetical optional pack with malformed `marketplace_id: 12345` (integer instead of string),
+
+**When** the manifest is loaded by `internal/template/catalog_loader.go` `LoadCatalog()` OR audit tests execute, AND plan-auditor reviews the PR,
+
+**Then** the system MUST reject the invalid changes by emitting:
+- `CATALOG_TIER_INVALID: <skill-name> tier=invalid-tier-name — allowed: [core, optional-pack:<name>, harness-generated]` (REQ-CATALOG-001-019),
+- `CATALOG_HASH_INVALID: <skill-name> hash=shorthash — expected 64 lowercase hex chars (sha256)` (REQ-CATALOG-001-020),
+- plan-auditor flags the tier-change PR as requiring an explicit SPEC ID amendment reference in the PR description (REQ-CATALOG-001-013), AND
+- `CATALOG_RESERVED_FIELD_INVALID: <pack> marketplace_id` on type violation of reserved optional fields when present (REQ-CATALOG-001-024).
+
+The CI build MUST fail on the audit-detectable items. plan-auditor flags the tier-amendment requirement as PR review feedback (process invariant, not runtime audit).
+
+> Maps: REQ-CATALOG-001-013, REQ-CATALOG-001-019, REQ-CATALOG-001-020, REQ-CATALOG-001-024.
+
+## Scenario 6: Manifest top-level structure is valid (D6 권장 수정 반영 — 신규)
+
+**Given** the binary build embeds `internal/template/catalog.yaml` at expected path,
+
+**When** the manifest is loaded by `LoadCatalog()` AND audit test `TestCatalogManifestPresent` (T3.2) runs,
+
+**Then** the system MUST verify all of the following structural invariants:
+- Exactly one manifest file exists at `internal/template/catalog.yaml` as single source of truth (REQ-CATALOG-001-001).
+- Top-level `version` field is a semver string (e.g., `"1.0.0"`) (REQ-CATALOG-001-002).
+- Top-level `generated_at` field is an ISO 8601 date (e.g., `"2026-05-12"`) (REQ-CATALOG-001-003).
+- Top-level `catalog` object contains exactly three sub-sections: `core`, `optional_packs`, `harness_generated` (REQ-CATALOG-001-004).
+- The audit suite file `internal/template/catalog_tier_audit_test.go` exists and fails CI on integrity violation (REQ-CATALOG-001-014).
+- The manifest schema MAY include reserved optional fields `marketplace_id`, `marketplace_url`, `publisher` at the pack level; when present, audit MUST verify type (string) (REQ-CATALOG-001-024).
+- Running `moai init` with the manifest present deploys every skill and agent through the existing Deployer interface without breaking the pipeline (REQ-CATALOG-001-025; verified via M4-T4.5 read-only check of `internal/template/deployer_test.go` existing test cases all GREEN).
+- If `catalog.yaml` is missing from the binary build, the audit MUST fail with sentinel `CATALOG_MANIFEST_ABSENT` (REQ-CATALOG-001-026).
+
+> Maps: REQ-CATALOG-001-001, REQ-CATALOG-001-002, REQ-CATALOG-001-003, REQ-CATALOG-001-004, REQ-CATALOG-001-014, REQ-CATALOG-001-024, REQ-CATALOG-001-025, REQ-CATALOG-001-026.
+
+## Scenario 7: Pack definition structure is valid (D6 권장 수정 반영 — 신규)
+
+**Given** the manifest declares 9 optional packs under `catalog.optional_packs.<pack-name>` (per OQ2 권장안: `backend`, `frontend`, `mobile`, `chrome-extension`, `auth`, `deployment`, `design`, `devops`, `testing`),
+
+**When** the manifest is loaded by `LoadCatalog()` AND audit tests run schema validation,
+
+**Then** for each pack the system MUST verify:
+- The pack entry under `catalog.optional_packs.<pack-name>` declares all four required fields: `description` (string), `depends_on` (list of pack names, may be empty `[]`), `skills` (list of skill names), `agents` (list of agent names) (REQ-CATALOG-001-011).
+- The pack name conforms to the regex `^[a-z][a-z0-9-]{1,30}$` (lowercase, hyphen-separated, length 2-31) (REQ-CATALOG-001-012).
+
+Invalid pack names or missing required fields MUST cause schema validation failure. Optional reserved fields (`marketplace_id`, `marketplace_url`, `publisher`) are validated for type only when present (cross-link to Scenario 6).
+
+> Maps: REQ-CATALOG-001-011, REQ-CATALOG-001-012.
+
+## Edge Cases
+
+### EC1: Skill exists on disk but missing from catalog.yaml
+
+- **Condition**: A new top-level skill directory `moai-domain-newfeature` is added under `.claude/skills/moai-domain-newfeature/SKILL.md` (per the catalog entry definition: a top-level skills/ directory containing SKILL.md), but the contributor forgets to register it in `catalog.yaml`.
+- **Behavior**: `TestAllSkillsInCatalog` (T3.3) fails with sentinel `CATALOG_ENTRY_MISSING: .claude/skills/moai-domain-newfeature`. CI blocks the merge.
+- **Recovery**: Contributor adds an entry under appropriate tier section (e.g., `catalog.core.skills` or `catalog.optional_packs.<pack>.skills`), runs `gen-catalog-hashes.go` helper to populate the `hash` field, commits the manifest update with the SKILL.md change in the same PR.
+- **Diagnostic**: Sentinel message includes the missing path so the contributor can locate the file. README / CONTRIBUTING.md documents the manifest update workflow (M5 task).
+- **Maps**: REQ-CATALOG-001-005, REQ-CATALOG-001-015.
+
+### EC2: Catalog entry references non-existent skill (orphan)
+
+- **Condition**: A contributor deletes `.claude/skills/moai-legacy-skill/` but forgets to remove the corresponding entry from `catalog.yaml`.
+- **Behavior**: `TestCatalogReferencesValid` (T3.5) fails with sentinel `CATALOG_ENTRY_ORPHAN: <path>` (REQ-CATALOG-001-017). CI blocks the merge.
+- **Recovery**: Contributor removes the orphan entry from `catalog.yaml` in the same PR as the file deletion.
+- **Note**: Orphan entries cause skill resolution failures at deploy time (SPEC-002+003), so detecting them at PR time prevents production breakage.
+- **Maps**: REQ-CATALOG-001-017.
+
+### EC3: Hash field empty or wrong format (not sha256 hex)
+
+- **Condition**: A contributor adds an entry but leaves `hash: ""` (placeholder forgotten) or `hash: "TODO"`.
+- **Behavior**: `TestManifestHashStability` (T3.8) fails with sentinel `CATALOG_HASH_INVALID: <entry>`. Regex `^[0-9a-f]{64}$` mismatch.
+- **Recovery**: Contributor runs `go run internal/template/scripts/gen-catalog-hashes.go --entry <name>` (offline helper, [NEW] file per spec.md §"Files to Modify / Create" — D5 권장 수정 반영) to compute the correct sha256 hash and updates the manifest. Helper also populates `path` field (REQ-CATALOG-001-009) for consistency.
+- **Note**: Helper script computes hash on the normalized file content (LF endings, trailing whitespace trimmed). Documented in `catalog_doc.md` (M5).
+- **Maps**: REQ-CATALOG-001-007 (hash), REQ-CATALOG-001-009 (path), REQ-CATALOG-001-020 (hash regex), REQ-CATALOG-001-022 (stability).
+
+### EC4: Two entries claim the same skill or agent name (collision)
+
+- **Condition**: Contributor accidentally adds `moai-domain-backend` to BOTH `catalog.core.skills` AND `catalog.optional_packs.backend.skills` (e.g., during a refactor).
+- **Behavior**: YAML parsing succeeds (different parent paths). Audit test `TestCatalogNoDuplicateEntries` (T3.10) computes the union of all tier sections; if a single skill name appears in multiple sections, the union size differs from the per-section count sum. The test emits sentinel `CATALOG_DUPLICATE_ENTRY: <skill-name> in [<tier1>, <tier2>]` per REQ-CATALOG-001-027 (D2 권장 수정 반영 — orphan sentinel 의 REQ 보호).
+- **Recovery**: Contributor removes the duplicate from one section. catalog_doc.md (M5) clarifies the invariant: "Every skill/agent MUST appear in exactly one tier section."
+- **Maps**: REQ-CATALOG-001-027.
+
+## Quality Gates
+
+- [ ] `go test ./internal/template/...` passes all audit tests (T3.1–T3.10).
+- [ ] `go vet ./internal/template/...` clean.
+- [ ] `golangci-lint run` passes on new files (catalog_loader.go, catalog_tier_audit_test.go, scripts/gen-catalog-hashes.go).
+- [ ] Test coverage for `internal/template/catalog_loader.go` ≥ 85% (per CLAUDE.local.md §6 critical-package threshold per package).
+- [ ] All 7 Given-When-Then scenarios pass when run individually AND in `t.Parallel()` mode.
+- [ ] All 4 edge cases (EC1–EC4) have corresponding negative test cases in `catalog_tier_audit_test.go`.
+- [ ] No HARD rule violations:
+  - Template-First (CLAUDE.local.md §2): catalog.yaml is in `internal/template/` (build artifact), not in `internal/template/templates/` (user-deployed content). Loader at `internal/template/catalog_loader.go`.
+  - 16-language neutrality (CLAUDE.local.md §15): manifest is language-agnostic (no language-specific entries).
+  - No hardcoded values (CLAUDE.local.md §14): tier enum values centralized as Go const in `catalog_loader.go`.
+- [ ] `catalog.yaml` is valid YAML (parses with `gopkg.in/yaml.v3` cleanly).
+- [ ] CI 6 jobs all green: Lint, Test (ubuntu-latest), Test (macos-latest), Test (windows-latest), Build (linux/amd64), CodeQL.
+- [ ] **Hash stability across platforms**: `TestManifestHashStability` GREEN on all three OSes (Linux/macOS/Windows). Tests against the normalized content invariant in `catalog_doc.md`. Pre-emptively handles CRLF/LF differences (M2-T2.4).
+- [ ] No backward incompatibility: `internal/template/deployer_test.go` existing test cases all GREEN (M4-T4.5). The current `moai init` and `moai update` behavior is unchanged.
+
+## Review Process Checklist (D10 권장 수정 반영 — non-runtime, PR review only)
+
+The following items are not runtime audit checks; they are independent process invariants surfaced to PR reviewers:
+
+- Frontmatter compliance for SPEC documents (spec.md, plan.md, acceptance.md): 9 required fields in spec.md, no legacy aliases (`created`, `updated`, `spec_id`). Verified during plan-auditor independent review.
+- Tier change requires SPEC ID amendment in PR description (REQ-CATALOG-001-013). Verified during plan-auditor independent review at PR review time.
+- Sentinel `CATALOG_DUPLICATE_ENTRY` (REQ-CATALOG-001-027) emits during audit but its root-cause documentation is reviewed in plan-auditor verdict.
+
+## Performance Criteria
+
+- **catalog.yaml load time**: < 50ms cold-load (measured via `LoadCatalog()` benchmark in M4 — `BenchmarkLoadCatalog`). At ~80KB YAML size, `yaml.v3` parsing should complete in 5-10ms.
+- **Audit test suite execution time**: < 5 seconds for the combined `go test -run TestCatalog ./internal/template/` (10 parallel sub-tests T3.1–T3.10, ~65 entries each).
+- **catalog.yaml file size**: 80-120KB at v1.0.0 (consistent with spec.md §"Files to Modify" 800-1200 YAML lines anticipated). 65 entries × ~6 fields × YAML indentation + 9 packs + comments. Hard cap 150KB enforced by audit test `TestCatalogFileSize` (optional, not required by EARS but recommended in M3).
+- **Binary size impact**: < 100KB increase to the final `moai` binary (catalog.yaml is the only new embedded asset). Negligible compared to current ~30MB binary.
+- **Build time impact**: < 100ms increase to `make build` (yaml embed + audit test compilation). Measured against the baseline pre-SPEC build.
+- **Memory footprint at runtime**: `LoadCatalog()` allocates < 200KB heap (65 entries × 3KB struct each). Released after Deploy() phase.

--- a/.moai/specs/SPEC-V3R4-CATALOG-001/plan.md
+++ b/.moai/specs/SPEC-V3R4-CATALOG-001/plan.md
@@ -1,0 +1,153 @@
+# Implementation Plan — SPEC-V3R4-CATALOG-001
+
+> **plan.md v0.2.0 (D3/D4/D8/D11 권장 수정 반영)**: 카운트 통일 (37 skills + 28 agents = 65 entries), workflows flat-md layout 반영 (T3.9 재작성), Estimated Complexity LOC 재계산, T1.1 schema 필드 분류 명확화.
+
+## Goal
+
+3-tier (core / optional-pack / harness-generated) 카탈로그 manifest 스키마를 `internal/template/catalog.yaml` 로 도입하고, **37 skills + 28 agents = 65 entries** 의 tier 분류를 lock-in 하며, `catalog_tier_audit_test.go` 로 무결성을 강제한다. 후속 6개 SPEC 의 foundation 을 확립한다.
+
+> **Catalog Entry 정의 (spec.md §Overview 와 일관성)**: "Catalog entry" 는 `internal/template/templates/.claude/skills/` 바로 아래 top-level 디렉토리 1개 (37개; `moai/` 컨테이너는 단일 logical skill 로 취급) 또는 `internal/template/templates/.claude/agents/moai/` 바로 아래 `.md` 파일 1개 (28개) 를 의미한다. `moai/workflows/*.md`, `moai/team/*.md`, `moai/references/*.md` 등 sub-file 은 `moai` skill 의 모듈로 별도 entry 가 아니다.
+
+## Approach
+
+본 SPEC 은 **데이터 + 검증 + 최소 통합** 의 3-layer 전략을 따른다:
+
+1. **Schema-first**: catalog.yaml 스키마를 먼저 확정 (M1). 후속 6개 SPEC 의 인터페이스를 미리 정의하므로 schema 결정이 가장 중요.
+2. **Data lock-in**: 현재 자산 **65 entries (37 skills + 28 agents)** 를 manifest 에 등록 (M2). research.md 의 Tier Classification Map 을 신뢰할 수 있는 기준으로 채택.
+3. **Audit-driven invariants**: `lang_boundary_audit_test.go` 패턴을 차용한 audit suite 로 schema 위반을 CI 단계에서 차단 (M3). manifest 와 disk 의 drift, pack DAG 순환, tier 오타, hash 형식 모두 자동 검출.
+4. **Minimal integration**: catalog.yaml 로딩은 audit test 와 향후 SPEC 의 입구 (catalog_loader.go) 로만 통합. Deploy() 의 actual filtering 은 SPEC-002 영역으로 격리하여 회귀 위험 최소화 (M4).
+5. **Documentation**: schema docstring + 후속 SPEC cross-reference (M5).
+
+본 SPEC 의 변경은 **현재 deploy 동작에 영향이 0 이어야 한다** (`moai init` 이 여전히 모든 자산을 deploy). manifest 는 selective deploy 의 기반만 제공하며, 실제 selective 동작은 SPEC-002+003 에서 도입.
+
+## Task Decomposition
+
+전체 task ~16개. development_mode 는 quality.yaml 기준 (TDD 가정). 단, 본 SPEC 은 데이터 중심이라 audit test 작성 (M3) 이 TDD-style RED 단계로 적합하지만, manifest 데이터 작성 (M2) 은 절차적 작업이라 GREEN 으로 묶음.
+
+### M1 — Schema 설계 + 결정 lock-in
+
+- T1.1: `catalog.yaml` schema 초안 작성. (D11 권장 수정 반영) 필드 분류:
+  - **Top-level (3)**: `version` (semver string), `generated_at` (ISO 8601), `catalog` (object).
+  - **Catalog sub-sections (3)**: `catalog.core`, `catalog.optional_packs` (map[pack-name]→Pack), `catalog.harness_generated`.
+  - **Per-entry (6)**: `name`, `path`, `tier`, `hash`, `version`, optional `depends_on` (optional-pack 만).
+  - **Per-pack (4 required + 3 reserved optional)**: `description`, `depends_on`, `skills`, `agents`; optional `marketplace_id`, `marketplace_url`, `publisher` (REQ-024).
+- T1.2: Open Question 1-6 권장안을 사용자에게 confirm (Decision Point 1). 결정 결과를 plan.md 본 섹션 끝에 기록.
+- T1.3: 기존 `harness.yaml`/`quality.yaml` manifest 패턴과 schema 호환성 검토 (YAML indentation, version 필드 위치, comment 스타일).
+- T1.4: schema 의 forward-compatibility 검토 — REQ-CATALOG-001-024 (marketplace 필드 reserve) 가 schema 에 자연스럽게 통합되는지 확인.
+
+### M2 — Tier Data Lock-in
+
+- T2.1: research.md §"Tier Classification Map" 의 18개 core skills + 15개 core agents 분류를 catalog.yaml 의 `catalog.core` 섹션에 입력.
+- T2.2: research.md 의 optional-pack 후보 9개 (backend, frontend, mobile, chrome-extension, auth, deployment, design, devops, testing) 를 `catalog.optional_packs` 에 입력.
+- T2.3: harness-generated 자산 (`builder-harness` 등) 을 `catalog.harness_generated` 에 입력.
+- T2.4: 각 entry 의 `hash` 필드를 sha256 으로 계산 (LF endings + trailing whitespace 정규화). 초기 빌드 시 `internal/template/scripts/gen-catalog-hashes.go` (offline 헬퍼) 로 생성.
+- T2.5: 각 entry 의 `version` 필드 초기값 `"1.0.0"` 으로 lock-in. 향후 entry 단위 변경 시 semver bump.
+- T2.6: 9개 pack 의 `depends_on` 그래프 작성 (예: design → frontend, deployment → backend). DAG 검증 (audit M3 가 잡지만, 수동으로 한 번 확인).
+- T2.7: `catalog.version` 필드 = `"1.0.0"`, `generated_at` = `2026-05-12` 로 설정.
+
+### M3 — Audit Suite (TDD RED → GREEN)
+
+- T3.1: `catalog_tier_audit_test.go` 골격 작성 — package 선언, import (`io/fs`, `regexp`, `strings`, `testing`, sha256 패키지), `EmbeddedTemplates()` 호출 패턴 reuse.
+- T3.2: `TestCatalogManifestPresent` — REQ-CATALOG-001-026 강제. embedded FS 에 `internal/template/catalog.yaml` 존재 검증. Sentinel: `CATALOG_MANIFEST_ABSENT`.
+- T3.3: `TestAllSkillsInCatalog` — REQ-CATALOG-001-005 강제. `.claude/skills/` walk + catalog.yaml 의 모든 tier 합집합 비교. Sentinel: `CATALOG_ENTRY_MISSING: <skill-path>`.
+- T3.4: `TestAllAgentsInCatalog` — REQ-CATALOG-001-006 강제. `.claude/agents/moai/` walk + catalog.yaml 합집합 비교. Sentinel: `CATALOG_ENTRY_MISSING: <agent-path>`.
+- T3.5: `TestCatalogReferencesValid` — REQ-CATALOG-001-017 강제. catalog.yaml 의 모든 entry path 가 embedded FS 에 실제 존재하는지 (orphan 검출). Sentinel: `CATALOG_ENTRY_ORPHAN: <path>`.
+- T3.6: `TestCatalogTierValid` — REQ-CATALOG-001-019 강제. tier 값이 `core | optional-pack:<name> | harness-generated` regex 매칭. Sentinel: `CATALOG_TIER_INVALID: <entry> tier=<value>`.
+- T3.7: `TestPackDependencyDAG` — REQ-CATALOG-001-018 강제. 위상정렬 또는 DFS-based 순환 검출. Sentinel: `PACK_DEPENDENCY_CYCLE: <pack-A> <-> <pack-B>`.
+- T3.8: `TestManifestHashStability` — REQ-CATALOG-001-020, 022, 023 강제. 각 entry 의 hash 가 sha256 hex (64 lowercase chars) 형식. 추가: 동일 file content 로 hash 재계산해도 결과 일치 (golden test). Sentinel: `CATALOG_HASH_INVALID: <entry>`, `CATALOG_HASH_UNSTABLE`.
+- T3.9: `TestWorkflowTriggerCoverage` — REQ-CATALOG-001-021 강제 (D4 권장 수정 반영). 현재 `.claude/skills/moai/workflows/` 는 20개 flat `.md` 파일 layout (subdirectory + SKILL.md 아님) 이며, `metadata.required-skills` frontmatter 키는 0건 (`grep -r 'required-skills' .claude/skills/moai/workflows/` → 0 matches). 따라서 본 테스트는 **conditional vacuously-true** 패턴으로 작성: 각 workflow `.md` 파일의 frontmatter 파싱 → `metadata.required-skills` 키 부재 시 통과 (vacuously true) → 키 존재 시 각 의존성을 catalog 에서 resolve 검증 + `metadata.required-packs` 와 cross-check. v1 manifest 단계에서는 모든 workflows 가 vacuously true 통과. 후속 SPEC 이 retrofit 시 자동 활성화. Sentinel: `WORKFLOW_UNCOVERED: <workflow> requires <skill>`.
+- T3.10: `TestCatalogNoDuplicateEntries` — REQ-CATALOG-001-027 강제 (D2 권장 수정 반영, 신규 REQ). skill 또는 agent 이름이 `catalog.core`, `catalog.optional_packs.<pack>`, `catalog.harness_generated` 의 2개 이상 tier section 에 동시 등장하는지 검출. 구현: tier 별 entry 이름 슬라이스 합집합 vs 합계 비교. Sentinel: `CATALOG_DUPLICATE_ENTRY: <name> in [<tier1>, <tier2>]`.
+
+### M4 — Loader + Minimal Integration
+
+- T4.1: `internal/template/catalog_loader.go` 작성. `LoadCatalog(fsys fs.FS) (*Catalog, error)` 함수. yaml.Unmarshal 로 catalog.yaml 파싱.
+- T4.2: `Catalog` struct 정의 — Version, GeneratedAt, Core, OptionalPacks (map[string]*Pack), HarnessGenerated 필드.
+- T4.3: `Catalog.LookupSkill(name string) (*Entry, bool)` + `Catalog.LookupAgent(name string) (*Entry, bool)` accessor 추가 (audit test + 후속 SPEC 의 사용자).
+- T4.4: audit test M3 를 catalog_loader 로 refactor — direct YAML parse 가 아닌 LoadCatalog() 호출. 단일 진실 공급원 유지.
+- T4.5: **현재 Deploy() 흐름 영향 검증** — catalog.yaml 추가가 기존 deploy 결과를 변경하지 않음을 통합 테스트로 확인 (`internal/template/deployer_test.go` 의 기존 케이스가 모두 GREEN 유지).
+
+### M5 — Documentation + Schema Notes
+
+- T5.1: `internal/template/catalog_doc.md` 작성 — schema 필드별 설명, tier 의미, hash 알고리즘 (sha256 정규화 절차), 후속 SPEC cross-reference (`SPEC-V3R4-CATALOG-002/003/004/005/006/007`).
+- T5.2: `catalog.yaml` 내 YAML 주석 — 각 섹션 (core / optional_packs / harness_generated) 시작에 짧은 설명 + IDEA-003 proposal.md 링크.
+
+## Risks & Mitigations
+
+| # | Risk | Likelihood | Impact | Mitigation |
+|---|------|-----------|--------|------------|
+| R1 | catalog.yaml schema 가 후속 SPEC-002~007 와 충돌 (예: SPEC-004 가 hash 형식을 다르게 가정) | 중 | 중 | M1 에서 후속 6 SPEC scope 모두 사전 검토. hash 알고리즘 / depends_on 형식을 OQ 권장안에 명시하여 사용자 confirm. |
+| R2 | hash 알고리즘 선택 (sha256 vs sha1 vs blake3) 로 인한 향후 호환성 부담 | 낮 | 중 | OQ6 권장안 sha256 채택. Go stdlib `crypto/sha256` 사용, 외부 의존성 0. |
+| R3 | audit test 가 너무 strict 해서 dev 마찰 증가 (예: tier 필드 변경마다 다중 sentinel) | 중 | 낮 | sentinel 메시지에 명확한 fix 가이드 포함 (e.g., "add entry to catalog.yaml under tier=<X>"). 초기에는 hard fail, 후속 SPEC 에서 warning option 검토. |
+| R4 | go:embed 변경이 binary 크기 + build 속도 영향 | 낮 | 낮 | catalog.yaml 약 80-120KB 추정 (65 entries × 6 fields). 현재 templates/ 약 1.2MB 대비 6.7-10% 증가. 무시 가능. |
+| R5 | 65 entries (37+28) 의 hash 계산이 build 시간에 영향 | 낮 | 낮 | hash 는 offline 헬퍼 (`internal/template/scripts/gen-catalog-hashes.go`) 에서 1회 계산 후 catalog.yaml 에 정적 저장. build 시 재계산 안 함 (audit test 만 read-only 검증). |
+| R6 | research.md 의 tier 분류 표가 잘못된 자산 매핑 (예: moai-foundation-thinking 을 core 로 분류했으나 실제 의존성은 optional-pack 에 적합) | 중 | 중 | T2.1-T2.6 작성 시 각 자산의 workflow trigger + dependency 를 catalog_doc.md 에 명시. plan-auditor 가 검증. 사용자 검토 (Decision Point 2) 로 최종 confirm. |
+| R7 | catalog.yaml 의 sha256 hash 가 OS 별 line ending 차이 (LF vs CRLF) 로 불일치 | 중 | 낮 | T2.4 의 normalization 절차 (LF endings, trailing whitespace trim) 를 catalog_doc.md 에 명시. audit test (T3.8) 가 hash stability 검증. Windows CI 에서도 GREEN 보장. |
+| R8 | `moai update` 가 본 SPEC 이후에도 모든 자산을 강제 동기화하여 사용자 손실 발생 | 중 | 높음 | **사용자 추가 제약**. 본 SPEC 은 hash 필드만 제공 (drift 감지 입력). 실제 안전 동기화는 SPEC-V3R4-CATALOG-004 에서 구현. 본 SPEC 단독 머지 시 동작 변경 0 (Deploy 흐름 영향 0). |
+| R9 | 신규 skill 추가 시 catalog.yaml 등록 누락 → CI 실패 | 중 | 낮 (의도된 동작) | audit test 의 sentinel 메시지에 정확한 추가 위치 + tier 선택 가이드 포함. README / CONTRIBUTING 에 catalog.yaml 갱신 의무 명시. |
+
+## Open Questions — Recommended Defaults (Decision Point 1)
+
+research.md 의 6 Open Questions 각각에 권장안 제시. 사용자가 Decision Point 1 에서 confirm.
+
+### OQ1: Manifest 파일 위치
+
+- **권장 (옵션 A)**: `internal/template/catalog.yaml` — code-driven, embed 가능, build-time artifact.
+- 대안 B: `.moai/catalogs/core.yaml` + `.moai/catalogs/packs.yaml` (tier 별 분할). 가독성 ↑ but 단일 source-of-truth 위배.
+- 대안 C: `internal/template/templates/.moai/config/sections/catalog.yaml` — 사용자 프로젝트의 `.moai/config/` 에 deploy 됨. 사용자가 직접 편집 가능 but 의도와 충돌 (catalog 는 build metadata).
+- **Rationale**: catalog 는 distribution metadata (사용자 편집 대상 아님). `internal/template/` 외부 단일 파일로 두는 게 single source of truth + Template-First (CLAUDE.local.md §2) 원칙 일관.
+
+### OQ2: Pack 개수 및 이름
+
+- **권장**: 9 packs — `backend`, `frontend`, `mobile`, `chrome-extension`, `auth`, `deployment`, `design`, `devops`, `testing`.
+- 대안: 7 packs (mobile + chrome-extension 통합, devops + deployment 통합).
+- **Rationale**: brain IDEA-003 proposal.md 와 research.md tier 분류표가 9 packs 로 정렬. 추후 사용 빈도 telemetry (SPEC-006) 에서 통합/분할 가능.
+
+### OQ3: Harness auto-activation 기본값
+
+- **권장**: opt-out (`harness_auto_activate: true` 가 manifest 기본값). brain Phase 1 사용자 답변 직접 반영.
+- 대안: opt-in (`harness_auto_activate: false`). 안전성 우선이나 사용자 명시 답변과 상충.
+- **Note**: SPEC-V3R4-CATALOG-005 의 `/moai project` 인터뷰 영역이지만, manifest 에 기본값 필드를 추가하여 후속 SPEC 의 입력으로 제공.
+
+### OQ4: CLI 문법 (manifest 영향 받는 영역만)
+
+- **권장**: `moai pack {add|remove|list|available}` (Git-style 동사 + 객체).
+- **Note**: SPEC-V3R4-CATALOG-003 영역. manifest 자체는 CLI-agnostic 으로 설계 (pack 이름 + depends_on 만 노출).
+
+### OQ5: 기존 프로젝트 migration 전략
+
+- **권장**: non-breaking by default. `moai update` 단독 실행 시 catalog.yaml 만 동기화 (사용자 자산 보존). `--catalog-sync` 명시적 opt-in 으로만 tier-based 재정렬 수행.
+- 대안: aggressive (자동 tier 재배치). 위험: 데이터 손실.
+- **Note**: SPEC-V3R4-CATALOG-004 영역. 본 SPEC 의 manifest 에 `legacy_compat: true` 기본 필드는 두지 않음 (SPEC-004 가 자체 flag 정의).
+
+### OQ6: Hash 알고리즘
+
+- **권장**: **sha256** (Go stdlib `crypto/sha256`, 64 lowercase hex chars 출력).
+- 대안 A: git blob hash (sha1). git 통합 자연스러우나 sha1 collision 우려.
+- 대안 B: blake3. 빠르나 외부 의존성 (`github.com/zeebo/blake3`).
+- **Rationale**: 보안 표준 + stdlib + audit test (T3.8) regex 단순화 (`^[0-9a-f]{64}$`).
+
+## MX Tag Plan
+
+본 SPEC 의 산출물은 catalog.yaml (데이터) + audit test (Go) + loader (Go) + doc (Markdown).
+
+**MX 적용 대상**:
+- `internal/template/catalog_tier_audit_test.go` 의 Sentinel 발신 함수 — @MX:ANCHOR 부착. `lang_boundary_audit_test.go` 선례와 동일. high fan_in 무결성 강제.
+- `internal/template/catalog_loader.go` 의 `LoadCatalog()` — @MX:NOTE 부착. intent 명시 (single source of truth, hash 검증 위임 안 함 — loader 는 parse only).
+- `internal/template/catalog.yaml` — 데이터 파일, MX 태그 불요 (YAML 주석으로 대체).
+
+**MX 코멘트 언어**: `.moai/config/sections/language.yaml` `code_comments: ko` 이지만, SPEC-V3R3-MX-INJECT-001 의 `feedback_mx_tag_language.md` 기준 (2026-05-05): MX 태그 설명은 영문. 단, NOTE/REASON 본문은 ko/en 혼용 가능.
+
+## Estimated Complexity
+
+(D8 권장 수정 반영 — 이전 v0.1.0 의 LOC 추정이 optimistic 했음. catalog.yaml ~600 lines 가 spec.md 의 ~80KB anticipated 와 불일치, audit test ~350 LOC 가 `lang_boundary_audit_test.go` ~250 LOC (9 sub-tests) 대비 underestimate. v0.2.0 은 sentinel discipline + 10 sub-test 기반 재계산.)
+
+- **Task count**: ~17 (M1: 4, M2: 7, M3: 10 (T3.10 신규), M4: 5, M5: 2). sub-task 포함 시 ~26.
+- **LOC delta**:
+  - `catalog.yaml`: **800-1200 lines (~80-120KB)** — 65 entries × ~6 fields × YAML indentation + 9개 pack 정의 + comments. spec.md §"Files to Modify" 와 일관.
+  - `catalog_tier_audit_test.go`: **~450-550 LOC** — 10 sub-tests (T3.1-T3.10), sentinel-based assertions, parallel test 패턴, helper functions (walkSkills, walkAgents, parseManifest, dagCycleDetect). `lang_boundary_audit_test.go` ~250 LOC (9 sub-tests) 대비 entry 65개의 walk + hash 검증 + DAG 추가.
+  - `catalog_loader.go`: ~150-200 LOC — Catalog struct + LoadCatalog + 2 LookupX accessors + yaml.Unmarshal helpers.
+  - `gen-catalog-hashes.go`: ~80-120 LOC — file walker + sha256 + LF normalization + CLI flag parser.
+  - `catalog_doc.md`: ~60-80 lines — markdown documentation.
+  - **Total: ~1500-1900 LOC** (Go + YAML + Markdown).
+- **Risk level**: **Low-Medium** (Wave 1 foundation, deploy 영향 0, audit test 만 새로 fail). 회귀 위험은 R6 (tier 분류 오류) 와 R7 (hash 불안정) 두 곳에 집중되어 audit test 로 자동 검출. LOC 증가에 따라 review 부담은 medium.
+- **사용자 검토 필요 지점**: Decision Point 1 (OQ 6건 권장안 confirm), Decision Point 2 (M2 tier 분류 표 final review).

--- a/.moai/specs/SPEC-V3R4-CATALOG-001/plan.md
+++ b/.moai/specs/SPEC-V3R4-CATALOG-001/plan.md
@@ -141,7 +141,7 @@ research.md 의 6 Open Questions 각각에 권장안 제시. 사용자가 Decisi
 
 (D8 권장 수정 반영 — 이전 v0.1.0 의 LOC 추정이 optimistic 했음. catalog.yaml ~600 lines 가 spec.md 의 ~80KB anticipated 와 불일치, audit test ~350 LOC 가 `lang_boundary_audit_test.go` ~250 LOC (9 sub-tests) 대비 underestimate. v0.2.0 은 sentinel discipline + 10 sub-test 기반 재계산.)
 
-- **Task count**: ~17 (M1: 4, M2: 7, M3: 10 (T3.10 신규), M4: 5, M5: 2). sub-task 포함 시 ~26.
+- **Task count**: ~28 (M1: 4, M2: 7, M3: 10 (T3.10 신규), M4: 5, M5: 2). Grouped into M1-M5 milestones; leaf tasks ~28 including sub-steps.
 - **LOC delta**:
   - `catalog.yaml`: **800-1200 lines (~80-120KB)** — 65 entries × ~6 fields × YAML indentation + 9개 pack 정의 + comments. spec.md §"Files to Modify" 와 일관.
   - `catalog_tier_audit_test.go`: **~450-550 LOC** — 10 sub-tests (T3.1-T3.10), sentinel-based assertions, parallel test 패턴, helper functions (walkSkills, walkAgents, parseManifest, dagCycleDetect). `lang_boundary_audit_test.go` ~250 LOC (9 sub-tests) 대비 entry 65개의 walk + hash 검증 + DAG 추가.

--- a/.moai/specs/SPEC-V3R4-CATALOG-001/research.md
+++ b/.moai/specs/SPEC-V3R4-CATALOG-001/research.md
@@ -1,0 +1,338 @@
+# Research — SPEC-V3R4-CATALOG-001
+
+## Goal
+
+3-tier manifest 스키마를 설계하고, 현재 36개 skills / 29개 agents를 core / optional-pack / harness-generated 으로 분류 lock-in하여 catalog 슬림화 foundation 확립.
+
+---
+
+## Architecture Analysis
+
+### Area 1: `.claude/skills/` & `.claude/agents/` 구조
+
+**36개 Skills 확보 (검증됨)**
+
+`.claude/skills/` 디렉토리의 정확한 skill 목록:
+
+**Foundation (5)**:
+- moai-foundation-cc (compatibility: Designed for Claude Code)
+- moai-foundation-core (description: Foundational principles including TRUST 5, SPEC-First DDD)
+- moai-foundation-quality (description: Code quality orchestrator enforcing TRUST 5 validation)
+- moai-foundation-thinking (description: Creative frameworks + Sequential Thinking MCP)
+- moai-meta-harness (description: Meta-harness skill that designs project-specific agent teams)
+
+**Workflow (13)**:
+- moai-workflow-ci-autofix, moai-workflow-ci-watch
+- moai-workflow-ddd, moai-workflow-design-context, moai-workflow-design-import, moai-workflow-gan-loop
+- moai-workflow-loop, moai-workflow-project, moai-workflow-spec, moai-workflow-tdd, moai-workflow-testing
+- moai-workflow-worktree
+
+**Domain (10)**:
+- moai-domain-backend, moai-domain-brand-design, moai-domain-copywriting, moai-domain-database
+- moai-domain-design-handoff, moai-domain-frontend, moai-domain-ideation, moai-domain-research
+- moai-design-system
+
+**Platform & Reference (8)**:
+- moai-platform-auth, moai-platform-chrome-extension, moai-platform-deployment
+- moai-ref-api-patterns, moai-ref-git-workflow, moai-ref-owasp-checklist, moai-ref-react-patterns, moai-ref-testing-pyramid
+
+**moai (1)**: Orchestrator skill
+
+**29개 Agents 확보 (검증됨)**
+
+`.claude/agents/moai/` 디렉토리:
+
+**Manager Agents (7)**:
+- manager-spec, manager-develop, manager-strategy, manager-quality, manager-docs, manager-project, manager-cycle, manager-ddd, manager-tdd, manager-brain, manager-git (11 files)
+
+**Expert Agents (8)**:
+- expert-backend, expert-frontend, expert-security, expert-devops, expert-mobile, expert-performance, expert-refactoring, expert-testing, expert-debug (9 files)
+
+**Builder & Special (4)**:
+- builder-harness, builder-plugin, builder-skill, builder-agent
+
+**Evaluator & Plan (2)**:
+- evaluator-active, plan-auditor
+
+**Support (6)**:
+- researcher, claude-code-guide, + others = 28 files in moai/
+
+Total: **28 markdown files in `.claude/agents/moai/`** (proposal.md mentions 29; researcher + claude-code-guide + 25 other agents ≈ 27-28 core agent definitions).
+
+### Area 2: Template Deploy 로직
+
+**Go embed pattern** (`internal/template/embed.go`):
+```go
+//go:embed all:templates
+var embeddedRaw embed.FS
+
+// EmbeddedTemplates() returns fs.FS with "templates/" prefix stripped.
+// Embedded path "templates/.claude/agents/..." → ".claude/agents/..."
+```
+
+File: `/Users/goos/MoAI/moai-adk-go/internal/template/embed.go:24-39`
+
+**Deploy mechanism** (`internal/template/deployer.go`):
+- `Deployer` interface: Deploy(ctx, projectRoot, m manifest.Manager, tmplCtx) error
+- `deployer` struct: fsys fs.FS, renderer Renderer, forceUpdate bool
+- `Deploy()` walks embedded FS, validates paths, renders .tmpl files, writes to projectRoot + registers in manifest
+- File: `/Users/goos/MoAI/moai-adk-go/internal/template/deployer.go:14-72`
+
+**Key contract**: 
+- All files tracked in manifest.Manager per deployment
+- .tmpl files rendered with TemplateContext, saved without .tmpl suffix
+- `forceUpdate` flag used by update flow to force overwrite (SPEC-V3R4-CATALOG-004 key)
+
+### Area 3: `moai init` & `moai update` CLI
+
+**init command** (referenced in proposal.md):
+- Uses Deployer to extract embedded templates and deploy to new project
+- Currently deploys all 36 skills + 29 agents
+- Config via wizard/interactive prompts
+- File reference: `internal/cli/` (structure visible but exact init.go not fully read)
+
+**update command** (`internal/cli/update.go:71-100+`):
+- `runUpdate()` function: orchestrates binary update + template sync
+- Manifest-based drift detection framework already in place
+- Flags: --check, --force, --templates-only, --binary, --dry-run, --no-hooks
+- Merge logic delegates to `internal/merge` package
+- File: `/Users/goos/MoAI/moai-adk-go/internal/cli/update.go`
+
+---
+
+## Existing Manifest Patterns (Reference)
+
+**`.moai/config/sections/` YAML structure** (24 files confirmed):
+
+| File | Top-Level Keys | Purpose |
+|------|------|---------|
+| harness.yaml | harness, learning | Harness depth levels (minimal/standard/thorough), evaluator profiles, learner config |
+| quality.yaml.tmpl | quality | LSP gates, coverage targets, development_mode (ddd/tdd) |
+| workflow.yaml | workflow | Team config, execution_mode, phase definitions |
+| language.yaml | language | conversation_language, code_comments, commit_messages |
+| constitution.yaml | constitution | Project technical constraints |
+| design.yaml | design | Design pipeline settings, GAN loop params, sprint contract |
+| user.yaml.tmpl | user | User metadata (email, role) |
+| mx.yaml | mx | @MX tag thresholds, exclude patterns, limits |
+| lsp.yaml.tmpl | lsp | LSP server config per language |
+| runtime.yaml | runtime | Hook paths, execution mode |
+| project.yaml.tmpl | project | Project metadata |
+| gate.yaml | gate | Quality gate phases |
+| db.yaml | db | Database schema ref |
+
+All YAML follow `key: value` structure, nested via YAML indentation. No complex JSON embedding.
+
+**Manifest pattern precedent**: `internal/manifest/` package already manages file registration during deploy. Catalog manifest will follow similar pattern: manifest.yaml or catalog.yaml recording tier, version, hash, dependencies.
+
+---
+
+## Tier Classification Map (Verified)
+
+**Methodology**: Analyze workflow entry points (`/moai plan/run/sync/brain/design` etc) to determine which skills are essential for all users vs optional.
+
+### Core Candidates (18 skills + 15 agents)
+
+| Skill | Category | Used by | Confidence | Tier | Rationale |
+|-------|----------|---------|------------|------|-----------|
+| moai | foundation | All workflows | high | core | Single orchestrator entry point |
+| moai-foundation-core | foundation | all agents, manager-spec | high | core | SPEC-First DDD, TRUST 5 foundation |
+| moai-foundation-cc | foundation | skill authoring, all agents | high | core | Claude Code extension patterns |
+| moai-foundation-quality | foundation | Phase 2 quality gates | high | core | TRUST 5 validation, mandatory gate |
+| moai-foundation-thinking | foundation | manager-strategy, evaluator-active | medium-high | core | Decision making, reasoning framework |
+| moai-workflow-spec | workflow | /moai plan, /moai run, /moai sync | high | core | SPEC execution lifecycle |
+| moai-workflow-project | workflow | /moai project command | high | core | Project initialization interview |
+| moai-workflow-testing | workflow | /moai coverage, test phase | high | core | TRUST 5 tested requirement |
+| moai-workflow-ddd | workflow | /moai run (DDD cycle) | high | core | Behavior-preserving refactoring |
+| moai-workflow-tdd | workflow | /moai run (TDD cycle) | high | core | Test-first development |
+| moai-workflow-loop | workflow | /moai loop command | medium | optional-pack:loop | Iterative error fixing |
+| moai-workflow-worktree | workflow | --worktree flag | medium | optional-pack:git | Parallel SPEC development |
+| moai-ref-api-patterns | reference | backend SPEC, expert-backend | medium | optional-pack:backend | Backend API design |
+| moai-ref-react-patterns | reference | frontend SPEC, expert-frontend | medium | optional-pack:frontend | React component patterns |
+| moai-ref-testing-pyramid | reference | testing phase | medium-high | core | Coverage strategy framework |
+| moai-ref-git-workflow | reference | /moai sync, manager-git | medium | optional-pack:git | Conventional commits, branching |
+| moai-ref-owasp-checklist | reference | security review | medium | optional-pack:security | OWASP validation |
+| moai-meta-harness | workflow | harness auto-generation | high | core | Dynamic skill/agent generation |
+
+**Domain skills** (10 total): All classified as `optional-pack:<domain>` except design-system (dependency of frontend).
+
+**Agent allocation**:
+
+| Agent | Category | Used by | Tier |
+|-------|----------|---------|------|
+| manager-spec | workflow | /moai plan | core |
+| manager-develop | workflow | /moai run | core |
+| manager-strategy | workflow | /moai plan (architecture) | core |
+| manager-quality | workflow | Phase 2.5 quality gate | core |
+| manager-docs | workflow | /moai sync | core |
+| manager-project | workflow | /moai project | core |
+| manager-git | workflow | PR creation, branch mgmt | core |
+| evaluator-active | quality | GAN loop, quality gate | core |
+| plan-auditor | quality | /moai plan audit | core |
+| expert-backend | implementation | run phase (backend) | optional-pack:backend |
+| expert-frontend | implementation | run phase (frontend) | optional-pack:frontend |
+| expert-security | security | /moai review | optional-pack:security |
+| expert-devops | deployment | /moai db, deploy phase | optional-pack:deployment |
+| expert-mobile | implementation | run phase (mobile) | optional-pack:mobile |
+| expert-performance | optimization | profiling, tuning | optional-pack:performance |
+| expert-testing | quality | testing, coverage | optional-pack:testing |
+| expert-refactoring | quality | /moai clean | optional-pack:refactoring |
+| builder-harness | generation | harness synthesis | harness-generated |
+| researcher | research | /moai brain | optional-pack:research |
+
+**Core total**: ~15 agents + 18 skills = 33 core assets.
+
+---
+
+## Audit Test Pattern (Reference)
+
+**Existing audit: `lang_boundary_audit_test.go`** (file: `/Users/goos/MoAI/moai-adk-go/internal/template/lang_boundary_audit_test.go:1-56`)
+
+Three tests enforce SPEC-V3R2-WF-005:
+
+1. **TestNoLangSkillDirectory**: Walks `.claude/skills/`, asserts no `^moai-lang-[a-z-]+$` directories exist.
+   - Sentinel: `LANG_AS_SKILL_FORBIDDEN`
+   - Fan_in: 16 (all language rules depend on this invariant)
+
+2. **TestRelatedSkillsNoLangReference**: Parses SKILL.md frontmatter, checks metadata.related-skills has no `moai-lang-*` references.
+   - Sentinel: `DEAD_LANG_FRONTMATTER_REFERENCE`
+   - Validates cross-skill dependencies
+
+3. **TestLanguageNeutrality**: (inferred) Checks code_comments field enforcement
+
+**Pattern for `catalog_tier_audit_test.go`** (to be implemented):
+
+```go
+// Sentinel: CATALOG_TIER_MISMATCH
+// Three parallel tests:
+
+// Test 1: Catalog manifest exhaustiveness
+// Assert: 36 skills + 29 agents in .claude/skills/ + .claude/agents/moai/
+// ALL appear in catalog.yaml (internal/template/catalog.yaml, new file)
+// with tier field set to exactly one of: "core", "optional-pack:<name>", "harness-generated"
+
+// Test 2: Workflow trigger coverage
+// Assert: Every workflow (/moai plan/run/sync/brain/design/db/project/feedback)
+// has at least one core-tier skill in its entry_point list (hardcoded per skill frontmatter)
+
+// Test 3: Pack dependency consistency
+// Assert: Skills in optional-pack:frontend have no undeclared dependencies on
+// optional-pack:backend skills (dependency DAG is acyclic per pack)
+
+// Test 4: Manifest hash stability
+// Assert: Calling manifest.Checksum(skill) twice returns same hash (not affected by
+// file modification time or metadata field order)
+```
+
+File location: `/Users/goos/MoAI/moai-adk-go/internal/template/catalog_tier_audit_test.go` (to create).
+
+---
+
+## Embedded / Marketplace Compatibility
+
+### Go embed pattern (production ready)
+
+Current `//go:embed all:templates` at compile time includes all .claude/, .moai/, .gitignore files.
+
+**Implication for catalog**: Can create subdirectories `internal/template/templates/catalogs/` or `internal/template/templates/.moai/catalogs/` for tier-specific manifests without additional embed directives — single `all:templates` covers all paths.
+
+### Marketplace publishing (future, not required for SPEC-001)
+
+Anthropic plugin marketplace (@-mentioned in brain/IDEA-003/research.md) uses GitHub as distribution, not npm.
+
+Standard formats referenced:
+- **Agent Skills API** (Anthropic official): skills are .md files with YAML frontmatter (already used)
+- **marketplace.json** (Anthropic): Single manifest file listing all plugins/skills in plugin marketplace
+
+No evidence of marketplace.json currently in codebase (grep: negative). Therefore, publishing is decoupled from SPEC-001 scope; the tier manifest can be internal-only initially.
+
+---
+
+## Risks & Constraints (구현 시 위험)
+
+1. **Embed size explosion**: As catalog.yaml + tier metadata added, binary size grows ~50KB per tier level. Mitigated by: (a) catalog.yaml kept minimal (no large descriptions), (b) tier data per-skill embedded once, not per-deploy.
+
+2. **Backward compatibility**: Existing projects deployed before SPEC-001 have ALL 36 skills. `moai update` must detect this state and preserve all (no forced removal). Risk: If catalog.yaml marks a skill as "harness-only", old project won't auto-remove it. Mitigation: Drift detection in SPEC-004 (moai update) will flag and ask user.
+
+3. **Circular dependencies**: If optional-pack:frontend depends on optional-pack:design, and design depends on frontend, DAG breaks. Audit test #3 catches this. Mitigation: SPEC-001 planning must avoid packs with bidirectional edges; model as strict hierarchy (foundation → core → packs → harness-generated).
+
+4. **Manifest parsing overhead**: Every init/update now parses catalog.yaml. YAML parsing is fast (~1ms for 10KB file), but if catalog.yaml grows >1MB, startup latency visible. Constraint: Keep catalog.yaml <100KB via reference pointers (not embedding full skill bodies).
+
+5. **Git conflict when multiple users update**: If two developers run `moai update` simultaneously, manifest.yaml can get corrupted. Mitigation: SPEC-004 (moai update) implements transactional updates (backup before write, rollback on error).
+
+6. **Skill metadata drift**: If skill frontmatter category changes but catalog.yaml not updated, audit test fails. Mitigation: SPEC-001 implements lock (tier field is immutable post-release; changes via SPEC amendment only).
+
+---
+
+## Recommendations for SPEC-V3R4-CATALOG-001 plan
+
+1. **Manifest schema**: Create `internal/template/catalog.yaml` (or `.moai/catalogs/core.yaml`, `.moai/catalogs/packs.yaml`) with structure:
+
+```yaml
+version: "1.0"
+catalog:
+  core:
+    skills:
+      - name: moai
+        description: "Orchestrator..."
+        version: "3.4.0"
+        hash: "sha256:abc..."  # for drift detection
+      ...
+  optional_packs:
+    backend:
+      description: "Backend development..."
+      skills: [moai-domain-backend, moai-ref-api-patterns, ...]
+      agents: [expert-backend, ...]
+      depends_on: [core]  # ordering for install
+    ...
+  harness_generated:
+    description: "Dynamic team + custom skills..."
+    skills: [my-harness-*]
+    agents: [builder-harness, ...]
+```
+
+2. **Tier assignment**: Use workflow trigger analysis (Area 5 partial results) + user feedback from IDEA-003 to assign all 36+29 to three tiers.
+
+3. **Audit test**: Implement `catalog_tier_audit_test.go` with 4 parallel tests (manifest exhaustiveness, workflow trigger coverage, pack DAG acyclicity, hash stability).
+
+4. **Lock-in mechanism**: Add catalog tier assignment as HARD rule in moai-constitution.md: "All skills/agents MUST have exactly one tier field; changing tier requires SPEC amendment + plan-auditor approval."
+
+5. **Documentation**: Add `internal/template/CATALOG.md` explaining tier system, pack dependencies, harness generation contract, migration path for existing users.
+
+---
+
+## Open Questions (manager-spec가 plan 작성 시 결정)
+
+1. **Manifest location**: `/internal/template/catalog.yaml` (code-driven) vs `.moai/specs/SPEC-V3R4-CATALOG-001/manifest.yaml` (SPEC-driven) vs `.moai/catalogs/core.yaml` (hierarchical per-tier)?
+   - Recommendation: Code-driven (`internal/template/catalog.yaml`); manifests are build artifacts, not specs.
+
+2. **Pack granularity**: How many packs? Current proposal: 9 (backend, frontend, mobile, chrome-extension, auth, deployment, design, devops, testing). Accept or revise based on market analysis?
+
+3. **Harness auto-activation**: When user runs `/moai project`, should harness be enabled by default (opt-out) or disabled (opt-in)?
+   - Proposal says: "예 권장" (default yes). Is this acceptable risk (potential skill bloat) or better as explicit opt-in?
+
+4. **moai pack add UX**: Command syntax: `moai pack add backend` vs `moai add-pack backend` vs `/moai add pack backend`?
+   - Proposal: `moai pack add` pattern (verb-object).
+
+5. **Existing project migration**: After SPEC-001+002 deployed, should `moai update` automatically offer "slim down to core + selected packs" (new UX) or only offer full sync (existing behavior)?
+   - Risk: Too aggressive → user data loss. Too conservative → catalog bloat persists.
+
+6. **Hash algorithm**: Use git blob hash (sha1) or sha256 for catalog drift detection?
+   - Proposal: SHA256 (OWASP alignment, future-proof).
+
+---
+
+## References
+
+- `/Users/goos/MoAI/moai-adk-go/internal/template/embed.go:24-39` — go:embed pattern
+- `/Users/goos/MoAI/moai-adk-go/internal/template/deployer.go:14-100+` — Deploy interface + implementation
+- `/Users/goos/MoAI/moai-adk-go/internal/cli/update.go:71-100+` — update command structure
+- `/Users/goos/MoAI/moai-adk-go/internal/template/lang_boundary_audit_test.go` — Audit test pattern (reference for catalog_tier_audit_test.go)
+- `/Users/goos/MoAI/moai-adk-go/internal/template/templates/.moai/config/sections/harness.yaml` — Harness config schema (version, levels, metadata structure)
+- `/Users/goos/MoAI/moai-adk-go/.moai/brain/IDEA-003/proposal.md` — SPEC decomposition mapping
+- `/Users/goos/MoAI/moai-adk-go/.moai/brain/IDEA-003/research.md` — Market context (Anthropic plugin marketplace, cruft drift model, context budget 1%)
+
+---
+
+**Research Date**: 2026-05-12  
+**Scope**: SPEC-V3R4-CATALOG-001 deep analysis  
+**Status**: Ready for plan phase

--- a/.moai/specs/SPEC-V3R4-CATALOG-001/spec-compact.md
+++ b/.moai/specs/SPEC-V3R4-CATALOG-001/spec-compact.md
@@ -1,0 +1,136 @@
+# SPEC-V3R4-CATALOG-001 — Compact
+
+> Auto-extracted from spec.md + acceptance.md. ~30% token savings for `/moai run`.
+> **v0.2.0**: 11 defects (D1–D11) 반영. 카운트 통일 (37 skills + 28 agents = 65 entries), REQ-027 신규 (duplicate sentinel REQ 보호), REQ-021 vacuously-true (workflows flat-md layout), Scenario 6/7 신규 (untracked REQ → AC mapping), Quality Gates 에서 self-referential plan-auditor 분리.
+
+## Catalog Entry Definition
+
+"Catalog entry" 는 `internal/template/templates/.claude/skills/` 바로 아래의 **top-level 디렉토리 1개** (37개; `moai/` 컨테이너는 단일 logical skill, 내부 `workflows/` / `team/` / `references/` 는 모듈) 또는 `internal/template/templates/.claude/agents/moai/` 바로 아래의 **`.md` 파일 1개** (28개) 를 의미한다. **총 65 entries**.
+
+## EARS Requirements (27)
+
+### Manifest Existence and Schema (Ubiquitous)
+- REQ-CATALOG-001-001: Single source of truth manifest at `internal/template/catalog.yaml`.
+- REQ-CATALOG-001-002: Top-level `version` field (semver string).
+- REQ-CATALOG-001-003: `generated_at` field (ISO 8601 date).
+- REQ-CATALOG-001-004: Top-level `catalog` with three sub-sections: `core`, `optional_packs`, `harness_generated`.
+- REQ-CATALOG-001-005: Every skill under `templates/.claude/skills/` appears once with valid `tier`.
+- REQ-CATALOG-001-006: Every agent under `templates/.claude/agents/moai/` appears once with valid `tier`.
+
+### Per-Entry Drift Detection Metadata (Ubiquitous, sourced from user constraint)
+- REQ-CATALOG-001-007: Each entry has `hash` (sha256 of normalized content — LF, no trailing ws). Skill entries' hash covers root `SKILL.md` / `skill.md` only; sub-files not covered (follow-up SPEC).
+- REQ-CATALOG-001-008: Each entry has `version` (semver, for SPEC-004 drift signal).
+- REQ-CATALOG-001-009: Each entry has `path` (relative to `templates/`).
+- REQ-CATALOG-001-010: Each optional-pack entry has `depends_on` (list, possibly empty).
+
+### Pack Definitions (Ubiquitous)
+- REQ-CATALOG-001-011: Each pack under `catalog.optional_packs.<name>` with `description`, `depends_on`, `skills`, `agents`.
+- REQ-CATALOG-001-012: Pack names match regex `^[a-z][a-z0-9-]{1,30}$`.
+
+### Tier Mutation Constraint (Unwanted Behavior) — D1 권장 수정 반영
+- REQ-CATALOG-001-013: If a contributor changes an entry's `tier` field, plan-auditor SHALL flag the change as requiring explicit SPEC ID amendment reference in PR description (process invariant, plan-auditor enforced at PR review time; not runtime audit).
+
+### Audit Suite (Ubiquitous)
+- REQ-CATALOG-001-014: `internal/template/catalog_tier_audit_test.go` fails CI on integrity violation.
+- REQ-CATALOG-001-015: Every embedded skill has catalog entry. Sentinel: `CATALOG_ENTRY_MISSING: <path>`.
+- REQ-CATALOG-001-016: Every embedded agent has catalog entry. Sentinel: `CATALOG_ENTRY_MISSING: <path>`.
+- REQ-CATALOG-001-017: Every catalog entry references existing path. Sentinel: `CATALOG_ENTRY_ORPHAN: <path>`.
+- REQ-CATALOG-001-018: Pack `depends_on` graph is acyclic (DAG). Sentinel: `PACK_DEPENDENCY_CYCLE: <A> <-> <B>`.
+- REQ-CATALOG-001-019: Tier values match allowed regex. Sentinel: `CATALOG_TIER_INVALID: <entry> tier=<value>`.
+- REQ-CATALOG-001-020: `hash` matches `^[0-9a-f]{64}$`. Sentinel: `CATALOG_HASH_INVALID: <entry>`.
+- **REQ-CATALOG-001-027** (D2 권장 수정 — 신규): Skill/agent appears in >1 tier section. Sentinel: `CATALOG_DUPLICATE_ENTRY: <name> in [<tier1>, <tier2>]`.
+
+### Workflow Trigger Coverage (Event-Driven, conditional) — D4 권장 수정 반영
+- REQ-CATALOG-001-021: When workflow's frontmatter declares `metadata.required-skills` list, audit verifies every listed skill resolves to `core` or explicitly declared `optional-pack:<name>` in `metadata.required-packs`. Sentinel: `WORKFLOW_UNCOVERED: <workflow> requires <skill>`. v1 status: 20 workflows are flat `.md` files with no `metadata.required-skills` key → all vacuously true.
+
+### Hash Stability (State-Driven)
+- REQ-CATALOG-001-022: Same content → same hash (stability).
+- REQ-CATALOG-001-023: Content changes → hash differs.
+
+### Marketplace Forward-Compat (Optional) — D9 권장 수정 반영
+- REQ-CATALOG-001-024: Manifest MAY include reserved optional fields `marketplace_id`, `marketplace_url`, `publisher` at pack level (no current verification requirement). If present, audit SHALL verify type (string). Sentinel: `CATALOG_RESERVED_FIELD_INVALID: <pack> <field>`.
+
+### Backward Compatibility (Unwanted Behavior)
+- REQ-CATALOG-001-025: `moai init` deploy pipeline unchanged by manifest introduction.
+- REQ-CATALOG-001-026: catalog.yaml absent from binary → fail with `CATALOG_MANIFEST_ABSENT`.
+
+## Acceptance Criteria (7 Given/When/Then + 4 Edge Cases) — D6 권장 수정 반영
+
+### Scenario 1: All 37 skills + 28 agents in catalog with valid tier
+- G: 37 skills + 28 agents on disk (verified via find/grep)
+- W: `TestAllSkillsInCatalog` + `TestAllAgentsInCatalog` + audit suite present (T3.2)
+- T: Each entry appears exactly once with `tier` matching `^(core|optional-pack:[a-z][a-z0-9-]{1,30}|harness-generated)$` + valid `path` field. Sentinels: `CATALOG_ENTRY_MISSING` / `CATALOG_TIER_INVALID`.
+- Maps: REQ-005, REQ-006, REQ-009, REQ-014, REQ-015, REQ-016, REQ-019.
+
+### Scenario 2: Hash field enables drift detection (foundation for SPEC-004)
+- G: Manifest v1.0.0 entry hash=A
+- W: Future v1.1.0 entry hash=B (content changed)
+- T: SPEC-004 can detect A≠B as drift. Hash regex `^[0-9a-f]{64}$`. Same content → same hash. Sentinel: `CATALOG_HASH_INVALID` / `CATALOG_HASH_UNSTABLE`.
+- Maps: REQ-007, REQ-008, REQ-020, REQ-022, REQ-023.
+- User constraint reflection: foundation for "moai update 손실 0".
+
+### Scenario 3: Pack dependency graph is acyclic (DAG invariant)
+- G: design→[frontend], frontend→[], deployment→[backend], backend→[]
+- W: `TestPackDependencyDAG` runs DFS
+- T: Linear DAG passes. Cycle (frontend→[design]) fails with `PACK_DEPENDENCY_CYCLE: design <-> frontend`.
+- Maps: REQ-010, REQ-018.
+
+### Scenario 4: Workflow Trigger Coverage — vacuously true at v1 (D4)
+- G: 20 flat `.md` workflows under `moai/workflows/` (no subdirectory + SKILL.md), `grep required-skills` → 0 matches
+- W: `TestWorkflowTriggerCoverage` parses frontmatter conditionally
+- T: Workflow without `metadata.required-skills` key → pass vacuously. Workflow with the key → resolve each dep to `core` or declared `optional-pack:*` in `metadata.required-packs`. v1: all 20 workflows pass vacuously. Future SPEC retrofit auto-activates. Sentinel: `WORKFLOW_UNCOVERED`.
+- Maps: REQ-021.
+
+### Scenario 5: Schema validation rejects malformed entries (D1 + D2 + D9)
+- G: Manual edit `tier: "invalid-tier-name"`, `hash: "shorthash"`, tier change w/o SPEC amendment, `marketplace_id: 12345` (integer)
+- W: `LoadCatalog()` or audit runs, plan-auditor reviews PR
+- T: Reject with `CATALOG_TIER_INVALID` + `CATALOG_HASH_INVALID` + `CATALOG_RESERVED_FIELD_INVALID`. plan-auditor flags tier-change amendment requirement.
+- Maps: REQ-013, REQ-019, REQ-020, REQ-024.
+
+### Scenario 6: Manifest top-level structure is valid (D6 권장 수정 — 신규)
+- G: Binary build embeds `catalog.yaml`
+- W: `LoadCatalog()` + `TestCatalogManifestPresent` (T3.2)
+- T: Exactly 1 manifest at fixed path. Top-level `version` (semver), `generated_at` (ISO 8601), `catalog` with 3 sub-sections. Audit suite file exists. Reserved optional fields type-checked when present. `moai init` deploy pipeline unchanged. Missing catalog.yaml → `CATALOG_MANIFEST_ABSENT`.
+- Maps: REQ-001, REQ-002, REQ-003, REQ-004, REQ-014, REQ-024, REQ-025, REQ-026.
+
+### Scenario 7: Pack definition structure is valid (D6 권장 수정 — 신규)
+- G: 9 optional packs (backend, frontend, mobile, chrome-extension, auth, deployment, design, devops, testing)
+- W: `LoadCatalog()` + schema validation
+- T: Each pack declares `description`, `depends_on`, `skills`, `agents`. Pack names match regex `^[a-z][a-z0-9-]{1,30}$`.
+- Maps: REQ-011, REQ-012.
+
+### Edge Cases
+- **EC1**: Skill on disk missing from catalog → `CATALOG_ENTRY_MISSING`. Recovery: add entry + hash via `gen-catalog-hashes.go` helper.
+- **EC2**: Catalog entry references non-existent skill → `CATALOG_ENTRY_ORPHAN` (REQ-017). Recovery: remove orphan in same PR.
+- **EC3**: `hash: ""` or `hash: "TODO"` → `CATALOG_HASH_INVALID`. Recovery: `internal/template/scripts/gen-catalog-hashes.go --entry <name>` helper. Maps: REQ-007, REQ-009, REQ-020, REQ-022.
+- **EC4**: Same skill in multiple tier sections → `CATALOG_DUPLICATE_ENTRY: <name> in [<tier1>, <tier2>]` (REQ-027, D2). Recovery: remove duplicate.
+
+## Files to Modify / Create
+
+- [NEW] `internal/template/catalog.yaml` — Single source of truth (80-120KB, 800-1200 lines, 65 entries × ~6 fields + 9 packs + comments).
+- [NEW] `internal/template/catalog_tier_audit_test.go` — Audit suite (~450-550 LOC, 10 parallel sub-tests T3.1–T3.10, sentinel-based, includes REQ-027 duplicate test).
+- [NEW] `internal/template/catalog_loader.go` — YAML parser + accessor (`LoadCatalog`, `Catalog.LookupSkill`, `Catalog.LookupAgent`). ~150-200 LOC.
+- [NEW] `internal/template/scripts/gen-catalog-hashes.go` — Offline helper to compute sha256 hashes for catalog.yaml entries (D5 권장 수정 반영 — 이전 v0.1.0 누락 등록). Invoked via `go run internal/template/scripts/gen-catalog-hashes.go [--entry <name>] [--all]`. Normalization: LF + trailing whitespace trim. Used in EC1/EC3 recovery + M2-T2.4 initial hash lock-in. ~80-120 LOC.
+- [NEW] `internal/template/catalog_doc.md` — Schema docstring + hash normalization spec + cross-reference to SPEC-002…007. ~60-80 lines.
+- [MODIFY] `internal/template/embed.go` — **No source changes anticipated**. Existing `//go:embed all:templates` covers external `catalog.yaml` indirectly. Audit-time confirmation only (REQ-026). If gap found, add additive `//go:embed catalog.yaml` directive.
+- [NO MODIFY] `internal/template/deployer.go` — **D7 권장 수정 반영**: SPEC-001 scope 에서 미수정. catalog.yaml load 는 audit + catalog_loader.go 만 사용. Deploy 흐름 manifest 의식 안 함. Tier filtering 은 SPEC-002+003.
+
+## Exclusions (Out of Scope)
+
+- Directory relocation → SPEC-V3R4-CATALOG-002
+- `moai pack` CLI → SPEC-V3R4-CATALOG-003
+- `moai update --catalog-sync` 안전 동기화 → SPEC-V3R4-CATALOG-004 (Wave 3, 최고위험)
+- `/moai project` 인터뷰 확장 → SPEC-V3R4-CATALOG-005
+- `moai doctor catalog` → SPEC-V3R4-CATALOG-006
+- 4개국어 migration docs → SPEC-V3R4-CATALOG-007
+- Tier filtering at deploy time → SPEC-002
+- Workflow `metadata.required-skills` retrofit → future SPEC (post-CATALOG-007). v1 manifest 는 vacuously true (D4).
+- Anthropic Marketplace publishing → future SPEC (TBD)
+- Skill frontmatter `tier:` field → manifest is sole source of truth
+- Skill module sub-files hash coverage → entry root `SKILL.md` / `skill.md` 만, sub-files (`workflows/*.md`, `references/*`) 별도 hash 미지원 (후속 SPEC)
+- Idle skill telemetry → SPEC-006
+
+## Dependencies
+
+- Depends on: (none — Wave 1 첫 SPEC)
+- Blocks: SPEC-V3R4-CATALOG-002 ~ 007 (모두 본 manifest 위에 빌드)

--- a/.moai/specs/SPEC-V3R4-CATALOG-001/spec.md
+++ b/.moai/specs/SPEC-V3R4-CATALOG-001/spec.md
@@ -7,7 +7,7 @@ updated_at: 2026-05-12
 author: GOOS행님
 priority: High
 labels: [catalog, manifest, tier, audit, infrastructure]
-issue_number: null
+issue_number: 859
 ---
 
 # SPEC-V3R4-CATALOG-001: 3-Tier Catalog Manifest

--- a/.moai/specs/SPEC-V3R4-CATALOG-001/spec.md
+++ b/.moai/specs/SPEC-V3R4-CATALOG-001/spec.md
@@ -1,0 +1,206 @@
+---
+id: SPEC-V3R4-CATALOG-001
+version: "0.2.0"
+status: draft
+created_at: 2026-05-12
+updated_at: 2026-05-12
+author: GOOS행님
+priority: High
+labels: [catalog, manifest, tier, audit, infrastructure]
+issue_number: null
+---
+
+# SPEC-V3R4-CATALOG-001: 3-Tier Catalog Manifest
+
+## HISTORY
+
+| Version | Date | Author | Description |
+|---------|------|--------|-------------|
+| 0.1.0 | 2026-05-12 | GOOS행님 | Initial draft from /moai brain IDEA-003 (Wave 1 첫 SPEC, manifest schema + tier lock-in) |
+| 0.2.0 | 2026-05-12 | manager-spec | plan-auditor iter 1 FAIL (0.72) 11 defects 반영: D1 (REQ-013 자체 모순 제거), D2 (REQ-027 duplicate sentinel 추가), D3 (37 skills + 28 agents = 65 entries 카운트 통일 + "catalog entry" 정의 명시), D4 (REQ-021 vacuously-true 재작성, workflows flat-md layout 반영), D5 (gen-catalog-hashes.go [NEW] 등록), D6 (15 untracked REQ → AC mapping 보강), D7 (deployer.go no-modify 명확화), D9 (REQ-024 약화). |
+
+## Overview
+
+moai-adk-go 카탈로그 슬림화 initiative (총 7 SPEC) 의 **foundation SPEC**이다. 현재 37 top-level skills 와 28 agents 가 분류 메타데이터 없이 일괄 deploy 되어, 신규 프로젝트는 사용하지 않는 도메인 자산까지 모두 받게 된다. Anthropic skill description budget (context window 의 약 1%) 압박과 `moai update` 시 drift 손실 위험이 누적되어 있다.
+
+본 SPEC 은 **3-tier (core / optional-pack / harness-generated) 카탈로그 manifest 스키마를 정의**하고, 현재 65개 자산 (37 skills + 28 agents) 의 tier 분류를 lock-in 한다. 후속 6개 SPEC (재배치, pack CLI, update 안전 동기화, project 인터뷰, doctor, 마이그레이션 docs) 이 본 SPEC 의 manifest 위에 빌드된다.
+
+**Catalog Entry 정의 (D3 권장 수정 반영):** "Catalog entry" 는 `internal/template/templates/.claude/skills/` 바로 아래의 top-level 디렉토리 1개 또는 `internal/template/templates/.claude/agents/moai/` 바로 아래의 `.md` 파일 1개를 의미한다. 본 SPEC 의 카운트 기준은 다음과 같다:
+
+- **Skills (37)**: `templates/.claude/skills/` 의 top-level 디렉토리 수. `moai/` 컨테이너는 단일 logical skill (그 root 의 `SKILL.md` 가 entry point) 로 취급하며, 내부의 `workflows/`, `team/`, `references/` 는 `moai` skill 의 모듈로 별도 entry 가 아님. 32개는 `SKILL.md` (대문자) 를, 5개 `moai-ref-*` 디렉토리는 `skill.md` (소문자, legacy reference skill 명명) 를 갖는다 — manifest schema 는 둘 다 entry path 로 허용.
+- **Agents (28)**: `templates/.claude/agents/moai/` 직속 `.md` 파일 수 (예: `manager-spec.md`, `expert-backend.md`).
+
+**총 65 entries** (37 + 28). 이 수치는 본 SPEC 의 4개 파일 (spec.md / plan.md / acceptance.md / spec-compact.md) 에서 동일하게 사용된다.
+
+**사용자 추가 제약 (brain Phase 1 응답):** `moai update` 요청 시 기존 프로젝트의 에이전트/스킬은 모두 안전하게 업데이트되어야 하며, 손실은 0 이어야 한다. 본 SPEC 의 manifest 스키마는 후속 SPEC-V3R4-CATALOG-004 의 drift detection 을 가능하게 하는 **hash + version 필드를 반드시 포함**한다.
+
+본 SPEC 의 결과물은 (1) `internal/template/catalog.yaml` manifest 단일 진실 공급원, (2) `internal/template/catalog_tier_audit_test.go` 무결성 강제 audit suite, (3) `internal/template/catalog_loader.go` typed accessor, (4) `internal/template/scripts/gen-catalog-hashes.go` offline hash 생성 헬퍼이다. 실제 디렉토리 재배치, CLI 명령, 안전 동기화는 후속 SPEC 의 scope 이다.
+
+## Background
+
+본 SPEC 의 의사결정 근거 체인:
+
+1. `.moai/brain/IDEA-003/proposal.md` — 7 SPEC 분해 + Wave 순서 (`Wave 1 Foundation → Wave 2 Distribution → Wave 3 Safety → Wave 4 Polish`) 와 hybrid 전략 (코어는 직접 배포, optional pack 은 Anthropic marketplace 검토 가능) 정립.
+2. `.moai/brain/IDEA-003/ideation.md` — Lean Canvas + 5 비판/대응 + First Principles 분해. 핵심 invariant: "skill 의 존재 자체가 비용 (description 은 항상 budget 차지)" → 사용 빈도가 낮은 skill 일수록 존재 비용 > 활용 가치 → lazy install 정당화.
+3. `.moai/specs/SPEC-V3R4-CATALOG-001/research.md` — 37 skills / 28 agents 검증, `internal/template/embed.go` go:embed 패턴, `internal/template/deployer.go` Deploy 인터페이스, `internal/cli/update.go` runUpdate 흐름, `internal/template/lang_boundary_audit_test.go` audit 패턴, 24개 `.moai/config/sections/*.yaml` manifest 선례 모두 분석.
+
+선례 참조:
+- **manifest 패턴**: `.moai/config/sections/harness.yaml` 의 `harness: levels: minimal/standard/thorough` 계층 구조 (research.md §"Existing Manifest Patterns").
+- **audit 패턴**: `internal/template/lang_boundary_audit_test.go` 의 sentinel + parallel test 패턴 (research.md §"Audit Test Pattern (Reference)"), specifically `TestNoLangSkillDirectory` (sentinel `LANG_AS_SKILL_FORBIDDEN`), `TestRelatedSkillsNoLangReference` (sentinel `DEAD_LANG_FRONTMATTER_REFERENCE`).
+- **embed 패턴**: `internal/template/embed.go:24-39` 의 `//go:embed all:templates` — catalog.yaml 을 templates 외부에 두어도 별도 directive 불필요 (단일 embed 가 모든 path 커버).
+- **외부 표준 (참조용, 본 SPEC 도입은 안 함)**: Anthropic Plugin Marketplace 의 `marketplace.json` (research.md §"Embedded / Marketplace Compatibility"). 본 SPEC 은 internal-only manifest 로 출발하고, 마켓플레이스 publishing 은 후속 SPEC 영역으로 격리.
+
+## EARS Requirements
+
+### 1. Manifest Existence and Schema (Ubiquitous)
+
+REQ-CATALOG-001-001: The system shall maintain exactly one catalog manifest file at `internal/template/catalog.yaml` as the single source of truth for skill and agent tier classification.
+
+REQ-CATALOG-001-002: The manifest shall declare a top-level `version` field (semver string) representing the manifest schema version.
+
+REQ-CATALOG-001-003: The manifest shall declare a top-level `generated_at` field (ISO 8601 date) recording when the manifest was last regenerated.
+
+REQ-CATALOG-001-004: The manifest shall organize entries under a top-level `catalog` object containing exactly three sub-sections: `core`, `optional_packs`, and `harness_generated`.
+
+REQ-CATALOG-001-005: Every top-level skill directory present under `internal/template/templates/.claude/skills/` (containing either `SKILL.md` or `skill.md`) shall appear in the manifest exactly once with a `tier` value of either `core`, `optional-pack:<name>`, or `harness-generated`.
+
+REQ-CATALOG-001-006: Every agent file (`.md`) directly under `internal/template/templates/.claude/agents/moai/` shall appear in the manifest exactly once with a `tier` value of either `core`, `optional-pack:<name>`, or `harness-generated`.
+
+### 2. Per-Entry Metadata for Drift Detection (Ubiquitous — sourced from user constraint)
+
+REQ-CATALOG-001-007: Each catalog entry (skill or agent) shall include a `hash` field containing the sha256 digest of the normalized source file content (LF line endings, trailing whitespace trimmed). For skill entries, the hash MUST cover the entry's `SKILL.md` (or `skill.md` for reference skills) only; module sub-files inside the skill directory are NOT covered by this hash (a follow-up SPEC may extend coverage).
+
+REQ-CATALOG-001-008: Each catalog entry shall include a `version` field (semver string) representing the entry's release version, used by SPEC-V3R4-CATALOG-004 to detect upstream changes.
+
+REQ-CATALOG-001-009: Each catalog entry shall include a `path` field (relative to `internal/template/templates/`) identifying the entry's deploy target location.
+
+REQ-CATALOG-001-010: Each optional-pack entry shall include a `depends_on` field (list of pack names, possibly empty `[]`) to enable acyclic dependency resolution in SPEC-V3R4-CATALOG-003.
+
+### 3. Pack Definitions (Ubiquitous)
+
+REQ-CATALOG-001-011: The manifest shall declare each optional pack under `catalog.optional_packs.<pack-name>` with the following fields: `description` (string), `depends_on` (list), `skills` (list of skill names), and `agents` (list of agent names).
+
+REQ-CATALOG-001-012: Pack names shall conform to the regex `^[a-z][a-z0-9-]{1,30}$` (lowercase, hyphen-separated, length 2-31).
+
+### 4. Tier Mutation Constraint (Unwanted Behavior) — D1 권장 수정 반영
+
+REQ-CATALOG-001-013: If a contributor changes an entry's `tier` field in `catalog.yaml`, then the plan-auditor SHALL flag the change as requiring an explicit SPEC ID amendment reference in the pull request description, enforced at PR review time.
+
+> **D1 fix note**: 이전 v0.1.0 의 REQ-013 은 audit suite 가 commit history 를 검증한다고 했으나, audit 은 runtime structural check 이고 history check 가 아님 — 자체 모순. v0.2.0 은 process invariant 를 명시적 plan-auditor 책임으로 재할당. Runtime audit suite (REQ-014..020) 는 manifest 구조만 검증하고, tier 변경 정당성은 PR 리뷰 (plan-auditor) 가 검증한다. 본 REQ 는 verifiable check (PR description 내 `SPEC-` 패턴 grep + tier delta 가 있는 commit 매칭) 로 후속 SPEC-V3R4-CATALOG-004 시점에 자동화 가능하며, 본 SPEC 단계에서는 plan-auditor 가 수동 검증한다.
+
+### 5. Audit Suite (Ubiquitous)
+
+REQ-CATALOG-001-014: The system shall provide a Go test file `internal/template/catalog_tier_audit_test.go` that fails the CI build when manifest integrity is violated.
+
+REQ-CATALOG-001-015: The audit suite shall verify that every top-level skill directory under `.claude/skills/` in the embedded FS has a corresponding entry in `catalog.yaml`, emitting sentinel `CATALOG_ENTRY_MISSING: <path>` on failure.
+
+REQ-CATALOG-001-016: The audit suite shall verify that every agent file under `.claude/agents/moai/` in the embedded FS has a corresponding entry in `catalog.yaml`, emitting sentinel `CATALOG_ENTRY_MISSING: <path>` on failure.
+
+REQ-CATALOG-001-017: The audit suite shall verify that every `catalog.yaml` entry references an existing path in the embedded FS, emitting sentinel `CATALOG_ENTRY_ORPHAN: <path>` on failure.
+
+REQ-CATALOG-001-018: The audit suite shall verify the pack dependency graph is acyclic, emitting sentinel `PACK_DEPENDENCY_CYCLE: <pack-A> <-> <pack-B>` on cycle detection.
+
+REQ-CATALOG-001-019: The audit suite shall verify each entry's `tier` field matches one of the allowed values, emitting sentinel `CATALOG_TIER_INVALID: <entry> tier=<value>` on violation.
+
+REQ-CATALOG-001-020: The audit suite shall verify each entry's `hash` field conforms to the sha256 hex format (64 lowercase hex chars), emitting sentinel `CATALOG_HASH_INVALID: <entry>` on violation.
+
+REQ-CATALOG-001-027: If a skill or agent name appears in more than one tier section (`catalog.core.*`, `catalog.optional_packs.<pack>.*`, `catalog.harness_generated.*`), then the audit suite shall fail with sentinel `CATALOG_DUPLICATE_ENTRY: <name> in [<tier1>, <tier2>]`. (D2 권장 수정 반영 — orphan sentinel 의 REQ 보호.)
+
+### 6. Workflow Trigger Coverage (Event-Driven, conditional — D4 권장 수정 반영)
+
+REQ-CATALOG-001-021: When a workflow skill's frontmatter declares a `metadata.required-skills` field (list of skill names), the audit suite shall verify that every listed skill resolves to a catalog entry whose `tier` is either `core` or `optional-pack:<name>` explicitly declared in the workflow's `metadata.required-packs` field, emitting sentinel `WORKFLOW_UNCOVERED: <workflow> requires <skill>` on violation.
+
+> **D4 fix note**: 이전 v0.1.0 은 workflow trigger coverage 를 unconditional 로 가정했으나, 현재 `internal/template/templates/.claude/skills/moai/workflows/` 의 20개 flat `.md` 파일은 `metadata.required-skills` frontmatter 키가 없음 (grep 결과 0 matches). 따라서 본 REQ 는 Event-Driven (conditional) 패턴으로 재작성되어, 해당 frontmatter 키가 부재한 경우 vacuously true 로 처리된다. 본 SPEC v1 manifest 는 workflow dependency 검증을 skip 하고, 후속 SPEC (TBD, post-CATALOG-007) 이 workflow 에 `metadata.required-skills` 필드를 retrofit 추가하여 실질 검증을 도입할 수 있다. 이 점은 Exclusions 에도 명시.
+
+### 7. Hash Stability (State-Driven)
+
+REQ-CATALOG-001-022: While the source content of a skill or agent file is unchanged (byte-identical after normalization), the regenerated `hash` value shall equal the previous `hash` value.
+
+REQ-CATALOG-001-023: While the source content changes (any byte differs after normalization), the regenerated `hash` value shall differ from the previous `hash` value.
+
+### 8. Optional Marketplace Compatibility (Optional) — D9 권장 수정 반영
+
+REQ-CATALOG-001-024: The manifest schema MAY include reserved optional fields `marketplace_id`, `marketplace_url`, and `publisher` at the pack level (no current verification requirement). If any of these fields are present on a pack entry, then the audit suite SHALL verify that the value conforms to its declared type (string), emitting sentinel `CATALOG_RESERVED_FIELD_INVALID: <pack> <field>` on type violation.
+
+> **D9 fix note**: 이전 v0.1.0 의 "reserved optional fields ... 매 audit 검증" 표현은 audit 으로 검증 불가했음 (필드가 부재해도 통과해야 하므로). v0.2.0 은 두 갈래 (1) 필드는 optional → 부재 OK, (2) 존재 시 type check 만 강제 — 로 명확화. 실제 marketplace 통합은 별도 SPEC 영역.
+
+### 9. Backward Compatibility (Unwanted Behavior)
+
+REQ-CATALOG-001-025: If a user runs `moai init` with the new manifest in place, then every skill and agent currently in the embedded FS shall still be deployable through the existing Deployer interface; the manifest must not break existing deploy pipelines.
+
+REQ-CATALOG-001-026: If catalog.yaml is missing from the binary build, then the audit suite shall fail with sentinel `CATALOG_MANIFEST_ABSENT`, preventing release of an unmanaged build.
+
+## Acceptance Criteria
+
+See `acceptance.md` for the full Given-When-Then scenarios (**7 scenarios + 4 edge cases**, 27 REQ all mapped). High-level acceptance:
+
+- AC-CATALOG-001-01: All 37 top-level skill directories + 28 agent files appear in `catalog.yaml` with a valid tier classification, with `path` field present and audit suite file existing. (maps REQ-CATALOG-001-005, REQ-CATALOG-001-006, REQ-CATALOG-001-009, REQ-CATALOG-001-014, REQ-CATALOG-001-015, REQ-CATALOG-001-016, REQ-CATALOG-001-019)
+- AC-CATALOG-001-02: Drift detection foundation in place: every entry has sha256 hash + semver version. (maps REQ-CATALOG-001-007, REQ-CATALOG-001-008, REQ-CATALOG-001-020, REQ-CATALOG-001-022, REQ-CATALOG-001-023)
+- AC-CATALOG-001-03: Pack dependency graph is acyclic (no circular packs). (maps REQ-CATALOG-001-010, REQ-CATALOG-001-018)
+- AC-CATALOG-001-04: Workflow dependency check is vacuously true at present (no `metadata.required-skills` frontmatter in current workflows); REQ-021 conditional logic active for future retrofit. (maps REQ-CATALOG-001-021)
+- AC-CATALOG-001-05: Schema validation rejects invalid tier values, malformed hashes, duplicate entries, tier changes without SPEC ID amendment, and (when present) malformed reserved marketplace fields. (maps REQ-CATALOG-001-013, REQ-CATALOG-001-019, REQ-CATALOG-001-020, REQ-CATALOG-001-024, REQ-CATALOG-001-027)
+- AC-CATALOG-001-06: Manifest top-level structure is valid (version, generated_at, catalog with 3 sub-sections; audit suite exists; absent manifest triggers `CATALOG_MANIFEST_ABSENT`; reserved optional fields type-checked when present; `moai init` deploy pipeline unchanged). (maps REQ-CATALOG-001-001, REQ-CATALOG-001-002, REQ-CATALOG-001-003, REQ-CATALOG-001-004, REQ-CATALOG-001-014, REQ-CATALOG-001-024, REQ-CATALOG-001-025, REQ-CATALOG-001-026)
+- AC-CATALOG-001-07: Pack definition structure is valid (each pack declares `description`, `depends_on`, `skills`, `agents`; pack names match regex). (maps REQ-CATALOG-001-011, REQ-CATALOG-001-012)
+- AC-CATALOG-001-08: Edge cases (EC1-EC4) cover missing entry, orphan, hash format, duplicate detection. (maps REQ-CATALOG-001-007, REQ-CATALOG-001-009, REQ-CATALOG-001-017, REQ-CATALOG-001-020, REQ-CATALOG-001-022, REQ-CATALOG-001-027)
+
+## Files to Modify / Create
+
+[NEW] `internal/template/catalog.yaml` — Single source of truth manifest (~80-120KB anticipated, schema + 65 entries with hash + version + depends_on). Estimated 800-1200 YAML lines.
+
+[NEW] `internal/template/catalog_tier_audit_test.go` — Audit suite (8-10 parallel sub-tests, sentinel-based assertions following `lang_boundary_audit_test.go` precedent). Estimated 450-550 LOC. Covers REQ-014, 015, 016, 017, 018, 019, 020, 021 (conditional), 022, 023, 024 (when fields present), 026, 027.
+
+[NEW] `internal/template/catalog_loader.go` — Catalog YAML parser + typed accessor (`LoadCatalog(fs.FS) (*Catalog, error)`, `Catalog.LookupSkill(name) (*Entry, bool)`, etc.). Required so audit tests can reuse parsing logic and so SPEC-V3R4-CATALOG-002+ can build atop a typed API. Estimated 180-220 LOC.
+
+[NEW] `internal/template/scripts/gen-catalog-hashes.go` — Offline helper to compute sha256 hashes for catalog.yaml entries. Invoked via `go run internal/template/scripts/gen-catalog-hashes.go [--entry <name>] [--all]`. Normalization: LF line endings, trailing whitespace trimmed. Used in EC1/EC3 recovery flows and during initial M2-T2.4 hash lock-in. Estimated 120-160 LOC. (D5 권장 수정 반영 — 이전 v0.1.0 의 acceptance EC1/EC3/plan T2.4 가 본 헬퍼를 언급했으나 Files to Modify 에 누락되어 있었음.)
+
+[NEW] `internal/template/catalog_doc.md` — Brief schema docstring + tier semantics + hash normalization spec + cross-reference to follow-up SPECs. Markdown, not Go. Estimated 60-80 lines.
+
+[MODIFY] `internal/template/embed.go` — **No source changes anticipated**. The existing `//go:embed all:templates` directive already covers `internal/template/catalog.yaml` (different path) but NOT `catalog.yaml` directly. **Audit-time confirmation only**: test asserts presence of `catalog.yaml` accessible via embed.FS (REQ-CATALOG-001-026). If go:embed coverage gap is found during M1, add a single new directive `//go:embed catalog.yaml` (additive, no removal). This is the only conditional modification.
+
+[NO MODIFY] `internal/template/deployer.go` — **D7 권장 수정 반영**: SPEC-V3R4-CATALOG-001 의 scope 에서는 `deployer.go` 미수정. `catalog.yaml` 의 load 는 audit 테스트 (`catalog_tier_audit_test.go`) 와 별도 `catalog_loader.go` 의 `LoadCatalog()` 함수에서만 사용. Deploy 흐름은 manifest 를 의식하지 않으며, 회귀 검증 (M4-T4.5) 은 `internal/template/deployer_test.go` 의 기존 케이스가 모두 GREEN 임을 확인하는 read-only 검증에 한정. tier 별 filtering 은 SPEC-V3R4-CATALOG-002+003 의 scope.
+
+## Exclusions (What NOT to Build)
+
+The following are explicitly **OUT OF SCOPE** for SPEC-V3R4-CATALOG-001 and deferred to follow-up SPECs:
+
+- **Directory relocation** (`internal/template/templates/` reorganization into `packs/<pack>/`) — SPEC-V3R4-CATALOG-002 영역. 본 SPEC 의 manifest 는 현재 디렉토리 구조 그대로 분류만 기록.
+- **CLI commands** (`moai pack add|remove|list|available`) — SPEC-V3R4-CATALOG-003 영역. manifest 만 제공, 사용자 인터페이스 없음.
+- **Safe update synchronization** (`moai update --catalog-sync`, drift detection runtime, 3-way merge, snapshot/rollback) — SPEC-V3R4-CATALOG-004 영역 (Wave 3, 최고위험). 본 SPEC 은 hash/version 필드만 제공하며, drift 비교 로직은 후속 SPEC.
+- **`/moai project` interview extension** (harness opt-out AskUserQuestion 라운드 추가) — SPEC-V3R4-CATALOG-005 영역.
+- **`moai doctor catalog` diagnostic command** (tier별 install 수, context budget 표시, idle skill 감지) — SPEC-V3R4-CATALOG-006 영역.
+- **4개국어 migration documentation** (CHANGELOG breaking-vs-non-breaking, docs-site ko/en/ja/zh 4-locale sync, `moai update` 첫 실행 시 인라인 안내) — SPEC-V3R4-CATALOG-007 영역.
+- **Tier filtering at deploy time** — `Deploy()` 가 manifest 를 읽지 않으며 tier 별 선별 deploy 도 안 함 (SPEC-V3R4-CATALOG-002 가 디렉토리 재배치 후 구현).
+- **Workflow `metadata.required-skills` retrofit** — 현재 `templates/.claude/skills/moai/workflows/*.md` 는 해당 frontmatter 키 부재. REQ-021 은 conditional 패턴으로 vacuously true. 향후 별도 SPEC 이 workflow 에 dependency 메타데이터를 추가하면 자동으로 활성화. (D4 권장 수정 반영.)
+- **Anthropic Plugin Marketplace publishing** — REQ-CATALOG-001-024 가 forward-compat 필드만 reserve 하고, 실제 publish 워크플로우는 별도 후속 SPEC (TBD).
+- **Skill frontmatter 의 `tier:` 필드 추가** — research.md §"Open Questions" 와 일관성. manifest 가 단독 source of truth 이므로, 개별 SKILL.md 에 tier 필드를 중복으로 적지 않는다. drift 감지는 manifest 의 hash + version 으로 충분.
+- **Skill module sub-files hash coverage** — REQ-007 의 hash 는 entry root 의 `SKILL.md` (또는 `skill.md`) 만 커버. `moai/workflows/*.md`, `moai-foundation-cc/references/*` 등 sub-file 은 별도 hash 미지원 (후속 SPEC 영역).
+- **Idle skill telemetry** (사용 빈도 추적 hook) — SPEC-V3R4-CATALOG-006 의 doctor 명령 영역.
+
+## Dependencies
+
+- **Depends on**: 없음 (Wave 1 의 첫 SPEC, foundation).
+- **Blocks**: SPEC-V3R4-CATALOG-002 (디렉토리 재배치는 본 manifest 의 tier 분류를 입력으로 사용), SPEC-V3R4-CATALOG-003 (`moai pack` 은 manifest 의 `depends_on` 필드로 의존성 해결), SPEC-V3R4-CATALOG-004 (`moai update --catalog-sync` 는 본 SPEC 의 hash/version 필드로 drift 계산), SPEC-V3R4-CATALOG-005, SPEC-V3R4-CATALOG-006, SPEC-V3R4-CATALOG-007.
+
+## References
+
+### Internal (필수 사전 read)
+- `.moai/brain/IDEA-003/proposal.md` — SPEC 분해 + Wave 순서 + Open Questions 6건.
+- `.moai/brain/IDEA-003/ideation.md` — Lean Canvas + Critical Evaluation 5 비판 + First Principles (skill 존재가 비용 invariant).
+- `.moai/specs/SPEC-V3R4-CATALOG-001/research.md` — 37 skills + 28 agents 검증, embed/deploy/update 코드 분석, audit 패턴 reference, tier 분류 표.
+- `.moai/project/product.md` — moai-adk-go 프로젝트 컨텍스트.
+
+### Code Reference
+- `internal/template/embed.go:24-39` — `//go:embed all:templates` 패턴.
+- `internal/template/deployer.go:14-72` — Deploy 인터페이스 + walk + render + manifest 등록 (본 SPEC 미수정).
+- `internal/cli/update.go:71-100+` — runUpdate 흐름 + 기존 drift 감지 framework + merge 위임.
+- `internal/template/lang_boundary_audit_test.go` — audit 패턴 reference (sentinel `LANG_AS_SKILL_FORBIDDEN`, `DEAD_LANG_FRONTMATTER_REFERENCE`, embedded FS WalkDir 패턴).
+
+### Configuration Patterns (선례)
+- `.moai/config/sections/harness.yaml` — manifest version + levels + metadata 계층 구조 reference.
+- `.moai/config/sections/quality.yaml` — yaml manifest 구조 reference.
+- `.moai/config/sections/workflow.yaml` — manifest 의 nested config 패턴 reference.
+
+### Rules
+- `.claude/rules/moai/development/skill-authoring.md` — Skill YAML frontmatter 스키마 (manifest 설계의 cross-reference; tier 필드는 frontmatter 가 아닌 manifest 에만).
+- `.claude/rules/moai/development/coding-standards.md` — Template-First, 16-language neutrality, single source of truth 원칙.
+- `.claude/rules/moai/core/zone-registry.md` CONST-V3R2-005 — Template-First discipline (catalog.yaml 도 templates/ 외부지만 templates → user project 흐름 일관 유지).


### PR DESCRIPTION
## Summary

Wave 1 first SPEC of catalog slimming initiative (sourced from /moai brain IDEA-003).

- **3-tier catalog manifest schema**: core / optional-pack / harness-generated 분류 + hash + version 필드로 drift detection foundation 제공
- **27 EARS Requirements**, 9 modules (Ubiquitous / Event-Driven / State-Driven / Unwanted / Optional)
- **7 G/W/T scenarios** + 4 edge cases, 27/27 REQ mapping
- **plan-auditor iteration 2 PASS** (0.92 overall, all categories ≥0.90)

Closes #859

## SPEC Details

| | |
|---|---|
| SPEC ID | SPEC-V3R4-CATALOG-001 |
| Wave | 1 of 4 (Foundation) |
| Estimated | ~1500-1900 LOC |
| Risk | Low (foundation, isolated) |
| Depends on | (none) |
| Blocks | CATALOG-002 ~ 007 |

## Test Plan

이 PR은 plan-only (markdown artifacts). 실제 구현은 후속 \`/moai run SPEC-V3R4-CATALOG-001\` PR.

- [ ] plan-auditor 검증 통과 (iteration 2 PASS 0.92 확인)
- [ ] spec.md 9 frontmatter fields 검증
- [ ] 27 REQ all have AC mapping (verified)
- [ ] Files to Modify 일관성 (4 [NEW] + 1 [NO MODIFY])
- [ ] manager-git diff review 후 squash merge

## Cross-References

- Brain IDEA-003 산출물: \`.moai/brain/IDEA-003/proposal.md\`
- GitHub Issue: #859
- plan-auditor reports: (internal, not committed)
- 후속 SPEC: SPEC-V3R4-CATALOG-002 (디렉토리 재배치) → 003 (pack CLI) + 005 (인터뷰) → 004 (안전 동기화) → 006 (doctor) + 007 (docs)

🗿 MoAI <bobby@afamily.kr>