### PR TITLE
feat(catalog): SPEC-V3R4-CATALOG-002 — Wave 2 Distribution slim init via SlimFS tier filter

### DIFF
--- a/.moai/specs/SPEC-V3R4-CATALOG-002/progress.md
+++ b/.moai/specs/SPEC-V3R4-CATALOG-002/progress.md
@@ -1,0 +1,172 @@
+## SPEC-V3R4-CATALOG-002 Progress
+
+- Started: 2026-05-12T08:10:00Z
+- Resume from: Phase 0.5 (Plan Audit Gate)
+- Harness level: standard
+- Development mode: tdd
+- Scale mode: Standard Mode (9 files, 1 domain: backend)
+- Detected language: go (go.mod present)
+- Worktree: /Users/goos/.moai/worktrees/MoAI-ADK/SPEC-V3R4-CATALOG-002
+- Branch: feature/SPEC-V3R4-CATALOG-002
+
+### Phase 0.5: Plan Audit Gate
+
+- audit_cache_hit: false
+- audit_verdict: PASS
+- audit_score: 0.91
+- audit_report: .moai/reports/plan-audit/SPEC-V3R4-CATALOG-002-review-1.md
+- audit_at: 2026-05-12T08:15:00Z
+- auditor_version: plan-auditor v1
+- plan_artifact_hash: 9279215bb98e382af17df3a1b1ada72e42a91f551a4c6c624c67ec6afc354b39
+- p3_findings: 4 (non-blocking — substring-count wording / S6 git baseline staleness / EC5(a) denySet immutability godoc / EC5(b) 32-goroutine statistical grounding)
+
+### Phase 1: Strategy
+
+- strategy_artifact: spec-compact.md (plan-auditor PASS 0.91 — 추가 manager-strategy 위임 생략)
+- scale_mode: Standard Mode (9 files, 1 domain: backend Go)
+- harness_level: standard
+- ultrathink: activated for Phase 1 reasoning
+
+### HUMAN GATE 1: Plan Approval — PASSED
+
+- user_choice: Wave-split sequential (M1→M2→M3→M4→M5)
+- approved_at: 2026-05-12T08:20:00Z
+
+### Phase 1.5-1.8: Decomposition + AC Init + Scaffold + MX Scan
+
+- tasks_md: .moai/specs/SPEC-V3R4-CATALOG-002/tasks.md (28 tasks across M1-M5)
+- ac_coverage: 21 REQ → 8 scenarios + 6 EC matrix in tasks.md
+- scaffold_strategy: manager-develop이 isolation 없이 worktree 내 자체 작성 (이미 SPEC worktree 안)
+- mx_context_scan:
+  - embed.go:32 EmbeddedTemplates @MX:ANCHOR fan_in=6 (consume-only, no break)
+  - catalog_loader.go:111 LoadCatalog @MX:ANCHOR fan_in>=3 (consume-only)
+  - init.go:115 runInit @MX:ANCHOR fan_in=3 (modify with care, T2.3)
+- catalog_doc_md: exists (REC-3 unconditional task feasible)
+
+### Phase 2B M1: SlimFS Wrapper — COMPLETED
+
+- delegation_pattern: manager-develop with cycle_type=tdd, no isolation (already inside SPEC worktree)
+- wave: 1 of 5
+- planned_files: internal/template/slim_fs.go, internal/template/slim_fs_test.go
+- actual_files: internal/template/slim_fs.go (235 LOC), internal/template/slim_fs_test.go (456 LOC)
+- additional_features: slimDir wrapper (R7 mitigation — fs.Sub does not propagate fs.StatFS in Go 1.26; required for fstest.TestFS contract)
+- tests: 14 PASS, 0 FAIL, race-clean
+- coverage: slim_fs.go 91.1% (target ≥90%)
+- d7_lock_diff: empty (deployer/update/embed/catalog/catalog_loader 변경 0)
+- drift: 0% (planned 2 == actual 2)
+- lint_fixes (orchestrator): slim_fs.go:78 CutSuffix, slim_fs_test.go:303/325 any, go.mod tidy (golang.org/x/sys indirect→direct)
+- post_m1_lsp: max_errors=0, max_type_errors=0, max_lint_errors=0
+- mx_tag_added: @MX:ANCHOR on SlimFS constructor + @MX:REASON
+- completed_at: 2026-05-12T08:35:00Z
+
+### Phase 2B M2: CLI Integration + Encapsulated Slim Deployer — COMPLETED
+
+- wave: 2 of 5
+- planned_files: 6 (embed_catalog.go, embed_catalog_test.go, slim_guard.go, slim_guard_test.go, init.go modify, init_slim_branch_test.go)
+- actual_files: 6 (same — helper name `newSlimTestCmd` to avoid `newTestInitCmd` collision per init_coverage_test.go)
+- additional_features: none
+- new_dependencies: stdlib only
+- tests: PASS all packages (template/cli/cli-pr/cli-wizard/cli-worktree), race-clean
+- coverage: slim_guard.go 100%, shouldDistributeAll 100%, embed_catalog 75-83% (unreachable error paths are architecturally impossible — embeddedRaw always valid in binary)
+- defect5_gate: 0 matches in internal/cli/ (encapsulation invariant maintained)
+- d7_lock_diff: empty (deployer/update/embed/catalog/catalog_loader/slim_fs 모두 unchanged)
+- post_m2_lsp: max_errors=0, max_type_errors=0, max_lint_errors=0 (golangci-lint package-level 0 issues)
+- stale_diagnostics_disregarded: 4 (LSP cache from intermediate manager-develop state — real build green)
+- baseline_p3_lints: 7 (migrate_agency_posix/update/launcher/coverage_test/github_workflow/glm — all pre-existing, M2 무관)
+- mx_tags_added: NewSlimDeployerWithRenderer @MX:ANCHOR+@MX:REASON, LoadEmbeddedCatalog @MX:NOTE, AssertBuilderHarnessAvailable @MX:NOTE, shouldDistributeAll @MX:NOTE
+- mx_tags_preserved: runInit @MX:ANCHOR (line 134 now), embed.go EmbeddedTemplates @MX:ANCHOR, catalog_loader.go LoadCatalog @MX:ANCHOR
+- completed_at: 2026-05-12T08:55:00Z
+
+### Phase 2B M3: Audit Suite — COMPLETED
+
+- wave: 3 of 5
+- planned_files: 1 (catalog_slim_audit_test.go ~220-300 LOC, T3.1-T3.6; T3.7 already in M2 slim_guard_test.go)
+- actual_files: 1 (catalog_slim_audit_test.go, 242 LOC)
+- subtest_results: T3.2 hides 25 non-core / T3.3 preserves 40 core + EC4 nested / T3.4 5 non-catalog (harness.yaml substituted for quality.yaml.tmpl) / T3.5 walks 523 paths zero leaks / T3.6 reflective_struct_check + 32-goroutine race-clean (1600 reads)
+- coverage_lift: slim_fs.go function-level: computeDenySet/isHidden/SlimFS 100%, Stat 90%, ReadDir(slimFS) 86.7%, ReadDir(slimDir) 87.5%, Open 83.3%
+- sentinel_discipline: all 7 failure emissions t.Errorf (CATALOG-001 EC3 lesson honored)
+- modernization_fixes (orchestrator): TypeFor[slimFS] + Fields() iteration + range over int (×2) — instance-free reflective check
+- post_m3_lsp: max_errors=0, max_type_errors=0, max_lint_errors=0
+- completed_at: 2026-05-12T09:05:00Z
+
+### Phase 2B M4: Backward Compat & Regression — VERIFIED
+
+- wave: 4 of 5
+- delegation: orchestrator-direct (verification only, no implementation needed)
+- t41_init_test_strategy_b: confirmed — `init_slim_branch_test.go` (M2 산출) covers slim path, existing `init_test.go` + `init_coverage_test.go` remain green (full test suite PASS race-clean)
+- t42_deployer_test_no_slim: confirmed — deployer_test.go timestamp 16:54 (baseline), no diff, no SlimFS reference
+- t43_update_test_no_slim: confirmed — update_test.go timestamp baseline, no diff, no SlimFS reference
+- t44_full_regression: confirmed — `go test -race -count=1 ./internal/template/... ./internal/cli/...` PASS (template 4.38s, cli 15.46s, cli/pr 2.32s, cli/wizard 3.43s, cli/worktree 4.75s)
+- final_git_diff_summary: 1 modified (init.go +42/-3), 8 untracked (6 new go files + 2 SPEC artifacts)
+- completed_at: 2026-05-12T09:08:00Z
+
+### Phase 2B M5: Documentation — COMPLETED
+
+- wave: 5 of 5 (final)
+- planned_files: 3 (CHANGELOG.md, init.go initCmd.Long, catalog_doc.md cross-ref)
+- actual_files: 3 (same)
+- t51_changelog: bilingual BREAKING CHANGE entry inserted at top of [Unreleased]
+- t52_slim_fs_godoc: present (added by manager-develop in M1)
+- t53_init_long: `moai init --all` 1-line added to Long help text
+- t54_catalog_doc_xref: "Tier filter consumers" section added + corrected Follow-up SPECs table (CATALOG-002 reality reflected, CATALOG-001 stale placeholder rows corrected)
+- t55_slim_guard_godoc: present (added by manager-develop in M2)
+- post_m5_lsp: max_errors=0, max_type_errors=0, max_lint_errors=0 (race-clean)
+- completed_at: 2026-05-12T09:18:00Z
+
+### Phase 2B M1-M5 Wave Summary
+
+- total_new_files: 9 (slim_fs.go, slim_fs_test.go, embed_catalog.go, embed_catalog_test.go, slim_guard.go, slim_guard_test.go, catalog_slim_audit_test.go, init_slim_branch_test.go, plus tasks.md+progress.md as SPEC artifacts)
+- total_modified_files: 3 (init.go +42/-3, CHANGELOG.md +new section, catalog_doc.md +Tier filter consumers section)
+- d7_lock_preserved: deployer.go / update.go / embed.go / catalog.yaml / catalog_loader.go all unchanged
+- defect5_encapsulation: 0 matches for `EmbeddedRaw[A-Za-z]*` in internal/cli/
+- coverage_per_file: slim_fs.go 91.1%, slim_guard.go 100%, shouldDistributeAll 100%
+- sentinel_discipline: 100% t.Errorf (CATALOG-001 EC3 lesson honored, 0 t.Logf failure emissions)
+- p3_findings_resolved: 4/4 (substring count internal to test logic, S6 git baseline via M4-T4.2 latest HEAD, EC5(a) godoc invariant, EC5(b) 32-goroutine rationale in code comment)
+
+### Phase 2.5-2.8b: Quality + evaluator-active — COMPLETED
+
+- delegation: evaluator-active (independent 4-dim assessment)
+- verdict: PASS
+- overall_score: 0.916 (≥ 0.85 threshold, ≥ 0.88 stretch)
+- dim_scores: Functionality 88, Security 100, Craft 88, Consistency 92
+- report: .moai/reports/evaluator/SPEC-V3R4-CATALOG-002-review-1.md
+- p0_p1_blocking: 0
+- p2_findings: 2 (P2-1 stdout test, P2-2 embed_catalog error path coverage)
+- p2_resolution: P2-1 fixed in this phase (user choice: P2-1만 fix 후 진행)
+- p2_2_deferred: post-merge or follow-up (error path is architecturally unreachable — embeddedRaw always valid in binary)
+- p3_findings: 3 (runInit CATALOG_LOAD_FAILED e2e, ANCHOR fan_in promotion after CATALOG-003/004, denySet immutability godoc-only)
+- p2_1_fix:
+  - extracted `emitSlimModeNotice(io.Writer)` helper in init.go (lines 27-39)
+  - added TestEmitSlimModeNotice_FourSubstrings in init_slim_branch_test.go (lines 158-184)
+  - 4-substring contract regression guard ("slim mode" / "--all" / "MOAI_DISTRIBUTE_ALL=1" / "SPEC-V3R4-CATALOG-005")
+- post_p2_1_lsp: race-clean, lint 0 issues
+- completed_at: 2026-05-12T09:30:00Z
+
+### Phase 2.9: MX Tag Update — VERIFIED
+
+- delegation: orchestrator-direct (verification only)
+- mx_tags_added (8 total during M1-M5 + P2-1):
+  - slim_fs.go:212 SlimFS @MX:ANCHOR + @MX:REASON (forward-looking fan_in≥3 policy)
+  - embed_catalog.go:19 LoadEmbeddedCatalog @MX:NOTE
+  - embed_catalog.go:37 NewSlimDeployerWithRenderer @MX:ANCHOR + @MX:REASON (forward-looking)
+  - slim_guard.go:8 AssertBuilderHarnessAvailable @MX:NOTE
+  - catalog_slim_audit_test.go:11 audit suite @MX:NOTE
+  - init.go:27 emitSlimModeNotice @MX:NOTE (P2-1)
+  - init.go:133 shouldDistributeAll @MX:NOTE
+- mx_tags_preserved (3):
+  - init.go:150 runInit @MX:ANCHOR (fan_in=3, intact)
+  - embed.go:32 EmbeddedTemplates @MX:ANCHOR (fan_in=6, intact)
+  - catalog_loader.go:111 LoadCatalog @MX:ANCHOR (fan_in≥3, intact)
+- p1_p2_violations: 0 (no new goroutines/async patterns, no fan_in regression)
+- completed_at: 2026-05-12T09:32:00Z
+
+### Phase 3: Git Operations (entering)
+
+- delegation: manager-git
+- branch: feature/SPEC-V3R4-CATALOG-002 (already exists from plan phase)
+- expected_commits: 1-3 (M1+M2 / M3 / M4+M5+P2-1, or single squash-ready commit)
+- conventional_commit: feat(catalog): SPEC-V3R4-CATALOG-002 — slim init via SlimFS tier filter
+- no_issue_number: SPEC metadata에 issue 없음, Fixes # 미사용
+- next_action: push + PR create
+
+

--- a/.moai/specs/SPEC-V3R4-CATALOG-002/tasks.md
+++ b/.moai/specs/SPEC-V3R4-CATALOG-002/tasks.md
@@ -1,0 +1,113 @@
+# Task Decomposition — SPEC-V3R4-CATALOG-002
+
+SPEC: SPEC-V3R4-CATALOG-002 (Wave 2 Distribution — slim init via catalog tier filter)
+Total tasks: 28 (M1=6, M2=6, M3=7, M4=4, M5=5)
+Development mode: TDD (RED → GREEN → REFACTOR per quality.yaml)
+Methodology entry point: M3 audit suite는 TDD RED 단계로 시작
+
+## Wave-Split Plan
+
+Per user choice (HUMAN GATE 1): M1 → M2 → M3 → M4 → M5 sequential delegation. 각 wave 사이 drift guard + LSP gate verification.
+
+## M1 — SlimFS Wrapper API + Implementation (6 tasks)
+
+| Task ID | Description | REQ | Dependencies | Planned Files | Status |
+|---------|-------------|-----|--------------|---------------|--------|
+| T1.1 | slim_fs.go 생성. Package docstring + `SlimFS(rawFS fs.FS, cat *Catalog) (fs.FS, error)` 시그니처. nil 입력 검증. | REQ-001 | — | internal/template/slim_fs.go | pending |
+| T1.2 | private `slimFS` struct (underlying fs.FS, denySet map). `fs.FS` + `fs.StatFS` + `fs.ReadDirFS` 3종 구현. immutable invariant. | REQ-001, REQ-003 | T1.1 | internal/template/slim_fs.go | pending |
+| T1.3 | `computeDenySet(cat *Catalog)` 헬퍼 — non-core entry Path를 templates/-prefixed namespace로 deny set 추가. | REQ-001, REQ-010 | T1.2 | internal/template/slim_fs.go | pending |
+| T1.4 | `(*slimFS) Open(name)` — name은 templates/-prefixed (Anti-pattern: re-prepend 금지). deny set prefix match → fs.ErrNotExist. | REQ-010, REQ-014 | T1.3 | internal/template/slim_fs.go | pending |
+| T1.5 | `(*slimFS) ReadDir`, `Stat` — T1.4와 동일 prefix space에서 deny match. ReadDir 결과 필터. | REQ-010, REQ-011 | T1.4 | internal/template/slim_fs.go | pending |
+| T1.6 | SlimFS 마지막 단계 — `slimWrapper := &slimFS{...}; return fs.Sub(slimWrapper, "templates")`. caller view에서 templates/ prefix 제거 (REQ-002). | REQ-002 | T1.5 | internal/template/slim_fs.go | pending |
+
+**M1 LOC target**: ~150-200 LOC. Risk R7 (fs.Sub bypass) mitigation: testing/fstest.TestFS calling convention 검증.
+
+## M2 — CLI Integration + Encapsulated Slim Deployer Constructor (6 tasks)
+
+| Task ID | Description | REQ | Dependencies | Planned Files | Status |
+|---------|-------------|-----|--------------|---------------|--------|
+| T2.1 | init.go에 `--all` Bool flag 추가 (initCmd.Flags().Bool). | REQ-013 | M1 done | internal/cli/init.go | pending |
+| T2.2 | `shouldDistributeAll(cmd)` 헬퍼 — `--all` OR `MOAI_DISTRIBUTE_ALL=1` OR case-insensitive "true". 비-canonical 값 (0/yes/empty) 모두 false. | REQ-012, REQ-013 | T2.1 | internal/cli/init.go (또는 init_helpers.go) | pending |
+| T2.3 | init.go:293-301 블록 수정 — LoadEmbeddedCatalog → shouldDistributeAll 분기. slim path는 NewSlimDeployerWithRenderer, full path는 기존 EmbeddedTemplates+NewDeployerWithRenderer. slim 진입 시 REQ-021 4-substring notice 출력. | REQ-007, REQ-008, REQ-021-notice | T2.2 | internal/cli/init.go | pending |
+| T2.4 | embed_catalog.go 신규 — `LoadEmbeddedCatalog()` + `NewSlimDeployerWithRenderer(cat, renderer)` 두 export. **NO EmbeddedRawForInternal** (DEFECT-5 encapsulation). | REQ-004 | T2.3 | internal/template/embed_catalog.go | pending |
+| T2.5 | slim_guard.go 신규 (~5-10 LOC) — `AssertBuilderHarnessAvailable(projectFS) error`. 4 substring (CATALOG_SLIM_HARNESS_MISSING + MOAI_DISTRIBUTE_ALL=1 + `moai init --all` + SPEC-V3R4-CATALOG-005). | REQ-021 | T2.4 | internal/template/slim_guard.go | pending |
+| T2.6 | slim_guard_test.go (~25 LOC) — present/missing/nil cases. missing case는 4 substring contains assert (t.Errorf 사용). | REQ-021 | T2.5 | internal/template/slim_guard_test.go | pending |
+
+**M2 LOC target**: ~115-155 LOC (init.go +30~35, embed_catalog.go +35~55, slim_guard +10, slim_guard_test +25). DEFECT-5 encapsulation: `git grep 'EmbeddedRaw[A-Za-z]*' internal/cli/` zero matches gate.
+
+## M3 — Audit Suite (7 tasks — TDD RED → GREEN entry point)
+
+모든 sentinel emission **t.Errorf 사용 (NOT t.Logf)** — CATALOG-001 eval-1 EC3 hash sentinel 교훈.
+
+| Task ID | Description | REQ | Dependencies | Planned Files | Status |
+|---------|-------------|-----|--------------|---------------|--------|
+| T3.1 | catalog_slim_audit_test.go 골격 + `loadSlimFS(t)` 헬퍼 (LoadCatalog + SlimFS 일괄). | — | M2 done | internal/template/catalog_slim_audit_test.go | pending |
+| T3.2 | TestSlimFS_HidesNonCoreEntries — REQ-014. non-core entry.Path 순회 fs.Stat. sentinel `CATALOG_SLIM_LEAK: <path> tier=<tier>`. | REQ-014 | T3.1 | internal/template/catalog_slim_audit_test.go | pending |
+| T3.3 | TestSlimFS_PreservesCoreEntries — REQ-015 + EC4 sub-assertion (`t.Run("nested_moai_workflows_plan", ...)`). sentinel `CATALOG_SLIM_CORE_MISSING: <path>`. | REQ-015, EC4 | T3.2 | internal/template/catalog_slim_audit_test.go | pending |
+| T3.4 | TestSlimFS_PreservesNonCatalogFiles — REQ-016. 5 non-catalog path 목록 fs.Stat. sentinel `CATALOG_SLIM_OVER_FILTER: <path>`. | REQ-016 | T3.3 | internal/template/catalog_slim_audit_test.go | pending |
+| T3.5 | TestSlimFS_WalkDirNoLeak — REQ-017. fs.WalkDir 전체 walk + deny set cross-check. t.Parallel. sentinel `CATALOG_SLIM_WALK_LEAK: <path>`. | REQ-017 | T3.4 | internal/template/catalog_slim_audit_test.go | pending |
+| T3.6 | TestSlimFS_ReadOnlyInvariant — REQ-003 두 부분: (a) reflective check (sync.*/chan/mutable field 탐지) + (b) 32-goroutine race test (`go test -race`). sentinel `CATALOG_SLIM_NOT_READONLY: ...`. | REQ-003 | T3.5 | internal/template/catalog_slim_audit_test.go | pending |
+| T3.7 | TestAssertBuilderHarnessAvailable — REQ-021. present/missing/nil 3 cases. missing 시 4 substring assert. | REQ-021 | T2.6 | internal/template/slim_guard_test.go | pending |
+
+**M3 LOC target**: ~220-300 LOC (audit_test.go). T3.6+T3.7는 +40 LOC. Risk R1 (deny set path bug) mitigation: T3.5 fs.WalkDir 전체 cross-check.
+
+## M4 — Backward Compat & Regression (4 tasks)
+
+| Task ID | Description | REQ | Dependencies | Planned Files | Status |
+|---------|-------------|-----|--------------|---------------|--------|
+| T4.1 | init_test.go + init_coverage_test.go 분석 → 전략 B 채택 (기존 보존 + slim 별도 신규 TestRunInit_SlimDefault). | REQ-018 | M3 done | internal/cli/init_test.go | pending |
+| T4.2 | deployer_test.go 가 EmbeddedTemplates 직접 사용 + SlimFS 무관 확인 (grep). `git diff deployer.go` empty 확인. | REQ-005, REQ-018 | T4.1 | (verification only) | pending |
+| T4.3 | update_test.go SlimFS 무관 확인 (update.go 미수정 invariant). | REQ-006, REQ-009 | T4.2 | (verification only) | pending |
+| T4.4 | `go test -race -count=1 ./...` 전체 회귀 0 확인. coverage delta 측정 (slim_fs.go ≥90%, slim_guard.go ≥90%). | (all) | T4.3 | (verification only) | pending |
+
+**M4 LOC target**: init_test.go +60 LOC (전략 B 신규 sub-test). Risk R4 mitigation: hardcoded file count 회귀 회피.
+
+## M5 — Documentation (5 tasks)
+
+| Task ID | Description | REQ | Dependencies | Planned Files | Status |
+|---------|-------------|-----|--------------|---------------|--------|
+| T5.1 | CHANGELOG.md `## [Unreleased]` BREAKING CHANGE entry — `moai init` slim default + `--all` + MOAI_DISTRIBUTE_ALL=1 + CATALOG-003/004 mention. | REQ-020 | M4 done | CHANGELOG.md | pending |
+| T5.2 | slim_fs.go godoc — D7 lock indirection 정당성 + init.go 호출 패턴. | — | T5.1 | internal/template/slim_fs.go | pending |
+| T5.3 | init.go `initCmd.Long` 텍스트에 slim mode 안내 1줄 추가. | — | T5.2 | internal/cli/init.go | pending |
+| T5.4 | catalog_doc.md (catalog.yaml:13 reserved.docs_ref 참조) — "Tier filter consumer: SlimFS() + NewSlimDeployerWithRenderer()" cross-reference. CATALOG-001 머지로 파일 존재 확정 (unconditional). | REC-3 | T5.3 | internal/template/catalog_doc.md | pending |
+| T5.5 | slim_guard.go godoc — REQ-021 sentinel + 두 안내 substring + 사용 예제 (moai doctor 호출 패턴). | REQ-021 | T5.4 | internal/template/slim_guard.go | pending |
+
+## Acceptance Criteria Coverage
+
+전체 21 REQ → 8 Scenarios (S1-S8) + 6 Edge Cases (EC1-EC6) 매핑 (spec-compact.md §Acceptance Criteria 참조). 각 task 완료 시 해당 AC sub-checklist 갱신.
+
+| AC | Verifies REQ | Owning Task(s) |
+|----|-------------|----------------|
+| S1 | REQ-001/002/004/007/010/011/021-notice | T1.1-T1.6, T2.3, T2.4 |
+| S2 | REQ-012 | T2.2, T2.3 |
+| S3 | REQ-013/019 | T2.1, T2.2, T2.3, T5.3 |
+| S4 | REQ-010/011/014/017 | T3.2, T3.5 |
+| S5 | REQ-015/016 | T3.3, T3.4 |
+| S6 | REQ-005/006/018 | T4.2, T4.3 |
+| S7 | REQ-009 | T4.3 |
+| S8 | REQ-020 | T5.1 |
+| EC1 | REQ-008 | T2.3 |
+| EC2 | REQ-019 | T2.2 |
+| EC3 | REQ-012 | T2.2 |
+| EC4 | REQ-010/015 | T3.3 |
+| EC5 | REQ-003 | T3.6 |
+| EC6 | REQ-021 | T2.5, T3.7 |
+
+## Quality Gates Targets
+
+- `go test -race -count=1 ./internal/template/... ./internal/cli/...` PASS
+- slim_fs.go coverage ≥ 90%; slim_guard.go coverage ≥ 90%
+- All 8 scenarios + 6 EC verifiable
+- CI 14 jobs GREEN (Test×3 OS + Build×5 + Lint + Constitution + Integration×3 + CodeQL)
+- D7 lock: `git diff deployer.go update.go` empty
+- Encapsulation gate: `git grep 'EmbeddedRaw[A-Za-z]*' internal/cli/` zero matches
+- CHANGELOG BREAKING CHANGE entry present
+
+## P3 Findings (plan-auditor review 1, non-blocking)
+
+| ID | Description | Fix in Phase |
+|----|-------------|--------------|
+| P3-1 | spec-compact.md L57 "3 substring" vs L127 "4 substring" wording inconsistency (REQ-021) | M3-T3.7 implementation에서 "4" 채택, sync-phase에서 spec-compact.md sync |
+| P3-2 | S6 git baseline `0d4bf14ef` staleness (사용자 측정 시점) | M4-T4.2 verification 시 최신 HEAD 기준 적용 |
+| P3-3 | EC5(a) denySet immutability godoc-only invariant | M5-T5.2 godoc에 명시 |
+| P3-4 | EC5(b) 32-goroutine 통계적 근거 | M3-T3.6 godoc comment에 race 검증 의도 명시 |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] — SPEC-V3R4-CATALOG-002: Wave 2 Distribution — Slim init via catalog tier filter
+
+### Changed (BREAKING CHANGE)
+
+- **`moai init` 기본 동작 변경**: catalog manifest 의 `tier == core` 자산만 배포 (20 core skills + 20 core agents + non-catalog 템플릿). Optional packs 9 종 (backend / frontend / mobile / auth / deployment / design / devops / testing / chrome-extension — 합계 17 skills + 7 agents) 및 builder-harness agent 1 개는 기본 배포에서 제외 → 약 38% (25/65 entries) 슬림. 두 가지 opt-out 경로: `moai init --all` flag 또는 `MOAI_DISTRIBUTE_ALL=1` 환경변수 (case-insensitive `"true"` 도 허용). `moai update` 동작은 영향 없음 (full FS 유지). Optional pack 인터랙티브 설치는 SPEC-V3R4-CATALOG-003 (`moai pack add`) 에서 제공 예정. 기존 프로젝트의 update drift sync 는 SPEC-V3R4-CATALOG-004. Builder-harness 자동 부트스트랩은 SPEC-V3R4-CATALOG-005.
+
+### Added
+
+- **SlimFS wrapper** (`internal/template/slim_fs.go`, +235 LOC): `fs.FS` 레벨 tier 필터. `SlimFS(rawFS fs.FS, cat *Catalog) (fs.FS, error)` API. `deployer.go` / `update.go` 미수정 (D7 lock 보존, REQ-005/006). 65 entries 중 25 non-core 자산이 `fs.ErrNotExist` 반환. `testing/fstest` 호환 (REQ-001/002/003/010/011/014/015). Coverage 91.1%.
+- **encapsulated slim deployer constructor** (`internal/template/embed_catalog.go`, +59 LOC): `LoadEmbeddedCatalog()` + `NewSlimDeployerWithRenderer(cat, renderer)` 두 export. `embeddedRaw` unexported 유지 (DEFECT-5 encapsulation invariant — `git grep 'EmbeddedRaw[A-Za-z]*' internal/cli/` zero matches).
+- **builder-harness 친절 에러 가드** (`internal/template/slim_guard.go`, +36 LOC): `AssertBuilderHarnessAvailable(projectFS) error` — slim mode 에서 builder-harness 부재 시 `CATALOG_SLIM_HARNESS_MISSING` sentinel + `MOAI_DISTRIBUTE_ALL=1` + `moai init --all` + `SPEC-V3R4-CATALOG-005` 4 substring 안내 (REQ-021). Coverage 100%.
+- **audit suite** (`internal/template/catalog_slim_audit_test.go`, +242 LOC): 6 sub-tests — `TestSlimFS_HidesNonCoreEntries` (REQ-014 `CATALOG_SLIM_LEAK`, 25 non-core 검증), `TestSlimFS_PreservesCoreEntries` + EC4 nested (REQ-015 `CATALOG_SLIM_CORE_MISSING`, 40 core + `.claude/skills/moai/workflows/plan.md` nested), `TestSlimFS_PreservesNonCatalogFiles` (REQ-016 `CATALOG_SLIM_OVER_FILTER`, 5 non-catalog paths), `TestSlimFS_WalkDirNoLeak` (REQ-017 `CATALOG_SLIM_WALK_LEAK`, 523 paths visited zero leaks), `TestSlimFS_ReadOnlyInvariant` (REQ-003, reflective struct check + 32-goroutine × 50 iteration race-clean, `CATALOG_SLIM_NOT_READONLY`). 모든 sentinel `t.Errorf` 사용 (CATALOG-001 eval-1 EC3 lesson 흡수).
+- **`--all` flag + `shouldDistributeAll(cmd)` helper** (`internal/cli/init.go`, +42/-3): 좁은 env 매칭 (`"1"` exact OR case-insensitive `"true"`). EC2 idempotent (env+flag 동시 set 시 한번만 bypass).
+- **slim mode 진입 안내**: `cmd.OutOrStdout()` 로 4 substring 1-line 출력 (REQ-021 notice — `"slim mode"` + `"--all"` + `"MOAI_DISTRIBUTE_ALL=1"` + `"SPEC-V3R4-CATALOG-005"`).
+
+plan-auditor PASS 0.91 (≥ 0.88 stretch). 8 new files (slim_fs.go/_test, embed_catalog.go/_test, slim_guard.go/_test, catalog_slim_audit_test.go, init_slim_branch_test.go) + 1 modified (init.go +42/-3). DEFECT-5 encapsulation gate enforced. Fixes part of #859.
+
+### English
+
+- **BREAKING CHANGE — `moai init` default behavior**: deploys only `tier == core` catalog entries by default (20 core skills + 20 core agents + non-catalog templates). The 9 optional packs (backend / frontend / mobile / auth / deployment / design / devops / testing / chrome-extension — 17 skills + 7 agents total) and the builder-harness agent are no longer deployed by default — approximately 38% (25 / 65 entries) slim. Two opt-out paths: `moai init --all` flag OR `MOAI_DISTRIBUTE_ALL=1` environment variable (also accepts case-insensitive `"true"`). `moai update` behavior is unchanged (always full FS). Interactive optional-pack installation arrives in SPEC-V3R4-CATALOG-003 (`moai pack add`). Update drift sync for existing projects lands in SPEC-V3R4-CATALOG-004. Builder-harness auto-bootstrap lands in SPEC-V3R4-CATALOG-005.
+
+- New `internal/template/slim_fs.go` SlimFS wrapper applies the tier filter at the `fs.FS` layer; `deployer.go` and `update.go` remain untouched (D7 lock). New `internal/template/embed_catalog.go` provides the encapsulated `LoadEmbeddedCatalog()` + `NewSlimDeployerWithRenderer()` entry points while keeping `embeddedRaw` unexported (DEFECT-5 invariant). New `internal/template/slim_guard.go` surfaces a friendly four-substring error when the builder-harness agent is absent. New `internal/template/catalog_slim_audit_test.go` adds 6 audit sub-tests (`CATALOG_SLIM_LEAK` / `CATALOG_SLIM_CORE_MISSING` + EC4 nested / `CATALOG_SLIM_OVER_FILTER` / `CATALOG_SLIM_WALK_LEAK` / `CATALOG_SLIM_NOT_READONLY` reflective + 32-goroutine race-clean) against the real production catalog. All sentinels use `t.Errorf` per the CATALOG-001 EC3 lesson.
+
+- plan-auditor PASS 0.91 (≥ 0.88 stretch target). 8 new files + 1 modified. `git grep 'EmbeddedRaw[A-Za-z]*' internal/cli/` returns zero matches. Fixes part of #859.
+
 ## [Unreleased] — Dev Tooling: release-update workflow harness
 
 ### Added

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"slices"
+	"strings"
 
 	"github.com/charmbracelet/huh"
 	"github.com/mattn/go-isatty"
@@ -21,6 +23,20 @@ import (
 	"github.com/modu-ai/moai-adk/internal/template"
 	"github.com/modu-ai/moai-adk/pkg/version"
 )
+
+// @MX:NOTE: [AUTO] CATALOG-002 REQ-021 4-substring informational notice — extracted as a helper so the contract is unit-testable without running the full runInit pipeline.
+//
+// emitSlimModeNotice prints the slim-mode informational notice to the given
+// writer. The notice MUST contain the four substrings "slim mode", "--all",
+// "MOAI_DISTRIBUTE_ALL=1", and "SPEC-V3R4-CATALOG-005" so downstream tooling
+// (moai doctor) can pattern-match on them. See SPEC-V3R4-CATALOG-002 REQ-021
+// and acceptance scenario S1.
+func emitSlimModeNotice(out io.Writer) {
+	_, _ = fmt.Fprintln(out,
+		"Deploying core templates only (slim mode). "+
+			"Use --all or MOAI_DISTRIBUTE_ALL=1 for full deploy. "+
+			"Note: builder-harness agent is omitted (see SPEC-V3R4-CATALOG-005 for bootstrap).")
+}
 
 var initCmd = &cobra.Command{
 	Use:     "init [project-name]",
@@ -36,7 +52,8 @@ Usage patterns:
 Examples:
   moai init my-app           Creates ./my-app/ and initializes MoAI inside
   moai init .                Initializes MoAI in the current directory
-  moai init --mode tdd       Initialize with specific development mode (default: tdd)`,
+  moai init --mode tdd       Initialize with specific development mode (default: tdd)
+  moai init --all            Deploy all catalog entries (default is core-only slim mode; SPEC-V3R4-CATALOG-002)`,
 	Args:    cobra.MaximumNArgs(1),
 	PreRunE: validateInitFlags,
 	RunE:    runInit,
@@ -57,6 +74,7 @@ func init() {
 	initCmd.Flags().Bool("non-interactive", false, "Skip interactive wizard; use flags and defaults")
 	initCmd.Flags().Bool("force", false, "Reinitialize an existing project (backs up current .moai/)")
 	initCmd.Flags().Bool("no-hooks", false, "Skip git hook installation (REQ-CIAUT-002)")
+	initCmd.Flags().Bool("all", false, "Deploy all catalog entries (core + optional packs + harness-generated). Bypasses slim mode (SPEC-V3R4-CATALOG-002).")
 }
 
 // getStringFlag retrieves a string flag value from the command.
@@ -110,6 +128,23 @@ func validateInitFlags(cmd *cobra.Command, _ []string) error {
 	}
 
 	return nil
+}
+
+// @MX:NOTE: [AUTO] CATALOG-002 REQ-012/013/EC3 — single decision point for slim/full opt-out. Narrow env matching: only "1" exact or case-insensitive "true".
+//
+// shouldDistributeAll returns true when the user has opted out of the slim
+// init default by passing --all on the command line or setting the
+// MOAI_DISTRIBUTE_ALL environment variable to "1" (exact) or "true"
+// (case-insensitive). Any other value — including "0", "yes", "", or unset —
+// returns false (slim mode remains active).
+//
+// Source: SPEC-V3R4-CATALOG-002 REQ-012, REQ-013, EC3.
+func shouldDistributeAll(cmd *cobra.Command) bool {
+	if all, _ := cmd.Flags().GetBool("all"); all {
+		return true
+	}
+	v := os.Getenv("MOAI_DISTRIBUTE_ALL")
+	return v == "1" || strings.EqualFold(v, "true")
 }
 
 // @MX:ANCHOR: [AUTO] runInit is the main entry point for project initialization
@@ -291,14 +326,31 @@ func runInit(cmd *cobra.Command, args []string) error {
 	mgr := manifest.NewManager()
 
 	// Wire embedded template deployer (REQ-E-030)
+	// Load catalog manifest (SPEC-V3R4-CATALOG-001) for slim/full deploy routing (CATALOG-002).
+	cat, catErr := template.LoadEmbeddedCatalog()
+	if catErr != nil {
+		return fmt.Errorf("CATALOG_LOAD_FAILED: %w", catErr)
+	}
+
+	// Both paths share the same renderer baseline (raw embedded FS).
 	embeddedFS, err := template.EmbeddedTemplates()
 	if err != nil {
 		return fmt.Errorf("load embedded templates: %w", err)
 	}
-
-	// Create renderer for template processing
 	renderer := template.NewRenderer(embeddedFS)
-	deployer := template.NewDeployerWithRenderer(embeddedFS, renderer)
+
+	var deployer template.Deployer
+	if shouldDistributeAll(cmd) {
+		deployer = template.NewDeployerWithRenderer(embeddedFS, renderer)
+	} else {
+		var slimErr error
+		deployer, slimErr = template.NewSlimDeployerWithRenderer(cat, renderer)
+		if slimErr != nil {
+			return fmt.Errorf("CATALOG_LOAD_FAILED: slim deployer: %w", slimErr)
+		}
+		// REQ-021 informational notice on slim mode (4 substring guarantee).
+		emitSlimModeNotice(cmd.OutOrStdout())
+	}
 
 	initializer := project.NewInitializer(deployer, mgr, nil)
 	executor := project.NewPhaseExecutor(detector, methDetector, validator, initializer, nil)

--- a/internal/cli/init_slim_branch_test.go
+++ b/internal/cli/init_slim_branch_test.go
@@ -1,0 +1,185 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// newSlimTestCmd creates a minimal cobra.Command with the --all flag
+// registered, mirroring the real initCmd flag definition.
+// Named differently from newTestInitCmd in init_coverage_test.go to avoid collision.
+func newSlimTestCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "init-slim-test"}
+	cmd.Flags().Bool("all", false, "Deploy all catalog entries (test)")
+	return cmd
+}
+
+// TestShouldDistributeAll_FlagTrue verifies that --all=true returns true.
+//
+// SPEC-V3R4-CATALOG-002 REQ-013.
+// Note: uses t.Setenv — must not call t.Parallel per Go 1.21+ rules.
+func TestShouldDistributeAll_FlagTrue(t *testing.T) {
+	t.Setenv("MOAI_DISTRIBUTE_ALL", "")
+
+	cmd := newSlimTestCmd()
+	if err := cmd.Flags().Set("all", "true"); err != nil {
+		t.Fatalf("failed to set --all flag: %v", err)
+	}
+
+	if !shouldDistributeAll(cmd) {
+		t.Error("shouldDistributeAll(--all=true, env='') = false, want true")
+	}
+}
+
+// TestShouldDistributeAll_EnvOne verifies that MOAI_DISTRIBUTE_ALL=1 returns true.
+//
+// SPEC-V3R4-CATALOG-002 REQ-012.
+func TestShouldDistributeAll_EnvOne(t *testing.T) {
+	t.Setenv("MOAI_DISTRIBUTE_ALL", "1")
+
+	cmd := newSlimTestCmd()
+	if !shouldDistributeAll(cmd) {
+		t.Error("shouldDistributeAll(--all=false, env='1') = false, want true")
+	}
+}
+
+// TestShouldDistributeAll_EnvTrueLower verifies case-insensitive "true" match.
+//
+// SPEC-V3R4-CATALOG-002 REQ-012.
+func TestShouldDistributeAll_EnvTrueLower(t *testing.T) {
+	t.Setenv("MOAI_DISTRIBUTE_ALL", "true")
+
+	cmd := newSlimTestCmd()
+	if !shouldDistributeAll(cmd) {
+		t.Error("shouldDistributeAll(env='true') = false, want true")
+	}
+}
+
+// TestShouldDistributeAll_EnvTrueUpper verifies case-insensitive "TRUE" match.
+//
+// SPEC-V3R4-CATALOG-002 REQ-012.
+func TestShouldDistributeAll_EnvTrueUpper(t *testing.T) {
+	t.Setenv("MOAI_DISTRIBUTE_ALL", "TRUE")
+
+	cmd := newSlimTestCmd()
+	if !shouldDistributeAll(cmd) {
+		t.Error("shouldDistributeAll(env='TRUE') = false, want true")
+	}
+}
+
+// TestShouldDistributeAll_EnvZero verifies that MOAI_DISTRIBUTE_ALL=0 returns false.
+//
+// SPEC-V3R4-CATALOG-002 REQ-012 EC narrow match.
+func TestShouldDistributeAll_EnvZero(t *testing.T) {
+	t.Setenv("MOAI_DISTRIBUTE_ALL", "0")
+
+	cmd := newSlimTestCmd()
+	if shouldDistributeAll(cmd) {
+		t.Error("shouldDistributeAll(env='0') = true, want false")
+	}
+}
+
+// TestShouldDistributeAll_EnvYes verifies that MOAI_DISTRIBUTE_ALL=yes returns false.
+// Only "1" and case-insensitive "true" are accepted.
+//
+// SPEC-V3R4-CATALOG-002 REQ-012 EC narrow match.
+func TestShouldDistributeAll_EnvYes(t *testing.T) {
+	t.Setenv("MOAI_DISTRIBUTE_ALL", "yes")
+
+	cmd := newSlimTestCmd()
+	if shouldDistributeAll(cmd) {
+		t.Error("shouldDistributeAll(env='yes') = true, want false")
+	}
+}
+
+// TestShouldDistributeAll_EnvEmpty verifies that MOAI_DISTRIBUTE_ALL="" returns false.
+//
+// SPEC-V3R4-CATALOG-002 REQ-012.
+func TestShouldDistributeAll_EnvEmpty(t *testing.T) {
+	t.Setenv("MOAI_DISTRIBUTE_ALL", "")
+
+	cmd := newSlimTestCmd()
+	if shouldDistributeAll(cmd) {
+		t.Error("shouldDistributeAll(env='') = true, want false")
+	}
+}
+
+// TestShouldDistributeAll_EnvUnset verifies that an absent env var returns false.
+//
+// SPEC-V3R4-CATALOG-002 REQ-012.
+func TestShouldDistributeAll_EnvUnset(t *testing.T) {
+	// Unset explicitly to be deterministic across all CI environments.
+	t.Setenv("MOAI_DISTRIBUTE_ALL", "")
+
+	cmd := newSlimTestCmd()
+	if shouldDistributeAll(cmd) {
+		t.Error("shouldDistributeAll(env unset/empty) = true, want false")
+	}
+}
+
+// TestShouldDistributeAll_BothFlagAndEnv verifies EC2 idempotency:
+// both --all and MOAI_DISTRIBUTE_ALL=1 set simultaneously returns true
+// without panicking or having double side-effects.
+//
+// SPEC-V3R4-CATALOG-002 REQ-019 (idempotent both-set).
+func TestShouldDistributeAll_BothFlagAndEnv(t *testing.T) {
+	t.Setenv("MOAI_DISTRIBUTE_ALL", "1")
+
+	cmd := newSlimTestCmd()
+	if err := cmd.Flags().Set("all", "true"); err != nil {
+		t.Fatalf("failed to set --all flag: %v", err)
+	}
+
+	if !shouldDistributeAll(cmd) {
+		t.Error("shouldDistributeAll(--all=true, env='1') = false, want true")
+	}
+}
+
+// TestInitCmd_AllFlagRegistered verifies that the --all flag is registered on
+// initCmd with the correct type (bool) and default (false).
+//
+// SPEC-V3R4-CATALOG-002 T2.1.
+func TestInitCmd_AllFlagRegistered(t *testing.T) {
+	t.Parallel()
+
+	f := initCmd.Flags().Lookup("all")
+	if f == nil {
+		t.Fatal("initCmd --all flag not registered")
+	}
+	if f.DefValue != "false" {
+		t.Errorf("initCmd --all flag default = %q, want \"false\"", f.DefValue)
+	}
+	if f.Value.Type() != "bool" {
+		t.Errorf("initCmd --all flag type = %q, want \"bool\"", f.Value.Type())
+	}
+}
+
+// TestEmitSlimModeNotice_FourSubstrings verifies that the slim-mode
+// informational notice (SPEC-V3R4-CATALOG-002 REQ-021 + acceptance scenario S1)
+// contains all four required substrings so downstream tooling (moai doctor) can
+// pattern-match the message. Regression guard against silent drift of any of
+// the four anchor strings.
+//
+// REQ-021 / S1.
+func TestEmitSlimModeNotice_FourSubstrings(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	emitSlimModeNotice(&buf)
+	out := buf.String()
+
+	required := []string{
+		"slim mode",
+		"--all",
+		"MOAI_DISTRIBUTE_ALL=1",
+		"SPEC-V3R4-CATALOG-005",
+	}
+	for _, sub := range required {
+		if !strings.Contains(out, sub) {
+			t.Errorf("REQ-021 notice missing substring %q (full output: %q)", sub, out)
+		}
+	}
+}

--- a/internal/template/catalog_doc.md
+++ b/internal/template/catalog_doc.md
@@ -141,16 +141,47 @@ tier := template.FormatOptionalPackTier("backend") // → "optional-pack:backend
 
 ---
 
+## Tier filter consumers
+
+The catalog manifest is consumed at runtime through typed accessors and tier
+filters. The primary consumers are:
+
+- **`LoadCatalog(fs.FS) (*Catalog, error)`** — typed loader (CATALOG-001).
+  Returns the parsed manifest including all 65 entries grouped by tier.
+- **`LoadEmbeddedCatalog() (*Catalog, error)`** — convenience wrapper
+  (CATALOG-002) around `LoadCatalog(embeddedRaw)`. External packages SHOULD
+  use this entry point rather than constructing their own catalog loader so
+  that `embeddedRaw` remains unexported (DEFECT-5 encapsulation invariant).
+- **`SlimFS(rawFS fs.FS, cat *Catalog) (fs.FS, error)`** — tier filter at
+  the `fs.FS` level (CATALOG-002). Applies the `tier == TierCore` filter so
+  only core-tier entries (and non-catalog templates) are visible through the
+  returned FS. Optional packs and harness-generated entries return
+  `fs.ErrNotExist`. The wrapper is read-only (no `sync.*`, no chan, no
+  mutation after construction) and goroutine-safe under parallel reads.
+- **`NewSlimDeployerWithRenderer(cat *Catalog, renderer Renderer) (Deployer, error)`** —
+  encapsulated slim deployer constructor (CATALOG-002). Wraps `embeddedRaw`
+  in `SlimFS` and returns a `Deployer` ready for `Deploy()`. This is the
+  sole external surface for slim mode; callers do not see the raw embedded
+  FS.
+
+The `moai init` command currently routes through `LoadEmbeddedCatalog()` +
+`NewSlimDeployerWithRenderer()` for the default slim path and through
+`EmbeddedTemplates()` + `NewDeployerWithRenderer()` for the `--all` /
+`MOAI_DISTRIBUTE_ALL=1` opt-out path.
+
+---
+
 ## Follow-up SPECs
 
-This document covers SPEC-V3R4-CATALOG-001 (manifest + loader + audit suite).
-Later SPECs in the CATALOG series extend this foundation:
+This document covers SPEC-V3R4-CATALOG-001 (manifest + loader + audit suite)
+and the tier filter consumers introduced in SPEC-V3R4-CATALOG-002. Remaining
+SPECs in the CATALOG series extend the foundation:
 
 | SPEC | Topic |
 |------|-------|
-| SPEC-V3R4-CATALOG-002 | `moai catalog list` CLI command |
-| SPEC-V3R4-CATALOG-003 | `moai catalog verify` hash integrity check |
-| SPEC-V3R4-CATALOG-004 | `moai catalog install <pack>` optional-pack installation |
-| SPEC-V3R4-CATALOG-005 | `moai catalog update` selective template refresh |
-| SPEC-V3R4-CATALOG-006 | Marketplace registry integration |
-| SPEC-V3R4-CATALOG-007 | Harness-generated entries lifecycle management |
+| SPEC-V3R4-CATALOG-002 | `moai init` slim default + `SlimFS` tier filter (this consumer) ✅ |
+| SPEC-V3R4-CATALOG-003 | `moai pack add` / `pack remove` / `pack list` interactive installer |
+| SPEC-V3R4-CATALOG-004 | `moai update --catalog-sync` drift-aware update |
+| SPEC-V3R4-CATALOG-005 | `/moai project` interview + harness bootstrap (builder-harness auto-deploy) |
+| SPEC-V3R4-CATALOG-006 | `moai doctor catalog` diagnostic + repair |
+| SPEC-V3R4-CATALOG-007 | Migration docs (4-locale docs-site sync, BREAKING CHANGE rollout) |

--- a/internal/template/catalog_slim_audit_test.go
+++ b/internal/template/catalog_slim_audit_test.go
@@ -1,0 +1,288 @@
+// Package template — SPEC-V3R4-CATALOG-002 audit suite.
+//
+// Audit invariants for the SlimFS layer over the REAL production catalog
+// (loaded from the embedded catalog.yaml). Complementary to slim_fs_test.go
+// which uses synthetic catalogs for unit-level coverage.
+//
+// REQ-014 / REQ-015 / REQ-016 / REQ-017 / REQ-003 invariants are enforced
+// here as audit tests. All sentinel emissions use t.Errorf (NOT t.Logf) —
+// CATALOG-001 eval-1 EC3 hash sentinel lesson.
+//
+// @MX:NOTE: [AUTO] CATALOG-002 audit suite — REQ-014/015/016/017/003 invariants over the real production catalog.
+package template
+
+import (
+	"errors"
+	"io/fs"
+	"reflect"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// loadSlimFS loads the embedded catalog and wraps embeddedRaw in SlimFS.
+// Returns both the wrapped fs.FS (caller-view, "templates/"-prefix stripped)
+// and the underlying Catalog for cross-checks.
+//
+// Audit tests use the real production catalog — they verify the slim filter
+// against the actual 65-entry manifest, not a synthetic one.
+func loadSlimFS(t *testing.T) (fs.FS, *Catalog) {
+	t.Helper()
+	cat, err := LoadCatalog(embeddedRaw)
+	if err != nil {
+		t.Fatalf("load catalog: %v", err)
+	}
+	slim, err := SlimFS(embeddedRaw, cat)
+	if err != nil {
+		t.Fatalf("wrap SlimFS: %v", err)
+	}
+	return slim, cat
+}
+
+// TestSlimFS_HidesNonCoreEntries verifies REQ-014: every non-core catalog
+// entry MUST be invisible through the slim FS (Stat returns fs.ErrNotExist).
+//
+// Non-core entries include optional-pack:* tiers and harness-generated.
+// Expected hidden count: 25 (17 optional skills + 7 optional agents + 1 harness-generated).
+//
+// Sentinel: CATALOG_SLIM_LEAK
+func TestSlimFS_HidesNonCoreEntries(t *testing.T) {
+	t.Parallel()
+	slim, cat := loadSlimFS(t)
+
+	audited := 0
+	for _, e := range cat.AllEntries() {
+		if e.Tier == TierCore {
+			continue
+		}
+		// entry.Path = "templates/.claude/skills/foo/" → caller view = ".claude/skills/foo/"
+		callerPath := strings.TrimPrefix(strings.TrimSuffix(e.Path, "/"), "templates/")
+		_, err := fs.Stat(slim, callerPath)
+		if err == nil {
+			t.Errorf("CATALOG_SLIM_LEAK: %s tier=%s (Stat succeeded, expected fs.ErrNotExist)", callerPath, e.Tier)
+			continue
+		}
+		if !errors.Is(err, fs.ErrNotExist) {
+			t.Errorf("CATALOG_SLIM_LEAK: %s tier=%s (got err=%v, want fs.ErrNotExist)", callerPath, e.Tier, err)
+		}
+		audited++
+	}
+	t.Logf("audited %d non-core entries", audited)
+}
+
+// TestSlimFS_PreservesCoreEntries verifies REQ-015: every core catalog entry
+// MUST be reachable through the slim FS (Stat returns no error).
+//
+// EC4 sub-assertion: a nested path inside a core skill directory must also
+// be reachable, validating that prefix-based filtering does not over-block.
+//
+// Expected reachable count: 40 (20 core skills + 20 core agents) at directory
+// granularity, plus the nested EC4 path.
+//
+// Sentinel: CATALOG_SLIM_CORE_MISSING
+func TestSlimFS_PreservesCoreEntries(t *testing.T) {
+	t.Parallel()
+	slim, cat := loadSlimFS(t)
+
+	audited := 0
+	for _, e := range cat.AllEntries() {
+		if e.Tier != TierCore {
+			continue
+		}
+		callerPath := strings.TrimPrefix(strings.TrimSuffix(e.Path, "/"), "templates/")
+		_, err := fs.Stat(slim, callerPath)
+		if err != nil {
+			t.Errorf("CATALOG_SLIM_CORE_MISSING: %s (got err=%v, want success)", callerPath, err)
+		}
+		audited++
+	}
+	t.Logf("audited %d core entries", audited)
+
+	// EC4 sub-assertion: nested path under a core skill.
+	// The "moai" skill is tier=core; its sub-file "workflows/plan.md" must be reachable.
+	t.Run("nested_moai_workflows_plan", func(t *testing.T) {
+		const nestedPath = ".claude/skills/moai/workflows/plan.md"
+		_, err := fs.Stat(slim, nestedPath)
+		if err != nil {
+			t.Errorf("CATALOG_SLIM_CORE_MISSING: nested %s: %v", nestedPath, err)
+		}
+	})
+}
+
+// TestSlimFS_PreservesNonCatalogFiles verifies REQ-016: files that are NOT
+// enumerated in catalog.yaml's skills/agents sections (e.g. rules, config,
+// root files) must remain reachable through the slim FS.
+//
+// These paths are outside the catalog's skill/agent lists and must pass
+// through the filter unchanged.
+//
+// T3.4 path verification (pre-checked against templates/ tree):
+//   - .claude/rules/moai/core/zone-registry.md  → OK
+//   - .claude/output-styles/moai/moai.md         → OK
+//   - .moai/config/sections/harness.yaml         → OK
+//   - CLAUDE.md                                  → OK
+//   - .gitignore                                 → OK
+//
+// Note: .moai/config/sections/quality.yaml is only present as quality.yaml.tmpl
+// in the templates tree; harness.yaml is used instead.
+//
+// Sentinel: CATALOG_SLIM_OVER_FILTER
+func TestSlimFS_PreservesNonCatalogFiles(t *testing.T) {
+	t.Parallel()
+	slim, _ := loadSlimFS(t)
+
+	// Non-catalog paths — these are NOT enumerated in catalog.yaml's
+	// skills+agents sections but are part of the templates/ tree.
+	nonCatalogPaths := []string{
+		".claude/rules/moai/core/zone-registry.md",
+		".claude/output-styles/moai/moai.md",
+		".moai/config/sections/harness.yaml",
+		"CLAUDE.md",
+		".gitignore",
+	}
+
+	for _, p := range nonCatalogPaths {
+		_, err := fs.Stat(slim, p)
+		if err != nil {
+			t.Errorf("CATALOG_SLIM_OVER_FILTER: %s (got err=%v, want success)", p, err)
+		}
+	}
+}
+
+// TestSlimFS_WalkDirNoLeak verifies REQ-017: a full walk of the slim FS must
+// not encounter any path that matches a denied (non-core) catalog entry.
+//
+// The deny set is reconstructed in caller-view namespace ("templates/" stripped)
+// and checked against every visited path using both exact and prefix matching.
+//
+// Sentinel: CATALOG_SLIM_WALK_LEAK
+func TestSlimFS_WalkDirNoLeak(t *testing.T) {
+	t.Parallel()
+	slim, cat := loadSlimFS(t)
+
+	// Reconstruct deny set in caller-view namespace (templates/ stripped).
+	denyCallerView := make(map[string]struct{})
+	for _, e := range cat.AllEntries() {
+		if e.Tier == TierCore {
+			continue
+		}
+		callerPath := strings.TrimPrefix(strings.TrimSuffix(e.Path, "/"), "templates/")
+		denyCallerView[callerPath] = struct{}{}
+	}
+
+	visited := 0
+	err := fs.WalkDir(slim, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		visited++
+		// Verify path does NOT match any deny entry as prefix.
+		for denied := range denyCallerView {
+			if path == denied {
+				t.Errorf("CATALOG_SLIM_WALK_LEAK: %s (exact match with denied %s)", path, denied)
+				return nil
+			}
+			if strings.HasPrefix(path, denied+"/") {
+				t.Errorf("CATALOG_SLIM_WALK_LEAK: %s (prefix match with denied %s)", path, denied)
+				return nil
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	if visited == 0 {
+		t.Errorf("CATALOG_SLIM_WALK_LEAK: walk visited 0 paths (slim FS appears empty)")
+	}
+	t.Logf("walk visited %d paths", visited)
+}
+
+// TestSlimFS_ReadOnlyInvariant verifies REQ-003: the slimFS wrapper must be
+// structurally read-only (no sync.* fields, no channels) and must handle
+// concurrent reads without data races.
+//
+// Two sub-tests:
+//   (a) reflective_struct_check — inspects slimFS field types via reflect.
+//   (b) concurrent_reads_race_clean — 32-goroutine fan-out to expose races
+//       when run with `go test -race`.
+func TestSlimFS_ReadOnlyInvariant(t *testing.T) {
+	t.Parallel()
+
+	t.Run("reflective_struct_check", func(t *testing.T) {
+		// Inspect slimFS struct type at the type level — no instance needed
+		// because the read-only invariant is a property of the struct shape,
+		// not of any particular constructed value.
+		ty := reflect.TypeFor[slimFS]()
+		for f := range ty.Fields() {
+			// No sync.* types — slimFS must be stateless and goroutine-safe
+			// without internal locks (immutable-after-construction design).
+			if strings.HasPrefix(f.Type.String(), "sync.") {
+				t.Errorf("CATALOG_SLIM_NOT_READONLY: field=%s type=%s (sync.* forbidden)", f.Name, f.Type)
+			}
+			// No channels — synchronous, non-blocking operations only.
+			if f.Type.Kind() == reflect.Chan {
+				t.Errorf("CATALOG_SLIM_NOT_READONLY: field=%s type=%s (chan forbidden)", f.Name, f.Type)
+			}
+		}
+		// denySet immutability is documented (godoc-only invariant per P3-3 finding):
+		// "denySet is set once at construction and used read-only thereafter."
+	})
+
+	// 32 goroutines × 50 iterations gives ~1600 concurrent reads, sufficient to
+	// surface most data races in production wrappers. See spec.md EC5(b) and
+	// the discussion of goroutine count rationale.
+	t.Run("concurrent_reads_race_clean", func(t *testing.T) {
+		slim, cat := loadSlimFS(t)
+
+		// Build a path pool from real catalog entries (mix of core + non-core).
+		var pool []string
+		for _, e := range cat.AllEntries() {
+			callerPath := strings.TrimPrefix(strings.TrimSuffix(e.Path, "/"), "templates/")
+			pool = append(pool, callerPath)
+		}
+		if len(pool) == 0 {
+			t.Fatalf("empty path pool")
+		}
+
+		const goroutines = 32
+		const iterations = 50
+		var wg sync.WaitGroup
+		var errCount int64
+		wg.Add(goroutines)
+		for g := range goroutines {
+			go func(seed int) {
+				defer wg.Done()
+				for i := range iterations {
+					path := pool[(seed*31+i)%len(pool)]
+					_, statErr := fs.Stat(slim, path)
+					_ = statErr // ignore — Stat may return ErrNotExist for non-core, both are fine
+					if i%5 == 0 {
+						_ = fs.WalkDir(slim, ".", func(p string, d fs.DirEntry, walkErr error) error {
+							if walkErr != nil {
+								atomic.AddInt64(&errCount, 1)
+								return walkErr
+							}
+							// briefly descend into directories
+							return nil
+						})
+					}
+					if i%3 == 0 {
+						if dirEntries, dirErr := fs.ReadDir(slim, "."); dirErr == nil {
+							_ = dirEntries
+						}
+					}
+				}
+			}(g)
+		}
+		wg.Wait()
+		if atomic.LoadInt64(&errCount) > 0 {
+			t.Errorf("CATALOG_SLIM_NOT_READONLY: %d errors during concurrent reads (potential data race or state mutation)", errCount)
+		}
+		// The real race detector verdict comes from `go test -race`. This test
+		// ensures the race detector has enough concurrent traffic to surface
+		// any data race. If -race is not enabled, this test still passes —
+		// it serves as a load test for the wrapper.
+	})
+}

--- a/internal/template/embed_catalog.go
+++ b/internal/template/embed_catalog.go
@@ -1,0 +1,59 @@
+// Package template — SPEC-V3R4-CATALOG-002 helpers.
+//
+// embed_catalog.go provides the orchestration surface between the catalog
+// manifest (CATALOG-001) and the slim deploy filter (CATALOG-002). The
+// embedded raw filesystem (embedded.FS) remains an UNEXPORTED package
+// variable; external callers MUST go through LoadEmbeddedCatalog() and
+// NewSlimDeployerWithRenderer() rather than accessing embeddedRaw directly.
+//
+// DEFECT-5 INVARIANT: No exported function returns embeddedRaw or fs.FS over
+// the raw (unfiltered) embed. The only externally visible names are
+// LoadEmbeddedCatalog and NewSlimDeployerWithRenderer. See spec.md §"Overview"
+// [INVARIANT] block.
+package template
+
+import (
+	"fmt"
+)
+
+// @MX:NOTE: [AUTO] CATALOG-001 + CATALOG-002 wrapper convenience. Loads embedded catalog.yaml and returns typed *Catalog.
+//
+// LoadEmbeddedCatalog parses catalog.yaml from the embedded filesystem and
+// returns a fully-typed *Catalog. This is a convenience wrapper around
+// LoadCatalog(embeddedRaw) — external packages SHOULD use this entry point
+// rather than constructing their own catalog loaders.
+//
+// Returns CATALOG_LOAD_FAILED-tagged error (via caller's error wrapping) when
+// the manifest is missing or corrupt. See SPEC-V3R4-CATALOG-001 §"Loader API"
+// for the typed contract.
+func LoadEmbeddedCatalog() (*Catalog, error) {
+	cat, err := LoadCatalog(embeddedRaw)
+	if err != nil {
+		return nil, fmt.Errorf("load embedded catalog: %w", err)
+	}
+	return cat, nil
+}
+
+// @MX:ANCHOR: [AUTO] CATALOG-002 encapsulated entry point — sole external surface for slim deploy.
+// @MX:REASON: [AUTO] fan_in=1 now (init.go); future CATALOG-003/004 will route through this; preserves embeddedRaw encapsulation (DEFECT-5).
+//
+// NewSlimDeployerWithRenderer constructs a Deployer that writes only
+// core-tier catalog entries (plus non-catalog template files) by wrapping
+// the raw embedded filesystem in SlimFS before passing it to
+// NewDeployerWithRenderer. The caller-provided renderer is reused as-is.
+//
+// This is the encapsulated entry point for slim mode. External packages
+// MUST use this constructor rather than calling SlimFS(embeddedRaw, cat)
+// directly — the raw embed FS is an unexported package variable.
+//
+// Returns an error if cat is nil or if SlimFS wrapping fails.
+func NewSlimDeployerWithRenderer(cat *Catalog, renderer Renderer) (Deployer, error) {
+	if cat == nil {
+		return nil, fmt.Errorf("nil catalog")
+	}
+	slim, err := SlimFS(embeddedRaw, cat)
+	if err != nil {
+		return nil, fmt.Errorf("slim fs: %w", err)
+	}
+	return NewDeployerWithRenderer(slim, renderer), nil
+}

--- a/internal/template/embed_catalog_test.go
+++ b/internal/template/embed_catalog_test.go
@@ -1,0 +1,143 @@
+package template
+
+import (
+	"testing"
+	"testing/fstest"
+)
+
+// TestLoadEmbeddedCatalog_Success verifies that LoadEmbeddedCatalog wraps the
+// embedded raw FS correctly and returns a fully-typed *Catalog.
+//
+// SPEC-V3R4-CATALOG-002 T2.4.
+func TestLoadEmbeddedCatalog_Success(t *testing.T) {
+	t.Parallel()
+
+	cat, err := LoadEmbeddedCatalog()
+	if err != nil {
+		t.Fatalf("LoadEmbeddedCatalog() error = %v, want nil", err)
+	}
+	if cat == nil {
+		t.Fatal("LoadEmbeddedCatalog() returned nil catalog")
+	}
+
+	// Total entry count must match catalog.yaml ground truth.
+	const wantTotal = 65
+	all := cat.AllEntries()
+	if len(all) != wantTotal {
+		t.Errorf("LoadEmbeddedCatalog() AllEntries() = %d, want %d", len(all), wantTotal)
+	}
+}
+
+// TestNewSlimDeployerWithRenderer_NilCatalog verifies that passing a nil catalog
+// returns a descriptive error and not a panic.
+//
+// SPEC-V3R4-CATALOG-002 T2.4.
+func TestNewSlimDeployerWithRenderer_NilCatalog(t *testing.T) {
+	t.Parallel()
+
+	deployer, err := NewSlimDeployerWithRenderer(nil, nil)
+	if err == nil {
+		t.Fatal("NewSlimDeployerWithRenderer(nil, ...) returned nil error, want error containing \"nil catalog\"")
+	}
+	if deployer != nil {
+		t.Error("NewSlimDeployerWithRenderer(nil, ...) returned non-nil Deployer, want nil")
+	}
+
+	const wantSubstr = "nil catalog"
+	if !containsSubstring(err.Error(), wantSubstr) {
+		t.Errorf("NewSlimDeployerWithRenderer(nil, ...) error = %q, want substring %q", err.Error(), wantSubstr)
+	}
+}
+
+// TestNewSlimDeployerWithRenderer_Success verifies the happy path: a valid
+// catalog produces a non-nil Deployer with no error.
+//
+// SPEC-V3R4-CATALOG-002 T2.4.
+func TestNewSlimDeployerWithRenderer_Success(t *testing.T) {
+	t.Parallel()
+
+	cat, err := LoadEmbeddedCatalog()
+	if err != nil {
+		t.Fatalf("LoadEmbeddedCatalog() setup error: %v", err)
+	}
+
+	// Renderer is nil — NewDeployerWithRenderer accepts nil renderer without panic.
+	deployer, err := NewSlimDeployerWithRenderer(cat, nil)
+	if err != nil {
+		t.Fatalf("NewSlimDeployerWithRenderer(validCat, nil) error = %v, want nil", err)
+	}
+	if deployer == nil {
+		t.Error("NewSlimDeployerWithRenderer(validCat, nil) returned nil Deployer, want non-nil")
+	}
+}
+
+// TestNewSlimDeployerWithRenderer_EncapsulationGate documents the DEFECT-5
+// invariant: embeddedRaw MUST remain unexported. This test asserts via godoc
+// expectation; the CI grep gate (git grep 'EmbeddedRaw' internal/cli/) is
+// the enforcement mechanism.
+//
+// The test passes trivially — it is here as a living specification comment.
+// SPEC-V3R4-CATALOG-002 DEFECT-5.
+func TestNewSlimDeployerWithRenderer_EncapsulationGate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no_embedded_raw_export", func(t *testing.T) {
+		t.Parallel()
+
+		// This test documents the DEFECT-5 invariant. The package-level
+		// variable embeddedRaw is declared in embed.go as unexported. The CI
+		// grep gate verifies this at the file level. From inside a *_test.go
+		// file in the same package we can confirm the variable is accessible
+		// (intra-package visibility) but NOT exported (no capital letter).
+		//
+		// We simply exercise LoadEmbeddedCatalog which internally uses
+		// embeddedRaw; if the encapsulation were broken the grep CI gate
+		// would have already failed. This test is a specification anchor.
+		cat, err := LoadEmbeddedCatalog()
+		if err != nil {
+			t.Errorf("encapsulation gate: LoadEmbeddedCatalog() unexpectedly failed: %v", err)
+		}
+		if cat == nil {
+			t.Error("encapsulation gate: LoadEmbeddedCatalog() returned nil catalog")
+		}
+	})
+}
+
+// TestLoadEmbeddedCatalog_LoadCatalogErrorWrapping verifies that LoadCatalog
+// returns a non-nil error when catalog.yaml is absent from the provided FS.
+// This exercises the error-return path that LoadEmbeddedCatalog wraps.
+//
+// Note: LoadEmbeddedCatalog itself can only fail in production if the binary's
+// embedded catalog.yaml is corrupt, which is not reproducible without patching
+// the unexported embeddedRaw variable. Instead we test the underlying path
+// to confirm coverage of the error-wrapping branch is met through LoadCatalog.
+//
+// SPEC-V3R4-CATALOG-002 T2.4.
+func TestLoadEmbeddedCatalog_LoadCatalogErrorWrapping(t *testing.T) {
+	t.Parallel()
+
+	// Use an empty FS — LoadCatalog must return CATALOG_MANIFEST_ABSENT error.
+	emptyFS := fstest.MapFS{}
+	_, err := LoadCatalog(emptyFS)
+	if err == nil {
+		t.Error("LoadCatalog(emptyFS) should return error, got nil")
+	}
+	if !containsSubstring(err.Error(), "CATALOG_MANIFEST_ABSENT") {
+		t.Errorf("LoadCatalog(emptyFS) error = %q, want CATALOG_MANIFEST_ABSENT", err.Error())
+	}
+}
+
+// containsSubstring is a helper to avoid importing strings inside
+// this test file (already imported elsewhere in the package).
+func containsSubstring(s, sub string) bool {
+	return len(s) >= len(sub) && containsHelper(s, sub)
+}
+
+func containsHelper(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/template/slim_fs.go
+++ b/internal/template/slim_fs.go
@@ -1,0 +1,232 @@
+// slim_fs.go — catalog-tier-aware filesystem wrapper for SPEC-V3R4-CATALOG-002 M1.
+//
+// SlimFS wraps a raw fs.FS (typically embeddedRaw) and filters out all catalog
+// entries whose tier is not TierCore. Non-catalog paths pass through unchanged.
+// The returned fs.FS strips the "templates/" prefix via fs.Sub so that callers
+// see paths matching deployment targets (e.g. ".claude/skills/moai/SKILL.md").
+//
+// REQ-001: nil-input validation.
+// REQ-002: prefix stripped via fs.Sub(wrapper, "templates").
+// REQ-003: read-only struct — no sync.*, no chan, no field mutation after construction.
+// REQ-010: hidden paths return &fs.PathError{Err: fs.ErrNotExist}.
+// REQ-011: ReadDir filters hidden entries from directory listings.
+package template
+
+import (
+	"errors"
+	"io/fs"
+	"path"
+	"strings"
+)
+
+// slimFS is an immutable filesystem wrapper that hides non-core catalog entries.
+//
+// Invariants:
+//   - underlying is set once at construction and never mutated.
+//   - denySet is set once at construction and used read-only thereafter.
+//   - No goroutines are spawned; all operations are synchronous and stateless.
+//
+// Interface compliance is asserted via compile-time blank-identifier checks below.
+type slimFS struct {
+	underlying fs.FS              // immutable after construction
+	denySet    map[string]struct{} // immutable after construction (read-only lookups)
+}
+
+// Compile-time interface assertions — fail at build time if not satisfied.
+var _ fs.FS        = (*slimFS)(nil)
+var _ fs.StatFS    = (*slimFS)(nil)
+var _ fs.ReadDirFS = (*slimFS)(nil)
+
+// computeDenySet builds the set of catalog entry paths that must be hidden.
+// Only non-core entries are added. Paths are kept as-is from catalog.yaml
+// (already "templates/"-prefixed). Both directory entries (ending with "/")
+// and single-file entries are supported.
+func computeDenySet(cat *Catalog) map[string]struct{} {
+	deny := make(map[string]struct{})
+	for _, e := range cat.AllEntries() {
+		if e.Tier == TierCore {
+			continue
+		}
+		// Path is already "templates/"-prefixed per catalog.yaml convention.
+		// Keep as-is — the wrapper receives "templates/"-prefixed names from
+		// fs.Sub because fs.Sub transparently re-prepends the prefix when
+		// dispatching to the wrapped FS.
+		deny[e.Path] = struct{}{}
+	}
+	return deny
+}
+
+// isHidden reports whether name refers to a hidden path (a non-core catalog
+// entry or anything under one).
+//
+// Matching rules:
+//  1. Exact match: name == deniedPath.
+//  2. Prefix match: name has deniedPath as prefix (covers nested files).
+//  3. Directory-without-slash: deniedPath ends with "/" but name omits the
+//     trailing slash (e.g. name="templates/foo", deny="templates/foo/").
+func (s *slimFS) isHidden(name string) bool {
+	for deniedPath := range s.denySet {
+		// Rule 1: exact match.
+		if name == deniedPath {
+			return true
+		}
+		// Rule 2: prefix match — name is inside the denied subtree.
+		if strings.HasPrefix(name, deniedPath) {
+			return true
+		}
+		// Rule 3: directory denied as "templates/foo/" but name is "templates/foo".
+		if withoutSlash, ok := strings.CutSuffix(deniedPath, "/"); ok && name == withoutSlash {
+			return true
+		}
+	}
+	return false
+}
+
+// slimDir wraps a directory fs.File and overrides ReadDir to apply the same
+// catalog-tier filtering as slimFS.ReadDir. This ensures consistency between
+// Open().ReadDir() and fs.ReadDir(fsys, name), which fstest.TestFS verifies.
+type slimDir struct {
+	fs.File                   // embedded underlying directory file
+	name   string             // directory path (for child path construction)
+	slim   *slimFS            // parent filter — provides isHidden
+}
+
+// ReadDir implements fs.ReadDirFile for slimDir, returning only non-hidden entries.
+func (d *slimDir) ReadDir(n int) ([]fs.DirEntry, error) {
+	rdf, ok := d.File.(fs.ReadDirFile)
+	if !ok {
+		return nil, &fs.PathError{Op: "readdir", Path: d.name, Err: errors.New("not a directory")}
+	}
+	entries, err := rdf.ReadDir(n)
+	if err != nil && len(entries) == 0 {
+		return nil, err
+	}
+	filtered := make([]fs.DirEntry, 0, len(entries))
+	for _, ent := range entries {
+		var childPath string
+		if d.name == "." {
+			childPath = ent.Name()
+		} else {
+			childPath = path.Join(d.name, ent.Name())
+		}
+		if d.slim.isHidden(childPath) {
+			continue
+		}
+		filtered = append(filtered, ent)
+	}
+	return filtered, err
+}
+
+// Open opens the named file. If the path is hidden, Open returns an error
+// satisfying errors.Is(err, fs.ErrNotExist).
+//
+// name must be a valid fs.FS path (no leading slash, use "/" as separator).
+// fs.Sub re-prepends "templates/" when dispatching here, so name is already
+// "templates/"-prefixed.
+//
+// For directory files, Open returns a slimDir that also filters ReadDir results
+// to ensure consistency with slimFS.ReadDir (required by fstest.TestFS).
+func (s *slimFS) Open(name string) (fs.File, error) {
+	if s.isHidden(name) {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrNotExist}
+	}
+	f, err := s.underlying.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	// Wrap directories so their ReadDir results are also filtered.
+	info, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	if info.IsDir() {
+		return &slimDir{File: f, name: name, slim: s}, nil
+	}
+	return f, nil
+}
+
+// Stat returns FileInfo for the named file. If the path is hidden, Stat
+// returns an error satisfying errors.Is(err, fs.ErrNotExist).
+func (s *slimFS) Stat(name string) (fs.FileInfo, error) {
+	if s.isHidden(name) {
+		return nil, &fs.PathError{Op: "stat", Path: name, Err: fs.ErrNotExist}
+	}
+	// Prefer StatFS fast path if the underlying FS implements it.
+	if statFS, ok := s.underlying.(fs.StatFS); ok {
+		return statFS.Stat(name)
+	}
+	// Fallback: open the file and call Stat on the handle.
+	f, err := s.underlying.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	return f.Stat()
+}
+
+// ReadDir reads the directory named by name and returns a filtered list of
+// directory entries. Hidden entries are excluded. If the directory itself is
+// hidden, ReadDir returns an error satisfying errors.Is(err, fs.ErrNotExist).
+func (s *slimFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	if s.isHidden(name) {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrNotExist}
+	}
+
+	entries, err := fs.ReadDir(s.underlying, name)
+	if err != nil {
+		return nil, err
+	}
+
+	filtered := make([]fs.DirEntry, 0, len(entries))
+	for _, ent := range entries {
+		var childPath string
+		if name == "." {
+			childPath = ent.Name()
+		} else {
+			childPath = path.Join(name, ent.Name())
+		}
+		if s.isHidden(childPath) {
+			continue
+		}
+		filtered = append(filtered, ent)
+	}
+	return filtered, nil
+}
+
+// SlimFS wraps rawFS such that catalog entries with tier != TierCore are
+// hidden from Open/Stat/ReadDir, while non-catalog files pass through unchanged.
+//
+// The returned fs.FS strips the "templates/" prefix via fs.Sub so that callers
+// see paths matching deployment targets (e.g. ".claude/skills/moai/SKILL.md").
+//
+// REQ-001 / REQ-002 contract:
+//   - SlimFS(rawFS fs.FS, cat *Catalog) (fs.FS, error)
+//   - Returned FS drops the "templates/" prefix via fs.Sub(wrapper, "templates")
+//
+// REQ-003 invariant: the returned FS is read-only — slimFS has no sync.*, no
+// chan, and no field mutation after construction. No goroutines are spawned.
+//
+// Returns a non-nil error if rawFS == nil or cat == nil.
+//
+// @MX:ANCHOR: [AUTO] Primary SlimFS constructor — expected fan_in >= 3 (init, update, audit, M3 parallel stress)
+// @MX:REASON: [AUTO] fan_in >= 3; sole entry point for catalog-tier-aware FS filtering; REQ-001/REQ-002/REQ-003 enforced here
+func SlimFS(rawFS fs.FS, cat *Catalog) (fs.FS, error) {
+	if rawFS == nil {
+		return nil, errors.New("slim fs: rawFS must not be nil")
+	}
+	if cat == nil {
+		return nil, errors.New("slim fs: catalog must not be nil")
+	}
+
+	wrapper := &slimFS{
+		underlying: rawFS,
+		denySet:    computeDenySet(cat),
+	}
+
+	// Strip the "templates/" prefix so the caller sees deployment-target paths.
+	// fs.Sub transparently re-prepends "templates/" when re-dispatching Open,
+	// Stat, and ReadDir to the wrapped slimFS — the wrapper must NOT re-prepend
+	// it again (anti-pattern: double-prefix bug).
+	return fs.Sub(wrapper, "templates")
+}

--- a/internal/template/slim_fs_test.go
+++ b/internal/template/slim_fs_test.go
@@ -1,0 +1,456 @@
+// slim_fs_test.go — unit tests for SlimFS (SPEC-V3R4-CATALOG-002 M1).
+//
+// Tests use a synthetic fstest.MapFS to avoid coupling to the real embedded
+// filesystem. Every test assertion emits via t.Errorf (not t.Logf) following
+// the CATALOG-001 EC3 sentinel discipline.
+//
+// REQ coverage: REQ-001 (nil validation), REQ-002 (prefix stripped),
+// REQ-003 (read-only struct), REQ-010 (fs.ErrNotExist on hidden),
+// REQ-011 (ReadDir filter).
+package template
+
+import (
+	"errors"
+	"io/fs"
+	"testing"
+	"testing/fstest"
+)
+
+// syntheticRaw builds a MapFS that mimics the shape of embeddedRaw:
+// paths are "templates/"-prefixed, and the FS is rooted at the embed root.
+//
+// The synthetic catalog contains:
+//   - One core skill directory: templates/.claude/skills/moai/
+//   - One optional skill directory: templates/.claude/skills/optional-pack/
+//   - One non-catalog file: templates/.claude/rules/some-rule.md
+func newSyntheticMapFS() fstest.MapFS {
+	return fstest.MapFS{
+		// Core skill (should be visible after SlimFS)
+		"templates/.claude/skills/moai/SKILL.md": {
+			Data: []byte("core skill content"),
+		},
+		"templates/.claude/skills/moai/sub-dir/nested.md": {
+			Data: []byte("nested core content"),
+		},
+		// Optional skill (should be hidden after SlimFS)
+		"templates/.claude/skills/optional-pack/SKILL.md": {
+			Data: []byte("optional skill content"),
+		},
+		"templates/.claude/skills/optional-pack/sub-dir/file.md": {
+			Data: []byte("optional nested content"),
+		},
+		// Non-catalog file (should pass through unchanged)
+		"templates/.claude/rules/some-rule.md": {
+			Data: []byte("rule content"),
+		},
+		// Parent directory entries for ReadDir tests
+		"templates/.claude/skills": {Mode: fs.ModeDir},
+		"templates/.claude":        {Mode: fs.ModeDir},
+		"templates":                {Mode: fs.ModeDir},
+	}
+}
+
+// newSyntheticCatalog builds a *Catalog with the synthetic entries above.
+// One core entry, one optional entry — no harness-generated entries.
+func newSyntheticCatalog() *Catalog {
+	return &Catalog{
+		Version:     "1.0.0",
+		GeneratedAt: "2026-05-12T00:00:00Z",
+		Catalog: CatalogSections{
+			Core: TierSection{
+				Skills: []Entry{
+					{
+						Name:    "moai",
+						Tier:    TierCore,
+						Path:    "templates/.claude/skills/moai/",
+						Hash:    "abc123",
+						Version: "1.0.0",
+					},
+				},
+			},
+			OptionalPacks: map[string]*Pack{
+				"domain": {
+					Description: "Domain pack",
+					Skills: []Entry{
+						{
+							Name:    "optional-pack",
+							Tier:    "optional-pack:domain",
+							Path:    "templates/.claude/skills/optional-pack/",
+							Hash:    "def456",
+							Version: "1.0.0",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestSlimFS_NilInputs verifies that SlimFS returns a non-nil error when
+// rawFS or cat is nil.
+//
+// REQ-001: nil-input validation.
+func TestSlimFS_NilInputs(t *testing.T) {
+	t.Parallel()
+
+	cat := newSyntheticCatalog()
+	rawFS := newSyntheticMapFS()
+
+	// nil rawFS
+	_, err := SlimFS(nil, cat)
+	if err == nil {
+		t.Errorf("SlimFS(nil, cat): expected non-nil error, got nil")
+	}
+
+	// nil catalog
+	_, err = SlimFS(rawFS, nil)
+	if err == nil {
+		t.Errorf("SlimFS(rawFS, nil): expected non-nil error, got nil")
+	}
+}
+
+// TestSlimFS_BasicHide verifies that a core entry is visible and an optional
+// entry is hidden after SlimFS returns the sub-FS.
+//
+// REQ-002: prefix stripped. REQ-010: fs.ErrNotExist on hidden.
+func TestSlimFS_BasicHide(t *testing.T) {
+	t.Parallel()
+
+	rawFS := newSyntheticMapFS()
+	cat := newSyntheticCatalog()
+
+	slim, err := SlimFS(rawFS, cat)
+	if err != nil {
+		t.Fatalf("SlimFS() unexpected error: %v", err)
+	}
+
+	// Core skill must be reachable (prefix stripped: no "templates/" in path)
+	if _, err := fs.Stat(slim, ".claude/skills/moai/SKILL.md"); err != nil {
+		t.Errorf("SlimFS: core skill hidden unexpectedly: fs.Stat(.claude/skills/moai/SKILL.md) = %v", err)
+	}
+
+	// Optional skill must be hidden
+	_, err = fs.Stat(slim, ".claude/skills/optional-pack/SKILL.md")
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("SlimFS: optional skill not hidden: fs.Stat(.claude/skills/optional-pack/SKILL.md) = %v (want fs.ErrNotExist)", err)
+	}
+}
+
+// TestSlimFS_NestedHide verifies that files nested inside a hidden directory
+// are also hidden (recursive deny).
+//
+// REQ-010: fs.ErrNotExist on hidden (recursive).
+func TestSlimFS_NestedHide(t *testing.T) {
+	t.Parallel()
+
+	rawFS := newSyntheticMapFS()
+	cat := newSyntheticCatalog()
+
+	slim, err := SlimFS(rawFS, cat)
+	if err != nil {
+		t.Fatalf("SlimFS() unexpected error: %v", err)
+	}
+
+	// Nested file inside the optional directory must also be hidden
+	_, err = fs.Stat(slim, ".claude/skills/optional-pack/sub-dir/file.md")
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("SlimFS: nested optional file not hidden: fs.Stat(.claude/skills/optional-pack/sub-dir/file.md) = %v (want fs.ErrNotExist)", err)
+	}
+}
+
+// TestSlimFS_NonCatalogPassthrough verifies that a file NOT in the catalog
+// passes through unchanged.
+//
+// REQ-002: non-catalog paths are not filtered.
+func TestSlimFS_NonCatalogPassthrough(t *testing.T) {
+	t.Parallel()
+
+	rawFS := newSyntheticMapFS()
+	cat := newSyntheticCatalog()
+
+	slim, err := SlimFS(rawFS, cat)
+	if err != nil {
+		t.Fatalf("SlimFS() unexpected error: %v", err)
+	}
+
+	// Non-catalog file must pass through
+	if _, err := fs.Stat(slim, ".claude/rules/some-rule.md"); err != nil {
+		t.Errorf("SlimFS: non-catalog file hidden unexpectedly: fs.Stat(.claude/rules/some-rule.md) = %v", err)
+	}
+}
+
+// TestSlimFS_ReadDirFilter verifies that ReadDir excludes hidden entries but
+// includes core entries.
+//
+// REQ-011: ReadDir filter.
+func TestSlimFS_ReadDirFilter(t *testing.T) {
+	t.Parallel()
+
+	rawFS := newSyntheticMapFS()
+	cat := newSyntheticCatalog()
+
+	slim, err := SlimFS(rawFS, cat)
+	if err != nil {
+		t.Fatalf("SlimFS() unexpected error: %v", err)
+	}
+
+	entries, err := fs.ReadDir(slim, ".claude/skills")
+	if err != nil {
+		t.Fatalf("SlimFS ReadDir(.claude/skills) unexpected error: %v", err)
+	}
+
+	foundCore := false
+	foundOptional := false
+	for _, e := range entries {
+		switch e.Name() {
+		case "moai":
+			foundCore = true
+		case "optional-pack":
+			foundOptional = true
+		}
+	}
+
+	if !foundCore {
+		t.Errorf("SlimFS ReadDir: core entry 'moai' missing from .claude/skills")
+	}
+	if foundOptional {
+		t.Errorf("SlimFS ReadDir: optional entry 'optional-pack' present in .claude/skills (should be filtered)")
+	}
+}
+
+// TestSlimFS_StatHiddenReturnsErrNotExist verifies that a direct fs.Stat on a
+// hidden path returns an error satisfying errors.Is(err, fs.ErrNotExist).
+//
+// REQ-010: exact error type check.
+func TestSlimFS_StatHiddenReturnsErrNotExist(t *testing.T) {
+	t.Parallel()
+
+	rawFS := newSyntheticMapFS()
+	cat := newSyntheticCatalog()
+
+	slim, err := SlimFS(rawFS, cat)
+	if err != nil {
+		t.Fatalf("SlimFS() unexpected error: %v", err)
+	}
+
+	_, err = fs.Stat(slim, ".claude/skills/optional-pack/SKILL.md")
+	if err == nil {
+		t.Errorf("SlimFS Stat(hidden): got nil error, want fs.ErrNotExist")
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("SlimFS Stat(hidden): got %v, want errors.Is(err, fs.ErrNotExist) = true", err)
+	}
+}
+
+// TestSlimFS_FsSubContract uses fstest.TestFS to verify the returned FS
+// satisfies the io/fs interface contract.
+//
+// REQ-002: fs.Sub bypass detection (R7 mitigation).
+func TestSlimFS_FsSubContract(t *testing.T) {
+	t.Parallel()
+
+	rawFS := newSyntheticMapFS()
+	cat := newSyntheticCatalog()
+
+	slim, err := SlimFS(rawFS, cat)
+	if err != nil {
+		t.Fatalf("SlimFS() unexpected error: %v", err)
+	}
+
+	// fstest.TestFS validates Open, Stat, ReadDir, and other fs.FS invariants.
+	// We exercise the core path which must be reachable.
+	if err := fstest.TestFS(slim, ".claude/skills/moai/SKILL.md"); err != nil {
+		t.Errorf("SlimFS fstest.TestFS contract violation: %v", err)
+	}
+}
+
+// TestSlimFS_NonCoreEntryIsTierOptionalOrHarness is a defensive test that
+// verifies every entry in the deny set has tier != TierCore.
+//
+// Protects against future manifest expansion introducing core entries in deny set.
+func TestSlimFS_NonCoreEntryIsTierOptionalOrHarness(t *testing.T) {
+	t.Parallel()
+
+	cat := newSyntheticCatalog()
+	deny := computeDenySet(cat)
+
+	// Build a reverse lookup: path → entry
+	for _, e := range cat.AllEntries() {
+		if _, inDeny := deny[e.Path]; inDeny {
+			if e.Tier == TierCore {
+				t.Errorf("SlimFS deny set contains core entry: %q (tier=%q)", e.Path, e.Tier)
+			}
+		}
+	}
+}
+
+// TestSlimFS_StatFSInterface confirms that the internal slimFS struct satisfies
+// fs.StatFS via type assertion.
+//
+// REQ-003: interface compliance lock-in.
+func TestSlimFS_StatFSInterface(t *testing.T) {
+	t.Parallel()
+
+	rawFS := newSyntheticMapFS()
+	cat := newSyntheticCatalog()
+
+	wrapper := &slimFS{
+		underlying: rawFS,
+		denySet:    computeDenySet(cat),
+	}
+
+	// Type assertion: slimFS must implement fs.StatFS
+	var _ fs.StatFS = wrapper
+	if _, ok := any(wrapper).(fs.StatFS); !ok {
+		t.Errorf("slimFS does not implement fs.StatFS")
+	}
+}
+
+// TestSlimFS_ReadDirFSInterface confirms that the internal slimFS struct
+// satisfies fs.ReadDirFS via type assertion.
+//
+// REQ-003: interface compliance lock-in.
+func TestSlimFS_ReadDirFSInterface(t *testing.T) {
+	t.Parallel()
+
+	rawFS := newSyntheticMapFS()
+	cat := newSyntheticCatalog()
+
+	wrapper := &slimFS{
+		underlying: rawFS,
+		denySet:    computeDenySet(cat),
+	}
+
+	// Type assertion: slimFS must implement fs.ReadDirFS
+	var _ fs.ReadDirFS = wrapper
+	if _, ok := any(wrapper).(fs.ReadDirFS); !ok {
+		t.Errorf("slimFS does not implement fs.ReadDirFS")
+	}
+}
+
+// noStatFS wraps an fs.FS but does NOT implement fs.StatFS, forcing SlimFS.Stat
+// to take the fallback Open+Stat code path.
+type noStatFS struct {
+	inner fs.FS
+}
+
+func (n noStatFS) Open(name string) (fs.File, error) { return n.inner.Open(name) }
+
+// TestSlimFS_StatFallbackPath exercises the Stat() fallback that uses Open+Stat
+// when the underlying FS does not implement fs.StatFS.
+//
+// REQ-003: read-only, all code paths exercised.
+func TestSlimFS_StatFallbackPath(t *testing.T) {
+	t.Parallel()
+
+	// Wrap the MapFS in noStatFS to strip the StatFS interface.
+	rawFS := noStatFS{inner: newSyntheticMapFS()}
+	cat := newSyntheticCatalog()
+
+	slim, err := SlimFS(rawFS, cat)
+	if err != nil {
+		t.Fatalf("SlimFS() unexpected error: %v", err)
+	}
+
+	// Core path must be reachable via the Stat fallback.
+	if _, err := fs.Stat(slim, ".claude/skills/moai/SKILL.md"); err != nil {
+		t.Errorf("SlimFS Stat fallback: core file stat failed: %v", err)
+	}
+
+	// Hidden path must still return fs.ErrNotExist.
+	_, err = fs.Stat(slim, ".claude/skills/optional-pack/SKILL.md")
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("SlimFS Stat fallback: hidden file returned %v, want fs.ErrNotExist", err)
+	}
+}
+
+// TestSlimFS_OpenCoreFileRead verifies that a core file can be opened and its
+// content read after SlimFS is applied.
+func TestSlimFS_OpenCoreFileRead(t *testing.T) {
+	t.Parallel()
+
+	rawFS := newSyntheticMapFS()
+	cat := newSyntheticCatalog()
+
+	slim, err := SlimFS(rawFS, cat)
+	if err != nil {
+		t.Fatalf("SlimFS() unexpected error: %v", err)
+	}
+
+	f, err := slim.Open(".claude/skills/moai/SKILL.md")
+	if err != nil {
+		t.Fatalf("SlimFS Open core file: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	buf := make([]byte, 64)
+	n, _ := f.Read(buf)
+	if n == 0 {
+		t.Errorf("SlimFS Open core file: read 0 bytes, expected content")
+	}
+}
+
+// TestSlimFSWrapper_StatDirect exercises slimFS.Stat() directly (bypassing fs.Sub),
+// covering both the StatFS fast path and the Open+Stat fallback path.
+//
+// Note: fs.Sub does NOT propagate StatFS to the outer FS (it implements only
+// Open/ReadDir/ReadFile), so direct invocation is the only way to cover Stat lines.
+func TestSlimFSWrapper_StatDirect(t *testing.T) {
+	t.Parallel()
+
+	rawFS := newSyntheticMapFS()
+	cat := newSyntheticCatalog()
+
+	// Fast path: underlying implements fs.StatFS (MapFS does).
+	wrapper := &slimFS{
+		underlying: rawFS,
+		denySet:    computeDenySet(cat),
+	}
+
+	// Stat a core (visible) path.
+	info, err := wrapper.Stat("templates/.claude/skills/moai/SKILL.md")
+	if err != nil {
+		t.Errorf("slimFS.Stat (fast path) core: %v", err)
+	}
+	if info == nil {
+		t.Errorf("slimFS.Stat (fast path) core: got nil FileInfo")
+	}
+
+	// Stat a hidden path.
+	_, err = wrapper.Stat("templates/.claude/skills/optional-pack/SKILL.md")
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("slimFS.Stat (fast path) hidden: got %v, want fs.ErrNotExist", err)
+	}
+
+	// Fallback path: underlying does NOT implement fs.StatFS.
+	noStatWrapper := &slimFS{
+		underlying: noStatFS{inner: rawFS},
+		denySet:    computeDenySet(cat),
+	}
+
+	info, err = noStatWrapper.Stat("templates/.claude/skills/moai/SKILL.md")
+	if err != nil {
+		t.Errorf("slimFS.Stat (fallback) core: %v", err)
+	}
+	if info == nil {
+		t.Errorf("slimFS.Stat (fallback) core: got nil FileInfo")
+	}
+}
+
+// TestSlimFSWrapper_ReadDirDirectHidden exercises slimFS.ReadDir() directly on a
+// hidden directory to cover the early-return path.
+func TestSlimFSWrapper_ReadDirDirectHidden(t *testing.T) {
+	t.Parallel()
+
+	rawFS := newSyntheticMapFS()
+	cat := newSyntheticCatalog()
+
+	wrapper := &slimFS{
+		underlying: rawFS,
+		denySet:    computeDenySet(cat),
+	}
+
+	_, err := wrapper.ReadDir("templates/.claude/skills/optional-pack")
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("slimFS.ReadDir hidden dir: got %v, want fs.ErrNotExist", err)
+	}
+}

--- a/internal/template/slim_guard.go
+++ b/internal/template/slim_guard.go
@@ -1,0 +1,36 @@
+package template
+
+import (
+	"fmt"
+	"io/fs"
+)
+
+// @MX:NOTE: [AUTO] CATALOG-002 REQ-021 friendly error — sentinel CATALOG_SLIM_HARNESS_MISSING + 4-substring hint for moai doctor diagnostic routing.
+//
+// AssertBuilderHarnessAvailable returns a CATALOG_SLIM_HARNESS_MISSING-tagged
+// error when the builder-harness agent is absent from the given project FS.
+// When builder-harness is present (e.g., after the user opted into full deploy
+// via --all or MOAI_DISTRIBUTE_ALL=1, or after SPEC-V3R4-CATALOG-005 bootstrap),
+// returns nil.
+//
+// The returned error message contains four well-known substrings that
+// downstream tooling (moai doctor) can match for diagnostic routing:
+//   - "CATALOG_SLIM_HARNESS_MISSING" (sentinel)
+//   - "MOAI_DISTRIBUTE_ALL=1" (env opt-out hint)
+//   - "moai init --all" (flag opt-out hint)
+//   - "SPEC-V3R4-CATALOG-005" (forward reference to auto-bootstrap)
+//
+// Source: SPEC-V3R4-CATALOG-002 REQ-021.
+func AssertBuilderHarnessAvailable(projectFS fs.FS) error {
+	if projectFS == nil {
+		return nil
+	}
+	_, err := fs.Stat(projectFS, ".claude/agents/moai/builder-harness.md")
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf(
+		"CATALOG_SLIM_HARNESS_MISSING: builder-harness omitted in slim mode. "+
+			"Run `moai init --all` or set MOAI_DISTRIBUTE_ALL=1, or wait for "+
+			"SPEC-V3R4-CATALOG-005 auto-bootstrap. (underlying: %w)", err)
+}

--- a/internal/template/slim_guard_test.go
+++ b/internal/template/slim_guard_test.go
@@ -1,0 +1,74 @@
+package template
+
+import (
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+// TestAssertBuilderHarnessAvailable_Present verifies that when builder-harness.md
+// exists in the project FS, AssertBuilderHarnessAvailable returns nil.
+//
+// SPEC-V3R4-CATALOG-002 T2.6 / REQ-021.
+func TestAssertBuilderHarnessAvailable_Present(t *testing.T) {
+	t.Parallel()
+
+	projectFS := fstest.MapFS{
+		".claude/agents/moai/builder-harness.md": &fstest.MapFile{
+			Data: []byte("# builder-harness\n"),
+		},
+	}
+
+	err := AssertBuilderHarnessAvailable(projectFS)
+	if err != nil {
+		t.Errorf("AssertBuilderHarnessAvailable(present) = %v, want nil", err)
+	}
+}
+
+// TestAssertBuilderHarnessAvailable_Missing verifies that when builder-harness.md
+// is absent, AssertBuilderHarnessAvailable returns a CATALOG_SLIM_HARNESS_MISSING
+// error containing all 4 required diagnostic substrings.
+//
+// SPEC-V3R4-CATALOG-002 T2.6 / REQ-021.
+func TestAssertBuilderHarnessAvailable_Missing(t *testing.T) {
+	t.Parallel()
+
+	projectFS := fstest.MapFS{
+		// Some other file exists but NOT builder-harness.md
+		".claude/agents/moai/expert-backend.md": &fstest.MapFile{
+			Data: []byte("# expert-backend\n"),
+		},
+	}
+
+	err := AssertBuilderHarnessAvailable(projectFS)
+	if err == nil {
+		t.Fatal("AssertBuilderHarnessAvailable(missing) = nil, want CATALOG_SLIM_HARNESS_MISSING error")
+	}
+
+	// Verify all 4 required substrings are present in the error message.
+	substrings := []string{
+		"CATALOG_SLIM_HARNESS_MISSING",
+		"MOAI_DISTRIBUTE_ALL=1",
+		"moai init --all",
+		"SPEC-V3R4-CATALOG-005",
+	}
+	for _, sub := range substrings {
+		if !strings.Contains(err.Error(), sub) {
+			t.Errorf("AssertBuilderHarnessAvailable(missing) error missing substring %q; full error: %q",
+				sub, err.Error())
+		}
+	}
+}
+
+// TestAssertBuilderHarnessAvailable_NilFS verifies the defensive nil check:
+// a nil projectFS must return nil (no panic).
+//
+// SPEC-V3R4-CATALOG-002 T2.6 / REQ-021.
+func TestAssertBuilderHarnessAvailable_NilFS(t *testing.T) {
+	t.Parallel()
+
+	err := AssertBuilderHarnessAvailable(nil)
+	if err != nil {
+		t.Errorf("AssertBuilderHarnessAvailable(nil) = %v, want nil", err)
+	}
+}


### PR DESCRIPTION
## Summary

- **BREAKING CHANGE**: `moai init` default deploys only core-tier catalog entries (25/65 hidden ≈ 38% slim). Opt-out via `--all` flag or `MOAI_DISTRIBUTE_ALL=1` env var.
- Introduces `SlimFS` `fs.FS` wrapper + encapsulated slim deployer constructor + builder-harness friendly error guard + 6-subtest audit suite against the real production catalog.
- D7 lock preserved (`deployer.go`, `update.go`, `embed.go`, `catalog.yaml`, `catalog_loader.go` all unchanged). DEFECT-5 encapsulation invariant maintained (`embeddedRaw` unexported).

## SPEC

- Plan PR: #865 (merged → `2d6d8c33b`)
- Wave 2 Distribution; builds on CATALOG-001 (#862 / `cc8079aed`).
- Cross-SPEC boundary: this SPEC is a *consumer* of CATALOG-001's manifest (no manifest change). CATALOG-003 = interactive `moai pack add`; CATALOG-004 = update drift sync; CATALOG-005 = builder-harness auto-bootstrap.

## Implementation

| Module | Files | LOC | Coverage |
|--------|-------|-----|----------|
| M1 SlimFS wrapper | `slim_fs.go` + `_test` | 235 + 456 | 91.1% |
| M2 Encapsulated constructor | `embed_catalog.go` + `_test`, `slim_guard.go` + `_test` | 59+143+36+74 | guard 100%, constructor 75-83% (error path architecturally unreachable) |
| M2 CLI integration | `init.go` (+58/-3), `init_slim_branch_test.go` | +58/+184 | shouldDistributeAll 100% |
| M3 Audit suite | `catalog_slim_audit_test.go` | 242 | hides 25 non-core + preserves 40 core + EC4 nested + 5 non-catalog + WalkDir 523 paths zero-leak + 32-goroutine race-clean |
| M5 Docs | `CHANGELOG.md` BREAKING CHANGE, `catalog_doc.md` Tier filter consumers, `init.go` Long help | bilingual ko+en | — |
| P2-1 fix | `emitSlimModeNotice` helper + 4-substring regression test | +25 LOC | included |

## Quality Gates

- ✅ plan-auditor PASS 0.91 (≥ 0.88 stretch target)
- ✅ evaluator-active PASS 0.916 (Func 88 / Sec 100 / Craft 88 / Cons 92) — zero P0/P1 defects
- ✅ `go test -race -count=1 ./internal/template/... ./internal/cli/...` PASS
- ✅ `golangci-lint run ./internal/template/... ./internal/cli/...` 0 issues
- ✅ DEFECT-5 encapsulation gate: `git grep 'EmbeddedRaw[A-Za-z]*' internal/cli/` zero matches
- ✅ D7 lock preserved: `git diff --name-only` empty for protected files
- ✅ Sentinel discipline: all failure emissions `t.Errorf` (NOT `t.Logf`) — CATALOG-001 EC3 lesson honored

## Sentinels Introduced

| Sentinel | Source | Verifies |
|---|---|---|
| `CATALOG_SLIM_LEAK: <path> tier=<tier>` | `TestSlimFS_HidesNonCoreEntries` | REQ-014 |
| `CATALOG_SLIM_CORE_MISSING: <path>` | `TestSlimFS_PreservesCoreEntries` | REQ-015 + EC4 |
| `CATALOG_SLIM_OVER_FILTER: <path>` | `TestSlimFS_PreservesNonCatalogFiles` | REQ-016 |
| `CATALOG_SLIM_WALK_LEAK: <path>` | `TestSlimFS_WalkDirNoLeak` | REQ-017 |
| `CATALOG_SLIM_NOT_READONLY: ...` | `TestSlimFS_ReadOnlyInvariant` | REQ-003 |
| `CATALOG_SLIM_HARNESS_MISSING` | `slim_guard.go` runtime + `slim_guard_test.go` | REQ-021 |
| `CATALOG_LOAD_FAILED` | `init.go` early return + `embed_catalog.go` | REQ-008 |

## Test Plan

- [x] `go test -race -count=1 ./internal/template/... ./internal/cli/...` (verified)
- [x] `golangci-lint run ./internal/template/... ./internal/cli/...` (0 issues)
- [x] DEFECT-5 grep + D7 lock diff (verified empty)
- [ ] CI 14 jobs GREEN (Test×3 OS + Build×5 + Lint + Constitution + Integration×3 + CodeQL) — pending CI run
- [ ] BREAKING CHANGE row visible in CHANGELOG.md (verify after merge)

## Follow-ups

- P2-2 (evaluator finding, deferred): `embed_catalog.go` error path coverage 75-83% — architecturally unreachable (`embeddedRaw` always valid in binary). Address in CATALOG-003 if structural changes allow.
- P3 findings (3, post-merge): runInit CATALOG_LOAD_FAILED e2e test, @MX:ANCHOR fan_in promotion after CATALOG-003/004 lands, denySet immutability godoc-only invariant.

## Merge

Use `--squash`. Per CLAUDE.local.md §18.3 + plan-in-main doctrine (PR #822), feature → main is always squash.

🗿 MoAI <email@mo.ai.kr>