### PR TITLE
fix(cli): theme adaptive detection — 어두운 터미널 배경 가독성 확보

### DIFF
--- a/internal/cli/banner.go
+++ b/internal/cli/banner.go
@@ -20,16 +20,26 @@ const moaiBanner = `
 ╚═╝     ╚═╝ ╚═════╝ ╚═╝  ╚═╝╚═╝      ╚═╝  ╚═╝╚═════╝ ╚═╝  ╚═╝
 `
 
-// resolveTheme returns a Theme based on the NO_COLOR env and MOAI_THEME env.
-// NO_COLOR=1 → MonochromeTheme; MOAI_THEME=dark → DarkTheme; otherwise LightTheme.
+// resolveTheme returns a Theme appropriate for the current terminal.
+//
+// Delegates to tui.ResolveOS() which applies the canonical priority chain:
+//  1. NO_COLOR set (any non-empty value, per https://no-color.org) → MonochromeTheme
+//  2. MOAI_THEME="light" → LightTheme
+//  3. MOAI_THEME="dark"  → DarkTheme
+//  4. MOAI_THEME="auto"/unset → lipgloss.HasDarkBackground() auto-detect
+//     - dark terminal background → DarkTheme (bright colours visible on dark bg)
+//     - light terminal background → LightTheme (deep colours visible on light bg)
+//  5. invalid MOAI_THEME → DarkTheme (safe default, REQ-CLI-TUI-010)
+//
+// Prior to this fix, the cli-local implementation forced LightTheme as the
+// fallback regardless of terminal background, rendering deep-teal accents
+// invisible against navy/black terminal backgrounds. The single source of
+// truth lives in internal/tui/detect.go.
+//
+// All cli package callers (banner, version, update, help, status, doctor,
+// update_archive) automatically benefit from this delegation.
 func resolveTheme() tui.Theme {
-	if os.Getenv("NO_COLOR") == "1" {
-		return tui.MonochromeTheme()
-	}
-	if strings.ToLower(os.Getenv("MOAI_THEME")) == "dark" {
-		return tui.DarkTheme()
-	}
-	return tui.LightTheme()
+	return tui.ResolveOS()
 }
 
 // goVersion returns a short Go version string (e.g. "1.21.5" from "go1.21.5").

--- a/internal/cli/banner_test.go
+++ b/internal/cli/banner_test.go
@@ -181,7 +181,7 @@ func TestPrintBanner_EmptyVersion(t *testing.T) {
 // 특징: deep teal Accent 색상 (tui.Theme().Accent), MoAI ASCII art banner + 3 tui.Pill.
 // Note: Go version is embedded in the golden snapshot — re-run UPDATE_GOLDEN=1 when Go toolchain updates.
 func TestBanner_Current_Light(t *testing.T) {
-	t.Setenv("NO_COLOR", "0")
+	t.Setenv("NO_COLOR", "")
 	t.Setenv("MOAI_THEME", "light")
 	t.Setenv("CLAUDE_CODE_VERSION", "1.0.18")      // pinned for deterministic golden
 	t.Setenv("MOAI_GO_VERSION_OVERRIDE", "1.26.0") // pin Go version for cross-toolchain deterministic golden
@@ -202,7 +202,7 @@ func TestBanner_Current_Light(t *testing.T) {
 // 특징: deep teal Accent 색상 (tui.DarkTheme().Accent), MoAI ASCII art banner + 3 tui.Pill.
 // Note: Go version is embedded in the golden snapshot — re-run UPDATE_GOLDEN=1 when Go toolchain updates.
 func TestBanner_Current_Dark(t *testing.T) {
-	t.Setenv("NO_COLOR", "0")
+	t.Setenv("NO_COLOR", "")
 	t.Setenv("MOAI_THEME", "dark")
 	t.Setenv("CLAUDE_CODE_VERSION", "1.0.18")      // pinned for deterministic golden
 	t.Setenv("MOAI_GO_VERSION_OVERRIDE", "1.26.0") // pin Go version for cross-toolchain deterministic golden
@@ -241,7 +241,7 @@ func TestBanner_NoColor(t *testing.T) {
 // TestWelcome_Current_Light captures PrintWelcomeMessage output with light-theme env.
 // 특징: deep teal Accent 색상 (tui.LightTheme().Accent), bold title.
 func TestWelcome_Current_Light(t *testing.T) {
-	t.Setenv("NO_COLOR", "0")
+	t.Setenv("NO_COLOR", "")
 	t.Setenv("MOAI_THEME", "light")
 
 	got, err := captureStdout(func() {
@@ -259,7 +259,7 @@ func TestWelcome_Current_Light(t *testing.T) {
 // TestWelcome_Current_Dark captures PrintWelcomeMessage output with dark-theme env.
 // 특징: deep teal Accent 색상 (tui.DarkTheme().Accent), bold title.
 func TestWelcome_Current_Dark(t *testing.T) {
-	t.Setenv("NO_COLOR", "0")
+	t.Setenv("NO_COLOR", "")
 	t.Setenv("MOAI_THEME", "dark")
 
 	got, err := captureStdout(func() {

--- a/internal/cli/doctor_golden_test.go
+++ b/internal/cli/doctor_golden_test.go
@@ -73,7 +73,7 @@ func captureDoctorCmd(t *testing.T) string {
 // TestDoctor_Current_Light captures doctorCmd output with light-theme env.
 // 특징: tui.Section + 19+ tui.CheckLine + tui.Box + tui.Pill 요약.
 func TestDoctor_Current_Light(t *testing.T) {
-	t.Setenv("NO_COLOR", "0")
+	t.Setenv("NO_COLOR", "")
 	t.Setenv("MOAI_THEME", "light")
 	t.Setenv("MOAI_GO_VERSION_OVERRIDE", "1.99.99")
 	t.Setenv("CLAUDE_CODE_VERSION", "test-claude-99")
@@ -92,7 +92,7 @@ func TestDoctor_Current_Light(t *testing.T) {
 // TestDoctor_Current_Dark captures doctorCmd output with dark-theme env.
 // 특징: tui.DarkTheme() 적용, Section 헤더 + CheckLine + Pill 요약.
 func TestDoctor_Current_Dark(t *testing.T) {
-	t.Setenv("NO_COLOR", "0")
+	t.Setenv("NO_COLOR", "")
 	t.Setenv("MOAI_THEME", "dark")
 	t.Setenv("MOAI_GO_VERSION_OVERRIDE", "1.99.99")
 	t.Setenv("CLAUDE_CODE_VERSION", "test-claude-99")

--- a/internal/cli/loop.go
+++ b/internal/cli/loop.go
@@ -151,7 +151,7 @@ func runLoopStart(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("loop start: %w", err)
 	}
 
-	th := tui.LightTheme()
+	th := resolveTheme()
 	pill := tui.Pill(tui.PillOpts{Kind: tui.PillPrimary, Solid: true, Label: "실행 중", Theme: &th})
 	stepper := tui.Stepper(1, 4, &th)
 	header := tui.Section("자율 개발 루프", tui.SectionOpts{Theme: &th})
@@ -175,7 +175,7 @@ func runLoopStatus(cmd *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	th := tui.LightTheme()
+	th := resolveTheme()
 	out := cmd.OutOrStdout()
 
 	// Header: section title
@@ -218,7 +218,7 @@ func runLoopPause(cmd *cobra.Command, _ []string) error {
 	if err := deps.LoopController.Pause(); err != nil {
 		return fmt.Errorf("loop pause: %w", err)
 	}
-	th := tui.LightTheme()
+	th := resolveTheme()
 	pill := tui.Pill(tui.PillOpts{Kind: tui.PillWarn, Label: "일시정지", Theme: &th})
 	_, _ = fmt.Fprintln(cmd.OutOrStdout(), tui.KV("루프", pill, tui.KVOpts{Theme: &th, KeyWidth: 8}))
 	return nil
@@ -233,7 +233,7 @@ func runLoopResume(cmd *cobra.Command, args []string) error {
 	if err := deps.LoopController.ResumeFromStorage(cmd.Context(), specID); err != nil {
 		return fmt.Errorf("loop resume: %w", err)
 	}
-	th := tui.LightTheme()
+	th := resolveTheme()
 	stepper := tui.Stepper(1, 4, &th)
 	pill := tui.Pill(tui.PillOpts{Kind: tui.PillPrimary, Solid: true, Label: "재시작", Theme: &th})
 	_, _ = fmt.Fprintln(cmd.OutOrStdout(), tui.KV("SPEC", specID, tui.KVOpts{Theme: &th, KeyWidth: 10}))
@@ -250,7 +250,7 @@ func runLoopCancel(cmd *cobra.Command, _ []string) error {
 	if err := deps.LoopController.Cancel(); err != nil {
 		return fmt.Errorf("loop cancel: %w", err)
 	}
-	th := tui.LightTheme()
+	th := resolveTheme()
 	pill := tui.Pill(tui.PillOpts{Kind: tui.PillErr, Label: "취소됨", Theme: &th})
 	_, _ = fmt.Fprintln(cmd.OutOrStdout(), tui.KV("루프", pill, tui.KVOpts{Theme: &th, KeyWidth: 8}))
 	return nil

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -103,7 +103,7 @@ func renderSummaryLine(ok, warn, fail int) string {
 // @MX:ANCHOR: [AUTO] RenderError is the global error render surface for M6-S6
 // @MX:REASON: rootCmd error handler and key command RunE paths call this function
 func RenderError(err error) string {
-	th := tui.LightTheme()
+	th := resolveTheme()
 	icon := tui.StatusIcon("err")
 	// Compose title line: error icon + styled label using the danger token.
 	dangerStyle := lipgloss.NewStyle().

--- a/internal/cli/status_golden_test.go
+++ b/internal/cli/status_golden_test.go
@@ -132,7 +132,7 @@ func checkStatusGoldenAbs(t *testing.T, pkgDir, name, got string) {
 // TestStatus_Current_Light captures statusCmd output with light-theme env.
 // 특징: tui.Section + tui.KV + tui.Box + tui.Pill 요약.
 func TestStatus_Current_Light(t *testing.T) {
-	t.Setenv("NO_COLOR", "0")
+	t.Setenv("NO_COLOR", "")
 	t.Setenv("MOAI_THEME", "light")
 
 	got, pkgDir := captureStatusCmdWithPkgDir(t)
@@ -145,7 +145,7 @@ func TestStatus_Current_Light(t *testing.T) {
 // TestStatus_Current_Dark captures statusCmd output with dark-theme env.
 // 특징: tui.DarkTheme() 적용, Section + KV + Box + Pill 요약.
 func TestStatus_Current_Dark(t *testing.T) {
-	t.Setenv("NO_COLOR", "0")
+	t.Setenv("NO_COLOR", "")
 	t.Setenv("MOAI_THEME", "dark")
 
 	got, pkgDir := captureStatusCmdWithPkgDir(t)

--- a/internal/cli/version_test.go
+++ b/internal/cli/version_test.go
@@ -174,7 +174,7 @@ func TestShortCommit_ExactlyNinePassthrough(t *testing.T) {
 
 // TestVersion_Current_Light captures versionCmd output with light-theme env.
 func TestVersion_Current_Light(t *testing.T) {
-	t.Setenv("NO_COLOR", "0")
+	t.Setenv("NO_COLOR", "")
 	t.Setenv("MOAI_THEME", "light")
 
 	// Pin build-time variables for deterministic golden output.
@@ -197,7 +197,7 @@ func TestVersion_Current_Light(t *testing.T) {
 
 // TestVersion_Current_Dark captures versionCmd output with dark-theme env.
 func TestVersion_Current_Dark(t *testing.T) {
-	t.Setenv("NO_COLOR", "0")
+	t.Setenv("NO_COLOR", "")
 	t.Setenv("MOAI_THEME", "dark")
 
 	orig, origC, origD := version.Version, version.Commit, version.Date


### PR DESCRIPTION
## Summary

`moai init`/`version`/`status`/`doctor`/`help`/`update`/`loop` 등 CLI 출력이 어두운 터미널 배경 (navy/black 등) 에서 가독성 망 — ASCII art와 Welcome 타이틀이 deep teal `#144a46`로 출력되어 묻힘.

근본 원인: `internal/cli/banner.go::resolveTheme()`가 `lipgloss.HasDarkBackground()` 자동 감지를 무시하고 **항상 LightTheme fallback 강제**. 이미 `internal/tui/detect.go::ResolveOS()`에 올바른 priority chain (NO_COLOR > MOAI_THEME > DetectDark > dark-default, REQ-CLI-TUI-010)이 구현되어 있는데 cli 패키지가 자체 `resolveTheme()`을 재정의해서 우회.

## Changes

### 1) banner.go (1 line fix, 8개 호출처 자동 fix)
- `resolveTheme()` body를 `tui.ResolveOS()` 위임으로 교체
- `banner/version/update (6건)/help/status/doctor/update_archive (2건)` 모두 자동으로 adaptive theme 적용

### 2) loop.go (5건)
- `th := tui.LightTheme()` (line 154/178/221/236/253) → `th := resolveTheme()`

### 3) render.go (1건)
- `RenderError` 함수의 `th := tui.LightTheme()` → `resolveTheme()`

### 4) Test fixture (4 files, NO_COLOR 표준 준수 부수효과)

`tui.OSEnv.NoColor()`가 [no-color.org](https://no-color.org) 표준 (`v != ""`)을 따르므로 `NO_COLOR=0`도 SET으로 간주됨. 기존 banner.go의 `os.Getenv("NO_COLOR") == "1"` 비교는 표준 미준수. 4개 golden test의 `t.Setenv("NO_COLOR", "0")` → `""`로 변경 — 의도(MOAI_THEME light/dark 분기 검증)는 동일하게 유지.

- `banner_test.go`, `status_golden_test.go`, `doctor_golden_test.go`, `version_test.go` (총 10 occurrences)

## Verification

- ✅ `go build ./...` PASS
- ✅ `go vet ./internal/cli/... ./internal/tui/...` PASS
- ✅ `go test ./internal/cli/... ./internal/tui/...` PASS
  - 4 golden test family (Banner/Status/Doctor/Version × light/dark/nocolor) all GREEN
  - loop/render tests all GREEN

## Behavior Matrix

| 환경 | 이전 | 이후 |
|---|---|---|
| NO_COLOR set (any non-empty) | mono (only "1") / colored (else) | mono (모든 값) |
| MOAI_THEME=light | Light | Light |
| MOAI_THEME=dark | Dark | Dark |
| MOAI_THEME=auto/unset, dark terminal | **Light (가독성 망)** | **Dark (정상)** |
| MOAI_THEME=auto/unset, light terminal | Light | Light |
| MOAI_THEME=invalid | Light | Dark (safe default, REQ-CLI-TUI-010) |

## Test plan

- [x] go build / vet / test PASS (local)
- [ ] CI all-green
- [ ] Manual smoke test: `moai init` on dark terminal background

## Out of scope

- `wizard/styles.go`, `worktree/render.go`, `github.go`, `update.go (package globals)` 등 이미 AdaptiveColor 패턴 적용된 곳은 변경 불요
- `internal/cli/{cc,glm,cg}.go` 등 다른 CLI 명령어의 추가 hardcoded theme 사용 여부는 별도 audit (본 PR 미포함)

🗿 MoAI <email@mo.ai.kr>