### PR TITLE
feat(spec): SPEC-V3R4-STATUS-LIFECYCLE-001 Wave 1 — Policy + Lint

### DIFF
--- a/.claude/rules/moai/workflow/spec-workflow.md
+++ b/.claude/rules/moai/workflow/spec-workflow.md
@@ -16,6 +16,34 @@ MoAI's three-phase development workflow with token budget management.
 
 <!-- @MX:ANCHOR fan_in=10 - Subcommand classification single source of truth; cross-referenced by 10 workflow skills (5 multi-agent + 5 utility). Changes here affect all workflow contracts. -->
 
+## Status Lifecycle
+
+The SPEC status field follows a canonical 8-value enum. The single source of truth for these values is `internal/spec/status.go` (`ValidStatuses`).
+
+### Canonical Status Values
+
+| Value | Description | Entry Trigger |
+|-------|-------------|---------------|
+| `draft` | Initial state, SPEC created but not yet planned | SPEC file created |
+| `planned` | Plan PR merged, ready for run phase | Plan PR merge |
+| `in-progress` | Run started, acceptance criteria partially met | Run PR merge (partial AC) |
+| `implemented` | Run complete, all AC GREEN, sync not yet done | Run PR merge (all AC) |
+| `completed` | Sync PR merged, lifecycle terminal-success | Sync PR merge |
+| `superseded` | Replaced by another SPEC | Manual or follow-up SPEC |
+| `archived` | Historical record, not active | Manual |
+| `rejected` | Never implemented, lifecycle terminal-decline | Manual |
+
+### Transition Map
+
+```
+draft → planned → in-progress → implemented → completed
+                                             ↓
+                                        superseded | archived | rejected
+```
+
+- Hyphen form `in-progress` is canonical (not underscore `in_progress`)
+- Status values are always lowercase in frontmatter
+
 ## SPEC Phase Discipline
 
 [HARD] Every MoAI SPEC follows this 4-step lifecycle. Each step has a fixed location (main checkout vs SPEC worktree), branch convention, and PR merge strategy.

--- a/.github/workflows/spec-lint.yml
+++ b/.github/workflows/spec-lint.yml
@@ -1,0 +1,19 @@
+name: SPEC Lint
+
+on:
+  pull_request:
+    paths:
+      - '.moai/specs/**'
+
+jobs:
+  spec-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Build moai
+        run: make build && make install
+      - name: Run SPEC lint
+        run: moai spec lint --strict

--- a/.moai/specs/SPEC-CC2122-HOOK-001/spec.md
+++ b/.moai/specs/SPEC-CC2122-HOOK-001/spec.md
@@ -1,3 +1,8 @@
+---
+id: SPEC-CC2122-HOOK-001
+status: completed
+---
+
 # SPEC-CC2122-HOOK-001: Claude Code v2.1.119-121 Hook Feature Integration
 
 ## Status: COMPLETED

--- a/.moai/specs/SPEC-CC2122-HOOK-002/spec.md
+++ b/.moai/specs/SPEC-CC2122-HOOK-002/spec.md
@@ -1,3 +1,8 @@
+---
+id: SPEC-CC2122-HOOK-002
+status: draft
+---
+
 # SPEC-CC2122-HOOK-002: HOOK-001 Follow-up (REQ-007 + REQ-008)
 
 ## Status: DRAFT

--- a/.moai/specs/SPEC-CI-MULTI-LLM-001/spec.md
+++ b/.moai/specs/SPEC-CI-MULTI-LLM-001/spec.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-CI-MULTI-LLM-001
 version: 1.0.0
-status: Planned
+status: planned
 created: 2026-04-27
 updated: 2026-04-27
 author: manager-spec

--- a/.moai/specs/SPEC-CICD-001/spec.md
+++ b/.moai/specs/SPEC-CICD-001/spec.md
@@ -1,3 +1,8 @@
+---
+id: SPEC-CICD-001
+status: completed
+---
+
 # SPEC-CICD-001: CI/CD AI 자동화 재설계
 
 ## 메타데이터

--- a/.moai/specs/SPEC-CORE-BEHAV-001/spec.md
+++ b/.moai/specs/SPEC-CORE-BEHAV-001/spec.md
@@ -1,3 +1,8 @@
+---
+id: SPEC-CORE-BEHAV-001
+status: draft
+---
+
 # SPEC-CORE-BEHAV-001: Agent Core Behaviors and SPEC Workflow Gates
 
 ## Meta

--- a/.moai/specs/SPEC-DESIGN-001/spec.md
+++ b/.moai/specs/SPEC-DESIGN-001/spec.md
@@ -1,3 +1,8 @@
+---
+id: SPEC-DESIGN-001
+status: completed
+---
+
 # SPEC-DESIGN-001: interface-design Plugin Integration
 
 ## Metadata

--- a/.moai/specs/SPEC-DOCS-SITE-001/spec.md
+++ b/.moai/specs/SPEC-DOCS-SITE-001/spec.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-DOCS-SITE-001
 version: 0.2.0
-status: Planned
+status: planned
 created: 2026-04-17
 updated: 2026-04-20
 author: manager-spec

--- a/.moai/specs/SPEC-EVO-001/spec.md
+++ b/.moai/specs/SPEC-EVO-001/spec.md
@@ -1,3 +1,8 @@
+---
+id: SPEC-EVO-001
+status: draft
+---
+
 # SPEC-EVO-001: Skill Evolution Preservation Infrastructure
 
 ## Meta

--- a/.moai/specs/SPEC-GLM-001/spec.md
+++ b/.moai/specs/SPEC-GLM-001/spec.md
@@ -1,3 +1,8 @@
+---
+id: SPEC-GLM-001
+status: completed
+---
+
 # SPEC-GLM-001: GLM Compatibility Automation
 
 **Status**: Implemented

--- a/.moai/specs/SPEC-HOOK-008/spec.md
+++ b/.moai/specs/SPEC-HOOK-008/spec.md
@@ -1,3 +1,8 @@
+---
+id: SPEC-HOOK-008
+status: completed
+---
+
 # SPEC-HOOK-008: Complete Hook Event System
 
 ## Metadata

--- a/.moai/specs/SPEC-I18N-001-ARCHIVED/spec.md
+++ b/.moai/specs/SPEC-I18N-001-ARCHIVED/spec.md
@@ -1,3 +1,8 @@
+---
+id: SPEC-I18N-001-ARCHIVED
+status: archived
+---
+
 ARCHIVED — SPEC-I18N-001
 
 이 SPEC은 moai-docs 레포(archived)에서 이관된 원본 문서입니다.

--- a/.moai/specs/SPEC-LSP-FLAKY-001/spec.md
+++ b/.moai/specs/SPEC-LSP-FLAKY-001/spec.md
@@ -1,3 +1,8 @@
+---
+id: SPEC-LSP-FLAKY-001
+status: draft
+---
+
 # SPEC-LSP-FLAKY-001: Ubuntu LSP Launcher ETXTBSY Flake Stabilization
 
 ## Status: DRAFT

--- a/.moai/specs/SPEC-LSP-FLAKY-002/spec.md
+++ b/.moai/specs/SPEC-LSP-FLAKY-002/spec.md
@@ -1,3 +1,8 @@
+---
+id: SPEC-LSP-FLAKY-002
+status: draft
+---
+
 # SPEC-LSP-FLAKY-002: LSP Launcher ETXTBSY Eager Initialization Hotfix
 
 ## Status: DRAFT

--- a/.moai/specs/SPEC-MX-001/spec.md
+++ b/.moai/specs/SPEC-MX-001/spec.md
@@ -1,3 +1,8 @@
+---
+id: SPEC-MX-001
+status: completed
+---
+
 # SPEC-MX-001: @MX TAG System -- MoAI eXtension Code Annotation System
 
 | Field       | Value                                         |

--- a/.moai/specs/SPEC-PSR-001/spec.md
+++ b/.moai/specs/SPEC-PSR-001/spec.md
@@ -1,3 +1,8 @@
+---
+id: SPEC-PSR-001
+status: completed
+---
+
 # SPEC-PSR-001: Profile Setup Redesign -- StatuslineMode Exposure
 
 ## Metadata

--- a/.moai/specs/SPEC-REFLECT-001/spec.md
+++ b/.moai/specs/SPEC-REFLECT-001/spec.md
@@ -1,3 +1,8 @@
+---
+id: SPEC-REFLECT-001
+status: draft
+---
+
 # SPEC-REFLECT-001: Reflective Write Hook
 
 ## Meta

--- a/.moai/specs/SPEC-SKILL-ENHANCE-001/spec.md
+++ b/.moai/specs/SPEC-SKILL-ENHANCE-001/spec.md
@@ -1,3 +1,8 @@
+---
+id: SPEC-SKILL-ENHANCE-001
+status: draft
+---
+
 # SPEC-SKILL-ENHANCE-001: Skill Anti-Rationalization, Red Flags, and Verification
 
 ## Meta

--- a/.moai/specs/SPEC-SLE-001/spec.md
+++ b/.moai/specs/SPEC-SLE-001/spec.md
@@ -1,3 +1,8 @@
+---
+id: SPEC-SLE-001
+status: completed
+---
+
 # SPEC-SLE-001: Statusline Enhancement
 
 ## Metadata

--- a/.moai/specs/SPEC-SLQG-001/spec.md
+++ b/.moai/specs/SPEC-SLQG-001/spec.md
@@ -1,3 +1,8 @@
+---
+id: SPEC-SLQG-001
+status: draft
+---
+
 # SPEC-SLQG-001: Self-Learning Quality Guard
 
 ## Overview

--- a/.moai/specs/SPEC-SLV3-001/spec.md
+++ b/.moai/specs/SPEC-SLV3-001/spec.md
@@ -1,3 +1,8 @@
+---
+id: SPEC-SLV3-001
+status: completed
+---
+
 # SPEC-SLV3-001: Statusline v3 Upgrade
 
 | 항목 | 내용 |

--- a/.moai/specs/SPEC-STATUSLINE-001/spec.md
+++ b/.moai/specs/SPEC-STATUSLINE-001/spec.md
@@ -1,3 +1,8 @@
+---
+id: SPEC-STATUSLINE-001
+status: completed
+---
+
 # SPEC-STATUSLINE-001: Statusline Segment Configuration
 
 ## Metadata

--- a/.moai/specs/SPEC-TEAM-001/spec.md
+++ b/.moai/specs/SPEC-TEAM-001/spec.md
@@ -1,3 +1,8 @@
+---
+id: SPEC-TEAM-001
+status: completed
+---
+
 # SPEC-TEAM-001: Agent Teams Dynamic Generation Architecture
 
 **Status**: Draft

--- a/.moai/specs/SPEC-TELEMETRY-001/spec.md
+++ b/.moai/specs/SPEC-TELEMETRY-001/spec.md
@@ -1,3 +1,8 @@
+---
+id: SPEC-TELEMETRY-001
+status: implemented
+---
+
 # SPEC-TELEMETRY-001: Skill Usage Telemetry
 
 ## Meta

--- a/internal/spec/lint.go
+++ b/internal/spec/lint.go
@@ -119,6 +119,8 @@ func NewLinter(opts LinterOptions) *Linter {
 		&DependencyExistsRule{},
 		&OutOfScopeRule{},
 		&BreakingChangeIDRule{},
+		&StatusValueEnumRule{},
+		&StatusCaseNormalizationRule{},
 		// cross-SPEC rules
 		&DependencyCycleRule{},
 		&DuplicateSPECIDRule{},
@@ -688,6 +690,67 @@ func (r *BreakingChangeIDRule) Check(doc *SPECDoc, _ []*SPECDoc) []Finding {
 			Code:     "OrphanBCID",
 			Message:  "breaking: false이지만 bc_id가 비어 있지 않음 — orphan breaking change ID",
 		})
+	}
+
+	return findings
+}
+
+// StatusValueEnumRule checks if status value is in the canonical 8-value enum
+// Implements REQ-STATUS-LIFECYCLE-001-03.1
+type StatusValueEnumRule struct{}
+
+func (r *StatusValueEnumRule) Code() string { return "StatusValueInvalid" }
+
+func (r *StatusValueEnumRule) Check(doc *SPECDoc, _ []*SPECDoc) []Finding {
+	fm := doc.Frontmatter
+	var findings []Finding
+
+	if fm.Status == "" {
+		// Empty status is handled by FrontmatterSchemaRule
+		return nil
+	}
+
+	if !IsValidStatus(fm.Status) {
+		findings = append(findings, Finding{
+			File:     doc.Path,
+			Line:     1,
+			Severity: SeverityError,
+			Code:     "StatusValueInvalid",
+			Message:  fmt.Sprintf("status %q is not in the canonical 8-value enum %v", fm.Status, ValidStatuses),
+		})
+	}
+
+	return findings
+}
+
+// StatusCaseNormalizationRule checks if status value contains uppercase letters
+// Implements REQ-STATUS-LIFECYCLE-001-03.2
+type StatusCaseNormalizationRule struct{}
+
+func (r *StatusCaseNormalizationRule) Code() string { return "StatusCaseInvalid" }
+
+func (r *StatusCaseNormalizationRule) Check(doc *SPECDoc, _ []*SPECDoc) []Finding {
+	fm := doc.Frontmatter
+	var findings []Finding
+
+	if fm.Status == "" {
+		// Empty status is handled by FrontmatterSchemaRule
+		return nil
+	}
+
+	// Check if status contains uppercase
+	if fm.Status != strings.ToLower(fm.Status) {
+		lowerStatus := strings.ToLower(fm.Status)
+		// Only report error if the lowercased version is valid
+		if IsValidStatus(lowerStatus) {
+			findings = append(findings, Finding{
+				File:     doc.Path,
+				Line:     1,
+				Severity: SeverityError,
+				Code:     "StatusCaseInvalid",
+				Message:  fmt.Sprintf("status %q contains uppercase; use lowercase %q instead", fm.Status, lowerStatus),
+			})
+		}
 	}
 
 	return findings

--- a/internal/spec/lint_test.go
+++ b/internal/spec/lint_test.go
@@ -570,3 +570,121 @@ func TestLinter_NoArgs_DiscoversSPECs(t *testing.T) {
 		t.Errorf("expected no errors for valid SPEC, got: %v", errors)
 	}
 }
+
+// TestStatusValueEnumRule_Valid는 유효한 status 값에서 findings가 없음을 검증한다.
+func TestStatusValueEnumRule_Valid(t *testing.T) {
+	doc := &spec.SPECDoc{
+		Frontmatter: spec.SPECFrontmatter{
+			Status: "planned",
+		},
+	}
+
+	rule := &spec.StatusValueEnumRule{}
+	findings := rule.Check(doc, nil)
+
+	if len(findings) != 0 {
+		t.Errorf("expected no findings for valid status, got: %v", findings)
+	}
+}
+
+// TestStatusValueEnumRule_Invalid는 유효하지 않은 status 값에서 오류를 보고함을 검증한다.
+func TestStatusValueEnumRule_Invalid(t *testing.T) {
+	doc := &spec.SPECDoc{
+		Frontmatter: spec.SPECFrontmatter{
+			Status: "Planned", // uppercase, not in enum
+		},
+	}
+
+	rule := &spec.StatusValueEnumRule{}
+	findings := rule.Check(doc, nil)
+
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d: %v", len(findings), findings)
+	}
+
+	if findings[0].Code != "StatusValueInvalid" {
+		t.Errorf("expected code StatusValueInvalid, got %s", findings[0].Code)
+	}
+}
+
+// TestStatusValueEnumRule_Empty는 빈 status 값에서 findings가 없음을 검증한다.
+func TestStatusValueEnumRule_Empty(t *testing.T) {
+	doc := &spec.SPECDoc{
+		Frontmatter: spec.SPECFrontmatter{
+			Status: "",
+		},
+	}
+
+	rule := &spec.StatusValueEnumRule{}
+	findings := rule.Check(doc, nil)
+
+	if len(findings) != 0 {
+		t.Errorf("expected no findings for empty status (handled by FrontmatterSchemaRule), got: %v", findings)
+	}
+}
+
+// TestStatusCaseNormalizationRule_Lowercase는 소문자 status에서 findings가 없음을 검증한다.
+func TestStatusCaseNormalizationRule_Lowercase(t *testing.T) {
+	doc := &spec.SPECDoc{
+		Frontmatter: spec.SPECFrontmatter{
+			Status: "planned",
+		},
+	}
+
+	rule := &spec.StatusCaseNormalizationRule{}
+	findings := rule.Check(doc, nil)
+
+	if len(findings) != 0 {
+		t.Errorf("expected no findings for lowercase status, got: %v", findings)
+	}
+}
+
+// TestStatusCaseNormalizationRule_Uppercase는 대문자 status에서 오류를 보고함을 검증한다.
+func TestStatusCaseNormalizationRule_Uppercase(t *testing.T) {
+	doc := &spec.SPECDoc{
+		Frontmatter: spec.SPECFrontmatter{
+			Status: "COMPLETED",
+		},
+	}
+
+	rule := &spec.StatusCaseNormalizationRule{}
+	findings := rule.Check(doc, nil)
+
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d: %v", len(findings), findings)
+	}
+
+	if findings[0].Code != "StatusCaseInvalid" {
+		t.Errorf("expected code StatusCaseInvalid, got %s", findings[0].Code)
+	}
+
+	expectedMsg := `status "COMPLETED" contains uppercase; use lowercase "completed" instead`
+	if findings[0].Message != expectedMsg {
+		t.Errorf("expected message %q, got %q", expectedMsg, findings[0].Message)
+	}
+}
+
+// TestStatusCaseNormalizationRule_MixedCase는 혼합 케이스 status에서 오류를 보고함을 검증한다.
+func TestStatusCaseNormalizationRule_MixedCase(t *testing.T) {
+	doc := &spec.SPECDoc{
+		Frontmatter: spec.SPECFrontmatter{
+			Status: "In-Progress",
+		},
+	}
+
+	rule := &spec.StatusCaseNormalizationRule{}
+	findings := rule.Check(doc, nil)
+
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d: %v", len(findings), findings)
+	}
+
+	if findings[0].Code != "StatusCaseInvalid" {
+		t.Errorf("expected code StatusCaseInvalid, got %s", findings[0].Code)
+	}
+
+	expectedMsg := `status "In-Progress" contains uppercase; use lowercase "in-progress" instead`
+	if findings[0].Message != expectedMsg {
+		t.Errorf("expected message %q, got %q", expectedMsg, findings[0].Message)
+	}
+}

--- a/internal/spec/status.go
+++ b/internal/spec/status.go
@@ -17,6 +17,8 @@ var ValidStatuses = []string{
 	"implemented",
 	"completed",
 	"superseded",
+	"archived",
+	"rejected",
 }
 
 // IsValidStatus checks if a status value is valid


### PR DESCRIPTION
## Summary

- **W1-T1**: Canonical 8-value status enum (`archived`, `rejected` 추가) in `spec-workflow.md` § Status Lifecycle + `status.go` ValidStatuses
- **W1-T2**: `StatusValueEnumRule` + `StatusCaseNormalizationRule` lint rules with 6 tests (REQ-3.1, REQ-3.2)
- **W1-T3**: 21 legacy SPECs YAML frontmatter backfill + 2 `Planned`→`planned` case fix → zero StatusValueInvalid findings
- **W1-T4**: `.github/workflows/spec-lint.yml` CI gate (triggers on `.moai/specs/**` path changes)

## Acceptance Gate

| AC ID | Status | Evidence |
|-------|--------|----------|
| AC-01.a | ✅ | `ValidStatuses` = 8 values (draft, planned, in-progress, implemented, completed, superseded, archived, rejected) |
| AC-01.b | ✅ | `StatusValueEnumRule` emits `StatusValueInvalid` on non-canonical values |
| AC-01.c | ✅ | `StatusCaseNormalizationRule` emits `StatusCaseInvalid` on uppercase (e.g., `Planned`→`planned`) |
| AC-01.d | ✅ | `spec-workflow.md` § Status Lifecycle documents canonical 8-value enum + transition map |
| AC-01.e | ✅ | `.github/workflows/spec-lint.yml` runs `moai spec lint --strict` |
| AC-01.f | ✅ | `go test ./internal/spec/...` PASS; 6 new tests; zero regressions |

## Test Plan

- [x] `go test ./internal/spec/... -count=1` — all pass (0.252s)
- [x] `go vet ./internal/spec/...` — zero issues
- [x] `moai spec lint` — zero `StatusValueInvalid` / `StatusCaseInvalid` findings (was 48 before backfill)
- [ ] CI: `spec-lint.yml` workflow runs on this PR

## Catalyst

PR #871 — "chore(spec): status drift sync — Sprint 12 plan-merged 10건"

REQ coverage: REQ-1, REQ-3.1, REQ-3.2, REQ-4, REQ-6

🗿 MoAI <email@mo.ai.kr>