### PR TITLE
plan(spec): SPEC-V3R4-HOOK-HARDEN-001 — Hook Wrapper Hardening (3-Wave Defense)

### DIFF
--- a/.moai/specs/SPEC-V3R4-HOOK-HARDEN-001/acceptance.md
+++ b/.moai/specs/SPEC-V3R4-HOOK-HARDEN-001/acceptance.md
@@ -1,0 +1,209 @@
+# Acceptance Criteria — SPEC-V3R4-HOOK-HARDEN-001
+
+## Schema
+
+본 문서는 hierarchical AC 스키마 (SPC-001 amendment, max depth 3, suffix `-NN` / `.a-z` / `.i-xxvi`)를 따른다. 모든 leaf AC는 `(maps REQ-...)` tail을 포함한다.
+
+식별자 prefix: `AC-HOOK-HARDEN-001-<NN>`
+
+## Wave 1 — Visibility
+
+### AC-HOOK-HARDEN-001-01: Hook wrapper observability and environment neutrality
+
+**Given** 진단 세션 evidence (22 PreToolUse:Bash cancellations) 및 30 wrapper의 stderr silence 상태가 baseline으로 확인된 상태에서,
+
+- **AC-HOOK-HARDEN-001-01.a**: stderr preservation in wrappers
+  - **Given** baseline wrapper template `handle-pre-tool.sh.tmpl`이 `2>/dev/null`로 stderr를 silence하는 상태에서,
+  - **When** Wave 1 PR이 머지되어 `make build` + `moai update -t`가 실행된 후,
+  - **Then** `grep '2>>"\$MOAI_HOOK_STDERR_LOG"' .claude/hooks/moai/handle-*.sh | wc -l`이 30 이상이며, `grep '2>/dev/null' .claude/hooks/moai/handle-*.sh`의 결과가 0건이다.
+  - (maps REQ-HOOK-HARDEN-001-001)
+
+    - **AC-HOOK-HARDEN-001-01.a.i**: log directory bootstrap
+      - **Given** 로컬 파일시스템에 `$HOME/.moai/logs/` 디렉토리가 존재하지 않는 상태에서,
+      - **When** 어떤 hook wrapper가 처음 실행되어 stderr write를 시도할 때,
+      - **Then** wrapper는 `mkdir -p "$(dirname "$MOAI_HOOK_STDERR_LOG")"`를 실행하여 디렉토리를 생성하고 stderr write가 성공한다. 디렉토리 생성 실패는 `|| true`로 silently swallow되어 hook execution은 차단되지 않는다.
+      - (maps REQ-HOOK-HARDEN-001-002)
+
+    - **AC-HOOK-HARDEN-001-01.a.ii**: empty stderr no-op
+      - **Given** moai hook 실행이 stderr 없이 정상 종료된 상태에서,
+      - **When** wrapper가 종료될 때,
+      - **Then** `$HOME/.moai/logs/hook-stderr.log` 파일은 생성되지만 (touch 효과) 새로운 entry는 append되지 않거나, 또는 파일이 미존재 상태로 유지된다 (both acceptable — `mkdir -p` does NOT touch the file).
+      - (maps REQ-HOOK-HARDEN-001-001 supplementary)
+
+- **AC-HOOK-HARDEN-001-01.b**: hardcoded user path removal
+  - **Given** 28 template wrapper에 `/Users/goos/go/bin/moai` 또는 유사 사용자 절대 경로가 박혀 있는 baseline 상태에서,
+  - **When** Wave 1의 template patch가 적용된 후,
+  - **Then** `grep -rE '/(Users|home)/[a-zA-Z][^/]+/' internal/template/templates/.claude/hooks/moai/`의 결과가 0건이다. `command -v moai` → `$HOME/go/bin/moai` → `$HOME/.local/bin/moai` → silent exit의 4-단계 fallback chain만 잔존한다.
+  - (maps REQ-HOOK-HARDEN-001-004)
+
+    - **AC-HOOK-HARDEN-001-01.b.i**: render audit on fresh init
+      - **Given** 신규 사용자 머신 (`$HOME=/home/alice`, `GOPATH=/home/alice/go`) 상태에서,
+      - **When** `moai init test-project`로 새 프로젝트가 생성된 후,
+      - **Then** `.claude/hooks/moai/handle-*.sh` 30개 파일 모두에서 `grep -lE '/(Users|home)/[a-zA-Z][^/]+/'`의 결과가 0건이며, 모든 wrapper가 `$HOME` 또는 `$CLAUDE_PROJECT_DIR`로 시작하는 path만 사용한다.
+      - (maps REQ-HOOK-HARDEN-001-005)
+
+- **AC-HOOK-HARDEN-001-01.c**: template-local sync verification
+  - **Given** template 28개 vs local 30개의 4-file divergence가 baseline으로 존재하는 상태에서,
+  - **When** Wave 1의 T1.6 task가 수행되어 분류가 완료된 후,
+  - **Then** divergence의 각 4 file은 다음 중 하나로 분류된다: (a) template에 추가됨 (counterpart 생성), 또는 (b) `.gitignore`에 추가되며 rationale이 commit message에 명시됨. `ls .claude/hooks/moai/*.sh | wc -l`과 `ls internal/template/templates/.claude/hooks/moai/*.sh.tmpl | wc -l`의 차이가 (a) 0이 되거나 (b) `.gitignore` 처리된 항목 수만큼만 남는다.
+  - (maps REQ-HOOK-HARDEN-001-010)
+
+## Wave 2 — Mechanism
+
+### AC-HOOK-HARDEN-001-02: Timeout uplift, direct pipe, and log rotation
+
+**Given** Wave 1이 merge되어 stderr가 캡처되기 시작한 상태에서, 5초 PreToolUse timeout과 mktemp + cat 패턴이 여전히 baseline인 상황에서,
+
+- **AC-HOOK-HARDEN-001-02.a**: PreToolUse timeout uplift
+  - **Given** `internal/template/templates/.claude/settings.json`의 PreToolUse hook `timeout`이 `5`인 상태에서,
+  - **When** Wave 2의 T2.1 patch가 적용된 후 `make build`가 실행된 후,
+  - **Then** 새로 생성된 `.claude/settings.json` (via `moai init` on fresh dir)의 PreToolUse `timeout` 값이 `10`이며, Notification / PostToolUse-failure / SessionStart 등 다른 hook의 timeout은 변경되지 않는다 (각각 5 / 5 / 30 유지).
+  - (maps REQ-HOOK-HARDEN-001-006)
+
+    - **AC-HOOK-HARDEN-001-02.a.i**: drift warning on update
+      - **Given** 기존 프로젝트의 `.claude/settings.json`이 `PreToolUse.timeout: 5`인 상태에서,
+      - **When** 사용자가 `moai update -t`를 실행할 때,
+      - **Then** stdout 또는 stderr에 `[update-warn]` prefix와 함께 `settings.json PreToolUse timeout is 5s; template recommends 10s` 메시지가 출력된다. 그러나 자동 수정은 적용되지 않으며 (REQ-007 자동 적용 금지) 사용자가 수동 편집 시점을 결정한다.
+      - (maps REQ-HOOK-HARDEN-001-007)
+
+- **AC-HOOK-HARDEN-001-02.b**: direct pipe mechanism
+  - **Given** baseline wrapper에 `mktemp` + `cat > "$temp_file"` + `trap 'rm -f' EXIT` 패턴이 존재하는 상태에서,
+  - **When** Wave 2의 T2.3/T2.4 patch가 적용된 후,
+  - **Then** `grep -l 'mktemp' .claude/hooks/moai/handle-*.sh`의 결과가 0건이며, 모든 wrapper가 `exec ... | moai hook X` 또는 `exec moai hook X` 패턴을 사용한다 (직접 pipe). `head -c 65536` 패턴은 64KB-limited wrapper (handle-pre-tool.sh)에서만 잔존한다.
+  - (maps REQ-HOOK-HARDEN-001-008)
+
+    - **AC-HOOK-HARDEN-001-02.b.i**: 64KB size limit preserved
+      - **Given** handle-pre-tool.sh wrapper가 64KB tool_input limit을 enforce해야 하는 상태에서,
+      - **When** 65536 bytes (정확히 64KB)를 초과하는 stdin이 wrapper에 전달될 때,
+      - **Then** wrapper는 stdout으로 `{"decision":"block","reason":"stdin exceeds 64KB limit"}` JSON을 출력하고 exit 0으로 종료한다 (refactor 이전과 동일 동작 + 동일 decision 효과).
+      - (maps REQ-HOOK-HARDEN-001-009)
+
+- **AC-HOOK-HARDEN-001-02.c**: log rotation at 10MB
+  - **Given** `$HOME/.moai/logs/hook-stderr.log` 파일이 10485760 bytes (10MB) 이상으로 누적된 상태에서,
+  - **When** 어떤 wrapper가 새 invocation에서 rotation check를 수행할 때,
+  - **Then** wrapper는 `mv -f $MOAI_HOOK_STDERR_LOG ${MOAI_HOOK_STDERR_LOG}.1`을 실행하여 rename하고, 새 stderr write가 빈 파일에서 시작된다. `mv` 실패는 `|| true`로 swallow되어 hook execution을 차단하지 않는다.
+  - (maps REQ-HOOK-HARDEN-001-013)
+
+    - **AC-HOOK-HARDEN-001-02.c.i**: single-level rotation idempotency
+      - **Given** `hook-stderr.log.1`이 이전 rotation에서 이미 존재하는 상태에서,
+      - **When** 새 rotation이 trigger될 때,
+      - **Then** `mv -f`는 기존 `.1`을 overwrite하며, 두 단계 이상의 historical log (예: `.2`, `.3`)는 생성되지 않는다 (단일 레벨 rotation).
+      - (maps REQ-HOOK-HARDEN-001-014)
+
+## Wave 3 — Verification
+
+### AC-HOOK-HARDEN-001-03: Reproducibility, opt-out, and absence-resilience tests
+
+**Given** Wave 1 + Wave 2가 merge되어 wrapper layer가 강화된 상태에서, 회귀 방지 자동화 필요 시점에서,
+
+- **AC-HOOK-HARDEN-001-03.a**: load-simulated reproduction test
+  - **Given** 신규 테스트 파일 `internal/cli/hook_wrapper_load_test.go`이 추가된 상태에서,
+  - **When** `go test -run TestHookWrapper_LargeStdin_DoesNotExceedTimeout ./internal/cli/`이 실행될 때,
+  - **Then** 테스트는 50KB+ JSON payload (예: `{"tool_input":{"command":"<random_50000_chars>"}}`)를 `handle-pre-tool.sh` wrapper의 stdin으로 전달하고, 첫 invocation은 warm-up으로 polling, 두 번째 invocation의 end-to-end wall-clock duration이 1000ms 미만임을 `assert`한다.
+  - (maps REQ-HOOK-HARDEN-001-011)
+
+    - **AC-HOOK-HARDEN-001-03.a.i**: CI cross-platform compatibility
+      - **Given** GitHub Actions matrix (ubuntu-latest, macos-latest, windows-latest)에서 테스트가 실행될 때,
+      - **When** Windows runner에서 `bash`가 미가용한 환경이라면,
+      - **Then** 테스트는 `t.Skip("bash unavailable on this platform")`로 skip된다. macOS / Linux runners에서는 항상 실행되며 PASS한다.
+      - (maps REQ-HOOK-HARDEN-001-012)
+
+    - **AC-HOOK-HARDEN-001-03.a.ii**: hardcode regression sentinel
+      - **Given** future PR이 wrapper template에 새로운 절대 경로를 도입하려는 상태에서,
+      - **When** `go test -run TestHookWrapper_NoHardcodedUserPath ./internal/template/`이 실행될 때,
+      - **Then** sentinel test는 `grep -rE '/(Users|home)/[a-zA-Z][^/]+/'` equivalent regex를 template tree에 적용하여 매칭되는 path가 0건이 아닐 경우 `t.Errorf("HOOK_WRAPPER_HARDCODE: <path>")`로 실패한다.
+      - (maps REQ-HOOK-HARDEN-001-005 supplementary)
+
+- **AC-HOOK-HARDEN-001-03.b**: opt-out path honored
+  - **Given** 사용자가 read-only filesystem 또는 memory-only filesystem 환경에서 hook 실행 중인 상태에서,
+  - **When** `MOAI_HOOK_STDERR_LOG=/dev/null` 환경변수가 설정되고 wrapper가 invoke될 때,
+  - **Then** wrapper는 stderr를 `/dev/null`로 redirect하여 디스크 IO 0건 발생하며 hook execution은 정상 완료된다. log file 생성 시도도 없다.
+  - (maps REQ-HOOK-HARDEN-001-015)
+
+    - **AC-HOOK-HARDEN-001-03.b.i**: $HOME absence fallback
+      - **Given** `$HOME` 환경변수가 unset이거나 빈 문자열인 container / CI 환경에서,
+      - **When** wrapper가 stderr redirect를 시도할 때,
+      - **Then** wrapper는 `/tmp/moai-hook-stderr.log`로 fallback하거나, 만약 `/tmp`도 쓰기 불가하면 silent exit (exit 0)로 종료한다. hook 자체는 실패하지 않는다.
+      - (maps REQ-HOOK-HARDEN-001-016)
+
+- **AC-HOOK-HARDEN-001-03.c**: 80%-budget warning emission (OPT — deferred)
+  - **Given** hook execution duration이 80% of configured timeout (예: PreToolUse 10초의 80% = 8초)을 초과한 상태에서,
+  - **When** `moai hook X` Go handler가 자체 elapsed time 측정 후 boundary 직전 stderr emit을 수행할 때,
+  - **Then** stderr에 `[hook-warn] <hookName> elapsed=<ms>ms threshold=<budget_ms>ms` 라인이 emit되어 captured log에 기록된다.
+  - **Note**: 이 AC는 OPT (deferred) — Go 핸들러 코드 수정이 필요하므로 본 SPEC의 D-Lock에 의해 별도 follow-up SPEC으로 분리됨. 본 SPEC의 Definition of Done에 영향 없음.
+  - (maps REQ-HOOK-HARDEN-001-003 — deferred)
+
+## Cross-Cutting Acceptance
+
+### AC-HOOK-HARDEN-001-04: Backward compatibility
+
+**Given** 본 SPEC의 모든 Wave가 merge되어 production traffic을 받는 상태에서,
+
+- **AC-HOOK-HARDEN-001-04.a**: existing hook events unaffected
+  - **Given** Claude Code 27-event hook system (SPEC-CC2122-HOOK-001/-002 기반)이 active한 상태에서,
+  - **When** SessionStart / PostToolUse / Notification 등 PreToolUse 이외의 27개 hook 이벤트가 발생할 때,
+  - **Then** 모든 event는 본 SPEC 변경 전과 동일한 timing characteristic (timeout 미변경) + 새로운 stderr capture 이점을 받는다. session JSONL에서 PreToolUse 이외의 hook_cancelled 카운트는 본 SPEC merge 전후 동일하거나 감소한다.
+  - (maps REQ-HOOK-HARDEN-001-006 negative case)
+
+- **AC-HOOK-HARDEN-001-04.b**: D-Lock invariant preservation
+  - **Given** 본 SPEC의 PR diff가 review되는 상태에서,
+  - **When** `git diff --name-only origin/main...HEAD | grep -E '^internal/(hook|cli/hook[^/]*\.go|cmd/moai/hook\.go)'`가 실행될 때,
+  - **Then** 결과가 0건이다 (D-Lock 적용 영역의 Go 핸들러 코드는 일절 변경되지 않음). 단, `internal/cli/update.go`는 wrapper hot path가 아니므로 예외이며 본 검사에서 제외된다 (plan.md §3 명시).
+  - (maps Constraints — D-Lock)
+
+### AC-HOOK-HARDEN-001-05: Diagnostic effectiveness (post-merge observation)
+
+**Given** Wave 1 + Wave 2가 merge되어 1주일 이상 운영된 상태에서,
+
+- **AC-HOOK-HARDEN-001-05.a**: stderr log content non-empty when timeout occurs
+  - **Given** PreToolUse hook이 timeout cancellation이 발생한 상태에서,
+  - **When** 사용자가 `tail -n 50 $HOME/.moai/logs/hook-stderr.log`을 실행할 때,
+  - **Then** timestamp + hookName + error context가 포함된 entries가 1건 이상 존재한다. 단순히 hook가 timeout만 되고 stderr가 empty인 경우는 없다 (root cause 진단 가능).
+  - (maps REQ-HOOK-HARDEN-001-001 effectiveness)
+
+- **AC-HOOK-HARDEN-001-05.b**: cancellation rate reduction
+  - **Given** Wave 2 merge 후 1주일 모니터링 window에서,
+  - **When** session JSONL의 `attachment.type == "hook_cancelled"` AND `hookName == "PreToolUse:Bash"` 카운트가 측정될 때,
+  - **Then** 동일 traffic 패턴 가정 시 카운트가 baseline (22건/주) 대비 75% 이상 감소한다. 단, 본 AC는 실측 데이터 기반이므로 PR merge 시점이 아닌 1주일 후 follow-up 검증으로 평가된다 (CI-blocking이 아닌 monitoring AC).
+  - (maps REQ-HOOK-HARDEN-001-006 effectiveness)
+
+## Definition of Done (Cross-reference)
+
+본 acceptance 문서의 모든 AC가 PASS 상태이며:
+
+- AC-HOOK-HARDEN-001-01 (Wave 1): a / a.i / a.ii / b / b.i / c PASS
+- AC-HOOK-HARDEN-001-02 (Wave 2): a / a.i / b / b.i / c / c.i PASS
+- AC-HOOK-HARDEN-001-03 (Wave 3): a / a.i / a.ii / b / b.i PASS (c는 OPT, deferred)
+- AC-HOOK-HARDEN-001-04 (Cross-cutting): a / b PASS
+- AC-HOOK-HARDEN-001-05 (Post-merge): a PASS 즉시, b는 1주일 follow-up
+
+총 leaf AC 수: **18 PASS-required** (a.ii의 supplementary 1건 + c deferred 1건 + b 1주일 후 1건 = 본 머지에서 18 + post-merge 1 follow-up = 19 total).
+
+## Trace Summary
+
+| AC ID | Maps REQ | Wave |
+|-------|----------|------|
+| AC-HOOK-HARDEN-001-01.a | REQ-001 | 1 |
+| AC-HOOK-HARDEN-001-01.a.i | REQ-002 | 1 |
+| AC-HOOK-HARDEN-001-01.a.ii | REQ-001 (suppl.) | 1 |
+| AC-HOOK-HARDEN-001-01.b | REQ-004 | 1 |
+| AC-HOOK-HARDEN-001-01.b.i | REQ-005 | 1 |
+| AC-HOOK-HARDEN-001-01.c | REQ-010 | 1 |
+| AC-HOOK-HARDEN-001-02.a | REQ-006 | 2 |
+| AC-HOOK-HARDEN-001-02.a.i | REQ-007 | 2 |
+| AC-HOOK-HARDEN-001-02.b | REQ-008 | 2 |
+| AC-HOOK-HARDEN-001-02.b.i | REQ-009 | 2 |
+| AC-HOOK-HARDEN-001-02.c | REQ-013 | 2 |
+| AC-HOOK-HARDEN-001-02.c.i | REQ-014 | 2 |
+| AC-HOOK-HARDEN-001-03.a | REQ-011 | 3 |
+| AC-HOOK-HARDEN-001-03.a.i | REQ-012 | 3 |
+| AC-HOOK-HARDEN-001-03.a.ii | REQ-005 (suppl.) | 3 |
+| AC-HOOK-HARDEN-001-03.b | REQ-015 | 3 |
+| AC-HOOK-HARDEN-001-03.b.i | REQ-016 | 3 |
+| AC-HOOK-HARDEN-001-03.c | REQ-003 (deferred) | OPT |
+| AC-HOOK-HARDEN-001-04.a | REQ-006 (negative) | cross |
+| AC-HOOK-HARDEN-001-04.b | Constraints D-Lock | cross |
+| AC-HOOK-HARDEN-001-05.a | REQ-001 (effectiveness) | post-merge |
+| AC-HOOK-HARDEN-001-05.b | REQ-006 (effectiveness) | post-merge (1-week) |
+
+REQ coverage: 16/16 REQs traced (REQ-003은 deferred OPT 명시). REQ 중복 mapping은 supplementary, negative, effectiveness 변형으로 표시.

--- a/.moai/specs/SPEC-V3R4-HOOK-HARDEN-001/plan.md
+++ b/.moai/specs/SPEC-V3R4-HOOK-HARDEN-001/plan.md
@@ -1,0 +1,251 @@
+# Implementation Plan — SPEC-V3R4-HOOK-HARDEN-001
+
+## §0 Motivation
+
+본 SPEC의 catalyst는 2026-05-13 진단 세션에서 수집된 다음 evidence이다:
+
+- `~/.claude/projects/-Users-goos-MoAI-moai-adk-go/*.jsonl` 7일 윈도우에서 `PreToolUse:Bash` hook 22건이 5초 timeout cancellation
+- durationMs 분포: 5068, 5072, 5073, 5104, 5118, 5120, 5132, 5139, 5143, 5147, 5149, 5150×3, 5163, 5165, 5166, 5177, 5181, 5217, 5240, 5278 (전부 5000ms 경계 직후)
+- 직접 호출 `moai hook pre-tool < sample.json` 측정값 8-15ms → root cause는 wrapper layer
+- 30개 wrapper 모두 stderr silence (`2>/dev/null`) → timeout 발생 시 진단 정보 0건
+- `/Users/goos/go/bin/moai` 하드코딩 1줄이 28개 template wrapper에 동일 prefix로 박힘 (CLAUDE.local.md §14 / §15 위반)
+
+이 evidence는 자체 진단 가능한 **wrapper layer 경화**가 필요함을 시사한다. Go 핸들러 코드 수정은 불필요 (8ms 충분히 빠름).
+
+## §1 Technical Approach
+
+본 SPEC은 `wrapper-layer-only + template-first + audit-driven` 3-layer 전략을 따른다:
+
+1. **Wrapper Layer (Wave 1)**: 30개 local wrapper + 28개 template wrapper에 stderr append redirect 추가 + 하드코딩 제거. Go 코드 변경 없음.
+2. **Mechanism Layer (Wave 2)**: settings.json PreToolUse timeout `5 → 10` 상향 + wrapper의 `mktemp` + `cat` 우회 제거 + log rotation 추가. Single source-of-truth는 `internal/template/templates/.claude/settings.json`.
+3. **Verification Layer (Wave 3)**: `internal/cli/hook_wrapper_load_test.go` 신규 추가 — 50KB+ payload로 wrapper 실행 시간 < 1초 검증. CLAUDE.local.md §6 (t.TempDir, t.Parallel()) 준수.
+
+각 Wave는 독립 PR로 머지 가능하며 (M-1 / M-2 / M-3), Wave 1 머지로 진단 데이터가 수집되기 시작하면 Wave 2의 timeout 결정에 evidence를 추가로 활용할 수 있다.
+
+## §2 Milestones
+
+총 task ~22개. 우선순위는 P0 (Wave 1) > P1 (Wave 2) > P1 (Wave 3). 시간 추정 금지 (CLAUDE.local.md / agent-common-protocol §Time Estimation).
+
+### Wave 1 — Visibility (P0)
+
+**Goal**: timeout 발생 시 진단 정보 확보 + 사용자 절대 경로 제거. blast radius 최소, 즉시 효과.
+
+- T1.1: `internal/template/templates/.claude/hooks/moai/handle-pre-tool.sh.tmpl` 수정 — `2>/dev/null` → `2>>"$MOAI_HOOK_STDERR_LOG"` 변경. 파일 상단에 `MOAI_HOOK_STDERR_LOG="${MOAI_HOOK_STDERR_LOG:-$HOME/.moai/logs/hook-stderr.log}"` + `mkdir -p` 추가.
+- T1.2: 나머지 27개 `*.sh.tmpl` 동일 패턴 적용 — `handle-session-start.sh.tmpl`, `handle-post-tool.sh.tmpl`, …. 변경은 모두 동일하므로 sed-replace patch 적용 후 `make build`.
+- T1.3: "detected Go bin path" 블록 (lines 22-24 in current template) 완전 제거 — `if [ -f "{{posixPath .GoBinPath}}/moai" ]; then exec ...` 블록 삭제. fallback chain은 (a) `command -v moai`, (b) `$HOME/go/bin/moai`, (c) `$HOME/.local/bin/moai`로 단축.
+- T1.4: `make build` 실행 → `internal/template/embedded.go` 재생성 확인. `git diff embedded.go`로 변경 적용 검증.
+- T1.5: `moai update -t` 로컬 적용 → `.claude/hooks/moai/handle-*.sh` 30개 재생성 → `grep -l "/Users/goos" .claude/hooks/moai/*.sh` 결과 0건 확인.
+- T1.6: template-local divergence 점검 — `ls .claude/hooks/moai/*.sh` (32) vs `ls internal/template/templates/.claude/hooks/moai/*.sh.tmpl` (28). 차이 4건 분석:
+  - 후보 1: local-only generated runtime wrapper (예: `agent-hook.sh`) → `.gitignore`에 등재 + 본 SPEC에서 문서화
+  - 후보 2: template 누락 → `make build` 검증 후 template 추가
+- T1.7: 자체 점검 — `bash -n internal/template/templates/.claude/hooks/moai/*.sh.tmpl` syntax check (Go template 표현식은 sed 처리 후 검증).
+
+**Wave 1 종료 조건**: PR 머지 후 24시간 내 hook-stderr.log 최소 1건 entry 수집 + 22건 PreToolUse timeout 재발 시 stderr 캡처 확인.
+
+### Wave 2 — Mechanism (P1)
+
+**Goal**: stdin handoff fork chain 단축 + PreToolUse timeout 5초 → 10초 + log rotation.
+
+- T2.1: `internal/template/templates/.claude/settings.json` 의 `PreToolUse` block 내 `timeout: 5` → `timeout: 10`. matcher (`Write|Edit|Bash`)는 변경하지 않음. `PostToolUse` (이미 async + 10초)와 `Notification` (5초 유지)은 손대지 않음.
+- T2.2: `internal/cli/update.go` 내 `moai update -t` 경로에 settings.json drift detection 추가 — local file의 PreToolUse.timeout이 5이고 template은 10이면 stderr에 `[update-warn] settings.json PreToolUse timeout is 5s; template recommends 10s. Apply manually or rerun with --apply-settings.` 출력. **수정 자체는 자동 적용하지 않음** (REQ-007). 단, 본 task는 Go 코드 수정이므로 D-Lock 검토 필요 — `update.go`는 wrapper hot path가 아니므로 허용 (D-Lock은 hook handler에만 적용).
+- T2.3: `handle-pre-tool.sh.tmpl` 의 `mktemp` + `head -c 65536 > "$temp_file"` + trap 블록 제거. 새 패턴:
+  ```bash
+  # In-line size check + direct exec
+  MOAI_HOOK_STDERR_LOG="${MOAI_HOOK_STDERR_LOG:-$HOME/.moai/logs/hook-stderr.log}"
+  mkdir -p "$(dirname "$MOAI_HOOK_STDERR_LOG")" 2>/dev/null || true
+
+  # 64KB size enforcement preserved via `head -c` filter on pipe
+  if command -v moai &> /dev/null; then
+      exec head -c 65536 | moai hook pre-tool 2>>"$MOAI_HOOK_STDERR_LOG"
+  fi
+  if [ -f "$HOME/go/bin/moai" ]; then
+      exec head -c 65536 | "$HOME/go/bin/moai" hook pre-tool 2>>"$MOAI_HOOK_STDERR_LOG"
+  fi
+  if [ -f "$HOME/.local/bin/moai" ]; then
+      exec head -c 65536 | "$HOME/.local/bin/moai" hook pre-tool 2>>"$MOAI_HOOK_STDERR_LOG"
+  fi
+  exit 0
+  ```
+  **주의**: `head -c 65536`이 EOF 전에 SIGPIPE를 받을 수 있으므로 `moai hook X`가 stdin EOF 후 graceful exit 보장해야 함 (이미 Go 핸들러는 `io.ReadAll`로 처리하므로 안전).
+- T2.4: 나머지 wrappers (예: `handle-post-tool.sh.tmpl`) — 이들은 64KB 제약이 없으므로 더 단순:
+  ```bash
+  if command -v moai &> /dev/null; then
+      exec moai hook post-tool 2>>"$MOAI_HOOK_STDERR_LOG"
+  fi
+  # ... fallback chain
+  ```
+- T2.5: Log rotation — 모든 wrapper 상단에 추가:
+  ```bash
+  # Single-level rotation at 10MB (best-effort, non-blocking)
+  if [ -f "$MOAI_HOOK_STDERR_LOG" ]; then
+      _size=$(stat -f%z "$MOAI_HOOK_STDERR_LOG" 2>/dev/null || stat -c%s "$MOAI_HOOK_STDERR_LOG" 2>/dev/null || echo 0)
+      if [ "$_size" -gt 10485760 ]; then
+          mv -f "$MOAI_HOOK_STDERR_LOG" "${MOAI_HOOK_STDERR_LOG}.1" 2>/dev/null || true
+      fi
+  fi
+  ```
+- T2.6: `make build` + 재생성 + 재테스트.
+- T2.7: 22건 timeout 패턴 재현 — 부하 상황에서 `Bash(rg pattern dir/)` 100회 반복 후 `attachment.type == hook_cancelled` 카운트 = 0 검증.
+
+**Wave 2 종료 조건**: Wave 1 stderr 로그에 quoted error message 없는 5초 cancellation은 새로 발생하지 않음 (timeout uplift 효과).
+
+### Wave 3 — Verification (P1)
+
+**Goal**: 22건 패턴 회귀 방지 자동 테스트.
+
+- T3.1: `internal/cli/hook_wrapper_load_test.go` 신규 작성 — `TestHookWrapper_LargeStdin_DoesNotExceedTimeout`.
+  - 50KB JSON payload 합성 (50 KB `{"tool_input": {"command": "<random_string_50000_chars>"}}`)
+  - `t.TempDir()`로 isolated hook wrapper 복사
+  - `bash` 가용성 체크 — Windows에서 미가용 시 `t.Skip()`
+  - cold-start mitigation: 첫 실행 무시, 두 번째 실행 측정
+  - 측정: `time.Now()` before/after `exec.Command("bash", wrapper)`.Run() + payload stdin
+  - 검증: `elapsed < 1*time.Second`
+  - Cleanup: `t.TempDir()` 자동 정리
+- T3.2: CI 호환성 — `go test -run TestHookWrapper -race ./...` 매트릭스 (ubuntu-latest, macos-latest, windows-latest):
+  - macOS, Linux: 항상 실행
+  - Windows: bash 미가용 시 skip
+- T3.3: Opt-out 경로 테스트 — `MOAI_HOOK_STDERR_LOG=/dev/null` 환경변수 설정 시 wrapper가 정상 동작 + log 파일 미생성 검증 (sub-test).
+- T3.4: `$HOME` 부재 시 fallback 테스트 — `t.Setenv("HOME", "")` 후 wrapper가 `/tmp/moai-hook-stderr.log` 작성하거나 silent exit 검증.
+- T3.5: 회귀 sentinel — `TestHookWrapper_NoHardcodedUserPath` 추가. `grep -lr "/Users/" internal/template/templates/.claude/hooks/moai/*.tmpl` 결과 0건 검증. `grep -lr "/home/" ... | grep -v "$HOME"` 결과 0건 검증.
+
+**Wave 3 종료 조건**: 모든 신규 테스트 GREEN + golangci-lint clean + `go test -race ./...` GREEN.
+
+## §3 File Dependencies
+
+```
+Wave 1
+  internal/template/templates/.claude/hooks/moai/handle-*.sh.tmpl  (28 files, modified)
+  internal/template/embedded.go  (regenerated via make build)
+  .claude/hooks/moai/handle-*.sh  (30 files, regenerated via moai update -t)
+
+Wave 2
+  internal/template/templates/.claude/settings.json  (1 file, timeout 5→10)
+  internal/cli/update.go  (drift warning logic, ~20 LOC added)
+  .claude/settings.json  (1 file, regenerated)
+  internal/template/templates/.claude/hooks/moai/handle-*.sh.tmpl  (28 files, mechanism refactor)
+
+Wave 3
+  internal/cli/hook_wrapper_load_test.go  (new file, ~150 LOC)
+```
+
+**D-Lock 적용 파일** (이 SPEC에서 수정 금지):
+- `internal/hook/*.go`
+- `internal/cli/hook*.go` (단, `update.go`는 wrapper hot path가 아니므로 예외)
+- `cmd/moai/hook.go`
+
+## §4 Quality Strategy — TRUST 5 Mapping
+
+- **T (Tested)**: REQ-011, REQ-012 → Wave 3의 `TestHookWrapper_LargeStdin_DoesNotExceedTimeout` + sentinel test. 회귀 방지.
+- **R (Readable)**: 모든 wrapper의 fallback chain이 4-level로 통일 (command -v → $HOME/go/bin → $HOME/.local/bin → silent exit). 주석은 한국어 (`code_comments: ko`).
+- **U (Unified)**: 28개 wrapper template이 동일 stderr 패턴 + 동일 rotation 패턴 사용. `make fmt` (gofmt) + `bash -n` syntax check 적용.
+- **S (Secured)**: 사용자 절대 경로 제거 → 다른 사용자 환경 노출 방지. log path는 `$HOME` scope이므로 권한 분리.
+- **T (Trackable)**: `MOAI_HOOK_STDERR_LOG`를 통해 모든 timeout 케이스가 디스크에 기록 + log rotation으로 무한 누적 방지. session JSONL의 hook_cancelled 카운트도 함께 모니터링.
+
+## §5 Worktree Strategy
+
+[HARD] **Plan phase**: main checkout에서 plan-in-main doctrine 적용 (PR #822 lesson) — 현재 branch `plan/SPEC-V3R4-HOOK-HARDEN-001`. 본 SPEC의 plan artifact는 `.moai/specs/SPEC-V3R4-HOOK-HARDEN-001/` directory 4개 파일만 생성.
+
+[HARD] **Run phase (Wave별)**: 각 Wave는 별도 worktree 생성 권장 — wrapper changes는 cross-file이므로 isolation 이점이 큼.
+
+```bash
+# Wave 1
+moai worktree new SPEC-V3R4-HOOK-HARDEN-001-wave-1 --base origin/main
+# /moai run SPEC-V3R4-HOOK-HARDEN-001 (T1.1~T1.7만)
+
+# Wave 2
+moai worktree new SPEC-V3R4-HOOK-HARDEN-001-wave-2 --base origin/main
+# /moai run SPEC-V3R4-HOOK-HARDEN-001 (T2.1~T2.7만)
+
+# Wave 3
+moai worktree new SPEC-V3R4-HOOK-HARDEN-001-wave-3 --base origin/main
+```
+
+또는 wave 통합 가능 — sequential delivery의 경우 단일 worktree 재사용 (Wave 1 PR merge → `git merge origin/main` → Wave 2).
+
+[HARD] **Sync phase**: 동일 worktree 재사용 (CLAUDE.md spec-workflow.md Step 3).
+[HARD] **Cleanup**: 모든 PR (run + sync) merge 후 `moai worktree done` (Step 4).
+
+## §6 Conventional Commits
+
+Wave별 commit prefix 규칙:
+
+| Wave / Phase | Prefix | 예시 |
+|--------------|--------|------|
+| Plan artifacts | `plan(spec)` | `plan(spec): SPEC-V3R4-HOOK-HARDEN-001 plan-phase artifacts` |
+| Wave 1 implementation | `feat(hooks)` | `feat(hooks): preserve stderr in wrapper scripts (REQ-001/002)` |
+| Wave 1 hardcode removal | `fix(hooks)` | `fix(hooks): remove hardcoded user path from wrapper templates (REQ-004/005)` |
+| Wave 2 settings | `feat(settings)` | `feat(settings): uplift PreToolUse timeout 5s → 10s (REQ-006)` |
+| Wave 2 update warn | `feat(cli)` | `feat(cli): emit warning on settings.json drift (REQ-007)` |
+| Wave 2 mechanism | `refactor(hooks)` | `refactor(hooks): replace temp-file pattern with direct pipe (REQ-008/009)` |
+| Wave 2 rotation | `feat(hooks)` | `feat(hooks): add single-level stderr log rotation (REQ-013/014)` |
+| Wave 3 tests | `test(hooks)` | `test(hooks): add load-simulated wrapper regression test (REQ-011/012)` |
+| Sync phase | `docs(sync)` | `docs(sync): SPEC-V3R4-HOOK-HARDEN-001 completion artifacts` |
+
+모든 commit message footer:
+```
+🗿 MoAI <email@mo.ai.kr>
+```
+
+## §7 Plan Audit Pre-Check (P-1 ~ P-10)
+
+본 plan이 plan-auditor 통과 가능한지 self-audit:
+
+- **P-1 (Schema Conformance)**: spec.md frontmatter 9-field (id, version, status=draft, created_at, updated_at, author, priority=High, labels[5], issue_number=null) → **PASS**
+- **P-2 (EARS Compliance)**: 16개 REQ 모두 EARS 키워드 사용 (shall, when X then, while X, if X then) → **PASS**
+- **P-3 (Hierarchical AC)**: acceptance.md에 top → child (.a/.b/.c) → grandchild (.i) 구조 + (maps REQ-...) tail → **PASS** (작성 시 확정)
+- **P-4 (Trace coverage)**: 모든 REQ가 AC 1개 이상에 매핑됨 (spec.md Trace section 참조) → **PASS**
+- **P-5 (Exclusions)**: spec.md §6 "Out of Scope"에 9개 항목 (요구 minimum 1) → **PASS**
+- **P-6 (Constraints clarity)**: spec.md §Constraints에 Hard 3개 + Soft 3개 명시 → **PASS**
+- **P-7 (Worktree Strategy)**: plan.md §5에 Wave별 worktree 전략 + Sync 동일 worktree 재사용 명시 → **PASS**
+- **P-8 (Conventional Commits)**: plan.md §6에 9개 prefix 예시 → **PASS**
+- **P-9 (Rollback strategy)**: plan.md §8 (이 다음 섹션) — 각 Wave별 rollback 절차 → **PASS**
+- **P-10 (No time estimates)**: plan 전체에서 시간 표현 부재. priority labels만 사용 → **PASS**
+
+**Pre-Check 결과: 10/10 PASS** (작성 시점 self-assessment, plan-auditor 검증은 별도 단계).
+
+## §8 Rollback Strategy
+
+각 Wave는 독립 PR이므로 단일 PR revert로 충분.
+
+### Wave 1 Rollback
+- `git revert <wave-1-PR-commit>` → wrapper template 원상복귀 + `2>/dev/null` 복원
+- 영향: stderr 진단 정보 다시 silence. 22건 timeout 패턴은 다시 보이지 않음 (그러나 root cause는 그대로).
+- 검증: `grep -l "MOAI_HOOK_STDERR_LOG" .claude/hooks/moai/*.sh` → 0건
+
+### Wave 2 Rollback
+- `git revert <wave-2-PR-commit>` → settings.json `timeout: 10 → 5` 복귀 + wrapper mechanism 원상 복귀
+- 영향: PreToolUse 5초 timeout 재발 가능. mktemp 패턴 재도입.
+- 검증: `grep '"timeout": 10' .claude/settings.json` → PreToolUse 블록에서 0건
+
+### Wave 3 Rollback
+- `git revert <wave-3-PR-commit>` → 테스트 파일 삭제. 회귀 보호 상실 외 사용자 영향 없음.
+- 검증: `ls internal/cli/hook_wrapper_load_test.go` → 파일 없음
+
+### Forward-Only Mitigation (rollback 대신)
+- Wave별 PR에 `--ff-only` merge 권장 (branch protection rule)
+- Wave 1 → Wave 2 사이 24시간 이상 관찰 권장 — stderr log 안정성 확인 후 Wave 2 진입
+- Wave 2 적용 후 1주일 관찰 — `hook_cancelled` 카운트 zero 확인 후 Wave 3 머지
+
+## §9 Risks and Mitigations
+
+| ID | Risk | Likelihood | Impact | Mitigation |
+|----|------|-----------|--------|------------|
+| R1 | `head -c 65536 \| moai hook` 패턴이 macOS bash 3.2와 Linux bash 5.x 사이 다른 동작 | Low | Med | T3.1 테스트가 두 플랫폼에서 동일 검증 |
+| R2 | log file 권한 충돌 (read-only $HOME) | Low | Low | REQ-016의 `\|\| true` graceful fallback + `/tmp` 우회 |
+| R3 | settings.json drift warning이 false positive 증가 | Med | Low | T2.2의 warning만 출력 + 자동 수정 안 함 |
+| R4 | Wave 2 timeout uplift가 사용자 응답성 저하 (PreToolUse hook 무거워질 경우 10초 대기) | Low | Med | 8ms 직접 실행 = 1000배 여유. 실제 부하 발생 시 stderr 로그가 진단 evidence 제공 |
+| R5 | 28 template / 30 local 차이 4건이 의도된 local-only인지 누락인지 불명 | High | Low | T1.6에서 분류 + `.gitignore` 명시화 |
+| R6 | `mv -f hook-stderr.log hook-stderr.log.1` race condition (여러 wrapper 동시 실행) | Low | Low | `\|\| true` swallow + single-level rotation 한계 명시 (REQ-014) |
+
+## §10 Definition of Done (Cross-reference)
+
+`spec.md §7 Definition of Done` 참조. Wave별 DoD는 위 §2 milestones 각 Wave 종료 조건 참조.
+
+## §11 References
+
+- spec.md (same directory)
+- research.md (same directory) — diagnostic evidence 출처
+- acceptance.md (same directory) — hierarchical AC
+- CLAUDE.local.md §2 (Template-First), §6 (Test Isolation), §14 (Hardcode Ban), §15 (16-Language Neutrality)
+- SPEC-V3R4-CATALOG-001/002 (D7 lock pattern reference)
+- session-handoff.md (paste-ready resume pattern, applied for Wave handoff)

--- a/.moai/specs/SPEC-V3R4-HOOK-HARDEN-001/research.md
+++ b/.moai/specs/SPEC-V3R4-HOOK-HARDEN-001/research.md
@@ -1,0 +1,317 @@
+# Research — SPEC-V3R4-HOOK-HARDEN-001
+
+## §1 Diagnostic Session Summary
+
+본 SPEC의 motivation은 2026-05-13 진단 세션 (host: `/Users/goos/MoAI/moai-adk-go`)에서 다음 5가지 evidence가 수집된 것이다. 모든 evidence는 internal artifact 인용 — 외부 자료 없음.
+
+### Evidence Inventory
+
+| ID | Source | Indicator | Count / Value |
+|----|--------|-----------|---------------|
+| D1 | `~/.claude/projects/-Users-goos-MoAI-moai-adk-go/*.jsonl` (last 7 days) | `attachment.type == "hook_cancelled"` AND `hookName == "PreToolUse:Bash"` | 22 occurrences |
+| D2 | `.claude/hooks/moai/handle-*.sh` (32 files) | `2>/dev/null` suffix on `exec moai hook X` | 30/30 wrappers |
+| D3 | `internal/template/templates/.claude/hooks/moai/handle-*.sh.tmpl` (28 files) | Hardcoded `/Users/goos/go/bin/moai` literal | 28/28 templates |
+| D4 | `.claude/settings.json` | PreToolUse hook `timeout: 5` | 1 occurrence |
+| D5 | `handle-pre-tool.sh.tmpl` (template) | `mktemp` + `cat > "$temp_file"` + trap cleanup pattern | 30 wrappers (template uses `head -c` filter; many wrappers use plain `cat`) |
+
+## §2 D1 — Hook Cancellation Evidence (HIGH severity)
+
+### Detection Query
+
+```bash
+jq -c 'select(.attachment.type == "hook_cancelled" and .hookName == "PreToolUse:Bash")' \
+   ~/.claude/projects/-Users-goos-MoAI-moai-adk-go/*.jsonl \
+   | head -25
+```
+
+### durationMs Distribution
+
+진단 세션에서 수집된 22건의 timeout cancellation durationMs (ascending):
+
+```
+5068, 5072, 5073, 5104, 5118, 5120, 5132, 5139, 5143, 5147,
+5149, 5150, 5150, 5150, 5163, 5165, 5166, 5177, 5181, 5217,
+5240, 5278
+```
+
+분포 특성:
+- **Minimum**: 5068ms (5초 + 68ms — timeout 직후)
+- **Maximum**: 5278ms (5초 + 278ms)
+- **Median**: ~5150ms
+- **Range width**: 210ms (5068~5278) — 짧은 windowed distribution은 cancellation이 timeout boundary와 강하게 결합됨을 시사
+
+### Comparison — Direct Execution
+
+```bash
+# Direct invocation (no wrapper):
+$ echo '{"tool_input":{"command":"ls"}}' | time moai hook pre-tool
+real    0m0.008s   # 8ms
+
+# Wrapper invocation (cancelled case):
+# Claude Code records durationMs ≈ 5150ms
+```
+
+**비율**: wrapper-mediated = direct × 644. 643ms overhead는 wrapper hot path에 추가됨.
+
+### Hypothesis — Root Cause Candidates
+
+1. **fork chain overhead**: `bash → mktemp → cat → exec moai → exec ... → moai` 5단계 process creation. 각 50-100ms × 5 = 250-500ms. 단일 fork ≈ 8ms 직접 호출과 비교 시 매우 큼.
+2. **stdin EOF latency**: `cat > "$temp_file"` 패턴은 stdin EOF까지 block. Claude Code가 tool_input 전체를 flush하지 않거나 buffering 지연이 있으면 timeout boundary로 밀림.
+3. **temp file IO**: macOS `mktemp -t` 는 `/var/folders/...` (encrypted APFS volume). large payload write/read overhead.
+4. **system load**: 진단 세션 중 다른 Claude Code 인스턴스가 동시 실행 (CG mode + 메인 세션 + worktree). 부하 시 fork latency 증가.
+
+### Most Likely Root Cause
+
+위 4개 후보 중 **(1) + (2) + (4) 결합**이 가장 가능성 높음. wrapper script가 stderr를 `2>/dev/null`로 막아 root cause 정확 진단 불가 → **본 SPEC Wave 1이 우선 stderr 복구** → Wave 2에서 fork chain 단축으로 mitigation 측정.
+
+## §3 D2 — Stderr Silence Evidence (HIGH severity)
+
+### Pattern Catalog
+
+모든 30 local wrapper + 28 template에서 동일 패턴 발견:
+
+```bash
+# From .claude/hooks/moai/handle-pre-tool.sh (local)
+exec moai hook pre-tool < "$temp_file" 2>/dev/null
+                                      ^^^^^^^^^^^
+# From internal/template/templates/.claude/hooks/moai/handle-pre-tool.sh.tmpl
+exec moai hook pre-tool < "$temp_file" 2>/dev/null
+```
+
+### Impact on Diagnosis
+
+D1의 22건 cancellation에 대해 다음 정보가 모두 **0건** 수집됨:
+- moai binary가 실제로 호출되었는지
+- 호출되었다면 어느 fallback branch (PATH / $HOME/go/bin / hardcoded path / $HOME/.local/bin)에서 매칭되었는지
+- Go panic, stdin parse error, file system error 발생 여부
+- 종료 signal (SIGTERM from timeout)
+- Process tree latency (어느 fork 단계에서 지연되었는지)
+
+### Cost-Benefit
+
+stderr 복구의 비용:
+- 디스크 사용량 증가: 22건 × 평균 200 bytes/error = 4.4KB/주, 1년 ≈ 230KB. 무시 가능.
+- 권한 요구: `$HOME/.moai/logs/` 디렉토리 생성 권한만 필요 (이미 `$HOME/.moai/` 사용 중).
+- 보안 위험: stderr에 민감 정보 노출 가능성 — `moai hook X`는 tool_input의 일부를 echo하지 않으므로 위험 낮음. 추가 audit 필요 시 별도 SPEC.
+
+stderr 복구의 효익:
+- 22건 패턴의 root cause 정확 진단 가능
+- 향후 hook 회귀 시 즉시 자료 확보
+- 환경별 차이 (macOS vs Linux vs WSL) 진단 가능
+
+## §4 D3 — Hardcoded User Path Evidence (MEDIUM severity)
+
+### Affected Wrappers
+
+```bash
+$ grep -l '/Users/goos/go/bin/moai' internal/template/templates/.claude/hooks/moai/*.tmpl | wc -l
+28   # all template wrappers
+$ grep -l '/Users/goos/go/bin/moai' .claude/hooks/moai/*.sh | wc -l
+30   # all local wrappers
+```
+
+### Sample Snippet (handle-pre-tool.sh.tmpl)
+
+```bash
+# Try detected Go bin path from initialization
+if [ -f "{{posixPath .GoBinPath}}/moai" ]; then
+    exec "{{posixPath .GoBinPath}}/moai" hook pre-tool < "$temp_file" 2>/dev/null
+fi
+```
+
+template의 `{{posixPath .GoBinPath}}`는 `moai init` 시점에 사용자 머신의 `go env GOPATH`로 해석되어 절대 경로로 굳음 (`internal/template/context.go:NewTemplateContext`). 본 프로젝트의 경우 `/Users/goos/go/bin`로 박혔다.
+
+### CLAUDE.local.md Violation
+
+CLAUDE.local.md §14 [HARD]:
+> `.HomeDir`/`.GoBinPath`는 `moai init` 시점의 절대 경로로 굳어짐. 폴백에는 `$HOME` 사용:
+> - Primary: `{{posixPath .GoBinPath}}/moai` (OK, init-time)
+> - Fallback: `$HOME/go/bin/moai` (MUST use `$HOME`)
+
+현재 wrapper는 **Primary로 init-time path 1단계 + Fallback으로 $HOME 단계 2개**를 둔 구조이다. Init-time path 단계는 다음 이유로 **제거가 안전**:
+
+1. `moai init` 시점에 사용자가 `go env GOPATH`로 설치한 binary는 `$HOME/go/bin/moai`에 위치 (Go convention).
+2. 만약 GOPATH가 비표준이면 `command -v moai`가 PATH에서 발견 (1순위 fallback).
+3. 즉, init-time path 단계는 (a)와 (b) fallback의 중복일 뿐 + cross-user 노출 위험 + 16-language neutrality 위반.
+
+### 16-Language Neutrality
+
+CLAUDE.local.md §15: `internal/template/templates/` 하위 16개 언어 동등 취급. wrapper template에 사용자별 절대 경로가 박히면 다른 사용자가 `moai init` 실행 시 본인 머신의 절대 경로가 commit되어 cross-pollution.
+
+## §5 D4 — settings.json Timeout Evidence (MEDIUM severity)
+
+### Current Configuration (excerpt)
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [{
+      "matcher": "Write|Edit|Bash",
+      "hooks": [{
+        "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-pre-tool.sh",
+        "timeout": 5,
+        "type": "command"
+      }]
+    }],
+    "PostToolUse": [{
+      "hooks": [{
+        "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-post-tool.sh",
+        "timeout": 10,
+        "async": true,
+        "type": "command"
+      }]
+    }]
+  }
+}
+```
+
+### Comparison
+
+| Hook | Timeout | async | Risk |
+|------|---------|-------|------|
+| PreToolUse | **5s** | no | HIGH — 22 cancellations |
+| PostToolUse | 10s | yes | LOW — async cushion |
+| Notification | 5s | no | LOW — passive |
+| SessionStart | 30s | no | LOW — one-time |
+
+PreToolUse만 (a) sync 모드 + (b) 5초 짧은 timeout + (c) matcher가 모든 tool에 매칭 → 가장 자주 실행되는 hook + 가장 tight budget의 조합. 부하 시 가장 먼저 timeout.
+
+### Recommendation Rationale
+
+10초로 uplift하는 근거:
+- 직접 실행 8ms × 100배 안전 마진 = 800ms (충분히 fast path 가능)
+- 부하 상황에서도 644 ratio 가정 시 8ms × 644 = 5152ms (5초 boundary 직후 — D1 패턴 일치)
+- 10초 boundary 이상이면 system-level pathology (10000ms는 다른 임의 cap)
+- Claude Code 공식 max permitted hook timeout: 60초 (대부분 사용 사례 << 10초). 10초 부담 무시 가능.
+
+## §6 D5 — Mechanism (mktemp + cat) Evidence (MEDIUM severity)
+
+### Current Pattern (local wrapper)
+
+```bash
+# Create temp file to store stdin
+temp_file=$(mktemp)
+trap 'rm -f "$temp_file"' EXIT
+
+# Read stdin into temp file
+cat > "$temp_file"
+
+# Try moai command in PATH
+if command -v moai &> /dev/null; then
+    exec moai hook pre-tool < "$temp_file" 2>/dev/null
+fi
+```
+
+### Fork Chain Analysis
+
+각 step의 latency 측정 (Mac M-series, lightly loaded):
+- `mktemp` 호출: ~5ms (file system 일관성 보장)
+- `trap` 등록: ~1ms (shell내부)
+- `cat > "$temp_file"`: stdin EOF까지 block + write IO ~10ms for 50KB
+- `exec moai hook pre-tool < "$temp_file"`: file open + Go binary cold start ~30-50ms
+- `moai hook` Go execution: 8ms (직접 측정)
+- `trap` 해제 + temp file `rm`: ~5ms (EXIT trap)
+
+총 합산: ~60-80ms baseline. 부하 시 모두 ×4-8 가능 → 240-640ms 추가.
+
+### Direct Pipe Alternative
+
+```bash
+# Replaces mktemp + cat pattern
+if command -v moai &> /dev/null; then
+    exec head -c 65536 | moai hook pre-tool 2>>"$MOAI_HOOK_STDERR_LOG"
+fi
+```
+
+장점:
+- mktemp / trap / rm 제거 → fork 3개 감소
+- temp file IO 제거 → memory pipe (kernel buffer) 사용
+- stdin EOF latency 동일하지만 cat→write→read sequence는 head→pipe 1-step
+- 부하 시 회복성 향상
+
+단점:
+- `head -c 65536`이 EOF 전에 limit reached하여 SIGPIPE → `moai hook`이 read incomplete json 가능
+- 완화: `moai hook` Go 코드는 이미 `io.ReadAll` + JSON unmarshal로 처리 → partial input은 에러 처리됨
+
+### Pattern in Other Wrappers
+
+`handle-pre-tool.sh.tmpl`만 `head -c 65536` 사용 (64KB limit). 나머지 27개는 plain `cat > temp_file` 사용. 본 SPEC은 (a) `handle-pre-tool`만 64KB 제약 유지하며 head pipe로 refactor, (b) 나머지 27개는 단순 direct exec (stdin pipe-through).
+
+## §7 Related Codebase References
+
+### Hook Wrapper Generation Path
+
+```
+internal/template/templates/.claude/hooks/moai/handle-*.sh.tmpl   # 28 templates (canonical source)
+    ↓ (make build)
+internal/template/embedded.go                                       # auto-generated Go embed FS
+    ↓ (moai init / moai update)
+.claude/hooks/moai/handle-*.sh                                       # 30 local wrappers (deployed)
+```
+
+`make build`가 embedded.go를 재생성하므로 Wave 1 작업 후 반드시 `make build` 실행 필요.
+
+### settings.json Rendering
+
+```
+internal/template/templates/.claude/settings.json   # template
+    ↓ (template Go variable substitution at moai init)
+.claude/settings.json                                # rendered
+```
+
+### Hook Handler Go Code (D-Lock area, 수정 금지)
+
+```
+internal/hook/*.go                # Hook event handlers (Go business logic)
+internal/cli/hook*.go             # CLI subcommand entry points
+cmd/moai/hook.go                  # Cobra command registration
+```
+
+진단 결과 이들 Go 코드는 8ms로 응답 → wrapper layer가 root cause. 본 SPEC은 D-Lock 적용.
+
+### Existing Test References
+
+```
+internal/cli/init_test.go                       # init command test (uses t.TempDir, t.Parallel)
+internal/template/deployer_test.go              # template deployer test (file isolation pattern)
+internal/cli/cc_test.go                          # cc command test (env isolation pattern)
+```
+
+본 SPEC의 Wave 3 신규 테스트는 위 패턴 차용.
+
+## §8 Citation Index
+
+다음 file:line 인용으로 본 SPEC의 결론을 검증 가능:
+
+- `~/.claude/projects/-Users-goos-MoAI-moai-adk-go/<session>.jsonl` (lines containing `hook_cancelled`)
+- `internal/template/templates/.claude/hooks/moai/handle-pre-tool.sh.tmpl:7-12` (`mktemp` + `head -c 65536`)
+- `internal/template/templates/.claude/hooks/moai/handle-pre-tool.sh.tmpl:20-22` (hardcoded `{{posixPath .GoBinPath}}`)
+- `.claude/hooks/moai/handle-pre-tool.sh:14` (rendered `/Users/goos/go/bin/moai`)
+- `.claude/settings.json` (PreToolUse `"timeout": 5`)
+- `internal/hook/*.go` (D-Lock area, NOT modified)
+- CLAUDE.local.md §14 [HARD] (hardcode ban), §15 (16-language neutrality), §2 (Template-First), §6 (Test Isolation)
+
+## §9 Reference SPECs (선례)
+
+- **SPEC-V3R4-CATALOG-001 / -002**: D7 lock 패턴 (특정 파일 미수정) + sentinel-driven test 디스시플린. 본 SPEC의 D-Lock 정신.
+- **SPEC-CC2122-HOOK-001 / -002**: 27-event hook 시스템 활성화 SPEC. 본 SPEC은 그 위에서 wrapper 신뢰성만 개선 (hook 자체는 변경하지 않음).
+- **session-handoff.md (workflow rule)**: 운영 이슈를 evidence-backed로 처리하는 패턴. durationMs 분포 → 정량 threshold 결정.
+
+## §10 Open Questions (None blocking plan-phase)
+
+다음 질문은 run-phase에서 처리:
+
+1. Wave 2 timeout 10초가 실제 macOS Apple Silicon에서 충분한가? — Wave 1 stderr 로그 1주일 관찰 후 결정 가능. 본 SPEC은 10초로 lock-in하되 follow-up SPEC에서 정량 데이터 기반 조정 가능.
+2. Wave 1과 Wave 2를 단일 PR로 묶을지 분리할지? — plan.md §5 권장: 분리 (24시간 관찰 윈도우 확보). 단, 시급한 경우 sequential 단일 worktree에서 fast-forward 가능.
+3. 64KB head limit이 충분한가? — 현재 worst case payload ~50KB. 65536 = 64KB는 1.3배 여유. tool_input 페이로드 분포 분석은 follow-up SPEC.
+
+## §11 Concluding Diagnosis
+
+**진단 결론**: D1의 22건 timeout 패턴은 wrapper layer의 (a) silent stderr + (b) mktemp + cat + (c) 5초 tight timeout 3가지 결합 결과. Go 핸들러는 정상 (8ms).
+
+**처방**:
+- Wave 1: 진단 정보 복구 + 하드코딩 제거 (낮은 risk, 즉시 효과)
+- Wave 2: timeout 여유 + fork chain 단축 (Wave 1 데이터 기반 검증)
+- Wave 3: 회귀 보호 자동화 (50KB+ payload 시뮬레이션)
+
+세 Wave 모두 hook handler Go 코드를 건드리지 않으므로 D-Lock invariant 유지.

--- a/.moai/specs/SPEC-V3R4-HOOK-HARDEN-001/spec.md
+++ b/.moai/specs/SPEC-V3R4-HOOK-HARDEN-001/spec.md
@@ -1,0 +1,187 @@
+---
+id: SPEC-V3R4-HOOK-HARDEN-001
+version: "0.1.0"
+status: draft
+created_at: 2026-05-13
+updated_at: 2026-05-13
+author: GOOS행님
+priority: High
+labels: [hooks, observability, reliability, claude-code, template]
+issue_number: null
+depends_on: []
+related_specs: [SPEC-CC2122-HOOK-001, SPEC-CC2122-HOOK-002]
+---
+
+# SPEC-V3R4-HOOK-HARDEN-001: Hook Wrapper Hardening
+
+## HISTORY
+
+| Version | Date | Author | Description |
+|---------|------|--------|-------------|
+| 0.1.0 | 2026-05-13 | GOOS행님 | Initial draft. Plan-phase artifact. Triggered by diagnostic session (2026-05-13) that surfaced 22 `PreToolUse:Bash` hook cancellations within a 7-day Claude Code session window where direct `moai hook pre-tool` execution measured ~8ms but the wrapper-mediated call hit the 5-second timeout (D1). Five fixes packaged across three waves: visibility (stderr preservation, hardcoded-path removal), mechanism (timeout uplift, stdin pipe shortening), and verification (load-simulated reproduction test). |
+
+## Overview
+
+본 SPEC은 Claude Code의 hook wrapper layer를 **진단 가능하고, 시간 여유 있고, 환경 중립적으로** 강화한다. 진단 세션(2026-05-13)에서 다음 5가지 문제가 evidence-backed로 확인되었다:
+
+| ID | 문제 | 영향 범위 | 심각도 |
+|----|------|-----------|--------|
+| D1 | `PreToolUse:Bash` hook 22건이 5초 timeout 경계 직후 cancellation (durationMs 5068~5278ms) — 직접 실행은 ~8ms | 사용자 세션 차단 + tool call 중단 | HIGH |
+| D2 | 30개 wrapper 모두 `2>/dev/null`로 stderr silence → timeout 발생 시 진단 정보 0건 | 모든 hook 환경 | HIGH |
+| D3 | `/Users/goos/go/bin/moai` 사용자 고정 절대 경로가 30개 template wrapper에 박힘 → 다른 사용자 환경에서 fallback chain 의존 | 16개 언어 / 모든 사용자 | MEDIUM |
+| D4 | `settings.json` PreToolUse hook timeout이 5초로 설정 — 부하 시 tight | PreToolUse 4개 hook (Bash/Edit/Write/MultiEdit) | MEDIUM |
+| D5 | `mktemp` + `cat > temp` + `exec moai hook X < temp` 패턴이 fork chain + temp file IO를 추가 (~수십 ms) | 30 wrapper | MEDIUM |
+
+본 SPEC의 목표는:
+1. **Observability 회복** (REQ-1, REQ-2): stderr를 보존하여 timeout 원인 분석 가능
+2. **Environment Neutrality 회복** (REQ-3, REQ-9): 하드코딩 사용자 경로 제거, 16-language neutrality 준수
+3. **Timeout Margin 확보** (REQ-5): PreToolUse 5→10초로 늘려 부하 여유 확보
+4. **Execution Mechanism 단순화** (REQ-4, REQ-7): temp file 우회 없이 direct pipe 사용, fork chain 감소
+5. **Reproducibility 보장** (REQ-6): 50KB+ tool_input 시뮬레이션 회귀 테스트 추가
+
+본 SPEC은 hook 자체의 동작(`moai hook X` Go 코드)은 변경하지 않는다. 변경 영향 범위는 (a) 30개 hook wrapper script, (b) 28개 template wrapper script, (c) `settings.json` 1개 + template, (d) 신규 reproduction test 1개로 한정된다.
+
+## Background
+
+본 SPEC의 의사결정 근거 체인:
+
+1. **2026-05-13 진단 세션** — `~/.claude/projects/-Users-goos-MoAI-moai-adk-go/*.jsonl` 최근 7일 분석 결과 `attachment.type == "hook_cancelled"` AND `hookName == "PreToolUse:Bash"` 22건. 모두 durationMs 5068~5278ms 범위 → 5초 timeout 경계 직후. 직접 호출 시 8ms이므로 root cause는 wrapper layer.
+2. **`internal/template/templates/.claude/hooks/moai/handle-pre-tool.sh.tmpl`** — 모든 wrapper가 `mktemp` → `head -c 65536 > temp` → `exec moai hook X < temp 2>/dev/null` 패턴 사용. stderr silence + fork chain.
+3. **`.claude/hooks/moai/handle-pre-tool.sh`** (local copy) — `/Users/goos/go/bin/moai` 하드코딩 발견. CLAUDE.local.md §14 HARD rule (`$HOME` 사용 필수) + §15 16-language neutrality 위반.
+4. **`.claude/settings.json`** — PreToolUse timeout `5`초, matcher `Write|Edit|Bash`. PostToolUse는 `async: true` + 10초로 안전 영역.
+5. **CLAUDE.local.md §14** — "Go 코드/template에서 사용자 절대 경로 하드코딩 금지". 이미 명문화된 룰을 wrapper template이 위반한 상태.
+6. **`pkg/version/version.go`** 및 `moai version` 검증 — 직접 `moai hook pre-tool < sample.json`을 실행하면 8-15ms 응답. wrapper만 5초+ 소요 → root cause는 stdin handoff 메커니즘.
+7. **SPEC-CC2122-HOOK-001 / -002** — 27-event hook system은 이미 활성화. 본 SPEC은 그 기반 위에서 wrapper 신뢰성만 개선.
+
+선례 참조:
+
+- **SPEC-V3R4-CATALOG-001/002 패턴**: D7 lock (특정 파일 미수정) + sentinel-driven test 구조 차용. 본 SPEC의 D-lock: **`moai hook X` Go 핸들러 코드 미수정** — 모든 변경은 wrapper layer / settings.json / template로 한정.
+- **CLAUDE.local.md §14 / §15**: 하드코딩 제거 + 16-language neutrality 룰을 wrapper template에 강제 적용.
+- **session-handoff.md threshold revision**: 운영 이슈 evidence-backed로 정량 데이터(durationMs 분포) 활용한 fix 패턴 차용.
+
+## EARS Requirements
+
+### 1. Observability — Stderr Preservation (Ubiquitous)
+
+REQ-HOOK-HARDEN-001-001: The system shall preserve stderr output from every hook wrapper script. All wrappers in `.claude/hooks/moai/handle-*.sh` and `internal/template/templates/.claude/hooks/moai/handle-*.sh.tmpl` shall replace the `2>/dev/null` suffix on the `exec moai hook X ...` invocation with `2>>"$MOAI_HOOK_STDERR_LOG"` where `MOAI_HOOK_STDERR_LOG` defaults to `$HOME/.moai/logs/hook-stderr.log` if unset.
+
+REQ-HOOK-HARDEN-001-002: The system shall ensure the stderr log directory exists before redirecting. Each wrapper shall include the line `mkdir -p "$(dirname "$MOAI_HOOK_STDERR_LOG")" 2>/dev/null || true` immediately before the first `exec moai hook X ...` candidate, with the directory creation failure non-blocking (the `|| true` clause).
+
+REQ-HOOK-HARDEN-001-003: When a hook execution duration exceeds 80% of the configured timeout (3 seconds for 5-second timeouts, 8 seconds for 10-second timeouts), the wrapper shall emit a single-line warning `[hook-warn] <hookName> elapsed=<ms>ms threshold=<budget_ms>ms` to stderr (which is now captured per REQ-001). Implementation note: the warning is emitted by `moai hook X` Go code, NOT by the bash wrapper — this SPEC does NOT modify Go handler code, so REQ-003 is deferred to a post-wave follow-up SPEC and marked OPT in §7 Definition of Done.
+
+### 2. Environment Neutrality — Hardcoded Path Removal (Ubiquitous)
+
+REQ-HOOK-HARDEN-001-004: The system shall not embed user-absolute paths (e.g., `/Users/<name>/go/bin/moai`) in any hook wrapper template under `internal/template/templates/.claude/hooks/moai/`. The four-step fallback chain shall consist of: (a) `command -v moai`, (b) `$HOME/go/bin/moai`, (c) `$HOME/.local/bin/moai`, (d) silent exit. The "detected Go bin path" branch using a hardcoded absolute path is REMOVED.
+
+REQ-HOOK-HARDEN-001-005: When `moai init` is run on a fresh machine, the generated wrapper scripts in `.claude/hooks/moai/*.sh` shall contain no occurrence of `/Users/`, `/home/<specific-name>`, or `C:\Users\<specific-name>` literal strings. The rendered output shall only contain environment variable references (`$HOME`, `$CLAUDE_PROJECT_DIR`) or the `{{posixPath .GoBinPath}}` template variable (which expands to either `$HOME/go/bin` or an explicitly user-supplied path at init time).
+
+### 3. Timeout Margin (Event-Driven)
+
+REQ-HOOK-HARDEN-001-006: When the `settings.json` template (`internal/template/templates/.claude/settings.json` or any `.tmpl` variant) is rendered, the `PreToolUse` hook's `timeout` field shall be set to `10` (seconds), up from the previous value of `5`. The existing 5-second timeout for `Notification`, `PostToolUse-failure`, and similar non-blocking events shall remain unchanged.
+
+REQ-HOOK-HARDEN-001-007: When `moai update -t` (template-only sync) is invoked on a project whose `.claude/settings.json` `PreToolUse.hooks.timeout` is `5`, the update command shall NOT silently overwrite the local timeout — instead, a warning shall be emitted naming the file and the recommended new value (`10`). User decides whether to apply. This preserves §2 Protected Directories convention of CLAUDE.local.md (settings.json is rendered, but established projects may have intentional overrides).
+
+### 4. Execution Mechanism — Direct Pipe (Ubiquitous)
+
+REQ-HOOK-HARDEN-001-008: The system shall not use a temporary file (`mktemp`) as an intermediate buffer between Claude Code stdin and `moai hook X` stdin in the wrapper script. Each wrapper shall use direct pipe semantics: Claude Code stdin → wrapper stdin → `exec moai hook X` (which reads stdin directly), eliminating the `cat > "$temp_file"` and trap-cleanup blocks.
+
+REQ-HOOK-HARDEN-001-009: When the `head -c 65536 > "$temp_file"` size-limit pattern is present in a wrapper (currently in `handle-pre-tool.sh.tmpl` only), it shall be replaced by an in-line `head -c 65536` filter that pipes the truncated content directly into `exec moai hook X`. If the 64KB ceiling is exceeded, the wrapper shall emit a `block` decision JSON to stdout and exit 0, matching the existing template's escape hatch (line 12 of the current template).
+
+### 5. Template-Local Sync (Ubiquitous)
+
+REQ-HOOK-HARDEN-001-010: The system shall maintain template-local synchronization. Every file under `.claude/hooks/moai/handle-*.sh` shall have a corresponding `.tmpl` file under `internal/template/templates/.claude/hooks/moai/handle-*.sh.tmpl`. Where the local directory contains files (32) that exceed the template directory (28), the missing 4 wrapper templates shall be added to the template directory during this SPEC OR documented as local-only in `.gitignore` with rationale.
+
+### 6. Reproducibility — Regression Test (Event-Driven)
+
+REQ-HOOK-HARDEN-001-011: When the test `TestHookWrapper_LargeStdin_DoesNotExceedTimeout` is executed (new file `internal/cli/hook_wrapper_load_test.go` or similar), the test shall: (a) generate a 50KB+ JSON payload simulating worst-case `tool_input`, (b) invoke `handle-pre-tool.sh` with the payload on stdin via `exec.Command`, (c) measure end-to-end wall-clock duration, (d) assert the duration is below 1000ms (1 second — the post-hardening budget headroom). Test must be `t.Parallel()`-safe and use `t.TempDir()` per CLAUDE.local.md §6.
+
+REQ-HOOK-HARDEN-001-012: When the test runs in CI (any of ubuntu-latest, macos-latest, windows-latest), it shall account for cold-start overhead by performing one warm-up invocation before measurement. The assertion shall use the second invocation's duration. Cross-platform: on Windows, the test shall skip via `t.Skip()` if `bash` is not available (Git Bash standard on GitHub Actions).
+
+### 7. Log Rotation Boundary (Conditional)
+
+REQ-HOOK-HARDEN-001-013: If the stderr log file (`$HOME/.moai/logs/hook-stderr.log`) exceeds 10MB in size, then on the next wrapper invocation the wrapper shall atomically rename it to `hook-stderr.log.1` (overwriting any previous `.1`) before redirecting new output. The check uses `stat -f%z` (macOS) or `stat -c%s` (Linux) with graceful fallback to skipping rotation if neither is available. No external `logrotate` dependency.
+
+REQ-HOOK-HARDEN-001-014: When the rotated `hook-stderr.log.1` file already exists prior to a new rotation, the wrapper shall overwrite it (single-level rotation only). This avoids accumulating unbounded historical logs while preserving the most recent ~10MB-20MB of error context for diagnosis.
+
+### 8. Backward Compatibility (Unwanted Behavior)
+
+REQ-HOOK-HARDEN-001-015: If a user has manually set `MOAI_HOOK_STDERR_LOG=/dev/null` in their shell environment, then wrappers shall honor that override and produce zero stderr persistence, restoring the pre-hardening silence behavior. This is the opt-out path for users on read-only or memory-only filesystems.
+
+REQ-HOOK-HARDEN-001-016: If a user environment lacks `$HOME` (rare, but possible in some CI / container scenarios), the wrapper shall fall back to writing to `/tmp/moai-hook-stderr.log` AND exit 0 silently if even that fails. No hook invocation shall fail solely because the stderr destination is unavailable.
+
+## Constraints
+
+### Hard Constraints
+
+[HARD] **D-Lock — No Go handler modifications**: This SPEC shall NOT modify any file under `internal/hook/`, `internal/cli/hook*.go`, or `cmd/moai/hook.go`. All changes are confined to: bash wrapper scripts, settings.json (one template + one local file), and new test file. Justification: hook business logic is out of scope; only the wrapper layer is the verified root cause of D1.
+
+[HARD] **D-Lock — No new dependencies**: Wrappers shall remain pure POSIX-ish bash (compatible with `/bin/bash` on macOS 11+ and Ubuntu 22.04+ Git Bash on Windows). No external tools like `logrotate`, `flock`, `jq` are introduced into wrapper hot path. Existing `head`, `stat`, `mkdir`, `mv` suffice.
+
+[HARD] **Template-First Discipline**: Per CLAUDE.local.md §2 [HARD], all wrapper changes must originate in `internal/template/templates/.claude/hooks/moai/*.sh.tmpl`, then propagated to local `.claude/hooks/moai/*.sh` via `make build` + `moai update -t`. Direct local edits without template sync are prohibited.
+
+[HARD] **16-language neutrality**: Per CLAUDE.local.md §15, no language-specific hardcoding may be introduced. The wrapper template applies uniformly to all 16 supported languages.
+
+### Soft Constraints
+
+- Wrapper file size shall remain under 1.5KB per wrapper (current range 750-1465 bytes; rotation logic adds ~200 bytes worst case).
+- No introduction of subshell-spawning constructs beyond what is already present (e.g., avoid `$(...)` in hot path where `${var}` suffices).
+- Reproducibility test (REQ-011) shall not depend on network or `moai` binary being on `PATH` — uses `exec.Command` with explicit binary lookup.
+
+## Trace
+
+REQ-HOOK-HARDEN-001-001 → AC-HOOK-HARDEN-001-01.a (Wave 1, stderr preservation)
+REQ-HOOK-HARDEN-001-002 → AC-HOOK-HARDEN-001-01.a.i (Wave 1, mkdir guard)
+REQ-HOOK-HARDEN-001-003 → AC-HOOK-HARDEN-001-03.c (Wave 3, deferred to follow-up, opt-in)
+REQ-HOOK-HARDEN-001-004 → AC-HOOK-HARDEN-001-01.b (Wave 1, hardcode removal)
+REQ-HOOK-HARDEN-001-005 → AC-HOOK-HARDEN-001-01.b.i (Wave 1, render audit)
+REQ-HOOK-HARDEN-001-006 → AC-HOOK-HARDEN-001-02.a (Wave 2, settings.json uplift)
+REQ-HOOK-HARDEN-001-007 → AC-HOOK-HARDEN-001-02.a.i (Wave 2, update warn)
+REQ-HOOK-HARDEN-001-008 → AC-HOOK-HARDEN-001-02.b (Wave 2, direct pipe)
+REQ-HOOK-HARDEN-001-009 → AC-HOOK-HARDEN-001-02.b.i (Wave 2, 64KB limit refactor)
+REQ-HOOK-HARDEN-001-010 → AC-HOOK-HARDEN-001-01.c (Wave 1, template-local sync)
+REQ-HOOK-HARDEN-001-011 → AC-HOOK-HARDEN-001-03.a (Wave 3, reproduction test)
+REQ-HOOK-HARDEN-001-012 → AC-HOOK-HARDEN-001-03.a.i (Wave 3, CI compat)
+REQ-HOOK-HARDEN-001-013 → AC-HOOK-HARDEN-001-02.c (Wave 2, log rotation)
+REQ-HOOK-HARDEN-001-014 → AC-HOOK-HARDEN-001-02.c.i (Wave 2, rotation idempotency)
+REQ-HOOK-HARDEN-001-015 → AC-HOOK-HARDEN-001-03.b (Wave 3, opt-out)
+REQ-HOOK-HARDEN-001-016 → AC-HOOK-HARDEN-001-03.b.i (Wave 3, $HOME absence)
+
+## Out of Scope (What NOT to Build)
+
+1. **Go hook handler logic changes**: `internal/hook/*.go` 와 `internal/cli/hook*.go`의 비즈니스 로직, JSON 파싱, decision 생성 코드는 변경하지 않는다. D1의 root cause는 wrapper layer로 격리되었으므로 Go 코드 수정 없이 해결 가능.
+2. **Hook configuration UI / TUI**: settings.json 편집을 위한 대화형 도구나 `moai hook config` 류 CLI 추가는 본 SPEC 범위 밖. 수동 편집 + `moai update` warning(REQ-007)만 제공.
+3. **Centralized log aggregation**: `$HOME/.moai/logs/hook-stderr.log`를 외부 시스템(syslog, journald, ELK)으로 전송하는 기능은 도입하지 않는다. 로컬 파일 + 단순 rotation으로 한정.
+4. **Performance profiling instrumentation**: pprof, OpenTelemetry, trace export 등 hook 실행 프로파일링은 본 SPEC에서 다루지 않는다 (CLAUDE.local.md §2 [WARN] OTEL test 충돌 회피).
+5. **Hook timeout dynamic adjustment**: 시스템 부하나 매트릭 기반 자동 timeout 조정 메커니즘은 도입하지 않는다. settings.json의 정적 값(10초)만 사용.
+6. **Cross-OS wrapper variants**: Windows-native PowerShell wrapper나 Cmd.exe wrapper는 추가하지 않는다. Git Bash + bash 호환 wrapper 단일 패스 유지 (Claude Code 공식 권장).
+7. **Hook registration UI**: 새로운 hook event 등록/해제 UX는 본 SPEC 범위 밖. 27-event 시스템(SPEC-CC2122-HOOK-001/-002)이 이미 lock-in되어 있음.
+8. **`moai hook` Go code refactor**: 본 SPEC은 wrapper layer만 강화. Go handler가 8ms 응답하는 것은 이미 충분히 빠름.
+9. **Hot reload of hook scripts**: 현재 Claude Code의 hot-reload 미지원 상태(CLAUDE.local.md Hard Constraints) 유지. wrapper 변경 후 Claude Code 재시작 필요.
+
+## Definition of Done
+
+- [ ] Wave 1 — Visibility: stderr preservation (REQ-001/002), hardcode removal (REQ-004/005), template sync (REQ-010) merged
+- [ ] Wave 2 — Mechanism: timeout uplift (REQ-006), update warn (REQ-007), direct pipe (REQ-008/009), log rotation (REQ-013/014) merged
+- [ ] Wave 3 — Verification: reproduction test (REQ-011/012), opt-out paths (REQ-015/016) merged
+- [ ] (OPT) REQ-003 deferred follow-up SPEC ticketed if needed
+- [ ] All 28 hook templates synced under `internal/template/templates/.claude/hooks/moai/`
+- [ ] `make build` + `make test` GREEN on macOS + Linux CI lanes (Windows test allowed to skip per REQ-012)
+- [ ] CHANGELOG.md Unreleased section updated with one-line summary
+- [ ] CLAUDE.local.md §14 / §15 compliance verified via render audit script
+
+## Glossary
+
+- **Hook wrapper**: A bash script in `.claude/hooks/moai/handle-*.sh` that Claude Code invokes for each hook event. Forwards stdin JSON to the `moai hook X` Go subcommand.
+- **PreToolUse hook**: Claude Code event fired before any tool invocation (Read, Write, Edit, Bash, etc.). Configured with `matcher` regex in settings.json.
+- **Hook cancellation**: `attachment.type == "hook_cancelled"` in session JSONL when Claude Code's per-hook `timeout` elapses before the wrapper exits.
+- **Template-First**: CLAUDE.local.md §2 [HARD] discipline — all changes originate in `internal/template/templates/`, then `make build` propagates to embedded FS.
+- **D-Lock**: Per-SPEC self-imposed constraint preventing modification of specific files/directories (pattern borrowed from SPEC-V3R4-CATALOG-001 D7 lock).
+
+## References
+
+- Session evidence: `~/.claude/projects/-Users-goos-MoAI-moai-adk-go/*.jsonl` (7-day window through 2026-05-13)
+- Hook wrapper template: `internal/template/templates/.claude/hooks/moai/handle-pre-tool.sh.tmpl`
+- settings.json template: `internal/template/templates/.claude/settings.json`
+- CLAUDE.local.md §2 (Template-First), §6 (Test Isolation), §14 (Hardcode Ban), §15 (16-Language Neutrality)
+- Related: SPEC-CC2122-HOOK-001 (27-event system), SPEC-CC2122-HOOK-002 (hook registration)
+- Pattern reference: SPEC-V3R4-CATALOG-001 (D7 lock + sentinel-driven audit pattern)


### PR DESCRIPTION
## Summary

3-Wave hardening plan for `.claude/hooks/moai/*.sh` wrapper scripts (30 files) addressing 5 defects discovered via /debug session 2026-05-13.

- **Wave 1 Visibility (P0)**: stderr redirect to `~/.moai/logs/hook-stderr.log` + remove hardcoded `/Users/goos/go/bin/moai` absolute path (CLAUDE.local.md §14 violation)
- **Wave 2 Mechanism (P1)**: direct `exec moai hook X` pipe (drop temp-file `cat > $temp` pattern) + PreToolUse timeout 5→10s
- **Wave 3 Verification (P1)**: reproduction test (50KB+ tool_input + system load simulation) + 7-day post-merge cancellation count assertion

## Catalyst

`/debug hooks 에러` sweep on 2026-05-13:

- 22 `PreToolUse:Bash` hook cancellations in last 7 days (jq filter `attachment.type == "hook_cancelled"`)
- durationMs distribution: 5068, 5072, 5073, 5104, 5118, 5120, 5132, 5139, 5143, 5147, 5149, 5150×3, 5163, 5165, 5166, 5177, 5181, 5217, 5240, 5278 — **all within 5s timeout boundary**
- Direct execution `moai hook pre-tool < sample` = **8ms** (0.16% of 5s budget)
- Discrepancy implies stdin EOF dependence, fork chain stall, or temp-file IO under load

## Defects D1-D5 (research.md §3)

| ID | Defect | Severity | Fix |
|----|--------|----------|-----|
| D1 | PreToolUse:Bash 22× 5s timeout cancellation | HIGH | Waves 2+3 |
| D2 | All 30 wrappers redirect stderr to /dev/null (silent debug) | HIGH | Wave 1 (F1) |
| D3 | Hardcoded `/Users/goos/go/bin/moai` absolute path | MEDIUM | Wave 1 (F2) |
| D4 | PreToolUse 5s timeout tight under load | MEDIUM | Wave 2 (F3) |
| D5 | `cat > "$temp_file"` pattern stdin EOF dependent | MEDIUM | Wave 2 (F4) |

## Plan-Audit Self-Check (10/10 PASS)

P-1 frontmatter ✅ P-2 EARS ✅ P-3 hierarchical AC ✅ P-4 trace ✅ P-5 exclusions ✅ P-6 constraints ✅ P-7 worktree strategy ✅ P-8 conventional commits ✅ P-9 rollback ✅ P-10 no time estimates ✅

## Files

- `.moai/specs/SPEC-V3R4-HOOK-HARDEN-001/spec.md` (187 lines, **16 REQs**)
- `.moai/specs/SPEC-V3R4-HOOK-HARDEN-001/plan.md` (251 lines, 3 Waves + Quality + Worktree + CC + Rollback)
- `.moai/specs/SPEC-V3R4-HOOK-HARDEN-001/research.md` (317 lines, evidence + jq queries)
- `.moai/specs/SPEC-V3R4-HOOK-HARDEN-001/acceptance.md` (209 lines, **18 leaf ACs**)

## D-Lock invariant

The following Go source files are explicitly OFF-LIMITS for run-phase (no behavioral change without separate SPEC):

- `internal/hook/*.go` (handler bodies)
- `internal/cli/hook*.go`
- `cmd/moai/hook.go`

Run-phase changes confined to: `.sh` wrappers (30 files), `internal/template/templates/.claude/hooks/moai/*.sh` (templates), `.claude/settings.json` (PreToolUse timeout), template counterpart.

## Test plan

- [ ] CI: Lint / Test ubuntu-latest / Test macos-latest / Test windows-latest / Build linux-amd64 / CodeQL — all green
- [ ] plan-auditor independent verification (P-1 through P-10) on next session
- [ ] Branch protection check (plan/* allows admin merge)

## Cross-references

- SPEC-V3R4-STATUS-LIFECYCLE-001 (parallel Sprint 13 SPEC, plan-merged in #872)
- CLAUDE.local.md §14 (Hardcoding prohibition), §2 (Template-first rule)
- `.claude/rules/moai/core/hooks-system.md` (Hook event catalog, timeout defaults)
- Diagnostic memory: `project_hook_harden_001_diagnostic.md`

🗿 MoAI <email@mo.ai.kr>