### PR TITLE
chore(glm): clear residual DISABLE_PROMPT_CACHING env on tmux teardown

### DIFF
--- a/internal/cli/glm.go
+++ b/internal/cli/glm.go
@@ -414,6 +414,9 @@ func clearTmuxSessionEnv() error {
 		"CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS",
 		"API_TIMEOUT_MS",
 		"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC",
+		// Legacy: DISABLE_PROMPT_CACHING was previously used for Z.AI compat
+		// but Z.AI now supports prompt caching. Cleanup residual values.
+		"DISABLE_PROMPT_CACHING",
 		// Issue #742: clear GLM context-size hint when leaving GLM mode
 		config.EnvStatuslineContextSize,
 	}


### PR DESCRIPTION
## Summary

- `clearTmuxSessionEnv()`이 GLM 모드 teardown 시 정리하는 env 리스트에 `DISABLE_PROMPT_CACHING` 추가
- Z.AI가 prompt caching을 지원한 이후 주입 경로는 제거됐으나, 과거 세션 잔존 값이 carry-over되어 다음 Claude 세션 caching이 비활성화되는 사례 방지

## Scope

`internal/cli/glm.go` `clearTmuxSessionEnv()` 함수 env 리스트 3 lines 추가. 타 모듈 영향 없음, behavior preserve.

## Test plan

- [x] `go vet ./...`
- [ ] `go test ./internal/cli/...` (CI)
- [ ] 회귀: GLM 모드 진입/종료 후 caching 재활성화 확인 (수동, post-merge)

## Labels (자동 부착 전 명시)

- `type:chore`
- `area:cli`
- `priority:P3`

🗿 MoAI <email@mo.ai.kr>