### PR TITLE
chore(statusline): emoji → ASCII WT prefix + ahead/behind suffix

### DIFF
--- a/internal/statusline/renderer.go
+++ b/internal/statusline/renderer.go
@@ -325,8 +325,8 @@ func (r *Renderer) renderBarsInline(data *StatusData, width int) string {
 }
 
 // renderDirGitLine renders the directory + branch + git status line (default L3, full L5).
-// Format: 📁 moai-adk-go │ 🅱️ main +6 │ 📬 +0 M6 ?0
-// When worktree is active: 🌿 replaces 🅱️ prefix
+// Format: 📁 moai-adk-go │ 🅱️ main ↑2↓1 +6 │ 📬 +0 M6 ?0
+// When worktree is active: "[WT] " prefix is prepended to the branch segment.
 func (r *Renderer) renderDirGitLine(data *StatusData) string {
 	var segs []string
 
@@ -339,7 +339,7 @@ func (r *Renderer) renderDirGitLine(data *StatusData) string {
 	if r.isSegmentEnabled(SegmentGitBranch) {
 		if branch := renderGitBranch(data); branch != "" {
 			if r.isSegmentEnabled(SegmentWorktree) && data.Worktree != "" {
-				branch = "🌿 " + branch
+				branch = "[WT] " + branch
 			}
 			segs = append(segs, branch)
 		}
@@ -470,10 +470,17 @@ func (r *Renderer) contextPercent(data *StatusData) int {
 	return usagePercent(data.Memory.TokensUsed, data.Memory.TokenBudget)
 }
 
-// renderGitBranch renders the git branch string with status emoji indicators.
-// REQ-V3-GIT-005: Status emoji prefixes: 📦(staged), 🔨(modified)
-// REQ-V3-GIT-006: Clean state → "🅱️ branch +0", Dirty → "emoji🅱️ branch +N"
-// Note: 🌿(worktree) prefix is added by renderDirGitLine when segment is enabled
+// renderGitBranch renders the git branch string with optional ahead/behind suffix.
+//
+// Format: "🅱️ <branch>[ ↑N][ ↓N] +<dirty>"
+//   - Ahead and Behind are shown only when non-zero (zero values are omitted).
+//   - The dirty count aggregates Modified + Staged + Untracked.
+//   - When data.Git is unavailable or branch is empty, returns "".
+//
+// Status emoji prefixes (legacy 🔨/📦) have been removed: the L3/L5 mailbox emoji
+// (📬/📫/📪/📭) plus the detailed `+S M_M ?U` counter already convey staged/modified
+// state, so prefixing the branch produced redundant visual noise.
+// Note: "[WT] " (worktree) prefix is added by renderDirGitLine when segment is enabled.
 func renderGitBranch(data *StatusData) string {
 	if !data.Git.Available || data.Git.Branch == "" {
 		return ""
@@ -481,28 +488,20 @@ func renderGitBranch(data *StatusData) string {
 
 	branch := data.Git.Branch
 
-	// Determine status emoji (priority: staged > modified)
-	var emoji string
-	if data.Git.Staged > 0 {
-		emoji = "📦"
-	} else if data.Git.Modified > 0 {
-		emoji = "🔨"
+	// Ahead/Behind suffix (0 values omitted).
+	var aheadBehind string
+	if data.Git.Ahead > 0 {
+		aheadBehind += fmt.Sprintf(" ↑%d", data.Git.Ahead)
+	}
+	if data.Git.Behind > 0 {
+		aheadBehind += fmt.Sprintf(" ↓%d", data.Git.Behind)
 	}
 
-	// Calculate dirty count (modified + staged + untracked)
+	// Dirty count (modified + staged + untracked); always rendered, includes +0.
 	dirty := data.Git.Modified + data.Git.Staged + data.Git.Untracked
+	dirtySuffix := fmt.Sprintf(" +%d", dirty)
 
-	var suffix string
-	if dirty > 0 {
-		suffix = fmt.Sprintf(" +%d", dirty)
-	} else {
-		suffix = " +0"
-	}
-
-	if emoji != "" {
-		return fmt.Sprintf("%s🅱️ %s%s", emoji, branch, suffix)
-	}
-	return fmt.Sprintf("🅱️ %s%s", branch, suffix)
+	return fmt.Sprintf("🅱️ %s%s%s", branch, aheadBehind, dirtySuffix)
 }
 
 // renderSessionTime converts milliseconds to a session time string in "⏳ Xh Ym" format.

--- a/internal/statusline/renderer_test.go
+++ b/internal/statusline/renderer_test.go
@@ -644,14 +644,24 @@ func TestRenderGitBranchV3(t *testing.T) {
 		worktree string
 		want     string
 	}{
-		// REQ-V3-GIT-006: Clean state → "🅱️ main +0"
+		// Clean state → "🅱️ main +0"
 		{"clean", GitStatusData{Branch: "main", Available: true}, "", "🅱️ main +0"},
-		// REQ-V3-GIT-005: Modified → "🔨🅱️ feat +2"
-		{"modified", GitStatusData{Branch: "feat", Modified: 2, Available: true}, "", "🔨🅱️ feat +2"},
-		// REQ-V3-GIT-005: Staged → "📦🅱️ main +1"
-		{"staged", GitStatusData{Branch: "main", Staged: 1, Available: true}, "", "📦🅱️ main +1"},
-		// REQ-V3-GIT-005: Modified + Staged (staged takes priority) → "📦🅱️ main +3"
-		{"modified+staged", GitStatusData{Branch: "main", Modified: 2, Staged: 1, Available: true}, "", "📦🅱️ main +3"},
+		// Modified files (no longer prefixed with 🔨 — mailbox/M-count carry the signal)
+		{"modified", GitStatusData{Branch: "feat", Modified: 2, Available: true}, "", "🅱️ feat +2"},
+		// Staged files (no longer prefixed with 📦)
+		{"staged", GitStatusData{Branch: "main", Staged: 1, Available: true}, "", "🅱️ main +1"},
+		// Modified + Staged: dirty count is sum, no prefix emoji
+		{"modified+staged", GitStatusData{Branch: "main", Modified: 2, Staged: 1, Available: true}, "", "🅱️ main +3"},
+		// Ahead only → "🅱️ feat ↑2 +0"
+		{"ahead", GitStatusData{Branch: "feat", Ahead: 2, Available: true}, "", "🅱️ feat ↑2 +0"},
+		// Behind only → "🅱️ feat ↓1 +0"
+		{"behind", GitStatusData{Branch: "feat", Behind: 1, Available: true}, "", "🅱️ feat ↓1 +0"},
+		// Ahead + Behind → "🅱️ feat ↑2 ↓1 +0"
+		{"ahead+behind", GitStatusData{Branch: "feat", Ahead: 2, Behind: 1, Available: true}, "", "🅱️ feat ↑2 ↓1 +0"},
+		// Ahead + dirty → "🅱️ feat ↑2 +3"
+		{"ahead+dirty", GitStatusData{Branch: "feat", Ahead: 2, Modified: 3, Available: true}, "", "🅱️ feat ↑2 +3"},
+		// Zero ahead/behind explicitly omitted
+		{"zero ahead/behind", GitStatusData{Branch: "main", Ahead: 0, Behind: 0, Available: true}, "", "🅱️ main +0"},
 		// Unavailable → empty string
 		{"unavailable", GitStatusData{Available: false}, "", ""},
 	}
@@ -864,11 +874,13 @@ func TestRenderDefaultV3_Line3(t *testing.T) {
 	if !strings.Contains(l3, "📁 moai-adk-go") {
 		t.Errorf("default L3 must contain directory, got: %q", l3)
 	}
-	if !strings.Contains(l3, "📦🅱️ feat/auth +6") {
-		t.Errorf("default L3 must contain branch with dirty count, got: %q", l3)
+	// Branch segment: 🅱️ <name> ↑<ahead> ↓<behind> +<dirty>
+	// dirty = Staged(3) + Modified(2) + Untracked(1) = 6
+	if !strings.Contains(l3, "🅱️ feat/auth ↑2 ↓1 +6") {
+		t.Errorf("default L3 must contain branch with ahead/behind and dirty count, got: %q", l3)
 	}
-	if !strings.Contains(l3, "🅱️") {
-		t.Errorf("default L3 must contain git status, got: %q", l3)
+	if strings.Contains(l3, "📦") || strings.Contains(l3, "🔨") {
+		t.Errorf("default L3 must not contain legacy 📦/🔨 prefix, got: %q", l3)
 	}
 }
 
@@ -1056,11 +1068,13 @@ func TestRenderFullV3_Line5_DirBranchGit(t *testing.T) {
 	if !strings.Contains(l5, "📁 moai-adk-go") {
 		t.Errorf("full L5 must contain directory, got: %q", l5)
 	}
-	if !strings.Contains(l5, "📦🅱️ feat/auth +6") {
-		t.Errorf("full L5 must contain branch with dirty count, got: %q", l5)
+	// Branch segment: 🅱️ <name> ↑<ahead> ↓<behind> +<dirty>
+	// dirty = Staged(3) + Modified(2) + Untracked(1) = 6
+	if !strings.Contains(l5, "🅱️ feat/auth ↑2 ↓1 +6") {
+		t.Errorf("full L5 must contain branch with ahead/behind and dirty count, got: %q", l5)
 	}
-	if !strings.Contains(l5, "🅱️") {
-		t.Errorf("full L5 must contain git status, got: %q", l5)
+	if strings.Contains(l5, "📦") || strings.Contains(l5, "🔨") {
+		t.Errorf("full L5 must not contain legacy 📦/🔨 prefix, got: %q", l5)
 	}
 }
 
@@ -1352,9 +1366,10 @@ func TestRenderUsageBarWithReset(t *testing.T) {
 	}
 }
 
-// TestRenderDirGitLine_WorktreeIndicator verifies that 🌿 prefix appears in branch
-// segment when worktree is active and SegmentWorktree is enabled.
-// REQ-CC297-003: 🌿 prefix shown in branch segment when worktree is active
+// TestRenderDirGitLine_WorktreeIndicator verifies that the "[WT] " prefix appears in
+// the branch segment when a worktree is active and SegmentWorktree is enabled.
+// REQ-CC297-003: worktree prefix shown in branch segment when worktree is active.
+// The legacy 🌿 emoji was replaced with the textual "[WT] " marker for clarity.
 func TestRenderDirGitLine_WorktreeIndicator(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -1363,25 +1378,25 @@ func TestRenderDirGitLine_WorktreeIndicator(t *testing.T) {
 		wantWT         bool
 	}{
 		{
-			name:           "worktree present and segment enabled: shows 🌿",
+			name:           "worktree present and segment enabled: shows [WT]",
 			worktree:       "/repo/.claude/worktrees/abc123",
 			segmentEnabled: true,
 			wantWT:         true,
 		},
 		{
-			name:           "worktree present but segment disabled: no 🌿",
+			name:           "worktree present but segment disabled: no [WT]",
 			worktree:       "/repo/.claude/worktrees/abc123",
 			segmentEnabled: false,
 			wantWT:         false,
 		},
 		{
-			name:           "no worktree with segment enabled: no 🌿",
+			name:           "no worktree with segment enabled: no [WT]",
 			worktree:       "",
 			segmentEnabled: true,
 			wantWT:         false,
 		},
 		{
-			name:           "no worktree and segment disabled: no 🌿",
+			name:           "no worktree and segment disabled: no [WT]",
 			worktree:       "",
 			segmentEnabled: false,
 			wantWT:         false,
@@ -1398,16 +1413,20 @@ func TestRenderDirGitLine_WorktreeIndicator(t *testing.T) {
 			}
 			r := NewRenderer("default", true, segCfg)
 			data := &StatusData{
-				Git:      GitStatusData{Branch: "feat/test", Available: true},
+				Git:       GitStatusData{Branch: "feat/test", Available: true},
 				Directory: "myproject",
-				Worktree: tt.worktree,
+				Worktree:  tt.worktree,
 			}
 			got := r.renderDirGitLine(data)
-			if tt.wantWT && !strings.Contains(got, "🌿") {
-				t.Errorf("expected 🌿 when worktree is active, got %q", got)
+			// Legacy emoji must never appear regardless of state.
+			if strings.Contains(got, "🌿") {
+				t.Errorf("legacy 🌿 emoji must not appear, got %q", got)
 			}
-			if !tt.wantWT && strings.Contains(got, "🌿") {
-				t.Errorf("unexpected 🌿 when worktree is inactive, got %q", got)
+			if tt.wantWT && !strings.Contains(got, "[WT] ") {
+				t.Errorf("expected [WT] prefix when worktree is active, got %q", got)
+			}
+			if !tt.wantWT && strings.Contains(got, "[WT]") {
+				t.Errorf("unexpected [WT] prefix when worktree is inactive, got %q", got)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

statusline의 worktree segment와 git branch suffix UX를 정리합니다.

- 🌿 (worktree emoji) → \`[WT] \` ASCII prefix — 터미널 폰트 호환성/좁은 화면 가독성 개선
- "↑N↓N" ahead/behind suffix 추가 (0이면 생략) — local/origin 동기화 상태 표시
- legacy 🔨(modified) / 📦(staged) prefix 제거 — L3/L5 mailbox emoji + dirty counter와 redundant
- docstring 갱신, 테스트 케이스 동시 업데이트

## Scope

- \`internal/statusline/renderer.go\` (49 line diff)
- \`internal/statusline/renderer_test.go\` (75 line diff)

타 모듈 영향 없음, behavior preserve, 신규 emoji/외부 의존성 없음.

## Test plan

- [x] \`go vet ./internal/statusline/...\`
- [x] \`go test ./internal/statusline/...\` (local, 2.74s ok)
- [ ] CI: ubuntu/macos/windows 회귀
- [ ] Manual: \`moai cc\` / \`moai cg\` / 일반 git branch에서 statusline 시각 확인 (post-merge)

## Labels

- \`type:chore\`
- \`area:cli\`
- \`priority:P3\`

## Provenance

- 출처: 별도 세션의 \`stash@{0} On main: statusline UI tweak: branch prefix WT + ahead/behind + tests (pre-HRN-002)\` → HRN-002 run-phase 시작 전 stash 보관 후 main에 pop된 변경
- HRN-002 (PR #879) 또는 HOOK-HARDEN-001 (PR #878) scope와 분리된 독립 UI tweak

🗿 MoAI <email@mo.ai.kr>