### PR TITLE
fix(ci): errcheck on hook_wrapper_load_test.go intentional discards

### DIFF
--- a/internal/cli/hook_wrapper_load_test.go
+++ b/internal/cli/hook_wrapper_load_test.go
@@ -43,7 +43,8 @@ func TestHookWrapper_LargeStdin_DoesNotExceedTimeout(t *testing.T) {
 
 	// Cold-start: first execution to warm caches
 	runWrapperOnce(t, wrapperCopy, payload, stderrLog)
-	os.Remove(stderrLog)
+	// Best-effort cleanup; failure is non-fatal for the warmup phase.
+	_ = os.Remove(stderrLog)
 
 	// Measured execution
 	start := time.Now()
@@ -87,7 +88,9 @@ func TestHookWrapper_OptOutStderrLog(t *testing.T) {
 		"MOAI_HOOK_STDERR_LOG=/dev/null",
 		"HOME="+tmpDir,
 	)
-	cmd.CombinedOutput()
+	// Run the wrapper; output/error are intentionally discarded because the
+	// assertion below only checks for absence of the stderr log file.
+	_, _ = cmd.CombinedOutput()
 
 	logFile := filepath.Join(tmpDir, ".moai", "logs", "hook-stderr.log")
 	if _, err := os.Stat(logFile); !os.IsNotExist(err) {


### PR DESCRIPTION
## Summary

main의 Lint job이 깨진 상태를 hotfix합니다. HOOK-HARDEN-001 Wave 3 (PR #878)에 포함된 \`internal/cli/hook_wrapper_load_test.go\` 가 golangci-lint errcheck 규칙 2건을 위반.

## Affected Tests

| Line | API | Fix |
|---|---|---|
| 46 | \`os.Remove(stderrLog)\` (warmup cleanup) | \`_ = os.Remove(stderrLog)\` + 인라인 코멘트 |
| 90 | \`cmd.CombinedOutput()\` (테스트 검증 대상 아님) | \`_, _ = cmd.CombinedOutput()\` + 인라인 코멘트 |

두 호출 모두 의도적 discard이므로 \`_\` 마킹이 정공 해법. 동작 변경 없음.

## Why hotfix priority

- main의 Lint job이 PR #878 머지 이후 깨진 상태
- 다른 OPEN PR (#880 statusline, #881 status drift sync, ... )이 main을 base로 빌드 시 동일 Lint 실패에 막힘
- 즉시 머지 시 후속 PR들이 정상화

## Test plan

- [x] \`golangci-lint run ./internal/cli/...\` → 0 issues
- [x] \`go test ./internal/cli/ -run 'TestHookWrapper_Load|TestHookWrapper_OptOut'\` → PASS (0.528s)
- [ ] CI: ubuntu/macos/windows Lint green 확인

## Labels

- \`type:fix\`
- \`area:ci\`
- \`priority:P1\`

🗿 MoAI <email@mo.ai.kr>