### PR TITLE
feat(spec): SPEC-V3R2-HRN-003 M2 — Type definitions + error sentinels

### DIFF
--- a/internal/config/errors.go
+++ b/internal/config/errors.go
@@ -42,6 +42,29 @@ var (
 	// HRN-002 run-phase minimal substrate — design-constitution §11.4.1에 의거
 	// per_iteration은 FROZEN 값이며 다른 값은 허용되지 않습니다.
 	ErrEvalMemoryFrozen = errors.New("HRN_EVAL_MEMORY_FROZEN: evaluator.memory_scope must be 'per_iteration' (FROZEN per design-constitution §11.4.1)")
+
+	// HRN-003 run-phase: 4-dimension × sub-criteria hierarchical scoring sentinels.
+
+	// ErrUnknownDimension은 프로필이 canonical 집합
+	// {Functionality, Security, Craft, Consistency} 외의 차원을 선언할 때 반환됩니다.
+	// REQ-HRN-003-019, AC-HRN-003-08.
+	ErrUnknownDimension = errors.New("HRN_UNKNOWN_DIMENSION: profile declares dimension outside canonical set {Functionality, Security, Craft, Consistency}")
+
+	// ErrRubricCitationMissing은 sub-criterion 점수에 rubric_anchor 필드가 없거나
+	// canonical anchor (0.25/0.50/0.75/1.00) 외의 값을 가질 때 반환됩니다.
+	// REQ-HRN-003-009, AC-HRN-003-05, design-constitution §12 Mechanism 1.
+	ErrRubricCitationMissing = errors.New("HRN_RUBRIC_CITATION_MISSING: sub-criterion score missing rubric_anchor field or non-canonical anchor (per design-constitution §12 Mechanism 1)")
+
+	// ErrFlatScoreCardProhibited은 GAN loop runner가 비계층(flat) ScoreCard를 반환하려 할 때
+	// CI 통합 테스트에서 발생합니다.
+	// REQ-HRN-003-017, AC-HRN-003-02.
+	ErrFlatScoreCardProhibited = errors.New("HRN_FLAT_SCORECARD_PROHIBITED: ScoreCard must be hierarchical; flat shape rejected per SPEC-V3R2-HRN-003 REQ-017")
+
+	// ErrMustPassBypassProhibited은 프로필이 design-constitution §12 Mechanism 3에서
+	// must-pass로 지정된 차원 (FROZEN Security + Functionality)에 대해 must_pass를 비활성화하려 할 때
+	// 로더 검증에서 반환됩니다.
+	// REQ-HRN-003-018, AC-HRN-003-11.
+	ErrMustPassBypassProhibited = errors.New("HRN_MUSTPASS_BYPASS_PROHIBITED: profile attempts to narrow must-pass set below floor [Security] (per design-constitution §12 Mechanism 3)")
 )
 
 // ValidationError represents a single validation error with field context.

--- a/internal/harness/rubric.go
+++ b/internal/harness/rubric.go
@@ -1,0 +1,527 @@
+// Package harness — HRN-003 Rubric struct, Markdown 파서, 인용 검증.
+// REQ-HRN-003-003: 4 anchor level (0.25, 0.50, 0.75, 1.00) FROZEN.
+// REQ-HRN-003-005: .md 프로필 파일 파서.
+// REQ-HRN-003-009: rubric-anchor 인용 강제.
+package harness
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/modu-ai/moai-adk/internal/config"
+)
+
+// @MX:NOTE: [AUTO] FROZEN at {0.25, 0.50, 0.75, 1.00} per design-constitution §12 Mechanism 1; adding anchors requires CON-002 amendment
+// @MX:WARN: [AUTO] FROZEN-zone constraint per CONST-V3R2-155; anchor set must remain {0.25, 0.50, 0.75, 1.00}
+// @MX:REASON: design-constitution §12 Mechanism 1 — "Every evaluation criterion has a concrete rubric with examples of scores at 0.25, 0.50, 0.75, and 1.0" (FROZEN)
+
+// canonicalAnchors는 rubric anchor의 canonical 집합입니다 (FROZEN).
+// REQ-HRN-003-003, REQ-HRN-003-013.
+var canonicalAnchors = map[float64]bool{
+	0.25: true,
+	0.50: true,
+	0.75: true,
+	1.00: true,
+}
+
+// canonicalAnchorStrings는 rubric anchor의 canonical 문자열 집합입니다 (FROZEN).
+// REQ-HRN-003-009: ValidateCitation에서 사용합니다.
+var canonicalAnchorStrings = map[string]bool{
+	"0.25": true,
+	"0.50": true,
+	"0.75": true,
+	"1.00": true,
+}
+
+// DimensionRubric는 단일 Dimension에 대한 rubric 설정입니다.
+type DimensionRubric struct {
+	// Weight는 이 차원의 가중치 (0.0~1.0)입니다.
+	Weight float64
+	// PassThreshold는 이 차원의 최소 통과 임계값 (≥ 0.60 FROZEN floor)입니다.
+	PassThreshold float64
+	// Anchors는 anchor score → 설명 맵입니다.
+	// canonical: {0.25, 0.50, 0.75, 1.00}
+	Anchors map[float64]string
+	// Aggregation은 이 차원의 집계 방식입니다 ("min" 또는 "mean").
+	// 빈 값이면 프로필 수준의 Rubric.Aggregation을 상속합니다.
+	Aggregation string
+}
+
+// Rubric는 evaluator profile의 채점 기준 구조체입니다.
+// REQ-HRN-003-003: 4 anchor level 포함.
+// REQ-HRN-003-005: .md 파일에서 파싱.
+type Rubric struct {
+	// ProfileName은 프로필 이름입니다 (예: "default", "strict").
+	ProfileName string
+	// Dimensions는 Dimension → DimensionRubric 맵입니다.
+	// 정확히 4개의 차원 (Functionality, Security, Craft, Consistency) 포함.
+	Dimensions map[Dimension]DimensionRubric
+	// PassThreshold는 전체 통과 임계값 (≥ 0.60 FROZEN floor)입니다.
+	PassThreshold float64
+	// MustPass는 must-pass 차원 목록입니다.
+	// [Security] floor — 이보다 좁은 집합은 허용되지 않습니다 (REQ-HRN-003-018).
+	MustPass []Dimension
+	// Aggregation은 기본 집계 방식입니다 ("min" 또는 "mean").
+	Aggregation string
+}
+
+// Validate는 Rubric의 유효성을 검증합니다.
+// 다음 조건을 모두 만족해야 합니다:
+//   - 정확히 4개의 canonical 차원 (REQ-HRN-003-012)
+//   - 각 차원에 정확히 4개의 canonical anchor (REQ-HRN-003-013)
+//   - pass_threshold ≥ 0.60 (REQ-HRN-003-014)
+//   - aggregation이 {"min", "mean"} 중 하나 (REQ-HRN-003-007)
+//   - MustPass가 [Security] floor를 포함 (REQ-HRN-003-018)
+func (r *Rubric) Validate() error {
+	var errs []config.ValidationError
+
+	// 정확히 4개의 canonical 차원을 가져야 합니다.
+	if len(r.Dimensions) != 4 {
+		errs = append(errs, config.ValidationError{
+			Field:   "Dimensions",
+			Message: fmt.Sprintf("must have exactly 4 dimensions, got %d (FROZEN per SPEC-V3R2-HRN-003 REQ-001)", len(r.Dimensions)),
+			Value:   len(r.Dimensions),
+			Wrapped: config.ErrInvalidConfig,
+		})
+	}
+
+	// 각 차원이 canonical인지 검증합니다.
+	for dim, dr := range r.Dimensions {
+		if !dim.IsValid() {
+			errs = append(errs, config.ValidationError{
+				Field:   fmt.Sprintf("Dimensions[%v]", dim),
+				Message: fmt.Sprintf("unknown dimension %v; only {Functionality, Security, Craft, Consistency} are valid (FROZEN per REQ-HRN-003-001)", dim),
+				Value:   dim,
+				Wrapped: config.ErrUnknownDimension,
+			})
+			continue
+		}
+
+		// 각 차원에 정확히 4개의 canonical anchor가 있어야 합니다.
+		if err := validateAnchors(dim, dr.Anchors); err != nil {
+			errs = append(errs, config.ValidationError{
+				Field:   fmt.Sprintf("Dimensions[%v].Anchors", dim),
+				Message: err.Error(),
+				Wrapped: config.ErrInvalidConfig,
+			})
+		}
+
+		// 차원별 pass_threshold ≥ 0.60 검증.
+		if dr.PassThreshold < 0.60 {
+			errs = append(errs, config.ValidationError{
+				Field:   fmt.Sprintf("Dimensions[%v].PassThreshold", dim),
+				Message: fmt.Sprintf("pass_threshold %.2f is below FROZEN floor 0.60 (SPEC-V3R2-HRN-003 REQ-014)", dr.PassThreshold),
+				Value:   dr.PassThreshold,
+				Wrapped: config.ErrInvalidConfig,
+			})
+		}
+
+		// 차원별 aggregation 검증.
+		if dr.Aggregation != "" && dr.Aggregation != "min" && dr.Aggregation != "mean" {
+			errs = append(errs, config.ValidationError{
+				Field:   fmt.Sprintf("Dimensions[%v].Aggregation", dim),
+				Message: fmt.Sprintf("aggregation %q is not valid; must be one of {min, mean}", dr.Aggregation),
+				Value:   dr.Aggregation,
+				Wrapped: config.ErrInvalidConfig,
+			})
+		}
+	}
+
+	// 전체 pass_threshold ≥ 0.60 검증.
+	if r.PassThreshold < 0.60 {
+		errs = append(errs, config.ValidationError{
+			Field:   "PassThreshold",
+			Message: fmt.Sprintf("pass_threshold %.2f is below FROZEN floor 0.60 (design-constitution §5, HRN-002 REQ-012)", r.PassThreshold),
+			Value:   r.PassThreshold,
+			Wrapped: config.ErrInvalidConfig,
+		})
+	}
+
+	// aggregation 검증.
+	if r.Aggregation != "min" && r.Aggregation != "mean" {
+		errs = append(errs, config.ValidationError{
+			Field:   "Aggregation",
+			Message: fmt.Sprintf("aggregation %q is not valid; must be one of {min, mean}", r.Aggregation),
+			Value:   r.Aggregation,
+			Wrapped: config.ErrInvalidConfig,
+		})
+	}
+
+	// MustPass가 [Security] floor를 포함하는지 검증합니다.
+	// REQ-HRN-003-018: [Security]가 floor이며 이보다 좁은 집합은 허용되지 않습니다.
+	if err := validateMustPassFloor(r.MustPass); err != nil {
+		errs = append(errs, config.ValidationError{
+			Field:   "MustPass",
+			Message: err.Error(),
+			Wrapped: config.ErrMustPassBypassProhibited,
+		})
+	}
+
+	if len(errs) > 0 {
+		return &config.ValidationErrors{Errors: errs}
+	}
+	return nil
+}
+
+// validateAnchors는 anchor 집합이 정확히 canonical {0.25, 0.50, 0.75, 1.00}인지 검증합니다.
+func validateAnchors(dim Dimension, anchors map[float64]string) error {
+	if len(anchors) != 4 {
+		return fmt.Errorf("dimension %v must have exactly 4 anchor levels, got %d (FROZEN per REQ-HRN-003-013)", dim, len(anchors))
+	}
+	for score := range anchors {
+		if !canonicalAnchors[score] {
+			return fmt.Errorf("dimension %v has non-canonical anchor %.2f; must be one of {0.25, 0.50, 0.75, 1.00}", dim, score)
+		}
+	}
+	return nil
+}
+
+// validateMustPassFloor는 MustPass 집합이 [Security] floor를 포함하는지 검증합니다.
+// REQ-HRN-003-018: profiles MAY widen but MAY NOT narrow below [Security].
+func validateMustPassFloor(mustPass []Dimension) error {
+	hasSecurityFloor := false
+	for _, d := range mustPass {
+		if d == Security {
+			hasSecurityFloor = true
+			break
+		}
+	}
+	if !hasSecurityFloor {
+		return fmt.Errorf("MustPass set must include Security (floor per OQ3 default + design-constitution §12 Mechanism 3 FROZEN); attempt to narrow below [Security] is prohibited")
+	}
+	return nil
+}
+
+// ValidateCitation는 SubCriterionScore의 RubricAnchor 필드가 canonical anchor 값 중 하나인지 검증합니다.
+// REQ-HRN-003-009: empty 또는 non-canonical anchor는 ErrRubricCitationMissing을 반환합니다.
+// AC-HRN-003-05.a: 빈 필드 → ErrRubricCitationMissing.
+// AC-HRN-003-05.b: non-canonical 값 (예: "0.65") → ErrRubricCitationMissing.
+// AC-HRN-003-05.c: canonical 값 → nil.
+func (r *Rubric) ValidateCitation(score SubCriterionScore) error {
+	if score.RubricAnchor == "" {
+		return fmt.Errorf("%w: sub-criterion score missing rubric_anchor field (per design-constitution §12 Mechanism 1)", config.ErrRubricCitationMissing)
+	}
+	if !canonicalAnchorStrings[score.RubricAnchor] {
+		return fmt.Errorf("%w: rubric_anchor %q is not a canonical anchor value; must be one of {\"0.25\", \"0.50\", \"0.75\", \"1.00\"}", config.ErrRubricCitationMissing, score.RubricAnchor)
+	}
+	return nil
+}
+
+// ─────────────────────────────────────────────
+// Markdown 프로필 파서
+// ─────────────────────────────────────────────
+
+// dimensionNameMap은 프로필 파일의 차원 이름을 Dimension enum으로 매핑합니다.
+var dimensionNameMap = map[string]Dimension{
+	"Functionality": Functionality,
+	"Security":      Security,
+	"Craft":         Craft,
+	"Consistency":   Consistency,
+}
+
+// ParseRubricMarkdown은 .md 형식의 evaluator profile 파일을 파싱하여 Rubric을 반환합니다.
+// REQ-HRN-003-005: .moai/config/evaluator-profiles/{name}.md 파일 소비.
+// 파서 구조:
+//   - H2 "## Evaluation Dimensions" 테이블 → Weight + PassThreshold per dim
+//   - H2 "## Must-Pass Criteria" → MustPass slice
+//   - H2 "## Scoring Rubric" → H3 per dimension → 2-column score 테이블 → anchor map
+//
+// 톨러런트: 추가 공백 허용; anchor score 정규화 ("1.0" → "1.00" 변환 후 float64 파싱).
+func ParseRubricMarkdown(path string) (*Rubric, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("ParseRubricMarkdown: open %q: %w", path, err)
+	}
+	defer f.Close()
+
+	// 프로필 이름은 파일명(확장자 제외)에서 추출합니다.
+	profileName := extractProfileName(path)
+
+	rubric := &Rubric{
+		ProfileName:   profileName,
+		PassThreshold: 0.60, // 기본값 (FROZEN floor)
+		Aggregation:   "min",
+		MustPass:      []Dimension{Functionality, Security}, // 기본값
+		Dimensions:    make(map[Dimension]DimensionRubric),
+	}
+
+	// 파서 상태 머신.
+	type parseSection int
+	const (
+		sectionNone parseSection = iota
+		sectionEvalDimensions
+		sectionMustPass
+		sectionScoringRubric
+	)
+
+	section := sectionNone
+	currentRubricDim := Dimension(0)
+	scanner := bufio.NewScanner(f)
+
+	for scanner.Scan() {
+		line := strings.TrimRight(scanner.Text(), " \t")
+
+		// H2 섹션 감지.
+		if strings.HasPrefix(line, "## ") {
+			heading := strings.TrimPrefix(line, "## ")
+			switch {
+			case strings.Contains(heading, "Evaluation Dimensions"):
+				section = sectionEvalDimensions
+				currentRubricDim = 0
+			case strings.Contains(heading, "Must-Pass Criteria"):
+				section = sectionMustPass
+				currentRubricDim = 0
+			case strings.Contains(heading, "Scoring Rubric"):
+				section = sectionScoringRubric
+				currentRubricDim = 0
+			default:
+				section = sectionNone
+				currentRubricDim = 0
+			}
+			continue
+		}
+
+		// H3 섹션 감지 (Scoring Rubric 내 차원별 섹션).
+		if strings.HasPrefix(line, "### ") && section == sectionScoringRubric {
+			heading := strings.TrimPrefix(line, "### ")
+			// 차원 이름 추출 (예: "Functionality (40%)" → "Functionality")
+			dimName := strings.Fields(heading)[0]
+			if dim, ok := dimensionNameMap[dimName]; ok {
+				currentRubricDim = dim
+				// 차원이 없으면 초기화합니다.
+				if _, exists := rubric.Dimensions[dim]; !exists {
+					rubric.Dimensions[dim] = DimensionRubric{
+						Weight:        0.25, // 기본값
+						PassThreshold: 0.60, // FROZEN floor
+						Anchors:       make(map[float64]string),
+					}
+				}
+			} else {
+				// Scoring Rubric에서 알 수 없는 차원 이름은 건너뜁니다.
+				// Evaluation Dimensions 테이블에서의 알 수 없는 차원은 Validate()에서 검증합니다.
+				// frontend.md는 "Craft & Functionality", "Design Quality", "Originality" 등의
+				// 섹션을 가지는데, 파서는 이를 무시하고 Craft에 UI 관련 내용을 매핑합니다.
+				currentRubricDim = 0
+			}
+			continue
+		}
+
+		// 테이블 행 파싱.
+		if !strings.HasPrefix(line, "|") {
+			continue
+		}
+
+		cells := parseTableRow(line)
+		if len(cells) < 2 {
+			continue
+		}
+
+		switch section {
+		case sectionEvalDimensions:
+			// "| Dimension | Weight | Pass Threshold |" 형식.
+			if len(cells) < 3 {
+				continue
+			}
+			dimName := cells[0]
+			dim, ok := dimensionNameMap[dimName]
+			if !ok {
+				// 헤더 행 또는 구분선이면 건너뜁니다.
+				continue
+			}
+			// Weight 파싱 (예: "40%" → 0.40).
+			weight := parsePercentOrFloat(cells[1])
+			// PassThreshold는 텍스트로 저장 — 숫자가 포함된 경우만 파싱.
+			passThreshold := 0.60 // 기본값
+			if pct := parsePercentOrFloat(cells[2]); pct > 0 {
+				passThreshold = pct
+			}
+
+			dr := rubric.Dimensions[dim]
+			if dr.Anchors == nil {
+				dr.Anchors = make(map[float64]string)
+			}
+			dr.Weight = weight
+			dr.PassThreshold = passThreshold
+			rubric.Dimensions[dim] = dr
+
+		case sectionMustPass:
+			// "- Functionality: ..." 형식 (리스트 항목).
+			// 테이블 행이 아니므로 이 case는 아래의 listItem 파싱에서 처리.
+
+		case sectionScoringRubric:
+			// "| Score | Description |" 형식.
+			if currentRubricDim == 0 {
+				continue
+			}
+			scoreStr := cells[0]
+			description := cells[1]
+			if scoreStr == "Score" || strings.Contains(scoreStr, "---") {
+				continue // 헤더 또는 구분선
+			}
+			// anchor score 파싱 ("1.0" → 1.00, "0.25" → 0.25).
+			anchor, err := parseAnchorScore(scoreStr)
+			if err != nil {
+				// 파싱 불가한 행은 건너뜁니다.
+				continue
+			}
+			dr := rubric.Dimensions[currentRubricDim]
+			if dr.Anchors == nil {
+				dr.Anchors = make(map[float64]string)
+			}
+			dr.Anchors[anchor] = description
+			rubric.Dimensions[currentRubricDim] = dr
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("ParseRubricMarkdown: scan %q: %w", path, err)
+	}
+
+	// Must-Pass Criteria 재파싱 (리스트 형식).
+	// 파일을 다시 열어 Must-Pass 섹션을 파싱합니다.
+	mustPass, err := parseMustPassSection(path)
+	if err != nil {
+		return nil, err
+	}
+	if len(mustPass) > 0 {
+		rubric.MustPass = mustPass
+	}
+
+	// 빈 Anchors를 가진 차원에 대해 기본값 초기화.
+	// (EvalDimensions 파싱에서 생성된 차원이지만 Rubric 테이블이 없는 경우)
+	for dim, dr := range rubric.Dimensions {
+		if dr.Anchors == nil {
+			dr.Anchors = make(map[float64]string)
+			rubric.Dimensions[dim] = dr
+		}
+	}
+
+	// strict.md 프로필의 경우 PassThreshold를 높게 설정합니다.
+	// Rubric.Validate()에서 min 0.60 floor를 보장하므로 여기서는 0 방지만 합니다.
+	if rubric.PassThreshold <= 0 {
+		rubric.PassThreshold = 0.60
+	}
+
+	return rubric, nil
+}
+
+// parseMustPassSection은 파일에서 "## Must-Pass Criteria" 섹션의 차원 목록을 파싱합니다.
+func parseMustPassSection(path string) ([]Dimension, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("parseMustPassSection: open %q: %w", path, err)
+	}
+	defer f.Close()
+
+	var result []Dimension
+	inSection := false
+	scanner := bufio.NewScanner(f)
+
+	for scanner.Scan() {
+		line := strings.TrimRight(scanner.Text(), " \t")
+
+		if strings.HasPrefix(line, "## ") {
+			if strings.Contains(line, "Must-Pass Criteria") {
+				inSection = true
+			} else {
+				inSection = false
+			}
+			continue
+		}
+
+		if !inSection {
+			continue
+		}
+
+		// "- Functionality: ..." 또는 "- Security: ..." 형식의 리스트 항목.
+		if strings.HasPrefix(line, "-") || strings.HasPrefix(line, "*") {
+			content := strings.TrimLeft(line, "-* \t")
+			// 첫 번째 단어가 dimension 이름인지 확인합니다.
+			parts := strings.SplitN(content, ":", 2)
+			dimName := strings.TrimSpace(parts[0])
+			if dim, ok := dimensionNameMap[dimName]; ok {
+				// 중복 추가 방지.
+				found := false
+				for _, d := range result {
+					if d == dim {
+						found = true
+						break
+					}
+				}
+				if !found {
+					result = append(result, dim)
+				}
+			}
+		}
+	}
+
+	return result, scanner.Err()
+}
+
+// parseTableRow는 Markdown 테이블 행을 파싱하여 셀 내용 슬라이스를 반환합니다.
+// 선행/후행 파이프(|)를 제거하고 각 셀을 trim합니다.
+func parseTableRow(line string) []string {
+	// 선행/후행 파이프 제거.
+	line = strings.Trim(line, "|")
+	parts := strings.Split(line, "|")
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		result = append(result, strings.TrimSpace(p))
+	}
+	return result
+}
+
+// parsePercentOrFloat은 "40%" 또는 "0.40" 형식의 문자열을 float64로 변환합니다.
+func parsePercentOrFloat(s string) float64 {
+	s = strings.TrimSpace(s)
+	if strings.HasSuffix(s, "%") {
+		s = strings.TrimSuffix(s, "%")
+		v, err := strconv.ParseFloat(strings.TrimSpace(s), 64)
+		if err != nil {
+			return 0
+		}
+		return v / 100.0
+	}
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0
+	}
+	return v
+}
+
+// parseAnchorScore는 anchor score 문자열을 float64로 변환합니다.
+// "1.0" → 1.00, "0.25" → 0.25 정규화를 포함합니다.
+func parseAnchorScore(s string) (float64, error) {
+	s = strings.TrimSpace(s)
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, err
+	}
+	// 정규화: float64로 변환 후 canonical 값 검증은 Validate()에서 수행합니다.
+	return v, nil
+}
+
+// extractProfileName은 파일 경로에서 프로필 이름을 추출합니다.
+// 예: ".moai/config/evaluator-profiles/default.md" → "default"
+func extractProfileName(path string) string {
+	// 마지막 슬래시 이후의 파일명 추출.
+	parts := strings.Split(path, "/")
+	filename := parts[len(parts)-1]
+	// 확장자 제거.
+	if idx := strings.LastIndex(filename, "."); idx >= 0 {
+		return filename[:idx]
+	}
+	return filename
+}
+
+// Unwrap is needed for errors.Is to work with ErrUnknownDimension wrapped inside ValidationError.
+var _ error = (*config.ValidationErrors)(nil)
+
+// isErrUnknownDimension은 error chain에서 ErrUnknownDimension를 탐지하는 헬퍼입니다.
+func isErrUnknownDimension(err error) bool {
+	return errors.Is(err, config.ErrUnknownDimension)
+}

--- a/internal/harness/rubric.go
+++ b/internal/harness/rubric.go
@@ -6,7 +6,6 @@ package harness
 
 import (
 	"bufio"
-	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -236,7 +235,7 @@ func ParseRubricMarkdown(path string) (*Rubric, error) {
 	if err != nil {
 		return nil, fmt.Errorf("ParseRubricMarkdown: open %q: %w", path, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	// 프로필 이름은 파일명(확장자 제외)에서 추출합니다.
 	profileName := extractProfileName(path)
@@ -415,7 +414,7 @@ func parseMustPassSection(path string) ([]Dimension, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parseMustPassSection: open %q: %w", path, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	var result []Dimension
 	inSection := false
@@ -520,8 +519,3 @@ func extractProfileName(path string) string {
 
 // Unwrap is needed for errors.Is to work with ErrUnknownDimension wrapped inside ValidationError.
 var _ error = (*config.ValidationErrors)(nil)
-
-// isErrUnknownDimension은 error chain에서 ErrUnknownDimension를 탐지하는 헬퍼입니다.
-func isErrUnknownDimension(err error) bool {
-	return errors.Is(err, config.ErrUnknownDimension)
-}

--- a/internal/harness/rubric_test.go
+++ b/internal/harness/rubric_test.go
@@ -1,0 +1,295 @@
+// Package harness — HRN-003 Rubric struct 및 Validate() 메서드 테스트.
+// REQ-HRN-003-003: 4개 anchor level 검증 (0.25, 0.50, 0.75, 1.00).
+// REQ-HRN-003-013: anchor level FROZEN.
+package harness
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/modu-ai/moai-adk/internal/config"
+)
+
+// TestRubric_AnchorLevelsValid는 4개의 canonical anchor level을 가진 Rubric이
+// Validate()를 통과하는지 검증합니다.
+// REQ-HRN-003-003, REQ-HRN-003-013.
+func TestRubric_AnchorLevelsValid(t *testing.T) {
+	rubric := &Rubric{
+		ProfileName: "test",
+		PassThreshold: 0.60,
+		Aggregation:   "min",
+		MustPass:      []Dimension{Functionality, Security},
+		Dimensions: map[Dimension]DimensionRubric{
+			Functionality: makeValidDimensionRubric(0.60),
+			Security:      makeValidDimensionRubric(0.60),
+			Craft:         makeValidDimensionRubric(0.60),
+			Consistency:   makeValidDimensionRubric(0.60),
+		},
+	}
+	if err := rubric.Validate(); err != nil {
+		t.Errorf("Rubric.Validate() = %v, want nil", err)
+	}
+}
+
+// TestRubric_AnchorLevelsRejectFifth는 5개 anchor를 가진 경우 ErrInvalidConfig를
+// 반환하는지 검증합니다.
+// REQ-HRN-003-013.
+func TestRubric_AnchorLevelsRejectFifth(t *testing.T) {
+	rubric := &Rubric{
+		ProfileName:   "test",
+		PassThreshold: 0.60,
+		Aggregation:   "min",
+		MustPass:      []Dimension{Functionality, Security},
+		Dimensions: map[Dimension]DimensionRubric{
+			Functionality: {
+				Weight:        0.40,
+				PassThreshold: 0.60,
+				// 5번째 anchor 추가 — 거부되어야 합니다.
+				Anchors: map[float64]string{
+					0.25: "low",
+					0.50: "medium",
+					0.75: "high",
+					1.00: "perfect",
+					0.10: "extra anchor — invalid",
+				},
+			},
+			Security:    makeValidDimensionRubric(0.60),
+			Craft:       makeValidDimensionRubric(0.60),
+			Consistency: makeValidDimensionRubric(0.60),
+		},
+	}
+	err := rubric.Validate()
+	if err == nil {
+		t.Fatal("Rubric.Validate() = nil, want error for 5 anchors")
+	}
+	if !errors.Is(err, config.ErrInvalidConfig) {
+		t.Errorf("Rubric.Validate() error = %v, want wrapping ErrInvalidConfig", err)
+	}
+}
+
+// TestRubric_AnchorLevelsRejectNonCanonical는 non-canonical anchor 값이 포함된 경우
+// ErrInvalidConfig를 반환하는지 검증합니다.
+// REQ-HRN-003-013: {0.20, 0.40, 0.60, 0.80} 등은 거부됩니다.
+func TestRubric_AnchorLevelsRejectNonCanonical(t *testing.T) {
+	rubric := &Rubric{
+		ProfileName:   "test",
+		PassThreshold: 0.60,
+		Aggregation:   "min",
+		MustPass:      []Dimension{Functionality, Security},
+		Dimensions: map[Dimension]DimensionRubric{
+			Functionality: {
+				Weight:        0.40,
+				PassThreshold: 0.60,
+				// non-canonical anchor 값들
+				Anchors: map[float64]string{
+					0.20: "low",
+					0.40: "medium",
+					0.60: "high",
+					0.80: "perfect",
+				},
+			},
+			Security:    makeValidDimensionRubric(0.60),
+			Craft:       makeValidDimensionRubric(0.60),
+			Consistency: makeValidDimensionRubric(0.60),
+		},
+	}
+	err := rubric.Validate()
+	if err == nil {
+		t.Fatal("Rubric.Validate() = nil, want error for non-canonical anchors")
+	}
+	if !errors.Is(err, config.ErrInvalidConfig) {
+		t.Errorf("Rubric.Validate() error = %v, want wrapping ErrInvalidConfig", err)
+	}
+}
+
+// TestParseRubricMarkdown_DefaultProfile는 default.md 프로필을 로드하여
+// 4개의 차원과 각 차원에 4개의 anchor가 있는지 검증합니다.
+// REQ-HRN-003-005, AC-HRN-003-07.a.
+func TestParseRubricMarkdown_DefaultProfile(t *testing.T) {
+	rubric, err := ParseRubricMarkdown("../../.moai/config/evaluator-profiles/default.md")
+	if err != nil {
+		t.Fatalf("ParseRubricMarkdown(default.md) = %v, want nil", err)
+	}
+
+	// 4개의 차원이 있어야 합니다.
+	if len(rubric.Dimensions) != 4 {
+		t.Errorf("rubric.Dimensions count = %d, want 4", len(rubric.Dimensions))
+	}
+
+	// 각 차원에 4개의 anchor가 있어야 합니다.
+	for dim, dr := range rubric.Dimensions {
+		if len(dr.Anchors) != 4 {
+			t.Errorf("dimension %v has %d anchors, want 4", dim, len(dr.Anchors))
+		}
+		// canonical anchor 검증.
+		for anchor := range dr.Anchors {
+			if !canonicalAnchors[anchor] {
+				t.Errorf("dimension %v has non-canonical anchor %.2f", dim, anchor)
+			}
+		}
+	}
+
+	// MustPass가 Functionality와 Security를 포함해야 합니다.
+	hasFunctionality, hasSecurity := false, false
+	for _, d := range rubric.MustPass {
+		if d == Functionality {
+			hasFunctionality = true
+		}
+		if d == Security {
+			hasSecurity = true
+		}
+	}
+	if !hasFunctionality || !hasSecurity {
+		t.Errorf("MustPass = %v, want to include Functionality and Security", rubric.MustPass)
+	}
+
+	// PassThreshold floor 검증.
+	if rubric.PassThreshold < 0.60 {
+		t.Errorf("PassThreshold = %.2f, want >= 0.60", rubric.PassThreshold)
+	}
+}
+
+// TestParseRubricMarkdown_AllProfiles는 4개의 shipping 프로필 파일이 모두
+// 오류 없이 로드되는지 검증합니다.
+// AC-HRN-003-07.b.
+func TestParseRubricMarkdown_AllProfiles(t *testing.T) {
+	profiles := []string{
+		"../../.moai/config/evaluator-profiles/default.md",
+		"../../.moai/config/evaluator-profiles/strict.md",
+		"../../.moai/config/evaluator-profiles/lenient.md",
+		"../../.moai/config/evaluator-profiles/frontend.md",
+	}
+	for _, path := range profiles {
+		t.Run(path, func(t *testing.T) {
+			rubric, err := ParseRubricMarkdown(path)
+			if err != nil {
+				t.Fatalf("ParseRubricMarkdown(%q) = %v, want nil", path, err)
+			}
+			if rubric == nil {
+				t.Fatal("ParseRubricMarkdown returned nil rubric")
+			}
+		})
+	}
+}
+
+// TestRubric_ValidateCitation은 SubCriterionScore의 RubricAnchor 필드 검증을
+// 확인합니다.
+// REQ-HRN-003-009, AC-HRN-003-05.
+func TestRubric_ValidateCitation(t *testing.T) {
+	rubric := &Rubric{
+		ProfileName: "test",
+		Dimensions: map[Dimension]DimensionRubric{
+			Functionality: makeValidDimensionRubric(0.60),
+			Security:      makeValidDimensionRubric(0.60),
+			Craft:         makeValidDimensionRubric(0.60),
+			Consistency:   makeValidDimensionRubric(0.60),
+		},
+	}
+
+	// AC-HRN-003-05.a: RubricAnchor 필드가 없으면 ErrRubricCitationMissing.
+	emptyAnchor := SubCriterionScore{
+		Score:        0.75,
+		RubricAnchor: "", // 빈 값
+		Evidence:     "test",
+		Dimension:    Functionality,
+	}
+	err := rubric.ValidateCitation(emptyAnchor)
+	if err == nil {
+		t.Fatal("ValidateCitation(empty anchor) = nil, want ErrRubricCitationMissing")
+	}
+	if !errors.Is(err, config.ErrRubricCitationMissing) {
+		t.Errorf("ValidateCitation(empty anchor) = %v, want ErrRubricCitationMissing", err)
+	}
+
+	// AC-HRN-003-05.b: non-canonical anchor 값은 ErrRubricCitationMissing.
+	nonCanonical := SubCriterionScore{
+		Score:        0.65,
+		RubricAnchor: "0.65", // non-canonical
+		Evidence:     "test",
+		Dimension:    Functionality,
+	}
+	err = rubric.ValidateCitation(nonCanonical)
+	if err == nil {
+		t.Fatal("ValidateCitation(non-canonical anchor 0.65) = nil, want ErrRubricCitationMissing")
+	}
+	if !errors.Is(err, config.ErrRubricCitationMissing) {
+		t.Errorf("ValidateCitation(non-canonical anchor) = %v, want ErrRubricCitationMissing", err)
+	}
+
+	// AC-HRN-003-05.c: canonical anchor 값은 nil (성공).
+	valid := SubCriterionScore{
+		Score:        0.75,
+		RubricAnchor: "0.75", // canonical
+		Evidence:     "test",
+		Dimension:    Functionality,
+	}
+	if err = rubric.ValidateCitation(valid); err != nil {
+		t.Errorf("ValidateCitation(canonical anchor 0.75) = %v, want nil", err)
+	}
+}
+
+// TestRubric_PassThresholdFloor는 pass_threshold < 0.60이면 ErrInvalidConfig를
+// 반환하는지 검증합니다.
+// REQ-HRN-003-014, AC-HRN-003-12.
+func TestRubric_PassThresholdFloor(t *testing.T) {
+	rubric := &Rubric{
+		ProfileName:   "test-low-threshold",
+		PassThreshold: 0.55, // 0.60 미만 — 거부되어야 합니다.
+		Aggregation:   "min",
+		MustPass:      []Dimension{Functionality, Security},
+		Dimensions: map[Dimension]DimensionRubric{
+			Functionality: makeValidDimensionRubric(0.60),
+			Security:      makeValidDimensionRubric(0.60),
+			Craft:         makeValidDimensionRubric(0.60),
+			Consistency:   makeValidDimensionRubric(0.60),
+		},
+	}
+	err := rubric.Validate()
+	if err == nil {
+		t.Fatal("Rubric.Validate() = nil, want error for pass_threshold < 0.60")
+	}
+	if !errors.Is(err, config.ErrInvalidConfig) {
+		t.Errorf("Rubric.Validate() error = %v, want wrapping ErrInvalidConfig", err)
+	}
+}
+
+// TestRubric_MustPassNonNarrowing는 MustPass에서 Security를 제거하면
+// ErrMustPassBypassProhibited를 반환하는지 검증합니다.
+// REQ-HRN-003-018, AC-HRN-003-11.
+func TestRubric_MustPassNonNarrowing(t *testing.T) {
+	rubric := &Rubric{
+		ProfileName:   "test-bypass",
+		PassThreshold: 0.60,
+		Aggregation:   "min",
+		// Security를 제거하여 must-pass floor 위반을 시도합니다.
+		MustPass: []Dimension{Functionality}, // Security 누락 — 거부되어야 합니다.
+		Dimensions: map[Dimension]DimensionRubric{
+			Functionality: makeValidDimensionRubric(0.60),
+			Security:      makeValidDimensionRubric(0.60),
+			Craft:         makeValidDimensionRubric(0.60),
+			Consistency:   makeValidDimensionRubric(0.60),
+		},
+	}
+	err := rubric.Validate()
+	if err == nil {
+		t.Fatal("Rubric.Validate() = nil, want error for MustPass narrowing (Security removed)")
+	}
+	if !errors.Is(err, config.ErrMustPassBypassProhibited) {
+		t.Errorf("Rubric.Validate() error = %v, want wrapping ErrMustPassBypassProhibited", err)
+	}
+}
+
+// makeValidDimensionRubric는 4개의 canonical anchor를 가진 유효한 DimensionRubric을
+// 생성하는 헬퍼 함수입니다.
+func makeValidDimensionRubric(passThreshold float64) DimensionRubric {
+	return DimensionRubric{
+		Weight:        0.25,
+		PassThreshold: passThreshold,
+		Anchors: map[float64]string{
+			0.25: "low quality",
+			0.50: "medium quality",
+			0.75: "high quality",
+			1.00: "perfect quality",
+		},
+	}
+}

--- a/internal/harness/scorer.go
+++ b/internal/harness/scorer.go
@@ -1,0 +1,109 @@
+// Package harness — HRN-003 Hierarchical Acceptance Scoring 구현.
+// 4-차원(Functionality / Security / Craft / Consistency) × sub-criteria 계층 채점.
+// design-constitution §12 Mechanism 1 (Rubric Anchoring) + Mechanism 3 (Must-Pass Firewall).
+package harness
+
+// @MX:NOTE: [AUTO] FROZEN at 4 values per spec.md REQ-HRN-003-001; 5th dimension requires CON-002 amendment
+// @MX:WARN: [AUTO] FROZEN-zone constraint; addition of 5th dimension requires CON-002 amendment per zone-registry CONST-V3R2-154
+// @MX:REASON: design-constitution §12 Mechanism 3 + SPEC-V3R2-HRN-003 REQ-001 — Dimension enum is FROZEN at {Functionality, Security, Craft, Consistency} for v3.0
+
+// Dimension은 evaluator-active의 4-차원 채점 열거형입니다.
+// FROZEN: v3.0 기간 동안 정확히 4개의 값을 가집니다.
+// REQ-HRN-003-001.
+type Dimension int
+
+const (
+	// Functionality는 기능 완성도 차원입니다.
+	Functionality Dimension = iota + 1
+	// Security는 보안 차원입니다.
+	Security
+	// Craft는 코드 품질 차원입니다.
+	Craft
+	// Consistency는 일관성 차원입니다.
+	Consistency
+)
+
+// String은 Dimension의 canonical 이름을 반환합니다.
+func (d Dimension) String() string {
+	switch d {
+	case Functionality:
+		return "Functionality"
+	case Security:
+		return "Security"
+	case Craft:
+		return "Craft"
+	case Consistency:
+		return "Consistency"
+	default:
+		return "Unknown"
+	}
+}
+
+// IsValid는 Dimension이 4개의 canonical 값 중 하나인지 검증합니다.
+// FROZEN 4-dimension set 외의 값은 false를 반환합니다.
+func (d Dimension) IsValid() bool {
+	return d >= Functionality && d <= Consistency
+}
+
+// DefaultMustPassDimensions는 기본 must-pass 차원 목록입니다.
+// OQ3 default: [Functionality, Security]; floor-only [Security] (REQ-018 prevents narrowing).
+var DefaultMustPassDimensions = []Dimension{Functionality, Security}
+
+// Verdict는 ScoreCard의 최종 판정 결과입니다.
+type Verdict string
+
+const (
+	// VerdictPass는 모든 평가 기준을 통과한 경우입니다.
+	VerdictPass Verdict = "pass"
+	// VerdictFail은 하나 이상의 평가 기준을 통과하지 못한 경우입니다.
+	VerdictFail Verdict = "fail"
+)
+
+// SubCriterionScore는 단일 sub-criterion에 대한 채점 결과입니다.
+// REQ-HRN-003-002: {Score, RubricAnchor, Evidence, Dimension} 필드 포함.
+type SubCriterionScore struct {
+	// Score는 0.0~1.0 범위의 점수입니다.
+	Score float64
+	// RubricAnchor는 rubric anchor 참조값입니다 (canonical: "0.25", "0.50", "0.75", "1.00").
+	// REQ-HRN-003-009: 빈 값 또는 non-canonical 값은 ErrRubricCitationMissing을 반환합니다.
+	RubricAnchor string
+	// Evidence는 채점 근거 설명입니다.
+	Evidence string
+	// Dimension은 이 sub-criterion이 속하는 차원입니다.
+	Dimension Dimension
+}
+
+// CriterionScore는 단일 criterion에 대한 채점 결과입니다.
+// SubCriteria map의 값들을 집계하여 Aggregate를 계산합니다.
+type CriterionScore struct {
+	// Aggregate는 sub-criterion 점수들의 집계값입니다 (min 또는 mean).
+	Aggregate float64
+	// SubCriteria는 sub-criterion ID → SubCriterionScore 맵입니다.
+	SubCriteria map[string]SubCriterionScore
+}
+
+// DimensionScore는 단일 Dimension에 대한 채점 결과입니다.
+// Criteria map의 값들을 집계하여 Aggregate를 계산합니다.
+type DimensionScore struct {
+	// Aggregate는 criterion 점수들의 집계값입니다 (min 또는 mean).
+	Aggregate float64
+	// Criteria는 criterion ID → CriterionScore 맵입니다.
+	Criteria map[string]CriterionScore
+}
+
+// ScoreCard는 하나의 SPEC 아티팩트에 대한 전체 채점 결과를 담는 계층 구조입니다.
+// REQ-HRN-003-002: Dimensions → Criteria → SubCriteria 계층 구조.
+// OQ4 default: SchemaVersion = "v1" (mirrors HRN-002 LogSchemaVersion pattern).
+type ScoreCard struct {
+	// SchemaVersion은 채점 스키마 버전입니다 ("v1").
+	SchemaVersion string
+	// SpecID는 평가 대상 SPEC ID입니다.
+	SpecID string
+	// Dimensions는 Dimension → DimensionScore 맵입니다.
+	Dimensions map[Dimension]DimensionScore
+	// Verdict는 최종 판정 결과입니다 (pass/fail).
+	Verdict Verdict
+	// Rationale는 판정 근거 설명입니다.
+	// must-pass firewall이 트리거된 경우 실패 차원과 임계값을 명시합니다.
+	Rationale string
+}

--- a/internal/harness/scorer_engine.go
+++ b/internal/harness/scorer_engine.go
@@ -1,0 +1,358 @@
+// Package harness — HRN-003 채점 엔진 구현.
+// EvaluatorRunner: 계층 집계 + must-pass firewall + Sprint Contract 영속화.
+// REQ-HRN-003-004: EvaluatorRunner.AggregateScoreCard().
+// REQ-HRN-003-007: aggregation rules (min 기본, mean opt-in).
+// REQ-HRN-003-008: must-pass firewall.
+// REQ-HRN-003-011: WriteContract() Sprint Contract sub-criterion status 영속화.
+package harness
+
+// @MX:NOTE: [AUTO] aggregation default = min per REQ-HRN-003-007; mean opt-in per REQ-HRN-003-015; per-dimension override supported
+// @MX:WARN: [AUTO] must-pass firewall FROZEN per design-constitution §12 Mechanism 3; bypass requires CON-002 amendment
+// @MX:REASON: design-constitution §12 Mechanism 3 — "Must-pass criteria cannot be compensated by high scores in other areas" (FROZEN per zone-registry CONST-V3R2-154)
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// EvaluatorRunner는 ScoreCard 계층 집계 + must-pass firewall 적용을 담당합니다.
+// REQ-HRN-003-004: Score() 또는 AggregateScoreCard()로 채점합니다.
+//
+// @MX:ANCHOR: [AUTO] EvaluatorRunner.AggregateScoreCard — fan_in=3 (scorer_engine_test + SKILL.md Phase 3b + future HRN-001 router)
+// @MX:REASON: SPEC-V3R2-HRN-003 REQ-004 — 채점 엔진의 단일 진입점; scorer_test.go + SKILL.md + future 라우터가 참조
+type EvaluatorRunner struct {
+	rubric *Rubric
+}
+
+// NewEvaluatorRunner는 주어진 Rubric으로 새 EvaluatorRunner를 생성합니다.
+func NewEvaluatorRunner(rubric *Rubric) *EvaluatorRunner {
+	return &EvaluatorRunner{rubric: rubric}
+}
+
+// AggregateScoreCard는 SubCriterionScore → CriterionScore → DimensionScore → ScoreCard
+// 계층 집계를 수행하고 Verdict를 결정합니다.
+// REQ-HRN-003-004, REQ-HRN-003-007, REQ-HRN-003-008.
+//
+// 집계 규칙:
+//   - CriterionScore.Aggregate = aggregateMin/Mean(SubCriterionScore.Score) per dim.Aggregation or rubric.Aggregation
+//   - DimensionScore.Aggregate = aggregateMin/Mean(CriterionScore.Aggregate) — dimension-level aggregation
+//   - Verdict = applyMustPassFirewall(card, rubric)
+func (r *EvaluatorRunner) AggregateScoreCard(card *ScoreCard) (*ScoreCard, error) {
+	if card == nil {
+		return nil, fmt.Errorf("AggregateScoreCard: card is nil")
+	}
+
+	result := &ScoreCard{
+		SchemaVersion: card.SchemaVersion,
+		SpecID:        card.SpecID,
+		Dimensions:    make(map[Dimension]DimensionScore, len(card.Dimensions)),
+	}
+
+	for dim, ds := range card.Dimensions {
+		// 차원별 aggregation 결정.
+		agg := r.effectiveAggregation(dim)
+
+		newDS := DimensionScore{
+			Criteria: make(map[string]CriterionScore, len(ds.Criteria)),
+		}
+
+		// CriterionScore 집계.
+		critAggregates := make([]float64, 0, len(ds.Criteria))
+		for critID, cs := range ds.Criteria {
+			subScores := make([]float64, 0, len(cs.SubCriteria))
+			for _, sub := range cs.SubCriteria {
+				subScores = append(subScores, sub.Score)
+			}
+
+			aggregator := selectAggregator(agg)
+			critAggregate := aggregator.Aggregate(subScores)
+
+			newCS := CriterionScore{
+				Aggregate:   critAggregate,
+				SubCriteria: cs.SubCriteria,
+			}
+			newDS.Criteria[critID] = newCS
+			critAggregates = append(critAggregates, critAggregate)
+		}
+
+		// DimensionScore 집계.
+		aggregator := selectAggregator(agg)
+		dimAggregate := aggregator.Aggregate(critAggregates)
+		newDS.Aggregate = dimAggregate
+		result.Dimensions[dim] = newDS
+	}
+
+	// Must-pass firewall 적용.
+	verdict, rationale := applyMustPassFirewall(result, r.rubric)
+	result.Verdict = verdict
+	result.Rationale = rationale
+
+	return result, nil
+}
+
+// effectiveAggregation은 차원별 override를 고려하여 실효 aggregation 방식을 반환합니다.
+// AC-HRN-003-03.c: 차원별 override가 있으면 그것을, 없으면 프로필 기본값을 사용합니다.
+func (r *EvaluatorRunner) effectiveAggregation(dim Dimension) string {
+	if r.rubric == nil {
+		return "min"
+	}
+	if dr, ok := r.rubric.Dimensions[dim]; ok && dr.Aggregation != "" {
+		return dr.Aggregation
+	}
+	if r.rubric.Aggregation != "" {
+		return r.rubric.Aggregation
+	}
+	return "min" // REQ-HRN-003-007 기본값
+}
+
+// Aggregator는 점수 슬라이스를 단일 집계값으로 줄이는 전략 인터페이스입니다.
+// T3.13 REFACTOR: aggregation 전략을 명시적 인터페이스로 추출하여 확장성을 확보합니다.
+type Aggregator interface {
+	Aggregate(scores []float64) float64
+}
+
+// MinAggregator는 최솟값 집계 전략입니다.
+// REQ-HRN-003-007 기본 집계.
+type MinAggregator struct{}
+
+// Aggregate는 슬라이스의 최솟값을 반환합니다.
+func (MinAggregator) Aggregate(scores []float64) float64 { return aggregateMin(scores) }
+
+// MeanAggregator는 평균값 집계 전략입니다.
+// REQ-HRN-003-015 opt-in 집계.
+type MeanAggregator struct{}
+
+// Aggregate는 슬라이스의 평균을 반환합니다.
+func (MeanAggregator) Aggregate(scores []float64) float64 { return aggregateMean(scores) }
+
+// selectAggregator는 aggregation 방식 문자열에 따라 Aggregator를 반환합니다.
+func selectAggregator(agg string) Aggregator {
+	if agg == "mean" {
+		return MeanAggregator{}
+	}
+	return MinAggregator{} // 기본값 "min"
+}
+
+// aggregateMin은 슬라이스의 최솟값을 반환합니다.
+// 빈 슬라이스에 대해 0.0을 반환합니다 (Edge Case E6).
+// REQ-HRN-003-007, AC-HRN-003-03.a.
+func aggregateMin(scores []float64) float64 {
+	if len(scores) == 0 {
+		return 0.0
+	}
+	min := scores[0]
+	for _, s := range scores[1:] {
+		if s < min {
+			min = s
+		}
+	}
+	return min
+}
+
+// aggregateMean은 슬라이스의 평균을 반환합니다.
+// 빈 슬라이스에 대해 0.0을 반환합니다.
+// REQ-HRN-003-015, AC-HRN-003-03.b.
+func aggregateMean(scores []float64) float64 {
+	if len(scores) == 0 {
+		return 0.0
+	}
+	var sum float64
+	for _, s := range scores {
+		sum += s
+	}
+	return sum / float64(len(scores))
+}
+
+// applyMustPassFirewall은 must-pass 차원들의 Aggregate가
+// 차원별 PassThreshold 이상인지 검증하고 Verdict를 반환합니다.
+// REQ-HRN-003-008, AC-HRN-003-04.
+//
+// 규칙:
+//   - 각 must-pass 차원에서 Aggregate < DimensionRubric.PassThreshold → VerdictFail
+//   - 모든 must-pass 차원 통과 → VerdictPass
+//   - Rationale에 실패 차원 및 점수 명시 (R6 user-friendliness 완화).
+func applyMustPassFirewall(card *ScoreCard, rubric *Rubric) (Verdict, string) {
+	if rubric == nil || len(rubric.MustPass) == 0 {
+		return VerdictPass, ""
+	}
+
+	var failedDims []string
+
+	for _, dim := range rubric.MustPass {
+		ds, exists := card.Dimensions[dim]
+		if !exists {
+			// 차원이 ScoreCard에 없으면 0으로 간주 → 실패.
+			failedDims = append(failedDims, fmt.Sprintf("%s (missing, 0.00 < threshold)", dim))
+			continue
+		}
+
+		// 차원별 PassThreshold 확인.
+		threshold := rubric.PassThreshold // 기본값: 프로필 전체 threshold
+		if dr, ok := rubric.Dimensions[dim]; ok && dr.PassThreshold > 0 {
+			threshold = dr.PassThreshold
+		}
+
+		if ds.Aggregate < threshold {
+			failedDims = append(failedDims, fmt.Sprintf(
+				"must-pass dimension %s failed (%.2f < %.2f)",
+				dim, ds.Aggregate, threshold,
+			))
+		}
+	}
+
+	if len(failedDims) > 0 {
+		rationale := strings.Join(failedDims, "; ")
+		return VerdictFail, rationale
+	}
+
+	return VerdictPass, ""
+}
+
+// ─────────────────────────────────────────────
+// Sprint Contract 영속화
+// ─────────────────────────────────────────────
+
+// ContractItem는 Sprint Contract YAML의 acceptance_checklist 항목입니다.
+// REQ-HRN-003-011: status 필드 포함.
+type ContractItem struct {
+	ID       string `yaml:"id"`
+	Criterion string `yaml:"criterion"`
+	Evidence string `yaml:"evidence,omitempty"`
+	Score    float64 `yaml:"score"`
+	Anchor   string  `yaml:"rubric_anchor"`
+	// Status는 sub-criterion 상태입니다: "passed | failed | refined | new".
+	// HRN-002 §11.4.1 Sprint Contract durability — passed 항목은 다음 iteration으로 계승됩니다.
+	Status string `yaml:"status"`
+}
+
+// SprintContractYAML은 WriteContract가 생성하는 YAML 문서의 구조입니다.
+// HRN-002 Sprint Contract shape에 sub-criterion status 필드를 추가합니다.
+// 기존 SKILL.md acceptance_checklist 형식과 호환됩니다.
+type SprintContractYAML struct {
+	SpecID             string         `yaml:"spec_id"`
+	SchemaVersion      string         `yaml:"schema_version"`
+	Verdict            string         `yaml:"verdict"`
+	Rationale          string         `yaml:"rationale,omitempty"`
+	AcceptanceChecklist []ContractItem `yaml:"acceptance_checklist"`
+}
+
+// WriteContract는 ScoreCard의 sub-criterion 점수와 상태를 Sprint Contract YAML로 영속화합니다.
+// REQ-HRN-003-011, AC-HRN-003-10.
+//
+// 파일 경로의 디렉토리가 없으면 자동 생성합니다.
+// AC-HRN-003-10: 생성된 YAML은 HRN-002 DetectPriorJudgmentLeak 패턴을 트리거하지 않습니다.
+// (criterion state만 포함; evaluator 판단 rationale 없음).
+func WriteContract(card *ScoreCard, path string) error {
+	if card == nil {
+		return fmt.Errorf("WriteContract: card is nil")
+	}
+
+	// 디렉토리 자동 생성.
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("WriteContract: mkdir %q: %w", dir, err)
+	}
+
+	// acceptance_checklist 생성: 차원별 > criterion별 > sub-criterion별 순서로 순회.
+	var items []ContractItem
+
+	// 결정론적 출력을 위해 차원 순서를 정렬합니다.
+	dims := sortedDimensions(card.Dimensions)
+	for _, dim := range dims {
+		ds := card.Dimensions[dim]
+		critIDs := sortedStringKeys(ds.Criteria)
+		for _, critID := range critIDs {
+			cs := ds.Criteria[critID]
+			subIDs := sortedStringKeys(cs.SubCriteria)
+			for _, subID := range subIDs {
+				sub := cs.SubCriteria[subID]
+				status := subCriterionStatus(sub.Score, sub.RubricAnchor)
+				items = append(items, ContractItem{
+					ID:       subID,
+					Criterion: critID,
+					Evidence: sub.Evidence,
+					Score:    sub.Score,
+					Anchor:   sub.RubricAnchor,
+					Status:   status,
+				})
+			}
+		}
+	}
+
+	// YAML 직렬화 (표준 라이브러리 없이 간단한 직접 포맷팅).
+	// 외부 의존성 없이 yaml 직렬화를 구현합니다.
+	content := buildContractYAML(card, items)
+
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		return fmt.Errorf("WriteContract: write %q: %w", path, err)
+	}
+
+	return nil
+}
+
+// subCriterionStatus는 sub-criterion 점수와 anchor에 따라 status를 결정합니다.
+// status: "passed" (≥ 0.75), "failed" (< 0.50), "refined" (0.50 ≤ score < 0.75).
+func subCriterionStatus(score float64, _ string) string {
+	switch {
+	case score >= 0.75:
+		return "passed"
+	case score < 0.50:
+		return "failed"
+	default:
+		return "refined"
+	}
+}
+
+// buildContractYAML은 SprintContract YAML 내용을 문자열로 생성합니다.
+// 외부 yaml 라이브러리 없이 직접 포맷팅합니다.
+// HARD(CLAUDE.local.md §14): 하드코딩 금지 — 모든 값은 파라미터에서 주입.
+func buildContractYAML(card *ScoreCard, items []ContractItem) string {
+	var sb strings.Builder
+	sb.WriteString("# Sprint Contract — HRN-003 sub-criterion status\n")
+	sb.WriteString("# format: HRN-003 WriteContract v1\n")
+	sb.WriteString("# HRN-002 §11.4.1: passed criteria carry forward; evaluator memory is per-iteration\n\n")
+	sb.WriteString(fmt.Sprintf("spec_id: %q\n", card.SpecID))
+	sb.WriteString(fmt.Sprintf("schema_version: %q\n", card.SchemaVersion))
+	sb.WriteString(fmt.Sprintf("verdict: %q\n", string(card.Verdict)))
+	if card.Rationale != "" {
+		sb.WriteString(fmt.Sprintf("rationale: %q\n", card.Rationale))
+	}
+	sb.WriteString("\nacceptance_checklist:\n")
+	for _, item := range items {
+		sb.WriteString(fmt.Sprintf("  - id: %q\n", item.ID))
+		sb.WriteString(fmt.Sprintf("    criterion: %q\n", item.Criterion))
+		if item.Evidence != "" {
+			sb.WriteString(fmt.Sprintf("    evidence: %q\n", item.Evidence))
+		}
+		sb.WriteString(fmt.Sprintf("    score: %.2f\n", item.Score))
+		sb.WriteString(fmt.Sprintf("    rubric_anchor: %q\n", item.Anchor))
+		sb.WriteString(fmt.Sprintf("    status: %q\n", item.Status))
+	}
+	return sb.String()
+}
+
+// sortedDimensions는 ScoreCard의 Dimension 키를 정렬된 순서로 반환합니다.
+// 결정론적 YAML 출력을 위해 사용합니다.
+func sortedDimensions(dims map[Dimension]DimensionScore) []Dimension {
+	result := make([]Dimension, 0, len(dims))
+	for d := range dims {
+		result = append(result, d)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return int(result[i]) < int(result[j])
+	})
+	return result
+}
+
+// sortedStringKeys는 map[string]T의 키를 정렬된 순서로 반환합니다.
+func sortedStringKeys[T any](m map[string]T) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/harness/scorer_engine.go
+++ b/internal/harness/scorer_engine.go
@@ -314,22 +314,22 @@ func buildContractYAML(card *ScoreCard, items []ContractItem) string {
 	sb.WriteString("# Sprint Contract — HRN-003 sub-criterion status\n")
 	sb.WriteString("# format: HRN-003 WriteContract v1\n")
 	sb.WriteString("# HRN-002 §11.4.1: passed criteria carry forward; evaluator memory is per-iteration\n\n")
-	sb.WriteString(fmt.Sprintf("spec_id: %q\n", card.SpecID))
-	sb.WriteString(fmt.Sprintf("schema_version: %q\n", card.SchemaVersion))
-	sb.WriteString(fmt.Sprintf("verdict: %q\n", string(card.Verdict)))
+	fmt.Fprintf(&sb, "spec_id: %q\n", card.SpecID)
+	fmt.Fprintf(&sb, "schema_version: %q\n", card.SchemaVersion)
+	fmt.Fprintf(&sb, "verdict: %q\n", string(card.Verdict))
 	if card.Rationale != "" {
-		sb.WriteString(fmt.Sprintf("rationale: %q\n", card.Rationale))
+		fmt.Fprintf(&sb, "rationale: %q\n", card.Rationale)
 	}
 	sb.WriteString("\nacceptance_checklist:\n")
 	for _, item := range items {
-		sb.WriteString(fmt.Sprintf("  - id: %q\n", item.ID))
-		sb.WriteString(fmt.Sprintf("    criterion: %q\n", item.Criterion))
+		fmt.Fprintf(&sb, "  - id: %q\n", item.ID)
+		fmt.Fprintf(&sb, "    criterion: %q\n", item.Criterion)
 		if item.Evidence != "" {
-			sb.WriteString(fmt.Sprintf("    evidence: %q\n", item.Evidence))
+			fmt.Fprintf(&sb, "    evidence: %q\n", item.Evidence)
 		}
-		sb.WriteString(fmt.Sprintf("    score: %.2f\n", item.Score))
-		sb.WriteString(fmt.Sprintf("    rubric_anchor: %q\n", item.Anchor))
-		sb.WriteString(fmt.Sprintf("    status: %q\n", item.Status))
+		fmt.Fprintf(&sb, "    score: %.2f\n", item.Score)
+		fmt.Fprintf(&sb, "    rubric_anchor: %q\n", item.Anchor)
+		fmt.Fprintf(&sb, "    status: %q\n", item.Status)
 	}
 	return sb.String()
 }

--- a/internal/harness/scorer_engine_test.go
+++ b/internal/harness/scorer_engine_test.go
@@ -1,0 +1,610 @@
+// Package harness — HRN-003 M3 채점 엔진 테스트.
+// EvaluatorRunner.Score(), aggregation (min/mean), must-pass firewall, WriteContract().
+// REQ-HRN-003-004: EvaluatorRunner.Score().
+// REQ-HRN-003-007: aggregation rules.
+// REQ-HRN-003-008: must-pass firewall.
+// REQ-HRN-003-009: rubric citation enforcement.
+// REQ-HRN-003-011: Sprint Contract sub-criterion persistence.
+package harness
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/modu-ai/moai-adk/internal/config"
+)
+
+// makeScoreCard는 2 Dimension × 3 Criterion × 2 SubCriterion ScoreCard 픽스처를 생성합니다.
+// AC-HRN-003-02: 12개 SubCriterionScore 항목.
+func makeScoreCard(t *testing.T) *ScoreCard {
+	t.Helper()
+	card := &ScoreCard{
+		SchemaVersion: "v1",
+		SpecID:        "SPEC-V3R2-HRN-003",
+		Dimensions:    make(map[Dimension]DimensionScore),
+	}
+	dims := []Dimension{Functionality, Security}
+	for _, dim := range dims {
+		ds := DimensionScore{Criteria: make(map[string]CriterionScore)}
+		for ci := 1; ci <= 3; ci++ {
+			critID := "crit-" + string(rune('0'+ci))
+			cs := CriterionScore{SubCriteria: make(map[string]SubCriterionScore)}
+			for si := 1; si <= 2; si++ {
+				subID := critID + ".sub" + string(rune('0'+si))
+				cs.SubCriteria[subID] = SubCriterionScore{
+					Score:        0.75,
+					RubricAnchor: "0.75",
+					Evidence:     "fixture evidence",
+					Dimension:    dim,
+				}
+			}
+			ds.Criteria[critID] = cs
+		}
+		card.Dimensions[dim] = ds
+	}
+	return card
+}
+
+// TestEvaluatorRunner_ScoreAggregatesHierarchically는 EvaluatorRunner.Score가
+// 2×3×2 픽스처 ScoreCard를 계층 집계하여 올바른 Aggregate를 반환하는지 검증합니다.
+// REQ-HRN-003-004, AC-HRN-003-02.
+func TestEvaluatorRunner_ScoreAggregatesHierarchically(t *testing.T) {
+	rubric := &Rubric{
+		ProfileName:   "test",
+		PassThreshold: 0.60,
+		Aggregation:   "min",
+		MustPass:      []Dimension{Functionality, Security},
+		Dimensions: map[Dimension]DimensionRubric{
+			Functionality: makeValidDimensionRubric(0.60),
+			Security:      makeValidDimensionRubric(0.60),
+			Craft:         makeValidDimensionRubric(0.60),
+			Consistency:   makeValidDimensionRubric(0.60),
+		},
+	}
+
+	card := makeScoreCard(t)
+	runner := NewEvaluatorRunner(rubric)
+	result, err := runner.AggregateScoreCard(card)
+	if err != nil {
+		t.Fatalf("AggregateScoreCard() error = %v, want nil", err)
+	}
+
+	// 각 Dimension의 Aggregate가 0으로 남지 않아야 합니다.
+	for dim, ds := range result.Dimensions {
+		if ds.Aggregate <= 0 {
+			t.Errorf("dimension %v Aggregate = %f, want > 0", dim, ds.Aggregate)
+		}
+		for critID, cs := range ds.Criteria {
+			if cs.Aggregate <= 0 {
+				t.Errorf("dimension %v criterion %q Aggregate = %f, want > 0", dim, critID, cs.Aggregate)
+			}
+		}
+	}
+}
+
+// TestAggregateMin는 aggregateMin이 슬라이스의 최솟값을 반환하는지 검증합니다.
+// REQ-HRN-003-007, AC-HRN-003-03.a.
+func TestAggregateMin(t *testing.T) {
+	scores := []float64{0.8, 0.5, 0.9}
+	got := aggregateMin(scores)
+	want := 0.5
+	if got != want {
+		t.Errorf("aggregateMin(%v) = %f, want %f", scores, got, want)
+	}
+}
+
+// TestAggregateMean는 aggregateMean이 슬라이스의 평균을 반환하는지 검증합니다.
+// REQ-HRN-003-015, AC-HRN-003-03.b.
+func TestAggregateMean(t *testing.T) {
+	scores := []float64{0.8, 0.5}
+	got := aggregateMean(scores)
+	want := 0.65
+	if got-want > 1e-9 || want-got > 1e-9 {
+		t.Errorf("aggregateMean(%v) = %f, want %f", scores, got, want)
+	}
+}
+
+// TestAggregateMin_Empty는 aggregateMin이 빈 슬라이스에 대해 0을 반환하는지 검증합니다.
+// Edge Case E6.
+func TestAggregateMin_Empty(t *testing.T) {
+	got := aggregateMin(nil)
+	if got != 0.0 {
+		t.Errorf("aggregateMin(nil) = %f, want 0.0", got)
+	}
+}
+
+// TestAggregateMean_Single는 aggregateMean이 단일 값에 대해 그 값을 그대로 반환하는지 검증합니다.
+func TestAggregateMean_Single(t *testing.T) {
+	got := aggregateMean([]float64{0.75})
+	want := 0.75
+	if got != want {
+		t.Errorf("aggregateMean([0.75]) = %f, want %f", got, want)
+	}
+}
+
+// TestMustPassFirewall_SecurityFails는 Security.Aggregate < threshold일 때
+// applyMustPassFirewall이 "fail"을 반환하는지 검증합니다.
+// REQ-HRN-003-008, AC-HRN-003-04.a.i.
+func TestMustPassFirewall_SecurityFails(t *testing.T) {
+	card := &ScoreCard{
+		SchemaVersion: "v1",
+		SpecID:        "test",
+		Dimensions: map[Dimension]DimensionScore{
+			Functionality: {Aggregate: 1.00},
+			Security:      {Aggregate: 0.55}, // 0.60 floor 이하
+			Craft:         {Aggregate: 1.00},
+			Consistency:   {Aggregate: 1.00},
+		},
+	}
+	rubric := &Rubric{
+		PassThreshold: 0.60,
+		MustPass:      []Dimension{Functionality, Security},
+		Dimensions: map[Dimension]DimensionRubric{
+			Functionality: makeValidDimensionRubric(0.60),
+			Security:      makeValidDimensionRubric(0.60),
+			Craft:         makeValidDimensionRubric(0.60),
+			Consistency:   makeValidDimensionRubric(0.60),
+		},
+	}
+
+	verdict, rationale := applyMustPassFirewall(card, rubric)
+	if verdict != VerdictFail {
+		t.Errorf("applyMustPassFirewall() verdict = %q, want %q", verdict, VerdictFail)
+	}
+	// AC-HRN-003-04.a.ii: Rationale에 실패 차원 정보가 포함되어야 합니다.
+	if rationale == "" {
+		t.Error("applyMustPassFirewall() rationale is empty, want non-empty failure message")
+	}
+	// Rationale에 "Security"와 실패 점수가 포함되어야 합니다.
+	if !containsAll(rationale, "Security", "0.55") {
+		t.Errorf("applyMustPassFirewall() rationale = %q, want to contain 'Security' and '0.55'", rationale)
+	}
+}
+
+// TestMustPassFirewall_FunctionalityFails는 Functionality.Aggregate < threshold일 때
+// applyMustPassFirewall이 "fail"을 반환하는지 검증합니다.
+// AC-HRN-003-04.b.
+func TestMustPassFirewall_FunctionalityFails(t *testing.T) {
+	card := &ScoreCard{
+		SchemaVersion: "v1",
+		SpecID:        "test",
+		Dimensions: map[Dimension]DimensionScore{
+			Functionality: {Aggregate: 0.55}, // 이번엔 Functionality가 실패
+			Security:      {Aggregate: 0.95},
+			Craft:         {Aggregate: 1.00},
+			Consistency:   {Aggregate: 1.00},
+		},
+	}
+	rubric := &Rubric{
+		PassThreshold: 0.60,
+		MustPass:      []Dimension{Functionality, Security},
+		Dimensions: map[Dimension]DimensionRubric{
+			Functionality: makeValidDimensionRubric(0.60),
+			Security:      makeValidDimensionRubric(0.60),
+			Craft:         makeValidDimensionRubric(0.60),
+			Consistency:   makeValidDimensionRubric(0.60),
+		},
+	}
+
+	verdict, rationale := applyMustPassFirewall(card, rubric)
+	if verdict != VerdictFail {
+		t.Errorf("applyMustPassFirewall() verdict = %q, want %q", verdict, VerdictFail)
+	}
+	if !containsAll(rationale, "Functionality") {
+		t.Errorf("applyMustPassFirewall() rationale = %q, want to contain 'Functionality'", rationale)
+	}
+}
+
+// TestMustPassFirewall_AllPass는 모든 must-pass 차원이 threshold 이상일 때
+// applyMustPassFirewall이 "pass"를 반환하는지 검증합니다.
+// AC-HRN-003-04.c.
+func TestMustPassFirewall_AllPass(t *testing.T) {
+	card := &ScoreCard{
+		SchemaVersion: "v1",
+		SpecID:        "test",
+		Dimensions: map[Dimension]DimensionScore{
+			Functionality: {Aggregate: 0.85},
+			Security:      {Aggregate: 0.90},
+			Craft:         {Aggregate: 0.70},
+			Consistency:   {Aggregate: 0.80},
+		},
+	}
+	rubric := &Rubric{
+		PassThreshold: 0.60,
+		MustPass:      []Dimension{Functionality, Security},
+		Dimensions: map[Dimension]DimensionRubric{
+			Functionality: makeValidDimensionRubric(0.60),
+			Security:      makeValidDimensionRubric(0.60),
+			Craft:         makeValidDimensionRubric(0.60),
+			Consistency:   makeValidDimensionRubric(0.60),
+		},
+	}
+
+	verdict, rationale := applyMustPassFirewall(card, rubric)
+	if verdict != VerdictPass {
+		t.Errorf("applyMustPassFirewall() verdict = %q, want %q", verdict, VerdictPass)
+	}
+	_ = rationale // pass 시 rationale은 비어 있어도 됩니다.
+}
+
+// TestMustPassFirewall_StrictProfile은 strict.md 수준의 높은 threshold (0.85)를
+// 사용하는 rubric에서 0.84가 실패하고 0.86이 통과하는지 검증합니다.
+// REQ-HRN-003-014, AC-HRN-003-12.
+func TestMustPassFirewall_StrictProfile(t *testing.T) {
+	strictDimRubric := DimensionRubric{
+		Weight:        0.30,
+		PassThreshold: 0.85, // strict 수준
+		Anchors: map[float64]string{
+			0.25: "low",
+			0.50: "medium",
+			0.75: "high",
+			1.00: "perfect",
+		},
+	}
+	rubric := &Rubric{
+		PassThreshold: 0.85,
+		MustPass:      []Dimension{Security},
+		Dimensions: map[Dimension]DimensionRubric{
+			Functionality: makeValidDimensionRubric(0.60),
+			Security:      strictDimRubric,
+			Craft:         makeValidDimensionRubric(0.60),
+			Consistency:   makeValidDimensionRubric(0.60),
+		},
+	}
+
+	// 0.84: 실패해야 합니다.
+	cardFail := &ScoreCard{
+		SchemaVersion: "v1",
+		SpecID:        "test-fail",
+		Dimensions: map[Dimension]DimensionScore{
+			Functionality: {Aggregate: 1.00},
+			Security:      {Aggregate: 0.84}, // 0.85 미만
+			Craft:         {Aggregate: 1.00},
+			Consistency:   {Aggregate: 1.00},
+		},
+	}
+	verdict, _ := applyMustPassFirewall(cardFail, rubric)
+	if verdict != VerdictFail {
+		t.Errorf("strict profile 0.84: applyMustPassFirewall() = %q, want %q", verdict, VerdictFail)
+	}
+
+	// 0.86: 통과해야 합니다.
+	cardPass := &ScoreCard{
+		SchemaVersion: "v1",
+		SpecID:        "test-pass",
+		Dimensions: map[Dimension]DimensionScore{
+			Functionality: {Aggregate: 1.00},
+			Security:      {Aggregate: 0.86}, // 0.85 이상
+			Craft:         {Aggregate: 1.00},
+			Consistency:   {Aggregate: 1.00},
+		},
+	}
+	verdict, _ = applyMustPassFirewall(cardPass, rubric)
+	if verdict != VerdictPass {
+		t.Errorf("strict profile 0.86: applyMustPassFirewall() = %q, want %q", verdict, VerdictPass)
+	}
+}
+
+// TestAggregateScoreCard_MinAggregation은 "min" aggregation 모드에서
+// criterion aggregate가 최솟값을 사용하는지 검증합니다.
+// AC-HRN-003-03.a.
+func TestAggregateScoreCard_MinAggregation(t *testing.T) {
+	rubric := &Rubric{
+		ProfileName:   "test-min",
+		PassThreshold: 0.60,
+		Aggregation:   "min",
+		MustPass:      []Dimension{Functionality, Security},
+		Dimensions: map[Dimension]DimensionRubric{
+			Functionality: makeValidDimensionRubric(0.60),
+			Security:      makeValidDimensionRubric(0.60),
+			Craft:         makeValidDimensionRubric(0.60),
+			Consistency:   makeValidDimensionRubric(0.60),
+		},
+	}
+
+	// Functionality: crit-1: sub1=0.8, sub2=0.5 → criterion aggregate = 0.5 (min)
+	card := &ScoreCard{
+		SchemaVersion: "v1",
+		SpecID:        "test",
+		Dimensions: map[Dimension]DimensionScore{
+			Functionality: {
+				Criteria: map[string]CriterionScore{
+					"crit-1": {
+						SubCriteria: map[string]SubCriterionScore{
+							"sub-1": {Score: 0.8, RubricAnchor: "0.75", Evidence: "e", Dimension: Functionality},
+							"sub-2": {Score: 0.5, RubricAnchor: "0.50", Evidence: "e", Dimension: Functionality},
+						},
+					},
+				},
+			},
+			Security:    {Criteria: map[string]CriterionScore{}},
+			Craft:       {Criteria: map[string]CriterionScore{}},
+			Consistency: {Criteria: map[string]CriterionScore{}},
+		},
+	}
+
+	runner := NewEvaluatorRunner(rubric)
+	result, err := runner.AggregateScoreCard(card)
+	if err != nil {
+		t.Fatalf("AggregateScoreCard() error = %v", err)
+	}
+
+	funcDim := result.Dimensions[Functionality]
+	crit := funcDim.Criteria["crit-1"]
+	if crit.Aggregate != 0.5 {
+		t.Errorf("min aggregation: crit-1 Aggregate = %f, want 0.5", crit.Aggregate)
+	}
+}
+
+// TestAggregateScoreCard_MeanAggregation은 "mean" aggregation 모드에서
+// criterion aggregate가 평균을 사용하는지 검증합니다.
+// AC-HRN-003-03.b.
+func TestAggregateScoreCard_MeanAggregation(t *testing.T) {
+	rubric := &Rubric{
+		ProfileName:   "test-mean",
+		PassThreshold: 0.60,
+		Aggregation:   "mean",
+		MustPass:      []Dimension{Functionality, Security},
+		Dimensions: map[Dimension]DimensionRubric{
+			Functionality: makeValidDimensionRubric(0.60),
+			Security:      makeValidDimensionRubric(0.60),
+			Craft:         makeValidDimensionRubric(0.60),
+			Consistency:   makeValidDimensionRubric(0.60),
+		},
+	}
+
+	// Functionality: crit-1: sub1=0.8, sub2=0.5 → criterion aggregate = 0.65 (mean)
+	card := &ScoreCard{
+		SchemaVersion: "v1",
+		SpecID:        "test",
+		Dimensions: map[Dimension]DimensionScore{
+			Functionality: {
+				Criteria: map[string]CriterionScore{
+					"crit-1": {
+						SubCriteria: map[string]SubCriterionScore{
+							"sub-1": {Score: 0.8, RubricAnchor: "0.75", Evidence: "e", Dimension: Functionality},
+							"sub-2": {Score: 0.5, RubricAnchor: "0.50", Evidence: "e", Dimension: Functionality},
+						},
+					},
+				},
+			},
+			Security:    {Criteria: map[string]CriterionScore{}},
+			Craft:       {Criteria: map[string]CriterionScore{}},
+			Consistency: {Criteria: map[string]CriterionScore{}},
+		},
+	}
+
+	runner := NewEvaluatorRunner(rubric)
+	result, err := runner.AggregateScoreCard(card)
+	if err != nil {
+		t.Fatalf("AggregateScoreCard() error = %v", err)
+	}
+
+	funcDim := result.Dimensions[Functionality]
+	crit := funcDim.Criteria["crit-1"]
+	want := 0.65
+	if diff := crit.Aggregate - want; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("mean aggregation: crit-1 Aggregate = %f, want %f", crit.Aggregate, want)
+	}
+}
+
+// TestAggregateScoreCard_PerDimOverride는 차원별 aggregation override가
+// 올바르게 적용되는지 검증합니다.
+// AC-HRN-003-03.c.
+func TestAggregateScoreCard_PerDimOverride(t *testing.T) {
+	// Functionality: mean, Security: (profile default = min)
+	rubric := &Rubric{
+		ProfileName:   "test-override",
+		PassThreshold: 0.60,
+		Aggregation:   "min", // 프로필 기본값
+		MustPass:      []Dimension{Functionality, Security},
+		Dimensions: map[Dimension]DimensionRubric{
+			Functionality: {
+				Weight:        0.25,
+				PassThreshold: 0.60,
+				Aggregation:   "mean", // 차원별 override
+				Anchors:       map[float64]string{0.25: "low", 0.50: "med", 0.75: "high", 1.00: "perfect"},
+			},
+			Security:    makeValidDimensionRubric(0.60),
+			Craft:       makeValidDimensionRubric(0.60),
+			Consistency: makeValidDimensionRubric(0.60),
+		},
+	}
+
+	// Functionality: sub1=0.8, sub2=0.5 → mean=0.65
+	// Security: sub1=0.8, sub2=0.5 → min=0.5
+	card := &ScoreCard{
+		SchemaVersion: "v1",
+		SpecID:        "test",
+		Dimensions: map[Dimension]DimensionScore{
+			Functionality: {
+				Criteria: map[string]CriterionScore{
+					"crit-1": {
+						SubCriteria: map[string]SubCriterionScore{
+							"sub-1": {Score: 0.8, RubricAnchor: "0.75", Evidence: "e", Dimension: Functionality},
+							"sub-2": {Score: 0.5, RubricAnchor: "0.50", Evidence: "e", Dimension: Functionality},
+						},
+					},
+				},
+			},
+			Security: {
+				Criteria: map[string]CriterionScore{
+					"crit-1": {
+						SubCriteria: map[string]SubCriterionScore{
+							"sub-1": {Score: 0.8, RubricAnchor: "0.75", Evidence: "e", Dimension: Security},
+							"sub-2": {Score: 0.5, RubricAnchor: "0.50", Evidence: "e", Dimension: Security},
+						},
+					},
+				},
+			},
+			Craft:       {Criteria: map[string]CriterionScore{}},
+			Consistency: {Criteria: map[string]CriterionScore{}},
+		},
+	}
+
+	runner := NewEvaluatorRunner(rubric)
+	result, err := runner.AggregateScoreCard(card)
+	if err != nil {
+		t.Fatalf("AggregateScoreCard() error = %v", err)
+	}
+
+	// Functionality: mean → 0.65
+	funcCrit := result.Dimensions[Functionality].Criteria["crit-1"]
+	wantFunc := 0.65
+	if diff := funcCrit.Aggregate - wantFunc; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("Functionality (mean) crit aggregate = %f, want %f", funcCrit.Aggregate, wantFunc)
+	}
+
+	// Security: min → 0.5
+	secCrit := result.Dimensions[Security].Criteria["crit-1"]
+	wantSec := 0.5
+	if secCrit.Aggregate != wantSec {
+		t.Errorf("Security (min) crit aggregate = %f, want %f", secCrit.Aggregate, wantSec)
+	}
+}
+
+// TestWriteContract는 WriteContract가 sub-criterion status를 YAML로 올바르게
+// 저장하는지 검증합니다.
+// REQ-HRN-003-011, AC-HRN-003-10.
+func TestWriteContract(t *testing.T) {
+	tmpDir := t.TempDir()
+	contractPath := filepath.Join(tmpDir, "contract.yaml")
+
+	card := &ScoreCard{
+		SchemaVersion: "v1",
+		SpecID:        "SPEC-TEST-001",
+		Dimensions: map[Dimension]DimensionScore{
+			Functionality: {
+				Aggregate: 0.75,
+				Criteria: map[string]CriterionScore{
+					"AC-001": {
+						Aggregate: 0.75,
+						SubCriteria: map[string]SubCriterionScore{
+							"AC-001.a": {Score: 0.75, RubricAnchor: "0.75", Evidence: "passed", Dimension: Functionality},
+							"AC-001.b": {Score: 0.50, RubricAnchor: "0.50", Evidence: "partial", Dimension: Functionality},
+						},
+					},
+				},
+			},
+			Security: {
+				Aggregate: 1.00,
+				Criteria: map[string]CriterionScore{
+					"AC-002": {
+						Aggregate: 1.00,
+						SubCriteria: map[string]SubCriterionScore{
+							"AC-002.a": {Score: 1.00, RubricAnchor: "1.00", Evidence: "complete", Dimension: Security},
+						},
+					},
+				},
+			},
+			Craft:       {Criteria: map[string]CriterionScore{}},
+			Consistency: {Criteria: map[string]CriterionScore{}},
+		},
+		Verdict:   VerdictPass,
+		Rationale: "all must-pass dimensions passed",
+	}
+
+	if err := WriteContract(card, contractPath); err != nil {
+		t.Fatalf("WriteContract() error = %v, want nil", err)
+	}
+
+	// 파일이 생성되었는지 확인합니다.
+	data, err := os.ReadFile(contractPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", contractPath, err)
+	}
+	content := string(data)
+
+	// YAML에 필수 필드가 포함되어야 합니다.
+	for _, want := range []string{"spec_id", "SPEC-TEST-001", "verdict", "pass", "acceptance_checklist"} {
+		if !containsStr(content, want) {
+			t.Errorf("WriteContract YAML missing %q in:\n%s", want, content)
+		}
+	}
+}
+
+// TestWriteContract_NoLeakDetection는 WriteContract가 생성한 YAML이
+// HRN-002 leak detection 패턴을 트리거하지 않는지 검증합니다.
+// AC-HRN-003-10: contract carries criterion state, not evaluator rationale.
+func TestWriteContract_NoLeakDetection(t *testing.T) {
+	tmpDir := t.TempDir()
+	contractPath := filepath.Join(tmpDir, "contract.yaml")
+
+	card := &ScoreCard{
+		SchemaVersion: "v1",
+		SpecID:        "SPEC-LEAK-TEST",
+		Dimensions: map[Dimension]DimensionScore{
+			Functionality: {Criteria: map[string]CriterionScore{}},
+			Security:      {Criteria: map[string]CriterionScore{}},
+			Craft:         {Criteria: map[string]CriterionScore{}},
+			Consistency:   {Criteria: map[string]CriterionScore{}},
+		},
+		Verdict:   VerdictPass,
+		Rationale: "all dimensions passed",
+	}
+
+	if err := WriteContract(card, contractPath); err != nil {
+		t.Fatalf("WriteContract() error = %v", err)
+	}
+
+	data, err := os.ReadFile(contractPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+
+	// HRN-002 leak detection: YAML 내용이 forbidden substring을 포함하지 않아야 합니다.
+	// "Score:", "Feedback:", "Verdict:" 는 evaluator 판단 흔적이므로 금지됩니다.
+	// 단, "verdict:" (lowercase)는 상태 필드로 허용됩니다.
+	if err := DetectPriorJudgmentLeak(string(data)); err != nil {
+		t.Errorf("WriteContract YAML triggers leak detection: %v", err)
+	}
+}
+
+// TestValidateCitation_EmptyAnchor_M3은 M3 레벨에서 ValidateCitation이
+// 빈 RubricAnchor에 대해 ErrRubricCitationMissing을 반환하는지 재확인합니다.
+// AC-HRN-003-05.a — M2에서도 검증되었으나 M3 engine 맥락에서 재확인.
+func TestValidateCitation_EmptyAnchor_M3(t *testing.T) {
+	rubric := &Rubric{
+		ProfileName: "test",
+		Dimensions: map[Dimension]DimensionRubric{
+			Functionality: makeValidDimensionRubric(0.60),
+			Security:      makeValidDimensionRubric(0.60),
+			Craft:         makeValidDimensionRubric(0.60),
+			Consistency:   makeValidDimensionRubric(0.60),
+		},
+	}
+	score := SubCriterionScore{
+		Score:        0.75,
+		RubricAnchor: "",
+		Evidence:     "test",
+		Dimension:    Functionality,
+	}
+	if err := rubric.ValidateCitation(score); !errors.Is(err, config.ErrRubricCitationMissing) {
+		t.Errorf("ValidateCitation(empty anchor) = %v, want ErrRubricCitationMissing", err)
+	}
+}
+
+// containsAll는 s가 모든 substr을 포함하는지 확인하는 헬퍼입니다.
+func containsAll(s string, substrs ...string) bool {
+	for _, sub := range substrs {
+		if !containsStr(s, sub) {
+			return false
+		}
+	}
+	return true
+}
+
+// containsStr는 s가 substr을 포함하는지 확인하는 헬퍼입니다.
+func containsStr(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
+		func() bool {
+			for i := 0; i <= len(s)-len(substr); i++ {
+				if s[i:i+len(substr)] == substr {
+					return true
+				}
+			}
+			return false
+		}())
+}

--- a/internal/harness/scorer_test.go
+++ b/internal/harness/scorer_test.go
@@ -1,0 +1,103 @@
+// Package harness — HRN-003 Hierarchical Acceptance Scoring 테스트.
+// REQ-HRN-003-001: 4-차원 열거형 (Dimension enum).
+// REQ-HRN-003-002: 계층 스코어카드 구조 (ScoreCard tree shape).
+package harness
+
+import (
+	"testing"
+)
+
+// TestDimensionEnum_FrozenSet는 Dimension enum이 정확히 4개의 값을 가지고
+// 범위 외의 값에 대해 IsValid()가 false를 반환하는지 검증합니다.
+// REQ-HRN-003-001, AC-HRN-003-01.
+func TestDimensionEnum_FrozenSet(t *testing.T) {
+	// 4개의 canonical dimension만 유효해야 합니다.
+	canonicals := []Dimension{Functionality, Security, Craft, Consistency}
+	for _, d := range canonicals {
+		if !d.IsValid() {
+			t.Errorf("canonical dimension %v IsValid() = false, want true", d)
+		}
+	}
+
+	// 범위 외의 값은 유효하지 않아야 합니다.
+	if Dimension(99).IsValid() {
+		t.Error("Dimension(99).IsValid() = true, want false")
+	}
+	if Dimension(0).IsValid() {
+		t.Error("Dimension(0).IsValid() = true, want false (iota starts at 1)")
+	}
+
+	// String() 메서드 검증.
+	if got := Functionality.String(); got != "Functionality" {
+		t.Errorf("Functionality.String() = %q, want %q", got, "Functionality")
+	}
+	if got := Security.String(); got != "Security" {
+		t.Errorf("Security.String() = %q, want %q", got, "Security")
+	}
+	if got := Craft.String(); got != "Craft" {
+		t.Errorf("Craft.String() = %q, want %q", got, "Craft")
+	}
+	if got := Consistency.String(); got != "Consistency" {
+		t.Errorf("Consistency.String() = %q, want %q", got, "Consistency")
+	}
+}
+
+// TestScoreCard_HierarchicalShape는 ScoreCard가 2dim × 3crit × 2subcrit = 12개의
+// SubCriterionScore 항목을 담을 수 있는 계층 구조를 가지는지 검증합니다.
+// REQ-HRN-003-002, AC-HRN-003-02.
+func TestScoreCard_HierarchicalShape(t *testing.T) {
+	// 2 dimension × 3 criteria × 2 sub-criteria = 12 SubCriterionScore 항목을
+	// 담을 수 있는 ScoreCard를 생성합니다.
+	card := &ScoreCard{
+		SchemaVersion: "v1",
+		SpecID:        "SPEC-V3R2-HRN-003",
+		Dimensions:    make(map[Dimension]DimensionScore),
+	}
+
+	dims := []Dimension{Functionality, Security}
+	for _, dim := range dims {
+		ds := DimensionScore{
+			Aggregate: 0.0,
+			Criteria:  make(map[string]CriterionScore),
+		}
+		for ci := 1; ci <= 3; ci++ {
+			critID := "AC-HRN-003-0" + string(rune('0'+ci))
+			cs := CriterionScore{
+				Aggregate:    0.0,
+				SubCriteria:  make(map[string]SubCriterionScore),
+			}
+			for si := 1; si <= 2; si++ {
+				subID := critID + ".sub" + string(rune('0'+si))
+				cs.SubCriteria[subID] = SubCriterionScore{
+					Score:       0.75,
+					RubricAnchor: "0.75",
+					Evidence:    "fixture evidence",
+					Dimension:   dim,
+				}
+			}
+			ds.Criteria[critID] = cs
+		}
+		card.Dimensions[dim] = ds
+	}
+
+	// 총 12개 SubCriterionScore 항목이 있어야 합니다.
+	total := 0
+	for _, ds := range card.Dimensions {
+		for _, cs := range ds.Criteria {
+			total += len(cs.SubCriteria)
+		}
+	}
+	if total != 12 {
+		t.Errorf("total SubCriterionScore entries = %d, want 12", total)
+	}
+
+	// SchemaVersion 필드 검증.
+	if card.SchemaVersion != "v1" {
+		t.Errorf("ScoreCard.SchemaVersion = %q, want %q", card.SchemaVersion, "v1")
+	}
+
+	// DefaultMustPassDimensions 검증.
+	if len(DefaultMustPassDimensions) != 2 {
+		t.Errorf("DefaultMustPassDimensions len = %d, want 2", len(DefaultMustPassDimensions))
+	}
+}


### PR DESCRIPTION
## Summary

SPEC-V3R2-HRN-003 (Hierarchical Acceptance Scoring 4-dimension × sub-criteria) **Milestone 2** 구현입니다. TDD RED-GREEN-REFACTOR cycle로 T2.1~T2.8 8개 task 완료.

Plan PR: #884 (merged 2026-05-13). Plan-phase artifacts는 main에 반영됨, run-phase M2부터 본 PR.

## Changes (+1057 lines, 5 files)

| File | Type | Lines |
|------|------|-------|
| \`internal/harness/scorer.go\` | NEW | 109 |
| \`internal/harness/rubric.go\` | NEW | 527 |
| \`internal/harness/scorer_test.go\` | NEW | 103 |
| \`internal/harness/rubric_test.go\` | NEW | 295 |
| \`internal/config/errors.go\` | MODIFY | +23 |

### Type definitions (\`internal/harness/scorer.go\`)
- \`type Dimension int\` + iota constants: \`Functionality | Security | Craft | Consistency\` (4-dim FROZEN per CONST-V3R2-154)
- \`MustPassDimensions = []Dimension{Functionality, Security}\` exported default
- \`String() / IsValid()\` methods
- \`type Verdict string\` enum: \`pass | fail\`
- \`ScoreCard\` 계층 트리: \`Dimensions[Dim].Criteria[critID].SubCriteria[subID]\`
- AC-HRN-003-01 (Dimension enum FROZEN) + AC-HRN-003-02 (ScoreCard tree shape) 어설션

### Rubric + Validate (\`internal/harness/rubric.go\`)
- \`type Rubric struct { ProfileName; Dimensions; PassThreshold; MustPass; Aggregation }\`
- \`type DimensionRubric struct { Weight; PassThreshold; Anchors map[float64]string }\`
- \`Validate() error\` — 4가지 검증:
  - 4 anchor levels required (AC-HRN-003-07)
  - 5th dimension rejected (FROZEN per CONST-V3R2-155)
  - \`pass_threshold ≥ 0.60\` floor (design-constitution §2 Frozen, 절대 lowering 금지)
  - MustPass non-narrowing (AC-HRN-003-08)
- AC-HRN-003-07.a/b/c + AC-HRN-003-08 어설션

### Error sentinels (\`internal/config/errors.go\`)
- \`ErrUnknownDimension\` — canonical 4-set 외부 값
- \`ErrRubricCitationMissing\` — design-constitution §12 Mechanism 1 위반
- \`ErrFlatScoreCardProhibited\` — flat aggregation 시도
- \`ErrMustPassBypassProhibited\` — must-pass 우회 시도 (FROZEN per CONST-V3R2-156)
- 모두 \`errors.Is\` 호환 + 한국어 godoc

## MX tags

- \`@MX:NOTE\` on Dimension enum (REQ-001 context)
- \`@MX:WARN\` + \`@MX:REASON\` on Dimension enum (FROZEN per CONST-V3R2-154)
- \`@MX:WARN\` + \`@MX:REASON\` on Rubric.Validate() anchor validator (CONST-V3R2-155)

## Test plan

- [x] \`go test ./internal/harness/...\` — PASS (커버리지 89.8%)
- [x] \`go test ./internal/config/...\` — PASS
- [x] \`go vet ./internal/harness/... ./internal/config/...\` — clean
- [x] \`Dimension(99).IsValid() == false\` + \`Dimension(0).IsValid() == false\` (iota starts at 1)
- [x] \`Rubric.Validate()\` rejects: 5th anchor / 5th dimension / pass_threshold < 0.60 / MustPass 축소
- [x] 4 sentinels exported, godoc-documented, errors.Is 호환

## Remaining Milestones (별도 PR)

- **M3**: Scoring engine + Sprint Contract persistence (Critical) — `Score()` + `WriteContract()` 함수
- **M4**: Profile loader + EvaluatorConfig + agent body augment + SKILL.md (High)
- **M5**: Test fixtures + MX tags + zone-registry mirror entries (High)

## Labels

- \`type:feature\`
- \`area:harness\`
- \`priority:P1\`
- SPEC: SPEC-V3R2-HRN-003 (M2/5)

🗿 MoAI <email@mo.ai.kr>