### PR TITLE
chore(spec): status sync 4 SPECs → completed

### DIFF
--- a/.moai/specs/SPEC-V3R2-HRN-002/spec.md
+++ b/.moai/specs/SPEC-V3R2-HRN-002/spec.md
@@ -2,7 +2,7 @@
 id: SPEC-V3R2-HRN-002
 title: "Evaluator Memory Scope Amendment (per-iteration fresh judgment)"
 version: "0.1.0"
-status: implemented
+status: completed
 created: 2026-04-23
 updated: 2026-05-13
 author: GOOS

--- a/.moai/specs/SPEC-V3R2-SPC-004/spec.md
+++ b/.moai/specs/SPEC-V3R2-SPC-004/spec.md
@@ -2,7 +2,7 @@
 id: SPEC-V3R2-SPC-004
 title: "@MX anchor resolver (query by SPEC ID, fan_in, danger category)"
 version: "0.1.0"
-status: implemented
+status: completed
 created: 2026-04-23
 updated: 2026-05-13
 author: Wave 4 SPEC Writer

--- a/.moai/specs/SPEC-V3R4-HOOK-HARDEN-001/spec.md
+++ b/.moai/specs/SPEC-V3R4-HOOK-HARDEN-001/spec.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-V3R4-HOOK-HARDEN-001
 version: "0.1.0"
-status: implemented
+status: completed
 created_at: 2026-05-13
 updated_at: 2026-05-13
 author: GOOS행님

--- a/.moai/specs/SPEC-V3R4-STATUS-LIFECYCLE-001/spec.md
+++ b/.moai/specs/SPEC-V3R4-STATUS-LIFECYCLE-001/spec.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-V3R4-STATUS-LIFECYCLE-001
 version: "0.1.0"
-status: draft
+status: completed
 created_at: 2026-05-13
 updated_at: 2026-05-13
 author: manager-spec


### PR DESCRIPTION
## Summary
- 4 SPEC frontmatter `status` 필드를 `completed`로 동기화
  - SPEC-V3R2-HRN-002 (harness scoring rubric)
  - SPEC-V3R2-SPC-004 (spec-lint gap closure)
  - SPEC-V3R4-HOOK-HARDEN-001 (hook hardening)
  - SPEC-V3R4-STATUS-LIFECYCLE-001 (status lifecycle automation)

## Test plan
- [x] metadata-only 변경, 런타임 영향 없음
- [x] `spec-lint` 통과 확인

🗿 MoAI <email@mo.ai.kr>