### PR TITLE
fix(quality): dotnet test step optional 처리 (#786)

### DIFF
--- a/internal/hook/quality/gate.go
+++ b/internal/hook/quality/gate.go
@@ -145,7 +145,7 @@ var toolchains = []langToolchain{
 	{
 		markerFiles: []string{"*.csproj", "*.sln"},
 		lintSteps:   []gateStep{{name: "dotnet format", binary: "dotnet", args: []string{"format", "--verify-no-changes"}, optional: true, changedExts: []string{".cs"}}},
-		testStep:    &gateStep{name: "dotnet test", binary: "dotnet", args: []string{"test"}},
+		testStep:    &gateStep{name: "dotnet test", binary: "dotnet", args: []string{"test"}, optional: true},
 	},
 	// Ruby: Gemfile
 	{


### PR DESCRIPTION
## Summary

- `internal/hook/quality/gate.go`에서 C#/.NET toolchain의 `dotnet test` step에 `optional: true` 추가
- .NET Core SDK가 설치되지 않은 환경(Unity, Xamarin, Mono)에서 binary 누락 시 graceful skip
- 기존에 `dotnet format`은 이미 `optional: true`였으나 `dotnet test`만 누락되어 있었음

## Test plan

- [x] `go test ./internal/hook/quality/` — PASS
- [ ] Unity 프로젝트(.csproj 포함, .NET Core SDK 미설치)에서 `gate.enabled: true` 상태로 git commit 시 정상 통과 확인

Fixes #786

🤖 MoAI <email@mo.ai.kr>