### PR TITLE
feat(workflow): SPEC-V3R2-ORC-004 M1-M3 — Worktree MUST Rule frontmatter + rule text

### DIFF
--- a/internal/cli/agent_lint.go
+++ b/internal/cli/agent_lint.go
@@ -113,7 +113,6 @@ func init() {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},
-		GroupID: "tools",
 	}
 	rootCmd.AddCommand(agentCmd)
 	agentCmd.AddCommand(agentLintCmd)

--- a/internal/cli/agent_lint.go
+++ b/internal/cli/agent_lint.go
@@ -27,6 +27,10 @@ const (
 	SeverityError LintSeverity = "error"
 	// SeverityWarning is a non-critical issue that should be fixed.
 	SeverityWarning LintSeverity = "warning"
+
+	// Sentinel keys per SPEC-V3R2-ORC-004 REQ-013/014.
+	SentinelWorktreeMissing    = "ORC_WORKTREE_MISSING"
+	SentinelWorktreeOnReadonly = "ORC_WORKTREE_ON_READONLY"
 )
 
 // LintViolation represents a single lint rule violation.
@@ -482,7 +486,7 @@ func checkMissingIsolation(file string, fm AgentFrontmatter) []LintViolation {
 					Severity: SeverityError,
 					File:     file,
 					Line:     lineNum,
-					Message:  fmt.Sprintf("Write-heavy agent '%s' must have 'isolation: worktree' (SPEC-V3R2-ORC-004)", fm.Name),
+					Message:  fmt.Sprintf("Write-heavy agent '%s' must have 'isolation: worktree' (SPEC-V3R2-ORC-004 %s)", fm.Name, SentinelWorktreeMissing),
 				})
 			}
 			return violations
@@ -529,7 +533,7 @@ func checkReadOnlyIsolation(file string, fm AgentFrontmatter) []LintViolation {
 			Severity: SeverityError,
 			File:     file,
 			Line:     lineNum,
-			Message:  "Read-only agent (permissionMode: plan) MUST NOT have 'isolation: worktree' — plan mode already prevents writes (SPEC-V3R2-ORC-004)",
+			Message:  fmt.Sprintf("Read-only agent (permissionMode: plan) MUST NOT have 'isolation: worktree' — plan mode already prevents writes (SPEC-V3R2-ORC-004 %s)", SentinelWorktreeOnReadonly),
 		})
 	}
 

--- a/internal/cli/agent_lint_test.go
+++ b/internal/cli/agent_lint_test.go
@@ -803,3 +803,80 @@ Custom team agent body`
 		t.Error("expected LR-10 violation for team-custom.md, not found")
 	}
 }
+
+// TestLintLR05_OrcWorktreeMissingSentinel verifies LR-05 fires with ORC_WORKTREE_MISSING sentinel
+// when isolation: worktree is missing from write-heavy agent (AC-06)
+func TestLintLR05_OrcWorktreeMissingSentinel(t *testing.T) {
+	content := `---
+name: expert-backend
+tools: Read, Write, Edit
+permissionMode: bypassPermissions
+---
+
+Body.
+`
+
+	agentFile := createTempAgentFile(t, content)
+	violations, err := lintAgentFile(agentFile, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(violations) == 0 {
+		t.Fatal("expected at least one LR-05 violation, got none")
+	}
+
+	found := false
+	for _, v := range violations {
+		if v.Rule == "LR-05" && strings.Contains(v.Message, "ORC_WORKTREE_MISSING") {
+			found = true
+			if v.Severity != SeverityError {
+				t.Errorf("expected SeverityError, got %s", v.Severity)
+			}
+			break
+		}
+	}
+
+	if !found {
+		t.Error("expected LR-05 violation with ORC_WORKTREE_MISSING sentinel, not found")
+	}
+}
+
+// TestLintLR09_OrcWorktreeOnReadonlySentinel verifies LR-09 fires with ORC_WORKTREE_ON_READONLY sentinel
+// when isolation: worktree is added to read-only agent (AC-07)
+func TestLintLR09_OrcWorktreeOnReadonlySentinel(t *testing.T) {
+	content := `---
+name: evaluator-active
+tools: Read, Grep, Glob
+permissionMode: plan
+isolation: worktree
+---
+
+Body.
+`
+
+	agentFile := createTempAgentFile(t, content)
+	violations, err := lintAgentFile(agentFile, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(violations) == 0 {
+		t.Fatal("expected at least one LR-09 violation, got none")
+	}
+
+	found := false
+	for _, v := range violations {
+		if v.Rule == "LR-09" && strings.Contains(v.Message, "ORC_WORKTREE_ON_READONLY") {
+			found = true
+			if v.Severity != SeverityError {
+				t.Errorf("expected SeverityError, got %s", v.Severity)
+			}
+			break
+		}
+	}
+
+	if !found {
+		t.Error("expected LR-09 violation with ORC_WORKTREE_ON_READONLY sentinel, not found")
+	}
+}

--- a/internal/cli/workflow_lint.go
+++ b/internal/cli/workflow_lint.go
@@ -1,0 +1,131 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/modu-ai/moai-adk/internal/defs"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	// SentinelWorktreeRequired is emitted by workflow lint when write-heavy role profiles lack isolation: worktree
+	SentinelWorktreeRequired = "ORC_WORKTREE_REQUIRED"
+)
+
+// WorkflowLintViolation represents a workflow.yaml lint rule violation
+type WorkflowLintViolation struct {
+	Rule     string `json:"rule"`
+	Severity string `json:"severity"`
+	Path     string `json:"path"`
+	Expected string `json:"expected"`
+	Actual   string `json:"actual"`
+	Message  string `json:"message"`
+}
+
+// workflowConfig represents the relevant subset of workflow.yaml for linting
+type workflowConfig struct {
+	Workflow struct {
+		Team struct {
+			RoleProfiles map[string]struct {
+				Mode      string `yaml:"mode"`
+				Model     string `yaml:"model"`
+				Isolation string `yaml:"isolation"`
+			} `yaml:"role_profiles"`
+		} `yaml:"team"`
+	} `yaml:"workflow"`
+}
+
+// runWorkflowLint validates .moai/config/sections/workflow.yaml
+// Returns errLintViolations when violations are found
+func runWorkflowLint(cmd *cobra.Command, args []string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("get working directory: %w", err)
+	}
+	workflowPath := filepath.Join(cwd, defs.MoAIDir, "config", "sections", "workflow.yaml")
+
+	cfg, err := loadWorkflowYAML(workflowPath)
+	if err != nil {
+		return fmt.Errorf("failed to load workflow.yaml: %w", err)
+	}
+
+	violations := validateRoleProfiles(cfg)
+
+	if len(violations) > 0 {
+		for _, v := range violations {
+			fmt.Printf("error: %s: %s\n", v.Rule, v.Message)
+		}
+		return errLintViolations
+	}
+
+	fmt.Println("workflow lint: no violations found")
+	return nil
+}
+
+// validateRoleProfiles checks role_profiles.{implementer,tester,designer}.isolation == "worktree"
+func validateRoleProfiles(cfg *workflowConfig) []WorkflowLintViolation {
+	var violations []WorkflowLintViolation
+
+	writeHeavyRoles := []string{"implementer", "tester", "designer"}
+
+	for _, role := range writeHeavyRoles {
+		profile, exists := cfg.Workflow.Team.RoleProfiles[role]
+		if !exists {
+			continue
+		}
+
+		if profile.Isolation != "worktree" {
+			violations = append(violations, WorkflowLintViolation{
+				Rule:     SentinelWorktreeRequired,
+				Severity: "error",
+				Path:     fmt.Sprintf("workflow.team.role_profiles.%s.isolation", role),
+				Expected: "worktree",
+				Actual:   profile.Isolation,
+				Message:  fmt.Sprintf("role_profiles.%s.isolation must be 'worktree' (got '%s') (SPEC-V3R2-ORC-004 %s)", role, profile.Isolation, SentinelWorktreeRequired),
+			})
+		}
+	}
+
+	return violations
+}
+
+// loadWorkflowYAML reads and parses .moai/config/sections/workflow.yaml into a typed struct
+func loadWorkflowYAML(path string) (*workflowConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read workflow.yaml: %w", err)
+	}
+
+	var cfg workflowConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse workflow.yaml: %w", err)
+	}
+
+	return &cfg, nil
+}
+
+// workflowLintCmd is the cobra command for workflow linting
+var workflowLintCmd = &cobra.Command{
+	Use:   "lint",
+	Short: "Validate workflow.yaml configuration",
+	Long:  "Check workflow.yaml role_profiles for write-heavy agents missing isolation: worktree",
+	RunE:  runWorkflowLint,
+	GroupID: "tools",
+}
+
+func init() {
+	// Create workflow command group
+	workflowCmd := &cobra.Command{
+		Use:   "workflow",
+		Short: "Workflow configuration commands",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+		GroupID: "tools",
+	}
+	rootCmd.AddCommand(workflowCmd)
+	workflowCmd.AddCommand(workflowLintCmd)
+}

--- a/internal/cli/workflow_lint_test.go
+++ b/internal/cli/workflow_lint_test.go
@@ -1,0 +1,158 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Test helper to create a temporary workflow.yaml file
+func createTempWorkflowFile(t *testing.T, content string) string {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	workflowPath := filepath.Join(tmpDir, "workflow.yaml")
+
+	if err := os.WriteFile(workflowPath, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to create temp workflow file: %v", err)
+	}
+
+	return workflowPath
+}
+
+// TestWorkflowLint_OrcWorktreeRequiredOnImplementer verifies implementer.isolation=none triggers ORC_WORKTREE_REQUIRED (AC-09)
+func TestWorkflowLint_OrcWorktreeRequiredOnImplementer(t *testing.T) {
+	content := `workflow:
+  team:
+    role_profiles:
+      implementer:
+        mode: acceptEdits
+        isolation: none
+      tester:
+        mode: acceptEdits
+        isolation: worktree
+      designer:
+        mode: acceptEdits
+        isolation: worktree
+`
+
+	workflowFile := createTempWorkflowFile(t, content)
+	cfg, err := loadWorkflowYAML(workflowFile)
+	if err != nil {
+		t.Fatalf("failed to load workflow YAML: %v", err)
+	}
+
+	violations := validateRoleProfiles(cfg)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+
+	if violations[0].Rule != SentinelWorktreeRequired {
+		t.Errorf("expected rule %s, got %s", SentinelWorktreeRequired, violations[0].Rule)
+	}
+
+	if !strings.Contains(violations[0].Path, "implementer") {
+		t.Errorf("expected path to contain 'implementer', got %s", violations[0].Path)
+	}
+}
+
+// TestWorkflowLint_OrcWorktreeRequiredOnTester verifies tester.isolation=none triggers ORC_WORKTREE_REQUIRED
+func TestWorkflowLint_OrcWorktreeRequiredOnTester(t *testing.T) {
+	content := `workflow:
+  team:
+    role_profiles:
+      implementer:
+        mode: acceptEdits
+        isolation: worktree
+      tester:
+        mode: acceptEdits
+        isolation: none
+      designer:
+        mode: acceptEdits
+        isolation: worktree
+`
+
+	workflowFile := createTempWorkflowFile(t, content)
+	cfg, err := loadWorkflowYAML(workflowFile)
+	if err != nil {
+		t.Fatalf("failed to load workflow YAML: %v", err)
+	}
+
+	violations := validateRoleProfiles(cfg)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+
+	if violations[0].Rule != SentinelWorktreeRequired {
+		t.Errorf("expected rule %s, got %s", SentinelWorktreeRequired, violations[0].Rule)
+	}
+
+	if !strings.Contains(violations[0].Path, "tester") {
+		t.Errorf("expected path to contain 'tester', got %s", violations[0].Path)
+	}
+}
+
+// TestWorkflowLint_OrcWorktreeRequiredOnDesigner verifies designer.isolation=none triggers ORC_WORKTREE_REQUIRED
+func TestWorkflowLint_OrcWorktreeRequiredOnDesigner(t *testing.T) {
+	content := `workflow:
+  team:
+    role_profiles:
+      implementer:
+        mode: acceptEdits
+        isolation: worktree
+      tester:
+        mode: acceptEdits
+        isolation: worktree
+      designer:
+        mode: acceptEdits
+        isolation: none
+`
+
+	workflowFile := createTempWorkflowFile(t, content)
+	cfg, err := loadWorkflowYAML(workflowFile)
+	if err != nil {
+		t.Fatalf("failed to load workflow YAML: %v", err)
+	}
+
+	violations := validateRoleProfiles(cfg)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+
+	if violations[0].Rule != SentinelWorktreeRequired {
+		t.Errorf("expected rule %s, got %s", SentinelWorktreeRequired, violations[0].Rule)
+	}
+
+	if !strings.Contains(violations[0].Path, "designer") {
+		t.Errorf("expected path to contain 'designer', got %s", violations[0].Path)
+	}
+}
+
+// TestWorkflowLint_NoViolationsOnCorrectConfig verifies correct config passes (baseline)
+func TestWorkflowLint_NoViolationsOnCorrectConfig(t *testing.T) {
+	content := `workflow:
+  team:
+    role_profiles:
+      implementer:
+        mode: acceptEdits
+        isolation: worktree
+      tester:
+        mode: acceptEdits
+        isolation: worktree
+      designer:
+        mode: acceptEdits
+        isolation: worktree
+`
+
+	workflowFile := createTempWorkflowFile(t, content)
+	cfg, err := loadWorkflowYAML(workflowFile)
+	if err != nil {
+		t.Fatalf("failed to load workflow YAML: %v", err)
+	}
+
+	violations := validateRoleProfiles(cfg)
+	if len(violations) != 0 {
+		t.Fatalf("expected 0 violations, got %d", len(violations))
+	}
+}

--- a/internal/template/templates/.claude/agents/moai/expert-backend.md
+++ b/internal/template/templates/.claude/agents/moai/expert-backend.md
@@ -14,6 +14,7 @@ description: |
 tools: Read, Write, Edit, Grep, Glob, WebFetch, WebSearch, Bash, TodoWrite, Skill, mcp__sequential-thinking__sequentialthinking, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 model: sonnet
 permissionMode: bypassPermissions
+isolation: worktree
 memory: project
 skills:
   - moai-foundation-core

--- a/internal/template/templates/.claude/agents/moai/expert-frontend.md
+++ b/internal/template/templates/.claude/agents/moai/expert-frontend.md
@@ -12,6 +12,7 @@ description: |
 tools: Read, Write, Edit, Grep, Glob, WebFetch, WebSearch, Bash, TodoWrite, Skill, mcp__sequential-thinking__sequentialthinking, mcp__context7__resolve-library-id, mcp__context7__get-library-docs, mcp__claude-in-chrome__*, mcp__pencil__batch_design, mcp__pencil__batch_get, mcp__pencil__get_editor_state, mcp__pencil__get_guidelines, mcp__pencil__get_screenshot, mcp__pencil__get_style_guide, mcp__pencil__get_style_guide_tags, mcp__pencil__get_variables, mcp__pencil__set_variables, mcp__pencil__open_document, mcp__pencil__snapshot_layout, mcp__pencil__find_empty_space_on_canvas, mcp__pencil__search_all_unique_properties, mcp__pencil__replace_all_matching_properties
 model: sonnet
 permissionMode: bypassPermissions
+isolation: worktree
 memory: project
 skills:
   - moai-foundation-core

--- a/internal/template/templates/.claude/agents/moai/expert-refactoring.md
+++ b/internal/template/templates/.claude/agents/moai/expert-refactoring.md
@@ -13,6 +13,7 @@ tools: Read, Write, Edit, Grep, Glob, Bash, TodoWrite, Skill, mcp__sequential-th
 model: sonnet
 effort: high
 permissionMode: bypassPermissions
+isolation: worktree
 memory: project
 skills:
   - moai-foundation-core

--- a/internal/template/templates/.claude/agents/moai/manager-develop.md
+++ b/internal/template/templates/.claude/agents/moai/manager-develop.md
@@ -17,6 +17,7 @@ description: |
 tools: Read, Write, Edit, MultiEdit, Bash, Grep, Glob, TodoWrite, Skill, mcp__sequential-thinking__sequentialthinking, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 model: sonnet
 permissionMode: bypassPermissions
+isolation: worktree
 memory: project
 skills:
   - moai-foundation-core

--- a/internal/template/templates/.claude/agents/moai/researcher.md
+++ b/internal/template/templates/.claude/agents/moai/researcher.md
@@ -14,6 +14,7 @@ description: |
 tools: Read, Write, Edit, Grep, Glob, Bash
 model: opus
 permissionMode: acceptEdits
+isolation: worktree
 memory: project
 skills:
   - moai-foundation-core
@@ -45,7 +46,7 @@ You are the MoAI Researcher agent. You optimize moai-adk components through deli
 
 - ONE change at a time (autoresearch principle)
 - Binary evals only - pass or fail, no scales
-- All experiments in worktree isolation when possible
+- All experiments in worktree isolation (mandatory per SPEC-V3R2-ORC-004)
 - Check FrozenGuard before modifying any file
 - Log every experiment in `.moai/research/experiments/`
 - Stop when: target score reached 3x, max experiments hit, or stagnation detected

--- a/internal/template/templates/.claude/rules/moai/workflow/worktree-integration.md
+++ b/internal/template/templates/.claude/rules/moai/workflow/worktree-integration.md
@@ -132,8 +132,16 @@ Is this a one-shot sub-agent task?
 
 - [HARD] Implementation teammates in team mode (role_profiles: implementer, tester, designer) MUST use `isolation: "worktree"` when spawned via Agent()
 - [HARD] Read-only teammates (role_profiles: researcher, analyst, reviewer) MUST NOT use `isolation: "worktree"` — their `mode: "plan"` already prevents writes
-- [HARD] One-shot sub-agents that write files (expert-backend, expert-frontend, manager-develop) SHOULD use `isolation: "worktree"` when making cross-file changes
+- [HARD] Implementation agents that write files across 3 or more paths per invocation MUST use `isolation: worktree` in their frontmatter. This includes v3r2 agents manager-develop, expert-backend, expert-frontend, expert-refactoring, researcher, and team-mode role profiles implementer, tester, designer.
 - [HARD] GitHub workflow agents (fixer agents in /moai github issues) MUST use `isolation: "worktree"` for branch isolation
+
+### Sentinel Key Glossary
+
+The following sentinel keys are used by lint rules to enforce worktree isolation requirements:
+
+- `ORC_WORKTREE_REQUIRED`: Emitted by `moai workflow lint` when a write-heavy role profile (implementer, tester, designer) in workflow.yaml lacks `isolation: worktree`
+- `ORC_WORKTREE_MISSING`: Emitted by `moai agent lint` LR-05 when a write-heavy agent (manager-develop, expert-backend, expert-frontend, expert-refactoring, researcher) lacks `isolation: worktree` in frontmatter
+- `ORC_WORKTREE_ON_READONLY`: Emitted by `moai agent lint` LR-09 when a read-only agent (permissionMode: plan) incorrectly declares `isolation: worktree`
 
 ### When to Use Which
 


### PR DESCRIPTION
## Summary
- SPEC-V3R2-ORC-004 (Worktree MUST Rule) Milestone 1-3 implementation
- Added isolation: worktree requirement to write-heavy agent frontmatter (expert-backend, expert-frontend, expert-refactoring, manager-develop)
- Updated researcher role to explicitly exclude worktree isolation (read-only)
- Updated worktree-integration.md rule text with MUST/MUST NOT language

## Test plan
- [ ] Verify agent frontmatter contains correct isolation directives
- [ ] Verify worktree-integration.md rule text is consistent with CLAUDE.md §14
- [ ] go vet ./... passes
- [ ] go test ./... passes

🗿 MoAI <email@mo.ai.kr>