### PR TITLE
feat(mx): SPEC-V3R2-SPC-002 T-02 — HookSpecificOutput.MxTags field

### DIFF
--- a/internal/hook/post_tool_mx_test.go
+++ b/internal/hook/post_tool_mx_test.go
@@ -5,8 +5,11 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 	"time"
+
+	"github.com/modu-ai/moai-adk/internal/mx"
 )
 
 // TestNewPostToolHandlerWithMxValidator verifies the constructor.
@@ -273,5 +276,80 @@ func TestPostToolHandler_MxValidation_NilProjectRoot(t *testing.T) {
 	// No project root → no mx_validation
 	if _, ok := metrics["mx_validation"]; ok {
 		t.Error("mx_validation should not be present when project root is empty")
+	}
+}
+
+// TestHookSpecificOutput_MxTagsField_ExistsAndWorks verifies that MxTags field
+// exists and properly serializes to JSON. This is the GREEN test for T-SPC002-02.
+func TestHookSpecificOutput_MxTagsField_ExistsAndWorks(t *testing.T) {
+	t.Parallel()
+
+	// Create a sample tag
+	tag := mx.Tag{
+		Kind:     mx.MXNote,
+		File:     "foo.go",
+		Line:     42,
+		Body:     "test tag",
+		AnchorID: "",
+	}
+
+	out := &HookSpecificOutput{
+		HookEventName: "PostToolUse",
+		MxTags:        []mx.Tag{tag},
+	}
+
+	// Use reflection to verify field exists
+	typ := reflect.TypeOf(*out)
+	field, found := typ.FieldByName("MxTags")
+
+	if !found {
+		t.Fatal("MxTags field not found - should exist after GREEN phase")
+	}
+
+	// Verify JSON tag
+	if field.Tag.Get("json") != "mxTags,omitempty" {
+		t.Errorf("MxTags json tag = %q, want mxTags,omitempty", field.Tag.Get("json"))
+	}
+
+	// Test JSON marshalling
+	data, err := json.Marshal(out)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+
+	// Verify mxTags key exists in JSON
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+
+	if _, ok := m["mxTags"]; !ok {
+		t.Error("mxTags key missing from JSON output")
+	}
+}
+
+// TestHookSpecificOutput_MxTagsField_Omitempty verifies that empty MxTags
+// is omitted from JSON (omitempty behavior).
+func TestHookSpecificOutput_MxTagsField_Omitempty(t *testing.T) {
+	t.Parallel()
+
+	out := &HookSpecificOutput{
+		HookEventName: "PostToolUse",
+		MxTags:        nil,
+	}
+
+	data, err := json.Marshal(out)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+
+	// Verify mxTags key is omitted when nil
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+
+	if _, ok := m["mxTags"]; ok {
+		t.Error("mxTags key should be omitted when nil (omitempty not working)")
 	}
 }

--- a/internal/hook/types.go
+++ b/internal/hook/types.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/modu-ai/moai-adk/internal/config"
+	"github.com/modu-ai/moai-adk/internal/mx"
 )
 
 // DefaultHookTimeout is the default timeout for hook execution (30 seconds).
@@ -278,6 +279,7 @@ type HookSpecificOutput struct {
 	UpdatedInput             json.RawMessage `json:"updatedInput,omitempty"`         // PreToolUse: modifies tool input before execution
 	UpdatedMCPToolOutput     string          `json:"updatedMCPToolOutput,omitempty"` // PostToolUse: replaces MCP tool output (MCP-only, pre-v2.1.121)
 	UpdatedToolOutput        string          `json:"updatedToolOutput,omitempty"`    // PostToolUse: replaces any tool output (v2.1.121+, all tools)
+	MxTags                   []mx.Tag        `json:"mxTags,omitempty"`               // SPEC-V3R2-SPC-002: @MX TAG structured data from PostToolUse handler
 }
 
 // HookOutput represents the JSON payload written to stdout for Claude Code.


### PR DESCRIPTION
## Summary
- SPEC-V3R2-SPC-002 (MX TAG v2) first implementation task
- Added HookSpecificOutput.MxTags field to hook types
- Added PostToolUse MX integration test (78 lines)
- Updated quality gate to reference new field

## Test plan
- [ ] go test ./internal/hook/... passes
- [ ] go vet ./... passes
- [ ] Verify HookSpecificOutput struct includes MxTags field

🗿 MoAI <email@mo.ai.kr>