### PR TITLE
docs: SPEC-DOCS-SITE-001 M1 — Hextra migration skeleton

### DIFF
--- a/docs-site/content/en/advanced/catalog-system.md
+++ b/docs-site/content/en/advanced/catalog-system.md
@@ -1,0 +1,91 @@
+---
+title: 카탈로그 시스템
+weight: 80
+draft: false
+---
+
+3계층 카탈로그 매니페스트와 slim init으로 프로젝트 초기화를 최적화합니다.
+
+## 개요
+
+MoAI-ADK v2.15+의 카탈로그 시스템은 모든 에이전트, 스킬, 플러그인, 규칙을 **3계층
+매니페스트**로 관리합니다. `moai init --slim`을 통해 프로젝트에 필요한 최소 템플릿만
+배포하여 초기화 시간을 단축합니다.
+
+## 3계층 매니페스트
+
+| 계층 | 설명 | 배포 기준 |
+|------|------|----------|
+| **Tier 1 (Core)** | 핵심 인프라 — 오케스트레이터, 품질 게이트, 기본 스킬 | 항상 배포 |
+| **Tier 2 (Standard)** | 표준 확장 — 언어별 규칙, 프레임워크 스킬 | 프로젝트 언어/프레임워크 감지 시 |
+| **Tier 3 (Optional)** | 선택적 — 도메인 스킬, 플랫폼별 설정 | 명시적 요청 또는 프로젝트 설정 시 |
+
+## 카탈로그 파일
+
+카탈로그 매니페스트는 YAML 형식으로 정의됩니다:
+
+```yaml
+# 카탈로그 엔트리 예시
+- id: moai-workflow-tdd
+  tier: 1                    # 1=Core, 2=Standard, 3=Optional
+  type: skill
+  path: .claude/skills/moai/workflows/tdd.md
+  languages: []              # 빈 배열 = 모든 언어
+  frameworks: []
+  hash: abc123...             # 콘텐츠 해시 (무결성 검증)
+```
+
+## SlimFS 필터
+
+`moai init --slim`은 SlimFS 필터를 통해 배포 파일을 제한합니다:
+
+```bash
+# 전체 설치 (모든 계층)
+moai init my-project
+
+# Slim 설치 (Tier 1 + 감지된 Tier 2만)
+moai init --slim my-project
+```
+
+### 필터 로직
+
+1. Tier 1은 항상 포함
+2. 프로젝트 언어 감지 (Go, Python, TypeScript 등)
+3. 감지된 언어에 해당하는 Tier 2 항목만 포함
+4. Tier 3은 제외
+
+## Typed Loader
+
+`LoadCatalog()` 함수가 매니페스트를 타입 안전하게 로드합니다:
+
+- 3계층 분류 검증
+- 해시 무결성 검사 (Hash Sentinel)
+- 누락 필드 감지
+- 100% 테스트 커버리지
+
+## 카탈로그 활용
+
+### 프로젝트 초기화
+
+```bash
+# 일반 초기화 — 모든 템플릿 배포
+moai init my-project
+
+# Slim 초기화 — 최소 템플릿만 배포
+moai init --slim my-project
+```
+
+### 업데이트
+
+```bash
+# 카탈로그 기반 업데이트
+moai update                  # 모든 계층 업데이트
+moai update --slim           # slim 모드로 업데이트
+```
+
+## 관련 문서
+
+- [설치](/ko/getting-started/installation) — 설치 가이드
+- [초기 설정](/ko/getting-started/init-wizard) — init 마법사
+- [업데이트](/ko/getting-started/update) — 업데이트 가이드
+- [스킬 가이드](/ko/advanced/skill-guide) — 스킬 작성 가이드

--- a/docs-site/content/en/advanced/harness-profiles.md
+++ b/docs-site/content/en/advanced/harness-profiles.md
@@ -1,0 +1,104 @@
+---
+title: 하네스 프로필과 평가 시스템
+weight: 75
+draft: false
+---
+
+3계층 하네스 레벨과 4차원 평가 프로필을 통한 적응형 품질 검증 시스템입니다.
+
+## 개요
+
+MoAI-ADK의 하네스(Harness)는 **3계층 적응형 품질 검증 시스템**입니다. SPEC의 복잡도에
+따라 자동으로 검증 깊이를 조절합니다. evaluator-active 에이전트가 4차원 스코어링으로
+독립적이고 회의적인 품질 평가를 수행합니다.
+
+## 3계층 하네스 레벨
+
+| 레벨 | 설명 | 적용 시점 | evaluator-active |
+|------|------|----------|-----------------|
+| **minimal** | 빠른 검증 | 단순 변경 (typos, 설정 수정) | 생략 가능 |
+| **standard** | 기본 품질 검증 | 대부분의 작업 | 선택적 |
+| **thorough** | 전체 검증 + TRUST 5 | 복잡한 SPEC, 대규모 변경 | 필수 |
+
+하네스 레벨은 SPEC scope를 기반으로 **복잡도 추정기**(Complexity Estimator)가 자동으로
+결정합니다.
+
+## 4차원 스코어링
+
+evaluator-active는 4개 차원으로 점수를 매깁니다:
+
+| 차원 | 설명 | 기본 Must-Pass |
+|------|------|---------------|
+| **Functionality** | 기능 완성도 — 의도된 목적을 달성했는가 | 예 |
+| **Security** | 보안 — OWASP, 인증, 권한, 입력 검증 | 예 |
+| **Craft** | 코드 품질 — 가독성, 구조, 테스트 커버리지 | 아니오 |
+| **Consistency** | 일관성 — 프로젝트 규칙, 코드 스타일 준수 | 아니오 |
+
+### 점수 범위
+
+각 차원은 0.0 ~ 1.0 점수를 받습니다.
+
+### 루브릭 앵커
+
+모든 평가 기준은 4단계 루브릭 앵커를 가집니다:
+
+| 점수 | 수준 | 의미 |
+|------|------|------|
+| 0.25 | 미달 | 기본 요구사항 미충족 |
+| 0.50 | 부분 | 일부 충족, 개선 필요 |
+| 0.75 | 충족 | 대부분 충족, 소규모 개선 |
+| 1.00 | 우수 | 모든 기준 완벽 충족 |
+
+## 평가 프로필
+
+`.moai/config/evaluator-profiles/`에 4개 프로필이 제공됩니다:
+
+| 프로필 | 설명 | 적합한 경우 |
+|--------|------|------------|
+| `default.md` | 균형 잡힌 기본 프로필 | 대부분의 작업 |
+| `strict.md` | 엄격한 기준 | 보안 중요 작업 |
+| `lenient.md` | 관대한 기준 | 프로토타이핑 |
+| `frontend.md` | 프론트엔드 특화 | UI/UX 작업 |
+
+## 평가자 편향 방지 (5가지 메커니즘)
+
+평가자의 관대함을 방지하기 위해 5가지 메커니즘이 작동합니다:
+
+| # | 메커니즘 | 설명 |
+|---|---------|------|
+| 1 | **루브릭 앵커링** | 점수에 루브릭 정당화 필수 |
+| 2 | **회귀 베이스라인** | 이전 프로젝트 대비 과도한 점수 상승 감지 |
+| 3 | **Must-Pass 방화벽** | 필수 기준은 다른 영역 점수로 보상 불가 |
+| 4 | **독립 재평가** | 5번째마다 독립 재평가 (편차 > 0.10 시 재조정) |
+| 5 | **안티패턴 교차 검사** | 알려진 안티패턴 발견 시 해당 차원 점수 0.50 제한 |
+
+## Evaluator Memory Scope
+
+평가자의 판단 기억은 **반복별로 일시적**입니다. GAN Loop의 각 반복에서 evaluator-active는
+새 컨텍스트로 재시작되며, 이전 반복의 판단 근거는 새 프롬프트에 포함되지 않습니다.
+Sprint Contract 상태만이 반복 간에 유지됩니다.
+
+## 설정
+
+`.moai/config/sections/harness.yaml`에서 설정합니다:
+
+```yaml
+harness:
+  level: auto              # auto | minimal | standard | thorough
+  evaluator:
+    memory_scope: per_iteration   # FROZEN — 변경 불가
+    profiles:
+      default: .moai/config/evaluator-profiles/default.md
+      strict: .moai/config/evaluator-profiles/strict.md
+    aggregation: min              # min | mean
+    must_pass_dimensions:
+      - Functionality
+      - Security
+```
+
+## 관련 문서
+
+- [하네스 엔지니어링](/ko/core-concepts/harness-engineering) — 하네스 개념 개요
+- [TRUST 5 품질](/ko/core-concepts/trust-5) — 5가지 품질 기준
+- [Constitution 시스템](/ko/core-concepts/constitution) — FROZEN/Evolvable 규칙
+- [GAN Loop](/ko/design/gan-loop) — 디자인 품질 검증 반복

--- a/docs-site/content/en/advanced/hooks-reference.md
+++ b/docs-site/content/en/advanced/hooks-reference.md
@@ -1,0 +1,169 @@
+---
+title: Hooks 이벤트 레퍼런스
+weight: 60
+draft: false
+---
+
+MoAI-ADK v2.10.1 기준, Claude Code의 훅 시스템은 **27개 이벤트 타입**, **4가지 훅 타입**, **이벤트별 매처**, **스마트 동작**을 지원합니다.
+
+> 훅의 기본 개념과 설정 방법은 [Hooks 가이드](/ko/advanced/hooks-guide)를 참조하세요. 이 페이지는 이벤트 전체 레퍼런스입니다.
+
+## 훅 타입
+
+| 타입 | 설명 | 예시 |
+|------|------|------|
+| **command** | 셸 스크립트 실행 | `".claude/hooks/moai/handle-session-start.sh"` |
+| **prompt** | LLM 평가 | 프롬프트 텍스트를 LLM이 실행하여 결과 반환 |
+| **agent** | 서브에이전트 검증 | 에이전트가 작업을 검증하고 결과 반환 |
+| **http** | 웹훅 엔드포인트 | HTTP POST 요청으로 이벤트 전달 |
+
+## 이벤트 전체 레퍼런스 (27개)
+
+### 라이프사이클 이벤트
+
+| 이벤트 | 설명 | 매처 |
+|--------|------|------|
+| `SessionStart` | 세션 시작 | — |
+| `SessionEnd` | 세션 종료 | — |
+| `Stop` | 에이전트 정지 | — |
+| `SubagentStop` | 서브에이전트 정지 | — |
+| `SubagentStart` | 서브에이전트 시작 | — |
+| `StopFailure` | 정지 실패 | `errorType` |
+| `Setup` | 초기 설정 | — |
+
+### 도구 이벤트
+
+| 이벤트 | 설명 | 매처 |
+|--------|------|------|
+| `PreToolUse` | 도구 실행 전 | `toolName` |
+| `PostToolUse` | 도구 실행 후 | `toolName` |
+| `PostToolUseFailure` | 도구 실행 실패 | `toolName`, `errorType` |
+
+### 컨텍스트 이벤트
+
+| 이벤트 | 설명 | 매처 |
+|--------|------|------|
+| `PreCompact` | 컨텍스트 압축 전 | — |
+| `PostCompact` | 컨텍스트 압축 후 | — |
+| `InstructionsLoaded` | 인스트럭션 로드 완료 | — |
+
+### 입력 이벤트
+
+| 이벤트 | 설명 | 매처 |
+|--------|------|------|
+| `UserPromptSubmit` | 사용자 프롬프트 제출 | — |
+| `Elicitation` | Elicitation 시작 | — |
+| `ElicitationResult` | Elicitation 완료 | — |
+
+### 보안 이벤트
+
+| 이벤트 | 설명 | 매처 |
+|--------|------|------|
+| `PermissionRequest` | 권한 요청 | `toolName` |
+| `PermissionDenied` | 권한 거부 | `toolName` |
+
+### 팀 이벤트
+
+| 이벤트 | 설명 | 매처 |
+|--------|------|------|
+| `TeammateIdle` | 팀원 유휴 상태 전환 | — |
+| `TaskCompleted` | 태스크 완료 표시 | — |
+| `TaskCreated` | 태스크 생성 | — |
+
+### 워크트리 이벤트
+
+| 이벤트 | 설명 | 매처 |
+|--------|------|------|
+| `WorktreeCreate` | 워크트리 생성 | — |
+| `WorktreeRemove` | 워크트리 삭제 | — |
+
+### 환경 이벤트
+
+| 이벤트 | 설명 | 매처 |
+|--------|------|------|
+| `ConfigChange` | 설정 변경 | `configSource` |
+| `CwdChanged` | 작업 디렉터리 변경 | — |
+| `FileChanged` | 파일 변경 | — |
+
+### UI 이벤트
+
+| 이벤트 | 설명 | 매처 |
+|--------|------|------|
+| `Notification` | 사용자 알림 | — |
+
+## 스마트 동작 (Smart Behaviors)
+
+MoAI-ADK 훅은 단순 이벤트 처리를 넘어 지능적인 동작을 수행합니다:
+
+### PermissionDenied 자동 재시도
+
+읽기 전용 도구(Read, Grep, Glob)의 권한이 거부되면, 훅이 자동으로 재시도를 트리거합니다. 이는 백그라운드 에이전트에서 권한 프롬프트가 표시되지 않는 문제를 완화합니다.
+
+### StopFailure 에러 타입 응답
+
+에이전트 정지 실패 시 에러 타입에 따라 차별화된 응답을 제공합니다. 장시간 실행 세션에서의 안정성을 보장합니다.
+
+### PostCompact 세션 메모 복원
+
+컨텍스트 압축 후 중요한 세션 메모(진행 상태, SPEC 참조)를 자동으로 복원합니다. 이를 통해 컨텍스트 압축 시 핵심 정보 유실을 방지합니다.
+
+### SubagentStart 컨텍스트 주입
+
+서브에이전트 시작 시 필요한 컨텍스트(프로젝트 규칙, MX 태그, 진행 상태)를 자동 주입합니다.
+
+## 매처 (Matchers)
+
+매처를 사용하면 특정 조건에서만 훅이 실행되도록 필터링할 수 있습니다:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [{
+      "matcher": { "toolName": "Bash" },
+      "hooks": [{
+        "type": "command",
+        "command": "echo 'Bash tool detected'",
+        "timeout": 5
+      }]
+    }]
+  }
+}
+```
+
+### 사용 가능한 매처 필드
+
+| 매처 필드 | 적용 이벤트 | 설명 |
+|----------|-----------|------|
+| `toolName` | PreToolUse, PostToolUse, PostToolUseFailure, PermissionRequest, PermissionDenied | 도구 이름으로 필터 |
+| `errorType` | StopFailure, PostToolUseFailure | 에러 유형으로 필터 |
+| `configSource` | ConfigChange | 설정 소스로 필터 |
+
+## CLAUDE_ENV_FILE
+
+`CwdChanged`와 `FileChanged` 훅을 통해 환경 변수를 지속적으로 관리할 수 있습니다:
+
+```bash
+# .claude/hooks/moai/handle-cwd-changed.sh
+# CLAUDE_ENV_FILE을 통해 환경 변수 영속화
+echo "MOAI_PROJECT_DIR=$(pwd)" >> "$CLAUDE_ENV_FILE"
+```
+
+이를 통해 세션 간 환경 변수를 유지하고, 디렉터리 변경 시 자동으로 환경을 재설정할 수 있습니다.
+
+## MoAI-ADK가 사용하는 주요 훅
+
+| 이벤트 | MoAI 핸들러 | 역할 |
+|--------|-----------|------|
+| `SessionStart` | `handle-session-start.sh` | Statusline 초기화, 메트릭 세션 시작 |
+| `PostToolUse` | `handle-post-tool.sh` | Task 메트릭 로깅 |
+| `TeammateIdle` | `handle-teammate-idle.sh` | LSP 품질 게이트 검증 |
+| `TaskCompleted` | `handle-task-completed.sh` | SPEC 문서 존재 확인 |
+| `WorktreeCreate` | `handle-worktree-create.sh` | 워크트리 생성 로깅 |
+| `WorktreeRemove` | `handle-worktree-remove.sh` | 워크트리 삭제 로깅 |
+| `UserPromptSubmit` | `handle-user-prompt.sh` | 품질 게이트 자동 실행 |
+
+## 다음 단계
+
+- [Hooks 가이드](/ko/advanced/hooks-guide) — 훅 기본 개념과 설정 방법
+- [settings.json 가이드](/ko/advanced/settings-json) — settings.json 전체 레퍼런스
+- [CLI 레퍼런스](/ko/getting-started/cli) — `moai hook` 명령어 상세

--- a/docs-site/content/en/contributing/_index.md
+++ b/docs-site/content/en/contributing/_index.md
@@ -1,0 +1,7 @@
+---
+title: "Contributing"
+draft: true
+aliases: ["/ko/contributing/"]
+---
+
+This section is only available in Korean.

--- a/docs-site/content/en/core-concepts/constitution.md
+++ b/docs-site/content/en/core-concepts/constitution.md
@@ -1,0 +1,128 @@
+---
+title: Constitution 시스템
+weight: 35
+draft: false
+---
+
+MoAI-ADK의 불변 규칙(FROZEN)과 진화 가능한 규칙(Evolvable)을 관리하는 헌법적 제약 시스템입니다.
+
+## 개요
+
+MoAI-ADK는 **Constitution(헌법)** 시스템을 통해 AI 에이전트가 임의로 변경할 수 없는
+불변 제약(FROZEN Zone)과 학습을 통해 개선할 수 있는 진화 가능 제약(Evolvable Zone)을
+구분합니다. 이는 하네스 엔지니어링의 핵심 안전 메커니즘입니다.
+
+## FROZEN vs Evolvable
+
+### FROZEN Zone (불변)
+
+AI 에이전트가 절대 수정할 수 없는 규칙입니다. 인간 개발자만 변경할 수 있습니다.
+
+**대표 항목**:
+
+| 항목 | 설명 | 소스 |
+|------|------|------|
+| TRUST 5 | 5가지 품질 기준 | moai-constitution.md |
+| SPEC + EARS | 명세서 형식 | spec-workflow.md |
+| AskUserQuestion 독점 | 사용자 질문 채널 | agent-common-protocol.md |
+| 평가 차원 4개 | Functionality/Security/Craft/Consistency | harness/scorer.go |
+| 루브릭 앵커 4단계 | 0.25/0.50/0.75/1.00 | harness/rubric.go |
+| 통과 임계값 하한 | 최소 0.60 (낮출 수 없음) | design-constitution.md |
+| 디자인 파이프라인 순서 | manager-spec 먼저, evaluator-active 마지막 | design-constitution.md |
+
+### Evolvable Zone (진화 가능)
+
+학습(lessons)과 연구(research)를 통해 개선 제안이 가능한 규칙입니다.
+
+**대표 항목**:
+
+| 항목 | 설명 |
+|------|------|
+| 스킬 본문 내용 | moai-domain-* 스킬의 세부 내용 |
+| 파이프라인 가중치 | design.yaml의 phase_weights |
+| 반복 한계 | design.yaml의 iteration_limits |
+| 에이전트 행동 규칙 | Surface Assumptions, Enforce Simplicity 등 |
+
+## Zone Registry
+
+모든 HARD 조항을 열거하는 **단일 진실 공급원**(Single Source of Truth)입니다.
+
+### ID 할당 규칙
+
+```
+CONST-V3R2-NNN (3자리 이상 zero-padding)
+
+001-050: 기존 HARD 조항
+051-099: design constitution 미러 엔트리
+100-149: design overflow (자동 확장)
+150+: 신규 추가
+```
+
+### Canary Gate
+
+FROZEN 조항은 `canary_gate: true`를 가집니다. 변경 전 canary 검증이 필수입니다.
+
+```yaml
+# Zone Registry 엔트리 예시
+- id: CONST-V3R2-154
+  zone: Frozen
+  file: internal/harness/scorer.go
+  anchor: "#dimension-enum"
+  clause: "Dimension enum FROZEN at 4 values"
+  canary_gate: true
+```
+
+## 안전 아키텍처 (5계층)
+
+Constitution 시스템은 5계층 안전 아키텍처로 보호됩니다:
+
+### Layer 1: Frozen Guard
+
+쓰기 작업 전 대상 파일이 FROZEN zone이 아닌지 확인합니다. 위반 시 쓰기 차단 + 로깅 +
+사용자 알림.
+
+### Layer 2: Canary Check
+
+제안된 변경을 메모리에 적용하고 최근 3개 프로젝트를 재평가합니다. 점수 하락이
+0.10 초과하면 변경을 거부합니다.
+
+### Layer 3: Contradiction Detector
+
+새 학습이 기존 규칙과 충돌하면 양쪽을 모두 사용자에게 제시합니다. 자동 덮어쓰기는
+절대 발생하지 않습니다.
+
+### Layer 4: Rate Limiter
+
+진화 속도를 제한합니다:
+
+| 파라미터 | 기본값 | 설명 |
+|-----------|--------|------|
+| `max_evolution_rate_per_week` | 3 | 주간 최대 진화 횟수 |
+| `cooldown_hours` | 24 | 진화 간 최소 대기 시간 |
+| `max_active_learnings` | 50 | 활성 학습 항목 최대 수 |
+
+### Layer 5: Human Oversight
+
+`require_approval: true`인 경우 모든 진화 제안은 사용자 승인이 필요합니다.
+
+## CLI에서 활용
+
+```bash
+# 전체 registry 조회
+moai constitution list
+
+# Frozen zone 필터
+moai constitution list --zone frozen
+
+# 특정 파일 조항만 조회
+moai constitution list --file internal/harness/scorer.go
+
+# JSON 형식 출력
+moai constitution list --format json
+```
+
+## 관련 문서
+
+- [TRUST 5 품질](/ko/core-concepts/trust-5) — 5가지 품질 기준
+- [하네스 엔지니어링](/ko/core-concepts/harness-engineering) — 하네스 개념 개요
+- [SPEC 기반 개발](/ko/core-concepts/spec-based-dev) — SPEC 워크플로우

--- a/docs-site/content/en/core-concepts/harness-engineering.md
+++ b/docs-site/content/en/core-concepts/harness-engineering.md
@@ -1,0 +1,130 @@
+---
+title: 하네스 엔지니어링
+weight: 30
+draft: false
+---
+
+## 하네스 엔지니어링이란?
+
+MoAI-ADK는 **하네스 엔지니어링(Harness Engineering)** 패러다임을 구현합니다. 이는 개발자가 직접 코드를 작성하는 대신, **AI 에이전트가 최적의 코드를 생산할 수 있는 환경(하네스)을 설계**하는 접근 방식입니다.
+
+> "Human steers, agents execute."
+> — 엔지니어의 역할은 코드 작성에서 하네스 설계로 전환됩니다: SPEC, 품질 게이트, 피드백 루프.
+
+기존 바이브코딩은 AI에게 자유롭게 코드를 생성하게 한 뒤 결과를 수동으로 검토합니다. 하네스 엔지니어링은 반대입니다 — **규격(SPEC), 자동 검증, 지속적 피드백 루프**로 AI 에이전트를 가이드하여 일관된 품질의 코드를 생산합니다.
+
+## 7가지 핵심 컴포넌트
+
+```mermaid
+graph TB
+    subgraph Harness["🏗️ 하네스 엔지니어링"]
+        direction TB
+        SF["📐 Scaffolding First<br/>빈 파일 스텁 생성"] --> FC["✅ Failing Checklist<br/>수락 기준 태스크 등록"]
+        FC --> SV["🔄 Self-Verify Loop<br/>코드→테스트→수정→통과"]
+        SV --> GC["🗑️ Garbage Collection<br/>데드 코드 제거"]
+        GC --> CM["🗺️ Context Map<br/>아키텍처 문서 유지"]
+        CM --> SP["💾 Session Persistence<br/>세션 간 진행 추적"]
+        SP --> LA["🌐 Language-Agnostic<br/>16개 언어 자동 감지"]
+        LA --> SF
+    end
+
+    style Harness fill:#f0f7ff,stroke:#1565C0
+```
+
+각 컴포넌트는 MoAI의 특정 명령어에 매핑됩니다:
+
+| 컴포넌트 | 설명 | 명령어 |
+|----------|------|--------|
+| **Self-Verify Loop** | 에이전트가 코드 작성 → 테스트 → 실패 → 수정 → 통과 사이클을 자율적으로 반복 | [`/moai loop`](/ko/utility-commands/moai-loop) |
+| **Context Map** | 코드베이스 아키텍처 맵과 문서를 항상 에이전트에게 제공 | [`/moai codemaps`](/ko/quality-commands/moai-codemaps) |
+| **Session Persistence** | `progress.md`가 세션 간 완료된 단계를 추적하여 중단된 작업을 자동 재개 | [`/moai run SPEC-XXX`](/ko/workflow-commands/moai-run) |
+| **Failing Checklist** | 실행 시작 시 모든 수락 기준을 대기 태스크로 등록하고 구현 완료 시 체크 | [`/moai run SPEC-XXX`](/ko/workflow-commands/moai-run) |
+| **Language-Agnostic** | 16개 언어 지원: 언어를 자동 감지하고 올바른 LSP/린터/테스트/커버리지 도구 선택 | 모든 워크플로우 |
+| **Garbage Collection** | 데드 코드, AI 슬롭(slop), 사용하지 않는 import를 주기적으로 스캔하고 제거 | [`/moai clean`](/ko/utility-commands/moai-clean) |
+| **Scaffolding First** | 구현 전에 빈 파일 스텁을 먼저 생성하여 코드 엔트로피 방지 | [`/moai run SPEC-XXX`](/ko/workflow-commands/moai-run) |
+
+## 작동 원리
+
+### 1. Scaffolding First (스캐폴딩 우선)
+
+`/moai run`이 시작되면, 에이전트는 코드를 작성하기 전에 먼저 필요한 파일 구조를 생성합니다:
+
+```
+src/
+├── auth/
+│   ├── handler.go      ← 빈 스텁
+│   ├── handler_test.go  ← 빈 테스트
+│   ├── service.go       ← 빈 스텁
+│   └── service_test.go  ← 빈 테스트
+└── middleware/
+    └── jwt.go           ← 빈 스텁
+```
+
+이 방식은 에이전트가 무질서하게 파일을 생성하는 것을 방지하고, 일관된 프로젝트 구조를 유지합니다.
+
+### 2. Failing Checklist (실패 체크리스트)
+
+SPEC의 수락 기준이 자동으로 태스크 목록에 등록됩니다:
+
+```
+- [ ] JWT 토큰 생성 엔드포인트
+- [ ] 토큰 검증 미들웨어
+- [ ] 리프레시 토큰 로직
+- [ ] 만료된 토큰 처리
+- [ ] 85%+ 테스트 커버리지
+```
+
+각 항목이 구현되고 테스트를 통과하면 체크됩니다. 모든 항목이 체크되어야 작업이 완료됩니다.
+
+### 3. Self-Verify Loop (자기검증 루프)
+
+에이전트가 자율적으로 실행하는 핵심 사이클:
+
+```mermaid
+graph LR
+    A["코드 작성"] --> B["테스트 실행"]
+    B --> C{"통과?"}
+    C -->|"실패"| D["에러 분석"]
+    D --> A
+    C -->|"통과"| E["다음 항목"]
+```
+
+이 루프는 `/moai loop`에서 최대 100회까지 반복되며, 수렴 감지(같은 에러 반복 시 대안 전략 적용)를 포함합니다.
+
+### 4. Context Map (컨텍스트 맵)
+
+`/moai codemaps`가 생성하는 아키텍처 문서는 에이전트에게 코드베이스의 전체 구조를 제공합니다. 이를 통해 에이전트는:
+
+- 기존 코드와 충돌하지 않는 구현 방법을 선택
+- 적절한 패턴과 규칙을 따름
+- 의존성 관계를 이해하고 영향 범위를 파악
+
+### 5. Session Persistence (세션 지속성)
+
+Claude Code 세션이 중단되더라도 `progress.md`가 완료된 단계를 기록합니다:
+
+```markdown
+## Progress
+- [x] Phase 1: 분석 완료
+- [x] Phase 2: 핸들러 구현
+- [ ] Phase 3: 테스트 작성 ← 여기서 재개
+- [ ] Phase 4: 리팩토링
+```
+
+`/moai run --resume SPEC-XXX`로 중단된 지점부터 자동으로 재개됩니다.
+
+## 전통적 개발 vs 하네스 엔지니어링
+
+| 관점 | 전통적 개발 | 하네스 엔지니어링 |
+|------|-----------|-----------------|
+| **개발자 역할** | 코드 작성자 | 환경 설계자 |
+| **코드 생산** | 수동 작성 | AI 에이전트 자동 생산 |
+| **품질 보증** | 사후 리뷰 | 내장된 자동 검증 루프 |
+| **세션 연속성** | 수동 메모 | 자동 진행 추적 |
+| **코드 정리** | 기술 부채 누적 | 자동 가비지 컬렉션 |
+| **문서화** | 별도 작업 | 자동 아키텍처 맵 생성 |
+
+## 다음 단계
+
+- [SPEC 기반 개발](/ko/core-concepts/spec-based-dev) — 하네스의 입력이 되는 SPEC 문서 작성법
+- [TRUST 5 품질](/ko/core-concepts/trust-5) — 하네스가 검증하는 5가지 품질 기준

--- a/docs-site/content/en/getting-started/profile.md
+++ b/docs-site/content/en/getting-started/profile.md
@@ -1,0 +1,102 @@
+---
+title: 프로필 관리
+weight: 80
+draft: false
+---
+
+MoAI-ADK의 프로필 시스템으로 여러 Claude Code 설정을 격리하여 관리합니다.
+
+## 프로필이란?
+
+프로필은 **격리된 Claude Code 설정 디렉토리**(`CLAUDE_CONFIG_DIR`)입니다. 프로필별로 독립적인 설정, 모델 선택, 언어 환경을 유지할 수 있습니다.
+
+```
+~/.moai/claude-profiles/
+├── default/           # 기본 프로필
+│   ├── settings.json
+│   └── settings.local.json
+├── work/              # 업무용 프로필
+│   ├── settings.json
+│   └── settings.local.json
+└── personal/          # 개인용 프로필
+    └── ...
+```
+
+## 명령어 레퍼런스
+
+### moai profile list
+
+사용 가능한 모든 프로필을 표시합니다.
+
+```bash
+moai profile list
+```
+
+### moai profile setup [name]
+
+인터랙티브 설정 위자드를 실행합니다.
+
+```bash
+moai profile setup          # 기본 프로필 설정
+moai profile setup work     # "work" 프로필 설정
+```
+
+**위자드 설정 항목:**
+- **Identity**: 사용자 이름, 역할
+- **Languages**: 대화 언어, 코드 주석 언어
+- **Model Settings**: 기본 모델, 1M 컨텍스트 모델 선택
+- **Display**: 출력 스타일, 상태 표시줄 설정
+
+### moai profile current
+
+현재 활성 프로필 이름을 표시합니다.
+
+```bash
+moai profile current
+```
+
+### moai profile delete [name]
+
+프로필을 삭제합니다.
+
+```bash
+moai profile delete old-profile
+```
+
+## 프로필로 Claude Code 실행
+
+`-p` (또는 `--profile`) 플래그로 프로필을 지정합니다.
+
+```bash
+moai cc -p work          # work 프로필로 Claude 실행
+moai glm -p cost-save    # cost-save 프로필로 GLM 실행
+moai cg -p team          # team 프로필로 CG 모드 실행
+```
+
+{{< callout type="info" >}}
+프로필 미지정 시 기본 프로필이 사용됩니다. 첫 실행 시 자동으로 설정 위자드가 시작됩니다.
+{{< /callout >}}
+
+## 1M 컨텍스트 모델 선택
+
+프로필 설정 시 1M 컨텍스트 윈도우를 지원하는 모델을 선택할 수 있습니다.
+
+**지원 모델:**
+- `claude-opus-4-6[1m]` - Opus 4.6 (1M context)
+- `claude-sonnet-4-6[1m]` - Sonnet 4.6 (1M context)
+
+설정 위자드에서 "Model Settings" 단계에서 선택하거나, 프로필 설정 파일을 직접 수정합니다.
+
+## 프로필 전환 시 동작
+
+| 전환 | 동작 |
+|------|------|
+| `moai cc` → `moai glm` | GLM 환경 변수 자동 주입 |
+| `moai glm` → `moai cc` | GLM 환경 변수 자동 제거 |
+| `moai cc` → `moai cg` | GLM env를 tmux 세션에만 주입, Leader는 Claude 유지 |
+
+## 관련 문서
+
+- [CLI 레퍼런스](/getting-started/cli) - 전체 CLI 명령어
+- [빠른 시작](/getting-started/quickstart) - 처음 시작하기
+- [초기 설정](/getting-started/init-wizard) - 프로젝트 초기화

--- a/docs-site/content/en/getting-started/windows-guide.md
+++ b/docs-site/content/en/getting-started/windows-guide.md
@@ -1,0 +1,146 @@
+---
+title: Windows 사용 가이드
+weight: 40
+draft: false
+---
+
+## 지원 환경
+
+| 환경 | 지원 여부 | 비고 |
+|------|----------|------|
+| **WSL (권장)** | ✅ 완전 지원 | 최적의 경험 |
+| **PowerShell 7.x+** | ✅ 지원 | 대안 환경 |
+| PowerShell 5.x (레거시) | ❌ 미지원 | Windows PowerShell |
+| cmd.exe | ❌ 미지원 | 명령 프롬프트 |
+
+**필수 요구사항:**
+- [Git for Windows](https://gitforwindows.org/) 설치 필수
+- WSL 또는 PowerShell 7.x 이상
+
+## 설치 방법
+
+### WSL (권장)
+
+WSL은 Windows에서 Linux 환경을 제공하며, MoAI-ADK의 모든 기능을 완벽하게 지원합니다.
+
+```bash
+# WSL 설치 (관리자 PowerShell에서 실행)
+wsl --install
+
+# WSL 내에서 MoAI-ADK 설치
+curl -fsSL https://raw.githubusercontent.com/modu-ai/moai-adk/main/install.sh \
+  | bash
+```
+
+### PowerShell 7.x+
+
+> **참고**: 최적의 경험을 위해 WSL 사용을 권장합니다.
+
+```powershell
+irm https://raw.githubusercontent.com/modu-ai/moai-adk/main/install.ps1 | iex
+```
+
+## 한글 사용자명 경로 에러
+
+### 문제 현상
+
+Windows 사용자명에 한글, 중국어 등 비-ASCII 문자가 포함된 경우, `EINVAL` 에러가 발생할 수 있습니다. 이는 Windows의 8.3 짧은 파일명 변환 과정에서 발생하는 문제입니다.
+
+```
+Error: EINVAL: invalid argument, open 'C:\Users\홍길동\AppData\Local\Temp\...'
+```
+
+### 해결 방법 1: 대체 임시 디렉터리 설정 (권장)
+
+ASCII 문자만 포함된 경로에 임시 디렉터리를 생성합니다:
+
+```bash
+# Command Prompt
+set MOAI_TEMP_DIR=C:\temp
+mkdir C:\temp 2>/dev/null
+```
+
+```powershell
+# PowerShell
+$env:MOAI_TEMP_DIR="C:\temp"
+New-Item -ItemType Directory -Path "C:\temp" -Force
+```
+
+환경 변수를 영구적으로 설정하려면 시스템 환경 변수에 `MOAI_TEMP_DIR`을 추가하세요.
+
+### 해결 방법 2: 8.3 파일명 생성 비활성화
+
+관리자 권한으로 실행:
+
+```bash
+fsutil 8dot3name set 1
+```
+
+> **주의**: 이 설정은 시스템 전체에 영향을 미칩니다. 일부 레거시 프로그램이 영향을 받을 수 있습니다.
+
+### 해결 방법 3: ASCII 사용자 계정 생성
+
+영어 이름으로 새 Windows 사용자 계정을 생성하면 경로 문제를 근본적으로 해결합니다.
+
+## WSL 설정 가이드
+
+### WSL 설치
+
+```powershell
+# 관리자 PowerShell에서 실행
+wsl --install
+
+# 기본 배포판: Ubuntu (권장)
+# 재시작 후 사용자명 및 비밀번호 설정
+```
+
+### 프로젝트 파일 접근
+
+WSL에서 Windows 파일에 접근:
+
+```bash
+# Windows 파일시스템 접근
+cd /mnt/c/Users/사용자명/projects/
+
+# WSL 네이티브 파일시스템 사용 (더 빠름)
+cd ~/projects/
+```
+
+> **성능 팁**: WSL 네이티브 파일시스템(`~/` 하위)에서 작업하면 크로스 파일시스템 오버헤드 없이 최적의 성능을 얻을 수 있습니다.
+
+### VS Code 연동
+
+1. VS Code에 [WSL 확장](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-wsl) 설치
+2. WSL 터미널에서 `code .` 실행
+3. VS Code가 자동으로 WSL 모드로 열림
+
+## CG 모드에서의 tmux 사용
+
+[CG 모드](/ko/multi-llm/cg-mode)를 사용하려면 tmux가 필요합니다. WSL에서 설치:
+
+```bash
+# Ubuntu/Debian
+sudo apt install tmux
+
+# tmux 세션 시작
+tmux new -s moai
+
+# CG 모드 실행
+moai cg
+```
+
+## 문제 해결
+
+| 문제 | 원인 | 해결 |
+|------|------|------|
+| `moai: command not found` | PATH에 Go bin 디렉터리 미포함 | `export PATH="$HOME/go/bin:$PATH"`를 `.bashrc`에 추가 |
+| `EINVAL` 에러 | 한글 사용자명 | 위의 [한글 사용자명 경로 에러](#한글-사용자명-경로-에러) 참조 |
+| 권한 거부 | 설치 스크립트 권한 | `chmod +x install.sh` 후 재실행 |
+| Git 명령 실패 | Git for Windows 미설치 | [Git for Windows](https://gitforwindows.org/) 설치 |
+| tmux 없음 | CG 모드 실행 불가 | `sudo apt install tmux` (WSL에서) |
+
+## 다음 단계
+
+- [설치](/ko/getting-started/installation) — 설치 상세 가이드
+- [초기 설정](/ko/getting-started/init-wizard) — 프로젝트 초기화
+- [CG 모드](/ko/multi-llm/cg-mode) — Claude + GLM 하이브리드 모드

--- a/docs-site/content/en/guides/ci-autonomy.md
+++ b/docs-site/content/en/guides/ci-autonomy.md
@@ -1,0 +1,108 @@
+---
+title: 자율 CI/CD 가이드
+weight: 10
+draft: false
+---
+
+MoAI-ADK의 자율 CI/CD 시스템으로 풀리퀘스트 품질을 자동으로 관리합니다.
+
+## 개요
+
+SPEC-V3R3-CI-AUTONOMY-001에서 도입된 자율 CI/CD 시스템은 8개 티어로 구성된
+품질 자동화 인프라입니다. pre-push hook부터 auto-fix 루프까지, 개발자가 수동으로
+품질을 검증할 필요 없이 CI가 자동으로 품질을 보장합니다.
+
+## 8-Tier 아키텍처
+
+| Tier | 이름 | 우선순위 | 설명 |
+|------|------|----------|------|
+| T1 | Pre-push Hook | P0 | push 전 자동 품질 검증 |
+| T2 | Branch Protection | P0 | main 브랜치 보호 규칙 |
+| T3 | Auto-fix Loop | P1 | CI 실패 시 자동 수정 |
+| T4 | Auxiliary Workflows | P2 | 보조 워크플로우 정리 |
+| T5 | Worktree State Guard | P1 | 워크트리 상태 무결성 보장 |
+| T6 | i18n Validator | P2 | 4개국어 문서 일관성 검증 |
+| T7 | BODP | P0 | 브랜치 원점 결정 프로토콜 |
+| T8 | Release Workflow | P1 | 릴리스 자동화 |
+
+## Pre-push Hook (T1)
+
+push 전에 로컬에서 자동으로 품질 검증을 실행합니다.
+
+```bash
+# 자동 설치됨 (moai init / moai update 시)
+.git/hooks/pre-push → moai hook pre-push
+```
+
+실행되는 검증:
+
+- `go vet` / `golangci-lint` (프로젝트 언어에 따라 자동 감지)
+- `go test ./...` (테스트 스위트)
+- MX 태그 무결성 검사
+
+## Auto-fix Loop (T3)
+
+CI 실패 시 `/moai loop`를 자동으로 호출하여 에러를 수정합니다.
+
+```yaml
+# .github/workflows/ci.yml (자동 생성)
+- name: Auto-fix on failure
+  if: failure()
+  run: |
+    claude -p "/moai loop --max-iterations 3"
+```
+
+## BODP — Branch Origin Decision Protocol (T7)
+
+새 브랜치/워크트리를 생성할 때 base branch를 자동으로 결정합니다.
+
+### 3-Signal 평가
+
+| 시그널 | 출처 | 의미 |
+|--------|------|------|
+| Signal A | SPEC `depends_on` + diff path overlap | 코드 의존성 |
+| Signal B | `git status`에서 `.moai/specs/<NewSpecID>/` 매칭 | 작업 트리 동위치 |
+| Signal C | `gh pr list --head <branch> --state open` ≥ 1 | 현재 브랜치 PR |
+
+### 결정 매트릭스
+
+| 시그널 | 결정 |
+|--------|------|
+| A만 있음 | `stacked` — 현재 브랜치 기반 |
+| B 있음 | `continue` — 현재 컨텍스트에서 계속 |
+| C만 있음 | `stacked` — 현재 브랜치 기반 |
+| 아무것도 없음 | `main` — origin/main 기반 |
+
+### 감사 추적
+
+모든 BODP 결정은 `.moai/branches/decisions/<branch-name>.md`에 기록됩니다.
+
+## i18n Validator (T6)
+
+4개국어 문서의 일관성을 자동 검증합니다.
+
+```bash
+scripts/docs-i18n-check.sh
+```
+
+검증 항목:
+
+- 4개 locale 간 파일 개수/경로 일치
+- front matter `title` 존재
+- H1 heading 존재
+- MoAI 용어집 준수
+
+## Worktree State Guard (T5)
+
+워크트리의 상태 무결성을 보장합니다:
+
+- 커밋되지 않은 변경 감지
+- 워크트리와 메인 브랜치 동기화 상태 확인
+- `moai status`에서 상태 표시
+
+## 관련 문서
+
+- [워크트리 가이드](/ko/worktree/guide) — Git Worktree 완벽 가이드
+- [/moai loop](/ko/utility-commands/moai-loop) — 반복 수정 루프
+- [/moai fix](/ko/utility-commands/moai-fix) — 자동 에러 수정
+- [멀티 LLM CI](/ko/guides/multi-llm-ci) — Multi-LLM CI 통합

--- a/docs-site/content/en/multi-llm/_index.md
+++ b/docs-site/content/en/multi-llm/_index.md
@@ -1,0 +1,7 @@
+---
+title: "Multi-LLM Mode"
+draft: true
+aliases: ["/ko/multi-llm/"]
+---
+
+This section is only available in Korean.

--- a/docs-site/content/en/multi-llm/cg-mode.md
+++ b/docs-site/content/en/multi-llm/cg-mode.md
@@ -1,0 +1,7 @@
+---
+title: "CG Mode"
+draft: true
+aliases: ["/ko/multi-llm/cg-mode"]
+---
+
+This page is only available in Korean.

--- a/docs-site/content/en/multi-llm/model-policy.md
+++ b/docs-site/content/en/multi-llm/model-policy.md
@@ -1,0 +1,7 @@
+---
+title: "Model Policy"
+draft: true
+aliases: ["/ko/multi-llm/model-policy"]
+---
+
+This page is only available in Korean.

--- a/docs-site/content/en/workflow-commands/moai-brain.md
+++ b/docs-site/content/en/workflow-commands/moai-brain.md
@@ -1,0 +1,94 @@
+---
+title: /moai brain
+weight: 25
+draft: false
+---
+
+모호한 아이디어를 검증된 제안으로 변환하는 7단계 아이디에이션 워크플로우입니다.
+
+{{< callout type="info" >}}
+**슬래시 커맨드**: Claude Code에서 `/moai:brain`을 입력하면 이 명령어를 바로 실행할 수 있습니다.
+{{< /callout >}}
+
+## 개요
+
+`/moai brain`은 `/moai plan` **이전**에 실행하는 사전 명세 워크플로우입니다. 아직 구체화되지
+않은 아이디어를 7단계 파이프라인을 통해 검증된 제안으로 변환합니다. 최종 산출물은 Claude Design
+핸드오프 패키지이며, 이후 `/moai design` 또는 `/moai project` → `/moai plan`으로 이어집니다.
+
+### 워크플로우 위치
+
+```
+brain (1회) → [claude.com Design] → design Path A → project (1회) → plan (SPEC별) → run → sync
+```
+
+## 7단계 파이프라인
+
+| 단계 | 이름 | 설명 | 산출물 |
+|------|------|------|--------|
+| 1 | **Discovery** | 소크라테스식 인터뷰로 아이디어 구체화 (최대 5라운드) | interview notes |
+| 2 | **Diverge** | 가능한 접근 방식을 확장하여 탐색 | diverge notes |
+| 3 | **Research** | WebSearch + Context7 병렬 조사 | research.md |
+| 4 | **Converge** | 탐색 결과를 최적 접근법으로 수렴 | converge notes |
+| 5 | **Critical Evaluation** | First Principles + 비판적 평가 | evaluation notes |
+| 6 | **Proposal** | SPEC 분해 후보가 포함된 제안서 조립 | proposal.md |
+| 7 | **Handoff** | Claude Design 5파일 핸드오프 패키지 생성 | 5-file bundle |
+
+## 입력
+
+`/moai brain <아이디어>` — 아이디어는 어떤 언어, 어떤 형태, 어떤 수준의 구체성이든 가능합니다.
+
+```bash
+# 예시
+/moai brain "AI 코드 리뷰어 만들고 싶어"
+/moai brain "E-commerce 플랫폼의 결제 시스템을 개선하고 싶다"
+/moai brain "모바일 앱 푸시 알림 시스템"
+```
+
+## IDEA-NNN 자동 증가
+
+워크플로우 시작 시 `.moai/brain/IDEA-NNN/` 디렉터리가 자동 생성됩니다.
+
+```
+.moai/brain/
+├── IDEA-001/     # 첫 번째 아이디어
+│   ├── interview.md
+│   ├── research.md
+│   ├── proposal.md
+│   └── handoff/
+├── IDEA-002/     # 두 번째 아이디어
+│   └── ...
+```
+
+- 기존 IDEA 번호의 최대값 + 1로 자동 증가
+- 3자리 zero-padding (IDEA-001, IDEA-002, ...)
+- 중간에 중단된 경우 이어하기 제안
+
+## 브랜드 컨텍스트 연동
+
+`.moai/project/brand/`가 존재하면 브랜드 컨텍스트를 자동으로 로드하여 제안서에 반영합니다.
+
+## Claude Design 핸드오프 (Phase 7)
+
+Phase 7에서 생성되는 5파일 핸드오프 패키지:
+
+| 파일 | 내용 |
+|------|------|
+| `prompt.md` | Claude Design 세션 프롬프트 |
+| `context.md` | 프로젝트 컨텍스트 |
+| `references.md` | 조사 결과 참고 자료 |
+| `acceptance.md` | 수락 기준 |
+| `checklist.md` | 디자인 체크리스트 |
+
+이 패키지는 claude.com Design 세션에 직접 붙여넣어 사용할 수 있습니다.
+
+## 이어하기 (Resume)
+
+이전에 중단된 IDEA가 있으면 자동으로 감지하여 이어하기를 제안합니다.
+
+## 관련 문서
+
+- [/moai design](/ko/workflow-commands/moai-design) — Claude Design 핸드오프 수행
+- [/moai project](/ko/workflow-commands/moai-project) — 프로젝트 초기 설정
+- [/moai plan](/ko/workflow-commands/moai-plan) — SPEC 문서 생성
+- [디자인 시스템](/ko/design/getting-started) — 디자인 파이프라인 개요

--- a/docs-site/content/en/workflow-commands/moai-db.md
+++ b/docs-site/content/en/workflow-commands/moai-db.md
@@ -1,0 +1,100 @@
+---
+title: /moai db
+weight: 50
+draft: false
+---
+
+프로젝트 데이터베이스 메타데이터를 관리하는 워크플로우 명령어입니다.
+
+{{< callout type="info" >}}
+**슬래시 커맨드**: Claude Code에서 `/moai:db`을 입력하면 이 명령어를 바로 실행할 수 있습니다.
+{{< /callout >}}
+
+## 개요
+
+`/moai db`는 데이터베이스 스키마, 마이그레이션, 시드를 관리하는 4개 하위 명령어를
+제공합니다. 대화형 인터뷰로 DB 엔진, ORM, 멀티테넌트 설정을 구성하고
+`.moai/project/db/` 아티팩트를 생성합니다.
+
+## 하위 명령어
+
+| 명령어 | 설명 | 읽기 전용 |
+|--------|------|-----------|
+| `init` | 대화형 초기 설정 | 아니오 |
+| `refresh` | 마이그레이션 재스캔 + 스키마 문서 재생성 | 아니오 |
+| `verify` | 드리프트 감지 (스키마 vs 마이그레이션) | 예 |
+| `list` | 테이블 목록 출력 | 예 |
+
+```bash
+/moai db init       # 대화형 설정 마법사
+/moai db refresh    # 마이그레이션 재스캔
+/moai db verify     # 드리프트 검사
+/moai db list       # 테이블 목록
+/moai db            # 하위 명령어 선택
+```
+
+## init — 대화형 초기 설정
+
+### Phase 1: 사전 확인
+
+기존 `.moai/project/db/` 확인 후 인터뷰를 진행합니다.
+
+### Phase 2: 인터뷰
+
+AskUserQuestion으로 다음 항목을 설정합니다:
+
+- **DB 엔진**: PostgreSQL, MySQL, SQLite, MongoDB 등
+- **ORM**: Prisma, TypeORM, SQLAlchemy, GORM 등
+- **멀티테넌트**: 스키마 분리 / 행 수준 분리 / 단일 테넌트
+- **마이그레이션 도구**: 선택한 ORM의 기본 도구 또는 커스텀
+
+### Phase 3: 템플릿 렌더링
+
+`.moai/project/db/` 디렉터리에 다음 파일을 생성합니다:
+
+```
+.moai/project/db/
+├── schema.md          # 스키마 문서 (Markdown)
+├── migrations.md      # 마이그레이션 추적
+└── seeds.md           # 시드 데이터 가이드
+```
+
+## refresh — 마이그레이션 재스캔
+
+마이그레이션 파일을 다시 스캔하고 스키마 문서를 재생성합니다.
+
+- 새 마이그레이션 파일 감지
+- `schema.md` 자동 업데이트
+- 변경사항 요약 출력
+
+## verify — 드리프트 검사
+
+`schema.md`의 테이블 목록과 실제 마이그레이션 파일을 비교합니다.
+
+- **일치**: 종료 코드 0
+- **드리프트 감지**: 종료 코드 1 + 상세 보고서
+
+CI 파이프라인에서 사용하여 스키마 동기화를 검증할 수 있습니다.
+
+```yaml
+# GitHub Actions 예시
+- name: DB Schema Drift Check
+  run: claude -p "/moai db verify"
+```
+
+## list — 테이블 목록
+
+`schema.md`의 모든 테이블을 Markdown 정렬 표로 출력합니다.
+
+## --mode 호환성
+
+이 명령어는 Multi-Mode Router의 `--mode` 축에 참여하지 않습니다. `--mode` 값을
+전달하면 조용히 무시됩니다. 단, `--mode pipeline`은 `MODE_PIPELINE_ONLY_UTILITY`
+오류를 발생시킵니다.
+
+## 관련 문서
+
+- [데이터베이스 시작하기](/ko/db/getting-started) — DB 관리 상세 가이드
+- [스키마 동기화](/ko/db/schema-sync) — 스키마 동기화 패턴
+- [마이그레이션 패턴](/ko/db/migration-patterns) — 마이그레이션 전략
+- [/moai plan](/ko/workflow-commands/moai-plan) — SPEC 문서 생성

--- a/docs-site/content/en/workflow-commands/moai-design.md
+++ b/docs-site/content/en/workflow-commands/moai-design.md
@@ -1,0 +1,106 @@
+---
+title: /moai design
+weight: 26
+draft: false
+---
+
+하이브리드 디자인 워크플로우로 브랜드 중심의 웹 경험을 생성합니다.
+
+{{< callout type="info" >}}
+**슬래시 커맨드**: Claude Code에서 `/moai:design`을 입력하면 이 명령어를 바로 실행할 수 있습니다.
+{{< /callout >}}
+
+## 개요
+
+`/moai design`은 자연어 브리프를 브랜드 일관성이 있는 웹 경험으로 변환하는 하이브리드
+디자인 워크플로우입니다. 3가지 경로를 지원합니다:
+
+| 경로 | 설명 | 적합한 경우 |
+|------|------|------------|
+| **Path A** | Claude Design 핸드오프 | claude.com Design 세션 사용 |
+| **Path B1** | Figma → 디자인 토큰 | 기존 Figma 디자인 있는 경우 |
+| **Path B2** | Pencil MCP → 디자인 토큰 | Pencil 파일로 작업하는 경우 |
+| **Path B-Common** | 코드 기반 브랜드 디자인 | 처음부터 시작하는 경우 |
+
+## --mode 플래그
+
+SPEC-V3R2-WF-003의 Multi-Mode Router를 지원합니다.
+
+| 모드 | 설명 |
+|------|------|
+| `autopilot` (기본) | Path B — 코드 기반 브랜드 디자인 자동 실행 |
+| `import` | Path A — Claude Design 핸드오프 번들 가져오기 |
+| `team` | Path B를 병렬 팀으로 실행 (Agent Teams 필요) |
+
+```bash
+/moai design                          # 경로 선택 AskUserQuestion
+/moai design --mode autopilot         # Path B 즉시 실행
+/moai design --mode import            # Path A 핸드오프 가져오기
+/moai design --mode team              # Path B 병렬 실행
+```
+
+## 실행 전 조건 확인
+
+### 브랜드 컨텍스트
+
+`.moai/project/brand/`에 3개 파일이 필요합니다:
+
+```
+.moai/project/brand/
+├── brand-voice.md       # 브랜드 톤, 용어, 메시지 가이드
+├── visual-identity.md   # 색상, 타이포그래피, 시각 언어
+└── target-audience.md   # 타겟 고객 프로필
+```
+
+파일이 없거나 `_TBD_` 마커가 있으면 브랜드 인터뷰가 먼저 진행됩니다.
+
+### Agency 데이터 감지
+
+기존 `.agency/` 디렉터리가 있으면 마이그레이션을 제안합니다:
+
+```bash
+moai migrate agency --dry-run   # 미리보기
+moai migrate agency             # 실행
+```
+
+## 파이프라인 아키텍처
+
+```
+manager-spec → [copywriting, brand-design] (병렬) → expert-frontend → evaluator-active
+                                                                       ↑              |
+                                                                       └──────────────┘
+                                                                  GAN Loop (최대 5회)
+```
+
+1. **manager-spec** — 브리프 문서 생성 (Goal/Audience/Brand 섹션)
+2. **copywriting + brand-design** — 카피 JSON + 디자인 토큰 (병렬 실행)
+3. **expert-frontend** — 코드 구현
+4. **evaluator-active** → **GAN Loop** — 품질 검증 반복
+
+## GAN Loop
+
+Builder-Evaluator 반복 루프가 품질을 보장합니다.
+
+| 파라미터 | 기본값 | 설명 |
+|-----------|--------|------|
+| `pass_threshold` | 0.75 | 통과 임계값 (최소 0.60) |
+| `max_iterations` | 5 | 최대 반복 횟수 |
+| `escalation_after` | 3 | 사용자 개입 요청 시점 |
+| `improvement_threshold` | 0.05 | 정체 감지 임계값 |
+
+## Sprint Contract
+
+`--mode team` 또는 `thorough` 하네스 레벨에서는 Sprint Contract가 협상됩니다:
+
+1. evaluator-active가 수락 체크리스트 생성
+2. expert-frontend가 체크리스트 리뷰
+3. 구현 → 평가 반복
+4. 통과한 기준은 다음 반복에서도 유지 (회귀 불가)
+
+## 관련 문서
+
+- [디자인 시작하기](/ko/design/getting-started) — 디자인 시스템 개요
+- [Claude Design 핸드오프](/ko/design/claude-design-handoff) — Path A 상세 가이드
+- [코드 기반 경로](/ko/design/code-based-path) — Path B 상세 가이드
+- [GAN Loop](/ko/design/gan-loop) — 품질 검증 상세
+- [/moai brain](/ko/workflow-commands/moai-brain) — 아이디에이션 워크플로우

--- a/docs-site/content/ja/advanced/catalog-system.md
+++ b/docs-site/content/ja/advanced/catalog-system.md
@@ -1,0 +1,91 @@
+---
+title: 카탈로그 시스템
+weight: 80
+draft: false
+---
+
+3계층 카탈로그 매니페스트와 slim init으로 프로젝트 초기화를 최적화합니다.
+
+## 개요
+
+MoAI-ADK v2.15+의 카탈로그 시스템은 모든 에이전트, 스킬, 플러그인, 규칙을 **3계층
+매니페스트**로 관리합니다. `moai init --slim`을 통해 프로젝트에 필요한 최소 템플릿만
+배포하여 초기화 시간을 단축합니다.
+
+## 3계층 매니페스트
+
+| 계층 | 설명 | 배포 기준 |
+|------|------|----------|
+| **Tier 1 (Core)** | 핵심 인프라 — 오케스트레이터, 품질 게이트, 기본 스킬 | 항상 배포 |
+| **Tier 2 (Standard)** | 표준 확장 — 언어별 규칙, 프레임워크 스킬 | 프로젝트 언어/프레임워크 감지 시 |
+| **Tier 3 (Optional)** | 선택적 — 도메인 스킬, 플랫폼별 설정 | 명시적 요청 또는 프로젝트 설정 시 |
+
+## 카탈로그 파일
+
+카탈로그 매니페스트는 YAML 형식으로 정의됩니다:
+
+```yaml
+# 카탈로그 엔트리 예시
+- id: moai-workflow-tdd
+  tier: 1                    # 1=Core, 2=Standard, 3=Optional
+  type: skill
+  path: .claude/skills/moai/workflows/tdd.md
+  languages: []              # 빈 배열 = 모든 언어
+  frameworks: []
+  hash: abc123...             # 콘텐츠 해시 (무결성 검증)
+```
+
+## SlimFS 필터
+
+`moai init --slim`은 SlimFS 필터를 통해 배포 파일을 제한합니다:
+
+```bash
+# 전체 설치 (모든 계층)
+moai init my-project
+
+# Slim 설치 (Tier 1 + 감지된 Tier 2만)
+moai init --slim my-project
+```
+
+### 필터 로직
+
+1. Tier 1은 항상 포함
+2. 프로젝트 언어 감지 (Go, Python, TypeScript 등)
+3. 감지된 언어에 해당하는 Tier 2 항목만 포함
+4. Tier 3은 제외
+
+## Typed Loader
+
+`LoadCatalog()` 함수가 매니페스트를 타입 안전하게 로드합니다:
+
+- 3계층 분류 검증
+- 해시 무결성 검사 (Hash Sentinel)
+- 누락 필드 감지
+- 100% 테스트 커버리지
+
+## 카탈로그 활용
+
+### 프로젝트 초기화
+
+```bash
+# 일반 초기화 — 모든 템플릿 배포
+moai init my-project
+
+# Slim 초기화 — 최소 템플릿만 배포
+moai init --slim my-project
+```
+
+### 업데이트
+
+```bash
+# 카탈로그 기반 업데이트
+moai update                  # 모든 계층 업데이트
+moai update --slim           # slim 모드로 업데이트
+```
+
+## 관련 문서
+
+- [설치](/ko/getting-started/installation) — 설치 가이드
+- [초기 설정](/ko/getting-started/init-wizard) — init 마법사
+- [업데이트](/ko/getting-started/update) — 업데이트 가이드
+- [스킬 가이드](/ko/advanced/skill-guide) — 스킬 작성 가이드

--- a/docs-site/content/ja/advanced/harness-profiles.md
+++ b/docs-site/content/ja/advanced/harness-profiles.md
@@ -1,0 +1,104 @@
+---
+title: 하네스 프로필과 평가 시스템
+weight: 75
+draft: false
+---
+
+3계층 하네스 레벨과 4차원 평가 프로필을 통한 적응형 품질 검증 시스템입니다.
+
+## 개요
+
+MoAI-ADK의 하네스(Harness)는 **3계층 적응형 품질 검증 시스템**입니다. SPEC의 복잡도에
+따라 자동으로 검증 깊이를 조절합니다. evaluator-active 에이전트가 4차원 스코어링으로
+독립적이고 회의적인 품질 평가를 수행합니다.
+
+## 3계층 하네스 레벨
+
+| 레벨 | 설명 | 적용 시점 | evaluator-active |
+|------|------|----------|-----------------|
+| **minimal** | 빠른 검증 | 단순 변경 (typos, 설정 수정) | 생략 가능 |
+| **standard** | 기본 품질 검증 | 대부분의 작업 | 선택적 |
+| **thorough** | 전체 검증 + TRUST 5 | 복잡한 SPEC, 대규모 변경 | 필수 |
+
+하네스 레벨은 SPEC scope를 기반으로 **복잡도 추정기**(Complexity Estimator)가 자동으로
+결정합니다.
+
+## 4차원 스코어링
+
+evaluator-active는 4개 차원으로 점수를 매깁니다:
+
+| 차원 | 설명 | 기본 Must-Pass |
+|------|------|---------------|
+| **Functionality** | 기능 완성도 — 의도된 목적을 달성했는가 | 예 |
+| **Security** | 보안 — OWASP, 인증, 권한, 입력 검증 | 예 |
+| **Craft** | 코드 품질 — 가독성, 구조, 테스트 커버리지 | 아니오 |
+| **Consistency** | 일관성 — 프로젝트 규칙, 코드 스타일 준수 | 아니오 |
+
+### 점수 범위
+
+각 차원은 0.0 ~ 1.0 점수를 받습니다.
+
+### 루브릭 앵커
+
+모든 평가 기준은 4단계 루브릭 앵커를 가집니다:
+
+| 점수 | 수준 | 의미 |
+|------|------|------|
+| 0.25 | 미달 | 기본 요구사항 미충족 |
+| 0.50 | 부분 | 일부 충족, 개선 필요 |
+| 0.75 | 충족 | 대부분 충족, 소규모 개선 |
+| 1.00 | 우수 | 모든 기준 완벽 충족 |
+
+## 평가 프로필
+
+`.moai/config/evaluator-profiles/`에 4개 프로필이 제공됩니다:
+
+| 프로필 | 설명 | 적합한 경우 |
+|--------|------|------------|
+| `default.md` | 균형 잡힌 기본 프로필 | 대부분의 작업 |
+| `strict.md` | 엄격한 기준 | 보안 중요 작업 |
+| `lenient.md` | 관대한 기준 | 프로토타이핑 |
+| `frontend.md` | 프론트엔드 특화 | UI/UX 작업 |
+
+## 평가자 편향 방지 (5가지 메커니즘)
+
+평가자의 관대함을 방지하기 위해 5가지 메커니즘이 작동합니다:
+
+| # | 메커니즘 | 설명 |
+|---|---------|------|
+| 1 | **루브릭 앵커링** | 점수에 루브릭 정당화 필수 |
+| 2 | **회귀 베이스라인** | 이전 프로젝트 대비 과도한 점수 상승 감지 |
+| 3 | **Must-Pass 방화벽** | 필수 기준은 다른 영역 점수로 보상 불가 |
+| 4 | **독립 재평가** | 5번째마다 독립 재평가 (편차 > 0.10 시 재조정) |
+| 5 | **안티패턴 교차 검사** | 알려진 안티패턴 발견 시 해당 차원 점수 0.50 제한 |
+
+## Evaluator Memory Scope
+
+평가자의 판단 기억은 **반복별로 일시적**입니다. GAN Loop의 각 반복에서 evaluator-active는
+새 컨텍스트로 재시작되며, 이전 반복의 판단 근거는 새 프롬프트에 포함되지 않습니다.
+Sprint Contract 상태만이 반복 간에 유지됩니다.
+
+## 설정
+
+`.moai/config/sections/harness.yaml`에서 설정합니다:
+
+```yaml
+harness:
+  level: auto              # auto | minimal | standard | thorough
+  evaluator:
+    memory_scope: per_iteration   # FROZEN — 변경 불가
+    profiles:
+      default: .moai/config/evaluator-profiles/default.md
+      strict: .moai/config/evaluator-profiles/strict.md
+    aggregation: min              # min | mean
+    must_pass_dimensions:
+      - Functionality
+      - Security
+```
+
+## 관련 문서
+
+- [하네스 엔지니어링](/ko/core-concepts/harness-engineering) — 하네스 개념 개요
+- [TRUST 5 품질](/ko/core-concepts/trust-5) — 5가지 품질 기준
+- [Constitution 시스템](/ko/core-concepts/constitution) — FROZEN/Evolvable 규칙
+- [GAN Loop](/ko/design/gan-loop) — 디자인 품질 검증 반복

--- a/docs-site/content/ja/advanced/hooks-reference.md
+++ b/docs-site/content/ja/advanced/hooks-reference.md
@@ -1,0 +1,169 @@
+---
+title: Hooks 이벤트 레퍼런스
+weight: 60
+draft: false
+---
+
+MoAI-ADK v2.10.1 기준, Claude Code의 훅 시스템은 **27개 이벤트 타입**, **4가지 훅 타입**, **이벤트별 매처**, **스마트 동작**을 지원합니다.
+
+> 훅의 기본 개념과 설정 방법은 [Hooks 가이드](/ko/advanced/hooks-guide)를 참조하세요. 이 페이지는 이벤트 전체 레퍼런스입니다.
+
+## 훅 타입
+
+| 타입 | 설명 | 예시 |
+|------|------|------|
+| **command** | 셸 스크립트 실행 | `".claude/hooks/moai/handle-session-start.sh"` |
+| **prompt** | LLM 평가 | 프롬프트 텍스트를 LLM이 실행하여 결과 반환 |
+| **agent** | 서브에이전트 검증 | 에이전트가 작업을 검증하고 결과 반환 |
+| **http** | 웹훅 엔드포인트 | HTTP POST 요청으로 이벤트 전달 |
+
+## 이벤트 전체 레퍼런스 (27개)
+
+### 라이프사이클 이벤트
+
+| 이벤트 | 설명 | 매처 |
+|--------|------|------|
+| `SessionStart` | 세션 시작 | — |
+| `SessionEnd` | 세션 종료 | — |
+| `Stop` | 에이전트 정지 | — |
+| `SubagentStop` | 서브에이전트 정지 | — |
+| `SubagentStart` | 서브에이전트 시작 | — |
+| `StopFailure` | 정지 실패 | `errorType` |
+| `Setup` | 초기 설정 | — |
+
+### 도구 이벤트
+
+| 이벤트 | 설명 | 매처 |
+|--------|------|------|
+| `PreToolUse` | 도구 실행 전 | `toolName` |
+| `PostToolUse` | 도구 실행 후 | `toolName` |
+| `PostToolUseFailure` | 도구 실행 실패 | `toolName`, `errorType` |
+
+### 컨텍스트 이벤트
+
+| 이벤트 | 설명 | 매처 |
+|--------|------|------|
+| `PreCompact` | 컨텍스트 압축 전 | — |
+| `PostCompact` | 컨텍스트 압축 후 | — |
+| `InstructionsLoaded` | 인스트럭션 로드 완료 | — |
+
+### 입력 이벤트
+
+| 이벤트 | 설명 | 매처 |
+|--------|------|------|
+| `UserPromptSubmit` | 사용자 프롬프트 제출 | — |
+| `Elicitation` | Elicitation 시작 | — |
+| `ElicitationResult` | Elicitation 완료 | — |
+
+### 보안 이벤트
+
+| 이벤트 | 설명 | 매처 |
+|--------|------|------|
+| `PermissionRequest` | 권한 요청 | `toolName` |
+| `PermissionDenied` | 권한 거부 | `toolName` |
+
+### 팀 이벤트
+
+| 이벤트 | 설명 | 매처 |
+|--------|------|------|
+| `TeammateIdle` | 팀원 유휴 상태 전환 | — |
+| `TaskCompleted` | 태스크 완료 표시 | — |
+| `TaskCreated` | 태스크 생성 | — |
+
+### 워크트리 이벤트
+
+| 이벤트 | 설명 | 매처 |
+|--------|------|------|
+| `WorktreeCreate` | 워크트리 생성 | — |
+| `WorktreeRemove` | 워크트리 삭제 | — |
+
+### 환경 이벤트
+
+| 이벤트 | 설명 | 매처 |
+|--------|------|------|
+| `ConfigChange` | 설정 변경 | `configSource` |
+| `CwdChanged` | 작업 디렉터리 변경 | — |
+| `FileChanged` | 파일 변경 | — |
+
+### UI 이벤트
+
+| 이벤트 | 설명 | 매처 |
+|--------|------|------|
+| `Notification` | 사용자 알림 | — |
+
+## 스마트 동작 (Smart Behaviors)
+
+MoAI-ADK 훅은 단순 이벤트 처리를 넘어 지능적인 동작을 수행합니다:
+
+### PermissionDenied 자동 재시도
+
+읽기 전용 도구(Read, Grep, Glob)의 권한이 거부되면, 훅이 자동으로 재시도를 트리거합니다. 이는 백그라운드 에이전트에서 권한 프롬프트가 표시되지 않는 문제를 완화합니다.
+
+### StopFailure 에러 타입 응답
+
+에이전트 정지 실패 시 에러 타입에 따라 차별화된 응답을 제공합니다. 장시간 실행 세션에서의 안정성을 보장합니다.
+
+### PostCompact 세션 메모 복원
+
+컨텍스트 압축 후 중요한 세션 메모(진행 상태, SPEC 참조)를 자동으로 복원합니다. 이를 통해 컨텍스트 압축 시 핵심 정보 유실을 방지합니다.
+
+### SubagentStart 컨텍스트 주입
+
+서브에이전트 시작 시 필요한 컨텍스트(프로젝트 규칙, MX 태그, 진행 상태)를 자동 주입합니다.
+
+## 매처 (Matchers)
+
+매처를 사용하면 특정 조건에서만 훅이 실행되도록 필터링할 수 있습니다:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [{
+      "matcher": { "toolName": "Bash" },
+      "hooks": [{
+        "type": "command",
+        "command": "echo 'Bash tool detected'",
+        "timeout": 5
+      }]
+    }]
+  }
+}
+```
+
+### 사용 가능한 매처 필드
+
+| 매처 필드 | 적용 이벤트 | 설명 |
+|----------|-----------|------|
+| `toolName` | PreToolUse, PostToolUse, PostToolUseFailure, PermissionRequest, PermissionDenied | 도구 이름으로 필터 |
+| `errorType` | StopFailure, PostToolUseFailure | 에러 유형으로 필터 |
+| `configSource` | ConfigChange | 설정 소스로 필터 |
+
+## CLAUDE_ENV_FILE
+
+`CwdChanged`와 `FileChanged` 훅을 통해 환경 변수를 지속적으로 관리할 수 있습니다:
+
+```bash
+# .claude/hooks/moai/handle-cwd-changed.sh
+# CLAUDE_ENV_FILE을 통해 환경 변수 영속화
+echo "MOAI_PROJECT_DIR=$(pwd)" >> "$CLAUDE_ENV_FILE"
+```
+
+이를 통해 세션 간 환경 변수를 유지하고, 디렉터리 변경 시 자동으로 환경을 재설정할 수 있습니다.
+
+## MoAI-ADK가 사용하는 주요 훅
+
+| 이벤트 | MoAI 핸들러 | 역할 |
+|--------|-----------|------|
+| `SessionStart` | `handle-session-start.sh` | Statusline 초기화, 메트릭 세션 시작 |
+| `PostToolUse` | `handle-post-tool.sh` | Task 메트릭 로깅 |
+| `TeammateIdle` | `handle-teammate-idle.sh` | LSP 품질 게이트 검증 |
+| `TaskCompleted` | `handle-task-completed.sh` | SPEC 문서 존재 확인 |
+| `WorktreeCreate` | `handle-worktree-create.sh` | 워크트리 생성 로깅 |
+| `WorktreeRemove` | `handle-worktree-remove.sh` | 워크트리 삭제 로깅 |
+| `UserPromptSubmit` | `handle-user-prompt.sh` | 품질 게이트 자동 실행 |
+
+## 다음 단계
+
+- [Hooks 가이드](/ko/advanced/hooks-guide) — 훅 기본 개념과 설정 방법
+- [settings.json 가이드](/ko/advanced/settings-json) — settings.json 전체 레퍼런스
+- [CLI 레퍼런스](/ko/getting-started/cli) — `moai hook` 명령어 상세

--- a/docs-site/content/ja/contributing/_index.md
+++ b/docs-site/content/ja/contributing/_index.md
@@ -1,0 +1,7 @@
+---
+title: "Contributing"
+draft: true
+aliases: ["/ko/contributing/"]
+---
+
+This section is only available in Korean.

--- a/docs-site/content/ja/core-concepts/constitution.md
+++ b/docs-site/content/ja/core-concepts/constitution.md
@@ -1,0 +1,128 @@
+---
+title: Constitution 시스템
+weight: 35
+draft: false
+---
+
+MoAI-ADK의 불변 규칙(FROZEN)과 진화 가능한 규칙(Evolvable)을 관리하는 헌법적 제약 시스템입니다.
+
+## 개요
+
+MoAI-ADK는 **Constitution(헌법)** 시스템을 통해 AI 에이전트가 임의로 변경할 수 없는
+불변 제약(FROZEN Zone)과 학습을 통해 개선할 수 있는 진화 가능 제약(Evolvable Zone)을
+구분합니다. 이는 하네스 엔지니어링의 핵심 안전 메커니즘입니다.
+
+## FROZEN vs Evolvable
+
+### FROZEN Zone (불변)
+
+AI 에이전트가 절대 수정할 수 없는 규칙입니다. 인간 개발자만 변경할 수 있습니다.
+
+**대표 항목**:
+
+| 항목 | 설명 | 소스 |
+|------|------|------|
+| TRUST 5 | 5가지 품질 기준 | moai-constitution.md |
+| SPEC + EARS | 명세서 형식 | spec-workflow.md |
+| AskUserQuestion 독점 | 사용자 질문 채널 | agent-common-protocol.md |
+| 평가 차원 4개 | Functionality/Security/Craft/Consistency | harness/scorer.go |
+| 루브릭 앵커 4단계 | 0.25/0.50/0.75/1.00 | harness/rubric.go |
+| 통과 임계값 하한 | 최소 0.60 (낮출 수 없음) | design-constitution.md |
+| 디자인 파이프라인 순서 | manager-spec 먼저, evaluator-active 마지막 | design-constitution.md |
+
+### Evolvable Zone (진화 가능)
+
+학습(lessons)과 연구(research)를 통해 개선 제안이 가능한 규칙입니다.
+
+**대표 항목**:
+
+| 항목 | 설명 |
+|------|------|
+| 스킬 본문 내용 | moai-domain-* 스킬의 세부 내용 |
+| 파이프라인 가중치 | design.yaml의 phase_weights |
+| 반복 한계 | design.yaml의 iteration_limits |
+| 에이전트 행동 규칙 | Surface Assumptions, Enforce Simplicity 등 |
+
+## Zone Registry
+
+모든 HARD 조항을 열거하는 **단일 진실 공급원**(Single Source of Truth)입니다.
+
+### ID 할당 규칙
+
+```
+CONST-V3R2-NNN (3자리 이상 zero-padding)
+
+001-050: 기존 HARD 조항
+051-099: design constitution 미러 엔트리
+100-149: design overflow (자동 확장)
+150+: 신규 추가
+```
+
+### Canary Gate
+
+FROZEN 조항은 `canary_gate: true`를 가집니다. 변경 전 canary 검증이 필수입니다.
+
+```yaml
+# Zone Registry 엔트리 예시
+- id: CONST-V3R2-154
+  zone: Frozen
+  file: internal/harness/scorer.go
+  anchor: "#dimension-enum"
+  clause: "Dimension enum FROZEN at 4 values"
+  canary_gate: true
+```
+
+## 안전 아키텍처 (5계층)
+
+Constitution 시스템은 5계층 안전 아키텍처로 보호됩니다:
+
+### Layer 1: Frozen Guard
+
+쓰기 작업 전 대상 파일이 FROZEN zone이 아닌지 확인합니다. 위반 시 쓰기 차단 + 로깅 +
+사용자 알림.
+
+### Layer 2: Canary Check
+
+제안된 변경을 메모리에 적용하고 최근 3개 프로젝트를 재평가합니다. 점수 하락이
+0.10 초과하면 변경을 거부합니다.
+
+### Layer 3: Contradiction Detector
+
+새 학습이 기존 규칙과 충돌하면 양쪽을 모두 사용자에게 제시합니다. 자동 덮어쓰기는
+절대 발생하지 않습니다.
+
+### Layer 4: Rate Limiter
+
+진화 속도를 제한합니다:
+
+| 파라미터 | 기본값 | 설명 |
+|-----------|--------|------|
+| `max_evolution_rate_per_week` | 3 | 주간 최대 진화 횟수 |
+| `cooldown_hours` | 24 | 진화 간 최소 대기 시간 |
+| `max_active_learnings` | 50 | 활성 학습 항목 최대 수 |
+
+### Layer 5: Human Oversight
+
+`require_approval: true`인 경우 모든 진화 제안은 사용자 승인이 필요합니다.
+
+## CLI에서 활용
+
+```bash
+# 전체 registry 조회
+moai constitution list
+
+# Frozen zone 필터
+moai constitution list --zone frozen
+
+# 특정 파일 조항만 조회
+moai constitution list --file internal/harness/scorer.go
+
+# JSON 형식 출력
+moai constitution list --format json
+```
+
+## 관련 문서
+
+- [TRUST 5 품질](/ko/core-concepts/trust-5) — 5가지 품질 기준
+- [하네스 엔지니어링](/ko/core-concepts/harness-engineering) — 하네스 개념 개요
+- [SPEC 기반 개발](/ko/core-concepts/spec-based-dev) — SPEC 워크플로우

--- a/docs-site/content/ja/core-concepts/harness-engineering.md
+++ b/docs-site/content/ja/core-concepts/harness-engineering.md
@@ -1,0 +1,130 @@
+---
+title: 하네스 엔지니어링
+weight: 30
+draft: false
+---
+
+## 하네스 엔지니어링이란?
+
+MoAI-ADK는 **하네스 엔지니어링(Harness Engineering)** 패러다임을 구현합니다. 이는 개발자가 직접 코드를 작성하는 대신, **AI 에이전트가 최적의 코드를 생산할 수 있는 환경(하네스)을 설계**하는 접근 방식입니다.
+
+> "Human steers, agents execute."
+> — 엔지니어의 역할은 코드 작성에서 하네스 설계로 전환됩니다: SPEC, 품질 게이트, 피드백 루프.
+
+기존 바이브코딩은 AI에게 자유롭게 코드를 생성하게 한 뒤 결과를 수동으로 검토합니다. 하네스 엔지니어링은 반대입니다 — **규격(SPEC), 자동 검증, 지속적 피드백 루프**로 AI 에이전트를 가이드하여 일관된 품질의 코드를 생산합니다.
+
+## 7가지 핵심 컴포넌트
+
+```mermaid
+graph TB
+    subgraph Harness["🏗️ 하네스 엔지니어링"]
+        direction TB
+        SF["📐 Scaffolding First<br/>빈 파일 스텁 생성"] --> FC["✅ Failing Checklist<br/>수락 기준 태스크 등록"]
+        FC --> SV["🔄 Self-Verify Loop<br/>코드→테스트→수정→통과"]
+        SV --> GC["🗑️ Garbage Collection<br/>데드 코드 제거"]
+        GC --> CM["🗺️ Context Map<br/>아키텍처 문서 유지"]
+        CM --> SP["💾 Session Persistence<br/>세션 간 진행 추적"]
+        SP --> LA["🌐 Language-Agnostic<br/>16개 언어 자동 감지"]
+        LA --> SF
+    end
+
+    style Harness fill:#f0f7ff,stroke:#1565C0
+```
+
+각 컴포넌트는 MoAI의 특정 명령어에 매핑됩니다:
+
+| 컴포넌트 | 설명 | 명령어 |
+|----------|------|--------|
+| **Self-Verify Loop** | 에이전트가 코드 작성 → 테스트 → 실패 → 수정 → 통과 사이클을 자율적으로 반복 | [`/moai loop`](/ko/utility-commands/moai-loop) |
+| **Context Map** | 코드베이스 아키텍처 맵과 문서를 항상 에이전트에게 제공 | [`/moai codemaps`](/ko/quality-commands/moai-codemaps) |
+| **Session Persistence** | `progress.md`가 세션 간 완료된 단계를 추적하여 중단된 작업을 자동 재개 | [`/moai run SPEC-XXX`](/ko/workflow-commands/moai-run) |
+| **Failing Checklist** | 실행 시작 시 모든 수락 기준을 대기 태스크로 등록하고 구현 완료 시 체크 | [`/moai run SPEC-XXX`](/ko/workflow-commands/moai-run) |
+| **Language-Agnostic** | 16개 언어 지원: 언어를 자동 감지하고 올바른 LSP/린터/테스트/커버리지 도구 선택 | 모든 워크플로우 |
+| **Garbage Collection** | 데드 코드, AI 슬롭(slop), 사용하지 않는 import를 주기적으로 스캔하고 제거 | [`/moai clean`](/ko/utility-commands/moai-clean) |
+| **Scaffolding First** | 구현 전에 빈 파일 스텁을 먼저 생성하여 코드 엔트로피 방지 | [`/moai run SPEC-XXX`](/ko/workflow-commands/moai-run) |
+
+## 작동 원리
+
+### 1. Scaffolding First (스캐폴딩 우선)
+
+`/moai run`이 시작되면, 에이전트는 코드를 작성하기 전에 먼저 필요한 파일 구조를 생성합니다:
+
+```
+src/
+├── auth/
+│   ├── handler.go      ← 빈 스텁
+│   ├── handler_test.go  ← 빈 테스트
+│   ├── service.go       ← 빈 스텁
+│   └── service_test.go  ← 빈 테스트
+└── middleware/
+    └── jwt.go           ← 빈 스텁
+```
+
+이 방식은 에이전트가 무질서하게 파일을 생성하는 것을 방지하고, 일관된 프로젝트 구조를 유지합니다.
+
+### 2. Failing Checklist (실패 체크리스트)
+
+SPEC의 수락 기준이 자동으로 태스크 목록에 등록됩니다:
+
+```
+- [ ] JWT 토큰 생성 엔드포인트
+- [ ] 토큰 검증 미들웨어
+- [ ] 리프레시 토큰 로직
+- [ ] 만료된 토큰 처리
+- [ ] 85%+ 테스트 커버리지
+```
+
+각 항목이 구현되고 테스트를 통과하면 체크됩니다. 모든 항목이 체크되어야 작업이 완료됩니다.
+
+### 3. Self-Verify Loop (자기검증 루프)
+
+에이전트가 자율적으로 실행하는 핵심 사이클:
+
+```mermaid
+graph LR
+    A["코드 작성"] --> B["테스트 실행"]
+    B --> C{"통과?"}
+    C -->|"실패"| D["에러 분석"]
+    D --> A
+    C -->|"통과"| E["다음 항목"]
+```
+
+이 루프는 `/moai loop`에서 최대 100회까지 반복되며, 수렴 감지(같은 에러 반복 시 대안 전략 적용)를 포함합니다.
+
+### 4. Context Map (컨텍스트 맵)
+
+`/moai codemaps`가 생성하는 아키텍처 문서는 에이전트에게 코드베이스의 전체 구조를 제공합니다. 이를 통해 에이전트는:
+
+- 기존 코드와 충돌하지 않는 구현 방법을 선택
+- 적절한 패턴과 규칙을 따름
+- 의존성 관계를 이해하고 영향 범위를 파악
+
+### 5. Session Persistence (세션 지속성)
+
+Claude Code 세션이 중단되더라도 `progress.md`가 완료된 단계를 기록합니다:
+
+```markdown
+## Progress
+- [x] Phase 1: 분석 완료
+- [x] Phase 2: 핸들러 구현
+- [ ] Phase 3: 테스트 작성 ← 여기서 재개
+- [ ] Phase 4: 리팩토링
+```
+
+`/moai run --resume SPEC-XXX`로 중단된 지점부터 자동으로 재개됩니다.
+
+## 전통적 개발 vs 하네스 엔지니어링
+
+| 관점 | 전통적 개발 | 하네스 엔지니어링 |
+|------|-----------|-----------------|
+| **개발자 역할** | 코드 작성자 | 환경 설계자 |
+| **코드 생산** | 수동 작성 | AI 에이전트 자동 생산 |
+| **품질 보증** | 사후 리뷰 | 내장된 자동 검증 루프 |
+| **세션 연속성** | 수동 메모 | 자동 진행 추적 |
+| **코드 정리** | 기술 부채 누적 | 자동 가비지 컬렉션 |
+| **문서화** | 별도 작업 | 자동 아키텍처 맵 생성 |
+
+## 다음 단계
+
+- [SPEC 기반 개발](/ko/core-concepts/spec-based-dev) — 하네스의 입력이 되는 SPEC 문서 작성법
+- [TRUST 5 품질](/ko/core-concepts/trust-5) — 하네스가 검증하는 5가지 품질 기준

--- a/docs-site/content/ja/getting-started/profile.md
+++ b/docs-site/content/ja/getting-started/profile.md
@@ -1,0 +1,102 @@
+---
+title: 프로필 관리
+weight: 80
+draft: false
+---
+
+MoAI-ADK의 프로필 시스템으로 여러 Claude Code 설정을 격리하여 관리합니다.
+
+## 프로필이란?
+
+프로필은 **격리된 Claude Code 설정 디렉토리**(`CLAUDE_CONFIG_DIR`)입니다. 프로필별로 독립적인 설정, 모델 선택, 언어 환경을 유지할 수 있습니다.
+
+```
+~/.moai/claude-profiles/
+├── default/           # 기본 프로필
+│   ├── settings.json
+│   └── settings.local.json
+├── work/              # 업무용 프로필
+│   ├── settings.json
+│   └── settings.local.json
+└── personal/          # 개인용 프로필
+    └── ...
+```
+
+## 명령어 레퍼런스
+
+### moai profile list
+
+사용 가능한 모든 프로필을 표시합니다.
+
+```bash
+moai profile list
+```
+
+### moai profile setup [name]
+
+인터랙티브 설정 위자드를 실행합니다.
+
+```bash
+moai profile setup          # 기본 프로필 설정
+moai profile setup work     # "work" 프로필 설정
+```
+
+**위자드 설정 항목:**
+- **Identity**: 사용자 이름, 역할
+- **Languages**: 대화 언어, 코드 주석 언어
+- **Model Settings**: 기본 모델, 1M 컨텍스트 모델 선택
+- **Display**: 출력 스타일, 상태 표시줄 설정
+
+### moai profile current
+
+현재 활성 프로필 이름을 표시합니다.
+
+```bash
+moai profile current
+```
+
+### moai profile delete [name]
+
+프로필을 삭제합니다.
+
+```bash
+moai profile delete old-profile
+```
+
+## 프로필로 Claude Code 실행
+
+`-p` (또는 `--profile`) 플래그로 프로필을 지정합니다.
+
+```bash
+moai cc -p work          # work 프로필로 Claude 실행
+moai glm -p cost-save    # cost-save 프로필로 GLM 실행
+moai cg -p team          # team 프로필로 CG 모드 실행
+```
+
+{{< callout type="info" >}}
+프로필 미지정 시 기본 프로필이 사용됩니다. 첫 실행 시 자동으로 설정 위자드가 시작됩니다.
+{{< /callout >}}
+
+## 1M 컨텍스트 모델 선택
+
+프로필 설정 시 1M 컨텍스트 윈도우를 지원하는 모델을 선택할 수 있습니다.
+
+**지원 모델:**
+- `claude-opus-4-6[1m]` - Opus 4.6 (1M context)
+- `claude-sonnet-4-6[1m]` - Sonnet 4.6 (1M context)
+
+설정 위자드에서 "Model Settings" 단계에서 선택하거나, 프로필 설정 파일을 직접 수정합니다.
+
+## 프로필 전환 시 동작
+
+| 전환 | 동작 |
+|------|------|
+| `moai cc` → `moai glm` | GLM 환경 변수 자동 주입 |
+| `moai glm` → `moai cc` | GLM 환경 변수 자동 제거 |
+| `moai cc` → `moai cg` | GLM env를 tmux 세션에만 주입, Leader는 Claude 유지 |
+
+## 관련 문서
+
+- [CLI 레퍼런스](/getting-started/cli) - 전체 CLI 명령어
+- [빠른 시작](/getting-started/quickstart) - 처음 시작하기
+- [초기 설정](/getting-started/init-wizard) - 프로젝트 초기화

--- a/docs-site/content/ja/getting-started/windows-guide.md
+++ b/docs-site/content/ja/getting-started/windows-guide.md
@@ -1,0 +1,146 @@
+---
+title: Windows 사용 가이드
+weight: 40
+draft: false
+---
+
+## 지원 환경
+
+| 환경 | 지원 여부 | 비고 |
+|------|----------|------|
+| **WSL (권장)** | ✅ 완전 지원 | 최적의 경험 |
+| **PowerShell 7.x+** | ✅ 지원 | 대안 환경 |
+| PowerShell 5.x (레거시) | ❌ 미지원 | Windows PowerShell |
+| cmd.exe | ❌ 미지원 | 명령 프롬프트 |
+
+**필수 요구사항:**
+- [Git for Windows](https://gitforwindows.org/) 설치 필수
+- WSL 또는 PowerShell 7.x 이상
+
+## 설치 방법
+
+### WSL (권장)
+
+WSL은 Windows에서 Linux 환경을 제공하며, MoAI-ADK의 모든 기능을 완벽하게 지원합니다.
+
+```bash
+# WSL 설치 (관리자 PowerShell에서 실행)
+wsl --install
+
+# WSL 내에서 MoAI-ADK 설치
+curl -fsSL https://raw.githubusercontent.com/modu-ai/moai-adk/main/install.sh \
+  | bash
+```
+
+### PowerShell 7.x+
+
+> **참고**: 최적의 경험을 위해 WSL 사용을 권장합니다.
+
+```powershell
+irm https://raw.githubusercontent.com/modu-ai/moai-adk/main/install.ps1 | iex
+```
+
+## 한글 사용자명 경로 에러
+
+### 문제 현상
+
+Windows 사용자명에 한글, 중국어 등 비-ASCII 문자가 포함된 경우, `EINVAL` 에러가 발생할 수 있습니다. 이는 Windows의 8.3 짧은 파일명 변환 과정에서 발생하는 문제입니다.
+
+```
+Error: EINVAL: invalid argument, open 'C:\Users\홍길동\AppData\Local\Temp\...'
+```
+
+### 해결 방법 1: 대체 임시 디렉터리 설정 (권장)
+
+ASCII 문자만 포함된 경로에 임시 디렉터리를 생성합니다:
+
+```bash
+# Command Prompt
+set MOAI_TEMP_DIR=C:\temp
+mkdir C:\temp 2>/dev/null
+```
+
+```powershell
+# PowerShell
+$env:MOAI_TEMP_DIR="C:\temp"
+New-Item -ItemType Directory -Path "C:\temp" -Force
+```
+
+환경 변수를 영구적으로 설정하려면 시스템 환경 변수에 `MOAI_TEMP_DIR`을 추가하세요.
+
+### 해결 방법 2: 8.3 파일명 생성 비활성화
+
+관리자 권한으로 실행:
+
+```bash
+fsutil 8dot3name set 1
+```
+
+> **주의**: 이 설정은 시스템 전체에 영향을 미칩니다. 일부 레거시 프로그램이 영향을 받을 수 있습니다.
+
+### 해결 방법 3: ASCII 사용자 계정 생성
+
+영어 이름으로 새 Windows 사용자 계정을 생성하면 경로 문제를 근본적으로 해결합니다.
+
+## WSL 설정 가이드
+
+### WSL 설치
+
+```powershell
+# 관리자 PowerShell에서 실행
+wsl --install
+
+# 기본 배포판: Ubuntu (권장)
+# 재시작 후 사용자명 및 비밀번호 설정
+```
+
+### 프로젝트 파일 접근
+
+WSL에서 Windows 파일에 접근:
+
+```bash
+# Windows 파일시스템 접근
+cd /mnt/c/Users/사용자명/projects/
+
+# WSL 네이티브 파일시스템 사용 (더 빠름)
+cd ~/projects/
+```
+
+> **성능 팁**: WSL 네이티브 파일시스템(`~/` 하위)에서 작업하면 크로스 파일시스템 오버헤드 없이 최적의 성능을 얻을 수 있습니다.
+
+### VS Code 연동
+
+1. VS Code에 [WSL 확장](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-wsl) 설치
+2. WSL 터미널에서 `code .` 실행
+3. VS Code가 자동으로 WSL 모드로 열림
+
+## CG 모드에서의 tmux 사용
+
+[CG 모드](/ko/multi-llm/cg-mode)를 사용하려면 tmux가 필요합니다. WSL에서 설치:
+
+```bash
+# Ubuntu/Debian
+sudo apt install tmux
+
+# tmux 세션 시작
+tmux new -s moai
+
+# CG 모드 실행
+moai cg
+```
+
+## 문제 해결
+
+| 문제 | 원인 | 해결 |
+|------|------|------|
+| `moai: command not found` | PATH에 Go bin 디렉터리 미포함 | `export PATH="$HOME/go/bin:$PATH"`를 `.bashrc`에 추가 |
+| `EINVAL` 에러 | 한글 사용자명 | 위의 [한글 사용자명 경로 에러](#한글-사용자명-경로-에러) 참조 |
+| 권한 거부 | 설치 스크립트 권한 | `chmod +x install.sh` 후 재실행 |
+| Git 명령 실패 | Git for Windows 미설치 | [Git for Windows](https://gitforwindows.org/) 설치 |
+| tmux 없음 | CG 모드 실행 불가 | `sudo apt install tmux` (WSL에서) |
+
+## 다음 단계
+
+- [설치](/ko/getting-started/installation) — 설치 상세 가이드
+- [초기 설정](/ko/getting-started/init-wizard) — 프로젝트 초기화
+- [CG 모드](/ko/multi-llm/cg-mode) — Claude + GLM 하이브리드 모드

--- a/docs-site/content/ja/guides/ci-autonomy.md
+++ b/docs-site/content/ja/guides/ci-autonomy.md
@@ -1,0 +1,108 @@
+---
+title: 자율 CI/CD 가이드
+weight: 10
+draft: false
+---
+
+MoAI-ADK의 자율 CI/CD 시스템으로 풀리퀘스트 품질을 자동으로 관리합니다.
+
+## 개요
+
+SPEC-V3R3-CI-AUTONOMY-001에서 도입된 자율 CI/CD 시스템은 8개 티어로 구성된
+품질 자동화 인프라입니다. pre-push hook부터 auto-fix 루프까지, 개발자가 수동으로
+품질을 검증할 필요 없이 CI가 자동으로 품질을 보장합니다.
+
+## 8-Tier 아키텍처
+
+| Tier | 이름 | 우선순위 | 설명 |
+|------|------|----------|------|
+| T1 | Pre-push Hook | P0 | push 전 자동 품질 검증 |
+| T2 | Branch Protection | P0 | main 브랜치 보호 규칙 |
+| T3 | Auto-fix Loop | P1 | CI 실패 시 자동 수정 |
+| T4 | Auxiliary Workflows | P2 | 보조 워크플로우 정리 |
+| T5 | Worktree State Guard | P1 | 워크트리 상태 무결성 보장 |
+| T6 | i18n Validator | P2 | 4개국어 문서 일관성 검증 |
+| T7 | BODP | P0 | 브랜치 원점 결정 프로토콜 |
+| T8 | Release Workflow | P1 | 릴리스 자동화 |
+
+## Pre-push Hook (T1)
+
+push 전에 로컬에서 자동으로 품질 검증을 실행합니다.
+
+```bash
+# 자동 설치됨 (moai init / moai update 시)
+.git/hooks/pre-push → moai hook pre-push
+```
+
+실행되는 검증:
+
+- `go vet` / `golangci-lint` (프로젝트 언어에 따라 자동 감지)
+- `go test ./...` (테스트 스위트)
+- MX 태그 무결성 검사
+
+## Auto-fix Loop (T3)
+
+CI 실패 시 `/moai loop`를 자동으로 호출하여 에러를 수정합니다.
+
+```yaml
+# .github/workflows/ci.yml (자동 생성)
+- name: Auto-fix on failure
+  if: failure()
+  run: |
+    claude -p "/moai loop --max-iterations 3"
+```
+
+## BODP — Branch Origin Decision Protocol (T7)
+
+새 브랜치/워크트리를 생성할 때 base branch를 자동으로 결정합니다.
+
+### 3-Signal 평가
+
+| 시그널 | 출처 | 의미 |
+|--------|------|------|
+| Signal A | SPEC `depends_on` + diff path overlap | 코드 의존성 |
+| Signal B | `git status`에서 `.moai/specs/<NewSpecID>/` 매칭 | 작업 트리 동위치 |
+| Signal C | `gh pr list --head <branch> --state open` ≥ 1 | 현재 브랜치 PR |
+
+### 결정 매트릭스
+
+| 시그널 | 결정 |
+|--------|------|
+| A만 있음 | `stacked` — 현재 브랜치 기반 |
+| B 있음 | `continue` — 현재 컨텍스트에서 계속 |
+| C만 있음 | `stacked` — 현재 브랜치 기반 |
+| 아무것도 없음 | `main` — origin/main 기반 |
+
+### 감사 추적
+
+모든 BODP 결정은 `.moai/branches/decisions/<branch-name>.md`에 기록됩니다.
+
+## i18n Validator (T6)
+
+4개국어 문서의 일관성을 자동 검증합니다.
+
+```bash
+scripts/docs-i18n-check.sh
+```
+
+검증 항목:
+
+- 4개 locale 간 파일 개수/경로 일치
+- front matter `title` 존재
+- H1 heading 존재
+- MoAI 용어집 준수
+
+## Worktree State Guard (T5)
+
+워크트리의 상태 무결성을 보장합니다:
+
+- 커밋되지 않은 변경 감지
+- 워크트리와 메인 브랜치 동기화 상태 확인
+- `moai status`에서 상태 표시
+
+## 관련 문서
+
+- [워크트리 가이드](/ko/worktree/guide) — Git Worktree 완벽 가이드
+- [/moai loop](/ko/utility-commands/moai-loop) — 반복 수정 루프
+- [/moai fix](/ko/utility-commands/moai-fix) — 자동 에러 수정
+- [멀티 LLM CI](/ko/guides/multi-llm-ci) — Multi-LLM CI 통합

--- a/docs-site/content/ja/multi-llm/_index.md
+++ b/docs-site/content/ja/multi-llm/_index.md
@@ -1,0 +1,7 @@
+---
+title: "Multi-LLM Mode"
+draft: true
+aliases: ["/ko/multi-llm/"]
+---
+
+This section is only available in Korean.

--- a/docs-site/content/ja/multi-llm/cg-mode.md
+++ b/docs-site/content/ja/multi-llm/cg-mode.md
@@ -1,0 +1,7 @@
+---
+title: "CG Mode"
+draft: true
+aliases: ["/ko/multi-llm/cg-mode"]
+---
+
+This page is only available in Korean.

--- a/docs-site/content/ja/multi-llm/model-policy.md
+++ b/docs-site/content/ja/multi-llm/model-policy.md
@@ -1,0 +1,7 @@
+---
+title: "Model Policy"
+draft: true
+aliases: ["/ko/multi-llm/model-policy"]
+---
+
+This page is only available in Korean.

--- a/docs-site/content/ja/workflow-commands/moai-brain.md
+++ b/docs-site/content/ja/workflow-commands/moai-brain.md
@@ -1,0 +1,94 @@
+---
+title: /moai brain
+weight: 25
+draft: false
+---
+
+모호한 아이디어를 검증된 제안으로 변환하는 7단계 아이디에이션 워크플로우입니다.
+
+{{< callout type="info" >}}
+**슬래시 커맨드**: Claude Code에서 `/moai:brain`을 입력하면 이 명령어를 바로 실행할 수 있습니다.
+{{< /callout >}}
+
+## 개요
+
+`/moai brain`은 `/moai plan` **이전**에 실행하는 사전 명세 워크플로우입니다. 아직 구체화되지
+않은 아이디어를 7단계 파이프라인을 통해 검증된 제안으로 변환합니다. 최종 산출물은 Claude Design
+핸드오프 패키지이며, 이후 `/moai design` 또는 `/moai project` → `/moai plan`으로 이어집니다.
+
+### 워크플로우 위치
+
+```
+brain (1회) → [claude.com Design] → design Path A → project (1회) → plan (SPEC별) → run → sync
+```
+
+## 7단계 파이프라인
+
+| 단계 | 이름 | 설명 | 산출물 |
+|------|------|------|--------|
+| 1 | **Discovery** | 소크라테스식 인터뷰로 아이디어 구체화 (최대 5라운드) | interview notes |
+| 2 | **Diverge** | 가능한 접근 방식을 확장하여 탐색 | diverge notes |
+| 3 | **Research** | WebSearch + Context7 병렬 조사 | research.md |
+| 4 | **Converge** | 탐색 결과를 최적 접근법으로 수렴 | converge notes |
+| 5 | **Critical Evaluation** | First Principles + 비판적 평가 | evaluation notes |
+| 6 | **Proposal** | SPEC 분해 후보가 포함된 제안서 조립 | proposal.md |
+| 7 | **Handoff** | Claude Design 5파일 핸드오프 패키지 생성 | 5-file bundle |
+
+## 입력
+
+`/moai brain <아이디어>` — 아이디어는 어떤 언어, 어떤 형태, 어떤 수준의 구체성이든 가능합니다.
+
+```bash
+# 예시
+/moai brain "AI 코드 리뷰어 만들고 싶어"
+/moai brain "E-commerce 플랫폼의 결제 시스템을 개선하고 싶다"
+/moai brain "모바일 앱 푸시 알림 시스템"
+```
+
+## IDEA-NNN 자동 증가
+
+워크플로우 시작 시 `.moai/brain/IDEA-NNN/` 디렉터리가 자동 생성됩니다.
+
+```
+.moai/brain/
+├── IDEA-001/     # 첫 번째 아이디어
+│   ├── interview.md
+│   ├── research.md
+│   ├── proposal.md
+│   └── handoff/
+├── IDEA-002/     # 두 번째 아이디어
+│   └── ...
+```
+
+- 기존 IDEA 번호의 최대값 + 1로 자동 증가
+- 3자리 zero-padding (IDEA-001, IDEA-002, ...)
+- 중간에 중단된 경우 이어하기 제안
+
+## 브랜드 컨텍스트 연동
+
+`.moai/project/brand/`가 존재하면 브랜드 컨텍스트를 자동으로 로드하여 제안서에 반영합니다.
+
+## Claude Design 핸드오프 (Phase 7)
+
+Phase 7에서 생성되는 5파일 핸드오프 패키지:
+
+| 파일 | 내용 |
+|------|------|
+| `prompt.md` | Claude Design 세션 프롬프트 |
+| `context.md` | 프로젝트 컨텍스트 |
+| `references.md` | 조사 결과 참고 자료 |
+| `acceptance.md` | 수락 기준 |
+| `checklist.md` | 디자인 체크리스트 |
+
+이 패키지는 claude.com Design 세션에 직접 붙여넣어 사용할 수 있습니다.
+
+## 이어하기 (Resume)
+
+이전에 중단된 IDEA가 있으면 자동으로 감지하여 이어하기를 제안합니다.
+
+## 관련 문서
+
+- [/moai design](/ko/workflow-commands/moai-design) — Claude Design 핸드오프 수행
+- [/moai project](/ko/workflow-commands/moai-project) — 프로젝트 초기 설정
+- [/moai plan](/ko/workflow-commands/moai-plan) — SPEC 문서 생성
+- [디자인 시스템](/ko/design/getting-started) — 디자인 파이프라인 개요

--- a/docs-site/content/ja/workflow-commands/moai-db.md
+++ b/docs-site/content/ja/workflow-commands/moai-db.md
@@ -1,0 +1,100 @@
+---
+title: /moai db
+weight: 50
+draft: false
+---
+
+프로젝트 데이터베이스 메타데이터를 관리하는 워크플로우 명령어입니다.
+
+{{< callout type="info" >}}
+**슬래시 커맨드**: Claude Code에서 `/moai:db`을 입력하면 이 명령어를 바로 실행할 수 있습니다.
+{{< /callout >}}
+
+## 개요
+
+`/moai db`는 데이터베이스 스키마, 마이그레이션, 시드를 관리하는 4개 하위 명령어를
+제공합니다. 대화형 인터뷰로 DB 엔진, ORM, 멀티테넌트 설정을 구성하고
+`.moai/project/db/` 아티팩트를 생성합니다.
+
+## 하위 명령어
+
+| 명령어 | 설명 | 읽기 전용 |
+|--------|------|-----------|
+| `init` | 대화형 초기 설정 | 아니오 |
+| `refresh` | 마이그레이션 재스캔 + 스키마 문서 재생성 | 아니오 |
+| `verify` | 드리프트 감지 (스키마 vs 마이그레이션) | 예 |
+| `list` | 테이블 목록 출력 | 예 |
+
+```bash
+/moai db init       # 대화형 설정 마법사
+/moai db refresh    # 마이그레이션 재스캔
+/moai db verify     # 드리프트 검사
+/moai db list       # 테이블 목록
+/moai db            # 하위 명령어 선택
+```
+
+## init — 대화형 초기 설정
+
+### Phase 1: 사전 확인
+
+기존 `.moai/project/db/` 확인 후 인터뷰를 진행합니다.
+
+### Phase 2: 인터뷰
+
+AskUserQuestion으로 다음 항목을 설정합니다:
+
+- **DB 엔진**: PostgreSQL, MySQL, SQLite, MongoDB 등
+- **ORM**: Prisma, TypeORM, SQLAlchemy, GORM 등
+- **멀티테넌트**: 스키마 분리 / 행 수준 분리 / 단일 테넌트
+- **마이그레이션 도구**: 선택한 ORM의 기본 도구 또는 커스텀
+
+### Phase 3: 템플릿 렌더링
+
+`.moai/project/db/` 디렉터리에 다음 파일을 생성합니다:
+
+```
+.moai/project/db/
+├── schema.md          # 스키마 문서 (Markdown)
+├── migrations.md      # 마이그레이션 추적
+└── seeds.md           # 시드 데이터 가이드
+```
+
+## refresh — 마이그레이션 재스캔
+
+마이그레이션 파일을 다시 스캔하고 스키마 문서를 재생성합니다.
+
+- 새 마이그레이션 파일 감지
+- `schema.md` 자동 업데이트
+- 변경사항 요약 출력
+
+## verify — 드리프트 검사
+
+`schema.md`의 테이블 목록과 실제 마이그레이션 파일을 비교합니다.
+
+- **일치**: 종료 코드 0
+- **드리프트 감지**: 종료 코드 1 + 상세 보고서
+
+CI 파이프라인에서 사용하여 스키마 동기화를 검증할 수 있습니다.
+
+```yaml
+# GitHub Actions 예시
+- name: DB Schema Drift Check
+  run: claude -p "/moai db verify"
+```
+
+## list — 테이블 목록
+
+`schema.md`의 모든 테이블을 Markdown 정렬 표로 출력합니다.
+
+## --mode 호환성
+
+이 명령어는 Multi-Mode Router의 `--mode` 축에 참여하지 않습니다. `--mode` 값을
+전달하면 조용히 무시됩니다. 단, `--mode pipeline`은 `MODE_PIPELINE_ONLY_UTILITY`
+오류를 발생시킵니다.
+
+## 관련 문서
+
+- [데이터베이스 시작하기](/ko/db/getting-started) — DB 관리 상세 가이드
+- [스키마 동기화](/ko/db/schema-sync) — 스키마 동기화 패턴
+- [마이그레이션 패턴](/ko/db/migration-patterns) — 마이그레이션 전략
+- [/moai plan](/ko/workflow-commands/moai-plan) — SPEC 문서 생성

--- a/docs-site/content/ja/workflow-commands/moai-design.md
+++ b/docs-site/content/ja/workflow-commands/moai-design.md
@@ -1,0 +1,106 @@
+---
+title: /moai design
+weight: 26
+draft: false
+---
+
+하이브리드 디자인 워크플로우로 브랜드 중심의 웹 경험을 생성합니다.
+
+{{< callout type="info" >}}
+**슬래시 커맨드**: Claude Code에서 `/moai:design`을 입력하면 이 명령어를 바로 실행할 수 있습니다.
+{{< /callout >}}
+
+## 개요
+
+`/moai design`은 자연어 브리프를 브랜드 일관성이 있는 웹 경험으로 변환하는 하이브리드
+디자인 워크플로우입니다. 3가지 경로를 지원합니다:
+
+| 경로 | 설명 | 적합한 경우 |
+|------|------|------------|
+| **Path A** | Claude Design 핸드오프 | claude.com Design 세션 사용 |
+| **Path B1** | Figma → 디자인 토큰 | 기존 Figma 디자인 있는 경우 |
+| **Path B2** | Pencil MCP → 디자인 토큰 | Pencil 파일로 작업하는 경우 |
+| **Path B-Common** | 코드 기반 브랜드 디자인 | 처음부터 시작하는 경우 |
+
+## --mode 플래그
+
+SPEC-V3R2-WF-003의 Multi-Mode Router를 지원합니다.
+
+| 모드 | 설명 |
+|------|------|
+| `autopilot` (기본) | Path B — 코드 기반 브랜드 디자인 자동 실행 |
+| `import` | Path A — Claude Design 핸드오프 번들 가져오기 |
+| `team` | Path B를 병렬 팀으로 실행 (Agent Teams 필요) |
+
+```bash
+/moai design                          # 경로 선택 AskUserQuestion
+/moai design --mode autopilot         # Path B 즉시 실행
+/moai design --mode import            # Path A 핸드오프 가져오기
+/moai design --mode team              # Path B 병렬 실행
+```
+
+## 실행 전 조건 확인
+
+### 브랜드 컨텍스트
+
+`.moai/project/brand/`에 3개 파일이 필요합니다:
+
+```
+.moai/project/brand/
+├── brand-voice.md       # 브랜드 톤, 용어, 메시지 가이드
+├── visual-identity.md   # 색상, 타이포그래피, 시각 언어
+└── target-audience.md   # 타겟 고객 프로필
+```
+
+파일이 없거나 `_TBD_` 마커가 있으면 브랜드 인터뷰가 먼저 진행됩니다.
+
+### Agency 데이터 감지
+
+기존 `.agency/` 디렉터리가 있으면 마이그레이션을 제안합니다:
+
+```bash
+moai migrate agency --dry-run   # 미리보기
+moai migrate agency             # 실행
+```
+
+## 파이프라인 아키텍처
+
+```
+manager-spec → [copywriting, brand-design] (병렬) → expert-frontend → evaluator-active
+                                                                       ↑              |
+                                                                       └──────────────┘
+                                                                  GAN Loop (최대 5회)
+```
+
+1. **manager-spec** — 브리프 문서 생성 (Goal/Audience/Brand 섹션)
+2. **copywriting + brand-design** — 카피 JSON + 디자인 토큰 (병렬 실행)
+3. **expert-frontend** — 코드 구현
+4. **evaluator-active** → **GAN Loop** — 품질 검증 반복
+
+## GAN Loop
+
+Builder-Evaluator 반복 루프가 품질을 보장합니다.
+
+| 파라미터 | 기본값 | 설명 |
+|-----------|--------|------|
+| `pass_threshold` | 0.75 | 통과 임계값 (최소 0.60) |
+| `max_iterations` | 5 | 최대 반복 횟수 |
+| `escalation_after` | 3 | 사용자 개입 요청 시점 |
+| `improvement_threshold` | 0.05 | 정체 감지 임계값 |
+
+## Sprint Contract
+
+`--mode team` 또는 `thorough` 하네스 레벨에서는 Sprint Contract가 협상됩니다:
+
+1. evaluator-active가 수락 체크리스트 생성
+2. expert-frontend가 체크리스트 리뷰
+3. 구현 → 평가 반복
+4. 통과한 기준은 다음 반복에서도 유지 (회귀 불가)
+
+## 관련 문서
+
+- [디자인 시작하기](/ko/design/getting-started) — 디자인 시스템 개요
+- [Claude Design 핸드오프](/ko/design/claude-design-handoff) — Path A 상세 가이드
+- [코드 기반 경로](/ko/design/code-based-path) — Path B 상세 가이드
+- [GAN Loop](/ko/design/gan-loop) — 품질 검증 상세
+- [/moai brain](/ko/workflow-commands/moai-brain) — 아이디에이션 워크플로우

--- a/docs-site/content/zh/advanced/catalog-system.md
+++ b/docs-site/content/zh/advanced/catalog-system.md
@@ -1,0 +1,91 @@
+---
+title: 카탈로그 시스템
+weight: 80
+draft: false
+---
+
+3계층 카탈로그 매니페스트와 slim init으로 프로젝트 초기화를 최적화합니다.
+
+## 개요
+
+MoAI-ADK v2.15+의 카탈로그 시스템은 모든 에이전트, 스킬, 플러그인, 규칙을 **3계층
+매니페스트**로 관리합니다. `moai init --slim`을 통해 프로젝트에 필요한 최소 템플릿만
+배포하여 초기화 시간을 단축합니다.
+
+## 3계층 매니페스트
+
+| 계층 | 설명 | 배포 기준 |
+|------|------|----------|
+| **Tier 1 (Core)** | 핵심 인프라 — 오케스트레이터, 품질 게이트, 기본 스킬 | 항상 배포 |
+| **Tier 2 (Standard)** | 표준 확장 — 언어별 규칙, 프레임워크 스킬 | 프로젝트 언어/프레임워크 감지 시 |
+| **Tier 3 (Optional)** | 선택적 — 도메인 스킬, 플랫폼별 설정 | 명시적 요청 또는 프로젝트 설정 시 |
+
+## 카탈로그 파일
+
+카탈로그 매니페스트는 YAML 형식으로 정의됩니다:
+
+```yaml
+# 카탈로그 엔트리 예시
+- id: moai-workflow-tdd
+  tier: 1                    # 1=Core, 2=Standard, 3=Optional
+  type: skill
+  path: .claude/skills/moai/workflows/tdd.md
+  languages: []              # 빈 배열 = 모든 언어
+  frameworks: []
+  hash: abc123...             # 콘텐츠 해시 (무결성 검증)
+```
+
+## SlimFS 필터
+
+`moai init --slim`은 SlimFS 필터를 통해 배포 파일을 제한합니다:
+
+```bash
+# 전체 설치 (모든 계층)
+moai init my-project
+
+# Slim 설치 (Tier 1 + 감지된 Tier 2만)
+moai init --slim my-project
+```
+
+### 필터 로직
+
+1. Tier 1은 항상 포함
+2. 프로젝트 언어 감지 (Go, Python, TypeScript 등)
+3. 감지된 언어에 해당하는 Tier 2 항목만 포함
+4. Tier 3은 제외
+
+## Typed Loader
+
+`LoadCatalog()` 함수가 매니페스트를 타입 안전하게 로드합니다:
+
+- 3계층 분류 검증
+- 해시 무결성 검사 (Hash Sentinel)
+- 누락 필드 감지
+- 100% 테스트 커버리지
+
+## 카탈로그 활용
+
+### 프로젝트 초기화
+
+```bash
+# 일반 초기화 — 모든 템플릿 배포
+moai init my-project
+
+# Slim 초기화 — 최소 템플릿만 배포
+moai init --slim my-project
+```
+
+### 업데이트
+
+```bash
+# 카탈로그 기반 업데이트
+moai update                  # 모든 계층 업데이트
+moai update --slim           # slim 모드로 업데이트
+```
+
+## 관련 문서
+
+- [설치](/ko/getting-started/installation) — 설치 가이드
+- [초기 설정](/ko/getting-started/init-wizard) — init 마법사
+- [업데이트](/ko/getting-started/update) — 업데이트 가이드
+- [스킬 가이드](/ko/advanced/skill-guide) — 스킬 작성 가이드

--- a/docs-site/content/zh/advanced/harness-profiles.md
+++ b/docs-site/content/zh/advanced/harness-profiles.md
@@ -1,0 +1,104 @@
+---
+title: 하네스 프로필과 평가 시스템
+weight: 75
+draft: false
+---
+
+3계층 하네스 레벨과 4차원 평가 프로필을 통한 적응형 품질 검증 시스템입니다.
+
+## 개요
+
+MoAI-ADK의 하네스(Harness)는 **3계층 적응형 품질 검증 시스템**입니다. SPEC의 복잡도에
+따라 자동으로 검증 깊이를 조절합니다. evaluator-active 에이전트가 4차원 스코어링으로
+독립적이고 회의적인 품질 평가를 수행합니다.
+
+## 3계층 하네스 레벨
+
+| 레벨 | 설명 | 적용 시점 | evaluator-active |
+|------|------|----------|-----------------|
+| **minimal** | 빠른 검증 | 단순 변경 (typos, 설정 수정) | 생략 가능 |
+| **standard** | 기본 품질 검증 | 대부분의 작업 | 선택적 |
+| **thorough** | 전체 검증 + TRUST 5 | 복잡한 SPEC, 대규모 변경 | 필수 |
+
+하네스 레벨은 SPEC scope를 기반으로 **복잡도 추정기**(Complexity Estimator)가 자동으로
+결정합니다.
+
+## 4차원 스코어링
+
+evaluator-active는 4개 차원으로 점수를 매깁니다:
+
+| 차원 | 설명 | 기본 Must-Pass |
+|------|------|---------------|
+| **Functionality** | 기능 완성도 — 의도된 목적을 달성했는가 | 예 |
+| **Security** | 보안 — OWASP, 인증, 권한, 입력 검증 | 예 |
+| **Craft** | 코드 품질 — 가독성, 구조, 테스트 커버리지 | 아니오 |
+| **Consistency** | 일관성 — 프로젝트 규칙, 코드 스타일 준수 | 아니오 |
+
+### 점수 범위
+
+각 차원은 0.0 ~ 1.0 점수를 받습니다.
+
+### 루브릭 앵커
+
+모든 평가 기준은 4단계 루브릭 앵커를 가집니다:
+
+| 점수 | 수준 | 의미 |
+|------|------|------|
+| 0.25 | 미달 | 기본 요구사항 미충족 |
+| 0.50 | 부분 | 일부 충족, 개선 필요 |
+| 0.75 | 충족 | 대부분 충족, 소규모 개선 |
+| 1.00 | 우수 | 모든 기준 완벽 충족 |
+
+## 평가 프로필
+
+`.moai/config/evaluator-profiles/`에 4개 프로필이 제공됩니다:
+
+| 프로필 | 설명 | 적합한 경우 |
+|--------|------|------------|
+| `default.md` | 균형 잡힌 기본 프로필 | 대부분의 작업 |
+| `strict.md` | 엄격한 기준 | 보안 중요 작업 |
+| `lenient.md` | 관대한 기준 | 프로토타이핑 |
+| `frontend.md` | 프론트엔드 특화 | UI/UX 작업 |
+
+## 평가자 편향 방지 (5가지 메커니즘)
+
+평가자의 관대함을 방지하기 위해 5가지 메커니즘이 작동합니다:
+
+| # | 메커니즘 | 설명 |
+|---|---------|------|
+| 1 | **루브릭 앵커링** | 점수에 루브릭 정당화 필수 |
+| 2 | **회귀 베이스라인** | 이전 프로젝트 대비 과도한 점수 상승 감지 |
+| 3 | **Must-Pass 방화벽** | 필수 기준은 다른 영역 점수로 보상 불가 |
+| 4 | **독립 재평가** | 5번째마다 독립 재평가 (편차 > 0.10 시 재조정) |
+| 5 | **안티패턴 교차 검사** | 알려진 안티패턴 발견 시 해당 차원 점수 0.50 제한 |
+
+## Evaluator Memory Scope
+
+평가자의 판단 기억은 **반복별로 일시적**입니다. GAN Loop의 각 반복에서 evaluator-active는
+새 컨텍스트로 재시작되며, 이전 반복의 판단 근거는 새 프롬프트에 포함되지 않습니다.
+Sprint Contract 상태만이 반복 간에 유지됩니다.
+
+## 설정
+
+`.moai/config/sections/harness.yaml`에서 설정합니다:
+
+```yaml
+harness:
+  level: auto              # auto | minimal | standard | thorough
+  evaluator:
+    memory_scope: per_iteration   # FROZEN — 변경 불가
+    profiles:
+      default: .moai/config/evaluator-profiles/default.md
+      strict: .moai/config/evaluator-profiles/strict.md
+    aggregation: min              # min | mean
+    must_pass_dimensions:
+      - Functionality
+      - Security
+```
+
+## 관련 문서
+
+- [하네스 엔지니어링](/ko/core-concepts/harness-engineering) — 하네스 개념 개요
+- [TRUST 5 품질](/ko/core-concepts/trust-5) — 5가지 품질 기준
+- [Constitution 시스템](/ko/core-concepts/constitution) — FROZEN/Evolvable 규칙
+- [GAN Loop](/ko/design/gan-loop) — 디자인 품질 검증 반복

--- a/docs-site/content/zh/advanced/hooks-reference.md
+++ b/docs-site/content/zh/advanced/hooks-reference.md
@@ -1,0 +1,169 @@
+---
+title: Hooks 이벤트 레퍼런스
+weight: 60
+draft: false
+---
+
+MoAI-ADK v2.10.1 기준, Claude Code의 훅 시스템은 **27개 이벤트 타입**, **4가지 훅 타입**, **이벤트별 매처**, **스마트 동작**을 지원합니다.
+
+> 훅의 기본 개념과 설정 방법은 [Hooks 가이드](/ko/advanced/hooks-guide)를 참조하세요. 이 페이지는 이벤트 전체 레퍼런스입니다.
+
+## 훅 타입
+
+| 타입 | 설명 | 예시 |
+|------|------|------|
+| **command** | 셸 스크립트 실행 | `".claude/hooks/moai/handle-session-start.sh"` |
+| **prompt** | LLM 평가 | 프롬프트 텍스트를 LLM이 실행하여 결과 반환 |
+| **agent** | 서브에이전트 검증 | 에이전트가 작업을 검증하고 결과 반환 |
+| **http** | 웹훅 엔드포인트 | HTTP POST 요청으로 이벤트 전달 |
+
+## 이벤트 전체 레퍼런스 (27개)
+
+### 라이프사이클 이벤트
+
+| 이벤트 | 설명 | 매처 |
+|--------|------|------|
+| `SessionStart` | 세션 시작 | — |
+| `SessionEnd` | 세션 종료 | — |
+| `Stop` | 에이전트 정지 | — |
+| `SubagentStop` | 서브에이전트 정지 | — |
+| `SubagentStart` | 서브에이전트 시작 | — |
+| `StopFailure` | 정지 실패 | `errorType` |
+| `Setup` | 초기 설정 | — |
+
+### 도구 이벤트
+
+| 이벤트 | 설명 | 매처 |
+|--------|------|------|
+| `PreToolUse` | 도구 실행 전 | `toolName` |
+| `PostToolUse` | 도구 실행 후 | `toolName` |
+| `PostToolUseFailure` | 도구 실행 실패 | `toolName`, `errorType` |
+
+### 컨텍스트 이벤트
+
+| 이벤트 | 설명 | 매처 |
+|--------|------|------|
+| `PreCompact` | 컨텍스트 압축 전 | — |
+| `PostCompact` | 컨텍스트 압축 후 | — |
+| `InstructionsLoaded` | 인스트럭션 로드 완료 | — |
+
+### 입력 이벤트
+
+| 이벤트 | 설명 | 매처 |
+|--------|------|------|
+| `UserPromptSubmit` | 사용자 프롬프트 제출 | — |
+| `Elicitation` | Elicitation 시작 | — |
+| `ElicitationResult` | Elicitation 완료 | — |
+
+### 보안 이벤트
+
+| 이벤트 | 설명 | 매처 |
+|--------|------|------|
+| `PermissionRequest` | 권한 요청 | `toolName` |
+| `PermissionDenied` | 권한 거부 | `toolName` |
+
+### 팀 이벤트
+
+| 이벤트 | 설명 | 매처 |
+|--------|------|------|
+| `TeammateIdle` | 팀원 유휴 상태 전환 | — |
+| `TaskCompleted` | 태스크 완료 표시 | — |
+| `TaskCreated` | 태스크 생성 | — |
+
+### 워크트리 이벤트
+
+| 이벤트 | 설명 | 매처 |
+|--------|------|------|
+| `WorktreeCreate` | 워크트리 생성 | — |
+| `WorktreeRemove` | 워크트리 삭제 | — |
+
+### 환경 이벤트
+
+| 이벤트 | 설명 | 매처 |
+|--------|------|------|
+| `ConfigChange` | 설정 변경 | `configSource` |
+| `CwdChanged` | 작업 디렉터리 변경 | — |
+| `FileChanged` | 파일 변경 | — |
+
+### UI 이벤트
+
+| 이벤트 | 설명 | 매처 |
+|--------|------|------|
+| `Notification` | 사용자 알림 | — |
+
+## 스마트 동작 (Smart Behaviors)
+
+MoAI-ADK 훅은 단순 이벤트 처리를 넘어 지능적인 동작을 수행합니다:
+
+### PermissionDenied 자동 재시도
+
+읽기 전용 도구(Read, Grep, Glob)의 권한이 거부되면, 훅이 자동으로 재시도를 트리거합니다. 이는 백그라운드 에이전트에서 권한 프롬프트가 표시되지 않는 문제를 완화합니다.
+
+### StopFailure 에러 타입 응답
+
+에이전트 정지 실패 시 에러 타입에 따라 차별화된 응답을 제공합니다. 장시간 실행 세션에서의 안정성을 보장합니다.
+
+### PostCompact 세션 메모 복원
+
+컨텍스트 압축 후 중요한 세션 메모(진행 상태, SPEC 참조)를 자동으로 복원합니다. 이를 통해 컨텍스트 압축 시 핵심 정보 유실을 방지합니다.
+
+### SubagentStart 컨텍스트 주입
+
+서브에이전트 시작 시 필요한 컨텍스트(프로젝트 규칙, MX 태그, 진행 상태)를 자동 주입합니다.
+
+## 매처 (Matchers)
+
+매처를 사용하면 특정 조건에서만 훅이 실행되도록 필터링할 수 있습니다:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [{
+      "matcher": { "toolName": "Bash" },
+      "hooks": [{
+        "type": "command",
+        "command": "echo 'Bash tool detected'",
+        "timeout": 5
+      }]
+    }]
+  }
+}
+```
+
+### 사용 가능한 매처 필드
+
+| 매처 필드 | 적용 이벤트 | 설명 |
+|----------|-----------|------|
+| `toolName` | PreToolUse, PostToolUse, PostToolUseFailure, PermissionRequest, PermissionDenied | 도구 이름으로 필터 |
+| `errorType` | StopFailure, PostToolUseFailure | 에러 유형으로 필터 |
+| `configSource` | ConfigChange | 설정 소스로 필터 |
+
+## CLAUDE_ENV_FILE
+
+`CwdChanged`와 `FileChanged` 훅을 통해 환경 변수를 지속적으로 관리할 수 있습니다:
+
+```bash
+# .claude/hooks/moai/handle-cwd-changed.sh
+# CLAUDE_ENV_FILE을 통해 환경 변수 영속화
+echo "MOAI_PROJECT_DIR=$(pwd)" >> "$CLAUDE_ENV_FILE"
+```
+
+이를 통해 세션 간 환경 변수를 유지하고, 디렉터리 변경 시 자동으로 환경을 재설정할 수 있습니다.
+
+## MoAI-ADK가 사용하는 주요 훅
+
+| 이벤트 | MoAI 핸들러 | 역할 |
+|--------|-----------|------|
+| `SessionStart` | `handle-session-start.sh` | Statusline 초기화, 메트릭 세션 시작 |
+| `PostToolUse` | `handle-post-tool.sh` | Task 메트릭 로깅 |
+| `TeammateIdle` | `handle-teammate-idle.sh` | LSP 품질 게이트 검증 |
+| `TaskCompleted` | `handle-task-completed.sh` | SPEC 문서 존재 확인 |
+| `WorktreeCreate` | `handle-worktree-create.sh` | 워크트리 생성 로깅 |
+| `WorktreeRemove` | `handle-worktree-remove.sh` | 워크트리 삭제 로깅 |
+| `UserPromptSubmit` | `handle-user-prompt.sh` | 품질 게이트 자동 실행 |
+
+## 다음 단계
+
+- [Hooks 가이드](/ko/advanced/hooks-guide) — 훅 기본 개념과 설정 방법
+- [settings.json 가이드](/ko/advanced/settings-json) — settings.json 전체 레퍼런스
+- [CLI 레퍼런스](/ko/getting-started/cli) — `moai hook` 명령어 상세

--- a/docs-site/content/zh/contributing/_index.md
+++ b/docs-site/content/zh/contributing/_index.md
@@ -1,0 +1,7 @@
+---
+title: "Contributing"
+draft: true
+aliases: ["/ko/contributing/"]
+---
+
+This section is only available in Korean.

--- a/docs-site/content/zh/core-concepts/constitution.md
+++ b/docs-site/content/zh/core-concepts/constitution.md
@@ -1,0 +1,128 @@
+---
+title: Constitution 시스템
+weight: 35
+draft: false
+---
+
+MoAI-ADK의 불변 규칙(FROZEN)과 진화 가능한 규칙(Evolvable)을 관리하는 헌법적 제약 시스템입니다.
+
+## 개요
+
+MoAI-ADK는 **Constitution(헌법)** 시스템을 통해 AI 에이전트가 임의로 변경할 수 없는
+불변 제약(FROZEN Zone)과 학습을 통해 개선할 수 있는 진화 가능 제약(Evolvable Zone)을
+구분합니다. 이는 하네스 엔지니어링의 핵심 안전 메커니즘입니다.
+
+## FROZEN vs Evolvable
+
+### FROZEN Zone (불변)
+
+AI 에이전트가 절대 수정할 수 없는 규칙입니다. 인간 개발자만 변경할 수 있습니다.
+
+**대표 항목**:
+
+| 항목 | 설명 | 소스 |
+|------|------|------|
+| TRUST 5 | 5가지 품질 기준 | moai-constitution.md |
+| SPEC + EARS | 명세서 형식 | spec-workflow.md |
+| AskUserQuestion 독점 | 사용자 질문 채널 | agent-common-protocol.md |
+| 평가 차원 4개 | Functionality/Security/Craft/Consistency | harness/scorer.go |
+| 루브릭 앵커 4단계 | 0.25/0.50/0.75/1.00 | harness/rubric.go |
+| 통과 임계값 하한 | 최소 0.60 (낮출 수 없음) | design-constitution.md |
+| 디자인 파이프라인 순서 | manager-spec 먼저, evaluator-active 마지막 | design-constitution.md |
+
+### Evolvable Zone (진화 가능)
+
+학습(lessons)과 연구(research)를 통해 개선 제안이 가능한 규칙입니다.
+
+**대표 항목**:
+
+| 항목 | 설명 |
+|------|------|
+| 스킬 본문 내용 | moai-domain-* 스킬의 세부 내용 |
+| 파이프라인 가중치 | design.yaml의 phase_weights |
+| 반복 한계 | design.yaml의 iteration_limits |
+| 에이전트 행동 규칙 | Surface Assumptions, Enforce Simplicity 등 |
+
+## Zone Registry
+
+모든 HARD 조항을 열거하는 **단일 진실 공급원**(Single Source of Truth)입니다.
+
+### ID 할당 규칙
+
+```
+CONST-V3R2-NNN (3자리 이상 zero-padding)
+
+001-050: 기존 HARD 조항
+051-099: design constitution 미러 엔트리
+100-149: design overflow (자동 확장)
+150+: 신규 추가
+```
+
+### Canary Gate
+
+FROZEN 조항은 `canary_gate: true`를 가집니다. 변경 전 canary 검증이 필수입니다.
+
+```yaml
+# Zone Registry 엔트리 예시
+- id: CONST-V3R2-154
+  zone: Frozen
+  file: internal/harness/scorer.go
+  anchor: "#dimension-enum"
+  clause: "Dimension enum FROZEN at 4 values"
+  canary_gate: true
+```
+
+## 안전 아키텍처 (5계층)
+
+Constitution 시스템은 5계층 안전 아키텍처로 보호됩니다:
+
+### Layer 1: Frozen Guard
+
+쓰기 작업 전 대상 파일이 FROZEN zone이 아닌지 확인합니다. 위반 시 쓰기 차단 + 로깅 +
+사용자 알림.
+
+### Layer 2: Canary Check
+
+제안된 변경을 메모리에 적용하고 최근 3개 프로젝트를 재평가합니다. 점수 하락이
+0.10 초과하면 변경을 거부합니다.
+
+### Layer 3: Contradiction Detector
+
+새 학습이 기존 규칙과 충돌하면 양쪽을 모두 사용자에게 제시합니다. 자동 덮어쓰기는
+절대 발생하지 않습니다.
+
+### Layer 4: Rate Limiter
+
+진화 속도를 제한합니다:
+
+| 파라미터 | 기본값 | 설명 |
+|-----------|--------|------|
+| `max_evolution_rate_per_week` | 3 | 주간 최대 진화 횟수 |
+| `cooldown_hours` | 24 | 진화 간 최소 대기 시간 |
+| `max_active_learnings` | 50 | 활성 학습 항목 최대 수 |
+
+### Layer 5: Human Oversight
+
+`require_approval: true`인 경우 모든 진화 제안은 사용자 승인이 필요합니다.
+
+## CLI에서 활용
+
+```bash
+# 전체 registry 조회
+moai constitution list
+
+# Frozen zone 필터
+moai constitution list --zone frozen
+
+# 특정 파일 조항만 조회
+moai constitution list --file internal/harness/scorer.go
+
+# JSON 형식 출력
+moai constitution list --format json
+```
+
+## 관련 문서
+
+- [TRUST 5 품질](/ko/core-concepts/trust-5) — 5가지 품질 기준
+- [하네스 엔지니어링](/ko/core-concepts/harness-engineering) — 하네스 개념 개요
+- [SPEC 기반 개발](/ko/core-concepts/spec-based-dev) — SPEC 워크플로우

--- a/docs-site/content/zh/core-concepts/harness-engineering.md
+++ b/docs-site/content/zh/core-concepts/harness-engineering.md
@@ -1,0 +1,130 @@
+---
+title: 하네스 엔지니어링
+weight: 30
+draft: false
+---
+
+## 하네스 엔지니어링이란?
+
+MoAI-ADK는 **하네스 엔지니어링(Harness Engineering)** 패러다임을 구현합니다. 이는 개발자가 직접 코드를 작성하는 대신, **AI 에이전트가 최적의 코드를 생산할 수 있는 환경(하네스)을 설계**하는 접근 방식입니다.
+
+> "Human steers, agents execute."
+> — 엔지니어의 역할은 코드 작성에서 하네스 설계로 전환됩니다: SPEC, 품질 게이트, 피드백 루프.
+
+기존 바이브코딩은 AI에게 자유롭게 코드를 생성하게 한 뒤 결과를 수동으로 검토합니다. 하네스 엔지니어링은 반대입니다 — **규격(SPEC), 자동 검증, 지속적 피드백 루프**로 AI 에이전트를 가이드하여 일관된 품질의 코드를 생산합니다.
+
+## 7가지 핵심 컴포넌트
+
+```mermaid
+graph TB
+    subgraph Harness["🏗️ 하네스 엔지니어링"]
+        direction TB
+        SF["📐 Scaffolding First<br/>빈 파일 스텁 생성"] --> FC["✅ Failing Checklist<br/>수락 기준 태스크 등록"]
+        FC --> SV["🔄 Self-Verify Loop<br/>코드→테스트→수정→통과"]
+        SV --> GC["🗑️ Garbage Collection<br/>데드 코드 제거"]
+        GC --> CM["🗺️ Context Map<br/>아키텍처 문서 유지"]
+        CM --> SP["💾 Session Persistence<br/>세션 간 진행 추적"]
+        SP --> LA["🌐 Language-Agnostic<br/>16개 언어 자동 감지"]
+        LA --> SF
+    end
+
+    style Harness fill:#f0f7ff,stroke:#1565C0
+```
+
+각 컴포넌트는 MoAI의 특정 명령어에 매핑됩니다:
+
+| 컴포넌트 | 설명 | 명령어 |
+|----------|------|--------|
+| **Self-Verify Loop** | 에이전트가 코드 작성 → 테스트 → 실패 → 수정 → 통과 사이클을 자율적으로 반복 | [`/moai loop`](/ko/utility-commands/moai-loop) |
+| **Context Map** | 코드베이스 아키텍처 맵과 문서를 항상 에이전트에게 제공 | [`/moai codemaps`](/ko/quality-commands/moai-codemaps) |
+| **Session Persistence** | `progress.md`가 세션 간 완료된 단계를 추적하여 중단된 작업을 자동 재개 | [`/moai run SPEC-XXX`](/ko/workflow-commands/moai-run) |
+| **Failing Checklist** | 실행 시작 시 모든 수락 기준을 대기 태스크로 등록하고 구현 완료 시 체크 | [`/moai run SPEC-XXX`](/ko/workflow-commands/moai-run) |
+| **Language-Agnostic** | 16개 언어 지원: 언어를 자동 감지하고 올바른 LSP/린터/테스트/커버리지 도구 선택 | 모든 워크플로우 |
+| **Garbage Collection** | 데드 코드, AI 슬롭(slop), 사용하지 않는 import를 주기적으로 스캔하고 제거 | [`/moai clean`](/ko/utility-commands/moai-clean) |
+| **Scaffolding First** | 구현 전에 빈 파일 스텁을 먼저 생성하여 코드 엔트로피 방지 | [`/moai run SPEC-XXX`](/ko/workflow-commands/moai-run) |
+
+## 작동 원리
+
+### 1. Scaffolding First (스캐폴딩 우선)
+
+`/moai run`이 시작되면, 에이전트는 코드를 작성하기 전에 먼저 필요한 파일 구조를 생성합니다:
+
+```
+src/
+├── auth/
+│   ├── handler.go      ← 빈 스텁
+│   ├── handler_test.go  ← 빈 테스트
+│   ├── service.go       ← 빈 스텁
+│   └── service_test.go  ← 빈 테스트
+└── middleware/
+    └── jwt.go           ← 빈 스텁
+```
+
+이 방식은 에이전트가 무질서하게 파일을 생성하는 것을 방지하고, 일관된 프로젝트 구조를 유지합니다.
+
+### 2. Failing Checklist (실패 체크리스트)
+
+SPEC의 수락 기준이 자동으로 태스크 목록에 등록됩니다:
+
+```
+- [ ] JWT 토큰 생성 엔드포인트
+- [ ] 토큰 검증 미들웨어
+- [ ] 리프레시 토큰 로직
+- [ ] 만료된 토큰 처리
+- [ ] 85%+ 테스트 커버리지
+```
+
+각 항목이 구현되고 테스트를 통과하면 체크됩니다. 모든 항목이 체크되어야 작업이 완료됩니다.
+
+### 3. Self-Verify Loop (자기검증 루프)
+
+에이전트가 자율적으로 실행하는 핵심 사이클:
+
+```mermaid
+graph LR
+    A["코드 작성"] --> B["테스트 실행"]
+    B --> C{"통과?"}
+    C -->|"실패"| D["에러 분석"]
+    D --> A
+    C -->|"통과"| E["다음 항목"]
+```
+
+이 루프는 `/moai loop`에서 최대 100회까지 반복되며, 수렴 감지(같은 에러 반복 시 대안 전략 적용)를 포함합니다.
+
+### 4. Context Map (컨텍스트 맵)
+
+`/moai codemaps`가 생성하는 아키텍처 문서는 에이전트에게 코드베이스의 전체 구조를 제공합니다. 이를 통해 에이전트는:
+
+- 기존 코드와 충돌하지 않는 구현 방법을 선택
+- 적절한 패턴과 규칙을 따름
+- 의존성 관계를 이해하고 영향 범위를 파악
+
+### 5. Session Persistence (세션 지속성)
+
+Claude Code 세션이 중단되더라도 `progress.md`가 완료된 단계를 기록합니다:
+
+```markdown
+## Progress
+- [x] Phase 1: 분석 완료
+- [x] Phase 2: 핸들러 구현
+- [ ] Phase 3: 테스트 작성 ← 여기서 재개
+- [ ] Phase 4: 리팩토링
+```
+
+`/moai run --resume SPEC-XXX`로 중단된 지점부터 자동으로 재개됩니다.
+
+## 전통적 개발 vs 하네스 엔지니어링
+
+| 관점 | 전통적 개발 | 하네스 엔지니어링 |
+|------|-----------|-----------------|
+| **개발자 역할** | 코드 작성자 | 환경 설계자 |
+| **코드 생산** | 수동 작성 | AI 에이전트 자동 생산 |
+| **품질 보증** | 사후 리뷰 | 내장된 자동 검증 루프 |
+| **세션 연속성** | 수동 메모 | 자동 진행 추적 |
+| **코드 정리** | 기술 부채 누적 | 자동 가비지 컬렉션 |
+| **문서화** | 별도 작업 | 자동 아키텍처 맵 생성 |
+
+## 다음 단계
+
+- [SPEC 기반 개발](/ko/core-concepts/spec-based-dev) — 하네스의 입력이 되는 SPEC 문서 작성법
+- [TRUST 5 품질](/ko/core-concepts/trust-5) — 하네스가 검증하는 5가지 품질 기준

--- a/docs-site/content/zh/getting-started/profile.md
+++ b/docs-site/content/zh/getting-started/profile.md
@@ -1,0 +1,102 @@
+---
+title: 프로필 관리
+weight: 80
+draft: false
+---
+
+MoAI-ADK의 프로필 시스템으로 여러 Claude Code 설정을 격리하여 관리합니다.
+
+## 프로필이란?
+
+프로필은 **격리된 Claude Code 설정 디렉토리**(`CLAUDE_CONFIG_DIR`)입니다. 프로필별로 독립적인 설정, 모델 선택, 언어 환경을 유지할 수 있습니다.
+
+```
+~/.moai/claude-profiles/
+├── default/           # 기본 프로필
+│   ├── settings.json
+│   └── settings.local.json
+├── work/              # 업무용 프로필
+│   ├── settings.json
+│   └── settings.local.json
+└── personal/          # 개인용 프로필
+    └── ...
+```
+
+## 명령어 레퍼런스
+
+### moai profile list
+
+사용 가능한 모든 프로필을 표시합니다.
+
+```bash
+moai profile list
+```
+
+### moai profile setup [name]
+
+인터랙티브 설정 위자드를 실행합니다.
+
+```bash
+moai profile setup          # 기본 프로필 설정
+moai profile setup work     # "work" 프로필 설정
+```
+
+**위자드 설정 항목:**
+- **Identity**: 사용자 이름, 역할
+- **Languages**: 대화 언어, 코드 주석 언어
+- **Model Settings**: 기본 모델, 1M 컨텍스트 모델 선택
+- **Display**: 출력 스타일, 상태 표시줄 설정
+
+### moai profile current
+
+현재 활성 프로필 이름을 표시합니다.
+
+```bash
+moai profile current
+```
+
+### moai profile delete [name]
+
+프로필을 삭제합니다.
+
+```bash
+moai profile delete old-profile
+```
+
+## 프로필로 Claude Code 실행
+
+`-p` (또는 `--profile`) 플래그로 프로필을 지정합니다.
+
+```bash
+moai cc -p work          # work 프로필로 Claude 실행
+moai glm -p cost-save    # cost-save 프로필로 GLM 실행
+moai cg -p team          # team 프로필로 CG 모드 실행
+```
+
+{{< callout type="info" >}}
+프로필 미지정 시 기본 프로필이 사용됩니다. 첫 실행 시 자동으로 설정 위자드가 시작됩니다.
+{{< /callout >}}
+
+## 1M 컨텍스트 모델 선택
+
+프로필 설정 시 1M 컨텍스트 윈도우를 지원하는 모델을 선택할 수 있습니다.
+
+**지원 모델:**
+- `claude-opus-4-6[1m]` - Opus 4.6 (1M context)
+- `claude-sonnet-4-6[1m]` - Sonnet 4.6 (1M context)
+
+설정 위자드에서 "Model Settings" 단계에서 선택하거나, 프로필 설정 파일을 직접 수정합니다.
+
+## 프로필 전환 시 동작
+
+| 전환 | 동작 |
+|------|------|
+| `moai cc` → `moai glm` | GLM 환경 변수 자동 주입 |
+| `moai glm` → `moai cc` | GLM 환경 변수 자동 제거 |
+| `moai cc` → `moai cg` | GLM env를 tmux 세션에만 주입, Leader는 Claude 유지 |
+
+## 관련 문서
+
+- [CLI 레퍼런스](/getting-started/cli) - 전체 CLI 명령어
+- [빠른 시작](/getting-started/quickstart) - 처음 시작하기
+- [초기 설정](/getting-started/init-wizard) - 프로젝트 초기화

--- a/docs-site/content/zh/getting-started/windows-guide.md
+++ b/docs-site/content/zh/getting-started/windows-guide.md
@@ -1,0 +1,146 @@
+---
+title: Windows 사용 가이드
+weight: 40
+draft: false
+---
+
+## 지원 환경
+
+| 환경 | 지원 여부 | 비고 |
+|------|----------|------|
+| **WSL (권장)** | ✅ 완전 지원 | 최적의 경험 |
+| **PowerShell 7.x+** | ✅ 지원 | 대안 환경 |
+| PowerShell 5.x (레거시) | ❌ 미지원 | Windows PowerShell |
+| cmd.exe | ❌ 미지원 | 명령 프롬프트 |
+
+**필수 요구사항:**
+- [Git for Windows](https://gitforwindows.org/) 설치 필수
+- WSL 또는 PowerShell 7.x 이상
+
+## 설치 방법
+
+### WSL (권장)
+
+WSL은 Windows에서 Linux 환경을 제공하며, MoAI-ADK의 모든 기능을 완벽하게 지원합니다.
+
+```bash
+# WSL 설치 (관리자 PowerShell에서 실행)
+wsl --install
+
+# WSL 내에서 MoAI-ADK 설치
+curl -fsSL https://raw.githubusercontent.com/modu-ai/moai-adk/main/install.sh \
+  | bash
+```
+
+### PowerShell 7.x+
+
+> **참고**: 최적의 경험을 위해 WSL 사용을 권장합니다.
+
+```powershell
+irm https://raw.githubusercontent.com/modu-ai/moai-adk/main/install.ps1 | iex
+```
+
+## 한글 사용자명 경로 에러
+
+### 문제 현상
+
+Windows 사용자명에 한글, 중국어 등 비-ASCII 문자가 포함된 경우, `EINVAL` 에러가 발생할 수 있습니다. 이는 Windows의 8.3 짧은 파일명 변환 과정에서 발생하는 문제입니다.
+
+```
+Error: EINVAL: invalid argument, open 'C:\Users\홍길동\AppData\Local\Temp\...'
+```
+
+### 해결 방법 1: 대체 임시 디렉터리 설정 (권장)
+
+ASCII 문자만 포함된 경로에 임시 디렉터리를 생성합니다:
+
+```bash
+# Command Prompt
+set MOAI_TEMP_DIR=C:\temp
+mkdir C:\temp 2>/dev/null
+```
+
+```powershell
+# PowerShell
+$env:MOAI_TEMP_DIR="C:\temp"
+New-Item -ItemType Directory -Path "C:\temp" -Force
+```
+
+환경 변수를 영구적으로 설정하려면 시스템 환경 변수에 `MOAI_TEMP_DIR`을 추가하세요.
+
+### 해결 방법 2: 8.3 파일명 생성 비활성화
+
+관리자 권한으로 실행:
+
+```bash
+fsutil 8dot3name set 1
+```
+
+> **주의**: 이 설정은 시스템 전체에 영향을 미칩니다. 일부 레거시 프로그램이 영향을 받을 수 있습니다.
+
+### 해결 방법 3: ASCII 사용자 계정 생성
+
+영어 이름으로 새 Windows 사용자 계정을 생성하면 경로 문제를 근본적으로 해결합니다.
+
+## WSL 설정 가이드
+
+### WSL 설치
+
+```powershell
+# 관리자 PowerShell에서 실행
+wsl --install
+
+# 기본 배포판: Ubuntu (권장)
+# 재시작 후 사용자명 및 비밀번호 설정
+```
+
+### 프로젝트 파일 접근
+
+WSL에서 Windows 파일에 접근:
+
+```bash
+# Windows 파일시스템 접근
+cd /mnt/c/Users/사용자명/projects/
+
+# WSL 네이티브 파일시스템 사용 (더 빠름)
+cd ~/projects/
+```
+
+> **성능 팁**: WSL 네이티브 파일시스템(`~/` 하위)에서 작업하면 크로스 파일시스템 오버헤드 없이 최적의 성능을 얻을 수 있습니다.
+
+### VS Code 연동
+
+1. VS Code에 [WSL 확장](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-wsl) 설치
+2. WSL 터미널에서 `code .` 실행
+3. VS Code가 자동으로 WSL 모드로 열림
+
+## CG 모드에서의 tmux 사용
+
+[CG 모드](/ko/multi-llm/cg-mode)를 사용하려면 tmux가 필요합니다. WSL에서 설치:
+
+```bash
+# Ubuntu/Debian
+sudo apt install tmux
+
+# tmux 세션 시작
+tmux new -s moai
+
+# CG 모드 실행
+moai cg
+```
+
+## 문제 해결
+
+| 문제 | 원인 | 해결 |
+|------|------|------|
+| `moai: command not found` | PATH에 Go bin 디렉터리 미포함 | `export PATH="$HOME/go/bin:$PATH"`를 `.bashrc`에 추가 |
+| `EINVAL` 에러 | 한글 사용자명 | 위의 [한글 사용자명 경로 에러](#한글-사용자명-경로-에러) 참조 |
+| 권한 거부 | 설치 스크립트 권한 | `chmod +x install.sh` 후 재실행 |
+| Git 명령 실패 | Git for Windows 미설치 | [Git for Windows](https://gitforwindows.org/) 설치 |
+| tmux 없음 | CG 모드 실행 불가 | `sudo apt install tmux` (WSL에서) |
+
+## 다음 단계
+
+- [설치](/ko/getting-started/installation) — 설치 상세 가이드
+- [초기 설정](/ko/getting-started/init-wizard) — 프로젝트 초기화
+- [CG 모드](/ko/multi-llm/cg-mode) — Claude + GLM 하이브리드 모드

--- a/docs-site/content/zh/guides/ci-autonomy.md
+++ b/docs-site/content/zh/guides/ci-autonomy.md
@@ -1,0 +1,108 @@
+---
+title: 자율 CI/CD 가이드
+weight: 10
+draft: false
+---
+
+MoAI-ADK의 자율 CI/CD 시스템으로 풀리퀘스트 품질을 자동으로 관리합니다.
+
+## 개요
+
+SPEC-V3R3-CI-AUTONOMY-001에서 도입된 자율 CI/CD 시스템은 8개 티어로 구성된
+품질 자동화 인프라입니다. pre-push hook부터 auto-fix 루프까지, 개발자가 수동으로
+품질을 검증할 필요 없이 CI가 자동으로 품질을 보장합니다.
+
+## 8-Tier 아키텍처
+
+| Tier | 이름 | 우선순위 | 설명 |
+|------|------|----------|------|
+| T1 | Pre-push Hook | P0 | push 전 자동 품질 검증 |
+| T2 | Branch Protection | P0 | main 브랜치 보호 규칙 |
+| T3 | Auto-fix Loop | P1 | CI 실패 시 자동 수정 |
+| T4 | Auxiliary Workflows | P2 | 보조 워크플로우 정리 |
+| T5 | Worktree State Guard | P1 | 워크트리 상태 무결성 보장 |
+| T6 | i18n Validator | P2 | 4개국어 문서 일관성 검증 |
+| T7 | BODP | P0 | 브랜치 원점 결정 프로토콜 |
+| T8 | Release Workflow | P1 | 릴리스 자동화 |
+
+## Pre-push Hook (T1)
+
+push 전에 로컬에서 자동으로 품질 검증을 실행합니다.
+
+```bash
+# 자동 설치됨 (moai init / moai update 시)
+.git/hooks/pre-push → moai hook pre-push
+```
+
+실행되는 검증:
+
+- `go vet` / `golangci-lint` (프로젝트 언어에 따라 자동 감지)
+- `go test ./...` (테스트 스위트)
+- MX 태그 무결성 검사
+
+## Auto-fix Loop (T3)
+
+CI 실패 시 `/moai loop`를 자동으로 호출하여 에러를 수정합니다.
+
+```yaml
+# .github/workflows/ci.yml (자동 생성)
+- name: Auto-fix on failure
+  if: failure()
+  run: |
+    claude -p "/moai loop --max-iterations 3"
+```
+
+## BODP — Branch Origin Decision Protocol (T7)
+
+새 브랜치/워크트리를 생성할 때 base branch를 자동으로 결정합니다.
+
+### 3-Signal 평가
+
+| 시그널 | 출처 | 의미 |
+|--------|------|------|
+| Signal A | SPEC `depends_on` + diff path overlap | 코드 의존성 |
+| Signal B | `git status`에서 `.moai/specs/<NewSpecID>/` 매칭 | 작업 트리 동위치 |
+| Signal C | `gh pr list --head <branch> --state open` ≥ 1 | 현재 브랜치 PR |
+
+### 결정 매트릭스
+
+| 시그널 | 결정 |
+|--------|------|
+| A만 있음 | `stacked` — 현재 브랜치 기반 |
+| B 있음 | `continue` — 현재 컨텍스트에서 계속 |
+| C만 있음 | `stacked` — 현재 브랜치 기반 |
+| 아무것도 없음 | `main` — origin/main 기반 |
+
+### 감사 추적
+
+모든 BODP 결정은 `.moai/branches/decisions/<branch-name>.md`에 기록됩니다.
+
+## i18n Validator (T6)
+
+4개국어 문서의 일관성을 자동 검증합니다.
+
+```bash
+scripts/docs-i18n-check.sh
+```
+
+검증 항목:
+
+- 4개 locale 간 파일 개수/경로 일치
+- front matter `title` 존재
+- H1 heading 존재
+- MoAI 용어집 준수
+
+## Worktree State Guard (T5)
+
+워크트리의 상태 무결성을 보장합니다:
+
+- 커밋되지 않은 변경 감지
+- 워크트리와 메인 브랜치 동기화 상태 확인
+- `moai status`에서 상태 표시
+
+## 관련 문서
+
+- [워크트리 가이드](/ko/worktree/guide) — Git Worktree 완벽 가이드
+- [/moai loop](/ko/utility-commands/moai-loop) — 반복 수정 루프
+- [/moai fix](/ko/utility-commands/moai-fix) — 자동 에러 수정
+- [멀티 LLM CI](/ko/guides/multi-llm-ci) — Multi-LLM CI 통합

--- a/docs-site/content/zh/multi-llm/_index.md
+++ b/docs-site/content/zh/multi-llm/_index.md
@@ -1,0 +1,7 @@
+---
+title: "Multi-LLM Mode"
+draft: true
+aliases: ["/ko/multi-llm/"]
+---
+
+This section is only available in Korean.

--- a/docs-site/content/zh/multi-llm/cg-mode.md
+++ b/docs-site/content/zh/multi-llm/cg-mode.md
@@ -1,0 +1,7 @@
+---
+title: "CG Mode"
+draft: true
+aliases: ["/ko/multi-llm/cg-mode"]
+---
+
+This page is only available in Korean.

--- a/docs-site/content/zh/multi-llm/model-policy.md
+++ b/docs-site/content/zh/multi-llm/model-policy.md
@@ -1,0 +1,7 @@
+---
+title: "Model Policy"
+draft: true
+aliases: ["/ko/multi-llm/model-policy"]
+---
+
+This page is only available in Korean.

--- a/docs-site/content/zh/workflow-commands/moai-brain.md
+++ b/docs-site/content/zh/workflow-commands/moai-brain.md
@@ -1,0 +1,94 @@
+---
+title: /moai brain
+weight: 25
+draft: false
+---
+
+모호한 아이디어를 검증된 제안으로 변환하는 7단계 아이디에이션 워크플로우입니다.
+
+{{< callout type="info" >}}
+**슬래시 커맨드**: Claude Code에서 `/moai:brain`을 입력하면 이 명령어를 바로 실행할 수 있습니다.
+{{< /callout >}}
+
+## 개요
+
+`/moai brain`은 `/moai plan` **이전**에 실행하는 사전 명세 워크플로우입니다. 아직 구체화되지
+않은 아이디어를 7단계 파이프라인을 통해 검증된 제안으로 변환합니다. 최종 산출물은 Claude Design
+핸드오프 패키지이며, 이후 `/moai design` 또는 `/moai project` → `/moai plan`으로 이어집니다.
+
+### 워크플로우 위치
+
+```
+brain (1회) → [claude.com Design] → design Path A → project (1회) → plan (SPEC별) → run → sync
+```
+
+## 7단계 파이프라인
+
+| 단계 | 이름 | 설명 | 산출물 |
+|------|------|------|--------|
+| 1 | **Discovery** | 소크라테스식 인터뷰로 아이디어 구체화 (최대 5라운드) | interview notes |
+| 2 | **Diverge** | 가능한 접근 방식을 확장하여 탐색 | diverge notes |
+| 3 | **Research** | WebSearch + Context7 병렬 조사 | research.md |
+| 4 | **Converge** | 탐색 결과를 최적 접근법으로 수렴 | converge notes |
+| 5 | **Critical Evaluation** | First Principles + 비판적 평가 | evaluation notes |
+| 6 | **Proposal** | SPEC 분해 후보가 포함된 제안서 조립 | proposal.md |
+| 7 | **Handoff** | Claude Design 5파일 핸드오프 패키지 생성 | 5-file bundle |
+
+## 입력
+
+`/moai brain <아이디어>` — 아이디어는 어떤 언어, 어떤 형태, 어떤 수준의 구체성이든 가능합니다.
+
+```bash
+# 예시
+/moai brain "AI 코드 리뷰어 만들고 싶어"
+/moai brain "E-commerce 플랫폼의 결제 시스템을 개선하고 싶다"
+/moai brain "모바일 앱 푸시 알림 시스템"
+```
+
+## IDEA-NNN 자동 증가
+
+워크플로우 시작 시 `.moai/brain/IDEA-NNN/` 디렉터리가 자동 생성됩니다.
+
+```
+.moai/brain/
+├── IDEA-001/     # 첫 번째 아이디어
+│   ├── interview.md
+│   ├── research.md
+│   ├── proposal.md
+│   └── handoff/
+├── IDEA-002/     # 두 번째 아이디어
+│   └── ...
+```
+
+- 기존 IDEA 번호의 최대값 + 1로 자동 증가
+- 3자리 zero-padding (IDEA-001, IDEA-002, ...)
+- 중간에 중단된 경우 이어하기 제안
+
+## 브랜드 컨텍스트 연동
+
+`.moai/project/brand/`가 존재하면 브랜드 컨텍스트를 자동으로 로드하여 제안서에 반영합니다.
+
+## Claude Design 핸드오프 (Phase 7)
+
+Phase 7에서 생성되는 5파일 핸드오프 패키지:
+
+| 파일 | 내용 |
+|------|------|
+| `prompt.md` | Claude Design 세션 프롬프트 |
+| `context.md` | 프로젝트 컨텍스트 |
+| `references.md` | 조사 결과 참고 자료 |
+| `acceptance.md` | 수락 기준 |
+| `checklist.md` | 디자인 체크리스트 |
+
+이 패키지는 claude.com Design 세션에 직접 붙여넣어 사용할 수 있습니다.
+
+## 이어하기 (Resume)
+
+이전에 중단된 IDEA가 있으면 자동으로 감지하여 이어하기를 제안합니다.
+
+## 관련 문서
+
+- [/moai design](/ko/workflow-commands/moai-design) — Claude Design 핸드오프 수행
+- [/moai project](/ko/workflow-commands/moai-project) — 프로젝트 초기 설정
+- [/moai plan](/ko/workflow-commands/moai-plan) — SPEC 문서 생성
+- [디자인 시스템](/ko/design/getting-started) — 디자인 파이프라인 개요

--- a/docs-site/content/zh/workflow-commands/moai-db.md
+++ b/docs-site/content/zh/workflow-commands/moai-db.md
@@ -1,0 +1,100 @@
+---
+title: /moai db
+weight: 50
+draft: false
+---
+
+프로젝트 데이터베이스 메타데이터를 관리하는 워크플로우 명령어입니다.
+
+{{< callout type="info" >}}
+**슬래시 커맨드**: Claude Code에서 `/moai:db`을 입력하면 이 명령어를 바로 실행할 수 있습니다.
+{{< /callout >}}
+
+## 개요
+
+`/moai db`는 데이터베이스 스키마, 마이그레이션, 시드를 관리하는 4개 하위 명령어를
+제공합니다. 대화형 인터뷰로 DB 엔진, ORM, 멀티테넌트 설정을 구성하고
+`.moai/project/db/` 아티팩트를 생성합니다.
+
+## 하위 명령어
+
+| 명령어 | 설명 | 읽기 전용 |
+|--------|------|-----------|
+| `init` | 대화형 초기 설정 | 아니오 |
+| `refresh` | 마이그레이션 재스캔 + 스키마 문서 재생성 | 아니오 |
+| `verify` | 드리프트 감지 (스키마 vs 마이그레이션) | 예 |
+| `list` | 테이블 목록 출력 | 예 |
+
+```bash
+/moai db init       # 대화형 설정 마법사
+/moai db refresh    # 마이그레이션 재스캔
+/moai db verify     # 드리프트 검사
+/moai db list       # 테이블 목록
+/moai db            # 하위 명령어 선택
+```
+
+## init — 대화형 초기 설정
+
+### Phase 1: 사전 확인
+
+기존 `.moai/project/db/` 확인 후 인터뷰를 진행합니다.
+
+### Phase 2: 인터뷰
+
+AskUserQuestion으로 다음 항목을 설정합니다:
+
+- **DB 엔진**: PostgreSQL, MySQL, SQLite, MongoDB 등
+- **ORM**: Prisma, TypeORM, SQLAlchemy, GORM 등
+- **멀티테넌트**: 스키마 분리 / 행 수준 분리 / 단일 테넌트
+- **마이그레이션 도구**: 선택한 ORM의 기본 도구 또는 커스텀
+
+### Phase 3: 템플릿 렌더링
+
+`.moai/project/db/` 디렉터리에 다음 파일을 생성합니다:
+
+```
+.moai/project/db/
+├── schema.md          # 스키마 문서 (Markdown)
+├── migrations.md      # 마이그레이션 추적
+└── seeds.md           # 시드 데이터 가이드
+```
+
+## refresh — 마이그레이션 재스캔
+
+마이그레이션 파일을 다시 스캔하고 스키마 문서를 재생성합니다.
+
+- 새 마이그레이션 파일 감지
+- `schema.md` 자동 업데이트
+- 변경사항 요약 출력
+
+## verify — 드리프트 검사
+
+`schema.md`의 테이블 목록과 실제 마이그레이션 파일을 비교합니다.
+
+- **일치**: 종료 코드 0
+- **드리프트 감지**: 종료 코드 1 + 상세 보고서
+
+CI 파이프라인에서 사용하여 스키마 동기화를 검증할 수 있습니다.
+
+```yaml
+# GitHub Actions 예시
+- name: DB Schema Drift Check
+  run: claude -p "/moai db verify"
+```
+
+## list — 테이블 목록
+
+`schema.md`의 모든 테이블을 Markdown 정렬 표로 출력합니다.
+
+## --mode 호환성
+
+이 명령어는 Multi-Mode Router의 `--mode` 축에 참여하지 않습니다. `--mode` 값을
+전달하면 조용히 무시됩니다. 단, `--mode pipeline`은 `MODE_PIPELINE_ONLY_UTILITY`
+오류를 발생시킵니다.
+
+## 관련 문서
+
+- [데이터베이스 시작하기](/ko/db/getting-started) — DB 관리 상세 가이드
+- [스키마 동기화](/ko/db/schema-sync) — 스키마 동기화 패턴
+- [마이그레이션 패턴](/ko/db/migration-patterns) — 마이그레이션 전략
+- [/moai plan](/ko/workflow-commands/moai-plan) — SPEC 문서 생성

--- a/docs-site/content/zh/workflow-commands/moai-design.md
+++ b/docs-site/content/zh/workflow-commands/moai-design.md
@@ -1,0 +1,106 @@
+---
+title: /moai design
+weight: 26
+draft: false
+---
+
+하이브리드 디자인 워크플로우로 브랜드 중심의 웹 경험을 생성합니다.
+
+{{< callout type="info" >}}
+**슬래시 커맨드**: Claude Code에서 `/moai:design`을 입력하면 이 명령어를 바로 실행할 수 있습니다.
+{{< /callout >}}
+
+## 개요
+
+`/moai design`은 자연어 브리프를 브랜드 일관성이 있는 웹 경험으로 변환하는 하이브리드
+디자인 워크플로우입니다. 3가지 경로를 지원합니다:
+
+| 경로 | 설명 | 적합한 경우 |
+|------|------|------------|
+| **Path A** | Claude Design 핸드오프 | claude.com Design 세션 사용 |
+| **Path B1** | Figma → 디자인 토큰 | 기존 Figma 디자인 있는 경우 |
+| **Path B2** | Pencil MCP → 디자인 토큰 | Pencil 파일로 작업하는 경우 |
+| **Path B-Common** | 코드 기반 브랜드 디자인 | 처음부터 시작하는 경우 |
+
+## --mode 플래그
+
+SPEC-V3R2-WF-003의 Multi-Mode Router를 지원합니다.
+
+| 모드 | 설명 |
+|------|------|
+| `autopilot` (기본) | Path B — 코드 기반 브랜드 디자인 자동 실행 |
+| `import` | Path A — Claude Design 핸드오프 번들 가져오기 |
+| `team` | Path B를 병렬 팀으로 실행 (Agent Teams 필요) |
+
+```bash
+/moai design                          # 경로 선택 AskUserQuestion
+/moai design --mode autopilot         # Path B 즉시 실행
+/moai design --mode import            # Path A 핸드오프 가져오기
+/moai design --mode team              # Path B 병렬 실행
+```
+
+## 실행 전 조건 확인
+
+### 브랜드 컨텍스트
+
+`.moai/project/brand/`에 3개 파일이 필요합니다:
+
+```
+.moai/project/brand/
+├── brand-voice.md       # 브랜드 톤, 용어, 메시지 가이드
+├── visual-identity.md   # 색상, 타이포그래피, 시각 언어
+└── target-audience.md   # 타겟 고객 프로필
+```
+
+파일이 없거나 `_TBD_` 마커가 있으면 브랜드 인터뷰가 먼저 진행됩니다.
+
+### Agency 데이터 감지
+
+기존 `.agency/` 디렉터리가 있으면 마이그레이션을 제안합니다:
+
+```bash
+moai migrate agency --dry-run   # 미리보기
+moai migrate agency             # 실행
+```
+
+## 파이프라인 아키텍처
+
+```
+manager-spec → [copywriting, brand-design] (병렬) → expert-frontend → evaluator-active
+                                                                       ↑              |
+                                                                       └──────────────┘
+                                                                  GAN Loop (최대 5회)
+```
+
+1. **manager-spec** — 브리프 문서 생성 (Goal/Audience/Brand 섹션)
+2. **copywriting + brand-design** — 카피 JSON + 디자인 토큰 (병렬 실행)
+3. **expert-frontend** — 코드 구현
+4. **evaluator-active** → **GAN Loop** — 품질 검증 반복
+
+## GAN Loop
+
+Builder-Evaluator 반복 루프가 품질을 보장합니다.
+
+| 파라미터 | 기본값 | 설명 |
+|-----------|--------|------|
+| `pass_threshold` | 0.75 | 통과 임계값 (최소 0.60) |
+| `max_iterations` | 5 | 최대 반복 횟수 |
+| `escalation_after` | 3 | 사용자 개입 요청 시점 |
+| `improvement_threshold` | 0.05 | 정체 감지 임계값 |
+
+## Sprint Contract
+
+`--mode team` 또는 `thorough` 하네스 레벨에서는 Sprint Contract가 협상됩니다:
+
+1. evaluator-active가 수락 체크리스트 생성
+2. expert-frontend가 체크리스트 리뷰
+3. 구현 → 평가 반복
+4. 통과한 기준은 다음 반복에서도 유지 (회귀 불가)
+
+## 관련 문서
+
+- [디자인 시작하기](/ko/design/getting-started) — 디자인 시스템 개요
+- [Claude Design 핸드오프](/ko/design/claude-design-handoff) — Path A 상세 가이드
+- [코드 기반 경로](/ko/design/code-based-path) — Path B 상세 가이드
+- [GAN Loop](/ko/design/gan-loop) — 품질 검증 상세
+- [/moai brain](/ko/workflow-commands/moai-brain) — 아이디에이션 워크플로우


### PR DESCRIPTION
## Summary
- SPEC-DOCS-SITE-001 docs-site Hextra 전환 첫 마일스톤
- 누락된 번역 파일 및 스켈레톤 플레이스홀더 추가
- 4개국어(ko/en/ja/zh) 동기화 작업 진행

## Test plan
- [ ] cd docs-site && hugo --minify 성공
- [ ] 4개 locale 파일 존재 확인
- [ ] 금지 URL(adk.moai.com 등) 미포함 확인

🗿 MoAI <email@mo.ai.kr>