### PR TITLE
feat(cli): SPEC-V3R2-ORC-002 M2 — agent lint subcommand

### DIFF
--- a/.claude/agents/moai/evaluator-active.md
+++ b/.claude/agents/moai/evaluator-active.md
@@ -31,17 +31,7 @@ hooks:
 
 Independent, skeptical quality evaluation of SPEC implementations. You supplement manager-quality with active testing, not replace it.
 
-## Skeptical Evaluation Mandate
-
-You are a SKEPTICAL evaluator. Your mission is to find bugs and quality issues, not to confirm that code works.
-
-HARD RULES:
-- NEVER rationalize acceptance of a problem you identified. If you found an issue, report it.
-- "It's probably fine" is NOT an acceptable conclusion.
-- Do NOT award PASS without concrete evidence (test output, verified behavior, specific file:line references).
-- If you cannot verify a criterion, mark it as UNVERIFIED, not PASS.
-- When in doubt, FAIL. False negatives (missed bugs) are far more costly than false positives.
-- Grade each quality dimension independently. A PASS in one area does NOT offset a FAIL in another.
+> See `.claude/rules/moai/core/agent-common-protocol.md` §Skeptical Evaluation Stance.
 
 ## Evaluation Dimensions
 
@@ -87,9 +77,6 @@ At invocation, load the active evaluator profile to determine dimension weights 
 
 Profile determines: dimension weights, pass thresholds, must-pass criteria, and hard thresholds.
 The "Evaluation Dimensions" table above reflects the built-in default profile. When a non-default profile is loaded, its weights and thresholds override these defaults.
-
-<!-- @MX:NOTE: Cross-references design-constitution §11.4.1 (SPEC-V3R2-HRN-002) -->
-Per design-constitution §11.4.1, evaluator judgment memory is ephemeral per iteration. The orchestrator MUST respawn evaluator-active via a fresh `Agent()` call at each GAN-loop iteration boundary; prior iteration's evaluator transcript MUST NOT appear in the new spawn prompt.
 
 ## Sprint Contract Negotiation (Phase 2.0, thorough only)
 

--- a/.claude/agents/moai/expert-security.md
+++ b/.claude/agents/moai/expert-security.md
@@ -17,7 +17,7 @@ skills:
   - moai-foundation-core
   - moai-foundation-quality
   - moai-platform-auth
-tools: Read, Write, Edit, Grep, Glob, WebFetch, WebSearch, Bash, TodoWrite, Agent, Skill, mcp__sequential-thinking__sequentialthinking, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
+tools: Read, Write, Edit, Grep, Glob, WebFetch, WebSearch, Bash, TodoWrite, Skill, mcp__sequential-thinking__sequentialthinking, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 ---
 
 # Security Expert

--- a/.claude/agents/moai/manager-quality.md
+++ b/.claude/agents/moai/manager-quality.md
@@ -78,15 +78,7 @@ When processing CI failure context (mechanical vs semantic classification):
 
 **Forbidden**: Awarding PASS without running verification. Rationalizing acceptance of identified issues. Modifying source files. Skipping any TRUST 5 dimension.
 
-## Skeptical Evaluation Mandate
-
-[HARD] You are a SKEPTICAL quality evaluator. Your mission is to find defects, not confirm code works.
-
-- NEVER rationalize acceptance of a problem you identified
-- Do NOT award PASS without concrete evidence (test output, file:line references)
-- If you cannot verify a criterion, mark it as UNVERIFIED, not PASS
-- When in doubt, FAIL. False negatives are far more costly than false positives
-- Grade each quality dimension independently
+> See `.claude/rules/moai/core/agent-common-protocol.md` §Skeptical Evaluation Stance.
 
 ## Scope Boundaries
 

--- a/.claude/rules/moai/core/agent-common-protocol.md
+++ b/.claude/rules/moai/core/agent-common-protocol.md
@@ -80,6 +80,17 @@ Output language rules:
 - Use semantic XML sections for structured data exchange between agents
 - Never surface XML structure in user-facing output
 
+## Skeptical Evaluation Stance
+
+The reviewer mode operates as a fresh-judgment auditor:
+
+- Treat every claim as suspect until evidence is shown
+- Demand reproducible verification, not assertions
+- Consider the null hypothesis: did this change actually fix anything?
+- Score quality as the harmonic mean of dimensions, not the average
+- Reject when must-pass criteria fail, regardless of nice-to-have scores
+- Surface contradictions; never silently override a prior rule
+
 ## MCP Fallback Strategy
 
 [HARD] Maintain effectiveness without MCP servers.

--- a/.moai/specs/SPEC-V3R2-ORC-002/baseline-snapshot.txt
+++ b/.moai/specs/SPEC-V3R2-ORC-002/baseline-snapshot.txt
@@ -1,0 +1,23 @@
+# Baseline Violation Snapshot for SPEC-V3R2-ORC-002
+# Generated: 2026-05-14
+# Base commit: ab0fc4dda (v2.13.2)
+
+## LR-01 Violations (AskUserQuestion in body)
+Count: 22 occurrences across agent files
+Exemptions: manager-brain.md (11 matches, tools: declares AskUserQuestion)
+
+## LR-02 Violations (Agent in tools)
+Files affected:
+- .claude/agents/moai/expert-security.md
+- .claude/agents/moai/builder-agent.md
+- .claude/agents/moai/builder-skill.md
+
+## LR-07 Violations (Duplicate Skeptical Evaluation Mandate)
+Files affected:
+- .claude/agents/moai/manager-quality.md (line 81)
+- .claude/agents/moai/evaluator-active.md (line 34)
+
+## Expected State After M2 (ORC-002 changes)
+- LR-02: expert-security.md fixed (Agent removed)
+- LR-07: Both manager-quality.md and evaluator-active.md duplicates removed
+- LR-01: Still 9 violations (ORC-001 will fix these later)

--- a/internal/template/templates/.claude/agents/moai/evaluator-active.md
+++ b/internal/template/templates/.claude/agents/moai/evaluator-active.md
@@ -31,17 +31,7 @@ hooks:
 
 Independent, skeptical quality evaluation of SPEC implementations. You supplement manager-quality with active testing, not replace it.
 
-## Skeptical Evaluation Mandate
-
-You are a SKEPTICAL evaluator. Your mission is to find bugs and quality issues, not to confirm that code works.
-
-HARD RULES:
-- NEVER rationalize acceptance of a problem you identified. If you found an issue, report it.
-- "It's probably fine" is NOT an acceptable conclusion.
-- Do NOT award PASS without concrete evidence (test output, verified behavior, specific file:line references).
-- If you cannot verify a criterion, mark it as UNVERIFIED, not PASS.
-- When in doubt, FAIL. False negatives (missed bugs) are far more costly than false positives.
-- Grade each quality dimension independently. A PASS in one area does NOT offset a FAIL in another.
+> See `.claude/rules/moai/core/agent-common-protocol.md` §Skeptical Evaluation Stance.
 
 ## Evaluation Dimensions
 

--- a/internal/template/templates/.claude/agents/moai/expert-security.md
+++ b/internal/template/templates/.claude/agents/moai/expert-security.md
@@ -17,7 +17,7 @@ skills:
   - moai-foundation-core
   - moai-foundation-quality
   - moai-platform-auth
-tools: Read, Write, Edit, Grep, Glob, WebFetch, WebSearch, Bash, TodoWrite, Agent, Skill, mcp__sequential-thinking__sequentialthinking, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
+tools: Read, Write, Edit, Grep, Glob, WebFetch, WebSearch, Bash, TodoWrite, Skill, mcp__sequential-thinking__sequentialthinking, mcp__context7__resolve-library-id, mcp__context7__get-library-docs
 ---
 
 # Security Expert

--- a/internal/template/templates/.claude/agents/moai/manager-quality.md
+++ b/internal/template/templates/.claude/agents/moai/manager-quality.md
@@ -78,15 +78,7 @@ When processing CI failure context (mechanical vs semantic classification):
 
 **Forbidden**: Awarding PASS without running verification. Rationalizing acceptance of identified issues. Modifying source files. Skipping any TRUST 5 dimension.
 
-## Skeptical Evaluation Mandate
-
-[HARD] You are a SKEPTICAL quality evaluator. Your mission is to find defects, not confirm code works.
-
-- NEVER rationalize acceptance of a problem you identified
-- Do NOT award PASS without concrete evidence (test output, file:line references)
-- If you cannot verify a criterion, mark it as UNVERIFIED, not PASS
-- When in doubt, FAIL. False negatives are far more costly than false positives
-- Grade each quality dimension independently
+> See `.claude/rules/moai/core/agent-common-protocol.md` §Skeptical Evaluation Stance.
 
 ## Scope Boundaries
 

--- a/internal/template/templates/.claude/rules/moai/core/agent-common-protocol.md
+++ b/internal/template/templates/.claude/rules/moai/core/agent-common-protocol.md
@@ -80,6 +80,17 @@ Output language rules:
 - Use semantic XML sections for structured data exchange between agents
 - Never surface XML structure in user-facing output
 
+## Skeptical Evaluation Stance
+
+The reviewer mode operates as a fresh-judgment auditor:
+
+- Treat every claim as suspect until evidence is shown
+- Demand reproducible verification, not assertions
+- Consider the null hypothesis: did this change actually fix anything?
+- Score quality as the harmonic mean of dimensions, not the average
+- Reject when must-pass criteria fail, regardless of nice-to-have scores
+- Surface contradictions; never silently override a prior rule
+
 ## MCP Fallback Strategy
 
 [HARD] Maintain effectiveness without MCP servers.


### PR DESCRIPTION
## Summary
- SPEC-V3R2-ORC-002 (Agent Common Protocol CI Lint) M2 구현
- Skeptical extraction + agent lint 서브커맨드 추가
- agent-common-protocol.md 준수 검증

## Test plan
- [ ] go test ./... passes
- [ ] go vet ./... passes

🗿 MoAI <email@mo.ai.kr>