### PR TITLE
test(evaluator): SPEC-EVAL-001 M1 — evaluator-active agent test scaffolding

### DIFF
--- a/internal/evaluator/evaluator_test.go
+++ b/internal/evaluator/evaluator_test.go
@@ -1,0 +1,49 @@
+package evaluator_test
+
+import (
+	"testing"
+)
+
+// SPEC-EVAL-001 M1 RED phase: evaluator-active agent scaffolding
+// The evaluator-active agent provides independent skeptical quality assessment
+// with 4-dimension scoring (Functionality/Security/Craft/Consistency).
+
+func TestEvaluatorAgent_ScoreDimensions(t *testing.T) {
+	tests := []struct {
+		name      string
+		dimension string
+		wantPanic bool
+	}{
+		{"functionality dimension exists", "functionality", false},
+		{"security dimension exists", "security", false},
+		{"craft dimension exists", "craft", false},
+		{"consistency dimension exists", "consistency", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.wantPanic {
+				t.Skip("dimension not yet implemented")
+			}
+		})
+	}
+}
+
+func TestEvaluatorAgent_ScoreRange(t *testing.T) {
+	// REQ-EVAL-001-001: Score SHALL be between 0.0 and 1.0
+	t.Skip("M2: implement score range validation")
+}
+
+func TestEvaluatorAgent_MustPassCriteria(t *testing.T) {
+	// REQ-EVAL-001-002: Must-pass criteria cannot be compensated by high scores
+	t.Skip("M3: implement must-pass firewall")
+}
+
+func TestEvaluatorAgent_SprintContract(t *testing.T) {
+	// REQ-EVAL-001-003: Sprint Contract negotiation between builder and evaluator
+	t.Skip("M4: implement sprint contract protocol")
+}
+
+func TestEvaluatorAgent_DebiasAnchoring(t *testing.T) {
+	// REQ-EVAL-001-004: Rubric anchoring prevents score inflation
+	t.Skip("M5: implement rubric anchoring")
+}


### PR DESCRIPTION
## Summary
- SPEC-EVAL-001 (evaluator-active Agent & Sprint Contract) M1 RED phase
- 5 test stubs for 4-dimension scoring, must-pass criteria, sprint contract, rubric anchoring

## Test plan
- [ ] go test ./internal/evaluator/... passes
- [ ] go vet ./... passes

🗿 MoAI <email@mo.ai.kr>