### PR TITLE
fix(hook): Stop hook crash when hook_event_name missing

### DIFF
--- a/.moai/specs/SPEC-AGENT-001/plan.md
+++ b/.moai/specs/SPEC-AGENT-001/plan.md
@@ -1,0 +1,95 @@
+---
+spec_id: SPEC-AGENT-001
+plan_version: "0.1.0"
+plan_date: 2026-05-14
+plan_author: manager-spec (auto)
+plan_status: draft
+---
+
+## HISTORY
+
+| Version | Date | Author | Description |
+|---------|------|--------|-------------|
+| 0.1.0 | 2026-05-14 | manager-spec | Initial plan |
+
+## 1. Plan Overview
+
+SPEC-AGENT-001 adds anti-trigger ("NOT for:") scope boundaries to agent descriptions and creates 3 agent-extending reference skills. Codebase analysis reveals significant pre-existing implementation:
+
+- **Anti-triggers**: Most agents already have "NOT for:" lines in their description fields (e.g., evaluator-active.md line 11, manager-quality.md line 11, expert-backend.md, expert-frontend.md).
+- **Reference skills**: 5 reference skills already exist (`moai-ref-api-patterns`, `moai-ref-react-patterns`, `moai-ref-git-workflow`, `moai-ref-owasp-checklist`, `moai-ref-testing-pyramid`), exceeding the 3 originally scoped.
+
+The remaining work is gap-closure: verifying all 17 agents have anti-triggers, confirming reference skills follow the agent-extending pattern, and closing any coverage gaps.
+
+## 2. Gap Analysis
+
+### Already Implemented
+
+| R | Status | Evidence |
+|---|--------|----------|
+| R1 | PARTIAL | Anti-triggers present in most agents; verify all 17+ agents |
+| R2 | DONE | 5 reference skills exist (3 original + 2 additional) |
+| R3 | DONE | Skills follow agent-extending pattern with "Target Agent" declarations |
+
+### Remaining Gaps
+
+1. **Anti-trigger audit**: Need to verify every agent in `.claude/agents/moai/` has a "NOT for:" line. Retired agents (manager-ddd.md, manager-tdd.md) are exempt.
+2. **Coverage completeness**: Verify builder-* and claude-code-guide agents have anti-triggers.
+
+## 3. Milestone Breakdown
+
+### M1 -- Anti-Trigger Audit -- Priority P0
+
+Audit all agent definitions for "NOT for:" anti-trigger presence:
+- Scan all `.claude/agents/moai/*.md` files
+- Identify agents missing anti-triggers
+- Add anti-trigger lines where missing
+- Exclude retired agents from the audit
+
+Files:
+- `internal/template/templates/.claude/agents/moai/*.md` (all agent files)
+
+### M2 -- Reference Skill Verification -- Priority P0
+
+Verify all reference skills follow the agent-extending pattern:
+- Confirm each skill has "Target Agent" declaration
+- Confirm skills contain pure reference content (tables, checklists, patterns)
+- Confirm skills are NOT procedural workflow instructions
+- Verify 3 originally scoped skills exist: moai-ref-api-patterns, moai-ref-react-patterns, moai-ref-git-workflow
+
+Files:
+- `internal/template/templates/.claude/skills/moai-ref-api-patterns/skill.md`
+- `internal/template/templates/.claude/skills/moai-ref-react-patterns/skill.md`
+- `internal/template/templates/.claude/skills/moai-ref-git-workflow/skill.md`
+
+### M3 -- Gap Closure -- Priority P1
+
+Fix any identified gaps from M1 and M2:
+- Add missing anti-triggers to agent descriptions
+- Fix any reference skills that deviate from the agent-extending pattern
+- Update agent frontmatter descriptions as needed
+
+Files:
+- Individual agent files identified in M1 audit
+
+## 4. File:line Anchors
+
+| File | Line(s) | Action | Purpose |
+|------|---------|--------|---------|
+| `internal/template/templates/.claude/agents/moai/evaluator-active.md` | 11 | Verify | "NOT for:" anti-trigger example |
+| `internal/template/templates/.claude/agents/moai/expert-backend.md` | description | Verify/Audit | Anti-trigger presence |
+| `internal/template/templates/.claude/agents/moai/expert-frontend.md` | description | Verify/Audit | Anti-trigger presence |
+| `internal/template/templates/.claude/agents/moai/builder-agent.md` | description | Verify/Audit | Anti-trigger presence |
+| `internal/template/templates/.claude/skills/moai-ref-api-patterns/skill.md` | frontmatter | Verify | Target Agent declaration |
+
+## 5. Quality Gates
+
+- All active (non-retired) agents have "NOT for:" anti-trigger in description
+- All 3 originally scoped reference skills exist and follow agent-extending pattern
+- No regression in existing agent functionality
+- Agent frontmatter valid per agent-authoring rules
+
+## 6. Dependencies
+
+- SPEC-AGENT-002: Agent body reduction (separate SPEC, out of scope)
+- SPEC-V3R3-RETIRED-AGENT-001: Agent retirement already completed

--- a/.moai/specs/SPEC-DRIFT-001/plan.md
+++ b/.moai/specs/SPEC-DRIFT-001/plan.md
@@ -1,0 +1,99 @@
+---
+spec_id: SPEC-DRIFT-001
+plan_version: "0.1.0"
+plan_date: 2026-05-14
+plan_author: manager-spec (auto)
+plan_status: draft
+---
+
+## 1. Plan Overview
+
+SPEC-DRIFT-001 introduces persistent tasks.md for task decomposition and real-time drift guard to detect scope creep during implementation. Codebase analysis reveals this is **already implemented** in run.md:
+
+- **tasks.md generation**: Present at run.md Phase 1.5 (lines 518-533) with structured format (Task ID, Description, REQ mapping, Dependencies, Status, Planned files)
+- **Drift guard calculation**: Present in both Phase 2A (DDD, lines 693-702) and Phase 2B (TDD, lines 736-745) with percentage-based thresholds
+- **Drift thresholds**: <= 20% informational, 20-30% warning, > 30% cumulative triggers re-planning
+
+The remaining work is verification that all REQ are satisfied and edge cases are handled correctly.
+
+## 2. Gap Analysis
+
+### Already Implemented
+
+| REQ | Status | Evidence |
+|-----|--------|----------|
+| REQ-001 | DONE | tasks.md generation at run.md lines 518-533 |
+| REQ-002 | DONE | Drift guard in run.md lines 693-702 (DDD) and 736-745 (TDD) |
+| REQ-003 | DONE | Warning to progress.md + > 30% cumulative triggers Phase 2.7 |
+
+### Remaining Gaps
+
+1. **tasks.md schema validation**: No automated check that generated tasks.md follows the required field structure.
+2. **Exclusion patterns**: Drift guard should exclude .gitignore patterns, test fixtures, and generated files. Verify this is documented.
+3. **Deterministic output**: REQ-001 requires "no timestamps" for git-trackability. Verify tasks.md generation avoids timestamps.
+
+## 3. Milestone Breakdown
+
+### M1 -- Verify tasks.md Generation -- Priority P0
+
+Verify tasks.md generation satisfies REQ-001:
+- Confirm all required fields present (Task ID, Description, REQ mapping, Dependencies, Status, Planned files)
+- Confirm output is deterministic (no timestamps, sorted consistently)
+- Confirm git-trackable format
+- Confirm each task maps to at least one REQ-XXX requirement
+
+Files:
+- `internal/template/templates/.claude/skills/moai/workflows/run.md` lines 518-533 (verify only)
+
+### M2 -- Verify Drift Guard Logic -- Priority P0
+
+Verify drift guard calculation satisfies REQ-002:
+- Confirm drift formula: (unplanned_new_files / total_planned_files) * 100
+- Confirm threshold tiers: <= 20% info, 20-30% warning, > 30% re-plan trigger
+- Confirm drift check runs after each DDD/TDD cycle completion
+- Confirm drift measurement logged to progress.md
+
+Files:
+- `internal/template/templates/.claude/skills/moai/workflows/run.md` lines 693-702, 736-745 (verify only)
+
+### M3 -- Verify Scope Alarm Integration -- Priority P1
+
+Verify scope alarm satisfies REQ-003:
+- Confirm warnings appended to progress.md with drift details
+- Confirm cumulative > 30% triggers Phase 2.7 re-planning gate
+- Confirm re-planning is an extension of existing Phase 2.7, not a replacement
+
+Files:
+- `internal/template/templates/.claude/skills/moai/workflows/run.md` lines 700-702, 744-745 (verify only)
+
+### M4 -- Add Exclusion Pattern Documentation -- Priority P2
+
+Document drift exclusion patterns explicitly:
+- .gitignore-matched files excluded from drift calculation
+- Test fixtures excluded
+- Generated files (e.g., embedded.go) excluded
+- .moai/state/, .moai/reports/, .moai/cache/ excluded
+
+Files:
+- `internal/template/templates/.claude/skills/moai/workflows/run.md` (add exclusion pattern note)
+
+## 4. File:line Anchors
+
+| File | Line(s) | Action | Purpose |
+|------|---------|--------|---------|
+| `internal/template/templates/.claude/skills/moai/workflows/run.md` | 518-533 | Verify | tasks.md generation |
+| `internal/template/templates/.claude/skills/moai/workflows/run.md` | 693-702 | Verify | DDD drift guard |
+| `internal/template/templates/.claude/skills/moai/workflows/run.md` | 736-745 | Verify | TDD drift guard |
+| `internal/template/templates/.claude/rules/moai/workflow/spec-workflow.md` | Drift Guard section | Verify | Drift guard reference |
+
+## 5. Quality Gates
+
+- tasks.md generated with all required fields for any SPEC entering Run phase
+- Drift guard correctly calculates percentage and applies threshold tiers
+- Cumulative drift > 30% triggers Phase 2.7
+- No regressions in existing Run phase flow
+
+## 6. Dependencies
+
+- SPEC-EVAL-001: evaluator-active evaluates against acceptance criteria (runs after drift guard)
+- run.md: Phase 2.7 re-planning gate must exist before scope alarm integration

--- a/.moai/specs/SPEC-EVAL-001/plan.md
+++ b/.moai/specs/SPEC-EVAL-001/plan.md
@@ -1,0 +1,104 @@
+---
+spec_id: SPEC-EVAL-001
+plan_version: "0.1.0"
+plan_date: 2026-05-14
+plan_author: manager-spec (auto)
+plan_status: draft
+---
+
+## HISTORY
+
+| Version | Date | Author | Description |
+|---------|------|--------|-------------|
+| 0.1.0 | 2026-05-14 | manager-spec | Initial plan |
+
+## 1. Plan Overview
+
+SPEC-EVAL-001 defines the evaluator-active agent and Sprint Contract mechanism. Codebase analysis reveals that the core functionality is **already implemented**: evaluator-active.md agent definition exists with 4-dimension scoring, Sprint Contract negotiation (Phase 2.0) and Phase 2.8a/2.8b split are present in run.md, mode-specific deployment (sub-agent/team/CG) is documented, and intervention modes (final-pass/per-sprint) are integrated.
+
+The remaining work is verification and gap-closure: confirming all REQ are satisfied in the current implementation, adding any missing acceptance criteria coverage, and ensuring HRN-003 hierarchical scoring integration is complete.
+
+## 2. Gap Analysis
+
+### Already Implemented
+
+| REQ | Status | Evidence |
+|-----|--------|----------|
+| REQ-001 | DONE | `evaluator-active.md` exists at `internal/template/templates/.claude/agents/moai/evaluator-active.md` with model: sonnet, permissionMode: plan, 4 dimensions, Security hard threshold |
+| REQ-002 | DONE | Phase 2.0 Sprint Contract in `run.md` line 606+, gated by harness level = thorough |
+| REQ-003 | DONE | Phase 2.8a (evaluator-active) and 2.8b (manager-quality) split in `run.md` lines 818-858 |
+| REQ-004 | DONE | Mode-specific deployment documented in evaluator-active.md lines 104-108 |
+| REQ-005 | DONE | final-pass (standard) and per-sprint (thorough) documented in evaluator-active.md lines 99-102 |
+
+### Gaps
+
+1. **HRN-003 integration completeness**: evaluator-active.md includes HRN-003 hierarchical scoring protocol, but no Go-level enforcement of canonical anchors (0.25, 0.50, 0.75, 1.0) exists. This is handled at prompt level only.
+2. **contract.md schema validation**: No automated check that generated contract.md follows the required schema.
+3. **evaluator-active hook**: SubagentStop hook exists (`evaluator-completion`) but no validation of output format.
+
+## 3. Milestone Breakdown
+
+### M1 -- Verify REQ-001 Compliance -- Priority P0
+
+Verify evaluator-active.md satisfies all REQ-001 acceptance criteria:
+- Confirm permissionMode: plan (read-only)
+- Confirm 4 evaluation dimensions with correct weights
+- Confirm Security FAIL = Overall FAIL hard threshold
+- Confirm skeptical evaluator prompt language
+
+Files:
+- `internal/template/templates/.claude/agents/moai/evaluator-active.md` (verify only, likely no changes needed)
+
+### M2 -- Verify REQ-002/003 Phase Integration -- Priority P0
+
+Verify run.md Phase 2.0 and Phase 2.8a/2.8b integration:
+- Phase 2.0 Sprint Contract gated by thorough harness level
+- contract.md persistence path correct
+- Phase 2.8a evaluator-active max 3 retry cycles enforced
+- Phase 2.8b manager-quality runs after 2.8a
+
+Files:
+- `internal/template/templates/.claude/skills/moai/workflows/run.md` (verify only)
+
+### M3 -- Add Evaluation Output Format Validation -- Priority P1
+
+Add structured output format enforcement to evaluator-active.md:
+- Validate evaluation report follows the required Markdown table format
+- Add SubagentStop hook validation for output structure
+- Ensure dimension scores are numeric and within [0, 100] range
+
+Files:
+- `internal/template/templates/.claude/agents/moai/evaluator-active.md` (output format section)
+- `internal/template/templates/.claude/hooks/moai/handle-agent-hook.sh` (evaluator-completion validation)
+
+### M4 -- Integration Test Scenarios -- Priority P1
+
+Document test scenarios for acceptance criteria verification:
+- Scenario 1: Standard Harness Evaluation flow
+- Scenario 2: Thorough Harness Full Cycle flow
+- Scenario 3: Security Hard Threshold enforcement
+
+Files:
+- `.moai/specs/SPEC-EVAL-001/acceptance.md` (verify existing scenarios match spec)
+
+## 4. File:line Anchors
+
+| File | Line(s) | Action | Purpose |
+|------|---------|--------|---------|
+| `internal/template/templates/.claude/agents/moai/evaluator-active.md` | 1-157 | Verify | Agent definition, dimensions, thresholds |
+| `internal/template/templates/.claude/skills/moai/workflows/run.md` | 606-630 | Verify | Phase 2.0 Sprint Contract |
+| `internal/template/templates/.claude/skills/moai/workflows/run.md` | 818-858 | Verify | Phase 2.8a/2.8b split |
+| `internal/template/templates/.moai/config/evaluator-profiles/default.md` | 1-EOF | Verify | Default profile dimensions/weights |
+
+## 5. Quality Gates
+
+- All 5 REQ acceptance criteria verifiable against existing implementation
+- No regressions in existing evaluator-active behavior
+- run.md phase ordering preserved (2.0 -> 2.1 -> ... -> 2.8a -> 2.8b)
+- evaluator-active.md frontmatter valid per agent-authoring rules
+
+## 6. Dependencies
+
+- SPEC-EVALLIB-001: Evaluator profiles already created and loaded by evaluator-active
+- SPEC-V3R2-HRN-003: Hierarchical scoring protocol already integrated in evaluator-active.md
+- SPEC-DRIFT-001: tasks.md generation already in run.md (drift guard dependency)

--- a/.moai/specs/SPEC-EVALLIB-001/plan.md
+++ b/.moai/specs/SPEC-EVALLIB-001/plan.md
@@ -1,0 +1,108 @@
+---
+spec_id: SPEC-EVALLIB-001
+plan_version: "0.1.0"
+plan_date: 2026-05-14
+plan_author: manager-spec (auto)
+plan_status: draft
+---
+
+## HISTORY
+
+| Version | Date | Author | Description |
+|---------|------|--------|-------------|
+| 0.1.0 | 2026-05-14 | manager-spec | Initial plan |
+
+## 1. Plan Overview
+
+SPEC-EVALLIB-001 creates an Evaluator Profile library with 4 default profiles and JSONL evaluation logging. Codebase analysis reveals this is **substantially implemented**:
+
+- **4 profile files exist**: `default.md`, `strict.md`, `lenient.md`, `frontend.md` in `internal/template/templates/.moai/config/evaluator-profiles/`
+- **Profile loading logic exists**: evaluator-active.md lines 79-89 describe profile loading from SPEC frontmatter and harness.yaml fallback
+- **Frontend anti-AI-slop criteria**: frontend.md profile includes AI-slop detection patterns
+
+The remaining work is JSONL logging (REQ-003) and verification of all acceptance criteria.
+
+## 2. Gap Analysis
+
+### Already Implemented
+
+| REQ | Status | Evidence |
+|-----|--------|----------|
+| REQ-001 | DONE | 4 profile files exist in evaluator-profiles/ directory |
+| REQ-002 | DONE | frontend.md has Originality/Design Quality/Craft dimensions with AI-slop penalties |
+| REQ-003 | PARTIAL | JSONL logging to .moai/metrics/evaluation-log.jsonl not yet implemented |
+
+### Remaining Gaps
+
+1. **JSONL evaluation logging**: No .moai/metrics/evaluation-log.jsonl append logic in run.md or evaluator-active.md
+2. **Periodic analysis trigger**: No 50-entry threshold for FP/FN analysis
+3. **Profile schema standardization**: Verify all 4 profiles follow consistent schema (dimensions, weights, thresholds, penalty_patterns)
+
+## 3. Milestone Breakdown
+
+### M1 -- Verify Profile Completeness -- Priority P0
+
+Verify all 4 evaluator profiles are complete and correctly structured:
+- default.md: Functionality 40%, Security 25%, Craft 20%, Consistency 15%
+- strict.md: Security 35%, all dimensions require 80%+
+- lenient.md: Functionality 60%, Security 20%, Craft 10%, Consistency 10%
+- frontend.md: Originality 40%, Design Quality 30%, Craft & Functionality 30% with AI-slop patterns
+
+Files:
+- `internal/template/templates/.moai/config/evaluator-profiles/default.md` (verify)
+- `internal/template/templates/.moai/config/evaluator-profiles/strict.md` (verify)
+- `internal/template/templates/.moai/config/evaluator-profiles/lenient.md` (verify)
+- `internal/template/templates/.moai/config/evaluator-profiles/frontend.md` (verify)
+
+### M2 -- Verify Profile Loading Logic -- Priority P0
+
+Verify evaluator-active.md profile loading satisfies REQ-001 acceptance:
+- SPEC frontmatter `evaluator_profile` field respected
+- Fallback to harness.yaml `default_profile` when no SPEC-level override
+- Final fallback to built-in defaults when profile file not found
+
+Files:
+- `internal/template/templates/.claude/agents/moai/evaluator-active.md` lines 79-89 (verify)
+
+### M3 -- Add JSONL Evaluation Logging -- Priority P1
+
+Implement evaluation result logging to .moai/metrics/evaluation-log.jsonl:
+- Append JSONL entry after each evaluator-active completion
+- Fields: timestamp, spec_id, profile_used, dimension_scores, overall_verdict, flags
+- Create .moai/metrics/ directory if not exists
+- Add JSONL logging instruction to run.md Phase 2.8a completion section
+
+Files:
+- `internal/template/templates/.claude/skills/moai/workflows/run.md` (Phase 2.8a post-evaluation logging step)
+
+### M4 -- Add Periodic Analysis Trigger -- Priority P2
+
+Add 50-entry analysis trigger for FP/FN tuning recommendations:
+- When evaluation-log.jsonl reaches 50 entries, generate summary analysis
+- Output to .moai/metrics/analysis-{date}.md
+- Recommendations only (not auto-applied per exclusion)
+- Analysis triggered by orchestrator, not automated
+
+Files:
+- `internal/template/templates/.claude/skills/moai/workflows/run.md` (add analysis trigger note in Phase 2.8a)
+
+## 4. File:line Anchors
+
+| File | Line(s) | Action | Purpose |
+|------|---------|--------|---------|
+| `internal/template/templates/.moai/config/evaluator-profiles/default.md` | 1-EOF | Verify | Default profile weights |
+| `internal/template/templates/.moai/config/evaluator-profiles/frontend.md` | 1-EOF | Verify | AI-slop detection criteria |
+| `internal/template/templates/.claude/agents/moai/evaluator-active.md` | 79-89 | Verify | Profile loading logic |
+| `internal/template/templates/.claude/skills/moai/workflows/run.md` | 818-858 | Edit | Add JSONL logging after Phase 2.8a |
+
+## 5. Quality Gates
+
+- All 4 profile files exist with correct dimensions, weights, and thresholds
+- Profile loading from SPEC frontmatter works (manual verification)
+- JSONL entries appended on each evaluation run
+- No profile auto-modification (human review required per exclusion)
+
+## 6. Dependencies
+
+- SPEC-EVAL-001: evaluator-active agent definition (profile loading consumer)
+- SPEC-V3R2-HRN-003: Hierarchical scoring protocol (sub-criterion anchors used in profiles)

--- a/.moai/specs/SPEC-PLAYWRIGHT-001/plan.md
+++ b/.moai/specs/SPEC-PLAYWRIGHT-001/plan.md
@@ -1,0 +1,118 @@
+---
+spec_id: SPEC-PLAYWRIGHT-001
+plan_version: "0.1.0"
+plan_date: 2026-05-14
+plan_author: manager-spec (auto)
+plan_status: draft
+---
+
+## HISTORY
+
+| Version | Date | Author | Description |
+|---------|------|--------|-------------|
+| 0.1.0 | 2026-05-14 | manager-spec | Initial plan |
+
+## 1. Plan Overview
+
+SPEC-PLAYWRIGHT-001 adds Playwright/claude-in-chrome MCP integration to evaluator-active for active testing of web interfaces. This enables evaluator-active to navigate, interact with, and evaluate running web applications during Phase 2.8a, gated by thorough harness level and web frontend detection.
+
+Codebase analysis shows this is **not yet implemented**. The evaluator-active agent currently uses read-only tools (`Read, Grep, Glob, Bash, mcp__sequential-thinking__sequentialthinking`) and does not include chrome MCP tools. Playwright testing is not referenced in run.md Phase 2.8a.
+
+## 2. Gap Analysis
+
+### Current State
+
+| REQ | Status | Evidence |
+|-----|--------|----------|
+| REQ-001 | NOT DONE | evaluator-active.md tools field lacks chrome MCP tools |
+| REQ-002 | NOT DONE | No web project detection logic in evaluator-active or run.md |
+| REQ-003 | NOT DONE | No Playwright testing integration in Phase 2.8a |
+
+### Implementation Required
+
+1. Add chrome MCP tools to evaluator-active.md allowed tools
+2. Add web project detection heuristic
+3. Add Playwright testing section to Phase 2.8a, gated by thorough + web detection
+4. Define Playwright test flow and scoring integration
+
+## 3. Milestone Breakdown
+
+### M1 -- Add Chrome MCP Tools to evaluator-active -- Priority P0
+
+Add claude-in-chrome MCP tools to evaluator-active agent definition:
+- Add `mcp__chrome-devtools__*` tools to the tools field
+- These tools enable: navigate_page, take_snapshot, take_screenshot, click, fill, press_key
+- Maintain backward compatibility: if chrome MCP is unavailable, skip gracefully
+
+Files:
+- `internal/template/templates/.claude/agents/moai/evaluator-active.md` line 12 (tools field)
+
+### M2 -- Web Project Detection Heuristic -- Priority P0
+
+Implement web project detection logic:
+- Check `.moai/project/tech.md` technology list for frontend frameworks
+- Check for `package.json` with frontend dependencies (react, vue, next, etc.)
+- Check for `index.html` in project root
+- Return detection result as boolean flag for gating
+
+Files:
+- `internal/template/templates/.claude/skills/moai/workflows/run.md` (add detection step before Phase 2.8a)
+
+### M3 -- Playwright Testing in Phase 2.8a -- Priority P0
+
+Add Playwright testing section to Phase 2.8a, gated by conditions:
+- Gate 1: harness level = thorough
+- Gate 2: web frontend detected (from M2 heuristic)
+- Test flow: navigate -> interact -> capture -> evaluate
+- Score integration: Playwright results contribute to Functionality dimension
+- Playwright failures do NOT independently override overall verdict (unlike Security)
+
+Files:
+- `internal/template/templates/.claude/skills/moai/workflows/run.md` (Phase 2.8a section)
+
+### M4 -- Accessibility Detection Integration -- Priority P1
+
+Add accessibility checks to Playwright testing:
+- Missing alt text detection
+- Broken tab order detection
+- Insufficient contrast detection
+- Missing focus indicators
+- Report accessibility findings in evaluation report
+
+Files:
+- `internal/template/templates/.claude/agents/moai/evaluator-active.md` (add accessibility evaluation section)
+- `internal/template/templates/.claude/skills/moai/workflows/run.md` (add accessibility check step)
+
+### M5 -- Graceful Skip Documentation -- Priority P2
+
+Document graceful skip behavior for non-web or non-thorough projects:
+- Informational log when Playwright testing is skipped
+- No error raised for missing web frontend
+- Static evaluation proceeds normally
+- Skip reason included in evaluation report
+
+Files:
+- `internal/template/templates/.claude/agents/moai/evaluator-active.md` (skip conditions)
+- `internal/template/templates/.claude/skills/moai/workflows/run.md` (skip branch in Phase 2.8a)
+
+## 4. File:line Anchors
+
+| File | Line(s) | Action | Purpose |
+|------|---------|--------|---------|
+| `internal/template/templates/.claude/agents/moai/evaluator-active.md` | 12 | Edit | Add chrome MCP tools |
+| `internal/template/templates/.claude/agents/moai/evaluator-active.md` | 46-55 | Edit | Update dimensions for Playwright results |
+| `internal/template/templates/.claude/skills/moai/workflows/run.md` | 818-858 | Edit | Add Playwright testing in Phase 2.8a |
+
+## 5. Quality Gates
+
+- evaluator-active can use chrome MCP tools when available
+- Playwright testing activates only when thorough + web frontend detected
+- Playwright failures contribute to Functionality dimension but do not override verdict
+- Graceful skip with informational log when conditions not met
+- No regression in static evaluation when Playwright is unavailable
+
+## 6. Dependencies
+
+- SPEC-EVAL-001: evaluator-active agent definition (must exist first)
+- SPEC-EVALLIB-001: frontend.md evaluator profile (Playwright scoring integration)
+- claude-in-chrome MCP server: Must be configured and available at runtime

--- a/.moai/specs/SPEC-SEMAP-001/plan.md
+++ b/.moai/specs/SPEC-SEMAP-001/plan.md
@@ -1,0 +1,116 @@
+---
+spec_id: SPEC-SEMAP-001
+plan_version: "0.1.0"
+plan_date: 2026-05-14
+plan_author: manager-spec (auto)
+plan_status: draft
+---
+
+## HISTORY
+
+| Version | Date | Author | Description |
+|---------|------|--------|-------------|
+| 0.1.0 | 2026-05-14 | manager-spec | Initial plan |
+
+## 1. Plan Overview
+
+SPEC-SEMAP-001 introduces behavioral contracts (preconditions, postconditions, invariants, forbidden) for MoAI agents. Phase 1 targets manager-ddd (now retired/consolidated into manager-develop) and manager-quality. The codebase has evolved since this SPEC was written: manager-ddd and manager-tdd have been retired into manager-develop (SPEC-V3R3-RETIRED-DDD-001).
+
+Key consideration: Since the original Phase 1 targets (manager-ddd, manager-quality) have changed, the plan must be updated to target the current agent roster: **manager-develop** (the consolidated implementation agent) and **manager-quality**.
+
+## 2. Gap Analysis
+
+### Current State
+
+| REQ | Status | Evidence |
+|-----|--------|----------|
+| REQ-001 | NOT DONE | No agent has a `## Contract` section |
+| REQ-002 | NOT DONE | No contract verification at phase completion points |
+| REQ-003 | NOT DONE | No phased rollout enforcement level in config |
+
+### Agent Roster Change
+
+- manager-ddd -> RETIRED, replaced by manager-develop (cycle_type=ddd)
+- manager-tdd -> RETIRED, replaced by manager-develop (cycle_type=tdd)
+- Phase 1 targets must be updated: manager-develop + manager-quality
+
+## 3. Milestone Breakdown
+
+### M1 -- Define Contract Schema and Template -- Priority P0
+
+Define the Markdown-based contract section format for agent definitions:
+- `## Contract` heading in agent body
+- `preconditions`: List of conditions before agent executes
+- `postconditions`: List of conditions after agent completes
+- `invariants`: Conditions that hold throughout execution
+- `forbidden`: Hard prohibitions
+- Each condition is a natural language assertion verifiable by inspection
+
+Files:
+- No file changes needed (schema definition is documentation-first)
+
+### M2 -- Add Contract Sections to Phase 1 Agents -- Priority P0
+
+Add `## Contract` sections to the two Phase 1 agents:
+- **manager-develop.md**: Preconditions (SPEC loaded, worktree active), Postconditions (all tests pass, coverage >= 85%), Invariants (existing tests pass), Forbidden (delete test files)
+- **manager-quality.md**: Preconditions (implementation files exist), Postconditions (LSP errors = 0, TRUST 5 pass), Invariants (no code modified), Forbidden (write code, apply fixes)
+
+Files:
+- `internal/template/templates/.claude/agents/moai/manager-develop.md` (add ## Contract section)
+- `internal/template/templates/.claude/agents/moai/manager-quality.md` (add ## Contract section)
+
+### M3 -- Contract Verification at Phase Completion -- Priority P1
+
+Add contract verification step to spec-workflow.md at phase completion points:
+- After manager-develop completes (Phase 2 implementation): verify postconditions
+- After manager-quality completes (Phase 2.8b): verify postconditions
+- Generate violation report as structured Markdown appended to progress.md
+- Phase 1 enforcement: violations are warnings (non-blocking)
+
+Files:
+- `internal/template/templates/.claude/rules/moai/workflow/spec-workflow.md` (add contract verification step)
+
+### M4 -- Configure Phase 1 Enforcement Level -- Priority P1
+
+Configure warning-only enforcement for Phase 1:
+- Add `contract_enforcement: warning` to quality.yaml or harness.yaml
+- Contract violations produce warnings, not errors
+- Violation data collected for threshold tuning
+- Phase 2 escalation to blocking enforcement requires separate SPEC amendment
+
+Files:
+- `internal/template/templates/.moai/config/sections/quality.yaml` (add contract_enforcement field)
+
+### M5 -- Backward Compatibility Verification -- Priority P2
+
+Verify backward compatibility:
+- Agents without `## Contract` sections behave exactly as before
+- No contract verification runs for agents without contracts
+- No performance impact on agents without contracts
+- Existing tests pass without modification
+
+Files:
+- No file changes (verification only)
+
+## 4. File:line Anchors
+
+| File | Line(s) | Action | Purpose |
+|------|---------|--------|---------|
+| `internal/template/templates/.claude/agents/moai/manager-develop.md` | body (end) | Edit | Add ## Contract section |
+| `internal/template/templates/.claude/agents/moai/manager-quality.md` | body (end) | Edit | Add ## Contract section |
+| `internal/template/templates/.claude/rules/moai/workflow/spec-workflow.md` | Phase completion | Edit | Add contract verification step |
+| `internal/template/templates/.moai/config/sections/quality.yaml` | end | Edit | Add contract_enforcement field |
+
+## 5. Quality Gates
+
+- Contract section parseable (4 fields: preconditions, postconditions, invariants, forbidden)
+- Phase 1 agents (manager-develop, manager-quality) have contracts
+- Contract violations in Phase 1 produce warnings only (non-blocking)
+- Agents without contracts are unaffected (backward compatible)
+- No contract auto-generation (contracts are human-authored per exclusion)
+
+## 6. Dependencies
+
+- SPEC-V3R3-RETIRED-DDD-001: manager-ddd retired into manager-develop (changes Phase 1 targets)
+- SPEC-EVAL-001: evaluator-active performs active evaluation (contract verification complements)
+- SPEC-DRIFT-001: Drift guard checks file scope (contract postconditions check behavior scope)

--- a/.moai/specs/SPEC-V3R2-SPC-001/spec.md
+++ b/.moai/specs/SPEC-V3R2-SPC-001/spec.md
@@ -2,7 +2,7 @@
 id: SPEC-V3R2-SPC-001
 title: "EARS + hierarchical acceptance criteria"
 version: "0.1.1"
-status: in-progress
+status: completed
 created: 2026-04-23
 updated: 2026-05-13
 author: Wave 4 SPEC Writer

--- a/internal/cli/hook.go
+++ b/internal/cli/hook.go
@@ -130,6 +130,11 @@ func runHookEvent(cmd *cobra.Command, event hook.EventType) error {
 		return fmt.Errorf("read hook input: %w", err)
 	}
 
+	// Inject event name from CLI subcommand when Claude Code omits it.
+	if input.HookEventName == "" || input.HookEventName == "unknown" {
+		input.HookEventName = string(event)
+	}
+
 	ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
 	defer cancel()
 

--- a/internal/hook/protocol.go
+++ b/internal/hook/protocol.go
@@ -91,8 +91,11 @@ func validateInput(input *HookInput) error {
 			input.CWD = projectDir
 		}
 	}
+	// hook_event_name is not strictly required: CLI subcommands (moai hook stop, etc.)
+	// already know the event type and inject it via runHookEvent after parsing.
+	// Claude Code may omit hook_event_name for events like Stop and SubagentStop.
 	if input.HookEventName == "" {
-		return fmt.Errorf("%w: missing required field hook_event_name", ErrHookInvalidInput)
+		input.HookEventName = "unknown"
 	}
 	return nil
 }

--- a/internal/hook/protocol_test.go
+++ b/internal/hook/protocol_test.go
@@ -151,16 +151,27 @@ func TestReadInput(t *testing.T) {
 			},
 		},
 		{
-			name:      "missing hook_event_name",
-			input:     `{"session_id": "sess-1", "cwd": "/tmp"}`,
-			wantErr:   true,
-			errTarget: ErrHookInvalidInput,
+			name:    "missing hook_event_name defaults to unknown",
+			input:   `{"session_id": "sess-1", "cwd": "/tmp"}`,
+			wantErr: false,
+			check: func(t *testing.T, got *HookInput) {
+				if got.HookEventName != "unknown" {
+					t.Errorf("HookEventName = %q, want %q", got.HookEventName, "unknown")
+				}
+				if got.SessionID != "sess-1" {
+					t.Errorf("SessionID = %q, want %q", got.SessionID, "sess-1")
+				}
+			},
 		},
 		{
-			name:      "empty JSON object",
-			input:     `{}`,
-			wantErr:   true,
-			errTarget: ErrHookInvalidInput,
+			name:    "empty JSON object defaults to unknown event",
+			input:   `{}`,
+			wantErr: false,
+			check: func(t *testing.T, got *HookInput) {
+				if got.HookEventName != "unknown" {
+					t.Errorf("HookEventName = %q, want %q", got.HookEventName, "unknown")
+				}
+			},
 		},
 		{
 			name:      "malformed JSON",


### PR DESCRIPTION
## Summary
- `handle-stop.sh`가 매 턴마다 `missing required field hook_event_name` 에러로 실패하던 문제 수정
- Claude Code는 Stop/SubagentStop 이벤트에서 `hook_event_name` 필드를 보내지 않음
- `validateInput()`이 이 누락을 에러 대신 `"unknown"`으로 폴백 처리하도록 변경
- `runHookEvent()`에서 CLI 서브커맨드의 이벤트명을 input에 자동 주입

## Test plan
- [x] `go vet ./...` PASS
- [x] `go test ./internal/hook/... ./internal/cli/...` 전체 통과 (15 패키지)
- [x] `echo '{"last_assistant_message":"test"}' | moai hook stop` → `{}` exit 0 확인
- [ ] CI: Windows/macOS/Linux 테스트 통과

🗿 MoAI <email@mo.ai.kr>