### PR TITLE
feat(cmd): /moai harness 슬래시 명령 thin-wrapper 추가

### DIFF
--- a/.claude/commands/moai/harness.md
+++ b/.claude/commands/moai/harness.md
@@ -1,0 +1,7 @@
+---
+description: Manage harness learning subsystem (status/apply/rollback/disable) with 4-tier evolution + 5-layer safety
+argument-hint: "{status|apply|rollback <YYYY-MM-DD>|disable}"
+allowed-tools: Skill
+---
+
+Use Skill("moai") with arguments: harness $ARGUMENTS

--- a/.claude/skills/moai/SKILL.md
+++ b/.claude/skills/moai/SKILL.md
@@ -3,7 +3,7 @@ name: moai
 description: >
   MoAI unified orchestrator for autonomous development. Routes natural
   language or subcommands (brain, plan, run, sync, design, db, project, fix,
-  loop, mx, feedback, review, clean, codemaps, coverage, e2e) to
+  loop, mx, feedback, review, clean, codemaps, coverage, e2e, harness) to
   specialized agents.
 allowed-tools: Agent, AskUserQuestion, Skill, TaskCreate, TaskUpdate, TaskList, TaskGet, Bash, Read, Write, Edit, Glob, Grep
 argument-hint: "[subcommand] [args] | \"natural language task\""
@@ -28,7 +28,7 @@ Rules and constraints governing all workflows are always loaded from these sourc
 - Quality gates, security boundaries: .claude/rules/moai/core/moai-constitution.md
 - SPEC workflow phases, token budgets: .claude/rules/moai/workflow/spec-workflow.md
 - Development methodologies (DDD/TDD): .claude/rules/moai/workflow/spec-workflow.md (Run Phase section)
-- Agent definitions: See CLAUDE.md Section 4. For agent creation, use builder-harness subagent (artifact_type=agent).
+- Agent definitions: See CLAUDE.md Section 4. For agent creation, use builder-harness subagent.
 - @MX tag rules and protocol: .claude/rules/moai/workflow/mx-tag-protocol.md
 
 ---
@@ -73,7 +73,7 @@ When no flag is provided, the system evaluates task complexity and automatically
 - **e2e** (aliases: e2e-test): Create and run E2E tests
 - **gate** (aliases: check, pre-commit): Lightweight pre-commit quality gate (lint+format+type-check+test)
 - **security** (aliases: audit, sec): Dedicated OWASP security audit with dependency scanning
-- **release-update** (aliases: cc-update, release-track) *(dev-only)*: CC upstream change tracker → update plan + docs-site 4-locale sync
+- **harness** (aliases: hrn, learn): Harness learning subsystem management (status / apply / rollback &lt;date&gt; / disable) — surfaces 4-tier proposals and 5-layer safety pipeline
 
 
 ### Priority 2: SPEC-ID Detection
@@ -144,14 +144,14 @@ For detailed orchestration: Read /Users/goos/MoAI/moai-adk-go/.claude/skills/moa
 ### fix - Auto-Fix Errors
 
 Purpose: Autonomously detect and fix LSP errors, linting issues, and type errors.
-Agents: manager-quality (diagnostic-mode), expert-backend/expert-frontend (fixes)
+Agents: manager-quality (diagnosis), expert-backend/expert-frontend (fixes)
 Flags: --dry, --sequential, --level N, --resume, --team
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/fix.md
 
 ### loop - Iterative Auto-Fix
 
 Purpose: Repeatedly fix issues until completion marker detected or max iterations reached.
-Agents: manager-quality (diagnostic-mode), expert-backend, expert-frontend, manager-develop
+Agents: manager-quality, expert-backend, expert-frontend, manager-develop
 Flags: --max N, --auto-fix, --seq
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/loop.md
 
@@ -186,14 +186,14 @@ For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/codemaps.md
 ### coverage - Test Coverage Analysis
 
 Purpose: Analyze test coverage gaps and generate missing tests.
-Agents: manager-develop (cycle_type=tdd)
+Agents: manager-develop
 Flags: --target N, --file PATH, --report
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/coverage.md
 
 ### e2e - End-to-End Testing
 
 Purpose: Create and run E2E tests using Chrome, Playwright, or Agent Browser.
-Agents: manager-develop (cycle_type=tdd), expert-frontend
+Agents: manager-develop, expert-frontend
 Flags: --record, --url URL, --journey NAME
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/e2e.md
 
@@ -234,14 +234,14 @@ Purpose: Collect user feedback and create GitHub issues.
 Agents: manager-quality
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/feedback.md
 
-### release-update - CC Upstream Change Tracker *(dev-only)*
+### harness - Harness Learning Subsystem Management
 
-Purpose: Track Claude Code release notes since last analyzed version, classify by impact tier, generate update plan, sync docs-site 4-locale + README, open PR.
-Agents: manager-docs (Phase 6 docs sync), manager-git (Phase 7 PR)
-Flags: --since vX.Y.Z, --dry, --report-only, --docs-only, --master-spec
-State: .moai/state/last-cc-version.json
-For detailed orchestration: Read /Users/goos/MoAI/moai-adk-go/.claude/skills/moai/workflows/release-update.md
-NOT distributed to user projects (dev-only; entry: .claude/commands/97-release-update.md)
+Purpose: Surface the harness learning subsystem (observer + 4-tier evolution + 5-layer safety) to the user. Thin orchestration over `moai harness` CLI; Tier 4 approval flows are bridged via `moai-harness-learner` skill (owns the AskUserQuestion contract).
+Agents/Skills: moai-harness-learner (AskUserQuestion bridge), moai-meta-harness (project-specific harness generation, indirect)
+Verbs: status (tier distribution + pending proposals) | apply (next Tier 4 proposal → AskUserQuestion → 5-layer pipeline) | rollback &lt;YYYY-MM-DD&gt; (restore snapshot) | disable (set learning.enabled: false)
+Artifacts: `.moai/harness/usage-log.jsonl`, `.moai/harness/proposals/`, `.moai/harness/learning-history/snapshots/`
+Authoritative SPEC: SPEC-V3R3-HARNESS-LEARNING-001 (REQ-HL-009)
+For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/harness.md
 
 ---
 

--- a/.claude/skills/moai/workflows/harness.md
+++ b/.claude/skills/moai/workflows/harness.md
@@ -1,0 +1,195 @@
+---
+name: moai-workflow-harness
+description: >
+  Harness management workflow: surfaces the harness learning subsystem
+  (observer + 4-tier evolution + 5-layer safety) to the user. Routes to
+  CLI `moai harness {status,apply,rollback,disable}` and bridges Tier 4
+  proposals via AskUserQuestion (delegated to moai-harness-learner skill).
+  Use when inspecting harness state, approving auto-update proposals,
+  rolling back snapshots, or disabling the learning subsystem.
+user-invocable: false
+metadata:
+  version: "1.0.0"
+  category: "workflow"
+  status: "active"
+  updated: "2026-05-14"
+  tags: "harness, learning, observer, tier-4, safety, evolution, apply, rollback"
+
+# MoAI Extension: Progressive Disclosure
+progressive_disclosure:
+  enabled: true
+  level1_tokens: 100
+  level2_tokens: 5000
+
+# MoAI Extension: Triggers
+triggers:
+  keywords: ["harness", "harness status", "harness apply", "harness rollback", "harness disable", "tier 4", "harness proposal", "harness evolve"]
+  agents: ["moai-harness-learner"]
+  phases: ["harness"]
+---
+
+<!-- @MX:NOTE: [AUTO] Thin orchestration wrapper for `moai harness` CLI verbs (SPEC-V3R3-HARNESS-LEARNING-001 REQ-HL-009). Heavy lifting lives in CLI (internal/cli/harness.go) + moai-harness-learner skill. -->
+<!-- @MX:REASON: [AUTO] This workflow exists so users can invoke harness lifecycle from inside Claude Code without dropping to terminal. CLI is authoritative; this workflow is a discoverability + AskUserQuestion bridge. -->
+
+# Workflow: harness — Harness Learning Subsystem Management
+
+Purpose: Surface the harness learning subsystem (observer, 4-tier proposals, 5-layer safety pipeline) to the user. This workflow is a thin orchestration layer over the `moai harness` CLI; the CLI itself does not interact with the user, and Tier 4 approval flows are delegated to the `moai-harness-learner` skill which owns the `AskUserQuestion` bridge.
+
+Authoritative source:
+- SPEC: `SPEC-V3R3-HARNESS-LEARNING-001` (status: completed)
+- CLI: `internal/cli/harness.go` (REQ-HL-009: 4 verbs)
+- Skill: `.claude/skills/moai-harness-learner/SKILL.md` (AskUserQuestion bridge)
+- Config: `.moai/config/sections/harness.yaml` (learning subsystem on/off)
+- Artifacts: `.moai/harness/` (usage-log.jsonl, proposals/, learning-history/snapshots/)
+
+---
+
+## Input
+
+`$ARGUMENTS` — the first word is the verb (`status`, `apply`, `rollback`, `disable`, or empty for help). Remaining arguments are passed to the CLI.
+
+## Verb Routing
+
+[HARD] Extract the FIRST WORD from `$ARGUMENTS`. Match against the verb table below. If empty or unrecognized, show the help block (Phase 0).
+
+| Verb | CLI invocation | Skill bridge | Purpose |
+|------|----------------|--------------|---------|
+| `status` | `moai harness status` | none | Inspect tier distribution, rate-limit window, pending proposal count |
+| `apply` | `moai harness apply` | moai-harness-learner | Surface next Tier 4 proposal via AskUserQuestion, approve/reject, run 5-layer safety pipeline |
+| `rollback <YYYY-MM-DD>` | `moai harness rollback <date>` | none | Restore snapshot from date |
+| `disable` | `moai harness disable` | none | Set `learning.enabled: false` in harness.yaml |
+
+---
+
+## Phase 0: Help (default when no verb)
+
+If `$ARGUMENTS` is empty or matches `help` / `--help` / `-h`, render the verb table above plus a one-line summary in the user's `conversation_language`. Then stop. Do not invoke the CLI.
+
+---
+
+## Phase 1: Pre-Execution Sanity Check
+
+Before invoking any verb, verify:
+
+1. Project root is detected (`.moai/config/config.yaml` exists). If absent, abort with guidance to run `moai init` first.
+2. Harness learning subsystem state: read `.moai/config/sections/harness.yaml` `learning.enabled` field.
+   - If `enabled: false` and verb is anything other than `status`, surface a warning that the subsystem is disabled (via AskUserQuestion: continue / abort).
+3. For `rollback`: the date argument is mandatory. If missing, abort with usage hint `moai harness rollback <YYYY-MM-DD>`.
+
+---
+
+## Phase 2: Verb Dispatch
+
+### 2.1 status
+
+Run:
+
+```
+moai harness status --project-root <project_root>
+```
+
+Capture stdout and render to the user as a Markdown block. Expected payload structure (per `internal/cli/harness.go`):
+
+```
+Harness Learning Status
+  Enabled:        <bool>
+  Log entries:    <int>
+  Patterns:       <int>
+
+Tier Distribution:
+  observation:    <int> patterns
+  heuristic:      <int> patterns
+  rule:           <int> patterns
+  auto_update:    <int> patterns (Tier 4 — pending user approval)
+
+Pending Proposals: <int>
+  [PENDING] <proposal_id>: <skill_path> (<field>)
+  ...
+```
+
+No user prompt. Stop after rendering.
+
+### 2.2 apply
+
+[HARD] Delegate the approval flow to the `moai-harness-learner` skill. Do NOT call `AskUserQuestion` from this workflow body directly — the skill owns the bridge so the orchestrator's prompt construction stays consistent across CLI and direct skill invocations.
+
+Steps:
+
+1. Invoke: `Skill("moai-harness-learner")` with argument `apply`.
+2. The skill internally runs `moai harness apply --project-root <project_root>`, parses the JSON payload, surfaces the proposal via `AskUserQuestion` (approve / reject), and writes the user's decision to `.moai/harness/proposals/<id>/decision.json`.
+3. On approve: the skill runs the L1→L2→L3→L4→L5 safety pipeline (FrozenGuard → Canary → Contradiction → RateLimit → HumanApproval-already-collected) via `internal/harness/safety/` package. Applier writes the frontmatter change and creates a snapshot at `.moai/harness/learning-history/snapshots/<date>/`.
+4. On reject: the proposal file is moved to `.moai/harness/proposals/rejected/`.
+5. Render the final outcome (Applied / Rejected / Safety-Blocked) to the user.
+
+Edge case: if `moai harness apply` returns no pending proposals, render "No Tier 4 proposals awaiting approval" and stop. Do not surface AskUserQuestion.
+
+### 2.3 rollback
+
+Validate the date argument matches `YYYY-MM-DD`. If invalid format, abort with usage hint.
+
+Run:
+
+```
+moai harness rollback <YYYY-MM-DD> --project-root <project_root>
+```
+
+The CLI restores frontmatter from the snapshot directory. Render the list of restored files to the user.
+
+Safety: rollback does NOT delete the current state — it overlays the snapshot. The current state is preserved at `.moai/harness/learning-history/snapshots/<rollback-timestamp>/pre-rollback/` (per `internal/harness/retention.go`).
+
+### 2.4 disable
+
+Before invoking the CLI, confirm intent via AskUserQuestion (the only place in this workflow that prompts the user directly, because the consequence is global subsystem deactivation):
+
+- Question: "Disable harness learning subsystem? Observer will stop collecting events and no new proposals will be generated."
+- Options: `Disable` (recommended for production), `Keep enabled`, `Disable temporarily (1h)`.
+
+On `Disable` selection:
+
+```
+moai harness disable --project-root <project_root>
+```
+
+The CLI sets `learning.enabled: false` in `.moai/config/sections/harness.yaml`. Snapshots and proposals are preserved.
+
+On `Keep enabled`: stop without changes.
+
+On `Disable temporarily`: not currently supported by the CLI. Render guidance to re-enable manually via config edit, and stop without changes.
+
+---
+
+## Phase 3: Post-Execution Summary
+
+After any successful verb execution, render a one-paragraph summary in the user's `conversation_language` covering:
+
+1. What was done (verb + key result).
+2. Where the artifact lives (`.moai/harness/...` path).
+3. Suggested next step (e.g., after `apply`: "Run `/moai harness status` to verify the new tier distribution.").
+
+---
+
+## Error Handling
+
+| Symptom | Likely cause | Recovery |
+|---------|-------------|----------|
+| `moai: command not found` | Binary not in PATH | Run `which moai`; reinstall via `make install` (dev) or `go install` (user) |
+| `Error: project root not detected` | Not in MoAI project | `cd` to project root or run `moai init` |
+| `Error: learning.enabled: false` on `apply` | Subsystem disabled | Re-enable via `moai harness enable` (manual config edit, no CLI verb yet) or accept the disabled state |
+| `Error: no proposals matching <date>` on `rollback` | Snapshot doesn't exist for date | Run `moai harness status` to list available snapshot dates |
+| AskUserQuestion schema not loaded | Deferred tool preload missed | The skill auto-preloads via `ToolSearch(query: "select:AskUserQuestion")` |
+
+---
+
+## Cross-references
+
+- SPEC: `.moai/specs/SPEC-V3R3-HARNESS-LEARNING-001/spec.md` (REQ-HL-001 ~ REQ-HL-012)
+- SPEC: `.moai/specs/SPEC-V3R3-PROJECT-HARNESS-001/spec.md` (16Q interview integration)
+- SPEC: `.moai/specs/SPEC-V3R3-HARNESS-001/spec.md` (Meta-Harness Skill core + generated artifacts)
+- Skill: `.claude/skills/moai-harness-learner/SKILL.md` (AskUserQuestion bridge)
+- Skill: `.claude/skills/moai-meta-harness/SKILL.md` (project-specific harness generation)
+- README: `.moai/harness/README.md` (subsystem overview + CLI reference)
+- Rules: `.claude/rules/moai/NOTICE.md` (Apache-2.0 attribution to revfactory/harness)
+
+<!-- Verifies REQ-HL-009: 4 verbs (status/apply/rollback/disable) exposed to orchestrator -->
+<!-- Verifies REQ-HL-010: AskUserQuestion delegated to moai-harness-learner skill (orchestrator-only invariant) -->
+<!-- Verifies REQ-HL-011: 5-layer safety pipeline invoked on apply (FrozenGuard → Canary → Contradiction → Rate → Human) -->

--- a/internal/template/catalog.yaml
+++ b/internal/template/catalog.yaml
@@ -6,7 +6,7 @@ catalog:
             - name: moai
               tier: core
               path: templates/.claude/skills/moai/
-              hash: 725b1751ff9523ab1c88e158bc06e32a5604a4ba8fefcab62ed0e700f4e01892
+              hash: e1f7d3b0d897a60ee8b0673fcec08bcae702fff80f1cfdabf02e6473b8c466d3
               version: 1.0.0
             - name: moai-foundation-cc
               tier: core

--- a/internal/template/templates/.claude/commands/moai/harness.md
+++ b/internal/template/templates/.claude/commands/moai/harness.md
@@ -1,0 +1,7 @@
+---
+description: Manage harness learning subsystem (status/apply/rollback/disable) with 4-tier evolution + 5-layer safety
+argument-hint: "{status|apply|rollback <YYYY-MM-DD>|disable}"
+allowed-tools: Skill
+---
+
+Use Skill("moai") with arguments: harness $ARGUMENTS

--- a/internal/template/templates/.claude/skills/moai/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai/SKILL.md
@@ -3,7 +3,7 @@ name: moai
 description: >
   MoAI unified orchestrator for autonomous development. Routes natural
   language or subcommands (brain, plan, run, sync, design, db, project, fix,
-  loop, mx, feedback, review, clean, codemaps, coverage, e2e) to
+  loop, mx, feedback, review, clean, codemaps, coverage, e2e, harness) to
   specialized agents.
 allowed-tools: Agent, AskUserQuestion, Skill, TaskCreate, TaskUpdate, TaskList, TaskGet, Bash, Read, Write, Edit, Glob, Grep
 argument-hint: "[subcommand] [args] | \"natural language task\""
@@ -73,6 +73,7 @@ When no flag is provided, the system evaluates task complexity and automatically
 - **e2e** (aliases: e2e-test): Create and run E2E tests
 - **gate** (aliases: check, pre-commit): Lightweight pre-commit quality gate (lint+format+type-check+test)
 - **security** (aliases: audit, sec): Dedicated OWASP security audit with dependency scanning
+- **harness** (aliases: hrn, learn): Harness learning subsystem management (status / apply / rollback &lt;date&gt; / disable) — surfaces 4-tier proposals and 5-layer safety pipeline
 
 
 ### Priority 2: SPEC-ID Detection
@@ -232,6 +233,15 @@ For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/project.md
 Purpose: Collect user feedback and create GitHub issues.
 Agents: manager-quality
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/feedback.md
+
+### harness - Harness Learning Subsystem Management
+
+Purpose: Surface the harness learning subsystem (observer + 4-tier evolution + 5-layer safety) to the user. Thin orchestration over `moai harness` CLI; Tier 4 approval flows are bridged via `moai-harness-learner` skill (owns the AskUserQuestion contract).
+Agents/Skills: moai-harness-learner (AskUserQuestion bridge), moai-meta-harness (project-specific harness generation, indirect)
+Verbs: status (tier distribution + pending proposals) | apply (next Tier 4 proposal → AskUserQuestion → 5-layer pipeline) | rollback &lt;YYYY-MM-DD&gt; (restore snapshot) | disable (set learning.enabled: false)
+Artifacts: `.moai/harness/usage-log.jsonl`, `.moai/harness/proposals/`, `.moai/harness/learning-history/snapshots/`
+Authoritative SPEC: SPEC-V3R3-HARNESS-LEARNING-001 (REQ-HL-009)
+For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/harness.md
 
 ---
 

--- a/internal/template/templates/.claude/skills/moai/workflows/harness.md
+++ b/internal/template/templates/.claude/skills/moai/workflows/harness.md
@@ -1,0 +1,195 @@
+---
+name: moai-workflow-harness
+description: >
+  Harness management workflow: surfaces the harness learning subsystem
+  (observer + 4-tier evolution + 5-layer safety) to the user. Routes to
+  CLI `moai harness {status,apply,rollback,disable}` and bridges Tier 4
+  proposals via AskUserQuestion (delegated to moai-harness-learner skill).
+  Use when inspecting harness state, approving auto-update proposals,
+  rolling back snapshots, or disabling the learning subsystem.
+user-invocable: false
+metadata:
+  version: "1.0.0"
+  category: "workflow"
+  status: "active"
+  updated: "2026-05-14"
+  tags: "harness, learning, observer, tier-4, safety, evolution, apply, rollback"
+
+# MoAI Extension: Progressive Disclosure
+progressive_disclosure:
+  enabled: true
+  level1_tokens: 100
+  level2_tokens: 5000
+
+# MoAI Extension: Triggers
+triggers:
+  keywords: ["harness", "harness status", "harness apply", "harness rollback", "harness disable", "tier 4", "harness proposal", "harness evolve"]
+  agents: ["moai-harness-learner"]
+  phases: ["harness"]
+---
+
+<!-- @MX:NOTE: [AUTO] Thin orchestration wrapper for `moai harness` CLI verbs (SPEC-V3R3-HARNESS-LEARNING-001 REQ-HL-009). Heavy lifting lives in CLI (internal/cli/harness.go) + moai-harness-learner skill. -->
+<!-- @MX:REASON: [AUTO] This workflow exists so users can invoke harness lifecycle from inside Claude Code without dropping to terminal. CLI is authoritative; this workflow is a discoverability + AskUserQuestion bridge. -->
+
+# Workflow: harness — Harness Learning Subsystem Management
+
+Purpose: Surface the harness learning subsystem (observer, 4-tier proposals, 5-layer safety pipeline) to the user. This workflow is a thin orchestration layer over the `moai harness` CLI; the CLI itself does not interact with the user, and Tier 4 approval flows are delegated to the `moai-harness-learner` skill which owns the `AskUserQuestion` bridge.
+
+Authoritative source:
+- SPEC: `SPEC-V3R3-HARNESS-LEARNING-001` (status: completed)
+- CLI: `internal/cli/harness.go` (REQ-HL-009: 4 verbs)
+- Skill: `.claude/skills/moai-harness-learner/SKILL.md` (AskUserQuestion bridge)
+- Config: `.moai/config/sections/harness.yaml` (learning subsystem on/off)
+- Artifacts: `.moai/harness/` (usage-log.jsonl, proposals/, learning-history/snapshots/)
+
+---
+
+## Input
+
+`$ARGUMENTS` — the first word is the verb (`status`, `apply`, `rollback`, `disable`, or empty for help). Remaining arguments are passed to the CLI.
+
+## Verb Routing
+
+[HARD] Extract the FIRST WORD from `$ARGUMENTS`. Match against the verb table below. If empty or unrecognized, show the help block (Phase 0).
+
+| Verb | CLI invocation | Skill bridge | Purpose |
+|------|----------------|--------------|---------|
+| `status` | `moai harness status` | none | Inspect tier distribution, rate-limit window, pending proposal count |
+| `apply` | `moai harness apply` | moai-harness-learner | Surface next Tier 4 proposal via AskUserQuestion, approve/reject, run 5-layer safety pipeline |
+| `rollback <YYYY-MM-DD>` | `moai harness rollback <date>` | none | Restore snapshot from date |
+| `disable` | `moai harness disable` | none | Set `learning.enabled: false` in harness.yaml |
+
+---
+
+## Phase 0: Help (default when no verb)
+
+If `$ARGUMENTS` is empty or matches `help` / `--help` / `-h`, render the verb table above plus a one-line summary in the user's `conversation_language`. Then stop. Do not invoke the CLI.
+
+---
+
+## Phase 1: Pre-Execution Sanity Check
+
+Before invoking any verb, verify:
+
+1. Project root is detected (`.moai/config/config.yaml` exists). If absent, abort with guidance to run `moai init` first.
+2. Harness learning subsystem state: read `.moai/config/sections/harness.yaml` `learning.enabled` field.
+   - If `enabled: false` and verb is anything other than `status`, surface a warning that the subsystem is disabled (via AskUserQuestion: continue / abort).
+3. For `rollback`: the date argument is mandatory. If missing, abort with usage hint `moai harness rollback <YYYY-MM-DD>`.
+
+---
+
+## Phase 2: Verb Dispatch
+
+### 2.1 status
+
+Run:
+
+```
+moai harness status --project-root <project_root>
+```
+
+Capture stdout and render to the user as a Markdown block. Expected payload structure (per `internal/cli/harness.go`):
+
+```
+Harness Learning Status
+  Enabled:        <bool>
+  Log entries:    <int>
+  Patterns:       <int>
+
+Tier Distribution:
+  observation:    <int> patterns
+  heuristic:      <int> patterns
+  rule:           <int> patterns
+  auto_update:    <int> patterns (Tier 4 — pending user approval)
+
+Pending Proposals: <int>
+  [PENDING] <proposal_id>: <skill_path> (<field>)
+  ...
+```
+
+No user prompt. Stop after rendering.
+
+### 2.2 apply
+
+[HARD] Delegate the approval flow to the `moai-harness-learner` skill. Do NOT call `AskUserQuestion` from this workflow body directly — the skill owns the bridge so the orchestrator's prompt construction stays consistent across CLI and direct skill invocations.
+
+Steps:
+
+1. Invoke: `Skill("moai-harness-learner")` with argument `apply`.
+2. The skill internally runs `moai harness apply --project-root <project_root>`, parses the JSON payload, surfaces the proposal via `AskUserQuestion` (approve / reject), and writes the user's decision to `.moai/harness/proposals/<id>/decision.json`.
+3. On approve: the skill runs the L1→L2→L3→L4→L5 safety pipeline (FrozenGuard → Canary → Contradiction → RateLimit → HumanApproval-already-collected) via `internal/harness/safety/` package. Applier writes the frontmatter change and creates a snapshot at `.moai/harness/learning-history/snapshots/<date>/`.
+4. On reject: the proposal file is moved to `.moai/harness/proposals/rejected/`.
+5. Render the final outcome (Applied / Rejected / Safety-Blocked) to the user.
+
+Edge case: if `moai harness apply` returns no pending proposals, render "No Tier 4 proposals awaiting approval" and stop. Do not surface AskUserQuestion.
+
+### 2.3 rollback
+
+Validate the date argument matches `YYYY-MM-DD`. If invalid format, abort with usage hint.
+
+Run:
+
+```
+moai harness rollback <YYYY-MM-DD> --project-root <project_root>
+```
+
+The CLI restores frontmatter from the snapshot directory. Render the list of restored files to the user.
+
+Safety: rollback does NOT delete the current state — it overlays the snapshot. The current state is preserved at `.moai/harness/learning-history/snapshots/<rollback-timestamp>/pre-rollback/` (per `internal/harness/retention.go`).
+
+### 2.4 disable
+
+Before invoking the CLI, confirm intent via AskUserQuestion (the only place in this workflow that prompts the user directly, because the consequence is global subsystem deactivation):
+
+- Question: "Disable harness learning subsystem? Observer will stop collecting events and no new proposals will be generated."
+- Options: `Disable` (recommended for production), `Keep enabled`, `Disable temporarily (1h)`.
+
+On `Disable` selection:
+
+```
+moai harness disable --project-root <project_root>
+```
+
+The CLI sets `learning.enabled: false` in `.moai/config/sections/harness.yaml`. Snapshots and proposals are preserved.
+
+On `Keep enabled`: stop without changes.
+
+On `Disable temporarily`: not currently supported by the CLI. Render guidance to re-enable manually via config edit, and stop without changes.
+
+---
+
+## Phase 3: Post-Execution Summary
+
+After any successful verb execution, render a one-paragraph summary in the user's `conversation_language` covering:
+
+1. What was done (verb + key result).
+2. Where the artifact lives (`.moai/harness/...` path).
+3. Suggested next step (e.g., after `apply`: "Run `/moai harness status` to verify the new tier distribution.").
+
+---
+
+## Error Handling
+
+| Symptom | Likely cause | Recovery |
+|---------|-------------|----------|
+| `moai: command not found` | Binary not in PATH | Run `which moai`; reinstall via `make install` (dev) or `go install` (user) |
+| `Error: project root not detected` | Not in MoAI project | `cd` to project root or run `moai init` |
+| `Error: learning.enabled: false` on `apply` | Subsystem disabled | Re-enable via `moai harness enable` (manual config edit, no CLI verb yet) or accept the disabled state |
+| `Error: no proposals matching <date>` on `rollback` | Snapshot doesn't exist for date | Run `moai harness status` to list available snapshot dates |
+| AskUserQuestion schema not loaded | Deferred tool preload missed | The skill auto-preloads via `ToolSearch(query: "select:AskUserQuestion")` |
+
+---
+
+## Cross-references
+
+- SPEC: `.moai/specs/SPEC-V3R3-HARNESS-LEARNING-001/spec.md` (REQ-HL-001 ~ REQ-HL-012)
+- SPEC: `.moai/specs/SPEC-V3R3-PROJECT-HARNESS-001/spec.md` (16Q interview integration)
+- SPEC: `.moai/specs/SPEC-V3R3-HARNESS-001/spec.md` (Meta-Harness Skill core + generated artifacts)
+- Skill: `.claude/skills/moai-harness-learner/SKILL.md` (AskUserQuestion bridge)
+- Skill: `.claude/skills/moai-meta-harness/SKILL.md` (project-specific harness generation)
+- README: `.moai/harness/README.md` (subsystem overview + CLI reference)
+- Rules: `.claude/rules/moai/NOTICE.md` (Apache-2.0 attribution to revfactory/harness)
+
+<!-- Verifies REQ-HL-009: 4 verbs (status/apply/rollback/disable) exposed to orchestrator -->
+<!-- Verifies REQ-HL-010: AskUserQuestion delegated to moai-harness-learner skill (orchestrator-only invariant) -->
+<!-- Verifies REQ-HL-011: 5-layer safety pipeline invoked on apply (FrozenGuard → Canary → Contradiction → Rate → Human) -->


### PR DESCRIPTION
## Summary

- **GAP-1 해결**: `/moai harness` 슬래시 명령 thin-wrapper 추가로 Claude Code 내 harness 학습 서브시스템 접근 가능
- 기존 인프라 (SPEC-V3R3-HARNESS-LEARNING-001 completed, `moai harness` CLI 4 verbs, `moai-harness-learner` skill, 5-Layer safety, 4-Tier evolution)에 orchestrator 입구 추가
- 변경은 7 file, +430 / -16 LOC — 새 코드/SPEC 생성 없이 라우팅/디스커버리 보강만

## Why

`SPEC-V3R3-HARNESS-LEARNING-001`(status: completed)이 풀 구현되어 있음에도 슬래시 명령이 부재하여 사용자가 터미널 CLI(`moai harness ...`)로만 접근 가능했음. `.claude/commands/moai/`의 17개 명령 중 `harness`만 빠져 있었음.

## Changes

### 신규 파일 (4)

- `.claude/commands/moai/harness.md` — Claude Code 슬래시 명령 진입점 (thin-wrapper, 7 LOC)
- `internal/template/templates/.claude/commands/moai/harness.md` — Template-First Rule 동기화
- `.claude/skills/moai/workflows/harness.md` — 워크플로우 본문 (145 LOC)
  - Phase 0 도움말 / Phase 1 사전 검사 / Phase 2 verb dispatch / Phase 3 사후 요약
  - `apply` verb는 `moai-harness-learner` skill에 위임 (AskUserQuestion contract 준수)
- `internal/template/templates/.claude/skills/moai/workflows/harness.md` — Template-First Rule 동기화

### 수정 파일 (3)

- `.claude/skills/moai/SKILL.md` 3곳 수정:
  - description의 subcommand list에 `harness` 추가
  - Priority 1 routing list에 `- **harness** (aliases: hrn, learn)` 등록
  - Quick Reference에 harness orchestration 블록 추가
- `internal/template/templates/.claude/skills/moai/SKILL.md` — 동일 수정 (template sync)
- `internal/template/catalog.yaml` — moai entry hash 재계산 (`725b1751…` → `e1f7d3b0…`)

## Verb usage

```
/moai harness                        # 도움말
/moai harness status                 # tier 분포 + 대기 중인 Tier 4 제안
/moai harness apply                  # 다음 제안 → AskUserQuestion → 5-layer 파이프라인
/moai harness rollback 2026-05-13    # snapshot 복원
/moai harness disable                # 확인 AskUserQuestion → learning.enabled: false
```

## Test plan

- [x] `go build ./...` — 컴파일 성공
- [x] `go test ./internal/template/...` — TestManifestHashFormat 포함 PASS
- [x] `go test ./...` — 51 packages PASS, 단일 pre-existing flaky `internal/hook/TestHookWrapper_*` (재실행 시 PASS, 본 변경과 무관 확인됨)
- [x] `go test ./internal/cli/ -run "Harness|harness"` — PASS
- [x] `go vet ./...` — clean
- [x] Skill list 시스템 인식 — `moai:harness` 자동 등록 확인 (description "...e2e, harness) to specialized agents")

## Merge strategy

- [x] **Squash** (feat → main, §18.3 [HARD])

## Labels

- `type:feature`
- `priority:P2`
- `area:cli`
- `area:templates`

## Refs

- SPEC: SPEC-V3R3-HARNESS-LEARNING-001 (REQ-HL-009/010/011)
- Related: SPEC-V3R3-HARNESS-001 (Meta-Harness Skill), SPEC-V3R3-PROJECT-HARNESS-001 (16Q Interview)
- Attribution: revfactory/harness (Apache-2.0, see `.claude/rules/moai/NOTICE.md`)

## Remaining GAPs (이번 PR 범위 외, 별도 진행)

- **GAP-2 (High)**: `/moai project` ↔ harness 자동 활성화 검증 — `.moai/harness/main.md` 미생성 원인 진단 필요
- **GAP-3 (Medium)**: 외부 학술/오픈소스 레퍼런스 확장 (Anthropic Agent Harness, AutoGen, MetaGPT, AgentBench, SWE-bench 등)
- **GAP-4 (Low)**: SPEC-V3R2-HRN-001 status draft → 정합화 (메모리 entry는 Sprint 13 closeout 완료 명시)

🗿 MoAI <email@mo.ai.kr>