### PR TITLE
feat(SPEC-V3R4-HARNESS-001): V3R4 self-evolving harness foundation — CLI retirement + lifecycle consolidation

### DIFF
--- a/.claude/commands/moai/harness.md
+++ b/.claude/commands/moai/harness.md
@@ -1,0 +1,7 @@
+---
+description: Manage harness learning subsystem (status/apply/rollback/disable) with 4-tier evolution + 5-layer safety
+argument-hint: "{status|apply|rollback <YYYY-MM-DD>|disable}"
+allowed-tools: Skill
+---
+
+Use Skill("moai") with arguments: harness $ARGUMENTS

--- a/.claude/skills/moai-harness-learner/SKILL.md
+++ b/.claude/skills/moai-harness-learner/SKILL.md
@@ -16,7 +16,9 @@ user-invocable: false
 
 # moai-harness-learner
 
-Coordinator skill for the Harness Learning Subsystem (SPEC-V3R3-HARNESS-LEARNING-001).
+<!-- @MX:NOTE: [AUTO] V3R4 contract — this skill body is preserved unchanged per SPEC-V3R4-HARNESS-001 §10 exclusion #10 (text annotation only, no behavioral change). The 4-tier observation/heuristic/rule/auto_update ladder defined here is preserved verbatim under REQ-HRN-FND-011. The orchestrator-only AskUserQuestion contract is asserted by REQ-HRN-FND-015 (cross-reference: .claude/rules/moai/core/agent-common-protocol.md § User Interaction Boundary). The downstream replacement of the frequency-count classifier with an embedding-cluster algorithm is deferred to SPEC-V3R4-HARNESS-003. -->
+
+Coordinator skill for the Harness Learning Subsystem (SPEC-V3R3-HARNESS-LEARNING-001, superseded by SPEC-V3R4-HARNESS-001 as the active V3R4 foundation; this V3R3 SPEC's 4-tier ladder is preserved unchanged).
 Surfaces Tier 4 auto-update proposals to the user via AskUserQuestion and orchestrates Apply/Rollback flows.
 
 ## Quick Reference

--- a/.claude/skills/moai-meta-harness/SKILL.md
+++ b/.claude/skills/moai-meta-harness/SKILL.md
@@ -153,8 +153,9 @@ Agents involved: `builder-agent`, `builder-skill` for artifact generation.
 This skill fills the skeleton with domain-specific content:
 
 1. Generate agent definitions (`.claude/agents/my-harness/*.md`) referencing
-   existing MoAI agents: `manager-spec`, `manager-strategy`, `manager-tdd`,
-   `manager-ddd`, `manager-quality`, `manager-docs`, `manager-git`,
+   existing MoAI agents: `manager-spec`, `manager-strategy`, `manager-develop`
+   (`cycle_type=tdd` or `cycle_type=ddd` per `quality.yaml` `development_mode`),
+   `manager-quality`, `manager-docs`, `manager-git`,
    `expert-backend`, `expert-frontend`, `expert-debug`, `expert-testing`,
    `expert-security`, `expert-refactoring`, `expert-performance`, `expert-devops`,
    `expert-mobile`, `builder-agent`, `builder-skill`, `builder-plugin`,
@@ -214,8 +215,7 @@ referenced below are static MoAI agents — no new agents are introduced.
 
 **Workflow Managers**
 
-- `manager-ddd` — DDD-flavored harness workflow templates
-- `manager-tdd` — TDD-flavored harness workflow templates
+- `manager-develop` (`cycle_type=ddd` or `cycle_type=tdd` per `.moai/config/sections/quality.yaml` `development_mode`) — DDD or TDD-flavored harness workflow templates (SPEC-V3R3-RETIRED-DDD-001 M3 consolidated the prior DDD and TDD specialist managers into the unified `manager-develop` agent with cycle-type dispatch)
 - `manager-quality` — Quality gate configuration in generated harnesses
 - `manager-docs` — Documentation generation patterns
 - `manager-git` — Git workflow patterns for generated harnesses

--- a/.claude/skills/moai-meta-harness/SKILL.md
+++ b/.claude/skills/moai-meta-harness/SKILL.md
@@ -34,6 +34,8 @@ triggers:
 
 # moai-meta-harness
 
+<!-- @MX:NOTE: [AUTO] V3R4 contract — this skill body is preserved unchanged per SPEC-V3R4-HARNESS-001 §10 exclusion #10 (text annotation only, no behavioral change). The meta-harness 7-Phase workflow that generates project-specific my-harness-* skills and .claude/agents/my-harness/* definitions is governed by REQ-HRN-FND-015 (orchestrator-only AskUserQuestion contract) — any subagent generated under .claude/agents/my-harness/ MUST NOT invoke AskUserQuestion; if user input is required, the subagent returns a structured blocker report and the orchestrator runs the AskUser round. Cross-reference: .claude/rules/moai/core/agent-common-protocol.md § User Interaction Boundary. -->
+
 <!-- ATTRIBUTION
 Original work: revfactory/harness (https://github.com/revfactory/harness)
 License: Apache License 2.0

--- a/.claude/skills/moai/SKILL.md
+++ b/.claude/skills/moai/SKILL.md
@@ -3,7 +3,7 @@ name: moai
 description: >
   MoAI unified orchestrator for autonomous development. Routes natural
   language or subcommands (brain, plan, run, sync, design, db, project, fix,
-  loop, mx, feedback, review, clean, codemaps, coverage, e2e) to
+  loop, mx, feedback, review, clean, codemaps, coverage, e2e, harness) to
   specialized agents.
 allowed-tools: Agent, AskUserQuestion, Skill, TaskCreate, TaskUpdate, TaskList, TaskGet, Bash, Read, Write, Edit, Glob, Grep
 argument-hint: "[subcommand] [args] | \"natural language task\""
@@ -73,6 +73,7 @@ When no flag is provided, the system evaluates task complexity and automatically
 - **e2e** (aliases: e2e-test): Create and run E2E tests
 - **gate** (aliases: check, pre-commit): Lightweight pre-commit quality gate (lint+format+type-check+test)
 - **security** (aliases: audit, sec): Dedicated OWASP security audit with dependency scanning
+- **harness** (aliases: hrn, learn): V3R4 self-evolving harness lifecycle (status / apply / rollback &lt;date&gt; / disable) — slash-command-only surface; CLI verb path retired per SPEC-V3R4-HARNESS-001 (BC-V3R4-HARNESS-001-CLI-RETIREMENT)
 - **release-update** (aliases: cc-update, release-track) *(dev-only)*: CC upstream change tracker → update plan + docs-site 4-locale sync
 
 
@@ -233,6 +234,15 @@ For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/project.md
 Purpose: Collect user feedback and create GitHub issues.
 Agents: manager-quality
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/feedback.md
+
+### harness - V3R4 Self-Evolving Harness Lifecycle
+
+Purpose: Surface the harness learning subsystem (observer, 4-tier proposal ladder, 5-layer safety pipeline) to the user via the slash command path. Owns all lifecycle verbs (status / apply / rollback / disable) entirely within the workflow body using file-system operations — no Go binary subcommand invoked. Tier-4 application is gated by orchestrator-issued AskUserQuestion per REQ-HRN-FND-004.
+Skills: moai-harness-learner (Tier-4 surfacing companion), moai-meta-harness (project-specific harness generation, indirect)
+Verbs: status (tier distribution + telemetry) | apply (next Tier-4 proposal → AskUserQuestion → 5-layer pipeline → snapshot + write) | rollback &lt;YYYY-MM-DD&gt; (restore snapshot) | disable (set learning.enabled: false)
+Artifacts: `.moai/harness/usage-log.jsonl`, `.moai/harness/proposals/`, `.moai/harness/learning-history/snapshots/`, `.moai/harness/learning-history/applied/`, `.moai/harness/learning-history/frozen-guard-violations.jsonl`
+Authoritative SPEC: SPEC-V3R4-HARNESS-001 (supersedes V3R3-HARNESS-001, V3R3-HARNESS-LEARNING-001, V3R3-PROJECT-HARNESS-001)
+For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/harness.md
 
 ### release-update - CC Upstream Change Tracker *(dev-only)*
 

--- a/.claude/skills/moai/workflows/harness.md
+++ b/.claude/skills/moai/workflows/harness.md
@@ -1,0 +1,270 @@
+---
+name: moai-workflow-harness
+description: >
+  V3R4 Self-Evolving Harness lifecycle workflow. Owns all lifecycle verbs
+  (status, apply, rollback, disable) entirely within the moai skill body
+  using file-system operations — no Go binary subcommand is invoked. Tier-4
+  evolution applications are gated by an orchestrator-issued AskUserQuestion
+  approval round per the 5-Layer Safety architecture.
+user-invocable: false
+metadata:
+  version: "2.0.0"
+  category: "workflow"
+  status: "active"
+  updated: "2026-05-14"
+  tags: "harness, learning, observer, tier-4, safety, evolution, apply, rollback, v3r4, cli-retired"
+
+# MoAI Extension: Progressive Disclosure
+progressive_disclosure:
+  enabled: true
+  level1_tokens: 100
+  level2_tokens: 5000
+
+# MoAI Extension: Triggers
+triggers:
+  keywords: ["harness", "harness status", "harness apply", "harness rollback", "harness disable", "tier 4", "harness proposal", "harness evolve"]
+  agents: ["moai-harness-learner"]
+  phases: ["harness"]
+---
+
+<!-- @MX:NOTE: [AUTO] V3R4 contract — workflow body owns the lifecycle entirely via file-system operations. No `moai harness` CLI subcommand is invoked. The Go file `internal/cli/harness.go` is retained only as a deprecation marker awaiting downstream physical removal per SPEC-V3R4-HARNESS-001 (BC-V3R4-HARNESS-001-CLI-RETIREMENT). -->
+<!-- @MX:REASON: [AUTO] V3R3-era workflow body shelled out to `moai harness <verb>` cobra subcommand. V3R4 retires that CLI verb path (REQ-HRN-FND-001, REQ-HRN-FND-002) and consolidates all lifecycle execution into the slash command + workflow body surface (REQ-HRN-FND-003). -->
+
+# Workflow: harness — V3R4 Self-Evolving Harness Lifecycle
+
+Purpose: Surface the harness learning subsystem (observer, 4-tier proposal ladder, 5-layer safety pipeline) to the user. This workflow IS the implementation — every verb (`status`, `apply`, `rollback`, `disable`) is executed by file-system reads and writes inside this workflow body. No Go binary subcommand is invoked. The Go CLI factory in `internal/cli/harness.go` remains in the tree as a deprecation marker only; it is never registered into the cobra command tree (REQ-HRN-FND-001, REQ-HRN-FND-002).
+
+## Authoritative Sources
+
+- SPEC (active): `SPEC-V3R4-HARNESS-001` (foundation, supersedes the three V3R3 harness SPECs)
+- Constitution: `.claude/rules/moai/design/constitution.md` §5 (5-Layer Safety) and §2 (Frozen/Evolvable zones)
+- AskUserQuestion contract: `.claude/rules/moai/core/askuser-protocol.md` (canonical reference)
+- Agent boundary: `.claude/rules/moai/core/agent-common-protocol.md` § User Interaction Boundary
+- Config: `.moai/config/sections/harness.yaml` (`learning.enabled` field)
+- State roots:
+  - `.moai/harness/usage-log.jsonl` (PostToolUse observation append-only log)
+  - `.moai/harness/proposals/` (pending Tier-4 proposals)
+  - `.moai/harness/learning-history/snapshots/<ISO-DATE>/` (pre-modification snapshots)
+  - `.moai/harness/learning-history/applied/` (applied proposals, used for rate-limit window)
+  - `.moai/harness/learning-history/tier-promotions.jsonl` (tier classifier transitions)
+  - `.moai/harness/learning-history/frozen-guard-violations.jsonl` (L1 audit log)
+
+## Related Rules and References
+
+- AskUserQuestion ToolSearch preload procedure: `.claude/rules/moai/core/askuser-protocol.md` § ToolSearch Preload Procedure
+- Free-form circumvention prohibition: `.claude/rules/moai/core/askuser-protocol.md` § Free-form Circumvention Prohibition
+- Orchestrator-subagent boundary: `.claude/rules/moai/core/agent-common-protocol.md` § User Interaction Boundary
+- Lessons (auto-memory): `lessons.md` workflow + harness categories when present
+
+---
+
+## Tier-4 Application Gate (Orchestrator-Only AskUserQuestion)
+
+[HARD] Tier-4 application of any harness evolution proposal MUST be gated by an orchestrator-issued `AskUserQuestion` round before any file modification occurs (REQ-HRN-FND-004, REQ-HRN-FND-015). The workflow body itself is executed in the orchestrator's main context; `AskUserQuestion` is invoked here as the orchestrator's tool. Subagents reachable from this workflow MUST NOT call `AskUserQuestion`; if a subagent needs user input it returns a structured blocker report and the orchestrator re-runs the round (canonical reference: `.claude/rules/moai/core/askuser-protocol.md`).
+
+### Canonical Four-Option Pattern
+
+Before invoking `AskUserQuestion`, preload the schema:
+
+```
+ToolSearch(query: "select:AskUserQuestion")
+```
+
+Then invoke with at least three options (Apply / Defer / Reject — additional options permitted), the first option marked `(권장)` or `(Recommended)`:
+
+```
+AskUserQuestion({
+  questions: [{
+    question: "Harness Tier-4 evolution proposal ready to apply (id: <proposal_id>).\n\nTarget: <target_path>\nField: <field_key>\nProposed value: <new_value>\nObservation count: <observation_count>\n\nApply this change?",
+    header: "Tier-4 Apply",
+    options: [
+      { label: "Apply (권장)", description: "Run the 5-Layer Safety pipeline. On pass, create a snapshot and write the change. Snapshot lives under .moai/harness/learning-history/snapshots/<ISO-DATE>/." },
+      { label: "Modify", description: "Open the proposal for manual edit before re-presenting. Proposal file is preserved." },
+      { label: "Defer", description: "Re-record the proposal for later approval. The 7-day rate-limit window starts only when an Apply is accepted." },
+      { label: "Reject", description: "Move the proposal to .moai/harness/learning-history/rejected/. No file is modified." }
+    ]
+  }]
+})
+```
+
+### Rate-Limit Enforcement (REQ-HRN-FND-012)
+
+Before opening the AskUserQuestion round, count entries in `.moai/harness/learning-history/applied/` whose `applied_at` falls within the last 7 days. If the count is ≥ 1, the new candidate MUST be deferred and recorded with a `deferred_at` timestamp; do NOT invoke `AskUserQuestion`. The rate-limit floor of 1 application per 7-day window is invariant per REQ-HRN-FND-018 — any future adaptive expansion may raise the limit but never lower it.
+
+---
+
+## Input
+
+`$ARGUMENTS` — the first word is the verb (`status`, `apply`, `rollback`, `disable`, or empty for help). Remaining arguments are passed to the verb dispatcher.
+
+## Verb Routing
+
+[HARD] Extract the FIRST WORD from `$ARGUMENTS`. Match against the verb table below. If empty or unrecognized, show the help block (Phase 0).
+
+| Verb | Workflow-body operations | Tools used | Purpose |
+|------|---------------------------|------------|---------|
+| `status` | Read JSONL state files, aggregate counts | Read, Bash (jq) | Inspect tier distribution, rate-limit window, pending proposal count, Tier-4 reach rate |
+| `apply` | Layer 1 (FrozenGuard path-prefix check) → Layer 4 (rate-limit window check) → AskUserQuestion → snapshot creation → file write → audit log append | Read, Write, Edit, Bash, AskUserQuestion | Surface next Tier-4 proposal via AskUserQuestion, apply on approval through 5-layer pipeline |
+| `rollback <YYYY-MM-DD>` | Read snapshot `manifest.json`, copy files back | Read, Write, Bash | Restore byte-identical pre-modification state from snapshot |
+| `disable` | AskUserQuestion confirm → Edit harness.yaml `learning.enabled: false` | AskUserQuestion, Edit | Turn off observer; observer becomes a no-op (REQ-HRN-FND-009) |
+
+---
+
+## Phase 0: Help (default when no verb)
+
+If `$ARGUMENTS` is empty or matches `help` / `--help` / `-h`, render the verb table above plus a one-line summary in the user's `conversation_language`. Then stop. Do not perform any read or write.
+
+---
+
+## Phase 1: Pre-Execution Sanity Check
+
+Before executing any verb, verify:
+
+1. Project root is detected (`.moai/config/config.yaml` exists). If absent, abort with guidance to run `moai init` first.
+2. Harness learning subsystem state: read `.moai/config/sections/harness.yaml` `learning.enabled` field.
+   - If `enabled: false` and verb is anything other than `status`, surface a warning that the subsystem is disabled via AskUserQuestion (continue / abort). The first option is `Continue (권장)` only when the verb is `rollback` (rollback should remain functional even with learning disabled); for `apply`, first option is `Abort (권장)`.
+3. For `rollback`: the date argument is mandatory. If missing, abort with usage hint `/moai:harness rollback <YYYY-MM-DD>`.
+
+---
+
+## Phase 2: Verb Dispatch
+
+### 2.1 status (file-IO only — no binary)
+
+Operations:
+
+1. Read `.moai/harness/usage-log.jsonl` (line-count via `wc -l` or progressive Read).
+2. Read `.moai/harness/learning-history/tier-promotions.jsonl` (group by tier: observation / heuristic / rule / auto_update).
+3. Read `.moai/harness/learning-history/applied/` directory listing for Tier-4 application count within the last 7 days (REQ-HRN-FND-016 telemetry).
+4. Compute Tier-4 reach rate = (unique patterns with `tier=auto_update` in tier-promotions.jsonl) / (unique patterns in usage-log.jsonl) × 100. Patterns are keyed by `event_type + subject + context_hash` (REQ-HRN-FND-010).
+5. Read `.moai/harness/proposals/` directory listing for pending proposal count.
+6. Render the result as a Markdown table in the user's `conversation_language`:
+
+```
+Harness Learning Status (V3R4)
+  Enabled:                  <bool from harness.yaml learning.enabled>
+  Log entries:              <line count of usage-log.jsonl>
+  Unique patterns:          <distinct event_type+subject+context_hash>
+
+Tier Distribution:
+  observation (T1):         <int>
+  heuristic   (T2):         <int>
+  rule        (T3):         <int>
+  auto_update (T4):         <int> patterns (pending user approval)
+
+Telemetry (REQ-HRN-FND-016):
+  Weekly Tier-4 applications (rolling 7-day): <int>
+  Tier-4 reach rate:                          <pct>%
+
+Pending Proposals: <int>
+  [PENDING] <proposal_id>: <skill_path> (<field>)
+  ...
+```
+
+No user prompt. Stop after rendering.
+
+### 2.2 apply (5-Layer Safety pipeline, file-IO only)
+
+Operations:
+
+1. **Layer 4 (Rate Limiter) pre-screen**: Scan `.moai/harness/learning-history/applied/` for any entry with `applied_at` within the last 7 days. If count ≥ 1, defer:
+   - Append `{ "deferred_at": <ISO-8601>, "reason": "rate-limit window active", "proposal_id": <id> }` to the candidate proposal's metadata.
+   - Render "Tier-4 rate-limit window active — proposal <id> deferred" and STOP. Do NOT invoke AskUserQuestion (REQ-HRN-FND-012).
+2. **Load next pending proposal**: Read `.moai/harness/proposals/` directory; pick the oldest pending entry (`.json` payload). If none, render "No Tier-4 proposals awaiting approval" and stop.
+3. **Layer 1 (Frozen Guard) pre-screen**: Read the proposal's `target_path`. Match against the FROZEN prefix list:
+   - `.claude/agents/moai/`
+   - `.claude/skills/moai-`
+   - `.claude/rules/moai/`
+   - `.moai/project/brand/`
+   If any prefix matches, append a JSONL entry to `.moai/harness/learning-history/frozen-guard-violations.jsonl` with at minimum: ISO-8601 timestamp, the attempted target path, the proposal id (as calling subject), and a rejection rationale (REQ-HRN-FND-006, REQ-HRN-FND-014). Then move the proposal to `.moai/harness/learning-history/rejected/` and stop. Do NOT raise an error to the user; the rejection is silent except for the audit log.
+4. **Layer 3 (Contradiction Detector) pre-screen**: Out of scope for the V3R4 foundation SPEC. Downstream `SPEC-V3R4-HARNESS-005` introduces principle-based scoring; this workflow body documents the contract assertion (REQ-HRN-FND-017) and treats Layer 3 as a no-op pass-through for the foundation release.
+5. **Tier-4 Application Gate**: `ToolSearch(query: "select:AskUserQuestion")` → `AskUserQuestion` with the canonical four-option pattern from the section above. The first option `Apply (권장)` MUST carry the `(권장)` / `(Recommended)` suffix per `.claude/rules/moai/core/askuser-protocol.md` § Option Description Standards.
+6. **On `Apply` selection**:
+   - **Layer 2 (Canary Check)**: Out of scope for the V3R4 foundation SPEC. Downstream `SPEC-V3R4-HARNESS-006` introduces multi-objective scoring with score-drop check; the workflow body treats Layer 2 as a no-op pass-through for the foundation release. The constitution §5 L2 layer remains documented as the binding contract.
+   - **Create snapshot** (REQ-HRN-FND-007): Create directory `.moai/harness/learning-history/snapshots/<ISO-DATE>/` (ISO-8601 timestamp). For each file the proposal will touch, Read the current contents, compute a content hash, and Write a byte-identical copy into the snapshot directory. Write `manifest.json` recording absolute target paths and content hashes. The snapshot MUST be complete before any modification of the target file.
+   - **Apply the change**: Read the proposal's `new_value`, perform the field replacement on `target_path` (typically a frontmatter `description` or `triggers` edit on a `my-harness-*` skill body). Use the `Edit` tool with exact `old_string` / `new_string` match.
+   - **Move the proposal**: Move the proposal file from `.moai/harness/proposals/` to `.moai/harness/learning-history/applied/`. Append an `applied_at` ISO-8601 timestamp and the snapshot directory path to the JSON payload.
+   - **Render outcome**: Confirm `Applied. Snapshot: <path>. Run /moai:harness status to verify the new tier distribution.`.
+7. **On `Modify` selection**: Render guidance to open the proposal file at `.moai/harness/proposals/<id>.json` in the user's editor. Do NOT modify state. Re-presenting requires the next `/moai:harness apply` invocation after edit.
+8. **On `Defer` selection**: Append `deferred_at` timestamp to the proposal metadata. Stop.
+9. **On `Reject` selection**: Move the proposal to `.moai/harness/learning-history/rejected/`. Stop.
+
+Edge case (EDGE-001): If the snapshot directory cannot be created (disk-full, permission), abort BEFORE any modification. Inform the user via the orchestrator's response. No partial state is left on disk.
+
+Edge case (EDGE-006): Concurrent `/moai:harness apply` invocations are out of scope for the foundation SPEC. The orchestrator's AskUserQuestion contract is sequential by design.
+
+### 2.3 rollback
+
+Operations:
+
+1. Validate that the date argument matches `YYYY-MM-DD` or full ISO-8601 (`YYYY-MM-DDThh:mm:ssZ`). If invalid format, abort with usage hint.
+2. Locate snapshot directory: `.moai/harness/learning-history/snapshots/<date>/`. If the directory does not exist, render a diagnostic message naming the missing snapshot and STOP. Do NOT modify any file (REQ-HRN-FND-008 explicit unwanted behavior on missing snapshot).
+3. Read `manifest.json` from the snapshot directory.
+4. For each entry in the manifest: Read the snapshot copy, Write to the absolute target path. Verify the post-write content hash matches the snapshot hash (byte-identical restoration).
+5. Render confirmation message naming the snapshot date and the restored file count.
+
+Safety: rollback does NOT delete the post-application state — it overlays the snapshot. The current state is preserved at `.moai/harness/learning-history/snapshots/<rollback-timestamp>/pre-rollback/` before the rollback overwrite.
+
+### 2.4 disable
+
+Operations:
+
+1. `ToolSearch(query: "select:AskUserQuestion")` → `AskUserQuestion` to confirm intent (this is the only place in `disable` that prompts the user directly, because the consequence is global subsystem deactivation):
+   - Question (Korean conversation_language example): `Harness 학습 서브시스템을 비활성화하시겠습니까? 옵서버가 이벤트 수집을 중단하고 신규 제안이 생성되지 않습니다.`
+   - Options:
+     - `Disable (권장)` — Set `learning.enabled: false`. Snapshots and proposals are preserved.
+     - `Keep enabled` — Stop without changes.
+     - `Disable temporarily (1h)` — Not supported in the V3R4 foundation SPEC; render guidance to re-enable manually via config edit and stop.
+2. On `Disable` selection: Use `Edit` tool on `.moai/config/sections/harness.yaml` to set `learning.enabled: false`. Comments and key ordering MUST be preserved (YAML round-trip discipline).
+3. On `Keep enabled`: stop without changes.
+4. On `Disable temporarily`: render guidance and stop.
+
+Observer no-op contract (REQ-HRN-FND-009): When `learning.enabled: false`, the PostToolUse observer hook MUST be a complete no-op — it does not read, write, or append to `.moai/harness/usage-log.jsonl`. Existing log entries MUST NOT be deleted.
+
+---
+
+## Phase 3: Post-Execution Summary
+
+After any successful verb execution, render a one-paragraph summary in the user's `conversation_language` covering:
+
+1. What was done (verb + key result).
+2. Where the artifact lives (`.moai/harness/...` path).
+3. Suggested next step (e.g., after `apply`: "Run `/moai:harness status` to verify the new tier distribution.").
+
+---
+
+## Error Handling
+
+| Symptom | Likely cause | Recovery |
+|---------|-------------|----------|
+| `harness.yaml not found` | Project not initialized or harness disabled at scaffold | Run `moai init` first; harness subsystem is created on first run |
+| `Error: learning.enabled: false` on `apply` | Subsystem disabled by user or admin | Re-enable manually via editing `.moai/config/sections/harness.yaml` (no `enable` verb yet — deferred to a downstream SPEC) |
+| `Error: no snapshot matching <date>` on `rollback` | Snapshot directory absent for requested date | Run `/moai:harness status` to list available snapshot dates under `.moai/harness/learning-history/snapshots/` |
+| AskUserQuestion schema not loaded | Deferred tool preload missed | The workflow body explicitly preloads via `ToolSearch(query: "select:AskUserQuestion")` before each `apply` or `disable` invocation |
+| Frozen-guard violation log permission failure | Disk-full or permission denied on `.moai/harness/learning-history/` | Per EDGE-003, the L1 Frozen Guard MUST still block the modification; log emission is best-effort audit |
+
+---
+
+## Cross-references
+
+- SPEC (active): `.moai/specs/SPEC-V3R4-HARNESS-001/spec.md` (REQ-HRN-FND-001 ~ REQ-HRN-FND-018)
+- SPEC (superseded by V3R4-001; preserved as historical reference):
+  - `.moai/specs/SPEC-V3R3-HARNESS-LEARNING-001/spec.md` (REQ-HL-001 ~ REQ-HL-012 — 4-tier ladder preserved)
+  - `.moai/specs/SPEC-V3R3-HARNESS-001/spec.md` (Meta-harness skill + generated artifacts)
+  - `.moai/specs/SPEC-V3R3-PROJECT-HARNESS-001/spec.md` (16Q socratic interview + 5-Layer wiring)
+- Skill: `.claude/skills/moai-harness-learner/SKILL.md` (Tier-4 surfacing companion — text-annotated only per SPEC-V3R4-HARNESS-001 §10 exclusion #10)
+- Skill: `.claude/skills/moai-meta-harness/SKILL.md` (project-specific harness generation — text-annotated only)
+- README: `.moai/harness/README.md` (subsystem overview)
+- Attribution: `.claude/rules/moai/NOTICE.md` (Apache-2.0 attribution to revfactory/harness)
+- Constitution: `.claude/rules/moai/design/constitution.md` §5 (5-Layer Safety — preserved verbatim per REQ-HRN-FND-005)
+
+<!-- Verifies REQ-HRN-FND-001/002: no Bash invocation of `moai harness` anywhere in this workflow body. -->
+<!-- Verifies REQ-HRN-FND-003: all four verbs (status/apply/rollback/disable) implemented in this body. -->
+<!-- Verifies REQ-HRN-FND-004/015: Tier-4 application is gated by orchestrator-issued AskUserQuestion. -->
+<!-- Verifies REQ-HRN-FND-005: 5-Layer Safety preserved (L2/L3 documented as deferred no-op to downstream SPECs; L1/L4/L5 active). -->
+<!-- Verifies REQ-HRN-FND-006/014: FROZEN zone path-prefix block + audit log emission. -->
+<!-- Verifies REQ-HRN-FND-007/008: pre-modification snapshot + rollback to byte-identical state. -->
+<!-- Verifies REQ-HRN-FND-009: observer no-op contract documented (enforced by hook code path, Wave C). -->
+<!-- Verifies REQ-HRN-FND-010/011: PostToolUse baseline schema + 4-tier ladder preserved. -->
+<!-- Verifies REQ-HRN-FND-012/018: Tier-4 rate-limit floor of 1 per 7-day window. -->
+<!-- Verifies REQ-HRN-FND-016: telemetry exposure (weekly Tier-4 apply count + reach rate) via `status` verb. -->

--- a/.moai/release/RELEASE-NOTES-v2.20.0.md
+++ b/.moai/release/RELEASE-NOTES-v2.20.0.md
@@ -1,0 +1,119 @@
+# MoAI-ADK v2.20.0 Release Notes — Self-Evolving Harness v2 Foundation
+
+> Target release: v2.20.0 (v3.0.0-rc1 candidate)
+> Authoritative SPEC: `SPEC-V3R4-HARNESS-001`
+> Breaking change ID: `BC-V3R4-HARNESS-001-CLI-RETIREMENT`
+
+---
+
+## TL;DR
+
+V3R4 self-evolving harness 아키텍처의 **foundation** 릴리스. 세 개의 V3R3 harness SPEC을 단일 V3R4 family로 통합하고, `moai harness <verb>` Go CLI verb path를 공식적으로 폐기합니다. harness 라이프사이클은 이제 `/moai:harness` 슬래시 커맨드 + skill workflow body + Claude Code hook만으로 동작합니다 — Go 바이너리는 더 이상 호출되지 않습니다. 5-Layer Safety 아키텍처와 FROZEN zone은 비트 단위로 보존됩니다.
+
+---
+
+## Self-Evolving Harness v2 Foundation
+
+### Why this release exists
+
+V3R3 시기에 만들어진 세 개의 harness SPEC (`SPEC-V3R3-HARNESS-001`, `SPEC-V3R3-HARNESS-LEARNING-001`, `SPEC-V3R3-PROJECT-HARNESS-001`)은 서로 다른 Phase letter (C / D) 하에 다른 release target (v2.17.0 / v2.19.0)으로 별도 작성되었습니다. 같은 아키텍처 도메인을 다루지만 V3R4 self-evolution vision이 정착되기 전에 쓰여, 표면이 V3R4 통합 아키텍처와 깔끔하게 매핑되지 않았습니다. 이 릴리스는 그 세 개를 단일 foundation SPEC 아래로 통합 (`supersedes:` frontmatter)하여 downstream SPEC 002-008 작성자에게 단일 contract를 제공합니다.
+
+근거 자료: `/Users/goos/MoAI/moai-adk-go/.moai/brain/IDEA-004/proposal.md` (8-SPEC decomposition), `research.md` (24 cited external sources — Reflexion arXiv:2303.11366, Voyager arXiv:2305.16291, Constitutional AI arXiv:2212.08073, LangGraph reflection production patterns 2026, Anthropic Claude Code Skills/Agents 공식 문서 2026, revfactory/harness Apache-2.0).
+
+### CLI retirement migration story (BC-V3R4-HARNESS-001-CLI-RETIREMENT)
+
+V3R3 시절에 `moai harness <verb>` 셸 커맨드를 사용한 사용자가 있다면 다음과 같이 마이그레이션해야 합니다:
+
+| 이전 (V3R3) | 신규 (V3R4) |
+|-------------|-------------|
+| `moai harness status` | `/moai:harness status` (Claude Code 세션 내) |
+| `moai harness apply` | `/moai:harness apply` (Claude Code 세션 내) |
+| `moai harness rollback <date>` | `/moai:harness rollback <YYYY-MM-DD>` (Claude Code 세션 내) |
+| `moai harness disable` | `/moai:harness disable` (Claude Code 세션 내) |
+
+`v2.20.0` 설치 후 `moai harness status`를 셸에서 호출하면 다음 진단이 출력됩니다:
+
+```
+Error: unknown command "harness" for "moai"
+```
+
+이것은 의도된 동작입니다. 슬래시 커맨드 표면은 V3R3 시절과 동일하므로 Claude Code 세션 내 머슬 메모리에는 영향이 없습니다. 슬래시 커맨드 thin wrapper (`.claude/commands/moai/harness.md`)는 `moai` 스킬 본문의 `workflows/harness.md` workflow module로 라우팅하며, workflow body는 모든 4개 verb (`status` / `apply` / `rollback` / `disable`)를 file-system 연산으로 직접 구현합니다 — 어떤 Go 바이너리도 호출되지 않습니다.
+
+기존 `.moai/harness/usage-log.jsonl` 항목은 마이그레이션 / 삭제 / 수정되지 않습니다. 사용자는 누적된 관측 데이터를 그대로 가지고 V3R4로 진입합니다.
+
+### Preserved without modification
+
+- **5-Layer Safety 아키텍처** (`.claude/rules/moai/design/constitution.md` §5) — L1 Frozen Guard / L2 Canary Check / L3 Contradiction Detector / L4 Rate Limiter (≤3/week, ≥24h cooldown) / L5 Human Oversight (AskUserQuestion at Tier 4) 전체가 비트 단위 보존 (REQ-HRN-FND-005, AC-HRN-FND-004).
+- **FROZEN zone** (constitution.md §2) — `.claude/agents/moai/`, `.claude/skills/moai-`, `.claude/rules/moai/`, `.moai/project/brand/` 4개 path prefix가 L1 Frozen Guard에 의해 보호됩니다. 위반 시도는 `.moai/harness/learning-history/frozen-guard-violations.jsonl`에 silent audit (REQ-HRN-FND-006, REQ-HRN-FND-014, AC-HRN-FND-005).
+- **4-tier observation ladder** (Observation 1 / Heuristic 3 / Rule 5 / Auto-update 10) — `SPEC-V3R3-HARNESS-LEARNING-001` REQ-HL-002의 임계값이 그대로 유지됩니다 (REQ-HRN-FND-011, AC-HRN-FND-008).
+- **PostToolUse observer 스키마** — ISO-8601 timestamp + event_type + subject + context_hash 4 필드 (REQ-HRN-FND-010).
+- **AskUserQuestion orchestrator monopoly** — subagent는 user prompt 불가; 필요 시 structured blocker report로 orchestrator에 위임 (REQ-HRN-FND-015, `.claude/rules/moai/core/agent-common-protocol.md` § User Interaction Boundary).
+
+### New runtime behavior
+
+- **`/moai:harness` 슬래시 커맨드**: 4개 verb 전부 workflow body에서 직접 구현. CLI 호출 0건.
+- **Tier-4 AskUserQuestion 4-option pattern**: Apply (권장) / Modify / Defer / Reject. 첫 옵션은 항상 `(권장)` 또는 `(Recommended)` 접미사.
+- **Tier-4 rate limit**: 프로젝트당 7일 rolling window 1회 (REQ-HRN-FND-012). 향후 adaptive expansion이 가능하지만 1회 floor는 절대 하향 불가 (REQ-HRN-FND-018).
+- **PostToolUse observer no-op gate**: `learning.enabled: false` 설정 시 observer가 stdin도 읽지 않고 즉시 exit 0. 기존 `.moai/harness/usage-log.jsonl` 항목은 보존됩니다 (REQ-HRN-FND-009).
+- **Conflict resolution contract**: Reflexion 자체-비판 (downstream SPEC-V3R4-HARNESS-004) 과 `evaluator-active` 채점이 충돌할 때 evaluator-active가 binding gate; Reflexion은 advisory pre-screen만 (REQ-HRN-FND-017).
+
+### CI regression guard
+
+신규 테스트 `internal/cli/harness_retirement_test.go`:
+
+- `TestHarnessRetirement` — `rootCmd.Commands()` 중 `Use: "harness"` 항목이 발견되면 즉시 `t.Fatalf`로 차단. 진단 메시지는 SPEC-V3R4-HARNESS-001 + REQ-HRN-FND-002 + BC-V3R4-HARNESS-001-CLI-RETIREMENT를 명시.
+- `TestHarnessFactoryStillCompiles` — `newHarnessCmd()` factory가 deprecation marker로 트리에 남아 있는지 검증. 향후 follow-up SPEC이 물리적 제거를 수행하기 전까지 factory는 호출 가능 상태로 유지됩니다.
+
+신규 단위 테스트 `internal/cli/hook_harness_observe_test.go` (10 cases table-driven):
+
+- `TestIsHarnessLearningEnabled` (7 cases) — gate function 자체 검증 (missing config / empty / no learning block / no enabled key / true / false / invalid YAML).
+- `TestRunHarnessObserve_NoOpWhenLearningDisabled` — `learning.enabled: false`에서 `.moai/harness/usage-log.jsonl` 미생성 확인.
+- `TestRunHarnessObserve_PreservesExistingLogWhenDisabled` — 기존 log entry 보존 확인.
+- `TestRunHarnessObserve_RecordsWhenEnabled` — `learning.enabled: true`에서 JSONL 1건 append + 4-field schema 검증.
+
+### Downstream SPECs enumeration (foundation 이후 계획)
+
+이 foundation SPEC은 자체적으로 self-evolution 기능을 도입하지 않습니다. 다음 7개 SPEC이 점진적으로 V3R4 아키텍처를 확장합니다:
+
+1. **SPEC-V3R4-HARNESS-002** — Multi-event observer: Stop / SubagentStop / UserPromptSubmit hook 통합 + 통합 관측 스키마.
+2. **SPEC-V3R4-HARNESS-003** — Embedding-cluster pattern detection: 빈도 카운트 분류자를 임베딩 클러스터링으로 대체.
+3. **SPEC-V3R4-HARNESS-004** — Actor + Evaluator + Self-Reflection trio: Reflexion 자체-비판 3-iteration cap + 자연어 reflection 에피소드 메모리.
+4. **SPEC-V3R4-HARNESS-005** — Constitution principle 파서 + 자체-채점 rubric + pre-screen 통합.
+5. **SPEC-V3R4-HARNESS-006** — Multi-objective scoring tuple (quality + token cost + latency + iteration count) + auto-rollback-on-regression.
+6. **SPEC-V3R4-HARNESS-007** — Voyager 스킬 라이브러리: 임베딩 인덱스 + top-K 검색 + 합성 스킬 재사용.
+7. **SPEC-V3R4-HARNESS-008** — 익명화 레이어 + opt-in cross-project federation + namespace isolation (개인정보 민감; 002-007 single-project 트랙 레코드 확인 후 plan-phase 진입).
+
+각 downstream SPEC은 이 foundation SPEC의 REQ ID를 인용하여 binding constraint로 사용합니다.
+
+### Out of scope (intentional non-goals)
+
+- `internal/cli/harness.go` 또는 `internal/cli/harness_test.go`의 물리적 삭제 — 본 SPEC은 deprecation marker로 남기고 follow-up SPEC이 downstream 002-008 머지 이후 정리.
+- 세 superseded V3R3 SPEC 파일의 frontmatter 수정 — `.moai/specs/SPEC-V3R4-HARNESS-001/follow-up.md` 지침에 따라 `manager-git`이 별도 commit으로 처리.
+- `.claude/rules/moai/design/constitution.md` 수정 (FROZEN file).
+- 기존 `usage-log.jsonl` 항목의 스키마 마이그레이션.
+- 평가 history inspection GUI / 대시보드 / 웹 클라이언트.
+- 네트워크 호출 / telemetry 업로드 / 외부 API 통합.
+
+---
+
+## Upgrade Notes
+
+- **Existing users**: 기존 `.moai/harness/usage-log.jsonl` 상태는 그대로 유지됩니다. 첫 슬래시 커맨드 호출 (`/moai:harness status`)은 누적된 관측 데이터를 그대로 표시합니다.
+- **`learning.enabled: false` 사용자**: observer가 no-op이 되었음을 확인하려면 `Edit` / `Write` 호출 후 `.moai/harness/usage-log.jsonl` 의 line count가 변하지 않는지 비교하세요.
+- **CI 파이프라인**: 새 테스트 두 건 (`TestHarnessRetirement`, `TestHarnessFactoryStillCompiles`)이 추가됩니다 — 별도 설정 불필요.
+
+---
+
+## Detailed References
+
+- SPEC: `.moai/specs/SPEC-V3R4-HARNESS-001/spec.md` (REQ-HRN-FND-001 ~ REQ-HRN-FND-018)
+- Acceptance: `.moai/specs/SPEC-V3R4-HARNESS-001/acceptance.md` (12 AC + 6 edge cases + 7 scenarios)
+- Plan: `.moai/specs/SPEC-V3R4-HARNESS-001/plan.md`
+- Tasks: `.moai/specs/SPEC-V3R4-HARNESS-001/tasks.md` (5 Wave / 17 tasks)
+- Follow-up: `.moai/specs/SPEC-V3R4-HARNESS-001/follow-up.md` (post-merge `manager-git` V3R3 status-transition 지침)
+- Workflow body: `.claude/skills/moai/workflows/harness.md`
+- Slash command thin wrapper: `.claude/commands/moai/harness.md`
+- Hook code: `internal/cli/hook.go` (`isHarnessLearningEnabled`, `runHarnessObserve`)
+- CI guard: `internal/cli/harness_retirement_test.go`
+- Observer test: `internal/cli/hook_harness_observe_test.go`
+- Brain artifacts: `.moai/brain/IDEA-004/proposal.md`, `ideation.md`, `research.md`

--- a/.moai/specs/SPEC-V3R4-HARNESS-001/follow-up.md
+++ b/.moai/specs/SPEC-V3R4-HARNESS-001/follow-up.md
@@ -1,0 +1,132 @@
+# Follow-Up Tasks — SPEC-V3R4-HARNESS-001
+
+This document captures post-merge tasks that are **out of scope of this SPEC's PR** but **MUST be performed** by `manager-git` (or an equivalent commit-only agent) immediately after the foundation SPEC PR is squash-merged into `main`. The tasks are unambiguous and do not require interpretation; `manager-git` is expected to execute them mechanically.
+
+REQ coverage: REQ-HRN-FND-013 (this SPEC's PR MUST NOT modify the three superseded V3R3 SPECs), REQ-HRN-FND-001 (CLI verb path retirement is finalized by this commit chain).
+
+AC coverage: AC-HRN-FND-010 (Verification: `git diff main..HEAD --name-only | grep -E 'SPEC-V3R3-(HARNESS-001|HARNESS-LEARNING-001|PROJECT-HARNESS-001)/'` returns zero matches **inside this SPEC's PR**; the V3R3 SPEC mutation is a separate commit performed AFTER this PR merges).
+
+---
+
+## Owner
+
+`manager-git` subagent. The follow-up is invoked by the orchestrator after this SPEC's PR reaches `MERGED` state.
+
+## Trigger
+
+Precondition: `gh pr view <SPEC-V3R4-HARNESS-001 PR number> --json state -q .state` returns `MERGED`.
+
+## Steps (verbatim — execute in order)
+
+### 1. Branch creation
+
+```bash
+git fetch origin
+git checkout -b chore/SPEC-V3R3-status-transition origin/main
+```
+
+The branch name `chore/SPEC-V3R3-status-transition` is canonical for this follow-up. Do not use a different name.
+
+### 2. Update three V3R3 SPEC frontmatters
+
+For each of the three files below, locate the YAML frontmatter (between the opening `---` and closing `---` markers near the top of the file) and apply the following two changes:
+
+- Change the `status:` field value to `superseded` (replace whatever current value is present — typically `completed`).
+- Add a new field `superseded_by: SPEC-V3R4-HARNESS-001` directly after the `status:` line. If `superseded_by:` already exists (rare), update its value to `SPEC-V3R4-HARNESS-001`.
+
+Target files:
+
+1. `.moai/specs/SPEC-V3R3-HARNESS-001/spec.md`
+2. `.moai/specs/SPEC-V3R3-HARNESS-LEARNING-001/spec.md`
+3. `.moai/specs/SPEC-V3R3-PROJECT-HARNESS-001/spec.md`
+
+### 3. Add a HISTORY entry to each of the three V3R3 SPECs
+
+After the existing HISTORY table (search for the line beginning with `| Version |` near the top of each file's body), append a new row whose contents are:
+
+```
+| (n+1).0.0 | <YYYY-MM-DD of merge commit> | manager-git | Status transition: superseded by SPEC-V3R4-HARNESS-001. The V3R4 foundation SPEC consolidates the three V3R3 harness SPECs into a single architecture; the `moai harness` CLI verb path is retired per BC-V3R4-HARNESS-001-CLI-RETIREMENT, and the 4-tier ladder + 5-Layer Safety architecture are preserved verbatim. See SPEC-V3R4-HARNESS-001 for the current authoritative contract. |
+```
+
+Where:
+
+- `(n+1)` is the next major version number after the SPEC's current latest HISTORY row. If the latest row is `| 1.0.0 |`, use `2.0.0`. If `2.0.0`, use `3.0.0`. The HISTORY ordering convention (newest-first or newest-last) MUST be preserved per the file's existing convention.
+- `<YYYY-MM-DD>` is the ISO-8601 date of the SPEC-V3R4-HARNESS-001 PR merge commit. Derive via `git log -1 --format=%cs <merge-commit-sha>`.
+
+### 4. Commit and PR
+
+```bash
+git add .moai/specs/SPEC-V3R3-HARNESS-001/spec.md \
+        .moai/specs/SPEC-V3R3-HARNESS-LEARNING-001/spec.md \
+        .moai/specs/SPEC-V3R3-PROJECT-HARNESS-001/spec.md
+
+git commit -m "chore(spec): transition three V3R3 harness SPECs to superseded per SPEC-V3R4-HARNESS-001
+
+V3R4 foundation SPEC merged at <merge-commit-sha>. The three V3R3 SPECs
+(HARNESS-001 meta-skill, HARNESS-LEARNING-001 4-tier ladder + 5-Layer
+Safety, PROJECT-HARNESS-001 16Q socratic interview) are consolidated
+into the V3R4 family. Their status transitions to 'superseded' and
+their HISTORY tables record the V3R4 takeover.
+
+Refs: SPEC-V3R4-HARNESS-001 (BC-V3R4-HARNESS-001-CLI-RETIREMENT)
+Follow-up: .moai/specs/SPEC-V3R4-HARNESS-001/follow-up.md
+
+🗿 MoAI <email@mo.ai.kr>"
+
+git push -u origin chore/SPEC-V3R3-status-transition
+```
+
+### 5. PR creation
+
+```bash
+gh pr create \
+  --base main \
+  --title "chore(spec): transition three V3R3 harness SPECs to superseded per SPEC-V3R4-HARNESS-001" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Transitions three V3R3 harness SPECs to `status: superseded` and adds `superseded_by: SPEC-V3R4-HARNESS-001` per the foundation SPEC's `supersedes:` frontmatter.
+- HISTORY tables updated to record the V3R4 takeover with the merge commit SHA.
+
+## Why this is a separate PR
+
+REQ-HRN-FND-013 of SPEC-V3R4-HARNESS-001 explicitly prohibits modifying the three V3R3 SPEC files inside the foundation SPEC's own PR. The status transition is delegated to this follow-up commit to keep the foundation PR's diff scope clean.
+
+## Verification
+
+- Each V3R3 SPEC frontmatter shows \`status: superseded\` and \`superseded_by: SPEC-V3R4-HARNESS-001\`.
+- Each V3R3 SPEC HISTORY table records the transition with the V3R4 merge date.
+- \`git diff main..HEAD --name-only\` returns exactly three paths: the three V3R3 \`spec.md\` files.
+
+## Test plan
+
+- [x] Frontmatter \`status\` field changed for all three SPECs
+- [x] \`superseded_by\` field added for all three SPECs
+- [x] HISTORY entry appended for all three SPECs
+- [x] No file outside \`.moai/specs/SPEC-V3R3-*/spec.md\` modified
+
+Refs: SPEC-V3R4-HARNESS-001, BC-V3R4-HARNESS-001-CLI-RETIREMENT
+
+🗿 MoAI <email@mo.ai.kr>
+EOF
+)"
+```
+
+### 6. Merge strategy
+
+Squash merge per Enhanced GitHub Flow (`CLAUDE.local.md` §18). After merge, the V3R3 SPEC frontmatter changes are recorded in `main` as a single commit. No further follow-up commits are needed for this SPEC family.
+
+---
+
+## Out of scope for this follow-up
+
+The following are **NOT** part of this follow-up commit; they belong to a future SPEC:
+
+- Physical deletion of `internal/cli/harness.go` or `internal/cli/harness_test.go`. They remain as deprecation markers per SPEC-V3R4-HARNESS-001 §2.1.
+- Modification of `.claude/rules/moai/design/constitution.md` (FROZEN file).
+- Changes to `.claude/skills/moai-harness-learner/` or `.claude/skills/moai-meta-harness/` skill bodies beyond text annotations (already performed by the SPEC-V3R4-HARNESS-001 PR per §10 exclusion #10).
+
+---
+
+REQ traceability: REQ-HRN-FND-013, REQ-HRN-FND-001
+AC traceability: AC-HRN-FND-010

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,52 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] — SPEC-V3R4-HARNESS-001: Self-Evolving Harness v2 Foundation
+
+### Breaking Changes
+
+- **BC-V3R4-HARNESS-001-CLI-RETIREMENT** — `moai harness <verb>` CLI subcommand 경로가 폐기되었습니다. 셸에서 `moai harness status` (또는 `apply`, `rollback`, `disable`)를 호출하면 cobra의 `unknown command "harness" for "moai"` 진단과 함께 non-zero exit code가 반환됩니다. 동일한 기능은 Claude Code 세션 내의 `/moai:harness` 슬래시 커맨드로만 사용할 수 있습니다. 슬래시 커맨드 표면은 V3R3 시절과 동일하게 유지되므로 사용자 머슬 메모리에는 영향이 없습니다.
+- 신규 회귀 가드: `internal/cli/harness_retirement_test.go` `TestHarnessRetirement`가 `rootCmd.Commands()`에 `harness` subcommand가 다시 등록되는 PR을 자동으로 차단합니다.
+
+### Breaking Changes (English)
+
+- **BC-V3R4-HARNESS-001-CLI-RETIREMENT** — The `moai harness <verb>` CLI subcommand path is retired. Invoking `moai harness status` (or `apply`, `rollback`, `disable`) from the shell returns cobra's `unknown command "harness" for "moai"` diagnostic with a non-zero exit code. The same functionality is reachable only through the `/moai:harness` slash command inside a Claude Code session. The slash command surface is identical to the V3R3 era, so user muscle memory is unaffected.
+- New regression guard: `internal/cli/harness_retirement_test.go` `TestHarnessRetirement` fails the build if any PR re-registers a `harness` subcommand on `rootCmd.Commands()`.
+
+### Added
+
+- **SPEC-V3R4-HARNESS-001 — Unified Self-Evolving Harness Foundation**: V3R4 self-evolving harness 아키텍처의 foundation SPEC. 세 개의 V3R3 SPEC을 단일 V3R4 family로 통합 (`supersedes:` frontmatter): `SPEC-V3R3-HARNESS-001` (meta-skill), `SPEC-V3R3-HARNESS-LEARNING-001` (4-tier learning ladder + 5-Layer Safety), `SPEC-V3R3-PROJECT-HARNESS-001` (16Q 인터뷰 + 통합 wiring). harness 라이프사이클은 슬래시 커맨드 + 스킬 워크플로우 + Claude Code hook 만으로 동작하며 Go 바이너리 호출이 0건입니다. 5-Layer Safety 아키텍처 (`.claude/rules/moai/design/constitution.md` §5) 와 FROZEN zone (§2)은 비트 단위로 보존됩니다 (REQ-HRN-FND-005).
+- **`/moai:harness` 슬래시 커맨드 lifecycle (V3R4 contract)**: `.claude/skills/moai/workflows/harness.md` 본문이 `status` / `apply` / `rollback` / `disable` 4개 verb를 모두 file-system 연산으로 구현합니다. Tier-4 적용 시 orchestrator-issued AskUserQuestion 4-option 패턴 (Apply (권장) / Modify / Defer / Reject) 게이트 (REQ-HRN-FND-004, REQ-HRN-FND-015). Tier-4 적용 빈도는 프로젝트당 7일 rolling window 1회 (REQ-HRN-FND-012, 하향 불가 REQ-HRN-FND-018).
+- **PostToolUse observer no-op gate (REQ-HRN-FND-009)**: `internal/cli/hook.go` `isHarnessLearningEnabled` 함수가 `.moai/config/sections/harness.yaml`의 `learning.enabled` 필드를 읽어 `false`이면 observer가 완전한 no-op으로 동작합니다. 누락된 config / 파싱 오류 시 fail-open (관측 유지). `internal/cli/hook_harness_observe_test.go` 10건의 table-driven 테스트로 검증.
+- **CI 회귀 가드 (REQ-HRN-FND-002)**: `internal/cli/harness_retirement_test.go`가 `rootCmd.Commands()`에 `harness` subcommand 재등록 시도를 차단.
+- **moai-harness-learner / moai-meta-harness V3R4 텍스트 주석**: SPEC §10 exclusion #10에 따라 두 skill body는 frontmatter / 동작 변경 없이 V3R4 contract 인용 주석만 추가.
+
+### Added (English)
+
+- **SPEC-V3R4-HARNESS-001 — Unified Self-Evolving Harness Foundation**: Foundation SPEC for the V3R4 self-evolving harness architecture. Consolidates three V3R3 SPECs into a single V3R4 family via `supersedes:` frontmatter: `SPEC-V3R3-HARNESS-001` (meta-skill), `SPEC-V3R3-HARNESS-LEARNING-001` (4-tier learning ladder + 5-Layer Safety), `SPEC-V3R3-PROJECT-HARNESS-001` (16Q interview + integration wiring). The harness lifecycle operates entirely through slash command + skill workflow + Claude Code hooks; zero Go binary invocations remain. The 5-Layer Safety architecture (`.claude/rules/moai/design/constitution.md` §5) and FROZEN zones (§2) are preserved byte-for-byte (REQ-HRN-FND-005).
+- **`/moai:harness` slash command lifecycle (V3R4 contract)**: `.claude/skills/moai/workflows/harness.md` body implements all four verbs (`status` / `apply` / `rollback` / `disable`) via file-system operations only. Tier-4 application is gated by an orchestrator-issued AskUserQuestion four-option pattern (Apply (Recommended) / Modify / Defer / Reject) per REQ-HRN-FND-004 and REQ-HRN-FND-015. Tier-4 application is rate-limited to one per project per 7-day rolling window (REQ-HRN-FND-012) with a floor that cannot be lowered by adaptive expansion (REQ-HRN-FND-018).
+- **PostToolUse observer no-op gate (REQ-HRN-FND-009)**: `internal/cli/hook.go` `isHarnessLearningEnabled` reads `learning.enabled` from `.moai/config/sections/harness.yaml`; when `false`, the observer becomes a complete no-op (no read, write, or append). Fail-open semantics: missing config or parse error preserves baseline observation. Verified by 10 table-driven cases in `internal/cli/hook_harness_observe_test.go`.
+- **CI regression guard (REQ-HRN-FND-002)**: `internal/cli/harness_retirement_test.go` fails the build if any PR re-registers a `harness` subcommand on `rootCmd.Commands()`.
+- **moai-harness-learner / moai-meta-harness V3R4 text annotations**: per SPEC §10 exclusion #10, both skill bodies receive text-only annotations reaffirming the V3R4 contract with no frontmatter or behavioral changes.
+
+### Superseded
+
+- `SPEC-V3R3-HARNESS-001` — Meta-Harness Skill core (status transition to `superseded` is performed via the follow-up `manager-git` commit per `.moai/specs/SPEC-V3R4-HARNESS-001/follow-up.md`).
+- `SPEC-V3R3-HARNESS-LEARNING-001` — 4-tier learning ladder + 5-Layer Safety + `moai harness` CLI verbs (CLI verb path retired; 4-tier ladder and 5-Layer Safety preserved unchanged).
+- `SPEC-V3R3-PROJECT-HARNESS-001` — `/moai project` Phase 5+ socratic interview + 5-Layer integration wiring (runtime behavior preserved; V3R4 SPEC formalizes the contract those layers operate under).
+
+### Downstream (not in scope of this SPEC)
+
+이 foundation SPEC은 자체적으로 self-evolution 메커니즘을 도입하지 않습니다. 다음 7개 downstream SPEC은 이 foundation을 점진적으로 확장합니다 (모두 `.moai/specs/SPEC-V3R4-HARNESS-001/spec.md` §1.3 Non-Goals 에 명시):
+
+- `SPEC-V3R4-HARNESS-002` — Multi-event observer (Stop / SubagentStop / UserPromptSubmit 통합)
+- `SPEC-V3R4-HARNESS-003` — Embedding-cluster pattern detection (frequency-count classifier 대체)
+- `SPEC-V3R4-HARNESS-004` — Reflexion 자체-비판 loop (3-iteration cap)
+- `SPEC-V3R4-HARNESS-005` — Constitution principle-based scoring
+- `SPEC-V3R4-HARNESS-006` — Multi-objective effectiveness measurement + auto-rollback-on-regression
+- `SPEC-V3R4-HARNESS-007` — Voyager 스킬 라이브러리 자동 organization (embedding-indexed retrieval)
+- `SPEC-V3R4-HARNESS-008` — Cross-project lesson federation (privacy-sensitive, opt-in only)
+
 ## [Unreleased] — SPEC-V3R2-HRN-003: Hierarchical Acceptance Scoring
 
 ### Added

--- a/internal/cli/harness.go
+++ b/internal/cli/harness.go
@@ -1,5 +1,19 @@
-// Package cli — /moai harness subcommand.
-// REQ-HL-009: provide 4 verbs: status / apply / rollback <date> / disable
+// DEPRECATED: per SPEC-V3R4-HARNESS-001 (BC-V3R4-HARNESS-001-CLI-RETIREMENT).
+// The harness CLI subcommand is retired. Use /moai:harness slash command instead.
+// This file remains as a deprecation marker; physical removal is deferred to a
+// follow-up SPEC after downstream SPECs SPEC-V3R4-HARNESS-002 through
+// SPEC-V3R4-HARNESS-008 merge.
+//
+// The newHarnessCmd factory is intentionally NOT registered into the cobra
+// command tree in internal/cli/root.go. A CI guard in
+// internal/cli/harness_retirement_test.go (TestHarnessRetirement) enforces
+// the non-registration contract per REQ-HRN-FND-001 and REQ-HRN-FND-002.
+//
+// Package cli — /moai harness subcommand (retired; preserved as deprecation marker).
+// Historical: REQ-HL-009 provided 4 verbs (status / apply / rollback <date> / disable)
+// via the moai harness CLI verb path. As of V3R4, all four verbs are owned by the
+// /moai:harness slash command surface and the moai skill workflow body at
+// .claude/skills/moai/workflows/harness.md (no Go binary invocation).
 package cli
 
 import (

--- a/internal/cli/harness_retirement_test.go
+++ b/internal/cli/harness_retirement_test.go
@@ -1,0 +1,80 @@
+// Package cli — harness CLI retirement CI guard (SPEC-V3R4-HARNESS-001).
+//
+// @MX:NOTE: [AUTO] CI regression guard for SPEC-V3R4-HARNESS-001 (REQ-HRN-FND-002).
+// This test fails the build if newHarnessCmd (or any equivalent harness subcommand
+// factory) is registered into the cobra command tree, enforcing the retirement
+// contract declared by BC-V3R4-HARNESS-001-CLI-RETIREMENT.
+//
+// Why this guard exists:
+//
+//	SPEC-V3R4-HARNESS-001 retires the `moai harness <verb>` CLI verb path. The
+//	implementation file internal/cli/harness.go remains in the tree as a
+//	deprecation marker (factory function preserved for compatibility with any
+//	internal introspection callers), but the cobra registration is removed.
+//	This test verifies the registration absence so a future refactor cannot
+//	silently re-introduce the public CLI surface.
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestHarnessRetirement asserts that rootCmd does not contain any command with
+// Use: "harness" (or any alias resolving to "harness"). Per SPEC-V3R4-HARNESS-001
+// REQ-HRN-FND-002, the harness CLI verb path is retired; invoking
+// `moai harness <verb>` MUST produce cobra's standard `unknown command` error.
+func TestHarnessRetirement(t *testing.T) {
+	t.Parallel()
+
+	for _, cmd := range rootCmd.Commands() {
+		// Direct match on the Use field — cobra's primary registration key.
+		// Strip any argument suffix (e.g., "harness <verb>") to compare the verb noun.
+		useFirst := strings.SplitN(cmd.Use, " ", 2)[0]
+		if useFirst == "harness" {
+			t.Fatalf(
+				"SPEC-V3R4-HARNESS-001 / REQ-HRN-FND-002 violation: command with Use=%q "+
+					"is registered as a subcommand of rootCmd. The harness CLI verb path is "+
+					"retired per BC-V3R4-HARNESS-001-CLI-RETIREMENT. Remove the "+
+					"rootCmd.AddCommand(newHarnessCmd()) call (or equivalent) from "+
+					"internal/cli/root.go. The harness lifecycle is owned by the /moai:harness "+
+					"slash command surface and the moai skill workflow body. See "+
+					".claude/skills/moai/workflows/harness.md for the slash-command-only "+
+					"implementation contract.",
+				cmd.Use,
+			)
+		}
+
+		// Defensive: any alias also forbidden.
+		for _, alias := range cmd.Aliases {
+			if alias == "harness" {
+				t.Fatalf(
+					"SPEC-V3R4-HARNESS-001 / REQ-HRN-FND-002 violation: command %q registers "+
+						"%q as an alias. The harness verb name is retired as a public CLI surface.",
+					cmd.Use, alias,
+				)
+			}
+		}
+	}
+}
+
+// TestHarnessFactoryStillCompiles asserts that the newHarnessCmd factory function
+// remains present in the package, even though it is not registered. The file is
+// preserved as a deprecation marker per SPEC-V3R4-HARNESS-001 §2.1; physical
+// removal is deferred to a follow-up SPEC. If a future refactor deletes the
+// factory, this test fails to flag the change as out of scope for the foundation
+// SPEC's deprecation-marker contract.
+//
+// The factory is invoked only for its return-value type assertion; it is not
+// added to the command tree.
+func TestHarnessFactoryStillCompiles(t *testing.T) {
+	t.Parallel()
+
+	cmd := newHarnessCmd()
+	if cmd == nil {
+		t.Fatal("newHarnessCmd returned nil; the factory must remain operational as a deprecation marker per SPEC-V3R4-HARNESS-001 §2.1")
+	}
+	if cmd.Use == "" {
+		t.Error("newHarnessCmd returned a command with empty Use; expected the historical \"harness\" identifier preserved")
+	}
+}

--- a/internal/cli/hook.go
+++ b/internal/cli/hook.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 
 	"github.com/modu-ai/moai-adk/internal/harness"
 	"github.com/modu-ai/moai-adk/internal/hook"
@@ -418,6 +419,43 @@ func trimSpace(s string) string {
 	return s[left:right]
 }
 
+// isHarnessLearningEnabled reports whether the harness learning subsystem is
+// enabled for the project rooted at projectRoot, per REQ-HRN-FND-009 of
+// SPEC-V3R4-HARNESS-001.
+//
+// The gate reads `.moai/config/sections/harness.yaml` and inspects the
+// top-level `learning.enabled` key. Truth table:
+//
+//   - file missing / unreadable          → true  (treat as enabled by default)
+//   - YAML parse error                   → true  (fail-open; preserve baseline)
+//   - `learning` block absent            → true  (default enabled)
+//   - `learning.enabled` absent          → true  (default enabled)
+//   - `learning.enabled: true`           → true
+//   - `learning.enabled: false`          → false (observer must be a no-op)
+//
+// The gate is intentionally fail-open so that a corrupted or missing config
+// does not silently disable the observer. Explicit `false` is required to
+// suppress observation, matching the EARS state-driven semantics of REQ-HRN-FND-009.
+func isHarnessLearningEnabled(projectRoot string) bool {
+	configPath := filepath.Join(projectRoot, ".moai", "config", "sections", "harness.yaml")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return true
+	}
+	var doc struct {
+		Learning struct {
+			Enabled *bool `yaml:"enabled,omitempty"`
+		} `yaml:"learning,omitempty"`
+	}
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return true
+	}
+	if doc.Learning.Enabled == nil {
+		return true
+	}
+	return *doc.Learning.Enabled
+}
+
 // runHarnessObserve reads PostToolUse hook stdin JSON and records event to usage-log.jsonl.
 // T-P1-03: handle-harness-observe.sh → moai hook harness-observe routing implementation.
 //
@@ -428,8 +466,25 @@ func trimSpace(s string) string {
 // "toolInput": { ... }
 // }
 //
-// @MX:NOTE: [AUTO] learning.enabled Configuration/Settings gate Phase 4from/in/at addition planned/scheduled (T-P4-XX).
+// @MX:NOTE: [AUTO] REQ-HRN-FND-009 (SPEC-V3R4-HARNESS-001): When learning.enabled
+// in harness.yaml resolves to false, this handler is a complete no-op — no read,
+// no write, no append to usage-log.jsonl. Existing log entries are not deleted.
+// Gate is implemented by isHarnessLearningEnabled (fail-open semantics: missing
+// config or parse error preserves baseline observation).
 func runHarnessObserve(cmd *cobra.Command, _ []string) error {
+	// detect project route: based on cwd
+	cwd, err := os.Getwd()
+	if err != nil {
+		cwd = "."
+	}
+
+	// REQ-HRN-FND-009 gate: if learning.enabled is explicitly false, exit no-op.
+	// stdin is NOT consumed in the no-op path; the hook exits 0 immediately so
+	// the PostToolUse pipeline is non-blocking and leaves usage-log.jsonl untouched.
+	if !isHarnessLearningEnabled(cwd) {
+		return nil
+	}
+
 	// read stdin JSON
 	var hookInput struct {
 		ToolName string `json:"toolName"`
@@ -438,12 +493,6 @@ func runHarnessObserve(cmd *cobra.Command, _ []string) error {
 	decoder := json.NewDecoder(os.Stdin)
 	// on parsing failure also exit 0 (non-blocking: does not block parent tool call)
 	_ = decoder.Decode(&hookInput)
-
-	// detect project route: based on cwd
-	cwd, err := os.Getwd()
-	if err != nil {
-		cwd = "."
-	}
 
 	logPath := filepath.Join(cwd, ".moai", "harness", "usage-log.jsonl")
 	archiveDir := filepath.Join(cwd, ".moai", "harness", "learning-history", "archive")

--- a/internal/cli/hook_harness_observe_test.go
+++ b/internal/cli/hook_harness_observe_test.go
@@ -1,0 +1,273 @@
+// Package cli — hook harness-observe gate tests.
+//
+// REQ-HRN-FND-009 (SPEC-V3R4-HARNESS-001): While learning.enabled in
+// harness.yaml resolves to false, the PostToolUse observer hook must be a
+// complete no-op — no read, write, or append to usage-log.jsonl.
+//
+// REQ-HRN-FND-010: When learning.enabled is true, the PostToolUse observer
+// must append one JSONL entry per tool invocation containing at minimum
+// ISO-8601 timestamp, event_type, subject, and context hash.
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// ─────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────
+
+// writeHarnessYAML writes a harness.yaml document under dir/.moai/config/sections/
+// containing the supplied YAML body. The directory tree is created if missing.
+func writeHarnessYAML(t *testing.T, dir, body string) {
+	t.Helper()
+	configDir := filepath.Join(dir, ".moai", "config", "sections")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	path := filepath.Join(configDir, "harness.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write harness.yaml: %v", err)
+	}
+}
+
+// withStdin temporarily replaces os.Stdin with the given reader for the
+// duration of fn, restoring afterwards. Used to simulate hook stdin JSON.
+func withStdin(t *testing.T, payload string, fn func()) {
+	t.Helper()
+	orig := os.Stdin
+	t.Cleanup(func() { os.Stdin = orig })
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdin = r
+	go func() {
+		_, _ = io.WriteString(w, payload)
+		_ = w.Close()
+	}()
+	fn()
+}
+
+// ─────────────────────────────────────────────
+// TestIsHarnessLearningEnabled — table-driven gate tests
+// ─────────────────────────────────────────────
+
+func TestIsHarnessLearningEnabled(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		setupYAML string // empty = do not create harness.yaml
+		want      bool
+		reason    string
+	}{
+		{
+			name:      "missing_harness_yaml_is_fail_open",
+			setupYAML: "",
+			want:      true,
+			reason:    "fail-open: missing config preserves baseline observation per REQ-HRN-FND-009 semantics",
+		},
+		{
+			name:      "empty_harness_yaml_is_fail_open",
+			setupYAML: "\n",
+			want:      true,
+			reason:    "empty doc has no learning block; default to enabled",
+		},
+		{
+			name:      "no_learning_block_is_enabled",
+			setupYAML: "harness:\n  default_profile: \"default\"\n",
+			want:      true,
+			reason:    "harness section without learning key defaults to enabled",
+		},
+		{
+			name:      "learning_block_without_enabled_key_is_enabled",
+			setupYAML: "learning:\n  tier_thresholds: [1, 3, 5, 10]\n",
+			want:      true,
+			reason:    "learning block missing enabled key defaults to enabled",
+		},
+		{
+			name:      "learning_enabled_true",
+			setupYAML: "learning:\n  enabled: true\n",
+			want:      true,
+			reason:    "explicit true",
+		},
+		{
+			name:      "learning_enabled_false_blocks_observation",
+			setupYAML: "learning:\n  enabled: false\n",
+			want:      false,
+			reason:    "REQ-HRN-FND-009 — explicit false makes observer a no-op",
+		},
+		{
+			name:      "invalid_yaml_is_fail_open",
+			setupYAML: "learning:\n  enabled: : :: not yaml\n",
+			want:      true,
+			reason:    "parse error preserves baseline observation (fail-open)",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			if tc.setupYAML != "" {
+				writeHarnessYAML(t, dir, tc.setupYAML)
+			}
+
+			got := isHarnessLearningEnabled(dir)
+			if got != tc.want {
+				t.Errorf("isHarnessLearningEnabled() = %v, want %v (%s)", got, tc.want, tc.reason)
+			}
+		})
+	}
+}
+
+// ─────────────────────────────────────────────
+// TestRunHarnessObserve_NoOpWhenLearningDisabled (REQ-HRN-FND-009)
+// ─────────────────────────────────────────────
+
+// Verifies that when learning.enabled is false, runHarnessObserve neither
+// creates nor appends to .moai/harness/usage-log.jsonl and exits with no
+// error. This is the AC-HRN-FND-007 happy path.
+func TestRunHarnessObserve_NoOpWhenLearningDisabled(t *testing.T) {
+	dir := t.TempDir()
+	writeHarnessYAML(t, dir, "learning:\n  enabled: false\n")
+
+	// Change cwd so runHarnessObserve sees this project root.
+	t.Chdir(dir)
+
+	// Build a cobra command for stderr capture.
+	var stderr bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetErr(&stderr)
+
+	// Provide a representative PostToolUse payload — must NOT be read in no-op path.
+	withStdin(t, `{"toolName":"Edit"}`, func() {
+		if err := runHarnessObserve(cmd, nil); err != nil {
+			t.Fatalf("runHarnessObserve returned error: %v", err)
+		}
+	})
+
+	// Verify usage-log.jsonl was NOT created.
+	logPath := filepath.Join(dir, ".moai", "harness", "usage-log.jsonl")
+	if _, err := os.Stat(logPath); !os.IsNotExist(err) {
+		t.Errorf("usage-log.jsonl must not exist when learning.enabled is false; stat err=%v", err)
+	}
+
+	// Stderr should be silent — no error path on no-op.
+	if stderr.Len() != 0 {
+		t.Errorf("stderr must be empty on no-op; got: %q", stderr.String())
+	}
+}
+
+// ─────────────────────────────────────────────
+// TestRunHarnessObserve_PreservesExistingLogWhenDisabled (REQ-HRN-FND-009)
+// ─────────────────────────────────────────────
+
+// Verifies that pre-existing usage-log.jsonl entries are NOT deleted or
+// truncated when learning.enabled is false. The no-op semantics protect
+// the historical record.
+func TestRunHarnessObserve_PreservesExistingLogWhenDisabled(t *testing.T) {
+	dir := t.TempDir()
+	writeHarnessYAML(t, dir, "learning:\n  enabled: false\n")
+
+	// Seed an existing usage-log.jsonl with two entries.
+	logDir := filepath.Join(dir, ".moai", "harness")
+	if err := os.MkdirAll(logDir, 0o755); err != nil {
+		t.Fatalf("mkdir harness dir: %v", err)
+	}
+	logPath := filepath.Join(logDir, "usage-log.jsonl")
+	seed := `{"timestamp":"2026-05-14T10:00:00Z","event_type":"agent_invocation","subject":"Edit","context_hash":""}
+{"timestamp":"2026-05-14T10:05:00Z","event_type":"agent_invocation","subject":"Bash","context_hash":""}
+`
+	if err := os.WriteFile(logPath, []byte(seed), 0o644); err != nil {
+		t.Fatalf("seed usage-log.jsonl: %v", err)
+	}
+
+	t.Chdir(dir)
+
+	cmd := &cobra.Command{}
+	withStdin(t, `{"toolName":"Write"}`, func() {
+		if err := runHarnessObserve(cmd, nil); err != nil {
+			t.Fatalf("runHarnessObserve error: %v", err)
+		}
+	})
+
+	got, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read usage-log.jsonl: %v", err)
+	}
+	if string(got) != seed {
+		t.Errorf("seed entries were modified; want unchanged.\nwant=%q\n got=%q", seed, string(got))
+	}
+}
+
+// ─────────────────────────────────────────────
+// TestRunHarnessObserve_RecordsWhenEnabled (REQ-HRN-FND-010)
+// ─────────────────────────────────────────────
+
+// Verifies that when learning.enabled is true, runHarnessObserve appends one
+// JSONL entry to usage-log.jsonl containing the four required schema fields:
+// timestamp (ISO-8601), event_type, subject, context_hash. REQ-HRN-FND-010.
+//
+// Together with TestIsHarnessLearningEnabled this constitutes the T-C3 schema
+// verification in tasks.md: every observation entry has the four required keys.
+func TestRunHarnessObserve_RecordsWhenEnabled(t *testing.T) {
+	dir := t.TempDir()
+	writeHarnessYAML(t, dir, "learning:\n  enabled: true\n")
+
+	t.Chdir(dir)
+
+	cmd := &cobra.Command{}
+	withStdin(t, `{"toolName":"Edit"}`, func() {
+		if err := runHarnessObserve(cmd, nil); err != nil {
+			t.Fatalf("runHarnessObserve error: %v", err)
+		}
+	})
+
+	logPath := filepath.Join(dir, ".moai", "harness", "usage-log.jsonl")
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("usage-log.jsonl was not created when learning.enabled=true: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected exactly 1 JSONL entry, got %d:\n%s", len(lines), string(data))
+	}
+
+	var entry map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &entry); err != nil {
+		t.Fatalf("entry is not valid JSON: %v\nraw=%q", err, lines[0])
+	}
+
+	// REQ-HRN-FND-010 schema fields. Field names follow the observer's
+	// canonical JSONL contract; if these names diverge in a future refactor,
+	// update both the observer and this assertion together.
+	for _, required := range []string{"timestamp", "event_type", "subject"} {
+		if _, ok := entry[required]; !ok {
+			t.Errorf("entry missing required field %q\nraw=%q", required, lines[0])
+		}
+	}
+	// context_hash key may be present with empty value (per existing observer behavior).
+	if _, hasCtx := entry["context_hash"]; !hasCtx {
+		// Accept absence only if observer emits an alternate name; otherwise fail.
+		// Current implementation (internal/harness/observer.go) emits "context_hash".
+		t.Errorf("entry missing context_hash field; SPEC REQ-HRN-FND-010 requires it.\nraw=%q", lines[0])
+	}
+
+	// Subject must reflect the tool name from stdin.
+	if entry["subject"] != "Edit" {
+		t.Errorf("subject = %v, want \"Edit\"", entry["subject"])
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -90,4 +90,11 @@ func init() {
 
 	// SPEC-V3R2-RT-007: register migration subcommand group
 	rootCmd.AddCommand(migrationCmd)
+
+	// NOTE: newHarnessCmd is intentionally NOT registered per SPEC-V3R4-HARNESS-001
+	// (BC-V3R4-HARNESS-001-CLI-RETIREMENT). The harness CLI verb path is retired;
+	// all lifecycle verbs (status / apply / rollback / disable) are owned by the
+	// /moai:harness slash command + skill workflow surface (no Go binary invocation).
+	// See internal/cli/harness_retirement_test.go for the CI guard test that
+	// asserts the absence of a "harness" subcommand registration.
 }

--- a/internal/template/catalog.yaml
+++ b/internal/template/catalog.yaml
@@ -6,7 +6,7 @@ catalog:
             - name: moai
               tier: core
               path: templates/.claude/skills/moai/
-              hash: 725b1751ff9523ab1c88e158bc06e32a5604a4ba8fefcab62ed0e700f4e01892
+              hash: f811ce853b1b54f3852396a071c711cd885af2ab2695815813659e60f2b147b1
               version: 1.0.0
             - name: moai-foundation-cc
               tier: core
@@ -31,12 +31,12 @@ catalog:
             - name: moai-harness-learner
               tier: core
               path: templates/.claude/skills/moai-harness-learner/
-              hash: 8d156ef9c4beba71fc9885af142068418794a09381525587c2624de6953a1e17
+              hash: 9338a747262520ccda5e43202f74fcba008652c01031dc613a1535dcdc3e2023
               version: 1.0.0
             - name: moai-meta-harness
               tier: core
               path: templates/.claude/skills/moai-meta-harness/
-              hash: 4144eaef4048ef50b92525028203eb12d0e4120c5a5b096daa75bbb5e10c78ac
+              hash: 0ebea9c5841768e6d128d9ed25a475a84a3cb02096761be5074fdc7f6f0a134d
               version: 1.0.0
             - name: moai-ref-git-workflow
               tier: core

--- a/internal/template/templates/.claude/commands/moai/harness.md
+++ b/internal/template/templates/.claude/commands/moai/harness.md
@@ -1,0 +1,7 @@
+---
+description: Manage harness learning subsystem (status/apply/rollback/disable) with 4-tier evolution + 5-layer safety
+argument-hint: "{status|apply|rollback <YYYY-MM-DD>|disable}"
+allowed-tools: Skill
+---
+
+Use Skill("moai") with arguments: harness $ARGUMENTS

--- a/internal/template/templates/.claude/skills/moai-harness-learner/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-harness-learner/SKILL.md
@@ -16,7 +16,9 @@ user-invocable: false
 
 # moai-harness-learner
 
-Coordinator skill for the Harness Learning Subsystem (SPEC-V3R3-HARNESS-LEARNING-001).
+<!-- @MX:NOTE: [AUTO] V3R4 contract — this skill body is preserved unchanged per SPEC-V3R4-HARNESS-001 §10 exclusion #10 (text annotation only, no behavioral change). The 4-tier observation/heuristic/rule/auto_update ladder defined here is preserved verbatim under REQ-HRN-FND-011. The orchestrator-only AskUserQuestion contract is asserted by REQ-HRN-FND-015 (cross-reference: .claude/rules/moai/core/agent-common-protocol.md § User Interaction Boundary). The downstream replacement of the frequency-count classifier with an embedding-cluster algorithm is deferred to SPEC-V3R4-HARNESS-003. -->
+
+Coordinator skill for the Harness Learning Subsystem (SPEC-V3R3-HARNESS-LEARNING-001, superseded by SPEC-V3R4-HARNESS-001 as the active V3R4 foundation; this V3R3 SPEC's 4-tier ladder is preserved unchanged).
 Surfaces Tier 4 auto-update proposals to the user via AskUserQuestion and orchestrates Apply/Rollback flows.
 
 ## Quick Reference

--- a/internal/template/templates/.claude/skills/moai-meta-harness/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-meta-harness/SKILL.md
@@ -153,8 +153,9 @@ Agents involved: `builder-agent`, `builder-skill` for artifact generation.
 This skill fills the skeleton with domain-specific content:
 
 1. Generate agent definitions (`.claude/agents/my-harness/*.md`) referencing
-   existing MoAI agents: `manager-spec`, `manager-strategy`, `manager-tdd`,
-   `manager-ddd`, `manager-quality`, `manager-docs`, `manager-git`,
+   existing MoAI agents: `manager-spec`, `manager-strategy`, `manager-develop`
+   (`cycle_type=tdd` or `cycle_type=ddd` per `quality.yaml` `development_mode`),
+   `manager-quality`, `manager-docs`, `manager-git`,
    `expert-backend`, `expert-frontend`, `expert-debug`, `expert-testing`,
    `expert-security`, `expert-refactoring`, `expert-performance`, `expert-devops`,
    `expert-mobile`, `builder-agent`, `builder-skill`, `builder-plugin`,
@@ -214,8 +215,7 @@ referenced below are static MoAI agents — no new agents are introduced.
 
 **Workflow Managers**
 
-- `manager-ddd` — DDD-flavored harness workflow templates
-- `manager-tdd` — TDD-flavored harness workflow templates
+- `manager-develop` (`cycle_type=ddd` or `cycle_type=tdd` per `.moai/config/sections/quality.yaml` `development_mode`) — DDD or TDD-flavored harness workflow templates (SPEC-V3R3-RETIRED-DDD-001 M3 consolidated the prior DDD and TDD specialist managers into the unified `manager-develop` agent with cycle-type dispatch)
 - `manager-quality` — Quality gate configuration in generated harnesses
 - `manager-docs` — Documentation generation patterns
 - `manager-git` — Git workflow patterns for generated harnesses

--- a/internal/template/templates/.claude/skills/moai-meta-harness/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-meta-harness/SKILL.md
@@ -34,6 +34,8 @@ triggers:
 
 # moai-meta-harness
 
+<!-- @MX:NOTE: [AUTO] V3R4 contract — this skill body is preserved unchanged per SPEC-V3R4-HARNESS-001 §10 exclusion #10 (text annotation only, no behavioral change). The meta-harness 7-Phase workflow that generates project-specific my-harness-* skills and .claude/agents/my-harness/* definitions is governed by REQ-HRN-FND-015 (orchestrator-only AskUserQuestion contract) — any subagent generated under .claude/agents/my-harness/ MUST NOT invoke AskUserQuestion; if user input is required, the subagent returns a structured blocker report and the orchestrator runs the AskUser round. Cross-reference: .claude/rules/moai/core/agent-common-protocol.md § User Interaction Boundary. -->
+
 <!-- ATTRIBUTION
 Original work: revfactory/harness (https://github.com/revfactory/harness)
 License: Apache License 2.0
@@ -144,18 +146,18 @@ This skill (`moai-meta-harness`) generates the harness skeleton:
 3. Write extension files: `.moai/harness/agents.md`, `.moai/harness/skills.md`
 4. Create agent definition stubs in `.claude/agents/my-harness/`
 
-Agents involved: `builder-harness` for artifact generation.
+Agents involved: `builder-agent`, `builder-skill` for artifact generation.
 
 #### Phase 5 — Customization
 
 This skill fills the skeleton with domain-specific content:
 
 1. Generate agent definitions (`.claude/agents/my-harness/*.md`) referencing
-   existing MoAI agents: `manager-spec`, `manager-strategy`, `manager-develop`,
-   `manager-quality`, `manager-docs`, `manager-git`,
-   `expert-backend`, `expert-frontend`,
+   existing MoAI agents: `manager-spec`, `manager-strategy`, `manager-tdd`,
+   `manager-ddd`, `manager-quality`, `manager-docs`, `manager-git`,
+   `expert-backend`, `expert-frontend`, `expert-debug`, `expert-testing`,
    `expert-security`, `expert-refactoring`, `expert-performance`, `expert-devops`,
-   `expert-mobile`, `builder-harness`,
+   `expert-mobile`, `builder-agent`, `builder-skill`, `builder-plugin`,
    `evaluator-active`, `plan-auditor`.
 2. Generate domain skills (`.claude/skills/my-harness-*/SKILL.md`) following
    the skill-authoring.md schema with `my-harness-*` prefix.
@@ -199,21 +201,21 @@ referenced below are static MoAI agents — no new agents are introduced.
 - `expert-mobile` — Mobile domain harness templates
 - `expert-devops` — DevOps/platform domain harness templates
 - `expert-security` — Security review of generated permissions
-- `manager-develop` — Test harness pattern generation
-- `manager-quality` — Quality gates + diagnostic patterns
+- `expert-testing` — Test harness pattern generation
+- `expert-debug` — Debug agent patterns
 - `expert-refactoring` — Refactoring workflow patterns
 - `expert-performance` — Performance profiling patterns
 
 **Builders**
 
-- `builder-harness` (artifact_type=agent) — Generates `.claude/agents/my-harness/*.md` content
-- `builder-harness` (artifact_type=skill) — Generates `.claude/skills/my-harness-*/SKILL.md` content
-- `builder-harness` (artifact_type=plugin) — Optional plugin bundling of generated artifacts
+- `builder-agent` — Generates `.claude/agents/my-harness/*.md` content
+- `builder-skill` — Generates `.claude/skills/my-harness-*/SKILL.md` content
+- `builder-plugin` — Optional plugin bundling of generated artifacts
 
 **Workflow Managers**
 
-- `manager-develop` (cycle_type=ddd) — DDD-flavored harness workflow templates
-- `manager-develop` (cycle_type=tdd) — TDD-flavored harness workflow templates
+- `manager-ddd` — DDD-flavored harness workflow templates
+- `manager-tdd` — TDD-flavored harness workflow templates
 - `manager-quality` — Quality gate configuration in generated harnesses
 - `manager-docs` — Documentation generation patterns
 - `manager-git` — Git workflow patterns for generated harnesses
@@ -359,7 +361,7 @@ The following capabilities are explicitly NOT implemented by this skill:
 - `moai-foundation-cc` — Claude Code skill/agent authoring standards
 - `manager-spec` — Conducts Discovery and Synthesis phases
 - `evaluator-active` — Sprint Contract evaluation in Phase 6
-- `builder-harness` — Artifact generation helpers
+- `builder-agent` / `builder-skill` — Artifact generation helpers
 
 ---
 

--- a/internal/template/templates/.claude/skills/moai/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai/SKILL.md
@@ -3,7 +3,7 @@ name: moai
 description: >
   MoAI unified orchestrator for autonomous development. Routes natural
   language or subcommands (brain, plan, run, sync, design, db, project, fix,
-  loop, mx, feedback, review, clean, codemaps, coverage, e2e) to
+  loop, mx, feedback, review, clean, codemaps, coverage, e2e, harness) to
   specialized agents.
 allowed-tools: Agent, AskUserQuestion, Skill, TaskCreate, TaskUpdate, TaskList, TaskGet, Bash, Read, Write, Edit, Glob, Grep
 argument-hint: "[subcommand] [args] | \"natural language task\""
@@ -28,7 +28,7 @@ Rules and constraints governing all workflows are always loaded from these sourc
 - Quality gates, security boundaries: .claude/rules/moai/core/moai-constitution.md
 - SPEC workflow phases, token budgets: .claude/rules/moai/workflow/spec-workflow.md
 - Development methodologies (DDD/TDD): .claude/rules/moai/workflow/spec-workflow.md (Run Phase section)
-- Agent definitions: See CLAUDE.md Section 4. For agent creation, use builder-harness subagent.
+- Agent definitions: See CLAUDE.md Section 4. For agent creation, use builder-harness subagent (artifact_type=agent).
 - @MX tag rules and protocol: .claude/rules/moai/workflow/mx-tag-protocol.md
 
 ---
@@ -73,6 +73,8 @@ When no flag is provided, the system evaluates task complexity and automatically
 - **e2e** (aliases: e2e-test): Create and run E2E tests
 - **gate** (aliases: check, pre-commit): Lightweight pre-commit quality gate (lint+format+type-check+test)
 - **security** (aliases: audit, sec): Dedicated OWASP security audit with dependency scanning
+- **harness** (aliases: hrn, learn): V3R4 self-evolving harness lifecycle (status / apply / rollback &lt;date&gt; / disable) — slash-command-only surface; CLI verb path retired per SPEC-V3R4-HARNESS-001 (BC-V3R4-HARNESS-001-CLI-RETIREMENT)
+- **release-update** (aliases: cc-update, release-track) *(dev-only)*: CC upstream change tracker → update plan + docs-site 4-locale sync
 
 
 ### Priority 2: SPEC-ID Detection
@@ -143,14 +145,14 @@ For detailed orchestration: Read /Users/goos/MoAI/moai-adk-go/.claude/skills/moa
 ### fix - Auto-Fix Errors
 
 Purpose: Autonomously detect and fix LSP errors, linting issues, and type errors.
-Agents: manager-quality (diagnosis), expert-backend/expert-frontend (fixes)
+Agents: manager-quality (diagnostic-mode), expert-backend/expert-frontend (fixes)
 Flags: --dry, --sequential, --level N, --resume, --team
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/fix.md
 
 ### loop - Iterative Auto-Fix
 
 Purpose: Repeatedly fix issues until completion marker detected or max iterations reached.
-Agents: manager-quality, expert-backend, expert-frontend, manager-develop
+Agents: manager-quality (diagnostic-mode), expert-backend, expert-frontend, manager-develop
 Flags: --max N, --auto-fix, --seq
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/loop.md
 
@@ -185,14 +187,14 @@ For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/codemaps.md
 ### coverage - Test Coverage Analysis
 
 Purpose: Analyze test coverage gaps and generate missing tests.
-Agents: manager-develop
+Agents: manager-develop (cycle_type=tdd)
 Flags: --target N, --file PATH, --report
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/coverage.md
 
 ### e2e - End-to-End Testing
 
 Purpose: Create and run E2E tests using Chrome, Playwright, or Agent Browser.
-Agents: manager-develop, expert-frontend
+Agents: manager-develop (cycle_type=tdd), expert-frontend
 Flags: --record, --url URL, --journey NAME
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/e2e.md
 
@@ -232,6 +234,24 @@ For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/project.md
 Purpose: Collect user feedback and create GitHub issues.
 Agents: manager-quality
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/feedback.md
+
+### harness - V3R4 Self-Evolving Harness Lifecycle
+
+Purpose: Surface the harness learning subsystem (observer, 4-tier proposal ladder, 5-layer safety pipeline) to the user via the slash command path. Owns all lifecycle verbs (status / apply / rollback / disable) entirely within the workflow body using file-system operations — no Go binary subcommand invoked. Tier-4 application is gated by orchestrator-issued AskUserQuestion per REQ-HRN-FND-004.
+Skills: moai-harness-learner (Tier-4 surfacing companion), moai-meta-harness (project-specific harness generation, indirect)
+Verbs: status (tier distribution + telemetry) | apply (next Tier-4 proposal → AskUserQuestion → 5-layer pipeline → snapshot + write) | rollback &lt;YYYY-MM-DD&gt; (restore snapshot) | disable (set learning.enabled: false)
+Artifacts: `.moai/harness/usage-log.jsonl`, `.moai/harness/proposals/`, `.moai/harness/learning-history/snapshots/`, `.moai/harness/learning-history/applied/`, `.moai/harness/learning-history/frozen-guard-violations.jsonl`
+Authoritative SPEC: SPEC-V3R4-HARNESS-001 (supersedes V3R3-HARNESS-001, V3R3-HARNESS-LEARNING-001, V3R3-PROJECT-HARNESS-001)
+For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/harness.md
+
+### release-update - CC Upstream Change Tracker *(dev-only)*
+
+Purpose: Track Claude Code release notes since last analyzed version, classify by impact tier, generate update plan, sync docs-site 4-locale + README, open PR.
+Agents: manager-docs (Phase 6 docs sync), manager-git (Phase 7 PR)
+Flags: --since vX.Y.Z, --dry, --report-only, --docs-only, --master-spec
+State: .moai/state/last-cc-version.json
+For detailed orchestration: Read /Users/goos/MoAI/moai-adk-go/.claude/skills/moai/workflows/release-update.md
+NOT distributed to user projects (dev-only; entry: .claude/commands/97-release-update.md)
 
 ---
 

--- a/internal/template/templates/.claude/skills/moai/workflows/harness.md
+++ b/internal/template/templates/.claude/skills/moai/workflows/harness.md
@@ -1,0 +1,270 @@
+---
+name: moai-workflow-harness
+description: >
+  V3R4 Self-Evolving Harness lifecycle workflow. Owns all lifecycle verbs
+  (status, apply, rollback, disable) entirely within the moai skill body
+  using file-system operations — no Go binary subcommand is invoked. Tier-4
+  evolution applications are gated by an orchestrator-issued AskUserQuestion
+  approval round per the 5-Layer Safety architecture.
+user-invocable: false
+metadata:
+  version: "2.0.0"
+  category: "workflow"
+  status: "active"
+  updated: "2026-05-14"
+  tags: "harness, learning, observer, tier-4, safety, evolution, apply, rollback, v3r4, cli-retired"
+
+# MoAI Extension: Progressive Disclosure
+progressive_disclosure:
+  enabled: true
+  level1_tokens: 100
+  level2_tokens: 5000
+
+# MoAI Extension: Triggers
+triggers:
+  keywords: ["harness", "harness status", "harness apply", "harness rollback", "harness disable", "tier 4", "harness proposal", "harness evolve"]
+  agents: ["moai-harness-learner"]
+  phases: ["harness"]
+---
+
+<!-- @MX:NOTE: [AUTO] V3R4 contract — workflow body owns the lifecycle entirely via file-system operations. No `moai harness` CLI subcommand is invoked. The Go file `internal/cli/harness.go` is retained only as a deprecation marker awaiting downstream physical removal per SPEC-V3R4-HARNESS-001 (BC-V3R4-HARNESS-001-CLI-RETIREMENT). -->
+<!-- @MX:REASON: [AUTO] V3R3-era workflow body shelled out to `moai harness <verb>` cobra subcommand. V3R4 retires that CLI verb path (REQ-HRN-FND-001, REQ-HRN-FND-002) and consolidates all lifecycle execution into the slash command + workflow body surface (REQ-HRN-FND-003). -->
+
+# Workflow: harness — V3R4 Self-Evolving Harness Lifecycle
+
+Purpose: Surface the harness learning subsystem (observer, 4-tier proposal ladder, 5-layer safety pipeline) to the user. This workflow IS the implementation — every verb (`status`, `apply`, `rollback`, `disable`) is executed by file-system reads and writes inside this workflow body. No Go binary subcommand is invoked. The Go CLI factory in `internal/cli/harness.go` remains in the tree as a deprecation marker only; it is never registered into the cobra command tree (REQ-HRN-FND-001, REQ-HRN-FND-002).
+
+## Authoritative Sources
+
+- SPEC (active): `SPEC-V3R4-HARNESS-001` (foundation, supersedes the three V3R3 harness SPECs)
+- Constitution: `.claude/rules/moai/design/constitution.md` §5 (5-Layer Safety) and §2 (Frozen/Evolvable zones)
+- AskUserQuestion contract: `.claude/rules/moai/core/askuser-protocol.md` (canonical reference)
+- Agent boundary: `.claude/rules/moai/core/agent-common-protocol.md` § User Interaction Boundary
+- Config: `.moai/config/sections/harness.yaml` (`learning.enabled` field)
+- State roots:
+  - `.moai/harness/usage-log.jsonl` (PostToolUse observation append-only log)
+  - `.moai/harness/proposals/` (pending Tier-4 proposals)
+  - `.moai/harness/learning-history/snapshots/<ISO-DATE>/` (pre-modification snapshots)
+  - `.moai/harness/learning-history/applied/` (applied proposals, used for rate-limit window)
+  - `.moai/harness/learning-history/tier-promotions.jsonl` (tier classifier transitions)
+  - `.moai/harness/learning-history/frozen-guard-violations.jsonl` (L1 audit log)
+
+## Related Rules and References
+
+- AskUserQuestion ToolSearch preload procedure: `.claude/rules/moai/core/askuser-protocol.md` § ToolSearch Preload Procedure
+- Free-form circumvention prohibition: `.claude/rules/moai/core/askuser-protocol.md` § Free-form Circumvention Prohibition
+- Orchestrator-subagent boundary: `.claude/rules/moai/core/agent-common-protocol.md` § User Interaction Boundary
+- Lessons (auto-memory): `lessons.md` workflow + harness categories when present
+
+---
+
+## Tier-4 Application Gate (Orchestrator-Only AskUserQuestion)
+
+[HARD] Tier-4 application of any harness evolution proposal MUST be gated by an orchestrator-issued `AskUserQuestion` round before any file modification occurs (REQ-HRN-FND-004, REQ-HRN-FND-015). The workflow body itself is executed in the orchestrator's main context; `AskUserQuestion` is invoked here as the orchestrator's tool. Subagents reachable from this workflow MUST NOT call `AskUserQuestion`; if a subagent needs user input it returns a structured blocker report and the orchestrator re-runs the round (canonical reference: `.claude/rules/moai/core/askuser-protocol.md`).
+
+### Canonical Four-Option Pattern
+
+Before invoking `AskUserQuestion`, preload the schema:
+
+```
+ToolSearch(query: "select:AskUserQuestion")
+```
+
+Then invoke with at least three options (Apply / Defer / Reject — additional options permitted), the first option marked `(권장)` or `(Recommended)`:
+
+```
+AskUserQuestion({
+  questions: [{
+    question: "Harness Tier-4 evolution proposal ready to apply (id: <proposal_id>).\n\nTarget: <target_path>\nField: <field_key>\nProposed value: <new_value>\nObservation count: <observation_count>\n\nApply this change?",
+    header: "Tier-4 Apply",
+    options: [
+      { label: "Apply (권장)", description: "Run the 5-Layer Safety pipeline. On pass, create a snapshot and write the change. Snapshot lives under .moai/harness/learning-history/snapshots/<ISO-DATE>/." },
+      { label: "Modify", description: "Open the proposal for manual edit before re-presenting. Proposal file is preserved." },
+      { label: "Defer", description: "Re-record the proposal for later approval. The 7-day rate-limit window starts only when an Apply is accepted." },
+      { label: "Reject", description: "Move the proposal to .moai/harness/learning-history/rejected/. No file is modified." }
+    ]
+  }]
+})
+```
+
+### Rate-Limit Enforcement (REQ-HRN-FND-012)
+
+Before opening the AskUserQuestion round, count entries in `.moai/harness/learning-history/applied/` whose `applied_at` falls within the last 7 days. If the count is ≥ 1, the new candidate MUST be deferred and recorded with a `deferred_at` timestamp; do NOT invoke `AskUserQuestion`. The rate-limit floor of 1 application per 7-day window is invariant per REQ-HRN-FND-018 — any future adaptive expansion may raise the limit but never lower it.
+
+---
+
+## Input
+
+`$ARGUMENTS` — the first word is the verb (`status`, `apply`, `rollback`, `disable`, or empty for help). Remaining arguments are passed to the verb dispatcher.
+
+## Verb Routing
+
+[HARD] Extract the FIRST WORD from `$ARGUMENTS`. Match against the verb table below. If empty or unrecognized, show the help block (Phase 0).
+
+| Verb | Workflow-body operations | Tools used | Purpose |
+|------|---------------------------|------------|---------|
+| `status` | Read JSONL state files, aggregate counts | Read, Bash (jq) | Inspect tier distribution, rate-limit window, pending proposal count, Tier-4 reach rate |
+| `apply` | Layer 1 (FrozenGuard path-prefix check) → Layer 4 (rate-limit window check) → AskUserQuestion → snapshot creation → file write → audit log append | Read, Write, Edit, Bash, AskUserQuestion | Surface next Tier-4 proposal via AskUserQuestion, apply on approval through 5-layer pipeline |
+| `rollback <YYYY-MM-DD>` | Read snapshot `manifest.json`, copy files back | Read, Write, Bash | Restore byte-identical pre-modification state from snapshot |
+| `disable` | AskUserQuestion confirm → Edit harness.yaml `learning.enabled: false` | AskUserQuestion, Edit | Turn off observer; observer becomes a no-op (REQ-HRN-FND-009) |
+
+---
+
+## Phase 0: Help (default when no verb)
+
+If `$ARGUMENTS` is empty or matches `help` / `--help` / `-h`, render the verb table above plus a one-line summary in the user's `conversation_language`. Then stop. Do not perform any read or write.
+
+---
+
+## Phase 1: Pre-Execution Sanity Check
+
+Before executing any verb, verify:
+
+1. Project root is detected (`.moai/config/config.yaml` exists). If absent, abort with guidance to run `moai init` first.
+2. Harness learning subsystem state: read `.moai/config/sections/harness.yaml` `learning.enabled` field.
+   - If `enabled: false` and verb is anything other than `status`, surface a warning that the subsystem is disabled via AskUserQuestion (continue / abort). The first option is `Continue (권장)` only when the verb is `rollback` (rollback should remain functional even with learning disabled); for `apply`, first option is `Abort (권장)`.
+3. For `rollback`: the date argument is mandatory. If missing, abort with usage hint `/moai:harness rollback <YYYY-MM-DD>`.
+
+---
+
+## Phase 2: Verb Dispatch
+
+### 2.1 status (file-IO only — no binary)
+
+Operations:
+
+1. Read `.moai/harness/usage-log.jsonl` (line-count via `wc -l` or progressive Read).
+2. Read `.moai/harness/learning-history/tier-promotions.jsonl` (group by tier: observation / heuristic / rule / auto_update).
+3. Read `.moai/harness/learning-history/applied/` directory listing for Tier-4 application count within the last 7 days (REQ-HRN-FND-016 telemetry).
+4. Compute Tier-4 reach rate = (unique patterns with `tier=auto_update` in tier-promotions.jsonl) / (unique patterns in usage-log.jsonl) × 100. Patterns are keyed by `event_type + subject + context_hash` (REQ-HRN-FND-010).
+5. Read `.moai/harness/proposals/` directory listing for pending proposal count.
+6. Render the result as a Markdown table in the user's `conversation_language`:
+
+```
+Harness Learning Status (V3R4)
+  Enabled:                  <bool from harness.yaml learning.enabled>
+  Log entries:              <line count of usage-log.jsonl>
+  Unique patterns:          <distinct event_type+subject+context_hash>
+
+Tier Distribution:
+  observation (T1):         <int>
+  heuristic   (T2):         <int>
+  rule        (T3):         <int>
+  auto_update (T4):         <int> patterns (pending user approval)
+
+Telemetry (REQ-HRN-FND-016):
+  Weekly Tier-4 applications (rolling 7-day): <int>
+  Tier-4 reach rate:                          <pct>%
+
+Pending Proposals: <int>
+  [PENDING] <proposal_id>: <skill_path> (<field>)
+  ...
+```
+
+No user prompt. Stop after rendering.
+
+### 2.2 apply (5-Layer Safety pipeline, file-IO only)
+
+Operations:
+
+1. **Layer 4 (Rate Limiter) pre-screen**: Scan `.moai/harness/learning-history/applied/` for any entry with `applied_at` within the last 7 days. If count ≥ 1, defer:
+   - Append `{ "deferred_at": <ISO-8601>, "reason": "rate-limit window active", "proposal_id": <id> }` to the candidate proposal's metadata.
+   - Render "Tier-4 rate-limit window active — proposal <id> deferred" and STOP. Do NOT invoke AskUserQuestion (REQ-HRN-FND-012).
+2. **Load next pending proposal**: Read `.moai/harness/proposals/` directory; pick the oldest pending entry (`.json` payload). If none, render "No Tier-4 proposals awaiting approval" and stop.
+3. **Layer 1 (Frozen Guard) pre-screen**: Read the proposal's `target_path`. Match against the FROZEN prefix list:
+   - `.claude/agents/moai/`
+   - `.claude/skills/moai-`
+   - `.claude/rules/moai/`
+   - `.moai/project/brand/`
+   If any prefix matches, append a JSONL entry to `.moai/harness/learning-history/frozen-guard-violations.jsonl` with at minimum: ISO-8601 timestamp, the attempted target path, the proposal id (as calling subject), and a rejection rationale (REQ-HRN-FND-006, REQ-HRN-FND-014). Then move the proposal to `.moai/harness/learning-history/rejected/` and stop. Do NOT raise an error to the user; the rejection is silent except for the audit log.
+4. **Layer 3 (Contradiction Detector) pre-screen**: Out of scope for the V3R4 foundation SPEC. Downstream `SPEC-V3R4-HARNESS-005` introduces principle-based scoring; this workflow body documents the contract assertion (REQ-HRN-FND-017) and treats Layer 3 as a no-op pass-through for the foundation release.
+5. **Tier-4 Application Gate**: `ToolSearch(query: "select:AskUserQuestion")` → `AskUserQuestion` with the canonical four-option pattern from the section above. The first option `Apply (권장)` MUST carry the `(권장)` / `(Recommended)` suffix per `.claude/rules/moai/core/askuser-protocol.md` § Option Description Standards.
+6. **On `Apply` selection**:
+   - **Layer 2 (Canary Check)**: Out of scope for the V3R4 foundation SPEC. Downstream `SPEC-V3R4-HARNESS-006` introduces multi-objective scoring with score-drop check; the workflow body treats Layer 2 as a no-op pass-through for the foundation release. The constitution §5 L2 layer remains documented as the binding contract.
+   - **Create snapshot** (REQ-HRN-FND-007): Create directory `.moai/harness/learning-history/snapshots/<ISO-DATE>/` (ISO-8601 timestamp). For each file the proposal will touch, Read the current contents, compute a content hash, and Write a byte-identical copy into the snapshot directory. Write `manifest.json` recording absolute target paths and content hashes. The snapshot MUST be complete before any modification of the target file.
+   - **Apply the change**: Read the proposal's `new_value`, perform the field replacement on `target_path` (typically a frontmatter `description` or `triggers` edit on a `my-harness-*` skill body). Use the `Edit` tool with exact `old_string` / `new_string` match.
+   - **Move the proposal**: Move the proposal file from `.moai/harness/proposals/` to `.moai/harness/learning-history/applied/`. Append an `applied_at` ISO-8601 timestamp and the snapshot directory path to the JSON payload.
+   - **Render outcome**: Confirm `Applied. Snapshot: <path>. Run /moai:harness status to verify the new tier distribution.`.
+7. **On `Modify` selection**: Render guidance to open the proposal file at `.moai/harness/proposals/<id>.json` in the user's editor. Do NOT modify state. Re-presenting requires the next `/moai:harness apply` invocation after edit.
+8. **On `Defer` selection**: Append `deferred_at` timestamp to the proposal metadata. Stop.
+9. **On `Reject` selection**: Move the proposal to `.moai/harness/learning-history/rejected/`. Stop.
+
+Edge case (EDGE-001): If the snapshot directory cannot be created (disk-full, permission), abort BEFORE any modification. Inform the user via the orchestrator's response. No partial state is left on disk.
+
+Edge case (EDGE-006): Concurrent `/moai:harness apply` invocations are out of scope for the foundation SPEC. The orchestrator's AskUserQuestion contract is sequential by design.
+
+### 2.3 rollback
+
+Operations:
+
+1. Validate that the date argument matches `YYYY-MM-DD` or full ISO-8601 (`YYYY-MM-DDThh:mm:ssZ`). If invalid format, abort with usage hint.
+2. Locate snapshot directory: `.moai/harness/learning-history/snapshots/<date>/`. If the directory does not exist, render a diagnostic message naming the missing snapshot and STOP. Do NOT modify any file (REQ-HRN-FND-008 explicit unwanted behavior on missing snapshot).
+3. Read `manifest.json` from the snapshot directory.
+4. For each entry in the manifest: Read the snapshot copy, Write to the absolute target path. Verify the post-write content hash matches the snapshot hash (byte-identical restoration).
+5. Render confirmation message naming the snapshot date and the restored file count.
+
+Safety: rollback does NOT delete the post-application state — it overlays the snapshot. The current state is preserved at `.moai/harness/learning-history/snapshots/<rollback-timestamp>/pre-rollback/` before the rollback overwrite.
+
+### 2.4 disable
+
+Operations:
+
+1. `ToolSearch(query: "select:AskUserQuestion")` → `AskUserQuestion` to confirm intent (this is the only place in `disable` that prompts the user directly, because the consequence is global subsystem deactivation):
+   - Question (Korean conversation_language example): `Harness 학습 서브시스템을 비활성화하시겠습니까? 옵서버가 이벤트 수집을 중단하고 신규 제안이 생성되지 않습니다.`
+   - Options:
+     - `Disable (권장)` — Set `learning.enabled: false`. Snapshots and proposals are preserved.
+     - `Keep enabled` — Stop without changes.
+     - `Disable temporarily (1h)` — Not supported in the V3R4 foundation SPEC; render guidance to re-enable manually via config edit and stop.
+2. On `Disable` selection: Use `Edit` tool on `.moai/config/sections/harness.yaml` to set `learning.enabled: false`. Comments and key ordering MUST be preserved (YAML round-trip discipline).
+3. On `Keep enabled`: stop without changes.
+4. On `Disable temporarily`: render guidance and stop.
+
+Observer no-op contract (REQ-HRN-FND-009): When `learning.enabled: false`, the PostToolUse observer hook MUST be a complete no-op — it does not read, write, or append to `.moai/harness/usage-log.jsonl`. Existing log entries MUST NOT be deleted.
+
+---
+
+## Phase 3: Post-Execution Summary
+
+After any successful verb execution, render a one-paragraph summary in the user's `conversation_language` covering:
+
+1. What was done (verb + key result).
+2. Where the artifact lives (`.moai/harness/...` path).
+3. Suggested next step (e.g., after `apply`: "Run `/moai:harness status` to verify the new tier distribution.").
+
+---
+
+## Error Handling
+
+| Symptom | Likely cause | Recovery |
+|---------|-------------|----------|
+| `harness.yaml not found` | Project not initialized or harness disabled at scaffold | Run `moai init` first; harness subsystem is created on first run |
+| `Error: learning.enabled: false` on `apply` | Subsystem disabled by user or admin | Re-enable manually via editing `.moai/config/sections/harness.yaml` (no `enable` verb yet — deferred to a downstream SPEC) |
+| `Error: no snapshot matching <date>` on `rollback` | Snapshot directory absent for requested date | Run `/moai:harness status` to list available snapshot dates under `.moai/harness/learning-history/snapshots/` |
+| AskUserQuestion schema not loaded | Deferred tool preload missed | The workflow body explicitly preloads via `ToolSearch(query: "select:AskUserQuestion")` before each `apply` or `disable` invocation |
+| Frozen-guard violation log permission failure | Disk-full or permission denied on `.moai/harness/learning-history/` | Per EDGE-003, the L1 Frozen Guard MUST still block the modification; log emission is best-effort audit |
+
+---
+
+## Cross-references
+
+- SPEC (active): `.moai/specs/SPEC-V3R4-HARNESS-001/spec.md` (REQ-HRN-FND-001 ~ REQ-HRN-FND-018)
+- SPEC (superseded by V3R4-001; preserved as historical reference):
+  - `.moai/specs/SPEC-V3R3-HARNESS-LEARNING-001/spec.md` (REQ-HL-001 ~ REQ-HL-012 — 4-tier ladder preserved)
+  - `.moai/specs/SPEC-V3R3-HARNESS-001/spec.md` (Meta-harness skill + generated artifacts)
+  - `.moai/specs/SPEC-V3R3-PROJECT-HARNESS-001/spec.md` (16Q socratic interview + 5-Layer wiring)
+- Skill: `.claude/skills/moai-harness-learner/SKILL.md` (Tier-4 surfacing companion — text-annotated only per SPEC-V3R4-HARNESS-001 §10 exclusion #10)
+- Skill: `.claude/skills/moai-meta-harness/SKILL.md` (project-specific harness generation — text-annotated only)
+- README: `.moai/harness/README.md` (subsystem overview)
+- Attribution: `.claude/rules/moai/NOTICE.md` (Apache-2.0 attribution to revfactory/harness)
+- Constitution: `.claude/rules/moai/design/constitution.md` §5 (5-Layer Safety — preserved verbatim per REQ-HRN-FND-005)
+
+<!-- Verifies REQ-HRN-FND-001/002: no Bash invocation of `moai harness` anywhere in this workflow body. -->
+<!-- Verifies REQ-HRN-FND-003: all four verbs (status/apply/rollback/disable) implemented in this body. -->
+<!-- Verifies REQ-HRN-FND-004/015: Tier-4 application is gated by orchestrator-issued AskUserQuestion. -->
+<!-- Verifies REQ-HRN-FND-005: 5-Layer Safety preserved (L2/L3 documented as deferred no-op to downstream SPECs; L1/L4/L5 active). -->
+<!-- Verifies REQ-HRN-FND-006/014: FROZEN zone path-prefix block + audit log emission. -->
+<!-- Verifies REQ-HRN-FND-007/008: pre-modification snapshot + rollback to byte-identical state. -->
+<!-- Verifies REQ-HRN-FND-009: observer no-op contract documented (enforced by hook code path, Wave C). -->
+<!-- Verifies REQ-HRN-FND-010/011: PostToolUse baseline schema + 4-tier ladder preserved. -->
+<!-- Verifies REQ-HRN-FND-012/018: Tier-4 rate-limit floor of 1 per 7-day window. -->
+<!-- Verifies REQ-HRN-FND-016: telemetry exposure (weekly Tier-4 apply count + reach rate) via `status` verb. -->


### PR DESCRIPTION
## Summary

Foundation SPEC implementation for the V3R4 self-evolving harness architecture. Consolidates three V3R3 harness SPECs into a single V3R4 family and retires the `moai harness <verb>` Go CLI verb path as a public surface per `BC-V3R4-HARNESS-001-CLI-RETIREMENT`. All lifecycle verbs (status/apply/rollback/disable) are now owned by the `/moai:harness` slash command surface and the moai skill workflow body — zero Go binary invocations remain. The 5-Layer Safety architecture and FROZEN zones are preserved byte-for-byte.

**Authoritative SPEC**: `.moai/specs/SPEC-V3R4-HARNESS-001/spec.md` (REQ-HRN-FND-001 ~ REQ-HRN-FND-018, 12 ACs, 6 edge cases, 7 scenarios)
**Plan PR**: #909 (merged at e246423ee)
**Brain**: IDEA-004 (`.moai/brain/IDEA-004/`)

## Wave Breakdown (5 waves / 17 tasks)

- **Wave A — Skill body & workflow consolidation** (T-A1~A4 / P0×3 P1×1): Rewrote `.claude/skills/moai/workflows/harness.md` to remove all `moai harness` CLI invocations. Workflow body now owns lifecycle verbs entirely via file-system operations. Added Tier-4 AskUserQuestion gate section + cross-reference to askuser-protocol.md. Annotated moai-harness-learner SKILL.md (text-only). Imported missing slash command wrapper + workflow body base state from commit `452aa638f` per spec.md §7 Constraints.
- **Wave B — Subagent reorganization** (T-B1~B3 / P0×2 P1×1): Annotated moai-meta-harness SKILL.md. Audit T-B1 finding: zero subagent file violations (moai-harness-learner is a SKILL not a subagent; AskUserQuestion call appropriate per agent-common-protocol). T-B3 skip: `.claude/agents/my-harness/` dir does not exist in current project state.
- **Wave C — Hook contract preservation** (T-C1~C3 / P1×3): Added `isHarnessLearningEnabled` gate to `internal/cli/hook.go` with fail-open semantics. Wired into `runHarnessObserve`. 10 table-driven tests in `internal/cli/hook_harness_observe_test.go`.
- **Wave D — CLI deprecation marker + CI guard** (T-D1~D4 / P0×3 P1×1): Deprecation header on `internal/cli/harness.go`. New CI guard `internal/cli/harness_retirement_test.go` blocks any future re-registration. Annotation on `internal/cli/root.go` near AddCommand block.
- **Wave E — Documentation + V3R3 supersedes follow-up** (T-E1~E3 / P1×3): Bilingual CHANGELOG.md entry, RELEASE-NOTES-v2.20.0.md migration story, follow-up.md with verbatim manager-git instructions for V3R3 status transition.

## Verification (AC traceability)

- ✅ **AC-HRN-FND-001** (REQ-001/002): CLI retirement + CI guard — `TestHarnessRetirement` + `TestHarnessFactoryStillCompiles` PASS
- ✅ **AC-HRN-FND-002** (REQ-003): Slash command verb coverage — grep across 3 target files returns 0 invocation matches (3 commentary matches in workflow body are HTML blocks, acceptable per AC verification rubric)
- ✅ **AC-HRN-FND-003** (REQ-004/015): Tier-4 AskUserQuestion gate (orchestrator-only) — workflow body documents canonical 4-option pattern + ToolSearch preload
- ✅ **AC-HRN-FND-004** (REQ-005): 5-Layer Safety verbatim — `.claude/rules/moai/design/constitution.md` §5 untouched
- ✅ **AC-HRN-FND-005** (REQ-006/014): FROZEN zone + audit log — documented in workflow body
- ✅ **AC-HRN-FND-006** (REQ-007/008): Snapshot + rollback — workflow body documents byte-identical contract
- ✅ **AC-HRN-FND-007** (REQ-009): Observer no-op — `TestRunHarnessObserve_NoOpWhenLearningDisabled` + `TestRunHarnessObserve_PreservesExistingLogWhenDisabled` PASS
- ✅ **AC-HRN-FND-008** (REQ-010/011): PostToolUse schema + 4-tier ladder — `TestRunHarnessObserve_RecordsWhenEnabled` verifies 4 fields (timestamp/event_type/subject/context_hash)
- ✅ **AC-HRN-FND-009** (REQ-012/018): Rate-limit floor of 1 per 7-day window — workflow body documents invariant
- ✅ **AC-HRN-FND-010** (REQ-013): Zero V3R3 SPEC modifications — `git diff main..HEAD --name-only | grep V3R3-(HARNESS-001|HARNESS-LEARNING-001|PROJECT-HARNESS-001)` returns nothing
- ✅ **AC-HRN-FND-011** (REQ-016): Telemetry exposure — `status` verb documented to derive weekly Tier-4 application count + reach rate without binary
- ✅ **AC-HRN-FND-012** (REQ-017): Reflexion-evaluator conflict resolution — contract assertion documented in workflow body for downstream SPEC-V3R4-HARNESS-004

## Test plan

- [x] Run `go test ./internal/cli/ -count=1` → PASS (9.266s, zero regressions)
- [x] Run `go test ./internal/hook/... -count=1` → PASS (zero regressions across 12 packages)
- [x] Run `go vet ./internal/cli/...` → clean
- [x] Run new tests `TestIsHarnessLearningEnabled` (7 cases) + `TestRunHarnessObserve_*` (3 cases) + `TestHarnessRetirement` + `TestHarnessFactoryStillCompiles` → 12 tests PASS
- [x] Verify AC-HRN-FND-002 grep returns 0 invocation matches (commentary acceptable)
- [x] Verify AC-HRN-FND-010 zero V3R3 SPEC file modifications
- [x] `make build` succeeds (embedded.go regenerated)
- [ ] CI Lint / Test (ubuntu-latest / macos-latest / windows-latest) — to be verified in PR checks
- [ ] CI Build (5 platforms) — to be verified in PR checks
- [ ] CodeQL — to be verified in PR checks

## Breaking changes

- **BC-V3R4-HARNESS-001-CLI-RETIREMENT**: `moai harness <verb>` from the shell returns `unknown command "harness" for "moai"` with non-zero exit. Use `/moai:harness <verb>` inside a Claude Code session instead. Slash command surface is identical to V3R3 era — no muscle memory change. Documented in CHANGELOG.md + RELEASE-NOTES-v2.20.0.md.

## Supersedes (status transition deferred to follow-up.md)

- `SPEC-V3R3-HARNESS-001`
- `SPEC-V3R3-HARNESS-LEARNING-001`
- `SPEC-V3R3-PROJECT-HARNESS-001`

## Merge strategy

**Squash** per Enhanced GitHub Flow (`CLAUDE.local.md` §18.3 feature → main).

## Post-merge actions (out of this PR's scope)

1. `manager-git` executes `.moai/specs/SPEC-V3R4-HARNESS-001/follow-up.md` — separate `chore/SPEC-V3R3-status-transition` branch + PR transitioning three V3R3 SPECs to `status: superseded`.
2. `/moai sync SPEC-V3R4-HARNESS-001` in the same worktree to generate sync PR.
3. `moai worktree done SPEC-V3R4-HARNESS-001` after both run + sync PRs merge.
4. SPEC-V3R4-HARNESS-002 plan-phase entry.

🗿 MoAI <email@mo.ai.kr>