### PR TITLE
fix(spec): comma multi-REQ 매핑 인식 (lint 3 ERROR 해소)

### DIFF
--- a/internal/spec/ears.go
+++ b/internal/spec/ears.go
@@ -112,16 +112,36 @@ func (a *Acceptance) ValidateDepth() error {
 	return nil
 }
 
-// ExtractRequirementMappings extracts (maps REQ-...) pattern from text
+// ExtractRequirementMappings extracts (maps REQ-...) pattern from text.
+// Supports both single-REQ form `(maps REQ-X-001)` and comma-separated
+// multi-REQ form `(maps REQ-X-001, REQ-X-002, REQ-X-003)`. Both forms are
+// canonical per SPEC-V3R2-SPC-001 §6 (hierarchical acceptance examples).
+// @MX:NOTE: "2-pass extraction: section locator + REQ enumerator. The single-pass
+// regex previously here only matched the first REQ after the `maps` keyword and
+// silently dropped subsequent comma-listed REQs, causing false-positive
+// CoverageIncomplete findings on every multi-REQ mapping."
 func ExtractRequirementMappings(text string) []string {
-	pattern := regexp.MustCompile(`\(?\s*(?:maps|MAPS)\s+REQ-([A-Z0-9-]+)\s*\)?`)
-	matches := pattern.FindAllStringSubmatch(text, -1)
+	// Pass 1: locate each `maps REQ-..., REQ-..., ...` section. The captured
+	// group covers a contiguous REQ list (optionally separated by commas and
+	// surrounding whitespace). Sections do not require enclosing parentheses
+	// because the legacy single-pass regex treated them as optional.
+	sectionPattern := regexp.MustCompile(`(?i)maps\s+(REQ-[A-Z0-9-]+(?:\s*,\s*REQ-[A-Z0-9-]+)*)`)
+	// Pass 2: enumerate every REQ-XXX identifier inside a located section.
+	reqPattern := regexp.MustCompile(`REQ-([A-Z0-9-]+)`)
 
 	var reqIDs []string
 	seen := make(map[string]bool)
 
-	for _, match := range matches {
-		if len(match) > 1 {
+	sections := sectionPattern.FindAllStringSubmatch(text, -1)
+	for _, section := range sections {
+		if len(section) < 2 {
+			continue
+		}
+		reqMatches := reqPattern.FindAllStringSubmatch(section[1], -1)
+		for _, match := range reqMatches {
+			if len(match) <= 1 {
+				continue
+			}
 			reqID := match[1]
 			if !seen[reqID] {
 				seen[reqID] = true

--- a/internal/spec/ears_test.go
+++ b/internal/spec/ears_test.go
@@ -348,6 +348,36 @@ func TestExtractRequirementMappings(t *testing.T) {
 			text:     "Just regular text",
 			expected: nil,
 		},
+		{
+			// Regression: SPC-001 spec.md AC-SPC-001-01 / AC-SPC-001-14
+			// previously lost REQ-005/011 and REQ-003 due to single-pass regex
+			// stopping at the first REQ after `maps`.
+			name:     "comma multi-REQ — 2 ids",
+			text:     "Given hierarchical AC ... (maps REQ-SPC-001-001, REQ-SPC-001-005)",
+			expected: []string{"SPC-001-001", "SPC-001-005"},
+		},
+		{
+			name:     "comma multi-REQ — 3 ids",
+			text:     "AC body ... (maps REQ-SPC-001-001, REQ-SPC-001-005, REQ-SPC-001-011)",
+			expected: []string{"SPC-001-001", "SPC-001-005", "SPC-001-011"},
+		},
+		{
+			name:     "comma multi-REQ — extra spaces around commas",
+			text:     "Body (maps REQ-X-001 ,  REQ-X-002 ,REQ-X-003)",
+			expected: []string{"X-001", "X-002", "X-003"},
+		},
+		{
+			// Mixed form: one comma-separated section + one separate parenthesised section.
+			// Both halves must contribute their REQs (no dedup needed here).
+			name:     "comma multi-REQ — mixed with separate section",
+			text:     "Body (maps REQ-A-001, REQ-A-002) trailing (maps REQ-B-003)",
+			expected: []string{"A-001", "A-002", "B-003"},
+		},
+		{
+			name:     "uppercase MAPS keyword",
+			text:     "Body (MAPS REQ-UP-001, REQ-UP-002)",
+			expected: []string{"UP-001", "UP-002"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- `internal/spec/ears.go` `ExtractRequirementMappings`를 2-pass 구조로 재구성하여 `(maps REQ-A, REQ-B, REQ-C)` 콤마 다중 REQ 형식 인식. 단일 형식은 backward-compatible.
- 결과: `moai spec lint --strict` 3 ERROR → 0 ERROR (SPC-001의 REQ-003/005/011 false-positive 해소).
- `ears_test.go`에 5개 regression test 추가 (콤마 2/3개, 공백 변형, 혼합 형식, 대문자 MAPS).

## Root cause
기존 single-pass regex `\(?\s*(?:maps|MAPS)\s+REQ-([A-Z0-9-]+)\s*\)?`는 `(maps REQ-A, REQ-B)`에서 첫 번째 REQ만 매칭하고 콤마 뒤를 누락. 이 형식은 SPEC-V3R2-SPC-001 §6에서 canonical로 정의된 hierarchical AC 매핑 패턴인데, 정작 lint가 이를 인식 못해 SPC-001 자기 정의를 위반하는 모순. STATUS-LIFECYCLE / CATALOG / CON / WF-006 등 다수 SPEC에서 사용되고 있어 silent breakage가 누적되어 있었음 (CON-001의 `(maps REQ-X) (maps REQ-Y)` 중복 표기는 우회 흔적).

## Test plan
- [x] `go test -race ./internal/spec/...` → 9/9 PASS
- [x] `go vet ./internal/spec/...` → clean
- [x] `moai spec lint --strict` → SPC-001 3 ERROR 해소 (남은 11 WARNING은 별도 status drift 영역)
- [ ] CI: Lint / Test ubuntu-latest / macos-latest / windows-latest / Build 5 / CodeQL

## Labels
- `type:fix`
- `priority:P1`
- `area:cli` (internal/spec/ + lint command)

🗿 MoAI <email@mo.ai.kr>