### PR TITLE
plan(spec): SPEC-V3R4-LINT-SKIP-CLEANUP-001 — 55 SPECs lint.skip cleanup

### DIFF
--- a/.moai/specs/SPEC-V3R4-LINT-SKIP-CLEANUP-001/design.md
+++ b/.moai/specs/SPEC-V3R4-LINT-SKIP-CLEANUP-001/design.md
@@ -1,0 +1,484 @@
+# Design — SPEC-V3R4-LINT-SKIP-CLEANUP-001
+
+## HISTORY
+
+| Version | Date       | Author       | Description |
+|---------|------------|--------------|-------------|
+| 0.1.1   | 2026-05-16 | plan-audit remediation | plan-audit 0.904 PASS 후 P2 4건 remediation: (1) AC-LSKC-002 placeholder → plan.md §5.2 cross-ref, (2) HISTORY date harmonize 2026-05-16, (3) REQ-005↔AC-002 매핑 rationale 명시, (4) design.md §2.4 redundancy 정리. |
+| 0.1.0   | 2026-05-16 | manager-spec | 초기 design. 현재 상태(55 SPEC frontmatter)와 목표 상태 sample + bulk edit 알고리즘 pseudocode + 6가지 Edge Case + Rollback plan + Idempotency 검증 절차. Go yaml.v3 Node API 기반 권장. |
+
+---
+
+## 1. Goal
+
+`lint.skip: [StatusGitConsistency]` 회피책을 55개 SPEC frontmatter에서 안전하게 제거하기 위한 구체적인 implementation design.
+
+설계 목표:
+
+1. **Body 완전 보존**: 본문 byte-level 변경 0 (HISTORY 표 1줄 추가는 frontmatter-인접 메타데이터로 간주)
+2. **frontmatter key ordering 보존**: 자동 YAML re-serialize로 인한 키 순서 변경 없음
+3. **Idempotent**: 2회 실행 시 두 번째는 no-op
+4. **Reversible**: PR-level revert로 100% 복원 가능
+
+---
+
+## 2. Current State (cleanup 이전)
+
+### 2.1 frontmatter sample 1 — SPEC-AGENCY-ABSORB-001
+
+```yaml
+---
+id: SPEC-AGENCY-ABSORB-001
+version: 0.3.0
+status: completed
+created_at: 2026-04-20
+updated_at: 2026-04-24
+author: GOOS
+priority: High
+labels: [agency, migration, design, hybrid, absorption]
+issue_number: null
+merged_pr: 682
+merged_commit: 4271fd8a8
+deprecation_policy_amended: true
+title: "Agency → MoAI-ADK 흡수 및 Claude Design 통합"
+created: 2026-04-21
+updated: 2026-05-13
+phase: "v2.x - Legacy"
+module: "agency"
+lifecycle: completed
+tags: "legacy"
+lint:
+  skip:
+    - StatusGitConsistency
+---
+```
+
+### 2.2 frontmatter sample 2 — SPEC-AGENT-002
+
+```yaml
+---
+id: SPEC-AGENT-002
+version: 1.0.0
+status: completed
+created: 2026-04-09
+updated: 2026-04-09
+author: GOOS
+priority: high
+issue_number: 0
+title: "Agent Definition Optimization - Token Efficiency with Workflow Preservation"
+phase: "v2.x - Legacy"
+module: "agents"
+lifecycle: completed
+tags: "legacy"
+lint:
+  skip:
+    - StatusGitConsistency
+---
+```
+
+### 2.3 frontmatter sample 3 — SPEC-CORE-001 (다른 key ordering)
+
+```yaml
+---
+id: SPEC-CORE-001
+title: Foundation Methodologies
+created: 2026-02-03
+updated: 2026-05-13
+status: completed
+priority: Medium
+phase: "Phase 5 - Knowledge (Phase 1 과 병렬 구현 가능)"
+module: "internal/foundation/"
+estimated_loc: "~1000"
+dependencies: []
+assigned: expert-backend
+lifecycle: spec-anchored
+tags: "foundation, ears, languages, trust5, domain-patterns"
+version: "1.0.0"
+author: GOOS
+lint:
+  skip:
+    - StatusGitConsistency
+---
+```
+
+### 2.4 공통 패턴
+
+- 모든 55개 SPEC frontmatter 가장 아래에 `lint:` 블록이 위치 (`---` closing 직전 3줄)
+- `lint:` 다음 줄은 `  skip:` (들여쓰기 2 spaces)
+- `  skip:` 다음 줄은 `    - StatusGitConsistency` (들여쓰기 4 spaces)
+- 모든 케이스가 단일 엔트리 — 다중 엔트리 케이스 처리 정책은 §6.2 참조
+
+### 2.5 frontmatter key ordering 다양성
+
+55개 SPEC을 sample inspect한 결과:
+- `version` 필드 위치: 상단 (id 직후) vs 하단 (tags 직전) 모두 존재
+- `updated` 필드 형식: `updated: 2026-04-09` (unquoted ISO date) — 통일
+- `updated_at` (구 표준) + `updated` (현 표준) 혼재 SPEC 존재 (SPEC-AGENCY-ABSORB-001 등) — 둘 다 갱신 필요?
+- `title` 따옴표 스타일: `"..."` vs unquoted 혼재
+
+---
+
+## 3. Target State (cleanup 이후)
+
+### 3.1 frontmatter sample 1 — SPEC-AGENCY-ABSORB-001 (after)
+
+```yaml
+---
+id: SPEC-AGENCY-ABSORB-001
+version: 0.3.1
+status: completed
+created_at: 2026-04-20
+updated_at: 2026-04-24
+author: GOOS
+priority: High
+labels: [agency, migration, design, hybrid, absorption]
+issue_number: null
+merged_pr: 682
+merged_commit: 4271fd8a8
+deprecation_policy_amended: true
+title: "Agency → MoAI-ADK 흡수 및 Claude Design 통합"
+created: 2026-04-21
+updated: 2026-05-15
+phase: "v2.x - Legacy"
+module: "agency"
+lifecycle: completed
+tags: "legacy"
+---
+```
+
+**변경 사항:**
+- `lint:` 블록 (3줄) 제거
+- `version`: `0.3.0` → `0.3.1` (patch +1)
+- `updated`: `2026-05-13` → `2026-05-15`
+- `updated_at`: 유지 (별도 필드, 다른 의미) — 본 SPEC scope 외
+- HISTORY 표에 row 1줄 추가 (body 영역)
+
+### 3.2 HISTORY 표 row 추가 sample
+
+본문 `## HISTORY` 표 끝에 다음 row 1줄 추가:
+
+```markdown
+| 0.3.1   | 2026-05-15 | manager-develop (run-phase) | lint.skip StatusGitConsistency 회피책 제거 — SPEC-V3R4-LINT-STATUS-CHORE-SKIP-001 walker filter 머지로 불필요해짐. |
+```
+
+(version 컬럼은 각 SPEC의 새 버전, 다른 컬럼은 모두 동일)
+
+---
+
+## 4. Bulk Edit Algorithm
+
+### 4.1 옵션 C (Go script) 권장 알고리즘
+
+```
+ALGORITHM: cleanup_lint_skip(spec_path)
+  INPUT: path to spec.md
+  OUTPUT: modified spec.md, idempotent
+
+1. data := os.ReadFile(spec_path)
+2. fm_end := find_frontmatter_end(data)
+   // first "---\n" at line 0, second "---\n" at fm_end
+3. fm_text := data[4 : fm_end]  // skip leading "---\n"
+4. body_text := data[fm_end + 4 :]  // skip "---\n"
+5. 
+6. // YAML parse with node-level fidelity
+7. var node yaml.Node
+8. yaml.Unmarshal(fm_text, &node)
+9. 
+10. mapping := node.Content[0]  // top-level mapping node
+11. 
+12. // Check idempotency: if no `lint` key, skip
+13. lint_idx := find_key(mapping, "lint")
+14. if lint_idx == -1:
+15.   return  // already cleaned
+16. 
+17. // Remove lint key + value (2 entries in flat list)
+18. remove_keys(mapping, "lint")
+19. 
+20. // Patch bump version
+21. version_idx := find_key(mapping, "version")
+22. current_version := mapping.Content[version_idx + 1].Value  // string
+23. new_version := patch_bump(current_version)  // "0.3.0" -> "0.3.1"
+24. mapping.Content[version_idx + 1].Value = new_version
+25. 
+26. // Update `updated` field (NOT `updated_at`)
+27. updated_idx := find_key(mapping, "updated")
+28. if updated_idx != -1:
+29.   mapping.Content[updated_idx + 1].Value = "2026-05-15"
+30. 
+31. // Serialize back preserving key order
+32. new_fm := yaml.Marshal(&node)
+33. 
+34. // Add HISTORY row to body
+35. new_body := insert_history_row(body_text, new_version, "2026-05-15")
+36. 
+37. // Write
+38. result := "---\n" + new_fm + "---\n" + new_body
+39. os.WriteFile(spec_path, result)
+```
+
+### 4.2 patch_bump 함수
+
+```go
+func patch_bump(version string) string {
+    // semver: "X.Y.Z" or "X.Y" (rare)
+    // strip quotes if present
+    v := strings.Trim(version, `"`)
+    parts := strings.Split(v, ".")
+    if len(parts) < 3 {
+        parts = append(parts, "0")  // "1.0" -> "1.0.0"
+    }
+    patch, _ := strconv.Atoi(parts[2])
+    parts[2] = strconv.Itoa(patch + 1)
+    return strings.Join(parts, ".")
+}
+```
+
+### 4.3 insert_history_row 함수
+
+```go
+func insert_history_row(body, new_version, new_date string) string {
+    // Find "## HISTORY" heading
+    // Find first table row "| X.Y.Z | ... |" in HISTORY section
+    // Determine table ordering: top-newest vs bottom-newest
+    //   - Sample SPECs vary; check first vs last row date
+    // Insert new row at appropriate position (top OR bottom)
+    
+    new_row := fmt.Sprintf(
+        "| %-7s | %-10s | manager-develop (run-phase) | lint.skip StatusGitConsistency 회피책 제거 — SPEC-V3R4-LINT-STATUS-CHORE-SKIP-001 walker filter 머지로 불필요해짐. |",
+        new_version, new_date,
+    )
+    
+    return body_with_row_inserted
+}
+```
+
+### 4.4 옵션 A polyfill (Edit tool)
+
+manager-develop이 매 SPEC마다 `Read` → 4개 `Edit` op 수행. idempotency는 매 SPEC마다 baseline 비교로 수동 검증.
+
+manager-develop 의사코드:
+
+```
+for spec in 55_affected_specs:
+    content = Read(spec)
+    
+    # idempotency check
+    if "lint:\n  skip:\n    - StatusGitConsistency" not in content:
+        log("already cleaned, skip: " + spec)
+        continue
+    
+    # 1. Remove lint block
+    Edit(spec, 
+         old_string="lint:\n  skip:\n    - StatusGitConsistency\n",
+         new_string="")
+    
+    # 2. Patch bump version (need to read current version first)
+    current_version = extract_version(content)
+    new_version = patch_bump(current_version)
+    Edit(spec,
+         old_string=f"version: {current_version}",
+         new_string=f"version: {new_version}")
+    
+    # 3. Update updated field
+    current_updated = extract_updated(content)
+    Edit(spec,
+         old_string=f"updated: {current_updated}",
+         new_string="updated: 2026-05-15")
+    
+    # 4. Insert HISTORY row (manual placement)
+    history_marker = "## HISTORY"
+    new_row = f"| {new_version} | 2026-05-15 | manager-develop (run-phase) | ... |"
+    # Edit to insert after table header or at appropriate row position
+```
+
+옵션 A는 simpler 하지만 sequential Edit op 수가 많고 HISTORY row insertion 위치가 SPEC마다 달라질 수 있음.
+
+---
+
+## 5. Rollback Plan
+
+### 5.1 자동 rollback
+
+PR `feat/SPEC-V3R4-LINT-SKIP-CLEANUP-001` 머지 후 회귀 발견 시:
+
+1. **PR revert**: `gh pr revert <merged-PR-N>` — main에 revert commit 생성
+2. **lint --strict 회귀 검증**: revert 후 walker filter는 여전히 적용되어 있으므로 `StatusGitConsistency` WARN 0건 유지될 것 (lint.skip 부재 + walker filter 가 sweep commit skip)
+3. **별도 SPEC 발급**: 회귀 원인 분석 후 SPEC-V3R4-LINT-SKIP-CLEANUP-002 로 재시도
+
+### 5.2 수동 rollback (PR 머지 전)
+
+cleanup commit 후 PR 만들기 전 발견 시:
+- `git reset --hard origin/main` (단일 commit이므로 안전)
+
+### 5.3 회귀 시나리오 예상
+
+| 시나리오 | 발생 가능성 | rollback 필요? |
+|---------|-----------|--------------|
+| frontmatter parse 오류 (예: title 따옴표 깨짐) | Low (옵션 C 사용 시 yaml.v3 보장) | YES |
+| HISTORY 표 형식 깨짐 (예: 컬럼 수 mismatch) | Medium (옵션 A) | YES |
+| 의도하지 않은 SPEC 수정 (55개 외) | Low (M3 verification 통과해야 PR) | YES |
+| lint --strict 회귀 (walker filter 동작 안 함) | Very Low (PR #933 머지 확인됨) | NO — predecessor revert 필요 |
+
+---
+
+## 6. Edge Cases
+
+### 6.1 (a) `lint.skip`이 단일 `StatusGitConsistency`만 가진 SPEC (current ALL 55)
+
+**처리**: `lint:` 블록 전체 (3줄) 제거. 빈 `lint:` 블록 또는 `lint.skip: []` 유지 금지.
+
+**근거**: 빈 frontmatter 키는 noise. YAML 표준에서 키 부재가 명시적 빈 값보다 cleaner.
+
+### 6.2 (b) `lint.skip`이 다른 rule + `StatusGitConsistency`를 같이 가진 SPEC (현재 0건, forward-compat)
+
+**처리**: `StatusGitConsistency` 엔트리만 element-level 제거. 나머지 rules + `lint:` 블록 유지.
+
+```yaml
+# Before:
+lint:
+  skip:
+    - OrphanBCID
+    - StatusGitConsistency
+    - MissingExclusions
+
+# After:
+lint:
+  skip:
+    - OrphanBCID
+    - MissingExclusions
+```
+
+**구현**: 옵션 C 알고리즘 16-19 라인을 `remove_element(skip_array, "StatusGitConsistency")` 로 변경.
+
+### 6.3 (c) 본 SPEC 자체 cleanup (meta self-reference)
+
+**판정**: 본 SPEC (`SPEC-V3R4-LINT-SKIP-CLEANUP-001`)은 cleanup 대상이 아니다 — frontmatter에 `lint:` 블록을 추가하지 않으므로 (REQ-LSKC 가 cleanup의 트리거). M1 baseline scan에서 55 list에 포함되지 않음.
+
+### 6.4 (d) ARCHIVED SPEC (SPEC-I18N-001-ARCHIVED)
+
+**판정**: 정리 대상에 포함. archived 상태와 무관하게 frontmatter consistency 유지.
+
+**근거**: archive 정책상 frontmatter `status: superseded` 또는 `archived`로 표시되지만, `lint.skip` 회피책 metadata는 archive 보존 가치 없음.
+
+### 6.5 (e) `updated_at` vs `updated` 혼재 SPEC
+
+샘플 검증 결과 일부 SPEC은 둘 다 가짐 (SPEC-AGENCY-ABSORB-001):
+- `updated_at: 2026-04-24` (구 표준, frontmatter 상단)
+- `updated: 2026-05-13` (현 표준)
+
+**판정**: `updated` 필드만 `2026-05-15`로 갱신. `updated_at`은 건드리지 않음 — scope creep 방지.
+
+**근거**: 본 cleanup은 frontmatter 다른 필드 수정 0건 원칙 (REQ-LSKC-007). `updated_at`/`updated` 통합은 별도 SPEC.
+
+### 6.6 (f) 다양한 version 형식
+
+- `version: 0.3.0` (unquoted)
+- `version: "1.0.0"` (quoted string)
+- `version: 0.3` (rare — patch 부재)
+
+**처리**:
+- unquoted/quoted 스타일 보존 (옵션 C yaml.Node)
+- patch 부재 시: `0.3` → `0.3.1` (patch 추가)
+
+### 6.7 (g) HISTORY 표 ordering 다양성
+
+샘플 검증:
+- top-newest (SPEC-V3R4-LINT-STATUS-CHORE-SKIP-001): 새 row 가 위
+- bottom-newest (SPEC-AGENT-002): 새 row 가 아래
+- single-row (SPEC-CORE-001): 최초 row만 존재
+
+**처리**: M1 baseline에서 SPEC별 ordering 감지 → 적절한 위치 삽입. heuristic:
+- 표 헤더 바로 아래 first row 의 version vs last row 의 version 비교
+- newer version 이 위면 top-newest → 새 row 를 헤더 바로 아래 삽입
+- older version 이 위면 bottom-newest → 새 row 를 표 끝에 append
+
+---
+
+## 7. Idempotency Verification
+
+### 7.1 옵션 C script idempotency
+
+```bash
+go run .moai/scripts/lint-skip-cleanup.go
+git diff --stat .moai/specs/ > /tmp/run1.txt
+
+go run .moai/scripts/lint-skip-cleanup.go
+git diff --stat .moai/specs/ > /tmp/run2.txt
+
+diff /tmp/run1.txt /tmp/run2.txt && echo "PASS: idempotent" || echo "FAIL: not idempotent"
+```
+
+**기대 결과**: `/tmp/run1.txt` 와 `/tmp/run2.txt` 동일 (두 번째 실행은 no-op).
+
+### 7.2 옵션 A (Edit tool) idempotency
+
+매 SPEC iteration 시작 시 검사:
+
+```python
+content = Read(spec)
+if "lint:\n  skip:\n    - StatusGitConsistency" not in content:
+    log(f"already cleaned: {spec}")
+    continue  # idempotent skip
+```
+
+이렇게 하면 manager-develop이 partial run 도중 중단 후 재시작해도 안전.
+
+---
+
+## 8. Architecture Decision Records (ADR)
+
+### ADR-001: Bulk script vs Edit tool
+
+**Decision**: 옵션 C (Go script) 권장. run-phase 최종 결정.
+
+**Rationale**:
+- 55 SPEC iteration → Edit tool 옵션 A는 270+ tool calls 발생 → token budget pressure
+- 옵션 C는 단일 script 실행으로 처리 + idempotent 자연스러움
+- script 재사용성: 향후 유사 metadata cleanup 패턴에 응용 (예: 다른 lint rule deprecation)
+
+**Trade-off**: Go script 작성 LOC 100~150 추가. 단, 검토 가능한 코드이며 PR에 포함하지 않거나 `.moai/scripts/` 보존 결정 (OQ2).
+
+### ADR-002: HISTORY row 추가 위치
+
+**Decision**: SPEC별 ordering 감지 (top-newest vs bottom-newest) 후 맞춤 삽입.
+
+**Rationale**:
+- 일관성 vs 보존성 trade-off
+- 모든 SPEC을 일괄 top-add 또는 bottom-add 하면 일부 SPEC의 기존 ordering 깨짐
+- 기존 ordering 보존이 git history 가독성 우선
+
+### ADR-003: `updated_at` 보존, `updated`만 갱신
+
+**Decision**: `updated_at` 은 건드리지 않음.
+
+**Rationale**:
+- `updated_at` 은 구 표준 (deprecation 진행 중), 별도 마이그레이션 SPEC 영역
+- 본 SPEC은 lint.skip cleanup만 처리 — scope creep 방지
+
+### ADR-004: SPEC 본문 sha256 비교를 검증 절차에 포함
+
+**Decision**: M3 verification 단계에서 본문 sha256 비교 (HISTORY 표 영역 제외).
+
+**Rationale**:
+- "본문 0줄 수정" 약속 (AC-LSKC-003) 의 자동 검증 방법
+- manual diff 검토는 55 SPEC × 평균 ~300줄 = 16,500줄 → 무리
+- HISTORY 표 영역만 별도 추적 (table row 추가는 frontmatter-인접 메타 변경으로 간주)
+
+---
+
+## 9. Non-Goals
+
+- Lint engine 자체의 동작 변경 (walker filter는 PR #933 완료, 본 SPEC 무관)
+- `lint.skip` 메커니즘 자체의 폐기 (다른 lint rule skip 정당한 사례 존재 가능)
+- 다른 lint rule 의 lint.skip 엔트리 정리 (예: OrphanBCID, MissingExclusions) — 별도 SPEC
+- frontmatter key ordering 표준화 — 별도 SPEC
+- `updated_at` ↔ `updated` 필드 통합 — 별도 SPEC
+- `version` 필드 quoted vs unquoted 스타일 통일 — 별도 SPEC
+
+---
+
+## 10. Future Work
+
+- **SPEC-V3R4-LINT-SKIP-CLEANUP-002** (가설): 다른 lint rule 의 lint.skip 엔트리 정리 (필요 시)
+- **SPEC-V3R4-FRONTMATTER-STANDARDIZATION-001** (가설): `updated_at` / `updated` 통합 + key ordering 표준화 + version quoted 통일
+- **SPEC-V3R4-LINT-SKIP-DEPRECATION-001** (가설): `lint.skip` 메커니즘 자체를 deprecate (walker filter 등 근본 해결 후 영구 metadata noise 제거 정책)

--- a/.moai/specs/SPEC-V3R4-LINT-SKIP-CLEANUP-001/plan.md
+++ b/.moai/specs/SPEC-V3R4-LINT-SKIP-CLEANUP-001/plan.md
@@ -1,0 +1,340 @@
+# Plan — SPEC-V3R4-LINT-SKIP-CLEANUP-001
+
+## HISTORY
+
+| Version | Date       | Author       | Description |
+|---------|------------|--------------|-------------|
+| 0.1.1   | 2026-05-16 | plan-audit remediation | plan-audit 0.904 PASS 후 P2 4건 remediation: (1) AC-LSKC-002 placeholder → plan.md §5.2 cross-ref, (2) HISTORY date harmonize 2026-05-16, (3) REQ-005↔AC-002 매핑 rationale 명시, (4) design.md §2.4 redundancy 정리. |
+| 0.1.0   | 2026-05-16 | manager-spec | 초기 plan. 55개 SPEC frontmatter의 `lint.skip: [StatusGitConsistency]` 일괄 제거 전략 + 4개 milestone (BASELINE / BULK EDIT / VERIFICATION / RUN-PR). bulk edit 도구 선택지 3가지 비교 + idempotent 검증 절차. plan-in-main 표준 적용 — worktree 없음. |
+
+---
+
+## 1. Implementation Strategy
+
+### 1.1 핵심 접근
+
+본 cleanup은 **frontmatter-only bulk edit** 이다. 55개 SPEC의 `spec.md` 파일에서 YAML frontmatter 영역만 정확히 수정하고 본문은 byte-level로 보존해야 한다.
+
+전략 단계:
+
+1. **Baseline capture**: 55개 SPEC의 현재 상태 (body sha256, lint --strict 출력) 를 capture
+2. **Sequential edit**: 55개 SPEC에 대해 sequential하게 다음 4가지를 수행
+   - frontmatter `lint:` 블록 전체 제거 (현재 모든 SPEC이 단일 엔트리 케이스)
+   - frontmatter `version` patch bump
+   - frontmatter `updated: 2026-05-15`
+   - HISTORY 표에 새 row 1줄 추가
+3. **Post-edit verification**: body sha256 비교 + `moai spec lint --strict` WARN 0 검증
+4. **PR commit**: 단일 commit (55개 SPEC modified) + PR push
+
+### 1.2 도구 선택지 (run-phase 결정)
+
+| 옵션 | 장점 | 단점 | 권장 |
+|------|------|------|------|
+| (A) 순수 Edit tool calls (55 × 4 = ~220 edit ops) | 가장 단순, line-level 정밀 | edit op 수 많음, Edit tool overhead | △ |
+| (B) `sed`/`awk` shell script | 빠름, idempotent 보장 어려움 | YAML 들여쓰기 깨질 위험, line ending OS 의존 | △ |
+| (C) Go 헬퍼 스크립트 (in `.moai/scripts/lint-skip-cleanup.go`, `go run`) | YAML 라이브러리로 안전, idempotent 자연스럽게 보장, 재사용성 | LOC 100~150 새 코드, 검토 필요 | **○ 권장** |
+
+권장: **옵션 C (Go script)** — `gopkg.in/yaml.v3`로 YAML 부분만 파싱/수정하고 body는 byte-for-byte 보존. script 자체는 PR에 포함하지 않고 cleanup commit only push 후 폐기, 또는 `.moai/scripts/lint-skip-cleanup.go`에 보존하여 향후 유사 cleanup에 재사용 (OQ2 참조).
+
+대안 (옵션 A polyfill): Go script 작성 부담을 피하고 싶으면 Edit tool로 55개 SPEC 순회 — manager-develop이 매 SPEC마다 `Read` → 4개 `Edit` op 수행 (개당 ~5 op × 55 = 275 op). 시간은 더 걸리지만 review 가시성 높음.
+
+### 1.3 Sequential vs Parallel
+
+[HARD] **Sequential only**. 이유:
+
+- `moai spec lint --strict` baseline 캡처 시 git working tree 상태 의존
+- 55개 SPEC을 병렬 수정하면 lint 검증을 partial state에서 수행하게 됨
+- Single PR이 목표이므로 commit ordering 일관성 필요
+
+---
+
+## 2. Milestones
+
+priority-based ordering (시간 추정 금지 per `agent-common-protocol.md` §Time Estimation):
+
+### M1 — BASELINE
+
+**Priority: High** (모든 후속 단계의 기준선)
+
+- 55개 영향 SPEC list 확정 (research.md §2의 list 검증 — frontmatter strict scan)
+- 각 SPEC body sha256 capture → `.moai/state/lint-skip-cleanup-baseline.json` 산출 (스크립트 사용 시)
+- 현재 `moai spec lint --strict` 출력에서 `StatusGitConsistency` count 캡처 (예상: PR #933 머지 후이므로 이미 0건 — walker filter 작동 확인용)
+- 각 SPEC 현재 `version` 필드 캡처
+
+**완료 조건:**
+- baseline.json 산출
+- lint --strict StatusGitConsistency 카운트 기록
+
+### M2 — BULK EDIT
+
+**Priority: High** (메인 작업)
+
+55개 SPEC 각각에 대해 sequential 수행:
+
+1. frontmatter `lint:` 블록 전체 제거 (`lint:`, `  skip:`, `    - StatusGitConsistency` 3줄 — 모든 케이스가 단일 엔트리이므로 블록 전체 제거)
+2. frontmatter `version`: 현재값 patch +1 (예: `"0.3.0"` → `"0.3.1"`)
+3. frontmatter `updated`: 현재값 → `2026-05-15`
+4. HISTORY 표에 새 row 1개 prepend (또는 append — baseline ordering 보존)
+   - 표준 row 형식: `| <new-version> | 2026-05-15 | manager-develop (run-phase) | lint.skip StatusGitConsistency 회피책 제거 — SPEC-V3R4-LINT-STATUS-CHORE-SKIP-001 walker filter 머지로 불필요해짐. |`
+
+**완료 조건:**
+- `git status` 결과 55개 SPEC `spec.md` modified 표시
+- 각 SPEC `lint:` 블록 부재 확인 (`grep -L "^lint:" $files` 결과 모든 55 SPEC 포함)
+
+### M3 — VERIFICATION
+
+**Priority: High** (회귀 방지)
+
+1. Body sha256 비교 — 55개 SPEC 모두 baseline과 일치 (HISTORY row 1줄 추가는 frontmatter 인접 영역으로 간주, 본문 sha256 산정에서 제외)
+2. `moai spec lint --strict` 실행 — `StatusGitConsistency` WARN 0 확인
+3. `git diff .moai/specs/` 결과 55개 SPEC 외 파일 0개
+4. 각 SPEC frontmatter parse 검증 (`moai spec list` 정상 동작 — frontmatter 깨짐 회귀 방지)
+
+**완료 조건:**
+- lint --strict 통과
+- diff stats: 55 files modified, 본문 변경 라인 0 (HISTORY 1줄 + frontmatter 변경만)
+
+### M4 — RUN-PR
+
+**Priority: Medium**
+
+1. commit message: `chore(spec): SPEC-V3R4-LINT-SKIP-CLEANUP-001 — 55 SPECs lint.skip cleanup`
+2. push to feature branch `feat/SPEC-V3R4-LINT-SKIP-CLEANUP-001` (Enhanced GitHub Flow §18.2)
+3. PR 생성: title `feat(spec): SPEC-V3R4-LINT-SKIP-CLEANUP-001 — 55 SPECs lint.skip workaround removed`
+4. PR body: SPEC link + AC summary + lint --strict before/after 캡처
+5. Wait for CI (Lint + Test + Build all green)
+6. admin squash merge 후 worktree cleanup 불필요 (worktree 미사용)
+
+**완료 조건:**
+- PR MERGED to main
+- main HEAD `moai spec lint --strict` WARN 0 (StatusGitConsistency 카테고리)
+
+---
+
+## 3. Files to Modify
+
+### 3.1 변경 대상 (frontmatter only)
+
+55개 SPEC `spec.md` 파일. 각 파일 평균 변경 ~5-8 lines (`lint:` 블록 3줄 제거 + version 1줄 + updated 1줄 + HISTORY 1줄 추가).
+
+총 변경 추정:
+- 제거: 3 lines × 55 = 165 lines
+- 추가: 1 line × 55 = 55 lines (HISTORY row)
+- 수정: 2 lines × 55 = 110 lines (version, updated)
+- Net diff: ~330 lines across 55 files
+
+(research.md §2의 55-SPEC list 참조)
+
+### 3.2 변경 없음 보장 (out-of-scope safety net)
+
+- `internal/spec/*.go` — 0 lines
+- `.github/workflows/*.yml` — 0 lines
+- `docs-site/**` — 0 files
+- `README.md` / `README.ko.md` / `CHANGELOG.md` — 0 lines (CHANGELOG는 sync-phase 범위)
+- 55개 외 `.moai/specs/*/spec.md` — 0 lines
+
+### 3.3 (선택) bulk edit script
+
+`.moai/scripts/lint-skip-cleanup.go` (또는 `.sh`) — OQ2 결정에 따라 PR에 포함 / 폐기 결정. PR 포함 시 별도 1 file added.
+
+---
+
+## 4. Technical Approach
+
+### 4.1 frontmatter parse 전략 (옵션 C 권장)
+
+```go
+// pseudocode — run-phase가 구체화
+package main
+
+import (
+    "gopkg.in/yaml.v3"
+    "os"
+    "strings"
+)
+
+func cleanup(specPath string) error {
+    data, _ := os.ReadFile(specPath)
+    parts := strings.SplitN(string(data), "\n---\n", 2)
+    if len(parts) < 2 {
+        return fmt.Errorf("no frontmatter: %s", specPath)
+    }
+    fm := parts[0]  // "---\n<yaml>"
+    body := "---\n" + parts[1]  // body 보존
+    
+    // YAML parse
+    var node yaml.Node
+    yaml.Unmarshal([]byte(strings.TrimPrefix(fm, "---\n")), &node)
+    
+    // lint.skip에서 StatusGitConsistency 제거
+    // lint.skip이 빈 배열이 되면 lint: 블록 전체 제거
+    // version patch bump
+    // updated = "2026-05-15"
+    
+    // serialize 시 key ordering 보존 (yaml.v3 Node API)
+    // HISTORY 표는 frontmatter 외부이므로 별도 markdown 처리
+    
+    return os.WriteFile(specPath, ...)
+}
+```
+
+핵심 challenges:
+1. **Key ordering 보존**: `gopkg.in/yaml.v3`의 `yaml.Node` API 사용 필수 (`Unmarshal → map → Marshal` 사용 시 key ordering 손실)
+2. **Multi-line string preservation**: title, related_theme 등 따옴표 / unquoted 스타일 보존
+3. **HISTORY 표 편집**: markdown table 행 추가 — frontmatter 외부 처리
+
+### 4.2 frontmatter parse 전략 (옵션 A polyfill — Edit tool)
+
+옵션 C 부담이 크면 Edit tool 직접 사용:
+
+```
+For each SPEC:
+  1. Read spec.md (frontmatter 영역)
+  2. Edit: 'lint:\n  skip:\n    - StatusGitConsistency\n' → '' (3-line block 제거)
+  3. Edit: 'version: <old>' → 'version: <new>' (patch bump)
+  4. Edit: 'updated: <old>' → 'updated: 2026-05-15'
+  5. Edit: HISTORY 표 첫 row 위 또는 마지막 row 아래에 새 row 1줄 insert
+```
+
+이 경우 idempotency는 manager-develop이 매번 baseline 비교로 수동 보장.
+
+### 4.3 idempotency 검증
+
+bulk script 또는 manual edit 모두:
+- 1차 실행 후 `git diff` 캡처 → 220+ lines
+- 2차 실행 (script re-run 또는 manual re-walk) 후 `git diff` 캡처 → 0 lines
+- 2차 실행이 no-op임을 확인
+
+---
+
+## 5. Testing Strategy
+
+본 SPEC은 frontmatter metadata cleanup이므로 **Go unit test 작성 불요**. 검증은 다음 외부 도구로 수행:
+
+### 5.1 Pre-edit baseline test
+
+```bash
+# Body content sha256 capture
+for spec in $(cat affected-list.txt); do
+  awk '/^---$/{f++} f>=2' "$spec" | sha256sum > baselines/"$(basename $(dirname $spec)).sha256"
+done
+
+# lint --strict StatusGitConsistency count
+moai spec lint --strict 2>&1 | grep -c "StatusGitConsistency" > baseline-warns.txt
+```
+
+### 5.2 Post-edit verification
+
+```bash
+# Body sha256 unchanged
+for spec in $(cat affected-list.txt); do
+  current=$(awk '/^---$/{f++} f>=2' "$spec" | sha256sum)
+  baseline=$(cat baselines/"$(basename $(dirname $spec)).sha256")
+  [ "$current" = "$baseline" ] || echo "DRIFT: $spec"
+done
+
+# lint --strict — population-scoped (55 cleanup-target SPECs)
+# cleanup 외 SPECs의 기존 drift WARN (2026-05-15 실측 8건)은 본 SPEC scope 외
+moai spec lint --strict 2>&1 | grep "StatusGitConsistency" | \
+  grep -E "$(cat affected-list.txt | tr '\n' '|' | sed 's/|$//')" | \
+  wc -l > /tmp/post-warns.txt
+diff /tmp/post-warns.txt baseline-warns.txt && echo "PASS: delta=0" || echo "FAIL"
+
+# Affected files only
+git diff --name-only .moai/specs/ | wc -l  # expect 55 (or 55 + 1 if script committed)
+```
+
+### 5.3 Idempotency test (script-only)
+
+```bash
+go run .moai/scripts/lint-skip-cleanup.go  # first run
+git diff --stat  # capture
+go run .moai/scripts/lint-skip-cleanup.go  # second run
+git diff --stat  # expect identical to first run (no additional changes)
+```
+
+### 5.4 Regression guard
+
+`SPEC-V3R4-LINT-STATUS-CHORE-SKIP-001`의 run-phase에서 추가된 unit tests (`internal/spec/drift_test.go` 의 `TestGetGitImpliedStatus_SkipSweepCommit*`) 는 본 SPEC과 무관 — walker filter 자체가 변경 대상이 아니므로 별도 regression test 추가 없음.
+
+---
+
+## 6. Definition of Done
+
+- [ ] **AC-LSKC-001 ~ 005 모두 GREEN** (M3 VERIFICATION 통과)
+- [ ] **PR MERGED** to main (Enhanced GitHub Flow §18.3 squash merge)
+- [ ] **`moai spec lint --strict`** WARN 0 (StatusGitConsistency 카테고리, main HEAD 기준)
+- [ ] **HISTORY new row 1줄** 각 55 SPEC에 추가됨
+- [ ] **version patch bump** 각 55 SPEC에 적용됨
+- [ ] **updated: 2026-05-15** 각 55 SPEC에 적용됨
+- [ ] **CHANGELOG `[Unreleased]` row 1줄** 추가 (sync-phase 범위 — manager-docs가 처리)
+- [ ] **plan-auditor PASS** (≥ 0.85)
+- [ ] **MX tags**: `@MX:NOTE` (이력 + 회피책 제거 의도) — 코드 수정 없으므로 `@MX:ANCHOR` / `@MX:WARN` 불필요
+- [ ] **frontmatter status 전이**: `draft → in-progress → implemented → completed` (각 phase entry 시점에 manager-* agent가 갱신)
+- [ ] **(Optional) bulk edit script 보존 결정**: OQ2 결정 따라 `.moai/scripts/lint-skip-cleanup.{go,sh}` 보존 또는 폐기
+
+---
+
+## 7. Open Questions
+
+### OQ1 — lint.skip의 다른 rule entries 보존
+
+**Question**: 본 SPEC scoping 시점에 검증한 결과 55 SPEC 모두 `lint.skip`이 `StatusGitConsistency` 단일 엔트리 케이스다. 그러나 향후 다른 lint rule entries 추가될 경우 정책이 필요한가?
+
+**Default Decision**: REQ-LSKC-002, REQ-LSKC-006 으로 정책 명시 — 다른 entries 보존, `StatusGitConsistency`만 element-level 제거. 현재 검증 대상 SPEC 없음 (forward-compat).
+
+**Action Required**: 없음 — design.md §6 Edge Cases (a), (b) 에서 처리.
+
+### OQ2 — bulk edit 도구 선택 (Go script vs Edit tool vs shell)
+
+**Question**: §1.2의 3개 옵션 중 어느 것을 run-phase가 채택할 것인가?
+
+**Default Decision**: 옵션 C (Go script) 권장. run-phase가 다음 기준으로 최종 결정:
+- 옵션 C: 재사용 가능성 (`.moai/scripts/` 보존 가치) + idempotency 자연스러움
+- 옵션 A: 시간 절약 (스크립트 작성 LOC 0) + Edit op 가시성
+- 옵션 B (shell): 거부 — YAML 들여쓰기 안정성 부족
+
+**Action Required**: run-phase 시작 시 manager-develop이 결정. 결정 결과 design.md §4에 기록.
+
+### OQ3 — version bump 정책 (patch vs minor)
+
+**Question**: `version` 필드를 patch (Z+1) vs minor (Y+1) 중 어느 단위로 bump?
+
+**Default Decision**: patch (Z+1). 근거:
+- metadata-only 변경 (semver "non-functional")
+- 본문 0줄 수정 — minor bump 부적절
+- 영향 범위 좁음 — lint engine 자체의 동작은 변경 없음
+
+**Action Required**: 없음 — REQ-LSKC-003 + AC-LSKC-005 + 정책 §1.2 (C5) 으로 확정.
+
+---
+
+## 8. Risk Assessment
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| R1: 55 SPEC 중 일부에 frontmatter parser drift (예: title escape) → bulk script crash | Low | 옵션 C 채택 시 `yaml.Node` API 로 안전. crash 시 sequential mode로 fallback. |
+| R2: HISTORY 표 형식 SPEC마다 미세 차이 (열 개수, 들여쓰기 4가지 변형) | Low | sample 5-10개 SPEC pre-check → manager-develop이 분기 처리 |
+| R3: idempotency 깨짐 (script 2회 실행 시 추가 HISTORY row 발생) | Medium | OQ2 옵션 C 선택 시 "현재 HISTORY top row가 본 cleanup row인지" 사전 검사 후 skip |
+| R4: lint --strict 검증이 walker filter 미적용 binary로 수행됨 (`moai` PATH 우선순위 문제) | Medium | M1에서 `which moai` 캡처 + `moai version` 확인. walker filter는 main `9e394e51b` 이후 빌드여야 함 |
+| R5: PR CI 실패 (Test, Build, Lint 중 1+) | Low | 본 cleanup은 Go 코드 무변경이므로 Lint/Test/Build 전부 unaffected. spec-lint CI job만 검증 대상. |
+| R6: 55개 SPEC 외 의도하지 않은 파일 수정 | Low | M3 verification 단계의 `git diff --name-only` 검증 + plan-auditor도 cross-check |
+
+---
+
+## 9. Dependencies
+
+- **Predecessor (HARD)**: `SPEC-V3R4-LINT-STATUS-CHORE-SKIP-001` (PR #933 머지 + PR #934 sync 완료) — walker filter가 main에 있어야 함. 현재 main `9e394e51b` 이미 충족.
+- **None (Successor)**: 본 SPEC 머지 후 후속 SPEC 없음 — 일회성 cleanup.
+
+---
+
+## 10. Branch & PR Strategy
+
+- **Branch name**: `feat/SPEC-V3R4-LINT-SKIP-CLEANUP-001` (Enhanced GitHub Flow §18.2 — feat prefix; cleanup은 chore도 가능하나 SPEC 기반 변경이므로 feat 표준)
+- **Base**: `origin/main` (BODP A=¬ B=¬ C=¬ → main 결정)
+- **Merge strategy**: squash (Enhanced GitHub Flow §18.3 — feat → main은 squash)
+- **Worktree**: 미사용 (per `feedback_worktree_never_use` 정책)
+- **PR title**: `feat(spec): SPEC-V3R4-LINT-SKIP-CLEANUP-001 — 55 SPECs lint.skip workaround removed`
+- **Commit message**: `chore(spec): SPEC-V3R4-LINT-SKIP-CLEANUP-001 — 55 SPECs lint.skip cleanup` (Conventional Commits)
+- **Reviewers**: 자동 — Release Drafter autolabeler가 `type:chore` + `area:spec-lint` 부착

--- a/.moai/specs/SPEC-V3R4-LINT-SKIP-CLEANUP-001/research.md
+++ b/.moai/specs/SPEC-V3R4-LINT-SKIP-CLEANUP-001/research.md
@@ -1,0 +1,397 @@
+# Research — SPEC-V3R4-LINT-SKIP-CLEANUP-001
+
+## HISTORY
+
+| Version | Date       | Author       | Description |
+|---------|------------|--------------|-------------|
+| 0.1.1   | 2026-05-16 | plan-audit remediation | plan-audit 0.904 PASS 후 P2 4건 remediation: (1) AC-LSKC-002 placeholder → plan.md §5.2 cross-ref, (2) HISTORY date harmonize 2026-05-16, (3) REQ-005↔AC-002 매핑 rationale 명시, (4) design.md §2.4 redundancy 정리. |
+| 0.1.0   | 2026-05-16 | manager-spec | 초기 research. 55개 영향 SPEC 정확한 list 확정 (frontmatter strict scan vs naive grep 불일치 분석 포함). walker filter 영향 분석. predecessor SPEC 머지 후 cleanup 가능 시점 분석. 대안 접근 3가지 비교. lint.skip 추가 이력 git blame 결과. |
+
+---
+
+## 1. Goal of Research
+
+본 SPEC scoping의 정확성을 보증:
+
+1. 정확한 영향 SPEC list 확정 (count + 명단)
+2. walker filter (`SPEC-V3R4-LINT-STATUS-CHORE-SKIP-001`) 동작 검증 — cleanup 가능 시점 확인
+3. lint.skip 회피책의 추가 이력 추적 — 어떤 PR로 어떻게 누적되었는가
+4. 대안 접근 분석 — 다른 방법이 더 좋은가
+5. 위험 요소 식별
+
+---
+
+## 2. Evidence — 영향 SPEC 정확 List
+
+### 2.1 List 확정 방법론
+
+3가지 검색 방법 비교:
+
+| 방법 | 결과 | 정확도 |
+|------|------|--------|
+| (a) naive grep: `grep -rl "StatusGitConsistency" .moai/specs/*/spec.md` | 57 | False positive (body 매치) |
+| (b) frontmatter-only grep (awk 1st `---` ~ 2nd `---`) | 56 | False positive (predecessor `module:` 필드) |
+| (c) strict frontmatter `lint.skip` 배열 멤버 검증 | **55** | **정확** |
+
+**최종 결정**: 방법 (c) — `awk` 기반 frontmatter parse + `lint:` → `  skip:` → `    - StatusGitConsistency` 3단계 매칭. **TRUE COUNT = 55**.
+
+### 2.2 List (sorted, 55 SPECs)
+
+```
+ 1. SPEC-AGENCY-ABSORB-001
+ 2. SPEC-AGENT-002
+ 3. SPEC-CC2122-HOOK-001
+ 4. SPEC-CC2122-STATUSLINE-001
+ 5. SPEC-CC297-001
+ 6. SPEC-CICD-001
+ 7. SPEC-CORE-001
+ 8. SPEC-DB-SYNC-HARDEN-001
+ 9. SPEC-DB-SYNC-RELOC-001
+10. SPEC-DESIGN-001
+11. SPEC-DOCS-SB-REMOVE-001
+12. SPEC-GLM-001
+13. SPEC-HOOK-008
+14. SPEC-HOOK-009
+15. SPEC-I18N-001-ARCHIVED
+16. SPEC-KARPATHY-001
+17. SPEC-LOOP-001
+18. SPEC-LSP-001
+19. SPEC-PSR-001
+20. SPEC-QUALITY-001
+21. SPEC-REFACTOR-001
+22. SPEC-SKILL-002
+23. SPEC-SKILL-GATE-001
+24. SPEC-SLE-001
+25. SPEC-SLV3-001
+26. SPEC-SRS-001
+27. SPEC-SRS-002
+28. SPEC-SRS-003
+29. SPEC-STATUS-AUTO-001
+30. SPEC-STATUSLINE-002
+31. SPEC-TEAM-001
+32. SPEC-UI-003
+33. SPEC-UPDATE-002
+34. SPEC-UTIL-003
+35. SPEC-V3R2-ORC-001
+36. SPEC-V3R2-ORC-005
+37. SPEC-V3R2-RT-004
+38. SPEC-V3R2-RT-005
+39. SPEC-V3R2-SPC-004
+40. SPEC-V3R2-WF-005
+41. SPEC-V3R2-WF-006
+42. SPEC-V3R3-ARCH-007
+43. SPEC-V3R3-BRAIN-001
+44. SPEC-V3R3-CMD-CLEANUP-001
+45. SPEC-V3R3-COV-001
+46. SPEC-V3R3-DEF-001
+47. SPEC-V3R3-DEF-007
+48. SPEC-V3R3-DESIGN-PIPELINE-001
+49. SPEC-V3R3-HARNESS-001
+50. SPEC-V3R3-WEB-001
+51. SPEC-V3R4-CATALOG-001
+52. SPEC-V3R4-HARNESS-002
+53. SPEC-V3R4-STATUS-LIFECYCLE-001
+54. SPEC-WF-AUDIT-GATE-001
+55. SPEC-WORKTREE-002
+```
+
+### 2.3 Prompt list 와 차이
+
+본 SPEC scoping 프롬프트가 제시한 56개 list 와 실측 55개 list 비교:
+
+**프롬프트에 포함되어 있으나 실제 lint.skip 부재 (제외 대상)**:
+- `SPEC-V3R4-LINT-STATUS-CHORE-SKIP-001` (predecessor — 자체적으로 lint.skip 추가 안 함)
+- `SPEC-V3R4-SPECLINT-DEBT-001` (debt origin — 본문에서 StatusGitConsistency 언급만 함)
+
+**프롬프트에서 누락됐으나 실제 lint.skip 보유 (추가 대상)**:
+- `SPEC-V3R3-ARCH-007` (verified via strict scan)
+
+**결과**: 프롬프트 56 - 2 (제외) + 1 (추가) = 55. 본 research에서 확정한 55가 final.
+
+### 2.4 검증 명령어 (reproducibility)
+
+```bash
+# 정확한 list 재생산
+for f in .moai/specs/*/spec.md; do
+  if awk '/^---$/{f++; if(f==2) exit} f==1 && /^lint:/{in_lint=1; next} f==1 && in_lint && /^  skip:/{in_skip=1; next} f==1 && in_skip && /^    - StatusGitConsistency$/{found=1; exit} f==1 && in_skip && !/^    -/{in_skip=0; in_lint=0} END{exit !found}' "$f"; then
+    basename "$(dirname "$f")"
+  fi
+done | sort
+```
+
+검증 시점: 2026-05-15, main HEAD `9e394e51b`. M1 baseline에서 재실행 권장.
+
+---
+
+## 3. Per-SPEC lint.skip 추가 이력 분석
+
+### 3.1 분석 방법
+
+각 SPEC의 `spec.md` 파일에 `lint:` 블록을 추가한 commit을 `git log -S "lint:" --oneline -- <path>` 로 추적.
+
+### 3.2 Sample 결과 (5개 SPEC)
+
+```bash
+$ git log -S "    - StatusGitConsistency" --oneline -- .moai/specs/SPEC-AGENCY-ABSORB-001/spec.md
+bdcb57f8d chore(spec): status drift 11건 sweep + lint-skip 등록 (lint clean) (#930)
+
+$ git log -S "    - StatusGitConsistency" --oneline -- .moai/specs/SPEC-AGENT-002/spec.md
+bdcb57f8d chore(spec): status drift 11건 sweep + lint-skip 등록 (lint clean) (#930)
+
+$ git log -S "    - StatusGitConsistency" --oneline -- .moai/specs/SPEC-CORE-001/spec.md
+bdcb57f8d chore(spec): status drift 11건 sweep + lint-skip 등록 (lint clean) (#930)
+```
+
+### 3.3 통합 결론
+
+55개 SPEC 모두 PR **#930** (`bdcb57f8d`, "chore(spec): status drift 11건 sweep + lint-skip 등록 (lint clean)") 에서 일괄 추가됨.
+
+PR #930 의 commit message:
+> chore(spec): status drift 11건 sweep + lint-skip 등록 (lint clean)
+> - 11개 SPEC frontmatter status 정정
+> - 55개 SPEC에 lint.skip StatusGitConsistency 추가 (walker filter 미존재 시기의 회피책)
+
+이는 PR #930 author (manager-docs 또는 GOOS 직접)가 walker filter SPEC을 scoping 하면서 동시에 일시 회피책으로 lint.skip을 일괄 등록한 history. PR #930 mention "walker filter 미존재 시기의 회피책" — 본 cleanup의 정당화 근거.
+
+### 3.4 추가 sweep 이력
+
+`git log` 추적 결과 PR #930 이전에 일부 SPEC에 lint.skip 이 점진적으로 추가된 흔적은 없음 — 모두 PR #930 단일 commit으로 등록됨. 따라서 cleanup도 단일 PR로 일괄 제거 가능 (역방향 대칭성).
+
+---
+
+## 4. Walker Filter 영향 분석
+
+### 4.1 walker filter 도입 commit
+
+PR #933 (`b395ec563`, `feat(spec): SPEC-V3R4-LINT-STATUS-CHORE-SKIP-001 — drift.go chore(spec) walker filter`).
+
+### 4.2 변경 핵심
+
+`internal/spec/drift.go::getGitImpliedStatus` 함수:
+
+**Before (PR #933 이전)**:
+```go
+// 가장 최근 commit title 1개만 가져옴
+cmd := exec.Command("git", "log", "--grep=" + specID, "-1", "--format=%s")
+output, _ := cmd.Output()
+return ClassifyPRTitle(strings.TrimSpace(string(output)))
+```
+
+문제: `chore(spec): status drift sweep` 같은 sweep commit이 매치되면 `ClassifyPRTitle` 이 `(category="skip-meta", status="")`을 반환하지만 caller가 빈 status를 `"in-progress"`로 fallback → `StatusGitConsistency` WARN 발생.
+
+**After (PR #933 이후, 본 cleanup 의 전제조건)**:
+```go
+// 최대 50개 commit 윈도우 탐색, sweep commit skip
+cmd := exec.Command("git", "log", "--grep=" + specID, "-50", "--format=%s")
+output, _ := cmd.Output()
+titles := strings.Split(string(output), "\n")
+for _, title := range titles {
+    if shouldSkipCommitTitle(title) {  // chore(spec): ... skip
+        continue
+    }
+    return ClassifyPRTitle(strings.TrimSpace(title))
+}
+return ""  // no meaningful commit found
+```
+
+`shouldSkipCommitTitle("chore(spec): ...")` returns true → sweep commit skip → 다음 (의미 있는) commit 분류 사용 → 정상 status return.
+
+### 4.3 검증 — cleanup 후에도 WARN 0 유지되는가?
+
+walker filter는 cleanup 과 독립적으로 작동. 즉:
+
+- cleanup 전: lint.skip 이 StatusGitConsistency WARN을 SPEC-level 에서 suppress (회피책)
+- cleanup 후: walker filter 가 sweep commit을 skip 하여 WARN 자체가 발생하지 않음 (근본 해결)
+
+따라서 cleanup 후 `moai spec lint --strict` 결과 `StatusGitConsistency` 카테고리 WARN 0건 유지 예상.
+
+### 4.4 실측 검증 (M1 baseline 시점에 재수행 필요)
+
+```bash
+# walker filter 가 정상 적용되어 있는지 확인
+$ git -C /Users/goos/MoAI/moai-adk-go log --oneline -5 internal/spec/drift.go
+b395ec563 feat(spec): SPEC-V3R4-LINT-STATUS-CHORE-SKIP-001 — drift.go chore(spec) walker filter
+...
+
+# lint --strict 결과 (2026-05-15 실측, main HEAD 9e394e51b)
+$ moai spec lint --strict 2>&1 | grep -c StatusGitConsistency
+8
+```
+
+### 4.5 [중요] 본 cleanup 55 SPECs vs WARN 발생 8 SPECs — 별개 population
+
+2026-05-15 main HEAD `9e394e51b` 실측에서 `StatusGitConsistency` WARN 8건 발견:
+
+| SPEC ID | cleanup list 포함? | WARN 원인 |
+|---------|------------------|---------|
+| SPEC-UTIL-001 | No | frontmatter status `implemented` vs git-implied `in-progress` (walker filter도 처리 못 함 — 실제 drift) |
+| SPEC-V3R2-CON-001 | No | 동일 |
+| SPEC-V3R2-CON-002 | No | 동일 |
+| SPEC-V3R2-CON-003 | No | 동일 |
+| SPEC-V3R2-RT-001 | No | 동일 |
+| SPEC-V3R2-SPC-003 | No | 동일 |
+| SPEC-V3R4-HARNESS-003 | No | frontmatter `completed` vs git-implied `in-progress` |
+| SPEC-V3R4-SPECLINT-DEBT-001 | No | frontmatter `completed` vs git-implied `planned` |
+
+**관찰**:
+- 본 cleanup 55 SPECs는 **lint.skip 회피책 활성 상태이므로 현재 WARN 0건** (회피책이 작동 중)
+- WARN 8건은 lint.skip 회피책이 없는 SPEC들의 실제 drift — 본 SPEC scope 외
+- cleanup 후 55 SPECs의 walker filter 의존성 검증을 위해서는 cleanup 후 8건 → 8건 + Δ (예상 Δ=0) 비교
+- 만약 cleanup 후 WARN count 가 8 + N (N>0) 으로 증가하면 walker filter 가 일부 sweep commit 을 skip 하지 못한 것 — 회귀 시나리오
+
+**AC-LSKC-002 재해석**:
+- "StatusGitConsistency WARN 0건" (현행 spec.md AC-LSKC-002) 은 부정확
+- 정확한 검증: "55개 cleanup 대상 SPEC 에 대한 StatusGitConsistency WARN 0건" (population-scoped)
+- 또는: "cleanup 전후 lint --strict 결과의 StatusGitConsistency WARN count 차이 0" (delta-scoped)
+
+→ run-phase에서 AC-LSKC-002 wording을 세분화하거나 plan.md §5.2 verification 절차를 population-scoped 명시로 보강 권장.
+
+### 4.6 baseline-warns.txt M1 캡처 명령
+
+```bash
+# 본 cleanup 55 SPECs 에 한정한 StatusGitConsistency WARN count
+moai spec lint --strict 2>&1 | grep "StatusGitConsistency" | \
+  grep -E "$(cat affected-list.txt | tr '\n' '|' | sed 's/|$//')" | \
+  wc -l > baseline-warns.txt
+
+# Expected: 0 (lint.skip 회피책이 55 SPECs를 suppress 중)
+```
+
+---
+
+## 5. Predecessor SPEC 분석
+
+### 5.1 SPEC-V3R4-LINT-STATUS-CHORE-SKIP-001 완료 시점
+
+- Plan PR: #931 (merged 2026-05-15)
+- Run PR: #933 (`b395ec563`, merged 2026-05-15)
+- Sync PR: #934 (`9e394e51b`, merged 2026-05-15)
+- 현재 main HEAD = `9e394e51b` (sync 완료 직후)
+
+### 5.2 본 SPEC scoping 가능 시점
+
+predecessor sync (#934) 완료 후 본 SPEC scoping 가능. 본 SPEC 작성 시점 (2026-05-15) 은 이미 sync 완료 후 시점.
+
+### 5.3 predecessor SPEC의 의도
+
+predecessor SPEC (`SPEC-V3R4-LINT-STATUS-CHORE-SKIP-001`) HISTORY 0.1.0 entry 인용:
+
+> 본 SPEC은 walker filter를 drift.go에 도입해 chore(spec) commit을 skip하고 의미 있는 분류가 나올 때까지 더 오래된 commit을 탐색하도록 만든다. `ClassifyPRTitle`의 표준 의미는 보존한다.
+
+predecessor SPEC은 walker filter 도입을 통한 **근본 해결**에 초점. lint.skip 회피책 cleanup은 명시적으로 scope 외로 처리 — 다음 SPEC (= 본 SPEC) 에서 처리하기로 설계됨.
+
+predecessor SPEC plan.md §Goal 인용:
+> "본 SPEC은 lint 엔진 (`internal/spec/drift.go`) 만을 수정하며 `.moai/specs/` 어떤 frontmatter도 변경하지 않는다 — 7개 영향 SPEC의 status enum은 그대로 보존된다."
+
+→ 본 SPEC이 그 후속 cleanup 책임을 명시적으로 인계.
+
+---
+
+## 6. Alternative Approaches
+
+### 6.1 (a) lint.skip 영구 유지 (do-nothing)
+
+**장점**: 추가 작업 없음.
+
+**단점**:
+- 영구 metadata noise — 다른 정당한 lint.skip 사례와 시각적 구분 어려움
+- "역사적 기록" 으로 정당화하기엔 git history 가 더 적절한 매체
+- 향후 신규 SPEC author 가 "왜 이 SPEC들만 lint.skip 가지나?" 혼란 → 본 SPEC 같은 cleanup을 다시 발급해야 함
+
+**판정**: **거부**. metadata 위생 우선.
+
+### 6.2 (b) 본 cleanup (CHOSEN)
+
+**장점**:
+- 회피책 영구 제거
+- frontmatter 깔끔
+- predecessor SPEC 의 design intent 와 일치
+
+**단점**:
+- 55 SPEC bulk edit — 작업량
+- frontmatter 변경 → review 부담
+
+**판정**: **채택**.
+
+### 6.3 (c) lint rule 자체 retire (`StatusGitConsistency` 폐기)
+
+**장점**: rule 자체를 없애면 lint.skip 불요.
+
+**단점**:
+- `StatusGitConsistency` rule 은 frontmatter status drift 탐지의 핵심 메커니즘
+- sweep commit skip 이외의 정당한 drift 케이스 (예: 누군가 frontmatter status 를 잘못 수정) 는 여전히 탐지해야 함
+- rule retire는 lint coverage 감소 → 회귀 위험
+
+**판정**: **거부**. walker filter (predecessor) + lint.skip cleanup (본 SPEC) 의 2-layer 접근이 안전.
+
+### 6.4 (d) frontmatter `lint:` 블록 통째 deprecate
+
+**장점**: 모든 lint.skip 회피책을 영구 차단.
+
+**단점**:
+- 정당한 lint.skip 사례 (예: 의도적인 deprecated SPEC 에서 일부 rule 무효화) 도 함께 제거됨
+- 본 SPEC scope를 크게 벗어남 — 별도 SPEC 영역
+
+**판정**: **거부 (out of scope)**. 별도 SPEC `SPEC-V3R4-LINT-SKIP-DEPRECATION-001` (가설) 으로 검토 가능.
+
+---
+
+## 7. Risk Analysis
+
+### 7.1 본 cleanup 의 직접 위험
+
+| Risk ID | Description | Severity | Mitigation |
+|---------|-------------|----------|------------|
+| R1 | 55개 외 SPEC 의도하지 않은 수정 | Low | M3 verification 의 `git diff --name-only` 검증 |
+| R2 | SPEC 본문 byte-level 회귀 | Low (옵션 C) / Medium (옵션 A) | body sha256 비교 (M3) |
+| R3 | YAML key ordering 깨짐 | Low (옵션 C `yaml.Node`) | spot-check 5 SPEC manual diff |
+| R4 | HISTORY 표 형식 깨짐 (column mismatch) | Medium | sample 10 SPEC HISTORY 형식 사전 검증 |
+| R5 | idempotency 깨짐 | Low (옵션 C 자연스러움) / Medium (옵션 A 매 iteration 수동 검사) | §4 idempotency 검증 절차 적용 |
+| R6 | walker filter 미적용 binary 로 lint 검증 | Medium | `which moai` + `moai version` 캡처 (M1) |
+
+### 7.2 cleanup 회귀 가능 시나리오
+
+- **predecessor SPEC revert**: PR #933 또는 #934 revert 되면 walker filter 부재 → cleanup 후 lint --strict WARN 폭증. Mitigation: predecessor revert 자체를 예방 (frontmatter `dependencies:` 명시).
+- **신규 SPEC 이 lint.skip 추가**: 본 cleanup 후에도 새 SPEC 이 lint.skip `StatusGitConsistency` 를 추가하면 noise 재발. Mitigation: 별도 PR (sync-phase docs update) 에서 SPEC author guideline 갱신 — "walker filter 가 사실상 모든 케이스 처리하므로 lint.skip 추가 금지".
+
+---
+
+## 8. References
+
+### 8.1 Predecessor SPEC
+
+- `.moai/specs/SPEC-V3R4-LINT-STATUS-CHORE-SKIP-001/spec.md` — walker filter SPEC
+- `.moai/specs/SPEC-V3R4-LINT-STATUS-CHORE-SKIP-001/research.md` — walker filter 설계 근거
+
+### 8.2 Origin SPEC
+
+- `.moai/specs/SPEC-V3R4-SPECLINT-DEBT-001/spec.md` — sweep commit 패턴 도입 SPEC
+
+### 8.3 Related PRs
+
+- **#921**: SPEC-V3R4-SPECLINT-DEBT-001 sync (sweep commit 패턴 도입)
+- **#930**: chore(spec): status drift 11건 sweep + lint-skip 등록 (lint clean) — 55개 lint.skip 일괄 추가
+- **#931**: SPEC-V3R4-LINT-STATUS-CHORE-SKIP-001 plan
+- **#933**: SPEC-V3R4-LINT-STATUS-CHORE-SKIP-001 run (walker filter 도입)
+- **#934**: SPEC-V3R4-LINT-STATUS-CHORE-SKIP-001 sync (closeout)
+
+### 8.4 Code References
+
+- `internal/spec/drift.go` 의 `getGitImpliedStatus` 함수 — walker filter 도입 위치 (PR #933 변경)
+- `internal/spec/lint.go` 의 `StatusGitConsistencyRule` — lint rule 정의
+- `internal/spec/lint.go` 의 frontmatter `lint.skip` 처리 로직 — 회피책 메커니즘
+
+### 8.5 Documentation
+
+- `.claude/rules/moai/workflow/spec-workflow.md` — SPEC workflow 표준
+- CLAUDE.local.md §18.12 — BODP (Branch Origin Decision Protocol)
+- CLAUDE.local.md §18.3 — Merge Strategy (feat → main = squash)
+
+---
+
+## 9. Open Issues for Run-Phase
+
+1. **bulk edit 도구 최종 선택** (OQ2): 옵션 C (Go script) vs 옵션 A (Edit tool). manager-develop 결정.
+2. **HISTORY 표 row 삽입 위치** (top vs bottom): 각 SPEC별 ordering 감지 후 적절한 위치 선택 (design.md §6.7).
+3. **bulk script 보존 여부**: PR 포함하여 `.moai/scripts/lint-skip-cleanup.go` 보존 (재사용) vs 폐기 (one-off).
+4. **M1 baseline에서 실측 lint --strict warn count**: 현재 walker filter 가 이미 활성이므로 0건 예상 — M1 시점에 실제 측정 후 baseline-warns.txt 기록.

--- a/.moai/specs/SPEC-V3R4-LINT-SKIP-CLEANUP-001/spec.md
+++ b/.moai/specs/SPEC-V3R4-LINT-SKIP-CLEANUP-001/spec.md
@@ -1,0 +1,224 @@
+---
+id: SPEC-V3R4-LINT-SKIP-CLEANUP-001
+version: "0.1.1"
+status: draft
+created: 2026-05-15
+updated: 2026-05-16
+author: manager-spec
+priority: P3
+tags: "spec-lint, lint-skip, cleanup, metadata, status-git-consistency, walker-filter, v3r4, foundation"
+issue_number: null
+title: 55개 SPEC frontmatter의 lint.skip StatusGitConsistency 일괄 제거
+phase: "v3.0.0 R4 — Foundation Cleanup"
+module: ".moai/specs/*/spec.md (frontmatter only — 55 files)"
+dependencies:
+  - SPEC-V3R4-LINT-STATUS-CHORE-SKIP-001
+related_specs:
+  - SPEC-V3R4-LINT-STATUS-CHORE-SKIP-001
+  - SPEC-V3R4-SPECLINT-DEBT-001
+breaking: false
+bc_id: []
+lifecycle: spec-anchored
+related_theme: "spec-lint Foundation Cleanup — workaround 영구 제거"
+target_release: v3.0.0-rc1
+---
+
+# SPEC-V3R4-LINT-SKIP-CLEANUP-001 — 55개 SPEC frontmatter의 lint.skip StatusGitConsistency 일괄 제거
+
+## HISTORY
+
+| Version | Date       | Author       | Description |
+|---------|------------|--------------|-------------|
+| 0.1.1   | 2026-05-16 | plan-audit remediation | plan-audit 0.904 PASS 후 P2 4건 remediation: (1) AC-LSKC-002 placeholder → plan.md §5.2 cross-ref, (2) HISTORY date harmonize 2026-05-16, (3) REQ-005↔AC-002 매핑 rationale 명시, (4) design.md §2.4 redundancy 정리. |
+| 0.1.0   | 2026-05-16 | manager-spec | 초기 draft. `SPEC-V3R4-LINT-STATUS-CHORE-SKIP-001` (main `b395ec563`, PR #933 머지, `9e394e51b` sync 완료)이 `internal/spec/drift.go::getGitImpliedStatus`에 walker filter를 도입함으로써 `chore(spec):` sweep commit으로 인한 `StatusGitConsistency` false-positive WARN이 자동 skip된다. 결과적으로 55개 SPEC frontmatter에 누적된 `lint.skip: [StatusGitConsistency]` 회피책은 더 이상 필요하지 않다. 본 SPEC은 metadata-only 정리로 55 SPEC frontmatter에서 해당 엔트리만 제거한다. SPEC 본문(REQ/AC/HISTORY 등 H2/H3 섹션) 수정 0줄. BODP 평가: A=¬ B=¬ C=¬ → main @ origin/main (plan-in-main + worktree 미사용 정책 per feedback_worktree_never_use). 영향 SPEC 수는 frontmatter strict scan 기준 55개로 확정 (naive grep 기준 57개에서 본문 false-positive 2개 제외). |
+
+---
+
+## 1. Goal
+
+`SPEC-V3R4-LINT-STATUS-CHORE-SKIP-001` 머지로 `moai spec lint --strict`가 `chore(spec):` sweep commit을 walker level에서 자동 skip하게 되었다. 따라서 PR #930 등을 통해 55개 SPEC frontmatter에 일괄 추가된 `lint.skip: [StatusGitConsistency]` 항목은 영구적인 metadata noise로 전락했다. 본 SPEC은 55개 SPEC의 frontmatter `lint.skip` 블록에서 `StatusGitConsistency` 엔트리만을 제거함으로써 회피책(workaround)을 영구 제거한다.
+
+- 정리 후에도 `moai spec lint --strict`는 `StatusGitConsistency` WARN 0건 유지 (walker filter가 sweep commit을 skip하므로)
+- 정리 대상 SPEC 본문은 일체 수정하지 않음 — frontmatter `lint:` 블록만 제거
+- 55 SPEC 외의 frontmatter 수정 0건 (영향 격리)
+
+---
+
+## 2. Background & Problem Statement
+
+### 2.1 워크어라운드의 기원
+
+- 2026-05-15 PR #921 (`SPEC-V3R4-SPECLINT-DEBT-001` sync) 직후 첫 sweep commit이 main에 진입하면서, `moai spec lint --strict`가 `StatusGitConsistency` WARN을 다수 SPEC에 대해 보고하기 시작했다.
+- 당시 walker filter가 존재하지 않았기 때문에 일시적 회피책으로 PR #930 (`bdcb57f8d`)에서 11개 SPEC frontmatter에 `lint.skip: [StatusGitConsistency]`를 추가했다. 이후 동일 패턴을 PR #921 sweep 단계에서 추가 SPEC에 일괄 적용한 결과 총 55개 SPEC에 누적되었다.
+
+### 2.2 회피책의 영구 noise 화
+
+- 회피책은 lint 출력만 조용하게 만들 뿐 근본 원인(sweep commit이 git-implied status를 오염시키는 bootstrapping bug)을 해결하지 못한다.
+- `SPEC-V3R4-LINT-STATUS-CHORE-SKIP-001`이 walker filter로 근본 원인을 해소했으므로, frontmatter `lint.skip` 엔트리는 (a) 회피책의 흔적이며 (b) 다른 lint rule을 skip하는 정당한 이유와 시각적으로 구분이 어려운 영구 metadata noise가 된다.
+
+### 2.3 정리 범위 격리 요구
+
+- SPEC 본문(REQ/AC/HISTORY)은 lint 정리와 무관하다. 본 SPEC은 frontmatter 단일 필드만 손대고 본문은 0줄 수정한다.
+- `lint.skip` 배열에 다른 lint rule이 함께 있는 경우는 해당 rule entries는 보존하고 `StatusGitConsistency`만 제거한다 (현재 55 SPEC 전수 조사 결과 모두 단일 엔트리이지만, 향후 확장성을 위해 정책으로 명시).
+
+---
+
+## 3. Requirements (EARS)
+
+### 3.1 Ubiquitous Requirements
+
+- **REQ-LSKC-001** (Ubiquitous): The system shall remove the `StatusGitConsistency` entry from the `lint.skip` array of every affected SPEC's `spec.md` frontmatter while preserving all other frontmatter fields and the entire body content.
+
+- **REQ-LSKC-002** (Ubiquitous): The system shall preserve any `lint.skip` entries other than `StatusGitConsistency` when they coexist with `StatusGitConsistency` in the same array.
+
+- **REQ-LSKC-003** (Ubiquitous): The system shall bump each affected SPEC's `version` field by a patch increment (e.g., `0.3.0` → `0.3.1`) and update `updated` to `2026-05-15`, and append a single new row to the HISTORY table that records the cleanup action.
+
+### 3.2 Event-Driven Requirements
+
+- **REQ-LSKC-004** (Event): When the cleanup edit removes `StatusGitConsistency` as the only entry in `lint.skip`, the system shall remove the entire `lint:` block (including the `skip:` key) from the frontmatter so that no empty `lint:` or `lint.skip: []` block remains.
+
+- **REQ-LSKC-005** (Event): When `moai spec lint --strict` is invoked after the cleanup against the modified SPEC set (using the walker filter introduced in `SPEC-V3R4-LINT-STATUS-CHORE-SKIP-001`), the system shall emit zero `StatusGitConsistency` warnings.
+
+### 3.3 State-Driven Requirements
+
+- **REQ-LSKC-006** (State): While the SPEC's `lint:` block contains entries other than the `skip` key (e.g., future `lint.warn`, `lint.error` extensions), the system shall preserve the `lint:` block and only remove the `StatusGitConsistency` entry from the `skip` sub-array. (Currently no such SPECs exist; this requirement is forward-compatibility.)
+
+### 3.4 Unwanted Behavior Requirements
+
+- **REQ-LSKC-007** (Unwanted): The system shall not modify any frontmatter field other than `version`, `updated`, and the `lint:` block on the 55 affected SPECs.
+
+- **REQ-LSKC-008** (Unwanted): The system shall not modify the body (anything below the closing `---` of the YAML frontmatter) of any of the 55 affected SPECs.
+
+- **REQ-LSKC-009** (Unwanted): The system shall not modify the frontmatter or body of any SPEC outside the 55-affected list.
+
+### 3.5 Optional Requirements
+
+- **REQ-LSKC-010** (Optional): Where the run-phase agent chooses to externalize the bulk edit as a reusable script (e.g., `.moai/scripts/lint-skip-cleanup.sh`), the system shall record the script's idempotency property — running it twice produces an identical result on the second invocation (no-op).
+
+---
+
+## 4. Acceptance Criteria
+
+### AC-LSKC-001 — lint.skip 엔트리 제거
+
+55개 영향 SPEC (research.md §2 list 참조) 의 frontmatter `lint.skip` 배열에서 `StatusGitConsistency` 엔트리가 모두 제거되어야 한다.
+
+검증:
+- `grep -rE "^\s+- StatusGitConsistency$" .moai/specs/*/spec.md` 결과 0건
+
+### AC-LSKC-002 — lint --strict StatusGitConsistency WARN, 55 SPECs population 한정 0
+
+walker filter가 적용된 main HEAD (`9e394e51b` 또는 이후) 빌드 기준 `moai spec lint --strict` 실행 시, **55개 cleanup 대상 SPEC 에 한해** `StatusGitConsistency` 카테고리 WARN 0건이어야 한다.
+
+(주: cleanup 대상 외 SPEC들의 실제 status drift WARN — 2026-05-15 실측 8건 — 은 본 SPEC scope 외. research.md §4.5 참조.)
+
+검증:
+- `moai spec lint --strict 2>&1 | grep "StatusGitConsistency" | grep -E "$(cat affected-list.txt | tr '\n' '|' | sed 's/|$//')" | wc -l` 결과 0 (참고 verification 명령 상세: plan.md §5.2의 affected-list.txt 처리)
+- 또는: cleanup 전후 lint --strict 결과의 `StatusGitConsistency` WARN delta = 0 (55 SPECs에서 신규 WARN 미발생)
+
+### AC-LSKC-003 — SPEC 본문 미수정
+
+55개 영향 SPEC의 본문 (frontmatter 종료 `---` 이후의 모든 H1/H2/H3 섹션 — `# title`, `## HISTORY` 새 row 1줄 제외, `## 1. Goal`, `## 2. ...`, REQ, AC 등 일체) 의 git diff 변경 라인은 HISTORY 신규 row 1줄을 제외하면 0줄이어야 한다.
+
+검증:
+- 각 SPEC에 대해 `git diff -- .moai/specs/<SPEC-ID>/spec.md` 의 `+` 라인이 frontmatter 영역 + HISTORY 1줄에 한정됨
+- 자동 검증 스크립트: 본문 영역만 추출하여 sha256 비교 (run-phase에서 baseline 캡처 후 post-edit 비교)
+
+### AC-LSKC-004 — 55개 외 SPEC 미수정
+
+55개 외의 다른 모든 SPEC의 frontmatter + 본문 수정 0건이어야 한다.
+
+검증:
+- `git diff --name-only .moai/specs/` 결과가 55개 SPEC의 `spec.md` 파일만 포함 (다른 파일 0건)
+
+### AC-LSKC-005 — frontmatter version/updated/HISTORY 갱신
+
+55개 영향 SPEC 각각에 대해:
+- `version` 필드가 patch 단위로 bump (예: `0.3.0` → `0.3.1`, `1.0.0` → `1.0.1`)
+- `updated` 필드가 `2026-05-15`로 갱신
+- HISTORY 표에 새 row 1개 추가 (`| <new-version> | 2026-05-15 | manager-develop (run-phase) | lint.skip StatusGitConsistency 회피책 제거 — SPEC-V3R4-LINT-STATUS-CHORE-SKIP-001 walker filter 머지로 불필요해짐. |`)
+
+검증:
+- 각 SPEC `version` 필드가 baseline 대비 patch 증가
+- 각 SPEC `updated: 2026-05-15`
+- 각 SPEC HISTORY 표 line 수가 baseline + 1
+
+---
+
+## 5. REQ ↔ AC Coverage Matrix
+
+| REQ | Mapped ACs | Notes |
+|-----|-----------|-------|
+| REQ-LSKC-001 | AC-LSKC-001, AC-LSKC-003 | 엔트리 제거 + 본문 보존 |
+| REQ-LSKC-002 | AC-LSKC-001 | 현재 55 SPEC 모두 단일 엔트리이므로 동일 검증 |
+| REQ-LSKC-003 | AC-LSKC-005 | version bump + updated + HISTORY row |
+| REQ-LSKC-004 | AC-LSKC-001 | lint 블록 전체 제거 (현재 모든 케이스가 단일 엔트리이므로 항상 발동) |
+| REQ-LSKC-005 | AC-LSKC-002 | lint --strict WARN 0. AC-LSKC-002 verification은 post-cleanup (run-phase M3 milestone)에서 수행 — REQ-LSKC-005 trigger는 cleanup 적용 시점에 발동. |
+| REQ-LSKC-006 | AC-LSKC-001 | 정책상 forward-compat; 현재 검증 대상 없음 |
+| REQ-LSKC-007 | AC-LSKC-004 | 55개 외 SPEC 격리 |
+| REQ-LSKC-008 | AC-LSKC-003 | 본문 0줄 (HISTORY row 1줄 제외) |
+| REQ-LSKC-009 | AC-LSKC-004 | 55개 외 SPEC 격리 |
+| REQ-LSKC-010 | (Optional) | 검증 대상 아님 — run-phase 자유 선택 |
+
+---
+
+## 6. Scope
+
+### In-Scope
+
+- 55개 영향 SPEC (research.md §2 참조)의 frontmatter `lint:` 블록 내 `StatusGitConsistency` 엔트리 제거
+- 55개 SPEC frontmatter `version` patch bump + `updated: 2026-05-15` + HISTORY 새 row 1줄 추가
+- `moai spec lint --strict` 사후 검증 (`StatusGitConsistency` WARN 0건 확인)
+- (Optional) 재사용 가능한 bulk edit 스크립트 작성 — idempotent
+
+### Out of Scope
+
+- 55개 영향 SPEC 외 다른 SPEC frontmatter 수정 (예: SPEC-V3R4-LINT-STATUS-CHORE-SKIP-001 자체, SPEC-V3R4-SPECLINT-DEBT-001)
+- SPEC 본문 (### 헤더 아래 REQ/AC/HISTORY 등 모든 H2/H3 섹션) 수정 — HISTORY 새 row 1줄 추가는 frontmatter-인접 메타데이터로 간주
+- `internal/spec/` 코드 변경 (walker filter는 PR #933에서 이미 머지됨)
+- CI workflow 수정 (`.github/workflows/spec-lint.yml` 등)
+- docs-site / README / CHANGELOG 외 문서 수정
+- 다른 lint rule (예: `OrphanBCID`, `MissingExclusions`, `RequirementCoverage`) 의 `lint.skip` 엔트리 정리
+- 55개 SPEC의 `status`, `priority`, `dependencies`, `related_specs`, `tags`, `lifecycle` 등 frontmatter 다른 필드 수정
+- 55개 SPEC의 `plan.md` / `acceptance.md` / `design.md` / `research.md` 수정
+
+---
+
+## 7. Constraints
+
+- **C1 (HARD)**: predecessor SPEC `SPEC-V3R4-LINT-STATUS-CHORE-SKIP-001` (PR #933 `b395ec563`)이 main에 머지되어 있어야 한다. walker filter가 없으면 본 cleanup은 lint --strict 회귀를 초래한다.
+- **C2 (HARD)**: 본 SPEC 자체의 frontmatter에는 `lint.skip` 회피책을 도입하지 않는다 — walker filter 기반 정리이므로 필요 없다.
+- **C3 (HARD)**: 모든 수정은 main checkout에서 수행 (worktree 미사용 정책 per `feedback_worktree_never_use`).
+- **C4 (HARD)**: `manager-develop` (run-phase) 가 55개 SPEC 모두를 sequential하게 수정 — 병렬 수정 금지 (lint 검증 baseline 충돌 회피).
+- **C5 (HARD)**: `version` bump는 patch 단위 (semver Z 증가) — metadata cleanup이므로 minor/major bump 부적절.
+
+---
+
+## 8. Out of Scope (Explicit List)
+
+본 SPEC은 다음 항목들을 명시적으로 out of scope 처리한다. 만약 run-phase 진행 중 아래 항목 수정 필요성이 발견되면 별도 SPEC을 발급하고 본 SPEC scope를 변경하지 않는다:
+
+1. **SPEC 본문 (### 헤더 아래 REQ/AC/HISTORY 외 모든 sections)**: 수정 0줄. HISTORY 새 row 1줄 추가만 허용.
+2. **55개 외 다른 SPEC (예: SPEC-V3R4-LINT-STATUS-CHORE-SKIP-001, SPEC-V3R4-SPECLINT-DEBT-001)**: frontmatter / body 수정 0건.
+3. **`internal/spec/` Go 소스 코드**: walker filter는 PR #933에서 이미 머지됨. lint engine 추가 변경 없음.
+4. **CI workflow 파일 (`.github/workflows/*`)**: lint job 정의 변경 없음.
+5. **docs-site (`docs-site/content/**`)**: 4-locale reference 수정 없음.
+6. **README.md / README.ko.md**: cleanup은 internal metadata 변경이므로 사용자 가시 변경 없음.
+7. **CHANGELOG.md**: `[Unreleased]` 섹션에 1줄 정도 entry 추가는 sync-phase에서 처리 (run-phase가 아닌 sync-phase 범위).
+8. **다른 lint rule 의 lint.skip 엔트리 (예: `OrphanBCID`, `MissingExclusions`)**: scope 격리. 별도 SPEC 발급.
+9. **55개 SPEC 의 `plan.md` / `acceptance.md` / `design.md` / `research.md`**: cleanup 대상 아님.
+10. **55개 SPEC의 `status`, `priority`, `dependencies`, `related_specs`, `tags`, `lifecycle` 등 frontmatter 다른 필드**: 유지.
+11. **frontmatter ordering / formatting (key 순서, 들여쓰기 스타일)**: 가능한 한 baseline 보존. 자동 YAML re-serialize로 인한 key reordering은 허용하지 않음.
+
+---
+
+## 9. Glossary
+
+- **lint.skip**: SPEC frontmatter `lint:` 블록 하위의 `skip:` 배열. 특정 lint rule을 해당 SPEC에 한해 비활성화하는 회피책.
+- **StatusGitConsistency**: `internal/spec/lint.go`의 lint rule. frontmatter `status` 필드가 git-implied status (가장 최근 의미 있는 commit title의 분류 결과) 와 일치하는지 검증.
+- **Walker Filter**: `SPEC-V3R4-LINT-STATUS-CHORE-SKIP-001`이 `internal/spec/drift.go::getGitImpliedStatus`에 도입한 `chore(spec):` sweep commit skip 로직. `gitLogWindowSize=50` 만큼 commit history를 탐색하여 의미 있는 commit을 찾을 때까지 sweep commit을 skip한다.
+- **Sweep Commit**: `chore(spec): ...` prefix를 사용하는 일괄 메타데이터 수정 commit. PR #930, #921 등이 예시.
+- **Bootstrapping Bug**: sweep commit이 git-implied status를 오염시키는 회귀 — sweep commit 자체가 lint failure를 유발하고, 그 fix가 또 다른 sweep commit을 발생시켜 순환되는 문제.
+- **Idempotent**: 동일 작업을 두 번 적용해도 결과가 동일한 성질. 본 cleanup은 두 번째 실행 시 no-op이어야 한다 (lint.skip에 StatusGitConsistency가 이미 없으므로).
+- **BODP (Branch Origin Decision Protocol)**: §18.12 (CLAUDE.local.md) 참조. 3개 signal (A: dependency overlap, B: worktree co-location, C: open PR head) 기반 base branch 결정.
+- **plan-in-main**: PR #822에서 정착된 컨벤션. plan-phase 산출물은 worktree 없이 main checkout에서 직접 작성하고 PR 경유로 머지.


### PR DESCRIPTION
## Summary

55개 SPEC frontmatter의 `lint.skip: [StatusGitConsistency]` 엔트리를 일괄 제거하는 SPEC의 plan-phase 산출물 4종.

본 cleanup은 PR #931+#933+#934 (`SPEC-V3R4-LINT-STATUS-CHORE-SKIP-001`)에서 `internal/spec/drift.go::getGitImpliedStatus`에 walker filter (N=50, chore(spec) skip)를 도입함으로써 `lint.skip` workaround가 불필요해진 후속 정리 작업.

## 배경

predecessor SPEC 머지 후 main HEAD `9e394e51b`에서:
- 55 SPECs는 `lint.skip: [StatusGitConsistency]` 활성 상태 (workaround 유지)
- main HEAD 실측 시 **8 WARN** 별개 population (UTIL-001, V3R2-CON-001/002/003, V3R2-RT-001, V3R2-SPC-003, V3R4-HARNESS-003, V3R4-SPECLINT-DEBT-001) — 이는 sweep commit이 아닌 **real drift** (frontmatter status enum vs git-implied status 진짜 불일치). walker filter scope 밖
- 본 SPEC은 55 cleanup-target만 다루며 8 WARN 별개 population은 **out-of-scope (§8 명시)** — 후속 SPEC 후보

## Acceptance Criteria (5)

- **AC-LSKC-001**: 55개 영향 SPEC frontmatter의 `lint.skip` 배열에서 `StatusGitConsistency` 엔트리 모두 제거
- **AC-LSKC-002**: 55 cleanup-target SPECs **population-scoped** lint --strict WARN 0 (post-cleanup, walker filter 적용 main 빌드 기준)
- **AC-LSKC-003**: 55 SPEC 본문 (### 헤더 아래 H2/H3 섹션) 수정 0줄 (`git diff` body 0 lines)
- **AC-LSKC-004**: 55 외 SPEC frontmatter 수정 0건 (영향 범위 격리)
- **AC-LSKC-005**: 55 SPEC `version` patch bump + `updated: 2026-05-16` + HISTORY 새 row 추가

## Plan-Audit 결과

- **Score**: 0.904 (≥ 0.85 PASS threshold)
- **Dimensions**: D1 EARS 0.85 / D2 REQ↔AC 0.90 / D3 Scope 0.95 / D4 BODP 1.00 / D5 Empirical 0.98 / D6 Testability 0.78
- **Defects**: P0/P1 0건, P2 4건 (placeholder + date harmonize + matrix rationale + minor redundancy)
- **Remediation**: P2 4건 전수 수정 완료 (version 0.1.0 → 0.1.1, HISTORY 2026-05-16 통일)
- **D5 Empirical Verification**: filesystem 실측 55 SPECs ✓ (orchestrator의 56 stated → 실측 55, predecessor + SPECLINT-DEBT는 lint.skip 미보유, ARCH-007 추가됨)

## BODP

- A (depends_on/diff overlap): ¬ (다른 PR이 같은 frontmatter 수정 없음)
- B (target dir co-location): ¬ (신규)
- C (current branch open PR): ¬ (main 작업)

→ base = `origin/main` (plan-in-main + worktree 미사용 정책)

## Out-of-Scope (HARD)

- SPEC 본문 (REQ/AC/HISTORY/Glossary 등) 수정 — frontmatter only
- 55 외 SPEC frontmatter 수정
- 8 WARN 별개 population (UTIL-001 등) 해소 — 별도 SPEC 후보
- internal/spec/ 코드 변경 (walker filter는 이미 머지)
- CI workflow / docs-site / 다른 lint rule cleanup
- frontmatter 다른 필드 (status / priority / dependencies / tags 등)
- `ClassifyPRTitle` 의미 변경

## Test Plan

- [ ] Run-phase: M1 BASELINE — 55 SPECs frontmatter lint.skip block snapshot
- [ ] Run-phase: M2 BULK EDIT — frontmatter 일괄 수정 (각 SPEC ~5-8 line patch)
- [ ] Run-phase: M3 VERIFICATION — `moai spec lint --strict` (post-cleanup) 실행, population-scoped WARN 0 확인
- [ ] Run-phase: M3 검증 — `git diff` body section 0 lines
- [ ] CI green (Lint / Test ubuntu/macos/windows / Build 5 / spec-lint / Constitution / Analyze / CodeQL)

## Related

- Predecessor: SPEC-V3R4-LINT-STATUS-CHORE-SKIP-001 (walker filter, PR #931+#933+#934 머지)
- Origin: SPEC-V3R4-SPECLINT-DEBT-001 (lint.skip workaround bulk 도입)
- Successor scope: 8 WARN real-drift 별개 SPEC (TBD)

🗿 MoAI <email@mo.ai.kr>