### PR TITLE
feat(spec): SPEC-V3R4-SPECLINT-DEBT-002 run-phase — dual-schema drift 영구 해소

### DIFF
--- a/.claude/rules/moai/development/spec-frontmatter-schema.md
+++ b/.claude/rules/moai/development/spec-frontmatter-schema.md
@@ -1,0 +1,142 @@
+---
+description: "SPEC 파일 frontmatter canonical 12-field 스키마 — Single Source of Truth (SSOT)"
+paths: "**/*.md,.moai/specs/**/*.md"
+---
+
+# SPEC Frontmatter Schema — SSOT
+
+> **Single Source of Truth** for the canonical SPEC frontmatter schema.
+> Enforcement: `internal/spec/lint.go` `FrontmatterSchemaRule` (REQ-SPC-003-006).
+> Cross-referenced by: `.claude/skills/moai/workflows/plan.md` § Pre-Write Frontmatter Checklist,
+> `.claude/skills/moai/team/plan.md` § Pre-Write Frontmatter Checklist.
+
+## Canonical 12 Required Fields
+
+All SPEC documents (`spec.md`) MUST contain exactly these 12 fields in YAML frontmatter.
+Missing any field or using a snake_case alias causes `FrontmatterInvalid` lint findings.
+
+```yaml
+---
+id: SPEC-{DOMAIN}-{NUM}
+title: "Human-readable title"
+version: "X.Y.Z"
+status: draft
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+author: Author Name
+priority: P1
+phase: "vX.Y.Z target"
+module: "path/to/module"
+lifecycle: spec-anchored
+tags: "tag1, tag2, tag3"
+---
+```
+
+## Field Reference
+
+| Field | Type | Constraints | Notes |
+|-------|------|-------------|-------|
+| `id` | string | `^SPEC-[A-Z][A-Z0-9]+-[0-9]{3}$` | Domain-namespaced identifier |
+| `title` | string | non-empty, quoted | Human-readable description |
+| `version` | string | semver `X.Y.Z`, quoted | Start at `"0.1.0"` |
+| `status` | enum | See Status Enum below | Lifecycle state |
+| `created` | date | `YYYY-MM-DD` ISO format | Creation date |
+| `updated` | date | `YYYY-MM-DD` ISO format | Last update date |
+| `author` | string | non-empty | Author name |
+| `priority` | enum | `P0`\|`P1`\|`P2`\|`P3` or `High`\|`Medium`\|`Low`\|`Critical` | Default `P1` |
+| `phase` | string | non-empty, typically release target | e.g. `"v3.0.0"` |
+| `module` | string | non-empty, path-like | Affected Go module or directory |
+| `lifecycle` | enum | `spec-anchored`\|`spec-lite`\|`exploratory` | Default `spec-anchored` |
+| `tags` | string | comma-separated, non-empty | Searchable labels |
+
+## Status Enum (8 values)
+
+```
+draft → planned → in-progress → implemented → completed
+                                         ↓
+                               superseded | archived | rejected
+```
+
+Valid values: `draft`, `planned`, `in-progress`, `implemented`, `completed`, `superseded`, `archived`, `rejected`
+
+## Optional Fields
+
+These fields may be included when needed but are NOT required by `FrontmatterSchemaRule`:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `issue_number` | integer or null | GitHub issue number. Omit entirely when not tracking. |
+| `depends_on` | list | SPEC IDs this SPEC depends on. Used by BODP signal A. |
+| `lint.skip` | list | Lint rule codes to skip. Use only for documented debt. |
+| `bc_id` | string | Backward-compatibility tracking ID. |
+
+## Rejected Snake_Case Aliases
+
+The YAML struct decoder in `internal/spec/lint.go` uses `yaml:"created"`, `yaml:"updated"`, `yaml:"tags"` tags.
+Snake_case aliases are silently dropped by the decoder, causing empty-value `FrontmatterInvalid` findings.
+
+| Do NOT use | Use instead |
+|------------|-------------|
+| `created_at:` | `created:` |
+| `updated_at:` | `updated:` |
+| `labels:` | `tags:` |
+| `spec_id:` | `id:` |
+
+## Lint Rule Implementation
+
+`FrontmatterSchemaRule` in `internal/spec/lint.go`:
+
+- **Rule code**: `FrontmatterInvalid`
+- **Severity**: Warning
+- **REQ coverage**: REQ-SPC-003-006
+- **Check**: Iterates all 12 required fields; emits one finding per missing/empty field.
+- **YAML binding**: `SPECFrontmatter` struct uses canonical field names (`created`, `updated`, `tags`).
+  Snake_case aliases in the source YAML file are not recognized — they produce empty values.
+
+See `internal/spec/lint.go` `FrontmatterSchemaRule.Check()` for the authoritative implementation.
+
+## Examples
+
+### Correct (all 12 fields, canonical names)
+
+```yaml
+---
+id: SPEC-AUTH-001
+title: "OAuth2 Authentication"
+version: "0.1.0"
+status: draft
+created: 2026-05-16
+updated: 2026-05-16
+author: GOOS Kim
+priority: P1
+phase: "v3.0.0"
+module: "internal/auth"
+lifecycle: spec-anchored
+tags: "auth, oauth2, security"
+---
+```
+
+### Wrong (snake_case aliases — produces 3 FrontmatterInvalid findings)
+
+```yaml
+---
+id: SPEC-AUTH-001
+title: "OAuth2 Authentication"
+version: "0.1.0"
+status: draft
+created_at: 2026-05-16   # WRONG — use created:
+updated_at: 2026-05-16   # WRONG — use updated:
+author: GOOS Kim
+priority: P1
+phase: "v3.0.0"
+module: "internal/auth"
+lifecycle: spec-anchored
+labels: [auth, oauth2]   # WRONG — use tags: "auth, oauth2"
+---
+```
+
+## Version History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-05-16 | SPEC-V3R4-SPECLINT-DEBT-002 | Initial creation — resolves dual-schema drift between plan.md (9-field) and lint.go (12-field) |

--- a/.claude/skills/moai/team/plan.md
+++ b/.claude/skills/moai/team/plan.md
@@ -157,6 +157,39 @@ After all research tasks complete and annotation cycle is approved:
 3. Delegate SPEC creation to manager-spec subagent (NOT a teammate) with all findings
 4. Include: codebase analysis (research.md), requirements, technical design, edge cases, reference implementations
 
+#### [HARD] Pre-Write Frontmatter Checklist
+
+[HARD] Before manager-spec calls Write/MultiEdit for spec.md, it MUST validate the frontmatter contains ALL 12 required fields AND rejects snake_case legacy aliases. This checklist prevents dual-schema drift between the plan workflow and `internal/spec/lint.go` `FrontmatterSchemaRule`. SSOT: `.claude/rules/moai/development/spec-frontmatter-schema.md`.
+
+Required 12 fields (canonical order):
+- [ ] `id: SPEC-{DOMAIN}-{NUM}` — matches `^SPEC-[A-Z][A-Z0-9]+-[0-9]{3}$`
+- [ ] `title: "Human-readable title"` — quoted string
+- [ ] `version: "X.Y.Z"` — quoted semver string (NOT `0.1` unquoted)
+- [ ] `status: draft` — enum: draft | planned | in-progress | implemented | completed | superseded | archived | rejected
+- [ ] `created: YYYY-MM-DD` — ISO date (NEVER `created_at`, NEVER `date`)
+- [ ] `updated: YYYY-MM-DD` — ISO date (NEVER `updated_at`)
+- [ ] `author: <name>` — string, not empty
+- [ ] `priority: P1` — uppercase Pn style (P0|P1|P2|P3) or High|Medium|Low|Critical
+- [ ] `phase: "vX.Y.Z target"` — release phase string
+- [ ] `module: "path/to/module"` — affected module path
+- [ ] `lifecycle: spec-anchored` — enum: spec-anchored | spec-lite | exploratory
+- [ ] `tags: "tag1, tag2, ..."` — comma-separated string (NOT `labels:`, NOT YAML array)
+
+Optional fields (do NOT include unless needed):
+- `issue_number: null` — integer or null (omit entirely when not tracking GitHub issue)
+
+Rejected legacy aliases (fail closed — do NOT accept):
+- `created_at:` (use `created:`)
+- `updated_at:` (use `updated:`)
+- `labels:` (use `tags:`)
+- `spec_id:` (use `id:`)
+
+Pre-write gate behavior:
+1. manager-spec generates frontmatter draft in memory.
+2. manager-spec self-audits against the 12-field checklist above.
+3. If any required field is missing OR any rejected alias appears: manager-spec HALTS, reports the schema violation, and re-generates. It does NOT call Write.
+4. Phase 2.3 plan-auditor independently re-verifies the schema on the written file as a second line of defense.
+
 SPEC output at: .moai/specs/SPEC-XXX/spec.md
 
 ## Phase 4: User Approval

--- a/.claude/skills/moai/workflows/plan.md
+++ b/.claude/skills/moai/workflows/plan.md
@@ -439,35 +439,41 @@ Input: Approved plan from Phase 1B, validated SPEC ID from Phase 1.5.
 File generation (all three files created simultaneously):
 
 - .moai/specs/SPEC-{ID}/spec.md
-  - YAML frontmatter with **9 required fields** (canonical schema — see checklist below)
+  - YAML frontmatter with **12 required fields** (canonical schema — see checklist below and `.claude/rules/moai/development/spec-frontmatter-schema.md`)
   - HISTORY section immediately after frontmatter
   - Complete EARS structure with all 5 requirement types
   - Content written in conversation_language
 
 #### [HARD] Pre-Write Frontmatter Checklist
 
-[HARD] Before manager-spec calls Write/MultiEdit for spec.md, it MUST validate the frontmatter contains ALL 9 required fields AND rejects 4 legacy aliases. This checklist blocks the 2026-04-21 mass-SPEC-drift pattern where 30 SPECs shipped with `created`/`updated` (wrong) and no `labels`.
+[HARD] Before manager-spec calls Write/MultiEdit for spec.md, it MUST validate the frontmatter contains ALL 12 required fields AND rejects snake_case legacy aliases. This checklist prevents dual-schema drift between the plan workflow and `internal/spec/lint.go` `FrontmatterSchemaRule`. SSOT: `.claude/rules/moai/development/spec-frontmatter-schema.md`.
 
-Required 9 fields (canonical order):
+Required 12 fields (canonical order):
 - [ ] `id: SPEC-{DOMAIN}-{NUM}` — matches `^SPEC-[A-Z][A-Z0-9]+-[0-9]{3}$`
+- [ ] `title: "Human-readable title"` — quoted string
 - [ ] `version: "X.Y.Z"` — quoted semver string (NOT `0.1` unquoted)
 - [ ] `status: draft` — enum: draft | planned | in-progress | implemented | completed | superseded | archived | rejected
-- [ ] `created_at: YYYY-MM-DD` — ISO date (NEVER `created`, NEVER `date`)
-- [ ] `updated_at: YYYY-MM-DD` — ISO date (NEVER `updated`)
+- [ ] `created: YYYY-MM-DD` — ISO date (NEVER `created_at`, NEVER `date`)
+- [ ] `updated: YYYY-MM-DD` — ISO date (NEVER `updated_at`)
 - [ ] `author: <name>` — string, not empty
-- [ ] `priority: High|Medium|Low|Critical` — Title-case (alt: P0|P1|P2|P3 uppercase)
-- [ ] `labels: [tag1, tag2, ...]` — YAML array, lowercase tags
-- [ ] `issue_number: null` — integer or null (0 if --no-issue)
+- [ ] `priority: P1` — uppercase Pn style (P0|P1|P2|P3) or High|Medium|Low|Critical
+- [ ] `phase: "vX.Y.Z target"` — release phase string
+- [ ] `module: "path/to/module"` — affected module path
+- [ ] `lifecycle: spec-anchored` — enum: spec-anchored | spec-lite | exploratory
+- [ ] `tags: "tag1, tag2, ..."` — comma-separated string (NOT `labels:`, NOT YAML array)
+
+Optional fields (do NOT include unless needed):
+- `issue_number: null` — integer or null (omit entirely when not tracking GitHub issue)
 
 Rejected legacy aliases (fail closed — do NOT accept):
-- `created:` (use `created_at:`)
-- `updated:` (use `updated_at:`)
+- `created_at:` (use `created:`)
+- `updated_at:` (use `updated:`)
+- `labels:` (use `tags:`)
 - `spec_id:` (use `id:`)
-- `title:` in frontmatter (put in H1 heading, not frontmatter)
 
 Pre-write gate behavior:
 1. manager-spec generates frontmatter draft in memory.
-2. manager-spec self-audits against the 9-field checklist above.
+2. manager-spec self-audits against the 12-field checklist above.
 3. If any required field is missing OR any rejected alias appears: manager-spec HALTS, reports the schema violation, and re-generates. It does NOT call Write.
 4. Phase 2.3 plan-auditor independently re-verifies the schema on the written file as a second line of defense.
 

--- a/.moai/specs/SPEC-V3R4-SPECLINT-DEBT-002/spec.md
+++ b/.moai/specs/SPEC-V3R4-SPECLINT-DEBT-002/spec.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-V3R4-SPECLINT-DEBT-002
 version: "0.2.0"
-status: draft
+status: planned
 created: 2026-05-16
 updated: 2026-05-16
 author: GOOS행님

--- a/internal/spec/lint.go
+++ b/internal/spec/lint.go
@@ -499,7 +499,16 @@ func (r *CoverageRule) Check(doc *SPECDoc, _ []*SPECDoc) []Finding {
 	return findings
 }
 
-// FrontmatterSchemaRule checks SPEC frontmatter schema
+// FrontmatterSchemaRule는 SPEC frontmatter 스키마를 검증한다.
+// canonical 12개 필드 (id, title, version, status, created, updated, author,
+// priority, phase, module, lifecycle, tags) 중 하나라도 누락되면 FrontmatterInvalid
+// finding을 생성한다.
+//
+// snake_case alias (created_at, updated_at, labels)는 SPECFrontmatter 구조체의
+// yaml 태그와 일치하지 않아 YAML 디코더가 무시하므로 empty string으로 처리되어
+// 동일한 finding이 발생한다.
+//
+// SSOT: .claude/rules/moai/development/spec-frontmatter-schema.md
 // Implements REQ-SPC-003-006
 type FrontmatterSchemaRule struct{}
 

--- a/internal/spec/lint_test.go
+++ b/internal/spec/lint_test.go
@@ -664,6 +664,73 @@ func TestStatusCaseNormalizationRule_Uppercase(t *testing.T) {
 	}
 }
 
+// TestFrontmatterSchemaRule_Valid12Field는 12-field canonical fixture에서
+// FrontmatterInvalid finding이 0건임을 검증한다.
+// AC-SDBT-002-002 (valid case): canonical 12 fields → 0 FrontmatterInvalid findings.
+func TestFrontmatterSchemaRule_Valid12Field(t *testing.T) {
+	linter := spec.NewLinter(spec.LinterOptions{
+		RegistryPath: testRegistryPath(),
+		BaseDir:      testdataDir,
+	})
+
+	path := filepath.Join(testdataDir, "frontmatter-schema", "valid-12-field", "spec.md")
+	report, err := linter.Lint([]string{path})
+	if err != nil {
+		t.Fatalf("Lint returned unexpected error: %v", err)
+	}
+
+	// FrontmatterInvalid findings만 추출
+	schemaFindings := findingsForCode(report.Findings, "FrontmatterInvalid")
+	if len(schemaFindings) != 0 {
+		t.Errorf("valid 12-field fixture에서 FrontmatterInvalid finding 0건 기대, 실제 %d건: %v",
+			len(schemaFindings), schemaFindings)
+	}
+}
+
+// TestFrontmatterSchemaRule_SnakeCaseRejected는 snake_case alias만 있는 fixture에서
+// FrontmatterInvalid finding이 정확히 3건 (created, updated, tags 누락)임을 검증한다.
+// AC-SDBT-002-002: snake_case aliases only (created_at/updated_at/labels) → exactly 3 FrontmatterInvalid findings.
+func TestFrontmatterSchemaRule_SnakeCaseRejected(t *testing.T) {
+	linter := spec.NewLinter(spec.LinterOptions{
+		RegistryPath: testRegistryPath(),
+		BaseDir:      testdataDir,
+	})
+
+	path := filepath.Join(testdataDir, "frontmatter-schema", "invalid-snake-case-only", "spec.md")
+	report, err := linter.Lint([]string{path})
+	if err != nil {
+		t.Fatalf("Lint returned unexpected error: %v", err)
+	}
+
+	// FrontmatterInvalid findings만 추출
+	schemaFindings := findingsForCode(report.Findings, "FrontmatterInvalid")
+
+	// 정확히 3건 (created, updated, tags 누락)
+	if len(schemaFindings) != 3 {
+		t.Fatalf("snake_case-only fixture에서 FrontmatterInvalid finding 정확히 3건 기대, 실제 %d건: %v",
+			len(schemaFindings), schemaFindings)
+	}
+
+	// 각 finding이 예상 field를 언급하는지 확인
+	expectedFields := map[string]bool{
+		"created": false,
+		"updated": false,
+		"tags":    false,
+	}
+	for _, f := range schemaFindings {
+		for field := range expectedFields {
+			if strings.Contains(f.Message, "Frontmatter required field missing: "+field) {
+				expectedFields[field] = true
+			}
+		}
+	}
+	for field, found := range expectedFields {
+		if !found {
+			t.Errorf("FrontmatterInvalid finding에서 field %q 언급 없음. findings: %v", field, schemaFindings)
+		}
+	}
+}
+
 // TestStatusCaseNormalizationRule_MixedCase는 혼합 케이스 status에서 오류를 보고함을 검증한다.
 func TestStatusCaseNormalizationRule_MixedCase(t *testing.T) {
 	doc := &spec.SPECDoc{

--- a/internal/spec/testdata/frontmatter-schema/invalid-snake-case-only/spec.md
+++ b/internal/spec/testdata/frontmatter-schema/invalid-snake-case-only/spec.md
@@ -1,0 +1,30 @@
+---
+id: SPEC-TST-INV-001
+title: "Invalid snake_case only fixture"
+version: "0.1.0"
+status: draft
+created_at: 2026-05-16
+updated_at: 2026-05-16
+author: Test Author
+priority: P1
+phase: "v3.0.0 test"
+module: "internal/spec/testdata"
+lifecycle: spec-anchored
+labels: [test, fixture, invalid]
+---
+
+# SPEC-TST-INV-001: Invalid snake_case only fixture
+
+이 fixture는 snake_case alias (`created_at:`, `updated_at:`, `labels:`)만 사용하고
+canonical field (`created:`, `updated:`, `tags:`)를 누락하여
+FrontmatterSchemaRule이 정확히 3개 FrontmatterInvalid finding을 생성함을 검증한다.
+
+## 2. Scope
+
+### 2.1 In Scope
+
+- Snake_case alias 사용 시 lint.go FrontmatterSchemaRule이 3개 finding 생성 확인
+
+### 2.2 Out of Scope
+
+- 정상 케이스 검증은 valid-12-field fixture가 담당

--- a/internal/spec/testdata/frontmatter-schema/valid-12-field/spec.md
+++ b/internal/spec/testdata/frontmatter-schema/valid-12-field/spec.md
@@ -1,0 +1,29 @@
+---
+id: SPEC-TST-VLD-001
+title: "Valid 12-field canonical fixture"
+version: "0.1.0"
+status: draft
+created: 2026-05-16
+updated: 2026-05-16
+author: Test Author
+priority: P1
+phase: "v3.0.0 test"
+module: "internal/spec/testdata"
+lifecycle: spec-anchored
+tags: "test, fixture, valid"
+---
+
+# SPEC-TST-VLD-001: Valid 12-field canonical fixture
+
+이 fixture는 lint.go FrontmatterSchemaRule이 요구하는 12개 canonical field를
+모두 보유하여 FrontmatterInvalid finding이 0건임을 검증한다.
+
+## 2. Scope
+
+### 2.1 In Scope
+
+- 12-field canonical frontmatter 사용 시 lint.go FrontmatterSchemaRule이 finding 0건 확인
+
+### 2.2 Out of Scope
+
+- snake_case alias 케이스는 invalid-snake-case-only fixture가 담당

--- a/internal/template/templates/.claude/rules/moai/development/spec-frontmatter-schema.md
+++ b/internal/template/templates/.claude/rules/moai/development/spec-frontmatter-schema.md
@@ -1,0 +1,142 @@
+---
+description: "SPEC 파일 frontmatter canonical 12-field 스키마 — Single Source of Truth (SSOT)"
+paths: "**/*.md,.moai/specs/**/*.md"
+---
+
+# SPEC Frontmatter Schema — SSOT
+
+> **Single Source of Truth** for the canonical SPEC frontmatter schema.
+> Enforcement: `internal/spec/lint.go` `FrontmatterSchemaRule` (REQ-SPC-003-006).
+> Cross-referenced by: `.claude/skills/moai/workflows/plan.md` § Pre-Write Frontmatter Checklist,
+> `.claude/skills/moai/team/plan.md` § Pre-Write Frontmatter Checklist.
+
+## Canonical 12 Required Fields
+
+All SPEC documents (`spec.md`) MUST contain exactly these 12 fields in YAML frontmatter.
+Missing any field or using a snake_case alias causes `FrontmatterInvalid` lint findings.
+
+```yaml
+---
+id: SPEC-{DOMAIN}-{NUM}
+title: "Human-readable title"
+version: "X.Y.Z"
+status: draft
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+author: Author Name
+priority: P1
+phase: "vX.Y.Z target"
+module: "path/to/module"
+lifecycle: spec-anchored
+tags: "tag1, tag2, tag3"
+---
+```
+
+## Field Reference
+
+| Field | Type | Constraints | Notes |
+|-------|------|-------------|-------|
+| `id` | string | `^SPEC-[A-Z][A-Z0-9]+-[0-9]{3}$` | Domain-namespaced identifier |
+| `title` | string | non-empty, quoted | Human-readable description |
+| `version` | string | semver `X.Y.Z`, quoted | Start at `"0.1.0"` |
+| `status` | enum | See Status Enum below | Lifecycle state |
+| `created` | date | `YYYY-MM-DD` ISO format | Creation date |
+| `updated` | date | `YYYY-MM-DD` ISO format | Last update date |
+| `author` | string | non-empty | Author name |
+| `priority` | enum | `P0`\|`P1`\|`P2`\|`P3` or `High`\|`Medium`\|`Low`\|`Critical` | Default `P1` |
+| `phase` | string | non-empty, typically release target | e.g. `"v3.0.0"` |
+| `module` | string | non-empty, path-like | Affected Go module or directory |
+| `lifecycle` | enum | `spec-anchored`\|`spec-lite`\|`exploratory` | Default `spec-anchored` |
+| `tags` | string | comma-separated, non-empty | Searchable labels |
+
+## Status Enum (8 values)
+
+```
+draft → planned → in-progress → implemented → completed
+                                         ↓
+                               superseded | archived | rejected
+```
+
+Valid values: `draft`, `planned`, `in-progress`, `implemented`, `completed`, `superseded`, `archived`, `rejected`
+
+## Optional Fields
+
+These fields may be included when needed but are NOT required by `FrontmatterSchemaRule`:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `issue_number` | integer or null | GitHub issue number. Omit entirely when not tracking. |
+| `depends_on` | list | SPEC IDs this SPEC depends on. Used by BODP signal A. |
+| `lint.skip` | list | Lint rule codes to skip. Use only for documented debt. |
+| `bc_id` | string | Backward-compatibility tracking ID. |
+
+## Rejected Snake_Case Aliases
+
+The YAML struct decoder in `internal/spec/lint.go` uses `yaml:"created"`, `yaml:"updated"`, `yaml:"tags"` tags.
+Snake_case aliases are silently dropped by the decoder, causing empty-value `FrontmatterInvalid` findings.
+
+| Do NOT use | Use instead |
+|------------|-------------|
+| `created_at:` | `created:` |
+| `updated_at:` | `updated:` |
+| `labels:` | `tags:` |
+| `spec_id:` | `id:` |
+
+## Lint Rule Implementation
+
+`FrontmatterSchemaRule` in `internal/spec/lint.go`:
+
+- **Rule code**: `FrontmatterInvalid`
+- **Severity**: Warning
+- **REQ coverage**: REQ-SPC-003-006
+- **Check**: Iterates all 12 required fields; emits one finding per missing/empty field.
+- **YAML binding**: `SPECFrontmatter` struct uses canonical field names (`created`, `updated`, `tags`).
+  Snake_case aliases in the source YAML file are not recognized — they produce empty values.
+
+See `internal/spec/lint.go` `FrontmatterSchemaRule.Check()` for the authoritative implementation.
+
+## Examples
+
+### Correct (all 12 fields, canonical names)
+
+```yaml
+---
+id: SPEC-AUTH-001
+title: "OAuth2 Authentication"
+version: "0.1.0"
+status: draft
+created: 2026-05-16
+updated: 2026-05-16
+author: GOOS Kim
+priority: P1
+phase: "v3.0.0"
+module: "internal/auth"
+lifecycle: spec-anchored
+tags: "auth, oauth2, security"
+---
+```
+
+### Wrong (snake_case aliases — produces 3 FrontmatterInvalid findings)
+
+```yaml
+---
+id: SPEC-AUTH-001
+title: "OAuth2 Authentication"
+version: "0.1.0"
+status: draft
+created_at: 2026-05-16   # WRONG — use created:
+updated_at: 2026-05-16   # WRONG — use updated:
+author: GOOS Kim
+priority: P1
+phase: "v3.0.0"
+module: "internal/auth"
+lifecycle: spec-anchored
+labels: [auth, oauth2]   # WRONG — use tags: "auth, oauth2"
+---
+```
+
+## Version History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-05-16 | SPEC-V3R4-SPECLINT-DEBT-002 | Initial creation — resolves dual-schema drift between plan.md (9-field) and lint.go (12-field) |

--- a/internal/template/templates/.claude/skills/moai/team/plan.md
+++ b/internal/template/templates/.claude/skills/moai/team/plan.md
@@ -157,6 +157,39 @@ After all research tasks complete and annotation cycle is approved:
 3. Delegate SPEC creation to manager-spec subagent (NOT a teammate) with all findings
 4. Include: codebase analysis (research.md), requirements, technical design, edge cases, reference implementations
 
+#### [HARD] Pre-Write Frontmatter Checklist
+
+[HARD] Before manager-spec calls Write/MultiEdit for spec.md, it MUST validate the frontmatter contains ALL 12 required fields AND rejects snake_case legacy aliases. This checklist prevents dual-schema drift between the plan workflow and `internal/spec/lint.go` `FrontmatterSchemaRule`. SSOT: `.claude/rules/moai/development/spec-frontmatter-schema.md`.
+
+Required 12 fields (canonical order):
+- [ ] `id: SPEC-{DOMAIN}-{NUM}` — matches `^SPEC-[A-Z][A-Z0-9]+-[0-9]{3}$`
+- [ ] `title: "Human-readable title"` — quoted string
+- [ ] `version: "X.Y.Z"` — quoted semver string (NOT `0.1` unquoted)
+- [ ] `status: draft` — enum: draft | planned | in-progress | implemented | completed | superseded | archived | rejected
+- [ ] `created: YYYY-MM-DD` — ISO date (NEVER `created_at`, NEVER `date`)
+- [ ] `updated: YYYY-MM-DD` — ISO date (NEVER `updated_at`)
+- [ ] `author: <name>` — string, not empty
+- [ ] `priority: P1` — uppercase Pn style (P0|P1|P2|P3) or High|Medium|Low|Critical
+- [ ] `phase: "vX.Y.Z target"` — release phase string
+- [ ] `module: "path/to/module"` — affected module path
+- [ ] `lifecycle: spec-anchored` — enum: spec-anchored | spec-lite | exploratory
+- [ ] `tags: "tag1, tag2, ..."` — comma-separated string (NOT `labels:`, NOT YAML array)
+
+Optional fields (do NOT include unless needed):
+- `issue_number: null` — integer or null (omit entirely when not tracking GitHub issue)
+
+Rejected legacy aliases (fail closed — do NOT accept):
+- `created_at:` (use `created:`)
+- `updated_at:` (use `updated:`)
+- `labels:` (use `tags:`)
+- `spec_id:` (use `id:`)
+
+Pre-write gate behavior:
+1. manager-spec generates frontmatter draft in memory.
+2. manager-spec self-audits against the 12-field checklist above.
+3. If any required field is missing OR any rejected alias appears: manager-spec HALTS, reports the schema violation, and re-generates. It does NOT call Write.
+4. Phase 2.3 plan-auditor independently re-verifies the schema on the written file as a second line of defense.
+
 SPEC output at: .moai/specs/SPEC-XXX/spec.md
 
 ## Phase 4: User Approval

--- a/internal/template/templates/.claude/skills/moai/workflows/plan.md
+++ b/internal/template/templates/.claude/skills/moai/workflows/plan.md
@@ -439,35 +439,41 @@ Input: Approved plan from Phase 1B, validated SPEC ID from Phase 1.5.
 File generation (all three files created simultaneously):
 
 - .moai/specs/SPEC-{ID}/spec.md
-  - YAML frontmatter with **9 required fields** (canonical schema — see checklist below)
+  - YAML frontmatter with **12 required fields** (canonical schema — see checklist below and `.claude/rules/moai/development/spec-frontmatter-schema.md`)
   - HISTORY section immediately after frontmatter
   - Complete EARS structure with all 5 requirement types
   - Content written in conversation_language
 
 #### [HARD] Pre-Write Frontmatter Checklist
 
-[HARD] Before manager-spec calls Write/MultiEdit for spec.md, it MUST validate the frontmatter contains ALL 9 required fields AND rejects 4 legacy aliases. This checklist blocks the 2026-04-21 mass-SPEC-drift pattern where 30 SPECs shipped with `created`/`updated` (wrong) and no `labels`.
+[HARD] Before manager-spec calls Write/MultiEdit for spec.md, it MUST validate the frontmatter contains ALL 12 required fields AND rejects snake_case legacy aliases. This checklist prevents dual-schema drift between the plan workflow and `internal/spec/lint.go` `FrontmatterSchemaRule`. SSOT: `.claude/rules/moai/development/spec-frontmatter-schema.md`.
 
-Required 9 fields (canonical order):
+Required 12 fields (canonical order):
 - [ ] `id: SPEC-{DOMAIN}-{NUM}` — matches `^SPEC-[A-Z][A-Z0-9]+-[0-9]{3}$`
+- [ ] `title: "Human-readable title"` — quoted string
 - [ ] `version: "X.Y.Z"` — quoted semver string (NOT `0.1` unquoted)
 - [ ] `status: draft` — enum: draft | planned | in-progress | implemented | completed | superseded | archived | rejected
-- [ ] `created_at: YYYY-MM-DD` — ISO date (NEVER `created`, NEVER `date`)
-- [ ] `updated_at: YYYY-MM-DD` — ISO date (NEVER `updated`)
+- [ ] `created: YYYY-MM-DD` — ISO date (NEVER `created_at`, NEVER `date`)
+- [ ] `updated: YYYY-MM-DD` — ISO date (NEVER `updated_at`)
 - [ ] `author: <name>` — string, not empty
-- [ ] `priority: High|Medium|Low|Critical` — Title-case (alt: P0|P1|P2|P3 uppercase)
-- [ ] `labels: [tag1, tag2, ...]` — YAML array, lowercase tags
-- [ ] `issue_number: null` — integer or null (0 if --no-issue)
+- [ ] `priority: P1` — uppercase Pn style (P0|P1|P2|P3) or High|Medium|Low|Critical
+- [ ] `phase: "vX.Y.Z target"` — release phase string
+- [ ] `module: "path/to/module"` — affected module path
+- [ ] `lifecycle: spec-anchored` — enum: spec-anchored | spec-lite | exploratory
+- [ ] `tags: "tag1, tag2, ..."` — comma-separated string (NOT `labels:`, NOT YAML array)
+
+Optional fields (do NOT include unless needed):
+- `issue_number: null` — integer or null (omit entirely when not tracking GitHub issue)
 
 Rejected legacy aliases (fail closed — do NOT accept):
-- `created:` (use `created_at:`)
-- `updated:` (use `updated_at:`)
+- `created_at:` (use `created:`)
+- `updated_at:` (use `updated:`)
+- `labels:` (use `tags:`)
 - `spec_id:` (use `id:`)
-- `title:` in frontmatter (put in H1 heading, not frontmatter)
 
 Pre-write gate behavior:
 1. manager-spec generates frontmatter draft in memory.
-2. manager-spec self-audits against the 9-field checklist above.
+2. manager-spec self-audits against the 12-field checklist above.
 3. If any required field is missing OR any rejected alias appears: manager-spec HALTS, reports the schema violation, and re-generates. It does NOT call Write.
 4. Phase 2.3 plan-auditor independently re-verifies the schema on the written file as a second line of defense.
 


### PR DESCRIPTION
## Summary

- `plan.md` Pre-Write Frontmatter Checklist를 9-field snake_case에서 12-field canonical로 정렬 (local + template 동기화)
- `spec-frontmatter-schema.md` SSOT 문서 신설 — 12개 필수 필드 레퍼런스, 상태 enum, 거부 alias 목록, 예시 (local + template 동기화)
- `team/plan.md` Pre-Write Frontmatter Checklist 섹션 삽입 (solo plan.md와 동일 내용)
- `lint.go` `FrontmatterSchemaRule` godoc → SSOT 크로스레퍼런스 추가
- TDD 픽스처 2건 + 테스트 2건: `TestFrontmatterSchemaRule_Valid12Field` / `TestFrontmatterSchemaRule_SnakeCaseRejected`
- `status: planned` (git-implied `planned` 정합)

## Acceptance Criteria

- [x] AC-SLD2-001: `TestFrontmatterSchemaRule_Valid12Field` PASS (valid 12-field → 0 findings)
- [x] AC-SLD2-002: `TestFrontmatterSchemaRule_SnakeCaseRejected` PASS (snake_case → exactly 3 FrontmatterInvalid findings)
- [x] AC-SLD2-003: `plan.md` Pre-Write Checklist 12-field canonical 정렬 (local + template)
- [x] AC-SLD2-004: `spec-frontmatter-schema.md` SSOT 신설 (local + template)
- [x] AC-SLD2-005: `team/plan.md` Checklist 삽입 (local + template)
- [x] AC-SLD2-006: `moai spec lint --strict .moai/specs/SPEC-V3R4-SPECLINT-DEBT-002/spec.md` exit 0
- [x] `go test ./...` 전체 PASS

## Test Plan

- [ ] CI: Lint / Test ubuntu/macos/windows / Build 5플랫폼 all green 확인
- [ ] `go test ./internal/spec/ -run TestFrontmatterSchemaRule -v` → 2 PASS
- [ ] `moai spec lint --strict` exit 0

## Scope (F-OUT-001 준수)

- `internal/spec/lint.go` FrontmatterSchemaRule 로직 변경 없음 (godoc만)
- 기존 snake_case SPEC 마이그레이션 없음

🗿 MoAI <email@mo.ai.kr>