### PR TITLE
chore(rules): AC-WTD-007 follow-up — skills run.md/team/run.md worktree [HARD]→[SHOULD]

### DIFF
--- a/.claude/skills/moai/team/run.md
+++ b/.claude/skills/moai/team/run.md
@@ -346,7 +346,7 @@ Agent(subagent_type: "general-purpose", team_name: "moai-run-SPEC-XXX", name: "f
 Agent(subagent_type: "general-purpose", team_name: "moai-run-SPEC-XXX", name: "tester", model: "sonnet", mode: "acceptEdits", isolation: "worktree", prompt: "Testing role. File ownership: test files exclusively. ...")
 ```
 
-[HARD] All implementation teammates MUST use `isolation: "worktree"` for parallel file safety.
+[SHOULD] When spawning implementation teammates via `Agent(isolation: "worktree")`, Claude Code runtime decides whether to materialize an L1 worktree. MoAI orchestrator does NOT mandate isolation. Per user policy 2026-05-17 (`feedback_worktree_autonomous`), L2/L3 worktree usage is user opt-in. See `.claude/rules/moai/workflow/worktree-integration.md` § Terminology Glossary for L1/L2/L3 layer definitions.
 
 ### Phase 3: Handle Idle Notifications
 

--- a/.claude/skills/moai/workflows/run.md
+++ b/.claude/skills/moai/workflows/run.md
@@ -998,8 +998,8 @@ Team composition: backend-dev (inherit) + frontend-dev (inherit) + tester (inher
 
 ### Worktree Isolation [HARD]
 
-- [HARD] Implementation teammates (backend-dev, frontend-dev, tester) MUST use `isolation: "worktree"` when spawned via Agent()
-- [HARD] Read-only teammates (quality) MUST NOT use `isolation: "worktree"` — permissionMode: plan is sufficient
+- [SHOULD] When spawning implementation teammates (backend-dev, frontend-dev, tester) via `Agent(isolation: "worktree")`, Claude Code runtime decides whether to materialize an L1 worktree. MoAI orchestrator does NOT mandate isolation (per user policy 2026-05-17 `feedback_worktree_autonomous`).
+- [SHOULD] Read-only teammates (quality) typically do not benefit from `isolation: "worktree"`; omit the flag unless a specific reason applies. `permissionMode: plan` is sufficient.
 - [HARD] All worktree path rules from "Worktree Path Rules [HARD] (All Modes)" section above apply to team mode as well
 - After team shutdown, run `git worktree prune` to clean up stale worktree references
 

--- a/internal/template/templates/.claude/skills/moai/team/run.md
+++ b/internal/template/templates/.claude/skills/moai/team/run.md
@@ -346,7 +346,7 @@ Agent(subagent_type: "general-purpose", team_name: "moai-run-SPEC-XXX", name: "f
 Agent(subagent_type: "general-purpose", team_name: "moai-run-SPEC-XXX", name: "tester", model: "sonnet", mode: "acceptEdits", isolation: "worktree", prompt: "Testing role. File ownership: test files exclusively. ...")
 ```
 
-[HARD] All implementation teammates MUST use `isolation: "worktree"` for parallel file safety.
+[SHOULD] When spawning implementation teammates via `Agent(isolation: "worktree")`, Claude Code runtime decides whether to materialize an L1 worktree. MoAI orchestrator does NOT mandate isolation. Per user policy 2026-05-17 (`feedback_worktree_autonomous`), L2/L3 worktree usage is user opt-in. See `.claude/rules/moai/workflow/worktree-integration.md` § Terminology Glossary for L1/L2/L3 layer definitions.
 
 ### Phase 3: Handle Idle Notifications
 

--- a/internal/template/templates/.claude/skills/moai/workflows/run.md
+++ b/internal/template/templates/.claude/skills/moai/workflows/run.md
@@ -998,8 +998,8 @@ Team composition: backend-dev (inherit) + frontend-dev (inherit) + tester (inher
 
 ### Worktree Isolation [HARD]
 
-- [HARD] Implementation teammates (backend-dev, frontend-dev, tester) MUST use `isolation: "worktree"` when spawned via Agent()
-- [HARD] Read-only teammates (quality) MUST NOT use `isolation: "worktree"` — permissionMode: plan is sufficient
+- [SHOULD] When spawning implementation teammates (backend-dev, frontend-dev, tester) via `Agent(isolation: "worktree")`, Claude Code runtime decides whether to materialize an L1 worktree. MoAI orchestrator does NOT mandate isolation (per user policy 2026-05-17 `feedback_worktree_autonomous`).
+- [SHOULD] Read-only teammates (quality) typically do not benefit from `isolation: "worktree"`; omit the flag unless a specific reason applies. `permissionMode: plan` is sufficient.
 - [HARD] All worktree path rules from "Worktree Path Rules [HARD] (All Modes)" section above apply to team mode as well
 - After team shutdown, run `git worktree prune` to clean up stale worktree references
 


### PR DESCRIPTION
DOCS-001 AC-WTD-007 비차단 findings 영구 해소. 2 stale `[HARD] MUST use isolation: "worktree"` mandates → `[SHOULD]` advisory + feedback_worktree_autonomous cross-reference. 4 files (local + templates). SPEC-WORKTREE-DOCS-001 lifecycle 100% closure.