### PR TITLE
feat(SPEC-V3R3-UPDATE-CLEANUP-001): moai update 멱등 배포 + 폐기 경로 정리

### DIFF
--- a/.moai/specs/SPEC-V3R3-UPDATE-CLEANUP-001/plan.md
+++ b/.moai/specs/SPEC-V3R3-UPDATE-CLEANUP-001/plan.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-V3R3-UPDATE-CLEANUP-001
 version: "0.2.3"
-status: draft
+status: implemented
 created_at: 2026-05-01
 updated_at: 2026-05-04
 author: manager-spec

--- a/.moai/specs/SPEC-V3R3-UPDATE-CLEANUP-001/spec.md
+++ b/.moai/specs/SPEC-V3R3-UPDATE-CLEANUP-001/spec.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-V3R3-UPDATE-CLEANUP-001
 version: "0.2.3"
-status: in-progress
+status: implemented
 created_at: 2026-05-01
 updated_at: 2026-05-04
 author: manager-spec

--- a/internal/cli/update_cleanup.go
+++ b/internal/cli/update_cleanup.go
@@ -1,0 +1,457 @@
+// Package cli — update_cleanup.go
+// Implements SPEC-V3R3-UPDATE-CLEANUP-001: deprecated path detection, backup,
+// user confirmation, manifest provenance classification, telemetry, symlink
+// safety, and lock file management for `moai update`.
+
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/modu-ai/moai-adk/internal/defs"
+	"github.com/modu-ai/moai-adk/internal/manifest"
+)
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const (
+	// updateLockFile is the path of the lock file relative to .moai/.
+	// JSON payload: {pid, started_at, hostname} (OQ4, spec.md §6).
+	updateLockFile = ".update.lock"
+
+	// BackupDirPrefix is the prefix for the dated backup directory (REQ-UPC-009).
+	BackupDirPrefix = "agency-"
+
+	// cleanupSpecID is the SPEC ID recorded in backup MANIFEST.json (REQ-UPC-011).
+	cleanupSpecID = "SPEC-V3R3-UPDATE-CLEANUP-001"
+)
+
+// ErrUpdateLockHeld is returned when a concurrent moai update is already running.
+var ErrUpdateLockHeld = errors.New("moai update is already running (lock held by another process)")
+
+// ---------------------------------------------------------------------------
+// M1 — Lock file management (REQ-UPC-005, NFR-UPC-S2)
+// ---------------------------------------------------------------------------
+
+// updateLockPayload is the JSON schema stored in .moai/.update.lock (OQ4).
+type updateLockPayload struct {
+	PID       int    `json:"pid"`
+	StartedAt string `json:"started_at"`
+	Hostname  string `json:"hostname"`
+}
+
+// acquireUpdateLock creates the lock file under <projectRoot>/.moai/.update.lock.
+// On success it returns a release function that removes the lock file.
+// If the lock is already held by a live process it returns ErrUpdateLockHeld.
+func acquireUpdateLock(projectRoot string) (release func(), err error) {
+	lockPath := filepath.Join(projectRoot, defs.MoAIDir, updateLockFile)
+
+	// Attempt to detect and clean a stale lock first.
+	cleanStaleLock(lockPath)
+
+	// Try to create the lock file exclusively.
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+	if err != nil {
+		if os.IsExist(err) {
+			return nil, ErrUpdateLockHeld
+		}
+		return nil, fmt.Errorf("create lock file %q: %w", lockPath, err)
+	}
+
+	hostname, _ := os.Hostname()
+	payload := updateLockPayload{
+		PID:       os.Getpid(),
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+		Hostname:  hostname,
+	}
+	data, _ := json.Marshal(payload)
+	_, _ = f.Write(data)
+	_ = f.Close()
+
+	return func() { _ = os.Remove(lockPath) }, nil
+}
+
+// cleanStaleLock removes the lock file if it belongs to a dead process.
+// Stale detection: parse PID from JSON payload and check if the process exists.
+func cleanStaleLock(lockPath string) {
+	data, err := os.ReadFile(lockPath)
+	if err != nil {
+		return // no lock file or unreadable — not stale
+	}
+	var payload updateLockPayload
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return // malformed — leave it; real lock may be writing
+	}
+	if payload.PID <= 0 {
+		return
+	}
+	if !isProcessAlive(payload.PID) {
+		_ = os.Remove(lockPath)
+	}
+}
+
+// isProcessAlive reports whether a process with the given PID is alive.
+// Uses syscall.Kill(pid, 0) on Unix (signal 0 checks existence without killing).
+// EPERM means the process exists but is owned by another user — still alive.
+// ESRCH means the process does not exist.
+// On Windows, always returns true (conservative; avoids platform-specific APIs).
+func isProcessAlive(pid int) bool {
+	if runtime.GOOS == "windows" {
+		return true // conservative: assume alive to avoid stale-lock false-positive
+	}
+	err := syscall.Kill(pid, 0)
+	if err == nil {
+		return true // process exists and we can signal it
+	}
+	if errors.Is(err, syscall.EPERM) {
+		return true // process exists but owned by different user
+	}
+	// syscall.ESRCH: no such process → stale
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// M2 — Deprecated path detection (REQ-UPC-007, REQ-UPC-024, REQ-UPC-025)
+// ---------------------------------------------------------------------------
+
+// scanDeprecatedPaths returns the slash-relative paths (relative to projectRoot)
+// of deprecated files that exist in the project. Paths under .moai/backup/ and
+// .moai/logs/ are excluded (REQ-UPC-024). Absent files are silently skipped
+// (REQ-UPC-025).
+func scanDeprecatedPaths(projectRoot string) ([]string, error) {
+	var found []string
+	for _, entry := range defs.DeprecatedPaths {
+		rel := filepath.ToSlash(entry.Path)
+		// Exclude self-referential backup and logs paths (REQ-UPC-024)
+		if strings.HasPrefix(rel, ".moai/backup/") ||
+			strings.HasPrefix(rel, ".moai/logs/") {
+			continue
+		}
+		abs := filepath.Join(projectRoot, filepath.FromSlash(rel))
+		// Use Lstat so we detect symlinks without following them.
+		if _, err := os.Lstat(abs); err != nil {
+			if os.IsNotExist(err) {
+				continue // silent skip (REQ-UPC-025)
+			}
+			return nil, fmt.Errorf("stat deprecated path %q: %w", rel, err)
+		}
+		found = append(found, rel)
+	}
+	return found, nil
+}
+
+// ---------------------------------------------------------------------------
+// M2 — Skip marker (REQ-UPC-018)
+// ---------------------------------------------------------------------------
+
+// filterSkipMarkerPaths partitions paths into (filtered, skipped).
+// A path is skipped if its containing directory has a .moai-skip-cleanup marker.
+// Skipped paths are logged to out with an [INFO] line.
+func filterSkipMarkerPaths(projectRoot string, paths []string, out io.Writer) (filtered, skipped []string) {
+	checkedDirs := make(map[string]bool)
+	for _, rel := range paths {
+		dir := filepath.Dir(filepath.FromSlash(rel))
+		skipDir, ok := checkedDirs[dir]
+		if !ok {
+			markerPath := filepath.Join(projectRoot, dir, ".moai-skip-cleanup")
+			_, err := os.Stat(markerPath)
+			skipDir = err == nil
+			checkedDirs[dir] = skipDir
+			if skipDir {
+				_, _ = fmt.Fprintf(out, "[INFO] cleanup skipped due to .moai-skip-cleanup marker: %s\n",
+					filepath.ToSlash(dir))
+			}
+		}
+		if skipDir {
+			skipped = append(skipped, rel)
+		} else {
+			filtered = append(filtered, rel)
+		}
+	}
+	return filtered, skipped
+}
+
+// ---------------------------------------------------------------------------
+// M2 — Backup (REQ-UPC-009, REQ-UPC-010, REQ-UPC-011)
+// ---------------------------------------------------------------------------
+
+// BackupManifestFile is the file written to the backup directory.
+type BackupManifestFile struct {
+	SpecID    string            `json:"spec_id"`
+	DeletedAt time.Time         `json:"deleted_at"`
+	Files     []BackupFileEntry `json:"files"`
+}
+
+// BackupFileEntry records metadata for one backed-up file.
+type BackupFileEntry struct {
+	Path               string `json:"path"`
+	Hash               string `json:"hash"`
+	Classification     string `json:"classification"`
+	SymlinkTarget      string `json:"symlink_target,omitempty"`
+	SymlinkTargetStatus string `json:"symlink_target_status,omitempty"`
+}
+
+// backupDeprecatedPaths copies each path from the project into a dated backup
+// directory and writes a MANIFEST.json. Returns the backup directory path.
+// If any copy fails the entire operation is aborted (REQ-UPC-010).
+func backupDeprecatedPaths(projectRoot string, paths []string, mgr manifest.Manager) (string, error) {
+	if len(paths) == 0 {
+		return "", nil
+	}
+
+	ts := time.Now().UTC().Format("2006-01-02T15-04-05Z")
+	backupDir := filepath.Join(projectRoot, defs.MoAIDir, "backup",
+		BackupDirPrefix+ts)
+	if err := os.MkdirAll(backupDir, 0o755); err != nil {
+		return "", fmt.Errorf("create backup dir %q: %w", backupDir, err)
+	}
+
+	manifest := BackupManifestFile{
+		SpecID:    cleanupSpecID,
+		DeletedAt: time.Now().UTC(),
+	}
+
+	for _, rel := range paths {
+		srcPath := filepath.Join(projectRoot, filepath.FromSlash(rel))
+		info := inspectDeprecatedPath(srcPath)
+		class := classifyDeprecatedFile(projectRoot, rel, mgr)
+
+		entry := BackupFileEntry{
+			Path:           rel,
+			Classification: string(class),
+		}
+
+		if info.IsSymlink {
+			entry.SymlinkTarget = info.SymlinkTarget
+			entry.SymlinkTargetStatus = info.SymlinkTargetStatus
+			// For symlinks we record metadata only — do not copy the target.
+		} else {
+			// Copy file contents preserving directory structure
+			destPath := filepath.Join(backupDir, filepath.FromSlash(rel))
+			if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+				return "", fmt.Errorf("backup mkdir %q: %w", filepath.Dir(destPath), err)
+			}
+			data, err := os.ReadFile(srcPath)
+			if err != nil {
+				return "", fmt.Errorf("backup read %q: %w", rel, err)
+			}
+			if err := os.WriteFile(destPath, data, 0o644); err != nil {
+				return "", fmt.Errorf("backup write %q: %w", rel, err)
+			}
+			entry.Hash = manifest2hashBytes(data)
+		}
+
+		manifest.Files = append(manifest.Files, entry)
+	}
+
+	// Write MANIFEST.json
+	manifestData, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal MANIFEST.json: %w", err)
+	}
+	manifestPath := filepath.Join(backupDir, "MANIFEST.json")
+	if err := os.WriteFile(manifestPath, manifestData, 0o644); err != nil {
+		return "", fmt.Errorf("write MANIFEST.json: %w", err)
+	}
+
+	return backupDir, nil
+}
+
+// manifest2hashBytes is a helper that avoids importing the manifest package's
+// internal hash directly; uses the same SHA-256 via manifest.HashBytes facade.
+func manifest2hashBytes(data []byte) string {
+	return manifest.HashBytes(data)
+}
+
+// ---------------------------------------------------------------------------
+// M3 — Path inspection (symlink detection, REQ-UPC-023)
+// ---------------------------------------------------------------------------
+
+// DeprecatedPathInfo describes metadata about a deprecated path on the filesystem.
+type DeprecatedPathInfo struct {
+	IsSymlink           bool
+	SymlinkTarget       string
+	SymlinkTargetStatus string // "ok" | "broken"
+}
+
+// inspectDeprecatedPath uses os.Lstat to determine whether a path is a symlink
+// and, if so, whether the target exists (REQ-UPC-023).
+func inspectDeprecatedPath(abs string) DeprecatedPathInfo {
+	linfo, err := os.Lstat(abs)
+	if err != nil {
+		return DeprecatedPathInfo{}
+	}
+	if linfo.Mode()&os.ModeSymlink == 0 {
+		return DeprecatedPathInfo{IsSymlink: false}
+	}
+	target, err := os.Readlink(abs)
+	if err != nil {
+		return DeprecatedPathInfo{IsSymlink: true, SymlinkTargetStatus: "broken"}
+	}
+	// Check if target exists
+	status := "ok"
+	if _, err := os.Stat(abs); err != nil { // follows the link
+		status = "broken"
+	}
+	return DeprecatedPathInfo{
+		IsSymlink:           true,
+		SymlinkTarget:       target,
+		SymlinkTargetStatus: status,
+	}
+}
+
+// removeDeprecatedFile removes a deprecated file or symlink from the project.
+// For symlinks, only the link itself is removed (target is preserved).
+func removeDeprecatedFile(abs string) error {
+	// Use Lstat to avoid following symlinks
+	info, err := os.Lstat(abs)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // already gone
+		}
+		return fmt.Errorf("lstat %q: %w", abs, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		// Regular file or symlink: use os.Remove (does not follow symlinks)
+		return os.Remove(abs)
+	}
+	// Directory: use RemoveAll
+	return os.RemoveAll(abs)
+}
+
+// ---------------------------------------------------------------------------
+// M3 — Provenance classification (REQ-UPC-015a/b/c)
+// ---------------------------------------------------------------------------
+
+// DeprecatedClassification describes how a deprecated file was classified.
+type DeprecatedClassification string
+
+const (
+	DeprecatedPristine     DeprecatedClassification = "PristineDeprecated"
+	DeprecatedUserModified DeprecatedClassification = "UserModifiedDeprecated"
+	DeprecatedUnverified   DeprecatedClassification = "UnverifiedDeprecated"
+)
+
+// classifyDeprecatedFile compares the current file content hash against the
+// manifest DeployedHash and returns the appropriate classification.
+func classifyDeprecatedFile(projectRoot, relPath string, mgr manifest.Manager) DeprecatedClassification {
+	entry, found := mgr.GetEntry(relPath)
+	if !found {
+		return DeprecatedUnverified
+	}
+	abs := filepath.Join(projectRoot, filepath.FromSlash(relPath))
+	data, err := os.ReadFile(abs)
+	if err != nil {
+		return DeprecatedUnverified
+	}
+	currentHash := manifest.HashBytes(data)
+	if currentHash == entry.DeployedHash {
+		return DeprecatedPristine
+	}
+	return DeprecatedUserModified
+}
+
+// ---------------------------------------------------------------------------
+// M3 — Telemetry (REQ-UPC-022)
+// ---------------------------------------------------------------------------
+
+// CleanupEvent is the structured telemetry record emitted at cleanup phase end.
+type CleanupEvent struct {
+	AtomicWriteUsed       bool     `json:"atomic_write_used"`
+	PreUpdateSuffix2Files []string `json:"pre_update_suffix2_files"`
+	BackupOutcome         string   `json:"backup_outcome"`  // "success" | "skipped" | "failed"
+	BackupPath            string   `json:"backup_path"`
+	CleanupOutcome        string   `json:"cleanup_outcome"` // "completed" | "deferred" | "aborted"
+	UserOptOutPaths       []string `json:"user_opt_out_paths"`
+}
+
+// ---------------------------------------------------------------------------
+// M4 — Case-insensitive filesystem probe (REQ-UPC-026)
+// ---------------------------------------------------------------------------
+
+// probeCaseSensitiveFS probes the filesystem rooted at projectRoot by creating a
+// temporary file then attempting to stat it with an upper-case variant.
+//
+//   - Returns (true, nil) when the FS is case-sensitive (Linux ext4 default).
+//   - Returns (false, nil) when the FS is case-insensitive (macOS APFS default).
+//   - Returns (true, nil) on probe failure (fallback to safe case-sensitive mode)
+//     and logs a [INFO] message to stderr (REQ-UPC-026 probe-failure fallback).
+//
+// The probe file is always cleaned up before returning (REQ-UPC-026).
+func probeCaseSensitiveFS(projectRoot string) (caseSensitive bool, _ error) {
+	probeFile := filepath.Join(projectRoot, ".moai-fscase-probe")
+
+	// Write lower-case probe file.
+	if err := os.WriteFile(probeFile, []byte("probe"), 0o600); err != nil {
+		// Cannot write → fallback to case-sensitive (safe default).
+		// Not an error from caller perspective; probe just couldn't run.
+		return true, nil
+	}
+	defer os.Remove(probeFile) //nolint:errcheck
+
+	// Attempt to stat the UPPER-CASE variant of the probe file.
+	upperProbe := filepath.Join(projectRoot, ".MOAI-FSCASE-PROBE")
+	_, err := os.Stat(upperProbe)
+	if err == nil {
+		// Upper-case path found → filesystem is case-insensitive.
+		return false, nil
+	}
+	if os.IsNotExist(err) {
+		// Upper-case path not found → filesystem is case-sensitive.
+		return true, nil
+	}
+	// Unexpected error → fallback to case-sensitive.
+	return true, nil
+}
+
+// emitCleanupTelemetry writes the CleanupEvent as a JSON line to:
+//  1. A dated file in <projectRoot>/.moai/logs/update-cleanup-{ts}.jsonl
+//  2. stderr (mirror for observability)
+//
+// If the log file cannot be written (e.g., chmod 0500 on parent), it emits a
+// [WARN] to stderr and continues without returning an error (REQ-UPC-022 D-02-03).
+func emitCleanupTelemetry(projectRoot string, event CleanupEvent, stderr io.Writer) error {
+	// Ensure slices are non-nil for consistent JSON output
+	if event.PreUpdateSuffix2Files == nil {
+		event.PreUpdateSuffix2Files = []string{}
+	}
+	if event.UserOptOutPaths == nil {
+		event.UserOptOutPaths = []string{}
+	}
+
+	data, err := json.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("marshal telemetry event: %w", err)
+	}
+	line := string(data) + "\n"
+
+	// Mirror to stderr always
+	_, _ = fmt.Fprint(stderr, line)
+
+	// Persist to file
+	logsDir := filepath.Join(projectRoot, defs.MoAIDir, defs.LogsSubdir)
+	if err := os.MkdirAll(logsDir, 0o755); err != nil {
+		_, _ = fmt.Fprintf(stderr, "[WARN] telemetry persistence skipped: cannot create %s: %v\n",
+			logsDir, err)
+		return nil // not a fatal error (REQ-UPC-022)
+	}
+
+	ts := time.Now().UTC().Format("2006-01-02T15-04-05Z")
+	logPath := filepath.Join(logsDir, "update-cleanup-"+ts+".jsonl")
+	if err := os.WriteFile(logPath, []byte(line), 0o644); err != nil {
+		_, _ = fmt.Fprintf(stderr, "[WARN] telemetry persistence skipped: %v\n", err)
+		return nil // not a fatal error
+	}
+	return nil
+}

--- a/internal/cli/update_cleanup_test.go
+++ b/internal/cli/update_cleanup_test.go
@@ -1,0 +1,684 @@
+// SPEC-V3R3-UPDATE-CLEANUP-001 — Unit tests for M1~M3 cleanup functionality.
+// Coverage: atomic write lock (M1), deprecated path detection/backup (M2),
+// user confirmation + provenance + telemetry + symlink safety (M3).
+
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/modu-ai/moai-adk/internal/defs"
+	"github.com/modu-ai/moai-adk/internal/manifest"
+)
+
+// ---------------------------------------------------------------------------
+// M1: Lock file (concurrent execution prevention)
+// ---------------------------------------------------------------------------
+
+// TestUpdate_ConcurrentLock verifies that a second acquireUpdateLock call fails
+// while the lock is held by the first call.
+func TestUpdate_ConcurrentLock(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	lockPath := filepath.Join(root, defs.MoAIDir, updateLockFile)
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	// First lock acquisition should succeed.
+	release, err := acquireUpdateLock(root)
+	if err != nil {
+		t.Fatalf("first acquireUpdateLock: %v", err)
+	}
+	t.Cleanup(release) // ensure released even if test panics
+
+	// Second acquisition should fail with ErrUpdateLockHeld.
+	_, err2 := acquireUpdateLock(root)
+	if !errors.Is(err2, ErrUpdateLockHeld) {
+		t.Errorf("expected ErrUpdateLockHeld, got: %v", err2)
+	}
+
+	// After release, a third acquisition should succeed.
+	release()
+	release3, err3 := acquireUpdateLock(root)
+	if err3 != nil {
+		t.Fatalf("third acquireUpdateLock after release: %v", err3)
+	}
+	release3()
+}
+
+// TestUpdate_LockFileJSON verifies that the lock file contains valid JSON
+// with pid, started_at, and hostname fields (OQ4 spec).
+func TestUpdate_LockFileJSON(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, defs.MoAIDir), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	release, err := acquireUpdateLock(root)
+	if err != nil {
+		t.Fatalf("acquireUpdateLock: %v", err)
+	}
+	defer release()
+
+	lockPath := filepath.Join(root, defs.MoAIDir, updateLockFile)
+	data, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatalf("read lock file: %v", err)
+	}
+
+	var lockInfo map[string]interface{}
+	if err := json.Unmarshal(data, &lockInfo); err != nil {
+		t.Fatalf("lock file is not valid JSON: %v\ncontent: %s", err, data)
+	}
+
+	for _, field := range []string{"pid", "started_at", "hostname"} {
+		if _, ok := lockInfo[field]; !ok {
+			t.Errorf("lock file missing field %q", field)
+		}
+	}
+}
+
+// TestUpdate_LockCleanedUpOnRelease verifies the lock file is removed after release.
+func TestUpdate_LockCleanedUpOnRelease(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, defs.MoAIDir), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	release, err := acquireUpdateLock(root)
+	if err != nil {
+		t.Fatalf("acquireUpdateLock: %v", err)
+	}
+	release()
+
+	lockPath := filepath.Join(root, defs.MoAIDir, updateLockFile)
+	if _, statErr := os.Stat(lockPath); !os.IsNotExist(statErr) {
+		t.Errorf("lock file should be removed after release, but Stat returned: %v", statErr)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// M2: Deprecated path detection + backup + skip marker
+// ---------------------------------------------------------------------------
+
+// setupProjectWithAgency creates a temp project containing the agency deprecated
+// files with the given content for each file.
+func setupProjectWithAgency(t *testing.T, content string) string {
+	t.Helper()
+	root := t.TempDir()
+	for _, p := range defs.DeprecatedPaths {
+		fullPath := filepath.Join(root, filepath.FromSlash(p.Path))
+		if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+			t.Fatalf("MkdirAll %q: %v", filepath.Dir(fullPath), err)
+		}
+		if err := os.WriteFile(fullPath, []byte(content), 0o644); err != nil {
+			t.Fatalf("WriteFile %q: %v", fullPath, err)
+		}
+	}
+	return root
+}
+
+// TestCleanup_AgencyPathsDetected verifies that agency files are detected by
+// scanDeprecatedPaths.
+func TestCleanup_AgencyPathsDetected(t *testing.T) {
+	t.Parallel()
+	root := setupProjectWithAgency(t, "# agency content")
+
+	found, err := scanDeprecatedPaths(root)
+	if err != nil {
+		t.Fatalf("scanDeprecatedPaths: %v", err)
+	}
+	if len(found) == 0 {
+		t.Error("expected to find deprecated paths, got none")
+	}
+	if len(found) != len(defs.DeprecatedPaths) {
+		t.Errorf("found %d deprecated paths, want %d", len(found), len(defs.DeprecatedPaths))
+	}
+}
+
+// TestCleanup_NoOpWhenAbsent verifies that scanDeprecatedPaths returns nothing
+// when no agency files are present.
+func TestCleanup_NoOpWhenAbsent(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+
+	found, err := scanDeprecatedPaths(root)
+	if err != nil {
+		t.Fatalf("scanDeprecatedPaths: %v", err)
+	}
+	if len(found) != 0 {
+		t.Errorf("expected 0 deprecated paths, got %d", len(found))
+	}
+}
+
+// TestCleanup_DeletedFileSkipped verifies that a path registered in DeprecatedPaths
+// but absent from the project is silently skipped (REQ-UPC-025).
+func TestCleanup_DeletedFileSkipped(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir() // empty — no agency files
+
+	found, err := scanDeprecatedPaths(root)
+	if err != nil {
+		t.Fatalf("scanDeprecatedPaths: %v", err)
+	}
+	// No file = no results (silent skip)
+	if len(found) != 0 {
+		t.Errorf("expected 0 for absent deprecated paths, got %d: %v", len(found), found)
+	}
+}
+
+// TestCleanup_BackupCreated verifies that backupDeprecatedPaths creates a backup
+// directory with a MANIFEST.json and the original files.
+func TestCleanup_BackupCreated(t *testing.T) {
+	t.Parallel()
+	root := setupProjectWithAgency(t, "# backup test")
+
+	found, err := scanDeprecatedPaths(root)
+	if err != nil {
+		t.Fatalf("scanDeprecatedPaths: %v", err)
+	}
+
+	mgr := newManifestManagerForTest(t, root)
+	backupDir, err := backupDeprecatedPaths(root, found, mgr)
+	if err != nil {
+		t.Fatalf("backupDeprecatedPaths: %v", err)
+	}
+
+	// MANIFEST.json must exist
+	manifestPath := filepath.Join(backupDir, "MANIFEST.json")
+	if _, err := os.Stat(manifestPath); err != nil {
+		t.Errorf("MANIFEST.json missing in backup dir %q: %v", backupDir, err)
+	}
+
+	// At least one backed-up file must exist
+	var fileCount int
+	_ = filepath.WalkDir(backupDir, func(p string, d os.DirEntry, _ error) error {
+		if !d.IsDir() && filepath.Base(p) != "MANIFEST.json" {
+			fileCount++
+		}
+		return nil
+	})
+	if fileCount == 0 {
+		t.Error("backup directory contains no files")
+	}
+}
+
+// TestCleanup_BackupManifestFields verifies that MANIFEST.json contains the
+// required fields per REQ-UPC-011 and REQ-UPC-017.
+func TestCleanup_BackupManifestFields(t *testing.T) {
+	t.Parallel()
+	root := setupProjectWithAgency(t, "# manifest fields test")
+
+	found, _ := scanDeprecatedPaths(root)
+	mgr := newManifestManagerForTest(t, root)
+	backupDir, err := backupDeprecatedPaths(root, found, mgr)
+	if err != nil {
+		t.Fatalf("backupDeprecatedPaths: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(backupDir, "MANIFEST.json"))
+	if err != nil {
+		t.Fatalf("read MANIFEST.json: %v", err)
+	}
+
+	var m backupManifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal MANIFEST.json: %v", err)
+	}
+
+	if m.SpecID == "" {
+		t.Error("MANIFEST.json missing spec_id")
+	}
+	if m.DeletedAt.IsZero() {
+		t.Error("MANIFEST.json missing deleted_at")
+	}
+	if len(m.Files) == 0 {
+		t.Error("MANIFEST.json has no file entries")
+	}
+}
+
+// TestCleanup_SkipMarkerHonored verifies that a directory containing
+// .moai-skip-cleanup is skipped (REQ-UPC-018).
+func TestCleanup_SkipMarkerHonored(t *testing.T) {
+	t.Parallel()
+	root := setupProjectWithAgency(t, "# skip marker test")
+
+	// Place .moai-skip-cleanup in the agency commands directory.
+	skipDir := filepath.Join(root, ".claude", "commands", "agency")
+	markerPath := filepath.Join(skipDir, ".moai-skip-cleanup")
+	if err := os.WriteFile(markerPath, []byte{}, 0o644); err != nil {
+		t.Fatalf("WriteFile marker: %v", err)
+	}
+
+	found, err := scanDeprecatedPaths(root)
+	if err != nil {
+		t.Fatalf("scanDeprecatedPaths: %v", err)
+	}
+
+	var out bytes.Buffer
+	filtered, skipped := filterSkipMarkerPaths(root, found, &out)
+
+	if len(skipped) == 0 {
+		t.Error("expected at least one path skipped due to .moai-skip-cleanup marker")
+	}
+	// Paths in the skipped directory must not appear in filtered.
+	for _, p := range filtered {
+		if strings.HasPrefix(filepath.ToSlash(p), ".claude/commands/agency/") {
+			t.Errorf("path %q should be filtered out (skip marker present)", p)
+		}
+	}
+	// INFO log must mention the skipped path.
+	outStr := out.String()
+	if !strings.Contains(outStr, ".moai-skip-cleanup") {
+		t.Errorf("expected [INFO] message about skip marker in output, got: %q", outStr)
+	}
+}
+
+// TestCleanup_SkipMarkerAbsent verifies normal behaviour when no skip marker
+// exists (REQ-UPC-018 complement).
+func TestCleanup_SkipMarkerAbsent(t *testing.T) {
+	t.Parallel()
+	root := setupProjectWithAgency(t, "# no skip marker")
+
+	found, _ := scanDeprecatedPaths(root)
+	var out bytes.Buffer
+	filtered, skipped := filterSkipMarkerPaths(root, found, &out)
+
+	if len(skipped) != 0 {
+		t.Errorf("expected 0 skipped paths when no marker, got %d", len(skipped))
+	}
+	if len(filtered) != len(found) {
+		t.Errorf("filtered=%d want %d", len(filtered), len(found))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// M3: Provenance classification
+// ---------------------------------------------------------------------------
+
+// TestCleanup_PristineDeprecated verifies that a file matching its deployed hash
+// is classified as PristineDeprecated.
+func TestCleanup_PristineDeprecated(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	content := []byte("# pristine content")
+	relPath := filepath.ToSlash(defs.DeprecatedPaths[0].Path)
+	fullPath := filepath.Join(root, filepath.FromSlash(relPath))
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(fullPath, content, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	mgr := newManifestManagerForTest(t, root)
+	hash := manifest.HashBytes(content)
+	// Track the file as template-managed (deployed hash matches current content)
+	_ = mgr.Track(relPath, manifest.TemplateManaged, hash)
+
+	class := classifyDeprecatedFile(root, relPath, mgr)
+	if class != DeprecatedPristine {
+		t.Errorf("classifyDeprecatedFile = %v, want DeprecatedPristine", class)
+	}
+}
+
+// TestCleanup_UserModifiedDeprecated verifies that a file with a different hash
+// than its deployed hash is classified as UserModifiedDeprecated.
+func TestCleanup_UserModifiedDeprecated(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	relPath := filepath.ToSlash(defs.DeprecatedPaths[0].Path)
+	fullPath := filepath.Join(root, filepath.FromSlash(relPath))
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	// Write "original" content and track it
+	original := []byte("# original deployed content")
+	if err := os.WriteFile(fullPath, original, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	mgr := newManifestManagerForTest(t, root)
+	_ = mgr.Track(relPath, manifest.TemplateManaged, manifest.HashBytes(original))
+
+	// Now modify the file (simulating user edit)
+	modified := []byte("# user modified content — different hash")
+	if err := os.WriteFile(fullPath, modified, 0o644); err != nil {
+		t.Fatalf("WriteFile modified: %v", err)
+	}
+
+	class := classifyDeprecatedFile(root, relPath, mgr)
+	if class != DeprecatedUserModified {
+		t.Errorf("classifyDeprecatedFile = %v, want DeprecatedUserModified", class)
+	}
+}
+
+// TestCleanup_UnverifiedDeprecated verifies that a file with no manifest entry
+// is classified as UnverifiedDeprecated.
+func TestCleanup_UnverifiedDeprecated(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	relPath := filepath.ToSlash(defs.DeprecatedPaths[0].Path)
+	fullPath := filepath.Join(root, filepath.FromSlash(relPath))
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(fullPath, []byte("# unverified"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	// Empty manifest (no entries)
+	mgr := newManifestManagerForTest(t, root)
+
+	class := classifyDeprecatedFile(root, relPath, mgr)
+	if class != DeprecatedUnverified {
+		t.Errorf("classifyDeprecatedFile = %v, want DeprecatedUnverified", class)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// M3: Telemetry
+// ---------------------------------------------------------------------------
+
+// TestCleanup_TelemetryEmitted verifies that a .moai/logs/update-cleanup-*.jsonl
+// file is created with the required fields (REQ-UPC-022).
+func TestCleanup_TelemetryEmitted(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+
+	var stderr bytes.Buffer
+	event := CleanupEvent{
+		AtomicWriteUsed:      true,
+		PreUpdateSuffix2Files: []string{},
+		BackupOutcome:        "skipped",
+		BackupPath:           "",
+		CleanupOutcome:       "completed",
+		UserOptOutPaths:      []string{},
+	}
+	if err := emitCleanupTelemetry(root, event, &stderr); err != nil {
+		t.Fatalf("emitCleanupTelemetry: %v", err)
+	}
+
+	logsDir := filepath.Join(root, defs.MoAIDir, defs.LogsSubdir)
+	entries, err := os.ReadDir(logsDir)
+	if err != nil {
+		t.Fatalf("ReadDir logs: %v", err)
+	}
+
+	var jsonlFile string
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "update-cleanup-") && strings.HasSuffix(e.Name(), ".jsonl") {
+			jsonlFile = filepath.Join(logsDir, e.Name())
+			break
+		}
+	}
+	if jsonlFile == "" {
+		t.Fatal("expected update-cleanup-*.jsonl file not found in .moai/logs/")
+	}
+
+	data, _ := os.ReadFile(jsonlFile)
+	var ev map[string]interface{}
+	if err := json.Unmarshal(bytes.TrimSpace(data), &ev); err != nil {
+		t.Fatalf("jsonl not valid JSON: %v\ncontent: %s", err, data)
+	}
+
+	for _, field := range []string{"atomic_write_used", "pre_update_suffix2_files",
+		"backup_outcome", "backup_path", "cleanup_outcome", "user_opt_out_paths"} {
+		if _, ok := ev[field]; !ok {
+			t.Errorf("telemetry missing field %q", field)
+		}
+	}
+
+	// stderr should also contain the JSON line (mirror)
+	if stderr.Len() == 0 {
+		t.Error("expected JSON line mirrored to stderr, got empty")
+	}
+
+	// user_opt_out_paths field present
+	if uop, ok := ev["user_opt_out_paths"]; ok {
+		if uop == nil {
+			t.Error("user_opt_out_paths should not be null")
+		}
+	}
+}
+
+// TestCleanup_TelemetryPermissionDenied verifies that if the logs directory
+// cannot be written, the telemetry is skipped with a WARN but the function
+// does not return an error (REQ-UPC-022 permission denied handling).
+func TestCleanup_TelemetryPermissionDenied(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod 0500 not supported on Windows")
+	}
+	t.Parallel()
+	root := t.TempDir()
+	logsDir := filepath.Join(root, defs.MoAIDir, defs.LogsSubdir)
+	if err := os.MkdirAll(logsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	// Make logs dir read-only so file creation fails
+	if err := os.Chmod(logsDir, 0o500); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+	defer os.Chmod(logsDir, 0o755) //nolint:errcheck // cleanup only
+
+	var stderr bytes.Buffer
+	event := CleanupEvent{
+		AtomicWriteUsed: true,
+		BackupOutcome:   "skipped",
+		CleanupOutcome:  "completed",
+	}
+	// Must NOT return error
+	err := emitCleanupTelemetry(root, event, &stderr)
+	if err != nil {
+		t.Errorf("emitCleanupTelemetry should not fail on permission denied, got: %v", err)
+	}
+
+	// WARN must appear in stderr
+	if !strings.Contains(stderr.String(), "[WARN]") || !strings.Contains(stderr.String(), "telemetry persistence skipped") {
+		t.Errorf("expected [WARN] telemetry persistence skipped in stderr, got: %q", stderr.String())
+	}
+
+	// No .jsonl file should exist (skip)
+	entries, _ := os.ReadDir(logsDir)
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".jsonl") {
+			t.Errorf("unexpected .jsonl file despite permission denied: %s", e.Name())
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// M3: Symlink safety
+// ---------------------------------------------------------------------------
+
+// TestCleanup_SymlinkNotFollowed verifies that a symlink among deprecated paths
+// is not followed — only the link itself is removed and the target is preserved
+// (REQ-UPC-023).
+func TestCleanup_SymlinkNotFollowed(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks require elevated privileges on Windows")
+	}
+	t.Parallel()
+	root := t.TempDir()
+
+	// Create an external target file (outside the deprecated tree)
+	targetDir := t.TempDir()
+	targetFile := filepath.Join(targetDir, "external.md")
+	if err := os.WriteFile(targetFile, []byte("external content"), 0o644); err != nil {
+		t.Fatalf("WriteFile target: %v", err)
+	}
+
+	// Create a symlink at the deprecated path location pointing to the external file
+	relLink := filepath.ToSlash(defs.DeprecatedPaths[0].Path)
+	linkPath := filepath.Join(root, filepath.FromSlash(relLink))
+	if err := os.MkdirAll(filepath.Dir(linkPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.Symlink(targetFile, linkPath); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	// removeDeprecatedFile should remove only the link, not the target
+	if err := removeDeprecatedFile(linkPath); err != nil {
+		t.Fatalf("removeDeprecatedFile: %v", err)
+	}
+
+	// Link is gone
+	if _, err := os.Lstat(linkPath); !os.IsNotExist(err) {
+		t.Errorf("expected symlink to be removed, Lstat returned: %v", err)
+	}
+
+	// Target still exists
+	if _, err := os.Stat(targetFile); err != nil {
+		t.Errorf("target file should still exist after symlink removal, Stat returned: %v", err)
+	}
+}
+
+// TestCleanup_SymlinkBroken verifies that a broken symlink (target missing) is
+// removed without error and recorded as symlink_target_status: "broken"
+// (REQ-UPC-023 broken symlink, v0.2.1).
+func TestCleanup_SymlinkBroken(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks require elevated privileges on Windows")
+	}
+	t.Parallel()
+	root := t.TempDir()
+
+	// Create a symlink pointing to a non-existent target
+	relLink := filepath.ToSlash(defs.DeprecatedPaths[0].Path)
+	linkPath := filepath.Join(root, filepath.FromSlash(relLink))
+	if err := os.MkdirAll(filepath.Dir(linkPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.Symlink("/nonexistent/target.md", linkPath); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	info := inspectDeprecatedPath(linkPath)
+	if !info.IsSymlink {
+		t.Fatal("expected IsSymlink=true for a symlink")
+	}
+	if info.SymlinkTargetStatus != "broken" {
+		t.Errorf("expected symlink_target_status=broken, got %q", info.SymlinkTargetStatus)
+	}
+
+	// Removal should succeed
+	if err := removeDeprecatedFile(linkPath); err != nil {
+		t.Fatalf("removeDeprecatedFile broken symlink: %v", err)
+	}
+	if _, err := os.Lstat(linkPath); !os.IsNotExist(err) {
+		t.Errorf("broken symlink should be removed, Lstat: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// M3: Backup self-reference and logs self-reference protection
+// ---------------------------------------------------------------------------
+
+// TestCleanup_BackupSelfReferenceSkipped verifies that paths under .moai/backup/
+// are excluded from deprecated path scanning (REQ-UPC-024).
+func TestCleanup_BackupSelfReferenceSkipped(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+
+	// Create a file under .moai/backup/ that has the same name as a deprecated path
+	backupPath := filepath.Join(root, defs.MoAIDir, "backup", "agency-test",
+		".claude", "commands", "agency", "agency.md")
+	if err := os.MkdirAll(filepath.Dir(backupPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll backup: %v", err)
+	}
+	if err := os.WriteFile(backupPath, []byte("# backup content"), 0o644); err != nil {
+		t.Fatalf("WriteFile backup: %v", err)
+	}
+
+	// Also create the real deprecated path (to prove it IS detected normally)
+	relPath := defs.DeprecatedPaths[0].Path
+	realPath := filepath.Join(root, filepath.FromSlash(relPath))
+	if err := os.MkdirAll(filepath.Dir(realPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll real: %v", err)
+	}
+	if err := os.WriteFile(realPath, []byte("# real agency"), 0o644); err != nil {
+		t.Fatalf("WriteFile real: %v", err)
+	}
+
+	found, err := scanDeprecatedPaths(root)
+	if err != nil {
+		t.Fatalf("scanDeprecatedPaths: %v", err)
+	}
+
+	// None of the found paths should start with .moai/backup/
+	for _, p := range found {
+		if strings.HasPrefix(filepath.ToSlash(p), ".moai/backup/") {
+			t.Errorf("scan should not include .moai/backup/ path: %s", p)
+		}
+	}
+}
+
+// TestCleanup_LogsSelfReferenceSkipped verifies that paths under .moai/logs/
+// are excluded from deprecated path scanning (REQ-UPC-024 extended, v0.2.1).
+func TestCleanup_LogsSelfReferenceSkipped(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+
+	// Create a file under .moai/logs/ (telemetry output area)
+	logsPath := filepath.Join(root, defs.MoAIDir, "logs", "update-cleanup-2026.jsonl")
+	if err := os.MkdirAll(filepath.Dir(logsPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll logs: %v", err)
+	}
+	if err := os.WriteFile(logsPath, []byte(`{}`), 0o644); err != nil {
+		t.Fatalf("WriteFile logs: %v", err)
+	}
+
+	found, err := scanDeprecatedPaths(root)
+	if err != nil {
+		t.Fatalf("scanDeprecatedPaths: %v", err)
+	}
+
+	for _, p := range found {
+		if strings.HasPrefix(filepath.ToSlash(p), ".moai/logs/") {
+			t.Errorf("scan should not include .moai/logs/ path: %s", p)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helper: newManifestManagerForTest creates and loads a manifest manager in root.
+// ---------------------------------------------------------------------------
+func newManifestManagerForTest(t *testing.T, root string) manifest.Manager {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(root, defs.MoAIDir), 0o755); err != nil {
+		t.Fatalf("MkdirAll .moai: %v", err)
+	}
+	mgr := manifest.NewManager()
+	if _, err := mgr.Load(root); err != nil {
+		t.Fatalf("manifest Load: %v", err)
+	}
+	return mgr
+}
+
+// ---------------------------------------------------------------------------
+// Helper: backupManifest mirrors the JSON schema used by backupDeprecatedPaths.
+// ---------------------------------------------------------------------------
+type backupManifest struct {
+	SpecID    string           `json:"spec_id"`
+	DeletedAt time.Time        `json:"deleted_at"`
+	Files     []backupFileEntry `json:"files"`
+}
+
+type backupFileEntry struct {
+	Path           string `json:"path"`
+	Hash           string `json:"hash"`
+	Classification string `json:"classification"`
+	SymlinkTarget  string `json:"symlink_target,omitempty"`
+}

--- a/internal/cli/update_e2e_test.go
+++ b/internal/cli/update_e2e_test.go
@@ -1,0 +1,356 @@
+// SPEC-V3R3-UPDATE-CLEANUP-001 — End-to-end regression scenarios (M4).
+// Scenarios A–F cover the six canonical deprecated-path cleanup cases.
+// Case-insensitive FS probe tests (REQ-UPC-026) are included here.
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/modu-ai/moai-adk/internal/defs"
+	"github.com/modu-ai/moai-adk/internal/manifest"
+)
+
+// ---------------------------------------------------------------------------
+// Shared helpers for E2E test fixtures
+// ---------------------------------------------------------------------------
+
+// setupE2EProject creates a temp project with .moai/ initialised.
+func setupE2EProject(t *testing.T) (root string, mgr manifest.Manager) {
+	t.Helper()
+	root = t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, defs.MoAIDir), 0o755); err != nil {
+		t.Fatalf("MkdirAll .moai: %v", err)
+	}
+	mgr = manifest.NewManager()
+	if _, err := mgr.Load(root); err != nil {
+		t.Fatalf("manifest Load: %v", err)
+	}
+	return root, mgr
+}
+
+// seedAgencyFiles populates the project with all deprecated agency paths,
+// recording them in mgr with the given content.
+func seedAgencyFiles(t *testing.T, root string, mgr manifest.Manager, content string) {
+	t.Helper()
+	for _, p := range defs.DeprecatedPaths {
+		abs := filepath.Join(root, filepath.FromSlash(p.Path))
+		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			t.Fatalf("MkdirAll %q: %v", filepath.Dir(abs), err)
+		}
+		data := []byte(content)
+		if err := os.WriteFile(abs, data, 0o644); err != nil {
+			t.Fatalf("WriteFile %q: %v", abs, err)
+		}
+		hash := manifest.HashBytes(data)
+		_ = mgr.Track(filepath.ToSlash(p.Path), manifest.TemplateManaged, hash)
+	}
+}
+
+// runCleanupPhase is a minimal simulation of the cleanup phase used in E2E tests:
+// scan → filter skip-markers → backup → remove.
+func runCleanupPhase(t *testing.T, root string, mgr manifest.Manager) (backupDir string, removed []string) {
+	t.Helper()
+
+	found, err := scanDeprecatedPaths(root)
+	if err != nil {
+		t.Fatalf("scanDeprecatedPaths: %v", err)
+	}
+
+	var devNull strings.Builder
+	filtered, _ := filterSkipMarkerPaths(root, found, &devNull)
+
+	if len(filtered) == 0 {
+		return "", nil
+	}
+
+	backupDir, err = backupDeprecatedPaths(root, filtered, mgr)
+	if err != nil {
+		t.Fatalf("backupDeprecatedPaths: %v", err)
+	}
+
+	for _, rel := range filtered {
+		abs := filepath.Join(root, filepath.FromSlash(rel))
+		if err := removeDeprecatedFile(abs); err != nil {
+			t.Fatalf("removeDeprecatedFile %q: %v", rel, err)
+		}
+		removed = append(removed, rel)
+	}
+	return backupDir, removed
+}
+
+// ---------------------------------------------------------------------------
+// Scenario A — agency files present, pristine → backup + delete
+// ---------------------------------------------------------------------------
+
+func TestE2E_ScenarioA_AgencyPresentPristine(t *testing.T) {
+	t.Parallel()
+	root, mgr := setupE2EProject(t)
+	seedAgencyFiles(t, root, mgr, "# scenario A pristine")
+
+	backupDir, removed := runCleanupPhase(t, root, mgr)
+
+	if backupDir == "" {
+		t.Fatal("expected a backup directory to be created")
+	}
+	if len(removed) != len(defs.DeprecatedPaths) {
+		t.Errorf("removed %d files, want %d", len(removed), len(defs.DeprecatedPaths))
+	}
+
+	// Original files must be gone
+	for _, p := range defs.DeprecatedPaths {
+		abs := filepath.Join(root, filepath.FromSlash(p.Path))
+		if _, err := os.Lstat(abs); !os.IsNotExist(err) {
+			t.Errorf("expected %q to be removed, Lstat: %v", p.Path, err)
+		}
+	}
+
+	// Backup directory must contain files
+	if _, err := os.Stat(filepath.Join(backupDir, "MANIFEST.json")); err != nil {
+		t.Errorf("backup MANIFEST.json missing: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Scenario B — agency files absent → no-op, no backup directory created
+// ---------------------------------------------------------------------------
+
+func TestE2E_ScenarioB_AgencyAbsent(t *testing.T) {
+	t.Parallel()
+	root, mgr := setupE2EProject(t)
+	// No agency files seeded
+
+	backupDir, removed := runCleanupPhase(t, root, mgr)
+
+	if backupDir != "" {
+		t.Errorf("expected no backup directory when agency absent, got %q", backupDir)
+	}
+	if len(removed) != 0 {
+		t.Errorf("expected 0 removed, got %d", len(removed))
+	}
+
+	// .moai/backup/ should not exist
+	backupRoot := filepath.Join(root, defs.MoAIDir, "backup")
+	if _, err := os.Stat(backupRoot); !os.IsNotExist(err) {
+		t.Errorf("backup dir should not exist when no deprecated paths found: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Scenario C — user modified agency.md → backup + classification recorded
+// ---------------------------------------------------------------------------
+
+func TestE2E_ScenarioC_UserModified(t *testing.T) {
+	t.Parallel()
+	root, mgr := setupE2EProject(t)
+
+	// Seed with original content (tracked in manifest)
+	original := "# original agency content"
+	seedAgencyFiles(t, root, mgr, original)
+
+	// Now modify the first file (simulate user edit)
+	firstDeprecated := defs.DeprecatedPaths[0]
+	abs := filepath.Join(root, filepath.FromSlash(firstDeprecated.Path))
+	if err := os.WriteFile(abs, []byte("# user modified content — different hash"), 0o644); err != nil {
+		t.Fatalf("WriteFile modified: %v", err)
+	}
+
+	// Classification should now be UserModifiedDeprecated for first file
+	class := classifyDeprecatedFile(root, filepath.ToSlash(firstDeprecated.Path), mgr)
+	if class != DeprecatedUserModified {
+		t.Errorf("expected UserModifiedDeprecated, got %v", class)
+	}
+
+	// Cleanup phase should still back up all files
+	backupDir, removed := runCleanupPhase(t, root, mgr)
+	if backupDir == "" {
+		t.Fatal("expected backup directory for user-modified files")
+	}
+	if len(removed) == 0 {
+		t.Error("expected files to be removed after backup")
+	}
+
+	// MANIFEST.json should record the classification
+	data, _ := os.ReadFile(filepath.Join(backupDir, "MANIFEST.json"))
+	if !strings.Contains(string(data), "UserModifiedDeprecated") {
+		t.Errorf("MANIFEST.json should record UserModifiedDeprecated classification")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Scenario D — moai update twice → no " 2" suffix files
+// ---------------------------------------------------------------------------
+// This scenario verifies the atomic write idempotency at the deployer level.
+// Since the E2E focuses on the cleanup path, we verify that running cleanup
+// twice on an already-cleaned project is a no-op.
+
+func TestE2E_ScenarioD_DoubleRunNoSuffix2(t *testing.T) {
+	t.Parallel()
+	root, mgr := setupE2EProject(t)
+	seedAgencyFiles(t, root, mgr, "# scenario D content")
+
+	// First cleanup run
+	_, _ = runCleanupPhase(t, root, mgr)
+
+	// Second cleanup run — agency files are already gone, should be no-op
+	backupDir2, removed2 := runCleanupPhase(t, root, mgr)
+
+	if backupDir2 != "" {
+		t.Errorf("second cleanup run should be no-op, got backup dir: %q", backupDir2)
+	}
+	if len(removed2) != 0 {
+		t.Errorf("second cleanup run should remove nothing, removed %d", len(removed2))
+	}
+
+	// No " 2" suffix files
+	_ = filepath.WalkDir(root, func(path string, d os.DirEntry, _ error) error {
+		if d != nil && !d.IsDir() {
+			name := filepath.Base(path)
+			if strings.Contains(name, " 2.") || strings.HasSuffix(name, " 2") {
+				t.Errorf("unexpected \" 2\" suffix file after double run: %s", path)
+			}
+		}
+		return nil
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Scenario E — concurrent lock acquisition → second call blocked
+// ---------------------------------------------------------------------------
+
+func TestE2E_ScenarioE_ConcurrentLock(t *testing.T) {
+	t.Parallel()
+	root, _ := setupE2EProject(t)
+
+	// First lock
+	release1, err := acquireUpdateLock(root)
+	if err != nil {
+		t.Fatalf("first lock: %v", err)
+	}
+	defer release1()
+
+	// Second lock must fail
+	release2, err2 := acquireUpdateLock(root)
+	if err2 == nil {
+		release2()
+		t.Fatal("expected second lock to fail, but it succeeded")
+	}
+	if !strings.Contains(err2.Error(), "already running") && err2.Error() != ErrUpdateLockHeld.Error() {
+		t.Errorf("expected ErrUpdateLockHeld, got: %v", err2)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Scenario F — manifest entry absent → UnverifiedDeprecated
+// ---------------------------------------------------------------------------
+
+func TestE2E_ScenarioF_UnverifiedDeprecated(t *testing.T) {
+	t.Parallel()
+	root, mgr := setupE2EProject(t)
+	// Seed agency files WITHOUT tracking in manifest
+	for _, p := range defs.DeprecatedPaths {
+		abs := filepath.Join(root, filepath.FromSlash(p.Path))
+		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		if err := os.WriteFile(abs, []byte("# unverified content"), 0o644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		// NOT tracked in mgr → UnverifiedDeprecated
+	}
+
+	// Each file should classify as UnverifiedDeprecated
+	for _, p := range defs.DeprecatedPaths {
+		class := classifyDeprecatedFile(root, filepath.ToSlash(p.Path), mgr)
+		if class != DeprecatedUnverified {
+			t.Errorf("path %q: expected UnverifiedDeprecated, got %v", p.Path, class)
+		}
+	}
+
+	// Cleanup still proceeds (backup + delete)
+	backupDir, removed := runCleanupPhase(t, root, mgr)
+	if backupDir == "" {
+		t.Fatal("expected backup directory even for unverified deprecated files")
+	}
+	if len(removed) == 0 {
+		t.Error("expected deprecated files to be removed")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// REQ-UPC-026: Case-insensitive filesystem probe
+// ---------------------------------------------------------------------------
+
+// TestCleanup_CaseInsensitiveFS verifies that the filesystem probe correctly
+// detects whether the project FS is case-insensitive.
+func TestCleanup_CaseInsensitiveFS(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+
+	caseSensitive, err := probeCaseSensitiveFS(root)
+	if err != nil {
+		t.Fatalf("probeCaseSensitiveFS: %v", err)
+	}
+
+	// On macOS APFS (default) we expect case-insensitive (false)
+	// On Linux ext4 we expect case-sensitive (true)
+	// We can't assert the exact value (CI may run any OS), but we can verify
+	// the probe function returns without error and a consistent result.
+	t.Logf("probeCaseSensitiveFS result: caseSensitive=%v (GOOS=%s)", caseSensitive, runtime.GOOS)
+
+	// Probe must leave no residue
+	probe := filepath.Join(root, ".moai-fscase-probe")
+	if _, err := os.Stat(probe); !os.IsNotExist(err) {
+		t.Errorf("probe file %q should be cleaned up, Stat: %v", probe, err)
+	}
+}
+
+// TestCleanup_CaseProbeRunsOncePerInvocation verifies that the probe result is
+// consistent when called twice in the same invocation (idempotent) and that no
+// residue is left.
+func TestCleanup_CaseProbeRunsOncePerInvocation(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+
+	result1, err1 := probeCaseSensitiveFS(root)
+	if err1 != nil {
+		t.Fatalf("first probe: %v", err1)
+	}
+
+	result2, err2 := probeCaseSensitiveFS(root)
+	if err2 != nil {
+		t.Fatalf("second probe: %v", err2)
+	}
+
+	if result1 != result2 {
+		t.Errorf("probe results are inconsistent: first=%v second=%v", result1, result2)
+	}
+}
+
+// TestCleanup_CaseProbeFailureFallback verifies that if the probe fails due to a
+// read-only filesystem, case-sensitive matching is used as fallback.
+func TestCleanup_CaseProbeFailureFallback(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod not supported on Windows")
+	}
+	t.Parallel()
+	root := t.TempDir()
+	// Make root read-only so probe file creation fails
+	if err := os.Chmod(root, 0o555); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+	defer os.Chmod(root, 0o755) //nolint:errcheck
+
+	// probeCaseSensitiveFS should return (true, nil) on error (fallback to case-sensitive)
+	caseSensitive, err := probeCaseSensitiveFS(root)
+	if err != nil {
+		t.Fatalf("expected fallback (no error), got: %v", err)
+	}
+	if !caseSensitive {
+		t.Error("expected fallback to case-sensitive (true) when probe fails")
+	}
+}

--- a/internal/defs/dirs.go
+++ b/internal/defs/dirs.go
@@ -12,6 +12,79 @@ const (
 	BackupsDir = ".moai-backups"
 )
 
+// DeprecatedPathEntry describes a single deprecated template path.
+type DeprecatedPathEntry struct {
+	// Path is the slash-separated path relative to the project root.
+	Path string
+	// DeprecatedSince is the SPEC ID that removed this path from templates.
+	DeprecatedSince string
+	// DeprecatedBy is the SPEC ID authorising cleanup.
+	DeprecatedBy string
+	// RemovalSchedule is the version when deletion is expected.
+	RemovalSchedule string
+}
+
+// DeprecatedPaths is the single source of truth for paths that have been removed
+// from the MoAI-ADK templates but may still exist in user projects.
+// Populated by SPEC-AGENCY-ABSORB-001 (2026-04-23, commit 3e8b61e80).
+// Managed by: SPEC-V3R3-UPDATE-CLEANUP-001 (REQ-UPC-006).
+var DeprecatedPaths = []DeprecatedPathEntry{
+	{
+		Path:            ".claude/commands/agency/agency.md",
+		DeprecatedSince: "SPEC-AGENCY-ABSORB-001",
+		DeprecatedBy:    "SPEC-V3R3-UPDATE-CLEANUP-001",
+		RemovalSchedule: "v3.0.0",
+	},
+	{
+		Path:            ".claude/commands/agency/brief.md",
+		DeprecatedSince: "SPEC-AGENCY-ABSORB-001",
+		DeprecatedBy:    "SPEC-V3R3-UPDATE-CLEANUP-001",
+		RemovalSchedule: "v3.0.0",
+	},
+	{
+		Path:            ".claude/commands/agency/build.md",
+		DeprecatedSince: "SPEC-AGENCY-ABSORB-001",
+		DeprecatedBy:    "SPEC-V3R3-UPDATE-CLEANUP-001",
+		RemovalSchedule: "v3.0.0",
+	},
+	{
+		Path:            ".claude/commands/agency/evolve.md",
+		DeprecatedSince: "SPEC-AGENCY-ABSORB-001",
+		DeprecatedBy:    "SPEC-V3R3-UPDATE-CLEANUP-001",
+		RemovalSchedule: "v3.0.0",
+	},
+	{
+		Path:            ".claude/commands/agency/learn.md",
+		DeprecatedSince: "SPEC-AGENCY-ABSORB-001",
+		DeprecatedBy:    "SPEC-V3R3-UPDATE-CLEANUP-001",
+		RemovalSchedule: "v3.0.0",
+	},
+	{
+		Path:            ".claude/commands/agency/profile.md",
+		DeprecatedSince: "SPEC-AGENCY-ABSORB-001",
+		DeprecatedBy:    "SPEC-V3R3-UPDATE-CLEANUP-001",
+		RemovalSchedule: "v3.0.0",
+	},
+	{
+		Path:            ".claude/commands/agency/resume.md",
+		DeprecatedSince: "SPEC-AGENCY-ABSORB-001",
+		DeprecatedBy:    "SPEC-V3R3-UPDATE-CLEANUP-001",
+		RemovalSchedule: "v3.0.0",
+	},
+	{
+		Path:            ".claude/commands/agency/review.md",
+		DeprecatedSince: "SPEC-AGENCY-ABSORB-001",
+		DeprecatedBy:    "SPEC-V3R3-UPDATE-CLEANUP-001",
+		RemovalSchedule: "v3.0.0",
+	},
+	{
+		Path:            ".claude/rules/agency/constitution.md",
+		DeprecatedSince: "SPEC-AGENCY-ABSORB-001",
+		DeprecatedBy:    "SPEC-V3R3-UPDATE-CLEANUP-001",
+		RemovalSchedule: "v3.0.0",
+	},
+}
+
 // MoAI subdirectory segments (relative to MoAIDir).
 const (
 	ConfigSubdir   = "config"

--- a/internal/template/deployer.go
+++ b/internal/template/deployer.go
@@ -11,6 +11,26 @@ import (
 	"github.com/modu-ai/moai-adk/internal/manifest"
 )
 
+// atomicWriteFile writes content to destPath using a write-to-tmp-then-rename
+// atomic pattern (REQ-UPC-001). The tmp file is written to <destPath>.moai-tmp
+// in the same directory as destPath so that os.Rename is always same-device
+// (NFR-UPC-S3). If the rename fails the tmp file is removed and the error is
+// returned (REQ-UPC-004).
+func atomicWriteFile(destPath string, content []byte, perm os.FileMode) error {
+	tmpPath := destPath + ".moai-tmp"
+	// Defer removal of tmp file on any failure path.
+	// On success the rename makes the tmp path disappear, so os.Remove is a no-op.
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	if err := os.WriteFile(tmpPath, content, perm); err != nil {
+		return fmt.Errorf("atomic write tmp %q: %w", tmpPath, err)
+	}
+	if err := os.Rename(tmpPath, destPath); err != nil {
+		return fmt.Errorf("atomic rename %q → %q: %w", tmpPath, destPath, err)
+	}
+	return nil
+}
+
 // @MX:ANCHOR: [AUTO] Deployer is the core interface that extracts templates from embedded filesystem and deploys to project root. Each file is tracked in manifest.
 // @MX:REASON: [AUTO] fan_in=8+, entry point for all project initialization, core contract for template deployment
 // Deployer extracts and deploys templates from an embedded filesystem
@@ -164,8 +184,8 @@ func (d *deployer) Deploy(ctx context.Context, projectRoot string, m manifest.Ma
 			perm = 0o755 // Executable: read/write/execute for owner, read/execute for others
 		}
 
-		// Write file
-		if err := os.WriteFile(destPath, content, perm); err != nil {
+		// Write file atomically (REQ-UPC-001): write to .moai-tmp then rename.
+		if err := atomicWriteFile(destPath, content, perm); err != nil {
 			return fmt.Errorf("template deploy write %q: %w", destPath, err)
 		}
 

--- a/internal/template/deployer_bench_test.go
+++ b/internal/template/deployer_bench_test.go
@@ -1,0 +1,117 @@
+// SPEC-V3R3-UPDATE-CLEANUP-001 — NFR-UPC-P1 benchmark gate.
+// Compares baseline (direct os.WriteFile) vs atomic write (write-to-tmp + rename).
+// The gate passes if delta ≤ 5% (benchstat analysis on ubuntu-latest CI).
+
+package template
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+
+	"github.com/modu-ai/moai-adk/internal/manifest"
+)
+
+// setupSyntheticProject builds a temp directory with numFiles regular files and
+// numDeprecated deprecated-path stubs. Returns the project root and an FS
+// with the same files for deployment.
+func setupSyntheticProject(b *testing.B, numFiles, numDeprecated, _ int) (root string, syntheticFS fstest.MapFS) {
+	b.Helper()
+	root = b.TempDir()
+	syntheticFS = make(fstest.MapFS)
+
+	for i := 0; i < numFiles; i++ {
+		name := fmt.Sprintf(".claude/agents/moai/agent-%03d.md", i)
+		data := []byte(fmt.Sprintf("# Agent %d\ncontent line 1\ncontent line 2\n", i))
+		syntheticFS[name] = &fstest.MapFile{Data: data}
+	}
+	for i := 0; i < numDeprecated; i++ {
+		name := fmt.Sprintf(".claude/commands/agency/cmd-%02d.md", i)
+		data := []byte(fmt.Sprintf("# Deprecated cmd %d\n", i))
+		syntheticFS[name] = &fstest.MapFile{Data: data}
+		// Create the file on disk to simulate a user project with deprecated paths
+		abs := filepath.Join(root, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			b.Fatalf("MkdirAll: %v", err)
+		}
+		if err := os.WriteFile(abs, data, 0o644); err != nil {
+			b.Fatalf("WriteFile deprecated: %v", err)
+		}
+	}
+	// Initialise .moai dir
+	if err := os.MkdirAll(filepath.Join(root, ".moai"), 0o755); err != nil {
+		b.Fatalf("MkdirAll .moai: %v", err)
+	}
+	return root, syntheticFS
+}
+
+// Benchmark_UpdateCleanup_Baseline simulates deployment WITHOUT atomic write.
+// This is the v2.14.0-equivalent: direct os.WriteFile (non-atomic).
+// Used as the baseline for benchstat comparison.
+func Benchmark_UpdateCleanup_Baseline(b *testing.B) {
+	root, syntheticFS := setupSyntheticProject(b, 100, 5, 0)
+	mgr := manifest.NewManager()
+	if _, err := mgr.Load(root); err != nil {
+		b.Fatalf("manifest Load: %v", err)
+	}
+
+	// Use direct WriteFile deployer (non-atomic baseline)
+	d := &baselineDeployer{fsys: syntheticFS}
+
+	ctx := context.Background()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := d.deployBaseline(ctx, root, mgr); err != nil {
+			b.Fatalf("baseline deploy: %v", err)
+		}
+	}
+}
+
+// Benchmark_UpdateCleanup_AtomicWrite simulates deployment WITH atomic write.
+// This is the SPEC-V3R3-UPDATE-CLEANUP-001 implementation.
+func Benchmark_UpdateCleanup_AtomicWrite(b *testing.B) {
+	root, syntheticFS := setupSyntheticProject(b, 100, 5, 0)
+	mgr := manifest.NewManager()
+	if _, err := mgr.Load(root); err != nil {
+		b.Fatalf("manifest Load: %v", err)
+	}
+
+	d := NewDeployerWithForceUpdate(syntheticFS, true)
+
+	ctx := context.Background()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := d.Deploy(ctx, root, mgr, nil); err != nil {
+			b.Fatalf("atomic deploy: %v", err)
+		}
+	}
+}
+
+// baselineDeployer is a minimal non-atomic deployer for benchmarking the
+// pre-SPEC write pattern (direct os.WriteFile without tmp+rename).
+type baselineDeployer struct {
+	fsys fstest.MapFS
+}
+
+func (d *baselineDeployer) deployBaseline(ctx context.Context, root string, m manifest.Manager) error {
+	for name, file := range d.fsys {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		destPath := filepath.Join(root, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(destPath, file.Data, 0o644); err != nil {
+			return err
+		}
+		hash := manifest.HashBytes(file.Data)
+		_ = m.Track(name, manifest.TemplateManaged, hash)
+	}
+	return nil
+}

--- a/internal/template/deployer_mode.go
+++ b/internal/template/deployer_mode.go
@@ -124,8 +124,8 @@ func (d *modeAwareDeployer) Deploy(ctx context.Context, projectRoot string, m ma
 			perm = 0o755
 		}
 
-		// Write file
-		if err := os.WriteFile(destPath, content, perm); err != nil {
+		// Write file atomically (REQ-UPC-001): write to .moai-tmp then rename.
+		if err := atomicWriteFile(destPath, content, perm); err != nil {
 			return fmt.Errorf("template deploy write %q: %w", destPath, err)
 		}
 

--- a/internal/template/deployer_test.go
+++ b/internal/template/deployer_test.go
@@ -1,6 +1,7 @@
 package template
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"os"
@@ -251,5 +252,159 @@ func TestValidateDeployPath(t *testing.T) {
 		if err != nil && !errors.Is(err, ErrPathTraversal) {
 			t.Errorf("expected ErrPathTraversal, got: %v", err)
 		}
+	})
+}
+
+// --- M1: Atomic Write + Idempotency Tests (SPEC-V3R3-UPDATE-CLEANUP-001) ---
+
+// TestDeployer_Idempotent verifies that two consecutive Deploy calls to the same
+// destination produce byte-identical files with no auxiliary artefacts.
+func TestDeployer_Idempotent(t *testing.T) {
+	t.Parallel()
+	root, mgr := setupDeployProject(t)
+	d := NewDeployerWithForceUpdate(testFS(), true)
+
+	ctx := context.Background()
+
+	// First deploy
+	if err := d.Deploy(ctx, root, mgr, nil); err != nil {
+		t.Fatalf("first Deploy error: %v", err)
+	}
+
+	// Snapshot file contents after first deploy
+	contents1 := snapshotFileContents(t, root)
+
+	// Second deploy (idempotent)
+	if err := d.Deploy(ctx, root, mgr, nil); err != nil {
+		t.Fatalf("second Deploy error: %v", err)
+	}
+
+	// Snapshot after second deploy
+	contents2 := snapshotFileContents(t, root)
+
+	// Verify byte-identical
+	for path, data1 := range contents1 {
+		data2, ok := contents2[path]
+		if !ok {
+			t.Errorf("file %q disappeared after second Deploy", path)
+			continue
+		}
+		if !bytes.Equal(data1, data2) {
+			t.Errorf("file %q content changed after second Deploy", path)
+		}
+	}
+
+	// Verify no .moai-tmp residue
+	assertNoTmpResidue(t, root)
+
+	// Verify no " 2" suffix files
+	assertNoSuffix2Files(t, root)
+}
+
+// TestDeployer_NoTmpResidue verifies that no .moai-tmp files are left after
+// a successful Deploy.
+func TestDeployer_NoTmpResidue(t *testing.T) {
+	t.Parallel()
+	root, mgr := setupDeployProject(t)
+	d := NewDeployerWithForceUpdate(testFS(), true)
+
+	if err := d.Deploy(context.Background(), root, mgr, nil); err != nil {
+		t.Fatalf("Deploy error: %v", err)
+	}
+
+	assertNoTmpResidue(t, root)
+}
+
+// TestDeployer_TmpCleanupOnFailure verifies that if the atomic rename fails,
+// the .moai-tmp file is cleaned up and an error is returned.
+// This test uses atomicWriteFile directly to simulate a rename failure.
+func TestDeployer_TmpCleanupOnFailure(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+
+	destPath := filepath.Join(root, "target.txt")
+	content := []byte("hello world")
+
+	// Create a directory at the tmp path location to force rename failure.
+	// atomicWriteFile writes to destPath+".moai-tmp"; make that path a directory.
+	tmpPath := destPath + ".moai-tmp"
+	if err := os.MkdirAll(tmpPath, 0o755); err != nil {
+		t.Fatalf("setup: MkdirAll %q: %v", tmpPath, err)
+	}
+
+	// atomicWriteFile should fail and clean up
+	err := atomicWriteFile(destPath, content, 0o644)
+	if err == nil {
+		t.Fatal("expected error when rename target is a directory, got nil")
+	}
+
+	// The tmp path should be cleaned up (removed) on failure.
+	// Since tmpPath was a directory we created, check that atomicWriteFile
+	// attempted cleanup (it may or may not succeed on a dir, but should not
+	// leave a regular tmp file).
+	// Key invariant: no .moai-tmp *file* residue (directories we set up, not atomicWriteFile).
+	entries, _ := os.ReadDir(root)
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".moai-tmp" && !e.IsDir() {
+			t.Errorf("tmp file residue found: %s", e.Name())
+		}
+	}
+}
+
+// snapshotFileContents walks root and returns a map of relpath → content for
+// all regular files.
+func snapshotFileContents(t *testing.T, root string) map[string][]byte {
+	t.Helper()
+	result := make(map[string][]byte)
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		rel, _ := filepath.Rel(root, path)
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		result[rel] = data
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("snapshotFileContents walk error: %v", err)
+	}
+	return result
+}
+
+// assertNoTmpResidue fails if any .moai-tmp file exists under root.
+func assertNoTmpResidue(t *testing.T, root string) {
+	t.Helper()
+	_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		if filepath.Ext(path) == ".moai-tmp" {
+			t.Errorf("unexpected .moai-tmp residue: %s", path)
+		}
+		return nil
+	})
+}
+
+// assertNoSuffix2Files fails if any file with a " 2" suffix exists under root.
+func assertNoSuffix2Files(t *testing.T, root string) {
+	t.Helper()
+	_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		name := filepath.Base(path)
+		// Check for patterns like "file 2.ext" or "file 2"
+		for _, ext := range []string{"", ".md", ".yaml", ".json", ".sh", ".txt"} {
+			if len(name) > 2+len(ext) {
+				suffix := " 2" + ext
+				if len(name) >= len(suffix) && name[len(name)-len(suffix):] == suffix {
+					t.Errorf("unexpected \" 2\" suffix file: %s", path)
+				}
+			}
+		}
+		return nil
 	})
 }

--- a/scripts/benchmark-overhead-check.sh
+++ b/scripts/benchmark-overhead-check.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# SPEC-V3R3-UPDATE-CLEANUP-001 — NFR-UPC-P1 benchstat overhead gate.
+# Usage: ./scripts/benchmark-overhead-check.sh <bench-report.txt>
+#
+# Reads benchstat output and fails (exit 1) if:
+#   delta_pct > 5% AND p_value < 0.05
+#
+# If delta_pct ≤ 5%, the test passes regardless of p-value.
+# If p_value ≥ 0.05 (not statistically significant), the test passes.
+#
+# Official gate OS: ubuntu-latest (CI). macOS/Windows results are informational.
+
+set -euo pipefail
+
+REPORT="${1:-bench-report.txt}"
+
+if [[ ! -f "$REPORT" ]]; then
+  echo "[ERROR] benchmark report not found: $REPORT" >&2
+  exit 1
+fi
+
+echo "=== NFR-UPC-P1 Benchmark Overhead Gate ==="
+echo "Report: $REPORT"
+echo ""
+cat "$REPORT"
+echo ""
+
+# Extract delta_pct and p-value from benchstat output.
+# benchstat output example:
+#   name                         old ns/op   new ns/op   delta
+#   UpdateCleanup_Baseline       8.2ms ± 2%  8.5ms ± 1%  +3.66%  (p=0.008 n=10+10)
+#
+# We parse the last numeric column for delta% and the p-value.
+
+FAIL=0
+
+while IFS= read -r line; do
+  # Skip header and empty lines
+  [[ -z "$line" ]] && continue
+  [[ "$line" == name* ]] && continue
+
+  # Look for lines containing delta % and p-value
+  if [[ "$line" =~ ([+-][0-9]+(\.[0-9]+)?)\%[[:space:]]+\(p=([0-9]+\.[0-9]+) ]]; then
+    delta_pct="${BASH_REMATCH[1]}"
+    p_value="${BASH_REMATCH[3]}"
+
+    echo "Detected: delta_pct=${delta_pct}% p_value=${p_value}"
+
+    # Remove leading + sign for comparison
+    abs_delta="${delta_pct#+}"
+    # abs_delta may start with - for improvement; use absolute value
+    abs_delta="${abs_delta#-}"
+
+    # Compare: delta_pct > 5 AND p_value < 0.05 → FAIL
+    gate_fail=$(awk -v d="$abs_delta" -v p="$p_value" 'BEGIN {
+      if (d > 5 && p < 0.05) { print "1" } else { print "0" }
+    }')
+
+    if [[ "$gate_fail" == "1" ]]; then
+      echo "[FAIL] Atomic write overhead exceeds 5% (delta=${delta_pct}%, p=${p_value})" >&2
+      FAIL=1
+    else
+      echo "[PASS] Overhead within acceptable range (delta=${delta_pct}%, p=${p_value})"
+    fi
+  fi
+done < "$REPORT"
+
+if [[ $FAIL -eq 1 ]]; then
+  echo ""
+  echo "[ERROR] NFR-UPC-P1 gate FAILED: atomic write overhead > 5% (p < 0.05)" >&2
+  exit 1
+fi
+
+echo ""
+echo "[OK] NFR-UPC-P1 gate PASSED"
+exit 0


### PR DESCRIPTION
## Summary

SPEC-V3R3-UPDATE-CLEANUP-001 TDD run-phase — `moai update` idempotent deployment + deprecated agency path cleanup.

**M1 — Atomic Write + Lock (REQ-UPC-001~005)**
- `atomicWriteFile()`: write-to-`.moai-tmp` then `os.Rename` — prevents `" 2"` suffix race condition
- `deployer.go` + `deployer_mode.go` both use atomic write
- `acquireUpdateLock()`: JSON `{pid, started_at, hostname}` lock at `.moai/.update.lock` with stale-PID detection via `syscall.Kill(pid, 0)`

**M2 — Deprecated Path Cleanup + Backup (REQ-UPC-006~018)**
- `defs.DeprecatedPaths`: 9 agency entries — single source of truth
- `scanDeprecatedPaths()`: Lstat-based, self-reference excludes `.moai/backup/` + `.moai/logs/`
- `backupDeprecatedPaths()`: dated `.moai/backup/agency-{ts}/` + MANIFEST.json with classifications
- `filterSkipMarkerPaths()`: `.moai-skip-cleanup` marker opt-out per directory

**M3 — Provenance + Telemetry + Symlink Safety (REQ-UPC-015~024)**
- `classifyDeprecatedFile()`: Pristine/UserModified/Unverified via `manifest.DeployedHash`
- `emitCleanupTelemetry()`: `.moai/logs/update-cleanup-{ts}.jsonl` + stderr mirror, permission-denied graceful skip
- `inspectDeprecatedPath()` + `removeDeprecatedFile()`: symlink-safe (no target follow), broken symlink

**M4 — E2E + Case-Insensitive FS + NFR Benchmark (REQ-UPC-026, NFR-UPC-P1)**
- Scenarios A-F: full cleanup pipeline regression tests
- `probeCaseSensitiveFS()`: `.moai-fscase-probe` probe with failure fallback
- `Benchmark_UpdateCleanup_Baseline` vs `AtomicWrite` for NFR-UPC-P1 gate
- `scripts/benchmark-overhead-check.sh`: benchstat delta_pct ≤ 5% AND p < 0.05 gate

## Test plan

- [x] M1 deployer: `TestDeployer_Idempotent`, `TestDeployer_NoTmpResidue`, `TestDeployer_TmpCleanupOnFailure`
- [x] M1 lock: `TestUpdate_ConcurrentLock`, `TestUpdate_LockFileJSON`, `TestUpdate_LockCleanedUpOnRelease`
- [x] M2 scan: `TestCleanup_AgencyPathsDetected`, `TestCleanup_NoOpWhenAbsent`, `TestCleanup_DeletedFileSkipped`
- [x] M2 backup: `TestCleanup_BackupCreated`, `TestCleanup_BackupManifestFields`
- [x] M2 skip: `TestCleanup_SkipMarkerHonored`, `TestCleanup_SkipMarkerAbsent`
- [x] M3 provenance: `TestCleanup_PristineDeprecated`, `TestCleanup_UserModifiedDeprecated`, `TestCleanup_UnverifiedDeprecated`
- [x] M3 telemetry: `TestCleanup_TelemetryEmitted`, `TestCleanup_TelemetryPermissionDenied`
- [x] M3 symlink: `TestCleanup_SymlinkNotFollowed`, `TestCleanup_SymlinkBroken`
- [x] M3 self-ref: `TestCleanup_BackupSelfReferenceSkipped`, `TestCleanup_LogsSelfReferenceSkipped`
- [x] M4 E2E: Scenarios A-F all pass
- [x] M4 case probe: `TestCleanup_CaseInsensitiveFS`, `TestCleanup_CaseProbeRunsOncePerInvocation`, `TestCleanup_CaseProbeFailureFallback`
- [x] Lint: 0 issues
- [x] Build: `make build` passes
- [x] Spec lint: No findings

🗿 MoAI <email@mo.ai.kr>