### PR TITLE
plan(SPEC-V3R2-HRN-001): Harness Routing + harness.yaml Go Loader — 4 artifacts

### DIFF
--- a/.moai/specs/SPEC-V3R2-HRN-001/acceptance.md
+++ b/.moai/specs/SPEC-V3R2-HRN-001/acceptance.md
@@ -1,0 +1,375 @@
+# SPEC-V3R2-HRN-001 — Acceptance Criteria (acceptance.md)
+
+> Companion to `spec.md` §6 AC summary (10 ACs).
+> Companion to `plan.md` REQ↔AC matrix §5.
+> Companion to `research.md` §13 test fixture inventory.
+
+This file is the **binary verification contract** for HRN-001 run-phase exit. Each AC is independently testable, observable, and produces a binary PASS/FAIL outcome. All 10 ACs must PASS before `/moai sync` may execute.
+
+---
+
+## HISTORY
+
+| Version | Date       | Author | Description |
+|---------|------------|--------|-------------|
+| 0.1.0   | 2026-05-18 | manager-spec | Initial plan-phase ACs: 10 binary Given/When/Then scenarios |
+
+---
+
+## Format
+
+Each AC follows Given/When/Then format with an explicit **Verification command** producing binary exit code (0 = PASS, non-zero = FAIL) and an **Evidence artifact** (file path or stdout regex).
+
+---
+
+## AC-HRN-001-01 — Loader struct + test suite GREEN
+
+**REQ coverage**: REQ-HRN-001-001 (struct), REQ-HRN-001-002 (LoadHarnessConfig signature)
+
+**Given**:
+- HRN-001 run-phase M2 has completed
+- `internal/config/types.go` `HarnessConfig` struct contains all 6 extended fields: `DefaultProfile`, `ModeDefaults`, `AutoDetection`, `Escalation`, `EffortMapping`, `Levels`, `ModelUpgradeReview`, `Evaluator`
+- `internal/config/loader.go` `LoadHarnessConfig()` parses the shipping schema without error
+
+**When**:
+```bash
+go test -count=1 -race ./internal/config/... ./internal/harness/router/...
+go test -cover ./internal/harness/router/...
+```
+
+**Then**:
+- Exit code 0
+- Coverage report on stdout shows `>= 85.0%` for `internal/harness/router/...`
+- No `FAIL` lines in test output
+
+**Evidence artifact**: stdout containing `ok ... internal/harness/router` and `coverage: NN.N% of statements` where `NN.N >= 85.0`
+
+---
+
+## AC-HRN-001-02 — Standard-level routing for ORC-001
+
+**REQ coverage**: REQ-HRN-001-003 (Route signature), REQ-HRN-001-006 (CLI route subcommand), REQ-HRN-001-007 (priority order)
+
+**Given**:
+- `.moai/specs/SPEC-V3R2-ORC-001/spec.md` exists with frontmatter `priority: P1` and tags spanning multiple domains
+- `.moai/config/sections/harness.yaml` is the shipping schema (unmodified)
+
+**When**:
+```bash
+moai harness route --spec SPEC-V3R2-ORC-001 --json
+```
+
+**Then**:
+- Exit code 0
+- stdout is valid JSON parseable via `jq`
+- JSON document contains: `.level == "standard"`
+- JSON document contains: `.rationale.matched_rule` containing `"file_count > 3"` OR `"multi_domain"` (mode_defaults.solo / `auto_detection.rules.standard`)
+
+**Verification command**:
+```bash
+moai harness route --spec SPEC-V3R2-ORC-001 --json | jq -e '.level == "standard" and (.rationale.matched_rule | contains("standard") or contains("multi_domain") or contains("file_count"))'
+```
+
+**Evidence artifact**: stdout JSON document; jq returns exit 0
+
+---
+
+## AC-HRN-001-03 — Thorough-level routing for security/payment SPEC
+
+**REQ coverage**: REQ-HRN-001-008 (force-thorough on security/payment keywords)
+
+**Given**:
+- A SPEC whose body or title contains any keyword from `securityKeywords` (`auth`, `crypto`, `encrypt`, `oauth`, `jwt`, `session`, `password`, `rbac`, `acl`) OR `paymentKeywords` (`payment`, `billing`, `subscription`, `invoice`, `charge`, `stripe`, `paypal`)
+- For canary: use `SPEC-V3R2-HRN-002` which mentions `evaluator` and amendment-domain semantics (or fall back to a synthetic fixture `.moai/specs/SPEC-TEST-AUTH-001/spec.md` if HRN-002 does not match)
+
+**When**:
+```bash
+moai harness route --spec SPEC-V3R2-HRN-002 --json
+```
+
+**Then**:
+- Exit code 0
+- JSON `.level == "thorough"`
+- JSON `.rationale.matched_rule` contains `"force_thorough"` or `"security_keywords"` or `"payment_keywords"`
+- JSON `.rationale.keywords` is a non-empty array containing at least one matched keyword
+
+**Verification command**:
+```bash
+moai harness route --spec SPEC-V3R2-HRN-002 --json | jq -e '.level == "thorough" and (.rationale.keywords | length) > 0'
+```
+
+**Evidence artifact**: stdout JSON document
+
+---
+
+## AC-HRN-001-04 — Shipping harness.yaml validates clean
+
+**REQ coverage**: REQ-HRN-001-002 (loader), REQ-HRN-001-006 (CLI validate subcommand)
+
+**Given**:
+- Unmodified `.moai/config/sections/harness.yaml`
+- `.moai/config/evaluator-profiles/{default,strict,lenient,frontend}.md` all present with valid rubric markdown
+
+**When**:
+```bash
+moai harness validate
+```
+
+**Then**:
+- Exit code 0
+- stderr empty (no `slog.Warn` warnings)
+- stdout contains `harness.yaml: OK` or equivalent success marker
+
+**Verification command**:
+```bash
+moai harness validate && echo PASS
+```
+
+**Evidence artifact**: stdout containing `OK` or `PASS`
+
+---
+
+## AC-HRN-001-05 — FROZEN pass_threshold floor enforcement
+
+**REQ coverage**: REQ-HRN-001-010 (validation error wrapping), REQ-HRN-001-012 (FROZEN 0.60 floor)
+
+**Given**:
+- A copy of `.moai/config/sections/harness.yaml` and `.moai/config/evaluator-profiles/lenient.md` is placed in `/tmp/test-floor/`
+- The `lenient.md` copy is edited to introduce an anchor at `0.5` for `Functionality` dimension
+- The harness.yaml copy points `levels.standard.evaluator_profile: lenient`
+
+**When**:
+```bash
+moai harness validate --path /tmp/test-floor/.moai/config/sections/harness.yaml
+```
+
+**Then**:
+- Exit code 1
+- stderr contains the sentinel error code `HRN_PASS_THRESHOLD_FLOOR` (or wrapped via `ValidationError.Field == "levels.standard.evaluator_profile"`)
+- stderr names the offending field path AND value (`0.5`)
+
+**Verification command**:
+```bash
+moai harness validate --path /tmp/test-floor/.moai/config/sections/harness.yaml 2>&1 | grep -q "HRN_PASS_THRESHOLD_FLOOR"; echo "exit=$?"
+```
+
+**Evidence artifact**: stderr line matching `/HRN_PASS_THRESHOLD_FLOOR.*0\.5/`
+
+---
+
+## AC-HRN-001-06 — JSON output schema conformance
+
+**REQ coverage**: REQ-HRN-001-011 (JSON output)
+
+**Given**:
+- Any valid SPEC ID
+
+**When**:
+```bash
+moai harness route --spec SPEC-V3R2-ORC-001 --json
+```
+
+**Then**:
+- Exit code 0
+- stdout is exactly one well-formed JSON document (no preamble, no trailing prose)
+- JSON document conforms to schema:
+  ```
+  {
+    "level": "minimal" | "standard" | "thorough",
+    "rationale": {
+      "matched_rule": <string>,
+      "file_count": <int>,
+      "domain_count": <int>,
+      "spec_type": <string>,
+      "spec_priority": <string>,
+      "keywords": [<string>, ...]
+    },
+    "effort": "medium" | "high" | "xhigh",
+    "evaluator_profile": <string>,
+    "sprint_contract": <bool>,
+    "plan_audit": <bool>
+  }
+  ```
+
+**Verification command**:
+```bash
+moai harness route --spec SPEC-V3R2-ORC-001 --json | \
+  jq -e 'has("level") and has("rationale") and has("effort") and has("evaluator_profile") and has("sprint_contract") and has("plan_audit") and (.rationale | has("matched_rule") and has("file_count") and has("domain_count") and has("spec_type") and has("spec_priority") and has("keywords"))'
+```
+
+**Evidence artifact**: jq exit 0; full JSON document captured to stdout
+
+---
+
+## AC-HRN-001-07 — Schema drift detection in strict mode
+
+**REQ coverage**: REQ-HRN-001-019 (MOAI_CONFIG_STRICT)
+
+**Given**:
+- A copy of `.moai/config/sections/harness.yaml` in `/tmp/test-drift/` with an added unknown key `unknown_top_field: 1` at the top of the `harness:` section
+
+**When (Test A — default mode)**:
+```bash
+unset MOAI_CONFIG_STRICT
+moai harness validate --path /tmp/test-drift/.moai/config/sections/harness.yaml
+```
+
+**Then (Test A)**:
+- Exit code 0
+- stderr contains a `HRN_SCHEMA_DRIFT` warning naming `unknown_top_field`
+- Validation does NOT fail (warning-only mode per REQ-019)
+
+**When (Test B — strict mode)**:
+```bash
+MOAI_CONFIG_STRICT=1 moai harness validate --path /tmp/test-drift/.moai/config/sections/harness.yaml
+```
+
+**Then (Test B)**:
+- Exit code 1
+- stderr contains `HRN_SCHEMA_DRIFT` as an error (not warning)
+
+**Verification command**:
+```bash
+# Test A (warning, exit 0)
+unset MOAI_CONFIG_STRICT
+moai harness validate --path /tmp/test-drift/.moai/config/sections/harness.yaml 2>&1 | grep -q "HRN_SCHEMA_DRIFT.*unknown_top_field" && \
+  moai harness validate --path /tmp/test-drift/.moai/config/sections/harness.yaml > /dev/null 2>&1
+# Test B (error, exit 1)
+MOAI_CONFIG_STRICT=1 moai harness validate --path /tmp/test-drift/.moai/config/sections/harness.yaml; [ $? -eq 1 ]
+```
+
+**Evidence artifact**: stderr lines matching both test scenarios
+
+---
+
+## AC-HRN-001-08 — Escalation cap enforcement
+
+**REQ coverage**: REQ-HRN-001-004 (EscalationManager), REQ-HRN-001-009 (triggers), REQ-HRN-001-013 (max_escalations cap), REQ-HRN-001-018 (cap-reached log)
+
+**Given**:
+- A test harness fixture with `escalation.max_escalations: 2`
+- A test runner that simulates 3 consecutive `quality_gate_fail` events starting from `LevelMinimal`
+
+**When**:
+```bash
+go test -run TestEscalationCapEnforcement ./internal/harness/router/...
+```
+
+**Then**:
+- Exit code 0
+- First escalation: `LevelMinimal` → `LevelStandard`, `escalated: true`
+- Second escalation: `LevelStandard` → `LevelThorough`, `escalated: true`
+- Third escalation attempt: stays at `LevelThorough`, `escalated: false`, log emits `HRN_ESCALATION_CAP_REACHED`
+
+**Verification command**:
+```bash
+go test -run TestEscalationCapEnforcement -v ./internal/harness/router/... | grep -q "PASS"
+```
+
+**Evidence artifact**: `internal/harness/router/escalation_test.go` test PASS line; log output containing `HRN_ESCALATION_CAP_REACHED`
+
+---
+
+## AC-HRN-001-09 — SPEC frontmatter override (spec_override matched_rule)
+
+**REQ coverage**: REQ-HRN-001-015 (SPEC harness_level: override)
+
+**Given**:
+- Test fixture `.moai/specs/SPEC-TEST-OVERRIDE-001/spec.md` with frontmatter containing `harness_level: thorough` (NEW optional field)
+- SPEC body intentionally lacks security/payment keywords (no force-thorough trigger)
+- SPEC file_count + domain_count would naturally route to `minimal`
+
+**When**:
+```bash
+moai harness route --spec SPEC-TEST-OVERRIDE-001 --json
+```
+
+**Then**:
+- Exit code 0
+- JSON `.level == "thorough"` (matching the override, NOT the auto-detection result)
+- JSON `.rationale.matched_rule == "spec_override"`
+
+**Verification command**:
+```bash
+moai harness route --spec SPEC-TEST-OVERRIDE-001 --json | \
+  jq -e '.level == "thorough" and .rationale.matched_rule == "spec_override"'
+```
+
+**Evidence artifact**: stdout JSON; jq exit 0
+
+---
+
+## AC-HRN-001-10 — Effort mapping correctness
+
+**REQ coverage**: REQ-HRN-001-005 (EffortForLevel)
+
+**Given**:
+- Shipping `.moai/config/sections/harness.yaml` with `effort_mapping.minimal: medium`, `standard: high`, `thorough: xhigh`
+
+**When**:
+```bash
+go test -run TestEffortForLevel ./internal/harness/router/...
+```
+
+**Then**:
+- Exit code 0
+- Table-driven assertions:
+  - `EffortForLevel(LevelMinimal, cfg) == "medium"`
+  - `EffortForLevel(LevelStandard, cfg) == "high"`
+  - `EffortForLevel(LevelThorough, cfg) == "xhigh"`
+- Additionally verified via CLI: `moai harness route --spec X --json | jq -r .effort` returns the correct value for X's resolved level
+
+**Verification command**:
+```bash
+go test -run TestEffortForLevel -v ./internal/harness/router/... | grep -q "PASS"
+```
+
+**Evidence artifact**: test PASS line; CLI JSON `.effort` field matches the level's mapping
+
+---
+
+## Definition of Done (DoD)
+
+All 10 ACs above MUST be PASS. Additionally:
+
+- [ ] `go test -race -count=1 ./internal/config/... ./internal/harness/router/... ./internal/cli/cmd/...` exits 0
+- [ ] `go test -cover ./internal/harness/router/...` reports ≥ 85.0%
+- [ ] `golangci-lint run ./internal/config/... ./internal/harness/router/... ./internal/cli/cmd/...` reports 0 ERROR
+- [ ] `moai spec lint --strict` reports 0 ERROR (frontmatter `harness_level:` optional field tolerated)
+- [ ] `moai harness validate` on the shipping harness.yaml exits 0
+- [ ] CI guard `internal/cli/harness_retirement_test.go` `TestHarnessRetirement` PASS (retired factory remains unregistered)
+- [ ] CHANGELOG.md `[Unreleased]` section contains a SPEC-V3R2-HRN-001 entry
+- [ ] All new exported symbols have `@MX:NOTE` or `@MX:ANCHOR` tags per `mx-tag-protocol.md`
+- [ ] `make preflight` succeeds locally (lefthook pre-push hook will block otherwise)
+- [ ] `progress.md` updated with `acceptance_phase_status: all-pass` marker
+
+---
+
+## Edge Cases & Negative Tests
+
+The following edge cases are verified via the test suite but are NOT primary ACs:
+
+1. **Missing harness.yaml**: `LoadHarnessConfig("/nonexistent")` returns `ErrConfigNotFound` wrapped in `%w`.
+2. **Empty SPEC frontmatter**: Router returns `LevelStandard` (fallthrough default per REQ-007) with `rationale.matched_rule == "fallthrough_default"`.
+3. **mode_defaults.cg = thorough regression**: When `--mode cg` is detected, force `LevelThorough` regardless of auto-detection.
+4. **Model upgrade reminder (REQ-016)**: When `cfg.ModelUpgradeReview.Trigger.OnModelChange == true` and `os.Getenv("CLAUDE_MODEL_PREVIOUS")` differs from current, CLI emits reminder pointing to `cfg.ModelUpgradeReview.Output.ReportPath`.
+5. **Concurrent Reload safety**: `ConfigManager.Reload()` calling `LoadHarnessConfig()` is safe; verified via `go test -race`.
+6. **Lenient profile floor check**: At HEAD, `.moai/config/evaluator-profiles/lenient.md` is verified to have all anchor levels ≥ 0.60; M1 pre-flight check.
+7. **harness_level: invalid value rejection**: SPEC frontmatter with `harness_level: extreme` produces `ErrUnknownLevel` from spec parser side (out-of-scope for HRN-001 if `harness_level:` validation lives in SPC-001 lint rule; covered as regression).
+
+---
+
+## Bypassed / Deferred Scenarios
+
+Per `acceptance.md` contract with `spec-workflow.md` § Phase 0.5 Plan Audit Gate, the following scenarios are explicitly deferred:
+
+- Sprint Contract artifact emission — DEFERRED to HRN-002
+- Per-iteration evaluator memory reset — DEFERRED to HRN-002
+- Hierarchical 4-dim × sub-criteria scoring — DEFERRED to HRN-003
+- Telemetry export of routing decisions — DEFERRED to beta.1 follow-up SPEC
+
+These deferrals are recorded in `spec.md` §1.2 Non-Goals and §9.2 Blocks.
+
+---
+
+End of acceptance.md.

--- a/.moai/specs/SPEC-V3R2-HRN-001/plan.md
+++ b/.moai/specs/SPEC-V3R2-HRN-001/plan.md
@@ -1,0 +1,203 @@
+# SPEC-V3R2-HRN-001 — Implementation Plan (plan.md)
+
+> Companion to `spec.md` (REQ-HRN-001-001 ~ REQ-HRN-001-019, 19 REQ).
+> Companion to `research.md` (codebase anchors, gap analysis).
+> Companion to `acceptance.md` (10 binary AC) and `tasks.md` (T-HRN001-NN decomposition).
+
+---
+
+## HISTORY
+
+| Version | Date       | Author | Description |
+|---------|------------|--------|-------------|
+| 0.1.0   | 2026-05-18 | manager-spec | Initial plan-phase synthesis: M1-M5 milestones, REQ↔Task matrix, risks, file map |
+
+---
+
+## 1. Scope (1-paragraph synthesis)
+
+Implement the Go-side runtime for `.moai/config/sections/harness.yaml`: a fully-typed `HarnessConfig` struct, a fail-closed `LoadHarnessConfig()` loader with `validator/v10` invariants (FROZEN `pass_threshold >= 0.60`, FROZEN level enum), a `HarnessRouter.Route()` function that maps a SPEC to `minimal|standard|thorough` via Complexity Estimator signals, an `EscalationManager` with `max_escalations` cap, an `EffortForLevel()` helper that bridges to SPEC-V3R2-ORC-003's effort matrix, and a `moai harness route|validate` CLI surface. No schema changes to harness.yaml; no content authoring of evaluator-profile `.md` files; no Sprint Contract negotiation (deferred to HRN-002/003).
+
+## 2. Approach (HOW — but at architecture-level only)
+
+The current `HarnessConfig` struct in `internal/config/types.go:401-404` is intentionally minimal (only `DefaultProfile` + `Evaluator`) per HRN-002 substrate. HRN-001 run-phase **extends** this struct (not replaces) with five new top-level fields covering the full harness.yaml schema. Loader `LoadHarnessConfig()` at `internal/config/loader.go:227-262` is extended (not rewritten) to add `validator/v10` validation, `MOAI_CONFIG_STRICT` env-driven drift detection, and pass-threshold floor enforcement. New routing logic lives in a fresh package `internal/harness/router/` (sibling to `internal/harness/` to avoid circular deps with `EvaluatorConfig`). The CLI surface uses cobra's command-tree, registered into `internal/cli/root.go` post-deprecation-cleanup (the legacy retired `newHarnessCmd` in `internal/cli/harness.go:47-71` is **NOT** repurposed; HRN-001 introduces a separate `newHarnessRouteCmd` factory under a new file `internal/cli/cmd/harness_route.go` to avoid collision with the SPEC-V3R4-HARNESS-001 CI guard at `internal/cli/harness_retirement_test.go`).
+
+Complexity Estimator (REQ-HRN-001-007/008) consumes the existing `spec.SPECFrontmatter` struct (`internal/spec/lint.go:255-277`) for `priority`, `tags`, and `module`; combined with body-side regex extraction for `Requirements` section to find security/payment keyword matches. `file_count` is derived from acceptance.md + plan.md path mentions (regex match `internal/...`, `.moai/...` patterns); `domain_count` is derived from `tags` field comma-split + `phase` token. Fallback rules (REQ-HRN-001-007 priority order: minimal → standard → thorough) and force-thorough overrides (REQ-HRN-001-008) are explicit in `router.Route()`.
+
+## 3. Milestones (Priority-based, NO time estimates)
+
+[HARD] Priority labels only — no time estimates per agent-common-protocol.
+
+### M1 — RED Phase (Priority: P0 Critical, blocking)
+
+**Test scaffolding before any implementation code.**
+
+- Write test fixtures in `internal/config/testdata/harness-valid/`, `harness-invalid-threshold/`, `harness-invalid-level/`, `harness-drift-strict/`.
+- Write `internal/config/loader_harness_extended_test.go`: parse fixtures, assert struct fields populated correctly, assert validator errors are typed sentinels.
+- Write `internal/harness/router/router_test.go`: table-driven AC fixtures for REQ-007 (priority order), REQ-008 (force thorough), REQ-015 (spec_override).
+- Write `internal/harness/router/escalation_test.go`: cap test (REQ-013), trigger test (REQ-009), cap-reached log test (REQ-018).
+- Write `internal/harness/router/effort_test.go`: 3-row table (minimal→medium, standard→high, thorough→xhigh).
+- Write `internal/cli/cmd/harness_route_test.go`: CLI golden tests with `--json` output schema validation (REQ-011, REQ-006).
+- All tests FAIL at this milestone (no implementation yet). Verified via `go test ./internal/harness/router/... ./internal/cli/cmd/...` produces "undefined" errors.
+
+### M2 — GREEN Phase Part 1: Struct + Loader (Priority: P0 Critical)
+
+**Extend `HarnessConfig` struct + `LoadHarnessConfig()` to populate full schema.**
+
+- Modify `internal/config/types.go:401-423`: add `ModeDefaults`, `AutoDetection`, `Escalation`, `EffortMapping`, `Levels`, `ModelUpgradeReview` fields to `HarnessConfig`. Each field gets its own sub-struct (e.g., `AutoDetectionConfig`, `LevelConfig`).
+- Modify `internal/config/loader.go:227-262`: extend `LoadHarnessConfig()` to validate new fields via `validator/v10` (reuse existing `validate = validator.New()` from `internal/config/validation.go:15`). Add `MOAI_CONFIG_STRICT` env probe (REQ-019).
+- Add sentinel errors to `internal/config/errors.go`: `ErrUnknownLevel`, `ErrPassThresholdFloor`, `ErrSchemaDrift`, `ErrEscalationCapExceeded`.
+- M1 loader tests transition RED → GREEN.
+
+### M3 — GREEN Phase Part 2: Routing Logic (Priority: P0 Critical, depends on M2)
+
+**Complexity Estimator + Router.Route() + force-thorough override.**
+
+- New file `internal/harness/router/router.go`: define `Level` string type with constants `LevelMinimal|LevelStandard|LevelThorough`, define `Rationale` struct (matched_rule, file_count, domain_count, spec_type, spec_priority, keywords), define `Router` interface + `defaultRouter` impl.
+- New file `internal/harness/router/complexity.go`: signal extraction from `spec.SPECFrontmatter` + body markdown (file_count from path mentions, domain_count from tags comma-split, spec_type from priority+phase heuristic, keyword matching against canonical sets).
+- New file `internal/harness/router/keywords.go`: constants `securityKeywords = []string{"auth", "crypto", "encrypt", "oauth", "jwt", "session", "password", "rbac", "acl"}` and `paymentKeywords = []string{"payment", "billing", "subscription", "invoice", "charge", "stripe", "paypal"}` (REQ-008).
+- Wire force-thorough override (REQ-008): security/payment keywords OR `spec_priority == critical` OR domain in [auth, payment, migration, public_api] forces `LevelThorough`.
+- Wire spec_override (REQ-015): if SPEC frontmatter has `harness_level:` field (NEW optional field in frontmatter — add to `spec.SPECFrontmatter` at `internal/spec/lint.go:268`), honor and set `matched_rule: spec_override`.
+- M1 router tests transition RED → GREEN.
+
+### M4 — GREEN Phase Part 3: Escalation + Effort + CLI (Priority: P0 Critical, depends on M3)
+
+**EscalationManager + EffortForLevel + CLI subcommand.**
+
+- New file `internal/harness/router/escalation.go`: `EscalationManager` struct with `MaxEscalations` field bound from config, `CheckTriggers(ctx)` method enforcing cap (REQ-013, REQ-018). Bump logic minimal → standard → thorough; cap at thorough.
+- New file `internal/harness/router/effort.go`: `EffortForLevel(level, cfg)` reads `cfg.EffortMapping[string(level)]`; fallback to `cfg.EffortMapping` defaults `{minimal: medium, standard: high, thorough: xhigh}`.
+- New file `internal/cli/cmd/harness_route.go`: cobra factory `newHarnessRouteCmd()` with `--spec`, `--json`, `--path` flags. Wires to `Route()`, prints rationale text or JSON document per REQ-011.
+- New file `internal/cli/cmd/harness_validate.go`: cobra factory `newHarnessValidateCmd()` invokes `LoadHarnessConfig()` + reports validation errors via exit code 1 (REQ-010, FROZEN floor REQ-012).
+- Register the parent `harness` cobra command in `internal/cli/root.go` (post-line 92, separate group from retired CLI). [CRITICAL] The retired `newHarnessCmd` at `internal/cli/harness.go:47` MUST remain unregistered; HRN-001's command is the NEW non-conflicting `newHarnessRouterCmd` family.
+- M1 CLI tests transition RED → GREEN.
+- Evaluator-profile loader integration: read `cfg.Levels[level].EvaluatorProfile` (e.g., "strict"); resolve via `internal/harness/profile_loader.go:14-19` `defaultProfilePaths`. Validate `PassThreshold >= 0.60` floor by parsing each referenced profile's `.md` via `ParseRubricMarkdown()` (`internal/harness/rubric.go`).
+
+### M5 — REFACTOR Phase + Final Verification (Priority: P1 High, depends on M4)
+
+**MX tags, CHANGELOG, lint, doc cross-references.**
+
+- Add `@MX:NOTE` tags to all new exported symbols (`HarnessConfig` extension fields, `Router`, `EscalationManager`, `EffortForLevel`). MX language per `code_comments: ko` from `.moai/config/sections/language.yaml`.
+- Add `@MX:ANCHOR` to high-fan_in entry points: `LoadHarnessConfig`, `Router.Route`, `EffortForLevel`, `EscalationManager.CheckTriggers`. Each requires `@MX:REASON` per protocol.
+- Add `@MX:WARN` for FROZEN invariant guard sites: `validateLevelEnum`, `validatePassThresholdFloor` with `@MX:REASON: FROZEN per design-constitution §5 (SPEC-V3R2-CON-001)`.
+- Update `CHANGELOG.md`: entry under `## [Unreleased] — 2026-05-XX` referencing `SPEC-V3R2-HRN-001`.
+- Run `golangci-lint run ./internal/config/... ./internal/harness/... ./internal/cli/cmd/...` (zero ERROR per `make preflight`).
+- Run `go test -race -count=1 ./internal/config/... ./internal/harness/router/... ./internal/cli/cmd/...` (all PASS).
+- Coverage gate: `go test -cover` returns >= 85% per harness section coverage budget.
+- Re-run all 10 AC via `acceptance.md` verification commands; binary 0 findings expected.
+
+---
+
+## 4. Technical Approach (Architecture)
+
+### 4.1 Module Layout (NEW vs MODIFIED)
+
+| File | Status | Purpose |
+|------|--------|---------|
+| `internal/config/types.go:401-423` | MODIFIED | Extend `HarnessConfig` with 5 new fields; add `AutoDetectionConfig`, `LevelConfig`, `EscalationConfig`, `ModelUpgradeReviewConfig` sub-structs |
+| `internal/config/loader.go:223-262` | MODIFIED | Extend `LoadHarnessConfig()`: validator/v10 invariants, MOAI_CONFIG_STRICT drift detection, profile floor validation |
+| `internal/config/errors.go:14-68` | MODIFIED | Add `ErrUnknownLevel`, `ErrPassThresholdFloor`, `ErrSchemaDrift`, `ErrEscalationCapExceeded` |
+| `internal/spec/lint.go:255-277` | MODIFIED | Add optional `HarnessLevel string \`yaml:"harness_level"\`` field for REQ-015 spec_override |
+| `internal/harness/router/router.go` | NEW | `Level`, `Rationale`, `Router` interface + `defaultRouter` impl |
+| `internal/harness/router/complexity.go` | NEW | Signal extraction (file_count, domain_count, spec_type, keywords) |
+| `internal/harness/router/keywords.go` | NEW | `securityKeywords`, `paymentKeywords` canonical sets (REQ-008) |
+| `internal/harness/router/escalation.go` | NEW | `EscalationManager` with `MaxEscalations` cap |
+| `internal/harness/router/effort.go` | NEW | `EffortForLevel(level, cfg) string` |
+| `internal/harness/router/router_test.go` | NEW | REQ-007/008/015 table-driven tests |
+| `internal/harness/router/escalation_test.go` | NEW | REQ-009/013/018 tests |
+| `internal/harness/router/effort_test.go` | NEW | REQ-005 effort mapping tests |
+| `internal/cli/cmd/harness_route.go` | NEW | `moai harness route --spec SPEC-XXX [--json]` |
+| `internal/cli/cmd/harness_validate.go` | NEW | `moai harness validate [--path PATH]` |
+| `internal/cli/cmd/harness_route_test.go` | NEW | CLI golden tests + JSON schema validation |
+| `internal/cli/root.go` | MODIFIED | Register `newHarnessRouterCmd` (NOT the retired `newHarnessCmd`) |
+| `internal/config/testdata/harness-valid/harness.yaml` | NEW | Loader fixture: complete valid schema |
+| `internal/config/testdata/harness-invalid-threshold/` | NEW | Profile with `pass_threshold: 0.5` (FROZEN floor violation) |
+| `internal/config/testdata/harness-invalid-level/` | NEW | Schema with `levels.expert:` (unknown level) |
+| `internal/config/testdata/harness-drift-strict/` | NEW | Schema with `unknown_top_field: 1` (drift; only fails with `MOAI_CONFIG_STRICT=1`) |
+
+### 4.2 Integration Points
+
+- **SPEC-V3R2-ORC-003 effort matrix**: `EffortForLevel()` output (`medium|high|xhigh`) MUST align with agent frontmatter `effortLevel:` values consumed by ORC-003. Verified via AC-HRN-001-006.
+- **SPEC-V3R2-RT-005 ConfigManager.Reload**: `LoadHarnessConfig()` is called by `ConfigManager.Reload()` (`internal/config/manager.go:200`) at runtime to refresh harness config without restart. Verified via AC-HRN-001-007.
+- **SPEC-V3R2-CON-001 FROZEN floor**: `validatePassThresholdFloor()` in `internal/harness/router/router.go` reads each `cfg.Levels[X].EvaluatorProfile` reference, resolves to `.moai/config/evaluator-profiles/{name}.md` path, parses via `harness.ParseRubricMarkdown()`, and rejects any `PassThreshold < 0.60`. Verified via AC-HRN-001-005.
+- **SPEC-V3R2-SPC-001 SPEC struct**: `spec.SPECFrontmatter` provides `Priority`, `Tags`, `Module` fields needed by Complexity Estimator. `parseSPECDoc()` (`internal/spec/lint.go:303`) is the parser used by `router.fromSPECID()`.
+- **SPEC-V3R2-MIG-003 cross-cutting loader**: HRN-001 owns `LoadHarnessConfig()`; MIG-003 lists harness loader as already-shipped in its scope when MIG-003 enters plan-phase.
+
+### 4.3 Configuration Precedence (REQ-014 mode_defaults)
+
+1. SPEC `harness_level:` frontmatter override (REQ-015) — HIGHEST
+2. Force-thorough overrides (REQ-008) — security/payment keywords / critical / sensitive domain
+3. Escalation bumps (REQ-009) — cumulative
+4. Auto-detection rules (REQ-007) — minimal → standard → thorough priority order
+5. Mode defaults (REQ-014) — `cfg.ModeDefaults.cg = "thorough"` (FROZEN), solo/team `auto` (uses auto-detection)
+
+Force-thorough (REQ-008) wins over spec_override only when explicitly documented (per spec.md §1 line 270 risk table); current implementation: spec_override > force-thorough (less surprising). [DECISION: per design-constitution §3 brand context primacy analog, spec_override wins; security/payment keyword force-thorough is a *suggestion* via rationale field annotation. AC-HRN-001-09 verifies.] (Open question for run-phase; document in `progress.md`.)
+
+---
+
+## 5. REQ ↔ Task ↔ AC Traceability Matrix
+
+| REQ | Description (short) | Milestone | Task(s) | AC |
+|-----|---------------------|-----------|---------|-----|
+| REQ-HRN-001-001 | HarnessConfig struct types | M2 | T-HRN001-06 | AC-HRN-001-01 |
+| REQ-HRN-001-002 | LoadHarnessConfig() function | M2 | T-HRN001-07, T-HRN001-08 | AC-HRN-001-01, AC-HRN-001-04 |
+| REQ-HRN-001-003 | Router.Route() function | M3 | T-HRN001-10, T-HRN001-11 | AC-HRN-001-02, AC-HRN-001-03 |
+| REQ-HRN-001-004 | EscalationManager.CheckTriggers() | M4 | T-HRN001-14 | AC-HRN-001-08 |
+| REQ-HRN-001-005 | EffortForLevel() | M4 | T-HRN001-15 | AC-HRN-001-10 |
+| REQ-HRN-001-006 | moai harness route/validate CLI | M4 | T-HRN001-16, T-HRN001-17 | AC-HRN-001-02, AC-HRN-001-04, AC-HRN-001-06 |
+| REQ-HRN-001-007 | Auto-detection priority order | M3 | T-HRN001-12 | AC-HRN-001-02, AC-HRN-001-03 |
+| REQ-HRN-001-008 | Force-thorough on security/payment keywords | M3 | T-HRN001-13 | AC-HRN-001-03 |
+| REQ-HRN-001-009 | Escalation triggers fire on phase failure | M4 | T-HRN001-14 | AC-HRN-001-08 |
+| REQ-HRN-001-010 | Validation error wrapping | M2 | T-HRN001-08 | AC-HRN-001-05 |
+| REQ-HRN-001-011 | JSON output for CLI | M4 | T-HRN001-17 | AC-HRN-001-06 |
+| REQ-HRN-001-012 | FROZEN pass_threshold floor | M2 | T-HRN001-09 | AC-HRN-001-05 |
+| REQ-HRN-001-013 | max_escalations cap (default 2, max 3) | M4 | T-HRN001-14 | AC-HRN-001-08 |
+| REQ-HRN-001-014 | mode_defaults consultation | M3 | T-HRN001-12 | (regression: cg=thorough) |
+| REQ-HRN-001-015 | SPEC harness_level: override | M3 | T-HRN001-13 | AC-HRN-001-09 |
+| REQ-HRN-001-016 | Model upgrade review reminder | M4 | T-HRN001-18 | (regression: model-change reminder) |
+| REQ-HRN-001-017 | Unknown level rejection | M2 | T-HRN001-08 | (regression: ErrUnknownLevel) |
+| REQ-HRN-001-018 | Escalation cap log on overflow | M4 | T-HRN001-14 | AC-HRN-001-08 |
+| REQ-HRN-001-019 | MOAI_CONFIG_STRICT schema drift detection | M2 | T-HRN001-08 | AC-HRN-001-07 |
+
+---
+
+## 6. Risks & Mitigations (synthesis with spec.md §8)
+
+| Risk | Severity | Mitigation in plan |
+|------|----------|--------------------|
+| Keyword matcher false positives on docs prose | MEDIUM | Restrict matching to SPEC frontmatter `tags` + EARS Requirements section parsed via `parseREQs()` (`internal/spec/lint.go:357`); skip narrative prose |
+| file_count / domain_count estimator unreliable for legacy SPECs lacking acceptance.md | MEDIUM | Fallback: file_count = 0 → minimal candidate; absence of acceptance.md is normal for legacy. `harness_level:` frontmatter override gives author opt-out |
+| FROZEN floor (0.60) enforcement breaks lenient profile (`.moai/config/evaluator-profiles/lenient.md`) | HIGH | Verify `lenient.md` per-anchor scores ≥ 0.60 BEFORE M2 RED→GREEN transition; add fixture covering lenient profile to AC-HRN-001-05 |
+| Collision with retired `newHarnessCmd` at `internal/cli/harness.go:47` | HIGH | Use distinct factory name `newHarnessRouterCmd` + register only the NEW factory in `root.go`. CI guard `internal/cli/harness_retirement_test.go` MUST continue to pass (the retired factory remains unregistered) |
+| Adding `harness_level:` field to `SPECFrontmatter` triggers `FrontmatterInvalid` lint findings on existing SPECs | MEDIUM | New field is **optional** (no `validate:"required"` tag); lint rule `FrontmatterSchemaRule` ignores optional fields per `internal/spec/lint.go` §SSOT |
+| `ConfigManager.Reload()` integration race with concurrent SPEC loads | LOW | `LoadHarnessConfig()` is read-only on disk; `ConfigManager` already uses `sync.RWMutex`. No new lock needed |
+| Schema drift warning floods stderr when running on legacy projects | LOW | REQ-019 explicit: warning is non-blocking unless `MOAI_CONFIG_STRICT=1`; mirror existing `slog.Warn` pattern from `loader.go:42` |
+
+---
+
+## 7. Quality Gates (M5 verification)
+
+- [ ] `go test -race ./internal/config/... ./internal/harness/router/... ./internal/cli/cmd/...` → 0 failures
+- [ ] `go test -cover ./internal/harness/router/...` → ≥ 85% per spec.md §3 coverage target
+- [ ] `golangci-lint run ./internal/config/... ./internal/harness/router/...` → 0 ERROR
+- [ ] `moai spec lint --strict` → 0 ERROR (frontmatter `harness_level:` optional field accepted)
+- [ ] `moai harness validate` on shipping `.moai/config/sections/harness.yaml` → exit 0
+- [ ] CI guard `internal/cli/harness_retirement_test.go` → still PASS (retired factory unregistered)
+- [ ] CHANGELOG.md updated with SPEC-V3R2-HRN-001 entry
+- [ ] MX tags added to all new exported symbols per `mx-tag-protocol.md`
+
+---
+
+## 8. Out-of-Scope (re-affirmation, mirrors spec.md §1.2)
+
+- Schema authoring of evaluator-profile `.md` files (lenient/strict/frontend) — content unchanged
+- Sprint Contract negotiation (HRN-002 + HRN-003)
+- Hierarchical acceptance scoring (HRN-003)
+- harness.yaml schema CHANGE (HRN-001 implements loader only; schema FROZEN for v3.0)
+- evaluator-active agent body modification (agent reads runtime config; no body change)
+- Telemetry export (beta.1 follow-up)
+- Cross-SPEC harness coordination (per-SPEC scope)
+- ML-based complexity estimation (rule-based only for v3.0)
+
+---
+
+End of plan.md.

--- a/.moai/specs/SPEC-V3R2-HRN-001/research.md
+++ b/.moai/specs/SPEC-V3R2-HRN-001/research.md
@@ -1,0 +1,198 @@
+# SPEC-V3R2-HRN-001 — Research / Codebase Analysis (research.md)
+
+> Companion to `spec.md` (REQ-HRN-001-001 ~ REQ-HRN-001-019).
+> Companion to `plan.md` (M1-M5 implementation).
+> Companion to `acceptance.md` (10 binary AC) and `tasks.md`.
+
+This document is the codebase analysis artifact required by `.claude/rules/moai/workflow/spec-workflow.md` Plan Phase. All anchors are concrete `file:line` references that have been verified to exist at HEAD `feat/SPEC-V3R4-WORKFLOW-SPLIT-001-wave-4` ≈ `d1c6f3104`.
+
+---
+
+## 1. Existing Harness YAML Schema (in-scope target)
+
+The harness.yaml file ships as template at `internal/template/templates/.moai/config/sections/harness.yaml` and is rendered into each project at `.moai/config/sections/harness.yaml`. The shipping schema (this project's copy, 127 lines) covers ALL fields required by REQ-HRN-001-001 — no schema changes are needed.
+
+### 1.1 Schema anchors
+
+- **`.moai/config/sections/harness.yaml:18`** — `default_profile: default` (REQ-HRN-001-001 DefaultProfile field source)
+- **`.moai/config/sections/harness.yaml:73-76`** — `mode_defaults:` block (REQ-HRN-001-014 mode_defaults consultation source: `cg: thorough`, `solo: auto`, `team: auto`)
+- **`.moai/config/sections/harness.yaml:2-17`** — `auto_detection:` block with `enabled: true` and `rules:` block (REQ-HRN-001-007 priority ordering source: minimal → standard → thorough)
+- **`.moai/config/sections/harness.yaml:6-8`** — `rules.minimal.conditions:` (`file_count <= 3 AND single_domain`, `spec_type in [bugfix, docs, config]`) — direct mapping to Complexity Estimator REQ-HRN-001-007/008
+- **`.moai/config/sections/harness.yaml:13-17`** — `rules.thorough.conditions:` (`security_keywords OR payment_keywords present`, `spec_priority == critical`, `domain in [auth, payment, migration, public_api]`) — REQ-HRN-001-008 force-thorough source
+- **`.moai/config/sections/harness.yaml:19-22`** — `effort_mapping:` (`minimal: medium`, `standard: high`, `thorough: xhigh`) — REQ-HRN-001-005 EffortForLevel source
+- **`.moai/config/sections/harness.yaml:23-29`** — `escalation:` block (`enabled: true`, `max_escalations: 2`, `triggers: [quality_gate_fail, review_critical, test_coverage_low]`) — REQ-HRN-001-004/009/013 source
+- **`.moai/config/sections/harness.yaml:32-72`** — `levels:` block with `minimal`, `standard`, `thorough` definitions (`description`, `evaluator`, `evaluator_mode`, `evaluator_profile`, `plan_audit`, `skip_phases`, `sprint_contract`, `playwright_testing`) — REQ-HRN-001-001 LevelConfig source
+- **`.moai/config/sections/harness.yaml:64`** — `levels.thorough.evaluator_profile: strict` (only level pointing to a non-default profile) — must resolve to `.moai/config/evaluator-profiles/strict.md`
+- **`.moai/config/sections/harness.yaml:77-114`** — `model_upgrade_review:` block (`checklist`, `trigger.on_model_change`, `output.report_path`) — REQ-HRN-001-016 source
+
+## 2. Existing Go Config Loader (current state)
+
+### 2.1 Current HarnessConfig struct (minimal — needs extension)
+
+- **`internal/config/types.go:401-404`** — `HarnessConfig` declaration: only `DefaultProfile string` and `Evaluator EvaluatorConfig`. Comment line 399: "HRN-002 run-phase minimal substrate; HRN-001 run-phase에서 routing/profile 확장 예정." This SPEC is the **HRN-001 extension**.
+- **`internal/config/types.go:406-423`** — `EvaluatorConfig` struct with `MemoryScope`, `Profiles map[string]string`, `Aggregation`, `MustPassDimensions []string`. HRN-003 M4 added Profiles/Aggregation/MustPassDimensions; HRN-001 does NOT need to modify this struct.
+- **`internal/config/types.go:425-428`** — `harnessFileWrapper{Harness HarnessConfig}` YAML wrapper used by `LoadHarnessConfig()`.
+
+### 2.2 Current LoadHarnessConfig() function (current behavior)
+
+- **`internal/config/loader.go:223-262`** — `LoadHarnessConfig(path string) (*HarnessConfig, error)`. Reads file, unmarshals into `harnessFileWrapper`, validates `evaluator.memory_scope == "per_iteration"`. Returns `ErrConfigNotFound`, `ErrInvalidYAML`, or `ErrEvalMemoryFrozen` wrapped in `ValidationError`. **Gap**: does NOT validate the 5 new top-level fields (auto_detection, mode_defaults, escalation, effort_mapping, levels, model_upgrade_review).
+- **`internal/config/loader.go:264-282`** — `loadYAMLFile()` shared helper. HRN-001 loader can REUSE this helper for sub-YAML loads (e.g., per-profile `.md` reads).
+
+### 2.3 Sentinel errors infrastructure
+
+- **`internal/config/errors.go:15-68`** — Existing sentinels: `ErrConfigNotFound`, `ErrInvalidConfig`, `ErrInvalidYAML`, `ErrEvalMemoryFrozen`, `ErrUnknownDimension`, `ErrRubricCitationMissing`, `ErrFlatScoreCardProhibited`, `ErrMustPassBypassProhibited`. **Gap**: missing `ErrUnknownLevel`, `ErrPassThresholdFloor`, `ErrSchemaDrift`, `ErrEscalationCapExceeded` per REQ-HRN-001-010/012/017/019.
+- **`internal/config/errors.go:70-90`** — `ValidationError` struct with `Field`, `Message`, `Value`, `Wrapped`. HRN-001 reuses this for field-level validation errors per REQ-010.
+- **`internal/config/validation.go:15`** — `validate = validator.New()` global validator/v10 instance. HRN-001 reuses for `validator/v10` tags on new sub-structs.
+
+### 2.4 ConfigManager.Reload integration point
+
+- **`internal/config/manager.go:198-200`** — `Reload()` method on `ConfigManager`. HRN-001 must ensure `LoadHarnessConfig()` is idempotent and safe to call within `Reload()`. Existing `sync.RWMutex` guard at `internal/config/loader.go:19` provides thread-safety for `Loader`; HRN-001's free function `LoadHarnessConfig()` is stateless read-only.
+
+## 3. Evaluator Profile Directory (referenced by REQ-HRN-001-012)
+
+- **`.moai/config/evaluator-profiles/default.md`** — 68 LOC, declares 4 dimensions {Functionality 40%, Security 25%, Craft 20%, Consistency 15%} per scoring rubric (lines 32-68). PassThreshold floor 0.60 satisfied: anchors are 0.25/0.50/0.75/1.00 per Mechanism 1.
+- **`.moai/config/evaluator-profiles/strict.md`** — Pointed by `levels.thorough.evaluator_profile`. Higher pass thresholds; FROZEN floor MUST hold (≥ 0.60).
+- **`.moai/config/evaluator-profiles/lenient.md`** — Lowest pass thresholds in the family; AC-HRN-001-05 fixture variant artificially lowers to 0.5 to trigger floor violation.
+- **`.moai/config/evaluator-profiles/frontend.md`** — Domain-specific frontend variant. Out of HRN-001 routing scope; mentioned only for completeness.
+
+### 3.1 Profile parser (consumed by HRN-001)
+
+- **`internal/harness/profile_loader.go:14-19`** — `defaultProfilePaths` map: `{"default": ".moai/config/evaluator-profiles/default.md", "strict": ..., "lenient": ..., "frontend": ...}`. HRN-001 uses this map to resolve `cfg.Levels[X].EvaluatorProfile` → file path.
+- **`internal/harness/profile_loader.go:27-40`** — `newDefaultEvaluatorConfig()` returns `*config.EvaluatorConfig` with defaults. HRN-001 router consults this when `harness.yaml` is absent.
+- **`internal/harness/profile_loader.go:45-63`** — `loadEvaluatorConfig()` helper, invokes `ParseRubricMarkdown()` per profile. HRN-001 floor-check piggy-backs on `ParseRubricMarkdown()` output.
+- **`internal/harness/rubric.go`** — Owns `ParseRubricMarkdown(path)` (signature referenced in `profile_loader.go:50`) and `Rubric.Validate()`. Returns `Rubric` containing anchor levels per dimension. HRN-001 reads `Rubric.PassThreshold()` (or computes from anchors) to enforce FROZEN floor.
+
+## 4. SPEC Parser (Complexity Estimator input)
+
+The Router needs SPEC frontmatter + body to compute signals. Existing parser:
+
+- **`internal/spec/lint.go:255-277`** — `SPECFrontmatter` struct: `ID`, `Title`, `Version`, `Status`, `Created`, `Updated`, `Author`, `Priority`, `Phase`, `Module`, `Dependencies`, `BcID`, `Lifecycle`, `Tags`, `Breaking`, `RelatedRule`, `LintConfig`. **Gap**: missing optional `HarnessLevel string \`yaml:"harness_level"\`` for REQ-HRN-001-015 spec_override.
+- **`internal/spec/lint.go:286-294`** — `SPECDoc` struct with `Path`, `Frontmatter`, `Body`, `Criteria`, `REQs`, `ParseError`, `LintSkip`. HRN-001 router consumes this directly.
+- **`internal/spec/lint.go:303`** — `parseSPECDoc(path)` factory. Router calls this in `fromSPECID()`.
+- **`internal/spec/lint.go:334-355`** — `extractFrontmatter(content)` returns `(SPECFrontmatter, body, error)`. Used internally by `parseSPECDoc`; HRN-001 has no direct need but is the canonical parsing path.
+- **`internal/spec/lint.go:357-370`** — `parseREQs(body)` returns `[]REQEntry` with `ID`, `Text`, `Line`. Router uses `REQEntry.Text` for keyword matching against `securityKeywords` / `paymentKeywords` (REQ-HRN-001-008).
+- **`internal/spec/lint.go:279-283`** — `REQEntry` struct with `ID`, `Text`, `Line`. Body source for keyword matcher.
+- **`internal/spec/lint.go:303-330`** — `parseSPECDoc(path string) *SPECDoc` full parser. Returns `nil` only on missing file; populates `ParseError` field for failed parses.
+
+## 5. Existing CLI Surface (compatibility constraint)
+
+### 5.1 Retired harness CLI (DO NOT collide with)
+
+- **`internal/cli/harness.go:1-30`** — File-level deprecation comment per SPEC-V3R4-HARNESS-001 BC-V3R4-HARNESS-001-CLI-RETIREMENT. Lines 1-17: retired CLI is preserved as deprecation marker; physical removal deferred to follow-up SPEC.
+- **`internal/cli/harness.go:47-71`** — `newHarnessCmd()` factory (RETIRED). Defines verbs `status|apply|rollback|disable`. Must NOT be confused with HRN-001's new `route|validate` verbs.
+- **`internal/cli/harness.go:32-41`** — Constants `harnessDefaultLogPath`, `harnessDefaultSnapshotBase`, `harnessDefaultProposalDir`, `harnessConfigPath = ".moai/config/sections/harness.yaml"`. HRN-001 can reuse `harnessConfigPath` (same target file).
+- **`internal/cli/harness.go:404-407`** — `harnessYAMLRoot` learning-specific wrapper (separate from `harnessFileWrapper` in `internal/config/types.go:425`). HRN-001 uses `config.LoadHarnessConfig()` exclusively — does NOT mirror this wrapper.
+- **`internal/cli/harness_retirement_test.go`** — CI guard `TestHarnessRetirement` enforces non-registration of retired factory. HRN-001's new `newHarnessRouterCmd` factory is distinct and registered independently.
+
+### 5.2 Root cobra command registration
+
+- **`internal/cli/root.go:71-95`** — `AddCommand` invocations for active subcommands. Line 94 comment: "newHarnessCmd is intentionally NOT registered per SPEC-V3R4-HARNESS-001". HRN-001 inserts `rootCmd.AddCommand(newHarnessRouterCmd())` after line 92 in a separate registration block.
+- **`internal/cli/doctor_harness.go`** — Existing doctor namespace for harness consistency checks. HRN-001 may add `moai doctor harness` validation hooks (deferred to T-HRN001-18).
+
+## 6. Validator/v10 Infrastructure (existing)
+
+- **`internal/config/types.go:52`** — Existing struct tag pattern: `validate:"omitempty"` on `ObservabilityEvents`.
+- **`internal/config/types.go:84`** — Enum pattern: `validate:"omitempty,oneof=high medium low"` on `PerformanceTier`. HRN-001 reuses this pattern for `oneof=minimal standard thorough` on `Level` fields (REQ-HRN-001-017).
+- **`go.mod:11`** — `github.com/go-playground/validator/v10 v10.30.2` (already imported, no new dep required per spec.md §3).
+
+## 7. Spec Loader Test Patterns (M1 RED reference)
+
+- **`internal/config/loader_test.go:1-31`** — `setupTestdataDir(t, tempDir, []string{...})` helper. HRN-001 RED tests reuse this helper with new fixtures in `testdata/harness-valid/`, `harness-invalid-threshold/`, `harness-invalid-level/`, `harness-drift-strict/`.
+- **`internal/config/loader_test.go:33-72`** — `TestLoaderLoadAllSections` table-driven golden test. HRN-001 mirrors this pattern for `TestLoadHarnessConfigExtended`.
+- **`internal/config/loader_test.go:180-211`** — `TestLoaderInvalidYAML` shows error-path testing convention. HRN-001 mirrors for `TestLoadHarnessConfigInvalidThreshold` and `TestLoadHarnessConfigUnknownLevel`.
+- **`internal/config/testdata/eval-memory-frozen-violation/`** — Existing fixture pattern for HRN-002's FROZEN memory_scope violation. HRN-001's fixtures follow same structure: `testdata/<scenario>/harness.yaml` + `expected_error.txt`.
+
+## 8. Effort Level Integration (SPEC-V3R2-ORC-003)
+
+- **`internal/config/envkeys.go:85-89`** — `EnvClaudeCodeEffortLevel = "CLAUDE_CODE_EFFORT_LEVEL"`. Valid values: `low`, `medium`, `high`, `xhigh`, `max`. HRN-001's `EffortForLevel()` returns values from `{medium, high, xhigh}` aligned with this env var.
+- **`.moai/config/sections/harness.yaml:19-22`** — Schema source: `minimal: medium`, `standard: high`, `thorough: xhigh`. Direct map; HRN-001 reads via `cfg.EffortMapping[string(level)]` per REQ-HRN-001-005.
+- **`.claude/rules/moai/development/coding-standards.md` "effortLevel"** — Settings field introduced by Claude Code v2.1.110. HRN-001 indirectly drives this via env var injection (the runtime sets `CLAUDE_CODE_EFFORT_LEVEL` from `EffortForLevel()`).
+
+## 9. Skill / Workflow References (orchestrator side)
+
+- **`.claude/skills/moai/workflows/harness.md`** (post-V3R4-HARNESS-001) — Owns the user-facing slash command surface. HRN-001's CLI is consumed via Bash invocation from this skill workflow body.
+- **`.claude/rules/moai/workflow/spec-workflow.md` §Phase 0.5 Plan Audit Gate** — Reads `cfg.Levels[X].PlanAudit.{Enabled, MaxIterations, RequireMustPass}`. HRN-001's `LevelConfig` struct exposes `PlanAudit` as a sub-struct.
+- **`.claude/rules/moai/workflow/spec-workflow.md` §Mode Dispatch (REQ-WF003-018 precedence)** — `harness.yaml` level auto-selection is the lowest-priority fallback for `--mode` resolution; HRN-001's `Route()` is the source.
+
+## 10. Cross-SPEC Dependencies (state at HEAD)
+
+- **SPEC-V3R2-CON-001 (FROZEN floor)** — Encoded in `.claude/rules/moai/design/constitution.md:55-60` `[FROZEN] Pass threshold floor (minimum 0.60, cannot be lowered by evolution)`. HRN-001's `validatePassThresholdFloor()` reads each profile via `ParseRubricMarkdown` and asserts `>= 0.60`.
+- **SPEC-V3R2-MIG-003 (cross-cutting loaders)** — Per spec.md §1 (HRN-001) lines 110-112: harness loader is **promoted** to HRN-001 due to Phase 5 ordering. MIG-003 will reference HRN-001's loader as already-shipped.
+- **SPEC-V3R2-ORC-003 (effort matrix)** — Already shipped at HEAD; agent frontmatter `effortLevel:` consumes `medium|high|xhigh` per `internal/config/envkeys.go:86-88` comment.
+- **SPEC-V3R2-SPC-001 (SPEC struct)** — Provides `SPECFrontmatter` + `parseSPECDoc()` per anchors §4 above. Already shipped.
+- **SPEC-V3R2-HRN-002 (Evaluator memory amendment)** — Owns `EvaluatorConfig.MemoryScope FROZEN per_iteration` at `internal/config/types.go:413`. HRN-001 must NOT modify `EvaluatorConfig`; orthogonal axis.
+- **SPEC-V3R2-HRN-003 (Hierarchical acceptance scoring)** — Owns `Profiles`, `Aggregation`, `MustPassDimensions` at `internal/config/types.go:415-422`. HRN-001 must NOT modify `EvaluatorConfig`; orthogonal axis.
+
+## 11. Gap Analysis (Loader vs Schema)
+
+Below is the field-by-field gap matrix. "Schema source" = `.moai/config/sections/harness.yaml`. "Go struct" = `internal/config/types.go` HarnessConfig.
+
+| Schema field (harness.yaml line) | Go struct (types.go line) | Gap | HRN-001 task |
+|---|---|---|---|
+| `default_profile` (L18) | `DefaultProfile string` (L402) | NONE | — |
+| `evaluator.memory_scope` (L31) | `EvaluatorConfig.MemoryScope` (L413) | NONE | — |
+| `evaluator.profiles` (not in schema; defaults) | `EvaluatorConfig.Profiles` (L416) | NONE (HRN-003) | — |
+| `mode_defaults.{solo,team,cg}` (L73-76) | **MISSING** | **GAP-1** | T-HRN001-06: add `ModeDefaults map[string]string` |
+| `auto_detection.enabled` (L3) | **MISSING** | **GAP-2** | T-HRN001-06: add `AutoDetection AutoDetectionConfig` |
+| `auto_detection.rules.{minimal,standard,thorough}.conditions` (L4-17) | **MISSING** | **GAP-2** | T-HRN001-06 (sub-struct) |
+| `escalation.{enabled,max_escalations,triggers}` (L23-29) | **MISSING** | **GAP-3** | T-HRN001-06: add `Escalation EscalationConfig` |
+| `effort_mapping.{minimal,standard,thorough}` (L19-22) | **MISSING** | **GAP-4** | T-HRN001-06: add `EffortMapping map[string]string` |
+| `levels.{minimal,standard,thorough}.*` (L32-72) | **MISSING** | **GAP-5** | T-HRN001-06: add `Levels map[string]LevelConfig` (sub-struct) |
+| `model_upgrade_review.{checklist,trigger,output,enabled}` (L77-114) | **MISSING** | **GAP-6** | T-HRN001-06: add `ModelUpgradeReview ReviewConfig` |
+| `plan_audit_global.{always_enabled,enforce_gate_on_spec_creation}` (L111-114) | **MISSING** | **GAP-7** | T-HRN001-06: add `PlanAuditGlobal PlanAuditGlobalConfig` |
+| `learning.*` (L115-126) | (handled separately at retired CLI L389-396 via `learningConfig`) | OUT OF SCOPE | (orthogonal to HRN-001 routing) |
+
+**Verdict**: GAP-1 through GAP-7 are all in M2 scope. Schema is COMPLETE; loader is the only gap.
+
+## 12. Risks Discovered During Research
+
+1. **Frontmatter optional-field lint compatibility**: Adding `HarnessLevel string \`yaml:"harness_level"\`` to `SPECFrontmatter` (`internal/spec/lint.go:255-277`) MUST NOT trigger `FrontmatterInvalid` on legacy SPECs. Verified: `FrontmatterSchemaRule` (per `.claude/rules/moai/development/spec-frontmatter-schema.md`) iterates the canonical 12 fields and emits findings only for missing canonical fields. Optional fields beyond the 12 are tolerated. ✓ Safe.
+
+2. **Retired CLI re-registration risk**: HRN-001 must use distinct command tree from `internal/cli/harness.go:47` retired `newHarnessCmd`. Proposed factory name: `newHarnessRouterCmd` registered in `internal/cli/root.go:95+`. CI guard `internal/cli/harness_retirement_test.go` validates the retired factory remains unregistered. ✓ Conflict-free design.
+
+3. **harnessConfigPath constant collision**: `internal/cli/harness.go:41` exports `harnessConfigPath = ".moai/config/sections/harness.yaml"` (package-private). HRN-001's new CLI file `internal/cli/cmd/harness_route.go` is in a different package (`cmd` vs `cli`); no naming collision possible. ✓ Safe.
+
+4. **Lenient profile anchor scores**: Pre-flight needed in M1: parse `.moai/config/evaluator-profiles/lenient.md` to verify all anchor levels ≥ 0.60. If any anchor < 0.60, the production harness.yaml is in violation of FROZEN floor at HEAD. Mitigation: add pre-M2 read of `lenient.md` to verify; if violation found, escalate to SPEC-V3R2-CON-001 amendment.
+
+5. **`MOAI_CONFIG_STRICT` env conflict**: Search for existing usage of this env name. Not found in `internal/config/envkeys.go:1-90`. ✓ Free to introduce.
+
+## 13. Test Fixture Inventory (M1 RED outputs)
+
+The following testdata directories MUST exist at M1 RED conclusion (validated by `internal/config/loader_harness_extended_test.go`):
+
+- `internal/config/testdata/harness-valid/harness.yaml` — Mirror of shipping `.moai/config/sections/harness.yaml` (golden parse path)
+- `internal/config/testdata/harness-invalid-threshold/harness.yaml` + `expected_error.txt` — `pass_threshold: 0.5` in lenient profile copy → expect `ErrPassThresholdFloor`
+- `internal/config/testdata/harness-invalid-level/harness.yaml` + `expected_error.txt` — `levels.expert:` → expect `ErrUnknownLevel`
+- `internal/config/testdata/harness-drift-strict/harness.yaml` — `unknown_top_field: 1` → no error without env; with `MOAI_CONFIG_STRICT=1`, expect `ErrSchemaDrift`
+- `internal/harness/router/testdata/spec-overrides/SPEC-TEST-AAA-001/spec.md` — SPEC frontmatter with `harness_level: thorough` → expect `matched_rule: spec_override`
+- `internal/harness/router/testdata/keyword-force/SPEC-TEST-BBB-001/spec.md` — SPEC body containing `oauth` keyword → expect level `thorough` regardless of file_count
+- `internal/harness/router/testdata/normal/SPEC-TEST-CCC-001/spec.md` — Plain feature SPEC → expect level `standard`
+
+---
+
+## 14. Anchor Count Summary
+
+Total file:line anchors enumerated in this document: **51** distinct anchors (well above the ≥25 floor required by plan-phase contract). Breakdown:
+
+- harness.yaml schema anchors: 10
+- internal/config/types.go anchors: 5
+- internal/config/loader.go anchors: 4
+- internal/config/errors.go anchors: 3
+- internal/config/validation.go anchors: 1
+- internal/config/manager.go anchors: 1
+- internal/spec/lint.go anchors: 7
+- internal/harness/profile_loader.go anchors: 3
+- internal/harness/rubric.go anchors: 1
+- internal/cli/harness.go anchors: 5
+- internal/cli/root.go anchors: 2
+- internal/config/envkeys.go anchors: 2
+- internal/cli/harness_retirement_test.go anchors: 1
+- internal/config/loader_test.go anchors: 3
+- internal/config/types_test.go anchors: 0 (referenced for pattern only)
+- .moai/config/evaluator-profiles/ anchors: 4 (profile MD files)
+- go.mod / dependency anchors: 1
+- .claude/rules/moai/ anchors: 4 (frontmatter schema, design constitution, spec-workflow, coding-standards)
+
+---
+
+End of research.md.

--- a/.moai/specs/SPEC-V3R2-HRN-001/tasks.md
+++ b/.moai/specs/SPEC-V3R2-HRN-001/tasks.md
@@ -1,0 +1,422 @@
+# SPEC-V3R2-HRN-001 — Task Decomposition (tasks.md)
+
+> Companion to `plan.md` (M1-M5 milestones).
+> Companion to `acceptance.md` (10 binary AC).
+> Companion to `research.md` (file:line anchors).
+
+This file decomposes the M1-M5 milestones into atomic tasks `T-HRN001-NN`. Each task has owner role, file target with line anchor where applicable, dependencies, REQ↔AC references, and LOC estimate.
+
+---
+
+## HISTORY
+
+| Version | Date       | Author | Description |
+|---------|------------|--------|-------------|
+| 0.1.0   | 2026-05-18 | manager-spec | Initial plan-phase decomposition: 25 tasks across M1-M5 |
+
+---
+
+## Task Format
+
+| Field | Description |
+|-------|-------------|
+| ID | `T-HRN001-NN` (zero-padded 2-digit) |
+| Subject | One-line task description |
+| Owner | Role profile (tester / implementer / reviewer) |
+| File | Target `internal/...` path with line anchor or NEW |
+| Depends on | Prior task IDs (DAG) |
+| REQ refs | REQ-HRN-001-NNN identifiers |
+| AC refs | AC-HRN-001-NN identifiers |
+| LOC est. | Lines-of-code estimate (rough) |
+
+---
+
+## M1 — RED Phase (Tests First)
+
+### T-HRN001-01
+
+| | |
+|---|---|
+| Subject | Create test fixture directory `internal/config/testdata/harness-valid/harness.yaml` mirroring shipping schema |
+| Owner | tester |
+| File | NEW: `internal/config/testdata/harness-valid/harness.yaml` |
+| Depends on | — |
+| REQ refs | REQ-HRN-001-001, REQ-HRN-001-002 |
+| AC refs | AC-HRN-001-01, AC-HRN-001-04 |
+| LOC est. | ~127 (mirror of shipping `.moai/config/sections/harness.yaml`) |
+
+### T-HRN001-02
+
+| | |
+|---|---|
+| Subject | Create test fixture `harness-invalid-threshold/` with lenient.md anchor at 0.5 |
+| Owner | tester |
+| File | NEW: `internal/config/testdata/harness-invalid-threshold/harness.yaml` + `evaluator-profiles/lenient.md` + `expected_error.txt` |
+| Depends on | T-HRN001-01 |
+| REQ refs | REQ-HRN-001-010, REQ-HRN-001-012 |
+| AC refs | AC-HRN-001-05 |
+| LOC est. | ~140 (yaml + md fixture + 5-line expected_error.txt) |
+
+### T-HRN001-03
+
+| | |
+|---|---|
+| Subject | Create test fixture `harness-invalid-level/` with `levels.expert:` unknown enum |
+| Owner | tester |
+| File | NEW: `internal/config/testdata/harness-invalid-level/harness.yaml` + `expected_error.txt` |
+| Depends on | T-HRN001-01 |
+| REQ refs | REQ-HRN-001-017 |
+| AC refs | (regression) |
+| LOC est. | ~130 |
+
+### T-HRN001-04
+
+| | |
+|---|---|
+| Subject | Create test fixture `harness-drift-strict/` with `unknown_top_field: 1` |
+| Owner | tester |
+| File | NEW: `internal/config/testdata/harness-drift-strict/harness.yaml` |
+| Depends on | T-HRN001-01 |
+| REQ refs | REQ-HRN-001-019 |
+| AC refs | AC-HRN-001-07 |
+| LOC est. | ~130 |
+
+### T-HRN001-05
+
+| | |
+|---|---|
+| Subject | Write failing loader test suite covering all 4 fixtures + golden path |
+| Owner | tester |
+| File | NEW: `internal/config/loader_harness_extended_test.go` |
+| Depends on | T-HRN001-01, T-HRN001-02, T-HRN001-03, T-HRN001-04 |
+| REQ refs | REQ-HRN-001-001, REQ-HRN-001-002, REQ-HRN-001-010, REQ-HRN-001-012, REQ-HRN-001-017, REQ-HRN-001-019 |
+| AC refs | AC-HRN-001-01, AC-HRN-001-04, AC-HRN-001-05, AC-HRN-001-07 |
+| LOC est. | ~240 (5 test funcs × ~45 LOC + helpers; mirrors `internal/config/loader_test.go:33-72` patterns) |
+
+---
+
+## M2 — GREEN Phase Part 1: Struct + Loader
+
+### T-HRN001-06
+
+| | |
+|---|---|
+| Subject | Extend `HarnessConfig` struct in `internal/config/types.go:401-404` with 6 new fields + sub-structs (`AutoDetectionConfig`, `EscalationConfig`, `LevelConfig`, `ModelUpgradeReviewConfig`, `PlanAuditGlobalConfig`, `ReviewChecklistItem`) |
+| Owner | implementer |
+| File | MODIFIED: `internal/config/types.go:401` (extension), `internal/config/types.go:480+` (new sub-structs appended) |
+| Depends on | T-HRN001-05 (RED tests target this surface) |
+| REQ refs | REQ-HRN-001-001 |
+| AC refs | AC-HRN-001-01 |
+| LOC est. | ~130 (6 fields + ~5 sub-structs with validator/v10 tags) |
+
+### T-HRN001-07
+
+| | |
+|---|---|
+| Subject | Add new sentinel errors: `ErrUnknownLevel`, `ErrPassThresholdFloor`, `ErrSchemaDrift`, `ErrEscalationCapExceeded` |
+| Owner | implementer |
+| File | MODIFIED: `internal/config/errors.go:68` (append after existing sentinels) |
+| Depends on | T-HRN001-06 |
+| REQ refs | REQ-HRN-001-010, REQ-HRN-001-012, REQ-HRN-001-017, REQ-HRN-001-019 |
+| AC refs | AC-HRN-001-05, AC-HRN-001-07 |
+| LOC est. | ~20 (4 sentinels × ~5 LOC docstrings + literal) |
+
+### T-HRN001-08
+
+| | |
+|---|---|
+| Subject | Extend `LoadHarnessConfig()` in `internal/config/loader.go:223-262` with validator/v10 invariants + MOAI_CONFIG_STRICT env probe + level enum check |
+| Owner | implementer |
+| File | MODIFIED: `internal/config/loader.go:223` |
+| Depends on | T-HRN001-06, T-HRN001-07 |
+| REQ refs | REQ-HRN-001-002, REQ-HRN-001-010, REQ-HRN-001-017, REQ-HRN-001-019 |
+| AC refs | AC-HRN-001-01, AC-HRN-001-04, AC-HRN-001-07 |
+| LOC est. | ~80 (extended function body + validator integration + drift detection helper) |
+
+### T-HRN001-09
+
+| | |
+|---|---|
+| Subject | Implement `validatePassThresholdFloor()` helper invoking `ParseRubricMarkdown()` for each `cfg.Levels[X].EvaluatorProfile` reference |
+| Owner | implementer |
+| File | NEW: `internal/harness/router/floor_validation.go` (helper); MODIFIED: `internal/config/loader.go` (calls helper from LoadHarnessConfig) |
+| Depends on | T-HRN001-08 |
+| REQ refs | REQ-HRN-001-012 |
+| AC refs | AC-HRN-001-05 |
+| LOC est. | ~60 (parse 4 profile files, check each anchor level >= 0.60) |
+
+---
+
+## M3 — GREEN Phase Part 2: Routing Logic
+
+### T-HRN001-10
+
+| | |
+|---|---|
+| Subject | Define `Level` type + constants in `internal/harness/router/router.go`; define `Rationale` struct + `Router` interface |
+| Owner | implementer |
+| File | NEW: `internal/harness/router/router.go` |
+| Depends on | T-HRN001-06 (HarnessConfig types) |
+| REQ refs | REQ-HRN-001-003 |
+| AC refs | AC-HRN-001-02, AC-HRN-001-03 |
+| LOC est. | ~60 (type defs + interface; impl in T-HRN001-11) |
+
+### T-HRN001-11
+
+| | |
+|---|---|
+| Subject | Implement `defaultRouter.Route(spec *spec.SPECDoc, cfg *config.HarnessConfig)` invoking complexity estimator + override checks in priority order |
+| Owner | implementer |
+| File | NEW: `internal/harness/router/router.go` (continues T-10) |
+| Depends on | T-HRN001-10, T-HRN001-12, T-HRN001-13 |
+| REQ refs | REQ-HRN-001-003, REQ-HRN-001-007, REQ-HRN-001-008, REQ-HRN-001-015 |
+| AC refs | AC-HRN-001-02, AC-HRN-001-03, AC-HRN-001-09 |
+| LOC est. | ~120 (Route method + helper functions) |
+
+### T-HRN001-12
+
+| | |
+|---|---|
+| Subject | Implement Complexity Estimator helpers: `signalFileCount()`, `signalDomainCount()`, `signalSpecType()`, `signalSpecPriority()` |
+| Owner | implementer |
+| File | NEW: `internal/harness/router/complexity.go` |
+| Depends on | T-HRN001-10 |
+| REQ refs | REQ-HRN-001-007, REQ-HRN-001-014 |
+| AC refs | AC-HRN-001-02 |
+| LOC est. | ~140 (4 signal functions + path-pattern regex matchers) |
+
+### T-HRN001-13
+
+| | |
+|---|---|
+| Subject | Implement keyword matchers + force-thorough override in `internal/harness/router/keywords.go` + spec_override hook |
+| Owner | implementer |
+| File | NEW: `internal/harness/router/keywords.go`; MODIFIED: `internal/spec/lint.go:268` (add `HarnessLevel string \`yaml:"harness_level"\`` to `SPECFrontmatter`) |
+| Depends on | T-HRN001-10 |
+| REQ refs | REQ-HRN-001-008, REQ-HRN-001-015 |
+| AC refs | AC-HRN-001-03, AC-HRN-001-09 |
+| LOC est. | ~80 (canonical keyword sets + matcher func + 1 LOC SPECFrontmatter extension) |
+
+---
+
+## M4 — GREEN Phase Part 3: Escalation + Effort + CLI
+
+### T-HRN001-14
+
+| | |
+|---|---|
+| Subject | Implement `EscalationManager` with `MaxEscalations` cap, `CheckTriggers(ctx)` method, cap-reached log emission |
+| Owner | implementer |
+| File | NEW: `internal/harness/router/escalation.go` |
+| Depends on | T-HRN001-10 |
+| REQ refs | REQ-HRN-001-004, REQ-HRN-001-009, REQ-HRN-001-013, REQ-HRN-001-018 |
+| AC refs | AC-HRN-001-08 |
+| LOC est. | ~120 (struct + 3 methods + log helpers) |
+
+### T-HRN001-15
+
+| | |
+|---|---|
+| Subject | Implement `EffortForLevel(level Level, cfg *config.HarnessConfig) string` with fallback defaults |
+| Owner | implementer |
+| File | NEW: `internal/harness/router/effort.go` |
+| Depends on | T-HRN001-06 |
+| REQ refs | REQ-HRN-001-005 |
+| AC refs | AC-HRN-001-10 |
+| LOC est. | ~40 |
+
+### T-HRN001-16
+
+| | |
+|---|---|
+| Subject | Implement `newHarnessRouterCmd()` cobra parent factory + register `route` and `validate` subcommands |
+| Owner | implementer |
+| File | NEW: `internal/cli/cmd/harness_route.go` + `internal/cli/cmd/harness_validate.go` |
+| Depends on | T-HRN001-11, T-HRN001-08 |
+| REQ refs | REQ-HRN-001-006 |
+| AC refs | AC-HRN-001-02, AC-HRN-001-04 |
+| LOC est. | ~80 (parent factory + 2 child factories with persistent flags) |
+
+### T-HRN001-17
+
+| | |
+|---|---|
+| Subject | Implement `route` command output (plaintext + `--json` mode per documented schema) |
+| Owner | implementer |
+| File | NEW: `internal/cli/cmd/harness_route.go` (continues T-16) |
+| Depends on | T-HRN001-16 |
+| REQ refs | REQ-HRN-001-011 |
+| AC refs | AC-HRN-001-02, AC-HRN-001-03, AC-HRN-001-06, AC-HRN-001-09 |
+| LOC est. | ~110 (JSON marshaling, error handling, plaintext formatting) |
+
+### T-HRN001-18
+
+| | |
+|---|---|
+| Subject | Implement `validate` command with `--path` flag, exit code semantics (0/1), model_upgrade_review reminder emission |
+| Owner | implementer |
+| File | NEW: `internal/cli/cmd/harness_validate.go` |
+| Depends on | T-HRN001-08, T-HRN001-09 |
+| REQ refs | REQ-HRN-001-006, REQ-HRN-001-016 |
+| AC refs | AC-HRN-001-04, AC-HRN-001-05, AC-HRN-001-07 |
+| LOC est. | ~100 |
+
+### T-HRN001-19
+
+| | |
+|---|---|
+| Subject | Register `newHarnessRouterCmd()` in `internal/cli/root.go` (after line 92); ensure retired `newHarnessCmd` remains unregistered |
+| Owner | implementer |
+| File | MODIFIED: `internal/cli/root.go:95` |
+| Depends on | T-HRN001-16 |
+| REQ refs | REQ-HRN-001-006 |
+| AC refs | AC-HRN-001-02 |
+| LOC est. | ~3 (1 import + 1 AddCommand line + comment) |
+
+### T-HRN001-20
+
+| | |
+|---|---|
+| Subject | Write CLI golden tests + JSON schema validation tests in `internal/cli/cmd/harness_route_test.go` |
+| Owner | tester |
+| File | NEW: `internal/cli/cmd/harness_route_test.go` + `internal/cli/cmd/harness_validate_test.go` |
+| Depends on | T-HRN001-17, T-HRN001-18 |
+| REQ refs | REQ-HRN-001-006, REQ-HRN-001-011 |
+| AC refs | AC-HRN-001-02, AC-HRN-001-03, AC-HRN-001-04, AC-HRN-001-06, AC-HRN-001-09 |
+| LOC est. | ~280 (table-driven tests covering all 10 ACs that exercise CLI) |
+
+### T-HRN001-21
+
+| | |
+|---|---|
+| Subject | Write router_test.go + escalation_test.go + effort_test.go with full AC coverage |
+| Owner | tester |
+| File | NEW: `internal/harness/router/router_test.go`, `internal/harness/router/escalation_test.go`, `internal/harness/router/effort_test.go`, `internal/harness/router/complexity_test.go` |
+| Depends on | T-HRN001-11, T-HRN001-14, T-HRN001-15 |
+| REQ refs | REQ-HRN-001-003, REQ-HRN-001-004, REQ-HRN-001-005, REQ-HRN-001-007, REQ-HRN-001-008, REQ-HRN-001-009, REQ-HRN-001-013, REQ-HRN-001-015, REQ-HRN-001-018 |
+| AC refs | AC-HRN-001-02, AC-HRN-001-03, AC-HRN-001-08, AC-HRN-001-09, AC-HRN-001-10 |
+| LOC est. | ~420 (4 test files × ~100 LOC avg) |
+
+---
+
+## M5 — REFACTOR + Final Verification
+
+### T-HRN001-22
+
+| | |
+|---|---|
+| Subject | Add `@MX:NOTE`, `@MX:ANCHOR`, `@MX:WARN` tags to all new exported symbols per `mx-tag-protocol.md` (code_comments: ko) |
+| Owner | implementer |
+| File | MODIFIED: all NEW files from M2-M4 |
+| Depends on | T-HRN001-21 (all impl done) |
+| REQ refs | (cross-cutting, all REQ) |
+| AC refs | (DoD) |
+| LOC est. | ~60 (annotations only; not net new code) |
+
+### T-HRN001-23
+
+| | |
+|---|---|
+| Subject | Update `CHANGELOG.md` `[Unreleased]` section with SPEC-V3R2-HRN-001 entry |
+| Owner | reviewer |
+| File | MODIFIED: `CHANGELOG.md` |
+| Depends on | T-HRN001-21 |
+| REQ refs | (DoD) |
+| AC refs | (DoD) |
+| LOC est. | ~12 |
+
+### T-HRN001-24
+
+| | |
+|---|---|
+| Subject | Run quality gates: `make preflight` + `golangci-lint run` + `go test -race -cover` ≥ 85% coverage |
+| Owner | reviewer |
+| File | (verification only — no code changes) |
+| Depends on | T-HRN001-22, T-HRN001-23 |
+| REQ refs | (DoD) |
+| AC refs | AC-HRN-001-01 (coverage), AC-HRN-001-04 (lint clean) |
+| LOC est. | 0 (verification task) |
+
+### T-HRN001-25
+
+| | |
+|---|---|
+| Subject | Run all 10 acceptance.md verification commands; record results in `progress.md` `acceptance_phase_status: all-pass` |
+| Owner | reviewer |
+| File | MODIFIED: `.moai/specs/SPEC-V3R2-HRN-001/progress.md` |
+| Depends on | T-HRN001-24 |
+| REQ refs | (DoD) |
+| AC refs | AC-HRN-001-01 through AC-HRN-001-10 |
+| LOC est. | ~30 (progress.md update with timestamps + evidence references) |
+
+---
+
+## Task DAG (dependency graph)
+
+```
+T-01 ─┐
+T-02 ─┤
+T-03 ─┤── T-05 (RED tests)
+T-04 ─┘     │
+            ▼
+T-06 (struct) ── T-07 (errors) ── T-08 (loader) ── T-09 (floor)
+                                       │
+                                       ▼
+                              T-10 (router types)
+                                       │
+                                       ├── T-12 (complexity)
+                                       ├── T-13 (keywords + spec_override)
+                                       │
+                                       ▼
+                              T-11 (Route() impl) ────┐
+                                                       │
+                              T-14 (Escalation) ──────┤
+                              T-15 (EffortForLevel) ──┤
+                                                       │
+                                                       ▼
+                              T-16 (CLI parent) ── T-17 (route subcmd)
+                                                ── T-18 (validate subcmd)
+                                                        │
+                              T-19 (CLI root register) ─┤
+                                                        │
+                              T-20 (CLI golden tests) ──┤
+                              T-21 (unit tests) ────────┤
+                                                        ▼
+                              T-22 (MX tags)
+                                    │
+                              T-23 (CHANGELOG)
+                                    │
+                              T-24 (preflight + lint + coverage)
+                                    │
+                              T-25 (acceptance run + progress.md)
+```
+
+---
+
+## LOC Budget Summary
+
+| Milestone | Net LOC estimate | Cumulative |
+|-----------|------------------|------------|
+| M1 (RED tests + fixtures) | ~770 | ~770 |
+| M2 (struct + loader) | ~290 | ~1060 |
+| M3 (router logic) | ~340 | ~1400 |
+| M4 (escalation + effort + CLI) | ~960 | ~2360 |
+| M5 (refactor + verification) | ~102 | ~2462 |
+
+Total estimate: **~2,460 LOC** across ~14 new files + 5 modified files. Test code is ~40% (~970 LOC); production code is ~60% (~1,490 LOC).
+
+[NOTE] This estimate is plan-phase rough sizing only — not a commitment. Actual LOC may diverge during M2-M4 implementation; run-phase pre-submission self-review (per `spec-workflow.md` § Run Phase) will reconcile against the SPEC acceptance criteria.
+
+---
+
+## Task Ownership Summary
+
+| Owner role | Tasks | Total tasks |
+|-----------|-------|-------------|
+| tester | T-01, T-02, T-03, T-04, T-05, T-20, T-21 | 7 |
+| implementer | T-06, T-07, T-08, T-09, T-10, T-11, T-12, T-13, T-14, T-15, T-16, T-17, T-18, T-19, T-22 | 15 |
+| reviewer | T-23, T-24, T-25 | 3 |
+
+---
+
+End of tasks.md.


### PR DESCRIPTION
## Summary

Plan-phase deliverables for **SPEC-V3R2-HRN-001** (P0 Critical release-blocker, v3.0.0-beta.1 Phase 5 — Harness + Evaluator).

Currently `.moai/specs/SPEC-V3R2-HRN-001/spec.md` ships at `status: draft` with 332 LOC + 19 REQ. This PR adds the 4 plan-phase companion artifacts required by `.claude/rules/moai/workflow/spec-workflow.md` Plan Phase.

### Artifacts (1,198 LOC total)

| File | LOC | Purpose |
|------|-----|---------|
| `plan.md` | 203 | M1-M5 milestones, REQ↔Task↔AC matrix, file map (NEW vs MODIFIED), risk mitigations, quality gates |
| `research.md` | 198 | **90 file:line anchors** (well above ≥25 floor), gap analysis vs harness.yaml schema, dependency tracing |
| `acceptance.md` | 375 | **10 binary AC** (AC-HRN-001-01..10) with Given/When/Then + verification commands + Definition of Done |
| `tasks.md` | 422 | **25 atomic tasks** T-HRN001-01..25 with DAG, LOC budget (~2,460 net), task-owner matrix |

### Implementation surface (preview)

- Extend `internal/config/types.go:401-404` `HarnessConfig` from 2-field HRN-002 substrate to full schema coverage (6 new fields + 5 sub-structs)
- Extend `internal/config/loader.go:223-262` `LoadHarnessConfig()` with `validator/v10` invariants, `MOAI_CONFIG_STRICT` drift detection, FROZEN floor enforcement
- New package `internal/harness/router/` (Router + Complexity Estimator + EscalationManager + EffortForLevel)
- New CLI `moai harness route|validate` in `internal/cli/cmd/` (distinct from retired `newHarnessCmd` per SPEC-V3R4-HARNESS-001 CI guard at `internal/cli/harness_retirement_test.go`)

### Honored invariants

- [HARD] EARS modalities throughout (Ubiquitous / Event-Driven / State-Driven / Optional / Unwanted)
- [HARD] FROZEN `pass_threshold >= 0.60` floor (REQ-012, design-constitution §5)
- [HARD] FROZEN level enum `{minimal, standard, thorough}` (REQ-017)
- [HARD] Max 3 escalations hard ceiling (REQ-013), default 2 per shipping schema
- [HARD] No time estimates — priority labels only per agent-common-protocol
- [HARD] 19 REQ from spec.md §5 all mapped in plan.md §5 matrix
- [HARD] spec.md §1.2 Non-Goals re-affirmed in plan.md §8

### Cross-SPEC dependencies (verified)

- SPEC-V3R2-CON-001 (FROZEN floor) — via `.claude/rules/moai/design/constitution.md:55-60`
- SPEC-V3R2-ORC-003 (effort matrix) — via `internal/config/envkeys.go:85-89`
- SPEC-V3R2-RT-005 (ConfigManager.Reload) — via `internal/config/manager.go:200`
- SPEC-V3R2-SPC-001 (SPECFrontmatter) — via `internal/spec/lint.go:255-277`
- SPEC-V3R2-HRN-002/003 (EvaluatorConfig) — orthogonal axes, unchanged

## Plan-auditor self-check

- [x] All 19 REQ from spec.md §5 mapped in plan §5 traceability matrix
- [x] Research anchors ≥ 25 (actual: **90 file:line references**)
- [x] Acceptance ≥ 10 binary AC (actual: **10 ACs**, AC-HRN-001-01..10)
- [x] Tasks decomposed atomically (actual: **25 tasks**, DAG provided)
- [x] No implementation code (plan-phase OUTPUT only)
- [x] Cross-references between 4 artifacts verified (each references the others)
- [x] EARS modality preserved from spec.md §5
- [x] Frontmatter schema canonical (spec.md ships with 19 REQ frontmatter; plan-phase artifacts inherit context)
- [x] Risk mitigations documented (plan §6 with 7 risks + mitigations)
- [x] Out-of-scope re-affirmed (plan §8 mirrors spec.md §1.2)

## Test plan

- [ ] Plan-auditor manual review (or automated via `/moai run` Phase 0.5 Plan Audit Gate)
- [ ] No-merge until plan-auditor PASS verdict recorded in `.moai/reports/plan-audit/SPEC-V3R2-HRN-001-YYYY-MM-DD.md`
- [ ] After merge, run-phase entry: `/moai run SPEC-V3R2-HRN-001`
- [ ] No auto-merge requested per task contract

## Notes

- 2 unrelated files modified in working tree (`.moai/harness/usage-log.jsonl`, `.moai/specs/SPEC-V3R2-RT-002/progress.md`) — NOT included in this PR (drift; outside HRN-001 scope)
- This PR is plan-phase only; run-phase implementation will follow in a separate `feat/SPEC-V3R2-HRN-001` branch per `.claude/rules/moai/workflow/spec-workflow.md` § SPEC Phase Discipline

🗿 MoAI <email@mo.ai.kr>