### PR TITLE
plan(SPEC-V3R2-MIG-002): Hook Registration Cleanup — 4 artifacts

### DIFF
--- a/.moai/specs/SPEC-V3R2-MIG-002/acceptance.md
+++ b/.moai/specs/SPEC-V3R2-MIG-002/acceptance.md
@@ -1,0 +1,236 @@
+---
+spec_id: SPEC-V3R2-MIG-002
+phase: acceptance
+status: draft
+---
+
+# Acceptance Criteria — SPEC-V3R2-MIG-002
+
+Each criterion is **binary verifiable** with a single shell command or Go test invocation. Mapping to REQs follows the spec.md ↔ plan.md reconciliation in research.md §9.
+
+## AC-MIG002-A1 — Three-way sync invariant holds
+
+**Given** the merged main branch after MIG-002
+**When** `go test ./internal/hook/ -run TestAuditThreeWaySync -v` is invoked
+**Then** the test PASSES with zero `HOOK_SYNC_DRIFT` and zero `HOOK_WRAPPER_ORPHAN` diagnostics.
+
+Maps: REQ-MIG002-009, REQ-MIG002-010.
+
+Binary verification:
+```bash
+go test ./internal/hook/ -run TestAuditThreeWaySync -v 2>&1 | grep -E "PASS|FAIL"
+# Expected: contains "PASS:", does not contain "FAIL:"
+```
+
+## AC-MIG002-A2 — EventSetup constant retired
+
+**Given** the merged main branch after MIG-002 M2.1
+**When** `grep -rn "EventSetup" internal/hook/ internal/cli/` is invoked
+**Then** output is empty (zero matches).
+
+Maps: REQ-MIG002-003 (`setupHandler` retire — reconciled to "EventSetup constant retire" per research.md §8).
+
+Binary verification:
+```bash
+test -z "$(grep -rn 'EventSetup' internal/hook/ internal/cli/ 2>/dev/null)"
+# Expected: exit code 0 (no matches)
+```
+
+## AC-MIG002-A3 — `moai hook setup` CLI subcommand removed
+
+**Given** the built `moai` binary after MIG-002
+**When** `moai hook setup --help` is invoked
+**Then** the command fails with cobra's "unknown command" error.
+
+Maps: REQ-MIG002-003.
+
+Binary verification:
+```bash
+moai hook setup --help 2>&1 | grep -q "unknown command"
+# Expected: exit code 0
+```
+
+## AC-MIG002-A4 — Per-file Resolution headers preserved
+
+**Given** the merged main branch after MIG-002
+**When** `go test ./internal/hook/ -run TestAuditPerFileCategoryHeader -v` is invoked
+**Then** all 25 handler files (down from 26 after EventSetup retirement) carry a valid `// Resolution: <CATEGORY>` header.
+
+Maps: REQ-MIG002-001 (3-way sync), implicitly REQ-MIG002-002.
+
+Binary verification:
+```bash
+go test ./internal/hook/ -run TestAuditPerFileCategoryHeader -v 2>&1 | grep -E "FAIL"
+# Expected: empty output (no FAIL lines)
+```
+
+## AC-MIG002-A5 — Retired events absent from settings.json.tmpl
+
+**Given** the rendered `settings.json` from `internal/template/templates/.claude/settings.json.tmpl`
+**When** parsed as JSON and `Object.keys(result.hooks)` is enumerated
+**Then** none of `Notification`, `Elicitation`, `ElicitationResult`, `TaskCreated`, `Setup` appear.
+
+Maps: REQ-MIG002-001, REQ-MIG002-003.
+
+Binary verification:
+```bash
+go test ./internal/hook/ -run TestAuditRetiredEventsNotInSettings -v 2>&1 | grep -q "PASS"
+# Expected: exit code 0
+```
+
+## AC-MIG002-A6 — Registration parity (22 native + 4 retired = 26 → 25 post-retirement)
+
+**Given** the merged main branch after MIG-002
+**When** `go test ./internal/hook/ -run TestAuditRegistrationParity -v` is invoked
+**Then** the test PASSES with `nativeCount == 22` (settings.json keys unchanged) AND the Go handler count adjusts to **25** (was 26; `EventSetup` no longer contributes since the constant is removed; `setupHandler` never existed so no actual handler is removed).
+
+Maps: REQ-MIG002-002 (handler count ≤ 22 reconciled — the spec.md target was off-by-one; correct target is 22 native settings.json keys + 4 retired-obs-only).
+
+Binary verification:
+```bash
+go test ./internal/hook/ -run TestAuditRegistrationParity -v 2>&1 | grep -q "PASS"
+# Expected: exit code 0
+```
+
+Note: the spec.md REQ-MIG002-002 said "≤ 22 handlers". That number conflated settings.json keys with Go handlers; the verifiable invariant after reconciliation is "22 settings.json keys + 4 obs-only Go handlers" (the truth-table from `audit_test.go:88-101`).
+
+## AC-MIG002-A7 — User-local settings.json cleanup is idempotent and archival
+
+**Given** a fixture `<projectRoot>/.claude/settings.json` with `Notification` + `Elicitation` entries
+**When** `internal/migrate.CleanupUserSettings(projectRoot)` is invoked
+**Then**:
+1. `<projectRoot>/.claude/settings.json` no longer contains those entries.
+2. `<projectRoot>/.moai/archive/hooks/v3.0/migration-<YYYY-MM-DD>.json` is created with the removed entries.
+3. Re-invoking `CleanupUserSettings(projectRoot)` produces no further modifications (idempotent).
+
+Maps: REQ-MIG002-011, REQ-MIG002-012, REQ-MIG002-019.
+
+Binary verification:
+```bash
+go test ./internal/migrate/ -run TestCleanupUserSettings -v 2>&1 | grep -q "PASS"
+# Expected: exit code 0
+```
+
+## AC-MIG002-A8 — RT-006 work product locked (no stub regression)
+
+**Given** the merged main branch after MIG-002
+**When** `go test ./internal/hook/ -run TestAuditNoStubHandlers -v` is invoked
+**Then** the test PASSES, confirming each of `subagent_stop.go`, `config_change.go`, `instructions_loaded.go`, `file_changed.go`, `post_tool_failure.go` carries a `UPGRADE` or `FIX` Resolution header (NOT a `STUB`-like marker).
+
+Maps: REQ-MIG002-004, REQ-MIG002-005, REQ-MIG002-006, REQ-MIG002-007, REQ-MIG002-008 (reconciled to characterization tests — the implementation already shipped via RT-006 per research.md §5.2 / §5.3).
+
+Binary verification:
+```bash
+go test ./internal/hook/ -run TestAuditNoStubHandlers -v 2>&1 | grep -q "PASS"
+# Expected: exit code 0
+```
+
+## AC-MIG002-A9 — Doctor coverage table summary consistent
+
+**Given** the merged main branch after MIG-002
+**When** `go test ./internal/cli/ -run TestDoctorHook -v` is invoked
+**Then** all doctor-hook tests PASS, with the counts adjusted to reflect EventSetup retirement (the existing assertion `summary.Remove == 1 (setupHandler)` MUST be updated to either `0` (preferred) or kept at `1` with `setupHandler` row preserved in `coverage_table.go` as a historical record; the choice MUST be consistent between code and test).
+
+Maps: implicit dependency from REQ-MIG002-002, REQ-MIG002-003.
+
+Binary verification:
+```bash
+go test ./internal/cli/ -run TestDoctorHook -v 2>&1 | grep -E "FAIL"
+# Expected: empty output
+```
+
+## AC-MIG002-A10 — SPEC frontmatter lint clean
+
+**Given** the post-MIG-002 spec.md with normalized 12-field frontmatter
+**When** `moai spec lint --strict .moai/specs/SPEC-V3R2-MIG-002/` is invoked
+**Then** the lint reports `✓ No findings`.
+
+Maps: implicit — `.claude/rules/moai/development/spec-frontmatter-schema.md` (canonical 12-field schema).
+
+Binary verification:
+```bash
+moai spec lint --strict .moai/specs/SPEC-V3R2-MIG-002/ 2>&1 | grep -q "No findings"
+# Expected: exit code 0
+```
+
+## AC-MIG002-A11 — Coverage thresholds met
+
+**Given** the merged main branch after MIG-002
+**When** `go test -cover ./internal/hook/ ./internal/migrate/` is invoked
+**Then**:
+- `internal/hook/` coverage ≥ 90% (critical-package tier per CLAUDE.local.md §6).
+- `internal/migrate/` coverage ≥ 85% (standard tier).
+
+Maps: TRUST 5 Tested pillar; implicit per CLAUDE.local.md §6.
+
+Binary verification:
+```bash
+go test -cover ./internal/hook/ 2>&1 | grep -E "coverage: ([9][0-9]|100)\.[0-9]+% of statements"
+go test -cover ./internal/migrate/ 2>&1 | grep -E "coverage: ([8-9][5-9]|9[0-9]|100)\.[0-9]+% of statements"
+# Both expected: exit code 0
+```
+
+## AC-MIG002-A12 — Linter clean
+
+**Given** the merged main branch after MIG-002
+**When** `golangci-lint run ./internal/hook/... ./internal/cli/... ./internal/migrate/...` is invoked
+**Then** zero findings reported.
+
+Maps: TRUST 5 Readable + Unified pillars.
+
+Binary verification:
+```bash
+golangci-lint run ./internal/hook/... ./internal/cli/... ./internal/migrate/... 2>&1 | tee /tmp/lint.out
+test ! -s /tmp/lint.out
+# Expected: exit code 0 (empty output)
+```
+
+## AC-MIG002-A13 — Race-free under concurrent dispatch
+
+**Given** the merged main branch after MIG-002
+**When** `go test -race ./internal/hook/` is invoked
+**Then** all tests PASS with zero data-race reports.
+
+Maps: TRUST 5 Secured pillar (concurrency safety).
+
+Binary verification:
+```bash
+go test -race ./internal/hook/ 2>&1 | grep -E "DATA RACE|FAIL"
+# Expected: empty output
+```
+
+## AC-MIG002-A14 — Observability opt-in path preserved
+
+**Given** a fixture `system.yaml` with `hook.observability_events: ["notification"]`
+**When** the `notificationHandler.Handle(...)` is invoked with that config
+**Then** the handler logs the notification (covered by `TestAuditObservabilityWhitelist` subcase `listed_event_returns_true`).
+
+Maps: REQ-MIG002-015 (`retain_noop` opt-in reconciled to `observability_events` opt-in per `internal/hook/observability.go:23-44`).
+
+Binary verification:
+```bash
+go test ./internal/hook/ -run TestAuditObservabilityWhitelist -v 2>&1 | grep -q "PASS"
+# Expected: exit code 0
+```
+
+## Definition of Done
+
+The SPEC-V3R2-MIG-002 implementation is complete when ALL of the following hold:
+
+- [ ] AC-MIG002-A1 through AC-MIG002-A14 all verified PASS.
+- [ ] Plan-PR merged into main with `plan-auditor` PASS verdict.
+- [ ] Run-PR merged into main; commits squashed with `feat(SPEC-V3R2-MIG-002):` prefix per CLAUDE.local.md §18.3.
+- [ ] Sync-PR merged into main with CHANGELOG entry under `v3.0.0-rc.X` heading describing: EventSetup retirement + three-way sync invariant + CleanupUserSettings migration step.
+- [ ] `.moai/specs/SPEC-V3R2-MIG-002/spec.md` status transitions `draft → implemented → completed`.
+- [ ] `moai spec lint --strict` reports `✓ No findings`.
+- [ ] Auto-memory project entry `project_v3r2_mig_002_complete.md` created with paste-ready resume + MEMORY.md index updated.
+
+## Edge cases (forecast-only — implementation discretion)
+
+- **Empty user-local settings.json**: `CleanupUserSettings` MUST handle a missing `hooks` key gracefully (no-op, no archive file).
+- **Malformed JSON in user-local settings.json**: `CleanupUserSettings` MUST return a wrapped error (`fmt.Errorf("parse settings.json: %w", err)`) and MUST NOT write a partial result.
+- **Race against concurrent user edit**: `CleanupUserSettings` writes atomically via temp file + rename; if rename fails, the temp file is removed and the error is returned.
+- **Pre-RT-006 build artifact**: if a user's project still has `handle-setup.sh` (from an earlier draft), the migration step MUST detect it via filesystem scan and archive-move it alongside the settings.json cleanup.
+- **`hook.RetiredEventNames` empty (future hypothetical)**: if MIG-002 is later extended to retire additional events, the migration logic MUST iterate the exported `RetiredEventNames` slice, not a hard-coded list.
+
+End of acceptance.

--- a/.moai/specs/SPEC-V3R2-MIG-002/plan.md
+++ b/.moai/specs/SPEC-V3R2-MIG-002/plan.md
@@ -1,0 +1,236 @@
+---
+spec_id: SPEC-V3R2-MIG-002
+phase: plan
+status: audit-ready
+plan_complete_at: 2026-05-18
+---
+
+# Implementation Plan — SPEC-V3R2-MIG-002
+
+## 1. Context
+
+The original spec.md was authored 2026-04-23 against the pre-RT-006 state of the hook registry. Between authoring and this plan-phase (2026-05-18), `SPEC-V3R2-RT-006` shipped the per-handler resolution program: 4 retirements (RETIRE-OBS-ONLY), 5 stub→real upgrades (UPGRADE), the `subagentStop` tmux-pane-kill fix (FIX), and the per-file `// Resolution: <CATEGORY>` header convention. See research.md §9 for the drift table.
+
+Consequently most of spec.md REQ-MIG002-004 through REQ-MIG002-008 are **already shipped** in main. The residual work for MIG-002 is now:
+
+- Retire the **EventSetup orphan** (constant + CLI binding + tests) — research.md §8.
+- Add a **3-way sync invariant test** preventing future Go ↔ wrapper ↔ settings.json drift — research.md §6, §11, §14.
+- Decide and execute the **retired-event wrapper template policy** — research.md §4, §14.
+- Provide a **migration path** for user-local settings.json upgrading from pre-RT-006 v3 builds — research.md §14, spec.md REQ-MIG002-012.
+- Normalize the SPEC's **own frontmatter** to the canonical 12-field schema (`.claude/rules/moai/development/spec-frontmatter-schema.md`).
+
+This plan turns the obsolete REQs into characterization tests where the implementation already exists, and codifies the genuine residual work as M1–M4 milestones.
+
+## 2. Approach
+
+TDD across M1–M4. Each milestone has an explicit RED (failing test capturing intent) → GREEN (minimal change to pass) → REFACTOR (cleanup + invariant check) loop.
+
+We do NOT re-implement subagent_stop, config_change, instructions_loaded, file_changed, or post_tool_failure — those are RT-006 work product. We DO add characterization tests that lock the current behavior so MIG-002's regression surface includes them.
+
+## 3. Milestones
+
+### M1 — RED: orphan + drift detection tests
+
+**Priority: High**
+
+Failing tests that name the residual cleanup surface. All tests in this milestone MUST fail at M1 entry and pass at M2 exit.
+
+Deliverables:
+- `internal/hook/audit_test.go` — extend with `TestAuditThreeWaySync`:
+  - Collects Go-registered events by parsing `internal/cli/deps.go` registrations (or, simpler, by reading from `Dependencies.HookRegistry.Handlers()` after `InitDependencies()`).
+  - Collects settings.json hook keys from `internal/template/templates/.claude/settings.json.tmpl` (parse with `gopkg.in/yaml.v3` after rendering, OR scan with a regex anchored on `"Event":` style keys).
+  - Asserts: `(Go events) == (settings.json keys) ∪ retiredEventNames`.
+  - On mismatch: report `HOOK_SYNC_DRIFT: <event-name>` for Go-only entries; `HOOK_WRAPPER_ORPHAN: <event-name>` for settings-only entries.
+- `internal/hook/audit_test.go` — extend with `TestAuditNoEventSetupOrphan`:
+  - Asserts `EventSetup` constant does NOT exist in `hook` package (compile-time via `_ = hook.EventSetup` reference being absent OR runtime via parsing `types.go`).
+  - Asserts `moai hook setup` cobra subcommand binding does NOT exist (parse `internal/cli/hook.go` for the `"setup"` entry).
+- `internal/hook/audit_test.go` — extend with `TestAuditNoStubHandlers`:
+  - For each of {subagent_stop, config_change, instructions_loaded, file_changed, post_tool_failure}, assert the file's `// Resolution:` header is one of {`UPGRADE`, `FIX`}, NOT a hypothetical `STUB` value.
+  - Locks RT-006 work product against silent regression.
+- `internal/template/render_test.go` (or extend an existing template renderer test) — assert that the 4 retired-event wrapper templates' fate matches the wrapper-ship decision (see M2 §Decision Gate).
+
+Verification (M1 exit):
+- `go test ./internal/hook/ -run TestAuditThreeWaySync` — FAIL (drift exists per research.md §9).
+- `go test ./internal/hook/ -run TestAuditNoEventSetupOrphan` — FAIL (EventSetup still present per research.md §8).
+- `go test ./internal/hook/ -run TestAuditNoStubHandlers` — PASS (RT-006 already shipped, but the test is added to lock it).
+- `go test ./internal/template/ -run TestRenderRetiredWrappers` — FAIL until M2 §Decision Gate resolves.
+
+### M2 — GREEN: EventSetup retirement + settings.json sync
+
+**Priority: High**
+
+Minimal-change retirement of the EventSetup orphan and reconciliation of the 4 retired-wrapper templates per the decision gate.
+
+#### M2.1 — EventSetup retirement (mandatory)
+
+Files to modify:
+- `internal/hook/types.go:83-85` — remove the `EventSetup EventType = "Setup"` constant and the surrounding comment block.
+- `internal/hook/types.go:139` — remove `EventSetup,` from the active-event slice.
+- `internal/hook/types_test.go:36` — remove the `EventSetup: true,` entry from the truth table.
+- `internal/cli/hook.go:58` — remove the `{"setup", "Handle setup event", hook.EventSetup},` cobra subcommand binding.
+- `internal/cli/hook_e2e_test.go:183, 305` — remove EventSetup references (both the active-set entry and the slug mapping).
+- `internal/hook/coverage_table.go` — drop the setup row; decrement `Total` and `Remove` accordingly.
+- `internal/cli/doctor_hook_test.go:127-131` — update `summary.Remove` expectation from `1` to `0` AND update `summary.Total` expectation if asserted.
+- `internal/cli/doctor_hook_test.go:18-36` — update `TestDoctorHook_27EventTableCount` if the count drops to 26.
+
+#### M2.2 — Wrapper template decision gate
+
+Decision Gate: **Option Keep** is the recommended choice. Rationale: the 4 retired-wrapper templates are harmless (Claude Code will never invoke them because no `settings.json` entry binds them) AND they preserve forward-compat with the planned `system.yaml hook.observability_events` opt-in path (`internal/hook/observability.go:21-44`).
+
+Under Option Keep:
+- No `.tmpl` files are deleted.
+- `internal/template/render_test.go` — adjust `TestRenderRetiredWrappers` to assert presence (the failing test from M1 flips to assert presence under Option Keep).
+- Add inline comment to the 4 retired `.sh.tmpl` files documenting the RETIRE-OBS-ONLY contract: "This wrapper is shipped for forward-compat with `system.yaml hook.observability_events` opt-in. Claude Code will not invoke it unless the corresponding `settings.json` entry is added by the user."
+
+Under Option Retire (deferred — not pursued in this plan):
+- Remove the 4 `.tmpl` files.
+- Add a migration step (M3) that removes user-local `.sh` copies.
+
+Recommendation rationale: lessons #16 (sync-prefix-correction) — silent files are forgivable; loud files (settings.json entries) are not. We err toward preserving silent surface area until user opt-in evidence appears.
+
+#### M2.3 — Frontmatter normalization
+
+- `.moai/specs/SPEC-V3R2-MIG-002/spec.md` — bring frontmatter to the canonical 12-field schema per `.claude/rules/moai/development/spec-frontmatter-schema.md`:
+  - Required: `id`, `title`, `version`, `status`, `created`, `updated`, `author`, `priority`, `phase`, `module`, `lifecycle`, `tags`.
+  - Tags as comma-separated string (NOT YAML list): `"hooks, cleanup, orphan, drift, mig"`.
+  - Optional `depends_on` retained for SPEC-V3R2-EXT-004 / blocked-by relation.
+  - Drop legacy keys (`related_gap`, `related_theme`, `breaking`, `bc_id` if empty).
+
+Verification (M2 exit):
+- All M1 tests pass.
+- `go test ./internal/hook/ ./internal/cli/ ./internal/template/` — PASS.
+- `moai spec lint --strict .moai/specs/SPEC-V3R2-MIG-002/` — `✓ No findings`.
+
+### M3 — GREEN: migration step for user-local settings.json
+
+**Priority: Medium**
+
+Provide a one-shot cleanup step for users upgrading from pre-RT-006 v3 builds whose local `settings.json` still carries the 4 retired event entries.
+
+Deliverables:
+- `internal/migrate/hook_cleanup.go` (new) — exposes `CleanupUserSettings(projectRoot string) error`:
+  - Reads `<projectRoot>/.claude/settings.json`.
+  - For each name in `hook.RetiredEventNames` (move the slice from `audit_test.go:46-51` to a non-test export in `internal/hook/`):
+    - If the key exists under `hooks`, remove it.
+    - Append the original entry to `<projectRoot>/.moai/archive/hooks/v3.0/migration-<YYYY-MM-DD>.json` (Pattern preserved per spec.md REQ-MIG002-019).
+  - Writes the cleaned settings.json back if any change occurred (atomic write via temp + rename).
+  - No-op when no retired entries are present.
+- Wire the new function into the migration framework provided by SPEC-V3R2-EXT-004 (the actual integration point lives in EXT-004's deliverable; MIG-002 contributes `CleanupUserSettings` as the unit-of-work).
+- `internal/migrate/hook_cleanup_test.go` — table-driven tests covering:
+  - User-settings.json with all 4 retired entries → all removed, archive file created.
+  - User-settings.json with 0 retired entries → no-op, no archive file.
+  - Mixed retired + active entries → only retired removed, active preserved.
+  - Malformed JSON → return wrapped error, do not write.
+
+Verification (M3 exit):
+- `go test ./internal/migrate/ -run TestCleanupUserSettings` — PASS.
+- Integration smoke: hand-craft a fixture settings.json with `Notification` + `Elicitation` entries, invoke `CleanupUserSettings`, assert removal + archive.
+
+### M4 — REFACTOR + verification gates
+
+**Priority: Medium**
+
+Cross-cutting polish and final gate verification.
+
+Deliverables:
+- Promote `retiredEventNames` from `internal/hook/audit_test.go:46-51` to an exported `internal/hook/retired_events.go` so both the audit test and the migration step in M3 share a single source of truth.
+- Update `.claude/rules/moai/core/hooks-system.md` (referenced in spec.md §3) to reflect the post-MIG-002 event roster: 22 native settings.json keys + 4 retired-obs-only + 0 orphans.
+- Add a `@MX:ANCHOR` on `InitDependencies` (already present at `internal/cli/deps.go:58-62`) — verify the `fan_in` annotation reflects the post-cleanup state.
+- Run the full audit suite + doctor_hook suite end-to-end:
+  - `go test -race -count=1 ./internal/hook/ ./internal/cli/ ./internal/template/ ./internal/migrate/`
+  - `golangci-lint run ./internal/hook/... ./internal/cli/... ./internal/migrate/...`
+  - `go vet ./...`
+- Confirm the audit_test.go drift detector continues to fire on artificially injected drift (negative test: temporarily add a fake `EventFoo` constant to types.go in a separate branch; `TestAuditThreeWaySync` MUST fail).
+
+Verification (M4 exit, equivalent to MIG-002 "DONE"):
+- All M1–M3 tests pass.
+- Coverage on `internal/hook/` ≥ 90% (per CLAUDE.local.md §6 critical-package tier).
+- `moai spec lint --strict .moai/specs/SPEC-V3R2-MIG-002/` → `✓ No findings`.
+- `audit_test.go` `TestAuditRegistrationParity` continues to hold `nativeCount == 22` and Go handler count == 25 (was 26 pre-MIG-002; setupHandler row removed via M2.1).
+- `doctor_hook_test.go` `TestDoctorHook_SummaryCountsConsistent` updated to `summary.Remove == 0` (or kept at 1 if `coverage_table.go` retains the setup row as a historical record — decision logged in M2.1 commit).
+
+## 4. Technical Approach
+
+### 4.1 Detection strategy for `TestAuditThreeWaySync`
+
+Three input sources:
+
+1. **Go event set**: Bootstrap by calling `cli.InitDependencies()` in the test fixture (or by reading `deps.go` source statically). The runtime path is safer because it captures registration intent exactly as the binary sees it. Iterate the `Handlers(event)` map across all `EventType` constants; an event is "Go-registered" if `len(Handlers(e)) > 0`.
+2. **settings.json key set**: Render `internal/template/templates/.claude/settings.json.tmpl` against a representative `TemplateContext` (GoBinPath = "/tmp/test/go/bin", HomeDir = "/tmp/test/home"), parse the JSON, extract `Object.keys(result.hooks)`.
+3. **Retired-event set**: Import from `internal/hook/retired_events.go` (the M4 promotion).
+
+Assertion:
+- `goEvents ∖ (settingsKeys ∪ retiredEvents)` MUST be empty (no orphan Go handlers).
+- `settingsKeys ∖ goEvents` MUST be empty (no orphan settings entries).
+- Reports per-event diagnostic on failure with `HOOK_SYNC_DRIFT` / `HOOK_WRAPPER_ORPHAN` prefixes (matches spec.md REQ-MIG002-009/010 error codes).
+
+### 4.2 Why we keep retired-wrapper templates
+
+Retiring the 4 `.sh.tmpl` files now is reversible but pre-mature:
+
+- Forward-compat path: `internal/hook/observability.go:23-44` already supports re-enabling these handlers via `system.yaml hook.observability_events`. Removing the wrappers severs the path.
+- Disk footprint: 4 × ~1.3 KB = ~5 KB total; negligible.
+- Risk surface: With no settings.json binding, Claude Code never invokes them. The Go handlers themselves return silently when not opted in (`audit_test.go:237-246` `TestAuditObservabilityWhitelist` subcase `notification_handler_silent_when_not_opted_in`).
+
+The decision is documented in M2.2 and captured by `TestRenderRetiredWrappers` asserting presence.
+
+### 4.3 Why `CleanupUserSettings` ships in `internal/migrate/`
+
+The migration framework lives in EXT-004 (per spec.md §9.1). MIG-002 contributes a single unit-of-work function. Co-locating with `internal/migrate/` avoids tangling user-data cleanup logic into `internal/hook/` (which should remain a pure event-handler package). Test fixtures under `internal/migrate/testdata/` keep handler tests fast.
+
+## 5. Risks & Mitigations
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| Removing `EventSetup` breaks `hook_e2e_test.go` flows that exercise the setup subcommand | Test-suite red after M2 | Update `hook_e2e_test.go:183, 305` and `types_test.go:36` in the same commit as the constant removal; verify `go test ./internal/cli/...` before commit. |
+| `TestAuditThreeWaySync` becomes flaky if settings.json.tmpl parser is sensitive to template directives | Intermittent CI failure | Render via the production `template.Render*` path (not a hand-rolled regex); commit a golden-file fixture in `testdata/`. |
+| Users on pre-RT-006 v3 builds run `CleanupUserSettings` and silently lose customizations to their `Notification` hook | User data loss | Archive every removed entry to `.moai/archive/hooks/v3.0/migration-<YYYY-MM-DD>.json` (already in deliverable); document the archive path in CLAUDE.local.md §2 "Protected Directories". |
+| The wrapper-keep decision is wrong (users expect retired wrappers to be gone) | Conceptual debt | Captured as M2.2 decision gate with rationale; revisit in a follow-up SPEC if user feedback signals otherwise. |
+| `coverage_table.go` decrements break `TestDoctorHook_27EventTableCount` assertion | Test-suite red after M2 | Update the doctor test in lockstep with `coverage_table.go` edits; bump expectation to 26. |
+| Frontmatter normalization invalidates other tooling that reads spec.md frontmatter | Indirect tooling break | Run `moai spec lint --strict` post-change; verify no downstream consumers parse the legacy keys (`related_gap`, `related_theme`). |
+
+## 6. Out of Scope (residual non-goals beyond spec.md §2.2)
+
+In addition to spec.md §2.2 exclusions, this plan explicitly does NOT cover:
+
+- Re-implementing any of the 5 UPGRADE-resolved handlers (config_change, instructions_loaded, file_changed, post_tool_failure, and any other RT-006 work product).
+- Re-implementing the `subagent_stop` FIX (RT-006 P-H02 work product — locked by characterization test only).
+- Adding new hook events beyond the 22 native + 4 retired = 26 (now 25 after EventSetup retirement) roster.
+- Modifying the hook protocol (JSON-OR-ExitCode contract per `internal/hook/protocol.go`).
+- Modifying `hookSpecificOutput` schema or block-decision short-circuit logic in `internal/hook/registry.go:127-202`.
+- Removing the 4 retired-event `.sh.tmpl` wrappers (Option Retire — deferred per M2.2 decision).
+- Changes to `system.yaml hook.observability_events` schema or `observabilityOptIn()` semantics.
+- Changes to harness-observer wrappers (`handle-harness-observe-*.sh`) added by SPEC-V3R4-HARNESS-002.
+- Reordering or merging existing handler chains under shared event keys (e.g., the `Stop` event's two-wrapper composition with `handle-harness-observe-stop`).
+
+## 7. Verification Matrix (input to acceptance.md)
+
+| AC | Verification command | Expected outcome |
+|---|---|---|
+| AC-MIG002-A1 | `go test ./internal/hook/ -run TestAuditThreeWaySync -v` | PASS; zero drift report |
+| AC-MIG002-A2 | `go test ./internal/hook/ -run TestAuditNoEventSetupOrphan -v` | PASS; `EventSetup` absent |
+| AC-MIG002-A3 | `grep -rn 'EventSetup\|"setup"' internal/hook/ internal/cli/hook.go internal/cli/hook_e2e_test.go` | Empty output |
+| AC-MIG002-A4 | `go test ./internal/hook/ -run TestAuditPerFileCategoryHeader -v` | PASS; all 26 handler files headed correctly |
+| AC-MIG002-A5 | `go test ./internal/hook/ -run TestAuditRetiredEventsNotInSettings -v` | PASS |
+| AC-MIG002-A6 | `go test ./internal/hook/ -run TestAuditRegistrationParity -v` | PASS; nativeCount == 22, Go handler total adjusts to 25 |
+| AC-MIG002-A7 | `go test ./internal/migrate/ -run TestCleanupUserSettings -v` | PASS; archive file written; user-active entries preserved |
+| AC-MIG002-A8 | `go test ./internal/hook/ -run TestAuditNoStubHandlers -v` | PASS; all 5 RT-006-touched handlers show UPGRADE or FIX header |
+| AC-MIG002-A9 | `go test ./internal/cli/ -run TestDoctorHook -v` | PASS; counts consistent with post-cleanup state |
+| AC-MIG002-A10 | `moai spec lint --strict .moai/specs/SPEC-V3R2-MIG-002/` | `✓ No findings` |
+| AC-MIG002-A11 | `go test -cover ./internal/hook/ ./internal/migrate/` | Coverage ≥ 90% on hook; ≥ 85% on migrate |
+| AC-MIG002-A12 | `golangci-lint run ./internal/hook/... ./internal/cli/... ./internal/migrate/...` | Zero findings |
+
+## 8. Dependencies
+
+- **Blocks**: nothing internally; downstream `SPEC-V3R2-MIG-001` consumes `CleanupUserSettings`.
+- **Blocked by**: `SPEC-V3R2-EXT-004` (migration framework path) — Already shipped per existing `internal/migrate/` package presence; verify integration surface during M3.
+- **Side-effect-coupled with**: `SPEC-V3R2-RT-006` (already merged); MIG-002 ships the *guardrails* against RT-006 regression.
+
+## 9. Lessons Applied
+
+- **Lesson #16 (sync-prefix-correction)**: silent files are forgivable; loud files are not. Keep wrapper templates; remove only the loud `EventSetup` binding.
+- **Lesson #17 (verify-only T-deliverable)**: M1's "RED tests" include `TestAuditNoStubHandlers` even though it passes immediately — the goal is to lock RT-006 work product, not re-implement it.
+- **Lesson #18 (plan-auditor race prevention)**: this plan does NOT add new HARD constitutional rules; it codifies existing invariants as test surface.
+- **Lessons #12/13 (worktree isolation)**: per user policy 2026-05-17, plan-phase runs in main checkout (`plan/SPEC-V3R2-MIG-002` branch), not in an L2 worktree.
+
+End of plan.

--- a/.moai/specs/SPEC-V3R2-MIG-002/research.md
+++ b/.moai/specs/SPEC-V3R2-MIG-002/research.md
@@ -1,0 +1,260 @@
+# Research — SPEC-V3R2-MIG-002
+
+> **Goal**: Document the *current* (2026-05-18) state of MoAI hook registration so plan.md can scope an honest residual cleanup. The original spec.md (2026-04-23) was authored BEFORE SPEC-V3R2-RT-006 shipped the per-handler resolution program; many of its premises are now obsolete and must be reconciled.
+
+## 1. Architectural anchors (current registry)
+
+- `internal/hook/registry.go:13-26` — `registry` struct is the central event-router (cfg + handlers map + timeout + traceWriter). `@MX:ANCHOR fan_in=20+`.
+- `internal/hook/registry.go:48-57` — `Register(handler)` is the single entry-point for handler installation; appends to per-event slice; no de-duplication.
+- `internal/hook/registry.go:67-173` — `Dispatch()` runs handlers sequentially under a per-event timeout (default 30s); short-circuits on `Decision == block` or `ExitCode == 2`; merges `SystemMessage` and `HookSpecificOutput`.
+- `internal/hook/registry.go:207-232` — `defaultOutputForEvent()` enumerates the canonical event set (Stop, SessionEnd, SessionStart, PreCompact, SubagentStop, PostToolUseFailure, Notification, SubagentStart, UserPromptSubmit, TeammateIdle, TaskCompleted, WorktreeCreate, WorktreeRemove, PermissionRequest, PreToolUse, PostToolUse).
+- `internal/hook/types.go:20-115` — `EventType` constants (27 events) — domain enum.
+- `internal/hook/types.go:85` — `EventSetup` constant still declared (no handler, no shell wrapper, no settings.json entry).
+- `internal/hook/types.go:139` — `EventSetup` listed in the canonical active-event slice (used by `hook list`).
+
+## 2. Composition root (Go-side registrations)
+
+- `internal/cli/deps.go:42-52` — `Dependencies` struct holds `HookRegistry hook.Registry` plus other domain services.
+- `internal/cli/deps.go:64-186` — `InitDependencies()` is the composition root.
+- `internal/cli/deps.go:115-117` — `hook.NewRegistry(deps.Config)` instantiates the registry.
+- `internal/cli/deps.go:152-185` — 27 explicit `deps.HookRegistry.Register(...)` calls. The active Go-side roster:
+  1. `NewSessionStartHandler(deps.Config)` — line 152
+  2. `buildSessionEndHandler(cwd)` — line 154
+  3. `NewAutoUpdateHandler(buildAutoUpdateFunc())` — line 157 (composite, shares SessionStart event key per audit_test.go:99-101)
+  4. `NewStopHandler()` — line 159
+  5. `NewPreToolHandlerWithScanner(...)` — line 163
+  6. `NewPostToolHandlerWithMxValidatorAndTimeout(...)` — line 164
+  7. `NewCompactHandler()` — line 165
+  8. `NewPostToolUseFailureHandler()` — line 166
+  9. `NewNotificationHandler()` — line 167 (RETIRE-OBS-ONLY)
+  10. `NewSubagentStartHandler()` — line 168
+  11. `NewUserPromptSubmitHandler(deps.Config)` — line 169
+  12. `NewPermissionRequestHandler()` — line 170
+  13. `NewTeammateIdleHandler()` — line 171
+  14. `NewTaskCompletedHandler()` — line 172
+  15. `NewWorktreeCreateHandler()` — line 173
+  16. `NewWorktreeRemoveHandler()` — line 174
+  17. `NewPostCompactHandler()` — line 175
+  18. `NewInstructionsLoadedHandler()` — line 176
+  19. `NewStopFailureHandler()` — line 177
+  20. `NewSubagentStopHandler()` — line 178
+  21. `NewTaskCreatedHandler()` — line 179 (RETIRE-OBS-ONLY)
+  22. `NewPermissionDeniedHandler()` — line 180
+  23. `NewConfigChangeHandler()` — line 181
+  24. `NewCwdChangedHandler()` — line 182
+  25. `NewFileChangedHandler()` — line 183
+  26. `NewElicitationHandler()` — line 184 (RETIRE-OBS-ONLY)
+  27. `NewElicitationResultHandler()` — line 185 (RETIRE-OBS-ONLY)
+
+Total: **26 distinct Go handlers** (`NewAutoUpdateHandler` shares the SessionStart key with `NewSessionStartHandler` per the `audit_test.go:89-101` formula).
+
+## 3. settings.json.tmpl native event keys
+
+`internal/template/templates/.claude/settings.json.tmpl` lines 4-369 enumerate the native hook event keys. The exhaustive list:
+
+- `SessionStart` — line 4
+- `PreCompact` — line 20
+- `SessionEnd` — line 36
+- `PreToolUse` — line 51
+- `PostToolUse` — line 67
+- `Stop` — line 84 (2 wrappers: handle-stop + handle-harness-observe-stop)
+- `SubagentStop` — line 108 (2 wrappers: handle-subagent-stop + handle-harness-observe-subagent-stop)
+- `PostToolUseFailure` — line 132
+- `SubagentStart` — line 147
+- `UserPromptSubmit` — line 162 (2 wrappers: handle-user-prompt-submit + handle-harness-observe-user-prompt-submit)
+- `TeammateIdle` — line 186
+- `TaskCompleted` — line 201
+- `WorktreeCreate` — line 216
+- `WorktreeRemove` — line 231
+- `ConfigChange` — line 246
+- `StopFailure` — line 262
+- `PostCompact` — line 278
+- `InstructionsLoaded` — line 294
+- `CwdChanged` — line 309
+- `FileChanged` — line 324
+- `PermissionDenied` — line 340
+- `PermissionRequest` — line 355
+
+Total: **22 native settings.json event keys** (matches `audit_test.go:93` `const expectedNative = 22`).
+
+Conspicuously **absent** from settings.json.tmpl (intentional RETIRE-OBS-ONLY per `audit_test.go:44-51`):
+- `Notification`
+- `Elicitation`
+- `ElicitationResult`
+- `TaskCreated`
+
+Also **absent** (true orphan, never had a settings.json entry):
+- `Setup`
+
+## 4. Shell wrappers (local + template)
+
+Local installed wrappers — `.claude/hooks/moai/`:
+
+- 32 `handle-*.sh` files present (verified by `ls .claude/hooks/moai/`).
+- Includes: `handle-notification.sh`, `handle-elicitation.sh`, `handle-elicitation-result.sh`, `handle-task-created.sh` (4 wrappers whose event keys are absent from settings.json — they ship via template even though they will never be invoked by Claude Code).
+- Does NOT include any `handle-setup.sh` wrapper.
+
+Template-source wrappers — `internal/template/templates/.claude/hooks/moai/`:
+
+- 32 `handle-*.sh.tmpl` files (verified by `ls`).
+- Mirrors the local-installed set 1:1.
+- Critically the 4 retired-event wrappers are still shipped in the template: `handle-notification.sh.tmpl`, `handle-elicitation.sh.tmpl`, `handle-elicitation-result.sh.tmpl`, `handle-task-created.sh.tmpl`.
+
+## 5. Per-handler current state — overview
+
+Each handler file declares `// Resolution: <CATEGORY>` at line 1 per `audit_test.go:110-170` (`TestAuditPerFileCategoryHeader`). The valid categories are: `KEEP | UPGRADE | FIX | REMOVE | RETIRE-OBS-ONLY | COMPOSITE`.
+
+### 5.1 RETIRE-OBS-ONLY handlers (4)
+
+- `internal/hook/notification.go:1` — `// Resolution: RETIRE-OBS-ONLY` header.
+- `internal/hook/notification.go:36-48` — `Handle()` returns silently when `observabilityOptIn(h.cfg, "notification")` is false (Pattern A).
+- `internal/hook/elicitation.go:1` — RETIRE-OBS-ONLY header (file contains BOTH `elicitationHandler` and `elicitationResultHandler`).
+- `internal/hook/elicitation.go:36-48` — `Handle()` returns silently when opt-in is false.
+- `internal/hook/elicitation.go:73-85` — `elicitationResultHandler.Handle()` mirror logic.
+- `internal/hook/task_created.go:1` — RETIRE-OBS-ONLY header.
+- `internal/hook/task_created.go:36-48` — silent return when not opted in.
+
+### 5.2 UPGRADE handlers (5) — formerly stub, now real logic
+
+- `internal/hook/config_change.go:1` — `// Resolution: UPGRADE — re-render + diff-aware reload via SPEC-V3R2-RT-005 + 20ms debounce.`
+- `internal/hook/config_change.go:44-91` — `Handle()` performs 20ms debounce + YAML validation + `ConfigManager.Reload()` via dependency injection.
+- `internal/hook/instructions_loaded.go:1` — `// Resolution: UPGRADE — CLAUDE.md 40,000-char budget check per coding-standards.md.`
+- `internal/hook/instructions_loaded.go:29-56` — checks both `input.InstructionFilePath` and a fallback `<cwd>/CLAUDE.md` against the 40,000 char budget.
+- `internal/hook/file_changed.go:1` — `// Resolution: UPGRADE — MX re-scan for 16 supported language extensions on FileChanged.`
+- `internal/hook/file_changed.go:14-37` — `supportedExtensions` map covers 19 extensions across 16 languages (per `language.yaml` neutrality policy in CLAUDE.local.md §15).
+- `internal/hook/file_changed.go:55-114` — `Handle()` scans the file with `mx.NewScanner()` and updates the sidecar via `mx.NewManager(stateDir).UpdateFile(...)`.
+- `internal/hook/post_tool_failure.go:1` — `// Resolution: UPGRADE — error classification (...).`
+- `internal/hook/post_tool_failure.go:13-34` — 7 `ErrorCategory` constants (`TimeoutError`, `PermissionDenied`, `ContextCancelled`, `SandboxViolation`, `OOMKilled`, `ExitError`, `UnknownFailure`).
+- `internal/hook/post_tool_failure.go:52-71` — `Handle()` runs `classifyError()` and emits a user-friendly `SystemMessage`.
+
+### 5.3 FIX handlers (1) — bug repair
+
+- `internal/hook/subagent_stop.go:1` — `// Resolution: FIX — P-H02 bug fix: read tmuxPaneId, kill-pane with 500ms timeout, update team registry.`
+- `internal/hook/subagent_stop.go:32-98` — `Handle()` reads `~/.claude/teams/<team-name>/config.json`, locates the teammate's `tmuxPaneId`, runs `tmux kill-pane -t <id>` in a goroutine bounded by a 500ms timeout (SPEC-V3R2-RT-006 AC-15, AC-02), then strips the teammate from the team config.
+- `internal/hook/subagent_stop.go:42-45` — Windows short-circuit (`runtime.GOOS == "windows"` → no-op).
+- `internal/hook/subagent_stop.go:76-86` — "pane not found" graceful-degradation path.
+
+### 5.4 KEEP handlers — observability gate helper
+
+- `internal/hook/observability.go:1` — `// Resolution: KEEP — observability gate helper for RETIRE-OBS-ONLY handlers.`
+- `internal/hook/observability.go:23-44` — `observabilityOptIn(cfg, eventName)` reads `cfg.Get().System.Hook.ObservabilityEvents` (declared at `internal/config/types.go:49-52` as `ObservabilityEvents []string \`yaml:"observability_events"\``).
+- `internal/hook/observability.go:21-22` — `@MX:ANCHOR fan_in=4` (notification, elicitation, elicitationResult, taskCreated).
+
+### 5.5 COMPOSITE handler — autoUpdate
+
+- `internal/hook/auto_update.go:1` — `// Resolution: COMPOSITE` (registered under SessionStart event key, not a separate event).
+
+## 6. Audit test suite (the de-facto invariant set)
+
+- `internal/hook/audit_test.go:46-51` — `retiredEventNames = []string{"Notification", "Elicitation", "ElicitationResult", "TaskCreated"}` (canonical list, used by 3 test cases).
+- `internal/hook/audit_test.go:59-103` — `TestAuditRegistrationParity` asserts:
+  - `nativeCount == 22` (settings.json hook keys).
+  - The 4 retired names MUST NOT appear in `settingsJSON.Hooks`.
+  - Expected total Go handlers = `22 + 4 = 26`.
+- `internal/hook/audit_test.go:110-170` — `TestAuditPerFileCategoryHeader` requires every handler file to carry the `// Resolution: CATEGORY` header in its first ~10 lines.
+- `internal/hook/audit_test.go:177-196` — `TestAuditRetiredEventsNotInSettings` independently asserts retired-event absence from local `settings.json`.
+- `internal/hook/audit_test.go:203-255` — `TestAuditObservabilityWhitelist` covers 5 subcases: empty/listed/case-insensitive/nil-cfg/strict-mode + a `notification_handler_silent_when_not_opted_in` integration assertion.
+- `internal/hook/audit_test.go:259-299` — `TestAuditRetiredHandlersNotActive` cross-checks `EventType` constants vs. an enumerated active list.
+
+## 7. Doctor coverage table (separate invariant surface)
+
+- `internal/cli/doctor_hook_test.go:18-36` — `TestDoctorHook_27EventTableCount` asserts the coverage table has exactly 27 entries (matches `hook.CoverageTable`).
+- `internal/cli/doctor_hook_test.go:113-135` — `TestDoctorHook_SummaryCountsConsistent` asserts the per-resolution counts:
+  - `RetireObsOnly == 4`
+  - `Fix == 1` (subagentStop P-H02)
+  - `Remove == 1` (setupHandler)
+  - `Composite == 1` (autoUpdate)
+- `internal/hook/coverage_table.go` (sized ~5.8 KB per `ls`) — source of `hook.CoverageTable` and `hook.Summarize()`.
+
+## 8. EventSetup orphan footprint
+
+- `internal/hook/types.go:83-85` — `EventSetup` constant retained (declared "triggered via --init, --init-only, or --maintenance CLI flags").
+- `internal/hook/types.go:139` — `EventSetup` still in active event slice.
+- `internal/hook/types_test.go:36` — `EventSetup: true` in the active-event truth table.
+- `internal/cli/hook.go:58` — `{"setup", "Handle setup event", hook.EventSetup}` cobra binding still wires a `moai hook setup` CLI subcommand.
+- `internal/cli/hook_e2e_test.go:183, 305` — references the setup event in e2e tests.
+- `internal/cli/doctor_hook_test.go:130` — explicitly expects `summary.Remove == 1 (setupHandler)`.
+- No `internal/hook/setup.go` exists (verified by `find . -name "setup*.go" -print` returning empty).
+- No `NewSetupHandler()` constructor exists (verified by `grep -rn "NewSetupHandler" internal/`).
+- No `handle-setup.sh` shell wrapper exists in `.claude/hooks/moai/` or `internal/template/templates/.claude/hooks/moai/`.
+- No `Setup` key in `internal/template/templates/.claude/settings.json.tmpl`.
+
+This is the **only true orphan** in the codebase post-RT-006: an `EventType` constant + CLI binding without a handler implementation.
+
+## 9. Original spec.md premises vs. reality (drift table)
+
+The `.moai/specs/SPEC-V3R2-MIG-002/spec.md` document was authored 2026-04-23 — before SPEC-V3R2-RT-006 landed (RT-006 references appear in `subagent_stop.go:64`, `audit_test.go:3`, `notification.go:3`, etc.). The drift between spec.md assumptions and the current tree:
+
+| spec.md claim | Reality (2026-05-18) | Reconciliation needed |
+|---|---|---|
+| `setupHandler` is a Go-handler orphan (R6 §2.2) | `setup.go` never existed; only `EventSetup` constant + CLI binding | Cleanup target shifts from "delete setupHandler" to "remove EventSetup constant + CLI subcommand binding + type_test entry" |
+| 14/27 handlers are "thin loggers" | All 4 retired handlers are observability taps; 5 former stubs are UPGRADE-resolved; subagent_stop is FIX-resolved | "Thin logger" framing is obsolete |
+| `subagentStopHandler` lacks tmux pane kill (REQ-MIG002-004, REQ-MIG002-013) | Already implemented at `subagent_stop.go:32-98` with 500ms timeout + graceful degradation | REQ duplicates RT-006 work; lift to "characterization test confirming the behavior holds" |
+| `configChangeHandler` lacks reload trigger (REQ-MIG002-005) | Implemented at `config_change.go:44-91` with diff-aware reload | Same — characterization test only |
+| `instructionsLoadedHandler` lacks CLAUDE.md budget check (REQ-MIG002-006, REQ-MIG002-014) | Implemented at `instructions_loaded.go:29-78` with 40,000 char limit | Same — characterization test only |
+| `fileChangedHandler` lacks MX rescan (REQ-MIG002-007, REQ-MIG002-016) | Implemented at `file_changed.go:55-114` with 19 supported extensions | Same — characterization test only |
+| `postToolUseFailureHandler` lacks error classification (REQ-MIG002-008) | Implemented at `post_tool_failure.go:13-135` with 7 error categories | Same — characterization test only |
+| Retire `setupHandler, notificationHandler, elicitationHandler, elicitationResultHandler, taskCreatedHandler` (REQ-MIG002-003) | 4 already retired-obs-only; `setupHandler` never existed | Only the EventSetup *constant/binding* removal remains |
+| Migration should remove user-local `handle-notification.sh` (REQ-MIG002-011, REQ-MIG002-019) | Wrappers still ship in template (`handle-notification.sh.tmpl` et al.); user-local copies follow | Decide: keep wrappers (they're harmless no-ops without a settings.json entry) OR remove templates + add `moai migrate hook-cleanup` step |
+| Migration should remove retired entries from user-local settings.json (REQ-MIG002-012) | Local settings.json already excludes the 4 retired keys (verified by `audit_test.go:177-196`) | Migration-step needed only for users upgrading from v3.0.0-pre-RT-006 |
+| `HOOK_SYNC_DRIFT` / `HOOK_WRAPPER_ORPHAN` CI failure modes (REQ-MIG002-009, REQ-MIG002-010) | Not implemented; `audit_test.go` only asserts hard-coded counts | Real residual work — introduce a 3-way-sync assertion that scans (Go handlers ∩ shell wrappers ∩ settings.json keys) and reports orphans |
+
+## 10. Hook protocol contract (boundary)
+
+- `internal/hook/protocol.go` — JSON-OR-ExitCode dispatch contract (`Protocol` interface).
+- `internal/hook/registry.go:127-148` — block-decision short-circuit + exit-code 2 propagation.
+- `internal/hook/registry.go:179-202` — `isBlockDecision()` + `getBlockReason()` cover both top-level decisions (Stop, PostToolUse) and `hookSpecificOutput.permissionDecision` (PreToolUse).
+- `internal/hook/types.go` — `HookInput` / `HookOutput` / `HookSpecificOutput` struct definitions (boundary types between Claude Code stdin and Go handlers).
+
+## 11. Coverage / quality posture
+
+- Per CLAUDE.local.md §6 the hook package targets 90%+ coverage (critical package tier).
+- Existing tests for the modules in scope:
+  - `notification_test.go` (1.3 KB) — verifies silent path.
+  - `subagent_stop` covered by `coverage_boost_test.go`, `misc_coverage_test.go`, and `new_handlers_coverage_test.go`.
+  - `config_change_test.go` (6.7 KB) — verifies debounce + reload trigger.
+  - `file_changed_test.go` (3.8 KB) — verifies extension filter + scanner invocation.
+  - `instructions_loaded_test.go` (3.8 KB) — verifies 40,000 char budget path.
+  - `audit_test.go` (9.6 KB) — registration parity + per-file header + retire-event absence + observability whitelist.
+- No file at `internal/template/settings_audit_test.go` (spec.md §3 referenced this name; actual audit-suite is `internal/hook/audit_test.go`).
+
+## 12. Dependencies on this SPEC
+
+- `SPEC-V3R2-MIG-001` blocks on this SPEC's "cleanup step" being callable from the v2→v3 migrator (spec.md §9.2).
+- This SPEC blocks on `SPEC-V3R2-EXT-004` providing the migration framework path (spec.md §9.1).
+- `SPEC-V3R2-RT-006` shipped the per-handler resolution program that supersedes spec.md REQ-MIG002-004 through REQ-MIG002-008 (and most of REQ-MIG002-003).
+
+## 13. Memory anchors (out-of-tree)
+
+- `~/.claude/projects/-Users-goos-MoAI-moai-adk-go/memory/feedback_team_tmux_cleanup.md` — original tmux-pane-cleanup gap that motivated subagent_stop FIX (now resolved at `subagent_stop.go:32-98`).
+- `~/.claude/projects/-Users-goos-MoAI-moai-adk-go/memory/MEMORY.md` (index) — references the RT-006 lifecycle entry; no entry for MIG-002 yet (this plan-phase PR will populate one).
+
+## 14. Residual work surface (input to plan.md)
+
+After reconciliation the residual MIG-002 surface is:
+
+1. **EventSetup constant removal**: drop `EventSetup` from `internal/hook/types.go:83-85, 139`; remove the `internal/cli/hook.go:58` cobra subcommand binding; update `internal/hook/types_test.go:36` and `internal/cli/hook_e2e_test.go:183, 305`; update `hook.CoverageTable` so `summary.Remove` becomes 0 (or update `doctor_hook_test.go:130-131` to match).
+2. **3-way sync invariant test**: extend `internal/hook/audit_test.go` with `TestAuditThreeWaySync` that asserts the Go-registered event set (from `deps.go` invocations) ≡ the settings.json.tmpl hook-key set ∪ `retiredEventNames`. Surfaces both `HOOK_SYNC_DRIFT` (Go-only) and `HOOK_WRAPPER_ORPHAN` (settings-only) drift.
+3. **Wrapper-ship decision**: confirm intent for the 4 retired-event template wrappers (`handle-notification.sh.tmpl`, `handle-elicitation.sh.tmpl`, `handle-elicitation-result.sh.tmpl`, `handle-task-created.sh.tmpl`). Two options:
+   - **Keep** — wrappers exist for hypothetical observability opt-in users; Claude Code won't invoke them because no settings.json entry binds them.
+   - **Retire** — remove the 4 tmpls + add a `moai migrate hook-cleanup` step that deletes user-local copies.
+4. **Migration step for legacy local settings.json**: detect user-local `settings.json` entries for the 4 retired events; archive/move on `moai migrate v2-to-v3` invocation (REQ-MIG002-012).
+5. **Frontmatter reconciliation**: spec.md frontmatter must be brought to the canonical 12-field schema (`.claude/rules/moai/development/spec-frontmatter-schema.md`). Current spec.md frontmatter uses 14 fields including legacy keys (`created`, `updated`, `dependencies`, `related_gap`, `related_theme`, `breaking`, `bc_id`) that need normalization to the 12-field schema before plan PR lints clean.
+
+The plan.md milestones key off these 5 residual items, not the original spec.md "stub upgrade" framing.
+
+## 15. Files modified by this SPEC (forecast)
+
+Forecast — to be confirmed during run-phase:
+
+- `internal/hook/types.go` — remove EventSetup constant + truth-table entry.
+- `internal/hook/types_test.go` — remove EventSetup truth-table assertion.
+- `internal/cli/hook.go` — remove `setup` cobra subcommand binding.
+- `internal/cli/hook_e2e_test.go` — remove EventSetup references.
+- `internal/cli/doctor_hook_test.go` — update `summary.Remove` expectation from 1 to 0.
+- `internal/hook/coverage_table.go` — drop the setup row, decrement counts.
+- `internal/hook/audit_test.go` — add `TestAuditThreeWaySync`.
+- `.moai/specs/SPEC-V3R2-MIG-002/spec.md` — frontmatter normalization (12-field schema).
+- Optional (pending decision in plan-phase): 4 wrapper `.tmpl` deletions + migrate step.
+
+End of research.

--- a/.moai/specs/SPEC-V3R2-MIG-002/tasks.md
+++ b/.moai/specs/SPEC-V3R2-MIG-002/tasks.md
@@ -1,0 +1,218 @@
+---
+spec_id: SPEC-V3R2-MIG-002
+phase: tasks
+status: draft
+---
+
+# Implementation Tasks — SPEC-V3R2-MIG-002
+
+Each task has explicit REQ ↔ AC traceability and points to the file:line anchors documented in research.md.
+
+## Milestone M1 — RED tests (orphan + drift + stub-regression guards)
+
+### T-MIG002-01 — Add `TestAuditThreeWaySync`
+
+- **Action**: Extend `internal/hook/audit_test.go` with a new test that asserts `Go-registered events ≡ settings.json hook keys ∪ retiredEventNames`.
+- **Traceability**: REQ-MIG002-009 (HOOK_SYNC_DRIFT), REQ-MIG002-010 (HOOK_WRAPPER_ORPHAN) → AC-MIG002-A1.
+- **Anchors**: `internal/hook/audit_test.go:59-103` (existing parity test as reference), `internal/cli/deps.go:152-185` (Go-side registration source), `internal/template/templates/.claude/settings.json.tmpl:4-369` (settings keys).
+- **Acceptance**: test compiles, FAILS at M1 (drift exists pre-M2.1), PASSES after M2.1.
+
+### T-MIG002-02 — Add `TestAuditNoEventSetupOrphan`
+
+- **Action**: Extend `internal/hook/audit_test.go` with a static scan of `types.go` and `internal/cli/hook.go` for the EventSetup symbol and the `"setup"` cobra binding.
+- **Traceability**: REQ-MIG002-003 (reconciled to EventSetup retire) → AC-MIG002-A2, AC-MIG002-A3.
+- **Anchors**: `internal/hook/types.go:83-85, 139`, `internal/cli/hook.go:58`, `internal/hook/types_test.go:36`, `internal/cli/hook_e2e_test.go:183, 305`.
+- **Acceptance**: test compiles, FAILS at M1 (constant still present), PASSES after M2.1.
+
+### T-MIG002-03 — Add `TestAuditNoStubHandlers`
+
+- **Action**: Extend `internal/hook/audit_test.go` with a per-file regex assertion that each of {subagent_stop, config_change, instructions_loaded, file_changed, post_tool_failure}.go carries `// Resolution: (UPGRADE|FIX)`.
+- **Traceability**: REQ-MIG002-004, REQ-MIG002-005, REQ-MIG002-006, REQ-MIG002-007, REQ-MIG002-008 (reconciled to characterization tests) → AC-MIG002-A8.
+- **Anchors**: `internal/hook/subagent_stop.go:1`, `internal/hook/config_change.go:1`, `internal/hook/instructions_loaded.go:1`, `internal/hook/file_changed.go:1`, `internal/hook/post_tool_failure.go:1`.
+- **Acceptance**: test compiles and PASSES immediately (RT-006 already shipped); test locks the work product against future regression.
+
+### T-MIG002-04 — Add `TestRenderRetiredWrappers` (template-side)
+
+- **Action**: Add or extend `internal/template/render_test.go` with assertion that the 4 retired-wrapper templates (`handle-notification.sh.tmpl`, `handle-elicitation.sh.tmpl`, `handle-elicitation-result.sh.tmpl`, `handle-task-created.sh.tmpl`) render successfully and contain a documented RETIRE-OBS-ONLY inline comment.
+- **Traceability**: REQ-MIG002-001 (3-way sync intent — the wrappers are retained as forward-compat surface; their presence must be documented) → AC-MIG002-A5 indirectly.
+- **Anchors**: `internal/template/templates/.claude/hooks/moai/handle-notification.sh.tmpl`, `handle-elicitation.sh.tmpl`, `handle-elicitation-result.sh.tmpl`, `handle-task-created.sh.tmpl`.
+- **Acceptance**: test compiles, FAILS at M1 (no inline RETIRE-OBS-ONLY comment in the tmpls yet), PASSES after M2.2.
+
+## Milestone M2 — GREEN: EventSetup retirement + sync
+
+### T-MIG002-05 — Remove EventSetup constant + active-event entry
+
+- **Action**: Edit `internal/hook/types.go` to delete the `EventSetup` declaration block (lines 83-85) and remove `EventSetup,` from the active-event slice at line 139.
+- **Traceability**: REQ-MIG002-003 → AC-MIG002-A2.
+- **Anchors**: `internal/hook/types.go:83-85, 139`.
+- **Acceptance**: `grep -rn "EventSetup" internal/hook/types.go` returns empty; `go build ./...` succeeds.
+
+### T-MIG002-06 — Remove EventSetup truth-table entry
+
+- **Action**: Edit `internal/hook/types_test.go` to drop the `EventSetup: true,` entry at line 36.
+- **Traceability**: REQ-MIG002-003 → AC-MIG002-A2.
+- **Anchors**: `internal/hook/types_test.go:36`.
+- **Acceptance**: `go test ./internal/hook/ -run TestEventType` passes.
+
+### T-MIG002-07 — Remove `moai hook setup` cobra binding
+
+- **Action**: Edit `internal/cli/hook.go` to delete the `{"setup", "Handle setup event", hook.EventSetup},` entry at line 58.
+- **Traceability**: REQ-MIG002-003 → AC-MIG002-A3.
+- **Anchors**: `internal/cli/hook.go:58`.
+- **Acceptance**: `moai hook setup --help` reports "unknown command"; `go test ./internal/cli/` passes.
+
+### T-MIG002-08 — Remove EventSetup references from e2e test
+
+- **Action**: Edit `internal/cli/hook_e2e_test.go` to drop EventSetup entries at lines 183 and 305.
+- **Traceability**: REQ-MIG002-003 → AC-MIG002-A2, AC-MIG002-A3.
+- **Anchors**: `internal/cli/hook_e2e_test.go:183, 305`.
+- **Acceptance**: `go test ./internal/cli/ -run TestHookE2E` passes.
+
+### T-MIG002-09 — Update doctor coverage table
+
+- **Action**: Edit `internal/hook/coverage_table.go` to drop the setup row; verify `Total` and `Remove` count adjustments. Update `internal/cli/doctor_hook_test.go:18-36, 127-131` expectations to match.
+- **Traceability**: REQ-MIG002-002 (reconciled) → AC-MIG002-A6, AC-MIG002-A9.
+- **Anchors**: `internal/hook/coverage_table.go`, `internal/cli/doctor_hook_test.go:18-36, 127-131`.
+- **Acceptance**: `go test ./internal/cli/ -run TestDoctorHook` passes.
+
+### T-MIG002-10 — Document RETIRE-OBS-ONLY contract in 4 wrapper tmpls
+
+- **Action**: Edit each of `internal/template/templates/.claude/hooks/moai/handle-{notification,elicitation,elicitation-result,task-created}.sh.tmpl` to add a 2-line inline comment: `# RETIRE-OBS-ONLY (SPEC-V3R2-RT-006): not registered in settings.json. Enable via system.yaml hook.observability_events.` near the file header.
+- **Traceability**: REQ-MIG002-001 (3-way sync intent / Decision Gate M2.2 Option Keep) → AC-MIG002-A14 indirectly.
+- **Anchors**: `internal/template/templates/.claude/hooks/moai/handle-notification.sh.tmpl`, `handle-elicitation.sh.tmpl`, `handle-elicitation-result.sh.tmpl`, `handle-task-created.sh.tmpl`.
+- **Acceptance**: `TestRenderRetiredWrappers` PASSES.
+
+### T-MIG002-11 — Run `make build` to regenerate embedded templates
+
+- **Action**: Per CLAUDE.local.md §2 Template-First rule, regenerate `internal/template/embedded.go` after the template wrapper edits.
+- **Traceability**: implicit (Template-First discipline) → AC-MIG002-A12.
+- **Anchors**: `internal/template/embedded.go` (generated), `Makefile` build target.
+- **Acceptance**: `make build` exits 0; `git diff internal/template/embedded.go` shows the embedded-blob delta corresponding to the wrapper comments added in T-MIG002-10.
+
+### T-MIG002-12 — Normalize spec.md frontmatter to canonical 12-field schema
+
+- **Action**: Edit `.moai/specs/SPEC-V3R2-MIG-002/spec.md` frontmatter:
+  - Replace `id` (keep), drop legacy `dependencies`/`related_gap`/`related_theme`/`breaking`/`bc_id` keys.
+  - Add `title: "Hook Registration Cleanup (orphan EventSetup, 3-way sync invariant, migration step)"`.
+  - Keep `created`/`updated` (canonical names).
+  - Convert `tags` to comma-separated string: `tags: "hooks, cleanup, orphan, drift, mig, v3"`.
+  - Add `lifecycle: spec-anchored` (already present).
+  - Ensure `priority: P1` (rewrite from `"P1 High"`).
+- **Traceability**: `.claude/rules/moai/development/spec-frontmatter-schema.md` → AC-MIG002-A10.
+- **Anchors**: `.moai/specs/SPEC-V3R2-MIG-002/spec.md:1-22`.
+- **Acceptance**: `moai spec lint --strict .moai/specs/SPEC-V3R2-MIG-002/` reports `✓ No findings`.
+
+## Milestone M3 — GREEN: migration step
+
+### T-MIG002-13 — Promote `retiredEventNames` to exported package symbol
+
+- **Action**: Move the `retiredEventNames` slice from `internal/hook/audit_test.go:46-51` to a new `internal/hook/retired_events.go` file. Export as `RetiredEventNames []string`. Update `audit_test.go` to reference the exported symbol.
+- **Traceability**: enables reuse by `internal/migrate/hook_cleanup.go` (T-MIG002-14).
+- **Anchors**: `internal/hook/audit_test.go:46-51`.
+- **Acceptance**: `go test ./internal/hook/` continues to pass; new file headed with `// Resolution: KEEP — shared canonical list of retired event names (SPEC-V3R2-RT-006 + SPEC-V3R2-MIG-002).`.
+
+### T-MIG002-14 — Implement `CleanupUserSettings`
+
+- **Action**: Create `internal/migrate/hook_cleanup.go` with `CleanupUserSettings(projectRoot string) error`:
+  - Reads `<projectRoot>/.claude/settings.json`.
+  - Iterates `hook.RetiredEventNames`; removes matching `hooks.<EventName>` entries.
+  - Archives removed entries to `<projectRoot>/.moai/archive/hooks/v3.0/migration-<YYYY-MM-DD>.json`.
+  - Writes cleaned settings.json atomically (temp + rename).
+- **Traceability**: REQ-MIG002-011, REQ-MIG002-012, REQ-MIG002-019 → AC-MIG002-A7.
+- **Anchors**: research.md §9 (drift table — REQ-MIG002-012 row), `.moai/archive/hooks/v3.0/` per spec.md §7.
+- **Acceptance**: function compiles; godoc present; error paths return wrapped errors.
+
+### T-MIG002-15 — Unit tests for `CleanupUserSettings`
+
+- **Action**: Create `internal/migrate/hook_cleanup_test.go` table-driven test covering:
+  - All 4 retired entries present → all removed + archive file written.
+  - 0 retired entries present → no-op + no archive file.
+  - Mixed retired + active entries → only retired removed.
+  - Malformed JSON → wrapped error + no write.
+  - Re-invocation idempotency (subsequent call is a no-op).
+- **Traceability**: REQ-MIG002-011, REQ-MIG002-012, REQ-MIG002-019 → AC-MIG002-A7.
+- **Anchors**: `internal/migrate/hook_cleanup_test.go` (new), `internal/migrate/testdata/` (fixtures).
+- **Acceptance**: `go test ./internal/migrate/ -run TestCleanupUserSettings -v -cover` PASSES with coverage ≥ 85%.
+
+### T-MIG002-16 — Wire CleanupUserSettings into migration framework
+
+- **Action**: Locate the SPEC-V3R2-EXT-004 migration entry point (search `internal/migrate/` for the v2→v3 dispatcher) and add a call to `CleanupUserSettings(projectRoot)` as a step.
+- **Traceability**: spec.md §9.1 (blocked-by EXT-004), spec.md §9.2 (blocks MIG-001).
+- **Anchors**: `internal/migrate/` (locate dispatcher during implementation).
+- **Acceptance**: integration smoke test invoking the full v2→v3 path on a fixture project shows the retired-event cleanup executed.
+
+## Milestone M4 — REFACTOR + verification gates
+
+### T-MIG002-17 — Update `hooks-system.md` rules document
+
+- **Action**: Edit `.claude/rules/moai/core/hooks-system.md` (referenced in spec.md §3) to reflect the post-MIG-002 event roster: 22 native settings.json keys + 4 retired-obs-only + 0 orphans = 26 total Go handlers.
+- **Traceability**: documentation alignment with spec.md §3.
+- **Anchors**: `.claude/rules/moai/core/hooks-system.md` (verify path during implementation; may be at a different location).
+- **Acceptance**: doc reflects the current truth-table; cross-referenced from spec.md.
+
+### T-MIG002-18 — Negative-test the drift detector
+
+- **Action**: In a throwaway branch, inject a fake `EventFoo EventType = "Foo"` constant + register a dummy handler in `deps.go`. Run `TestAuditThreeWaySync`; verify it FAILS with `HOOK_SYNC_DRIFT: Foo`. Discard the branch.
+- **Traceability**: REQ-MIG002-009 verification (regression detection actually works) → AC-MIG002-A1.
+- **Anchors**: `internal/hook/types.go`, `internal/cli/deps.go:152-185`.
+- **Acceptance**: documented in PR description / `progress.md` that the negative test was run and the detector fired correctly.
+
+### T-MIG002-19 — Full verification suite
+
+- **Action**: Run:
+  - `go test -race -count=1 ./internal/hook/ ./internal/cli/ ./internal/template/ ./internal/migrate/`
+  - `go test -cover ./internal/hook/ ./internal/migrate/`
+  - `golangci-lint run ./internal/hook/... ./internal/cli/... ./internal/migrate/...`
+  - `go vet ./...`
+  - `moai spec lint --strict .moai/specs/SPEC-V3R2-MIG-002/`
+- **Traceability**: AC-MIG002-A1 through AC-MIG002-A14.
+- **Anchors**: CI surface; CLAUDE.local.md §3 + §6.
+- **Acceptance**: all commands exit 0; coverage thresholds met.
+
+### T-MIG002-20 — Update `@MX:ANCHOR` on InitDependencies
+
+- **Action**: Re-verify the `@MX:ANCHOR fan_in=5` annotation at `internal/cli/deps.go:58-62` still reflects post-cleanup reality. If fan_in count changed (e.g., e2e test references dropped), update the annotation.
+- **Traceability**: MX-Tag Protocol (Quality Gates).
+- **Anchors**: `internal/cli/deps.go:58-62`.
+- **Acceptance**: `@MX:REASON` text matches current call-site count verified by `grep -rn "InitDependencies\b" internal/ | wc -l`.
+
+## Traceability Matrix
+
+| REQ | AC | Tasks |
+|---|---|---|
+| REQ-MIG002-001 | AC-MIG002-A1, A4 | T-MIG002-01, T-MIG002-04, T-MIG002-10 |
+| REQ-MIG002-002 | AC-MIG002-A6, A9 | T-MIG002-09 |
+| REQ-MIG002-003 | AC-MIG002-A2, A3, A5 | T-MIG002-02, T-MIG002-05, T-MIG002-06, T-MIG002-07, T-MIG002-08 |
+| REQ-MIG002-004 | AC-MIG002-A8 | T-MIG002-03 (characterization only — RT-006 already shipped impl) |
+| REQ-MIG002-005 | AC-MIG002-A8 | T-MIG002-03 |
+| REQ-MIG002-006 | AC-MIG002-A8 | T-MIG002-03 |
+| REQ-MIG002-007 | AC-MIG002-A8 | T-MIG002-03 |
+| REQ-MIG002-008 | AC-MIG002-A8 | T-MIG002-03 |
+| REQ-MIG002-009 | AC-MIG002-A1 | T-MIG002-01, T-MIG002-18 |
+| REQ-MIG002-010 | AC-MIG002-A1 | T-MIG002-01 |
+| REQ-MIG002-011 | AC-MIG002-A7 | T-MIG002-14, T-MIG002-15 |
+| REQ-MIG002-012 | AC-MIG002-A7 | T-MIG002-14, T-MIG002-15, T-MIG002-16 |
+| REQ-MIG002-013 | AC-MIG002-A8 | T-MIG002-03 (characterization — RT-006 P-H02 impl at subagent_stop.go:32-98) |
+| REQ-MIG002-014 | AC-MIG002-A8 | T-MIG002-03 (characterization — instructions_loaded.go:29-78) |
+| REQ-MIG002-015 | AC-MIG002-A14 | T-MIG002-10 (reconciled to observability_events opt-in, not retain_noop) |
+| REQ-MIG002-016 | AC-MIG002-A8 | T-MIG002-03 (characterization — file_changed.go:55-114) |
+| REQ-MIG002-017 | AC-MIG002-A8 | T-MIG002-03 (characterization — subagent_stop.go:76-86 graceful degradation) |
+| REQ-MIG002-018 | AC-MIG002-A8 | T-MIG002-03 (characterization — config_change.go:56-71 reload-fail path) |
+| REQ-MIG002-019 | AC-MIG002-A7 | T-MIG002-14 (archive path `.moai/archive/hooks/v3.0/`) |
+
+Cross-cutting:
+- **TRUST 5 Tested**: AC-MIG002-A11 → T-MIG002-15, T-MIG002-19.
+- **TRUST 5 Readable + Unified**: AC-MIG002-A12 → T-MIG002-19.
+- **TRUST 5 Secured**: AC-MIG002-A13 → T-MIG002-19 (race detector).
+- **TRUST 5 Trackable**: implicit via `feat(SPEC-V3R2-MIG-002):` commit prefix per CLAUDE.local.md §18.3.
+
+## Execution Order
+
+Sequential within milestones; parallel across non-conflicting tasks:
+
+1. M1: T-MIG002-01, T-MIG002-02, T-MIG002-03, T-MIG002-04 (parallel — all add to test files; no production code mutation).
+2. M2 (sequential due to interlocking file edits): T-MIG002-05 → T-MIG002-06 → T-MIG002-07 → T-MIG002-08 → T-MIG002-09 → T-MIG002-10 → T-MIG002-11 → T-MIG002-12.
+3. M3: T-MIG002-13 → T-MIG002-14 → T-MIG002-15 → T-MIG002-16 (sequential — each task depends on the previous).
+4. M4: T-MIG002-17, T-MIG002-18, T-MIG002-19, T-MIG002-20 (mostly parallel; T-MIG002-19 is the gate).
+
+End of tasks.


### PR DESCRIPTION
## Summary

Plan-phase artifacts for SPEC-V3R2-MIG-002 (Hook Registration Cleanup). Reconciles the obsolete pre-RT-006 spec.md (2026-04-23) framing into an honest residual cleanup scope.

- **research.md** (260 LOC, 78 file:line anchors) — drift table between spec.md assumptions and current 2026-05-18 state
- **plan.md** (236 LOC, M1-M4 milestones) — RED tests → EventSetup retirement → CleanupUserSettings migration → verification gates
- **acceptance.md** (236 LOC, 14 binary ACs A1-A14) — each verifiable with a single shell or Go test command
- **tasks.md** (218 LOC, 20 tasks T-MIG002-01..20) — full REQ↔AC↔Task traceability matrix

## Key Findings

1. **Only true orphan**: `EventSetup` constant + `moai hook setup` cobra binding (no handler file; no shell wrapper; no settings.json entry). The spec.md \"setupHandler orphan\" framing referred to a file that never existed — reconciled.
2. **RT-006 already shipped** the upgrades the spec.md called for:
   - `subagent_stop.go` (FIX P-H02 with 500ms tmux kill timeout)
   - `config_change.go`, `instructions_loaded.go`, `file_changed.go`, `post_tool_failure.go` (5 UPGRADE)
   - `notification.go`, `elicitation.go`, `task_created.go` (4 RETIRE-OBS-ONLY)
   - Plan converts spec.md REQs 004-008 into **characterization tests** locking the RT-006 work product against regression — no re-implementation.
3. **3-way sync invariant** (`HOOK_SYNC_DRIFT` / `HOOK_WRAPPER_ORPHAN` per spec.md REQ-009/010) is the genuine new test surface; not yet implemented in the audit suite.
4. **Wrapper-keep decision** (M2.2 Decision Gate, Option Keep recommended): the 4 retired-event `.sh.tmpl` files stay shipped to preserve the `system.yaml hook.observability_events` opt-in forward-compat path.
5. **Migration step** `CleanupUserSettings` (M3) handles users upgrading from pre-RT-006 v3 builds whose local settings.json still carries retired entries; archives to `.moai/archive/hooks/v3.0/migration-<YYYY-MM-DD>.json`.

## Plan-auditor Self-Check

- [x] research.md ≥ 25 file:line anchors → **78 anchors** present (registry.go, types.go, deps.go, settings.json.tmpl, audit_test.go, doctor_hook_test.go, all 5 RT-006-touched handlers, observability.go, hook.go).
- [x] acceptance.md ≥ 10 binary ACs → **14 ACs** (A1-A14), each with `Binary verification:` shell snippet.
- [x] plan.md no time estimates → priority labels (High/Medium) only.
- [x] tasks.md REQ↔AC↔Task matrix → traceability table at tasks.md §Traceability Matrix.
- [x] Plan-phase OUTPUT only — no Go code modifications in this PR.
- [x] RT-006 baseline acknowledged — spec.md REQs 004-008 reconciled to characterization tests per research.md §9 drift table.
- [x] tags string CSV format (frontmatter normalization queued in T-MIG002-12 / M2.3; spec.md frontmatter cleanup is a deliverable, not a precondition).
- [x] CLAUDE.local.md §18.3 commit format observed: `plan(SPEC-V3R2-MIG-002): ...`
- [x] Per user policy 2026-05-17: plan-phase in main checkout, no L2 worktree.

## Test plan

- [ ] plan-auditor agent reviews the 4 artifacts and issues PASS verdict
- [ ] User confirms wrapper-keep decision (M2.2 Option Keep recommended)
- [ ] Run-phase entry point: M1 RED tests added to `internal/hook/audit_test.go`

## Out of Scope

Per plan.md §6, this SPEC does NOT:
- Re-implement any of the 5 RT-006 UPGRADE/FIX handlers
- Add new hook events
- Modify hook protocol or `hookSpecificOutput` schema
- Remove the 4 retired-event `.sh.tmpl` wrappers (Option Retire deferred)
- Modify `system.yaml hook.observability_events` semantics

🗿 MoAI <email@mo.ai.kr>