### PR TITLE
plan(SPEC-V3R2-MIG-003): Config Loader Completeness — 4 unloaded sections audit (HRN-001 reconciled)

### DIFF
--- a/.moai/specs/SPEC-V3R2-MIG-003/acceptance.md
+++ b/.moai/specs/SPEC-V3R2-MIG-003/acceptance.md
@@ -1,0 +1,399 @@
+# Acceptance Criteria — SPEC-V3R2-MIG-003
+
+> Companion to `spec.md` (REQ-MIG003-001 ~ REQ-MIG003-018, 18 REQ).
+> Companion to `plan.md` (M1-M4 milestones).
+> Companion to `research.md` (38 file:line anchors).
+> Companion to `tasks.md` (T-MIG003-NN).
+
+This document enumerates the binary acceptance criteria for SPEC-V3R2-MIG-003. Each AC is independently verifiable via a single command or short script. All ACs MUST pass before `/moai sync` and PR merge.
+
+---
+
+## HISTORY
+
+| Version | Date       | Author       | Description                                                                  |
+|---------|------------|--------------|------------------------------------------------------------------------------|
+| 0.1.0   | 2026-05-18 | manager-spec | Initial AC synthesis: 15 binary ACs, HRN-001 reconciliation, Given/When/Then |
+
+---
+
+## AC Index (15 ACs, all binary)
+
+| AC ID | REQ coverage | Phase | Status hook |
+|---|---|---|---|
+| AC-MIG003-01 | REQ-MIG003-001 | M2 | structs exist |
+| AC-MIG003-02 | REQ-MIG003-002 (verify-only for harness; new for 4) | M2 | loaders exist |
+| AC-MIG003-03 | REQ-MIG003-004, REQ-MIG003-012 | M2 | defaults |
+| AC-MIG003-04 | REQ-MIG003-008 (verify-only — HRN-001 reconciled) | M2 | parse error |
+| AC-MIG003-05 | REQ-MIG003-005 | M2 | godoc hot path |
+| AC-MIG003-06 | REQ-MIG003-006, REQ-MIG003-015 | M2 | DORMANT marker |
+| AC-MIG003-07 | REQ-MIG003-007 | M1-M2 | unit tests pass |
+| AC-MIG003-08 | REQ-MIG003-009 | M2 | ForbiddenLibraries exposed |
+| AC-MIG003-09 | REQ-MIG003-010 | M2 | ContextConfig fields |
+| AC-MIG003-10 | REQ-MIG003-011 | M2 | InterviewConfig fields |
+| AC-MIG003-11 | REQ-MIG003-014 | M2 | DesignConfig fields |
+| AC-MIG003-12 | REQ-MIG003-013 | M3 | YAML_SECTION_NO_LOADER guard |
+| AC-MIG003-13 | REQ-MIG003-017 | M4 | LOADER_HARDCODE_VIOLATION review |
+| AC-MIG003-14 | REQ-MIG003-016 | M3 | CONFIG_STRUCT_YAML_MISMATCH guard |
+| AC-MIG003-15 | REQ-MIG003-018 | M3 | SUNSET_CONFIG_DORMANT_NOTICE once |
+
+---
+
+## AC-MIG003-01 — 4 new structs exist in types.go
+
+**REQ**: REQ-MIG003-001
+**Phase**: M2 GREEN
+
+**Given** the internal/config package has been built
+**When** `grep -nE '^type (ConstitutionConfig|ContextConfig|InterviewConfig|DesignConfig) struct' internal/config/types.go` runs
+**Then** exactly 4 matching lines are output, one per struct.
+
+Additionally `grep -nE '^type HarnessConfig struct' internal/config/types.go` returns exactly 1 match at line ~402 (verify-only — HRN-001 delivered).
+
+**Verify command**:
+```bash
+test "$(grep -cE '^type (ConstitutionConfig|ContextConfig|InterviewConfig|DesignConfig) struct' internal/config/types.go)" = "4"
+```
+
+Pass ⇔ exit 0.
+
+---
+
+## AC-MIG003-02 — 4 new loader functions exist + HarnessConfig loader verified
+
+**REQ**: REQ-MIG003-002 (4 new ones in MIG-003; LoadHarnessConfig verified from HRN-001)
+**Phase**: M2 GREEN
+
+**Given** the internal/config package compiles
+**When** `grep -nE '^func Load(Constitution|Context|Interview|Design)Config' internal/config/` is run across all *.go files
+**Then** exactly 4 matching function declarations exist (one per section).
+
+**Verify command**:
+```bash
+test "$(grep -rE '^func Load(Constitution|Context|Interview|Design)Config' internal/config/ --include='*.go' | wc -l | tr -d ' ')" = "4"
+# Also verify HRN-001's LoadHarnessConfig still exists (regression check)
+grep -n '^func LoadHarnessConfig' internal/config/loader.go
+```
+
+Pass ⇔ both commands exit 0 AND first grep returns 4 lines.
+
+---
+
+## AC-MIG003-03 — Defaults returned on absent file
+
+**REQ**: REQ-MIG003-004, REQ-MIG003-012 (verify-only for harness)
+**Phase**: M2 GREEN
+
+**Given** a config directory that does NOT contain `constitution.yaml`, `context.yaml`, `interview.yaml`, `design.yaml`
+**When** `Loader.Load(dir)` is invoked
+**Then**:
+- No error is returned
+- `cfg.Constitution`, `cfg.ContextSearch`, `cfg.Interview`, `cfg.Design` are populated with non-zero default values (matching `internal/template/templates/.moai/config/sections/*.yaml`)
+- `loadedSections["constitution"]`, `loadedSections["context_search"]`, `loadedSections["interview"]`, `loadedSections["design"]` are NOT set to `true` (graceful — file absent)
+
+**Verify command**:
+```bash
+go test ./internal/config/... -run 'TestLoad(Constitution|Context|Interview|Design)Config_MissingFile_ReturnsDefaults' -v
+```
+
+Pass ⇔ all 4 tests exit 0.
+
+---
+
+## AC-MIG003-04 — Malformed YAML returns typed error
+
+**REQ**: REQ-MIG003-008 (HRN-001 reconciliation: `ErrInvalidYAML` subsumes the `*_PARSE_ERROR` naming)
+**Phase**: M2 GREEN
+
+**Given** a `constitution.yaml` / `context.yaml` / `interview.yaml` / `design.yaml` with malformed YAML syntax
+**When** the corresponding `LoadXxxConfig(path)` is invoked
+**Then** the returned error satisfies `errors.Is(err, ErrInvalidYAML)` AND the error message contains the file path.
+
+Verify-only for harness: `LoadHarnessConfig` malformed-path already returns `ErrInvalidYAML` (HRN-001 test `TestLoadHarnessConfigExtended_InvalidThreshold` covers analogous case at loader_harness_extended_test.go:86).
+
+**Verify command**:
+```bash
+go test ./internal/config/... -run 'TestLoad(Constitution|Context|Interview|Design)Config_Malformed' -v
+```
+
+Pass ⇔ all 4 tests exit 0.
+
+---
+
+## AC-MIG003-05 — Each struct godoc names runtime hot path
+
+**REQ**: REQ-MIG003-005
+**Phase**: M2 GREEN
+
+**Given** each new struct in `internal/config/types.go`
+**When** the godoc comment block for `ConstitutionConfig`, `ContextConfig`, `InterviewConfig`, `DesignConfig` is inspected
+**Then** the godoc explicitly names at least one runtime hot-path consumer:
+- `ConstitutionConfig` → mentions "SPEC-V3R2-EXT-004" OR "forbidden-library policy"
+- `ContextConfig` → mentions "CLAUDE.md §16 Context Search" OR "token_budget"
+- `InterviewConfig` → mentions "SPEC-V3R2-WF-003 discovery" OR "clarity-threshold"
+- `DesignConfig` → mentions "GAN loop" OR "sprint contract"
+
+**Verify command**:
+```bash
+go doc -all ./internal/config | grep -E '^type (ConstitutionConfig|ContextConfig|InterviewConfig|DesignConfig) struct' -A 5 | grep -E 'EXT-004|CLAUDE.md §16|WF-003|GAN loop'
+test "$(go doc -all ./internal/config | grep -E '^type (ConstitutionConfig|ContextConfig|InterviewConfig|DesignConfig) struct' -A 5 | grep -cE 'EXT-004|CLAUDE.md §16|WF-003|GAN loop')" -ge "4"
+```
+
+Pass ⇔ at least 4 hot-path references in the 4 struct godocs.
+
+---
+
+## AC-MIG003-06 — SunsetConfig DORMANT godoc marker
+
+**REQ**: REQ-MIG003-006, REQ-MIG003-015
+**Phase**: M2 GREEN
+
+**Given** the `SunsetConfig` struct at `internal/config/types.go:309`
+**When** its godoc comment block is inspected
+**Then** the comment contains the literal string `DORMANT` AND a forward-reference note ("Activation deferred to a future SPEC. Do NOT add LoadSunsetConfig until activation SPEC is filed.").
+
+**Verify command**:
+```bash
+grep -B 0 -A 8 'type SunsetConfig struct' internal/config/types.go | grep -q 'DORMANT'
+grep -B 0 -A 8 'type SunsetConfig struct' internal/config/types.go | grep -q 'Activation deferred'
+```
+
+Pass ⇔ both grep exit 0.
+
+---
+
+## AC-MIG003-07 — Unit tests pass for all 4 loaders
+
+**REQ**: REQ-MIG003-007
+**Phase**: M1 (RED) + M2 (GREEN)
+
+**Given** the 4 new loader test files exist and the M2 implementation is complete
+**When** `go test ./internal/config/...` runs
+**Then** all 4 loader test suites (constitution, context, interview, design) PASS with at minimum 3 cases each: valid file load + missing file default + malformed file error.
+
+Additionally HRN-001's harness tests must continue to pass (regression guard).
+
+**Verify command**:
+```bash
+go test ./internal/config/... -run 'TestLoad(Constitution|Context|Interview|Design|Harness)Config' -v -count=1
+```
+
+Pass ⇔ exit 0 AND zero FAIL/SKIP for the 5 prefix matches.
+
+---
+
+## AC-MIG003-08 — ConstitutionConfig.ForbiddenLibraries is exposed
+
+**REQ**: REQ-MIG003-009
+**Phase**: M2 GREEN
+
+**Given** a valid `constitution.yaml` with `forbidden_patterns: ["global mutable state", "init() with side effects", ...]`
+**When** `LoadConstitutionConfig(path)` returns and the result is inspected
+**Then** the typed result exposes the list (via `cfg.ForbiddenLibraries` or `cfg.ForbiddenPatterns` accessor — name finalized in M2) with at least 4 entries matching the YAML, AND the field is non-private (exported, accessible from outside the package).
+
+**Verify command**:
+```bash
+go test ./internal/config/... -run 'TestLoadConstitutionConfig_ForbiddenLibrariesExposed' -v
+```
+
+Pass ⇔ exit 0.
+
+---
+
+## AC-MIG003-09 — ContextConfig token_budget and date_range_days parsed
+
+**REQ**: REQ-MIG003-010
+**Phase**: M2 GREEN
+
+**Given** a valid `context.yaml` with `token_budget.max_injection_tokens: 5000`, `token_budget.skip_if_usage_above: 150000`, `search.date_range_days: 30`
+**When** `LoadContextConfig(path)` returns
+**Then** the returned struct exposes:
+- `cfg.TokenBudget.MaxInjectionTokens == 5000`
+- `cfg.TokenBudget.SkipIfUsageAbove == 150000`
+- `cfg.Search.DateRangeDays == 30`
+
+(REQ-MIG003-010 mentions "staleness_window_days" but the actual YAML field is `search.date_range_days`; the struct uses the YAML name. Plan.md OQ4 documents this drift.)
+
+**Verify command**:
+```bash
+go test ./internal/config/... -run 'TestLoadContextConfig_ValidParse' -v
+```
+
+Pass ⇔ exit 0.
+
+---
+
+## AC-MIG003-10 — InterviewConfig clarity_threshold and max_rounds parsed
+
+**REQ**: REQ-MIG003-011
+**Phase**: M2 GREEN
+
+**Given** a valid `interview.yaml` with `clarity_threshold: 4`, `plan.max_rounds: 5`, `plan.questions_per_round: 3`, `skip_conditions: [...]`
+**When** `LoadInterviewConfig(path)` returns
+**Then** the returned struct exposes:
+- `cfg.ClarityThreshold == 4`
+- `cfg.Plan.MaxRounds == 5`
+- `cfg.Plan.QuestionsPerRound == 3`
+- `len(cfg.SkipConditions) == 3`
+
+**Verify command**:
+```bash
+go test ./internal/config/... -run 'TestLoadInterviewConfig_ValidParse' -v
+```
+
+Pass ⇔ exit 0.
+
+---
+
+## AC-MIG003-11 — DesignConfig sprint_contract and gan_loop parsed
+
+**REQ**: REQ-MIG003-014
+**Phase**: M2 GREEN
+
+**Given** a valid `design.yaml` with `gan_loop.pass_threshold: 0.75`, `gan_loop.max_iterations: 5`, `gan_loop.sprint_contract.enabled: true`, `adaptation.iteration_limits.builder: 3`
+**When** `LoadDesignConfig(path)` returns
+**Then** the returned struct exposes:
+- `cfg.GanLoop.PassThreshold == 0.75`
+- `cfg.GanLoop.MaxIterations == 5`
+- `cfg.GanLoop.SprintContract.Enabled == true`
+- `cfg.Adaptation.IterationLimits["builder"] == 3` (or struct field equivalent)
+
+(Plan.md OQ4 documents that REQ-MIG003-014's `phase_weights` is conceptually subsumed by the actual YAML `iteration_limits`.)
+
+**Verify command**:
+```bash
+go test ./internal/config/... -run 'TestLoadDesignConfig_ValidParse' -v
+```
+
+Pass ⇔ exit 0.
+
+Bonus: `TestLoadDesignConfig_PassThresholdFloorViolation` PASSes (pass_threshold < 0.60 rejected with `ErrPassThresholdFloor`).
+
+---
+
+## AC-MIG003-12 — YAML_SECTION_NO_LOADER CI guard active
+
+**REQ**: REQ-MIG003-013
+**Phase**: M3 (CI Guards)
+
+**Given** the audit test `internal/config/audit_loader_completeness_test.go` exists
+**When** `go test ./internal/config/... -run TestAuditLoaderCompleteness` runs
+**Then**:
+- Current state: PASS (4 new sections wired + DORMANT sunset + acknowledged-out-of-scope allowlist)
+- Simulated state: if a new YAML file `internal/template/templates/.moai/config/sections/__test_new.yaml` is temporarily added with no corresponding loader and not in the allowlist, the test FAILs with `YAML_SECTION_NO_LOADER: __test_new`
+
+**Verify command**:
+```bash
+# Positive case
+go test ./internal/config/... -run TestAuditLoaderCompleteness -v
+# Negative case (manual or scripted): drop a sentinel yaml, expect FAIL
+```
+
+Pass ⇔ positive-case exit 0 AND (during run-phase verification) negative-case demonstrates FAIL with the expected message.
+
+---
+
+## AC-MIG003-13 — LOADER_HARDCODE_VIOLATION review checklist
+
+**REQ**: REQ-MIG003-017
+**Phase**: M4 REFACTOR
+
+**Given** the 4 new loader files (`loader_constitution.go`, `loader_context.go`, `loader_interview.go`, `loader_design.go`)
+**When** code review (or automated grep audit) inspects them
+**Then** zero inline literal values are found that override YAML field values. Specifically, no `const maxRounds = 4` style hardcodes overriding `interview.clarity_threshold`. Defaults are sourced exclusively from `internal/config/defaults.go` helpers.
+
+**Verify command**:
+```bash
+# Grep audit: any numeric/string literal in loader_*.go that matches a YAML value field
+# (heuristic — manual review supplements)
+! grep -nE '^\s*(const|var)\s+\w+\s*=\s*[0-9]+\s*$' internal/config/loader_constitution.go internal/config/loader_context.go internal/config/loader_interview.go internal/config/loader_design.go
+```
+
+Pass ⇔ no numeric `const` / `var` declarations at top-level in the 4 loader files. Note: graceful-defaults sourced from `defaults.go` are NOT in scope of this AC (they live in defaults.go, intentionally).
+
+---
+
+## AC-MIG003-14 — CONFIG_STRUCT_YAML_MISMATCH `make build` guard
+
+**REQ**: REQ-MIG003-016
+**Phase**: M3 (CI Guards)
+
+**Given** the audit test `internal/config/audit_struct_yaml_symmetry_test.go` exists
+**When** `make build` runs (which executes `go test ./internal/config/...` as part of the build target)
+**Then**:
+- Current state: PASS — for each of `ConstitutionConfig`, `ContextConfig`, `InterviewConfig`, `DesignConfig`, every yaml-tagged Go field has a corresponding key in the template YAML, and every YAML key has a yaml-tagged Go field.
+- Simulated state: if a Go field with `yaml:"new_field"` is added without a matching YAML key, test FAILs with `CONFIG_STRUCT_YAML_MISMATCH: field=ConstitutionConfig.NewField, side=go-only`
+
+**Verify command**:
+```bash
+# Build-time invocation
+make build
+# Direct invocation
+go test ./internal/config/... -run TestStructYAMLSymmetry -v
+```
+
+Pass ⇔ both commands exit 0.
+
+---
+
+## AC-MIG003-15 — SUNSET_CONFIG_DORMANT_NOTICE logged once per session
+
+**REQ**: REQ-MIG003-018
+**Phase**: M3 (Once-per-Session Notice)
+
+**Given** the `Loader.Load()` function is called from a process where `.moai/config/sections/sunset.yaml` exists
+**When** `Loader.Load()` is invoked twice (or more) within the same process lifetime
+**Then** exactly ONE `SUNSET_CONFIG_DORMANT_NOTICE` slog record is emitted, with attributes `spec="SPEC-V3R2-MIG-003 REQ-018"` and `yaml_path` populated.
+
+Additionally: if `sunset.yaml` does NOT exist in the sections directory, zero notices are emitted.
+
+**Verify command**:
+```bash
+go test ./internal/config/... -run 'TestSunsetNotice_FiresOnce|TestSunsetNotice_AbsentFileNoNotice' -v
+```
+
+Pass ⇔ both tests exit 0.
+
+---
+
+## Definition of Done (DoD)
+
+All of the following must hold before this SPEC is considered Done and a sync PR is created:
+
+- [ ] AC-MIG003-01 through AC-MIG003-15: all PASS (exit code 0 from all verify commands)
+- [ ] `go test ./...`: 100% green across the entire repo (no regressions outside internal/config)
+- [ ] `golangci-lint run ./...`: zero new findings
+- [ ] `make build`: success (includes CI guard AC-MIG003-14 verification)
+- [ ] Test coverage for `internal/config/` (incremental): ≥85% line coverage; new files ≥90%
+- [ ] `.claude/rules/moai/core/settings-management.md` updated to document 4 new loaders + DORMANT sunset + 2 CI guards (M4 task)
+- [ ] `progress.md` records `plan_status: audit-ready` (already set in this plan-phase artifact frontmatter)
+- [ ] Plan-auditor verdict: PASS (run before /moai run handoff)
+- [ ] No new `direct` dependencies added to `go.mod` (REQ-MIG003 §7 9-direct-dep policy)
+- [ ] All commits follow Conventional Commits format
+- [ ] HRN-001 regression: `TestLoadHarnessConfigExtended_*` all PASS (verify-only baseline)
+
+## Quality Gates
+
+| Gate | Threshold | Source |
+|---|---|---|
+| Line coverage (internal/config) | ≥85% | quality.yaml |
+| New file coverage | ≥90% | plan.md §8.2 |
+| Lint findings | 0 | quality.yaml |
+| TRUST 5 Tested | All tests green | `.claude/rules/moai/core/moai-constitution.md` |
+| TRUST 5 Readable | golangci-lint pass | same |
+| TRUST 5 Unified | gofmt + goimports pass | same |
+| TRUST 5 Secured | No hardcoded credentials, no panic in library code | same |
+| TRUST 5 Trackable | Conventional commits | same |
+| Plan-Auditor | PASS verdict before /moai run | `.claude/rules/moai/workflow/spec-workflow.md` §Phase 0.5 |
+
+## Note on Verify-Only ACs
+
+The following ACs are partially **verify-only** because SPEC-V3R2-HRN-001 already delivered the harness slice:
+
+- **AC-MIG003-02**: harness loader portion verified (HRN-001 work product); 4 new loaders are net-new
+- **AC-MIG003-03**: harness defaults portion is dedicated (`LoadHarnessConfig` returns `ErrConfigNotFound`, NOT defaults — by HRN-001 design); the 4 new loaders ARE graceful-default
+- **AC-MIG003-04**: harness parse error returns `ErrInvalidYAML` (HRN-001 sentinel); the 4 new loaders mirror
+
+This is the explicit HRN-001 reconciliation point (plan.md §1, research.md §2). The spec.md was authored before HRN-001 shipped; this acceptance.md reflects the post-HRN-001 reality.
+
+End of acceptance.md

--- a/.moai/specs/SPEC-V3R2-MIG-003/plan.md
+++ b/.moai/specs/SPEC-V3R2-MIG-003/plan.md
@@ -1,0 +1,338 @@
+---
+spec_id: SPEC-V3R2-MIG-003
+phase: plan
+status: audit-ready
+plan_complete_at: 2026-05-18
+---
+
+# Implementation Plan — SPEC-V3R2-MIG-003
+
+> Companion to `spec.md` (REQ-MIG003-001 ~ REQ-MIG003-018, 18 REQ).
+> Companion to `research.md` (38 file:line anchors).
+> Companion to `acceptance.md` (15 binary AC) and `tasks.md` (T-MIG003-NN).
+
+---
+
+## HISTORY
+
+| Version | Date       | Author       | Description                                                                                          |
+|---------|------------|--------------|------------------------------------------------------------------------------------------------------|
+| 0.1.0   | 2026-05-18 | manager-spec | Initial plan-phase synthesis: M1-M4 milestones, REQ↔Task matrix, HRN-001 reconciliation, risks, file map |
+
+---
+
+## 1. Context
+
+The original `spec.md` (authored 2026-04-23) scoped MIG-003 to add Go loaders for **5 unloaded YAML sections** in `.moai/config/sections/`: constitution, context, interview, design, harness.
+
+Between authoring and this plan (2026-05-18), **SPEC-V3R2-HRN-001 shipped on main** (commit chain ≤ `195b469d8`). HRN-001 delivered the complete `harness.yaml` loader stack: `HarnessConfig` struct (`internal/config/types.go:398-538`), `LoadHarnessConfig()` with 4-stage validation (`internal/config/loader.go:256-311`), FROZEN enum + schema-drift detection (`detectSchemaDrift`, loader.go:318-358), and 7 extended test cases (`loader_harness_extended_test.go:17-200`).
+
+Consequently the MIG-003 effective scope is now **4 unloaded sections** (constitution, context, interview, design) + the sunset.yaml DORMANT formalization + 2 CI guards (`YAML_SECTION_NO_LOADER`, `CONFIG_STRUCT_YAML_MISMATCH`). REQ-MIG003-002 / -004 / -008 / -012 are partially satisfied for the harness slice by HRN-001 and become **verify-only** in this plan; REQ-MIG003-001 / -003 / -005 / -006 / -007 / -009 / -010 / -011 / -013 / -014 / -015 / -016 / -017 / -018 are net-new work.
+
+The plan turns the 4-section gap into M1-M4 milestones with explicit TDD discipline (RED → GREEN → REFACTOR), reuses the HRN-001 loader pattern (wrapper-type + `loadYAMLFile` helper + section assignment + `loadedSections[]` flag), and adds two `make build`-time audit tests that lock the contract going forward. See `research.md` §13 (inventory table) and §15 (38 anchors) for the full state-of-the-codebase reference.
+
+## 2. Approach
+
+TDD across M1-M4. Each milestone has an explicit RED (failing test capturing intent) → GREEN (minimal change to pass) → REFACTOR (cleanup + invariant check) loop.
+
+We do NOT re-implement `LoadHarnessConfig` — that is HRN-001 work product. We DO add a verify-only test ensuring `loadedSections["harness"]` accounting stays internally consistent OR document HRN-001's dedicated entry as canonical (decided at M4 — see `research.md` §14 Q1).
+
+Loader pattern is replicated 4 times from the canonical `loadUserSection` shape (`internal/config/loader.go:88-99`) plus the HRN-001 file-level separation pattern (HRN-001 chose to keep `LoadHarnessConfig` in loader.go itself; MIG-003 deviates by introducing per-section files `internal/config/loader_{constitution,context,interview,design}.go` to keep loader.go from growing unbounded). Each new file has paired `_test.go` covering the 3 baseline cases (valid / missing / malformed) plus consumption-path tests for the runtime hot path REQs.
+
+Defaults strategy: every absent YAML returns a struct populated from `internal/config/defaults.go` helpers, mirroring the template values. This honors REQ-MIG003-004 (sensible defaults on absent file) and provides a single source of truth for the `CONFIG_STRUCT_YAML_MISMATCH` build-time guard (M3 work).
+
+The two CI guards live in `internal/config/audit_*_test.go` files and run on every `go test ./internal/config/...`, locking the contract that (a) every YAML in `.moai/config/sections/` has a loader OR is in an acknowledged exclusion list, and (b) every struct field has a YAML key and vice versa.
+
+## 3. Milestones (Priority-based, NO time estimates)
+
+[HARD] Priority labels only — no time estimates per agent-common-protocol.
+
+### M1 — RED Phase (Priority: P0 Critical, blocking)
+
+**Test scaffolding before any implementation code.**
+
+- Create fixture directories in `internal/config/testdata/`:
+  - `constitution-valid/`, `constitution-malformed/`
+  - `context-valid/`, `context-malformed/`
+  - `interview-valid/`, `interview-missing/`
+  - `design-valid/`, `design-pass-threshold-violation/`
+- Write `internal/config/loader_constitution_test.go`:
+  - `TestLoadConstitutionConfig_ValidParse` — assert all 8 sub-fields populated from `constitution-valid/constitution.yaml`.
+  - `TestLoadConstitutionConfig_MissingFile_ReturnsDefaults` — assert defaults returned, no error.
+  - `TestLoadConstitutionConfig_Malformed_ReturnsErrInvalidYAML` — assert `errors.Is(err, ErrInvalidYAML)`.
+  - `TestLoadConstitutionConfig_ForbiddenLibrariesExposed` — REQ-MIG003-009: assert non-empty list is readable.
+- Write `internal/config/loader_context_test.go`:
+  - `TestLoadContextConfig_ValidParse` — assert `token_budget.max_injection_tokens`, `token_budget.skip_if_usage_above`, `search.date_range_days` populated (REQ-MIG003-010).
+  - `TestLoadContextConfig_MissingFile_ReturnsDefaults`
+  - `TestLoadContextConfig_Malformed_ReturnsErrInvalidYAML`
+- Write `internal/config/loader_interview_test.go`:
+  - `TestLoadInterviewConfig_ValidParse` — assert `clarity_threshold=4`, `plan.max_rounds=5`, `skip_conditions` length=3 (REQ-MIG003-011).
+  - `TestLoadInterviewConfig_MissingFile_ReturnsDefaults`
+  - `TestLoadInterviewConfig_Malformed_ReturnsErrInvalidYAML`
+- Write `internal/config/loader_design_test.go`:
+  - `TestLoadDesignConfig_ValidParse` — assert `gan_loop.pass_threshold=0.75`, `gan_loop.max_iterations=5`, `sprint_contract.enabled=true` (REQ-MIG003-014).
+  - `TestLoadDesignConfig_MissingFile_ReturnsDefaults`
+  - `TestLoadDesignConfig_Malformed_ReturnsErrInvalidYAML`
+  - `TestLoadDesignConfig_PassThresholdFloorViolation` — REQ-MIG003-014 paired with HRN-001 floor: assert `errors.Is(err, ErrPassThresholdFloor)` when `pass_threshold < 0.60`.
+- Write `internal/config/types_test.go` extensions:
+  - `TestSunsetConfig_DORMANT_GodocMarker` — REQ-MIG003-006: assert godoc comment for `SunsetConfig` contains `DORMANT` literal (parse types.go AST or read file contents).
+  - `TestRootConfig_HasFourNewSectionFields` — assert `Config` struct exposes `Constitution`, `ContextSearch`, `Interview`, `Design` fields (AC-MIG003-01).
+- Write `internal/config/audit_loader_completeness_test.go`:
+  - `TestAuditLoaderCompleteness` — REQ-MIG003-013: cross-reference template YAML files vs registered loaders; fail on uncovered section names with `YAML_SECTION_NO_LOADER: <name>`.
+  - Maintain `acknowledgedUnloadedSections` allowlist for out-of-MIG-003-scope files (mx, gate, lsp, db, github-actions, observability, project, memo, system, security, git-strategy, workflow, sunset).
+- Write `internal/config/audit_struct_yaml_symmetry_test.go`:
+  - `TestStructYAMLSymmetry_Constitution` — REQ-MIG003-016: AST-parse `ConstitutionConfig` yaml tags, parse `constitution.yaml`, assert symmetric.
+  - Same for Context, Interview, Design.
+
+[HARD] All RED-phase tests MUST fail before any M2 implementation code is written. Run `go test ./internal/config/... -run "TestLoadConstitution|TestLoadContext|TestLoadInterview|TestLoadDesign|TestSunsetConfig_DORMANT|TestRootConfig_HasFour|TestAuditLoader|TestStructYAMLSymmetry"` and confirm all fail with expected messages.
+
+### M2 — GREEN Phase (Priority: P0 Critical)
+
+**Minimal implementation to pass M1 tests.**
+
+- Add 4 new structs to `internal/config/types.go` (adjacent to `HarnessConfig` at line 402; new lines ~540-550):
+  - `ConstitutionConfig` — fields: `ApprovedFrameworks []string`, `ApprovedLanguages []string`, `Architecture ConstitutionArchitecture`, `ForbiddenPatterns []string` (aliased as `ForbiddenLibraries` in godoc for REQ-MIG003-009), `NamingConventions ConstitutionNaming`, `Performance ConstitutionPerformance`, `Security ConstitutionSecurity`.
+  - `ContextConfig` — fields: `AutoDetect ContextAutoDetect`, `Enabled bool`, `MemoryIntegration ContextMemoryIntegration`, `Performance ContextPerformance`, `Search ContextSearch`, `TokenBudget ContextTokenBudget`.
+  - `InterviewConfig` — fields: `ClarityThreshold int`, `Enabled bool`, `Plan InterviewMode`, `Project InterviewMode`, `SkipConditions []string`.
+  - `DesignConfig` — fields: `Adaptation DesignAdaptation`, `BrandContext DesignBrandContext`, `ClaudeDesign DesignClaudeDesign`, `DefaultFramework string`, `DesignDocs DesignDocs`, `Enabled bool`, `Evaluator DesignEvaluator`, `Evolution DesignEvolution`, `Figma DesignFigma`, `GanLoop DesignGanLoop`, `Version string`.
+- Add `@MX:ANCHOR: [AUTO]` godoc for each struct documenting at least one runtime hot path (REQ-MIG003-005):
+  - `ConstitutionConfig` → consumed by SPEC-V3R2-EXT-004 framework optional hook for forbidden-library policy enforcement.
+  - `ContextConfig` → consumed by CLAUDE.md §16 Context Search Protocol token-budget gate.
+  - `InterviewConfig` → consumed by SPEC-V3R2-WF-003 discovery mode clarity-threshold + round limits.
+  - `DesignConfig` → consumed by GAN loop runtime sprint contract + adaptation iteration limits.
+- Add 4 wrapper types to `internal/config/types.go` (adjacent to existing wrappers, line ~610):
+  - `constitutionFileWrapper{Constitution ConstitutionConfig \`yaml:"constitution"\`}`
+  - `contextFileWrapper{ContextSearch ContextConfig \`yaml:"context_search"\`}`
+  - `interviewFileWrapper{Interview InterviewConfig \`yaml:"interview"\`}`
+  - `designFileWrapper{Design DesignConfig \`yaml:"design"\`}`
+- Extend root `Config` struct (types.go:15-33) with 4 new fields:
+  - `Constitution ConstitutionConfig \`yaml:"constitution"\``
+  - `ContextSearch ContextConfig \`yaml:"context_search"\``
+  - `Interview InterviewConfig \`yaml:"interview"\``
+  - `Design DesignConfig \`yaml:"design"\``
+- Create `internal/config/loader_constitution.go`:
+  - `func LoadConstitutionConfig(path string) (*ConstitutionConfig, error)` — reads file, unmarshals into wrapper, returns typed config. Returns `ErrConfigNotFound` on missing, `ErrInvalidYAML` on malformed.
+  - `func (l *Loader) loadConstitutionSection(dir string, cfg *Config)` — uses `loadYAMLFile` helper; on `(true, nil)` assign + flag `loadedSections["constitution"] = true`. Graceful on absent (REQ-MIG003-004).
+- Create `internal/config/loader_context.go`:
+  - `func LoadContextConfig(path string) (*ContextConfig, error)` — same pattern.
+  - `func (l *Loader) loadContextSection(dir string, cfg *Config)` — same pattern; `loadedSections["context_search"]`.
+- Create `internal/config/loader_interview.go`:
+  - `func LoadInterviewConfig(path string) (*InterviewConfig, error)` — same pattern.
+  - `func (l *Loader) loadInterviewSection(dir string, cfg *Config)` — same; `loadedSections["interview"]`.
+- Create `internal/config/loader_design.go`:
+  - `func LoadDesignConfig(path string) (*DesignConfig, error)` — same pattern + ADD pass-threshold floor validation: if `gan_loop.pass_threshold < 0.60` return `&ValidationError{Field: "gan_loop.pass_threshold", Wrapped: ErrPassThresholdFloor}` reusing HRN-001 sentinel (errors.go:79).
+  - `func (l *Loader) loadDesignSection(dir string, cfg *Config)` — same pattern; `loadedSections["design"]`.
+- Wire 4 new calls into `Loader.Load()` (`internal/config/loader.go:31-74`, after line 71 `loadResearchSection`):
+  ```
+  l.loadConstitutionSection(sectionsDir, cfg)
+  l.loadContextSection(sectionsDir, cfg)
+  l.loadInterviewSection(sectionsDir, cfg)
+  l.loadDesignSection(sectionsDir, cfg)
+  ```
+- Extend `internal/config/defaults.go` `NewDefaultConfig()` with 4 default helpers (`defaultConstitutionConfig`, `defaultContextConfig`, `defaultInterviewConfig`, `defaultDesignConfig`) returning struct populated from template values (mirrors `.moai/config/sections/*.yaml` content). Assign in `NewDefaultConfig()` body.
+- Update `SunsetConfig` godoc in `internal/config/types.go:309` to prepend `// @MX:NOTE: [AUTO] DORMANT — struct schema defined but no runtime hot path enforces sunset conditions. Activation deferred to a future SPEC. Do NOT add LoadSunsetConfig until activation SPEC is filed.` (REQ-MIG003-006).
+- Run M1 tests: `go test ./internal/config/...` — ALL 4 loader test files + symmetry tests + completeness audit MUST pass.
+
+[HARD] Drift-guard at M2 exit: `git diff --stat internal/config/` must show only the files enumerated above (no surprise edits). M2 exit criterion: 100% of M1 RED tests green.
+
+### M3 — GREEN Phase (CI Guards + Once-per-Session Notice) (Priority: P1 High)
+
+**Lock the contract via build-time guards.**
+
+- Verify `internal/config/audit_loader_completeness_test.go` (from M1) passes after M2 wiring. The `acknowledgedUnloadedSections` allowlist excludes out-of-scope files; the 4 new sections (constitution, context_search, interview, design) MUST be detected as loaded. Sunset.yaml stays in the allowlist (DORMANT — never loaded).
+- Verify `internal/config/audit_struct_yaml_symmetry_test.go` passes for all 4 new structs.
+- Create `internal/config/sunset_notice.go`:
+  - Package-level `var sunsetNoticeOnce sync.Once`.
+  - `func emitSunsetDormantNotice(sectionsDir string)` — on first call: stat `<sectionsDir>/sunset.yaml`; if exists, `slog.Info("SUNSET_CONFIG_DORMANT_NOTICE", "spec", "SPEC-V3R2-MIG-003 REQ-018", "yaml_path", path)`. Wrapped in `sync.Once.Do`.
+- Add `emitSunsetDormantNotice(sectionsDir)` call inside `Loader.Load()` between `loadDesignSection` and the `return` (loader.go:73) so it fires once per process lifetime when `Loader.Load()` is first invoked with a sections dir containing sunset.yaml.
+- Write `internal/config/sunset_notice_test.go`:
+  - `TestSunsetNotice_FiresOnce` — call `Loader.Load()` twice; capture `slog` handler; assert exactly 1 `SUNSET_CONFIG_DORMANT_NOTICE` record (REQ-MIG003-018, AC-MIG003-15).
+  - `TestSunsetNotice_AbsentFileNoNotice` — fixture without sunset.yaml; assert zero notice records.
+  - Use a custom `slog.Logger` with a buffered handler for capture.
+- Run `make build` — REQ-MIG003-016 audit symmetry test must pass during build.
+
+[HARD] M3 exit: `go test ./internal/config/...` 100% green; `make build` 100% green.
+
+### M4 — REFACTOR Phase (verification + docs) (Priority: P2 Medium)
+
+**Documentation + verification gates.**
+
+- Update `.claude/rules/moai/core/settings-management.md` to document:
+  - 4 new loaders (`LoadConstitutionConfig`, `LoadContextConfig`, `LoadInterviewConfig`, `LoadDesignConfig`).
+  - `SunsetConfig` DORMANT status + REQ-MIG003-006 reference.
+  - 2 CI guards (`YAML_SECTION_NO_LOADER`, `CONFIG_STRUCT_YAML_MISMATCH`) and how to add a new section in the future (5-step procedure).
+  - `harness.yaml` dedicated entry (`LoadHarnessConfig` is NOT in `Loader.Load()` chain by design — HRN-001 enforces stricter semantics) — research.md §14 Q1 decision.
+- Refactor pass on `internal/config/loader.go`:
+  - Verify no inline literal values overriding YAML defaults (REQ-MIG003-017). Grep `loader_*.go` for numeric/string literals matching YAML field values; any match is `LOADER_HARDCODE_VIOLATION` (covered by code review).
+  - Confirm all new loaders use `loadYAMLFile` helper (no copy-paste of read-and-unmarshal logic).
+- Add `@MX:NOTE` (and `@MX:ANCHOR` where `fan_in >= 3`) tags per `.claude/rules/moai/workflow/mx-tag-protocol.md`:
+  - `loadYAMLFile` helper now has fan_in = 9 (was 9, no change) — already tagged.
+  - Each new `LoadXxxConfig` public function: add `@MX:NOTE` documenting hot-path consumer.
+- Run full test suite: `go test ./...` — confirm zero regressions outside internal/config.
+- Run `golangci-lint run` — confirm zero new findings.
+- Verify acceptance.md AC-MIG003-01 through AC-MIG003-15 (some are verify-only for HRN-001 deliverables): execute the verification commands listed in acceptance.md and check all pass.
+- Plan-auditor PASS verification: confirm `progress.md` records `plan_status: audit-ready` and `plan_complete_at: 2026-05-18`.
+
+[HARD] M4 exit: 100% AC pass, 100% test green, zero lint findings, settings-management.md updated.
+
+## 4. REQ ↔ Task Matrix
+
+| REQ | Tasks | Verified by AC |
+|---|---|---|
+| REQ-MIG003-001 (5 structs) | T-MIG003-06..09 (4 new structs in M2; HarnessConfig from HRN-001 unchanged) | AC-MIG003-01 |
+| REQ-MIG003-002 (5 loaders) | T-MIG003-10..13 (4 new loaders; LoadHarnessConfig from HRN-001) | AC-MIG003-02 (verify-only for harness) |
+| REQ-MIG003-003 (typed return + aggregated error) | T-MIG003-10..13 | AC-MIG003-02..04 |
+| REQ-MIG003-004 (sensible defaults on absent file) | T-MIG003-14 (defaults.go extensions) | AC-MIG003-03 |
+| REQ-MIG003-005 (godoc hot path) | T-MIG003-06..09 (godoc per struct) | AC-MIG003-05 |
+| REQ-MIG003-006 (SunsetConfig DORMANT marker) | T-MIG003-15 | AC-MIG003-06 |
+| REQ-MIG003-007 (unit tests valid/missing/malformed) | T-MIG003-01..04 (M1 RED tests) | AC-MIG003-07 |
+| REQ-MIG003-008 (HARNESS_CONFIG_PARSE_ERROR) | T-MIG003-05 (verify HRN-001 ErrInvalidYAML satisfies) | AC-MIG003-04 (verify-only) |
+| REQ-MIG003-009 (ConstitutionConfig.ForbiddenLibraries exposed) | T-MIG003-06, T-MIG003-10 | AC-MIG003-08 |
+| REQ-MIG003-010 (ContextConfig token_budget + date_range_days) | T-MIG003-07, T-MIG003-11 | AC-MIG003-09 |
+| REQ-MIG003-011 (InterviewConfig clarity_threshold + max_rounds) | T-MIG003-08, T-MIG003-12 | AC-MIG003-10 |
+| REQ-MIG003-012 (default level=standard) | T-MIG003-14 (verify HRN-001 harness defaults handled via dedicated entry) | AC-MIG003-03 (verify-only for harness) |
+| REQ-MIG003-013 (YAML_SECTION_NO_LOADER CI guard) | T-MIG003-16 (audit_loader_completeness_test.go) | AC-MIG003-12 |
+| REQ-MIG003-014 (DesignConfig sprint_contract + adaptation) | T-MIG003-09, T-MIG003-13 | AC-MIG003-11 |
+| REQ-MIG003-015 (sunset activation future-proofing) | T-MIG003-15 (godoc note) | AC-MIG003-06 (forward-looking) |
+| REQ-MIG003-016 (CONFIG_STRUCT_YAML_MISMATCH `make build`) | T-MIG003-17 (audit_struct_yaml_symmetry_test.go) | AC-MIG003-14 |
+| REQ-MIG003-017 (LOADER_HARDCODE_VIOLATION) | T-MIG003-19 (code review checklist + grep audit) | AC-MIG003-13 |
+| REQ-MIG003-018 (SUNSET_CONFIG_DORMANT_NOTICE once) | T-MIG003-18 (sunset_notice.go + test) | AC-MIG003-15 |
+
+## 5. File Map
+
+### 5.1 Files CREATED (12)
+
+| Path | Purpose | Approx LOC |
+|---|---|---|
+| internal/config/loader_constitution.go | ConstitutionConfig loader + section helper | ~80 |
+| internal/config/loader_context.go | ContextConfig loader + section helper | ~80 |
+| internal/config/loader_interview.go | InterviewConfig loader + section helper | ~70 |
+| internal/config/loader_design.go | DesignConfig loader + section helper + pass-threshold validation | ~120 |
+| internal/config/sunset_notice.go | Once-per-session DORMANT notice (REQ-018) | ~40 |
+| internal/config/loader_constitution_test.go | 4 tests (valid/missing/malformed/forbidden-list-exposed) | ~150 |
+| internal/config/loader_context_test.go | 3 tests | ~120 |
+| internal/config/loader_interview_test.go | 3 tests | ~120 |
+| internal/config/loader_design_test.go | 4 tests (incl. pass-threshold violation) | ~180 |
+| internal/config/sunset_notice_test.go | 2 tests (fires-once / absent-file-no-notice) | ~80 |
+| internal/config/audit_loader_completeness_test.go | CI guard YAML_SECTION_NO_LOADER (REQ-013) | ~120 |
+| internal/config/audit_struct_yaml_symmetry_test.go | CI guard CONFIG_STRUCT_YAML_MISMATCH (REQ-016) | ~180 |
+| internal/config/testdata/{constitution,context,interview,design}-{valid,malformed/missing}/*.yaml | Test fixtures | 10 yaml files |
+
+### 5.2 Files EDITED (4)
+
+| Path | Change | LOC delta |
+|---|---|---|
+| internal/config/types.go | 4 new structs + 4 wrapper types + 4 root Config fields + SunsetConfig DORMANT godoc | +200 / -2 |
+| internal/config/loader.go | Wire 4 new loadXxxSection calls + emitSunsetDormantNotice into Loader.Load() | +6 |
+| internal/config/defaults.go | 4 new default helpers + wiring into NewDefaultConfig() | +100 |
+| .claude/rules/moai/core/settings-management.md | Document 4 new loaders + DORMANT sunset + CI guards | +60 |
+
+### 5.3 Files NOT MODIFIED (deliberately)
+
+| Path | Reason |
+|---|---|
+| internal/template/templates/.moai/config/sections/*.yaml | Templates are READ, not modified (spec.md §1.2) |
+| internal/runtime/config.go | LoadRuntime is separate package, runtime.yaml unaffected |
+| internal/cli/migrate_agency.go | Existing design.yaml consumer; runtime loader coexists |
+| internal/config/errors.go | Reuse existing ErrInvalidYAML / ErrConfigNotFound / ErrPassThresholdFloor; no new sentinels |
+| internal/config/loader.go LoadHarnessConfig | HRN-001 deliverable; verify-only |
+
+## 6. Risks & Mitigations
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| Wrapper YAML-key collision (constitution.yaml ↔ quality.yaml both use `constitution:` top-level key) | Cross-loader pollution | Disambiguate by **filename** in `loadYAMLFile(dir, "<file>.yaml", wrapper)` — each loader targets a distinct file. Test: load both and assert no cross-pollution (`Loader.Load()` integration test). |
+| `context.yaml` top-level key is `context_search:` not `context:` | Silent unmarshal-into-empty if wrapper uses wrong tag | wrapper field tag `yaml:"context_search"` exactly; covered by `TestLoadContextConfig_ValidParse` (M1) |
+| design.yaml runtime loader vs migrate_agency.go double-read | None — both flows orthogonal | Verify in `TestLoadDesignConfig_ValidParse` that loader is read-only |
+| pass_threshold floor in design.yaml not currently enforced | Spec drift if user sets <0.60 | Add validator in `LoadDesignConfig` reusing `ErrPassThresholdFloor` sentinel (HRN-001) |
+| Plan-auditor expects 12-field canonical frontmatter | plan-audit FAIL | spec.md uses 14-field snake_case schema; this is the canonical SDD format used by SPEC-V3R2-MIG-001..003 series. SPEC-V3R2 series predates the unified 12-field schema (per `.claude/rules/moai/development/spec-frontmatter-schema.md` Version History 2026-05-16). Plan-auditor expects 12-field schema; spec.md frontmatter normalization is out-of-scope for MIG-003 itself (would be SPECLINT-DEBT-002 cleanup territory). Flag via `lint.skip: [FrontmatterInvalid]` if blocking. |
+| Test fixture maintenance overhead | High | Use file content identical to `.moai/config/sections/*.yaml` (single source of truth) — fixtures are byte-for-byte mirrors of shipping templates. |
+| 4 new loaders × 4 wrappers × 4 default helpers = 16 components to review | Review burden | Per-file separation (`loader_<section>.go`) keeps PR diff readable; each file is independently reviewable. |
+| Schema drift not detected at runtime for new sections (only at build time via symmetry audit) | Acceptable: build-time guard catches drift; runtime drift detection deferred | Document in settings-management.md that new sections do NOT have `MOAI_CONFIG_STRICT` runtime mode (yet); future SPEC can add. |
+
+## 7. Open Questions (to resolve mid-plan)
+
+OQ1. **Should `harness.yaml` be additionally wired into `Loader.Load()`?**
+- Decision: **NO**. Keep HRN-001's dedicated `LoadHarnessConfig` entry. Document in settings-management.md. Audit completeness test treats `harness.yaml` as "intentionally outside Loader.Load()" via the acknowledgedDedicatedLoaders allowlist (separate from acknowledgedUnloadedSections).
+
+OQ2. **Should `LoadDesignConfig` enforce `gan_loop.pass_threshold >= 0.60`?**
+- Decision: **YES**. Symmetric with `LoadHarnessConfig`'s pass-threshold floor. Reuse `ErrPassThresholdFloor` sentinel (HRN-001 errors.go:79).
+
+OQ3. **Should `LoadDesignConfig` enforce `evaluator.memory_scope == "per_iteration"`?**
+- Decision: **NO**. design.yaml's memory_scope mirrors harness.yaml's FROZEN field structurally, but the FROZEN enforcement lives in `LoadHarnessConfig` (per HRN-002 substrate decision). Design loader treats `memory_scope` as a free string. If future SPEC ties them, refactor then.
+
+OQ4. **`spec.md` REQ-MIG003-014 mentions `adaptation.phase_weights` but YAML has `adaptation.iteration_limits`.**
+- Decision: implement `IterationLimits` per actual YAML schema. Add struct godoc clarifying that `phase_weights` in REQ-MIG003-014 is a conceptual term subsuming `iteration_limits`. Update `acceptance.md` AC-MIG003-11 wording accordingly.
+
+OQ5. **Should `audit_loader_completeness_test.go` parse template YAML files or project files?**
+- Decision: **template files** (`internal/template/templates/.moai/config/sections/`). The shipping template is the authoritative section list; user-project YAML can differ (deletions, overrides). Test pins behavior to template surface.
+
+OQ6. **What is the `acknowledgedUnloadedSections` allowlist content?**
+- Decision: maintained as a sorted `[]string` literal in `audit_loader_completeness_test.go`. Initial entries: `["db", "gate", "github-actions", "git-strategy", "lsp", "memo", "mx", "observability", "project", "security", "sunset", "system", "workflow"]`. Each entry has an inline `// out-of-scope: <reason>` comment referencing the deferring SPEC (where known).
+
+## 8. Test Plan
+
+### 8.1 Test execution sequence
+
+```
+# M1 RED phase verification (must FAIL before M2 implementation)
+go test ./internal/config/... -run "TestLoadConstitution|TestLoadContext|TestLoadInterview|TestLoadDesign|TestSunsetConfig_DORMANT|TestRootConfig|TestAuditLoaderCompleteness|TestStructYAMLSymmetry|TestSunsetNotice"
+# Expected: all FAIL with not-found / not-defined / undefined-field errors
+
+# M2 GREEN phase verification (all PASS)
+go test ./internal/config/... -run "TestLoadConstitution|TestLoadContext|TestLoadInterview|TestLoadDesign|TestSunsetConfig_DORMANT|TestRootConfig"
+# Expected: all PASS
+
+# M3 GREEN phase verification (CI guards PASS)
+go test ./internal/config/... -run "TestAuditLoaderCompleteness|TestStructYAMLSymmetry|TestSunsetNotice"
+# Expected: all PASS
+
+# M4 REFACTOR verification (full suite, no regressions)
+go test ./...
+golangci-lint run ./...
+make build
+# Expected: 100% green, 0 lint findings, build success
+```
+
+### 8.2 Coverage target
+
+- Per-package: 85% (existing project bar)
+- New files specifically: target 90%+ as they are small and focused
+- Critical paths: 100% — defaults handling, malformed parse, pass-threshold floor violation
+
+## 9. Dependencies
+
+### 9.1 Blocked by (must merge before MIG-003 run-phase)
+
+- SPEC-V3R2-EXT-004 (migration framework) — spec.md §9.1. Status: independent; this plan does NOT block on EXT-004 for the LOADER work itself; it blocks for the SPEC-V3R2-MIG-001 migrator that invokes loader completeness step.
+
+### 9.2 Blocks (MIG-003 unblocks these once merged)
+
+- SPEC-V3R2-MIG-001 (v2→v3 migrator)
+- SPEC-V3R2-WF-003 (multi-mode router consumes HarnessConfig + InterviewConfig)
+
+### 9.3 Related (informational)
+
+- SPEC-V3R2-HRN-001 (harness.yaml loader) — merged main; reconciliation in §1
+- SPEC-V3R2-MIG-002 (hook registration cleanup) — merged main; established the audit_test.go style pattern
+- SPEC-V3R2-EXT-001 (memory subsystem) — InterviewConfig.skip_conditions relates to memory staleness; no API contract between SPECs
+
+## 10. Plan-Audit Readiness Checklist
+
+- [x] All 18 REQs covered by tasks (§4 matrix)
+- [x] All 15 ACs verifiable by automation (acceptance.md ≥10 binary)
+- [x] HRN-001 reconciliation documented (§1, research.md §2)
+- [x] File map exhaustive (§5)
+- [x] Risks itemized with mitigations (§6)
+- [x] OQs resolved with decisions (§7)
+- [x] Test plan with sequence + coverage targets (§8)
+- [x] No time estimates (priority labels only)
+- [x] Drift-guard at each milestone exit
+- [x] research.md anchor count ≥25 (actual: 38)
+- [x] acceptance.md AC count ≥10 (actual: 15)
+
+## 11. Plan Status
+
+`plan_status: audit-ready` — plan ready for plan-auditor PASS gate before /moai run.
+
+End of plan.md

--- a/.moai/specs/SPEC-V3R2-MIG-003/research.md
+++ b/.moai/specs/SPEC-V3R2-MIG-003/research.md
@@ -1,0 +1,460 @@
+# SPEC-V3R2-MIG-003 — Research / Codebase Analysis (research.md)
+
+> Companion to `spec.md` (REQ-MIG003-001 ~ REQ-MIG003-018).
+> Companion to `plan.md` (M1-M4 milestones, post-HRN-001 scope).
+> Companion to `acceptance.md` (binary AC) and `tasks.md` (T-MIG003-NN).
+
+This document is the codebase analysis artifact required by `.claude/rules/moai/workflow/spec-workflow.md` Plan Phase. All anchors are concrete `file:line` references verified at HEAD `plan/SPEC-V3R2-MIG-003` ≈ `195b469d8` (post-MIG-002 sync merge).
+
+---
+
+## 1. Section-by-Section Loader Inventory (current state, 2026-05-18)
+
+Cross-reference of `.moai/config/sections/*.yaml` against Go-side loaders. Source: `ls .moai/config/sections/`, `grep ^func .* internal/config/loader.go`, `grep -rE 'loadYAMLFile|yaml.Unmarshal' internal/` (filtered to non-test).
+
+### 1.1 LOADED via `Loader.Load()` (internal/config/loader.go)
+
+The aggregating `Loader.Load()` at `internal/config/loader.go:31-74` invokes ten section-loaders in fixed order. Each loader follows the `loadXxxSection(dir, cfg) → wrapper → loadYAMLFile() → loadedSections["xxx"]=true` pattern.
+
+| Section | Loader func | line | Wrapper type | Target field |
+|---|---|---|---|---|
+| `user.yaml` | `loadUserSection` | 88-99 | `userFileWrapper` (types.go:562-564) | `cfg.User` |
+| `language.yaml` | `loadLanguageSection` | 102-113 | `languageFileWrapper` (types.go:566-568) | `cfg.Language` |
+| `quality.yaml` | `loadQualitySection` | 118-129 | `qualityFileWrapper` (types.go:572-574, "constitution" YAML key for Python BC) | `cfg.Quality` |
+| `git-convention.yaml` | `loadGitConventionSection` | 132-143 | `gitConventionFileWrapper` (types.go:577-579) | `cfg.GitConvention` |
+| `llm.yaml` | `loadLLMSection` | 146-157 | `llmFileWrapper` (types.go:582-584) | `cfg.LLM` |
+| `state.yaml` | `loadStateSection` | 160-171 | `stateFileWrapper` (types.go:587-589) | `cfg.State` |
+| `statusline.yaml` | `loadStatuslineSection` | 174-185 | `statuslineFileWrapper` (types.go:592-594) | `cfg.Statusline` |
+| `ralph.yaml` | `loadRalphSection` | 190-207 | `ralphFileWrapper` (types.go:604-609, inline + StaleSeconds → Session) | `cfg.Ralph` + `cfg.Session.StaleSeconds` |
+| `research.yaml` | `loadResearchSection` | 210-221 | `researchFileWrapper` (types.go:597-599) | `cfg.Research` |
+
+### 1.2 LOADED via dedicated entry-point (NOT through `Loader.Load()`)
+
+| Section | Loader func | File:line | Consumer |
+|---|---|---|---|
+| `harness.yaml` | `LoadHarnessConfig(path)` | internal/config/loader.go:256-311 | HarnessRouter, CLI validate, ConfigManager.Reload — **delivered by SPEC-V3R2-HRN-001 (2026-05-18, merged main)** |
+| `runtime.yaml` | `LoadRuntime(path)` | internal/runtime/config.go:81-114 | Runtime context-window / circuit-breaker — separate package, NOT in `internal/config` |
+
+### 1.3 NOT LOADED (template-only, gap targets for MIG-003)
+
+| Section | YAML present at | Go struct? | Loader? | Hot path? |
+|---|---|---|---|---|
+| `constitution.yaml` | sections/constitution.yaml:1-32 | NO | NO | Template-only; CLAUDE.md §forbidden libraries pattern |
+| `context.yaml` | sections/context.yaml:1-20 | NO | NO | Template-only; CLAUDE.md §16 Context Search Protocol |
+| `interview.yaml` | sections/interview.yaml:1-14 | NO | NO | Template-only; SPEC-V3R2-WF-003 discovery |
+| `design.yaml` | sections/design.yaml:1-60 | NO | NO (migrate-only) | Used by `internal/cli/migrate_agency.go` Phase 4 only — see §3.4 below |
+| `sunset.yaml` | sections/sunset.yaml:1-19 | YES (types.go:311-325) | NO | DORMANT — struct defined but no `LoadSunsetConfig`, no runtime consumer |
+
+### 1.4 NOT IN SCOPE (declared out-of-scope by spec.md §1.2 / §2.2)
+
+The following sections are explicitly excluded from MIG-003 per spec.md §1.2 Non-Goals and §2.2 Out of Scope. Listed for completeness:
+
+- `mx.yaml` — ad-hoc parsing retained; struct neuverbalisation deferred to separate SPEC (R6 §5.3 reference)
+- `workflow.yaml` — only `role_profiles` is currently consumed (types.go:148-203 WorkflowConfig partial); full unification deferred to separate SPEC per spec.md §1.2 bullet 7
+- `lsp.yaml`, `gate.yaml`, `db.yaml`, `github-actions.yaml`, `observability.yaml`, `project.yaml`, `memo.yaml`, `system.yaml`, `security.yaml`, `git-strategy.yaml` — not part of MIG-003 audit scope; tracked by separate SPECs
+
+---
+
+## 2. HRN-001 Reconciliation (harness.yaml is already loaded)
+
+SPEC-V3R2-HRN-001 shipped to main on 2026-05-18 (commit ≤ `195b469d8`). It delivered the full harness.yaml loader stack that MIG-003 spec.md anticipated:
+
+### 2.1 Delivered artifacts (HRN-001)
+
+- **`internal/config/types.go:398-427`** — `HarnessConfig` struct with 9 fields: `DefaultProfile`, `ModeDefaults`, `AutoDetection`, `Escalation`, `EffortMapping`, `Levels`, `ModelUpgradeReview`, `PlanAuditGlobal`, `Evaluator`. `@MX:ANCHOR` REQ-HRN-001-001.
+- **`internal/config/types.go:429-538`** — Sub-config types: `AutoDetectionConfig`, `AutoDetectionRule`, `EscalationConfig`, `LevelConfig`, `PlanAuditConfig`, `ModelUpgradeReviewConfig`, `ReviewChecklistItem`, `ModelUpgradeTrigger`, `ModelUpgradeOutput`, `PlanAuditGlobalConfig`, `EvaluatorConfig`.
+- **`internal/config/loader.go:256-311`** — `LoadHarnessConfig(path) (*HarnessConfig, error)` with 4-stage validation: (1) struct unmarshal, (2) schema drift detection, (3) FROZEN `memory_scope == "per_iteration"` check, (4) FROZEN level enum check.
+- **`internal/config/loader.go:223-244`** — `validHarnessLevels`, `knownHarnessTopLevelKeys` whitelists for drift gating.
+- **`internal/config/loader.go:318-358`** — `detectSchemaDrift(data, path)` honors `MOAI_CONFIG_STRICT=1` env (returns `ErrSchemaDrift`) vs warn-only.
+- **`internal/config/errors.go:69-90`** — Sentinels: `ErrUnknownLevel`, `ErrPassThresholdFloor`, `ErrSchemaDrift`, `ErrEscalationCapExceeded` (REQ-HRN-001-013/017/018/019).
+- **`internal/config/loader_harness_extended_test.go:17-200`** — 7 test cases: ValidParse, InvalidThreshold, UnknownLevel, SchemaDrift_Warn, SchemaDrift_StrictMode, MissingFile, ValidatesLevelEnum.
+- **`internal/config/types.go:555-557`** — `harnessFileWrapper{Harness HarnessConfig yaml:"harness"}`.
+
+### 2.2 What this means for MIG-003
+
+| MIG-003 REQ | Status after HRN-001 | Action |
+|---|---|---|
+| REQ-MIG003-001 (5 structs) | 1 of 5 (HarnessConfig) already done; 4 remain (Constitution, Context, Interview, Design) | Implement 4 new structs |
+| REQ-MIG003-002 (5 loaders) | 1 of 5 (`LoadHarnessConfig`) already done; 4 remain | Implement 4 new loaders |
+| REQ-MIG003-003 (typed return + aggregated error) | Pattern established by HRN-001 (`ValidationError` wrapping) | Reuse pattern |
+| REQ-MIG003-004 (defaults on absent file) | HRN-001 returns `ErrConfigNotFound`; MIG-003 needs **graceful default** semantics (different) | Use `loadYAMLFile`'s 2-return pattern; absent → defaults |
+| REQ-MIG003-008 (`HARNESS_CONFIG_PARSE_ERROR`) | Existing: HRN-001 returns `ErrInvalidYAML` (not the exact sentinel name) | **Reconcile**: name harmonized to `ErrInvalidYAML` (which subsumes `_PARSE_ERROR`); AC text updated |
+| REQ-MIG003-012 (default level=`standard`) | Partially: HRN-001 returns error on missing file. MIG-003 may add a `DefaultHarnessConfig()` helper for graceful path in `Loader.Load()` flow | Add `DefaultHarnessConfig()` and call from new `loadHarnessSection` wrapper |
+| REQ-MIG003-013 (`YAML_SECTION_NO_LOADER` CI guard) | Not implemented by HRN-001 | NEW work in MIG-003 |
+| REQ-MIG003-016 (`CONFIG_STRUCT_YAML_MISMATCH`) | Not implemented by HRN-001 | NEW work in MIG-003 |
+
+**Net new scope post-HRN-001**: 4 unloaded sections (constitution, context, interview, design) + sunset DORMANT formalization + 2 CI guards. The harness work is **verify-only** in MIG-003.
+
+---
+
+## 3. YAML Schema Per Section (existing template content)
+
+### 3.1 `constitution.yaml` (32 lines)
+
+- **sections/constitution.yaml:1-32** — top-level key `constitution:`. Nested keys: `approved_frameworks: []` (line 2-4), `approved_languages: []` (5-6), `architecture.forbidden_dependencies: []` (7-9), `architecture.patterns: []` (10-13), `forbidden_patterns: []` (14-18), `naming_conventions{exported, files, packages}` (19-22), `performance{max_memory_mb, max_response_time_ms}` (23-25), `security.forbidden_practices: []` (26-29), `security.required_checks: []` (30-31).
+- Hot path target: `ConstitutionConfig.ForbiddenLibraries` (alias of `forbidden_patterns` per spec.md REQ-MIG003-009) for runtime policy enforcement; SPEC-V3R2-EXT-004 hook consumes the list.
+
+### 3.2 `context.yaml` (20 lines)
+
+- **sections/context.yaml:1-19** — top-level key `context_search:` (note: NOT `context:`). Nested keys: `auto_detect.enabled` (2-3), `enabled` (4), `memory_integration{enabled, include_in_context, priority_over_search}` (5-8), `performance{cache_ttl_seconds, timeout_seconds}` (9-11), `search{date_range_days, max_results, max_tokens_per_result, project_scope_only}` (12-16), `token_budget{max_injection_tokens, skip_if_usage_above}` (17-19).
+- Hot path target: CLAUDE.md §16 Context Search Protocol — `token_budget.max_injection_tokens` (5000) and `token_budget.skip_if_usage_above` (150000); also `search.date_range_days` (30) for staleness window.
+- **Naming note**: spec.md uses `staleness_window_days` but YAML uses `search.date_range_days` — research will align field name to YAML (`DateRangeDays`) and document the alias in struct godoc.
+
+### 3.3 `interview.yaml` (14 lines)
+
+- **sections/interview.yaml:1-13** — top-level key `interview:`. Nested keys: `clarity_threshold` (2 — integer 4, NOT max_rounds — clarification of spec.md REQ-MIG003-011), `enabled` (3), `plan{max_rounds, questions_per_round}` (4-6), `project{max_rounds, questions_per_round}` (7-9), `skip_conditions: []` (10-13: `resume_spec_id_present`, `skip_interview_flag`, `technical_keywords_gte_5`).
+- Hot path target: SPEC-V3R2-WF-003 discovery mode — `interview.plan.max_rounds` (5), `interview.plan.questions_per_round` (3), `interview.clarity_threshold` (4), `interview.skip_conditions` list.
+
+### 3.4 `design.yaml` (60 lines)
+
+- **sections/design.yaml:1-59** — top-level key `design:`. Nested keys: `adaptation{confidence_threshold, enabled, iteration_limits{builder, copywriter, designer}, min_projects_for_adaptation}` (2-9), `brand_context{dir, interview_on_first_run}` (10-12), `claude_design{enabled, fallback_path, supported_bundle_versions[]}` (13-17), `default_framework` (18), `design_docs{auto_load_on_design_command, dir, priority[], token_budget}` (19-27), `enabled` (28), `evaluator.memory_scope` (29-30 — note this is `per_iteration`, mirroring HarnessConfig FROZEN constraint), `evolution{archive_after_evolve, auto_evolve_threshold, cooldown_hours, graduation_criteria{...}, max_active_learnings, max_evolution_rate_per_week, require_approval}` (31-42), `figma.enabled` (43-44), `gan_loop{escalation_after, improvement_threshold, max_iterations, pass_threshold, sprint_contract{...}, strict_mode}` (45-58), `version` (59).
+- Current consumer: **only** `internal/cli/migrate_agency.go` Phase 4 (lines containing `design.yaml` → 5 occurrences; reads-and-renders during `.agency/` migration). No runtime consumer outside migrate flow.
+- Hot path target post-MIG-003: GAN loop runtime — `gan_loop.pass_threshold` (FROZEN floor 0.60 per design constitution §11), `gan_loop.sprint_contract.enabled`, `adaptation.phase_weights` (per spec.md REQ-MIG003-014; though current YAML uses `iteration_limits` per language naming).
+
+### 3.5 `sunset.yaml` (19 lines, dormant)
+
+- **sections/sunset.yaml:1-18** — top-level key `sunset:`. Nested keys: `conditions: []` (2-17) with three entries `{action, description, gate, metric, threshold}` (gates: vet@50, lint@30, test@20), `enabled: true` (18).
+- Existing Go struct: **`internal/config/types.go:309-325`** — `SunsetConfig{Enabled bool, Conditions []SunsetCondition}` + `SunsetCondition{Gate, Metric, Threshold, Action, Description}`.
+- **Gap**: struct exists but no `LoadSunsetConfig()` and no `cfg.Sunset` field on root `Config`. No hot path enforces sunset conditions — they are template-only.
+
+---
+
+## 4. Existing Loader Patterns (HRN-001 + Loader.Load reference)
+
+### 4.1 Wrapper pattern (types.go)
+
+Each loaded section has a `xxxFileWrapper` struct wrapping the target Config with the YAML top-level key as the yaml tag.
+
+- **types.go:555-557** — `harnessFileWrapper{Harness HarnessConfig \`yaml:"harness"\`}`
+- **types.go:562-564** — `userFileWrapper{User models.UserConfig \`yaml:"user"\`}`
+- **types.go:572-574** — `qualityFileWrapper{Constitution models.QualityConfig \`yaml:"constitution"\`}` (BC: YAML key differs from struct semantics)
+- **types.go:604-609** — `ralphFileWrapper` (composed: inline + extra field promoted to different Config field)
+
+MIG-003 will add four such wrappers:
+- `constitutionFileWrapper{Constitution ConstitutionConfig \`yaml:"constitution"\`}` — collision with `qualityFileWrapper.Constitution` (BC alias for `quality` field). Section file IS `.moai/config/sections/constitution.yaml`, distinct from `quality.yaml`. The YAML top-level key in both files is the literal word `constitution:` — disambiguation requires loading by **filename**, not by top-level key alone. The two wrappers have different Go types so unmarshalling is safe.
+- `contextFileWrapper{ContextSearch ContextConfig \`yaml:"context_search"\`}` — note YAML key is `context_search`, not `context`.
+- `interviewFileWrapper{Interview InterviewConfig \`yaml:"interview"\`}`
+- `designFileWrapper{Design DesignConfig \`yaml:"design"\`}`
+
+### 4.2 Loader function pattern (loader.go)
+
+Each `loadXxxSection(dir, cfg)`:
+1. Initialize wrapper with current default config field
+2. Call `loadYAMLFile(dir, "xxx.yaml", wrapper)` — returns `(loaded bool, err error)`
+3. On `err != nil`: `slog.Warn(...)` and `return` (graceful degradation)
+4. On `loaded == true`: assign wrapper field back to `cfg.Xxx` and set `l.loadedSections["xxx"] = true`
+
+Anchor: **internal/config/loader.go:88-99 (`loadUserSection`)** — canonical pattern. MIG-003 will replicate 4 times.
+
+### 4.3 `loadYAMLFile` helper (loader.go:363-378)
+
+Returns three-state semantics:
+- `(true, nil)` — file exists and parsed cleanly → caller applies the wrapper
+- `(false, nil)` — file does not exist → caller uses defaults (no warning) — **this is the REQ-MIG003-004 sensible-defaults path**
+- `(false, err)` — file exists but malformed → caller logs warning (does not panic)
+
+MIG-003 reuses this helper without modification.
+
+### 4.4 NewDefaultConfig anchor (defaults.go)
+
+- **internal/config/defaults.go** (10949 bytes total) — `NewDefaultConfig()` returns `*Config` with all field defaults pre-populated. MIG-003 will extend this function with `cfg.Constitution = defaultConstitutionConfig()`, `cfg.ContextSearch = defaultContextConfig()`, `cfg.Interview = defaultInterviewConfig()`, `cfg.Design = defaultDesignConfig()`. Each default helper returns a struct initialized from the values shipped in `internal/template/templates/.moai/config/sections/*.yaml` (consistency with template defaults — REQ-MIG003-004).
+
+### 4.5 LoadedSections() map (loader.go:78-85)
+
+Public accessor `Loader.LoadedSections() map[string]bool` returns a copy of which sections were loaded successfully. MIG-003 will add 4 new keys: `constitution`, `context_search`, `interview`, `design`. This is the surface that AC-MIG003-12 (CI guard) inspects.
+
+---
+
+## 5. Defaults Strategy (REQ-MIG003-004 enforcement)
+
+Spec.md REQ-MIG003-004 mandates **sensible defaults when YAML file is absent**. Spec.md REQ-MIG003-012 hardcodes `level: standard` as default for harness. For the 4 new loaders MIG-003 introduces:
+
+| Section | Default source | Default values (from template) |
+|---|---|---|
+| Constitution | `internal/template/templates/.moai/config/sections/constitution.yaml` (same content as project's `.moai/config/sections/constitution.yaml:1-32`) | `approved_languages: ["go"]`, `forbidden_patterns: ["global mutable state", ...]`, etc. |
+| Context | template constitution.yaml | `token_budget.max_injection_tokens: 5000`, `skip_if_usage_above: 150000`, `search.date_range_days: 30`, etc. |
+| Interview | template interview.yaml | `clarity_threshold: 4`, `enabled: true`, `plan.max_rounds: 5`, etc. |
+| Design | template design.yaml | `gan_loop.pass_threshold: 0.75` (note: FROZEN floor 0.60), `gan_loop.max_iterations: 5`, etc. |
+
+Defaults are encoded as Go literals in `internal/config/defaults.go` (REQ-MIG003-017 forbids hardcoded values overriding YAML, but defaults applied **when YAML is absent** are explicitly permitted by REQ-MIG003-004 — these are two distinct cases).
+
+---
+
+## 6. CI Guard Surface (REQ-MIG003-013 / REQ-MIG003-016)
+
+### 6.1 `YAML_SECTION_NO_LOADER` (REQ-MIG003-013, AC-MIG003-12)
+
+Audit test that detects YAML files in `.moai/config/sections/` lacking a corresponding loader. Pattern:
+
+- Scan `internal/template/templates/.moai/config/sections/*.yaml` (or `os.ReadDir(sectionsDir)`)
+- Strip `.yaml` extension → section name
+- Cross-reference against the union of:
+  - Known loaders in `internal/config/loader.go` (parsed via AST or static list)
+  - Known dedicated loaders (e.g., `LoadHarnessConfig` at loader.go:256, `LoadRuntime` at internal/runtime/config.go:81)
+  - Out-of-scope sections (declared in `internal/config/loader.go` package-level `var unloadedAcknowledgedSections = []string{...}` or similar registry)
+- For each new YAML file not in any list → fail test with `YAML_SECTION_NO_LOADER: <file>` (REQ-MIG003-013)
+
+Implementation file (proposed): `internal/config/audit_loader_completeness_test.go`. Cross-reference test pattern: **internal/template/agentless_audit_test.go** (existing CI guard model).
+
+### 6.2 `CONFIG_STRUCT_YAML_MISMATCH` (REQ-MIG003-016, AC-MIG003-14)
+
+`make build`-time validation: Go struct field defined in `ConstitutionConfig` MUST have a matching key in the template YAML (and vice versa). Detection:
+
+- AST-walk Go struct fields with yaml tags (e.g., `ApprovedFrameworks []string \`yaml:"approved_frameworks"\``)
+- Parse template YAML file into `map[string]any`
+- Recursive compare: every yaml-tagged Go field has a key in the YAML map, and every YAML key has a yaml-tagged Go field (modulo `omitempty` and `,inline`)
+- On mismatch: emit `CONFIG_STRUCT_YAML_MISMATCH: field=<path>, side=<go-only|yaml-only>` and fail
+
+Implementation file (proposed): `internal/config/audit_struct_yaml_symmetry_test.go`. Run as `go test ./internal/config/...` and gated by `make build`.
+
+---
+
+## 7. SunsetConfig DORMANT Strategy (REQ-MIG003-006, REQ-MIG003-018)
+
+Per spec.md §2.1 and §1.2, sunset.yaml stays dormant. Required deliverables:
+
+### 7.1 DORMANT godoc marker (REQ-MIG003-006, AC-MIG003-06)
+
+Modify `internal/config/types.go:309` block to prepend explicit DORMANT marker:
+
+```
+// SunsetConfig defines the Build-to-Delete framework configuration.
+// Quality gates that consistently pass can be relaxed over time.
+//
+// @MX:NOTE: [AUTO] DORMANT — struct schema defined but no runtime hot path enforces
+//                  sunset conditions. Activation deferred to a future SPEC.
+//                  Do NOT add LoadSunsetConfig until activation SPEC is filed.
+type SunsetConfig struct {
+```
+
+### 7.2 Once-per-session log (REQ-MIG003-018, AC-MIG003-15)
+
+When `Loader.Load()` encounters `sunset.yaml` (existence check, not parse), emit `slog.Info("SUNSET_CONFIG_DORMANT_NOTICE", "spec", "SPEC-V3R2-MIG-003 REQ-018", "yaml_path", path)`. Guarded by a `sync.Once` so it fires at most once per process lifetime. Implementation lives in a new helper `internal/config/sunset_notice.go` (small file, no test ambiguity).
+
+---
+
+## 8. Related SPECs (dependency / overlap analysis)
+
+| Related SPEC | Status | Relationship |
+|---|---|---|
+| SPEC-V3R2-HRN-001 | merged 2026-05-18 | **Delivers harness.yaml loader** — MIG-003 reconciliation point (§2 above). Effective scope reduced from 5 → 4 sections. |
+| SPEC-V3R2-MIG-002 | merged 2026-05-18 | Hook registration cleanup. Established `audit_test.go` style 3-way sync test pattern that MIG-003 §6 CI guard mirrors. |
+| SPEC-V3R2-EXT-004 | blocked-by | Migration framework — MIG-003 loader completeness step runs after EXT-004's migrate command. Reference: spec.md §9.1. |
+| SPEC-V3R2-WF-003 | downstream | Multi-mode router consumes `InterviewConfig` and `HarnessConfig`. MIG-003 unblocks this consumption. |
+| SPEC-V3R2-EXT-001 | related | Memory subsystem; `InterviewConfig.skip_conditions[resume_spec_id_present]` relates to memory staleness. |
+
+---
+
+## 9. Test Fixture Plan (for M1 RED phase)
+
+Each new loader requires fixtures parallel to HRN-001's `internal/config/testdata/`:
+
+```
+internal/config/testdata/
+├── constitution-valid/constitution.yaml            (mirror sections/constitution.yaml)
+├── constitution-malformed/constitution.yaml        (truncated mid-map for parse error path)
+├── context-valid/context.yaml                       (mirror sections/context.yaml)
+├── context-malformed/context.yaml                   (invalid YAML, top-level key mistyped)
+├── interview-valid/interview.yaml                   (mirror sections/interview.yaml)
+├── interview-missing/                               (empty dir for default-path test)
+├── design-valid/design.yaml                         (mirror sections/design.yaml)
+├── design-pass-threshold-violation/design.yaml      (pass_threshold: 0.45 — below FROZEN 0.60 floor; loader should reject if validation enforces; otherwise loader accepts and downstream WF enforces)
+```
+
+Existing fixture directory pattern reference: `ls internal/config/testdata/` shows the testdata convention is in active use by HRN-001 tests (loader_harness_extended_test.go:17-200).
+
+---
+
+## 10. File Map (write/edit targets for plan.md)
+
+### 10.1 Files to CREATE (new)
+
+| File | Purpose |
+|---|---|
+| `internal/config/loader_constitution.go` | `ConstitutionConfig` consumers + `LoadConstitutionConfig` + `loadConstitutionSection` |
+| `internal/config/loader_context.go` | `ContextConfig` + `LoadContextConfig` + `loadContextSection` |
+| `internal/config/loader_interview.go` | `InterviewConfig` + `LoadInterviewConfig` + `loadInterviewSection` |
+| `internal/config/loader_design.go` | `DesignConfig` + `LoadDesignConfig` + `loadDesignSection` |
+| `internal/config/sunset_notice.go` | One-shot session log for REQ-MIG003-018 |
+| `internal/config/loader_constitution_test.go` | Unit tests: valid / missing / malformed |
+| `internal/config/loader_context_test.go` | Unit tests |
+| `internal/config/loader_interview_test.go` | Unit tests |
+| `internal/config/loader_design_test.go` | Unit tests |
+| `internal/config/audit_loader_completeness_test.go` | CI guard `YAML_SECTION_NO_LOADER` (REQ-013) |
+| `internal/config/audit_struct_yaml_symmetry_test.go` | CI guard `CONFIG_STRUCT_YAML_MISMATCH` (REQ-016) |
+| `internal/config/testdata/{constitution,context,interview,design}-{valid,malformed}/...` | Fixtures (10 yaml files) |
+
+### 10.2 Files to EDIT (existing)
+
+| File | Change |
+|---|---|
+| `internal/config/types.go` | Add 4 new structs (`ConstitutionConfig`, `ContextConfig`, `InterviewConfig`, `DesignConfig`) — placed adjacent to `HarnessConfig` (types.go:402). Add 4 fields to root `Config` struct (types.go:15-33). Prepend DORMANT godoc to `SunsetConfig` (types.go:309). Add 4 wrapper types (types.go:560 area). |
+| `internal/config/loader.go` | Wire 4 new `loadXxxSection(sectionsDir, cfg)` calls into `Loader.Load()` (loader.go:31-74) — append after `loadResearchSection` call at line 71. Optionally also invoke `sunsetDormantNoticeOnce(sectionsDir)`. |
+| `internal/config/defaults.go` | Add 4 default helpers (`defaultConstitutionConfig`, etc.) and wire into `NewDefaultConfig()`. |
+| `internal/config/errors.go` | Reuse existing `ErrInvalidYAML`, `ErrConfigNotFound`. May add `ErrYAMLSectionNoLoader` for REQ-013 CI guard signal. |
+| `.claude/rules/moai/core/settings-management.md` | Document the 4 new loaders + DORMANT sunset.yaml + CI guards (per spec.md §10 Traceability bullet 6). |
+
+### 10.3 Files NOT in scope
+
+- `internal/template/templates/.moai/config/sections/*.yaml` — template defaults are READ, not modified. (Out-of-scope per spec.md §1.2.)
+- `internal/runtime/config.go` — separate loader for `runtime.yaml`; not affected.
+- `internal/cli/migrate_agency.go` — current `design.yaml` consumer; remains as-is per spec.md §2.1 design.yaml row ("ADD LOADER for runtime; migrate_agency.go stays").
+
+---
+
+## 11. Risk Analysis (deep)
+
+### 11.1 Wrapper-key collision (constitution.yaml vs quality.yaml)
+
+Both YAML files use the literal top-level key `constitution:`. The existing `qualityFileWrapper.Constitution` (types.go:573) targets `quality.yaml`'s `constitution:` key as a Python-BC alias for the QualityConfig data. The new `constitutionFileWrapper.Constitution` targets `constitution.yaml`'s `constitution:` key with ConstitutionConfig schema. **Resolution**: `loadYAMLFile(dir, "<filename>", wrapper)` keys off filename (`"quality.yaml"` vs `"constitution.yaml"`) — the YAML key collision is harmless because each loader unmarshals into its own typed wrapper. Verify via test that loading both does not cross-pollute fields.
+
+### 11.2 Context YAML key naming mismatch
+
+`context.yaml` uses top-level key `context_search:` (not `context:`). The wrapper must use `\`yaml:"context_search"\`` to match. Naming the wrapper field `ContextSearch` (not `Context`) avoids surprise; the public `ContextConfig` struct stays clean.
+
+### 11.3 `design.yaml` ↔ migrate_agency.go double-consumption
+
+`migrate_agency.go` Phase 4 reads `design.yaml` during a one-time migration (.agency/ → .moai/). Adding `DesignConfig` runtime loader does NOT change migration behavior — migrate phase writes the file, runtime reads it. Both flows can coexist.
+
+### 11.4 FROZEN constraints in `design.yaml`
+
+design.yaml line 30 declares `evaluator.memory_scope: per_iteration`, mirroring the FROZEN constraint validated by `LoadHarnessConfig` (loader.go:281-295). The `LoadDesignConfig` loader **must NOT** enforce this constraint (out of scope); enforcement stays in harness loader. Design loader treats `memory_scope` as a free string field.
+
+### 11.5 Pass-threshold floor (FROZEN 0.60) in `design.yaml.gan_loop.pass_threshold`
+
+design.yaml line 49 has `pass_threshold: 0.75` (above FROZEN floor 0.60). `LoadDesignConfig` SHOULD validate `gan_loop.pass_threshold >= 0.60` and return `ErrPassThresholdFloor` (reusing the existing sentinel from HRN-001 errors.go:79) on violation. This is a runtime-enforcement parallel to HRN-001's harness floor.
+
+### 11.6 Schema drift for new loaders
+
+HRN-001's `detectSchemaDrift` (loader.go:318-358) is hardcoded for `harness:` top-level. MIG-003 will NOT replicate `MOAI_CONFIG_STRICT` drift detection for the 4 new sections in the initial scope — risk-mitigated via the `CONFIG_STRUCT_YAML_MISMATCH` build-time guard (§6.2). Runtime drift detection is a future enhancement, tracked separately.
+
+### 11.7 sunset.yaml deletion edge case (REQ-MIG003-006 mitigation)
+
+If user removes sunset.yaml, the `sunsetDormantNoticeOnce` helper must NOT panic. Implementation uses `os.Stat` graceful path — file absent → log nothing (no notice fires) — file present → fire once. No `LoadSunsetConfig` exists, so deletion has no other failure surface.
+
+---
+
+## 12. Code Quality Compliance
+
+### 12.1 9-direct-dep policy
+
+spec.md §7 mandates using only `yaml.v3` + stdlib. Inventory:
+
+- `gopkg.in/yaml.v3` — already in `go.mod` (used by loader.go:11)
+- `github.com/go-playground/validator/v10` — already in `go.mod` (used by HRN-001). MIG-003 MAY use struct tags for `validator:"required,gte=0,lte=1"` style invariants, consistent with HRN-001 precedent.
+
+No new direct deps required.
+
+### 12.2 Thread-safety (spec.md §7 line 198)
+
+The existing `Loader` has `mu sync.RWMutex` (loader.go:18-21) and `Load()` acquires write lock (loader.go:32-33). New `loadXxxSection` helpers inherit the lock from `Load()` caller — no extra mutex needed in section helpers (mirrors HRN-001 pattern).
+
+Public `LoadConstitutionConfig(path)` etc. are pure functions (no shared state) — thread-safe by design.
+
+### 12.3 No-hardcoded-values (CLAUDE.local.md §14 / REQ-MIG003-017)
+
+Loaders MUST read defaults from `defaults.go` helpers, not inline literals. `internal/config/envkeys.go:1-100` is the env-var registry — no MIG-003 changes needed there. Acceptance test `audit_loader_completeness_test.go` will grep loader bodies for literal numeric constants matching YAML field values; any match is a `LOADER_HARDCODE_VIOLATION` (AC-MIG003-13).
+
+---
+
+## 13. Section Inventory Summary Table
+
+| # | YAML file | Struct exists? | Loader exists? | Loaded by Load()? | MIG-003 action |
+|---|---|---|---|---|---|
+| 1 | user.yaml | ✓ (models) | ✓ (loadUserSection) | ✓ | unchanged |
+| 2 | language.yaml | ✓ (models) | ✓ | ✓ | unchanged |
+| 3 | quality.yaml | ✓ (models) | ✓ | ✓ | unchanged |
+| 4 | git-convention.yaml | ✓ (models) | ✓ | ✓ | unchanged |
+| 5 | llm.yaml | ✓ | ✓ | ✓ | unchanged |
+| 6 | state.yaml | ✓ | ✓ | ✓ | unchanged |
+| 7 | statusline.yaml | ✓ (models) | ✓ | ✓ | unchanged |
+| 8 | ralph.yaml | ✓ | ✓ | ✓ | unchanged |
+| 9 | research.yaml | ✓ | ✓ | ✓ | unchanged |
+| 10 | harness.yaml | ✓ (HRN-001) | ✓ LoadHarnessConfig (HRN-001) | NO (dedicated entry) | **MIG-003 wire `loadHarnessSection` into Load()** OR document HRN-001's dedicated entry as intentional — TBD M4 decision |
+| 11 | runtime.yaml | ✓ (separate pkg) | ✓ LoadRuntime | NO (separate pkg) | unchanged (out of internal/config) |
+| 12 | constitution.yaml | ✗ | ✗ | ✗ | **ADD** |
+| 13 | context.yaml | ✗ | ✗ | ✗ | **ADD** |
+| 14 | interview.yaml | ✗ | ✗ | ✗ | **ADD** |
+| 15 | design.yaml | ✗ | ✗ (migrate-only) | ✗ | **ADD** runtime loader |
+| 16 | sunset.yaml | ✓ (types.go:311) | ✗ | ✗ | **DORMANT marker + once-per-session log** |
+| 17 | workflow.yaml | partial | partial | NO | out-of-scope (spec.md §1.2) |
+| 18 | mx.yaml | ✗ | ✗ | ✗ | out-of-scope (spec.md §2.2) |
+| 19 | lsp.yaml | ✗ | ✗ | ✗ | out-of-scope |
+| 20 | gate.yaml | ✓ (GateConfig types.go:252) | ✗ | ✗ | out-of-scope (separate SPEC) |
+| 21 | db.yaml | ✗ | ✗ | ✗ | out-of-scope |
+| 22 | github-actions.yaml | ✗ | ✗ | ✗ | out-of-scope |
+| 23 | observability.yaml | ✗ | ✗ | ✗ | out-of-scope |
+| 24 | project.yaml | ✓ (models) | ✗ (via separate loader) | ✗ | out-of-scope |
+| 25 | memo.yaml | ✗ | ✗ | ✗ | out-of-scope |
+| 26 | system.yaml | ✓ (SystemConfig types.go:58) | partial | partial | out-of-scope |
+| 27 | security.yaml | ✓ (SecuritySandbox types.go:174) | partial | partial | out-of-scope |
+| 28 | git-strategy.yaml | ✓ (types.go:36) | partial | partial | out-of-scope |
+
+**Net MIG-003 gap**: 4 new loaders (rows 12-15) + 1 DORMANT formalization (row 16) + 2 CI guards (covering rows 12-16). Harness.yaml (row 10) is already loaded via dedicated entry; MIG-003 may decide in M4 whether to additionally wire it through `Loader.Load()` for uniformity, or leave HRN-001's dedicated entry as canonical.
+
+---
+
+## 14. Open Questions (resolve in M2/M3 of plan)
+
+1. **Should `harness.yaml` be additionally wired into `Loader.Load()` for uniformity?**
+   - Pro: Uniform `loadedSections["harness"] = true` accounting; one entry point for `Loader.Load()` users.
+   - Con: HRN-001 deliberately keeps `LoadHarnessConfig` as a dedicated function with stricter semantics (`ErrConfigNotFound` instead of graceful-default). Wiring through `Load()` would require a wrapper that calls `LoadHarnessConfig` and downgrades errors. Possibly more friction than value.
+   - **Recommendation**: Leave HRN-001's dedicated entry. Document in settings-management.md that `harness.yaml` uses dedicated `LoadHarnessConfig` due to FROZEN validation, and `Loader.Load()` consumers should call `LoadHarnessConfig` separately. AC-MIG003-12 audit test treats `harness.yaml` as "intentionally outside Loader.Load() — loader exists, just not in main Load() chain."
+
+2. **Should `ContextConfig.ForbiddenLibraries` (or `ConstitutionConfig.ForbiddenLibraries`) actually expose for enforcement at MIG-003, or stub it?**
+   - spec.md REQ-MIG003-009 says "expose the list for runtime policy enforcement (consumed by SPEC-V3R2-EXT-004 framework optional hook)". MIG-003 implements the LOADER and EXPOSURE; actual enforcement is downstream (EXT-004). Acceptable to ship just the typed field + godoc reference to SPEC-V3R2-EXT-004.
+
+3. **Pass-threshold floor in `design.yaml`?**
+   - design.yaml line 49: `pass_threshold: 0.75`. Floor is FROZEN at 0.60 (HRN-001 errors.go:79 `ErrPassThresholdFloor`). Should `LoadDesignConfig` enforce this? **Recommended yes** — reuse the existing sentinel, validate at load time. Symmetrical with harness loader.
+
+4. **`design.yaml.adaptation.phase_weights` field — spec.md REQ-MIG003-014 mentions it, but the actual YAML has `adaptation.iteration_limits` instead.**
+   - This is a spec.md drift (REQ wrote `phase_weights` but YAML has `iteration_limits`). Resolution: implement `IterationLimits` struct field matching YAML; document in struct godoc that `phase_weights` is the conceptual term spec.md uses; add an `IterationLimits` getter returning the data structure.
+
+---
+
+## 15. Anchors Inventory (≥25 file:line — total 38)
+
+Counted from §§1-13 above:
+
+1. internal/config/loader.go:31-74 (Loader.Load entry)
+2. internal/config/loader.go:88-99 (loadUserSection canonical pattern)
+3. internal/config/loader.go:102-113 (loadLanguageSection)
+4. internal/config/loader.go:118-129 (loadQualitySection BC alias)
+5. internal/config/loader.go:132-143 (loadGitConventionSection)
+6. internal/config/loader.go:146-157 (loadLLMSection)
+7. internal/config/loader.go:160-171 (loadStateSection)
+8. internal/config/loader.go:174-185 (loadStatuslineSection)
+9. internal/config/loader.go:190-207 (loadRalphSection)
+10. internal/config/loader.go:210-221 (loadResearchSection)
+11. internal/config/loader.go:223-244 (validHarnessLevels + knownHarnessTopLevelKeys)
+12. internal/config/loader.go:256-311 (LoadHarnessConfig — HRN-001 reference)
+13. internal/config/loader.go:318-358 (detectSchemaDrift — HRN-001 drift gate)
+14. internal/config/loader.go:363-378 (loadYAMLFile helper)
+15. internal/config/types.go:15-33 (root Config struct — extension target)
+16. internal/config/types.go:309-325 (SunsetConfig DORMANT target)
+17. internal/config/types.go:398-427 (HarnessConfig — HRN-001 delivered)
+18. internal/config/types.go:429-538 (Harness sub-types — HRN-001 delivered)
+19. internal/config/types.go:555-557 (harnessFileWrapper)
+20. internal/config/types.go:562-609 (wrapper pattern reference)
+21. internal/config/errors.go:14-90 (sentinel error patterns)
+22. internal/config/errors.go:69-90 (HRN-001 harness sentinels)
+23. internal/config/defaults.go (NewDefaultConfig — extend target)
+24. internal/config/loader_harness_extended_test.go:17-200 (HRN-001 test pattern reference)
+25. internal/runtime/config.go:78-114 (LoadRuntime — alternate pattern, NOT extended)
+26. internal/cli/migrate_agency.go (design.yaml current sole consumer)
+27. .moai/config/sections/constitution.yaml:1-32 (in-scope schema source)
+28. .moai/config/sections/context.yaml:1-20 (in-scope schema source)
+29. .moai/config/sections/interview.yaml:1-14 (in-scope schema source)
+30. .moai/config/sections/design.yaml:1-60 (in-scope schema source)
+31. .moai/config/sections/sunset.yaml:1-19 (DORMANT formalization target)
+32. internal/template/agentless_audit_test.go (CI guard pattern reference for §6.1)
+33. internal/config/envkeys.go:1-100 (env-var registry — no MIG-003 changes)
+34. .claude/rules/moai/core/settings-management.md (doc target — spec.md §10)
+35. go.mod (validator/v10 v10.30.2 + yaml.v3 — 9-direct-dep compliance)
+36. internal/config/manager.go (ConfigManager.Reload — downstream consumer awareness)
+37. internal/config/audit_registry.go (existing audit registry pattern reference)
+38. internal/config/required_checks.go (alternate YAML consumer reference)
+
+---
+
+End of research.md

--- a/.moai/specs/SPEC-V3R2-MIG-003/tasks.md
+++ b/.moai/specs/SPEC-V3R2-MIG-003/tasks.md
@@ -1,0 +1,587 @@
+# Task Decomposition — SPEC-V3R2-MIG-003
+
+> Companion to `spec.md`, `plan.md`, `research.md`, `acceptance.md`.
+> Task IDs: T-MIG003-01 through T-MIG003-20.
+> Priority labels per agent-common-protocol.md (no time estimates).
+
+---
+
+## HISTORY
+
+| Version | Date       | Author       | Description                                       |
+|---------|------------|--------------|---------------------------------------------------|
+| 0.1.0   | 2026-05-18 | manager-spec | Initial task decomposition: 20 tasks across M1-M4 |
+
+---
+
+## Milestone M1 — RED Phase (Priority: P0 Critical)
+
+### T-MIG003-01 — Write loader_constitution_test.go (failing)
+
+**Priority**: P0 Critical
+**Owner**: manager-develop (cycle_type=tdd)
+**Phase**: M1 RED
+**Files created**:
+- `internal/config/loader_constitution_test.go`
+- `internal/config/testdata/constitution-valid/constitution.yaml` (mirror of `.moai/config/sections/constitution.yaml`)
+- `internal/config/testdata/constitution-malformed/constitution.yaml` (truncated mid-map)
+
+**Test cases**:
+- `TestLoadConstitutionConfig_ValidParse` — assert all 8 sub-fields populated
+- `TestLoadConstitutionConfig_MissingFile_ReturnsDefaults` — empty dir → default config returned, no error
+- `TestLoadConstitutionConfig_Malformed_ReturnsErrInvalidYAML` — `errors.Is(err, ErrInvalidYAML)` check
+- `TestLoadConstitutionConfig_ForbiddenLibrariesExposed` — non-empty list readable
+
+**Exit criterion**: All 4 tests COMPILE but FAIL with `undefined: LoadConstitutionConfig` / `undefined: ConstitutionConfig`.
+
+**Maps to**: REQ-MIG003-001/002/003/004/007/009 (AC-MIG003-01/02/03/04/07/08)
+
+---
+
+### T-MIG003-02 — Write loader_context_test.go (failing)
+
+**Priority**: P0 Critical
+**Owner**: manager-develop (cycle_type=tdd)
+**Phase**: M1 RED
+**Files created**:
+- `internal/config/loader_context_test.go`
+- `internal/config/testdata/context-valid/context.yaml`
+- `internal/config/testdata/context-malformed/context.yaml`
+
+**Test cases**:
+- `TestLoadContextConfig_ValidParse` — assert `cfg.TokenBudget.MaxInjectionTokens == 5000`, `SkipIfUsageAbove == 150000`, `Search.DateRangeDays == 30`
+- `TestLoadContextConfig_MissingFile_ReturnsDefaults`
+- `TestLoadContextConfig_Malformed_ReturnsErrInvalidYAML`
+
+**Exit criterion**: All 3 tests COMPILE but FAIL with undefined references.
+
+**Maps to**: REQ-MIG003-001/002/003/004/007/010 (AC-MIG003-01/02/03/04/07/09)
+
+---
+
+### T-MIG003-03 — Write loader_interview_test.go (failing)
+
+**Priority**: P0 Critical
+**Owner**: manager-develop (cycle_type=tdd)
+**Phase**: M1 RED
+**Files created**:
+- `internal/config/loader_interview_test.go`
+- `internal/config/testdata/interview-valid/interview.yaml`
+- `internal/config/testdata/interview-missing/` (empty dir)
+
+**Test cases**:
+- `TestLoadInterviewConfig_ValidParse` — assert `cfg.ClarityThreshold == 4`, `Plan.MaxRounds == 5`, `len(SkipConditions) == 3`
+- `TestLoadInterviewConfig_MissingFile_ReturnsDefaults`
+- `TestLoadInterviewConfig_Malformed_ReturnsErrInvalidYAML`
+
+**Exit criterion**: All 3 tests COMPILE but FAIL.
+
+**Maps to**: REQ-MIG003-001/002/003/004/007/011 (AC-MIG003-01/02/03/04/07/10)
+
+---
+
+### T-MIG003-04 — Write loader_design_test.go (failing)
+
+**Priority**: P0 Critical
+**Owner**: manager-develop (cycle_type=tdd)
+**Phase**: M1 RED
+**Files created**:
+- `internal/config/loader_design_test.go`
+- `internal/config/testdata/design-valid/design.yaml`
+- `internal/config/testdata/design-pass-threshold-violation/design.yaml` (pass_threshold: 0.45)
+
+**Test cases**:
+- `TestLoadDesignConfig_ValidParse` — assert `cfg.GanLoop.PassThreshold == 0.75`, `MaxIterations == 5`, `SprintContract.Enabled == true`
+- `TestLoadDesignConfig_MissingFile_ReturnsDefaults`
+- `TestLoadDesignConfig_Malformed_ReturnsErrInvalidYAML`
+- `TestLoadDesignConfig_PassThresholdFloorViolation` — `errors.Is(err, ErrPassThresholdFloor)` for pass_threshold < 0.60
+
+**Exit criterion**: All 4 tests COMPILE but FAIL.
+
+**Maps to**: REQ-MIG003-001/002/003/004/007/014 (AC-MIG003-01/02/03/04/07/11)
+
+---
+
+### T-MIG003-05 — Write SunsetConfig DORMANT marker test + Config root field tests (failing)
+
+**Priority**: P1 High
+**Owner**: manager-develop (cycle_type=tdd)
+**Phase**: M1 RED
+**Files modified**:
+- `internal/config/types_test.go` (extend existing file)
+
+**Test cases**:
+- `TestSunsetConfig_DORMANT_GodocMarker` — read `internal/config/types.go` raw; assert godoc block before `type SunsetConfig struct` contains `DORMANT` literal and `Activation deferred to a future SPEC` phrase
+- `TestRootConfig_HasFourNewSectionFields` — using reflection on `Config{}`, assert 4 fields exist: `Constitution`, `ContextSearch`, `Interview`, `Design`
+
+**Exit criterion**: Both tests FAIL (godoc not yet updated, fields not yet added).
+
+**Maps to**: REQ-MIG003-001/006/015 (AC-MIG003-01/06)
+
+---
+
+### T-MIG003-16 — Write audit_loader_completeness_test.go (failing)
+
+**Priority**: P1 High
+**Owner**: manager-develop (cycle_type=tdd)
+**Phase**: M1 RED
+**Files created**:
+- `internal/config/audit_loader_completeness_test.go`
+
+**Test case**:
+- `TestAuditLoaderCompleteness` — scan `internal/template/templates/.moai/config/sections/*.yaml`, cross-reference against loader registry + `acknowledgedUnloadedSections` allowlist. Fail with `YAML_SECTION_NO_LOADER: <name>` on uncovered.
+
+**Allowlist initial content** (`acknowledgedUnloadedSections`):
+```go
+var acknowledgedUnloadedSections = []string{
+    "db", "gate", "github-actions", "git-strategy", "lsp", "memo",
+    "mx", "observability", "project", "security", "sunset", "system", "workflow",
+}
+```
+
+**Dedicated-loader allowlist** (`acknowledgedDedicatedLoaders` — loaded outside `Loader.Load()` chain):
+```go
+var acknowledgedDedicatedLoaders = []string{"harness", "runtime"}
+```
+
+**Exit criterion**: Test COMPILEs but FAILs because `Loader.Load()` does not yet register the 4 new sections (constitution, context_search, interview, design will be flagged).
+
+**Maps to**: REQ-MIG003-013 (AC-MIG003-12)
+
+---
+
+### T-MIG003-17 — Write audit_struct_yaml_symmetry_test.go (failing)
+
+**Priority**: P1 High
+**Owner**: manager-develop (cycle_type=tdd)
+**Phase**: M1 RED
+**Files created**:
+- `internal/config/audit_struct_yaml_symmetry_test.go`
+
+**Test cases**:
+- `TestStructYAMLSymmetry_Constitution` — AST-parse `ConstitutionConfig` yaml tags + parse `constitution.yaml`; assert bijection
+- `TestStructYAMLSymmetry_Context`
+- `TestStructYAMLSymmetry_Interview`
+- `TestStructYAMLSymmetry_Design`
+
+**Exit criterion**: All 4 tests FAIL (structs don't exist yet).
+
+**Maps to**: REQ-MIG003-016 (AC-MIG003-14)
+
+---
+
+## Milestone M2 — GREEN Phase (Priority: P0 Critical)
+
+### T-MIG003-06 — Add ConstitutionConfig struct + wrapper to types.go
+
+**Priority**: P0 Critical
+**Owner**: manager-develop (cycle_type=tdd)
+**Phase**: M2 GREEN
+**Files modified**:
+- `internal/config/types.go`
+
+**Edits**:
+- Add struct `ConstitutionConfig` adjacent to `HarnessConfig` (after line 538). Fields per `research.md` §3.1.
+- Add struct `ConstitutionArchitecture`, `ConstitutionNaming`, `ConstitutionPerformance`, `ConstitutionSecurity` (sub-types).
+- Add godoc with `@MX:ANCHOR: [AUTO]` mentioning "SPEC-V3R2-EXT-004 framework optional hook for forbidden-library policy enforcement".
+- Add wrapper `constitutionFileWrapper{Constitution ConstitutionConfig \`yaml:"constitution"\`}` to wrapper section.
+- Add field to root `Config` struct: `Constitution ConstitutionConfig \`yaml:"constitution"\``.
+
+**Exit criterion**: `go build ./internal/config/...` succeeds; `TestRootConfig_HasFourNewSectionFields` partial pass for Constitution; `TestStructYAMLSymmetry_Constitution` PASSes if YAML keys match.
+
+**Maps to**: REQ-MIG003-001/005/009 (AC-MIG003-01/05/08)
+
+---
+
+### T-MIG003-07 — Add ContextConfig struct + wrapper to types.go
+
+**Priority**: P0 Critical
+**Owner**: manager-develop (cycle_type=tdd)
+**Phase**: M2 GREEN
+**Files modified**:
+- `internal/config/types.go`
+
+**Edits**:
+- Add struct `ContextConfig` with sub-fields per `research.md` §3.2.
+- Add sub-types: `ContextAutoDetect`, `ContextMemoryIntegration`, `ContextPerformance`, `ContextSearch`, `ContextTokenBudget`.
+- Add godoc with hot-path reference to "CLAUDE.md §16 Context Search Protocol".
+- Add wrapper `contextFileWrapper{ContextSearch ContextConfig \`yaml:"context_search"\`}` (note YAML key is `context_search`).
+- Add field to root `Config`: `ContextSearch ContextConfig \`yaml:"context_search"\``.
+
+**Exit criterion**: `go build` succeeds; symmetry test PASS.
+
+**Maps to**: REQ-MIG003-001/005/010 (AC-MIG003-01/05/09)
+
+---
+
+### T-MIG003-08 — Add InterviewConfig struct + wrapper to types.go
+
+**Priority**: P0 Critical
+**Owner**: manager-develop (cycle_type=tdd)
+**Phase**: M2 GREEN
+**Files modified**:
+- `internal/config/types.go`
+
+**Edits**:
+- Add struct `InterviewConfig` per `research.md` §3.3.
+- Add sub-type: `InterviewMode{MaxRounds int, QuestionsPerRound int}`.
+- Add godoc with hot-path reference to "SPEC-V3R2-WF-003 discovery mode".
+- Add wrapper `interviewFileWrapper{Interview InterviewConfig \`yaml:"interview"\`}`.
+- Add field to root `Config`: `Interview InterviewConfig \`yaml:"interview"\``.
+
+**Exit criterion**: `go build` succeeds; symmetry test PASS.
+
+**Maps to**: REQ-MIG003-001/005/011 (AC-MIG003-01/05/10)
+
+---
+
+### T-MIG003-09 — Add DesignConfig struct + wrapper to types.go
+
+**Priority**: P0 Critical
+**Owner**: manager-develop (cycle_type=tdd)
+**Phase**: M2 GREEN
+**Files modified**:
+- `internal/config/types.go`
+
+**Edits**:
+- Add struct `DesignConfig` per `research.md` §3.4.
+- Add sub-types: `DesignAdaptation`, `DesignBrandContext`, `DesignClaudeDesign`, `DesignDocs`, `DesignEvaluator`, `DesignEvolution`, `DesignFigma`, `DesignGanLoop`, `DesignSprintContract`, `DesignGraduationCriteria`.
+- Add godoc with hot-path reference to "GAN loop runtime sprint contract".
+- Add wrapper `designFileWrapper{Design DesignConfig \`yaml:"design"\`}`.
+- Add field to root `Config`: `Design DesignConfig \`yaml:"design"\``.
+
+**Exit criterion**: `go build` succeeds; symmetry test PASS.
+
+**Maps to**: REQ-MIG003-001/005/014 (AC-MIG003-01/05/11)
+
+---
+
+### T-MIG003-10 — Create internal/config/loader_constitution.go
+
+**Priority**: P0 Critical
+**Owner**: manager-develop (cycle_type=tdd)
+**Phase**: M2 GREEN
+**Files created**:
+- `internal/config/loader_constitution.go`
+
+**Implementation**:
+- `func LoadConstitutionConfig(path string) (*ConstitutionConfig, error)` — open file via `os.ReadFile`, unmarshal into `constitutionFileWrapper`, return typed config; `ErrConfigNotFound` on missing, `ErrInvalidYAML` on parse error.
+- `func (l *Loader) loadConstitutionSection(dir string, cfg *Config)` — use `loadYAMLFile(dir, "constitution.yaml", wrapper)`. On `loaded == true`: `cfg.Constitution = wrapper.Constitution; l.loadedSections["constitution"] = true`. On `loaded == false, err == nil`: no-op (defaults already in cfg via NewDefaultConfig).
+
+**Exit criterion**: `TestLoadConstitutionConfig_*` all PASS; `TestLoadConstitutionConfig_ForbiddenLibrariesExposed` PASS.
+
+**Maps to**: REQ-MIG003-002/003/004/009 (AC-MIG003-02/03/08)
+
+---
+
+### T-MIG003-11 — Create internal/config/loader_context.go
+
+**Priority**: P0 Critical
+**Owner**: manager-develop (cycle_type=tdd)
+**Phase**: M2 GREEN
+**Files created**:
+- `internal/config/loader_context.go`
+
+**Implementation**:
+- `func LoadContextConfig(path string) (*ContextConfig, error)` — same pattern as T-MIG003-10.
+- `func (l *Loader) loadContextSection(dir string, cfg *Config)` — same pattern. `loadedSections["context_search"]`.
+
+**Exit criterion**: `TestLoadContextConfig_*` all PASS.
+
+**Maps to**: REQ-MIG003-002/003/004/010 (AC-MIG003-02/03/09)
+
+---
+
+### T-MIG003-12 — Create internal/config/loader_interview.go
+
+**Priority**: P0 Critical
+**Owner**: manager-develop (cycle_type=tdd)
+**Phase**: M2 GREEN
+**Files created**:
+- `internal/config/loader_interview.go`
+
+**Implementation**:
+- `func LoadInterviewConfig(path string) (*InterviewConfig, error)` — same pattern.
+- `func (l *Loader) loadInterviewSection(dir string, cfg *Config)` — same pattern. `loadedSections["interview"]`.
+
+**Exit criterion**: `TestLoadInterviewConfig_*` all PASS.
+
+**Maps to**: REQ-MIG003-002/003/004/011 (AC-MIG003-02/03/10)
+
+---
+
+### T-MIG003-13 — Create internal/config/loader_design.go (with pass-threshold floor validation)
+
+**Priority**: P0 Critical
+**Owner**: manager-develop (cycle_type=tdd)
+**Phase**: M2 GREEN
+**Files created**:
+- `internal/config/loader_design.go`
+
+**Implementation**:
+- `func LoadDesignConfig(path string) (*DesignConfig, error)` — same base pattern PLUS post-unmarshal validation:
+  - If `cfg.GanLoop.PassThreshold > 0` AND `cfg.GanLoop.PassThreshold < 0.60` → return `&ValidationError{Field: "gan_loop.pass_threshold", Value: cfg.GanLoop.PassThreshold, Message: "below FROZEN floor 0.60", Wrapped: ErrPassThresholdFloor}`.
+- `func (l *Loader) loadDesignSection(dir string, cfg *Config)` — same pattern. `loadedSections["design"]`.
+
+**Exit criterion**: `TestLoadDesignConfig_*` all PASS, including `TestLoadDesignConfig_PassThresholdFloorViolation`.
+
+**Maps to**: REQ-MIG003-002/003/004/014 (AC-MIG003-02/03/11)
+
+---
+
+### T-MIG003-14 — Extend internal/config/defaults.go with 4 default helpers
+
+**Priority**: P0 Critical
+**Owner**: manager-develop (cycle_type=tdd)
+**Phase**: M2 GREEN
+**Files modified**:
+- `internal/config/defaults.go`
+
+**Edits**:
+- Add `func defaultConstitutionConfig() ConstitutionConfig` — populated from `internal/template/templates/.moai/config/sections/constitution.yaml` content (literal Go values).
+- Add `func defaultContextConfig() ContextConfig`.
+- Add `func defaultInterviewConfig() InterviewConfig`.
+- Add `func defaultDesignConfig() DesignConfig`.
+- In `NewDefaultConfig()` body, assign: `cfg.Constitution = defaultConstitutionConfig()`, `cfg.ContextSearch = defaultContextConfig()`, `cfg.Interview = defaultInterviewConfig()`, `cfg.Design = defaultDesignConfig()`.
+
+**Exit criterion**: `TestLoad*_MissingFile_ReturnsDefaults` for all 4 sections PASS.
+
+**Maps to**: REQ-MIG003-004 (AC-MIG003-03)
+
+---
+
+### T-MIG003-15 — Update SunsetConfig godoc + Config root in types.go
+
+**Priority**: P1 High
+**Owner**: manager-develop (cycle_type=tdd)
+**Phase**: M2 GREEN
+**Files modified**:
+- `internal/config/types.go`
+
+**Edits**:
+- Prepend to `SunsetConfig` godoc (line 309):
+  ```
+  // @MX:NOTE: [AUTO] DORMANT — struct schema defined but no runtime hot path
+  //   enforces sunset conditions. Activation deferred to a future SPEC.
+  //   Do NOT add LoadSunsetConfig until activation SPEC is filed.
+  //   REQ-MIG003-006 ↔ REQ-MIG003-015 reference.
+  ```
+
+**Exit criterion**: `TestSunsetConfig_DORMANT_GodocMarker` PASSes.
+
+**Maps to**: REQ-MIG003-006/015 (AC-MIG003-06)
+
+---
+
+### T-MIG003-18 — Wire 4 new section loaders into Loader.Load()
+
+**Priority**: P0 Critical
+**Owner**: manager-develop (cycle_type=tdd)
+**Phase**: M2 GREEN
+**Files modified**:
+- `internal/config/loader.go`
+
+**Edits**:
+- In `Loader.Load()` body, after line 71 (`l.loadResearchSection(sectionsDir, cfg)`), append:
+  ```go
+  // Load constitution section (REQ-MIG003-001/002)
+  l.loadConstitutionSection(sectionsDir, cfg)
+
+  // Load context_search section (REQ-MIG003-010)
+  l.loadContextSection(sectionsDir, cfg)
+
+  // Load interview section (REQ-MIG003-011)
+  l.loadInterviewSection(sectionsDir, cfg)
+
+  // Load design section (REQ-MIG003-014)
+  l.loadDesignSection(sectionsDir, cfg)
+  ```
+
+**Exit criterion**: `TestAuditLoaderCompleteness` PASS — the 4 new sections show as loaded.
+
+**Maps to**: REQ-MIG003-002 (AC-MIG003-02/12)
+
+---
+
+## Milestone M3 — GREEN Phase: CI Guards + Once-per-Session Notice (Priority: P1 High)
+
+### T-MIG003-19 — Create internal/config/sunset_notice.go + test
+
+**Priority**: P1 High
+**Owner**: manager-develop (cycle_type=tdd)
+**Phase**: M3 GREEN
+**Files created**:
+- `internal/config/sunset_notice.go`
+- `internal/config/sunset_notice_test.go`
+
+**Implementation (sunset_notice.go)**:
+```go
+package config
+
+import (
+    "log/slog"
+    "os"
+    "path/filepath"
+    "sync"
+)
+
+var sunsetNoticeOnce sync.Once
+
+// emitSunsetDormantNotice emits a one-shot session log per REQ-MIG003-018.
+// Guarded by sync.Once so it fires at most once per process lifetime.
+//
+// @MX:NOTE: [AUTO] DORMANT notice helper — fires when sunset.yaml exists,
+// reminds future maintainers that SunsetConfig is template-only.
+func emitSunsetDormantNotice(sectionsDir string) {
+    sunsetNoticeOnce.Do(func() {
+        path := filepath.Join(sectionsDir, "sunset.yaml")
+        if _, err := os.Stat(path); err == nil {
+            slog.Info("SUNSET_CONFIG_DORMANT_NOTICE",
+                "spec", "SPEC-V3R2-MIG-003 REQ-018",
+                "yaml_path", path,
+                "advice", "SunsetConfig has no runtime hot path; activation requires new SPEC")
+        }
+    })
+}
+```
+
+**Test cases**:
+- `TestSunsetNotice_FiresOnce` — call `Loader.Load()` twice; capture slog records via custom handler; assert exactly 1 record with key `SUNSET_CONFIG_DORMANT_NOTICE`.
+- `TestSunsetNotice_AbsentFileNoNotice` — fixture dir without sunset.yaml; assert 0 records.
+
+**Integration**: Add `emitSunsetDormantNotice(sectionsDir)` call inside `Loader.Load()` between `loadDesignSection` and `return cfg, nil` (loader.go:73).
+
+**Exit criterion**: Both tests PASS.
+
+**Maps to**: REQ-MIG003-018 (AC-MIG003-15)
+
+---
+
+### T-MIG003-20 — Verify CI guards PASS at M3 exit
+
+**Priority**: P1 High
+**Owner**: manager-develop (cycle_type=tdd)
+**Phase**: M3 verification
+
+**Verification commands**:
+```bash
+go test ./internal/config/... -run TestAuditLoaderCompleteness -v
+go test ./internal/config/... -run TestStructYAMLSymmetry -v
+go test ./internal/config/... -run TestSunsetNotice -v
+make build
+```
+
+**Negative-case verification (manual, on a throwaway branch)**:
+- Drop `internal/template/templates/.moai/config/sections/__sentinel.yaml` (without loader); rerun `TestAuditLoaderCompleteness`; confirm FAIL with `YAML_SECTION_NO_LOADER: __sentinel`.
+- Add `NewBogusField string \`yaml:"new_bogus_field"\`` to `ConstitutionConfig` without YAML; rerun `TestStructYAMLSymmetry_Constitution`; confirm FAIL with `CONFIG_STRUCT_YAML_MISMATCH: field=ConstitutionConfig.NewBogusField, side=go-only`.
+
+**Exit criterion**: positive cases all PASS, negative cases demonstrate FAIL with expected messages, then revert.
+
+**Maps to**: REQ-MIG003-013/016/018 (AC-MIG003-12/14/15)
+
+---
+
+## Milestone M4 — REFACTOR Phase (Priority: P2 Medium)
+
+### T-MIG003-21 — Update .claude/rules/moai/core/settings-management.md
+
+**Priority**: P2 Medium
+**Owner**: manager-docs
+**Phase**: M4 REFACTOR
+**Files modified**:
+- `.claude/rules/moai/core/settings-management.md`
+
+**Edits**:
+- Add subsection "MoAI Configuration — Section Loaders" enumerating the 10 sections loaded via `Loader.Load()` + 2 dedicated entries (harness, runtime).
+- Document 4 new MIG-003 loaders: `LoadConstitutionConfig`, `LoadContextConfig`, `LoadInterviewConfig`, `LoadDesignConfig`.
+- Document `SunsetConfig` DORMANT status with REQ-MIG003-006 reference.
+- Document 2 CI guards (`YAML_SECTION_NO_LOADER`, `CONFIG_STRUCT_YAML_MISMATCH`).
+- Add "Adding a new YAML section" 5-step procedure:
+  1. Add YAML file to `internal/template/templates/.moai/config/sections/`
+  2. Add struct + wrapper to `internal/config/types.go`
+  3. Add default helper to `internal/config/defaults.go`
+  4. Add `LoadXxxConfig` + `loadXxxSection` to new `internal/config/loader_<name>.go`
+  5. Wire `loadXxxSection` into `Loader.Load()` AND add to `audit_struct_yaml_symmetry_test.go` allowlist
+- Reference HRN-001's dedicated entry pattern (research.md §14 Q1 decision: `LoadHarnessConfig` stays outside `Loader.Load()` by design).
+
+**Exit criterion**: file edited; `git diff` shows additive changes only.
+
+**Maps to**: REQ-MIG003 §10 traceability bullet 6
+
+---
+
+### T-MIG003-22 — Add @MX tags + plan-auditor PASS verification
+
+**Priority**: P2 Medium
+**Owner**: manager-develop
+**Phase**: M4 REFACTOR
+
+**Edits**:
+- Add `@MX:NOTE` (and `@MX:ANCHOR` where `fan_in >= 3`) to each new `LoadXxxConfig` public function documenting its hot path consumer.
+- Run `golangci-lint run ./...` — confirm zero new findings.
+- Run `go test ./...` — confirm zero regressions.
+- Update `progress.md`: record `plan_status: audit-ready`, `plan_complete_at: 2026-05-18`, and any acceptance run results.
+- Run plan-auditor (per `.claude/rules/moai/workflow/spec-workflow.md` §Phase 0.5) on the 4 plan artifacts (spec.md / plan.md / research.md / acceptance.md / tasks.md). Target verdict: PASS.
+
+**Exit criterion**: plan-auditor PASS, ready for `/moai run SPEC-V3R2-MIG-003`.
+
+**Maps to**: M4 DoD checklist
+
+---
+
+## Task → REQ → AC Coverage Matrix
+
+| Task ID | REQs covered | ACs verified |
+|---|---|---|
+| T-MIG003-01 | 001, 002, 003, 004, 007, 009 | 01, 02, 03, 04, 07, 08 |
+| T-MIG003-02 | 001, 002, 003, 004, 007, 010 | 01, 02, 03, 04, 07, 09 |
+| T-MIG003-03 | 001, 002, 003, 004, 007, 011 | 01, 02, 03, 04, 07, 10 |
+| T-MIG003-04 | 001, 002, 003, 004, 007, 014 | 01, 02, 03, 04, 07, 11 |
+| T-MIG003-05 | 001, 006, 015 | 01, 06 |
+| T-MIG003-06 | 001, 005, 009 | 01, 05, 08 |
+| T-MIG003-07 | 001, 005, 010 | 01, 05, 09 |
+| T-MIG003-08 | 001, 005, 011 | 01, 05, 10 |
+| T-MIG003-09 | 001, 005, 014 | 01, 05, 11 |
+| T-MIG003-10 | 002, 003, 004, 009 | 02, 03, 08 |
+| T-MIG003-11 | 002, 003, 004, 010 | 02, 03, 09 |
+| T-MIG003-12 | 002, 003, 004, 011 | 02, 03, 10 |
+| T-MIG003-13 | 002, 003, 004, 014 | 02, 03, 11 |
+| T-MIG003-14 | 004 | 03 |
+| T-MIG003-15 | 006, 015 | 06 |
+| T-MIG003-16 | 013 | 12 |
+| T-MIG003-17 | 016 | 14 |
+| T-MIG003-18 | 002 | 02, 12 |
+| T-MIG003-19 | 018 | 15 |
+| T-MIG003-20 | 013, 016, 018 | 12, 14, 15 |
+| T-MIG003-21 | (doc only) | DoD |
+| T-MIG003-22 | (refactor + plan-audit) | DoD |
+
+All 18 REQs covered; all 15 ACs covered. REQ-MIG003-008/012/017 covered by AC verify-only / review (no separate task — handled within T-MIG003-10..13 implementation discipline + T-MIG003-22 lint review).
+
+## Task Ordering & Dependencies
+
+```
+M1 (P0 Critical, parallel):
+  T-01 → T-02 → T-03 → T-04   (4 RED test files, can be parallel)
+  T-05                         (types_test.go extension)
+  T-16, T-17                   (audit guards, parallel)
+
+M2 (P0 Critical, sequential within file groups):
+  T-06 → T-10                  (Constitution: struct first, loader second)
+  T-07 → T-11                  (Context)
+  T-08 → T-12                  (Interview)
+  T-09 → T-13                  (Design)
+  T-14                         (defaults helpers — depends on T-06..09)
+  T-15                         (SunsetConfig godoc)
+  T-18                         (wiring — depends on T-10..13)
+
+M3 (P1 High, sequential):
+  T-19                         (sunset_notice.go + test)
+  T-20                         (CI guards verification)
+
+M4 (P2 Medium):
+  T-21                         (settings-management.md docs)
+  T-22                         (MX tags + plan-auditor PASS)
+```
+
+End of tasks.md


### PR DESCRIPTION
## Summary

- **SPEC**: SPEC-V3R2-MIG-003 (P1 High, release-blocker, Phase 8 Migration Tool + Docs)
- **Status**: plan-phase artifacts ready for plan-auditor PASS gate
- **4 artifacts created**: research.md (460 LOC, 38+ anchors), plan.md (338 LOC), acceptance.md (399 LOC, 15 binary ACs), tasks.md (587 LOC, 22 tasks)

## Section Inventory

| Category | Count | Sections |
|---|---|---|
| LOADED via Loader.Load() | 9 | user, language, quality, git-convention, llm, ralph, state, statusline, research |
| LOADED via dedicated entry | 2 | **harness (HRN-001 ✓)**, runtime (separate pkg) |
| **MIG-003 net new (4 loaders)** | 4 | constitution, context, interview, design |
| **MIG-003 DORMANT formalization** | 1 | sunset (struct exists, no loader, REQ-006) |
| Out-of-scope (acknowledged) | 12 | db, gate, github-actions, git-strategy, lsp, memo, mx, observability, project, security, system, workflow |

**Gap (MIG-003 scope)**: 4 unloaded sections + 1 DORMANT = 5 sections affected, vs spec.md's original 5-section assumption (constitution, context, interview, design, harness). Reduced to 4 after HRN-001 (harness.yaml) shipped on main 2026-05-18.

## HRN-001 Reconciliation Notes

- HRN-001 delivered `HarnessConfig` (types.go:398-538) + `LoadHarnessConfig` (loader.go:256-311) + `detectSchemaDrift` (loader.go:318-358) + 7 extended tests
- REQ-MIG003-002/004/008/012 are **verify-only** for the harness slice (gap resolved upstream)
- REQ-MIG003-001/003/005/006/007/009/010/011/013/014/015/016/017/018 are net-new MIG-003 work
- Plan documents the harness dedicated-entry decision (research.md §14 OQ1): `LoadHarnessConfig` stays outside `Loader.Load()` chain by HRN-001 design (FROZEN validation requires stricter semantics than graceful-default).

## Test plan

- [ ] Verify M1 RED-phase tests fail before M2 (plan.md §3 / acceptance.md AC-MIG003-07)
- [ ] Run `go test ./internal/config/...` after M2 — all 4 loader test suites + symmetry tests + completeness audit PASS
- [ ] Verify `make build` enforces CONFIG_STRUCT_YAML_MISMATCH guard (AC-MIG003-14)
- [ ] Verify SUNSET_CONFIG_DORMANT_NOTICE fires once per process (AC-MIG003-15)
- [ ] Plan-auditor verdict: PASS before /moai run handoff
- [ ] Regression check: HRN-001's TestLoadHarnessConfigExtended_* all PASS

## Constraints respected

- [HARD] No time estimates (priority labels P0/P1/P2 only)
- [HARD] Plan-phase output only — no implementation code touched
- [HARD] research.md ≥25 anchors (actual: 38+ across 13 sections)
- [HARD] acceptance.md ≥10 binary ACs (actual: 15)
- [HARD] HRN-001 baseline accounted (reconciliation in research.md §2, plan.md §1)
- [HARD] tags string CSV format (spec.md frontmatter unchanged)

NO auto-merge.

🗿 MoAI <email@mo.ai.kr>