### PR TITLE
feat(SPEC-V3R2-MIG-003): Config Loader Completeness — 4 new section loaders + CI guards

### DIFF
--- a/.claude/rules/moai/core/settings-management.md
+++ b/.claude/rules/moai/core/settings-management.md
@@ -118,6 +118,57 @@ Activate with `--deepthink` flag for enhanced analysis.
 - sections/language.yaml: Language preferences
 - sections/user.yaml: User information
 
+#### MoAI Configuration — Section Loaders (SPEC-V3R2-MIG-003)
+
+Configuration sections are loaded via two mechanisms:
+
+**1. `Loader.Load()` chain** (`internal/config/loader.go:31-74`):
+Loads the following 10 sections in fixed order. All return defaults on absent file.
+
+| YAML file | loadedSections key | Go field |
+|---|---|---|
+| user.yaml | `user` | `cfg.User` |
+| language.yaml | `language` | `cfg.Language` |
+| quality.yaml | `quality` | `cfg.Quality` |
+| git-convention.yaml | `git_convention` | `cfg.GitConvention` |
+| llm.yaml | `llm` | `cfg.LLM` |
+| ralph.yaml | `ralph` | `cfg.Ralph` |
+| state.yaml | `state` | `cfg.State` |
+| statusline.yaml | `statusline` | `cfg.Statusline` |
+| research.yaml | `research` | `cfg.Research` |
+| constitution.yaml | `constitution` | `cfg.Constitution` |
+| context.yaml | `context_search` | `cfg.ContextSearch` |
+| interview.yaml | `interview` | `cfg.Interview` |
+| design.yaml | `design` | `cfg.Design` |
+
+**2. Dedicated entry-points** (outside `Loader.Load()` by design):
+
+| Section | Loader | Package | Rationale |
+|---|---|---|---|
+| harness.yaml | `LoadHarnessConfig(path)` | `internal/config` | FROZEN validation (HRN-001); returns error on absent file (not defaults) |
+| runtime.yaml | `LoadRuntime(path)` | `internal/runtime` | Separate package, separate lifecycle |
+
+**MIG-003 new loaders** (`internal/config/loader_{constitution,context,interview,design}.go`):
+
+- `LoadConstitutionConfig(path)` — constitution.yaml; exposes `ForbiddenPatterns` (ForbiddenLibraries alias) for SPEC-V3R2-EXT-004 policy enforcement.
+- `LoadContextConfig(path)` — context.yaml; provides `TokenBudget.MaxInjectionTokens` and `Search.DateRangeDays` for CLAUDE.md §16 Context Search.
+- `LoadInterviewConfig(path)` — interview.yaml; provides `ClarityThreshold`, `Plan.MaxRounds`, `SkipConditions` for SPEC-V3R2-WF-003 discovery mode.
+- `LoadDesignConfig(path)` — design.yaml; provides `GanLoop.PassThreshold` (FROZEN floor 0.60), `GanLoop.SprintContract.Enabled`, `Adaptation.IterationLimits` for GAN loop runtime.
+
+**SunsetConfig** (`internal/config/types.go`): DORMANT — struct defined but no runtime hot path enforces sunset conditions. `LoadSunsetConfig` must NOT be added until an activation SPEC is filed (REQ-MIG003-006).
+
+**CI Guards** (run on every `go test ./internal/config/...`):
+
+- `YAML_SECTION_NO_LOADER` (`audit_loader_completeness_test.go:TestAuditLoaderCompleteness`): fails if a new `.moai/config/sections/*.yaml` file has no loader and is not in the acknowledged allowlist.
+- `CONFIG_STRUCT_YAML_MISMATCH` (`audit_struct_yaml_symmetry_test.go:TestStructYAMLSymmetry_*`): fails if a Go struct field lacks a matching YAML key or vice versa.
+
+**Adding a new YAML section** (5-step procedure):
+1. Add `<name>.yaml` to `internal/template/templates/.moai/config/sections/`
+2. Add `XxxConfig` struct + sub-types + `xxxFileWrapper` to `internal/config/types.go`
+3. Add `defaultXxxConfig()` helper to `internal/config/defaults.go` and wire into `NewDefaultConfig()`
+4. Create `internal/config/loader_<name>.go` with `LoadXxxConfig(path)` + `loadXxxSection(dir, cfg *Config)`
+5. Wire `l.loadXxxSection(sectionsDir, cfg)` into `Loader.Load()` AND add the struct to `audit_struct_yaml_symmetry_test.go` symmetryCases
+
 ## Hooks Configuration
 
 Hooks support environment variables and must be quoted to handle spaces:

--- a/internal/config/audit_loader_completeness_test.go
+++ b/internal/config/audit_loader_completeness_test.go
@@ -1,0 +1,142 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// acknowledgedUnloadedSections is the allowlist of YAML sections that intentionally
+// have no loader in internal/config/loader.go (outside the Loader.Load() chain).
+// Each entry should have a comment explaining why it's out of scope.
+// REQ-MIG003-013 (OQ6 decision): maintain as sorted []string literal.
+var acknowledgedUnloadedSections = []string{
+	"db",             // out-of-scope: separate SPEC (database config not yet runtime-consumed)
+	"gate",           // out-of-scope: GateConfig exists but loaded via separate path (not Loader.Load)
+	"github-actions", // out-of-scope: CI config, not consumed at runtime
+	"git-strategy",   // out-of-scope: loaded via git-strategy.yaml.tmpl template rendering path
+	"lsp",            // out-of-scope: LSP config not yet runtime-enforced (separate SPEC)
+	"memo",           // out-of-scope: memo configuration, not runtime-consumed
+	"mx",             // out-of-scope: ad-hoc parsing retained; struct neuverbalisation deferred (spec.md §2.2)
+	"observability",  // out-of-scope: observability config, separate SPEC
+	"project",        // out-of-scope: loaded via separate ProjectConfig loader path
+	"security",       // out-of-scope: security config, partial loader via separate path
+	"sunset",         // out-of-scope: DORMANT — struct defined but no runtime hot path (REQ-MIG003-006)
+	"system",         // out-of-scope: SystemConfig has partial loader via template
+	"workflow",       // out-of-scope: role_profiles subset loaded; full unification deferred (spec.md §1.2)
+}
+
+// acknowledgedDedicatedLoaders is the list of sections loaded via dedicated entry-points
+// outside Loader.Load() (e.g., LoadHarnessConfig, LoadRuntime). These count as "loaded"
+// for the purposes of the completeness audit.
+// REQ-MIG003-013 (plan.md OQ1 decision: harness stays outside Loader.Load() by design).
+var acknowledgedDedicatedLoaders = []string{
+	"harness", // dedicated: LoadHarnessConfig (HRN-001) — stricter FROZEN validation semantics
+	"runtime", // dedicated: LoadRuntime (internal/runtime/config.go) — separate package
+}
+
+// fileNameToSectionKey maps YAML filename stems to their loadedSections key when
+// the two differ. This handles cases like context.yaml → "context_search" and
+// git-convention.yaml → "git_convention".
+var fileNameToSectionKey = map[string]string{
+	"context":        "context_search", // context.yaml top-level key is context_search:
+	"git-convention": "git_convention", // loaded as git_convention (underscore, not hyphen)
+}
+
+// TestAuditLoaderCompleteness verifies that every YAML file in the template
+// sections directory either:
+//  1. Has a corresponding loader registered in Loader.Load() (via loadedSections),
+//  2. Is listed in acknowledgedDedicatedLoaders (separate entry-point), OR
+//  3. Is listed in acknowledgedUnloadedSections (explicitly out-of-scope).
+//
+// Fails with YAML_SECTION_NO_LOADER: <name> for any uncovered section.
+// REQ-MIG003-013, AC-MIG003-12
+func TestAuditLoaderCompleteness(t *testing.T) {
+	// Find repo root via GOFILE path
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	// thisFile = .../internal/config/audit_loader_completeness_test.go
+	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..")
+
+	templateSectionsDir := filepath.Join(repoRoot, "internal", "template", "templates",
+		".moai", "config", "sections")
+
+	entries, err := os.ReadDir(templateSectionsDir)
+	if err != nil {
+		t.Fatalf("os.ReadDir(%q): %v", templateSectionsDir, err)
+	}
+
+	// Build quick-lookup sets
+	unloadedSet := make(map[string]bool, len(acknowledgedUnloadedSections))
+	for _, s := range acknowledgedUnloadedSections {
+		unloadedSet[s] = true
+	}
+
+	dedicatedSet := make(map[string]bool, len(acknowledgedDedicatedLoaders))
+	for _, s := range acknowledgedDedicatedLoaders {
+		dedicatedSet[s] = true
+	}
+
+	// Run Loader.Load() against a real sections dir to capture loadedSections map.
+	// Use the template directory itself as the config dir for audit purposes.
+	loader := NewLoader()
+	// Loader.Load() expects configDir/.moai/... but templateSectionsDir already is
+	// the sections dir. We need to pass a parent dir such that
+	// filepath.Join(parent, "config", "sections") == templateSectionsDir.
+	// parent = filepath.Join(repoRoot, "internal", "template", "templates", ".moai")
+	moaiDir := filepath.Join(repoRoot, "internal", "template", "templates", ".moai")
+	_, _ = loader.Load(moaiDir) // ignore errors — we only need loadedSections
+	loaded := loader.LoadedSections()
+
+	var uncovered []string
+	for _, entry := range entries {
+		name := entry.Name()
+		// Only process .yaml files (not .yaml.tmpl, not subdirectories)
+		if entry.IsDir() {
+			continue
+		}
+		if !strings.HasSuffix(name, ".yaml") || strings.HasSuffix(name, ".yaml.tmpl") {
+			continue
+		}
+
+		// Strip .yaml suffix to get the section name
+		sectionName := strings.TrimSuffix(name, ".yaml")
+
+		// Resolve alias: some YAML filenames use a different key in loadedSections.
+		lookupKey := sectionName
+		if alias, ok := fileNameToSectionKey[sectionName]; ok {
+			lookupKey = alias
+		}
+
+		// Check if covered
+		if loaded[lookupKey] {
+			continue // loaded by Loader.Load()
+		}
+		if dedicatedSet[sectionName] {
+			continue // dedicated entry-point (HRN-001, runtime)
+		}
+		if unloadedSet[sectionName] {
+			continue // explicitly acknowledged out-of-scope
+		}
+
+		// Not covered by any mechanism → test failure
+		uncovered = append(uncovered, sectionName)
+	}
+
+	for _, name := range uncovered {
+		t.Errorf("YAML_SECTION_NO_LOADER: %s (add loader or acknowledge in allowlist)", name)
+	}
+
+	if len(uncovered) > 0 {
+		t.Logf("To fix: add a loader for each uncovered section OR add to acknowledgedUnloadedSections with a reason comment")
+		t.Logf("Uncovered sections: %v", uncovered)
+	} else {
+		t.Logf("All YAML sections are accounted for (loaded=%d, dedicated=%d, acknowledged=%d)",
+			len(loaded), len(acknowledgedDedicatedLoaders), len(acknowledgedUnloadedSections))
+	}
+}
+

--- a/internal/config/audit_struct_yaml_symmetry_test.go
+++ b/internal/config/audit_struct_yaml_symmetry_test.go
@@ -1,0 +1,178 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Note: collectYAMLKeys and collectStructYAMLTags helpers are omitted because
+// the symmetry check uses only top-level keys (one level deep), which avoids
+// false positives from deeply nested optional fields.
+
+// symmetryTestCase defines one struct↔YAML symmetry check.
+type symmetryTestCase struct {
+	structType    reflect.Type
+	templateYAML  string // path relative to internal/template/templates/.moai/config/sections/
+	yamlTopKey    string // top-level YAML key (e.g., "constitution", "context_search")
+}
+
+// symmetryCases lists the 4 new MIG-003 sections.
+// REQ-MIG003-016, AC-MIG003-14
+var symmetryCases = []symmetryTestCase{
+	{
+		structType:   reflect.TypeOf(ConstitutionConfig{}),
+		templateYAML: "constitution.yaml",
+		yamlTopKey:   "constitution",
+	},
+	{
+		structType:   reflect.TypeOf(ContextConfig{}),
+		templateYAML: "context.yaml",
+		yamlTopKey:   "context_search",
+	},
+	{
+		structType:   reflect.TypeOf(InterviewConfig{}),
+		templateYAML: "interview.yaml",
+		yamlTopKey:   "interview",
+	},
+	{
+		structType:   reflect.TypeOf(DesignConfig{}),
+		templateYAML: "design.yaml",
+		yamlTopKey:   "design",
+	},
+}
+
+// checkSymmetry verifies that every top-level yaml tag in the Go struct has a
+// corresponding key in the YAML file and vice versa.
+// Reports CONFIG_STRUCT_YAML_MISMATCH findings for any discrepancy.
+// Only checks top-level keys to avoid false positives from nested optional keys.
+func checkSymmetry(t *testing.T, tc symmetryTestCase, yamlPath string) {
+	t.Helper()
+
+	data, err := os.ReadFile(yamlPath)
+	if err != nil {
+		t.Fatalf("os.ReadFile(%q): %v", yamlPath, err)
+	}
+
+	// Parse YAML into map
+	var rawRoot map[string]any
+	if err := yaml.Unmarshal(data, &rawRoot); err != nil {
+		t.Fatalf("yaml.Unmarshal(%q): %v", yamlPath, err)
+	}
+
+	// Navigate to the top-level key
+	topVal, ok := rawRoot[tc.yamlTopKey]
+	if !ok {
+		t.Fatalf("YAML file %q missing top-level key %q", yamlPath, tc.yamlTopKey)
+	}
+	topMap, ok := topVal.(map[string]any)
+	if !ok {
+		// Some values are nil (null YAML) — treat as empty map
+		if topVal == nil {
+			topMap = map[string]any{}
+		} else {
+			t.Fatalf("YAML key %q in %q is not a map (type: %T)", tc.yamlTopKey, yamlPath, topVal)
+		}
+	}
+
+	// Collect top-level YAML keys (one level deep only for symmetry check)
+	yamlTopKeys := make(map[string]bool)
+	for k := range topMap {
+		yamlTopKeys[k] = true
+	}
+
+	// Collect top-level Go struct yaml tags (one level deep only)
+	structTopTags := make(map[string]bool)
+	st := tc.structType
+	if st.Kind() == reflect.Ptr {
+		st = st.Elem()
+	}
+	for i := 0; i < st.NumField(); i++ {
+		field := st.Field(i)
+		tag := field.Tag.Get("yaml")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		tagName := strings.Split(tag, ",")[0]
+		if tagName != "" && tagName != "-" {
+			structTopTags[tagName] = true
+		}
+	}
+
+	// Check: Go struct field NOT in YAML (go-only)
+	for tag := range structTopTags {
+		if !yamlTopKeys[tag] {
+			t.Errorf("CONFIG_STRUCT_YAML_MISMATCH: field=%s.%s, side=go-only (key %q exists in struct but not in %s)",
+				tc.structType.Name(), tag, tag, tc.templateYAML)
+		}
+	}
+
+	// Check: YAML key NOT in Go struct (yaml-only)
+	for k := range yamlTopKeys {
+		if !structTopTags[k] {
+			t.Errorf("CONFIG_STRUCT_YAML_MISMATCH: field=%s.%s, side=yaml-only (key %q exists in %s but not in struct)",
+				tc.structType.Name(), k, k, tc.templateYAML)
+		}
+	}
+}
+
+// TestStructYAMLSymmetry_Constitution verifies Go struct ↔ YAML bijection.
+// REQ-MIG003-016, AC-MIG003-14
+func TestStructYAMLSymmetry_Constitution(t *testing.T) {
+	t.Parallel()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..")
+	yamlPath := filepath.Join(repoRoot, "internal", "template", "templates",
+		".moai", "config", "sections", "constitution.yaml")
+	checkSymmetry(t, symmetryCases[0], yamlPath)
+}
+
+// TestStructYAMLSymmetry_Context verifies Go struct ↔ YAML bijection.
+// REQ-MIG003-016, AC-MIG003-14
+func TestStructYAMLSymmetry_Context(t *testing.T) {
+	t.Parallel()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..")
+	yamlPath := filepath.Join(repoRoot, "internal", "template", "templates",
+		".moai", "config", "sections", "context.yaml")
+	checkSymmetry(t, symmetryCases[1], yamlPath)
+}
+
+// TestStructYAMLSymmetry_Interview verifies Go struct ↔ YAML bijection.
+// REQ-MIG003-016, AC-MIG003-14
+func TestStructYAMLSymmetry_Interview(t *testing.T) {
+	t.Parallel()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..")
+	yamlPath := filepath.Join(repoRoot, "internal", "template", "templates",
+		".moai", "config", "sections", "interview.yaml")
+	checkSymmetry(t, symmetryCases[2], yamlPath)
+}
+
+// TestStructYAMLSymmetry_Design verifies Go struct ↔ YAML bijection.
+// REQ-MIG003-016, AC-MIG003-14
+func TestStructYAMLSymmetry_Design(t *testing.T) {
+	t.Parallel()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..")
+	yamlPath := filepath.Join(repoRoot, "internal", "template", "templates",
+		".moai", "config", "sections", "design.yaml")
+	checkSymmetry(t, symmetryCases[3], yamlPath)
+}

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -95,6 +95,11 @@ func NewDefaultConfig() *Config {
 		Sunset:        NewDefaultSunsetConfig(),
 		Research:      NewDefaultResearchConfig(),
 		Session:       NewDefaultSessionConfig(),
+		// MIG-003: 4 new section defaults (REQ-MIG003-004)
+		Constitution:  defaultConstitutionConfig(),
+		ContextSearch: defaultContextConfig(),
+		Interview:     defaultInterviewConfig(),
+		Design:        defaultDesignConfig(),
 	}
 }
 
@@ -356,5 +361,162 @@ func NewDefaultLSPQualityGates() LSPQualityGates {
 		},
 		CacheTTLSeconds: DefaultCacheTTLSeconds,
 		TimeoutSeconds:  DefaultTimeoutSeconds,
+	}
+}
+
+// defaultConstitutionConfig returns a ConstitutionConfig with defaults matching
+// internal/template/templates/.moai/config/sections/constitution.yaml.
+// REQ-MIG003-004: sensible defaults on absent file.
+func defaultConstitutionConfig() ConstitutionConfig {
+	return ConstitutionConfig{
+		ApprovedFrameworks: []string{"cobra", "viper"},
+		ApprovedLanguages:  []string{"go"},
+		Architecture: ConstitutionArchitecture{
+			ForbiddenDependencies: []string{
+				"circular imports",
+				"direct template access from CLI handlers",
+			},
+			Patterns: []string{"clean-architecture", "repository-pattern"},
+		},
+		ForbiddenPatterns: []string{
+			"global mutable state",
+			"init() with side effects",
+			"panic() in library code",
+			"raw SQL without parameterized queries",
+		},
+		NamingConventions: ConstitutionNaming{
+			Exported: "PascalCase",
+			Files:    "snake_case.go",
+			Packages: "lowercase, single word",
+		},
+		Performance: ConstitutionPerformance{},
+		Security: ConstitutionSecurity{
+			ForbiddenPractices: []string{
+				"hardcoded credentials",
+				"os.Exit in library code",
+			},
+			RequiredChecks: []string{"input-validation"},
+		},
+	}
+}
+
+// defaultContextConfig returns a ContextConfig with defaults matching
+// internal/template/templates/.moai/config/sections/context.yaml.
+// REQ-MIG003-004: sensible defaults on absent file.
+func defaultContextConfig() ContextConfig {
+	return ContextConfig{
+		AutoDetect: ContextAutoDetect{Enabled: true},
+		Enabled:    true,
+		MemoryIntegration: ContextMemoryIntegration{
+			Enabled:            true,
+			IncludeInContext:   true,
+			PriorityOverSearch: true,
+		},
+		Performance: ContextPerformance{
+			CacheTTLSeconds: 300,
+			TimeoutSeconds:  10,
+		},
+		Search: ContextSearch{
+			DateRangeDays:      30,
+			MaxResults:         5,
+			MaxTokensPerResult: 1000,
+			ProjectScopeOnly:   true,
+		},
+		TokenBudget: ContextTokenBudget{
+			MaxInjectionTokens: 5000,
+			SkipIfUsageAbove:   150000,
+		},
+	}
+}
+
+// defaultInterviewConfig returns an InterviewConfig with defaults matching
+// internal/template/templates/.moai/config/sections/interview.yaml.
+// REQ-MIG003-004: sensible defaults on absent file.
+func defaultInterviewConfig() InterviewConfig {
+	return InterviewConfig{
+		ClarityThreshold: 4,
+		Enabled:          true,
+		Plan: InterviewMode{
+			MaxRounds:         5,
+			QuestionsPerRound: 3,
+		},
+		Project: InterviewMode{
+			MaxRounds:         3,
+			QuestionsPerRound: 3,
+		},
+		SkipConditions: []string{
+			"resume_spec_id_present",
+			"skip_interview_flag",
+			"technical_keywords_gte_5",
+		},
+	}
+}
+
+// defaultDesignConfig returns a DesignConfig with defaults matching
+// internal/template/templates/.moai/config/sections/design.yaml.
+// REQ-MIG003-004: sensible defaults on absent file.
+// Note: PassThreshold default 0.75 is above the FROZEN floor 0.60.
+func defaultDesignConfig() DesignConfig {
+	return DesignConfig{
+		Adaptation: DesignAdaptation{
+			ConfidenceThreshold: 0.7,
+			Enabled:             true,
+			IterationLimits: DesignIterationLimits{
+				Builder:    3,
+				Copywriter: 3,
+				Designer:   2,
+			},
+			MinProjectsForAdaptation: 5,
+		},
+		BrandContext: DesignBrandContext{
+			Dir:                 ".moai/project/brand",
+			InterviewOnFirstRun: true,
+		},
+		ClaudeDesign: DesignClaudeDesign{
+			Enabled:                 true,
+			FallbackPath:            "code_based",
+			SupportedBundleVersions: []string{"1.0"},
+		},
+		DefaultFramework: "next.js",
+		DesignDocs: DesignDocs{
+			AutoLoadOnDesignCommand: true,
+			Dir:                     ".moai/design",
+			Priority:                []string{"spec", "system", "research", "pencil-plan"},
+			TokenBudget:             20000,
+		},
+		Enabled: true,
+		Evaluator: DesignEvaluator{
+			MemoryScope: "per_iteration",
+		},
+		Evolution: DesignEvolution{
+			ArchiveAfterEvolve:  true,
+			AutoEvolveThreshold: 3,
+			CooldownHours:       24,
+			GraduationCriteria: DesignGraduationCriteria{
+				ConsistencyRatio:    0.8,
+				MinimumConfidence:   0.8,
+				MinimumObservations: 5,
+				StalenessWindowDays: 30,
+			},
+			MaxActiveLearnings:      50,
+			MaxEvolutionRatePerWeek: 3,
+			RequireApproval:         true,
+		},
+		Figma: DesignFigma{Enabled: false},
+		GanLoop: DesignGanLoop{
+			EscalationAfter:      3,
+			ImprovementThreshold: 0.05,
+			MaxIterations:        5,
+			PassThreshold:        0.75,
+			SprintContract: DesignSprintContract{
+				ArtifactDir:           ".moai/sprints",
+				Enabled:               true,
+				MaxNegotiationRounds:  2,
+				OptionalHarnessLevels: []string{"standard"},
+				RequiredHarnessLevels: []string{"thorough"},
+			},
+			StrictMode: false,
+		},
+		Version: "1.0.0",
 	}
 }

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -70,6 +70,21 @@ func (l *Loader) Load(configDir string) (*Config, error) {
 	// Load research section
 	l.loadResearchSection(sectionsDir, cfg)
 
+	// Load constitution section (REQ-MIG003-001/002)
+	l.loadConstitutionSection(sectionsDir, cfg)
+
+	// Load context_search section (REQ-MIG003-010)
+	l.loadContextSection(sectionsDir, cfg)
+
+	// Load interview section (REQ-MIG003-011)
+	l.loadInterviewSection(sectionsDir, cfg)
+
+	// Load design section (REQ-MIG003-014)
+	l.loadDesignSection(sectionsDir, cfg)
+
+	// Emit once-per-session DORMANT notice for sunset.yaml (REQ-MIG003-018)
+	emitSunsetDormantNotice(sectionsDir)
+
 	return cfg, nil
 }
 

--- a/internal/config/loader_constitution.go
+++ b/internal/config/loader_constitution.go
@@ -1,0 +1,53 @@
+package config
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// LoadConstitutionConfig reads constitution.yaml from the given file path and
+// returns a typed ConstitutionConfig.
+//
+// Return semantics:
+//   - (cfg, nil) on successful parse
+//   - (defaultCfg, nil) on file-not-found (REQ-MIG003-004 graceful default)
+//   - (nil, ErrInvalidYAML) on malformed YAML (REQ-MIG003-008)
+//
+// @MX:ANCHOR: [AUTO] LoadConstitutionConfig — public loader consumed by Loader.Load(), CLI validation, and SPEC-V3R2-EXT-004 framework hook
+// @MX:REASON: fan_in >= 3: loadConstitutionSection (Loader.Load chain), standalone CLI consumer, EXT-004 enforcement hook
+// REQ-MIG003-002/003/004/009.
+func LoadConstitutionConfig(path string) (*ConstitutionConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			defaults := defaultConstitutionConfig()
+			return &defaults, nil
+		}
+		return nil, fmt.Errorf("LoadConstitutionConfig read %s: %w", path, err)
+	}
+
+	var wrapper constitutionFileWrapper
+	if err := yaml.Unmarshal(data, &wrapper); err != nil {
+		return nil, fmt.Errorf("LoadConstitutionConfig parse %s: %w", path, ErrInvalidYAML)
+	}
+
+	return &wrapper.Constitution, nil
+}
+
+// loadConstitutionSection loads the constitution section via the loadYAMLFile helper.
+// On absent file, defaults from NewDefaultConfig() remain (REQ-MIG003-004).
+func (l *Loader) loadConstitutionSection(dir string, cfg *Config) {
+	wrapper := &constitutionFileWrapper{Constitution: cfg.Constitution}
+	loaded, err := loadYAMLFile(dir, "constitution.yaml", wrapper)
+	if err != nil {
+		slog.Warn("failed to load constitution config, using defaults", "error", err)
+		return
+	}
+	if loaded {
+		cfg.Constitution = wrapper.Constitution
+		l.loadedSections["constitution"] = true
+	}
+}

--- a/internal/config/loader_constitution_test.go
+++ b/internal/config/loader_constitution_test.go
@@ -1,0 +1,101 @@
+package config
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+// TestLoadConstitutionConfig_ValidParse verifies that a valid constitution.yaml
+// is correctly parsed into ConstitutionConfig with all sub-fields populated.
+// Maps to: REQ-MIG003-001/002/003/007/009, AC-MIG003-02/07/08
+func TestLoadConstitutionConfig_ValidParse(t *testing.T) {
+	path := filepath.Join("testdata", "constitution-valid", "constitution.yaml")
+	cfg, err := LoadConstitutionConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConstitutionConfig(%q): unexpected error: %v", path, err)
+	}
+	if cfg == nil {
+		t.Fatal("LoadConstitutionConfig returned nil config")
+	}
+
+	// ApprovedLanguages
+	if len(cfg.ApprovedLanguages) == 0 {
+		t.Error("expected non-empty ApprovedLanguages")
+	}
+
+	// ForbiddenPatterns (aka ForbiddenLibraries per REQ-MIG003-009)
+	if len(cfg.ForbiddenPatterns) == 0 {
+		t.Error("expected non-empty ForbiddenPatterns (forbidden_patterns)")
+	}
+
+	// Architecture sub-fields
+	if len(cfg.Architecture.ForbiddenDependencies) == 0 {
+		t.Error("expected non-empty Architecture.ForbiddenDependencies")
+	}
+
+	// NamingConventions
+	if cfg.NamingConventions.Exported == "" {
+		t.Error("expected non-empty NamingConventions.Exported")
+	}
+
+	// Security
+	if len(cfg.Security.ForbiddenPractices) == 0 {
+		t.Error("expected non-empty Security.ForbiddenPractices")
+	}
+}
+
+// TestLoadConstitutionConfig_MissingFile_ReturnsDefaults verifies that when the
+// constitution.yaml file is absent, sensible defaults are returned (no error).
+// Maps to: REQ-MIG003-004, AC-MIG003-03
+func TestLoadConstitutionConfig_MissingFile_ReturnsDefaults(t *testing.T) {
+	path := filepath.Join("testdata", "nonexistent-dir", "constitution.yaml")
+	cfg, err := LoadConstitutionConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConstitutionConfig with absent file: expected no error, got: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("LoadConstitutionConfig returned nil config on missing file")
+	}
+}
+
+// TestLoadConstitutionConfig_Malformed_ReturnsErrInvalidYAML verifies that malformed
+// YAML returns an error wrapping ErrInvalidYAML.
+// Maps to: REQ-MIG003-003/007/008, AC-MIG003-04/07
+func TestLoadConstitutionConfig_Malformed_ReturnsErrInvalidYAML(t *testing.T) {
+	path := filepath.Join("testdata", "constitution-malformed", "constitution.yaml")
+	_, err := LoadConstitutionConfig(path)
+	if err == nil {
+		t.Fatal("expected error for malformed YAML, got nil")
+	}
+	if !errors.Is(err, ErrInvalidYAML) {
+		t.Errorf("expected errors.Is(err, ErrInvalidYAML), got: %v", err)
+	}
+}
+
+// TestLoadConstitutionConfig_ForbiddenLibrariesExposed verifies that the
+// ForbiddenPatterns (ForbiddenLibraries alias per REQ-MIG003-009) field is
+// exposed as a non-empty list when the YAML contains entries.
+// Maps to: REQ-MIG003-009, AC-MIG003-08
+func TestLoadConstitutionConfig_ForbiddenLibrariesExposed(t *testing.T) {
+	path := filepath.Join("testdata", "constitution-valid", "constitution.yaml")
+	cfg, err := LoadConstitutionConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConstitutionConfig: %v", err)
+	}
+	// ForbiddenPatterns is the field aliased as "ForbiddenLibraries" in godoc.
+	if len(cfg.ForbiddenPatterns) == 0 {
+		t.Error("REQ-MIG003-009: ForbiddenPatterns (forbidden_libraries alias) is empty; expected non-empty list for policy enforcement")
+	}
+	// Verify the list contains at least one meaningful entry.
+	found := false
+	for _, p := range cfg.ForbiddenPatterns {
+		if p != "" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("ForbiddenPatterns contains only empty strings")
+	}
+}

--- a/internal/config/loader_context.go
+++ b/internal/config/loader_context.go
@@ -1,0 +1,53 @@
+package config
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// LoadContextConfig reads context.yaml from the given file path and
+// returns a typed ContextConfig.
+//
+// Return semantics:
+//   - (cfg, nil) on successful parse
+//   - (defaultCfg, nil) on file-not-found (REQ-MIG003-004 graceful default)
+//   - (nil, ErrInvalidYAML) on malformed YAML
+//
+// @MX:ANCHOR: [AUTO] LoadContextConfig — public loader for context_search section, consumed by Loader.Load() and CLAUDE.md §16 runtime
+// @MX:REASON: fan_in >= 3: loadContextSection (Loader.Load chain), standalone CLI consumer, CLAUDE.md §16 Context Search consumer
+// REQ-MIG003-002/003/004/010.
+func LoadContextConfig(path string) (*ContextConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			defaults := defaultContextConfig()
+			return &defaults, nil
+		}
+		return nil, fmt.Errorf("LoadContextConfig read %s: %w", path, err)
+	}
+
+	var wrapper contextFileWrapper
+	if err := yaml.Unmarshal(data, &wrapper); err != nil {
+		return nil, fmt.Errorf("LoadContextConfig parse %s: %w", path, ErrInvalidYAML)
+	}
+
+	return &wrapper.ContextSearch, nil
+}
+
+// loadContextSection loads the context_search section via the loadYAMLFile helper.
+// Note: YAML file is "context.yaml" but top-level key is "context_search:" (research.md §3.2).
+func (l *Loader) loadContextSection(dir string, cfg *Config) {
+	wrapper := &contextFileWrapper{ContextSearch: cfg.ContextSearch}
+	loaded, err := loadYAMLFile(dir, "context.yaml", wrapper)
+	if err != nil {
+		slog.Warn("failed to load context config, using defaults", "error", err)
+		return
+	}
+	if loaded {
+		cfg.ContextSearch = wrapper.ContextSearch
+		l.loadedSections["context_search"] = true
+	}
+}

--- a/internal/config/loader_context_test.go
+++ b/internal/config/loader_context_test.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+// TestLoadContextConfig_ValidParse verifies that a valid context.yaml is parsed
+// correctly with token_budget and search fields populated.
+// Maps to: REQ-MIG003-001/002/003/007/010, AC-MIG003-02/07/09
+func TestLoadContextConfig_ValidParse(t *testing.T) {
+	path := filepath.Join("testdata", "context-valid", "context.yaml")
+	cfg, err := LoadContextConfig(path)
+	if err != nil {
+		t.Fatalf("LoadContextConfig(%q): unexpected error: %v", path, err)
+	}
+	if cfg == nil {
+		t.Fatal("LoadContextConfig returned nil config")
+	}
+
+	// REQ-MIG003-010: token_budget fields
+	if cfg.TokenBudget.MaxInjectionTokens != 5000 {
+		t.Errorf("TokenBudget.MaxInjectionTokens: want 5000, got %d", cfg.TokenBudget.MaxInjectionTokens)
+	}
+	if cfg.TokenBudget.SkipIfUsageAbove != 150000 {
+		t.Errorf("TokenBudget.SkipIfUsageAbove: want 150000, got %d", cfg.TokenBudget.SkipIfUsageAbove)
+	}
+
+	// REQ-MIG003-010: search.date_range_days (staleness_window_days alias)
+	if cfg.Search.DateRangeDays != 30 {
+		t.Errorf("Search.DateRangeDays: want 30, got %d", cfg.Search.DateRangeDays)
+	}
+}
+
+// TestLoadContextConfig_MissingFile_ReturnsDefaults verifies that an absent
+// context.yaml returns defaults with no error.
+// Maps to: REQ-MIG003-004, AC-MIG003-03
+func TestLoadContextConfig_MissingFile_ReturnsDefaults(t *testing.T) {
+	path := filepath.Join("testdata", "nonexistent-dir", "context.yaml")
+	cfg, err := LoadContextConfig(path)
+	if err != nil {
+		t.Fatalf("LoadContextConfig with absent file: expected no error, got: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("LoadContextConfig returned nil config on missing file")
+	}
+}
+
+// TestLoadContextConfig_Malformed_ReturnsErrInvalidYAML verifies that malformed
+// context.yaml returns an error wrapping ErrInvalidYAML.
+// Maps to: REQ-MIG003-003/007, AC-MIG003-04/07
+func TestLoadContextConfig_Malformed_ReturnsErrInvalidYAML(t *testing.T) {
+	path := filepath.Join("testdata", "context-malformed", "context.yaml")
+	_, err := LoadContextConfig(path)
+	if err == nil {
+		t.Fatal("expected error for malformed YAML, got nil")
+	}
+	if !errors.Is(err, ErrInvalidYAML) {
+		t.Errorf("expected errors.Is(err, ErrInvalidYAML), got: %v", err)
+	}
+}

--- a/internal/config/loader_design.go
+++ b/internal/config/loader_design.go
@@ -1,0 +1,73 @@
+package config
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// LoadDesignConfig reads design.yaml from the given file path and
+// returns a typed DesignConfig.
+//
+// Return semantics:
+//   - (cfg, nil) on successful parse + validation
+//   - (defaultCfg, nil) on file-not-found (REQ-MIG003-004 graceful default)
+//   - (nil, ErrInvalidYAML) on malformed YAML
+//   - (nil, ErrPassThresholdFloor) if gan_loop.pass_threshold < 0.60 (OQ2 decision)
+//
+// @MX:ANCHOR: [AUTO] LoadDesignConfig — public loader for design section with pass_threshold floor validation
+// @MX:REASON: fan_in >= 3: loadDesignSection (Loader.Load chain), standalone CLI consumer, GAN loop runtime sprint contract
+// REQ-MIG003-002/003/004/014.
+func LoadDesignConfig(path string) (*DesignConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			defaults := defaultDesignConfig()
+			return &defaults, nil
+		}
+		return nil, fmt.Errorf("LoadDesignConfig read %s: %w", path, err)
+	}
+
+	var wrapper designFileWrapper
+	if err := yaml.Unmarshal(data, &wrapper); err != nil {
+		return nil, fmt.Errorf("LoadDesignConfig parse %s: %w", path, ErrInvalidYAML)
+	}
+
+	cfg := &wrapper.Design
+
+	// Validate pass_threshold FROZEN floor 0.60 (OQ2: YES, reuse ErrPassThresholdFloor).
+	// Only validate when the field is explicitly set (non-zero).
+	// REQ-MIG003-014, design-constitution §11 GAN Loop Contract.
+	if cfg.GanLoop.PassThreshold > 0 && cfg.GanLoop.PassThreshold < 0.60 {
+		return nil, &ValidationError{
+			Field:   "gan_loop.pass_threshold",
+			Value:   cfg.GanLoop.PassThreshold,
+			Message: "below FROZEN floor 0.60 (design-constitution §11 GAN Loop Contract, SPEC-V3R2-CON-001)",
+			Wrapped: ErrPassThresholdFloor,
+		}
+	}
+
+	return cfg, nil
+}
+
+// loadDesignSection loads the design section via the loadYAMLFile helper.
+func (l *Loader) loadDesignSection(dir string, cfg *Config) {
+	wrapper := &designFileWrapper{Design: cfg.Design}
+	loaded, err := loadYAMLFile(dir, "design.yaml", wrapper)
+	if err != nil {
+		slog.Warn("failed to load design config, using defaults", "error", err)
+		return
+	}
+	if loaded {
+		// Apply pass_threshold validation even in Loader.Load() path.
+		if wrapper.Design.GanLoop.PassThreshold > 0 && wrapper.Design.GanLoop.PassThreshold < 0.60 {
+			slog.Warn("design.yaml gan_loop.pass_threshold below FROZEN floor 0.60; using defaults",
+				"value", wrapper.Design.GanLoop.PassThreshold)
+			return
+		}
+		cfg.Design = wrapper.Design
+		l.loadedSections["design"] = true
+	}
+}

--- a/internal/config/loader_design_test.go
+++ b/internal/config/loader_design_test.go
@@ -1,0 +1,84 @@
+package config
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestLoadDesignConfig_ValidParse verifies that a valid design.yaml is parsed
+// with gan_loop fields and sprint_contract populated.
+// Maps to: REQ-MIG003-001/002/003/007/014, AC-MIG003-02/07/11
+func TestLoadDesignConfig_ValidParse(t *testing.T) {
+	path := filepath.Join("testdata", "design-valid", "design.yaml")
+	cfg, err := LoadDesignConfig(path)
+	if err != nil {
+		t.Fatalf("LoadDesignConfig(%q): unexpected error: %v", path, err)
+	}
+	if cfg == nil {
+		t.Fatal("LoadDesignConfig returned nil config")
+	}
+
+	// REQ-MIG003-014: gan_loop.pass_threshold = 0.75
+	if cfg.GanLoop.PassThreshold != 0.75 {
+		t.Errorf("GanLoop.PassThreshold: want 0.75, got %f", cfg.GanLoop.PassThreshold)
+	}
+
+	// REQ-MIG003-014: gan_loop.max_iterations = 5
+	if cfg.GanLoop.MaxIterations != 5 {
+		t.Errorf("GanLoop.MaxIterations: want 5, got %d", cfg.GanLoop.MaxIterations)
+	}
+
+	// REQ-MIG003-014: sprint_contract.enabled = true
+	if !cfg.GanLoop.SprintContract.Enabled {
+		t.Error("GanLoop.SprintContract.Enabled: want true, got false")
+	}
+}
+
+// TestLoadDesignConfig_MissingFile_ReturnsDefaults verifies that an absent
+// design.yaml returns defaults with no error.
+// Maps to: REQ-MIG003-004, AC-MIG003-03
+func TestLoadDesignConfig_MissingFile_ReturnsDefaults(t *testing.T) {
+	path := filepath.Join("testdata", "nonexistent-dir", "design.yaml")
+	cfg, err := LoadDesignConfig(path)
+	if err != nil {
+		t.Fatalf("LoadDesignConfig with absent file: expected no error, got: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("LoadDesignConfig returned nil config on missing file")
+	}
+}
+
+// TestLoadDesignConfig_Malformed_ReturnsErrInvalidYAML verifies that malformed
+// design.yaml returns an error wrapping ErrInvalidYAML.
+// Maps to: REQ-MIG003-003/007, AC-MIG003-04/07
+func TestLoadDesignConfig_Malformed_ReturnsErrInvalidYAML(t *testing.T) {
+	tmpDir := t.TempDir()
+	malformedPath := filepath.Join(tmpDir, "design.yaml")
+	if err := os.WriteFile(malformedPath, []byte("design:\n  gan_loop: [\n"), 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	_, err := LoadDesignConfig(malformedPath)
+	if err == nil {
+		t.Fatal("expected error for malformed YAML, got nil")
+	}
+	if !errors.Is(err, ErrInvalidYAML) {
+		t.Errorf("expected errors.Is(err, ErrInvalidYAML), got: %v", err)
+	}
+}
+
+// TestLoadDesignConfig_PassThresholdFloorViolation verifies that a pass_threshold
+// below the FROZEN floor 0.60 returns ErrPassThresholdFloor.
+// Maps to: REQ-MIG003-014 (OQ2 decision: YES), AC-MIG003-11
+func TestLoadDesignConfig_PassThresholdFloorViolation(t *testing.T) {
+	path := filepath.Join("testdata", "design-pass-threshold-violation", "design.yaml")
+	_, err := LoadDesignConfig(path)
+	if err == nil {
+		t.Fatal("expected error for pass_threshold < 0.60, got nil")
+	}
+	if !errors.Is(err, ErrPassThresholdFloor) {
+		t.Errorf("expected errors.Is(err, ErrPassThresholdFloor), got: %v", err)
+	}
+}

--- a/internal/config/loader_interview.go
+++ b/internal/config/loader_interview.go
@@ -1,0 +1,52 @@
+package config
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// LoadInterviewConfig reads interview.yaml from the given file path and
+// returns a typed InterviewConfig.
+//
+// Return semantics:
+//   - (cfg, nil) on successful parse
+//   - (defaultCfg, nil) on file-not-found (REQ-MIG003-004 graceful default)
+//   - (nil, ErrInvalidYAML) on malformed YAML
+//
+// @MX:ANCHOR: [AUTO] LoadInterviewConfig — public loader for interview section, consumed by Loader.Load() and SPEC-V3R2-WF-003 discovery mode
+// @MX:REASON: fan_in >= 3: loadInterviewSection (Loader.Load chain), standalone CLI consumer, WF-003 discovery mode runtime
+// REQ-MIG003-002/003/004/011.
+func LoadInterviewConfig(path string) (*InterviewConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			defaults := defaultInterviewConfig()
+			return &defaults, nil
+		}
+		return nil, fmt.Errorf("LoadInterviewConfig read %s: %w", path, err)
+	}
+
+	var wrapper interviewFileWrapper
+	if err := yaml.Unmarshal(data, &wrapper); err != nil {
+		return nil, fmt.Errorf("LoadInterviewConfig parse %s: %w", path, ErrInvalidYAML)
+	}
+
+	return &wrapper.Interview, nil
+}
+
+// loadInterviewSection loads the interview section via the loadYAMLFile helper.
+func (l *Loader) loadInterviewSection(dir string, cfg *Config) {
+	wrapper := &interviewFileWrapper{Interview: cfg.Interview}
+	loaded, err := loadYAMLFile(dir, "interview.yaml", wrapper)
+	if err != nil {
+		slog.Warn("failed to load interview config, using defaults", "error", err)
+		return
+	}
+	if loaded {
+		cfg.Interview = wrapper.Interview
+		l.loadedSections["interview"] = true
+	}
+}

--- a/internal/config/loader_interview_test.go
+++ b/internal/config/loader_interview_test.go
@@ -1,0 +1,71 @@
+package config
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestLoadInterviewConfig_ValidParse verifies that a valid interview.yaml is parsed
+// with clarity_threshold, plan.max_rounds, and skip_conditions populated.
+// Maps to: REQ-MIG003-001/002/003/007/011, AC-MIG003-02/07/10
+func TestLoadInterviewConfig_ValidParse(t *testing.T) {
+	path := filepath.Join("testdata", "interview-valid", "interview.yaml")
+	cfg, err := LoadInterviewConfig(path)
+	if err != nil {
+		t.Fatalf("LoadInterviewConfig(%q): unexpected error: %v", path, err)
+	}
+	if cfg == nil {
+		t.Fatal("LoadInterviewConfig returned nil config")
+	}
+
+	// REQ-MIG003-011: clarity_threshold = 4
+	if cfg.ClarityThreshold != 4 {
+		t.Errorf("ClarityThreshold: want 4, got %d", cfg.ClarityThreshold)
+	}
+
+	// REQ-MIG003-011: plan.max_rounds = 5
+	if cfg.Plan.MaxRounds != 5 {
+		t.Errorf("Plan.MaxRounds: want 5, got %d", cfg.Plan.MaxRounds)
+	}
+
+	// REQ-MIG003-011: skip_conditions length = 3
+	if len(cfg.SkipConditions) != 3 {
+		t.Errorf("SkipConditions: want len=3, got %d", len(cfg.SkipConditions))
+	}
+}
+
+// TestLoadInterviewConfig_MissingFile_ReturnsDefaults verifies that an absent
+// interview.yaml returns defaults with no error.
+// Maps to: REQ-MIG003-004, AC-MIG003-03
+func TestLoadInterviewConfig_MissingFile_ReturnsDefaults(t *testing.T) {
+	path := filepath.Join("testdata", "interview-missing", "interview.yaml")
+	cfg, err := LoadInterviewConfig(path)
+	if err != nil {
+		t.Fatalf("LoadInterviewConfig with absent file: expected no error, got: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("LoadInterviewConfig returned nil config on missing file")
+	}
+}
+
+// TestLoadInterviewConfig_Malformed_ReturnsErrInvalidYAML verifies that a
+// missing/malformed interview.yaml from a malformed fixture returns ErrInvalidYAML.
+// Maps to: REQ-MIG003-003/007, AC-MIG003-04/07
+func TestLoadInterviewConfig_Malformed_ReturnsErrInvalidYAML(t *testing.T) {
+	// Write a temporary malformed file for this test
+	tmpDir := t.TempDir()
+	malformedPath := filepath.Join(tmpDir, "interview.yaml")
+	if err := os.WriteFile(malformedPath, []byte("interview:\n  clarity_threshold: [\n"), 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	_, err := LoadInterviewConfig(malformedPath)
+	if err == nil {
+		t.Fatal("expected error for malformed YAML, got nil")
+	}
+	if !errors.Is(err, ErrInvalidYAML) {
+		t.Errorf("expected errors.Is(err, ErrInvalidYAML), got: %v", err)
+	}
+}

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -488,6 +488,115 @@ func TestLoaderGitConventionDefaults(t *testing.T) {
 	}
 }
 
+// TestLoaderMIG003SectionsLoadedViaLoaderLoad verifies that the 4 new MIG-003
+// sections are correctly loaded when valid YAML files are present.
+// Covers the happy path of loadConstitutionSection / loadContextSection /
+// loadInterviewSection / loadDesignSection (T-MIG003-18).
+func TestLoaderMIG003SectionsLoadedViaLoaderLoad(t *testing.T) {
+	t.Parallel()
+	resetSunsetNoticeOnce() // avoid notice side-effects
+
+	tmpDir := t.TempDir()
+	sectionsDir := filepath.Join(tmpDir, ".moai", "config", "sections")
+	if err := os.MkdirAll(sectionsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	// Copy valid fixture files into the sections dir.
+	fixtures := map[string]string{
+		"constitution.yaml": filepath.Join("testdata", "constitution-valid", "constitution.yaml"),
+		"context.yaml":      filepath.Join("testdata", "context-valid", "context.yaml"),
+		"interview.yaml":    filepath.Join("testdata", "interview-valid", "interview.yaml"),
+		"design.yaml":       filepath.Join("testdata", "design-valid", "design.yaml"),
+	}
+	for dst, src := range fixtures {
+		data, err := os.ReadFile(src)
+		if err != nil {
+			t.Fatalf("read fixture %s: %v", src, err)
+		}
+		if err := os.WriteFile(filepath.Join(sectionsDir, dst), data, 0o644); err != nil {
+			t.Fatalf("write %s: %v", dst, err)
+		}
+	}
+
+	loader := NewLoader()
+	cfg, err := loader.Load(filepath.Join(tmpDir, ".moai"))
+	if err != nil {
+		t.Fatalf("Loader.Load(): %v", err)
+	}
+
+	// Verify all 4 sections loaded.
+	sections := loader.LoadedSections()
+	for _, key := range []string{"constitution", "context_search", "interview", "design"} {
+		if !sections[key] {
+			t.Errorf("section %q not marked as loaded", key)
+		}
+	}
+
+	// Spot-check values.
+	if len(cfg.Constitution.ForbiddenPatterns) == 0 {
+		t.Error("Constitution.ForbiddenPatterns: expected non-empty")
+	}
+	if cfg.ContextSearch.TokenBudget.MaxInjectionTokens != 5000 {
+		t.Errorf("ContextSearch.TokenBudget.MaxInjectionTokens: want 5000, got %d",
+			cfg.ContextSearch.TokenBudget.MaxInjectionTokens)
+	}
+	if cfg.Interview.ClarityThreshold != 4 {
+		t.Errorf("Interview.ClarityThreshold: want 4, got %d", cfg.Interview.ClarityThreshold)
+	}
+	if cfg.Design.GanLoop.PassThreshold != 0.75 {
+		t.Errorf("Design.GanLoop.PassThreshold: want 0.75, got %f", cfg.Design.GanLoop.PassThreshold)
+	}
+}
+
+// TestLoaderMIG003MalformedSectionsUseDefaults verifies that when a MIG-003 section
+// YAML is malformed, the loader skips it (with slog.Warn) and uses defaults.
+// Covers the slog.Warn branch in loadConstitutionSection / loadContextSection /
+// loadInterviewSection / loadDesignSection.
+func TestLoaderMIG003MalformedSectionsUseDefaults(t *testing.T) {
+	t.Parallel()
+	resetSunsetNoticeOnce()
+
+	for _, tc := range []struct {
+		file    string
+		section string
+	}{
+		{"constitution.yaml", "constitution"},
+		{"context.yaml", "context_search"},
+		{"interview.yaml", "interview"},
+		{"design.yaml", "design"},
+	} {
+		tc := tc
+		t.Run(tc.file, func(t *testing.T) {
+			t.Parallel()
+			resetSunsetNoticeOnce()
+
+			tmpDir := t.TempDir()
+			sectionsDir := filepath.Join(tmpDir, ".moai", "config", "sections")
+			if err := os.MkdirAll(sectionsDir, 0o755); err != nil {
+				t.Fatalf("MkdirAll: %v", err)
+			}
+			// Write malformed YAML for this section.
+			malformed := []byte(tc.file[:len(tc.file)-5] + ":\n  broken: [\n")
+			if err := os.WriteFile(filepath.Join(sectionsDir, tc.file), malformed, 0o644); err != nil {
+				t.Fatalf("write %s: %v", tc.file, err)
+			}
+
+			loader := NewLoader()
+			_, err := loader.Load(filepath.Join(tmpDir, ".moai"))
+			if err != nil {
+				t.Fatalf("Loader.Load() should not error on malformed section: %v", err)
+			}
+
+			// Section should NOT be marked loaded (slog.Warn path taken).
+			sections := loader.LoadedSections()
+			if sections[tc.section] {
+				t.Errorf("section %q should NOT be loaded for malformed YAML", tc.section)
+			}
+		})
+	}
+}
+
 // TestLoadHarnessConfigValid는 per_iteration 값을 가진 유효한 harness 설정이
 // 오류 없이 로드되는지 검증합니다 (AC-HRN-002-04).
 func TestLoadHarnessConfigValid(t *testing.T) {

--- a/internal/config/sunset_notice.go
+++ b/internal/config/sunset_notice.go
@@ -1,0 +1,38 @@
+package config
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// sunsetNoticeOnce guards the once-per-process DORMANT notice emission.
+// REQ-MIG003-018: emitted at most once per process lifetime.
+var sunsetNoticeOnce sync.Once
+
+// emitSunsetDormantNotice emits a one-shot session log per REQ-MIG003-018.
+// Guarded by sync.Once so it fires at most once per process lifetime.
+// The notice is advisory only — it reminds future maintainers that
+// SunsetConfig is template-only and has no runtime hot path.
+//
+// @MX:NOTE: [AUTO] DORMANT notice helper — fires when sunset.yaml exists,
+// reminds future maintainers that SunsetConfig is template-only.
+// REQ-MIG003-018, AC-MIG003-15.
+func emitSunsetDormantNotice(sectionsDir string) {
+	sunsetNoticeOnce.Do(func() {
+		path := filepath.Join(sectionsDir, "sunset.yaml")
+		if _, err := os.Stat(path); err == nil {
+			slog.Info("SUNSET_CONFIG_DORMANT_NOTICE",
+				"spec", "SPEC-V3R2-MIG-003 REQ-018",
+				"yaml_path", path,
+				"advice", "SunsetConfig has no runtime hot path; activation requires a new SPEC")
+		}
+	})
+}
+
+// resetSunsetNoticeOnce resets the once guard. FOR TESTING ONLY.
+// Tests that need to verify the notice fires must call this before Loader.Load().
+func resetSunsetNoticeOnce() {
+	sunsetNoticeOnce = sync.Once{}
+}

--- a/internal/config/sunset_notice_test.go
+++ b/internal/config/sunset_notice_test.go
@@ -1,0 +1,106 @@
+package config
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// bufferHandler is a minimal slog.Handler that captures log records.
+type bufferHandler struct {
+	buf *bytes.Buffer
+}
+
+func newBufferHandler() (*bufferHandler, *bytes.Buffer) {
+	buf := &bytes.Buffer{}
+	return &bufferHandler{buf: buf}, buf
+}
+
+func (h *bufferHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+
+func (h *bufferHandler) Handle(_ context.Context, r slog.Record) error {
+	h.buf.WriteString(r.Message)
+	h.buf.WriteByte('\n')
+	return nil
+}
+
+func (h *bufferHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+func (h *bufferHandler) WithGroup(_ string) slog.Handler      { return h }
+
+// TestSunsetNotice_FiresOnce verifies that SUNSET_CONFIG_DORMANT_NOTICE is emitted
+// exactly once even when Loader.Load() is called twice with a sunset.yaml present.
+// REQ-MIG003-018, AC-MIG003-15.
+func TestSunsetNotice_FiresOnce(t *testing.T) {
+	// Reset the sync.Once guard so this test runs independently.
+	resetSunsetNoticeOnce()
+
+	// Set up a sections dir that contains sunset.yaml.
+	tmpDir := t.TempDir()
+	sectionsDir := filepath.Join(tmpDir, "moai", "config", "sections")
+	if err := os.MkdirAll(sectionsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	sunsetPath := filepath.Join(sectionsDir, "sunset.yaml")
+	if err := os.WriteFile(sunsetPath, []byte("sunset:\n  enabled: true\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile sunset.yaml: %v", err)
+	}
+
+	// Install a capturing logger.
+	handler, buf := newBufferHandler()
+	origLogger := slog.Default()
+	slog.SetDefault(slog.New(handler))
+	defer slog.SetDefault(origLogger)
+
+	moaiDir := filepath.Join(tmpDir, "moai")
+
+	// First Loader.Load() call.
+	loader1 := NewLoader()
+	resetSunsetNoticeOnce() // ensure the once is fresh before first call
+	_, _ = loader1.Load(moaiDir)
+
+	// Second Loader.Load() call — notice must NOT fire again.
+	loader2 := NewLoader()
+	_, _ = loader2.Load(moaiDir)
+
+	// Count occurrences.
+	output := buf.String()
+	count := strings.Count(output, "SUNSET_CONFIG_DORMANT_NOTICE")
+	if count != 1 {
+		t.Errorf("SUNSET_CONFIG_DORMANT_NOTICE: expected exactly 1 occurrence, got %d\nlog output:\n%s",
+			count, output)
+	}
+}
+
+// TestSunsetNotice_AbsentFileNoNotice verifies that when sunset.yaml is absent,
+// no SUNSET_CONFIG_DORMANT_NOTICE is emitted.
+// REQ-MIG003-018, AC-MIG003-15.
+func TestSunsetNotice_AbsentFileNoNotice(t *testing.T) {
+	// Reset the sync.Once guard.
+	resetSunsetNoticeOnce()
+
+	// Set up a sections dir WITHOUT sunset.yaml.
+	tmpDir := t.TempDir()
+	sectionsDir := filepath.Join(tmpDir, "moai", "config", "sections")
+	if err := os.MkdirAll(sectionsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	// Install a capturing logger.
+	handler, buf := newBufferHandler()
+	origLogger := slog.Default()
+	slog.SetDefault(slog.New(handler))
+	defer slog.SetDefault(origLogger)
+
+	moaiDir := filepath.Join(tmpDir, "moai")
+	loader := NewLoader()
+	_, _ = loader.Load(moaiDir)
+
+	output := buf.String()
+	if strings.Contains(output, "SUNSET_CONFIG_DORMANT_NOTICE") {
+		t.Errorf("expected no SUNSET_CONFIG_DORMANT_NOTICE when sunset.yaml is absent, got:\n%s", output)
+	}
+}

--- a/internal/config/testdata/constitution-malformed/constitution.yaml
+++ b/internal/config/testdata/constitution-malformed/constitution.yaml
@@ -1,0 +1,4 @@
+constitution:
+    approved_frameworks:
+        - cobra
+    forbidden_patterns: [

--- a/internal/config/testdata/constitution-valid/constitution.yaml
+++ b/internal/config/testdata/constitution-valid/constitution.yaml
@@ -1,0 +1,31 @@
+constitution:
+    approved_frameworks:
+        - cobra
+        - viper
+    approved_languages:
+        - go
+    architecture:
+        forbidden_dependencies:
+            - circular imports
+            - direct template access from CLI handlers
+        patterns:
+            - clean-architecture
+            - repository-pattern
+    forbidden_patterns:
+        - global mutable state
+        - init() with side effects
+        - panic() in library code
+        - raw SQL without parameterized queries
+    naming_conventions:
+        exported: PascalCase
+        files: snake_case.go
+        packages: lowercase, single word
+    performance:
+        max_memory_mb: null
+        max_response_time_ms: null
+    security:
+        forbidden_practices:
+            - hardcoded credentials
+            - os.Exit in library code
+        required_checks:
+            - input-validation

--- a/internal/config/testdata/context-malformed/context.yaml
+++ b/internal/config/testdata/context-malformed/context.yaml
@@ -1,0 +1,2 @@
+context_search:
+    token_budget: {

--- a/internal/config/testdata/context-valid/context.yaml
+++ b/internal/config/testdata/context-valid/context.yaml
@@ -1,0 +1,19 @@
+context_search:
+    auto_detect:
+        enabled: true
+    enabled: true
+    memory_integration:
+        enabled: true
+        include_in_context: true
+        priority_over_search: true
+    performance:
+        cache_ttl_seconds: 300
+        timeout_seconds: 10
+    search:
+        date_range_days: 30
+        max_results: 5
+        max_tokens_per_result: 1000
+        project_scope_only: true
+    token_budget:
+        max_injection_tokens: 5000
+        skip_if_usage_above: 150000

--- a/internal/config/testdata/design-pass-threshold-violation/design.yaml
+++ b/internal/config/testdata/design-pass-threshold-violation/design.yaml
@@ -1,0 +1,15 @@
+design:
+    enabled: true
+    evaluator:
+        memory_scope: per_iteration
+    gan_loop:
+        escalation_after: 3
+        improvement_threshold: 0.05
+        max_iterations: 5
+        pass_threshold: 0.45
+        sprint_contract:
+            artifact_dir: .moai/sprints
+            enabled: true
+            max_negotiation_rounds: 2
+        strict_mode: false
+    version: 1.0.0

--- a/internal/config/testdata/design-valid/design.yaml
+++ b/internal/config/testdata/design-valid/design.yaml
@@ -1,0 +1,59 @@
+design:
+    adaptation:
+        confidence_threshold: 0.7
+        enabled: true
+        iteration_limits:
+            builder: 3
+            copywriter: 3
+            designer: 2
+        min_projects_for_adaptation: 5
+    brand_context:
+        dir: .moai/project/brand
+        interview_on_first_run: true
+    claude_design:
+        enabled: true
+        fallback_path: code_based
+        supported_bundle_versions:
+            - "1.0"
+    default_framework: next.js
+    design_docs:
+        auto_load_on_design_command: true
+        dir: .moai/design
+        priority:
+            - spec
+            - system
+            - research
+            - pencil-plan
+        token_budget: 20000
+    enabled: true
+    evaluator:
+        memory_scope: per_iteration
+    evolution:
+        archive_after_evolve: true
+        auto_evolve_threshold: 3
+        cooldown_hours: 24
+        graduation_criteria:
+            consistency_ratio: 0.8
+            minimum_confidence: 0.8
+            minimum_observations: 5
+            staleness_window_days: 30
+        max_active_learnings: 50
+        max_evolution_rate_per_week: 3
+        require_approval: true
+    figma:
+        enabled: false
+    gan_loop:
+        escalation_after: 3
+        improvement_threshold: 0.05
+        max_iterations: 5
+        pass_threshold: 0.75
+        sprint_contract:
+            artifact_dir: .moai/sprints
+            enabled: true
+            max_negotiation_rounds: 2
+            optional_harness_levels:
+                - standard
+            required_harness_levels:
+                - thorough
+        strict_mode: false
+    version: 1.0.0

--- a/internal/config/testdata/interview-valid/interview.yaml
+++ b/internal/config/testdata/interview-valid/interview.yaml
@@ -1,0 +1,13 @@
+interview:
+    clarity_threshold: 4
+    enabled: true
+    plan:
+        max_rounds: 5
+        questions_per_round: 3
+    project:
+        max_rounds: 3
+        questions_per_round: 3
+    skip_conditions:
+        - resume_spec_id_present
+        - skip_interview_flag
+        - technical_keywords_gte_5

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -30,6 +30,11 @@ type Config struct {
 	Sunset        SunsetConfig               `yaml:"sunset"`
 	Research      ResearchConfig             `yaml:"research"`
 	Session       SessionConfig              `yaml:"session"` // SPEC-V3R2-RT-004 REQ-022: STALE_SECONDS
+	// MIG-003: 4 new sections loaded by Loader.Load() (REQ-MIG003-001)
+	Constitution  ConstitutionConfig `yaml:"constitution"`
+	ContextSearch ContextConfig      `yaml:"context_search"`
+	Interview     InterviewConfig    `yaml:"interview"`
+	Design        DesignConfig       `yaml:"design"`
 }
 
 // GitStrategyConfig represents the git strategy configuration section.
@@ -308,6 +313,11 @@ func (g *GateConfig) TestTimeoutDuration() time.Duration {
 
 // SunsetConfig defines the Build-to-Delete framework configuration.
 // Quality gates that consistently pass can be relaxed over time.
+//
+// @MX:NOTE: [AUTO] DORMANT — struct schema defined but no runtime hot path
+// enforces sunset conditions. Activation deferred to a future SPEC.
+// Do NOT add LoadSunsetConfig until activation SPEC is filed.
+// REQ-MIG003-006 ↔ REQ-MIG003-015 reference.
 type SunsetConfig struct {
 	// Enabled controls whether sunset tracking is active.
 	Enabled    bool              `yaml:"enabled"`
@@ -551,9 +561,253 @@ type EvaluatorConfig struct {
 	MustPassDimensions []string `yaml:"must_pass_dimensions,omitempty"`
 }
 
+// ConstitutionConfig는 constitution.yaml 최상위 설정 구조체입니다.
+// @MX:ANCHOR: [AUTO] constitution.yaml 전체 스키마의 Go 표현
+// @MX:REASON: fan_in >= 3 (LoadConstitutionConfig, Loader.Load, SPEC-V3R2-EXT-004 hook consumer)
+//
+// Hot path: SPEC-V3R2-EXT-004 framework optional hook for forbidden-library policy enforcement.
+// ForbiddenPatterns is exposed as the "ForbiddenLibraries" list per REQ-MIG003-009.
+type ConstitutionConfig struct {
+	ApprovedFrameworks []string                   `yaml:"approved_frameworks"`
+	ApprovedLanguages  []string                   `yaml:"approved_languages"`
+	Architecture       ConstitutionArchitecture   `yaml:"architecture"`
+	ForbiddenPatterns  []string                   `yaml:"forbidden_patterns"`
+	NamingConventions  ConstitutionNaming         `yaml:"naming_conventions"`
+	Performance        ConstitutionPerformance    `yaml:"performance"`
+	Security           ConstitutionSecurity       `yaml:"security"`
+}
+
+// ConstitutionArchitecture holds architecture constraint fields.
+type ConstitutionArchitecture struct {
+	ForbiddenDependencies []string `yaml:"forbidden_dependencies"`
+	Patterns              []string `yaml:"patterns"`
+}
+
+// ConstitutionNaming holds naming convention fields.
+type ConstitutionNaming struct {
+	Exported string `yaml:"exported"`
+	Files    string `yaml:"files"`
+	Packages string `yaml:"packages"`
+}
+
+// ConstitutionPerformance holds performance threshold fields.
+type ConstitutionPerformance struct {
+	MaxMemoryMB        *int `yaml:"max_memory_mb"`
+	MaxResponseTimeMS  *int `yaml:"max_response_time_ms"`
+}
+
+// ConstitutionSecurity holds security policy fields.
+type ConstitutionSecurity struct {
+	ForbiddenPractices []string `yaml:"forbidden_practices"`
+	RequiredChecks     []string `yaml:"required_checks"`
+}
+
+// ContextConfig는 context.yaml (context_search:) 최상위 설정 구조체입니다.
+// @MX:ANCHOR: [AUTO] context_search section Go 표현
+// @MX:REASON: fan_in >= 3 (LoadContextConfig, Loader.Load, CLAUDE.md §16 Context Search consumer)
+//
+// Hot path: CLAUDE.md §16 Context Search Protocol — token_budget.max_injection_tokens
+// and token_budget.skip_if_usage_above gate context injection.
+// search.date_range_days is the "staleness_window_days" alias per REQ-MIG003-010.
+type ContextConfig struct {
+	AutoDetect        ContextAutoDetect        `yaml:"auto_detect"`
+	Enabled           bool                     `yaml:"enabled"`
+	MemoryIntegration ContextMemoryIntegration `yaml:"memory_integration"`
+	Performance       ContextPerformance       `yaml:"performance"`
+	Search            ContextSearch            `yaml:"search"`
+	TokenBudget       ContextTokenBudget       `yaml:"token_budget"`
+}
+
+// ContextAutoDetect holds auto-detection settings.
+type ContextAutoDetect struct {
+	Enabled bool `yaml:"enabled"`
+}
+
+// ContextMemoryIntegration holds memory integration settings.
+type ContextMemoryIntegration struct {
+	Enabled          bool `yaml:"enabled"`
+	IncludeInContext bool `yaml:"include_in_context"`
+	PriorityOverSearch bool `yaml:"priority_over_search"`
+}
+
+// ContextPerformance holds performance settings.
+type ContextPerformance struct {
+	CacheTTLSeconds int `yaml:"cache_ttl_seconds"`
+	TimeoutSeconds  int `yaml:"timeout_seconds"`
+}
+
+// ContextSearch holds search configuration fields.
+// DateRangeDays is aliased as "staleness_window_days" in spec.md (REQ-MIG003-010).
+type ContextSearch struct {
+	DateRangeDays      int  `yaml:"date_range_days"`
+	MaxResults         int  `yaml:"max_results"`
+	MaxTokensPerResult int  `yaml:"max_tokens_per_result"`
+	ProjectScopeOnly   bool `yaml:"project_scope_only"`
+}
+
+// ContextTokenBudget holds token budget fields consumed by CLAUDE.md §16.
+type ContextTokenBudget struct {
+	MaxInjectionTokens int `yaml:"max_injection_tokens"`
+	SkipIfUsageAbove   int `yaml:"skip_if_usage_above"`
+}
+
+// InterviewConfig는 interview.yaml 최상위 설정 구조체입니다.
+// @MX:ANCHOR: [AUTO] interview section Go 표현
+// @MX:REASON: fan_in >= 3 (LoadInterviewConfig, Loader.Load, SPEC-V3R2-WF-003 discovery mode)
+//
+// Hot path: SPEC-V3R2-WF-003 discovery mode consumes clarity_threshold, plan.max_rounds,
+// plan.questions_per_round, and skip_conditions to control Socratic interview behavior.
+type InterviewConfig struct {
+	ClarityThreshold int            `yaml:"clarity_threshold"`
+	Enabled          bool           `yaml:"enabled"`
+	Plan             InterviewMode  `yaml:"plan"`
+	Project          InterviewMode  `yaml:"project"`
+	SkipConditions   []string       `yaml:"skip_conditions"`
+}
+
+// InterviewMode holds per-mode interview settings.
+type InterviewMode struct {
+	MaxRounds        int `yaml:"max_rounds"`
+	QuestionsPerRound int `yaml:"questions_per_round"`
+}
+
+// DesignConfig는 design.yaml 최상위 설정 구조체입니다.
+// @MX:ANCHOR: [AUTO] design section Go 표현
+// @MX:REASON: fan_in >= 3 (LoadDesignConfig, Loader.Load, GAN loop runtime sprint contract consumer)
+//
+// Hot path: GAN loop runtime consumes gan_loop.pass_threshold (FROZEN floor 0.60),
+// gan_loop.sprint_contract.enabled, and adaptation.iteration_limits.
+// Note: adaptation.iteration_limits is the Go field for spec.md's conceptual "phase_weights" (REQ-MIG003-014 OQ4).
+type DesignConfig struct {
+	Adaptation      DesignAdaptation   `yaml:"adaptation"`
+	BrandContext    DesignBrandContext  `yaml:"brand_context"`
+	ClaudeDesign    DesignClaudeDesign  `yaml:"claude_design"`
+	DefaultFramework string             `yaml:"default_framework"`
+	DesignDocs      DesignDocs         `yaml:"design_docs"`
+	Enabled         bool               `yaml:"enabled"`
+	Evaluator       DesignEvaluator    `yaml:"evaluator"`
+	Evolution       DesignEvolution    `yaml:"evolution"`
+	Figma           DesignFigma        `yaml:"figma"`
+	GanLoop         DesignGanLoop      `yaml:"gan_loop"`
+	Version         string             `yaml:"version"`
+}
+
+// DesignAdaptation holds pipeline adaptation settings.
+type DesignAdaptation struct {
+	ConfidenceThreshold       float64                   `yaml:"confidence_threshold"`
+	Enabled                   bool                      `yaml:"enabled"`
+	IterationLimits            DesignIterationLimits    `yaml:"iteration_limits"`
+	MinProjectsForAdaptation  int                       `yaml:"min_projects_for_adaptation"`
+}
+
+// DesignIterationLimits holds per-role iteration limit settings.
+type DesignIterationLimits struct {
+	Builder    int `yaml:"builder"`
+	Copywriter int `yaml:"copywriter"`
+	Designer   int `yaml:"designer"`
+}
+
+// DesignBrandContext holds brand context directory settings.
+type DesignBrandContext struct {
+	Dir                string `yaml:"dir"`
+	InterviewOnFirstRun bool   `yaml:"interview_on_first_run"`
+}
+
+// DesignClaudeDesign holds Claude Design import settings.
+type DesignClaudeDesign struct {
+	Enabled                 bool     `yaml:"enabled"`
+	FallbackPath            string   `yaml:"fallback_path"`
+	SupportedBundleVersions []string `yaml:"supported_bundle_versions"`
+}
+
+// DesignDocs holds design document auto-loading settings.
+type DesignDocs struct {
+	AutoLoadOnDesignCommand bool     `yaml:"auto_load_on_design_command"`
+	Dir                     string   `yaml:"dir"`
+	Priority                []string `yaml:"priority"`
+	TokenBudget             int      `yaml:"token_budget"`
+}
+
+// DesignEvaluator holds evaluator configuration for design pipeline.
+// memory_scope is treated as a free string here (not FROZEN-enforced;
+// that enforcement stays in LoadHarnessConfig per plan.md §11.4).
+type DesignEvaluator struct {
+	MemoryScope string `yaml:"memory_scope"`
+}
+
+// DesignEvolution holds evolution and self-learning settings.
+type DesignEvolution struct {
+	ArchiveAfterEvolve      bool                       `yaml:"archive_after_evolve"`
+	AutoEvolveThreshold     int                        `yaml:"auto_evolve_threshold"`
+	CooldownHours           int                        `yaml:"cooldown_hours"`
+	GraduationCriteria      DesignGraduationCriteria   `yaml:"graduation_criteria"`
+	MaxActiveLearnings      int                        `yaml:"max_active_learnings"`
+	MaxEvolutionRatePerWeek int                        `yaml:"max_evolution_rate_per_week"`
+	RequireApproval         bool                       `yaml:"require_approval"`
+}
+
+// DesignGraduationCriteria holds graduation thresholds for learnings.
+type DesignGraduationCriteria struct {
+	ConsistencyRatio    float64 `yaml:"consistency_ratio"`
+	MinimumConfidence   float64 `yaml:"minimum_confidence"`
+	MinimumObservations int     `yaml:"minimum_observations"`
+	StalenessWindowDays int     `yaml:"staleness_window_days"`
+}
+
+// DesignFigma holds Figma integration settings.
+type DesignFigma struct {
+	Enabled bool `yaml:"enabled"`
+}
+
+// DesignGanLoop holds GAN loop configuration.
+// PassThreshold is validated against the FROZEN floor 0.60 by LoadDesignConfig.
+// REQ-MIG003-014, OQ2 decision: enforce floor in loader.
+type DesignGanLoop struct {
+	EscalationAfter     int                  `yaml:"escalation_after"`
+	ImprovementThreshold float64             `yaml:"improvement_threshold"`
+	MaxIterations       int                  `yaml:"max_iterations"`
+	PassThreshold       float64              `yaml:"pass_threshold"`
+	SprintContract      DesignSprintContract `yaml:"sprint_contract"`
+	StrictMode          bool                 `yaml:"strict_mode"`
+}
+
+// DesignSprintContract holds sprint contract configuration.
+type DesignSprintContract struct {
+	ArtifactDir             string   `yaml:"artifact_dir"`
+	Enabled                 bool     `yaml:"enabled"`
+	MaxNegotiationRounds    int      `yaml:"max_negotiation_rounds"`
+	OptionalHarnessLevels   []string `yaml:"optional_harness_levels"`
+	RequiredHarnessLevels   []string `yaml:"required_harness_levels"`
+}
+
 // harnessFileWrapper는 harness.yaml 파일 언마샬링용 래퍼입니다.
 type harnessFileWrapper struct {
 	Harness HarnessConfig `yaml:"harness"`
+}
+
+// MIG-003 wrapper types for the 4 new section files.
+
+// constitutionFileWrapper는 constitution.yaml 파일 언마샬링용 래퍼입니다.
+// Note: Both constitution.yaml and quality.yaml use top-level key "constitution:".
+// They are disambiguated by filename in loadYAMLFile (REQ-MIG003 risk §11.1).
+type constitutionFileWrapper struct {
+	Constitution ConstitutionConfig `yaml:"constitution"`
+}
+
+// contextFileWrapper는 context.yaml 파일 언마샬링용 래퍼입니다.
+// context.yaml uses top-level key "context_search:" (NOT "context:").
+type contextFileWrapper struct {
+	ContextSearch ContextConfig `yaml:"context_search"`
+}
+
+// interviewFileWrapper는 interview.yaml 파일 언마샬링용 래퍼입니다.
+type interviewFileWrapper struct {
+	Interview InterviewConfig `yaml:"interview"`
+}
+
+// designFileWrapper는 design.yaml 파일 언마샬링용 래퍼입니다.
+type designFileWrapper struct {
+	Design DesignConfig `yaml:"design"`
 }
 
 // YAML file wrapper types for proper unmarshaling with top-level keys.

--- a/internal/config/types_test.go
+++ b/internal/config/types_test.go
@@ -1,6 +1,9 @@
 package config
 
 import (
+	"os"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/modu-ai/moai-adk/pkg/models"
@@ -382,5 +385,58 @@ func TestSecuritySandbox_Fields(t *testing.T) {
 	}
 	if ss.DockerImage != "moai/sandbox:v1" {
 		t.Errorf("SecuritySandbox.DockerImage: got %q, want %q", ss.DockerImage, "moai/sandbox:v1")
+	}
+}
+
+// T-MIG003-05: TestSunsetConfig_DORMANT_GodocMarker verifies that the godoc block
+// before type SunsetConfig struct contains the DORMANT literal and the
+// "Activation deferred to a future SPEC" phrase.
+// Maps to: REQ-MIG003-006/015, AC-MIG003-06
+func TestSunsetConfig_DORMANT_GodocMarker(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile("types.go")
+	if err != nil {
+		t.Fatalf("os.ReadFile(types.go): %v", err)
+	}
+
+	content := string(data)
+
+	// Find the position of the struct declaration
+	structDecl := "type SunsetConfig struct"
+	idx := strings.Index(content, structDecl)
+	if idx < 0 {
+		t.Fatalf("types.go does not contain %q", structDecl)
+	}
+
+	// Extract the 500 chars before the struct declaration (should contain the godoc)
+	start := idx - 500
+	if start < 0 {
+		start = 0
+	}
+	preceding := content[start:idx]
+
+	if !strings.Contains(preceding, "DORMANT") {
+		t.Errorf("godoc before SunsetConfig does not contain 'DORMANT'\npreceding text:\n%s", preceding)
+	}
+	if !strings.Contains(preceding, "Activation deferred to a future SPEC") {
+		t.Errorf("godoc before SunsetConfig does not contain 'Activation deferred to a future SPEC'\npreceding text:\n%s", preceding)
+	}
+}
+
+// T-MIG003-05: TestRootConfig_HasFourNewSectionFields verifies via reflection that
+// the root Config struct exposes the 4 new section fields.
+// Maps to: REQ-MIG003-001, AC-MIG003-01
+func TestRootConfig_HasFourNewSectionFields(t *testing.T) {
+	t.Parallel()
+
+	required := []string{"Constitution", "ContextSearch", "Interview", "Design"}
+	cfgType := reflect.TypeOf(Config{})
+
+	for _, fieldName := range required {
+		_, ok := cfgType.FieldByName(fieldName)
+		if !ok {
+			t.Errorf("Config struct missing field %q (REQ-MIG003-001)", fieldName)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- **4 new Go config loaders** for previously unloaded YAML sections: `constitution.yaml`, `context.yaml`, `interview.yaml`, `design.yaml` (constitution/context_search/interview/design) with `@MX:ANCHOR` tags, typed structs, defaults, and unit tests.
- **2 CI guard tests** locking the contract: `YAML_SECTION_NO_LOADER` (audit_loader_completeness_test.go) + `CONFIG_STRUCT_YAML_MISMATCH` (audit_struct_yaml_symmetry_test.go).
- **SunsetConfig DORMANT formalization**: `@MX:NOTE: [AUTO] DORMANT` godoc marker + once-per-session `SUNSET_CONFIG_DORMANT_NOTICE` slog.Info via `sunset_notice.go` + `sync.Once`.
- **`ErrPassThresholdFloor` sentinel reuse**: `LoadDesignConfig` validates `gan_loop.pass_threshold >= 0.60` (OQ2 YES decision).
- **settings-management.md docs**: 5-step "Adding a new YAML section" procedure + full section-loader inventory table.
- **HRN-001 reconciliation**: `harness.yaml` dedicated loader stays outside `Loader.Load()` by design; acknowledged in `acknowledgedDedicatedLoaders` allowlist.

## Test plan

- [x] `go test ./internal/config/... -count=1` → 0 fail (includes all 15 AC test cases)
- [x] `golangci-lint run ./internal/config/...` → 0 issues
- [x] `make build` → 0 errors
- [x] AC-MIG003-01~15 all PASS (see task log below)
- [x] AC-MIG003-12 (YAML_SECTION_NO_LOADER) negative case: adding a sentinel YAML without loader causes test failure with expected message
- [x] AC-MIG003-14 (CONFIG_STRUCT_YAML_MISMATCH) negative case: adding bogus Go field without YAML causes test failure

## AC Verification Results

| AC | REQ | Status |
|---|---|---|
| AC-MIG003-01 | 4 new structs in types.go | PASS |
| AC-MIG003-02 | 4 new loader functions | PASS |
| AC-MIG003-03 | Defaults on absent file | PASS |
| AC-MIG003-04 | Malformed → ErrInvalidYAML | PASS |
| AC-MIG003-05 | Godoc hot path documented | PASS |
| AC-MIG003-06 | SunsetConfig DORMANT marker | PASS |
| AC-MIG003-07 | Unit tests valid/missing/malformed | PASS |
| AC-MIG003-08 | ForbiddenPatterns exposed | PASS |
| AC-MIG003-09 | ContextConfig token_budget fields | PASS |
| AC-MIG003-10 | InterviewConfig clarity_threshold + max_rounds | PASS |
| AC-MIG003-11 | DesignConfig sprint_contract + iteration_limits | PASS |
| AC-MIG003-12 | YAML_SECTION_NO_LOADER CI guard | PASS |
| AC-MIG003-13 | LOADER_HARDCODE_VIOLATION (grep audit) | PASS |
| AC-MIG003-14 | CONFIG_STRUCT_YAML_MISMATCH CI guard | PASS |
| AC-MIG003-15 | SUNSET_CONFIG_DORMANT_NOTICE once | PASS |

🗿 MoAI <email@mo.ai.kr>