### PR TITLE
fix(lint): add Out of Scope section to 3 HRN-001 testdata fixtures

### DIFF
--- a/.moai/specs/SPEC-TEST-AUTH-001/spec.md
+++ b/.moai/specs/SPEC-TEST-AUTH-001/spec.md
@@ -22,3 +22,10 @@ HRN-001 AC-03 test fixture. Contains security keywords in requirements to trigge
 - REQ-TEST-AUTH-001-001 (Ubiquitous) — OAuth 인증 구현. The system shall implement oauth authentication flow with jwt token validation.
 - REQ-TEST-AUTH-001-002 (Ubiquitous) — 세션 관리. The system shall manage session lifecycle with proper session invalidation.
 - REQ-TEST-AUTH-001-003 (Ubiquitous) — 암호화. The system shall encrypt sensitive data using approved encryption algorithms.
+
+## Scope
+
+### Out of Scope
+
+- Production usage (this is a HRN-001 AC fixture only)
+

--- a/.moai/specs/SPEC-TEST-ORC-LIKE-001/spec.md
+++ b/.moai/specs/SPEC-TEST-ORC-LIKE-001/spec.md
@@ -24,3 +24,10 @@ No security/payment keywords in requirements.
 - REQ-TEST-ORC-001-002 (Ubiquitous) — 중복 제거. The system shall remove duplicate agent entries.
 - REQ-TEST-ORC-001-003 (Ubiquitous) — 라우팅 규칙. The system shall apply consistent routing rules.
 - REQ-TEST-ORC-001-004 (Ubiquitous) — CLI 통합. The system shall integrate with CLI commands.
+
+## Scope
+
+### Out of Scope
+
+- Production usage (this is a HRN-001 AC fixture only)
+

--- a/.moai/specs/SPEC-TEST-OVERRIDE-001/spec.md
+++ b/.moai/specs/SPEC-TEST-OVERRIDE-001/spec.md
@@ -19,3 +19,10 @@ harness_level: thorough
 ## 5. Requirements
 
 - REQ-TEST-OVR-001-001 (Ubiquitous) — 단순 기능. The system shall implement a basic feature.
+
+## Scope
+
+### Out of Scope
+
+- Production usage (this is a HRN-001 AC fixture only)
+


### PR DESCRIPTION
HRN-001 testdata fixtures lint error 정정. 3 SPEC-TEST-* spec.md에 `### Out of Scope` sub-section 추가. `moai spec lint --strict` ✓ No findings 복원.

🗿 MoAI <email@mo.ai.kr>