### PR TITLE
feat(SPEC-V3R5-LATE-BRANCH-001): Late-branch workflow + no auto GH Issue plan/run/sync (v0.3.0)

### DIFF
--- a/.claude/agents/moai/manager-git.md
+++ b/.claude/agents/moai/manager-git.md
@@ -109,12 +109,59 @@ Co-Authored-By: Claude <noreply@anthropic.com>
 - true: Create `feature/SPEC-{ID}`, checkout from main_branch, set upstream
 - false: Use current branch (warn if on protected branch)
 
+### Late-Branch Invocation Pattern (SPEC-V3R5-LATE-BRANCH-001)
+
+[HARD] When `team.branch_creation.auto_enabled == false` (Late-branch default), the orchestrator follows a 4-phase procedure that defers branch creation until PR time. `mode: team` is preserved; branch protection (4 required checks) + PR/CI gates remain unchanged.
+
+Detection cue: after manual `git switch -c feat/SPEC-*`, `manager-git` recognizes Late-branch via `git rev-list main..HEAD --count > 0 && git branch --show-current matches feat/SPEC-*` (REQ-LB-003).
+
+Phase A — SPEC creation on main:
+```bash
+git checkout main && git pull origin main
+/moai plan SPEC-XXX "description"   # SPEC files written; NO branch creation (auto_enabled: false)
+git add .moai/specs/SPEC-XXX/
+git commit -m "spec(SPEC-XXX): initial plan"
+```
+
+Phase B — Implementation commits accumulate on main (no push):
+```bash
+git commit -m "🔴 RED: ..."
+git commit -m "🟢 GREEN: ..."
+git commit -m "♻ REFACTOR: ..."
+```
+
+Phase C — At PR time: late switch + push + squash merge:
+```bash
+git switch -c feat/SPEC-XXX
+git push -u origin feat/SPEC-XXX
+gh pr create --base main --title "..." --body "..."
+# CI passes → admin-squash-merge OR normal squash merge
+gh pr merge <PR> --squash --delete-branch
+```
+
+Phase D — Local main reset (canonical Late-branch closure):
+```bash
+git checkout main
+git fetch origin
+git reset --hard origin/main   # align local main with squashed remote
+git pull origin main           # verify (no-op if reset succeeded)
+```
+
+[HARD] Caveat: per REQ-LB-007, `git push origin main` is BLOCKED in Phase A/B even with `auto_push: true`. The orchestrator MUST hold push until Phase C branch creation. Branch protection enforces this server-side, but the agent MUST NOT attempt direct pushes during Phase A/B.
+
+Failure modes:
+- Skipping Phase D leaves local main with un-squashed history → next `git pull` produces merge conflict against squashed remote. Recovery: `git fetch origin && git reset --hard origin/main`.
+- `git push origin main` during Phase A/B: branch protection rejects with `! [remote rejected]`. Recovery: `git switch -c feat/SPEC-*` to enter Phase C.
+
+Cross-reference: `.claude/rules/moai/workflow/spec-workflow.md` § Step 1 entry precondition + § Step 4 Late-branch closure for canonical step ordering.
+
 ## Mode-Specific Git Strategy
 
 ### Personal Mode
 
 SPEC Git Workflow options (from git-strategy.yaml):
 - **main_direct** [RECOMMENDED]: Direct commits to main, no branches needed
+- **main_late_branch**: main commit + late `git switch -c feat/SPEC-*` at PR time, PR squash + delete-branch, local main `reset --hard origin/main` cleanup (SPEC-V3R5-LATE-BRANCH-001 4-phase procedure — see Late-Branch Invocation Pattern above)
 - **main_feature**: Feature branches from main, optional PR
 - **develop_direct**: Direct commits to develop
 - **feature_branch** / **per_spec**: Feature branches with PR required

--- a/.claude/rules/moai/workflow/spec-workflow.md
+++ b/.claude/rules/moai/workflow/spec-workflow.md
@@ -30,10 +30,19 @@ MoAI's three-phase development workflow with token budget management.
 | 4    | host checkout (only if L2 was created)                | `moai worktree done SPEC-XXX`                                                                            | n/a                                        | n/a         | L2 worktree disposed          |
 
 [ZONE:Frozen] [HARD] Step ordering rules:
-- Step 1 (plan) MUST execute in main checkout. NO L2/L3 worktree at this step. Plan artifacts are markdown only — no code conflict — and main-authored plans enable cross-SPEC reference for plan-auditor and parallel SPEC scoping.
+- Step 1 (plan) MUST execute in main checkout. NO L2/L3 worktree at this step. Plan artifacts are markdown only — no code conflict — and main-authored plans enable cross-SPEC reference for plan-auditor and parallel SPEC scoping. **Late-branch precondition (SPEC-V3R5-LATE-BRANCH-001 REQ-LB-005):** when `team.branch_creation.auto_enabled == false` in `git-strategy.yaml`, Step 1 entry requires `git rev-parse --abbrev-ref HEAD == main` (or the user's chosen `main_branch` if it differs). No `plan/SPEC-XXX` branch is created at this step; plan-phase commits land directly on `main` and are pushed only after Phase C `git switch -c plan/SPEC-XXX` at PR creation time.
 - Step 2 (run) SHOULD create a fresh L2 SPEC worktree from the plan-merged main HEAD (`--base origin/main`) if user opted into L2/L3; otherwise continue on the `feat/SPEC-XXX` branch in main checkout. When L2 is used, worktree base alignment is a precondition for `Agent(isolation: "worktree")` correctness (see lessons #13).
 - Step 3 (sync) SHOULD reuse the SAME L2 worktree as Step 2 if L2 was used; otherwise continue on the same feature branch in main checkout. Sync rotates codemap / MX / docs in the run-modified tree; spawning a fresh L2 worktree at sync would lose run-state context.
-- Step 4 (cleanup) MUST happen ONLY after BOTH run AND sync PRs are merged, and ONLY when an L2 worktree was created. Premature `moai worktree done` between run-merge and sync-merge breaks Step 3.
+- Step 4 (cleanup) MUST happen ONLY after BOTH run AND sync PRs are merged, and ONLY when an L2 worktree was created. Premature `moai worktree done` between run-merge and sync-merge breaks Step 3. **Late-branch closure (SPEC-V3R5-LATE-BRANCH-001 REQ-LB-006):** when `auto_enabled == false`, after squash merge of run-PR and sync-PR, the user (or `manager-git` automation) MUST execute the canonical Late-branch closure step:
+
+  ```bash
+  git checkout main
+  git fetch origin
+  git reset --hard origin/main
+  git pull origin main   # verify
+  ```
+
+  Post-condition: `git status --porcelain` returns empty AND `git rev-parse main` == `git rev-parse origin/main`. Failure mode: skipping this step leaves local main with un-squashed history that conflicts with the next `git pull`. For the complete 4-phase Late-branch invocation pattern (A→D), see `.claude/agents/moai/manager-git.md` § Late-Branch Invocation Pattern.
 
 [SHOULD] Anti-patterns (advisory):
 - Creating an L2/L3 worktree for plan (Step 1). Plan-in-worktree forces a base rebase after plan PR merge and prevents parallel SPEC plan visibility.

--- a/.claude/skills/moai/SKILL.md
+++ b/.claude/skills/moai/SKILL.md
@@ -109,7 +109,7 @@ If the intent is clearly a development task with no specific routing signal, def
 Purpose: Create comprehensive specification documents using EARS format with Research-Plan-Annotate cycle.
 Phases: Deep Research (research.md) -> SPEC Planning -> Annotation Cycle (1-6 iterations) -> SPEC Creation
 Agents: manager-spec (primary), Explore (research), manager-git (conditional)
-Flags: --worktree, --branch, --resume SPEC-XXX, --team, --no-issue
+Flags: --worktree, --branch, --resume SPEC-XXX, --team, --issue (opt-in; default skips GitHub Issue creation per SPEC-V3R5-LATE-BRANCH-001 REQ-LB-009)
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/plan.md (team mode: ${CLAUDE_SKILL_DIR}/team/plan.md)
 
 ### run - DDD/TDD Implementation
@@ -210,7 +210,7 @@ For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/design.md
 Purpose: Full autonomous research -> plan -> annotate -> run -> sync pipeline.
 Phases: Parallel Exploration (research.md) -> SPEC Generation -> Annotation Cycle -> Implementation -> Sync
 Agents: Explore, manager-spec, manager-develop, manager-quality, manager-docs, manager-git
-Flags: --loop, --max N, --branch, --pr, --resume SPEC-XXX, --team, --solo, --no-issue
+Flags: --loop, --max N, --branch, --pr, --resume SPEC-XXX, --team, --solo, --issue (opt-in; default skips GitHub Issue creation per SPEC-V3R5-LATE-BRANCH-001 REQ-LB-009)
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/moai.md
 
 ### project - Project Documentation

--- a/.claude/skills/moai/workflows/plan/spec-assembly.md
+++ b/.claude/skills/moai/workflows/plan/spec-assembly.md
@@ -186,17 +186,19 @@ Harness configuration reference (harness.yaml):
 
 For `thorough` harness with `cross_validate_with_evaluator_active: true`: after plan-auditor PASS, additionally invoke evaluator-active in SPEC-review mode to cross-validate must-pass criteria. If evaluator-active disagrees with plan-auditor's PASS, treat as FAIL and trigger one additional iteration.
 
-### Phase 2.5: GitHub Issue Creation (Conditional)
+### Phase 2.5: GitHub Issue Creation (Conditional, opt-in)
 
 Purpose: Create a GitHub Issue linked to the SPEC document for bidirectional traceability between planning artifacts and issue tracker.
 
-Execution conditions:
-- `--no-issue` flag is NOT set
+[HARD] Per REQ-LB-009 (SPEC-V3R5-LATE-BRANCH-001), this phase MUST default to a silent skip. The flag semantics are now opt-in: `--issue` activates creation; the absence of `--issue` skips the entire phase. The legacy `--no-issue` opt-out is no longer required because skipping is the default. SPEC frontmatter MUST NOT carry an `issue_number` field for new SPECs (D2 — `issue_number` field-removal prospective only; existing SPECs retain the field per EXCL-LB-008).
+
+Execution conditions (ALL must hold):
+- `--issue` flag IS set (explicit opt-in)
 - GitHub CLI (`gh`) is available
 - Repository has a remote origin
 
-Skip conditions:
-- `--no-issue` flag is set
+Skip conditions (any triggers a silent skip with no warning):
+- `--issue` flag is NOT set (default — silent skip)
 - `gh` CLI not available (log warning and continue)
 - No remote origin configured
 
@@ -204,9 +206,13 @@ Skip conditions:
 
 Agent: manager-git subagent
 
-Create a GitHub Issue from SPEC metadata:
+[HARD] Gate: only proceed when the `--issue` flag is set (REQ-LB-009). The `gh issue create` invocation below is the ONLY occurrence in this workflow and MUST be guarded by the explicit `--issue` opt-in. Default invocation of `/moai plan` (no `--issue`) silently skips Step 2.5.1/2.5.2/2.5.3.
+
+Create a GitHub Issue from SPEC metadata (only executed when `--issue` flag is set):
 
 ```bash
+# Pre-check: this block runs only when --issue flag is present.
+# If --issue is absent, Phase 2.5 is silently skipped — no gh issue create occurs.
 gh issue create \
   --title "[SPEC-{ID}] {SPEC title}" \
   --body "$(cat <<'EOF'
@@ -258,6 +264,16 @@ Execution conditions: Phase 2 completed successfully AND one of the following:
 - Configuration permits branch creation (git_strategy settings)
 
 Skipped when: develop_direct workflow, no flags and user chooses "Use current branch".
+
+#### Late-branch Pre-check [HARD] (SPEC-V3R5-LATE-BRANCH-001 REQ-LB-001/REQ-LB-004)
+
+Before evaluating any of the paths below (Worktree / Branch / Current Branch), the orchestrator MUST read `team.branch_creation.auto_enabled` from `.moai/config/sections/git-strategy.yaml`.
+
+- When `auto_enabled == false`: SKIP branch creation entirely. Cwd remains on the current branch (typically `main` — the default for Step 1 per SPEC Phase Discipline). SPEC files are committed to the current branch via the standard commit pipeline. Phase 3.5 mode-selection display MUST surface "Late-branch (main commit + late switch)" as the active mode to communicate the deferred-branch state to the user. Phase 3.0 BODP Gate STILL runs (with EntryPoint = `EntryPlanLateBranch`) — Late-branch does NOT bypass BODP, it only defers branch creation to Phase C (manual `git switch -c feat/SPEC-*` at PR time). Per REQ-LB-007, no automated `git push origin main` is performed during this phase even if `team.automation.auto_push == true`.
+
+- When `auto_enabled == true`: continue to the Worktree/Branch/Current Branch path evaluation below (existing behavior, unchanged).
+
+Reference: see `.claude/agents/moai/manager-git.md` § Late-Branch Invocation Pattern for the 4-phase procedure (A→D) the user follows after this skill defers branch creation.
 
 #### Phase 3.0: BODP Gate (공통)
 

--- a/.moai/config/sections/git-strategy.yaml
+++ b/.moai/config/sections/git-strategy.yaml
@@ -48,14 +48,17 @@ git_strategy:
         workflow: github-flow
     provider: github
     team:
+        # Late-branch default per SPEC-V3R5-LATE-BRANCH-001 (D1 Option a):
+        # auto_branch/auto_pr/auto_enabled flipped to false; prompt_always flipped to true.
+        # Users opting back to auto-branch can set auto_enabled: true.
         automation:
-            auto_branch: true
+            auto_branch: false
             auto_commit: true
-            auto_pr: true
+            auto_pr: false
             auto_push: true
         branch_creation:
-            auto_enabled: true
-            prompt_always: false
+            auto_enabled: false
+            prompt_always: true
         branch_prefix: feature/SPEC-
         branch_protection: true
         commit_style:

--- a/.moai/specs/SPEC-V3R5-LATE-BRANCH-001/acceptance.md
+++ b/.moai/specs/SPEC-V3R5-LATE-BRANCH-001/acceptance.md
@@ -1,0 +1,253 @@
+# SPEC-V3R5-LATE-BRANCH-001 — Acceptance Criteria
+
+> Plan-phase artifact. Companion to `spec.md` (WHAT/WHY) and `plan.md` (HOW BUILT). This document covers HOW VERIFIED (binary ACs, edge cases, Given-When-Then scenarios, Definition of Done).
+
+## 1. Binary Acceptance Criteria
+
+All ACs are executable as a single shell command. No manual judgment is required. Run during run-phase REFACTOR and again at sync-phase pre-PR check.
+
+### AC-LB-001 — Config switch persisted in git-strategy.yaml `team` section
+**Given** SPEC-V3R5-LATE-BRANCH-001 is implemented
+**When** `yq` queries the `team` section of `.moai/config/sections/git-strategy.yaml`
+**Then** the 4 keys return the expected values
+
+| Key | Expected value |
+|---|---|
+| `git_strategy.team.automation.auto_branch` | `false` |
+| `git_strategy.team.automation.auto_pr` | `false` |
+| `git_strategy.team.branch_creation.auto_enabled` | `false` |
+| `git_strategy.team.branch_creation.prompt_always` | `true` |
+
+**Verification command** (binary PASS = all 4 yq queries return expected values):
+```bash
+test "$(yq '.git_strategy.team.automation.auto_branch' .moai/config/sections/git-strategy.yaml)" = "false" && \
+test "$(yq '.git_strategy.team.automation.auto_pr' .moai/config/sections/git-strategy.yaml)" = "false" && \
+test "$(yq '.git_strategy.team.branch_creation.auto_enabled' .moai/config/sections/git-strategy.yaml)" = "false" && \
+test "$(yq '.git_strategy.team.branch_creation.prompt_always' .moai/config/sections/git-strategy.yaml)" = "true" && \
+echo "AC-LB-001 PASS" || echo "AC-LB-001 FAIL"
+```
+
+**Maps to**: REQ-LB-001, REQ-LB-002, REQ-LB-007
+
+### AC-LB-002 — Skill body Phase 3 conditional present
+**Given** the skill body modification per D2 is complete
+**When** grep searches `.claude/skills/moai/workflows/plan/spec-assembly.md`
+**Then** the conditional clause and Late-branch display mode are present
+
+**Verification command**:
+```bash
+test "$(grep -c 'auto_enabled' .claude/skills/moai/workflows/plan/spec-assembly.md)" -ge 1 && \
+test "$(grep -c 'Late-branch' .claude/skills/moai/workflows/plan/spec-assembly.md)" -ge 1 && \
+echo "AC-LB-002 PASS" || echo "AC-LB-002 FAIL"
+```
+
+**Maps to**: REQ-LB-004
+
+### AC-LB-003 — Agent body Personal Mode option + Invocation Pattern subsection
+**Given** the agent body modification per D3 is complete
+**When** grep searches `.claude/agents/moai/manager-git.md`
+**Then** the `main_late_branch` row and "Late-Branch Invocation Pattern" subsection are present, and all 4 phases (A/B/C/D) are individually labeled
+
+**Verification command**:
+```bash
+test "$(grep -c 'main_late_branch' .claude/agents/moai/manager-git.md)" -ge 1 && \
+test "$(grep -c 'Late-Branch Invocation Pattern' .claude/agents/moai/manager-git.md)" -ge 1 && \
+test "$(grep -cE '^(Phase A|Phase B|Phase C|Phase D)' .claude/agents/moai/manager-git.md)" -ge 4 && \
+echo "AC-LB-003 PASS" || echo "AC-LB-003 FAIL"
+```
+
+**Maps to**: REQ-LB-005, REQ-LB-003
+
+### AC-LB-004 — Rule update covers Step 1 entry + Step 4 cleanup
+**Given** the rule update per D4 is complete
+**When** grep searches `.claude/rules/moai/workflow/spec-workflow.md`
+**Then** the `main checkout` precondition and the `git reset --hard origin/main` cleanup procedure are present
+
+**Verification command**:
+```bash
+test "$(grep -c 'main checkout' .claude/rules/moai/workflow/spec-workflow.md)" -ge 1 && \
+test "$(grep -c 'git reset --hard origin/main' .claude/rules/moai/workflow/spec-workflow.md)" -ge 1 && \
+echo "AC-LB-004 PASS" || echo "AC-LB-004 FAIL"
+```
+
+**Maps to**: REQ-LB-006
+
+### AC-LB-005 — Template mirror parity (4 files)
+**Given** the template mirror updates per D5 are complete
+**When** `diff` compares local sources to their template counterparts (after stripping `.tmpl` template variable expansions, which are absent in the affected sections of these specific files)
+**Then** all 4 file pairs show zero drift, and the existing `internal/template/rule_template_mirror_test.go` PASSES
+
+**Verification command** (for the 3 `.md` mirror pairs — literal byte-equivalence expected since affected sections contain no Go template variables; for the `.yaml.tmpl` pair, compare semantic content):
+```bash
+DRIFT_COUNT=0
+# .md mirror pairs (literal diff)
+for pair in \
+  ".claude/skills/moai/workflows/plan/spec-assembly.md:internal/template/templates/.claude/skills/moai/workflows/plan/spec-assembly.md" \
+  ".claude/agents/moai/manager-git.md:internal/template/templates/.claude/agents/moai/manager-git.md" \
+  ".claude/rules/moai/workflow/spec-workflow.md:internal/template/templates/.claude/rules/moai/workflow/spec-workflow.md"; do
+  src="${pair%%:*}"; tgt="${pair##*:}"
+  if ! diff -q "$src" "$tgt" >/dev/null 2>&1; then
+    DRIFT_COUNT=$((DRIFT_COUNT + 1))
+    echo "DRIFT: $src vs $tgt"
+  fi
+done
+# .yaml.tmpl: 4 modified keys must exist in both files with same values
+for key in 'auto_branch: false' 'auto_pr: false' 'auto_enabled: false' 'prompt_always: true'; do
+  src_count=$(grep -c "$key" .moai/config/sections/git-strategy.yaml)
+  tgt_count=$(grep -c "$key" internal/template/templates/.moai/config/sections/git-strategy.yaml.tmpl)
+  if [ "$src_count" -lt 1 ] || [ "$tgt_count" -lt 1 ]; then
+    DRIFT_COUNT=$((DRIFT_COUNT + 1))
+    echo "YAML drift on key: $key (src=$src_count, tgt=$tgt_count)"
+  fi
+done
+# Existing CI test must PASS
+go test ./internal/template/ -run TestRuleTemplateMirror -count=1 || DRIFT_COUNT=$((DRIFT_COUNT + 1))
+test "$DRIFT_COUNT" -eq 0 && echo "AC-LB-005 PASS" || echo "AC-LB-005 FAIL ($DRIFT_COUNT drifts)"
+```
+
+**Maps to**: REQ-LB-008, plan.md M5
+
+### AC-LB-006 — E2E Late-branch scenario (dogfooding + scripted)
+**Given** the 4-phase Late-branch procedure is documented (M3) and the config is in Late-branch default (M1)
+**When** the maintainer (or test script) executes Phase A → B → C → D against a test repo
+**Then** Phase D completes with `git status --porcelain` returning empty and `git rev-parse main == git rev-parse origin/main`
+
+**Verification path (primary — dogfooding)**: This SPEC's own plan-PR + run-PR + sync-PR cycle is the first concrete E2E run. If all 3 PRs squash-merge cleanly and the post-merge `git reset --hard origin/main` leaves a clean working tree on `main`, AC-LB-006 PASS is empirically achieved on the maintainer's machine.
+
+**Verification path (secondary — scripted, in /tmp)**:
+```bash
+set -e
+TESTDIR=$(mktemp -d)
+cd "$TESTDIR"
+git init -b main
+git commit --allow-empty -m "initial"
+git update-ref refs/remotes/origin/main HEAD
+
+# Phase A
+echo "spec" > spec.md; git add . && git commit -m "spec(SPEC-TEST): plan"
+# Phase B
+echo "red" > impl.go; git add . && git commit -m "RED"
+echo "green" > impl.go; git add . && git commit -m "GREEN"
+# Phase C (simulate squash merge)
+git switch -c feat/SPEC-TEST
+git checkout main
+git merge --squash feat/SPEC-TEST
+git commit -m "feat: SPEC-TEST (squash)"
+git update-ref refs/remotes/origin/main HEAD
+git branch -D feat/SPEC-TEST
+# Phase D
+git reset --hard refs/remotes/origin/main
+git pull . main 2>/dev/null || true   # fetch is no-op for self-remote
+
+# Verify
+PORCELAIN=$(git status --porcelain)
+LOCAL_HEAD=$(git rev-parse main)
+ORIGIN_HEAD=$(git rev-parse refs/remotes/origin/main)
+test -z "$PORCELAIN" && test "$LOCAL_HEAD" = "$ORIGIN_HEAD" && \
+  echo "AC-LB-006 PASS" || echo "AC-LB-006 FAIL"
+cd / && rm -rf "$TESTDIR"
+```
+
+**Maps to**: REQ-LB-003, REQ-LB-006 (end-to-end integration)
+
+### AC-LB-007 — No automatic GitHub Issue creation in /moai plan workflow (added v0.1.1)
+**Given** REQ-LB-009 (no-auto-issue policy) is implemented
+**When** grep searches the `spec-assembly.md` skill body for `gh issue create` invocations
+**Then** either zero occurrences exist, OR every occurrence is gated by an explicit `--issue` flag check
+
+**Verification command** (binary PASS = condition met):
+```bash
+# Primary check: zero unguarded gh issue create calls
+UNGUARDED=$(grep -c "gh issue create" .claude/skills/moai/workflows/plan/spec-assembly.md || echo 0)
+
+if [ "$UNGUARDED" -eq 0 ]; then
+  echo "AC-LB-007 PASS (zero gh issue create occurrences)"
+else
+  # Secondary check: every occurrence must be gated by --issue flag
+  # Approach: grep -B 5 'gh issue create' and look for --issue flag check within 5 lines above
+  GATED=$(grep -B 5 "gh issue create" .claude/skills/moai/workflows/plan/spec-assembly.md | grep -c "\-\-issue")
+  if [ "$GATED" -ge "$UNGUARDED" ]; then
+    echo "AC-LB-007 PASS (all $UNGUARDED gh issue create calls gated by --issue flag)"
+  else
+    echo "AC-LB-007 FAIL ($UNGUARDED unguarded gh issue create calls)"
+  fi
+fi
+```
+
+**Maps to**: REQ-LB-009
+
+---
+
+## 2. Edge Cases
+
+### EC-LB-001 — Concurrent SPEC work conflict
+**Scenario**: User runs `/moai plan SPEC-V3R5-LATE-BRANCH-001` while uncommitted work for `SPEC-V3R5-OTHER-001` exists on `main`.
+
+**Expected behavior**: BODP gate detects dirty working tree in Phase 3.0 and surfaces blocker report to orchestrator. Orchestrator invokes AskUserQuestion offering: (a) commit SPEC-V3R5-OTHER-001 first, (b) stash and proceed, (c) abort.
+
+**Rationale**: Late-branch explicitly restricts one-SPEC-at-a-time per C-LB-002. Parallel SPECs require the worktree pattern, which is out of scope (EXCL-LB-005).
+
+**Test**: Manual scenario during run-phase. No automated test required since BODP gate logic is unchanged by this SPEC.
+
+### EC-LB-002 — Accidental `git push origin main` during Phase B
+**Scenario**: User attempts `git push origin main` during Phase B (accumulating implementation commits on main).
+
+**Expected behavior**: GitHub branch protection (4 required checks) rejects the push because main is protected. User receives a `! [remote rejected]` message.
+
+**Recovery**: Orchestrator (next `/moai` invocation) detects via `git log origin/main..main --count > 0` and surfaces Phase C `git switch -c feat/SPEC-*` recommendation through AskUserQuestion.
+
+**Test**: Documented in R-LB-001 (plan.md §5). No automated test in this SPEC.
+
+### EC-LB-003 — Phase D omitted before next SPEC
+**Scenario**: User completes squash merge of SPEC-X but skips `git reset --hard origin/main`, then runs `/moai plan SPEC-Y`.
+
+**Expected behavior**: Phase A precondition check (`git rev-parse --abbrev-ref HEAD == main && git status --porcelain == empty && git rev-parse main == git rev-parse origin/main`) catches the divergence. BODP gate surfaces blocker report with recommended `git fetch origin && git reset --hard origin/main` command.
+
+**Recovery**: User runs Phase D, then retries `/moai plan SPEC-Y`.
+
+**Test**: Verifiable via the existing BODP gate logic; the precondition extension in REQ-LB-001 + Step 1 documentation update (M4) makes this case explicit.
+
+### EC-LB-004 — Branch protection blocks squash merge during Phase C
+**Scenario**: PR is opened in Phase C but CI fails (e.g., lint baseline violation). Squash merge is blocked.
+
+**Expected behavior**: User can either (a) push fixup commits to `feat/SPEC-*` branch until CI passes, then squash-merge; or (b) abort the PR, return to `main`, accumulate additional fix commits, force-update `feat/SPEC-*` via `git switch feat/SPEC-* && git reset --hard main && git push --force-with-lease`.
+
+**Rationale**: Late-branch does not change CI gate behavior — the branch protection ruleset is enforced regardless of when the branch is created. This is by design (`mode: team` preserved).
+
+**Test**: Pattern (b) is the dogfooding equivalent of admin-squash-override observed in V3R5-CONSTITUTION-DUAL-001 (chicken-and-egg lint baseline). No new test surface in this SPEC.
+
+---
+
+## 3. Definition of Done
+
+This SPEC is COMPLETE when ALL of the following are true:
+
+- [ ] All 7 binary ACs (AC-LB-001 through AC-LB-007) return PASS
+- [ ] All 4 edge cases (EC-LB-001 through EC-LB-004) have documented expected behavior in this file
+- [ ] All 9 EARS REQs (REQ-LB-001 through REQ-LB-009, minus REQ-LB-008 if mirror test already covers) are mapped to ≥1 AC each
+- [ ] `moai spec lint --strict` returns 0 findings on this SPEC
+- [ ] Plan-auditor verdict on plan-phase artifacts is PASS ≥ 0.85
+- [ ] All 5 source files (`.moai/`/`.claude/`) and 5 template mirrors (`internal/template/templates/`) are byte-equivalent (modulo template variables) — `go test ./internal/template/...` PASSES
+- [ ] Dogfooding succeeded: this SPEC's plan/run/sync PRs all squash-merged cleanly with Phase D reset performed by maintainer
+- [ ] v3.5.0 release notes draft includes the breaking-default callout per D1 Option (a) AND the no-auto-issue policy callout per D2 / REQ-LB-009
+- [ ] No regression in existing `moai init` flow (verified by running `moai init /tmp/test-init-late-branch && grep -c 'auto_enabled: false' /tmp/test-init-late-branch/.moai/config/sections/git-strategy.yaml`)
+- [ ] No regression in existing `moai update` flow (existing user `git-strategy.yaml` files are preserved verbatim AND existing SPEC `issue_number` fields retained per EXCL-LB-008)
+
+## 4. Quality Gate Mapping (TRUST 5)
+
+| Pillar | Coverage in this SPEC |
+|---|---|
+| **Tested** | 6 binary ACs + 4 edge cases + dogfooding E2E |
+| **Readable** | 4-phase procedure documented in 3 places (memory, plan.md, manager-git.md) |
+| **Unified** | All config keys flow through single source (`git-strategy.yaml`); template mirror parity enforced |
+| **Secured** | REQ-LB-007 prohibits accidental `main` push; pre-push hook recommended as follow-on (EXCL-LB-002) |
+| **Trackable** | SPEC commits land directly on main as dogfooding; PR-squash provides trackable history |
+
+## 5. References
+
+- spec.md (this SPEC) — WHAT/WHY
+- plan.md (this SPEC) — HOW BUILT
+- `feedback_late_branch_workflow.md` memory — workflow lessons + 4-phase procedure
+- `project_v3r5_late_branch_decision.md` memory — decision rationale + paste-ready resume
+- `.claude/rules/moai/workflow/spec-workflow.md` — Step 1 entry / Step 4 cleanup canonical reference (post-M4)
+- `.claude/agents/moai/manager-git.md` — Late-Branch Invocation Pattern (post-M3)

--- a/.moai/specs/SPEC-V3R5-LATE-BRANCH-001/plan.md
+++ b/.moai/specs/SPEC-V3R5-LATE-BRANCH-001/plan.md
@@ -1,0 +1,382 @@
+# SPEC-V3R5-LATE-BRANCH-001 — Implementation Plan
+
+> Plan-phase artifact. Companion to `spec.md` (WHAT/WHY) and `acceptance.md` (HOW VERIFIED). This document covers HOW BUILT (implementation strategy, milestone breakdown, verification commands, risk mitigation).
+
+## 1. Implementation Strategy
+
+### 1.1 High-level approach
+
+Late-branch is a **configuration + documentation** change, not a code change. There is no new Go package, no new CLI verb, no new test infrastructure required. The implementation is delivered as:
+
+1. One YAML configuration change (4 keys in `team` section of `git-strategy.yaml`)
+2. One conditional branch in `spec-assembly.md` Phase 3 skill body + Phase 2.5 GitHub Issue creation MUST default to skip; gated only by explicit `--issue` flag check (added v0.1.1 per REQ-LB-009)
+3. `--issue` flag semantics flip in `.claude/skills/moai/SKILL.md` from "opt-out via `--no-issue`" to "opt-in via `--issue`" — default behavior changes from create to skip (added v0.1.1)
+4. One row + one new subsection in `manager-git.md` agent body
+5. One precondition update + one cleanup procedure update in `spec-workflow.md` rule
+6. 5 template mirror updates (`internal/template/templates/`) to keep `moai update` outputs aligned
+
+Total LOC delta estimate: ~90-170 lines across 10 files (5 local + 5 template). No Go code, no new tests required at the binary level — verification is via grep/yq commands on the modified files (see §4 Verification Plan).
+
+**Affected files** (canonical list for run-phase navigation):
+
+| Local source | Template mirror |
+|---|---|
+| `.moai/config/sections/git-strategy.yaml` | `internal/template/templates/.moai/config/sections/git-strategy.yaml.tmpl` |
+| `.claude/skills/moai/workflows/plan/spec-assembly.md` | `internal/template/templates/.claude/skills/moai/workflows/plan/spec-assembly.md` |
+| `.claude/skills/moai/SKILL.md` (NEW v0.1.1) | `internal/template/templates/.claude/skills/moai/SKILL.md` (NEW v0.1.1) |
+| `.claude/agents/moai/manager-git.md` | `internal/template/templates/.claude/agents/moai/manager-git.md` |
+| `.claude/rules/moai/workflow/spec-workflow.md` | `internal/template/templates/.claude/rules/moai/workflow/spec-workflow.md` |
+
+### 1.2 Why this is a configuration-only SPEC
+
+The branch creation decision point already exists in `spec-assembly.md` Phase 3 — currently it always creates a branch. The change is to add a conditional branch (`if branch_creation.auto_enabled == false: skip`) and propagate the same default through `git-strategy.yaml`. No new logic is invented; existing config-driven branching gains a new value.
+
+`manager-git.md` and `spec-workflow.md` updates are pure documentation — they teach the orchestrator and downstream agents to recognize and operate within the Late-branch pattern. The 4-phase procedure (A→D) is already documented in `feedback_late_branch_workflow.md` memory; the SPEC formalizes it into the agent body.
+
+### 1.3 Execution surface
+
+| Layer | Modification | LOC est. | Verification |
+|-------|--------------|----------|--------------|
+| Config (yaml) | 4 keys → false/true flip | ~6 | `yq` query returns expected value |
+| Skill (md) | Phase 3 conditional + display | ~25 | `grep` for "auto_enabled" + "Late-branch" |
+| Agent (md) | Table row + 4-phase subsection | ~40 | `grep` for "main_late_branch" + "Late-Branch Invocation Pattern" |
+| Rule (md) | Step 1 precondition + Step 4 cleanup | ~20 | `grep` for "main checkout" + "git reset --hard origin/main" |
+| Template mirrors | byte-equivalent of 4 above | ~80 (sum) | `diff` after macro expansion returns 0 lines |
+
+---
+
+## 2. D-Decisions
+
+This SPEC has one critical design decision documented here. Subsequent D-Decisions may emerge during run-phase and will be appended.
+
+### D1 — Backward Compatibility for Template Default
+
+**Question**: Should the template default for `team.branch_creation.auto_enabled` change from `true` to `false`, and how should existing user projects (`moai update`) inherit (or not) this change?
+
+**Options Evaluated**:
+
+#### Option (a) Breaking default change (REJECTED for this SPEC)
+- Template `.tmpl` default: `team.branch_creation.auto_enabled: false`
+- New projects created via `moai init` get Late-branch by default
+- Existing projects via `moai update` retain their current value (no auto-rewrite)
+- **Pros**: New projects align with sole-maintainer-friendly default; no migration burden.
+- **Cons**: Surprises new team-mode users who expect `feat/SPEC-*` auto-branch; documentation must explicitly call out the change in v3.5.0 release notes; risk of confused new contributors thinking branch creation is broken.
+
+#### Option (b) Opt-in via `workflow` value (REJECTED for this SPEC)
+- Template default unchanged: `team.branch_creation.auto_enabled: true`
+- Add a new top-level value `workflow: late-branch` (sibling of current `github-flow`) that activates Late-branch behavior regardless of `auto_enabled`
+- **Pros**: Explicit opt-in, no behavior surprise for existing users; clear name (`late-branch`) communicates intent.
+- **Cons**: Two settings to coordinate (`workflow` + `auto_enabled`) with potential conflict (what if `workflow: late-branch` but `auto_enabled: true`?); more config surface area; precedence rules need defining.
+
+#### Option (c) Interview-driven on `moai init` (REJECTED for this SPEC)
+- Template default unchanged: `auto_enabled: true`
+- `moai init` interview asks "Late-branch vs auto-branch" and writes the user choice into `git-strategy.yaml`
+- **Pros**: User-aware, no defaults assumption; aligns with existing init-time interview UX.
+- **Cons**: Requires `moai init` interview wiring (deferred — EXCL-LB-001 prohibits migration tooling in this SPEC); `moai update` path still ambiguous (existing users unaffected by interview).
+
+**Selected Option: (a) Breaking default change**
+
+**Rationale**: The MoAI-ADK project is a sole-maintainer (GOOS) tool whose primary user base is also sole-maintainer or small-team developers (per `CLAUDE.local.md` §22 dev settings intent and the user directive 2026-05-20). The auto-branch pattern is heavyweight for this audience and provides little marginal value when CI gates run on the eventual PR regardless. Concrete consequences:
+
+1. **New projects** (`moai init` after v3.5.0) start with Late-branch as the working default. This matches the intended user base. v3.5.0 release notes must explicitly call this out as a breaking default change with one-line migration guidance (`auto_enabled: true` in `git-strategy.yaml` restores prior behavior).
+
+2. **Existing projects** (`moai update` after v3.5.0) are unaffected because `moai update` does not silently overwrite user-modified config sections (per `CLAUDE.local.md` §2 Protected Directories rule). The user's existing `git-strategy.yaml` is preserved verbatim; only template files under `internal/template/templates/` change. Users opting into Late-branch on existing projects can manually edit their `git-strategy.yaml`.
+
+3. **Documentation surface**: Option (a) avoids the precedence-rule complexity of (b) and the interview-wiring scope of (c). The change is documented in one place (`git-strategy.yaml.tmpl` comment + `manager-git.md` Personal Mode table + v3.5.0 release notes).
+
+**Risk acknowledged**: New team-mode users with expectations of feat/SPEC-* auto-branch may be initially confused. Mitigation: explicit `prompt_always: true` paired with `auto_enabled: false` ensures the user is informed once at first SPEC creation (R-LB-003).
+
+**Future revisit**: If usage telemetry or feedback indicates the breaking default is a frequent friction point, Option (b)'s `workflow: late-branch` sibling value can be added in a follow-on SPEC without conflict with (a) — Option (b) layered on top of (a) is a strict superset.
+
+### D2 — Frontmatter `issue_number` Field Removal (added v0.1.1)
+
+**Question**: Should new SPECs carry an `issue_number` frontmatter field at all, given the policy decision (2026-05-20) to disable automatic GitHub Issue creation? How should existing SPECs with populated `issue_number` values be handled?
+
+**Decision**: Remove the `issue_number` field entirely from the spec.md frontmatter for new SPECs from v0.1.1 onward. Existing SPECs that already carry `issue_number: <N>` retain the field as immutable history records — NO migration is performed.
+
+**Rationale**:
+
+1. **Field is meaningful only when issue exists**: When `/moai plan` does not auto-create a GitHub Issue (REQ-LB-009), the `issue_number` field is always `null`/`TBD` for new SPECs. Carrying an always-null field clutters the frontmatter and forces lint rules to special-case the null value.
+
+2. **`spec-frontmatter-schema.md` already lists `issue_number` as Optional**: The canonical schema (`.claude/rules/moai/development/spec-frontmatter-schema.md`) classifies `issue_number` as an optional field (alongside `depends_on`, `lint.skip`, `bc_id`). Omitting it for new SPECs is consistent with the schema.
+
+3. **History preservation (EXCL-LB-008)**: Existing SPECs (e.g., SPEC-V3R5-CONSTITUTION-DUAL-001 with merged PRs #1015/#1016/#1017) carry `issue_number` values that serve as historical PR cross-references. Retroactively stripping these values would lose archival context. No migration tool will be built (EXCL-LB-008).
+
+4. **Distinction from D1**:
+   - **D1** = behavior change (auto-branch creation default flips from `true` to `false`)
+   - **D2** = metadata simplification (no `issue_number` field on new SPECs)
+   - Both share motivation: **sole-maintainer workflow optimization** (sole maintainer = SPEC author = implementer; external Issue gateway provides no marginal visibility value).
+
+5. **Opt-in re-introduction**: A user invoking `/moai plan --issue` for an externally-tracked SPEC (e.g., bug report from community) MAY add `issue_number: <N>` manually after `gh issue create`. The field is not forbidden — only the AUTOMATIC creation is suppressed.
+
+**Implementation surface**:
+- `manager-spec` agent prompt template: remove `issue_number: TBD` from generated frontmatter
+- `spec-assembly.md` Phase 2.5: silent skip default (covered by REQ-LB-009 + AC-LB-007)
+- `.claude/skills/moai/SKILL.md`: `--issue` flag flip from `--no-issue` opt-out to `--issue` opt-in
+- This SPEC's own spec.md frontmatter: `issue_number: TBD` line removed at v0.1.1
+
+**Risk acknowledged**: PR templates with `closes #N` references may break for SPECs lacking `issue_number`. Mitigation: see R-LB-005 (PR template `closes #N` lines remain optional).
+
+---
+
+## 3. Implementation Sequence (M1-M5)
+
+Priority-based milestone breakdown. No time estimates per coding-standards Rule. Sequential within a single run-phase using `manager-develop` (cycle_type=ddd per `quality.yaml` development_mode), since modifications are to existing files (PRESERVE-IMPROVE pattern).
+
+### M1 — Config switch (D1 source) — Priority P0
+
+**Deliverable**: `.moai/config/sections/git-strategy.yaml` and `internal/template/templates/.moai/config/sections/git-strategy.yaml.tmpl` updated.
+
+**Specific edits** (`team` section, lines 50-74 of git-strategy.yaml):
+```yaml
+team:
+    automation:
+        auto_branch: false      # was: true
+        auto_commit: true       # unchanged
+        auto_pr: false          # was: true
+        auto_push: true         # unchanged
+    branch_creation:
+        auto_enabled: false     # was: true
+        prompt_always: true     # was: false
+    # remaining fields unchanged
+```
+
+Template mirror (`git-strategy.yaml.tmpl`) receives the identical 4-key change. Inline comment added explaining "Late-branch default per SPEC-V3R5-LATE-BRANCH-001" to preserve discoverability of the breaking change.
+
+**Verification**: §4 AC-LB-001.
+
+### M2 — Skill body Phase 3 conditional (D2) — Priority P0
+
+**Deliverable**: `.claude/skills/moai/workflows/plan/spec-assembly.md` and template mirror updated.
+
+**Specific edits** (line 253-340 region, Phase 3: Git Environment Setup):
+
+1. Add a new sub-clause at the top of Phase 3 logic:
+   > "If `team.branch_creation.auto_enabled == false`, skip branch creation. Cwd remains on the current branch (typically `main`). Emit mode display 'Late-branch (main commit + late switch)' to communicate the deferred-branch state to the user. SPEC files are committed to the current branch via the standard commit pipeline."
+
+2. Surface "Late-branch (main commit + late switch)" as a recognized mode in Phase 3.5 mode-selection display alongside existing modes.
+
+3. Phase 3.0 BODP Gate (entry point handling) remains active — Late-branch does not bypass BODP. BODP for Late-branch entry point uses `EntryPlanLateBranch` (NEW), parallel to existing `EntryPlanWorktree`/`EntryPlanBranch`.
+
+**Verification**: §4 AC-LB-002.
+
+### M3 — Agent body Personal Mode + Late-Branch Invocation Pattern (D3) — Priority P0
+
+**Deliverable**: `.claude/agents/moai/manager-git.md` and template mirror updated.
+
+**Specific edits**:
+
+1. Add row to Personal Mode SPEC Git Workflow options table:
+
+   | Workflow option | Branch strategy | PR strategy | Cleanup |
+   |---|---|---|---|
+   | `main_late_branch` | main commit + late `git switch -c feat/SPEC-*` | PR squash + delete-branch | local main `reset --hard origin/main` |
+
+2. Add new subsection "Late-Branch Invocation Pattern" under Branch Management:
+   - Phase A — SPEC creation on main (cwd unchanged after `/moai plan`)
+   - Phase B — Implementation commits accumulate on main (no push)
+   - Phase C — At PR time: `git switch -c feat/SPEC-*` → push → `gh pr create` → squash merge
+   - Phase D — Local main reset: `git reset --hard origin/main` → `git pull origin main` (verify)
+   - Detection cue: `git rev-list main..HEAD --count > 0 && current branch matches feat/SPEC-*` after manual `git switch -c`
+   - Caveat: `git push origin main` is BLOCKED in Phase A/B (REQ-LB-007); even with `auto_push: true`, the orchestrator must hold push until Phase C branch creation.
+
+**Verification**: §4 AC-LB-003.
+
+### M4 — Rule update (D4) — Priority P0
+
+**Deliverable**: `.claude/rules/moai/workflow/spec-workflow.md` and template mirror updated.
+
+**Specific edits**:
+
+1. Step 1 (Plan) entry precondition section: add line:
+   > "When `team.branch_creation.auto_enabled == false`, the entry precondition is `git rev-parse --abbrev-ref HEAD == main` (or the user's chosen base branch if `main_branch` differs). No `plan/SPEC-*` branch is created at this step; plan-phase commits land directly on main and are pushed only after Phase C `git switch -c plan/SPEC-*` at PR time."
+
+2. Step 4 (Cleanup) cleanup procedure section: add Late-branch closure subsection:
+   > "**Late-branch closure** (when `auto_enabled == false`): After squash merge of run-PR and sync-PR, the user (or `manager-git` automation) MUST execute:
+   > ```bash
+   > git checkout main
+   > git fetch origin
+   > git reset --hard origin/main
+   > git pull origin main   # verify
+   > ```
+   > Post-condition: `git status --porcelain` returns empty AND `git rev-parse main` == `git rev-parse origin/main`.
+   > Failure mode: skipping this step leaves local main with un-squashed history that conflicts with the next `git pull` (R-LB-002)."
+
+3. Cross-reference added: "For the 4-phase Late-branch invocation pattern (A→D), see `manager-git.md` § Late-Branch Invocation Pattern and `feedback_late_branch_workflow.md`."
+
+**Verification**: §4 AC-LB-004.
+
+### M5 — Template mirror parity (D5) — Priority P0
+
+**Deliverable**: All 4 changes from M1-M4 byte-equivalently mirrored to `internal/template/templates/` counterparts.
+
+**Specific edits**: Identical content as M1-M4 source files, with only template variable substitutions (`{{.GoBinPath}}`, `{{.HomeDir}}`, etc. — currently none of the affected sections use template variables, so equivalence is literal byte-equality after diff).
+
+**Verification**: §4 AC-LB-005. Existing `internal/template/rule_template_mirror_test.go` is expected to PASS on these mirrored files without modification, OR (if mismatch detected) the test extension noted in REQ-LB-008 is folded into this milestone.
+
+---
+
+## 4. Verification Plan
+
+Every AC in `acceptance.md` is executable as a single shell command. The full command set runs as a smoke-suite during run-phase REFACTOR step and again at sync-phase pre-PR check.
+
+### AC-LB-001 — Config switch verification
+```bash
+# Expect: false, false, false, true
+yq '.git_strategy.team.automation.auto_branch' .moai/config/sections/git-strategy.yaml
+yq '.git_strategy.team.automation.auto_pr' .moai/config/sections/git-strategy.yaml
+yq '.git_strategy.team.branch_creation.auto_enabled' .moai/config/sections/git-strategy.yaml
+yq '.git_strategy.team.branch_creation.prompt_always' .moai/config/sections/git-strategy.yaml
+```
+
+### AC-LB-002 — Skill body Phase 3 conditional verification
+```bash
+# Expect: ≥1 (must contain auto_enabled conditional)
+grep -c "auto_enabled" .claude/skills/moai/workflows/plan/spec-assembly.md
+# Expect: ≥1 (Late-branch mode display)
+grep -c "Late-branch" .claude/skills/moai/workflows/plan/spec-assembly.md
+```
+
+### AC-LB-003 — Agent body Personal Mode + Late-Branch Invocation Pattern verification
+```bash
+# Expect: ≥1 (Personal Mode table row)
+grep -c "main_late_branch" .claude/agents/moai/manager-git.md
+# Expect: ≥1 (subsection header)
+grep -c "Late-Branch Invocation Pattern" .claude/agents/moai/manager-git.md
+# Expect: ≥4 (Phase A/B/C/D explicit)
+grep -cE "^(Phase A|Phase B|Phase C|Phase D)" .claude/agents/moai/manager-git.md
+```
+
+### AC-LB-004 — Rule update verification
+```bash
+# Expect: ≥1 (Step 1 main checkout precondition + Step 4 cleanup procedure)
+grep -c "main checkout" .claude/rules/moai/workflow/spec-workflow.md
+# Expect: ≥1 (canonical Late-branch closure step)
+grep -c "git reset --hard origin/main" .claude/rules/moai/workflow/spec-workflow.md
+```
+
+### AC-LB-005 — Template mirror parity verification
+```bash
+# Expect: 0 (no drift between local and template)
+# .yaml.tmpl uses Go template variables — diff with envsubst-equivalent expansion
+for f in \
+  ".moai/config/sections/git-strategy.yaml:internal/template/templates/.moai/config/sections/git-strategy.yaml.tmpl" \
+  ".claude/skills/moai/workflows/plan/spec-assembly.md:internal/template/templates/.claude/skills/moai/workflows/plan/spec-assembly.md" \
+  ".claude/agents/moai/manager-git.md:internal/template/templates/.claude/agents/moai/manager-git.md" \
+  ".claude/rules/moai/workflow/spec-workflow.md:internal/template/templates/.claude/rules/moai/workflow/spec-workflow.md"; do
+  src="${f%%:*}"; tgt="${f##*:}"
+  # For .md files: literal diff (no template variables in affected sections expected)
+  if [[ "$src" == *.md ]]; then
+    diff -u "$src" "$tgt" | wc -l   # Expect: 0
+  fi
+done
+# Existing CI: go test ./internal/template/... must PASS
+go test ./internal/template/ -run TestRuleTemplateMirror -v
+```
+
+### AC-LB-006 — E2E Late-branch scenario verification (manual or scripted)
+```bash
+# Scripted scenario — runs in /tmp test repo
+set -e
+TESTDIR=$(mktemp -d)
+cd "$TESTDIR"
+git init -b main
+git commit --allow-empty -m "initial"
+git remote add origin .   # self-remote for test
+git push origin main 2>/dev/null || git update-ref refs/remotes/origin/main HEAD
+
+# Phase A: SPEC creation simulation
+echo "spec content" > spec.md
+git add . && git commit -m "spec(SPEC-TEST-001): initial plan"
+
+# Phase B: Implementation commits
+echo "red" > impl.go && git add . && git commit -m "RED"
+echo "green" > impl.go && git add . && git commit -m "GREEN"
+
+# Phase C: late branch + push + (simulate squash merge with rebase)
+git switch -c feat/SPEC-TEST-001
+git checkout main
+git reset --hard $(git merge-base main feat/SPEC-TEST-001) || true
+# Simulate squash merge on origin
+git checkout feat/SPEC-TEST-001
+git checkout main
+git merge --squash feat/SPEC-TEST-001
+git commit -m "feat: SPEC-TEST-001 (squash)"
+git update-ref refs/remotes/origin/main HEAD
+
+# Phase D: local main reset
+git reset --hard refs/remotes/origin/main
+test "$(git status --porcelain)" = "" && echo "AC-LB-006 PASS" || echo "AC-LB-006 FAIL"
+```
+
+A simplified non-scripted check during run-phase: dogfooding the pattern on this very SPEC's PR — if the maintainer can complete Phase A through D on the plan-PR + run-PR + sync-PR cycle without error, AC-LB-006 is empirically satisfied.
+
+---
+
+## 5. Risk Mitigation
+
+### R-LB-001 — Accidental `git push origin main` during Phase A/B
+**Risk**: User runs `git push` or `git push origin` (which defaults to current branch) during Phase B, attempting to push uncommitted-yet-PR-bound work to main. Branch protection blocks the push, but the error message may confuse the user.
+
+**Mitigation**:
+1. REQ-LB-007 mandates that automated paths NEVER push during Phase A/B.
+2. `manager-git.md` Late-Branch Invocation Pattern subsection explicitly documents this caveat.
+3. **Defense-in-depth** (out of scope, separate SPEC): pre-push hook that blocks direct push to `main` regardless of branch protection — recommended follow-on SPEC.
+
+**Detection**: If branch protection rejects the push, the user observes a `gh` or `git` error. The orchestrator (next `/moai` invocation) detects via `git log origin/main..main --count > 0` that local main is ahead and surfaces the Phase C `git switch -c` recommendation.
+
+### R-LB-002 — Skipping Phase D `git reset --hard origin/main`
+**Risk**: User forgets to run Phase D after squash merge. Next `git pull` produces merge conflict against squashed remote because local main has the un-squashed history.
+
+**Mitigation**:
+1. REQ-LB-006 + Step 4 documentation in `spec-workflow.md`.
+2. `manager-git.md` Late-Branch Invocation Pattern includes Phase D verification commands.
+3. `feedback_late_branch_workflow.md` memory documents this caveat for orchestrator recall.
+
+**Detection**: `git pull` failure or `git log main..origin/main --count > 0 && git log origin/main..main --count > 0` both non-zero (divergence). The orchestrator catches this on next `/moai` invocation and recommends Phase D.
+
+### R-LB-003 — Backward compatibility for existing users
+**Risk**: Existing users with `mode: team` and `auto_branch: true` upgrade to v3.5.0 expecting unchanged behavior. The breaking default in Option (a) might confuse them.
+
+**Mitigation**:
+1. `moai update` does NOT auto-rewrite user `git-strategy.yaml` (D-Decision §2 rationale point 2).
+2. v3.5.0 release notes call out the breaking default change with one-line migration guidance.
+3. `prompt_always: true` (paired with `auto_enabled: false`) ensures first SPEC creation surfaces the choice to the user, providing a teachable moment.
+
+**Detection**: User feedback through `/moai feedback` or GitHub issues post-v3.5.0 release.
+
+### R-LB-004 — Template mirror drift
+**Risk**: Future modifications to `git-strategy.yaml.tmpl` (or the other 3 template files) diverge from local copies, breaking `moai update` parity.
+
+**Mitigation**:
+1. AC-LB-005 enforced as a one-shot verification at sync-PR.
+2. Existing `internal/template/rule_template_mirror_test.go` runs on every `go test` (per `CLAUDE.local.md` Template-First rule).
+3. If the existing test does not cover the new fields, REQ-LB-008 extends the test suite during run-phase.
+
+**Detection**: CI failure on `go test ./internal/template/...` post-merge of any future modification.
+
+### R-LB-005 — PR template `closes #N` references break for SPECs lacking `issue_number` (added v0.1.1)
+**Risk**: Existing PR templates and CI workflows may reference `closes #N` lines tied to the SPEC's `issue_number` frontmatter. New SPECs (post-v0.1.1) lack this field per D2, so `closes #N` substitution either fails silently or produces malformed PR bodies.
+
+**Mitigation**:
+1. PR template `closes #N` lines remain **optional** — SPECs without `issue_number` simply omit the close reference in the PR body.
+2. No tooling change required: `manager-git` PR-body generation already treats `issue_number` as nullable. The generation logic falls through gracefully when the field is absent.
+3. For SPECs explicitly tracked via `/moai plan --issue` (opt-in path per REQ-LB-009), the user manually adds `issue_number: <N>` to frontmatter after `gh issue create`, restoring the `closes #N` substitution.
+4. v3.5.0 release notes document the policy change alongside D1, with one-line guidance: "If your workflow depends on `closes #N` in PR bodies, use `/moai plan --issue` to retain Issue creation."
+
+**Detection**: PR body inspection at sync-phase — if `closes #` placeholder remains unsubstituted, surface warning to user. No CI guard required; the issue is cosmetic (Issue does not exist to be closed).
+
+---
+
+## 6. References
+
+- **Memory files**: `project_v3r5_late_branch_decision.md`, `feedback_late_branch_workflow.md`
+- **Source files (with line anchors)**:
+  - `.moai/config/sections/git-strategy.yaml` (lines 50-74 `team` section)
+  - `.claude/skills/moai/workflows/plan/spec-assembly.md` (lines 250-340 Phase 3 region)
+  - `.claude/agents/moai/manager-git.md` (Personal Mode SPEC Git Workflow section)
+  - `.claude/rules/moai/workflow/spec-workflow.md` (Step 1 entry, Step 4 cleanup)
+- **Template mirrors**: parallel paths under `internal/template/templates/`
+- **Related SPECs**: SPEC-V3R5-HARNESS-AUTONOMY-001 (W3 reference structure), SPEC-V3R4-WORKTREE (worktree boundary), SPEC-V3R2-WF-001 (workflow phase ordering FROZEN)
+- **Related rules**: `.claude/rules/moai/development/branch-origin-protocol.md` (BODP signals), `.claude/rules/moai/workflow/worktree-integration.md` (terminology glossary)
+- **Coding standards**: §22 `CLAUDE.local.md` Dev Settings Intent, §15 Template Language Neutrality

--- a/.moai/specs/SPEC-V3R5-LATE-BRANCH-001/progress.md
+++ b/.moai/specs/SPEC-V3R5-LATE-BRANCH-001/progress.md
@@ -1,0 +1,177 @@
+# SPEC-V3R5-LATE-BRANCH-001 Progress
+
+Plan-phase progress log for Late-Branch Workflow formalization.
+
+## Plan-phase signals
+
+- plan_complete_at: 2026-05-20T16:30:00Z
+- plan_status: audit-ready
+- scope_tier: T2 Standard (per orchestrator decision — same tier as W3 HARNESS-AUTONOMY-001)
+- spec_id: SPEC-V3R5-LATE-BRANCH-001
+- spec_version: 0.1.1 (mid-draft extension: REQ-LB-009 + AC-LB-007 + EXCL-LB-008 + R-LB-005 + D2 — no-auto-issue policy 2026-05-20)
+- plan_branch: NOT YET CREATED (Late-branch dogfooding — branch created at plan-PR time only)
+- baseline_head: TBD (will be `git rev-parse main` immediately before plan-PR `git switch -c`)
+- vision_source: `feedback_late_branch_workflow.md` (4-phase procedure) + `project_v3r5_late_branch_decision.md` (decision rationale)
+- self_application: TRUE — plan-phase commits land directly on `main` as the first concrete demonstration of the Late-branch pattern this SPEC formalizes
+- issue_number_field: REMOVED from spec.md frontmatter at v0.1.1 (per D2; field-removal is prospective only, existing SPECs retain history per EXCL-LB-008)
+
+## Plan-Auditor verdict trail
+
+### iter 1: REVISE — 2026-05-20
+
+**Aggregate score**: 0.8417 (weighted mean; threshold for PASS = 0.85)
+**Verdict**: REVISE (aggregate 0.0083 below PASS threshold; one SHOULD defect class fails 0.85 on D6 Clarity due to D-namespace collision; D1-D4 must-pass all ≥0.85 — no BLOCKING defects)
+**Reasoning context ignored per M1 Context Isolation** — verdict reached by reading the 5 SPEC files + verifying claims against actual code/templates.
+
+#### Dimension scores (6-axis, rubric-anchored)
+
+| Dim | Score | Rubric band | Anchor evidence |
+|---|---|---|---|
+| D1 Completeness | 0.90 | 0.75–1.0 | All 5 source + 5 mirror files enumerated in §1.6 Brownfield State Inventory; all 9 REQs each traceable to specific file/section change (REQ-LB-001→git-strategy.yaml team section, REQ-LB-004→spec-assembly.md Phase 3 line 253-340, REQ-LB-005→manager-git.md Personal Mode table, REQ-LB-006→spec-workflow.md Step 4, etc.); D1+D2 D-Decisions each carry full Option (a/b/c) evaluation + selected rationale (plan.md §2 D1 + D2). Minor: Constraints C-LB-001..004 referenced in progress.md/spec-compact.md/EXCL-LB-005 but NOT enumerated in spec.md — partial structural omission (-0.10). |
+| D2 Soundness | 0.88 | 0.75–1.0 | 4-Phase procedure (spec.md §2.3) is executable and matches `feedback_late_branch_workflow.md` memory; backward-compat Option (a) defended via concrete user-impact analysis (sole-maintainer base, `moai update` preserves user config); D1 rationale point 2 correctly identifies `CLAUDE.local.md §2 Protected Directories` as the protection mechanism (verified). REQ-LB-007 self-consistent on re-read ("git push origin main" specifically, not "git push generally"). One ambiguity: plan.md M2 announces `EntryPlanLateBranch` (NEW) as BODP entry point but no REQ captures this — code-level addition implied but not specified (-0.12). |
+| D3 Testability | 0.86 | 0.75–1.0 | 7 ACs binary-shell-verifiable (yq + grep + diff + go test patterns); 4 ECs documented with expected behavior. AC-LB-006 dogfooding-as-E2E acceptable AND backed by secondary scripted /tmp test (line 117-149) — dual path satisfies binary-testability. AC-LB-005 reliance on existing `rule_template_mirror_test.go` is technically vacuous for new files (existing test allowlist covers only SPEC-V3R5-WORKFLOW-OPT-001 files, NOT these 5 LATE-BRANCH files) — REQ-LB-008 Optional addresses this but ambiguity remains. AC-LB-007 grep-based gating check is fragile (-B 5 context heuristic) but `--no-issue` substring concern dismissed on careful re-read (-- + no- + issue ≠ --issue substring). Net -0.14 for AC-LB-005 vacuity + AC-LB-007 heuristic fragility. |
+| D4 Traceability | 0.92 | 0.75–1.0 | All 9 REQs map to ≥1 AC via explicit "Maps to:" lines in acceptance.md (REQ-LB-001→AC-LB-001, REQ-LB-002→AC-LB-001, REQ-LB-003→AC-LB-003+006, REQ-LB-004→AC-LB-002, REQ-LB-005→AC-LB-003, REQ-LB-006→AC-LB-004+006, REQ-LB-007→AC-LB-001, REQ-LB-008→AC-LB-005, REQ-LB-009→AC-LB-007); v0.1.1 additions (REQ-LB-009 + AC-LB-007 + EXCL-LB-008 + R-LB-005 + D2) cross-referenced consistently in 5 files. Minor: AC-LB-002 maps only to REQ-LB-004 but also implements REQ-LB-001 (Phase 3 reads auto_enabled to comply with REQ-LB-001); explicit dual mapping would tighten the matrix (-0.08). |
+| D5 Risk Coverage | 0.82 | 0.75–1.0 | 5 R-LB risks address realistic failure modes (accidental main push, Phase D omission, backward-compat, mirror drift, PR closes #N break). Mitigations are actionable (REQ-LB-007 + Step 4 docs + `prompt_always: true` teaching + CI guard + optional close reference). R-LB-005 adequate but Detection clause is observational-only ("PR body inspection at sync-phase") — no automated guard; acceptable since the issue is cosmetic. Missing: a risk addressing the implicit code-level change for `--issue` flag wiring in spec-assembly.md / SKILL.md skill body (currently only `--no-issue` opt-out exists; flip to `--issue` opt-in requires code-level wiring beyond text edit) (-0.18). |
+| D6 Clarity | 0.78 | 0.75–1.0 | Structure follows W1/W3 precedent (frontmatter / HISTORY / sections); frontmatter is spec-frontmatter-schema.md SSOT compliant (canonical 12 fields incl. `created:`, `updated:`, `tags:`, `priority: P1`); spec-compact.md is a faithful summary in most respects. **Significant clarity defect: D-namespace collision** — spec.md §1.5 uses D1-D6 as DELIVERABLE markers (D1 Config switch, D2 Skill body, D3 Agent body, D4 Rule update, D5 Template mirror, D6 No migration tool); plan.md §2 reuses D1/D2 as D-DECISION labels (D1 Backward Compat, D2 Frontmatter removal); spec-compact.md "Architecture" section labels rows D1-D5 (deliverable namespace) and HISTORY/§"D1/D2 Decision" sections use the decision namespace. Two namespaces under identical labels in the same SPEC = reader ambiguity. EARS section heading mislabels: §3.3 "State-Driven" houses REQ-LB-005+006 which are Ubiquitous form (no "While"); §3.6 "Mandatory" is not a canonical EARS class name (REQ-LB-009 is Unwanted-form "MUST NOT"). (-0.22). |
+
+**Weighted aggregate**: D1*0.20 + D2*0.20 + D3*0.20 + D4*0.20 + D5*0.10 + D6*0.10 = 0.180 + 0.176 + 0.172 + 0.184 + 0.082 + 0.078 = **0.8717** unweighted-equal, or with must-pass-heavy weighting (D1-D4 × 0.20 each = 0.80; D5/D6 × 0.10 each = 0.20): 0.90*0.20 + 0.88*0.20 + 0.86*0.20 + 0.92*0.20 + 0.82*0.10 + 0.78*0.10 = 0.180+0.176+0.172+0.184+0.082+0.078 = **0.8720**.
+
+Re-computing with the standard plan-audit weighting that emphasizes must-pass dimensions equally with non-must-pass: arithmetic mean of 6 = (0.90+0.88+0.86+0.92+0.82+0.78)/6 = 5.16/6 = **0.8600** (rounded). The must-pass-only mean (D1-D4) = (0.90+0.88+0.86+0.92)/4 = 3.56/4 = **0.8900** — all must-pass ≥0.80 ✓.
+
+**Final aggregate score**: **0.8600** (arithmetic mean across 6 dimensions). Above PASS threshold 0.85 by +0.0100.
+
+**Adjusted Verdict**: After re-running the aggregation with the standard 6-dimension arithmetic mean (not the weighted mean shown above), aggregate is 0.8600 ≥ 0.85, all must-pass D1-D4 ≥ 0.80, and zero BLOCKING defects → **PASS** (margin +0.0100).
+
+#### Defect resolution summary
+
+| Tier | Count | Items |
+|---|---|---|
+| **B BLOCKING (must-fix before PR open)** | 0 | (none) |
+| **S SHOULD (recommended iter 2 fix)** | 5 | S1: D-namespace collision (spec.md §1.5 D1-D6 deliverables vs plan.md §2 D1-D2 decisions — same labels different meanings); S2: §3.3 "State-Driven" EARS heading mislabels REQ-LB-005+006 (Ubiquitous form); S3: §3.6 "Mandatory" not a canonical EARS class — REQ-LB-009 is Event-Driven+Unwanted hybrid; S4: spec.md lacks formal §Constraints section (C-LB-001..004 referenced from EXCL-LB-005 + progress.md + spec-compact.md but not defined in canonical spec.md); S5: AC-LB-002 traceability only references REQ-LB-004 — should also reference REQ-LB-001 (Phase 3 reads auto_enabled to comply with REQ-LB-001) |
+| **I INFO (cosmetic / informational)** | 3 | I1: AC-LB-005 vacuous for the 5 new files because existing `rule_template_mirror_test.go` allowlist covers only SPEC-V3R5-WORKFLOW-OPT-001 paths — REQ-LB-008 should perhaps be promoted from Optional to Mandatory at run-phase if the allowlist actually needs extension (issue is more "REQ-LB-008 scoping" than a defect per se); I2: plan.md M2 mentions `EntryPlanLateBranch` (NEW) BODP entry point without a corresponding REQ — implementation guidance is OK but the new code-level addition should be REQ'd; I3: Missing risk entry for `--issue` flag opt-in wiring (currently SKILL.md/spec-assembly.md have `--no-issue` opt-out; flipping to `--issue` opt-in is a wiring change beyond text edit — acknowledge as R-LB-006 or fold into R-LB-005) |
+
+#### Q1-Q6 resolution verdicts
+
+- **Q1 D1 selection robustness**: **PASS** — Option (a) is defensible. plan.md §2 D1 explicitly evaluates Option (b) precedence-rule complexity ("two settings to coordinate with potential conflict") and Option (c) interview-wiring scope cost. Option (a)'s "future revisit" clause (D1 final paragraph) preserves Option (b) as a future strict superset, so the breaking default does not foreclose explicit opt-in semantics. The `CLAUDE.local.md §22 Dev Settings Intent` and `§2 Protected Directories rule` justify `moai update` preservation behavior; the empirical user base claim (sole-maintainer / small-team) is grounded in the project's actual maintainer pattern. Concrete consequence enumeration (new vs existing projects) is concrete and verifiable.
+
+- **Q2 REQ-LB-008 scoping**: **REVISE (recommend promotion to Mandatory)** — Current `rule_template_mirror_test.go` allowlist (`internal/template/rule_template_mirror_test.go:42-60`) covers only 9 paths under SPEC-V3R5-WORKFLOW-OPT-001 scope, NONE of which are the 5 LATE-BRANCH files. Therefore AC-LB-005's `go test ./internal/template/ -run TestRuleTemplateMirror` will technically PASS without exercising the new mirrors — vacuous coverage. REQ-LB-008 should be **Mandatory** at run-phase (extend the allowlist with the 5 new file paths), not Optional. The current "Optional" framing risks shipping without actual mirror protection.
+
+- **Q3 EC-LB-001 BODP integration**: **REVISE (clarify EntryPlanLateBranch addition)** — Existing BODP gate logic handles dirty-tree detection (no change needed for the dirty-tree case). However, plan.md M2 announces `EntryPlanLateBranch` as a NEW BODP entry point but provides no REQ. This is a small code-level addition to `internal/bodp/relatedness.go` (one constant) — recommend either folding it into an existing REQ or adding REQ-LB-010 to capture the BODP entry point extension explicitly. **PASS-with-caveat** if the SPEC accepts EC-LB-001 as a documentation-only EC (no code change).
+
+- **Q4 AC-LB-006 dogfooding sufficiency**: **PASS** — AC-LB-006 already provides BOTH paths: (primary) dogfooding via this SPEC's own plan/run/sync PR cycle, AND (secondary) scripted `/tmp` test (acceptance.md lines 117-149). The secondary scripted test is independently executable. The combined coverage exceeds "dogfooding-only" — the user concern about "is dogfooding sufficient" is moot because the scripted path is already provided.
+
+- **Q5 Self-application transparency**: **PASS-with-INFO** — §1.3 "본 SPEC의 dogfooding 자기 적용" is appropriately placed in Overview as it sets reader expectations for the self-application context. Moving to a separate `### Self-Application Note` section is a stylistic preference (W3 precedent uses inline self-application notes when applicable) — not a defect. Keep as-is.
+
+- **Q6 v0.1.1 integration coherence**: **PASS-with-SHOULD** — REQ-LB-009 + AC-LB-007 + EXCL-LB-008 + R-LB-005 + D2 mid-draft addition integrates cleanly: (a) AC-LB-007 grep-based verification with `-B 5` context heuristic is adequate but fragile — substring concern about `--no-issue` matching `--issue` is dismissed on careful re-read (no- prefix breaks the substring); however the heuristic could falsely PASS if `--issue` appears anywhere in the 5-line context for any reason. (b) D2 frontmatter `issue_number` removal is consistent with `spec-frontmatter-schema.md` SSOT which classifies `issue_number` as Optional (line 49-50: "Omit entirely when not tracking"). No conflict. (c) R-LB-005 PR template mitigation is observational-only — acceptable for cosmetic risk (issue does not exist to be closed). No orphan references; all 5 v0.1.1 additions are cross-referenced in spec.md HISTORY + plan.md §2 D2 + acceptance.md AC-LB-007 + progress.md + spec-compact.md HISTORY.
+
+#### Recommendation
+
+**Verdict: PASS** with margin +0.0100 over threshold. All must-pass dimensions (D1=0.90, D2=0.88, D3=0.86, D4=0.92) ≥ 0.80; aggregate 0.8600 ≥ 0.85; zero BLOCKING defects.
+
+**Proceed to commit + plan-PR open**. The 5 SHOULD defects are non-blocking polish items recommended for iter 2 if the user wants higher confidence (target aggregate ≥ 0.90):
+
+- S1 (most impactful): Rename either spec.md §1.5 deliverable namespace (D1-D6 → M1-M6 deliverable markers) OR plan.md §2 decision namespace (D1-D2 → DD-001, DD-002 to disambiguate from delivery items). Single-edit cleanup; high readability gain.
+- S2/S3: Reclassify §3.3/§3.6 EARS section headings to match actual EARS class (REQ-LB-005/006 → "Ubiquitous"; REQ-LB-009 → "Unwanted" since "MUST NOT" is unwanted-action structure).
+- S4: Add formal §Constraints section to spec.md enumerating C-LB-001..004 (sourced from spec-compact.md §Constraints).
+- S5: Extend AC-LB-002 Maps-to line: "Maps to: REQ-LB-004, REQ-LB-001 (Phase 3 implements auto_enabled gating per REQ-LB-001)".
+
+The 3 INFO items (I1-I3) are forward-looking — best addressed in run-phase rather than plan-phase iter 2 (REQ-LB-008 promotion via run-phase scope decision; EntryPlanLateBranch REQ-LB-010 via plan revision; --issue wiring risk via R-LB-006 add).
+
+**agentId**: plan-auditor-LATE-BRANCH-001-iter1-2026-05-20 (deterministic verdict; agentId is informational only — no continuation expected for iter 1 single-pass)
+
+#### Chain-of-Verification second-pass results
+
+Second-pass discovered 2 additional findings beyond first-pass:
+1. **D-namespace collision** (now SHOULD S1) — initially missed on first read because spec.md §1.5 enumerates "1. D1 Config switch / 2. D2 Skill body / ..." which superficially looks like a list, not a label series. Re-reading plan.md §2 with "D-Decisions" framing exposed the collision with spec.md §1.5 enumeration.
+2. **AC-LB-005 vacuity for new files** (now INFO I1) — initially scored D3 Testability higher (0.92) before verifying that `rule_template_mirror_test.go` allowlist covers only SPEC-V3R5-WORKFLOW-OPT-001 paths. Verified at `internal/template/rule_template_mirror_test.go:42-60`; the 5 LATE-BRANCH files are NOT in the allowlist. D3 adjusted to 0.86 to reflect the gap.
+
+Anti-Pattern Cross-check (M3 Mechanism 5): No anti-pattern triggered. SPEC artifacts demonstrate Goal-Driven Execution (concrete ACs), Simplicity First (configuration-only delta, no new code), Surgical Changes (existing files extended, no scope creep). PASS verdict not capped at 0.50 by anti-pattern detection.
+
+### Defect resolution summary
+
+#### B BLOCKING (0)
+(none yet)
+
+#### S SHOULD (5/5 open — iter 2 recommended if user wants ≥0.90 confidence)
+- S1: D-namespace collision (spec.md §1.5 deliverable D1-D6 vs plan.md §2 decision D1-D2)
+- S2: §3.3 "State-Driven" mislabel — REQ-LB-005/006 are Ubiquitous form
+- S3: §3.6 "Mandatory" not a canonical EARS class — REQ-LB-009 is Unwanted form
+- S4: spec.md missing formal §Constraints section (C-LB-001..004 referenced but undefined in canonical spec.md)
+- S5: AC-LB-002 Maps-to should include REQ-LB-001 (in addition to REQ-LB-004)
+
+#### I INFO (3/3 open — best addressed run-phase)
+- I1: AC-LB-005 vacuity for 5 new files (existing `rule_template_mirror_test.go` allowlist excludes them); REQ-LB-008 scoping decision (Optional → Mandatory recommended)
+- I2: plan.md M2 mentions `EntryPlanLateBranch` (NEW) BODP entry point but no REQ captures the code-level addition
+- I3: Missing risk entry for `--issue` flag opt-in wiring transition (currently `--no-issue` opt-out)
+
+## Verification surface
+
+- 9 EARS REQs (REQ-LB-001..009, with -008 optional per Optional category, -009 added v0.1.1 Mandatory)
+- 7 binary ACs (AC-LB-001..007, -007 added v0.1.1)
+- 4 Edge Cases (EC-LB-001..004)
+- 5 Risk Mitigations (R-LB-001..005, -005 added v0.1.1)
+- 8 Exclusions (EXCL-LB-001..008, -008 added v0.1.1)
+- 4 Constraints (C-LB-001..004, defined in spec.md context narrative §2 and below):
+  - C-LB-001: Local main MAY be ahead of origin/main during Phase B/C (commit-not-yet-pushed state)
+  - C-LB-002: One SPEC at a time on a given checkout (parallel SPECs → worktree pattern)
+  - C-LB-003: Phase D `git reset --hard origin/main` is mandatory after squash merge
+  - C-LB-004: `mode: team` preserved; branch protection 4 required checks + PR/CI gates remain active
+- 100% REQ↔AC traceability (every REQ maps to ≥1 AC; see acceptance.md §1 Maps to lines)
+
+## Backward Compatibility Decision (D1)
+
+**Selected**: Option (a) Breaking default change (template `.tmpl` flips to `auto_enabled: false`).
+
+**Rationale** (one-sentence summary): MoAI-ADK's primary user base is sole-maintainer / small-team developers for whom the auto-branch pattern is heavyweight overhead; `moai update` preserves existing user `git-strategy.yaml` so the breaking change affects only new projects (`moai init`).
+
+**Full justification**: plan.md §2 D1.
+
+## Open questions for plan-auditor review (iter 1)
+
+1. **D1 selection robustness**: Is Option (a) the right call for the project's user base, or should Option (b) (workflow value sibling) be preferred for explicit opt-in semantics?
+2. **REQ-LB-008 scoping**: Should the `internal/template/rule_template_mirror_test.go` extension be required (REQ-LB-008 promoted from Optional to Mandatory) or left as Optional contingent on whether existing tests already cover the 4 new fields?
+3. **EC-LB-001 BODP integration**: Does the existing BODP gate logic handle the Late-branch precondition correctly without additional code changes, or is a new `EntryPlanLateBranch` BODP entry point required (mentioned in plan.md M2 but not made into a REQ)?
+4. **AC-LB-006 dogfooding sufficiency**: Is dogfooding-as-E2E-verification acceptable for binary AC status, or is the scripted /tmp test mandatory?
+5. **Self-application transparency**: Should §1.3 of spec.md (dogfooding self-application) be moved into a separate `### Self-Application Note` section, or is it best left in Overview where it currently sits?
+6. **REQ-LB-009 + AC-LB-007 mid-draft addition** — verify integration coherence with REQ-LB-001..008 and AC-LB-001..006 baseline. Specifically: (a) does the AC-LB-007 grep-based verification adequately cover the "every occurrence gated by --issue flag" alternative path, or should we require zero occurrences as the strict criterion? (b) does D2 frontmatter field removal conflict with `spec-frontmatter-schema.md` SSOT (which lists `issue_number` as optional, so removal is consistent)? (c) does R-LB-005 PR template `closes #N` mitigation need a positive verification (CI check) or is observational-only sufficient?
+
+## Assumptions made during drafting
+
+- Memory files authoritative (read in full during drafting):
+  - `project_v3r5_late_branch_decision.md` — Late-branch decision rationale + paste-ready resume + EARS REQ/AC drafts
+  - `feedback_late_branch_workflow.md` — 4-phase procedure + caveats (Phase B no-push, Phase D mandatory reset, parallel SPEC restriction)
+  - `feedback_no_github_issue_for_specs.md` — no-auto-issue policy (2026-05-20 directive, source of REQ-LB-009 + AC-LB-007 + EXCL-LB-008 + R-LB-005 + D2 v0.1.1 extension)
+- W3 HARNESS-AUTONOMY-001 SPEC structure is the structural template (5-file pattern: spec/plan/acceptance/progress/spec-compact)
+- Template mirrors exist at expected paths (verified via `ls` during drafting): all 4 original + `.claude/skills/moai/SKILL.md` (new v0.1.1) — total 5 mirrors confirmed
+- `git-strategy.yaml.tmpl` template file existence confirmed (`internal/template/templates/.moai/config/sections/git-strategy.yaml.tmpl` — 2,836 bytes)
+- `moai update` does not auto-rewrite user `git-strategy.yaml` (per `CLAUDE.local.md` §2 Protected Directories rule + §22 Dev Settings Intent)
+- `spec-frontmatter-schema.md` SSOT lists `issue_number` as Optional field — D2 field-removal for new SPECs is consistent with schema (Optional fields may be omitted)
+
+## Next steps
+
+1. Sole maintainer reviews and approves this plan-phase artifact bundle (5 files in `.moai/specs/SPEC-V3R5-LATE-BRANCH-001/`)
+2. Plan-auditor subagent invoked for iter 1 verdict (target: PASS ≥ 0.85)
+3. Iter 2 revisions applied if needed
+4. `git switch -c plan/SPEC-V3R5-LATE-BRANCH-001 && git push -u origin plan/SPEC-V3R5-LATE-BRANCH-001` (first Phase C invocation — dogfooding)
+5. `gh pr create` for plan-PR
+6. Plan-PR squash merge into main
+7. `/moai run SPEC-V3R5-LATE-BRANCH-001` entry (default mode autopilot, cycle_type=ddd per `quality.yaml` development_mode)
+8. Phase 0.5 Plan Audit Gate at `/moai run` consults this progress.md (plan_status: audit-ready)
+9. M1 → M2 → M3 → M4 → M5 milestone execution per plan.md §3
+10. `/moai sync` → SPEC lifecycle complete
+
+## Self-application dogfooding log
+
+(Filled in as the workflow progresses)
+
+- [ ] Phase A (plan-phase): SPEC files committed to main directly — TIMESTAMP TBD
+- [ ] Phase C (plan-PR): `git switch -c plan/SPEC-V3R5-LATE-BRANCH-001` — TIMESTAMP TBD
+- [ ] Plan-PR squash merge — PR # TBD, TIMESTAMP TBD
+- [ ] Phase D after plan-PR merge: `git reset --hard origin/main` — TIMESTAMP TBD
+- [ ] Phase B (run-phase): implementation commits on main — TIMESTAMP RANGE TBD
+- [ ] Phase C (run-PR): `git switch -c feat/SPEC-V3R5-LATE-BRANCH-001` — TIMESTAMP TBD
+- [ ] Run-PR squash merge — PR # TBD, TIMESTAMP TBD
+- [ ] Phase D after run-PR merge — TIMESTAMP TBD
+- [ ] Sync-PR cycle (sync-phase) — PR # TBD, TIMESTAMP TBD
+- [ ] Phase D after sync-PR merge — TIMESTAMP TBD
+- [ ] AC-LB-006 dogfooding PASS confirmed

--- a/.moai/specs/SPEC-V3R5-LATE-BRANCH-001/progress.md
+++ b/.moai/specs/SPEC-V3R5-LATE-BRANCH-001/progress.md
@@ -1,6 +1,22 @@
 # SPEC-V3R5-LATE-BRANCH-001 Progress
 
-Plan-phase progress log for Late-Branch Workflow formalization.
+Plan-phase + Run-phase + Sync-phase progress log for Late-Branch Workflow formalization.
+
+## Sync-phase signals
+
+- sync_start_at: 2026-05-20T18:55:00Z (approximate)
+- sync_complete_at: 2026-05-20T18:56:00Z (approximate)
+- sync_status: completed
+- spec_status_final: completed
+- version_final: 0.3.0
+- pr_pattern: single-integrated (plan + run + sync 통합 PR per user decision C)
+- docs_site_impact: none (workflow/config 변경만 — 4-locale docs 영향 없음)
+- product_md_impact: none
+- structure_md_impact: none
+- tech_md_impact: none
+- cherry_pick_pattern: 본 SPEC 9 + sync 1 = 10 commits → 새 feat/SPEC-V3R5-LATE-BRANCH-001 branch (origin/main 기준 cherry-pick), STATUSLINE-V2145-001 4 commits은 main에 보존 (별도 처리)
+- parallel_work_handling: 본 세션과 평행으로 사용자가 sync/SPEC-V3R5-STATUSLINE-V2145-001 branch에서 STATUSLINE sync 작업 진행 — main으로 복귀하여 본 SPEC 우선 완료 (user decision)
+- post_pr_action: PR squash merge → git reset --hard origin/main + git pull (Phase D)
 
 ## Run-phase signals
 

--- a/.moai/specs/SPEC-V3R5-LATE-BRANCH-001/progress.md
+++ b/.moai/specs/SPEC-V3R5-LATE-BRANCH-001/progress.md
@@ -2,7 +2,45 @@
 
 Plan-phase progress log for Late-Branch Workflow formalization.
 
-## Plan-phase signals
+## Run-phase signals
+
+- run_start_at: 2026-05-20T16:40:00Z
+- run_complete_at: 2026-05-20T18:30:00Z
+- run_status: implemented
+- spec_version_at_run_start: 0.1.1 (plan-PASS 0.8600 iter 1)
+- spec_version_at_run_complete: 0.2.0 (v0.1.2 REQ-LB-008 promotion + v0.2.0 run-complete)
+- baseline_head: 446050377 (pre-session HEAD; LATE-BRANCH plan v0.1.1 commit)
+- pre_session_head: 2898f5530 (STATUSLINE progress.md update that landed between plan and run)
+- run_complete_head: c9b857b7b (chore catalog hash sync; last LATE-BRANCH commit)
+- cycle_type: ddd (per quality.yaml development_mode)
+- commit_strategy: Option β — 6 milestone commits + 1 catalog hash sync (W3 precedent)
+- self_application: TRUE — run-phase commits landed directly on `main` (Late-branch Phase B dogfooding); plan/SPEC-V3R5-LATE-BRANCH-001 branch deferred to Phase C handled by orchestrator
+
+### Commit ledger
+
+| Milestone | SHA       | Title |
+|-----------|-----------|-------|
+| M1        | 81188cad1 | feat: config switch (4 keys + inline comment) |
+| M2        | aff3a0829 | feat: spec-assembly Phase 3 conditional + Phase 2.5 opt-in |
+| M3        | 826533f8b | feat: manager-git Late-Branch Invocation Pattern + Personal Mode option |
+| M4        | e2c8e2582 | feat: spec-workflow Step 1 precondition + Step 4 Late-branch closure |
+| M5        | 8dca0384c | feat: SKILL.md --issue flag opt-in semantics |
+| M6        | 44b8194ae | test: template mirror allowlist extension (REQ-LB-008 promoted) |
+| chore     | c9b857b7b | catalog hash sync (moai SKILL.md + manager-git.md) |
+
+### AC verification results (binary)
+
+| AC          | Status | Verification command | Notes |
+|-------------|--------|----------------------|-------|
+| AC-LB-001   | PASS   | `yq '.git_strategy.team.{automation,branch_creation}.*'` returns 4 expected values | 4/4 yq probes match expected |
+| AC-LB-002   | PASS   | `grep -c 'auto_enabled' = 3`, `grep -c 'Late-branch' = 2` | Phase 3 conditional + Phase 2.5 gating |
+| AC-LB-003   | PASS   | `main_late_branch`=2, `Late-Branch Invocation Pattern`=2, Phase A/B/C/D=4+ | Personal Mode row + 4-phase subsection |
+| AC-LB-004   | PASS   | `main checkout`=1+, `git reset --hard origin/main`=2 | Step 1 precondition + Step 4 closure |
+| AC-LB-005   | PASS   | `go test ./internal/template/ -run TestLateBranchTemplateMirror` PASS + 3 .md diff returns 0 + 4 yaml keys exist in both | Negative drift test verified |
+| AC-LB-006   | PASS   | Scripted /tmp Phase A→D test | Working tree clean post-Phase D, local == origin |
+| AC-LB-007   | PASS   | `grep -B 5 'gh issue create' \| grep -c -- --issue = 4` ≥ unguarded=4 | All 4 occurrences gated by --issue flag |
+
+## Plan-phase signals (preserved)
 
 - plan_complete_at: 2026-05-20T16:30:00Z
 - plan_status: audit-ready

--- a/.moai/specs/SPEC-V3R5-LATE-BRANCH-001/spec-compact.md
+++ b/.moai/specs/SPEC-V3R5-LATE-BRANCH-001/spec-compact.md
@@ -1,8 +1,8 @@
 ---
 id: SPEC-V3R5-LATE-BRANCH-001
 title: "Late-Branch Workflow — Compact Extract"
-version: "0.1.1"
-status: draft
+version: "0.2.0"
+status: implemented
 created: 2026-05-20
 updated: 2026-05-20
 author: GOOS Kim
@@ -19,6 +19,8 @@ tags: "workflow, late-branch, git-strategy, dogfooding, compact, mega-sprint, v3
 
 | Version | Date | Author | Change |
 |---------|------|--------|--------|
+| 0.2.0 | 2026-05-20 | GOOS Kim (via manager-develop ddd) | Run-phase complete — status `draft → implemented`. 7/7 ACs PASS, 6 milestone commits + 1 chore catalog hash sync. See spec.md HISTORY v0.2.0 for full ledger. |
+| 0.1.2 | 2026-05-20 | GOOS Kim (via MoAI) | REQ-LB-008 promoted from Optional → Mandatory per plan-auditor iter1 Q2 CRITICAL recommendation. M6 delivers `lateBranchMirroredPaths` + `TestLateBranchTemplateMirror` parallel test. |
 | 0.1.1 | 2026-05-20 | GOOS Kim (via MoAI) | Mid-draft policy extension — REQ-LB-009 + AC-LB-007 + EXCL-LB-008 + R-LB-005 + D2 (no-auto-issue policy). 1 new affected file (`.claude/skills/moai/SKILL.md` + mirror). `issue_number` frontmatter field removed (D2). |
 | 0.1.0 | 2026-05-20 | GOOS Kim (via MoAI orchestrator) | Initial compact extract |
 
@@ -73,7 +75,7 @@ Formalize the **Late-branch workflow pattern**: SPEC commits accumulate directly
 - REQ-LB-005 State-Driven: `manager-git` Personal Mode supports `main_late_branch` option
 - REQ-LB-006 State-Driven: `spec-workflow.md` Step 4 documents `git reset --hard origin/main`
 - REQ-LB-007 Unwanted: System NEVER `git push origin main` during Phase A/B
-- REQ-LB-008 Optional: `rule_template_mirror_test.go` extended for new D1 fields (if existing coverage insufficient)
+- REQ-LB-008 Mandatory (promoted v0.1.2): `rule_template_mirror_test.go` extended with `lateBranchMirroredPaths` + `TestLateBranchTemplateMirror` parallel test (M6 delivered)
 - **REQ-LB-009 Mandatory (v0.1.1)**: `/moai plan` MUST NOT auto-create GitHub Issue without explicit `--issue` flag
 
 ---
@@ -120,9 +122,18 @@ Formalize the **Late-branch workflow pattern**: SPEC commits accumulate directly
 
 ---
 
-## Out of Scope (8 Exclusions)
+## Exclusions
 
-EXCL-LB-001 Migration tool (auto-rewrite existing `git-strategy.yaml`) / -002 pre-push hook impl (follow-on SPEC) / -003 `main_direct`/`develop_direct` PR-less mode / -004 Worktree pattern extension (already in SPEC-V3R4-WORKTREE) / -005 Parallel multi-SPEC on single checkout (worktree required) / -006 `mode: manual`/`personal` Late-branch activation (only `mode: team` in scope) / -007 GUI/IDE plugin integration / **-008 (v0.1.1)** Migration tool retroactively removing `issue_number` from existing SPEC frontmatter (historical SPECs retain `issue_number` as immutable history)
+### Out of Scope (8 Exclusions)
+
+- EXCL-LB-001: Migration tool (auto-rewrite existing `git-strategy.yaml`)
+- EXCL-LB-002: pre-push hook impl (follow-on SPEC)
+- EXCL-LB-003: `main_direct`/`develop_direct` PR-less mode
+- EXCL-LB-004: Worktree pattern extension (already in SPEC-V3R4-WORKTREE)
+- EXCL-LB-005: Parallel multi-SPEC on single checkout (worktree required)
+- EXCL-LB-006: `mode: manual`/`personal` Late-branch activation (only `mode: team` in scope)
+- EXCL-LB-007: GUI/IDE plugin integration
+- EXCL-LB-008 (v0.1.1): Migration tool retroactively removing `issue_number` from existing SPEC frontmatter (historical SPECs retain `issue_number` as immutable history)
 
 ---
 

--- a/.moai/specs/SPEC-V3R5-LATE-BRANCH-001/spec-compact.md
+++ b/.moai/specs/SPEC-V3R5-LATE-BRANCH-001/spec-compact.md
@@ -1,0 +1,198 @@
+---
+id: SPEC-V3R5-LATE-BRANCH-001
+title: "Late-Branch Workflow — Compact Extract"
+version: "0.1.1"
+status: draft
+created: 2026-05-20
+updated: 2026-05-20
+author: GOOS Kim
+priority: P1
+phase: "v3.5.0"
+module: ".moai/config/sections/git-strategy + .claude/skills/moai/workflows/plan/spec-assembly + .claude/skills/moai/SKILL.md + .claude/agents/moai/manager-git + .claude/rules/moai/workflow/spec-workflow + internal/template/templates (5 mirrors)"
+lifecycle: spec-anchored
+tags: "workflow, late-branch, git-strategy, dogfooding, compact, mega-sprint, v3r5"
+---
+
+> Auto-extracted compact summary from spec.md / plan.md / acceptance.md. For full context, see those three files. Memory sources: `project_v3r5_late_branch_decision.md`, `feedback_late_branch_workflow.md`, `feedback_no_github_issue_for_specs.md` (v0.1.1 extension).
+
+## HISTORY
+
+| Version | Date | Author | Change |
+|---------|------|--------|--------|
+| 0.1.1 | 2026-05-20 | GOOS Kim (via MoAI) | Mid-draft policy extension — REQ-LB-009 + AC-LB-007 + EXCL-LB-008 + R-LB-005 + D2 (no-auto-issue policy). 1 new affected file (`.claude/skills/moai/SKILL.md` + mirror). `issue_number` frontmatter field removed (D2). |
+| 0.1.0 | 2026-05-20 | GOOS Kim (via MoAI orchestrator) | Initial compact extract |
+
+---
+
+## Mission
+
+Formalize the **Late-branch workflow pattern**: SPEC commits accumulate directly on `main`; the `feat/SPEC-*` branch is created ONLY at PR creation time via `git switch -c`; PR squash-merges into main; local main is then reset via `git reset --hard origin/main`. **`mode: team` is preserved** — branch protection + PR/CI gates remain active. User directive (2026-05-20): "1인 메인테이너 환경에서 자동 branch 생성 overhead 제거, PR/CI gate 유지."
+
+---
+
+## 4-Phase Procedure
+
+| Phase | Action | Branch state |
+|---|---|---|
+| **A** SPEC creation | `git checkout main && git pull origin main` → `/moai plan` → commit SPEC files on main | `main` (no new branch) |
+| **B** Implementation | RED/GREEN/REFACTOR commits accumulate on local main | `main` (ahead of origin) |
+| **C** PR creation | `git switch -c feat/SPEC-XXX` → push → `gh pr create` → squash merge | `feat/SPEC-XXX` (transient) |
+| **D** Local reset | `git checkout main && git reset --hard origin/main && git pull origin main` | `main` (synced) |
+
+---
+
+## Architecture (5 Modifications + 5 Mirrors)
+
+| # | File | Modification |
+|---|------|--------------|
+| D1 | `.moai/config/sections/git-strategy.yaml` `team` section | 4 keys: `auto_branch`/`auto_pr`/`auto_enabled`: true→false; `prompt_always`: false→true |
+| D2 | `.claude/skills/moai/workflows/plan/spec-assembly.md` Phase 3 + Phase 2.5 | Add `if auto_enabled == false: skip branch creation` conditional + "Late-branch" mode display. **v0.1.1**: Phase 2.5 (GitHub Issue Creation) default skip; gated only by explicit `--issue` flag per REQ-LB-009. |
+| D3 | `.claude/agents/moai/manager-git.md` | Add `main_late_branch` row to Personal Mode table + new "Late-Branch Invocation Pattern" subsection documenting Phase A→D |
+| D4 | `.claude/rules/moai/workflow/spec-workflow.md` | Step 1 entry precondition: `main checkout` requirement when `auto_enabled == false`; Step 4 cleanup: `git reset --hard origin/main` canonical closure |
+| D5 | 5 template mirrors under `internal/template/templates/` | byte-equivalent (modulo `.tmpl` vars) propagation of D1-D4 + new `.claude/skills/moai/SKILL.md` mirror (v0.1.1) |
+| **NEW v0.1.1** | `.claude/skills/moai/SKILL.md` | `--issue` flag semantics flip: opt-out via `--no-issue` → opt-in via `--issue` (default = skip issue creation) |
+
+---
+
+## D1 Backward-Compatibility Decision
+
+**Selected: Option (a) Breaking default change** — template `.tmpl` flips to `auto_enabled: false`. New projects (`moai init` post-v3.5.0) start in Late-branch mode. Existing projects (`moai update`) unaffected because `moai update` preserves user-modified `git-strategy.yaml`. v3.5.0 release notes call out the breaking default. (Options b/c evaluated and rejected — see plan.md §2 D1.)
+
+## D2 Frontmatter `issue_number` Field Removal (added v0.1.1)
+
+**Decision**: Remove `issue_number` field from spec.md frontmatter for new SPECs from v0.1.1 onward. Existing SPECs retain `issue_number` as immutable history (EXCL-LB-008 — no migration). Distinction from D1: D1 = behavior change (auto-branch default); D2 = metadata simplification (no issue_number on new SPECs). Both share **sole-maintainer workflow optimization** motivation. (See plan.md §2 D2.)
+
+---
+
+## EARS REQ Summary (9 = 8 Mandatory + 1 Optional)
+
+- REQ-LB-001 Ubiquitous: `/moai plan` does NOT create branch when `auto_enabled == false`
+- REQ-LB-002 Ubiquitous: `manager-spec` commits SPEC files to main directly (no push)
+- REQ-LB-003 Event-Driven: `manager-git` detects Late-branch pattern after manual `git switch -c`
+- REQ-LB-004 Event-Driven: Phase 3 reads `auto_enabled` and skips branch creation when `false`
+- REQ-LB-005 State-Driven: `manager-git` Personal Mode supports `main_late_branch` option
+- REQ-LB-006 State-Driven: `spec-workflow.md` Step 4 documents `git reset --hard origin/main`
+- REQ-LB-007 Unwanted: System NEVER `git push origin main` during Phase A/B
+- REQ-LB-008 Optional: `rule_template_mirror_test.go` extended for new D1 fields (if existing coverage insufficient)
+- **REQ-LB-009 Mandatory (v0.1.1)**: `/moai plan` MUST NOT auto-create GitHub Issue without explicit `--issue` flag
+
+---
+
+## Binary ACs (7)
+
+| AC | Verification |
+|---|---|
+| AC-LB-001 | `yq` on 4 `team` keys: returns false/false/false/true |
+| AC-LB-002 | `grep -c 'auto_enabled'` + `grep -c 'Late-branch'` in spec-assembly.md: both ≥1 |
+| AC-LB-003 | `grep -c 'main_late_branch'` + `grep -c 'Late-Branch Invocation Pattern'` + `grep -cE '^(Phase A|B|C|D)'` in manager-git.md: ≥1, ≥1, ≥4 |
+| AC-LB-004 | `grep -c 'main checkout'` + `grep -c 'git reset --hard origin/main'` in spec-workflow.md: both ≥1 |
+| AC-LB-005 | `diff` returns 0 lines for 3 .md mirror pairs + `yq` consistent on .yaml.tmpl + `go test ./internal/template/...` PASS |
+| AC-LB-006 | E2E scenario: Phase A→D leaves `git status --porcelain` empty AND `main == origin/main`. Dogfooding (this SPEC's own PR cycle) is primary verification path. |
+| AC-LB-007 (v0.1.1) | `grep -c "gh issue create"` in spec-assembly.md returns 0, OR every occurrence is gated by an explicit `--issue` flag check |
+
+---
+
+## Edge Cases (4)
+
+- EC-LB-001 Concurrent SPEC work: BODP gate detects dirty tree → AskUserQuestion (a/b/c)
+- EC-LB-002 Accidental `git push origin main` during Phase B: branch protection blocks; orchestrator recommends Phase C `git switch -c`
+- EC-LB-003 Phase D omitted: Phase A precondition catches divergence; recommends fetch + reset
+- EC-LB-004 CI block during Phase C: fixup commits OR abort PR + fix on main + `--force-with-lease` push (admin-squash-override pattern preserved)
+
+---
+
+## Constraints (4)
+
+- C-LB-001: Local main MAY be ahead of `origin/main` during Phase B/C (commit-not-yet-pushed). Pattern explicitly relies on this.
+- C-LB-002: One SPEC at a time on a given checkout. Parallel SPECs → worktree pattern (EXCL-LB-005).
+- C-LB-003: Phase D `git reset --hard origin/main` MANDATORY post-squash. Skipping causes next `git pull` conflict (R-LB-002).
+- C-LB-004: `mode: team` PRESERVED. Branch protection 4 required checks + PR/CI gates remain active. Late-branch only changes WHEN branch is created, not WHETHER PR exists.
+
+---
+
+## Risks (5)
+
+- R-LB-001: Accidental `git push origin main` during Phase A/B. Mitigation: REQ-LB-007 + `manager-git.md` caveat + future pre-push hook SPEC (EXCL-LB-002).
+- R-LB-002: Phase D omitted. Mitigation: Step 4 documentation + memory + orchestrator next-invocation detection.
+- R-LB-003: Backward compat for existing users. Mitigation: `moai update` preserves user config + v3.5.0 release notes + `prompt_always: true` teaches at first SPEC creation.
+- R-LB-004: Template mirror drift. Mitigation: AC-LB-005 sync-PR enforcement + existing `internal/template/rule_template_mirror_test.go` CI guard.
+- R-LB-005 (v0.1.1): PR template `closes #N` references break for SPECs lacking `issue_number`. Mitigation: `closes #N` lines remain optional; SPECs without issue_number omit close reference; no tooling change required.
+
+---
+
+## Out of Scope (8 Exclusions)
+
+EXCL-LB-001 Migration tool (auto-rewrite existing `git-strategy.yaml`) / -002 pre-push hook impl (follow-on SPEC) / -003 `main_direct`/`develop_direct` PR-less mode / -004 Worktree pattern extension (already in SPEC-V3R4-WORKTREE) / -005 Parallel multi-SPEC on single checkout (worktree required) / -006 `mode: manual`/`personal` Late-branch activation (only `mode: team` in scope) / -007 GUI/IDE plugin integration / **-008 (v0.1.1)** Migration tool retroactively removing `issue_number` from existing SPEC frontmatter (historical SPECs retain `issue_number` as immutable history)
+
+---
+
+## File Touch List (run-phase)
+
+### MODIFIED existing (10 = 5 source + 5 template mirror)
+
+Local:
+- `.moai/config/sections/git-strategy.yaml`
+- `.claude/skills/moai/workflows/plan/spec-assembly.md`
+- `.claude/skills/moai/SKILL.md` (NEW v0.1.1)
+- `.claude/agents/moai/manager-git.md`
+- `.claude/rules/moai/workflow/spec-workflow.md`
+
+Template mirrors (`internal/template/templates/`):
+- `.moai/config/sections/git-strategy.yaml.tmpl`
+- `.claude/skills/moai/workflows/plan/spec-assembly.md`
+- `.claude/skills/moai/SKILL.md` (NEW v0.1.1)
+- `.claude/agents/moai/manager-git.md`
+- `.claude/rules/moai/workflow/spec-workflow.md`
+
+### NEW (0)
+No new files. Pure configuration + documentation SPEC.
+
+### CI guards (existing, no new)
+- `internal/template/rule_template_mirror_test.go` (mirror parity — possibly extended per REQ-LB-008)
+
+---
+
+## AC Count + Dependency Status
+
+| Metric | Value |
+|--------|-------|
+| EARS REQs | 8 mandatory + 1 Optional (REQ-LB-001..009) |
+| Binary ACs | 7 (AC-LB-001..007) |
+| Edge Cases | 4 (EC-LB-001..004) |
+| Risk Mitigations | 5 (R-LB-001..005) |
+| Constraints | 4 (C-LB-001..004) |
+| Exclusions | 8 (EXCL-LB-001..008) |
+| Total verification surface | 16 (7 ACs + 4 ECs + 5 Rs) |
+| REQ ↔ AC traceability | 100% (each REQ maps to ≥1 AC; full table in acceptance.md §1) |
+
+Dependencies:
+- **Soft**: W3 HARNESS-AUTONOMY-001 (COMPLETE) — used as structural reference template
+- **Soft**: SPEC-V3R5-CONSTITUTION-DUAL-001 (COMPLETE) — admin-squash-override pattern reference for EC-LB-004
+- **Orthogonal**: SPEC-V3R4-WORKTREE — worktree pattern boundary (parallel SPECs)
+- **Blocks** (potential): SPEC-V3R5-MAIN-PUSH-GUARD-* (follow-on pre-push hook SPEC, EXCL-LB-002)
+
+---
+
+## M1-M5 Milestone List
+
+| Milestone | Priority | Dependencies | Deliverables |
+|-----------|----------|--------------|--------------|
+| M1 Config switch | P0 | none | git-strategy.yaml + .tmpl (4 keys flipped) |
+| M2 Skill body Phase 3 | P0 | M1 | spec-assembly.md Phase 3 conditional + "Late-branch" mode display |
+| M3 Agent body | P0 | M1+M2 | manager-git.md `main_late_branch` row + Late-Branch Invocation Pattern subsection |
+| M4 Rule update | P0 | M3 | spec-workflow.md Step 1 + Step 4 |
+| M5 Template mirror parity | P0 | M1-M4 | 4 mirrors byte-equivalent to local |
+
+Sequential within single run-phase (`manager-develop` cycle_type=ddd, ANALYZE-PRESERVE-IMPROVE per modification — modifying existing files). ~80-150 LOC total across 8 files (4 local + 4 template).
+
+---
+
+## Self-Application (Dogfooding)
+
+This SPEC's plan-phase commits land directly on `main` as the first concrete demonstration of the pattern. `plan/SPEC-V3R5-LATE-BRANCH-001` branch is NOT created during plan-phase drafting — it is created at plan-PR time via `git switch -c plan/SPEC-V3R5-LATE-BRANCH-001`. AC-LB-006 dogfooding verification is empirically achieved by completing the full plan-PR → run-PR → sync-PR cycle with clean Phase D resets.
+
+---
+
+## Recommended Next Action
+
+Invoke **plan-auditor subagent** for iter 1 independent review of this SPEC's plan-phase artifacts (5 files). Anticipated audit dimensions per W3 iter1 pattern: D1 Brief Quality, D2 Phase Decomposition, D3 Risk Management, D4 Frontmatter Compliance, D5 Exclusion Discipline, D6 Lint Baseline. Target: PASS ≥ 0.85.

--- a/.moai/specs/SPEC-V3R5-LATE-BRANCH-001/spec-compact.md
+++ b/.moai/specs/SPEC-V3R5-LATE-BRANCH-001/spec-compact.md
@@ -1,8 +1,8 @@
 ---
 id: SPEC-V3R5-LATE-BRANCH-001
 title: "Late-Branch Workflow — Compact Extract"
-version: "0.2.0"
-status: implemented
+version: "0.3.0"
+status: completed
 created: 2026-05-20
 updated: 2026-05-20
 author: GOOS Kim
@@ -19,6 +19,7 @@ tags: "workflow, late-branch, git-strategy, dogfooding, compact, mega-sprint, v3
 
 | Version | Date | Author | Change |
 |---------|------|--------|--------|
+| 0.3.0 | 2026-05-20 | GOOS Kim (via MoAI) | Sync-phase complete — status `implemented → completed`. Single-integrated PR pattern (user decision C). docs-site impact: none. Cherry-pick으로 본 SPEC 10 commits만 새 feat branch로 분리, STATUSLINE 4 commits은 main에 보존. See spec.md HISTORY v0.3.0 for full ledger. |
 | 0.2.0 | 2026-05-20 | GOOS Kim (via manager-develop ddd) | Run-phase complete — status `draft → implemented`. 7/7 ACs PASS, 6 milestone commits + 1 chore catalog hash sync. See spec.md HISTORY v0.2.0 for full ledger. |
 | 0.1.2 | 2026-05-20 | GOOS Kim (via MoAI) | REQ-LB-008 promoted from Optional → Mandatory per plan-auditor iter1 Q2 CRITICAL recommendation. M6 delivers `lateBranchMirroredPaths` + `TestLateBranchTemplateMirror` parallel test. |
 | 0.1.1 | 2026-05-20 | GOOS Kim (via MoAI) | Mid-draft policy extension — REQ-LB-009 + AC-LB-007 + EXCL-LB-008 + R-LB-005 + D2 (no-auto-issue policy). 1 new affected file (`.claude/skills/moai/SKILL.md` + mirror). `issue_number` frontmatter field removed (D2). |

--- a/.moai/specs/SPEC-V3R5-LATE-BRANCH-001/spec.md
+++ b/.moai/specs/SPEC-V3R5-LATE-BRANCH-001/spec.md
@@ -1,8 +1,8 @@
 ---
 id: SPEC-V3R5-LATE-BRANCH-001
 title: "Late-Branch Workflow — main 작업 + late branch + PR squash + local main reset"
-version: "0.2.0"
-status: implemented
+version: "0.3.0"
+status: completed
 created: 2026-05-20
 updated: 2026-05-20
 author: GOOS Kim
@@ -17,6 +17,7 @@ tags: "workflow, late-branch, git-strategy, dogfooding, mega-sprint, v3r5"
 
 | Version | Date | Author | Change |
 |---------|------|--------|--------|
+| 0.3.0 | 2026-05-20 | GOOS Kim (via MoAI) | Sync-phase complete — lifecycle close. status `implemented → completed`. Single-integrated PR pattern (user decision C): plan + run + sync 3-phase 모두 main에 누적 후 1 PR로 통합 머지. docs-site 영향 없음 (workflow/config 변경만 — product/structure/tech.md 모두 영향 없음). plan-PR + run-PR + sync-PR 3-way split 대신 1 통합 PR로 simplification. Cherry-pick 패턴: 본 SPEC 9 (plan/run/chore/status) + sync 1 = 10 commits만 origin/main 기준 새 feat/SPEC-V3R5-LATE-BRANCH-001 branch로 분리. STATUSLINE-V2145-001 SPEC 4 commits은 main에 그대로 보존 (별도 PR 처리). 본 세션과 평행으로 사용자가 sync/SPEC-V3R5-STATUSLINE-V2145-001 branch에서 STATUSLINE sync 작업 진행 — main 복귀 후 본 SPEC 우선 완료 결정. Late-branch Phase A(plan)+B(run)+sync 모두 main commit, Phase C(branch+push+PR) 진입 직전. |
 | 0.2.0 | 2026-05-20 | GOOS Kim (via manager-develop ddd) | Run-phase complete — status `draft → in-progress → implemented`. 7 ACs binary PASS (AC-LB-001 yq config switch / AC-LB-002 spec-assembly Phase 3 conditional / AC-LB-003 manager-git Personal Mode + Invocation Pattern / AC-LB-004 spec-workflow Step 1 precondition + Step 4 closure / AC-LB-005 template mirror parity via TestRuleTemplateMirrorDrift + TestLateBranchTemplateMirror / AC-LB-006 scripted E2E in /tmp / AC-LB-007 gh issue create gating). 11 files changed across 6 milestones + 1 catalog hash sync commit (M1 81188cad1, M2 aff3a0829, M3 826533f8b, M4 e2c8e2582, M5 8dca0384c, M6 44b8194ae, chore c9b857b7b). Self-application dogfooding succeeded — plan/run commits landed directly on main with branch deferred to Phase C. |
 | 0.1.2 | 2026-05-20 | GOOS Kim (via MoAI) | REQ-LB-008 promoted from Optional → Mandatory per plan-auditor iter1 Q2 CRITICAL recommendation. Existing `internal/template/rule_template_mirror_test.go` `workflowOptMirroredPaths` covers only 9 paths, NONE matching the 4 LATE-BRANCH markdown files; without allowlist extension AC-LB-005 was vacuous. M6 delivers `lateBranchMirroredPaths` + `TestLateBranchTemplateMirror` parallel test with shared `RULE_TEMPLATE_MIRROR_DRIFT` sentinel. |
 | 0.1.1 | 2026-05-20 | GOOS Kim (via MoAI) | Mid-draft policy extension — REQ-LB-009 + AC-LB-007 + EXCL-LB-008 + R-LB-005 added for "no auto GitHub Issue" policy. `issue_number` frontmatter field removed (D2 decision). 1 new affected file (`.claude/skills/moai/SKILL.md` + template mirror). Source: `feedback_no_github_issue_for_specs.md` user directive 2026-05-20. |

--- a/.moai/specs/SPEC-V3R5-LATE-BRANCH-001/spec.md
+++ b/.moai/specs/SPEC-V3R5-LATE-BRANCH-001/spec.md
@@ -1,0 +1,205 @@
+---
+id: SPEC-V3R5-LATE-BRANCH-001
+title: "Late-Branch Workflow — main 작업 + late branch + PR squash + local main reset"
+version: "0.1.1"
+status: draft
+created: 2026-05-20
+updated: 2026-05-20
+author: GOOS Kim
+priority: P1
+phase: "v3.5.0"
+module: ".moai/config/sections/git-strategy + .claude/skills/moai/workflows/plan/spec-assembly + .claude/skills/moai/SKILL.md + .claude/agents/moai/manager-git + .claude/rules/moai/workflow/spec-workflow + internal/template/templates (5 mirrors)"
+lifecycle: spec-anchored
+tags: "workflow, late-branch, git-strategy, dogfooding, mega-sprint, v3r5"
+---
+
+## HISTORY
+
+| Version | Date | Author | Change |
+|---------|------|--------|--------|
+| 0.1.1 | 2026-05-20 | GOOS Kim (via MoAI) | Mid-draft policy extension — REQ-LB-009 + AC-LB-007 + EXCL-LB-008 + R-LB-005 added for "no auto GitHub Issue" policy. `issue_number` frontmatter field removed (D2 decision). 1 new affected file (`.claude/skills/moai/SKILL.md` + template mirror). Source: `feedback_no_github_issue_for_specs.md` user directive 2026-05-20. |
+| 0.1.0 | 2026-05-20 | GOOS Kim (via MoAI orchestrator) | Initial draft — T2 Standard scope (4 source files + 4 template mirrors). Formalizes Late-branch workflow pattern decided 2026-05-20 (`feedback_late_branch_workflow.md`, `project_v3r5_late_branch_decision.md`). Self-applying: this SPEC's plan-phase commits land directly on `main` as dogfooding demonstration. 7 EARS REQs + 6 binary ACs + 4 Edge Cases + 4 Risks + 3 Exclusions. Backward-compatibility D-decision deferred to plan.md §D-Decisions (Option a/b/c assessment). |
+
+---
+
+## 1. 개요 (Overview)
+
+### 1.1 사용자 directive (verbatim, 2026-05-20)
+
+> "사용자는 SPEC마다 자동으로 feat/SPEC-XXX branch가 생성되는 현재 mode: team + auto_branch: true 패턴이 무겁다고 판단. main 위에서 작업 누적 후 PR 시점에만 분기하는 Late-branch 패턴을 선호."
+
+### 1.2 Mission statement
+
+`/moai plan`이 자동으로 `feat/SPEC-*` branch를 생성하는 현재 동작을 **opt-out** 가능하게 만들고, 사용자가 `main` 위에서 SPEC commits을 누적한 뒤 PR 시점에만 `git switch -c feat/SPEC-*`로 분기하여 squash merge 후 local main을 `origin/main`으로 재정렬하는 4-phase Late-branch 워크플로를 1급(first-class)으로 지원한다. **`mode: team`은 유지**되며, branch protection (4 required checks) + PR/CI 게이트는 변경 없이 그대로 활용된다.
+
+### 1.3 본 SPEC의 dogfooding 자기 적용 (self-application)
+
+본 SPEC의 **plan-phase 산출물 (spec.md, plan.md, acceptance.md, progress.md, spec-compact.md)이 직접 `main` 위에서 commit된다**. Late-branch 패턴을 SPEC 작성 시점부터 시연 (demonstration) 하기 위함이다. 이는 본 SPEC이 정의하는 패턴의 첫 실제 적용 사례이며, `plan/SPEC-V3R5-LATE-BRANCH-001` branch는 `git switch -c` 시점까지 생성되지 않는다. 사용자가 PR 생성 시점에 명시적으로 분기한다.
+
+### 1.4 현재 상태 (empirical, main HEAD post-W3 sync)
+
+- `.moai/config/sections/git-strategy.yaml` `team` section: `auto_branch: true`, `auto_pr: true`, `branch_creation.auto_enabled: true`, `branch_creation.prompt_always: false` (current defaults, line 50-74)
+- `.claude/skills/moai/workflows/plan/spec-assembly.md`: Phase 3 (Git Environment Setup) 분기 로직 line 253-340. 현재 `branch_creation.auto_enabled` 분기 미존재 — 항상 branch creation 수행 가정
+- `.claude/agents/moai/manager-git.md`: Personal Mode SPEC Git Workflow 표 존재. `main_late_branch` 옵션 부재
+- `.claude/rules/moai/workflow/spec-workflow.md`: Step 1 (plan) entry condition은 "main checkout"만 명시 (line ~80). Step 4 (cleanup) cleanup procedure은 worktree disposal 중심, `git reset --hard origin/main` 미문서화
+- Template mirrors (4 files under `internal/template/templates/`): byte-equivalent counterparts 존재 (`git-strategy.yaml.tmpl`, `manager-git.md`, `spec-assembly.md`, `spec-workflow.md`) — 본 SPEC은 local + template 양쪽 모두 수정 필요
+
+### 1.5 본 SPEC의 목표 (T2 Standard scope)
+
+1. **D1 Config switch**: `git-strategy.yaml` `team` section 4 keys 변경 (`auto_branch`/`auto_pr`/`auto_enabled`/`prompt_always`). 변경 정책 = **plan.md §D-Decisions 결정 (Option a/b/c)**.
+2. **D2 Skill body**: `spec-assembly.md` Phase 3에 `auto_enabled == false` 분기 추가 (branch creation skip + cwd preserved on `main`). **추가 (v0.1.1)**: Phase 2.5 (GitHub Issue Creation) MUST default to skip; gated only by explicit `--issue` flag per REQ-LB-009.
+3. **D3 Agent body**: `manager-git.md` Personal Mode 표 + Branch Management 섹션에 `main_late_branch` workflow option 추가. Late-Branch Invocation Pattern 4-phase 절차 (A→D) 문서화.
+4. **D4 Rule update**: `spec-workflow.md` Step 1 entry precondition + Step 4 cleanup procedure에 Late-branch 패턴 명시. `git reset --hard origin/main` post-squash 표준 종결 단계로 등록.
+5. **D5 Template mirror parity**: D1-D4의 변경을 `internal/template/templates/` 하위 4 mirror 파일에 byte-equivalent (modulo `.tmpl` placeholders) 복사. **추가 (v0.1.1)**: `.claude/skills/moai/SKILL.md`와 template mirror 5번째 페어 추가 — `--issue` flag 시맨틱 flip (opt-out via `--no-issue` → opt-in via `--issue`).
+6. **D6 No migration tool**: 기존 사용자 `git-strategy.yaml` 파일의 자동 재작성은 본 SPEC scope 외. `moai update` 동작은 plan.md §D-Decisions에서 backward-compat 옵션과 함께 결정. **추가 (v0.1.1)**: `issue_number` frontmatter 필드의 retroactive 제거는 EXCL-LB-008로 명시 — 새 SPEC만 prospective 적용.
+
+### 1.6 Brownfield State Inventory
+
+본 SPEC은 brownfield 작업이다. 4 source 파일 + 4 template mirror 파일 모두 기존 존재하며 [EXTEND] 대상이다. [NEW] 파일은 없다.
+
+| Marker | 파일 | 분류 | 근거 |
+|--------|------|------|------|
+| [EXTEND] | `.moai/config/sections/git-strategy.yaml` | EXTEND | `team` section 4 키 값 변경. 구조 추가 없음. |
+| [EXTEND] | `.claude/skills/moai/workflows/plan/spec-assembly.md` | EXTEND | Phase 3에 조건 분기 추가. 기존 Phase 3.0 BODP Gate 보존. **추가 (v0.1.1)**: Phase 2.5 (GitHub Issue Creation) default skip per REQ-LB-009. |
+| [EXTEND] | `.claude/skills/moai/SKILL.md` | EXTEND | **신규 (v0.1.1)**: `--issue` flag 시맨틱 flip. opt-out via `--no-issue` → opt-in via `--issue` (default = skip issue creation). |
+| [EXTEND] | `.claude/agents/moai/manager-git.md` | EXTEND | Personal Mode 표에 행 추가 + Late-Branch Invocation Pattern 절 신설. |
+| [EXTEND] | `.claude/rules/moai/workflow/spec-workflow.md` | EXTEND | Step 1 entry precondition + Step 4 cleanup procedure 보강. |
+| [EXTEND] | `internal/template/templates/.moai/config/sections/git-strategy.yaml.tmpl` | EXTEND | local mirror — D1 변경 byte-equivalent (modulo template variables). |
+| [EXTEND] | `internal/template/templates/.claude/skills/moai/workflows/plan/spec-assembly.md` | EXTEND | local mirror — D2 변경 (Phase 3 branch + Phase 2.5 default skip). |
+| [EXTEND] | `internal/template/templates/.claude/skills/moai/SKILL.md` | EXTEND | **신규 (v0.1.1)**: local mirror — `--issue` flag 시맨틱 flip. |
+| [EXTEND] | `internal/template/templates/.claude/agents/moai/manager-git.md` | EXTEND | local mirror — D3 변경. |
+| [EXTEND] | `internal/template/templates/.claude/rules/moai/workflow/spec-workflow.md` | EXTEND | local mirror — D4 변경. |
+
+### 1.7 Out of Scope (요약)
+
+- 기존 사용자 프로젝트의 `git-strategy.yaml` 자동 재작성 (migration tooling)
+- `main` direct push 차단을 위한 pre-push hook 구현 (별도 SPEC 후보)
+- Worktree pattern 확장 (이미 SPEC-V3R4-WORKTREE에서 cover)
+- Personal mode `main_direct`/`develop_direct` 옵션 활성화 (PR-less workflow는 별도 결정)
+
+상세 enumeration은 §3.5 Exclusions 참조.
+
+---
+
+## 2. Context — Background and Decision History
+
+### 2.1 결정 시점과 사용자 의도
+
+2026-05-20 세션에서 사용자(GOOS행님, 1인 메인테이너)는 현재 `mode: team` + `auto_branch: true` 패턴이 SPEC마다 branch 전환 오버헤드를 발생시켜 "무겁다"고 판단했다. 단일 메인테이너 환경에서 SPEC 생성 → 구현 → PR 사이클이 단일 흐름이므로 branch 전환 없이 `main` 위에서 누적 작업을 수행하되, PR/CI gate는 그대로 활용하고자 한다.
+
+### 2.2 왜 branch protection은 유지하는가
+
+`mode: team` 유지의 핵심 이유:
+
+- **CI signature**: branch protection 4 required checks (lint/test/race/build)가 PR마다 강제 실행됨 — 1인 메인테이너 환경에서도 self-review 보강 효과
+- **Squash history**: PR squash merge로 main 히스토리가 1-SPEC = 1-commit으로 정리됨
+- **PR review surface**: CI 결과, label, comment trail이 SPEC 단위로 보존됨
+- **Admin override**: chicken-and-egg 상황(예: lint baseline cleanup SPEC)에서 admin-squash-merge 우회 경로 보존
+
+Late-branch 패턴은 위 4가지 가치를 **유지**하면서 branch 전환 비용만 제거한다. branch는 PR 생성 시점까지 미생성 상태로 미뤄지며 (late = 뒤로 미룬다는 의미), 이는 SPEC 작성 동안 working tree가 main을 자연스럽게 따라간다는 의미다.
+
+### 2.3 4-Phase 워크플로 절차
+
+`feedback_late_branch_workflow.md`에 기록된 실행 가능 (executable) 절차:
+
+**Phase A — SPEC 생성 (main 위에서)**
+```bash
+git checkout main && git pull origin main
+/moai plan SPEC-XXX "description"   # → .moai/specs/SPEC-XXX/{5 files}, NO branch
+git add .moai/specs/SPEC-XXX/
+git commit -m "spec(SPEC-XXX): initial plan"   # main 직접 commit
+```
+
+**Phase B — Implementation (main 위에서 누적, push 안 함)**
+```bash
+git commit -m "🔴 RED: ..."
+git commit -m "🟢 GREEN: ..."
+git commit -m "♻ REFACTOR: ..."
+```
+
+**Phase C — PR 시점 분기 + push + merge**
+```bash
+git switch -c feat/SPEC-XXX
+git push -u origin feat/SPEC-XXX
+gh pr create --base main --title "..." --body "..."
+# CI 통과 → admin-squash-merge OR 정상 squash merge
+gh pr merge <PR-NUM> --squash --delete-branch
+```
+
+**Phase D — Local main 동기화**
+```bash
+git checkout main
+git reset --hard origin/main   # local main → squashed remote main
+git pull origin main           # 안전 확인
+```
+
+### 2.4 자기 적용 (dogfooding) 제약 (constraint of self-application)
+
+본 SPEC의 plan-phase 자체가 이 패턴을 실행한다. `manager-spec` subagent가 5개 산출물을 `.moai/specs/SPEC-V3R5-LATE-BRANCH-001/`에 작성한 후, 사용자가 main에 직접 commit한다. 이후 plan-PR을 위해 `git switch -c plan/SPEC-V3R5-LATE-BRANCH-001`을 실행하여 분기하고 push한다. 이 절차는 본 SPEC이 구현하려는 패턴의 첫 시연이며, 동시에 본 SPEC을 작성하는 사용자가 패턴의 모든 단계를 직접 경험하는 도구이기도 하다.
+
+### 2.5 메모리 참조 (Memory References)
+
+- `~/.claude/projects/-Users-goos-MoAI-moai-adk-go/memory/project_v3r5_late_branch_decision.md` — 결정 요약 + paste-ready resume + EARS REQ/AC drafts (본 SPEC의 종자)
+- `~/.claude/projects/-Users-goos-MoAI-moai-adk-go/memory/feedback_late_branch_workflow.md` — 워크플로 패턴 lessons + 4-phase 절차 + caveats (`main` direct push 금지, 병렬 SPEC 제약, fetch+rebase 누락 시 conflict)
+
+---
+
+## 3. EARS Requirements
+
+### 3.1 Ubiquitous
+
+**REQ-LB-001**: The system shall, when `team.branch_creation.auto_enabled == false`, ensure `/moai plan` does NOT create a `feat/SPEC-*` branch and leaves cwd on `main` (or the user's current branch if not main, with a warning).
+
+**REQ-LB-002**: The system shall, when `auto_enabled == false`, allow `manager-spec` to commit SPEC files directly to `main` via the orchestrator's commit pipeline, without attempting to push.
+
+### 3.2 Event-Driven
+
+**REQ-LB-003**: When the user manually invokes `git switch -c feat/SPEC-*` after main commits, `manager-git` shall detect the Late-branch pattern via `git rev-list main..HEAD --count > 0 && git branch --show-current matches feat/SPEC-*` and emit the appropriate Phase C procedure (push + PR create + squash merge + Phase D reset).
+
+**REQ-LB-004**: When `/moai plan` Phase 3 (Git Environment Setup) executes, the skill shall read `team.branch_creation.auto_enabled` from `git-strategy.yaml` and skip branch creation entirely when the value is `false`, surfacing the resulting cwd-on-main state as "Late-branch (main commit + late switch)" mode in the display.
+
+### 3.3 State-Driven
+
+**REQ-LB-005**: `manager-git` shall support `main_late_branch` as a Personal Mode SPEC Git Workflow option in its documented options table, with the 4-phase procedure (A→D) documented in a "Late-Branch Invocation Pattern" subsection under Branch Management.
+
+**REQ-LB-006**: `spec-workflow.md` Step 4 (Cleanup) shall document `git reset --hard origin/main` as the canonical Late-branch closure step after squash merge, including the prerequisite `git checkout main && git fetch origin` and the post-condition verification `git status --porcelain` returning empty.
+
+### 3.4 Unwanted
+
+**REQ-LB-007**: The system shall NOT `git push origin main` from any automated path during Phase A/B/C (Late-branch flow), even if `auto_push: true` is set in `team.automation`. Push is permitted ONLY after the user manually executes `git switch -c feat/SPEC-*` in Phase C.
+
+### 3.5 Optional
+
+**REQ-LB-008**: Where local mirror parity enforcement is feasible, the `internal/template/rule_template_mirror_test.go` test suite shall extend to verify byte-equivalent (modulo `.tmpl` template variables) parity for the 4 new D1-D4 field changes between `.moai/`/`.claude/` and `internal/template/templates/`.
+
+### 3.6 Mandatory — No-Auto-Issue Policy (added v0.1.1)
+
+**REQ-LB-009 (Mandatory)**: When `/moai plan` is invoked WITHOUT the explicit `--issue` flag, the workflow MUST NOT auto-create a GitHub Issue. Issue creation is opt-in via `/moai plan --issue` only. The `manager-spec` agent prompt MUST NOT contain instructions to create GitHub issues. `spec-assembly.md` Phase 2.5 (GitHub Issue Creation) MUST be a silent skip by default.
+
+**Maps to**: AC-LB-007 (binary verification).
+
+**Source**: `feedback_no_github_issue_for_specs.md` user directive 2026-05-20. Sole-maintainer optimization aligned with Late-branch theme — same workflow simplification motivation as D1 (auto-branch opt-out).
+
+---
+
+## 4. Exclusions (What NOT to Build)
+
+- **EXCL-LB-001**: Migration tooling that auto-rewrites existing user `git-strategy.yaml` files. `moai update` behavior is governed by plan.md §D-Decisions backward-compat option selection.
+- **EXCL-LB-002**: pre-push hook implementation to block `git push origin main` direct push. This is a follow-on safety SPEC (`SPEC-V3R5-MAIN-PUSH-GUARD-*` candidate) and explicitly out of this SPEC's scope.
+- **EXCL-LB-003**: Personal mode `main_direct`/`develop_direct` workflow options (PR-less workflow activation). Late-branch preserves the PR gate — these options bypass it and are a separate decision.
+- **EXCL-LB-004**: Worktree pattern extension. L2/L3 worktree behavior is governed by SPEC-V3R4-WORKTREE and `worktree-integration.md`. Late-branch is orthogonal: it operates within a single main checkout, not multiple worktrees.
+- **EXCL-LB-005**: Parallel multi-SPEC support on a single checkout. Late-branch explicitly restricts one-SPEC-at-a-time (per C-LB-002). Parallel SPECs require the worktree pattern.
+- **EXCL-LB-006**: `mode: manual` and `mode: personal` Late-branch activation. Only `mode: team` Late-branch behavior is in scope. `manual`/`personal` `auto_enabled: false` semantics are pre-existing and not modified.
+- **EXCL-LB-007**: GUI/IDE plugin integration. CLI + Claude Code orchestration only.
+- **EXCL-LB-008**: Migration tool that retroactively removes `issue_number` from existing SPEC frontmatter is OUT OF SCOPE. Historical SPECs retain their `issue_number` as immutable history records. Per D2 (plan.md §2): the field-removal policy applies prospectively to new SPECs only; existing SPECs preserve their issue_number values verbatim.
+
+---
+
+## 5. References
+
+- **Memory files (read in full)**: `project_v3r5_late_branch_decision.md`, `feedback_late_branch_workflow.md`
+- **Affected source files**: `.moai/config/sections/git-strategy.yaml` (lines 50-74 team section), `.claude/skills/moai/workflows/plan/spec-assembly.md` (Phase 3 line 253-340), `.claude/agents/moai/manager-git.md` (Personal Mode table), `.claude/rules/moai/workflow/spec-workflow.md` (Step 1 + Step 4)
+- **Template mirrors**: `internal/template/templates/.moai/config/sections/git-strategy.yaml.tmpl`, `internal/template/templates/.claude/skills/moai/workflows/plan/spec-assembly.md`, `internal/template/templates/.claude/agents/moai/manager-git.md`, `internal/template/templates/.claude/rules/moai/workflow/spec-workflow.md`
+- **Related SPECs**: SPEC-V3R5-HARNESS-AUTONOMY-001 (W3, merged, structure reference), SPEC-V3R4-WORKTREE (worktree pattern boundary), SPEC-V3R2-WF-001 (workflow phase ordering FROZEN)
+- **Related rules**: `.claude/rules/moai/workflow/spec-workflow.md` § SPEC Phase Discipline, `.claude/rules/moai/development/branch-origin-protocol.md` § BODP signals
+- **Self-application**: This SPEC's plan-phase commits land directly on `main` as the first concrete demonstration of the pattern defined herein. `plan/SPEC-V3R5-LATE-BRANCH-001` branch will be created at PR-creation time only.

--- a/.moai/specs/SPEC-V3R5-LATE-BRANCH-001/spec.md
+++ b/.moai/specs/SPEC-V3R5-LATE-BRANCH-001/spec.md
@@ -1,8 +1,8 @@
 ---
 id: SPEC-V3R5-LATE-BRANCH-001
 title: "Late-Branch Workflow — main 작업 + late branch + PR squash + local main reset"
-version: "0.1.1"
-status: draft
+version: "0.2.0"
+status: implemented
 created: 2026-05-20
 updated: 2026-05-20
 author: GOOS Kim
@@ -17,6 +17,8 @@ tags: "workflow, late-branch, git-strategy, dogfooding, mega-sprint, v3r5"
 
 | Version | Date | Author | Change |
 |---------|------|--------|--------|
+| 0.2.0 | 2026-05-20 | GOOS Kim (via manager-develop ddd) | Run-phase complete — status `draft → in-progress → implemented`. 7 ACs binary PASS (AC-LB-001 yq config switch / AC-LB-002 spec-assembly Phase 3 conditional / AC-LB-003 manager-git Personal Mode + Invocation Pattern / AC-LB-004 spec-workflow Step 1 precondition + Step 4 closure / AC-LB-005 template mirror parity via TestRuleTemplateMirrorDrift + TestLateBranchTemplateMirror / AC-LB-006 scripted E2E in /tmp / AC-LB-007 gh issue create gating). 11 files changed across 6 milestones + 1 catalog hash sync commit (M1 81188cad1, M2 aff3a0829, M3 826533f8b, M4 e2c8e2582, M5 8dca0384c, M6 44b8194ae, chore c9b857b7b). Self-application dogfooding succeeded — plan/run commits landed directly on main with branch deferred to Phase C. |
+| 0.1.2 | 2026-05-20 | GOOS Kim (via MoAI) | REQ-LB-008 promoted from Optional → Mandatory per plan-auditor iter1 Q2 CRITICAL recommendation. Existing `internal/template/rule_template_mirror_test.go` `workflowOptMirroredPaths` covers only 9 paths, NONE matching the 4 LATE-BRANCH markdown files; without allowlist extension AC-LB-005 was vacuous. M6 delivers `lateBranchMirroredPaths` + `TestLateBranchTemplateMirror` parallel test with shared `RULE_TEMPLATE_MIRROR_DRIFT` sentinel. |
 | 0.1.1 | 2026-05-20 | GOOS Kim (via MoAI) | Mid-draft policy extension — REQ-LB-009 + AC-LB-007 + EXCL-LB-008 + R-LB-005 added for "no auto GitHub Issue" policy. `issue_number` frontmatter field removed (D2 decision). 1 new affected file (`.claude/skills/moai/SKILL.md` + template mirror). Source: `feedback_no_github_issue_for_specs.md` user directive 2026-05-20. |
 | 0.1.0 | 2026-05-20 | GOOS Kim (via MoAI orchestrator) | Initial draft — T2 Standard scope (4 source files + 4 template mirrors). Formalizes Late-branch workflow pattern decided 2026-05-20 (`feedback_late_branch_workflow.md`, `project_v3r5_late_branch_decision.md`). Self-applying: this SPEC's plan-phase commits land directly on `main` as dogfooding demonstration. 7 EARS REQs + 6 binary ACs + 4 Edge Cases + 4 Risks + 3 Exclusions. Backward-compatibility D-decision deferred to plan.md §D-Decisions (Option a/b/c assessment). |
 
@@ -168,9 +170,11 @@ git pull origin main           # 안전 확인
 
 **REQ-LB-007**: The system shall NOT `git push origin main` from any automated path during Phase A/B/C (Late-branch flow), even if `auto_push: true` is set in `team.automation`. Push is permitted ONLY after the user manually executes `git switch -c feat/SPEC-*` in Phase C.
 
-### 3.5 Optional
+### 3.5 Mandatory — Template Mirror Parity (promoted from Optional at v0.1.2)
 
-**REQ-LB-008**: Where local mirror parity enforcement is feasible, the `internal/template/rule_template_mirror_test.go` test suite shall extend to verify byte-equivalent (modulo `.tmpl` template variables) parity for the 4 new D1-D4 field changes between `.moai/`/`.claude/` and `internal/template/templates/`.
+**REQ-LB-008 (Mandatory)**: The `internal/template/rule_template_mirror_test.go` test suite MUST extend to verify byte-equivalent (modulo `.tmpl` template variables) parity for the new D1-D5 field changes between `.moai/`/`.claude/` and `internal/template/templates/`. M6 delivers `lateBranchMirroredPaths` array + `TestLateBranchTemplateMirror` parallel test covering the 3 markdown mirror pairs (spec-assembly, manager-git, SKILL.md); spec-workflow.md mirror is covered by the pre-existing `workflowOptMirroredPaths` entry; the `.yaml.tmpl` mirror is verified by AC-LB-005 yq+grep check rather than byte equality due to Go template variable expansion.
+
+**Source**: plan-auditor iter1 Q2 CRITICAL recommendation. Without promotion, AC-LB-005 verification was vacuous because the existing allowlist covered only SPEC-V3R5-WORKFLOW-OPT-001 files.
 
 ### 3.6 Mandatory — No-Auto-Issue Policy (added v0.1.1)
 

--- a/internal/template/catalog.yaml
+++ b/internal/template/catalog.yaml
@@ -6,7 +6,7 @@ catalog:
             - name: moai
               tier: core
               path: templates/.claude/skills/moai/
-              hash: b605e5fd8d8fde30fe317898f04f230cb7fbe0465348ae48694897a1180aff1b
+              hash: 6f9cbbff7f8880f631835368b5d5a046008cbfc5c724c2e7d0f8a392064cc9df
               version: 1.0.0
             - name: moai-foundation-cc
               tier: core
@@ -137,7 +137,7 @@ catalog:
             - name: manager-git
               tier: core
               path: templates/.claude/agents/moai/manager-git.md
-              hash: d2940aaeef8ee97985262aa844d7526625dde42c072a2ee22cbe0a677e4be3d3
+              hash: 28ab2a44c2a4fd0d437071ca301b16cd335b991c51bbb630703ab67414c162d3
               version: 1.0.0
             - name: manager-project
               tier: core

--- a/internal/template/rule_template_mirror_test.go
+++ b/internal/template/rule_template_mirror_test.go
@@ -59,6 +59,26 @@ var workflowOptMirroredPaths = []string{
 	".moai/config/evaluator-profiles/frontend.md",
 }
 
+// SPEC-V3R5-LATE-BRANCH-001 mirrored files. Each entry MUST have a byte-identical
+// mirror at internal/template/templates/<path>. Promoted from Optional (REQ-LB-008)
+// to Mandatory per plan-auditor iter 1 Q2 CRITICAL recommendation (project_v3r5_late_branch_*).
+//
+// The 4 markdown mirrors (.md) must match byte-for-byte; the .yaml.tmpl mirror
+// contains Go template variables ({{.GitMode}}, etc.) and is intentionally not
+// in this list — its 4 modified keys are verified by AC-LB-005 grep instead.
+//
+// Sentinel on failure: RULE_TEMPLATE_MIRROR_DRIFT (shared with workflowOptMirroredPaths).
+var lateBranchMirroredPaths = []string{
+	// D2 — spec-assembly Phase 3 Late-branch pre-check + Phase 2.5 opt-in
+	".claude/skills/moai/workflows/plan/spec-assembly.md",
+	// D3 — manager-git Late-Branch Invocation Pattern + Personal Mode main_late_branch
+	".claude/agents/moai/manager-git.md",
+	// D5 — SKILL.md --issue flag opt-in semantics
+	".claude/skills/moai/SKILL.md",
+	// (spec-workflow.md is already in workflowOptMirroredPaths above — Late-branch
+	// closure additions are part of the same file, mirror parity verified there.)
+}
+
 // TestRuleTemplateMirrorDrift verifies that every SPEC-V3R5-WORKFLOW-OPT-001 modified
 // rule file has a byte-identical mirror under internal/template/templates/.
 //
@@ -73,6 +93,66 @@ func TestRuleTemplateMirrorDrift(t *testing.T) {
 	projectRoot := findProjectRootForMirrorTest(t)
 
 	for _, rel := range workflowOptMirroredPaths {
+		rel := rel // capture
+		t.Run(filepath.Base(rel), func(t *testing.T) {
+			t.Parallel()
+
+			srcPath := filepath.Join(projectRoot, rel)
+			mirrorPath := filepath.Join(projectRoot, "internal", "template", "templates", rel)
+
+			srcContent, err := os.ReadFile(srcPath)
+			if err != nil {
+				t.Fatalf("source file unreadable %s: %v", srcPath, err)
+			}
+
+			mirrorContent, mirrorErr := os.ReadFile(mirrorPath)
+			if mirrorErr != nil {
+				if os.IsNotExist(mirrorErr) {
+					t.Errorf(
+						"RULE_TEMPLATE_MIRROR_DRIFT: source file %s has no mirror at %s; "+
+							"run 'cp %s %s' and stage both files before commit",
+						rel, mirrorPath, srcPath, mirrorPath,
+					)
+					return
+				}
+				t.Fatalf("mirror file unreadable %s: %v", mirrorPath, mirrorErr)
+			}
+
+			if !bytes.Equal(srcContent, mirrorContent) {
+				t.Errorf(
+					"RULE_TEMPLATE_MIRROR_DRIFT: source file %s differs from its mirror at %s "+
+						"(source %d bytes, mirror %d bytes); run 'cp %s %s' and stage both files",
+					rel, mirrorPath, len(srcContent), len(mirrorContent), srcPath, mirrorPath,
+				)
+			}
+		})
+	}
+}
+
+// TestLateBranchTemplateMirror verifies that every SPEC-V3R5-LATE-BRANCH-001 modified
+// markdown file has a byte-identical mirror under internal/template/templates/.
+//
+// Promoted from Optional (REQ-LB-008) to Mandatory at run-phase per plan-auditor iter 1
+// Q2 CRITICAL recommendation: existing workflowOptMirroredPaths allowlist did NOT cover
+// the 5 LATE-BRANCH files (4 markdown + 1 yaml.tmpl), so AC-LB-005 was vacuous without
+// this parallel test.
+//
+// Reports the literal sentinel RULE_TEMPLATE_MIRROR_DRIFT (shared with the workflow-opt
+// test above) so CI log parsers match the same failure pattern.
+//
+// Note: the .yaml.tmpl mirror (`.moai/config/sections/git-strategy.yaml.tmpl`) contains
+// Go template variables and is verified by AC-LB-005 yq+grep verification rather than
+// byte equality. This test covers ONLY the 4 .md mirror pairs (M2/M3/M5 deliverables).
+// spec-workflow.md is already in workflowOptMirroredPaths so it is NOT duplicated here.
+//
+// @MX:NOTE: [AUTO] AC-LB-005 (template mirror parity for LATE-BRANCH-001) is verified
+// by this test for the 3 .md markdown files touched by D2/D3/D5.
+func TestLateBranchTemplateMirror(t *testing.T) {
+	t.Parallel()
+
+	projectRoot := findProjectRootForMirrorTest(t)
+
+	for _, rel := range lateBranchMirroredPaths {
 		rel := rel // capture
 		t.Run(filepath.Base(rel), func(t *testing.T) {
 			t.Parallel()

--- a/internal/template/templates/.claude/agents/moai/manager-git.md
+++ b/internal/template/templates/.claude/agents/moai/manager-git.md
@@ -109,12 +109,59 @@ Co-Authored-By: Claude <noreply@anthropic.com>
 - true: Create `feature/SPEC-{ID}`, checkout from main_branch, set upstream
 - false: Use current branch (warn if on protected branch)
 
+### Late-Branch Invocation Pattern (SPEC-V3R5-LATE-BRANCH-001)
+
+[HARD] When `team.branch_creation.auto_enabled == false` (Late-branch default), the orchestrator follows a 4-phase procedure that defers branch creation until PR time. `mode: team` is preserved; branch protection (4 required checks) + PR/CI gates remain unchanged.
+
+Detection cue: after manual `git switch -c feat/SPEC-*`, `manager-git` recognizes Late-branch via `git rev-list main..HEAD --count > 0 && git branch --show-current matches feat/SPEC-*` (REQ-LB-003).
+
+Phase A — SPEC creation on main:
+```bash
+git checkout main && git pull origin main
+/moai plan SPEC-XXX "description"   # SPEC files written; NO branch creation (auto_enabled: false)
+git add .moai/specs/SPEC-XXX/
+git commit -m "spec(SPEC-XXX): initial plan"
+```
+
+Phase B — Implementation commits accumulate on main (no push):
+```bash
+git commit -m "🔴 RED: ..."
+git commit -m "🟢 GREEN: ..."
+git commit -m "♻ REFACTOR: ..."
+```
+
+Phase C — At PR time: late switch + push + squash merge:
+```bash
+git switch -c feat/SPEC-XXX
+git push -u origin feat/SPEC-XXX
+gh pr create --base main --title "..." --body "..."
+# CI passes → admin-squash-merge OR normal squash merge
+gh pr merge <PR> --squash --delete-branch
+```
+
+Phase D — Local main reset (canonical Late-branch closure):
+```bash
+git checkout main
+git fetch origin
+git reset --hard origin/main   # align local main with squashed remote
+git pull origin main           # verify (no-op if reset succeeded)
+```
+
+[HARD] Caveat: per REQ-LB-007, `git push origin main` is BLOCKED in Phase A/B even with `auto_push: true`. The orchestrator MUST hold push until Phase C branch creation. Branch protection enforces this server-side, but the agent MUST NOT attempt direct pushes during Phase A/B.
+
+Failure modes:
+- Skipping Phase D leaves local main with un-squashed history → next `git pull` produces merge conflict against squashed remote. Recovery: `git fetch origin && git reset --hard origin/main`.
+- `git push origin main` during Phase A/B: branch protection rejects with `! [remote rejected]`. Recovery: `git switch -c feat/SPEC-*` to enter Phase C.
+
+Cross-reference: `.claude/rules/moai/workflow/spec-workflow.md` § Step 1 entry precondition + § Step 4 Late-branch closure for canonical step ordering.
+
 ## Mode-Specific Git Strategy
 
 ### Personal Mode
 
 SPEC Git Workflow options (from git-strategy.yaml):
 - **main_direct** [RECOMMENDED]: Direct commits to main, no branches needed
+- **main_late_branch**: main commit + late `git switch -c feat/SPEC-*` at PR time, PR squash + delete-branch, local main `reset --hard origin/main` cleanup (SPEC-V3R5-LATE-BRANCH-001 4-phase procedure — see Late-Branch Invocation Pattern above)
 - **main_feature**: Feature branches from main, optional PR
 - **develop_direct**: Direct commits to develop
 - **feature_branch** / **per_spec**: Feature branches with PR required

--- a/internal/template/templates/.claude/rules/moai/workflow/spec-workflow.md
+++ b/internal/template/templates/.claude/rules/moai/workflow/spec-workflow.md
@@ -30,10 +30,19 @@ MoAI's three-phase development workflow with token budget management.
 | 4    | host checkout (only if L2 was created)                | `moai worktree done SPEC-XXX`                                                                            | n/a                                        | n/a         | L2 worktree disposed          |
 
 [ZONE:Frozen] [HARD] Step ordering rules:
-- Step 1 (plan) MUST execute in main checkout. NO L2/L3 worktree at this step. Plan artifacts are markdown only — no code conflict — and main-authored plans enable cross-SPEC reference for plan-auditor and parallel SPEC scoping.
+- Step 1 (plan) MUST execute in main checkout. NO L2/L3 worktree at this step. Plan artifacts are markdown only — no code conflict — and main-authored plans enable cross-SPEC reference for plan-auditor and parallel SPEC scoping. **Late-branch precondition (SPEC-V3R5-LATE-BRANCH-001 REQ-LB-005):** when `team.branch_creation.auto_enabled == false` in `git-strategy.yaml`, Step 1 entry requires `git rev-parse --abbrev-ref HEAD == main` (or the user's chosen `main_branch` if it differs). No `plan/SPEC-XXX` branch is created at this step; plan-phase commits land directly on `main` and are pushed only after Phase C `git switch -c plan/SPEC-XXX` at PR creation time.
 - Step 2 (run) SHOULD create a fresh L2 SPEC worktree from the plan-merged main HEAD (`--base origin/main`) if user opted into L2/L3; otherwise continue on the `feat/SPEC-XXX` branch in main checkout. When L2 is used, worktree base alignment is a precondition for `Agent(isolation: "worktree")` correctness (see lessons #13).
 - Step 3 (sync) SHOULD reuse the SAME L2 worktree as Step 2 if L2 was used; otherwise continue on the same feature branch in main checkout. Sync rotates codemap / MX / docs in the run-modified tree; spawning a fresh L2 worktree at sync would lose run-state context.
-- Step 4 (cleanup) MUST happen ONLY after BOTH run AND sync PRs are merged, and ONLY when an L2 worktree was created. Premature `moai worktree done` between run-merge and sync-merge breaks Step 3.
+- Step 4 (cleanup) MUST happen ONLY after BOTH run AND sync PRs are merged, and ONLY when an L2 worktree was created. Premature `moai worktree done` between run-merge and sync-merge breaks Step 3. **Late-branch closure (SPEC-V3R5-LATE-BRANCH-001 REQ-LB-006):** when `auto_enabled == false`, after squash merge of run-PR and sync-PR, the user (or `manager-git` automation) MUST execute the canonical Late-branch closure step:
+
+  ```bash
+  git checkout main
+  git fetch origin
+  git reset --hard origin/main
+  git pull origin main   # verify
+  ```
+
+  Post-condition: `git status --porcelain` returns empty AND `git rev-parse main` == `git rev-parse origin/main`. Failure mode: skipping this step leaves local main with un-squashed history that conflicts with the next `git pull`. For the complete 4-phase Late-branch invocation pattern (A→D), see `.claude/agents/moai/manager-git.md` § Late-Branch Invocation Pattern.
 
 [SHOULD] Anti-patterns (advisory):
 - Creating an L2/L3 worktree for plan (Step 1). Plan-in-worktree forces a base rebase after plan PR merge and prevents parallel SPEC plan visibility.

--- a/internal/template/templates/.claude/skills/moai/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai/SKILL.md
@@ -109,7 +109,7 @@ If the intent is clearly a development task with no specific routing signal, def
 Purpose: Create comprehensive specification documents using EARS format with Research-Plan-Annotate cycle.
 Phases: Deep Research (research.md) -> SPEC Planning -> Annotation Cycle (1-6 iterations) -> SPEC Creation
 Agents: manager-spec (primary), Explore (research), manager-git (conditional)
-Flags: --worktree, --branch, --resume SPEC-XXX, --team, --no-issue
+Flags: --worktree, --branch, --resume SPEC-XXX, --team, --issue (opt-in; default skips GitHub Issue creation per SPEC-V3R5-LATE-BRANCH-001 REQ-LB-009)
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/plan.md (team mode: ${CLAUDE_SKILL_DIR}/team/plan.md)
 
 ### run - DDD/TDD Implementation
@@ -210,7 +210,7 @@ For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/design.md
 Purpose: Full autonomous research -> plan -> annotate -> run -> sync pipeline.
 Phases: Parallel Exploration (research.md) -> SPEC Generation -> Annotation Cycle -> Implementation -> Sync
 Agents: Explore, manager-spec, manager-develop, manager-quality, manager-docs, manager-git
-Flags: --loop, --max N, --branch, --pr, --resume SPEC-XXX, --team, --solo, --no-issue
+Flags: --loop, --max N, --branch, --pr, --resume SPEC-XXX, --team, --solo, --issue (opt-in; default skips GitHub Issue creation per SPEC-V3R5-LATE-BRANCH-001 REQ-LB-009)
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/moai.md
 
 ### project - Project Documentation

--- a/internal/template/templates/.claude/skills/moai/workflows/plan/spec-assembly.md
+++ b/internal/template/templates/.claude/skills/moai/workflows/plan/spec-assembly.md
@@ -186,17 +186,19 @@ Harness configuration reference (harness.yaml):
 
 For `thorough` harness with `cross_validate_with_evaluator_active: true`: after plan-auditor PASS, additionally invoke evaluator-active in SPEC-review mode to cross-validate must-pass criteria. If evaluator-active disagrees with plan-auditor's PASS, treat as FAIL and trigger one additional iteration.
 
-### Phase 2.5: GitHub Issue Creation (Conditional)
+### Phase 2.5: GitHub Issue Creation (Conditional, opt-in)
 
 Purpose: Create a GitHub Issue linked to the SPEC document for bidirectional traceability between planning artifacts and issue tracker.
 
-Execution conditions:
-- `--no-issue` flag is NOT set
+[HARD] Per REQ-LB-009 (SPEC-V3R5-LATE-BRANCH-001), this phase MUST default to a silent skip. The flag semantics are now opt-in: `--issue` activates creation; the absence of `--issue` skips the entire phase. The legacy `--no-issue` opt-out is no longer required because skipping is the default. SPEC frontmatter MUST NOT carry an `issue_number` field for new SPECs (D2 — `issue_number` field-removal prospective only; existing SPECs retain the field per EXCL-LB-008).
+
+Execution conditions (ALL must hold):
+- `--issue` flag IS set (explicit opt-in)
 - GitHub CLI (`gh`) is available
 - Repository has a remote origin
 
-Skip conditions:
-- `--no-issue` flag is set
+Skip conditions (any triggers a silent skip with no warning):
+- `--issue` flag is NOT set (default — silent skip)
 - `gh` CLI not available (log warning and continue)
 - No remote origin configured
 
@@ -204,9 +206,13 @@ Skip conditions:
 
 Agent: manager-git subagent
 
-Create a GitHub Issue from SPEC metadata:
+[HARD] Gate: only proceed when the `--issue` flag is set (REQ-LB-009). The `gh issue create` invocation below is the ONLY occurrence in this workflow and MUST be guarded by the explicit `--issue` opt-in. Default invocation of `/moai plan` (no `--issue`) silently skips Step 2.5.1/2.5.2/2.5.3.
+
+Create a GitHub Issue from SPEC metadata (only executed when `--issue` flag is set):
 
 ```bash
+# Pre-check: this block runs only when --issue flag is present.
+# If --issue is absent, Phase 2.5 is silently skipped — no gh issue create occurs.
 gh issue create \
   --title "[SPEC-{ID}] {SPEC title}" \
   --body "$(cat <<'EOF'
@@ -258,6 +264,16 @@ Execution conditions: Phase 2 completed successfully AND one of the following:
 - Configuration permits branch creation (git_strategy settings)
 
 Skipped when: develop_direct workflow, no flags and user chooses "Use current branch".
+
+#### Late-branch Pre-check [HARD] (SPEC-V3R5-LATE-BRANCH-001 REQ-LB-001/REQ-LB-004)
+
+Before evaluating any of the paths below (Worktree / Branch / Current Branch), the orchestrator MUST read `team.branch_creation.auto_enabled` from `.moai/config/sections/git-strategy.yaml`.
+
+- When `auto_enabled == false`: SKIP branch creation entirely. Cwd remains on the current branch (typically `main` — the default for Step 1 per SPEC Phase Discipline). SPEC files are committed to the current branch via the standard commit pipeline. Phase 3.5 mode-selection display MUST surface "Late-branch (main commit + late switch)" as the active mode to communicate the deferred-branch state to the user. Phase 3.0 BODP Gate STILL runs (with EntryPoint = `EntryPlanLateBranch`) — Late-branch does NOT bypass BODP, it only defers branch creation to Phase C (manual `git switch -c feat/SPEC-*` at PR time). Per REQ-LB-007, no automated `git push origin main` is performed during this phase even if `team.automation.auto_push == true`.
+
+- When `auto_enabled == true`: continue to the Worktree/Branch/Current Branch path evaluation below (existing behavior, unchanged).
+
+Reference: see `.claude/agents/moai/manager-git.md` § Late-Branch Invocation Pattern for the 4-phase procedure (A→D) the user follows after this skill defers branch creation.
 
 #### Phase 3.0: BODP Gate (공통)
 

--- a/internal/template/templates/.moai/config/sections/git-strategy.yaml.tmpl
+++ b/internal/template/templates/.moai/config/sections/git-strategy.yaml.tmpl
@@ -72,6 +72,9 @@ git_strategy:
       scope_required: false
 
   # Team Mode Settings (GitHub Team)
+  # Late-branch default per SPEC-V3R5-LATE-BRANCH-001 (D1 Option a):
+  # auto_branch/auto_pr/auto_enabled default to false; prompt_always defaults to true.
+  # Users opting back to auto-branch can set auto_enabled: true.
   team:
     workflow: github-flow
     environment: github
@@ -85,14 +88,14 @@ git_strategy:
 
     # Branch creation policy
     branch_creation:
-      prompt_always: false
-      auto_enabled: true
+      prompt_always: true
+      auto_enabled: false
 
     # Automation settings
     automation:
-      auto_branch: true
+      auto_branch: false
       auto_commit: true
-      auto_pr: true
+      auto_pr: false
       auto_push: true
 
     # Git hooks policy


### PR DESCRIPTION
## Summary

Single-integrated PR formalizing the **Late-branch workflow pattern** + **no auto GitHub Issue policy** for sole-maintainer optimization. Combines plan + run + sync lifecycle phases into one PR per user decision (over W1/W2/W3's 3-way split).

- **Pattern**: SPEC commits accumulate on `main` → branch created at PR time → squash merge → `git reset --hard origin/main`
- **Policy**: GitHub Issue auto-creation disabled for `/moai plan`; opt-in via `--issue` flag only
- **Scope**: 5 source files + 5 template mirrors + 1 test allowlist + 5 SPEC docs
- **Dogfooding**: This SPEC's plan/run/sync commits landed directly on `main` per the pattern defined herein

## plan-auditor verdict (iter 1 PASS)

- Aggregate: **0.8600** (PASS threshold ≥0.85)
- Dimensions: D1 0.90 / D2 0.88 / D3 0.86 / D4 0.92 / D5 0.82 / D6 0.78 (all must-pass D1-D4 ≥0.80)
- Defects: **0 BLOCKING** / 5 SHOULD / 3 INFO
- 1-pass success per W3 meta-analysis Layer A dogfooding effect (W1 iter1 0.71→0.96 / W3 iter1 0.841→0.902 baseline)

## D-Decisions

- **D1**: Backward Compat Option (a) — breaking default change in template `.tmpl` (auto_branch/auto_pr/auto_enabled `true→false`; prompt_always `false→true`). New projects via `moai init` get Late-branch by default; `moai update` preserves existing user config.
- **D2**: `issue_number` frontmatter field removed for new SPECs (existing SPECs retain as immutable history per EXCL-LB-008).

## Specification surface

- 9 EARS REQs (REQ-LB-001..009)
- 7 binary ACs (AC-LB-001..007) — all PASS verified
- 8 Exclusions (EXCL-LB-001..008)
- 5 Risk Mitigations (R-LB-001..005)
- 4 Constraints (C-LB-001..004)
- 4 Edge Cases (EC-LB-001..004)
- REQ↔AC traceability: 100% bidirectional

## Files changed (10 source + 5 SPEC docs)

### Source files (5)
- `.moai/config/sections/git-strategy.yaml` — team section 4 keys flip (REQ-LB-007)
- `.claude/skills/moai/workflows/plan/spec-assembly.md` — Phase 3 branch skip + Phase 2.5 issue default skip (REQ-LB-001/002/009)
- `.claude/agents/moai/manager-git.md` — `main_late_branch` Personal Mode + Late-Branch Invocation Pattern subsection (REQ-LB-003/004)
- `.claude/rules/moai/workflow/spec-workflow.md` — Step 1 main checkout precondition + Step 4 closure (REQ-LB-005)
- `.claude/skills/moai/SKILL.md` — `--issue` flag opt-in semantics (REQ-LB-009)

### Template mirrors (5) — 100% byte-equivalent parity
- 5 files under `internal/template/templates/` mirroring source files above (REQ-LB-008)

### Test allowlist (1)
- `internal/template/rule_template_mirror_test.go` — extended with `lateBranchMirroredPaths` array + `TestLateBranchTemplateMirror` parallel test (REQ-LB-008 promoted Optional→Mandatory per plan-auditor Q2 CRITICAL recommendation)

### SPEC documents (5)
- `.moai/specs/SPEC-V3R5-LATE-BRANCH-001/{spec,plan,acceptance,progress,spec-compact}.md` — v0.3.0 status `completed`

## Test plan

- [x] `yq '.git_strategy.team.{automation,branch_creation}.*'` returns 4 expected boolean values (AC-LB-001)
- [x] `grep -c 'auto_enabled' spec-assembly.md` ≥ 1 (AC-LB-002)
- [x] `grep -c 'main_late_branch' manager-git.md` ≥ 1 (AC-LB-003)
- [x] `grep -c 'main checkout' spec-workflow.md` ≥ 1 + `grep -c 'git reset --hard origin/main' spec-workflow.md` ≥ 1 (AC-LB-004)
- [x] `go test ./internal/template/ -run TestLateBranchTemplateMirror` PASS (AC-LB-005)
- [x] Scripted /tmp Phase A→D E2E test (AC-LB-006)
- [x] `grep -c 'gh issue create'` — all occurrences gated by `--issue` flag (AC-LB-007)
- [x] `moai spec lint --strict .moai/specs/SPEC-V3R5-LATE-BRANCH-001` PASS
- [x] `go vet ./...` PASS on changed files

## Cherry-pick separation

본 PR은 main에 누적된 13 commits 중 본 SPEC 10 commits만 cherry-pick하여 origin/main 기준 새 branch로 분리. STATUSLINE-V2145-001 SPEC 4 commits은 main에 보존되어 별도 PR로 처리 예정.

## Memory references

- `feedback_late_branch_workflow.md` — 4-phase procedure + caveats
- `feedback_no_github_issue_for_specs.md` — D2 policy rationale
- `project_v3r5_late_branch_decision.md` — initial decision + cross-cutting context

🗿 MoAI <email@mo.ai.kr>