### PR TITLE
feat(statusline): layout v3 + STATUSLINE-PROFILE-WIZARD SPEC + 4-locale docs

### DIFF
--- a/.moai/specs/SPEC-V3R5-STATUSLINE-PROFILE-WIZARD-001/acceptance.md
+++ b/.moai/specs/SPEC-V3R5-STATUSLINE-PROFILE-WIZARD-001/acceptance.md
@@ -1,0 +1,311 @@
+---
+id: SPEC-V3R5-STATUSLINE-PROFILE-WIZARD-001
+title: "Acceptance Criteria — profile setup wizard에 statusline preset/segments 입력 UI 추가"
+version: "0.1.0"
+created: 2026-05-22
+updated: 2026-05-22
+---
+
+# Acceptance Criteria — SPEC-V3R5-STATUSLINE-PROFILE-WIZARD-001
+
+7개 binary AC. 각 AC는 단일 verifiable command + 명시적 PASS 조건을 가진다. 본 acceptance.md는 plan-auditor와 run-phase Section E self-verification matrix가 동일 명령으로 PASS/FAIL 판정하도록 작성되었다.
+
+REQ ↔ AC 매핑:
+
+| REQ | AC | 검증 표면 |
+|-----|----|----------|
+| REQ-SPW-001 | AC-SPW-001 | profile_setup.go Display group에 Preset Select |
+| REQ-SPW-002 | AC-SPW-002 | profile_setup.go Display group에 Segments MultiSelect (conditional) |
+| REQ-SPW-003 | AC-SPW-003 | profile_setup_translations.go 4-locale × (Preset* + Segment*) keys |
+| REQ-SPW-004 | AC-SPW-004 | profile_setup.go normalizeStatuslinePreset helper |
+| REQ-SPW-005 | AC-SPW-005, AC-SPW-006 | 회귀 테스트 + cross-platform |
+| (out-of-scope guard) | AC-SPW-007 | sync.go / preferences.go 무변경 |
+
+---
+
+## AC-SPW-001: StatuslinePreset Select widget 존재
+
+**Given** `profile_setup.go` Display group (Section 4, line 282-300 region)
+**When** 사용자가 wizard 4번째 group에 진입
+**Then** Preset Select widget이 표시되고 4개 옵션 (`full`, `compact`, `minimal`, `custom`)을 노출한다.
+
+### Binary Verification Commands
+
+```bash
+# 1. StatuslinePresetTitle 사용 확인 (huh.NewSelect Title 인자)
+grep -n 'StatuslinePresetTitle' /Users/goos/MoAI/moai-adk-go/internal/cli/profile_setup.go
+# Expected: ≥1 match
+```
+
+```bash
+# 2. 4개 preset 옵션 모두 huh.NewOption 으로 정의되어 있는지 확인
+grep -E 'huh\.NewOption\([^,]*(PresetFull|PresetCompact|PresetMinimal|PresetCustom)' /Users/goos/MoAI/moai-adk-go/internal/cli/profile_setup.go | wc -l
+# Expected: 4 (exactly)
+```
+
+```bash
+# 3. statuslinePreset 변수가 prefs 저장 시 사용되는지 확인
+grep -E 'StatuslinePreset\s*:\s*statuslinePreset|StatuslinePreset:\s*normalizeStatuslinePreset' /Users/goos/MoAI/moai-adk-go/internal/cli/profile_setup.go
+# Expected: ≥1 match
+```
+
+**PASS condition**: 세 명령 모두 만족.
+
+---
+
+## AC-SPW-002: Segments MultiSelect widget 존재 (custom 조건부)
+
+**Given** AC-SPW-001 PASS 상태 (Preset Select 추가됨)
+**When** 사용자가 `custom` preset을 선택
+**Then** Segments MultiSelect widget이 표시되고 15개 segment 키를 노출한다. `custom` 외 preset 선택 시 widget은 숨겨지거나 무시된다.
+
+### Binary Verification Commands
+
+```bash
+# 1. StatuslineSegmentsTitle 사용 확인
+grep -n 'StatuslineSegmentsTitle' /Users/goos/MoAI/moai-adk-go/internal/cli/profile_setup.go
+# Expected: ≥1 match
+```
+
+```bash
+# 2. huh.NewMultiSelect widget 사용 확인 (이전에 wizard에 없던 신규 API)
+grep -n 'huh\.NewMultiSelect' /Users/goos/MoAI/moai-adk-go/internal/cli/profile_setup.go
+# Expected: ≥1 match
+```
+
+```bash
+# 3. 15개 segment 키 모두 옵션으로 정의되어 있는지 확인
+grep -cE 'huh\.NewOption\([^,]*(SegmentModel|SegmentContext|SegmentOutputStyle|SegmentDirectory|SegmentGitStatus|SegmentGitBranch|SegmentClaudeVersion|SegmentMoaiVersion|SegmentSessionTime|SegmentUsage5h|SegmentUsage7d|SegmentEffortThinking|SegmentPR|SegmentTask|SegmentWorktree)' /Users/goos/MoAI/moai-adk-go/internal/cli/profile_setup.go
+# Expected: 15 (exactly)
+```
+
+```bash
+# 4. custom 조건부 표시: WithHideFunc 또는 statuslinePreset 변수 참조 확인
+grep -E 'WithHideFunc|statuslinePreset\s*!=\s*"custom"|statuslinePreset\s*==\s*"custom"' /Users/goos/MoAI/moai-adk-go/internal/cli/profile_setup.go
+# Expected: ≥1 match (conditional rendering 구현 증거)
+```
+
+**PASS condition**: 네 명령 모두 만족.
+
+---
+
+## AC-SPW-003: 4-locale 번역 키 모두 존재
+
+**Given** `profile_setup_translations.go`의 `profileSetupText` struct 및 `profileSetupTexts` map
+**When** `go test -run TestProfileSetupTranslations_PresetSegments` 실행
+**Then** 4-locale (en/ko/ja/zh) 각각에서 모든 신규 키가 빈 문자열이 아니다.
+
+### Binary Verification Commands
+
+```bash
+# 1. profileSetupText struct에 신규 필드 모두 존재 확인 (struct 정의)
+grep -E 'StatuslinePresetTitle\s+string|StatuslinePresetDesc\s+string|StatuslineSegmentsTitle\s+string|StatuslineSegmentsDesc\s+string|PresetFull\s+string|PresetCompact\s+string|PresetMinimal\s+string|PresetCustom\s+string' /Users/goos/MoAI/moai-adk-go/internal/cli/profile_setup_translations.go | wc -l
+# Expected: ≥8 (8개 핵심 필드)
+```
+
+```bash
+# 2. 15 segment 레이블 필드 정의 확인
+grep -E 'Segment(Model|Context|OutputStyle|Directory|GitStatus|GitBranch|ClaudeVersion|MoaiVersion|SessionTime|Usage5h|Usage7d|EffortThinking|PR|Task|Worktree)\s+string' /Users/goos/MoAI/moai-adk-go/internal/cli/profile_setup_translations.go | wc -l
+# Expected: 15 (exactly)
+```
+
+```bash
+# 3. 4 locale × (8 핵심 + 15 segment) = 92 항목 모두 비어있지 않음 검증
+go test -count=1 -run TestProfileSetupTranslations_PresetSegments ./internal/cli/...
+# Expected: PASS (test 자체가 빈 문자열 검증 포함)
+```
+
+**PASS condition**: 세 명령 모두 만족.
+
+---
+
+## AC-SPW-004: normalizeStatuslinePreset 함수 정의 + 유효/무효 처리
+
+**Given** `profile_setup.go` 상단 helper 영역
+**When** `go test -run TestNormalizeStatuslinePreset` 실행
+**Then** 유효 입력 (`full`, `compact`, `minimal`, `custom`)이 통과되고 무효 입력 (`fullbar`, `invalid`, etc)이 빈 문자열로 fall back된다.
+
+### Binary Verification Commands
+
+```bash
+# 1. 함수 정의 존재 확인
+grep -n 'func normalizeStatuslinePreset' /Users/goos/MoAI/moai-adk-go/internal/cli/profile_setup.go
+# Expected: ≥1 match
+```
+
+```bash
+# 2. isCanonicalStatuslinePreset 패턴 따름 확인 (statuslinePresetCanonical slice 권장)
+grep -E 'statuslinePresetCanonical|isCanonicalStatuslinePreset' /Users/goos/MoAI/moai-adk-go/internal/cli/profile_setup.go
+# Expected: ≥1 match
+```
+
+```bash
+# 3. 유효/무효 처리 unit test PASS
+go test -count=1 -run TestNormalizeStatuslinePreset ./internal/cli/...
+# Expected: PASS
+```
+
+**PASS condition**: 세 명령 모두 만족.
+
+---
+
+## AC-SPW-005: 회귀 테스트 PASS + 전체 cli 패키지 회귀 없음
+
+**Given** 변경 적용 후
+**When** `go test ./internal/cli/...` 실행
+**Then** 전체 cli 패키지 테스트가 PASS이며 NEW failure가 0이다.
+
+### Binary Verification Commands
+
+```bash
+# 1. 전체 cli 패키지 회귀 테스트
+go test -count=1 ./internal/cli/...
+# Expected: PASS (exit 0)
+```
+
+```bash
+# 2. 신규 추가 테스트 함수 모두 PASS
+go test -count=1 -v -run 'TestProfileSetupTranslations_PresetSegments|TestNormalizeStatuslinePreset' ./internal/cli/...
+# Expected: PASS, 각 테스트가 출력에 PASS로 표시됨
+```
+
+```bash
+# 3. Coverage 측정 (cli 패키지 baseline 유지 — drop 허용 ≤ 2pp)
+go test -count=1 -cover ./internal/cli/...
+# Expected: coverage 측정 가능, 새 헬퍼/widget 코드도 적어도 한 번 실행됨
+```
+
+**PASS condition**: 세 명령 모두 만족.
+
+---
+
+## AC-SPW-006: Cross-platform build PASS
+
+**Given** 변경 적용 후
+**When** darwin/amd64 + windows/amd64 build
+**Then** 두 GOOS 모두 build exit 0.
+
+### Binary Verification Commands
+
+```bash
+# 1. native (darwin) build
+go build ./...
+# Expected: exit 0
+```
+
+```bash
+# 2. windows cross-compile
+GOOS=windows GOARCH=amd64 go build ./...
+# Expected: exit 0
+```
+
+```bash
+# 3. linux cross-compile (extra safety)
+GOOS=linux GOARCH=amd64 go build ./...
+# Expected: exit 0
+```
+
+**PASS condition**: 세 명령 모두 exit 0.
+
+---
+
+## AC-SPW-007: sync 영역 무변경 (out-of-scope guard)
+
+**Given** SPEC scope는 wizard UI에 한정 (sync logic은 이미 작동)
+**When** SPEC 변경 적용 후 git diff
+**Then** `internal/profile/sync.go`, `internal/profile/preferences.go`, `internal/statusline/` 의 source 파일이 byte-identical.
+
+### Binary Verification Commands
+
+```bash
+# 1. sync.go + preferences.go 변경 없음 검증 (main 기준)
+git diff main -- internal/profile/sync.go internal/profile/preferences.go
+# Expected: empty output
+```
+
+```bash
+# 2. statusline renderer 변경 없음 검증
+git diff main -- internal/statusline/renderer.go internal/statusline/builder.go internal/statusline/types.go
+# Expected: empty output
+```
+
+```bash
+# 3. .moai/config/sections/statusline.yaml 변경 없음 (template + local 둘 다)
+git diff main -- internal/template/templates/.moai/config/sections/statusline.yaml .moai/config/sections/statusline.yaml
+# Expected: empty output
+```
+
+**PASS condition**: 세 명령 모두 empty output (no diff).
+
+---
+
+## Edge Case Scenarios (Given-When-Then)
+
+### EC-SPW-001: 기존 preset 값 보존 (preserve existing value)
+
+**Given** 사용자 `~/.moai/claude-profiles/work/preferences.yaml` 에 다음이 저장됨:
+```yaml
+statusline_preset: compact
+statusline_segments:
+  context: true
+  directory: true
+  git_branch: true
+```
+
+**When** `moai profile setup work` 실행 후 Display group에 도달
+
+**Then** Preset Select widget의 default(highlighted) 선택지가 `compact`이며, 사용자가 Enter만 눌러도 `prefs.StatuslinePreset == "compact"`로 유지되어 저장된다.
+
+Verification: wizard interactive test는 자동화 어려우므로 unit test가 default 값 결정 로직(`normalizeStatuslinePreset(existingPrefs.StatuslinePreset)`)을 검증한다.
+
+```bash
+go test -count=1 -run 'TestNormalizeStatuslinePreset/preserves_compact' ./internal/cli/...
+# Expected: PASS
+```
+
+### EC-SPW-002: 잘못된 legacy 값 fall back (forward-compat)
+
+**Given** 사용자 prefs.yaml에 `statusline_preset: fullbar` (canonical 4개 외 값) 저장됨 (이전 버전 또는 수동 편집)
+
+**When** `moai profile setup` 실행
+
+**Then** wizard는 panic 없이 시작하고, Preset Select의 default 값이 `""` (또는 첫 옵션)으로 reset되며, 사용자는 4개 유효 옵션 중에서 다시 선택할 수 있다.
+
+Verification:
+
+```bash
+go test -count=1 -run 'TestNormalizeStatuslinePreset/rejects_invalid' ./internal/cli/...
+# Expected: PASS — input "fullbar" → output ""
+```
+
+### EC-SPW-003: 빈 preset 보존 (no override)
+
+**Given** 사용자가 wizard에서 Preset Select의 default(빈 문자열 또는 미선택) 상태로 진행
+
+**When** wizard 완료 후 prefs 저장 + `SyncToProjectConfig` 호출
+
+**Then** `syncStatusline`(`sync.go:123-125`)의 `if prefs.StatuslinePreset != ""` 분기가 false로 평가되어 기존 `.moai/config/sections/statusline.yaml`의 `preset` 값이 보존된다 (override 회피).
+
+Verification: 본 동작은 기존 sync 로직(AC-SPW-007이 byte-identical 보장) 이므로 별도 unit test 추가 없이 sync 로직 회귀 테스트에 의해 보장된다.
+
+```bash
+# 기존 sync 회귀 테스트 PASS 유지
+go test -count=1 ./internal/profile/...
+# Expected: PASS (no regression)
+```
+
+---
+
+## Definition of Done
+
+다음 조건이 모두 충족되면 SPEC 구현 완료로 간주한다:
+
+- [ ] AC-SPW-001 ~ AC-SPW-007 모두 PASS
+- [ ] EC-SPW-001 ~ EC-SPW-003 모두 verification command PASS
+- [ ] `go test -count=1 ./...` 전체 PASS (또는 NEW failure 0)
+- [ ] `golangci-lint run --timeout=2m` NEW issues = 0
+- [ ] `go build ./...` + `GOOS=windows GOARCH=amd64 go build ./...` 둘 다 exit 0
+- [ ] spec.md status `draft → implemented`, version `0.1.0 → 0.2.0` 갱신
+- [ ] HISTORY 행 추가 (run-phase 작업 요약 + manager-develop verdict)
+- [ ] Conventional Commit `plan(SPEC-V3R5-STATUSLINE-PROFILE-WIZARD-001): ...` (plan-phase) / `feat(...)` (run-phase) 메시지 + `🗿 MoAI <email@mo.ai.kr>` trailer
+- [ ] PRESERVE 대상 파일 (pre-existing dirty + 무관 untracked) 무변경 — `git status --porcelain` 으로 변경 범위 확인

--- a/.moai/specs/SPEC-V3R5-STATUSLINE-PROFILE-WIZARD-001/plan.md
+++ b/.moai/specs/SPEC-V3R5-STATUSLINE-PROFILE-WIZARD-001/plan.md
@@ -1,0 +1,377 @@
+---
+id: SPEC-V3R5-STATUSLINE-PROFILE-WIZARD-001
+title: "Implementation Plan — profile setup wizard에 statusline preset/segments 입력 UI 추가"
+version: "0.1.0"
+created: 2026-05-22
+updated: 2026-05-22
+---
+
+# Implementation Plan — SPEC-V3R5-STATUSLINE-PROFILE-WIZARD-001
+
+Tier S — 3-artifact 채택 근거: spec/plan/acceptance 3 분리. AC가 binary verification command 중심이며 plan-auditor + run-phase Self-Verification matrix가 동일 명령 참조해야 하므로 acceptance.md를 별도 분리. spec.md inline AC는 high-level summary로 유지. Tier S 표준 2-artifact는 단순 SPEC에 적합하나, 본 SPEC은 7 AC + 3 Edge Case + 4 locale × 23 keys = 92 translation 데이터 검증 → acceptance.md 분리가 plan-auditor 평가 효율을 높인다.
+
+## 1. Implementation Strategy
+
+### 1.1 핵심 원칙
+
+- **Frontend-Only Change**: backend(`internal/profile/preferences.go`, `internal/profile/sync.go`)는 무변경. AC-SPW-007이 byte-identical 검증.
+- **Sequential, Single-File Atomic Edit**: 각 파일은 한 번에 모든 관련 변경을 atomic MultiEdit으로 적용 (Tier S small-scope 권장 패턴).
+- **Test-First for New Functions**: `normalizeStatuslinePreset`은 helper로 단순 — 함수 정의 + unit test를 같은 commit에 포함.
+- **Locale Parity**: en이 canonical reference. ko/ja/zh는 en과 1:1 키 매칭 검증 (test가 자동 보장).
+
+### 1.2 Brownfield Strategy (PRESERVE)
+
+다음 파일은 wizard에서 호출되지만 본 SPEC scope에서 무변경:
+
+| 파일 | 이유 |
+|------|------|
+| `internal/profile/preferences.go` | StatuslinePreset/StatuslineSegments 필드 이미 존재 (line 46-47) |
+| `internal/profile/sync.go` | syncStatusline + defaultStatuslineSegments 이미 작동 |
+| `internal/statusline/renderer.go` | renderer 영역 (별도 SPEC `STATUSLINE-PRESET-FIX-001`) |
+| `internal/statusline/builder.go` | builder data 수집 영역 |
+| `.moai/config/sections/statusline.yaml` | scheme 무변경 |
+| `internal/template/templates/.moai/config/sections/statusline.yaml` | template parity |
+
+### 1.3 위험 (Risks)
+
+| ID | Risk | Likelihood | Impact | Mitigation |
+|----|------|-----------|--------|------------|
+| R-SPW-001 | huh `WithHideFunc` conditional rendering이 form lifecycle 시점에 statuslinePreset 값을 평가하지 못함 (huh 버전 의존성) | M | M | `huh.NewGroup`을 2개로 분리: 첫 group(preset Select)이 끝난 후 두 번째 group(segments MultiSelect with `WithHideFunc`) 진입. 또는 사용자가 custom 선택 시만 prefs.StatuslineSegments 저장. **fallback**: `WithHideFunc` 작동 안 하면 form 분리(`form1.Run()` 후 if preset == "custom" then form2.Run()) 방식으로 전환. M1 자체 검증 필수. |
+| R-SPW-002 | Translation parity 누락 (en 추가 후 ko/ja/zh 중 일부 누락) | L | M | TestProfileSetupTranslations_PresetSegments가 4 locale 모두 검증 (loop으로 빈 문자열 확인). CI에서 강제. |
+| R-SPW-003 | huh v0.x → v0.7+ API 차이 (MultiSelect 옵션 API 변경) | L | L | 현재 wizard 코드에서 `huh.NewSelect` + `huh.NewOption` 사용 패턴 확인 후 동일 스타일로 작성. go.mod의 huh 버전 확인 후 implementation. |
+| R-SPW-004 | 11-segment defaultStatuslineSegments vs 15-segment statusline.yaml mismatch 노출 | L | L | 본 SPEC에서 다루지 않음 (out-of-scope §3.2 명시). MultiSelect는 15개 모두 표시하되 default 선택은 기존 prefs.StatuslineSegments 값을 따른다 (sync.go 보수적 default 보존). |
+
+## 2. Milestones (Priority-Based)
+
+phase 순서: M1 → M2 → M3 → M4. 시간 추정 없음 (`time-estimation` HARD 준수).
+
+### M1 (Priority: High): Translation 데이터 + helper 함수
+
+**Goal**: profile_setup_translations.go에 신규 23개 키(8 핵심 + 15 segment)를 4 locale로 추가하고 normalizeStatuslinePreset helper를 정의한다.
+
+**Atomic Edit Targets**:
+- `internal/cli/profile_setup_translations.go`: profileSetupText struct에 23개 필드 추가 + 4 locale × 23 entries 채우기 (atomic MultiEdit 1회)
+- `internal/cli/profile_setup.go`: file 상단(~line 50-77 region)에 `statuslinePresetCanonical` slice + `isCanonicalStatuslinePreset` + `normalizeStatuslinePreset` helper 추가 (atomic MultiEdit 1회)
+
+**Verification**: AC-SPW-003 + AC-SPW-004의 grep + unit test 명령으로 PASS 확인. cross-platform build pre-check.
+
+**Dependencies**: 없음 (entry point).
+
+### M2 (Priority: High): wizard Display group widget 추가
+
+**Goal**: profile_setup.go의 huh.NewForm 4번째 Display group(line 282-300)에 Preset Select + Segments MultiSelect widget을 추가한다.
+
+**Atomic Edit Targets**:
+- `internal/cli/profile_setup.go`: Display group 본문 + statuslinePreset/statuslineSegmentsSelection 변수 선언 + prefs 저장 시점 변환 로직 (atomic MultiEdit 1회)
+
+**huh API 사용 패턴 (검증 후 확정, R-SPW-001 mitigation)**:
+- 1단계: 기존 Display group에 Preset Select 추가
+- 2단계: huh.NewGroup 분리 + `WithHideFunc(func() bool { return statuslinePreset != "custom" })` 시도
+- 3단계: 작동 안 하면 form 2개로 분리 (form1.Run() → if custom then form2.Run())
+
+**Conversion logic** (선택된 string slice → `map[string]bool`):
+- 모든 15 segment 키에 대해 선택 list 포함 여부로 true/false 결정
+- 결과를 `prefs.StatuslineSegments` 에 저장
+
+**Verification**: AC-SPW-001 + AC-SPW-002의 grep 명령으로 PASS 확인.
+
+**Dependencies**: M1 (translation 키 + normalizer 필요).
+
+### M3 (Priority: High): 회귀 테스트 추가
+
+**Goal**: AC-SPW-003 + AC-SPW-004 + AC-SPW-005 검증을 위한 test 함수 추가.
+
+**Atomic Edit Targets**:
+- `internal/cli/profile_setup_translations_test.go`: `TestProfileSetupTranslations_PresetSegments` 추가 — 4 locale × 23 키 빈 문자열 검증 (table-driven)
+- `internal/cli/profile_setup_test.go` 또는 신규 `internal/cli/normalize_statusline_preset_test.go`: `TestNormalizeStatuslinePreset` 추가 — 유효 입력 4건 + 무효 입력 2건 + 빈 문자열 1건 = 7 sub-test cases (table-driven, EC-SPW-001/002/003 커버)
+
+**Verification**: `go test ./internal/cli/...` 전체 PASS. NEW failure 0. coverage 측정.
+
+**Dependencies**: M1 + M2 (검증 대상 코드 존재 필요).
+
+### M4 (Priority: Medium): 최종 검증 + commit 준비
+
+**Goal**: 7개 AC + 3개 Edge Case + cross-platform 모두 PASS 상태 확인 후 commit.
+
+**Tasks**:
+- AC-SPW-001 ~ AC-SPW-007 binary verification 명령 7-item parallel batch 실행 (verification-batch-pattern 적용)
+- `golangci-lint run --timeout=2m` NEW issues 0 확인
+- `git diff --stat` 으로 변경 파일 범위 확인 (out-of-scope 파일 변경 없는지)
+- HISTORY 행 추가 + status 갱신은 manager-docs sync-phase에서 처리 (run-phase에서는 status `draft` 유지)
+- Conventional Commit 메시지 작성: `feat(SPEC-V3R5-STATUSLINE-PROFILE-WIZARD-001): wizard에 statusline preset/segments 입력 UI 추가`
+
+**Dependencies**: M1 + M2 + M3 모두 완료.
+
+## 3. Technical Approach
+
+### 3.1 파일 변경 매트릭스 (verified line ranges)
+
+| 파일 | 종류 | 변경 종류 | 예상 LOC delta |
+|------|------|----------|----------------|
+| `internal/cli/profile_setup.go` (412 lines) | source | helper 추가 + Display group 확장 | +50 ~ +70 |
+| `internal/cli/profile_setup_translations.go` (418 lines) | source | struct 확장 + 4 locale × 23 entries | +100 ~ +130 |
+| `internal/cli/profile_setup_translations_test.go` (existing) | test | TestProfileSetupTranslations_PresetSegments 추가 | +30 ~ +50 |
+| `internal/cli/profile_setup_test.go` (1930 bytes, existing) | test | TestNormalizeStatuslinePreset 추가 | +20 ~ +30 |
+
+총 LOC delta: ~200 ~ ~280 < Tier S 임계 300 LOC. 영향 source 파일 2개 + test 파일 2개 = 4 < 5 Tier S 임계.
+
+### 3.2 huh API 사용 패턴 (verified from profile_setup.go:282-300)
+
+기존 패턴 (Display group):
+
+```go
+huh.NewGroup(
+    huh.NewSelect[string]().
+        Title(t.StatuslineModeTitle).
+        Description(t.StatuslineModeDesc).
+        Options(
+            huh.NewOption(t.ModeDefault, "default"),
+            huh.NewOption(t.ModeFull, "full"),
+        ).
+        Value(&statuslineMode),
+    // ... StatuslineTheme Select
+).Title(t.DisplayTitle),
+```
+
+본 SPEC이 추가하는 패턴 (예시, R-SPW-001 mitigation에 따라 최종 형태는 implementation 시 확정):
+
+```go
+// In Display group 또는 별도 group:
+huh.NewSelect[string]().
+    Title(t.StatuslinePresetTitle).
+    Description(t.StatuslinePresetDesc).
+    Options(
+        huh.NewOption(t.PresetFull, "full"),
+        huh.NewOption(t.PresetCompact, "compact"),
+        huh.NewOption(t.PresetMinimal, "minimal"),
+        huh.NewOption(t.PresetCustom, "custom"),
+    ).
+    Value(&statuslinePreset),
+
+// Conditional MultiSelect (별도 group with WithHideFunc):
+huh.NewGroup(
+    huh.NewMultiSelect[string]().
+        Title(t.StatuslineSegmentsTitle).
+        Description(t.StatuslineSegmentsDesc).
+        Options(
+            huh.NewOption(t.SegmentModel, "model"),
+            // ... 14 more
+        ).
+        Value(&statuslineSegmentsSelection),
+).WithHideFunc(func() bool { return statuslinePreset != "custom" })
+```
+
+### 3.3 Helper 함수 패턴 (verified from profile_setup.go:18-77)
+
+기존 패턴 (`statuslineModeCanonical`, `isCanonicalStatuslineMode`, `normalizeStatuslineMode`):
+
+```go
+var statuslinePresetCanonical = []string{"full", "compact", "minimal", "custom"}
+
+func isCanonicalStatuslinePreset(s string) bool {
+    for _, v := range statuslinePresetCanonical {
+        if v == s {
+            return true
+        }
+    }
+    return false
+}
+
+func normalizeStatuslinePreset(p string) string {
+    if p == "" {
+        return ""  // EC-SPW-003: 빈 문자열 그대로 보존 → syncStatusline 기존 yaml 값 유지
+    }
+    if isCanonicalStatuslinePreset(p) {
+        return p  // EC-SPW-001: 유효 값 보존
+    }
+    return ""  // EC-SPW-002: 무효 값 reset
+}
+```
+
+### 3.4 Segments map ↔ string slice 변환 (M2 보조 로직)
+
+prefs read (default 결정):
+
+```go
+// existing prefs.StatuslineSegments map[string]bool 에서 true 값 키만 slice로 추출
+var statuslineSegmentsSelection []string
+if existingPrefs.StatuslineSegments != nil {
+    for key, enabled := range existingPrefs.StatuslineSegments {
+        if enabled {
+            statuslineSegmentsSelection = append(statuslineSegmentsSelection, key)
+        }
+    }
+}
+```
+
+prefs write (저장 시점 변환):
+
+```go
+// MultiSelect 결과 (선택된 string slice) → map[string]bool
+// 15개 segment 모두에 대해 explicit true/false 설정
+allSegmentKeys := []string{
+    "claude_version", "context", "directory", "effort_thinking",
+    "git_branch", "git_status", "moai_version", "model",
+    "output_style", "pr", "session_time", "task",
+    "usage_5h", "usage_7d", "worktree",
+}
+selectedSet := make(map[string]bool, len(statuslineSegmentsSelection))
+for _, key := range statuslineSegmentsSelection {
+    selectedSet[key] = true
+}
+segmentsMap := make(map[string]bool, len(allSegmentKeys))
+for _, key := range allSegmentKeys {
+    segmentsMap[key] = selectedSet[key]
+}
+// 단, preset != "custom" 인 경우 segmentsMap을 nil로 두어 syncStatusline 기존 yaml 보존
+if statuslinePreset == "custom" {
+    prefs.StatuslineSegments = segmentsMap
+}
+```
+
+### 3.5 Known Issues 적용 (Section B filtered for Tier S)
+
+- **B4 frontmatter**: spec/plan/acceptance 3 파일 모두 canonical 12-field schema 준수 (`created:` not `created_at:`, `tags:` not `labels:`).
+- **B5 CI 3-tier**: spec-lint + golangci-lint + Test (per OS) 각각 PASS 의무. AC-SPW-005/006이 검증.
+- **B6 spec-lint heading**: `### 4.1 Out of Scope` h3 사용 (spec.md). `## Exclusions (What NOT to Build)` h2 wrapper. MissingExclusions ERROR 회피.
+- **B8 working tree hygiene**: pre-existing 11개 dirty(M) + 11개 untracked(??) PRESERVE — SPEC artifacts 3개만 touch.
+
+## 4. Pre-flight Check (Section C)
+
+Plan-auditor + run-phase 진입 전 확인:
+
+```bash
+# 1. 현재 branch + baseline
+git rev-parse HEAD  # → 02a0a8304be7330dd9ba62cbf24be3976f8f0ee6 (refreshed 2026-05-22, plan-auditor S1 fix)
+git branch --show-current  # → main
+
+# 2. cross-platform build 사전 확인 (NEW baseline)
+go build ./...
+GOOS=windows GOARCH=amd64 go build ./...
+
+# 3. profile + cli + statusline 패키지 baseline
+go test -count=1 ./internal/cli/... ./internal/profile/... ./internal/statusline/...
+
+# 4. lint baseline
+golangci-lint run --timeout=2m ./internal/cli/... ./internal/profile/... 2>&1 | tail -10
+
+# 5. PRESERVE 대상 enumeration
+git status --porcelain | grep -v "^??" | head -20  # M files (preserved)
+git status --porcelain | grep "^??" | head -20     # untracked (preserved)
+```
+
+## 5. Constraints (Section D)
+
+### 5.1 DO NOT VIOLATE
+
+- DO NOT modify `internal/profile/preferences.go` (StatuslinePreset/StatuslineSegments 필드 이미 존재)
+- DO NOT modify `internal/profile/sync.go` (syncStatusline 작동)
+- DO NOT modify `internal/statusline/` (renderer 영역 무관)
+- DO NOT modify `.moai/config/sections/statusline.yaml` (스키마 무변경)
+- DO NOT modify `internal/template/templates/.moai/config/sections/statusline.yaml` (template parity)
+- DO NOT touch pre-existing 11 dirty(M) files + 11 untracked(??) files (PRESERVE)
+- DO NOT amend commits, DO NOT force-push, DO NOT use `--no-verify`
+- DO NOT add `time-estimation` (Priority labels only)
+- DO NOT use AskUserQuestion (subagent boundary HARD — blocker report only)
+
+### 5.2 사용 의무
+
+- Conventional Commits: `plan(SPEC-V3R5-STATUSLINE-PROFILE-WIZARD-001): ...` (plan-phase) / `feat(SPEC-V3R5-STATUSLINE-PROFILE-WIZARD-001): ...` (run-phase)
+- Commit trailer: `🗿 MoAI <email@mo.ai.kr>`
+- Late-Branch policy (main 직진, push deferred to sync-phase per SPEC-V3R5-LATE-BRANCH-001 REQ-LB-005)
+
+## 6. Self-Verification Deliverables (Section E)
+
+run-phase manager-develop이 보고서에 포함할 사항:
+
+### E1. AC Binary PASS/FAIL Matrix
+
+| AC | Status | Verification Command | Actual Output |
+|----|--------|---------------------|---------------|
+| AC-SPW-001 | TBD | `grep -n 'StatuslinePresetTitle' internal/cli/profile_setup.go` | TBD |
+| AC-SPW-002 | TBD | `grep -n 'huh\.NewMultiSelect' internal/cli/profile_setup.go` | TBD |
+| AC-SPW-003 | TBD | `go test -run TestProfileSetupTranslations_PresetSegments ./internal/cli/...` | TBD |
+| AC-SPW-004 | TBD | `go test -run TestNormalizeStatuslinePreset ./internal/cli/...` | TBD |
+| AC-SPW-005 | TBD | `go test -count=1 ./internal/cli/...` | TBD |
+| AC-SPW-006 | TBD | `go build ./...` + `GOOS=windows ... go build ./...` | TBD |
+| AC-SPW-007 | TBD | `git diff main -- internal/profile/sync.go internal/profile/preferences.go` | TBD |
+
+### E2. Cross-Platform Build 결과
+
+```
+$ go build ./...                          → exit 0
+$ GOOS=windows GOARCH=amd64 go build ./... → exit 0
+$ GOOS=linux GOARCH=amd64 go build ./...   → exit 0
+```
+
+### E3. Coverage 측정
+
+```
+$ go test -count=1 -cover ./internal/cli/...
+```
+
+(cli 패키지 coverage baseline 유지 — 신규 helper + widget 코드 실행 경로 포함 확인)
+
+### E4. Subagent Boundary Grep (C-HRA-008 류 — Tier S filter)
+
+본 SPEC은 `internal/cli/` 영역 변경이므로 C-HRA-008 (subagent 도메인 `internal/harness/`, `internal/hook/` 한정) 직접 영향 없음. 그러나 일관성 확인:
+
+```
+$ grep -rn 'AskUserQuestion\|mcp__askuser' internal/cli/profile_setup.go internal/cli/profile_setup_translations.go | grep -v "_test.go" | grep -v "// "
+(no output expected)
+```
+
+### E5. Lint Status
+
+```
+$ golangci-lint run --timeout=2m
+```
+
+NEW issues 발견 시 explicit report (line + diagnosis). pre-existing baseline은 별도 mark.
+
+### E6. Branch HEAD + Push 상태
+
+- 새 commits SHA 리스트
+- 본 SPEC plan-phase: main 직진 (Late-Branch). push는 sync-phase에 통합.
+
+### E7. Blocker Report (있을 시)
+
+위임 prompt에서 명시 안 된 사용자 결정 필요 항목 (예: huh `WithHideFunc` 미작동 시 form 분리 결정, segment 정렬 순서, ja/zh 번역 품질 검토 요청 등)이 발견되면 structured 보고. **AskUserQuestion 절대 호출 금지** (subagent boundary HARD per agent-common-protocol).
+
+## 7. Risks & Mitigations Summary
+
+| Phase | Risk | Mitigation |
+|-------|------|------------|
+| M1 | translation 키 누락 | 23개 키 + 4 locale을 atomic MultiEdit으로 묶음. 즉시 TestProfileSetupTranslations_PresetSegments로 검증 |
+| M2 | huh `WithHideFunc` 미작동 | form 분리 fallback 준비 (3.2 참조). M2 자체 검증으로 작동 여부 확인 |
+| M2 | segments map 변환 오류 | M3 unit test (M2와 함께 작성)가 round-trip 보장. 15개 키 enumeration 명시 |
+| M3 | test가 cli 패키지 외 segment 영향 | _test.go 파일은 `package cli` 내에 위치. profile/statusline 패키지 호출 없음 (translation slice + normalizer만 검증) |
+| M4 | lint NEW issues | M1-M3 commit 전 incremental lint 확인. gofmt + go vet 사전 통과 |
+
+## 8. Out of Scope (h3 — spec-lint MissingExclusions 회피)
+
+### 8.1 본 SPEC 미포함
+
+- statusline renderer 변경
+- statusline.yaml 스키마 변경
+- segment list 추가/제거
+- Path B/C/D 다른 wizard gap 처리
+- defaultStatuslineSegments 11→15 확장
+- 4-locale 번역 audit (quality grade)
+- preset `full` short-circuit 동작 변경 (`STATUSLINE-PRESET-FIX-001` 가칭)
+
+## 9. Tier S 정당화
+
+본 SPEC이 Tier S 분류 기준을 만족함을 명시:
+
+| 기준 | 임계 | 본 SPEC | 결과 |
+|------|------|---------|------|
+| LOC delta | < 300 | ~200-280 | PASS |
+| 영향 source 파일 | < 5 | 2 (profile_setup.go + profile_setup_translations.go) | PASS |
+| 영향 test 파일 | (test는 별도 카운트) | 2 (기존 _test.go 확장 + 신규 함수) | OK |
+| 영향 패키지 | 1 | `internal/cli` 만 | PASS |
+| Backend 변경 | 없음 | 없음 | PASS |
+| Cross-platform 회귀 위험 | 낮음 | huh API는 cross-platform — windows/linux/darwin 모두 동일 동작 | PASS |
+| plan-auditor 임계 | 0.75 | target | TBD |
+
+Tier S 채택 결정 — plan-auditor PASS 임계 0.75 적용. Section A-E delegation template 적용은 OPTIONAL이나, 본 plan.md는 Section C/D/E 명시적으로 포함하여 run-phase Section A-E 완성도를 높였다 (5-section 권장 패턴).

--- a/.moai/specs/SPEC-V3R5-STATUSLINE-PROFILE-WIZARD-001/progress.md
+++ b/.moai/specs/SPEC-V3R5-STATUSLINE-PROFILE-WIZARD-001/progress.md
@@ -1,0 +1,89 @@
+---
+id: SPEC-V3R5-STATUSLINE-PROFILE-WIZARD-001
+title: "Run-phase Progress — profile setup wizard statusline preset/segments"
+version: "0.2.0"
+created: 2026-05-22
+updated: 2026-05-22
+---
+
+# Run-Phase Progress — SPEC-V3R5-STATUSLINE-PROFILE-WIZARD-001
+
+## Summary
+
+Tier S Quick Win — backend (preferences + sync) was already complete; only frontend wizard input UI was missing. Implementation completed orchestrator-direct (manager-develop Agent delegation failed with `WorktreeCreate hook returned a path that is not a directory: {}` — Claude Code runtime autonomous L1 isolation regression, identical to `cleanupBogusRootDir` lesson pattern; per CLAUDE.md §16 fallback to orchestrator-direct).
+
+## Milestone Status
+
+| Milestone | Status | Commits | Notes |
+|-----------|--------|---------|-------|
+| M1 translations + helper | DONE | (this commit) | 23 keys × 4 locales (92 cells) + `statuslinePresetCanonical` + `statuslineAllSegments` + `isCanonicalStatuslinePreset` + `normalizeStatuslinePreset` |
+| M2 wizard Display + Segments group | DONE | (this commit) | Display group: + Preset Select (4 options). Section 5: MultiSelect group with `WithHideFunc(preset != "custom")` (R-SPW-001 mitigation A worked — no form-split fallback needed) |
+| M3 regression tests | DONE | (this commit) | `TestNormalizeStatuslinePreset` (7 cases covering EC-SPW-001/002/003) + `TestStatuslineAllSegments_CardinalityAndOrder` + `TestProfileSetupTranslations_PresetSegments` (4 locale × 23 cells = 92 cells verified) |
+| M4 final verification + commit | DONE | (this commit) | 7/7 ACs PASS / cross-platform PASS / lint NEW=0 in profile_setup*.go |
+
+## AC PASS/FAIL Matrix
+
+| AC | Status | Verification Command | Actual |
+|----|--------|---------------------|--------|
+| AC-SPW-001 | PASS | `grep -n 'StatuslinePresetTitle' internal/cli/profile_setup.go` | `352: Title(t.StatuslinePresetTitle)` |
+| AC-SPW-002 | PASS | `grep -n 'huh.NewMultiSelect' internal/cli/profile_setup.go` | `376: huh.NewMultiSelect[string]()` + 50 NewOption (preset 4 + 15 segments included) |
+| AC-SPW-003 | PASS | `go test -run TestProfileSetupTranslations_PresetSegments ./internal/cli/...` | PASS |
+| AC-SPW-004 | PASS | `go test -run TestNormalizeStatuslinePreset ./internal/cli/...` | PASS |
+| AC-SPW-005 | PASS | `go test -count=1 ./internal/cli/...` | PASS (cli pkg + sub-packages all ok) |
+| AC-SPW-006 | PASS | `go build ./...` + `GOOS=windows GOARCH=amd64 go build ./...` + linux | darwin exit 0 / windows exit 0 / linux exit 0 |
+| AC-SPW-007 | PASS | `git diff 02a0a8304 -- internal/profile/sync.go internal/profile/preferences.go` | 0 lines (backend byte-identical preserved) |
+
+## Plan-Auditor SHOULD Findings — Run-Phase Absorption
+
+- **S1** (stale SHA) — resolved inline before commit (plan.md line 245 `9e14c180...` → `02a0a8304...`).
+- **S2** (LOC inconsistency) — resolved inline before commit (spec.md HISTORY `~130` → `~200-280`).
+- **S3** (git diff reference-point) — AC-SPW-007 used explicit `git diff 02a0a8304` (pre-SPEC HEAD) instead of `git diff main`. PASS.
+- **S4** (nil-map default rendering) — `internal/cli/profile_setup.go:212-227` documents explicit choice: nil map → all-15 segments enabled (matches statusline.yaml baseline, NOT 11-segment `defaultStatuslineSegments()`). Comment explicitly states rationale. Run-phase absorbed.
+- **S5** (PRESET-FIX-001 dangling reference) — resolved inline before commit (spec.md "proposed, not yet filed").
+
+## Out-of-Scope Baseline Failures (Pre-Existing, NOT This SPEC's Responsibility)
+
+Full repo `go test ./...` shows these pre-existing baseline failures (verified absent in `internal/cli/...` scope where this SPEC operates):
+
+- `internal/hook/` 2 (TestHookWrapper_*) — hook subsystem, unrelated
+- `internal/lsp/subprocess/` 1 (TestSupervisor_NonZeroExit) — LSP, unrelated
+- `internal/skills/` 2 (TestTemplateMirrorParity / TestSubSkillLOCCeiling) — template drift (memory project_v3r6_template_mirror_drift_audit_2026_05_22 documents 25-file drift)
+- `internal/statusline/` 1 (TestRenderPRSegment_Absence) — statusline renderer baseline (memory project_v3r5_statusline_fmc_001_run_complete documents)
+- `internal/template/` 3 (TestLateBranchTemplateMirror / TestRuleTemplateMirrorDrift / TestSkillsContainPlanAuditGateMarkers) — template drift
+
+All pre-existing per memory `project_v3r5_statusline_fmc_001_run_complete` and `project_v3r6_template_mirror_drift_audit_2026_05_22`. Out of scope per spec.md §4.1.
+
+## Coverage
+
+```
+internal/cli       67.2% of statements
+internal/cli/pr    91.7%
+internal/cli/wizard 37.1%
+internal/cli/worktree 84.2%
+```
+
+(internal/cli baseline stable — new code paths exercised by 3 new tests.)
+
+## Files Modified
+
+- `internal/cli/profile_setup.go` — +50 LOC (helper + canonical slice + Preset Select + Segments MultiSelect group + segments map conversion)
+- `internal/cli/profile_setup_translations.go` — +96 LOC (struct 23 fields + 4 locale × 23 entries = 92 cells)
+- `internal/cli/profile_setup_test.go` — +43 LOC (TestNormalizeStatuslinePreset + TestStatuslineAllSegments_CardinalityAndOrder)
+- `internal/cli/profile_setup_translations_test.go` — +49 LOC (TestProfileSetupTranslations_PresetSegments)
+
+**Total LOC delta**: ~238 (estimated in plan.md §3.1 was ~200-280, on-target).
+
+## Branch State
+
+- Pre-run-phase HEAD: `56a618587` (after plan commit `b5b3354ed` + research commit `56a618587`)
+- Post-run-phase HEAD: (this commit SHA — to be filled by commit step)
+- Branch: `main` (Late-Branch policy, REQ-LB-005)
+- Push status: deferred to sync-phase per REQ-LB-005
+
+## Sync-Phase Handoff
+
+Ready for `/moai sync SPEC-V3R5-STATUSLINE-PROFILE-WIZARD-001` (manager-docs):
+
+- README/CHANGELOG update for v2.20.0-rc1 release notes
+- Optional: docs-site `advanced/statusline.md` update mentioning preset/segments configurability via `moai profile setup`
+- PR creation (squash) with batch sync of accumulated SPECs since last push

--- a/.moai/specs/SPEC-V3R5-STATUSLINE-PROFILE-WIZARD-001/spec.md
+++ b/.moai/specs/SPEC-V3R5-STATUSLINE-PROFILE-WIZARD-001/spec.md
@@ -1,0 +1,158 @@
+---
+id: SPEC-V3R5-STATUSLINE-PROFILE-WIZARD-001
+title: "profile setup wizard에 statusline preset/segments 입력 UI 추가"
+version: "0.1.0"
+status: draft
+created: 2026-05-22
+updated: 2026-05-22
+author: manager-spec
+priority: P2
+phase: "v2.20.0-rc1"
+module: "internal/cli"
+lifecycle: spec-anchored
+tags: "statusline, profile, wizard, ui, huh, tier-s, quick-win"
+tier: S
+---
+
+# SPEC-V3R5-STATUSLINE-PROFILE-WIZARD-001 — profile setup wizard에 statusline preset/segments 입력 UI 추가
+
+## HISTORY
+
+| Version | Date | Author | Change |
+|---------|------|--------|--------|
+| 0.1.0 | 2026-05-22 | manager-spec | 초안 작성. `ProfilePreferences.StatuslinePreset` + `StatuslineSegments` 필드(`internal/profile/preferences.go:46-47`)는 이미 존재하며 `syncStatusline`(`internal/profile/sync.go:95-145`)이 `.moai/config/sections/statusline.yaml`로 sync 하는 로직도 구현되어 있으나, `profile_setup.go:282-300` 의 huh.NewForm 4번째 Display group은 Mode + Theme만 입력받아 사용자가 preset/segments를 wizard에서 입력할 수 없음. Quick Win: backend 인프라 완비, frontend wizard input UI만 누락. Tier S 분류 근거: 3 source 파일 (`profile_setup.go` + `profile_setup_translations.go` + 신규/기존 test 파일) + LOC delta 추정 ~200-280 < 300 (plan.md §3.1 정밀 산정 반영, plan-auditor S2 fix). |
+
+## 1. Background
+
+### 1.1 출처
+
+본 SPEC은 statusline preset/segments 설정의 **frontend gap**을 해소한다. 사용자가 `moai profile setup` wizard 실행 시 다음 두 옵션이 노출되지 않아 CLI 흐름만으로는 preset 변경이 불가능하다:
+
+1. `statusline.preset` (full / compact / minimal / custom) — 미노출
+2. `statusline.segments` (15개 segment 토글 맵, custom preset 시만 의미) — 미노출
+
+### 1.2 다루는 결함
+
+#### 1.2.1 Backend는 완비, Frontend만 누락 (verifiable evidence)
+
+`ProfilePreferences` struct에 두 필드가 이미 존재하며 sync 로직도 작동한다:
+
+| 검증 항목 | 위치 | 상태 |
+|-----------|------|------|
+| `StatuslinePreset string` 필드 정의 | `internal/profile/preferences.go:46` | EXISTS |
+| `StatuslineSegments map[string]bool` 필드 정의 | `internal/profile/preferences.go:47` | EXISTS |
+| `SyncToProjectConfig` 두 필드 sync 분기 | `internal/profile/sync.go:69-77` | EXISTS |
+| `syncStatusline` preset/segments merge 로직 | `internal/profile/sync.go:95-145` | EXISTS |
+| `defaultStatuslineSegments` 11-segment map | `internal/profile/sync.go:148-162` | EXISTS |
+| `.moai/config/sections/statusline.yaml` 15-segment 정의 | (statusline.yaml) | EXISTS |
+| wizard huh.NewForm Display group preset/segments input | `internal/cli/profile_setup.go:282-300` | **MISSING** |
+| profileSetupText 번역 키 (Preset*, Segment*) | `internal/cli/profile_setup_translations.go` | **MISSING** |
+| `normalizeStatuslinePreset()` 정규화 함수 | `internal/cli/profile_setup.go` (상단 helper) | **MISSING** |
+
+#### 1.2.2 사용자 영향
+
+- preset이 `compact`/`minimal`/`custom`인 사용자가 wizard 재실행 시 자동으로 `default` 또는 `full` 로 fall back될 위험 (현재 wizard가 preset 값을 read/write 하지 않으므로 sync에서 누락)
+- 새 사용자가 wizard를 통해 preset 변경 불가 — `.moai/config/sections/statusline.yaml`을 수동 편집해야 함
+- custom preset 사용자가 segments 토글 불가
+
+### 1.3 Quick Win 정의
+
+본 SPEC은 다음을 변경하지 **않는다**:
+- `ProfilePreferences` struct (필드 이미 존재)
+- `SyncToProjectConfig` / `syncStatusline` (sync 이미 작동)
+- `internal/statusline/` renderer (출력 영역 무관)
+- `.moai/config/sections/statusline.yaml` 스키마
+
+본 SPEC은 오직 다음만 추가한다:
+1. wizard Display group에 Preset Select widget
+2. preset이 `custom`일 때 Segments MultiSelect widget
+3. 4-locale 번역 키 + 정규화 함수 + 회귀 테스트
+
+## 2. Requirements (EARS)
+
+### REQ-SPW-001 (Event-Driven): Preset 입력 widget 추가
+
+**WHEN** 사용자가 `moai profile setup [name]` 명령으로 wizard를 실행하고 Display group(`profile_setup.go:282-300`)에 도달하면 **THEN** wizard는 Statusline mode/theme Select 사이 또는 직후에 `huh.NewSelect[string]()` for StatuslinePreset을 표시해야 한다.
+
+- 옵션: 4개 (`full`, `compact`, `minimal`, `custom`)
+- Default: `normalizeStatuslinePreset(existingPrefs.StatuslinePreset)` 결과
+- 결과: 선택값을 `prefs.StatuslinePreset` 필드에 저장
+- 빈 문자열(`""`) 허용 — `syncStatusline`이 기존 yaml 값 보존
+
+### REQ-SPW-002 (State-Driven): Segments 입력 widget — custom preset 조건부
+
+**IF** 사용자가 REQ-SPW-001에서 `custom` preset을 선택했다면 **THEN** wizard는 후속 `huh.NewMultiSelect[string]()` for StatuslineSegments를 표시해야 한다.
+
+- 옵션: 15개 segment 키 (`claude_version`, `context`, `directory`, `effort_thinking`, `git_branch`, `git_status`, `moai_version`, `model`, `output_style`, `pr`, `session_time`, `task`, `usage_5h`, `usage_7d`, `worktree`)
+- Default: 기존 `existingPrefs.StatuslineSegments` map에서 `true` 값인 키 list
+- 결과: 선택된 list를 `map[string]bool`로 변환 (선택=true, 미선택=false)
+- huh의 conditional rendering은 `WithHideFunc` 또는 별도 group으로 구현 (실행 시점에 preset 값 평가)
+
+### REQ-SPW-003 (Ubiquitous): 4-locale 번역 키 추가
+
+The system **shall** add the following keys to `profileSetupText` struct and provide translations for all 4 locales (en / ko / ja / zh):
+
+- `StatuslinePresetTitle`, `StatuslinePresetDesc`
+- `PresetFull`, `PresetCompact`, `PresetMinimal`, `PresetCustom`
+- `StatuslineSegmentsTitle`, `StatuslineSegmentsDesc`
+- 15개 segment 레이블 키 (`SegmentModel`, `SegmentContext`, `SegmentOutputStyle`, `SegmentDirectory`, `SegmentGitStatus`, `SegmentGitBranch`, `SegmentClaudeVersion`, `SegmentMoaiVersion`, `SegmentSessionTime`, `SegmentUsage5h`, `SegmentUsage7d`, `SegmentEffortThinking`, `SegmentPR`, `SegmentTask`, `SegmentWorktree`)
+
+기존 번역 패턴 (예: `ModelOpus`, `EffortLevelXHigh`)과 일관성을 유지한다. en이 canonical reference이며 ko/ja/zh는 번역 품질을 유지하되 segment 식별성을 위해 영어 키 이름을 괄호로 병기할 수 있다 (예: ko `"Model (모델)"`).
+
+### REQ-SPW-004 (Ubiquitous): 정규화 함수 추가
+
+The system **shall** add a `normalizeStatuslinePreset(p string) string` helper function in `profile_setup.go` near the existing `normalizeStatuslineMode` / `normalizeStatuslineTheme` helpers (top of file, around line 50-77 region), following the `isCanonical*` check pattern.
+
+- 4개 canonical 값 (`full`, `compact`, `minimal`, `custom`)을 통과시키고
+- 빈 문자열은 빈 문자열로 반환 (`syncStatusline`이 기존 yaml 값 보존하도록)
+- 알 수 없는 값 (예: 이전 버전 prefs의 `fullbar`)은 빈 문자열로 reset
+
+### REQ-SPW-005 (Unwanted + Event-Driven): 회귀 테스트
+
+The system **shall not** allow regressions in the wizard's preset/segments input behavior. **WHEN** `go test ./internal/cli/...` is executed **THEN** the test suite must verify:
+
+- 4 locale 각각에서 `StatuslinePresetTitle`, `StatuslinePresetDesc`, `StatuslineSegmentsTitle`, `StatuslineSegmentsDesc` 가 빈 문자열이 아님
+- 4 locale 각각에서 모든 PresetFull/Compact/Minimal/Custom 레이블이 빈 문자열이 아님
+- 4 locale 각각에서 15개 Segment 레이블이 모두 빈 문자열이 아님
+- `normalizeStatuslinePreset` 유효 입력 4개 통과 + 무효 입력 (`"fullbar"`, `"invalid"`) → `""` 반환
+- 정규화 + write + read round-trip이 등가 (existing prefs와 default 값 일치)
+
+## 3. Acceptance Criteria (Binary)
+
+전체 AC는 `acceptance.md`에 binary verification command 형식으로 정의된다. spec.md §3는 high-level summary만 제공한다.
+
+| AC | 요약 | Binary Check |
+|----|------|--------------|
+| AC-SPW-001 | StatuslinePreset Select widget 존재 | `grep -n 'StatuslinePresetTitle' internal/cli/profile_setup.go` → ≥1 match |
+| AC-SPW-002 | Segments MultiSelect widget 존재 (custom 조건부) | `grep -n 'StatuslineSegmentsTitle\|NewMultiSelect' internal/cli/profile_setup.go` → ≥2 matches |
+| AC-SPW-003 | 4-locale 번역 키 모두 존재 (en/ko/ja/zh × Preset* + Segment* keys) | `go test -run TestProfileSetupTranslations_PresetSegments ./internal/cli/...` → PASS |
+| AC-SPW-004 | `normalizeStatuslinePreset` 정규화 함수 정의 + 유효/무효 처리 | `go test -run TestNormalizeStatuslinePreset ./internal/cli/...` → PASS |
+| AC-SPW-005 | 회귀 테스트 PASS + 전체 cli 패키지 회귀 없음 | `go test ./internal/cli/...` → PASS (NEW failures = 0) |
+| AC-SPW-006 | Cross-platform build PASS | `go build ./...` + `GOOS=windows GOARCH=amd64 go build ./...` → exit 0 둘 다 |
+| AC-SPW-007 | sync round-trip 정상 (`SyncToProjectConfig` 무변경 확인) | `git diff internal/profile/sync.go internal/profile/preferences.go` → no output |
+
+각 AC의 단위 검증 명령은 `acceptance.md` Given-When-Then 시나리오에서 정확히 정의된다.
+
+## Exclusions (What NOT to Build)
+
+### 4.1 Out of Scope
+
+본 SPEC에서 다루지 **않는** 항목:
+
+- statusline renderer 변경 (`internal/statusline/renderer.go`, `builder.go`, `types.go`) — 출력 layout 무관
+- statusline.yaml 스키마 변경 (15개 segment fixed list 유지)
+- segment 추가/제거 — 별도 SPEC로 처리 (`SPEC-V3R5-STATUSLINE-SEGMENTS-EXTEND-NNN` 가칭, 향후)
+- `ProfilePreferences` struct 필드 추가/변경
+- `syncStatusline` / `SyncToProjectConfig` 로직 변경
+- `defaultStatuslineSegments` 11→15 확장 (현 11이 의도된 보수적 default — 별도 결정 필요, `SPEC-V3R5-STATUSLINE-DEFAULT-FULL-NNN` 가칭)
+- Path B/C/D 등 다른 dead key/wizard gap 처리 (이번 Quick Win은 preset/segments에 한정)
+- `.moai/config/sections/statusline.yaml` 의 `preset: full` short-circuit 동작 (별도 SPEC `SPEC-V3R5-STATUSLINE-PRESET-FIX-001` proposed, not yet filed — project memory `feedback_workflow_inflation_root_cause` 등에서 언급, plan-auditor S5 fix)
+- 4-locale 번역 품질 audit (en이 canonical, ko/ja/zh는 일관성 수준만 검증)
+
+### 4.2 Edge Cases (must handle)
+
+다음 edge case는 본 SPEC scope에 포함되며 acceptance.md에서 정확히 정의된다:
+
+- **EC-SPW-001 (existing user preserve)**: 기존 prefs에 `StatuslinePreset: "compact"` 값이 있는 사용자가 wizard 재실행 시, Preset Select widget의 default 값이 `compact`로 표시되어야 한다 (값 손실 방지)
+- **EC-SPW-002 (invalid legacy value)**: 이전 버전 또는 수동 편집으로 `StatuslinePreset: "fullbar"` (canonical 4개 외 값)이 prefs에 저장된 경우 wizard는 panic 없이 `normalizeStatuslinePreset` 통해 `""` 으로 fall back하고 사용자가 다시 선택할 수 있어야 한다 (forward-compat 보장)
+- **EC-SPW-003 (empty preset preserved)**: 사용자가 빈 문자열을 선택 (또는 default 유지)한 경우 `prefs.StatuslinePreset = ""` 저장되며 `syncStatusline` (`sync.go:123-125`)이 기존 yaml의 `preset` 값을 보존해야 한다 (override 회피)

--- a/.moai/specs/SPEC-V3R5-STATUSLINE-PROFILE-WIZARD-001/spec.md
+++ b/.moai/specs/SPEC-V3R5-STATUSLINE-PROFILE-WIZARD-001/spec.md
@@ -1,8 +1,8 @@
 ---
 id: SPEC-V3R5-STATUSLINE-PROFILE-WIZARD-001
 title: "profile setup wizard에 statusline preset/segments 입력 UI 추가"
-version: "0.1.0"
-status: draft
+version: "0.2.0"
+status: implemented
 created: 2026-05-22
 updated: 2026-05-22
 author: manager-spec
@@ -21,6 +21,7 @@ tier: S
 | Version | Date | Author | Change |
 |---------|------|--------|--------|
 | 0.1.0 | 2026-05-22 | manager-spec | 초안 작성. `ProfilePreferences.StatuslinePreset` + `StatuslineSegments` 필드(`internal/profile/preferences.go:46-47`)는 이미 존재하며 `syncStatusline`(`internal/profile/sync.go:95-145`)이 `.moai/config/sections/statusline.yaml`로 sync 하는 로직도 구현되어 있으나, `profile_setup.go:282-300` 의 huh.NewForm 4번째 Display group은 Mode + Theme만 입력받아 사용자가 preset/segments를 wizard에서 입력할 수 없음. Quick Win: backend 인프라 완비, frontend wizard input UI만 누락. Tier S 분류 근거: 3 source 파일 (`profile_setup.go` + `profile_setup_translations.go` + 신규/기존 test 파일) + LOC delta 추정 ~200-280 < 300 (plan.md §3.1 정밀 산정 반영, plan-auditor S2 fix). |
+| 0.2.0 | 2026-05-22 | orchestrator-direct | run-phase 완료 (manager-develop 위임 시 `WorktreeCreate hook returned a path that is not a directory: {}` 반복 실패 — Claude Code runtime autonomous L1 isolation regression, cleanupBogusRootDir lesson 일치, CLAUDE.md §16 "위임 대상 부재" 조항으로 orchestrator-direct 전환). M1 translations 23 키 × 4 locale + helper 추가 / M2 Display group에 Preset Select + 별도 Segments MultiSelect group with WithHideFunc("custom") / M3 2 신규 테스트 추가 (TestNormalizeStatuslinePreset 7 cases + TestStatuslineAllSegments_CardinalityAndOrder + TestProfileSetupTranslations_PresetSegments 4 locale × 23 cells = 92 cells) / M4 7/7 ACs PASS (AC-SPW-001 line 352 / AC-SPW-002 line 376 NewMultiSelect + 50 NewOption / AC-SPW-003 PASS / AC-SPW-004 PASS / AC-SPW-005 internal/cli/... PASS / AC-SPW-006 darwin+windows+linux exit 0 / AC-SPW-007 git diff 02a0a8304 0 lines preserved). plan-auditor S4 absorbed (nil-map default = 15-segment all-true). status `draft → implemented`. Late-Branch policy main 직진 (push deferred to sync-phase per REQ-LB-005). |
 
 ## 1. Background
 

--- a/docs-site/content/en/advanced/statusline.md
+++ b/docs-site/content/en/advanced/statusline.md
@@ -1,353 +1,368 @@
 ---
-title: Statusline System and PR Segment
+title: Statusline System — Complete 3-line Layout Guide
 weight: 78
 draft: false
 ---
 
-A **custom statusline system** for integrating Claude Code with moai-adk-go. Starting from v2.1.145, you can display GitHub PR information in the statusline.
+A **custom statusline system** for Claude Code ↔ moai-adk-go integration. Since Claude Code v2.1.139 (effort/thinking) and v2.1.145 (workspace.repo + pr), stdin JSON exposes rich session context that this statusline visualizes.
 
-> The MoAI workflow is PR-centric. Every SPEC generates plan-PR → run-PR → sync-PR, so displaying the current PR status in the statusline improves development efficiency.
+> MoAI workflows are PR-centric. Every SPEC produces a plan-PR → run-PR → sync-PR cycle, so surfacing the current PR number, review state, context usage, and handoff hint directly in the statusline dramatically improves development efficiency.
 
 ## Overview
 
-### Why a Custom Statusline?
+### Final Layout (3-line v3)
 
-Claude Code's default statusline is optimized for general usage patterns. However, MoAI-ADK users need specialized information:
+```
+🤖 Opus 4.7 │ 🧠 xhigh·t │ 🔅 v2.1.146 │ 🗿 v2.20.0-rc1 │ ⏳ 4h 52m │ 💬 MoAI
+🪫 CW: ███████░░░ 72% (⚠️/clear) │ 🔋 5H: █████░░░░░ 56% (46m) │ 🔋 7D: █░░░░░░░░░ 13% (May 28)
+📁 moai-adk-go │ 🔀 modu-ai/moai-adk (🅱️ main ↑5 +2) │ 💾 +0 M1 ?1 │ 💌 PR #1234 (⌥approved)
+```
 
-- **PR-Centric Workflow**: Display the current PR number and review status (approved/pending/changes_requested)
-- **Multi-Pane Development**: Show current SPEC status when using worktree-based parallel development
-- **Cost Tracking**: Real-time cost monitoring when using GLM environments
-- **Context Management**: Current session token usage and cumulative costs
+- **Line 1 (Info)**: model · effort/thinking · Claude Code version · MoAI version · session time · output style
+- **Line 2 (Usage bars)**: CW (context window) · 5H (rolling) · 7D (rolling) — each bar shows emoji + label + bar + % + reset info
+- **Line 3 (Git/PR)**: directory · combined repo+branch · git status · active SPEC task · PR info
 
-The custom statusline displays this information through the `.moai/status_line.sh` renderer.
-
-### Statusline Architecture
+### Data Flow
 
 ```
 Claude Code stdin (JSON)
     ↓
 internal/statusline/types.go (StdinData parsing)
     ↓
-internal/statusline/builder.go (segment composition)
+internal/statusline/builder.go (CollectMemory, CollectMetrics, etc.)
     ↓
-internal/statusline/renderer.go (color coding and rendering)
+internal/statusline/renderer.go (3-line v3 layout)
     ↓
-.moai/status_line.sh (template-based final rendering)
+.moai/status_line.sh → terminal display
 ```
+
+## Line 1 — Info (7 segments)
+
+### 🤖 Model
+
+- **Format**: `🤖 <model display name>`
+- **Data source**: stdin `model.display_name` (or string shorthand)
+- **Examples**: `🤖 Opus 4.7`, `🤖 Sonnet 4.6`, `🤖 Haiku 4.5`
+- **Hidden when**: `model` field absent or `data.Metrics.Model == ""`
+- **Segment key**: `model`
+
+### 🧠 Effort / Thinking
+
+- **Format**: `🧠 <level>[·t]`
+- **Data source**: stdin `effort.level` + `thinking.enabled` (Claude Code v2.1.139+)
+- **Level values**: `low` / `medium` / `high` / `xhigh` / `max`
+- **`·t` suffix**: appended when `thinking.enabled == true` (extended reasoning active)
+- **Examples**:
+  - `🧠 xhigh·t` (xhigh effort + thinking active)
+  - `🧠 high` (high effort, no thinking)
+  - `·t` (effort absent + only thinking active)
+- **Hidden when**: both `effort` + `thinking` absent (including empty effort.level)
+- **Segment key**: `effort_thinking`
+
+### 🔅 Claude Code Version
+
+- **Format**: `🔅 v<version>` (default mode) or `🔅 cc v<version>` (full mode)
+- **Data source**: stdin `version` string
+- **Example**: `🔅 v2.1.146`
+- **Hidden when**: `version` empty string
+- **Segment key**: `claude_version`
+
+### 🗿 MoAI Version
+
+- **Format**: `🗿 v<current>` or `🗿 v<current> -> 🗿 v<latest>` when update available
+- **Data source**: `.moai/config/sections/system.yaml` `moai.version` + background update checker
+- **Examples**:
+  - `🗿 v2.20.0-rc1` (latest)
+  - `🗿 v2.18.0 -> 🗿 v2.20.0-rc1` (update recommended)
+- **Segment key**: `moai_version`
+
+### ⏳ Session Time
+
+- **Format**: `⏳ <X>h <Y>m` (≥1h) / `⏳ <X>m` (<1h) / `⏳ <X>d <Y>h` (≥24h)
+- **Data source**: stdin `cost.total_duration_ms`
+- **Examples**: `⏳ 4h 52m`, `⏳ 35m`, `⏳ 1d 3h`
+- **Segment key**: `session_time`
+
+### 💬 Output Style
+
+- **Format**: `💬 <style name>`
+- **Data source**: stdin `output_style.name`
+- **Examples**: `💬 MoAI`, `💬 R2-D2`, `💬 default`
+- **Hidden when**: `output_style.name` empty string
+- **Segment key**: `output_style`
+
+## Line 2 — Usage Bars (3 segments)
+
+### 🪫/🔋 CW (Context Window)
+
+- **Format**: `<icon> CW: <bar> <pct>% [(⚠️/clear)]`
+- **Data source**:
+  - bar: `context_window.context_window_size` × auto-compact threshold (default 85%) → scaled budget
+  - percentage: `context_window.used_percentage` (pre-calculated) or sum of `current_usage` tokens
+  - (⚠️/clear) gated by: `shouldShowHandoffGuide(data) == true`
+- **Icons**:
+  - 🔋 (normal, <50% scaled)
+  - 🪫 (warning, 50-79% scaled)
+  - 🪫 (critical, ≥80% scaled, color added)
+- **(⚠️/clear) handoff suffix**:
+  - 1M context model (Opus 4.7): used_percentage ≥50% (against raw context_window_size)
+  - 200K context model (Sonnet/Haiku): used_percentage ≥90%
+  - Meaning: recommend running `/clear` before next turn + use paste-ready resume message
+- **Example**: `🪫 CW: ███████░░░ 72% (⚠️/clear)`
+- **Segment key**: `context`
+
+### 🔋 5H (5-hour rolling rate limit)
+
+- **Format**: `🔋 5H: <bar> <pct>% [(<reset>)]`
+- **Data source**: stdin `rate_limits.five_hour.{used_percentage, resets_at}`
+- **Reset format**:
+  - <60 min: `(Nm)` (e.g., `(47m)`)
+  - <24 hours: `(Nh Nm)` (e.g., `(2h 15m)`)
+  - ≥24 hours: `(Mon DD)` (e.g., `(May 28)`)
+- **Example**: `🔋 5H: █████░░░░░ 56% (47m)`
+- **No data**: `rate_limits.five_hour == null` → bar 0%, reset `(rolling)`
+- **Segment key**: `usage_5h`
+
+### 🔋 7D (7-day rolling rate limit)
+
+- **Format**: `🔋 7D: <bar> <pct>% [(<reset>)]`
+- **Data source**: stdin `rate_limits.seven_day.{used_percentage, resets_at}`
+- **Reset format**: `(Mon DD)` (absolute date)
+- **Example**: `🔋 7D: █░░░░░░░░░ 13% (May 28)`
+- **Segment key**: `usage_7d`
+
+## Line 3 — Git / PR (5 segments)
+
+### 📁 Directory
+
+- **Format**: `📁 <directory name>`
+- **Data source**: stdin `workspace.project_dir` (basename) or `cwd`
+- **Examples**: `📁 moai-adk-go`, `📁 my-project`
+- **Hidden when**: `data.Directory` empty string
+- **Segment key**: `directory`
+
+### 🔀 Repo + Branch (combined segment)
+
+- **Format**: `🔀 <owner>/<name> (🅱️ <branch>[ ↑N][ ↓N][ +N])`
+- **Data source**:
+  - `🔀 owner/name`: stdin `workspace.repo.{host, owner, name}` (Claude Code v2.1.145+)
+  - `🅱️ branch`: local git `branch --show-current`
+  - `↑N`: ahead count (vs origin/<branch>)
+  - `↓N`: behind count
+  - `+N`: dirty count = Modified + Staged + Untracked
+- **Examples**:
+  - `🔀 modu-ai/moai-adk (🅱️ main ↑3 +2)` (repo + branch + ahead + dirty)
+  - `🔀 modu-ai/moai-adk (🅱️ main)` (clean branch, no ahead)
+  - `🔀 (🅱️ feat/auth ↑2 ↓1 +6)` (fallback: no repo info)
+- **Hidden when**:
+  - branch empty string → whole segment hidden
+  - repo nil → fallback (only branch shown in parens)
+- **Worktree mode**: if `worktree` segment enabled, `[WT] ` prefix prepended to branch
+- **Segment key**: `git_branch` (combined)
+
+### 💾 Git Status
+
+- **Format**: `💾 +<staged> M<modified> ?<untracked>`
+- **Data source**: local git `git status --porcelain` parsing
+- **Example**: `💾 +0 M1 ?1` (staged 0, modified 1, untracked 1)
+- **Hidden when**: git unavailable
+- **Note**: previous mailbox quartet emoji (📬/📫/📪/📭) retired in favor of unified 💾
+- **Segment key**: `git_status`
+
+### 📋 Task (Active SPEC workflow)
+
+- **Format**: `📋 [<command> <SPEC-ID>-<stage>]`
+- **Data source**: `~/.moai/state/last-session-state.json` `active_task` field (populated only when that file exists)
+- **Example**: `📋 [/moai run SPEC-V3R5-STATUSLINE-001-implement]`
+- **Hidden when**: file absent or `active_task` nil → segment hidden
+- **Segment key**: `task` (opt-in default off)
+
+### 💌 PR (Active GitHub Pull Request)
+
+- **Format**: `💌 PR #<number> (⌥<review_state>)` (when state present) / `💌 PR #<number>` (when state empty)
+- **Data source**: stdin `pr.{number, url, review_state}` (Claude Code v2.1.146+)
+- **Review state values**: `approved` / `pending` / `changes_requested` / `draft` / others (raw passthrough)
+- **Color coding** (review_state portion):
+  - `approved`: green (Success)
+  - `pending`: yellow (Warning)
+  - `changes_requested`: red (Error)
+  - `draft`: gray (Muted)
+  - other: no color (raw passthrough)
+- **Examples**:
+  - `💌 PR #1234 (⌥approved)` (green)
+  - `💌 PR #1023 (⌥pending)` (yellow)
+  - `💌 PR #7 (⌥changes_requested)` (red)
+  - `💌 PR #99 (⌥draft)` (gray)
+  - `💌 PR #100` (no state)
+- **Hidden when**:
+  - `pr` field absent (no PR or Claude Code below v2.1.145)
+  - `pr.number == 0`
+  - `SegmentPR` config explicitly false
+- **Segment key**: `pr` (default on per v2.20.0-rc1)
 
 ## Configuration
 
 ### Basic Structure
 
-Configure the statusline in `.moai/config/sections/statusline.yaml`:
+Segment activation is managed in `.moai/config/sections/statusline.yaml`:
 
 ```yaml
 statusline:
-  mode: default              # default | compact | verbose
-  theme: catppuccin-mocha    # Color theme selection
-  preset: full               # full | minimal | custom
+  mode: default              # default | full
+  theme: catppuccin-mocha    # color theme
+  preset: custom             # full | minimal | custom
   segments:
-    model: true              # Display Claude model
-    context: true            # Display context usage
-    directory: true          # Display working directory
-    git_status: true         # Display Git status
-    git_branch: true         # Display Git branch
-    worktree: false          # Display worktree info (optional)
-    effort_thinking: false   # Display effort/thinking state (optional)
-    pr: false                # Display PR info (optional, v2.1.145+)
+    # Line 1
+    model: true
+    effort_thinking: true
+    claude_version: true
+    moai_version: true
+    session_time: true
+    output_style: true
+
+    # Line 2
+    context: true
+    usage_5h: true
+    usage_7d: true
+
+    # Line 3
+    directory: true
+    git_branch: true       # combined repo+branch
+    git_status: true
+    task: true             # opt-in default off in older versions
+    pr: true               # default on per v2.20.0-rc1
+    worktree: false
 ```
 
-### Segment Options
+### Segment Activation Matrix
 
-| Segment | Default | Purpose | Description |
-|---------|---------|---------|-------------|
-| `model` | true | Current model | Display Claude model version |
-| `context` | true | Context usage | Current session token usage |
-| `directory` | true | Working path | Current working directory |
-| `git_status` | true | Git status | Modified files count, stash status |
-| `git_branch` | true | Current branch | Branch name and divergence from remote |
-| `worktree` | false | Worktree info | Display current worktree (parallel dev) |
-| `effort_thinking` | false | Thinking mode | effort and thinking state |
-| `pr` | false | PR info | GitHub PR number and review status (NEW v2.1.145+) |
+| Segment | Line | Default Active | stdin field |
+|---------|------|---------------|-------------|
+| `model` | L1 | ✅ | `model.display_name` |
+| `effort_thinking` | L1 | ✅ | `effort.level` + `thinking.enabled` |
+| `claude_version` | L1 | ✅ | `version` |
+| `moai_version` | L1 | ✅ | (local config) |
+| `session_time` | L1 | ✅ | `cost.total_duration_ms` |
+| `output_style` | L1 | ✅ | `output_style.name` |
+| `context` | L2 | ✅ | `context_window.*` |
+| `usage_5h` | L2 | ✅ | `rate_limits.five_hour.*` |
+| `usage_7d` | L2 | ✅ | `rate_limits.seven_day.*` |
+| `directory` | L3 | ✅ | `workspace.project_dir` |
+| `git_branch` (combined) | L3 | ✅ | `workspace.repo.*` + local git |
+| `git_status` | L3 | ✅ | local git |
+| `task` | L3 | ⚠️ opt-in | `~/.moai/state/last-session-state.json` |
+| `pr` | L3 | ✅ (v2.20.0-rc1+) | `pr.*` (Claude Code v2.1.146+) |
+| `worktree` | L3 | ❌ opt-in | `workspace.git_worktree` |
 
-## Available Segments
+## Handoff Guide — (⚠️/clear) Threshold
 
-### Always-Active Segments (4)
+The CW bar's `(⚠️/clear)` suffix activates when context usage crosses model-specific thresholds. It is a visual marker that helps prevent SSE stall risk and prompts the user to leverage a paste-ready resume message.
 
-**model** — Claude model
-- Display current model (Claude 3.5 Sonnet, Claude 3.7 Opus, etc.)
-- Example: `Claude 3.5 Sonnet`
+| Model Class | Context Window | Threshold | When Recommended |
+|-------------|----------------|-----------|------------------|
+| **1M context** (Opus 4.7) | 1,000,000 tokens | **≥50%** | ~500K tokens used |
+| **200K context** (Sonnet, Haiku) | 200,000 tokens | **≥90%** | ~180K tokens used |
+| Other / unknown | — | not shown | (safety default) |
 
-**context** — Context usage
-- Display current session token usage
-- Format: `150K/200K` (used / total)
-- Warning color when usage exceeds 75%
+> Thresholds are enforced by `internal/statusline/renderer.go shouldShowHandoffGuide()`. These match the HARD rule in `.claude/rules/moai/workflow/context-window-management.md`.
 
-**directory** — Working directory
-- Display relative path of current working directory
-- Shows location relative to project root
+User flow when activated:
+1. `(⚠️/clear)` marker appears
+2. Save in-flight work to `progress.md` or equivalent
+3. Orchestrator generates paste-ready resume message (session-handoff.md 6-block format)
+4. Run `/clear`, then paste the resume message
+5. Continue work in the fresh session
 
-**git_status** — Git status
-- Modified files count: `M5` (5 files modified)
-- Stash status: `S2` (2 stashes)
-- Example: `M5 S2`
+## stdin JSON Schema Reference
 
-**git_branch** — Current branch
-- Branch name
-- Commit difference from remote
-- Example: `feat/SPEC-001 +3 -1`
-
-### Optional Segments (7)
-
-**worktree** — Worktree information (optional)
-- Display when using L2 worktree
-- Show current SPEC name
-- Enable: `segments.worktree: true`
-
-**effort_thinking** — Effort/thinking state (optional)
-- Claude 4.7 thinking mode status
-- effort level (high/xhigh/max)
-- Enable: `segments.effort_thinking: true`
-
-**output_style** — Output style (optional)
-- Current output style setting
-- Enable: `segments.output_style: true`
-
-**claude_version** — Claude version (optional)
-- Claude Code version
-- Enable: `segments.claude_version: true`
-
-**moai_version** — moai version (optional)
-- MoAI-ADK version
-- Enable: `segments.moai_version: true`
-
-**session_time** — Session elapsed time (optional)
-- Time elapsed since current session start
-- Enable: `segments.session_time: true`
-
-**usage_5h** — 5-hour cumulative cost (optional)
-- Cost tracking for the past 5 hours
-- Useful in GLM environments
-- Enable: `segments.usage_5h: true`
-
-**usage_7d** — 7-day cumulative cost (optional)
-- Cost tracking for the past 7 days
-- Enable: `segments.usage_7d: true`
-
-**task** — Active SPEC workflow info (optional)
-- Output format: `📋 [<command> <SPEC-ID>-<stage>]` (e.g. `📋 [/moai run SPEC-V3R5-DOCS-SECURITY-001-M3]`)
-- Data source: `~/.moai/state/last-session-state.json` `active_task` field (auto-set by the SessionStart hook)
-- Inactive task renders nothing (segment hidden — graceful no-output)
-- Enable: `segments.task: true` (default `true` as of v2.20.0-rc1, opt-out via `false`)
-
-**repo** — Repository information (optional, v2.1.145+)
-- Display current GitHub repository owner/name
-- Example: `modu-ai/moai-adk`
-- Enable: `segments.repo: true`
-
-**long_context** — Long context warning (optional, v2.1.139+)
-- Display warning marker when 200K tokens exceeded
-- Example: `⚠️ 200K+ exceeded`
-- Enable: `segments.long_context: true`
-
-**handoff_guide** — Handoff threshold guide (optional, v2.1.146+)
-- Display current model's context window size and recommended handoff threshold
-- 1M model: 50% threshold (≈500K tokens)
-- 200K model: 90% threshold (≈180K tokens)
-- Example: `[1M: 50% | 200K: 90%]`
-- Enable: `segments.handoff_guide: true`
-
-## NEW v2.1.145: PR Segment
-
-### Overview
-
-Starting from Claude Code v2.1.145, the statusline stdin JSON includes GitHub PR information. MoAI-ADK leverages this to display the current PR's review status in the statusline.
-
-**Enable**: Default `true` as of v2.20.0-rc1 (default-on). Set `segments.pr: false` to opt out. Graceful no-output: when no PR info is present, the segment is hidden automatically.
-
-### PR Segment Display Format
-
-The PR segment is displayed in the following format:
-
-```
-#1023 ⌥approved
-```
-
-- `#1023`: PR number
-- `⌥`: PR status indicator symbol
-- `approved`: Review status (color coded)
-
-### Review State Colors
-
-The PR's review status is displayed in different colors:
-
-| State | Color | Meaning |
-|-------|-------|---------|
-| `approved` | Green | PR is approved |
-| `pending` | Yellow | Waiting for review |
-| `changes_requested` | Red | Changes requested |
-| `draft` | Gray | Draft state |
-| (other / empty) | Default | No style applied |
-
-### How to Enable
-
-1. Edit `.moai/config/sections/statusline.yaml`
-
-```yaml
-statusline:
-  segments:
-    pr: true   # Enable PR segment
-```
-
-2. Restart Claude Code session
-
-Now the statusline will display the current PR number and review status.
-
-### JSON Input Schema (v2.1.145+)
-
-Claude Code v2.1.145+ passes the following JSON format to the statusline stdin:
+For the complete list of stdin JSON fields Claude Code passes to the statusline script, see the [official docs Available data](https://code.claude.com/docs/en/statusline#available-data). moai-adk-go consumes the following fields:
 
 ```json
 {
-  "pr": {
-    "number": 1023,
-    "url": "https://github.com/modu-ai/moai-adk/pull/1023",
-    "review_state": "pending"
-  },
+  "session_id": "abc...",
+  "transcript_path": "/path/to/transcript.jsonl",
+  "cwd": "/path/to/cwd",
+  "model": {"id": "claude-opus-4-7", "display_name": "Opus 4.7"},
   "workspace": {
-    "repo": {
-      "host": "github.com",
-      "owner": "modu-ai",
-      "name": "moai-adk"
+    "current_dir": "...",
+    "project_dir": "...",
+    "git_worktree": "feature-xyz",
+    "repo": {"host": "github.com", "owner": "modu-ai", "name": "moai-adk"}
+  },
+  "version": "2.1.146",
+  "output_style": {"name": "MoAI"},
+  "cost": {
+    "total_cost_usd": 1.234,
+    "total_duration_ms": 17520000,
+    "total_lines_added": 156,
+    "total_lines_removed": 23
+  },
+  "context_window": {
+    "used_percentage": 62,
+    "context_window_size": 1000000,
+    "total_input_tokens": 620000,
+    "total_output_tokens": 0,
+    "current_usage": {
+      "input_tokens": 8500,
+      "output_tokens": 1200,
+      "cache_creation_input_tokens": 5000,
+      "cache_read_input_tokens": 605300
     }
+  },
+  "exceeds_200k_tokens": true,
+  "effort": {"level": "xhigh"},
+  "thinking": {"enabled": true},
+  "rate_limits": {
+    "five_hour": {"used_percentage": 56, "resets_at": 1779286800},
+    "seven_day": {"used_percentage": 13, "resets_at": 1779832400}
+  },
+  "pr": {
+    "number": 1234,
+    "url": "https://github.com/modu-ai/moai-adk/pull/1234",
+    "review_state": "approved"
   }
 }
 ```
 
-- **pr.number**: PR number (required)
-- **pr.url**: PR URL (optional)
-- **pr.review_state**: Review state (optional, default: empty)
-- **workspace.repo.host**: Git host (github.com)
-- **workspace.repo.owner**: Repository owner
-- **workspace.repo.name**: Repository name
+## Version History
 
-### Related Information
+- **v2.20.0-rc1 layout v3** (2026-05-22): 3-line layout redesign — combined repo+branch segment, directory on L3 head, `🪫 CW:` emoji moved to front, `(⚠️/clear)` handoff suffix, unified `💾` git status, `💌 PR #N (⌥state)` format
+- **v2.20.0-rc1 STATUSLINE-STDINFIELDS-001** (2026-05-21): added `workspace.repo` + `exceeds_200k_tokens` + `pr` stdin field mappings, tightened 1M context handoff threshold 75% → 50%
+- **v2.20.0-rc1 STATUSLINE-V2145-001** (2026-05-20): PR segment added (v2.1.145+ stdin), 4-locale docs sync
+- **v2.1.139** (Claude Code): `effort.level` + `thinking.enabled` added to stdin JSON
+- **v2.1.146** (Claude Code): `workspace.repo` + `pr` added to stdin JSON
 
-- **SPEC Reference**: [SPEC-V3R5-STATUSLINE-V2145-001](/en/advanced/statusline#reference)
-- **Minimum Version**: Claude Code v2.1.145 or later required
-- **Optional Feature**: Default is `false`, must be explicitly enabled
-- **Backward Compatibility**: Earlier versions of Claude Code do not provide PR information (segment will not display)
+## Troubleshooting
 
-## Troubleshooting: Statusline Disappearing
+### PR not showing in statusline
 
-### Symptoms
+- Verify Claude Code version: needs `🔅 v2.1.146` or higher (v2.1.145 does not include `pr` in stdin)
+- Verify current branch has an open PR: `gh pr view`
+- Check `statusline.yaml` for explicit `pr: false`
 
-- Statusline intermittently does not display
-- Statusline area is blank in Claude Code UI
-- `.moai/cache/statusline_debug.log` file keeps growing
+### (⚠️/clear) not appearing
 
-### Root Cause Analysis (Before v2.1.145 M1 fix)
+- 1M context model: used_percentage below 50% → expected (threshold not yet reached)
+- 200K context model: used_percentage below 90% → expected
+- Above threshold but no marker: verify `MemoryData.ContextWindowSize` mapping in `shouldShowHandoffGuide` (possible boundary defect)
 
-The statusline renderer must comply with Claude Code's **300ms debounce contract**. Violations cause in-flight executions to be cancelled.
+### No colors displayed
 
-Issues in previous code:
+- Verify terminal supports ANSI 256-color
+- Confirm `theme: catppuccin-mocha` is appropriate for your environment
+- Check whether `NO_COLOR=1` env var is set
 
-```bash
-# Problem: DEBUG_STATUSLINE defaults to 1 (always enabled)
-DEBUG_STATUSLINE=${DEBUG_STATUSLINE:-1}
-
-# This caused every render to:
-# 1. Fork python3 -m json.tool process (50-250ms)
-# 2. Write to ~/.moai/cache/statusline_debug.log (~10ms)
-# Total: 60-260ms → exceeds 300ms debounce boundary
-# → Claude Code cancels in-flight statusline rendering
-# → Result: statusline does not display
-```
-
-### Solution (Fixed in v2.1.145 M1)
-
-From v3.5.0 onwards, `DEBUG_STATUSLINE` defaults to **0**:
+### Verification Command
 
 ```bash
-# Fixed: default 0 (disabled)
-DEBUG_STATUSLINE=${DEBUG_STATUSLINE:-0}
-
-# Only enable explicitly when debugging:
-export DEBUG_STATUSLINE=1
+# Verify actual statusline output with stdin fixture
+NOW=$(date +%s)
+echo '{"session_id":"test","model":{"display_name":"Opus 4.7"},"workspace":{"repo":{"host":"github.com","owner":"modu-ai","name":"moai-adk"}},"version":"2.1.146","output_style":{"name":"MoAI"},"context_window":{"used_percentage":62,"context_window_size":1000000},"exceeds_200k_tokens":true,"effort":{"level":"xhigh"},"thinking":{"enabled":true},"rate_limits":{"five_hour":{"used_percentage":56,"resets_at":'$((NOW + 2820))'},"seven_day":{"used_percentage":13,"resets_at":'$((NOW + 518400))'}},"cost":{"total_duration_ms":17520000},"pr":{"number":1234,"url":"https://github.com/modu-ai/moai-adk/pull/1234","review_state":"approved"}}' | moai statusline
 ```
 
-### Padding Adjustment
+## Related Documentation
 
-Previously, `echo ""` was used to adjust spacing around the statusline. This is no longer recommended.
-
-**Instead**, configure it in `.claude/settings.json`:
-
-```json
-{
-  "statusLine": {
-    "padding": 1
-  }
-}
-```
-
-- `padding: 0`: No padding
-- `padding: 1`: 1 line padding above and below (default)
-- `padding: 2`: 2 lines padding above and below
-
-### Troubleshooting Checklist
-
-Steps to resolve statusline display issues:
-
-1. ✓ Check `DEBUG_STATUSLINE` environment variable
-   ```bash
-   echo $DEBUG_STATUSLINE  # Should be unset or 0 by default
-   ```
-
-2. ✓ Verify `.moai/status_line.sh` file
-   ```bash
-   grep "DEBUG_STATUSLINE=" ~/.moai/status_line.sh
-   # Should show: DEBUG_STATUSLINE=${DEBUG_STATUSLINE:-0}
-   ```
-
-3. ✓ Enable debugging explicitly (only if needed)
-   ```bash
-   export DEBUG_STATUSLINE=1
-   # Debug information will now be recorded
-   ```
-
-4. ✓ Configure padding
-   ```json
-   {
-     "statusLine": {
-       "padding": 1
-     }
-   }
-   ```
-
-5. ✓ Restart Claude Code session
-
-## Reference
-
-### Official Documentation
-
-- [Claude Code Statusline Official Documentation](https://code.claude.com/docs/en/statusline) — Claude Code's statusline contract and JSON schema
-
-### moai-adk-go Internals
-
-- **Package**: `internal/statusline/`
-  - `types.go`: StdinData, PRInfo, RepoInfo struct definitions
-  - `builder.go`: Segment creation logic
-  - `renderer.go`: Color coding and final rendering
-
-- **Template**: `.moai/status_line.sh.tmpl`
-  - Renderer invocation and execution logic
-
-- **Configuration**: `.moai/config/sections/statusline.yaml`
-  - Segment enable/disable settings
-
-### Related SPEC
-
-- **[SPEC-V3R5-STATUSLINE-V2145-001](https://github.com/modu-ai/moai-adk/blob/main/.moai/specs/SPEC-V3R5-STATUSLINE-V2145-001/spec.md)**
-  - M1: Fix statusline disappearing issue
-  - M2: Add v2.1.145 PR segment
-  - M3: Documentation (this page)
+- [Settings JSON](/advanced/settings-json) — Claude Code `statusLine` field configuration
+- [Context Window Management](/advanced/context-window-management) — handoff threshold policy (1M = 50%, 200K = 90%)
+- [Session Handoff](/advanced/session-handoff) — paste-ready resume message 6-block format
+- [PR Workflow](/git/pr-workflow) — MoAI PR-centric workflow

--- a/docs-site/content/ja/advanced/statusline.md
+++ b/docs-site/content/ja/advanced/statusline.md
@@ -1,353 +1,368 @@
 ---
-title: ステータスラインシステムとPRセグメント
+title: Statusline システム — 3-line レイアウト完全ガイド
 weight: 78
 draft: false
 ---
 
-Claude Code と moai-adk-go を統合するための**カスタムステータスラインシステム**です。v2.1.145 以降では、GitHub PR 情報をステータスラインに表示できます。
+Claude Code と moai-adk-go の統合のための **カスタム statusline システム** です。Claude Code v2.1.139 から effort/thinking、v2.1.145 から workspace.repo + pr フィールドが stdin JSON に追加され、豊富なセッションコンテキストを表示できるようになりました。
 
-> MoAI ワークフローは PR 中心です。すべての SPEC は plan-PR → run-PR → sync-PR を生成するため、ステータスラインに現在の PR 状態を表示することで、開発効率が向上します。
+> MoAI ワークフローは PR 中心です。すべての SPEC は plan-PR → run-PR → sync-PR サイクルを生成するため、現在の PR 番号、レビュー状態、コンテキスト使用率、ハンドオフ推奨を statusline に即座に表示すると開発効率が大幅に向上します。
 
 ## 概要
 
-### カスタムステータスラインが必要な理由
+### 最終レイアウト (3-line v3)
 
-Claude Code のデフォルトステータスラインは、一般的な使用パターンに最適化されています。しかし MoAI-ADK ユーザーは以下のような特殊な情報が必要です：
+```
+🤖 Opus 4.7 │ 🧠 xhigh·t │ 🔅 v2.1.146 │ 🗿 v2.20.0-rc1 │ ⏳ 4h 52m │ 💬 MoAI
+🪫 CW: ███████░░░ 72% (⚠️/clear) │ 🔋 5H: █████░░░░░ 56% (46m) │ 🔋 7D: █░░░░░░░░░ 13% (May 28)
+📁 moai-adk-go │ 🔀 modu-ai/moai-adk (🅱️ main ↑5 +2) │ 💾 +0 M1 ?1 │ 💌 PR #1234 (⌥approved)
+```
 
-- **PR 中心ワークフロー**：現在の PR 番号とレビュー状態（approved/pending/changes_requested）
-- **マルチペイン開発**：ワークツリーベースの並列開発時に現在の SPEC ステータスを表示
-- **コスト追跡**：GLM 環境使用時のリアルタイムコスト監視
-- **コンテキスト管理**：現在のセッションのトークン使用率と累積コスト
+- **Line 1 (Info)**: モデル · effort/thinking · Claude Code バージョン · MoAI バージョン · セッション時間 · output style
+- **Line 2 (Usage bars)**: CW (context window) · 5H (rolling) · 7D (rolling) — 各 bar に絵文字 + label + bar + % + reset 情報
+- **Line 3 (Git/PR)**: ディレクトリ · リポジトリ+ブランチ統合 · git status · アクティブ SPEC task · PR 情報
 
-カスタムステータスラインは `.moai/status_line.sh` レンダラーを通じてこれらの情報を表示します。
-
-### ステータスラインアーキテクチャ
+### データフロー
 
 ```
 Claude Code stdin (JSON)
     ↓
 internal/statusline/types.go (StdinData パース)
     ↓
-internal/statusline/builder.go (セグメント構成)
+internal/statusline/builder.go (CollectMemory, CollectMetrics, etc.)
     ↓
-internal/statusline/renderer.go (色分けとレンダリング)
+internal/statusline/renderer.go (3-line v3 レイアウト)
     ↓
-.moai/status_line.sh (テンプレートベースの最終レンダリング)
+.moai/status_line.sh → ターミナル表示
 ```
+
+## Line 1 — Info (7 セグメント)
+
+### 🤖 Model
+
+- **フォーマット**: `🤖 <model display name>`
+- **データソース**: stdin `model.display_name` (または string shorthand)
+- **例**: `🤖 Opus 4.7`, `🤖 Sonnet 4.6`, `🤖 Haiku 4.5`
+- **非表示条件**: `model` フィールド不在または `data.Metrics.Model == ""`
+- **セグメントキー**: `model`
+
+### 🧠 Effort / Thinking
+
+- **フォーマット**: `🧠 <level>[·t]`
+- **データソース**: stdin `effort.level` + `thinking.enabled` (Claude Code v2.1.139+)
+- **Level 値**: `low` / `medium` / `high` / `xhigh` / `max`
+- **`·t` サフィックス**: `thinking.enabled == true` 時に追加 (extended reasoning 有効)
+- **例**:
+  - `🧠 xhigh·t` (xhigh effort + thinking 有効)
+  - `🧠 high` (high effort, thinking なし)
+  - `·t` (effort 不在 + thinking のみ有効)
+- **非表示条件**: `effort` + `thinking` の両方が不在 (effort.level 空文字列含む)
+- **セグメントキー**: `effort_thinking`
+
+### 🔅 Claude Code バージョン
+
+- **フォーマット**: `🔅 v<version>` (default) または `🔅 cc v<version>` (full mode)
+- **データソース**: stdin `version` 文字列
+- **例**: `🔅 v2.1.146`
+- **非表示条件**: `version` 空文字列
+- **セグメントキー**: `claude_version`
+
+### 🗿 MoAI バージョン
+
+- **フォーマット**: `🗿 v<current>` または更新可能時 `🗿 v<current> -> 🗿 v<latest>`
+- **データソース**: `.moai/config/sections/system.yaml` `moai.version` + バックグラウンド更新チェッカー
+- **例**:
+  - `🗿 v2.20.0-rc1` (最新)
+  - `🗿 v2.18.0 -> 🗿 v2.20.0-rc1` (更新推奨)
+- **セグメントキー**: `moai_version`
+
+### ⏳ セッション時間
+
+- **フォーマット**: `⏳ <X>h <Y>m` (≥1h) / `⏳ <X>m` (<1h) / `⏳ <X>d <Y>h` (≥24h)
+- **データソース**: stdin `cost.total_duration_ms`
+- **例**: `⏳ 4h 52m`, `⏳ 35m`, `⏳ 1d 3h`
+- **セグメントキー**: `session_time`
+
+### 💬 Output Style
+
+- **フォーマット**: `💬 <style name>`
+- **データソース**: stdin `output_style.name`
+- **例**: `💬 MoAI`, `💬 R2-D2`, `💬 default`
+- **非表示条件**: `output_style.name` 空文字列
+- **セグメントキー**: `output_style`
+
+## Line 2 — Usage Bars (3 セグメント)
+
+### 🪫/🔋 CW (Context Window)
+
+- **フォーマット**: `<icon> CW: <bar> <pct>% [(⚠️/clear)]`
+- **データソース**:
+  - bar: `context_window.context_window_size` × auto-compact threshold (default 85%) → scaled budget
+  - パーセント: `context_window.used_percentage` (事前計算済み) または `current_usage` tokens 合算
+  - (⚠️/clear) 有効化条件: `shouldShowHandoffGuide(data) == true`
+- **絵文字**:
+  - 🔋 (正常, <50% scaled)
+  - 🪫 (警告, 50-79% scaled)
+  - 🪫 (危険, ≥80% scaled, 色追加)
+- **(⚠️/clear) handoff サフィックス**:
+  - 1M context モデル (Opus 4.7): used_percentage ≥50% (raw context_window_size 基準)
+  - 200K context モデル (Sonnet/Haiku): used_percentage ≥90%
+  - 意味: 次の turn 開始前に `/clear` 推奨 + paste-ready resume message 活用
+- **例**: `🪫 CW: ███████░░░ 72% (⚠️/clear)`
+- **セグメントキー**: `context`
+
+### 🔋 5H (5時間 rolling rate limit)
+
+- **フォーマット**: `🔋 5H: <bar> <pct>% [(<reset>)]`
+- **データソース**: stdin `rate_limits.five_hour.{used_percentage, resets_at}`
+- **Reset フォーマット**:
+  - <60 分: `(Nm)` (例: `(47m)`)
+  - <24 時間: `(Nh Nm)` (例: `(2h 15m)`)
+  - ≥24 時間: `(Mon DD)` (例: `(May 28)`)
+- **例**: `🔋 5H: █████░░░░░ 56% (47m)`
+- **データ不在**: `rate_limits.five_hour == null` → bar 0%, reset `(rolling)`
+- **セグメントキー**: `usage_5h`
+
+### 🔋 7D (7日 rolling rate limit)
+
+- **フォーマット**: `🔋 7D: <bar> <pct>% [(<reset>)]`
+- **データソース**: stdin `rate_limits.seven_day.{used_percentage, resets_at}`
+- **Reset フォーマット**: `(Mon DD)` (絶対日付)
+- **例**: `🔋 7D: █░░░░░░░░░ 13% (May 28)`
+- **セグメントキー**: `usage_7d`
+
+## Line 3 — Git / PR (5 セグメント)
+
+### 📁 Directory
+
+- **フォーマット**: `📁 <directory name>`
+- **データソース**: stdin `workspace.project_dir` (basename) または `cwd`
+- **例**: `📁 moai-adk-go`, `📁 my-project`
+- **非表示条件**: `data.Directory` 空文字列
+- **セグメントキー**: `directory`
+
+### 🔀 Repo + Branch (統合セグメント)
+
+- **フォーマット**: `🔀 <owner>/<name> (🅱️ <branch>[ ↑N][ ↓N][ +N])`
+- **データソース**:
+  - `🔀 owner/name`: stdin `workspace.repo.{host, owner, name}` (Claude Code v2.1.145+)
+  - `🅱️ branch`: ローカル git `branch --show-current`
+  - `↑N`: ahead カウント (origin/<branch> 対比)
+  - `↓N`: behind カウント
+  - `+N`: dirty カウント = Modified + Staged + Untracked
+- **例**:
+  - `🔀 modu-ai/moai-adk (🅱️ main ↑3 +2)` (repo + branch + ahead + dirty)
+  - `🔀 modu-ai/moai-adk (🅱️ main)` (clean branch, no ahead)
+  - `🔀 (🅱️ feat/auth ↑2 ↓1 +6)` (repo 情報不在 fallback)
+- **非表示条件**:
+  - branch 空文字列 → セグメント全体非表示
+  - repo nil 時 fallback (括弧内 branch のみ表示)
+- **Worktree モード**: `worktree` セグメント有効時 branch に `[WT] ` prefix
+- **セグメントキー**: `git_branch` (combined)
+
+### 💾 Git Status
+
+- **フォーマット**: `💾 +<staged> M<modified> ?<untracked>`
+- **データソース**: ローカル git `git status --porcelain` パース
+- **例**: `💾 +0 M1 ?1` (staged 0, modified 1, untracked 1)
+- **非表示条件**: git 不可
+- **注記**: 旧 mailbox 4種 emoji (📬/📫/📪/📭) 廃止、統一された 💾 を使用
+- **セグメントキー**: `git_status`
+
+### 📋 Task (アクティブ SPEC workflow)
+
+- **フォーマット**: `📋 [<command> <SPEC-ID>-<stage>]`
+- **データソース**: `~/.moai/state/last-session-state.json` `active_task` フィールド (そのファイル生成時のみ表示)
+- **例**: `📋 [/moai run SPEC-V3R5-STATUSLINE-001-implement]`
+- **非表示条件**: ファイル不在または `active_task` nil → セグメント非表示
+- **セグメントキー**: `task` (opt-in default off)
+
+### 💌 PR (アクティブ GitHub Pull Request)
+
+- **フォーマット**: `💌 PR #<number> (⌥<review_state>)` (state あり) / `💌 PR #<number>` (state 空文字列)
+- **データソース**: stdin `pr.{number, url, review_state}` (Claude Code v2.1.146+)
+- **Review state 値**: `approved` / `pending` / `changes_requested` / `draft` / その他 (raw passthrough)
+- **カラーコーディング** (review_state 部分):
+  - `approved`: 緑 (Success)
+  - `pending`: 黄 (Warning)
+  - `changes_requested`: 赤 (Error)
+  - `draft`: 灰 (Muted)
+  - その他: 色なし (raw passthrough)
+- **例**:
+  - `💌 PR #1234 (⌥approved)` (緑)
+  - `💌 PR #1023 (⌥pending)` (黄)
+  - `💌 PR #7 (⌥changes_requested)` (赤)
+  - `💌 PR #99 (⌥draft)` (灰)
+  - `💌 PR #100` (state なし)
+- **非表示条件**:
+  - `pr` フィールド不在 (PR なしまたは v2.1.145 以下)
+  - `pr.number == 0`
+  - `SegmentPR` config 明示的 false
+- **セグメントキー**: `pr` (default on per v2.20.0-rc1)
 
 ## 設定
 
 ### 基本構造
 
-`.moai/config/sections/statusline.yaml` でステータスラインを設定します：
+`.moai/config/sections/statusline.yaml` でセグメント有効化を管理:
 
 ```yaml
 statusline:
-  mode: default              # default | compact | verbose
-  theme: catppuccin-mocha    # 色のテーマを選択
-  preset: full               # full | minimal | custom
+  mode: default              # default | full
+  theme: catppuccin-mocha    # 色テーマ
+  preset: custom             # full | minimal | custom
   segments:
-    model: true              # Claude モデルを表示
-    context: true            # コンテキスト使用率を表示
-    directory: true          # 作業ディレクトリを表示
-    git_status: true         # Git ステータスを表示
-    git_branch: true         # Git ブランチを表示
-    worktree: false          # ワークツリー情報を表示（オプション）
-    effort_thinking: false   # Effort/thinking ステータス（オプション）
-    pr: false                # PR 情報を表示（オプション、v2.1.145+）
+    # Line 1
+    model: true
+    effort_thinking: true
+    claude_version: true
+    moai_version: true
+    session_time: true
+    output_style: true
+
+    # Line 2
+    context: true
+    usage_5h: true
+    usage_7d: true
+
+    # Line 3
+    directory: true
+    git_branch: true       # combined repo+branch
+    git_status: true
+    task: true             # opt-in default off in older versions
+    pr: true               # default on per v2.20.0-rc1
+    worktree: false
 ```
 
-### セグメントオプション
+### セグメント有効化マトリックス
 
-| セグメント | デフォルト | 用途 | 説明 |
-|-----------|-----------|------|------|
-| `model` | true | 現在のモデル | Claude モデルバージョンを表示 |
-| `context` | true | コンテキスト使用率 | 現在のセッションのトークン使用率 |
-| `directory` | true | 作業パス | 現在の作業ディレクトリ |
-| `git_status` | true | Git ステータス | 変更されたファイル数、stash ステータス |
-| `git_branch` | true | 現在のブランチ | ブランチ名とリモートとの差分 |
-| `worktree` | false | ワークツリー情報 | 現在のワークツリーを表示（並列開発） |
-| `effort_thinking` | false | 思考モード | effort および thinking ステータス |
-| `pr` | false | PR 情報 | GitHub PR 番号とレビュー状態（NEW v2.1.145+） |
+| セグメント | ライン | 既定有効 | stdin field |
+|---------|------|----------|-------------|
+| `model` | L1 | ✅ | `model.display_name` |
+| `effort_thinking` | L1 | ✅ | `effort.level` + `thinking.enabled` |
+| `claude_version` | L1 | ✅ | `version` |
+| `moai_version` | L1 | ✅ | (ローカル config) |
+| `session_time` | L1 | ✅ | `cost.total_duration_ms` |
+| `output_style` | L1 | ✅ | `output_style.name` |
+| `context` | L2 | ✅ | `context_window.*` |
+| `usage_5h` | L2 | ✅ | `rate_limits.five_hour.*` |
+| `usage_7d` | L2 | ✅ | `rate_limits.seven_day.*` |
+| `directory` | L3 | ✅ | `workspace.project_dir` |
+| `git_branch` (combined) | L3 | ✅ | `workspace.repo.*` + ローカル git |
+| `git_status` | L3 | ✅ | ローカル git |
+| `task` | L3 | ⚠️ opt-in | `~/.moai/state/last-session-state.json` |
+| `pr` | L3 | ✅ (v2.20.0-rc1+) | `pr.*` (Claude Code v2.1.146+) |
+| `worktree` | L3 | ❌ opt-in | `workspace.git_worktree` |
 
-## 利用可能なセグメント
+## Handoff Guide — (⚠️/clear) 推奨基準
 
-### 常に有効なセグメント（4個）
+CW bar の `(⚠️/clear)` サフィックスはコンテキスト使用量がモデル別閾値を超えると有効化されます。これは SSE stall 危険を事前防止し paste-ready resume message 活用を推奨する視覚マーカーです。
 
-**model** — Claude モデル
-- 現在のモデル（Claude 3.5 Sonnet、Claude 3.7 Opus など）を表示
-- 例：`Claude 3.5 Sonnet`
+| モデルクラス | Context Window | 閾値 | 推奨時点 |
+|------------|----------------|------|----------|
+| **1M context** (Opus 4.7) | 1,000,000 tokens | **≥50%** | ~500K トークン使用 |
+| **200K context** (Sonnet, Haiku) | 200,000 tokens | **≥90%** | ~180K トークン使用 |
+| その他 / 不明 | — | 表示なし | (安全 default) |
 
-**context** — コンテキスト使用率
-- 現在のセッションのトークン使用率を表示
-- 形式：`150K/200K`（使用中 / 全体）
-- 75% 以上の場合、警告色で表示
+> 閾値は `internal/statusline/renderer.go shouldShowHandoffGuide()` 関数で強制されます。この閾値は `.claude/rules/moai/workflow/context-window-management.md` HARD rule と一致します。
 
-**directory** — 作業ディレクトリ
-- 現在の作業ディレクトリの相対パス
-- プロジェクトルートからの位置を表示
+有効化時のユーザーフロー:
+1. `(⚠️/clear)` marker 表示
+2. 進行中の作業を `progress.md` 等に保存
+3. orchestrator が paste-ready resume message を生成 (session-handoff.md 6-block フォーマット)
+4. `/clear` 実行後 resume message ペースト
+5. 新しいセッションで作業継続
 
-**git_status** — Git ステータス
-- 変更されたファイル数：`M5`（5ファイル変更）
-- Stash ステータス：`S2`（2個の stash）
-- 例：`M5 S2`
+## stdin JSON スキーマリファレンス
 
-**git_branch** — 現在のブランチ
-- ブランチ名
-- リモートとのコミット差分表示
-- 例：`feat/SPEC-001 +3 -1`
-
-### オプションセグメント（7個）
-
-**worktree** — ワークツリー情報（オプション）
-- L2 ワークツリー使用時に表示
-- 現在の SPEC 名を表示
-- 有効化：`segments.worktree: true`
-
-**effort_thinking** — Effort/thinking ステータス（オプション）
-- Claude 4.7 の thinking モード有効化状態
-- effort レベル（high/xhigh/max）
-- 有効化：`segments.effort_thinking: true`
-
-**output_style** — 出力スタイル（オプション）
-- 現在の出力スタイル設定
-- 有効化：`segments.output_style: true`
-
-**claude_version** — Claude バージョン（オプション）
-- Claude Code バージョン
-- 有効化：`segments.claude_version: true`
-
-**moai_version** — moai バージョン（オプション）
-- MoAI-ADK バージョン
-- 有効化：`segments.moai_version: true`
-
-**session_time** — セッション経過時間（オプション）
-- 現在のセッション開始からの経過時間
-- 有効化：`segments.session_time: true`
-
-**usage_5h** — 5時間累積コスト（オプション）
-- 過去 5 時間のコスト追跡
-- GLM 環境で有用
-- 有効化：`segments.usage_5h: true`
-
-**usage_7d** — 7日累積コスト（オプション）
-- 過去 7 日のコスト追跡
-- 有効化：`segments.usage_7d: true`
-
-**task** — アクティブな SPEC ワークフロー情報（オプション）
-- 出力形式：`📋 [<command> <SPEC-ID>-<stage>]`（例：`📋 [/moai run SPEC-V3R5-DOCS-SECURITY-001-M3]`）
-- データソース：`~/.moai/state/last-session-state.json` の `active_task` フィールド（SessionStart フックが自動設定）
-- 非アクティブの場合はセグメント自体が非表示（graceful no-output）
-- 有効化：`segments.task: true`（v2.20.0-rc1 以降は既定値 true — default-on、`false` で opt-out）
-
-**repo** — リポジトリ情報（オプション、v2.1.145+）
-- 現在の GitHub リポジトリのオーナー / 名前を表示
-- 例：`modu-ai/moai-adk`
-- 有効化：`segments.repo: true`
-
-**long_context** — 長いコンテキスト警告（オプション、v2.1.139+）
-- 200K トークン超過時に警告マークを表示
-- 例：`⚠️ 200K+ exceeded`
-- 有効化：`segments.long_context: true`
-
-**handoff_guide** — ハンドオフ閾値ガイド（オプション、v2.1.146+）
-- 現在のモデルのコンテキストウィンドウサイズと推奨ハンドオフ閾値を表示
-- 1M モデル：50% 閾値（≈500K トークン）
-- 200K モデル：90% 閾値（≈180K トークン）
-- 例：`[1M: 50% | 200K: 90%]`
-- 有効化：`segments.handoff_guide: true`
-
-## NEW v2.1.145: PR セグメント
-
-### 概要
-
-Claude Code v2.1.145 以降、ステータスラインの stdin JSON に GitHub PR 情報が含まれます。MoAI-ADK はこれを活用して、ステータスラインに現在の PR のレビュー状態を表示します。
-
-**有効化**：v2.20.0-rc1 以降は既定値 `true`（default-on）。`segments.pr: false` で明示的に無効化可能。graceful no-output パターン：PR 情報が無い場合は segment 自体が非表示。
-
-### PR セグメント表示形式
-
-PR セグメントは以下の形式で表示されます：
-
-```
-#1023 ⌥approved
-```
-
-- `#1023`：PR 番号
-- `⌥`：PR ステータス表示シンボル
-- `approved`：レビュー状態（色分け）
-
-### レビュー状態別の色
-
-PR のレビュー状態に応じて異なる色で表示されます：
-
-| 状態 | 色 | 意味 |
-|------|-----|------|
-| `approved` | 緑 | PR が承認されている |
-| `pending` | 黄 | レビュー待ち中 |
-| `changes_requested` | 赤 | 変更リクエストされた |
-| `draft` | グレー | ドラフト状態 |
-| （その他 / 空） | デフォルト | スタイル未適用 |
-
-### 有効化方法
-
-1. `.moai/config/sections/statusline.yaml` ファイルを編集
-
-```yaml
-statusline:
-  segments:
-    pr: true   # PR セグメントを有効化
-```
-
-2. Claude Code セッションを再起動
-
-これでステータスラインに現在の PR 番号とレビュー状態が表示されます。
-
-### JSON 入力スキーマ（v2.1.145+）
-
-Claude Code v2.1.145+ は以下の形式の JSON をステータスラインの stdin に渡します：
+Claude Code が statusline スクリプトに渡す stdin JSON 全フィールド一覧は [公式 docs Available data](https://code.claude.com/docs/en/statusline#available-data) を参照。moai-adk-go は次のフィールドを使用:
 
 ```json
 {
-  "pr": {
-    "number": 1023,
-    "url": "https://github.com/modu-ai/moai-adk/pull/1023",
-    "review_state": "pending"
-  },
+  "session_id": "abc...",
+  "transcript_path": "/path/to/transcript.jsonl",
+  "cwd": "/path/to/cwd",
+  "model": {"id": "claude-opus-4-7", "display_name": "Opus 4.7"},
   "workspace": {
-    "repo": {
-      "host": "github.com",
-      "owner": "modu-ai",
-      "name": "moai-adk"
+    "current_dir": "...",
+    "project_dir": "...",
+    "git_worktree": "feature-xyz",
+    "repo": {"host": "github.com", "owner": "modu-ai", "name": "moai-adk"}
+  },
+  "version": "2.1.146",
+  "output_style": {"name": "MoAI"},
+  "cost": {
+    "total_cost_usd": 1.234,
+    "total_duration_ms": 17520000,
+    "total_lines_added": 156,
+    "total_lines_removed": 23
+  },
+  "context_window": {
+    "used_percentage": 62,
+    "context_window_size": 1000000,
+    "total_input_tokens": 620000,
+    "total_output_tokens": 0,
+    "current_usage": {
+      "input_tokens": 8500,
+      "output_tokens": 1200,
+      "cache_creation_input_tokens": 5000,
+      "cache_read_input_tokens": 605300
     }
+  },
+  "exceeds_200k_tokens": true,
+  "effort": {"level": "xhigh"},
+  "thinking": {"enabled": true},
+  "rate_limits": {
+    "five_hour": {"used_percentage": 56, "resets_at": 1779286800},
+    "seven_day": {"used_percentage": 13, "resets_at": 1779832400}
+  },
+  "pr": {
+    "number": 1234,
+    "url": "https://github.com/modu-ai/moai-adk/pull/1234",
+    "review_state": "approved"
   }
 }
 ```
 
-- **pr.number**：PR 番号（必須）
-- **pr.url**：PR URL（オプション）
-- **pr.review_state**：レビュー状態（オプション、デフォルト：空）
-- **workspace.repo.host**：Git ホスト（github.com）
-- **workspace.repo.owner**：リポジトリオーナー
-- **workspace.repo.name**：リポジトリ名
+## バージョン履歴
 
-### 関連情報
+- **v2.20.0-rc1 layout v3** (2026-05-22): 3-line layout 再設計 — repo+branch 統合セグメント、directory L3 head、`🪫 CW:` emoji 前方、`(⚠️/clear)` handoff サフィックス、`💾` git status 統一、`💌 PR #N (⌥state)` フォーマット
+- **v2.20.0-rc1 STATUSLINE-STDINFIELDS-001** (2026-05-21): `workspace.repo` + `exceeds_200k_tokens` + `pr` stdin フィールド マッピング追加、1M context handoff threshold 75% → 50%
+- **v2.20.0-rc1 STATUSLINE-V2145-001** (2026-05-20): PR segment 追加 (v2.1.145+ stdin)、4-locale docs 同期
+- **v2.1.139** (Claude Code): `effort.level` + `thinking.enabled` stdin JSON 追加
+- **v2.1.146** (Claude Code): `workspace.repo` + `pr` stdin JSON 追加
 
-- **SPEC リファレンス**：[SPEC-V3R5-STATUSLINE-V2145-001](/ja/advanced/statusline#リファレンス)
-- **最小バージョン**：Claude Code v2.1.145 以上が必要
-- **オプション機能**：デフォルトは `false` なので、明示的に有効化が必要
-- **後方互換性**：以前のバージョンの Claude Code は PR 情報を提供しません（セグメントは表示されません）
+## トラブルシューティング
 
-## トラブルシューティング：ステータスラインが消える問題
+### Statusline に PR が出ない
 
-### 症状
+- Claude Code バージョン確認: `🔅 v2.1.146` 以上が必要 (v2.1.145 は stdin に `pr` フィールド非含有)
+- 現在の branch に OPEN PR があるか確認: `gh pr view`
+- `statusline.yaml` に `pr: false` 明示があるか確認
 
-- ステータスラインが間欠的に表示されない
-- Claude Code UI でステータスラインエリアが空白
-- `.moai/cache/statusline_debug.log` ファイルが増え続ける
+### (⚠️/clear) 表示されない
 
-### 原因分析（v2.1.145 M1 修正前）
+- 1M context モデル: used_percentage 50% 未満 → 正常 (まだ閾値未満)
+- 200K context モデル: used_percentage 90% 未満 → 正常
+- 閾値超過なのに表示なし: `shouldShowHandoffGuide` 関数の `MemoryData.ContextWindowSize` マッピング確認 (boundary defect 可能性)
 
-ステータスラインレンダラーは Claude Code の**300ms デバウンス契約**を遵守する必要があります。これに違反すると、進行中の実行がキャンセルされます。
+### 色が表示されない
 
-以前のコードの問題点：
+- ターミナルが ANSI 256-color 対応か確認
+- `theme: catppuccin-mocha` が環境に適しているか確認
+- `NO_COLOR=1` 環境変数設定有無確認
 
-```bash
-# 問題：DEBUG_STATUSLINE のデフォルトが 1（常に有効）
-DEBUG_STATUSLINE=${DEBUG_STATUSLINE:-1}
-
-# このため、毎回のレンダリングで：
-# 1. python3 -m json.tool プロセスのフォーク（50-250ms）
-# 2. ~/.moai/cache/statusline_debug.log への書き込み（~10ms）
-# 合計：60-260ms → 300ms デバウンス境界線を超える
-# → Claude Code が進行中のステータスラインレンダリングをキャンセル
-# → 結果：ステータスラインが表示されない
-```
-
-### 解決策（v2.1.145 M1 で修正）
-
-v3.5.0 以降では、`DEBUG_STATUSLINE` のデフォルト値が**0**になっています：
+### 検証コマンド
 
 ```bash
-# 修正：デフォルト 0（無効）
-DEBUG_STATUSLINE=${DEBUG_STATUSLINE:-0}
-
-# デバッグが必要な場合は明示的に有効化：
-export DEBUG_STATUSLINE=1
+# stdin fixture で statusline 実出力を確認
+NOW=$(date +%s)
+echo '{"session_id":"test","model":{"display_name":"Opus 4.7"},"workspace":{"repo":{"host":"github.com","owner":"modu-ai","name":"moai-adk"}},"version":"2.1.146","output_style":{"name":"MoAI"},"context_window":{"used_percentage":62,"context_window_size":1000000},"exceeds_200k_tokens":true,"effort":{"level":"xhigh"},"thinking":{"enabled":true},"rate_limits":{"five_hour":{"used_percentage":56,"resets_at":'$((NOW + 2820))'},"seven_day":{"used_percentage":13,"resets_at":'$((NOW + 518400))'}},"cost":{"total_duration_ms":17520000},"pr":{"number":1234,"url":"https://github.com/modu-ai/moai-adk/pull/1234","review_state":"approved"}}' | moai statusline
 ```
 
-### パディング調整
+## 関連ドキュメント
 
-以前は `echo ""` を使用してステータスラインの周囲の余白を調整していました。これはもはや推奨されていません。
-
-**代わりに** `.claude/settings.json` で設定してください：
-
-```json
-{
-  "statusLine": {
-    "padding": 1
-  }
-}
-```
-
-- `padding: 0`：余白なし
-- `padding: 1`：上下 1 行の余白（デフォルト）
-- `padding: 2`：上下 2 行の余白
-
-### チェックリスト
-
-ステータスラインの表示問題を解決する手順：
-
-1. ✓ `DEBUG_STATUSLINE` 環境変数を確認
-   ```bash
-   echo $DEBUG_STATUSLINE  # デフォルトは unset または 0 であるべき
-   ```
-
-2. ✓ `.moai/status_line.sh` ファイルを確認
-   ```bash
-   grep "DEBUG_STATUSLINE=" ~/.moai/status_line.sh
-   # 結果：DEBUG_STATUSLINE=${DEBUG_STATUSLINE:-0} であるべき
-   ```
-
-3. ✓ デバッグを明示的に有効化（必要な場合のみ）
-   ```bash
-   export DEBUG_STATUSLINE=1
-   # デバッグ情報が記録されるようになります
-   ```
-
-4. ✓ パディングを設定
-   ```json
-   {
-     "statusLine": {
-       "padding": 1
-     }
-   }
-   ```
-
-5. ✓ Claude Code セッションを再起動
-
-## リファレンス
-
-### 公式ドキュメント
-
-- [Claude Code ステータスライン公式ドキュメント](https://code.claude.com/docs/en/statusline) — Claude Code のステータスライン契約と JSON スキーマ
-
-### moai-adk-go 内部
-
-- **パッケージ**：`internal/statusline/`
-  - `types.go`：StdinData、PRInfo、RepoInfo 構造体定義
-  - `builder.go`：セグメント作成ロジック
-  - `renderer.go`：色分けと最終レンダリング
-
-- **テンプレート**：`.moai/status_line.sh.tmpl`
-  - レンダラー呼び出しと実行ロジック
-
-- **設定**：`.moai/config/sections/statusline.yaml`
-  - セグメントの有効化 / 無効化設定
-
-### 関連 SPEC
-
-- **[SPEC-V3R5-STATUSLINE-V2145-001](https://github.com/modu-ai/moai-adk/blob/main/.moai/specs/SPEC-V3R5-STATUSLINE-V2145-001/spec.md)**
-  - M1：ステータスラインが消える問題を修正
-  - M2：v2.1.145 PR セグメントを追加
-  - M3：ドキュメント化（このページ）
+- [Settings JSON](/advanced/settings-json) — Claude Code `statusLine` フィールド設定
+- [Context Window Management](/advanced/context-window-management) — handoff threshold ポリシー (1M = 50%, 200K = 90%)
+- [Session Handoff](/advanced/session-handoff) — paste-ready resume message 6-block フォーマット
+- [PR Workflow](/git/pr-workflow) — MoAI PR 中心ワークフロー

--- a/docs-site/content/ko/advanced/statusline.md
+++ b/docs-site/content/ko/advanced/statusline.md
@@ -1,354 +1,368 @@
 ---
-title: Statusline 시스템 및 PR 세그먼트
+title: Statusline 시스템 — 3-line 레이아웃 완전 가이드
 weight: 78
 draft: false
 ---
 
-Claude Code와 moai-adk-go의 통합을 위한 **커스텀 statusline 시스템**입니다. v2.1.145부터 GitHub PR 정보를 statusline에 표시할 수 있습니다.
+Claude Code와 moai-adk-go 통합을 위한 **커스텀 statusline 시스템**입니다. Claude Code v2.1.139부터 effort/thinking, v2.1.145부터 workspace.repo + pr 필드가 stdin JSON에 추가되어 풍부한 컨텍스트를 표시할 수 있습니다.
 
-> MoAI 워크플로우는 PR 중심입니다. 모든 SPEC은 plan-PR → run-PR → sync-PR을 생성하므로, statusline에 현재 PR 상태를 표시하면 개발 효율이 높아집니다.
+> MoAI 워크플로우는 PR 중심입니다. 모든 SPEC은 plan-PR → run-PR → sync-PR 사이클을 생성하므로, statusline에 현재 PR 번호 + 리뷰 상태 + 컨텍스트 사용률 + handoff 권고를 즉시 노출하면 개발 효율이 크게 높아집니다.
 
 ## 개요
 
-### 커스텀 statusline이 필요한 이유
+### 최종 레이아웃 (3-line v3)
 
-Claude Code의 기본 statusline은 일반적인 사용 패턴에 최적화되어 있습니다. 하지만 MoAI-ADK 사용자는 다음과 같은 특화된 정보가 필요합니다:
+```
+🤖 Opus 4.7 │ 🧠 xhigh·t │ 🔅 v2.1.146 │ 🗿 v2.20.0-rc1 │ ⏳ 4h 52m │ 💬 MoAI
+🪫 CW: ███████░░░ 72% (⚠️/clear) │ 🔋 5H: █████░░░░░ 56% (46m) │ 🔋 7D: █░░░░░░░░░ 13% (May 28)
+📁 moai-adk-go │ 🔀 modu-ai/moai-adk (🅱️ main ↑5 +2) │ 💾 +0 M1 ?1 │ 💌 PR #1234 (⌥approved)
+```
 
-- **PR 중심 워크플로우**: 현재 작업 중인 PR 번호와 리뷰 상태 (approved/pending/changes_requested)
-- **멀티팬 개발**: worktree 기반 병렬 개발 시 현재 SPEC 상태
-- **비용 추적**: GLM 환경 사용 시 실시간 비용 모니터링
-- **컨텍스트 관리**: 현재 세션의 token 사용률과 누적 비용
+- **Line 1 (Info)**: 모델 · effort/thinking · Claude Code 버전 · MoAI 버전 · 세션 시간 · output style
+- **Line 2 (Usage bars)**: CW (context window) · 5H (rolling) · 7D (rolling) — 각 bar는 이모지 + label + bar + % + reset 정보
+- **Line 3 (Git/PR)**: 디렉터리 · 리포지토리+브랜치 통합 · git status · 활성 SPEC task · PR 정보
 
-커스텀 statusline은 `.moai/status_line.sh` 렌더러를 통해 이러한 정보를 표시합니다.
-
-### Statusline 아키텍처
+### 데이터 흐름
 
 ```
 Claude Code stdin (JSON)
     ↓
 internal/statusline/types.go (StdinData 파싱)
     ↓
-internal/statusline/builder.go (세그먼트 구성)
+internal/statusline/builder.go (CollectMemory, CollectMetrics, etc.)
     ↓
-internal/statusline/renderer.go (색상 코딩 및 렌더링)
+internal/statusline/renderer.go (3-line v3 layout)
     ↓
-.moai/status_line.sh (템플릿 기반 최종 렌더링)
+.moai/status_line.sh → 터미널 표시
 ```
+
+## Line 1 — Info (7 segments)
+
+### 🤖 Model
+
+- **포맷**: `🤖 <model display name>`
+- **데이터 소스**: stdin `model.display_name` (또는 string shorthand)
+- **예시**: `🤖 Opus 4.7`, `🤖 Sonnet 4.6`, `🤖 Haiku 4.5`
+- **숨김 조건**: `model` field 부재 또는 `data.Metrics.Model == ""`
+- **세그먼트 키**: `model`
+
+### 🧠 Effort / Thinking
+
+- **포맷**: `🧠 <level>[·t]`
+- **데이터 소스**: stdin `effort.level` + `thinking.enabled` (Claude Code v2.1.139+)
+- **Level 값**: `low` / `medium` / `high` / `xhigh` / `max`
+- **`·t` 접미사**: `thinking.enabled == true` 일 때 추가 (extended reasoning 활성)
+- **예시**:
+  - `🧠 xhigh·t` (xhigh effort + thinking 활성)
+  - `🧠 high` (high effort, thinking 없음)
+  - `·t` (effort 부재 + thinking만 활성)
+- **숨김 조건**: `effort` + `thinking` 모두 부재 (effort.level 빈 문자열 포함)
+- **세그먼트 키**: `effort_thinking`
+
+### 🔅 Claude Code 버전
+
+- **포맷**: `🔅 v<version>` (default) 또는 `🔅 cc v<version>` (full mode)
+- **데이터 소스**: stdin `version` 문자열
+- **예시**: `🔅 v2.1.146`
+- **숨김 조건**: `version` 빈 문자열
+- **세그먼트 키**: `claude_version`
+
+### 🗿 MoAI 버전
+
+- **포맷**: `🗿 v<current>` 또는 업데이트 가능 시 `🗿 v<current> -> 🗿 v<latest>`
+- **데이터 소스**: `.moai/config/sections/system.yaml` `moai.version` + 백그라운드 update checker 결과
+- **예시**:
+  - `🗿 v2.20.0-rc1` (최신)
+  - `🗿 v2.18.0 -> 🗿 v2.20.0-rc1` (업데이트 권고)
+- **세그먼트 키**: `moai_version`
+
+### ⏳ 세션 시간
+
+- **포맷**: `⏳ <X>h <Y>m` (≥1h) / `⏳ <X>m` (<1h) / `⏳ <X>d <Y>h` (≥24h)
+- **데이터 소스**: stdin `cost.total_duration_ms`
+- **예시**: `⏳ 4h 52m`, `⏳ 35m`, `⏳ 1d 3h`
+- **세그먼트 키**: `session_time`
+
+### 💬 Output Style
+
+- **포맷**: `💬 <style name>`
+- **데이터 소스**: stdin `output_style.name`
+- **예시**: `💬 MoAI`, `💬 R2-D2`, `💬 default`
+- **숨김 조건**: `output_style.name` 빈 문자열
+- **세그먼트 키**: `output_style`
+
+## Line 2 — Usage Bars (3 segments)
+
+### 🪫/🔋 CW (Context Window)
+
+- **포맷**: `<icon> CW: <bar> <pct>% [(⚠️/clear)]`
+- **데이터 소스**:
+  - bar: `context_window.context_window_size` × auto-compact threshold (default 85%) → scaled budget
+  - 퍼센티지: `context_window.used_percentage` (사전 계산) 또는 `current_usage` tokens 합산
+  - (⚠️/clear) 활성 조건: `shouldShowHandoffGuide(data) == true`
+- **이모지**:
+  - 🔋 (정상, <50% scaled)
+  - 🪫 (경고, 50-79% scaled)
+  - 🪫 (위험, ≥80% scaled, 색상 추가)
+- **(⚠️/clear) handoff suffix**:
+  - 1M context 모델 (Opus 4.7): used_percentage ≥50% (raw context_window_size 기준)
+  - 200K context 모델 (Sonnet/Haiku): used_percentage ≥90%
+  - 의미: 다음 turn 시작 전에 `/clear` 권고 + paste-ready resume message 활용
+- **예시**: `🪫 CW: ███████░░░ 72% (⚠️/clear)`
+- **세그먼트 키**: `context`
+
+### 🔋 5H (5시간 rolling rate limit)
+
+- **포맷**: `🔋 5H: <bar> <pct>% [(<reset>)]`
+- **데이터 소스**: stdin `rate_limits.five_hour.{used_percentage, resets_at}`
+- **Reset 포맷**:
+  - <60분: `(Nm)` (예: `(47m)`)
+  - <24시간: `(Nh Nm)` (예: `(2h 15m)`)
+  - ≥24시간: `(Mon DD)` (예: `(May 28)`)
+- **예시**: `🔋 5H: █████░░░░░ 56% (47m)`
+- **데이터 부재**: `rate_limits.five_hour == null` → bar 0%, reset `(rolling)`
+- **세그먼트 키**: `usage_5h`
+
+### 🔋 7D (7일 rolling rate limit)
+
+- **포맷**: `🔋 7D: <bar> <pct>% [(<reset>)]`
+- **데이터 소스**: stdin `rate_limits.seven_day.{used_percentage, resets_at}`
+- **Reset 포맷**: `(Mon DD)` (절대 날짜)
+- **예시**: `🔋 7D: █░░░░░░░░░ 13% (May 28)`
+- **세그먼트 키**: `usage_7d`
+
+## Line 3 — Git / PR (5 segments)
+
+### 📁 Directory
+
+- **포맷**: `📁 <directory name>`
+- **데이터 소스**: stdin `workspace.project_dir` (basename) 또는 `cwd`
+- **예시**: `📁 moai-adk-go`, `📁 my-project`
+- **숨김 조건**: `data.Directory` 빈 문자열
+- **세그먼트 키**: `directory`
+
+### 🔀 Repo + Branch (통합 세그먼트)
+
+- **포맷**: `🔀 <owner>/<name> (🅱️ <branch>[ ↑N][ ↓N][ +N])`
+- **데이터 소스**:
+  - `🔀 owner/name`: stdin `workspace.repo.{host, owner, name}` (Claude Code v2.1.145+)
+  - `🅱️ branch`: 로컬 git `branch --show-current`
+  - `↑N`: ahead count (origin/<branch> 대비)
+  - `↓N`: behind count
+  - `+N`: dirty count = Modified + Staged + Untracked
+- **예시**:
+  - `🔀 modu-ai/moai-adk (🅱️ main ↑3 +2)` (repo + branch + ahead + dirty)
+  - `🔀 modu-ai/moai-adk (🅱️ main)` (clean branch, no ahead)
+  - `🔀 (🅱️ feat/auth ↑2 ↓1 +6)` (repo 정보 부재 fallback)
+- **숨김 조건**:
+  - branch 빈 문자열 → 전체 segment 숨김
+  - repo nil 시 fallback (괄호 안 branch만 표시)
+- **Worktree 모드**: `worktree` segment 활성 시 branch에 `[WT] ` prefix
+- **세그먼트 키**: `git_branch` (combined)
+
+### 💾 Git Status
+
+- **포맷**: `💾 +<staged> M<modified> ?<untracked>`
+- **데이터 소스**: 로컬 git `git status --porcelain` 파싱
+- **예시**: `💾 +0 M1 ?1` (staged 0, modified 1, untracked 1)
+- **숨김 조건**: git 미가용
+- **참고**: 이전 mailbox 4종 emoji (📬/📫/📪/📭) 폐기, 통일된 💾 사용
+- **세그먼트 키**: `git_status`
+
+### 📋 Task (활성 SPEC workflow)
+
+- **포맷**: `📋 [<command> <SPEC-ID>-<stage>]`
+- **데이터 소스**: `~/.moai/state/last-session-state.json` `active_task` 필드 (해당 파일 작성 시점에만 노출)
+- **예시**: `📋 [/moai run SPEC-V3R5-STATUSLINE-001-implement]`
+- **숨김 조건**: 파일 부재 또는 `active_task` nil → segment 숨김
+- **세그먼트 키**: `task` (opt-in default off)
+
+### 💌 PR (활성 GitHub Pull Request)
+
+- **포맷**: `💌 PR #<number> (⌥<review_state>)` (state 있을 때) / `💌 PR #<number>` (state 빈 문자열)
+- **데이터 소스**: stdin `pr.{number, url, review_state}` (Claude Code v2.1.146+)
+- **Review state 값**: `approved` / `pending` / `changes_requested` / `draft` / 기타 (raw passthrough)
+- **색상 코딩** (review_state portion):
+  - `approved`: 녹색 (Success)
+  - `pending`: 노란색 (Warning)
+  - `changes_requested`: 빨간색 (Error)
+  - `draft`: 회색 (Muted)
+  - 기타: 색상 없음 (raw passthrough)
+- **예시**:
+  - `💌 PR #1234 (⌥approved)` (녹색)
+  - `💌 PR #1023 (⌥pending)` (노란색)
+  - `💌 PR #7 (⌥changes_requested)` (빨간색)
+  - `💌 PR #99 (⌥draft)` (회색)
+  - `💌 PR #100` (state 없음)
+- **숨김 조건**:
+  - `pr` 필드 부재 (PR 없음 또는 v2.1.145 이하)
+  - `pr.number == 0`
+  - `SegmentPR` config 명시적 false
+- **세그먼트 키**: `pr` (default on per v2.20.0-rc1)
 
 ## 설정
 
 ### 기본 구조
 
-`.moai/config/sections/statusline.yaml`에서 statusline을 설정합니다:
+`.moai/config/sections/statusline.yaml`에서 segment 활성화를 관리합니다:
 
 ```yaml
 statusline:
-  mode: default              # default | compact | verbose
-  theme: catppuccin-mocha    # 색상 테마 선택
-  preset: full               # full | minimal | custom
+  mode: default              # default | full
+  theme: catppuccin-mocha    # 색상 테마
+  preset: custom             # full | minimal | custom
   segments:
-    model: true              # Claude 모델 표시
-    context: true            # 컨텍스트 사용률 표시
-    directory: true          # 작업 디렉터리 표시
-    git_status: true         # Git 상태 표시
-    git_branch: true         # Git 브랜치 표시
-    worktree: false          # Worktree 정보 표시 (선택적)
-    effort_thinking: false   # Effort/thinking 상태 (선택적)
-    pr: false                # PR 정보 표시 (선택적, v2.1.145+)
+    # Line 1
+    model: true
+    effort_thinking: true
+    claude_version: true
+    moai_version: true
+    session_time: true
+    output_style: true
+
+    # Line 2
+    context: true
+    usage_5h: true
+    usage_7d: true
+
+    # Line 3
+    directory: true
+    git_branch: true       # combined repo+branch
+    git_status: true
+    task: true             # opt-in default off in older versions
+    pr: true               # default on per v2.20.0-rc1
+    worktree: false
 ```
 
-### 세그먼트 옵션
+### Segment 활성 매트릭스
 
-| 세그먼트 | 기본값 | 용도 | 설명 |
-|---------|--------|------|------|
-| `model` | true | 현재 모델 | Claude 모델 버전 표시 |
-| `context` | true | 컨텍스트 사용률 | 현재 세션의 token 사용률 |
-| `directory` | true | 작업 경로 | 현재 작업 디렉터리 |
-| `git_status` | true | Git 상태 | 수정된 파일 개수, stash 상태 |
-| `git_branch` | true | 현재 브랜치 | 브랜치 이름과 원격과의 차이 |
-| `worktree` | false | Worktree 정보 | 현재 worktree 표시 (병렬 개발) |
-| `effort_thinking` | false | 사고 모드 | effort 및 thinking 상태 |
-| `pr` | false | PR 정보 | GitHub PR 번호와 리뷰 상태 (NEW v2.1.145+) |
+| 세그먼트 | 라인 | 기본 활성 | stdin field |
+|---------|------|----------|-------------|
+| `model` | L1 | ✅ | `model.display_name` |
+| `effort_thinking` | L1 | ✅ | `effort.level` + `thinking.enabled` |
+| `claude_version` | L1 | ✅ | `version` |
+| `moai_version` | L1 | ✅ | (로컬 config) |
+| `session_time` | L1 | ✅ | `cost.total_duration_ms` |
+| `output_style` | L1 | ✅ | `output_style.name` |
+| `context` | L2 | ✅ | `context_window.*` |
+| `usage_5h` | L2 | ✅ | `rate_limits.five_hour.*` |
+| `usage_7d` | L2 | ✅ | `rate_limits.seven_day.*` |
+| `directory` | L3 | ✅ | `workspace.project_dir` |
+| `git_branch` (combined) | L3 | ✅ | `workspace.repo.*` + local git |
+| `git_status` | L3 | ✅ | local git |
+| `task` | L3 | ⚠️ opt-in | `~/.moai/state/last-session-state.json` |
+| `pr` | L3 | ✅ (v2.20.0-rc1+) | `pr.*` (Claude Code v2.1.146+) |
+| `worktree` | L3 | ❌ opt-in | `workspace.git_worktree` |
 
-## 이용 가능한 세그먼트
+## Handoff Guide — (⚠️/clear) 권고 기준
 
-### 항상 활성화되는 세그먼트 (4개)
+CW bar의 `(⚠️/clear)` suffix는 컨텍스트 사용량이 모델별 임계값을 넘으면 활성화됩니다. 이는 SSE stall 위험을 사전에 방지하고 paste-ready resume message 활용을 권장하는 시각적 마커입니다.
 
-**model** — Claude 모델
-- Claude 3.5 Sonnet, Claude 3.7 Opus 등 현재 모델 표시
-- 예: `Claude 3.5 Sonnet`
+| 모델 클래스 | Context Window | 임계값 | 권고 시점 |
+|------------|----------------|--------|----------|
+| **1M context** (Opus 4.7) | 1,000,000 tokens | **≥50%** | ~500K 토큰 사용 |
+| **200K context** (Sonnet, Haiku) | 200,000 tokens | **≥90%** | ~180K 토큰 사용 |
+| 기타 / 알 수 없음 | — | 표시 안 함 | (안전 default) |
 
-**context** — 컨텍스트 사용률
-- 현재 세션의 token 사용률 표시
-- 형식: `150K/200K` (사용 중 / 전체)
-- 75% 이상 시 경고 색상 표시
+> 임계값은 `internal/statusline/renderer.go shouldShowHandoffGuide()` 함수에서 강제됩니다. 이 임계값은 `.claude/rules/moai/workflow/context-window-management.md` HARD rule과 일치합니다.
 
-**directory** — 작업 디렉터리
-- 현재 작업 디렉터리의 상대 경로
-- 프로젝트 루트에서의 위치 표시
+활성화 시 사용자 흐름:
+1. `(⚠️/clear)` marker 노출
+2. 진행 중인 작업을 `progress.md` 등에 저장
+3. orchestrator가 paste-ready resume message 생성 (session-handoff.md 6-block 포맷)
+4. `/clear` 실행 후 resume message 붙여넣기
+5. 새 세션으로 이어 작업
 
-**git_status** — Git 상태
-- 수정된 파일 개수: `M5` (5개 파일 수정)
-- Stash 상태: `S2` (2개 스테시)
-- 예: `M5 S2`
+## stdin JSON 스키마 참조
 
-**git_branch** — 현재 브랜치
-- 브랜치 이름
-- 원격과의 커밋 차이 표시
-- 예: `feat/SPEC-001 +3 -1`
-
-### 선택적 세그먼트 (7개)
-
-**worktree** — Worktree 정보 (선택적)
-- L2 worktree 사용 시 표시
-- 현재 SPEC 이름
-- 활성화: `segments.worktree: true`
-
-**effort_thinking** — Effort/thinking 상태 (선택적)
-- Claude 4.7의 thinking 모드 활성화 상태
-- effort 레벨 (high/xhigh/max)
-- 활성화: `segments.effort_thinking: true`
-
-**output_style** — 출력 스타일 (선택적)
-- 현재 출력 스타일 설정
-- 활성화: `segments.output_style: true`
-
-**claude_version** — Claude 버전 (선택적)
-- Claude Code 버전
-- 활성화: `segments.claude_version: true`
-
-**moai_version** — moai 버전 (선택적)
-- MoAI-ADK 버전
-- 활성화: `segments.moai_version: true`
-
-**session_time** — 세션 경과 시간 (선택적)
-- 현재 세션 시작 후 경과 시간
-- 활성화: `segments.session_time: true`
-
-**usage_5h** — 5시간 누적 비용 (선택적)
-- 지난 5시간의 비용 추적
-- GLM 환경에서 유용
-- 활성화: `segments.usage_5h: true`
-
-**usage_7d** — 7일 누적 비용 (선택적)
-- 지난 7일의 비용 추적
-- 활성화: `segments.usage_7d: true`
-
-**task** — 활성 SPEC 워크플로 정보 (선택적)
-- 출력 형식: `📋 [<command> <SPEC-ID>-<stage>]` (예: `📋 [/moai run SPEC-V3R5-DOCS-SECURITY-001-M3]`)
-- 데이터 소스: `~/.moai/state/last-session-state.json` `active_task` 필드 (SessionStart hook이 자동 set)
-- 비활성 task인 경우 graceful no-output (segment 자체가 표시되지 않음)
-- 활성화: `segments.task: true` (기본값 true — default-on as of v2.20.0-rc1, opt-out via false)
-
-**repo** — 저장소 정보 (선택적, v2.1.145+)
-- 현재 작업 중인 GitHub 저장소 소유자/이름 표시
-- 예: `modu-ai/moai-adk`
-- 활성화: `segments.repo: true`
-
-**long_context** — 긴 컨텍스트 경고 (선택적, v2.1.139+)
-- 200K 토큰 초과 시 경고 마크 표시
-- 예: `⚠️ 200K+ exceeded`
-- 활성화: `segments.long_context: true`
-
-**handoff_guide** — 핸드오프 임계값 안내 (선택적, v2.1.146+)
-- 현재 모델의 컨텍스트 창 크기와 권장 핸드오프 임계값 표시
-- 1M 모델: 50% 임계값 (≈500K 토큰)
-- 200K 모델: 90% 임계값 (≈180K 토큰)
-- 예: `[1M: 50% | 200K: 90%]`
-- 활성화: `segments.handoff_guide: true`
-
-## NEW v2.1.145: PR 세그먼트
-
-### 개요
-
-Claude Code v2.1.145부터 statusline stdin JSON이 GitHub PR 정보를 포함합니다. MoAI-ADK는 이를 활용하여 statusline에 현재 PR의 리뷰 상태를 표시합니다.
-
-**활성화**: 기본값 `true` (v2.20.0-rc1부터 default-on). `segments.pr: false`로 명시 설정 시 비활성화. graceful no-output 패턴 적용으로 PR 정보가 없으면 segment 자체가 표시되지 않습니다.
-
-### PR 세그먼트 표시 형식
-
-PR 세그먼트는 다음 형식으로 표시됩니다:
-
-```
-#1023 ⌥approved
-```
-
-- `#1023`: PR 번호
-- `⌥`: PR 상태 표시 기호
-- `approved`: 리뷰 상태 (색상 코딩)
-
-### 리뷰 상태별 색상
-
-PR의 리뷰 상태에 따라 다른 색상으로 표시됩니다:
-
-| 상태 | 색상 | 의미 |
-|------|------|------|
-| `approved` | 녹색 | PR이 승인됨 |
-| `pending` | 노란색 | 리뷰 대기 중 |
-| `changes_requested` | 빨간색 | 변경 요청됨 |
-| `draft` | 회색 | 드래프트 상태 |
-| (기타/빈 값) | 기본값 | 스타일 미적용 |
-
-### 활성화 방법
-
-1. `.moai/config/sections/statusline.yaml` 파일 편집
-
-```yaml
-statusline:
-  segments:
-    pr: true   # PR 세그먼트 활성화
-```
-
-2. Claude Code 세션 재시작
-
-이제 statusline에 현재 PR의 번호와 리뷰 상태가 표시됩니다.
-
-### JSON 입력 스키마 (v2.1.145+)
-
-Claude Code v2.1.145+는 다음 형식의 JSON을 statusline stdin으로 전달합니다:
+Claude Code가 statusline 스크립트로 전달하는 stdin JSON 전체 필드 목록은 [공식 docs Available data](https://code.claude.com/docs/en/statusline#available-data)를 참조하세요. moai-adk-go는 다음 필드를 활용합니다:
 
 ```json
 {
-  "pr": {
-    "number": 1023,
-    "url": "https://github.com/modu-ai/moai-adk/pull/1023",
-    "review_state": "pending"
-  },
+  "session_id": "abc...",
+  "transcript_path": "/path/to/transcript.jsonl",
+  "cwd": "/path/to/cwd",
+  "model": {"id": "claude-opus-4-7", "display_name": "Opus 4.7"},
   "workspace": {
-    "repo": {
-      "host": "github.com",
-      "owner": "modu-ai",
-      "name": "moai-adk"
+    "current_dir": "...",
+    "project_dir": "...",
+    "git_worktree": "feature-xyz",
+    "repo": {"host": "github.com", "owner": "modu-ai", "name": "moai-adk"}
+  },
+  "version": "2.1.146",
+  "output_style": {"name": "MoAI"},
+  "cost": {
+    "total_cost_usd": 1.234,
+    "total_duration_ms": 17520000,
+    "total_lines_added": 156,
+    "total_lines_removed": 23
+  },
+  "context_window": {
+    "used_percentage": 62,
+    "context_window_size": 1000000,
+    "total_input_tokens": 620000,
+    "total_output_tokens": 0,
+    "current_usage": {
+      "input_tokens": 8500,
+      "output_tokens": 1200,
+      "cache_creation_input_tokens": 5000,
+      "cache_read_input_tokens": 605300
     }
+  },
+  "exceeds_200k_tokens": true,
+  "effort": {"level": "xhigh"},
+  "thinking": {"enabled": true},
+  "rate_limits": {
+    "five_hour": {"used_percentage": 56, "resets_at": 1779286800},
+    "seven_day": {"used_percentage": 13, "resets_at": 1779832400}
+  },
+  "pr": {
+    "number": 1234,
+    "url": "https://github.com/modu-ai/moai-adk/pull/1234",
+    "review_state": "approved"
   }
 }
 ```
 
-- **pr.number**: PR 번호 (필수)
-- **pr.url**: PR URL (선택적)
-- **pr.review_state**: 리뷰 상태 (선택적, 기본값: empty)
-- **workspace.repo.host**: Git 호스트 (github.com)
-- **workspace.repo.owner**: 저장소 소유자
-- **workspace.repo.name**: 저장소 이름
+## 버전 히스토리
 
-### 관련 사항
+- **v2.20.0-rc1 layout v3** (2026-05-22): 3-line layout 재설계 — repo+branch 통합 segment, directory L3 head, `🪫 CW:` emoji 앞으로, `(⚠️/clear)` handoff suffix, `💾` git status 통일, `💌 PR #N (⌥state)` 형식
+- **v2.20.0-rc1 STATUSLINE-STDINFIELDS-001** (2026-05-21): `workspace.repo` + `exceeds_200k_tokens` + `pr` stdin 필드 매핑 추가, 1M context handoff threshold 75% → 50%
+- **v2.20.0-rc1 STATUSLINE-V2145-001** (2026-05-20): PR segment 추가 (v2.1.145+ stdin), 4-locale docs 동기화
+- **v2.1.139** (Claude Code): `effort.level` + `thinking.enabled` stdin JSON 추가
+- **v2.1.146** (Claude Code): `workspace.repo` + `pr` stdin JSON 추가
 
-- **SPEC 참조**: [SPEC-V3R5-STATUSLINE-V2145-001](/ko/advanced/statusline#spec-참조)
-- **최소 버전**: Claude Code v2.1.145 이상 필요
-- **기본 활성화**: v2.20.0-rc1부터 default-on. PR 정보가 없으면 자동 hidden (graceful no-output).
-- **명시적 비활성화**: `segments.pr: false`로 opt-out 가능.
-- **역호환성**: 이전 버전의 Claude Code는 PR 정보를 전달하지 않음 (세그먼트가 표시되지 않음)
+## 트러블슈팅
 
-## 문제 해결: Statusline 사라짐 현상
+### Statusline에 PR이 안 나옴
 
-### 증상
+- Claude Code 버전 확인: `🔅 v2.1.146` 이상 필요 (v2.1.145는 stdin에 `pr` 필드 미포함)
+- 현재 branch에 OPEN PR이 있는지 확인: `gh pr view`
+- `statusline.yaml`에 `pr: false`로 명시되었는지 확인
 
-- Statusline이 간헐적으로 표시되지 않음
-- Claude Code UI에서 statusline 영역이 비어 있음
-- `.moai/cache/statusline_debug.log` 파일이 계속 커짐
+### (⚠️/clear) 표시 안 됨
 
-### 원인 분석 (v2.1.145 M1 수정 이전)
+- 1M context 모델: used_percentage 50% 미만 → 정상 (아직 임계값 미달)
+- 200K context 모델: used_percentage 90% 미만 → 정상
+- 임계값 초과인데 표시 안 됨: `shouldShowHandoffGuide` 함수의 `MemoryData.ContextWindowSize` 매핑 확인 (boundary defect 가능성)
 
-statusline 렌더러는 Claude Code의 **300ms 디바운스 계약**을 준수해야 합니다. 이를 위반하면 진행 중인 실행이 취소됩니다.
+### 색상이 표시 안 됨
 
-이전 코드의 문제점:
+- 터미널이 ANSI 256-color 지원하는지 확인
+- `theme: catppuccin-mocha`가 환경 적합한지 확인
+- `NO_COLOR=1` 환경변수 설정 여부 확인
 
-```bash
-# 문제: DEBUG_STATUSLINE의 기본값이 1 (항상 활성화)
-DEBUG_STATUSLINE=${DEBUG_STATUSLINE:-1}
-
-# 이로 인해 매 렌더링마다:
-# 1. python3 -m json.tool 프로세스 포크 (50-250ms)
-# 2. ~/.moai/cache/statusline_debug.log 쓰기 (~10ms)
-# 총 60-260ms → 300ms 디바운스 경계선 넘음
-# → Claude Code가 진행 중인 statusline 렌더링을 취소
-# → 결과: statusline 표시되지 않음
-```
-
-### 해결책 (v2.1.145 M1에서 수정됨)
-
-v3.5.0부터는 `DEBUG_STATUSLINE`의 기본값이 **0**입니다:
+### 검증 명령
 
 ```bash
-# 수정됨: 기본값 0 (비활성화)
-DEBUG_STATUSLINE=${DEBUG_STATUSLINE:-0}
-
-# 디버깅이 필요할 때만 명시적으로 활성화:
-export DEBUG_STATUSLINE=1
+# stdin fixture로 statusline 실 출력 확인
+NOW=$(date +%s)
+echo '{"session_id":"test","model":{"display_name":"Opus 4.7"},"workspace":{"repo":{"host":"github.com","owner":"modu-ai","name":"moai-adk"}},"version":"2.1.146","output_style":{"name":"MoAI"},"context_window":{"used_percentage":62,"context_window_size":1000000},"exceeds_200k_tokens":true,"effort":{"level":"xhigh"},"thinking":{"enabled":true},"rate_limits":{"five_hour":{"used_percentage":56,"resets_at":'$((NOW + 2820))'},"seven_day":{"used_percentage":13,"resets_at":'$((NOW + 518400))'}},"cost":{"total_duration_ms":17520000},"pr":{"number":1234,"url":"https://github.com/modu-ai/moai-adk/pull/1234","review_state":"approved"}}' | moai statusline
 ```
 
-### Padding 조정
+## 관련 문서
 
-이전에는 `echo ""`를 사용하여 statusline 주변 여백을 조정했습니다. 이는 이제 권장되지 않습니다.
-
-**대신** `.claude/settings.json`에서 설정하세요:
-
-```json
-{
-  "statusLine": {
-    "padding": 1
-  }
-}
-```
-
-- `padding: 0`: 여백 없음
-- `padding: 1`: 위 아래 1줄 여백 (기본값)
-- `padding: 2`: 위 아래 2줄 여백
-
-### 체크리스트
-
-statusline 표시 문제 해결 순서:
-
-1. ✓ `DEBUG_STATUSLINE` 환경 변수 확인
-   ```bash
-   echo $DEBUG_STATUSLINE  # 기본값은 unset 또는 0이어야 함
-   ```
-
-2. ✓ `.moai/status_line.sh` 파일 확인
-   ```bash
-   grep "DEBUG_STATUSLINE=" ~/.moai/status_line.sh
-   # 결과: DEBUG_STATUSLINE=${DEBUG_STATUSLINE:-0} 이어야 함
-   ```
-
-3. ✓ 명시적 디버깅 활성화 (필요한 경우만)
-   ```bash
-   export DEBUG_STATUSLINE=1
-   # 이제 디버그 정보가 기록됨
-   ```
-
-4. ✓ Padding 설정
-   ```json
-   {
-     "statusLine": {
-       "padding": 1
-     }
-   }
-   ```
-
-5. ✓ Claude Code 세션 재시작
-
-## 참고 자료
-
-### 공식 문서
-
-- [Claude Code Statusline 공식 문서](https://code.claude.com/docs/en/statusline) — Claude Code의 statusline 계약 및 JSON 스키마
-
-### moai-adk-go 내부
-
-- **패키지**: `internal/statusline/`
-  - `types.go`: StdinData, PRInfo, RepoInfo 구조체 정의
-  - `builder.go`: 세그먼트 생성 로직
-  - `renderer.go`: 색상 코딩 및 최종 렌더링
-
-- **템플릿**: `.moai/status_line.sh.tmpl`
-  - 렌더러 호출 및 실행 로직
-
-- **설정**: `.moai/config/sections/statusline.yaml`
-  - 세그먼트 활성화/비활성화 설정
-
-### 관련 SPEC
-
-- **[SPEC-V3R5-STATUSLINE-V2145-001](https://github.com/modu-ai/moai-adk/blob/main/.moai/specs/SPEC-V3R5-STATUSLINE-V2145-001/spec.md)**
-  - M1: Statusline 사라짐 현상 수정
-  - M2: v2.1.145 PR 세그먼트 추가
-  - M3: 문서화 (현재 페이지)
+- [Settings JSON](/advanced/settings-json) — Claude Code `statusLine` 필드 설정
+- [Context Window Management](/advanced/context-window-management) — handoff threshold 정책 (1M = 50%, 200K = 90%)
+- [Session Handoff](/advanced/session-handoff) — paste-ready resume message 6-block 포맷
+- [PR Workflow](/git/pr-workflow) — MoAI PR 중심 워크플로우

--- a/docs-site/content/zh/advanced/statusline.md
+++ b/docs-site/content/zh/advanced/statusline.md
@@ -1,353 +1,368 @@
 ---
-title: 状态栏系统与PR段
+title: Statusline 系统 — 3-line 布局完整指南
 weight: 78
 draft: false
 ---
 
-这是用于集成 Claude Code 和 moai-adk-go 的**自定义状态栏系统**。从 v2.1.145 开始，您可以在状态栏中显示 GitHub PR 信息。
+Claude Code 与 moai-adk-go 集成的 **自定义 statusline 系统**。从 Claude Code v2.1.139 开始 effort/thinking,v2.1.145 开始 workspace.repo + pr 字段已添加到 stdin JSON,可以显示丰富的会话上下文。
 
-> MoAI 工作流是以 PR 为中心的。所有 SPEC 都会生成 plan-PR → run-PR → sync-PR，因此在状态栏中显示当前 PR 状态可以提高开发效率。
+> MoAI 工作流是 PR 中心的。每个 SPEC 都会生成 plan-PR → run-PR → sync-PR 周期,因此在 statusline 中即时显示当前 PR 号码、审查状态、上下文使用率和 handoff 建议可显著提高开发效率。
 
 ## 概述
 
-### 为什么需要自定义状态栏
+### 最终布局 (3-line v3)
 
-Claude Code 的默认状态栏针对通用使用模式进行了优化。但是 MoAI-ADK 用户需要以下特殊信息：
+```
+🤖 Opus 4.7 │ 🧠 xhigh·t │ 🔅 v2.1.146 │ 🗿 v2.20.0-rc1 │ ⏳ 4h 52m │ 💬 MoAI
+🪫 CW: ███████░░░ 72% (⚠️/clear) │ 🔋 5H: █████░░░░░ 56% (46m) │ 🔋 7D: █░░░░░░░░░ 13% (May 28)
+📁 moai-adk-go │ 🔀 modu-ai/moai-adk (🅱️ main ↑5 +2) │ 💾 +0 M1 ?1 │ 💌 PR #1234 (⌥approved)
+```
 
-- **PR 中心工作流**：当前 PR 编号和审核状态（approved/pending/changes_requested）
-- **多窗格开发**：使用工作树进行并行开发时显示当前 SPEC 状态
-- **成本跟踪**：使用 GLM 环境时的实时成本监控
-- **上下文管理**：当前会话的令牌使用率和累计成本
+- **Line 1 (Info)**: 模型 · effort/thinking · Claude Code 版本 · MoAI 版本 · 会话时间 · output style
+- **Line 2 (Usage bars)**: CW (context window) · 5H (rolling) · 7D (rolling) — 每个 bar 显示 emoji + label + bar + % + reset 信息
+- **Line 3 (Git/PR)**: 目录 · 仓库+分支组合 · git status · 活动 SPEC task · PR 信息
 
-自定义状态栏通过 `.moai/status_line.sh` 渲染器显示这些信息。
-
-### 状态栏架构
+### 数据流
 
 ```
 Claude Code stdin (JSON)
     ↓
 internal/statusline/types.go (StdinData 解析)
     ↓
-internal/statusline/builder.go (段构建)
+internal/statusline/builder.go (CollectMemory, CollectMetrics, etc.)
     ↓
-internal/statusline/renderer.go (颜色编码和渲染)
+internal/statusline/renderer.go (3-line v3 布局)
     ↓
-.moai/status_line.sh (基于模板的最终渲染)
+.moai/status_line.sh → 终端显示
 ```
+
+## Line 1 — Info (7 个段)
+
+### 🤖 Model
+
+- **格式**: `🤖 <model display name>`
+- **数据源**: stdin `model.display_name` (或 string shorthand)
+- **示例**: `🤖 Opus 4.7`, `🤖 Sonnet 4.6`, `🤖 Haiku 4.5`
+- **隐藏条件**: `model` 字段缺失或 `data.Metrics.Model == ""`
+- **段键**: `model`
+
+### 🧠 Effort / Thinking
+
+- **格式**: `🧠 <level>[·t]`
+- **数据源**: stdin `effort.level` + `thinking.enabled` (Claude Code v2.1.139+)
+- **Level 值**: `low` / `medium` / `high` / `xhigh` / `max`
+- **`·t` 后缀**: `thinking.enabled == true` 时添加 (extended reasoning 启用)
+- **示例**:
+  - `🧠 xhigh·t` (xhigh effort + thinking 启用)
+  - `🧠 high` (high effort,无 thinking)
+  - `·t` (effort 缺失 + 仅 thinking 启用)
+- **隐藏条件**: `effort` + `thinking` 都缺失 (包括 effort.level 空字符串)
+- **段键**: `effort_thinking`
+
+### 🔅 Claude Code 版本
+
+- **格式**: `🔅 v<version>` (default) 或 `🔅 cc v<version>` (full mode)
+- **数据源**: stdin `version` 字符串
+- **示例**: `🔅 v2.1.146`
+- **隐藏条件**: `version` 空字符串
+- **段键**: `claude_version`
+
+### 🗿 MoAI 版本
+
+- **格式**: `🗿 v<current>` 或更新可用时 `🗿 v<current> -> 🗿 v<latest>`
+- **数据源**: `.moai/config/sections/system.yaml` `moai.version` + 后台更新检查器
+- **示例**:
+  - `🗿 v2.20.0-rc1` (最新)
+  - `🗿 v2.18.0 -> 🗿 v2.20.0-rc1` (建议更新)
+- **段键**: `moai_version`
+
+### ⏳ 会话时间
+
+- **格式**: `⏳ <X>h <Y>m` (≥1h) / `⏳ <X>m` (<1h) / `⏳ <X>d <Y>h` (≥24h)
+- **数据源**: stdin `cost.total_duration_ms`
+- **示例**: `⏳ 4h 52m`, `⏳ 35m`, `⏳ 1d 3h`
+- **段键**: `session_time`
+
+### 💬 Output Style
+
+- **格式**: `💬 <style name>`
+- **数据源**: stdin `output_style.name`
+- **示例**: `💬 MoAI`, `💬 R2-D2`, `💬 default`
+- **隐藏条件**: `output_style.name` 空字符串
+- **段键**: `output_style`
+
+## Line 2 — Usage Bars (3 个段)
+
+### 🪫/🔋 CW (Context Window)
+
+- **格式**: `<icon> CW: <bar> <pct>% [(⚠️/clear)]`
+- **数据源**:
+  - bar: `context_window.context_window_size` × auto-compact threshold (default 85%) → scaled budget
+  - 百分比: `context_window.used_percentage` (预计算) 或 `current_usage` tokens 总和
+  - (⚠️/clear) 启用条件: `shouldShowHandoffGuide(data) == true`
+- **emoji**:
+  - 🔋 (正常, <50% scaled)
+  - 🪫 (警告, 50-79% scaled)
+  - 🪫 (危险, ≥80% scaled, 颜色添加)
+- **(⚠️/clear) handoff 后缀**:
+  - 1M context 模型 (Opus 4.7): used_percentage ≥50% (基于 raw context_window_size)
+  - 200K context 模型 (Sonnet/Haiku): used_percentage ≥90%
+  - 含义: 下一 turn 开始前建议 `/clear` + 利用 paste-ready resume message
+- **示例**: `🪫 CW: ███████░░░ 72% (⚠️/clear)`
+- **段键**: `context`
+
+### 🔋 5H (5小时 rolling rate limit)
+
+- **格式**: `🔋 5H: <bar> <pct>% [(<reset>)]`
+- **数据源**: stdin `rate_limits.five_hour.{used_percentage, resets_at}`
+- **Reset 格式**:
+  - <60 分: `(Nm)` (例: `(47m)`)
+  - <24 小时: `(Nh Nm)` (例: `(2h 15m)`)
+  - ≥24 小时: `(Mon DD)` (例: `(May 28)`)
+- **示例**: `🔋 5H: █████░░░░░ 56% (47m)`
+- **数据缺失**: `rate_limits.five_hour == null` → bar 0%, reset `(rolling)`
+- **段键**: `usage_5h`
+
+### 🔋 7D (7天 rolling rate limit)
+
+- **格式**: `🔋 7D: <bar> <pct>% [(<reset>)]`
+- **数据源**: stdin `rate_limits.seven_day.{used_percentage, resets_at}`
+- **Reset 格式**: `(Mon DD)` (绝对日期)
+- **示例**: `🔋 7D: █░░░░░░░░░ 13% (May 28)`
+- **段键**: `usage_7d`
+
+## Line 3 — Git / PR (5 个段)
+
+### 📁 Directory
+
+- **格式**: `📁 <directory name>`
+- **数据源**: stdin `workspace.project_dir` (basename) 或 `cwd`
+- **示例**: `📁 moai-adk-go`, `📁 my-project`
+- **隐藏条件**: `data.Directory` 空字符串
+- **段键**: `directory`
+
+### 🔀 Repo + Branch (组合段)
+
+- **格式**: `🔀 <owner>/<name> (🅱️ <branch>[ ↑N][ ↓N][ +N])`
+- **数据源**:
+  - `🔀 owner/name`: stdin `workspace.repo.{host, owner, name}` (Claude Code v2.1.145+)
+  - `🅱️ branch`: 本地 git `branch --show-current`
+  - `↑N`: ahead 计数 (对比 origin/<branch>)
+  - `↓N`: behind 计数
+  - `+N`: dirty 计数 = Modified + Staged + Untracked
+- **示例**:
+  - `🔀 modu-ai/moai-adk (🅱️ main ↑3 +2)` (repo + branch + ahead + dirty)
+  - `🔀 modu-ai/moai-adk (🅱️ main)` (clean branch, no ahead)
+  - `🔀 (🅱️ feat/auth ↑2 ↓1 +6)` (repo 信息缺失 fallback)
+- **隐藏条件**:
+  - branch 空字符串 → 整段隐藏
+  - repo nil 时 fallback (仅在括号内显示 branch)
+- **Worktree 模式**: `worktree` 段启用时 branch 加 `[WT] ` prefix
+- **段键**: `git_branch` (combined)
+
+### 💾 Git Status
+
+- **格式**: `💾 +<staged> M<modified> ?<untracked>`
+- **数据源**: 本地 git `git status --porcelain` 解析
+- **示例**: `💾 +0 M1 ?1` (staged 0, modified 1, untracked 1)
+- **隐藏条件**: git 不可用
+- **注意**: 之前的 mailbox 四种 emoji (📬/📫/📪/📭) 已弃用,统一使用 💾
+- **段键**: `git_status`
+
+### 📋 Task (活动 SPEC workflow)
+
+- **格式**: `📋 [<command> <SPEC-ID>-<stage>]`
+- **数据源**: `~/.moai/state/last-session-state.json` `active_task` 字段 (仅在该文件创建时显示)
+- **示例**: `📋 [/moai run SPEC-V3R5-STATUSLINE-001-implement]`
+- **隐藏条件**: 文件缺失或 `active_task` nil → 段隐藏
+- **段键**: `task` (opt-in default off)
+
+### 💌 PR (活动 GitHub Pull Request)
+
+- **格式**: `💌 PR #<number> (⌥<review_state>)` (state 存在时) / `💌 PR #<number>` (state 空字符串)
+- **数据源**: stdin `pr.{number, url, review_state}` (Claude Code v2.1.146+)
+- **Review state 值**: `approved` / `pending` / `changes_requested` / `draft` / 其他 (raw passthrough)
+- **颜色编码** (review_state 部分):
+  - `approved`: 绿色 (Success)
+  - `pending`: 黄色 (Warning)
+  - `changes_requested`: 红色 (Error)
+  - `draft`: 灰色 (Muted)
+  - 其他: 无颜色 (raw passthrough)
+- **示例**:
+  - `💌 PR #1234 (⌥approved)` (绿色)
+  - `💌 PR #1023 (⌥pending)` (黄色)
+  - `💌 PR #7 (⌥changes_requested)` (红色)
+  - `💌 PR #99 (⌥draft)` (灰色)
+  - `💌 PR #100` (无 state)
+- **隐藏条件**:
+  - `pr` 字段缺失 (无 PR 或 v2.1.145 以下)
+  - `pr.number == 0`
+  - `SegmentPR` config 明确 false
+- **段键**: `pr` (default on per v2.20.0-rc1)
 
 ## 配置
 
 ### 基本结构
 
-在 `.moai/config/sections/statusline.yaml` 中配置状态栏：
+`.moai/config/sections/statusline.yaml` 中管理段启用:
 
 ```yaml
 statusline:
-  mode: default              # default | compact | verbose
-  theme: catppuccin-mocha    # 选择颜色主题
-  preset: full               # full | minimal | custom
+  mode: default              # default | full
+  theme: catppuccin-mocha    # 颜色主题
+  preset: custom             # full | minimal | custom
   segments:
-    model: true              # 显示 Claude 模型
-    context: true            # 显示上下文使用率
-    directory: true          # 显示工作目录
-    git_status: true         # 显示 Git 状态
-    git_branch: true         # 显示 Git 分支
-    worktree: false          # 显示工作树信息（可选）
-    effort_thinking: false   # 显示 Effort/thinking 状态（可选）
-    pr: false                # 显示 PR 信息（可选，v2.1.145+）
+    # Line 1
+    model: true
+    effort_thinking: true
+    claude_version: true
+    moai_version: true
+    session_time: true
+    output_style: true
+
+    # Line 2
+    context: true
+    usage_5h: true
+    usage_7d: true
+
+    # Line 3
+    directory: true
+    git_branch: true       # combined repo+branch
+    git_status: true
+    task: true             # opt-in default off in older versions
+    pr: true               # default on per v2.20.0-rc1
+    worktree: false
 ```
 
-### 段选项
+### 段启用矩阵
 
-| 段 | 默认值 | 用途 | 说明 |
-|------|--------|------|------|
-| `model` | true | 当前模型 | 显示 Claude 模型版本 |
-| `context` | true | 上下文使用率 | 显示当前会话的令牌使用率 |
-| `directory` | true | 工作路径 | 显示当前工作目录 |
-| `git_status` | true | Git 状态 | 修改的文件数、贮藏状态 |
-| `git_branch` | true | 当前分支 | 分支名称和远程差异 |
-| `worktree` | false | 工作树信息 | 显示当前工作树（并行开发） |
-| `effort_thinking` | false | 思考模式 | effort 和 thinking 状态 |
-| `pr` | false | PR 信息 | GitHub PR 编号和审核状态（新 v2.1.145+） |
+| 段 | 行 | 默认启用 | stdin field |
+|---------|------|----------|-------------|
+| `model` | L1 | ✅ | `model.display_name` |
+| `effort_thinking` | L1 | ✅ | `effort.level` + `thinking.enabled` |
+| `claude_version` | L1 | ✅ | `version` |
+| `moai_version` | L1 | ✅ | (本地 config) |
+| `session_time` | L1 | ✅ | `cost.total_duration_ms` |
+| `output_style` | L1 | ✅ | `output_style.name` |
+| `context` | L2 | ✅ | `context_window.*` |
+| `usage_5h` | L2 | ✅ | `rate_limits.five_hour.*` |
+| `usage_7d` | L2 | ✅ | `rate_limits.seven_day.*` |
+| `directory` | L3 | ✅ | `workspace.project_dir` |
+| `git_branch` (combined) | L3 | ✅ | `workspace.repo.*` + 本地 git |
+| `git_status` | L3 | ✅ | 本地 git |
+| `task` | L3 | ⚠️ opt-in | `~/.moai/state/last-session-state.json` |
+| `pr` | L3 | ✅ (v2.20.0-rc1+) | `pr.*` (Claude Code v2.1.146+) |
+| `worktree` | L3 | ❌ opt-in | `workspace.git_worktree` |
 
-## 可用的段
+## Handoff Guide — (⚠️/clear) 建议标准
 
-### 始终启用的段（4个）
+CW bar 的 `(⚠️/clear)` 后缀在上下文使用量超过模型特定阈值时启用。这是预防 SSE stall 风险并建议使用 paste-ready resume message 的视觉标记。
 
-**model** — Claude 模型
-- 显示当前模型（Claude 3.5 Sonnet、Claude 3.7 Opus 等）
-- 示例：`Claude 3.5 Sonnet`
+| 模型类别 | Context Window | 阈值 | 建议时机 |
+|------------|----------------|------|----------|
+| **1M context** (Opus 4.7) | 1,000,000 tokens | **≥50%** | ~500K tokens 使用 |
+| **200K context** (Sonnet, Haiku) | 200,000 tokens | **≥90%** | ~180K tokens 使用 |
+| 其他 / 未知 | — | 不显示 | (安全 default) |
 
-**context** — 上下文使用率
-- 显示当前会话的令牌使用率
-- 格式：`150K/200K`（使用中 / 总计）
-- 75% 以上时以警告颜色显示
+> 阈值由 `internal/statusline/renderer.go shouldShowHandoffGuide()` 函数强制执行。这些阈值与 `.claude/rules/moai/workflow/context-window-management.md` HARD rule 一致。
 
-**directory** — 工作目录
-- 当前工作目录的相对路径
-- 显示相对于项目根目录的位置
+启用时用户流程:
+1. `(⚠️/clear)` marker 显示
+2. 保存进行中的工作到 `progress.md` 等
+3. orchestrator 生成 paste-ready resume message (session-handoff.md 6-block 格式)
+4. 执行 `/clear` 后粘贴 resume message
+5. 在新会话中继续工作
 
-**git_status** — Git 状态
-- 修改的文件数：`M5`（5个文件修改）
-- 贮藏状态：`S2`（2个贮藏）
-- 示例：`M5 S2`
+## stdin JSON 模式参考
 
-**git_branch** — 当前分支
-- 分支名称
-- 与远程的提交差异显示
-- 示例：`feat/SPEC-001 +3 -1`
-
-### 可选段（7个）
-
-**worktree** — 工作树信息（可选）
-- 使用 L2 工作树时显示
-- 显示当前 SPEC 名称
-- 启用：`segments.worktree: true`
-
-**effort_thinking** — Effort/thinking 状态（可选）
-- Claude 4.7 思考模式启用状态
-- effort 级别（high/xhigh/max）
-- 启用：`segments.effort_thinking: true`
-
-**output_style** — 输出样式（可选）
-- 当前输出样式设置
-- 启用：`segments.output_style: true`
-
-**claude_version** — Claude 版本（可选）
-- Claude Code 版本
-- 启用：`segments.claude_version: true`
-
-**moai_version** — moai 版本（可选）
-- MoAI-ADK 版本
-- 启用：`segments.moai_version: true`
-
-**session_time** — 会话经过时间（可选）
-- 当前会话开始以来的经过时间
-- 启用：`segments.session_time: true`
-
-**usage_5h** — 5小时累计成本（可选）
-- 过去 5 小时的成本跟踪
-- 在 GLM 环境中有用
-- 启用：`segments.usage_5h: true`
-
-**usage_7d** — 7天累计成本（可选）
-- 过去 7 天的成本跟踪
-- 启用：`segments.usage_7d: true`
-
-**task** — 活动 SPEC 工作流信息（可选）
-- 输出格式：`📋 [<command> <SPEC-ID>-<stage>]`（例如：`📋 [/moai run SPEC-V3R5-DOCS-SECURITY-001-M3]`）
-- 数据源：`~/.moai/state/last-session-state.json` 的 `active_task` 字段（由 SessionStart 钩子自动设置）
-- 非活动状态下 segment 不显示（graceful no-output）
-- 启用：`segments.task: true`（自 v2.20.0-rc1 起默认 true — default-on，可通过 `false` 显式禁用）
-
-**repo** — 存储库信息（可选，v2.1.145+）
-- 显示当前 GitHub 存储库所有者/名称
-- 示例：`modu-ai/moai-adk`
-- 启用：`segments.repo: true`
-
-**long_context** — 长上下文警告（可选，v2.1.139+）
-- 当 200K 令牌超过时显示警告标记
-- 示例：`⚠️ 200K+ exceeded`
-- 启用：`segments.long_context: true`
-
-**handoff_guide** — 切换指南阈值（可选，v2.1.146+）
-- 显示当前模型的上下文窗口大小和推荐的切换阈值
-- 1M 模型：50% 阈值（≈500K 令牌）
-- 200K 模型：90% 阈值（≈180K 令牌）
-- 示例：`[1M: 50% | 200K: 90%]`
-- 启用：`segments.handoff_guide: true`
-
-## 新增 v2.1.145：PR 段
-
-### 概述
-
-从 Claude Code v2.1.145 开始，状态栏 stdin JSON 包含 GitHub PR 信息。MoAI-ADK 利用这些信息在状态栏中显示当前 PR 的审核状态。
-
-**启用**：自 v2.20.0-rc1 起默认 `true`（default-on）。设置 `segments.pr: false` 可显式禁用。graceful no-output 模式：当无 PR 信息时 segment 自动隐藏。
-
-### PR 段显示格式
-
-PR 段以以下格式显示：
-
-```
-#1023 ⌥approved
-```
-
-- `#1023`：PR 编号
-- `⌥`：PR 状态显示符号
-- `approved`：审核状态（颜色编码）
-
-### 按审核状态的颜色
-
-根据 PR 的审核状态以不同颜色显示：
-
-| 状态 | 颜色 | 含义 |
-|------|------|------|
-| `approved` | 绿色 | PR 已批准 |
-| `pending` | 黄色 | 等待审核中 |
-| `changes_requested` | 红色 | 已请求更改 |
-| `draft` | 灰色 | 草稿状态 |
-| （其他/空） | 默认 | 未应用样式 |
-
-### 启用方法
-
-1. 编辑 `.moai/config/sections/statusline.yaml` 文件
-
-```yaml
-statusline:
-  segments:
-    pr: true   # 启用 PR 段
-```
-
-2. 重启 Claude Code 会话
-
-现在状态栏将显示当前 PR 的编号和审核状态。
-
-### JSON 输入架构（v2.1.145+）
-
-Claude Code v2.1.145+ 将以下格式的 JSON 传递给状态栏 stdin：
+Claude Code 传递给 statusline 脚本的 stdin JSON 完整字段列表请参考 [官方 docs Available data](https://code.claude.com/docs/en/statusline#available-data)。moai-adk-go 使用以下字段:
 
 ```json
 {
-  "pr": {
-    "number": 1023,
-    "url": "https://github.com/modu-ai/moai-adk/pull/1023",
-    "review_state": "pending"
-  },
+  "session_id": "abc...",
+  "transcript_path": "/path/to/transcript.jsonl",
+  "cwd": "/path/to/cwd",
+  "model": {"id": "claude-opus-4-7", "display_name": "Opus 4.7"},
   "workspace": {
-    "repo": {
-      "host": "github.com",
-      "owner": "modu-ai",
-      "name": "moai-adk"
+    "current_dir": "...",
+    "project_dir": "...",
+    "git_worktree": "feature-xyz",
+    "repo": {"host": "github.com", "owner": "modu-ai", "name": "moai-adk"}
+  },
+  "version": "2.1.146",
+  "output_style": {"name": "MoAI"},
+  "cost": {
+    "total_cost_usd": 1.234,
+    "total_duration_ms": 17520000,
+    "total_lines_added": 156,
+    "total_lines_removed": 23
+  },
+  "context_window": {
+    "used_percentage": 62,
+    "context_window_size": 1000000,
+    "total_input_tokens": 620000,
+    "total_output_tokens": 0,
+    "current_usage": {
+      "input_tokens": 8500,
+      "output_tokens": 1200,
+      "cache_creation_input_tokens": 5000,
+      "cache_read_input_tokens": 605300
     }
+  },
+  "exceeds_200k_tokens": true,
+  "effort": {"level": "xhigh"},
+  "thinking": {"enabled": true},
+  "rate_limits": {
+    "five_hour": {"used_percentage": 56, "resets_at": 1779286800},
+    "seven_day": {"used_percentage": 13, "resets_at": 1779832400}
+  },
+  "pr": {
+    "number": 1234,
+    "url": "https://github.com/modu-ai/moai-adk/pull/1234",
+    "review_state": "approved"
   }
 }
 ```
 
-- **pr.number**：PR 编号（必需）
-- **pr.url**：PR 网址（可选）
-- **pr.review_state**：审核状态（可选，默认：空）
-- **workspace.repo.host**：Git 主机（github.com）
-- **workspace.repo.owner**：存储库所有者
-- **workspace.repo.name**：存储库名称
+## 版本历史
 
-### 相关信息
+- **v2.20.0-rc1 layout v3** (2026-05-22): 3-line 布局重新设计 — repo+branch 组合段、directory L3 head、`🪫 CW:` emoji 前移、`(⚠️/clear)` handoff 后缀、`💾` git status 统一、`💌 PR #N (⌥state)` 格式
+- **v2.20.0-rc1 STATUSLINE-STDINFIELDS-001** (2026-05-21): 添加 `workspace.repo` + `exceeds_200k_tokens` + `pr` stdin 字段映射、1M context handoff threshold 75% → 50%
+- **v2.20.0-rc1 STATUSLINE-V2145-001** (2026-05-20): 添加 PR segment (v2.1.145+ stdin)、4-locale docs 同步
+- **v2.1.139** (Claude Code): `effort.level` + `thinking.enabled` 添加到 stdin JSON
+- **v2.1.146** (Claude Code): `workspace.repo` + `pr` 添加到 stdin JSON
 
-- **SPEC 参考**：[SPEC-V3R5-STATUSLINE-V2145-001](/zh/advanced/statusline#参考)
-- **最低版本**：需要 Claude Code v2.1.145 或更高版本
-- **可选功能**：默认为 `false`，需要明确启用
-- **向后兼容性**：早期版本的 Claude Code 不提供 PR 信息（段不显示）
+## 故障排除
 
-## 故障排除：状态栏消失问题
+### Statusline 中 PR 未显示
 
-### 症状
+- 验证 Claude Code 版本: 需要 `🔅 v2.1.146` 以上 (v2.1.145 stdin 不包含 `pr` 字段)
+- 验证当前 branch 有 OPEN PR: `gh pr view`
+- 检查 `statusline.yaml` 中是否明确 `pr: false`
 
-- 状态栏间歇性不显示
-- Claude Code UI 中的状态栏区域为空
-- `.moai/cache/statusline_debug.log` 文件持续增长
+### (⚠️/clear) 未出现
 
-### 原因分析（v2.1.145 M1 修复前）
+- 1M context 模型: used_percentage 低于 50% → 正常 (尚未达到阈值)
+- 200K context 模型: used_percentage 低于 90% → 正常
+- 高于阈值但未显示: 验证 `shouldShowHandoffGuide` 函数的 `MemoryData.ContextWindowSize` 映射 (可能的 boundary defect)
 
-状态栏渲染器必须遵守 Claude Code 的**300ms 防抖契约**。违反此合同将取消正在进行的执行。
+### 颜色未显示
 
-以前代码的问题：
+- 验证终端是否支持 ANSI 256-color
+- 确认 `theme: catppuccin-mocha` 是否适合环境
+- 检查是否设置了 `NO_COLOR=1` 环境变量
 
-```bash
-# 问题：DEBUG_STATUSLINE 的默认值为 1（始终启用）
-DEBUG_STATUSLINE=${DEBUG_STATUSLINE:-1}
-
-# 这导致每次渲染时：
-# 1. python3 -m json.tool 进程分叉（50-250ms）
-# 2. 写入 ~/.moai/cache/statusline_debug.log（~10ms）
-# 合计：60-260ms → 超过 300ms 防抖边界
-# → Claude Code 取消正在进行的状态栏渲染
-# → 结果：状态栏不显示
-```
-
-### 解决方案（v2.1.145 M1 中已修复）
-
-从 v3.5.0 开始，`DEBUG_STATUSLINE` 的默认值为 **0**：
+### 验证命令
 
 ```bash
-# 已修复：默认值 0（禁用）
-DEBUG_STATUSLINE=${DEBUG_STATUSLINE:-0}
-
-# 仅在需要调试时明确启用：
-export DEBUG_STATUSLINE=1
+# 使用 stdin fixture 验证 statusline 实际输出
+NOW=$(date +%s)
+echo '{"session_id":"test","model":{"display_name":"Opus 4.7"},"workspace":{"repo":{"host":"github.com","owner":"modu-ai","name":"moai-adk"}},"version":"2.1.146","output_style":{"name":"MoAI"},"context_window":{"used_percentage":62,"context_window_size":1000000},"exceeds_200k_tokens":true,"effort":{"level":"xhigh"},"thinking":{"enabled":true},"rate_limits":{"five_hour":{"used_percentage":56,"resets_at":'$((NOW + 2820))'},"seven_day":{"used_percentage":13,"resets_at":'$((NOW + 518400))'}},"cost":{"total_duration_ms":17520000},"pr":{"number":1234,"url":"https://github.com/modu-ai/moai-adk/pull/1234","review_state":"approved"}}' | moai statusline
 ```
 
-### 填充调整
+## 相关文档
 
-以前使用 `echo ""` 来调整状态栏周围的空白。这现在不再推荐。
-
-**改为**在 `.claude/settings.json` 中设置：
-
-```json
-{
-  "statusLine": {
-    "padding": 1
-  }
-}
-```
-
-- `padding: 0`：无填充
-- `padding: 1`：上下 1 行填充（默认）
-- `padding: 2`：上下 2 行填充
-
-### 检查清单
-
-解决状态栏显示问题的步骤：
-
-1. ✓ 检查 `DEBUG_STATUSLINE` 环境变量
-   ```bash
-   echo $DEBUG_STATUSLINE  # 默认应为 unset 或 0
-   ```
-
-2. ✓ 检查 `.moai/status_line.sh` 文件
-   ```bash
-   grep "DEBUG_STATUSLINE=" ~/.moai/status_line.sh
-   # 结果应为：DEBUG_STATUSLINE=${DEBUG_STATUSLINE:-0}
-   ```
-
-3. ✓ 明确启用调试（仅在需要时）
-   ```bash
-   export DEBUG_STATUSLINE=1
-   # 现在将记录调试信息
-   ```
-
-4. ✓ 设置填充
-   ```json
-   {
-     "statusLine": {
-       "padding": 1
-     }
-   }
-   ```
-
-5. ✓ 重启 Claude Code 会话
-
-## 参考
-
-### 官方文档
-
-- [Claude Code 状态栏官方文档](https://code.claude.com/docs/en/statusline) — Claude Code 的状态栏契约和 JSON 架构
-
-### moai-adk-go 内部
-
-- **包**：`internal/statusline/`
-  - `types.go`：StdinData、PRInfo、RepoInfo 结构体定义
-  - `builder.go`：段构建逻辑
-  - `renderer.go`：颜色编码和最终渲染
-
-- **模板**：`.moai/status_line.sh.tmpl`
-  - 渲染器调用和执行逻辑
-
-- **配置**：`.moai/config/sections/statusline.yaml`
-  - 段启用/禁用设置
-
-### 相关 SPEC
-
-- **[SPEC-V3R5-STATUSLINE-V2145-001](https://github.com/modu-ai/moai-adk/blob/main/.moai/specs/SPEC-V3R5-STATUSLINE-V2145-001/spec.md)**
-  - M1：修复状态栏消失问题
-  - M2：添加 v2.1.145 PR 段
-  - M3：文档化（当前页面）
+- [Settings JSON](/advanced/settings-json) — Claude Code `statusLine` 字段配置
+- [Context Window Management](/advanced/context-window-management) — handoff threshold 策略 (1M = 50%, 200K = 90%)
+- [Session Handoff](/advanced/session-handoff) — paste-ready resume message 6-block 格式
+- [PR Workflow](/git/pr-workflow) — MoAI PR 中心工作流

--- a/internal/cli/profile_setup.go
+++ b/internal/cli/profile_setup.go
@@ -76,6 +76,47 @@ func normalizeStatuslineTheme(theme string) string {
 	return defaultStatuslineTheme
 }
 
+// statuslinePresetCanonical lists the four canonical preset names offered by the
+// wizard's Preset Select widget. Order matches the huh.NewOption block (~line 290-320).
+// SPEC-V3R5-STATUSLINE-PROFILE-WIZARD-001 REQ-SPW-001.
+var statuslinePresetCanonical = []string{"full", "compact", "minimal", "custom"}
+
+// statuslineAllSegments lists the 15 canonical segment keys that the MultiSelect
+// widget offers when preset == "custom". Order MUST match statusline.yaml segment
+// definitions and Segment* fields in profileSetupText (REQ-SPW-002, REQ-SPW-003).
+var statuslineAllSegments = []string{
+	"claude_version", "context", "directory", "effort_thinking",
+	"git_branch", "git_status", "moai_version", "model",
+	"output_style", "pr", "session_time", "task",
+	"usage_5h", "usage_7d", "worktree",
+}
+
+// isCanonicalStatuslinePreset reports whether p is a known wizard preset value.
+func isCanonicalStatuslinePreset(p string) bool {
+	for _, v := range statuslinePresetCanonical {
+		if v == p {
+			return true
+		}
+	}
+	return false
+}
+
+// normalizeStatuslinePreset returns a wizard-compatible preset value.
+//
+// Behavior (SPEC-V3R5-STATUSLINE-PROFILE-WIZARD-001 REQ-SPW-004):
+//   - Empty string passes through unchanged (EC-SPW-003: syncStatusline preserves existing yaml).
+//   - Canonical values (full|compact|minimal|custom) pass through unchanged (EC-SPW-001).
+//   - Invalid values (legacy or typo) reset to "" so the Select widget falls back to default (EC-SPW-002).
+func normalizeStatuslinePreset(p string) string {
+	if p == "" {
+		return ""
+	}
+	if isCanonicalStatuslinePreset(p) {
+		return p
+	}
+	return ""
+}
+
 // @MX:NOTE: [AUTO] Wizard v3 migration — normalizes deprecated Claude model IDs to canonical aliases.
 // @MX:REASON: Prevents silent loss of existing prefs values in huh.Select bindings after the "claude-opus-4-7" option was removed from the previous wizard.
 func normalizeModel(m string) string {
@@ -167,6 +208,24 @@ func runProfileSetup(cmd *cobra.Command, args []string) error {
 
 	statuslineMode := normalizeStatuslineMode(existingPrefs.StatuslineMode)
 	statuslineTheme := normalizeStatuslineTheme(existingPrefs.StatuslineTheme)
+	statuslinePreset := normalizeStatuslinePreset(existingPrefs.StatuslinePreset)
+
+	// SPEC-V3R5-STATUSLINE-PROFILE-WIZARD-001 REQ-SPW-002 / plan-auditor S4:
+	// Extract enabled segment keys for MultiSelect default selection.
+	// When prefs.StatuslineSegments is nil (new user), default to all 15 segments enabled
+	// (matching .moai/config/sections/statusline.yaml 15-segment baseline, NOT the
+	// 11-segment defaultStatuslineSegments() in internal/profile/sync.go which serves a
+	// different purpose: yaml fallback when statusline.yaml is absent).
+	statuslineSegmentsSelection := make([]string, 0, len(statuslineAllSegments))
+	if existingPrefs.StatuslineSegments != nil {
+		for _, key := range statuslineAllSegments {
+			if existingPrefs.StatuslineSegments[key] {
+				statuslineSegmentsSelection = append(statuslineSegmentsSelection, key)
+			}
+		}
+	} else {
+		statuslineSegmentsSelection = append(statuslineSegmentsSelection, statuslineAllSegments...)
+	}
 
 	// ====== Step 1: Language selection ======
 	langOptions := []huh.Option[string]{
@@ -277,8 +336,8 @@ func runProfileSetup(cmd *cobra.Command, args []string) error {
 				Value(&permissionMode),
 		).Title(t.ModelSettingsTitle),
 
-		// Section 4: Display — mode, theme
-		// KEEP IN SYNC with statuslineModeCanonical at top of file
+		// Section 4: Display — mode, preset, theme
+		// KEEP IN SYNC with statuslineModeCanonical + statuslinePresetCanonical at top of file
 		huh.NewGroup(
 			huh.NewSelect[string]().
 				Title(t.StatuslineModeTitle).
@@ -288,6 +347,17 @@ func runProfileSetup(cmd *cobra.Command, args []string) error {
 					huh.NewOption(t.ModeFull, "full"),
 				).
 				Value(&statuslineMode),
+			// SPEC-V3R5-STATUSLINE-PROFILE-WIZARD-001 REQ-SPW-001 — preset Select
+			huh.NewSelect[string]().
+				Title(t.StatuslinePresetTitle).
+				Description(t.StatuslinePresetDesc).
+				Options(
+					huh.NewOption(t.PresetFull, "full"),
+					huh.NewOption(t.PresetCompact, "compact"),
+					huh.NewOption(t.PresetMinimal, "minimal"),
+					huh.NewOption(t.PresetCustom, "custom"),
+				).
+				Value(&statuslinePreset),
 			// KEEP IN SYNC with statuslineThemeCanonical at top of file
 			huh.NewSelect[string]().
 				Title(t.StatuslineThemeTitle).
@@ -298,6 +368,35 @@ func runProfileSetup(cmd *cobra.Command, args []string) error {
 				).
 				Value(&statuslineTheme),
 		).Title(t.DisplayTitle),
+
+		// Section 5: Segments (custom preset only) — SPEC-V3R5-STATUSLINE-PROFILE-WIZARD-001 REQ-SPW-002
+		// WithHideFunc gates display on statuslinePreset == "custom" (R-SPW-001 mitigation).
+		// 15 segments KEEP IN SYNC with statuslineAllSegments slice at top of file.
+		huh.NewGroup(
+			huh.NewMultiSelect[string]().
+				Title(t.StatuslineSegmentsTitle).
+				Description(t.StatuslineSegmentsDesc).
+				Options(
+					huh.NewOption(t.SegmentClaudeVersion, "claude_version"),
+					huh.NewOption(t.SegmentContext, "context"),
+					huh.NewOption(t.SegmentDirectory, "directory"),
+					huh.NewOption(t.SegmentEffortThinking, "effort_thinking"),
+					huh.NewOption(t.SegmentGitBranch, "git_branch"),
+					huh.NewOption(t.SegmentGitStatus, "git_status"),
+					huh.NewOption(t.SegmentMoaiVersion, "moai_version"),
+					huh.NewOption(t.SegmentModel, "model"),
+					huh.NewOption(t.SegmentOutputStyle, "output_style"),
+					huh.NewOption(t.SegmentPR, "pr"),
+					huh.NewOption(t.SegmentSessionTime, "session_time"),
+					huh.NewOption(t.SegmentTask, "task"),
+					huh.NewOption(t.SegmentUsage5h, "usage_5h"),
+					huh.NewOption(t.SegmentUsage7d, "usage_7d"),
+					huh.NewOption(t.SegmentWorktree, "worktree"),
+				).
+				Value(&statuslineSegmentsSelection),
+		).Title(t.StatuslineSegmentsTitle).WithHideFunc(func() bool {
+			return statuslinePreset != "custom"
+		}),
 	)
 
 	if err := form.Run(); err != nil {
@@ -313,18 +412,36 @@ func runProfileSetup(cmd *cobra.Command, args []string) error {
 		permissionMode = ""
 	}
 
+	// SPEC-V3R5-STATUSLINE-PROFILE-WIZARD-001 REQ-SPW-002:
+	// Build segments map only when preset == "custom". For other presets the segments
+	// map is left nil so syncStatusline (internal/profile/sync.go:95-145) preserves the
+	// existing statusline.yaml segment values without unwanted overrides.
+	var statuslineSegmentsMap map[string]bool
+	if statuslinePreset == "custom" {
+		selected := make(map[string]bool, len(statuslineSegmentsSelection))
+		for _, key := range statuslineSegmentsSelection {
+			selected[key] = true
+		}
+		statuslineSegmentsMap = make(map[string]bool, len(statuslineAllSegments))
+		for _, key := range statuslineAllSegments {
+			statuslineSegmentsMap[key] = selected[key]
+		}
+	}
+
 	// Save preferences.
 	prefs := profile.ProfilePreferences{
-		UserName:         userName,
-		ConversationLang: convLang,
-		GitCommitLang:    gitCommitLang,
-		CodeCommentLang:  codeCommentLang,
-		DocLang:          docLang,
-		Model:            model,
-		EffortLevel:      effortLevel,
-		PermissionMode:   permissionMode,
-		StatuslineMode:   statuslineMode,
-		StatuslineTheme:  statuslineTheme,
+		UserName:           userName,
+		ConversationLang:   convLang,
+		GitCommitLang:      gitCommitLang,
+		CodeCommentLang:    codeCommentLang,
+		DocLang:            docLang,
+		Model:              model,
+		EffortLevel:        effortLevel,
+		PermissionMode:     permissionMode,
+		StatuslineMode:     statuslineMode,
+		StatuslinePreset:   statuslinePreset,
+		StatuslineSegments: statuslineSegmentsMap,
+		StatuslineTheme:    statuslineTheme,
 	}
 
 	if err := profile.WritePreferences(profileName, prefs); err != nil {

--- a/internal/cli/profile_setup_test.go
+++ b/internal/cli/profile_setup_test.go
@@ -61,3 +61,51 @@ func TestGetProfileText_ModeFields(t *testing.T) {
 		})
 	}
 }
+
+// TestNormalizeStatuslinePreset verifies the canonical-list normalizer
+// behavior covering EC-SPW-001 (preserve valid), EC-SPW-002 (reset invalid),
+// EC-SPW-003 (preserve empty).
+// SPEC-V3R5-STATUSLINE-PROFILE-WIZARD-001 REQ-SPW-004.
+func TestNormalizeStatuslinePreset(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "EC-SPW-003 empty preserved", input: "", want: ""},
+		{name: "EC-SPW-001 valid full", input: "full", want: "full"},
+		{name: "EC-SPW-001 valid compact", input: "compact", want: "compact"},
+		{name: "EC-SPW-001 valid minimal", input: "minimal", want: "minimal"},
+		{name: "EC-SPW-001 valid custom", input: "custom", want: "custom"},
+		{name: "EC-SPW-002 invalid legacy fullbar", input: "fullbar", want: ""},
+		{name: "EC-SPW-002 invalid typo cusotm", input: "cusotm", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeStatuslinePreset(tt.input)
+			if got != tt.want {
+				t.Errorf("normalizeStatuslinePreset(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestStatuslineAllSegments_CardinalityAndOrder verifies the 15-segment
+// canonical list matches .moai/config/sections/statusline.yaml keys.
+// SPEC-V3R5-STATUSLINE-PROFILE-WIZARD-001 REQ-SPW-002 / REQ-SPW-003.
+func TestStatuslineAllSegments_CardinalityAndOrder(t *testing.T) {
+	if got, want := len(statuslineAllSegments), 15; got != want {
+		t.Fatalf("statuslineAllSegments length = %d, want %d", got, want)
+	}
+	expected := []string{
+		"claude_version", "context", "directory", "effort_thinking",
+		"git_branch", "git_status", "moai_version", "model",
+		"output_style", "pr", "session_time", "task",
+		"usage_5h", "usage_7d", "worktree",
+	}
+	for i, key := range expected {
+		if statuslineAllSegments[i] != key {
+			t.Errorf("statuslineAllSegments[%d] = %q, want %q", i, statuslineAllSegments[i], key)
+		}
+	}
+}

--- a/internal/cli/profile_setup_translations.go
+++ b/internal/cli/profile_setup_translations.go
@@ -72,6 +72,35 @@ type profileSetupText struct {
 	ModeVerbose string // label for mode = "verbose" (deprecated)
 	ModeMinimal string // label for mode = "minimal" (deprecated)
 
+	// Statusline preset selector (SPEC-V3R5-STATUSLINE-PROFILE-WIZARD-001)
+	StatuslinePresetTitle string
+	StatuslinePresetDesc  string
+	PresetFull            string
+	PresetCompact         string
+	PresetMinimal         string
+	PresetCustom          string
+
+	// Statusline segments multi-select (SPEC-V3R5-STATUSLINE-PROFILE-WIZARD-001)
+	// Only shown when preset = "custom".
+	// Order matches statuslineAllSegments slice in profile_setup.go (15 segments).
+	StatuslineSegmentsTitle string
+	StatuslineSegmentsDesc  string
+	SegmentClaudeVersion    string
+	SegmentContext          string
+	SegmentDirectory        string
+	SegmentEffortThinking   string
+	SegmentGitBranch        string
+	SegmentGitStatus        string
+	SegmentMoaiVersion      string
+	SegmentModel            string
+	SegmentOutputStyle      string
+	SegmentPR               string
+	SegmentSessionTime      string
+	SegmentTask             string
+	SegmentUsage5h          string
+	SegmentUsage7d          string
+	SegmentWorktree         string
+
 	// Statusline theme selector
 	StatuslineThemeTitle string
 	StatuslineThemeDesc  string
@@ -155,11 +184,34 @@ var profileSetupTexts = map[string]profileSetupText{
 		ModeCompact:          "Compact - 2-line: model+CW bar, git status",
 		ModeFull:             "Full - 5-line: info, CW/5H/7D bars (40-block), dir+git",
 		ModeVerbose:          "Verbose - 3-line detailed view with cost tracking",
-		ModeMinimal:          "Minimal - Model and context only",
-		StatuslineThemeTitle: "Statusline Theme",
-		StatuslineThemeDesc:  "Select a color theme for the statusline.",
-		ThemeMoaiDark:        "MoAI Dark",
-		ThemeMoaiLight:       "MoAI Light",
+		ModeMinimal:             "Minimal - Model and context only",
+		StatuslinePresetTitle:   "Statusline preset",
+		StatuslinePresetDesc:    "Choose a preset segment bundle. Select 'custom' to toggle individual segments below.",
+		PresetFull:              "full - Show all segments (full visibility)",
+		PresetCompact:           "compact - Essential segments only (minimal noise)",
+		PresetMinimal:           "minimal - Just model and context",
+		PresetCustom:            "custom - Pick individual segments below",
+		StatuslineSegmentsTitle: "Statusline segments (custom preset only)",
+		StatuslineSegmentsDesc:  "Toggle which segments appear. Applied only when preset = 'custom'.",
+		SegmentClaudeVersion:    "Claude version",
+		SegmentContext:          "Context usage",
+		SegmentDirectory:        "Current directory",
+		SegmentEffortThinking:   "Effort + thinking mode",
+		SegmentGitBranch:        "Git branch",
+		SegmentGitStatus:        "Git status (porcelain)",
+		SegmentMoaiVersion:      "MoAI version",
+		SegmentModel:            "Model name",
+		SegmentOutputStyle:      "Output style",
+		SegmentPR:               "Open PR number",
+		SegmentSessionTime:      "Session elapsed time",
+		SegmentTask:             "Current task (/moai run XXX)",
+		SegmentUsage5h:          "Usage 5h window bar",
+		SegmentUsage7d:          "Usage 7d window bar",
+		SegmentWorktree:         "Worktree path / identifier",
+		StatuslineThemeTitle:    "Statusline Theme",
+		StatuslineThemeDesc:     "Select a color theme for the statusline.",
+		ThemeMoaiDark:           "MoAI Dark",
+		ThemeMoaiLight:          "MoAI Light",
 		SetupCancelled:       "Setup cancelled.",
 		SavedProfile:         "\nSaved profile '%s':\n  Preferences → %s\n",
 
@@ -231,11 +283,34 @@ var profileSetupTexts = map[string]profileSetupText{
 		ModeCompact:          "Compact - 2줄: 모델+CW 바, git 상태",
 		ModeFull:             "Full - 5줄: 정보, CW/5H/7D 바(40블록), 디렉토리+git",
 		ModeVerbose:          "Verbose - 비용 추적이 포함된 3줄 상세 뷰",
-		ModeMinimal:          "Minimal - 모델과 컨텍스트만 표시",
-		StatuslineThemeTitle: "Statusline 테마",
-		StatuslineThemeDesc:  "상태줄 색상 테마를 선택하세요.",
-		ThemeMoaiDark:        "MoAI Dark",
-		ThemeMoaiLight:       "MoAI Light",
+		ModeMinimal:             "Minimal - 모델과 컨텍스트만 표시",
+		StatuslinePresetTitle:   "상태줄 프리셋",
+		StatuslinePresetDesc:    "세그먼트 묶음 프리셋을 선택하세요. 'custom'을 선택하면 아래에서 개별 세그먼트를 토글할 수 있습니다.",
+		PresetFull:              "full - 모든 세그먼트 표시 (전체 가시성)",
+		PresetCompact:           "compact - 필수 세그먼트만 (최소 노이즈)",
+		PresetMinimal:           "minimal - 모델과 컨텍스트만",
+		PresetCustom:            "custom - 아래에서 개별 세그먼트를 선택",
+		StatuslineSegmentsTitle: "상태줄 세그먼트 (custom 프리셋 전용)",
+		StatuslineSegmentsDesc:  "표시할 세그먼트를 토글합니다. preset이 'custom'일 때만 적용됩니다.",
+		SegmentClaudeVersion:    "Claude 버전",
+		SegmentContext:          "컨텍스트 사용량",
+		SegmentDirectory:        "현재 디렉토리",
+		SegmentEffortThinking:   "추론 강도 + 사고 모드",
+		SegmentGitBranch:        "Git 브랜치",
+		SegmentGitStatus:        "Git 상태 (porcelain)",
+		SegmentMoaiVersion:      "MoAI 버전",
+		SegmentModel:            "모델 이름",
+		SegmentOutputStyle:      "출력 스타일",
+		SegmentPR:               "열린 PR 번호",
+		SegmentSessionTime:      "세션 경과 시간",
+		SegmentTask:             "현재 작업 (/moai run XXX)",
+		SegmentUsage5h:          "사용량 5시간 바",
+		SegmentUsage7d:          "사용량 7일 바",
+		SegmentWorktree:         "워크트리 경로 / 식별자",
+		StatuslineThemeTitle:    "Statusline 테마",
+		StatuslineThemeDesc:     "상태줄 색상 테마를 선택하세요.",
+		ThemeMoaiDark:           "MoAI Dark",
+		ThemeMoaiLight:          "MoAI Light",
 		SetupCancelled:       "설정이 취소되었습니다.",
 		SavedProfile:         "\n프로필 '%s' 저장 완료:\n  환경설정 → %s\n",
 
@@ -307,11 +382,34 @@ var profileSetupTexts = map[string]profileSetupText{
 		ModeCompact:          "Compact - 2行: モデル+CWバー、gitステータス",
 		ModeFull:             "Full - 5行: 情報、CW/5H/7Dバー(40ブロック)、ディレクトリ+git",
 		ModeVerbose:          "Verbose - コスト追跡付きの3行詳細表示",
-		ModeMinimal:          "Minimal - モデルとコンテキストのみ",
-		StatuslineThemeTitle: "ステータスラインテーマ",
-		StatuslineThemeDesc:  "ステータスラインのカラーテーマを選択してください。",
-		ThemeMoaiDark:        "MoAI Dark",
-		ThemeMoaiLight:       "MoAI Light",
+		ModeMinimal:             "Minimal - モデルとコンテキストのみ",
+		StatuslinePresetTitle:   "ステータスラインプリセット",
+		StatuslinePresetDesc:    "セグメントバンドルプリセットを選択。'custom'を選ぶと下のセグメントを個別に切り替えられます。",
+		PresetFull:              "full - 全セグメント表示 (全可視性)",
+		PresetCompact:           "compact - 必須セグメントのみ (最小ノイズ)",
+		PresetMinimal:           "minimal - モデルとコンテキストのみ",
+		PresetCustom:            "custom - 下で個別セグメントを選択",
+		StatuslineSegmentsTitle: "ステータスラインセグメント (custom プリセット専用)",
+		StatuslineSegmentsDesc:  "表示するセグメントを切り替えます。preset = 'custom' の時のみ適用されます。",
+		SegmentClaudeVersion:    "Claude バージョン",
+		SegmentContext:          "コンテキスト使用量",
+		SegmentDirectory:        "現在のディレクトリ",
+		SegmentEffortThinking:   "推論強度 + 思考モード",
+		SegmentGitBranch:        "Git ブランチ",
+		SegmentGitStatus:        "Git ステータス (porcelain)",
+		SegmentMoaiVersion:      "MoAI バージョン",
+		SegmentModel:            "モデル名",
+		SegmentOutputStyle:      "出力スタイル",
+		SegmentPR:               "オープン PR 番号",
+		SegmentSessionTime:      "セッション経過時間",
+		SegmentTask:             "現在のタスク (/moai run XXX)",
+		SegmentUsage5h:          "使用量 5h ウィンドウバー",
+		SegmentUsage7d:          "使用量 7d ウィンドウバー",
+		SegmentWorktree:         "ワークツリーパス / 識別子",
+		StatuslineThemeTitle:    "ステータスラインテーマ",
+		StatuslineThemeDesc:     "ステータスラインのカラーテーマを選択してください。",
+		ThemeMoaiDark:           "MoAI Dark",
+		ThemeMoaiLight:          "MoAI Light",
 		SetupCancelled:       "セットアップがキャンセルされました。",
 		SavedProfile:         "\nプロファイル '%s' を保存しました:\n  環境設定 → %s\n",
 
@@ -383,11 +481,34 @@ var profileSetupTexts = map[string]profileSetupText{
 		ModeCompact:          "Compact - 2行: 模型+CW栏、git状态",
 		ModeFull:             "Full - 5行: 信息、CW/5H/7D栏(40块)、目录+git",
 		ModeVerbose:          "Verbose - 含费用追踪的3行详细视图",
-		ModeMinimal:          "Minimal - 仅显示模型和上下文",
-		StatuslineThemeTitle: "状态栏主题",
-		StatuslineThemeDesc:  "选择状态栏的颜色主题。",
-		ThemeMoaiDark:        "MoAI Dark",
-		ThemeMoaiLight:       "MoAI Light",
+		ModeMinimal:             "Minimal - 仅显示模型和上下文",
+		StatuslinePresetTitle:   "状态栏预设",
+		StatuslinePresetDesc:    "选择段位束预设。选择 'custom' 可在下方逐个切换段位。",
+		PresetFull:              "full - 显示所有段位 (完全可见)",
+		PresetCompact:           "compact - 仅必需段位 (最小噪声)",
+		PresetMinimal:           "minimal - 仅模型和上下文",
+		PresetCustom:            "custom - 在下方选择单独段位",
+		StatuslineSegmentsTitle: "状态栏段位 (仅 custom 预设)",
+		StatuslineSegmentsDesc:  "切换显示哪些段位。仅当 preset = 'custom' 时应用。",
+		SegmentClaudeVersion:    "Claude 版本",
+		SegmentContext:          "上下文使用量",
+		SegmentDirectory:        "当前目录",
+		SegmentEffortThinking:   "推理强度 + 思考模式",
+		SegmentGitBranch:        "Git 分支",
+		SegmentGitStatus:        "Git 状态 (porcelain)",
+		SegmentMoaiVersion:      "MoAI 版本",
+		SegmentModel:            "模型名称",
+		SegmentOutputStyle:      "输出样式",
+		SegmentPR:               "开放 PR 编号",
+		SegmentSessionTime:      "会话经过时间",
+		SegmentTask:             "当前任务 (/moai run XXX)",
+		SegmentUsage5h:          "使用量 5 小时窗口条",
+		SegmentUsage7d:          "使用量 7 天窗口条",
+		SegmentWorktree:         "工作树路径 / 标识符",
+		StatuslineThemeTitle:    "状态栏主题",
+		StatuslineThemeDesc:     "选择状态栏的颜色主题。",
+		ThemeMoaiDark:           "MoAI Dark",
+		ThemeMoaiLight:          "MoAI Light",
 		SetupCancelled:       "设置已取消。",
 		SavedProfile:         "\n配置文件 '%s' 已保存:\n  偏好设置 → %s\n",
 

--- a/internal/cli/profile_setup_translations_test.go
+++ b/internal/cli/profile_setup_translations_test.go
@@ -196,3 +196,53 @@ func TestGetProfileText_EmptyString(t *testing.T) {
 		t.Errorf("empty string fallback = %q, want %q", empty.LangSelectTitle, en.LangSelectTitle)
 	}
 }
+
+// TestProfileSetupTranslations_PresetSegments verifies that all 4 locales
+// (en/ko/ja/zh) provide non-empty translations for the statusline preset
+// selector + 15 segment toggle labels added by
+// SPEC-V3R5-STATUSLINE-PROFILE-WIZARD-001 REQ-SPW-003.
+//
+// 4 locales × 23 keys (2 preset titles + 4 preset options + 2 segments
+// section titles + 15 segment labels) = 92 cells verified.
+func TestProfileSetupTranslations_PresetSegments(t *testing.T) {
+	langs := []string{"en", "ko", "ja", "zh"}
+	type cell struct {
+		key   string
+		value func(profileSetupText) string
+	}
+	cells := []cell{
+		{"StatuslinePresetTitle", func(p profileSetupText) string { return p.StatuslinePresetTitle }},
+		{"StatuslinePresetDesc", func(p profileSetupText) string { return p.StatuslinePresetDesc }},
+		{"PresetFull", func(p profileSetupText) string { return p.PresetFull }},
+		{"PresetCompact", func(p profileSetupText) string { return p.PresetCompact }},
+		{"PresetMinimal", func(p profileSetupText) string { return p.PresetMinimal }},
+		{"PresetCustom", func(p profileSetupText) string { return p.PresetCustom }},
+		{"StatuslineSegmentsTitle", func(p profileSetupText) string { return p.StatuslineSegmentsTitle }},
+		{"StatuslineSegmentsDesc", func(p profileSetupText) string { return p.StatuslineSegmentsDesc }},
+		{"SegmentClaudeVersion", func(p profileSetupText) string { return p.SegmentClaudeVersion }},
+		{"SegmentContext", func(p profileSetupText) string { return p.SegmentContext }},
+		{"SegmentDirectory", func(p profileSetupText) string { return p.SegmentDirectory }},
+		{"SegmentEffortThinking", func(p profileSetupText) string { return p.SegmentEffortThinking }},
+		{"SegmentGitBranch", func(p profileSetupText) string { return p.SegmentGitBranch }},
+		{"SegmentGitStatus", func(p profileSetupText) string { return p.SegmentGitStatus }},
+		{"SegmentMoaiVersion", func(p profileSetupText) string { return p.SegmentMoaiVersion }},
+		{"SegmentModel", func(p profileSetupText) string { return p.SegmentModel }},
+		{"SegmentOutputStyle", func(p profileSetupText) string { return p.SegmentOutputStyle }},
+		{"SegmentPR", func(p profileSetupText) string { return p.SegmentPR }},
+		{"SegmentSessionTime", func(p profileSetupText) string { return p.SegmentSessionTime }},
+		{"SegmentTask", func(p profileSetupText) string { return p.SegmentTask }},
+		{"SegmentUsage5h", func(p profileSetupText) string { return p.SegmentUsage5h }},
+		{"SegmentUsage7d", func(p profileSetupText) string { return p.SegmentUsage7d }},
+		{"SegmentWorktree", func(p profileSetupText) string { return p.SegmentWorktree }},
+	}
+	for _, lang := range langs {
+		t.Run(lang, func(t *testing.T) {
+			text := getProfileText(lang)
+			for _, c := range cells {
+				if c.value(text) == "" {
+					t.Errorf("lang %q: %s is empty", lang, c.key)
+				}
+			}
+		})
+	}
+}

--- a/internal/statusline/builder_test.go
+++ b/internal/statusline/builder_test.go
@@ -107,8 +107,8 @@ func TestBuilder_Build_FullData(t *testing.T) {
 	if !strings.Contains(got, "📁 my-project") {
 		t.Errorf("should contain directory, got %q", got)
 	}
-	if !strings.Contains(got, "📬 +3 M2") {
-		t.Errorf("should contain git status, got %q", got)
+	if !strings.Contains(got, "💾 +3 M2") {
+		t.Errorf("should contain git status (unified 💾 emoji), got %q", got)
 	}
 	if !strings.Contains(got, "🗿 v1.2.0") {
 		t.Errorf("should contain MoAI version with moai emoji, got %q", got)

--- a/internal/statusline/builder_test.go
+++ b/internal/statusline/builder_test.go
@@ -298,11 +298,11 @@ func TestBuilder_Build_NoNewline(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Layout v3: without git data, default renders L1 (info incl. directory) + L2 (bars)
-	// = 2 lines (L3 is empty when no git + no repo + no PR).
+	// Layout v3: without git data, default renders L1 (info) + L2 (bars) + L3 (directory)
+	// = 3 lines (directory on L3 head per amend).
 	lines := strings.Split(got, "\n")
-	if len(lines) != 2 {
-		t.Errorf("default without git should be 2 lines (layout v3 — directory moved to L1, L3 empty without git), got %d lines: %q", len(lines), got)
+	if len(lines) != 3 {
+		t.Errorf("default without git should be 3 lines (directory on L3), got %d lines: %q", len(lines), got)
 	}
 }
 

--- a/internal/statusline/builder_test.go
+++ b/internal/statusline/builder_test.go
@@ -81,6 +81,11 @@ func TestBuilder_Build_FullData(t *testing.T) {
 		ContextWindow: &ContextWindowInfo{Used: 50000, Total: 200000},
 		CWD:           "/Users/test/my-project",
 		OutputStyle:   &OutputStyleInfo{Name: "Mr.Alfred"},
+		Workspace: &WorkspaceInfo{
+			CurrentDir: "/Users/test/my-project",
+			ProjectDir: "/Users/test/my-project",
+			Repo:       &RepoInfo{Host: "github.com", Owner: "modu-ai", Name: "moai-adk"},
+		},
 	}
 
 	got, err := builder.Build(context.Background(), makeStdinJSON(input))

--- a/internal/statusline/builder_test.go
+++ b/internal/statusline/builder_test.go
@@ -298,10 +298,11 @@ func TestBuilder_Build_NoNewline(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Without git data, default renders L1 (info) + L2 (bars) + L3 (directory) = 3 lines
+	// Layout v3: without git data, default renders L1 (info incl. directory) + L2 (bars)
+	// = 2 lines (L3 is empty when no git + no repo + no PR).
 	lines := strings.Split(got, "\n")
-	if len(lines) != 3 {
-		t.Errorf("default without git should be 3 lines, got %d lines: %q", len(lines), got)
+	if len(lines) != 2 {
+		t.Errorf("default without git should be 2 lines (layout v3 — directory moved to L1, L3 empty without git), got %d lines: %q", len(lines), got)
 	}
 }
 

--- a/internal/statusline/memory.go
+++ b/internal/statusline/memory.go
@@ -217,9 +217,10 @@ func CollectMemory(input *StdinData) *MemoryData {
 		// Calculate tokens from percentage (of full context window)
 		tokensUsed = int(float64(contextSize) * (*ctx.UsedPercentage) / 100.0)
 		return &MemoryData{
-			TokensUsed:  tokensUsed,
-			TokenBudget: effectiveBudget,
-			Available:   true,
+			TokensUsed:        tokensUsed,
+			TokenBudget:       effectiveBudget,
+			ContextWindowSize: contextSize,
+			Available:         true,
 		}
 	}
 
@@ -228,26 +229,29 @@ func CollectMemory(input *StdinData) *MemoryData {
 		cu := ctx.CurrentUsage
 		tokensUsed = cu.InputTokens + cu.CacheCreationTokens + cu.CacheReadTokens
 		return &MemoryData{
-			TokensUsed:  tokensUsed,
-			TokenBudget: effectiveBudget,
-			Available:   true,
+			TokensUsed:        tokensUsed,
+			TokenBudget:       effectiveBudget,
+			ContextWindowSize: contextSize,
+			Available:         true,
 		}
 	}
 
 	// Priority 3: Fall back to legacy used/total fields
 	if ctx.Used > 0 || ctx.Total > 0 {
 		return &MemoryData{
-			TokensUsed:  ctx.Used,
-			TokenBudget: ctx.Total * threshold / 100,
-			Available:   true,
+			TokensUsed:        ctx.Used,
+			TokenBudget:       ctx.Total * threshold / 100,
+			ContextWindowSize: contextSize,
+			Available:         true,
 		}
 	}
 
 	// No data available - return 0% (session start state)
 	return &MemoryData{
-		TokensUsed:  0,
-		TokenBudget: effectiveBudget,
-		Available:   true,
+		TokensUsed:        0,
+		TokenBudget:       effectiveBudget,
+		ContextWindowSize: contextSize,
+		Available:         true,
 	}
 }
 

--- a/internal/statusline/renderer.go
+++ b/internal/statusline/renderer.go
@@ -281,7 +281,7 @@ func (r *Renderer) renderBarsInline(data *StatusData, width int) string {
 		pct := usagePercent(data.Memory.TokensUsed, data.Memory.TokenBudget)
 		bar := renderUsageBar("CW:", pct, width, r.noColor)
 		if shouldShowHandoffGuide(data) {
-			bar += " ⚠️ /clear"
+			bar += " (⚠️/clear)"
 		}
 		segs = append(segs, bar)
 	}

--- a/internal/statusline/renderer.go
+++ b/internal/statusline/renderer.go
@@ -275,13 +275,13 @@ func renderEffortThinking(data *StatusData) string {
 func (r *Renderer) renderBarsInline(data *StatusData, width int) string {
 	var segs []string
 
-	// CW bar with handoff_guide (/clear) suffix integration (layout v3 CH2).
+	// CW bar with handoff_guide ⚠️ /clear suffix integration (layout v3 CH2).
 	// shouldShowHandoffGuide gates the suffix per 1M ≥50% / 200K ≥90% threshold.
 	if r.isSegmentEnabled(SegmentContext) && data.Memory.Available && data.Memory.TokenBudget > 0 {
 		pct := usagePercent(data.Memory.TokensUsed, data.Memory.TokenBudget)
 		bar := renderUsageBar("CW:", pct, width, r.noColor)
 		if shouldShowHandoffGuide(data) {
-			bar += " (/clear)"
+			bar += " ⚠️ /clear"
 		}
 		segs = append(segs, bar)
 	}

--- a/internal/statusline/renderer.go
+++ b/internal/statusline/renderer.go
@@ -320,7 +320,7 @@ func (r *Renderer) renderBarsInline(data *StatusData, width int) string {
 }
 
 // renderDirGitLine renders the L3 line for layout v3.
-// Format: 🔀 owner/name (branch ↑N +N) │ 📫 +0 M6 ?0 │ [task] │ 💌 PR #1023 (⌥approved)
+// Format: 🔀 owner/name | 🅱️ branch ↑N +N │ 📫 +0 M6 ?0 │ [task] │ 💌 PR #1023 (⌥approved)
 //
 // Layout v3 changes (CH3 + CH5):
 //   - directory moved to L1 end (CH5)
@@ -459,11 +459,11 @@ func (r *Renderer) isPREnabled() bool {
 }
 
 // renderRepoBranchSegment renders the combined repo + branch segment in the
-// form "🔀 owner/name (branch ↑N +N)" — layout v3 CH3.
+// form "🔀 owner/name | 🅱️ branch ↑N +N" — layout v3 CH3.
 //
 // Behavior:
-//   - Workspace.Repo present + Branch present: "🔀 owner/name (branch ↑N +N)"
-//   - Workspace.Repo nil + Branch present:     "🔀 (branch ↑N +N)" (repo prefix omitted)
+//   - Workspace.Repo present + Branch present: "🔀 owner/name | 🅱️ branch ↑N +N"
+//   - Workspace.Repo nil or incomplete:        "" (segment hidden — no git remote context)
 //   - Branch empty:                            "" (empty — no git context)
 //   - Ahead == 0:                              "↑N" portion omitted
 //   - Behind > 0:                              " ↓N" appended after ahead
@@ -471,8 +471,18 @@ func (r *Renderer) isPREnabled() bool {
 //   - Worktree active:                          "[WT] " prefix prepended to branch
 //
 // @MX:NOTE: [AUTO] layout v3 CH3 — replaces standalone renderGitBranch + renderRepoSegment pair.
+// @MX:NOTE: [AUTO] git 미초기화 또는 remote repo 정보 부재 시 segment 전체를 숨긴다 (사용자 요청 2026-05-22).
 func (r *Renderer) renderRepoBranchSegment(data *StatusData) string {
 	if data == nil || !data.Git.Available || data.Git.Branch == "" {
+		return ""
+	}
+
+	// Repo info 누락 시 segment 숨김 (git 미초기화 또는 remote 미설정 케이스).
+	if data.Workspace.Repo == nil {
+		return ""
+	}
+	repo := data.Workspace.Repo
+	if repo.Owner == "" || repo.Name == "" {
 		return ""
 	}
 
@@ -498,17 +508,7 @@ func (r *Renderer) renderRepoBranchSegment(data *StatusData) string {
 	}
 
 	inner := fmt.Sprintf("%s%s%s", branch, aheadBehind, dirtySuffix)
-
-	// Repo prefix when Workspace.Repo available
-	if data.Workspace.Repo != nil {
-		repo := data.Workspace.Repo
-		if repo.Owner != "" && repo.Name != "" {
-			return fmt.Sprintf("🔀 %s/%s (%s)", repo.Owner, repo.Name, inner)
-		}
-	}
-
-	// Fallback: no repo info, just branch in parens with marker
-	return fmt.Sprintf("🔀 (%s)", inner)
+	return fmt.Sprintf("🔀 %s/%s | %s", repo.Owner, repo.Name, inner)
 }
 
 // shouldShowHandoffGuide returns true when accumulated context usage crosses

--- a/internal/statusline/renderer.go
+++ b/internal/statusline/renderer.go
@@ -242,9 +242,14 @@ func (r *Renderer) renderInfoLine(data *StatusData, withPrefix bool) string {
 		}
 	}
 
-	// Output style (moved to end of L1 per user request)
+	// Output style
 	if r.isSegmentEnabled(SegmentOutputStyle) && data.OutputStyle != "" {
 		segs = append(segs, fmt.Sprintf("💬 %s", data.OutputStyle))
+	}
+
+	// Directory (layout v3 CH5: moved from L3 to L1 end)
+	if r.isSegmentEnabled(SegmentDirectory) && data.Directory != "" {
+		segs = append(segs, fmt.Sprintf("📁 %s", data.Directory))
 	}
 
 	return r.joinSegments(segs)
@@ -319,26 +324,23 @@ func (r *Renderer) renderBarsInline(data *StatusData, width int) string {
 	return r.joinSegments(segs)
 }
 
-// renderDirGitLine renders the directory + branch + git status + PR line (default L3, full L5).
-// Format: 📁 moai-adk-go │ 🅱️ main ↑2↓1 +6 │ 📬 +0 M6 ?0 │ #1023 ⌥pending
-// When worktree is active: "[WT] " prefix is prepended to the branch segment.
-// When PR segment is enabled AND stdin contains a valid pr.* object: a PR
-// segment is appended (REQ-SLV-013).
+// renderDirGitLine renders the L3 line for layout v3.
+// Format: 🔀 owner/name (branch ↑N +N) │ 📫 +0 M6 ?0 │ [task] │ 💌 PR #1023 (⌥approved)
+//
+// Layout v3 changes (CH3 + CH5):
+//   - directory moved to L1 end (CH5)
+//   - branch + repo merged into single repo_branch segment (CH3)
+//   - long_context + handoff_guide separate segments removed (CH1, CH2)
+//   - handoff_guide integrated as CW bar (/clear) suffix in renderBarsInline (CH2)
+//   - PR segment last position with new format "💌 PR #N (⌥state)" (CH7, CH8)
 func (r *Renderer) renderDirGitLine(data *StatusData) string {
 	var segs []string
 
-	// Directory
-	if r.isSegmentEnabled(SegmentDirectory) && data.Directory != "" {
-		segs = append(segs, fmt.Sprintf("📁 %s", data.Directory))
-	}
-
-	// Branch + ahead/behind (+ worktree indicator)
+	// Combined repo+branch segment (layout v3 CH3): replaces former
+	// SegmentDirectory (L1 now) + SegmentGitBranch + SegmentRepo trio.
 	if r.isSegmentEnabled(SegmentGitBranch) {
-		if branch := renderGitBranch(data); branch != "" {
-			if r.isSegmentEnabled(SegmentWorktree) && data.Worktree != "" {
-				branch = "[WT] " + branch
-			}
-			segs = append(segs, branch)
+		if rb := r.renderRepoBranchSegment(data); rb != "" {
+			segs = append(segs, rb)
 		}
 	}
 
@@ -357,17 +359,7 @@ func (r *Renderer) renderDirGitLine(data *StatusData) string {
 		segs = append(segs, task)
 	}
 
-	// Repo segment (Claude Code v2.1.145+, REQ-SSE-001/002).
-	// Order: repo → pr → long_context → handoff_guide per plan.md M2.
-	if r.isRepoEnabled() {
-		if repo := renderRepoSegment(data); repo != "" {
-			segs = append(segs, repo)
-		}
-	}
-
-	// PR segment (Claude Code v2.1.145+, REQ-SLV-013) — last position on line 3
-	// per layout v3 (CH7). Long-context + handoff_guide separate segments removed
-	// (CH1, CH2) — handoff_guide is now a CW bar (/clear) suffix in renderBarsInline.
+	// PR segment last position (layout v3 CH7 + CH8 format)
 	if pr := r.renderPRSegment(data); pr != "" {
 		segs = append(segs, pr)
 	}
@@ -466,48 +458,57 @@ func (r *Renderer) isPREnabled() bool {
 	return enabled
 }
 
-// renderRepoSegment renders the GitHub repository identity segment in the
-// form "owner/name" (e.g., "modu-ai/moai-adk") when stdin provides
-// workspace.repo (Claude Code v2.1.145+, REQ-SSE-001).
+// renderRepoBranchSegment renders the combined repo + branch segment in the
+// form "🔀 owner/name (branch ↑N +N)" — layout v3 CH3.
 //
-// Returns empty string when:
-//   - data is nil
-//   - data.Workspace.Repo is nil
-//   - Owner or Name is empty (REQ-SSE-001 strict non-empty check)
+// Behavior:
+//   - Workspace.Repo present + Branch present: "🔀 owner/name (branch ↑N +N)"
+//   - Workspace.Repo nil + Branch present:     "🔀 (branch ↑N +N)" (repo prefix omitted)
+//   - Branch empty:                            "" (empty — no git context)
+//   - Ahead == 0:                              "↑N" portion omitted
+//   - Behind > 0:                              " ↓N" appended after ahead
+//   - Dirty (Modified + Staged + Untracked) == 0: " +N" portion omitted
+//   - Worktree active:                          "[WT] " prefix prepended to branch
 //
-// Format literal: "%s/%s" for Owner/Name interpolation. The Host field is
-// captured by StdinData but not currently surfaced — owner/name alone is the
-// disambiguation key for cross-repo PR segment context.
-//
-// @MX:NOTE: [AUTO] workspace.repo 렌더링 진입점 — v2.1.145+ stdin field, default-on per REQ-SSE-002.
-func renderRepoSegment(data *StatusData) string {
-	if data == nil {
+// @MX:NOTE: [AUTO] layout v3 CH3 — replaces standalone renderGitBranch + renderRepoSegment pair.
+func (r *Renderer) renderRepoBranchSegment(data *StatusData) string {
+	if data == nil || !data.Git.Available || data.Git.Branch == "" {
 		return ""
 	}
-	repo := data.Workspace.Repo
-	if repo == nil {
-		return ""
-	}
-	if repo.Owner == "" || repo.Name == "" {
-		return ""
-	}
-	return fmt.Sprintf("%s/%s", repo.Owner, repo.Name)
-}
 
-// isRepoEnabled returns true when SegmentRepo is enabled in segmentConfig.
-// Default-on for v2.20.0-rc1 per REQ-SSE-002 (follows isPREnabled pattern):
-// unset key resolves to enabled, matching isSegmentEnabled semantics.
-// Graceful no-output handles the no-repo case (Workspace.Repo == nil →
-// renderRepoSegment returns empty).
-func (r *Renderer) isRepoEnabled() bool {
-	if len(r.segmentConfig) == 0 {
-		return true
+	branch := data.Git.Branch
+	if r.isSegmentEnabled(SegmentWorktree) && data.Worktree != "" {
+		branch = "[WT] " + branch
 	}
-	enabled, exists := r.segmentConfig[SegmentRepo]
-	if !exists {
-		return true
+
+	// Ahead/Behind suffix (0 values omitted)
+	var aheadBehind string
+	if data.Git.Ahead > 0 {
+		aheadBehind += fmt.Sprintf(" ↑%d", data.Git.Ahead)
 	}
-	return enabled
+	if data.Git.Behind > 0 {
+		aheadBehind += fmt.Sprintf(" ↓%d", data.Git.Behind)
+	}
+
+	// Dirty count (omitted when 0)
+	dirty := data.Git.Modified + data.Git.Staged + data.Git.Untracked
+	var dirtySuffix string
+	if dirty > 0 {
+		dirtySuffix = fmt.Sprintf(" +%d", dirty)
+	}
+
+	inner := fmt.Sprintf("%s%s%s", branch, aheadBehind, dirtySuffix)
+
+	// Repo prefix when Workspace.Repo available
+	if data.Workspace.Repo != nil {
+		repo := data.Workspace.Repo
+		if repo.Owner != "" && repo.Name != "" {
+			return fmt.Sprintf("🔀 %s/%s (%s)", repo.Owner, repo.Name, inner)
+		}
+	}
+
+	// Fallback: no repo info, just branch in parens with marker
+	return fmt.Sprintf("🔀 (%s)", inner)
 }
 
 // shouldShowHandoffGuide returns true when accumulated context usage crosses
@@ -575,13 +576,14 @@ func (r *Renderer) prReviewStateColor(state string) (lipgloss.Color, bool) {
 // Helper functions
 // ─────────────────────────────────────────────────────────────────────────────
 
-// renderUsageBar renders label + battery icon + gradient bar + percentage.
-// Format: {label} {BatteryIcon(pct)} {BuildGradientBar(pct, width, noColor)} {pct}%
-// Example: CW: 🪫 ████████████████████████████████████░░░░ 88%
+// renderUsageBar renders battery icon + label + gradient bar + percentage.
+// Format: {BatteryIcon(pct)} {label} {BuildGradientBar(pct, width, noColor)} {pct}%
+// Example: 🪫 CW: ████████████████████████████████████░░░░ 88%
+// Layout v3 CH6: icon position moved before label for visual prominence.
 func renderUsageBar(label string, pct int, width int, noColor bool) string {
 	icon := BatteryIcon(pct)
 	bar := BuildGradientBar(pct, width, noColor)
-	return fmt.Sprintf("%s %s %s %d%%", label, icon, bar, pct)
+	return fmt.Sprintf("%s %s %s %d%%", icon, label, bar, pct)
 }
 
 // renderUsageBarWithReset renders a usage bar with optional reset time suffix.

--- a/internal/statusline/renderer.go
+++ b/internal/statusline/renderer.go
@@ -550,33 +550,33 @@ func (r *Renderer) isLongContextEnabled() bool {
 // the model-class threshold and the orchestrator should hint the user toward
 // a /clear handoff (REQ-SSE-005). Threshold table:
 //
-//   - 1M context (TokenBudget == 1,000,000): >=50% usage
-//   - 200K context (TokenBudget == 200,000):  >=90% usage
-//   - other / 0 budget: hidden (safety default — no marker without budget signal)
+//   - 1M context (ContextWindowSize == 1,000,000): >=50% raw usage
+//   - 200K context (ContextWindowSize == 200,000):  >=90% raw usage
+//   - other / 0 window size: hidden (safety default — no marker without raw signal)
 //
-// Note: REQ-SSE-005 originally specified the safety default as "treat unknown
-// budget as 200K (>=90%)", but with TokenBudget == 0 the percentage division
-// is undefined; emitting a marker under that condition is misleading. The
-// implementation chooses "hidden when budget unknown" — strictly safer (no
-// false-positive marker) and the tested behavior in
-// TestRenderHandoffGuideSegment_UnknownBudgetHidden.
+// Uses raw Memory.ContextWindowSize (Claude Code stdin context_window_size)
+// instead of Memory.TokenBudget — TokenBudget is auto-compact-threshold-scaled
+// (e.g., 1M × 85% = 850K) which would never match the raw 1M/200K switch cases.
+// Boundary defect fix: handoff_guide was permanently hidden because production
+// TokenBudget never equals raw class boundaries (only unit tests bypassed this
+// by injecting raw values directly into MemoryData).
 //
 // @MX:NOTE: [AUTO] 1M=50%/200K=90% 임계값 — context-window-management.md HARD rule와 일치.
 func shouldShowHandoffGuide(data *StatusData) bool {
 	if data == nil {
 		return false
 	}
-	budget := data.Memory.TokenBudget
-	if budget <= 0 {
+	cwSize := data.Memory.ContextWindowSize
+	if cwSize <= 0 {
 		return false
 	}
 	used := data.Memory.TokensUsed
-	pct := float64(used) * 100.0 / float64(budget)
-	switch budget {
+	rawPct := float64(used) * 100.0 / float64(cwSize)
+	switch cwSize {
 	case 1_000_000:
-		return pct >= 50.0
+		return rawPct >= 50.0
 	case 200_000:
-		return pct >= 90.0
+		return rawPct >= 90.0
 	default:
 		return false
 	}

--- a/internal/statusline/renderer.go
+++ b/internal/statusline/renderer.go
@@ -748,22 +748,16 @@ func renderSessionTime(ms int) string {
 	return fmt.Sprintf("⏳ %dm", totalMinutes)
 }
 
-// mailboxEmoji returns a single mailbox emoji based on git status priority:
-// 📬(staged) > 📫(modified) > 📪(untracked) > 📭(clean)
+// mailboxEmoji returns a single disk emoji for the git status segment.
+// Layout v3 amend: unified 💾 marker replaces the prior mailbox quartet
+// (📬 staged / 📫 modified / 📪 untracked / 📭 clean) per user request —
+// granular state is conveyed by the trailing "+S MM ?U" counter, so the
+// leading emoji no longer needs to encode state independently.
 func mailboxEmoji(data *StatusData) string {
 	if !data.Git.Available {
 		return ""
 	}
-	if data.Git.Staged > 0 {
-		return "📬"
-	}
-	if data.Git.Modified > 0 {
-		return "📫"
-	}
-	if data.Git.Untracked > 0 {
-		return "📪"
-	}
-	return "📭"
+	return "💾"
 }
 
 // renderGitStatusDetail renders detailed git status string (+N M?N).

--- a/internal/statusline/renderer.go
+++ b/internal/statusline/renderer.go
@@ -242,14 +242,9 @@ func (r *Renderer) renderInfoLine(data *StatusData, withPrefix bool) string {
 		}
 	}
 
-	// Output style
+	// Output style (last L1 segment per layout v3 amend: directory moved back to L3 head)
 	if r.isSegmentEnabled(SegmentOutputStyle) && data.OutputStyle != "" {
 		segs = append(segs, fmt.Sprintf("💬 %s", data.OutputStyle))
-	}
-
-	// Directory (layout v3 CH5: moved from L3 to L1 end)
-	if r.isSegmentEnabled(SegmentDirectory) && data.Directory != "" {
-		segs = append(segs, fmt.Sprintf("📁 %s", data.Directory))
 	}
 
 	return r.joinSegments(segs)
@@ -336,8 +331,13 @@ func (r *Renderer) renderBarsInline(data *StatusData, width int) string {
 func (r *Renderer) renderDirGitLine(data *StatusData) string {
 	var segs []string
 
+	// Directory (layout v3 amend: L3 head — placed before repo_branch)
+	if r.isSegmentEnabled(SegmentDirectory) && data.Directory != "" {
+		segs = append(segs, fmt.Sprintf("📁 %s", data.Directory))
+	}
+
 	// Combined repo+branch segment (layout v3 CH3): replaces former
-	// SegmentDirectory (L1 now) + SegmentGitBranch + SegmentRepo trio.
+	// SegmentGitBranch + SegmentRepo pair.
 	if r.isSegmentEnabled(SegmentGitBranch) {
 		if rb := r.renderRepoBranchSegment(data); rb != "" {
 			segs = append(segs, rb)

--- a/internal/statusline/renderer.go
+++ b/internal/statusline/renderer.go
@@ -476,7 +476,7 @@ func (r *Renderer) renderRepoBranchSegment(data *StatusData) string {
 		return ""
 	}
 
-	branch := data.Git.Branch
+	branch := "🅱️ " + data.Git.Branch
 	if r.isSegmentEnabled(SegmentWorktree) && data.Worktree != "" {
 		branch = "[WT] " + branch
 	}

--- a/internal/statusline/renderer.go
+++ b/internal/statusline/renderer.go
@@ -275,10 +275,15 @@ func renderEffortThinking(data *StatusData) string {
 func (r *Renderer) renderBarsInline(data *StatusData, width int) string {
 	var segs []string
 
-	// CW bar
+	// CW bar with handoff_guide (/clear) suffix integration (layout v3 CH2).
+	// shouldShowHandoffGuide gates the suffix per 1M ≥50% / 200K ≥90% threshold.
 	if r.isSegmentEnabled(SegmentContext) && data.Memory.Available && data.Memory.TokenBudget > 0 {
 		pct := usagePercent(data.Memory.TokensUsed, data.Memory.TokenBudget)
-		segs = append(segs, renderUsageBar("CW:", pct, width, r.noColor))
+		bar := renderUsageBar("CW:", pct, width, r.noColor)
+		if shouldShowHandoffGuide(data) {
+			bar += " (/clear)"
+		}
+		segs = append(segs, bar)
 	}
 
 	// 5H bar - always shown, defaults to 0% when no data.
@@ -360,24 +365,11 @@ func (r *Renderer) renderDirGitLine(data *StatusData) string {
 		}
 	}
 
-	// PR segment (Claude Code v2.1.145+, REQ-SLV-013)
+	// PR segment (Claude Code v2.1.145+, REQ-SLV-013) — last position on line 3
+	// per layout v3 (CH7). Long-context + handoff_guide separate segments removed
+	// (CH1, CH2) — handoff_guide is now a CW bar (/clear) suffix in renderBarsInline.
 	if pr := r.renderPRSegment(data); pr != "" {
 		segs = append(segs, pr)
-	}
-
-	// Long-context Layer 1 visual marker (Claude Code v2.1.139+, REQ-SSE-003/004).
-	if r.isLongContextEnabled() {
-		if lc := renderLongContextSegment(data); lc != "" {
-			segs = append(segs, lc)
-		}
-	}
-
-	// Layer 2 handoff guide hint (REQ-SSE-005/006). Activates at 1M ≥50% or
-	// 200K ≥90% context window usage — co-anchored to context-window-management.md.
-	if r.isHandoffGuideEnabled() {
-		if hg := renderHandoffGuideSegment(data); hg != "" {
-			segs = append(segs, hg)
-		}
 	}
 
 	return r.joinSegments(segs)
@@ -438,15 +430,16 @@ func (r *Renderer) renderPRSegment(data *StatusData) string {
 		return ""
 	}
 
-	// Base segment text: "#<number>"
-	numberText := fmt.Sprintf("#%d", data.PR.Number)
+	// Base segment text: "💌 PR #<number>" (layout v3 CH8)
+	numberText := fmt.Sprintf("💌 PR #%d", data.PR.Number)
 
-	// Review-state suffix: "⌥<state>" (omitted when ReviewState is empty)
+	// Review-state suffix: "(⌥<state>)" — parenthesised per layout v3 CH8
+	// (omitted when ReviewState is empty)
 	state := data.PR.ReviewState
 	if state == "" {
 		return numberText
 	}
-	stateText := fmt.Sprintf("⌥%s", state)
+	stateText := fmt.Sprintf("(⌥%s)", state)
 
 	// Apply color to the review-state suffix only (number stays uncolored)
 	if !r.noColor {
@@ -517,35 +510,6 @@ func (r *Renderer) isRepoEnabled() bool {
 	return enabled
 }
 
-// renderLongContextSegment emits the Layer 1 long-context visual marker
-// "⚠️ long" when stdin reported exceeds_200k_tokens == true (REQ-SSE-004).
-// This is a pure visual signal — no handoff semantics, no escalation.
-//
-// Returns empty string when data is nil or ExceedsLongTokens is false.
-//
-// @MX:NOTE: [AUTO] Layer 1 시각 마커 — v2.1.139+ exceeds_200k_tokens 매핑, Warning 색상.
-func renderLongContextSegment(data *StatusData) string {
-	if data == nil || !data.ExceedsLongTokens {
-		return ""
-	}
-	return "⚠️ long"
-}
-
-// isLongContextEnabled returns true when SegmentLongContext is enabled in
-// segmentConfig. Default-on per REQ-SSE-004 (follows isPREnabled pattern):
-// unset key resolves to enabled. Graceful no-output covers the
-// ExceedsLongTokens=false case via renderLongContextSegment.
-func (r *Renderer) isLongContextEnabled() bool {
-	if len(r.segmentConfig) == 0 {
-		return true
-	}
-	enabled, exists := r.segmentConfig[SegmentLongContext]
-	if !exists {
-		return true
-	}
-	return enabled
-}
-
 // shouldShowHandoffGuide returns true when accumulated context usage crosses
 // the model-class threshold and the orchestrator should hint the user toward
 // a /clear handoff (REQ-SSE-005). Threshold table:
@@ -580,41 +544,6 @@ func shouldShowHandoffGuide(data *StatusData) bool {
 	default:
 		return false
 	}
-}
-
-// renderHandoffGuideSegment emits the Layer 2 paste-ready handoff hint
-// "📋 /clear" when shouldShowHandoffGuide is true AND the segment is enabled
-// (REQ-SSE-006). The user pastes the orchestrator-generated resume message
-// after running /clear; see session-handoff.md canonical format.
-//
-// Returns empty string when:
-//   - data is nil
-//   - shouldShowHandoffGuide(data) returns false
-//
-// Enable-gating is performed by isHandoffGuideEnabled at the call site
-// inside renderDirGitLine — this function itself only enforces the
-// threshold semantics.
-//
-// @MX:NOTE: [AUTO] Layer 2 handoff hint — 임계값 진입 시 /clear 권고 마커.
-func renderHandoffGuideSegment(data *StatusData) string {
-	if !shouldShowHandoffGuide(data) {
-		return ""
-	}
-	return "📋 /clear"
-}
-
-// isHandoffGuideEnabled returns true when SegmentHandoffGuide is enabled
-// in segmentConfig. Default-on per REQ-SSE-006 (follows isPREnabled
-// pattern): unset key resolves to enabled.
-func (r *Renderer) isHandoffGuideEnabled() bool {
-	if len(r.segmentConfig) == 0 {
-		return true
-	}
-	enabled, exists := r.segmentConfig[SegmentHandoffGuide]
-	if !exists {
-		return true
-	}
-	return enabled
 }
 
 // prReviewStateColor maps a Claude Code v2.1.145 review_state value to a

--- a/internal/statusline/renderer_test.go
+++ b/internal/statusline/renderer_test.go
@@ -875,14 +875,10 @@ func TestRenderDefaultV3_Line3(t *testing.T) {
 	got := r.Render(data, ModeDefault)
 	lines := strings.Split(got, "\n")
 	l3 := lines[2]
-	l1 := lines[0]
 
-	// Layout v3 CH5: directory moved to L1 end (not L3).
-	if !strings.Contains(l1, "📁 moai-adk-go") {
-		t.Errorf("default L1 must contain directory (layout v3 CH5), got: %q", l1)
-	}
-	if strings.Contains(l3, "📁") {
-		t.Errorf("default L3 must NOT contain directory (moved to L1 by CH5), got: %q", l3)
+	// Layout v3 amend: directory back on L3 head (before repo_branch).
+	if !strings.Contains(l3, "📁 moai-adk-go") {
+		t.Errorf("default L3 must contain directory at head, got: %q", l3)
 	}
 	// Layout v3 CH3: combined repo+branch segment "🔀 (branch ↑N ↓N +N)"
 	// (no Workspace.Repo in fixture → owner/name portion omitted).

--- a/internal/statusline/renderer_test.go
+++ b/internal/statusline/renderer_test.go
@@ -44,6 +44,9 @@ func TestRender_DefaultMode(t *testing.T) {
 		Directory:   "moai-adk-go",
 		OutputStyle: "Mr.Alfred",
 		Version:     VersionData{Current: "1.14.5", Available: true},
+		Workspace: WorkspaceData{
+			Repo: &RepoInfo{Host: "github.com", Owner: "modu-ai", Name: "moai-adk"},
+		},
 	}
 
 	got := r.Render(data, ModeDefault)
@@ -226,6 +229,9 @@ func TestRender_EmptyMemory(t *testing.T) {
 		Git:     GitStatusData{Branch: "main", Modified: 2, Available: true},
 		Memory:  MemoryData{Available: false},
 		Metrics: MetricsData{Model: "Sonnet 3.5", Available: true},
+		Workspace: WorkspaceData{
+			Repo: &RepoInfo{Host: "github.com", Owner: "modu-ai", Name: "moai-adk"},
+		},
 	}
 
 	got := r.Render(data, ModeDefault)
@@ -269,14 +275,34 @@ func TestRender_GitOnlyBranch(t *testing.T) {
 	data := &StatusData{
 		Git:    GitStatusData{Branch: "main", Staged: 0, Modified: 0, Untracked: 0, Available: true},
 		Memory: MemoryData{TokensUsed: 50000, TokenBudget: 200000, Available: true},
+		Workspace: WorkspaceData{
+			Repo: &RepoInfo{Host: "github.com", Owner: "modu-ai", Name: "moai-adk"},
+		},
 	}
 
 	got := r.Render(data, ModeDefault)
 
-	// Layout v3 CH3: branch shown via combined repo_branch segment "🔀 (🅱️ main)"
-	// (no Workspace.Repo → owner/name portion omitted; clean → no dirty suffix).
-	if !strings.Contains(got, "🔀 (🅱️ main)") && !strings.Contains(got, "📭 main +0") {
-		t.Errorf("should show clean branch as '🔀 (🅱️ main)' or '📭 main +0', got %q", got)
+	// Layout v3 CH3 (2026-05-22 정정): repo info 존재 → "🔀 owner/name | 🅱️ branch" 형식.
+	// clean → no dirty suffix.
+	if !strings.Contains(got, "🔀 modu-ai/moai-adk | 🅱️ main") && !strings.Contains(got, "📭 main +0") {
+		t.Errorf("should show clean branch as '🔀 modu-ai/moai-adk | 🅱️ main' or '📭 main +0', got %q", got)
+	}
+}
+
+// TestRender_GitOnlyBranch_NoRepo verifies the 🔀 segment is hidden entirely
+// when Workspace.Repo is nil (git not initialized or no remote configured).
+// User policy 2026-05-22: hide segment to avoid "🔀 (🅱️ main)" partial display.
+func TestRender_GitOnlyBranch_NoRepo(t *testing.T) {
+	r := newTestRenderer()
+	data := &StatusData{
+		Git:    GitStatusData{Branch: "main", Staged: 0, Modified: 0, Untracked: 0, Available: true},
+		Memory: MemoryData{TokensUsed: 50000, TokenBudget: 200000, Available: true},
+	}
+
+	got := r.Render(data, ModeDefault)
+
+	if strings.Contains(got, "🔀") {
+		t.Errorf("repo info absent → 🔀 segment must be hidden, got %q", got)
 	}
 }
 
@@ -514,6 +540,9 @@ func TestRender_SegmentFiltering(t *testing.T) {
 		OutputStyle:       "MoAI",
 		ClaudeCodeVersion: "1.0.80",
 		Version:           VersionData{Current: "2.3.1", Available: true},
+		Workspace: WorkspaceData{
+			Repo: &RepoInfo{Host: "github.com", Owner: "modu-ai", Name: "moai-adk"},
+		},
 	}
 
 	tests := []struct {
@@ -870,6 +899,9 @@ func TestRenderDefaultV3_Line3(t *testing.T) {
 			Untracked: 1,
 			Available: true,
 		},
+		Workspace: WorkspaceData{
+			Repo: &RepoInfo{Host: "github.com", Owner: "modu-ai", Name: "moai-adk"},
+		},
 	}
 
 	got := r.Render(data, ModeDefault)
@@ -880,11 +912,11 @@ func TestRenderDefaultV3_Line3(t *testing.T) {
 	if !strings.Contains(l3, "📁 moai-adk-go") {
 		t.Errorf("default L3 must contain directory at head, got: %q", l3)
 	}
-	// Layout v3 CH3: combined repo+branch segment "🔀 (branch ↑N ↓N +N)"
-	// (no Workspace.Repo in fixture → owner/name portion omitted).
+	// Layout v3 CH3 (2026-05-22 정정): combined repo+branch segment
+	// "🔀 owner/name | 🅱️ branch ↑N ↓N +N" (pipe separator, repo prefix required).
 	// dirty = Staged(3) + Modified(2) + Untracked(1) = 6
-	if !strings.Contains(l3, "🔀 (🅱️ feat/auth ↑2 ↓1 +6)") {
-		t.Errorf("default L3 must contain combined repo_branch segment with 🅱️ prefix, got: %q", l3)
+	if !strings.Contains(l3, "🔀 modu-ai/moai-adk | 🅱️ feat/auth ↑2 ↓1 +6") {
+		t.Errorf("default L3 must contain combined repo_branch segment with pipe separator, got: %q", l3)
 	}
 	if strings.Contains(l3, "📦") || strings.Contains(l3, "🔨") {
 		t.Errorf("default L3 must not contain legacy 📦/🔨 prefix, got: %q", l3)
@@ -1221,6 +1253,9 @@ func TestRenderDirGitLine_WorktreeIndicator(t *testing.T) {
 				Git:       GitStatusData{Branch: "feat/test", Available: true},
 				Directory: "myproject",
 				Worktree:  tt.worktree,
+				Workspace: WorkspaceData{
+					Repo: &RepoInfo{Host: "github.com", Owner: "modu-ai", Name: "moai-adk"},
+				},
 			}
 			got := r.renderDirGitLine(data)
 			// Legacy emoji must never appear regardless of state.
@@ -1584,6 +1619,9 @@ func TestRenderDirGitLine_PRSegment(t *testing.T) {
 				Git:       GitStatusData{Branch: "feat/x", Available: true},
 				Directory: "myproject",
 				PR:        tt.pr,
+				Workspace: WorkspaceData{
+					Repo: &RepoInfo{Host: "github.com", Owner: "modu-ai", Name: "moai-adk"},
+				},
 			}
 			got := r.renderDirGitLine(data)
 			for _, want := range tt.wantContains {

--- a/internal/statusline/renderer_test.go
+++ b/internal/statusline/renderer_test.go
@@ -1341,32 +1341,32 @@ func TestRenderPRSegment_Format(t *testing.T) {
 		{
 			name: "approved pr 1023",
 			pr:   &PRInfo{Number: 1023, URL: "https://x/pull/1023", ReviewState: "approved"},
-			want: "#1023 ⌥approved",
+			want: "💌 PR #1023 (⌥approved)",
 		},
 		{
 			name: "pending pr 42",
 			pr:   &PRInfo{Number: 42, URL: "https://x/pull/42", ReviewState: "pending"},
-			want: "#42 ⌥pending",
+			want: "💌 PR #42 (⌥pending)",
 		},
 		{
 			name: "changes_requested pr 7",
 			pr:   &PRInfo{Number: 7, URL: "https://x/pull/7", ReviewState: "changes_requested"},
-			want: "#7 ⌥changes_requested",
+			want: "💌 PR #7 (⌥changes_requested)",
 		},
 		{
 			name: "draft pr 99",
 			pr:   &PRInfo{Number: 99, URL: "https://x/pull/99", ReviewState: "draft"},
-			want: "#99 ⌥draft",
+			want: "💌 PR #99 (⌥draft)",
 		},
 		{
 			name: "empty url tolerated",
 			pr:   &PRInfo{Number: 50, URL: "", ReviewState: "approved"},
-			want: "#50 ⌥approved",
+			want: "💌 PR #50 (⌥approved)",
 		},
 		{
 			name: "empty review_state: no marker",
 			pr:   &PRInfo{Number: 100, URL: "https://x/pull/100", ReviewState: ""},
-			want: "#100",
+			want: "💌 PR #100",
 		},
 	}
 

--- a/internal/statusline/renderer_test.go
+++ b/internal/statusline/renderer_test.go
@@ -273,10 +273,10 @@ func TestRender_GitOnlyBranch(t *testing.T) {
 
 	got := r.Render(data, ModeDefault)
 
-	// Layout v3 CH3: branch shown via combined repo_branch segment "🔀 (main)"
+	// Layout v3 CH3: branch shown via combined repo_branch segment "🔀 (🅱️ main)"
 	// (no Workspace.Repo → owner/name portion omitted; clean → no dirty suffix).
-	if !strings.Contains(got, "🔀 (main)") && !strings.Contains(got, "📭 main +0") {
-		t.Errorf("should show clean branch as '🔀 (main)' or '📭 main +0', got %q", got)
+	if !strings.Contains(got, "🔀 (🅱️ main)") && !strings.Contains(got, "📭 main +0") {
+		t.Errorf("should show clean branch as '🔀 (🅱️ main)' or '📭 main +0', got %q", got)
 	}
 }
 
@@ -883,8 +883,8 @@ func TestRenderDefaultV3_Line3(t *testing.T) {
 	// Layout v3 CH3: combined repo+branch segment "🔀 (branch ↑N ↓N +N)"
 	// (no Workspace.Repo in fixture → owner/name portion omitted).
 	// dirty = Staged(3) + Modified(2) + Untracked(1) = 6
-	if !strings.Contains(l3, "🔀 (feat/auth ↑2 ↓1 +6)") {
-		t.Errorf("default L3 must contain combined repo_branch segment (layout v3 CH3), got: %q", l3)
+	if !strings.Contains(l3, "🔀 (🅱️ feat/auth ↑2 ↓1 +6)") {
+		t.Errorf("default L3 must contain combined repo_branch segment with 🅱️ prefix, got: %q", l3)
 	}
 	if strings.Contains(l3, "📦") || strings.Contains(l3, "🔨") {
 		t.Errorf("default L3 must not contain legacy 📦/🔨 prefix, got: %q", l3)

--- a/internal/statusline/renderer_test.go
+++ b/internal/statusline/renderer_test.go
@@ -273,8 +273,10 @@ func TestRender_GitOnlyBranch(t *testing.T) {
 
 	got := r.Render(data, ModeDefault)
 
-	if !strings.Contains(got, "🅱️ main +0") && !strings.Contains(got, "📭 main +0") {
-		t.Errorf("should show clean branch as '🅱️ main +0' or '📭 main +0', got %q", got)
+	// Layout v3 CH3: branch shown via combined repo_branch segment "🔀 (main)"
+	// (no Workspace.Repo → owner/name portion omitted; clean → no dirty suffix).
+	if !strings.Contains(got, "🔀 (main)") && !strings.Contains(got, "📭 main +0") {
+		t.Errorf("should show clean branch as '🔀 (main)' or '📭 main +0', got %q", got)
 	}
 }
 
@@ -523,12 +525,12 @@ func TestRender_SegmentFiltering(t *testing.T) {
 		{
 			name:          "nil config shows all segments",
 			segmentConfig: nil,
-			wantContain:   []string{"🤖 Opus 4.5", "🔋", "💬 MoAI", "📁 moai-adk-go", "🅱️", "v1.0.80", "🗿 v2.3.1", "main"},
+			wantContain:   []string{"🤖 Opus 4.5", "🔋", "💬 MoAI", "📁 moai-adk-go", "🔀", "v1.0.80", "🗿 v2.3.1", "main"},
 		},
 		{
 			name:          "empty config shows all segments",
 			segmentConfig: map[string]bool{},
-			wantContain:   []string{"🤖 Opus 4.5", "🔋", "💬 MoAI", "📁 moai-adk-go", "🅱️", "v1.0.80", "🗿 v2.3.1", "main"},
+			wantContain:   []string{"🤖 Opus 4.5", "🔋", "💬 MoAI", "📁 moai-adk-go", "🔀", "v1.0.80", "🗿 v2.3.1", "main"},
 		},
 		{
 			name: "model disabled hides model",
@@ -547,7 +549,7 @@ func TestRender_SegmentFiltering(t *testing.T) {
 				SegmentDirectory: false, SegmentGitStatus: true, SegmentClaudeVersion: false,
 				SegmentMoaiVersion: false, SegmentGitBranch: true,
 			},
-			wantContain:    []string{"🤖 Opus 4.5", "🔋", "🅱️", "main"},
+			wantContain:    []string{"🤖 Opus 4.5", "🔋", "🔀", "main"},
 			wantNotContain: []string{"💬", "📁", "🔅", "🗿"},
 		},
 		{
@@ -873,14 +875,20 @@ func TestRenderDefaultV3_Line3(t *testing.T) {
 	got := r.Render(data, ModeDefault)
 	lines := strings.Split(got, "\n")
 	l3 := lines[2]
+	l1 := lines[0]
 
-	if !strings.Contains(l3, "📁 moai-adk-go") {
-		t.Errorf("default L3 must contain directory, got: %q", l3)
+	// Layout v3 CH5: directory moved to L1 end (not L3).
+	if !strings.Contains(l1, "📁 moai-adk-go") {
+		t.Errorf("default L1 must contain directory (layout v3 CH5), got: %q", l1)
 	}
-	// Branch segment: 🅱️ <name> ↑<ahead> ↓<behind> +<dirty>
+	if strings.Contains(l3, "📁") {
+		t.Errorf("default L3 must NOT contain directory (moved to L1 by CH5), got: %q", l3)
+	}
+	// Layout v3 CH3: combined repo+branch segment "🔀 (branch ↑N ↓N +N)"
+	// (no Workspace.Repo in fixture → owner/name portion omitted).
 	// dirty = Staged(3) + Modified(2) + Untracked(1) = 6
-	if !strings.Contains(l3, "🅱️ feat/auth ↑2 ↓1 +6") {
-		t.Errorf("default L3 must contain branch with ahead/behind and dirty count, got: %q", l3)
+	if !strings.Contains(l3, "🔀 (feat/auth ↑2 ↓1 +6)") {
+		t.Errorf("default L3 must contain combined repo_branch segment (layout v3 CH3), got: %q", l3)
 	}
 	if strings.Contains(l3, "📦") || strings.Contains(l3, "🔨") {
 		t.Errorf("default L3 must not contain legacy 📦/🔨 prefix, got: %q", l3)
@@ -1050,7 +1058,7 @@ func TestRenderUsageBar(t *testing.T) {
 			pct:     88,
 			width:   10,
 			noColor: true,
-			wantPfx: "CW: 🪫",
+			wantPfx: "🪫 CW:",
 		},
 		{
 			name:    "5H 45% noColor",
@@ -1058,7 +1066,7 @@ func TestRenderUsageBar(t *testing.T) {
 			pct:     45,
 			width:   10,
 			noColor: true,
-			wantPfx: "5H: 🔋",
+			wantPfx: "🔋 5H:",
 		},
 	}
 
@@ -1557,7 +1565,7 @@ func TestRenderDirGitLine_PRSegment(t *testing.T) {
 				SegmentGitBranch: true,
 				SegmentPR:        false,
 			},
-			wantContains: []string{"📁"},
+			wantContains: []string{"🔀"},
 			wantAbsent:   []string{"#1023", "⌥"},
 		},
 		{
@@ -1568,7 +1576,7 @@ func TestRenderDirGitLine_PRSegment(t *testing.T) {
 				SegmentGitBranch: true,
 				SegmentPR:        true,
 			},
-			wantContains: []string{"📁"},
+			wantContains: []string{"🔀"},
 			wantAbsent:   []string{"#", "⌥"},
 		},
 	}

--- a/internal/statusline/stdinfields_test.go
+++ b/internal/statusline/stdinfields_test.go
@@ -13,74 +13,12 @@ import (
 	"testing"
 )
 
-// ---------- REQ-SSE-001/002: renderRepoSegment ----------
-
-func TestRenderRepoSegment_PopulatedShowsOwnerName(t *testing.T) {
-	t.Parallel()
-
-	data := &StatusData{
-		Workspace: WorkspaceData{
-			Repo: &RepoInfo{
-				Host:  "github.com",
-				Owner: "modu-ai",
-				Name:  "moai-adk",
-			},
-		},
-	}
-
-	out := renderRepoSegment(data)
-	if !strings.Contains(out, "modu-ai/moai-adk") {
-		t.Fatalf("expected output to contain owner/name marker %q, got %q", "modu-ai/moai-adk", out)
-	}
-}
-
-func TestRenderRepoSegment_NilRepoReturnsEmpty(t *testing.T) {
-	t.Parallel()
-
-	data := &StatusData{
-		Workspace: WorkspaceData{Repo: nil},
-	}
-
-	out := renderRepoSegment(data)
-	if out != "" {
-		t.Fatalf("expected empty output when Workspace.Repo is nil, got %q", out)
-	}
-}
-
-func TestRenderRepoSegment_EmptyOwnerReturnsEmpty(t *testing.T) {
-	t.Parallel()
-
-	data := &StatusData{
-		Workspace: WorkspaceData{Repo: &RepoInfo{Host: "github.com", Owner: "", Name: "moai-adk"}},
-	}
-
-	out := renderRepoSegment(data)
-	if out != "" {
-		t.Fatalf("expected empty output when Owner is empty, got %q", out)
-	}
-}
-
-func TestRenderRepoSegment_EmptyNameReturnsEmpty(t *testing.T) {
-	t.Parallel()
-
-	data := &StatusData{
-		Workspace: WorkspaceData{Repo: &RepoInfo{Host: "github.com", Owner: "modu-ai", Name: ""}},
-	}
-
-	out := renderRepoSegment(data)
-	if out != "" {
-		t.Fatalf("expected empty output when Name is empty, got %q", out)
-	}
-}
-
-func TestRenderRepoSegment_NilDataReturnsEmpty(t *testing.T) {
-	t.Parallel()
-
-	out := renderRepoSegment(nil)
-	if out != "" {
-		t.Fatalf("expected empty output when data is nil, got %q", out)
-	}
-}
+// NOTE: TestRenderRepoSegment_* removed (layout v3 CH3). The standalone
+// renderRepoSegment function was replaced by renderRepoBranchSegment which
+// combines repo identity with branch info into a single L3 segment. The new
+// segment is covered by end-to-end fixture verification via
+// /Users/goos/go/bin/moai statusline; unit-level coverage may be added later
+// when the function signature stabilizes.
 
 // NOTE: renderLongContextSegment + renderHandoffGuideSegment tests removed
 // (layout v3 CH1 + CH2). The ⚠️ long marker segment was removed per user
@@ -180,30 +118,9 @@ func TestShouldShowHandoffGuide_NilDataFalse(t *testing.T) {
 
 // ---------- isXxxEnabled predicate edge cases (default-on contract) ----------
 
-// TestIsRepoEnabled_DefaultOnContract verifies REQ-SSE-002 default-on
-// activation across the three documented config states.
-func TestIsRepoEnabled_DefaultOnContract(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		name string
-		cfg  map[string]bool
-		want bool
-	}{
-		{"nil config → enabled", nil, true},
-		{"unset key → enabled (default-on)", map[string]bool{SegmentPR: true}, true},
-		{"explicit false → disabled", map[string]bool{SegmentRepo: false}, false},
-		{"explicit true → enabled", map[string]bool{SegmentRepo: true}, true},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			r := NewRenderer("default", true, tc.cfg)
-			if got := r.isRepoEnabled(); got != tc.want {
-				t.Errorf("isRepoEnabled() = %v, want %v", got, tc.want)
-			}
-		})
-	}
-}
+// NOTE: TestIsRepoEnabled_DefaultOnContract removed (layout v3 CH3).
+// The isRepoEnabled predicate was retired with renderRepoSegment.
+// renderRepoBranchSegment is gated by SegmentGitBranch (combined segment).
 
 // NOTE: TestIsLongContextEnabled_DefaultOnContract +
 // TestIsHandoffGuideEnabled_DefaultOnContract removed (layout v3 CH1 + CH2).

--- a/internal/statusline/stdinfields_test.go
+++ b/internal/statusline/stdinfields_test.go
@@ -82,137 +82,99 @@ func TestRenderRepoSegment_NilDataReturnsEmpty(t *testing.T) {
 	}
 }
 
-// ---------- REQ-SSE-003/004: renderLongContextSegment + ExceedsLongTokens ----------
+// NOTE: renderLongContextSegment + renderHandoffGuideSegment tests removed
+// (layout v3 CH1 + CH2). The ⚠️ long marker segment was removed per user
+// explicit request; handoff_guide is now integrated as a CW bar (/clear)
+// suffix in renderBarsInline. shouldShowHandoffGuide threshold helper is
+// preserved and tested via TestShouldShowHandoffGuide below.
 
-func TestRenderLongContextSegment_TrueShowsMarker(t *testing.T) {
+// ---------- shouldShowHandoffGuide threshold helper (preserved per CH2) ----------
+
+func TestShouldShowHandoffGuide_OneMillionFiftyPercentTrue(t *testing.T) {
 	t.Parallel()
 
-	data := &StatusData{ExceedsLongTokens: true}
-
-	out := renderLongContextSegment(data)
-	if !strings.Contains(out, "⚠️") || !strings.Contains(out, "long") {
-		t.Fatalf("expected output to contain ⚠️ and 'long' markers, got %q", out)
-	}
-}
-
-func TestRenderLongContextSegment_FalseReturnsEmpty(t *testing.T) {
-	t.Parallel()
-
-	data := &StatusData{ExceedsLongTokens: false}
-
-	out := renderLongContextSegment(data)
-	if out != "" {
-		t.Fatalf("expected empty output when ExceedsLongTokens is false, got %q", out)
-	}
-}
-
-func TestRenderLongContextSegment_NilDataReturnsEmpty(t *testing.T) {
-	t.Parallel()
-
-	out := renderLongContextSegment(nil)
-	if out != "" {
-		t.Fatalf("expected empty output when data is nil, got %q", out)
-	}
-}
-
-// ---------- REQ-SSE-005/006: renderHandoffGuideSegment ----------
-
-func TestRenderHandoffGuideSegment_OneMillionFiftyPercentShows(t *testing.T) {
-	t.Parallel()
-
-	// 1M budget, 50% usage = 500,000 tokens → should show
 	data := &StatusData{
 		Memory: MemoryData{
 			ContextWindowSize: 1_000_000,
-			TokensUsed:  500_000,
-			Available:   true,
+			TokensUsed:        500_000,
+			Available:         true,
 		},
 	}
 
-	out := renderHandoffGuideSegment(data)
-	if out == "" {
-		t.Fatalf("expected non-empty handoff guide for 1M @ 50%%, got empty")
+	if !shouldShowHandoffGuide(data) {
+		t.Fatalf("expected true for 1M @ 50%%, got false")
 	}
 }
 
-func TestRenderHandoffGuideSegment_OneMillionFortyNinePercentHidden(t *testing.T) {
+func TestShouldShowHandoffGuide_OneMillionFortyNinePercentFalse(t *testing.T) {
 	t.Parallel()
 
-	// 1M budget, 49% usage = 490,000 tokens → should hide
 	data := &StatusData{
 		Memory: MemoryData{
 			ContextWindowSize: 1_000_000,
-			TokensUsed:  490_000,
-			Available:   true,
+			TokensUsed:        490_000,
+			Available:         true,
 		},
 	}
 
-	out := renderHandoffGuideSegment(data)
-	if out != "" {
-		t.Fatalf("expected empty handoff guide for 1M @ 49%%, got %q", out)
+	if shouldShowHandoffGuide(data) {
+		t.Fatalf("expected false for 1M @ 49%%, got true")
 	}
 }
 
-func TestRenderHandoffGuideSegment_TwoHundredKNinetyPercentShows(t *testing.T) {
+func TestShouldShowHandoffGuide_TwoHundredKNinetyPercentTrue(t *testing.T) {
 	t.Parallel()
 
-	// 200K budget, 90% usage = 180,000 tokens → should show
 	data := &StatusData{
 		Memory: MemoryData{
 			ContextWindowSize: 200_000,
-			TokensUsed:  180_000,
-			Available:   true,
+			TokensUsed:        180_000,
+			Available:         true,
 		},
 	}
 
-	out := renderHandoffGuideSegment(data)
-	if out == "" {
-		t.Fatalf("expected non-empty handoff guide for 200K @ 90%%, got empty")
+	if !shouldShowHandoffGuide(data) {
+		t.Fatalf("expected true for 200K @ 90%%, got false")
 	}
 }
 
-func TestRenderHandoffGuideSegment_TwoHundredKEightyNinePercentHidden(t *testing.T) {
+func TestShouldShowHandoffGuide_TwoHundredKEightyNinePercentFalse(t *testing.T) {
 	t.Parallel()
 
-	// 200K budget, 89% usage = 178,000 tokens → should hide
 	data := &StatusData{
 		Memory: MemoryData{
 			ContextWindowSize: 200_000,
-			TokensUsed:  178_000,
-			Available:   true,
+			TokensUsed:        178_000,
+			Available:         true,
 		},
 	}
 
-	out := renderHandoffGuideSegment(data)
-	if out != "" {
-		t.Fatalf("expected empty handoff guide for 200K @ 89%%, got %q", out)
+	if shouldShowHandoffGuide(data) {
+		t.Fatalf("expected false for 200K @ 89%%, got true")
 	}
 }
 
-func TestRenderHandoffGuideSegment_UnknownBudgetHidden(t *testing.T) {
+func TestShouldShowHandoffGuide_UnknownCwSizeFalse(t *testing.T) {
 	t.Parallel()
 
-	// Budget not in {200000, 1000000} (e.g., zero / unknown) → should hide
 	data := &StatusData{
 		Memory: MemoryData{
 			ContextWindowSize: 0,
-			TokensUsed:  100_000,
-			Available:   false,
+			TokensUsed:        100_000,
+			Available:         false,
 		},
 	}
 
-	out := renderHandoffGuideSegment(data)
-	if out != "" {
-		t.Fatalf("expected empty handoff guide for unknown budget, got %q", out)
+	if shouldShowHandoffGuide(data) {
+		t.Fatalf("expected false for unknown context window size, got true")
 	}
 }
 
-func TestRenderHandoffGuideSegment_NilDataReturnsEmpty(t *testing.T) {
+func TestShouldShowHandoffGuide_NilDataFalse(t *testing.T) {
 	t.Parallel()
 
-	out := renderHandoffGuideSegment(nil)
-	if out != "" {
-		t.Fatalf("expected empty handoff guide for nil data, got %q", out)
+	if shouldShowHandoffGuide(nil) {
+		t.Fatalf("expected false for nil data, got true")
 	}
 }
 
@@ -243,53 +205,11 @@ func TestIsRepoEnabled_DefaultOnContract(t *testing.T) {
 	}
 }
 
-// TestIsLongContextEnabled_DefaultOnContract verifies REQ-SSE-004 default-on.
-func TestIsLongContextEnabled_DefaultOnContract(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		name string
-		cfg  map[string]bool
-		want bool
-	}{
-		{"nil config → enabled", nil, true},
-		{"unset key → enabled", map[string]bool{SegmentPR: true}, true},
-		{"explicit false → disabled", map[string]bool{SegmentLongContext: false}, false},
-		{"explicit true → enabled", map[string]bool{SegmentLongContext: true}, true},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			r := NewRenderer("default", true, tc.cfg)
-			if got := r.isLongContextEnabled(); got != tc.want {
-				t.Errorf("isLongContextEnabled() = %v, want %v", got, tc.want)
-			}
-		})
-	}
-}
-
-// TestIsHandoffGuideEnabled_DefaultOnContract verifies REQ-SSE-006 default-on.
-func TestIsHandoffGuideEnabled_DefaultOnContract(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		name string
-		cfg  map[string]bool
-		want bool
-	}{
-		{"nil config → enabled", nil, true},
-		{"unset key → enabled", map[string]bool{SegmentPR: true}, true},
-		{"explicit false → disabled", map[string]bool{SegmentHandoffGuide: false}, false},
-		{"explicit true → enabled", map[string]bool{SegmentHandoffGuide: true}, true},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			r := NewRenderer("default", true, tc.cfg)
-			if got := r.isHandoffGuideEnabled(); got != tc.want {
-				t.Errorf("isHandoffGuideEnabled() = %v, want %v", got, tc.want)
-			}
-		})
-	}
-}
+// NOTE: TestIsLongContextEnabled_DefaultOnContract +
+// TestIsHandoffGuideEnabled_DefaultOnContract removed (layout v3 CH1 + CH2).
+// The corresponding isLongContextEnabled + isHandoffGuideEnabled predicate
+// functions were removed; segment config keys SegmentLongContext +
+// SegmentHandoffGuide no longer exist.
 
 // TestCollectAll_RepoAndExceedsLongPropagation verifies REQ-SSE-001/003 wiring
 // from StdinData → StatusData via builder.collectAll.

--- a/internal/statusline/stdinfields_test.go
+++ b/internal/statusline/stdinfields_test.go
@@ -123,7 +123,7 @@ func TestRenderHandoffGuideSegment_OneMillionFiftyPercentShows(t *testing.T) {
 	// 1M budget, 50% usage = 500,000 tokens → should show
 	data := &StatusData{
 		Memory: MemoryData{
-			TokenBudget: 1_000_000,
+			ContextWindowSize: 1_000_000,
 			TokensUsed:  500_000,
 			Available:   true,
 		},
@@ -141,7 +141,7 @@ func TestRenderHandoffGuideSegment_OneMillionFortyNinePercentHidden(t *testing.T
 	// 1M budget, 49% usage = 490,000 tokens → should hide
 	data := &StatusData{
 		Memory: MemoryData{
-			TokenBudget: 1_000_000,
+			ContextWindowSize: 1_000_000,
 			TokensUsed:  490_000,
 			Available:   true,
 		},
@@ -159,7 +159,7 @@ func TestRenderHandoffGuideSegment_TwoHundredKNinetyPercentShows(t *testing.T) {
 	// 200K budget, 90% usage = 180,000 tokens → should show
 	data := &StatusData{
 		Memory: MemoryData{
-			TokenBudget: 200_000,
+			ContextWindowSize: 200_000,
 			TokensUsed:  180_000,
 			Available:   true,
 		},
@@ -177,7 +177,7 @@ func TestRenderHandoffGuideSegment_TwoHundredKEightyNinePercentHidden(t *testing
 	// 200K budget, 89% usage = 178,000 tokens → should hide
 	data := &StatusData{
 		Memory: MemoryData{
-			TokenBudget: 200_000,
+			ContextWindowSize: 200_000,
 			TokensUsed:  178_000,
 			Available:   true,
 		},
@@ -195,7 +195,7 @@ func TestRenderHandoffGuideSegment_UnknownBudgetHidden(t *testing.T) {
 	// Budget not in {200000, 1000000} (e.g., zero / unknown) → should hide
 	data := &StatusData{
 		Memory: MemoryData{
-			TokenBudget: 0,
+			ContextWindowSize: 0,
 			TokensUsed:  100_000,
 			Available:   false,
 		},

--- a/internal/statusline/types.go
+++ b/internal/statusline/types.go
@@ -269,9 +269,10 @@ type GitStatusData struct {
 
 // MemoryData holds context window token usage information.
 type MemoryData struct {
-	TokensUsed  int
-	TokenBudget int
-	Available   bool
+	TokensUsed        int
+	TokenBudget       int // Scaled to auto-compact threshold for CW bar (e.g., 1M × 85% = 850K)
+	ContextWindowSize int // Raw context_window_size from Claude Code stdin (1M / 200K) — used by handoff_guide threshold matching
+	Available         bool
 }
 
 // MetricsData holds session cost and model information.

--- a/internal/statusline/types.go
+++ b/internal/statusline/types.go
@@ -320,11 +320,13 @@ const (
 	// REQ-SSE-001/002: workspace.repo segment (Claude Code 2.1.145+)
 	SegmentRepo = "repo" // GitHub repo identity owner/name indicator
 
-	// REQ-SSE-003/004: exceeds_200k_tokens visual marker (Claude Code 2.1.139+)
-	SegmentLongContext = "long_context" // Long-context overflow ⚠️ marker
+	// NOTE: SegmentLongContext removed per user explicit request (layout v3 CH1).
+	// StdinData.ExceedsLong + StatusData.ExceedsLongTokens fields preserved
+	// for future use, but no visual segment renders the ⚠️ long marker.
 
-	// REQ-SSE-005/006: handoff guide segment (orchestrator handoff hint)
-	SegmentHandoffGuide = "handoff_guide" // Paste-ready /clear hint at threshold
+	// NOTE: SegmentHandoffGuide removed per user explicit request (layout v3 CH2).
+	// shouldShowHandoffGuide() preserved as helper — its output is now integrated
+	// into the CW bar as a " (/clear)" suffix at the model-class threshold.
 )
 
 // UsageData represents API usage information.


### PR DESCRIPTION
## Summary

- **statusline layout v3** 2-phase migration (CH1~CH8) + 사용자 amend 반영 fix 체인
- **SPEC-V3R5-STATUSLINE-PROFILE-WIZARD-001** Tier S Quick Win (plan + implementation)
- **4-locale comprehensive guide** for statusline layout v3 (ko/en/ja/zh)

## Scope (12 commits, origin/main `720a636b5` base)

### Layout v3 migration (8 commits)
1. `8518618cc` fix: handoff_guide raw cwSize boundary defect (TokenBudget → ContextWindowSize)
2. `c85fb3c10` feat: layout v3 phase 1 — CH1 long_context revert + CH2 handoff→CW + CH8 PR format
3. `833b90848` feat: layout v3 phase 2 — CH3 repo+branch combined + CH5 directory L1 + CH6 emoji/label swap
4. `770a7ca54` fix: directory moves back to L3 head (before repo_branch)
5. `f70d7d6e2` fix: handoff_guide suffix '(/clear)' → '⚠️ /clear'
6. `c77e4d650` fix: handoff_guide suffix '⚠️ /clear' → '(⚠️/clear)'
7. `70e0a7795` fix: branch '🅱️' prefix inside repo_branch segment
8. `9e14c1804` fix: git status emoji unified to 💾 (replaces 📬/📫/📪/📭 quartet)

### Documentation (1 commit)
9. `02a0a8304` docs: 4-locale comprehensive guide for layout v3

### SPEC-V3R5-STATUSLINE-PROFILE-WIZARD-001 (3 commits)
10. `6bd655150` plan: Tier S — profile setup wizard에 statusline preset/segments 입력 UI 추가
11. `8a0ba4c22` feat: wizard에 statusline preset/segments 입력 UI 추가 (Tier S Quick Win)
12. `29140da17` feat: repo info 부재 시 🔀 segment 숨김 + pipe separator 형식 변경

## Test plan

- [x] cherry-pick conflict 0 — origin/main base에 깨끗하게 12 commits 적용
- [x] statusline+cli+pr+worktree+wizard 회귀 PASS (개별 commit 시점에서 검증됨)
- [x] hugo 4-locale 200 OK (commit 9 시점에서 검증)
- [x] forbidden URL / Mermaid LR 위반 0
- [ ] CI 전체 통과 확인 (이 PR의 spec-lint pre-existing 결함은 PR #1038과 동일 — 본 PR 변경과 무관)

## Context

- main HEAD `720a636b5` (PR #1037 main-sync) 기준 cherry-pick으로 분리됨
- 원래 local main에 PR #1038과 함께 누적된 19 commits 중 statusline 12 commits을 별도 PR로 분리
- 사용자 정책 2026-05-22: PR #1038은 Wave 1 Foundation Cleanup만 포함, 14 commits (statusline + research)는 별도 PR

🗿 MoAI <email@mo.ai.kr>