### PR TITLE
docs(research): config audit + LSP yaml audit v2 corrections (dead-classification retracted)

### DIFF
--- a/.moai/research/config-audit-2026-05-22.md
+++ b/.moai/research/config-audit-2026-05-22.md
@@ -1,0 +1,236 @@
+---
+created: 2026-05-22
+updated: 2026-05-22
+tags: [research, config, audit, dead-code, retracted]
+status: retracted-v1-corrected-v2
+authors: [Claude Opus 4.7 + manager-spec verification]
+related_specs:
+  - SPEC-CONFIG-001 (Configuration Management System) status:completed v1.1.0
+  - SPEC-CI-MULTI-LLM-001 (Multi-LLM GitHub Actions Self-Hosted Runner) status:in-progress v1.0.0
+  - SPEC-V3R2-RT-006 (Hook Handler Completeness) status:completed
+  - SPEC-V3R2-MIG-002 (Hook Registration Cleanup) status:completed
+---
+
+# Config Dead Code Audit — 2026-05-22 (v2 corrected)
+
+> **NOTICE**: This document supersedes the initial audit summary surfaced in the orchestrator response of 2026-05-22. The initial audit (v1) used grep-only symbol reference signals and **mis-classified 3 active items as dead**. Manager-spec cross-check against `.moai/specs/` SPEC catalog blocked the proposed cleanup SPEC and surfaced this defect. v2 documents the correction and the SPEC catalog cross-check procedure that must precede future dead-code audits.
+
+---
+
+## 1. Retraction Summary
+
+The 2026-05-22 v1 audit proposed three items as "fully dead config":
+
+- **A1**: `PricingConfig` struct (`internal/config/types.go:130-134` + defaults + manager)
+- **A2**: `github-actions.yaml` + `.tmpl` (725B yaml + 918B tmpl)
+- **A3**: `system.hook.observability_events` field (`internal/config/types.go:53-60`)
+
+All three are **withdrawn**. Each has an active SPEC owner. Removing them without SPEC supersession would partially revert completed SPECs or strand in-progress work.
+
+---
+
+## 2. Item-by-Item Correction
+
+### 2.1 A1 — PricingConfig
+
+**v1 claim**: "yaml file `pricing:` key not found anywhere, self-references only, external consumers 0 → dead struct"
+
+**v2 correction**: PricingConfig is **forward-compat infrastructure registered by SPEC-CONFIG-001 v1.1.0 (status: completed)**. Evidence:
+
+| Location | Content |
+|----------|---------|
+| `.moai/specs/SPEC-CONFIG-001/spec.md:83` | `pricing.yaml # PricingConfig` |
+| `.moai/specs/SPEC-CONFIG-001/spec.md:316` | `Pricing PricingConfig yaml:"pricing"` field declaration |
+| `.moai/specs/SPEC-CONFIG-001/spec.md:435` | `type PricingConfig struct {…}` schema |
+| `.moai/specs/SPEC-CONFIG-001/plan.md:46` | T1.7 "Define PricingConfig in config types" |
+| `.moai/specs/SPEC-CONFIG-001/plan.md:231` | Pricing type decl block |
+
+**Interpretation**: The runtime yaml `pricing.yaml` was never created in v1.1.0 (deferred deliverable). The struct + defaults + manager wiring exist as **explicit forward-compat scaffolding**. The "zero yaml consumer" signal does not equal dead — it equals "yaml deliverable pending in completed SPEC".
+
+**Disposition**: Keep PricingConfig as-is. Audit signal was insufficient — symbol grep does not detect deliverable-pending scaffolding.
+
+### 2.2 A2 — github-actions.yaml
+
+**v1 claim**: "yaml is 725B with rich content (auto_panel/review.llms.{claude,codex,gemini,glm}/runner/sha_pin), code consumer 0, dead"
+
+**v2 correction**: github-actions.yaml is **scaffolding for SPEC-CI-MULTI-LLM-001 v1.0.0 (status: in-progress)**. Evidence:
+
+| Location | Content |
+|----------|---------|
+| `.moai/specs/SPEC-CI-MULTI-LLM-001/tasks.md` | T-21 status=`pending`, label "github-actions.yaml.tmpl (Config Template)" |
+| `.moai/specs/SPEC-CI-MULTI-LLM-001/plan.md:64,86,375-381` | yaml + tmpl declared as REQ-CI-015/CI-020 deliverable |
+| `.moai/specs/SPEC-CI-MULTI-LLM-001/spec.md:105,154,191,219,331,366,424` | runtime contract reading this yaml (auto_panel.trigger, review.llms.*, runner.mode, sha_pin.actions_checkout, etc.) |
+
+**Interpretation**: "zero Go consumer" is true *today only because the consumer hasn't been written yet*. T-21 = pending means the implementer task is queued. Deleting the yaml would strand the in-progress SPEC.
+
+**Secondary finding**: yaml is NOT registered in `internal/config/audit_registry.go` `yamlToStructRegistry` nor `yamlAuditExceptions`. This is an **orphan-registration defect** independent of the dead-code claim. Recommended fix: add `github_actions` to `yamlAuditExceptions` with comment "pending SPEC-CI-MULTI-LLM-001 T-21".
+
+**Disposition**: Keep yaml + tmpl. Optionally add registry exception entry as separate hygiene task.
+
+### 2.3 A3 — system.hook.observability_events
+
+**v1 claim**: "yaml default `[]`, comment says 'silent no-op', field effectively unused even when set → dead"
+
+**v2 correction**: The audit misread the comment. The "silent no-op" wording describes opt-in OFF behavior. When the list is populated, the field activates a live opt-in path:
+
+| Location | Content |
+|----------|---------|
+| `internal/hook/observability.go:21-44` | LIVE `observabilityOptIn()` function reads `cfg.Get().System.Hook.ObservabilityEvents` |
+| `internal/hook/observability.go` header | `@MX:ANCHOR fan_in=4`. Resolution comment: "KEEP — observability gate helper for RETIRE-OBS-ONLY handlers. Implements SPEC-V3R2-RT-006 REQ-040" |
+| Call sites (4) | `notification`, `elicitation`, `elicitationResult`, `taskCreated` hook handlers |
+| SPEC-V3R2-RT-006 | status: completed. REQ-040 defines opt-in semantics |
+| SPEC-V3R2-MIG-002 | status: completed. Established the retire-with-opt-in pattern |
+
+**Interpretation**: `ObservabilityEvents` is **active opt-in infrastructure for retired-event observability**. The field is "always-no-op-when-empty" by design, not by accident. Populating it activates 4 handlers as taps. Deleting the field would silently break the retired-event observability story without retiring REQ-040 first.
+
+**Disposition**: Keep field. Audit's reading of the comment was incorrect.
+
+---
+
+## 3. Root Cause Analysis
+
+### 3.1 What signal was used in v1
+
+```
+For each yaml top-level key K:
+  1. grep -rln "yaml:\"K\"" internal pkg
+  2. If hit count == 0 outside _test.go and templates/, mark "dead"
+  3. For struct fields, check if consumer code outside config package references the field
+  4. If no external consumer, mark "dead struct"
+```
+
+### 3.2 Why the signal fails (5 Whys)
+
+1. **WHY** did v1 misclassify? — grep symbol reference is a **necessary but insufficient** signal for dead-config detection.
+2. **WHY** insufficient? — Three orthogonal "alive" patterns are invisible to grep:
+   - **Forward-compat scaffolding**: code wired but yaml deliverable deferred (A1 pattern)
+   - **In-progress deliverable**: yaml exists ahead of consumer code (A2 pattern)
+   - **Opt-in inactive-by-default**: empty default means inactive but populating activates (A3 pattern)
+3. **WHY** wasn't SPEC catalog checked? — v1 audit was built around runtime artifacts (yaml + Go code). SPEC documents at `.moai/specs/<SPEC-ID>/{spec,plan,acceptance,tasks}.md` declare ownership and lifecycle but live outside the runtime tree.
+4. **WHY** is `audit_registry.go` insufficient? — Registry tracks yaml→struct symmetry but does not encode SPEC ownership, status, or supersession. github-actions is orphan-registered (neither in registry nor exceptions) which made it look extra-dead.
+5. **WHY** wasn't this caught earlier? — `audit_loader_completeness_test.go` and `audit_struct_yaml_symmetry_test.go` test symmetry between Go struct and yaml. They do NOT cross-reference SPEC catalog. This is a test infrastructure gap.
+
+### 3.3 Bias contributor
+
+The v1 audit was framed as "find dead code", which biases toward false positives. A balanced framing ("classify each config item as: live / dormant-by-design / forward-compat / dead") would have produced different candidates.
+
+---
+
+## 4. Required Procedure for v3 Audit
+
+Future config dead-code audits MUST execute these checks per candidate item:
+
+### Step 1 — Symbol reference (necessary)
+
+```bash
+# Same as v1
+grep -rn "yaml:\"<key>\"" internal pkg
+grep -rn "<StructName>" internal pkg | grep -v _test | grep -v templates
+```
+
+### Step 2 — SPEC catalog cross-check (mandatory addition)
+
+```bash
+# Find owner SPECs
+grep -rln "<StructName>\|<yaml_key>" .moai/specs/
+
+# For each owner SPEC, read frontmatter and tasks
+for spec in $(grep -rln "<symbol>" .moai/specs/ | sort -u); do
+  echo "=== $spec ==="
+  head -20 "$spec"  # frontmatter: status, superseded_by, version
+  grep -n "$symbol" "$spec"  # context
+done
+```
+
+### Step 3 — Owner SPEC disposition resolution
+
+Per owner SPEC, classify:
+- `status: completed` + symbol in spec.md as deliverable → **forward-compat scaffolding** (NOT dead)
+- `status: in-progress` + symbol in tasks.md `pending` → **deliverable pending** (NOT dead)
+- `status: archived/superseded` + no successor → **retire candidate** (verify successor SPEC)
+- `superseded_by: <newer SPEC>` → check successor SPEC; if newer SPEC defines successor symbol → **safe to retire old**
+- No owner SPEC found → **orphan** (possibly genuine dead, but verify with `git log -S <symbol>` for historical context)
+
+### Step 4 — Consumer fan_in measurement (replace `grep -v _test`)
+
+```bash
+# Count NON-TEST consumers
+grep -rn "<symbol>" internal pkg --include="*.go" | grep -v "_test.go" | grep -v "/templates/" | wc -l
+
+# Count @MX:ANCHOR fan_in declarations
+grep -rn "@MX:ANCHOR.*<symbol>\|fan_in.*<symbol>" internal pkg
+```
+
+A consumer count of 0 but `@MX:ANCHOR fan_in=N` declaration means audit must investigate why annotation and reality disagree (likely audit reading wrong symbol).
+
+### Step 5 — Opt-in pattern detection
+
+For struct fields with empty/zero default in yaml, check for opt-in pattern:
+```bash
+# Look for "If empty, ... otherwise ..." patterns
+grep -B2 -A5 "ObservabilityEvents\|<field>" internal/hook/
+grep -rn "len(<field>) == 0\|<field> != nil\|<field> != \"\"" internal pkg
+```
+
+If field gates a conditional path, the empty-default does NOT mean dead — it means **inactive by default**.
+
+### Step 6 — Cross-SPEC dependency graph
+
+For each candidate, list:
+- Defining SPEC(s)
+- Consuming SPEC(s)
+- Superseding SPEC(s) (if any)
+- Owner SPEC's current status
+
+Only items where ALL owner SPECs are `superseded` or `archived` AND no consuming SPEC depends on them are eligible for dead classification.
+
+---
+
+## 5. v1 Audit's Other Categories (B/C/D) — Re-verification Required
+
+The v1 audit also categorized:
+
+- **B1**: `git-strategy.yaml` nested mode-based structure ~80% dead
+- **B2**: `workflow.yaml` completion/loop_prevention/memory/default_mode/execution_mode ~60% dead
+- **B3**: `lsp.yaml` aggregator/circuit_breaker/delegate_to_astgrep/discovery/enabled ~80% dead
+- **B4**: `llm.yaml` default_model/quality_model/speed_model legacy fields
+- **B5**: `constitution.yaml.performance.{max_memory_mb,max_response_time_ms}`
+- **C1-C5**: Various dormant items (SunsetConfig, trust5_integration, skip_conditions, simplicity.max_parallel_tasks, report_generation.user_choice)
+- **D1-D3**: Struct overhang items (design.gan_loop.strict_mode, state.retention_days, session.stale_seconds)
+
+**Status**: These were NOT verified against SPEC catalog in v1. They remain candidates but **MUST be re-verified via Step 1-6 above before any cleanup SPEC is filed**. The categorization may shift significantly once SPEC ownership is mapped.
+
+---
+
+## 6. Lessons for Future Audits
+
+1. **Grep symbol reference is necessary but insufficient** for dead-config detection.
+2. **SPEC catalog cross-check is mandatory** — read `.moai/specs/<*>/{spec,plan,tasks}.md` frontmatter (status / superseded_by) and content (deliverables, REQ-X-NNN mappings) for every candidate.
+3. **Three "alive but invisible to grep" patterns**: forward-compat scaffolding, in-progress deliverable, opt-in inactive-by-default.
+4. **`audit_registry.go` does not encode SPEC lifecycle** — orphan entries (not in registry AND not in exceptions) require independent SPEC catalog investigation.
+5. **Audit framing matters** — "find dead code" biases toward false positives. Use neutral classification ("live / dormant / forward-compat / dead") instead.
+6. **`@MX:ANCHOR fan_in=N`** disagreement with grep results is a red flag: either the annotation is stale or the audit is reading the wrong symbol.
+
+---
+
+## 7. Disposition
+
+- **No code change**: 0 files modified.
+- **No SPEC created**: `SPEC-V3R5-CONFIG-DEAD-CLEANUP-001` abandoned.
+- **Working tree**: clean (manager-spec made no writes; this document is the only new file).
+- **Follow-up SPEC candidates**: Deferred to a v2 audit re-run that applies the Step 1-6 procedure to CATEGORY B/C/D candidates. Each surviving candidate needs its own scoped SPEC with explicit owner-SPEC supersession trail.
+
+---
+
+## 8. References
+
+- v1 audit (initial misclassification): turn-of-2026-05-22 orchestrator response, not persisted to disk.
+- `internal/config/types.go` — Config aggregate root + section structs.
+- `internal/config/audit_registry.go` — yaml↔struct symmetry registry.
+- `internal/config/audit_loader_completeness_test.go` — current audit coverage (missing SPEC catalog cross-check).
+- `internal/config/audit_struct_yaml_symmetry_test.go` — symmetry test (also missing SPEC cross-check).
+- `internal/hook/observability.go` — A3 active consumer (proves A3 is live).
+- `.moai/specs/SPEC-CONFIG-001/` — A1 owner.
+- `.moai/specs/SPEC-CI-MULTI-LLM-001/` — A2 owner.
+- `.moai/specs/SPEC-V3R2-RT-006/` — A3 owner.
+- `.moai/specs/SPEC-V3R2-MIG-002/` — A3 retire-with-opt-in pattern origin.

--- a/.moai/research/lsp-yaml-v2-audit-2026-05-22.md
+++ b/.moai/research/lsp-yaml-v2-audit-2026-05-22.md
@@ -1,0 +1,182 @@
+---
+created: 2026-05-22
+updated: 2026-05-22
+tags: [research, config, audit, lsp, dead-code, v2-audit]
+status: active
+authors: [Claude Opus 4.7 — applying v2 6-step procedure]
+related_specs:
+  - SPEC-LSP-001 (Language Server Protocol Client System) status:superseded
+  - SPEC-LSP-CORE-002 (LSP Core foundation) status:in-progress v1.0.0
+  - SPEC-LSP-AGG-003 (LSP Aggregator) status:completed v1.0.0
+  - SPEC-LSP-QGATE-004 (LSP Quality Gates) status:completed v1.0.0
+  - SPEC-GOPLS-BRIDGE-001 (Gopls Bridge) status:completed v1.0.0
+parent_audit: .moai/research/config-audit-2026-05-22.md
+---
+
+# LSP yaml v2 Audit — 2026-05-22
+
+> Applies the 6-step procedure from `.moai/research/config-audit-2026-05-22.md` §4 to `lsp.yaml`. v1 audit classified ~80% of lsp.yaml as "dead" based on grep symbol reference alone. This v2 re-verification finds the classification is **incorrect or premature** — the keys are owned by completed SPECs but lack yaml→Go binding (hardcoded constants used instead). Decision required: WontDo + yaml removal, or forward-compat retention.
+
+---
+
+## 1. Summary
+
+- **Total lsp.yaml top-level keys**: 6 (`enabled`, `aggregator`, `circuit_breaker`, `client_impl`, `delegate_to_astgrep`, `discovery`, `servers`)
+- **Total Go consumer files** (excluding tests/templates): 5 keys with consumers
+- **Owner SPECs identified**: 5 (LSP-001 superseded / LSP-CORE-002 in-progress / LSP-AGG-003 completed / LSP-QGATE-004 completed / GOPLS-BRIDGE-001 completed)
+- **v1 audit "dead" claim**: 80% (`aggregator.*`, `circuit_breaker.*`, `delegate_to_astgrep.*`, `discovery.*`, `enabled`)
+- **v2 verdict**: 0% confirmed dead. Mixed disposition required.
+
+---
+
+## 2. Step-by-Step Analysis
+
+### Step 1 — Symbol reference (necessary)
+
+```
+lsp.aggregator           → 0 Go consumer files (struct field with yaml:"aggregator" tag)
+lsp.circuit_breaker      → 0
+lsp.delegate_to_astgrep  → 0
+lsp.discovery            → 0
+lsp.enabled              → 1 (internal/lsp/gopls/config.go)
+lsp.client_impl          → 2 (internal/lsp/config/types.go + core/manager.go)
+lsp.servers              → 1 (internal/lsp/core/manager.go)
+```
+
+The `lspYAMLRoot` struct in `internal/lsp/config/loader.go:13-18` declares only `ClientImpl` + `Servers` — the other 4 sub-keys never bind to Go structs. v1 audit conclusion derived from this signal.
+
+### Step 2 — SPEC catalog cross-check (mandatory)
+
+| Key | Owner SPEC(s) | Status |
+|-----|---------------|--------|
+| `lsp.enabled` | SPEC-GOPLS-BRIDGE-001, SPEC-LSP-CORE-002 | completed / in-progress |
+| `lsp.client_impl` | SPEC-LSP-CORE-002 | in-progress (AC10 feature flag) |
+| `lsp.servers` | SPEC-LSP-001, SPEC-LSP-AGG-003 | superseded / completed |
+| `lsp.aggregator.cache_ttl_seconds` | SPEC-LSP-AGG-003 | **completed** |
+| `lsp.aggregator.diagnostics_debounce_ms` | SPEC-LSP-AGG-003 | **completed** |
+| `lsp.aggregator.max_parallel_servers` | SPEC-LSP-AGG-003 | **completed** |
+| `lsp.aggregator.request_timeout_seconds` | SPEC-LSP-AGG-003 | **completed** |
+| `lsp.aggregator.diagnostic_pull_enabled` | SPEC-LSP-AGG-003 | **completed** |
+| `lsp.aggregator.server_startup_timeout_seconds` | SPEC-LSP-AGG-003 | **completed** |
+| `lsp.aggregator.shutdown_timeout_seconds` | SPEC-LSP-AGG-003 | **completed** |
+| `lsp.circuit_breaker.threshold` | SPEC-LSP-AGG-003 | **completed** |
+| `lsp.circuit_breaker.open_duration_seconds` | SPEC-LSP-AGG-003 | **completed** |
+| `lsp.delegate_to_astgrep.enabled` | (none found by grep — needs deeper check) | unknown |
+| `lsp.delegate_to_astgrep.languages` | (none found) | unknown |
+| `lsp.delegate_to_astgrep.rules_dir` | (none found) | unknown |
+| `lsp.discovery.auto_detect_language` | (none found) | unknown |
+| `lsp.discovery.on_missing` | (none found) | unknown |
+
+**Critical finding**: SPEC-LSP-AGG-003 is status `completed` v1.0.0. The aggregator/circuit_breaker yaml keys belong to a completed SPEC, but the runtime uses **hardcoded constants**:
+
+```go
+// internal/lsp/aggregator/aggregator.go (verified 2026-05-22)
+const defaultQueryTimeout = 5 * time.Second
+const defaultCacheTTL = 5 * time.Second
+const defaultCBThreshold = 3
+const defaultCBTimeout = 30 * time.Second
+```
+
+The yaml values for `aggregator.cache_ttl_seconds: 5`, `circuit_breaker.threshold: 3`, `circuit_breaker.open_duration_seconds: 30` happen to **match** the hardcoded defaults — suggesting the yaml was authored alongside the SPEC as documentation/intent but the implementer chose to inline the constants rather than wire them through. This is **not dead config** per the v2 procedure definition — it is **WontDo or deferred yaml override**.
+
+### Step 3 — Owner SPEC disposition
+
+| Key category | Owner SPEC | Status | Disposition |
+|--------------|-----------|--------|-------------|
+| `client_impl` + `servers` + `enabled` | LSP-CORE-002 / GOPLS-BRIDGE-001 | live | **Active, keep** |
+| `aggregator.*` (8 keys) | LSP-AGG-003 | completed | **WontDo or deferred** — yaml present, code uses hardcoded constants. Requires SPEC owner decision: (a) remove yaml keys + comment "intentional, see SPEC-LSP-AGG-003 completion notes"; or (b) wire through yaml→Go binding to honor the yaml values |
+| `circuit_breaker.*` (2 keys) | LSP-AGG-003 | completed | Same as aggregator (`defaultCBThreshold = 3`, `defaultCBTimeout = 30s` are hardcoded counterparts) |
+| `delegate_to_astgrep.*` (3 keys) | unknown | unknown | Investigation required — search astgrep integration code for whether yaml is read |
+| `discovery.*` (4 keys) | unknown | unknown | Investigation required — search server discovery code |
+
+### Step 4 — Consumer fan_in vs `@MX:ANCHOR` declaration
+
+Verified `@MX:ANCHOR` in `internal/lsp/`:
+- `ServersConfig` (config/types.go:56) — `top-level config type returned by Load() and used as a Manager initialization argument`
+- `Load` (config/loader.go) — `primary entry point for LSP config; all server startup paths call this`
+- 8+ additional anchors in core/, transport/, models.go
+
+No `@MX:ANCHOR` declares fan_in for the orphan keys (`aggregator/circuit_breaker/delegate_to_astgrep/discovery`). This is **consistent with "yaml documents intent, code uses hardcoded"** — no ANCHOR contradiction, just a yaml↔Go binding gap.
+
+### Step 5 — Opt-in pattern detection
+
+`lsp.enabled: false` (default in yaml). The single consumer is `internal/lsp/gopls/config.go`. Confirmed yaml→Go binding exists. **Not dead** — it gates whether LSP infrastructure starts at all. Default `false` is consistent with the project's posture (LSP optional, opt-in via yaml flip).
+
+`lsp.aggregator.diagnostic_pull_enabled: true` — if implementation were yaml-wired, this would be opt-in. But hardcoded → no opt-in semantics. WontDo signature.
+
+### Step 6 — Cross-SPEC dependency graph
+
+```
+SPEC-LSP-001 (superseded by ...) ──────┐
+                                       ▼
+                              SPEC-LSP-CORE-002 (in-progress, defines client_impl + servers)
+                                       │
+                                       ├──▶ uses ──▶  config.Load() reading client_impl + servers
+                                       │
+                                       └──▶ delegates to ──▶ SPEC-LSP-AGG-003 (completed)
+                                                              │
+                                                              ├──▶ aggregator.go const defaultQueryTimeout = 5s
+                                                              ├──▶ aggregator.go const defaultCacheTTL = 5s
+                                                              ├──▶ aggregator.go const defaultCBThreshold = 3
+                                                              └──▶ aggregator.go const defaultCBTimeout = 30s
+                                                                   (yaml aggregator.* + circuit_breaker.*
+                                                                    values match but are not consumed)
+
+SPEC-LSP-QGATE-004 (completed) — separate quality-gate concern, lsp.servers consumer only
+SPEC-GOPLS-BRIDGE-001 (completed) — gopls-specific consumer of lsp.enabled
+```
+
+`delegate_to_astgrep.*` and `discovery.*` have no identifiable owner SPEC by grep — likely planned by SPEC-LSP-001 (superseded). Verify via SPEC-LSP-CORE-002 successor coverage.
+
+---
+
+## 3. v2 Verdict — Mixed Disposition
+
+| Group | v1 claim | v2 verdict | Action |
+|-------|----------|-----------|--------|
+| `enabled` + `client_impl` + `servers` | "live" | **CONFIRMED LIVE** | Keep |
+| `aggregator.*` (8 keys) | "dead 80%" | **WontDo or deferred — NOT dead** | Owner SPEC LSP-AGG-003 completed but yaml→Go binding intentionally omitted; either (a) remove yaml keys with SPEC amendment, or (b) wire through as separate cleanup SPEC |
+| `circuit_breaker.*` (2 keys) | "dead 80%" | Same as aggregator | Same |
+| `delegate_to_astgrep.*` (3 keys) | "dead" | **Unknown — needs owner SPEC discovery** | Search SPEC catalog and astgrep integration code |
+| `discovery.*` (4 keys) | "dead" | **Unknown — needs owner SPEC discovery** | Search server discovery code |
+
+---
+
+## 4. Recommended Next Steps (NOT executed in this audit)
+
+1. **For `aggregator.*` + `circuit_breaker.*`**: Open AskUserQuestion to owner: should yaml be honored (wire through Aggregator constructor options) OR be retired (remove yaml + add SPEC-LSP-AGG-003 HISTORY note "yaml override not implemented, hardcoded defaults retained")?
+
+2. **For `delegate_to_astgrep.*`**: Investigate `internal/lsp/aggregator/` or new astgrep integration package for yaml consumer. If none found, locate the SPEC that declared the integration (possibly SPEC-LSP-001 superseded). Verify successor coverage.
+
+3. **For `discovery.*`**: Investigate `internal/lsp/core/manager.go` or `subprocess/launcher.go` for auto-detection logic. If yaml-blind, repeat (a) wire-or-retire decision.
+
+4. **DO NOT create a "CONFIG-DEAD-CLEANUP-LSP-001" SPEC** without resolving steps 1-3 first — repeating the v1 audit anti-pattern (premature dead classification) will produce a second manager-spec blocker report.
+
+---
+
+## 5. Lessons Reinforced (apply to future audits)
+
+1. **Hardcoded constants matching yaml values** is a strong signal of **deferred wire-through**, not dead config.
+2. **SPEC-LSP-AGG-003 status: completed** + yaml binding absent = the SPEC was completed using hardcoded defaults; the yaml may have been authored as design intent before the binding decision. This is **WontDo**, not dead.
+3. The 6-step procedure correctly identifies the mismatch — Step 2 (SPEC catalog cross-check) + Step 5 (opt-in pattern) reveal the wire-through gap.
+
+---
+
+## 6. Disposition
+
+- **No yaml or Go changes made in this audit.** This document is analysis only.
+- **No SPEC created** — premature.
+- **Follow-up**: orchestrator should surface 3 questions (aggregator/circuit_breaker wire-or-retire, delegate_to_astgrep ownership, discovery ownership) via AskUserQuestion when the user is ready to act on this category.
+
+---
+
+## 7. References
+
+- `internal/lsp/config/loader.go` lines 13-18 — `lspYAMLRoot` struct with only ClientImpl + Servers
+- `internal/lsp/config/types.go` lines 54-79 — `ServersConfig` definition with `@MX:ANCHOR`
+- `internal/lsp/aggregator/aggregator.go` lines 18-27 — hardcoded constants (`defaultQueryTimeout`, `defaultCacheTTL`, `defaultCBThreshold`, `defaultCBTimeout`)
+- `internal/lsp/gopls/config.go` — `lsp.enabled` consumer (verified via grep)
+- `.moai/specs/SPEC-LSP-AGG-003/` v1.0.0 status:completed — yaml owner without wire-through
+- `.moai/specs/SPEC-LSP-CORE-002/` v1.0.0 status:in-progress — client_impl + servers consumer
+- `.moai/specs/SPEC-LSP-001/` status:superseded — predecessor, possible owner of `delegate_to_astgrep` and `discovery`
+- `.moai/research/config-audit-2026-05-22.md` — parent v2 procedure document (6-step)


### PR DESCRIPTION
## Summary

2개 research audit document의 v2 정정본 추가. 모두 v1 \"80% dead\" / \"3 dead config items\" 분류가 cross-check 결여로 부정확하다는 결론에 따라 retraction + v2 정정 procedure 제안.

## Scope (2 commits, origin/main `720a636b5` base)

1. `56a618587` docs(research): config audit v1 RETRACTED + v2 6-step procedure for future dead-config classifications
   - 결과물: `.moai/research/config-audit-2026-05-22.md` (236 lines)
   - SPEC-V3R5-CONFIG-DEAD-CLEANUP-001 ABORTED 후속 — 6-step procedure for future dead-config classifications
   - **Lesson learned**: grep symbol reference + SPEC catalog cross-check 동시 필수

2. `6b6733c8e` docs(research): LSP yaml v2 audit — v1 \"80% dead\" classification corrected
   - 결과물: `.moai/research/lsp-yaml-v2-audit-2026-05-22.md` (182 lines)
   - LSP yaml v1 audit \"80% dead\" classification 정정

## Test plan

- [x] cherry-pick conflict 0 — origin/main base에 깨끗하게 2 commits 적용
- [x] Documentation-only PR — code 변경 없음
- [ ] spec-lint / golangci-lint NEW=0 확인

## Context

- main HEAD `720a636b5` (PR #1037) 기준 cherry-pick으로 분리됨
- 14 commits (statusline 12 + research 2) 중 research 2 commits 별도 PR
- 사용자 정책 2026-05-22: 별도 PR 2개로 분리

🗿 MoAI <email@mo.ai.kr>