### PR TITLE
fix: open-issue sweep — statusLine quoting (#1096), hook failure classification (#1089), labels.yml (#1094)

### DIFF
--- a/.moai/specs/SPEC-HOOK-FAILURE-CLASSIFY-001/plan.md
+++ b/.moai/specs/SPEC-HOOK-FAILURE-CLASSIFY-001/plan.md
@@ -1,0 +1,73 @@
+---
+id: SPEC-HOOK-FAILURE-CLASSIFY-001
+title: "Implementation plan — PostToolUseFailure nested-error classification"
+version: "0.1.0"
+status: draft
+created: 2026-07-17
+updated: 2026-07-17
+author: manager-spec
+tier: S
+---
+
+# Plan — SPEC-HOOK-FAILURE-CLASSIFY-001
+
+## §A Context
+
+Single-package fix in `internal/hook`. Tier S (LEAN): ≤5 files, no cross-package surface. Development mode: TDD (RED-GREEN-REFACTOR) is the natural fit — the bug is reproducible as a failing test, and every REQ has a mechanically verifiable assertion (Reproduction-First, CLAUDE.md §7 Rule 4).
+
+Anchors (verify at run-phase entry — line numbers drift, prefer content tokens):
+- `internal/hook/post_tool_failure.go` — `classifyError` (reads only `input.Error`), `formatMessage` (content-free `UnknownFailure` default).
+- `internal/hook/types.go` — `HookInput.ToolResponse json.RawMessage` (`tool_response`).
+- `internal/hook/evidence_writer.go` — `decodeToolResponse(result []byte) (text string, isObject bool)` + `textKeys` family (`stdout`/`stderr`/`output`/`content`/`result`). **Reuse candidate** (Simplicity ladder step 2): it already normalizes wrapped-object vs plain-text `tool_response` into text.
+- `internal/hook/protocol.go` — `validateInput` sets `input.SessionID = "unknown"` on empty `session_id`.
+- `internal/hook/trace/writer.go` — `filePath()` = `trace-<sessionID>.jsonl`; `registry.go` `ensureTraceWriter` binds `sessionID` from `input.SessionID`.
+- `internal/hook/post_tool_failure_test.go` — existing top-level-`Error` table (must keep passing = backward-compat gate AC-HFC-002).
+
+## §B Known Issues / Risks
+
+- **R1 — `tool_response` shape variance.** Live Bash `tool_response` is a wrapped object; some tools may send a bare JSON string or nest `error` under a sub-object. Mitigation: reuse `decodeToolResponse` (already handles object/plain-text) and aggregate; REQ-HFC-006 resilience table guards malformed/absent shapes. Cross-ref: boundary-verification.md Case 6/7 (async/generic shape).
+- **R2 — session_id genuinely absent.** If neither `session_id` nor `transcript_path` resolves a UUID, the fix cannot invent one. Mitigation: REQ-HFC-004 permits a documented last-resort fallback; the win is not-colliding for RESOLVABLE sessions, not eliminating "unknown" entirely.
+- **R3 — precedence ambiguity.** Aggregating all error sources for classification could let a stray token in one field mis-steer the category. Mitigation: keep the existing ordered matcher (timeout→permission→context→sandbox→oom→exit→unknown); aggregation only widens the haystack, and the ordered first-match semantics are unchanged.
+
+## §C Pre-flight
+
+- `git rev-parse --short HEAD` (baseline anchor; audit ran at `efd423b88`).
+- `go test ./internal/hook/...` green baseline before any change.
+- Re-verify the five anchors above by content token (not line number).
+
+## §D Constraints
+
+- No new `ErrorCategory`; no learning-loop event-format change; no `TraceWriter` redesign (§C exclusions).
+- Fail-open: handler never returns an error for a malformed payload (matches `recordToolFailureEvent` contract).
+- Subagent boundary: no `AskUserQuestion`/`mcp__askuser` in `internal/hook` (C-HRA-008).
+- ≤5s hook budget — parsing is O(payload size), well within budget.
+
+## §F Milestones (ordered by decision-reversibility — highest-change-likelihood first)
+
+### M1 — Classification-input sourcing + precedence (highest change likelihood: semantics)
+The core design decision. Broaden `classifyError` to build its lowercased haystack from top-level `input.Error` **plus** the normalized `tool_response` text (via reused `decodeToolResponse`). Define precedence: top-level `Error` wins for the displayed excerpt; classification sees the union. RED: add AC-HFC-001a/001b nested cases (currently → `UnknownFailure`). GREEN: implement aggregation. Keep the ordered matcher untouched. This milestone is where human review should focus — it changes observable classification semantics.
+
+### M2 — session_id resolution for the trace filename (behavioral / observability-facing; investigation)
+Investigate the root cause end-to-end (audit left this evidence-pending). Determine whether `transcript_path` (present in the payload, `types.go:211`) encodes the session UUID and can seed `sessionID` when `session_id` is empty, BEFORE `validateInput` substitutes `"unknown"`. Choose the resolution source, implement it at the trace-filename binding path, and record the chosen source + last-resort fallback in `progress.md` §E.2. AC-HFC-004. Reversible-risky because it changes observable trace filenames and depends on an investigated external payload shape.
+
+### M3 — Unclassifiable message policy (user-facing message content)
+Change `formatMessage` so the `UnknownFailure` branch appends a bounded excerpt (e.g. first ~200 chars) of the observed raw error (top-level precedence, else nested) instead of the fixed content-free string. Decision recorded: emit-with-excerpt (NOT emit-nothing) — the `systemMessage` is the sole model-facing failure surface; emitting nothing regresses the hook's purpose. AC-HFC-005.
+
+### M4 — Regression + resilience test suite (mechanical)
+Add per-category nested-payload cases (AC-HFC-003) and the malformed/bare-string/absent resilience table (AC-HFC-006). Preserve all existing top-level-`Error` cases verbatim (AC-HFC-002).
+
+### M5 — Verification gate (mechanical)
+`go test ./internal/hook/...`, coverage ≥85% on the classification path, `go vet`, `golangci-lint run internal/hook/...`, subagent-boundary grep = 0. Record verbatim output in `progress.md` §E.2/§E.3.
+
+## §G Anti-Patterns to avoid
+
+- Writing a bespoke `tool_response` parser when `decodeToolResponse` exists (Simplicity ladder violation).
+- Adding an eighth `ErrorCategory` (out of scope).
+- Claiming the session_id fix works without a test that exercises a session-id-less payload (verify-don't-assume; the audit explicitly did NOT verify this end-to-end).
+- Editing existing top-level-`Error` test assertions to make them pass (that would mask a backward-compat regression).
+
+## §H Cross-References
+
+- Issue #1089; `internal/hook/CLAUDE.md` (JSON I/O contract, subagent boundary, fail-open).
+- `.claude/rules/moai/quality/boundary-verification.md` Case 6/7 (payload shape variance).
+- `internal/hook/evidence_writer.go` `decodeToolResponse` (reuse).

--- a/.moai/specs/SPEC-HOOK-FAILURE-CLASSIFY-001/plan.md
+++ b/.moai/specs/SPEC-HOOK-FAILURE-CLASSIFY-001/plan.md
@@ -2,9 +2,9 @@
 id: SPEC-HOOK-FAILURE-CLASSIFY-001
 title: "Implementation plan — PostToolUseFailure nested-error classification"
 version: "0.1.0"
-status: draft
+status: in-progress
 created: 2026-07-17
-updated: 2026-07-17
+updated: 2026-07-21
 author: manager-spec
 tier: S
 ---

--- a/.moai/specs/SPEC-HOOK-FAILURE-CLASSIFY-001/progress.md
+++ b/.moai/specs/SPEC-HOOK-FAILURE-CLASSIFY-001/progress.md
@@ -2,9 +2,9 @@
 id: SPEC-HOOK-FAILURE-CLASSIFY-001
 title: "Progress — PostToolUseFailure nested-error classification"
 version: "0.1.0"
-status: draft
+status: in-progress
 created: 2026-07-17
-updated: 2026-07-17
+updated: 2026-07-21
 author: manager-spec
 tier: S
 ---
@@ -22,11 +22,43 @@ tier: S
 
 ## §E.2 Run-phase Evidence
 
-_<pending run-phase — owned by manager-develop>_
+Run-phase baseline: HEAD `35119252c` (green `go test ./...` before change). TDD RED confirmed (4 new tests failing pre-fix: nested classification, unknown-excerpt, precedence, resolver), then GREEN.
+
+**session_id resolution investigation outcome (REQ-HFC-004)**: chosen source = `transcript_path` base name. Claude Code names the session transcript `~/.claude/projects/<hash>/<session-uuid>.jsonl`, so when `session_id` is absent (bug #541 → `validateInput` substitutes `"unknown"`), the session UUID is derived from `filepath.Base(transcript_path)` after stripping `.jsonl` and validating against the RFC 4122 UUID regex. Implemented in `internal/hook/trace_session.go` (`resolveTraceSessionID`), wired at the trace-filename binding site `internal/hook/registry.go` `Dispatch` → `ensureTraceWriter(resolveTraceSessionID(input))`. Last-resort fallback: when neither `session_id` nor a UUID-shaped transcript base is available, the original `"unknown"` value is kept (documented, unchanged) — the win is non-collision for RESOLVABLE sessions (plan.md R2). The global `validateInput` substitution for other events is untouched (§C exclusion).
+
+| AC | Status | Verification Command | Actual Output |
+|----|--------|---------------------|---------------|
+| AC-HFC-001a | PASS | `go test -run TestPostToolUseFailureHandler_NestedToolResponse ./internal/hook/` | `ok` — nested `{"error":"permission denied: open /f"}` → `PermissionDenied:` prefix |
+| AC-HFC-001b | PASS | same | nested `{"stderr":"...context deadline exceeded..."}` → `TimeoutError` |
+| AC-HFC-002 | PASS | `go test -run TestPostToolUseFailureHandler_Handle ./internal/hook/` | pre-existing top-level-Error table passes UNMODIFIED (assertions untouched) |
+| AC-HFC-003 | PASS | `grep -c 'ToolResponse\|tool_response' internal/hook/post_tool_failure_test.go` → `13` (≥7); 7 per-category nested cases in `TestPostToolUseFailureHandler_NestedToolResponse` | package `ok` |
+| AC-HFC-004 | PASS | `go test -run TestResolveTraceSessionID ./internal/hook/` | UUID derived from transcript_path when session_id absent/"unknown"; explicit session_id wins (no regression); unresolvable → "unknown" |
+| AC-HFC-005 | PASS | `go test -run TestPostToolUseFailureHandler_UnknownFailureExcerpt ./internal/hook/` | message ≠ content-free string; contains `something went wrong`; 500-char error truncated at 200 runes + `...` |
+| AC-HFC-006 | PASS | `go test -run TestPostToolUseFailureHandler_ToolResponseResilience ./internal/hook/` | malformed `[}` / bare string / array / absent / `{}` → no error, no panic, non-empty systemMessage |
+| AC-HFC-GATE | PASS | `go test ./...` exit=0 (106 pkgs ok); `go vet ./internal/hook/...` exit=0; `golangci-lint run internal/hook/...` → `0 issues`; boundary grep → 0 matches | evidence: `.moai/state/verify/hfc001/1-go-test.log` |
+
+Invariants: no new `ErrorCategory`; ordered matcher untouched (aggregation widens the haystack only); `recordToolFailureEvent` / event-key format unchanged; no `TraceWriter` redesign (only the sessionID value bound at `ensureTraceWriter`).
 
 ## §E.3 Run-phase Audit-Ready Signal
 
-_<pending run-phase — owned by manager-develop>_
+```yaml
+run_complete_at: 2026-07-21
+run_commit_sha: pending-backfill-hfc001
+run_status: audit-ready
+ac_pass_count: 8
+ac_fail_count: 0
+preserve_list_post_run_count: 0
+l44_pre_commit_fetch: "0 0 (synced with origin/main at spawn)"
+l44_post_push_fetch: "n/a — push not performed per delegation (Do NOT push)"
+new_warnings_or_lints_introduced: 0
+cross_platform_build:
+  darwin: "go build ./... exit 0"
+  windows: "GOOS=windows GOARCH=amd64 go build ./... exit 0"
+total_run_phase_files: 5
+m1_to_mN_commit_strategy: "single commit (Tier S, M1-M5 consolidated)"
+```
+
+Coverage (classification path, ≥85% target): `Handle` 100%, `classificationText` 100%, `rawErrorExcerpt` 100%, `classifyError` 100%, `formatMessage` 100%, `resolveTraceSessionID` 100%, `sessionUUIDFromTranscriptPath` 100% (`go tool cover -func`). Package-wide `internal/hook` 83.6% is the pre-existing baseline (unrelated handlers); every touched function meets the target.
 
 ## §E.4 Sync-phase Audit-Ready Signal
 

--- a/.moai/specs/SPEC-HOOK-FAILURE-CLASSIFY-001/progress.md
+++ b/.moai/specs/SPEC-HOOK-FAILURE-CLASSIFY-001/progress.md
@@ -43,7 +43,7 @@ Invariants: no new `ErrorCategory`; ordered matcher untouched (aggregation widen
 
 ```yaml
 run_complete_at: 2026-07-21
-run_commit_sha: pending-backfill-hfc001
+run_commit_sha: 99309448a
 run_status: audit-ready
 ac_pass_count: 8
 ac_fail_count: 0

--- a/.moai/specs/SPEC-HOOK-FAILURE-CLASSIFY-001/progress.md
+++ b/.moai/specs/SPEC-HOOK-FAILURE-CLASSIFY-001/progress.md
@@ -1,0 +1,33 @@
+---
+id: SPEC-HOOK-FAILURE-CLASSIFY-001
+title: "Progress — PostToolUseFailure nested-error classification"
+version: "0.1.0"
+status: draft
+created: 2026-07-17
+updated: 2026-07-17
+author: manager-spec
+tier: S
+---
+
+# Progress — SPEC-HOOK-FAILURE-CLASSIFY-001
+
+## §E.1 Plan-phase Audit-Ready Signal
+
+- Plan-phase artifact set authored (Tier S LEAN): `spec.md` (AC inline §D) + `plan.md` + `progress.md`.
+- SPEC ID pre-write self-check: `decomposition: SPEC ✓ | HOOK ✓ | FAILURE ✓ | CLASSIFY ✓ | 001 ✓ → PASS` (canonical regex `^SPEC(-[A-Z][A-Z0-9]*)+-\d{3}$`, executed → PASS). No collision in `.moai/specs/`.
+- Root causes verified against source at HEAD `efd423b88`: (1) `classifyError` reads only top-level `input.Error`; (2) `validateInput` sets `session_id = "unknown"` → `trace-unknown.jsonl`.
+- 6 REQ (GEARS) / 8 AC. Reuse candidate identified: `decodeToolResponse` (evidence_writer.go).
+- Open run-phase investigation (NOT a product-decision clarification): session_id resolution source (M2 — likely `transcript_path`, evidence pending).
+- No `[NEEDS CLARIFICATION]` markers — all choices resolved from code evidence.
+
+## §E.2 Run-phase Evidence
+
+_<pending run-phase — owned by manager-develop>_
+
+## §E.3 Run-phase Audit-Ready Signal
+
+_<pending run-phase — owned by manager-develop>_
+
+## §E.4 Sync-phase Audit-Ready Signal
+
+_<pending sync-phase — owned by manager-docs>_

--- a/.moai/specs/SPEC-HOOK-FAILURE-CLASSIFY-001/spec.md
+++ b/.moai/specs/SPEC-HOOK-FAILURE-CLASSIFY-001/spec.md
@@ -2,9 +2,9 @@
 id: SPEC-HOOK-FAILURE-CLASSIFY-001
 title: "PostToolUseFailure nested-error classification and session_id trace resolution"
 version: "0.1.0"
-status: draft
+status: in-progress
 created: 2026-07-17
-updated: 2026-07-17
+updated: 2026-07-21
 author: manager-spec
 priority: P1
 phase: "v3.0.0 target"

--- a/.moai/specs/SPEC-HOOK-FAILURE-CLASSIFY-001/spec.md
+++ b/.moai/specs/SPEC-HOOK-FAILURE-CLASSIFY-001/spec.md
@@ -1,0 +1,104 @@
+---
+id: SPEC-HOOK-FAILURE-CLASSIFY-001
+title: "PostToolUseFailure nested-error classification and session_id trace resolution"
+version: "0.1.0"
+status: draft
+created: 2026-07-17
+updated: 2026-07-17
+author: manager-spec
+priority: P1
+phase: "v3.0.0 target"
+module: "internal/hook"
+lifecycle: spec-anchored
+tags: "hook, post-tool-failure, classification, observability, bugfix"
+issue_number: 1089
+tier: S
+---
+
+# SPEC-HOOK-FAILURE-CLASSIFY-001 — PostToolUseFailure nested-error classification
+
+## HISTORY
+
+| Version | Date | Author | Change |
+|---------|------|--------|--------|
+| 0.1.0 | 2026-07-17 | manager-spec | Initial draft — fixes GitHub issue #1089 (UnknownFailure always + trace-unknown.jsonl) |
+
+## §A Context / Why
+
+GitHub issue #1089 (moai-adk-go v3.0.0-rc12): `moai hook post-tool-failure` **always** classifies real tool failures as `UnknownFailure` and writes the trace to `trace-unknown.jsonl`. Both symptoms were mechanically reproduced by the orchestrator at HEAD `efd423b88`.
+
+Ground-truth root causes (verified against current source):
+
+1. **Misclassification.** `internal/hook/post_tool_failure.go` `classifyError` (lines 87-122) lowercases and substring-matches **only** the top-level `input.Error` field. The actual Claude Code `PostToolUseFailure` stdin payload nests failure text under `tool_response.error` / `tool_response.stderr` (`input.ToolResponse`, `internal/hook/types.go:220`, a `json.RawMessage`). `input.ToolResponse` is never parsed by the classifier, so every real payload arrives with an empty `input.Error`, falls through every matcher, and returns `UnknownFailure`. Reproduction: a nested-error payload yields `{"systemMessage":"UnknownFailure: ..."}`, while a synthetic top-level `"error":"exit status 1"` correctly yields `ExitError` — proving the matcher works only at the top level.
+
+2. **`trace-unknown.jsonl`.** The trace filename is `trace-<sessionID>.jsonl` (`internal/hook/trace/writer.go:99`), and `sessionID` flows from `input.SessionID` (`internal/hook/registry.go:341-350`). `validateInput` (`internal/hook/protocol.go:110-112`) substitutes `input.SessionID = "unknown"` whenever `session_id` is empty. Per the existing comment (`protocol.go:93-95`), `PostToolUse`/`PostToolUseFailure` payloads may omit `session_id` (Claude Code bug #541), so the substitution fires and the trace is written to `trace-unknown.jsonl`. The end-to-end path was NOT verified by the audit — the resolution mechanism is a run-phase investigation (evidence pending).
+
+WHY it matters: the failure handler feeds the harness learning loop (`recordToolFailureEvent`, `tool_failure:<tool>:<category>`) and surfaces an actionable `systemMessage` to the model. A universally-`UnknownFailure` signal poisons the learning loop with a single degenerate category and gives the model no actionable guidance. A single shared `trace-unknown.jsonl` collides across all session-id-less events, corrupting per-session observability.
+
+## §B Requirements (GEARS)
+
+### REQ-HFC-001 — Nested-error classification input (Event-driven)
+
+**When** a `PostToolUseFailure` payload carries failure text under `tool_response.error` and/or `tool_response.stderr`, the failure handler **shall** derive its classification input from those nested `tool_response` fields (in addition to the top-level `error` field), so that a realistic nested payload classifies to its correct `ErrorCategory` rather than `UnknownFailure`.
+
+### REQ-HFC-002 — Top-level precedence and backward compatibility (Ubiquitous)
+
+The failure handler **shall** continue to honor a non-empty top-level `error` field, classifying such a payload identically to the pre-fix behavior. **Where** both the top-level `error` field and nested `tool_response` error text are present, the failure handler **shall** apply a defined precedence: the top-level `error` field takes precedence for the human-facing error excerpt, while classification considers all available sources so no correct category is lost.
+
+### REQ-HFC-003 — Per-category nested regression tests (Ubiquitous)
+
+The regression test suite **shall** include realistic nested `tool_response` payload cases covering each error category (`TimeoutError`, `PermissionDenied`, `ContextCancelled`, `SandboxViolation`, `OOMKilled`, `ExitError`, and a genuinely unclassifiable case), asserting the classified category and the presence of a non-degenerate `systemMessage`.
+
+### REQ-HFC-004 — session_id resolution for the trace filename (Event-driven)
+
+**When** a `PostToolUseFailure` (or any hook) payload omits `session_id`, the failure/trace subsystem **shall** resolve a session identifier from an available payload source, or fall back to a documented deterministic identifier, such that a resolvable session is NOT written to the shared `trace-unknown.jsonl`. The concrete resolution mechanism (e.g. deriving the session UUID from `transcript_path`) **shall** be investigated during run-phase and the chosen source recorded; **when** no source is resolvable, the documented last-resort fallback applies.
+
+### REQ-HFC-005 — No content-free UnknownFailure message (unwanted behavior)
+
+**When** a failure is genuinely unclassifiable, the failure handler **shall not** emit a content-free `UnknownFailure` `systemMessage`; it **shall** include a bounded excerpt of the observed raw error text (drawn from the top-level `error` field with precedence, else the nested `tool_response` text) so the model receives an actionable signal.
+
+### REQ-HFC-006 — tool_response shape resilience (capability gate / fail-open)
+
+**Where** `tool_response` is a wrapped JSON object, a bare JSON string, malformed, or absent, the failure handler **shall** degrade gracefully — never panic and never return a handler error — falling back to whatever error text is available (fail-open, consistent with the existing `recordToolFailureEvent` fail-open contract).
+
+## §C Exclusions
+
+This SPEC fixes classification-input sourcing and the trace session_id for the `PostToolUseFailure` handler only. The following are explicitly out of scope.
+
+### Out of Scope — new error categories
+
+- No new `ErrorCategory` constants are introduced. The seven existing categories (`TimeoutError`, `PermissionDenied`, `ContextCancelled`, `SandboxViolation`, `OOMKilled`, `ExitError`, `UnknownFailure`) are the complete set.
+- No change to the substring-matching heuristics themselves (which token maps to which category); only the **input** the matchers see is broadened.
+
+### Out of Scope — harness learning-loop semantics
+
+- No change to `recordToolFailureEvent`, the `tool_failure:<tool>:<category>` event key format, or `usage-log.jsonl` recording. The category flows into the learning loop unchanged; only its accuracy improves as a side effect.
+
+### Out of Scope — trace subsystem redesign
+
+- No change to the async `TraceWriter`, rotation, channel-drop degradation, or the `trace-<sessionID>.jsonl` naming scheme. Only the value bound to `sessionID` is corrected.
+- The global `validateInput` `session_id = "unknown"` substitution for OTHER events is not redesigned here; the fix targets the trace-filename resolution path.
+
+### Out of Scope — other hook events
+
+- Only `PostToolUseFailure` classification and its trace filename are addressed. `PostToolUse`, `Stop`, `StopFailure`, and other events are untouched.
+
+## §D Acceptance Criteria (inline — Tier S LEAN)
+
+Each AC is observable and independently verifiable. Given/When/Then.
+
+- **AC-HFC-001a** (REQ-HFC-001): **Given** a `PostToolUseFailure` `HookInput` with an empty top-level `Error` and `tool_response` = `{"error":"permission denied: open /f","stderr":""}`, **When** `Handle` runs, **Then** the classified category is `PermissionDenied` (not `UnknownFailure`) and the `systemMessage` has the `PermissionDenied:` prefix.
+- **AC-HFC-001b** (REQ-HFC-001): **Given** a `PostToolUseFailure` payload with empty top-level `Error` and `tool_response` = `{"stderr":"...context deadline exceeded..."}`, **When** `Handle` runs, **Then** the classified category is `TimeoutError`.
+- **AC-HFC-002** (REQ-HFC-002): **Given** the existing `post_tool_failure_test.go` table cases that set the top-level `Error` field, **When** the suite runs after the fix, **Then** every pre-existing case still classifies to its original expected category (zero regression) — the existing test file passes unmodified in its top-level-Error assertions.
+- **AC-HFC-003** (REQ-HFC-003): **Given** the regression suite, **When** `go test ./internal/hook/...` runs, **Then** the suite contains at least one nested-`tool_response` case for each of the seven categories, each asserting the classified category. Verify: `grep -c 'tool_response\|ToolResponse' internal/hook/post_tool_failure_test.go` returns ≥ 7 nested-payload cases and the test package passes.
+- **AC-HFC-004** (REQ-HFC-004): **Given** a payload that omits `session_id` but carries a resolvable source (per the run-phase-chosen mechanism), **When** the trace filename is computed, **Then** it is NOT `trace-unknown.jsonl`; **and** the chosen resolution source and the last-resort fallback are documented in code and in `progress.md` §E.2. A payload with a present `session_id` still produces `trace-<session_id>.jsonl` (no regression).
+- **AC-HFC-005** (REQ-HFC-005): **Given** a genuinely unclassifiable payload (top-level `Error` empty, `tool_response` = `{"error":"something went wrong"}`), **When** `Handle` runs, **Then** the `systemMessage` is `UnknownFailure`-classified BUT is NOT the exact content-free string `"UnknownFailure: Tool execution failed. Review error logs for details."` — it contains a bounded excerpt of `something went wrong`.
+- **AC-HFC-006** (REQ-HFC-006): **Given** malformed `tool_response` (e.g. `[}`), a bare JSON string, and an absent `tool_response`, **When** `Handle` runs for each, **Then** it returns no error, does not panic, and produces a `systemMessage` (fail-open). Verify with a table-driven resilience test.
+- **AC-HFC-GATE** (quality gate): **Given** the full package, **When** `go test ./internal/hook/... && go vet ./internal/hook/... && golangci-lint run internal/hook/...` runs, **Then** all pass with zero errors and the subagent-boundary grep (`grep -rn 'AskUserQuestion\|mcp__askuser' internal/hook/ | grep -v _test.go`) returns 0 matches.
+
+## §E Definition of Done
+
+- All six REQs implemented; all AC-HFC-* observable checks pass with cited command output.
+- No new `ErrorCategory`; no change to learning-loop event format.
+- Coverage for `internal/hook` classification path ≥ 85% (per-package target).
+- `progress.md` §E.2 records the session_id resolution investigation outcome (chosen source + fallback).

--- a/internal/hook/post_tool_failure.go
+++ b/internal/hook/post_tool_failure.go
@@ -83,9 +83,53 @@ func (h *postToolUseFailureHandler) Handle(ctx context.Context, input *HookInput
 	}, nil
 }
 
+// classificationText aggregates every available error-text source into a
+// single haystack for the ordered category matchers (REQ-HFC-001/002).
+// Real Claude Code PostToolUseFailure payloads nest the failure text under
+// tool_response.error / tool_response.stderr with an empty top-level error
+// field (issue #1089); the union widens the haystack without changing the
+// ordered first-match semantics. tool_response normalization reuses
+// decodeToolResponse (evidence_writer.go), which degrades gracefully on
+// malformed / bare-string / absent payloads (REQ-HFC-006 fail-open).
+func classificationText(input *HookInput) string {
+	var b strings.Builder
+	b.WriteString(input.Error)
+	if len(input.ToolResponse) > 0 {
+		if text, _ := decodeToolResponse(input.ToolResponse); text != "" {
+			b.WriteByte('\n')
+			b.WriteString(text)
+		}
+	}
+	return b.String()
+}
+
+// maxErrorExcerptLen bounds the raw-error excerpt appended to the
+// UnknownFailure message (REQ-HFC-005).
+const maxErrorExcerptLen = 200
+
+// rawErrorExcerpt returns a bounded excerpt of the observed raw error text.
+// Precedence (REQ-HFC-002): the top-level error field wins for the
+// human-facing excerpt; nested tool_response text is the fallback.
+// Returns "" when no raw text is observable.
+func rawErrorExcerpt(input *HookInput) string {
+	text := strings.TrimSpace(input.Error)
+	if text == "" && len(input.ToolResponse) > 0 {
+		decoded, _ := decodeToolResponse(input.ToolResponse)
+		text = strings.TrimSpace(decoded)
+	}
+	if text == "" {
+		return ""
+	}
+	runes := []rune(text)
+	if len(runes) > maxErrorExcerptLen {
+		return string(runes[:maxErrorExcerptLen]) + "..."
+	}
+	return text
+}
+
 // classifyError determines the error category based on error signature.
 func (h *postToolUseFailureHandler) classifyError(input *HookInput) ErrorCategory {
-	errorText := strings.ToLower(input.Error)
+	errorText := strings.ToLower(classificationText(input))
 
 	// Check for timeout (exit code 124 or "timeout" in error message)
 	if strings.Contains(errorText, "timeout") || strings.Contains(errorText, "context deadline exceeded") {
@@ -122,7 +166,7 @@ func (h *postToolUseFailureHandler) classifyError(input *HookInput) ErrorCategor
 }
 
 // formatMessage generates an actionable message for the error category.
-func (h *postToolUseFailureHandler) formatMessage(category ErrorCategory, _ *HookInput) string {
+func (h *postToolUseFailureHandler) formatMessage(category ErrorCategory, input *HookInput) string {
 	switch category {
 	case TimeoutError:
 		return "TimeoutError: Tool execution exceeded time limit. Consider optimizing the operation or increasing timeout settings."
@@ -143,6 +187,13 @@ func (h *postToolUseFailureHandler) formatMessage(category ErrorCategory, _ *Hoo
 		return "ExitError: Tool exited with non-zero status. Check tool logs for details."
 
 	default:
+		// REQ-HFC-005: never emit a content-free UnknownFailure when raw error
+		// text is observable — append a bounded excerpt so the model receives
+		// an actionable signal. The fixed string remains only for payloads
+		// with no observable text at all.
+		if excerpt := rawErrorExcerpt(input); excerpt != "" {
+			return "UnknownFailure: Tool execution failed: " + excerpt
+		}
 		return "UnknownFailure: Tool execution failed. Review error logs for details."
 	}
 }

--- a/internal/hook/post_tool_failure_test.go
+++ b/internal/hook/post_tool_failure_test.go
@@ -2,6 +2,8 @@ package hook
 
 import (
 	"context"
+	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -155,6 +157,272 @@ func TestPostToolUseFailureHandler_Handle(t *testing.T) {
 					got.SystemMessage[:len(expectedPrefix)] != expectedPrefix {
 					t.Errorf("Handle() SystemMessage = %v, want prefix %v", got.SystemMessage, expectedPrefix)
 				}
+			}
+		})
+	}
+}
+
+// contentFreeUnknownMessage is the pre-fix fixed UnknownFailure string that
+// AC-HFC-005 forbids for payloads carrying observable raw error text.
+const contentFreeUnknownMessage = "UnknownFailure: Tool execution failed. Review error logs for details."
+
+// TestPostToolUseFailureHandler_NestedToolResponse covers REQ-HFC-001/003:
+// realistic PostToolUseFailure payloads nest failure text under
+// tool_response.error / tool_response.stderr with an empty top-level Error.
+// One nested case per category (AC-HFC-003).
+func TestPostToolUseFailureHandler_NestedToolResponse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		toolResponse     string
+		expectedCategory ErrorCategory
+	}{
+		{
+			// AC-HFC-001b
+			name:             "nested timeout in stderr",
+			toolResponse:     `{"stderr":"run: context deadline exceeded while waiting"}`,
+			expectedCategory: TimeoutError,
+		},
+		{
+			// AC-HFC-001a
+			name:             "nested permission denied in error",
+			toolResponse:     `{"error":"permission denied: open /f","stderr":""}`,
+			expectedCategory: PermissionDenied,
+		},
+		{
+			name:             "nested context canceled",
+			toolResponse:     `{"error":"context canceled"}`,
+			expectedCategory: ContextCancelled,
+		},
+		{
+			name:             "nested sandbox violation",
+			toolResponse:     `{"stderr":"seccomp filter blocked syscall"}`,
+			expectedCategory: SandboxViolation,
+		},
+		{
+			name:             "nested oom killed",
+			toolResponse:     `{"error":"process killed: out of memory"}`,
+			expectedCategory: OOMKilled,
+		},
+		{
+			name:             "nested exit status",
+			toolResponse:     `{"error":"exit status 1","stderr":"make: *** [build] Error 1"}`,
+			expectedCategory: ExitError,
+		},
+		{
+			name:             "nested genuinely unclassifiable",
+			toolResponse:     `{"error":"something went wrong"}`,
+			expectedCategory: UnknownFailure,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := NewPostToolUseFailureHandler()
+			input := &HookInput{
+				SessionID:     "sess-nested",
+				ToolName:      "Bash",
+				ToolUseID:     "tool-nested",
+				HookEventName: "PostToolUseFailure",
+				ToolResponse:  json.RawMessage(tt.toolResponse),
+			}
+
+			got, err := h.Handle(context.Background(), input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got == nil || got.SystemMessage == "" {
+				t.Fatal("expected non-empty SystemMessage")
+			}
+			expectedPrefix := string(tt.expectedCategory) + ":"
+			if !strings.HasPrefix(got.SystemMessage, expectedPrefix) {
+				t.Errorf("SystemMessage = %q, want prefix %q", got.SystemMessage, expectedPrefix)
+			}
+		})
+	}
+}
+
+// TestPostToolUseFailureHandler_UnknownFailureExcerpt covers REQ-HFC-005
+// (AC-HFC-005): a genuinely unclassifiable failure must carry a bounded
+// excerpt of the observed raw error text, never the content-free string.
+func TestPostToolUseFailureHandler_UnknownFailureExcerpt(t *testing.T) {
+	t.Parallel()
+
+	h := NewPostToolUseFailureHandler()
+	input := &HookInput{
+		SessionID:     "sess-unk",
+		ToolName:      "Bash",
+		HookEventName: "PostToolUseFailure",
+		ToolResponse:  json.RawMessage(`{"error":"something went wrong"}`),
+	}
+
+	got, err := h.Handle(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.SystemMessage == contentFreeUnknownMessage {
+		t.Fatalf("SystemMessage is the content-free string: %q", got.SystemMessage)
+	}
+	if !strings.HasPrefix(got.SystemMessage, "UnknownFailure:") {
+		t.Errorf("SystemMessage = %q, want UnknownFailure: prefix", got.SystemMessage)
+	}
+	if !strings.Contains(got.SystemMessage, "something went wrong") {
+		t.Errorf("SystemMessage = %q, want raw-error excerpt %q", got.SystemMessage, "something went wrong")
+	}
+
+	// Boundedness: a very long raw error is truncated to maxErrorExcerptLen.
+	long := strings.Repeat("z", 500)
+	got2, err := h.Handle(context.Background(), &HookInput{
+		SessionID:     "sess-unk2",
+		ToolName:      "Bash",
+		HookEventName: "PostToolUseFailure",
+		Error:         long,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.HasSuffix(got2.SystemMessage, "...") {
+		t.Errorf("long excerpt not truncated: %q", got2.SystemMessage[:50])
+	}
+	if len(got2.SystemMessage) > len("UnknownFailure: Tool execution failed: ")+maxErrorExcerptLen+3 {
+		t.Errorf("excerpt exceeds bound: len=%d", len(got2.SystemMessage))
+	}
+}
+
+// TestPostToolUseFailureHandler_TopLevelErrorPrecedence covers REQ-HFC-002:
+// when both top-level Error and nested tool_response text are present, the
+// top-level Error wins for the displayed excerpt while classification sees both.
+func TestPostToolUseFailureHandler_TopLevelErrorPrecedence(t *testing.T) {
+	t.Parallel()
+
+	h := NewPostToolUseFailureHandler()
+	input := &HookInput{
+		SessionID:     "sess-prec",
+		ToolName:      "Bash",
+		HookEventName: "PostToolUseFailure",
+		Error:         "top-level mystery text",
+		ToolResponse:  json.RawMessage(`{"error":"nested other text"}`),
+	}
+
+	got, err := h.Handle(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Both sources unclassifiable → UnknownFailure with the TOP-LEVEL excerpt.
+	if !strings.HasPrefix(got.SystemMessage, "UnknownFailure:") {
+		t.Fatalf("SystemMessage = %q, want UnknownFailure: prefix", got.SystemMessage)
+	}
+	if !strings.Contains(got.SystemMessage, "top-level mystery text") {
+		t.Errorf("SystemMessage = %q, want top-level excerpt", got.SystemMessage)
+	}
+	// Classification still considers nested text when top-level misses a category.
+	input2 := &HookInput{
+		SessionID:     "sess-prec2",
+		ToolName:      "Bash",
+		HookEventName: "PostToolUseFailure",
+		Error:         "opaque wrapper failure",
+		ToolResponse:  json.RawMessage(`{"stderr":"permission denied: open /etc/x"}`),
+	}
+	got2, err := h.Handle(context.Background(), input2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.HasPrefix(got2.SystemMessage, "PermissionDenied:") {
+		t.Errorf("SystemMessage = %q, want PermissionDenied: (classification union)", got2.SystemMessage)
+	}
+}
+
+// TestPostToolUseFailureHandler_ToolResponseResilience covers REQ-HFC-006
+// (AC-HFC-006): malformed, bare-string, and absent tool_response degrade
+// gracefully — no panic, no handler error, non-empty SystemMessage.
+func TestPostToolUseFailureHandler_ToolResponseResilience(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		toolResponse json.RawMessage
+	}{
+		{name: "malformed json", toolResponse: json.RawMessage(`[}`)},
+		{name: "bare json string", toolResponse: json.RawMessage(`"boom went the tool"`)},
+		{name: "json array", toolResponse: json.RawMessage(`["a","b"]`)},
+		{name: "absent tool_response", toolResponse: nil},
+		{name: "empty object", toolResponse: json.RawMessage(`{}`)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := NewPostToolUseFailureHandler()
+			input := &HookInput{
+				SessionID:     "sess-res",
+				ToolName:      "Bash",
+				HookEventName: "PostToolUseFailure",
+				ToolResponse:  tt.toolResponse,
+			}
+			got, err := h.Handle(context.Background(), input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got == nil || got.SystemMessage == "" {
+				t.Fatal("expected non-empty SystemMessage (fail-open)")
+			}
+		})
+	}
+}
+
+// TestResolveTraceSessionID covers REQ-HFC-004 (AC-HFC-004): when session_id
+// is absent (substituted to "unknown"), the trace session identifier is
+// derived from the transcript_path session UUID; a present session_id wins;
+// an unresolvable payload keeps the documented "unknown" last-resort fallback.
+func TestResolveTraceSessionID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input *HookInput
+		want  string
+	}{
+		{
+			name:  "explicit session_id wins",
+			input: &HookInput{SessionID: "sess-explicit", TranscriptPath: "/x/.claude/projects/p/0d661925-1111-2222-3333-444455556666.jsonl"},
+			want:  "sess-explicit",
+		},
+		{
+			name:  "unknown session_id derives UUID from transcript_path",
+			input: &HookInput{SessionID: "unknown", TranscriptPath: "/x/.claude/projects/p/0d661925-1111-2222-3333-444455556666.jsonl"},
+			want:  "0d661925-1111-2222-3333-444455556666",
+		},
+		{
+			name:  "empty session_id derives UUID from transcript_path",
+			input: &HookInput{SessionID: "", TranscriptPath: "/x/.claude/projects/p/0d661925-1111-2222-3333-444455556666.jsonl"},
+			want:  "0d661925-1111-2222-3333-444455556666",
+		},
+		{
+			name:  "non-UUID transcript base falls back to unknown",
+			input: &HookInput{SessionID: "unknown", TranscriptPath: "/x/notes.jsonl"},
+			want:  "unknown",
+		},
+		{
+			name:  "no sources falls back to unknown",
+			input: &HookInput{SessionID: "unknown"},
+			want:  "unknown",
+		},
+		{
+			name:  "nil input falls back to empty",
+			input: nil,
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := resolveTraceSessionID(tt.input); got != tt.want {
+				t.Errorf("resolveTraceSessionID() = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/internal/hook/registry.go
+++ b/internal/hook/registry.go
@@ -79,9 +79,13 @@ func (r *registry) Dispatch(ctx context.Context, event EventType, input *HookInp
 		return r.defaultOutputForEvent(event, input), nil
 	}
 
-	// Lazily initialize TraceWriter on first Dispatch with a known SessionID (REQ-OBS-001).
+	// Lazily initialize TraceWriter on first Dispatch with a known SessionID
+	// (REQ-OBS-001). REQ-HFC-004: when session_id was omitted by Claude Code
+	// (validateInput substituted "unknown"), derive the session UUID from
+	// transcript_path so resolvable sessions do not collide into
+	// trace-unknown.jsonl.
 	if input != nil {
-		r.ensureTraceWriter(input.SessionID)
+		r.ensureTraceWriter(resolveTraceSessionID(input))
 	}
 
 	// Apply timeout from registry configuration

--- a/internal/hook/trace_session.go
+++ b/internal/hook/trace_session.go
@@ -1,0 +1,52 @@
+// SPEC-HOOK-FAILURE-CLASSIFY-001 REQ-HFC-004: trace session_id resolution.
+// PostToolUse / PostToolUseFailure payloads may omit session_id (Claude Code
+// bug #541), in which case validateInput substitutes "unknown" and every
+// session-id-less event collides into a shared trace-unknown.jsonl. The
+// transcript_path field, however, is named after the session UUID
+// (~/.claude/projects/<hash>/<session-uuid>.jsonl), so a resolvable session
+// can be recovered from it. Fallback chain (documented last resort):
+// explicit session_id → transcript_path UUID → "unknown" (unchanged).
+package hook
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// sessionUUIDPattern matches a canonical RFC 4122 UUID string, the filename
+// stem Claude Code uses for session transcripts.
+var sessionUUIDPattern = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+
+// resolveTraceSessionID returns the session identifier to bind into the
+// trace filename (trace-<sessionID>.jsonl). A present, non-placeholder
+// session_id always wins (no regression for well-formed payloads); the
+// "unknown" placeholder injected by validateInput and an empty value both
+// trigger transcript_path derivation. When nothing resolves, the original
+// value is kept so the documented "unknown" last-resort fallback applies.
+func resolveTraceSessionID(input *HookInput) string {
+	if input == nil {
+		return ""
+	}
+	if input.SessionID != "" && input.SessionID != "unknown" {
+		return input.SessionID
+	}
+	if uuid := sessionUUIDFromTranscriptPath(input.TranscriptPath); uuid != "" {
+		return uuid
+	}
+	return input.SessionID
+}
+
+// sessionUUIDFromTranscriptPath extracts the session UUID from a transcript
+// path of the form .../<session-uuid>.jsonl. Returns "" when the path is
+// empty or its base name is not a UUID (fail-open — never guesses).
+func sessionUUIDFromTranscriptPath(transcriptPath string) string {
+	if transcriptPath == "" {
+		return ""
+	}
+	base := strings.TrimSuffix(filepath.Base(transcriptPath), ".jsonl")
+	if sessionUUIDPattern.MatchString(base) {
+		return base
+	}
+	return ""
+}

--- a/internal/template/settings_test.go
+++ b/internal/template/settings_test.go
@@ -254,8 +254,10 @@ func TestSettingsTemplateStatusLine(t *testing.T) {
 	// $CLAUDE_PROJECT_DIR is a Claude Code built-in token available to the
 	// statusLine command at runtime (same env vars as hooks). Anchoring the
 	// path to it makes statusLine resolve regardless of cwd (e.g. after /cd).
-	if sl["command"] != "$CLAUDE_PROJECT_DIR/.moai/status_line.sh" {
-		t.Errorf("statusLine.command = %v, want %q", sl["command"], "$CLAUDE_PROJECT_DIR/.moai/status_line.sh")
+	// The path is double-quoted so projects whose absolute path contains
+	// spaces do not word-split (issue #1096).
+	if sl["command"] != `"$CLAUDE_PROJECT_DIR/.moai/status_line.sh"` {
+		t.Errorf("statusLine.command = %v, want %q", sl["command"], `"$CLAUDE_PROJECT_DIR/.moai/status_line.sh"`)
 	}
 }
 

--- a/internal/template/templates/.claude/settings.json.tmpl
+++ b/internal/template/templates/.claude/settings.json.tmpl
@@ -388,7 +388,7 @@
 {{- if eq .Platform "windows"}}
     "command": "bash \"$CLAUDE_PROJECT_DIR/.moai/status_line.sh\"",
 {{- else}}
-    "command": "$CLAUDE_PROJECT_DIR/.moai/status_line.sh",
+    "command": "\"$CLAUDE_PROJECT_DIR/.moai/status_line.sh\"",
 {{- end}}
     "refreshInterval": 10
   },

--- a/internal/template/templates/.github/labels.yml
+++ b/internal/template/templates/.github/labels.yml
@@ -1,0 +1,127 @@
+# Standardized label definitions for this repository
+# Compatible with EndBug/label-sync or manual reference
+#
+# Usage with EndBug/label-sync (see .github/workflows/label-sync.yml):
+#   - uses: EndBug/label-sync@v2
+#     with:
+#       config-file: .github/labels.yml
+#
+# Taxonomy: 3-axis scheme (type:* / priority:* / status:*) plus
+# GitHub-standard functional labels. Extend with project-specific
+# area:* labels as needed.
+
+# ============================================================================
+# GitHub-standard / functional labels
+# ============================================================================
+
+- name: stale
+  color: "ededed"
+  description: "Marked as stale due to inactivity"
+
+- name: pinned
+  color: "006b75"
+  description: "Pinned and exempt from stale bot"
+
+- name: "help wanted"
+  color: "008672"
+  description: "Extra attention is needed"
+
+- name: "good first issue"
+  color: "7ae07a"
+  description: "Good for newcomers"
+
+- name: wontfix
+  color: "ffffff"
+  description: "This will not be worked on"
+
+- name: duplicate
+  color: "cfd3d7"
+  description: "This issue or pull request already exists"
+
+- name: security
+  color: "ee0701"
+  description: "Security-related issue"
+
+- name: dependencies
+  color: "0366d6"
+  description: "Dependency updates"
+
+# ============================================================================
+# type:* (one per PR)
+# ============================================================================
+
+- name: "type:feature"
+  color: "1f883d"
+  description: "New feature or capability"
+
+- name: "type:fix"
+  color: "d73a4a"
+  description: "Bug fix"
+
+- name: "type:docs"
+  color: "0075ca"
+  description: "Documentation only change"
+
+- name: "type:chore"
+  color: "fbca04"
+  description: "Maintenance (dependencies, cleanup)"
+
+- name: "type:ci"
+  color: "e3d21c"
+  description: "CI/CD change"
+
+- name: "type:refactor"
+  color: "d2dae6"
+  description: "Code restructuring without behavior change"
+
+- name: "type:security"
+  color: "ee0701"
+  description: "Security fix or hardening"
+
+- name: "type:test"
+  color: "d876e3"
+  description: "Test addition or improvement"
+
+# ============================================================================
+# priority:*
+# ============================================================================
+
+- name: "priority:P0"
+  color: "b60205"
+  description: "Critical — immediate response required"
+
+- name: "priority:P1"
+  color: "d93f0b"
+  description: "High"
+
+- name: "priority:P2"
+  color: "fbca04"
+  description: "Medium"
+
+- name: "priority:P3"
+  color: "85e89d"
+  description: "Low — backlog"
+
+- name: "priority:P4"
+  color: "c2c2c2"
+  description: "Icebox — deferred indefinitely"
+
+# ============================================================================
+# status:* (optional, progress tracking)
+# ============================================================================
+
+- name: "status:in-progress"
+  color: "ffd700"
+  description: "Currently being worked on"
+
+- name: "status:review"
+  color: "0075ca"
+  description: "In code review"
+
+- name: "status:blocked"
+  color: "d73a4a"
+  description: "Blocked on external dependency"
+
+- name: "status:needs-info"
+  color: "ffffa5"
+  description: "Waiting for additional information from reporter"


### PR DESCRIPTION
## Summary

Three-issue sweep, each with test evidence:

- **#1096** — quote the statusLine path in the non-Windows branch of `settings.json.tmpl` so spaces-in-path projects render the statusbar (1-line template patch + test expectation update). Fixes #1096
- **#1089** — `SPEC-HOOK-FAILURE-CLASSIFY-001` (TDD, 8/8 AC): classify nested `tool_response.error`/`stderr` instead of only top-level `error`; bounded raw-error excerpt on genuinely unclassifiable failures; trace session id resolved from `transcript_path` UUID when `session_id` is absent. Fixes #1089
- **#1094** (secondary defect) — ship the neutral `.github/labels.yml` referenced by the distributed `label-sync.yml` workflow. Refs #1094 (primary claim pending reproduction info)

## Verification

- `go test ./...` exit 0 (full suite), `go build ./...` exit 0 (incl. GOOS=windows for touched pkg)
- Real-binary smoke: nested timeout payload → `TimeoutError`; unclassifiable → excerpt-bearing message
- golangci-lint: no new issues in touched packages

🗿 MoAI