### PR TITLE
fix(ci): close paths-filter dead zone for workflow-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
           filters: |
             docs_only:
               - '**.md'
+              - '.github/**'
               - '.moai/specs/**'
               - '.moai/docs/**'
               - '.moai/reports/**'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,6 +41,7 @@ jobs:
           filters: |
             docs_only:
               - '**.md'
+              - '.github/**'
               - '.moai/specs/**'
               - '.moai/docs/**'
               - '.moai/reports/**'


### PR DESCRIPTION
A PR changing only a non-ci/codeql workflow file (e.g. dependabot's claude-code-action bump in #1097) matches neither `docs_only` nor `go_code`, so the required `Test (ubuntu-latest)` / `Analyze (Go) (go)` contexts never report — the PR is permanently unmergeable under branch protection. Adds `.github/**` to `docs_only` in ci.yml + codeql.yml so such PRs get the existing skip-markers; edits to ci.yml/codeql.yml themselves still run full CI via `go_code` (mixed-PR guard unchanged).

🗿 MoAI