### PR TITLE
feat(cli): add language, user name, and advanced-bridge steps to init wizard

### DIFF
--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -376,13 +376,29 @@ func runInit(cmd *cobra.Command, args []string) error {
 		// Use RunWithDefaultsModes when --standard or --advanced is set; otherwise
 		// fall back to RunWithDefaults for Quick mode backward-compat (REQ-IWE-006).
 		// runWizardFn is the injectable wizard seam (REQ-TUX2-001 order contract).
-		result, wizErr := runWizardFn(rootFlag, "", standardMode, advancedMode)
+		// The profile locale + user name pre-fill the conversation_language and
+		// user_name question defaults (empty when no profile exists).
+		result, wizErr := runWizardFn(rootFlag, opts.ConvLang, opts.UserName, standardMode, advancedMode)
 		if wizErr != nil {
 			if errors.Is(wizErr, wizard.ErrCancelled) {
 				_, _ = fmt.Fprintln(cmd.OutOrStderr(), "Initialization cancelled.")
 				return nil
 			}
 			return fmt.Errorf("wizard failed: %w", wizErr)
+		}
+
+		// Conversation language + user name: the wizard answer wins over the
+		// profile value. Update both opts (drives template deployment of
+		// language.yaml/user.yaml) AND prefs (SyncToProjectConfig runs after
+		// deployment and would otherwise re-apply the stale profile value over
+		// the wizard choice). Empty answers leave the profile fallback intact.
+		if result.ConversationLang != "" {
+			opts.ConvLang = result.ConversationLang
+			prefs.ConversationLang = result.ConversationLang
+		}
+		if result.UserName != "" {
+			opts.UserName = result.UserName
+			prefs.UserName = result.UserName
 		}
 
 		// Apply wizard results to opts (wizard values override empty flags)

--- a/internal/cli/init_update_notice.go
+++ b/internal/cli/init_update_notice.go
@@ -65,11 +65,11 @@ var isInteractiveStdin = func() bool {
 
 // runWizardFn runs the init wizard. Injectable seam for the network-order
 // contract test (AC-TUX2-001); the default dispatches on the mode flags.
-var runWizardFn = func(rootFlag, locale string, standardMode, advancedMode bool) (*wizard.WizardResult, error) {
+var runWizardFn = func(rootFlag, locale, userName string, standardMode, advancedMode bool) (*wizard.WizardResult, error) {
 	if standardMode {
-		return wizard.RunWithDefaultsModes(rootFlag, locale, standardMode, advancedMode)
+		return wizard.RunWithDefaultsModes(rootFlag, locale, userName, standardMode, advancedMode)
 	}
-	return wizard.RunWithDefaults(rootFlag, locale)
+	return wizard.RunWithDefaults(rootFlag, locale, userName)
 }
 
 // startDeferredUpdateNotice launches the non-blocking deferred binary-update

--- a/internal/cli/init_update_notice_test.go
+++ b/internal/cli/init_update_notice_test.go
@@ -109,7 +109,7 @@ func TestInitNoNetworkBeforeWizard(t *testing.T) {
 	t.Cleanup(func() { isInteractiveStdin = origInteractive })
 
 	origWizard := runWizardFn
-	runWizardFn = func(rootFlag, locale string, standardMode, advancedMode bool) (*wizard.WizardResult, error) {
+	runWizardFn = func(rootFlag, locale, userName string, standardMode, advancedMode bool) (*wizard.WizardResult, error) {
 		rec.record("wizard-start")
 		if got := rec.count("update-check"); got != 0 {
 			t.Errorf("update-check ran before/during wizard: %d calls", got)

--- a/internal/cli/init_wizard_identity_test.go
+++ b/internal/cli/init_wizard_identity_test.go
@@ -1,0 +1,72 @@
+package cli
+
+// Focused coverage for the init wizard identity/locale wiring: the wizard's
+// conversation_language and user_name answers must flow into opts (driving
+// template deployment of language.yaml / user.yaml) and win over the profile
+// fallback. This exercises runInit through the injectable runWizardFn seam.
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/modu-ai/moai-adk/internal/cli/wizard"
+)
+
+// TestInitWizardIdentityPersisted asserts the wizard's conversation_language and
+// user_name answers land in the generated config files.
+func TestInitWizardIdentityPersisted(t *testing.T) {
+	// Isolate HOME so no real profile leaks in and the profile auto-prompt path
+	// stays inert (stdin is not a TTY in tests → the huh.Confirm never runs).
+	t.Setenv("HOME", t.TempDir())
+
+	origInteractive := isInteractiveStdin
+	isInteractiveStdin = func() bool { return true }
+	t.Cleanup(func() { isInteractiveStdin = origInteractive })
+
+	origDeps := deps
+	deps = nil
+	t.Cleanup(func() { deps = origDeps })
+
+	origWizard := runWizardFn
+	runWizardFn = func(_, _, _ string, _, _ bool) (*wizard.WizardResult, error) {
+		return &wizard.WizardResult{
+			ConversationLang: "ja",
+			UserName:         "WizardName",
+			ProjectName:      "ident-proj",
+			ModelPolicy:      "high",
+			ReportFormat:     "html+md",
+			GitMode:          "manual",
+		}, nil
+	}
+	t.Cleanup(func() { runWizardFn = origWizard })
+
+	projectDir := filepath.Join(t.TempDir(), "ident-proj")
+	cmd := newInitTestCmd()
+	var out, errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+
+	if err := runInit(cmd, []string{projectDir}); err != nil {
+		t.Fatalf("runInit: %v", err)
+	}
+
+	langPath := filepath.Join(projectDir, ".moai", "config", "sections", "language.yaml")
+	langData, err := os.ReadFile(langPath)
+	if err != nil {
+		t.Fatalf("read language.yaml: %v", err)
+	}
+	if !bytes.Contains(langData, []byte(`conversation_language: "ja"`)) {
+		t.Errorf("language.yaml must carry the wizard locale 'ja', got:\n%s", langData)
+	}
+
+	userPath := filepath.Join(projectDir, ".moai", "config", "sections", "user.yaml")
+	userData, err := os.ReadFile(userPath)
+	if err != nil {
+		t.Fatalf("read user.yaml: %v", err)
+	}
+	if !bytes.Contains(userData, []byte("WizardName")) {
+		t.Errorf("user.yaml must carry the wizard user name 'WizardName', got:\n%s", userData)
+	}
+}

--- a/internal/cli/wizard/coverage_boost_test.go
+++ b/internal/cli/wizard/coverage_boost_test.go
@@ -223,7 +223,7 @@ func TestRunWithDefaults_ReturnsError(t *testing.T) {
 	// and returns ErrNoQuestions only when no questions given (covered elsewhere).
 	// Here we call it and expect a non-nil error (not ErrNoQuestions since
 	// DefaultQuestions returns multiple questions).
-	_, err := RunWithDefaults("/tmp/test-run-defaults", "")
+	_, err := RunWithDefaults("/tmp/test-run-defaults", "", "")
 	// In non-TTY: huh returns an error. We just verify the function is callable.
 	if err == ErrNoQuestions {
 		t.Error("RunWithDefaults should not return ErrNoQuestions (questions exist)")

--- a/internal/cli/wizard/expansion_test.go
+++ b/internal/cli/wizard/expansion_test.go
@@ -51,6 +51,37 @@ func TestPhase1QuestionsStructure(t *testing.T) {
 	}
 }
 
+// TestAdvancedBridgeRevealsPhase1 verifies the requirement-C mechanism: in a
+// quick-mode question set (DefaultQuestions + Phase1Questions), answering the
+// advanced_bridge Confirm Yes flips StandardMode, which makes the Phase 1
+// questions visible in the same run (and hides the bridge itself).
+func TestAdvancedBridgeRevealsPhase1(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	all := append(DefaultQuestions(tmpDir), Phase1Questions(tmpDir)...)
+
+	// Quick mode before answering the bridge: Phase 1 hidden, bridge visible.
+	quick := &WizardResult{EnforceQuality: true, DesignEnabled: true, ClaudeDesignEnabled: true}
+	if q := QuestionByID(all, "project_mode"); q == nil || q.Condition(quick) {
+		t.Error("project_mode (Phase 1) must be hidden before the bridge is answered")
+	}
+	if q := QuestionByID(all, "advanced_bridge"); q == nil || !q.Condition(quick) {
+		t.Error("advanced_bridge must be visible in quick mode")
+	}
+
+	// Bridge answered Yes → StandardMode flips → Phase 1 revealed, bridge hidden.
+	saveBoolAnswer("advanced_bridge", true, quick)
+	if !quick.StandardMode {
+		t.Fatal("advanced_bridge=Yes must set StandardMode")
+	}
+	if q := QuestionByID(all, "project_mode"); q == nil || !q.Condition(quick) {
+		t.Error("project_mode (Phase 1) must be visible after the bridge is answered Yes")
+	}
+	if q := QuestionByID(all, "advanced_bridge"); q == nil || q.Condition(quick) {
+		t.Error("advanced_bridge must hide itself once StandardMode is set")
+	}
+}
+
 // TestPhase1Questions_StandardModeGating verifies questions are hidden when StandardMode=false.
 func TestPhase1Questions_StandardModeGating(t *testing.T) {
 	t.Parallel()

--- a/internal/cli/wizard/questions.go
+++ b/internal/cli/wizard/questions.go
@@ -9,16 +9,19 @@ import (
 
 // DefaultQuestions returns the standard set of questions for project initialization.
 // The questions follow this order:
-// 1. Project name (required)
-// 2. Model policy
-// 3. Report format
-// 4. Git mode
-// 5. Git provider (conditional)
-// 6. GitLab instance URL (conditional)
-// 7. GitHub username (conditional)
-// 8. GitHub token (conditional)
-// 9. GitLab username (conditional)
-// 10. GitLab token (conditional)
+// 1. Conversation language (drives the rendering language of every later question)
+// 2. User name (optional)
+// 3. Project name (required)
+// 4. Model policy
+// 5. Report format
+// 6. Git mode
+// 7. Git provider (conditional)
+// 8. GitLab instance URL (conditional)
+// 9. GitHub username (conditional)
+// 10. GitHub token (conditional)
+// 11. GitLab username (conditional)
+// 12. GitLab token (conditional)
+// 13. Advanced-settings bridge (conditional — hidden when StandardMode is preset by flag)
 //
 // plan_type and development_mode are NO LONGER interactive questions — they
 // default silently (plan_type → subscription at persistence; development_mode →
@@ -31,7 +34,39 @@ func DefaultQuestions(projectRoot string) []Question {
 	}
 
 	return []Question{
-		// 1. Project Name
+		// 1. Conversation language — asked first so every subsequent question
+		// renders in the chosen language (saveAnswer updates the live locale).
+		// The default is pre-filled from the profile's ConversationLang by the
+		// wizard entry point when available (else "en"). Option labels carry the
+		// native language name and are never translated (GetLocalizedQuestion
+		// leaves them untouched because the translation entry supplies no options).
+		{
+			ID:          "conversation_language",
+			Group:       "Language",
+			Type:        QuestionTypeSelect,
+			Title:       "Select conversation language",
+			Description: "The language MoAI uses when talking with you. The wizard switches to it immediately.",
+			Options: []Option{
+				{Label: "English", Value: "en", Desc: "English"},
+				{Label: "Korean (한국어)", Value: "ko", Desc: "한국어"},
+				{Label: "Japanese (日本語)", Value: "ja", Desc: "日本語"},
+				{Label: "Chinese (中文)", Value: "zh", Desc: "中文"},
+			},
+			Default:  "en",
+			Required: true,
+		},
+		// 2. User Name — optional; pre-filled from the profile's UserName by the
+		// wizard entry point when available. Empty is allowed.
+		{
+			ID:          "user_name",
+			Group:       "Identity",
+			Type:        QuestionTypeInput,
+			Title:       "Enter your name",
+			Description: "How MoAI addresses you. Persisted to user.yaml (user.name). Leave empty to skip.",
+			Default:     "",
+			Required:    false,
+		},
+		// 3. Project Name
 		{
 			ID:          "project_name",
 			Group:       "Project",
@@ -169,6 +204,21 @@ func DefaultQuestions(projectRoot string) []Question {
 			Condition: func(r *WizardResult) bool {
 				return (r.GitMode == "personal" || r.GitMode == "team") && r.GitProvider == "gitlab"
 			},
+		},
+		// 13. Advanced-settings bridge (Quick mode only). Answering Yes flips
+		// StandardMode on, which reveals the Phase 1 questions (gated on
+		// r.StandardMode) in the same wizard run. Hidden when --standard/--advanced
+		// already preset StandardMode (Condition returns false), so the flag path
+		// never double-asks.
+		{
+			ID:          "advanced_bridge",
+			Group:       "Options",
+			Type:        QuestionTypeConfirm,
+			Title:       "Configure advanced settings? (default: No)",
+			Description: "Reveals project mode, harness profile, LSP, quality gates, and design options in this run.",
+			Default:     "false",
+			Required:    false,
+			Condition:   func(r *WizardResult) bool { return !r.StandardMode },
 		},
 	}
 }

--- a/internal/cli/wizard/questions_test.go
+++ b/internal/cli/wizard/questions_test.go
@@ -87,12 +87,15 @@ func TestReportFormatTranslationsExist(t *testing.T) {
 func TestQuestionOrder(t *testing.T) {
 	questions := DefaultQuestions("/tmp/test-project")
 
-	// The first question should now be "project_name"
-	if questions[0].ID != "project_name" {
-		t.Errorf("first question should be 'project_name', got %q", questions[0].ID)
+	// The first question is now "conversation_language" (drives the render
+	// language of every later question); "user_name" is second.
+	if questions[0].ID != "conversation_language" {
+		t.Errorf("first question should be 'conversation_language', got %q", questions[0].ID)
 	}
 
 	expectedIDs := []string{
+		"conversation_language",
+		"user_name",
 		"project_name",
 		"model_policy",
 		"report_format",
@@ -103,6 +106,7 @@ func TestQuestionOrder(t *testing.T) {
 		"github_token",
 		"gitlab_username",
 		"gitlab_token",
+		"advanced_bridge",
 	}
 
 	for i, expectedID := range expectedIDs {
@@ -164,8 +168,10 @@ func TestRemovedQuestionsAbsent(t *testing.T) {
 	questions := DefaultQuestions("/tmp/test-project")
 
 	removedIDs := []string{
+		// "locale" stays removed — the language question uses the clearer ID
+		// "conversation_language". "user_name" was RE-ADDED as wizard step 2, so
+		// it is intentionally absent from this removed list.
 		"locale",
-		"user_name",
 		"git_commit_lang",
 		"code_comment_lang",
 		"doc_lang",
@@ -196,6 +202,8 @@ func TestQuestionsAllPresent(t *testing.T) {
 	questions := DefaultQuestions("/tmp/test-project")
 
 	expectedIDs := []string{
+		"conversation_language",
+		"user_name",
 		"project_name",
 		"model_policy",
 		"report_format",
@@ -206,6 +214,7 @@ func TestQuestionsAllPresent(t *testing.T) {
 		"github_token",
 		"gitlab_username",
 		"gitlab_token",
+		"advanced_bridge",
 	}
 
 	for _, id := range expectedIDs {
@@ -241,6 +250,201 @@ func TestGitConditionalFilteredByMode(t *testing.T) {
 	}
 	if !providerFound {
 		t.Error("git_provider should be visible when git_mode is 'team'")
+	}
+}
+
+// TestConversationLanguageQuestion verifies the language question is first, is a
+// Select with the 4 supported locales, defaults to "en", and is unconditional.
+func TestConversationLanguageQuestion(t *testing.T) {
+	questions := DefaultQuestions("/tmp/test-project")
+
+	if questions[0].ID != "conversation_language" {
+		t.Fatalf("conversation_language must be the first question, got %q", questions[0].ID)
+	}
+	q := QuestionByID(questions, "conversation_language")
+	if q == nil {
+		t.Fatal("conversation_language question not found")
+		return
+	}
+	if q.Type != QuestionTypeSelect {
+		t.Errorf("conversation_language should be QuestionTypeSelect, got %v", q.Type)
+	}
+	wantValues := []string{"en", "ko", "ja", "zh"}
+	if len(q.Options) != len(wantValues) {
+		t.Fatalf("conversation_language should have %d options, got %d", len(wantValues), len(q.Options))
+	}
+	for i, v := range wantValues {
+		if q.Options[i].Value != v {
+			t.Errorf("option %d value = %q, want %q", i, q.Options[i].Value, v)
+		}
+	}
+	if q.Default != "en" {
+		t.Errorf("conversation_language default = %q, want %q", q.Default, "en")
+	}
+	if !q.Required {
+		t.Error("conversation_language should be required")
+	}
+	if q.Condition != nil {
+		t.Error("conversation_language should be unconditional (always visible)")
+	}
+}
+
+// TestUserNameQuestion verifies the user_name question is second, is an optional
+// Input, and is unconditional.
+func TestUserNameQuestion(t *testing.T) {
+	questions := DefaultQuestions("/tmp/test-project")
+
+	if questions[1].ID != "user_name" {
+		t.Fatalf("user_name must be the second question, got %q", questions[1].ID)
+	}
+	q := QuestionByID(questions, "user_name")
+	if q == nil {
+		t.Fatal("user_name question not found")
+		return
+	}
+	if q.Type != QuestionTypeInput {
+		t.Errorf("user_name should be QuestionTypeInput, got %v", q.Type)
+	}
+	if q.Required {
+		t.Error("user_name should not be required (empty allowed)")
+	}
+	if q.Condition != nil {
+		t.Error("user_name should be unconditional (always visible)")
+	}
+}
+
+// TestAdvancedBridgeQuestion verifies the bridge Confirm is last, defaults to No,
+// and is hidden once StandardMode is preset (by --standard/--advanced).
+func TestAdvancedBridgeQuestion(t *testing.T) {
+	questions := DefaultQuestions("/tmp/test-project")
+
+	if last := questions[len(questions)-1]; last.ID != "advanced_bridge" {
+		t.Fatalf("advanced_bridge must be the last question, got %q", last.ID)
+	}
+	q := QuestionByID(questions, "advanced_bridge")
+	if q == nil {
+		t.Fatal("advanced_bridge question not found")
+		return
+	}
+	if q.Type != QuestionTypeConfirm {
+		t.Errorf("advanced_bridge should be QuestionTypeConfirm, got %v", q.Type)
+	}
+	if q.Default != "false" {
+		t.Errorf("advanced_bridge default = %q, want %q (No)", q.Default, "false")
+	}
+	if q.Condition == nil {
+		t.Fatal("advanced_bridge must have a condition")
+	}
+	// Visible in quick mode (StandardMode false), hidden when preset by flag.
+	if !q.Condition(&WizardResult{StandardMode: false}) {
+		t.Error("advanced_bridge should be visible in quick mode (StandardMode=false)")
+	}
+	if q.Condition(&WizardResult{StandardMode: true}) {
+		t.Error("advanced_bridge should be hidden when StandardMode is preset by flag")
+	}
+}
+
+// TestSaveAnswerConversationLanguage verifies the answer stores the code AND
+// updates the live locale pointer (drives reactive re-render of later questions).
+func TestSaveAnswerConversationLanguage(t *testing.T) {
+	result := &WizardResult{}
+	locale := "en"
+
+	saveAnswer("conversation_language", "ko", result, &locale)
+	if result.ConversationLang != "ko" {
+		t.Errorf("ConversationLang = %q, want %q", result.ConversationLang, "ko")
+	}
+	if locale != "ko" {
+		t.Errorf("live locale = %q, want %q (must update for reactive rendering)", locale, "ko")
+	}
+}
+
+// TestSaveAnswerUserName verifies the user_name answer is stored.
+func TestSaveAnswerUserName(t *testing.T) {
+	result := &WizardResult{}
+	locale := ""
+
+	saveAnswer("user_name", "GOOS", result, &locale)
+	if result.UserName != "GOOS" {
+		t.Errorf("UserName = %q, want %q", result.UserName, "GOOS")
+	}
+}
+
+// TestSaveBoolAnswerAdvancedBridge verifies the bridge flips StandardMode so the
+// gated Phase 1 questions become visible in the same run.
+func TestSaveBoolAnswerAdvancedBridge(t *testing.T) {
+	result := &WizardResult{}
+	saveBoolAnswer("advanced_bridge", true, result)
+	if !result.StandardMode {
+		t.Error("advanced_bridge=Yes must set StandardMode=true")
+	}
+	saveBoolAnswer("advanced_bridge", false, result)
+	if result.StandardMode {
+		t.Error("advanced_bridge=No must set StandardMode=false")
+	}
+}
+
+// TestNewQuestionTranslationsExist verifies ko/ja/zh translations exist for the
+// three new questions (no hardcoded UI strings that belong in the tables).
+func TestNewQuestionTranslationsExist(t *testing.T) {
+	ids := []string{"conversation_language", "user_name", "advanced_bridge"}
+	for _, locale := range []string{"ko", "ja", "zh"} {
+		langTrans, ok := translations[locale]
+		if !ok {
+			t.Fatalf("translations for locale %q not found", locale)
+		}
+		for _, id := range ids {
+			trans, ok := langTrans[id]
+			if !ok {
+				t.Errorf("translation for %q in locale %q not found", id, locale)
+				continue
+			}
+			if trans.Title == "" {
+				t.Errorf("translation for %q in locale %q has empty title", id, locale)
+			}
+			if trans.Description == "" {
+				t.Errorf("translation for %q in locale %q has empty description", id, locale)
+			}
+		}
+	}
+	// The conversation_language options must NOT be translated — native language
+	// names (Korean (한국어), etc.) stay in the base question.
+	q := QuestionByID(DefaultQuestions("/tmp/test"), "conversation_language")
+	localized := GetLocalizedQuestion(q, "ko")
+	if localized.Options[1].Label != "Korean (한국어)" {
+		t.Errorf("language option labels must stay native, got %q", localized.Options[1].Label)
+	}
+}
+
+// TestPrefillIdentityDefaults verifies the profile user name pre-fills the
+// user_name question default (empty leaves it untouched).
+func TestPrefillIdentityDefaults(t *testing.T) {
+	questions := DefaultQuestions("/tmp/test")
+	prefillIdentityDefaults(questions, "GOOS")
+	if q := QuestionByID(questions, "user_name"); q == nil || q.Default != "GOOS" {
+		t.Errorf("user_name default should be pre-filled to 'GOOS', got %+v", q)
+	}
+
+	questions2 := DefaultQuestions("/tmp/test")
+	prefillIdentityDefaults(questions2, "")
+	if q := QuestionByID(questions2, "user_name"); q == nil || q.Default != "" {
+		t.Errorf("empty userName should leave default empty, got %+v", q)
+	}
+}
+
+// TestPrefillLocaleDefault verifies the profile/project locale pre-fills the
+// conversation_language default (empty leaves the static "en" default).
+func TestPrefillLocaleDefault(t *testing.T) {
+	questions := DefaultQuestions("/tmp/test")
+	prefillLocaleDefault(questions, "ja")
+	if q := QuestionByID(questions, "conversation_language"); q == nil || q.Default != "ja" {
+		t.Errorf("conversation_language default should be 'ja', got %+v", q)
+	}
+
+	questions2 := DefaultQuestions("/tmp/test")
+	prefillLocaleDefault(questions2, "")
+	if q := QuestionByID(questions2, "conversation_language"); q == nil || q.Default != "en" {
+		t.Errorf("empty locale should keep the static 'en' default, got %+v", q)
 	}
 }
 

--- a/internal/cli/wizard/translations.go
+++ b/internal/cli/wizard/translations.go
@@ -23,6 +23,19 @@ type UIStrings struct {
 // translations maps language code -> question ID -> translation.
 var translations = map[string]map[string]QuestionTranslation{
 	"ko": {
+		"conversation_language": {
+			Title:       "대화 언어 선택",
+			Description: "MoAI가 대화할 때 사용하는 언어입니다. 마법사가 즉시 해당 언어로 전환됩니다.",
+			// Options intentionally omitted: language labels stay in their native form.
+		},
+		"user_name": {
+			Title:       "이름 입력",
+			Description: "MoAI가 부를 이름입니다. user.yaml(user.name)에 저장됩니다. 비워두면 건너뜁니다.",
+		},
+		"advanced_bridge": {
+			Title:       "고급 설정을 구성할까요? (기본값: 아니오)",
+			Description: "프로젝트 모드, 하네스 프로파일, LSP, 품질 게이트, 디자인 옵션을 이번 실행에서 표시합니다.",
+		},
 		"project_name": {
 			Title:       "프로젝트 이름 입력",
 			Description: "프로젝트의 이름입니다.",
@@ -82,6 +95,18 @@ var translations = map[string]map[string]QuestionTranslation{
 		},
 	},
 	"ja": {
+		"conversation_language": {
+			Title:       "会話言語を選択",
+			Description: "MoAIが会話に使用する言語です。ウィザードは直ちにその言語に切り替わります。",
+		},
+		"user_name": {
+			Title:       "お名前を入力",
+			Description: "MoAIがあなたを呼ぶ名前です。user.yaml（user.name）に保存されます。空欄でスキップできます。",
+		},
+		"advanced_bridge": {
+			Title:       "詳細設定を構成しますか？（デフォルト: いいえ）",
+			Description: "プロジェクトモード、ハーネスプロファイル、LSP、品質ゲート、デザインオプションをこの実行で表示します。",
+		},
 		"project_name": {
 			Title:       "プロジェクト名を入力",
 			Description: "プロジェクトの名前です。",
@@ -141,6 +166,18 @@ var translations = map[string]map[string]QuestionTranslation{
 		},
 	},
 	"zh": {
+		"conversation_language": {
+			Title:       "选择对话语言",
+			Description: "MoAI 与您交流时使用的语言。向导会立即切换到该语言。",
+		},
+		"user_name": {
+			Title:       "输入您的姓名",
+			Description: "MoAI 对您的称呼。保存到 user.yaml（user.name）。留空则跳过。",
+		},
+		"advanced_bridge": {
+			Title:       "配置高级设置？（默认：否）",
+			Description: "在本次运行中显示项目模式、评估套件配置、LSP、质量门禁和设计选项。",
+		},
 		"project_name": {
 			Title:       "输入项目名称",
 			Description: "项目的名称。",

--- a/internal/cli/wizard/types.go
+++ b/internal/cli/wizard/types.go
@@ -10,6 +10,11 @@ import (
 
 // WizardResult holds the user's selections from the init wizard.
 type WizardResult struct {
+	// Identity / locale (asked first so the rest of the wizard renders in the
+	// chosen language).
+	ConversationLang string // conversation_language code: en, ko, ja, zh
+	UserName         string // user.name display value (empty allowed)
+
 	// Core settings
 	ProjectName string // Project name (required)
 

--- a/internal/cli/wizard/unified_form_test.go
+++ b/internal/cli/wizard/unified_form_test.go
@@ -88,6 +88,19 @@ func TestUnifiedForm_MultiGroupSinglePage(t *testing.T) {
 	form := buildUnifiedForm(questions, result, "")
 	d := newFormDriver(t, form)
 
+	// Initial page is the Language select (question 1 of 7 visible:
+	// conversation_language, user_name, project_name, model_policy, report_format,
+	// git_mode, advanced_bridge; git conditionals hidden). The stepper note
+	// renders the dynamic denominator "1 / 7" (REQ-TUX2-008).
+	if initial := d.view(); !strings.Contains(initial, "1 / 7") {
+		t.Errorf("initial stepper note must render dynamic denominator '1 / 7', frame:\n%s", initial)
+	}
+
+	// Page 1 is the Language select, page 2 is the Identity (user_name) input;
+	// advance past both to reach the unified Project page.
+	d.enter() // conversation_language = en -> Identity page
+	d.enter() // user_name (empty) -> Project page
+
 	frame := d.view()
 	for _, want := range []string{
 		"Enter project name",
@@ -97,11 +110,6 @@ func TestUnifiedForm_MultiGroupSinglePage(t *testing.T) {
 		if !strings.Contains(frame, want) {
 			t.Errorf("Project group page must render %q (unified multi-field page), frame:\n%s", want, frame)
 		}
-	}
-	// Initial state: 4 visible questions (git conditionals hidden) — the
-	// stepper note renders "1 / 4" (dynamic denominator, REQ-TUX2-008).
-	if !strings.Contains(frame, "1 / 4") {
-		t.Errorf("stepper note must render dynamic denominator '1 / 4', frame:\n%s", frame)
 	}
 }
 
@@ -114,7 +122,13 @@ func TestUnifiedForm_ConditionalGroupsAppear(t *testing.T) {
 	form := buildUnifiedForm(questions, result, "")
 	d := newFormDriver(t, form)
 
-	// Group 1 (Project): project name + 3 selects. The input pre-fills the
+	// Page 1 (Language): default "en" selected.
+	d.enter() // conversation_language = en -> Identity page
+	// Page 2 (Identity): user_name input.
+	d.typeText("octo-dev")
+	d.enter() // user_name -> Project page
+
+	// Group (Project): project name + 3 selects. The input pre-fills the
 	// default (directory basename, v1-preserved behavior) — clear it first,
 	// then type a fresh name.
 	for range len("unified-cond") {
@@ -125,7 +139,7 @@ func TestUnifiedForm_ConditionalGroupsAppear(t *testing.T) {
 	d.enter() // model_policy (high)
 	d.enter() // report_format (html+md) -> next group
 
-	// Group 2 (Git): git_mode manual -> personal (one cursor down).
+	// Group (Git): git_mode manual -> personal (one cursor down).
 	frame := d.view()
 	if !strings.Contains(frame, "Select Git automation mode") {
 		t.Fatalf("expected git_mode group, frame:\n%s", frame)
@@ -137,10 +151,12 @@ func TestUnifiedForm_ConditionalGroupsAppear(t *testing.T) {
 	if !strings.Contains(frame, "Select your Git provider") {
 		t.Fatalf("conditional git_provider group must appear for personal mode, frame:\n%s", frame)
 	}
-	// Dynamic denominator grew: git_provider visible -> 5 total; provider
-	// answer pending so github/gitlab questions are still hidden.
-	if !strings.Contains(frame, "5 / 5") {
-		t.Errorf("git_provider stepper must render '5 / 5' (dynamic), frame:\n%s", frame)
+	// Dynamic denominator: base 6 (language, user_name, project_name,
+	// model_policy, report_format, git_mode) + git_provider + advanced_bridge = 8;
+	// git_provider is question 7. Provider answer pending so github/gitlab
+	// sub-questions are still hidden.
+	if !strings.Contains(frame, "7 / 8") {
+		t.Errorf("git_provider stepper must render '7 / 8' (dynamic), frame:\n%s", frame)
 	}
 	d.enter() // git_provider = github -> github_username group
 
@@ -148,25 +164,35 @@ func TestUnifiedForm_ConditionalGroupsAppear(t *testing.T) {
 	if !strings.Contains(frame, "GitHub username") {
 		t.Fatalf("github_username group must appear for github provider, frame:\n%s", frame)
 	}
-	// Provider answered: github_username + github_token now visible -> 6/7.
-	if !strings.Contains(frame, "6 / 7") {
-		t.Errorf("github_username stepper must render '6 / 7' (dynamic), frame:\n%s", frame)
+	// Provider answered: github_username + github_token now visible. Total = base
+	// 6 + git_provider + github_username + github_token + advanced_bridge = 10;
+	// github_username is question 8.
+	if !strings.Contains(frame, "8 / 10") {
+		t.Errorf("github_username stepper must render '8 / 10' (dynamic), frame:\n%s", frame)
 	}
 	d.typeText("octocat")
 	d.enter() // github_username
-	d.enter() // github_token (empty, optional) -> form complete
+	d.enter() // github_token (empty, optional) -> advanced_bridge group
+
+	frame = d.view()
+	if !strings.Contains(frame, "advanced settings") {
+		t.Fatalf("advanced_bridge group must appear at end of quick mode, frame:\n%s", frame)
+	}
+	d.enter() // advanced_bridge = No (default) -> form complete
 
 	if form.State != huh.StateCompleted {
 		t.Fatalf("form must complete, state=%v", form.State)
 	}
 
 	want := WizardResult{
-		ProjectName:    "uniproj",
-		ModelPolicy:    "high",
-		ReportFormat:   "html+md",
-		GitMode:        "personal",
-		GitProvider:    "github",
-		GitHubUsername: "octocat",
+		ConversationLang: "en",
+		UserName:         "octo-dev",
+		ProjectName:      "uniproj",
+		ModelPolicy:      "high",
+		ReportFormat:     "html+md",
+		GitMode:          "personal",
+		GitProvider:      "github",
+		GitHubUsername:   "octocat",
 	}
 	if *result != want {
 		t.Errorf("WizardResult mismatch:\n got: %+v\nwant: %+v", *result, want)
@@ -181,19 +207,26 @@ func TestUnifiedForm_ManualModeSkipsConditionals(t *testing.T) {
 	form := buildUnifiedForm(questions, result, "")
 	d := newFormDriver(t, form)
 
-	d.typeText("quickproj")
-	d.enter() // project_name
+	d.enter() // conversation_language = en -> Identity page
+	d.enter() // user_name (empty) -> Project page
+	d.enter() // project_name (keep default) -> model_policy
 	d.enter() // model_policy
-	d.enter() // report_format
+	d.enter() // report_format -> Git page
 
 	frame := d.view()
 	if strings.Contains(frame, "Select your Git provider") {
 		t.Fatalf("git_provider must stay hidden before git_mode is answered, frame:\n%s", frame)
 	}
-	d.enter() // git_mode = manual -> all conditional groups hidden -> complete
+	d.enter() // git_mode = manual -> all git conditionals hidden -> advanced_bridge
+
+	frame = d.view()
+	if !strings.Contains(frame, "advanced settings") {
+		t.Fatalf("advanced_bridge group must appear after manual git_mode, frame:\n%s", frame)
+	}
+	d.enter() // advanced_bridge = No (default) -> complete
 
 	if form.State != huh.StateCompleted {
-		t.Fatalf("form must complete after manual git_mode, state=%v", form.State)
+		t.Fatalf("form must complete after manual git_mode + advanced_bridge, state=%v", form.State)
 	}
 	if result.GitMode != "manual" || result.GitProvider != "" {
 		t.Errorf("manual path result mismatch: %+v", *result)
@@ -209,11 +242,12 @@ func TestBuildFormGroups_Partition(t *testing.T) {
 	questions := DefaultQuestions("/tmp/unified-partition")
 
 	groups := buildFormGroups(questions, result, &locale)
-	// DefaultQuestions: 3 unconditional "Project" (project_name, model_policy,
-	// report_format) + 1 unconditional "Git" (git_mode) + 6 conditional git
-	// questions = 1 + 1 + 6 = 8 groups.
-	if len(groups) != 8 {
-		t.Errorf("expected 8 groups (Project, Git, 6 conditionals), got %d", len(groups))
+	// DefaultQuestions groups: "Language" (conversation_language) + "Identity"
+	// (user_name) + "Project" (project_name, model_policy, report_format) + "Git"
+	// (git_mode) + 6 conditional git questions + advanced_bridge (conditional) =
+	// 1 + 1 + 1 + 1 + 6 + 1 = 11 groups.
+	if len(groups) != 11 {
+		t.Errorf("expected 11 groups (Language, Identity, Project, Git, 6 git conditionals, advanced_bridge), got %d", len(groups))
 	}
 	for i, g := range groups {
 		if g == nil {

--- a/internal/cli/wizard/wizard.go
+++ b/internal/cli/wizard/wizard.go
@@ -25,16 +25,23 @@ func Run(questions []Question, styles *Styles) (*WizardResult, error) {
 }
 
 // RunWithDefaults runs the wizard with default questions for the given project root.
-// If locale is not empty, the wizard UI is displayed in that language.
-func RunWithDefaults(projectRoot, locale string) (*WizardResult, error) {
-	questions := DefaultQuestions(projectRoot)
-	return RunWithLocale(questions, nil, locale)
+// If locale is not empty, the wizard UI is displayed in that language and the
+// conversation_language question defaults to it. userName pre-fills the user_name
+// question. Quick mode is RunWithDefaultsModes with both mode flags off — the
+// advanced-settings bridge (Condition: !StandardMode) is therefore visible and,
+// when answered Yes, reveals the Phase 1 questions in the same run.
+func RunWithDefaults(projectRoot, locale, userName string) (*WizardResult, error) {
+	return RunWithDefaultsModes(projectRoot, locale, userName, false, false)
 }
 
 // RunWithDefaultsModes runs the wizard with mode flags controlling Phase 1 question visibility.
 // standardMode=true presents Phase 1 questions; advancedMode=true implies standardMode.
-func RunWithDefaultsModes(projectRoot, locale string, standardMode, advancedMode bool) (*WizardResult, error) {
-	// Merge default + Phase 1 questions
+// locale pre-fills the conversation_language default (and initial render language);
+// userName pre-fills the user_name default.
+func RunWithDefaultsModes(projectRoot, locale, userName string, standardMode, advancedMode bool) (*WizardResult, error) {
+	// Merge default + Phase 1 questions. Phase 1 questions are always present in
+	// the form but gated on r.StandardMode, so the Quick-mode advanced_bridge can
+	// reveal them by flipping StandardMode without rebuilding the form.
 	questions := DefaultQuestions(projectRoot)
 	questions = append(questions, Phase1Questions(projectRoot)...)
 
@@ -43,6 +50,9 @@ func RunWithDefaultsModes(projectRoot, locale string, standardMode, advancedMode
 		gate := IsAdvancedWizardReady()
 		questions = append(questions, Phase2Questions(gate)...)
 	}
+
+	// Pre-fill the identity/locale defaults from the caller (profile values).
+	prefillIdentityDefaults(questions, userName)
 
 	// Pre-populate mode flags so Condition funcs see them from the start
 	result := &WizardResult{
@@ -60,6 +70,28 @@ func RunWithDefaultsModes(projectRoot, locale string, standardMode, advancedMode
 		return nil, err
 	}
 	return result, nil
+}
+
+// prefillLocaleDefault seeds the conversation_language question default from the
+// incoming locale. Empty locale leaves the static "en" default untouched.
+func prefillLocaleDefault(questions []Question, locale string) {
+	if locale != "" {
+		if q := QuestionByID(questions, "conversation_language"); q != nil {
+			q.Default = locale
+		}
+	}
+}
+
+// prefillIdentityDefaults overrides the user_name question default from the
+// caller-supplied value (typically the active profile's UserName). The
+// conversation_language default is handled centrally in runWithResult so every
+// entry point (including the update reconfigure flow) benefits.
+func prefillIdentityDefaults(questions []Question, userName string) {
+	if userName != "" {
+		if q := QuestionByID(questions, "user_name"); q != nil {
+			q.Default = userName
+		}
+	}
 }
 
 // RunWithLocale initializes the locale and runs the wizard.
@@ -82,6 +114,12 @@ func runWithResult(questions []Question, _ *Styles, locale string, result *Wizar
 	if len(questions) == 0 {
 		return ErrNoQuestions
 	}
+
+	// Seed the conversation_language default from the incoming locale so the
+	// pre-selected option matches the initial render language (profile value on
+	// init, project value on update reconfigure). Empty locale keeps the static
+	// "en" default.
+	prefillLocaleDefault(questions, locale)
 
 	// Behavior preservation: when every question's condition is false for the
 	// pre-populated result, the former per-question loop skipped all forms and
@@ -325,6 +363,17 @@ func buildInputField(q *Question, result *WizardResult, locale *string) *huh.Inp
 // saveAnswer stores an answer in the result.
 func saveAnswer(id, value string, result *WizardResult, locale *string) {
 	switch id {
+	case "conversation_language":
+		result.ConversationLang = value
+		// Update the live locale so every subsequent question re-renders in the
+		// chosen language (huh re-evaluates the Title/Description funcs bound to
+		// this pointer when the pointee changes).
+		if locale != nil {
+			*locale = value
+		}
+		return
+	case "user_name":
+		result.UserName = value
 	case "project_name":
 		result.ProjectName = value
 	case "model_policy":
@@ -359,6 +408,10 @@ func saveAnswer(id, value string, result *WizardResult, locale *string) {
 // saveBoolAnswer stores a boolean answer in the result.
 func saveBoolAnswer(id string, value bool, result *WizardResult) {
 	switch id {
+	case "advanced_bridge":
+		// Quick-mode bridge: Yes reveals the Phase 1 questions (gated on
+		// StandardMode) within the same wizard run.
+		result.StandardMode = value
 	case "lsp_enabled":
 		result.LSPEnabled = value
 	case "enforce_quality":

--- a/internal/cli/wizard/wizard_test.go
+++ b/internal/cli/wizard/wizard_test.go
@@ -76,9 +76,10 @@ func TestDefaultQuestions(t *testing.T) {
 		t.Fatal("DefaultQuestions() returned empty slice")
 	}
 
-	// Verify first question is project_name
-	if questions[0].ID != "project_name" {
-		t.Errorf("expected first question ID 'project_name', got %q", questions[0].ID)
+	// Verify first question is conversation_language (asked before everything
+	// else so subsequent questions render in the chosen language).
+	if questions[0].ID != "conversation_language" {
+		t.Errorf("expected first question ID 'conversation_language', got %q", questions[0].ID)
 	}
 
 	// Verify project name question default
@@ -580,14 +581,16 @@ func TestStepperTotal_DynamicDenominator(t *testing.T) {
 		result *WizardResult
 		want   int
 	}{
-		// Quick mode, git manual: 4 unconditional questions
-		// (project_name, model_policy, report_format, git_mode).
-		{"manual", &WizardResult{GitMode: "manual"}, 4},
-		// personal+github reveals git_provider + github_username + github_token.
-		{"personal-github", &WizardResult{GitMode: "personal", GitProvider: "github"}, 7},
+		// Quick mode, git manual: 6 unconditional questions (conversation_language,
+		// user_name, project_name, model_policy, report_format, git_mode) plus the
+		// advanced_bridge (visible while StandardMode is false) = 7.
+		{"manual", &WizardResult{GitMode: "manual"}, 7},
+		// personal+github reveals git_provider + github_username + github_token
+		// (6 base + 3 + advanced_bridge = 10).
+		{"personal-github", &WizardResult{GitMode: "personal", GitProvider: "github"}, 10},
 		// personal+gitlab reveals git_provider + gitlab_instance_url +
-		// gitlab_username + gitlab_token.
-		{"personal-gitlab", &WizardResult{GitMode: "personal", GitProvider: "gitlab"}, 8},
+		// gitlab_username + gitlab_token (6 base + 4 + advanced_bridge = 11).
+		{"personal-gitlab", &WizardResult{GitMode: "personal", GitProvider: "gitlab"}, 11},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -598,11 +601,13 @@ func TestStepperTotal_DynamicDenominator(t *testing.T) {
 		})
 	}
 
-	// Standard mode expands the denominator further (Phase 1 questions).
+	// Standard mode expands the denominator further (Phase 1 questions). The
+	// advanced_bridge hides when StandardMode is preset, so the total is 6
+	// unconditional defaults (git conditionals hidden for manual) + 7 Phase 1 = 13.
 	all := append(DefaultQuestions("/tmp/steppertotal"), Phase1Questions("/tmp/steppertotal")...)
 	std := &WizardResult{GitMode: "manual", StandardMode: true, DesignEnabled: true}
-	if got := stepperDenominator(all, std); got != 11 {
-		t.Errorf("standard-mode denominator: expected 11 (4 + 7 Phase 1), got %d", got)
+	if got := stepperDenominator(all, std); got != 13 {
+		t.Errorf("standard-mode denominator: expected 13 (6 + 7 Phase 1), got %d", got)
 	}
 	// Single dynamic source invariant: stepperDenominator == TotalVisibleQuestions.
 	if stepperDenominator(all, std) != TotalVisibleQuestions(all, std) {
@@ -915,7 +920,9 @@ func TestBuildInputField_RequiredWithDefault(t *testing.T) {
 func TestDefaultQuestions_AllQuestionTypesValid(t *testing.T) {
 	questions := DefaultQuestions("/tmp/test")
 	for _, q := range questions {
-		if q.Type != QuestionTypeSelect && q.Type != QuestionTypeInput {
+		// DefaultQuestions now includes the advanced_bridge Confirm, so Confirm is
+		// a valid type alongside Select and Input.
+		if q.Type != QuestionTypeSelect && q.Type != QuestionTypeInput && q.Type != QuestionTypeConfirm {
 			t.Errorf("question %q has invalid type %v", q.ID, q.Type)
 		}
 		if q.ID == "" {


### PR DESCRIPTION
## Summary
- **A — Language Step 1**: `conversation_language` select (en/ko/ja/zh) as the first wizard question; answering it re-renders all subsequent wizard text in the chosen language. Persisted to `.moai/config/sections/language.yaml` (wizard answer wins over profile).
- **B — User name Step 2**: `user_name` input pre-filled from the profile; persisted to `.moai/config/sections/user.yaml`.
- **C — Advanced bridge**: final confirm question that reveals the existing `--standard`/`--advanced` Phase 1 questions (project mode, harness profile, LSP, quality gates) in the same run without needing the flag. Hidden when the flag already set StandardMode.

## Verification
- `go build ./...` exit 0
- `go test ./internal/cli/... -count=1` — 17 packages ok (independently re-run by orchestrator)
- `go vet ./internal/cli/...` exit 0
- New e2e-style test `TestInitWizardIdentityPersisted` proves wizard answers land in `language.yaml`/`user.yaml` (including the profile SyncToProjectConfig overwrite hazard fix).

## Known follow-up (out of scope)
- `moai update` reconfigure flow now also shows the three questions but persists only git fields (harmless; wiring is a separate task).
- Banner `vv3.0.0` double-v display defect — separate fix candidate.

🗿 MoAI