### PR TITLE
fix(cli): dedupe banner v-prefix and persist language/name on update reconfigure

### DIFF
--- a/internal/cli/uikit/banner.go
+++ b/internal/cli/uikit/banner.go
@@ -85,7 +85,11 @@ func bannerString(version string) string {
 	ident := identStyle.Render("◆ MoAI-ADK") + " " +
 		dimStyle.Render("Modu-AI's Agentic Development Kit w/ SuperAgent MoAI")
 
-	p1 := tui.Pill(tui.PillOpts{Kind: tui.PillPrimary, Solid: true, Label: fmt.Sprintf("v%s", version), Theme: &th})
+	// Tolerate an optional leading "v" so the version pill never renders a
+	// doubled prefix (regression: vv3.0.0). version.GetVersion() carries a "v"
+	// prefix ("v3.0.0") while test callers pass bare versions ("1.2.3"); both
+	// normalize to a single-"v" pill by trimming at most one leading "v".
+	p1 := tui.Pill(tui.PillOpts{Kind: tui.PillPrimary, Solid: true, Label: "v" + strings.TrimPrefix(version, "v"), Theme: &th})
 	p2 := tui.Pill(tui.PillOpts{Kind: tui.PillOk, Solid: false, Label: fmt.Sprintf("go %s", GoVersion()), Theme: &th})
 	p3 := tui.Pill(tui.PillOpts{Kind: tui.PillInfo, Solid: false, Label: ClaudeVersion(), Theme: &th})
 	pillRow := lipgloss.JoinHorizontal(lipgloss.Top, p1, " ", p2, " ", p3)

--- a/internal/cli/uikit/banner_test.go
+++ b/internal/cli/uikit/banner_test.go
@@ -145,6 +145,37 @@ func TestPrintBanner_WithVersion(t *testing.T) {
 	}
 }
 
+// TestPrintBanner_OptionalLeadingV is the regression guard for the vv3.0.0
+// banner bug: version.GetVersion() returns "v3.0.0" (already v-prefixed) and the
+// pill previously prepended a second "v", rendering "vv3.0.0". The pill must
+// normalize an optional leading "v" — both a prefixed ("v3.0.0") and a bare
+// ("3.0.0") version yield exactly a single-"v" pill ("v3.0.0"), never "vv3.0.0".
+func TestPrintBanner_OptionalLeadingV(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"prefixed version (v3.0.0)", "v3.0.0"},
+		{"bare version (3.0.0)", "3.0.0"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output, err := captureStdout(func() {
+				uikit.PrintBanner(tt.input)
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(output, "v3.0.0") {
+				t.Errorf("banner should contain single-v %q, got:\n%s", "v3.0.0", output)
+			}
+			if strings.Contains(output, "vv3.0.0") {
+				t.Errorf("banner must NOT contain doubled-v %q, got:\n%s", "vv3.0.0", output)
+			}
+		})
+	}
+}
+
 // TestPrintBanner_EmptyVersion verifies banner handles empty version gracefully.
 func TestPrintBanner_EmptyVersion(t *testing.T) {
 	output, err := captureStdout(func() {

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -1308,9 +1308,13 @@ func runInitWizard(cmd *cobra.Command, reconfigure bool) error {
 func applyWizardConfig(projectRoot string, result *wizard.WizardResult) error {
 	sectionsDir := filepath.Join(projectRoot, defs.MoAIDir, defs.SectionsSubdir)
 
-	// user.yaml: Save GitHub/GitLab username and token (REQ-4, REQ-5)
+	// user.yaml: Save GitHub/GitLab username and token (REQ-4, REQ-5) plus the
+	// wizard-collected user display name. The block also triggers on UserName
+	// alone, so a reconfigure that answers only the user_name question (no git
+	// credentials) still persists user.name.
 	hasUserFields := result.GitHubUsername != "" || result.GitHubToken != "" ||
-		result.GitLabUsername != "" || result.GitLabToken != ""
+		result.GitLabUsername != "" || result.GitLabToken != "" ||
+		result.UserName != ""
 	if hasUserFields {
 		userPath := filepath.Join(sectionsDir, defs.UserYAML)
 		// Read existing file
@@ -1353,6 +1357,11 @@ func applyWizardConfig(projectRoot string, result *wizard.WizardResult) error {
 			userConfig["gitlab_token"] = result.GitLabToken
 		}
 
+		// Save user display name (reconfigure wizard user_name question)
+		if result.UserName != "" {
+			userConfig["name"] = result.UserName
+		}
+
 		user["user"] = userConfig
 
 		// Save to file
@@ -1362,6 +1371,46 @@ func applyWizardConfig(projectRoot string, result *wizard.WizardResult) error {
 		}
 		if err := os.WriteFile(userPath, updatedData, defs.FilePerm); err != nil {
 			return fmt.Errorf("write user.yaml: %w", err)
+		}
+	}
+
+	// language.yaml: Save conversation language (reconfigure wizard language
+	// question). Sets both conversation_language and conversation_language_name
+	// while preserving all sibling keys (agent_prompt_language, code_comments, ...).
+	if result.ConversationLang != "" {
+		langPath := filepath.Join(sectionsDir, defs.LanguageYAML)
+		langData, err := os.ReadFile(langPath)
+		if err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("read language.yaml: %w", err)
+		}
+
+		var lang map[string]any
+		if len(langData) > 0 {
+			if err := yaml.Unmarshal(langData, &lang); err != nil {
+				return fmt.Errorf("parse language.yaml: %w", err)
+			}
+		} else {
+			lang = make(map[string]any)
+		}
+
+		// Ensure language section exists
+		var language map[string]any
+		if existing, ok := lang["language"].(map[string]any); ok {
+			language = existing
+		} else {
+			language = make(map[string]any)
+		}
+
+		language["conversation_language"] = result.ConversationLang
+		language["conversation_language_name"] = result.ConversationLang
+		lang["language"] = language
+
+		updatedData, err := yaml.Marshal(lang)
+		if err != nil {
+			return fmt.Errorf("marshal language.yaml: %w", err)
+		}
+		if err := os.WriteFile(langPath, updatedData, defs.FilePerm); err != nil {
+			return fmt.Errorf("write language.yaml: %w", err)
 		}
 	}
 

--- a/internal/cli/wizard/questions.go
+++ b/internal/cli/wizard/questions.go
@@ -280,9 +280,8 @@ func loadHarnessProfiles(projectRoot string) []Option {
 		if e.IsDir() {
 			continue
 		}
-		name := e.Name()
-		if strings.HasSuffix(name, ".md") {
-			profiles = append(profiles, strings.TrimSuffix(name, ".md"))
+		if base, ok := strings.CutSuffix(e.Name(), ".md"); ok {
+			profiles = append(profiles, base)
 		}
 	}
 

--- a/internal/cli/wizard_config_test.go
+++ b/internal/cli/wizard_config_test.go
@@ -404,6 +404,124 @@ func TestApplyWizardConfig_AllFields(t *testing.T) {
 	}
 }
 
+// --- ConversationLang persistence tests (reconfigure wizard language question) ---
+
+func TestApplyWizardConfig_ConversationLang(t *testing.T) {
+	root := setupSectionsDir(t)
+
+	// Pre-create language.yaml with the full schema to verify sibling keys survive.
+	sectionsDir := filepath.Join(root, defs.MoAIDir, defs.SectionsSubdir)
+	langPath := filepath.Join(sectionsDir, defs.LanguageYAML)
+	existing := "language:\n  conversation_language: en\n  conversation_language_name: en\n  agent_prompt_language: en\n  code_comments: en\n"
+	if err := os.WriteFile(langPath, []byte(existing), defs.FilePerm); err != nil {
+		t.Fatalf("write language.yaml: %v", err)
+	}
+
+	result := &wizard.WizardResult{ConversationLang: "ko"}
+	if err := applyWizardConfig(root, result); err != nil {
+		t.Fatalf("applyWizardConfig: %v", err)
+	}
+
+	parsed := readYAML(t, langPath)
+	language, ok := parsed["language"].(map[string]any)
+	if !ok {
+		t.Fatal("expected language key in language.yaml")
+	}
+	if language["conversation_language"] != "ko" {
+		t.Errorf("conversation_language = %v, want %q", language["conversation_language"], "ko")
+	}
+	if language["conversation_language_name"] != "ko" {
+		t.Errorf("conversation_language_name = %v, want %q", language["conversation_language_name"], "ko")
+	}
+	// Sibling keys must be preserved.
+	if language["agent_prompt_language"] != "en" {
+		t.Errorf("agent_prompt_language should be preserved, got %v", language["agent_prompt_language"])
+	}
+	if language["code_comments"] != "en" {
+		t.Errorf("code_comments should be preserved, got %v", language["code_comments"])
+	}
+}
+
+func TestApplyWizardConfig_ConversationLang_NoFileCreatedWhenEmpty(t *testing.T) {
+	root := setupSectionsDir(t)
+
+	result := &wizard.WizardResult{ConversationLang: ""}
+	if err := applyWizardConfig(root, result); err != nil {
+		t.Fatalf("applyWizardConfig: %v", err)
+	}
+
+	langPath := filepath.Join(root, defs.MoAIDir, defs.SectionsSubdir, defs.LanguageYAML)
+	if _, err := os.Stat(langPath); !os.IsNotExist(err) {
+		t.Error("language.yaml should not be created when ConversationLang is empty")
+	}
+}
+
+// --- UserName persistence tests (reconfigure wizard user_name question) ---
+
+func TestApplyWizardConfig_UserName(t *testing.T) {
+	root := setupSectionsDir(t)
+
+	result := &wizard.WizardResult{UserName: "GOOS"}
+	if err := applyWizardConfig(root, result); err != nil {
+		t.Fatalf("applyWizardConfig: %v", err)
+	}
+
+	userPath := filepath.Join(root, defs.MoAIDir, defs.SectionsSubdir, defs.UserYAML)
+	parsed := readYAML(t, userPath)
+	user, ok := parsed["user"].(map[string]any)
+	if !ok {
+		t.Fatal("expected user key in user.yaml")
+	}
+	if user["name"] != "GOOS" {
+		t.Errorf("user.name = %v, want %q", user["name"], "GOOS")
+	}
+}
+
+// TestApplyWizardConfig_UserNameWithoutGitCredentials verifies the user.yaml
+// write triggers on UserName alone — no git credentials present.
+func TestApplyWizardConfig_UserNameWithoutGitCredentials(t *testing.T) {
+	root := setupSectionsDir(t)
+
+	result := &wizard.WizardResult{UserName: "Solo"}
+	if err := applyWizardConfig(root, result); err != nil {
+		t.Fatalf("applyWizardConfig: %v", err)
+	}
+
+	userPath := filepath.Join(root, defs.MoAIDir, defs.SectionsSubdir, defs.UserYAML)
+	if _, err := os.Stat(userPath); err != nil {
+		t.Fatalf("user.yaml should be created when only UserName is set: %v", err)
+	}
+	parsed := readYAML(t, userPath)
+	user := parsed["user"].(map[string]any)
+	if user["name"] != "Solo" {
+		t.Errorf("user.name = %v, want %q", user["name"], "Solo")
+	}
+}
+
+// TestApplyWizardConfig_UserNamePreservesGitCredentials verifies user.name does
+// not clobber github/gitlab credentials written in the same call.
+func TestApplyWizardConfig_UserNamePreservesGitCredentials(t *testing.T) {
+	root := setupSectionsDir(t)
+
+	result := &wizard.WizardResult{
+		UserName:       "Both",
+		GitHubUsername: "ghuser",
+	}
+	if err := applyWizardConfig(root, result); err != nil {
+		t.Fatalf("applyWizardConfig: %v", err)
+	}
+
+	userPath := filepath.Join(root, defs.MoAIDir, defs.SectionsSubdir, defs.UserYAML)
+	parsed := readYAML(t, userPath)
+	user := parsed["user"].(map[string]any)
+	if user["name"] != "Both" {
+		t.Errorf("user.name = %v, want %q", user["name"], "Both")
+	}
+	if user["github_username"] != "ghuser" {
+		t.Errorf("github_username = %v, want %q", user["github_username"], "ghuser")
+	}
+}
+
 // presetToSegments tests removed (SPEC-V3R6-STATUSLINE-PRESET-RETIRE-001):
 // the lowercase presetToSegments wrapper in update.go and the capital
 // statusline.PresetToSegments function were both deleted. Named presets no


### PR DESCRIPTION
## Summary
Handles the two follow-ups from #1111.

### Defect 1 — banner `vv3.0.0`
`version.GetVersion()` returns `"v3.0.0"` (v-prefixed SSOT), but `bannerString` blindly did `fmt.Sprintf("v%s", version)` → `vv3.0.0`. Existing tests passed versions without `v`, hiding the bug. Fix: `"v" + strings.TrimPrefix(version, "v")` — tolerant to an optional leading `v`. `version.go` SSOT untouched. Verified against the real binary: banner pill now renders `v3.0.0`.

### Defect 2 — `moai update` reconfigure dropped wizard language/name
`applyWizardConfig` persisted only git/model fields. It now also writes:
- `ConversationLang` → `.moai/config/sections/language.yaml` (`conversation_language` + `conversation_language_name`, preserving sibling keys)
- `UserName` → `.moai/config/sections/user.yaml` (`user.name`), triggering even with no git credentials, without clobbering github/gitlab fields.

Plus a one-line `strings.CutSuffix` modernization in `questions.go`.

## Verification (independently re-run by orchestrator)
- `go build ./...` exit 0
- `go test ./internal/cli/... ./pkg/version/... -count=1` — 18 packages ok
- `go vet ./internal/cli/...` exit 0
- Golden snapshots unchanged (they pass versions without `v`; TrimPrefix is a no-op there)
- Real binary check: root banner pill renders `v3.0.0` (single v)

## Not touched
- `pkg/version/version.go` (SSOT)
- `expansion_test.go:298` unused-write nit (scope discipline — reported, not one-line-safe)

🗿 MoAI