### PR TITLE
refactor(cli): drop Git questions from init wizard, auto-detect git mode

### DIFF
--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -326,6 +326,21 @@ func runInit(cmd *cobra.Command, args []string) error {
 		ClaudeDesignEnabled:       true, // wizard-only; default true
 	}
 
+	// Git mode + provider are auto-detected from the repository's configured
+	// remotes rather than asked in the wizard (no remote → manual, ≥1 remote →
+	// personal; provider from the origin host). Explicit --git-mode /
+	// --git-provider flags take precedence: detection only fills a value still
+	// empty after flag parsing.
+	if opts.GitMode == "" || opts.GitProvider == "" {
+		detectedMode, detectedProvider := detectGitConfig(rootFlag)
+		if opts.GitMode == "" {
+			opts.GitMode = detectedMode
+		}
+		if opts.GitProvider == "" {
+			opts.GitProvider = detectedProvider
+		}
+	}
+
 	// Apply user-level defaults from profile preferences.
 	// Profile preferences (identity, languages, model policy) are set via
 	// "moai profile setup" and stored in ~/.moai/claude-profiles/<name>/preferences.yaml.
@@ -408,18 +423,10 @@ func runInit(cmd *cobra.Command, args []string) error {
 		if opts.DevelopmentMode == "" {
 			opts.DevelopmentMode = result.DevelopmentMode
 		}
-		if opts.GitMode == "" {
-			opts.GitMode = result.GitMode
-		}
-		if opts.GitProvider == "" {
-			opts.GitProvider = result.GitProvider
-		}
-		if opts.GitHubUsername == "" {
-			opts.GitHubUsername = result.GitHubUsername
-		}
-		if opts.GitLabInstanceURL == "" {
-			opts.GitLabInstanceURL = result.GitLabInstanceURL
-		}
+		// Git mode, provider, and credentials are NOT wizard-supplied on the
+		// init path: mode/provider come from remote detection above, and the
+		// remaining Git values stay flag-fed (--github-username,
+		// --gitlab-instance-url). The reconfigure wizard still asks them.
 		if result.ModelPolicy != "" {
 			opts.ModelPolicy = result.ModelPolicy
 		}

--- a/internal/cli/init_gitdetect.go
+++ b/internal/cli/init_gitdetect.go
@@ -1,0 +1,106 @@
+package cli
+
+import (
+	"os/exec"
+	"strings"
+)
+
+// Git mode / provider values resolved by detection. These mirror the closed
+// value sets validated by validateInitFlags (--git-mode / --git-provider).
+const (
+	gitModeManual     = "manual"
+	gitModePersonal   = "personal"
+	gitProviderGitHub = "github"
+	gitProviderGitLab = "gitlab"
+
+	// gitHubHost is the canonical GitHub host. Any other remote host is
+	// treated as GitLab (self-hosted instances use arbitrary hostnames).
+	gitHubHost = "github.com"
+)
+
+// gitRemoteListFunc lists the configured remote names for a directory.
+// Overridable in tests.
+var gitRemoteListFunc = func(dir string) (string, error) {
+	out, err := exec.Command("git", "-C", dir, "remote").Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+// gitOriginURLFunc resolves the origin remote URL for a directory.
+// Overridable in tests.
+var gitOriginURLFunc = func(dir string) (string, error) {
+	out, err := exec.Command("git", "-C", dir, "remote", "get-url", "origin").Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// detectGitConfig resolves the Git automation mode and hosting provider from
+// the repository's configured remotes, replacing the git_mode / git_provider
+// wizard questions on the init path.
+//
+// Mode: a directory with no configured remote — including a non-git directory —
+// yields "manual"; at least one remote yields "personal".
+//
+// Provider: derived from the origin remote's host. A github.com host yields
+// "github"; any other host yields "gitlab" (self-hosted GitLab instances use
+// arbitrary hostnames). When origin is absent or its host cannot be parsed,
+// the provider falls back to the "github" default.
+func detectGitConfig(dir string) (mode, provider string) {
+	provider = gitProviderGitHub
+
+	out, err := gitRemoteListFunc(dir)
+	if err != nil || strings.TrimSpace(out) == "" {
+		return gitModeManual, provider
+	}
+	mode = gitModePersonal
+
+	url, err := gitOriginURLFunc(dir)
+	if err != nil {
+		return mode, provider
+	}
+	if host := hostFromRemoteURL(url); host != "" && !strings.EqualFold(host, gitHubHost) {
+		provider = gitProviderGitLab
+	}
+	return mode, provider
+}
+
+// hostFromRemoteURL extracts the host from a git remote URL. It handles the
+// scp-like SSH form (git@github.com:user/repo.git), explicit schemes
+// (https://github.com/user/repo.git, ssh://git@gitlab.example.com/u/r.git),
+// and returns "" when no host can be determined (e.g. a local filesystem path).
+func hostFromRemoteURL(url string) string {
+	url = strings.TrimSpace(url)
+	if url == "" {
+		return ""
+	}
+
+	// Strip an explicit scheme (https://, ssh://, git://, ...).
+	if i := strings.Index(url, "://"); i >= 0 {
+		url = url[i+3:]
+	} else if strings.Contains(url, ":") && !strings.HasPrefix(url, "/") {
+		// scp-like form: [user@]host:path — normalize the colon to a slash so
+		// the shared parsing below applies. A leading "/" means a local path.
+		url = strings.Replace(url, ":", "/", 1)
+	} else {
+		// Local filesystem path — no host.
+		return ""
+	}
+
+	// Drop userinfo (user@host).
+	if i := strings.Index(url, "@"); i >= 0 {
+		url = url[i+1:]
+	}
+	// Keep only the host segment.
+	if i := strings.Index(url, "/"); i >= 0 {
+		url = url[:i]
+	}
+	// Drop an explicit port.
+	if i := strings.Index(url, ":"); i >= 0 {
+		url = url[:i]
+	}
+	return url
+}

--- a/internal/cli/init_gitdetect_test.go
+++ b/internal/cli/init_gitdetect_test.go
@@ -1,0 +1,294 @@
+package cli
+
+// Coverage for the init-path git auto-detection that replaced the git_mode /
+// git_provider wizard questions: mode comes from whether any remote is
+// configured, provider from the origin remote's host, and an explicit
+// --git-mode / --git-provider flag always wins over detection.
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/modu-ai/moai-adk/internal/cli/wizard"
+)
+
+// gitDetectInitRepo creates a git repository in a fresh temp dir and returns its path.
+// Remotes are added by the caller.
+func gitDetectInitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := exec.Command("git", "-C", dir, "init").Run(); err != nil {
+		t.Skipf("git init unavailable: %v", err)
+	}
+	return dir
+}
+
+// gitAddRemote registers a remote on the repository at dir.
+func gitAddRemote(t *testing.T, dir, name, url string) {
+	t.Helper()
+	if err := exec.Command("git", "-C", dir, "remote", "add", name, url).Run(); err != nil {
+		t.Fatalf("git remote add %s %s: %v", name, url, err)
+	}
+}
+
+// TestDetectGitConfig drives detection against real repositories.
+func TestDetectGitConfig(t *testing.T) {
+	tests := []struct {
+		name         string
+		remotes      map[string]string // remote name -> URL
+		gitRepo      bool
+		wantMode     string
+		wantProvider string
+	}{
+		{
+			name:         "non-git directory falls back to manual",
+			gitRepo:      false,
+			wantMode:     "manual",
+			wantProvider: "github",
+		},
+		{
+			name:         "git repo with no remote is manual",
+			gitRepo:      true,
+			wantMode:     "manual",
+			wantProvider: "github",
+		},
+		{
+			name:         "github https origin is personal + github",
+			gitRepo:      true,
+			remotes:      map[string]string{"origin": "https://github.com/modu-ai/moai-adk.git"},
+			wantMode:     "personal",
+			wantProvider: "github",
+		},
+		{
+			name:         "github ssh origin is personal + github",
+			gitRepo:      true,
+			remotes:      map[string]string{"origin": "git@github.com:modu-ai/moai-adk.git"},
+			wantMode:     "personal",
+			wantProvider: "github",
+		},
+		{
+			name:         "gitlab.com origin is personal + gitlab",
+			gitRepo:      true,
+			remotes:      map[string]string{"origin": "https://gitlab.com/group/proj.git"},
+			wantMode:     "personal",
+			wantProvider: "gitlab",
+		},
+		{
+			name:         "self-hosted non-github origin is personal + gitlab",
+			gitRepo:      true,
+			remotes:      map[string]string{"origin": "git@git.example.com:team/proj.git"},
+			wantMode:     "personal",
+			wantProvider: "gitlab",
+		},
+		{
+			name:         "remote present but not named origin keeps github default",
+			gitRepo:      true,
+			remotes:      map[string]string{"upstream": "https://gitlab.com/group/proj.git"},
+			wantMode:     "personal",
+			wantProvider: "github",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var dir string
+			if tt.gitRepo {
+				dir = gitDetectInitRepo(t)
+			} else {
+				dir = t.TempDir()
+			}
+			for name, url := range tt.remotes {
+				gitAddRemote(t, dir, name, url)
+			}
+
+			mode, provider := detectGitConfig(dir)
+			if mode != tt.wantMode {
+				t.Errorf("mode = %q, want %q", mode, tt.wantMode)
+			}
+			if provider != tt.wantProvider {
+				t.Errorf("provider = %q, want %q", provider, tt.wantProvider)
+			}
+		})
+	}
+}
+
+// TestHostFromRemoteURL covers the remote-URL host parser directly, including
+// the forms that are awkward to materialize as real remotes.
+func TestHostFromRemoteURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{"https", "https://github.com/u/r.git", "github.com"},
+		{"https with userinfo", "https://user@github.com/u/r.git", "github.com"},
+		{"scp-like ssh", "git@github.com:u/r.git", "github.com"},
+		{"ssh scheme", "ssh://git@gitlab.example.com/u/r.git", "gitlab.example.com"},
+		{"ssh scheme with port", "ssh://git@gitlab.example.com:2222/u/r.git", "gitlab.example.com"},
+		{"git scheme", "git://github.com/u/r.git", "github.com"},
+		{"local absolute path", "/srv/git/repo.git", ""},
+		{"empty", "", ""},
+		{"whitespace only", "   ", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := hostFromRemoteURL(tt.url); got != tt.want {
+				t.Errorf("hostFromRemoteURL(%q) = %q, want %q", tt.url, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDetectGitConfig_RemoteListError falls back to manual when the git
+// invocation itself fails (git absent, permission error, ...).
+func TestDetectGitConfig_RemoteListError(t *testing.T) {
+	orig := gitRemoteListFunc
+	gitRemoteListFunc = func(string) (string, error) { return "", os.ErrNotExist }
+	t.Cleanup(func() { gitRemoteListFunc = orig })
+
+	mode, provider := detectGitConfig(t.TempDir())
+	if mode != "manual" {
+		t.Errorf("mode = %q, want %q on git failure", mode, "manual")
+	}
+	if provider != "github" {
+		t.Errorf("provider = %q, want %q on git failure", provider, "github")
+	}
+}
+
+// TestDetectGitConfig_OriginURLError keeps the detected mode and falls back to
+// the github provider default when origin's URL cannot be read.
+func TestDetectGitConfig_OriginURLError(t *testing.T) {
+	origList, origURL := gitRemoteListFunc, gitOriginURLFunc
+	gitRemoteListFunc = func(string) (string, error) { return "origin\n", nil }
+	gitOriginURLFunc = func(string) (string, error) { return "", os.ErrNotExist }
+	t.Cleanup(func() {
+		gitRemoteListFunc, gitOriginURLFunc = origList, origURL
+	})
+
+	mode, provider := detectGitConfig(t.TempDir())
+	if mode != "personal" {
+		t.Errorf("mode = %q, want %q", mode, "personal")
+	}
+	if provider != "github" {
+		t.Errorf("provider = %q, want %q", provider, "github")
+	}
+}
+
+// TestInitGitFlagOverridesDetection asserts the explicit --git-mode /
+// --git-provider flags win over detection: the project dir has no remote (so
+// detection yields manual+github) yet the persisted config carries the flags.
+func TestInitGitFlagOverridesDetection(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	origInteractive := isInteractiveStdin
+	isInteractiveStdin = func() bool { return true }
+	t.Cleanup(func() { isInteractiveStdin = origInteractive })
+
+	origDeps := deps
+	deps = nil
+	t.Cleanup(func() { deps = origDeps })
+
+	// The wizard no longer answers any git question on the init path.
+	origWizard := runWizardFn
+	runWizardFn = func(_, _, _ string, _, _ bool) (*wizard.WizardResult, error) {
+		return &wizard.WizardResult{
+			ProjectName:  "flag-proj",
+			ModelPolicy:  "high",
+			ReportFormat: "html+md",
+		}, nil
+	}
+	t.Cleanup(func() { runWizardFn = origWizard })
+
+	projectDir := filepath.Join(t.TempDir(), "flag-proj")
+	cmd := newInitTestCmd()
+	var out, errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	if err := cmd.Flags().Set("git-mode", "team"); err != nil {
+		t.Fatalf("set --git-mode: %v", err)
+	}
+	if err := cmd.Flags().Set("git-provider", "gitlab"); err != nil {
+		t.Fatalf("set --git-provider: %v", err)
+	}
+
+	if err := runInit(cmd, []string{projectDir}); err != nil {
+		t.Fatalf("runInit: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(projectDir, ".moai", "config", "sections", "git-strategy.yaml"))
+	if err != nil {
+		t.Fatalf("read git-strategy.yaml: %v", err)
+	}
+	got := string(data)
+	if !strings.Contains(got, `mode: "team"`) {
+		t.Errorf("--git-mode=team must win over detected 'manual', got:\n%s", got)
+	}
+	if !strings.Contains(got, `provider: "gitlab"`) {
+		t.Errorf("--git-provider=gitlab must win over detected 'github', got:\n%s", got)
+	}
+}
+
+// TestInitGitDetectionFillsConfig asserts detection fills the persisted config
+// when no git flag is supplied: a repo with a github origin yields
+// personal + github without the wizard asking anything.
+func TestInitGitDetectionFillsConfig(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	origInteractive := isInteractiveStdin
+	isInteractiveStdin = func() bool { return true }
+	t.Cleanup(func() { isInteractiveStdin = origInteractive })
+
+	origDeps := deps
+	deps = nil
+	t.Cleanup(func() { deps = origDeps })
+
+	origWizard := runWizardFn
+	runWizardFn = func(_, _, _ string, _, _ bool) (*wizard.WizardResult, error) {
+		return &wizard.WizardResult{
+			ProjectName:  "detect-proj",
+			ModelPolicy:  "high",
+			ReportFormat: "html+md",
+		}, nil
+	}
+	t.Cleanup(func() { runWizardFn = origWizard })
+
+	// Initialize the project dir as a git repo with a github origin BEFORE
+	// running init, so detection sees the remote.
+	projectDir := filepath.Join(t.TempDir(), "detect-proj")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := exec.Command("git", "-C", projectDir, "init").Run(); err != nil {
+		t.Skipf("git init unavailable: %v", err)
+	}
+	gitAddRemote(t, projectDir, "origin", "https://github.com/modu-ai/moai-adk.git")
+
+	cmd := newInitTestCmd()
+	var out, errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+
+	if err := runInit(cmd, []string{projectDir}); err != nil {
+		t.Fatalf("runInit: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(projectDir, ".moai", "config", "sections", "git-strategy.yaml"))
+	if err != nil {
+		t.Fatalf("read git-strategy.yaml: %v", err)
+	}
+	got := string(data)
+	if !strings.Contains(got, `mode: "personal"`) {
+		t.Errorf("configured remote must detect mode 'personal', got:\n%s", got)
+	}
+	if !strings.Contains(got, `provider: "github"`) {
+		t.Errorf("github origin must detect provider 'github', got:\n%s", got)
+	}
+}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -1265,7 +1265,7 @@ func runInitWizard(cmd *cobra.Command, reconfigure bool) error {
 	ghAuthenticated := wizard.IsGhAuthenticated()
 
 	// Generate default questions and set defaults from existing values
-	questions := wizard.DefaultQuestions(cwd)
+	questions := wizard.ReconfigureQuestions(cwd)
 	if existingGitHubUsername != "" {
 		if q := wizard.QuestionByID(questions, "github_username"); q != nil {
 			q.Default = existingGitHubUsername

--- a/internal/cli/wizard/expansion_test.go
+++ b/internal/cli/wizard/expansion_test.go
@@ -361,13 +361,12 @@ func TestTotalVisibleQuestions_StandardMode(t *testing.T) {
 	tmpDir := t.TempDir()
 	all := append(DefaultQuestions(tmpDir), Phase1Questions(tmpDir)...)
 
-	// Quick mode: 4 unconditional questions visible (git conditionals hidden)
+	// Quick mode: the init set is fully unconditional apart from
+	// advanced_bridge (visible while StandardMode is false); no git questions
+	// and 0 Phase 1 questions.
 	quickResult := &WizardResult{StandardMode: false}
-	// 4 unconditional questions (project_name, model_policy, report_format, git_mode)
-	// Plus 4 conditional git questions (default hidden unless GitMode is set)
-	// and 0 Phase 1 questions
 	quickCount := TotalVisibleQuestions(all, quickResult)
-	if quickCount != 4 { // project_name, model_policy, report_format, git_mode
+	if quickCount != 4 {
 		// More lenient check: all originals minus conditional ones
 		if quickCount > 9 {
 			t.Errorf("Quick mode shows more than 9 questions: %d", quickCount)

--- a/internal/cli/wizard/questions.go
+++ b/internal/cli/wizard/questions.go
@@ -7,21 +7,26 @@ import (
 	"strings"
 )
 
-// DefaultQuestions returns the standard set of questions for project initialization.
-// The questions follow this order:
-// 1. Conversation language (drives the rendering language of every later question)
-// 2. User name (optional)
-// 3. Project name (required)
-// 4. Model policy
-// 5. Report format
-// 6. Git mode
-// 7. Git provider (conditional)
-// 8. GitLab instance URL (conditional)
-// 9. GitHub username (conditional)
-// 10. GitHub token (conditional)
-// 11. GitLab username (conditional)
-// 12. GitLab token (conditional)
-// 13. Advanced-settings bridge (conditional — hidden when StandardMode is preset by flag)
+// The wizard question set is split across three constructors:
+//
+//   - DefaultQuestions      — the `moai init` set (NO Git questions)
+//   - GitQuestions          — the 7 Git questions, on their own
+//   - ReconfigureQuestions  — DefaultQuestions with GitQuestions spliced back in,
+//     used by the `moai update --reconfigure` path
+//
+// DefaultQuestions returns the question set asked during project
+// initialization, in this order:
+//  1. Conversation language (drives the rendering language of every later question)
+//  2. User name (optional)
+//  3. Project name (required)
+//  4. Model policy
+//  5. Report format
+//  6. Advanced-settings bridge (conditional — hidden when StandardMode is preset by flag)
+//
+// Git mode and provider are NOT asked here: `moai init` derives them from the
+// repository's configured remotes (see detectGitConfig in internal/cli), so a
+// fresh init no longer interrogates the user about Git. The reconfigure path
+// still asks them — see ReconfigureQuestions.
 //
 // plan_type and development_mode are NO LONGER interactive questions — they
 // default silently (plan_type → subscription at persistence; development_mode →
@@ -108,7 +113,39 @@ func DefaultQuestions(projectRoot string) []Question {
 			Default:  "html+md",
 			Required: true,
 		},
-		// 4. Git Mode
+		// 6. Advanced-settings bridge (Quick mode only). Answering Yes flips
+		// StandardMode on, which reveals the Phase 1 questions (gated on
+		// r.StandardMode) in the same wizard run. Hidden when --standard/--advanced
+		// already preset StandardMode (Condition returns false), so the flag path
+		// never double-asks.
+		{
+			ID:          "advanced_bridge",
+			Group:       "Options",
+			Type:        QuestionTypeConfirm,
+			Title:       "Configure advanced settings? (default: No)",
+			Description: "Reveals project mode, harness profile, LSP, quality gates, and design options in this run.",
+			Default:     "false",
+			Required:    false,
+			Condition:   func(r *WizardResult) bool { return !r.StandardMode },
+		},
+	}
+}
+
+// GitQuestions returns the 7 Git questions, in their canonical order:
+//  1. Git mode
+//  2. Git provider (conditional)
+//  3. GitLab instance URL (conditional)
+//  4. GitHub username (conditional)
+//  5. GitHub token (conditional)
+//  6. GitLab username (conditional)
+//  7. GitLab token (conditional)
+//
+// These are asked by the `moai update --reconfigure` path only (via
+// ReconfigureQuestions); `moai init` auto-detects mode and provider from the
+// repository's remotes instead.
+func GitQuestions() []Question {
+	return []Question{
+		// 1. Git Mode
 		{
 			ID:          "git_mode",
 			Group:       "Git",
@@ -123,7 +160,7 @@ func DefaultQuestions(projectRoot string) []Question {
 			Default:  "manual",
 			Required: true,
 		},
-		// 4. Git Provider (conditional - only for personal/team modes)
+		// 2. Git Provider (conditional - only for personal/team modes)
 		{
 			ID:          "git_provider",
 			Group:       "Git",
@@ -140,7 +177,7 @@ func DefaultQuestions(projectRoot string) []Question {
 				return r.GitMode == "personal" || r.GitMode == "team"
 			},
 		},
-		// 5. GitLab Instance URL (conditional - only for gitlab provider)
+		// 3. GitLab Instance URL (conditional - only for gitlab provider)
 		{
 			ID:          "gitlab_instance_url",
 			Group:       "Git",
@@ -153,7 +190,7 @@ func DefaultQuestions(projectRoot string) []Question {
 				return (r.GitMode == "personal" || r.GitMode == "team") && r.GitProvider == "gitlab"
 			},
 		},
-		// 6. GitHub Username (conditional - only for github provider)
+		// 4. GitHub Username (conditional - only for github provider)
 		{
 			ID:          "github_username",
 			Group:       "Git",
@@ -166,7 +203,7 @@ func DefaultQuestions(projectRoot string) []Question {
 				return (r.GitMode == "personal" || r.GitMode == "team") && r.GitProvider == "github"
 			},
 		},
-		// 7. GitHub Token (conditional - only for github provider)
+		// 5. GitHub Token (conditional - only for github provider)
 		{
 			ID:          "github_token",
 			Group:       "Git",
@@ -179,7 +216,7 @@ func DefaultQuestions(projectRoot string) []Question {
 				return (r.GitMode == "personal" || r.GitMode == "team") && r.GitProvider == "github"
 			},
 		},
-		// 8. GitLab Username (conditional - only for gitlab provider)
+		// 6. GitLab Username (conditional - only for gitlab provider)
 		{
 			ID:          "gitlab_username",
 			Group:       "Git",
@@ -192,7 +229,7 @@ func DefaultQuestions(projectRoot string) []Question {
 				return (r.GitMode == "personal" || r.GitMode == "team") && r.GitProvider == "gitlab"
 			},
 		},
-		// 9. GitLab Token (conditional - only for gitlab provider)
+		// 7. GitLab Token (conditional - only for gitlab provider)
 		{
 			ID:          "gitlab_token",
 			Group:       "Git",
@@ -205,22 +242,33 @@ func DefaultQuestions(projectRoot string) []Question {
 				return (r.GitMode == "personal" || r.GitMode == "team") && r.GitProvider == "gitlab"
 			},
 		},
-		// 13. Advanced-settings bridge (Quick mode only). Answering Yes flips
-		// StandardMode on, which reveals the Phase 1 questions (gated on
-		// r.StandardMode) in the same wizard run. Hidden when --standard/--advanced
-		// already preset StandardMode (Condition returns false), so the flag path
-		// never double-asks.
-		{
-			ID:          "advanced_bridge",
-			Group:       "Options",
-			Type:        QuestionTypeConfirm,
-			Title:       "Configure advanced settings? (default: No)",
-			Description: "Reveals project mode, harness profile, LSP, quality gates, and design options in this run.",
-			Default:     "false",
-			Required:    false,
-			Condition:   func(r *WizardResult) bool { return !r.StandardMode },
-		},
 	}
+}
+
+// ReconfigureQuestions returns the full question set used by the
+// `moai update --reconfigure` path: DefaultQuestions with GitQuestions spliced
+// back in at their original position — after report_format, before
+// advanced_bridge — so the reconfigure wizard's question order is unchanged.
+func ReconfigureQuestions(projectRoot string) []Question {
+	base := DefaultQuestions(projectRoot)
+	git := GitQuestions()
+
+	// Splice point: immediately after report_format. Falling back to
+	// "before the trailing advanced_bridge" keeps the order correct if the
+	// base set is ever reordered.
+	splice := len(base)
+	for i, q := range base {
+		if q.ID == "report_format" {
+			splice = i + 1
+			break
+		}
+	}
+
+	merged := make([]Question, 0, len(base)+len(git))
+	merged = append(merged, base[:splice]...)
+	merged = append(merged, git...)
+	merged = append(merged, base[splice:]...)
+	return merged
 }
 
 // FilteredQuestions returns questions filtered by their conditions.

--- a/internal/cli/wizard/questions_test.go
+++ b/internal/cli/wizard/questions_test.go
@@ -93,7 +93,76 @@ func TestQuestionOrder(t *testing.T) {
 		t.Errorf("first question should be 'conversation_language', got %q", questions[0].ID)
 	}
 
+	// Git questions are absent from the init set — mode and provider are
+	// auto-detected from the repository's remotes.
 	expectedIDs := []string{
+		"conversation_language",
+		"user_name",
+		"project_name",
+		"model_policy",
+		"report_format",
+		"advanced_bridge",
+	}
+
+	if len(questions) != len(expectedIDs) {
+		t.Fatalf("DefaultQuestions() returned %d questions, want %d", len(questions), len(expectedIDs))
+	}
+	for i, expectedID := range expectedIDs {
+		if questions[i].ID != expectedID {
+			t.Errorf("question[%d].ID = %q, want %q", i, questions[i].ID, expectedID)
+		}
+	}
+}
+
+// gitQuestionIDs is the canonical Git question ID set, in order. Shared by the
+// split-set tests below.
+var gitQuestionIDs = []string{
+	"git_mode",
+	"git_provider",
+	"gitlab_instance_url",
+	"github_username",
+	"github_token",
+	"gitlab_username",
+	"gitlab_token",
+}
+
+// TestDefaultQuestionsHasNoGitQuestions verifies the init path asks nothing
+// about Git — the 7 Git questions moved to the reconfigure-only set.
+func TestDefaultQuestionsHasNoGitQuestions(t *testing.T) {
+	questions := DefaultQuestions("/tmp/test-project")
+
+	for _, id := range gitQuestionIDs {
+		if q := QuestionByID(questions, id); q != nil {
+			t.Errorf("git question %q must not be in DefaultQuestions (init auto-detects git config)", id)
+		}
+	}
+}
+
+// TestGitQuestionsReturnsExactSet verifies GitQuestions returns exactly the 7
+// Git questions, in canonical order.
+func TestGitQuestionsReturnsExactSet(t *testing.T) {
+	questions := GitQuestions()
+
+	if len(questions) != len(gitQuestionIDs) {
+		t.Fatalf("GitQuestions() returned %d questions, want %d", len(questions), len(gitQuestionIDs))
+	}
+	for i, want := range gitQuestionIDs {
+		if questions[i].ID != want {
+			t.Errorf("GitQuestions()[%d].ID = %q, want %q", i, questions[i].ID, want)
+		}
+		if questions[i].Group != "Git" {
+			t.Errorf("question %q group = %q, want %q", questions[i].ID, questions[i].Group, "Git")
+		}
+	}
+}
+
+// TestReconfigureQuestionsOrder verifies the reconfigure set is the union of
+// both sets with the Git block spliced between report_format and
+// advanced_bridge — the pre-split order, preserved for `moai update`.
+func TestReconfigureQuestionsOrder(t *testing.T) {
+	questions := ReconfigureQuestions("/tmp/test-project")
+
+	wantIDs := []string{
 		"conversation_language",
 		"user_name",
 		"project_name",
@@ -109,12 +178,37 @@ func TestQuestionOrder(t *testing.T) {
 		"advanced_bridge",
 	}
 
-	for i, expectedID := range expectedIDs {
-		if i >= len(questions) {
-			t.Fatalf("expected question at index %d (%s), but only %d questions", i, expectedID, len(questions))
+	if len(questions) != len(wantIDs) {
+		t.Fatalf("ReconfigureQuestions() returned %d questions, want %d", len(questions), len(wantIDs))
+	}
+	for i, want := range wantIDs {
+		if questions[i].ID != want {
+			t.Errorf("ReconfigureQuestions()[%d].ID = %q, want %q", i, questions[i].ID, want)
 		}
-		if questions[i].ID != expectedID {
-			t.Errorf("question[%d].ID = %q, want %q", i, questions[i].ID, expectedID)
+	}
+
+	// Every ID from both source sets must be present.
+	for _, q := range append(DefaultQuestions("/tmp/test-project"), GitQuestions()...) {
+		if QuestionByID(questions, q.ID) == nil {
+			t.Errorf("ReconfigureQuestions() missing %q", q.ID)
+		}
+	}
+
+	// The Git block sits strictly between report_format and advanced_bridge.
+	indexOf := func(id string) int {
+		for i, q := range questions {
+			if q.ID == id {
+				return i
+			}
+		}
+		return -1
+	}
+	reportIdx, bridgeIdx := indexOf("report_format"), indexOf("advanced_bridge")
+	for _, id := range gitQuestionIDs {
+		i := indexOf(id)
+		if i <= reportIdx || i >= bridgeIdx {
+			t.Errorf("git question %q at index %d must sit between report_format (%d) and advanced_bridge (%d)",
+				id, i, reportIdx, bridgeIdx)
 		}
 	}
 }
@@ -207,13 +301,6 @@ func TestQuestionsAllPresent(t *testing.T) {
 		"project_name",
 		"model_policy",
 		"report_format",
-		"git_mode",
-		"git_provider",
-		"gitlab_instance_url",
-		"github_username",
-		"github_token",
-		"gitlab_username",
-		"gitlab_token",
 		"advanced_bridge",
 	}
 
@@ -224,9 +311,10 @@ func TestQuestionsAllPresent(t *testing.T) {
 	}
 }
 
-// TestGitConditionalFilteredByMode verifies conditional git questions hide when manual.
+// TestGitConditionalFilteredByMode verifies conditional git questions hide when
+// manual. Git questions live on the reconfigure set only.
 func TestGitConditionalFilteredByMode(t *testing.T) {
-	questions := DefaultQuestions("/tmp/test-project")
+	questions := ReconfigureQuestions("/tmp/test-project")
 
 	// When git_mode is "manual", git provider questions should be hidden
 	result := &WizardResult{GitMode: "manual"}

--- a/internal/cli/wizard/unified_form_test.go
+++ b/internal/cli/wizard/unified_form_test.go
@@ -88,12 +88,12 @@ func TestUnifiedForm_MultiGroupSinglePage(t *testing.T) {
 	form := buildUnifiedForm(questions, result, "")
 	d := newFormDriver(t, form)
 
-	// Initial page is the Language select (question 1 of 7 visible:
-	// conversation_language, user_name, project_name, model_policy, report_format,
-	// git_mode, advanced_bridge; git conditionals hidden). The stepper note
-	// renders the dynamic denominator "1 / 7" (REQ-TUX2-008).
-	if initial := d.view(); !strings.Contains(initial, "1 / 7") {
-		t.Errorf("initial stepper note must render dynamic denominator '1 / 7', frame:\n%s", initial)
+	// Initial page is the Language select (question 1 of 6 visible:
+	// conversation_language, user_name, project_name, model_policy,
+	// report_format, advanced_bridge — the init set asks nothing about Git).
+	// The stepper note renders the dynamic denominator "1 / 6" (REQ-TUX2-008).
+	if initial := d.view(); !strings.Contains(initial, "1 / 6") {
+		t.Errorf("initial stepper note must render dynamic denominator '1 / 6', frame:\n%s", initial)
 	}
 
 	// Page 1 is the Language select, page 2 is the Identity (user_name) input;
@@ -118,7 +118,8 @@ func TestUnifiedForm_MultiGroupSinglePage(t *testing.T) {
 // harvested WizardResult must match the v1 per-question-form behavior.
 func TestUnifiedForm_ConditionalGroupsAppear(t *testing.T) {
 	result := &WizardResult{}
-	questions := DefaultQuestions("/tmp/unified-cond")
+	// Git conditionals live on the reconfigure set only.
+	questions := ReconfigureQuestions("/tmp/unified-cond")
 	form := buildUnifiedForm(questions, result, "")
 	d := newFormDriver(t, form)
 
@@ -203,7 +204,7 @@ func TestUnifiedForm_ConditionalGroupsAppear(t *testing.T) {
 // never surfaces provider questions (visibility semantics preserved).
 func TestUnifiedForm_ManualModeSkipsConditionals(t *testing.T) {
 	result := &WizardResult{}
-	questions := DefaultQuestions("/tmp/unified-manual")
+	questions := ReconfigureQuestions("/tmp/unified-manual")
 	form := buildUnifiedForm(questions, result, "")
 	d := newFormDriver(t, form)
 
@@ -239,17 +240,22 @@ func TestUnifiedForm_ManualModeSkipsConditionals(t *testing.T) {
 func TestBuildFormGroups_Partition(t *testing.T) {
 	result := &WizardResult{}
 	locale := ""
-	questions := DefaultQuestions("/tmp/unified-partition")
 
-	groups := buildFormGroups(questions, result, &locale)
-	// DefaultQuestions groups: "Language" (conversation_language) + "Identity"
-	// (user_name) + "Project" (project_name, model_policy, report_format) + "Git"
-	// (git_mode) + 6 conditional git questions + advanced_bridge (conditional) =
-	// 1 + 1 + 1 + 1 + 6 + 1 = 11 groups.
+	// Init set: "Language" (conversation_language) + "Identity" (user_name) +
+	// "Project" (project_name, model_policy, report_format) + advanced_bridge
+	// (conditional) = 1 + 1 + 1 + 1 = 4 groups. No Git groups.
+	initGroups := buildFormGroups(DefaultQuestions("/tmp/unified-partition"), result, &locale)
+	if len(initGroups) != 4 {
+		t.Errorf("expected 4 init groups (Language, Identity, Project, advanced_bridge), got %d", len(initGroups))
+	}
+
+	// Reconfigure set adds "Git" (git_mode) + 6 conditional git questions,
+	// each its own hideable group = 4 + 1 + 6 = 11 groups.
+	groups := buildFormGroups(ReconfigureQuestions("/tmp/unified-partition"), result, &locale)
 	if len(groups) != 11 {
 		t.Errorf("expected 11 groups (Language, Identity, Project, Git, 6 git conditionals, advanced_bridge), got %d", len(groups))
 	}
-	for i, g := range groups {
+	for i, g := range append(initGroups, groups...) {
 		if g == nil {
 			t.Fatalf("group %d is nil", i)
 		}

--- a/internal/cli/wizard/wizard_test.go
+++ b/internal/cli/wizard/wizard_test.go
@@ -300,7 +300,8 @@ func TestGetUIStrings(t *testing.T) {
 // --- Git provider conditional tests ---
 
 func TestGitProviderQuestion(t *testing.T) {
-	questions := DefaultQuestions("/tmp/test-project")
+	// Git questions live on the reconfigure path only (init auto-detects).
+	questions := ReconfigureQuestions("/tmp/test-project")
 
 	// Verify git_provider question exists
 	q := QuestionByID(questions, "git_provider")
@@ -327,7 +328,7 @@ func TestGitProviderQuestion(t *testing.T) {
 }
 
 func TestGitLabQuestionsConditional(t *testing.T) {
-	questions := DefaultQuestions("/tmp/test-project")
+	questions := ReconfigureQuestions("/tmp/test-project")
 
 	// gitlab_instance_url should only show for gitlab provider
 	q := QuestionByID(questions, "gitlab_instance_url")
@@ -373,7 +374,7 @@ func TestGitLabQuestionsConditional(t *testing.T) {
 }
 
 func TestGitHubQuestionsHiddenForGitLab(t *testing.T) {
-	questions := DefaultQuestions("/tmp/test-project")
+	questions := ReconfigureQuestions("/tmp/test-project")
 
 	// github_username should be hidden for gitlab provider
 	q := QuestionByID(questions, "github_username")
@@ -574,7 +575,9 @@ func TestCharacterize_WizardTheme_BlurredInheritsFromFocused(t *testing.T) {
 // derived from the single dynamic source (TotalVisibleQuestions) and varies
 // with the visible-question set (AC-TUX2-007).
 func TestStepperTotal_DynamicDenominator(t *testing.T) {
-	questions := DefaultQuestions("/tmp/steppertotal")
+	// Exercised against the reconfigure set, which retains the conditional Git
+	// questions that make the denominator vary.
+	questions := ReconfigureQuestions("/tmp/steppertotal")
 
 	cases := []struct {
 		name   string
@@ -604,7 +607,7 @@ func TestStepperTotal_DynamicDenominator(t *testing.T) {
 	// Standard mode expands the denominator further (Phase 1 questions). The
 	// advanced_bridge hides when StandardMode is preset, so the total is 6
 	// unconditional defaults (git conditionals hidden for manual) + 7 Phase 1 = 13.
-	all := append(DefaultQuestions("/tmp/steppertotal"), Phase1Questions("/tmp/steppertotal")...)
+	all := append(ReconfigureQuestions("/tmp/steppertotal"), Phase1Questions("/tmp/steppertotal")...)
 	std := &WizardResult{GitMode: "manual", StandardMode: true, DesignEnabled: true}
 	if got := stepperDenominator(all, std); got != 13 {
 		t.Errorf("standard-mode denominator: expected 13 (6 + 7 Phase 1), got %d", got)
@@ -944,7 +947,9 @@ func TestDefaultQuestions_SelectQuestionsHaveOptions(t *testing.T) {
 }
 
 func TestDefaultQuestions_ConditionalQuestionsHaveConditions(t *testing.T) {
-	questions := DefaultQuestions("/tmp/test")
+	// The conditional IDs below are Git questions, which survive on the
+	// reconfigure set only.
+	questions := ReconfigureQuestions("/tmp/test")
 	conditionalIDs := map[string]bool{
 		"git_provider":        true,
 		"gitlab_instance_url": true,
@@ -1006,7 +1011,7 @@ func TestRunWithDefaults_AcceptsLocaleParameter(t *testing.T) {
 
 func TestDefaultQuestions_GitHubUsernameDefaultOverride(t *testing.T) {
 	// The github_username default from DefaultQuestions should be overridable
-	questions := DefaultQuestions("/tmp/test")
+	questions := ReconfigureQuestions("/tmp/test")
 	q := QuestionByID(questions, "github_username")
 	if q == nil {
 		t.Fatal("github_username question not found")
@@ -1025,7 +1030,7 @@ func TestDefaultQuestions_GitHubUsernameDefaultOverride(t *testing.T) {
 }
 
 func TestDefaultQuestions_GitLabUsernameDefaultOverride(t *testing.T) {
-	questions := DefaultQuestions("/tmp/test")
+	questions := ReconfigureQuestions("/tmp/test")
 	q := QuestionByID(questions, "gitlab_username")
 	if q == nil {
 		t.Fatal("gitlab_username question not found")
@@ -1046,7 +1051,7 @@ func TestDefaultQuestions_GitLabUsernameDefaultOverride(t *testing.T) {
 // --- REQ-3: skip github_token question when gh auth is authenticated test ---
 
 func TestDefaultQuestions_GitHubTokenCondition(t *testing.T) {
-	questions := DefaultQuestions("/tmp/test")
+	questions := ReconfigureQuestions("/tmp/test")
 	q := QuestionByID(questions, "github_token")
 	if q == nil {
 		t.Fatal("github_token question not found")
@@ -1213,7 +1218,7 @@ func TestGetUIStrings_AllLocales(t *testing.T) {
 }
 
 func TestGetLocalizedQuestion_AllLocales_ForGitModeQuestion(t *testing.T) {
-	questions := DefaultQuestions("/tmp/test")
+	questions := ReconfigureQuestions("/tmp/test")
 	q := QuestionByID(questions, "git_mode")
 	if q == nil {
 		t.Fatal("git_mode question not found")


### PR DESCRIPTION
## Why

The `moai init` wizard asked 7 Git questions, **3 of which were silently discarded**:

`internal/cli/init.go` reads only `result.GitMode / GitProvider / GitHubUsername / GitLabInstanceURL` from the wizard. It never reads `result.GitHubToken`, `result.GitLabToken`, or `result.GitLabUsername` — only `update.go:1348-1357` persists those. So a PAT typed at init went nowhere.

`init.go` also never called `wizard.IsGhAuthenticated()` (only `update.go:1265` does), so it prompted for a token even when `gh auth` was already configured — and then threw the answer away.

## What changed

**Question set split** (`internal/cli/wizard/questions.go`) — `DefaultQuestions` was shared by both the init path (`wizard.go:45`) and the update reconfigure path (`update.go:1268`), so a plain deletion would have stripped both:

| Function | Returns |
|---|---|
| `DefaultQuestions` | init set — Git group removed |
| `GitQuestions` | the 7 Git questions |
| `ReconfigureQuestions` | both, spliced back in the original order |

`update.go` now calls `ReconfigureQuestions` (1-line change). The reconfigure path, its `gh auth` skip, and token persistence are unchanged.

**Auto-detection** (`internal/cli/init_gitdetect.go`, new) — `git_strategy.mode` stays load-bearing (19 references across shipped templates; `manager-git.md:33` resolves `main_branch` and `merge_method` from it), so init resolves it from the repository instead of asking:

- no remote (or not a git repo) → `manual`
- ≥1 remote → `personal`
- provider from the `origin` host: `github.com` → `github`, anything else → `gitlab`; unparseable or absent → `github` fallback

Explicit `--git-mode` / `--git-provider` flags still take precedence — detection only fills a value left empty after flag parsing.

## Effect

| | before | after |
|---|---|---|
| `moai init` quick | 7 questions | **6** (0 Git) |
| `moai init` personal+github | 10 | **6** |
| `moai init` personal+gitlab | 11 | **6** |
| `moai update --reconfigure` | — | unchanged |

## Accepted trade-off

New **team** projects now initialize as `personal`. Opting into the team profile (`draft_pr`, `required_reviews`, `branch_protection`) requires `moai init --git-mode team` or `moai web`. This was chosen deliberately over hard-defaulting to `manual`, which would have disabled the PR flow for every user with an existing remote.

## Not changed

`WizardResult` Git fields, `translations.go` Git entries (4 locales), `saveAnswer` Git branches, and `internal/template/templates/` — all still exercised by the update path and template rendering.

## Verification

| check | result |
|---|---|
| `go test ./internal/cli/...` | ok (20.6s) |
| `go vet ./...` | exit 0 |
| `make build` | exit 0 |
| `GOOS=windows GOARCH=amd64 go build ./...` | exit 0 |

New tests cover: `DefaultQuestions` contains no Git IDs, `GitQuestions` returns exactly 7, `ReconfigureQuestions` preserves order, and detection branches (no-remote → manual, remote → personal, github/non-github provider, flag precedence). Repo fixtures use `t.TempDir()`.

🗿 MoAI