### PR TITLE
fix(windows): close remaining 10 Windows failures — claim exclusivity + racy reads

### DIFF
--- a/internal/atomicfile/read_unix.go
+++ b/internal/atomicfile/read_unix.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package atomicfile
+
+import "os"
+
+// readFile is a direct os.ReadFile passthrough. POSIX rename(2) swaps the
+// directory entry atomically and never leaves the destination momentarily
+// unopenable, so a reader racing a replace sees either the old or the new file
+// and never needs a retry.
+func readFile(path string) ([]byte, error) {
+	return os.ReadFile(path)
+}

--- a/internal/atomicfile/read_windows.go
+++ b/internal/atomicfile/read_windows.go
@@ -1,0 +1,44 @@
+//go:build windows
+
+package atomicfile
+
+import (
+	"os"
+	"time"
+)
+
+// Retry budget for a transiently-blocked read. Deliberately smaller than the
+// replace budget: a blocked replace must eventually win or the write is lost,
+// whereas a blocked read has a caller waiting on it, and the window it absorbs
+// (one concurrent rename) is short.
+const (
+	readMaxAttempts = 20
+	readRetryDelay  = 5 * time.Millisecond
+)
+
+// readFile reads path, retrying while Windows reports a transient sharing
+// conflict.
+//
+// Opening a file for reading fails with ERROR_ACCESS_DENIED or
+// ERROR_SHARING_VIOLATION while another process is replacing it, because the
+// destination sits briefly in a delete-pending state that MoveFileEx creates.
+// This is the mirror image of the conflict Replace absorbs: there the reader
+// blocks the writer, here the writer blocks the reader. Both are transient, so
+// the same bounded-retry policy converges.
+//
+// A missing file is NOT transient and returns immediately, so callers keep
+// matching on os.IsNotExist as with os.ReadFile.
+func readFile(path string) ([]byte, error) {
+	var (
+		data []byte
+		err  error
+	)
+	for attempt := 0; attempt < readMaxAttempts; attempt++ {
+		data, err = os.ReadFile(path)
+		if err == nil || !isTransientReplaceError(err) {
+			return data, err
+		}
+		time.Sleep(readRetryDelay)
+	}
+	return data, err
+}

--- a/internal/atomicfile/replace.go
+++ b/internal/atomicfile/replace.go
@@ -11,10 +11,48 @@
 // changing their error-handling shape.
 package atomicfile
 
+import "os"
+
 // Replace renames oldpath onto newpath, replacing newpath if it exists.
 //
 // The returned error is the underlying *os.LinkError from os.Rename, so
 // callers may keep matching on os.IsNotExist / errors.Is as before.
 func Replace(oldpath, newpath string) error {
 	return replace(oldpath, newpath)
+}
+
+// ReadFile reads path, absorbing the transient window in which a concurrent
+// Replace makes the file briefly unopenable on Windows. On POSIX it is a plain
+// os.ReadFile. A missing file returns immediately in both cases, so callers may
+// keep matching on os.IsNotExist.
+//
+// Use it for any read that can race a writer of the same file; a read fully
+// serialized against writers does not need it.
+func ReadFile(path string) ([]byte, error) {
+	return readFile(path)
+}
+
+// Claim exclusively creates path, returning an error wrapping fs.ErrExist when
+// path already exists. Exactly one concurrent caller can succeed for a given
+// path: O_CREATE|O_EXCL is atomic on POSIX and maps to CREATE_NEW on Windows,
+// so the exclusivity is guaranteed by both platforms rather than inferred from
+// a particular failure errno.
+//
+// Claim is deliberately the opposite of Replace, and the two must not be
+// substituted for each other:
+//
+//   - Replace answers "make newpath be this content", so replacing an existing
+//     destination is success, and on Windows it retries a transient sharing
+//     violation until the destination is writable.
+//   - Claim answers "am I the one who gets to proceed", so an existing path is
+//     failure, and it NEVER retries — a retry would hand the same claim to a
+//     second caller and destroy the mutual exclusion it exists to provide.
+//
+// Callers own removing the claim once the guarded work is done.
+func Claim(path string, perm os.FileMode) error {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, perm)
+	if err != nil {
+		return err
+	}
+	return f.Close()
 }

--- a/internal/cli/glm_tools.go
+++ b/internal/cli/glm_tools.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/modu-ai/moai-adk/internal/atomicfile"
 	"github.com/modu-ai/moai-adk/internal/lockfile"
 )
 
@@ -472,7 +473,11 @@ func writeClaudeJSONBytes(configPath string, data []byte) error {
 // feeds the prep-phase apply. Returns (nil, empty-map, nil) when the file does
 // not exist, matching readClaudeJSON semantics.
 func readClaudeJSONRaw(configPath string) ([]byte, map[string]any, error) {
-	data, err := os.ReadFile(configPath)
+	// The prep read runs OUTSIDE the guard's lock, so it races another writer's
+	// atomic replace. On Windows that read transiently fails with a sharing
+	// violation, which would surface as a spurious "설정 파일 읽기 실패" rather
+	// than the lost update the guard exists to prevent.
+	data, err := atomicfile.ReadFile(configPath)
 	if os.IsNotExist(err) {
 		return nil, map[string]any{}, nil
 	}
@@ -574,7 +579,9 @@ func mutateClaudeJSONAtomic(configPath string, apply func(root map[string]any) (
 		publishOut := prepOut
 		compareData := prepData
 		for attempt := 0; ; attempt++ {
-			data, rerr := os.ReadFile(configPath)
+			// A non-cooperating writer (Claude Code itself) can be replacing the
+			// file even while we hold the lock, so this read races too.
+			data, rerr := atomicfile.ReadFile(configPath)
 			if rerr != nil && !os.IsNotExist(rerr) {
 				return fmt.Errorf("설정 파일 읽기 실패: %w", rerr)
 			}
@@ -645,7 +652,7 @@ func withClaudeJSONLock(configPath string, fn func(locked bool) error) error {
 // backupClaudeJSON backs up the current contents of configPath (REQ-GMC-005)
 // Does not back up when the file does not exist.
 func backupClaudeJSON(configPath string) error {
-	data, err := os.ReadFile(configPath)
+	data, err := atomicfile.ReadFile(configPath)
 	if os.IsNotExist(err) {
 		return nil // No backup needed when the file does not exist
 	}

--- a/internal/hook/handoff/pending.go
+++ b/internal/hook/handoff/pending.go
@@ -60,6 +60,13 @@ func ConsumedDir(projectDir string) string {
 	return filepath.Join(handoffStateDir(projectDir), "consumed")
 }
 
+// ClaimGatePath returns the exclusive-creation gate that elects a single
+// consumer of pending.json when several SessionStart hooks race. It sits beside
+// pending.json rather than inside consumed/, which is an enumerated audit trail.
+func ClaimGatePath(projectDir string) string {
+	return PendingPath(projectDir) + ".claim"
+}
+
 // SavePending writes rec to handoff/pending.json using an atomic temp-file +
 // rename (reusing the persist.go atomicWriteFile contract). REQ-AUTORESUME-005:
 // it writes ONLY the handoff/ tree and NEVER touches session-handoff/pending.md.
@@ -87,6 +94,12 @@ func SavePending(projectDir string, rec *PendingRecord) error {
 	if err := atomicWriteFile(dir, "pending.json", data, 0o600); err != nil {
 		return fmt.Errorf("atomic write pending.json: %w", err)
 	}
+	// Clear any claim gate leaked by a killed consumer. This record was just
+	// written, so it has never been claimed and no live consumer can hold a gate
+	// for it; leaving a stale gate here would silently block every future
+	// auto-resume. Best-effort — a failure here only costs one injection, and
+	// the save itself already succeeded.
+	_ = os.Remove(ClaimGatePath(projectDir))
 	return nil
 }
 

--- a/internal/hook/handoff_inject.go
+++ b/internal/hook/handoff_inject.go
@@ -14,13 +14,16 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/modu-ai/moai-adk/internal/atomicfile"
 	"github.com/modu-ai/moai-adk/internal/config"
 	"github.com/modu-ai/moai-adk/internal/hook/handoff"
 )
@@ -117,13 +120,36 @@ func (h *handoffInjectHandler) claimAndInject(projectDir string, rec *handoff.Pe
 		return &HookOutput{}
 	}
 
+	// Elect the winner BEFORE renaming. Exclusivity must come from a primitive
+	// that guarantees it (O_CREATE|O_EXCL on a path both racers compute
+	// identically), not from the rename failing for the loser: POSIX rename(2)
+	// gives the loser ENOENT once the source is gone, but that is a property of
+	// POSIX, not a documented cross-platform contract, and on Windows two
+	// concurrent claims were observed to both succeed (AC-013a: injected=2 with
+	// a single consumed file — one file object moved twice).
+	if !claimPendingGate(projectDir) {
+		return &HookOutput{}
+	}
+	defer releasePendingGate(projectDir)
+
+	// Re-check inside the gate. The record was read before the gate was taken,
+	// so a contender that lost an earlier round still holds a stale "present"
+	// observation; without this the read-then-consume window stays open and the
+	// gate only narrows it. Every consumer serializes through the gate, so this
+	// check and the rename below are now atomic with respect to each other.
+	if _, err := os.Stat(handoff.PendingPath(projectDir)); err != nil {
+		return &HookOutput{}
+	}
+
 	// Consumed filename: <UnixNano ts>-<nonce8>.json. ts is the integer consume
 	// timestamp (not the RFC3339 saved_at) so AC-014's `^\d+-` regex holds.
 	ts := time.Now().UnixNano()
 	consumedPath := filepath.Join(consumedDir, fmt.Sprintf("%d-%s.json", ts, consumeNonce(rec.SavedBySession)))
 
-	// Claim via atomic rename. The rename-as-claim guarantee means at most one
-	// concurrent session wins; the loser observes a rename error (errno-agnostic).
+	// Archive the claimed record. This rename is no longer load-bearing for
+	// exclusivity — the gate above already decided the winner — so it is a plain
+	// move whose only job is preserving the pending bytes verbatim (AC-013b:
+	// any rename error still skips injection, errno-agnostic).
 	if err := handoffRenameFunc(handoff.PendingPath(projectDir), consumedPath); err != nil {
 		slog.Warn("session_start: handoff: claim rename failed; skipping injection (fail-open)",
 			"error", err,
@@ -137,6 +163,37 @@ func (h *handoffInjectHandler) claimAndInject(projectDir string, rec *handoff.Pe
 			HookEventName:     string(EventSessionStart),
 			AdditionalContext: renderHandoffContext(rec),
 		},
+	}
+}
+
+// claimPendingGate reports whether this caller won the right to consume
+// pending.json. Exactly one concurrent caller gets true.
+//
+// The gate is never force-reclaimed here. Timing out and stealing it would
+// reintroduce the very defect this replaced: two contenders that both decide a
+// gate is stale each remove it and each then create it, so both win. A gate
+// leaked by a killed process is instead cleared by handoff.SavePending when the
+// next record is written — a record that has just been saved has by definition
+// never been claimed, so clearing it there is unambiguous and race-free.
+func claimPendingGate(projectDir string) bool {
+	err := atomicfile.Claim(handoff.ClaimGatePath(projectDir), 0o600)
+	if err == nil {
+		return true
+	}
+	if !errors.Is(err, fs.ErrExist) {
+		slog.Warn("session_start: handoff: claim gate unavailable; skipping injection (fail-open)",
+			"error", err,
+		)
+	}
+	return false
+}
+
+// releasePendingGate drops the gate once the claim is complete. The gate is
+// held only across the rename below, so this normally runs microseconds after
+// claimPendingGate.
+func releasePendingGate(projectDir string) {
+	if err := os.Remove(handoff.ClaimGatePath(projectDir)); err != nil && !os.IsNotExist(err) {
+		slog.Warn("session_start: handoff: could not release claim gate", "error", err)
 	}
 }
 

--- a/internal/hook/handoff_inject_test.go
+++ b/internal/hook/handoff_inject_test.go
@@ -382,6 +382,134 @@ func TestRenameFailure_FailOpen(t *testing.T) {
 	}
 }
 
+// TestConcurrentConsume_SingleWinner_RenameAlwaysSucceeds reproduces, on any
+// platform, the Windows failure this claim path was fixed for: two concurrent
+// claims both saw their rename succeed, so both injected (AC-013a observed
+// injected=2 against a single consumed file — one file object moved twice).
+//
+// Stubbing rename to always succeed models exactly that, and pins the invariant
+// that exclusivity comes from the claim gate rather than from the loser's
+// rename happening to fail. Under the previous rename-as-claim design this
+// fails with injected=2.
+//
+// NOT parallel: mutates the handoffRenameFunc package global.
+func TestConcurrentConsume_SingleWinner_RenameAlwaysSucceeds(t *testing.T) {
+	pd := t.TempDir()
+	mustSavePending(t, pd, livePending("resume"))
+
+	orig := handoffRenameFunc
+	defer func() { handoffRenameFunc = orig }()
+	// Model the observed Windows behaviour: the move still happens, but a caller
+	// whose source is already gone is told it succeeded rather than failing.
+	handoffRenameFunc = func(from, to string) error {
+		_ = os.Rename(from, to)
+		return nil
+	}
+
+	h := NewHandoffInjectHandler(autoCfgProvider(false))
+	var injected int32
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			out, err := h.Handle(context.Background(), injectInput("clear", pd))
+			if err != nil {
+				t.Errorf("Handle: %v", err)
+				return
+			}
+			if additionalContextOf(out) != "" {
+				atomic.AddInt32(&injected, 1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if injected != 1 {
+		t.Errorf("expected exactly 1 winner even when every rename succeeds, got %d", injected)
+	}
+}
+
+// TestClaimGate_HeldGateBlocksClaim pins that a held gate makes the claim yield
+// rather than steal it — the property that keeps the winner single.
+//
+// NOT parallel: mutates the handoffRenameFunc package global.
+func TestClaimGate_HeldGateBlocksClaim(t *testing.T) {
+	pd := t.TempDir()
+	mustSavePending(t, pd, livePending("resume"))
+
+	orig := handoffRenameFunc
+	defer func() { handoffRenameFunc = orig }()
+	handoffRenameFunc = func(from, to string) error { _ = os.Rename(from, to); return nil }
+
+	if err := os.WriteFile(handoff.ClaimGatePath(pd), nil, 0o600); err != nil {
+		t.Fatalf("seed gate: %v", err)
+	}
+
+	h := NewHandoffInjectHandler(autoCfgProvider(false))
+	out, err := h.Handle(context.Background(), injectInput("clear", pd))
+	if err != nil {
+		t.Fatalf("Handle must be fail-open, got: %v", err)
+	}
+	if additionalContextOf(out) != "" {
+		t.Error("a held gate must block the claim")
+	}
+	if !pendingExists(pd) {
+		t.Error("a blocked claim must leave pending.json in place")
+	}
+}
+
+// TestClaimGate_ReleasedAfterClaim proves the gate does not leak on the success
+// path: a second record saved afterwards is still claimable.
+func TestClaimGate_ReleasedAfterClaim(t *testing.T) {
+	t.Parallel()
+
+	pd := t.TempDir()
+	mustSavePending(t, pd, livePending("first"))
+
+	h := NewHandoffInjectHandler(autoCfgProvider(false))
+	if out, err := h.Handle(context.Background(), injectInput("clear", pd)); err != nil {
+		t.Fatalf("Handle: %v", err)
+	} else if additionalContextOf(out) == "" {
+		t.Fatal("expected the first record to be injected")
+	}
+	if _, err := os.Stat(handoff.ClaimGatePath(pd)); !os.IsNotExist(err) {
+		t.Errorf("gate must be released after a successful claim; stat err=%v", err)
+	}
+
+	mustSavePending(t, pd, livePending("second"))
+	if out, err := h.Handle(context.Background(), injectInput("clear", pd)); err != nil {
+		t.Fatalf("Handle: %v", err)
+	} else if additionalContextOf(out) == "" {
+		t.Error("expected the second record to be injected too")
+	}
+}
+
+// TestSavePending_ClearsLeakedGate proves a gate orphaned by a killed consumer
+// does not disable auto-resume forever: writing the next record clears it.
+func TestSavePending_ClearsLeakedGate(t *testing.T) {
+	t.Parallel()
+
+	pd := t.TempDir()
+	mustSavePending(t, pd, livePending("resume"))
+	if err := os.WriteFile(handoff.ClaimGatePath(pd), nil, 0o600); err != nil {
+		t.Fatalf("seed gate: %v", err)
+	}
+
+	// Re-saving is the recovery point: the new record has never been claimed.
+	mustSavePending(t, pd, livePending("resume"))
+	if _, err := os.Stat(handoff.ClaimGatePath(pd)); !os.IsNotExist(err) {
+		t.Fatalf("SavePending must clear a leaked gate; stat err=%v", err)
+	}
+
+	h := NewHandoffInjectHandler(autoCfgProvider(false))
+	if out, err := h.Handle(context.Background(), injectInput("clear", pd)); err != nil {
+		t.Fatalf("Handle: %v", err)
+	} else if additionalContextOf(out) == "" {
+		t.Error("expected injection after the leaked gate was cleared")
+	}
+}
+
 // --- AC-014: NULL session_id nonce filename shape ----------------------------
 
 func TestNonceFallback_FilenameShape(t *testing.T) {

--- a/internal/hook/user_decision_capture_test.go
+++ b/internal/hook/user_decision_capture_test.go
@@ -463,22 +463,19 @@ func assertAllow(t *testing.T, out *HookOutput) {
 	}
 }
 
-// resolveMemoryDirForTest replicates the in-package resolveMemoryDir for the
-// test's HOME-isolated dir. It mirrors the slug derivation so the test seeds
-// the same path the production resolver will target.
+// resolveMemoryDirForTest returns the memory dir the production resolver will
+// target for the test's HOME-isolated dir.
+//
+// It delegates to the in-package resolveMemoryDir rather than re-deriving the
+// slug: a duplicated derivation drifts from production silently. It previously
+// omitted the `:` mapping, so on Windows the seeded path kept the drive colon
+// (`...\projects\C:-Users-...`) and every seeding mkdir failed with "The
+// directory name is invalid" while production wrote elsewhere.
 func resolveMemoryDirForTest(t *testing.T, homeDir string) string {
 	t.Helper()
-	abs, err := filepath.Abs(homeDir)
+	dir, err := resolveMemoryDir(homeDir, homeDir)
 	if err != nil {
-		t.Fatalf("abs: %v", err)
+		t.Fatalf("resolveMemoryDir: %v", err)
 	}
-	slug := strings.Map(func(r rune) rune {
-		switch r {
-		case '/', '\\', '.':
-			return '-'
-		default:
-			return r
-		}
-	}, filepath.Clean(abs))
-	return filepath.Join(homeDir, ".claude", "projects", slug, "memory")
+	return dir
 }


### PR DESCRIPTION
Round 2 of the Windows portability sweep. Follows #1114, which took `Test (windows-latest)` from **71 failures / 17 packages** to **10 / 2**. This closes the last 10.

Both remaining clusters turned out to be **production defects**, not test defects.

## Claim exclusivity — `TestConcurrentConsume_SingleWinner`

Handoff consume is a *claim*: exactly one concurrent SessionStart may consume `pending.json`. Exclusivity rested on `os.Rename` failing for the loser — which POSIX guarantees and Windows does not.

The CI log settled it: only the `injected=2` assertion fired; the consumed-count and pending-absent assertions never did. So there were **2 winners but exactly 1 consumed file** — both callers moved the same file object, meaning the loser's rename reported success. `ReadPending` also ran *before* the claim, so the loser acted on a stale observation.

Fix: an explicit claim gate via new `atomicfile.Claim` (`O_CREATE|O_EXCL` — exclusivity guaranteed by both platforms rather than inferred from an errno) plus an in-gate re-check. The rename is demoted to a plain archival move. `Claim` never retries, unlike `Replace`, and is documented against it. `SavePending` clears a leaked gate, since a just-written record has by definition never been claimed.

Reproduction-first: stubbing rename to report success while still moving the file reproduces the defect against the pre-fix design (**7–8 winners**) and passes after (**1**). 500× `-race` on darwin passes both before and after — which is exactly why this only ever surfaced on Windows.

**Availability trade-off (deliberate):** a consumer killed between gate creation and release leaves auto-resume blocked for that project until the next `handoff save`. Chosen over a reclaim path, which reintroduces a double-injection window. An earlier TTL-based reclaim attempt was discarded after its own new test caught it granting 2 winners — remove-then-recreate is not exclusive.

## Racy reads — `TestClaudeJSONGuard_Concurrent*`

The guard's prep read runs outside its lock and races a concurrent replace; on Windows that read transiently fails and surfaced as a spurious error. **Lost-update protection was never broken.** Fixed with a bounded read retry (`atomicfile.ReadFile` — 20×5ms on Windows sharing errors, plain passthrough on POSIX).

## Cluster A — 7 `TestCaptureUserDecision_*`

A test-side slug copy that omitted `:`, so the colon fix from #1114 never reached them. Now delegating to production `resolveMemoryDir`. These tests **run on Windows** rather than being skipped — verified with `-v`.

Repo-wide slug audit: 3 derivations total. Production `session_end.go` and `cli/preference/cmd.go` both map `:` correctly; the test copy was the only bug. `cmd.go` remains a documented cross-package mirror of an unexported symbol — correct today, drift risk tomorrow. Left alone as follow-up scope.

## Verification

| check | result |
|---|---|
| `go test ./...` (darwin) | exit 0 — 107 packages |
| `go test -race ./internal/hook/... ./internal/cli/...` | exit 0 |
| `go vet ./...` | exit 0 |
| `go build ./...` | exit 0 |
| `GOOS=windows GOARCH=amd64 go build ./...` | exit 0 |

**Windows runtime behavior is not verified locally.** The root-cause analysis is inference from the CI log plus elimination, not direct observation. The fixes are designed to hold regardless of which mechanism is at play — `O_CREATE|O_EXCL` exclusivity is guaranteed rather than inferred — but `Test (windows-latest)` on this PR is the real gate.

## Follow-up

Once green, `release-pr-multi-os.yml:58` `continue-on-error: ${{ matrix.os == 'windows-latest' }}` is removed so Windows blocks the release gate.

Note: #1114 auto-merged while Windows was still red, because `Test (windows-latest)` is not in the required-checks set. That is the gap this series exists to close.

🗿 MoAI