### PR TITLE
fix(windows): isolate HOME on Windows in user-decision capture tests

### DIFF
--- a/internal/hook/user_decision_capture_coverage_test.go
+++ b/internal/hook/user_decision_capture_coverage_test.go
@@ -59,7 +59,7 @@ func TestCaptureUserDecision_WarnFailOpen_UpsertError(t *testing.T) {
 		t.Skip("permission injection ineffective as root")
 	}
 	dir := t.TempDir()
-	t.Setenv("HOME", dir)
+	setTestHome(t, dir)
 
 	memDir := resolveMemoryDirForTest(t, dir)
 	udDir := filepath.Join(memDir, "user_decisions")
@@ -93,7 +93,7 @@ func TestCaptureUserDecision_WarnFailOpen_UpsertError(t *testing.T) {
 // expected (NewFileStore MkdirAll fails).
 func TestCaptureUserDecision_WarnFailOpen_StoreConstructionError(t *testing.T) {
 	dir := t.TempDir()
-	t.Setenv("HOME", dir)
+	setTestHome(t, dir)
 
 	memDir := resolveMemoryDirForTest(t, dir)
 	if err := os.MkdirAll(memDir, 0o755); err != nil {
@@ -118,7 +118,7 @@ func TestCaptureUserDecision_WarnFailOpen_StoreConstructionError(t *testing.T) {
 // memory-dir resolution error path by unsetting HOME so os.UserHomeDir
 // fails.
 func TestCaptureUserDecision_WarnFailOpen_ResolveError(t *testing.T) {
-	t.Setenv("HOME", "")
+	setTestHome(t, "")
 	input := &HookInput{
 		ToolName:     askUserQuestionTool,
 		ToolInput:    mustMarshal(t, map[string]any{"questions": []map[string]any{{"header": "x"}}}),
@@ -134,7 +134,7 @@ func TestCaptureUserDecision_WarnFailOpen_ResolveError(t *testing.T) {
 // tool_response.
 func TestCaptureUserDecision_ToolInputOnlySelection(t *testing.T) {
 	dir := t.TempDir()
-	t.Setenv("HOME", dir)
+	setTestHome(t, dir)
 	memDir := resolveMemoryDirForTest(t, dir)
 	if err := os.MkdirAll(filepath.Join(memDir, "user_decisions", "archival"), 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
@@ -168,7 +168,7 @@ func TestCaptureUserDecision_ToolInputOnlySelection(t *testing.T) {
 // empty.
 func TestCaptureUserDecision_CLAUDEProjectDirFallback(t *testing.T) {
 	dir := t.TempDir()
-	t.Setenv("HOME", dir)
+	setTestHome(t, dir)
 	t.Setenv("CLAUDE_PROJECT_DIR", dir)
 	memDir := resolveMemoryDirForTest(t, dir)
 	if err := os.MkdirAll(filepath.Join(memDir, "user_decisions", "archival"), 0o755); err != nil {
@@ -206,7 +206,7 @@ func TestCaptureUserDecision_NilInputSafe(t *testing.T) {
 // returns early for a non-AskUserQuestion tool.
 func TestCaptureUserDecision_WrongToolNameSafe(t *testing.T) {
 	dir := t.TempDir()
-	t.Setenv("HOME", dir)
+	setTestHome(t, dir)
 	input := &HookInput{
 		ToolName: "Write",
 		CWD:      dir,
@@ -223,7 +223,7 @@ func TestCaptureUserDecision_WrongToolNameSafe(t *testing.T) {
 // tool_use_id-present and tool_use_id-absent citation formats.
 func TestCaptureUserDecision_SourceCitationVariants(t *testing.T) {
 	dir := t.TempDir()
-	t.Setenv("HOME", dir)
+	setTestHome(t, dir)
 	memDir := resolveMemoryDirForTest(t, dir)
 	_ = os.MkdirAll(filepath.Join(memDir, "user_decisions", "archival"), 0o755)
 

--- a/internal/hook/user_decision_capture_test.go
+++ b/internal/hook/user_decision_capture_test.go
@@ -95,7 +95,7 @@ func mustMarshal(t *testing.T, v any) []byte {
 // (a): when the tool_input JSON is malformed, the capture MUST fail open.
 func TestCaptureUserDecision_StdinParseFailure_FailOpen(t *testing.T) {
 	dir := t.TempDir()
-	t.Setenv("HOME", dir) // isolate home so resolveMemoryDir targets the temp.
+	setTestHome(t, dir) // isolate home so resolveMemoryDir targets the temp.
 
 	h := NewPostToolHandler()
 	input := &HookInput{
@@ -126,7 +126,7 @@ func TestCaptureUserDecision_UpsertFailure_FailOpen(t *testing.T) {
 		t.Skip("permission-denied injection ineffective when running as root")
 	}
 	dir := t.TempDir()
-	t.Setenv("HOME", dir)
+	setTestHome(t, dir)
 
 	// Pre-create the user_decisions layout but make the memory root read-only
 	// so atomicWrite's temp-file creation fails.
@@ -163,7 +163,7 @@ func TestCaptureUserDecision_UpsertFailure_FailOpen(t *testing.T) {
 // cause.
 func TestCaptureUserDecision_DiskFullInjection_FailOpen(t *testing.T) {
 	dir := t.TempDir()
-	t.Setenv("HOME", dir)
+	setTestHome(t, dir)
 
 	// Plant a regular file at the user_decisions path — NewFileStore's
 	// MkdirAll will fail because the path is a file.
@@ -200,7 +200,7 @@ func TestCaptureUserDecision_PermissionDeniedInjection_FailOpen(t *testing.T) {
 		t.Skip("permission-denied injection ineffective when running as root")
 	}
 	dir := t.TempDir()
-	t.Setenv("HOME", dir)
+	setTestHome(t, dir)
 
 	memDir := filepath.Join(dir, ".claude", "projects", "test", "memory")
 	udDir := filepath.Join(memDir, "user_decisions")
@@ -235,7 +235,7 @@ func TestCaptureUserDecision_PermissionDeniedInjection_FailOpen(t *testing.T) {
 // to confirm no panic escapes.
 func TestCaptureUserDecision_PanicRecovery_FailOpen(t *testing.T) {
 	dir := t.TempDir()
-	t.Setenv("HOME", dir)
+	setTestHome(t, dir)
 
 	h := NewPostToolHandler()
 	toolInput, toolResponse := buildAskUserQuestionInput(t, "effort", "high")
@@ -316,7 +316,7 @@ func TestCaptureUserDecision_RecoverySignalCarveOut_Documented(t *testing.T) {
 // NOT produce an inferred entry.
 func TestCaptureUserDecision_ObservedConfidenceAndCitation(t *testing.T) {
 	dir := t.TempDir()
-	t.Setenv("HOME", dir)
+	setTestHome(t, dir)
 
 	memDir := resolveMemoryDirForTest(t, dir)
 	if err := os.MkdirAll(filepath.Join(memDir, "user_decisions", "archival"), 0o755); err != nil {
@@ -381,7 +381,7 @@ func TestCaptureUserDecision_ObservedConfidenceAndCitation(t *testing.T) {
 // orchestrator elsewhere, not by this advisory hook (REQ-ADM-018).
 func TestCaptureUserDecision_NoInferredEntryFromCapturePath(t *testing.T) {
 	dir := t.TempDir()
-	t.Setenv("HOME", dir)
+	setTestHome(t, dir)
 	memDir := resolveMemoryDirForTest(t, dir)
 	if err := os.MkdirAll(filepath.Join(memDir, "user_decisions", "archival"), 0o755); err != nil {
 		t.Fatalf("seed mkdir: %v", err)
@@ -423,7 +423,7 @@ func TestCaptureUserDecision_NoInferredEntryFromCapturePath(t *testing.T) {
 // status-transition-ownership.sh.
 func TestCaptureUserDecision_NonAskUserTools_DoNotCapture(t *testing.T) {
 	dir := t.TempDir()
-	t.Setenv("HOME", dir)
+	setTestHome(t, dir)
 	memDir := resolveMemoryDirForTest(t, dir)
 	_ = os.MkdirAll(filepath.Join(memDir, "user_decisions", "archival"), 0o755)
 
@@ -461,6 +461,23 @@ func assertAllow(t *testing.T, out *HookOutput) {
 			t.Errorf("expected PostToolUse event, got %q", out.HookSpecificOutput.HookEventName)
 		}
 	}
+}
+
+// setTestHome redirects the home directory production code resolves via
+// os.UserHomeDir() to dir, on every platform.
+//
+// os.UserHomeDir() reads $HOME on Unix but %USERPROFILE% on Windows, so
+// setting HOME alone leaves the real user profile in effect on Windows: the
+// capture wrote into the runner's actual C:\Users\<user>\.claude\projects\...
+// while the test seeded and read the temp dir, so every assertion that a
+// recall entry EXISTS failed. Tests asserting absence passed vacuously for the
+// same reason. Both env vars are set so exactly one takes effect per platform.
+//
+// Passing "" clears both, which is how a test forces os.UserHomeDir() to fail.
+func setTestHome(t *testing.T, dir string) {
+	t.Helper()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
 }
 
 // resolveMemoryDirForTest returns the memory dir the production resolver will


### PR DESCRIPTION
Final round of the Windows portability sweep. Takes `Test (windows-latest)` to **0 failures**.

## Series progress

| round | PR | failures | packages |
|---|---|---|---|
| baseline | — | 71 | 17 |
| 1 | #1114 | 10 | 2 |
| 2 | #1115 | 4 | 1 |
| 3 | this | **0** | 0 |

## Root cause — test isolation, not production behavior

The tests set only `HOME` to redirect memory resolution at a temp dir. But `os.UserHomeDir()` reads **`USERPROFILE`** on Windows and ignores `HOME`. Production therefore resolved the runner's real home and wrote `recall.jsonl` to `C:\Users\runneradmin\.claude\...`, while the test read from the temp dir and found it empty:

```
user_decision_capture_coverage_test.go:247
  recall.jsonl empty: open C:\...\Temp\TestCaptureUserDecision_SourceCitationVariants...\.claude\projects\C--Users-RUNNER~1-Ap...
```

Note the slug is already correct here (`C--Users-...`, colon gone — that was #1114's fix). The remaining mismatch was purely *which home* each side resolved.

The `RUNNER~1` 8.3 short name visible in those paths was **incidental** — it is simply how the temp dir is spelled, and both sides use it consistently once `USERPROFILE` is set. An initial short-name-vs-long-name path-identity hypothesis was investigated and **disproved** by the evidence; no production canonicalization was needed, and `resolveMemoryDir`'s documented per-cwd resolution model (`@MX:NOTE`) is untouched.

## Fix

Added `setTestHome(t, dir)`, which sets `HOME` and `USERPROFILE` together, and routed the affected tests through it.

All **17** `TestCaptureUserDecision_*` now run and pass with **zero skips** — Windows coverage is restored, not waived:

```
--- PASS: TestCaptureUserDecision_CLAUDEProjectDirFallback
--- PASS: TestCaptureUserDecision_ObservedConfidenceAndCitation
--- PASS: TestCaptureUserDecision_SourceCitationVariants
--- PASS: TestCaptureUserDecision_ToolInputOnlySelection
... (17 total, 0 SKIP)
```

## Known follow-up

**93 other test sites** still set `HOME` without `USERPROFILE` — the same latent isolation gap. None fail on Windows today, so fixing them here would be unrelated churn. Recorded rather than bundled.

Also still open from #1115: `internal/cli/preference/cmd.go:163` holds a documented cross-package mirror of the unexported `projectSlug`. Correct today, drift-prone.

## Verification

| check | result |
|---|---|
| `go test ./...` (darwin) | exit 0 — 107 packages |
| `go test -run TestCaptureUserDecision -v` | 17 PASS, 0 SKIP |
| `go vet ./...` | exit 0 |
| `go build ./...` | exit 0 |
| `GOOS=windows GOARCH=amd64 go build ./...` | exit 0 |

Windows behavior remains CI-only — `Test (windows-latest)` on this PR is the real gate.

## After this merges

Two levers close the "Windows must be green to release" requirement:

1. `release-pr-multi-os.yml:58` — drop `continue-on-error: ${{ matrix.os == 'windows-latest' }}` so Windows blocks the release gate.
2. Branch protection required checks — add `Test (windows-latest)`. Without this, PRs still auto-merge while Windows is red: **both #1114 and #1115 did exactly that**, since the required set is only `Test (ubuntu-latest)` / `Lint` / `Build (linux/amd64)` / `Analyze (Go) (go)`.

🗿 MoAI