### PR TITLE
fix(tui): resolve wizard theme axis so dark-terminal descriptions stay readable

### DIFF
--- a/internal/cli/wizard/wizard.go
+++ b/internal/cli/wizard/wizard.go
@@ -450,15 +450,27 @@ func buildConfirmField(q *Question, result *WizardResult, locale *string) *huh.C
 	return conf
 }
 
+// wizardIsDark resolves the light/dark axis for the wizard theme. It is a
+// package-level var so tests can force either axis without mutating the
+// process environment.
+var wizardIsDark = tui.IsDarkOS
+
 // newMoAIWizardTheme adapts the MoAI wizard styles to the huh v2 Theme
-// interface: huh resolves the terminal background once and passes the isDark
-// axis to moaiWizardStyles (this replaces the lipgloss v1 AdaptiveColor
-// mechanism used before the v2 migration).
+// interface. The axis is resolved once from internal/tui (NO_COLOR >
+// MOAI_THEME > terminal detection) and huh's own isDark argument is
+// deliberately discarded: huh assigns Form.hasDarkBg only when the terminal
+// answers the async OSC 11 background query (tea.BackgroundColorMsg), so it
+// holds the zero value false on every render before that reply lands — and
+// permanently on terminals that never answer. Honouring it painted the
+// LightTheme near-black body token over a dark background, leaving the
+// question descriptions unreadable. huh v2 exposes no option to seed the
+// field, so resolving it here is the only correction point.
 //
 // @MX:ANCHOR: [AUTO] Consumed by every buildUnifiedForm invocation; single huh.Theme factory
 // @MX:REASON: All wizard groups share one theme; changes here affect the entire init wizard UX
 func newMoAIWizardTheme() huh.Theme {
-	return huh.ThemeFunc(moaiWizardStyles)
+	dark := wizardIsDark()
+	return huh.ThemeFunc(func(bool) *huh.Styles { return moaiWizardStyles(dark) })
 }
 
 // moaiWizardStyles builds the MoAI-branded huh v2 style set for the resolved

--- a/internal/cli/wizard/wizard_test.go
+++ b/internal/cli/wizard/wizard_test.go
@@ -3,6 +3,9 @@ package wizard
 import (
 	"os"
 	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/modu-ai/moai-adk/internal/tui"
 )
 
 func TestWizardResult(t *testing.T) {
@@ -510,6 +513,50 @@ func TestNewMoAIWizardTheme_ReturnsNonNil(t *testing.T) {
 	theme := newMoAIWizardTheme()
 	if theme == nil {
 		t.Error("expected non-nil theme")
+	}
+}
+
+// TestNewMoAIWizardTheme_IgnoresHuhBackgroundArgument reproduces the dark-terminal
+// contrast defect: huh v2 assigns Form.hasDarkBg only when the terminal answers
+// the async OSC 11 background query (tea.BackgroundColorMsg), so it holds the
+// zero value false on every render before that reply lands — and forever on
+// terminals that never answer. Theme(false) therefore painted the LightTheme
+// near-black body token over a dark background, making the question description
+// unreadable. The theme factory must resolve the axis itself and discard huh's
+// argument.
+//
+// Foregrounds are compared through RGBA() rather than == because
+// lipgloss.Color returns an interface whose concrete type is an
+// implementation detail. Expected values come from the tui tokens, never a
+// hex literal (AC-CLI-TUI-013).
+func TestNewMoAIWizardTheme_IgnoresHuhBackgroundArgument(t *testing.T) {
+	tests := []struct {
+		name     string
+		dark     bool
+		wantBody string
+	}{
+		{"resolver says dark", true, tui.DarkTheme().Body},
+		{"resolver says light", false, tui.LightTheme().Body},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orig := wizardIsDark
+			t.Cleanup(func() { wizardIsDark = orig })
+			wizardIsDark = func() bool { return tt.dark }
+
+			// false simulates huh's pre-OSC-11 zero value; true simulates the
+			// post-reply value. Both must yield the resolver's axis.
+			for _, huhArg := range []bool{false, true} {
+				got := newMoAIWizardTheme().Theme(huhArg).Focused.Description.GetForeground()
+				wantR, wantG, wantB, wantA := lipgloss.Color(tt.wantBody).RGBA()
+				gotR, gotG, gotB, gotA := got.RGBA()
+				if gotR != wantR || gotG != wantG || gotB != wantB || gotA != wantA {
+					t.Errorf("Theme(%v).Focused.Description foreground = %v, want tui token %q",
+						huhArg, got, tt.wantBody)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/tui/detect.go
+++ b/internal/tui/detect.go
@@ -79,6 +79,51 @@ func Resolve(env Env) Theme {
 	return LightTheme()
 }
 
+// IsDark reports whether the dark colour axis applies for the given
+// environment. It is the boolean twin of [Resolve] and follows the same
+// priority chain:
+//
+//  1. NO_COLOR set → true (safe dark). Resolve returns MonochromeTheme on this
+//     path, which has no light/dark counterpart; colour is suppressed anyway,
+//     so the axis must report dark rather than fall through to the light
+//     near-black tokens and render unreadable text on a dark terminal.
+//  2. MOAI_THEME="light" → false
+//  3. MOAI_THEME="dark"  → true
+//  4. MOAI_THEME="auto" or unset → env.DetectDark()
+//  5. any other MOAI_THEME value → true (safe dark default, matching Resolve)
+//
+// Callers that need the palette should use Resolve; IsDark exists for the ones
+// that need the axis itself — notably the huh v2 theme factory, whose own
+// isDark argument stays false until the terminal answers the async OSC 11
+// background query.
+//
+// @MX:NOTE: [AUTO] Boolean twin of Resolve; NO_COLOR yields dark (safe default),
+// not light, because the light tokens are unreadable on a dark background.
+func IsDark(env Env) bool {
+	if env.NoColor() {
+		return true
+	}
+
+	switch env.MoaiTheme() {
+	case "light":
+		return false
+	case "dark":
+		return true
+	case "auto", "":
+		return env.DetectDark()
+	default:
+		// Invalid value: safe dark default without querying the terminal,
+		// mirroring Resolve.
+		return true
+	}
+}
+
+// IsDarkOS is a convenience wrapper that calls IsDark with the production
+// OSEnv, mirroring [ResolveOS].
+func IsDarkOS() bool {
+	return IsDark(OSEnv{})
+}
+
 // OSEnv is the production implementation of Env that reads from the process
 // environment and uses [lipgloss.HasDarkBackground] for terminal background detection.
 //

--- a/internal/tui/detect_test.go
+++ b/internal/tui/detect_test.go
@@ -2,6 +2,7 @@
 package tui_test
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -135,6 +136,67 @@ func TestThemeResolve(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestIsDark verifies the boolean axis mirrors Resolve's priority chain:
+// NO_COLOR > MOAI_THEME > DetectDark > default-dark. The NO_COLOR case returns
+// true (safe dark) rather than falling through to the light near-black tokens.
+func TestIsDark(t *testing.T) {
+	tests := []struct {
+		name string
+		env  staticEnv
+		want bool
+	}{
+		{"NO_COLOR wins and yields safe dark", staticEnv{noColor: true, moaiTheme: "light", darkBg: false}, true},
+		{"NO_COLOR wins over dark-bg detection", staticEnv{noColor: true, moaiTheme: "", darkBg: false}, true},
+		{"MOAI_THEME=light overrides dark-bg detection", staticEnv{noColor: false, moaiTheme: "light", darkBg: true}, false},
+		{"MOAI_THEME=dark overrides light-bg detection", staticEnv{noColor: false, moaiTheme: "dark", darkBg: false}, true},
+		{"MOAI_THEME=auto defers to DetectDark (dark)", staticEnv{noColor: false, moaiTheme: "auto", darkBg: true}, true},
+		{"MOAI_THEME=auto defers to DetectDark (light)", staticEnv{noColor: false, moaiTheme: "auto", darkBg: false}, false},
+		{"MOAI_THEME unset defers to DetectDark (dark)", staticEnv{noColor: false, moaiTheme: "", darkBg: true}, true},
+		{"MOAI_THEME unset defers to DetectDark (light)", staticEnv{noColor: false, moaiTheme: "", darkBg: false}, false},
+		{"MOAI_THEME invalid falls back to safe dark", staticEnv{noColor: false, moaiTheme: "sepia", darkBg: false}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tui.IsDark(tt.env); got != tt.want {
+				t.Errorf("IsDark(%+v) = %v, want %v", tt.env, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIsDark_AgreesWithResolve pins the two entry points to one decision: for
+// every colour-enabled case, IsDark must select the same palette Resolve does.
+// NO_COLOR is excluded because Resolve returns MonochromeTheme there, which has
+// no light/dark counterpart.
+func TestIsDark_AgreesWithResolve(t *testing.T) {
+	for _, theme := range []string{"", "auto", "light", "dark", "sepia"} {
+		for _, darkBg := range []bool{false, true} {
+			env := staticEnv{noColor: false, moaiTheme: theme, darkBg: darkBg}
+			want := tui.DarkTheme()
+			if !tui.IsDark(env) {
+				want = tui.LightTheme()
+			}
+			if got := tui.Resolve(env); got != want {
+				t.Errorf("IsDark/Resolve disagree for MOAI_THEME=%q darkBg=%v", theme, darkBg)
+			}
+		}
+	}
+}
+
+// TestIsDarkOS_NonTTYDefaultsDark exercises the production wrapper. Under
+// `go test` stdin/stdout are pipes, so OSEnv.DetectDark short-circuits to the
+// safe-dark default; with NO_COLOR and MOAI_THEME unset in the test
+// environment, IsDarkOS must report dark rather than the light near-black axis.
+func TestIsDarkOS_NonTTYDefaultsDark(t *testing.T) {
+	if os.Getenv("NO_COLOR") != "" || os.Getenv("MOAI_THEME") != "" {
+		t.Skip("NO_COLOR or MOAI_THEME set in the ambient environment")
+	}
+	if !tui.IsDarkOS() {
+		t.Error("IsDarkOS() under non-TTY = false, want true (safe-dark default)")
 	}
 }
 


### PR DESCRIPTION
`moai init` renders its question **descriptions unreadable** on a dark terminal — near-black text on a dark background. Titles and option rows are fine; only the description lines are lost.

## Root cause

huh v2 hands the theme function its background axis from `Form.hasDarkBg`. That field has exactly one writer across the whole module:

```go
case tea.BackgroundColorMsg:
    f.hasDarkBg = msg.IsDark()
```

It is set **only** when the terminal answers the async OSC 11 background-colour query, so it holds Go's zero value `false` on every render before that reply lands — and permanently on terminals that never answer. huh v2 exposes no option to seed it (`WithTheme`, `WithProgramOptions`, `WithOutput`, … — none touch the axis).

With `isDark=false` the wizard paints **LightTheme tokens on a dark terminal**. `t.Focused.Description` comes from `Body`, which is `#1f2826` (near-black) in the light theme versus `#d8dedb` in the dark one — hence the vanished descriptions.

## The fix

The axis is now resolved once from `internal/tui`, and huh's argument is deliberately discarded:

```go
dark := wizardIsDark()
return huh.ThemeFunc(func(bool) *huh.Styles { return moaiWizardStyles(dark) })
```

`internal/tui` gains `IsDark(env)` / `IsDarkOS()`, exposing the boolean form of the priority chain `Resolve` already implements: `NO_COLOR` → `MOAI_THEME` (light/dark/auto) → TTY-guarded `DetectDark()`, with the safe-dark default on failure. `NO_COLOR` maps to dark so the axis never falls through to the light near-black tokens.

No palette change: `moaiWizardStyles`, `wizardTokens`, the token→role mapping and every hex value are untouched. The bug was the axis, not the colours.

## Verification

Reproduction-first: with the resolver forced to *dark*, `Theme(false)` (huh's pre-OSC-11 default) produced `{31 40 38}` = `#1f2826` — the unreadable light body token — before the fix.

| check | result |
|---|---|
| `TestNewMoAIWizardTheme_IgnoresHuhBackgroundArgument` (both axes × both huh args) | RED before, PASS after |
| `TestIsDark` 9-case priority chain + `TestIsDark_AgreesWithResolve` | PASS |
| `go test ./internal/cli/... ./internal/tui/...` | exit 0 |
| `go vet ./internal/cli/... ./internal/tui/...` | exit 0 |
| `GOOS=windows GOARCH=amd64 go build ./...` | exit 0 |

Assertions compare against `tui.DarkTheme().Body` / `tui.LightTheme().Body`, never hex literals (AC-CLI-TUI-013).

🗿 MoAI