### PR TITLE
ci(release): gate publishing on harness-issued tag provenance

### DIFF
--- a/.claude/agents/harness/hns-release-specialist.md
+++ b/.claude/agents/harness/hns-release-specialist.md
@@ -47,7 +47,7 @@ to surface a user-decision prompt (patch/minor/major).
 - Target `main` (production only). Tag `vX.Y.Z` (SemVer, GoReleaser trigger). Tags
   are NOT branch-protected — the `scripts/release.sh` tag-push flow is unaffected.
 - [HARD] Merge strategy **merge commit** (`gh pr merge --merge --delete-branch`) — squash forbidden (preserve individual SPEC commits, project git workflow doctrine §18.3).
-- [HARD] Tag push via `./scripts/release.sh vX.Y.Z` or `make release V=vX.Y.Z` — manual `git tag + push` forbidden.
+- [HARD] Tag push via `MOAI_RELEASE_VIA_HARNESS=1 ./scripts/release.sh vX.Y.Z` (or `make release V=vX.Y.Z` with the same prefix) — manual `git tag + push` forbidden. The env var is the release provenance gate: without it the script aborts, and a tag produced any other way fails `verify-provenance` in `release.yml` so GoReleaser never runs.
 - [HARD] PR 3-axis labels: `type:*` + `priority:*` + `area:*`.
 
 ## Phase Sequence (Enhanced GitHub Flow — structural fidelity preserved)
@@ -115,7 +115,7 @@ no reviewer wait. Delegate to manager-git (`isolation: "worktree"`):
 3. `gh pr checks --watch`.
 4. [HARD] `gh pr merge --merge --delete-branch` (merge commit, NOT squash — §18.3).
 5. `git checkout main && git pull origin main`.
-6. [HARD] `./scripts/release.sh vX.Y.Z` (or `make release V=vX.Y.Z`; `--hotfix` for hotfix) — automatic CHANGELOG verify + CI check + tag + push + GoReleaser watch. Fallback (script failure): manual tag AFTER CHANGELOG verify (`grep "^## \[X.Y.Z\]" CHANGELOG.md` → `git tag -a vX.Y.Z -m ...` → `git push origin vX.Y.Z`).
+6. [HARD] `MOAI_RELEASE_VIA_HARNESS=1 ./scripts/release.sh vX.Y.Z` (or `MOAI_RELEASE_VIA_HARNESS=1 make release V=vX.Y.Z`; add `--hotfix` for hotfix) — automatic CHANGELOG verify + CI check + tag + push + GoReleaser watch. The `MOAI_RELEASE_VIA_HARNESS=1` prefix is mandatory: `scripts/release.sh` aborts without it (release provenance gate), and it is what causes the annotated tag to carry the `Released-via: harness:release` / `Release-version:` / `Release-commit:` trailer that `.github/workflows/release.yml` `verify-provenance` requires before GoReleaser runs. Never export it outside this harness-driven invocation, and never hand-craft the trailer on a manual tag. Fallback on script failure: re-run the script (fix the reported validation) — a manual `git tag` + push is NOT a valid fallback, because such a tag fails `verify-provenance` and publishes nothing.
 7. Verify GoReleaser workflow triggered (tags bypass branch protection).
 
 ### Phase 7 — GitHub Release Notes (bilingual: English first)
@@ -145,7 +145,9 @@ needed; `moai version` confirms `vX.Y.Z`.
 | Anti-Pattern | Correct Approach |
 |--------------|-----------------|
 | Squash-merging the release PR | `--merge` (merge commit) — preserve individual SPEC commits (§18.3) |
-| Manual `git tag + push` | `./scripts/release.sh vX.Y.Z` (CHANGELOG verify + CI check included) |
+| Manual `git tag + push` | `MOAI_RELEASE_VIA_HARNESS=1 ./scripts/release.sh vX.Y.Z` (CHANGELOG verify + CI check + provenance trailer included) |
+| Running `scripts/release.sh` without `MOAI_RELEASE_VIA_HARNESS=1` | Prefix the invocation — the script aborts otherwise (release provenance gate) |
+| Hand-writing the `Released-via:` trailer onto a manual tag | Let `scripts/release.sh` stamp it; a hand-crafted tag still fails `verify-provenance` checks 5-7 |
 | Direct `git push origin main` | Always PR merge flow via manager-git |
 | Calling the user-decision channel directly (Phase 3/5) | Return blocker report; orchestrator surfaces the user-decision prompt + re-delegates |
 | Referencing archived `expert-debug` | Use a per-spawn `Agent(general-purpose)` diagnostic specialist |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,106 @@ concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
+# Release provenance gate (verify-provenance job below).
+#
+# This workflow is the only publishing surface, and its only trigger is a `v*`
+# tag push — so every route to a production release converges on one choke
+# point. The gate checks that the pushed tag was produced by the
+# `/harness:release` maintainer harness (via scripts/release.sh, which stamps a
+# provenance trailer into the annotated tag message).
+#
+# Honest limitations — do NOT read this gate as making unauthorized releases
+# impossible:
+#   - The trailer lives in a public tag annotation. Anyone with push rights can
+#     read it and hand-craft a tag carrying the same three lines. The trailer
+#     therefore stops *accidental* and *habitual* releases through the
+#     unsanctioned routes (direct scripts/release.sh runs, manual `git tag` +
+#     push, `gh release create`, the GitHub web UI, other CI automation) — it is
+#     not an authentication mechanism.
+#   - The substantive protection is checks 5-7 (CHANGELOG section present at the
+#     tagged commit, version SSOT agreement, tagged commit is an ancestor of
+#     origin/main). An ad-hoc or out-of-process tag fails those even when the
+#     trailer has been copied verbatim.
+#   - A repository admin can still bypass the gate entirely by editing this
+#     workflow. That bypass is a commit and is therefore visible in git history.
 jobs:
+  verify-provenance:
+    name: Verify release provenance
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Verify tag provenance, version bindings and ancestry
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          fail() {
+            echo "::error::RELEASE_PROVENANCE_GATE: $1"
+            echo "Releases must be produced by the /harness:release maintainer harness."
+            exit 1
+          }
+
+          git fetch --force origin "refs/tags/${TAG}:refs/tags/${TAG}"
+          git fetch origin +refs/heads/main:refs/remotes/origin/main
+
+          # Check 1 — annotated tag (lightweight tags from `gh release create` or
+          # the GitHub web UI resolve to `commit` and are rejected here).
+          TAG_TYPE="$(git cat-file -t "${TAG}")"
+          if [ "${TAG_TYPE}" != "tag" ]; then
+            fail "check 1 (annotated tag): '${TAG}' is a ${TAG_TYPE} object, not an annotated tag."
+          fi
+
+          ANNOTATION="$(git for-each-ref "refs/tags/${TAG}" --format='%(contents)')"
+
+          # Check 2 — provenance trailer written by scripts/release.sh.
+          if ! printf '%s\n' "${ANNOTATION}" | grep -qxF 'Released-via: harness:release'; then
+            fail "check 2 (provenance trailer): tag annotation has no 'Released-via: harness:release' line."
+          fi
+
+          # Check 3 — the trailer's version equals the pushed tag name.
+          TRAILER_VERSION="$(printf '%s\n' "${ANNOTATION}" | sed -n 's/^Release-version: //p' | tail -n1)"
+          if [ "${TRAILER_VERSION}" != "${TAG}" ]; then
+            fail "check 3 (version binding): trailer Release-version='${TRAILER_VERSION}' != pushed tag '${TAG}'."
+          fi
+
+          # Check 4 — the trailer's commit equals the commit the tag points to.
+          TAG_COMMIT="$(git rev-list -n1 "${TAG}")"
+          TRAILER_COMMIT="$(printf '%s\n' "${ANNOTATION}" | sed -n 's/^Release-commit: //p' | tail -n1)"
+          if [ "${TRAILER_COMMIT}" != "${TAG_COMMIT}" ]; then
+            fail "check 4 (commit binding): trailer Release-commit='${TRAILER_COMMIT}' != tagged commit '${TAG_COMMIT}'."
+          fi
+
+          # Check 5 — CHANGELOG.md at the tagged commit has this version's section.
+          VERSION_NO_V="${TAG#v}"
+          if ! git show "${TAG_COMMIT}:CHANGELOG.md" | grep -qE "^## \[${VERSION_NO_V}\]"; then
+            fail "check 5 (CHANGELOG): CHANGELOG.md at ${TAG_COMMIT} has no '## [${VERSION_NO_V}]' section."
+          fi
+
+          # Check 6 — version SSOT (.moai/config/sections/system.yaml stores the
+          # v-prefixed form, e.g. `version: v3.0.1`).
+          SSOT_PATH='.moai/config/sections/system.yaml'
+          if ! git show "${TAG_COMMIT}:${SSOT_PATH}" | grep -qE "^[[:space:]]*version:[[:space:]]*${TAG}[[:space:]]*$"; then
+            ACTUAL="$(git show "${TAG_COMMIT}:${SSOT_PATH}" | sed -n 's/^[[:space:]]*version:[[:space:]]*//p' | head -n1)"
+            fail "check 6 (version SSOT): ${SSOT_PATH} at ${TAG_COMMIT} has version='${ACTUAL}', expected '${TAG}'."
+          fi
+
+          # Check 7 — the tagged commit is an ancestor of origin/main.
+          if ! git merge-base --is-ancestor "${TAG_COMMIT}" origin/main; then
+            fail "check 7 (main ancestry): tagged commit ${TAG_COMMIT} is not an ancestor of origin/main."
+          fi
+
+          echo "RELEASE_PROVENANCE_GATE: all 7 checks passed for ${TAG} (${TAG_COMMIT})."
+
   release:
     name: Release
+    needs: verify-provenance
     runs-on: ubuntu-latest
     timeout-minutes: 45
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -80,18 +80,35 @@ log_info "Release version: ${BOLD}$VERSION${NC}"
 [[ "$DRY_RUN" == true ]] && log_warn "DRY RUN mode — no tag/push will occur"
 [[ "$HOTFIX" == true ]] && log_info "Hotfix mode — relaxed branch check"
 
-# ─── Validation 2: Repository root ─────────────────────────────────────────
+# ─── Validation 2: 하네스 경유 확인 (release provenance) ────────────────────
+# 프로덕션 릴리스는 `/harness:release` 하네스를 통해서만 수행한다.
+# 하네스가 MOAI_RELEASE_VIA_HARNESS=1 을 export 한 상태로 이 스크립트를 호출하며,
+# 여기서 생성되는 annotated tag 에는 provenance trailer 가 기록된다
+# (release.yml 의 verify-provenance job 이 이를 검증).
+# --dry-run 은 tag/push 가 발생하지 않으므로 예외로 허용하되 경고를 출력한다.
+if [[ "${MOAI_RELEASE_VIA_HARNESS:-}" != "1" ]]; then
+    if [[ "$DRY_RUN" == true ]]; then
+        log_warn "MOAI_RELEASE_VIA_HARNESS is not set — dry-run only."
+        log_warn "The real release run requires the /harness:release harness (it exports MOAI_RELEASE_VIA_HARNESS=1)."
+    else
+        die "Release must run through the /harness:release harness (MOAI_RELEASE_VIA_HARNESS=1 not set). Run '/harness:release $VERSION' instead of invoking this script directly."
+    fi
+else
+    log_ok "Harness provenance confirmed (MOAI_RELEASE_VIA_HARNESS=1)"
+fi
+
+# ─── Validation 3: Repository root ─────────────────────────────────────────
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || die 'Not in a git repository')"
 cd "$REPO_ROOT"
 
-# ─── Validation 3: Clean working tree ──────────────────────────────────────
+# ─── Validation 4: Clean working tree ──────────────────────────────────────
 if [[ -n "$(git status --porcelain)" ]]; then
     git status --short
     die "Working tree is dirty. Commit or stash changes first."
 fi
 log_ok "Working tree clean"
 
-# ─── Validation 4: Current branch ──────────────────────────────────────────
+# ─── Validation 5: Current branch ──────────────────────────────────────────
 CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 if [[ "$CURRENT_BRANCH" != "main" ]]; then
     if [[ "$HOTFIX" == true ]]; then
@@ -102,7 +119,7 @@ if [[ "$CURRENT_BRANCH" != "main" ]]; then
 fi
 log_ok "On expected branch: $CURRENT_BRANCH"
 
-# ─── Validation 5: Synced with origin ──────────────────────────────────────
+# ─── Validation 6: Synced with origin ──────────────────────────────────────
 git fetch origin --tags --quiet
 LOCAL_SHA="$(git rev-parse HEAD)"
 REMOTE_SHA="$(git rev-parse "origin/$CURRENT_BRANCH" 2>/dev/null || echo "")"
@@ -118,7 +135,7 @@ if [[ "$LOCAL_SHA" != "$REMOTE_SHA" ]]; then
 fi
 log_ok "Local $CURRENT_BRANCH synced with origin"
 
-# ─── Validation 6: Tag does not exist ──────────────────────────────────────
+# ─── Validation 7: Tag does not exist ──────────────────────────────────────
 if git rev-parse "$VERSION" >/dev/null 2>&1; then
     die "Tag $VERSION already exists (local)."
 fi
@@ -127,7 +144,7 @@ if git ls-remote --exit-code --tags origin "$VERSION" >/dev/null 2>&1; then
 fi
 log_ok "Tag $VERSION does not exist yet"
 
-# ─── Validation 7: CHANGELOG.md 에 해당 버전 섹션 존재 ───────────────────────
+# ─── Validation 8: CHANGELOG.md 에 해당 버전 섹션 존재 ───────────────────────
 CHANGELOG_VERSION="${VERSION#v}" # v2.14.0 → 2.14.0
 CHANGELOG_HEADER="## [$CHANGELOG_VERSION]"
 
@@ -136,7 +153,7 @@ if ! grep -q "^## \[$CHANGELOG_VERSION\]" CHANGELOG.md; then
 fi
 log_ok "CHANGELOG.md contains $CHANGELOG_HEADER section"
 
-# ─── Validation 8: CI status on HEAD (optional) ────────────────────────────
+# ─── Validation 9: CI status on HEAD (optional) ────────────────────────────
 if [[ "$SKIP_CI_CHECK" != true ]]; then
     if command -v gh >/dev/null 2>&1; then
         CI_STATE="$(gh pr list --head "$CURRENT_BRANCH" --state merged --limit 1 --json number --jq '.[0].number // ""' 2>/dev/null || echo "")"
@@ -168,7 +185,7 @@ else
     log_warn "CI check skipped (--skip-ci-check)"
 fi
 
-# ─── Validation 9: SPEC status 확인 (optional, informational) ───────────────
+# ─── Validation 10: SPEC status 확인 (optional, informational) ───────────────
 if [[ -d .moai/specs ]]; then
     DRAFT_COUNT="$(find .moai/specs -name 'spec.md' -exec grep -l '^status: draft' {} \; 2>/dev/null | wc -l | tr -d ' ')"
     if [[ "$DRAFT_COUNT" -gt 0 ]]; then
@@ -196,6 +213,18 @@ awk -v target="$CHANGELOG_HEADER " '
 if [[ ! -s "$TMP_NOTES" ]]; then
     die "Failed to extract CHANGELOG section for $VERSION"
 fi
+
+# ─── Provenance trailer 추가 ────────────────────────────────────────────────
+# annotation 본문 끝에 provenance trailer 3줄을 append 한다.
+# release.yml 의 verify-provenance job 이 이 3개 키를 literal 로 파싱하므로
+# 키 철자(Released-via / Release-version / Release-commit)를 변경하면 안 된다.
+TAG_COMMIT="$(git rev-parse HEAD^{commit})"
+{
+    echo
+    echo "Released-via: harness:release"
+    echo "Release-version: $VERSION"
+    echo "Release-commit: $TAG_COMMIT"
+} >> "$TMP_NOTES"
 
 NOTES_LINES="$(wc -l < "$TMP_NOTES" | tr -d ' ')"
 log_ok "Extracted $NOTES_LINES line(s) from CHANGELOG.md as tag annotation"


### PR DESCRIPTION
Production releases must happen only through the `/harness:release` maintainer harness. Today six routes reach a published release and only one is sanctioned.

## The choke point

`.github/workflows/release.yml` is the only publishing workflow and its sole trigger is `push: tags: v*` (no `workflow_dispatch`). Every route converges there:

| # | route | sanctioned |
|---|---|---|
| 1 | `/harness:release` → `hns-release-specialist` → `scripts/release.sh` | yes |
| 2 | `scripts/release.sh vX.Y.Z` run directly | no |
| 3 | `git tag -a vX.Y.Z && git push origin vX.Y.Z` | no |
| 4 | `gh release create vX.Y.Z` | no |
| 5 | GitHub web UI → Releases → new tag | no |
| 6 | any other automation pushing a `v*` tag | no |

Gating the choke point closes all five unsanctioned routes at once.

## What lands

**`verify-provenance` job (new), and `release` now `needs:` it.** Seven checks must all pass before GoReleaser runs:

1. **annotated tag** — `git cat-file -t` must return `tag`. Rejects routes 4 and 5 outright, which create lightweight tags.
2. **provenance trailer** — annotation contains `Released-via: harness:release`.
3. **version binding** — trailer `Release-version:` equals the pushed tag.
4. **commit binding** — trailer `Release-commit:` equals the commit the tag points to.
5. **CHANGELOG consistency** — a `## [X.Y.Z]` section exists at the tagged commit.
6. **version SSOT consistency** — `.moai/config/sections/system.yaml` carries the same version at that commit.
7. **main ancestry** — the tagged commit is an ancestor of `origin/main`.

**`scripts/release.sh`** refuses to run unless `MOAI_RELEASE_VIA_HARNESS=1` is set, pointing the operator at `/harness:release`; `--dry-run` still runs without it but warns. It appends the three trailer lines to the tag annotation.

**`hns-release-specialist`** exports the variable when invoking the script.

## Honest limitation

The trailer lives in a public tag annotation, so a maintainer with push rights can copy it. It is not a secret and is not claimed to be one. What it does is stop accidental and habitual releases through routes 2–6. The substantive protection is checks 5–7: an ad-hoc tag fails CHANGELOG, version-SSOT, or main-ancestry even if the trailer is replicated. A repository admin can still bypass by editing this workflow — and that edit is visible in git history.

Complementary repo setting (applied separately, not in this diff): a `v*` tag ruleset blocking deletion and update, so a published tag cannot be silently removed or re-pointed. Tag *creation* stays allowed — blocking it would break the sanctioned path too.

## Verification

| check | result |
|---|---|
| `bash -n scripts/release.sh` | exit 0 (`shellcheck` not installed on this machine) |
| `yaml.safe_load` on `release.yml` | exit 0 |
| `scripts/release.sh v9.9.9` without the env var | aborts with the harness message, exit 1, no tag created |
| `scripts/release.sh v9.9.9 --dry-run` without it | clears the guard, prints the warning, no tag created |
| seven checks exercised end-to-end in a scratch repo | all 7 pass for a well-formed tag; lightweight tag correctly fails check 1 |

Residual risk: the checks were exercised against a synthetic repo, not a live tag-triggered Actions run. Runner behaviour of the two `git fetch` lines under `actions/checkout@v7` with `fetch-depth: 0` is unproven until the first real release.

🗿 MoAI