### PR TITLE
ci: report required checks for every non-Go PR, not just docs-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,16 +156,25 @@ jobs:
     runs-on: ubuntu-latest
     needs: detect
     timeout-minutes: 5
-    # EC-1 mutual exclusivity guard: mixed PR (docs + Go code) runs real test only, NOT skip-marker.
-    # Without this guard, both jobs would emit Test (X) check-runs on mixed PRs, wasting compute.
-    if: needs.detect.outputs.docs_only == 'true' && needs.detect.outputs.go_code != 'true'
+    # Complement of the real `test` job, so exactly one of the two always runs and
+    # the required contexts Test (ubuntu|macos|windows-latest) are ALWAYS reported.
+    # EC-1 mutual exclusivity still holds: this is the strict negation of the real
+    # job's `go_code == 'true'`, so a mixed PR (docs + Go) runs the real test only.
+    #
+    # Previously this was gated on `docs_only == 'true'`, which is NARROWER than
+    # "not go_code": a PR touching only files in neither filter — .gitignore, a
+    # shell script, e2e/**, any root config — matched neither job, so those four
+    # required contexts were never reported and the PR could never merge (GitHub
+    # waits forever for a status that will not arrive). Gating on the negation
+    # closes that hole for every non-Go change, not just documentation.
+    if: needs.detect.outputs.go_code != 'true'
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - name: Skip (docs-only PR)
-        run: echo "Docs-only PR — Go test matrix skipped per paths-filter (SPEC-V3R4-CI-FASTTRACK-001)"
+      - name: Skip (no Go changes)
+        run: echo "No Go-code changes per paths-filter — Go test matrix skipped; required check satisfied."
 
   # ---------------------------------------------------------------------------
   # Integration Tests: Harness Learning Subsystem (SPEC-V3R3-HARNESS-LEARNING-001)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -123,12 +123,23 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: detect
-    # EC-1 mutual exclusivity guard: mixed PR (docs + Go code) runs real analyze only, NOT skip-marker.
-    if: needs.detect.outputs.docs_only == 'true' && needs.detect.outputs.go_code != 'true' && github.event_name == 'pull_request'
+    # Complement of the real `analyze` job (go_code == 'true' || push || schedule),
+    # so exactly one of the two always runs and the required context
+    # "Analyze (Go) (go)" is ALWAYS reported on a pull request.
+    # EC-1 mutual exclusivity still holds: this is the strict negation, so a mixed
+    # PR (docs + Go) runs the real analyze only.
+    #
+    # Previously this was gated on `docs_only == 'true'`, which is NARROWER than
+    # "not go_code": a PR touching only files in neither filter — .gitignore, a
+    # shell script, e2e/**, any root config — matched neither job, so the required
+    # context was never reported and the PR could never merge (GitHub waits forever
+    # for a status that will not arrive). Gating on the negation closes that hole
+    # for every non-Go change, not just documentation.
+    if: needs.detect.outputs.go_code != 'true' && github.event_name == 'pull_request'
     strategy:
       fail-fast: false
       matrix:
         language: [go]
     steps:
-      - name: Skip (docs-only PR)
-        run: echo "Docs-only PR — CodeQL analysis skipped via skip-marker (SPEC-V3R4-CI-FASTTRACK-001)"
+      - name: Skip (no Go changes)
+        run: echo "No Go-code changes per paths-filter — CodeQL analysis skipped; required check satisfied."


### PR DESCRIPTION
A PR that touches only files in **neither** paths-filter — `.gitignore`, a shell script, `e2e/**`, any root config — matches neither the real Go jobs nor their skip-markers. The required contexts are then never reported, GitHub waits forever for a status that will not arrive, and the PR can never merge.

#1122 (e2e journey script + `.gitignore`) hit exactly this:

```
❌ Test (ubuntu-latest)     ❌ Analyze (Go) (go)
❌ Test (macos-latest)      ❌ Test (windows-latest)
✅ Lint                     ✅ Build (linux/amd64)
```

`mergeable: MERGEABLE`, yet permanently blocked — and with `enforce_admins: true` there is no bypass. This is not specific to #1122: **no docs-or-config-only PR can merge in this repository today.**

## Cause

The skip-markers already exist and already carry the correct job names. They were simply gated too narrowly:

```yaml
if: needs.detect.outputs.docs_only == 'true' && needs.detect.outputs.go_code != 'true'
```

`docs_only` is a strict *subset* of "not `go_code`" — it lists `**.md`, `.github/**`, `.moai/*`, `.claude/rules|skills`, `docs-site/**` and a few root files. Everything else falls through the gap between the two jobs.

## Fix

Each marker now uses the strict negation of its real job's condition:

| workflow | job | condition |
|---|---|---|
| `ci.yml` | `test-skip-marker` | `go_code != 'true'` |
| `codeql.yml` | `analyze-skip-marker` | `go_code != 'true' && event == 'pull_request'` |

The `pull_request` guard on the CodeQL marker is retained because the real `analyze` also runs on `push`/`schedule`.

## Verification

Truth table over `go_code` × `event` — exactly one job of each pair runs in every case:

```
go_code=true  event=pull_request  | test=1 skip=0 sum=1 || analyze=1 skip=0 sum=1
go_code=true  event=push          | test=1 skip=0 sum=1 || analyze=1 skip=0 sum=1
go_code=false event=pull_request  | test=0 skip=1 sum=1 || analyze=0 skip=1 sum=1
go_code=false event=push          | test=0 skip=1 sum=1 || analyze=1 skip=0 sum=1
```

- EC-1 mutual exclusivity is **preserved** — being the strict negation, a mixed docs+Go PR still runs the real job only, never both.
- Job names are unchanged (`Test (${{ matrix.os }})`, `Analyze (Go)`), so branch-protection context matching is unaffected.
- Both files parse (`yaml.safe_load`).

This PR is itself a `.github/workflows/**` change, which `go_code` matches (`ci.yml`/`codeql.yml` are in that filter) — so it exercises the real Go jobs, not the markers.

🗿 MoAI