### PR TITLE
fix(hook): keep the handoff claim gate held on the consuming path

### DIFF
--- a/internal/hook/handoff_inject.go
+++ b/internal/hook/handoff_inject.go
@@ -50,7 +50,7 @@ func NewHandoffInjectHandler(cfg ConfigProvider) Handler {
 func (h *handoffInjectHandler) EventType() EventType { return EventSessionStart }
 
 // @MX:ANCHOR: [AUTO] SessionStart auto-resume 주입 단일 진입점 (4-source × mode branch table). 유일 소비 셀 = source==clear ∧ mode==auto ∧ live pending. 나머지 7셀은 pending 보존.
-// @MX:REASON: registry에 3번째 SessionStart 핸들러로 등록 (deps.go). claim-then-inject 순서(rename 성공 후 주입)가 2세션 race에서 중복 주입을 방지하는 불변식 — 순서 반전 시 AC-013 회귀. rename 실패는 errno 무관 fail-open (Windows MoveFileEx). manual mode는 stale이어도 pure no-op (REQ-009 vs REQ-019 모순 해소). AskUserQuestion 미호출 (C-HRA-008).
+// @MX:REASON: registry에 3번째 SessionStart 핸들러로 등록 (deps.go). 중복 주입을 막는 불변식은 exclusive-create claim gate 단독 — 소비 경로에서 gate를 계속 보유하므로 rename이 loser에게 실패를 돌려주지 않아도(Windows sharing violation) 뒤 세션이 같은 레코드를 다시 이길 수 없다. gate 해제는 SavePending(다음 레코드 기록) 담당. claim-then-inject 순서(claim 성공 후 주입)는 유지 — 순서 반전 시 AC-013 회귀. rename 실패는 errno 무관 fail-open (Windows MoveFileEx). manual mode는 stale이어도 pure no-op (REQ-009 vs REQ-019 모순 해소). AskUserQuestion 미호출 (C-HRA-008).
 // @MX:SPEC: SPEC-HANDOFF-AUTORESUME-001
 //
 // Handle processes a SessionStart event. Best-effort: every path returns allow
@@ -130,14 +130,25 @@ func (h *handoffInjectHandler) claimAndInject(projectDir string, rec *handoff.Pe
 	if !claimPendingGate(projectDir) {
 		return &HookOutput{}
 	}
-	defer releasePendingGate(projectDir)
+
+	// The gate is a DURABLE claim marker, not a mutex, so it is NOT released on
+	// every path. It is dropped only on the two early returns below, where
+	// nothing was consumed and the record is still live — holding it there would
+	// strand a record no caller ever claimed. From the rename onwards the gate is
+	// retained, because this caller may have consumed the record: retaining it is
+	// the only thing that stops a later contender from winning the same record
+	// when the rename reports success without the record actually moving (the
+	// Windows fault above). Exclusivity therefore rests solely on the
+	// exclusive-create claim, never on the rename failing for the loser and never
+	// on the stat re-check below. The retained gate is cleared by
+	// handoff.SavePending when the next record is written.
 
 	// Re-check inside the gate. The record was read before the gate was taken,
 	// so a contender that lost an earlier round still holds a stale "present"
-	// observation; without this the read-then-consume window stays open and the
-	// gate only narrows it. Every consumer serializes through the gate, so this
-	// check and the rename below are now atomic with respect to each other.
+	// observation. This narrows the read-then-consume window; it is a freshness
+	// check, not the exclusivity mechanism.
 	if _, err := os.Stat(handoff.PendingPath(projectDir)); err != nil {
+		releasePendingGate(projectDir)
 		return &HookOutput{}
 	}
 
@@ -149,11 +160,14 @@ func (h *handoffInjectHandler) claimAndInject(projectDir string, rec *handoff.Pe
 	// Archive the claimed record. This rename is no longer load-bearing for
 	// exclusivity — the gate above already decided the winner — so it is a plain
 	// move whose only job is preserving the pending bytes verbatim (AC-013b:
-	// any rename error still skips injection, errno-agnostic).
+	// any rename error still skips injection, errno-agnostic). A rename error
+	// consumed nothing and left the record live, so the gate is released here to
+	// keep it claimable by a later session.
 	if err := handoffRenameFunc(handoff.PendingPath(projectDir), consumedPath); err != nil {
 		slog.Warn("session_start: handoff: claim rename failed; skipping injection (fail-open)",
 			"error", err,
 		)
+		releasePendingGate(projectDir)
 		return &HookOutput{}
 	}
 
@@ -171,10 +185,12 @@ func (h *handoffInjectHandler) claimAndInject(projectDir string, rec *handoff.Pe
 //
 // The gate is never force-reclaimed here. Timing out and stealing it would
 // reintroduce the very defect this replaced: two contenders that both decide a
-// gate is stale each remove it and each then create it, so both win. A gate
-// leaked by a killed process is instead cleared by handoff.SavePending when the
-// next record is written — a record that has just been saved has by definition
-// never been claimed, so clearing it there is unambiguous and race-free.
+// gate is stale each remove it and each then create it, so both win. A gate that
+// outlives its consumer — retained by a caller that claimed the record, or
+// leaked by a killed process — is instead cleared by handoff.SavePending when
+// the next record is written: a record that has just been saved has by
+// definition never been claimed, so clearing it there is unambiguous and
+// race-free.
 func claimPendingGate(projectDir string) bool {
 	err := atomicfile.Claim(handoff.ClaimGatePath(projectDir), 0o600)
 	if err == nil {
@@ -188,9 +204,11 @@ func claimPendingGate(projectDir string) bool {
 	return false
 }
 
-// releasePendingGate drops the gate once the claim is complete. The gate is
-// held only across the rename below, so this normally runs microseconds after
-// claimPendingGate.
+// releasePendingGate drops the gate. It is called ONLY from the paths that
+// consumed nothing and left pending.json live (the in-gate stat re-check finding
+// the record already gone, and a failed claim rename), so that the record stays
+// claimable by a later session. A caller that reached the rename keeps the gate:
+// see the release policy in claimAndInject.
 func releasePendingGate(projectDir string) {
 	if err := os.Remove(handoff.ClaimGatePath(projectDir)); err != nil && !os.IsNotExist(err) {
 		slog.Warn("session_start: handoff: could not release claim gate", "error", err)

--- a/internal/hook/handoff_inject_test.go
+++ b/internal/hook/handoff_inject_test.go
@@ -430,6 +430,82 @@ func TestConcurrentConsume_SingleWinner_RenameAlwaysSucceeds(t *testing.T) {
 	}
 }
 
+// TestClaimGate_DurableAcrossCallers_WhenRenameLies forces, deterministically and
+// on every platform, the interleaving that
+// TestConcurrentConsume_SingleWinner_RenameAlwaysSucceeds only reaches by luck on
+// Windows CI.
+//
+// The Windows failure is a claim whose rename reported success while the record
+// did NOT move: the real os.Rename hit a sharing violation from a concurrent
+// reader of pending.json and the caller was still told it succeeded, so it
+// injected and left the record live for the next caller (AC-013a: injected=2
+// against a single consumed file). Reporting success without moving models that
+// exactly, with no timing dependency.
+//
+// Sequential calls are the serialized form of that race: each call is a caller
+// that reaches the gate after the previous one is done with it. Exactly one may
+// consume the record, and that must hold without relying on the rename moving
+// the file or on the stat re-check observing it gone.
+//
+// NOT parallel: mutates the handoffRenameFunc package global.
+func TestClaimGate_DurableAcrossCallers_WhenRenameLies(t *testing.T) {
+	pd := t.TempDir()
+	mustSavePending(t, pd, livePending("resume"))
+
+	orig := handoffRenameFunc
+	defer func() { handoffRenameFunc = orig }()
+	handoffRenameFunc = func(_, _ string) error { return nil }
+
+	h := NewHandoffInjectHandler(autoCfgProvider(false))
+	injected := 0
+	for i := 0; i < 4; i++ {
+		out, err := h.Handle(context.Background(), injectInput("clear", pd))
+		if err != nil {
+			t.Fatalf("Handle #%d must be fail-open, got: %v", i, err)
+		}
+		if additionalContextOf(out) != "" {
+			injected++
+		}
+	}
+
+	if injected != 1 {
+		t.Errorf("expected exactly 1 caller to consume the record even when rename reports success without moving it, got %d", injected)
+	}
+}
+
+// TestClaimGate_ReleasedWhenNothingConsumed pins the release policy for the
+// non-consuming early return: a rename that fails consumed nothing and left the
+// record live, so the gate must be dropped and a later session must still be
+// able to claim the same record.
+//
+// NOT parallel: mutates the handoffRenameFunc package global.
+func TestClaimGate_ReleasedWhenNothingConsumed(t *testing.T) {
+	pd := t.TempDir()
+	mustSavePending(t, pd, livePending("resume"))
+
+	orig := handoffRenameFunc
+	defer func() { handoffRenameFunc = orig }()
+	handoffRenameFunc = func(_, _ string) error { return errors.New("forced rename failure (EACCES-like)") }
+
+	h := NewHandoffInjectHandler(autoCfgProvider(false))
+	if out, err := h.Handle(context.Background(), injectInput("clear", pd)); err != nil {
+		t.Fatalf("Handle must be fail-open, got: %v", err)
+	} else if additionalContextOf(out) != "" {
+		t.Fatal("a failed rename must skip injection")
+	}
+	if _, err := os.Stat(handoff.ClaimGatePath(pd)); !os.IsNotExist(err) {
+		t.Errorf("gate must be released when nothing was consumed; stat err=%v", err)
+	}
+
+	// A later session (working rename) must still be able to claim the record.
+	handoffRenameFunc = orig
+	if out, err := h.Handle(context.Background(), injectInput("clear", pd)); err != nil {
+		t.Fatalf("Handle: %v", err)
+	} else if additionalContextOf(out) == "" {
+		t.Error("a record left live by a failed claim must remain claimable")
+	}
+}
+
 // TestClaimGate_HeldGateBlocksClaim pins that a held gate makes the claim yield
 // rather than steal it — the property that keeps the winner single.
 //
@@ -459,9 +535,17 @@ func TestClaimGate_HeldGateBlocksClaim(t *testing.T) {
 	}
 }
 
-// TestClaimGate_ReleasedAfterClaim proves the gate does not leak on the success
-// path: a second record saved afterwards is still claimable.
-func TestClaimGate_ReleasedAfterClaim(t *testing.T) {
+// TestClaimGate_RetainedAfterClaim_NextRecordStillClaimable proves the gate is a
+// durable claim marker on the success path — it survives the consume so no later
+// contender can win the same record — and that retaining it does not disable
+// auto-resume: a second record saved afterwards is still claimable, because
+// handoff.SavePending clears the gate when it writes the next record.
+//
+// The retention assertion replaces an earlier "gate must be released after a
+// successful claim" assertion. That earlier assertion encoded the defect this
+// test file's Windows failure came from: a gate released on the success path is
+// only a mutex, leaving exclusivity to the rename and the stat re-check.
+func TestClaimGate_RetainedAfterClaim_NextRecordStillClaimable(t *testing.T) {
 	t.Parallel()
 
 	pd := t.TempDir()
@@ -473,8 +557,8 @@ func TestClaimGate_ReleasedAfterClaim(t *testing.T) {
 	} else if additionalContextOf(out) == "" {
 		t.Fatal("expected the first record to be injected")
 	}
-	if _, err := os.Stat(handoff.ClaimGatePath(pd)); !os.IsNotExist(err) {
-		t.Errorf("gate must be released after a successful claim; stat err=%v", err)
+	if _, err := os.Stat(handoff.ClaimGatePath(pd)); err != nil {
+		t.Errorf("gate must be retained after a successful claim; stat err=%v", err)
 	}
 
 	mustSavePending(t, pd, livePending("second"))


### PR DESCRIPTION
`TestConcurrentConsume_SingleWinner_RenameAlwaysSucceeds` fails intermittently on Windows CI with `expected exactly 1 winner even when every rename succeeds, got 2` — two sessions both consume the same pending handoff record and both inject it. Pre-existing on main (2 of the last 5 main CI runs).

## Mechanism

`claimPendingGate` takes an exclusive-create gate (`atomicfile.Claim`, `O_CREATE|O_EXCL`) and its own doc comment describes a **durable** claim marker: *"The gate is never force-reclaimed here… cleared by handoff.SavePending when the next record is written"* — which `handoff/pending.go:102` implements.

But `claimAndInject` dropped it with `defer releasePendingGate(projectDir)` on **every** path. That contradicted the documented design and degraded the gate to a short-lived mutex, leaving exclusivity resting on the in-gate `os.Stat` re-check plus the rename actually moving the file.

The gate does serialize contenders, so the two-winner path is strictly sequential through it:

1. A claims → stat OK → rename **reports success without the record moving** → A injects → A releases.
2. B claims (gate now free) → stat still sees the record → rename succeeds → B injects.

`atomicfile.Claim` was never the problem — how long its result was held was.

## Fix

`defer releasePendingGate` is removed. The gate is retained from the rename onwards and released explicitly only on the two paths that consumed nothing and left the record live (stat re-check finds it already gone; rename returns an error). Policy documented in code as **hold iff we may have consumed** — holding on a non-consuming path would strand a record no caller ever claims. `MkdirAll` failure precedes the claim and needs no release.

Exclusivity now rests solely on the exclusive-create primitive, never on rename semantics or a stat re-check.

## Deterministic reproduction

The existing test is timing-dependent and passes on darwin (`-count=5` green), so a new test reproduces the defect with no goroutines and no timing — `handoffRenameFunc` reports success without moving, then four sequential `Handle` calls:

```
=== RUN   TestClaimGate_DurableAcrossCallers_WhenRenameLies
    handoff_inject_test.go:472: expected exactly 1 caller to consume the record
    even when rename reports success without moving it, got 4
--- FAIL: TestClaimGate_DurableAcrossCallers_WhenRenameLies (0.01s)
```

## One test was inverted — please review

`TestClaimGate_ReleasedAfterClaim` (added with the gate in `640709c0c`) asserted *"gate must be released after a successful claim"* — literally the defect. It is renamed `TestClaimGate_RetainedAfterClaim_NextRecordStillClaimable` with the assertion inverted. Its second half — save a second record, confirm it still injects — is kept **verbatim** and passes, which is the evidence that retaining the gate does not disable auto-resume (`SavePending` clears it). Nothing else was weakened, skipped, or deleted.

## Verification

| check | result |
|---|---|
| new deterministic test | RED (`got 4`) → PASS |
| `go test -count=20 ./internal/hook/ -run TestConcurrentConsume` | exit 0, 40 PASS / 0 FAIL |
| `go test -race -count=10 ./internal/hook/...` | exit 0, 0 races |
| `go test ./internal/hook/...` | exit 0 (all 11 packages) |
| `go vet` / `golangci-lint` / `gofmt -l` | exit 0, 0 issues |
| `GOOS=windows GOARCH=amd64 go build ./...` | exit 0 |
| `go test ./...` full repo | exit 0 (cascade check) |

**Darwin green is necessary but not sufficient** — the original failure manifests only on Windows CI. The deterministic test proves the code-level invariant on any platform; the Windows job on this PR is the real proof.

## Out of scope, reported

`internal/hook` has a pre-existing flaky data race between `TestPostTool_MemoryMissingType` (restores global `os.Stderr`, `t.Parallel()`) and `runEvidenceGate`'s `fmt.Fprintln(os.Stderr, …)`. Reproduced 8 races in 30 runs on a clean tree with this PR's files stashed. Not touched here.

🗿 MoAI