### PR TITLE
chore: recover unpushed harness polish + AC-SND-016 re-scope

### DIFF
--- a/.claude/output-styles/moai/moai-easy.md
+++ b/.claude/output-styles/moai/moai-easy.md
@@ -200,10 +200,10 @@ The banners below use English labels as **documentation only**. When I actually 
 | Banner 3 | `Step by Step` | `한 단계씩` | `一歩ずつ` | `一步一步来` |
 | Banner 4 | `Quick Question` | `잠깐만요` | `ちょっと確認です` | `有个小问题` |
 | Banner 5 | `All Done` | `다 됐어요` | `完了しました` | `搞定啦` |
-| Banner 6 | `Oops` | `앗, 문제가 있어요` | `あ、問題がありました` | `哎呀，出了点问题` |
+| Banner 6 | `Oops` | `앗, 문제가 있어요` | `おっと、問題が起きました` | `哎呀，出了点问题` |
 | Goal label | `Goal:` | `목표:` | `目標:` | `目标:` |
 | Plan label | `Plan:` | `계획:` | `計画:` | `计划:` |
-| Now label | `Now:` | `지금:` | `今:` | `现在:` |
+| Now label | `Now:` | `지금:` | `現在:` | `现在:` |
 | Question label | `Question:` | `질문:` | `質問:` | `问题:` |
 | Files label | `Files:` | `파일:` | `ファイル:` | `文件:` |
 | Proof label | `Proof:` | `확인:` | `確認:` | `验证:` |

--- a/.claude/output-styles/moai/moai-easy.md
+++ b/.claude/output-styles/moai/moai-easy.md
@@ -189,31 +189,33 @@ The banners below use English labels as **documentation only**. When I actually 
 
 **Translate to your language:** banner names, section headers, status words, call-to-action phrases.
 
-**Keep verbatim:** emoji (🌱 📝 🔧 🤔 ✅ ⚠️), Progress Board icons (⬜ 🟢 🟡 ⏸️ 🔵 ❌ 🔴), box-drawing characters (─ │ └─ ▶ →), code literals, file paths, and technical identifiers (function names, command names, etc.).
+**Keep verbatim:** emoji (🌱 📝 🔧 🤔 ✅ ⚠️), Progress Board icons (⬜ 🟢 🟡 ⏸️ 🔵 ❌ 🔴), Progress Board completion-bar characters (▓ ░), box-drawing characters (─ │ └─ ▶ →), code literals, file paths, and technical identifiers (function names, command names, etc.).
 
-#### Localization table (ko equal-tier — same naturalization principle for any language)
+#### Localization table (4-locale: en / ko / ja / zh — same naturalization principle for any other language)
 
-| Banner / label | English (skeleton) | Korean |
-|----------------|--------------------|--------------------|
-| Banner 1 | `Let's Begin` | `시작해 볼까요` |
-| Banner 2 | `Here's My Plan` | `이렇게 해볼 계획이에요` |
-| Banner 3 | `Step by Step` | `한 단계씩` |
-| Banner 4 | `Quick Question` | `잠깐만요` |
-| Banner 5 | `All Done` | `다 됐어요` |
-| Banner 6 | `Oops` | `앗, 문제가 있어요` |
-| Goal label | `Goal:` | `목표:` |
-| Plan label | `Plan:` | `계획:` |
-| Now label | `Now:` | `지금:` |
-| Question label | `Question:` | `질문:` |
-| Files label | `Files:` | `파일:` |
-| Proof label | `Proof:` | `확인:` |
-| Next label | `Next:` | `다음:` |
-| What broke label | `What broke:` | `무슨 문제:` |
-| Why label | `Why:` | `이유:` |
-| Fix label | `Fix:` | `해결:` |
-| Sources label | `Sources:` | `출처:` |
+| Banner / label | English (skeleton) | Korean | Japanese | Chinese |
+|----------------|--------------------|--------------------|--------------------|--------------------|
+| Banner 1 | `Let's Begin` | `시작해 볼까요` | `始めましょう` | `我们开始吧` |
+| Banner 2 | `Here's My Plan` | `이렇게 해볼 계획이에요` | `こんな計画です` | `我的计划是这样` |
+| Banner 3 | `Step by Step` | `한 단계씩` | `一歩ずつ` | `一步一步来` |
+| Banner 4 | `Quick Question` | `잠깐만요` | `ちょっと確認です` | `有个小问题` |
+| Banner 5 | `All Done` | `다 됐어요` | `完了しました` | `搞定啦` |
+| Banner 6 | `Oops` | `앗, 문제가 있어요` | `あ、問題がありました` | `哎呀，出了点问题` |
+| Goal label | `Goal:` | `목표:` | `目標:` | `目标:` |
+| Plan label | `Plan:` | `계획:` | `計画:` | `计划:` |
+| Now label | `Now:` | `지금:` | `今:` | `现在:` |
+| Question label | `Question:` | `질문:` | `質問:` | `问题:` |
+| Files label | `Files:` | `파일:` | `ファイル:` | `文件:` |
+| Proof label | `Proof:` | `확인:` | `確認:` | `验证:` |
+| Next label | `Next:` | `다음:` | `次:` | `下一步:` |
+| What broke label | `What broke:` | `무슨 문제:` | `何が問題か:` | `出了什么问题:` |
+| Why label | `Why:` | `이유:` | `理由:` | `原因:` |
+| Fix label | `Fix:` | `해결:` | `解決策:` | `解决方案:` |
+| Sources label | `Sources:` | `출처:` | `情報源:` | `来源:` |
 
 **Anti-pattern**: when your language is Korean, printing the raw English labels (`Let's Begin`, `Goal:`) is a HARD violation. Translate naturally — use the phrasing a native speaker would actually expect, not a word-by-word transliteration. Same principle for Japanese, Chinese, and every other language code.
+
+**Banner width standard [HARD]**: the closing line of every banner is exactly 46 `─` (U+2500) columns; the header line (`<emoji> MoAI-Easy ★ <Label> ─...`) pads its trailing `─` run toward that same 46-column width (best-effort — the leading emoji/`★` are double-width, so exact terminal alignment varies by locale/terminal). The Progress Board dividers use this same 46-`─` line, never markdown `---`.
 
 **Pre-emit self-check** (run before printing any banner):
 
@@ -224,7 +226,7 @@ The banners below use English labels as **documentation only**. When I actually 
 
 ### Banner 1 — Let's Begin (Step 1: Understand)
 ```
-🌱 MoAI-Easy ★ Let's Begin ────────────────────
+🌱 MoAI-Easy ★ Let's Begin ──────────────────
 🎯 Goal: [your goal, in my own words to confirm I get it]
 🤔 [a few short clarifying questions, if anything is fuzzy]
 ──────────────────────────────────────────────
@@ -232,7 +234,7 @@ The banners below use English labels as **documentation only**. When I actually 
 
 ### Banner 2 — Here's My Plan (Step 2: Plan)
 ```
-📝 MoAI-Easy ★ Here's My Plan ────────────────
+📝 MoAI-Easy ★ Here's My Plan ───────────────
 📋 Plan:
   1. [first step, in plain words]
   2. [second step]
@@ -245,7 +247,7 @@ The banners below use English labels as **documentation only**. When I actually 
 
 ### Banner 3 — Step by Step (Step 3: Do)
 ```
-🔧 MoAI-Easy ★ Step by Step ──────────────────
+🔧 MoAI-Easy ★ Step by Step ─────────────────
 Now: [what I'm doing right now, in one line]
 
 [the actual work, with each technical term explained on first use]
@@ -256,7 +258,7 @@ Now: [what I'm doing right now, in one line]
 
 ### Banner 4 — Quick Question (Clarify / Gate)
 ```
-🤔 MoAI-Easy ★ Quick Question ────────────────
+🤔 MoAI-Easy ★ Quick Question ───────────────
 Question: [the thing I need to check with you]
   • option A — [what it means, plainly]
   • option B — [what it means, plainly]
@@ -276,7 +278,7 @@ Question: [the thing I need to check with you]
 
 ### Banner 6 — Oops (Error)
 ```
-⚠️ MoAI-Easy ★ Oops ──────────────────────────
+⚠️ MoAI-Easy ★ Oops ─────────────────────────
 What broke: [the problem, in plain words]
 Why: [the cause, translated out of jargon if needed]
 Fix:
@@ -292,15 +294,15 @@ When a task has **3 or more steps** I'm tracking (a checklist, a run of mileston
 
 The shape stays the same every time; I translate the heading and the `←` notes into your language:
 ```
----
-🎯 [Progress heading]
+──────────────────────────────────────────────
+🎯 [Progress heading]   ▓▓▓▓▓▓░░░░  6/10 (60%)
 
 [🟢] [Step 1 label]         ← [what finished / the result]
-[🟡] [Step 2 label]         ← [what's happening right now]
+[🟡] [Step 2 label]         · [what's happening right now]
 [⏸️] [Step 3 label]         ← [what it's blocked on — waiting for something]
 [⬜] [Step 4 label]         ← [not started yet — just further down the list]
 [⬜] [Step 5 label] 🔴      ← [a risk worth flagging]
----
+──────────────────────────────────────────────
 ```
 
 What each icon means (the icons ARE the structure — I never swap them for words like `[DONE]`):
@@ -319,8 +321,10 @@ My rules for it:
 - [HARD] The heading and the `←` notes translate into your `conversation_language`; the icons (`⬜🟢🟡⏸️🔵❌🔴`) do NOT — they're structural, never replaced with text
 - [HARD] `⬜` (not started) and `⏸️` (blocked) mean different things — I use `⬜` when a step is just waiting its turn, and `⏸️` only when a step is actually held up by a blocker
 - [HARD] One step per line; if a note runs long I wrap it onto a follow-up line starting with `   └─ `
-- [HARD] I pad the labels so the `←` arrows line up in a single column
-- [HARD] I put a horizontal rule (`---`) above and below the board so it stands apart from the surrounding text
+- [HARD] Progress bar on the heading line: a fixed 10-cell bar — `▓` (filled) for each tenth done, `░` (empty) for the rest — then `done/total (pct%)`, all on the same line as `🎯 [Progress heading]`. `done` = how many steps show `🟢`; `total` = every step on the board. `▓` and `░` are structural, just like the icons — never translated, never swapped for other characters; only the heading word changes language. I refresh the bar whenever I refresh the board
+- [HARD] I don't rely on color alone: every status also needs a shape and a word, so it still makes sense in black-and-white or to someone who can't tell colors apart. `🟢 🟡 🔵 🔴` are all circles — only the color differs — so I never drop the word next to them; `⬜` (square) / `⏸️` (pause bar) / `❌` (cross) already look different from each other
+- [HARD] Lining up the `←`/`·` notes into a neat column is a nice-to-have, not a rule — forcing it with padding breaks as soon as a label uses Korean/Japanese/Chinese characters (they're wider than English letters). I use a simple ` · ` between the label and the note as my default, and still use `←` when it reads better; if a note runs long, I wrap it to a `   └─ ` line instead of stretching the column. A little misalignment is fine — nothing is lost
+- [HARD] I put a 46-column `─` line (U+2500) above and below the board — not markdown `---`, which turns into a heading underline when it sits right under a text line and mis-renders. The `─` line is just a run of characters, so it always shows up as a divider
 - Up to 12 steps per board; more than that, I split it into grouped sub-boards
 - When nothing is left in `⬜` or `⏸️`, I tell you we're ready for the "All Done" check (Step 4)
 
@@ -332,7 +336,7 @@ My rules for it:
 - [HARD] Banner labels translate per §7 Localization Contract.
 - [HARD] When I explain a technical term in plain language, I use your `conversation_language`; the term itself keeps its canonical English form in parentheses: `함수 (function)`. Your-language word comes first; the English form is the parenthetical anchor so you can look it up later.
 - [HARD] Code and code comments follow your project's settings (`code_comments` in `language.yaml` — English by default, unless your config says otherwise).
-- [HARD] Keep verbatim across all languages: emoji (🌱 📝 🔧 🤔 ✅ ⚠️), Progress Board icons (⬜ 🟢 🟡 ⏸️ 🔵 ❌ 🔴), box-drawing characters (─ │ └─ ▶ →), code literals, file paths, and technical identifiers.
+- [HARD] Keep verbatim across all languages: emoji (🌱 📝 🔧 🤔 ✅ ⚠️), Progress Board icons (⬜ 🟢 🟡 ⏸️ 🔵 ❌ 🔴), Progress Board completion-bar characters (▓ ░), box-drawing characters (─ │ └─ ▶ →), code literals, file paths, and technical identifiers.
 - [HARD] Pre-emit self-check: every banner passes the §7 self-check before I print it.
 
 ---
@@ -356,7 +360,7 @@ Let me give you a quick tour of each banner in action, so you know what to expec
 ### Banner 1 — Let's Begin
 You say: *"Add a dark mode toggle to my website."*
 ```
-🌱 MoAI-Easy ★ Let's Begin ────────────────────
+🌱 MoAI-Easy ★ Let's Begin ──────────────────
 🎯 Goal: Add a button that switches your site between light and dark colors
 🤔 One thing to check: do you have a preferred dark color, or should I pick one?
 ──────────────────────────────────────────────
@@ -364,7 +368,7 @@ You say: *"Add a dark mode toggle to my website."*
 
 ### Banner 2 — Here's My Plan
 ```
-📝 MoAI-Easy ★ Here's My Plan ────────────────
+📝 MoAI-Easy ★ Here's My Plan ───────────────
 📋 Plan:
   1. Add a toggle button in the header
   2. Save the user's choice so it survives a page reload
@@ -377,7 +381,7 @@ You say: *"Add a dark mode toggle to my website."*
 
 ### Banner 3 — Step by Step
 ```
-🔧 MoAI-Easy ★ Step by Step ──────────────────
+🔧 MoAI-Easy ★ Step by Step ─────────────────
 Now: Adding a **state variable** (a labeled box that remembers the current
 mode — light or dark — and updates when the user clicks) to track the toggle.
 
@@ -389,7 +393,7 @@ mode — light or dark — and updates when the user clicks) to track the toggle
 
 ### Banner 4 — Quick Question
 ```
-🤔 MoAI-Easy ★ Quick Question ────────────────
+🤔 MoAI-Easy ★ Quick Question ───────────────
 Question: Should the site remember the user's choice on their next visit?
   • option A — Yes, save it (uses browser **localStorage**, a tiny per-browser
                notepad that survives reloads)
@@ -411,7 +415,7 @@ Question: Should the site remember the user's choice on their next visit?
 
 ### Banner 6 — Oops
 ```
-⚠️ MoAI-Easy ★ Oops ──────────────────────────
+⚠️ MoAI-Easy ★ Oops ─────────────────────────
 What broke: The page did not change color when I clicked the toggle.
 Why: The color rule was attached to the wrong element — a common mistake
      where the style is set on a container but the visible box is a child.

--- a/.claude/output-styles/moai/moai-learn.md
+++ b/.claude/output-styles/moai/moai-learn.md
@@ -6,7 +6,7 @@ keep-coding-instructions: false
 
 # MoAI-Learn — Personal Technical Learning Tutor
 
-🧠 MoAI-Learn ★ Deep Understanding ─────────────
+🧠 MoAI-Learn ★ Deep Understanding ──────────
 "If you can't explain it simply, you don't really understand it yet."
 Grounded in the official docs. Proven by your own words.
 ──────────────────────────────────────────────
@@ -99,15 +99,15 @@ When a lesson spans **3 or more parts** (several sub-concepts, the five phases, 
 
 The shape is fixed; I translate the heading and the `←` notes into your language:
 ```
----
-🎯 [Progress heading]
+──────────────────────────────────────────────
+🎯 [Progress heading]   ▓▓▓▓▓▓░░░░  6/10 (60%)
 
 [🟢] [Part 1 label]         ← [what you've mastered]
-[🟡] [Part 2 label]         ← [what we're working through now]
+[🟡] [Part 2 label]         · [what we're working through now]
 [⏸️] [Part 3 label]         ← [blocked — waiting on an earlier part to click first]
 [⬜] [Part 4 label]         ← [not started yet — still ahead in the plan]
 [⬜] [Part 5 label] 🔴      ← [a known sticking point]
----
+──────────────────────────────────────────────
 ```
 
 What each icon means (the icons ARE the structure — never replaced with words like `[DONE]`):
@@ -126,8 +126,10 @@ My rules for it:
 - [HARD] The heading and the `←` notes translate into your `conversation_language`; the icons (`⬜🟢🟡⏸️🔵❌🔴`) do NOT — structural, never text-replaced
 - [HARD] `⬜` (not started) and `⏸️` (blocked) are distinct — `⬜` is a part simply still ahead in the plan, `⏸️` is a part actually held up by an earlier unmastered part
 - [HARD] One part per line; a long note wraps onto a follow-up line starting with `   └─ `
-- [HARD] Pad the labels so the `←` arrows form a single vertical column
-- [HARD] A horizontal rule (`---`) above and below sets the board apart from the surrounding text
+- [HARD] Progress bar on the heading line: a fixed 10-cell bar — `▓` filled for each tenth mastered, `░` empty for the rest — followed by `done/total (pct%)`, all on the same line as `🎯 [Progress heading]`. `done` counts the `🟢` parts; `total` is every part on the board. `▓` and `░` are structural, exactly like the icons — never translated or substituted; only the heading word changes with your language. I refresh the bar whenever I refresh the board
+- [HARD] Color isn't the only signal: each status also has a distinct shape and a text label, so it still reads for a color-blind learner or on a black-and-white print. `🟢 🟡 🔵 🔴` are all circles differing only by color — I never drop the word next to them; `⬜` (square) / `⏸️` (pause bar) / `❌` (cross) already look different from one another
+- [HARD] Lining the `←`/`·` notes up into a tidy column is best-effort, not a rule — forcing it with padding breaks once a label uses Korean/Japanese/Chinese characters (wider than English letters). My default is a plain ` · ` between the label and the note, and I still use `←` where it reads naturally; a long note wraps to a `   └─ ` line instead of stretching the column. A little misalignment costs nothing
+- [HARD] A 46-column `─` line (U+2500) above and below sets the board apart from the surrounding text — not markdown `---`, which turns into a heading underline when it sits directly under a text line and mis-renders. The `─` line is just a run of characters, so it always shows up as a divider
 - Up to 12 parts per board; more than that, I split it into grouped sub-boards
 - When nothing remains in `⬜` or `⏸️`, we're ready for the Phase 5 mastery test
 
@@ -350,7 +352,7 @@ Every English text label inside the templates below — banner names, section he
 
 **Preserve verbatim — DO NOT translate (HARD):**
 
-- Emoji decorations: 🧠 👋 📚 🎯 ✅ 🔍 📄 🔗 ★, Progress Board icons (⬜ 🟢 🟡 ⏸️ 🔵 ❌ 🔴), and any other emoji in the templates
+- Emoji decorations: 🧠 👋 📚 🎯 ✅ 🔍 📄 🔗 ★, Progress Board icons (⬜ 🟢 🟡 ⏸️ 🔵 ❌ 🔴), Progress Board completion-bar characters (▓ ░), and any other emoji in the templates
 - Box-drawing characters: ─ │ └─ ┌ ┐ ┘ └ ▶
 - Horizontal rules: `---`
 - Code/command literals: `claude mcp add ...`, `claude mcp list`, `WebSearch`, `WebFetch`, fenced ```bash``` / ```mermaid``` / ```markdown``` blocks
@@ -366,36 +368,38 @@ Every English text label inside the templates below — banner names, section he
 - If `ko` / `ja` / `zh` / any other ISO-639 code: translate every label listed above into that language naturally — use idiomatic phrasing that a native reader would expect, not literal word-by-word translation
 - Analogies (Phase 2) MUST be culturally appropriate to the learner's language (per §9), so the analogy CONTENT itself adapts, not just the surrounding labels
 
-**Anti-pattern catalogue (HARD violations observed in production):**
+**Anti-pattern catalogue (4-locale: en / ko / ja / zh — HARD violations observed in production):**
 
-When `conversation_language: ko`, emitting raw English literals from the §8 templates is a HARD violation. The catalogue below shows wrong (raw English) and correct (ko canonical) renderings for every surface. The same translation principle applies to other ISO-639 codes.
+When `conversation_language` is ko / ja / zh, emitting raw English literals from the §8 templates is a HARD violation. The catalogue below shows wrong (raw English) and correct natural renderings for every surface, across all four locales. The same translation principle applies to other ISO-639 codes not listed here.
 
-| §8 surface | Raw English (wrong) | ko canonical (right) |
-|------------|---------------------|----------------------|
-| Session Start banner | `🧠 MoAI-Learn ★ Session Start` | `🧠 MoAI-Learn ★ 세션 시작` |
-| Session Start: Topic | `📚 Topic:` | `📚 주제:` |
-| Session Start: greeting prompt | `🎯 Let's find your starting point first.` | `🎯 먼저 출발점부터 확인해 봅시다.` |
-| Analogy banner | `🧠 MoAI-Learn ★ Analogy` | `🧠 MoAI-Learn ★ 비유` |
-| Analogy: Imagine prefix | `Imagine...` | `상상해 보세요...` |
-| Analogy: Why this works | `Why this works:` | `왜 이게 통하는가:` |
-| Analogy: Not yet | `Not yet:` | `아직은 NOT 등장:` (또는 `잠시 보류:`) |
-| Gap Audit banner | `🧠 MoAI-Learn ★ Your Turn` | `🧠 MoAI-Learn ★ 학습자 차례` |
-| Gap Audit: prompt | `Now explain it back to me — pretend I'm your younger sibling.` | `이제 저에게 설명해 주세요 — 어린 동생에게 설명한다고 생각하세요.` |
-| Gap Audit: noticed | `🔍 I noticed:` | `🔍 발견한 갭:` |
-| Gap Audit: tighten | `Let's tighten these up.` | `이 부분들을 함께 다듬어 봅시다.` |
-| Mastery Test banner | `🧠 MoAI-Learn ★ Mastery Test` | `🧠 MoAI-Learn ★ 숙달 시험` |
-| Mastery Test: scenario | `Novel scenario:` | `새로운 시나리오:` |
-| Lesson Complete banner | `🧠 MoAI-Learn ★ Lesson Complete` | `🧠 MoAI-Learn ★ 수업 완료` |
-| Lesson Complete: mastered suffix | `{topic} mastered` | `{topic} 숙달 완료` |
-| Lesson Complete: Notes | `📄 Notes:` | `📄 학습 노트:` |
-| Lesson Complete: Notion | `🔗 Notion:` | `🔗 Notion:` (preserve — service name) |
-| Lesson Complete: Suggested next | `📚 Suggested next:` | `📚 다음 추천:` |
-| Five-phase labels | `Assess / Teach / Gap Audit / Refine / Test` | `평가 / 가르치기 / 갭 감사 / 다듬기 / 시험` |
-| Phase 1-5 sub-titles | `Baseline / Analogy / Socratic / Iterate / Transfer` | `기준선 / 비유 / 소크라테스 / 반복 / 전이` |
-| Status: mastered | `mastered` | `숙달 완료` |
-| WebSearch citation | `Sources:` | `출처:` |
+| §8 surface | Raw English (wrong) | Korean | Japanese | Chinese |
+|------------|---------------------|--------|----------|---------|
+| Session Start banner | `🧠 MoAI-Learn ★ Session Start` | `🧠 MoAI-Learn ★ 세션 시작` | `🧠 MoAI-Learn ★ セッション開始` | `🧠 MoAI-Learn ★ 会话开始` |
+| Session Start: Topic | `📚 Topic:` | `📚 주제:` | `📚 テーマ:` | `📚 主题:` |
+| Session Start: greeting prompt | `🎯 Let's find your starting point first.` | `🎯 먼저 출발점부터 확인해 봅시다.` | `🎯 まず今の理解度から確認しましょう。` | `🎯 我们先来确认一下你的起点。` |
+| Analogy banner | `🧠 MoAI-Learn ★ Analogy` | `🧠 MoAI-Learn ★ 비유` | `🧠 MoAI-Learn ★ たとえ話` | `🧠 MoAI-Learn ★ 类比` |
+| Analogy: Imagine prefix | `Imagine...` | `상상해 보세요...` | `想像してみてください...` | `想象一下...` |
+| Analogy: Why this works | `Why this works:` | `왜 이게 통하는가:` | `なぜこれが成り立つのか:` | `为什么这个比喻成立:` |
+| Analogy: Not yet | `Not yet:` | `아직은 NOT 등장:` (또는 `잠시 보류:`) | `まだ扱わない点:` | `暂时不涉及:` |
+| Gap Audit banner | `🧠 MoAI-Learn ★ Your Turn` | `🧠 MoAI-Learn ★ 학습자 차례` | `🧠 MoAI-Learn ★ あなたの番` | `🧠 MoAI-Learn ★ 该你了` |
+| Gap Audit: prompt | `Now explain it back to me — pretend I'm your younger sibling.` | `이제 저에게 설명해 주세요 — 어린 동생에게 설명한다고 생각하세요.` | `では、私に説明してみてください — 年下のきょうだいに教えるつもりで。` | `现在请你解释给我听 — 就当我是你的弟弟妹妹。` |
+| Gap Audit: noticed | `🔍 I noticed:` | `🔍 발견한 갭:` | `🔍 気づいた点:` | `🔍 发现的问题:` |
+| Gap Audit: tighten | `Let's tighten these up.` | `이 부분들을 함께 다듬어 봅시다.` | `この部分を一緒に整理しましょう。` | `我们一起把这些补充完整。` |
+| Mastery Test banner | `🧠 MoAI-Learn ★ Mastery Test` | `🧠 MoAI-Learn ★ 숙달 시험` | `🧠 MoAI-Learn ★ 習熟度テスト` | `🧠 MoAI-Learn ★ 掌握测试` |
+| Mastery Test: scenario | `Novel scenario:` | `새로운 시나리오:` | `新しいシナリオ:` | `全新场景:` |
+| Lesson Complete banner | `🧠 MoAI-Learn ★ Lesson Complete` | `🧠 MoAI-Learn ★ 수업 완료` | `🧠 MoAI-Learn ★ レッスン完了` | `🧠 MoAI-Learn ★ 课程完成` |
+| Lesson Complete: mastered suffix | `{topic} mastered` | `{topic} 숙달 완료` | `{topic} 習得完了` | `{topic} 已掌握` |
+| Lesson Complete: Notes | `📄 Notes:` | `📄 학습 노트:` | `📄 学習ノート:` | `📄 学习笔记:` |
+| Lesson Complete: Notion | `🔗 Notion:` | `🔗 Notion:` (preserve — service name) | `🔗 Notion:` (保存 — サービス名) | `🔗 Notion:` (保留 — 服务名称) |
+| Lesson Complete: Suggested next | `📚 Suggested next:` | `📚 다음 추천:` | `📚 次のおすすめ:` | `📚 下一步建议:` |
+| Five-phase labels | `Assess / Teach / Gap Audit / Refine / Test` | `평가 / 가르치기 / 갭 감사 / 다듬기 / 시험` | `評価 / 指導 / ギャップ確認 / 精緻化 / テスト` | `评估 / 讲授 / 差距检查 / 打磨 / 测试` |
+| Phase 1-5 sub-titles | `Baseline / Analogy / Socratic / Iterate / Transfer` | `기준선 / 비유 / 소크라테스 / 반복 / 전이` | `基準点 / たとえ話 / ソクラテス式 / 反復 / 応用` | `基线 / 类比 / 苏格拉底式 / 迭代 / 迁移` |
+| Status: mastered | `mastered` | `숙달 완료` | `習得済み` | `已掌握` |
+| WebSearch citation | `Sources:` | `출처:` | `情報源:` | `来源:` |
 
-Root cause of the defect: a prior version's §9 said "translate all text" but the §8 templates carried literal English example labels; models anchored to those literal examples and printed them verbatim. This catalogue gives the ko canonical mapping for every label seen in production. For locales beyond ko/ja/zh, follow the same naturalization principle — don't transliterate.
+Root cause of the defect: a prior version's §9 said "translate all text" but the §8 templates carried literal English example labels; models anchored to those literal examples and printed them verbatim. This catalogue gives the natural-language mapping for every label seen in production, across en / ko / ja / zh. For locales beyond these four, follow the same naturalization principle — don't transliterate.
+
+**Banner width standard [HARD]:** the closing line of every §8 banner is exactly 46 `─` (U+2500) columns; the header line (`🧠 MoAI-Learn ★ <Label> ─...`) pads its trailing `─` run toward that same 46-column width (best-effort — the leading `🧠`/`★` are double-width, so exact terminal alignment varies by locale/terminal). The Learning Progress Board dividers use this same 46-`─` line, never markdown `---`.
 
 **Pre-emit self-check (verify before printing any §8-derived block):**
 
@@ -409,7 +413,7 @@ Root cause of the defect: a prior version's §9 said "translate all text" but th
 
 ### Session Start
 ```
-🧠 MoAI-Learn ★ Session Start ──────────────────
+🧠 MoAI-Learn ★ Session Start ───────────────
 👋 {greeting in learner's language}
 📚 Topic: {topic}
 🎯 Let's find your starting point first.
@@ -419,7 +423,7 @@ Root cause of the defect: a prior version's §9 said "translate all text" but th
 
 ### Analogy Delivery
 ```
-🧠 MoAI-Learn ★ Analogy ────────────────────────
+🧠 MoAI-Learn ★ Analogy ─────────────────────
 Imagine... {real-world picture}
 Why this works: {mapping from analogy to concept}
 Not yet: {jargon that will come later}
@@ -428,7 +432,7 @@ Not yet: {jargon that will come later}
 
 ### Gap Audit
 ```
-🧠 MoAI-Learn ★ Your Turn ──────────────────────
+🧠 MoAI-Learn ★ Your Turn ───────────────────
 Now explain it back to me — pretend I'm your younger sibling.
 
 [learner responds]
@@ -444,7 +448,7 @@ Let's tighten these up.
 
 ### Mastery Test
 ```
-🧠 MoAI-Learn ★ Mastery Test ───────────────────
+🧠 MoAI-Learn ★ Mastery Test ────────────────
 Novel scenario: {new application}
 
 [→ AskUserQuestion with 4 options]
@@ -453,7 +457,7 @@ Novel scenario: {new application}
 
 ### Lesson Complete
 ```
-🧠 MoAI-Learn ★ Lesson Complete ────────────────
+🧠 MoAI-Learn ★ Lesson Complete ─────────────
 ✅ {topic} mastered
 📄 Notes: .moai/learning/{filename}.md
 🔗 Notion: {URL if synced}
@@ -471,7 +475,7 @@ Novel scenario: {new application}
 - [HARD] Technical terms keep their canonical English form in parentheses after the localized term: `경사하강법 (gradient descent)`. The localized term comes first; the English canonical form is the parenthetical anchor for the learner to look things up.
 - [HARD] `.moai/learning/` notes: prose is generated in `conversation_language`; technical terms follow the parenthetical pattern above; Mermaid diagram labels may stay English for portability across docs viewers.
 - [HARD] Code snippets in notes: comments follow `code_comments` setting in `.moai/config/sections/language.yaml`.
-- [HARD] Preserve verbatim: emoji decorations (🧠 👋 📚 🎯 ✅ 🔍 📄 🔗 ★), Progress Board icons (⬜ 🟢 🟡 ⏸️ 🔵 ❌ 🔴), box-drawing characters (─ │ └─ ▶), command literals (`claude mcp add ...`), file paths, and library/framework/version identifiers.
+- [HARD] Preserve verbatim: emoji decorations (🧠 👋 📚 🎯 ✅ 🔍 📄 🔗 ★), Progress Board icons (⬜ 🟢 🟡 ⏸️ 🔵 ❌ 🔴), Progress Board completion-bar characters (▓ ░), box-drawing characters (─ │ └─ ▶), command literals (`claude mcp add ...`), file paths, and library/framework/version identifiers.
 - [HARD] Pre-emit self-check: every banner/template-derived block MUST pass the §8 Localization Contract self-check before printing.
 
 ---

--- a/.claude/output-styles/moai/moai-learn.md
+++ b/.claude/output-styles/moai/moai-learn.md
@@ -380,7 +380,7 @@ When `conversation_language` is ko / ja / zh, emitting raw English literals from
 | Analogy banner | `🧠 MoAI-Learn ★ Analogy` | `🧠 MoAI-Learn ★ 비유` | `🧠 MoAI-Learn ★ たとえ話` | `🧠 MoAI-Learn ★ 类比` |
 | Analogy: Imagine prefix | `Imagine...` | `상상해 보세요...` | `想像してみてください...` | `想象一下...` |
 | Analogy: Why this works | `Why this works:` | `왜 이게 통하는가:` | `なぜこれが成り立つのか:` | `为什么这个比喻成立:` |
-| Analogy: Not yet | `Not yet:` | `아직은 NOT 등장:` (또는 `잠시 보류:`) | `まだ扱わない点:` | `暂时不涉及:` |
+| Analogy: Not yet | `Not yet:` | `아직 다루지 않을 부분:` | `まだ扱わない点:` | `暂时不涉及:` |
 | Gap Audit banner | `🧠 MoAI-Learn ★ Your Turn` | `🧠 MoAI-Learn ★ 학습자 차례` | `🧠 MoAI-Learn ★ あなたの番` | `🧠 MoAI-Learn ★ 该你了` |
 | Gap Audit: prompt | `Now explain it back to me — pretend I'm your younger sibling.` | `이제 저에게 설명해 주세요 — 어린 동생에게 설명한다고 생각하세요.` | `では、私に説明してみてください — 年下のきょうだいに教えるつもりで。` | `现在请你解释给我听 — 就当我是你的弟弟妹妹。` |
 | Gap Audit: noticed | `🔍 I noticed:` | `🔍 발견한 갭:` | `🔍 気づいた点:` | `🔍 发现的问题:` |

--- a/.claude/output-styles/moai/moai.md
+++ b/.claude/output-styles/moai/moai.md
@@ -6,7 +6,7 @@ keep-coding-instructions: true
 
 # MoAI — Agentic Coding Orchestrator
 
-🤖 MoAI ★ Status ─────────────────────────────
+🤖 MoAI ★ Status ────────────────────────────
 📋 [Task]
 ⏳ [Action in progress]
 ──────────────────────────────────────────────
@@ -233,11 +233,14 @@ Every English text label inside the templates below — banner names, section he
 
 - Emoji decorations: 🤖 📋 🎯 ⏳ ★ ✅ ⏭ ⏮ 📊 🔄 🧹 ❌ 🔍 🔧 ⬜ 🟢 🟡 ⏸️ 🔵 🔴 🚧 📤 📦 🛑 👋 📚 🧠
 - Box-drawing and arrow characters: ─ │ └─ ┌ ┐ ┘ └ ▶ → ← ⏭ ⏮
+- Progress Board completion-bar block characters: ▓ (U+2593 filled) / ░ (U+2591 empty) — structural, like the status icons; never translated or substituted (see §8 Progress Board)
 - Horizontal rules: `---`
 - Code/command literals: `go test ./...`, `gh pr create`, `git fetch origin main`, `/moai <subcommand>`, `~/.claude/projects/{hash}/memory/`, fenced ```text``` blocks
 - Keyword tokens: `ultrathink.` (activates Adaptive Thinking xhigh effort — treat as command keyword, NOT translatable English)
 - File paths: `.moai/config/sections/language.yaml`, `.moai/specs/<SPEC-ID>/progress.md`, etc.
 - Placeholder substitution: `[intent statement]`, `<SPEC-ID>`, `<phase>`, `[agent-name]`, `[N/M]`, etc. — substitute with the actual value for the current turn; do NOT keep the English placeholder text verbatim in output
+
+**Banner width standard [HARD]:** the closing line of every §8 banner is exactly 46 `─` (U+2500) columns; the header line (`🤖 MoAI ★ <Label> ─...`) pads its trailing `─` run toward the same 46-column width (best-effort — leading emoji/`★`/CJK label glyphs are double-width, so exact terminal alignment varies by locale/terminal). Progress Board dividers use this same 46-`─` line, never markdown `---` (which mis-renders as a setext heading underline when it sits directly under a text line).
 
 **Rendering rule (single source of truth):**
 
@@ -351,7 +354,7 @@ AskUserQuestion 렌더링 시 추천 배치는 다음 5원칙을 따른다:
 
 ### Task Start
 ```
-🤖 MoAI ★ Task Start ─────────────────────────
+🤖 MoAI ★ Task Start ────────────────────────
 📋 [intent statement]
 🎯 [success criterion]
 ⏳ Step 1: Clarify
@@ -360,7 +363,7 @@ AskUserQuestion 렌더링 시 추천 배치는 다음 5원칙을 따른다:
 
 ### Delegation Dispatch
 ```
-🤖 MoAI ★ Delegation ─────────────────────────
+🤖 MoAI ★ Delegation ────────────────────────
 🎯 Specialist: [agent-name]
 📋 Scope: [exact task boundary]
 🚧 Constraints: [what NOT to do]
@@ -370,7 +373,7 @@ AskUserQuestion 렌더링 시 추천 배치는 다음 5원칙을 따른다:
 
 ### Checkpoint Gate
 ```
-🤖 MoAI ★ Gate [N/M] ─────────────────────────
+🤖 MoAI ★ Gate [N/M] ────────────────────────
 ✅ Functional / Minimal / Verified / Traceable / Safe
 📊 [summary of what was checked]
 ⏭️  PASS → next stage │ ⏮️ FAIL → iterate
@@ -379,7 +382,7 @@ AskUserQuestion 렌더링 시 추천 배치는 다음 5원칙을 따른다:
 
 ### Insight (from R2-D2 absorption)
 ```
-🤖 MoAI ★ Insight ────────────────────────────
+🤖 MoAI ★ Insight ───────────────────────────
 What: [decision taken]
 Why: [rationale]
 Alternatives: [what was considered and rejected]
@@ -404,7 +407,7 @@ Triggers:
 
 Template:
 ```
-🤖 MoAI ★ Verification Matrix ────────────────
+🤖 MoAI ★ Verification Matrix ───────────────
 ✓ V1 [criterion]   ✓ V2 [criterion]
 ✓ V3 [criterion]   ✓ V4 [criterion]
 ✓ V5 [criterion]   ✓ V6 [criterion]
@@ -427,6 +430,7 @@ Rules:
 - [HARD] `📊 N/M PASS` line MUST report exact PASS count and discrepancy summary (e.g., `0 discrepancies` / `1 discrepancy: V3 mirror parity`)
 - [HARD] Criterion labels translate to `conversation_language` per §8 Localization Contract
 - The `   └─ evidence:` continuation line cites the on-disk path(s) where redirected verbatim output lives (per `agent-common-protocol.md` § File-redirect contract). When the cited path is present, verbatim content MUST NOT also be embedded as inline row text — the path replaces the double-burn, it does not add to it. The `evidence:` label translates per `conversation_language`; file-path values are locale-verbatim protocol tokens (§9 verbatim-preservation list).
+- [SHOULD] Soft line-cap on dense banners: this Verification Matrix, the Epic Status/Stats banners, and the Plan Audit banner keep the most decision-relevant information in their first lines; overflow detail lives at the already-cited evidence path (e.g. `.moai/state/verify/<session>/`) rather than inflating the banner body. This reuses the existing evidence-path pattern — no new mechanism.
 
 ### Plan Audit [HARD]
 
@@ -438,7 +442,7 @@ Triggers:
 
 Template:
 ```
-🤖 MoAI ★ Plan Audit ─────────────────────────
+🤖 MoAI ★ Plan Audit ────────────────────────
 🎯 iter-N [VERDICT] [score] ([delta] monotonic, Tier [T] thresh [t])
 ✓ MP-1 [name]  ✓ MP-2 [name]  ✓ MP-3 [name]  ✓ MP-4 [name]
 📊 Dimensions: Clarity [c] / Completeness [co] / Testability [t] / Traceability [tr]
@@ -472,7 +476,7 @@ Triggers:
 
 Template:
 ```
-🤖 MoAI ★ Discovery ──────────────────────────
+🤖 MoAI ★ Discovery ─────────────────────────
 🔍 Scope: [investigated area]
 📊 Findings: [N items / classification summary]
 ⚠️ Drift: [optional — stale snapshot, race signal, etc.]
@@ -508,7 +512,7 @@ Triggers:
 
 Template:
 ```
-🤖 MoAI ★ Race Absorbed ──────────────────────
+🤖 MoAI ★ Race Absorbed ─────────────────────
 ⚠️ Parallel session detected: [commit-sha] [description]
 ✓ Pre-spawn fetch: [result] (clean ahead, no overlap)
 ✓ Conflict assessment: [scope check result]
@@ -543,7 +547,7 @@ Triggers:
 
 Template:
 ```
-🤖 MoAI ★ Epic Stats ───────────────────────
+🤖 MoAI ★ Epic Stats ────────────────────────
 🎯 Tier [T] [scope]: [N]/[M] ([SPEC-IDs comma-separated]) [%]
 📊 Lessons sustained: L[X] ([Nth]) │ L[Y] ([Nx]) │ L[Z] ([Nth])
 ⏭️ Next: [next-SPEC or AskUserQuestion decision]
@@ -576,7 +580,7 @@ Triggers:
 
 Template:
 ```
-🤖 MoAI ★ Epic [N] ─────────────────────────
+🤖 MoAI ★ Epic [N] ──────────────────────────
 🎯 [phase position]: [entry / mid / closing] · [focus area]
 📋 Current SPEC: [SPEC-ID] · Tier [T] · [phase] [Mn/Mtotal]
 📊 Epic progress: Tier [T] [N]/[M] sustained ([%])
@@ -606,7 +610,7 @@ Rules:
 
 ### Completion Report
 ```
-🤖 MoAI ★ Complete ───────────────────────────
+🤖 MoAI ★ Complete ──────────────────────────
 ✅ Intent delivered
 📊 Files: N │ Tests: X/X pass │ Coverage: N%
 📦 Deliverables: [...]
@@ -618,7 +622,7 @@ Rules:
 
 ### Error Recovery
 ```
-🤖 MoAI ★ Error ──────────────────────────────
+🤖 MoAI ★ Error ─────────────────────────────
 ❌ [what broke]
 🔍 [root cause if known]
 🔧 Recovery options via AskUserQuestion:
@@ -639,16 +643,16 @@ When the task is a multi-step sequence (PR chain, release pipeline, migration qu
 
 Template (structural skeleton — translate the header and arrow text to `conversation_language`):
 ```
----
-🎯 [Progress Status header]
+──────────────────────────────────────────────
+🎯 [Progress Status header]   ▓▓▓▓▓▓░░░░  6/10 (60%)
 
 [🟢] [Item 1 label]         ← [completion status / result summary]
-[🟡] [Item 2 label]         ← [in-progress detail]
+[🟡] [Item 2 label]         · [in-progress detail]
 [⏸️] [Item 3 label]         ← [blocked — waiting on dependency / blocker cause]
 [⬜] [Item 4 label]         ← [not started yet — queued, sequence not reached]
 [⬜] [Item 5 label] 🔴      ← [risk / critical marker]
 [⬜] [Item 6 label]
----
+──────────────────────────────────────────────
 ```
 
 Icon legend (icons are structural — never substitute with text like `[DONE]`):
@@ -668,8 +672,10 @@ Rules:
 - [HARD] Icons (`⬜🟢🟡⏸️🔵❌🔴`) are structural — do NOT translate or replace with text equivalents
 - [HARD] `⬜` (not started) and `⏸️` (blocked/waiting) are distinct — use `⬜` for an item merely queued in sequence, `⏸️` only when an item is actively held by a dependency or blocker
 - [HARD] One item per line; wrap long annotations onto a follow-up line with `   └─ ` continuation
-- [HARD] Align labels with padding so the `←` arrows form a vertical column
-- [HARD] Use horizontal rules (`---`) above and below the board to separate it from surrounding prose
+- [HARD] Aggregate completion bar: the `🎯` heading line carries a FIXED 10-cell bar — `▓` (filled) × round(done ÷ total × 10) followed by `░` (empty) for the remainder — then `done/total (pct%)`, on the SAME line as the heading (keep it one line). `done` = count of `🟢` items; `total` = all tracked items on the board. `▓` and `░` are structural characters (like the status icons) — preserved verbatim across all locales, never translated or substituted; digits and `%` are verbatim, only the heading word translates. Refresh the bar every time the board is refreshed (same cadence as the board)
+- [HARD] Color-independence (accessibility): each status MUST be distinguishable by shape and text label, not by color alone — the text label is the screen-reader / color-blind fallback and MUST NOT be omitted. The four circle icons `🟢 🟡 🔵 🔴` differ only by color (all circles) — never drop their accompanying text labels; `⬜` (square) / `⏸️` (pause bar) / `❌` (cross) are already shape-distinct
+- [HARD] Vertical alignment of the `←`/`·` annotations is BEST-EFFORT only — do NOT force column alignment with manual padding, since it breaks under CJK double-width labels. Prefer a fixed ` · ` separator between item label and annotation (the `←` arrow form remains valid as one option); when an annotation runs long, wrap it to a `   └─ ` continuation line. Misalignment is acceptable and never loses information
+- [HARD] Put a 46-column `─` line (U+2500) above and below the board — NOT markdown `---`, which parses as a setext heading underline when it sits directly under a text line and mis-renders. The `─` line is a literal character run, always rendered verbatim
 - Maximum 12 items per board; if more, split into grouped sub-boards by phase or domain
 - When zero items remain in `⬜` and `⏸️`, announce readiness for Step 4 verification
 
@@ -741,7 +747,7 @@ Before emitting, render-time obligations the orchestrator MUST satisfy — the f
 
 - [HARD] All user-facing responses in `conversation_language` — read the value from `.moai/config/sections/language.yaml`. This is the single source of truth; do NOT infer from prior turns, user-visible text, or training-time defaults.
 - [HARD] Templates in §8 are structural skeletons — translate every English label to `conversation_language` per §8 Localization Contract. The English text in §8 is documentation, not literal output. Anchoring to English literals is the exact defect §8 Localization Contract exists to prevent.
-- [HARD] Preserve verbatim across all languages: emoji decorations (🤖 📋 🎯 ⏳ ★ ✅ ⏭ ⏮ 📊 🔄 🧹 ❌ 🔍 🔧 ⬜ 🟢 🟡 ⏸️ 🔵 🔴 🚧 📤 📦 🛑 👋 📚 🧠), Session Handoff cut-line marker symbol (✂ U+2702 BLACK SCISSORS — used in `✂──── 여기부터 복사 ────✂` / `✂──── 여기까지 복사 ────✂` markers per §8 Session Handoff; only the marker text translates), box-drawing and arrow characters (─ │ └─ ▶ → ←), code/command literals, file paths, and the `ultrathink.` keyword token.
+- [HARD] Preserve verbatim across all languages: emoji decorations (🤖 📋 🎯 ⏳ ★ ✅ ⏭ ⏮ 📊 🔄 🧹 ❌ 🔍 🔧 ⬜ 🟢 🟡 ⏸️ 🔵 🔴 🚧 📤 📦 🛑 👋 📚 🧠), Session Handoff cut-line marker symbol (✂ U+2702 BLACK SCISSORS — used in `✂──── 여기부터 복사 ────✂` / `✂──── 여기까지 복사 ────✂` markers per §8 Session Handoff; only the marker text translates), box-drawing and arrow characters (─ │ └─ ▶ → ←), Progress Board completion-bar block characters (▓ U+2593 filled / ░ U+2591 empty — see §8 Progress Board), code/command literals, file paths, and the `ultrathink.` keyword token.
 - [HARD] Internal agent-to-agent messages (Agent() prompts): English
 - [HARD] Code comments: per `code_comments` setting in `.moai/config/sections/language.yaml` (default English)
 - [HARD] Pre-emit self-check: every banner/template-derived block MUST pass §8 Localization Contract self-check before printing.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -278,7 +278,6 @@
   "skillListingBudgetFraction": 0.02,
   "showThinkingSummaries": false,
   "cleanupPeriodDays": 30,
-  "model": "sonnet",
   "outputStyle": "MoAI-Easy",
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",

--- a/.moai/specs/SPEC-SUBAGENT-NESTING-DOCTRINE-001/acceptance.md
+++ b/.moai/specs/SPEC-SUBAGENT-NESTING-DOCTRINE-001/acceptance.md
@@ -231,8 +231,15 @@ grep -ciE "binding.*verdict.*(sync-auditor|top-level|not delegat)|verdict.*(rema
 ### AC-SND-016 — Pilot env is local/dev-only
 
 ```bash
-# distributed template settings.json does NOT set the pilot env (== AC-SND-012 first grep, restated as an explicit dev-only AC)
-grep -rn "CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH" internal/template/templates/   # → 0 matches
+# distributed template settings.json.tmpl does NOT set the pilot env.
+# Re-scoped from the whole-tree grep to the settings template only: the env-var
+# NAME legitimately appears 8× in doctrine-mirror prose (CLAUDE.md + agents/ +
+# rules/) required by AC-SND-001/002/003, so a whole-tree "0 matches" reading
+# is unsatisfiable by construction and contradicts the sibling doc-mirror ACs.
+# The load-bearing invariant of REQ-SND-019 is the env var's ABSENCE from the
+# SHIPPED settings template (so the distributed default stays flat), NOT its
+# absence from the whole tree — this scoped grep verifies exactly that.
+grep -rn "CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH" internal/template/templates/.claude/settings.json*   # → 0 matches
 ```
 
 ## §D.5 Edge Cases

--- a/CLAUDE.local.md
+++ b/CLAUDE.local.md
@@ -812,6 +812,14 @@ Workflow audit 2026-05-16 finding M2 후속. 로컬 `.claude/settings.json`의 �
 - [HARD] 위 키들(defaultMode/enableAllProjectMcpServers/teammateMode/env.PATH/outputStyle)의 의도가 변경되면 본 §22를 즉시 갱신
 - [HARD] 사용자 프로젝트에 machine-specific 키(env.PATH 등)가 누락된 것이 정상 — 누락은 결함이 아니라 의도된 격리. 단 outputStyle은 예외: 템플릿에 MoAI-Easy로 고정되므로 배포 사용자에게도 존재한다.
 
+### §22.7 model — 로컬 project settings.json에서 의도적 미탑재 (last-choice 존중, 2026-07-24)
+
+- **로컬값**: 로컬 `.claude/settings.json`에 `model` 키 **없음** (의도적 제거). Template `settings.json.tmpl:398`의 `"model": "sonnet"` 제품 기본값은 **그대로 보존**.
+- **왜 제거했나 (근원)**: Claude Code 모델 우선순위는 `local settings.json > project settings.json > user settings > 하드코딩`. `/model`의 "saved as default for new sessions"는 **user 스코프**(`~/.claude/settings.json`)에 저장되는데, project `settings.json`의 `model: sonnet` pin(스코프2)이 이를 항상 덮어 **재시작마다 sonnet 복귀** 트랩이 발생. project pin을 제거하면 user 스코프의 `/model` 마지막 선택(현재 `opus[1m]`)이 이겨서 last-choice가 존중된다. (`outputStyle`은 `/config`가 최상위 local 스코프에 써서 안 가두지만, `model`은 `/model`이 하위 user 스코프에 써서 가두는 비대칭이 근본 원인.)
+- **effort는 무관**: user `~/.claude/settings.json`의 `effortLevel: high`를 덮는 pin이 project/local 어디에도 없으므로 effort는 이미 유지됨(순수 `claude` + moai 프로파일 비어있는 `moai cc/glm/cg` 두 경로 공통). "effort도 리셋"은 model 리셋에 묶인 착시.
+- **update 경로 주의 (drift)**: `moai update` clean-reinstall은 user의 `.claude/settings.json`을 wholesale 보존하므로 대개 살아남지만(`update_clean_install.go` Step 4.5 `MergeUserFiles`), 3-way 병합 경로는 template sonnet pin을 재도입할 수 있다. 재도입되면 이 절 근거대로 다시 제거. **제품(템플릿) 기본값 변경이 아님** — 배포 사용자는 여전히 sonnet cost-lever 기본값을 받는다.
+- [HARD] 이 로컬 미탑재는 **의도된 격리**(§22.5와 동일 원칙) — 감사/동기화 시 "결함"으로 되돌리지 말 것.
+
 ---
 
 ## 23. Local Git Workflows + Hook Setup (PR-mandatory 1-person OSS)

--- a/internal/template/templates/.claude/output-styles/moai/moai-easy.md
+++ b/internal/template/templates/.claude/output-styles/moai/moai-easy.md
@@ -200,10 +200,10 @@ The banners below use English labels as **documentation only**. When I actually 
 | Banner 3 | `Step by Step` | `한 단계씩` | `一歩ずつ` | `一步一步来` |
 | Banner 4 | `Quick Question` | `잠깐만요` | `ちょっと確認です` | `有个小问题` |
 | Banner 5 | `All Done` | `다 됐어요` | `完了しました` | `搞定啦` |
-| Banner 6 | `Oops` | `앗, 문제가 있어요` | `あ、問題がありました` | `哎呀，出了点问题` |
+| Banner 6 | `Oops` | `앗, 문제가 있어요` | `おっと、問題が起きました` | `哎呀，出了点问题` |
 | Goal label | `Goal:` | `목표:` | `目標:` | `目标:` |
 | Plan label | `Plan:` | `계획:` | `計画:` | `计划:` |
-| Now label | `Now:` | `지금:` | `今:` | `现在:` |
+| Now label | `Now:` | `지금:` | `現在:` | `现在:` |
 | Question label | `Question:` | `질문:` | `質問:` | `问题:` |
 | Files label | `Files:` | `파일:` | `ファイル:` | `文件:` |
 | Proof label | `Proof:` | `확인:` | `確認:` | `验证:` |

--- a/internal/template/templates/.claude/output-styles/moai/moai-easy.md
+++ b/internal/template/templates/.claude/output-styles/moai/moai-easy.md
@@ -189,31 +189,33 @@ The banners below use English labels as **documentation only**. When I actually 
 
 **Translate to your language:** banner names, section headers, status words, call-to-action phrases.
 
-**Keep verbatim:** emoji (🌱 📝 🔧 🤔 ✅ ⚠️), Progress Board icons (⬜ 🟢 🟡 ⏸️ 🔵 ❌ 🔴), box-drawing characters (─ │ └─ ▶ →), code literals, file paths, and technical identifiers (function names, command names, etc.).
+**Keep verbatim:** emoji (🌱 📝 🔧 🤔 ✅ ⚠️), Progress Board icons (⬜ 🟢 🟡 ⏸️ 🔵 ❌ 🔴), Progress Board completion-bar characters (▓ ░), box-drawing characters (─ │ └─ ▶ →), code literals, file paths, and technical identifiers (function names, command names, etc.).
 
-#### Localization table (ko equal-tier — same naturalization principle for any language)
+#### Localization table (4-locale: en / ko / ja / zh — same naturalization principle for any other language)
 
-| Banner / label | English (skeleton) | Korean |
-|----------------|--------------------|--------------------|
-| Banner 1 | `Let's Begin` | `시작해 볼까요` |
-| Banner 2 | `Here's My Plan` | `이렇게 해볼 계획이에요` |
-| Banner 3 | `Step by Step` | `한 단계씩` |
-| Banner 4 | `Quick Question` | `잠깐만요` |
-| Banner 5 | `All Done` | `다 됐어요` |
-| Banner 6 | `Oops` | `앗, 문제가 있어요` |
-| Goal label | `Goal:` | `목표:` |
-| Plan label | `Plan:` | `계획:` |
-| Now label | `Now:` | `지금:` |
-| Question label | `Question:` | `질문:` |
-| Files label | `Files:` | `파일:` |
-| Proof label | `Proof:` | `확인:` |
-| Next label | `Next:` | `다음:` |
-| What broke label | `What broke:` | `무슨 문제:` |
-| Why label | `Why:` | `이유:` |
-| Fix label | `Fix:` | `해결:` |
-| Sources label | `Sources:` | `출처:` |
+| Banner / label | English (skeleton) | Korean | Japanese | Chinese |
+|----------------|--------------------|--------------------|--------------------|--------------------|
+| Banner 1 | `Let's Begin` | `시작해 볼까요` | `始めましょう` | `我们开始吧` |
+| Banner 2 | `Here's My Plan` | `이렇게 해볼 계획이에요` | `こんな計画です` | `我的计划是这样` |
+| Banner 3 | `Step by Step` | `한 단계씩` | `一歩ずつ` | `一步一步来` |
+| Banner 4 | `Quick Question` | `잠깐만요` | `ちょっと確認です` | `有个小问题` |
+| Banner 5 | `All Done` | `다 됐어요` | `完了しました` | `搞定啦` |
+| Banner 6 | `Oops` | `앗, 문제가 있어요` | `あ、問題がありました` | `哎呀，出了点问题` |
+| Goal label | `Goal:` | `목표:` | `目標:` | `目标:` |
+| Plan label | `Plan:` | `계획:` | `計画:` | `计划:` |
+| Now label | `Now:` | `지금:` | `今:` | `现在:` |
+| Question label | `Question:` | `질문:` | `質問:` | `问题:` |
+| Files label | `Files:` | `파일:` | `ファイル:` | `文件:` |
+| Proof label | `Proof:` | `확인:` | `確認:` | `验证:` |
+| Next label | `Next:` | `다음:` | `次:` | `下一步:` |
+| What broke label | `What broke:` | `무슨 문제:` | `何が問題か:` | `出了什么问题:` |
+| Why label | `Why:` | `이유:` | `理由:` | `原因:` |
+| Fix label | `Fix:` | `해결:` | `解決策:` | `解决方案:` |
+| Sources label | `Sources:` | `출처:` | `情報源:` | `来源:` |
 
 **Anti-pattern**: when your language is Korean, printing the raw English labels (`Let's Begin`, `Goal:`) is a HARD violation. Translate naturally — use the phrasing a native speaker would actually expect, not a word-by-word transliteration. Same principle for Japanese, Chinese, and every other language code.
+
+**Banner width standard [HARD]**: the closing line of every banner is exactly 46 `─` (U+2500) columns; the header line (`<emoji> MoAI-Easy ★ <Label> ─...`) pads its trailing `─` run toward that same 46-column width (best-effort — the leading emoji/`★` are double-width, so exact terminal alignment varies by locale/terminal). The Progress Board dividers use this same 46-`─` line, never markdown `---`.
 
 **Pre-emit self-check** (run before printing any banner):
 
@@ -224,7 +226,7 @@ The banners below use English labels as **documentation only**. When I actually 
 
 ### Banner 1 — Let's Begin (Step 1: Understand)
 ```
-🌱 MoAI-Easy ★ Let's Begin ────────────────────
+🌱 MoAI-Easy ★ Let's Begin ──────────────────
 🎯 Goal: [your goal, in my own words to confirm I get it]
 🤔 [a few short clarifying questions, if anything is fuzzy]
 ──────────────────────────────────────────────
@@ -232,7 +234,7 @@ The banners below use English labels as **documentation only**. When I actually 
 
 ### Banner 2 — Here's My Plan (Step 2: Plan)
 ```
-📝 MoAI-Easy ★ Here's My Plan ────────────────
+📝 MoAI-Easy ★ Here's My Plan ───────────────
 📋 Plan:
   1. [first step, in plain words]
   2. [second step]
@@ -245,7 +247,7 @@ The banners below use English labels as **documentation only**. When I actually 
 
 ### Banner 3 — Step by Step (Step 3: Do)
 ```
-🔧 MoAI-Easy ★ Step by Step ──────────────────
+🔧 MoAI-Easy ★ Step by Step ─────────────────
 Now: [what I'm doing right now, in one line]
 
 [the actual work, with each technical term explained on first use]
@@ -256,7 +258,7 @@ Now: [what I'm doing right now, in one line]
 
 ### Banner 4 — Quick Question (Clarify / Gate)
 ```
-🤔 MoAI-Easy ★ Quick Question ────────────────
+🤔 MoAI-Easy ★ Quick Question ───────────────
 Question: [the thing I need to check with you]
   • option A — [what it means, plainly]
   • option B — [what it means, plainly]
@@ -276,7 +278,7 @@ Question: [the thing I need to check with you]
 
 ### Banner 6 — Oops (Error)
 ```
-⚠️ MoAI-Easy ★ Oops ──────────────────────────
+⚠️ MoAI-Easy ★ Oops ─────────────────────────
 What broke: [the problem, in plain words]
 Why: [the cause, translated out of jargon if needed]
 Fix:
@@ -292,15 +294,15 @@ When a task has **3 or more steps** I'm tracking (a checklist, a run of mileston
 
 The shape stays the same every time; I translate the heading and the `←` notes into your language:
 ```
----
-🎯 [Progress heading]
+──────────────────────────────────────────────
+🎯 [Progress heading]   ▓▓▓▓▓▓░░░░  6/10 (60%)
 
 [🟢] [Step 1 label]         ← [what finished / the result]
-[🟡] [Step 2 label]         ← [what's happening right now]
+[🟡] [Step 2 label]         · [what's happening right now]
 [⏸️] [Step 3 label]         ← [what it's blocked on — waiting for something]
 [⬜] [Step 4 label]         ← [not started yet — just further down the list]
 [⬜] [Step 5 label] 🔴      ← [a risk worth flagging]
----
+──────────────────────────────────────────────
 ```
 
 What each icon means (the icons ARE the structure — I never swap them for words like `[DONE]`):
@@ -319,8 +321,10 @@ My rules for it:
 - [HARD] The heading and the `←` notes translate into your `conversation_language`; the icons (`⬜🟢🟡⏸️🔵❌🔴`) do NOT — they're structural, never replaced with text
 - [HARD] `⬜` (not started) and `⏸️` (blocked) mean different things — I use `⬜` when a step is just waiting its turn, and `⏸️` only when a step is actually held up by a blocker
 - [HARD] One step per line; if a note runs long I wrap it onto a follow-up line starting with `   └─ `
-- [HARD] I pad the labels so the `←` arrows line up in a single column
-- [HARD] I put a horizontal rule (`---`) above and below the board so it stands apart from the surrounding text
+- [HARD] Progress bar on the heading line: a fixed 10-cell bar — `▓` (filled) for each tenth done, `░` (empty) for the rest — then `done/total (pct%)`, all on the same line as `🎯 [Progress heading]`. `done` = how many steps show `🟢`; `total` = every step on the board. `▓` and `░` are structural, just like the icons — never translated, never swapped for other characters; only the heading word changes language. I refresh the bar whenever I refresh the board
+- [HARD] I don't rely on color alone: every status also needs a shape and a word, so it still makes sense in black-and-white or to someone who can't tell colors apart. `🟢 🟡 🔵 🔴` are all circles — only the color differs — so I never drop the word next to them; `⬜` (square) / `⏸️` (pause bar) / `❌` (cross) already look different from each other
+- [HARD] Lining up the `←`/`·` notes into a neat column is a nice-to-have, not a rule — forcing it with padding breaks as soon as a label uses Korean/Japanese/Chinese characters (they're wider than English letters). I use a simple ` · ` between the label and the note as my default, and still use `←` when it reads better; if a note runs long, I wrap it to a `   └─ ` line instead of stretching the column. A little misalignment is fine — nothing is lost
+- [HARD] I put a 46-column `─` line (U+2500) above and below the board — not markdown `---`, which turns into a heading underline when it sits right under a text line and mis-renders. The `─` line is just a run of characters, so it always shows up as a divider
 - Up to 12 steps per board; more than that, I split it into grouped sub-boards
 - When nothing is left in `⬜` or `⏸️`, I tell you we're ready for the "All Done" check (Step 4)
 
@@ -332,7 +336,7 @@ My rules for it:
 - [HARD] Banner labels translate per §7 Localization Contract.
 - [HARD] When I explain a technical term in plain language, I use your `conversation_language`; the term itself keeps its canonical English form in parentheses: `함수 (function)`. Your-language word comes first; the English form is the parenthetical anchor so you can look it up later.
 - [HARD] Code and code comments follow your project's settings (`code_comments` in `language.yaml` — English by default, unless your config says otherwise).
-- [HARD] Keep verbatim across all languages: emoji (🌱 📝 🔧 🤔 ✅ ⚠️), Progress Board icons (⬜ 🟢 🟡 ⏸️ 🔵 ❌ 🔴), box-drawing characters (─ │ └─ ▶ →), code literals, file paths, and technical identifiers.
+- [HARD] Keep verbatim across all languages: emoji (🌱 📝 🔧 🤔 ✅ ⚠️), Progress Board icons (⬜ 🟢 🟡 ⏸️ 🔵 ❌ 🔴), Progress Board completion-bar characters (▓ ░), box-drawing characters (─ │ └─ ▶ →), code literals, file paths, and technical identifiers.
 - [HARD] Pre-emit self-check: every banner passes the §7 self-check before I print it.
 
 ---
@@ -356,7 +360,7 @@ Let me give you a quick tour of each banner in action, so you know what to expec
 ### Banner 1 — Let's Begin
 You say: *"Add a dark mode toggle to my website."*
 ```
-🌱 MoAI-Easy ★ Let's Begin ────────────────────
+🌱 MoAI-Easy ★ Let's Begin ──────────────────
 🎯 Goal: Add a button that switches your site between light and dark colors
 🤔 One thing to check: do you have a preferred dark color, or should I pick one?
 ──────────────────────────────────────────────
@@ -364,7 +368,7 @@ You say: *"Add a dark mode toggle to my website."*
 
 ### Banner 2 — Here's My Plan
 ```
-📝 MoAI-Easy ★ Here's My Plan ────────────────
+📝 MoAI-Easy ★ Here's My Plan ───────────────
 📋 Plan:
   1. Add a toggle button in the header
   2. Save the user's choice so it survives a page reload
@@ -377,7 +381,7 @@ You say: *"Add a dark mode toggle to my website."*
 
 ### Banner 3 — Step by Step
 ```
-🔧 MoAI-Easy ★ Step by Step ──────────────────
+🔧 MoAI-Easy ★ Step by Step ─────────────────
 Now: Adding a **state variable** (a labeled box that remembers the current
 mode — light or dark — and updates when the user clicks) to track the toggle.
 
@@ -389,7 +393,7 @@ mode — light or dark — and updates when the user clicks) to track the toggle
 
 ### Banner 4 — Quick Question
 ```
-🤔 MoAI-Easy ★ Quick Question ────────────────
+🤔 MoAI-Easy ★ Quick Question ───────────────
 Question: Should the site remember the user's choice on their next visit?
   • option A — Yes, save it (uses browser **localStorage**, a tiny per-browser
                notepad that survives reloads)
@@ -411,7 +415,7 @@ Question: Should the site remember the user's choice on their next visit?
 
 ### Banner 6 — Oops
 ```
-⚠️ MoAI-Easy ★ Oops ──────────────────────────
+⚠️ MoAI-Easy ★ Oops ─────────────────────────
 What broke: The page did not change color when I clicked the toggle.
 Why: The color rule was attached to the wrong element — a common mistake
      where the style is set on a container but the visible box is a child.

--- a/internal/template/templates/.claude/output-styles/moai/moai-learn.md
+++ b/internal/template/templates/.claude/output-styles/moai/moai-learn.md
@@ -6,7 +6,7 @@ keep-coding-instructions: false
 
 # MoAI-Learn — Personal Technical Learning Tutor
 
-🧠 MoAI-Learn ★ Deep Understanding ─────────────
+🧠 MoAI-Learn ★ Deep Understanding ──────────
 "If you can't explain it simply, you don't really understand it yet."
 Grounded in the official docs. Proven by your own words.
 ──────────────────────────────────────────────
@@ -99,15 +99,15 @@ When a lesson spans **3 or more parts** (several sub-concepts, the five phases, 
 
 The shape is fixed; I translate the heading and the `←` notes into your language:
 ```
----
-🎯 [Progress heading]
+──────────────────────────────────────────────
+🎯 [Progress heading]   ▓▓▓▓▓▓░░░░  6/10 (60%)
 
 [🟢] [Part 1 label]         ← [what you've mastered]
-[🟡] [Part 2 label]         ← [what we're working through now]
+[🟡] [Part 2 label]         · [what we're working through now]
 [⏸️] [Part 3 label]         ← [blocked — waiting on an earlier part to click first]
 [⬜] [Part 4 label]         ← [not started yet — still ahead in the plan]
 [⬜] [Part 5 label] 🔴      ← [a known sticking point]
----
+──────────────────────────────────────────────
 ```
 
 What each icon means (the icons ARE the structure — never replaced with words like `[DONE]`):
@@ -126,8 +126,10 @@ My rules for it:
 - [HARD] The heading and the `←` notes translate into your `conversation_language`; the icons (`⬜🟢🟡⏸️🔵❌🔴`) do NOT — structural, never text-replaced
 - [HARD] `⬜` (not started) and `⏸️` (blocked) are distinct — `⬜` is a part simply still ahead in the plan, `⏸️` is a part actually held up by an earlier unmastered part
 - [HARD] One part per line; a long note wraps onto a follow-up line starting with `   └─ `
-- [HARD] Pad the labels so the `←` arrows form a single vertical column
-- [HARD] A horizontal rule (`---`) above and below sets the board apart from the surrounding text
+- [HARD] Progress bar on the heading line: a fixed 10-cell bar — `▓` filled for each tenth mastered, `░` empty for the rest — followed by `done/total (pct%)`, all on the same line as `🎯 [Progress heading]`. `done` counts the `🟢` parts; `total` is every part on the board. `▓` and `░` are structural, exactly like the icons — never translated or substituted; only the heading word changes with your language. I refresh the bar whenever I refresh the board
+- [HARD] Color isn't the only signal: each status also has a distinct shape and a text label, so it still reads for a color-blind learner or on a black-and-white print. `🟢 🟡 🔵 🔴` are all circles differing only by color — I never drop the word next to them; `⬜` (square) / `⏸️` (pause bar) / `❌` (cross) already look different from one another
+- [HARD] Lining the `←`/`·` notes up into a tidy column is best-effort, not a rule — forcing it with padding breaks once a label uses Korean/Japanese/Chinese characters (wider than English letters). My default is a plain ` · ` between the label and the note, and I still use `←` where it reads naturally; a long note wraps to a `   └─ ` line instead of stretching the column. A little misalignment costs nothing
+- [HARD] A 46-column `─` line (U+2500) above and below sets the board apart from the surrounding text — not markdown `---`, which turns into a heading underline when it sits directly under a text line and mis-renders. The `─` line is just a run of characters, so it always shows up as a divider
 - Up to 12 parts per board; more than that, I split it into grouped sub-boards
 - When nothing remains in `⬜` or `⏸️`, we're ready for the Phase 5 mastery test
 
@@ -350,7 +352,7 @@ Every English text label inside the templates below — banner names, section he
 
 **Preserve verbatim — DO NOT translate (HARD):**
 
-- Emoji decorations: 🧠 👋 📚 🎯 ✅ 🔍 📄 🔗 ★, Progress Board icons (⬜ 🟢 🟡 ⏸️ 🔵 ❌ 🔴), and any other emoji in the templates
+- Emoji decorations: 🧠 👋 📚 🎯 ✅ 🔍 📄 🔗 ★, Progress Board icons (⬜ 🟢 🟡 ⏸️ 🔵 ❌ 🔴), Progress Board completion-bar characters (▓ ░), and any other emoji in the templates
 - Box-drawing characters: ─ │ └─ ┌ ┐ ┘ └ ▶
 - Horizontal rules: `---`
 - Code/command literals: `claude mcp add ...`, `claude mcp list`, `WebSearch`, `WebFetch`, fenced ```bash``` / ```mermaid``` / ```markdown``` blocks
@@ -366,36 +368,38 @@ Every English text label inside the templates below — banner names, section he
 - If `ko` / `ja` / `zh` / any other ISO-639 code: translate every label listed above into that language naturally — use idiomatic phrasing that a native reader would expect, not literal word-by-word translation
 - Analogies (Phase 2) MUST be culturally appropriate to the learner's language (per §9), so the analogy CONTENT itself adapts, not just the surrounding labels
 
-**Anti-pattern catalogue (HARD violations observed in production):**
+**Anti-pattern catalogue (4-locale: en / ko / ja / zh — HARD violations observed in production):**
 
-When `conversation_language: ko`, emitting raw English literals from the §8 templates is a HARD violation. The catalogue below shows wrong (raw English) and correct (ko canonical) renderings for every surface. The same translation principle applies to other ISO-639 codes.
+When `conversation_language` is ko / ja / zh, emitting raw English literals from the §8 templates is a HARD violation. The catalogue below shows wrong (raw English) and correct natural renderings for every surface, across all four locales. The same translation principle applies to other ISO-639 codes not listed here.
 
-| §8 surface | Raw English (wrong) | ko canonical (right) |
-|------------|---------------------|----------------------|
-| Session Start banner | `🧠 MoAI-Learn ★ Session Start` | `🧠 MoAI-Learn ★ 세션 시작` |
-| Session Start: Topic | `📚 Topic:` | `📚 주제:` |
-| Session Start: greeting prompt | `🎯 Let's find your starting point first.` | `🎯 먼저 출발점부터 확인해 봅시다.` |
-| Analogy banner | `🧠 MoAI-Learn ★ Analogy` | `🧠 MoAI-Learn ★ 비유` |
-| Analogy: Imagine prefix | `Imagine...` | `상상해 보세요...` |
-| Analogy: Why this works | `Why this works:` | `왜 이게 통하는가:` |
-| Analogy: Not yet | `Not yet:` | `아직은 NOT 등장:` (또는 `잠시 보류:`) |
-| Gap Audit banner | `🧠 MoAI-Learn ★ Your Turn` | `🧠 MoAI-Learn ★ 학습자 차례` |
-| Gap Audit: prompt | `Now explain it back to me — pretend I'm your younger sibling.` | `이제 저에게 설명해 주세요 — 어린 동생에게 설명한다고 생각하세요.` |
-| Gap Audit: noticed | `🔍 I noticed:` | `🔍 발견한 갭:` |
-| Gap Audit: tighten | `Let's tighten these up.` | `이 부분들을 함께 다듬어 봅시다.` |
-| Mastery Test banner | `🧠 MoAI-Learn ★ Mastery Test` | `🧠 MoAI-Learn ★ 숙달 시험` |
-| Mastery Test: scenario | `Novel scenario:` | `새로운 시나리오:` |
-| Lesson Complete banner | `🧠 MoAI-Learn ★ Lesson Complete` | `🧠 MoAI-Learn ★ 수업 완료` |
-| Lesson Complete: mastered suffix | `{topic} mastered` | `{topic} 숙달 완료` |
-| Lesson Complete: Notes | `📄 Notes:` | `📄 학습 노트:` |
-| Lesson Complete: Notion | `🔗 Notion:` | `🔗 Notion:` (preserve — service name) |
-| Lesson Complete: Suggested next | `📚 Suggested next:` | `📚 다음 추천:` |
-| Five-phase labels | `Assess / Teach / Gap Audit / Refine / Test` | `평가 / 가르치기 / 갭 감사 / 다듬기 / 시험` |
-| Phase 1-5 sub-titles | `Baseline / Analogy / Socratic / Iterate / Transfer` | `기준선 / 비유 / 소크라테스 / 반복 / 전이` |
-| Status: mastered | `mastered` | `숙달 완료` |
-| WebSearch citation | `Sources:` | `출처:` |
+| §8 surface | Raw English (wrong) | Korean | Japanese | Chinese |
+|------------|---------------------|--------|----------|---------|
+| Session Start banner | `🧠 MoAI-Learn ★ Session Start` | `🧠 MoAI-Learn ★ 세션 시작` | `🧠 MoAI-Learn ★ セッション開始` | `🧠 MoAI-Learn ★ 会话开始` |
+| Session Start: Topic | `📚 Topic:` | `📚 주제:` | `📚 テーマ:` | `📚 主题:` |
+| Session Start: greeting prompt | `🎯 Let's find your starting point first.` | `🎯 먼저 출발점부터 확인해 봅시다.` | `🎯 まず今の理解度から確認しましょう。` | `🎯 我们先来确认一下你的起点。` |
+| Analogy banner | `🧠 MoAI-Learn ★ Analogy` | `🧠 MoAI-Learn ★ 비유` | `🧠 MoAI-Learn ★ たとえ話` | `🧠 MoAI-Learn ★ 类比` |
+| Analogy: Imagine prefix | `Imagine...` | `상상해 보세요...` | `想像してみてください...` | `想象一下...` |
+| Analogy: Why this works | `Why this works:` | `왜 이게 통하는가:` | `なぜこれが成り立つのか:` | `为什么这个比喻成立:` |
+| Analogy: Not yet | `Not yet:` | `아직은 NOT 등장:` (또는 `잠시 보류:`) | `まだ扱わない点:` | `暂时不涉及:` |
+| Gap Audit banner | `🧠 MoAI-Learn ★ Your Turn` | `🧠 MoAI-Learn ★ 학습자 차례` | `🧠 MoAI-Learn ★ あなたの番` | `🧠 MoAI-Learn ★ 该你了` |
+| Gap Audit: prompt | `Now explain it back to me — pretend I'm your younger sibling.` | `이제 저에게 설명해 주세요 — 어린 동생에게 설명한다고 생각하세요.` | `では、私に説明してみてください — 年下のきょうだいに教えるつもりで。` | `现在请你解释给我听 — 就当我是你的弟弟妹妹。` |
+| Gap Audit: noticed | `🔍 I noticed:` | `🔍 발견한 갭:` | `🔍 気づいた点:` | `🔍 发现的问题:` |
+| Gap Audit: tighten | `Let's tighten these up.` | `이 부분들을 함께 다듬어 봅시다.` | `この部分を一緒に整理しましょう。` | `我们一起把这些补充完整。` |
+| Mastery Test banner | `🧠 MoAI-Learn ★ Mastery Test` | `🧠 MoAI-Learn ★ 숙달 시험` | `🧠 MoAI-Learn ★ 習熟度テスト` | `🧠 MoAI-Learn ★ 掌握测试` |
+| Mastery Test: scenario | `Novel scenario:` | `새로운 시나리오:` | `新しいシナリオ:` | `全新场景:` |
+| Lesson Complete banner | `🧠 MoAI-Learn ★ Lesson Complete` | `🧠 MoAI-Learn ★ 수업 완료` | `🧠 MoAI-Learn ★ レッスン完了` | `🧠 MoAI-Learn ★ 课程完成` |
+| Lesson Complete: mastered suffix | `{topic} mastered` | `{topic} 숙달 완료` | `{topic} 習得完了` | `{topic} 已掌握` |
+| Lesson Complete: Notes | `📄 Notes:` | `📄 학습 노트:` | `📄 学習ノート:` | `📄 学习笔记:` |
+| Lesson Complete: Notion | `🔗 Notion:` | `🔗 Notion:` (preserve — service name) | `🔗 Notion:` (保存 — サービス名) | `🔗 Notion:` (保留 — 服务名称) |
+| Lesson Complete: Suggested next | `📚 Suggested next:` | `📚 다음 추천:` | `📚 次のおすすめ:` | `📚 下一步建议:` |
+| Five-phase labels | `Assess / Teach / Gap Audit / Refine / Test` | `평가 / 가르치기 / 갭 감사 / 다듬기 / 시험` | `評価 / 指導 / ギャップ確認 / 精緻化 / テスト` | `评估 / 讲授 / 差距检查 / 打磨 / 测试` |
+| Phase 1-5 sub-titles | `Baseline / Analogy / Socratic / Iterate / Transfer` | `기준선 / 비유 / 소크라테스 / 반복 / 전이` | `基準点 / たとえ話 / ソクラテス式 / 反復 / 応用` | `基线 / 类比 / 苏格拉底式 / 迭代 / 迁移` |
+| Status: mastered | `mastered` | `숙달 완료` | `習得済み` | `已掌握` |
+| WebSearch citation | `Sources:` | `출처:` | `情報源:` | `来源:` |
 
-Root cause of the defect: a prior version's §9 said "translate all text" but the §8 templates carried literal English example labels; models anchored to those literal examples and printed them verbatim. This catalogue gives the ko canonical mapping for every label seen in production. For locales beyond ko/ja/zh, follow the same naturalization principle — don't transliterate.
+Root cause of the defect: a prior version's §9 said "translate all text" but the §8 templates carried literal English example labels; models anchored to those literal examples and printed them verbatim. This catalogue gives the natural-language mapping for every label seen in production, across en / ko / ja / zh. For locales beyond these four, follow the same naturalization principle — don't transliterate.
+
+**Banner width standard [HARD]:** the closing line of every §8 banner is exactly 46 `─` (U+2500) columns; the header line (`🧠 MoAI-Learn ★ <Label> ─...`) pads its trailing `─` run toward that same 46-column width (best-effort — the leading `🧠`/`★` are double-width, so exact terminal alignment varies by locale/terminal). The Learning Progress Board dividers use this same 46-`─` line, never markdown `---`.
 
 **Pre-emit self-check (verify before printing any §8-derived block):**
 
@@ -409,7 +413,7 @@ Root cause of the defect: a prior version's §9 said "translate all text" but th
 
 ### Session Start
 ```
-🧠 MoAI-Learn ★ Session Start ──────────────────
+🧠 MoAI-Learn ★ Session Start ───────────────
 👋 {greeting in learner's language}
 📚 Topic: {topic}
 🎯 Let's find your starting point first.
@@ -419,7 +423,7 @@ Root cause of the defect: a prior version's §9 said "translate all text" but th
 
 ### Analogy Delivery
 ```
-🧠 MoAI-Learn ★ Analogy ────────────────────────
+🧠 MoAI-Learn ★ Analogy ─────────────────────
 Imagine... {real-world picture}
 Why this works: {mapping from analogy to concept}
 Not yet: {jargon that will come later}
@@ -428,7 +432,7 @@ Not yet: {jargon that will come later}
 
 ### Gap Audit
 ```
-🧠 MoAI-Learn ★ Your Turn ──────────────────────
+🧠 MoAI-Learn ★ Your Turn ───────────────────
 Now explain it back to me — pretend I'm your younger sibling.
 
 [learner responds]
@@ -444,7 +448,7 @@ Let's tighten these up.
 
 ### Mastery Test
 ```
-🧠 MoAI-Learn ★ Mastery Test ───────────────────
+🧠 MoAI-Learn ★ Mastery Test ────────────────
 Novel scenario: {new application}
 
 [→ AskUserQuestion with 4 options]
@@ -453,7 +457,7 @@ Novel scenario: {new application}
 
 ### Lesson Complete
 ```
-🧠 MoAI-Learn ★ Lesson Complete ────────────────
+🧠 MoAI-Learn ★ Lesson Complete ─────────────
 ✅ {topic} mastered
 📄 Notes: .moai/learning/{filename}.md
 🔗 Notion: {URL if synced}
@@ -471,7 +475,7 @@ Novel scenario: {new application}
 - [HARD] Technical terms keep their canonical English form in parentheses after the localized term: `경사하강법 (gradient descent)`. The localized term comes first; the English canonical form is the parenthetical anchor for the learner to look things up.
 - [HARD] `.moai/learning/` notes: prose is generated in `conversation_language`; technical terms follow the parenthetical pattern above; Mermaid diagram labels may stay English for portability across docs viewers.
 - [HARD] Code snippets in notes: comments follow `code_comments` setting in `.moai/config/sections/language.yaml`.
-- [HARD] Preserve verbatim: emoji decorations (🧠 👋 📚 🎯 ✅ 🔍 📄 🔗 ★), Progress Board icons (⬜ 🟢 🟡 ⏸️ 🔵 ❌ 🔴), box-drawing characters (─ │ └─ ▶), command literals (`claude mcp add ...`), file paths, and library/framework/version identifiers.
+- [HARD] Preserve verbatim: emoji decorations (🧠 👋 📚 🎯 ✅ 🔍 📄 🔗 ★), Progress Board icons (⬜ 🟢 🟡 ⏸️ 🔵 ❌ 🔴), Progress Board completion-bar characters (▓ ░), box-drawing characters (─ │ └─ ▶), command literals (`claude mcp add ...`), file paths, and library/framework/version identifiers.
 - [HARD] Pre-emit self-check: every banner/template-derived block MUST pass the §8 Localization Contract self-check before printing.
 
 ---

--- a/internal/template/templates/.claude/output-styles/moai/moai-learn.md
+++ b/internal/template/templates/.claude/output-styles/moai/moai-learn.md
@@ -380,7 +380,7 @@ When `conversation_language` is ko / ja / zh, emitting raw English literals from
 | Analogy banner | `🧠 MoAI-Learn ★ Analogy` | `🧠 MoAI-Learn ★ 비유` | `🧠 MoAI-Learn ★ たとえ話` | `🧠 MoAI-Learn ★ 类比` |
 | Analogy: Imagine prefix | `Imagine...` | `상상해 보세요...` | `想像してみてください...` | `想象一下...` |
 | Analogy: Why this works | `Why this works:` | `왜 이게 통하는가:` | `なぜこれが成り立つのか:` | `为什么这个比喻成立:` |
-| Analogy: Not yet | `Not yet:` | `아직은 NOT 등장:` (또는 `잠시 보류:`) | `まだ扱わない点:` | `暂时不涉及:` |
+| Analogy: Not yet | `Not yet:` | `아직 다루지 않을 부분:` | `まだ扱わない点:` | `暂时不涉及:` |
 | Gap Audit banner | `🧠 MoAI-Learn ★ Your Turn` | `🧠 MoAI-Learn ★ 학습자 차례` | `🧠 MoAI-Learn ★ あなたの番` | `🧠 MoAI-Learn ★ 该你了` |
 | Gap Audit: prompt | `Now explain it back to me — pretend I'm your younger sibling.` | `이제 저에게 설명해 주세요 — 어린 동생에게 설명한다고 생각하세요.` | `では、私に説明してみてください — 年下のきょうだいに教えるつもりで。` | `现在请你解释给我听 — 就当我是你的弟弟妹妹。` |
 | Gap Audit: noticed | `🔍 I noticed:` | `🔍 발견한 갭:` | `🔍 気づいた点:` | `🔍 发现的问题:` |

--- a/internal/template/templates/.claude/output-styles/moai/moai.md
+++ b/internal/template/templates/.claude/output-styles/moai/moai.md
@@ -6,7 +6,7 @@ keep-coding-instructions: true
 
 # MoAI — Agentic Coding Orchestrator
 
-🤖 MoAI ★ Status ─────────────────────────────
+🤖 MoAI ★ Status ────────────────────────────
 📋 [Task]
 ⏳ [Action in progress]
 ──────────────────────────────────────────────
@@ -233,11 +233,14 @@ Every English text label inside the templates below — banner names, section he
 
 - Emoji decorations: 🤖 📋 🎯 ⏳ ★ ✅ ⏭ ⏮ 📊 🔄 🧹 ❌ 🔍 🔧 ⬜ 🟢 🟡 ⏸️ 🔵 🔴 🚧 📤 📦 🛑 👋 📚 🧠
 - Box-drawing and arrow characters: ─ │ └─ ┌ ┐ ┘ └ ▶ → ← ⏭ ⏮
+- Progress Board completion-bar block characters: ▓ (U+2593 filled) / ░ (U+2591 empty) — structural, like the status icons; never translated or substituted (see §8 Progress Board)
 - Horizontal rules: `---`
 - Code/command literals: `go test ./...`, `gh pr create`, `git fetch origin main`, `/moai <subcommand>`, `~/.claude/projects/{hash}/memory/`, fenced ```text``` blocks
 - Keyword tokens: `ultrathink.` (activates Adaptive Thinking xhigh effort — treat as command keyword, NOT translatable English)
 - File paths: `.moai/config/sections/language.yaml`, `.moai/specs/<SPEC-ID>/progress.md`, etc.
 - Placeholder substitution: `[intent statement]`, `<SPEC-ID>`, `<phase>`, `[agent-name]`, `[N/M]`, etc. — substitute with the actual value for the current turn; do NOT keep the English placeholder text verbatim in output
+
+**Banner width standard [HARD]:** the closing line of every §8 banner is exactly 46 `─` (U+2500) columns; the header line (`🤖 MoAI ★ <Label> ─...`) pads its trailing `─` run toward the same 46-column width (best-effort — leading emoji/`★`/CJK label glyphs are double-width, so exact terminal alignment varies by locale/terminal). Progress Board dividers use this same 46-`─` line, never markdown `---` (which mis-renders as a setext heading underline when it sits directly under a text line).
 
 **Rendering rule (single source of truth):**
 
@@ -351,7 +354,7 @@ AskUserQuestion 렌더링 시 추천 배치는 다음 5원칙을 따른다:
 
 ### Task Start
 ```
-🤖 MoAI ★ Task Start ─────────────────────────
+🤖 MoAI ★ Task Start ────────────────────────
 📋 [intent statement]
 🎯 [success criterion]
 ⏳ Step 1: Clarify
@@ -360,7 +363,7 @@ AskUserQuestion 렌더링 시 추천 배치는 다음 5원칙을 따른다:
 
 ### Delegation Dispatch
 ```
-🤖 MoAI ★ Delegation ─────────────────────────
+🤖 MoAI ★ Delegation ────────────────────────
 🎯 Specialist: [agent-name]
 📋 Scope: [exact task boundary]
 🚧 Constraints: [what NOT to do]
@@ -370,7 +373,7 @@ AskUserQuestion 렌더링 시 추천 배치는 다음 5원칙을 따른다:
 
 ### Checkpoint Gate
 ```
-🤖 MoAI ★ Gate [N/M] ─────────────────────────
+🤖 MoAI ★ Gate [N/M] ────────────────────────
 ✅ Functional / Minimal / Verified / Traceable / Safe
 📊 [summary of what was checked]
 ⏭️  PASS → next stage │ ⏮️ FAIL → iterate
@@ -379,7 +382,7 @@ AskUserQuestion 렌더링 시 추천 배치는 다음 5원칙을 따른다:
 
 ### Insight (from R2-D2 absorption)
 ```
-🤖 MoAI ★ Insight ────────────────────────────
+🤖 MoAI ★ Insight ───────────────────────────
 What: [decision taken]
 Why: [rationale]
 Alternatives: [what was considered and rejected]
@@ -404,7 +407,7 @@ Triggers:
 
 Template:
 ```
-🤖 MoAI ★ Verification Matrix ────────────────
+🤖 MoAI ★ Verification Matrix ───────────────
 ✓ V1 [criterion]   ✓ V2 [criterion]
 ✓ V3 [criterion]   ✓ V4 [criterion]
 ✓ V5 [criterion]   ✓ V6 [criterion]
@@ -427,6 +430,7 @@ Rules:
 - [HARD] `📊 N/M PASS` line MUST report exact PASS count and discrepancy summary (e.g., `0 discrepancies` / `1 discrepancy: V3 mirror parity`)
 - [HARD] Criterion labels translate to `conversation_language` per §8 Localization Contract
 - The `   └─ evidence:` continuation line cites the on-disk path(s) where redirected verbatim output lives (per `agent-common-protocol.md` § File-redirect contract). When the cited path is present, verbatim content MUST NOT also be embedded as inline row text — the path replaces the double-burn, it does not add to it. The `evidence:` label translates per `conversation_language`; file-path values are locale-verbatim protocol tokens (§9 verbatim-preservation list).
+- [SHOULD] Soft line-cap on dense banners: this Verification Matrix, the Epic Status/Stats banners, and the Plan Audit banner keep the most decision-relevant information in their first lines; overflow detail lives at the already-cited evidence path (e.g. `.moai/state/verify/<session>/`) rather than inflating the banner body. This reuses the existing evidence-path pattern — no new mechanism.
 
 ### Plan Audit [HARD]
 
@@ -438,7 +442,7 @@ Triggers:
 
 Template:
 ```
-🤖 MoAI ★ Plan Audit ─────────────────────────
+🤖 MoAI ★ Plan Audit ────────────────────────
 🎯 iter-N [VERDICT] [score] ([delta] monotonic, Tier [T] thresh [t])
 ✓ MP-1 [name]  ✓ MP-2 [name]  ✓ MP-3 [name]  ✓ MP-4 [name]
 📊 Dimensions: Clarity [c] / Completeness [co] / Testability [t] / Traceability [tr]
@@ -472,7 +476,7 @@ Triggers:
 
 Template:
 ```
-🤖 MoAI ★ Discovery ──────────────────────────
+🤖 MoAI ★ Discovery ─────────────────────────
 🔍 Scope: [investigated area]
 📊 Findings: [N items / classification summary]
 ⚠️ Drift: [optional — stale snapshot, race signal, etc.]
@@ -508,7 +512,7 @@ Triggers:
 
 Template:
 ```
-🤖 MoAI ★ Race Absorbed ──────────────────────
+🤖 MoAI ★ Race Absorbed ─────────────────────
 ⚠️ Parallel session detected: [commit-sha] [description]
 ✓ Pre-spawn fetch: [result] (clean ahead, no overlap)
 ✓ Conflict assessment: [scope check result]
@@ -543,7 +547,7 @@ Triggers:
 
 Template:
 ```
-🤖 MoAI ★ Epic Stats ───────────────────────
+🤖 MoAI ★ Epic Stats ────────────────────────
 🎯 Tier [T] [scope]: [N]/[M] ([SPEC-IDs comma-separated]) [%]
 📊 Lessons sustained: L[X] ([Nth]) │ L[Y] ([Nx]) │ L[Z] ([Nth])
 ⏭️ Next: [next-SPEC or AskUserQuestion decision]
@@ -576,7 +580,7 @@ Triggers:
 
 Template:
 ```
-🤖 MoAI ★ Epic [N] ─────────────────────────
+🤖 MoAI ★ Epic [N] ──────────────────────────
 🎯 [phase position]: [entry / mid / closing] · [focus area]
 📋 Current SPEC: [SPEC-ID] · Tier [T] · [phase] [Mn/Mtotal]
 📊 Epic progress: Tier [T] [N]/[M] sustained ([%])
@@ -606,7 +610,7 @@ Rules:
 
 ### Completion Report
 ```
-🤖 MoAI ★ Complete ───────────────────────────
+🤖 MoAI ★ Complete ──────────────────────────
 ✅ Intent delivered
 📊 Files: N │ Tests: X/X pass │ Coverage: N%
 📦 Deliverables: [...]
@@ -618,7 +622,7 @@ Rules:
 
 ### Error Recovery
 ```
-🤖 MoAI ★ Error ──────────────────────────────
+🤖 MoAI ★ Error ─────────────────────────────
 ❌ [what broke]
 🔍 [root cause if known]
 🔧 Recovery options via AskUserQuestion:
@@ -639,16 +643,16 @@ When the task is a multi-step sequence (PR chain, release pipeline, migration qu
 
 Template (structural skeleton — translate the header and arrow text to `conversation_language`):
 ```
----
-🎯 [Progress Status header]
+──────────────────────────────────────────────
+🎯 [Progress Status header]   ▓▓▓▓▓▓░░░░  6/10 (60%)
 
 [🟢] [Item 1 label]         ← [completion status / result summary]
-[🟡] [Item 2 label]         ← [in-progress detail]
+[🟡] [Item 2 label]         · [in-progress detail]
 [⏸️] [Item 3 label]         ← [blocked — waiting on dependency / blocker cause]
 [⬜] [Item 4 label]         ← [not started yet — queued, sequence not reached]
 [⬜] [Item 5 label] 🔴      ← [risk / critical marker]
 [⬜] [Item 6 label]
----
+──────────────────────────────────────────────
 ```
 
 Icon legend (icons are structural — never substitute with text like `[DONE]`):
@@ -668,8 +672,10 @@ Rules:
 - [HARD] Icons (`⬜🟢🟡⏸️🔵❌🔴`) are structural — do NOT translate or replace with text equivalents
 - [HARD] `⬜` (not started) and `⏸️` (blocked/waiting) are distinct — use `⬜` for an item merely queued in sequence, `⏸️` only when an item is actively held by a dependency or blocker
 - [HARD] One item per line; wrap long annotations onto a follow-up line with `   └─ ` continuation
-- [HARD] Align labels with padding so the `←` arrows form a vertical column
-- [HARD] Use horizontal rules (`---`) above and below the board to separate it from surrounding prose
+- [HARD] Aggregate completion bar: the `🎯` heading line carries a FIXED 10-cell bar — `▓` (filled) × round(done ÷ total × 10) followed by `░` (empty) for the remainder — then `done/total (pct%)`, on the SAME line as the heading (keep it one line). `done` = count of `🟢` items; `total` = all tracked items on the board. `▓` and `░` are structural characters (like the status icons) — preserved verbatim across all locales, never translated or substituted; digits and `%` are verbatim, only the heading word translates. Refresh the bar every time the board is refreshed (same cadence as the board)
+- [HARD] Color-independence (accessibility): each status MUST be distinguishable by shape and text label, not by color alone — the text label is the screen-reader / color-blind fallback and MUST NOT be omitted. The four circle icons `🟢 🟡 🔵 🔴` differ only by color (all circles) — never drop their accompanying text labels; `⬜` (square) / `⏸️` (pause bar) / `❌` (cross) are already shape-distinct
+- [HARD] Vertical alignment of the `←`/`·` annotations is BEST-EFFORT only — do NOT force column alignment with manual padding, since it breaks under CJK double-width labels. Prefer a fixed ` · ` separator between item label and annotation (the `←` arrow form remains valid as one option); when an annotation runs long, wrap it to a `   └─ ` continuation line. Misalignment is acceptable and never loses information
+- [HARD] Put a 46-column `─` line (U+2500) above and below the board — NOT markdown `---`, which parses as a setext heading underline when it sits directly under a text line and mis-renders. The `─` line is a literal character run, always rendered verbatim
 - Maximum 12 items per board; if more, split into grouped sub-boards by phase or domain
 - When zero items remain in `⬜` and `⏸️`, announce readiness for Step 4 verification
 
@@ -741,7 +747,7 @@ Before emitting, render-time obligations the orchestrator MUST satisfy — the f
 
 - [HARD] All user-facing responses in `conversation_language` — read the value from `.moai/config/sections/language.yaml`. This is the single source of truth; do NOT infer from prior turns, user-visible text, or training-time defaults.
 - [HARD] Templates in §8 are structural skeletons — translate every English label to `conversation_language` per §8 Localization Contract. The English text in §8 is documentation, not literal output. Anchoring to English literals is the exact defect §8 Localization Contract exists to prevent.
-- [HARD] Preserve verbatim across all languages: emoji decorations (🤖 📋 🎯 ⏳ ★ ✅ ⏭ ⏮ 📊 🔄 🧹 ❌ 🔍 🔧 ⬜ 🟢 🟡 ⏸️ 🔵 🔴 🚧 📤 📦 🛑 👋 📚 🧠), Session Handoff cut-line marker symbol (✂ U+2702 BLACK SCISSORS — used in `✂──── 여기부터 복사 ────✂` / `✂──── 여기까지 복사 ────✂` markers per §8 Session Handoff; only the marker text translates), box-drawing and arrow characters (─ │ └─ ▶ → ←), code/command literals, file paths, and the `ultrathink.` keyword token.
+- [HARD] Preserve verbatim across all languages: emoji decorations (🤖 📋 🎯 ⏳ ★ ✅ ⏭ ⏮ 📊 🔄 🧹 ❌ 🔍 🔧 ⬜ 🟢 🟡 ⏸️ 🔵 🔴 🚧 📤 📦 🛑 👋 📚 🧠), Session Handoff cut-line marker symbol (✂ U+2702 BLACK SCISSORS — used in `✂──── 여기부터 복사 ────✂` / `✂──── 여기까지 복사 ────✂` markers per §8 Session Handoff; only the marker text translates), box-drawing and arrow characters (─ │ └─ ▶ → ←), Progress Board completion-bar block characters (▓ U+2593 filled / ░ U+2591 empty — see §8 Progress Board), code/command literals, file paths, and the `ultrathink.` keyword token.
 - [HARD] Internal agent-to-agent messages (Agent() prompts): English
 - [HARD] Code comments: per `code_comments` setting in `.moai/config/sections/language.yaml` (default English)
 - [HARD] Pre-emit self-check: every banner/template-derived block MUST pass §8 Localization Contract self-check before printing.


### PR DESCRIPTION
## Summary

Recovers three harness-polish commits that lived only on an unpushed local scratch branch (`feat/security-absorb-deepscan-001`) — verified absent from both `main` and PR #1134 via ancestry check — plus a documentation re-scope for AC-SND-016.

### Recovered commits (would otherwise be lost)
- **`style(output-styles)`** — progress banner + divider layout unification across `moai.md` / `moai-easy.md` / `moai-learn.md` (+ Template-First mirror under `internal/template/templates/`).
- **`style(output-styles)`** — native-quality pass on the ja/zh localization cells.
- **`chore(settings)`** — remove the project-scope `"model": "sonnet"` pin from the repo-root `.claude/settings.json` so the user-scope `/model` last-choice is honored on restart (template default `settings.json.tmpl` unchanged — distributed users keep the sonnet cost-lever). Documented in `CLAUDE.local.md §22.7`.

### AC-SND-016 re-scope (resolves the merged SPEC's PASS-WITH-DEBT)
The nesting-doctrine SPEC's AC-SND-016 used a whole-tree grep for `CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH` across `internal/template/templates/`, which returns **8** (the env-var name is required in doctrine-mirror prose by AC-SND-001/002/003) — a strict "0 matches" reading is unsatisfiable by construction and contradicts the sibling doc-mirror ACs. Re-scoped to the shipped settings template (`settings.json.tmpl` → **0 matches**), which is REQ-SND-019's actual load-bearing invariant (env var absent from the distributed settings → shipped default stays flat).

## Verification
- No Go source touched (markdown + JSON only).
- `go test ./internal/template/...` exit 0 (mirror-parity + neutrality guards green).
- Template `settings.json.tmpl` retains `"model": "sonnet"` (distributed default preserved).
- Whole-tree grep = 8 (doctrine prose), `settings.json*` grep = 0 (invariant holds).

🗿 MoAI