### PR TITLE
fix(harness): Phase-0 audit fixes — routing, multilingual guard, token scope, stale refs

### DIFF
--- a/.claude/agents/moai/e2e-tester.md
+++ b/.claude/agents/moai/e2e-tester.md
@@ -8,6 +8,7 @@ description: |
   project-local e2e/ directories.
   Use PROACTIVELY when the e2e workflow delegates detection, journey mapping, script
   creation, execution, or recording.
+  Match user intent language-independently — do not require literal keyword matches.
   NOT for: implementation-cycle code changes (manager-develop), SPEC authoring
   (manager-spec), unit/integration test authoring within a TDD cycle (manager-develop),
   documentation (manager-docs), git operations (manager-git).

--- a/.claude/rules/moai/core/moai-constitution.md
+++ b/.claude/rules/moai/core/moai-constitution.md
@@ -27,7 +27,7 @@ Execute all independent tool calls in parallel when no dependencies exist.
 Rules:
 - Launch multiple agents in a single message when tasks are independent
 - Use sequential execution only when dependencies exist
-- Maximum 10 parallel agents for optimal throughput
+- MoAI ceiling: 3-5 concurrent Agent() calls (Mode 4); runtime cap is 20. See orchestration-mode-selection.md §C.2 (SSOT).
 - For sub-agent mode: Launch multiple Agent() calls in a single message for parallel execution
 - For team mode: spawn teammates directly with the Agent tool's `name` parameter (the team forms implicitly on first spawn — one team per session, no setup step)
 - Team agents share TaskList for work coordination; sub-agents return results directly

--- a/.claude/rules/moai/core/zone-registry.md
+++ b/.claude/rules/moai/core/zone-registry.md
@@ -1,6 +1,6 @@
 ---
 description: "Constitution zone registry — CONST-* clause records consumed by moai constitution CLI and zone audits"
-paths: "**/.claude/rules/**,**/.moai/config/sections/constitution.yaml"
+paths: "**/zone-registry.md,**/.moai/config/sections/constitution.yaml"
 ---
 
 # Zone Registry

--- a/.claude/rules/moai/development/model-policy.md
+++ b/.claude/rules/moai/development/model-policy.md
@@ -46,7 +46,7 @@ Upstream tracking (Anthropic claude-code repository):
 Workaround pattern (`model: inherit`):
 - The subagent fully inherits the parent's model + context entitlement, eliminating the mismatch.
 - Reference implementation: `.claude/agents/moai/plan-auditor.md` has used `model: inherit`.
-- All 10 MoAI-custom retained agents under `.claude/agents/moai/` declare `model: inherit` (per the 11-agent catalog: 10 MoAI-custom + 1 Anthropic built-in `Explore`, aligned with CLAUDE.md §4). The No-Haiku policy (SPEC-AGENT-ARCH-V2-001 §D) retired the former `model: haiku` exception — `manager-docs` and `manager-git` moved from `model: haiku` to `model: sonnet` with `effort: low` (cost reduction via effort tiering, not model-class substitution).
+- 8 of the 10 MoAI-custom retained agents under `.claude/agents/moai/` declare `model: inherit`; `manager-docs` and `manager-git` intentionally pin `model: sonnet` as the No-Haiku cost lever (`manager-docs` runs `effort: medium`, `manager-git` runs `effort: low`). The No-Haiku policy retired the former `model: haiku` exception — cost reduction is achieved via effort tiering, not model-class substitution.
 
 Exceptions (do NOT migrate to inherit):
 - Documentation/example YAML inside skill bodies (`.claude/skills/moai-foundation-cc/reference/**/*.md`) — these mirror official Claude Code documentation and MUST show all valid values (`sonnet`, `opus`, `haiku`, `inherit`) for educational purposes.

--- a/.claude/rules/moai/workflow/repo-local-pr-policy.md
+++ b/.claude/rules/moai/workflow/repo-local-pr-policy.md
@@ -1,0 +1,14 @@
+---
+description: "Repo-local PR policy override — moai-adk-go forces all-tier PR (Route B); Route A Hybrid-Trunk main-direct is disabled by branch protection"
+paths: ".moai/specs/**,.claude/skills/moai/workflows/run.md,.claude/skills/moai/workflows/sync.md,.claude/skills/moai/workflows/moai.md"
+---
+
+# Repo-Local PR Policy (moai-adk-go maintainer override)
+
+[HARD] In THIS repository, the `spec-workflow.md` Route A ("Hybrid Trunk main-direct" for Tier S / M) is DISABLED. `main` is protected with `enforce_admins: true` + required PR (verified via `gh api repos/modu-ai/moai-adk/branches/main/protection`), so a direct push to `main` is rejected even for admins.
+
+- ALL tiers (S / M / L) use **Route B (PR)**: work lands on a feature branch and merges via PR (self-merge allowed; 0 required approvals; CI must pass).
+- The orchestrator MUST NOT instruct `manager-develop` to commit-and-push directly to `main`, regardless of Tier.
+- This is a repo-local addendum (local-only, NOT mirrored to `internal/template/templates/`). The distributed template keeps the generic Route A / Route B choice for downstream users who have no branch protection.
+
+Cross-reference: CLAUDE.local.md §23 (Hybrid Trunk RETIRED for this repo); `spec-workflow.md` § Route Selection.

--- a/.claude/skills/moai-foundation-core/SKILL.md
+++ b/.claude/skills/moai-foundation-core/SKILL.md
@@ -302,11 +302,7 @@ Context window optimization, /clear strategy, session state persistence, and mul
 
 ### Context Window Targets
 
-| Model class | Window | 75% threshold | /clear trigger |
-|-------------|--------|---------------|----------------|
-| Opus 4.7 (1M) | 1,000,000 tokens | ~750,000 | Above threshold |
-| Sonnet/Opus standard | 200,000 tokens | ~150,000 | Above threshold |
-| Haiku | 200,000 tokens | ~150,000 | Above threshold |
+See `.claude/rules/moai/workflow/context-window-management.md` § Context Window Targets for the authoritative per-model-class `/clear` threshold table (1M/GLM = 50%, 200K/256K = 90%). Do not restate thresholds here (SSOT).
 
 ### Phase Token Allocation
 

--- a/.claude/skills/moai/SKILL.md
+++ b/.claude/skills/moai/SKILL.md
@@ -3,7 +3,7 @@ name: moai
 description: >
   MoAI unified orchestrator for autonomous development. Routes natural
   language or subcommands (plan, run, sync, project, fix, loop, mx,
-  feedback, review, clean, codemaps, gate, e2e, harness) to specialized
+  feedback, review, clean, codemaps, gate, e2e, harness, goal) to specialized
   agents.
 allowed-tools: Agent, AskUserQuestion, Skill, TaskCreate, TaskUpdate, TaskList, TaskGet, Bash, Read, Write, Edit, Glob, Grep
 argument-hint: "[subcommand] [args] | \"natural language task\""
@@ -35,7 +35,7 @@ Rules and constraints governing all workflows are always loaded from these sourc
 
 ## Routing Observation Ledger
 
-When dispatching a subcommand or workflow, the orchestrator records the routing decision to the append-only routing-ledger (`.moai/state/routing-ledger.jsonl`) via `moai harness ledger record` at dispatch time — the request text is piped via stdin and only a privacy-preserving digest is stored, never verbatim user text. As the routed pipeline reaches gate points, machine evidence is appended via `moai harness ledger evidence` (gate exits, audit verdicts, verify-log paths). Outcome is never supplied as an input; it is finalized from machine evidence only. This observation is opt-in and fail-open — it never blocks routing, and it is a silent no-op unless the harness observability opt-in is enabled.
+When dispatching a subcommand or workflow, the orchestrator records the routing decision to the append-only routing-ledger (`.moai/state/routing-ledger.jsonl`) via `moai harness ledger record` at dispatch time — the request text is piped via stdin and only a privacy-preserving digest is stored, never verbatim user text. As the routed pipeline reaches gate points, machine evidence is appended via `moai harness ledger evidence` (gate exits, audit verdicts, verify-log paths). Outcome is never supplied as an input; it is finalized from machine evidence only. This observation is opt-in and fail-open — it never blocks routing. NOTE: recording depends on the orchestrator actually invoking `moai harness ledger record` at dispatch; when the observability opt-in is ON but that record call is not emitted, the ledger stays empty — an un-recorded dispatch, NOT an opt-in-off no-op. Do not read an empty routing-ledger as 'opt-in disabled'.
 
 ---
 
@@ -61,11 +61,13 @@ The `--team` / `--solo` flags are forced overrides onto the catalog; the flag-fr
 
 [HARD] Extract the FIRST WORD from the Raw User Input section above. If it matches any subcommand below (or its alias), route to that workflow IMMEDIATELY. Do NOT analyze the remaining text for routing — it is context for the matched workflow:
 
+[HARD] Mixed-language guard: FIRST-WORD subcommand matching applies only when (a) the input is pure ASCII/Latin, OR (b) the message is prefixed with a literal `/moai ` slash form. When the message contains non-Latin script (Korean/Japanese/Chinese/etc.) beyond the first token, do NOT route immediately on the leading English word — treat it as a possible embedded loanword and fall through to Priority 3 semantic classification of the ENTIRE message. Rationale: CJK technical writing embeds English loanwords such as 'goal', 'run', 'fix', 'plan' at sentence start; immediate first-word routing misfires on them.
+
 - **plan** (aliases: spec): SPEC document creation workflow
 - **run** (aliases: impl): DDD/TDD implementation workflow (per quality.yaml development_mode)
 - **sync** (aliases: docs, pr): Documentation synchronization and PR creation
 - **project** (aliases: init): Project documentation generation
-- **feedback** (aliases: fb, bug, issue): GitHub issue creation
+- **feedback** (aliases: fb): GitHub issue creation
 - **fix**: Auto-fix errors in a single pass
 - **loop**: Iterative auto-fix until completion conditions are satisfied
 - **mx**: MX tag scan and annotation for codebase
@@ -74,7 +76,7 @@ The `--team` / `--solo` flags are forced overrides onto the catalog; the flag-fr
 - **codemaps**: Generate architecture documentation in `.moai/project/codemaps/`
 - **gate** (aliases: check, pre-commit): Lightweight pre-commit quality gate (lint+format+type-check+test)
 - **e2e** (aliases: e2e-test, end-to-end): Multi-platform end-to-end testing (web/mobile/desktop) with project-type auto-detection and CLI-first toolchain selection
-- **harness** (aliases: hrn, learn): harness lifecycle management — learning-lifecycle verbs (status / apply / rollback &lt;date&gt; / disable) + v4-lifecycle verbs (list / edit / remove / doctor), all dispatching through the unified `moai harness` Go-binary Cobra subcommand tree; the slash command is the documented user-facing entry point
+- **harness** (aliases: hrn): harness lifecycle management — learning-lifecycle verbs (status / apply / rollback &lt;date&gt; / disable) + v4-lifecycle verbs (list / edit / remove / doctor), all dispatching through the unified `moai harness` Go-binary Cobra subcommand tree; the slash command is the documented user-facing entry point
 - **goal**: Condition-declared universal agentic loop — arm a completion condition (`/moai goal "<condition>"`), check status, clear, or resume; evaluated each turn-end by the `stop-goal` Stop hook
 
 ### Priority 2: SPEC-ID Detection

--- a/.claude/skills/moai/references/reference.md
+++ b/.claude/skills/moai/references/reference.md
@@ -79,8 +79,8 @@ When team mode is enabled, use Agent Teams for persistent parallel coordination.
 
 Use Cases:
 
-- Plan Phase: Parallel research team (researcher + analyst + architect)
-- Run Phase: Parallel implementation team (backend-dev + frontend-dev + tester) with file ownership boundaries
+- Plan Phase: Parallel read-only exploration via the Explore subagent + per-spawn Agent(general-purpose) with domain instructions (the archived researcher/analyst/architect agents are retired)
+- Run Phase: Sequential implementation via manager-develop (write fan-out stays foreground-sequential; the archived backend-dev/frontend-dev/tester agents are retired) with file ownership boundaries
 - Debug Phase: Competing hypothesis investigation team
 
 Implementation:
@@ -147,7 +147,7 @@ Propagation Method:
 - --worktree: Create an isolated git worktree for the SPEC implementation
 - --branch: Create a feature branch for the SPEC (default branch naming: feature/SPEC-XXX)
 - --resume SPEC-XXX: Resume an interrupted plan session
-- --team: Force team-based exploration (researcher + analyst + architect)
+- --team: RETIRED — Agent Teams Mode 3 is a tombstone; a forced --team falls back to sub-agent mode. Use parallel Agent(general-purpose) fan-out for exploration.
 
 ### Run Flags
 

--- a/.claude/skills/moai/workflows/fix.md
+++ b/.claude/skills/moai/workflows/fix.md
@@ -172,13 +172,13 @@ Before applying fixes, scan target files for existing @MX tags to understand con
 - List of @MX:WARN zones (approach with caution)
 - Relevant @MX:NOTE context (understand before modifying)
 
-**Skip Condition:** If no @MX tags found in target files, proceed directly to Phase 3.
+**Skip Condition:** If no @MX tags found in target files, proceed directly to Phase 4.
 
 See .claude/rules/moai/workflow/mx-tag-protocol.md for tag type definitions.
 
 ## Phase 4: Auto-Fix
 
-<!-- @MX:WARN @MX:REASON - Future PRs may be tempted to add LLM-driven Level-to-agent dispatch here. The current static lookup table (lines 175-179) MUST remain a fixed mapping. Any LLM-decided dispatch fails TestAgentlessUtilityNoLLMControlFlow. -->
+<!-- @MX:WARN @MX:REASON - Future PRs may be tempted to add LLM-driven Level-to-agent dispatch here. The current static lookup table (lines 185-188) MUST remain a fixed mapping. Any LLM-decided dispatch fails TestAgentlessUtilityNoLLMControlFlow. -->
 
 [HARD] Agent delegation mandate (Level 2+): ALL Level 2 and above fix tasks MUST be delegated to specialized agents. NEVER execute Level 2+ fixes directly. Level 1 (import sorting, whitespace, formatting) is exempt: the orchestrator runs the language's deterministic formatter command directly (e.g., gofmt/goimports, ruff format, prettier, rustfmt) without an Agent() spawn — a formatter run needs no agent specialization.
 

--- a/.claude/skills/moai/workflows/moai.md
+++ b/.claude/skills/moai/workflows/moai.md
@@ -35,7 +35,7 @@ For phase overview, token budgets, and phase transitions, see: .claude/rules/moa
 ## Supported Flags
 
 - --loop: Enable auto iterative fixing during run phase
-- --max N: Maximum iteration count for loop (default 100)
+- --max N: Maximum iteration count for loop (effective default is ralph.yaml loop.max_iterations = 10; the workflow.yaml loop_prevention fallback of 100 is the lowest-precedence ceiling, not the default)
 - --branch: Auto-create feature branch
 - --pr: Auto-create pull request after completion
 - --resume SPEC-XXX: Resume previous work from existing SPEC

--- a/.moai/config/sections/delegation.yaml
+++ b/.moai/config/sections/delegation.yaml
@@ -66,7 +66,7 @@ delegation:
             skills: [moai-foundation-quality, moai-ref-testing-pyramid]
         harness:
             agents: [builder-harness]
-            skills: [moai-meta-harness, moai-harness-learner]
+            skills: [moai-harness-learner]
         goal:
             agents: []                     # orchestrator + stop-goal Stop hook
             skills: []

--- a/CLAUDE.local.md
+++ b/CLAUDE.local.md
@@ -742,12 +742,6 @@ See: `.moai/docs/git-workflow-doctrine.md`
 
 ---
 
-**Status**: Active (Local Development)
-**Version**: 3.10.0 (§23/§24/§25 본문을 `.moai/docs/` 3개 doctrine 파일로 추출 — 세션 런칭 컨텍스트 59.9K→32.0K 축소; §17/§18/§21 stub+pointer 패턴 일관 적용)
-**Last Updated**: 2026-06-03
-
----
-
 ## 20. Vercel Build Cost Guard
 
 ### [HARD] Build Machine = Elastic 유지

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Report: consolidate agent results and format the response in the user's `convers
 
 Single entry point for all MoAI development workflows.
 
-Subcommands: plan, run, sync, project, fix, loop, mx, feedback, review, clean, codemaps, gate, e2e, harness
+Subcommands: plan, run, sync, project, fix, loop, mx, feedback, review, clean, codemaps, gate, e2e, harness, goal
 Default (natural language): Routes to autonomous workflow (plan -> run -> sync pipeline)
 
 `/moai loop` and `/moai fix` are goal-preset siblings built on the goal engine: `/moai loop` is the goal preset for a bounded project-wide improvement sweep (scan a finite issue queue, then delegate iterate-until-done to the goal engine), and `/moai fix` is the one-shot turn-based preset.
@@ -229,7 +229,7 @@ Resume interrupted agent work using agentId (e.g., "Resume agent abc123 and cont
 
 MoAI-ADK integrates MCP servers and deep-analysis modes:
 
-- **UltraThink** (`ultrathink` keyword) / **Adaptive Thinking** (Opus 4.7+, including 4.8): the `ultrathink` keyword sets `effort: xhigh` and triggers Adaptive Thinking (dynamically allocated reasoning tokens, no fixed budget_tokens; controlled by effort level high/xhigh/max, not budget_tokens). See Skill("moai-workflow-thinking").
+- **UltraThink** (`ultrathink` keyword) / **Adaptive Thinking** (Opus 4.7+, including 4.8): the `ultrathink` keyword sets `effort: xhigh` and triggers Adaptive Thinking (dynamically allocated reasoning tokens, no fixed budget_tokens; controlled by effort level high/xhigh/max, not budget_tokens). See Skill("moai-foundation-thinking").
 - **Context7**: Up-to-date library documentation lookup (resolve-library-id, get-library-docs).
 - **claude-in-chrome**: Browser automation for web-based tasks.
 - **Dynamic Workflows / ultracode**: `/effort ultracode` combines xhigh effort with automatic workflow orchestration (Claude Code v2.1.154+). See .claude/rules/moai/workflow/dynamic-workflows.md.

--- a/internal/template/catalog.yaml
+++ b/internal/template/catalog.yaml
@@ -6,7 +6,7 @@ catalog:
             - name: moai
               tier: core
               path: templates/.claude/skills/moai/
-              hash: 67a8502b837c4c7e313f8de1d185a6ecc12e49cc8ffe3056d0d4227c4d42ea07
+              hash: fb78f579583a99743bbdbb02e391b786a20131f5c5d4cd30cb1fa466c8ea0f6f
               version: 1.0.0
             - name: moai-foundation-cc
               tier: core
@@ -16,7 +16,7 @@ catalog:
             - name: moai-foundation-core
               tier: core
               path: templates/.claude/skills/moai-foundation-core/
-              hash: c9d4dab9d8bbf3ce47341a4dda6af5ab659089df42e30b45e7db249f200da2af
+              hash: f9abe12668904cc90c1cb424a00fa84e9db927ea5396ab852bbb10bf8a02c7fb
               version: 1.0.0
             - name: moai-foundation-quality
               tier: core
@@ -137,7 +137,7 @@ catalog:
             - name: e2e-tester
               tier: core
               path: templates/.claude/agents/moai/e2e-tester.md
-              hash: e8b57600567d8025f5596b449dda5de69130d8ef77462e5910c2958e7c2a5287
+              hash: ddab0ddbf28412dc0170d23b08b35a54b6b8cc601033db843514d16f41321682
               version: 1.0.0
     optional_packs:
         backend:

--- a/internal/template/templates/.claude/agents/moai/e2e-tester.md
+++ b/internal/template/templates/.claude/agents/moai/e2e-tester.md
@@ -8,6 +8,7 @@ description: |
   project-local e2e/ directories.
   Use PROACTIVELY when the e2e workflow delegates detection, journey mapping, script
   creation, execution, or recording.
+  Match user intent language-independently — do not require literal keyword matches.
   NOT for: implementation-cycle code changes (manager-develop), SPEC authoring
   (manager-spec), unit/integration test authoring within a TDD cycle (manager-develop),
   documentation (manager-docs), git operations (manager-git).

--- a/internal/template/templates/.claude/rules/moai/core/moai-constitution.md
+++ b/internal/template/templates/.claude/rules/moai/core/moai-constitution.md
@@ -27,7 +27,7 @@ Execute all independent tool calls in parallel when no dependencies exist.
 Rules:
 - Launch multiple agents in a single message when tasks are independent
 - Use sequential execution only when dependencies exist
-- Maximum 10 parallel agents for optimal throughput
+- MoAI ceiling: 3-5 concurrent Agent() calls (Mode 4); runtime cap is 20. See orchestration-mode-selection.md §C.2 (SSOT).
 - For sub-agent mode: Launch multiple Agent() calls in a single message for parallel execution
 - For team mode: spawn teammates directly with the Agent tool's `name` parameter (the team forms implicitly on first spawn — one team per session, no setup step)
 - Team agents share TaskList for work coordination; sub-agents return results directly

--- a/internal/template/templates/.claude/rules/moai/core/zone-registry.md
+++ b/internal/template/templates/.claude/rules/moai/core/zone-registry.md
@@ -1,6 +1,6 @@
 ---
 description: "Constitution zone registry — CONST-* clause records consumed by moai constitution CLI and zone audits"
-paths: "**/.claude/rules/**,**/.moai/config/sections/constitution.yaml"
+paths: "**/zone-registry.md,**/.moai/config/sections/constitution.yaml"
 ---
 
 # Zone Registry

--- a/internal/template/templates/.claude/rules/moai/development/model-policy.md
+++ b/internal/template/templates/.claude/rules/moai/development/model-policy.md
@@ -46,7 +46,7 @@ Upstream tracking (Anthropic claude-code repository):
 Workaround pattern (`model: inherit`):
 - The subagent fully inherits the parent's model + context entitlement, eliminating the mismatch.
 - Reference implementation: `.claude/agents/moai/plan-auditor.md` has used `model: inherit`.
-- All 10 MoAI-custom retained agents under `.claude/agents/moai/` declare `model: inherit` (per the 11-agent catalog: 10 MoAI-custom + 1 Anthropic built-in `Explore`, aligned with CLAUDE.md §4). The No-Haiku policy (SPEC-AGENT-ARCH-V2-001 §D) retired the former `model: haiku` exception — `manager-docs` and `manager-git` moved from `model: haiku` to `model: sonnet` with `effort: low` (cost reduction via effort tiering, not model-class substitution).
+- 8 of the 10 MoAI-custom retained agents under `.claude/agents/moai/` declare `model: inherit`; `manager-docs` and `manager-git` intentionally pin `model: sonnet` as the No-Haiku cost lever (`manager-docs` runs `effort: medium`, `manager-git` runs `effort: low`). The No-Haiku policy retired the former `model: haiku` exception — cost reduction is achieved via effort tiering, not model-class substitution.
 
 Exceptions (do NOT migrate to inherit):
 - Documentation/example YAML inside skill bodies (`.claude/skills/moai-foundation-cc/reference/**/*.md`) — these mirror official Claude Code documentation and MUST show all valid values (`sonnet`, `opus`, `haiku`, `inherit`) for educational purposes.

--- a/internal/template/templates/.claude/skills/moai-foundation-core/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-foundation-core/SKILL.md
@@ -302,11 +302,7 @@ Context window optimization, /clear strategy, session state persistence, and mul
 
 ### Context Window Targets
 
-| Model class | Window | 75% threshold | /clear trigger |
-|-------------|--------|---------------|----------------|
-| Opus 4.7 (1M) | 1,000,000 tokens | ~750,000 | Above threshold |
-| Sonnet/Opus standard | 200,000 tokens | ~150,000 | Above threshold |
-| Haiku | 200,000 tokens | ~150,000 | Above threshold |
+See `.claude/rules/moai/workflow/context-window-management.md` § Context Window Targets for the authoritative per-model-class `/clear` threshold table (1M/GLM = 50%, 200K/256K = 90%). Do not restate thresholds here (SSOT).
 
 ### Phase Token Allocation
 

--- a/internal/template/templates/.claude/skills/moai/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai/SKILL.md
@@ -3,7 +3,7 @@ name: moai
 description: >
   MoAI unified orchestrator for autonomous development. Routes natural
   language or subcommands (plan, run, sync, project, fix, loop, mx,
-  feedback, review, clean, codemaps, gate, e2e, harness) to specialized
+  feedback, review, clean, codemaps, gate, e2e, harness, goal) to specialized
   agents.
 allowed-tools: Agent, AskUserQuestion, Skill, TaskCreate, TaskUpdate, TaskList, TaskGet, Bash, Read, Write, Edit, Glob, Grep
 argument-hint: "[subcommand] [args] | \"natural language task\""
@@ -35,7 +35,7 @@ Rules and constraints governing all workflows are always loaded from these sourc
 
 ## Routing Observation Ledger
 
-When dispatching a subcommand or workflow, the orchestrator records the routing decision to the append-only routing-ledger (`.moai/state/routing-ledger.jsonl`) via `moai harness ledger record` at dispatch time — the request text is piped via stdin and only a privacy-preserving digest is stored, never verbatim user text. As the routed pipeline reaches gate points, machine evidence is appended via `moai harness ledger evidence` (gate exits, audit verdicts, verify-log paths). Outcome is never supplied as an input; it is finalized from machine evidence only. This observation is opt-in and fail-open — it never blocks routing, and it is a silent no-op unless the harness observability opt-in is enabled.
+When dispatching a subcommand or workflow, the orchestrator records the routing decision to the append-only routing-ledger (`.moai/state/routing-ledger.jsonl`) via `moai harness ledger record` at dispatch time — the request text is piped via stdin and only a privacy-preserving digest is stored, never verbatim user text. As the routed pipeline reaches gate points, machine evidence is appended via `moai harness ledger evidence` (gate exits, audit verdicts, verify-log paths). Outcome is never supplied as an input; it is finalized from machine evidence only. This observation is opt-in and fail-open — it never blocks routing. NOTE: recording depends on the orchestrator actually invoking `moai harness ledger record` at dispatch; when the observability opt-in is ON but that record call is not emitted, the ledger stays empty — an un-recorded dispatch, NOT an opt-in-off no-op. Do not read an empty routing-ledger as 'opt-in disabled'.
 
 ---
 
@@ -61,11 +61,13 @@ The `--team` / `--solo` flags are forced overrides onto the catalog; the flag-fr
 
 [HARD] Extract the FIRST WORD from the Raw User Input section above. If it matches any subcommand below (or its alias), route to that workflow IMMEDIATELY. Do NOT analyze the remaining text for routing — it is context for the matched workflow:
 
+[HARD] Mixed-language guard: FIRST-WORD subcommand matching applies only when (a) the input is pure ASCII/Latin, OR (b) the message is prefixed with a literal `/moai ` slash form. When the message contains non-Latin script (Korean/Japanese/Chinese/etc.) beyond the first token, do NOT route immediately on the leading English word — treat it as a possible embedded loanword and fall through to Priority 3 semantic classification of the ENTIRE message. Rationale: CJK technical writing embeds English loanwords such as 'goal', 'run', 'fix', 'plan' at sentence start; immediate first-word routing misfires on them.
+
 - **plan** (aliases: spec): SPEC document creation workflow
 - **run** (aliases: impl): DDD/TDD implementation workflow (per quality.yaml development_mode)
 - **sync** (aliases: docs, pr): Documentation synchronization and PR creation
 - **project** (aliases: init): Project documentation generation
-- **feedback** (aliases: fb, bug, issue): GitHub issue creation
+- **feedback** (aliases: fb): GitHub issue creation
 - **fix**: Auto-fix errors in a single pass
 - **loop**: Iterative auto-fix until completion conditions are satisfied
 - **mx**: MX tag scan and annotation for codebase
@@ -74,7 +76,7 @@ The `--team` / `--solo` flags are forced overrides onto the catalog; the flag-fr
 - **codemaps**: Generate architecture documentation in `.moai/project/codemaps/`
 - **gate** (aliases: check, pre-commit): Lightweight pre-commit quality gate (lint+format+type-check+test)
 - **e2e** (aliases: e2e-test, end-to-end): Multi-platform end-to-end testing (web/mobile/desktop) with project-type auto-detection and CLI-first toolchain selection
-- **harness** (aliases: hrn, learn): harness lifecycle management — learning-lifecycle verbs (status / apply / rollback &lt;date&gt; / disable) + v4-lifecycle verbs (list / edit / remove / doctor), all dispatching through the unified `moai harness` Go-binary Cobra subcommand tree; the slash command is the documented user-facing entry point
+- **harness** (aliases: hrn): harness lifecycle management — learning-lifecycle verbs (status / apply / rollback &lt;date&gt; / disable) + v4-lifecycle verbs (list / edit / remove / doctor), all dispatching through the unified `moai harness` Go-binary Cobra subcommand tree; the slash command is the documented user-facing entry point
 - **goal**: Condition-declared universal agentic loop — arm a completion condition (`/moai goal "<condition>"`), check status, clear, or resume; evaluated each turn-end by the `stop-goal` Stop hook
 
 ### Priority 2: SPEC-ID Detection

--- a/internal/template/templates/.claude/skills/moai/references/reference.md
+++ b/internal/template/templates/.claude/skills/moai/references/reference.md
@@ -79,8 +79,8 @@ When team mode is enabled, use Agent Teams for persistent parallel coordination.
 
 Use Cases:
 
-- Plan Phase: Parallel research team (researcher + analyst + architect)
-- Run Phase: Parallel implementation team (backend-dev + frontend-dev + tester) with file ownership boundaries
+- Plan Phase: Parallel read-only exploration via the Explore subagent + per-spawn Agent(general-purpose) with domain instructions (the archived researcher/analyst/architect agents are retired)
+- Run Phase: Sequential implementation via manager-develop (write fan-out stays foreground-sequential; the archived backend-dev/frontend-dev/tester agents are retired) with file ownership boundaries
 - Debug Phase: Competing hypothesis investigation team
 
 Implementation:
@@ -147,7 +147,7 @@ Propagation Method:
 - --worktree: Create an isolated git worktree for the SPEC implementation
 - --branch: Create a feature branch for the SPEC (default branch naming: feature/SPEC-XXX)
 - --resume SPEC-XXX: Resume an interrupted plan session
-- --team: Force team-based exploration (researcher + analyst + architect)
+- --team: RETIRED — Agent Teams Mode 3 is a tombstone; a forced --team falls back to sub-agent mode. Use parallel Agent(general-purpose) fan-out for exploration.
 
 ### Run Flags
 

--- a/internal/template/templates/.claude/skills/moai/workflows/fix.md
+++ b/internal/template/templates/.claude/skills/moai/workflows/fix.md
@@ -172,13 +172,13 @@ Before applying fixes, scan target files for existing @MX tags to understand con
 - List of @MX:WARN zones (approach with caution)
 - Relevant @MX:NOTE context (understand before modifying)
 
-**Skip Condition:** If no @MX tags found in target files, proceed directly to Phase 3.
+**Skip Condition:** If no @MX tags found in target files, proceed directly to Phase 4.
 
 See .claude/rules/moai/workflow/mx-tag-protocol.md for tag type definitions.
 
 ## Phase 4: Auto-Fix
 
-<!-- @MX:WARN @MX:REASON - Future PRs may be tempted to add LLM-driven Level-to-agent dispatch here. The current static lookup table (lines 175-179) MUST remain a fixed mapping. Any LLM-decided dispatch fails TestAgentlessUtilityNoLLMControlFlow. -->
+<!-- @MX:WARN @MX:REASON - Future PRs may be tempted to add LLM-driven Level-to-agent dispatch here. The current static lookup table (lines 185-188) MUST remain a fixed mapping. Any LLM-decided dispatch fails TestAgentlessUtilityNoLLMControlFlow. -->
 
 [HARD] Agent delegation mandate (Level 2+): ALL Level 2 and above fix tasks MUST be delegated to specialized agents. NEVER execute Level 2+ fixes directly. Level 1 (import sorting, whitespace, formatting) is exempt: the orchestrator runs the language's deterministic formatter command directly (e.g., gofmt/goimports, ruff format, prettier, rustfmt) without an Agent() spawn — a formatter run needs no agent specialization.
 

--- a/internal/template/templates/.claude/skills/moai/workflows/moai.md
+++ b/internal/template/templates/.claude/skills/moai/workflows/moai.md
@@ -35,7 +35,7 @@ For phase overview, token budgets, and phase transitions, see: .claude/rules/moa
 ## Supported Flags
 
 - --loop: Enable auto iterative fixing during run phase
-- --max N: Maximum iteration count for loop (default 100)
+- --max N: Maximum iteration count for loop (effective default is ralph.yaml loop.max_iterations = 10; the workflow.yaml loop_prevention fallback of 100 is the lowest-precedence ceiling, not the default)
 - --branch: Auto-create feature branch
 - --pr: Auto-create pull request after completion
 - --resume SPEC-XXX: Resume previous work from existing SPEC

--- a/internal/template/templates/.moai/config/sections/delegation.yaml
+++ b/internal/template/templates/.moai/config/sections/delegation.yaml
@@ -66,7 +66,7 @@ delegation:
             skills: [moai-foundation-quality, moai-ref-testing-pyramid]
         harness:
             agents: [builder-harness]
-            skills: [moai-meta-harness, moai-harness-learner]
+            skills: [moai-harness-learner]
         goal:
             agents: []                     # orchestrator + stop-goal Stop hook
             skills: []

--- a/internal/template/templates/CLAUDE.md
+++ b/internal/template/templates/CLAUDE.md
@@ -50,7 +50,7 @@ Report: consolidate agent results and format the response in the user's `convers
 
 Single entry point for all MoAI development workflows.
 
-Subcommands: plan, run, sync, project, fix, loop, mx, feedback, review, clean, codemaps, gate, e2e, harness
+Subcommands: plan, run, sync, project, fix, loop, mx, feedback, review, clean, codemaps, gate, e2e, harness, goal
 Default (natural language): Routes to autonomous workflow (plan -> run -> sync pipeline)
 
 `/moai loop` and `/moai fix` are goal-preset siblings built on the goal engine: `/moai loop` is the goal preset for a bounded project-wide improvement sweep (scan a finite issue queue, then delegate iterate-until-done to the goal engine), and `/moai fix` is the one-shot turn-based preset.
@@ -229,7 +229,7 @@ Resume interrupted agent work using agentId (e.g., "Resume agent abc123 and cont
 
 MoAI-ADK integrates MCP servers and deep-analysis modes:
 
-- **UltraThink** (`ultrathink` keyword) / **Adaptive Thinking** (Opus 4.7+, including 4.8): the `ultrathink` keyword sets `effort: xhigh` and triggers Adaptive Thinking (dynamically allocated reasoning tokens, no fixed budget_tokens; controlled by effort level high/xhigh/max, not budget_tokens). See Skill("moai-workflow-thinking").
+- **UltraThink** (`ultrathink` keyword) / **Adaptive Thinking** (Opus 4.7+, including 4.8): the `ultrathink` keyword sets `effort: xhigh` and triggers Adaptive Thinking (dynamically allocated reasoning tokens, no fixed budget_tokens; controlled by effort level high/xhigh/max, not budget_tokens). See Skill("moai-foundation-thinking").
 - **Context7**: Up-to-date library documentation lookup (resolve-library-id, get-library-docs).
 - **claude-in-chrome**: Browser automation for web-based tasks.
 - **Dynamic Workflows / ultracode**: `/effort ultracode` combines xhigh effort with automatic workflow orchestration (Claude Code v2.1.154+). See .claude/rules/moai/workflow/dynamic-workflows.md.


### PR DESCRIPTION
## Summary

Phase-0 fixes from a full read-only audit of the `/moai` workflow system (skills, agents, hooks, rules, CLAUDE.md) against official Claude Code docs. **18 low-risk edits** applied Template-First (template + local pairs edited identically); structural / code-level items are deferred to a follow-up improvement SPEC.

The audit also verified the healthy parts: every wired hook event is a real dispatched Claude Code event (no dead wrappers), subagent-nesting / concurrency defaults are correct, `/goal` semantics are accurate, and output-style precedence is correct — none of those are touched.

## What changed

**Routing / correctness**
- Dropped `bug`/`issue`/`learn` bare-word aliases — they misrouted CJK-loanword-leading requests (a Korean request starting with `bug`/`goal` was captured as a subcommand, sending fix intent to upstream issue-filing)
- New **P1 mixed-language guard**: non-Latin messages fall through to P3 semantic classification instead of routing immediately on a leading English word
- Broken `Skill("moai-workflow-thinking")` -> `moai-foundation-thinking` (always-loaded)
- `goal` subcommand added to CLAUDE.md section 3 + router description (was undiscoverable)
- `fix.md` Phase-3 self-loop skip target -> Phase 4; `--max` default corrected (10, not 100)
- Deprecated `moai-meta-harness` removed from harness delegation skills
- Archived `researcher` + phantom team agents removed from `reference.md`

**Consistency / token**
- `Maximum 10 parallel agents` -> 3-5 `Agent()` ceiling (SSOT); removes a live over-fan-out risk
- `model-policy.md` false "all 10 inherit" universal corrected (8/10 inherit; docs/git pin `sonnet`) + internal SPEC ID removed
- `moai-foundation-core` stale 75% `/clear` table -> SSOT pointer (canonical is 50%)
- `zone-registry.md` self-scoped — stops injecting ~10K tokens on every rule-file edit (highest token-per-keystroke recovery in the audit)
- `e2e-tester.md` language-independence directive added (parity with the other 9 agents)

**Local-only (not distributed)**
- `CLAUDE.local.md` stranded mid-document footer removed
- `repo-local-pr-policy.md` (new): forces all-tier PR for this repo (Route A main-direct is disabled by `enforce_admins:true`)

## Verification

- `make build` -> exit 0 (catalog regenerated)
- `go build ./...` -> exit 0
- `go test ./internal/template/...` -> `ok` (mirror-parity + neutrality guards pass)

No code logic or runtime behavior change — documentation, config, and router-instruction edits only.

## Deferred to a follow-up improvement SPEC

Token diet (session-handoff / askuser-protocol / CLAUDE.local split, ~18K tokens/session), SSOT deduplication, Stop-hook consolidation, routing-ledger hook migration (mechanical dispatch capture), security-skill cap reconciliation, worktree HARD-vs-opt-in reconciliation, `manager-design` routing surface, `worktree-create/remove` wiring, and the `zone-registry.md` file-size split.

🗿 MoAI
