### PR TITLE
fix(update): preserve .gitignore user patterns + unblock agency migration in v2→v3 clean-reinstall

### DIFF
--- a/internal/cli/migrate_agency_test.go
+++ b/internal/cli/migrate_agency_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -810,5 +811,128 @@ func TestMigrateAgency_NoMergeConflict(t *testing.T) {
 	_, err := m.Run()
 	if err != nil {
 		t.Fatalf("expected success when frameworks match, got: %v", err)
+	}
+}
+
+// --- runAgencyMigrationAdapter swallow/force coverage (issue #1132) ---
+//
+// The adapter-level tests below pin the #1132 fix contract:
+//   - MIGRATE_TARGET_EXISTS / MIGRATE_ARCHIVE_EXISTS are already-migrated
+//     no-ops (return nil + skip log) so clean-reinstall Step 3.5 never
+//     aborts before Step 4 clears the .agency/ residue.
+//   - force=true reaches the runner and performs a real forced migration
+//     (the CLI --force contract the pre-fix hardcoded force:false dropped).
+//   - Genuine migration failures (e.g. merge conflict) still propagate —
+//     the swallow is narrow, not a blanket error suppressor.
+
+// TestAgencyMigrationAdapter_TargetExistsSwallowed_Issue1132 verifies the
+// adapter treats MIGRATE_TARGET_EXISTS as an already-migrated no-op.
+func TestAgencyMigrationAdapter_TargetExistsSwallowed_Issue1132(t *testing.T) {
+	dir := t.TempDir()
+	setupAgencyFixture(t, dir)
+	if err := os.MkdirAll(filepath.Join(dir, ".moai", "config", "sections"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	designYAML := filepath.Join(dir, ".moai", "config", "sections", "design.yaml")
+	if err := os.WriteFile(designYAML, []byte("existing"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	if err := runAgencyMigrationAdapter(dir, false, false, &out); err != nil {
+		t.Fatalf("#1132: adapter returned error on pre-existing target (loop re-trigger): %v", err)
+	}
+	if !strings.Contains(out.String(), "agency migration skipped: target already migrated") {
+		t.Errorf("missing skip log; output:\n%s", out.String())
+	}
+	// The skip path must not mutate the pre-existing target.
+	data, err := os.ReadFile(designYAML)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "existing" {
+		t.Errorf("design.yaml mutated by skip path: %q", data)
+	}
+}
+
+// TestAgencyMigrationAdapter_ArchiveExistsSwallowed_Issue1132 verifies the
+// adapter treats MIGRATE_ARCHIVE_EXISTS as an already-migrated no-op.
+func TestAgencyMigrationAdapter_ArchiveExistsSwallowed_Issue1132(t *testing.T) {
+	dir := t.TempDir()
+	setupAgencyFixture(t, dir)
+	if err := os.MkdirAll(filepath.Join(dir, ".agency.archived"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	if err := runAgencyMigrationAdapter(dir, false, false, &out); err != nil {
+		t.Fatalf("#1132: adapter returned error on pre-existing archive (loop re-trigger): %v", err)
+	}
+	if !strings.Contains(out.String(), "agency migration skipped: target already migrated") {
+		t.Errorf("missing skip log; output:\n%s", out.String())
+	}
+}
+
+// TestAgencyMigrationAdapter_ForceRunsRealMigration verifies that force=true
+// reaches the runner: the pre-existing target is overwritten by a real forced
+// migration instead of the skip no-op.
+func TestAgencyMigrationAdapter_ForceRunsRealMigration(t *testing.T) {
+	dir := t.TempDir()
+	setupAgencyFixture(t, dir)
+	if err := os.MkdirAll(filepath.Join(dir, ".moai", "config", "sections"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, ".moai", "research"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	designYAML := filepath.Join(dir, ".moai", "config", "sections", "design.yaml")
+	if err := os.WriteFile(designYAML, []byte("old-content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	if err := runAgencyMigrationAdapter(dir, false, true, &out); err != nil {
+		t.Fatalf("adapter with force=true returned error: %v", err)
+	}
+	if strings.Contains(out.String(), "agency migration skipped") {
+		t.Errorf("force=true must not take the skip path; output:\n%s", out.String())
+	}
+	data, err := os.ReadFile(designYAML)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) == "old-content" {
+		t.Error("force=true did not overwrite the pre-existing target (force not plumbed to runner)")
+	}
+}
+
+// TestAgencyMigrationAdapter_GenuineErrorPropagates verifies the swallow is
+// narrow: a genuine migration failure (tech-preferences merge conflict) still
+// aborts, so clean-reinstall Step 4 cannot destroy an unmigrated .agency/
+// after a real failure.
+func TestAgencyMigrationAdapter_GenuineErrorPropagates(t *testing.T) {
+	dir := t.TempDir()
+	setupAgencyFixture(t, dir)
+	// Conflicting Framework declarations trigger MIGRATE_MERGE_CONFLICT
+	// (checked after the target-exists gates, so no targets pre-exist here).
+	if err := os.WriteFile(filepath.Join(dir, ".agency", "context", "tech-preferences.md"),
+		[]byte("Framework: React\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, ".moai", "project"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".moai", "project", "tech.md"),
+		[]byte("Framework: Vue\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	err := runAgencyMigrationAdapter(dir, false, false, &out)
+	if err == nil {
+		t.Fatal("expected merge-conflict error to propagate; adapter swallowed it")
+	}
+	if !strings.Contains(err.Error(), ErrMigrateMergeConflict) {
+		t.Errorf("expected %s in error, got: %v", ErrMigrateMergeConflict, err)
 	}
 }

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -342,14 +342,17 @@ func runUpdate(cmd *cobra.Command, _ []string) error {
 
 			result, runErr := runCleanReinstall(ctx, cwd, CleanReinstallOptions{
 				DryRun: getBoolFlag(cmd, "dry-run"),
-				Out:    out,
+				// Propagate the CLI --force flag to the Step 3.5 migration
+				// adapter (issue #1132): explicit `moai update --force`
+				// performs a real forced migration instead of the
+				// already-migrated skip.
+				Force: getBoolFlag(cmd, "force"),
+				Out:   out,
 				// Inject the canonical .agency/ migration adapter. When the
 				// project carries a .agency/ legacy directory, this is invoked
 				// in Step 3.5 of the canonical order (REQ-VVCR-025), mirroring
 				// the migrateLegacyMemoryDir auto-invoke precedent at line 1731.
-				RunMigrateAgency: func(projectRoot string, dryRun bool, out io.Writer) error {
-					return runAgencyMigrationAdapter(projectRoot, dryRun, out)
-				},
+				RunMigrateAgency: runAgencyMigrationAdapter,
 			})
 			if runErr != nil {
 				return fmt.Errorf("v2-to-v3 clean reinstall: %w", runErr)
@@ -386,7 +389,7 @@ func runUpdate(cmd *cobra.Command, _ []string) error {
 		// double-fire (the adapter need not swallow ErrMigrateArchiveExists).
 		if fpErr == nil && !fingerprint.IsV2 && isMoAIProject(cwd) {
 			if _, agencyStatErr := os.Stat(filepath.Join(cwd, ".agency")); agencyStatErr == nil {
-				if migrateErr := runAgencyMigrationAdapter(cwd, getBoolFlag(cmd, "dry-run"), out); migrateErr != nil {
+				if migrateErr := runAgencyMigrationAdapter(cwd, getBoolFlag(cmd, "dry-run"), getBoolFlag(cmd, "force"), out); migrateErr != nil {
 					return fmt.Errorf("pre-step agency migration: %w", migrateErr)
 				}
 			}
@@ -1192,18 +1195,32 @@ func runShellEnvConfig(cmd *cobra.Command) error {
 
 // runAgencyMigrationAdapter is the auto-invoke entrypoint for the
 // .agency/ → .moai/ migration triggered by runCleanReinstall Step 3.5
-// (REQ-VVCR-025 of SPEC-V3R6-V2-V3-CLEAN-REINSTALL-001).
+// (REQ-VVCR-025 of SPEC-V3R6-V2-V3-CLEAN-REINSTALL-001) and by the
+// runUpdate v3-project pre-step (REQ-CRR-007).
 //
 // Unlike runMigrateAgency (which is cobra-driven and reads --dry-run /
 // --force / --resume from CLI flags), this adapter constructs the runner
 // directly with the values supplied by the clean-reinstall orchestrator.
 // It mirrors the auto-invoke precedent of migrateLegacyMemoryDir.
 //
-// When `.agency/` is absent at projectRoot, the underlying migrateAgency
-// runner returns ErrMigrateNoSource — which this adapter swallows
-// gracefully because the clean-reinstall flow already verified .agency/
-// presence via Signal 2.
-func runAgencyMigrationAdapter(projectRoot string, dryRun bool, out io.Writer) error {
+// force propagates the CLI --force flag (issue #1132): an explicit
+// `moai update --force` performs a real forced migration (overwriting
+// existing targets), matching the `moai migrate agency --force` contract.
+//
+// Swallowed error codes (graceful no-ops):
+//   - ErrMigrateNoSource: .agency/ disappeared between detection and
+//     adapter invocation (race-safe no-op).
+//   - ErrMigrateTargetExists / ErrMigrateArchiveExists (issue #1132):
+//     a migration target (design.yaml / research/observations) or the
+//     .agency.archived/ backup already exists — the project is already
+//     migrated (typically by an earlier interrupted update whose v3
+//     template deploy created the targets). Pre-fix, this error aborted
+//     clean-reinstall Step 3.5 BEFORE Step 4 removed .agency/, so the v2
+//     fingerprint (Signal 2) never converged and every `moai update`
+//     re-entered the same abort — a permanent retry loop the CLI --force
+//     flag never reached. Treating it as already-migrated lets Step 4
+//     clear the residue and the fingerprint converge.
+func runAgencyMigrationAdapter(projectRoot string, dryRun, force bool, out io.Writer) error {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return fmt.Errorf("agency migration adapter: home dir: %w", err)
@@ -1213,17 +1230,20 @@ func runAgencyMigrationAdapter(projectRoot string, dryRun bool, out io.Writer) e
 		projectRoot: projectRoot,
 		homeDir:     homeDir,
 		dryRun:      dryRun,
-		// force=false: respect existing .moai/ contents; clean-reinstall
-		// pre-emptively preserves user-owned namespaces via Step 2 inventory
-		// so any forced overwrite here would risk re-introducing collisions.
-		force: false,
+		force:       force,
 	}
 
 	if _, runErr := r.Run(); runErr != nil {
-		// ErrMigrateNoSource is acceptable when .agency/ disappeared
-		// between detection and adapter invocation (race-safe no-op).
-		if me, ok := runErr.(*MigrateError); ok && me.Code == ErrMigrateNoSource {
-			return nil
+		var me *MigrateError
+		if errors.As(runErr, &me) {
+			switch me.Code {
+			case ErrMigrateNoSource:
+				return nil
+			case ErrMigrateTargetExists, ErrMigrateArchiveExists:
+				_, _ = fmt.Fprintf(out,
+					"[clean-reinstall] agency migration skipped: target already migrated (%s)\n", me.Code)
+				return nil
+			}
 		}
 		return fmt.Errorf("agency migration: %w", runErr)
 	}

--- a/internal/cli/update_clean_install.go
+++ b/internal/cli/update_clean_install.go
@@ -299,6 +299,18 @@ func runCleanReinstall(ctx context.Context, projectRoot string, opts CleanReinst
 			mergeableBackups = append(mergeableBackups, updatemerge.FileBackup{Path: mf, Data: data})
 		}
 	}
+	// Backup .gitignore for the user-pattern EntryMerge after deploy (issues
+	// #1131/#1094): the Step 5 force-deploy overwrites .gitignore with the
+	// template version, silently dropping user-added patterns. This mirrors
+	// the normal `moai update` path's Backup-step capture. .gitignore is
+	// intentionally NOT part of the PRESERVE inventory — Step 7 requires
+	// byte-identical restore, while .gitignore must MERGE (deployed template
+	// content + user additions appended).
+	var gitignoreBackup []byte
+	if data, readErr := os.ReadFile(filepath.Join(projectRoot, ".gitignore")); readErr == nil {
+		gitignoreBackup = data
+	}
+
 	// ---------------------------------------------------------------
 	// Step 5 — Reinstall embedded templates
 	// ---------------------------------------------------------------
@@ -359,11 +371,23 @@ func runCleanReinstall(ctx context.Context, projectRoot string, opts CleanReinst
 	// to the normal path's (AC-RIL-007), not a lower-protection bypass. The
 	// preserved config files are OUTSIDE the PRESERVE inventory (inv.Files), so the
 	// Step 7 byte-identical integrity check does not flag their merged content.
+	// Log-claim accuracy: each restoration below reports its own success line
+	// scoped to what actually ran, instead of one unconditional
+	// "merge-preserved" claim emitted even when nothing was backed up.
 	if configBackupPath != "" {
 		// nil recorder: the noise-suppression merge-history ledger stays in the
 		// normal update flow; the clean-reinstall path does not need it.
 		if restoreErr := backup.RestoreMoaiConfig(projectRoot, configBackupPath, nil); restoreErr != nil {
 			return result, fmt.Errorf("step 5.5: restore .moai/config sections: %w", restoreErr)
+		}
+		_, _ = fmt.Fprintln(out, "[clean-reinstall] .moai/config/sections/*.yaml merge-restored (user values preserved)")
+		// Backup-dir accumulation cap — the same pruning the normal path
+		// performs after its restore step (backup.CleanupOldBackups). Only
+		// timestamped config-backup dirs under .moai-backups/ are candidates;
+		// the v2-to-v3-* forensic backups live under .moai/backups/ and are
+		// never touched by this cleanup.
+		if deleted := backup.CleanupOldBackups(projectRoot, 5); deleted > 0 {
+			_, _ = fmt.Fprintf(out, "[clean-reinstall] Cleaned up %d old config backup(s)\n", deleted)
 		}
 	}
 	if len(mergeableBackups) > 0 {
@@ -371,9 +395,22 @@ func runCleanReinstall(ctx context.Context, projectRoot string, opts CleanReinst
 		// warning (not a hard error) matches the normal path's tolerance.
 		if mergeErr := updatemerge.MergeUserFiles(projectRoot, mergeableBackups, out); mergeErr != nil {
 			_, _ = fmt.Fprintf(out, "[clean-reinstall] settings merge warning: %v\n", mergeErr)
+		} else {
+			_, _ = fmt.Fprintln(out, "[clean-reinstall] settings.json / status_line.sh merge-preserved")
 		}
 	}
-	_, _ = fmt.Fprintln(out, "[clean-reinstall] user config (settings.json + sections/*.yaml) merge-preserved")
+	// Merge .gitignore: preserve user-added patterns via EntryMerge (issues
+	// #1131/#1094) — the same updatemerge.MergeGitignoreFile call the normal
+	// `moai update` path performs after deploy. Warn-not-fail matches that
+	// path's tolerance.
+	if len(gitignoreBackup) > 0 {
+		gitignorePath := filepath.Join(projectRoot, ".gitignore")
+		if mergeErr := updatemerge.MergeGitignoreFile(gitignorePath, gitignoreBackup); mergeErr != nil {
+			_, _ = fmt.Fprintf(out, "[clean-reinstall] .gitignore merge warning: %v\n", mergeErr)
+		} else {
+			_, _ = fmt.Fprintln(out, "[clean-reinstall] .gitignore user patterns preserved")
+		}
+	}
 
 	// One-shot v2->v3 deny-rule migration (issue #1101): the wholesale
 	// settings.json preservation above also preserves retired v2-era deny
@@ -418,7 +455,10 @@ func runCleanReinstall(ctx context.Context, projectRoot string, opts CleanReinst
 		_, _ = fmt.Fprintf(out, "[clean-reinstall] Integrity check FAILED: %d mismatches\n", len(mismatches))
 		return result, fmt.Errorf("step 7: PRESERVE integrity violation on %d paths (backup retained at %s)", len(mismatches), finalBackupDir)
 	}
-	_, _ = fmt.Fprintln(out, "[clean-reinstall] Integrity check PASSED")
+	// Log-claim accuracy: the integrity check covers ONLY the PRESERVE
+	// inventory hashes (inv.Files) — not merged config, settings, or
+	// .gitignore, whose content legitimately changes via the merges above.
+	_, _ = fmt.Fprintf(out, "[clean-reinstall] Integrity check PASSED (%d PRESERVE-inventory files verified)\n", len(hashesPre))
 
 	return result, nil
 }

--- a/internal/cli/update_clean_install.go
+++ b/internal/cli/update_clean_install.go
@@ -69,11 +69,17 @@ type CleanReinstallOptions struct {
 	// new manifest.Manager using projectRoot.
 	Manifest manifest.Manager
 
+	// Force: propagate the CLI --force flag to the Step 3.5 agency-migration
+	// adapter (issue #1132). When true, an explicit `moai update --force`
+	// performs a real forced migration (overwriting existing targets) instead
+	// of the already-migrated skip no-op.
+	Force bool
+
 	// RunMigrateAgency: optional override for the .agency/ → .moai/ migration
 	// invocation (REQ-VVCR-025). nil defaults to a no-op when not testing;
 	// production callers from M5 inject the canonical runMigrateAgency
 	// adapter that proxies cobra command flags.
-	RunMigrateAgency func(projectRoot string, dryRun bool, out io.Writer) error
+	RunMigrateAgency func(projectRoot string, dryRun, force bool, out io.Writer) error
 }
 
 // CleanReinstallResult summarizes the outcome of runCleanReinstall for
@@ -218,7 +224,7 @@ func runCleanReinstall(ctx context.Context, projectRoot string, opts CleanReinst
 	// Step 3.5 — Auto-invoke .agency/ migration if present (REQ-VVCR-025)
 	// ---------------------------------------------------------------
 	if fp.V2DetectedViaAgencyDir && opts.RunMigrateAgency != nil {
-		if err := opts.RunMigrateAgency(projectRoot, opts.DryRun, out); err != nil {
+		if err := opts.RunMigrateAgency(projectRoot, opts.DryRun, opts.Force, out); err != nil {
 			return result, fmt.Errorf("step 3.5: auto-invoke migrate agency: %w", err)
 		}
 		result.AgencyMigrated = true
@@ -293,7 +299,6 @@ func runCleanReinstall(ctx context.Context, projectRoot string, opts CleanReinst
 			mergeableBackups = append(mergeableBackups, updatemerge.FileBackup{Path: mf, Data: data})
 		}
 	}
-
 	// ---------------------------------------------------------------
 	// Step 5 — Reinstall embedded templates
 	// ---------------------------------------------------------------

--- a/internal/cli/update_clean_install_config_preserve_test.go
+++ b/internal/cli/update_clean_install_config_preserve_test.go
@@ -43,6 +43,9 @@ func (d *overwritingDeployer) Deploy(ctx context.Context, projectRoot string, mg
 		".moai/config/sections/user.yaml":     "user:\n  name: \"\"\n",
 		".moai/config/sections/language.yaml": "language:\n  conversation_language: \"en\"\n",
 		".moai/config/sections/design.yaml":   "design:\n  default_framework: \"next.js\"\n",
+		// .gitignore is force-deployed too (issues #1131/#1094): the template
+		// version carries no user patterns.
+		".gitignore": "# MoAI template gitignore\n.moai/cache/\n.moai/logs/\n",
 	}
 	for rel, content := range clobber {
 		abs := filepath.Join(projectRoot, filepath.FromSlash(rel))
@@ -90,6 +93,11 @@ func makeConfigPreserveFixture(t *testing.T) string {
 
 	// A PRESERVE-inventory seed so the reinstall has inventory work too.
 	writeTestFile(t, root, ".moai/specs/SPEC-USER-CFG/spec.md", "user spec\n")
+
+	// User-customized .gitignore (issues #1131/#1094): template lines plus a
+	// user-added pattern that MUST survive the force-deploy clobber.
+	writeTestFile(t, root, ".gitignore",
+		"# MoAI template gitignore\n.moai/cache/\n.moai/logs/\nuser-secret-dir/\n")
 	return root
 }
 
@@ -220,5 +228,17 @@ func TestCleanReinstall_MatchesNormalPathProtection(t *testing.T) {
 	}
 	if got := yamlNestedString(t, root, ".moai/config/sections/user.yaml", "user", "name"); got != "GOOS-CUSTOM-NAME" {
 		t.Errorf("clean-reinstall provided lower protection than the normal path: user.yaml name = %q", got)
+	}
+
+	// .gitignore parity (issues #1131/#1094): the normal path merges user
+	// patterns back after deploy (updatemerge.MergeGitignoreFile); the clean
+	// path must provide the same protection.
+	gitignore, err := os.ReadFile(filepath.Join(root, ".gitignore"))
+	if err != nil {
+		t.Fatalf("read .gitignore: %v", err)
+	}
+	if !strings.Contains(string(gitignore), "user-secret-dir/") {
+		t.Errorf("clean-reinstall provided lower protection than the normal path: "+
+			".gitignore lost user pattern user-secret-dir/; content:\n%s", gitignore)
 	}
 }

--- a/internal/cli/update_clean_install_test.go
+++ b/internal/cli/update_clean_install_test.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/modu-ai/moai-adk/internal/manifest"
@@ -66,14 +67,16 @@ func (s *stubDeployer) ExtractTemplate(name string) ([]byte, error) {
 // stubMigrateRunner is the fake adapter for opts.RunMigrateAgency. Records
 // invocations for assertion.
 type stubMigrateRunner struct {
-	calls    int
-	lastRoot string
-	err      error
+	calls     int
+	lastRoot  string
+	lastForce bool
+	err       error
 }
 
-func (s *stubMigrateRunner) Run(projectRoot string, dryRun bool, out io.Writer) error {
+func (s *stubMigrateRunner) Run(projectRoot string, dryRun, force bool, out io.Writer) error {
 	s.calls++
 	s.lastRoot = projectRoot
+	s.lastForce = force
 	return s.err
 }
 
@@ -963,5 +966,92 @@ func TestFingerprintPredicate_CrossPlatformParity(t *testing.T) {
 			t.Errorf("iteration %d: AC-CRR-010(a): IsV2=true on a v3 project; "+
 				"verdict must be a stable false on %s", i, runtime.GOOS)
 		}
+	}
+}
+
+// TestReproduction_MigrateTargetExistsLoop_Issue1132 reproduces the #1132
+// permanent-retry loop: a v2-fingerprint project whose .agency/ legacy
+// directory remains while a migration target (.moai/config/sections/design.yaml)
+// already exists — e.g. an earlier interrupted update already deployed the v3
+// template that ships design.yaml.
+//
+// Pre-fix mechanics: runAgencyMigrationAdapter hardcodes force=false, so the
+// migrateAgencyRunner's checkTargetsAbsent gate returns MIGRATE_TARGET_EXISTS,
+// runCleanReinstall aborts at Step 3.5 BEFORE Step 4 removes .agency/, the v2
+// fingerprint (Signal 2) stays positive, and every subsequent `moai update`
+// re-enters the same abort — a permanent retry loop the CLI --force flag never
+// reaches.
+//
+// Post-fix: the adapter treats MIGRATE_TARGET_EXISTS (and
+// MIGRATE_ARCHIVE_EXISTS) as already-migrated no-ops, so the reinstall
+// completes, Step 4 removes .agency/, and the migration never re-fires.
+//
+// Pre-fix: runCleanReinstall returns "step 3.5: ... MIGRATE_TARGET_EXISTS" → FAIL.
+// Post-fix: reinstall completes; second run has no .agency/ signal → PASS.
+func TestReproduction_MigrateTargetExistsLoop_Issue1132(t *testing.T) {
+	root := t.TempDir()
+	// v2 fingerprint: v2.* version (Signal 1) + .agency/ residue (Signal 2).
+	writeTestFile(t, root, ".moai/config/sections/system.yaml",
+		"moai:\n    version: v2.16.1\n")
+	makeTestDir(t, root, ".agency")
+	writeTestFile(t, root, ".agency/index.md", "legacy agency content\n")
+	// The #1132 trigger: a migration target already exists on disk.
+	writeTestFile(t, root, ".moai/config/sections/design.yaml",
+		"design:\n    default_framework: flutter\n")
+
+	var out bytes.Buffer
+	opts := CleanReinstallOptions{
+		Out:      &out,
+		Deployer: &stubDeployer{},
+		// The REAL adapter — the loop lives in its error handling, so the
+		// stubMigrateRunner must not stand in for it here.
+		RunMigrateAgency: runAgencyMigrationAdapter,
+	}
+
+	// First run: pre-fix this aborts at Step 3.5 with MIGRATE_TARGET_EXISTS.
+	result, err := runCleanReinstall(context.Background(), root, opts)
+	if err != nil {
+		t.Fatalf("#1132 regression: clean-reinstall aborted on a pre-existing "+
+			"migration target (permanent retry loop): %v", err)
+	}
+	if !result.AgencyMigrated {
+		t.Errorf("first run: AgencyMigrated = false; want true (Step 3.5 ran)")
+	}
+	if !strings.Contains(out.String(), "agency migration skipped: target already migrated") {
+		t.Errorf("first run: missing skip log line; output:\n%s", out.String())
+	}
+
+	// Step 4 must have removed the loop-driving Signal 2 residue.
+	if _, statErr := os.Stat(filepath.Join(root, ".agency")); !os.IsNotExist(statErr) {
+		t.Errorf(".agency/ still present after clean-reinstall (statErr=%v); "+
+			"Signal 2 stays positive → the retry loop persists", statErr)
+	}
+
+	// The pre-existing migration target is untouched by the skip path.
+	design, readErr := os.ReadFile(filepath.Join(root, ".moai/config/sections/design.yaml"))
+	if readErr != nil {
+		t.Fatalf("read design.yaml after reinstall: %v", readErr)
+	}
+	if !strings.Contains(string(design), "flutter") {
+		t.Errorf("design.yaml content clobbered by the skip path: %s", design)
+	}
+
+	// Signal 2 converged: the fingerprint no longer reports the agency dir.
+	fp2, fpErr := detectV2Fingerprint(root)
+	if fpErr != nil {
+		t.Fatalf("second fingerprint: %v", fpErr)
+	}
+	if fp2.V2DetectedViaAgencyDir {
+		t.Errorf("second fingerprint: V2DetectedViaAgencyDir = true; want false")
+	}
+
+	// Second run is a migration no-op: no .agency/ → Step 3.5 gate closed,
+	// and the reinstall completes cleanly again (no re-abort).
+	result2, err2 := runCleanReinstall(context.Background(), root, opts)
+	if err2 != nil {
+		t.Fatalf("second run: unexpected error (loop not converged): %v", err2)
+	}
+	if result2.AgencyMigrated {
+		t.Errorf("second run: AgencyMigrated = true; want false (no .agency/ left)")
 	}
 }

--- a/internal/cli/update_clean_install_test.go
+++ b/internal/cli/update_clean_install_test.go
@@ -1055,3 +1055,121 @@ func TestReproduction_MigrateTargetExistsLoop_Issue1132(t *testing.T) {
 		t.Errorf("second run: AgencyMigrated = true; want false (no .agency/ left)")
 	}
 }
+
+// gitignoreClobberingDeployer reproduces the #1131/#1094 clobber: on Deploy()
+// it overwrites .gitignore with template-only content — exactly what the real
+// forceUpdate deployer does to a v2 project's .gitignore, silently dropping
+// every user-added pattern because the clean-reinstall path (pre-fix) never
+// captured or merged the user's .gitignore the way the normal `moai update`
+// path does (EntryMerge via updatemerge.MergeGitignoreFile).
+type gitignoreClobberingDeployer struct {
+	deployCalls int
+}
+
+func (d *gitignoreClobberingDeployer) Deploy(ctx context.Context, projectRoot string, mgr manifest.Manager, tmplCtx *template.TemplateContext) error {
+	d.deployCalls++
+	content := "# MoAI template gitignore\n.moai/cache/\n.moai/logs/\nnode_modules/\n"
+	return os.WriteFile(filepath.Join(projectRoot, ".gitignore"), []byte(content), 0o644)
+}
+
+func (d *gitignoreClobberingDeployer) ListTemplates() []string { return nil }
+func (d *gitignoreClobberingDeployer) ValidateAll(ctx context.Context, c *template.TemplateContext) error {
+	return nil
+}
+func (d *gitignoreClobberingDeployer) ExtractTemplate(name string) ([]byte, error) { return nil, nil }
+
+// TestReproduction_GitignoreUserBlockDeleted_Issue1131 reproduces the
+// #1131/#1094 data loss: a v2 project's .gitignore carrying user-added
+// patterns loses them across the clean-reinstall because Step 5's force-deploy
+// overwrites .gitignore with the template version and (pre-fix) no backup +
+// EntryMerge step existed on the clean path — unlike the normal `moai update`
+// path, which backs up .gitignore before deploy and merges user patterns back
+// afterwards.
+//
+// Pre-fix: user patterns absent from post-reinstall .gitignore → FAIL.
+// Post-fix: Step 4.5 captures .gitignore, Step 5.5 merges user additions back
+// under the "User Custom Patterns" header → PASS.
+func TestReproduction_GitignoreUserBlockDeleted_Issue1131(t *testing.T) {
+	root := t.TempDir()
+	// v2 fingerprint via v2.* version + a deprecated path (Signals 1 + 3).
+	writeTestFile(t, root, ".moai/config/sections/system.yaml",
+		"moai:\n    version: v2.16.1\n")
+	writeTestFile(t, root, ".claude/agents/moai/manager-strategy.md", "retired\n")
+	writeTestFile(t, root, ".moai/specs/SPEC-USER-GI/spec.md", "user spec\n")
+
+	// The user's .gitignore: template-era lines + user-added patterns.
+	writeTestFile(t, root, ".gitignore",
+		"# MoAI template gitignore\n.moai/cache/\n.moai/logs/\n\n"+
+			"# User Custom Patterns (preserved by moai update)\n"+
+			"my-secret-dir/\n*.private\n")
+
+	var out bytes.Buffer
+	_, err := runCleanReinstall(context.Background(), root, CleanReinstallOptions{
+		Out:              &out,
+		Deployer:         &gitignoreClobberingDeployer{},
+		RunMigrateAgency: (&stubMigrateRunner{}).Run,
+	})
+	if err != nil {
+		t.Fatalf("runCleanReinstall: %v", err)
+	}
+
+	data, readErr := os.ReadFile(filepath.Join(root, ".gitignore"))
+	if readErr != nil {
+		t.Fatalf("read .gitignore after reinstall: %v", readErr)
+	}
+	content := string(data)
+
+	// #1131/#1094: user-added patterns must survive the clean-reinstall.
+	for _, pattern := range []string{"my-secret-dir/", "*.private"} {
+		if !strings.Contains(content, pattern) {
+			t.Errorf("#1131 regression: user .gitignore pattern %q lost after clean-reinstall; content:\n%s",
+				pattern, content)
+		}
+	}
+	// The deployed template content is kept as-is (merge appends, not restores).
+	if !strings.Contains(content, "node_modules/") {
+		t.Errorf("deployed template .gitignore content missing after merge; content:\n%s", content)
+	}
+}
+
+// TestCleanReinstall_PrunesOldConfigBackups verifies the clean path applies
+// the same config-backup accumulation cap the normal `moai update` path
+// applies after its restore step (backup.CleanupOldBackups keepCount=5).
+// Without the cap, the pre-fix #1132 retry loop left one new
+// .moai-backups/<stamp>/ directory behind on EVERY `moai update` attempt.
+func TestCleanReinstall_PrunesOldConfigBackups(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, ".moai/config/sections/system.yaml",
+		"moai:\n    version: v2.16.1\n")
+	writeTestFile(t, root, ".claude/agents/moai/manager-strategy.md", "retired\n")
+	writeTestFile(t, root, ".moai/specs/SPEC-USER-PRUNE/spec.md", "user spec\n")
+
+	// Seed 7 stale timestamped config-backup dirs (the shape BackupMoaiConfig
+	// creates and CleanupOldBackups targets: YYYYMMDD_HHMMSS under .moai-backups/).
+	for i := 1; i <= 7; i++ {
+		makeTestDir(t, root, fmt.Sprintf(".moai-backups/2025010%d_000000", i))
+	}
+
+	if _, err := runCleanReinstall(context.Background(), root, CleanReinstallOptions{
+		Out:              io.Discard,
+		Deployer:         &stubDeployer{},
+		RunMigrateAgency: (&stubMigrateRunner{}).Run,
+	}); err != nil {
+		t.Fatalf("runCleanReinstall: %v", err)
+	}
+
+	entries, err := os.ReadDir(filepath.Join(root, ".moai-backups"))
+	if err != nil {
+		t.Fatalf("read .moai-backups: %v", err)
+	}
+	var stamped int
+	for _, e := range entries {
+		if e.IsDir() && len(e.Name()) == 15 {
+			stamped++
+		}
+	}
+	// 7 stale + 1 created by Step 4.5 = 8; the keepCount=5 cap prunes to 5.
+	if stamped != 5 {
+		t.Errorf("config-backup accumulation cap not applied: %d timestamped dirs remain; want 5", stamped)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the v2→v3 clean-reinstall defect cluster reported in #1131, #1094, #1132.

- **#1132**: `runAgencyMigrationAdapter` treats `MIGRATE_TARGET_EXISTS` / `MIGRATE_ARCHIVE_EXISTS` as already-migrated no-ops (same pattern as the existing `ErrMigrateNoSource` swallow), ending the permanent retry loop. `--force` is now plumbed through `CleanReinstallOptions` to perform a real forced migration when explicitly requested.
- **#1131 / #1094**: clean-reinstall now backs up `.gitignore` in Step 4.5 and merges it back via the existing `updatemerge.MergeGitignoreFile` in Step 5.5 — exact parity with the normal update path, preserving the `# User Custom Patterns` block.
- **Log-claim correction**: the unconditional "merge-preserved" line is replaced with per-restoration scoped lines; "Integrity check PASSED" now names its actual scope (PRESERVE-inventory file hashes only).
- Hardening: clean path now prunes old `v2-to-v3-*` backup dirs (cap 5, normal-path parity).

## Tests

- `TestReproduction_MigrateTargetExistsLoop_Issue1132` (RED→GREEN)
- `TestReproduction_GitignoreUserBlockDeleted_Issue1131` (RED→GREEN)
- `TestCleanReinstall_MatchesNormalPathProtection` extended with gitignore-parity assertion
- Adapter-level swallow/force tests; `TestCleanReinstall_PrunesOldConfigBackups`
- Full suite: `go test ./...` 107 packages ok · `go vet` clean · `golangci-lint` 0 issues

## Notes

- "Step 3.5 failure non-fatal" hardening was **rejected as unsafe**: `.agency/` is not in the preserve inventory and Step 4 removes it, so warn-and-continue after a genuine migration failure would destroy unmigrated legacy data.
- Deferred debt: `verifyNamespaceBackupCoverage` on the clean path (needs snapshot-set expansion first); pre-existing `CleanupOldBackups` keeps oldest-5 quirk flagged for review.

Closes #1131
Closes #1132
Closes #1094

🗿 MoAI