### PR TITLE
fix(hooks): add fork to SessionStart matcher (CC 2.1.214 regression)

### DIFF
--- a/.claude/rules/moai/core/hooks-system.md
+++ b/.claude/rules/moai/core/hooks-system.md
@@ -16,7 +16,7 @@ Active settings.json keys: 20. RETIRE-OBS-ONLY (Go-only): 4.
 
 | Event | Matcher | Can Block | Description |
 |-------|---------|-----------|-------------|
-| SessionStart | Source | No | Runs when a new session begins. Matchers: startup, resume, clear, compact |
+| SessionStart | Source | No | Runs when a new session begins. Matchers: startup, resume, clear, compact, fork |
 | SessionEnd | Reason | No | Runs when session terminates. Matchers: clear, resume, logout, prompt_input_exit, bypass_permissions_disabled, other |
 | PostSession | No | No | Runs after a session ends (self-hosted runner lifecycle event, CC 2.1.169+). Fires once the session is fully torn down, later than SessionEnd. MoAI-ADK does not wire this hook today; documented as an available option for self-hosted deployments that need post-session cleanup/telemetry. |
 | PreToolUse | Tool name | Yes | Runs before a tool executes |
@@ -226,7 +226,7 @@ Define hooks in `.claude/settings.json`. Each event key maps to an array of matc
 {
   "hooks": {
     "SessionStart": [{
-      "matcher": "startup|resume|clear|compact",
+      "matcher": "startup|resume|clear|compact|fork",
       "hooks": [{
         "type": "command",
         "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-session-start.sh\"",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,7 @@
   "hooks": {
     "SessionStart": [
       {
-        "matcher": "startup|resume|clear|compact",
+        "matcher": "startup|resume|clear|compact|fork",
         "hooks": [
           {
             "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-session-start.sh\"",

--- a/internal/template/templates/.claude/rules/moai/core/hooks-system.md
+++ b/internal/template/templates/.claude/rules/moai/core/hooks-system.md
@@ -16,7 +16,7 @@ Active settings.json keys: 20. RETIRE-OBS-ONLY (Go-only): 4.
 
 | Event | Matcher | Can Block | Description |
 |-------|---------|-----------|-------------|
-| SessionStart | Source | No | Runs when a new session begins. Matchers: startup, resume, clear, compact |
+| SessionStart | Source | No | Runs when a new session begins. Matchers: startup, resume, clear, compact, fork |
 | SessionEnd | Reason | No | Runs when session terminates. Matchers: clear, resume, logout, prompt_input_exit, bypass_permissions_disabled, other |
 | PostSession | No | No | Runs after a session ends (self-hosted runner lifecycle event, CC 2.1.169+). Fires once the session is fully torn down, later than SessionEnd. MoAI-ADK does not wire this hook today; documented as an available option for self-hosted deployments that need post-session cleanup/telemetry. |
 | PreToolUse | Tool name | Yes | Runs before a tool executes |
@@ -226,7 +226,7 @@ Define hooks in `.claude/settings.json`. Each event key maps to an array of matc
 {
   "hooks": {
     "SessionStart": [{
-      "matcher": "startup|resume|clear|compact",
+      "matcher": "startup|resume|clear|compact|fork",
       "hooks": [{
         "type": "command",
         "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-session-start.sh\"",

--- a/internal/template/templates/.claude/settings.json.tmpl
+++ b/internal/template/templates/.claude/settings.json.tmpl
@@ -3,7 +3,7 @@
   "hooks": {
     "SessionStart": [
       {
-        "matcher": "startup|resume|clear|compact",
+        "matcher": "startup|resume|clear|compact|fork",
         "hooks": [
           {
 {{- if eq .Platform "windows"}}


### PR DESCRIPTION
## Summary
Since Claude Code 2.1.214, forked sessions (`--fork-session`, `/fork`, `/branch`) report SessionStart source `fork` instead of `resume`. MoAI's SessionStart matcher `startup|resume|clear|compact` no longer matched, so the hook (GLM credential injection, `CLAUDE_ENV_FILE`, session registration) has been silently skipped on forked sessions for 5 upstream versions.

## Changes
- `.claude/settings.json` + template mirror `settings.json.tmpl`: matcher → `startup|resume|clear|compact|fork`
- `hooks-system.md` (live + template): document the `fork` source

## Evidence
- Upstream changelog 2.1.214: "Changed SessionStart hooks to report source 'fork' when a session begins as a fork instead of 'resume'"
- Research report: `.moai/research/cc-update-2.1.207-to-2.1.219.md` §GD-3

## Verification
- `go build ./...` clean; `go test ./internal/template/... ./internal/cli/...` green
- No test references the old matcher string

🗿 MoAI