### PR TITLE
docs(rules): add merge convergence under a strict base to the CI watch protocol

### DIFF
--- a/.claude/rules/moai/workflow/ci-watch-protocol.md
+++ b/.claude/rules/moai/workflow/ci-watch-protocol.md
@@ -192,5 +192,86 @@ both `gh pr checks --watch` and `run_in_background: true` literals.
 
 ---
 
-Version: 1.1.0
+## Merge Convergence Under a Strict Base
+
+Applies when the base branch requires branches to be up to date before merging
+(GitHub branch protection `required_status_checks.strict: true`). Under that
+setting a merge into the base makes every other open pull request `BEHIND`, and
+bringing one up to date **restarts its entire check suite from zero**.
+
+Two failure modes follow, and both are self-inflicted.
+
+### Failure mode 1 — update-restart livelock
+
+Updating a branch whose own checks are still running discards their progress and
+starts them again. Repeat that while waiting for a long-tail check — a
+cross-platform test matrix routinely runs ten minutes or more — and the check
+can never complete. The pull request appears permanently `pending`, and the loop
+looks like slow CI rather than the caller resetting it.
+
+[ZONE:Evolvable] [HARD] Do NOT update a branch while any of its own required
+checks is `pending`. Update only when the check set has settled — every required
+check `pass` or `fail`, none `pending` — AND merge state is `BEHIND`.
+
+### Failure mode 2 — parallel update convergence collapse
+
+Updating several pull requests in the same round makes them all up to date at
+once. The first to merge returns every other one to `BEHIND`, and each of those
+restarts a full check suite. For N pull requests against a base whose slowest
+check takes T, updating in parallel costs on the order of N²·T; serializing
+costs N·T.
+
+[ZONE:Evolvable] [HARD] Drive **one** pull request to merge at a time. Do not
+update a second branch until the first has merged or has been abandoned.
+
+### Procedure
+
+```bash
+# 1. Enable auto-merge once per PR. GitHub merges each one as soon as its
+#    requirements are met, so no polling is needed to complete the merge.
+gh pr merge <PR> --squash --auto
+
+# 2. Read state without mutating it.
+gh pr view <PR> --json state,mergeStateStatus --jq '"\(.state) \(.mergeStateStatus)"'
+gh pr checks <PR> --json name,bucket
+
+# 3. Update ONLY when checks have settled and the branch is BEHIND.
+gh pr update-branch <PR>
+```
+
+Between steps, follow § Background watch standardization — `gh pr checks --watch`
+under `run_in_background: true`, never a foreground `sleep N` loop. The
+sleep-and-poll anti-pattern is what turns a slow merge into an hour of blocked
+wall-time, and it compounds this section's failure modes by hiding them behind
+apparent progress.
+
+### Bounded retries
+
+[ZONE:Evolvable] [HARD] Allow at most **3** update cycles per pull request.
+Exceeding that means the base is advancing faster than the check suite
+completes, which no amount of retrying resolves. Stop, report the situation, and
+let the user choose: pause the other merge sources, adopt a merge queue, batch
+the changes into one pull request, or accept a longer settle window.
+
+Never leave an unbounded update-or-poll loop running. A loop with no exit
+condition other than success cannot report the case where success is
+unreachable.
+
+### Anti-patterns
+
+```bash
+# PROHIBITED — updates while the PR's own checks are still running.
+for pr in 1 2 3; do gh pr update-branch $pr; done; sleep 60
+```
+
+- Updating a branch on a `pending` check set — resets the work being waited on.
+- Updating several pull requests in one round under a strict base — guarantees
+  that all but one are immediately invalidated again.
+- Treating `mergeStateStatus: UNKNOWN` as a failure. It means GitHub has not
+  finished computing mergeability; re-read it rather than acting on it.
+- Foreground `sleep N` polling of a check that takes minutes.
+
+---
+
+Version: 1.2.0
 Classification: HARD operational rule, applies to all /moai sync workflows

--- a/internal/template/templates/.claude/rules/moai/workflow/ci-watch-protocol.md
+++ b/internal/template/templates/.claude/rules/moai/workflow/ci-watch-protocol.md
@@ -192,5 +192,86 @@ both `gh pr checks --watch` and `run_in_background: true` literals.
 
 ---
 
-Version: 1.1.0
+## Merge Convergence Under a Strict Base
+
+Applies when the base branch requires branches to be up to date before merging
+(GitHub branch protection `required_status_checks.strict: true`). Under that
+setting a merge into the base makes every other open pull request `BEHIND`, and
+bringing one up to date **restarts its entire check suite from zero**.
+
+Two failure modes follow, and both are self-inflicted.
+
+### Failure mode 1 — update-restart livelock
+
+Updating a branch whose own checks are still running discards their progress and
+starts them again. Repeat that while waiting for a long-tail check — a
+cross-platform test matrix routinely runs ten minutes or more — and the check
+can never complete. The pull request appears permanently `pending`, and the loop
+looks like slow CI rather than the caller resetting it.
+
+[ZONE:Evolvable] [HARD] Do NOT update a branch while any of its own required
+checks is `pending`. Update only when the check set has settled — every required
+check `pass` or `fail`, none `pending` — AND merge state is `BEHIND`.
+
+### Failure mode 2 — parallel update convergence collapse
+
+Updating several pull requests in the same round makes them all up to date at
+once. The first to merge returns every other one to `BEHIND`, and each of those
+restarts a full check suite. For N pull requests against a base whose slowest
+check takes T, updating in parallel costs on the order of N²·T; serializing
+costs N·T.
+
+[ZONE:Evolvable] [HARD] Drive **one** pull request to merge at a time. Do not
+update a second branch until the first has merged or has been abandoned.
+
+### Procedure
+
+```bash
+# 1. Enable auto-merge once per PR. GitHub merges each one as soon as its
+#    requirements are met, so no polling is needed to complete the merge.
+gh pr merge <PR> --squash --auto
+
+# 2. Read state without mutating it.
+gh pr view <PR> --json state,mergeStateStatus --jq '"\(.state) \(.mergeStateStatus)"'
+gh pr checks <PR> --json name,bucket
+
+# 3. Update ONLY when checks have settled and the branch is BEHIND.
+gh pr update-branch <PR>
+```
+
+Between steps, follow § Background watch standardization — `gh pr checks --watch`
+under `run_in_background: true`, never a foreground `sleep N` loop. The
+sleep-and-poll anti-pattern is what turns a slow merge into an hour of blocked
+wall-time, and it compounds this section's failure modes by hiding them behind
+apparent progress.
+
+### Bounded retries
+
+[ZONE:Evolvable] [HARD] Allow at most **3** update cycles per pull request.
+Exceeding that means the base is advancing faster than the check suite
+completes, which no amount of retrying resolves. Stop, report the situation, and
+let the user choose: pause the other merge sources, adopt a merge queue, batch
+the changes into one pull request, or accept a longer settle window.
+
+Never leave an unbounded update-or-poll loop running. A loop with no exit
+condition other than success cannot report the case where success is
+unreachable.
+
+### Anti-patterns
+
+```bash
+# PROHIBITED — updates while the PR's own checks are still running.
+for pr in 1 2 3; do gh pr update-branch $pr; done; sleep 60
+```
+
+- Updating a branch on a `pending` check set — resets the work being waited on.
+- Updating several pull requests in one round under a strict base — guarantees
+  that all but one are immediately invalidated again.
+- Treating `mergeStateStatus: UNKNOWN` as a failure. It means GitHub has not
+  finished computing mergeability; re-read it rather than acting on it.
+- Foreground `sleep N` polling of a check that takes minutes.
+
+---
+
+Version: 1.2.0
 Classification: HARD operational rule, applies to all /moai sync workflows


### PR DESCRIPTION
Adds a **Merge Convergence Under a Strict Base** section to
`.claude/rules/moai/workflow/ci-watch-protocol.md` (+ template mirror).

## Why

With branch protection `required_status_checks.strict: true`, a merge into the
base makes every other open PR `BEHIND`, and `gh pr update-branch` **restarts
that PR's whole check suite from zero**. Two failure modes follow — both caused
by the caller, not by slow CI.

**Update-restart livelock.** Updating a branch whose own checks are still
running discards their progress. Repeat that while waiting on a long-tail check
— a cross-platform test matrix routinely exceeds ten minutes — and the check can
never finish. The PR looks permanently `pending`, so the symptom reads as slow
CI while the caller is the one resetting it.

**Parallel update convergence collapse.** Updating several PRs in one round
makes them all up to date together; the first merge returns the rest to
`BEHIND`, and each restarts a full suite. For N PRs against a base whose slowest
check takes T, parallel updates cost on the order of **N²·T** where serializing
costs **N·T**.

This was hit for real while landing the sibling PRs in this batch — roughly an
hour of wall-time went to a loop that could not converge.

## What the section adds

Three HARD rules:

1. **Never update while the PR's own required checks are `pending`** — update
   only when the set has settled (every required check `pass`/`fail`, none
   `pending`) and merge state is `BEHIND`.
2. **Drive one PR to merge at a time** — do not update a second branch until the
   first has merged or been abandoned.
3. **Cap update cycles at 3 per PR** — exceeding that means the base advances
   faster than CI completes, which retrying cannot fix. Stop and report so the
   user can choose: pause other merge sources, adopt a merge queue, batch into
   one PR, or accept a longer settle window.

Plus the read-only inspection commands, an anti-pattern list, and a note that
`mergeStateStatus: UNKNOWN` means "not yet computed" rather than "failed".

It also points back at the existing **Background watch standardization** section
in the same file. Foreground `sleep N` polling is already prohibited there; it
compounds these failure modes by hiding them behind apparent progress, which is
how an unbounded retry loop survives long enough to matter.

## Verification

| Check | Result |
|-------|--------|
| `make build` | exit 0 — `catalog.yaml` regenerated identical |
| Binary embedding | `strings bin/moai` matches the new section heading |
| `go test ./...` | exit 0 — 106 ok / 0 FAIL |
| Local ↔ template mirror | byte-identical |
| Existing CI-watch AC literals | preserved — `gh pr checks <PR> --watch` ×1, `run_in_background: true` ×5 |
| Forbidden-content scan (SPEC IDs, REQ/AC tokens, dates, SHAs, absolute host paths, local-doc refs) | all 0 |

Docs-only: no Go source touched.

🗿 MoAI