### PR TITLE
feat(SPEC-GOAL-DOCS-RETIRE-001): retire native /goal emission references across four locales (run phase, 12/12 AC)

### DIFF
--- a/.moai/docs/autonomous-workflow-strategy.md
+++ b/.moai/docs/autonomous-workflow-strategy.md
@@ -4,6 +4,7 @@
 > **대상**: moai-adk-go 메인테이너
 > **최적화 목표**: BALANCED — quality · autonomy · efficiency 3축 균형
 > **근거 primitive 버전**: Dynamic Workflows = research preview / Claude Code v2.1.154+ · `/goal` = v2.1.139+
+> **후속 (2026-07-27)**: native `/goal` emission is retired — MoAI 파이프라인의 goal 표면은 `/moai goal` 하나로 통합되었다. 아래 3-엔진 모델은 제안 시점의 기록으로 보존한다.
 
 ---
 

--- a/.moai/specs/SPEC-GOAL-DOCS-RETIRE-001/acceptance.md
+++ b/.moai/specs/SPEC-GOAL-DOCS-RETIRE-001/acceptance.md
@@ -41,7 +41,7 @@ Every detector below is therefore anchored on a token that **survives translatio
 | structural markers (`^## `, `^\| `, `^### `) | No | AC-GDR-006 |
 | `per-turn`, "continuation", "per-tool" | **Yes — PROHIBITED as anchors** | none |
 
-The meta-guard is **AC-GDR-010**: it asserts every emission detector yields exactly ONE distinct value across the four locales, **and** that each detector still matches non-zero content against the immutable recorded base — the second component being what distinguishes a swept surface from a broken regex (finding B-1).
+The meta-guard is **AC-GDR-010**: it asserts every emission detector yields exactly ONE distinct value across the four locales, **and** that each detector still matches non-zero content against the immutable recorded base, **and** that each detector's pattern actually carries a literal `/goal` token. The second component distinguishes a swept surface from a broken regex (finding B-1); the third distinguishes a detector aimed at the emission reference from one aimed at a token that merely sits beside it (finding B2-1).
 
 ### §A.3 Asymmetry carve-out — why symmetry is not an unconditional rule
 
@@ -179,7 +179,7 @@ for p in advanced/autonomous-loops.md cli-reference/handoff.md advanced/self-evo
 - Recorded baseline: `autonomous-loops.md=4 handoff.md=4 self-evolving.md=4`
 - Target: **identical** (`4` each), and AC-GDR-012 at `0`
 
-**AC-GDR-010** — **The locale-invariance meta-guard, with a liveness floor.** Compound, three components:
+**AC-GDR-010** — **The locale-invariance meta-guard, with a liveness floor and an aptness assertion.** Compound, four components:
 
 **(a) Symmetry** — every emission detector yields exactly ONE distinct value across the four locales. A prose-anchored detector produces ≥ 2 distinct values (e.g. `{2, 0}`) and fails here even while its own aggregate reads `0`.
 
@@ -187,27 +187,41 @@ for p in advanced/autonomous-loops.md cli-reference/handoff.md advanced/self-evo
 
 **(c) Asymmetry carve-out (added at audit iteration 1, finding B-2)** — component (a) is disqualifying only where the underlying **content** is locale-symmetric. Where content is genuinely locale-asymmetric, the asymmetry is recorded in the baseline with a justification and the detector is exempted from (a) **by name**. No detector is currently exempt; the exemption list is empty and any addition must cite the measured content asymmetry. See §A.3.
 
+**(d) Aptness (added at audit iteration 2, finding B2-1)** — every emission detector's match pattern contains a literal `/goal` token. Components (a) and (b) constrain a detector's *behaviour* (symmetric, non-empty against the base) but never tie it to the token the sweep must remove, so a detector that is live and symmetric yet semantically aimed elsewhere passes both. Each detector therefore declares its pattern **once** in a `p=` variable that the counting function `w()` and the aptness test both read, so a weakening of the pattern cannot leave a stale assertion behind. The mechanism is one `case` expansion, not a second command.
+
+> **Rejected alternative — base-match-set subset.** Audit iteration 2 proposed a stronger form: assert each detector's base-match line set is a subset of the base lines carrying `` `/goal` ``. It was **executed and refuted**. In the base `e306e21a9`, `ac_converge` and `auto mode` both occur on the same line as `` `/goal` `` (`advanced/autonomous-loops.md` line 7 in `en`), so both attack detectors yield `leak=0` and pass the subset test. Line granularity is exactly the granularity the "adjacent token" attack exploits, so the subset form cannot discriminate here; the pattern-literal form rejects all three controls.
+
 ```bash
 # (a) symmetry — distinct values per detector, working tree
 # (b) liveness — same detector against the immutable base, minimum across locales
+# (d) aptness  — the single pattern source $p carries a literal /goal token
 for name in paired_al auto_mode l7 paired_se handoff; do
   case $name in
-    paired_al) w() { grep -ohE '`/moai loop`[ ·/]+`/goal`' "$1" | wc -l | tr -d ' '; }; f=advanced/autonomous-loops.md;;
-    auto_mode) w() { grep -c 'auto mode.*`/goal`' "$1"; };                            f=advanced/autonomous-loops.md;;
-    l7)        w() { sed -n '7p' "$1" | grep -c '`/goal`'; };                          f=advanced/autonomous-loops.md;;
-    paired_se) w() { grep -ohE '`/moai loop`[ ·/]+`/goal`' "$1" | wc -l | tr -d ' '; }; f=advanced/self-evolving.md;;
-    handoff)   w() { grep -ohF '`/goal' "$1" | wc -l | tr -d ' '; };                    f=cli-reference/handoff.md;;
+    paired_al) p='`/moai loop`[ ·/]+`/goal`'; w() { grep -ohE "$p" "$1" | wc -l | tr -d ' '; }; f=advanced/autonomous-loops.md;;
+    auto_mode) p='auto mode.*`/goal`';        w() { grep -c "$p" "$1"; };                      f=advanced/autonomous-loops.md;;
+    l7)        p='`/goal`';                   w() { sed -n '7p' "$1" | grep -c "$p"; };        f=advanced/autonomous-loops.md;;
+    paired_se) p='`/moai loop`[ ·/]+`/goal`'; w() { grep -ohE "$p" "$1" | wc -l | tr -d ' '; }; f=advanced/self-evolving.md;;
+    handoff)   p='`/goal';                    w() { grep -ohF "$p" "$1" | wc -l | tr -d ' '; }; f=cli-reference/handoff.md;;
   esac
   d=$(for l in en ja ko zh; do w docs-site/content/$l/$f; done | sort -u | wc -l | tr -d ' ')
   m=$(for l in en ja ko zh; do git show e306e21a9:docs-site/content/$l/$f > /tmp/gdr-live.md; w /tmp/gdr-live.md; done | sort -n | head -1)
-  printf "%s:distinct=%s,live_min=%s " "$name" "$d" "$m"
+  case "$p" in *'/goal'*) a=1;; *) a=0;; esac
+  printf "%s:distinct=%s,live_min=%s,apt=%s " "$name" "$d" "$m" "$a"
 done
 ```
 
-- Recorded baseline: `paired_al:distinct=1,live_min=1 auto_mode:distinct=1,live_min=1 l7:distinct=1,live_min=1 paired_se:distinct=1,live_min=2 handoff:distinct=1,live_min=1`
-- Target: **all five keep `distinct=1` AND `live_min >= 1`**, and AC-GDR-012 at `0`
-- **Dead-detector control, executed.** The audit's typo'd anchor `auto-mode` (hyphenated, co-occurring with `` `/goal` `` nowhere) reads `distinct=1` on the working tree — passing component (a) — but `live_min=0` against `e306e21a9`, so component (b) rejects it. Both were run; this is the discriminating evidence the criterion previously lacked.
-- Symmetry and liveness both hold at baseline, so this criterion is compounded with AC-GDR-012 for falsifiability.
+- Recorded baseline: `paired_al:distinct=1,live_min=1,apt=1 auto_mode:distinct=1,live_min=1,apt=1 l7:distinct=1,live_min=1,apt=1 paired_se:distinct=1,live_min=2,apt=1 handoff:distinct=1,live_min=1,apt=1`
+- Target: **all five keep `distinct=1` AND `live_min >= 1` AND `apt=1`**, and AC-GDR-012 at `0`
+- **Three controls, all executed against this block.** Each defeats a different component, and none is defeated by the others:
+
+  | Control detector | `distinct` | `live_min` | `apt` | Rejected by |
+  |---|---|---|---|---|
+  | `auto-mode` (hyphenated typo — the iteration-1 dead-detector control) | `1` | **`0`** | — | (b) liveness |
+  | `ac_converge` (adjacent token, co-occurs with `` `/goal` `` on the same line) | `1` | `1` | **`0`** | (d) aptness |
+  | `auto mode` (AC-GDR-005's compound regex with its `` `/goal` `` half dropped) | `1` | `1` | **`0`** | (d) aptness |
+
+- The second and third controls pass (a) **and** (b) — that is the hole component (d) closes. They are the plausible-mutation path, not a contrived one: simplifying a compound regex to its untranslated-anchor half is exactly the edit a sweep makes while driving a count toward zero, and it leaves a criterion satisfiable by deleting the words "auto mode" while the native-`/goal` reference survives.
+- All four components hold at baseline, so this criterion is compounded with AC-GDR-012 for falsifiability.
 
 **AC-GDR-011** — Compound held-out: the docs-site builds **and** the aggregate emission is `0`. A sweep that broke shortcode or front-matter syntax in one locale would fail the build half.
 
@@ -266,12 +280,13 @@ The hugo build appears as AC-GDR-011's first half rather than a pure gate, becau
 | REQ-GDR-004 (per-locale baselines) | AC-GDR-001..005 | Every emission criterion records per locale |
 | REQ-GDR-009 (symmetry, content-conditioned) | AC-GDR-010 (a) + §A.3 | Component (a) plus the named-exemption carve-out |
 | REQ-GDR-010 (liveness floor) | AC-GDR-010 (b) | Detector run against the immutable base `e306e21a9` |
+| REQ-GDR-011 (aptness) | AC-GDR-010 (d) | Single `p=` pattern source asserted to carry a literal `/goal` token |
 | REQ-GDR-005 (retention register) | AC-GDR-006, AC-GDR-007, AC-GDR-008 | One guard per register row |
 | REQ-GDR-006 (do not modify CC / contrast / archives) | AC-GDR-008 | Five pinned counts |
 | REQ-GDR-007 (split surface pinned, not zeroed) | AC-GDR-006 | Per-locale structural pins |
 | REQ-GDR-008 (no locale-symmetry manufacture) | AC-GDR-008 (`hooks=2`), AC-GDR-009 (inventory) | Two independent guards: adding a line fails the first, adding a page fails the second |
 
-Coverage: **10 / 10 REQs** cited by ≥ 1 AC. Reverse: every AC-GDR-001..012 appears in ≥ 1 row. AC-GDR-010's three components are cited separately, since each answers a different requirement.
+Coverage: **11 / 11 REQs** cited by ≥ 1 AC. Reverse: every AC-GDR-001..012 appears in ≥ 1 row. AC-GDR-010's four components are cited separately, since each answers a different requirement.
 
 ---
 
@@ -280,6 +295,7 @@ Coverage: **10 / 10 REQs** cited by ≥ 1 AC. Reverse: every AC-GDR-001..012 app
 - **Sweeping `autonomous-loops.md` to zero.** Blocked by AC-GDR-006's per-locale `h3=1,h2=1,row=1` pins.
 - **Editing `en` only.** Blocked twice: the per-locale targets in AC-GDR-001..005, and AC-GDR-010's `distinct=1` requirement.
 - **Re-introducing a prose-anchored detector.** Blocked by AC-GDR-010, which fails at `distinct=2` even when the detector's own aggregate reads `0`.
+- **Substituting a live, symmetric, semantically-wrong detector** — swapping an emission anchor for an adjacent token (`ac_converge`), or dropping the `` `/goal` `` half of a compound regex. Blocked by AC-GDR-010 (d) at `apt=0`; (a) and (b) both pass in this case, which is why (d) exists.
 - **Rewriting the strategy record instead of annotating it.** Blocked by AC-GDR-007's `25` content pin.
 - **Adding `ja`/`zh` `hooks-reference.md` lines** to force symmetry. Blocked by AC-GDR-008's `hooks=2` pin.
 - **Creating a new locale page.** Blocked by AC-GDR-009's inventory pin.

--- a/.moai/specs/SPEC-GOAL-DOCS-RETIRE-001/acceptance.md
+++ b/.moai/specs/SPEC-GOAL-DOCS-RETIRE-001/acceptance.md
@@ -145,11 +145,12 @@ for l in en ja ko zh; do printf "%s:%s " $l "$(grep -ohF '`/goal' docs-site/cont
 
 ```bash
 grep -ciF 'native `/goal` emission is retired' .moai/docs/autonomous-workflow-strategy.md
-grep -ohF '`/goal' .moai/docs/autonomous-workflow-strategy.md | wc -l | tr -d ' '
+grep -vF 'native `/goal` emission is retired' .moai/docs/autonomous-workflow-strategy.md | grep -ohF '`/goal' | wc -l | tr -d ' '
 ```
 
 - Recorded baseline: `0` / `25`
 - Target: `>= 1` / `25`
+- The second detector excludes the sentinel line before counting because the phrase component 1 mandates — ``native `/goal` emission is retired`` — itself carries a backticked `` `/goal ``; counting it would drive the pin to `26` the moment component 1 is satisfied, making the compound self-contradictory. Excluding it keeps the pin asserting exactly what it means: all 25 *historical* occurrences survive.
 - A generic `grep -ciE 'superseded|retired'` is disqualified as a detector: it already reads `4` at baseline against unrelated prose. Both were run; hence the specific sentinel.
 
 ### N5 — Retention and locale-parity verification

--- a/.moai/specs/SPEC-GOAL-DOCS-RETIRE-001/acceptance.md
+++ b/.moai/specs/SPEC-GOAL-DOCS-RETIRE-001/acceptance.md
@@ -232,7 +232,7 @@ cd docs-site && hugo --quiet --destination /tmp/gdr-build >/dev/null 2>&1; echo 
 - Recorded baseline: `exit=0`
 - Target: `exit=0`, and AC-GDR-012 at `0`
 
-**AC-GDR-012** — Aggregate emission across all 8 sweep-target files reaches `0`. This is the integration criterion the four compounds above reference.
+**AC-GDR-012** — Aggregate emission across all 12 sweep-target locale files reaches `0`. This is the integration criterion the four compounds above reference.
 
 ```bash
 t=0

--- a/.moai/specs/SPEC-GOAL-DOCS-RETIRE-001/progress.md
+++ b/.moai/specs/SPEC-GOAL-DOCS-RETIRE-001/progress.md
@@ -25,7 +25,7 @@ Origin: split from `SPEC-GOAL-SURFACE-UNIFY-001` after that SPEC's plan-audit it
 - ID confirmed unused before authoring (`ls .moai/specs/SPEC-GOAL-DOCS-RETIRE-001` → `No such file or directory`).
 - **12** acceptance criteria; every judgment command executed and its verbatim baseline recorded. All 12 fail at baseline.
 - **Every emission criterion carries a per-locale baseline**, and all five emission detectors measure symmetric (`distinct=1`). This is the requirement that closes the parent's audit finding N2.
-- 10 REQs, all cited by ≥ 1 AC (`acceptance.md` §E).
+- 11 REQs, all cited by ≥ 1 AC (`acceptance.md` §E). (10 at authoring; REQ-GDR-011 added closing audit iteration 2 finding B2-1.)
 - 13 paths, single-owner across N1-N5 (`plan.md` §F.1). 41 retained files owned by no milestone.
 - Four retention surfaces registered in this SPEC's own register (`plan.md` §A.2) — not inherited from the parent.
 
@@ -54,7 +54,21 @@ The first audit confirmed Tier M correct, reproduced all 12 baselines with zero 
 | **B-6** | Beyond-minimum artifact set documented as deliberate; tier stays M |
 | **B-7** | AC-GDR-004's fallback re-specified as the locale-invariant triple co-occurrence, replacing the prose-adjacent `provides` (measured `1/1/1/1`) |
 
-_Awaiting plan-audit iteration 2 for this SPEC. N3 additionally blocked on the parent's M7 landing (`acceptance.md` §C dependency gate)._
+### Plan-audit iteration 2 — PASS 0.86 (Tier M threshold 0.80), MUST-FIX B2-1 closed
+
+Iteration 2 reproduced 12 of 12 baselines with zero divergence and scored Clarity 0.90 / Completeness 0.85 / Testability 0.80 / Traceability 0.90 (harmonic mean 0.8605). One MUST-FIX and two SHOULD-FIX were raised.
+
+| Finding | Severity | Resolution |
+|---|---|---|
+| **B2-1** — AC-GDR-010 validated liveness and symmetry but not *aptness*: a detector aimed at an adjacent token (`ac_converge`) or a compound regex with its `` `/goal` `` half dropped passes (a) and (b) while matching no emission reference | MUST-FIX | **CLOSED.** New **REQ-GDR-011**; AC-GDR-010 gained component **(d)**, asserting each detector's pattern carries a literal `/goal` token from a single `p=` source shared by `w()` and the assertion. Three controls executed: the hyphenated dead detector is rejected by (b); `ac_converge` and the weakened `auto mode` half are rejected by (d) |
+| **B2-2** — liveness against a frozen base can be stale-true; no criterion asserts the base is still current for the scoped pages | SHOULD-FIX | Open — deferred as follow-on |
+| **B2-3** — the empty exemption list is guarded by prose, not by a check | SHOULD-FIX | Open — deferred as follow-on |
+
+**Auditor's stronger alternative for B2-1 was executed and refuted.** The audit proposed asserting each detector's base-match line set is a subset of the base lines carrying `` `/goal` ``. Run against `e306e21a9`, both attack detectors yield `leak=0` and pass: `ac_converge` and `auto mode` occur on the *same line* as `` `/goal` `` (`en/advanced/autonomous-loops.md` line 7). Line granularity is precisely the granularity the adjacent-token attack exploits, so the subset form cannot discriminate. The pattern-literal form was adopted instead, with the single-`p=`-source discipline closing its own divergence risk.
+
+Residual (not in B2-1's required fix): AC-GDR-012's aggregate still carries its own inline copies of the five detector definitions, so the single-source discipline does not extend to the aggregate path.
+
+N3 remains blocked on the parent's M7 landing (`acceptance.md` §C dependency gate) — the parent is now `completed`, so the gate is expected to clear at run-phase entry and must be re-measured there.
 
 ## §E.2 Run-phase Evidence
 
@@ -67,3 +81,36 @@ _<pending run-phase>_
 ## §E.4 Sync-phase Audit-Ready Signal
 
 _<pending sync-phase>_
+
+## §F Phase 4 Mode Selection
+
+**Decision: sub-agent** (Mode 5, sequential per-milestone delegation)
+
+**Input parameters**
+
+| Signal | Value |
+|---|---|
+| tier | M (3-artifact set; 5 authored) |
+| scope (file count) | 8 sweep-target documentation files; 12 scoped locale files across 3 pages |
+| domain count | 1 — docs-site markdown content |
+| file language mix | 100% markdown (4 locales: en / ja / ko / zh) |
+| concurrency benefit | LOW — per-locale prose differs, and 4-locale parity requires coordinated edits within one reasoning context |
+
+**Mode evaluation**
+
+| Mode | Selected | Rationale |
+|---|---|---|
+| 1 `trivial` | no | Multi-file semantic sweep with 12 acceptance criteria; not a typo class |
+| 2 `background` | no | Work is write-heavy (Edit on scoped pages), not read-only analysis |
+| 3 `agent-team` | no | RETIRED tombstone; never selected by the decision tree |
+| 4 `parallel` | no | Single domain (< 3) and edit-heavy, not research-heavy; the coding-task parallelism caveat routes this to Mode 5 |
+| 5 `sub-agent` | **YES** | Default fallback; sequential per-milestone delegation preserves 4-locale coordination |
+| 6 `workflow` | no | Scope is ~12 files, below the ~30-file entry threshold, and the transform is not one uniform mechanical rule — each locale's surrounding prose differs |
+
+**Decision: sub-agent**
+
+Mode 5 is selected. The sweep is edit-heavy rather than research-heavy, touches one domain, and its hardest constraint is locale parity — four files must change consistently against a shared detector set, which a single sequential agent holds in one reasoning context. Anthropic's coding-task parallelism caveat ("most coding tasks involve fewer truly parallelizable tasks than research") applies directly, and the Mode 6 file-count threshold is not met.
+
+**Boundary case** — none. No signal sat at a threshold ±1: domain count 1 (vs 3), file count ~12 (vs 30), and the transform-kind test fails Mode 6 independently of count.
+
+**Gate provenance** — Implementation Kickoff Approval obtained from the user before this section was written. Progression mode selected at the same gate: **autonomous** (`/moai goal` armed after the gate, per `goal-directive.md` § Goal-Presentation Timing — arming pairs with the work-starting command, never replaces it).

--- a/.moai/specs/SPEC-GOAL-DOCS-RETIRE-001/progress.md
+++ b/.moai/specs/SPEC-GOAL-DOCS-RETIRE-001/progress.md
@@ -72,11 +72,68 @@ N3 remains blocked on the parent's M7 landing (`acceptance.md` §C dependency ga
 
 ## §E.2 Run-phase Evidence
 
-_<pending run-phase>_
+All 12 baselines were re-measured at run-phase entry against `d54ea108d` and reproduced the values recorded in `acceptance.md` §B exactly (12/12), so every row below is a measured transition, not an assumed one.
+
+### AC matrix
+
+| AC | Judgment command (per `acceptance.md` §B) | Baseline | Actual output | Status |
+|---|---|---|---|---|
+| AC-GDR-001 | paired listing, `autonomous-loops.md`, per locale | `en:1 ja:1 ko:1 zh:1` | `en:0 ja:0 ko:0 zh:0` | PASS |
+| AC-GDR-002 | paired listing, `self-evolving.md`, per locale | `en:2 ja:2 ko:2 zh:2` | `en:0 ja:0 ko:0 zh:0` | PASS |
+| AC-GDR-003 | `` `/goal `` in `handoff.md`, per locale | `en:1 ja:1 ko:1 zh:1` | `en:0 ja:0 ko:0 zh:0` | PASS |
+| AC-GDR-004 | line-7 mis-attribution, per locale | `en:1 ja:1 ko:1 zh:1` | `en:0 ja:0 ko:0 zh:0` | PASS |
+| AC-GDR-005 | `auto mode` + `` `/goal` `` co-occurrence, per locale | `en:1 ja:1 ko:1 zh:1` | `en:0 ja:0 ko:0 zh:0` | PASS |
+| AC-GDR-006 | split-surface structural pins, per locale | `h3=1,h2=1,row=1` ×4 | `en:h3=1,h2=1,row=1 ja:h3=1,h2=1,row=1 ko:h3=1,h2=1,row=1 zh:h3=1,h2=1,row=1` | PASS |
+| AC-GDR-007 | superseding sentinel / content pin | `0` / `25` | `1` / `26` | **PASS-WITH-DEBT** — see below |
+| AC-GDR-008 | five retention pins | `cc=80 goal.md=12 moai-goal=4 hooks=2 research=4` | `cc=80 goal.md=12 moai-goal=4 hooks=2 research=4` | PASS |
+| AC-GDR-009 | four-locale file inventory | `autonomous-loops.md=4 handoff.md=4 self-evolving.md=4` | `autonomous-loops.md=4 handoff.md=4 self-evolving.md=4` | PASS |
+| AC-GDR-010 | locale-invariance meta-guard (a/b/d) | all five `distinct=1,live_min>=1,apt=1` | `paired_al:distinct=1,live_min=1,apt=1 auto_mode:distinct=1,live_min=1,apt=1 l7:distinct=1,live_min=1,apt=1 paired_se:distinct=1,live_min=2,apt=1 handoff:distinct=1,live_min=1,apt=1` | PASS |
+| AC-GDR-011 | docs-site build | `exit=0` | `exit=0` | PASS |
+| AC-GDR-012 | aggregate emission | `total=24` | `total=0` | PASS |
+
+### Invariants
+
+| Invariant | Evidence | Status |
+|---|---|---|
+| Retention register row 2 intact (native H3, `Native /goal Details` H2, comparison row, factual statements) | `grep -n '`/goal`'` on `autonomous-loops.md` returns exactly the table row, the H3, and the four factual lines in every locale — `en:7 ja:7 ko:7 zh:7`, symmetric | HOLDS |
+| No new locale pages (REQ-GDR-008) | AC-GDR-009 inventory unchanged at 4 each; `hooks=2` pin unchanged | HOLDS |
+| Scope discipline (13 paths) | `git diff --stat d54ea108d..HEAD` = 12 docs-site files + `.moai/docs/autonomous-workflow-strategy.md` + `spec.md` frontmatter only; zero changes under `docs-site/content/*/claude-code/`, `.moai/research/`, `.claude/`, `internal/template/templates/` | HOLDS |
+| `--goal` CLI flag name unchanged | `grep -c '`--goal <condition>`'` = 1 per locale | HOLDS |
+| `handoff.md` L51 `/cli-reference/goal` link path survives (D6) | `grep -c "\[moai goal\](/<locale>/cli-reference/goal)"` = 1 per locale | HOLDS |
+| Locale parity (4-locale same-PR obligation) | Every swept marker reached its target in all four locales simultaneously; no detector shows a locale split (`distinct=1` on all five) | HOLDS |
+| Build warning-free | `hugo --minify --gc` exit 0, `grep -cE 'WARN\|ERROR'` = 0, sitemap present | HOLDS |
+| URL blacklist / Mermaid TD-only | both greps clean | HOLDS |
+
+### AC-GDR-007 debt — criterion internal contradiction (off-by-one)
+
+The two components cannot both hold as literally written. Component 1 requires the file to contain the literal sentinel `native `/goal` emission is retired`; that phrase itself contains a backticked `/goal`, so satisfying it necessarily raises the component-2 occurrence count from 25 to 26. Measured on a scratch copy before editing: adding the sentinel alone yields `sentinel=1, pin=26`.
+
+The milestone's intent — annotate the record, sweep nothing — is met and verifiable: the diff is `1 insertion, 0 deletions` (`git diff --numstat`), and excluding the note line the count is exactly `25` (all historical occurrences byte-identical). The criterion's target value for component 2 is off by one; it should be `26` (25 historical + the sentinel) or the sentinel should be excluded from the count. `acceptance.md` was not modified — the correction is manager-spec's to make.
 
 ## §E.3 Run-phase Audit-Ready Signal
 
-_<pending run-phase>_
+```yaml
+run_complete_at: 2026-07-27
+run_commit_sha: pending-backfill-run-final
+run_status: audit-ready
+ac_pass_count: 11
+ac_fail_count: 0
+ac_pass_with_debt_count: 1
+preserve_list_post_run_count: 5
+l44_pre_commit_fetch: not-run
+l44_post_push_fetch: not-run
+new_warnings_or_lints_introduced: 0
+cross_platform_build:
+  applicable: false
+  reason: documentation-only SPEC; no Go source in scope
+docs_build:
+  command: hugo --minify --gc
+  exit: 0
+  warnings: 0
+  sitemap: present
+total_run_phase_files: 14
+m1_to_mN_commit_strategy: one commit per milestone (N1..N4); N5 verification edits nothing
+```
 
 ## §E.4 Sync-phase Audit-Ready Signal
 

--- a/.moai/specs/SPEC-GOAL-DOCS-RETIRE-001/progress.md
+++ b/.moai/specs/SPEC-GOAL-DOCS-RETIRE-001/progress.md
@@ -91,7 +91,7 @@ _<pending sync-phase>_
 | Signal | Value |
 |---|---|
 | tier | M (3-artifact set; 5 authored) |
-| scope (file count) | 8 sweep-target documentation files; 12 scoped locale files across 3 pages |
+| scope (file count) | 12 scoped locale files across 3 pages (sweep targets) + 1 annotate-only strategy record = 13 |
 | domain count | 1 — docs-site markdown content |
 | file language mix | 100% markdown (4 locales: en / ja / ko / zh) |
 | concurrency benefit | LOW — per-locale prose differs, and 4-locale parity requires coordinated edits within one reasoning context |

--- a/.moai/specs/SPEC-GOAL-DOCS-RETIRE-001/progress.md
+++ b/.moai/specs/SPEC-GOAL-DOCS-RETIRE-001/progress.md
@@ -104,11 +104,28 @@ All 12 baselines were re-measured at run-phase entry against `d54ea108d` and rep
 | Build warning-free | `hugo --minify --gc` exit 0, `grep -cE 'WARN\|ERROR'` = 0, sitemap present | HOLDS |
 | URL blacklist / Mermaid TD-only | both greps clean | HOLDS |
 
-### AC-GDR-007 debt — criterion internal contradiction (off-by-one)
+### AC-GDR-007 debt — criterion internal contradiction (off-by-one) — **CLOSED**
 
 The two components cannot both hold as literally written. Component 1 requires the file to contain the literal sentinel `native `/goal` emission is retired`; that phrase itself contains a backticked `/goal`, so satisfying it necessarily raises the component-2 occurrence count from 25 to 26. Measured on a scratch copy before editing: adding the sentinel alone yields `sentinel=1, pin=26`.
 
-The milestone's intent — annotate the record, sweep nothing — is met and verifiable: the diff is `1 insertion, 0 deletions` (`git diff --numstat`), and excluding the note line the count is exactly `25` (all historical occurrences byte-identical). The criterion's target value for component 2 is off by one; it should be `26` (25 historical + the sentinel) or the sentinel should be excluded from the count. `acceptance.md` was not modified — the correction is manager-spec's to make.
+The milestone's intent — annotate the record, sweep nothing — is met and verifiable: the diff is `1 insertion, 0 deletions` (`git diff --numstat`), and excluding the note line the count is exactly `25` (all historical occurrences byte-identical). The criterion's target value for component 2 is off by one; it should be `26` (25 historical + the sentinel) or the sentinel should be excluded from the count. `acceptance.md` was not modified during the run phase — the correction was manager-spec's to make.
+
+**Resolution (manager-spec, 2026-07-27).** The exclusion form was adopted: component 2's detector now filters the sentinel line out before counting, leaving the pin at `25`. The raise-to-`26` alternative was declined — `26` is a composite (25 historical + 1 sentinel) that obscures what the pin asserts.
+
+```bash
+grep -ciF 'native `/goal` emission is retired' .moai/docs/autonomous-workflow-strategy.md
+grep -vF 'native `/goal` emission is retired' .moai/docs/autonomous-workflow-strategy.md | grep -ohF '`/goal' | wc -l | tr -d ' '
+```
+
+Three validating measurements, all run before the edit was delegated:
+
+| Measurement | Result |
+|-------------|--------|
+| Post-edit working tree, exclusion-form count | `25` (the target) |
+| Sentinel component (component 1) | `1` (satisfied, target `>= 1`) |
+| Pre-edit base — `git show origin/main:.moai/docs/autonomous-workflow-strategy.md`, exclusion form | `25` (recorded baseline unchanged) |
+
+Neither the recorded baseline (`0` / `25`) nor the target (`>= 1` / `25`) changed; only the second detector's command did. The criterion's semantics ("all 25 historical occurrences survive") are preserved, and it is now satisfiable. Recorded in `spec.md` HISTORY `1.3.0`. AC-GDR-007 is now satisfiable and satisfied; the §E.3 signal below is the frozen run-phase snapshot and still records it as the one PASS-WITH-DEBT row.
 
 ## §E.3 Run-phase Audit-Ready Signal
 

--- a/.moai/specs/SPEC-GOAL-DOCS-RETIRE-001/research.md
+++ b/.moai/specs/SPEC-GOAL-DOCS-RETIRE-001/research.md
@@ -111,7 +111,7 @@ Full per-detector symmetry table, each row an executed command:
 | `` `/goal `` — claude-code/** per locale | 20 | 20 | 20 | 20 | yes | AC-GDR-008 |
 | **superseded** `per-turn` anchor | **2** | **0** | **0** | **0** | **NO** | none — disqualified |
 
-Aggregate emission across the 8 sweep files: **24** (paired_al 4 + paired_se 8 + auto_mode 4 + l7 4 + handoff 4).
+Aggregate emission across the 12 sweep-target locale files: **24** (paired_al 4 + paired_se 8 + auto_mode 4 + l7 4 + handoff 4).
 
 ## §D Retention Rationale, Per Surface
 

--- a/.moai/specs/SPEC-GOAL-DOCS-RETIRE-001/spec.md
+++ b/.moai/specs/SPEC-GOAL-DOCS-RETIRE-001/spec.md
@@ -2,7 +2,7 @@
 id: SPEC-GOAL-DOCS-RETIRE-001
 title: Retire native /goal emission references from public and internal documentation across four locales
 version: 1.2.0
-status: draft
+status: in-progress
 created: 2026-07-25
 updated: 2026-07-27
 author: manager-spec

--- a/.moai/specs/SPEC-GOAL-DOCS-RETIRE-001/spec.md
+++ b/.moai/specs/SPEC-GOAL-DOCS-RETIRE-001/spec.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-GOAL-DOCS-RETIRE-001
 title: Retire native /goal emission references from public and internal documentation across four locales
-version: 1.1.0
+version: 1.2.0
 status: draft
 created: 2026-07-25
 updated: 2026-07-27
@@ -21,6 +21,7 @@ depends_on: [SPEC-GOAL-SURFACE-UNIFY-001]
 |---------|------|--------|--------|
 | 1.0.0 | 2026-07-25 | Initial authoring. Split from `SPEC-GOAL-SURFACE-UNIFY-001` after its plan-audit iteration 2 emitted STOP (score regression 0.71 → 0.64) and the user chose scope reduction over iteration 3. Carries the public-documentation scope with locale-invariant detectors. | manager-spec |
 | 1.1.0 | 2026-07-27 | Plan-audit iteration 2 MUST-FIX **B2-1** (aptness) closed. New `REQ-GDR-011` requires every emission detector's pattern to carry a literal `/goal` token, declared once and shared by the counting step and the assertion; `AC-GDR-010` gains component **(d)** and re-records its baseline with an `apt` field. The auditor's stronger alternative — a base-match-set subset check — was executed and **refuted**: `ac_converge` and `auto mode` co-occur with `` `/goal` `` on the same base line, so a line-level subset test admits both attack detectors. | orchestrator |
+| 1.2.0 | 2026-07-27 | Run-gate plan-audit (PASS 0.849) finding **D1** closed. The sweep-target file count is corrected `8 → 12` and the retained-within-scope count `5 → 1` (annotate-only), reconciling `spec.md` §A.3 and `REQ-GDR-001` with `plan.md` §F.1's ownership map (`autonomous-loops.md` ×4 + `self-evolving.md` ×4 + `handoff.md` ×4 + strategy ×1 = 13). The same correction is applied to `acceptance.md` AC-GDR-012's header and to `progress.md` §F's scope row, which had recorded both figures side by side without reconciling them. Iteration 2's finding B-4 corrected the adjacent **marker** count `18 → 24` but did not question the **file** partition. A fourth site the D1 block did not enumerate — `research.md` §C's aggregate sentence — carried the same `8` and was self-contradictory (its own decomposition includes `handoff 4`); it is corrected with the rest, keeping the `24` and the decomposition verbatim. Prose-only: no judgment command, recorded baseline, or target value changed. | manager-spec |
 
 ---
 
@@ -56,7 +57,7 @@ which mirrors `internal/cli/handoff.go:104`'s help string `"record a /goal condi
 Commands and observed outputs are recorded in `research.md`. Backticked detector (`` `/goal ``) throughout, because an unbackticked search matches link paths such as `/en/cli-reference/goal`:
 
 - **50 `docs-site` files** carry a native-`/goal` reference: **28** under `claude-code/`, **22** on the MoAI surface.
-- **13 files** are in this SPEC's scope; of those, **8 are sweep targets** carrying **24 emission markers**, and 5 are retained. The figure is the measured AC-GDR-012 aggregate (`total=24`), derived by running the command rather than carried from an earlier estimate. A superseded `18` appeared here at authoring: it used the disqualified `per-turn` detector's `2` instead of the corrected `4`, and omitted the L7 marker's `4` entirely — understating scope by exactly the two things this SPEC exists to fix (finding B-4).
+- **13 files** are in this SPEC's scope; of those, **12 are sweep targets** carrying **24 emission markers** (3 pages × 4 locales), and **1 is annotate-only** — the strategy record, swept of nothing per AC-GDR-007. The partition matches `plan.md` §F.1's ownership map (`autonomous-loops.md` ×4 + `self-evolving.md` ×4 + `handoff.md` ×4 + strategy ×1 = 13). The marker figure is the measured AC-GDR-012 aggregate (`total=24`), derived by running the command rather than carried from an earlier estimate. A superseded `18` appeared here at authoring: it used the disqualified `per-turn` detector's `2` instead of the corrected `4`, and omitted the L7 marker's `4` entirely — understating scope by exactly the two things this SPEC exists to fix (finding B-4).
 - **Four retention surfaces** at this layer — see §B.2 and `plan.md` §A.2.
 
 ---
@@ -65,7 +66,7 @@ Commands and observed outputs are recorded in `research.md`. Backticked detector
 
 ### §B.1 Emission retirement
 
-- **REQ-GDR-001** (Event-driven) — **When** the sync phase runs, `manager-docs` shall replace every native-`/goal` **emission** reference in the 8 sweep-target documentation files with `/moai goal`, or reword it so the MoAI pipeline is no longer described as emitting native `/goal`.
+- **REQ-GDR-001** (Event-driven) — **When** the sync phase runs, `manager-docs` shall replace every native-`/goal` **emission** reference in the 12 sweep-target locale files (3 pages × 4 locales) with `/moai goal`, or reword it so the MoAI pipeline is no longer described as emitting native `/goal`.
 
 - **REQ-GDR-002** (State-driven) — **While** a documentation page exists in more than one locale, an emission reference removed in one locale shall be removed in every locale in which it appears.
 

--- a/.moai/specs/SPEC-GOAL-DOCS-RETIRE-001/spec.md
+++ b/.moai/specs/SPEC-GOAL-DOCS-RETIRE-001/spec.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-GOAL-DOCS-RETIRE-001
 title: Retire native /goal emission references from public and internal documentation across four locales
-version: 1.2.0
+version: 1.3.0
 status: in-progress
 created: 2026-07-25
 updated: 2026-07-27
@@ -22,6 +22,7 @@ depends_on: [SPEC-GOAL-SURFACE-UNIFY-001]
 | 1.0.0 | 2026-07-25 | Initial authoring. Split from `SPEC-GOAL-SURFACE-UNIFY-001` after its plan-audit iteration 2 emitted STOP (score regression 0.71 → 0.64) and the user chose scope reduction over iteration 3. Carries the public-documentation scope with locale-invariant detectors. | manager-spec |
 | 1.1.0 | 2026-07-27 | Plan-audit iteration 2 MUST-FIX **B2-1** (aptness) closed. New `REQ-GDR-011` requires every emission detector's pattern to carry a literal `/goal` token, declared once and shared by the counting step and the assertion; `AC-GDR-010` gains component **(d)** and re-records its baseline with an `apt` field. The auditor's stronger alternative — a base-match-set subset check — was executed and **refuted**: `ac_converge` and `auto mode` co-occur with `` `/goal` `` on the same base line, so a line-level subset test admits both attack detectors. | orchestrator |
 | 1.2.0 | 2026-07-27 | Run-gate plan-audit (PASS 0.849) finding **D1** closed. The sweep-target file count is corrected `8 → 12` and the retained-within-scope count `5 → 1` (annotate-only), reconciling `spec.md` §A.3 and `REQ-GDR-001` with `plan.md` §F.1's ownership map (`autonomous-loops.md` ×4 + `self-evolving.md` ×4 + `handoff.md` ×4 + strategy ×1 = 13). The same correction is applied to `acceptance.md` AC-GDR-012's header and to `progress.md` §F's scope row, which had recorded both figures side by side without reconciling them. Iteration 2's finding B-4 corrected the adjacent **marker** count `18 → 24` but did not question the **file** partition. A fourth site the D1 block did not enumerate — `research.md` §C's aggregate sentence — carried the same `8` and was self-contradictory (its own decomposition includes `handoff 4`); it is corrected with the rest, keeping the `24` and the decomposition verbatim. Prose-only: no judgment command, recorded baseline, or target value changed. | manager-spec |
+| 1.3.0 | 2026-07-27 | `AC-GDR-007`'s content-pin detector corrected to exclude the mandated sentinel line, closing an off-by-one internal contradiction found during run-phase N5 verification. The criterion is compound: component 1 mandates the literal sentinel ``native `/goal` emission is retired``, and that phrase itself carries a backticked `` `/goal `` that component 2's occurrence count picked up — so satisfying component 1 necessarily drove the pin from `25` to `26`, making the criterion unsatisfiable as written. The second detector now filters the sentinel line out before counting (`grep -vF … \| grep -ohF … \| wc -l`). The pin value (`25`) and the recorded baseline (`0` / `25`) are **unchanged**, as is the criterion's semantics ("all 25 historical occurrences survive"); the raise-to-`26` alternative was declined because `26` is a composite that obscures what the pin asserts. The implementation was already correct — `git diff origin/main...HEAD` on the strategy record is `1 insertion, 0 deletions`. | manager-spec |
 
 ---
 

--- a/.moai/specs/SPEC-GOAL-DOCS-RETIRE-001/spec.md
+++ b/.moai/specs/SPEC-GOAL-DOCS-RETIRE-001/spec.md
@@ -1,10 +1,10 @@
 ---
 id: SPEC-GOAL-DOCS-RETIRE-001
 title: Retire native /goal emission references from public and internal documentation across four locales
-version: 1.0.0
+version: 1.1.0
 status: draft
 created: 2026-07-25
-updated: 2026-07-25
+updated: 2026-07-27
 author: manager-spec
 priority: MEDIUM
 phase: "v3.1.0"
@@ -20,6 +20,7 @@ depends_on: [SPEC-GOAL-SURFACE-UNIFY-001]
 | Version | Date | Change | Author |
 |---------|------|--------|--------|
 | 1.0.0 | 2026-07-25 | Initial authoring. Split from `SPEC-GOAL-SURFACE-UNIFY-001` after its plan-audit iteration 2 emitted STOP (score regression 0.71 → 0.64) and the user chose scope reduction over iteration 3. Carries the public-documentation scope with locale-invariant detectors. | manager-spec |
+| 1.1.0 | 2026-07-27 | Plan-audit iteration 2 MUST-FIX **B2-1** (aptness) closed. New `REQ-GDR-011` requires every emission detector's pattern to carry a literal `/goal` token, declared once and shared by the counting step and the assertion; `AC-GDR-010` gains component **(d)** and re-records its baseline with an `apt` field. The auditor's stronger alternative — a base-match-set subset check — was executed and **refuted**: `ac_converge` and `auto mode` co-occur with `` `/goal` `` on the same base line, so a line-level subset test admits both attack detectors. | orchestrator |
 
 ---
 
@@ -89,6 +90,8 @@ Commands and observed outputs are recorded in `research.md`. Backticked detector
 - **REQ-GDR-009** (Capability gate) — **Where** the content a detector targets is locale-symmetric, the detector's per-locale baseline shall be symmetric; an asymmetric baseline is then evidence the detector is prose-anchored and shall be re-anchored before the criterion is accepted. **Where** the targeted content is genuinely locale-asymmetric, the asymmetry shall be recorded with its justification and the detector exempted by name, because forcing symmetry there would require creating content REQ-GDR-008 forbids.
 
 - **REQ-GDR-010** (Event-driven) — **When** an emission detector's target state is zero in every locale, the criterion judging it shall additionally assert the detector matches non-zero content against an immutable recorded base, so a detector that matches nothing is distinguishable from a surface that was swept.
+
+- **REQ-GDR-011** (Ubiquitous) — Every emission detector's match pattern shall contain a literal `/goal` token, so that a detector which is live and locale-symmetric but semantically aimed elsewhere is rejected before the criterion is accepted. Each detector's pattern shall be declared once and consumed by both the counting step and the aptness assertion, so the two cannot diverge.
 
 ---
 

--- a/docs-site/content/en/advanced/autonomous-loops.md
+++ b/docs-site/content/en/advanced/autonomous-loops.md
@@ -4,7 +4,7 @@ weight: 6
 draft: false
 ---
 
-The core question of agentic loops is "when to stop and when to continue." MoAI-ADK provides three continuation-loop primitives, each with different trigger semantics and ownership. This page distinguishes `/goal`, `/moai goal`, and `/moai loop`, and explains each one's implementation status and safety guardrails.
+The core question of agentic loops is "when to stop and when to continue." MoAI-ADK provides two continuation-loop primitives, `/moai goal` and `/moai loop`; Claude Code provides a third of its own, the native goal command. This page distinguishes all three, and explains each one's ownership, implementation status, and safety guardrails.
 
 ## When to Stop, When to Continue
 
@@ -14,7 +14,7 @@ The continuation-loop primitives solve this. Declare a completion condition, and
 
 ## Three Continuation-Loop Primitives
 
-MoAI-ADK has three continuation-loop primitives, each with different trigger semantics and ownership.
+Three continuation-loop primitives are in play — two owned by MoAI-ADK and one owned by Claude Code itself — each with different trigger semantics.
 
 | Primitive | Ownership | Trigger | When appropriate |
 |-----------|-----------|---------|------------------|
@@ -91,9 +91,9 @@ Include a turn bound to bound the loop ("`or stop after 20 turns`"). Running `/c
 
 - **Implementation Kickoff Approval** (plan → run HUMAN GATE) cannot be bypassed by any loop. Even with `/goal` active, user approval before run-phase entry is mandatory.
 - **Safety boundary unchanged** — even with a loop active, the "confirm before hard-to-reverse / shared-system actions" boundary is not relaxed. The goal evaluator only decides whether to continue; it does not pre-approve destructive operations.
-- **Combination with auto mode** — combining Claude Code auto mode (per-tool auto-approval) with `/goal` (per-turn continuation) enables an unattended `ac_converge` loop. Auto mode removes per-tool approval prompts; `/goal` removes per-turn STOP prompts. Implementation Kickoff Approval is still mandatory before run-phase entry.
+- **Combination with auto mode** — combining Claude Code auto mode (per-tool auto-approval) with `/moai goal` (per-turn continuation) enables an unattended `ac_converge` loop. Auto mode removes per-tool approval prompts; `/moai goal` removes per-turn STOP prompts. Implementation Kickoff Approval is still mandatory before run-phase entry.
 
 ## Next Steps
 
 - [Tokenomics Overview](/en/advanced/tokenomics-overview/) — where autonomous loops connect to tokenomics
-- [Harness Self-Evolution](/en/advanced/self-evolving/) — `/moai loop` / `/goal` convergence trajectories integrated into Loop 0 observation
+- [Harness Self-Evolution](/en/advanced/self-evolving/) — `/moai loop` / `/moai goal` convergence trajectories integrated into Loop 0 observation

--- a/docs-site/content/en/advanced/self-evolving.md
+++ b/docs-site/content/en/advanced/self-evolving.md
@@ -37,7 +37,7 @@ flowchart TD
 
 ### Loop 0 — Observation (every turn)
 
-{{< icon database >}} Every routing decision is recorded as a privacy-preserving digest in routing-ledger.jsonl. Implemented in SPEC-HARNESS-EVOLVE-001 (CLOSED). Recorded fields include routing decisions, gate evidence, `/moai loop` / `/goal` convergence trajectories, and subagent delegation results.
+{{< icon database >}} Every routing decision is recorded as a privacy-preserving digest in routing-ledger.jsonl. Implemented in SPEC-HARNESS-EVOLVE-001 (CLOSED). Recorded fields include routing decisions, gate evidence, `/moai loop` / `/moai goal` convergence trajectories, and subagent delegation results.
 
 ### Loop 1 — Reflection (session boundary)
 
@@ -94,5 +94,5 @@ These surfaces are recorded as roadmap items alongside the v5.1 MCE (learning of
 ## Next Steps
 
 - [3-Tier Agent Architecture](/en/advanced/no-haiku-3tier/) — the model architecture substrate on which self-evolution operates
-- [Autonomous Continuation Loops](/en/advanced/autonomous-loops/) — `/moai loop` / `/goal` convergence trajectories integrated into Loop 0 observation
+- [Autonomous Continuation Loops](/en/advanced/autonomous-loops/) — `/moai loop` / `/moai goal` convergence trajectories integrated into Loop 0 observation
 - [Tokenomics Overview](/en/advanced/tokenomics-overview/) — where self-evolution connects to tokenomics

--- a/docs-site/content/en/cli-reference/handoff.md
+++ b/docs-site/content/en/cli-reference/handoff.md
@@ -31,7 +31,7 @@ moai handoff save --stdin --spec SPEC-AUTH-001 --phase run < resume.txt
 | `--lang <lang>` | conversation_language snapshot |
 | `--ultrathink` | Record the ultrathink directive (for restore guidance) |
 | `--ultracode` | Record the ultracode directive (for restore guidance) |
-| `--goal <condition>` | Record the `/goal` condition (for restore guidance) |
+| `--goal <condition>` | Record the `/moai goal` condition (for restore guidance) |
 
 ## moai handoff clear
 

--- a/docs-site/content/ja/advanced/autonomous-loops.md
+++ b/docs-site/content/ja/advanced/autonomous-loops.md
@@ -4,7 +4,7 @@ weight: 6
 draft: false
 ---
 
-エージェント的ループの核心の問いは「いつ止まり、いつ続くか」です。MoAI-ADKは3つの連続ループプリミティブを提供し、それぞれトリガーセマンティクスと所有権が異なります。このページは`/goal`、`/moai goal`、`/moai loop`を区別し、それぞれの実装状態と安全ガードレールを説明します。
+エージェント的ループの核心の問いは「いつ止まり、いつ続くか」です。MoAI-ADKは`/moai goal`と`/moai loop`の2つの連続ループプリミティブを提供し、Claude Code自身がネイティブのgoalコマンドを提供します。このページはこの3つを区別し、それぞれの所有権、実装状態、安全ガードレールを説明します。
 
 ## いつ止まり、いつ続くか
 
@@ -14,7 +14,7 @@ draft: false
 
 ## 3つの連続ループプリミティブ
 
-MoAI-ADKには3つの連続ループプリミティブがあり、それぞれトリガーセマンティクスと所有権が異なります。
+連続ループプリミティブは3つあり — 2つはMoAI-ADK、残る1つはClaude Code自身が所有します — それぞれトリガーセマンティクスが異なります。
 
 | プリミティブ | 所有権 | トリガー | 適切な場合 |
 |-------------|--------|---------|-----------|
@@ -91,9 +91,9 @@ moai goal clear                         # 条件削除 (ループ終了)
 
 - **Implementation Kickoff Approval** (plan → run HUMAN GATE)はどのループでもバイパス不可です。`/goal`がアクティブでもrun-phase進入前のユーザー承認は必須です。
 - **安全境界 unchanged** — ループがアクティブでも「元に戻しにくい / 共有システム作業前の確認」境界は緩和されません。goal評価者は継続の可否のみを決定し、破壊的操作を事前承認しません。
-- **auto modeとの組合せ** — Claude Code auto mode(ツールごとの自動承認)と`/goal`(ターンごとの連続)を組合せると無人`ac_converge`ループが可能です。auto modeはツールごとの承認プロンプトを削除し、`/goal`はターンごとのSTOPプロンプトを削除します。Implementation Kickoff Approvalはrun-phase進入前に依然必須です。
+- **auto modeとの組合せ** — Claude Code auto mode(ツールごとの自動承認)と`/moai goal`(ターンごとの連続)を組合せると無人`ac_converge`ループが可能です。auto modeはツールごとの承認プロンプトを削除し、`/moai goal`はターンごとのSTOPプロンプトを削除します。Implementation Kickoff Approvalはrun-phase進入前に依然必須です。
 
 ## 次のステップ
 
 - [トークノミクス概論](/ja/advanced/tokenomics-overview/) — 自律ループがトークノミクスと接続するポイント
-- [ハーネス自己進化](/ja/advanced/self-evolving/) — `/moai loop` / `/goal`収束軌跡がLoop 0観察に統合
+- [ハーネス自己進化](/ja/advanced/self-evolving/) — `/moai loop` / `/moai goal`収束軌跡がLoop 0観察に統合

--- a/docs-site/content/ja/advanced/self-evolving.md
+++ b/docs-site/content/ja/advanced/self-evolving.md
@@ -37,7 +37,7 @@ flowchart TD
 
 ### Loop 0 — 観察 (Observation, 毎ターン)
 
-{{< icon database >}} 全ルーティング決定をプライバシー保存ダイジェストとしてrouting-ledger.jsonlに記録します。SPEC-HARNESS-EVOLVE-001 (CLOSED)で実装されました。記録フィールドにはルーティング決定、ゲート証拠、`/moai loop` / `/goal`収束軌跡、サブエージェント委任結果が含まれます。
+{{< icon database >}} 全ルーティング決定をプライバシー保存ダイジェストとしてrouting-ledger.jsonlに記録します。SPEC-HARNESS-EVOLVE-001 (CLOSED)で実装されました。記録フィールドにはルーティング決定、ゲート証拠、`/moai loop` / `/moai goal`収束軌跡、サブエージェント委任結果が含まれます。
 
 ### Loop 1 — 反省 (Reflection, セッション境界)
 
@@ -94,5 +94,5 @@ SPEC-HARNESS-EVOLVE-003 (CLOSED)で以下7つの核心要素がプロダクシ�
 ## 次のステップ
 
 - [3層エージェントアーキテクチャ](/ja/advanced/no-haiku-3tier/) — 自己進化が動作する基盤モデルアーキテクチャ
-- [自律連続ループ](/ja/advanced/autonomous-loops/) — `/moai loop` / `/goal`収束軌跡がLoop 0観察に統合
+- [自律連続ループ](/ja/advanced/autonomous-loops/) — `/moai loop` / `/moai goal`収束軌跡がLoop 0観察に統合
 - [トークノミクス概論](/ja/advanced/tokenomics-overview/) — 自己進化がトークノミクスと接続するポイント

--- a/docs-site/content/ja/cli-reference/handoff.md
+++ b/docs-site/content/ja/cli-reference/handoff.md
@@ -31,7 +31,7 @@ moai handoff save --stdin --spec SPEC-AUTH-001 --phase run < resume.txt
 | `--lang <lang>` | conversation_language のスナップショット |
 | `--ultrathink` | ultrathink 指示を記録 (復元案内用) |
 | `--ultracode` | ultracode 指示を記録 (復元案内用) |
-| `--goal <condition>` | `/goal` 条件を記録 (復元案内用) |
+| `--goal <condition>` | `/moai goal` 条件を記録 (復元案内用) |
 
 ## moai handoff clear
 

--- a/docs-site/content/ko/advanced/autonomous-loops.md
+++ b/docs-site/content/ko/advanced/autonomous-loops.md
@@ -4,7 +4,7 @@ weight: 6
 draft: false
 ---
 
-에이전틱 루프의 핵심 질문은 "언제 멈추고 언제 계속할 것인가"입니다. MoAI-ADK는 세 가지 연속 루프 원시(primitive)를 제공하며, 각각의 트리거 시맨틱과 소유권이 다릅니다. 이 페이지는 `/goal`, `/moai goal`, `/moai loop`를 구분하고 각각의 구현 상태와 안전 가드레일을 설명합니다.
+에이전틱 루프의 핵심 질문은 "언제 멈추고 언제 계속할 것인가"입니다. MoAI-ADK는 `/moai goal`과 `/moai loop` 두 가지 연속 루프 원시(primitive)를 제공하고, Claude Code는 자체적으로 네이티브 goal 명령을 제공합니다. 이 페이지는 이 세 가지를 구분하고 각각의 소유권, 구현 상태, 안전 가드레일을 설명합니다.
 
 ## 언제 멈추고 언제 계속할 것인가
 
@@ -14,7 +14,7 @@ draft: false
 
 ## 3가지 연속 루프 원시
 
-MoAI-ADK에는 세 가지 연속 루프 원시가 있으며 각각 트리거 시맨틱과 소유권이 다릅니다.
+연속 루프 원시는 세 가지이며 — 두 가지는 MoAI-ADK가, 나머지 하나는 Claude Code 자체가 소유합니다 — 각각 트리거 시맨틱이 다릅니다.
 
 | 원시 | 소유권 | 트리거 | 언제 적합한가 |
 |------|--------|--------|---------------|
@@ -91,9 +91,9 @@ moai goal clear                         # 조건 제거 (루프 종료)
 
 - **Implementation Kickoff Approval** (plan → run HUMAN GATE)은 어떤 루프로도 bypass할 수 없습니다. `/goal`이 활성화되어 있어도 run-phase 진입 전 사용자 승인은 필수입니다.
 - **안전 경계 유지** — 루프가 활성화되어도 "되돌리기 어려운 / 공유 시스템 작업 전 확인" 경계는 완화되지 않습니다. goal 평가자는 계속 여부만 결정하며 파괴적 작업을 사전 승인하지 않습니다.
-- **auto mode와 조합** — Claude Code auto mode(도구별 자동 승인)와 `/goal`(턴별 연속)을 조합하면 무인 `ac_converge` 루프가 가능합니다. auto mode는 도구별 승인 프롬프트를 제거하고 `/goal`은 턴별 STOP 프롬프트를 제거합니다. Implementation Kickoff Approval은 여전히 run-phase 진입 전 필수입니다.
+- **auto mode와 조합** — Claude Code auto mode(도구별 자동 승인)와 `/moai goal`(턴별 연속)을 조합하면 무인 `ac_converge` 루프가 가능합니다. auto mode는 도구별 승인 프롬프트를 제거하고 `/moai goal`은 턴별 STOP 프롬프트를 제거합니다. Implementation Kickoff Approval은 여전히 run-phase 진입 전 필수입니다.
 
 ## 다음 단계
 
 - [토크노믹스 개요](/ko/advanced/tokenomics-overview/) — 자율 루프가 토크노믹스와 연결되는 지점
-- [하네스 자가 진화](/ko/advanced/self-evolving/) — `/moai loop`·`/goal` 수렴 궤적이 Loop 0 관찰에 통합
+- [하네스 자가 진화](/ko/advanced/self-evolving/) — `/moai loop`·`/moai goal` 수렴 궤적이 Loop 0 관찰에 통합

--- a/docs-site/content/ko/advanced/self-evolving.md
+++ b/docs-site/content/ko/advanced/self-evolving.md
@@ -37,7 +37,7 @@ flowchart TD
 
 ### Loop 0 — 관찰 (Observation, 매 턴)
 
-{{< icon database >}} 모든 라우팅 결정을 프라이버시 보존 다이제스트로 routing-ledger.jsonl에 기록합니다. SPEC-HARNESS-EVOLVE-001(CLOSED)에서 구현되었습니다. 기록 필드에는 라우팅 결정, 게이트 증거, `/moai loop`·`/goal` 수렴 궤적, 서브에이전트 위임 결과가 포함됩니다.
+{{< icon database >}} 모든 라우팅 결정을 프라이버시 보존 다이제스트로 routing-ledger.jsonl에 기록합니다. SPEC-HARNESS-EVOLVE-001(CLOSED)에서 구현되었습니다. 기록 필드에는 라우팅 결정, 게이트 증거, `/moai loop`·`/moai goal` 수렴 궤적, 서브에이전트 위임 결과가 포함됩니다.
 
 ### Loop 1 — 반추 (Reflection, 세션 경계)
 
@@ -94,5 +94,5 @@ SPEC-HARNESS-EVOLVE-003(CLOSED)에서 다음 7개 핵심 요소가 프로덕션 
 ## 다음 단계
 
 - [3-티어 에이전트 아키텍처](/ko/advanced/no-haiku-3tier/) — 자가 진화가 작동하는 기반 모델 아키텍처
-- [자율 연속 루프](/ko/advanced/autonomous-loops/) — `/moai loop`·`/goal` 수렴 궤적이 Loop 0 관찰에 통합
+- [자율 연속 루프](/ko/advanced/autonomous-loops/) — `/moai loop`·`/moai goal` 수렴 궤적이 Loop 0 관찰에 통합
 - [토크노믹스 개요](/ko/advanced/tokenomics-overview/) — 자가 진화가 토크노믹스와 연결되는 지점

--- a/docs-site/content/ko/cli-reference/handoff.md
+++ b/docs-site/content/ko/cli-reference/handoff.md
@@ -31,7 +31,7 @@ moai handoff save --stdin --spec SPEC-AUTH-001 --phase run < resume.txt
 | `--lang <lang>` | conversation_language 스냅샷 |
 | `--ultrathink` | ultrathink 지시 기록 (복원 안내용) |
 | `--ultracode` | ultracode 지시 기록 (복원 안내용) |
-| `--goal <condition>` | `/goal` 조건 기록 (복원 안내용) |
+| `--goal <condition>` | `/moai goal` 조건 기록 (복원 안내용) |
 
 ## moai handoff clear
 

--- a/docs-site/content/zh/advanced/autonomous-loops.md
+++ b/docs-site/content/zh/advanced/autonomous-loops.md
@@ -4,7 +4,7 @@ weight: 6
 draft: false
 ---
 
-代理式循环的核心问题是"何时停止、何时继续"。MoAI-ADK 提供三种连续循环原语，各有不同的触发语义和所有权。本页区分 `/goal`、`/moai goal`、`/moai loop`，并解释各自的实现状态和安全护栏。
+代理式循环的核心问题是"何时停止、何时继续"。MoAI-ADK 提供 `/moai goal` 和 `/moai loop` 两种连续循环原语，Claude Code 自身则提供原生 goal 命令。本页区分这三者，并解释各自的所有权、实现状态和安全护栏。
 
 ## 何时停止、何时继续
 
@@ -14,7 +14,7 @@ draft: false
 
 ## 三种连续循环原语
 
-MoAI-ADK 有三种连续循环原语，各有不同的触发语义和所有权。
+连续循环原语共三种 — 其中两种由 MoAI-ADK 拥有，另一种由 Claude Code 自身拥有 — 各有不同的触发语义。
 
 | 原语 | 所有权 | 触发 | 适用场景 |
 |------|--------|------|---------|
@@ -91,9 +91,9 @@ moai goal clear                         # 删除条件 (结束循环)
 
 - **Implementation Kickoff Approval** (plan → run HUMAN GATE) 不能被任何循环绕过。即使 `/goal` 活动，run-phase 进入前的用户批准仍是强制的。
 - **安全边界不变** — 即使循环活动，"难以逆转/共享系统操作前确认"边界不会被放宽。goal 评估器仅决定是否继续; 不预批准破坏性操作。
-- **与 auto mode 组合** — 将 Claude Code auto mode(每工具自动批准)与 `/goal`(每回合连续)组合可实现无人值守 `ac_converge` 循环。auto mode 移除每工具批准提示; `/goal` 移除每回合 STOP 提示。Implementation Kickoff Approval 在 run-phase 进入前仍强制。
+- **与 auto mode 组合** — 将 Claude Code auto mode(每工具自动批准)与 `/moai goal`(每回合连续)组合可实现无人值守 `ac_converge` 循环。auto mode 移除每工具批准提示; `/moai goal` 移除每回合 STOP 提示。Implementation Kickoff Approval 在 run-phase 进入前仍强制。
 
 ## 下一步
 
 - [代币经济学概述](/zh/advanced/tokenomics-overview/) — 自主循环与代币经济学的连接点
-- [线束自我进化](/zh/advanced/self-evolving/) — `/moai loop` / `/goal` 收敛轨迹整合到 Loop 0 观察
+- [线束自我进化](/zh/advanced/self-evolving/) — `/moai loop` / `/moai goal` 收敛轨迹整合到 Loop 0 观察

--- a/docs-site/content/zh/advanced/self-evolving.md
+++ b/docs-site/content/zh/advanced/self-evolving.md
@@ -37,7 +37,7 @@ flowchart TD
 
 ### Loop 0 — 观察 (Observation, 每回合)
 
-{{< icon database >}} 所有路由决策以隐私保留摘要记录到 routing-ledger.jsonl。在 SPEC-HARNESS-EVOLVE-001 (CLOSED)中实现。记录字段包括路由决策、门控证据、`/moai loop` / `/goal` 收敛轨迹、子代理委派结果。
+{{< icon database >}} 所有路由决策以隐私保留摘要记录到 routing-ledger.jsonl。在 SPEC-HARNESS-EVOLVE-001 (CLOSED)中实现。记录字段包括路由决策、门控证据、`/moai loop` / `/moai goal` 收敛轨迹、子代理委派结果。
 
 ### Loop 1 — 反思 (Reflection, 会话边界)
 
@@ -94,5 +94,5 @@ SPEC-HARNESS-EVOLVE-003 (CLOSED)生产接线了 7 个核心要素:
 ## 下一步
 
 - [三层代理架构](/zh/advanced/no-haiku-3tier/) — 自我进化运作的基础模型架构
-- [自主连续循环](/zh/advanced/autonomous-loops/) — `/moai loop` / `/goal` 收敛轨迹整合到 Loop 0 观察
+- [自主连续循环](/zh/advanced/autonomous-loops/) — `/moai loop` / `/moai goal` 收敛轨迹整合到 Loop 0 观察
 - [代币经济学概述](/zh/advanced/tokenomics-overview/) — 自我进化与代币经济学的连接点

--- a/docs-site/content/zh/cli-reference/handoff.md
+++ b/docs-site/content/zh/cli-reference/handoff.md
@@ -31,7 +31,7 @@ moai handoff save --stdin --spec SPEC-AUTH-001 --phase run < resume.txt
 | `--lang <lang>` | conversation_language 快照 |
 | `--ultrathink` | 记录 ultrathink 指令(用于恢复引导) |
 | `--ultracode` | 记录 ultracode 指令(用于恢复引导) |
-| `--goal <condition>` | 记录 `/goal` 条件(用于恢复引导) |
+| `--goal <condition>` | 记录 `/moai goal` 条件(用于恢复引导) |
 
 ## moai handoff clear
 


### PR DESCRIPTION
Run phase of `SPEC-GOAL-DOCS-RETIRE-001` (Tier M). Carries the documentation consequence of `SPEC-GOAL-SURFACE-UNIFY-001`: MoAI no longer emits native `/goal`, so documentation must stop describing the pipeline as emitting it — while keeping every factual statement about Claude Code's own `/goal`, which is a HUMAN-ONLY built-in and the reason `/moai goal` exists.

## What changed

| Milestone | Files | Change |
|---|---|---|
| N1 | `advanced/autonomous-loops.md` ×4 | Split surface — 6 emission markers swept, 3 native structures retained. The L7 mis-attribution now reads: Claude Code provides native `/goal`; MoAI-ADK provides `/moai goal` + `/moai loop` |
| N2 | `advanced/self-evolving.md` ×4 | Convergence-trajectory references → `/moai goal` |
| N3 | `cli-reference/handoff.md` ×4 | `--goal` row description mirrors the parent's landed help string. The flag **name** is a CLI contract and is unchanged |
| N4 | `.moai/docs/autonomous-workflow-strategy.md` | Annotate only — superseding note added, all 25 historical occurrences preserved byte-identical (`1 insertion, 0 deletions`) |
| N5 | — | Verification only |

Untouched by design: `docs-site/content/*/claude-code/**` (28 pages), `cli-reference/goal.md`, `utility-commands/moai-goal.md`, `advanced/hooks-reference.md`, `.moai/research/`.

## Acceptance — 12/12 PASS

Every criterion re-run independently by the orchestrator, not taken from the implementing agent's report.

| AC | Target | Observed |
|---|---|---|
| 001-005 emission detectors | `0` per locale | `en:0 ja:0 ko:0 zh:0` (all five) |
| 006 retained structure | `h3=1,h2=1,row=1` ×4 | all four identical |
| 007 strategy record | `>=1` / `25` | `sentinel=1 pin=25` |
| 008 retention pins | `cc=80 goal.md=12 moai-goal=4 hooks=2 research=4` | identical |
| 009 locale inventory | `4 4 4` | `4 4 4` |
| 010 meta-guard | all `distinct=1, live_min>=1, apt=1` | all five satisfied |
| 011 docs build | exit 0 | `exit=0` |
| 012 aggregate | `total=0` | `total=0` (from baseline 24) |

Forbidden-surface diff: **0 changes**.

## Two defects found and closed during this run

**D1 (major, from the run-gate plan-audit).** `spec.md` partitioned the 13 in-scope paths as "8 sweep targets + 5 retained", contradicting `plan.md` §F.1's ownership map (12 sweep + 1 annotate-only). The wrong count sat inside normative REQ-GDR-001 text, and `handoff.md`'s dependency block had just cleared — so an implementer routed by that sentence could have under-swept exactly the milestone that had just become actionable. Corrected across `spec.md`, `acceptance.md`, `progress.md`, and `research.md`; `plan-audit.md`'s verbatim quotation of the pre-fix wording is preserved as a historical record.

**AC-GDR-007 self-contradiction (found at N5).** The criterion's two components could not both hold: component 1 mandates the sentinel ``native `/goal` emission is retired``, and that phrase itself carries a backticked `/goal`, which component 2's counter then counted — so satisfying component 1 necessarily drove the pin from 25 to 26. The implementation was already correct; the criterion was not. Component 2's detector now excludes the sentinel line, leaving **both the recorded baseline and the target unchanged** at `0` / `25` and `>=1` / `25`. Raising the target to 26 was rejected: 26 is a composite (25 historical + 1 sentinel) that obscures what the pin asserts.

## Gate provenance

- Run-gate plan-audit: **PASS 0.849** (Tier M threshold 0.80), all 12 baselines reproduced post-rebase; the 4 new `origin/main` commits independently confirmed to perturb no scoped or retained surface.
- Parent `SPEC-GOAL-SURFACE-UNIFY-001` is `completed`; the N3 dependency gate cleared.
- Implementation Kickoff Approval obtained before run-phase entry (`progress.md` §F).
- Phase 4 mode: sub-agent (Mode 5), sequential per-milestone.

Sync phase (`implemented → completed`, `sync_commit_sha`) follows separately.

🗿 MoAI