### PR TITLE
fix(constitution): sort SPECs by progress.md mtime, not directory mtime

### DIFF
--- a/internal/constitution/canary.go
+++ b/internal/constitution/canary.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -17,6 +18,10 @@ const (
 	canaryMinSpecs = 3
 	// canaryMaxSpecs is the maximum number of SPECs used for canary evaluation.
 	canaryMaxSpecs = 3
+	// canaryProgressFile is the per-SPEC record whose presence marks a SPEC as
+	// completed and whose mtime represents that SPEC's recency. Both readers
+	// resolve it from here so they cannot drift apart.
+	canaryProgressFile = "progress.md"
 )
 
 // canary is an implementation of the Canary interface.
@@ -71,7 +76,7 @@ func (c *canary) Evaluate(proposal *AmendmentProposal, projectDir string) (*Cana
 			continue
 		}
 		// Determine completion by checking progress.md existence (simple implementation)
-		progressPath := filepath.Join(specsDir, name, "progress.md")
+		progressPath := filepath.Join(specsDir, name, canaryProgressFile)
 		if _, err := os.Stat(progressPath); err == nil {
 			completedSpecs = append(completedSpecs, name)
 		}
@@ -177,6 +182,17 @@ func (c *canary) estimateScoreImpact(proposal *AmendmentProposal) float64 {
 }
 
 // sortMostRecent returns the list of most recent SPECs by modification time.
+//
+// Recency is read from each SPEC's progress.md, not from its directory: a
+// directory's mtime changes only when an entry is added or removed, so editing
+// progress.md — the actual record of SPEC activity — leaves it untouched. The
+// caller has already established that progress.md exists for every name passed
+// here; a spec whose progress.md cannot be stat'ed is skipped, as before.
+//
+// Equal mtimes are broken by name so the result is deterministic. Coarse
+// filesystem timestamp resolution can collapse distinct writes onto the same
+// mtime, and an order that depended on the input slice would then vary by
+// platform.
 func (c *canary) sortMostRecent(specs []string, specsDir string, limit int) []string {
 	type specTime struct {
 		name string
@@ -185,21 +201,19 @@ func (c *canary) sortMostRecent(specs []string, specsDir string, limit int) []st
 
 	var specTimes []specTime
 	for _, spec := range specs {
-		info, err := os.Stat(filepath.Join(specsDir, spec))
+		info, err := os.Stat(filepath.Join(specsDir, spec, canaryProgressFile))
 		if err != nil {
 			continue
 		}
 		specTimes = append(specTimes, specTime{name: spec, time: info.ModTime()})
 	}
 
-	// Sort by ModTime descending
-	for i := 0; i < len(specTimes); i++ {
-		for j := i + 1; j < len(specTimes); j++ {
-			if specTimes[j].time.After(specTimes[i].time) {
-				specTimes[i], specTimes[j] = specTimes[j], specTimes[i]
-			}
+	slices.SortFunc(specTimes, func(a, b specTime) int {
+		if c := b.time.Compare(a.time); c != 0 {
+			return c
 		}
-	}
+		return strings.Compare(a.name, b.name)
+	})
 
 	// Return the latest limit items
 	var result []string

--- a/internal/constitution/canary_test.go
+++ b/internal/constitution/canary_test.go
@@ -158,6 +158,95 @@ func TestCanary_sortMostRecent(t *testing.T) {
 	}
 }
 
+// TestCanary_sortMostRecent_ordersByProgressFile pins the two mtime signals in
+// OPPOSITE directions so the assertion can only pass when sortMostRecent reads
+// progress.md rather than the spec directory.
+//
+// Directory mtime is not a usable recency signal for SPEC activity: it changes
+// only when an entry is added to or removed from the directory, so editing
+// progress.md leaves it untouched. The caller (Evaluate) has already verified
+// progress.md exists for every name it passes here.
+func TestCanary_sortMostRecent_ordersByProgressFile(t *testing.T) {
+	c := &canary{completedSpecPattern: regexp.MustCompile(`^SPEC-[A-Z0-9]+$`)}
+	specsDir := filepath.Join(t.TempDir(), ".moai", "specs")
+	names := []string{"SPEC-AAA-001", "SPEC-BBB-001", "SPEC-CCC-001"}
+	base := time.Now().Add(-time.Hour)
+
+	for _, name := range names {
+		dir := filepath.Join(specsDir, name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "progress.md"), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// progress.md recency: AAA newest, CCC oldest.
+	for i, name := range names {
+		mt := base.Add(time.Duration(len(names)-i) * time.Hour)
+		if err := os.Chtimes(filepath.Join(specsDir, name, "progress.md"), mt, mt); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Directory recency: exactly reversed — CCC newest, AAA oldest. Set last so
+	// the file writes above cannot perturb it.
+	for i, name := range names {
+		mt := base.Add(time.Duration(i+1) * time.Hour)
+		if err := os.Chtimes(filepath.Join(specsDir, name), mt, mt); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got := c.sortMostRecent(names, specsDir, 3)
+	want := []string{"SPEC-AAA-001", "SPEC-BBB-001", "SPEC-CCC-001"}
+	if len(got) != len(want) {
+		t.Fatalf("sortMostRecent: got %d entries (%v), want %d", len(got), got, len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("sortMostRecent%v: got %v, want %v (directory mtime is reversed, so a directory-mtime sort yields %v)",
+				names, got, want, []string{"SPEC-CCC-001", "SPEC-BBB-001", "SPEC-AAA-001"})
+			break
+		}
+	}
+}
+
+// TestCanary_sortMostRecent_tieIsDeterministic guards the equal-mtime case.
+// Coarse filesystem timestamp resolution (notably on Windows) can collapse
+// distinct writes onto the same mtime; the order must not depend on that.
+func TestCanary_sortMostRecent_tieIsDeterministic(t *testing.T) {
+	c := &canary{completedSpecPattern: regexp.MustCompile(`^SPEC-[A-Z0-9]+$`)}
+	specsDir := filepath.Join(t.TempDir(), ".moai", "specs")
+	// Deliberately not in sorted order, so "input order" and "name order" differ.
+	names := []string{"SPEC-CCC-001", "SPEC-AAA-001", "SPEC-BBB-001"}
+	mt := time.Now().Add(-time.Hour)
+
+	for _, name := range names {
+		dir := filepath.Join(specsDir, name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		path := filepath.Join(dir, "progress.md")
+		if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chtimes(path, mt, mt); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	want := []string{"SPEC-AAA-001", "SPEC-BBB-001", "SPEC-CCC-001"}
+	for attempt := range 3 {
+		got := c.sortMostRecent(names, specsDir, 3)
+		for i := range want {
+			if i >= len(got) || got[i] != want[i] {
+				t.Fatalf("attempt %d: sortMostRecent = %v, want %v (all mtimes equal → name order)", attempt, got, want)
+			}
+		}
+	}
+}
+
 // TestParseScoreFromProgress verifies score extraction from progress.md content.
 func TestParseScoreFromProgress(t *testing.T) {
 	root := t.TempDir()


### PR DESCRIPTION
Closes #1175.

## The defect

`sortMostRecent` stats the SPEC **directory**; its test stages mtimes on **`progress.md` inside** that directory. The test therefore asserts on a signal it never sets — it passed on Linux/macOS only because the three directories happened to be created in an order that made the assertion hold, and tied or inverted on Windows, where `Test (windows-latest)` is a required check.

## Which side was wrong

The issue framed this as a real choice between fixing the test and fixing the implementation. This PR takes the implementation, on three grounds:

1. **Directory mtime does not express the intended signal.** A directory's mtime changes only when an entry is added or removed. Editing `progress.md` — the actual record of SPEC activity — leaves it untouched, so a SPEC being actively worked on never rises in the ordering.
2. **The caller already guarantees `progress.md` exists.** `Evaluate` (`canary.go:73-77`) selects `completedSpecs` precisely by stat'ing `progress.md`, so reading it in the sort cannot fail more often than reading the directory did.
3. **Fixing the test instead would keep coverage at zero.** It would conform the test to the weaker signal, leaving "does `sortMostRecent` order by recency?" unverified on every platform — the issue's own "why it matters beyond the flake" point.

## Changes

| Change | Why |
|---|---|
| `sortMostRecent` stats `progress.md` | reads the signal that actually tracks SPEC activity |
| Equal mtimes break by name | coarse filesystem timestamp resolution must not make the order platform-dependent |
| `canaryProgressFile` constant used by both readers | the two sites disagreeing on the filename is what let this drift |

The hand-rolled selection sort is replaced by `slices.SortFunc`, which is what makes the tie-break expressible.

## Tests — added, not adjusted

The existing test could not distinguish a correct implementation from a broken one, so two tests are added. Both were confirmed to fail before the fix and pass after, and each was re-broken to confirm it guards something specific:

| Test | Probe | Result |
|---|---|---|
| `ordersByProgressFile` — pins directory mtime and `progress.md` mtime in **opposite** directions, so it can only pass when `progress.md` is read | revert the stat target to the directory | FAIL, as required |
| `tieIsDeterministic` — gives every SPEC the same mtime, asserts name order over repeated runs | remove the name tie-break | FAIL, as required |

The pre-existing `TestCanary_sortMostRecent` is left unchanged and now passes for the right reason.

## Verification

| Check | Result |
|---|---|
| `go test -count=1 ./...` | exit 0 — 105 ok / 0 FAIL |
| `golangci-lint run --timeout=3m` | `0 issues.` |
| `go vet ./internal/constitution/` | exit 0 |
| `GOOS=windows GOARCH=amd64 go build ./...` | exit 0 |
| `go test -race -run TestCanary ./internal/constitution/` | ok |

## Behaviour change

Ordering semantics change for one case: a SPEC directory touched without its `progress.md` changing now sorts differently. This is the intended correction — the issue names it explicitly as the cost of this option.

🗿 MoAI