### PR TITLE
chore(SPEC-GOAL-DOCS-RETIRE-001): backfill run/sync_commit_sha to 62df55fab

### DIFF
--- a/.moai/specs/SPEC-GOAL-DOCS-RETIRE-001/progress.md
+++ b/.moai/specs/SPEC-GOAL-DOCS-RETIRE-001/progress.md
@@ -131,7 +131,7 @@ Neither the recorded baseline (`0` / `25`) nor the target (`>= 1` / `25`) change
 
 ```yaml
 run_complete_at: 2026-07-27
-run_commit_sha: pending-backfill-run-final
+run_commit_sha: 62df55fab
 run_status: audit-ready
 ac_pass_count: 11
 ac_fail_count: 0
@@ -156,7 +156,7 @@ m1_to_mN_commit_strategy: one commit per milestone (N1..N4); N5 verification edi
 
 ```yaml
 sync_complete_at: 2026-07-27
-sync_commit_sha: pending-backfill-sync-2
+sync_commit_sha: 62df55fab
 sync_status: audit-ready
 docs_build:
   command: hugo --minify --gc


### PR DESCRIPTION
D3 placeholder-backfill for SPEC-GOAL-DOCS-RETIRE-001 v1.5.0 amendment.

PR #1181 squash-merged as `62df55fab`. The two `pending-backfill-*` placeholders in `progress.md` §E.3 (`run_commit_sha`) and §E.4 (`sync_commit_sha`) — written per the SHA-placeholder backfill exemption (a commit cannot reference its own SHA) — are now filled with `62df55fab`.

Same pattern as PR #1177 / #1179.

Docs-only: 1 file (progress.md), 2 lines. No code, no acceptance-criteria change.

🗿 MoAI