### PR TITLE
chore(SPEC-GOAL-DOCS-RETIRE-001): backfill v1.6.0 sync_commit_sha (D3)

### DIFF
--- a/.moai/specs/SPEC-GOAL-DOCS-RETIRE-001/progress.md
+++ b/.moai/specs/SPEC-GOAL-DOCS-RETIRE-001/progress.md
@@ -156,7 +156,7 @@ m1_to_mN_commit_strategy: one commit per milestone (N1..N4); N5 verification edi
 
 ```yaml
 sync_complete_at: 2026-07-28
-sync_commit_sha: pending-backfill-v1.6.0
+sync_commit_sha: 3891b2bb7
 sync_status: audit-ready
 docs_build:
   command: hugo --minify --gc


### PR DESCRIPTION
D3 placeholder-backfill (follow-up to #1186). progress.md §E.4 sync_commit_sha: pending-backfill-v1.6.0 -> 3891b2bb7 (the #1186 squash-merge SHA on origin/main). A commit cannot reference its own SHA, so the v1.6.0 sync commit wrote the placeholder; this backfills the real SHA now that #1186 merged. v1.5.0 sync_commit_sha (62df55fab) preserved untouched. 1-line change, progress.md only. 🗿 MoAI