### PR TITLE
chore(SPEC-TEMPLATE-DATE-NEUTRALITY-002): backfill sync_commit_sha 86c94b90d

### DIFF
--- a/.moai/specs/SPEC-TEMPLATE-DATE-NEUTRALITY-002/progress.md
+++ b/.moai/specs/SPEC-TEMPLATE-DATE-NEUTRALITY-002/progress.md
@@ -235,7 +235,7 @@ m1_to_mN_commit_strategy: "one commit per milestone (M1-M6), explicit-pathspec s
 sync_status: audit-ready
 sync_complete_at: 2026-07-28
 spec_id: SPEC-TEMPLATE-DATE-NEUTRALITY-002
-sync_commit_sha: pending-backfill
+sync_commit_sha: 86c94b90d
 close_type: 3-phase close (plan→run→sync)
 ac_total: 33
 ac_pass: 33
@@ -244,7 +244,7 @@ run_commit_sha: f0c71168c
 preserve_verified: true
 ```
 
-The single sync commit carries the `in-progress → implemented → completed` frontmatter transition (3-phase close; MX Tag is a cross-cutting sync concern, not a separate phase). `sync_commit_sha` is `pending-backfill` — a commit cannot reference its own SHA (D3 self-referential-hazard backfill exemption, per spec-frontmatter-schema.md); the orchestrator backfills the real SHA after the PR's squash merge lands.
+The single sync commit carried the `in-progress → implemented → completed` frontmatter transition (3-phase close; MX Tag is a cross-cutting sync concern, not a separate phase). `sync_commit_sha` backfilled to `86c94b90d` — the squash-merge SHA of PR #1187 (D3 self-referential-hazard backfill exemption applied: the sync commit `414ce54d6` could not reference its own SHA, so the real SHA was populated in this follow-up commit after merge).
 
 Sync produced via orchestrator-direct recovery after manager-docs spawn failed with `Prompt is too long` (PTL) — rung-1 in-turn self-correction per runtime-recovery-doctrine §2; no work was lost (the spawn terminated before any file edit).
 


### PR DESCRIPTION
## Summary

D3 self-referential-hazard backfill for SPEC-TEMPLATE-DATE-NEUTRALITY-002 (already merged via #1187).

PR #1187 merged as squash `86c94b90d`. The sync commit (`414ce54d6`) could not reference its own SHA (a commit does not know its hash until it lands), so `progress.md` §E.4 `sync_commit_sha` was written as `pending-backfill`. This follow-up populates the real SHA, completing the 3-phase close record.

## Scope

Single 2-line edit to `.moai/specs/SPEC-TEMPLATE-DATE-NEUTRALITY-002/progress.md` §E.4 (the field value + the explanatory note). No code, no behavior change.

🗿 MoAI