### PR TITLE
chore(SPEC-WORKTREE-BRANCH-GUARD-001): backfill sync_commit_sha e89d01461

### DIFF
--- a/.moai/specs/SPEC-WORKTREE-BRANCH-GUARD-001/progress.md
+++ b/.moai/specs/SPEC-WORKTREE-BRANCH-GUARD-001/progress.md
@@ -171,10 +171,9 @@ _Populated by orchestrator 2026-07-28 (run-phase functionally complete)._
 
 _Populated by manager-docs 2026-07-28 (sync-phase 3-phase close)._
 
-- **sync_commit_sha**: `pending-backfill-SPEC-WORKTREE-BRANCH-GUARD-001`
-  (self-referential-SHA hazard — a commit cannot reference its own hash; the
-  real SHA is backfilled in a FOLLOW-UP commit after PR merge, per the
-  established pattern documented in
+- **sync_commit_sha**: `e89d01461`
+  (PR #1192 squash-merge commit; backfilled in this follow-up commit per the
+  self-referential-SHA pattern documented in
   `.claude/rules/moai/development/spec-frontmatter-schema.md` § D3 SHA
   placeholder backfill exemption).
 - **sync_status**: completed (single sync commit carries the merged


### PR DESCRIPTION
Backfills the real `sync_commit_sha` (`e89d01461`, PR #1192 squash-merge) into `progress.md` §E.4, replacing the `pending-backfill` placeholder.

Per `spec-frontmatter-schema.md` § D3 SHA placeholder backfill exemption: the sync commit cannot reference its own hash, so the real SHA is backfilled in this follow-up commit. Precedent: #1190, #1188.

One-line edit to `.moai/specs/SPEC-WORKTREE-BRANCH-GUARD-001/progress.md` — no code/test changes.

🗿 MoAI