### PR TITLE
docs(oss-docs): 한국어 docs-site Phase 3 — SPEC 드리프트 일괄 수정

### DIFF
--- a/docs-site/content/ko/advanced/settings-json.md
+++ b/docs-site/content/ko/advanced/settings-json.md
@@ -856,7 +856,7 @@ MoAI-ADK statusline에는 다음이 포함됩니다.
 
 - **그라디언트 색상**: 컨텍스트 사용률에 따른 동적 색상 그라디언트
 - **5H/7D 사용량 모니터링**: 5시간 및 7일 API 사용량 바 표시
-- **다중 라인 레이아웃**: Compact (3줄), default, full 디스플레이 모드
+- **세그먼트 기반 레이아웃**: 활성화된 세그먼트 수에 따라 자동으로 라인 수가 결정되며, 별도의 디스플레이 프리셋(full/compact/minimal)은 퇴역했습니다 — `segments:` 토글이 유일한 구성 레버입니다
 - **테마** (`internal/statusline/theme.go` 정의):
   - **catppuccin-mocha** (기본값): 다크 팔레트
   - **catppuccin-latte**: 밝은 환경을 위한 라이트 팔레트

--- a/docs-site/content/ko/advanced/skill-guide.md
+++ b/docs-site/content/ko/advanced/skill-guide.md
@@ -54,9 +54,9 @@ flowchart TD
 
 ## 스킬 카테고리
 
-MoAI-ADK 템플릿에는 총 **27개 `moai-*` 스킬**이 5개 기능 카테고리로 분류되어 있습니다 (Foundation 4 + Workflow 8 + Domain 5 + Reference 8 + Meta/Harness 2 = 27). 여기에 요청을 전문 스킬로 라우팅하는 `moai` umbrella 스킬 1개가 별도로 존재합니다. 사용자 프로젝트에서는 추가로 `harness-*` 사용자 정의 스킬을 작성할 수 있습니다. 프로그래밍 언어 지원은 `rules/moai/languages/` 아래의 규칙으로 제공되며 별도 스킬이 아닙니다.
+MoAI-ADK 템플릿에는 총 **29개 `moai-*` 스킬**이 5개 기능 카테고리로 분류되어 있습니다 (Foundation 4 + Workflow 9 + Domain 6 + Reference 8 + Meta/Harness 2 = 29). 여기에 요청을 전문 스킬로 라우팅하는 `moai` umbrella 스킬 1개가 별도로 존재합니다. 사용자 프로젝트에서는 추가로 `harness-*` 사용자 정의 스킬을 작성할 수 있습니다. 프로그래밍 언어 지원은 `rules/moai/languages/` 아래의 규칙으로 제공되며 별도 스킬이 아닙니다.
 
-이 숫자도 다이어트의 결과입니다 — 스킬 카탈로그는 v3 기간 동안 48 → 38 → 27개로 정련되었습니다. 사용자 정의 하네스 스킬의 현재 접두사는 `hns-*`입니다(레거시 `harness-*`도 인식됨).
+이 숫자도 다이어트의 결과입니다 — 스킬 카탈로그는 v3 기간 동안 48 → 38 → 29개로 정련되었습니다. 사용자 정의 하네스 스킬의 현재 접두사는 `hns-*`입니다(레거시 `harness-*`도 인식됨).
 
 ### Foundation (핵심 철학) - 4개
 
@@ -67,20 +67,21 @@ MoAI-ADK 템플릿에는 총 **27개 `moai-*` 스킬**이 5개 기능 카테고�
 | `moai-foundation-thinking` | 구조화 사고, 아이디에이션, 제1원리 분석             |
 | `moai-foundation-quality`  | 코드 품질 자동 검증, TRUST 5 밸리데이션             |
 
-### Workflow (자동화 워크플로우) - 8개
+### Workflow (자동화 워크플로우) - 9개
 
-| 스킬 이름                | 설명                                          |
-| ------------------------ | --------------------------------------------- |
-| `moai-workflow-spec`     | SPEC 문서 생성, GEARS 형식, 요구사항 분석     |
-| `moai-workflow-project`  | 프로젝트 초기화, 문서 생성, 언어 설정         |
-| `moai-workflow-ddd`      | ANALYZE-PRESERVE-IMPROVE 사이클               |
-| `moai-workflow-tdd`      | RED-GREEN-REFACTOR 테스트 주도 개발           |
-| `moai-workflow-testing`  | 테스트 생성, 디버깅, 코드 리뷰 통합           |
-| `moai-workflow-worktree` | Git worktree 기반 병렬 개발                   |
-| `moai-workflow-loop`     | Ralph Engine 자율 루프, LSP 연동              |
-| `moai-workflow-ci-loop`  | CI 감시 및 자동 수정 루프 워크플로우          |
+| 스킬 이름                       | 설명                                          |
+| ------------------------------- | --------------------------------------------- |
+| `moai-workflow-spec`            | SPEC 문서 생성, GEARS 형식, 요구사항 분석     |
+| `moai-workflow-project`         | 프로젝트 초기화, 문서 생성, 언어 설정         |
+| `moai-workflow-ddd`             | ANALYZE-PRESERVE-IMPROVE 사이클               |
+| `moai-workflow-tdd`             | RED-GREEN-REFACTOR 테스트 주도 개발           |
+| `moai-workflow-testing`         | 테스트 생성, 디버깅, 코드 리뷰 통합           |
+| `moai-workflow-worktree`        | Git worktree 기반 병렬 개발                   |
+| `moai-workflow-loop`            | Ralph Engine 자율 루프, LSP 연동              |
+| `moai-workflow-ci-loop`         | CI 감시 및 자동 수정 루프 워크플로우          |
+| `moai-workflow-docs-claim-check`| 공개 문서(README·릴리스 노트) 주장 검증, 읽기 전용 |
 
-### Domain (도메인 전문성) - 5개
+### Domain (도메인 전문성) - 6개
 
 | 스킬 이름                   | 설명                                             |
 | --------------------------- | ------------------------------------------------ |
@@ -89,6 +90,7 @@ MoAI-ADK 템플릿에는 총 **27개 `moai-*` 스킬**이 5개 기능 카테고�
 | `moai-domain-database`      | PostgreSQL, MongoDB, Redis, 고급 데이터 패턴     |
 | `moai-domain-html-report`   | Markdown → 단일 HTML 리포트 렌더러 (6개 모드, 외부 의존성 없음) |
 | `moai-domain-humanize`      | AI 텍스트 휴머나이제이션, 윤문 (KO/EN/JA/ZH)    |
+| `moai-domain-svg-infographic` | 편집 가능 SVG 기술 인포그래픽 (아키텍처·흐름·비교), CJK 폰트 |
 
 ### Reference (모범 사례) - 8개
 
@@ -110,7 +112,7 @@ MoAI-ADK 템플릿에는 총 **27개 `moai-*` 스킬**이 5개 기능 카테고�
 | `moai-meta-harness`    | **DEPRECATED** — 레거시 7-Phase 메타 하네스. v4 Builder(`/moai:harness <자연어 요청>`)로 리다이렉트 |
 | `moai-harness-learner` | Harness 학습 서브시스템, 자동 업데이트 제안 |
 
-> 27개 `moai-*` 스킬은 MoAI-ADK 템플릿에 기본으로 포함되며, 각 스킬은 독립적으로 로드되어 토큰을 절약합니다. 사용자는 추가적으로 프로젝트별 `hns-*` 사용자 정의 하네스 스킬을 작성할 수 있습니다(레거시 `harness-*` 접두사도 인식됨).
+> 29개 `moai-*` 스킬은 MoAI-ADK 템플릿에 기본으로 포함되며, 각 스킬은 독립적으로 로드되어 토큰을 절약합니다. 사용자는 추가적으로 프로젝트별 `hns-*` 사용자 정의 하네스 스킬을 작성할 수 있습니다(레거시 `harness-*` 접두사도 인식됨).
 
 ## 점진적 공개 시스템
 
@@ -148,7 +150,7 @@ flowchart TD
 
 ### 토큰 절약 효과
 
-- **기존 방식**: 27개 스킬 전체 로드 = 약 135,000 토큰 (불가능)
+- **기존 방식**: 29개 스킬 전체 로드 = 약 145,000 토큰 (불가능)
 - **점진적 공개**: 메타데이터만 로드 = 약 5,200 토큰 (97% 절약)
 - **필요 시 로드**: 작업에 필요한 2~3개 스킬만 = 약 15,000 토큰 추가
 

--- a/docs-site/content/ko/advanced/skill-guide.md
+++ b/docs-site/content/ko/advanced/skill-guide.md
@@ -54,9 +54,9 @@ flowchart TD
 
 ## 스킬 카테고리
 
-MoAI-ADK 템플릿에는 총 **29개 `moai-*` 스킬**이 5개 기능 카테고리로 분류되어 있습니다 (Foundation 4 + Workflow 9 + Domain 6 + Reference 8 + Meta/Harness 2 = 29). 여기에 요청을 전문 스킬로 라우팅하는 `moai` umbrella 스킬 1개가 별도로 존재합니다. 사용자 프로젝트에서는 추가로 `harness-*` 사용자 정의 스킬을 작성할 수 있습니다. 프로그래밍 언어 지원은 `rules/moai/languages/` 아래의 규칙으로 제공되며 별도 스킬이 아닙니다.
+MoAI-ADK 템플릿에는 총 **30개 `moai-*` 스킬**이 5개 기능 카테고리로 분류되어 있습니다 (Foundation 4 + Workflow 9 + Domain 6 + Reference 9 + Meta/Harness 2 = 30). 여기에 요청을 전문 스킬로 라우팅하는 `moai` umbrella 스킬 1개가 별도로 존재합니다. 사용자 프로젝트에서는 추가로 `harness-*` 사용자 정의 스킬을 작성할 수 있습니다. 프로그래밍 언어 지원은 `rules/moai/languages/` 아래의 규칙으로 제공되며 별도 스킬이 아닙니다.
 
-이 숫자도 다이어트의 결과입니다 — 스킬 카탈로그는 v3 기간 동안 48 → 38 → 29개로 정련되었습니다. 사용자 정의 하네스 스킬의 현재 접두사는 `hns-*`입니다(레거시 `harness-*`도 인식됨).
+이 숫자도 다이어트의 결과입니다 — 스킬 카탈로그는 v3 기간 동안 48 → 38 → 29개로 정련되었으며, 이후 moai-ref-ui-polish 추가로 현재 30개입니다. 사용자 정의 하네스 스킬의 현재 접두사는 `hns-*`입니다(레거시 `harness-*`도 인식됨).
 
 ### Foundation (핵심 철학) - 4개
 
@@ -92,7 +92,7 @@ MoAI-ADK 템플릿에는 총 **29개 `moai-*` 스킬**이 5개 기능 카테고�
 | `moai-domain-humanize`      | AI 텍스트 휴머나이제이션, 윤문 (KO/EN/JA/ZH)    |
 | `moai-domain-svg-infographic` | 편집 가능 SVG 기술 인포그래픽 (아키텍처·흐름·비교), CJK 폰트 |
 
-### Reference (모범 사례) - 8개
+### Reference (모범 사례) - 9개
 
 | 스킬 이름                  | 설명                                              |
 | -------------------------- | ------------------------------------------------- |
@@ -104,6 +104,7 @@ MoAI-ADK 템플릿에는 총 **29개 `moai-*` 스킬**이 5개 기능 카테고�
 | `moai-ref-llm-security`    | AI/LLM 방어 보안 (프롬프트 인젝션, OWASP LLM Top 10) |
 | `moai-ref-secops`          | DevSecOps/컨테이너/API 운영 방어 보안             |
 | `moai-ref-supply-chain`    | 소프트웨어 공급망 방어 보안 (SBOM, SLSA, Sigstore) |
+| `moai-ref-ui-polish`       | UI 디자인 완성도, 인터페이스 폴리시 참조            |
 
 ### Meta/Harness (시스템 확장) - 2개
 
@@ -112,7 +113,7 @@ MoAI-ADK 템플릿에는 총 **29개 `moai-*` 스킬**이 5개 기능 카테고�
 | `moai-meta-harness`    | **DEPRECATED** — 레거시 7-Phase 메타 하네스. v4 Builder(`/moai:harness <자연어 요청>`)로 리다이렉트 |
 | `moai-harness-learner` | Harness 학습 서브시스템, 자동 업데이트 제안 |
 
-> 29개 `moai-*` 스킬은 MoAI-ADK 템플릿에 기본으로 포함되며, 각 스킬은 독립적으로 로드되어 토큰을 절약합니다. 사용자는 추가적으로 프로젝트별 `hns-*` 사용자 정의 하네스 스킬을 작성할 수 있습니다(레거시 `harness-*` 접두사도 인식됨).
+> 30개 `moai-*` 스킬은 MoAI-ADK 템플릿에 기본으로 포함되며, 각 스킬은 독립적으로 로드되어 토큰을 절약합니다. 사용자는 추가적으로 프로젝트별 `hns-*` 사용자 정의 하네스 스킬을 작성할 수 있습니다(레거시 `harness-*` 접두사도 인식됨).
 
 ## 점진적 공개 시스템
 
@@ -150,7 +151,7 @@ flowchart TD
 
 ### 토큰 절약 효과
 
-- **기존 방식**: 29개 스킬 전체 로드 = 약 145,000 토큰 (불가능)
+- **기존 방식**: 30개 스킬 전체 로드 = 약 150,000 토큰 (불가능)
 - **점진적 공개**: 메타데이터만 로드 = 약 5,200 토큰 (97% 절약)
 - **필요 시 로드**: 작업에 필요한 2~3개 스킬만 = 약 15,000 토큰 추가
 

--- a/docs-site/content/ko/advanced/ultracode-workflows.md
+++ b/docs-site/content/ko/advanced/ultracode-workflows.md
@@ -147,7 +147,7 @@ for (const pkg of packages) {
   // 각 패키지마다 독립 에이전트 생성
   const result = await agent({
     agentType: "Explore",
-    model: "haiku",
+    model: "sonnet",
     effort: "low",
     prompt: `
       ${pkg} 패키지에서 모든 TODO 주석을 찾고 분류하세요.
@@ -214,7 +214,7 @@ return summary;
 | 전체 리포 스캔 | 100+ | 높음 |
 
 **비용 조절**:
-- 모델: `haiku` 사용 (read-only 추출)
+- 모델: `sonnet` 사용 (read-only 추출, Explore 매트릭스 기준)
 - 에이전트 수: 범위 제한 (`packages.slice(0, 20)`)
 - 병렬도: 최대 16에서 수동 조정
 

--- a/docs-site/content/ko/core-concepts/what-is-moai-adk.md
+++ b/docs-site/content/ko/core-concepts/what-is-moai-adk.md
@@ -4,7 +4,7 @@ weight: 20
 draft: false
 ---
 
-MoAI-ADK는 **토크노믹스** (Token Economics) 를 목표로 하는 **Agentic Development Kit**입니다. 같은 품질의 코드를 더 적은 토큰으로, 같은 토큰으로 더 높은 품질을 — 모델 선택·추론 깊이·컨텍스트 사용량을 시스템이 관리합니다. 11개의 전문 AI 에이전트와 29개의 스킬이 협력하고, 새 프로젝트에는 TDD (기본값), 테스트 커버리지가 낮은 기존 프로젝트에는 DDD를 자동으로 적용합니다.
+MoAI-ADK는 **토크노믹스** (Token Economics) 를 목표로 하는 **Agentic Development Kit**입니다. 같은 품질의 코드를 더 적은 토큰으로, 같은 토큰으로 더 높은 품질을 — 모델 선택·추론 깊이·컨텍스트 사용량을 시스템이 관리합니다. 11개의 전문 AI 에이전트와 30개의 스킬이 협력하고, 새 프로젝트에는 TDD (기본값), 테스트 커버리지가 낮은 기존 프로젝트에는 DDD를 자동으로 적용합니다.
 
 Go로 작성된 단일 바이너리 -- 의존성 없이 모든 플랫폼에서 즉시 실행됩니다.
 
@@ -71,7 +71,7 @@ Python 기반 MoAI-ADK (~73,000줄)를 Go로 완전히 재작성했습니다.
 ### 핵심 수치 (v3.0 기준)
 
 - **11개** 에이전트 카탈로그 (10 MoAI 커스텀 + 1 Anthropic 빌트인 `Explore`)
-- **29개** 스킬 (template-managed)
+- **30개** 스킬 (template-managed)
 - **약 37개** CLI 명령 · **14종** `/moai` 서브커맨드
 - **16개** 프로그래밍 언어 지원
 - **3단계 하네스** (minimal / standard / thorough) — SPEC 복잡도에 따른 적응형 품질 게이트
@@ -313,7 +313,7 @@ flowchart TD
     MoAI --> Explore
 ```
 
-### 29개 스킬 (Progressive Disclosure)
+### 30개 스킬 (Progressive Disclosure)
 
 3레벨 Progressive Disclosure 시스템으로 토큰을 아껴 씁니다. 스킬 설명 (~100 토큰) 만 항시 목록에 노출되고, 본문 (~5K 토큰) 은 실제 호출 시에만 로드됩니다. 컨텍스트 다이어트의 한 축입니다.
 
@@ -613,7 +613,7 @@ my-project/
 ├── CLAUDE.md                  # MoAI의 실행 지침서
 ├── .claude/
 │   ├── agents/moai/           # 10개 MoAI 커스텀 에이전트 정의 (+ Explore 빌트인)
-│   ├── skills/moai-*/         # 29개 스킬 모듈
+│   ├── skills/moai-*/         # 30개 스킬 모듈
 │   ├── hooks/moai/            # 자동화 훅 스크립트
 │   └── rules/moai/            # 코딩 규칙 및 표준
 └── .moai/

--- a/docs-site/content/ko/core-concepts/what-is-moai-adk.md
+++ b/docs-site/content/ko/core-concepts/what-is-moai-adk.md
@@ -4,7 +4,7 @@ weight: 20
 draft: false
 ---
 
-MoAI-ADK는 **토크노믹스** (Token Economics) 를 목표로 하는 **Agentic Development Kit**입니다. 같은 품질의 코드를 더 적은 토큰으로, 같은 토큰으로 더 높은 품질을 — 모델 선택·추론 깊이·컨텍스트 사용량을 시스템이 관리합니다. 11개의 전문 AI 에이전트와 27개의 스킬이 협력하고, 새 프로젝트에는 TDD (기본값), 테스트 커버리지가 낮은 기존 프로젝트에는 DDD를 자동으로 적용합니다.
+MoAI-ADK는 **토크노믹스** (Token Economics) 를 목표로 하는 **Agentic Development Kit**입니다. 같은 품질의 코드를 더 적은 토큰으로, 같은 토큰으로 더 높은 품질을 — 모델 선택·추론 깊이·컨텍스트 사용량을 시스템이 관리합니다. 11개의 전문 AI 에이전트와 29개의 스킬이 협력하고, 새 프로젝트에는 TDD (기본값), 테스트 커버리지가 낮은 기존 프로젝트에는 DDD를 자동으로 적용합니다.
 
 Go로 작성된 단일 바이너리 -- 의존성 없이 모든 플랫폼에서 즉시 실행됩니다.
 
@@ -71,7 +71,7 @@ Python 기반 MoAI-ADK (~73,000줄)를 Go로 완전히 재작성했습니다.
 ### 핵심 수치 (v3.0 기준)
 
 - **11개** 에이전트 카탈로그 (10 MoAI 커스텀 + 1 Anthropic 빌트인 `Explore`)
-- **27개** 스킬 (template-managed)
+- **29개** 스킬 (template-managed)
 - **약 37개** CLI 명령 · **14종** `/moai` 서브커맨드
 - **16개** 프로그래밍 언어 지원
 - **3단계 하네스** (minimal / standard / thorough) — SPEC 복잡도에 따른 적응형 품질 게이트
@@ -313,7 +313,7 @@ flowchart TD
     MoAI --> Explore
 ```
 
-### 27개 스킬 (Progressive Disclosure)
+### 29개 스킬 (Progressive Disclosure)
 
 3레벨 Progressive Disclosure 시스템으로 토큰을 아껴 씁니다. 스킬 설명 (~100 토큰) 만 항시 목록에 노출되고, 본문 (~5K 토큰) 은 실제 호출 시에만 로드됩니다. 컨텍스트 다이어트의 한 축입니다.
 
@@ -613,7 +613,7 @@ my-project/
 ├── CLAUDE.md                  # MoAI의 실행 지침서
 ├── .claude/
 │   ├── agents/moai/           # 10개 MoAI 커스텀 에이전트 정의 (+ Explore 빌트인)
-│   ├── skills/moai-*/         # 27개 스킬 모듈
+│   ├── skills/moai-*/         # 29개 스킬 모듈
 │   ├── hooks/moai/            # 자동화 훅 스크립트
 │   └── rules/moai/            # 코딩 규칙 및 표준
 └── .moai/

--- a/docs-site/content/ko/getting-started/faq.md
+++ b/docs-site/content/ko/getting-started/faq.md
@@ -52,20 +52,12 @@ MoAI statusline은 버전 정보와 업데이트 알림을 함께 표시합니�
 
 ## Q: statusline에 표시되는 세그먼트를 커스터마이징하려면?
 
-statusline은 4가지 디스플레이 프리셋과 커스텀 설정을 지원합니다:
-
-| 프리셋 | 설명 |
-|--------|------|
-| **Full** (기본값) | 모든 8개 세그먼트 표시 |
-| **Compact** | Model + Context + Git Status + Branch만 표시 |
-| **Minimal** | Model + Context만 표시 |
-| **Custom** | 개별 세그먼트 선택 |
+statusline은 개별 세그먼트 단위로 켜고 끌 수 있습니다. 각 세그먼트를 독립적으로 토글하여 원하는 정보만 표시하세요 — 별도의 디스플레이 프리셋 없이 세그먼트 자체가 유일한 구성 레버입니다(테마와 함께).
 
 `moai init` 또는 `moai update -c` 마법사에서 설정하거나, `.moai/config/sections/statusline.yaml`을 직접 편집합니다:
 
 ```yaml
 statusline:
-  preset: compact  # 또는 full, minimal, custom
   segments:
     model: true
     context: true
@@ -76,6 +68,8 @@ statusline:
     moai_version: false
     git_branch: true
 ```
+
+`segments:` 블록이 없으면 기본적으로 모든 세그먼트가 활성화됩니다.
 
 {{< callout type="info" >}}
 자세한 내용은 [SPEC-STATUSLINE-001](https://github.com/modu-ai/moai-adk/blob/main/.moai/specs/SPEC-STATUSLINE-001/spec.md)을 참조하세요.

--- a/docs-site/content/ko/getting-started/introduction.md
+++ b/docs-site/content/ko/getting-started/introduction.md
@@ -147,7 +147,7 @@ MoAI-ADK는 Python Edition을 Go로 완전히 재작성하여 성능과 효율�
 ### 핵심 수치 (v3.0 기준)
 
 - **11개** 에이전트 카탈로그 (10 MoAI 커스텀 + 1 Anthropic 빌트인 `Explore`)
-- **29개** 스킬 (template-managed)
+- **30개** 스킬 (template-managed)
 - **약 37개** 터미널 CLI 명령 · **14종** `/moai` 슬래시 서브커맨드
 - **16개** 프로그래밍 언어 지원
 - **504개** SPEC 문서 기반으로 개발된 코드베이스

--- a/docs-site/content/ko/getting-started/introduction.md
+++ b/docs-site/content/ko/getting-started/introduction.md
@@ -147,7 +147,7 @@ MoAI-ADK는 Python Edition을 Go로 완전히 재작성하여 성능과 효율�
 ### 핵심 수치 (v3.0 기준)
 
 - **11개** 에이전트 카탈로그 (10 MoAI 커스텀 + 1 Anthropic 빌트인 `Explore`)
-- **27개** 스킬 (template-managed)
+- **29개** 스킬 (template-managed)
 - **약 37개** 터미널 CLI 명령 · **14종** `/moai` 슬래시 서브커맨드
 - **16개** 프로그래밍 언어 지원
 - **504개** SPEC 문서 기반으로 개발된 코드베이스


### PR DESCRIPTION
## 개요

oss-docs 한국어 docs-site(`docs-site/content/ko/`) Phase 3 — SPEC 드리프트 일괄 수정. **한국어 정준만** 먼저 반영하며, 4-locale(EN/JA/ZH) 동기화는 후속 PR에서 수행합니다.

## 수정 내역

**STATUSLINE-PRESET-RETIRE (completed SPEC)**
- `getting-started/faq.md`: 디스플레이 프리셋 표(Full/Compact/Minimal/Custom) 및 `preset:` 줄 제거 → **세그먼트 토글 기반**으로 재작성
- `advanced/settings-json.md`: "Compact/default/full 디스플레이 모드" 서술 → 세그먼트 기반으로 정정

**skill 카운트 정정 (사실 오류)**
- `advanced/skill-guide.md`: 27→**29** (Workflow 8→9, Domain 5→6), 누락 스킬 2개 추가
  - `moai-workflow-docs-claim-check` (Workflow)
  - `moai-domain-svg-infographic` (Domain)
- `core-concepts/what-is-moai-adk.md`·`getting-started/introduction.md`: "27개 스킬" → 29개 동기화

**AGENT-PARALLEL-OPT (no-haiku 정책 정합)**
- `advanced/ultracode-workflows.md`: Workflow 예시 `model: "haiku"` → `sonnet` (Go 매트릭스 Explore = sonnet/low 기준)

## 범위에서 의도적으로 제외 (진단 재검증 결과)

- **MODEL-PROFILE-MATRIX effort 어휘(max↔xhigh)**: 진단이 "max→high 통일"을 제안했으나, **Go 프로덕션 매트릭스 SSOT**(`internal/template/profile_matrix.go`)는 effort `{low, medium, high, max}`를 현행 값으로 사용(`xhigh` 퇴역). 진단이 반대 방향을 제안한 상태이며 문서 3곳 + Go 코드가 복잡하게 꼬여 있어 **별도 후속**으로 분리.
- **DB-RETIRE "27→26 / moai-domain-database 제거"**: `moai-domain-database` 스킬이 템플릿에 **실제 존재**(29개/Domain 6개). DB-RETIRE SPEC은 db-schema-sync 서브시스템 제거이지 스킬 제거가 아님 → 진단 오류, 제외.
- **GOAL-DOCS-RETIRE-001**: 한국어 sweep-target(`self-evolving.md`·`handoff.md`)은 이미 native `/goal` 없음; `autonomous-loops.md`는 RETAINED 분할 표면. `cli-reference/goal.md`·`moai-goal.md`·`hooks-reference.md`·`claude-code/**`는 SPEC이 보존 명시.

## 검증

- `hugo --logLevel warning --printPathWarnings` → exit 0, warning 0 (KO 154 페이지 정상 렌더)
- 잔존 드리프트 grep(preset 표·`model:"haiku"`·"27개 스킬") → 0건 확인

## 후속

- 4-locale 동기화 (EN/JA/ZH) — same-PR 의무 per `hns-oss-docs-i18n-rules`
- MODEL-PROFILE-MATRIX effort 어휘 정합 (Go SSOT 기준 별도 조사)

🗿 MoAI