### PR TITLE
chore(SPEC-PRETOOL-GATE-MOVE-001): backfill sync_commit_sha 883d53852

### DIFF
--- a/.moai/specs/SPEC-PRETOOL-GATE-MOVE-001/progress.md
+++ b/.moai/specs/SPEC-PRETOOL-GATE-MOVE-001/progress.md
@@ -231,7 +231,7 @@ m1_to_mN_commit_strategy: per-milestone (M1 evidence-only → M2 code → M3 gua
 
 ```yaml
 sync_complete_at: 2026-07-28
-sync_commit_sha: pending-backfill
+sync_commit_sha: 883d53852
 sync_status: complete
 sync_method: orchestrator-direct (manager-docs subagent PTL'd — runtime-recovery escalation; PR via manager-git next)
 close_infix: "3-phase close"


### PR DESCRIPTION
Backfills progress.md §E.4 sync_commit_sha placeholder (pending-backfill → 883d53852, the #1189 squash-merge SHA on main) per the D3 self-referential-hazard exemption — the sync commit could not reference its own SHA.

F1 coverage follow-up landed separately via #1191 (500c2dc52).

One-line doc backfill; matches the #1193 precedent.

🗿 MoAI