### PR TITLE
docs(hook): mark spec-status subcommand manual-only — no auto-fire path

### DIFF
--- a/internal/cli/hook.go
+++ b/internal/cli/hook.go
@@ -136,7 +136,7 @@ func init() {
 	specStatusCmd := &cobra.Command{
 		Use:   "spec-status",
 		Short: "Auto-update SPEC status on git commit",
-		Long:  "Extract SPEC-IDs from git commit messages and update their status to 'implemented'. Called from handle-spec-status.sh.",
+		Long:  "Extract SPEC-IDs from PR titles / commit messages and update their status to 'implemented'. Manual invocation only (moai hook spec-status): no handle-spec-status.sh wrapper exists and there is no settings.json registration — Claude Code exposes no native hook event that delivers a PR title to stdin, so this subcommand has no auto-fire path.",
 		RunE:  runSpecStatus,
 	}
 	hookCmd.AddCommand(specStatusCmd)

--- a/internal/hook/spec_status.go
+++ b/internal/hook/spec_status.go
@@ -10,8 +10,13 @@ import (
 	"github.com/modu-ai/moai-adk/internal/spec"
 )
 
-// specStatusHandler processes PostToolUse events to auto-update SPEC status on git commits.
+// specStatusHandler parses PR-title / commit-message SPEC-IDs to auto-update SPEC status.
 // It implements REQ-3 of SPEC-STATUS-AUTO-001.
+//
+// Manual invocation only (moai hook spec-status): no handle-spec-status.sh wrapper exists
+// and the subcommand is NOT registered in settings.json. Claude Code exposes no native
+// hook event that delivers a PR title to stdin, so there is no auto-fire path. Kept as a
+// manual utility until a CI/PR-context trigger is wired.
 type specStatusHandler struct{}
 
 // NewSpecStatusHandler creates a new spec status hook handler.


### PR DESCRIPTION
## What
- Corrects the stale `Called from handle-spec-status.sh` doc on the `spec-status` subcommand — that wrapper does not exist.
- Marks `spec-status` as **manual-invocation only**: no `settings.json` registration, no auto-fire path (Claude Code exposes no native hook event that delivers a PR title to stdin).

## Why
Follow-up to a hook/template audit. On tool-verified re-measurement, `spec-status` was the only real gap, and only doc-level — its handler parses PR titles, but no wrapper or hook event wires it to fire automatically.

## Verification
- `go build ./internal/cli/ ./internal/hook/` → exit 0
- `go vet ./internal/hook/` → exit 0
- No behavior change (comments only).

🗿 MoAI