### PR TITLE
fix(session): structural in-process mutex for registry flock starvation (SPEC-V3R6-CI-FLAKY-STABILIZE-003)

### DIFF
--- a/.moai/specs/SPEC-V3R6-CI-FLAKY-STABILIZE-003/acceptance.md
+++ b/.moai/specs/SPEC-V3R6-CI-FLAKY-STABILIZE-003/acceptance.md
@@ -1,0 +1,206 @@
+# Acceptance Criteria — SPEC-V3R6-CI-FLAKY-STABILIZE-003
+
+> Given-When-Then 시나리오 + 반증 가능 구조적 AC. 본 SPEC 의 결함은 로컬에서 재현되지 않으므로(`registry_starvation_test.go:8`), AC 는 **구조적 불변(invariant)** 기반이다. CI-only 재현 가능성에 의존하지 않는다.
+
+---
+
+## §D. AC Matrix
+
+### AC-CFS3-001 — in-process mutex 가 임계 구역을 직렬화한다 (REQ-CFS3-001)
+
+**Given** 하나의 `Registry` 인스턴스(또는 동일 경로를 가리키는 여러 `Registry` 인스턴스)가 `t.TempDir()` 의 단일 레지스트리 파일에 바인딩되어 있고,
+**When** 10개의 goroutine 이 각각 100회(`workers=10 × perWorker=100`, 총 1000회) `Registry.Register` 를 동시에 호출하면,
+**Then** 모든 1000회 호출이 오류 없이 완료되고 최종 엔트리 수는 정확히 1000이며, 이것은 in-process mutex 가 각 호출의 임계 구역을 상호 배타적으로 직렬화했기 때문이다(경합에 의한 `ErrLockTimeout` 발생 0건).
+
+**Evidence:** `go test -race -run TestRegisterSessionConcurrent ./internal/session/` 의 종료 코드 0 + 테스트 본문의 엔트리 수 비교 통과.
+
+### AC-CFS3-002 — 반증 가능 구조적 AC: 뮤텍스 제거 시 실패 (REQ-CFS3-002) ★ 핵심
+
+**Given** 동일 `Registry` 의 `withLock` 임계 구역 진입/이탈을 추적하는 `atomic.Int64` probe(임계 구역 진입 시 increment, 이탈 시 decrement, "현재 임계 구역 동시 진입 goroutine 수" 를 관측)가 테스트 전용으로 노출되어 있고, **probe 의 inc/dec 는 `Registry.withLock` 본문 전체를 bracket 해야 한다** (in-process mutex 획득 직후 — 즉 동일 프로세스 lock 을 잡은 직후 `withLock` 본문 최상단 — 에 inc, 함수 exit 에서 dec). 이 배치가 probe 로 하여금 "현재 `withLock` 본문 내부에 있는 goroutine 수" 를 측정하게 한다. **주의(load-bearing):** probe 가 flock 보유 구간만 bracket 하면, OS-level flock 이 post-acquire 임계 구역을 단일 보유자로 직렬화하므로 뮤텍스 존재 여부와 무관하게 max ≤ 1 만 관측한다 — 이는 양방향 반증(적용 시 ≤ 1 / 제거 시 ≥ 2) 이 불가능한 vacuous AC 가 되어 `verification-claim-integrity.md` §1.1 surface 3 에 위반된다.
+**When** 10 goroutine × 1000 iteration(총 10000회) 경합 하에서 probe 의 "최대 동시 진입 수" 를 관측하면,
+**Then** in-process mutex 가 적용된 상태에서는 최대 동시 진입 수 ≤ 1 이고, **뮤텍스 획득문을 제거/무력화한 상태에서는 충분한 iteration(총 10000회 권장) 하에서 최대 동시 진입 수 ≥ 2 가 관측된다** (확률적 수렴; 관측되지 않을 경우 iteration 수를 늘려 재실행). 이 조건이 충족되지 않으면 AC 는 반증 불가능한 dead prose 이다.
+
+**Evidence:**
+- 적용 상태: 신규 테스트 `TestRegistryWithLockInProcessSerialization` 종료 코드 0 (probe max ≤ 1).
+- 반증 상태(로컬 검증): 동일 테스트의 falsifiability 서브-케이스(M1) 실행 시 충분한 iteration 하에서 probe max ≥ 2 가 관측된다(확률적 수렴; 미관측 시 iteration 증가 재실행). 이 서브-케이스는 CI 기본 skip, env flag 로만 실행(`MOAI_CFS3_FALSIFIABILITY=1`).
+- run-phase 는 양방향(적용/제거) 관측 출력을 `progress.md` §E.2 에 인용.
+
+**★ falsifiability 요구:** 이 AC 의 유효성 조건은 "뮤텍스 제거 시 실패" 이다. run-phase 가 이 조건을 관측하지 못한 채 green 만 보고하면 AC 는 미충족이다(`verification-claim-integrity.md` §1.1 surface 3). 반증 관측은 충분한 iteration 하의 확률적 수렴이므로 미관측 시 iteration 수를 늘려 재실행한다.
+
+### AC-CFS3-003 — cross-process timeout 경로 보존 (REQ-CFS3-003, REQ-CFS3-004)
+
+**Given** 별도의 `registryLock` 인스턴스(`newRegistryLock()`, `Registry.withLock` 의 in-process mutex 를 경유하지 않음)가 레지스트리 파일의 OS flock 을 획득하여 보유하고 있고,
+**When** `Registry.WithLockTimeout(80ms).Register(...)` 가 이와 경합하면,
+**Then** 기존과 동일하게 `ErrLockTimeout` 으로 래핑된 오류가 반환되며 `errors.Is(err, ErrLockTimeout) == true` 이다. in-process mutex 가 cross-process timeout 경로를 단축하지 않는다.
+
+**Evidence:** `TestWithLockTimeoutContract`(`registry_starvation_test.go:107`) 가 수정·삭제 없이 green. 테스트 종료 코드 0.
+
+### AC-CFS3-004 — 지터 백오프 계약 보존 (REQ-CFS3-005)
+
+**Given** `lockRetryDelay` 가 cross-process 경합 하에서 호출되면,
+**When** attempt ∈ [0, 20] 범위로 호출 sampled,
+**Then** 각 지연 값은 (0, `lockBackoffCap`] 범위에 속하고 remaining budget 을 초과하지 않는다. full jitter 가 실제로 작동한다.
+
+**Evidence:** `TestLockRetryDelayBoundsAndJitter`(`registry_starvation_test.go:137`) green 유지.
+
+### AC-CFS3-005 — 기아 특성화 테스트 보존 (REQ-CFS3-009)
+
+**Given** 8 goroutine × 25 registration = 200회 경합 시,
+**When** in-process mutex 가 적용된 상태에서 실행하면,
+**Then** 최대 단일 획득 대기 시간이 `maxWaitCeiling = 15s` 이하이다. (구조적 뮤텍스 적용 후 이 값은 사실상 스케줄링 오버헤드 수준으로 수렴해야 한다.)
+
+**Evidence:** `TestRegisterStarvationCharacterization`(`registry_starvation_test.go:32`) green 유지 + `t.Logf` 의 p50/p95/max 수치가 이전 관측 대비 개선 또는 동등.
+
+### AC-CFS3-006a — Windows run-phase build parity (REQ-CFS3-006)
+
+**Given** `registry_lock_windows.go` 가 존재하고,
+**When** in-process mutex 설계가 적용되면,
+**Then** Windows 빌드에서도 동일한 직렬화 의미론이 코드 수준에서 적용된다(in-process mutex 는 `Registry.withLock` 공통 경로에 있으므로 platform-conditional 코드가 아니다). run-phase 증빙은 **빌드 수준**이다.
+
+**Evidence:**
+- `GOOS=windows go vet ./internal/session/...` green.
+- `GOOS=windows go build ./internal/session/...` green.
+
+**Note:** Windows 런타임 결정론성(green `go test` 실행)은 run-phase 에서는 관측 불가하며 sync-phase CI 증빙으로 연기된다 — see AC-CFS3-006b.
+
+### AC-CFS3-006b — Windows sync-phase CI runtime green (REQ-CFS3-006)
+
+**Given** AC-CFS3-006a 의 빌드 호환성이 확보되어 있고,
+**When** 본 SPEC 변경이 머지되면,
+**Then** Windows CI 잡의 `go test ./internal/session/...` 가 green 이다. Windows 런타임 결정론성은 sync-phase CI 증빙으로 관측된다(run-phase 에서는 Windows 런타임 실검이 불가하므로 SHOULD).
+
+**Evidence:** sync-phase Windows CI 잡 green 증빙.
+
+### AC-CFS3-007 — 비차단 flock 유지 (REQ-CFS3-007, REQ-CFS3-008)
+
+**Given** 본 SPEC 의 변경이 적용되어도,
+**When** `registry_lock_unix.go` 의 `acquire` 호출을 정적 검사하면,
+**Then** `unix.Flock(fd, unix.LOCK_EX|unix.LOCK_NB)` 호출이 그대로 존재하며(차단 flock 전환 금지), `lockRetryDelay` 지터 백오프 루프가 `withLock` 에 그대로 존재한다(제거 금지).
+
+**Evidence:** `grep -n "LOCK_EX|unix.LOCK_NB" internal/session/registry_lock_unix.go` 일치; `grep -n "lockRetryDelay" internal/session/registry.go` 일치.
+
+### AC-CFS3-008 — LockTimeout 기본값 불변 (REQ-CFS3-011, 관련 전작 REQ-CFS-012)
+
+**Given** 본 SPEC 변경 전후,
+**When** `grep -n "^const LockTimeout" internal/session/registry.go` 실행,
+**Then** `LockTimeout = 2 * time.Second` 가 불변.
+
+**Evidence:** grep 출력 일치.
+
+### AC-CFS3-009 — 60s override 평가 (REQ-CFS3-010)
+
+**Given** 구조적 뮤텍스가 적용되어 `TestRegisterSessionConcurrent` 가 결정론적으로 green 이고,
+**When** run-phase 가 `registry_test.go:291` 의 60s override 를 제거/축소/유지 중 하나로 결정하면,
+**Then** 그 결정과 근거가 `progress.md` §E.2 에 기록된다. 제거를 택한 경우 프로덕션 기본값(2s)에서 `-count=20 -race` green 이 관측되어야 한다.
+
+**Evidence:** progress.md §E.2 의 결정 기록 + (제거 시) 2s 기본값에서의 green 테스트 출력.
+
+### AC-CFS3-010 — 하드코딩 방지 (REQ-CFS3-011, REQ-CFS3-012)
+
+**Given** 본 SPEC 이 신규 상수를 도입하는 경우,
+**When** 소스 정적 검사,
+**Then** 해당 상수가 `internal/session` 패키지 레벨 `const` 또는 `internal/config/defaults.go` 에 단일 원천으로 존재하며 hot path 인라인 리터럴이 아니다. 본 SPEC 은 프로덕션 코드를 `internal/session` 외에 수정하지 않는다(defaults.go 신규 상수 추가는 예외).
+
+**Evidence:** grep + 코드 리뷰.
+
+### AC-CFS3-011 — 전체 스위트 + vet + lint + race green (REQ-CFS3-013)
+
+**Given** 본 SPEC 변경이 적용되면,
+**When** 다음 명령을 실행:
+- `go test ./...`
+- `go test -race ./internal/session/...`
+- `go vet ./...`
+- `golangci-lint run`
+
+**Then** 네 명령 모두 종료 코드 0.
+
+**Evidence:** 각 명령의 종료 코드 + verbatim tail 출력.
+
+### AC-CFS3-012 — PR 경유 (REQ-CFS3-014)
+
+**Given** 브랜치 보호 `enforce_admins: true`,
+**When** 본 SPEC 의 변경을 머지하면,
+**Then** 모든 변경이 PR(squash merge) 을 경유하며 main 직접 push 는 없다.
+
+**Evidence:** `gh pr view <PR> --json mergeCommit,mergedAt` + commit history.
+
+### AC-CFS3-013 — MX 태그 보존/추가 (REQ-CFS3-015)
+
+**Given** 패키지가 기존 `@MX:ANCHOR`(`registry.go:15`, withLock NOTE ~358) 를 보유하고,
+**When** 본 SPEC 이 신규 헬퍼/필드를 도입하면,
+**Then** 기존 ANCHOR 는 보존되고 신규 표면(`acquireInProcessMutex` 헬퍼 또는 `Registry.mu` 필드)에는 `@MX:NOTE` (또는 fan_in ≥ 3 예상 시 `@MX:ANCHOR`) 가 태깅된다.
+
+**Evidence:** `grep -n "@MX" internal/session/registry*.go` + 리뷰.
+
+---
+
+## §D.1 Severity Classification
+
+| AC | Severity | Rationale |
+|----|----------|-----------|
+| AC-CFS3-001 | MUST | 결함 재발 방지 핵심. |
+| AC-CFS3-002 | MUST ★ | 반증 가능성이 본 SPEC 의 유효성 조건. 관측 못하면 SPEC 무효. 단, 충분한 iteration(총 10000회 권장) 하의 확률적 수렴이며, 미관측 시 iteration 증가 재실행. |
+| AC-CFS3-003 | MUST | ErrLockTimeout 계약 — 전작 SPEC 의 핵심 계약 보존. |
+| AC-CFS3-004 | MUST | 지터 백오프 계약 보존 — cross-process 전략 회귀 방지. |
+| AC-CFS3-005 | SHOULD | 기아 특성화 유지 — 수치 개선은 관측 부수물. |
+| AC-CFS3-006a | MUST | Windows run-phase 빌드 패리티(REQ-COORD-022 연장). run-phase 관측 가능. |
+| AC-CFS3-006b | SHOULD | Windows CI 런타임 green. run-phase 불가 → sync-phase CI 증빙. |
+| AC-CFS3-007 | MUST | 비차단 + 지터 유지(회귀 방지). |
+| AC-CFS3-008 | MUST | 프로덕션 기본값 불변. |
+| AC-CFS3-009 | SHOULD | 60s override 결정 자체가 요구; 세부 결정은 run-phase 재량. |
+| AC-CFS3-010 | MUST | 하드코딩 방지(CLAUDE.local.md §14). |
+| AC-CFS3-011 | MUST | 전체 게이트. |
+| AC-CFS3-012 | MUST | PR 의무. |
+| AC-CFS3-013 | SHOULD | MX 태깅(M6). |
+
+---
+
+## §D.2 Traceability (REQ ↔ AC)
+
+| REQ | AC |
+|-----|----|
+| REQ-CFS3-001 | AC-CFS3-001 |
+| REQ-CFS3-002 | AC-CFS3-002 ★ |
+| REQ-CFS3-003 | AC-CFS3-003 |
+| REQ-CFS3-004 | AC-CFS3-003 |
+| REQ-CFS3-005 | AC-CFS3-004 |
+| REQ-CFS3-006 | AC-CFS3-006a, AC-CFS3-006b |
+| REQ-CFS3-007 | AC-CFS3-007 |
+| REQ-CFS3-008 | AC-CFS3-007 |
+| REQ-CFS3-009 | AC-CFS3-005, AC-CFS3-004, AC-CFS3-003 |
+| REQ-CFS3-010 | AC-CFS3-009 |
+| REQ-CFS3-011 | AC-CFS3-010 |
+| REQ-CFS3-012 | AC-CFS3-010 |
+| REQ-CFS3-013 | AC-CFS3-011 |
+| REQ-CFS3-014 | AC-CFS3-012 |
+| REQ-CFS3-015 | AC-CFS3-013 |
+
+---
+
+## §D.3 Indirect Verification (직접 관측이 어려운 항목)
+
+- **결함의 로컬 미재현성(`§G` gap 1):** AC-CFS3-001/002 는 이 한계를 보상하기 위해 (a) probe 카운터(결정론적 신호), (b) 반증 가능성(뮤텍스 제거 시 실패 관측) 의 두 메커니즘으로 검증한다. CI-only 재현 가능성에 의존하지 않는다.
+- **cross-process 공정성(§H 잔여 위험 1):** 본 SPEC 은 이 영역을 건드리지 않으므로 AC 가 없다. 대신 AC-CFS3-007 로 cross-process 전략(지터 백오프)의 회귀만 방지한다.
+- **Windows 런타임 결정론성(§G gap 4):** AC-CFS3-006a(run-phase 빌드/vet 수준 MUST) 와 AC-CFS3-006b(sync-phase Windows CI runtime green SHOULD) 로 분리 관측.
+
+---
+
+## §D.4 Closure Gates (Definition of Done)
+
+run-phase 종료 조건:
+1. 모든 MUST AC 가 PASS(observability 충족).
+2. AC-CFS3-002 의 반증 관측(뮤텍스 제거 시 probe max ≥ 2)이 `progress.md` §E.2 에 인용됨.
+3. AC-CFS3-009(60s override 결정)가 `progress.md` §E.2 에 기록됨.
+4. `progress.md` §E.2 E1-E7 매트릭스가 관측된 명령/출력과 함께 채워짐.
+
+sync-phase 종료 조건(추가):
+5. Windows CI 잡 green 증빙(AC-CFS3-006b — Windows runtime).
+6. CI 미재발 관측: 본 SPEC 머지 후 최소 3회 연속 macOS CI green 관측(유한 관측이지만 회귀 탐지 보조).
+
+---
+
+## §D.5 Forward-Looking Checks (미래 회귀 방지)
+
+- **뮤텍스 제거 리팩터 탐지:** AC-CFS3-002 의 falsifiability 서브-케이스는 CI 기본 skip 이므로 future 리팩터를 자동 탐지하지 못한다. 권장: 일종의 "mutation test" 를 periodic job 으로 두거나, falsifiability 검증을 로컬 `make` 타겟으로 등록(선택). 본 SPEC 은 이를 강제하지 않는다.
+- **패키지 헬퍼 경로 회귀:** path-keyed 설계(A) 채택 시 `defaultRegistry()` 매 호출 새 인스턴스 경로도 동일 뮤텍스 공유. per-Registry(B) 채택 시 이 회귀 경로가 열리므로, B 안을 택할 경우 AC-CFS3-002 의 probe 를 패키지 헬퍼 경로까지 확장 적용할 것을 권장.
+- **cross-process timeout 계약 회귀:** `TestWithLockTimeoutContract` 가 본 SPEC 의 회귀 신호. 테스트 유지.

--- a/.moai/specs/SPEC-V3R6-CI-FLAKY-STABILIZE-003/plan.md
+++ b/.moai/specs/SPEC-V3R6-CI-FLAKY-STABILIZE-003/plan.md
@@ -1,0 +1,192 @@
+# Implementation Plan — SPEC-V3R6-CI-FLAKY-STABILIZE-003
+
+> Tier M (standard). Owner: manager-develop (run-phase). Approach ordered by decision-reversibility — the most change-likely decisions first.
+
+---
+
+## §A. Context
+
+`internal/session` 의 `Registry.withLock`(`registry.go:361`) 는 1000회 in-process 경합 시 macOS CI `-race` 에서 NB-flock 의 공정성 부재로 인해 `ErrLockTimeout`(60s 예산 초과) 을 발생시킨다(`§A`/`§B` 참조). 전작 SPEC-CI-FLAKY-STABILIZE-001 의 jitter 백오프는 확률적 완화일 뿐이었고, 한계가 관측되었다.
+
+본 SPEC 은 **in-process mutex + cross-process flock double-locking** 패턴으로 전환해 동일 프로세스 경합을 결정론적으로 직렬화한다. 레지스트리의 본래 목적인 cross-process 조정(REQ-COORD-008/022) 은 flock + 지터 백오프로 보존된다.
+
+**선순위 결정(결정-가역성 높은 순):**
+1. 뮤텍스 범위 선택 (path-keyed vs per-Registry) — §B 결정 안건.
+2. `Registry` 구조체 필드 형태(`*sync.Mutex` 포인터 필수 — copylocks 회피).
+3. 반증 가능 구조적 테스트 probe 설계.
+4. 60s per-acquisition override 축소/제거 평가.
+5. 기계적 수정(헬퍼 추출, MX 태깅, 주석).
+
+---
+
+## §B. Known Issues (이슈 / 트레이드오프)
+
+### B.1 뮤텍스 범위 — [RESOLVED: ADOPTED A — path-keyed (orchestrator at Implementation Kickoff Approval)]
+
+> **설계 결정 RECORD (OQ-1 RESOLVED).** Implementation Kickoff Approval 게이트에서 **Option A (path-keyed)** 가 채택되었다. 아래 A/B 표는 rationale 보존용이며, B 안은 채택되지 않았다(rejected).
+
+**채택 이유 (auditor-verified):** `defaultRegistry()` 가 호출마다 **새 `Registry` 인스턴스**를 반환하므로, per-Registry (B) 안은 패키지 헬퍼(`RegisterSession` 등) 가 거치는 경로를 직렬화하지 못한다. 동일 in-process 경합이라도 별도 `Registry` 인스턴스면 뮤텍스가 미공유되어 결함이 잔존한다. path-keyed (A) 만이 모든 in-process 경합 형태(인스턴스 무관)를 구조적으로 차단한다. `Registry` 복사(`WithLockTimeout`) 시 `*sync.Mutex` 를 공유해야 하는 요구(B 안도 동일)가 이미 존재하므로 A 가 추가로 요구하는 설계 비용이 작다.
+
+| 옵션 | 설명 | 장점 | 단점 |
+|------|------|------|------|
+| **A. path-keyed (ADOPTED)** | 패키지 레벨 `sync.Map[absLockPath]*sync.Mutex`; `Registry.withLock` 가 LoadOrStore 후 Lock. | (1) 동일 경로를 가리키는 별도 `Registry` 인스턴스(예: 패키지 헬퍼 `RegisterSession` 가 호출마다 생성하는 `defaultRegistry()`) 도 직렬화. (2) AC-CFS3-002 의 반증 가능 신호가 경로-수준이라 모든 in-process 경합 형태를 커버. | 맵이 프로세스 수명 동안 단조 성장(테스트 임시 경로). 실영향 미미. |
+| **B. per-Registry (REJECTED)** | `Registry.mu *sync.Mutex` 필드; `NewRegistry` 에서 초기화. | 단순. 맵 관리 부재. | 패키지 헬퍼(`defaultRegistry()` 매 호출 새 인스턴스) 경로를 직렬화하지 못함 — 동일 in-process 라도 별도 `Registry` 면 뮤텍스 미공유. `defaultRegistry()` 가 새 인스턴스를 반환하므로 본 SPEC 의 결함 경로 자체가 B 안에서는 수정되지 않는다. |
+
+[RESOLVED: ADOPTED A — path-keyed (orchestrator at Implementation Kickoff Approval)]
+
+### B.2 Windows parity 관측 공백
+
+`registry_lock_windows.go` 의 in-process 직렬화는 코드 수준에서 동일 추상화로 보장된다(뮤텍스 자체는 OS-독립적 `sync.Mutex`). 단, 본 리포지토리의 Windows CI 잡에서의 결정론적 green 실검은 sync-phase 관측에 의존한다. run-phase는 `GOOS=windows go vet ./internal/session/...` 와 크로스 컴파일로 빌드 호환성만 보장하고, Windows 런타임 실검은 sync-phase 의 CI 증빙으로 연기한다(§G gap 4).
+
+### B.3 반증 가능 테스트 probe 설계 난이도
+
+AC-CFS3-002 의 구조적 테스트는 "뮤텍스 제거 시 실패" 여야 하지만, 동시에 (a) 우발적 flaky 가 아님, (b) 타이밍 의존 아님, (c) 뮤텍스 존재 시 결정론적 green 여야 한다.
+
+후보 probe 설계(결정론적):
+- `atomic.Int64` inCriticalSection 카운터를 뮤텍스 보호 구간 진입 시 increment, 이탈 시 decrement.
+- 테스트는 카운터가 1 을 초과한 적이 있는지(=임계 구역 동시 진입) 를 관측. 뮤텍스 존재 시 항상 0 또는 1, 제거 시 ≥ 2 관측 가능.
+- N goroutine × M iteration 으로 stress. 단, "관측 가능성" 은 스케줄러에 따라 달라지므로 **충분한 iteration** 으로 확률을 1 에 수렴시킨다(결정론에 가까운 관측).
+
+이 테스트 자체가 flaky 가 되는 것을 막기 위해 (a) iteration 수를 충분히 크게(예: 총 10000 회), (b) probe 의 increment/decrement 는 반드시 atomic, (c) `_test.go` 안에서만 probe 를 노출(exported 표면 아님).
+
+**★ Probe placement (load-bearing, AC-CFS3-002):** atomic counter probe 의 inc/dec 는 **`Registry.withLock` 본문 전체**를 bracket 해야 한다 — in-process mutex 획득 직후(동일 프로세스 lock 획득 후 `withLock` 본문 최상단)에 inc, 함수 exit 에서 dec. 이 배치가 probe 로 하여금 "현재 `withLock` 본문 내부에 있는 goroutine 수" 를 측정하게 하고, "현재 flock 을 보유한 goroutine 수" 가 아니게 만든다. OS-level flock 은 post-acquire 임계 구역을 단일 보유자로 직렬화하므로, probe 가 flock 보유 구간만 bracket 하면 뮤텍스 존재 여부와 무관하게 max ≤ 1 만 관측한다 — 양방향 반증(적용 시 ≤ 1 / 제거 시 ≥ 2) 이 불가능한 vacuous AC 가 되어 `verification-claim-integrity.md` §1.1 surface 3 에 위반된다.
+
+### B.4 60s per-acquisition override 결정
+
+`registry_test.go:291` 의 `r = r.WithLockTimeout(60 * time.Second)` 는 프로덕션 기본값(2s) 이 테스트의 in-process 경합을 감당 못했기 때문이다. 구조적 뮤텍스 적용 후에는 in-process 경합이 직렬화되므로 2s 로도 충분할 것으로 예상. 단, run-phase 가 실측 후 (i) 2s 유지 green → 제거, (ii) 약간의 여유 필요 → 5~10s 축소, (iii) 유지(운영 여유) — 중 합리적 결정을 택한다. 결정과 근거를 progress.md §E.2 에 기록.
+
+### B.5 `*sync.Mutex` 포인터 — copylocks 회피 (설계 제약)
+
+`Registry.WithLockTimeout`(`registry.go:141`) 이 `clone := *r` 얕은 복사를 한다. 따라서:
+- `Registry` 에 `sync.Mutex` **값 필드**를 두면 안 된다 → `go vet` copylocks 경고.
+- `*sync.Mutex` **포인터 필드**를 둔다 → clone 이 동일 뮤텍스를 가리킨다 → 올바른 의미론(동일 파일 레지스트리 복제본은 동일 in-process 직렬화를 공유).
+- path-keyed 설계(A)에서는 `Registry.mu *sync.Mutex` 대신 `Registry.withLock` 내에서 `acquireInProcessMutex(absLockPath)` 헬퍼 호출 — 포인터 필드 불필요, 맵에서 조회.
+
+---
+
+## §C. Pre-flight (run-phase 착수 전 확인)
+
+- [ ] 현재 브랜치가 `feat/SPEC-V3R6-CI-FLAKY-STABILIZE-003` (또는 동등 worktree), base `origin/main`.
+- [ ] `git fetch origin main` + divergence 확인(orchestrator pre-spawn sync check).
+- [ ] `internal/session/registry.go`, `registry_lock_unix.go`, `registry_lock_windows.go`, `registry_starvation_test.go`, `registry_test.go` 가 HEAD 와 일치.
+- [ ] §B.1 [RESOLVED: ADOPTED A — path-keyed] 가 확정되어 있음(orchestrator 가 Implementation Kickoff Approval 게이트에서 채택). run-phase M2 는 A 를 전제로 진행한다.
+
+---
+
+## §D. Constraints (코딩/테스트 표준)
+
+- **Go test isolation:** `t.TempDir()`; 병렬 테스트에서 OTEL env 금지(`CLAUDE.local.md §WARN`).
+- **Hardcoding prevention:** 신규 상수(예: 맵 초기 용량 — 실질적으로 필요하지 않으면 추가하지 않음) 는 `internal/session` 패키지 `const` 또는 `internal/config/defaults.go` 단일 원천.
+- **Copylocks:** `Registry` 얕은 복사 경로(`WithLockTimeout`) 호환성 — `*sync.Mutex` 포인터 또는 path-keyed 헬퍼.
+- **Lock ordering:** `Registry.in-process mutex` → `registryLock.mu`(fd 가드) → flock. 순환 없음. 리뷰 확인.
+- **말투:** 영문 코드·주석, 한국어 산출물.
+- **MX tags:** `registry.go:15` ANCHOR + withLock NOTE 보존. 신규 내보낸 헬퍼(`acquireInProcessMutex` 등) 에 `@MX:NOTE`.
+
+---
+
+## §E. Self-Verification (run-phase E1-E7 매트릭스)
+
+run-phase 가 `progress.md` §E.2 에 채우는 항목들:
+- E1: AC PASS/FAIL 매트릭스(AC-CFS3-001..015).
+- E2: `go test -race ./internal/session/...` 베리스 출력.
+- E3: `go test -cover ./internal/session/...` 커버리지(패키지 85%+ 유지).
+- E4: Archived-agent / AskUserQuestion boundary grep — 해당 없음(코드 전용).
+- E5: `golangci-lint run` + `go vet ./...` green.
+- E6: commit/push 상태.
+- E7: 동기화 게이트 단계에서 sync-auditor 4-dim 스코어.
+
+---
+
+## §F. Technical Approach — Milestones (decision-reversibility 역순)
+
+> Milestone 은 결정-가역성 높은 순으로 배치. P0 가 가장 변경 가능성 높은 의사결정.
+
+### P0 — 설계 확정 (뮤텍스 범위) — [RESOLVED: ADOPTED A]
+
+§B.1 OQ-1 은 orchestrator Implementation Kickoff Approval 게이트에서 **A (path-keyed)** 로 확정되었다. run-phase 는 A 가 적용되어 있음을 확인하고, 아래 milestone 들(M1~M6) 은 A 를 전제로 파생한다. (다시 결정을 여는 것이 아님 — ADOPTED A 를 그대로 실행.)
+
+### M1 — RED: 반증 가능 구조적 테스트 먼저 작성 (TDD)
+
+`registry_starvation_test.go` 또는 신규 `registry_inprocess_mutex_test.go` 에:
+
+1. **TestRegistryWithLockInProcessSerialization** (AC-CFS3-002): N goroutine × M iteration 경합시 probe 가 임계 구역 동시 진입을 관측하지 않는다(카운터 max ≤ 1). 결정론적 관측을 위해 N=10, M=1000(총 10000 회) 정도.
+2. **Falsifiability check**: 동일 테스트의 서브-케이스로, 의도적으로 뮤텍스를 끄는 옵션(`Registry.noMutex` 테스트 전용 필드, 또는 별도 bypass 함수) 을 두고 그 상태에서 카운터 max ≥ 2 가 관측됨을 확인. 이 서브-케이스는 일반 CI 에서는 skip(`t.Run("falsifiability", ...)` + env flag) 하고 로컬 검증 용도로만 실행.
+3. **TestRegistryWithLockCrossProcessTimeoutPreserved** (AC-CFS3-004 보강): 기존 `TestWithLockTimeoutContract` 의 변주 — blocker 가 `registryLock.acquire` 직접 경로(뮤텍스 미경유) 로 flock 보유 시, `Registry.withLock` 경로가 여전히 `ErrLockTimeout` 을 반환함. (이미 `TestWithLockTimeoutContract` 가 커버하므로, 신규 테스트가 필요할지는 run-phase 가 중복 회피 후 결정.)
+
+관측: M1 테스트는 뮤텍스 구현 전에는 실패해야 한다(RED). 단, "결정론적 실패" 가 아니라 "구조적 실패" 여야 하므로, M1 은 우선 probe 카운터 관측치를 기록하는 characterization 용도로 작성하고, M2 적용 후 green 전환을 관측한다.
+
+### M2 — GREEN: in-process mutex 적용
+
+선택된 설계(A 권장) 에 따라:
+
+**A (path-keyed):**
+```go
+// registry.go (or new registry_inprocess.go)
+var inProcessMutexes sync.Map // map[string]*sync.Mutex
+
+func acquireInProcessMutex(absLockPath string) *sync.Mutex {
+    v, _ := inProcessMutexes.LoadOrStore(absLockPath, &sync.Mutex{})
+    return v.(*sync.Mutex)
+}
+
+// in withLock, at the top:
+absLockPath, _ := filepath.Abs(lockPath)
+ipm := acquireInProcessMutex(absLockPath)
+ipm.Lock()
+defer ipm.Unlock()
+// ... 기존 flock 획득 + 지터 백오프 루프 + 임계 구역 ...
+```
+
+**B (per-Registry):** `Registry` 에 `mu *sync.Mutex` 필드 추가; `NewRegistry` 에서 초기화; `WithLockTimeout` clone 은 동일 포인터 공유(자동); `withLock` 상단에서 `r.mu.Lock()` / `defer r.mu.Unlock()`.
+
+양안 모두 flock 루프와 `ErrLockTimeout` 반환 경로는 **변경 없음**.
+
+### M3 — 기존 계약 테스트 전수 green 확인
+
+- `TestRegisterSessionConcurrent` (registry_test.go:283) — green.
+- `TestRegisterStarvationCharacterization`, `TestWithLockTimeoutContract`, `TestLockRetryDelayBoundsAndJitter` — 모두 green.
+- 전체 `go test -race ./internal/session/...` green.
+
+### M4 — 60s override 평가 (REQ-CFS3-010)
+
+`registry_test.go:291` 의 60s override 를:
+- (i) 제거(`WithLockTimeout` 호출 삭제) 후 `go test -race -count=20 -run TestRegisterSessionConcurrent ./internal/session/` green 관측 → 제거 확정.
+- (ii) 제거 시 간헐 실패 → 적정 값(예: 10s) 로 축소.
+- (iii) 유지(운영 여유) — 주석으로 "구조적 뮤텍스가 정확성 메커니즘이고, 이 60s 는 운영 여유일 뿐" 명시.
+
+결정과 근거를 `progress.md` §E.2 에 기록.
+
+### M5 — 크로스 플랫폼 빌드 보장
+
+- `GOOS=windows go vet ./internal/session/...` green.
+- `GOOS=windows go build ./internal/session/...` green.
+- `registry_lock_windows.go` 가 in-process mutex 의미론 동일하게 적용받는지 코드 리뷰(뮤텍스는 `Registry.withLock` 공통 경로에 있으므로 자동 적용 — but 명시적으로 리뷰에서 확인).
+
+### M6 — MX 태깅 + 주석 + 커밋
+
+- 신규 헬퍼(`acquireInProcessMutex` 또는 `Registry.mu`) 에 `@MX:NOTE` ("in-process 직렬화; cross-process flock 과 이중 락킹").
+- `registry.go:326` 의 기존 자체 기술 주석(확률적 완화 한계) 갱신 — 본 SPEC 이 구조적으로 해결했음을 명시, 단 cross-process 경합은 여전히 동일 전략 유지.
+- Conventional Commit: `fix(session): structural in-process mutex for registry flock starvation (SPEC-V3R6-CI-FLAKY-STABILIZE-003)`.
+
+---
+
+## §G. Anti-Patterns (회피 패턴)
+
+- **AP-CFS3-001** — 차단 flock(`LOCK_EX` 단독) 전환. REQ-CFS3-007 위반. cross-process 데드 홀더 시 무한 블록 재도입.
+- **AP-CFS3-002** — 지터 백오프 제거. REQ-CFS3-008 위반. cross-process 공정성 퇴행.
+- **AP-CFS3-003** — 뮤텍스 값 필드(`sync.Mutex`) 를 `Registry` 에 두어 `WithLockTimeout` clone 시 copylocks 경고. §B.5 위반.
+- **AP-CFS3-004** — 뮤텍스를 `registryLock.acquire` 내부에 넣기. blocker 직접 경로(`TestWithLockTimeoutContract`) 가 뮤텍스를 공유하게 되어 ErrLockTimeout 계약이 깨짐. REQ-CFS3-004 위반.
+- **AP-CFS3-005** — 신규 구조적 테스트를 타이밍 의존 `time.Since` 비교로 작성. 우발적 flaky 재발.
+- **AP-CFS3-006** — `TestRegisterSessionConcurrent` 의 60s override 를 "정확성 게이트" 로 착각. REQ-CFS3-010 위반 — 뮤텍스가 정확성 메커니즘이며 60s 는 운영 여유일 뿐.
+- **AP-CFS3-007** — `internal/session/lock.go`(`flockLock`, SPEC-V3R2-RT-004 CHECKPOINT 용) 를 본 SPEC 범위로 혼동해 수정. §C.2 위반.
+- **AP-CFS3-008** — WES-001 / worktree / launcher 파일에 손대기. §C.2 위반 (STANDALONE SPEC).
+
+---
+
+## §H. Cross-References
+
+- spec.md: 본 SPEC 의 요구사항/AC 매트릭스.
+- acceptance.md: Given-When-Then 시나리오 + 반증 가능 AC 상세.
+- `.claude/rules/moai/workflow/mx-tag-protocol.md` — MX 태깅(M6).
+- `CLAUDE.local.md §6`(테스트 격리), §14(하드코딩 방지), §22.8(worktree auto-toggle 기본 off — 본 SPEC 무관하지만 reference).
+- 선행 SPEC: `SPEC-V3R6-MULTI-SESSION-COORD-001`(REQ-COORD-008/022), `SPEC-CI-FLAKY-STABILIZE-001`(REQ-CFS-010/011/014/015/016).

--- a/.moai/specs/SPEC-V3R6-CI-FLAKY-STABILIZE-003/progress.md
+++ b/.moai/specs/SPEC-V3R6-CI-FLAKY-STABILIZE-003/progress.md
@@ -1,0 +1,74 @@
+# Progress — SPEC-V3R6-CI-FLAKY-STABILIZE-003
+
+> Plan-phase skeleton. §E.2/§E.3/§E.4 are placeholder headings only; manager-develop (run-phase) populates §E.2/§E.3, manager-docs (sync-phase) populates §E.4. manager-spec populates §E.1 only at plan-phase.
+
+---
+
+## §A. Status
+
+| Phase | State | Owner |
+|-------|-------|-------|
+| Plan | complete (pending audit + Implementation Kickoff Approval) | manager-spec |
+| Run | not started | manager-develop |
+| Sync | not started | manager-docs |
+
+---
+
+## §B. Artifact Set
+
+- `spec.md` — GEARS requirements (15 REQs), 7 success criteria, structural mutex fix (v0.2.0 — iter-1 audit defect fixes D1–D5 applied).
+- `plan.md` — Tier M, 6 milestones (M1-M6), §B.1 [RESOLVED: ADOPTED A — path-keyed] (OQ-1 resolved at Implementation Kickoff Approval).
+- `acceptance.md` — 14 ACs (AC-CFS3-001..013, with AC-CFS3-006 split into 006a/006b per D5), AC-CFS3-002 is the falsifiable structural anchor.
+- `progress.md` — this file.
+
+---
+
+## §C. Open Questions for Implementation Kickoff Approval Gate
+
+- **OQ-1 (§B.1 of plan.md):** [RESOLVED: ADOPTED A — path-keyed (orchestrator at Implementation Kickoff Approval)]. Rationale: `defaultRegistry()` returns a NEW `Registry` per call, so per-Registry (B) would NOT serialize the package-helper path.
+
+---
+
+## §D. Pre-Flight Checklist (for run-phase)
+
+- [x] OQ-1 resolved — ADOPTED A (path-keyed) at Implementation Kickoff Approval.
+- [ ] Branch `feat/SPEC-V3R6-CI-FLAKY-STABILIZE-003` at origin/main base.
+- [ ] Pre-spawn sync check passed (orchestrator).
+
+---
+
+## §E.1 Plan-phase Audit-Ready Signal
+
+**plan-auditor: iter1 FAIL 0.86 (MP-7 clarification gate) → D1–D5 수정 → iter2 PASS 0.92** (Tier M threshold 0.80). MP-1..MP-7 전부 PASS at iter2; D1–D5 cleared with file:line evidence. 구현 착수 승인(Implementation Kickoff Approval): **GRANTED** (GOOS, 2026-07-29, OQ-1=A path-keyed).
+
+Plan-phase artifacts: spec.md (0.2.0 — iter-1 audit fixes D1–D5 applied), plan.md (Tier M), acceptance.md (14 ACs, AC-CFS3-006 split into 006a/006b), progress.md (this skeleton).
+OQ-1 (mutex scope) [RESOLVED: ADOPTED A — path-keyed at Implementation Kickoff Approval].
+Lineage: supersedes SPEC-CI-FLAKY-STABILIZE-001 defect 2 (REQ-CFS-010/011/014/015/016) structurally; preserves SPEC-V3R6-MULTI-SESSION-COORD-001 REQ-COORD-008/022.
+
+---
+
+## §E.2 Run-phase Evidence
+
+_<pending run-phase>_
+
+---
+
+## §E.3 Run-phase Audit-Ready Signal
+
+_<pending run-phase>_
+
+---
+
+## §E.4 Sync-phase Audit-Ready Signal
+
+_<pending sync-phase>_
+
+---
+
+## §F Phase 4 Mode Selection
+
+**Input parameters:** tier=M; scope≈4 files (registry.go, registry_lock_{unix,windows}.go, +test files); domain count=1 (internal/session concurrency); language=Go; concurrency benefit=LOW (coding-heavy, contract-sensitive). Agent Teams: RETIRED (Mode 3 tombstone).
+
+**Decision: Mode 5 (sub-agent, sequential)** — single-domain coding-heavy concurrency fix; Anthropic coding-task parallelism caveat → sequential sub-agent. Mode 6 (workflow) rejected (not high-volume mechanical; semantic concurrency change, <30 files). Mode 4 (parallel) rejected (single domain, not multi-domain research).
+
+**Justification:** Tier M, one package, contract-sensitive (ErrLockTimeout / `TestWithLockTimeoutContract` preservation) — sequential TDD (M1 RED → M2 GREEN) under a single manager-develop is the safe default. **Branch reality:** primary checkout is on the WES-001 branch; the flaky fix is assembled in isolated worktree `session-flock-flaky` (branch `worktree-session-flock-flaky`, origin/main base, verified `0 0` divergence) per `feedback_index_level_commit_shared_checkout` — manager-develop edits disjoint `internal/session` files in primary, orchestrator cp+commit in worktree. Implementation Kickoff Approval PASSED (GOOS, 2026-07-29) before this spawn.

--- a/.moai/specs/SPEC-V3R6-CI-FLAKY-STABILIZE-003/spec.md
+++ b/.moai/specs/SPEC-V3R6-CI-FLAKY-STABILIZE-003/spec.md
@@ -1,0 +1,238 @@
+---
+id: SPEC-V3R6-CI-FLAKY-STABILIZE-003
+title: "CI Flaky Test Stabilization — session registry flock starvation structural fix (in-process mutex + cross-process flock double-locking)"
+version: "0.2.0"
+status: draft
+created: 2026-07-29
+updated: 2026-07-29
+author: manager-spec
+priority: P1
+phase: "v3.0.2"
+module: "internal/session"
+lifecycle: spec-anchored
+tags: "ci, flaky-test, flock, starvation, concurrency, mutex, double-locking, cross-platform, structural"
+tier: M
+---
+
+## HISTORY
+
+| Version | Date | Author | Change |
+|---------|------|--------|--------|
+| 0.1.0 | 2026-07-29 | manager-spec | Initial plan-phase draft. Structural fix for the macOS CI flaky `TestRegisterSessionConcurrent` (`internal/session`). Supersedes the jitter-backoff mitigation in SPEC-CI-FLAKY-STABILIZE-001 defect 2 (REQ-CFS-010/011/014/015/016), which self-documented as a probabilistic, non-structural mitigation and has now failed on macOS CI (`-race`, run `30374096068`, 2026-07-28). Introduces the standard in-process mutex + cross-process flock double-locking pattern. |
+| 0.2.0 | 2026-07-29 | manager-spec | iter-1 audit defect fixes D1–D5 applied (OQ-1 resolved A path-keyed); technical approach unchanged (auditor-verified-sound). D1: OQ-1 ADOPTED A (path-keyed) — `defaultRegistry()` returns new Registry per call so B would not serialize package-helper path. D2: AC-CFS3-002 probe placement brackets entire `withLock` body. D3: AC-CFS3-002 Then-clause softened to probabilistic convergence. D4: REQ-CFS3-001 scope extended to entire `withLock` body incl. NB-flock retry loop. D5: AC-CFS3-006 split into 006a (build parity MUST) / 006b (Windows CI runtime SHOULD). |
+
+---
+
+## §A. 배경 (Context)
+
+`internal/session` 의 다중 세션 레지스트리(`active-sessions.json`)는 `SPEC-V3R6-MULTI-SESSION-COORD-001` 이 도입한 cross-process 조정 프리미티브다. 모든 mutation 경로(`Register` / `Heartbeat` / `Deregister` / `Purge`)는 `Registry.withLock` (`registry.go:361`) 을 경유해 비차단 `flock(LOCK_EX|LOCK_NB)` 으로 보호된 임계 구역을 직렬화한다.
+
+`TestRegisterSessionConcurrent` (`registry_test.go:283`) 는 10 goroutine × 100 registration = 1000회의 **동일 프로세스 내(in-process)** 경합으로 이 락을 스트레스한다. 2026-07-28 macOS CI (`-race`, run `30374096068`) 에서 이 테스트가 102.01s 만에 다음과 같이 실패했다:
+
+```
+--- FAIL: TestRegisterSessionConcurrent (102.01s)
+    registry_test.go:316: concurrent Register: session registry: lock acquisition timed out:
+    registry lock flock .../active-sessions.json.lock: resource temporarily unavailable
+```
+
+이 실패는 SPEC-CI-FLAKY-STABILIZE-001 defect 2 의 재발이다. 전작 SPEC은 결함 2 에 대해 **jittered exponential backoff** (`lockRetryDelay`, `registry.go:330`) 와 **기아 특성화 테스트** (`registry_starvation_test.go`) 를 도입했으나, `registry.go:326` 에 스스로 "이것은 확률적 완화이지 구조적 공정성이 아니다 — 지속적 경합 하에서 반복 패배자는 여전히 가능하다" 고 명시했고, macOS CI `-race` 조건에서 정확히 그 시나리오가 관측되었다.
+
+### A.1 로컬 미재현
+
+`registry_starvation_test.go:8` 에 이미 문서화된 대로, 이 결함은 로컬에서 재현되지 않는다. 본 SPEC 의 검증 축은 (a) 메커니즘 정확성 — 식별된 코드 경로를 구조적으로 수정했는가, (b) 반증 가능한 구조적 AC — 뮤텍스를 제거하면 AC 가 실패하는가, (c) CI 미재발 — 의 세 축이다. 로컬 red→green 재현은 검증 축이 아니다(`§G` 참조).
+
+---
+
+## §B. 문제 정의 (Problem Statement)
+
+### B.1 근본 원인 — 비차단 flock + in-process 직렬화 부재
+
+`registryLock.acquire` (`registry_lock_unix.go:31`) 는 `unix.FLOCK_EX | unix.LOCK_NB`(비차단) 를 사용한다. 구조체의 `mu sync.Mutex` 필드는 `fd` 필드 보호용일 뿐, **파일 임계 구역 자체를 직렬화하지 않는다**. `Registry.withLock` 은 NB-flock → EAGAIN → `lockRetryDelay` 지터 백오프 sleep → 재시도 루프를 `lockTimeout` 데드라인까지 반복한다.
+
+NB flock 은 커널 대기열에 경합자를 큐잉하지 않는다. 즉 **동일 프로세스의 goroutine 들 사이에 커널 공정성 보장이 없다**. 10 goroutine 이 동일 프로세스에서 동일 락 파일에 대해 반복적으로 NB 획득을 시도할 때, 불운한 goroutine 이 반복적으로 경쟁에서 패배해 `lockTimeout` 데드라인을 넘길 수 있다 — 이것이 관측된 `ErrLockTimeout` 이다.
+
+### B.2 왜 "전반적 느림"이 아니라 "기아"인가
+
+`withLock` 의 `deadline` 은 **호출마다** 재계산된다(`registry.go:372`). 테스트의 60s 예산은 **획득 1회당** 예산이다. 1000회 획득 중 단일 `Register` 가 60s 를 넘겼다는 것은 집계 지연으로 설명될 수 없고, 한 goroutine 이 반복적으로 경쟁에서 밀렸음을 뜻한다. 이 판정은 전작 SPEC-CI-FLAKY-STABILIZE-001 §B.2 에서 이미 확립된 것이다.
+
+### B.3 전작의 확률적 완화가 충분하지 않은 이유
+
+`lockRetryDelay` 의 full-jitter 백오프는 경합자들의 깨어남 주기를 무작위화하여 동시성 동기화(synchronization) 를 끊는다. 그러나 NB flock 자체가 커널 공정성 큐를 제공하지 않기 때문에, 지속적 경합 하에서 **반복 패배자가 확률적으로 여전히 존재**한다. 이것은 전작 SPEC 의 §H 잔여 위험 1 과 `registry.go:326` 의 자체 기술 주석이 이미 인정한 한계다. macOS CI `-race` 조건(스케줄러 특성 + race detector 오버헤드)이 이 확률적 창을 실제로 넘어뜨렸다.
+
+---
+
+## §C. 범위 (Scope)
+
+### C.1 대상 파일
+
+- `internal/session/registry.go` — `Registry.withLock` 임계 구역; `Registry` 구조체(또는 패키지 레벨 path-keyed 뮤텍스 맵).
+- `internal/session/registry_lock_unix.go` — `registryLock` 의 `mu` 역할 재확정(또는 축소).
+- `internal/session/registry_lock_windows.go` — Windows 패리티.
+- `internal/session/registry_starvation_test.go` — 기존 특성화/계약 테스트 **보존** + 신규 반증 가능 구조적 AC 추가.
+- `internal/session/registry_test.go:283` — `TestRegisterSessionConcurrent`. 결정론화 이후 60s override 축소/제거 평가.
+
+### C.2 비대상 (명시적 분리)
+
+- `internal/session/lock.go` (`flockLock` / `fileLock`) — `SPEC-V3R2-RT-004` CHECKPOINT 서브시스템 전용이며 **다른 락**이다. 레지스트리 락과 동일한 인프라를 공유하지 않는 한 이 SPEC 에서 절대 건드리지 않는다.
+- WES-001 / worktree / launcher / `moai cc -w` 관련 파일 — STANDALONE SPEC, 일절 미접촉.
+
+### C.3 제외 항목 (Exclusions)
+
+본 SPEC 은 아래 항목을 명시적으로 out of scope 로 둔다.
+
+### Out of Scope — 락 아키텍처 전환
+
+- 비차단 `LOCK_NB` → 차단 flock (`LOCK_EX` 단독) 전환. 커널 대기열 기반 공정성 확보는 구조적 해법이지만, CLI/hook 컨텍스트에서 데드 홀더에 의한 무한 블록 위험(`AP-MSC-005`) 을 재도입하므로 본 SPEC 에서 다루지 않는다.
+- 파일 락 → 다른 동기화 기전(락 서버, DB 트랜잭션, 단일 프로세스 싱글톤 registry) 교체.
+
+### Out of Scope — 프로덕션 동작 변경
+
+- `LockTimeout = 2 * time.Second` 기본값 변경.
+- `ErrLockTimeout` 에러 계약(반환 조건, 래핑 형태, `errors.Is(err, ErrLockTimeout)` 판정) 변경 — `TestWithLockTimeoutContract` 가 green 이어야 함.
+- `Query` 경로의 eventually-consistent read 설계 변경.
+- `Entry` 스키마(`SPEC-V3R6-MULTI-SESSION-COORD-001` REQ-COORD-024 frozen) 변경.
+- 레지스트리 파일 포맷(`active-sessions.json`) 변경.
+
+### Out of Scope — 테스트 약화
+
+- `TestRegisterSessionConcurrent` 삭제 / skip / 조건부 비활성화.
+- `TestRegisterStarvationCharacterization`, `TestWithLockTimeoutContract`, `TestLockRetryDelayBoundsAndJitter` 삭제 또는 약화 — 전작 SPEC 의 계약을 그대로 보존한다.
+- `-race` 플래그를 CI 에서 제거하거나 대상 패키지만 예외 처리.
+
+### Out of Scope — 인접 리팩터링
+
+- 본 결함과 무관한 `internal/session` 코드 정리.
+- 다른 flaky 테스트 이력 조사·수정.
+- CI 워크플로 재시도 정책(`retry` 횟수) 조정 — 증상 은폐.
+
+### Out of Scope — 전작 SPEC 결함 1 (cobra lazy-sort race)
+
+- `SPEC-CI-FLAKY-STABILIZE-001` 결함 1 (`internal/cli` / `internal/cli/preference` TestMain warm-up) 은 무관하며, 본 SPEC 은 그것을 건드리지 않는다. 본 SPEC 은 동일 전작의 **결함 2 (레지스트리 flock 기아) 만** 구조적으로 대체한다.
+
+---
+
+## §D. 요구사항 (GEARS)
+
+### D.1 핵심 — in-process 직렬화
+
+**REQ-CFS3-001** (Ubiquitous)
+`Registry.withLock` 의 본문 전체(NB-flock 재시도 루프 + open + flock + read + mutate + write + close 포함)은, 동일 프로세스 내에서 동일 락 경로를 공유하는 모든 경합자를 직렬하는 **in-process mutex** 로 보호되어야 한다(shall). 이 뮤텍스는 post-acquire 임계 구역만이 아니라 **NB-flock 재시도 루프 전체**를 감싸야 한다(shall) — 기아는 바로 이 재시도 루프 수준에서 발생한다(NB flock 가 커널 공정성 큐를 제공하지 않기 때문에, 불운한 goroutine 이 반복적으로 경쟁에서 밀려 `lockTimeout` 을 넘긴다). 따라서 post-acquire 임계 구역만 감쌀 경우 결함이 잔존하므로, 뮤텍스는 `withLock` 본문 전체를 감싸야 결함이 구조적으로 제거된다. 이 뮤텍스는 동일 프로세스 내 경합자가 다른 동일 프로세스 경합자에 의해 flock 수준에서 굶주리는 것을 구조적으로 차단한다.
+
+**REQ-CFS3-002** (Event-driven / 구조적 반증)
+**When** N ≥ 2 goroutine 이 동일한 레지스트리 경로(동일 `Registry` 인스턴스 또는 동일 경로를 가리키는 별도 `Registry` 인스턴스) 에 대해 동시에 `Registry.withLock` 을 진입하면, in-process mutex 는 그들의 임계 구역을 **상호 배타적으로 직렬**해야 한다(shall). 이 요구사항은 **반증 가능한 구조적 테스트**로 검증된다 — 뮤텍스 획득문을 제거하면 테스트가 실패해야 한다(shall). (`acceptance.md` §D AC-CFS3-002)
+
+**REQ-CFS3-003** (Capability gate / 설계 규칙)
+**Where** `Registry.withLock` 가 in-process mutex 를 획득한 상태에서 cross-process(또는 `Registry.withLock` 를 경유하지 않는 별도 `registryLock`) 경합자가 이미 OS flock 을 보유하고 있으면, `Registry.withLock` 는 기존의 지터 백오프 재시도 루프에 따라 NB-flock 재시도를 계속해야 하며(shall), 데드라인 도달 시 `ErrLockTimeout` 으로 래핑된 오류를 반환해야 한다(shall). in-process mutex 는 cross-process timeout 경로를 단축하지 않는다.
+
+### D.2 계약 보존 — ErrLockTimeout + jitter
+
+**REQ-CFS3-004** (Event-driven)
+**When** `TestWithLockTimeoutContract` (`registry_starvation_test.go:107`) 가 별도의 `registryLock` 인스턴스로 OS flock 을 보유한 상태에서 `Registry.withLock` 경로가 이와 경합하면, 기존과 동일하게 `ErrLockTimeout` 으로 래핑된 오류가 반환되어야 하며(shall), `errors.Is(err, ErrLockTimeout)` 판정 결과는 변경 전후 동일해야 한다. 해당 테스트는 본 SPEC 변경 후에도 수정·삭제 없이 green 이어야 한다(shall).
+
+**REQ-CFS3-005** (Ubiquitous)
+`lockRetryDelay` (`registry.go:330`) 의 지터 백오프 계약(`lockBackoffBase`, `lockBackoffCap`, deadline clamp) 은 **보존**되어야 한다(shall). in-process mutex 가 동일 프로세스 경합을 제거한 후에도, cross-process 경합(레지스트리의 본래 목적) 은 여전히 NB flock 이므로 지터 백오프는 cross-process 재시도 전략으로 그대로 쓰인다. `TestLockRetryDelayBoundsAndJitter` 는 green 이어야 한다(shall).
+
+### D.3 크로스 플랫폼 패리티
+
+**REQ-CFS3-006** (Ubiquitous)
+in-process mutex guard 는 `registry_lock_windows.go` 경로에 동일하게 적용되어야 한다(shall). in-process 직렬화는 OS-독립적이므로 Windows 빌드에서도 동일한 직렬화 의미론을 가져야 한다. Windows parity 증빙은 두 티어로 분리된다: (a) **run-phase 빌드 호환성(MUST)** — `GOOS=windows go vet ./internal/session/...` + `GOOS=windows go build ./internal/session/...` green 으로 관측(`acceptance.md` AC-CFS3-006a); (b) **sync-phase Windows CI 런타임 green(SHOULD)** — Windows CI 잡의 `go test ./internal/session/...` green 증빙(run-phase 에서는 Windows 런타임 실검이 불가하므로 SHOULD, `acceptance.md` AC-CFS3-006b). Windows parity 는 `REQ-COORD-022` (크로스 플랫폼 호환) 의 연장선이다.
+
+### D.4 금지 — 비차단 flock 제거 / 차단 flock 전환
+
+**REQ-CFS3-007** (Unwanted)
+본 SPEC 의 변경은 `unix.LOCK_NB`(비차단) 획득 방식을 차단 flock(`LOCK_EX` 단독) 으로 전환해서는 안 된다(shall not). 이유: CLI/hook 컨텍스트에서 데드 홀더에 의한 무한 블록 위험(`AP-MSC-005`) 재도입. in-process mutex 는 동일 프로세스 경합을 제거하지만, cross-process 데드 홀더 시나리오는 여전히 가능하므로 비차단 + timeout 계약이 여전히 필요하다.
+
+**REQ-CFS3-008** (Unwanted)
+본 SPEC 의 변경은 기존의 `lockRetryDelay` 지터 백오프 루프를 제거해서는 안 된다(shall not). cross-process 경합 하에서 지터 백오프는 여전히 유효한 재시도 전략이다. 제거할 경우 cross-process 데드라인 경합의 공정성이 퇴행한다.
+
+### D.5 기존 테스트 보존 + 60s override 평가
+
+**REQ-CFS3-009** (Unwanted)
+본 SPEC 의 변경은 `TestRegisterSessionConcurrent`, `TestRegisterStarvationCharacterization`, `TestWithLockTimeoutContract`, `TestLockRetryDelayBoundsAndJitter` 중 어느 것도 삭제·skip·조건부 비활성화해서는 안 된다(shall not). 이 테스트들은 전작 SPEC-CI-FLAKY-STABILIZE-001 의 계약을 구성하며, 본 SPEC 은 그것을 회귀시키지 않는다.
+
+**REQ-CFS3-010** (Event-driven / 평가)
+**When** 본 SPEC 의 구조적 수정이 적용되어 `TestRegisterSessionConcurrent` 가 결정론적으로 green 이 되면, run-phase 는 `registry_test.go:291` 의 60s per-acquisition timeout override 가 여전히 필요한지 **평가**해야 한다(shall). 결정(축소/제거/유지)과 그 근거는 `progress.md` §E.2 에 기록되어야 하며(shall), 제거 시 프로덕션 기본값(2s)에서도 테스트가 green 이어야 한다(shall). (평가 후 유지를 결정할 수 있으며, 그 경우에도 구조적 뮤텍스가 정확성 메커니즘이고 60s override는 운영 여유일 뿐임을 주석으로 명시해야 한다.)
+
+### D.6 품질 / 절차
+
+**REQ-CFS3-011** (Ubiquitous / 코딩 표준)
+본 SPEC 이 새로 도입하는 임계값/상수(예: path-keyed mutex 맵 초기 용량, 신규 패키지 상수) 가 있으면 `internal/session` 패키지 레벨 `const` 또는 `internal/config/defaults.go` 에 단일 원천으로 정의되어야 한다(shall). 인라인 리터럴이 hot path 에 산재해서는 안 된다(shall not). (`CLAUDE.local.md §14` hardcoding-prevention)
+
+**REQ-CFS3-012** (Ubiquitous)
+본 SPEC 의 변경은 `internal/session` 패키지 외의 프로덕션 코드를 수정해서는 안 된다(shall not). 단, 신규 상수가 `defaults.go` 에 추가되는 경우는 예외로 한다.
+
+**REQ-CFS3-013** (Ubiquitous)
+변경 후 `go test ./...`, `go test -race ./internal/session/...`, `go vet ./...`, `golangci-lint run` 이 모두 통과해야 한다(shall).
+
+**REQ-CFS3-014** (Ubiquitous)
+모든 변경은 PR을 경유해야 한다(shall) — 브랜치 보호 `enforce_admins: true`.
+
+**REQ-CFS3-015** (Ubiquitous / MX)
+패키지가 보유한 기존 `@MX:ANCHOR` (`registry.go:15` withLock NOTE ~358)는 보존되어야 하며(shall), 신규 내보낸 표면(예: path-keyed mutex 맵, 신규 헬퍼)에는 `@MX:NOTE` 또는 `@MX:ANCHOR` 가 태깅되어야 한다(shall) — `.claude/rules/moai/workflow/mx-tag-protocol.md`.
+
+---
+
+## §E. 성공 기준 (Success Criteria)
+
+| # | 기준 | 측정 방법 |
+|---|------|-----------|
+| 1 | `TestRegisterSessionConcurrent` 가 구조적 뮤텍스 적용 후 결정론적으로 green | `go test -race -run TestRegisterSessionConcurrent ./internal/session/` 종료 코드 0 |
+| 2 | 반증 가능 구조적 AC(AC-CFS3-002)가 뮤텍스 제거 시 FAIL, 적용 시 PASS | run-phase 에서 뮤텍스 라인을 제거/무력화한 상태의 `go test` 실패 출력 |
+| 3 | `TestWithLockTimeoutContract` green 유지 | 테스트 종료 코드 0 (ErrLockTimeout 계약 보존 근거) |
+| 4 | `TestLockRetryDelayBoundsAndJitter`, `TestRegisterStarvationCharacterization` green 유지 | 각 테스트 종료 코드 0 |
+| 5 | 전체 스위트 + `-race ./internal/session/` + vet + lint green | 각 명령 종료 코드 0 |
+| 6 | Windows parity — `registry_lock_windows.go` 경로 동일 직렬화 의미론 | Windows 빌드 크로스 컴파일 + `go vet` (CI Windows 잡에서 실검 증빙은 sync-phase) |
+| 7 | `LockTimeout = 2 * time.Second` 기본값 불변 | 소스 grep |
+
+상세 검증 명령과 기대 출력은 `acceptance.md` §D AC 매트릭스에 있다.
+
+---
+
+## §F. 의존성 및 제약
+
+- 선행 SPEC (확립된 계약): `SPEC-V3R6-MULTI-SESSION-COORD-001` (REQ-COORD-008 cross-process 조정, REQ-COORD-022 크로스 플랫폼 패리티), `SPEC-CI-FLAKY-STABILIZE-001` (REQ-CFS-010/011/014/015/016 — 본 SPEC이 structurally 대체).
+- 개발 모드: `tdd` (`.moai/config/sections/quality.yaml` `constitution.development_mode`).
+- Go 1.26.4.
+- 대상 브랜치: `feat/SPEC-V3R6-CI-FLAKY-STABILIZE-003` (base `origin/main`).
+- 브랜치 보호: `enforce_admins: true`, `strict: true` — 머지 전 base 최신화 필요.
+- 커밋 규약: Conventional Commits, 영문.
+- 코드·주석: 영문 / SPEC 산출물 산문: 한국어.
+- 하드코딩 방지(`CLAUDE.local.md §14`): 신규 상수는 `internal/session` 패키지 `const` 또는 `internal/config/defaults.go`.
+- 테스트 격리(`CLAUDE.local.md §6`): `t.TempDir()`; 병렬 테스트에서 OTEL env 금지.
+
+---
+
+## §G. 검증 공백 (Gaps — 미검증 사항)
+
+`.claude/rules/moai/core/verification-claim-integrity.md` §3.4 에 따라 관측되지 **않은** 것을 명시한다.
+
+1. **결함이 로컬에서 재현되지 않는다.** `registry_starvation_test.go:8` 에 이미 문서화된 전작의 한계가 그대로 적용된다. 본 SPEC 의 수정은 원래 CI 실패의 로컬 red→green 재현으로 검증되지 않는다.
+2. **CI 미재발은 유한 횟수 관측이다.** 간헐적 결함에 대해 N 회 성공은 부재의 증거로서 약하다. 본 SPEC 은 (a) 메커니즘 정확성(동일 프로세스 경합을 뮤텍스로 직렬화하는 것이 공정성 부재를 구조적으로 제거하는가) + (b) 반증 가능 AC(뮤텍스를 제거하면 테스트가 실패하는가) 로 검증 축을 삼는다.
+3. **반증 가능 구조적 테스트의 설계 정확성.** 뮤텍스 제거 시 테스트가 실패하는 것은 올바른 신호지만, "뮤텍스를 제거한 상태에서의 경합 관측" 자체가 확률적일 수 있다. AC-CFS3-002 는 이 한계를 인정하며, 가능한 한 결정론적인 probe(임계 구역 진입 카운터 / 교차 검증) 로 관측한다 — run-phase 설계 상세.
+4. **Windows CI 실검.** 본 SPEC 의 Windows parity 는 코드 수준에서 보장되나(동일한 in-process mutex 추상화), 실제 Windows CI 잡에서의 결정론적 green 증빙은 sync-phase 관측에 의존한다. plan.md §B 에 명시.
+5. **60s override 제거 결정.** REQ-CFS3-010 의 평가는 run-phase 관측에 기반하며, 유지·축소·제거 중 어느 쪽이든 합리적 근거가 있으면 수용 가능하다. 본 SPEC 은 결정을 강제하지 않는다.
+
+---
+
+## §H. 잔여 위험 (Residual Risk)
+
+1. **cross-process 경합의 공정성은 본 SPEC 이 다루지 않는다.** in-process mutex 는 동일 프로세스 경합자 간의 공정성을 구조적으로 보장하지만, 서로 다른 moai 프로세스(또는 서로 다른 Claude Code 세션) 간의 cross-process 경합은 여전히 NB flock + 지터 백오프에 의존한다. 이것은 레지스트리의 본래 설계 의도(REQ-COORD-008) 이며, 전작 SPEC §H 잔여 위험 1 이 인정한 대로 프로덕션 cross-process 경합은 세션 수 개 수준이라 실제 기아 확률이 낮다. 본 SPEC 은 이 영역을 건드리지 않는다.
+
+2. **path-keyed mutex 맵의 무한 성장(채택 설계인 경우).** 패키지 레벨 `sync.Map[path]*sync.Mutex` 설계를 택할 경우, 테스트가 무한히 다른 임시 경로를 만들면 맵이 성장한다. 프로세스 수명 자원이므로 실제 영향은 미미하지만, run-phase 가 명시적 청소 정책을 둘지 결정해야 한다. plan.md §F 대안 B 참조.
+
+3. **`Registry` 복사 시 뮤텍스 의미론.** `Registry.WithLockTimeout` 이 `clone := *r` 로 얕은 복사를 한다. 뮤텍스를 값 필드로 두면 `go vet` copylocks 경고가 발생한다. 따라서 `*sync.Mutex` 포인터 필드(path-keyed 맵 설계에서는 동일 뮤텍스를 가리키는 포인터)를 사용해야 하며, clone 도 동일 뮤텍스를 공유해야 한다. 이것은 설계 제약이지 위험은 아니지만, run-phase 가 이를 간과할 위험을 명시한다.
+
+4. **신규 구조적 테스트 자체가 우발적 flaky 가 될 가능성.** 반증 가능 AC(AC-CFS3-002) 의 probe 가 타이밍 의존적이면 신규 테스트 자체가 flaky 를 유발할 수 있다. run-phase 는 probe 를 카운터 기반 결정론적 신호로 설계해야 한다(동시성 안전한 카운터, 절대 타이밍 비교 금지).
+
+5. **뮤텍스 vs flock 순서로 인한 데드락 가능성(현재 설계에서는 없음).** 현재 설계는 `Registry.mu` → `registryLock.mu`(fd 가드) → flock 순서이며 순환 없음. run-phase 가 이 순서를 깨거나 추가 락을 끼워넣지 않는 한 데드락은 발생하지 않는다. 코드 리뷰에서 순서 불변을 확인해야 한다.
+
+---
+
+## §I. Cross-References
+
+- `SPEC-V3R6-MULTI-SESSION-COORD-001` REQ-COORD-008 (cross-process lockfile atomic write), REQ-COORD-022 (cross-platform parity) — 본 SPEC이 보존하는 계약.
+- `SPEC-CI-FLAKY-STABILIZE-001` defect 2 (REQ-CFS-010/011/014/015/016) — 본 SPEC이 structurally 대체하는 확률적 완화.
+- `SPEC-V3R6-CI-FLAKY-STABILIZE-001`, `-002` — 동일 패밀리의 다른 flaky 결함 (본 SPEC과 무관).
+- `.claude/rules/moai/core/verification-claim-integrity.md` §3.4 — Gaps 섹션 의무.
+- `.claude/rules/moai/workflow/mx-tag-protocol.md` — MX 태깅 의무(REQ-CFS3-015).
+- `CLAUDE.local.md §6`(테스트 격리), §14(하드코딩 방지) — 코딩 표준.

--- a/internal/session/registry.go
+++ b/internal/session/registry.go
@@ -25,6 +25,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/modu-ai/moai-adk/internal/atomicfile"
@@ -322,8 +324,17 @@ const (
 // contenders never queue in the kernel and there is no fairness guarantee. With
 // a fixed sleep every contender wakes on the same cadence, and an unlucky
 // goroutine can lose the race repeatedly. Randomizing wake times breaks that
-// synchronization. This is a probabilistic mitigation, NOT structural fairness —
-// under sustained contention a repeated loser remains possible.
+// synchronization. This is a probabilistic mitigation, NOT structural fairness.
+//
+// SPEC-V3R6-CI-FLAKY-STABILIZE-003 added the structural fix: the path-keyed
+// in-process mutex (acquired at the top of withLock) now serializes same-process
+// contenders deterministically, eliminating the same-process starvation scenario
+// this jitter could only probabilistically mitigate. Jitter remains the
+// cross-process retry strategy — distinct moai processes still contend on the
+// NB flock with no kernel fairness, so under cross-process contention a repeated
+// loser remains possible (the registry's original coordination purpose,
+// REQ-COORD-008; production cross-process contention is a handful of sessions,
+// so the probability is low).
 //
 // The clamp keeps one sleep from overshooting the deadline and costing the
 // caller its final retry.
@@ -346,6 +357,95 @@ func lockRetryDelay(attempt int, remaining time.Duration) time.Duration {
 	return delay
 }
 
+// envFalsifiabilityDisableMutex is the env var that disables the in-process
+// mutex for the AC-CFS3-002 falsifiability sub-case (local verification only;
+// CI never sets it). When set to "1", withLock skips the in-process mutex so
+// the structural probe can observe concurrent residency >= 2, proving the AC
+// is not vacuous. SPEC-V3R6-CI-FLAKY-STABILIZE-003.
+const envFalsifiabilityDisableMutex = "MOAI_CFS3_FALSIFIABILITY"
+
+// inProcessMutexDisabled reports whether the in-process mutex is deliberately
+// disabled for the AC-CFS3-002 falsifiability sub-case.
+func inProcessMutexDisabled() bool {
+	return os.Getenv(envFalsifiabilityDisableMutex) == "1"
+}
+
+// inProcessMutexes is the package-level path-keyed map of in-process mutexes
+// (SPEC-V3R6-CI-FLAKY-STABILIZE-003, REQ-CFS3-001/002). Each distinct absolute
+// lock path gets its own *sync.Mutex, so ALL Registry instances sharing a path
+// serialize against each other — including the per-call defaultRegistry()
+// instances the package helpers (RegisterSession, Heartbeat, ...) create, which
+// a per-Registry field would miss. The map is path-keyed (not per-Registry) by
+// design decision OQ-1 (ADOPT A): defaultRegistry() returns a fresh Registry per
+// call, so only a path-keyed map covers every in-process contention shape.
+//
+// Lock ordering: in-process mutex -> registryLock.mu (fd guard) -> flock. No
+// cycle (the in-process mutex is always released before withLock returns, and
+// flock is released within the same withLock call).
+//
+// The map grows monotonically with distinct paths over the process lifetime;
+// for the registry this is effectively bounded (one path per project). Tests
+// use t.TempDir() paths which are process-lifetime, so the growth is bounded
+// by the test run.
+//
+// @MX:NOTE: [AUTO] path-keyed in-process mutex; double-locking with cross-process flock (in-process serialization + cross-process coordination)
+var inProcessMutexes sync.Map // map[string]*sync.Mutex
+
+// acquireInProcessMutex returns the *sync.Mutex for the given absolute lock
+// path, allocating it on first use via LoadOrStore. Callers MUST pair the
+// returned Lock with a defer Unlock.
+func acquireInProcessMutex(absLockPath string) *sync.Mutex {
+	v, _ := inProcessMutexes.LoadOrStore(absLockPath, &sync.Mutex{})
+	return v.(*sync.Mutex)
+}
+
+// withLockProbe is the structural probe for AC-CFS3-002
+// (SPEC-V3R6-CI-FLAKY-STABILIZE-003). It counts how many goroutines are
+// simultaneously resident inside a withLock critical section. The in-process
+// mutex (added by this SPEC) must keep the observed maximum at <= 1; the
+// falsifiability sub-case (MOAI_CFS3_FALSIFIABILITY=1, which disables the
+// mutex) must observe >= 2 under sufficient contention, proving the AC is not
+// vacuous. Pure atomic operations; safe under -race.
+//
+// The inc/dec bracket the ENTIRE withLock body (including the NB-flock retry
+// loop), so the probe measures "goroutines inside withLock" rather than "flock
+// holders" — the latter is <= 1 regardless of the mutex (the OS serializes
+// flock) and would make the AC unfalsifiable (verification-claim-integrity
+// §1.1 surface 3).
+type withLockProbeType struct {
+	inFlight    atomic.Int64
+	maxInFlight atomic.Int64
+}
+
+var withLockProbe = &withLockProbeType{}
+
+// enter increments the in-flight counter and refreshes the observed maximum.
+func (p *withLockProbeType) enter() {
+	n := p.inFlight.Add(1)
+	for {
+		m := p.maxInFlight.Load()
+		if n <= m || p.maxInFlight.CompareAndSwap(m, n) {
+			return
+		}
+	}
+}
+
+// exit decrements the in-flight counter.
+func (p *withLockProbeType) exit() {
+	p.inFlight.Add(-1)
+}
+
+// max returns the highest concurrent in-flight count observed since reset.
+func (p *withLockProbeType) max() int64 {
+	return p.maxInFlight.Load()
+}
+
+// reset clears the probe counters. Test-only; used between sub-cases.
+func (p *withLockProbeType) reset() {
+	p.inFlight.Store(0)
+	p.maxInFlight.Store(0)
+}
+
 // withLock acquires the advisory lock, reads the registry, applies the
 // mutation function, writes back atomically (temp + rename), and releases
 // the lock. The lock is best-effort: on contention, it retries up to
@@ -362,6 +462,33 @@ func (r *Registry) withLock(mutate func([]Entry) ([]Entry, error)) error {
 	if err := os.MkdirAll(filepath.Dir(r.path), 0o755); err != nil {
 		return fmt.Errorf("session registry: mkdir parent: %w", err)
 	}
+
+	// In-process mutex (SPEC-V3R6-CI-FLAKY-STABILIZE-003, REQ-CFS3-001).
+	// NB-flock provides no kernel fairness queue, so without this mutex an
+	// unlucky same-process goroutine can lose the flock race repeatedly and
+	// exceed lockTimeout (starvation -> ErrLockTimeout). The mutex is
+	// path-keyed so every Registry instance sharing a lock path serializes.
+	// It brackets the ENTIRE body (including the NB-flock retry loop below),
+	// which is where the starvation occurs. Cross-process contention still
+	// relies on flock + jittered backoff (REQ-CFS3-005/007/008); the mutex
+	// only removes same-process unfairness.
+	//
+	// Placed at the withLock level (NOT inside registryLock.acquire) so the
+	// TestWithLockTimeoutContract blocker — which calls acquire() directly on
+	// a separate registryLock — does NOT take this mutex and the
+	// ErrLockTimeout contract is preserved (AP-CFS3-004).
+	if !inProcessMutexDisabled() {
+		absLockPath, _ := filepath.Abs(r.path + ".lock")
+		ipm := acquireInProcessMutex(absLockPath)
+		ipm.Lock()
+		defer ipm.Unlock()
+	}
+
+	// Structural probe (AC-CFS3-002): brackets the entire body so the
+	// in-process mutex's serialization effect is observable. See withLockProbe
+	// doc. enter()/exit() are pure atomic ops; negligible hot-path cost.
+	withLockProbe.enter()
+	defer withLockProbe.exit()
 
 	lockPath := r.path + ".lock"
 	lock := newRegistryLock()

--- a/internal/session/registry_inprocess_mutex_test.go
+++ b/internal/session/registry_inprocess_mutex_test.go
@@ -1,0 +1,128 @@
+package session
+
+// Structural in-process serialization probe for AC-CFS3-002
+// (SPEC-V3R6-CI-FLAKY-STABILIZE-003).
+//
+// This test verifies the in-process mutex added by the SPEC serializes
+// withLock critical sections, AND that the AC is falsifiable: when the mutex
+// is disabled (MOAI_CFS3_FALSIFIABILITY=1) the probe must observe concurrent
+// residency >= 2. The probe (withLockProbe) brackets the ENTIRE withLock body
+// (including the NB-flock retry loop), so it measures "goroutines inside
+// withLock" rather than "flock holders" — the OS serializes flock, so a
+// flock-scoped probe would be <= 1 regardless of the mutex and the AC would
+// be vacuous.
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+)
+
+// runContention drives N goroutines × M Register calls against a single
+// registry and returns the maximum concurrent withLock residency observed by
+// the probe during the run. The probe is reset at entry so the returned max
+// reflects only this run.
+func runContention(t *testing.T, r *Registry, workers, perWorker int) int64 {
+	t.Helper()
+	withLockProbe.reset()
+
+	done := make(chan struct{})
+	errCh := make(chan error, workers*perWorker)
+	for w := 0; w < workers; w++ {
+		go func(workerID int) {
+			defer func() { done <- struct{}{} }()
+			for i := 0; i < perWorker; i++ {
+				id := fmt.Sprintf("uuid-probe-%d-%d", workerID, i)
+				if err := r.Register(id, "SPEC-PROBE", "run"); err != nil {
+					errCh <- err
+					return
+				}
+			}
+		}(w)
+	}
+	for w := 0; w < workers; w++ {
+		<-done
+	}
+	close(errCh)
+	for err := range errCh {
+		t.Fatalf("Register under contention: %v", err)
+	}
+	return withLockProbe.max()
+}
+
+// TestRegistryWithLockInProcessSerialization is the AC-CFS3-002 structural
+// test. The in-process mutex MUST keep concurrent withLock-body residency at
+// <= 1 under heavy in-process contention (10 goroutines x 1000 iterations =
+// 10000 acquisitions).
+func TestRegistryWithLockInProcessSerialization(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in-process serialization probe in -short mode")
+	}
+	r, _ := newTestRegistry(t)
+	r = r.WithLockTimeout(60 * time.Second) // operational headroom; mutex is the correctness mechanism
+
+	// AC-CFS3-002 recommends 10000 total acquisitions (10 x 1000). Reduced to
+	// 1000 (10 x 100) here because under -race the mutex serializes every
+	// acquisition, and 10000 sequential atomic file writes (temp + rename)
+	// exceed 8 minutes under -race — impractical for CI. The serialization
+	// invariant (max <= 1) is count-independent: the mutex guarantees it
+	// whether the count is 10 or 10000, so 1000 acquisitions across 10
+	// concurrent goroutines is more than sufficient to demonstrate it. This
+	// matches the AC-CFS3-001 TestRegisterSessionConcurrent scale.
+	const (
+		workers   = 10
+		perWorker = 100
+	)
+
+	maxObserved := runContention(t, r, workers, perWorker)
+	t.Logf("withLock concurrent residency (mutex enabled): max=%d (workers=%d perWorker=%d total=%d)",
+		maxObserved, workers, perWorker, workers*perWorker)
+
+	// AC-CFS3-002: with the in-process mutex, at most one goroutine is
+	// resident inside withLock at any instant.
+	if maxObserved > 1 {
+		t.Errorf("AC-CFS3-002 FAILED: withLock saw %d concurrent residents; want <= 1 (in-process mutex not serializing)",
+			maxObserved)
+	}
+}
+
+// TestRegistryWithLockInProcessSerializationFalsifiability is the
+// falsifiability sub-case (AC-CFS3-002 both-directions requirement). Under
+// MOAI_CFS3_FALSIFIABILITY=1 the in-process mutex is disabled, so the probe
+// MUST observe >= 2 concurrent residents under sufficient contention — proving
+// the AC is not vacuous. This sub-case runs ONLY under the env flag (local
+// verification; CI never sets it). Per verification-claim-integrity §1.1
+// surface 3, if >= 2 is not observed the AC is UNMET.
+func TestRegistryWithLockInProcessSerializationFalsifiability(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping falsifiability probe in -short mode")
+	}
+	if os.Getenv("MOAI_CFS3_FALSIFIABILITY") != "1" {
+		t.Skip("MOAI_CFS3_FALSIFIABILITY!=1; skipping falsifiability sub-case (local verification only)")
+	}
+
+	r, _ := newTestRegistry(t)
+	r = r.WithLockTimeout(60 * time.Second)
+
+	// The mutex is DISABLED here (env=1), so a large iteration count would
+	// re-trigger the pathological NB-flock starvation the SPEC fixes. 500
+	// acquisitions (10 x 50) is more than enough to reliably observe max >= 2
+	// (concurrent residency appears within the first few entries) while
+	// completing promptly under -race even without the mutex.
+	const (
+		workers   = 10
+		perWorker = 50
+	)
+
+	maxObserved := runContention(t, r, workers, perWorker)
+	t.Logf("withLock concurrent residency (mutex DISABLED via MOAI_CFS3_FALSIFIABILITY=1): max=%d (workers=%d perWorker=%d total=%d)",
+		maxObserved, workers, perWorker, workers*perWorker)
+
+	// AC-CFS3-002 falsifiability direction: with the mutex disabled,
+	// concurrent residency >= 2 MUST be observable under sufficient contention.
+	if maxObserved < 2 {
+		t.Errorf("AC-CFS3-002 FALSIFIABILITY UNMET: with mutex disabled, withLock saw max=%d concurrent residents; want >= 2 under %d acquisitions (AC may be vacuous)",
+			maxObserved, workers*perWorker)
+	}
+}

--- a/internal/session/registry_test.go
+++ b/internal/session/registry_test.go
@@ -285,10 +285,10 @@ func TestRegisterSessionConcurrent(t *testing.T) {
 		t.Skip("skipping concurrent stress test in -short mode")
 	}
 	r, _ := newTestRegistry(t)
-	// Stress test holds the lock 1000 times in rapid succession; the
-	// production 2s timeout is insufficient for the 10-goroutine pile-up
-	// under -race. Override with 60s for this test only.
-	r = r.WithLockTimeout(60 * time.Second)
+	// The in-process mutex (SPEC-V3R6-CI-FLAKY-STABILIZE-003) serializes
+	// same-process contenders, so the production 2s LockTimeout is now
+	// sufficient. The previous 60s override was a workaround for the NB-flock
+	// starvation this SPEC structurally removed; it is no longer needed.
 
 	const (
 		workers   = 10


### PR DESCRIPTION
## What
Structural fix for the macOS CI flaky `TestRegisterSessionConcurrent` (`internal/session`). Adds a path-keyed in-process `sync.Mutex` bracketing the entire `Registry.withLock` body (incl. the NB-flock retry loop), so same-process goroutine contention is serialized deterministically.

## Why
`registryLock.acquire` used non-blocking `flock(LOCK_EX|LOCK_NB)` with no in-process serialization. Under 10-goroutine in-process contention on macOS CI `-race`, a goroutine starved past the lockTimeout -> `ErrLockTimeout` (102s FAIL). The prior jitter backoff (SPEC-CI-FLAKY-STABILIZE-001 defect 2) was probabilistic and insufficient on macOS CI.

## Verification (orchestrator-independent, run in this tree)
- `TestRegisterSessionConcurrent` deterministically green at the **2s default** under `-race` (was 102s FAIL)
- AC-CFS3-002 both-directions falsifiability: mutex -> probe max<=1; `MOAI_CFS3_FALSIFIABILITY=1` -> max>=2 observed
- `TestWithLockTimeoutContract` green (`ErrLockTimeout` contract preserved — blocker bypasses `withLock`)
- `go vet ./...`, `golangci-lint`, `GOOS=windows go build/vet` all clean; coverage 86.8%
- Preserved unchanged: cross-process flock (REQ-COORD-008/022), jitter backoff retry, `LockTimeout=2s` default, `internal/session/lock.go` (checkpoint subsystem)

plan-auditor iter2 PASS 0.92. SPEC: SPEC-V3R6-CI-FLAKY-STABILIZE-003 (Tier M).

🗿 MoAI
