### PR TITLE
feat(SPEC-TDD-ANTICHEAT-001): M1 test-first anti-cheat enforcement

### DIFF
--- a/.claude/agents/moai/manager-develop.md
+++ b/.claude/agents/moai/manager-develop.md
@@ -74,7 +74,7 @@ Per the canonical CI auto-fix protocol, the `manager-develop` agent supports a t
 
 **Invariants**: Existing test suite never broken during any cycle. Each transformation is atomic and reversible.
 
-**Forbidden**: Deleting/modifying existing tests without SPEC requirement. Introducing global mutable state. Skipping tests. Modifying files outside SPEC scope.
+**Forbidden**: Deleting/modifying existing tests without SPEC requirement. Introducing global mutable state. Skipping tests. Modifying files outside SPEC scope. Writing implementation before its failing test (test-after; the implementation MUST be deleted and re-derived test-first).
 
 ## Scope Boundaries and Delegation
 
@@ -113,6 +113,7 @@ Selected by `development_mode` in quality.yaml: `ddd` for existing codebases wit
 
 **`tdd` — RED (write failing tests)**
 For each test case: write a specification test (descriptive name, Arrange-Act-Assert pattern), run it and confirm the RED state, then record the test-case state via TaskUpdate.
+- **RED-evidence + delete-pre-test-code invariant**: the verbatim RED failing-test output MUST be captured as completion evidence (it is the proof the test ran before GREEN — the `§E` E8 item requires it), and any implementation code written before its failing test MUST be deleted and re-derived test-first.
 
 ### STEP 2.5 — LSP baseline capture (both)
 

--- a/.claude/rules/moai/development/manager-develop-prompt-template.md
+++ b/.claude/rules/moai/development/manager-develop-prompt-template.md
@@ -204,6 +204,13 @@ $ golangci-lint run --timeout=2m
 **E7. Blocker Report (if any)**
 - When the delegation prompt did not specify a needed user decision, report it as a structured blocker (NEVER call AskUserQuestion)
 
+**E8. RED Failure Output (TDD only — verbatim pre-GREEN evidence)**
+```
+$ <test-runner command>   # captured BEFORE the implementation makes the test pass
+# verbatim failing-test output, e.g. "--- FAIL: TestX ... expected Y, got Z"
+```
+The verbatim RED failing-test output captured before GREEN MUST be shown. A run that skipped RED (test-after) has no such output to supply, so without this item the self-verification matrix is structurally incomplete — test-first is falsifiable via this item (a test-after run cannot produce pre-GREEN failing output).
+
 ## 2. Delegation Prompt Authoring Workflow (from the orchestrator's perspective)
 
 ```

--- a/.claude/skills/moai-workflow-tdd/SKILL.md
+++ b/.claude/skills/moai-workflow-tdd/SKILL.md
@@ -325,7 +325,6 @@ When TDD discipline breaks down:
 
 Version: 1.0.0
 Status: Active
-Last Updated: 2026-02-03
 
 <!-- moai:evolvable-start id="rationalizations" -->
 ## Common Rationalizations
@@ -370,3 +369,12 @@ Last Updated: 2026-02-03
 - [ ] REFACTOR phase was executed or explicitly justified as unnecessary
 
 <!-- moai:evolvable-end -->
+
+## Test-First Anti-Cheat
+
+[ZONE:Evolvable] [HARD] The Red Flags and Verification checklists above sit in advisory (evolvable) blocks and are consumed by no completion gate. This section promotes them into two enforced invariants that make test-first falsifiable in the completion matrix.
+
+- **Invariant i — RED failure output is mandatory completion evidence.** The verbatim RED failing-test output (the failing-test run captured BEFORE any implementation makes it pass) MUST be observed and shown as part of run-phase completion evidence. A run that cannot produce this output skipped RED and cannot be reported as clean.
+- **Invariant ii — implementation written before its failing test is deleted and re-derived test-first.** Any implementation code written before its failing test exists MUST be deleted and re-derived from a failing test (RED then GREEN). "I already wrote the implementation, so the test passes on first run" is the exact failure mode this invariant forbids — it is test-after, not test-first, and it leaves no RED output (Invariant i) to show as evidence.
+
+These two invariants close the falsifiability gap: before them, a fully-passing self-verification matrix was producible with NO RED evidence, so test-first could not be distinguished from test-after by the completion report. After them, the matrix requires the verbatim pre-GREEN RED output, so a run that skipped RED has no such output to supply and the matrix is structurally incomplete.

--- a/.moai/specs/SPEC-TDD-ANTICHEAT-001/progress.md
+++ b/.moai/specs/SPEC-TDD-ANTICHEAT-001/progress.md
@@ -12,11 +12,50 @@
 
 ## §E.2 Run-phase Evidence
 
-_<pending run-phase>_
+### AC PASS/FAIL matrix (acceptance.md §D)
+
+| AC | Status | Verification command | Observed output |
+|----|--------|---------------------|-----------------|
+| AC-TDD-001 | PASS | `grep -q "Test-First Anti-Cheat" …SKILL.md` + `grep -qi "RED failure output"` + `grep -qi "re-derived test-first"` | exit=0 (heading + Invariant i RED-output + Invariant ii re-derived present in both copies) |
+| AC-TDD-002 | PASS | `diff -q <operational> <mirror>` × 3 pairs | pair1/pair2/pair3 all exit=0 (byte-identical) |
+| AC-TDD-003 | PASS | `make build` | exit=0; `go build -ldflags … -o bin/moai ./cmd/moai` succeeded |
+| AC-TDD-004 | PASS | `grep -cE '^\*\*E[0-9]+\.' …prompt-template.md` + `git diff … \| grep -E 'E[1-7]\.'` | E-count=8 (was 7); no E1-E7 lines removed (additive-only) |
+| AC-TDD-005 | PASS | `go test ./internal/template/ -run TestTemplateNoInternalContentLeak` + targeted `grep -rEn "SPEC-TDD-ANTICHEAT-001\|REQ-TDD-\|AC-TDD-\|2026-07" <3 mirrors>` | CI guard `ok`; targeted grep exit=1 (0 internal markers in mirrors) |
+| AC-TDD-006 | PASS | `git status --porcelain -- .claude internal/template/templates/.claude` | exactly 6 files `M`, zero `A`/`??` harness files |
+| AC-TDD-007 | PASS | `grep -A6 -iE 'RED (failure\|failing).*(evidence\|output)' …prompt-template.md \| grep -qi 'MUST\|verbatim\|before GREEN'` | exit=0 (E8 carries MUST + verbatim + before GREEN) |
+| AC-TDD-008 | PASS | `grep -iE 'implementation before its failing test' …manager-develop.md` + `grep -A12 'STEP 2' … \| grep -iE 'RED\|delete\|before its'` | Forbidden phrase exit=0; STEP 2 invariant sub-line matches RED/delete/before-its |
+
+### Implementation summary
+
+Three additive prose changes, dual-written to operational + template-mirror (6 files), then `make build`:
+
+1. **`.claude/skills/moai-workflow-tdd/SKILL.md`** — appended a HARD `## Test-First Anti-Cheat` section after the Verification checklist, promoting the advisory Red Flags / Verification content into two enforced invariants: (i) verbatim RED failure output is mandatory completion evidence; (ii) implementation written before its failing test is deleted and re-derived test-first. (Plus a baseline reconciliation: the operational copy carried a stray `Last Updated: 2026-02-03` line absent from the mirror — removed to satisfy AC-TDD-002 byte-parity; mirror is the Template-First SSOT.)
+2. **`.claude/rules/moai/development/manager-develop-prompt-template.md` `§E`** — added exactly one new self-verification item `E8. RED Failure Output (TDD only — verbatim pre-GREEN evidence)` after E7; E1-E7 byte-preserved (additive-only).
+3. **`.claude/agents/moai/manager-develop.md`** — appended `Writing implementation before its failing test (test-after; the implementation MUST be deleted and re-derived test-first).` to the Behavioral Contract Forbidden list; added a `RED-evidence + delete-pre-test-code invariant` sub-line under STEP 2 `tdd — RED`.
+
+### Baseline-precondition correction (plan.md §B/§C)
+
+The plan-phase pre-flight asserted all 3 file pairs were byte-identical at baseline. Mechanical `diff -q` at run-phase entry showed pair 1 (tdd skill) diverged by exactly one stray `Last Updated: 2026-02-03` line present only in the operational copy. This was an unobserved plan-phase verification claim (the "verified" assertion was never mechanically confirmed by the plan author). Reconciled at run-phase by dropping the stray line from the operational copy (mirror is SSOT per Template-First) — a within-scope cascade on a named file to satisfy AC-TDD-002.
 
 ## §E.3 Run-phase Audit-Ready Signal
 
-_<pending run-phase>_
+```yaml
+run_complete_at: 2026-07-29
+run_commit_sha: pending-backfill
+run_status: audit-ready
+ac_pass_count: 8
+ac_fail_count: 0
+preserve_list_post_run_count: 0   # additive-only; no PRESERVE-list entries invalidated
+l44_pre_commit_fetch: origin/main fetched; worktree HEAD at cd21df594 base — no divergence
+l44_post_push_fetch: pending push
+new_warnings_or_lints_introduced: 0   # docs/prose-only change; go vet ./internal/template/... exit 0; golangci-lint n/a (no Go touched)
+cross_platform_build:
+  go_build: ok
+  go_test_internal_template: ok (TestTemplateNoInternalContentLeak + full suite)
+  go_test_internal_spec: not run (no spec-package Go change)
+total_run_phase_files: 6   # 3 operational + 3 mirror; bin/moai rebuild artifact is gitignored
+m1_to_mN_commit_strategy: single M1 commit covers all 3 logical changes (Tier S)
+```
 
 ## §E.4 Sync-phase Audit-Ready Signal
 

--- a/.moai/specs/SPEC-TDD-ANTICHEAT-001/spec.md
+++ b/.moai/specs/SPEC-TDD-ANTICHEAT-001/spec.md
@@ -2,9 +2,9 @@
 id: SPEC-TDD-ANTICHEAT-001
 title: "TDD Test-First Anti-Cheat Enforcement"
 version: "0.1.0"
-status: draft
+status: in-progress
 created: 2026-07-24
-updated: 2026-07-24
+updated: 2026-07-29
 author: manager-spec
 priority: P1
 phase: "v3.0.2 target"

--- a/internal/template/catalog.yaml
+++ b/internal/template/catalog.yaml
@@ -81,7 +81,7 @@ catalog:
             - name: moai-workflow-tdd
               tier: core
               path: templates/.claude/skills/moai-workflow-tdd/
-              hash: c1972207bcc65cc3b8739a98eceb929d223ee0492c3bb86141e691135f5256e6
+              hash: e3d74303d6d9916c3c633564d874488f4d879f9a14fe767d9ce8e21c7cdf78d9
               version: 1.0.0
             - name: moai-workflow-testing
               tier: core
@@ -112,7 +112,7 @@ catalog:
             - name: manager-develop
               tier: core
               path: templates/.claude/agents/moai/manager-develop.md
-              hash: 2ff233abfb8aa9620907ea93daecf4d4e145eeb92bedee862115ce6e8b2a3c44
+              hash: 3f90e6497c6559ef1883901ff1f28a738cc968772b9684c752c66ec5df06a7e5
               version: 1.0.0
             - name: manager-docs
               tier: core

--- a/internal/template/templates/.claude/agents/moai/manager-develop.md
+++ b/internal/template/templates/.claude/agents/moai/manager-develop.md
@@ -74,7 +74,7 @@ Per the canonical CI auto-fix protocol, the `manager-develop` agent supports a t
 
 **Invariants**: Existing test suite never broken during any cycle. Each transformation is atomic and reversible.
 
-**Forbidden**: Deleting/modifying existing tests without SPEC requirement. Introducing global mutable state. Skipping tests. Modifying files outside SPEC scope.
+**Forbidden**: Deleting/modifying existing tests without SPEC requirement. Introducing global mutable state. Skipping tests. Modifying files outside SPEC scope. Writing implementation before its failing test (test-after; the implementation MUST be deleted and re-derived test-first).
 
 ## Scope Boundaries and Delegation
 
@@ -113,6 +113,7 @@ Selected by `development_mode` in quality.yaml: `ddd` for existing codebases wit
 
 **`tdd` — RED (write failing tests)**
 For each test case: write a specification test (descriptive name, Arrange-Act-Assert pattern), run it and confirm the RED state, then record the test-case state via TaskUpdate.
+- **RED-evidence + delete-pre-test-code invariant**: the verbatim RED failing-test output MUST be captured as completion evidence (it is the proof the test ran before GREEN — the `§E` E8 item requires it), and any implementation code written before its failing test MUST be deleted and re-derived test-first.
 
 ### STEP 2.5 — LSP baseline capture (both)
 

--- a/internal/template/templates/.claude/rules/moai/development/manager-develop-prompt-template.md
+++ b/internal/template/templates/.claude/rules/moai/development/manager-develop-prompt-template.md
@@ -204,6 +204,13 @@ $ golangci-lint run --timeout=2m
 **E7. Blocker Report (if any)**
 - When the delegation prompt did not specify a needed user decision, report it as a structured blocker (NEVER call AskUserQuestion)
 
+**E8. RED Failure Output (TDD only — verbatim pre-GREEN evidence)**
+```
+$ <test-runner command>   # captured BEFORE the implementation makes the test pass
+# verbatim failing-test output, e.g. "--- FAIL: TestX ... expected Y, got Z"
+```
+The verbatim RED failing-test output captured before GREEN MUST be shown. A run that skipped RED (test-after) has no such output to supply, so without this item the self-verification matrix is structurally incomplete — test-first is falsifiable via this item (a test-after run cannot produce pre-GREEN failing output).
+
 ## 2. Delegation Prompt Authoring Workflow (from the orchestrator's perspective)
 
 ```

--- a/internal/template/templates/.claude/skills/moai-workflow-tdd/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-tdd/SKILL.md
@@ -369,3 +369,12 @@ Status: Active
 - [ ] REFACTOR phase was executed or explicitly justified as unnecessary
 
 <!-- moai:evolvable-end -->
+
+## Test-First Anti-Cheat
+
+[ZONE:Evolvable] [HARD] The Red Flags and Verification checklists above sit in advisory (evolvable) blocks and are consumed by no completion gate. This section promotes them into two enforced invariants that make test-first falsifiable in the completion matrix.
+
+- **Invariant i — RED failure output is mandatory completion evidence.** The verbatim RED failing-test output (the failing-test run captured BEFORE any implementation makes it pass) MUST be observed and shown as part of run-phase completion evidence. A run that cannot produce this output skipped RED and cannot be reported as clean.
+- **Invariant ii — implementation written before its failing test is deleted and re-derived test-first.** Any implementation code written before its failing test exists MUST be deleted and re-derived from a failing test (RED then GREEN). "I already wrote the implementation, so the test passes on first run" is the exact failure mode this invariant forbids — it is test-after, not test-first, and it leaves no RED output (Invariant i) to show as evidence.
+
+These two invariants close the falsifiability gap: before them, a fully-passing self-verification matrix was producible with NO RED evidence, so test-first could not be distinguished from test-after by the completion report. After them, the matrix requires the verbatim pre-GREEN RED output, so a run that skipped RED has no such output to supply and the matrix is structurally incomplete.


### PR DESCRIPTION
## What

SPEC-TDD-ANTICHEAT-001 run-phase (Tier S, cycle_type=tdd). Promotes the TDD skill's advisory Red Flags / Verification content into enforced invariants so **test-first becomes falsifiable in the completion matrix** — a test-after run can no longer produce an identical clean self-verification matrix.

## Changes (3 logical, dual-written across 6 files + catalog.yaml)

| File (operational + mirror) | Change |
|---|---|
| `moai-workflow-tdd/SKILL.md` | New HARD **Test-First Anti-Cheat** section: (i) verbatim RED failure output is mandatory completion evidence; (ii) implementation written before its failing test is deleted and re-derived test-first. |
| `manager-develop-prompt-template.md` §E | New **E8. RED Failure Output** item (verbatim pre-GREEN failing-test output). E1-E7 byte-preserved — additive-only. |
| `manager-develop.md` agent | Forbidden += "Writing implementation before its failing test"; STEP 2 RED phase += RED-evidence + delete-pre-test-code invariant sub-line. |

Also: `internal/template/catalog.yaml` regenerated by `make build` (hash manifest for the 3 changed embedded templates).

## Baseline reconciliation

plan.md §B/§C asserted all 3 file pairs were byte-identical at baseline. Mechanical `diff -q` at run-phase entry showed pair 1 (tdd skill) diverged by one stray `Last Updated: 2026-02-03` line present only in the operational copy (the plan-phase "verified" claim was never mechanically confirmed). Dropped the stray line from the operational copy (mirror = Template-First SSOT) to satisfy AC-TDD-002 byte-parity.

## Acceptance — all 8 ACs GREEN

| AC | Gate | Evidence |
|---|---|---|
| AC-TDD-001 | content additions present | heading + Invariant i (RED output) + Invariant ii (re-derived) grep exit 0 |
| AC-TDD-002 | dual-write byte-parity | `diff -q` x 3 pairs -> all exit 0 |
| AC-TDD-003 | `make build` | exit 0 |
| AC-TDD-004 | §E additive-only | E-count = 8 (was 7); no E1-E7 lines removed |
| AC-TDD-005 | neutrality | `TestTemplateNoInternalContentLeak` PASS; targeted SPEC-token grep on 3 mirrors exit 1 (clean) |
| AC-TDD-006 | simplicity bound | exactly 6 harness files `M`, zero `A`/`??` |
| AC-TDD-007 | falsifiability contrast | E8 carries MUST + verbatim + before GREEN |
| AC-TDD-008 | agent Forbidden + STEP 2 | forbidden phrase grep exit 0; STEP 2 invariant matches RED/delete/before-its |

## Verification commands run

- `make build` -> exit 0
- `go test ./internal/template/... -count=1` -> ok
- `go vet ./internal/template/...` -> exit 0
- `diff -q` x 3 operational/mirror pairs -> all identical

## Notes

- Run-phase only. Sync-phase (CHANGELOG, README, `in-progress -> completed` frontmatter transition) is a separate manager-docs delegation.
- The commit carries the `draft -> in-progress` SPEC frontmatter transition (manager-develop owns this on M1).
