### PR TITLE
docs(project): refresh v3.0 codemaps + project docs to actual codebase state

### DIFF
--- a/.moai/project/codemaps/data-flow.md
+++ b/.moai/project/codemaps/data-flow.md
@@ -72,7 +72,7 @@ flowchart TD
     A["Claude Code emits event"]
     B["handle-event.sh wrapper"]
     C["moai hook event<br/>(stdin JSON)"]
-    D["Registry.Dispatch<br/>(28+ handlers)"]
+    D["Registry.Dispatch<br/>(30 EventType handlers)"]
     E["Handler chain<br/>(sequential)"]
     F["first 2-error<br/>short-circuit"]
     G["JSON + exit-code<br/>(stdout)"]
@@ -89,7 +89,7 @@ flowchart TD
 1. Claude Code hook event 발생
 2. `.claude/hooks/moai/handle-<event>.sh` 래퍼 실행
 3. `moai hook <event>` stdin 통해 JSON 수신
-4. `Registry.Dispatch()` 중앙 허브가 28+ 타입 핸들러로 라우팅
+4. `Registry.Dispatch()` 중앙 허브가 30개 EventType 핸들러로 라우팅
 5. 핸들러 체인 순차 실행 (각각 exit 0 or 2)
 6. 첫 번째 2-exit (차단) 시 short-circuit
 7. JSON 결과 + exit-code stdout으로 반환

--- a/.moai/project/codemaps/dependencies.md
+++ b/.moai/project/codemaps/dependencies.md
@@ -14,7 +14,7 @@ graph TD
     cmd["cmd/moai<br/>main()"]
     
     subgraph P["Presentation Layer"]
-        cli["internal/cli<br/>(241파일)<br/>50+ subcommand"]
+        cli["internal/cli<br/>(109 non-test)<br/>~40 verbs"]
         tui["internal/tui"]
         statusline["internal/statusline"]
         web["internal/web"]
@@ -95,6 +95,21 @@ graph TD
 - `config` → models, defs (핵심 주입)
 - `hook` → config, lsp, session, mx
 - `coreGit` → foundation
+
+---
+
+## 신규 인프라 패키지 (2026-07 기준)
+
+| 패키지 | 역할 |
+|---|---|
+| `internal/goal` | 목표 엔진 — 조건 선언형 에이전틱 루프 (`/moai goal`) |
+| `internal/lockfile` | 크로스 플랫폼 잠금 (Unix `flock(2)` / Windows in-process mutex) |
+| `internal/atomicfile` | 원자적 파일 쓰기 (write-temp + rename) |
+| `internal/tokenusage` | 토큰 사용량 계수 (statusline 연동) |
+| `internal/verify` | 검증 서브시스템 |
+| `internal/settings` | settings.json / settings.local.json 헬퍼 |
+
+> 이 패키지들은 `merge`/`manifest`/`session` 등 기존 인프라와 협력합니다. `goal`은 self-contained (의존성 없음), `lockfile`은 `session`이, `atomicfile`은 `merge`/`manifest`가 사용합니다.
 
 ---
 

--- a/.moai/project/codemaps/docs-truth.md
+++ b/.moai/project/codemaps/docs-truth.md
@@ -9,9 +9,9 @@
 
 ---
 
-## §1. Agent Catalog (8 retained)
+## §1. Agent Catalog (11 retained)
 
-The MoAI agent catalog consists of exactly **8 retained agents** (7 MoAI-custom + 1 Anthropic built-in `Explore`).
+The MoAI agent catalog consists of exactly **11 retained agents** (10 MoAI-custom + 1 Anthropic built-in `Explore`).
 
 | # | Agent | Class | Phase scope |
 |---|-------|-------|-------------|
@@ -22,13 +22,16 @@ The MoAI agent catalog consists of exactly **8 retained agents** (7 MoAI-custom 
 | 5 | `plan-auditor` | meta/evaluator | Independent plan-phase audit, bias prevention, GEARS compliance |
 | 6 | `sync-auditor` | meta/evaluator | Independent skeptical quality assessment, 4-dimension scoring |
 | 7 | `builder-harness` | builder | Dynamic project-specific harness specialist generation |
-| 8 | `Explore` | Anthropic built-in | Read-only codebase exploration (no MoAI file — invoked directly) |
+| 8 | `super-advisor` | meta/advisor | On-demand high-reasoning consultation (E1-E4 escalation) |
+| 9 | `manager-design` | core/manager | Design-phase collaboration (Claude Design bidirectional sync, D1-D5) |
+| 10 | `e2e-tester` | core/specialist | E2E test execution (web/mobile/desktop journey scripting) |
+| 11 | `Explore` | Anthropic built-in | Read-only codebase exploration (no MoAI file — invoked directly) |
 
-Class breakdown: Manager ×4 (`manager-spec`, `manager-develop`, `manager-docs`, `manager-git`) · Evaluator ×2 (`plan-auditor`, `sync-auditor`) · Builder ×1 (`builder-harness`) · Anthropic built-in ×1 (`Explore`).
+Class breakdown: Manager ×5 (`manager-spec`, `manager-develop`, `manager-docs`, `manager-git`, `manager-design`) · Evaluator ×2 (`plan-auditor`, `sync-auditor`) · Builder ×1 (`builder-harness`) · Advisor ×1 (`super-advisor`) · Specialist ×1 (`e2e-tester`) · Anthropic built-in ×1 (`Explore`).
 
 **Archived agents**: 12 legacy agent names are archived and MUST NOT be spawned. The full archived-name list + per-archived-agent migration table lives in `.claude/rules/moai/workflow/archived-agent-rejection.md` (consult that file rather than naming the archived agents here, to keep this checklist free of archived-name leakage).
 
-**Source:** `ls .claude/agents/moai/*.md` (= 7 MoAI-custom files) + CLAUDE.md §4 Retained Agents table + `.claude/rules/moai/workflow/archived-agent-rejection.md` (archived-agent migration table). Verified 2026-06-17: `ls -1 .claude/agents/moai/*.md | wc -l` → 7.
+**Source:** `ls .claude/agents/moai/*.md` (= 10 MoAI-custom files) + CLAUDE.md §4 Retained Agents table + `.claude/rules/moai/workflow/archived-agent-rejection.md` (archived-agent migration table). Verified 2026-07-29: `ls -1 .claude/agents/moai/*.md | wc -l` → 10 (manager-spec, manager-develop, manager-docs, manager-git, plan-auditor, sync-auditor, builder-harness, super-advisor, manager-design, e2e-tester).
 
 ---
 
@@ -71,24 +74,24 @@ Top-level verbs rendered by `moai --help`, grouped by capability:
 |------------------|-------|
 | Project | `init`, `doctor`, `status`, `update`, `version` |
 | Launchers | `cc`, `cg`, `glm`, `web`, `statusline` |
-| Autonomous Development | `loop`, `spec`, `worktree`, `brain` |
+| Autonomous Development | `loop`, `spec`, `worktree`, `goal` |
 | Governance | `constitution`, `mx`, `telemetry` |
 
-Additional verbs registered across the `internal/cli/` tree (40 files, 119 `rootCmd.AddCommand` calls): `hook`, `agent`, `research`, `workflow`, `migrate`, `profile`, `lsp`, `github`, `clean`, `feedback`, `review`, `coverage`, `e2e`, `codemaps`, `design`, `project`, `plan`, `run`, `sync`, `harness`, `session`, `fix`, `gate`, `mx`.
+Additional verbs registered across the `internal/cli/` tree (109 non-test `.go` files, 152 non-test `.AddCommand(` calls): `hook`, `agent`, `research`, `workflow`, `migrate`, `profile`, `lsp`, `github`, `clean`, `feedback`, `review`, `coverage`, `e2e`, `codemaps`, `design`, `project`, `plan`, `run`, `sync`, `harness`, `session`, `fix`, `gate`, `mx`.
 
 The checklist lists human-facing verb names (e.g. `init`, `update`, `glm`, `cc`, `cg`, `web`, `session`, `spec`, `harness`, `worktree`, `hook`, `agent`, `research`, `workflow`), NOT internal Go identifiers like `worktree.WorktreeCmd`.
 
-**Source:** `moai --help` rendered output + `grep -rnE '\.AddCommand\(' internal/cli/` (spans 40 files, 119 non-test calls). Verified 2026-06-17.
+**Source:** `moai --help` rendered output + `grep -rn '\.AddCommand(' internal/cli/ --include='*.go' | grep -v _test` (109 non-test files, 152 non-test calls). Verified 2026-07-29.
 
-### §4.2 `/moai` Claude Code skill set (17 commands)
+### §4.2 `/moai` Claude Code skill set (15 commands)
 
 The complete `/moai` slash-command set in `.claude/commands/moai/`:
 
-`brain` · `clean` · `codemaps` · `coverage` · `design` · `e2e` · `feedback` · `fix` · `gate` · `harness` · `loop` · `mx` · `plan` · `project` · `review` · `run` · `sync`
+`clean` · `codemaps` · `e2e` · `feedback` · `fix` · `gate` · `goal` · `harness` · `loop` · `mx` · `plan` · `project` · `review` · `run` · `sync`
 
-(17 files total)
+(15 files total)
 
-**Source:** `ls -1 .claude/commands/moai/*.md | wc -l` → 17. Verified 2026-06-17: `ls -1 .claude/commands/moai/*.md | xargs -n1 basename | sed 's/\.md$//'` yields the 17 names above.
+**Source:** `ls -1 .claude/commands/moai/*.md | wc -l` → 15. Verified 2026-07-29: `ls -1 .claude/commands/moai/*.md | xargs -n1 basename | sed 's/\.md$//'` yields the 15 names above (note: `goal` added since v3.0; `brain`/`coverage`/`design` are NOT present as standalone command files).
 
 ---
 
@@ -99,18 +102,18 @@ The GLM→Claude-tier model mapping reflects the glm-5.2[1m] activation. The ful
 | Constant | Value | Claude tier |
 |----------|-------|-------------|
 | `DefaultGLMBaseURL` | `https://api.z.ai/api/anthropic` | (z.ai gateway) |
-| `DefaultGLMHigh` | `glm-5.2[1m]` | High (1M context) |
+| `DefaultGLMHigh` | `glm-5.2` | High |
 | `DefaultGLMMedium` | `glm-4.7` | Medium |
 | `DefaultGLMLow` | `glm-4.5-air` | Low |
 | `DefaultGLMSonnet` | `glm-4.7` | Sonnet |
 | `DefaultGLMHaiku` | `glm-4.5-air` | Haiku |
-| `DefaultGLMOpus` | `glm-5.2[1m]` | Opus (1M context) |
+| `DefaultGLMOpus` | `glm-5.2` | Opus |
 
-The `[1m]` suffix on `glm-5.2[1m]` activates Claude Code's 1M context mode (the suffix is parsed and stripped by Claude Code before the upstream API call; z.ai never sees it).
+The `[1m]` 1M-context suffix is NOT hardcoded in `defaults.go` — `DefaultGLMHigh`/`DefaultGLMOpus` are the bare value `glm-5.2`. The `[1m]` suffix is expanded at the launcher layer (`internal/cli/launcher.go` — `expandModelString` / `splitModelSuffix`) only when the 1M-context variant is explicitly requested; Claude Code parses and strips the suffix before the upstream API call because z.ai rejects a verbatim `[1m]`.
 
 Additional GLM models available but not default-mapped: `glm-4.5`, `glm-4.6`, `glm-5.1`, `glm-5-turbo`.
 
-**Source:** `internal/config/defaults.go` lines 40-57 (DefaultGLM* constants block). Verified 2026-06-17: `grep -q 'DefaultGLMHigh.*=.*"glm-5\.2\[1m\]"' internal/config/defaults.go` → exit 0. Base URL SSOT: `DefaultGLMBaseURL = "https://api.z.ai/api/anthropic"`.
+**Source:** `internal/config/defaults.go` lines 59-79 (DefaultGLM* constants block). Verified 2026-07-29: `grep -E 'DefaultGLM(High|Medium|Low|Fable|Opus)' internal/config/defaults.go` → `DefaultGLMHigh = "glm-5.2"`, `DefaultGLMMedium = "glm-4.7"`, `DefaultGLMLow = "glm-4.5-air"`, `DefaultGLMFable = "glm-5.2"`, `DefaultGLMOpus = "glm-5.2"` (NO `[1m]` suffix on any default). Base URL SSOT: `DefaultGLMBaseURL = "https://api.z.ai/api/anthropic"`.
 
 ---
 

--- a/.moai/project/codemaps/entry-points.md
+++ b/.moai/project/codemaps/entry-points.md
@@ -25,18 +25,18 @@ InitDependencies() // 모든 서브시스템 와이어링
 
 ---
 
-## CLI 명령 (~50+)
+## CLI 명령 (~40 root verbs, 152 non-test AddCommand 호출)
 
 **프로젝트**: init, update, doctor, config, version, web  
 **SPEC**: plan, run, sync, spec (audit/lint/close)  
-**개발**: loop, clean, mx, fix  
+**개발**: loop, clean, mx, fix, goal  
 **인프라**: hook, migration, worktree, session  
 **다중LLM**: cc, glm, cg  
-**기타**: brain, research, constitution, design, project, codemaps, feedback, review, coverage, e2e
+**기타**: research, constitution, design, project, codemaps, feedback, review, coverage, e2e
 
 ---
 
-## 훅 진입점 (28+ 이벤트)
+## 훅 진입점 (30 이벤트 · 35개 handle-*.sh 스크립트)
 
 ```bash
 moai hook <event>  # JSON stdin → Handler dispatch → exit 0/2
@@ -45,14 +45,14 @@ moai hook <event>  # JSON stdin → Handler dispatch → exit 0/2
 **주요 이벤트**:
 - SessionStart, PostToolUse, Stop, SubagentStop, TaskCompleted
 - PreCompact, PostCompact, WorktreeCreate, WorktreeRemove
-- UserPromptSubmit, Notification, ... (25+ 더)
+- UserPromptSubmit, Notification, TeammateIdle, TaskCompleted, ... (총 30개 EventType — `internal/hook/types.go`)
 
 ---
 
 ## HTTP 서버
 
 ```bash
-moai web  # loopback localhost:3456
+moai web  # 127.0.0.1:3041 (loopback only, 기본 포트)
 ```
 
 ---

--- a/.moai/project/codemaps/modules.md
+++ b/.moai/project/codemaps/modules.md
@@ -13,22 +13,22 @@
 진입점: `main()` → `cli.Execute()`  
 의존성: `internal/cli`
 
-### internal/cli (241파일)
+### internal/cli (109 non-test 파일)
 **역할**: Cobra 커맨드 트리, composition root  
 **팬-아웃**: ~48개 internal 패키지  
-**핵심**: `Execute()`, `InitDependencies()`, 50+ subcommand 라우팅
+**핵심**: `Execute()`, `InitDependencies()`, ~40 root verbs (152 non-test `.AddCommand()` 호출)
 
-### internal/tui (32파일)
+### internal/tui (19 non-test 파일)
 **역할**: Bubbletea TUI 요소, 28개 색상 토큰  
 **기본**: Box, Pill, Table, Status, ProgressLine  
 **의존성**: lipgloss
 
-### internal/statusline (32파일)
+### internal/statusline (15 non-test 파일)
 **역할**: Claude Code 상태 렌더러, 3/5L 레이아웃  
 **기능**: GitDataProvider, UpdateProvider, UsageProvider  
 **의존성**: internal/core/git, internal/config
 
-### internal/web (37파일)
+### internal/web (18 non-test 파일)
 **역할**: loopback HTTP 콘솔, Templ + HTMX  
 **기능**: host-header validation, graceful shutdown (5s 드레인)  
 **의존성**: internal/profile, internal/config
@@ -51,11 +51,11 @@
 **기능**: `LanguageRegistry`, 16개 언어 지원  
 **팬-인 (High)**: 32+개 패키지
 
-### internal/spec (41파일)
+### internal/spec (24 non-test 파일)
 **역할**: SPEC 라이프사이클 엔진  
 **핵심**: Linter (13+3 규칙), ClassifyEra(), Audit(), DetectDrift(), ClassifyPRTitle()
 
-### internal/constitution (23파일)
+### internal/constitution (13 non-test 파일)
 **역할**: 동결/진화 구역 모델, 5단계 병합 안전  
 **기능**: FrozenGuard, Canary, ContradictionDetector, RateLimiter, HumanOversight
 
@@ -63,7 +63,7 @@
 **역할**: Plan-Run-Sync 워크트리 오케스트레이션  
 **기능**: `WorktreeOrchestrator`, `PhaseExecutor`, 품질 게이트
 
-### internal/loop (18파일)
+### internal/loop (6 non-test 파일)
 **역할**: 진단 피드백 루프 컨트롤러  
 **핵심**: `LoopController`, `DecisionEngine`, `GoFeedbackGenerator`
 
@@ -71,7 +71,7 @@
 **역할**: Ralph 의사결정 엔진  
 **기능**: `Decide()` (max_iter > perfect_gate > stagnation > human_review)
 
-### internal/harness (64파일)
+### internal/harness (75 non-test 파일)
 **역할**: 하네스 학습 서브시스템  
 **기능**: Observer, Learner (4-tier), Applier, 5단계 safety
 
@@ -88,9 +88,7 @@
 **역할**: 3-way 파일 병합 (ADR-008)  
 **전략**: LineMerge, YAMLDeep, JSONMerge, SectionMerge, EvolvableZoneMerge, Overwrite
 
-### internal/design
-**역할**: 디자인 시스템 도구  
-**기능**: DTCG 토큰 검증, Path A/B1/B2 선택, BrandConflictAnalyzer
+> **`internal/design`** — v3.0 코드베이스에 독립 패키지로 존재하지 않음 (이전 문서 드리프트). design 관련 로직은 `internal/harness` 등에 분산.
 
 ### internal/bodp
 **역할**: Branch Origin Decision Protocol  
@@ -121,13 +119,13 @@
 **역할**: 토큰 circuit-breaker, 예산 추적  
 **기능**: soft 75% / hard 90%, stall 감지, progress.md auto-save
 
-### internal/template (75파일)
-**역할**: go:embed Template-First 시스템  
-**소스**: internal/template/templates/ (단일 진실 공급원)  
-**생성**: embedded.go (자동 생성, 편집 금지)  
-**기능**: Deployer (원자적), Renderer (strict mode), Manifest.Track()
+### internal/template
+**역할**: go:embed Template-First 시스템
+**소스**: internal/template/templates/ (단일 진실 공급원)
+**임베드**: `embed.go`가 직접 `//go:embed all:templates` 사용 (별도 `embedded.go` 자동 생성 없음)
+**기능**: Deployer (원자적), Renderer (strict mode), Manifest.Track(), profile_matrix (11 agents × 3 profiles = 33 cells)
 
-### internal/config (61파일)
+### internal/config (35 non-test 파일)
 **역할**: 계층화 YAML config SSOT  
 **우선순위**: env > yaml > defaults  
 **팬-인 (Very High)**: 48+개 패키지
@@ -144,23 +142,22 @@
 **역할**: 버전 기반 마이그레이션 실행기  
 **기능**: Apply, Status, Rollback, 멱등성
 
-### internal/migrate
-**역할**: 마이그레이션 중 hook 정리  
-**기능**: CleanupUserSettings, 아카이브 우선
+> **`internal/migrate`** — v3.0에 없음. 마이그레이션은 `internal/migration` (단수형) 사용.
 
 ### internal/update
 **역할**: self-update  
 **기능**: Checker, Updater, Rollback, 체크섬 gate, 원자적 replace
 
-### internal/i18n
-**역할**: 다국어 GitHub 코멘트  
-**언어**: en, ko, ja, zh
+### internal/goal
+**역할**: 목표 엔진 — 조건 선언형 에이전틱 루프 (`/moai goal`)
+**핵심**: `moai goal arm|status|clear`, Condition {Mechanical,Model}, Stop-hook 평가 계약
+**상태**: `.moai/state/goal/<session-id>.json` (세션별)
 
-### internal/hook (143파일)
-**역할**: 컴파일된 훅 시스템  
-**이벤트**: 28+ (SessionStart, PostToolUse, Stop, etc)  
-**기능**: Registry.Dispatch(), exit 0/2, 순차 + short-circuit  
-**서브**: trace, memo, quality, security, mx, handoff, lifecycle, dbsync
+### internal/hook
+**역할**: 컴파일된 훅 시스템 + main-checkout branch-state guard
+**이벤트**: 30개 EventType (SessionStart, PostToolUse, Stop, etc), 35개 `handle-*.sh` 래퍼
+**기능**: Registry.Dispatch(), Stop은 stdout JSON `decision:"block"` (exit 0), 순차 + short-circuit
+**서브**: trace, memo, quality, security, mx, handoff, lifecycle, dbsync, branch_guard
 
 ### internal/sandbox (19파일)
 **역할**: OS 샌드박스 (seatbelt, bubblewrap, docker)  
@@ -170,15 +167,15 @@
 **역할**: shell 감지 및 config 변경  
 **기능**: Configurator, AddEnvVar, AddPathEntry (멱등성)
 
-### internal/astgrep (14파일)
+### internal/astgrep (5 non-test 파일)
 **역할**: ast-grep CLI 래퍼  
 **기능**: Scanner.Scan(), Finding 타입, SARIF
 
-### internal/lsp (12 sub-packages)
+### internal/lsp (8 sub-packages: aggregator, cache, config, core, gopls, hook, subprocess, transport)
 **역할**: 다중언어 LSP 클라이언트  
 **sub**: core, aggregator, gopls, cache, config, hook, subprocess, transport
 
-### internal/mx (27파일)
+### internal/mx (12 non-test 파일)
 **역할**: @MX 태그 스캐너/리졸버  
 **기능**: Scanner, Resolver, FanInCounter, Sidecar JSON
 
@@ -198,15 +195,13 @@
 **역할**: gh CLI 통합  
 **기능**: GHClient 인터페이스, SpecLinker, SecretManager
 
-### internal/session (25파일)
+### internal/session (12 non-test 파일)
 **역할**: 다중 세션 조율 레지스트리  
 **기능**: Registry, FileSessionStore, PhaseState, advisory lock
 
-### internal/state
-**역할**: prompt-cache 사용량 원격측정  
-**기능**: CacheUsageEntry JSONL, windowed 집계
+> **`internal/state`** — v3.0에 독립 패키지 없음. 세션/상태 관리는 `internal/session` (registry, checkpoint, phase).
 
-### internal/tmux (12파일)
+### internal/tmux (4 non-test 파일)
 **역할**: tmux 감지, CG/GLM 모드  
 **기능**: IsCGMode(), SessionManager
 
@@ -218,9 +213,7 @@
 **역할**: 사용자 프로필 관리  
 **기능**: ProfilePreferences, GetCurrentName(), Sync
 
-### internal/research
-**역할**: 연구/계측 서브시스템  
-**sub**: eval, experiment, safety, observe, dashboard
+> **`internal/research`** — v3.0에 독립 패키지 없음 (이전 문서 드리프트).
 
 ### internal/measure
 **역할**: zero-dependency 리프 파서  
@@ -241,7 +234,7 @@
 ## 검증
 
 **순환 의존성**: 0개 (검증됨)  
-**패키지 수**: 45 internal 디렉터리 = 44 runtime 패키지 + 1 test-only + 2 pkg + 1 cmd = 48개 (runtime만 카탈로그에 포함)
+**패키지 수**: 46 internal 디렉터리 (318 subpackage) + 2 pkg (`models`, `version`) + 1 cmd = 49개 경로
 
 ---
 

--- a/.moai/project/codemaps/overview.md
+++ b/.moai/project/codemaps/overview.md
@@ -4,8 +4,8 @@
 
 **모듈**: `github.com/modu-ai/moai-adk`  
 **Go 버전**: go 1.26.4  
-**코드 규모**: ~645개 Go 소스 파일 (테스트 제외)  
-**패키지 수**: 45 internal 디렉터리 = 44 runtime 패키지 + 1 test-only 패키지 (`internal/skills`, 프로덕션 코드 없음) + 2 pkg + 1 cmd
+**코드 규모**: ~730개 non-test Go 소스 파일 + ~1000개 테스트 파일 (~148k non-test LOC)  
+**패키지 수**: 46 internal 디렉터리 (318 subpackage) + 2 pkg (`models`, `version`) + 1 cmd
 
 ---
 
@@ -17,10 +17,10 @@ moai-adk-go는 Claude Code 내에서 AI 기반 개발 워크플로우를 오케�
 
 | 계층 | 책임 | 주요 패키지 |
 |------|------|-----------|
-| **프레젠테이션** | CLI 명령, 터미널 UI, HTTP 인터페이스 | `cmd/moai`, `internal/cli` (241파일), `internal/tui`, `internal/statusline`, `internal/web` |
+| **프레젠테이션** | CLI 명령, 터미널 UI, HTTP 인터페이스 | `cmd/moai`, `internal/cli` (109 non-test), `internal/tui`, `internal/statusline`, `internal/web` |
 | **비즈니스/도메인** | 개발 워크플로우, SPEC 라이프사이클, 정책 | `internal/spec`, `internal/workflow`, `internal/loop`, `internal/harness`, `internal/constitution`, `internal/permission`, `internal/merge` |
 | **인프라** | Git 추상화, 템플릿 배포, 설정, 훅, 세션 | `internal/core/git`, `internal/template`, `internal/config`, `internal/hook`, `internal/session`, `internal/lsp/*`, `internal/mx` |
-| **계측/지원** | 성능 측정, LSP 통합, 다국어 | `internal/measure`, `internal/astgrep`, `internal/i18n`, `internal/shell` |
+| **계측/지원** | 성능 측정, LSP 통합, 셸, 재시도 | `internal/measure`, `internal/astgrep`, `internal/shell`, `internal/resilience` |
 
 ---
 
@@ -28,7 +28,7 @@ moai-adk-go는 Claude Code 내에서 AI 기반 개발 워크플로우를 오케�
 
 ### Presentation (프레젠테이션)
 - **cmd/moai**: 바이너리 진입점 → `cli.Execute()`
-- **internal/cli** (241파일): Cobra 커맨드 트리, composition root, ~48개 내부 패키지 가져옴, 50+개 subcommand 라우팅
+- **internal/cli** (109 non-test 파일): Cobra 커맨드 트리, composition root, ~40 root verbs (152 non-test `.AddCommand()` 호출)
 - **internal/tui**: Catppuccin 색상 토큰, Box/Pill/Table/Status 컴포넌트, 테마 선택
 - **internal/statusline**: Claude Code 상태 렌더러, 3L/5L 레이아웃, pluggable 데이터 제공자
 - **internal/web**: loopback HTTP 콘솔, Templ 컴파일 핸들러, 5s 드레인 종료
@@ -36,10 +36,10 @@ moai-adk-go는 Claude Code 내에서 AI 기반 개발 워크플로우를 오케�
 
 ### Business/Domain (비즈니스 영역)
 - **pkg/models**: 공유 config 타입 (매우 높은 팬-인) — ProjectType, DevelopmentMode, ProjectConfig
-- **internal/spec** (41파일): SPEC 라이프사이클 — Linter (13+3 규칙), Audit(), ClassifyEra(), DetectDrift(), ClassifyPRTitle()
+- **internal/spec** (24 non-test 파일): SPEC 라이프사이클 — Linter (13+3 규칙), Audit(), ClassifyEra(), DetectDrift(), ClassifyPRTitle()
 - **internal/workflow**: Plan-Run-Sync 워크트리 오케스트레이션
 - **internal/loop** (18파일): 진단 피드백 루프 — LoopController, DecisionEngine, RalphEngine
-- **internal/harness** (64파일): 하네스 학습 — Observer, Learner (4-tier), Applier, 5-phase safety
+- **internal/harness** (75 non-test 파일): 하네스 자가학습 — Observer, Learner (4-tier), Applier (45KB), v4manifest, routing, 5-phase safety
 - **internal/permission** (18파일): 8-tier 권한 스택, 5 모드, bubble 모드
 - **internal/merge**: 3-way 파일 병합 (ADR-008), 사용자 커스터마이징 보존
 - **internal/constitution**: 동결/진화 구역 모델, 5단계 병합 안전 파이프라인
@@ -47,11 +47,11 @@ moai-adk-go는 Claude Code 내에서 AI 기반 개발 워크플로우를 오케�
 ### Infrastructure (인프라)
 - **internal/core/git**: exec 기반 Git 추상화, Repository/BranchManager 인터페이스
 - **internal/core/project**: FindProjectRoot() ANCHOR — `.moai/` 발견
-- **internal/template** (75파일): go:embed Template-First, Deployer, Renderer, TemplateContext
-- **internal/config** (61파일): 계층화 YAML (env > yaml > defaults), 20+ 섹션 구조
-- **internal/hook** (143파일): 컴파일된 훅 시스템, 28+ Claude Code 이벤트, JSON 디스패치, exit 0/2 의미
+- **internal/template**: go:embed Template-First (`embed.go`가 직접 `//go:embed all:templates` — 별도 `embedded.go` 생성 없음), Deployer, Renderer, profile_matrix (33-cell)
+- **internal/config**: 계층화 YAML (env > yaml > defaults), 14개 `loader_*.go`가 32개 YAML 파일을 조합 (section loader chain)
+- **internal/hook**: 컴파일된 훅 시스템, 30개 Claude Code 이벤트 (35개 `handle-*.sh` 래퍼), branch-state guard, JSON 디스패치
 - **internal/session** (25파일): 다중 세션 레지스트리, active-sessions.json, Heartbeat/Purge
-- **internal/lsp** (12 sub-packages): JSON-RPC 클라이언트, Gopls 브리지, 집계기, 캐시, 회로 차단기
+- **internal/lsp** (8 sub-packages): aggregator, cache, config, core, gopls, hook, subprocess, transport — JSON-RPC 클라이언트, 16-언어 자동감지, 회로 차단기
 - **internal/mx**: @MX 태그 스캐너, FanInCounter, 사이드카 JSON 인덱스
 
 ---
@@ -155,7 +155,7 @@ cli.InitDependencies() // 모든 서브시스템 와이어링
 - **SPEC**: `spec` (audit/lint/close)
 - **워크플로우**: `plan`, `run`, `sync`, `loop`, `clean`
 - **인프라**: `hook`, `migration`, `worktree`, `session`
-- **개발**: `mx`, `fix`, `brain`, `research`
+- **개발**: `mx`, `fix`, `research`, `goal`
 
 ### 훅 진입점
 ```bash
@@ -182,7 +182,7 @@ moai hook <event>  # SessionStart, PostToolUse, Stop, etc.
 
 ### 4. 훅 레지스트리 패턴
 - Claude Code JSON 이벤트 → stdin 수신
-- Registry가 28+ 타입 핸들러로 디스패치
+- Registry가 30개 EventType 핸들러로 디스패치
 - 각 핸들러는 `Handler` 인터페이스 준수
 
 ### 5. 멀티 LLM 실행 모드
@@ -197,9 +197,9 @@ moai hook <event>  # SessionStart, PostToolUse, Stop, etc.
 
 이 개요는 빠른 이해를 제공합니다. 더 깊은 분석은 다음을 참고하세요:
 
-- **modules.md**: 44개 runtime 패키지의 함수/타입/역할 상세 설명 + test-only 패키지 목록
+- **modules.md**: 46개 internal 패키지의 함수/타입/역할 상세 설명
 - **dependencies.md**: Mermaid 패키지 의존도 그래프 + 팬-인/팬-아웃 정량화
-- **entry-points.md**: ~50+ CLI 명령 + 훅 진입점 목록
+- **entry-points.md**: ~40 root CLI 명령 + 훅 진입점 목록
 - **data-flow.md**: 5가지 주요 플로우 시각화 (Mermaid)
 - **docs-truth.md**: 문서 검증을 위한 수동 유지보수 사실 체크리스트
 

--- a/.moai/project/product.md
+++ b/.moai/project/product.md
@@ -8,7 +8,7 @@ MoAI-ADK (Go Edition) -- Agentic Development Kit for Claude Code
 
 ### Description
 
-MoAI-ADK is a high-performance, compiled development toolkit that serves as the runtime backbone for the MoAI framework within Claude Code. This Go edition is a complete rewrite of the existing Python-based MoAI-ADK (~73,000+ lines, 220+ source files), redesigned to leverage Go's strengths: compiled single-binary distribution, native concurrency via goroutines, strong static typing, and minimal runtime dependencies.
+MoAI-ADK is a high-performance, compiled development toolkit that serves as the runtime backbone for the MoAI framework within Claude Code. This Go edition (v3.0) is a complete rewrite of the former Python-based MoAI-ADK (~73,000+ lines, 220+ source files -- now retired), redesigned to leverage Go's strengths: compiled single-binary distribution, native concurrency via goroutines, strong static typing, and minimal runtime dependencies. The v3.0 Go codebase is ~148k non-test LOC across ~730 source files plus ~1000 test files.
 
 The toolkit provides CLI tooling, configuration management, LSP integration, Git operations, quality gates, and autonomous development loop capabilities -- all orchestrated through Claude Code's agent and skill system.
 
@@ -79,9 +79,10 @@ Language Server Protocol client supporting 16+ programming languages.
 
 Comprehensive Git domain powered by system Git via exec for reliable operations.
 
-- **Branch Management**: Create, switch, merge, and delete branches with MoAI naming conventions
+- **Branch Management**: Create, switch, merge, and delete branches with MoAI naming conventions; BODP (Branch Origin Decision Protocol) drives the main / stacked / continue decision from a 3-signal / 8-row matrix
 - **Conflict Detection**: Pre-merge conflict analysis with resolution suggestions
-- **Worktree Management**: Parallel development via Git worktrees with automatic registry tracking
+- **Worktree Management**: Parallel development via Git worktrees with automatic registry tracking; `moai cc -w <name>` / `moai cg -w` / `moai glm -w` enter an isolated worktree before the session starts (EnterWorktree-first policy)
+- **Main-Checkout Branch Guard**: A PreToolUse hook (`internal/hook/branch_guard.go`, SPEC-WORKTREE-BRANCH-GUARD-001) denies `git checkout` / `switch` / `stash` / `reset --hard` / `rebase` on the primary checkout while permitting them in worktrees -- `manager-git` and the `MOAI_BRANCH_GUARD_EXEMPT=1` env sentinel are exempt
 - **Event Detection**: Git hook integration and event-driven automation
 - **Hook Execution Contract**: Formal specification of hook runtime guarantees -- stdin JSON format, exit code semantics, timeout behavior, config access. Explicitly documents what is NOT guaranteed (user's PATH, shell environment, Python availability). Contract tests verify behavior across all 6 platform targets in CI, preventing regression.
 - **Checkpoint System**: Automatic save points before risky operations with rollback capability
@@ -125,14 +126,14 @@ Autonomous feedback loop engine for iterative development cycles.
 - **Convergence Detection**: Automatic detection of diminishing returns to prevent infinite loops
 - **Human-in-the-Loop**: Configurable breakpoints for human review and approval
 
-### 9. Performance Ranking
+### 9. Performance Ranking (RETIRED at v3.0)
 
-Session ranking and community submission system.
+The Python predecessor shipped a session-ranking and community-leaderboard subsystem. This capability is NOT present in the v3.0 Go codebase -- there is no `internal/rank/` package and no `MOAI_RANK_API_URL` env var. Telemetry about token usage is still collected locally (`internal/telemetry/`, `internal/tokenusage/`) but is not submitted to any external leaderboard. The bullet list below is preserved as historical context only:
 
-- **Session Metrics**: Token efficiency, task completion rate, quality scores
-- **Leaderboard Integration**: Anonymous submission to community ranking boards
-- **Authentication**: Secure credential management for ranking API access
-- **Hook Integration**: Automatic metric collection via Git and session hooks
+- **Session Metrics** (historical): Token efficiency, task completion rate, quality scores
+- **Leaderboard Integration** (historical): Anonymous submission to community ranking boards
+- **Authentication** (historical): Secure credential management for ranking API access
+- **Hook Integration** (historical): Automatic metric collection via Git and session hooks
 
 ### 10. AST-Grep Integration
 
@@ -145,23 +146,20 @@ Code analysis via structural AST (Abstract Syntax Tree) pattern matching.
 
 ### 11. Multi-Model Architecture
 
-Support for multiple LLM providers and hybrid cost-optimization modes with Opus 4.7 integration.
+Support for multiple LLM providers, a 33-cell profile matrix, and hybrid cost-optimization modes.
 
-- **Claude Mode** (`moai cc`): Full Claude model stack including Opus 4.7 with 5-level effort scaling (low/medium/high/xhigh/max) for critical reasoning agents, with automatic fallback to Opus 4.6/Sonnet 4.6/Haiku 4.5 for backward compatibility (Requires Claude Code v2.1.110+)
-- **Opus 4.7 Prompt Philosophy**: Built-in support for Opus 4.7's "one-turn fully-loaded" principle with effort configuration at agent level, enabling xhigh/max effort assignments for critical reasoning workflows (manager-spec, plan-auditor, sync-auditor, manager-strategy, expert-security, expert-refactoring)
-- **GLM Mode** (`moai glm`): Switch all agents to Z.AI's GLM models for cost reduction
-- **Hybrid CG Mode** (`moai cg`): Claude leader with GLM workers via worktree-based environment isolation for 60-70% cost reduction on implementation tasks
-- **Model Policy** (`moai init --model-policy`): Apply high/medium/low/xhigh/max effort distribution across all agent definitions based on role-specific mappings and model capabilities
+- **Claude Mode** (`moai cc`): Full Claude model stack anchored on Opus 5 (1M-context) with a 5-level effort scale (`low` / `medium` / `high` / `xhigh` / `max`). Per-agent effort calibration is driven by the 33-cell profile matrix (11 retained agents x 3 model tiers) materialized by `internal/template/profile_matrix`
+- **GLM Mode** (`moai glm`): Route the session through Z.AI's GLM-5.2 (1M-context, `DefaultGLMHigh = "glm-5.2"` without the `[1m]` suffix -- the `[1m]` is expanded at the launcher layer in `internal/cli/launcher.go` only when the 1M-context variant is requested)
+- **Hybrid CG Mode** (`moai cg`): Claude leader with GLM teammates via tmux panes for 60-70% cost reduction on implementation-heavy tasks
+- **Model Profile Matrix** (`.moai/config/sections/llm.yaml`): 3-tier model profiles (`low` / `medium` / `high`) composing the 33-cell agent-by-tier matrix rendered into template deployment
 
-### 12. Agent Teams Integration (Experimental)
+### 12. Goal Engine (Autonomous Continuation)
 
-Support for Claude Code's experimental Agent Teams API for parallel phase execution.
+Condition-declared agentic loop that keeps the session working across turns until a stated end-state holds.
 
-- **Team Orchestration**: Spawn and manage multiple specialized teammates (researcher, analyst, architect, backend-dev, frontend-dev, tester, quality)
-- **Worktree Isolation**: Implementation agents run in isolated git worktrees to prevent file conflicts (`isolation: worktree`)
-- **Background Execution**: Non-blocking parallel execution for implementation teammates (`background: true`)
-- **Hook Integration**: WorktreeCreate/WorktreeRemove lifecycle hooks for worktree tracking
-- **Graceful Fallback**: Automatically falls back to sub-agent mode when Agent Teams prerequisites are not met
+- **`/moai goal "<condition>"`**: Arm a completion condition parsed into `Mechanical` (shell exit code) and `Model` (transcript claim) clauses; state lives at `.moai/state/goal/<session-id>.json`
+- **Stop-hook evaluator** (`moai hook stop-goal`): Blocks turn-end until the condition converges, the turn ceiling (default 30) hits, or stagnation guard fires -- then emits a 5-section Claim/Evidence/Baseline-attribution/Gaps/Residual-risk verdict
+- **Semi-autonomous checkpoints**: Optionally surfaces an `AskUserQuestion` round at each checkpoint instead of running fully unattended
 
 ---
 
@@ -207,17 +205,17 @@ Support for Claude Code's experimental Agent Teams API for parallel phase execut
 
 ### 13. Official Documentation Site
 
-공식 사용자 문서는 `https://adk.mo.ai.kr`에서 서비스되며, moai-adk-go 모노레포의 `docs-site/` 하위에서 관리된다.
+The official user documentation is served at `https://adk.mo.ai.kr` and maintained inside the `docs-site/` subtree of the moai-adk-go monorepo.
 
-**구성**:
-- 4개국어 지원 (한국어, English, 日本語, 简体中文)
-- 버전별 문서 관리 (최신은 unversioned, 과거는 `/v2.X/` 경로)
-- Hugo + Hextra 정적 사이트 생성기 (Go 단일 바이너리 빌드)
-- Vercel 배포 (Edge Function으로 Accept-Language 기반 locale detection)
+**Composition**:
+- 4 locales (Korean, English, Japanese, Simplified Chinese)
+- Versioned docs (latest is unversioned; prior minor/major releases are snapshotted under `/v2.X/` paths)
+- Hugo + Hextra static site generator (Go single-binary build, zero Node runtime dependency)
+- Vercel deployment with an Edge Function performing Accept-Language-based locale detection
 
-**책임**:
-- 기능 추가/변경 시 4개국어 문서 동시 업데이트 (CLAUDE.local.md §17.3)
-- Minor/Major 릴리스 시 이전 버전 스냅샷 자동 생성 (scripts/docs-version-snapshot)
+**Responsibilities**:
+- Any user-facing feature addition or change MUST update all 4 locales in the same PR (CLAUDE.local.md §17.3)
+- Minor / major releases snapshot the prior version via `scripts/docs-version-snapshot`
 
 ---
 
@@ -243,48 +241,63 @@ Support for Claude Code's experimental Agent Teams API for parallel phase execut
 
 ## Implementation Status
 
-All 14 SPEC documents have been fully implemented. The Go codebase contains 40,000+ lines of Go code across 20+ test packages with 85-100% test coverage. Module path: `github.com/modu-ai/moai-adk`.
+The v3.0 Go codebase is approximately **148k non-test LOC** across **~730 non-test Go source files** and **~1000 test files**, organized into **46 internal/ top-level packages** (318 subpackages) + **2 pkg/ packages** (`models`, `version`) + **1 cmd** binary. The single binary embeds all Claude Code templates via `//go:embed all:templates` in `internal/template/embed.go` (no separate `embedded.go` is generated). Module path: `github.com/modu-ai/moai-adk` (Go 1.26.4).
 
 ### Feature Completion
 
 | Feature | Status | Notes |
 |---------|--------|-------|
-| CLI Tool | Complete | All commands implemented (init, doctor, status, update, hook, rank, worktree) |
-| Configuration Management | Complete | Custom YAML loader with thread-safe access (no Viper dependency) |
-| LSP Integration | Complete | Custom LSP client implementation (no go.lsp.dev dependency) |
-| Git Operations | Complete | Pure Go git operations via exec (no go-git dependency) |
+| CLI Tool | Complete | ~40 root verbs / 152 non-test `.AddCommand()` calls across 109 non-test files in `internal/cli/` |
+| Configuration Management | Complete | 14 `loader_*.go` files composing 32 YAML files; env > yaml > defaults |
+| LSP Integration | Complete | 8 sub-packages under `internal/lsp/` powernap-based, 16-language auto-detection |
+| Git Operations | Complete | System Git via exec; BODP branch-origin decision; main-checkout branch-state guard |
 | Quality Gates (TRUST 5) | Complete | All five principles validated |
-| Statusline | Complete | Real-time project metrics rendering |
-| EARS Methodology | Complete | Requirement templates and validation |
-| Loop Controller (Ralph) | Complete | Autonomous feedback loop engine |
-| Performance Ranking | Complete | Session ranking and submission |
-| AST-Grep Integration | Complete | Structural code analysis |
-| Hook System | Complete | Compiled binary subcommands replacing 46 Python scripts |
-| Manifest System | Complete | File provenance tracking |
-| Merge Engine | Complete | 3-way merge for template updates |
+| Statusline | Complete | Real-time project metrics rendering (15 non-test files) |
+| GEARS / EARS Methodology | Complete | GEARS is the current notation; EARS retained as 6-month backward-compat legacy reference |
+| Loop Controller (Ralph) | Complete | Autonomous feedback loop engine (6 non-test files) |
+| AST-Grep Integration | Complete | Structural code analysis (5 non-test files) |
+| Goal Engine | Complete | `/moai goal` condition-declared agentic loop (11 files under `internal/goal/`) |
+| Hook System | Complete | 30 EventTypes + 35 `handle-*.sh` wrappers; compiled binary subcommands |
+| Manifest System | Complete | File provenance tracking via 3-way hash |
+| Merge Engine | Complete | 3-way merge for template updates (7 non-test files) |
 | Self-Update | Complete | Binary self-replacement with rollback |
+| Worktree-Entry Strategy | Complete | `moai cc/cg/glm -w <name>` EnterWorktree-first + main-checkout branch guard |
+| Multi-Session Registry | Complete | `internal/session/` (12 non-test files) with advisory flock / Windows mutex |
+| Web Console | Complete | `moai web` loopback HTTP on `127.0.0.1:3041` (Templ + HTMX) |
 
-### Runtime Dependencies
+### Runtime Dependencies (v3.0)
 
 | Package | Version | Purpose |
 |---------|---------|---------|
-| `github.com/charmbracelet/bubbles` | v1.0.0 | TUI components (spinners, progress bars, text input) |
-| `github.com/charmbracelet/bubbletea` | v1.3.10 | Interactive TUI framework |
-| `github.com/charmbracelet/lipgloss` | v1.1.1+ | Terminal layout and styling |
-| `github.com/mattn/go-isatty` | v0.0.20 | TTY detection for headless mode |
 | `github.com/spf13/cobra` | v1.10.2 | CLI framework with subcommands |
-| `golang.org/x/text` | v0.34.0 | Text processing utilities |
-| `gopkg.in/yaml.v3` | v3.0.1 | YAML configuration parsing |
+| `charm.land/bubbletea/v2` | v2.0.8 | Interactive TUI framework (Elm architecture) |
+| `charm.land/bubbles/v2` | v2.1.1 | Reusable TUI components |
+| `charm.land/lipgloss/v2` | v2.0.5 | Terminal layout and styling |
+| `charm.land/huh/v2` | v2.0.3 | Form components (Select, MultiSelect, Input, Confirm) |
+| `charm.land/fang/v2` | v2.0.1 | Cobra wrapper for charm-branded CLI UX |
+| `github.com/charmbracelet/glamour` | v1.0.0 | Terminal markdown rendering |
+| `github.com/a-h/templ` | v0.3.1020 | Type-safe HTML templating for `internal/web` (Templ + HTMX) |
+| `mvdan.cc/sh/v3` | v3.13.1 | POSIX shell parser used by hook/sandbox script analysis |
+| `github.com/smacker/go-tree-sitter` | master | Tree-sitter AST bindings for code analysis |
+| `github.com/charmbracelet/x/powernap` | v0.1.6 | JSON-RPC 2.0 foundation for the multi-language LSP client |
+| `github.com/go-playground/validator/v10` | v10.30.3 | Struct validation for config types |
+| `gopkg.in/yaml.v3` | v3.0.1 | YAML marshaling/unmarshaling |
+| `golang.org/x/text` | v0.40.0 | Unicode / language-tag processing |
+| `golang.org/x/sync` | v0.22.0 | `errgroup` / `semaphore` for parallel quality gates |
+| `github.com/mattn/go-isatty` | v0.0.24 | TTY detection for headless mode |
+| `github.com/stretchr/testify` | v1.11.1 | Test assertions (replaces earlier stdlib-only stance) |
+| `go.uber.org/goleak` | v1.3.0 | Goroutine-leak detection in tests |
+
+> The Python predecessor's "no Viper / no go-git / no go.lsp.dev" decisions still hold. The "no testify" stance was reversed at v3.0 -- testify is now a direct dependency.
 
 ### Design Decisions Made During Implementation
 
 Several planned dependencies were replaced with simpler, purpose-built solutions:
 
 - **No go-git**: Git operations use `exec.Command("git", ...)` for reliability and full feature coverage
-- **No Viper**: Custom YAML loader in `internal/config/loader.go` provides simpler, type-safe configuration
-- **No testify**: Standard `testing` package used throughout, reducing external dependencies
-- **No go.lsp.dev packages**: Custom LSP protocol implementation in `internal/lsp/` for full control
-- **Go 1.26**: Final Go version used is significantly newer than the originally planned Go 1.22+; includes Green Tea GC for 10-40% GC overhead reduction
+- **No Viper**: Custom YAML loader with 14 `loader_*.go` files provides simpler, type-safe configuration
+- **No go.lsp.dev packages**: Multi-language LSP client built on `github.com/charmbracelet/x/powernap` in `internal/lsp/` (8 sub-packages)
+- **Go 1.26.4**: Final Go toolchain version; Green Tea GC for 10-40% GC overhead reduction, range-over-int iterators, enhanced `log/slog`
 
 ---
 

--- a/.moai/project/structure.md
+++ b/.moai/project/structure.md
@@ -56,214 +56,80 @@ MoAI-ADK follows a **Modular Monolithic** architecture with clear Domain-Driven 
 ```
 moai-adk-go/
 ├── docs-site/                        # Official documentation site (Hugo + Hextra)
-│   ├── content/                      # 4개 locale 콘텐츠 (ko 63, en/ja/zh 각 52 페이지)
-│   │   ├── ko/
-│   │   ├── en/
-│   │   ├── ja/
-│   │   └── zh/
-│   ├── layouts/                      # Hugo partial override
-│   │   ├── _default/baseof.html
-│   │   └── partials/
-│   │       ├── language-switch.html
-│   │       ├── seo-jsonld.html
-│   │       ├── version-banner.html
-│   │       └── custom/head-end.html
-│   ├── i18n/                         # 4개 locale 번역 문자열
-│   ├── config/_default/              # Hugo + Hextra 설정
-│   ├── api/                          # Vercel Edge Function
-│   │   └── i18n-detect.ts
-│   ├── static/                       # 정적 자산 (og.jpg, favicon 등)
+│   ├── content/                      # 4 locales (ko, en, ja, zh)
+│   ├── layouts/                      # Hugo partial overrides (language switch, SEO, version banner)
+│   ├── i18n/                         # 4-locale translation strings
+│   ├── config/_default/              # Hugo + Hextra configuration
+│   ├── api/                          # Vercel Edge Function (Accept-Language locale detection)
+│   ├── static/                       # Static assets (og.jpg, favicon, etc.)
 │   ├── go.mod                        # Hugo module system (Hextra import)
-│   ├── hugo.yaml                     # Hugo 설정
-│   └── vercel.json                   # Vercel 빌드/배포 설정
+│   ├── hugo.toml                     # Hugo configuration
+│   └── vercel.json                   # Vercel build / deploy config
 ├── cmd/
 │   └── moai/
-│       └── main.go
-├── internal/
-│   ├── astgrep/                    # AST-Grep integration
-│   │   ├── analyzer.go
-│   │   ├── models.go
-│   │   └── rules.go
-│   ├── cli/                        # Cobra CLI commands
-│   │   ├── cc.go                   #   Claude Code integration commands
-│   │   ├── deps.go                 #   Dependency injection and wiring
-│   │   ├── doctor.go               #   Diagnostics (MCP scope duplicate detection v2.1.110+)
-│   │   ├── glm.go                  #   GLM (Go Language Model) commands
-│   │   ├── hook.go                 #   Hook dispatcher (moai hook <event>)
-│   │   ├── init.go
-│   │   ├── rank.go
-│   │   ├── root.go
-│   │   ├── status.go
-│   │   ├── statusline.go           #   Statusline rendering command
-│   │   ├── update.go
-│   │   ├── version.go              #   Version display command
-│   │   └── worktree/
-│   │       ├── clean.go
-│   │       ├── list.go
-│   │       ├── new.go
-│   │       ├── remove.go
-│   │       ├── root.go             #   Worktree root command registration
-│   │       ├── switch.go
-│   │       └── sync.go
-│   ├── config/                     # Configuration management (custom YAML loader)
-│   │   ├── defaults.go             #   Compiled default values
-│   │   ├── errors.go               #   Configuration error types
-│   │   ├── loader.go               #   Custom YAML section loader
-│   │   ├── manager.go              #   Central config with sync.RWMutex
-│   │   ├── types.go                #   Config struct definitions with defaults
-│   │   └── validation.go           #   Schema validation
-│   ├── defs/                       # Constant definitions (6 files)
-│   │   └── specid.go               #   SPEC ID parsing and validation
-│   ├── core/                       # Core business logic domains
-│   │   ├── git/                    #   Git domain (system Git via exec)
-│   │   │   ├── branch.go
-│   │   │   ├── conflict.go
-│   │   │   ├── doc.go
-│   │   │   ├── errors.go
-│   │   │   ├── event.go
-│   │   │   ├── manager.go
-│   │   │   ├── types.go
-│   │   │   └── worktree.go
-│   │   ├── project/
-│   │   │   ├── detector.go
-│   │   │   ├── errors.go
-│   │   │   ├── initializer.go
-│   │   │   ├── methodology_detector.go
-│   │   │   ├── phase.go
-│   │   │   └── validator.go
-│   │   └── quality/
-│   │       ├── trust.go
-│   │       └── validators.go
-│   ├── foundation/                 # Foundation methodologies
-│   │   ├── doc.go
-│   │   ├── ears.go                 #   EARS requirement patterns
-│   │   ├── errors.go
-│   │   ├── language.go             #   Language ecosystem definitions (16+ languages)
-│   │   ├── methodology.go          #   Development methodology patterns
-│   │   └── trust5.go               #   TRUST 5 principle definitions and checklists
-│   ├── github/                     # GitHub API integration (20 files)
-│   │   ├── gh.go                   #   GitHub CLI wrapper (gh command)
-│   │   ├── issue_closer.go         #   Automated GitHub issue closing
-│   │   ├── issue_parser.go         #   Issue content parsing
-│   │   ├── pr_merger.go            #   Pull request merge automation
-│   │   ├── pr_reviewer.go          #   PR review automation
-│   │   ├── spec_linker.go          #   Link SPECs to GitHub issues/PRs
-│   │   └── worktree_orchestrator.go#   Worktree-based PR workflows
-│   ├── hook/                       # Hook system (replaces 46 Python scripts)
-│   │   ├── auto_update.go          #   Auto-update hook handler
-│   │   ├── compact.go              #   Context preservation
-│   │   ├── contract.go             #   Hook execution contract
-│   │   ├── doc.go
-│   │   ├── errors.go
-│   │   ├── notification.go         #   Notification hook handler
-│   │   ├── permission_request.go   #   Permission request hook handler (updatedInput deny re-validation v2.1.110+)
-│   │   ├── post_tool.go            #   Linter, formatter, LSP diagnostics
-│   │   ├── post_tool_failure.go    #   Post-tool failure handler
-│   │   ├── pre_tool.go             #   Security guard, validation
-│   │   ├── protocol.go             #   Claude Code JSON stdin/stdout protocol
-│   │   ├── rank_session.go         #   Session ranking hook handler
-│   │   ├── registry.go             #   Hook registration & dispatch
-│   │   ├── session_end.go          #   Cleanup, rank submission
-│   │   ├── session_start.go        #   Project info, config validation, Windows CLAUDE_ENV_FILE injection (v2.1.111+)
-│   │   ├── stop.go                 #   Loop controller
-│   │   ├── subagent_start.go       #   Subagent start hook handler
-│   │   ├── task_completed.go       #   Task completed hook handler
-│   │   ├── teammate_idle.go        #   Teammate idle hook handler
-│   │   ├── types.go                #   Hook type definitions
-│   │   ├── user_prompt_submit.go   #   User prompt submit hook handler
-│   │   ├── worktree_create.go      #   Worktree create lifecycle hook
-│   │   └── worktree_remove.go      #   Worktree remove lifecycle hook
-│   ├── i18n/                       # Internationalization (3 files)
-│   │   └── templates.go            #   Translation templates for supported languages
-│   ├── loop/                       # Ralph feedback loop
-│   │   ├── controller.go
-│   │   ├── feedback.go
-│   │   ├── state.go
-│   │   └── storage.go
-│   ├── lsp/                        # Custom LSP client implementation
-│   │   ├── client.go
-│   │   ├── doc.go
-│   │   ├── models.go
-│   │   ├── protocol.go
-│   │   └── server.go
-│   ├── manifest/                   # File provenance tracking
-│   │   ├── hasher.go               #   SHA-256 file hashing
-│   │   ├── manifest.go             #   Manifest CRUD (.moai/manifest.json)
-│   │   └── types.go                #   FileProvenance enum
-│   ├── merge/                      # Smart merge engine
-│   │   ├── conflict.go             #   Conflict detection & reporting
-│   │   ├── differ.go               #   Diff generation
-│   │   ├── strategies.go           #   Per-filetype merge strategies
-│   │   ├── three_way.go            #   3-way merge algorithm
-│   │   └── types.go                #   Merge type definitions
-│   ├── ralph/
-│   │   └── engine.go               #   Decision engine for loop iterations
-│   ├── rank/                       # Performance ranking
-│   │   ├── auth.go
-│   │   ├── client.go
-│   │   └── config.go
-│   ├── resilience/                 # Retry and error recovery (11 files)
-│   │   ├── circuit.go              #   Circuit breaker pattern
-│   │   ├── health.go               #   Health check monitoring
-│   │   ├── monitor.go              #   Resilience metrics monitoring
-│   │   └── retry.go                #   Retry with exponential backoff
-│   ├── statusline/                 # Statusline rendering
-│   │   ├── builder.go
-│   │   ├── git.go
-│   │   ├── memory.go
-│   │   ├── metrics.go
-│   │   ├── renderer.go
-│   │   ├── types.go                #   Statusline type definitions
-│   │   └── update.go
-│   ├── shell/                      # Shell environment detection (9 files)
-│   │   ├── detect.go               #   Shell type detection (bash, zsh, fish)
-│   │   └── env.go                  #   Shell environment variable management
-│   ├── template/                   # Template deployment
-│   │   ├── deployer.go             #   go:embed extraction with manifest
-│   │   ├── deployer_mode.go        #   Model policy application to agent definitions
-│   │   ├── errors.go               #   Template error types
-│   │   ├── model_policy.go         #   Per-agent model assignment (5-level effort: low/medium/high/xhigh/max; Opus 4.7 support)
-│   │   ├── agent_effort_map.go     #   Effort level mapping for critical reasoning agents (SPEC-OPUS47-COMPAT-001)
-│   │   ├── renderer.go             #   Go text/template strict rendering
-│   │   ├── settings.go             #   Platform-aware settings.json generation (v2.1.110+ disableBypassPermissionsMode)
-│   │   ├── validator.go            #   Post-deployment validation
-│   │   └── templates/              #   go:embed source (bundled into binary)
-│   │       ├── .claude/            #       Agent definitions, skills, commands, rules
-│   │       ├── .moai/              #       Config section templates
-│   │       └── CLAUDE.md           #       CLAUDE.md template
-│   ├── tmux/                       # Tmux split-pane integration (6 files)
-│   │   └── session.go              #   Tmux session management for CG mode
-│   ├── ui/                         # Charmbracelet TUI
-│   │   ├── checkbox.go             #   Multi-select with search
-│   │   ├── headless.go             #   Non-interactive mode support
-│   │   ├── progress.go             #   Progress bars + spinners
-│   │   ├── prompt.go               #   Confirm/input prompts
-│   │   ├── runner.go               #   TUI program runner
-│   │   ├── selector.go             #   Fuzzy single-select
-│   │   ├── theme.go                #   MoAI color theme (lipgloss)
-│   │   ├── ui.go                   #   UI package entry point
-│   │   └── wizard.go               #   Init wizard (bubbletea Elm model)
-│   ├── workflow/                   # Workflow state management (6 files)
-│   │   └── state.go                #   Workflow phase and SPEC state tracking
-│   └── update/                     # Self-update system
-│       ├── checker.go              #   GitHub Releases API version check
-│       ├── orchestrator.go         #   Full update workflow coordinator
-│       ├── rollback.go             #   Atomic rollback on failure
-│       ├── types.go                #   Update type definitions
-│       └── updater.go              #   Binary self-replacement
+│       └── main.go                   # main() → cli.Execute() → cobra rootCmd
+├── internal/                         # 46 top-level packages (318 subpackages)
+│   ├── astgrep/                      # ast-grep CLI wrapper (5 non-test files, SARIF output)
+│   ├── atomicfile/                   # Atomic file writes (write-temp + rename)
+│   ├── bodp/                         # Branch Origin Decision Protocol (3-signal / 8-row matrix)
+│   ├── ciwatch/                      # CI check classification (gh pr checks consumer)
+│   ├── cli/                          # Cobra command tree, composition root (109 non-test files, 152 non-test AddCommand calls)
+│   ├── config/                       # Layered YAML config SSOT (35 non-test files, 14 loader_*.go, 32 YAML files)
+│   ├── constitution/                 # Frozen/Evolvable zone model, 5-stage merge safety (13 non-test files)
+│   ├── core/                         # Core domain packages
+│   │   ├── git/                      #   System Git via exec (Repository / BranchManager / WorktreeManager)
+│   │   ├── project/                  #   FindProjectRoot() ANCHOR (`.moai/` discovery)
+│   │   ├── quality/                  #   TRUST 5 gate enforcement, phase-aware thresholds
+│   │   ├── integration/              #   Integration test domain (legacy stub)
+│   │   └── migration/                #   Version migration domain (legacy stub)
+│   ├── defs/                         # Directory-layout constants (`.moai/`, `.claude/` structure)
+│   ├── evolution/                    # Reflective Write Phase (LearningEntry, 5-layer safety, 15 files)
+│   ├── foundation/                   # Language registry (16 langs), TRUST 5, errors
+│   ├── git/                          # Label → branch-prefix conventions
+│   ├── goal/                         # Goal engine — `/moai goal` condition-declared loop (4 non-test files)
+│   ├── harness/                      # Harness self-learning subsystem (75 non-test files, 4-tier Learner)
+│   ├── hook/                         # Compiled hook system + main-checkout branch-state guard (30 EventTypes, 35 handle-*.sh)
+│   ├── lockfile/                     # Cross-platform locking (Unix flock / Windows in-process mutex)
+│   ├── loop/                         # Ralph feedback loop (6 non-test files)
+│   ├── lsp/                          # Multi-language LSP client (8 sub-packages: aggregator, cache, config, core, gopls, hook, subprocess, transport)
+│   ├── manifest/                     # File provenance tracking (3-way hash)
+│   ├── measure/                      # Zero-dependency leaf parsers (go test JSON, coverage, LOC)
+│   ├── merge/                        # 3-way file merge engine (7 non-test files)
+│   ├── migration/                    # Version-based migration executor (Apply / Status / Rollback)
+│   ├── mx/                           # @MX tag scanner/resolver, FanInCounter (12 non-test files)
+│   ├── permission/                   # 8-tier permission stack (5 modes: default, acceptEdits, bypassPermissions, plan, bubble)
+│   ├── profile/                      # User profile management (3-tier profile matrix)
+│   ├── ralph/                        # Ralph decision engine
+│   ├── resilience/                   # Circuit breaker FSM (closed / open / half-open)
+│   ├── runtime/                      # Token circuit-breaker, budget tracking (soft 75% / hard 90%)
+│   ├── sandbox/                      # OS sandbox (seatbelt / bubblewrap / docker)
+│   ├── session/                      # Multi-session registry (25 files, active-sessions.json, Heartbeat/Purge)
+│   ├── settings/                     # settings.json / settings.local.json helpers (10 non-test files)
+│   ├── shell/                        # Shell detection and config changes
+│   ├── spec/                         # SPEC lifecycle engine (24 non-test / 59 incl. tests, Linter 13+3, ClassifyEra, Audit, DetectDrift)
+│   ├── statusline/                   # Claude Code statusline renderer, 3L/5L layouts (15 non-test files)
+│   ├── telemetry/                    # Async skill-usage metrics (JSONL)
+│   ├── template/                     # go:embed Template-First (`embed.go` directly uses `//go:embed all:templates`), profile_matrix 33-cell
+│   │   ├── embed.go                  #   //go:embed all:templates (NO separate embedded.go)
+│   │   ├── deployer.go               #   Atomic deploy with manifest tracking
+│   │   ├── renderer.go               #   Go text/template strict mode
+│   │   ├── profile_matrix.go         #   11 agents × 3 profiles = 33-cell effort matrix
+│   │   ├── settings.go               #   Platform-aware settings.json generation
+│   │   ├── validator.go              #   Post-deployment validation
+│   │   └── templates/                #   Embedded source (`.claude/`, `.moai/`, `CLAUDE.md`)
+│   ├── tokenusage/                   # Token usage counter (statusline integration)
+│   ├── tmux/                         # tmux detection, CG / GLM mode (4 non-test files)
+│   ├── tui/                          # Charm.land v2 TUI stack (Catppuccin, Box/Pill/Table/Status, 32 files)
+│   ├── update/                       # Self-update (Checker, Updater, Rollback, checksum gate)
+│   ├── verify/                       # Verification subsystem (orchestrator-side verification batches)
+│   ├── web/                          # Loopback HTTP console on 127.0.0.1:3041 (Templ + HTMX)
+│   ├── workflow/                     # Plan-Run-Sync worktree orchestration
+│   ├── worktree/                     # Worktree state guard (Capture / Diff / DivergenceLog)
+│   └── skills/                       # Test-only fixtures (LOC-ceiling / template-mirror-parity tests, NOT in runtime catalog)
 ├── pkg/
-│   ├── models/
-│   │   ├── config.go
-│   │   ├── doc.go                 #   Package documentation
-│   │   ├── lang.go                #   Language support (LangNameMap, GetLanguageName)
-│   │   └── project.go
-│   ├── utils/
-│   │   ├── logger.go
-│   │   └── path.go
-│   └── version/
-│       ├── doc.go                 #   Package documentation
-│       └── version.go
-├── go.mod
+│   ├── models/                       # Shared config types (Very High fan-in, 45+): ProjectType, DevelopmentMode, ProjectConfig
+│   └── version/                      # Build-time version / commit / date (ldflags)
+├── go.mod                            # module github.com/modu-ai/moai-adk, go 1.26.4
 ├── go.sum
 ├── Makefile
 ├── CHANGELOG.md
@@ -277,7 +143,7 @@ moai-adk-go/
 - Local: `cd docs-site && hugo server`
 - Build: `hugo --minify --gc` → `docs-site/public/`
 - Deploy: Vercel (Framework=Hugo, Root Directory=docs-site)
-- Edge: `docs-site/api/i18n-detect.ts` (Accept-Language + cookie 검출)
+- Edge: `docs-site/api/i18n-detect.ts` (Accept-Language + cookie locale detection)
 
 ---
 
@@ -495,14 +361,16 @@ Defines all CLI commands using the Cobra library. Each file registers one comman
 | File | Purpose | Python Equivalent | Issues Addressed |
 |------|---------|-------------------|------------------|
 | `root.go` | Root command, global flags, version display | `cli/main.py` | -- |
-| `init.go` | Project initialization wizard (bubbletea) | `cli/commands/init_command.py` | #2, #9, #256, #310 |
+| `init.go` | Project initialization wizard (charm.land v2) | `cli/commands/init_command.py` | #2, #9, #256, #310 |
 | `doctor.go` | System diagnostics and health checks | `cli/commands/doctor_command.py` | -- |
-| `status.go` | Project status overview | `cli/spec_status.py` | -- |
 | `update.go` | Self-update with smart merge | `cli/commands/update_command.py` | #246, #187, #318 |
-| `hook.go` | Hook dispatcher (`moai hook <event>`) | -- (NEW) | All 28 hook issues |
-| `switch.go` | Branch switching with context | `cli/commands/switch_command.py` | -- |
-| `rank.go` | Performance ranking commands | `cli/commands/rank_command.py` | -- |
-| `worktree/` | Git worktree management subcommands | `cli/worktree/` | #270 |
+| `hook.go` | Hook dispatcher (`moai hook <event>`) | -- (NEW) | All hook-related Python-era issues |
+| `deps.go` | Composition root -- `InitDependencies()` wires every subsystem | -- (NEW) | -- |
+| `cc.go` / `glm.go` / `cg.go` | Multi-LLM launcher commands (Claude / GLM / Hybrid CG) | -- (NEW) | -- |
+| `web.go` | Loopback HTTP console (`127.0.0.1:3041`, Templ + HTMX) | -- (NEW) | -- |
+| `worktree/` | Git worktree management subcommands (new / list / remove / clean / sync) | `cli/worktree/` | #270 |
+
+> v3.0 dropped the `switch.go` and `rank.go` files that earlier drafts listed -- branch switching is handled inside `worktree/` and the ranking subsystem is retired (see `internal/rank/` note below).
 
 #### `internal/config/` -- Configuration Management (Custom YAML Loader + Typed Structs)
 
@@ -545,33 +413,24 @@ Contains the primary domain packages, each encapsulating a bounded context.
 | `trust.go` | TRUST 5 orchestrator and gate logic | `core/quality/trust_checker.py` |
 | `validators.go` | Individual principle validators | `core/quality/validators/` |
 
-**`internal/core/integration/`** -- Integration Testing Domain
+**`internal/core/integration/`** -- Integration Testing Domain (LEGACY STUB)
 
-| File | Purpose | Python Equivalent |
-|------|---------|-------------------|
-| `engine.go` | Integration test execution engine | `core/integration/engine.py` |
-| `models.go` | Test result models and reporting | `core/integration/models.py` |
+This directory is a `.gitkeep` placeholder only -- no Go source files. It exists as a tombstone for a planned domain that was superseded by `internal/verify/` (orchestrator-side verification batches). Do not add real code here without first consulting the codemaps.
 
-**`internal/core/migration/`** -- Version Migration Domain
+**`internal/core/migration/`** -- Version Migration Domain (LEGACY STUB)
 
-| File | Purpose | Python Equivalent |
-|------|---------|-------------------|
-| `migrator.go` | Version migration orchestrator | `core/migration/version_migrator.py` |
-| `backup.go` | Backup creation and restoration | `core/migration/backup_manager.py` |
+Also a `.gitkeep` placeholder. The actual version-migration executor lives in `internal/migration/` (top-level, not under `core/`) -- see Apply / Status / Rollback with idempotency guarantees.
 
 #### `internal/foundation/` -- Foundation Methodologies
 
-| File | Purpose | Python Equivalent |
-|------|---------|-------------------|
-| `ears.go` | EARS requirement pattern templates | `foundation/ears.py` |
-| `langs.go` | Language ecosystem definitions (16+ languages) | `foundation/langs.py` |
-| `backend.go` | Backend architecture patterns | `foundation/backend.py` |
-| `frontend.go` | Frontend architecture patterns | `foundation/frontend.py` |
-| `database.go` | Database patterns and strategies | `foundation/database.py` |
-| `testing.go` | Testing strategy definitions | `foundation/testing.py` |
-| `devops.go` | DevOps and CI/CD patterns | `foundation/devops.py` |
-| `trust/principles.go` | TRUST 5 principle definitions | `foundation/trust5.py` |
-| `trust/checklist.go` | Quality checklist generation | `foundation/trust5.py` |
+The v3.0 `internal/foundation/` package is much smaller than earlier drafts claimed. It currently holds only: `doc.go`, `errors.go`, `language.go` (the 16-language registry, Very High fan-in), `timeouts.go`, and a `trust/` subdirectory carrying TRUST 5 principle definitions and checklists. The per-domain pattern files once rumored here (`backend.go`, `frontend.go`, `database.go`, `testing.go`, `devops.go`, `ears.go`, `methodology.go`) do NOT exist in v3.0; those concerns live in skills and reference docs, not in this package.
+
+| File / Subdir | Purpose |
+|------|---------|
+| `language.go` | 16-language registry (`LanguageRegistry`, `SupportedLanguages`) |
+| `errors.go` | Foundation error types |
+| `timeouts.go` | Shared timeout defaults |
+| `trust/` | TRUST 5 principle definitions and checklists |
 
 #### `internal/lsp/` -- Language Server Protocol
 
@@ -599,14 +458,9 @@ Custom LSP client supporting 16+ language servers via JSON-RPC 2.0.
 |------|---------|-------------------|
 | `engine.go` | Decision engine for loop iterations | `ralph/engine.py` |
 
-#### `internal/rank/` -- Performance Ranking
+#### `internal/rank/` -- Performance Ranking (RETIRED at v3.0)
 
-| File | Purpose | Python Equivalent |
-|------|---------|-------------------|
-| `client.go` | Ranking API HTTP client | `rank/client.py` |
-| `auth.go` | API authentication and credentials | `rank/auth.py` |
-| `config.go` | Ranking configuration | `rank/config.py` |
-| `hook.go` | Git hook integration for metrics | `rank/hook.py` |
+The `internal/rank/` package existed in the Python predecessor and in earlier Go drafts but is NOT present in the v3.0 codebase. The 46-package `internal/` listing does not include it. Any ranking-API references remaining in hook handlers are historical scaffolding and should not be treated as a current feature.
 
 #### `internal/statusline/` -- Statusline Rendering
 
@@ -627,20 +481,11 @@ Custom LSP client supporting 16+ language servers via JSON-RPC 2.0.
 | `models.go` | AST match result models | `astgrep/models.py` |
 | `rules.go` | Custom rule definitions and loading | `astgrep/rules.py` |
 
-#### `internal/ui/` -- Terminal UI (Charmbracelet Ecosystem)
+#### `internal/tui/` -- Terminal UI (charm.land v2 Ecosystem)
 
-Modern TUI using Charmbracelet's Elm-architecture framework. Replaces Rich + InquirerPy.
+Modern TUI using the charm.land v2 stack (`bubbletea/v2`, `bubbles/v2`, `lipgloss/v2`, `huh/v2`, `fang/v2`). Box / Pill / Table / Status / ProgressLine components, Catppuccin color tokens. 32 files. Replaces the Python Rich + InquirerPy stack.
 
-**Resolves**: #268 (ESC freeze), #249 (encoding), #286 (Windows emoji)
-
-| File | Purpose | Python Equivalent |
-|------|---------|-------------------|
-| `wizard.go` | Init wizard (bubbletea Elm model) | `cli/prompts/init_prompts.py` |
-| `selector.go` | Fuzzy single-select with filtering | InquirerPy `fuzzy_select()` |
-| `checkbox.go` | Multi-select with search | InquirerPy `fuzzy_checkbox()` |
-| `progress.go` | Progress bars + spinners (bubbles) | Rich `Progress()` |
-| `theme.go` | MoAI color theme (lipgloss) | `cli/ui/theme.py` |
-| `prompt.go` | Confirm/input prompts (huh) | `cli/ui/prompts.py` |
+> The legacy path `internal/ui/` referenced in earlier drafts does NOT exist in v3.0; all UI code lives in `internal/tui/`.
 
 ### `pkg/` -- Public Packages
 
@@ -665,15 +510,9 @@ Version constants and build metadata injected at compile time via `-ldflags`. No
 | `project.go` | Project metadata, type enums, configuration models |
 | `spec.go` | SPEC document models, status enums |
 
-#### `pkg/utils/`
+#### `pkg/utils/` -- (RETIRED at v3.0)
 
-| File | Purpose |
-|------|---------|
-| `logger.go` | Structured logging via `log/slog` |
-| `file.go` | File system helpers (safe write, atomic operations) |
-| `path.go` | Path resolution, `.moai/` directory discovery |
-| `timeout.go` | Context-based timeout utilities |
-| `validator.go` | Input validation helpers |
+The `pkg/utils/` package existed in earlier Go drafts but is NOT present in the v3.0 codebase. The v3.0 `pkg/` tree contains only `pkg/models/` and `pkg/version/`. Logging lives in the standard library `log/slog`; path resolution lives in `internal/core/project/` (`FindProjectRoot()`); atomic file writes live in `internal/atomicfile/`; validation lives in `github.com/go-playground/validator/v10` consumed by `internal/config/`.
 
 ### `internal/template/templates/` -- Embedded Templates
 
@@ -730,7 +569,7 @@ internal/lsp/              internal/core/git/
     +---------------------------+
     |
     v
-internal/ui/               -- Render output (bubbletea/lipgloss)
+internal/tui/              -- Render output (charm.land v2: bubbletea/lipgloss/huh/fang)
     |
     v
 Terminal (stdout/stderr)
@@ -812,7 +651,7 @@ internal/update/updater.go     -- Atomic binary replacement
 internal/update/rollback.go    -- On failure: restore previous
     |
     v
-internal/ui/progress.go        -- Show summary (updated/merged/conflicted/skipped)
+internal/tui/                  -- Show summary (updated/merged/conflicted/skipped) via charm.land v2 components
 ```
 
 ### Quality Gate Flow
@@ -873,28 +712,30 @@ Converged? --> Yes: Complete
 | Language Servers | JSON-RPC 2.0 (stdio/TCP) | `internal/lsp/` | Code diagnostics |
 | Git | system Git via `exec.Command` | `internal/core/git/` | Version control |
 | ast-grep | CLI subprocess | `internal/astgrep/` | Structural code analysis |
-| Ranking API | HTTPS REST | `internal/rank/` | Performance metrics |
+| GitHub API | `gh` CLI subprocess | `internal/github/` | Issue/PR automation, spec linking |
 | GitHub Releases | HTTPS REST | `internal/update/` | Self-update |
-| File system | OS syscalls | `pkg/utils/` | Configuration, templates |
+| File system | OS syscalls | `internal/atomicfile/`, `internal/manifest/` | Atomic writes, provenance tracking |
 
 ### Internal Module Dependencies
 
 ```
-cli/ ────────→ config/, core/*, hook/, update/, ui/, github/, tmux/
-hook/ ───────→ config/, core/quality/, lsp/, loop/, resilience/
+cli/ ────────→ config/, core/*, hook/, update/, tui/, github/, tmux/, session/, spec/, loop/, harness/
+hook/ ───────→ config/, core/quality/, lsp/, loop/, resilience/, session/, goal/, mx/
 update/ ─────→ manifest/, merge/, template/
-template/ ───→ manifest/
+template/ ───→ manifest/, atomicfile/
 core/project/ → config/, core/git/, foundation/, defs/
 core/quality/ → lsp/, astgrep/, core/git/
 loop/ ────────→ ralph/, core/quality/, core/git/
-statusline/ ──→ core/git/, config/, pkg/version/
-rank/ ────────→ config/, core/git/
+statusline/ ──→ core/git/, config/, pkg/version/, tokenusage/
 github/ ─────→ shell/, resilience/, workflow/
 shell/ ──────→ (no internal deps)
 resilience/ ─→ (no internal deps)
-workflow/ ───→ config/, defs/
-i18n/ ───────→ (no internal deps)
+workflow/ ───→ config/, defs/, core/git/
+session/ ───→ lockfile/, config/, core/git/
+goal/ ───────→ (self-contained, no internal deps)
 ```
+
+> The phantom `rank/`, `i18n/`, and `ui/` dependencies listed in earlier drafts are NOT present in v3.0. `internal/rank/` was retired; internationalization strings live in the docs-site `i18n/` subtree (not in the Go binary); UI lives in `internal/tui/`.
 
 **Dependency Rule**: Dependencies flow downward and inward. `cli/` depends on everything; `pkg/` depends on nothing internal. Circular dependencies are prohibited.
 
@@ -912,7 +753,7 @@ i18n/ ───────→ (no internal deps)
 
 **Decision**: All domain logic under `internal/` with minimal `pkg/` surface.
 
-**Rationale**: Aggressive API minimization. Only `pkg/version/`, `pkg/models/`, and `pkg/utils/` are public. This allows refactoring internal implementations freely without semver concerns.
+**Rationale**: Aggressive API minimization. Only `pkg/version/` and `pkg/models/` are public (v3.0 dropped the earlier `pkg/utils/` draft). This allows refactoring internal implementations freely without semver concerns.
 
 ### ADR-003: Interface-Based Domain Boundaries
 

--- a/.moai/project/tech.md
+++ b/.moai/project/tech.md
@@ -8,19 +8,14 @@ Go is the implementation language for the MoAI-ADK rewrite. The project uses Go 
 
 ## Claude Code Integration
 
-**Minimum Recommended Version: Claude Code v2.1.110** (released April 2026)
+**Minimum Recommended Version: Claude Code v2.1.110+** (April 2026). v3.0 development tracks the v2.1.219+ subagent-nesting defaults and the v2.1.198+ background-subagent defaults.
 
-MoAI-ADK v2.12+ requires Claude Code v2.1.110 or later to support:
-- MCP scope duplicate detection in `moai doctor` (v2.1.110+)
-- Bash tool timeout ceiling enforcement (600,000ms) (v2.1.110+)
-- `disableBypassPermissionsMode` policy for security gates (v2.1.110+)
-
-**Opus 4.7 Support** (v2.12.0+):
-- Model: `claude-opus-4-7`
-- Effort levels: `low`, `medium`, `high`, `xhigh` (default), `max`
-- Recommended for: manager-spec, plan-auditor, sync-auditor, manager-strategy, expert-security, expert-refactoring
-- Backward compatibility: Opus 4.6, Sonnet 4.6, Haiku 4.5 supported with effort field auto-downgrade
-- Windows support: CLAUDE_ENV_FILE injection via SessionStart hook (v2.12.0+)
+**Opus 5 / 4.8 Model Matrix** (v3.0):
+- Anchor model: `claude-opus-5` (1M-context, the default Opus as of Claude Code 2.1.219); `claude-opus-4-8` and `claude-opus-4-7` still supported
+- Effort levels: `low` / `medium` / `high` (default) / `xhigh` / `max`. Opus 5 carries a previously-set effort level across sessions (no hold)
+- Adaptive Thinking: enabled via `thinking: {type: "adaptive"}` -- Opus 4.7+ rejects fixed `budget_tokens` with HTTP 400, so fixed thinking budgets are prohibited
+- 33-cell profile matrix: 11 retained agents x 3 model tiers (`low` / `medium` / `high`) materialized by `internal/template/profile_matrix.go` and rendered into agent frontmatter at deploy time
+- GLM tier-models table (`internal/config/defaults.go`): `DefaultGLMHigh = "glm-5.2"` (NO `[1m]` suffix -- the `[1m]` is added at the launcher layer in `internal/cli/launcher.go` only when the 1M-context variant is requested); `DefaultGLMMedium = "glm-4.7"`; `DefaultGLMLow = "glm-4.5-air"`; `DefaultGLMBaseURL = "https://api.z.ai/api/anthropic"`
 
 ## Go Module
 
@@ -34,29 +29,41 @@ The module path follows Go conventions with the GitHub organization and reposito
 
 ## Technology Stack
 
-### Core Dependencies
+### Core Dependencies (v3.0)
 
 | Category | Package | Version | Purpose |
 |----------|---------|---------|---------|
 | CLI Framework | `github.com/spf13/cobra` | v1.10.2 | Command-line interface with subcommands, flags, and shell completion |
+| CLI UX Wrapper | `charm.land/fang/v2` | v2.0.1 | Charm-branded Cobra wrapper (help rendering, themes) |
 | YAML Parsing | `gopkg.in/yaml.v3` | v3.0.1 | YAML marshaling/unmarshaling for configuration and SPEC documents |
-| TUI Components | `github.com/charmbracelet/bubbles` | v1.0.0 | Reusable TUI components (spinners, progress bars, viewport, text input) |
-| Terminal UI | `github.com/charmbracelet/bubbletea` | v1.3.10 | Interactive TUI framework with Elm-architecture patterns |
-| Terminal Forms | `github.com/charmbracelet/huh` | v0.8.0 | Modern form components (Select, MultiSelect, Input, Confirm, Form) with themes and accessibility |
-| Terminal Styling | `github.com/charmbracelet/lipgloss` | v1.1.1+ | Terminal layout and styling for statusline and UI components |
-| Markdown Rendering | `github.com/charmbracelet/glamour` | v0.10.0 | Terminal markdown rendering with syntax highlighting and auto dark/light detection |
-| TTY Detection | `github.com/mattn/go-isatty` | v0.0.20 | Terminal detection for headless mode support |
-| Text Processing | `golang.org/x/text` | v0.34.0 | Unicode normalization, language tag processing, and text utilities |
-| Configuration | Custom YAML loader | -- | Custom implementation in `internal/config/loader.go` (Viper was not used) |
+| TUI Components | `charm.land/bubbles/v2` | v2.1.1 | Reusable TUI components (spinners, progress bars, viewport, text input) |
+| Terminal UI | `charm.land/bubbletea/v2` | v2.0.8 | Interactive TUI framework with Elm-architecture patterns |
+| Terminal Forms | `charm.land/huh/v2` | v2.0.3 | Modern form components (Select, MultiSelect, Input, Confirm, Form) |
+| Terminal Styling | `charm.land/lipgloss/v2` | v2.0.5 | Terminal layout and styling for statusline and UI components |
+| Markdown Rendering | `github.com/charmbracelet/glamour` | v1.0.0 | Terminal markdown rendering with syntax highlighting and auto dark/light detection |
+| HTML Templating | `github.com/a-h/templ` | v0.3.1020 | Type-safe HTML templating for `internal/web` (loopback HTTP console, Templ + HTMX) |
+| Shell Parsing | `mvdan.cc/sh/v3` | v3.13.1 | POSIX shell parser used by hook and sandbox script analysis |
+| Tree-sitter | `github.com/smacker/go-tree-sitter` | master | Tree-sitter AST bindings for code analysis |
+| LSP Client | `github.com/charmbracelet/x/powernap` | v0.1.6 | Multi-language LSP client foundation. Wraps `sourcegraph/jsonrpc2` with VSCode-compatible codec. Used by `internal/lsp/core/` and `internal/lsp/transport/` |
+| Struct Validation | `github.com/go-playground/validator/v10` | v10.30.3 | Config struct validation |
+| TTY Detection | `github.com/mattn/go-isatty` | v0.0.24 | Terminal detection for headless mode support |
+| Runewidth | `github.com/mattn/go-runewidth` | v0.0.27 | East-Asian width-aware text rendering |
+| Terminal Env | `github.com/muesli/termenv` | v0.16.0 | Cross-platform terminal environment detection |
+| Color Profile | `github.com/charmbracelet/colorprofile` | v0.4.3 | Correct color rendering across terminal capabilities |
+| Text Processing | `golang.org/x/text` | v0.40.0 | Unicode normalization, language tag processing, and text utilities |
+| Sync Primitives | `golang.org/x/sync` | v0.22.0 | `errgroup` / `semaphore` for parallel quality gates and LSP queries |
+| System Calls | `golang.org/x/sys` | v0.47.0 | Low-level OS primitives (signal, syscall) |
+| Test Assertions | `github.com/stretchr/testify` | v1.11.1 | Replaces the earlier "stdlib-only" stance at v3.0 |
+| Goroutine Leak Detection | `go.uber.org/goleak` | v1.3.0 | Goroutine-leak assertions in tests |
+| Configuration | Custom YAML loader | -- | 14 `loader_*.go` files composing 32 YAML (Viper was not used) |
 | Git Operations | System Git via `exec.Command` | -- | All Git operations use system Git binary (go-git was not used) |
 | Logging | `log/slog` (stdlib) | Go 1.26 | Structured, leveled logging with JSON and text handlers |
-| Testing | `testing` (stdlib) | Go 1.26 | Standard test framework with benchmarks and fuzzing (testify was not used) |
-| HTTP Client | `net/http` (stdlib) | Go 1.26 | HTTP client for ranking API and update checking |
+| Testing | `testing` (stdlib) | Go 1.26 | Standard test framework with benchmarks and fuzzing |
+| HTTP Client | `net/http` (stdlib) | Go 1.26 | HTTP client for update checking and `moai web` loopback console |
 | Concurrency | goroutines + channels (stdlib) | Go 1.26 | Native concurrent execution for LSP, quality gates, and parallel operations |
-| File Embedding | `embed` (stdlib) | Go 1.26 | Compile-time template embedding into the binary |
+| File Embedding | `embed` (stdlib) | Go 1.26 | Compile-time template embedding via `//go:embed all:templates` in `internal/template/embed.go` |
 | Context | `context` (stdlib) | Go 1.26 | Cancellation, timeouts, and request-scoped values |
-| LSP Client | `github.com/charmbracelet/x/powernap` | v0.1.3 | Multi-language LSP client foundation (SPEC-LSP-CORE-002). Wraps `sourcegraph/jsonrpc2` with VSCode-compatible codec. Used by `internal/lsp/core/` and `internal/lsp/transport/` |
-| URI Encoding | `net/url` (stdlib) | Go 1.26 | RFC 3986 file:// URI encoding for LSP (`internal/lsp/gopls/uri.go`). Handles space, unicode, Windows drive paths correctly |
+| URI Encoding | `net/url` (stdlib) | Go 1.26 | RFC 3986 file:// URI encoding for LSP (`internal/lsp/gopls/uri.go`) |
 
 ### Security Patterns (v2.10.4)
 
@@ -105,30 +112,29 @@ MoAI-ADK provides built-in internationalization with 4 supported languages:
 
 Official documentation site running at `https://adk.mo.ai.kr`:
 
-| 항목 | 기술 | 버전 |
-|------|------|------|
-| 정적 사이트 생성기 | Hugo Extended | v0.160.1+ |
-| 테마 | Hextra | v0.12.2+ (Hugo module) |
-| 콘텐츠 포맷 | Hugo Markdown + shortcode | — |
-| 다이어그램 | Mermaid (Hextra 내장, 클라이언트 사이드) | v11+ |
-| 다국어 | Hugo multilingual (파일 기반) | ko/en/ja/zh 4개 |
-| 검색 | FlexSearch | Hextra 내장 |
-| 배포 | Vercel | Framework Preset=Hugo |
-| Edge Runtime | Vercel Edge Function | @runtime: 'edge' |
-| 릴리스 자동화 | Go + git archive | scripts/docs-version-snapshot |
+| Component | Technology | Version |
+|-----------|-----------|---------|
+| Static site generator | Hugo Extended | v0.160.1+ |
+| Theme | Hextra | v0.12.2+ (Hugo module) |
+| Content format | Hugo Markdown + shortcodes | -- |
+| Diagrams | Mermaid (Hextra built-in, client-side) | v11+ |
+| Multilingual | Hugo multilingual (file-based) | 4 locales: ko / en / ja / zh |
+| Search | FlexSearch | Hextra built-in |
+| Hosting | Vercel | Framework Preset = Hugo |
+| Edge runtime | Vercel Edge Function | `@runtime: 'edge'` for Accept-Language locale detection |
+| Release automation | Go + git archive | `scripts/docs-version-snapshot` |
 
-**Bun/Node.js 제거**: Phase 2 이전의 Nextra(Next.js + Bun) 스택을 전면 교체하여
-`docs-site/` 빌드에 Node 런타임 의존성이 0건이다. 로컬 개발도 Hugo 단일 바이너리만으로 가능.
+**Bun/Node.js removed**: the Phase-2 Nextra (Next.js + Bun) stack was fully replaced, so `docs-site/` builds with zero Node runtime dependency. Local development requires only the Hugo single binary.
 
 ### LSP Dependencies
 
-| Category | Package | Version | Purpose |
-|----------|---------|---------|---------|
-| JSON-RPC | Custom implementation | -- | Lightweight JSON-RPC 2.0 client over stdio and TCP |
-| LSP Types | Custom implementation | -- | LSP protocol type definitions in `internal/lsp/models.go` |
-| LSP Protocol | Custom implementation | -- | JSON-RPC 2.0 transport in `internal/lsp/protocol.go` |
+| Category | Package | Purpose |
+|----------|---------|---------|
+| JSON-RPC transport | `github.com/charmbracelet/x/powernap` | VSCode-compatible JSON-RPC 2.0 codec |
+| LSP Types | In-tree types under `internal/lsp/` (8 sub-packages) | MoAI-specific abstractions over raw protocol types |
+| Multi-server management | `internal/lsp/core/`, `internal/lsp/aggregator/`, `internal/lsp/gopls/` | Lifecycle, parallel diagnostic collection, gopls bridge |
 
-**Decision**: The `go.lsp.dev` packages were not used. Instead, a fully custom LSP client was implemented in `internal/lsp/` providing MoAI-specific abstractions (multi-server management, diagnostic aggregation) without external dependencies.
+**Decision**: The `go.lsp.dev` packages were not used. The v3.0 LSP client (8 sub-packages) is built on `powernap` and wraps it with MoAI-specific abstractions (multi-server management, diagnostic aggregation, cache, circuit breaker). 16-language auto-detection via project_markers; `lsp.client_impl` feature flag selects `gopls_bridge` (legacy, Go-only) or `powernap_core` (default, 16 languages).
 
 ### Planned Dependencies Not Used
 
@@ -136,20 +142,24 @@ The following dependencies were considered during planning but replaced with sim
 
 | Planned Package | Replacement | Rationale |
 |----------------|-------------|-----------|
-| `github.com/spf13/viper` | Custom YAML loader | Simpler, type-safe configuration without Viper's complexity |
+| `github.com/spf13/viper` | Custom YAML loader (14 `loader_*.go` files) | Simpler, type-safe configuration without Viper's complexity |
 | `github.com/go-git/go-git/v5` | System Git via `exec.Command` | Full Git feature coverage including worktrees without library limitations |
-| `github.com/stretchr/testify` | Standard `testing` package | Reduced external dependencies; standard assertions sufficient |
-| `go.lsp.dev/protocol` | Custom types in `internal/lsp/` | Full control over LSP type definitions without external dependency |
-| `go.lsp.dev/jsonrpc2` | Custom protocol in `internal/lsp/` | Lightweight implementation tailored to MoAI's needs |
+| `go.lsp.dev/protocol` | `github.com/charmbracelet/x/powernap` + in-tree types in `internal/lsp/` | Multi-language LSP client without `go.lsp.dev` coupling |
+| `go.lsp.dev/jsonrpc2` | `powernap` JSON-RPC codec in `internal/lsp/transport/` | Lightweight implementation tailored to MoAI's needs |
+
+> The "no testify" stance was reversed at v3.0 -- `github.com/stretchr/testify v1.11.1` is now a direct dependency. The reversal is recorded to prevent stale "testify was not used" claims from propagating back.
 
 ### Development Dependencies
 
 | Category | Package | Purpose |
 |----------|---------|---------|
 | Linter | `github.com/golangci/golangci-lint` | Comprehensive Go linter aggregator (staticcheck, gosec, ineffassign, etc.) |
+| PR Reviewer | CodeRabbit (`.coderabbit.yaml`) | Automated PR review; the `claude-pr-review` GitHub App was disabled at v3.0 in favor of CodeRabbit |
 | Mock Generation | Manual test doubles | Interface-based test doubles written manually (mockery was not used) |
 | Release | `github.com/goreleaser/goreleaser` | Cross-platform binary builds and release automation |
-| Code Generation | `go generate` (stdlib) | Driving mockery and embed directives |
+| Code Generation | `go generate` (stdlib) | Driving `go:embed` directives and templ source generation |
+| CI Platform | GitHub Actions | Workflow files under `.github/workflows/` |
+| Vulnerability Scan | `govulncheck` (stdlib golang.org/x/vuln) | Known vulnerability detection in dependency tree |
 
 ---
 
@@ -157,12 +167,14 @@ The following dependencies were considered during planning but replaced with sim
 
 ### Primary Build
 
-```makefile
-# Build the binary
-build:
-    go build -ldflags "-X pkg/version.Version=$(VERSION) -X pkg/version.Commit=$(COMMIT)" -o bin/moai ./cmd/moai
+The canonical targets are defined in the project `Makefile` under `##` help banners -- run `make help` to see them. The Template-First cycle is: edit `internal/template/templates/` -> `make build` (recompiles the binary, re-embedding templates via `//go:embed all:templates`) -> run tests -> commit. There is NO separate `embedded.go` generation step.
 
-# Run all tests with coverage
+```makefile
+# Rebuild the binary (re-embeds templates at compile time)
+build:
+    go build -ldflags "-X github.com/modu-ai/moai-adk/pkg/version.Version=$(VERSION) -X github.com/modu-ai/moai-adk/pkg/version.Commit=$(COMMIT)" -o bin/moai ./cmd/moai
+
+# Run all tests with coverage and race detector
 test:
     go test -race -coverprofile=coverage.out ./...
 
@@ -170,11 +182,7 @@ test:
 lint:
     golangci-lint run ./...
 
-# Generate mocks and embedded resources
-generate:
-    go generate ./...
-
-# Cross-compile for all platforms
+# Cross-compile release binaries for all 6 platform targets
 release:
     goreleaser release --clean
 ```
@@ -236,7 +244,13 @@ Recommended gopls settings for the project:
 | `MOAI_LOG_LEVEL` | Log verbosity (debug, info, warn, error) | `info` |
 | `MOAI_LOG_FORMAT` | Log output format (text, json) | `text` |
 | `MOAI_NO_COLOR` | Disable terminal colors | `false` |
-| `MOAI_RANK_API_URL` | Ranking API endpoint | Production URL |
+| `MOAI_DEVELOPMENT_MODE` | Override `quality.yaml` development mode | (unset -- file value wins) |
+| `MOAI_BRANCH_GUARD_EXEMPT` | Exempt a spawn from the main-checkout branch guard (set to `1`) | (unset -- guard active) |
+| `MOAI_SYNC_GATE_BLOCKING` | Make the sync-phase quality gate blocking (set to `1`) | advisory (`systemMessage` only) |
+| `CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH` | Cap subagent nesting depth (Claude Code runtime) | `3` on v2.1.219+ |
+| `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS` | Cap concurrent subagents (Claude Code runtime) | `20` |
+
+> `MOAI_USER_NAME` and `MOAI_CONVERSATION_LANG` are NOT implemented in v3.0 -- user / language come from `.moai/config/sections/user.yaml` and `language.yaml` only. The retired `MOAI_RANK_API_URL` is also gone (ranking subsystem retired).
 
 ---
 
@@ -244,7 +258,7 @@ Recommended gopls settings for the project:
 
 ### Test Framework
 
-**Standard `testing` package** only (testify was not used). All 20 test packages use Go's built-in test assertions.
+**Standard `testing` package** as the foundation, augmented at v3.0 by `github.com/stretchr/testify v1.11.1` for assertions. The test suite spans ~1000 `*_test.go` files (table-driven, `t.Parallel()` where safe, `t.TempDir()` for filesystem isolation, `-race` enforced in CI).
 
 ```
 go test -race -coverprofile=coverage.out -covermode=atomic ./...
@@ -375,9 +389,10 @@ The Go edition introduces formal contract testing for Claude Code hook integrati
 
 | Credential | Storage | Access Method |
 |------------|---------|---------------|
-| Ranking API token | System keyring (macOS Keychain, Linux secret-service) | `internal/rank/auth.go` |
 | Git credentials | System Git credential helper | System Git credential store |
 | LSP server tokens | Environment variables | `os.Getenv()` with validation |
+| GLM API token | `~/.moai/.env.glm` (local file) | `internal/cli/glm.go` `loadGLMKey()` |
+| Hook skip audit trail | `.moai/logs/hook-skip.log` (text log) | `MOAI_BRANCH_GUARD_EXEMPT=1` opt-out writes a record |
 
 ### Supply Chain Security
 
@@ -409,8 +424,9 @@ The Go edition introduces formal contract testing for Claude Code hook integrati
 
 - `pkg/version/`: External tools may query MoAI-ADK version
 - `pkg/models/`: External tools may need to parse MoAI-ADK data structures
-- `pkg/utils/`: General utilities that are stable and useful outside the project
 - Everything else: `internal/` (CLI commands, domain logic, LSP client, etc.)
+
+> v3.0 dropped the earlier `pkg/utils/` draft -- the v3.0 `pkg/` tree contains only `models` and `version`. General utilities (logging, path resolution, atomic file writes, validation) live in `internal/` packages or the standard library.
 
 **Impact**: Aggressive internalization allows breaking changes to implementation details without semver bumps on the module.
 


### PR DESCRIPTION
## Summary

Refreshes the 9 `.moai/project/` docs (6 codemaps + product/structure/tech) from the 2026-07-08 baseline to the 2026-07-29 v3.0 codebase. All numeric claims re-derived from code; an independent plan-auditor pass moved the verdict FAIL → PASS (18 defects fixed).

## Key drift fixes

- retained agents 8 → 11 (+ super-advisor, manager-design, e2e-tester)
- /moai commands 17 → 15 (brain/coverage/design gone; goal added)
- GLM `DefaultGLMHigh` `glm-5.2[1m]` → `glm-5.2` (no suffix; [1m] is launcher-layer)
- web port 3456 → 3041; hooks 28+ → 30 events (35 handle-*.sh)
- config loaders 19 → 14 `loader_*.go`; lsp 12 → 8 subpackages
- AddCommand 158 → 152 (non-test); packages 45 → 46; LOC ~40k → ~148k

Removed phantom references to non-existent packages (i18n/rank/ui/design/migrate/state/research) and the retired `brain` command.

## v3.0/v4 boundary

v4 design content (moai-pi-pack, multi-runtime, omp fork) stays in `.moai/reports/` only — **zero leakage** into these docs (grep verified: 0 hits).

## Verification

- 9 files updated 2026-07-29
- v4 keyword grep across .moai/project/: 0 hits
- plan-auditor independent audit: FAIL → PASS (MAJOR 5 + MINOR 13 defects fixed)

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated product and architecture documentation for the v3.0 release.
  - Clarified available CLI capabilities, including the new `/moai goal` workflow.
  - Documented 30 hook events and updated command and feature inventories.
  - Added guidance on worktree safety, branch protections, model routing, and multi-model workflows.
  - Updated server documentation to reflect the default loopback port of 3041.
  - Revised setup, environment, testing, security, and supported tooling guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->