### PR TITLE
fix(config): allow empty user.name so init/update/web run without a name

### DIFF
--- a/internal/config/manager_test.go
+++ b/internal/config/manager_test.go
@@ -99,7 +99,10 @@ func TestConfigManagerLoadDefaults(t *testing.T) {
 	}
 }
 
-func TestConfigManagerLoadValidationError(t *testing.T) {
+// TestConfigManagerLoadEmptyUserNameAllowed asserts that an empty user.name does
+// NOT fail ConfigManager.Load. An unset name is the normal "not yet set" state
+// (wizard/init/update/profile/sync.go all allow it), so the load must succeed.
+func TestConfigManagerLoadEmptyUserNameAllowed(t *testing.T) {
 	t.Parallel()
 
 	root := setupManagerTestDir(t, []string{"user.yaml"})
@@ -113,8 +116,8 @@ func TestConfigManagerLoadValidationError(t *testing.T) {
 
 	m := NewConfigManager()
 	_, err := m.Load(root)
-	if err == nil {
-		t.Fatal("Load() expected validation error for empty user.name")
+	if err != nil {
+		t.Errorf("Load() expected NO error for empty user.name, got: %v", err)
 	}
 }
 

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -38,9 +38,6 @@ func Validate(cfg *Config, loadedSections map[string]bool) error {
 	// or with existing custom checks are skipped inside runStructValidation.
 	errs = append(errs, runStructValidation(cfg, loadedSections)...)
 
-	// Check required fields for loaded sections
-	errs = append(errs, validateRequired(cfg, loadedSections)...)
-
 	// Check development mode
 	errs = append(errs, validateDevelopmentMode(cfg.Quality.DevelopmentMode)...)
 
@@ -101,21 +98,6 @@ func validateGLMBaseURL(baseURL string) []ValidationError {
 		return reject("URL has no host")
 	}
 	return nil
-}
-
-// validateRequired checks that required fields are populated for loaded sections.
-func validateRequired(cfg *Config, loadedSections map[string]bool) []ValidationError {
-	var errs []ValidationError
-
-	if loadedSections["user"] && cfg.User.Name == "" {
-		errs = append(errs, ValidationError{
-			Field:   "user.name",
-			Message: "required field is empty; set the user name in .moai/config/sections/user.yaml (example: name: YourName)",
-			Wrapped: ErrInvalidConfig,
-		})
-	}
-
-	return errs
 }
 
 // validateDevelopmentMode checks that the development mode is a valid value.
@@ -448,12 +430,6 @@ func runStructValidation(cfg *Config, loadedSections map[string]bool) []Validati
 		for _, fe := range ve {
 			ns := fe.Namespace()
 			tag := fe.Tag()
-
-			// User.Name required: skip here — handled by validateRequired which
-			// gates on loadedSections["user"].
-			if ns == "Config.User.Name" && tag == "required" {
-				continue
-			}
 
 			// DevelopmentMode oneof: skip here — handled by validateDevelopmentMode
 			// which wraps ErrInvalidDevelopmentMode expected by existing tests.

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -33,32 +33,20 @@ func TestValidateDefaultConfigNoLoadedSections(t *testing.T) {
 	}
 }
 
-func TestValidateRequiredUserNameWhenLoaded(t *testing.T) {
+// TestValidateUserNameEmptyAllowedWhenLoaded asserts the design contract that
+// an empty user.name is NOT an error, even when the user section is explicitly
+// loaded. The wizard (wizard/types.go "empty allowed"), init, update, and
+// profile/sync.go all treat an unset name as the normal "not yet set" state.
+func TestValidateUserNameEmptyAllowedWhenLoaded(t *testing.T) {
 	t.Parallel()
 
 	cfg := NewDefaultConfig()
-	// User section loaded but name is empty
+	// User section loaded but name is empty — empty is allowed.
 	loaded := map[string]bool{"user": true}
 
 	err := Validate(cfg, loaded)
-	if err == nil {
-		t.Fatal("Validate() expected error for empty user.name when user section loaded")
-	}
-
-	var ve *ValidationErrors
-	if !errors.As(err, &ve) {
-		t.Fatalf("expected *ValidationErrors, got %T", err)
-	}
-
-	found := false
-	for _, e := range ve.Errors {
-		if e.Field == "user.name" {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Error("expected validation error for field user.name")
+	if err != nil {
+		t.Errorf("Validate() expected NO error for empty user.name when user section loaded, got: %v", err)
 	}
 }
 
@@ -227,7 +215,6 @@ func TestValidateMultipleErrors(t *testing.T) {
 	t.Parallel()
 
 	cfg := NewDefaultConfig()
-	cfg.User.Name = "" // required when loaded
 	cfg.Quality.DevelopmentMode = "invalid_mode"
 	cfg.Quality.TestCoverageTarget = -1
 	loaded := map[string]bool{"user": true}
@@ -242,9 +229,10 @@ func TestValidateMultipleErrors(t *testing.T) {
 		t.Fatalf("expected *ValidationErrors, got %T", err)
 	}
 
-	// Should have at least 3 errors: user.name, development_mode, test_coverage_target
-	if len(ve.Errors) < 3 {
-		t.Errorf("expected at least 3 validation errors, got %d: %v", len(ve.Errors), ve.Errors)
+	// Should have at least 2 errors: development_mode, test_coverage_target
+	// (user.name is no longer required — empty is allowed).
+	if len(ve.Errors) < 2 {
+		t.Errorf("expected at least 2 validation errors, got %d: %v", len(ve.Errors), ve.Errors)
 	}
 }
 
@@ -647,40 +635,6 @@ func TestDevelopmentModeStrings(t *testing.T) {
 		if !expected[s] {
 			t.Errorf("unexpected mode string: %q", s)
 		}
-	}
-}
-
-// TestValidate_RequiredFieldMissing exercises the validator/v10 required path
-// for User.Name when the user section is explicitly loaded.
-// AC-05 hardening: validator now produces type errors for required-field-missing cases.
-func TestValidate_RequiredFieldMissing(t *testing.T) {
-	t.Parallel()
-
-	cfg := NewDefaultConfig()
-	// User.Name is empty — the validate:"required" tag on UserConfig.Name
-	// triggers the validator/v10 path (skipped by runStructValidation and
-	// delegated to the existing validateRequired custom check).
-	loaded := map[string]bool{"user": true}
-
-	err := Validate(cfg, loaded)
-	if err == nil {
-		t.Fatal("Validate() expected error when User.Name is empty and user section is loaded")
-	}
-
-	var ve *ValidationErrors
-	if !errors.As(err, &ve) {
-		t.Fatalf("expected *ValidationErrors, got %T: %v", err, err)
-	}
-
-	found := false
-	for _, e := range ve.Errors {
-		if e.Field == "user.name" {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Errorf("expected validation error for field user.name in: %v", ve.Errors)
 	}
 }
 

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -30,7 +30,10 @@ func (m DevelopmentMode) IsValid() bool {
 
 // UserConfig represents the user configuration section.
 type UserConfig struct {
-	Name string `yaml:"name" validate:"required"`
+	// Name is intentionally optional: the wizard (wizard/types.go, "empty allowed"),
+	// init, update, and profile/sync.go all treat an unset name as the normal
+	// "not yet set" state that may be populated later. Validation must NOT reject it.
+	Name string `yaml:"name"`
 }
 
 // LanguageConfig represents the language configuration section.


### PR DESCRIPTION
## Problem

A fresh project with an empty `user.yaml` `name` (the default "not yet set" state) failed `ConfigManager.Load`, which blocked `moai init` / `update` / `web`. `UserConfig.Name` carried both `validate:"required"` and a custom `validateRequired` gate that rejected an empty name whenever the `user` section was loaded.

## Why empty should be allowed

The wizard (`wizard/types.go`, "empty allowed"), `init`, `update`, and `profile`/`sync.go` all treat an unset name as the normal "not yet set" state that may be populated later. Validation rejecting it contradicts that contract.

## Changes (4 files)

- `pkg/models/config.go` — drop `validate:"required"` from `UserConfig.Name`
- `internal/config/validation.go` — remove `validateRequired` and the `User.Name` required-skip inside `runStructValidation`
- `internal/config/validation_test.go` + `internal/config/manager_test.go` — assert an empty `user.name` is allowed (no error) rather than required

## Verification

```
go build ./...                                              # exit 0
go test -count=1 ./internal/config/ ./pkg/models/           # ok
go test -count=1 ./internal/cli/                            # ok (157s)
go vet ./internal/config/... ./pkg/models/...               # exit 0
```

This is scoped strictly to the `user.name` change; unrelated worktree changes (gopls logging, post-sync header) are intentionally excluded and remain on the working tree.

🗿 MoAI