### PR TITLE
feat(SPEC-I18N-GOVERNANCE-001): web console i18n catalogue governance

### DIFF
--- a/.moai/specs/SPEC-I18N-GOVERNANCE-001/spec.md
+++ b/.moai/specs/SPEC-I18N-GOVERNANCE-001/spec.md
@@ -2,9 +2,9 @@
 id: SPEC-I18N-GOVERNANCE-001
 title: "Web Console i18n Catalogue Governance"
 version: "0.1.0"
-status: draft
+status: in-progress
 created: 2026-07-25
-updated: 2026-07-25
+updated: 2026-07-29
 author: manager-spec
 priority: P2
 phase: "v3.0.2 target"

--- a/internal/web/assets/i18n.js
+++ b/internal/web/assets/i18n.js
@@ -16,6 +16,13 @@
 // active-locale string. A key absent from a locale leaves the element's English
 // baseline text intact (it is never blanked). Loaded offline via go:embed — no
 // network fetch.
+//
+// Governance: untranslated values are governed by the allowlist artifact at
+// internal/web/i18n_untranslated_allowlist_test.go (SPEC-I18N-GOVERNANCE-001).
+// Any catalogue change — adding a key, editing, or translating a value — MUST
+// be reviewed against that contract: an intentionally-locale-invariant value
+// is recorded there with a taxonomy reason and justification, and any value
+// that admits no taxonomy reason is a translation defect to fix here.
 window.MOAI_I18N = {
   en: {
     // Agent-settings surface keys (frontmatter card + generic section).
@@ -520,7 +527,7 @@ window.MOAI_I18N = {
     "f.model_policy.title": "모델 정책",
     "f.model_policy.desc": "모델 자동 선택 시 품질과 속도의 균형입니다.",
     "f.model.title": "모델",
-    "f.model.desc": "The specific model to run.",
+    "f.model.desc": "실행할 특정 모델.",
     "f.model.opt.opus": "Opus 5",
     "f.model.opt.opus[1m]": "Opus 5",
     "f.model.opt.sonnet": "Sonnet 5",
@@ -561,7 +568,7 @@ window.MOAI_I18N = {
     "mp.subtitle": "읽기 전용 모델 라우팅 정책 (로컬 머신 · 루프백 전용)",
     "mp.tier.title": "활성 성능 티어",
     "mp.tier.desc": "llm.performance_tier — 라우팅 프로파일 선택자 (max/medium/low). Launch 섹션의 model_policy (init 시점 agent frontmatter 정책, high/medium/low)와 구분됨.",
-    "mp.tier.empty": "(runtime default: medium)",
+    "mp.tier.empty": "(런타임 기본값: medium)",
     "mp.tier.active": "활성 티어",
     "mp.tier.default": "(런타임 기본값: medium — llm.performance_tier 미설정)",
     "mp.tier.select": "성능 티어 전환",
@@ -573,7 +580,7 @@ window.MOAI_I18N = {
     "mp.col.tier": "티어",
     "mp.col.phase": "페이즈",
     "mp.col.model": "모델",
-    "mp.col.effort": "effort",
+    "mp.col.effort": "에포트",
     "mp.fallback": "(폴백)",
     "mp.plan.title": "플랜 타입",
     "mp.plan.desc": "llm.plan_type — 과금 컨텍스트 티어 프로파일 (api = API 종량제, subscription = 주간 쿼터). 전환하면 해당 model/effort 티어 매트릭스가 배포 에이전트에 다시 적용됩니다.",
@@ -884,7 +891,7 @@ window.MOAI_I18N = {
     "f.model_policy.title": "モデルポリシー",
     "f.model_policy.desc": "モデル自動選択時の品質と速度のバランスです。",
     "f.model.title": "モデル",
-    "f.model.desc": "The specific model to run.",
+    "f.model.desc": "実行する特定のモデル。",
     "f.model.opt.opus": "Opus 5",
     "f.model.opt.opus[1m]": "Opus 5",
     "f.model.opt.sonnet": "Sonnet 5",
@@ -925,7 +932,7 @@ window.MOAI_I18N = {
     "mp.subtitle": "読み取り専用のモデルルーティングポリシー（ローカルマシン・ループバック専用）",
     "mp.tier.title": "アクティブなパフォーマンスティア",
     "mp.tier.desc": "llm.performance_tier — ルーティングプロファイルセレクタ（max/medium/low）。Launch セクションの model_policy（init 時の agent frontmatter ポリシー、high/medium/low）とは別物。",
-    "mp.tier.empty": "(runtime default: medium)",
+    "mp.tier.empty": "(ランタイムデフォルト: medium)",
     "mp.tier.active": "アクティブティア",
     "mp.tier.default": "(ランタイムデフォルト: medium — llm.performance_tier 未設定)",
     "mp.tier.select": "パフォーマンスティアを切り替え",
@@ -937,7 +944,7 @@ window.MOAI_I18N = {
     "mp.col.tier": "ティア",
     "mp.col.phase": "フェーズ",
     "mp.col.model": "モデル",
-    "mp.col.effort": "effort",
+    "mp.col.effort": "エフォート",
     "mp.fallback": "(フォールバック)",
     "mp.plan.title": "プランタイプ",
     "mp.plan.desc": "llm.plan_type — 課金コンテキストのティアプロファイル (api = API 従量課金、subscription = 週次クォータ)。切り替えると対応する model/effort ティア行列が配布エージェントに再適用されます。",
@@ -1248,7 +1255,7 @@ window.MOAI_I18N = {
     "f.model_policy.title": "模型策略",
     "f.model_policy.desc": "自动选择模型时质量与速度的取向。",
     "f.model.title": "模型",
-    "f.model.desc": "The specific model to run.",
+    "f.model.desc": "要运行的具体模型。",
     "f.model.opt.opus": "Opus 5",
     "f.model.opt.opus[1m]": "Opus 5",
     "f.model.opt.sonnet": "Sonnet 5",
@@ -1289,7 +1296,7 @@ window.MOAI_I18N = {
     "mp.subtitle": "只读的模型路由策略（本地机器 · 仅回环）",
     "mp.tier.title": "当前性能层级",
     "mp.tier.desc": "llm.performance_tier — 路由配置选择器（max/medium/low）。区别于 Launch 部分的 model_policy（init 时的 agent frontmatter 策略，high/medium/low）。",
-    "mp.tier.empty": "(runtime default: medium)",
+    "mp.tier.empty": "(运行时默认: medium)",
     "mp.tier.active": "当前层级",
     "mp.tier.default": "(运行时默认: medium — llm.performance_tier 未设置)",
     "mp.tier.select": "切换性能层级",
@@ -1301,7 +1308,7 @@ window.MOAI_I18N = {
     "mp.col.tier": "层级",
     "mp.col.phase": "阶段",
     "mp.col.model": "模型",
-    "mp.col.effort": "effort",
+    "mp.col.effort": "努力度",
     "mp.fallback": "(回退)",
     "mp.plan.title": "计划类型",
     "mp.plan.desc": "llm.plan_type — 计费上下文的层级配置 (api = API 按量计费，subscription = 每周配额)。切换后会将对应的 model/effort 层级矩阵重新应用到已部署的代理。",

--- a/internal/web/i18n_governance_test.go
+++ b/internal/web/i18n_governance_test.go
@@ -1,0 +1,523 @@
+package web
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/unicode/norm"
+)
+
+// i18n_governance_test.go — the value-level governance suite for
+// internal/web/assets/i18n.js (SPEC-I18N-GOVERNANCE-001).
+//
+// This file owns the parser (REQ-I18NGOV-007), the pure-function detector
+// (REQ-I18NGOV-008/009/010/011), the orphan check (REQ-I18NGOV-015), the
+// endonym invariants (REQ-I18NGOV-012/013/014), the key-coverage checks
+// (REQ-I18NGOV-018/019), the shape guard (REQ-I18NGOV-002..005/016), the
+// governance-contract presence check (REQ-I18NGOV-006/021/023), the
+// special-character-key parse test (REQ-I18NGOV-007), and the negative control
+// (REQ-I18NGOV-017).
+//
+// All symbols here are test-binary only; the shipped console binary is
+// byte-unaffected (C4).
+
+// i18nLocaleOrder is the fixed four-locale order the catalogue carries.
+var i18nLocaleOrder = []string{"en", "ko", "ja", "zh"}
+
+// i18nNonEnLocales is every locale except en.
+var i18nNonEnLocales = []string{"ko", "ja", "zh"}
+
+// i18nLangOptPrefix is the endonym family delegated to the endonym invariants
+// rather than the generic identity comparison (REQ-I18NGOV-011).
+const i18nLangOptPrefix = "lang.opt."
+
+// i18nKVRegexp matches a quoted catalogue key, its separating colon, and a
+// quoted value that may contain backslash-escaped characters. The key class is
+// "any character except a double quote" so keys containing '+', '[', ']', and
+// '.' all parse (REQ-I18NGOV-007, plan §B4).
+var i18nKVRegexp = regexp.MustCompile(`"([^"]+)"\s*:\s*"((?:[^"\\]|\\.)*)"`)
+
+// parseI18nCatalogue parses the window.MOAI_I18N object literal into a
+// per-locale key→value map. It splits the four locale blocks by their top-level
+// markers, then within each block extracts "key": "value" pairs, tolerating
+// backslash-escaped characters in values (REQ-I18NGOV-007). It is a pure
+// function of its input so callers may pass a synthetic catalogue without
+// touching the shipped file (REQ-I18NGOV-008).
+func parseI18nCatalogue(dict string) (map[string]map[string]string, error) {
+	// Locate each top-level locale block by its "\n  <loc>: {" marker.
+	idx := make(map[string]int, len(i18nLocaleOrder))
+	for _, loc := range i18nLocaleOrder {
+		marker := "\n  " + loc + ": {"
+		i := strings.Index(dict, marker)
+		if i < 0 {
+			return nil, fmt.Errorf("i18n catalogue has no %q locale block", loc)
+		}
+		idx[loc] = i
+	}
+	out := make(map[string]map[string]string, len(i18nLocaleOrder))
+	for n, loc := range i18nLocaleOrder {
+		start := idx[loc] + len("\n  "+loc+": {")
+		end := len(dict)
+		if n+1 < len(i18nLocaleOrder) {
+			end = idx[i18nLocaleOrder[n+1]]
+		}
+		block := dict[start:end]
+		out[loc] = parseI18nBlock(block)
+	}
+	return out, nil
+}
+
+// parseI18nBlock extracts the key→value pairs from one locale block's body.
+func parseI18nBlock(block string) map[string]string {
+	m := make(map[string]string)
+	for _, mt := range i18nKVRegexp.FindAllStringSubmatch(block, -1) {
+		m[mt[1]] = i18nUnescapeValue(mt[2])
+	}
+	return m
+}
+
+// i18nUnescapeValue expands the common JS string escape sequences so a value
+// carrying a quote / backslash / newline is compared against its true string
+// form. No value in the shipped catalogue currently contains an escape, but the
+// parser must tolerate a future translation that introduces one (plan §B4).
+func i18nUnescapeValue(raw string) string {
+	if !strings.ContainsRune(raw, '\\') {
+		return raw
+	}
+	var b strings.Builder
+	b.Grow(len(raw))
+	for i := 0; i < len(raw); i++ {
+		if raw[i] != '\\' {
+			b.WriteByte(raw[i])
+			continue
+		}
+		if i+1 >= len(raw) {
+			b.WriteByte('\\')
+			break
+		}
+		i++
+		switch raw[i] {
+		case '"':
+			b.WriteByte('"')
+		case '\\':
+			b.WriteByte('\\')
+		case 'n':
+			b.WriteByte('\n')
+		case 't':
+			b.WriteByte('\t')
+		case 'r':
+			b.WriteByte('\r')
+		case '/':
+			b.WriteByte('/')
+		default:
+			b.WriteByte('\\')
+			b.WriteByte(raw[i])
+		}
+	}
+	return b.String()
+}
+
+// i18nNormalize applies the REQ-I18NGOV-009 normalization: Unicode NFC
+// composition, surrounding-whitespace trimming, and Unicode case folding.
+func i18nNormalize(s string) string {
+	folder := cases.Fold()
+	return folder.String(norm.NFC.String(strings.TrimSpace(s)))
+}
+
+// i18nViolation is one untranslated-value finding.
+type i18nViolation struct {
+	Key        string
+	Locale     string
+	EnValue    string
+	LocaleValue string
+}
+
+// detectI18nUntranslated is the pure-function detector (REQ-I18NGOV-008). For
+// every non-en locale it compares each value (that also exists in en) to its en
+// counterpart under NFC + trim + casefold normalization, excluding the
+// lang.opt.* family (REQ-I18NGOV-011) and every allowlisted key. It returns one
+// violation per (key, locale) that is normalized-identical yet neither excluded
+// nor allowlisted (REQ-I18NGOV-010).
+func detectI18nUntranslated(cat map[string]map[string]string, allowlist []i18nAllowEntry) []i18nViolation {
+	allowed := make(map[string]struct{}, len(allowlist))
+	for _, e := range allowlist {
+		allowed[e.Key] = struct{}{}
+	}
+	en := cat["en"]
+	var out []i18nViolation
+	for _, loc := range i18nNonEnLocales {
+		block, ok := cat[loc]
+		if !ok {
+			continue
+		}
+		for k, v := range block {
+			env, present := en[k]
+			if !present {
+				continue // reverse-coverage handles en-absent keys separately.
+			}
+			if strings.HasPrefix(k, i18nLangOptPrefix) {
+				continue // endonym family — structural invariant, not identity.
+			}
+			if _, ok := allowed[k]; ok {
+				continue
+			}
+			if i18nNormalize(v) == i18nNormalize(env) {
+				out = append(out, i18nViolation{Key: k, Locale: loc, EnValue: env, LocaleValue: v})
+			}
+		}
+	}
+	return out
+}
+
+// detectI18nOrphans returns allowlist entries that no longer earn their place:
+// their key is absent from the catalogue, or its value is not identical to en
+// in ANY non-en locale (the key was deleted or later translated)
+// (REQ-I18NGOV-015).
+func detectI18nOrphans(cat map[string]map[string]string, allowlist []i18nAllowEntry) []i18nAllowEntry {
+	en := cat["en"]
+	var out []i18nAllowEntry
+	for _, e := range allowlist {
+		if _, ok := en[e.Key]; !ok {
+			out = append(out, e)
+			continue
+		}
+		env := en[e.Key]
+		matched := false
+		for _, loc := range i18nNonEnLocales {
+			if v, ok := cat[loc][e.Key]; ok && i18nNormalize(v) == i18nNormalize(env) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// shippedI18nCatalogue loads and parses the embedded i18n.js, failing the test
+// if the catalogue cannot be parsed. Every real-catalogue test calls this once.
+func shippedI18nCatalogue(t *testing.T) map[string]map[string]string {
+	t.Helper()
+	dict := readEmbeddedAsset(t, "i18n.js")
+	cat, err := parseI18nCatalogue(dict)
+	if err != nil {
+		t.Fatalf("parse shipped i18n.js: %v", err)
+	}
+	return cat
+}
+
+// --- AC-I18NGOV-001: detector is green on the real catalogue (007..011) ---
+
+func TestI18nUntranslatedValues(t *testing.T) {
+	cat := shippedI18nCatalogue(t)
+	viol := detectI18nUntranslated(cat, i18nUntranslatedAllowlist)
+	for _, v := range viol {
+		t.Errorf("untranslated value: locale=%s key=%s en=%q locale=%q", v.Locale, v.Key, v.EnValue, v.LocaleValue)
+	}
+}
+
+// --- AC-I18NGOV-002: negative control — a non-allowlisted untranslated key
+// fails, and the identical input passes once allowlisted (008, 017) ---
+
+func TestI18nUntranslatedDetectorNegativeControl(t *testing.T) {
+	// Synthetic catalogue with an inert placeholder key + a short interface
+	// word. Contains no secret-shaped or key-shaped literal (C2).
+	synthetic := strings.Join([]string{
+		"window.MOAI_I18N = {",
+		"  en: {",
+		`    "syn.placeholder.key": "Refresh",`,
+		`    "syn.word.save": "Save",`,
+		"  },",
+		"  ko: {",
+		`    "syn.placeholder.key": "Refresh",`, // identical to en — not allowlisted → violation
+		`    "syn.word.save": "저장",`,           // genuinely translated → no violation
+		"  },",
+		"  ja: {",
+		`    "syn.placeholder.key": "Refresh",`,
+		`    "syn.word.save": "保存",`,
+		"  },",
+		"  zh: {",
+		`    "syn.placeholder.key": "Refresh",`,
+		`    "syn.word.save": "保存",`,
+		"  },",
+		"}",
+		"",
+	}, "\n")
+	cat, err := parseI18nCatalogue(synthetic)
+	if err != nil {
+		t.Fatalf("parse synthetic catalogue: %v", err)
+	}
+
+	// With an EMPTY allowlist the placeholder key must produce a violation in
+	// every non-en locale (proves the detector is not a rubber stamp).
+	violEmpty := detectI18nUntranslated(cat, nil)
+	if len(violEmpty) == 0 {
+		t.Fatal("detector reported zero violations on a synthetic untranslated key — the allowlist gate is not falsifiable")
+	}
+	sawPlaceholder := false
+	for _, v := range violEmpty {
+		if v.Key == "syn.placeholder.key" {
+			sawPlaceholder = true
+			if v.Locale != "ko" && v.Locale != "ja" && v.Locale != "zh" {
+				t.Errorf("violation named a non-en locale %q for the placeholder key", v.Locale)
+			}
+		}
+	}
+	if !sawPlaceholder {
+		t.Errorf("no violation named the placeholder key syn.placeholder.key; got %v", violEmpty)
+	}
+
+	// With the placeholder key allowlisted, the identical catalogue must report
+	// zero violations.
+	allowWithPlaceholder := []i18nAllowEntry{
+		{Key: "syn.placeholder.key", Reason: reasonTechnicalIdentifier, Justification: "inert synthetic test key"},
+	}
+	if v := detectI18nUntranslated(cat, allowWithPlaceholder); len(v) != 0 {
+		t.Errorf("allowlisting the key did not suppress the violation; got %v", v)
+	}
+}
+
+// --- AC-I18NGOV-003: allowlist has no orphan entries (015) ---
+
+func TestI18nAllowlistNoOrphans(t *testing.T) {
+	cat := shippedI18nCatalogue(t)
+	orphans := detectI18nOrphans(cat, i18nUntranslatedAllowlist)
+	for _, o := range orphans {
+		t.Errorf("orphan allowlist entry: key=%s reason=%s — key is absent or no longer identical to en in any locale", o.Key, o.Reason)
+	}
+}
+
+// --- AC-I18NGOV-004: allowlist shape — exact keys, closed taxonomy, bounded
+// size (002..005, 016) ---
+
+func TestI18nAllowlistShape(t *testing.T) {
+	seen := make(map[string]struct{}, len(i18nUntranslatedAllowlist))
+	for _, e := range i18nUntranslatedAllowlist {
+		if _, dup := seen[e.Key]; dup {
+			t.Errorf("duplicate allowlist entry for key %q", e.Key)
+		}
+		seen[e.Key] = struct{}{}
+
+		// No wildcard / glob pattern in the key (REQ-I18NGOV-004). Only the
+		// unambiguous glob wildcards '*' and '?' are rejected: '.', '+', '[',
+		// ']' appear in legitimate exact catalogue keys (plan §B4 —
+		// f.report.format.opt.html+md, f.model.opt.*[1m]) and are not pattern
+		// indicators in this dotted-key namespace.
+		for _, bad := range []string{"*", "?"} {
+			if strings.Contains(e.Key, bad) {
+				t.Errorf("allowlist key %q contains forbidden wildcard %q", e.Key, bad)
+			}
+		}
+
+		// No lang.opt.* key in the allowlist (REQ-I18NGOV-014).
+		if strings.HasPrefix(e.Key, i18nLangOptPrefix) {
+			t.Errorf("allowlist carries a lang.opt.* key %q — the endonym family is handled structurally", e.Key)
+		}
+
+		// Non-empty justification (REQ-I18NGOV-002).
+		if strings.TrimSpace(e.Justification) == "" {
+			t.Errorf("allowlist entry for %q has an empty justification", e.Key)
+		}
+
+		// Reason is a member of the closed taxonomy (REQ-I18NGOV-003).
+		if _, ok := i18nAllowReasons[e.Reason]; !ok {
+			t.Errorf("allowlist entry for %q has reason %q outside the closed taxonomy %v", e.Key, e.Reason, i18nAllowReasons)
+		}
+	}
+
+	// Entry cap (REQ-I18NGOV-016).
+	if n := len(i18nUntranslatedAllowlist); n > i18nMaxAllowlistEntries {
+		t.Errorf("allowlist has %d entries, exceeding the cap of %d", n, i18nMaxAllowlistEntries)
+	}
+
+	// The closed taxonomy is exactly the three documented reasons.
+	wantReasons := map[i18nAllowReason]struct{}{
+		reasonTechnicalIdentifier: {},
+		reasonProperNoun:          {},
+		reasonAcronym:             {},
+	}
+	if len(i18nAllowReasons) != len(wantReasons) {
+		t.Errorf("closed taxonomy has %d reasons, expected %d", len(i18nAllowReasons), len(wantReasons))
+	}
+	for r := range wantReasons {
+		if _, ok := i18nAllowReasons[r]; !ok {
+			t.Errorf("closed taxonomy is missing reason %q", r)
+		}
+	}
+}
+
+// --- AC-I18NGOV-005: endonym family is correct by construction (012..014) ---
+
+func TestI18nEndonymInvariants(t *testing.T) {
+	cat := shippedI18nCatalogue(t)
+	en := cat["en"]
+
+	// REQ-I18NGOV-012: self-consistency — lang.opt.<L> in locale L equals its
+	// en value (both render the endonym).
+	for _, loc := range i18nLocaleOrder {
+		key := i18nLangOptPrefix + loc
+		enV, ok := en[key]
+		if !ok {
+			t.Errorf("en locale has no %q key — endonym baseline missing", key)
+			continue
+		}
+		locV, ok := cat[loc][key]
+		if !ok {
+			t.Errorf("locale %q has no own %q key", loc, key)
+			continue
+		}
+		if i18nNormalize(locV) != i18nNormalize(enV) {
+			t.Errorf("endonym self-consistency failed: lang.opt.%s in %s = %q, en = %q", loc, loc, locV, enV)
+		}
+	}
+
+	// REQ-I18NGOV-013: exonym distinctness — for a NON-en locale L and language
+	// X != L, lang.opt.<X> in L differs from its en value (locale L renders the
+	// exonym; en is the endonym baseline and is trivially equal to itself, so
+	// it is excluded from this direction).
+	for _, loc := range i18nNonEnLocales {
+		for _, x := range i18nLocaleOrder {
+			if x == loc {
+				continue
+			}
+			key := i18nLangOptPrefix + x
+			enV, ok := en[key]
+			if !ok {
+				continue
+			}
+			locV, ok := cat[loc][key]
+			if !ok {
+				t.Errorf("locale %q is missing %q (forward coverage is tested separately)", loc, key)
+				continue
+			}
+			if i18nNormalize(locV) == i18nNormalize(enV) {
+				t.Errorf("exonym distinctness failed: lang.opt.%s in %s = %q equals its en value %q", x, loc, locV, enV)
+			}
+		}
+	}
+}
+
+// --- AC-I18NGOV-006: forward key coverage (018) ---
+
+func TestI18nKeyCoverageForward(t *testing.T) {
+	cat := shippedI18nCatalogue(t)
+	en := cat["en"]
+	for _, loc := range i18nNonEnLocales {
+		for k := range en {
+			if _, ok := cat[loc][k]; !ok {
+				t.Errorf("locale %q is missing en key %q", loc, k)
+			}
+		}
+	}
+}
+
+// --- AC-I18NGOV-007: reverse key coverage modulo the exempt registry
+// (019, 020) ---
+
+func TestI18nKeyCoverageReverse(t *testing.T) {
+	cat := shippedI18nCatalogue(t)
+	en := cat["en"]
+	for _, loc := range i18nNonEnLocales {
+		for k := range cat[loc] {
+			if _, ok := en[k]; ok {
+				continue
+			}
+			if !i18nMatchesExemptPrefix(k) {
+				t.Errorf("locale %q defines key %q absent from en and matching no exempt prefix", loc, k)
+			}
+		}
+	}
+	// The registry must be non-empty and every member justified.
+	if len(i18nEnExemptPrefixes) == 0 {
+		t.Error("en-exempt prefix registry is empty")
+	}
+	for _, p := range i18nEnExemptPrefixes {
+		if strings.TrimSpace(p.Prefix) == "" || strings.TrimSpace(p.Justification) == "" {
+			t.Errorf("exempt-prefix registry entry %+v has an empty prefix or justification", p)
+		}
+	}
+}
+
+// i18nMatchesExemptPrefix reports whether key begins with any registered
+// en-exempt prefix (REQ-I18NGOV-019/020).
+func i18nMatchesExemptPrefix(key string) bool {
+	for _, p := range i18nEnExemptPrefixes {
+		if strings.HasPrefix(key, p.Prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// --- AC-I18NGOV-008: parser reads special-character keys (007) ---
+
+func TestI18nParserSpecialKeys(t *testing.T) {
+	cat := shippedI18nCatalogue(t)
+	specials := []string{
+		"f.report.format.opt.html+md",
+		"f.model.opt.opus[1m]",
+		"f.model.opt.sonnet[1m]",
+		"f.model.opt.fable[1m]",
+	}
+	for _, k := range specials {
+		v, ok := cat["en"][k]
+		if !ok {
+			t.Errorf("parser dropped special key %q from the en locale", k)
+			continue
+		}
+		if strings.TrimSpace(v) == "" {
+			t.Errorf("special key %q parsed to an empty value", k)
+		}
+	}
+}
+
+// --- AC-I18NGOV-009: governance contract and named owner are present
+// (001, 006, 021, 023) ---
+
+func TestI18nGovernanceContractPresent(t *testing.T) {
+	// The allowlist artifact carries an inline governance contract naming its
+	// location, entry format, who adds an entry, the reviewer assertion, and
+	// the ruling procedure (REQ-I18NGOV-006/023). Those headings live in this
+	// file's doc comment — assert their tokens are present so the contract
+	// cannot be silently deleted.
+	allowSrc := readTestSource(t, "i18n_untranslated_allowlist_test.go")
+	for _, token := range []string{
+		"Governance contract",
+		"Entry form",
+		"Who adds",
+		"Reviewer assertion",
+		"Ruling procedure",
+	} {
+		if !strings.Contains(allowSrc, token) {
+			t.Errorf("allowlist governance contract is missing the %q section", token)
+		}
+	}
+
+	// The i18n.js header names the allowlist artifact path as the owning
+	// governance surface (REQ-I18NGOV-021).
+	dict := readEmbeddedAsset(t, "i18n.js")
+	if !strings.Contains(dict, "i18n_untranslated_allowlist") {
+		t.Error("i18n.js header does not name the i18n_untranslated_allowlist governance surface")
+	}
+}
+
+// readTestSource reads a test-file's own source so a test can assert on its
+// doc-comment contract without duplicating the contract text.
+func readTestSource(t *testing.T, name string) string {
+	t.Helper()
+	src, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatalf("read test source %q: %v", name, err)
+	}
+	return string(src)
+}
+
+// --- AC-I18NGOV-011 is structurally asserted by `go build ./...` and
+// `GOOS=windows GOARCH=amd64 go build ./...` both succeeding (no production
+// symbol added); the run-phase report quotes their verbatim output. ---

--- a/internal/web/i18n_untranslated_allowlist_test.go
+++ b/internal/web/i18n_untranslated_allowlist_test.go
@@ -1,0 +1,247 @@
+package web
+
+// i18n_untranslated_allowlist_test.go — the untranslated-value allowlist for
+// internal/web/assets/i18n.js.
+//
+// ─── Governance contract (REQ-I18NGOV-001 / 006 / 023) ────────────────────────
+//
+// Location:   this file (internal/web/i18n_untranslated_allowlist_test.go),
+//             co-located with the console package and OUTSIDE
+//             internal/web/assets/ so the /static/ handler never serves it
+//             (REQ-I18NGOV-001). Test-binary only — the shipped console binary
+//             is byte-unaffected (C4).
+//
+// Entry form: each entry carries three fields —
+//               • Key          the exact catalogue key (no wildcards / globs /
+//                              regex metacharacters; REQ-I18NGOV-004). One
+//                              entry applies to EVERY non-en locale
+//                              (REQ-I18NGOV-005).
+//               • Reason       one of the closed taxonomy below
+//                              (REQ-I18NGOV-003). An invented reason fails to
+//                              compile, not merely fails a test.
+//               • Justification why the value is locale-invariant, citing the
+//                              mechanical evidence (config value, CLI token,
+//                              model/vendor/convention name, …).
+//
+// Who adds:   a contributor who has measured a key's value identical to its en
+//             counterpart under NFC + trim + casefold normalization in at least
+//             one non-en locale, and who can classify the value against the
+//             closed taxonomy with mechanical evidence.
+//
+// Reviewer assertion: before accepting an entry the reviewer confirms that (a)
+//             the key is genuinely locale-invariant by intent rather than an
+//             untranslated defect, (b) no taxonomy-short English-prose value is
+//             being rubber-stamped (prose whose siblings are translated is a
+//             translation fix, not an allowlist entry), and (c) the entry cap
+//             of 30 (REQ-I18NGOV-016) is not exceeded.
+//
+// Ruling procedure (REQ-I18NGOV-023) for a borderline value:
+//             1. Re-measure the key against en under NFC + trim + casefold.
+//             2. Attempt to classify against the closed taxonomy:
+//                  technical-identifier | proper-noun | acronym.
+//             3. If a taxonomy reason fits with mechanical evidence, record the
+//                entry here with the justification.
+//             4. If no taxonomy reason fits (the value is English prose, a
+//                sentence, or a label whose siblings are translated), the value
+//                is a translation defect: fix it in i18n.js instead.
+//
+// Anti-rubber-stamp: the detector is a pure function over (catalogue,
+//             allowlist); a negative-control test proves a non-allowlisted
+//             untranslated key fails. An orphan check removes any entry whose
+//             key was deleted or later translated.
+//
+// Owning surface pointer: internal/web/assets/i18n.js header names this file
+//             as the governance surface (REQ-I18NGOV-021).
+
+// i18nAllowReason is the closed taxonomy of reasons a catalogue value is
+// intentionally locale-invariant (REQ-I18NGOV-003). It is a Go type so that an
+// invented reason fails to compile before any test runs.
+type i18nAllowReason string
+
+const (
+	// reasonTechnicalIdentifier: the value must match a configuration value,
+	// CLI token, or machine-emitted string byte-for-byte.
+	reasonTechnicalIdentifier i18nAllowReason = "technical-identifier"
+	// reasonProperNoun: a product, brand, vendor, model, or convention name.
+	reasonProperNoun i18nAllowReason = "proper-noun"
+	// reasonAcronym: a locale-invariant initialism.
+	reasonAcronym i18nAllowReason = "acronym"
+)
+
+// i18nAllowReasons is the closed set — membership is asserted by
+// TestI18nAllowlistShape so adding a fourth reason is a reviewed act.
+var i18nAllowReasons = map[i18nAllowReason]struct{}{
+	reasonTechnicalIdentifier: {},
+	reasonProperNoun:          {},
+	reasonAcronym:             {},
+}
+
+// i18nAllowEntry is one allowlist row (REQ-I18NGOV-002).
+type i18nAllowEntry struct {
+	Key           string
+	Reason        i18nAllowReason
+	Justification string
+}
+
+// i18nUntranslatedAllowlist is the single, exhaustive registry of catalogue
+// keys whose non-en value is intentionally identical to the en value. Every
+// member was re-measured at run-phase entry; the two identity-set members that
+// admit no taxonomy reason — mp.tier.empty and f.model.desc (English prose whose
+// siblings are translated) — were translated in i18n.js rather than listed here.
+//
+// The lang.opt.* endonym family is NOT listed here: it is handled structurally
+// by the endonym invariants (REQ-I18NGOV-012/013) and is explicitly forbidden
+// from this allowlist (REQ-I18NGOV-014).
+var i18nUntranslatedAllowlist = []i18nAllowEntry{
+	// Severity literal — the console badge must read the token the CLI/JSON emit.
+	{
+		Key:           "board.badge.mustfix",
+		Reason:        reasonTechnicalIdentifier,
+		Justification: "the MUST-FIX Severity value emitted by internal/spec/audit.go and matched by internal/web/board.go and internal/cli/spec_audit.go; the console badge must read the same token a user greps from `moai spec audit --json`.",
+	},
+	// session_ttl duration / sentinel literals (config enum values).
+	{
+		Key:           "f.cacheStrategy.session_ttl.opt.1h",
+		Reason:        reasonTechnicalIdentifier,
+		Justification: "duration literal matching the session_ttl configuration value byte-for-byte.",
+	},
+	{
+		Key:           "f.cacheStrategy.session_ttl.opt.5m",
+		Reason:        reasonTechnicalIdentifier,
+		Justification: "duration literal matching the session_ttl configuration value byte-for-byte.",
+	},
+	{
+		Key:           "f.cacheStrategy.session_ttl.opt.off",
+		Reason:        reasonTechnicalIdentifier,
+		Justification: "sentinel value that disables the session cache; translating it would diverge from the config enum.",
+	},
+	// Git-convention brand names.
+	{
+		Key:           "f.git_convention.opt.angular",
+		Reason:        reasonProperNoun,
+		Justification: "Angular commit-convention brand name.",
+	},
+	{
+		Key:           "f.git_convention.opt.conventional-commits",
+		Reason:        reasonProperNoun,
+		Justification: "Conventional Commits convention name.",
+	},
+	{
+		Key:           "f.git_convention.opt.karma",
+		Reason:        reasonProperNoun,
+		Justification: "Karma test-runner convention name.",
+	},
+	// handoff.mode config enum values.
+	{
+		Key:           "f.handoff.mode.opt.auto",
+		Reason:        reasonTechnicalIdentifier,
+		Justification: "handoff.mode configuration enum value.",
+	},
+	{
+		Key:           "f.handoff.mode.opt.manual",
+		Reason:        reasonTechnicalIdentifier,
+		Justification: "handoff.mode configuration enum value.",
+	},
+	// Anthropic model names (product/brand names).
+	{
+		Key:           "f.model.opt.fable",
+		Reason:        reasonProperNoun,
+		Justification: "Anthropic Fable model name.",
+	},
+	{
+		Key:           "f.model.opt.fable[1m]",
+		Reason:        reasonProperNoun,
+		Justification: "Anthropic Fable model name, 1M-context variant selector.",
+	},
+	{
+		Key:           "f.model.opt.haiku",
+		Reason:        reasonProperNoun,
+		Justification: "Anthropic Haiku model name.",
+	},
+	{
+		Key:           "f.model.opt.opus",
+		Reason:        reasonProperNoun,
+		Justification: "Anthropic Opus model name.",
+	},
+	{
+		Key:           "f.model.opt.opus[1m]",
+		Reason:        reasonProperNoun,
+		Justification: "Anthropic Opus model name, 1M-context variant selector.",
+	},
+	{
+		Key:           "f.model.opt.sonnet",
+		Reason:        reasonProperNoun,
+		Justification: "Anthropic Sonnet model name.",
+	},
+	{
+		Key:           "f.model.opt.sonnet[1m]",
+		Reason:        reasonProperNoun,
+		Justification: "Anthropic Sonnet model name, 1M-context variant selector.",
+	},
+	// report.format config enum literals.
+	{
+		Key:           "f.report.format.opt.html+md",
+		Reason:        reasonTechnicalIdentifier,
+		Justification: "report.format configuration enum literal emitted by the HTML report skill.",
+	},
+	{
+		Key:           "f.report.format.opt.md",
+		Reason:        reasonTechnicalIdentifier,
+		Justification: "report.format configuration enum literal.",
+	},
+	// Anthropic model family names (v4 surface).
+	{
+		Key:           "f.v4.model.opt.haiku",
+		Reason:        reasonProperNoun,
+		Justification: "Anthropic Haiku model family name.",
+	},
+	{
+		Key:           "f.v4.model.opt.opus",
+		Reason:        reasonProperNoun,
+		Justification: "Anthropic Opus model family name.",
+	},
+	{
+		Key:           "f.v4.model.opt.sonnet",
+		Reason:        reasonProperNoun,
+		Justification: "Anthropic Sonnet model family name.",
+	},
+	// Locale-invariant initialism.
+	{
+		Key:           "sec.launch.title",
+		Reason:        reasonAcronym,
+		Justification: "LLM is a locale-invariant initialism.",
+	},
+	// Product feature name.
+	{
+		Key:           "sec.ralph.title",
+		Reason:        reasonProperNoun,
+		Justification: "MoAI-Loop product feature name.",
+	},
+}
+
+// i18nMaxAllowlistEntries bounds the allowlist so blanket growth fails loudly
+// rather than accreting silently (REQ-I18NGOV-016). Derived from the 23 measured
+// legitimate members plus headroom.
+const i18nMaxAllowlistEntries = 30
+
+// i18nExemptPrefix is one row of the en-exempt prefix registry
+// (REQ-I18NGOV-020): a key prefix that is legitimately present in a non-en
+// locale but absent from en, with the surface that supplies the English
+// baseline instead.
+type i18nExemptPrefix struct {
+	Prefix        string
+	Justification string
+}
+
+// i18nEnExemptPrefixes is the explicit, enumerated registry of key prefixes
+// that may appear in non-en locales without an en counterpart. Its sole initial
+// member is agentdesc. (REQ-I18NGOV-020, C1): English reads the agent .md
+// frontmatter description as the server-rendered baseline, and applyI18n guards
+// its assignment on a non-empty string so an absent key leaves that baseline
+// intact. Adding a prefix is a reviewed act, not a silent one.
+var i18nEnExemptPrefixes = []i18nExemptPrefix{
+	{
+		Prefix:        "agentdesc.",
+		Justification: "English reads the agent .md frontmatter description (the SSOT) as the server-rendered baseline; applyI18n leaves the node untouched when the key is absent, so an en copy would duplicate the .md text into a second surface that silently goes stale.",
+	},
+}


### PR DESCRIPTION
## Summary

SPEC-I18N-GOVERNANCE-001 run-phase (Epic B2, Tier M, cycle_type=tdd). Adds value-level i18n governance to `internal/web/assets/i18n.js`: an explicit allowlist of intentionally-untranslated keys, a pure-function detector, structural endonym invariants, bidirectional key-coverage checks, and a named owning surface. No runtime behavior change — all artifacts are consumed by tests only.

## What changed

- **`internal/web/i18n_untranslated_allowlist_test.go`** (new) — typed allowlist slice with a closed reason taxonomy (`technical-identifier` / `proper-noun` / `acronym` as a Go enum so an invented reason fails to compile), the `agentdesc.` en-exempt prefix registry, and the inline governance contract (location / entry form / who adds / reviewer assertion / ruling procedure).
- **`internal/web/i18n_governance_test.go`** (new) — locale-block parser (reads `+`/`[`/`]` keys, tolerates escapes), pure-function detector (NFC + trim + casefold), orphan check, bidirectional endonym invariants, forward/reverse key coverage, negative control, shape guard, special-key parse test, governance-contract presence test.
- **`internal/web/assets/i18n.js`** — header owner line naming the allowlist artifact; 9 translation fixes (3 keys × 3 locales) for identity-set members that admit no taxonomy reason.

## M1 rulings

23 identity-set members allowlisted with taxonomy reasons. 3 members translated (no taxonomy reason fits — English prose whose siblings are translated):
- `mp.tier.empty` `"(runtime default: medium)"` → per plan §F M1
- `mp.col.effort` `"Effort"` → per plan §B3 (sibling columns translated)
- `f.model.desc` `"The specific model to run."` → discovered at run-phase re-measure: this key was not in the plan-phase identity set (which counted 25/locale; actual is 26/locale) and fits none of §A.2's legitimate-invariant categories, so per REQ-I18NGOV-023's ruling procedure it is a translation defect, not an allowlist entry.

The `lang.opt.*` endonym family is handled structurally (bidirectional invariant) and is absent from the allowlist.

## Verification (observed)

- `go test ./internal/web/...` → ok (all 9 governance ACs + pre-existing suite green)
- `go test -run 'TestD3AgentDesc' ./internal/web/ -v` → both pass unmodified (C1)
- `go build ./...` → exit 0
- `GOOS=windows GOARCH=amd64 go build ./...` → exit 0
- `golangci-lint run ./internal/web/...` → 0 issues
- `go vet ./internal/web/` → clean
- `git diff --name-only | grep -v '_test\.go$'` → `internal/web/assets/i18n.js` only (C4: no production symbol added)
- `moai spec lint` → no findings

sync-phase is separate.

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Korean, Japanese, and Chinese translations for model descriptions, marketplace tier labels, and effort indicators.
  * Added safeguards to identify missing, untranslated, or inconsistent localization entries.
* **Documentation**
  * Added governance guidance for reviewing intentional untranslated values.
  * Updated the localization governance specification status and revision date.
* **Tests**
  * Added comprehensive checks for translation coverage, consistency, allowlisted terms, and localization catalog integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->