### PR TITLE
docs(SPEC-V3R6-CI-FLAKY-STABILIZE-003): sync §A Status table to actual 3-phase completion

### DIFF
--- a/.moai/specs/SPEC-V3R6-CI-FLAKY-STABILIZE-003/progress.md
+++ b/.moai/specs/SPEC-V3R6-CI-FLAKY-STABILIZE-003/progress.md
@@ -8,9 +8,9 @@
 
 | Phase | State | Owner |
 |-------|-------|-------|
-| Plan | complete (pending audit + Implementation Kickoff Approval) | manager-spec |
-| Run | not started | manager-develop |
-| Sync | not started | manager-docs |
+| Plan | complete (iter2 PASS 0.92; Implementation Kickoff Approval GRANTED 2026-07-29, OQ-1=A path-keyed) | manager-spec |
+| Run | complete (§E.2/§E.3 — all AC-CFS3-001..013 satisfied; 60s override REMOVED) | manager-develop |
+| Sync | complete (§E.4 — sync_commit_sha: e24067904) | manager-docs |
 
 ---
 


### PR DESCRIPTION
## Summary

Syncs the `§A Status` table in `progress.md` to match the already-completed 3-phase lifecycle recorded in `§E.1–§E.4` + `sync_commit_sha: e24067904`.

## Why
The `§E` sections already record full 3-phase completion, but the `§A Status` table still read `Run/Sync: not started` — a stale-table vs §E-content contradiction. This closes that gap (doc-only, no code change).

| Phase | Before | After |
|-------|--------|-------|
| Plan | complete (pending audit + Kickoff) | complete (iter2 PASS 0.92; Kickoff GRANTED) |
| Run | not started | complete (§E.2/§E.3 — all AC satisfied; 60s override REMOVED) |
| Sync | not started | complete (§E.4 — sync_commit_sha: e24067904) |

## Note
Supersedes the closed #1226 (which bundled a conflicting codemaps refresh — codemaps are already on main via #1218). This PR is §A-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the stabilization progress record to show Plan, Run, and Sync phases as complete.
  * Recorded validation of all acceptance criteria and the associated synchronization commit.
  * Documented removal of the per-acquisition timeout override.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->