### PR TITLE
feat(web): derive agentfm badge color from model tier (llm matrix SSOT)

### DIFF
--- a/internal/harness/v4manifest/schema.go
+++ b/internal/harness/v4manifest/schema.go
@@ -73,6 +73,46 @@ var validModels = map[string]bool{
 	ModelOpus:    true,
 }
 
+// modelColors maps each model tier to its render glyph, mirroring the LLM
+// profile matrix (llm.yaml profiles). The agentfm badge derives its color from
+// the agent's resolved model (the llm matrix SSOT) rather than the manual
+// name→tier table: opus (deep reasoning) → 🔴, sonnet → 🟠, haiku → 🔵,
+// inherit/unknown → 🩵 (light/default).
+var modelColors = map[string]string{
+	ModelOpus:    "🔴",
+	ModelSonnet:  "🟠",
+	ModelHaiku:   "🔵",
+	ModelInherit: "🩵",
+}
+
+// ModelColor returns the render glyph (emoji) for the model tier. An empty or
+// unmapped model falls back to "🩵" (the light/default glyph) so an agent with
+// an unresolved model still renders a neutral badge. The UI layer (moai-web
+// agentfm) renders the glyph as the color badge.
+func ModelColor(model string) string {
+	if g, ok := modelColors[model]; ok {
+		return g
+	}
+	return "🩵"
+}
+
+// ModelColorRank returns a sort rank for a model tier (lower = more expensive =
+// renders first within each sub-tab). Mirrors the tier-based agentTierSortRank
+// ordering so the model-derived badge sorts the same way: opus=0, sonnet=1,
+// haiku=2, inherit/unknown=3.
+func ModelColorRank(model string) int {
+	switch model {
+	case ModelOpus:
+		return 0
+	case ModelSonnet:
+		return 1
+	case ModelHaiku:
+		return 2
+	default:
+		return 3
+	}
+}
+
 // Schedule mechanisms. "loop" is the native /loop scheduler (session-scoped);
 // "cron" is the Cron tools registration (persistent across sessions).
 const (
@@ -173,8 +213,9 @@ var tierSuggestions = map[Tier]struct {
 
 // agentTiers is the name-keyed lookup table: agent file stem (the base name
 // of the .md under .claude/agents/{moai,harness}/, matching agentfm.
-// AgentInfo.Name's contract) → Tier. This is the SSOT for badge color
-// (plan.md §F M1.2 + design.md §C). Distribution: 🔴×4 · 🟠×4 · 🔵×5 · 🩵×7 = 20.
+// AgentInfo.Name's contract) → Tier. The agentfm badge color is now model-derived
+// (ModelColor / modelColors); this table remains the reasoning-role classification
+// that powers tier click-to-suggest (tierSuggestions). Distribution: 🔴×4 · 🟠×4 · 🔵×5 · 🩵×7 = 20.
 //
 // @MX:ANCHOR: [AUTO] sub-agent tier SSOT — name-keyed lookup table (Option A)
 // @MX:REASON: display-only tier invariant; 3+ consumers (AgentTier accessor, moai-web agentfm render, tests). Mutating this map changes badge colors project-wide.

--- a/internal/harness/v4manifest/tier_test.go
+++ b/internal/harness/v4manifest/tier_test.go
@@ -209,6 +209,55 @@ func TestTierColor_UnknownTierReturnsEmpty(t *testing.T) {
 	}
 }
 
+// TestModelColor verifies each model tier maps to its render glyph, mirroring
+// the LLM profile matrix (opus → 🔴, sonnet → 🟠, haiku → 🔵, inherit → 🩵).
+func TestModelColor(t *testing.T) {
+	cases := []struct {
+		model string
+		glyph string
+	}{
+		{ModelOpus, "🔴"},
+		{ModelSonnet, "🟠"},
+		{ModelHaiku, "🔵"},
+		{ModelInherit, "🩵"},
+	}
+	for _, tc := range cases {
+		if got := ModelColor(tc.model); got != tc.glyph {
+			t.Errorf("ModelColor(%q) = %q, want %q", tc.model, got, tc.glyph)
+		}
+	}
+}
+
+// TestModelColor_UnknownReturnsDefault asserts an empty or unmapped model falls
+// back to the light/default glyph (🩵), not "".
+func TestModelColor_UnknownReturnsDefault(t *testing.T) {
+	for _, m := range []string{"", "not-a-real-model"} {
+		if got := ModelColor(m); got != "🩵" {
+			t.Errorf("ModelColor(%q) = %q, want %q (default)", m, got, "🩵")
+		}
+	}
+}
+
+// TestModelColorRank verifies the model-derived sort rank used by the agentfm
+// row ordering: opus=0, sonnet=1, haiku=2, inherit/unknown=3.
+func TestModelColorRank(t *testing.T) {
+	cases := []struct {
+		model string
+		rank  int
+	}{
+		{ModelOpus, 0},
+		{ModelSonnet, 1},
+		{ModelHaiku, 2},
+		{ModelInherit, 3},
+		{"", 3},
+	}
+	for _, tc := range cases {
+		if got := ModelColorRank(tc.model); got != tc.rank {
+			t.Errorf("ModelColorRank(%q) = %d, want %d", tc.model, got, tc.rank)
+		}
+	}
+}
+
 // catalogAgentStems reads the agent catalog from disk (.claude/agents/{moai,
 // harness}/*.md) and returns the file stems (without extension), sorted. The
 // stems are the lookup keys into the name→tier table and match agentfm.

--- a/internal/web/agentfm.go
+++ b/internal/web/agentfm.go
@@ -106,63 +106,45 @@ func applyPerfTierEdits(projectRoot, perfTier string) error {
 	return nil
 }
 
-// agentBadgeInfo carries the M5 tier-badge display data for one agent row
+// agentBadgeInfo carries the M5 model-badge display data for one agent row
 // (SPEC-WEBCONF-SIMPLIFY-001 M5, REQ-WC-006/007/008, design.md §E).
 type agentBadgeInfo struct {
-	Glyph      string // emoji glyph (🔴🟠🔵🩵) or "custom" for the override-sentinel badge
-	TooltipKey string // fieldDesc.agentfm.<tier|custom> i18n key (M4 description mechanism)
-	HasBadge   bool   // false for unmapped agents (EC-6 — no badge rendered)
-	IsCustom   bool   // true when model=inherit or effort=max (EC-2 / AC-WC-018 neutral badge)
+	Glyph      string // emoji glyph (🔴🟠🔵🩵) derived from the model, or "custom"
+	TooltipKey string // fieldDesc.agentfm.model.<model> / fieldDesc.agentfm.custom i18n key
+	HasBadge   bool   // false only when the row carries no usable model state
+	IsCustom   bool   // true when effort=max (AC-WC-018 neutral "custom" badge)
 }
 
-// agentTierBadge computes the display-only tier badge for an agent row. The badge
-// comes from the name-keyed lookup table (design.md §C — Option A, NOT from the
-// agent's effort file). When the agent's current effort is the override sentinel
-// `max`, the badge is a neutral "custom" marker (EC-2, AC-WC-018).
+// agentTierBadge computes the display-only badge for an agent row. The badge
+// color is derived from the agent's resolved model (the llm.yaml profile-matrix
+// SSOT via agentResolvedModel) — NOT the manual name→tier table — so the badge
+// tracks the model the matrix actually assigns: opus → 🔴, sonnet → 🟠,
+// haiku → 🔵, inherit/unknown → 🩵. When the agent's current effort is the
+// override sentinel `max`, the badge is a neutral "custom" marker (AC-WC-018).
 //
-// `model: inherit` is NOT an override signal: SPEC-MODEL-PROFILE-MATRIX-001
-// REQ-MPM-040 stopped mutating agent frontmatter (see applyPerfTierEdits above),
-// so `inherit` is the SHIPPED default for the core agents. Treating it as a
-// manual override mislabeled those defaults CUSTOM and produced the inconsistent
-// mix of CUSTOM pills and tier glyphs across the agent rows. The model parameter
-// is retained (unused) so the call sites keep passing the row's full state.
+// The tooltip key reuses the existing model-selector i18n entries
+// (fieldDesc.agentfm.model.<model>). The name parameter is retained so call
+// sites keep passing the row's full state; it is not used now that the badge is
+// model-derived.
 func agentTierBadge(name, model, effort string) agentBadgeInfo {
 	if effort == v4manifest.EffortMax {
 		return agentBadgeInfo{Glyph: "custom", TooltipKey: "fieldDesc.agentfm.custom", HasBadge: true, IsCustom: true}
 	}
-	tier, ok := v4manifest.AgentTier(name)
-	if !ok {
-		return agentBadgeInfo{} // unmapped agent — no badge (EC-6)
-	}
 	return agentBadgeInfo{
-		Glyph:      v4manifest.TierColor(tier),
-		TooltipKey: "fieldDesc.agentfm." + string(tier),
+		Glyph:      v4manifest.ModelColor(model),
+		TooltipKey: "fieldDesc.agentfm.model." + model,
 		HasBadge:   true,
 	}
 }
 
-// agentTierSortRank returns a sort rank for the agent's display-only tier
+// agentTierSortRank returns a sort rank for the agent's model-derived badge
 // (lower = more expensive = renders first within each sub-tab). Used to order
-// the agentfm rows red-first (post-close polish round 3,
-// SPEC-WEBCONF-SIMPLIFY-001). red=0, orange=1, blue=2, lightblue=3,
-// unmapped=4 (agents without a tier table entry sort last).
-func agentTierSortRank(name string) int {
-	tier, ok := v4manifest.AgentTier(name)
-	if !ok {
-		return 4
-	}
-	switch tier {
-	case v4manifest.TierRed:
-		return 0
-	case v4manifest.TierOrange:
-		return 1
-	case v4manifest.TierBlue:
-		return 2
-	case v4manifest.TierLightBlue:
-		return 3
-	default:
-		return 4
-	}
+// the agentfm rows opus-first (post-close polish round 3,
+// SPEC-WEBCONF-SIMPLIFY-001). Delegates to v4manifest.ModelColorRank so the
+// sort order matches the model-derived badge color: opus=0, sonnet=1, haiku=2,
+// inherit/unknown=3.
+func agentTierSortRank(model string) int {
+	return v4manifest.ModelColorRank(model)
 }
 
 // agentIsMoaiCore reports whether the agent lives in .claude/agents/moai/ (the 10
@@ -298,7 +280,7 @@ func (a *app) listAllAgentFMs(projectRoot string) ([]agentfm.AgentInfo, error) {
 		all = append(all, agents...)
 	}
 	sort.Slice(all, func(i, j int) bool {
-		ri, rj := agentTierSortRank(all[i].Name), agentTierSortRank(all[j].Name)
+		ri, rj := agentTierSortRank(all[i].Model), agentTierSortRank(all[j].Model)
 		if ri != rj {
 			return ri < rj
 		}

--- a/internal/web/agentfm_polish_test.go
+++ b/internal/web/agentfm_polish_test.go
@@ -139,34 +139,34 @@ func TestAgentFMDescriptionShown(t *testing.T) {
 // (post-close polish round 3).
 func TestAgentFMTierSortOrder(t *testing.T) {
 	root := t.TempDir()
-	// Seed one agent from each tier present in .claude/agents/moai/.
-	// 🔴 manager-spec, 🔴 plan-auditor, 🟠 manager-develop, 🔵 manager-docs.
-	seedAgentFMFile(t, root, "moai", "manager-spec", "", "")
-	seedAgentFMFile(t, root, "moai", "plan-auditor", "", "")
-	seedAgentFMFile(t, root, "moai", "manager-develop", "", "")
-	seedAgentFMFile(t, root, "moai", "manager-docs", "", "")
+	// Seed agents with distinct models so the model-derived sort order applies:
+	// opus (manager-spec, plan-auditor) before sonnet (manager-git) before
+	// inherit (manager-docs).
+	seedAgentFMFile(t, root, "moai", "manager-spec", "opus", "")
+	seedAgentFMFile(t, root, "moai", "plan-auditor", "opus", "")
+	seedAgentFMFile(t, root, "moai", "manager-git", "sonnet", "")
+	seedAgentFMFile(t, root, "moai", "manager-docs", "inherit", "")
 	body := renderAgentFMBody(t, root)
 
-	// Red agents before orange before blue.
-	// Use the form field name anchor (agentfm.<name>.model) to find document positions.
+	// opus before sonnet before inherit.
 	specPos := strings.Index(body, `agentfm.manager-spec.model`)
 	auditorPos := strings.Index(body, `agentfm.plan-auditor.model`)
-	devPos := strings.Index(body, `agentfm.manager-develop.model`)
+	gitPos := strings.Index(body, `agentfm.manager-git.model`)
 	docsPos := strings.Index(body, `agentfm.manager-docs.model`)
-	if specPos < 0 || auditorPos < 0 || devPos < 0 || docsPos < 0 {
-		t.Fatalf(`agent row anchors not found in render (spec=%d auditor=%d dev=%d docs=%d)`, specPos, auditorPos, devPos, docsPos)
+	if specPos < 0 || auditorPos < 0 || gitPos < 0 || docsPos < 0 {
+		t.Fatalf(`agent row anchors not found in render (spec=%d auditor=%d git=%d docs=%d)`, specPos, auditorPos, gitPos, docsPos)
 	}
-	// Red (manager-spec, plan-auditor) must come before orange (manager-develop).
-	if devPos < specPos || devPos < auditorPos {
-		t.Errorf(`orange agent (manager-develop pos=%d) must come AFTER red agents (manager-spec pos=%d, plan-auditor pos=%d)`, devPos, specPos, auditorPos)
+	// opus (manager-spec, plan-auditor) must come before sonnet (manager-git).
+	if gitPos < specPos || gitPos < auditorPos {
+		t.Errorf(`sonnet agent (manager-git pos=%d) must come AFTER opus agents (manager-spec pos=%d, plan-auditor pos=%d)`, gitPos, specPos, auditorPos)
 	}
-	// Orange (manager-develop) must come before blue (manager-docs).
-	if docsPos < devPos {
-		t.Errorf(`blue agent (manager-docs pos=%d) must come AFTER orange agent (manager-develop pos=%d)`, docsPos, devPos)
+	// sonnet (manager-git) must come before inherit (manager-docs).
+	if docsPos < gitPos {
+		t.Errorf(`inherit agent (manager-docs pos=%d) must come AFTER sonnet agent (manager-git pos=%d)`, docsPos, gitPos)
 	}
-	// Alphabetical within same tier (red): manager-spec before plan-auditor.
+	// Alphabetical within same model (opus): manager-spec before plan-auditor.
 	if auditorPos < specPos {
-		t.Errorf(`within red tier, manager-spec (pos=%d) should come before plan-auditor (pos=%d) alphabetically`, specPos, auditorPos)
+		t.Errorf(`within opus model, manager-spec (pos=%d) should come before plan-auditor (pos=%d) alphabetically`, specPos, auditorPos)
 	}
 }
 

--- a/internal/web/console_ux_fix_test.go
+++ b/internal/web/console_ux_fix_test.go
@@ -295,18 +295,17 @@ func agentFMSectionCount(t *testing.T, body string) int {
 // frontmatter), so it must NOT be treated as a manual override. Only `effort: max`
 // still marks a row CUSTOM.
 func TestAgentTierBadgeInheritIsDefault(t *testing.T) {
-	// inherit alone → the agent's tier glyph, not the CUSTOM pill.
+	// inherit → the inherit glyph (🩵), the default model badge — NOT the CUSTOM pill.
 	for _, name := range []string{"manager-spec", "manager-develop", "manager-docs"} {
 		b := agentTierBadge(name, v4manifest.ModelInherit, v4manifest.EffortXhigh)
 		if b.IsCustom {
-			t.Errorf("%s (model=inherit): CUSTOM badge rendered for the SHIPPED default (G2-3)", name)
+			t.Errorf("%s (model=inherit): CUSTOM badge rendered (effort=xhigh is not max)", name)
 		}
 		if !b.HasBadge {
-			t.Errorf("%s (model=inherit): expected a tier badge", name)
+			t.Errorf("%s (model=inherit): expected a badge", name)
 		}
-		tier, _ := v4manifest.AgentTier(name)
-		if want := v4manifest.TierColor(tier); b.Glyph != want {
-			t.Errorf("%s (model=inherit): glyph = %q, want the tier glyph %q", name, b.Glyph, want)
+		if want := v4manifest.ModelColor(v4manifest.ModelInherit); b.Glyph != want {
+			t.Errorf("%s (model=inherit): glyph = %q, want the inherit glyph %q", name, b.Glyph, want)
 		}
 	}
 
@@ -319,9 +318,9 @@ func TestAgentTierBadgeInheritIsDefault(t *testing.T) {
 	}
 }
 
-// TestAgentTierBadgeGlyphConsistency verifies the G2-3 user-visible symptom is
-// gone: with the shipped `model: inherit` frontmatter, EVERY tier-mapped core
-// agent renders a tier glyph — no mixed CUSTOM/glyph rows.
+// TestAgentTierBadgeGlyphConsistency verifies the badge is model-derived and
+// consistent: with the shipped `model: inherit` frontmatter, EVERY seeded core
+// agent renders the inherit glyph (🩵) — no mixed CUSTOM/glyph rows.
 func TestAgentTierBadgeGlyphConsistency(t *testing.T) {
 	root := t.TempDir()
 	for _, name := range []string{"manager-spec", "manager-develop", "manager-docs", "manager-git"} {
@@ -330,11 +329,10 @@ func TestAgentTierBadgeGlyphConsistency(t *testing.T) {
 	body := renderAgentFMBody(t, root)
 
 	if strings.Contains(body, "agentfm-badge--custom") {
-		t.Error("a CUSTOM badge renders for shipped `model: inherit` agents (G2-3 — inconsistent glyph/label)")
+		t.Error("a CUSTOM badge renders for shipped `model: inherit` agents")
 	}
-	for _, glyph := range []string{"🔴", "🟠", "🔵"} {
-		if !strings.Contains(body, glyph) {
-			t.Errorf("tier glyph %q missing from the render — inherit agents must show their tier color", glyph)
-		}
+	want := v4manifest.ModelColor(v4manifest.ModelInherit)
+	if !strings.Contains(body, want) {
+		t.Errorf("inherit glyph %q missing from the render — all seeded agents share model=inherit", want)
 	}
 }

--- a/internal/web/m5_agentfm_test.go
+++ b/internal/web/m5_agentfm_test.go
@@ -17,30 +17,30 @@ import (
 // agent's effort file). M1 supplied TierForAgent/TierColor/TierSuggestedModelEffort;
 // M5 wires them into the agentFMRow render.
 
-// TestM5AgentTierBadgeAll20Agents verifies AC-WC-005: every catalog agent gets a
-// non-custom tier badge from the name-keyed lookup table, with the distribution
-// 🔴×4 / 🟠×4 / 🔵×5 / 🩵×7 (design.md §C).
-func TestM5AgentTierBadgeAll20Agents(t *testing.T) {
-	counts := map[string]int{}
-	total := 0
-	for name := range v4manifest.AllAgentTiers() {
-		total++
-		b := agentTierBadge(name, "", "") // empty model/effort = no override sentinel
+// TestM5AgentTierBadgeModelGlyphMap verifies the badge is model-derived: each
+// model tier maps to its glyph (opus → 🔴, sonnet → 🟠, haiku → 🔵, inherit → 🩵)
+// and every model yields a non-custom badge.
+func TestM5AgentTierBadgeModelGlyphMap(t *testing.T) {
+	cases := []struct {
+		model string
+		glyph string
+	}{
+		{v4manifest.ModelOpus, "🔴"},
+		{v4manifest.ModelSonnet, "🟠"},
+		{v4manifest.ModelHaiku, "🔵"},
+		{v4manifest.ModelInherit, "🩵"},
+	}
+	for _, tc := range cases {
+		b := agentTierBadge("any-agent", tc.model, "")
 		if !b.HasBadge {
-			t.Errorf("agent %q: expected a tier badge, got none (EC-6 unmapped?)", name)
+			t.Errorf("model=%s: expected a badge, got none", tc.model)
 			continue
 		}
 		if b.IsCustom {
-			t.Errorf("agent %q: unexpected custom badge (no max/inherit override set)", name)
+			t.Errorf("model=%s: unexpected custom badge (no max effort set)", tc.model)
 		}
-		counts[b.Glyph]++
-	}
-	if total != 20 {
-		t.Errorf("catalog agent count = %d, want 20", total)
-	}
-	for glyph, want := range map[string]int{"🔴": 4, "🟠": 4, "🔵": 5, "🩵": 7} {
-		if got := counts[glyph]; got != want {
-			t.Errorf("tier glyph %q: %d agents, want %d", glyph, got, want)
+		if b.Glyph != tc.glyph {
+			t.Errorf("model=%s: glyph = %q, want %q", tc.model, b.Glyph, tc.glyph)
 		}
 	}
 }


### PR DESCRIPTION
## What & why

The agentfm row badge color was keyed off the manual name→tier table (`tierColors`), which could drift from the model the `llm.yaml` profile matrix actually assigns each agent. This PR derives the badge color from the agent's **resolved model** instead, so the badge tracks the model the matrix assigns.

## Mapping

| model | badge |
|-------|-------|
| opus | 🔴 (deep reasoning) |
| sonnet | 🟠 |
| haiku | 🔵 |
| inherit / unknown | 🩵 (default) |

## Changes

- `v4manifest/schema.go` — add `modelColors` map + `ModelColor` / `ModelColorRank` helpers
- `web/agentfm.go` — `agentTierBadge` Glyph + tooltip now model-derived (tooltip reuses the existing `fieldDesc.agentfm.model.<m>` i18n keys); `agentTierSortRank` sorts by model rank (opus first); the name→tier table is kept for click-to-suggest
- tests — rewrite the 4 tier-based badge/sort tests for the model-derived badge; add `ModelColor`/`ModelColorRank` coverage in `tier_test.go`

## Verification

```
go build ./...                                            # exit 0
go vet ./internal/web/ ./internal/harness/v4manifest/     # exit 0
go test ./internal/web/ -count=1                          # ok (0.86s)
go test ./internal/harness/v4manifest/ -count=1           # ok
```

Note: the `name→tier` table and `tierColors` are intentionally kept (they power tier click-to-suggest / tooltips); only the badge **glyph** source switched from tier to model.

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent badges now reflect the configured model, including distinct indicators for Opus, Sonnet, Haiku, and inherited models.
  * Agent lists are ordered by model tier for more consistent presentation.
  * Custom effort overrides are clearly identified in agent badges.

* **Bug Fixes**
  * Corrected badge and sorting behavior when agents use inherited or explicitly configured models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->