### PR TITLE
fix(cli): stop emitting startup warnings on launcher paths

### DIFF
--- a/internal/cli/deps.go
+++ b/internal/cli/deps.go
@@ -175,7 +175,13 @@ func InitDependencies() {
 	// @MX:NOTE: [AUTO] goplsBridge (loop layer) and lsphook LSP client (hook layer) are
 	// separate paths. The former populates Feedback.Diagnostics; the latter handles the PostTool hook.
 	fallbackDiags := lsphook.NewFallbackDiagnosticsWithCircuitBreaker(lspCircuitBreaker)
-	if goplsBridge == nil {
+	// Report a missing bridge only when it is a degradation. lsp.gopls_bridge.enabled
+	// defaults to false (gopls/config.go DefaultConfig), so a project without that
+	// block is in its intended state, not a failed one — warning there put an
+	// unactionable line on every operator-facing command. A load error or a failed
+	// initialization is a real degradation and already warned above; the branch
+	// below covers an enabled-but-nil bridge, which nothing else reports.
+	if goplsBridge == nil && cfgErr == nil && goplsCfg.Enabled {
 		slog.Warn("gopls bridge disabled — quality gates fall back to CLI tools only",
 			"impact", "gopls-backed diagnostics are disabled; phase-aware LSP gates bypassed",
 			"fallback", "go vet, go test, golangci-lint, ast-grep",

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -38,6 +38,11 @@ Use 'moai cc', 'moai cg', or 'moai glm' to launch Claude Code.`,
 //
 // R3 nil-access mitigation: only commands verified to NOT touch `deps` are listed
 // here. Adding a command that accesses deps without InitDependencies would panic.
+// The launch group (cc/cg/glm) is listed for a second reason: those commands
+// end in syscall.Exec, replacing this process with the claude binary, so the
+// whole graph would be assembled and immediately discarded. The only deps read
+// on that path is loadGLMConfig's nil-safe branch (glm.go), which falls back to
+// reading llm.yaml from disk — its documented live runtime path.
 var trivialCommands = map[string]bool{
 	"--version":  true,
 	"version":    true,
@@ -46,6 +51,9 @@ var trivialCommands = map[string]bool{
 	"--help":     true,
 	"-h":         true,
 	"completion": true, // cobra built-in
+	"cc":         true, // launcher: exec's claude, discards the graph
+	"cg":         true, // launcher: exec's claude, discards the graph
+	"glm":        true, // launcher: exec's claude, discards the graph
 }
 
 // @MX:ANCHOR: [AUTO] Execute is the main entry point for the moai CLI

--- a/internal/hook/path_resolve.go
+++ b/internal/hook/path_resolve.go
@@ -31,9 +31,36 @@ package hook
 import (
 	"log/slog"
 	"os"
+	"sync"
 
 	"github.com/modu-ai/moai-adk/internal/config"
 )
+
+// projectRootResolver defers registration-time project-root resolution to first
+// use. Handlers embed it and expose a projectRoot() accessor.
+//
+// Why deferred: InitDependencies (internal/cli/deps.go) constructs every handler
+// for every non-trivial subcommand, long before — and usually without — a hook
+// event ever being dispatched. Resolving in the constructor therefore emitted a
+// cwd_fallback warning on operator-facing commands, where CLAUDE_PROJECT_DIR is
+// legitimately unset and cwd is the right answer rather than a degraded one.
+// Resolution semantics are unchanged: CLAUDE_PROJECT_DIR, then os.Getwd()
+// (REQ-HCWA-005, REQ-HCWA-008).
+type projectRootResolver struct {
+	caller string
+	once   sync.Once
+}
+
+// resolve fills *dir on first call and returns it. A dir already set by the
+// caller (tests construct handlers with an explicit project root) is preserved.
+func (r *projectRootResolver) resolve(dir *string) string {
+	r.once.Do(func() {
+		if *dir == "" && r.caller != "" {
+			*dir = resolveProjectRootFromEnv(r.caller)
+		}
+	})
+	return *dir
+}
 
 // resolveProjectRootFromEnv returns CLAUDE_PROJECT_DIR or os.Getwd() fallback
 // without the .moai/ existence guard. Emits slog.Warn with key

--- a/internal/hook/pre_tool.go
+++ b/internal/hook/pre_tool.go
@@ -312,27 +312,31 @@ func (p *SecurityPolicy) MergeExtraPatterns(extra *security.ExtraSecurityConfig)
 // and scanning tool input for dangerous patterns (REQ-HOOK-031, REQ-HOOK-032).
 // Optionally integrates with SecurityScanner for AST-based security scanning.
 type preToolHandler struct {
-	cfg        ConfigProvider
-	policy     *SecurityPolicy
-	scanner    *security.SecurityScanner
+	cfg     ConfigProvider
+	policy  *SecurityPolicy
+	scanner *security.SecurityScanner
+	// projectDir is the resolved project root. Tests may set it directly; the
+	// production constructors leave it empty and let projectRoot resolve it.
 	projectDir string
+	projectRootResolver
 }
 
 // NewPreToolHandler creates a new PreToolUse event handler with the given security policy.
-// projectDir is resolved via resolveProjectRootFromEnv: CLAUDE_PROJECT_DIR env
-// var first, then os.Getwd() fallback with slog.Warn cwd_fallback:true marker
+// projectDir is resolved on first use via resolveProjectRootFromEnv: CLAUDE_PROJECT_DIR
+// env var first, then os.Getwd() fallback with slog.Warn cwd_fallback:true marker
 // (REQ-HCWA-005, REQ-HCWA-008).
 func NewPreToolHandler(cfg ConfigProvider, policy *SecurityPolicy) Handler {
-	projectDir := resolveProjectRootFromEnv("NewPreToolHandler")
-	return &preToolHandler{cfg: cfg, policy: policy, projectDir: projectDir}
+	return &preToolHandler{
+		cfg:                 cfg,
+		policy:              policy,
+		projectRootResolver: projectRootResolver{caller: "NewPreToolHandler"},
+	}
 }
 
 // NewPreToolHandlerWithScanner creates a PreToolUse handler with AST-based security scanning.
 // If scanner is nil or unavailable, falls back to pattern-based security only.
-// projectDir is resolved via resolveProjectRootFromEnv (REQ-HCWA-005, REQ-HCWA-008).
+// projectDir is resolved on first use via resolveProjectRootFromEnv (REQ-HCWA-005, REQ-HCWA-008).
 func NewPreToolHandlerWithScanner(cfg ConfigProvider, policy *SecurityPolicy, scanner *security.SecurityScanner) Handler {
-	projectDir := resolveProjectRootFromEnv("NewPreToolHandlerWithScanner")
-
 	// Validate scanner availability
 	if scanner != nil && !scanner.IsAvailable() {
 		slog.Info("ast-grep not available, security scanning disabled")
@@ -340,11 +344,16 @@ func NewPreToolHandlerWithScanner(cfg ConfigProvider, policy *SecurityPolicy, sc
 	}
 
 	return &preToolHandler{
-		cfg:        cfg,
-		policy:     policy,
-		scanner:    scanner,
-		projectDir: projectDir,
+		cfg:                 cfg,
+		policy:              policy,
+		scanner:             scanner,
+		projectRootResolver: projectRootResolver{caller: "NewPreToolHandlerWithScanner"},
 	}
+}
+
+// projectRoot returns the project root, resolving it on first use.
+func (h *preToolHandler) projectRoot() string {
+	return h.resolve(&h.projectDir)
 }
 
 // EventType returns EventPreToolUse.
@@ -452,7 +461,7 @@ func (h *preToolHandler) Handle(ctx context.Context, input *HookInput) (*HookOut
 	// git commands ONLY in the primary checkout when the invoking agent is not
 	// exempt; fails OPEN on any git-context uncertainty (REQ-WBG-012).
 	if input.ToolName == "Bash" && len(input.ToolInput) > 0 {
-		if decision, reason := checkBranchState(input, h.projectDir); decision == DecisionDeny {
+		if decision, reason := checkBranchState(input, h.projectRoot()); decision == DecisionDeny {
 			slog.Warn("branch guard denied",
 				"tool_name", input.ToolName,
 				"session_id", input.SessionID,
@@ -560,7 +569,7 @@ func (h *preToolHandler) scanWriteContent(ctx context.Context, toolInput json.Ra
 	_ = tmpFile.Close() // Close before scanning
 
 	// Scan the temporary file
-	result, err := h.scanner.ScanFile(ctx, tmpFile.Name(), h.projectDir)
+	result, err := h.scanner.ScanFile(ctx, tmpFile.Name(), h.projectRoot())
 	if err != nil {
 		slog.Warn("security scan failed", "error", err)
 		return "", ""
@@ -643,8 +652,8 @@ func (h *preToolHandler) loadGateConfig() *quality.GateConfig {
 	// (including the DefaultGateConfig fallback when no config provider is
 	// loaded), so a project requiring non-default build tags (e.g. goolm) is
 	// vetted/linted/tested under them regardless of config availability.
-	qcfg.ProjectDir = h.projectDir
-	qcfg.GoBuildTags = readGoBuildTags(h.projectDir)
+	qcfg.ProjectDir = h.projectRoot()
+	qcfg.GoBuildTags = readGoBuildTags(qcfg.ProjectDir)
 	return qcfg
 }
 
@@ -750,8 +759,8 @@ func (h *preToolHandler) checkFileAccess(toolInput json.RawMessage, toolName str
 	}
 
 	// Check if path is within project directory
-	if h.projectDir != "" {
-		projectAbs, absErr := filepath.Abs(h.projectDir)
+	if projectDir := h.projectRoot(); projectDir != "" {
+		projectAbs, absErr := filepath.Abs(projectDir)
 		if absErr != nil {
 			// Cannot resolve project directory, skip boundary check
 			slog.Debug("cannot resolve project directory", "error", absErr)

--- a/internal/hook/subagent_start.go
+++ b/internal/hook/subagent_start.go
@@ -16,8 +16,12 @@ import (
 // subagentStartHandler processes SubagentStart events.
 // It logs subagent startup for session tracking and optionally injects project context.
 type subagentStartHandler struct {
-	cfg        ConfigProvider
+	cfg ConfigProvider
+	// projectDir is the resolved project root, used only as a fallback when the
+	// hook input carries no CWD. Tests may set it directly; the production
+	// constructor leaves it empty and lets projectRoot resolve it.
 	projectDir string
+	projectRootResolver
 }
 
 // NewSubagentStartHandler creates a new SubagentStart event handler without config.
@@ -28,12 +32,19 @@ func NewSubagentStartHandler() Handler {
 
 // NewSubagentStartHandlerWithConfig creates a new SubagentStart event handler with
 // config access for project context injection.
-// projectDir is resolved via resolveProjectRootFromEnv: CLAUDE_PROJECT_DIR env
-// var first, then os.Getwd() fallback with slog.Warn cwd_fallback:true marker
-// (REQ-HCWA-003, REQ-HCWA-008).
+// projectDir is resolved on first use via resolveProjectRootFromEnv:
+// CLAUDE_PROJECT_DIR env var first, then os.Getwd() fallback with slog.Warn
+// cwd_fallback:true marker (REQ-HCWA-003, REQ-HCWA-008).
 func NewSubagentStartHandlerWithConfig(cfg ConfigProvider) Handler {
-	dir := resolveProjectRootFromEnv("NewSubagentStartHandlerWithConfig")
-	return &subagentStartHandler{cfg: cfg, projectDir: dir}
+	return &subagentStartHandler{
+		cfg:                 cfg,
+		projectRootResolver: projectRootResolver{caller: "NewSubagentStartHandlerWithConfig"},
+	}
+}
+
+// projectRoot returns the project root, resolving it on first use.
+func (h *subagentStartHandler) projectRoot() string {
+	return h.resolve(&h.projectDir)
 }
 
 // EventType returns EventSubagentStart.
@@ -91,7 +102,7 @@ func (h *subagentStartHandler) buildContext(input *HookInput) string {
 	// Resolve project directory from input CWD, handler field, or env
 	dir := input.CWD
 	if dir == "" {
-		dir = h.projectDir
+		dir = h.projectRoot()
 	}
 
 	if spec := h.detectActiveSpec(dir); spec != "" {


### PR DESCRIPTION
## Problem

Three WARN lines were printed on **every** non-trivial `moai` invocation, including the `cc`/`cg`/`glm` launchers that immediately `syscall.Exec` into `claude`:

```
WARN gopls bridge disabled — quality gates fall back to CLI tools only gopls_bridge_status=disabled
WARN cwd fallback used (CLAUDE_PROJECT_DIR not set) caller=NewPreToolHandlerWithScanner
WARN cwd fallback used (CLAUDE_PROJECT_DIR not set) caller=NewSubagentStartHandlerWithConfig
```

None were actionable. All three originate in `InitDependencies` (`internal/cli/deps.go`), which assembles the full dependency graph before cobra dispatches — so the launchers built 25+ hook handlers plus the LSP wiring and then discarded the lot. `-d` was irrelevant: `ccCmd` sets `DisableFlagParsing: true`, and the default log level is WARN, so the lines appeared unconditionally.

## Fixes

- **`root.go`** — add `cc`/`cg`/`glm` to `trivialCommands`. The launchers replace the process, so the graph was throwaway work; the only `deps` read on that path is `loadGLMConfig`'s nil-safe branch, which falls back to reading `llm.yaml` from disk (its documented live runtime path).
- **`deps.go`** — warn about a missing gopls bridge only when it is a real degradation. `lsp.gopls_bridge.enabled` defaults to `false` (`gopls/config.go` `DefaultConfig`), so a project without that block is in its intended state, not a failed one. A load error or failed init is still warned by the existing branches above.
- **`pre_tool.go` / `subagent_start.go`** — defer project-root resolution to first use via a new `projectRootResolver` helper. These two constructors ran at registration time, where `CLAUDE_PROJECT_DIR` is legitimately unset and cwd is the right answer rather than a degraded one. Every other handler already resolved lazily in `Handle`. Resolution semantics are unchanged (`CLAUDE_PROJECT_DIR`, then `os.Getwd`), and `subagentStartHandler` still prefers `input.CWD`.

## Verification

| Check | Result |
|---|---|
| `./bin/moai cc --help` stderr WARN count | **0** (was 3) |
| `./bin/moai session current` stderr WARN count | **0** |
| `go test ./internal/hook/` | ok 4.978s |
| `go test ./internal/cli/` | ok 161.618s |
| `go build ./...` / `go vet` | pass |
| `make build` | pass |

Hook-event behavior is untouched — `moai hook <event>` still resolves the same root, and its logs were already discarded (`logging.go` routes the hook path to `io.Discard`), which is why these lines only ever showed on operator-facing commands.

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced misleading GoPLS bridge warnings when the bridge is intentionally disabled or configuration cannot be loaded.
  * Improved command startup by avoiding unnecessary initialization for commands that immediately launch another process.
  * Improved project-root detection across hooks and subagents, including security checks, quality gates, and injected project context.
  * Ensured project-root resolution occurs consistently and only when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->