### PR TITLE
docs(changelog): publish release notes on the docs site in 4 locales

### DIFF
--- a/.claude/agents/harness/hns-release-specialist.md
+++ b/.claude/agents/harness/hns-release-specialist.md
@@ -98,6 +98,28 @@ Changes / Added / Changed / Fixed / Installation & Update), then `---`, then
 수정됨 / 설치 및 업데이트), then previous entry. Commit:
 `docs: update CHANGELOG for vX.Y.Z`.
 
+[HARD] Docs-site release-notes page, same commit. `CHANGELOG.md` stays the
+source of truth; the four `docs-site/content/{en,ko,ja,zh}/changelog/_index.md`
+pages mirror its most recent entries so the release history is readable at
+`adk.mo.ai.kr/<locale>/changelog/`. For each release:
+
+1. Insert the new version at the TOP of the `## Releases` section (locale
+   headings: `## Releases` / `## 릴리스 내역` / `## リリース履歴` / `## 发布记录`),
+   under a `### [X.Y.Z] - YYYY-MM-DD` subheading.
+2. `en` and `ko` reuse the CHANGELOG bodies verbatim (English section → `en`,
+   the `(한국어)` section → `ko`). `ja` and `zh` are translated from the English
+   section — CHANGELOG.md carries no ja/zh, so this is the only place they are
+   authored.
+3. Keep at most **5** versions per page. Drop the oldest entry when the sixth
+   arrives; the GitHub `CHANGELOG.md` link already at the bottom of each page
+   remains the complete history, so nothing is lost.
+4. All four locales move in the same commit — a partial update breaks the
+   4-locale parity obligation (CLAUDE.local.md §17.3).
+
+Where a release ships no user-visible change (a docs-only or CI-only release
+per the content filter above), skip the docs-site page rather than adding an
+empty entry.
+
 ### Phase 5 — Final Approval (human gate — specialist-held)
 
 [HARD] Return a blocker report with the release summary (version change, commits,

--- a/docs-site/content/en/_meta.yaml
+++ b/docs-site/content/en/_meta.yaml
@@ -34,3 +34,6 @@ advanced:
 contributing:
   title: "Contributing"
   weight: 110
+changelog:
+  title: "Release Notes"
+  weight: 120

--- a/docs-site/content/en/changelog/_index.md
+++ b/docs-site/content/en/changelog/_index.md
@@ -1,0 +1,25 @@
+---
+title: Release Notes
+weight: 120
+draft: false
+---
+
+This page collects the changes shipped in each version of MoAI-ADK. Every entry
+is updated at release time alongside the repository's `CHANGELOG.md`, and lists
+what was added, what changed, and what was fixed in that order.
+
+Version numbers follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html),
+and entries follow the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+format.
+
+## Releases
+
+The five most recent versions appear here. No entries yet — this section fills
+from the next release onward.
+
+## Earlier versions
+
+The complete history for versions not listed here lives in the repository's
+[CHANGELOG.md](https://github.com/modu-ai/moai-adk/blob/main/CHANGELOG.md).
+Per-release build artifacts are on
+[GitHub Releases](https://github.com/modu-ai/moai-adk/releases).

--- a/docs-site/content/ja/_meta.yaml
+++ b/docs-site/content/ja/_meta.yaml
@@ -34,3 +34,6 @@ advanced:
 contributing:
   title: "Contributing"
   weight: 110
+changelog:
+  title: "リリースノート"
+  weight: 120

--- a/docs-site/content/ja/changelog/_index.md
+++ b/docs-site/content/ja/changelog/_index.md
@@ -1,0 +1,25 @@
+---
+title: リリースノート
+weight: 120
+draft: false
+---
+
+MoAI-ADK のバージョンごとの変更点をまとめたページです。各項目はリリース時に
+リポジトリの `CHANGELOG.md` と合わせて更新され、追加された機能・変更された挙動・
+修正された不具合を同じ順序で記載します。
+
+バージョン番号は [セマンティック バージョニング](https://semver.org/lang/ja/) に、
+項目の構成は [Keep a Changelog](https://keepachangelog.com/ja/1.1.0/) の形式に
+従います。
+
+## リリース履歴
+
+直近 5 バージョンをここに掲載します。まだ登録された項目はありません — 次回の
+リリースから追加されます。
+
+## 以前のバージョン
+
+ここに掲載されていない過去バージョンの全履歴は、リポジトリの
+[CHANGELOG.md](https://github.com/modu-ai/moai-adk/blob/main/CHANGELOG.md) で
+確認できます。リリースごとの配布物は
+[GitHub Releases](https://github.com/modu-ai/moai-adk/releases) にあります。

--- a/docs-site/content/ko/_meta.yaml
+++ b/docs-site/content/ko/_meta.yaml
@@ -34,3 +34,6 @@ advanced:
 contributing:
   title: "참여하기"
   weight: 110
+changelog:
+  title: "릴리스 노트"
+  weight: 120

--- a/docs-site/content/ko/changelog/_index.md
+++ b/docs-site/content/ko/changelog/_index.md
@@ -1,0 +1,24 @@
+---
+title: 릴리스 노트
+weight: 120
+draft: false
+---
+
+MoAI-ADK의 버전별 변경 사항을 정리한 페이지입니다. 각 항목은 릴리스 시점에
+저장소의 `CHANGELOG.md`와 함께 갱신되며, 추가된 기능·변경된 동작·수정된 결함을
+같은 순서로 담습니다.
+
+버전 번호는 [유의적 버전](https://semver.org/lang/ko/)을 따르고, 항목 구성은
+[Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형식을 따릅니다.
+
+## 릴리스 내역
+
+최근 5개 버전을 이 자리에 싣습니다. 아직 등록된 항목이 없습니다 — 다음 릴리스부터
+채워집니다.
+
+## 이전 버전
+
+여기에 실리지 않은 과거 버전의 전체 기록은 저장소의
+[CHANGELOG.md](https://github.com/modu-ai/moai-adk/blob/main/CHANGELOG.md)에서
+확인할 수 있습니다. 릴리스별 배포 산출물은
+[GitHub Releases](https://github.com/modu-ai/moai-adk/releases)에 있습니다.

--- a/docs-site/content/zh/_meta.yaml
+++ b/docs-site/content/zh/_meta.yaml
@@ -34,3 +34,6 @@ advanced:
 contributing:
   title: "Contributing"
   weight: 110
+changelog:
+  title: "发布说明"
+  weight: 120

--- a/docs-site/content/zh/changelog/_index.md
+++ b/docs-site/content/zh/changelog/_index.md
@@ -1,0 +1,22 @@
+---
+title: 发布说明
+weight: 120
+draft: false
+---
+
+本页汇总 MoAI-ADK 各版本的变更内容。每条记录在发布时与仓库的 `CHANGELOG.md`
+一同更新，按照新增功能、行为变更、缺陷修复的顺序列出。
+
+版本号遵循[语义化版本](https://semver.org/lang/zh-CN/)，条目结构遵循
+[Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/) 格式。
+
+## 发布记录
+
+此处收录最近 5 个版本。目前尚无记录 —— 将从下一次发布开始填充。
+
+## 更早的版本
+
+未在此处列出的历史版本，完整记录见仓库的
+[CHANGELOG.md](https://github.com/modu-ai/moai-adk/blob/main/CHANGELOG.md)。
+各版本的构建产物位于
+[GitHub Releases](https://github.com/modu-ai/moai-adk/releases)。

--- a/docs-site/data/menu/main.yaml
+++ b/docs-site/data/menu/main.yaml
@@ -634,3 +634,13 @@ main:
     icon: handshake
     defaultOpen: true
     sub:
+
+  - name:
+      ko: 릴리스 노트
+      en: Release Notes
+      ja: リリースノート
+      zh: 发布说明
+    ref: /changelog
+    icon: tag
+    defaultOpen: true
+    sub:


### PR DESCRIPTION
## Summary

`CHANGELOG.md` was only readable on GitHub. This adds a **Release Notes** section to adk.mo.ai.kr so users find what changed in each version alongside the rest of the documentation, and wires the release harness to keep it current.

## What changed

| File | Change |
|---|---|
| `docs-site/content/{en,ko,ja,zh}/changelog/_index.md` | new section (weight 120) — 4 files |
| `docs-site/content/{en,ko,ja,zh}/_meta.yaml` | sidebar ordering entry |
| `docs-site/data/menu/main.yaml` | sidebar section, `icon: tag` |
| `.claude/agents/harness/hns-release-specialist.md` | Phase 4 now also updates the docs-site pages |

## Why the pages ship empty

`CHANGELOG.md` carries English for every release, Korean for `3.0.0` only, and **no Japanese or Chinese at all**. Back-filling would mean translating already-shipped releases. Instead each page links to `CHANGELOG.md` for the full history and starts accumulating from the next release, where all four locales are written together.

## Release-harness contract (Phase 4)

- `en` / `ko` reuse the CHANGELOG bodies verbatim (English section → `en`, `(한국어)` section → `ko`)
- `ja` / `zh` are translated from the English section — the only place they are authored
- at most **5** versions stay on the page; older history remains in `CHANGELOG.md`
- all four locales move in the same commit (4-locale parity)

## Icon

`icon: tag` reuses the SVG case already defined at `menu.html:34` and previously unused by any section — no new icon case was added.

## Verification

- `hugo --gc --minify` → exit 0, no warnings; emits `public/{en,ko,ja,zh}/changelog/index.html`
- sidebar renders 14 sections including the new one, with the tag icon
- `_meta.yaml` parity: 13 / 13 / 13 / 13
- `scripts/docs-i18n-check.sh` → **0 changelog-attributable errors**

### Not verified

The 114 errors `docs-i18n-check.sh` reports are pre-existing (106 missing-H1 + 8 glossary) and unrelated to this change; the CI gate runs warn-only during rollout, so they do not block. `_index.md` files are exempt from the H1 check (`docs-i18n-check.sh:203`), so these pages are outside that check's scope rather than passing it.

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Release Notes section to the documentation site in English, Korean, Japanese, and Chinese.
  * Added localized navigation links for easier access to release notes.
  * Release notes highlight the five most recent versions, with links to the complete history and downloadable releases.

* **Documentation**
  * Established a consistent format for maintaining multilingual release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->