### PR TITLE
docs(readme): escape pipes inside the CLI-commands table cells (4-locale)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -266,13 +266,13 @@ claude        # launch Claude Code inside the project
 | `moai status` | プロジェクト状態要約（Git ブランチ、品質指標） |
 | `moai update` | 最新版へアップデート（自動ロールバック対応） |
 | `moai cc` / `moai glm` / `moai cg` | Claude 専用 / GLM 専用 / ハイブリッド Claude リーダー + GLM ワーカーセッション |
-| `moai worktree <new|list|switch|sync|remove|clean|go>` | 並列 SPEC 開発用 Git worktree 管理 |
-| `moai session <list|register|current>` | マルチセッション調整 |
-| `moai spec <audit|archive|lint|list|new>` | SPEC ライフサイクルツール |
-| `moai goal <arm|status|clear>` | Goal エンジン CLI |
-| `moai harness <status|apply|rollback|disable>` | harness 学習ライフサイクル |
-| `moai handoff <save|list>` | セッションハンドオフ記録 |
-| `moai preference <list|decay-scan|toggle>` | 決定メモリ管理 |
+| `moai worktree <new\|list\|switch\|sync\|remove\|clean\|go>` | 並列 SPEC 開発用 Git worktree 管理 |
+| `moai session <list\|register\|current>` | マルチセッション調整 |
+| `moai spec <audit\|archive\|lint\|list\|new>` | SPEC ライフサイクルツール |
+| `moai goal <arm\|status\|clear>` | Goal エンジン CLI |
+| `moai harness <status\|apply\|rollback\|disable>` | harness 学習ライフサイクル |
+| `moai handoff <save\|list>` | セッションハンドオフ記録 |
+| `moai preference <list\|decay-scan\|toggle>` | 決定メモリ管理 |
 | `moai web` | Web Console — 6 タブ設定コンソール |
 
 > 全 36 コマンド: [CLI Reference](https://adk.mo.ai.kr/ja/cli-reference)

--- a/README.ko.md
+++ b/README.ko.md
@@ -266,13 +266,13 @@ claude        # 프로젝트 안에서 Claude Code 실행
 | `moai status` | 프로젝트 상태 요약 (Git 브랜치, 품질 지표) |
 | `moai update` | 최신 버전으로 업데이트 (자동 롤백 지원) |
 | `moai cc` / `moai glm` / `moai cg` | Claude 전용 / GLM 전용 / 하이브리드 Claude 리더 + GLM 워커 세션 |
-| `moai worktree <new|list|switch|sync|remove|clean|go>` | 병렬 SPEC 개발을 위한 Git worktree 관리 |
-| `moai session <list|register|current>` | 멀티 세션 조율 |
-| `moai spec <audit|archive|lint|list|new>` | SPEC 라이프사이클 도구 |
-| `moai goal <arm|status|clear>` | Goal 엔진 CLI |
-| `moai harness <status|apply|rollback|disable>` | 하네스 학습 라이프사이클 |
-| `moai handoff <save|list>` | 세션 핸드오프 기록 |
-| `moai preference <list|decay-scan|toggle>` | 결정 메모리 관리 |
+| `moai worktree <new\|list\|switch\|sync\|remove\|clean\|go>` | 병렬 SPEC 개발을 위한 Git worktree 관리 |
+| `moai session <list\|register\|current>` | 멀티 세션 조율 |
+| `moai spec <audit\|archive\|lint\|list\|new>` | SPEC 라이프사이클 도구 |
+| `moai goal <arm\|status\|clear>` | Goal 엔진 CLI |
+| `moai harness <status\|apply\|rollback\|disable>` | 하네스 학습 라이프사이클 |
+| `moai handoff <save\|list>` | 세션 핸드오프 기록 |
+| `moai preference <list\|decay-scan\|toggle>` | 결정 메모리 관리 |
 | `moai web` | Web Console — 6탭 설정 콘솔 |
 
 > 전체 36개 커맨드: [CLI 레퍼런스](https://adk.mo.ai.kr/ko/cli-reference)

--- a/README.md
+++ b/README.md
@@ -270,13 +270,13 @@ Natural language works too. `/moai "fix the login bug"` triggers intent analysis
 | `moai status` | Project status summary (Git branch, quality metrics) |
 | `moai update` | Update to latest version (auto-rollback supported) |
 | `moai cc` / `moai glm` / `moai cg` | Claude-only / GLM-only / hybrid Claude leader + GLM worker sessions |
-| `moai worktree <new|list|switch|sync|remove|clean|go>` | Git worktree management for parallel SPEC development |
-| `moai session <list|register|current>` | Multi-session coordination |
-| `moai spec <audit|archive|lint|list|new>` | SPEC lifecycle tools |
-| `moai goal <arm|status|clear>` | Goal engine CLI |
-| `moai harness <status|apply|rollback|disable>` | Harness learning lifecycle |
-| `moai handoff <save|list>` | Session handoff records |
-| `moai preference <list|decay-scan|toggle>` | Decision memory management |
+| `moai worktree <new\|list\|switch\|sync\|remove\|clean\|go>` | Git worktree management for parallel SPEC development |
+| `moai session <list\|register\|current>` | Multi-session coordination |
+| `moai spec <audit\|archive\|lint\|list\|new>` | SPEC lifecycle tools |
+| `moai goal <arm\|status\|clear>` | Goal engine CLI |
+| `moai harness <status\|apply\|rollback\|disable>` | Harness learning lifecycle |
+| `moai handoff <save\|list>` | Session handoff records |
+| `moai preference <list\|decay-scan\|toggle>` | Decision memory management |
 | `moai web` | Web Console — 6-tab settings console |
 
 > Full 36 commands: [CLI Reference](https://adk.mo.ai.kr/en/cli-reference)

--- a/README.zh.md
+++ b/README.zh.md
@@ -272,13 +272,13 @@ claude        # launch Claude Code inside the project
 | `moai status` | 项目状态摘要（Git 分支、质量指标） |
 | `moai update` | 更新到最新版本（支持自动回滚） |
 | `moai cc` / `moai glm` / `moai cg` | Claude 专用 / GLM 专用 / 混合 Claude 领导 + GLM worker 会话 |
-| `moai worktree <new|list|switch|sync|remove|clean|go>` | Git worktree 管理并行 SPEC 开发 |
-| `moai session <list|register|current>` | 多会话协调 |
-| `moai spec <audit|archive|lint|list|new>` | SPEC 生命周期工具 |
-| `moai goal <arm|status|clear>` | Goal 引擎 CLI |
-| `moai harness <status|apply|rollback|disable>` | Harness 学习生命周期 |
-| `moai handoff <save|list>` | 会话交接记录 |
-| `moai preference <list|decay-scan|toggle>` | 决策记忆管理 |
+| `moai worktree <new\|list\|switch\|sync\|remove\|clean\|go>` | Git worktree 管理并行 SPEC 开发 |
+| `moai session <list\|register\|current>` | 多会话协调 |
+| `moai spec <audit\|archive\|lint\|list\|new>` | SPEC 生命周期工具 |
+| `moai goal <arm\|status\|clear>` | Goal 引擎 CLI |
+| `moai harness <status\|apply\|rollback\|disable>` | Harness 学习生命周期 |
+| `moai handoff <save\|list>` | 会话交接记录 |
+| `moai preference <list\|decay-scan\|toggle>` | 决策记忆管理 |
 | `moai web` | Web Console — 6 标签设置控制台 |
 
 > 全部 36 个命令：[CLI Reference](https://adk.mo.ai.kr/zh/cli-reference)


### PR DESCRIPTION
Rescues an uncommitted fix found in the primary checkout during a pre-pull audit, and lands it properly.

## The bug

The "CLI Commands" table lists subcommand alternatives as `<new|list|switch>`. Inside a markdown table cell an unescaped `|` **terminates the cell**, so GitHub splits each of those rows across extra columns and the table renders misaligned.

Present on `main` in all four locales, 7 rows each:

```
| `moai worktree <new|list|switch|sync|remove|clean|go>` | Git worktree management ... |
| `moai session <list|register|current>` | Multi-session coordination |
| `moai spec <audit|archive|lint|list|new>` | SPEC lifecycle tools |
| `moai goal <arm|status|clear>` | Goal engine CLI |
| `moai harness <status|apply|rollback|disable>` | Harness learning lifecycle |
| `moai handoff <save|list>` | Session handoff records |
| `moai preference <list|decay-scan|toggle>` | Decision memory management |
```

## The fix

Escape as `\|` so the pipe is literal. Content otherwise unchanged — 28 insertions, 28 deletions, all escaping.

## Verification

```
README.md     0 unescaped   7 escaped
README.ko.md  0 unescaped   7 escaped
README.ja.md  0 unescaped   7 escaped
README.zh.md  0 unescaped   7 escaped
```

The escaped rows were verified **byte-identical** (md5 per file) to an independently-produced fix of the same table that was sitting uncommitted in the primary checkout — two separate derivations agreeing.

Note: rows like `` | `review` / `gate` / `clean` | ... | `` look similar to a naive grep but are **not** affected; those pipes are genuine cell separators.

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed Markdown rendering in CLI command tables across English, Japanese, Korean, and Chinese documentation.
  * Escaped pipe separators in command option examples so alternatives display correctly without disrupting table formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->