### PR TITLE
fix(hook): restore deferred project-root resolution in pre_tool.go

### DIFF
--- a/internal/hook/pre_tool.go
+++ b/internal/hook/pre_tool.go
@@ -312,27 +312,31 @@ func (p *SecurityPolicy) MergeExtraPatterns(extra *security.ExtraSecurityConfig)
 // and scanning tool input for dangerous patterns (REQ-HOOK-031, REQ-HOOK-032).
 // Optionally integrates with SecurityScanner for AST-based security scanning.
 type preToolHandler struct {
-	cfg        ConfigProvider
-	policy     *SecurityPolicy
-	scanner    *security.SecurityScanner
+	cfg     ConfigProvider
+	policy  *SecurityPolicy
+	scanner *security.SecurityScanner
+	// projectDir is the resolved project root. Tests may set it directly; the
+	// production constructors leave it empty and let projectRoot resolve it.
 	projectDir string
+	projectRootResolver
 }
 
 // NewPreToolHandler creates a new PreToolUse event handler with the given security policy.
-// projectDir is resolved via resolveProjectRootFromEnv: CLAUDE_PROJECT_DIR env
-// var first, then os.Getwd() fallback with slog.Warn cwd_fallback:true marker
+// projectDir is resolved on first use via resolveProjectRootFromEnv: CLAUDE_PROJECT_DIR
+// env var first, then os.Getwd() fallback with slog.Warn cwd_fallback:true marker
 // (REQ-HCWA-005, REQ-HCWA-008).
 func NewPreToolHandler(cfg ConfigProvider, policy *SecurityPolicy) Handler {
-	projectDir := resolveProjectRootFromEnv("NewPreToolHandler")
-	return &preToolHandler{cfg: cfg, policy: policy, projectDir: projectDir}
+	return &preToolHandler{
+		cfg:                 cfg,
+		policy:              policy,
+		projectRootResolver: projectRootResolver{caller: "NewPreToolHandler"},
+	}
 }
 
 // NewPreToolHandlerWithScanner creates a PreToolUse handler with AST-based security scanning.
 // If scanner is nil or unavailable, falls back to pattern-based security only.
-// projectDir is resolved via resolveProjectRootFromEnv (REQ-HCWA-005, REQ-HCWA-008).
+// projectDir is resolved on first use via resolveProjectRootFromEnv (REQ-HCWA-005, REQ-HCWA-008).
 func NewPreToolHandlerWithScanner(cfg ConfigProvider, policy *SecurityPolicy, scanner *security.SecurityScanner) Handler {
-	projectDir := resolveProjectRootFromEnv("NewPreToolHandlerWithScanner")
-
 	// Validate scanner availability
 	if scanner != nil && !scanner.IsAvailable() {
 		slog.Info("ast-grep not available, security scanning disabled")
@@ -340,11 +344,16 @@ func NewPreToolHandlerWithScanner(cfg ConfigProvider, policy *SecurityPolicy, sc
 	}
 
 	return &preToolHandler{
-		cfg:        cfg,
-		policy:     policy,
-		scanner:    scanner,
-		projectDir: projectDir,
+		cfg:                 cfg,
+		policy:              policy,
+		scanner:             scanner,
+		projectRootResolver: projectRootResolver{caller: "NewPreToolHandlerWithScanner"},
 	}
+}
+
+// projectRoot returns the project root, resolving it on first use.
+func (h *preToolHandler) projectRoot() string {
+	return h.resolve(&h.projectDir)
 }
 
 // EventType returns EventPreToolUse.
@@ -458,7 +467,7 @@ func (h *preToolHandler) Handle(ctx context.Context, input *HookInput) (*HookOut
 	// (MOAI_BRANCH_GUARD_EXEMPT + manager-git identity) is unchanged and is
 	// consulted only on the enabled path (REQ-6 backward compat).
 	if input.ToolName == "Bash" && len(input.ToolInput) > 0 && h.branchGuardEnabled() {
-		if decision, reason := checkBranchState(input, h.projectDir); decision == DecisionDeny {
+		if decision, reason := checkBranchState(input, h.projectRoot()); decision == DecisionDeny {
 			slog.Warn("branch guard denied",
 				"tool_name", input.ToolName,
 				"session_id", input.SessionID,
@@ -503,7 +512,7 @@ func (h *preToolHandler) Handle(ctx context.Context, input *HookInput) (*HookOut
 		// edit. The return is intentionally discarded (advisory only — never Deny).
 		// This is the mechanical companion to the procedural Pre-Edit Sync Check
 		// doctrine (agent-common-protocol.md § Pre-Edit Sync Check).
-		checkForeignSessionAdvisory(input, h.projectDir)
+		checkForeignSessionAdvisory(input, h.projectRoot())
 
 		// AST-based security scanning for Write operations
 		if input.ToolName == "Write" && h.scanner != nil {
@@ -566,7 +575,7 @@ func (h *preToolHandler) scanWriteContent(ctx context.Context, toolInput json.Ra
 	_ = tmpFile.Close() // Close before scanning
 
 	// Scan the temporary file
-	result, err := h.scanner.ScanFile(ctx, tmpFile.Name(), h.projectDir)
+	result, err := h.scanner.ScanFile(ctx, tmpFile.Name(), h.projectRoot())
 	if err != nil {
 		slog.Warn("security scan failed", "error", err)
 		return "", ""
@@ -668,8 +677,8 @@ func (h *preToolHandler) loadGateConfig() *quality.GateConfig {
 	// (including the DefaultGateConfig fallback when no config provider is
 	// loaded), so a project requiring non-default build tags (e.g. goolm) is
 	// vetted/linted/tested under them regardless of config availability.
-	qcfg.ProjectDir = h.projectDir
-	qcfg.GoBuildTags = readGoBuildTags(h.projectDir)
+	qcfg.ProjectDir = h.projectRoot()
+	qcfg.GoBuildTags = readGoBuildTags(qcfg.ProjectDir)
 	return qcfg
 }
 
@@ -775,8 +784,8 @@ func (h *preToolHandler) checkFileAccess(toolInput json.RawMessage, toolName str
 	}
 
 	// Check if path is within project directory
-	if h.projectDir != "" {
-		projectAbs, absErr := filepath.Abs(h.projectDir)
+	if projectDir := h.projectRoot(); projectDir != "" {
+		projectAbs, absErr := filepath.Abs(projectDir)
 		if absErr != nil {
 			// Cannot resolve project directory, skip boundary check
 			slog.Debug("cannot resolve project directory", "error", absErr)
@@ -947,7 +956,7 @@ func (h *preToolHandler) allowedExternalPaths() []string {
 	if h.policy != nil {
 		paths = append(paths, h.policy.AllowedExternalPaths...)
 	}
-	paths = append(paths, loadAdditionalDirectories(h.projectDir)...)
+	paths = append(paths, loadAdditionalDirectories(h.projectRoot())...)
 	return paths
 }
 


### PR DESCRIPTION
## Problem

Running any non-trivial `moai` subcommand printed a startup warning that names a
condition which is not a fault:

```
level=WARN msg="cwd fallback used (CLAUDE_PROJECT_DIR not set)" \
  cwd_fallback=true caller=NewPreToolHandlerWithScanner
```

## Cause

#1235 fixed this by moving `preToolHandler`'s project-root resolution from the
constructor to first use. #1237 branched **before** #1235 and its squash-merge
reverted `internal/hook/pre_tool.go`, restoring the eager
`resolveProjectRootFromEnv` call. The sibling fixes in `root.go`, `deps.go` and
`subagent_start.go` survived — only this file regressed.

`InitDependencies` constructs every handler for every non-trivial subcommand,
long before a hook event is dispatched. `CLAUDE_PROJECT_DIR` is legitimately
unset at that point, so cwd is the correct answer rather than a degraded one.

## Change

Restores the `projectRootResolver` embed and the `projectRoot()` accessor, and
routes every read through it — including the three call sites #1237 added after
#1235 was authored (`checkBranchState`, `checkForeignSessionAdvisory`,
`loadAdditionalDirectories`). Those read `h.projectDir` directly, which under
deferred resolution would observe the empty pre-resolution value.

Resolution semantics are unchanged: `CLAUDE_PROJECT_DIR`, then `os.Getwd`,
computed once via `sync.Once`.

## Verification

| Check | Result |
|---|---|
| WARN count, pre-fix binary, non-trivial subcommand | 3 |
| WARN count, rebuilt binary | 0 |
| `go build ./...` | pass |
| `go vet ./internal/hook/...` | pass |
| `go test ./internal/hook/...` | all packages ok |
| `moai hook pre-tool` with a real event payload | `{"permissionDecision":"allow"}` — resolution intact |

Unrelated pre-existing failure, confirmed present without this change:
`scripts/i18n-validator` `TestBudget_FullRepoScanWithin35Sec` (58s vs 35s ceiling).

🗿 MoAI