### PR TITLE
docs(SPEC-UPDATE-YAML-PRESERVE-001): plan-phase artifacts + independent audit

### DIFF
--- a/.moai/specs/SPEC-UPDATE-YAML-PRESERVE-001/acceptance.md
+++ b/.moai/specs/SPEC-UPDATE-YAML-PRESERVE-001/acceptance.md
@@ -1,0 +1,275 @@
+# Acceptance — SPEC-UPDATE-YAML-PRESERVE-001
+
+All commands are run from the repository root `/Users/goos/MoAI/moai-adk-go`.
+
+## §D AC Matrix
+
+| AC | REQ | Milestone | Severity | Verification |
+|----|-----|-----------|----------|--------------|
+| AC-UYP-001 | REQ-UYP-001 | M3 | MUST | golden test — comment count preserved |
+| AC-UYP-002 | REQ-UYP-002 | M3 | MUST | golden test — key order preserved |
+| AC-UYP-003 | REQ-UYP-003 | M3 | MUST | golden test — quoting preserved |
+| AC-UYP-004 | REQ-UYP-004 | M2 | MUST | `SetIndent(2)` present + indent-width assertion |
+| AC-UYP-005 | REQ-UYP-005 | M3 | MUST | byte-identity on no-edit merge |
+| AC-UYP-006 | REQ-UYP-006 | M4 | MUST | user-added key survives |
+| AC-UYP-007 | REQ-UYP-007 | M4 | SHOULD | stderr advisory names retained key |
+| AC-UYP-008 | REQ-UYP-008 | M4 | MUST | 3-way retention ⊇ 2-way retention |
+| AC-UYP-009 | REQ-UYP-009 | M2 | MUST | existing decision tests still green |
+| AC-UYP-010 | REQ-UYP-010 | M2 | MUST | system-field tests still green |
+| AC-UYP-011 | REQ-UYP-011 | M2 | MUST | invalid-YAML error tests still green |
+| AC-UYP-012 | REQ-UYP-012 | M1 | MUST | alias node not expanded |
+| AC-UYP-013 | REQ-UYP-013 | M1 | SHOULD | merge key treated as ordinary key |
+| AC-UYP-014 | REQ-UYP-014 | M1 | MUST | sequence replaced wholesale |
+| AC-UYP-015 | REQ-UYP-015 | M2 | MUST | multi-document input errors |
+| AC-UYP-016 | REQ-UYP-016 | M1 | MUST | null ≠ empty mapping |
+| AC-UYP-017 | REQ-UYP-017 | M3 | MUST | golden test enumerates all templates |
+| AC-UYP-018 | REQ-UYP-018 | M4 | MUST | no drop-asserting test remains |
+| AC-UYP-019 | REQ-UYP-019 | M6 | MUST | no fixture under templates/ |
+| AC-UYP-020 | §D constraint | M6 | MUST | coverage not regressed |
+| AC-UYP-021 | §E success | M6 | MUST | end-to-end `moai update` preserves |
+| AC-UYP-022 | plan M3 | M3 | MUST | falsifiability — test RED on reverted impl |
+
+## §D.1 Given-When-Then Scenarios
+
+### AC-UYP-001 — comments preserved on merge
+
+**Given** `internal/template/templates/.moai/config/sections/cache.yaml` (16 comment-bearing lines, measured this session)
+**When** it is passed to `MergeYAML3Way(src, src, src)`
+**Then** the output contains the same number of `#`-bearing lines as the input.
+
+```bash
+go test ./internal/cli/update/backup/ -run TestPreserveGolden_Comments -count=1 -v
+```
+
+Falsification baseline (must FAIL before the fix — see AC-UYP-022):
+```bash
+# with the map round-trip restored, this same test reports comments in=16 out=0
+```
+
+### AC-UYP-002 — key order preserved
+
+**Given** a mapping whose source key order is `enabled, session_ttl, spec_ttl, min_cacheable_tokens`
+**When** merged with no user edit
+**Then** the output key order is identical and is NOT the alphabetized `enabled, min_cacheable_tokens, session_ttl, spec_ttl`.
+
+```bash
+go test ./internal/cli/update/backup/ -run TestPreserveGolden_KeyOrder -count=1 -v
+```
+
+### AC-UYP-003 — scalar quoting preserved
+
+**Given** `session_ttl: "1h"` in the source
+**When** the value is carried through unchanged
+**Then** the output line is `session_ttl: "1h"`, not `session_ttl: 1h`.
+
+```bash
+go test ./internal/cli/update/backup/ -run TestPreserveGolden_Quoting -count=1 -v
+```
+
+### AC-UYP-004 — indentation pinned to 2
+
+**Given** the encoder configuration in the merge implementation
+**When** any nested mapping is emitted
+**Then** each nesting level adds exactly 2 spaces.
+
+```bash
+grep -n 'SetIndent(2)' internal/cli/update/backup/*.go
+# expect: at least one match
+go test ./internal/cli/update/backup/ -run TestPreserveGolden_Indent -count=1 -v
+```
+
+### AC-UYP-005 — byte identity on the no-edit case
+
+**Given** any section template where new == old == base
+**When** merged
+**Then** the output bytes equal the input bytes exactly.
+
+```bash
+go test ./internal/cli/update/backup/ -run TestPreserveGolden_ByteIdentity -count=1 -v
+```
+
+### AC-UYP-006 — user-added key survives 3-way merge
+
+**Given** `newData = "shared: new_val\n"`, `oldData = "shared: new_val\nuser_added: custom\n"`, `baseData = "shared: base_val\n"`
+**When** `MergeYAML3Way` runs
+**Then** the output contains `user_added`.
+
+```bash
+go test ./internal/cli/ -run 'TestMergeYAML3Way/user_added_key_not_in_new_template_is_preserved' -count=1 -v
+```
+
+### AC-UYP-007 — retained key is reported
+
+**Given** the AC-UYP-006 inputs
+**When** the merge retains `user_added`
+**Then** an advisory naming `user_added` is written to stderr.
+
+```bash
+go test ./internal/cli/update/backup/ -run TestMergeYAML3Way_ReportsRetainedKey -count=1 -v
+```
+
+### AC-UYP-008 — 3-way is never more destructive than 2-way
+
+**Given** any `(new, old)` pair
+**When** both `MergeYAML3Way(new, old, base)` and `MergeYAMLDeep(new, old)` run
+**Then** every top-level key present in the 2-way output is also present in the 3-way output.
+
+```bash
+go test ./internal/cli/update/backup/ -run TestMerge3WayNotMoreDestructiveThan2Way -count=1 -v
+```
+
+### AC-UYP-009 / AC-UYP-010 / AC-UYP-011 — decision semantics, system fields, error wrapping unchanged
+
+**Given** the pre-existing decision, system-field, and invalid-input test bodies
+**When** run against the node-tree implementation
+**Then** all pass with their semantic assertions intact (whitespace-coupled substrings may be updated per plan M5; decision outcomes may not).
+
+```bash
+go test ./internal/cli/update/backup/ -run 'TestMergeYAML3Way|TestDeepMerge3Way|TestMergeYAMLDeep|TestDeepMergeMaps' -count=1 -v
+go test ./internal/cli/ -run 'TestMergeYAML3Way|TestDeepMerge3Way|TestMergeYAMLDeep|TestDeepMergeMaps|TestValuesEqual' -count=1 -v
+```
+
+### AC-UYP-012 — anchors and aliases not expanded
+
+**Given** a document containing `base: &a {k: v}` and `derived: *a`
+**When** merged
+**Then** the output still contains the literal `*a` alias and does not inline `{k: v}` a second time.
+
+```bash
+go test ./internal/cli/update/backup/ -run TestNodeMerge_AliasNotExpanded -count=1 -v
+```
+
+### AC-UYP-013 — merge key treated as an ordinary key
+
+**Given** a document containing `<<: *defaults`
+**When** merged
+**Then** the `<<` key appears in the output as an ordinary mapping key and its referent is not resolved into sibling keys.
+
+```bash
+go test ./internal/cli/update/backup/ -run TestNodeMerge_MergeKeyNotResolved -count=1 -v
+```
+
+### AC-UYP-014 — sequences replaced wholesale
+
+**Given** `new: [a, b]`, `old: [c]`, `base: [a, b]`
+**When** merged
+**Then** the output sequence is exactly `[c]` (user differs from base → user wins, whole), and never `[a, b, c]` or `[c, b]`.
+
+```bash
+go test ./internal/cli/update/backup/ -run TestNodeMerge_SequenceReplaced -count=1 -v
+```
+
+### AC-UYP-015 — multi-document input errors rather than silently truncating
+
+**Given** input containing two documents separated by `---`
+**When** passed to `MergeYAML3Way`
+**Then** a non-nil error is returned, and its message names the multi-document condition.
+
+```bash
+go test ./internal/cli/update/backup/ -run TestMergeYAML3Way_MultiDocumentErrors -count=1 -v
+```
+
+### AC-UYP-016 — explicit null is distinct from empty mapping
+
+**Given** `k:` (null) on one side and `k: {}` on the other
+**When** compared by the node equality primitive
+**Then** they compare unequal.
+
+```bash
+go test ./internal/cli/update/backup/ -run TestNodeValuesEqual_NullVsEmptyMap -count=1 -v
+```
+
+### AC-UYP-017 — golden test covers every section template
+
+**Given** the 31 files under `internal/template/templates/.moai/config/sections/`
+**When** the golden test runs
+**Then** it reports one subtest per file, and the subtest count equals the file count.
+
+```bash
+ls internal/template/templates/.moai/config/sections/ | grep -cE '\.yaml(\.tmpl)?$'
+go test ./internal/cli/update/backup/ -run TestPreserveGolden -count=1 -v 2>&1 | grep -c '^    --- PASS'
+# the two counts must match
+```
+
+### AC-UYP-018 — no test asserts a user key must be dropped
+
+**Given** the full test tree
+**When** searched for the retired expectation
+**Then** zero matches.
+
+```bash
+matches=$(grep -rn 'expected user_added to be dropped' --include='*_test.go' . || true)
+[ -z "$matches" ] && echo PASS || { echo "FAIL: $matches"; exit 1; }
+```
+
+### AC-UYP-019 — no fixture leaked into the template tree
+
+```bash
+git status --porcelain internal/template/templates/ | tee /dev/stderr | grep -q . && { echo "FAIL: template tree modified"; exit 1; } || echo PASS
+grep -rn 'SPEC-UPDATE-YAML-PRESERVE\|REQ-UYP-' internal/template/templates/ && { echo FAIL; exit 1; } || echo PASS
+```
+
+### AC-UYP-020 — package coverage not regressed
+
+**Given** the pre-flight baseline captured in plan §C step 3
+**When** coverage is re-measured after the change
+**Then** the post-change percentage is greater than or equal to the baseline.
+
+```bash
+go test -cover ./internal/cli/update/backup/
+# compare against the verbatim pre-flight figure recorded in progress.md §E.2
+```
+
+### AC-UYP-021 — end-to-end `moai update` preserves a customized file
+
+**Given** a scratch project in `t.TempDir()` whose `.moai/config/sections/cache.yaml` is the shipped template with `enabled` flipped to `false` and a hand-added `user_note: "keep me"` key
+**When** the update restore path runs over it
+**Then** the resulting file contains all 16 comments, `enabled: false`, `user_note: "keep me"`, `session_ttl: "1h"` still quoted, and 2-space indentation.
+
+```bash
+go test ./internal/cli/ -run TestUpdateEndToEnd_PreservesCustomizedSection -count=1 -v
+```
+
+### AC-UYP-022 — falsifiability: the golden test fails against the old implementation
+
+**Given** `merge.go` temporarily reverted to the `map[string]any` round-trip
+**When** the golden test runs
+**Then** it FAILS.
+
+```bash
+git stash push internal/cli/update/backup/merge.go internal/cli/update/backup/node_merge.go
+go test ./internal/cli/update/backup/ -run TestPreserveGolden -count=1   # expect FAIL
+git stash pop
+go test ./internal/cli/update/backup/ -run TestPreserveGolden -count=1   # expect PASS
+```
+
+Both observations are recorded verbatim in `progress.md` §E.2. A golden test that passes in both states is vacuous and does not satisfy this AC.
+
+## §D.2 Indirect Verification
+
+- **AC-UYP-005 subsumes AC-UYP-001 through AC-UYP-004** on the no-edit path: byte identity implies comment, order, quoting, and indent preservation. The four narrower ACs are retained because they localize a failure — a byte-identity failure alone does not say which property broke.
+- **AC-UYP-009/010/011** are verified by the survival of pre-existing tests rather than by new ones; that is deliberate, since the point is that nothing changed.
+
+## §D.3 Closure Gate (Definition of Done)
+
+- [ ] All MUST-severity ACs pass with verbatim command output recorded
+- [ ] AC-UYP-022 falsifiability check shows RED-then-GREEN, both captured
+- [ ] `go test ./... -count=1` fully green
+- [ ] `golangci-lint run ./internal/cli/...` clean
+- [ ] `GOOS=windows GOARCH=amd64 go build ./...` succeeds
+- [ ] `internal/template/templates/` unmodified (AC-UYP-019)
+- [ ] Package coverage ≥ pre-flight baseline (AC-UYP-020)
+- [ ] Decision D5 deferral carried into a follow-up SPEC stub at sync time
+
+## §D.4 Forward-Looking Checks (Post-Merge)
+
+- Re-run AC-UYP-021 against a real user project after the next release to confirm the #1243 report is closed in practice.
+- Confirm the D5 follow-up SPEC (`SPEC-UPDATE-TEMPLATE-BASE-SNAPSHOT-001`) is filed, since this SPEC's fix makes the stale-base symptom the remaining visible one.
+
+## §D.5 Quality Gate Criteria (TRUST 5)
+
+- **Tested**: coverage at or above baseline; every requirement bound to a runnable command above.
+- **Readable**: English godoc on every new exported symbol; the node-walk primitive documented with the yaml.v3 `Content` pairing convention it depends on.
+- **Unified**: `gofmt` clean; `snake_case.go` filenames.
+- **Secured**: no new external input surface — the merge reads files the update path already read. Error paths return wrapped errors and never panic.
+- **Trackable**: single conventional commit referencing `#1243`.

--- a/.moai/specs/SPEC-UPDATE-YAML-PRESERVE-001/audit.md
+++ b/.moai/specs/SPEC-UPDATE-YAML-PRESERVE-001/audit.md
@@ -1,0 +1,329 @@
+# Plan-Phase Audit — SPEC-UPDATE-YAML-PRESERVE-001
+
+Auditor: `plan-auditor` (independent, adversarial stance)
+Date: 2026-07-31
+Iteration: 1/3
+Tier: M → PASS threshold **0.80**
+
+**Reasoning context ignored per M1 Context Isolation.** The authoring agent's claims (clean `moai spec lint`, "every `file:line` matches the current tree") were treated as unverified and re-measured independently. The "Background" section supplied in the audit request was likewise treated as unverified — one of its claims (`internal/cli/update/coverage_improvement_test.go`) is wrong; the file is `internal/cli/coverage_improvement_test.go`.
+
+---
+
+## Verdict
+
+| | |
+|---|---|
+| **Verdict** | **FAIL** |
+| **Overall score** | **0.71** (harmonic mean; Tier M threshold 0.80) |
+| Must-pass firewall | all clear (MP-1..MP-7) |
+| Failure driver | Consistency + Testability — one requirement is **unsatisfiable with the chosen mechanism**, one **contradicts a sibling requirement**, and 14 of 22 AC commands **pass vacuously** |
+
+The SPEC is well-researched and its two headline defect diagnoses (Defect A, Defect B) are **CONFIRMED true**. It fails on the third axis: the preservation *contract* it writes is partly unachievable, partly unfalsifiable, and misses one loss class and one unparseable template.
+
+---
+
+## Must-Pass Results
+
+- **[PASS] MP-1 REQ number consistency** — REQ-UYP-001 … REQ-UYP-019, sequential, no gaps, no duplicates, consistent 3-digit padding (`spec.md:121-165`).
+- **[PASS] MP-2 GEARS format compliance** — every REQ matches a GEARS pattern: event-driven `When …, the … shall` (001,002,003,006,007,012,013,014,015,016), state-driven `While …, the … shall` (005), ubiquitous `The … shall` (004,008,009,010,011,017,018,019). Zero informal ACs-as-requirements, zero Given/When/Then mislabelled as GEARS.
+- **[PASS] MP-3 YAML frontmatter validity** — all 12 canonical fields present with canonical names (`spec.md:2-17`); no rejected snake_case alias (`created_at`/`updated_at`/`labels`/`spec_id`). Minor deviations noted as NICE-TO-HAVE #15.
+- **[N/A] MP-4 language neutrality** — single-language SPEC (Go only; `module: cli`). Auto-pass.
+- **[PASS] MP-5 D7 cross-SPEC reconciliation** — all 3 `related_specs` exist; none is retired/superseded/archived:
+  ```
+  SPEC-CLI-TUX-V3-003: status: completed
+  SPEC-V3R6-UPDATE-NOISE-001: status: implemented
+  SPEC-V3R6-V2-V3-CLEAN-REINSTALL-002: status: completed
+  ```
+- **[N/A] MP-6 D8 cross-platform discipline** — `grep -c syscall` over all 4 artifacts returns `0` in each. D8 auto-PASS.
+- **[PASS] MP-7 clarification gate** — `grep -rn '\[NEEDS CLARIFICATION' .moai/specs/SPEC-UPDATE-YAML-PRESERVE-001/` → exit 1, no matches.
+
+---
+
+## Category Scores
+
+| Dimension | Score | Band | Evidence |
+|---|---|---|---|
+| Clarity | 0.75 | 0.75 | REQ-UYP-004 vs REQ-UYP-005 contradict for 4-space-indented sources (`archive.yaml`); "31 files" stated where 30 exist |
+| Completeness | 0.75 | 0.75 | blank-line loss class absent from the requirement set; `quality.yaml.tmpl` unparseability unhandled |
+| Testability | 0.50 | 0.50 | 14 of 22 AC commands exit 0 with `no tests to run`; the single falsifiability guard (AC-UYP-022) is non-executable as written |
+| Traceability | 1.00 | 1.0 | REQ-001..019 each have ≥1 AC; AC-001..019 each cite a valid REQ; AC-020/021/022 cite spec sections (see NICE-TO-HAVE #14) |
+
+Harmonic mean = 4 / (1/0.75 + 1/0.75 + 1/0.50 + 1/1.00) = **0.706 → 0.71**
+
+---
+
+## What the SPEC gets RIGHT (independently confirmed)
+
+Every one of these was re-measured; none is taken on the author's word.
+
+| Claim | Cited location | Status |
+|---|---|---|
+| `MergeYAML3Way` map round-trip | `merge.go:20-35` (func at `:20`, `yaml.Marshal` at `:34`) | **CONFIRMED** |
+| `MergeYAMLDeep` map round-trip | `merge.go:116-130` (func at `:116`, marshal at `:129`) | **CONFIRMED** |
+| Old-only-key drop comment | `merge.go:95-97` — `grep -n 'Keys only in old'` → `95:` | **CONFIRMED verbatim** |
+| 2-way preserves old-only keys | `merge.go:168-171` — `grep -n 'Only exists in old'` → `169:` | **CONFIRMED** |
+| Misnamed subtest asserting the opposite of its name | `update_yaml_test.go:591-603` — name at `:591`, inverted assertion at `:600` | **CONFIRMED** |
+| Three production call sites | `restore.go:121,139,207` | **CONFIRMED** |
+| Zero comment-preservation tests | AC-UYP-018 grep executed → 1 hit, and it is the *drop*-asserting one | **CONFIRMED** |
+| Comment loss is total on every merge | measured across all 30 templates (see Evidence §2) | **CONFIRMED and worse than stated** — e.g. `llm.yaml` 120→0, `harness.yaml` 65→0, `lsp.yaml.tmpl` 88→0 |
+| 0 anchors / 0 merge keys / 0 multi-document | re-surveyed independently | **CONFIRMED — all three counts hold** |
+| 8 files carry block sequences | re-derived: `design, harness, interview, lsp.tmpl, mx, quality.tmpl, security, sunset` | **CONFIRMED — exact match** |
+| `moai spec lint` clean | `moai spec lint .moai/specs/SPEC-UPDATE-YAML-PRESERVE-001/spec.md` → `✓ No findings` | **CONFIRMED** |
+
+---
+
+## Defects Found
+
+### MUST-FIX
+
+**D1 — `acceptance.md:81-89` + `spec.md:129` (REQ-UYP-005) + `plan.md:186` — byte-identity is UNSATISFIABLE with the chosen mechanism. Severity: critical.**
+
+REQ-UYP-005 requires byte-identical output on a no-change merge; plan M3 calls it "the strongest single assertion"; acceptance §D.2 builds a subsumption argument on it; spec §E success criterion 1 restates it. **Measured against a faithful implementation of exactly what D1 prescribes** (`yaml.Unmarshal` → `yaml.Node` → `yaml.NewEncoder` + `SetIndent(2)` → `Encode`/`Close`), only **8 of 30** templates are byte-identical; **22 differ**.
+
+Failure scenario: M3 is authored, the golden byte-identity assertion is written, and it fails on 22 of 30 subtests through no fault of the implementation. The plan's own §G anti-pattern ("Do not delete a failing assertion to reach green") then blocks the only escape, and M3 deadlocks.
+
+Minimal correction: demote REQ-UYP-005 from byte-identity to the property set it was proxying (comment count **and content**, key order, quoting, emitted indent), and move byte-identity to a documented non-goal with the measured 8/30 figure as its rationale. Update `spec.md` §E criterion 1 and `acceptance.md` §D.2 accordingly.
+
+---
+
+**D2 — `spec.md:127` (REQ-UYP-004) vs `spec.md:129` (REQ-UYP-005) — direct intra-SPEC contradiction. Severity: critical.**
+
+REQ-UYP-004 mandates `SetIndent(2)`. `archive.yaml` is authored at **4-space** indent. A `SetIndent(2)` encoder therefore MUST reindent it, which MUST violate REQ-UYP-005. Verified by diff (Evidence §3): every line of `archive.yaml` shifts left by 2 columns.
+
+This also falsifies the `spec.md:53` premise "**indent widened** (2-space → yaml.v3's default 4-space)" as a general statement — for `archive.yaml` the current behaviour is a *no-op* on indent and the fix *narrows* it.
+
+Minimal correction: state REQ-UYP-004 as "the emitted document uses 2-space block-mapping indentation, normalizing sources that differ", and record `archive.yaml` as the known reindent case. Resolve against D1's demotion of REQ-UYP-005.
+
+---
+
+**D3 — `spec.md:53` ("Four distinct losses") — a fifth loss class (blank lines) is missing from the entire requirement set. Severity: major.**
+
+The node round-trip preserves comment *count* perfectly (measured: every DIFFER file shows `comments N->N`) yet still loses bytes. The delta is **blank lines**, which `yaml.v3` does not model: `workflow.yaml` 6797→6195 (−602 B), `llm.yaml` 9780→9173 (−607 B), `delegation.yaml` 4826→4301 (−525 B). No REQ, no AC, and no Out of Scope entry mentions blank lines.
+
+Failure scenario: the fix ships, all 19 ACs pass, and a user running `moai update` still sees their config visually reflowed — every blank line between config groups collapsed. The #1243 complaint is only partly closed, and the SPEC's own §E criterion 2 ("preserves … every comment, key order, and quoting style") is technically met while the file still looks mangled.
+
+Minimal correction: add a REQ for blank-line preservation, **or** add an explicit `### Out of Scope — blank-line preservation` entry naming the measured byte deltas. Silence is the one option that is not acceptable.
+
+---
+
+**D4 — `plan.md:144` (Decision D6) — the claim that `.tmpl` files "parse fine as scalars" is FALSE, and its consequence is a live production defect the SPEC never identifies. Severity: critical.**
+
+`quality.yaml.tmpl` contains **unquoted** placeholders — `enforce_quality: {{.EnforceQuality}}` (`:13`) and `test_coverage_target: {{.TestCoverageTarget}}` (`:16`). YAML reads `{{…}}` as a nested flow mapping, so the map decode fails:
+
+```
+MERGE-FAIL quality.yaml.tmpl: unmarshal new YAML: yaml: invalid map key: map[string]interface {}{".EnforceQuality":interface {}(nil)}
+```
+
+Every other `.tmpl` quotes its placeholders; `quality.yaml.tmpl` is the sole exception. Three consequences:
+
+1. **REQ-UYP-017 / AC-UYP-017 are unsatisfiable against the current implementation** — the golden set is defined as *every* `*.yaml`/`*.yaml.tmpl`, and one member cannot be merged at all.
+2. **`plan.md:144`'s appeal to `SaveTemplateDefaults` (`backup.go:180-186`) is not evidence** — that function copies `.tmpl` files **raw** and never parses them, so it cannot testify to parseability.
+3. **Undiscovered live defect**: `SaveTemplateDefaults` writes the raw template as the base, stripping `.tmpl` (`backup.go:184`), so the 3-way base for `quality.yaml` is unparseable. `restore.go:121` therefore errors and **silently falls back to 2-way merge for `quality.yaml` on every single `moai update` today.** The SPEC's blast-radius section (`spec.md:84-86`) does not mention this.
+
+The node tree *does* parse the file (measured 6605→6607 bytes), so the fix incidentally repairs it — which makes this a behaviour change that must be named, not a free win.
+
+Minimal correction: (a) correct `plan.md` D6; (b) record the `quality.yaml` 2-way-fallback finding in `spec.md` §A blast radius; (c) add an AC asserting `MergeYAML3Way` on `quality.yaml.tmpl` returns nil error post-fix; (d) see D9 for the D5-interaction this creates.
+
+---
+
+**D5 — `acceptance.md:239-244` (AC-UYP-022) — the falsifiability command is NON-EXECUTABLE. Severity: critical.**
+
+Run verbatim:
+
+```
+$ git stash push internal/cli/update/backup/merge.go internal/cli/update/backup/node_merge.go
+error: pathspec ':(prefix:0)internal/cli/update/backup/node_merge.go' did not match any file(s) known to git
+Did you forget to 'git add'?
+exit 1
+```
+
+`node_merge.go` is a **new, untracked** file at the moment AC-UYP-022 runs, and `git stash push` rejects untracked pathspecs without `-u`. The command aborts atomically — nothing is stashed, so the operator sees the golden test still GREEN and may mis-read that as "the check ran and the tree was fine".
+
+This is the load-bearing defect: AC-UYP-022 is the *only* mechanism in the entire SPEC that distinguishes a real preservation test from a vacuous one, and it does not run.
+
+Minimal correction: `git stash push -u internal/cli/update/backup/merge.go internal/cli/update/backup/node_merge.go`, and assert the intermediate state explicitly (`git status --porcelain internal/cli/update/backup/` shows `merge.go` restored and `node_merge.go` absent) before running the RED test.
+
+---
+
+**D6 — `acceptance.md` §D.1 (14 ACs) — commands pass VACUOUSLY. Severity: critical.**
+
+Every AC of the form `go test ./pkg/ -run TestX` exits 0 when `TestX` does not exist. Verified verbatim against the current tree:
+
+```
+$ go test ./internal/cli/update/backup/ -run TestPreserveGolden_Comments -count=1 -v
+testing: warning: no tests to run
+PASS
+ok  github.com/modu-ai/moai-adk/internal/cli/update/backup  15.316s [no tests to run]
+exit 0
+```
+
+Affected: **AC-UYP-001, -002, -003, -004 (second command), -005, -006, -007, -008, -012, -013, -014, -015, -016, -021** — 14 of 22. Only AC-017 (count comparison), AC-018 and AC-019 (grep with explicit exit) are guarded today.
+
+Failure scenario: run-phase reports a green AC matrix having implemented none of the named tests, or having named them slightly differently (e.g. `TestPreserveGolden_Comment` singular). Every command exits 0 and the matrix reads PASS.
+
+Minimal correction: append an existence assertion to each, e.g.
+```bash
+go test ./internal/cli/update/backup/ -run TestPreserveGolden_Comments -count=1 -v 2>&1 \
+  | tee /dev/stderr | grep -q '^--- PASS: TestPreserveGolden_Comments'
+```
+AC-UYP-006's subtest form additionally needs the exact Go-normalized subtest name (spaces → underscores) pinned.
+
+### SHOULD-FIX
+
+**D7 — `plan.md:32`, `plan.md:144`, `acceptance.md:184`, `progress.md:10` — the template count is 30, not 31.**
+```
+$ ls internal/template/templates/.moai/config/sections/ | grep -cE '\.yaml(\.tmpl)?$'
+30
+```
+AC-UYP-017's command self-derives the count, so the AC survives; the stale figure sits in the risk register and in the "verified baseline" table, weakening confidence in the surrounding measurements. Correct all four occurrences to 30.
+
+**D8 — `plan.md:93` (Decision D2) — "seven test call sites" enumerates eight.**
+`update_yaml_test.go:346,925` (2) + `backup_test.go:427,445,536,551` (4) + `backup_error_test.go:99,117` (2) = **8**. All eight verified present at the cited lines. The prose count is off by one; the enumeration is correct.
+
+**D9 — `plan.md:136` (Decision D5, safety argument #4) — the deferral rationale is directionally sound but under-verified given D4.**
+D5 argues the deferral is safe because "a node-tree base loads through the same code path a map base does". For `quality.yaml` the base does not load *at all* today (D4). Post-fix it will load, so `quality.yaml` transitions from *always-2-way* to *real-3-way* — and D5's wrong-base problem, which currently cannot manifest for that file, starts manifesting: every `{{.Version}}`-style placeholder in the base differs from the user's rendered value, so `old != base` fires and every key is read as a user edit. The deferral remains defensible (D5's failure mode is a stale value; this SPEC's is a destroyed file), but the plan must state that this SPEC **enlarges** D5's blast radius rather than leaving it neutral.
+
+**D10 — `merge.go:102` `ValuesEqual` — fate unspecified under the D2 signature change.**
+`ValuesEqual` is exported and is the sole equality primitive of the map implementation. Once `DeepMerge3Way`/`DeepMergeMaps` are node-typed it has no caller, yet `TestValuesEqual` appears in AC-UYP-009's command list (`acceptance.md:129`). The plan must state: retain (and why), or delete (and drop the test from AC-UYP-009).
+
+**D11 — `acceptance.md:214-221` (AC-UYP-020) — the coverage baseline does not exist yet.**
+The AC compares against "the verbatim pre-flight figure recorded in `progress.md` §E.2", and `progress.md:16` currently reads `_<pending run-phase>_`. Until the figure is captured the constraint cannot fail. Capture `go test -cover ./internal/cli/update/backup/` at plan time and write the number into the SPEC.
+
+**D12 — `acceptance.md:225-231` (AC-UYP-021) — the end-to-end fixture is the least-affected file.**
+`cache.yaml` is one of the **8** templates that round-trip byte-identically. Using it as the sole end-to-end subject is selection bias: the E2E will pass even if blank-line handling (D3) is entirely broken. Add a DIFFER-class file — `workflow.yaml` (−602 B) is the strongest single discriminator.
+
+**D13 — `acceptance.md:208` (AC-UYP-019) — brittle command form.**
+`git status --porcelain internal/template/templates/ | tee /dev/stderr | grep -q . && { … exit 1; } || echo PASS` mixes a diagnostic tee into the exit-status path. Measured today: 0 porcelain lines (would PASS). Prefer `[ -z "$(git status --porcelain internal/template/templates/)" ] && echo PASS || { git status --porcelain internal/template/templates/; exit 1; }`.
+
+### NICE-TO-HAVE
+
+**D14 — `acceptance.md:28-30`** — AC-UYP-020/021/022 trace to `§D constraint` / `§E success` / `plan M3` rather than a `REQ-UYP-xxx`. Defensible (they verify constraints and the test contract itself), but strict traceability would prefer promoting the falsifiability obligation to a REQ.
+
+**D15 — `spec.md:4,9,10`** — frontmatter cosmetics vs `spec-frontmatter-schema.md`: `version: 0.1.0` is unquoted where the schema specifies a quoted semver string; `priority: high` is lowercase against the `High|Medium|Low|Critical` enum; `phase: plan` names a lifecycle phase where the schema expects a release target (`"v3.0.0"`). `moai spec lint` accepts all three, so this is cosmetic only.
+
+**D16 — `spec.md:53`** — "indent widened (2-space → yaml.v3's default 4-space)" generalizes a `cache.yaml`-specific observation. See D2.
+
+---
+
+## Report — 5-Section Evidence Format
+
+### 1. Claim
+
+The plan-phase artifacts of `SPEC-UPDATE-YAML-PRESERVE-001` correctly diagnose the defect but specify a preservation contract that is (a) partly unachievable with the chosen mechanism, (b) internally contradictory on indentation, (c) incomplete on blank lines and on `quality.yaml.tmpl`, and (d) largely unfalsifiable because its verification commands pass vacuously and its single anti-vacuity guard does not execute.
+
+### 2. Evidence (verbatim commands + output)
+
+**§2.1 — Vacuous AC (AC-UYP-001, verbatim from `acceptance.md:41`)**
+```
+$ go test ./internal/cli/update/backup/ -run TestPreserveGolden_Comments -count=1 -v
+testing: warning: no tests to run
+PASS
+ok  	github.com/modu-ai/moai-adk/internal/cli/update/backup	15.316s [no tests to run]
+EXIT=0
+```
+
+**§2.2 — Current-implementation loss, measured over all 30 templates** (scratch `_test.go` in the package, removed after measurement; `MergeYAML3Way(b,b,b)` per AC-UYP-001's Given/When)
+```
+FILE COUNT = 30
+LOSS archive.yaml: comments in=18 out=0  bytes in=1099 out=28
+LOSS cache.yaml: comments in=16 out=0  bytes in=1127 out=101
+LOSS harness.yaml: comments in=65 out=0  bytes in=8160 out=4785
+LOSS llm.yaml: comments in=120 out=0  bytes in=9780 out=4385
+LOSS lsp.yaml.tmpl: comments in=88 out=0  bytes in=11295 out=8244
+LOSS workflow.yaml: comments in=46 out=0  bytes in=6797 out=4776
+... (26 files total show total comment loss)
+MERGE-FAIL quality.yaml.tmpl: unmarshal new YAML: yaml: invalid map key: map[string]interface {}{".EnforceQuality":interface {}(nil)}
+```
+(`llm.yaml` measures 120 comment lines, not the 119 stated at `spec.md:86`/`plan.md:40`.)
+
+**§2.3 — Node round-trip byte identity (the mechanism `plan.md` §E D1 prescribes)**
+```
+DIFFER archive.yaml: bytes 1099->1061 comments 18->18
+DIFFER delegation.yaml: bytes 4826->4301 comments 37->37
+DIFFER harness.yaml: bytes 8160->8017 comments 65->65
+DIFFER llm.yaml: bytes 9780->9173 comments 120->120
+DIFFER quality.yaml.tmpl: bytes 6605->6607 comments 84->84
+DIFFER workflow.yaml: bytes 6797->6195 comments 46->46
+... (22 files DIFFER)
+SUMMARY identical=8 differ=22 fail=0 total=30
+```
+
+**§2.4 — AC-UYP-022 executed verbatim (`acceptance.md:240`)**
+```
+$ git stash push internal/cli/update/backup/merge.go internal/cli/update/backup/node_merge.go
+error: pathspec ':(prefix:0)internal/cli/update/backup/node_merge.go' did not match any file(s) known to git
+Did you forget to 'git add'?
+STASH-EXIT=1
+```
+
+**§2.5 — Edge-case survey re-run independently**
+```
+anchors/aliases: 0 matches
+merge keys (<<:): 0 matches
+multi-document (^---): 0 matches
+block sequences: 8 files — design, harness, interview, lsp.yaml.tmpl, mx, quality.yaml.tmpl, security, sunset
+file count: 30
+```
+
+**§2.6 — AC-UYP-004, -018, -019 executed verbatim**
+```
+$ grep -n 'SetIndent(2)' internal/cli/update/backup/*.go      → exit 1 (no match — expected pre-fix)
+$ grep -rn 'expected user_added to be dropped' --include='*_test.go' .
+  FAIL: internal/cli/update_yaml_test.go:600
+$ git status --porcelain internal/template/templates/          → 0 lines (PASS)
+$ grep -rn 'SPEC-UPDATE-YAML-PRESERVE\|REQ-UYP-' internal/template/templates/ → exit 1 (PASS)
+```
+
+**§2.7 — `moai spec lint`**
+```
+$ moai spec lint .moai/specs/SPEC-UPDATE-YAML-PRESERVE-001/spec.md
+✓ No findings — all SPEC documents are valid
+```
+
+**§2.8 — `archive.yaml` indent diff (D2)**
+```
+-    # SPEC auto-archive behavior for `moai spec archive`.
++  # SPEC auto-archive behavior for `moai spec archive`.
+-    grace_days: 90
++  grace_days: 90
+```
+
+### 3. Baseline-attribution
+
+All measurements were taken **this session**, against the working tree at `/Users/goos/MoAI/moai-adk-go` on branch `main`. `git status --porcelain internal/template/templates/` returned 0 lines, so the template tree measured is the committed tree. No figure in this report is carried over from the SPEC's own narrative, from `plan.md` §A's "Verified baseline" table, or from the audit request's Background section. Scratch measurement files (`zz_audit_probe*_test.go`) were created under `internal/cli/update/backup/` and **removed**; `git status --porcelain` confirms no residue. The failed `git stash push` (§2.4) aborted atomically — `git stash list` shows only the three pre-existing entries.
+
+### 4. Gaps (NOT verified)
+
+- **AC-UYP-009/010/011** — I did not run the pre-existing decision/system-field/error test suites. Their current green state is assumed from the author's report, not observed.
+- **AC-UYP-020** — package coverage was not measured; the AC's baseline does not exist yet (D11).
+- **`go test ./... -count=1`, `golangci-lint run`, `GOOS=windows go build`** (`acceptance.md` §D.3) — not executed; these are run-phase closure gates.
+- **AC-UYP-021 end-to-end** — the `moai update` restore path was not exercised against a scratch project.
+- The working tree carries unrelated modifications from a parallel session (`docs-site/`, `README.ko.md`). I did not verify whether they affect anything in scope; they touch no path this SPEC names.
+- I did **not** attempt a full node-tree 3-way merge implementation. §2.3 measures the round-trip only (`new == old == base` reduces to a round-trip by construction), which is exactly REQ-UYP-005's stated case — but a real merge could introduce *additional* divergence beyond the 22 files measured. The 8/30 figure is therefore an **upper bound** on byte-identity, not a floor.
+- Whether blank-line preservation is achievable at all within `gopkg.in/yaml.v3 v3.0.1` was not investigated; D3 asks the SPEC to decide, not to assume it is impossible.
+
+### 5. Residual risk
+
+- **The 8/30 byte-identity figure could be read as "mostly works".** It is not: the 22 failures include every large, comment-heavy file (`llm.yaml`, `harness.yaml`, `workflow.yaml`, `lsp.yaml.tmpl`) — precisely the files the SPEC cites as the reason the defect matters.
+- **D6 (vacuous ACs) can mask D1/D2/D3 during run-phase.** If the AC commands are not hardened first, a run-phase agent can report a fully green matrix on a partially-implemented contract. Fix D5 and D6 **before** M1 begins, not at M6.
+- **`quality.yaml.tmpl` (D4) is a behaviour change in disguise.** The node fix silently promotes that file from 2-way to 3-way merge. Without a dedicated AC, that transition is untested and its interaction with the deferred D5 defect (D9) is unobserved.
+- **`llm.yaml` measures 120 comment lines against the SPEC's stated 119.** A one-line drift is harmless in itself, but it is a second independent instance (with the 31-vs-30 count) of a figure in the "verified baseline" table not matching the tree — the table should be regenerated rather than spot-corrected.
+
+---
+
+## Recommendation
+
+**FAIL — return to `manager-spec` for revision.** Ordered, minimal, and scoped to the enumerated defect delta; the confirming re-audit is scoped to these items rather than a from-scratch review.
+
+1. **Resolve the REQ-UYP-004 / REQ-UYP-005 contradiction (D1, D2).** Demote byte-identity to a property set; state the 2-space normalization as intentional; cite the measured 8/30 and the `archive.yaml` reindent. Update `spec.md:127,129`, `spec.md:178` (§E criterion 1), `acceptance.md:81-89`, `acceptance.md:250` (§D.2 subsumption), `plan.md:186`.
+2. **Decide blank-line preservation (D3).** Add a REQ or an explicit `### Out of Scope — blank-line preservation` entry with the measured deltas. Do not leave it unstated.
+3. **Fix `plan.md:144` D6 and record the `quality.yaml` finding (D4).** Correct the "parse fine as scalars" claim; add the permanent 2-way fallback to `spec.md` §A blast radius; add an AC asserting a nil-error 3-way merge for `quality.yaml.tmpl` post-fix.
+4. **Repair AC-UYP-022 (D5).** Add `-u` and an explicit intermediate-state assertion. This is the highest-leverage single edit in the list — it is what makes every other preservation AC non-vacuous.
+5. **Harden the 14 vacuous AC commands (D6)** with a `grep -q '^--- PASS: <TestName>'` (or equivalent) existence assertion, and pin AC-UYP-006's Go-normalized subtest name.
+6. **Correct the stale figures (D7, D8, and `llm.yaml` 119→120).** Regenerate the `plan.md` §A "Verified baseline" and edge-case tables rather than patching individual cells.
+7. **Amend D5's safety argument (D9)** to state that this SPEC enlarges the deferred defect's blast radius for `quality.yaml`.
+8. **Specify `ValuesEqual`'s fate (D10)**, capture the coverage baseline (D11), add a DIFFER-class E2E fixture (D12), and simplify AC-UYP-019 (D13).
+
+Items 1-6 are blocking. Items 7-8 are SHOULD-FIX and may ride the same revision.
+
+**Not required, and explicitly endorsed:** the `SaveTemplateDefaults` deferral itself (D5 in `plan.md`) is a **sound** decision. Its four-point rationale holds — different defect class, new persisted artifact required, backward-compatibility design space, and harm ordering (a stale value is strictly less damaging than a destroyed file). Only the safety argument's fourth point needs the D9 amendment; the deferral should not be reversed.

--- a/.moai/specs/SPEC-UPDATE-YAML-PRESERVE-001/plan.md
+++ b/.moai/specs/SPEC-UPDATE-YAML-PRESERVE-001/plan.md
@@ -1,0 +1,252 @@
+# Plan — SPEC-UPDATE-YAML-PRESERVE-001
+
+Tier **M** (standard). Justification in §A.
+
+## §A Context
+
+### Tier assessment
+
+Tier **M**, matching the prior estimate. The reasoning:
+
+- **File count**: 6-9 files. One production file rewritten (`merge.go`), one new production file (`node_merge.go`), four-plus test files revised (`update_yaml_test.go`, `backup_test.go`, `backup_error_test.go`, `coverage_improvement_test.go`), one new golden test file.
+- **Blast radius**: contained to `internal/cli/update/backup` plus its test consumers. No new package, no new dependency, no config schema change, no template change.
+- **Risk**: medium — the change is behaviour-visible on every `moai update`, and the exported API is consumed from four packages. But the decision semantics are held constant, which bounds what can go wrong.
+- **Not Tier S**: a Tier S SPEC would be a metadata-only or single-file edit with no test-contract work. Here the test contract does not exist and must be built (REQ-UYP-017 through REQ-UYP-019), and a large existing assertion table must be revised.
+- **Not Tier L**: no architectural decision is open, no cross-subsystem coordination is needed, and no research phase is required — the mechanism (`yaml.Node`) is already available in the pinned dependency and its behaviour was reproduced directly.
+
+### Verified baseline (re-read this session, 2026-07-31)
+
+| Claim | Location | Status |
+|---|---|---|
+| `MergeYAML3Way` map round-trip | `merge.go:20-35` | CONFIRMED |
+| `MergeYAMLDeep` map round-trip | `merge.go:116-130` | CONFIRMED |
+| Old-only-key drop comment | `merge.go:95-97` | CONFIRMED verbatim |
+| 2-way preserves old-only keys | `merge.go:168-171` | CONFIRMED |
+| Misnamed subtest | `update_yaml_test.go:591-603` | CONFIRMED (assertion at `:599-601`) |
+| `SaveTemplateDefaults` base from new template | `backup.go:149-192` | CONFIRMED |
+| Zero comment-preservation tests | `grep -rin comment` over both test files | CONFIRMED, 0 matches |
+| Round-trip loss | executed against `cache.yaml` | CONFIRMED — 16 comments → 0, keys alphabetized, `"1h"` → `1h`, 2→4 space indent |
+
+### Edge-case survey of the shipped templates
+
+Executed over `internal/template/templates/.moai/config/sections/` (31 files):
+
+| Feature | Files | Consequence for the plan |
+|---|---|---|
+| Anchors / aliases (`&x` / `*x`) | 0 | REQ-UYP-012 is a defensive contract, not an active migration concern |
+| Merge keys (`<<:`) | 0 | REQ-UYP-013 likewise defensive |
+| Multi-document (`---`) | 0 | REQ-UYP-015 likewise defensive |
+| Block sequences | 8 (`design`, `mx`, `interview`, `harness`, `sunset`, `security`, `lsp.tmpl`, `quality.tmpl`) | REQ-UYP-014 is **live** — sequence policy must be decided, not deferred |
+| Heavy comment payload | `llm.yaml` 119, `lsp.yaml.tmpl` 88, `quality.yaml.tmpl` 84 | golden test must cover all 31, not a sample |
+
+## §B Known Issues
+
+- The existing `internal/cli/update_yaml_test.go` table (from `TestMergeYAML3Way` at `:471` through `:648`) asserts on `contains(string(result), ...)` substrings. Node output changes whitespace and quoting, so several of these assertions become brittle even where behaviour is unchanged. Budgeted as M5.
+- `internal/cli/coverage_improvement_test.go` carries three further `MergeYAML3Way` tests (`:5716`, `:5733`, `:5750`) with the same substring style. Same treatment.
+- `DeepMerge3Way` and `DeepMergeMaps` take and return `map[string]any` in their current exported signatures. A node-tree implementation cannot preserve formatting through a map-typed signature — see Decision D2.
+
+## §C Pre-Flight (Run-Phase Entry Checks)
+
+```bash
+# 1. Confirm the pinned YAML version has not moved
+grep 'gopkg.in/yaml.v3' /Users/goos/MoAI/moai-adk-go/go.mod
+
+# 2. Confirm the baseline suite is green before any edit
+go test ./internal/cli/... 2>&1 | tail -20
+
+# 3. Capture the pre-change package coverage as the baseline for the coverage constraint
+go test -cover ./internal/cli/update/backup/
+
+# 4. Re-confirm the misnamed subtest is still at the cited location
+sed -n '591,603p' internal/cli/update_yaml_test.go
+```
+
+## §D Constraints (Hard)
+
+1. No new dependency. `gopkg.in/yaml.v3 v3.0.1` only.
+2. No file added or modified under `internal/template/templates/` (template neutrality, CLAUDE.local.md §25). Fixtures live in `_test.go` bodies or `t.TempDir()`.
+3. `t.TempDir()` for every temp path; no project-root writes from tests.
+4. Decision semantics held constant (REQ-UYP-009, REQ-UYP-010) — this is a representation change, not a policy change, except for the single deliberate policy reversal in REQ-UYP-006.
+5. Package coverage must not fall below the M0-captured baseline.
+
+## §E Self-Verification (Design Decisions)
+
+### Decision D1 — merge on `*yaml.Node`, not on a formatting-aware map wrapper
+
+**Chosen**: decode each document with `yaml.Unmarshal(data, &node)` into a `yaml.Node`, walk the three node trees in parallel, and encode the result with a `yaml.Encoder` configured `SetIndent(2)`.
+
+**Rejected — a custom `OrderedMap` type carrying comment metadata**: reimplements what `yaml.Node` already provides, and would still lose any node property not modelled by the custom type (style flags, tags, line/column). More code, strictly less fidelity.
+
+**Rejected — textual patching of the template file**: preserves formatting perfectly but cannot express the 3-way decision, which requires structural comparison.
+
+**Consequence**: the merged output's structure and comments come from whichever document supplied each node. Since the new template supplies the structure, template comments (the ones users read) are the ones preserved — which is the desired behaviour, because template comments explain the keys while a user's local edit is usually a value change.
+
+### Decision D2 — signature change for `DeepMerge3Way` / `DeepMergeMaps` (highest-reversibility decision in this SPEC)
+
+`DeepMerge3Way(newMap, oldMap, baseMap map[string]any) map[string]any` cannot preserve formatting: the map type has nowhere to store a comment. The signature must become node-typed:
+
+```go
+func DeepMerge3Way(newNode, oldNode, baseNode *yaml.Node) (*yaml.Node, error)
+func DeepMergeMaps(newNode, oldNode *yaml.Node) (*yaml.Node, error)
+```
+
+**Cascade**: seven test call sites across three files — `update_yaml_test.go:346,925`, `backup_test.go:427,445,536,551`, `backup_error_test.go:99,117`.
+
+**Rejected — keep the map signatures and add parallel node functions**: leaves two merge implementations in the tree, one of which is silently wrong. A future caller picks the wrong one. Dead-code risk with no offsetting benefit.
+
+**Rejected — keep the exported names map-typed and make the node functions unexported**: `DeepMerge3Way` is exercised directly by tests specifically to reach branches `MergeYAML3Way` cannot; hiding it loses that coverage.
+
+**Mitigation**: the two wrapper functions `MergeYAML3Way` / `MergeYAMLDeep` keep their `([]byte, ...) ([]byte, error)` signatures unchanged, so `restore.go` — the only production consumer — needs no edit at all. The cascade is entirely test-side.
+
+### Decision D3 — old-only keys preserved AND reported (REQ-UYP-006, REQ-UYP-007)
+
+Three candidate policies for a key present in the user file and absent from the new template:
+
+| Policy | Behaviour | Verdict |
+|---|---|---|
+| Drop silently | current | Rejected — data loss with no signal; this is the #1243 complaint |
+| Preserve silently | matches `DeepMergeMaps` | Rejected — a genuinely retired template key accumulates as invisible cruft |
+| **Preserve + advisory stderr notice** | **chosen** | Data-safe by default, and the user learns which keys are no longer template-managed |
+
+The asymmetry argument settles it: the 3-way path must not be more destructive than the fallback it degrades to (REQ-UYP-008). Reporting rides the existing stderr advisory channel already used by `restore.go:141` and the fallback recorder — no new output surface.
+
+### Decision D4 — sequence replace, not append (REQ-UYP-014)
+
+Eight shipped templates carry block sequences. Merge policy must be explicit or the behaviour is accidental.
+
+**Chosen — replace wholesale**: a sequence value is treated as a single scalar-like unit for decision purposes. If the user's sequence equals base, take the template's; otherwise keep the user's, whole.
+
+**Rejected — element-wise append**: unbounded growth across repeated `moai update` runs, and no identity notion for elements to deduplicate against.
+
+**Rejected — element-wise merge by index**: meaningless for lists whose order carries no key semantics.
+
+This matches the current behaviour, where a sequence lands in the non-map branch of `DeepMerge3Way` (`merge.go:80-92`) and is compared by `ValuesEqual`'s `fmt.Sprintf("%v", ...)` stringification — so replace-wholesale is a preservation of existing semantics, not a new policy.
+
+### Decision D5 — `SaveTemplateDefaults` base derivation is DEFERRED (explicit, per the SPEC's fourth requirement)
+
+**Decision: DEFER to a follow-up SPEC. Not fixed here.**
+
+The defect is real and confirmed: `SaveTemplateDefaults` (`backup.go:149-192`) reads from `template.EmbeddedTemplates()` — the NEW embedded template — and writes it as the 3-way merge BASE. The 3-way premise is "base = what the user started from". Consequence: when a template default changes between versions and the user never touched that key, `old != base` evaluates true, the key is misread as a user edit, and the stale value sticks.
+
+**Why defer**:
+
+1. **Different defect class**. This SPEC fixes a *representation* defect (a lossy encoding). D5 is a *provenance* defect (the wrong document is being used as base). They share a file family but not a mechanism, and fixing them together conflates two independent risk surfaces in one diff.
+2. **It requires a new persisted artifact.** A correct base is the template as it existed at the user's *previous* install. Nothing on disk records that today — `SaveTemplateDefaults` is called at backup time (`backup.go:115`), by which point the old template is already gone. A correct fix needs an install-time template snapshot written on every `moai init` / `moai update`, which is a new on-disk data model.
+3. **It carries a backward-compatibility problem this SPEC does not.** Every existing user project has no such snapshot. The follow-up must define the behaviour for a first-run-after-upgrade with no recorded base — a design question with several defensible answers, warranting its own requirements and its own audit.
+4. **The deferral is safe.** D5's failure mode is a stale *value*; this SPEC's failure mode is a destroyed *file*. Fixing the destructive defect first strictly reduces harm, and does not make D5 harder — a node-tree base loads through the same code path a map base does.
+
+**What this SPEC does owe D5**: the node-tree rewrite must not entrench the wrong-base assumption. `MergeYAML3Way` continues to take `baseData []byte` from its caller, so the follow-up changes only *which bytes* are passed, not the merge's shape. M2 must not add any code that assumes base and new originate from the same document.
+
+**Follow-up marker**: file as `SPEC-UPDATE-TEMPLATE-BASE-SNAPSHOT-001` at sync time. Not created by this SPEC.
+
+### Decision D6 — golden test covers all 31 section templates, not a sample
+
+The golden test (REQ-UYP-017) enumerates `internal/template/templates/.moai/config/sections/*.yaml` and `*.yaml.tmpl` at runtime with `filepath.Glob`, rather than hard-coding a fixture list. A new template added later is automatically covered; a hard-coded list silently stops covering it. `.tmpl` files are read as raw text (they contain `{{...}}` placeholders that are not valid YAML values but parse fine as scalars) — consistent with how `SaveTemplateDefaults` treats them (`backup.go:180-186`).
+
+## §F Milestones (Ordered by Decision-Reversibility)
+
+Highest-change-likelihood decisions first; mechanical revisions last.
+
+### M1 — Node-tree merge core (the data-model decision)
+
+**Files**: new `internal/cli/update/backup/node_merge.go`.
+
+Implement the node-tree primitives before touching any existing function:
+
+- `mergeMappingNode3Way(newNode, oldNode, baseNode *yaml.Node) (*yaml.Node, error)` — walks `Content` pairwise (yaml.v3 mapping nodes store `[k1,v1,k2,v2,...]`), preserving new-node key order, appending old-only keys at the end of the mapping.
+- `nodeValuesEqual(a, b *yaml.Node) bool` — structural equality on `Kind`/`Tag`/`Value` and recursively on `Content`. Replaces the `fmt.Sprintf("%v", ...)` stringification of `ValuesEqual` for node inputs. Note: this must distinguish explicit null from empty mapping (REQ-UYP-016), which the stringified comparison does not.
+- `encodeNode(n *yaml.Node) ([]byte, error)` — `yaml.NewEncoder` + `SetIndent(2)` + `Encode` + `Close`, errors wrapped.
+
+Unit tests for each primitive land in this milestone, in `node_merge_test.go`.
+
+**Exit**: `go test ./internal/cli/update/backup/ -run 'TestMergeMappingNode|TestNodeValuesEqual|TestEncodeNode' -count=1` green.
+
+### M2 — Rewire the four merge entry points (the behaviour decision)
+
+**Files**: `internal/cli/update/backup/merge.go`.
+
+- `MergeYAML3Way` / `MergeYAMLDeep`: unmarshal into `yaml.Node` instead of `map[string]any`; delegate to the M1 primitives; encode via `encodeNode`. Wrapper signatures unchanged (D2 mitigation).
+- `DeepMerge3Way` / `DeepMergeMaps`: signatures change to node-typed per D2.
+- Old-only-key retention + stderr advisory per D3.
+- Document-node unwrapping: `yaml.Unmarshal` into a `yaml.Node` yields a `DocumentNode` whose single `Content[0]` is the mapping. Multi-document input surfaces as extra content — detect and error per REQ-UYP-015.
+- Empty-input handling: an empty `[]byte` yields a zero-Kind node. Preserve the current contract that empty input produces empty output (`update_yaml_test.go:604-616` asserts `{}\n` or `null\n`) — reconcile the exact expected bytes with node encoding and adjust that assertion in M5 if the byte form legitimately changes.
+
+**Exit**: `go build ./...` clean; `go vet ./internal/cli/...` clean.
+
+### M3 — Preservation test contract (the new contract, REQ-UYP-017)
+
+**Files**: new `internal/cli/update/backup/preserve_golden_test.go`.
+
+Golden round-trip over all section templates per D6. For each file, with `new == old == base` (the no-user-edit case), assert on the merged output:
+
+- comment-line count equals the source's
+- block-mapping indent width is 2
+- key order at every mapping level equals the source's
+- quoted scalars remain quoted
+- and, as the strongest single assertion, output bytes equal input bytes (REQ-UYP-005) — the four properties above are then diagnostics that localize a failure
+
+A second test covers the user-edit case: change one value, assert the value changes and every comment survives.
+
+**Falsifiability check** — before declaring this milestone done, revert `merge.go` to the map round-trip and confirm the golden test FAILS. A preservation test that passes against the broken implementation proves nothing.
+
+**Exit**: golden test green on the new implementation, RED on the reverted one (both observations recorded verbatim in `progress.md` §E.2).
+
+### M4 — Old-only-key policy reversal + its test (REQ-UYP-006/007/018)
+
+**Files**: `internal/cli/update_yaml_test.go:591-603`.
+
+Rename the subtest to describe the new behaviour and invert the assertion:
+
+```go
+name: "user added key not in new template is preserved",
+...
+if !contains(s, "user_added") {
+    t.Errorf("expected user_added preserved (user-added key must survive), got %s", s)
+}
+```
+
+Add a sibling assertion that the stderr advisory names the retained key path.
+
+**Exit**: `go test ./internal/cli/ -run TestMergeYAML3Way -count=1 -v` green with the renamed subtest visible in output.
+
+### M5 — Revise the conflicting assertion tables (mechanical)
+
+**Files**: `internal/cli/update_yaml_test.go` (`:130-350` `TestDeepMergeMaps`, `:471-648` `TestMergeYAML3Way`, `:650-944` `TestDeepMerge3Way`), `internal/cli/update/backup/backup_test.go` (`:338-560`), `internal/cli/update/backup/backup_error_test.go` (`:61-140`, `:91-120`), `internal/cli/coverage_improvement_test.go` (`:5716`, `:5733`, `:5750`).
+
+Convert map-literal inputs to node construction (a small `mustNode(t, yamlString) *yaml.Node` test helper), and loosen substring assertions that were coupled to map-marshal whitespace while keeping the semantic assertions intact. Do **not** weaken an assertion to make it pass — where output legitimately changed, update the expectation to the new correct value and note why in the test comment.
+
+**Exit**: `go test ./internal/cli/... -count=1` fully green.
+
+### M6 — Verification sweep
+
+```bash
+go test ./... -count=1
+go test -cover ./internal/cli/update/backup/          # vs M0/pre-flight baseline
+golangci-lint run ./internal/cli/...
+GOOS=windows GOARCH=amd64 go build ./...
+grep -rn "SPEC-UPDATE-YAML-PRESERVE" internal/template/templates/ ; # expect zero matches
+```
+
+Plus an end-to-end check: `moai update` against a scratch project in `t.TempDir()` with a comment-bearing, user-edited `cache.yaml`, asserting comments and the edit both survive.
+
+### M7 — Commit
+
+Conventional commit, one logical unit. `fix(update): preserve YAML comments, key order, and user-added keys across config merge (#1243)`.
+
+## §G Anti-Patterns (Avoid)
+
+- **Do not** delete a failing assertion to reach green. Every changed expectation needs a stated reason.
+- **Do not** add YAML fixture files under `internal/template/templates/` — template neutrality (constraint 2).
+- **Do not** silently change the 3-way decision semantics while changing the representation. If a decision outcome changes, that is a bug in M2, not an improvement.
+- **Do not** expand alias nodes for convenience (REQ-UYP-012) — an expanded alias is an irreversible loss of the source's intent.
+- **Do not** claim comment preservation without running the M3 falsifiability check. A green test on an unreverted tree does not distinguish "preserves" from "vacuous".
+- **Do not** widen scope into `SaveTemplateDefaults` (D5). If the run phase finds the base-derivation defect blocking a test, report it as a blocker rather than fixing it inline.
+
+## §H Cross-References
+
+- `spec.md` §C — the 19 requirements this plan implements.
+- `acceptance.md` §D — the AC matrix each milestone is verified against.
+- `internal/cli/update/backup/merge.go` — primary change target.
+- `internal/cli/update/backup/restore.go:121,139,207` — the three production call sites (unchanged by D2's mitigation).
+- CLAUDE.local.md §6 (test isolation), §25 (template neutrality).
+- `.claude/rules/moai/languages/go.md` — Go conventions.

--- a/.moai/specs/SPEC-UPDATE-YAML-PRESERVE-001/progress.md
+++ b/.moai/specs/SPEC-UPDATE-YAML-PRESERVE-001/progress.md
@@ -1,0 +1,24 @@
+# Progress — SPEC-UPDATE-YAML-PRESERVE-001
+
+## §E.1 Plan-phase Audit-Ready Signal
+
+- **Artifacts**: `spec.md`, `plan.md`, `acceptance.md`, `progress.md` created 2026-07-31 by `manager-spec`.
+- **Tier**: M (justified in `plan.md` §A).
+- **SPEC ID regex check**: executed as Bash, verbatim output `PASS` for `SPEC-UPDATE-YAML-PRESERVE-001` against `^SPEC(-[A-Z][A-Z0-9]*)+-[0-9]{3}$`.
+- **ID uniqueness**: `ls .moai/specs/ | grep -c "SPEC-UPDATE-YAML-PRESERVE-001"` → `0` prior occurrences.
+- **Baseline verification**: every file:line reference in `spec.md` §A was re-read this session and confirmed against the current tree (table in `plan.md` §A). The round-trip loss was reproduced by executing a scratch test against `internal/template/templates/.moai/config/sections/cache.yaml` with the pinned `gopkg.in/yaml.v3 v3.0.1` — observed `comments in=16 out=0`, keys alphabetized, `"1h"` → `1h`, 2-space → 4-space indent.
+- **Edge-case survey**: executed over the 31 shipped section templates — 0 anchors, 0 merge keys, 0 multi-document; 8 files carry block sequences (so REQ-UYP-014 is a live decision, the other three are defensive contracts).
+- **Open clarifications**: none. Decision D5 (`SaveTemplateDefaults` base derivation) is explicitly DEFERRED with rationale in `plan.md` §E, per the SPEC's fourth stated requirement.
+- **Status**: `draft` — awaiting plan-audit and Implementation Kickoff Approval.
+
+## §E.2 Run-phase Evidence
+
+_<pending run-phase>_
+
+## §E.3 Run-phase Audit-Ready Signal
+
+_<pending run-phase>_
+
+## §E.4 Sync-phase Audit-Ready Signal
+
+_<pending sync-phase>_

--- a/.moai/specs/SPEC-UPDATE-YAML-PRESERVE-001/spec.md
+++ b/.moai/specs/SPEC-UPDATE-YAML-PRESERVE-001/spec.md
@@ -1,0 +1,190 @@
+---
+id: SPEC-UPDATE-YAML-PRESERVE-001
+title: "moai update — preserve YAML comments, key order, scalar style, and user-added keys across config merge"
+version: 0.1.0
+status: draft
+created: 2026-07-31
+updated: 2026-07-31
+author: manager-spec
+priority: high
+phase: plan
+module: cli
+lifecycle: spec-anchored
+era: V3R6
+tier: M
+tags: "cli, update, yaml, merge, config, preservation, regression"
+issue_number: 1243
+related_specs: [SPEC-CLI-TUX-V3-003, SPEC-V3R6-UPDATE-NOISE-001, SPEC-V3R6-V2-V3-CLEAN-REINSTALL-002]
+---
+
+# SPEC-UPDATE-YAML-PRESERVE-001
+
+## §A Problem / Motivation
+
+GitHub issue **#1243** reported that `moai update` silently reverted local customizations in `.moai/config/sections/*.yaml`. Root-cause analysis isolated three independent defects. Two are already handled and are excluded here (see §B). The third — the subject of this SPEC — is unfixed.
+
+### Defect A — the `map[string]any` round-trip destroys everything but values
+
+`internal/cli/update/backup/merge.go` decodes YAML into `map[string]any`, merges the maps, then re-emits with `yaml.Marshal`:
+
+- `MergeYAML3Way` — `merge.go:20-35` (unmarshal at `:21-31`, marshal at `:34`)
+- `MergeYAMLDeep` — `merge.go:116-130` (unmarshal at `:117-124`, marshal at `:129`)
+
+The map is a lossy intermediate representation: `yaml.Node`'s `HeadComment` / `LineComment` / `FootComment`, the source key order, the scalar quoting style, and the source indentation all exist only on the node tree and are discarded the moment the document becomes a `map[string]any`.
+
+**Reproduced against the repo's pinned `gopkg.in/yaml.v3 v3.0.1`**, unmarshal→marshal of `internal/template/templates/.moai/config/sections/cache.yaml`:
+
+```
+comments in=16 out=0
+```
+
+```yaml
+# BEFORE (source, 22 lines)             # AFTER (round-trip, 5 lines)
+# Anthropic Prompt Caching strategy.    cacheStrategy:
+# ...16 comment lines total...              enabled: true
+cacheStrategy:                              min_cacheable_tokens: 2048
+  # Toggle cache_control injection.         session_ttl: 1h
+  enabled: true                             spec_ttl: 5m
+  session_ttl: "1h"
+  spec_ttl: "5m"
+  min_cacheable_tokens: 2048
+```
+
+Four distinct losses in one round trip: **all 16 comments dropped**, **keys alphabetized** (`enabled, min_cacheable_tokens, session_ttl, spec_ttl` — source order was `enabled, session_ttl, spec_ttl, min_cacheable_tokens`), **quoting stripped** (`"1h"` → `1h`), **indent widened** (2-space → yaml.v3's default 4-space).
+
+The loss occurs on **every successful merge**, not only on fallback. It is idempotent — a file already stripped stays stripped — which explains why the reported run visibly changed only those files that still carried comments in the user's committed tree.
+
+### Defect B — the 3-way path silently deletes user-added keys
+
+`DeepMerge3Way` deliberately drops keys present in the user's file but absent from the new template (`merge.go:95-97`):
+
+```go
+// Keys only in old (not in new template) are dropped:
+// they were removed from the template, so we don't carry them forward.
+```
+
+A key the user added by hand is indistinguishable from a key the template retired, so both are deleted with no notice.
+
+The asymmetry is the tell: the 2-way fallback `DeepMergeMaps` **preserves** old-only keys (`merge.go:168-171`, `// Only exists in old, add it`). The 3-way path — the one that runs when template defaults are available, i.e. the normal path — is strictly more destructive than its own degraded fallback.
+
+A test currently pins the destructive behavior. `internal/cli/update_yaml_test.go:591-603`, subtest **`user_added_key_not_in_base_preserved`**, asserts the exact opposite of its own name:
+
+```go
+name: "user added key not in base preserved",
+...
+if contains(s, "user_added") {
+    t.Errorf("expected user_added to be dropped (not in new template), got %s", s)
+}
+```
+
+### Defect C — no preservation contract exists
+
+`grep -rin "comment" internal/cli/update/backup/*_test.go internal/cli/update_yaml_test.go` returns **zero matches**. There is no test anywhere asserting that a merge preserves comments, key order, scalar style, or indentation. Establishing that contract is half the work of this SPEC: without it, a future refactor silently regresses the fix.
+
+### Blast radius
+
+Both entry points are reached from `restore.go` on the normal `moai update` path: `MergeYAML3Way` at `restore.go:121`, `MergeYAMLDeep` at `restore.go:139` (2-way fallback) and `restore.go:207` (legacy backup format). Every `.moai/config/sections/*.yaml` file in every user project passes through one of them. Across the 31 shipped section templates the comment payload is substantial — `llm.yaml` carries 119 comment lines, `lsp.yaml.tmpl` 88, `quality.yaml.tmpl` 84.
+
+## §B Scope
+
+**In Scope**:
+
+- Replace the `map[string]any` round-trip in `MergeYAML3Way`, `MergeYAMLDeep`, `DeepMerge3Way`, and `DeepMergeMaps` with a `*yaml.Node` tree merge that preserves comments, key order, and scalar style.
+- Pin the encoder indentation to 2 spaces (`enc.SetIndent(2)`).
+- Reverse the old-only-key drop policy in the 3-way path to preserve-and-report, aligning it with `DeepMergeMaps`.
+- Amend `internal/cli/update_yaml_test.go:591-603` and its misnamed subtest to assert preservation.
+- Establish a comment/format-preservation test contract, including a golden round-trip test over every section template under `internal/template/templates/.moai/config/sections/`.
+- Revise the string-assertion table in `internal/cli/update_yaml_test.go` (from `TestMergeYAML3Way` at `:471`) that conflicts with node-based output.
+- Explicitly declare the handling of each YAML edge case: anchors/aliases, multi-document streams, sequence merge policy, null vs empty-map nodes, and merge keys (`<<`).
+
+**Out of Scope**:
+
+### Out of Scope — `.gitignore` user-pattern loss
+- The `.gitignore` user-pattern regression is a duplicate of issue **#1131**, already fixed on `main` (`b4ef28e5d`) and pending release. This SPEC does not touch `.gitignore` handling.
+
+### Out of Scope — clean-reinstall fallback reporting
+- The clean-reinstall path's failure to report 3-way merge fallbacks was fixed in **PR #1247** (recorder wiring in `internal/cli/update_clean_install.go`). This SPEC does not touch the fallback recorder or its wiring.
+
+### Out of Scope — `SaveTemplateDefaults` base derivation
+- `SaveTemplateDefaults` (`internal/cli/update/backup/backup.go:149-192`) derives the 3-way merge BASE from the NEW embedded template rather than from the old template the user actually had installed, violating the 3-way premise. This is a real defect and is **deferred to a follow-up SPEC** — the decision and its rationale are recorded in `plan.md` §E Decision D5. It is named here so the deferral is explicit rather than implicit.
+
+### Out of Scope — merge decision semantics
+- The 3-way decision logic itself (`old == base` → take new; `old != base` → keep old; system-field always-new) is preserved byte-for-byte in meaning. This SPEC changes the representation the decision operates on, not the decision.
+
+### Out of Scope — non-YAML config formats
+- JSON settings files (`settings.json`, `settings.local.json`) merge through `internal/cli/settings.go` helpers and are untouched.
+
+## §C Requirements (GEARS)
+
+### Preservation
+
+**REQ-UYP-001** — **When** `MergeYAML3Way` or `MergeYAMLDeep` completes a merge successfully, the merge function shall emit output in which every comment (`HeadComment`, `LineComment`, `FootComment`) present in the source document that supplied each surviving node is retained.
+
+**REQ-UYP-002** — **When** `MergeYAML3Way` or `MergeYAMLDeep` completes a merge successfully, the merge function shall emit mapping keys in the key order of the document that supplied the mapping's structure, and shall not reorder them alphabetically.
+
+**REQ-UYP-003** — **When** a scalar value is carried through a merge unchanged, the merge function shall preserve that scalar's source quoting style, so that `session_ttl: "1h"` does not become `session_ttl: 1h`.
+
+**REQ-UYP-004** — The merge function shall emit block-mapping output at an indentation width of 2 spaces, by configuring the encoder with `SetIndent(2)`.
+
+**REQ-UYP-005** — **While** a merge produces no change to any value, the merge function shall emit output byte-identical to the input template document.
+
+### Key retention
+
+**REQ-UYP-006** — **When** a key is present in the user's document and absent from the new template document, `DeepMerge3Way` shall retain that key and its value in the merged output.
+
+**REQ-UYP-007** — **When** `DeepMerge3Way` retains a key that is absent from the new template, the merge function shall report the retained key path on stderr as an advisory notice, so the user learns that a key no longer shipped by the template survived.
+
+**REQ-UYP-008** — The 3-way merge path shall not delete any key that the 2-way fallback path (`DeepMergeMaps`) would preserve.
+
+### Decision preservation
+
+**REQ-UYP-009** — The merge function shall preserve the existing 3-way decision semantics: a value equal to its base takes the new template value; a value differing from its base keeps the user value; a key with no base entry keeps the user value.
+
+**REQ-UYP-010** — The merge function shall continue to take the new template value unconditionally for the system fields `version` and `template_version`, on both the 3-way and 2-way paths.
+
+**REQ-UYP-011** — **When** the merge function encounters a YAML document it cannot parse, the merge function shall return a wrapped error using `fmt.Errorf("...: %w", err)`, preserving the existing caller fallback behaviour in `restore.go`.
+
+### Edge cases
+
+**REQ-UYP-012** — **When** a source document contains a YAML anchor or alias node, the merge function shall carry the node through without expanding the alias into its resolved value.
+
+**REQ-UYP-013** — **When** a source document contains a merge key (`<<`), the merge function shall treat it as an ordinary mapping key and shall not resolve its semantics.
+
+**REQ-UYP-014** — **When** a merged mapping value is a sequence node, the merge function shall replace the sequence wholesale rather than appending or element-wise merging.
+
+**REQ-UYP-015** — **When** a source document is a multi-document stream (more than one document node), the merge function shall merge the first document and return a wrapped error naming the unsupported input rather than silently discarding the trailing documents.
+
+**REQ-UYP-016** — **When** a node is an explicit null and its counterpart is an empty mapping, the merge function shall treat them as distinct values and shall not coerce one into the other.
+
+### Test contract
+
+**REQ-UYP-017** — The test suite shall contain a golden round-trip test that, for every `*.yaml` and `*.yaml.tmpl` file under `internal/template/templates/.moai/config/sections/`, asserts a no-user-edit merge preserves comment count, indentation width, key order, and scalar quoting.
+
+**REQ-UYP-018** — The test suite shall not contain any assertion that requires a user-added key to be dropped from 3-way merge output.
+
+**REQ-UYP-019** — The test suite shall place all YAML fixtures inside `_test.go` files or `t.TempDir()` directories, and shall not add fixture files under `internal/template/templates/`.
+
+## §D Constraints
+
+- **Pinned dependency**: `gopkg.in/yaml.v3 v3.0.1` — no new YAML library may be introduced. The `yaml.Node` API is already available in this version.
+- **Template neutrality** (CLAUDE.local.md §25): no SPEC ID, REQ token, internal date, or commit SHA may appear in any file under `internal/template/templates/`.
+- **Test isolation** (CLAUDE.local.md §6): every temporary directory via `t.TempDir()`; no writes into the project root from a test.
+- **Go conventions**: `snake_case.go` filenames, `fmt.Errorf("...: %w", err)` error wrapping, English code comments and godoc.
+- **Coverage**: `internal/cli/update/backup` must hold at or above its current package coverage after the change.
+- **API stability**: the four exported function signatures (`MergeYAML3Way`, `MergeYAMLDeep`, `DeepMerge3Way`, `DeepMergeMaps`) are consumed by tests in four packages; signature changes cascade and must be justified in `plan.md`.
+
+## §E Success Criteria
+
+- A `moai update` over a project whose `.moai/config/sections/*.yaml` files are unmodified template copies produces a byte-identical tree.
+- A `moai update` over a project with user-edited values preserves those values **and** every comment, key order, and quoting style in the file.
+- A user-added key absent from the new template survives the merge and is reported on stderr.
+- The full suite is green: `go test ./internal/cli/... ./internal/template/...`.
+
+## §F Cross-References
+
+- Issue **#1243** — the originating report.
+- Issue **#1131** / commit `b4ef28e5d` — the `.gitignore` sibling defect (out of scope).
+- PR **#1247** — the clean-reinstall fallback-reporting sibling defect (out of scope).
+- `internal/cli/update/backup/merge.go` — the file under change.
+- `internal/cli/update/backup/restore.go:121,139,207` — the three call sites.
+- `internal/cli/update/backup/backup.go:149-192` — `SaveTemplateDefaults`, deferred (plan.md §E D5).


### PR DESCRIPTION
Plan-phase SPEC for the third defect surfaced by #1243. **No code changes** — artifacts only.

## Defect

`internal/cli/update/backup/merge.go` decodes YAML into `map[string]any`, merges, then re-marshals. That round-trip destroys comments, key order, scalar quoting, and indentation on **every successful merge** — not only on fallback. It also drops user-added keys absent from the new template (`merge.go:95-97`), which is strictly more destructive than its own 2-way fallback (`DeepMergeMaps` preserves them).

## Status: draft — audit FAILed, revision precedes run-phase

`plan-auditor` returned **FAIL, 0.71** against the Tier M threshold of 0.80. All 7 must-pass gates passed; the failure is on consistency and verifiability. Findings are in `audit.md`. The three that change the design:

- **The prescribed mechanism cannot meet its own headline requirement.** The auditor implemented `yaml.Node` + `SetIndent(2)` as specified and ran it over the 30 section templates: **8 byte-identical, 22 differ**. REQ-UYP-005 (byte-identity) is unreachable as written, and `plan.md` §G forbids deleting the failing assertion — so M3 deadlocks.
- **A fifth loss class is missing from the requirement set.** Node round-trip preserves comment *count* exactly (`N->N`) yet still shrinks files — `workflow.yaml` −602B, `llm.yaml` −607B. The cause is blank lines, which yaml.v3 does not model. Absent from all 19 REQs and from Out of Scope.
- **`quality.yaml.tmpl` does not decode as YAML today.** `enforce_quality: {{.EnforceQuality}}` is unquoted (every other tmpl quotes it), so `MergeYAML3Way` errors on it. That means `quality.yaml` is silently falling back to 2-way on every `moai update` right now — a production defect the SPEC had not identified.

Also blocking: the falsification command in AC-UYP-022 fails to execute (`git stash push` rejects the untracked `node_merge.go` without `-u`), and 14 of 22 ACs pass vacuously (`go test -run` with a zero-match pattern exits 0).

Deferral of the `SaveTemplateDefaults` wrong-base defect (`plan.md` §E D5) was judged **sound**; only its wording needs correcting, since the fix will promote `quality.yaml` from 2-way to real 3-way and thereby newly expose that defect on that file.

## Next

Revise per the MUST-FIX list, re-audit, then Implementation Kickoff Approval. Not ready for `/moai run`.

🗿 MoAI