### PR TITLE
chore(SPEC-CLIFIX-HYGIENE-001): backfill sync_commit_sha in progress.md §E.4

### DIFF
--- a/.moai/specs/SPEC-CLIFIX-HYGIENE-001/progress.md
+++ b/.moai/specs/SPEC-CLIFIX-HYGIENE-001/progress.md
@@ -444,10 +444,13 @@ ac_command_defects_found: 3        # AC-001 vacuous selector, AC-003 over-broad 
 
 ```yaml
 sync_complete_at: 2026-07-31
-sync_commit_sha: pending-backfill-sync-commit   # a commit cannot reference its own SHA;
-                                                # backfilled in a follow-up commit after
-                                                # this sync commit lands (schema §SHA
-                                                # placeholder backfill exemption D3)
+sync_commit_sha: 316fe3e84   # squash merge of sync PR #1248 onto main.
+                             # Written as a placeholder in the sync commit itself
+                             # (a commit cannot reference its own SHA) and backfilled
+                             # here per the schema §SHA placeholder backfill exemption.
+sync_pr: 1248
+sync_merged_at: 2026-07-30T15:38:29Z
+sync_ci: 15 SUCCESS / 8 SKIPPED / 0 FAILURE
 sync_status: complete
 run_phase_pr: 1245
 run_phase_merge_commit: 1d6b33526


### PR DESCRIPTION
## Summary

Backfills the `sync_commit_sha` placeholder left by the SPEC-CLIFIX-HYGIENE-001 sync commit. Docs-only, one file, one field.

A commit cannot reference its own hash, so `progress.md` §E.4 shipped with `sync_commit_sha: pending-backfill-sync-commit` — the sanctioned workaround under the schema's §SHA placeholder backfill exemption. This replaces it with the real value.

```
sync_commit_sha: 316fe3e84   # squash merge of sync PR #1248 onto main
```

Verified rather than assumed:

```
$ git cat-file -t 316fe3e84
commit
$ git log -1 --format='%H %s' 316fe3e84
316fe3e8492647c24bd3d0f3b1fd8eb0be143401 docs(SPEC-CLIFIX-HYGIENE-001): sync-phase artifacts + 3-phase close (#1248)
```

Also records `sync_pr`, `sync_merged_at`, and `sync_ci` beside it so the §E.4 block carries the same evidence shape as the run-phase fields already present in that section.

## Scope

- `.moai/specs/SPEC-CLIFIX-HYGIENE-001/progress.md` — 7 insertions, 4 deletions.
- No frontmatter change. The SPEC stays `completed`; no `completed → in-progress` amendment is involved, because §E.4 SHA backfill by the phase-owning surface is explicitly not an ownership crossing.
- No `.go` file, no other SPEC, no CHANGELOG.

## Why this is a completeness fix, not a drift fix

`moai spec audit` reported clean **both before and after** the backfill — the placeholder never produced a finding, because the era heuristic only tests that `sync_commit_sha` is non-empty:

```
$ moai spec audit --json | jq '{must_fix: [...] | length, this_spec: [...]}'
{ "must_fix": 0, "this_spec": [] }
```

So this closes a readability/completeness gap — a future reader would otherwise find a literal placeholder string where a commit hash belongs — rather than repairing a detected defect.

## Test plan

- [x] `git cat-file -t 316fe3e84` → `commit`
- [x] `moai spec audit` → `must_fix: 0`, zero findings for this SPEC
- [x] Commit scope: 1 file, zero `.go` files

🗿 MoAI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated sync audit documentation with the verified commit identifier.
  * Clarified the rationale and schema exception for backfilling the commit reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->