### PR TITLE
fix(update): run the retired-deny-rule migration on the v3 update path

### DIFF
--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -303,6 +303,28 @@ func runUpdate(cmd *cobra.Command, _ []string) error {
 		return dryRunArchiveLegacySkills(cwd, out)
 	}
 
+	// Retired-deny-rule migration on the v3 path (issue #1101 follow-up). The
+	// same one-shot strip runs inside runCleanReinstall, but that path opens
+	// only on a v2 fingerprint — a project already on v3 keeps the retired
+	// Write/Grep/Glob entries forever, because every v3 update merge-preserves
+	// the user's settings.json. Running it here covers the v3-to-v3 case.
+	//
+	// Placement is deliberate: after the --binary / --dry-run early-returns (so
+	// a dry run never mutates) but BEFORE the version-match short-circuit
+	// further below, since a same-version `moai update` is exactly the case
+	// that leaves the stale entries in place. stripRetiredV2DenyEntries is a
+	// no-op when nothing matches, so a clean v3 file is never rewritten and the
+	// second call inside runCleanReinstall stays idempotent.
+	{
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("get working directory for deny-rule migration: %w", err)
+		}
+		if stripErr := stripRetiredV2DenyEntries(cwd, out); stripErr != nil {
+			_, _ = fmt.Fprintln(out, tui.CheckLine("warn", "Deny-rule migration", "failed", stripErr.Error(), &th))
+		}
+	}
+
 	// SPEC-V3R6-V2-V3-CLEAN-REINSTALL-001 REQ-VVCR-002: detect v2 fingerprint
 	// and short-circuit to the clean-reinstall code path when the project is
 	// v2 (or partial-v2). The detector inspects three signals (system.yaml

--- a/internal/cli/update_deny_migration.go
+++ b/internal/cli/update_deny_migration.go
@@ -100,6 +100,11 @@ func stripRetiredV2DenyEntries(projectRoot string, out io.Writer) error {
 	if err := os.WriteFile(path, outData, mode); err != nil {
 		return fmt.Errorf("write settings.json: %w", err)
 	}
-	_, _ = fmt.Fprintf(out, "[clean-reinstall] Removed %d retired v2 permission deny entries from settings.json\n", removed)
+	// Prefix is deliberately NOT "[clean-reinstall]": this migration now also
+	// runs on the plain v3 update path, where a clean-reinstall label would be
+	// false. It also keeps the message clear of the AC-CRR-009(c) assertion,
+	// which greps "[clean-reinstall] Removed" to prove the REMOVE phase did not
+	// re-activate on a v3 project.
+	_, _ = fmt.Fprintf(out, "[settings] Removed %d retired permission deny entries from settings.json\n", removed)
 	return nil
 }

--- a/internal/cli/update_deny_migration_test.go
+++ b/internal/cli/update_deny_migration_test.go
@@ -2,9 +2,12 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 	"testing"
 )
 
@@ -227,5 +230,151 @@ func TestStripRetiredV2DenyEntries_NoPermissionsKeyNoop(t *testing.T) {
 	}
 	if string(got) != noPerms {
 		t.Errorf("no-permissions settings.json was rewritten:\n%s", got)
+	}
+}
+
+// runUpdateInFixture chdirs into root, runs the real `moai update` command with
+// a mocked update checker, and returns the combined output. Mirrors the
+// TestRunUpdate_ThreeRunIdempotency_V3Project harness: updateCmd is a
+// package-level cobra command, so callers must not run in parallel.
+func runUpdateInFixture(t *testing.T, root string) string {
+	t.Helper()
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("chdir fixture: %v", err)
+	}
+
+	origDeps := deps
+	defer func() { deps = origDeps }()
+	deps = &Dependencies{UpdateChecker: &mockUpdateChecker{}}
+
+	var buf bytes.Buffer
+	updateCmd.SetOut(&buf)
+	updateCmd.SetErr(&buf)
+	updateCmd.SetContext(context.Background())
+	if err := updateCmd.Flags().Set("check", "false"); err != nil {
+		t.Fatalf("set check flag: %v", err)
+	}
+	if err := updateCmd.Flags().Set("yes", "true"); err != nil {
+		t.Fatalf("set yes flag: %v", err)
+	}
+
+	if runErr := updateCmd.RunE(updateCmd, []string{}); runErr != nil {
+		// Template sync on a minimal fixture may warn; the filesystem
+		// assertions in the caller are the load-bearing invariants.
+		t.Logf("runUpdate returned (non-fatal): %v", runErr)
+	}
+	return buf.String()
+}
+
+// writeV3ProjectFixture lays down the minimum markers that make detectV2Fingerprint
+// return IsV2:false — a v3 system.yaml, no .agency/, no deprecated paths — so
+// `moai update` routes to the plain v3 file-level sync rather than to
+// runCleanReinstall. This is the exact shape that previously never received the
+// deny-rule migration.
+func writeV3ProjectFixture(t *testing.T, root string) {
+	t.Helper()
+	writeTestFile(t, root, ".moai/config/sections/system.yaml",
+		"moai:\n    version: v3.0.1\n")
+	writeTestFile(t, root, ".moai/config/sections/language.yaml",
+		"language:\n    conversation_language: ko\n")
+}
+
+// TestRunUpdate_V3Path_StripsRetiredDenyEntries pins the reachability of
+// stripRetiredV2DenyEntries from the plain v3 update path (issue #1101
+// follow-up). Before the fix the call site existed ONLY inside
+// runCleanReinstall, which opens on a v2 fingerprint — so a project already on
+// v3 kept the retired Write/Grep/Glob entries through every `moai update` and
+// Claude Code warned about them on every session start.
+//
+// Falsifiability: disabling the runUpdate call site makes this test fail
+// (verified by running it with the call stubbed out).
+//
+// Coverage note — what this fixture does and does NOT exercise: under the test
+// binary's version the fixture takes the full file-level sync branch, so the
+// version-match short-circuit (`syncSkipped` early return) is NOT covered here.
+// That branch is why the call site sits BEFORE the short-circuit rather than in
+// the post-sync section; the placement is asserted by the call site's own
+// comment in update.go, not by this test.
+func TestRunUpdate_V3Path_StripsRetiredDenyEntries(t *testing.T) {
+	root := t.TempDir()
+	writeV3ProjectFixture(t, root)
+	settingsPath := writeSettingsFixture(t, root, v2SettingsFixture)
+
+	out := runUpdateInFixture(t, root)
+
+	deny, m := readDenyList(t, settingsPath)
+
+	for _, retired := range retiredV2DenyEntries {
+		if slices.Contains(deny, retired) {
+			t.Errorf("retired deny entry %q survived the v3 update path; deny=%v\n--- output ---\n%s",
+				retired, deny, out)
+		}
+	}
+
+	// The surviving rules must be untouched: the 8 template Read/Edit entries
+	// plus the user's own custom entry (exact-match strip only).
+	mustKeep := []string{
+		"Read(./secrets/**)", "Read(~/.ssh/**)", "Read(~/.aws/**)", "Read(~/.config/gcloud/**)",
+		"Edit(./secrets/**)", "Edit(~/.ssh/**)", "Edit(~/.aws/**)", "Edit(~/.config/gcloud/**)",
+		"Write(./my-custom-protected/**)",
+	}
+	for _, want := range mustKeep {
+		if !slices.Contains(deny, want) {
+			t.Errorf("deny entry %q was removed but must be preserved; deny=%v", want, deny)
+		}
+	}
+
+	// Unknown top-level keys round-trip (SPEC-CLIFIX-CRITICAL-001 precedent).
+	if m["outputStyle"] != "MoAI-Easy" {
+		t.Errorf("outputStyle not preserved through the v3 update path: %v", m["outputStyle"])
+	}
+
+	// The migration must not claim a clean reinstall happened on the v3 path,
+	// and must not collide with the AC-CRR-009(c) "[clean-reinstall] Removed"
+	// assertion in update_clean_install_test.go.
+	if !strings.Contains(out, "[settings] Removed") {
+		t.Errorf("expected the neutral-prefix migration log on the v3 path; output:\n%s", out)
+	}
+	if strings.Contains(out, "[clean-reinstall] Removed") {
+		t.Errorf("deny migration emitted a clean-reinstall label on the v3 path; output:\n%s", out)
+	}
+}
+
+// TestRunUpdate_V3Path_CleanSettingsUntouched pins the no-op half of the
+// contract: a v3 project whose settings.json carries no retired entries must
+// come out byte-identical, so adding the call site to the always-run path
+// cannot churn an already-clean file.
+func TestRunUpdate_V3Path_CleanSettingsUntouched(t *testing.T) {
+	const v3Clean = `{
+  "outputStyle": "MoAI-Easy",
+  "permissions": {
+    "deny": [
+      "Read(./secrets/**)",
+      "Edit(./secrets/**)"
+    ]
+  }
+}`
+	root := t.TempDir()
+	writeV3ProjectFixture(t, root)
+	settingsPath := writeSettingsFixture(t, root, v3Clean)
+
+	out := runUpdateInFixture(t, root)
+
+	got, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != v3Clean {
+		t.Errorf("clean v3 settings.json was rewritten by the update path:\n--- got ---\n%s\n--- want ---\n%s",
+			got, v3Clean)
+	}
+	if strings.Contains(out, "[settings] Removed") {
+		t.Errorf("migration logged a removal on a clean file; output:\n%s", out)
 	}
 }


### PR DESCRIPTION
## Problem

Claude Code prints a startup warning for every retired permission deny rule in `.claude/settings.json`:

```
Permission deny rule (.claude/settings.json): Write(./secrets/**) is not matched by
file permission checks — only Edit(path) rules are.
Permission deny rule (.claude/settings.json): Glob(./secrets/**) is not matched by
file permission checks — only Read(path) rules are.
```

The v3 template stopped shipping these 12 entries (`Write`/`Grep`/`Glob` × 4 protected paths) — the same paths are already covered by `Read(...)`/`Edit(...)`, so nothing is unprotected — and `stripRetiredV2DenyEntries` was added to remove them from existing projects (#1101).

But that migration was wired **only** into `runCleanReinstall`, which opens on a v2 fingerprint. A project already on v3 never receives it: every `moai update` merge-preserves the user's `settings.json`, so the retired entries survive indefinitely.

Reproduced on a v3.0.1 project: `system.yaml` at v3.0.1, no `.agency/` → `IsV2: false` → clean-reinstall never runs → all 12 entries still present, warning on every session start.

## Change

- **`update.go`** — call `stripRetiredV2DenyEntries` from `runUpdate`, placed after the `--binary` / `--dry-run` early-returns and **before** the version-match short-circuit. The placement is load-bearing: a same-version `moai update` is exactly the case that leaves the stale entries in place, so a post-sync call site would not have covered it. The function is a no-op when nothing matches, so a clean v3 `settings.json` is never rewritten and the second call inside `runCleanReinstall` stays idempotent.
- **`update_deny_migration.go`** — log prefix `[clean-reinstall]` → `[settings]`. The clean-reinstall label is false on the v3 path, and the old prefix collided with the `AC-CRR-009(c)` assertion in `update_clean_install_test.go`, which greps `"[clean-reinstall] Removed"` to prove the REMOVE phase did not re-activate on a v3 project.

Exact-string matching is unchanged, so user-authored deny rules are never touched.

## Tests

Two `runUpdate`-level tests in `update_deny_migration_test.go`:

- `TestRunUpdate_V3Path_StripsRetiredDenyEntries` — retired entries stripped; the 8 template `Read`/`Edit` entries, a user-custom `Write(./my-custom-protected/**)`, and unknown top-level keys (`outputStyle`, `$schema`, `env`) all preserved.
- `TestRunUpdate_V3Path_CleanSettingsUntouched` — an already-clean `settings.json` comes out byte-identical.

**Falsification verified**: stubbing out the new call site makes the first test fail; the pass is not vacuous.

**Coverage limit (stated, not hidden)**: under the test binary's version the fixture takes the full file-level sync branch, so the `syncSkipped` short-circuit is not itself covered by a test. The call-site placement that handles it is documented in `update.go`.

## Verification

| Check | Result |
|---|---|
| `go build ./...` | exit 0 |
| `go vet ./internal/cli/` | clean |
| `golangci-lint run ./internal/cli/...` | 0 issues |
| `go test ./... -count=1` | exit 0, 0 FAIL |
| `AC-CRR-009` idempotency test | passes (no prefix collision) |

Run on a worktree branched from current `origin/main`.

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated `moai update` to automatically remove retired permission deny entries from existing v3 project settings.
  * Preserved active deny rules and unrelated settings during migration.
  * Kept clean settings unchanged when no retired entries are present.
  * Added a non-fatal warning if the cleanup cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->