### PR TITLE
refactor(SPEC-ENVKEY-ANTHROPIC-SSOT-001): single-source the ANTHROPIC_* env-var names through envkeys.go

### DIFF
--- a/.moai/specs/SPEC-ENVKEY-ANTHROPIC-SSOT-001/acceptance.md
+++ b/.moai/specs/SPEC-ENVKEY-ANTHROPIC-SSOT-001/acceptance.md
@@ -294,8 +294,9 @@ go test ./internal/config/ -run 'TestAnthropicBannedSetCoversAllNames' \
 
 ## AC-EAS-007 - SSOT exclusion is present AND narrow (M2, re-checked M6)
 
-**Given** a repo-root walk reaches `internal/config/envkeys.go` (6 bare literals
-by design) and 291 `_test.go` occurrences, and an *over-broad* exclusion
+**Given** a repo-root walk reaches `internal/config/envkeys.go` (bare literals by
+design -- `6` at base `76d9a8f3b`, `9` from M1 onward, since M1 adds three
+constants to that same file) and 291 `_test.go` occurrences, and an *over-broad* exclusion
 (`strings.Contains(path, "internal/config")` or `"envkeys"`) would exempt the
 entire SSOT package while looking identical from the outside,
 **When** the guard runs on a clean tree and then on a tree with a literal planted
@@ -333,13 +334,18 @@ go test ./internal/config/ -run 'TestNoBareAnthropicEnvVarLiteralsInProduction' 
 ```
 
 - **Baseline (the runnable legs, observed at base):** `envkeys.go` holds `6`
-  literals; `_test.go` files hold `291`.
+  literals; `_test.go` files hold `291`. **M1 raises the `envkeys.go` count to
+  `9`** by adding the three missing constants to that file, so the M6 expectation
+  below is `9`, NOT the base `6`. The leg's intent is "the excluded surface is
+  still populated" -- a non-zero count that matches the post-M1 constant count --
+  not a fixed number carried over from the base tree.
 - **Baseline (the guard legs): not runnable at base** - the guard does not exist
   at `76d9a8f3b`; a `-run` against it yields `[no tests to run]` (verbatim output
   recorded under AC-EAS-006), which is a vacuous pass, not a baseline.
 - **Expected at M6:**
-  - (a) `--- PASS: TestNoBareAnthropicEnvVarLiteralsInProduction`; counts still
-    `6` and `291`
+  - (a) `--- PASS: TestNoBareAnthropicEnvVarLiteralsInProduction`; `envkeys.go`
+    count is `9` (base `6` + the three M1 constants) and `_test.go` count is
+    still `291` (unchanged -- test files are never transitioned)
   - (b) `--- FAIL: ...` **and** an offender line containing `internal/config/log.go`
   - (c) `git status --porcelain` empty; `--- PASS: ...` again
 - **Fails the AC if:** step (b) passes. A guard that ignores a bare literal in

--- a/.moai/specs/SPEC-ENVKEY-ANTHROPIC-SSOT-001/acceptance.md
+++ b/.moai/specs/SPEC-ENVKEY-ANTHROPIC-SSOT-001/acceptance.md
@@ -1,0 +1,654 @@
+---
+spec: SPEC-ENVKEY-ANTHROPIC-SSOT-001
+phase: plan
+tier: M
+---
+
+# Acceptance Criteria - SPEC-ENVKEY-ANTHROPIC-SSOT-001
+
+Every verdict command below that **can** run against the base tree
+(`76d9a8f3b`, worktree `spec-envkey-anthropic`) was executed during plan-phase
+authoring, and its observed pre-change output is recorded verbatim as the
+baseline. An AC whose runnable command was never run is not an AC.
+
+Commands that depend on artefacts M1-M5 create (the guard test, the new
+constants, the post-transition state) **cannot** run at base. Those are marked
+`not runnable at base` with the reason. That marking is the honest form; an
+invented exit code would be a fabricated baseline
+(`.claude/rules/moai/core/verification-claim-integrity.md` section 2).
+
+## Standing verdict rules
+
+1. **No vacuous `-run` selectors.** Any AC resting on `go test -run <pattern>`
+   MUST use `-v -count=1` and read the verdict from an observed
+   `--- PASS: <exact test name>` line. A zero-match selector exits 0 and would
+   otherwise read as a false PASS.
+2. **Presence is not reachability.** `grep -c` proves a token exists; it does not
+   prove the code path bites. Guard ACs carry a falsification step.
+3. **Scoped commands only.** Each grep states its directory roots, its
+   `--include` filter, and its `_test.go` exclusion explicitly.
+4. **`_test.go` exclusion via `--exclude`, never `grep -v` after `-h`.** `grep -h`
+   suppresses filenames, so a downstream `grep -v '_test.go'` matches nothing and
+   is inert - a latent trap that silently widens scope the moment a test file
+   contributes a unique literal. Every grep in this file uses
+   `--exclude='*_test.go'`.
+5. **Exit codes are captured before a pipe, never after.** `cmd | tail -5; echo $?`
+   yields `tail`'s status - `0` whether `cmd` succeeded, failed, or was absent.
+   Verified: `bash -c 'false | tail -5; echo "exit=$?"'` prints `exit=0`. Every
+   exit-code verdict here uses `cmd; rc=$?; echo "exit=$rc"`.
+6. **A command that cannot run at base says so.** Some verdicts depend on artefacts
+   that M1-M5 create (the guard test, the new constants). For those the baseline is
+   recorded as *not runnable at base, and why* - never as an invented exit code. An
+   honestly-absent baseline is evidence; a fabricated one is not.
+
+---
+
+## D. AC Matrix
+
+| AC | REQ | Milestone | Subject |
+|----|-----|-----------|---------|
+| AC-EAS-001 | REQ-EAS-002 | M1 | Two missing constants added |
+| AC-EAS-002 | REQ-EAS-003 | M1 | Prefix constant added and documented |
+| AC-EAS-003 | REQ-EAS-001 | M1 | Constant set covers all 9 literal values |
+| AC-EAS-004 | REQ-EAS-009 | M1 | Constant values byte-identical to literals |
+| AC-EAS-005 | REQ-EAS-005 | M2 | Guard walk root reaches outside `internal/cli` |
+| AC-EAS-006 | REQ-EAS-008 | M2 | Guard banned set covers all 9 names (runtime assertion) |
+| AC-EAS-007 | REQ-EAS-006 | M2/M6 | SSOT exclusion is present **and narrow** (sibling file still scanned) |
+| AC-EAS-008 | REQ-EAS-004 | M3 | `internal/cli` transitioned |
+| AC-EAS-009 | REQ-EAS-004 | M4 | `internal/hook` transitioned |
+| AC-EAS-010 | REQ-EAS-004 | M5 | Remaining packages transitioned |
+| AC-EAS-011 | REQ-EAS-004 | M5 | Zero bare literals repo-wide; guard GREEN |
+| AC-EAS-012 | REQ-EAS-007, REQ-EAS-005 | M6 | Guard falsifiable outside `internal/cli` **and** under `cmd/` |
+| AC-EAS-013 | REQ-EAS-009 | M6 | Behaviour preserved: suite, vet, lint green |
+| AC-EAS-014 | REQ-EAS-010 | M6 | Template surface untouched |
+| AC-EAS-015 | REQ-EAS-011 | M6 | Test files untouched |
+
+---
+
+## AC-EAS-001 - Two missing constants added (M1)
+
+**Given** `envkeys.go` defines 6 ANTHROPIC constants and two names in active use
+(`ANTHROPIC_API_KEY`, `ANTHROPIC_DEFAULT_FABLE_MODEL`) have none,
+**When** M1 lands,
+**Then** both constants exist with the OQ-3 names.
+
+```bash
+grep -c 'EnvAnthropic[A-Za-z]* = "ANTHROPIC_' internal/config/envkeys.go
+grep -n 'EnvAnthropicAPIKey = "ANTHROPIC_API_KEY"' internal/config/envkeys.go
+grep -n 'EnvAnthropicDefaultFableModel = "ANTHROPIC_DEFAULT_FABLE_MODEL"' internal/config/envkeys.go
+```
+
+- **Baseline observed:** `6`; both `grep -n` return no match (exit 1).
+- **Expected after M1:** `9`; both `grep -n` return exactly one line each.
+
+## AC-EAS-002 - Prefix constant added and documented (M1)
+
+**Given** `"ANTHROPIC_"` is used as a prefix at
+`internal/cli/worktree/tmux_integration.go:238`,
+**When** M1 lands,
+**Then** `EnvAnthropicPrefix` exists and its doc comment identifies it as a
+namespace prefix rather than a variable name.
+
+```bash
+grep -n -B3 'EnvAnthropicPrefix = "ANTHROPIC_"' internal/config/envkeys.go
+```
+
+- **Baseline observed:** no match (exit 1).
+- **Expected after M1:** one match, preceded by a doc comment containing the word
+  `prefix`.
+
+## AC-EAS-003 - Constant set covers all 9 literal values (M1)
+
+**Given** 9 distinct `ANTHROPIC_*` literal values are in production use,
+**When** M1 lands,
+**Then** every one has a constant, so the transition has no orphan.
+
+```bash
+# left: literals in use (production).  right: literals defined in envkeys.go
+# NOTE: --exclude (not `grep -v` after -h) -- see standing rule 4.
+comm -23 \
+  <(grep -rho '"ANTHROPIC_[A-Z_]*"' internal/ pkg/ cmd/ --include='*.go' \
+      --exclude='*_test.go' | sort -u) \
+  <(grep -o '"ANTHROPIC_[A-Z_]*"' internal/config/envkeys.go | sort -u)
+```
+
+- **Baseline observed (re-run with the corrected `--exclude` form):**
+  unique-literal count `9`; `envkeys.go` defines `6`; `comm -23` emits exactly the
+  3 uncovered values:
+
+  ```
+  "ANTHROPIC_"
+  "ANTHROPIC_API_KEY"
+  "ANTHROPIC_DEFAULT_FABLE_MODEL"
+  ```
+- **Expected after M1:** `comm -23` emits **nothing** (empty output).
+- **Correction note (S5):** the prior form piped `grep -rho` into
+  `grep -v '_test.go'`. `-h` suppresses filenames, so that filter matched nothing
+  and was inert. Both forms happen to yield `9` today (verified: test files
+  contribute no *unique* literal), so the defect had no present effect - but it
+  would silently widen scope the first time a test file introduced a new value.
+
+## AC-EAS-004 - Constant values byte-identical (M1)
+
+**Given** this is a name-indirection refactor,
+**When** M1 lands,
+**Then** no constant's value differs from the literal it replaces.
+
+```bash
+go build ./...; build_rc=$?; echo "build_exit=$build_rc"
+
+# Mechanical: every value ADDED to envkeys.go must already exist in the base-tree
+# production inventory. `comm -13` emits lines present ONLY on the right (added
+# values with no base-tree counterpart) -- i.e. an invented or typo'd value.
+comm -13 \
+  <(git grep -ho -E '"ANTHROPIC_[A-Z_]*"' 76d9a8f3b \
+      -- 'internal/*.go' 'pkg/*.go' 'cmd/*.go' ':(exclude)*_test.go' | sort -u) \
+  <(git diff 76d9a8f3b -- internal/config/envkeys.go \
+      | grep '^+' | grep -oE '"ANTHROPIC_[A-Z_]*"' | sort -u)
+```
+
+- **Baseline observed:** `build_exit=0`. The `comm -13` produced **empty output**
+  (the right-hand side is empty at base - no diff against `76d9a8f3b` yet - so the
+  command is trivially satisfied; it becomes load-bearing only after M1). The
+  base-tree left-hand inventory was confirmed to be exactly the 9 known values.
+- **Expected after M1:** `build_exit=0`; `comm -13` still emits **nothing**. A
+  non-empty line names a constant whose value does not correspond to any literal
+  actually in use at base - a typo or an invented name.
+- **Correction note (S6):** the prior verdict was "manual read of 3 added lines",
+  a judgement call rather than a binary command. `git grep` at the base rev pins
+  the left-hand inventory to `76d9a8f3b` so the check stays meaningful after M3-M5
+  have driven the working-tree literal count to zero.
+
+---
+
+## AC-EAS-005 - Guard walk root reaches outside `internal/cli` (M2)
+
+This is the AC that closes the load-bearing defect. It is deliberately verified
+by **natural RED against the un-transitioned tree**, because at M2 the 37
+out-of-CLI literals form a ready-made falsification corpus.
+
+**Given** the existing guard walks only `internal/cli` and 37 occurrences live
+outside it,
+**When** the new repo-root guard runs at M2 against the still-untransitioned
+tree,
+**Then** it fails, and its offender list contains paths from `internal/hook/`,
+`internal/tmux/`, `internal/statusline/`, and `internal/sandbox/`.
+
+```bash
+go test ./internal/config/ -run 'TestNoBareAnthropicEnvVarLiteralsInProduction' \
+  -v -count=1 > /tmp/m2-guard.log 2>&1; echo "guard_exit=$?"
+grep -E '^(--- (PASS|FAIL)|FAIL)' /tmp/m2-guard.log
+# reachability assertion: offenders outside internal/cli must be present
+grep -c 'internal/hook/\|internal/tmux/\|internal/statusline/\|internal/sandbox/' /tmp/m2-guard.log
+```
+
+- **Baseline observed (base tree, guard absent):** the test does not exist; a
+  `-run` against it would match nothing and exit 0 — precisely the vacuous-PASS
+  trap standing rule 1 forbids. The reference point instead is the **existing**
+  guard, observed at base:
+
+  ```
+  === RUN   TestNoBareGLMEnvVarLiteralsInCLIProduction
+  --- PASS: TestNoBareGLMEnvVarLiteralsInCLIProduction (0.05s)
+  ok  	github.com/modu-ai/moai-adk/internal/cli	3.776s
+  ```
+
+  That PASS is green on a tree holding 83 violations — the defect made visible.
+- **Expected at M2:** `guard_exit` non-zero, an observed
+  `--- FAIL: TestNoBareAnthropicEnvVarLiteralsInProduction` line, and the
+  reachability grep returning **>= 37**.
+- **Fails the AC if:** the guard reports FAIL but every offender path starts with
+  `internal/cli/` — that is the old scope bug reproduced.
+- **Threshold provenance (S-census).** The `>= 37` figure is
+  `83 (total) - 46 (internal/cli)`, both measured at `76d9a8f3b`. Per-name
+  out-of-CLI counts, verified individually: `ANTHROPIC_AUTH_TOKEN` 12,
+  `ANTHROPIC_BASE_URL` 8, `ANTHROPIC_DEFAULT_OPUS_MODEL` 6,
+  `ANTHROPIC_DEFAULT_HAIKU_MODEL` 5, `ANTHROPIC_DEFAULT_SONNET_MODEL` 5,
+  `ANTHROPIC_API_KEY` 1, and `ANTHROPIC_` / `ANTHROPIC_DEFAULT_FABLE_MODEL` /
+  `ANTHROPIC_REASONING_EFFORT` 0 each — sum 37. If the plan.md section C.1 census
+  gate reports different totals at run-phase entry, this threshold MUST be
+  recomputed before M2 or the assertion is unattributable.
+- **Redirect note:** `tee ... | tail -40` was replaced by a plain redirect plus a
+  scoped grep. `tail -40` can crop the `--- FAIL:` line below a long offender list,
+  and its exit status is `tail`'s, not the test's (standing rule 5).
+
+## AC-EAS-006 - Guard banned set covers all 9 names, asserted at runtime (M2)
+
+**Given** REQ-EAS-008 requires the banned set to track `envkeys.go`, and the
+banned set is **derived from the constants** (plan.md F/M2 item 3) so the guard
+file contains no bare literals to grep,
+**When** M2 lands,
+**Then** a **top-level test function named exactly
+`TestAnthropicBannedSetCoversAllNames`** asserts the set has exactly 9 members
+and that each of the 9 expected names is present.
+
+Implementation shape (plan.md F/M2 item 4) - the guard exposes
+`bannedAnthropicEnvNames`, and a table-driven **top-level test function** in the
+same package asserts the following. It MUST NOT be a `t.Run` sub-test: the
+verdict command below selects it with a bare top-level `-run` pattern, which
+cannot select a sub-test, so a sub-test implementation would report
+`[no tests to run]` and trip this AC's own fail-condition.
+
+```go
+if len(bannedAnthropicEnvNames) != 9 { t.Fatalf("banned set size = %d, want 9", ...) }
+for _, want := range []string{
+    EnvAnthropicPrefix, EnvAnthropicAPIKey, EnvAnthropicAuthToken,
+    EnvAnthropicBaseURL, EnvAnthropicDefaultFableModel,
+    EnvAnthropicDefaultHaikuModel, EnvAnthropicDefaultOpusModel,
+    EnvAnthropicDefaultSonnetModel, EnvAnthropicReasoningEffort,
+} { /* assert membership; t.Errorf naming the missing name */ }
+```
+
+```bash
+go test ./internal/config/ -run 'TestAnthropicBannedSetCoversAllNames' \
+  -v -count=1 2>&1 | grep -E '^(=== RUN|--- (PASS|FAIL)|ok|FAIL)'
+```
+
+- **Baseline: not runnable at base.** The guard file
+  `internal/config/anthropic_env_ssot_test.go` does not exist at `76d9a8f3b`, so
+  that test function cannot run. Per standing rule 1 the `-run` selector would match
+  nothing and exit 0 - **observed verbatim** on this tree with an absent selector:
+
+  ```
+  testing: warning: no tests to run
+  PASS
+  ok  	github.com/modu-ai/moai-adk/internal/config	0.359s [no tests to run]
+  ```
+
+  That is the vacuous-PASS trap, not a baseline. No exit code is claimed here.
+- **Expected after M2:** an observed
+  `--- PASS: TestAnthropicBannedSetCoversAllNames` line.
+- **Fails the AC if:** the run reports `[no tests to run]`. Exit 0 with no
+  `--- PASS:` line is a vacuous pass, not a verdict.
+- **Correction note (M2, two defects in the prior form):**
+  1. *Fabricated baseline.* The prior text claimed "guard file does not exist;
+     command errors (exit 2)". Executed on this tree, the `comm` pipeline in fact
+     **exits 0 and prints 6 lines** - `comm` treats a missing right-hand file as
+     the empty set, so all 6 defined names are reported as unbanned. Observed:
+
+     ```
+     "ANTHROPIC_AUTH_TOKEN"
+     "ANTHROPIC_BASE_URL"
+     "ANTHROPIC_DEFAULT_HAIKU_MODEL"
+     "ANTHROPIC_DEFAULT_OPUS_MODEL"
+     "ANTHROPIC_DEFAULT_SONNET_MODEL"
+     "ANTHROPIC_REASONING_EFFORT"
+     exit=0
+     ```
+
+     The recorded baseline did not reproduce.
+  2. *Design contradiction - a correct implementation failed the AC.* plan.md
+     requires the banned set be derived from the `envkeys.go` constants. A derived
+     guard references `EnvAnthropic*` identifiers and therefore contains **zero**
+     bare `"ANTHROPIC_*"` literals, so the prior `comm -23` would emit all 9 names
+     and FAIL. The AC could only pass if the implementer duplicated 9 bare literals
+     into the guard, abandoning the derivation. The runtime assertion above removes
+     the contradiction: it verifies the property REQ-EAS-008 actually asserts
+     (set completeness) rather than a source-text proxy that contradicts the design.
+- **Coverage note (S2).** This assertion is the *only* check covering
+  `ANTHROPIC_`, `ANTHROPIC_DEFAULT_FABLE_MODEL`, and `ANTHROPIC_REASONING_EFFORT`
+  - the three names with **zero** out-of-CLI offenders (verified per-name counts:
+  0, 0, 0; the other six total 37). Without it, a guard silently omitting all
+  three still yields exactly 37 out-of-CLI offenders and passes AC-EAS-005,
+  AC-EAS-011, and AC-EAS-012 alike.
+
+## AC-EAS-007 - SSOT exclusion is present AND narrow (M2, re-checked M6)
+
+**Given** a repo-root walk reaches `internal/config/envkeys.go` (6 bare literals
+by design) and 291 `_test.go` occurrences, and an *over-broad* exclusion
+(`strings.Contains(path, "internal/config")` or `"envkeys"`) would exempt the
+entire SSOT package while looking identical from the outside,
+**When** the guard runs on a clean tree and then on a tree with a literal planted
+in a **sibling** `internal/config` production file,
+**Then** the clean run is GREEN (exclusion present) and the planted run is RED
+naming the sibling file (exclusion narrow).
+
+```bash
+# (a) exclusion present -- guard GREEN with the excluded surfaces populated
+go test ./internal/config/ -run 'TestNoBareAnthropicEnvVarLiteralsInProduction' \
+  -v -count=1 2>&1 | grep -E '^(=== RUN|--- (PASS|FAIL)|ok|FAIL)'
+grep -c '"ANTHROPIC_[A-Z_]*"' internal/config/envkeys.go        # excluded surface still populated
+grep -rn '"ANTHROPIC_[A-Z_]*"' internal/ pkg/ cmd/ --include='*_test.go' | wc -l
+
+# (b) exclusion NARROW -- plant one bare literal in a SIBLING internal/config
+#     production file and require RED naming that file.
+#     Target: internal/config/log.go (verified present, non-envkeys, package config)
+printf '\n// scope-probe (AC-EAS-007b): revert immediately\nvar _ = "ANTHROPIC_API_KEY"\n' \
+  >> internal/config/log.go
+go test ./internal/config/ -run 'TestNoBareAnthropicEnvVarLiteralsInProduction' \
+  -v -count=1 2>&1 | tee /tmp/ac007b.log | grep -E '^(--- (PASS|FAIL)|FAIL)|log\.go'
+# Two SEPARATE observations are required, in this order, so that a build failure
+# in package config (whose error lines also name log.go) cannot masquerade as a
+# guard detection:
+grep -c -- '--- FAIL: TestNoBareAnthropicEnvVarLiteralsInProduction' /tmp/ac007b.log  # MUST be 1
+grep -c 'anthropic_env_ssot_test.go' /tmp/ac007b.log   # MUST be >= 1 (the guard's own
+                                                       # t.Fatalf site -- present only
+                                                       # when the guard actually ran)
+
+# (c) revert and prove the tree is byte-clean again
+git checkout -- internal/config/log.go
+git status --porcelain internal/config/log.go        # MUST be empty
+go test ./internal/config/ -run 'TestNoBareAnthropicEnvVarLiteralsInProduction' \
+  -v -count=1 2>&1 | grep -E '^(--- (PASS|FAIL)|ok|FAIL)'
+```
+
+- **Baseline (the runnable legs, observed at base):** `envkeys.go` holds `6`
+  literals; `_test.go` files hold `291`.
+- **Baseline (the guard legs): not runnable at base** - the guard does not exist
+  at `76d9a8f3b`; a `-run` against it yields `[no tests to run]` (verbatim output
+  recorded under AC-EAS-006), which is a vacuous pass, not a baseline.
+- **Expected at M6:**
+  - (a) `--- PASS: TestNoBareAnthropicEnvVarLiteralsInProduction`; counts still
+    `6` and `291`
+  - (b) `--- FAIL: ...` **and** an offender line containing `internal/config/log.go`
+  - (c) `git status --porcelain` empty; `--- PASS: ...` again
+- **Fails the AC if:** step (b) passes. A guard that ignores a bare literal in
+  `internal/config/log.go` has an exclusion scoped to the package or to the
+  substring `envkeys`, not to the single SSOT file - it would exempt the entire
+  SSOT package while every other AC still passed.
+- **Correction note (S1).** The prior verdict grepped `go test -v` output for
+  `envkeys.go\|_test.go` expecting `0`. On the GREEN path `go test -v` emits only
+  `=== RUN` / `--- PASS` / `ok <pkg>` lines - no filenames - so it returns `0`
+  unconditionally, whether the exclusion is correct, over-broad, or absent
+  entirely. Worse, its risk was inverted: on a FAIL the runner prints
+  `anthropic_env_ssot_test.go:NN:`, which *contains* `_test.go`, producing a false
+  exclusion violation. No AC constrained the exclusion's scope, so an
+  implementation exempting all of `internal/config` passed all 15 ACs. Step (b) is
+  the constraint that was missing.
+
+---
+
+## AC-EAS-008 - `internal/cli` transitioned (M3)
+
+**Given** `internal/cli` holds 46 of the 83 bare literals,
+**When** M3 lands,
+**Then** none remain there and the package's tests still pass.
+
+```bash
+grep -rn '"ANTHROPIC_[A-Z_]*"' internal/cli/ --include='*.go' --exclude='*_test.go' | wc -l
+go test ./internal/cli/... -count=1 2>&1 | grep -c '^FAIL'
+```
+
+- **Baseline observed:** literal count `46`; `FAIL` count `0` (executed at base:
+  every `internal/cli/...` package reported `ok`).
+- **Expected after M3:** `0`; `FAIL` count still `0`.
+- **Correction note (S4/S5):** the test leg had no recorded baseline and used
+  `tail -5`, which truncates the package list and can hide a `FAIL` line above the
+  window. `grep -c '^FAIL'` is a deterministic verdict over the whole output.
+
+## AC-EAS-009 - `internal/hook` transitioned (M4)
+
+**Given** `internal/hook` holds 29 bare literals,
+**When** M4 lands,
+**Then** none remain there and the package's tests still pass.
+
+```bash
+grep -rn '"ANTHROPIC_[A-Z_]*"' internal/hook/ --include='*.go' --exclude='*_test.go' | wc -l
+go test ./internal/hook/... -count=1 2>&1 | grep -c '^FAIL'
+```
+
+- **Baseline observed:** literal count `29`; `FAIL` count `0` (executed at base).
+- **Expected after M4:** `0`; `FAIL` count still `0`.
+
+## AC-EAS-010 - Remaining packages transitioned (M5)
+
+**Given** `internal/tmux`, `internal/statusline`, and `internal/sandbox` hold the
+last 8 bare literals,
+**When** M5 lands,
+**Then** none remain and those packages' tests still pass.
+
+```bash
+grep -rn '"ANTHROPIC_[A-Z_]*"' internal/tmux/ internal/statusline/ internal/sandbox/ \
+  --include='*.go' --exclude='*_test.go' | wc -l
+go test ./internal/tmux/... ./internal/statusline/... ./internal/sandbox/... \
+  -count=1 2>&1 | grep -c '^FAIL'
+```
+
+- **Baseline observed:** literal count `8`; `FAIL` count `0` (executed at base).
+- **Expected after M5:** `0`; `FAIL` count still `0`.
+
+## AC-EAS-011 - Zero bare literals repo-wide; guard GREEN (M5)
+
+**Given** M3-M5 have transitioned all 10 files,
+**When** the guard runs,
+**Then** the RED window from plan.md D.3 closes.
+
+```bash
+grep -rn '"ANTHROPIC_[A-Z_]*"' internal/ pkg/ cmd/ --include='*.go' --exclude='*_test.go' \
+  | grep -v '^internal/config/envkeys.go' | wc -l
+go test ./internal/config/ -run 'TestNoBareAnthropicEnvVarLiteralsInProduction' \
+  -v -count=1 2>&1 | grep -E '^(=== RUN|--- (PASS|FAIL)|ok|FAIL)'
+```
+
+- **Baseline observed:** literal count `83` (re-run with the corrected
+  `--exclude` form; identical to the prior form's value). Guard leg **not runnable
+  at base** - the test does not exist at `76d9a8f3b`.
+- **Expected after M5:** `0`, and an observed
+  `--- PASS: TestNoBareAnthropicEnvVarLiteralsInProduction` line.
+- **Fails the AC if:** the guard leg prints `[no tests to run]` - vacuous pass
+  (standing rule 1). `tail -6` was replaced because it can crop the `--- PASS:`
+  line out of view when the runner emits build or cache chatter.
+
+---
+
+## AC-EAS-012 - Guard falsifiable outside `internal/cli` and under `cmd/` (M6)
+
+The decisive AC. A green guard proves nothing unless it can be made to fail on
+demand, in every region REQ-EAS-005 claims.
+
+> **[HARD] Precondition - M1 through M5 MUST be committed before M6 runs.**
+> Steps (b)-(e) revert their probes with `git checkout -- <file>`, which
+> restores the file to its last **commit**, not to its pre-probe working-tree
+> state. If any M1-M5 transition of `internal/sandbox/env.go` (or
+> `cmd/moai/main.go`) is still uncommitted when M6 runs, the checkout silently
+> discards that transition and permanently reintroduces the bare literal --
+> and `git status --porcelain` then reports **empty**, so the AC's own
+> clean-revert proof would affirm the corruption. Verify before starting M6:
+> `git status --porcelain internal/sandbox/env.go cmd/moai/main.go` MUST be
+> empty, i.e. every transition is already committed.
+
+**Given** the tree is clean, all M1-M5 work is committed, and the guard is GREEN,
+**When** a bare literal is deliberately re-introduced (i) in `internal/sandbox`
+(outside `internal/cli`, where the old guard was blind) and (ii) in `cmd/` (a root
+with zero natural offenders), and each is then reverted,
+**Then** the guard fails naming the planted file each time, passes again after
+each revert, and the working tree is byte-identical to its pre-probe state.
+
+```bash
+# (a) GREEN before
+go test ./internal/config/ -run 'TestNoBareAnthropicEnvVarLiteralsInProduction' \
+  -v -count=1 2>&1 | grep -E '^(--- (PASS|FAIL)|ok|FAIL)'
+
+# (b) plant OUTSIDE internal/cli. Target verified by grep: "ANTHROPIC_API_KEY"
+#     has exactly ONE production occurrence repo-wide --
+#     internal/sandbox/env.go:32, inside the defaultDenyList string slice.
+#     After M5 that element reads `config.EnvAnthropicAPIKey`. The probe below
+#     appends an equivalent bare literal to the same file rather than editing
+#     the slice element in place: appending is executable verbatim and reverts
+#     cleanly, whereas an in-place edit cannot be expressed as a command.
+printf '\n// reachability probe (AC-EAS-012b): revert immediately\nvar _ = "ANTHROPIC_API_KEY"\n' \
+  >> internal/sandbox/env.go
+go test ./internal/config/ -run 'TestNoBareAnthropicEnvVarLiteralsInProduction' \
+  -v -count=1 2>&1 | grep -E '^(--- (PASS|FAIL)|FAIL)|sandbox/env\.go'
+
+# (c) revert; prove no residual diff; re-confirm GREEN
+git checkout -- internal/sandbox/env.go
+git status --porcelain internal/sandbox/env.go            # MUST be empty
+git diff --stat internal/sandbox/env.go                   # MUST be empty
+go test ./internal/config/ -run 'TestNoBareAnthropicEnvVarLiteralsInProduction' \
+  -v -count=1 2>&1 | grep -E '^(--- (PASS|FAIL)|ok|FAIL)'
+
+# (d) plant under cmd/ -- REQ-EAS-005 coverage proof (pkg/ + cmd/ hold 0 literals,
+#     so nothing there is exercised by the natural corpus).
+printf '\n// reachability probe (AC-EAS-012d): revert immediately\nvar _ = "ANTHROPIC_API_KEY"\n' \
+  >> cmd/moai/main.go
+go test ./internal/config/ -run 'TestNoBareAnthropicEnvVarLiteralsInProduction' \
+  -v -count=1 2>&1 | grep -E '^(--- (PASS|FAIL)|FAIL)|cmd/moai/main\.go'
+git checkout -- cmd/moai/main.go
+git status --porcelain cmd/moai/main.go                   # MUST be empty
+go test ./internal/config/ -run 'TestNoBareAnthropicEnvVarLiteralsInProduction' \
+  -v -count=1 2>&1 | grep -E '^(--- (PASS|FAIL)|ok|FAIL)'
+
+# (f) plant under pkg/ -- the third enumerated root. plan.md F/M2 item 6 states
+#     these are three ENUMERATED roots that fail independently, so step (d)'s
+#     cmd/ plant proves nothing about pkg/. Target verified: pkg/version/version.go
+#     (package version, no build constraint, ends at package scope).
+printf '\n// reachability probe (AC-EAS-012f): revert immediately\nvar _ = "ANTHROPIC_API_KEY"\n' \
+  >> pkg/version/version.go
+go test ./internal/config/ -run 'TestNoBareAnthropicEnvVarLiteralsInProduction' \
+  -v -count=1 2>&1 | grep -E '^(--- (PASS|FAIL)|FAIL)|pkg/version/version\.go'
+git checkout -- pkg/version/version.go
+git status --porcelain pkg/version/version.go             # MUST be empty
+go test ./internal/config/ -run 'TestNoBareAnthropicEnvVarLiteralsInProduction' \
+  -v -count=1 2>&1 | grep -E '^(--- (PASS|FAIL)|ok|FAIL)'
+
+# (e) per-name falsification table -- every one of the 9 banned names, in turn.
+#     Three names (ANTHROPIC_, ANTHROPIC_DEFAULT_FABLE_MODEL,
+#     ANTHROPIC_REASONING_EFFORT) have ZERO out-of-CLI offenders (verified counts
+#     0/0/0), so no other AC exercises them.
+for NAME in ANTHROPIC_ ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN ANTHROPIC_BASE_URL \
+            ANTHROPIC_DEFAULT_FABLE_MODEL ANTHROPIC_DEFAULT_HAIKU_MODEL \
+            ANTHROPIC_DEFAULT_OPUS_MODEL ANTHROPIC_DEFAULT_SONNET_MODEL \
+            ANTHROPIC_REASONING_EFFORT; do
+  printf '\nvar _ = "%s"\n' "$NAME" >> internal/sandbox/env.go
+  go test ./internal/config/ -run 'TestNoBareAnthropicEnvVarLiteralsInProduction' \
+    -v -count=1 >/dev/null 2>&1; rc=$?
+  git checkout -- internal/sandbox/env.go
+  echo "$NAME guard_exit=$rc"      # every line MUST show a NON-ZERO exit
+done
+git status --porcelain internal/sandbox/env.go            # MUST be empty
+```
+
+- **Baseline: not runnable at base.** The guard does not exist at `76d9a8f3b`, and
+  after M5 the plant targets hold constants rather than literals. No exit code is
+  claimed for any leg (standing rule 6).
+- **Expected at M6:**
+  - (a) `--- PASS: TestNoBareAnthropicEnvVarLiteralsInProduction`
+  - (b) `--- FAIL: ...` **and** an offender line containing
+    `internal/sandbox/env.go`
+  - (c) both git checks empty; `--- PASS: ...`
+  - (d) `--- FAIL: ...` **and** an offender line containing `cmd/moai/main.go`;
+    then git check empty and `--- PASS: ...`
+  - (e) all 9 lines show a non-zero `guard_exit`; final git check empty
+- **Fails the AC if:** any of (b), (d), or any row of (e) passes. A guard that
+  cannot be made to fail in `internal/sandbox/`, under `cmd/`, or on any single
+  banned name has not covered the surface REQ-EAS-005 and REQ-EAS-008 claim,
+  regardless of what step (a) showed.
+- **Evidence requirement:** all outputs recorded verbatim in `progress.md`
+  section E.2, including the `git status --porcelain` empties. A summary
+  ("falsification confirmed") is not evidence.
+- **Correction note (M4).** The prior text targeted
+  `internal/hook/session_start.go`, instructing the implementer to "replace one
+  `config.EnvAnthropicAPIKey` reference with the bare literal". Verified by grep:
+  that file contains **no** `ANTHROPIC_API_KEY` reference at all - its ANTHROPIC
+  references are `ANTHROPIC_AUTH_TOKEN` (lines 365, 380), `ANTHROPIC_BASE_URL`
+  (381-382), and the three `ANTHROPIC_DEFAULT_*_MODEL` names (350-352, 435). There
+  would have been nothing to replace; the implementer would have had to *insert* an
+  unused literal, risking a lint failure that collides with AC-EAS-013. The retarget
+  to `internal/sandbox/env.go:32` uses the sole real `ANTHROPIC_API_KEY` site,
+  which is also outside `internal/cli/` and sits inside an existing string slice
+  (no unused identifier on revert).
+- **Correction note (S2).** Step (e) closes the banned-set-subset hole: the three
+  zero-offender names previously had no falsification coverage anywhere. It
+  composes with AC-EAS-006's runtime membership assertion - (e) proves the guard
+  *acts* on each name, AC-EAS-006 proves the set *contains* each name.
+- **Correction note (S3/N3).** Steps (d) and (f) are the evidence for the `cmd/`
+  and `pkg/` roots of REQ-EAS-005's claimed surface -- one plant per root, because
+  plan.md F/M2 item 6 enumerates the three roots as independently-failing list
+  elements, so a plant in one root proves nothing about another. The `git status --porcelain` /
+  `git diff --stat` checks in (c), (d), and (e) are the residual-diff proof that
+  every deliberately-planted literal was actually reverted - previously asserted
+  by the `git checkout` line alone, with nothing verifying it took effect.
+
+## AC-EAS-013 - Behaviour preserved (M6)
+
+**Given** this is a name-indirection refactor with no intended behaviour change,
+**When** M6 runs the full toolchain,
+**Then** the suite, `go vet`, and `golangci-lint` are all clean.
+
+```bash
+go test ./... -count=1 2>&1 | grep -c '^FAIL'
+go vet ./... 2>&1; vet_rc=$?; echo "vet_exit=$vet_rc"
+golangci-lint run --timeout=3m; lint_rc=$?; echo "lint_exit=$lint_rc"
+```
+
+- **Baseline observed:**
+  - `go vet ./...` produced no output, `vet_exit=0`.
+  - `golangci-lint run --timeout=3m` printed `0 issues.`, **`lint_exit=0`**
+    (executed at base with the corrected capture form; `golangci-lint` resolved to
+    `/opt/homebrew/bin/golangci-lint`).
+  - The **full** `go test ./...` leg was **not run at base**. It was deliberately
+    skipped: the repository's package-level suites are individually slow (several
+    `internal/cli/...` packages exceed 5 s each) and a whole-repo run risks a
+    tool timeout that would leave no observed output at all. In its place the four
+    packages this SPEC actually touches were run and their `^FAIL` counts observed:
+    `internal/cli/...` `0`, `internal/hook/...` `0`,
+    `internal/tmux/... internal/statusline/... internal/sandbox/...` `0`,
+    `internal/config/...` `0`. This is stated rather than fabricated
+    (standing rule 6); the whole-repo leg's first real observation is at M6.
+- **Expected at M6:** `FAIL` count `0`; `vet_exit=0`; `lint_exit=0`.
+- **Correction note (M3).** The prior lint leg read
+  `golangci-lint run --timeout=3m 2>&1 | tail -5; echo "lint_exit=$?"`. `$?` after
+  a pipeline is **`tail`'s** status, never `golangci-lint`'s, so the AC passed
+  whether lint succeeded, failed, or the binary was missing. Proof observed on this
+  machine: `bash -c 'false | tail -5; echo "lint_exit=$?"'` prints `lint_exit=0`,
+  while `bash -c 'false; lint_exit=$?; echo "lint_exit=$lint_exit"'` prints
+  `lint_exit=1`. The capture-before-pipe form is now standing rule 5. The
+  `go test` leg's redundant intermediate `grep -E` was also dropped - `grep -c
+  '^FAIL'` alone is the verdict.
+
+## AC-EAS-014 - Template surface untouched (M6)
+
+**Given** REQ-EAS-010 forbids any edit under `internal/template/templates/`,
+**When** M6 checks the template surface,
+**Then** both the reference count and the changed-file count are unchanged.
+
+```bash
+grep -rn 'ANTHROPIC_' internal/template/templates/ | wc -l
+git diff --name-only 76d9a8f3b -- internal/template/templates/ | wc -l
+```
+
+- **Baseline observed:** `12` references; changed-file count `0` (both legs
+  executed at base - the second leg previously had no recorded baseline).
+- **Expected at M6:** still `12`; changed-file count still `0`.
+
+## AC-EAS-015 - Test files untouched (M6)
+
+**Given** `_test.go` is a declared hardcoding-allowed zone and REQ-EAS-011 forbids
+migrating its literals,
+**When** M6 counts them,
+**Then** the count is unchanged.
+
+```bash
+grep -rn '"ANTHROPIC_[A-Z_]*"' internal/ pkg/ cmd/ --include='*_test.go' | wc -l
+```
+
+- **Baseline observed:** `291`.
+- **Expected at M6:** `291` (unchanged). A **lower** number means the
+  out-of-scope boundary in spec.md section D was crossed and the run must be
+  corrected, not accepted.
+
+---
+
+## Definition of Done
+
+- [ ] plan.md section C.1 census gate run BEFORE M1; all four counts matched the
+      recorded values, or the SPEC was re-baselined and the HISTORY table updated
+- [ ] All 15 ACs PASS with observed, verbatim-recorded evidence
+- [ ] AC-EAS-005 (natural RED reachability) and AC-EAS-012 (deliberate
+      re-introduction) both recorded — the guard is proven to see the wider
+      surface **and** to still bite once clean
+- [ ] AC-EAS-006 runtime banned-set assertion and AC-EAS-012 step (e) per-name
+      table both recorded — the three zero-offender names
+      (`ANTHROPIC_`, `ANTHROPIC_DEFAULT_FABLE_MODEL`, `ANTHROPIC_REASONING_EFFORT`)
+      are covered
+- [ ] AC-EAS-007 step (b) recorded — the SSOT exclusion is proven narrow, not a
+      package-wide exemption
+- [ ] AC-EAS-012 step (d) recorded — `cmd/` reachability proven by plant, closing
+      REQ-EAS-005's otherwise-unexercised `pkg/`+`cmd/` claim
+- [ ] Every deliberate plant reverted with an empty `git status --porcelain`
+      recorded as proof
+- [ ] `go test ./...`, `go vet ./...`, `golangci-lint run` all green
+- [ ] Untouched surfaces confirmed: template refs `12`, `_test.go` refs `291`
+- [ ] All milestones landed in a single PR; `main` never observed the RED window
+- [ ] OQ-1..OQ-4 resolutions reflected in the implementation as approved

--- a/.moai/specs/SPEC-ENVKEY-ANTHROPIC-SSOT-001/plan.md
+++ b/.moai/specs/SPEC-ENVKEY-ANTHROPIC-SSOT-001/plan.md
@@ -1,0 +1,416 @@
+---
+spec: SPEC-ENVKEY-ANTHROPIC-SSOT-001
+phase: plan
+tier: M
+---
+
+# Implementation Plan - SPEC-ENVKEY-ANTHROPIC-SSOT-001
+
+Milestones are ordered by **decision reversibility**: the decisions most likely
+to change (constant naming, prefix handling, guard architecture) lead; the
+mechanical per-package transitions follow. Review attention belongs at M1 and M2.
+
+---
+
+## A. Context
+
+Base commit: `76d9a8f3b`. Worktree branch: `plan/SPEC-ENVKEY-ANTHROPIC-SSOT-001`.
+
+Scope confirmed by measurement, not assumption: 83 bare `ANTHROPIC_*` literals
+across 10 production files, 9 distinct literal values, 6 existing constants, 2
+names with no constant. See `spec.md` section A for the full per-file table and
+the reproducing commands.
+
+---
+
+## B. Known Issues (discovered during plan-phase investigation)
+
+### B.1 The existing guard is scope-blind (load-bearing)
+
+`internal/cli/glm_env_parity_test.go:66` walks from `os.Getwd()`, which under
+`go test` is the package directory `internal/cli`. 37 of the 83 occurrences live
+outside that root and are structurally unreachable. Copying this pattern would
+produce a guard covering 55 percent of the surface while reporting PASS.
+
+Observed baseline (the guard currently passes, on a tree with 83 violations of
+the invariant this SPEC introduces):
+
+```
+--- PASS: TestNoBareGLMEnvVarLiteralsInCLIProduction (0.03s)
+```
+
+That PASS is exactly the failure mode: it is green because it cannot see, not
+because the tree is clean.
+
+### B.2 Widening the walk root exposes the SSOT file
+
+`internal/config/envkeys.go` contains 6 bare `"ANTHROPIC_*"` literals by design
+(they are the constant definitions). A repo-root walk reaches them. The new guard
+MUST exclude that file or it flags its own SSOT. This hazard did not exist for the
+`internal/cli`-rooted guard.
+
+### B.3 CI is PR-mandatory, so the RED window must not reach `main`
+
+Branch protection is `enforce_admins: true`; all changes route through a PR with
+4 required CI checks. The guard introduced at M2 is RED until the last package
+transition lands at M5. Therefore **all milestones land in a single PR**, and the
+RED state exists only inside this worktree. `main` never observes a failing guard.
+See section D.3.
+
+---
+
+## C. Pre-flight
+
+- [ ] Worktree is at `plan/SPEC-ENVKEY-ANTHROPIC-SSOT-001`, base `76d9a8f3b`
+- [ ] `go test ./...` green before any edit (establish the behaviour-preservation baseline)
+- [ ] `git status` clean apart from the SPEC directory
+- [ ] Open questions OQ-1..OQ-4 resolved at the Implementation Kickoff Approval gate
+
+### C.1 [HARD] Census re-measurement gate - run BEFORE M1
+
+Every count in this SPEC is a snapshot at `76d9a8f3b` (spec.md section A.5). Run
+these four commands against the run-phase HEAD and compare to the recorded values.
+**If any differs, halt** - do not enter M1. Re-baseline the affected ACs, record
+the new numbers plus the new base commit in the spec.md HISTORY table, then resume.
+
+```bash
+# 1. total production literals            expect 83
+grep -rn '"ANTHROPIC_[A-Z_]*"' internal/ pkg/ cmd/ --include='*.go' \
+  --exclude='*_test.go' | grep -v '^internal/config/envkeys.go' | wc -l
+# 2. reachable by the OLD internal/cli walk root   expect 46
+grep -rn '"ANTHROPIC_[A-Z_]*"' internal/cli/ --include='*.go' --exclude='*_test.go' | wc -l
+# 3. unique literal values                 expect 9
+grep -rho '"ANTHROPIC_[A-Z_]*"' internal/ pkg/ cmd/ --include='*.go' \
+  --exclude='*_test.go' | sort -u | wc -l
+# 4. constants already in the SSOT         expect 6
+grep -c '"ANTHROPIC_[A-Z_]*"' internal/config/envkeys.go
+# 5. internal/hook split (AC-EAS-009)      expect 29
+grep -rn '"ANTHROPIC_[A-Z_]*"' internal/hook/ --include='*.go' --exclude='*_test.go' | wc -l
+# 6. tmux+statusline+sandbox split (AC-EAS-010)   expect 8
+grep -rn '"ANTHROPIC_[A-Z_]*"' internal/tmux/ internal/statusline/ internal/sandbox/ \
+  --include='*.go' --exclude='*_test.go' | wc -l
+```
+
+Command 1 minus command 2 is the out-of-CLI figure (`83 - 46 = 37`) that AC-EAS-005's
+`>= 37` reachability threshold rests on. If commands 1 and 2 shift, that threshold
+MUST be recomputed before M2, or the reachability assertion becomes unattributable.
+
+Commands 5 and 6 exist because the totals alone are insufficient: a main-ward
+commit that MOVES three literals from `internal/hook` to `internal/tmux` leaves
+83 / 46 / 9 / 6 all unchanged, passes commands 1-4, and silently invalidates
+AC-EAS-009's `29` and AC-EAS-010's `8`. The per-package splits must therefore be
+re-measured too.
+
+Numbers this gate does NOT re-measure, stated explicitly so their staleness is a
+known and accepted risk rather than an unnoticed one: the `291` `_test.go`
+occurrence count (AC-EAS-015), the `12` template-reference count (AC-EAS-014),
+and the 10-file distribution table in spec.md A.1. All three are stability
+assertions (their ACs require the number to stay unchanged), so a shift surfaces
+as an AC failure rather than as a silent wrong baseline.
+
+---
+
+## D. Constraints
+
+### D.1 Language and style
+
+- All Go code, comments, and godoc in English (project rule).
+- New constants follow the existing `EnvAnthropic<CamelCase>` pattern with Go
+  initialism casing.
+
+### D.2 Behaviour preservation
+
+- Every constant's value is byte-identical to the literal it replaces. This is a
+  name-indirection refactor only.
+- Evidence: `go test ./...` green, plus `go vet ./...` clean.
+
+### D.3 Landing strategy - single PR, no RED on main
+
+The guard lands before the transitions (so it drives the work), which means it is
+RED for the duration of M3-M5. To keep `main` green:
+
+- All milestones M1-M6 land in **one PR** from this worktree.
+- The RED window is intra-worktree only. CI observes the branch only at PR time,
+  by which point M6 has driven the guard GREEN.
+- A run-phase reader seeing the guard fail after M2 is observing the **expected
+  RED window**, not a regression. This is stated here so it is not mis-triaged.
+
+### D.4 Untouched surfaces
+
+- `internal/template/templates/` (template neutrality) - no edits, no `make build`.
+- `_test.go` files (hardcoding-allowed zone) - 291 occurrences stay as-is.
+- `internal/cli/glm_env_parity_test.go` - the existing CLAUDE_CODE_* guard is not
+  modified (OQ-4 recommendation).
+
+---
+
+## E. Self-Verification
+
+Each milestone's exit is a command whose output is observed, not assumed. Verdict
+commands and their pre-change baselines are enumerated in `acceptance.md`.
+
+Standing rule for this SPEC: any AC whose verdict rests on a `go test -run`
+selector MUST be run with `-v -count=1` and the verdict read from an observed
+`--- PASS: <exact test name>` line. A zero-match `-run` selector exits 0 and would
+otherwise read as a false PASS.
+
+---
+
+## F. Milestones
+
+### M1 - SSOT constants (highest-reversibility decisions)
+
+**Why first:** the naming choice and the prefix-vs-name decision are the two
+judgements most likely to be revised on review. Everything downstream references
+them, so settling them first avoids rework.
+
+Work:
+
+1. Add to the ANTHROPIC const block in `internal/config/envkeys.go`:
+   - `EnvAnthropicAPIKey = "ANTHROPIC_API_KEY"`
+   - `EnvAnthropicDefaultFableModel = "ANTHROPIC_DEFAULT_FABLE_MODEL"`
+   - `EnvAnthropicPrefix = "ANTHROPIC_"` (doc comment must state: namespace
+     prefix, not a variable name - resolves OQ-1)
+2. Each constant carries an English godoc comment consistent with the existing 6.
+
+Exit: constant count 6 -> 9; `go build ./...` clean. (AC-EAS-001, AC-EAS-002)
+
+### M2 - repo-root guard, with reachability proven by natural RED
+
+**Why second:** the guard's architecture (walk root, exclusion set, host package,
+new-vs-extend) is the other high-reversibility decision. Landing it before the
+transitions makes it the progress meter for M3-M5.
+
+Work:
+
+1. Create `internal/config/anthropic_env_ssot_test.go` with
+   `TestNoBareAnthropicEnvVarLiteralsInProduction`.
+2. **Walk root - reuse the same-package helper; do NOT copy a colliding symbol.**
+   The guard file is `package config` (verified: `internal/config/required_checks_test.go:1`
+   declares `package config`), so it can call the existing helper directly:
+
+   | Symbol | Location | Signature | Usable here? |
+   |--------|----------|-----------|--------------|
+   | `findProjectRoot` | `internal/config/required_checks_test.go:162` | `func findProjectRoot(t *testing.T) string` | **YES - reuse this.** Same package, test-scoped, directly callable, no import needed. |
+   | `findRepoRoot` | `internal/config/token_budget_guard.go:45` | `func findRepoRoot(start string) (string, bool)` | Already declared in this package (a **production** file). See hazard below. |
+   | `findRepoRoot` | `internal/spec/drift_doctrine_test.go:13` | `func findRepoRoot(t *testing.T) string` | **NO** - unexported in a different package; not importable. |
+
+   > **[HAZARD] `findRepoRoot` redeclaration.** `internal/config` already declares
+   > `findRepoRoot` at `internal/config/token_budget_guard.go:45`. Copying the
+   > `internal/spec` helper of that name into `internal/config` produces
+   > `findRepoRoot redeclared in this block`, which breaks compilation of the
+   > **entire** `internal/config` package - and with it every AC that runs
+   > `go test ./internal/config/`. Call `findProjectRoot(t)` instead. Do not
+   > copy, do not rename-and-copy: a second root-finder in one package is
+   > duplicated logic with no benefit.
+
+3. **Banned set - derived from the constants, exposed for runtime assertion.**
+   Declare the banned set in terms of the `envkeys.go` identifiers, not bare
+   literals:
+
+   ```go
+   // bannedAnthropicEnvNames is derived from the envkeys.go constants, so a new
+   // constant that is not added here is a visible omission (REQ-EAS-008).
+   var bannedAnthropicEnvNames = []string{
+       EnvAnthropicPrefix, EnvAnthropicAPIKey, EnvAnthropicAuthToken,
+       EnvAnthropicBaseURL, EnvAnthropicDefaultFableModel,
+       EnvAnthropicDefaultHaikuModel, EnvAnthropicDefaultOpusModel,
+       EnvAnthropicDefaultSonnetModel, EnvAnthropicReasoningEffort,
+   }
+   ```
+
+   Consequence to note: a correctly-derived guard therefore contains **zero** bare
+   `"ANTHROPIC_*"` literals. Any AC that tries to verify banned-set completeness by
+   grepping this file for bare literals is structurally unsatisfiable - it can only
+   pass if the derivation intent is abandoned. Completeness is verified **at
+   runtime** instead (next item, and AC-EAS-006).
+
+4. **Runtime banned-set assertion** (satisfies REQ-EAS-008 and closes the
+   banned-set-subset hole): a **top-level test function named exactly
+   `TestAnthropicBannedSetCoversAllNames`** asserts
+   `len(bannedAnthropicEnvNames) == 9` and, table-driven, that each of the 9
+   expected names is a member. It MUST be a top-level `func Test...`, NOT a
+   `t.Run` sub-test: AC-EAS-006 selects it with a bare top-level `-run`
+   pattern, which cannot select a sub-test, so a sub-test implementation
+   would make a correct guard fail the AC. It lives in the same file as the
+   scan guard but as a separate top-level function, so it can be GREEN while
+   the scan guard is RED (exit signal 2 below). A guard that silently omits `ANTHROPIC_`,
+   `ANTHROPIC_DEFAULT_FABLE_MODEL`, or `ANTHROPIC_REASONING_EFFORT` - the three
+   names with **zero** out-of-CLI offenders, hence zero natural falsification
+   coverage - fails here and only here.
+5. Exclusions: `_test.go` suffix, and the SSOT file `internal/config/envkeys.go`
+   (per B.2). The `envkeys.go` exclusion MUST be an exact-path match, not a
+   substring or package-level match: excluding `internal/config` or `envkeys`
+   broadly would exempt the whole SSOT package. AC-EAS-007 asserts the exclusion
+   is narrow by planting a literal in a **sibling** `internal/config` file and
+   observing RED.
+6. Scan limited to `internal/`, `pkg/`, `cmd/`. These are three **enumerated**
+   roots: a typo'd or omitted entry fails independently of the others, which is
+   why AC-EAS-012 plants a probe under `cmd/` as well as under `internal/`
+   (a probe in one root cannot prove another root is scanned).
+7. **Failure output format**: on failure the guard MUST emit **one offender per
+   line**, each line containing the offending file's path. AC-EAS-005 counts
+   those lines (`grep -c ... >= 37`), so a guard that instead emits a summary
+   count plus a truncated sample would satisfy REQ-EAS-007 yet fail AC-EAS-005.
+   Reuse the existing `strings.Join(offenders, "\n  ")` shape from
+   `internal/cli/glm_env_parity_test.go`.
+
+**Reachability proof - the natural falsification corpus.** At M2 the tree still
+holds all 83 literals, 37 of them outside `internal/cli/`. The guard's first run
+must therefore report RED with **at least 37 offenders whose paths are outside
+`internal/cli/`**. That observation is the direct evidence that the walk root
+reaches past `internal/cli` - the defect in B.1 made mechanically visible. A guard
+that goes RED with only `internal/cli` paths has the old scope bug and MUST be
+fixed before M3. (AC-EAS-005)
+
+Exit, three separable signals:
+
+1. **The scan test is RED** (expected - the tree still holds 83 literals): its
+   offender list contains paths from `internal/hook/`, `internal/tmux/`,
+   `internal/statusline/`, and `internal/sandbox/`, and `envkeys.go` appears in
+   **no** offender path. (AC-EAS-005)
+2. **The runtime banned-set test `TestAnthropicBannedSetCoversAllNames`
+   (top-level function, not a sub-test) is GREEN** - it asserts set membership, not
+   tree cleanliness, so it does not participate in the RED window and must pass
+   from the moment it lands. A RED here at M2 means the derived set is wrong.
+   (AC-EAS-006)
+3. `go build ./...` and the rest of `internal/config`'s suite still compile - the
+   F/M2 `findRepoRoot` hazard did not fire. (AC-EAS-007 step (b) is deferred to M6,
+   since it requires a clean tree to distinguish the planted offender from the
+   83 pre-existing ones.)
+
+### M3 - transition `internal/cli` (46 occurrences)
+
+- `internal/cli/glm.go` (32)
+- `internal/cli/launcher.go` (7)
+- `internal/cli/settings.go` (6)
+- `internal/cli/worktree/tmux_integration.go` (1, the prefix usage from OQ-1)
+
+Exit: 0 bare literals under `internal/cli/`; guard still RED (37 remain);
+`go test ./internal/cli/... ./internal/cli/worktree/...` green. (AC-EAS-008)
+
+### M4 - transition `internal/hook` (29 occurrences)
+
+- `internal/hook/session_end.go` (12)
+- `internal/hook/glm_tmux.go` (9)
+- `internal/hook/session_start.go` (8)
+
+Exit: 0 bare literals under `internal/hook/`; guard still RED (8 remain);
+`go test ./internal/hook/...` green. (AC-EAS-009)
+
+### M5 - transition the remaining packages (8 occurrences)
+
+- `internal/tmux/cg_detect.go` (4)
+- `internal/statusline/metrics.go` (3)
+- `internal/sandbox/env.go` (1)
+
+Exit: guard turns **GREEN** - the RED window from D.3 closes here.
+(AC-EAS-010, AC-EAS-011)
+
+### M6 - post-green falsifiability proof and full verification
+
+**Why last, and why not merged into M2:** M2's natural RED proves the guard
+*reaches* the wider surface while violations still exist. It does not prove the
+guard *still bites* once the tree is clean - a guard that is green because its
+banned set silently emptied would look identical. M6 supplies the second,
+independent proof.
+
+Work:
+
+1. **Deliberate re-introduction, `internal/` (verified target).** After M5,
+   `internal/sandbox/env.go:32` holds `config.EnvAnthropicAPIKey` as an element of
+   `defaultDenyList`. Revert that one element to the bare `"ANTHROPIC_API_KEY"`.
+   Run the guard; observe FAIL naming that file. Revert; re-run; observe PASS.
+   Both directions recorded verbatim. (AC-EAS-012 steps a-c)
+
+   > Target verified at base by grep: `"ANTHROPIC_API_KEY"` has **exactly one**
+   > production occurrence repo-wide, `internal/sandbox/env.go:32`. The earlier
+   > draft named `internal/hook/session_start.go`, which contains **no**
+   > `ANTHROPIC_API_KEY` reference at all (its ANTHROPIC references are
+   > `_AUTH_TOKEN`, `_BASE_URL`, and the three `_DEFAULT_*_MODEL` names) - there
+   > would have been nothing to replace, forcing the implementer to *insert* an
+   > unused literal and risk a lint failure colliding with AC-EAS-013.
+   > `internal/sandbox/env.go` is outside `internal/cli/`, so it still exercises
+   > the widened walk root. The literal sits inside an existing string slice, so
+   > reverting it introduces no unused identifier.
+
+2. **Deliberate re-introduction, `cmd/` (REQ-EAS-005 coverage proof).** `pkg/` and
+   `cmd/` hold zero literals (spec.md A.1), so nothing there is proven by the
+   natural corpus. Plant one bare `"ANTHROPIC_API_KEY"` in `cmd/moai/main.go`,
+   observe FAIL naming that file, revert, observe PASS. Without this step two
+   thirds of REQ-EAS-005's claimed surface is asserted and never exercised.
+   (AC-EAS-012 step d)
+3. **SSOT-exclusion scope proof - both directions.** Confirm the guard stays GREEN
+   with `envkeys.go`'s 6 literals present (the exclusion works), **and** that a
+   bare literal planted in a *sibling* `internal/config` production file
+   (`internal/config/log.go`) still goes RED (the exclusion is narrow, not a
+   package-wide exemption). A one-directional check cannot distinguish a correct
+   exact-path exclusion from an over-broad one that exempts the whole SSOT package.
+   (AC-EAS-007)
+4. Full suite: `go test ./...`, `go vet ./...`, `golangci-lint run`.
+   (AC-EAS-013)
+5. Untouched-surface confirmation: template refs still 12, `_test.go` occurrences
+   still 291. (AC-EAS-014, AC-EAS-015)
+
+Exit: all ACs PASS with observed evidence.
+
+---
+
+## G. Anti-Patterns
+
+- **Copying the existing guard's walk root.** `os.Getwd()` under `go test` is the
+  package dir. Copying it reproduces the exact defect this SPEC exists to fix.
+- **Reading a `-run` selector's exit 0 as PASS.** A zero-match selector exits 0.
+  Always `-v -count=1` and read the `--- PASS: <name>` line.
+- **Treating the M2-M5 RED window as a regression.** It is the designed progress
+  meter (D.3).
+- **Declaring the guard proven by presence alone.** `grep -c` on the banned list
+  shows tokens exist, not that the code path bites. The M6 re-introduction is the
+  proof.
+- **Grepping the guard file for bare `"ANTHROPIC_*"` literals.** The banned set is
+  *derived from the constants* (F/M2 item 3), so a correct guard contains none. A
+  source-grep completeness check is unsatisfiable-by-construction: it can only pass
+  if the implementer duplicates all 9 bare literals in the guard, abandoning the
+  derivation. Verify completeness at runtime (AC-EAS-006).
+- **Copying `findRepoRoot` into `internal/config`.** The package already declares
+  it at `internal/config/token_budget_guard.go:45`; the copy fails to compile and
+  takes the whole package - and every `go test ./internal/config/` AC - with it.
+  Reuse `findProjectRoot(t)` at `internal/config/required_checks_test.go:162`.
+- **Reading `$?` after a pipeline.** `cmd | tail -5; echo $?` reports `tail`'s
+  status, never `cmd`'s - it is `0` whether the command succeeded, failed, or was
+  missing. Capture into a variable before the pipe:
+  `cmd; rc=$?; echo "exit=$rc"`.
+- **Excluding `_test.go` with `grep -v` after `grep -h`.** `-h` suppresses
+  filenames, so the `-v` filter has nothing to match and is inert. Use
+  `--exclude='*_test.go'`.
+- **Excluding the SSOT by package or substring.** An exclusion on
+  `internal/config` or `envkeys` exempts far more than the one SSOT file. Match the
+  exact path; AC-EAS-007 plants in a sibling `internal/config` file to prove the
+  exclusion is narrow.
+- **Entering M1 on a stale census.** The counts are a `76d9a8f3b` snapshot. Run the
+  section C.1 gate first.
+- **Migrating `_test.go` literals.** Out of scope by record (spec.md section D);
+  a well-meaning cleanup here contradicts CLAUDE.local.md section 14.
+- **Touching `internal/template/templates/`.** Template neutrality; also would
+  entail `make build`, which this SPEC explicitly does not.
+- **Renaming or widening `TestNoBareGLMEnvVarLiteralsInCLIProduction`.** OQ-4
+  recommends leaving it intact; its name encodes its scope.
+
+---
+
+## H. Cross-References
+
+- `spec.md` sections A.2, A.3 - the guard defect and the SSOT-exclusion hazard
+- `acceptance.md` - AC verdict commands with observed pre-change baselines
+- `internal/cli/glm_env_parity_test.go:66` - the defective guard (unmodified)
+- `internal/config/required_checks_test.go:162` - `findProjectRoot(t *testing.T) string`,
+  the same-package helper the new guard reuses (verified by grep)
+- `internal/config/token_budget_guard.go:45` - `findRepoRoot(start string) (string, bool)`,
+  the pre-existing same-package symbol a copied helper would collide with (F/M2 hazard)
+- `internal/spec/drift_doctrine_test.go:13` - `findRepoRoot(t)`; a *different-package*
+  unexported helper, cited as design precedent only, NOT importable or copyable here
+- `internal/sandbox/env.go:32` - the sole production `"ANTHROPIC_API_KEY"` site;
+  the M6 falsification target
+- `cmd/moai/main.go` - the M6 `cmd/` plant target for REQ-EAS-005 coverage
+- CLAUDE.local.md section 14 (hardcoding policy), sections 15 and 25 (template
+  neutrality), section 23 (PR-mandatory git policy)

--- a/.moai/specs/SPEC-ENVKEY-ANTHROPIC-SSOT-001/progress.md
+++ b/.moai/specs/SPEC-ENVKEY-ANTHROPIC-SSOT-001/progress.md
@@ -1,6 +1,6 @@
 ---
 spec: SPEC-ENVKEY-ANTHROPIC-SSOT-001
-phase: plan
+phase: run
 ---
 
 # Progress - SPEC-ENVKEY-ANTHROPIC-SSOT-001

--- a/.moai/specs/SPEC-ENVKEY-ANTHROPIC-SSOT-001/progress.md
+++ b/.moai/specs/SPEC-ENVKEY-ANTHROPIC-SSOT-001/progress.md
@@ -1,0 +1,65 @@
+---
+spec: SPEC-ENVKEY-ANTHROPIC-SSOT-001
+phase: plan
+---
+
+# Progress - SPEC-ENVKEY-ANTHROPIC-SSOT-001
+
+## §E.1 Plan-phase Audit-Ready Signal
+
+Plan-phase artifacts authored at base commit `76d9a8f3b` on branch
+`plan/SPEC-ENVKEY-ANTHROPIC-SSOT-001`.
+
+- Artifacts: `spec.md`, `plan.md`, `acceptance.md`, `progress.md`
+- SPEC ID regex pre-write check: executed as Bash, observed `PASS`
+- Duplicate SPEC ID check: observed `NO_DUPLICATE_SPEC_ID`
+- `moai spec lint` on `spec.md`: observed `✓ No findings — all SPEC documents are valid`
+- Baseline measurements re-verified in this worktree (not carried over):
+  83 bare literals / 10 files / 9 unique values / 6 existing constants /
+  46 reachable + 37 unreachable by the existing guard / 291 `_test.go` refs /
+  12 template refs / `go vet ./...` exit 0
+- 15 acceptance criteria authored, each carrying either an executed verdict
+  command with its observed pre-change baseline, or an explicit
+  `not runnable at base` marking with the reason
+- 4 open questions (OQ-1..OQ-4) recorded with recommendations, pending
+  resolution at the Implementation Kickoff Approval gate
+
+### Audit iteration 2 (plan-auditor FAIL 0.72 -> remediation)
+
+An independent plan-auditor returned FAIL (0.72) with 5 MUST-FIX and 6 SHOULD-FIX
+findings. Remediation landed in `spec.md` v0.2.0, `plan.md`, and `acceptance.md`.
+Every remediating code fact was re-verified by executed command in this worktree:
+
+- `lifecycle` corrected `spec-first` -> `spec-anchored` (canonical enum,
+  `.claude/rules/moai/development/spec-frontmatter-schema.md:48`)
+- AC-EAS-006 rebuilt as a **runtime** banned-set assertion; the prior source-grep
+  baseline was fabricated (executed: exit 0 with 6 lines, not exit 2) and
+  contradicted plan.md's derive-from-constants design
+- AC-EAS-013 lint verdict rebuilt to capture the exit code before the pipe;
+  vacuity proven by executed `bash -c 'false | tail -5; echo $?'` -> `0`
+- M6 falsification retargeted `internal/hook/session_start.go` ->
+  `internal/sandbox/env.go:32` (the sole production `ANTHROPIC_API_KEY` site,
+  confirmed by repo-wide grep)
+- Guard root-finder retargeted to `findProjectRoot(t)` at
+  `internal/config/required_checks_test.go:162`; the
+  `findRepoRoot`-redeclaration hazard against
+  `internal/config/token_budget_guard.go:45` recorded in plan.md F/M2
+- AC-EAS-007 gained a positive scope assertion (sibling-file plant); AC-EAS-012
+  gained a `cmd/` plant, a 9-name falsification table, and residual-diff checks
+- Missing baselines executed and recorded: per-package `^FAIL` counts (all `0`),
+  `golangci-lint run --timeout=3m` -> `0 issues.` / `lint_exit=0`, template
+  changed-file count `0`
+- Census re-measurement gate added as a [HARD] run-phase entry precondition
+  (spec.md A.5, plan.md C.1)
+
+## §E.2 Run-phase Evidence
+
+_<pending run-phase>_
+
+## §E.3 Run-phase Audit-Ready Signal
+
+_<pending run-phase>_
+
+## §E.4 Sync-phase Audit-Ready Signal
+
+_<pending sync-phase>_

--- a/.moai/specs/SPEC-ENVKEY-ANTHROPIC-SSOT-001/progress.md
+++ b/.moai/specs/SPEC-ENVKEY-ANTHROPIC-SSOT-001/progress.md
@@ -122,7 +122,86 @@ M6 (falsifiability proof + full-suite verification) is NOT part of this run.
 
 ## §E.3 Run-phase Audit-Ready Signal
 
-_<pending run-phase>_
+run_status: audit-ready
+run_complete_at: 2026-07-31
+milestones_complete: M1, M2, M3, M4, M5, M6
+
+### M6 — falsifiability proof + full-suite verification (executed by the orchestrator)
+
+Precondition verified before any probe: `git status --porcelain` on the four probe
+targets was empty, i.e. every M1-M5 transition was already committed, so
+`git checkout --` could not discard uncommitted work.
+
+**AC-EAS-007 — SSOT exclusion is present AND narrow — PASS**
+
+| Step | Observed |
+|------|----------|
+| (a) clean tree | `--- PASS: TestNoBareAnthropicEnvVarLiteralsInProduction (0.28s)` |
+| (b) plant in sibling `internal/config/log.go` | `exit=1`; `--- FAIL:` line count `1`; offender naming `config/log.go` count `1`; guard-ran evidence `anthropic_env_ssot_test.go` count `1` |
+| (c) revert | `git status --porcelain internal/config/log.go` → 0 lines; `--- PASS:` again |
+
+The sibling plant being detected is the positive proof that the `envkeys.go`
+exclusion is an exact-path match and not a package-wide exemption.
+
+**AC-EAS-012 — guard falsifiable in all three enumerated roots — PASS**
+
+| Leg | Root | Observed |
+|-----|------|----------|
+| (b) | `internal/` — `internal/sandbox/env.go` | `exit=1`, `--- FAIL` ×1, file named ×1, revert residue 0 |
+| (d) | `cmd/` — `cmd/moai/main.go` | `exit=1`, `--- FAIL` ×1, file named ×1, revert residue 0 |
+| (f) | `pkg/` — `pkg/version/version.go` | `exit=1`, `--- FAIL` ×1, file named ×1, revert residue 0 |
+| (a)/(post) | clean tree before and after | `--- PASS:` both times |
+
+(e) per-name falsification, all 9 banned names planted in turn into
+`internal/sandbox/env.go` and reverted: **9/9 produced a non-zero guard exit**,
+including the three names with zero natural offenders (`ANTHROPIC_`,
+`ANTHROPIC_DEFAULT_FABLE_MODEL`, `ANTHROPIC_REASONING_EFFORT`) that no other AC
+exercises. Total residual diff after the loop: `git status --porcelain` → 0 lines.
+
+**AC-EAS-013 — behaviour preservation — PASS, with a disclosed flaky observation**
+
+| Leg | Observed |
+|-----|----------|
+| `go vet ./...` | no output, `vet_exit=0` |
+| `golangci-lint run --timeout=3m` | `0 issues.`, `lint_exit=0` (exit captured directly, not after a pipe) |
+| `go test ./...` run 1 | `exit=1`; 2 failing packages: `internal/lsp/subprocess` (`TestSupervisor_MultipleWatchers`), `internal/web`; 104 `ok` |
+| `go test -count=1 ./...` run 2 | `exit=0`, 0 `^FAIL`, 106 `ok` |
+| `go test -count=1 ./...` run 3 | `exit=0`, 0 `^FAIL`, 106 `ok` |
+
+Run 1's failure was investigated rather than assumed away, and is attributed to
+pre-existing load-sensitive flakiness, not to this refactor. Evidence for that
+attribution:
+
+- Both packages pass **in isolation** on this tree (`go test ./internal/lsp/subprocess/... ./internal/web/...` → `exit=0`, both `ok`).
+- Both packages contain **zero** `ANTHROPIC` references (`grep -rn 'ANTHROPIC'` → 0 each).
+- **Zero** files changed by M1-M5 live in either package (`git diff --name-only 76d9a8f3b..HEAD -- internal/lsp internal/web` → 0).
+- Two subsequent cache-disabled full-suite runs were clean.
+- `TestSupervisor_MultipleWatchers` is a ~10 s multi-watcher timing test — the shape that degrades under a 106-package parallel run.
+
+Counter-evidence recorded for honesty: a single full-suite run at base
+`76d9a8f3b` (in a temporary probe worktree, since removed) was clean (0 `^FAIL`,
+106 `ok`). That is one sample against this tree's three, so it does not establish
+that base is immune; it is disclosed rather than omitted.
+
+**Stability ACs re-confirmed at M6**
+
+| AC | Command | Observed | Required |
+|----|---------|----------|----------|
+| AC-EAS-011 | production bare literals, `envkeys.go` excluded | `0` | `0` |
+| AC-EAS-014 | `git diff --name-only 76d9a8f3b -- internal/template/templates/ \| wc -l` | `0` | `0` |
+| AC-EAS-015 | `_test.go` ANTHROPIC occurrences | `291` | `291` (unchanged) |
+| AC-EAS-001 | `envkeys.go` ANTHROPIC literals | `9` | `9` (6 base + 3 from M1) |
+
+Cross-platform: `go build ./...` → 0; `GOOS=windows GOARCH=amd64 go build ./...` → 0.
+
+**Gaps at run-phase close**
+
+- No Windows test *run* (cross-compile only); `internal/hook` and `internal/tmux` carry platform-conditional code.
+- No end-to-end runtime exercise of the GLM/tmux/hook paths against a live tmux
+  session or a real endpoint. Behaviour preservation rests on the value-identity
+  attestation (forward round-trip from base, all 10 files `IDENTICAL`) plus the
+  per-package suites.
+- Coverage was not measured; this refactor adds no production branches.
 
 ## §E.4 Sync-phase Audit-Ready Signal
 

--- a/.moai/specs/SPEC-ENVKEY-ANTHROPIC-SSOT-001/progress.md
+++ b/.moai/specs/SPEC-ENVKEY-ANTHROPIC-SSOT-001/progress.md
@@ -54,7 +54,71 @@ Every remediating code fact was re-verified by executed command in this worktree
 
 ## §E.2 Run-phase Evidence
 
-_<pending run-phase>_
+### M3-M5 — literal-to-constant transition (AC-EAS-008 / 009 / 010 / 011)
+
+| AC | Milestone | Status | Verification Command | Actual Output |
+|----|-----------|--------|----------------------|---------------|
+| AC-EAS-008 | M3 | PASS | `grep -rn '"ANTHROPIC_[A-Z_]*"' internal/cli/ --include='*.go' --exclude='*_test.go' \| wc -l` | `0` |
+| AC-EAS-008 | M3 | PASS | `go test ./internal/cli/... -count=1 2>&1 \| grep -c '^FAIL'` | `0` (test_exit=0) |
+| AC-EAS-009 | M4 | PASS | `grep -rn '"ANTHROPIC_[A-Z_]*"' internal/hook/ --include='*.go' --exclude='*_test.go' \| wc -l` | `0` |
+| AC-EAS-009 | M4 | PASS | `go test ./internal/hook/... -count=1 2>&1 \| grep -c '^FAIL'` | `0` (test_exit=0) |
+| AC-EAS-010 | M5 | PASS | `grep -rn '"ANTHROPIC_[A-Z_]*"' internal/tmux/ internal/statusline/ internal/sandbox/ --include='*.go' --exclude='*_test.go' \| wc -l` | `0` |
+| AC-EAS-010 | M5 | PASS | `go test ./internal/tmux/... ./internal/statusline/... ./internal/sandbox/... -count=1 2>&1 \| grep -c '^FAIL'` | `0` (`ok` for all three packages) |
+| AC-EAS-011 | M5 | PASS | `grep -rn '"ANTHROPIC_[A-Z_]*"' internal/ pkg/ cmd/ --include='*.go' --exclude='*_test.go' \| grep -v '^internal/config/envkeys.go' \| wc -l` | `0` |
+| AC-EAS-011 | M5 | PASS | `go test ./internal/config/ -run 'TestNoBareAnthropicEnvVarLiteralsInProduction' -v -count=1` | `--- PASS: TestNoBareAnthropicEnvVarLiteralsInProduction (0.29s)` / `ok  github.com/modu-ai/moai-adk/internal/config  6.862s` (guard_exit=0) |
+
+### Guard trajectory (the RED-window progress meter)
+
+| Point | Offender count | Guard verdict |
+|-------|----------------|---------------|
+| M2 landed (base of this run) | 83 | `--- FAIL` |
+| after M3 (`internal/cli`, 46 replaced) | 37 | `--- FAIL`, zero `internal/cli/` paths |
+| after M4 (`internal/hook`, 29 replaced) | 8 | `--- FAIL`, zero `internal/hook/` paths |
+| after M5 (remaining 8 replaced) | 0 | `--- PASS` — RED window closed |
+
+Offender count measured as
+`grep -cE '\.go:[0-9]+:[0-9]+: ANTHROPIC_' <guard-log>`.
+
+### Per-file replacement counts (46 + 29 + 8 = 83)
+
+| File | Replaced |
+|------|---------:|
+| `internal/cli/glm.go` | 32 |
+| `internal/cli/launcher.go` | 7 |
+| `internal/cli/settings.go` | 6 |
+| `internal/cli/worktree/tmux_integration.go` | 1 (prefix) |
+| `internal/hook/session_end.go` | 12 |
+| `internal/hook/glm_tmux.go` | 9 |
+| `internal/hook/session_start.go` | 8 |
+| `internal/tmux/cg_detect.go` | 4 |
+| `internal/statusline/metrics.go` | 3 |
+| `internal/sandbox/env.go` | 1 |
+
+`internal/config` imports were added to `glm_tmux.go`, `cg_detect.go`,
+`metrics.go`, and `env.go` (no import cycle: `internal/config` depends only on
+`internal/defs` + `pkg/models`).
+
+### Behaviour-preservation evidence
+
+- Each literal was replaced by the constant whose declared value in
+  `envkeys.go` is byte-identical (all 9 pairs machine-verified).
+- Forward attestation: applying the same value-preserving mapping to the base
+  (`f4055ca36`) source of all 10 files and gofmt-comparing against the working
+  tree reports `IDENTICAL` for all 10 (`FORWARD_ALL_IDENTICAL`) — the tree is
+  exactly the mechanical transform of base, so no wrong-but-compiling constant
+  was substituted.
+- `go build ./...` exit 0; `GOOS=windows GOARCH=amd64 go build ./...` exit 0.
+- `go vet ./...` no output, exit 0.
+- `golangci-lint run --timeout=3m` → `0 issues.`, exit 0 (identical to the
+  pre-M3 baseline; zero NEW issues).
+
+### Untouched-surface confirmation (AC-EAS-014 / AC-EAS-015 spot-check)
+
+- `_test.go` ANTHROPIC_* occurrences: `291` (unchanged).
+- `internal/template/templates/` ANTHROPIC_ references: `12`; changed-file
+  count vs `f4055ca36`: `0`.
+
+M6 (falsifiability proof + full-suite verification) is NOT part of this run.
 
 ## §E.3 Run-phase Audit-Ready Signal
 

--- a/.moai/specs/SPEC-ENVKEY-ANTHROPIC-SSOT-001/spec.md
+++ b/.moai/specs/SPEC-ENVKEY-ANTHROPIC-SSOT-001/spec.md
@@ -2,7 +2,7 @@
 id: SPEC-ENVKEY-ANTHROPIC-SSOT-001
 title: Single-source the ANTHROPIC_* environment-variable name family through internal/config/envkeys.go
 version: 0.2.0
-status: draft
+status: in-progress
 created: 2026-07-31
 updated: 2026-07-31
 author: manager-spec

--- a/.moai/specs/SPEC-ENVKEY-ANTHROPIC-SSOT-001/spec.md
+++ b/.moai/specs/SPEC-ENVKEY-ANTHROPIC-SSOT-001/spec.md
@@ -1,0 +1,377 @@
+---
+id: SPEC-ENVKEY-ANTHROPIC-SSOT-001
+title: Single-source the ANTHROPIC_* environment-variable name family through internal/config/envkeys.go
+version: 0.2.0
+status: draft
+created: 2026-07-31
+updated: 2026-07-31
+author: manager-spec
+priority: P2
+phase: plan
+module: internal/config
+lifecycle: spec-anchored
+tags: "envkeys, hardcoding, refactor, guard-test, ssot"
+tier: M
+---
+
+## HISTORY
+
+| Version | Date | Change | Author |
+|---------|------|--------|--------|
+| 0.1.0 | 2026-07-31 | Initial plan-phase authoring. Baseline measured at `76d9a8f3b`: 83 bare literals across 10 production files; guard-test scope defect identified. | manager-spec |
+| 0.2.0 | 2026-07-31 | Audit iteration 2 (plan-auditor FAIL 0.72). `lifecycle` corrected to the canonical enum value; REQ-EAS-007 relabelled Event-driven; A.1 extended with the `pkg/`+`cmd/` zero-literal fact; A.5 census re-measurement gate added. Companion fixes in plan.md (M2 guard design, M6 falsification targets, symbol citations) and acceptance.md (runtime banned-set assertion, lint exit-code capture, positive scope assertion, mechanized AC-EAS-004, recorded baselines). | manager-spec |
+
+---
+
+## A. Context
+
+### A.1 Problem
+
+The `ANTHROPIC_*` environment-variable **name** family is referenced as bare string
+literals throughout the production Go source. `internal/config/envkeys.go` is the
+declared single source of truth (SSOT) for environment-variable names
+(CLAUDE.local.md section 14: environment-variable names must be defined as
+constants in `internal/config/envkeys.go` and referenced from there), but the
+ANTHROPIC family only partially honours it.
+
+Measured at base commit `76d9a8f3b`:
+
+```bash
+grep -rn '"ANTHROPIC_[A-Z_]*"' internal/ pkg/ cmd/ --include='*.go' --exclude='*_test.go' \
+  | grep -v '^internal/config/envkeys.go' | wc -l
+# observed: 83
+```
+
+Distribution across 10 production files:
+
+| File | Count |
+|------|------:|
+| `internal/cli/glm.go` | 32 |
+| `internal/hook/session_end.go` | 12 |
+| `internal/hook/glm_tmux.go` | 9 |
+| `internal/hook/session_start.go` | 8 |
+| `internal/cli/launcher.go` | 7 |
+| `internal/cli/settings.go` | 6 |
+| `internal/tmux/cg_detect.go` | 4 |
+| `internal/statusline/metrics.go` | 3 |
+| `internal/sandbox/env.go` | 1 |
+| `internal/cli/worktree/tmux_integration.go` | 1 |
+| **Total** | **83** |
+
+Nine distinct literal values are in use:
+
+```
+"ANTHROPIC_"                    (bare prefix, used for prefix-matching - see OQ-1)
+"ANTHROPIC_API_KEY"             (NO constant exists)
+"ANTHROPIC_AUTH_TOKEN"
+"ANTHROPIC_BASE_URL"
+"ANTHROPIC_DEFAULT_FABLE_MODEL" (NO constant exists)
+"ANTHROPIC_DEFAULT_HAIKU_MODEL"
+"ANTHROPIC_DEFAULT_OPUS_MODEL"
+"ANTHROPIC_DEFAULT_SONNET_MODEL"
+"ANTHROPIC_REASONING_EFFORT"
+```
+
+**Distribution is entirely under `internal/`.** Measured at the same commit:
+
+```bash
+grep -rn '"ANTHROPIC_[A-Z_]*"' pkg/ cmd/ --include='*.go' --exclude='*_test.go' | wc -l
+# observed: 0
+find pkg cmd -name '*.go' -not -name '*_test.go' | wc -l
+# observed: 7
+```
+
+`pkg/` and `cmd/` hold **zero** bare literals today across their 7 production Go
+files. REQ-EAS-005 nonetheless claims those roots as guarded surface, so their
+coverage cannot be demonstrated by the natural corpus - there is nothing there to
+find. It is demonstrated instead by **deliberate plants** at M6 -- one under `cmd/`
+(acceptance.md AC-EAS-012 step (d)) and one under `pkg/` (step (f)). One plant per
+root, because plan.md F/M2 item 6 enumerates the three scan roots as
+independently-failing list elements: a guard whose root list silently omits or
+typos `pkg/` would still pass a `cmd/`-only probe. Without both plants the `pkg/`
+and `cmd/` portions of REQ-EAS-005's claimed surface would be asserted and never
+proven.
+
+`internal/config/envkeys.go` currently defines exactly **6** ANTHROPIC constants
+(`EnvAnthropicBaseURL`, `EnvAnthropicAuthToken`, `EnvAnthropicDefaultHaikuModel`,
+`EnvAnthropicDefaultSonnetModel`, `EnvAnthropicDefaultOpusModel`,
+`EnvAnthropicReasoningEffort`). Two names in active use have **no constant at all**.
+
+### A.2 The load-bearing finding: the existing guard cannot see most of the surface
+
+`internal/cli/glm_env_parity_test.go:66`
+`TestNoBareGLMEnvVarLiteralsInCLIProduction` is the mechanical gate that was
+supposed to prevent this class of drift. It carries **two independent defects**
+that make it structurally incapable of covering the ANTHROPIC family:
+
+1. **Wrong banned list.** Its `banned` slice contains only three `CLAUDE_CODE_*`
+   names. No `ANTHROPIC_*` name is checked at all.
+
+2. **Wrong walk root.** Its walk root is `os.Getwd()`, which under `go test`
+   resolves to the **package directory** `internal/cli`, not the repository
+   root. Every occurrence outside `internal/cli/` is therefore structurally
+   unreachable.
+
+Measured reachability split at `76d9a8f3b`:
+
+```bash
+grep -rn '"ANTHROPIC_[A-Z_]*"' internal/cli/ --include='*.go' --exclude='*_test.go' | wc -l
+# observed: 46   (reachable by the current walk root)
+
+grep -rn '"ANTHROPIC_[A-Z_]*"' internal/ pkg/ cmd/ --include='*.go' --exclude='*_test.go' \
+  | grep -v '^internal/config/envkeys.go' \
+  | grep -v '^internal/cli/' | wc -l
+# observed: 37   (structurally unreachable)
+```
+
+46 of 83 (55.4 percent) are reachable; **37 are not**. Naively reusing the
+existing pattern would therefore produce a guard that silently passes on 45
+percent of the surface. This SPEC treats the guard repair (walk root AND banned
+list AND a demonstrated falsification) as a first-class deliverable, not a
+by-product.
+
+### A.3 New hazard introduced by widening the walk root
+
+A repo-root-scoped walk reaches `internal/config/envkeys.go`, which by design
+contains 6 bare `"ANTHROPIC_*"` literals - they are the constant definitions,
+the SSOT itself:
+
+```bash
+grep -c '"ANTHROPIC_[A-Z_]*"' internal/config/envkeys.go
+# observed: 6
+```
+
+The current `internal/cli`-rooted guard never faced this because `envkeys.go`
+lives outside its walk root. A repo-root guard MUST exclude the SSOT definition
+file, or it flags the very constants it exists to enforce. This is a new
+requirement created by the widening, not an inherited one.
+
+### A.4 Why now
+
+This is mechanical name-indirection debt. It carries no user-visible symptom, but
+it is the same drift class that `SPEC-CLIFIX-HYGIENE-001` closed for the
+`CLAUDE_CODE_*` family, and the guard that closed it is the one shown above to be
+scope-blind. Leaving the ANTHROPIC family unguarded means the next env-var rename
+silently diverges across `internal/cli`, `internal/hook`, `internal/tmux`,
+`internal/statusline`, and `internal/sandbox`.
+
+### A.5 The census is a point-in-time snapshot - re-measurement is a run-phase gate
+
+Every count in this SPEC (83 / 46 / 37 / 9 / 6 / 291 / 12) and every acceptance
+baseline in `acceptance.md` was measured at `76d9a8f3b`. Any main-ward commit
+touching the 10 files in the A.1 table, `internal/config/envkeys.go`, or the
+guard-precedent files invalidates those numbers and, with them, the M3-M5
+milestone arithmetic.
+
+**[HARD] Run-phase entry precondition.** Before starting M1, the implementer MUST
+re-run the A.1 census commands (the 83 / 46 / 37 totals and the 9-value unique
+inventory) against the run-phase HEAD and compare them to the values recorded
+here. **If any count differs, halt**: do not proceed into M1. Re-baseline the
+affected ACs in `acceptance.md`, record the new numbers and the base commit in the
+HISTORY table, and only then resume. Proceeding on a stale census would make every
+downstream AC verdict unattributable to an observed baseline
+(`.claude/rules/moai/core/verification-claim-integrity.md` section 2).
+
+The exact commands and their expected values are enumerated as pre-flight items in
+`plan.md` section C.
+
+---
+
+## B. Requirements (GEARS)
+
+### B.1 SSOT constants
+
+**REQ-EAS-001** (Ubiquitous)
+The `internal/config/envkeys.go` file shall be the single definition site for
+every `ANTHROPIC_*` environment-variable name referenced by production Go source
+under `internal/`, `pkg/`, and `cmd/`.
+
+**REQ-EAS-002** (Ubiquitous)
+The `envkeys.go` file shall define a named constant for `ANTHROPIC_API_KEY` and a
+named constant for `ANTHROPIC_DEFAULT_FABLE_MODEL`, following the existing
+`EnvAnthropic<CamelCase>` naming pattern with Go initialism casing.
+
+**REQ-EAS-003** (Ubiquitous)
+The `envkeys.go` file shall define a constant for the bare namespace prefix
+`ANTHROPIC_`, documented as a prefix, distinct from any full variable name.
+
+**REQ-EAS-004** (Unwanted)
+Production Go source under `internal/`, `pkg/`, and `cmd/`, excluding
+`internal/config/envkeys.go` and excluding `_test.go` files, shall not contain a
+bare `ANTHROPIC_*` string literal.
+
+### B.2 Mechanical guard
+
+**REQ-EAS-005** (Ubiquitous)
+The guard test shall resolve its walk root to the repository root, so that every
+production Go file under `internal/`, `pkg/`, and `cmd/` is reachable, including
+files outside `internal/cli/`.
+
+> Coverage-proof note: `pkg/` and `cmd/` hold zero bare literals today (A.1), so
+> the natural corpus cannot demonstrate their reachability. AC-EAS-012 step (d)
+> plants one literal under `cmd/moai/main.go` and observes RED, which is the only
+> evidence this clause is satisfied rather than merely asserted.
+
+**REQ-EAS-006** (Ubiquitous)
+The guard test shall exclude `internal/config/envkeys.go` (the SSOT definition
+site) and all `_test.go` files from its scan.
+
+**REQ-EAS-007** (Event-driven)
+**When** a bare `ANTHROPIC_*` string literal is introduced into any production Go
+file reachable from the repository root, including a package outside
+`internal/cli/`, the guard test shall fail and name the offending file and
+position.
+
+**REQ-EAS-008** (Ubiquitous)
+The guard test's banned set shall cover every `ANTHROPIC_*` name defined in
+`envkeys.go`, so that adding a constant without adding it to the guard is a
+visible omission rather than a silent gap.
+
+### B.3 Behaviour preservation (non-functional)
+
+**REQ-EAS-009** (Ubiquitous)
+The transition shall be a mechanical name-indirection refactor with no intended
+change to runtime behaviour: every constant's value shall be byte-identical to
+the literal it replaces.
+
+**REQ-EAS-010** (Unwanted)
+The change shall not modify any file under `internal/template/templates/`
+(template neutrality, CLAUDE.local.md sections 15 and 25).
+
+**REQ-EAS-011** (Unwanted)
+The change shall not modify `ANTHROPIC_*` literals inside `_test.go` files, which
+are a declared hardcoding-allowed zone (CLAUDE.local.md section 14).
+
+---
+
+## C. Success Criteria
+
+| # | Criterion | Baseline (observed at `76d9a8f3b`) | Target |
+|---|-----------|-----------------------------------:|-------:|
+| 1 | ANTHROPIC constants in `envkeys.go` | 6 | 9 |
+| 2 | Bare literals in production source (excl. `envkeys.go`, excl. `_test.go`) | 83 | 0 |
+| 3 | Guard walk root reaches outside `internal/cli` | no (37 unreachable) | yes (0 unreachable) |
+| 4 | Guard falsifiable by deliberate re-introduction outside `internal/cli` | n/a (guard absent) | proven RED then GREEN |
+| 5 | `go test ./...` | not observed at base (see acceptance.md AC-EAS-013 skip note) | green |
+| 6 | ANTHROPIC refs under `internal/template/templates/` | 12 | unchanged (12) |
+| 7 | `ANTHROPIC_*` occurrences in `_test.go` files | 291 | unchanged (291) |
+
+---
+
+## D. Exclusions
+
+### Out of Scope - the CLAUDE_CODE_* family
+
+- Widening `TestNoBareGLMEnvVarLiteralsInCLIProduction` to repo-root scope for the
+  three `CLAUDE_CODE_*` names it already guards. Those names remain unguarded
+  outside `internal/cli/` after this SPEC lands. This is a known, recorded
+  residual gap and a candidate follow-up SPEC; it is deliberately excluded here
+  to keep this SPEC's blast radius to one env-var family.
+- Auditing any other env-var family (`MOAI_*`, `GLM_*`, `CLAUDE_*`) for the same
+  drift class.
+
+### Out of Scope - test files
+
+- `_test.go` files contain 291 `ANTHROPIC_*` occurrences. These are **not**
+  migrated and **not** guarded. CLAUDE.local.md section 14 declares `_test.go` an
+  allowed-hardcoding zone. A future reader MUST NOT treat these 291 occurrences
+  as residual debt from this SPEC; their exclusion is intentional and recorded
+  here so it is not "fixed" later by mistake.
+
+### Out of Scope - template surface
+
+- `internal/template/templates/` carries 12 `ANTHROPIC_` references. These are
+  distributed user-facing template assets, governed by template neutrality
+  (CLAUDE.local.md sections 15 and 25) and outside the Go compilation surface.
+  They are untouched.
+
+### Out of Scope - behaviour and configuration
+
+- Any change to which environment variables are read, written, cleared, or
+  injected; any change to their values, precedence, or lifecycle. This SPEC
+  changes only how the **names** are spelled in Go source.
+- Adding, removing, or renaming any `ANTHROPIC_*` environment variable.
+- `make build` and template regeneration: no template file changes, so no rebuild
+  is entailed by this SPEC.
+
+---
+
+## E. Open Questions
+
+Recorded with a recommendation each; resolved at the Implementation Kickoff
+Approval gate, not silently during run-phase.
+
+### OQ-1 - the bare `ANTHROPIC_` prefix literal
+
+**Finding.** Exactly one production usage, at
+`internal/cli/worktree/tmux_integration.go:238`:
+
+```go
+// Only include ANTHROPIC_* vars
+if strings.HasPrefix(key, "ANTHROPIC_") {
+    cfg.GLMEnvVars[key] = value
+}
+```
+
+It filters `.env.glm` entries down to the ANTHROPIC namespace. It is a **prefix**,
+semantically distinct from a variable name.
+
+**Recommendation.** Define `EnvAnthropicPrefix = "ANTHROPIC_"` in `envkeys.go`
+with a doc comment stating it is a namespace prefix, not a variable name, and
+route the call site through it. Rationale: it is the same SSOT concern (a rename
+of the namespace must land in one place), and leaving it bare would require an
+awkward carve-out in the guard.
+
+**Guard interaction, verified safe.** The guard matches on **exact literal
+equality** (`bannedSet[val]`), not substring containment, so banning the exact
+string `"ANTHROPIC_"` does not collide with `"ANTHROPIC_API_KEY"` or any other
+member. Confirmed by reading `glm_env_parity_test.go:103-107`.
+
+### OQ-2 - `_test.go` exclusion
+
+**Finding.** 291 `ANTHROPIC_*` occurrences live in `_test.go` files.
+CLAUDE.local.md section 14 declares `_test.go` a hardcoding-allowed zone, and the
+existing guard already skips `_test.go`.
+
+**Recommendation.** Exclude test files from **both** the transition and the
+guard, and state the exclusion explicitly in section D (done above) so a later
+reader does not interpret the 291 as leftover debt. No change required to the
+existing suffix check.
+
+### OQ-3 - naming of the new constants
+
+**Recommendation.** Follow the existing `EnvAnthropic<CamelCase>` pattern with Go
+initialism casing (consistent with the existing `EnvAnthropicBaseURL`, which uses
+`URL` not `Url`):
+
+| Literal | Constant |
+|---------|----------|
+| `ANTHROPIC_API_KEY` | `EnvAnthropicAPIKey` |
+| `ANTHROPIC_DEFAULT_FABLE_MODEL` | `EnvAnthropicDefaultFableModel` |
+| `ANTHROPIC_` | `EnvAnthropicPrefix` |
+
+### OQ-4 - extend the existing guard, or add a new one?
+
+**Recommendation: add a NEW repo-root-scoped guard; leave the existing test
+intact.**
+
+Rationale:
+
+1. **The existing name would become a lie.**
+   `TestNoBareGLMEnvVarLiteralsInCLIProduction` asserts CLI scope in its
+   identifier. Widening it to repo-root scope without renaming misleads every
+   future reader; renaming it churns a test owned by a different, already-closed
+   SPEC.
+2. **Different owners, different families.** The existing test guards three
+   `CLAUDE_CODE_*` names for `SPEC-CLIFIX-HYGIENE-001`. Its narrow scope is
+   recorded behaviour, not an accident to be silently overwritten.
+3. **Clean falsification target.** A separate test gives this SPEC an independent
+   RED/GREEN signal that cannot be confounded with the CLAUDE_CODE_* assertions.
+
+**Proposed home and name.** `internal/config/anthropic_env_ssot_test.go`,
+`TestNoBareAnthropicEnvVarLiteralsInProduction`. Hosting it in `internal/config`
+places the guard beside the SSOT it enforces.
+
+**Consequence to accept.** The three `CLAUDE_CODE_*` names remain unguarded
+outside `internal/cli/`. Recorded in section D as an explicit out-of-scope
+residual gap and a follow-up candidate.

--- a/internal/cli/glm.go
+++ b/internal/cli/glm.go
@@ -209,12 +209,12 @@ func glmAutoCompactWindow(highModel string) (string, bool) {
 // @MX:WARN: [AUTO] Global environment variable mutation without rollback mechanism
 // @MX:REASON: Process-level state mutation affects all subsequent goroutines; no cleanup on error
 func setGLMEnv(glmConfig *GLMConfigFromYAML, apiKey string) {
-	_ = os.Setenv("ANTHROPIC_AUTH_TOKEN", apiKey)                            //nolint:errcheck
-	_ = os.Setenv("ANTHROPIC_BASE_URL", glmConfig.BaseURL)                   //nolint:errcheck
-	_ = os.Setenv("ANTHROPIC_DEFAULT_OPUS_MODEL", glmConfig.Models.High)     //nolint:errcheck
-	_ = os.Setenv("ANTHROPIC_DEFAULT_SONNET_MODEL", glmConfig.Models.Medium) //nolint:errcheck
-	_ = os.Setenv("ANTHROPIC_DEFAULT_HAIKU_MODEL", glmConfig.Models.Low)     //nolint:errcheck
-	_ = os.Setenv("ANTHROPIC_DEFAULT_FABLE_MODEL", glmConfig.Models.Fable)   //nolint:errcheck
+	_ = os.Setenv(config.EnvAnthropicAuthToken, apiKey)                           //nolint:errcheck
+	_ = os.Setenv(config.EnvAnthropicBaseURL, glmConfig.BaseURL)                  //nolint:errcheck
+	_ = os.Setenv(config.EnvAnthropicDefaultOpusModel, glmConfig.Models.High)     //nolint:errcheck
+	_ = os.Setenv(config.EnvAnthropicDefaultSonnetModel, glmConfig.Models.Medium) //nolint:errcheck
+	_ = os.Setenv(config.EnvAnthropicDefaultHaikuModel, glmConfig.Models.Low)     //nolint:errcheck
+	_ = os.Setenv(config.EnvAnthropicDefaultFableModel, glmConfig.Models.Fable)   //nolint:errcheck
 	// 1M context activation: when the High slot model resolves to the 1M context
 	// tier, scale the auto-compact window to the full 1M context.
 	if window, ok := glmAutoCompactWindow(glmConfig.Models.High); ok {
@@ -474,12 +474,12 @@ func injectTmuxSessionEnv(glmConfig *GLMConfigFromYAML, apiKey string) error {
 // injectTmuxSessionEnvVia.
 func buildTmuxInjectVars(glmConfig *GLMConfigFromYAML, apiKey string) map[string]string {
 	vars := map[string]string{
-		"ANTHROPIC_AUTH_TOKEN":           apiKey,
-		"ANTHROPIC_BASE_URL":             glmConfig.BaseURL,
-		"ANTHROPIC_DEFAULT_OPUS_MODEL":   glmConfig.Models.High,
-		"ANTHROPIC_DEFAULT_SONNET_MODEL": glmConfig.Models.Medium,
-		"ANTHROPIC_DEFAULT_HAIKU_MODEL":  glmConfig.Models.Low,
-		"ANTHROPIC_DEFAULT_FABLE_MODEL":  glmConfig.Models.Fable,
+		config.EnvAnthropicAuthToken:          apiKey,
+		config.EnvAnthropicBaseURL:            glmConfig.BaseURL,
+		config.EnvAnthropicDefaultOpusModel:   glmConfig.Models.High,
+		config.EnvAnthropicDefaultSonnetModel: glmConfig.Models.Medium,
+		config.EnvAnthropicDefaultHaikuModel:  glmConfig.Models.Low,
+		config.EnvAnthropicDefaultFableModel:  glmConfig.Models.Fable,
 		// Z.AI proxy compatibility: strip Anthropic beta headers
 		config.EnvClaudeCodeDisableExperimentalBetas: "1",
 		"API_TIMEOUT_MS": "3000000",
@@ -513,7 +513,7 @@ func injectTmuxSessionEnvVia(mgr tmux.SessionManager, glmConfig *GLMConfigFromYA
 	// failure we MUST NOT fall back to argv (would re-leak the token).
 	ctx := context.Background()
 
-	const sensitiveKey = "ANTHROPIC_AUTH_TOKEN"
+	const sensitiveKey = config.EnvAnthropicAuthToken
 	if token := vars[sensitiveKey]; token != "" {
 		if err := mgr.InjectSensitiveEnv(ctx, sensitiveKey, token); err != nil {
 			return fmt.Errorf("inject sensitive tmux env: %w", err)
@@ -555,11 +555,11 @@ func clearTmuxSessionEnv() error {
 // GLM activation indicator — removing it is sufficient to deactivate GLM mode.
 func buildTmuxClearVars() []string {
 	return []string{
-		"ANTHROPIC_BASE_URL",
-		"ANTHROPIC_DEFAULT_OPUS_MODEL",
-		"ANTHROPIC_DEFAULT_SONNET_MODEL",
-		"ANTHROPIC_DEFAULT_HAIKU_MODEL",
-		"ANTHROPIC_DEFAULT_FABLE_MODEL",
+		config.EnvAnthropicBaseURL,
+		config.EnvAnthropicDefaultOpusModel,
+		config.EnvAnthropicDefaultSonnetModel,
+		config.EnvAnthropicDefaultHaikuModel,
+		config.EnvAnthropicDefaultFableModel,
 		// GLM effort overlay (SPEC-MODEL-TIER-PLANTYPE-001 M5, REQ-MTP-030 Branch-B
 		// inject↔clear parity, REQ-CGH-009): clear the reasoning-control env when
 		// leaving GLM mode so it does not leak into a subsequent `moai cc` session.
@@ -667,17 +667,17 @@ func injectGLMEnvForTeam(settingsPath string, glmConfig *GLMConfigFromYAML, apiK
 
 		// Back up any existing ANTHROPIC_AUTH_TOKEN that is not the GLM key itself.
 		// This preserves a Claude OAuth token so that removeGLMEnv can restore it.
-		if existing, ok := env["ANTHROPIC_AUTH_TOKEN"].(string); ok && existing != "" && existing != apiKey {
+		if existing, ok := env[config.EnvAnthropicAuthToken].(string); ok && existing != "" && existing != apiKey {
 			env["MOAI_BACKUP_AUTH_TOKEN"] = existing
 		}
 
 		// Inject GLM environment variables for teammates
-		env["ANTHROPIC_AUTH_TOKEN"] = apiKey
-		env["ANTHROPIC_BASE_URL"] = glmConfig.BaseURL
-		env["ANTHROPIC_DEFAULT_OPUS_MODEL"] = glmConfig.Models.High
-		env["ANTHROPIC_DEFAULT_SONNET_MODEL"] = glmConfig.Models.Medium
-		env["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = glmConfig.Models.Low
-		env["ANTHROPIC_DEFAULT_FABLE_MODEL"] = glmConfig.Models.Fable
+		env[config.EnvAnthropicAuthToken] = apiKey
+		env[config.EnvAnthropicBaseURL] = glmConfig.BaseURL
+		env[config.EnvAnthropicDefaultOpusModel] = glmConfig.Models.High
+		env[config.EnvAnthropicDefaultSonnetModel] = glmConfig.Models.Medium
+		env[config.EnvAnthropicDefaultHaikuModel] = glmConfig.Models.Low
+		env[config.EnvAnthropicDefaultFableModel] = glmConfig.Models.Fable
 		// Z.AI proxy compatibility: strip Anthropic beta headers
 		env[config.EnvClaudeCodeDisableExperimentalBetas] = "1"
 		env["API_TIMEOUT_MS"] = "3000000"
@@ -934,17 +934,17 @@ func injectGLMEnv(settingsPath string, glmConfig *GLMConfigFromYAML) error {
 
 		// Back up any existing ANTHROPIC_AUTH_TOKEN that is not the GLM key itself.
 		// This preserves a Claude OAuth token so that removeGLMEnv can restore it.
-		if existing, ok := env["ANTHROPIC_AUTH_TOKEN"].(string); ok && existing != "" && existing != apiKey {
+		if existing, ok := env[config.EnvAnthropicAuthToken].(string); ok && existing != "" && existing != apiKey {
 			env["MOAI_BACKUP_AUTH_TOKEN"] = existing
 		}
 
 		// Inject GLM environment variables with actual API key value
-		env["ANTHROPIC_AUTH_TOKEN"] = apiKey
-		env["ANTHROPIC_BASE_URL"] = glmConfig.BaseURL
-		env["ANTHROPIC_DEFAULT_OPUS_MODEL"] = glmConfig.Models.High
-		env["ANTHROPIC_DEFAULT_SONNET_MODEL"] = glmConfig.Models.Medium
-		env["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = glmConfig.Models.Low
-		env["ANTHROPIC_DEFAULT_FABLE_MODEL"] = glmConfig.Models.Fable
+		env[config.EnvAnthropicAuthToken] = apiKey
+		env[config.EnvAnthropicBaseURL] = glmConfig.BaseURL
+		env[config.EnvAnthropicDefaultOpusModel] = glmConfig.Models.High
+		env[config.EnvAnthropicDefaultSonnetModel] = glmConfig.Models.Medium
+		env[config.EnvAnthropicDefaultHaikuModel] = glmConfig.Models.Low
+		env[config.EnvAnthropicDefaultFableModel] = glmConfig.Models.Fable
 		// Z.AI proxy compatibility: strip Anthropic beta headers
 		env[config.EnvClaudeCodeDisableExperimentalBetas] = "1"
 		env["API_TIMEOUT_MS"] = "3000000"

--- a/internal/cli/launcher.go
+++ b/internal/cli/launcher.go
@@ -291,16 +291,16 @@ func removeGLMEnv(settingsPath string) error {
 		if env, ok := m["env"].(map[string]any); ok {
 			// Restore backed-up OAuth token before removing GLM vars
 			if backup, bok := env["MOAI_BACKUP_AUTH_TOKEN"].(string); bok && backup != "" {
-				env["ANTHROPIC_AUTH_TOKEN"] = backup
+				env[config.EnvAnthropicAuthToken] = backup
 				delete(env, "MOAI_BACKUP_AUTH_TOKEN")
 			} else {
-				delete(env, "ANTHROPIC_AUTH_TOKEN")
+				delete(env, config.EnvAnthropicAuthToken)
 			}
-			delete(env, "ANTHROPIC_BASE_URL")
-			delete(env, "ANTHROPIC_DEFAULT_HAIKU_MODEL")
-			delete(env, "ANTHROPIC_DEFAULT_SONNET_MODEL")
-			delete(env, "ANTHROPIC_DEFAULT_OPUS_MODEL")
-			delete(env, "ANTHROPIC_DEFAULT_FABLE_MODEL")
+			delete(env, config.EnvAnthropicBaseURL)
+			delete(env, config.EnvAnthropicDefaultHaikuModel)
+			delete(env, config.EnvAnthropicDefaultSonnetModel)
+			delete(env, config.EnvAnthropicDefaultOpusModel)
+			delete(env, config.EnvAnthropicDefaultFableModel)
 			// Remove Z.AI proxy compatibility flags (set by moai glm/cg)
 			delete(env, config.EnvClaudeCodeDisableExperimentalBetas)
 			delete(env, "API_TIMEOUT_MS")

--- a/internal/cli/settings.go
+++ b/internal/cli/settings.go
@@ -180,15 +180,15 @@ func stripGLMCredsAndSetTeammateMode(m map[string]any) {
 	if env, ok := m["env"].(map[string]any); ok {
 		// Restore backed-up OAuth token before removing GLM vars.
 		if backup, bok := env["MOAI_BACKUP_AUTH_TOKEN"].(string); bok && backup != "" {
-			env["ANTHROPIC_AUTH_TOKEN"] = backup
+			env[config.EnvAnthropicAuthToken] = backup
 			delete(env, "MOAI_BACKUP_AUTH_TOKEN")
 		} else {
-			delete(env, "ANTHROPIC_AUTH_TOKEN")
+			delete(env, config.EnvAnthropicAuthToken)
 		}
-		delete(env, "ANTHROPIC_BASE_URL")
-		delete(env, "ANTHROPIC_DEFAULT_HAIKU_MODEL")
-		delete(env, "ANTHROPIC_DEFAULT_SONNET_MODEL")
-		delete(env, "ANTHROPIC_DEFAULT_OPUS_MODEL")
+		delete(env, config.EnvAnthropicBaseURL)
+		delete(env, config.EnvAnthropicDefaultHaikuModel)
+		delete(env, config.EnvAnthropicDefaultSonnetModel)
+		delete(env, config.EnvAnthropicDefaultOpusModel)
 		delete(env, config.EnvClaudeCodeDisableExperimentalBetas)
 		delete(env, "API_TIMEOUT_MS")
 		delete(env, config.EnvClaudeCodeDisableNonessentialTraffic)

--- a/internal/cli/worktree/tmux_integration.go
+++ b/internal/cli/worktree/tmux_integration.go
@@ -235,7 +235,7 @@ func BuildTmuxSessionConfig(projectName, specID, worktreePath, projectRoot strin
 					key := strings.TrimSpace(parts[0])
 					value := strings.TrimSpace(parts[1])
 					// Only include ANTHROPIC_* vars
-					if strings.HasPrefix(key, "ANTHROPIC_") {
+					if strings.HasPrefix(key, config.EnvAnthropicPrefix) {
 						cfg.GLMEnvVars[key] = value
 					}
 				}

--- a/internal/config/anthropic_env_ssot_test.go
+++ b/internal/config/anthropic_env_ssot_test.go
@@ -1,0 +1,165 @@
+package config
+
+// anthropic_env_ssot_test.go — SPEC-ENVKEY-ANTHROPIC-SSOT-001 (M2)
+//
+// Repo-root-scoped guard for the ANTHROPIC_* environment-variable name family.
+// It asserts that no bare ANTHROPIC_* string literal survives in production Go
+// source under internal/, pkg/, and cmd/ — every reference MUST go through the
+// EnvAnthropic* constants in envkeys.go (REQ-EAS-004/005/006/007/008).
+//
+// Two properties distinguish this guard from the pre-existing
+// TestNoBareGLMEnvVarLiteralsInCLIProduction in internal/cli:
+//
+//  1. Walk root is the REPOSITORY ROOT, not the package directory. The older
+//     guard walks os.Getwd(), which under `go test` is the package dir, making
+//     every file outside internal/cli structurally unreachable.
+//  2. The banned set is DERIVED from the envkeys.go constants rather than
+//     duplicated as bare literals, so adding a constant without adding it here
+//     is a visible omission. Consequently this file contains zero bare
+//     ANTHROPIC_* literals by design; set completeness is asserted at runtime
+//     by TestAnthropicBannedSetCoversAllNames below.
+//
+// Exclusions: _test.go files (hardcoding-allowed zone) and the SSOT definition
+// file internal/config/envkeys.go itself, which holds the constant definitions.
+// The envkeys.go exclusion is an EXACT PATH match, never a package- or
+// substring-scoped one: a broader exclusion would silently exempt the whole
+// internal/config package.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// bannedAnthropicEnvNames is derived from the envkeys.go constants, so a new
+// ANTHROPIC_* constant that is not added here is a visible omission rather than
+// a silent gap (REQ-EAS-008).
+var bannedAnthropicEnvNames = []string{
+	EnvAnthropicPrefix,
+	EnvAnthropicAPIKey,
+	EnvAnthropicAuthToken,
+	EnvAnthropicBaseURL,
+	EnvAnthropicDefaultFableModel,
+	EnvAnthropicDefaultHaikuModel,
+	EnvAnthropicDefaultOpusModel,
+	EnvAnthropicDefaultSonnetModel,
+	EnvAnthropicReasoningEffort,
+}
+
+// anthropicScanRoots are the three ENUMERATED production roots this guard
+// walks. They fail independently: a typo'd or omitted entry leaves that root
+// unscanned while the others still report clean.
+var anthropicScanRoots = []string{"internal", "pkg", "cmd"}
+
+// TestNoBareAnthropicEnvVarLiteralsInProduction walks internal/, pkg/, and cmd/
+// from the repository root and fails if any non-test production .go file
+// contains a bare ANTHROPIC_* string literal. Offenders are reported one per
+// line, each line carrying the offending file's repo-relative path.
+func TestNoBareAnthropicEnvVarLiteralsInProduction(t *testing.T) {
+	t.Parallel()
+
+	bannedSet := make(map[string]bool, len(bannedAnthropicEnvNames))
+	for _, b := range bannedAnthropicEnvNames {
+		bannedSet[b] = true
+	}
+
+	root := findProjectRoot(t)
+	// The single SSOT definition file, excluded by EXACT path.
+	ssotFile := filepath.Clean(filepath.Join(root, "internal", "config", "envkeys.go"))
+
+	var offenders []string
+	for _, scanRoot := range anthropicScanRoots {
+		base := filepath.Join(root, scanRoot)
+		if _, err := os.Stat(base); err != nil {
+			t.Fatalf("scan root %q not found under %s: %v", scanRoot, root, err)
+		}
+		_ = filepath.WalkDir(base, func(path string, d os.DirEntry, err error) error {
+			if err != nil || d.IsDir() {
+				return nil
+			}
+			if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			if filepath.Clean(path) == ssotFile {
+				return nil // the SSOT definition site itself
+			}
+			fset := token.NewFileSet()
+			node, perr := parser.ParseFile(fset, path, nil, parser.ParseComments)
+			if perr != nil {
+				return nil // skip unparseable files; not the concern of this test
+			}
+			ast.Inspect(node, func(n ast.Node) bool {
+				lit, ok := n.(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					return true
+				}
+				val := strings.Trim(lit.Value, `"`)
+				if !bannedSet[val] {
+					return true
+				}
+				pos := fset.Position(lit.Pos())
+				rel, rerr := filepath.Rel(root, pos.Filename)
+				if rerr != nil {
+					rel = pos.Filename
+				}
+				offenders = append(offenders,
+					filepath.ToSlash(rel)+":"+strconv.Itoa(pos.Line)+":"+strconv.Itoa(pos.Column)+": "+val)
+				return true
+			})
+			return nil
+		})
+	}
+
+	if len(offenders) > 0 {
+		sort.Strings(offenders)
+		t.Fatalf("bare ANTHROPIC_* env-var string literal(s) found in production source "+
+			"(must reference the config.EnvAnthropic* constants instead) — %d offender(s):\n  %s",
+			len(offenders), strings.Join(offenders, "\n  "))
+	}
+}
+
+// TestAnthropicBannedSetCoversAllNames asserts at runtime that the derived
+// banned set holds exactly the 9 ANTHROPIC_* names defined in envkeys.go
+// (REQ-EAS-008). It is a top-level test function — NOT a sub-test — because the
+// acceptance verdict selects it with a bare top-level -run pattern.
+//
+// This assertion is the only coverage for the three names with zero
+// out-of-internal/cli offenders, which no scan-based check can exercise.
+func TestAnthropicBannedSetCoversAllNames(t *testing.T) {
+	t.Parallel()
+
+	const wantLen = 9
+	if len(bannedAnthropicEnvNames) != wantLen {
+		t.Fatalf("banned set size = %d, want %d", len(bannedAnthropicEnvNames), wantLen)
+	}
+
+	got := make(map[string]bool, len(bannedAnthropicEnvNames))
+	for _, b := range bannedAnthropicEnvNames {
+		got[b] = true
+	}
+
+	for _, tc := range []struct {
+		name  string
+		value string
+	}{
+		{"EnvAnthropicPrefix", EnvAnthropicPrefix},
+		{"EnvAnthropicAPIKey", EnvAnthropicAPIKey},
+		{"EnvAnthropicAuthToken", EnvAnthropicAuthToken},
+		{"EnvAnthropicBaseURL", EnvAnthropicBaseURL},
+		{"EnvAnthropicDefaultFableModel", EnvAnthropicDefaultFableModel},
+		{"EnvAnthropicDefaultHaikuModel", EnvAnthropicDefaultHaikuModel},
+		{"EnvAnthropicDefaultOpusModel", EnvAnthropicDefaultOpusModel},
+		{"EnvAnthropicDefaultSonnetModel", EnvAnthropicDefaultSonnetModel},
+		{"EnvAnthropicReasoningEffort", EnvAnthropicReasoningEffort},
+	} {
+		if !got[tc.value] {
+			t.Errorf("banned set is missing %s (%q)", tc.name, tc.value)
+		}
+	}
+}

--- a/internal/config/envkeys.go
+++ b/internal/config/envkeys.go
@@ -171,8 +171,16 @@ const (
 	// EnvAnthropicAuthToken provides the Anthropic API authentication token.
 	EnvAnthropicAuthToken = "ANTHROPIC_AUTH_TOKEN"
 
+	// EnvAnthropicAPIKey provides the Anthropic API key. It is the API-key
+	// counterpart of EnvAnthropicAuthToken: both authenticate against the same
+	// API, but they are distinct variables with distinct client precedence.
+	EnvAnthropicAPIKey = "ANTHROPIC_API_KEY"
+
 	// EnvAnthropicDefaultHaikuModel overrides the default Haiku model ID.
 	EnvAnthropicDefaultHaikuModel = "ANTHROPIC_DEFAULT_HAIKU_MODEL"
+
+	// EnvAnthropicDefaultFableModel overrides the default Fable model ID.
+	EnvAnthropicDefaultFableModel = "ANTHROPIC_DEFAULT_FABLE_MODEL"
 
 	// EnvAnthropicDefaultSonnetModel overrides the default Sonnet model ID.
 	EnvAnthropicDefaultSonnetModel = "ANTHROPIC_DEFAULT_SONNET_MODEL"
@@ -188,4 +196,10 @@ const (
 	// requires the reasoning_effort field in the request body (making this env
 	// inert) is a run-phase empirical determination (AC-MTP-032b).
 	EnvAnthropicReasoningEffort = "ANTHROPIC_REASONING_EFFORT"
+
+	// EnvAnthropicPrefix is the namespace prefix shared by every ANTHROPIC_*
+	// environment variable. It is a prefix, NOT a variable name: it is intended
+	// for prefix matching (strings.HasPrefix) when filtering an environment map
+	// down to the Anthropic namespace, and must never be read with os.Getenv.
+	EnvAnthropicPrefix = "ANTHROPIC_"
 )

--- a/internal/hook/glm_tmux.go
+++ b/internal/hook/glm_tmux.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/modu-ai/moai-adk/internal/config"
 	"github.com/modu-ai/moai-adk/internal/tmux"
 )
 
@@ -18,11 +19,11 @@ import (
 // statusline reflects the real GLM model context window (128K/200K/etc.)
 // instead of the Claude slot's nominal size (1M for the Opus slot).
 var glmTmuxKeys = []string{
-	"ANTHROPIC_AUTH_TOKEN",
-	"ANTHROPIC_BASE_URL",
-	"ANTHROPIC_DEFAULT_OPUS_MODEL",
-	"ANTHROPIC_DEFAULT_SONNET_MODEL",
-	"ANTHROPIC_DEFAULT_HAIKU_MODEL",
+	config.EnvAnthropicAuthToken,
+	config.EnvAnthropicBaseURL,
+	config.EnvAnthropicDefaultOpusModel,
+	config.EnvAnthropicDefaultSonnetModel,
+	config.EnvAnthropicDefaultHaikuModel,
 	"CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS",
 	"API_TIMEOUT_MS",
 	"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC",
@@ -36,7 +37,7 @@ var glmTmuxKeys = []string{
 //   - Only keys listed in glmTmuxKeys are included in the result
 //   - Keys absent from settings are not included in the result
 func buildGLMTmuxEnvVars(env map[string]string) map[string]string {
-	if env["ANTHROPIC_AUTH_TOKEN"] == "" {
+	if env[config.EnvAnthropicAuthToken] == "" {
 		return nil
 	}
 
@@ -48,8 +49,8 @@ func buildGLMTmuxEnvVars(env map[string]string) map[string]string {
 	}
 
 	// Always include ANTHROPIC_AUTH_TOKEN if present
-	if token := env["ANTHROPIC_AUTH_TOKEN"]; token != "" {
-		result["ANTHROPIC_AUTH_TOKEN"] = token
+	if token := env[config.EnvAnthropicAuthToken]; token != "" {
+		result[config.EnvAnthropicAuthToken] = token
 	}
 
 	return result
@@ -126,7 +127,7 @@ func ensureTmuxGLMEnv(projectDir string) string {
 
 	// Pull out the credential, inject via source-file, and feed the
 	// remainder through the bulk argv path.
-	sensitiveKey := "ANTHROPIC_AUTH_TOKEN"
+	sensitiveKey := config.EnvAnthropicAuthToken
 	if token, ok := vars[sensitiveKey]; ok && token != "" {
 		if err := mgr.InjectSensitiveEnv(ctx, sensitiveKey, token); err != nil {
 			slog.Warn("ensureTmuxGLMEnv: sensitive token injection failed; aborting (no argv fallback)",

--- a/internal/hook/session_end.go
+++ b/internal/hook/session_end.go
@@ -611,11 +611,11 @@ func cleanupOrphanedTmuxSessions(ctx context.Context) {
 // unsetting the tmux var is always safe — it either removes a GLM key (correct)
 // or is a no-op when it was never set.
 var glmEnvVarsToClean = []string{
-	"ANTHROPIC_AUTH_TOKEN",
-	"ANTHROPIC_BASE_URL",
-	"ANTHROPIC_DEFAULT_OPUS_MODEL",
-	"ANTHROPIC_DEFAULT_SONNET_MODEL",
-	"ANTHROPIC_DEFAULT_HAIKU_MODEL",
+	config.EnvAnthropicAuthToken,
+	config.EnvAnthropicBaseURL,
+	config.EnvAnthropicDefaultOpusModel,
+	config.EnvAnthropicDefaultSonnetModel,
+	config.EnvAnthropicDefaultHaikuModel,
 }
 
 // clearTmuxSessionEnv removes GLM environment variables from tmux session.
@@ -704,23 +704,23 @@ func cleanupGLMSettingsLocal(projectDir string) {
 
 	// ANTHROPIC_BASE_URL is the GLM-active indicator.
 	// Claude Code's own OAuth flow never sets this variable.
-	if _, glmActive := env["ANTHROPIC_BASE_URL"]; !glmActive {
+	if _, glmActive := env[config.EnvAnthropicBaseURL]; !glmActive {
 		// Not in GLM mode — nothing to clean.
 		return
 	}
 
 	// Restore backed-up OAuth token if present; otherwise remove the GLM key.
 	if backup, ok := env["MOAI_BACKUP_AUTH_TOKEN"]; ok && backup != "" {
-		env["ANTHROPIC_AUTH_TOKEN"] = backup
+		env[config.EnvAnthropicAuthToken] = backup
 	} else {
-		delete(env, "ANTHROPIC_AUTH_TOKEN")
+		delete(env, config.EnvAnthropicAuthToken)
 	}
 
 	delete(env, "MOAI_BACKUP_AUTH_TOKEN")
-	delete(env, "ANTHROPIC_BASE_URL")
-	delete(env, "ANTHROPIC_DEFAULT_HAIKU_MODEL")
-	delete(env, "ANTHROPIC_DEFAULT_SONNET_MODEL")
-	delete(env, "ANTHROPIC_DEFAULT_OPUS_MODEL")
+	delete(env, config.EnvAnthropicBaseURL)
+	delete(env, config.EnvAnthropicDefaultHaikuModel)
+	delete(env, config.EnvAnthropicDefaultSonnetModel)
+	delete(env, config.EnvAnthropicDefaultOpusModel)
 
 	// Re-encode the cleaned env map back into the raw JSON document.
 	if len(env) == 0 {

--- a/internal/hook/session_start.go
+++ b/internal/hook/session_start.go
@@ -347,9 +347,9 @@ func ensureGLMCredentials(projectDir string) string {
 	// Check if GLM model overrides exist
 	hasGLMModel := false
 	for _, key := range []string{
-		"ANTHROPIC_DEFAULT_OPUS_MODEL",
-		"ANTHROPIC_DEFAULT_SONNET_MODEL",
-		"ANTHROPIC_DEFAULT_HAIKU_MODEL",
+		config.EnvAnthropicDefaultOpusModel,
+		config.EnvAnthropicDefaultSonnetModel,
+		config.EnvAnthropicDefaultHaikuModel,
 	} {
 		if val, ok := settings.Env[key]; ok && strings.Contains(strings.ToLower(val), "glm") {
 			hasGLMModel = true
@@ -362,7 +362,7 @@ func ensureGLMCredentials(projectDir string) string {
 	}
 
 	// GLM models configured — check if AUTH_TOKEN exists
-	if token := settings.Env["ANTHROPIC_AUTH_TOKEN"]; token != "" {
+	if token := settings.Env[config.EnvAnthropicAuthToken]; token != "" {
 		return "" // Already has credentials
 	}
 
@@ -377,9 +377,9 @@ func ensureGLMCredentials(projectDir string) string {
 	}
 
 	// Inject credentials
-	settings.Env["ANTHROPIC_AUTH_TOKEN"] = apiKey
-	if settings.Env["ANTHROPIC_BASE_URL"] == "" {
-		settings.Env["ANTHROPIC_BASE_URL"] = config.DefaultGLMBaseURL
+	settings.Env[config.EnvAnthropicAuthToken] = apiKey
+	if settings.Env[config.EnvAnthropicBaseURL] == "" {
+		settings.Env[config.EnvAnthropicBaseURL] = config.DefaultGLMBaseURL
 	}
 	// Ensure compatibility flags are set
 	if settings.Env["CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS"] == "" {
@@ -432,7 +432,7 @@ func maybeSet1MAutoCompactWindow(env map[string]string) {
 	if env[config.EnvClaudeCodeAutoCompactWindow] != "" {
 		return
 	}
-	if statusline.ResolveGLMContextWindow(env["ANTHROPIC_DEFAULT_OPUS_MODEL"]) >= config.Default1MContextTokens {
+	if statusline.ResolveGLMContextWindow(env[config.EnvAnthropicDefaultOpusModel]) >= config.Default1MContextTokens {
 		env[config.EnvClaudeCodeAutoCompactWindow] = strconv.Itoa(config.Default1MContextTokens)
 	}
 }

--- a/internal/sandbox/env.go
+++ b/internal/sandbox/env.go
@@ -3,6 +3,8 @@ package sandbox
 import (
 	"strings"
 	"sync"
+
+	"github.com/modu-ai/moai-adk/internal/config"
 )
 
 // @MX:ANCHOR: [AUTO] ScrubEnv is the single entry point for sandbox environment-variable scrubbing
@@ -29,7 +31,7 @@ func initAWSPrefix() {
 // security.yaml sandbox.env_scrub_extra (additive).
 var defaultDenyList = []string{
 	"GITHUB_TOKEN",
-	"ANTHROPIC_API_KEY",
+	config.EnvAnthropicAPIKey,
 	"OPENAI_API_KEY",
 	"NPM_TOKEN",
 	"GH_TOKEN",

--- a/internal/statusline/metrics.go
+++ b/internal/statusline/metrics.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/modu-ai/moai-adk/internal/config"
 )
 
 // CollectMetrics extracts session cost and model information from stdin data.
@@ -207,11 +209,11 @@ func resolveGLMModelName(displayName string) string {
 	var envKey string
 	switch {
 	case strings.Contains(lower, "opus"):
-		envKey = "ANTHROPIC_DEFAULT_OPUS_MODEL"
+		envKey = config.EnvAnthropicDefaultOpusModel
 	case strings.Contains(lower, "sonnet"):
-		envKey = "ANTHROPIC_DEFAULT_SONNET_MODEL"
+		envKey = config.EnvAnthropicDefaultSonnetModel
 	case strings.Contains(lower, "haiku"):
-		envKey = "ANTHROPIC_DEFAULT_HAIKU_MODEL"
+		envKey = config.EnvAnthropicDefaultHaikuModel
 	default:
 		// Not a known Claude display name — might be GLM model name passed directly.
 		// Strip [1m] for non-Claude models and return.

--- a/internal/tmux/cg_detect.go
+++ b/internal/tmux/cg_detect.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/modu-ai/moai-adk/internal/config"
 	"gopkg.in/yaml.v3"
 )
 
@@ -181,10 +182,10 @@ func sessionEnvHasGLM() bool {
 	if err != nil {
 		return false
 	}
-	if env["ANTHROPIC_AUTH_TOKEN"] != "" {
+	if env[config.EnvAnthropicAuthToken] != "" {
 		return true
 	}
-	if strings.Contains(env["ANTHROPIC_BASE_URL"], "z.ai") {
+	if strings.Contains(env[config.EnvAnthropicBaseURL], "z.ai") {
 		return true
 	}
 	return false
@@ -200,10 +201,10 @@ func sessionEnvHasGLM() bool {
 // process env (C-7 + AC-CGH-006 Scenario 6b). The NEW design-clean path above is
 // additive, not a replacement.
 func hasGLMEnv() bool {
-	if os.Getenv("ANTHROPIC_AUTH_TOKEN") != "" {
+	if os.Getenv(config.EnvAnthropicAuthToken) != "" {
 		return true
 	}
-	if strings.Contains(os.Getenv("ANTHROPIC_BASE_URL"), "z.ai") {
+	if strings.Contains(os.Getenv(config.EnvAnthropicBaseURL), "z.ai") {
 		return true
 	}
 	return false


### PR DESCRIPTION
## What

83 bare `"ANTHROPIC_*"` string literals across 10 production files now reference the `config.EnvAnthropic*` constants, and a repo-root-walking AST guard prevents them from coming back.

Three constants were missing and are added: `EnvAnthropicAPIKey`, `EnvAnthropicDefaultFableModel`, and `EnvAnthropicPrefix` (the last is a prefix used by `strings.HasPrefix`, not a variable name). `internal/config/envkeys.go` goes from 6 ANTHROPIC constants to 9.

## Why the existing guard was not enough

`TestNoBareGLMEnvVarLiteralsInCLIProduction` walks `os.Getwd()`, which under `go test` is the **package directory** `internal/cli`. It therefore could not see `internal/hook/` (29 occurrences), `internal/tmux/` (4), `internal/statusline/` (3), or `internal/sandbox/` (1) — **37 of the 83 occurrences were structurally unreachable**. Reusing that pattern verbatim would have produced a guard covering ~55% of the surface while looking green.

The new guard (`internal/config/anthropic_env_ssot_test.go`) walks from the repository root over `internal/`, `pkg/`, `cmd/`. It reuses the same-package `findProjectRoot(t)` helper rather than copying `internal/spec`'s `findRepoRoot`, which would have collided with the pre-existing `findRepoRoot` in `internal/config/token_budget_guard.go` and broken the whole package.

## How the guard is proven, not asserted

A green guard proves nothing on its own, so each property was falsified on demand:

- **Walk root reaches past `internal/cli`** — on first landing (M2) the guard went RED against the 83 pre-existing literals, 37 of them outside `internal/cli`.
- **Still bites once the tree is clean** — a literal planted in each of the three enumerated scan roots was detected and named: `internal/sandbox/env.go`, `cmd/moai/main.go`, `pkg/version/version.go`. One plant per root, because the roots are independent list elements — a `cmd/` probe proves nothing about `pkg/`.
- **Every banned name is live** — all 9 names planted in turn produced a non-zero guard exit, including the three (`ANTHROPIC_`, `ANTHROPIC_DEFAULT_FABLE_MODEL`, `ANTHROPIC_REASONING_EFFORT`) that have zero natural offenders and are therefore exercised by no other check.
- **The SSOT exclusion is narrow, not package-wide** — `internal/config/envkeys.go` is excluded by exact path; a literal planted in the sibling `internal/config/log.go` is still caught.

Every probe reverted with zero residual diff.

## Behaviour preservation

This is a mechanical name-indirection refactor; no runtime behaviour changes. Each replacement was verified value-identical by a forward round-trip from the base tree (all 10 files byte-identical after applying the mapping), because a wrong-but-compiling constant would pass both the guard and the literal count.

- `go build ./...` and `GOOS=windows GOARCH=amd64 go build ./...` — exit 0
- `go vet ./...` — exit 0
- `golangci-lint run` — `0 issues.`
- `go test ./...` — clean on two cache-disabled runs

One earlier full-suite run showed `internal/lsp/subprocess` and `internal/web` failing. Both pass in isolation, contain zero `ANTHROPIC` references, and hold zero files touched by this change; attributed to pre-existing load-sensitive flakiness and disclosed in `progress.md` rather than omitted.

`_test.go` files are an allowed-hardcoding zone and are deliberately untouched (291 occurrences, unchanged). `internal/template/templates/` is untouched.

## Process

Tier M · 11 REQ · 15 AC · 6 milestones. Three independent plan-auditor rounds before implementation: 0.72 FAIL → 0.86 → 0.87, all Must-Pass gates passing. Sync-phase (CHANGELOG + status transition) follows separately.

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centralized handling for Anthropic environment variable names across GLM setup, cleanup, credential injection, sandboxing, tmux, and status displays.
  * Added support for missing Anthropic API key, Fable model, and environment prefix constants.

* **Tests**
  * Added repository-wide validation to detect hard-coded Anthropic environment variable names and verify complete coverage.

* **Documentation**
  * Added specifications, acceptance criteria, implementation planning, and progress evidence for the environment-variable standardization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->