### PR TITLE
fix(handoff): make rendering the resume block a HARD obligation, add the MoAI-Easy banner

### DIFF
--- a/.claude/output-styles/moai/moai-easy.md
+++ b/.claude/output-styles/moai/moai-easy.md
@@ -181,7 +181,7 @@ If you ever go "wait, what does X mean?" — I'll stop right there, explain X in
 
 ## 7. Response Templates
 
-I lean on six simple banners. Think of them as little signposts, so you always know where we are in the four steps.
+I lean on seven simple banners. Think of them as little signposts, so you always know where we are in the four steps. Six of them mark a step; the seventh (Banner 7) only shows up when a session ends mid-journey.
 
 ### Localization Contract [HARD]
 
@@ -201,6 +201,7 @@ The banners below use English labels as **documentation only**. When I actually 
 | Banner 4 | `Quick Question` | `잠깐만요` | `ちょっと確認です` | `有个小问题` |
 | Banner 5 | `All Done` | `다 됐어요` | `完了しました` | `搞定啦` |
 | Banner 6 | `Oops` | `앗, 문제가 있어요` | `おっと、問題が起きました` | `哎呀，出了点问题` |
+| Banner 7 | `Picking Up Next Time` | `다음에 이어서` | `次回はここから` | `下次从这里继续` |
 | Goal label | `Goal:` | `목표:` | `目標:` | `目标:` |
 | Plan label | `Plan:` | `계획:` | `計画:` | `计划:` |
 | Now label | `Now:` | `지금:` | `現在:` | `现在:` |
@@ -287,6 +288,27 @@ Fix:
 ──────────────────────────────────────────────
 [→ "Want me to try A?"]
 ```
+
+### Banner 7 — Picking Up Next Time (Session Handoff)
+
+Use this when the session is ending mid-journey and the next session needs to pick up where we left off. The rules for **when** to emit one, and what goes inside the block, are not mine to invent — they live in `.claude/rules/moai/workflow/session-handoff.md` (the single source of truth for the 5 triggers, the 6-block skeleton, the cut-line markers, and the diet limits). This banner is only the wrapper I render it in.
+
+[HARD] The handoff is delivered by being **printed here, in the reply**. Saving it to a memory file and then telling you where it lives is not delivery — you would have nothing to paste. Both go together: save it *and* show it.
+
+```
+🧭 MoAI-Easy ★ Picking Up Next Time ──────────
+📌 [one sentence: what the next session continues]
+💾 [memory file path where this is also saved]
+
+✂──── [Copy from here] ────✂
+
+[the 6-block resume body, verbatim, per session-handoff.md]
+
+✂──── [Copy to here] ────✂
+──────────────────────────────────────────────
+```
+
+The `✂` scissors and the `─` box-drawing characters stay exactly as they are in every language; only the words between them translate (§7 Localization Contract). The three things I always include: the pasteable block, the memory file path, and the one-line "here's what's next".
 
 ### Progress Board — when there are many steps at once
 

--- a/.claude/rules/moai/workflow/session-handoff.md
+++ b/.claude/rules/moai/workflow/session-handoff.md
@@ -152,7 +152,17 @@ This ensures the message survives `/clear` and is discoverable at the start of t
 
 ## Output Surface (User-Facing)
 
-At session end, the orchestrator displays: (1) the main message in a fenced ```text``` block **bounded by cut-line markers** (per § Cut-line Marker Specification — marker text translated per `conversation_language`, `✂`/`─` symbols preserved verbatim) for verbatim paste, (2) the memory file path, (3) a one-sentence summary of what next session continues.
+[ZONE:Evolvable] [HARD] Emitting a resume message means **rendering it in the response body of the turn that generates it** — not storing it. At session end the orchestrator displays all three of: (1) the main message in a fenced ```text``` block **bounded by cut-line markers** (per § Cut-line Marker Specification — marker text translated per `conversation_language`, `✂`/`─` symbols preserved verbatim) for verbatim paste, (2) the memory file path, (3) a one-sentence summary of what next session continues.
+
+**reference-instead-of-render (named anti-pattern).** Writing the resume into the memory topic file (§ Auto-Memory Integration) and then merely *citing* that file path in the completion report is NOT emission. The memory write and the `moai handoff save` record are both persistence steps; neither reaches the user, so a report stating the resume "is saved in memory" while rendering no block leaves the user with nothing to paste. The hazard is structural rather than a lapse of attention: § Auto-Memory Integration is discharged by concrete tool calls whose results are visible, so the turn feels complete once they succeed — while the render, being ordinary response text, is the one step with no tool call to confirm it happened. Persistence without rendering is an unobserved completion claim under `.claude/rules/moai/core/verification-claim-integrity.md` §1.1 surface 1.
+
+**Render-surface dependency.** The per-persona banner template for this render lives in the active output style, and not every persona defines one. Where the active style carries no handoff banner, this obligation still binds unchanged — render the cut-line-bounded block from the § Canonical Format skeleton directly, styled to match that persona's other banners. A missing banner template is never a reason to skip the render.
+
+### Pre-emit self-check (emission surface) — 3 items
+
+- [ ] Is the cut-line-bounded block rendered in THIS response body — not only written to memory or persisted via the CLI?
+- [ ] Are all three surface items present: the block, the memory file path, and the one-sentence continuation summary?
+- [ ] Does the completion report avoid claiming the handoff was delivered when only the persistence steps ran?
 
 ## Anti-Patterns
 

--- a/internal/template/templates/.claude/output-styles/moai/moai-easy.md
+++ b/internal/template/templates/.claude/output-styles/moai/moai-easy.md
@@ -181,7 +181,7 @@ If you ever go "wait, what does X mean?" — I'll stop right there, explain X in
 
 ## 7. Response Templates
 
-I lean on six simple banners. Think of them as little signposts, so you always know where we are in the four steps.
+I lean on seven simple banners. Think of them as little signposts, so you always know where we are in the four steps. Six of them mark a step; the seventh (Banner 7) only shows up when a session ends mid-journey.
 
 ### Localization Contract [HARD]
 
@@ -201,6 +201,7 @@ The banners below use English labels as **documentation only**. When I actually 
 | Banner 4 | `Quick Question` | `잠깐만요` | `ちょっと確認です` | `有个小问题` |
 | Banner 5 | `All Done` | `다 됐어요` | `完了しました` | `搞定啦` |
 | Banner 6 | `Oops` | `앗, 문제가 있어요` | `おっと、問題が起きました` | `哎呀，出了点问题` |
+| Banner 7 | `Picking Up Next Time` | `다음에 이어서` | `次回はここから` | `下次从这里继续` |
 | Goal label | `Goal:` | `목표:` | `目標:` | `目标:` |
 | Plan label | `Plan:` | `계획:` | `計画:` | `计划:` |
 | Now label | `Now:` | `지금:` | `現在:` | `现在:` |
@@ -287,6 +288,27 @@ Fix:
 ──────────────────────────────────────────────
 [→ "Want me to try A?"]
 ```
+
+### Banner 7 — Picking Up Next Time (Session Handoff)
+
+Use this when the session is ending mid-journey and the next session needs to pick up where we left off. The rules for **when** to emit one, and what goes inside the block, are not mine to invent — they live in `.claude/rules/moai/workflow/session-handoff.md` (the single source of truth for the 5 triggers, the 6-block skeleton, the cut-line markers, and the diet limits). This banner is only the wrapper I render it in.
+
+[HARD] The handoff is delivered by being **printed here, in the reply**. Saving it to a memory file and then telling you where it lives is not delivery — you would have nothing to paste. Both go together: save it *and* show it.
+
+```
+🧭 MoAI-Easy ★ Picking Up Next Time ──────────
+📌 [one sentence: what the next session continues]
+💾 [memory file path where this is also saved]
+
+✂──── [Copy from here] ────✂
+
+[the 6-block resume body, verbatim, per session-handoff.md]
+
+✂──── [Copy to here] ────✂
+──────────────────────────────────────────────
+```
+
+The `✂` scissors and the `─` box-drawing characters stay exactly as they are in every language; only the words between them translate (§7 Localization Contract). The three things I always include: the pasteable block, the memory file path, and the one-line "here's what's next".
 
 ### Progress Board — when there are many steps at once
 

--- a/internal/template/templates/.claude/rules/moai/workflow/session-handoff.md
+++ b/internal/template/templates/.claude/rules/moai/workflow/session-handoff.md
@@ -152,7 +152,17 @@ This ensures the message survives `/clear` and is discoverable at the start of t
 
 ## Output Surface (User-Facing)
 
-At session end, the orchestrator displays: (1) the main message in a fenced ```text``` block **bounded by cut-line markers** (per § Cut-line Marker Specification — marker text translated per `conversation_language`, `✂`/`─` symbols preserved verbatim) for verbatim paste, (2) the memory file path, (3) a one-sentence summary of what next session continues.
+[ZONE:Evolvable] [HARD] Emitting a resume message means **rendering it in the response body of the turn that generates it** — not storing it. At session end the orchestrator displays all three of: (1) the main message in a fenced ```text``` block **bounded by cut-line markers** (per § Cut-line Marker Specification — marker text translated per `conversation_language`, `✂`/`─` symbols preserved verbatim) for verbatim paste, (2) the memory file path, (3) a one-sentence summary of what next session continues.
+
+**reference-instead-of-render (named anti-pattern).** Writing the resume into the memory topic file (§ Auto-Memory Integration) and then merely *citing* that file path in the completion report is NOT emission. The memory write and the `moai handoff save` record are both persistence steps; neither reaches the user, so a report stating the resume "is saved in memory" while rendering no block leaves the user with nothing to paste. The hazard is structural rather than a lapse of attention: § Auto-Memory Integration is discharged by concrete tool calls whose results are visible, so the turn feels complete once they succeed — while the render, being ordinary response text, is the one step with no tool call to confirm it happened. Persistence without rendering is an unobserved completion claim under `.claude/rules/moai/core/verification-claim-integrity.md` §1.1 surface 1.
+
+**Render-surface dependency.** The per-persona banner template for this render lives in the active output style, and not every persona defines one. Where the active style carries no handoff banner, this obligation still binds unchanged — render the cut-line-bounded block from the § Canonical Format skeleton directly, styled to match that persona's other banners. A missing banner template is never a reason to skip the render.
+
+### Pre-emit self-check (emission surface) — 3 items
+
+- [ ] Is the cut-line-bounded block rendered in THIS response body — not only written to memory or persisted via the CLI?
+- [ ] Are all three surface items present: the block, the memory file path, and the one-sentence continuation summary?
+- [ ] Does the completion report avoid claiming the handoff was delivered when only the persistence steps ran?
 
 ## Anti-Patterns
 


### PR DESCRIPTION
## Problem

A session handoff was persisted to auto-memory and to `.moai/state/handoff/pending.json`, and the completion report then cited the memory file path instead of printing the block. Nothing reached the user — there was nothing to paste.

## Root cause (three structural gaps, each verified against the tree)

| # | Gap | Evidence |
|---|-----|----------|
| 1 | `Output Surface` was the **only** obligation section in `session-handoff.md` with no `[ZONE:] [HARD]` marker | every sibling obligation (When To Generate, Emission-Time Save, Canonical Format, Auto-Memory Integration, Diet Constraints) carries one |
| 2 | The 9-item pre-emit self-check covers the **paste-ready budget** only | no item asks whether the block was rendered, so a never-emitted block passes all nine |
| 3 | The handoff banner template exists only in `moai.md` | `moai-easy.md` and `moai-learn.md` had zero handoff content — the active persona had no template to render |

Amplifier: `Auto-Memory Integration` is discharged by tool calls whose results are visible, so the turn feels complete once they succeed. The render is plain response text with no tool call to confirm it happened.

## Changes

- **`session-handoff.md` § Output Surface** — `[ZONE:Evolvable] [HARD]`; names the **reference-instead-of-render** anti-pattern; adds a render-surface dependency clause (the obligation binds even where the active style defines no banner); adds a dedicated **3-item emission-surface self-check**, kept separate from the budget checklist so the SSOT↔render-surface parity sentinel still holds.
- **`moai-easy.md`** — Banner 7 (session handoff) + its 4-locale row + banner-count prose.
- **Template mirrors** updated in the same commit, byte-identical (`session-handoff.md` is covered by the mirror-parity guard).

`moai-learn` is deliberately excluded: it writes no code and runs no SPEC phases, so the SPEC-shaped 6-block format does not fit it.

## Verification

```
TestRuleTemplateMirrorDrift        PASS  (session-handoff.md subtest included)
TestTemplateNeutralityAudit        PASS  (C1/C2/C4/C5/C6/C9)
TestTemplateNoInternalContentLeak  PASS
make build                         clean, catalog.yaml unchanged
cmp local vs template mirror       identical, both files
```

Held-in: the fixed rule was exercised in the same session — the handoff was rendered via the new Banner 7 rather than only stored. Held-out: the three guards above.

Docs-only change; no runtime behavior is affected.

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated session-handoff banner for sessions ending mid-journey.
  - Handoff responses now include a paste-ready resume block, memory file path, and continuation summary.
  - Added localized support for the new handoff banner.

- **Documentation**
  - Clarified that handoff details must be displayed directly in the response, rather than only saved or referenced.
  - Added validation guidance to ensure all required handoff elements are present, including cut-line markers and resume instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->