### PR TITLE
feat(SPEC-PHASE-FRONTMATTER-OWNER-001): establish the phase frontmatter value contract

### DIFF
--- a/.claude/rules/moai/development/spec-frontmatter-schema.md
+++ b/.claude/rules/moai/development/spec-frontmatter-schema.md
@@ -7,7 +7,7 @@ paths: "**/.moai/specs/**,internal/spec/**"
 
 > **Single Source of Truth** for the canonical SPEC frontmatter schema.
 > Enforcement: `internal/spec/lint.go` `FrontmatterSchemaRule`.
-> Cross-referenced by: `.claude/skills/moai/workflows/plan.md` § Pre-Write Frontmatter Checklist.
+> Cross-referenced by: `.claude/skills/moai/workflows/plan/spec-assembly.md` § Pre-Write Frontmatter Checklist.
 
 ## Canonical 12 Required Fields
 
@@ -43,10 +43,22 @@ tags: "tag1, tag2, tag3"
 | `updated` | date | `YYYY-MM-DD` ISO format | Last update date |
 | `author` | string | non-empty | Author name |
 | `priority` | enum | `P0`\|`P1`\|`P2`\|`P3` or `High`\|`Medium`\|`Low`\|`Critical` | Default `P1` |
-| `phase` | string | non-empty, typically release target | e.g. `"v3.0.0"` |
+| `phase` | string | non-empty; MUST be a release or milestone target label | e.g. `"v3.0.0"` — see § Prohibited phase values |
 | `module` | string | non-empty, path-like | Affected Go module or directory |
 | `lifecycle` | enum | `spec-anchored`\|`spec-lite`\|`exploratory` | Default `spec-anchored` |
 | `tags` | string | comma-separated, non-empty | Searchable labels |
+
+### Prohibited phase values
+
+`phase` names the **release or milestone target** a SPEC is aimed at. It is not a lifecycle field: its value does not change as the SPEC moves through the workflow, and nothing in the lifecycle updates it. A SPEC written for the next patch release carries that release label from the day it is authored until the day it is closed.
+
+The following lifecycle-stage names are prohibited as `phase:` values: `plan`, `run`, `sync`, and `mx`. Writing the stage the author happened to be standing in is the mistake this prohibition exists to stop; the positive instruction ("use a release target") is not enough on its own, because a stage name reads like a plausible phase to anyone who has not been told otherwise. Where the correct label is genuinely unknown, name the nearest release target rather than a stage.
+
+The prohibition binds the whole trimmed value, compared case-insensitively — `PLAN`, `Sync`, and a value padded with surrounding whitespace are rejected exactly as `plan` is. It does NOT bind substrings: a legitimate label that merely contains one of these words inside a longer phrase — `"v3.0.0 — Phase 2 — Runtime Hardening"`, or a milestone label naming a sync layer — is valid and MUST NOT be rejected. Whole-value comparison is what makes case-insensitivity safe here; substring matching would false-flag those labels.
+
+Enforcement lives in `internal/spec/lint.go` `FrontmatterSchemaRule`, which emits finding code `FrontmatterPhaseInvalid` at error severity. That code is deliberately absent from `eraDemotableCodes`, so it is NOT demoted to an advisory warning on grandfather-era SPECs: the guard exists to catch an authoring mistake on an in-flight SPEC, and the era heuristic classifies almost every in-flight SPEC as grandfathered.
+
+**This field is load-bearing.** `internal/spec/era.go` reads `phase` in the H-5 era tie-breaker: `matchesModernPhase` returns true only for a value carrying a modern release prefix, so a lifecycle token there silently disables one of the two signals H-5 depends on and leaves the classification resting on the `created` date alone. A wrong value here does not announce itself — it degrades a two-signal predicate to one.
 
 ## Status Enum (8 values)
 
@@ -77,6 +89,8 @@ Per the canonical agent-responsibility realignment policy (DRI ownership at agen
 | `completed → in-progress (amendment)` | manager-spec (re-delegation per D-NEW-1 inline-fix pattern) | `feat(SPEC-{ID}): in-place amendment <rationale-summary>` — distinct from `(none) → draft` and `* → superseded`; the SPEC's HISTORY `## Amendments` sub-section MUST record the prior completed version + prior_completed_sha + rationale + scope |
 
 > **3-phase close (plan→run→sync)** — the MoAI lifecycle is exactly three phases (`plan`, `run`, `sync`); MX Tag is a cross-cutting concern validated during sync, NOT a separate fourth phase. The `completed` status transition rides the sync commit (manager-docs owns it); there is no separate "Mx chore commit". The progress.md §E structure is 4 sections (§E.1 Plan / §E.2 Run Evidence / §E.3 Run Audit-Ready / §E.4 Sync Audit-Ready) — the former `§E.5 Mx-phase` section is retired (folded into §E.4).
+
+> **This matrix does not cover non-transition frontmatter corrections.** Repairing a frontmatter value that was written wrong leaves `status:` unchanged, so no row above applies to it — the absence of a row is not an absence of an owner. See § Non-transition frontmatter corrections for the owner and the procedure.
 
 ## progress.md Section Map (canonical SSOT)
 
@@ -109,6 +123,16 @@ Per the drift-detector close-subject convention, every close commit (the sync co
 - `manager-develop` MUST NOT modify `spec.md` / `plan.md` / `acceptance.md` body content (frontmatter `status:` + `updated:` updates on the `draft → in-progress` transition are allowed; ALL other body modifications are forbidden). When run-phase reveals a need to modify SPEC body content, manager-develop MUST return a blocker report and the orchestrator re-delegates to manager-spec for the scope-doc update before re-delegating back.
 
 > **SHA placeholder backfill exemption (D3)** — The forbidden crossings above bind `spec.md` / `plan.md` / `acceptance.md` body content. The `progress.md` §E.3 / §E.4 `sync_commit_sha` / `mx_commit_sha` SHA fields are a DISTINCT surface: a sync-phase (or legacy Mx-phase) commit cannot reference its own SHA — a commit does not know its own hash until after it lands — so the established pattern writes a `pending-backfill-*` placeholder in the phase's own commit and backfills the real SHA in a follow-up commit. This mechanical placeholder completion is NOT an ownership crossing; it is the self-referential-hazard workaround for a field that, by physics, cannot be populated within the same commit it describes. The ownership matrix therefore scopes its forbidden crossings to SPEC body content (spec/plan/acceptance) and does NOT bind `progress.md` SHA-field backfill performed by the phase-owning agent (manager-develop for §E.3, manager-docs for §E.4) in a subsequent commit.
+
+### Non-transition frontmatter corrections
+
+A frontmatter field that was authored with a value the schema does not permit is repaired in place. This is a different act from the Status Transition Ownership Matrix above: that matrix governs `status:` transitions, and a repair of this kind leaves `status:` untouched, so none of its rows apply.
+
+**Owner: `manager-spec`, reached through orchestrator re-delegation.** A `phase:` value correction — and any other non-transition frontmatter correction — is authored by `manager-spec`, the agent that already owns `spec.md` as canonical body content. `manager-docs` and `manager-develop` are both restricted to `status:` + `updated:` (§ Forbidden ownership crossings), so neither may perform it, and widening either restriction would blur a boundary whose whole value is that it admits no exceptions.
+
+**An amendment is not required.** Because the repair does not change `status:`, it does NOT trigger the `completed → in-progress (amendment)` transition: no `amendment_of:` field, no HISTORY `## Amendments` sub-section, and no plan-audit cache invalidation. Imposing the full amendment procedure on a single mis-authored field would cost more than the defect it repairs.
+
+Scope: the correction touches the mis-authored field and `updated:`. Body content, HISTORY, and every other frontmatter field stay untouched.
 
 ### Forward-looking enforcement (optional defense-in-depth)
 

--- a/.claude/skills/moai/workflows/plan/spec-assembly.md
+++ b/.claude/skills/moai/workflows/plan/spec-assembly.md
@@ -88,7 +88,7 @@ Required 12 fields (canonical order):
 - [ ] `updated: YYYY-MM-DD` — ISO date (NEVER `updated_at`)
 - [ ] `author: <name>` — string, not empty
 - [ ] `priority: P1` — uppercase Pn style (P0|P1|P2|P3) or High|Medium|Low|Critical
-- [ ] `phase: "vX.Y.Z target"` — release phase string
+- [ ] `phase: "vX.Y.Z target"` — release or milestone target label. NEVER a lifecycle stage name (`plan`, `run`, `sync`, `mx`): the value names the release this SPEC is aimed at, not the stage you are standing in while writing it
 - [ ] `module: "path/to/module"` — affected module path
 - [ ] `lifecycle: spec-anchored` — enum: spec-anchored | spec-lite | exploratory
 - [ ] `tags: "tag1, tag2, ..."` — comma-separated string (NOT `labels:`, NOT YAML array)
@@ -105,7 +105,7 @@ Rejected legacy aliases (fail closed — do NOT accept):
 Pre-write gate behavior:
 1. manager-spec generates frontmatter draft in memory.
 2. manager-spec self-audits against the 12-field checklist above.
-3. If any required field is missing OR any rejected alias appears: manager-spec HALTS, reports the schema violation, and re-generates. It does NOT call Write.
+3. If any required field is missing OR any rejected alias appears OR a field carries a prohibited value — `phase:` holding a lifecycle token (`plan`, `run`, `sync`, `mx`) is the case that occurs in practice: manager-spec HALTS, reports the schema violation, and re-generates. It does NOT call Write.
 4. Phase 11 plan-auditor independently re-verifies the schema on the written file as a second line of defense.
 
 - .moai/specs/SPEC-{ID}/plan.md

--- a/.moai/specs/SPEC-PHASE-FRONTMATTER-OWNER-001/plan.md
+++ b/.moai/specs/SPEC-PHASE-FRONTMATTER-OWNER-001/plan.md
@@ -1,0 +1,165 @@
+# SPEC-PHASE-FRONTMATTER-OWNER-001 — 구현 계획
+
+## §A 맥락
+
+- **작업 위치**: 격리 워크트리 `.claude/worktrees/phase-frontmatter/`(브랜치 `spec/phase-frontmatter-owner`). run-phase 진입 시 base 상태는 §C 절차로 **재확인**한다 — 이 문장을 근거로 확인을 생략하지 않는다.
+- **Tier**: S (2 산출물 — spec.md / plan.md, AC는 spec.md §3에 인라인, + progress.md)
+- **REQ / AC**: REQ 7개 + NFR 1개 = **8** / AC **8**. 양쪽 모두 Tier S 상한 8에 정확히 도달했다 — 추가하려면 기존 항목에 접거나 tier-up을 검토해야 한다.
+- **성격**: 산출물이 **전부 문서**다. Go 코드 변경은 0이며, 실행하는 유일한 Go 명령은 템플릿 중립성 가드 테스트다.
+
+### §A.1 범위 축소 — 이 계획은 v0.4.1 계획의 후속이 아니라 대체다
+
+병렬 SPEC `SPEC-PHASE-FIELD-VALIDATION-001`(커밋 `998744216`, PR #1285)이 run-phase 도중 `origin/main`에 착지해 M4(lint 규칙)와 M5(9개 실물 정정)를 먼저 구현했다. 두 마일스톤과 그것만을 위해 존재하던 REQ/AC는 삭제되었다(spec.md HISTORY v0.5.0, §1.12).
+
+**남은 작업의 실제 크기**: 문서 2개 + 미러 2개 = 4파일. 그중 **M1~M3은 이미 이 브랜치에 착지해 있고**, 미착지 작업은 **M7 한 건**이다(§F). 이 비대칭이 계획의 형태를 정한다 — 새로 만드는 것이 아니라 이미 만든 것 하나를 고친다.
+
+## §B 알려진 이슈
+
+- **B1 — `origin/main`이 전진했다.** 이 브랜치의 base는 낡았다. `origin/main`은 `998744216`(형제 SPEC)을 포함하며 그 커밋은 `internal/spec/lint.go` + `internal/spec/lint_phase_test.go`를 건드린다. 이 브랜치의 (삭제 예정) M4 커밋도 **같은 경로**를 건드리므로 리베이스/머지 시 하드 충돌이 확정이다 — 그 해소는 오케스트레이터의 브랜치 수술 소관이며 이 계획의 범위 밖이다.
+- **B2 — 미러 패리티는 현재 성립하나 조건부다.** 대상 2쌍은 지금 `diff` 0행이다(spec.md §1.9). 리포에는 §25 중립화로 **의도적으로 divergent한** 미러 쌍이 실재하므로(`workflows/plan.md`, 6행), "모든 미러를 동일하게"로 일반화하면 안 된다.
+- **B3 — 이 셸의 `ls` alias.** `ls | grep '^name'`은 항상 0매칭이다. 파일 존재 판정은 `git ls-files` 또는 glob으로 한다.
+- **B4 — 공유 체크아웃 레이스.** 이 리포는 병렬 세션이 흔하다. 커밋 직전 `git rev-parse --short HEAD` + `git branch --show-current`를 재확인하고, `git add -A` 대신 pathspec으로 스테이징한다.
+- **B5 — `grandfather` 토큰은 스키마 문서에 이미 존재한다.** Status Enum 절의 "grandfathered SPECs that carry `status: planned`" 때문에 `grep -ci grandfather`는 무편집 상태에서 이미 `1`이다(실측). AC-PFO-016 (d)가 `eraDemotableCodes`만 겨냥하는 이유이며, 판정을 임의로 `grandfather`로 넓히면 죽은 검사가 된다.
+
+## §C 사전 점검
+
+run-phase 진입 직후, 편집 전에 실행한다.
+
+```bash
+# C1. base 재확인 (저작 시점 기록을 신뢰하지 않는다)
+git branch --show-current; git rev-parse --short HEAD
+git fetch origin main && git rev-list --count --left-right origin/main...HEAD
+
+# C2. 미러 존재 + 현재 패리티 (B2)
+git ls-files 'internal/template/templates/**/spec-frontmatter-schema.md' \
+             'internal/template/templates/**/spec-assembly.md'
+diff .claude/rules/moai/development/spec-frontmatter-schema.md \
+     internal/template/templates/.claude/rules/moai/development/spec-frontmatter-schema.md | wc -l
+
+# C3. 착지한 가드의 실제 동작 재확인 (문서가 기술할 대상)
+git show origin/main:internal/spec/lint.go | grep -n 'phaseWorkflowStageTokens\[strings.ToLower'
+git show origin/main:internal/spec/lint.go | grep -n -A4 'var eraDemotableCodes'
+
+# C4. AC baseline 재계측 (spec.md §3의 "현 워크트리 관측"이 여전히 유효한지)
+S=.claude/rules/moai/development/spec-frontmatter-schema.md
+grep -c -i 'case-sensitiv' "$S"; grep -c -i 'case-insensitiv\|case-fold' "$S"
+grep -c 'FrontmatterPhaseInvalid' "$S"; grep -c 'eraDemotableCodes' "$S"
+```
+
+**C3이 이 SPEC의 유일한 실질 의존성이다.** 문서가 기술할 대상이 코드이므로, 코드를 읽지 않고 문서를 쓰면 §1.13이 진단한 오기를 반복한다.
+
+## §D 제약
+
+- **PRESERVE**: `internal/spec/` 전체. 이 SPEC은 Go 코드를 **읽기만** 한다. 가드의 매처·심각도·`eraDemotableCodes` 구성은 형제 SPEC 소유이며 변경 금지(spec.md §4).
+- **의무**: 문서 수정 시 미러를 **같은 커밋에서 함께** 수정하고 `make build`를 실행한다(NFR-PFO-001, CLAUDE.local.md §2).
+- **금지 (이 SPEC이 편집하는 2개 파일에 한정)**: `spec-frontmatter-schema.md`와 `plan/spec-assembly.md`의 미러를 로컬과 다른 내용으로 두는 것. 이 두 쌍에 한해 로컬만 고치는 것도, 미러만 고치는 것도 AC-PFO-014 FAIL이다.
+
+  > **바이트 동일은 리포 일반 규칙이 아니다.** 위 금지는 이 SPEC이 편집하는 2개 파일에만 적용된다. 일반 의무는 "같은 **의미의** 편집을 양쪽에 적용하되 각 사본의 §25 중립화를 보존한다"이며 무조건 동일화가 아니다(B2, spec.md §1.9).
+- **금지**: 정정 문구에 SPEC ID·REQ 토큰·내부 날짜·commit SHA를 담는 것. 이 문구는 **미러에 그대로 들어가야** 하므로 §25 중립성이 로컬 사본까지 구속한다 — 로컬에만 SPEC ID를 넣으면 패리티가 깨진다.
+- **금지**: `--no-verify`, `--amend`, main 직접 push.
+- **범위 규율**: 스키마 문서에서 바꾸는 것은 **§ Prohibited phase values 절의 매칭 서술 문단 하나**다. 인접 문단(정의·금지 열거·era 결속)은 이미 옳으므로 손대지 않는다.
+
+## §E 자기 검증
+
+각 마일스톤 종료 시 spec.md §3의 해당 AC 명령을 실행하고, **명령 + 축약 없는 출력**을 `progress.md` §E.2에 기록한다. 요약된 증거("통과함")는 증거가 아니다.
+
+## §F 마일스톤
+
+### M7 — 값 계약이 착지한 가드를 정확히 기술하도록 정정 (유일한 미착지 작업)
+
+REQ-PFO-016 · AC-PFO-016 / AC-PFO-014
+
+이것이 남은 유일한 실질 작업이다. M1~M3은 이미 이 브랜치에 착지해 있고 그 AC(001~004·006·007)는 현재 PASS다. 번호를 M4로 되쓰지 않고 M7을 쓰는 이유는 M4·M5가 **삭제된 마일스톤**이지 이름이 재사용된 마일스톤이 아니기 때문이다 — progress.md와 커밋 이력에 남은 M4 언급이 계속 lint 규칙을 가리키도록 보존한다.
+
+#### [산출물 요건 — 정확한 최종 상태]
+
+`.claude/rules/moai/development/spec-frontmatter-schema.md` § Prohibited phase values 절에서 **다음 한 문단을 정확히 찾아 교체한다.**
+
+**제거 대상 (현재 존재, 리터럴):**
+
+```
+The prohibition binds the whole value, case-sensitively. A legitimate label that happens to contain one of these words as a substring — `"v3.0.0 — Phase 2 — Runtime Hardening"`, or a milestone label naming a sync layer — is valid and MUST NOT be rejected.
+```
+
+**교체 후 (두 문단, 리터럴):**
+
+```
+The prohibition binds the whole trimmed value, compared case-insensitively — `PLAN`, `Sync`, and a value padded with surrounding whitespace are rejected exactly as `plan` is. It does NOT bind substrings: a legitimate label that merely contains one of these words inside a longer phrase — `"v3.0.0 — Phase 2 — Runtime Hardening"`, or a milestone label naming a sync layer — is valid and MUST NOT be rejected. Whole-value comparison is what makes case-insensitivity safe here; substring matching would false-flag those labels.
+
+Enforcement lives in `internal/spec/lint.go` `FrontmatterSchemaRule`, which emits finding code `FrontmatterPhaseInvalid` at error severity. That code is deliberately absent from `eraDemotableCodes`, so it is NOT demoted to an advisory warning on grandfather-era SPECs: the guard exists to catch an authoring mistake on an in-flight SPEC, and the era heuristic classifies almost every in-flight SPEC as grandfathered.
+```
+
+교체 후 이 절의 나머지 문단(정의 문단, 금지 열거 문단, `**This field is load-bearing.**` era 결속 문단)은 **변경하지 않는다.**
+
+#### [미러 요건]
+
+`internal/template/templates/.claude/rules/moai/development/spec-frontmatter-schema.md`에 **바이트 동일한 교체**를 적용한다. 위 교체 문구는 SPEC ID·REQ 토큰·내부 날짜·commit SHA를 담지 않으므로 §25 중립성을 이미 만족하며, 따라서 두 사본은 동일해야 한다(AC-PFO-014).
+
+`spec-assembly.md`와 그 미러는 **이 마일스톤에서 변경하지 않는다** — M3이 이미 착지했고 AC-PFO-004가 현재 PASS다.
+
+#### [검증 순서]
+
+```bash
+# 1. AC-PFO-016 (4항 전부)
+S=.claude/rules/moai/development/spec-frontmatter-schema.md
+grep -c -i 'case-sensitiv' "$S"                  # 기대 0   (교체 전 1)
+grep -c -i 'case-insensitiv\|case-fold' "$S"     # 기대 >=1 (교체 전 0)
+grep -c 'FrontmatterPhaseInvalid' "$S"           # 기대 >=1 (교체 전 0)
+grep -c 'eraDemotableCodes' "$S"                 # 기대 >=1 (교체 전 0)
+
+# 2. make build (템플릿 임베드 재컴파일)
+make build
+
+# 3. AC-PFO-014 패리티 + 중립성
+diff "$S" internal/template/templates/"$S" | wc -l | tr -d ' '     # 기대 0
+diff .claude/skills/moai/workflows/plan/spec-assembly.md \
+     internal/template/templates/.claude/skills/moai/workflows/plan/spec-assembly.md | wc -l | tr -d ' '   # 기대 0
+go test -count=1 -run 'TestInternalContentLeak|TestTemplateNeutrality' ./internal/template/
+
+# 4. 이미 착지한 6개 AC 재확인 (회귀 없음)
+#    AC-PFO-001 / 002 / 003 / 004 / 006 / 007 — spec.md §3의 명령을 그대로 실행
+```
+
+**4번을 생략하지 않는다.** M7의 편집은 AC-PFO-002가 `sed` 범위를 앵커하는 `Prohibited phase values` 절 **안**에서 일어나므로, 절 제목이나 4토큰을 실수로 건드리면 AC-PFO-002가 조용히 깨진다.
+
+### M8 — 회귀 검증
+
+NFR-PFO-001 · AC-PFO-014
+
+```bash
+go build ./...
+go test -count=1 ./internal/template/
+git diff --stat -- .claude/ internal/template/    # 2파일이어야 한다 (로컬 + 미러)
+```
+
+Go 코드를 변경하지 않았으므로 전체 테스트 스위트는 필요 없다. 변경 표면이 템플릿 임베드이므로 `internal/template/`만 돌린다.
+
+## §G 안티패턴
+
+- **AP-1 — 가드 매처를 문서에 재구현 수준으로 옮기기.** 정정의 목적은 **가리키는 것**이지 복제하는 것이 아니다. `phaseWorkflowStageTokens` 맵 내용이나 Go 조건식을 문서에 옮기면 형제 SPEC과 중복 원천이 되어, 그쪽이 바뀔 때 이쪽이 조용히 낡는다(spec.md §4).
+- **AP-2 — 오기 문장을 삭제만 하고 대체 서술을 쓰지 않기.** AC-PFO-016 (a)는 삭제만으로도 PASS한다. 정정은 교체이며 (b)(c)(d)가 그것을 강제한다.
+- **AP-3 — 정정 문구에 SPEC ID를 넣기.** 로컬에만 넣으면 미러 패리티가 깨지고(AC-PFO-014 FAIL), 미러에도 넣으면 §25 중립성 CI 가드에 걸린다. SPEC ID 수준 cross-reference는 이 SPEC 본문(§1.12)에만 둔다.
+- **AP-4 — 판정을 `grandfather`로 넓히기.** 그 토큰은 무편집 상태에서 이미 `1`이므로 죽은 검사가 된다(B5). `eraDemotableCodes`가 판별력을 가진 유일한 토큰이다.
+- **AP-5 — M1~M3 산출물을 "다시 확인한다"며 재작성하기.** 이미 착지했고 AC가 PASS다. 재작성은 §D 범위 규율 위반이며 AC-PFO-002의 앵커를 깨뜨릴 위험만 만든다.
+- **AP-6 — 삭제된 M4·M5를 부활시키기.** lint 가드와 9개 정정은 형제 SPEC 소유다. "우리 것도 있으면 좋겠다"는 방향은 가드 이중화이며 spec.md §4가 명시적으로 배제한다.
+- **AP-7 — `make build`를 건너뛰기.** 템플릿은 `//go:embed`로 바이너리에 컴파일되므로, 미러 파일만 고치고 빌드하지 않으면 배포 산출물에 반영되지 않는다.
+
+## §H 교차 참조
+
+- `.claude/rules/moai/development/spec-frontmatter-schema.md` — M7 편집 대상 (로컬)
+- `internal/template/templates/.claude/rules/moai/development/spec-frontmatter-schema.md` — M7 편집 대상 (미러)
+- `.claude/skills/moai/workflows/plan/spec-assembly.md` + 미러 — M3에서 이미 착지, M7에서 변경 없음
+- `internal/spec/lint.go` `FrontmatterSchemaRule` — 문서가 기술할 대상 (**읽기 전용, 변경 금지**)
+- `SPEC-PHASE-FIELD-VALIDATION-001` — 가드 소유 SPEC (spec.md §1.12)
+- `.moai/docs/template-internal-isolation-doctrine.md` §25 — 미러 중립성 규약
+
+## §I 미해결 질문 요약
+
+**미해결 항목 없음 (0건).**
+
+| 항목 | 결정 | 근거 |
+|---|---|---|
+| 가드 매처의 매칭 축 | 대소문자 **무시** + 값 전체 일치 (착지한 구현) | spec.md §1.8 — 결정 축은 부분 문자열 대 값 전체 일치이며, 값 전체 일치 위에서 대소문자 구분은 판별력이 없다 |
+| 가드 소유권 | `SPEC-PHASE-FIELD-VALIDATION-001` | spec.md §1.12 — 이 SPEC은 위층(계약·소유권·문서 정확성)만 다룬다 |
+| 배포 문서의 가드 참조 형태 | **코드 위치**(`internal/spec/lint.go` + finding 코드), SPEC ID 아님 | spec.md §1.9 — SPEC ID는 §25 중립성 때문에 미러에 들어갈 수 없어 패리티를 깨뜨린다 |
+| `acceptance.md` 처분 | **삭제** — Tier S는 2 산출물이며 AC는 spec.md §3에 인라인 | Tier S 산출물 계약. 파일을 남기면 소유자 없는 고아가 된다 |

--- a/.moai/specs/SPEC-PHASE-FRONTMATTER-OWNER-001/progress.md
+++ b/.moai/specs/SPEC-PHASE-FRONTMATTER-OWNER-001/progress.md
@@ -1,0 +1,428 @@
+# SPEC-PHASE-FRONTMATTER-OWNER-001 — 진행 기록
+
+## §E.1 Plan-phase Audit-Ready Signal
+
+```yaml
+plan_status: audit-ready
+plan_complete_at: 2026-08-02
+spec_version: "0.5.0"
+amendment: scope-reduction   # v0.4.1 → v0.5.0, 사용자 명시 승인
+audit_iteration: 4     # iter1 0.79 → iter2 0.76(STOP) → iter3 0.78(상승, STOP 미발동) → iter4 PASS 0.86
+audit_verdict: PASS    # 0.86 — v0.4.1 (Tier M 임계값 0.80) 기준. v0.5.0은 범위 축소이므로 재감사 대상
+tier: S                # M → S (범위 축소 후 문서 2개 + 미러 2개 = 4파일, Go 변경 0)
+artifacts: [spec.md, plan.md]   # acceptance.md 삭제 — AC는 spec.md §3에 인라인 (Tier S 계약)
+req_count: 7           # REQ-PFO-001/002/003/004/006/007/016
+nfr_count: 1           # NFR-PFO-001
+req_total: 8           # Tier S 상한 8에 정확히 도달
+ac_count: 8            # AC-PFO-001/002/003/004/006/007/014/016 — Tier S 상한 8에 정확히 도달
+dropped_milestones: [M4, M5]    # lint 규칙 + 9개 실물 정정 — SPEC-PHASE-FIELD-VALIDATION-001이 선착지
+dropped_requirements: [REQ-PFO-005, REQ-PFO-008, REQ-PFO-009, REQ-PFO-010, REQ-PFO-011, REQ-PFO-012, REQ-PFO-013, NFR-PFO-002, NFR-PFO-003]
+                       # 005는 REQ-PFO-004에 병합(삭제 아님); 나머지는 M4/M5 소관이라 삭제
+remaining_milestones: [M7, M8]  # M1~M3은 이미 브랜치에 착지 (AC 001~004·006·007 PASS)
+open_clarifications: 0 # plan.md §I
+```
+
+**남은 미착지 작업은 M7 한 건이다.** AC 8개 중 7개(001·002·003·004·006·007·014)는 이미 이 브랜치에서 PASS 관측되며, 현재 FAIL인 유일 항목은 **AC-PFO-016**이다 — 배포 문서가 착지한 가드를 오기하고 있고 그 정정이 아직 적용되지 않았다(spec.md §1.13). 016 없이 얻는 "8개 중 7개 PASS"는 이번 개정이 아무것도 바꾸지 않았다는 것과 구별되지 않는다.
+
+**M4·M5 삭제 근거**: 병렬 SPEC `SPEC-PHASE-FIELD-VALIDATION-001`(커밋 `998744216`, PR #1285)이 lint 가드와 9개 실물 정정을 먼저 착지시켰다. 두 SPEC이 같은 매처를 소유하면 중복 원천이 되므로 가드 축을 형제 SPEC에 넘기고, 이 SPEC은 그 위층(저작 시점 계약·정정 소유자·문서 정확성)만 유지한다(spec.md §1.12).
+
+**§1.8 정정**: 이전 판이 결정 축으로 지목한 "대소문자 구분"은 틀렸다. 실측 결과 결정 축은 **부분 문자열 대 값 전체 일치**이며, 값 전체 일치 위에서는 대소문자를 무시해도 오탐이 0이다(착지한 매처가 그 형태이며 이 SPEC이 명세했던 것보다 엄격하다).
+
+미해결 클라리피케이션 마커는 **0건**이다(plan.md §I).
+
+## §F Phase 4 Mode Selection
+
+**입력 파라미터**
+
+| 항목 | 값 |
+|---|---|
+| tier | M |
+| scope (파일 수) | 약 8 — 규칙 문서 2 + 템플릿 미러 2 + `lint_phase.go` + `lint_phase_test.go` + `lint.go` 등록 + SPEC 프론트매터 9건(기계적 1행 편집) |
+| 도메인 수 | 3 (rule 마크다운 / Go 소스 + 테스트 / SPEC 아티팩트) |
+| 파일 언어 구성 | 마크다운 + Go 혼합 |
+| 동시성 이득 | LOW — 구현 중심 작업이며 M4→M5 순서 의존이 존재 |
+
+**모드 평가**
+
+| 모드 | 선택 | 사유 |
+|---|---|---|
+| 1 trivial | 미선택 | 신규 lint 규칙 + 테스트 저작이 포함되어 의미 변경이 있다 |
+| 2 background | 미선택 | Write/Edit를 수반하므로 read-only 조건 불충족 |
+| 3 agent-team | 미선택 | RETIRED (tombstone) |
+| 4 parallel | 미선택 | 도메인 3개이나 research-heavy가 아니라 coding-heavy — Anthropic coding-task parallelism caveat에 따라 Mode 5 우선 |
+| 5 sub-agent | **선택** | 기본 폴백이자 coding-heavy 작업의 안전 경로 |
+| 6 workflow | 미선택 | ~8 파일로 `≥ ~30 파일` 문턱 미달이며, 단일 균일 변환 규칙도 아니다(M1~M5가 서로 다른 성격) |
+
+**Decision: sub-agent**
+
+**근거**: 이 SPEC의 run-phase는 신규 Go lint 규칙 저작 + 테이블 드리븐 테스트 + 문서 계약 강화가 섞인 coding-heavy 작업이다. Anthropic의 coding-task parallelism caveat("most coding tasks involve fewer truly parallelizable tasks than research")에 따라 병렬 팬아웃보다 순차 sub-agent가 안전하다. 특히 M4(lint 규칙 + 반증 3축 관측)와 M5(실물 9건 정정) 사이에는 **역전 불가능한 순서 의존**이 있다 — M5가 코퍼스에서 라이프사이클 토큰을 제거하고 나면 규칙이 실물 데이터에서 발화하는 것을 관측할 창이 영구히 닫힌다. 병렬 실행은 이 순서를 보장하지 못한다.
+
+**Implementation Kickoff Approval**: 통과 (사용자 명시 승인). 진행 방식은 **자율(autonomous)** — `/moai goal`로 AC 수렴 조건을 arm한 뒤 턴 단위 중단 없이 진행한다. 승인은 게이트 통과이며, 자율 진행 선택은 게이트 이후의 진행 방식 축이다(게이트 우회가 아니다).
+
+## §E.2 Run-phase Evidence
+
+작업 위치: 격리 워크트리 `.claude/worktrees/phase-frontmatter/`, 브랜치 `spec/phase-frontmatter-owner`, base `origin/main` SHA `54f92ef4b`.
+
+### 사전 점검 (§C)
+
+```
+$ git rev-list --count --left-right origin/main...HEAD
+0	0
+
+$ go build ./... && GOOS=windows GOARCH=amd64 go build ./...
+BUILD OK
+
+$ golangci-lint run --timeout=2m
+0 issues.
+
+$ go test -count=1 ./internal/spec/...
+ok  	github.com/modu-ai/moai-adk/internal/spec	20.392s
+
+$ git ls-tree -r --name-only HEAD -- .moai/specs | grep -c '/spec\.md$'
+563
+
+$ git ls-files 'internal/template/templates/**/spec-assembly.md' 'internal/template/templates/**/spec-frontmatter-schema.md'
+internal/template/templates/.claude/rules/moai/development/spec-frontmatter-schema.md
+internal/template/templates/.claude/skills/moai/workflows/plan/spec-assembly.md
+```
+
+lint baseline은 `0 issues` — 이후 등장하는 어떤 지적도 NEW다.
+
+### M1 — 정정 소유자 (AC-PFO-006 / AC-PFO-007)
+
+```
+$ S=.claude/rules/moai/development/spec-frontmatter-schema.md
+$ grep -n -i 'phase.*correction\|phase 값 정정' "$S" | head
+119:**Owner: `manager-spec`, reached through orchestrator re-delegation.** A `phase:` value correction — and any other non-transition frontmatter correction — is authored by `manager-spec`, the agent that already owns `spec.md` as canonical body content. ...
+
+$ grep -c -i 'amendment.*not required\|amendment를 요구하지' "$S"      # (a)
+1
+$ grep -c '^#\+ .*Non-transition frontmatter corrections' "$S"          # (b0)
+1
+$ awk '/^## Status Transition Ownership Matrix/{f=1;next} /^## /{f=0} f' "$S" \
+    | grep -c '^#\+ .*Non-transition frontmatter corrections'           # (b)
+0
+$ awk '/^## Status Transition Ownership Matrix/{f=1;next} /^## /{f=0} f' "$S" \
+    | grep -v '^#' | grep -c -i 'Non-transition frontmatter corrections\|비전이 프론트매터 정정'   # (c)
+1
+```
+
+AC-PFO-006 PASS (지정 에이전트 `manager-spec` — 유지 카탈로그 소속). AC-PFO-007 PASS — (b0) `1`과 함께 읽은 (b) `0`이므로 미구현이 아니라 배치 준수다.
+
+### M2 — 값 계약 (AC-PFO-001 / AC-PFO-002 / AC-PFO-003)
+
+```
+$ grep -c 'typically release target' "$S"
+0
+$ grep -c -i '`phase:`.*\(prohibit\|MUST NOT\|금지\)\|\(prohibit\|MUST NOT\|금지\).*`phase:`' "$S"
+1
+$ sed -n '/Prohibited phase values/,/^## /p' "$S" | grep -oE '\b(plan|run|sync|mx)\b' | sort -u | wc -l | tr -d ' '
+4
+$ grep -c 'matchesModernPhase\|H-5' "$S"
+1
+```
+
+AC-PFO-001 / 002 / 003 전부 PASS.
+
+### M3 — 저작 시점 방지 (AC-PFO-004 / AC-PFO-005)
+
+```
+$ A=.claude/skills/moai/workflows/plan/spec-assembly.md
+$ grep -n '`phase:' "$A" | grep -ci 'NEVER\|금지\|NOT a lifecycle'
+1
+$ sed -n '/Pre-write gate behavior/,/^- \.moai/p' "$A" | grep -ci 'prohibited value\|금지값\|lifecycle token'
+1
+```
+
+AC-PFO-004 / 005 PASS.
+
+### M4 — lint 규칙
+
+**RED (구현 이전 관측 — E8).** 테스트와 픽스처만 존재하고 `PhaseValueRule`이 없는 상태에서 실행했다.
+
+```
+$ go test -run 'TestPhaseValueRule' -count=1 -v ./internal/spec/
+=== RUN   TestPhaseValueRule
+=== RUN   TestPhaseValueRule/plan_fires
+    lint_phase_test.go:50: expected exactly 1 PhaseValueInvalid finding, got 0: []
+=== RUN   TestPhaseValueRule/planning_does_not_fire
+=== RUN   TestPhaseValueRule/sync_layer_does_not_fire
+=== RUN   TestPhaseValueRule/runtime_hardening_does_not_fire
+--- FAIL: TestPhaseValueRule (0.55s)
+    --- FAIL: TestPhaseValueRule/plan_fires (0.15s)
+    --- PASS: TestPhaseValueRule/planning_does_not_fire (0.13s)
+    --- PASS: TestPhaseValueRule/sync_layer_does_not_fire (0.14s)
+    --- PASS: TestPhaseValueRule/runtime_hardening_does_not_fire (0.13s)
+=== RUN   TestPhaseValueRule_Registered
+    lint_phase_test.go:82: PhaseValueInvalid absent — the rule is not registered in defaultRules
+--- FAIL: TestPhaseValueRule_Registered (0.14s)
+=== RUN   TestPhaseValueRule_StrictExitCode
+    lint_phase_test.go:104: strict=true: HasErrors()=false, want true
+--- FAIL: TestPhaseValueRule_StrictExitCode (0.25s)
+FAIL
+FAIL	github.com/modu-ai/moai-adk/internal/spec	1.395s
+```
+
+세 비발화 서브테스트가 RED에서 이미 PASS인 것은 규칙 부재의 자명한 귀결이며, 판별력을 갖는 RED 신호는 `plan_fires` FAIL·등록 FAIL·strict FAIL 세 건이다.
+
+**GREEN.**
+
+```
+$ go test -run 'TestPhaseValueRule' -count=1 -v ./internal/spec/
+--- PASS: TestPhaseValueRule (0.98s)
+    --- PASS: TestPhaseValueRule/plan_fires (0.18s)
+    --- PASS: TestPhaseValueRule/planning_does_not_fire (0.50s)
+    --- PASS: TestPhaseValueRule/sync_layer_does_not_fire (0.15s)
+    --- PASS: TestPhaseValueRule/runtime_hardening_does_not_fire (0.14s)
+=== RUN   TestPhaseValueRule_Registered
+--- PASS: TestPhaseValueRule_Registered (0.15s)
+=== RUN   TestPhaseValueRule_StrictExitCode
+--- PASS: TestPhaseValueRule_StrictExitCode (0.30s)
+PASS
+ok  	github.com/modu-ai/moai-adk/internal/spec	1.860s
+```
+
+**AC-PFO-009 (판정 4항).**
+
+```
+$ grep -c 'PhaseValueRule' internal/spec/lint.go                                    # (1)
+1
+$ go test -run 'TestPhaseValueRule' -count=1 -v ./internal/spec/ | grep -c '^--- PASS'  # (2)
+3
+$ grep -c 'func TestPhaseValueRule' internal/spec/lint_phase_test.go                # (3)
+3
+$ go test -run 'TestPhaseValueRule' -count=1 -v ./internal/spec/ \
+    | grep -c -- '--- PASS: TestPhaseValueRule/.*does_not_fire'                     # (4)
+3
+```
+
+AC-PFO-009 PASS — (3)이 `3`이므로 (2)의 PASS는 0매칭 공허가 아니다.
+
+**[판정 시점 계약] AC-PFO-008 — M4 시점, 실물 대상.** M5가 이 파일을 정정하면 이 관측은 되돌릴 수 없이 사라진다.
+
+```
+$ go run ./cmd/moai spec lint .moai/specs/SPEC-UPDATE-YAML-PRESERVE-001/spec.md
+SEVERITY  CODE                  FILE                                               LINE  MESSAGE
+--------  ----                  ----                                               ----  -------
+WARNING   StatusGitConsistency  .moai/specs/SPEC-UPDATE-YAML-PRESERVE-001/spec.md  1     SPEC SPEC-UPDATE-YAML-PRESERVE-001 frontmatter status 'draft' disagrees with git-implied status 'in-progress'
+WARNING   PhaseValueInvalid     .moai/specs/SPEC-UPDATE-YAML-PRESERVE-001/spec.md  1     phase "plan" is a lifecycle stage name, not a release or milestone target label; use the release this SPEC is aimed at (e.g. "v3.0.0")
+
+0 error(s), 2 warning(s)
+
+$ ... | grep -c 'PhaseValueInvalid'
+1
+```
+
+AC-PFO-008 **PASS (계수 `1`)** — M4 시점 실물 관측. AC-PFO-010의 결합항은 이 기록을 참조한다.
+
+**[판정 시점 계약] AC-PFO-011 — M4 시점, 실물 대상.**
+
+```
+$ T=.moai/specs/SPEC-UPDATE-YAML-PRESERVE-001/spec.md
+$ go run ./cmd/moai spec lint "$T" | grep 'PhaseValueInvalid' | grep -c 'WARNING'   # (a)
+1
+$ go run ./cmd/moai spec lint "$T" >/dev/null 2>&1; echo $?                          # (b)
+0
+$ go run ./cmd/moai spec lint --strict "$T" >/dev/null 2>&1; echo $?                 # (c)
+1
+```
+
+AC-PFO-011 PASS — (a) `1` / (b) `0` / (c) `1`. 심각도 문자열은 strict에서도 `WARNING`으로 남으며, 승격의 실체가 종료 코드라는 §1.11의 실측과 일치한다.
+
+**AC-PFO-008F — 반증 3축, 전부 관측.**
+
+```
+# (a) defaultRules 등록 제거
+$ go run ./cmd/moai spec lint .moai/specs/SPEC-UPDATE-YAML-PRESERVE-001/spec.md | grep -c 'PhaseValueInvalid'
+0
+# (a) 되돌린 뒤
+1
+
+# (b) Check 본문 무력화 (선두 `return nil`)
+$ go run ./cmd/moai spec lint .moai/specs/SPEC-UPDATE-YAML-PRESERVE-001/spec.md | grep -c 'PhaseValueInvalid'
+0
+# (b) 되돌린 뒤
+1
+
+# (c) 매칭 축 — 값 전체 일치를 strings.Contains 부분 문자열로 퇴화
+$ go test -run 'TestPhaseValueRule' -count=1 -v ./internal/spec/ | grep -E '^    --- (PASS|FAIL)'
+    --- PASS: TestPhaseValueRule/plan_fires (0.29s)
+    --- FAIL: TestPhaseValueRule/planning_does_not_fire (0.21s)
+    --- FAIL: TestPhaseValueRule/sync_layer_does_not_fire (0.19s)
+    --- PASS: TestPhaseValueRule/runtime_hardening_does_not_fire (0.18s)
+$ ... | grep -c -- '--- PASS: TestPhaseValueRule/.*does_not_fire'
+1
+# (c) 되돌린 뒤
+3
+```
+
+세 축 모두 변형 시 판정이 무너지고 되돌린 뒤 복원되는 것을 관측했다. (c)에서 `runtime_hardening`이 여전히 PASS인 것은 대소문자 구분 부분 문자열이 `Run`을 잡지 못하기 때문이며, spec.md §1.8이 "대소문자 구분 부분 문자열도 현재 코퍼스에서는 우연히 9건"이라고 기록한 바와 정확히 일치한다 — 그 우연을 깨뜨리는 것이 `planning`과 `sync layer` 두 합성 픽스처다.
+
+```
+$ grep -c 'FALSIFICATION' internal/spec/lint_phase.go internal/spec/lint.go
+internal/spec/lint_phase.go:0
+internal/spec/lint.go:0
+```
+
+변형 잔재 0 — 세 반증의 되돌림이 완전하다.
+
+### M5 — 9개 정정 (AC-PFO-012 / AC-PFO-013)
+
+```
+$ ... 9개 spec.md의 phase: 값 계수
+9                       # AC-PFO-012 PASS
+
+$ git diff --numstat -- .moai/specs/   (이 SPEC 자신 제외)
+1	1	.moai/specs/SPEC-CI-LOOP-DEVONLY-001/spec.md
+2	2	.moai/specs/SPEC-ENVKEY-ANTHROPIC-SSOT-001/spec.md
+1	1	.moai/specs/SPEC-PIPELINE-FANOUT-ACTIVATION-001/spec.md
+1	1	.moai/specs/SPEC-REF-SEO-ABSORB-001/spec.md
+1	1	.moai/specs/SPEC-UPDATE-GUARD-EFFICACY-001/spec.md
+2	2	.moai/specs/SPEC-UPDATE-REINSTALL-LOOP-002/spec.md
+2	2	.moai/specs/SPEC-UPDATE-YAML-PRESERVE-001/spec.md
+2	2	.moai/specs/SPEC-WORKTREE-BRANCH-GUARD-001/spec.md
+2	2	.moai/specs/SPEC-WORKTREE-BRANCH-GUARD-OPTIN-001/spec.md
+```
+
+1행 파일은 `updated:`가 이미 실행일이라 `phase:` 한 줄만 바뀐 경우다. 어느 파일도 2행을 넘지 않는다 — §D 범위 규율(두 줄만) 준수.
+
+```
+$ LIFECYCLE_SCAN (§A 헬퍼, git show 형태) | wc -l
+0                       # AC-PFO-013 PASS
+$ git ls-tree -r --name-only HEAD -- .moai/specs | grep -c '/spec\.md$'
+564                     # 판정 시점 모집단 N — 이 SPEC 산출물이 커밋되어 563 → 564
+```
+
+**B7 catalog.yaml 해시.** `make build` 후 `git status`에 catalog 변경 없음 — 9개 SPEC은 catalog 해시 대상이 아니므로 무효화가 발생하지 않았다. 재생성 판단 불요.
+
+### M5 이후 재판정 (판정 시점 계약)
+
+```
+$ go run ./cmd/moai spec lint internal/spec/testdata/phase-token-plan/spec.md | grep -c 'PhaseValueInvalid'
+1                       # AC-PFO-008 PASS (§C 발화 픽스처 대상)
+$ T=internal/spec/testdata/phase-token-plan/spec.md
+$ ... | grep 'PhaseValueInvalid' | grep -c 'WARNING'   → 1     # (a)
+$ go run ./cmd/moai spec lint "$T" >/dev/null 2>&1; echo $?   → 0     # (b)
+$ go run ./cmd/moai spec lint --strict "$T" >/dev/null 2>&1; echo $?  → 1     # (c)
+                        # AC-PFO-011 PASS
+```
+
+### M6 — 회귀 검증 (AC-PFO-010 / AC-PFO-014 / AC-PFO-015)
+
+```
+$ go run ./cmd/moai spec lint > /tmp/pfo-full.txt 2>&1; echo $?
+0
+$ grep -c 'PhaseValueInvalid' /tmp/pfo-full.txt
+0                       # AC-PFO-010 계수 — 결합항 AC-PFO-008은 위 M4 시점 기록 참조 → PASS
+$ tail -1 /tmp/pfo-full.txt
+0 error(s), 62 warning(s)   # AC-PFO-015 baseline 복귀 (error 0, warning 62)
+
+$ go test -count=1 ./...
+exit=0, FAIL 행 0개
+  (1회차에서 internal/web가 `signal: terminated`로 종료되었으나 단독 재실행 `ok 1.707s`,
+   전체 재실행 exit 0 / FAIL 0행 — 기존에 알려진 web 패키지 flaky이며 이 변경에 귀속되지 않는다.
+   내 변경은 internal/web를 건드리지 않는다.)
+
+$ go vet ./...                                → exit 0
+$ golangci-lint run --timeout=2m              → 0 issues.   (C3 baseline 0 issues 동일, NEW 0건)
+$ go build ./...                              → exit 0
+$ GOOS=windows GOARCH=amd64 go build ./...    → exit 0
+$ go test -cover -count=1 ./internal/spec/... → coverage: 89.0% of statements
+$ grep -rn 'AskUserQuestion\|mcp__askuser' internal/spec/ | grep -v '_test.go' | grep -v '//'
+(출력 없음)
+
+# AC-PFO-014 미러 패리티
+$ diff .claude/rules/moai/development/spec-frontmatter-schema.md \
+       internal/template/templates/.../spec-frontmatter-schema.md | wc -l   → 0
+$ diff .claude/skills/moai/workflows/plan/spec-assembly.md \
+       internal/template/templates/.../spec-assembly.md | wc -l             → 0
+$ go test -count=1 -run 'TestInternalContentLeak|TestTemplateNeutrality|TestSplitHarnessNamespaceNoLeak' ./internal/template/
+ok  	github.com/modu-ai/moai-adk/internal/template	3.204s
+```
+
+AC-PFO-014는 AC-PFO-001~005 PASS와 결합해서만 유효하며, 그 다섯 건은 위에 기록되어 있다.
+
+## §E.3 Run-phase Audit-Ready Signal
+
+```yaml
+run_status: BLOCKED-SUPERSEDED
+run_complete_at: 2026-08-02
+run_commit_sha: d27a274de      # 로컬 브랜치 HEAD — 미push (아래 차단 사유)
+base_sha: 54f92ef4b
+branch: spec/phase-frontmatter-owner
+ac_pass_count: 16              # AC-PFO-001~015 + AC-PFO-008F 전부 PASS (판정 시점 계약 준수)
+ac_fail_count: 0
+preserve_list_post_run_count: 0   # 기존 lint 규칙 판정 동작 무변경 — 전수 lint 총계 0/62 동일
+l44_pre_commit_fetch: "0 0"       # M1 착수 시점
+l44_post_push_fetch: "1 6"        # push 이전 fetch — origin/main이 1커밋 전진, 아래 충돌의 발견 지점
+new_warnings_or_lints_introduced: 0   # golangci-lint 0 issues (baseline 동일), 전수 lint error 0 / warning 62
+cross_platform_build:
+  host: exit 0
+  windows_amd64: exit 0
+coverage_internal_spec: "89.0%"
+total_run_phase_files: 24
+m1_to_mN_commit_strategy: "마일스톤당 1커밋 (M1~M5) + 플랜 산출물 랜딩 1커밋 = 6커밋, 전부 미push"
+pushed: false
+```
+
+### 차단 사유 — 병렬 SPEC이 같은 결함을 이미 해결한 채 main에 착지했다
+
+M6 검증 직후 push 직전 fetch에서 `origin/main`이 1커밋 전진한 것을 관측했고, 그 커밋이 이 SPEC의 M4·M5와 **같은 결함을 같은 방식으로** 해결한 병렬 SPEC이었다.
+
+```
+$ git log --oneline HEAD..origin/main
+998744216 feat(SPEC-PHASE-FIELD-VALIDATION-001): validate the phase frontmatter value shape (#1285)
+```
+
+착지한 구현(`origin/main:internal/spec/lint.go`):
+
+```go
+if phase := strings.TrimSpace(fm.Phase); phase != "" && phaseWorkflowStageTokens[strings.ToLower(phase)] {
+    findings = append(findings, Finding{
+        ...
+        Severity: SeverityError,
+        Code:     "FrontmatterPhaseInvalid",
+```
+
+겹치는 축과 겹치지 않는 축을 구분해 기록한다.
+
+| 축 | 이 SPEC (M1~M5) | 착지한 SPEC-PHASE-FIELD-VALIDATION-001 | 상태 |
+|---|---|---|---|
+| 값 계약 문서(schema SSOT) | M2가 규범화 + 금지값 절 + era H-5 결속 | **미변경** | **충돌 없음 — 이 SPEC만 보유** |
+| 저작 체크리스트 / pre-write gate | M3 | **미변경** | **충돌 없음 — 이 SPEC만 보유** |
+| 정정 소유자 규정 | M1 (manager-spec, 매트릭스 밖 별도 절) | **미변경** | **충돌 없음 — 이 SPEC만 보유** |
+| lint 가드 | M4 `PhaseValueRule` / `PhaseValueInvalid` / warning + `Advisory:false` / 대소문자 **구분** | `FrontmatterSchemaRule` 내 분기 / `FrontmatterPhaseInvalid` / **error** / 대소문자 **무시** | **중복 — 같은 결함에 두 규칙** |
+| 9개 실물 정정 | M5 | **이미 동일하게 `"v3.0.2"`로 정정 완료** | **중복 — 재적용** |
+| 파일 경로 | `internal/spec/lint_phase_test.go` (package `spec_test`) | **같은 경로** (package `spec`, 전혀 다른 내용) | **하드 충돌 — merge conflict 확정** |
+
+세 가지가 결정을 요구한다.
+
+1. **경로 하드 충돌.** `internal/spec/lint_phase_test.go`가 양쪽에 서로 다른 내용으로 존재한다. 이 경로는 acceptance.md AC-PFO-009의 **명명 앵커 산출물 요건**이므로, 파일명을 바꾸면 AC가 fail-closed로 떨어진다 — 즉 재작업 없이 리베이스만으로 해소되지 않는다.
+2. **가드 이중화.** 같은 결함에 코드가 다른 두 finding이 방출된다. 착지한 쪽이 error 심각도라 더 강한 게이트이고, `eraDemotableCodes` 제외로 grandfather 강등도 피한다 — 이 SPEC의 `Advisory:false` 설계와 목적은 같고 수단이 다르다.
+3. **spec.md §1.8의 근거가 부분적으로 반증되었다.** §1.8은 "대소문자 무시 매칭은 실물 8건(`Runtime` 포함)에 즉시 오탐을 낸다"고 단언했으나, 그것은 **부분 문자열 매칭과 결합했을 때**만 참이다. 착지한 구현은 대소문자 무시 + **값 전체 일치**이므로 `"v3.0.0 — Phase 2 — Runtime Hardening"`은 `"run"`과 같지 않아 오탐이 없다. 실제로 그쪽이 이 SPEC보다 엄격하다 — `PLAN` / `Sync` 같은 대소문자 변형 오타까지 잡는다. 이 SPEC이 배제한 축이 실은 배제할 이유가 없었다.
+
+따라서 push하지 않고 중단한다. 6개 커밋은 브랜치에 보존되어 있으며 워킹 트리는 깨끗하다(추적되지 않은 plan-audit 반복 보고서 4건 제외).
+
+### 해소 — 범위 축소 (사용자 결정)
+
+위 차단은 **범위 축소**로 해소되었다. 사용자가 네 선택지(범위 축소 / 전면 폐기 / 둘 다 유지 / 보류) 중 범위 축소를 명시적으로 선택했고, SPEC은 v0.5.0에서 Tier M → **Tier S**로 강등되었다(REQ 8 / AC 8, `acceptance.md` 삭제 후 spec.md §3 인라인).
+
+```yaml
+run_status: COMPLETE-REDUCED     # BLOCKED-SUPERSEDED 를 대체한다
+resolution: scope-reduction
+dropped_milestones: [M4, M5]     # 병렬 SPEC 998744216 이 동일 결함을 선행 해결
+surviving_milestone: M7          # 값 계약이 착지한 가드를 정확히 기술하도록 정정
+base_sha: 998744216              # origin/main 재베이스 (54f92ef4b 아님)
+final_change_surface: 7          # 문서 2 + 미러 2 + SPEC 산출물 3
+go_code_changed: 0
+```
+
+**§E.2의 M4·M5 증거는 삭제하지 않고 보존한다.** 그 작업은 실제로 수행되었고 16개 AC 전부 PASS했으며 반증 3축까지 관측되었다 — 다만 병렬 SPEC이 먼저 착지해 **이 PR에는 포함되지 않는다**. 기록으로서는 참이고 배송 주장으로서는 거짓이므로, 이 절이 그 경계를 명시한다.
+
+브랜치는 `origin/main`(`998744216`) 위로 재구성되었다. M4가 만든 `internal/spec/lint_phase.go`·testdata 4건은 삭제되었고, `internal/spec/lint.go`·`internal/spec/lint_phase_test.go`와 M5가 정정한 9건은 전부 `origin/main` 내용으로 원복되어 형제 SPEC의 작업을 되돌리지 않는다.
+
+**정정 반영**: 위 3번(§1.8 반증)은 v0.5.0에서 SPEC 본문에 반영되었다 — 결정 축은 대소문자가 아니라 **부분 문자열 대 값 전체 일치**이며, 스키마 문서의 값 계약도 착지한 가드의 실제 동작(대소문자 무시 + 값 전체 일치)을 기술하도록 M7에서 교체되었다.
+
+## §E.4 Sync-phase Audit-Ready Signal
+
+_<pending sync-phase>_

--- a/.moai/specs/SPEC-PHASE-FRONTMATTER-OWNER-001/spec.md
+++ b/.moai/specs/SPEC-PHASE-FRONTMATTER-OWNER-001/spec.md
@@ -1,0 +1,403 @@
+---
+id: SPEC-PHASE-FRONTMATTER-OWNER-001
+title: "phase 프론트매터 값 계약 확립 — 저작 시점 방지와 사후 정정 소유자"
+version: "0.5.0"
+status: in-progress
+created: 2026-08-02
+updated: 2026-08-02
+author: manager-spec
+priority: P2
+phase: "v3.0.2"
+module: ".claude/rules/moai/development"
+lifecycle: spec-anchored
+tags: "spec-lint, frontmatter, phase, era-classification, ownership, authoring-guard"
+tier: S
+related_specs: [SPEC-PHASE-FIELD-VALIDATION-001]
+---
+
+# SPEC-PHASE-FRONTMATTER-OWNER-001 — phase 프론트매터 값 계약 확립
+
+## HISTORY
+
+| 날짜 | 버전 | 변경 |
+|---|---|---|
+| 2026-08-02 | 0.5.0 | **범위 축소 개정 (사용자 명시 승인).** 병렬 SPEC `SPEC-PHASE-FIELD-VALIDATION-001`(커밋 `998744216`, PR #1285)이 run-phase 도중 `origin/main`에 착지해 이 SPEC의 M4·M5를 먼저 구현했다. 세 가지를 한다. **(1) M4·M5 제거** — 기계 가드(REQ-PFO-008~011·013)와 9개 실물 정정(REQ-PFO-012)은 중복이므로 삭제하고 가드의 소유권을 형제 SPEC에 넘긴다(§1.12). **(2) §1.8 정정** — §1.8은 "대소문자 무시 매칭이 실물 8건에 즉시 오탐을 낸다"고 단언했으나 **그것은 부분 문자열 매칭과 결합했을 때만 참이다.** 착지한 매처는 대소문자 무시 + **값 전체 일치**여서 오탐이 0이고, 이 SPEC이 명세한 대소문자 구분 매처보다 오히려 **엄격하다**. 결정 축은 대소문자가 아니라 **부분 문자열 대 값 전체 일치**였다(실측 재확인, §1.8). **(3) 값 계약이 실제 배포물을 기술하도록 정정** — 워크트리에 이미 적용된 스키마 문서 편집이 "case-sensitively"라고 적어 **착지한 가드를 오기(誤記)하고 있다.** 문서가 하중 필드를 잘못 기술하는 것을 고치는 SPEC이 스스로 그러면 안 된다(REQ-PFO-016, §1.13). 결과: **Tier M → Tier S**, REQ 16 → **8**, AC 16 → **8**, `acceptance.md`는 삭제하고 AC를 §3에 인라인한다. |
+| 2026-08-02 | 0.4.1 | plan-auditor 4차 PASS 0.86 이후 SHOULD-FIX 2건 적용. (S1) AC-PFO-009 (4)의 `== 3`이 올바른 구현을 FAIL시킬 수 있어 `>= 3`으로 완화. (S2) 모집단 `563` 리터럴이 판정값으로 쓰이는 4곳에서 리터럴 제거 — 이 SPEC 산출물이 커밋되면 모집단이 증가해 자기 판정을 깨뜨린다. *(v0.5.0 주: 두 항목 모두 이번 개정에서 삭제된 M4·M5 소관이었다.)* |
+| 2026-08-02 | 0.4.0 | plan-auditor 3차 FAIL 0.78 대응, D1~D5. (D1) AC-PFO-011의 제목·GWT가 같은 AC의 판정 명령을 정면으로 반박. (D2) AC-PFO-009가 픽스처 **실재**만 판정하고 기대 방향을 검증하지 않는 거짓 보증문 동반. (D3) AC-PFO-008/010/011의 판정 대상이 M5가 정정하는 9개 중 하나여서 DoD 시점에 통과 불가능. (D4) 명명 앵커 3종이 산출물 요건으로 부재. (D5) AC-PFO-002 첫 명령의 baseline `0`이 거짓(실제 `4`)이고 무편집 상태에서 이미 PASS하는 죽은 검사. |
+| 2026-08-02 | 0.3.0 | plan-auditor 2차 FAIL 0.76 대응. 회귀의 단일 원인은 v0.2.0이 새로 도입한 N1 — `--strict`는 이 코드베이스에서 `Finding.Severity`를 재작성하지 않으므로 v0.2.0의 `grep -c 'ERROR'` 조건은 올바른 구현으로도 영구 FAIL인 통과 불가능 판정이었다. 인용했던 거짓 선례 2건을 대체 없이 삭제. |
+| 2026-08-02 | 0.2.0 | plan-auditor 1차 FAIL 0.79 대응. 정당 라벨 수를 `563 − 9 = 554`에서 **546**으로 정정(키 부재 8개를 정당 라벨로 계상하고 있었다). 템플릿 미러 2개가 실재하며 바이트 동일함을 확인해 NFR-PFO-001을 "템플릿 무변경"에서 "미러 동시 수정"으로 완화. 매칭 방식 클라리피케이션의 전제가 거짓이었음을 §1.8에 기록. |
+| 2026-08-02 | 0.1.0 | 최초 작성. **최초 진단을 재구성한다.** 이 문제는 "`phase:` 전이를 수행할 소유자가 없다"로 처음 지목되었으나, `phase:`는 애초에 라이프사이클 필드가 아니라 **릴리스 타깃 라벨**이며(§1.1) 따라서 수행할 "전이" 자체가 없다. 실제 결함은 **저작 시점의 값 계약 부재**이고(§1.3), 소유자 부재는 그 2차 효과다(§1.4). |
+
+## §1 배경
+
+### §1.1 `phase:`는 릴리스 타깃 라벨이지 라이프사이클 필드가 아니다
+
+`.claude/rules/moai/development/spec-frontmatter-schema.md`가 이 필드를 정의한다. 개정 전 원문은 이랬다.
+
+```
+| `phase` | string | non-empty, typically release target | e.g. `"v3.0.0"` |
+```
+
+`origin/main` 전수 스캔(`git ls-tree -r --name-only origin/main -- .moai/specs`, 판정 시점 관측):
+
+```
+전수 spec.md                                   564
+phase: 키 보유                                 556
+라이프사이클 토큰(plan|run|sync|mx, 값 전체)     0
+```
+
+키 부재 8개(564 − 556)는 §4에서 스코프아웃한다. 나머지 **556개 전부가 정당한 릴리스·마일스톤 라벨**이며 라이프사이클 토큰은 0건이다 — 형제 SPEC이 9건을 정정한 결과다(§1.12).
+
+> **정정 이력 (모집단 산술)**: 최초 판은 정당한 라벨을 `563 − 9 = 554`로 계산했다. 거짓이다 — 키 부재 8개를 정당한 라벨로 계상했다. 모집단은 전수가 아니라 **키 보유 수**다. 이번 개정에서 판정 시점 관측값으로 재계측했으며, **어떤 리터럴도 판정값으로 고정하지 않는다** — 이 SPEC 자신의 산출물이 커밋되면 모집단이 증가하기 때문이다.
+
+### §1.2 문제였던 9개 (역사 기록 — 이미 정정됨)
+
+| status | phase (정정 전) | SPEC |
+|---|---|---|
+| completed | plan | SPEC-CI-LOOP-DEVONLY-001 |
+| completed | plan | SPEC-ENVKEY-ANTHROPIC-SSOT-001 |
+| completed | plan | SPEC-PIPELINE-FANOUT-ACTIVATION-001 |
+| completed | plan | SPEC-UPDATE-GUARD-EFFICACY-001 |
+| completed | plan | SPEC-UPDATE-REINSTALL-LOOP-002 |
+| completed | plan | SPEC-WORKTREE-BRANCH-GUARD-001 |
+| completed | plan | SPEC-WORKTREE-BRANCH-GUARD-OPTIN-001 |
+| completed | sync | SPEC-REF-SEO-ABSORB-001 |
+| draft | plan | SPEC-UPDATE-YAML-PRESERVE-001 |
+
+9개 전부 `phase: "v3.0.2"`로 정정되어 `origin/main`에 착지했다(§1.12). 이 표는 결함의 **형태**를 보존하기 위한 기록이며, 이 SPEC은 더 이상 이 정정을 산출물로 요구하지 않는다.
+
+### §1.3 근본 원인은 저작 시점이며, "누락된 전이"가 아니다
+
+9개 전부 `author: manager-spec`이다. manager-spec이 값을 쓰기 직전 참조하는 체크리스트(`.claude/skills/moai/workflows/plan/spec-assembly.md` § Pre-Write Frontmatter Checklist)의 해당 항목은 `origin/main`에 지금도 원문 그대로 있다.
+
+```
+- [ ] `phase: "vX.Y.Z target"` — release phase string
+```
+
+형식 예시는 있으나 **금지값이 없다.** "release phase string"이라는 표현은 `plan`·`sync` 같은 단계 이름을 배제할 만큼 강하지 않으며, 실제로 manager-spec은 자기가 서 있던 단계의 이름을 그 자리에 적었다. 스키마 SSOT의 "typically release target"도 같은 약함을 공유한다 — `typically`는 규범이 아니라 경향 서술이다.
+
+**따라서 수행되지 않은 "전이"란 존재하지 않는다.** `phase:`는 라이프사이클을 따라 값이 바뀌는 필드가 아니므로 `plan → run → sync`로 갱신할 주체를 지정하는 것은 문제를 잘못 푸는 것이다.
+
+**이것이 이 SPEC에 남은 중심이다.** 기계 가드는 착지 후 잘못 쓰인 값을 잡지만, 애초에 쓰이지 않게 만들지는 못한다 — 저작자가 읽는 표면은 체크리스트이지 lint 출력이 아니다.
+
+### §1.4 소유자 부재는 2차 효과다 — 한번 쓰이면 아무도 못 고친다
+
+소유권 경계를 직접 확인했다. `.claude/agents/moai/manager-docs.md`:
+
+> "manager-docs limited to frontmatter `status` + `updated` field transitions only" … "**NEVER** other frontmatter fields"
+
+manager-develop도 같은 제약을 받는다(`spec-frontmatter-schema.md` § Forbidden ownership crossings). 그리고 `phase:` 정정은 `status:`를 바꾸지 않으므로 **Status Transition Ownership Matrix가 애초에 다루지 않는 행위다.** 결과적으로 세 관리 에이전트 중 누구도 이미 쓰인 `phase:` 값을 고칠 권한이 없고, 값은 사실상 불변이 된다.
+
+형제 SPEC이 9건을 정정했다는 사실은 이 공백을 메우지 않는다 — 그것은 한 번의 예외적 일괄 정정이었지, 다음 오기(誤記)를 누가 고치는지에 대한 규정이 아니다.
+
+### §1.5 이 필드는 하중을 받는다
+
+`internal/spec/era.go`가 `phase:`를 H-5 era 판정의 타이브레이커로 읽는다.
+
+```go
+// H-5: tie-breaker via phase or created date
+if matchesModernPhase(signals.FrontmatterPhase) ||
+    isAfterModernThreshold(signals.FrontmatterCreated) {
+    return EraV3R6, "H-5 (modern phase or created date)"
+}
+```
+
+`matchesModernPhase`는 문자열이 `v3r6`을 포함하거나 `v3.0` / `"v3.0`으로 시작할 때만 참이다. 따라서 `matchesModernPhase("plan")` → **거짓**이며, H-5의 두 신호 중 하나가 조용히 무력화된다.
+
+**다만 오분류를 일으키지는 않았다.** 9개 모두 `created`가 2026-07-28~08-02이고 `modernEraThreshold`는 `2026-04-01`이므로 두 번째 이접지가 발화해 era는 여전히 V3R6으로 확정됐다. 이 SPEC이 주장하는 바는 "era 분류가 깨졌다"가 아니라 **"두 신호짜리 술어가 한 신호로 퇴화했고, 그 퇴화가 created-date 폴백에 가려져 있다"**이다. 문서를 읽는 사람이 이 결속을 알 수 없다는 것이 남은 결함이다(REQ-PFO-003).
+
+### §1.6 기계 가드는 이제 존재하며, 이 SPEC의 소유가 아니다
+
+`moai spec lint`에 `phase:` 값 가드가 착지했다. 소유자는 **`SPEC-PHASE-FIELD-VALIDATION-001`**이며, 이 SPEC은 그 매처를 재기술하지 않고 소유자를 가리킨다(§1.12).
+
+이 SPEC에 남는 의무는 가드의 **구현**이 아니라, 스키마 SSOT가 그 가드의 동작을 **정확히 기술하는 것**이다(REQ-PFO-016). 하중 필드의 계약을 적는 문서가 집행 규칙의 의미를 잘못 적으면, 그것은 계약이 없는 것보다 나쁘다 — 독자가 틀린 확신을 갖는다.
+
+### §1.8 매칭 축은 대소문자가 아니라 부분 문자열 대 값 전체 일치였다
+
+> **이 절은 v0.4.1까지 틀렸다.** 이전 판은 "대소문자 무시 매칭은 즉시 실물 8건에 오탐을 낸다"고 단언하고 그것을 **결정 축**으로 삼아 대소문자 구분 매칭을 SPEC의 결론으로 확정했다. **그 단언은 부분 문자열 매칭과 결합했을 때만 참이다.**
+
+`origin/main`의 `phase:` 값 556개를 네 방식으로 계수했다(판정 시점 실측).
+
+```
+대소문자 무시 + 값 전체 일치 (착지한 매처)   → 0
+대소문자 무시 + 부분 문자열                  → 8
+대소문자 구분 + 부분 문자열                  → 0
+'Runtime' 포함 값                            → 8
+```
+
+**두 축은 독립이며, 판별력을 가진 것은 두 번째다.**
+
+- **부분 문자열 매칭**은 대소문자를 무시하는 순간 `Runtime`의 `Run`을 잡아 실물 8건에 오탐을 낸다. 이전 판이 관측한 것이 이것이다.
+- **값 전체 일치**로 판정하면 대소문자를 무시해도 오탐이 없다. `"v3.0.0 — Phase 2 — Runtime Hardening"`을 케이스 폴딩해도 `"run"`과 **같지 않기** 때문이다. 실측 계수 `0`이 이를 확인한다.
+
+따라서 이전 판이 배제한 축(대소문자 무시)은 **배제할 이유가 없었다.** 착지한 매처는 대소문자 무시 + 값 전체 일치이며, 이 SPEC이 명세했던 대소문자 구분 + 값 전체 일치보다 **엄격하다** — `PLAN`, `Sync`, `"  run  "` 같은 대소문자·공백 변형 오타를 추가로 잡으면서 오탐은 늘지 않는다.
+
+**정정된 결론: 결정 축은 부분 문자열 대 값 전체 일치다. 대소문자 구분 여부는 값 전체 일치 위에서는 판별력이 없고, 무시하는 쪽이 더 넓게 잡는다.** 이전 판은 두 축이 얽힌 관측(`grep -icE` 대 `grep -cE`, **둘 다 부분 문자열**)에서 잘못된 축을 결정 축으로 지목했다 — 한 축만 바꾼 대조군을 만들지 않은 것이 오진의 기법적 원인이다.
+
+> **왜 조용히 고치지 않고 기록하는가.** 이 SPEC의 HISTORY 관행이 "무엇이 틀렸는지 이름을 붙인다"이며, 이 오진은 사용자 왕복을 대체하겠다며 제시한 실측 근거 자체가 틀렸던 사례다. 근거가 틀린 채로 결론만 맞는 것은 다음 판단을 보증하지 못한다.
+
+### §1.9 대상 문서 2개 모두 템플릿 미러를 가지며, 현재 바이트 동일하다
+
+이 SPEC이 고치는 문서 두 개는 템플릿 미러가 실재하고 현재 패리티 상태다(양쪽 `diff` 0행, 판정 시점 실측).
+
+```
+internal/template/templates/.claude/rules/moai/development/spec-frontmatter-schema.md
+internal/template/templates/.claude/skills/moai/workflows/plan/spec-assembly.md
+```
+
+로컬만 고치면 지금 성립하는 패리티가 깨지고, 결함 있는 문구가 배포 사용자에게 그대로 나간다. 더 나쁜 것은 **탐지되지 않는다**는 점이다 — 로컬 경로만 grep하는 판정은 미러가 드리프트해도 전부 PASS한다. 따라서 CLAUDE.local.md §2 Template-First Rule에 따라 로컬과 미러를 같은 커밋에서 함께 수정하고 `make build`를 실행한다(NFR-PFO-001).
+
+**중립성이 패리티의 형태를 규정한다.** 추가 문구는 §25 템플릿 중립성을 지켜야 하므로 SPEC ID·REQ 토큰·내부 날짜·commit SHA를 담지 않는다. 이 제약이 REQ-PFO-016의 형태를 결정한다 — 가드 소유자를 **SPEC ID로** 가리키면 미러에는 넣을 수 없어 패리티가 깨진다. 따라서 배포 문서에서는 소유자를 **코드 위치**(`internal/spec/lint.go` `FrontmatterSchemaRule`, finding 코드 `FrontmatterPhaseInvalid`)로 가리키고, SPEC ID 수준의 cross-reference는 이 SPEC 자신의 본문(§1.12)에만 둔다.
+
+> **바이트 동일은 이 두 파일의 조건부 사실이지, 리포 일반 규칙이 아니다.** 리포에는 §25 중립화 때문에 **의도적으로 divergent한 미러 쌍이 실재한다** — `.claude/skills/moai/workflows/plan.md`와 그 미러는 `diff` **6행**이며, 그 차이는 로컬 사본의 내부 수치·내부 날짜·말미 `Updated:` 줄이 템플릿에서 제거된 결과다. 올바른 일반 의무는 "두 파일을 동일하게 만든다"가 아니라 **"같은 의미의 편집을 양쪽에 적용하되 각 사본의 중립화를 보존한다"**이다. 이 SPEC은 `workflows/plan.md`를 편집하지 않으므로 그 쌍은 대상이 아니다.
+
+### §1.10 정정 소유자 결정 — manager-spec, 매트릭스 바깥 별도 절
+
+두 결정 모두 보유 증거로 확정한다(사용자 왕복 불요).
+
+**결정 1 — 소유자는 manager-spec(오케스트레이터 재위임 경유).** 근거는 경계 훼손이 가장 작다는 것이다. manager-spec은 이미 `spec.md`를 정본(canonical SSOT) 본문으로 소유하고 있고, 오케스트레이터 재위임을 통한 mid-run 편집 권한(D-NEW-1 inline-fix 패턴)도 이미 규정되어 있다. 새 권한을 만드는 것이 아니라 **기존 소유 범위가 이미 덮는 영역**이다.
+
+| 기각한 대안 | 사유 |
+|---|---|
+| manager-docs | 허용 필드를 넓히려면 "**NEVER** other frontmatter fields"라는 밝은 선(bright line)을 흐려야 한다. 그 경계의 가치는 정확히 예외가 없다는 데 있다. 한 필드를 위해 예외를 뚫으면 다음 필드의 근거가 된다. |
+| 오케스트레이터 직접 | 매트릭스의 유일한 오케스트레이터 행(`* → rejected`)조차 실제 기록은 manager-docs가 한다. 오케스트레이터가 `spec.md`를 직접 쓰는 선례가 없고, 이 SPEC이 그 선례를 만들 이유가 없다. |
+
+**결정 2 — 매트릭스 바깥의 별도 절.** 매트릭스의 이름과 계약은 *Status Transition* Ownership Matrix다. `phase:` 정정은 status를 바꾸지 않으므로 그 안에 행을 추가하면 매트릭스가 무엇을 관장하는지가 흐려진다. 다만 매트릭스만 읽는 독자가 "소유자 없음"으로 오독할 위험은 실재하므로, 별도 절 배치와 **매트릭스 내 한 줄 포인터 주석**을 함께 요구한다(REQ-PFO-007).
+
+### §1.12 형제 SPEC과의 분업 — 무엇이 넘어갔고 무엇이 남았나
+
+run-phase 도중 `SPEC-PHASE-FIELD-VALIDATION-001`(커밋 `998744216`, PR #1285)이 `origin/main`에 착지해 이 SPEC의 기계 가드 축과 실물 정정 축을 먼저 구현했다.
+
+| 축 | 소유 | 상태 (`origin/main` 실측) |
+|---|---|---|
+| lint 가드 (매처 · finding 코드 · 심각도 · grandfather 상호작용) | **SPEC-PHASE-FIELD-VALIDATION-001** | 착지 완료 — 이 SPEC은 재기술하지 않고 가리킨다 |
+| 9개 실물 정정 | **SPEC-PHASE-FIELD-VALIDATION-001** | 착지 완료 — 전수 스캔 라이프사이클 토큰 0건(§1.1) |
+| 스키마 SSOT 값 계약 규범화 + 금지값 열거 + era H-5 결속 | **이 SPEC** | 미착지 — `typically release target` 1건 잔존, 금지값 절 0건, `H-5` 0건 |
+| 저작 체크리스트 + pre-write gate HALT | **이 SPEC** | 미착지 — 체크리스트 원문 그대로 |
+| 정정 소유자 규정 (비전이 프론트매터 정정 절) | **이 SPEC** | 미착지 — 0건 |
+| 배포 문서가 착지한 가드를 정확히 기술 | **이 SPEC** | 미착지 — 현재 워크트리 문구가 오기 상태(§1.13) |
+
+**분업의 원칙: 가드는 형제 SPEC이 소유하고, 이 SPEC은 그 위층(저작 시점 계약·소유권·문서 정확성)만 다룬다.** 두 SPEC이 같은 매처를 기술하면 중복 원천이 되어, 한쪽이 바뀔 때 다른 쪽이 조용히 낡는다.
+
+### §1.13 배포 문서가 착지한 가드를 오기(誤記)하고 있다
+
+이 SPEC의 브랜치가 스키마 SSOT에 이미 추가한 문장이 있다.
+
+```
+The prohibition binds the whole value, case-sensitively.
+```
+
+**착지한 가드는 대소문자를 구분하지 않는다**(§1.8 실측). 즉 이 문장은 배포되는 규칙 문서가 집행 규칙의 의미를 잘못 말하는 상태다.
+
+이것은 사소한 오타가 아니라 **이 SPEC의 주제에 대한 자기모순**이다. 이 SPEC의 논지는 "하중을 받는 필드의 계약을 문서가 약하게·부정확하게 적어서 결함이 났다"는 것이다. 그 문서를 고치는 SPEC이 같은 문서에 새로운 부정확성을 심으면, 세우려는 계약 자체가 신뢰를 잃는다. 게다가 이 오기는 **틀린 방향으로 안전하다** — 독자는 `PLAN`·`Sync` 같은 대소문자 변형이 허용된다고 읽지만 실제로는 거부된다. 문서를 믿고 쓴 값이 가드에 걸린다.
+
+REQ-PFO-016이 이 정정을 요구한다.
+
+## §2 요구사항 (GEARS)
+
+### 값 계약 — `phase:`가 무엇인지 규범적으로 말한다
+
+- **REQ-PFO-001** — 스키마 SSOT(`spec-frontmatter-schema.md`)는 `phase:`의 유효값을 **릴리스 또는 마일스톤 타깃 라벨**로 규범적으로 정의해야 한다(shall). "typically release target"이라는 경향 서술로는 부족하며, 규범 표현으로 대체해야 한다.
+- **REQ-PFO-002** — 스키마 SSOT는 라이프사이클 단계 이름(`plan` / `run` / `sync` / `mx`)을 `phase:` 값으로 쓰는 것을 **명시적으로 금지해야 한다**(shall not). 금지 대상을 열거해야 하며, "릴리스 타깃을 쓰라"는 긍정 지시만으로 갈음해서는 안 된다 — 긍정 지시만 있던 것이 이 결함의 직접 원인이다(§1.3).
+- **REQ-PFO-003** — 스키마 SSOT는 `phase:`가 `internal/spec/era.go`의 H-5 era 판정에 입력된다는 사실과, 라이프사이클 토큰이 그 술어의 한 신호를 무력화한다는 결과를 기술해야 한다(shall). 현재 문서를 읽는 사람은 이 필드가 하중을 받는다는 것을 알 수 없다.
+- **REQ-PFO-016** — 스키마 SSOT의 금지 서술은 **착지한 집행 규칙의 동작을 정확히 기술해야 한다**(shall): 판정이 트림한 **값 전체**에 대해 **대소문자를 무시하고** 이루어진다는 점, finding 코드가 `FrontmatterPhaseInvalid`라는 점, 심각도가 error라는 점, 그리고 그 코드가 grandfather 강등 목록에서 **의도적으로 제외**되어 있다는 점. 이 서술은 매처를 재구현 수준으로 복제해서는 안 되며(shall not), 집행 지점을 **코드 위치**로 가리켜야 한다(shall) — SPEC ID 참조는 §25 템플릿 중립성 때문에 배포 사본에 넣을 수 없다(§1.9).
+
+  > **정정 이력**: 이 SPEC의 브랜치는 같은 자리에 "The prohibition binds the whole value, case-sensitively."를 이미 써 넣었다. **거짓이며**(§1.8 실측), 배포 문서가 집행 규칙을 오기하는 상태다(§1.13). 이 REQ는 그 문장의 정정을 요구한다.
+
+### 저작 시점 방지와 사후 정정 소유자
+
+- **REQ-PFO-004** — `.claude/skills/moai/workflows/plan/spec-assembly.md`는 저작 시점에 두 표면에서 금지값을 차단해야 한다(shall): (i) Pre-Write Frontmatter Checklist의 `phase:` 항목이 REQ-PFO-002의 금지 열거를 담아야 하며, (ii) **When** manager-spec이 `phase:` 값으로 라이프사이클 토큰을 담은 프론트매터를 생성하면, pre-write gate가 Write를 중단하고 스키마 위반을 보고해야 한다(shall halt) — 기존 HALT 트리거(누락 필드·거부 별칭)에 금지값 조건을 추가한다.
+
+  > 이 REQ는 v0.4.1의 REQ-PFO-004(체크리스트)와 REQ-PFO-005(gate HALT)를 병합한 것이다. 두 절은 같은 파일의 같은 관심사(저작 시점 차단)이고 한 번의 편집으로 함께 착지하며, Tier S 요구사항 상한 8에 맞추기 위한 통합이다. 판정은 AC-PFO-004가 두 명령으로 각각 수행하므로 검증력은 보존된다.
+
+- **REQ-PFO-006** — 이미 쓰인 `phase:` 값을 정정할 소유자는 **manager-spec**(오케스트레이터 재위임 경유)으로 소유권 문서에 지정되어야 한다(shall). 현재는 세 관리 에이전트 모두 금지되어 있어 소유자가 0명이다(§1.4). 선택 근거와 기각한 대안은 §1.10에 기록한다.
+- **REQ-PFO-007** — `phase:` 값 정정은 `completed → in-progress (amendment)` 전이를 **요구해서는 안 된다**(shall not require). 한 필드의 오타성 정정에 amendment 절차(status 왕복 + `amendment_of` 필드 + HISTORY `## Amendments` 절 + plan-audit 캐시 무효화)를 강제하는 것은 비용이 결함에 비해 과도하다. 정정 경로는 `status:`를 건드리지 않으므로 Status Transition Ownership Matrix의 어느 행에도 해당하지 않는다. 따라서 그 규정은 매트릭스 **바깥의 별도 절**로 배치하고(shall), 매트릭스에는 그 절을 가리키는 한 줄 주석을 남겨야 한다(shall) — 근거는 §1.10.
+
+### 비기능 요구사항
+
+- **NFR-PFO-001** — 문서를 수정하는 모든 마일스톤은 로컬 사본과 템플릿 미러를 **같은 커밋에서 함께** 수정해야 하며(shall), 이어서 `make build`를 실행해야 한다(CLAUDE.local.md §2 Template-First Rule). 대상 미러 2개는 §1.9가 열거한다. 미러에 추가하는 문구는 §25 템플릿 중립성을 지켜야 하며 SPEC ID·REQ 토큰·내부 날짜·commit SHA를 담아서는 안 된다(shall not).
+
+## §3 수용 기준 (Tier S — 인라인)
+
+### 판정 규약
+
+- **판정 기준(base)은 실행 시점에 재계산한다.** 이 문서는 SHA를 판정 앵커로 쓰지 않는다 — 저작 시점의 SHA는 판정 시점에 낡는다. 위치 지정은 라인 번호가 아니라 내용 토큰으로 한다.
+- **이 셸은 `ls`를 `ls -la`로 alias한다.** 파일 존재 판정에는 `git ls-files` 또는 glob을 쓴다.
+- **baseline 두 값을 구분해 기록한다.** `origin/main`(편집 이전 상태)과 **현 워크트리**(M1~M3 편집이 이미 착지한 상태). 두 값이 다른 항목은 그 편집이 이미 존재한다는 뜻이지 남은 작업이 없다는 뜻이 아니다 — REQ-PFO-016이 요구하는 정정은 아직 미착지다.
+
+공통 변수:
+
+```bash
+S=.claude/rules/moai/development/spec-frontmatter-schema.md
+A=.claude/skills/moai/workflows/plan/spec-assembly.md
+TS=internal/template/templates/.claude/rules/moai/development/spec-frontmatter-schema.md
+TA=internal/template/templates/.claude/skills/moai/workflows/plan/spec-assembly.md
+```
+
+### AC-PFO-001 — 스키마 SSOT가 유효값을 규범적으로 정의한다 (REQ-PFO-001)
+
+**Given** `phase` 행이 "typically release target"이라는 경향 서술만 담고 있고,
+**When** 그 행이 릴리스·마일스톤 타깃 라벨을 규범 표현(MUST)으로 정의하도록 개정되면,
+**Then** `typically release target` 문자열이 사라진다.
+
+```bash
+grep -c 'typically release target' "$S"
+```
+
+- `origin/main` 관측 `1` · 현 워크트리 관측 `0`
+- PASS 조건: `0`
+
+### AC-PFO-002 — 스키마 SSOT가 라이프사이클 토큰을 명시적으로 금지한다 (REQ-PFO-002)
+
+**Given** 금지값 열거가 없고,
+**When** `plan` / `run` / `sync` / `mx` 네 토큰을 금지하는 절이 추가되면,
+**Then** 금지 문맥과 네 토큰이 모두 검출된다.
+
+```bash
+# (a) `phase:` 값 문맥의 금지 표현
+grep -c -i '`phase:`.*\(prohibit\|MUST NOT\|금지\)\|\(prohibit\|MUST NOT\|금지\).*`phase:`' "$S"
+# (b) 금지 절 본문의 4토큰
+sed -n '/Prohibited phase values/,/^## /p' "$S" | grep -oE '\b(plan|run|sync|mx)\b' | sort -u | wc -l | tr -d ' '
+```
+
+- `origin/main` 관측 (a) `0` / (b) `0`(절 부재) · 현 워크트리 관측 (a) `1` / (b) `4`
+- PASS 조건: (a) `>= 1`, (b) `4`
+- **[산출물 요건] 신설 절의 제목은 리터럴 `Prohibited phase values`를 포함해야 한다.** (b)의 `sed` 범위가 이 제목에 앵커되어 있다 — 다른 제목을 쓰면 출력이 비어 계수가 `0`이 되고 fail-closed로 떨어진다.
+
+### AC-PFO-003 — 스키마 SSOT가 era.go 결속을 기술한다 (REQ-PFO-003)
+
+**Given** 독자가 `phase:`의 era 결속을 알 수 없고,
+**When** H-5 결속과 그 결과가 기술되면,
+**Then** `matchesModernPhase` 또는 `H-5` 토큰이 검출된다.
+
+```bash
+grep -c 'matchesModernPhase\|H-5' "$S"
+```
+
+- `origin/main` 관측 `0` · 현 워크트리 관측 `1`
+- PASS 조건: `>= 1`
+
+### AC-PFO-004 — 저작 시점 차단이 두 표면에 존재한다 (REQ-PFO-004)
+
+**Given** 체크리스트 항목이 형식 예시만 담고, pre-write gate가 "누락 필드 OR 거부 별칭"에만 HALT하고,
+**When** 두 표면에 금지값 조건이 추가되면,
+**Then** 두 판정이 모두 만족된다.
+
+```bash
+# (a) 체크리스트 항목 줄의 금지 표현
+grep -n '`phase:' "$A" | grep -ci 'NEVER\|금지\|NOT a lifecycle'
+# (b) pre-write gate 절의 금지값 HALT 트리거
+sed -n '/Pre-write gate behavior/,/^- \.moai/p' "$A" | grep -ci 'prohibited value\|금지값\|lifecycle token'
+```
+
+- `origin/main` 관측 (a) `0` / (b) `0` · 현 워크트리 관측 (a) `1` / (b) `1`
+- PASS 조건: (a) `>= 1` **AND** (b) `>= 1` — 한쪽만으로는 PASS가 아니다. 체크리스트는 사람이 읽는 표면이고 gate는 기계가 멈추는 표면이며, 서로를 대체하지 않는다.
+
+### AC-PFO-006 — 정정 소유자가 지정된다 (REQ-PFO-006)
+
+**Given** 세 관리 에이전트 모두 금지되어 소유자가 0명이고,
+**When** 단일 소유 에이전트가 소유권 문서에 지정되면,
+**Then** 지정이 검출되고, 명명된 에이전트가 유지 카탈로그 소속이다.
+
+```bash
+grep -n -i 'phase.*correction\|phase 값 정정' "$S" | head
+```
+
+- `origin/main` 관측 0행 · 현 워크트리 관측 `1`행
+- PASS 조건: `>= 1`행, 그리고 그 행이 명명한 에이전트가 `manager-spec` / `manager-docs` / `manager-develop` 중 하나 (archived 에이전트 이름이면 FAIL)
+
+### AC-PFO-007 — amendment 비요구 + 배치 2건 (REQ-PFO-007)
+
+REQ-PFO-007은 **세 가지**를 요구한다: (a) amendment 비요구 명시, (b) 규정을 매트릭스 **바깥** 별도 절에 배치, (c) 매트릭스 **안에** 그 절을 가리키는 포인터 주석.
+
+```bash
+grep -c -i 'amendment.*not required\|amendment를 요구하지' "$S"                        # (a)
+grep -c '^#\+ .*Non-transition frontmatter corrections' "$S"                            # (b0)
+awk '/^## Status Transition Ownership Matrix/{f=1;next} /^## /{f=0} f' "$S" \
+  | grep -c '^#\+ .*Non-transition frontmatter corrections'                             # (b)
+awk '/^## Status Transition Ownership Matrix/{f=1;next} /^## /{f=0} f' "$S" \
+  | grep -v '^#' | grep -c -i 'Non-transition frontmatter corrections\|비전이 프론트매터 정정'  # (c)
+```
+
+- `origin/main` 관측 전부 `0` · 현 워크트리 관측 (a) `1` / (b0) `1` / (b) `0` / (c) `1`
+- PASS 조건: (a) `>= 1`, **(b0) `>= 1`**, (b) `0`, (c) `>= 1`
+- **(b)는 (b0) 없이는 공허하다.** 절이 아예 없어도 (b)는 `0`을 반환한다 — `origin/main` baseline이 정확히 그 상태다. (b0)가 `0`이면 (b)의 `0`은 PASS가 아니라 미구현이다.
+- **(c)의 매칭은 헤딩이 아닌 산문 줄이어야 한다.** 포인터를 인용 줄(`>`)로 쓰면 (b)의 헤딩 계수를 올리지 않는다.
+- **[산출물 요건] 신설 절의 제목은 리터럴 `Non-transition frontmatter corrections`를 포함해야 한다.**
+
+### AC-PFO-016 — 배포 문서가 착지한 가드를 정확히 기술한다 (REQ-PFO-016)
+
+**Given** 브랜치가 스키마 SSOT에 "The prohibition binds the whole value, case-sensitively."를 써 넣었고 그것이 착지한 가드와 반대이고(§1.13),
+**When** 그 서술이 대소문자 무시 + 값 전체 일치로 정정되고 finding 코드·심각도·grandfather 제외가 함께 기술되면,
+**Then** 오기 문자열이 사라지고 네 사실이 모두 검출된다.
+
+```bash
+grep -c -i 'case-sensitiv' "$S"                       # (a) 오기 제거
+grep -c -i 'case-insensitiv\|case-fold' "$S"          # (b) 정정된 매칭 서술
+grep -c 'FrontmatterPhaseInvalid' "$S"                # (c) finding 코드
+grep -c 'eraDemotableCodes' "$S"                      # (d) grandfather 강등 제외
+```
+
+- `origin/main` 관측 (a) `0` / (b) `0` / (c) `0` / (d) `0` — 서술 자체가 없다
+- **현 워크트리 관측 (a) `1` / (b) `0` / (c) `0` / (d) `0` — 오기가 존재하고 정정이 미착지다. 이 SPEC의 남은 작업 중 유일하게 현재 FAIL인 항목이다.**
+- PASS 조건: (a) `0` **AND** (b) `>= 1` **AND** (c) `>= 1` **AND** (d) `>= 1`
+- **(a)와 (b)를 함께 판정하는 이유**: (a) 단독은 문장을 통째로 삭제해도 PASS한다. 정정은 삭제가 아니라 **올바른 서술로의 교체**이므로 (b)가 대체 서술의 실재를 요구한다.
+
+  > **정정 이력 ((d) 선택자)**: 이 AC의 첫 판은 (d)를 `grep -ci 'eraDemotableCodes\|grandfather'`로 쓰고 baseline을 `0`으로 기록했다. **거짓이다** — `grandfather`는 Status Enum 절의 "grandfathered SPECs that carry `status: planned`" 문장 때문에 `origin/main`과 현 워크트리 양쪽에서 이미 `1`이며, 그 이접지는 무편집 상태에서 이미 충족되는 **비판별 검사**였다. 실측으로 확인해 정확한 토큰 `eraDemotableCodes`(양쪽 `0`)만 남겼다. 이 SPEC이 v0.4.0에서 AC-PFO-002에 대해 고쳤던 것과 **같은 결함 유형**(죽은 검사)이 다른 AC에서 재발한 것이다.
+- 판정은 **로컬 사본**에서 하고, 미러 준수는 AC-PFO-014(패리티)와의 결합으로 함의된다.
+
+### AC-PFO-014 — 로컬↔미러 패리티가 유지된다 (NFR-PFO-001)
+
+**Given** 대상 문서 2개가 로컬과 템플릿 미러 사이에 바이트 동일 패리티를 이루고 있고(§1.9),
+**When** 편집이 로컬에 적용되면,
+**Then** 같은 편집이 미러에도 적용되어 패리티가 **여전히** 0행이다.
+
+```bash
+diff "$S" "$TS" | wc -l | tr -d ' '
+diff "$A" "$TA" | wc -l | tr -d ' '
+go test -count=1 -run 'TestInternalContentLeak|TestTemplateNeutrality' ./internal/template/
+```
+
+- `origin/main` 관측 양쪽 `0` · 현 워크트리 관측 양쪽 `0`
+- PASS 조건: 두 `diff` 모두 `0` **AND** 중립성 가드 `ok` **AND** AC-PFO-001~004·006·007·016 PASS
+- **단독 판정 금지.** 두 파일을 **전혀 편집하지 않아도** `diff`는 `0`이다. 이 AC는 로컬 grep AC들과의 결합으로만 미러 준수를 함의한다 — 로컬 grep이 PASS이고 미러가 로컬과 바이트 동일하면 미러도 같은 grep을 만족한다.
+
+### Definition of Done
+
+- [ ] AC-PFO-001 / 002 / 003 / 004 / 006 / 007 / 014 / 016 = **8개** 전부 PASS (Tier S 상한 8)
+- [ ] **AC-PFO-016이 실제로 관측 PASS** — 이 SPEC의 남은 작업 중 현재 FAIL인 유일 항목이며, 이것 없이 나머지 7개가 PASS인 것은 착수 이전 상태와 구별되지 않는다
+- [ ] AC-PFO-014가 AC-PFO-001~004·006·007·016 PASS와 **결합해서** 판정되었음 — 무편집 상태에서도 `diff` `0`이므로 단독 PASS로 읽지 않았음
+- [ ] AC-PFO-007의 (b) 배치 판정이 (b0) 절-실재 판정과 **함께** 읽혔음 — (b0)가 `0`인 채로 (b)의 `0`을 PASS로 읽지 않았음
+- [ ] AC-PFO-004의 (a)·(b) 두 표면이 **모두** 만족되었음 — 한쪽만으로 갈음하지 않았음
+- [ ] `make build` 실행 후 템플릿 중립성 가드 통과
+- [ ] `progress.md` §E.2에 위 관측이 명령 + 축약 없는 출력으로 기록됨
+
+## §4 범위 밖 (Out of Scope)
+
+### Out of Scope — lint 가드의 구현·매처·심각도
+
+`phase:` 값 가드는 `SPEC-PHASE-FIELD-VALIDATION-001`이 소유하며 이미 착지했다(§1.12).
+
+- 이 SPEC은 그 매처를 **재구현하지 않고, 재기술하지도 않는다.** 두 SPEC이 같은 매처를 기술하면 중복 원천이 되어 한쪽이 바뀔 때 다른 쪽이 조용히 낡는다.
+- 이 SPEC이 요구하는 것은 배포 문서가 그 가드의 동작을 **정확히 가리키는 것**뿐이다(REQ-PFO-016).
+- 가드의 심각도(error)·grandfather 제외·finding 코드 변경 요구는 이 SPEC의 소관이 아니다. 이견이 있으면 소유 SPEC에 제기한다.
+
+### Out of Scope — 9개 실물 SPEC의 `phase:` 값 정정
+
+형제 SPEC이 이미 전부 `"v3.0.2"`로 정정했고, 전수 스캔이 라이프사이클 토큰 0건을 확인한다(§1.1). 재적용은 무변경 편집이 되거나 불필요한 충돌을 만든다.
+
+### Out of Scope — `phase:` 필드가 아예 없는 8개 SPEC
+
+값이 틀린 것과 필드가 없는 것은 원인도 처방도 다르다. 후자는 필드 도입 이전의 유물이며, `FrontmatterSchemaRule`의 필수 필드 루프가 이미 `FrontmatterInvalid`로 검출하되 grandfather 정책에 의해 의도적으로 warning으로 강등한 기존 부채다. 이 SPEC이 손대면 grandfather 보호를 우회한다. 8개 중 6개가 `_archive/` 하위라는 점도 별도 판단을 요구한다 — 아카이브 문서의 소급 정규화는 별개 정책 문제다.
+
+### Out of Scope — era.go의 H-5 술어 자체 수정
+
+`matchesModernPhase`가 `v3.0`·`v3r6` 접두만 인정하는 것은 이 SPEC의 결함이 아니다. 이 SPEC은 그 함수에 올바른 입력이 들어가도록 값 계약을 세울 뿐, 함수의 매칭 범위를 넓히거나 좁히지 않는다. §1.5가 기록한 대로 현재 오분류는 0이므로 술어 변경은 필요를 증명하지 못한 변경이 된다.
+
+### Out of Scope — 다른 프론트매터 필드의 값 계약
+
+`module:`·`lifecycle:`·`tags:`도 비어있음만 검사받는다. 같은 계열의 공백일 수 있으나 그 필드들에서 실제 일탈이 관측되지 않았다. 관측 없이 가드를 세우는 것은 이 SPEC이 비판하는 것과 같은 종류의 미검증 처방이다. 일탈이 관측되면 별도 SPEC으로 다룬다.
+
+## §5 성공 기준
+
+§3의 AC 8개가 전부 PASS이며, 그중 **AC-PFO-016이 관측으로 PASS**해야 한다. 나머지 7개는 이미 브랜치에 착지해 있으므로, 016 없이 얻은 "8개 중 7개 PASS"는 이번 개정이 아무것도 바꾸지 않았다는 것과 구별되지 않는다.

--- a/internal/template/templates/.claude/rules/moai/development/spec-frontmatter-schema.md
+++ b/internal/template/templates/.claude/rules/moai/development/spec-frontmatter-schema.md
@@ -7,7 +7,7 @@ paths: "**/.moai/specs/**,internal/spec/**"
 
 > **Single Source of Truth** for the canonical SPEC frontmatter schema.
 > Enforcement: `internal/spec/lint.go` `FrontmatterSchemaRule`.
-> Cross-referenced by: `.claude/skills/moai/workflows/plan.md` § Pre-Write Frontmatter Checklist.
+> Cross-referenced by: `.claude/skills/moai/workflows/plan/spec-assembly.md` § Pre-Write Frontmatter Checklist.
 
 ## Canonical 12 Required Fields
 
@@ -43,10 +43,22 @@ tags: "tag1, tag2, tag3"
 | `updated` | date | `YYYY-MM-DD` ISO format | Last update date |
 | `author` | string | non-empty | Author name |
 | `priority` | enum | `P0`\|`P1`\|`P2`\|`P3` or `High`\|`Medium`\|`Low`\|`Critical` | Default `P1` |
-| `phase` | string | non-empty, typically release target | e.g. `"v3.0.0"` |
+| `phase` | string | non-empty; MUST be a release or milestone target label | e.g. `"v3.0.0"` — see § Prohibited phase values |
 | `module` | string | non-empty, path-like | Affected Go module or directory |
 | `lifecycle` | enum | `spec-anchored`\|`spec-lite`\|`exploratory` | Default `spec-anchored` |
 | `tags` | string | comma-separated, non-empty | Searchable labels |
+
+### Prohibited phase values
+
+`phase` names the **release or milestone target** a SPEC is aimed at. It is not a lifecycle field: its value does not change as the SPEC moves through the workflow, and nothing in the lifecycle updates it. A SPEC written for the next patch release carries that release label from the day it is authored until the day it is closed.
+
+The following lifecycle-stage names are prohibited as `phase:` values: `plan`, `run`, `sync`, and `mx`. Writing the stage the author happened to be standing in is the mistake this prohibition exists to stop; the positive instruction ("use a release target") is not enough on its own, because a stage name reads like a plausible phase to anyone who has not been told otherwise. Where the correct label is genuinely unknown, name the nearest release target rather than a stage.
+
+The prohibition binds the whole trimmed value, compared case-insensitively — `PLAN`, `Sync`, and a value padded with surrounding whitespace are rejected exactly as `plan` is. It does NOT bind substrings: a legitimate label that merely contains one of these words inside a longer phrase — `"v3.0.0 — Phase 2 — Runtime Hardening"`, or a milestone label naming a sync layer — is valid and MUST NOT be rejected. Whole-value comparison is what makes case-insensitivity safe here; substring matching would false-flag those labels.
+
+Enforcement lives in `internal/spec/lint.go` `FrontmatterSchemaRule`, which emits finding code `FrontmatterPhaseInvalid` at error severity. That code is deliberately absent from `eraDemotableCodes`, so it is NOT demoted to an advisory warning on grandfather-era SPECs: the guard exists to catch an authoring mistake on an in-flight SPEC, and the era heuristic classifies almost every in-flight SPEC as grandfathered.
+
+**This field is load-bearing.** `internal/spec/era.go` reads `phase` in the H-5 era tie-breaker: `matchesModernPhase` returns true only for a value carrying a modern release prefix, so a lifecycle token there silently disables one of the two signals H-5 depends on and leaves the classification resting on the `created` date alone. A wrong value here does not announce itself — it degrades a two-signal predicate to one.
 
 ## Status Enum (8 values)
 
@@ -77,6 +89,8 @@ Per the canonical agent-responsibility realignment policy (DRI ownership at agen
 | `completed → in-progress (amendment)` | manager-spec (re-delegation per D-NEW-1 inline-fix pattern) | `feat(SPEC-{ID}): in-place amendment <rationale-summary>` — distinct from `(none) → draft` and `* → superseded`; the SPEC's HISTORY `## Amendments` sub-section MUST record the prior completed version + prior_completed_sha + rationale + scope |
 
 > **3-phase close (plan→run→sync)** — the MoAI lifecycle is exactly three phases (`plan`, `run`, `sync`); MX Tag is a cross-cutting concern validated during sync, NOT a separate fourth phase. The `completed` status transition rides the sync commit (manager-docs owns it); there is no separate "Mx chore commit". The progress.md §E structure is 4 sections (§E.1 Plan / §E.2 Run Evidence / §E.3 Run Audit-Ready / §E.4 Sync Audit-Ready) — the former `§E.5 Mx-phase` section is retired (folded into §E.4).
+
+> **This matrix does not cover non-transition frontmatter corrections.** Repairing a frontmatter value that was written wrong leaves `status:` unchanged, so no row above applies to it — the absence of a row is not an absence of an owner. See § Non-transition frontmatter corrections for the owner and the procedure.
 
 ## progress.md Section Map (canonical SSOT)
 
@@ -109,6 +123,16 @@ Per the drift-detector close-subject convention, every close commit (the sync co
 - `manager-develop` MUST NOT modify `spec.md` / `plan.md` / `acceptance.md` body content (frontmatter `status:` + `updated:` updates on the `draft → in-progress` transition are allowed; ALL other body modifications are forbidden). When run-phase reveals a need to modify SPEC body content, manager-develop MUST return a blocker report and the orchestrator re-delegates to manager-spec for the scope-doc update before re-delegating back.
 
 > **SHA placeholder backfill exemption (D3)** — The forbidden crossings above bind `spec.md` / `plan.md` / `acceptance.md` body content. The `progress.md` §E.3 / §E.4 `sync_commit_sha` / `mx_commit_sha` SHA fields are a DISTINCT surface: a sync-phase (or legacy Mx-phase) commit cannot reference its own SHA — a commit does not know its own hash until after it lands — so the established pattern writes a `pending-backfill-*` placeholder in the phase's own commit and backfills the real SHA in a follow-up commit. This mechanical placeholder completion is NOT an ownership crossing; it is the self-referential-hazard workaround for a field that, by physics, cannot be populated within the same commit it describes. The ownership matrix therefore scopes its forbidden crossings to SPEC body content (spec/plan/acceptance) and does NOT bind `progress.md` SHA-field backfill performed by the phase-owning agent (manager-develop for §E.3, manager-docs for §E.4) in a subsequent commit.
+
+### Non-transition frontmatter corrections
+
+A frontmatter field that was authored with a value the schema does not permit is repaired in place. This is a different act from the Status Transition Ownership Matrix above: that matrix governs `status:` transitions, and a repair of this kind leaves `status:` untouched, so none of its rows apply.
+
+**Owner: `manager-spec`, reached through orchestrator re-delegation.** A `phase:` value correction — and any other non-transition frontmatter correction — is authored by `manager-spec`, the agent that already owns `spec.md` as canonical body content. `manager-docs` and `manager-develop` are both restricted to `status:` + `updated:` (§ Forbidden ownership crossings), so neither may perform it, and widening either restriction would blur a boundary whose whole value is that it admits no exceptions.
+
+**An amendment is not required.** Because the repair does not change `status:`, it does NOT trigger the `completed → in-progress (amendment)` transition: no `amendment_of:` field, no HISTORY `## Amendments` sub-section, and no plan-audit cache invalidation. Imposing the full amendment procedure on a single mis-authored field would cost more than the defect it repairs.
+
+Scope: the correction touches the mis-authored field and `updated:`. Body content, HISTORY, and every other frontmatter field stay untouched.
 
 ### Forward-looking enforcement (optional defense-in-depth)
 

--- a/internal/template/templates/.claude/skills/moai/workflows/plan/spec-assembly.md
+++ b/internal/template/templates/.claude/skills/moai/workflows/plan/spec-assembly.md
@@ -88,7 +88,7 @@ Required 12 fields (canonical order):
 - [ ] `updated: YYYY-MM-DD` — ISO date (NEVER `updated_at`)
 - [ ] `author: <name>` — string, not empty
 - [ ] `priority: P1` — uppercase Pn style (P0|P1|P2|P3) or High|Medium|Low|Critical
-- [ ] `phase: "vX.Y.Z target"` — release phase string
+- [ ] `phase: "vX.Y.Z target"` — release or milestone target label. NEVER a lifecycle stage name (`plan`, `run`, `sync`, `mx`): the value names the release this SPEC is aimed at, not the stage you are standing in while writing it
 - [ ] `module: "path/to/module"` — affected module path
 - [ ] `lifecycle: spec-anchored` — enum: spec-anchored | spec-lite | exploratory
 - [ ] `tags: "tag1, tag2, ..."` — comma-separated string (NOT `labels:`, NOT YAML array)
@@ -105,7 +105,7 @@ Rejected legacy aliases (fail closed — do NOT accept):
 Pre-write gate behavior:
 1. manager-spec generates frontmatter draft in memory.
 2. manager-spec self-audits against the 12-field checklist above.
-3. If any required field is missing OR any rejected alias appears: manager-spec HALTS, reports the schema violation, and re-generates. It does NOT call Write.
+3. If any required field is missing OR any rejected alias appears OR a field carries a prohibited value — `phase:` holding a lifecycle token (`plan`, `run`, `sync`, `mx`) is the case that occurs in practice: manager-spec HALTS, reports the schema violation, and re-generates. It does NOT call Write.
 4. Phase 11 plan-auditor independently re-verifies the schema on the written file as a second line of defense.
 
 - .moai/specs/SPEC-{ID}/plan.md


### PR DESCRIPTION
## What

`phase:` in SPEC frontmatter is a **release-target label**, not a lifecycle field. Nothing said so strongly enough — the schema read `typically release target`, and the authoring checklist read `release phase string`. Nine SPECs were authored carrying the lifecycle stage their author happened to be standing in (`plan` ×8, `sync` ×1).

The **mechanical guard** for that mistake now lives in `SPEC-PHASE-FIELD-VALIDATION-001` (`998744216`, #1285), which landed while this SPEC was in run-phase. This PR is reduced to the layer that guard does not cover.

## Changes

| Concern | Change |
|---|---|
| Value contract | `spec-frontmatter-schema.md` gains a normative `Prohibited phase values` section; `typically release target` removed |
| Load-bearing disclosure | The era.go H-5 coupling is now stated — `matchesModernPhase` reads this field, so a wrong value silently degrades a two-signal predicate to one |
| Authoring-time prevention | `plan/spec-assembly.md` checklist states the prohibition at the point of writing, not only after |
| Correction ownership | New `Non-transition frontmatter corrections` section — repairing a wrong value changes no `status:`, so it matched no row in the Status Transition Ownership Matrix, and the absence of a row was being read as the absence of an owner |

Both template mirrors updated in the same commit per Template-First; both pairs measure `diff` 0. `make build` run.

## The value contract describes the shipped matcher

An earlier draft of this SPEC asserted the prohibition binds **case-sensitively**. That was wrong twice over: the shipped guard uses `phaseWorkflowStageTokens[strings.ToLower(strings.TrimSpace(phase))]`, and the SPEC's own rationale for excluding case-insensitivity was falsified — case-insensitive matching only false-flags the eight `Runtime`-bearing labels *when combined with substring matching*. On whole-value comparison it does not. The shipped matcher is therefore **stricter** than the one this SPEC originally specified, catching `PLAN` / `Sync` / whitespace-padded variants at no false-positive cost.

Shipping a doc that misdescribed the guard would have been the exact defect class this SPEC exists to prevent.

## Scope reduction

M4 (a duplicate lint rule) and M5 (the nine corrections) were **dropped** — the sibling SPEC applied both, and its test file occupies the same path this SPEC's acceptance criteria anchored on. `progress.md` §E.3 records what was built, why it is not in this PR, and how the branch was rebuilt on `origin/main` without reverting the sibling's work.

Tier M → **S** (REQ 8 / AC 8). `acceptance.md` removed; criteria inlined in `spec.md` §3.

## Verification

```
AC-PFO-016  (a) case-sensitiv 0  (b) case-insensitiv 1  (c) FrontmatterPhaseInvalid 1  (d) eraDemotableCodes 1
AC-PFO-014  mirror parity  schema 0 lines / spec-assembly 0 lines
AC-001~004, 006, 007        re-verified, no regression
go build ./...              exit 0
go test ./internal/template/  ok (neutrality + mirror-parity guards)
```

plan-auditor: 4 iterations, **PASS 0.86** (Tier M threshold 0.80) at v0.4.1, before the reduction.

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that `phase` identifies a release or milestone, not a lifecycle stage.
  * Documented case-insensitive whole-value validation and prohibited lifecycle values such as `plan`, `run`, `sync`, and `mx`.
  * Added guidance for correcting invalid frontmatter and preserving synchronized documentation across templates.
* **Planning**
  * Added specifications and progress records covering validation, ownership, acceptance criteria, and verification procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->