### PR TITLE
chore(SPEC-PROFILE-MEMORY-001): backfill sync_commit_sha 24d7d3eb1

### DIFF
--- a/.moai/specs/SPEC-PROFILE-MEMORY-001/progress.md
+++ b/.moai/specs/SPEC-PROFILE-MEMORY-001/progress.md
@@ -181,7 +181,7 @@ unverified:
 
 ```yaml
 sync_complete_at: 2026-08-02
-sync_commit_sha: "pending-backfill-sync-amend"
+sync_commit_sha: "24d7d3eb1"
 sync_status: audit-ready
 b12_self_test_a: "grep -c 'SPEC-PROFILE-MEMORY-001' CHANGELOG.md → 0 (사전 중복 없음, 발행 진행)"
 b12_self_test_b: "acceptance.md 의 고유 AC 식별자 21건 = CHANGELOG 항목이 명시한 21건 (19 PASS / 2 PASS-WITH-DEBT / 0 FAIL)"


### PR DESCRIPTION
D3 self-referential-hazard backfill: the amendment sync commit squash-merged as `24d7d3eb1` (PR #1291) cannot reference its own SHA, so `progress.md` §E.4 carried a `pending-backfill-sync-amend` placeholder. This chore replaces it with the real merge SHA. Single-line change, no production code. 🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the audit record with the completed synchronization commit reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->