### PR TITLE
feat(SPEC-WORKTREE-SQUASH-MERGE-001): squash-merge detection for worktree --stale cleanup

### DIFF
--- a/.moai/specs/SPEC-WORKTREE-SQUASH-MERGE-001/acceptance.md
+++ b/.moai/specs/SPEC-WORKTREE-SQUASH-MERGE-001/acceptance.md
@@ -1,0 +1,1625 @@
+# Acceptance Criteria — SPEC-WORKTREE-SQUASH-MERGE-001
+
+---
+
+## §A Evidence Provenance
+
+Two classes of command appear below, and they are labelled distinctly so neither is
+mistaken for the other:
+
+- **Authoring-time evidence (executed).** The scenario-construction recipes and the raw git
+  probes in §B and §C were run during plan-phase authoring against throwaway repositories,
+  and their observed output is recorded verbatim. These establish the *expected verdict*
+  for every scenario — the oracle the implementation is measured against.
+- **Run-phase judge (to execute).** The `go test` invocations are named per criterion and
+  are run during the run phase, once the code exists. They were necessarily not run at
+  authoring time against a *passing* implementation; that gap is stated here rather than
+  concealed. Every named selector WAS, however, executed against the pre-implementation
+  tree so its baseline behaviour is on record — see the non-vacuity discipline below.
+
+**Non-vacuity discipline (applies to every `go test -run` judge in this document).** A
+`-run` selector matching nothing exits 0 and prints `testing: warning: no tests to run`,
+which would make any criterion judged on exit status vacuously true. Every criterion below
+that names a `go test -run` judge is therefore judged by **reading the `--- PASS:` lines**,
+not the exit code: at least one `--- PASS:` line must be present, and the observed count is
+recorded alongside the verdict. Zero is a FAIL regardless of exit status.
+
+All **thirteen** selectors named in §D were executed against the pre-implementation tree
+(`f5129374b`); the observed counts are:
+
+```
+IsBranchMerged.*Squash                                            PASS-lines=0   [no tests to run]
+IsBranchMerged.*Rebase                                            PASS-lines=0   [no tests to run]
+IsBranchMerged.*EmptyDiff                                         PASS-lines=0   [no tests to run]
+IsBranchMerged.*Reachab                                           PASS-lines=0   [no tests to run]
+IsBranchMerged.*(Partial|Unmerged)                                PASS-lines=0   [no tests to run]
+IsBranchMerged.*(Rename|NonASCII|ColonPath|Textconv|Submodule)    PASS-lines=0   [no tests to run]
+IsBranchMerged.*(ModeOnly|SymlinkFile)                            PASS-lines=0   [no tests to run]
+IsBranchMerged.*ProbeExit                                         PASS-lines=0   [no tests to run]
+SyntheticCommit.*Determinis                                       PASS-lines=0   [no tests to run]
+IsBranchMerged.*Revert                                            PASS-lines=0   [no tests to run]
+TestWorktreeIsBranchMerged                                        PASS-lines=3   ok
+TestCleanStale_KeepsDirtyWorktree                                 PASS-lines=1   ok
+TestCleanStale_PreviewsByDefault|TestCleanStale_RemovesWithYes    PASS-lines=2   ok
+```
+
+The ten zeros name scenario tests this SPEC has yet to add, and each exits **0** despite
+matching nothing — which is precisely why the guard is load-bearing rather than decorative.
+The three non-zero rows are the pre-existing tests AC-WSM-013, AC-WSM-010, and AC-WSM-016
+check 2 pin at 3, 1, and 2 respectively; they are recorded here as the regression floor, and
+a later count below those values means tests were lost rather than passing. Criteria whose
+baseline output is individually interesting reproduce it verbatim in place.
+
+Two selectors changed at v0.6.0 and both changes are substantive rather than cosmetic.
+AC-WSM-006's was widened from `(Rename|NonASCII|ColonPath)` to
+`(Rename|NonASCII|ColonPath|Textconv|Submodule)`, because the earlier form would not have
+matched a textconv or submodule test — adding the scenarios without widening the selector
+would have left them unjudged. AC-WSM-017's is new. Regex-matched against candidate test
+names to confirm the widening is real:
+
+```
+TestIsBranchMerged_TextconvDriverCollapsesChange   old=no   widened=YES  mode-selector=no
+TestIsBranchMerged_SubmoduleIgnoreDirective        old=no   widened=YES  mode-selector=no
+TestIsBranchMerged_ModeOnlyDivergence              old=no   widened=no   mode-selector=YES
+TestIsBranchMerged_SymlinkFileOIDCollision         old=no   widened=no   mode-selector=YES
+TestIsBranchMerged_ColonPathRemovedFromBase        old=YES  widened=YES  mode-selector=no
+```
+
+Baseline for the authoring-time evidence: worktree
+`.claude/worktrees/clean-stale-squash`, `git rev-parse --short HEAD` → `f5129374b`;
+`git --version` → `git version 2.50.1 (Apple Git-155)`; `git config --get diff.renames`
+exits 1 (unset), so git's default rename detection is in effect. Each scenario repository
+sets `core.quotePath true` explicitly — that is git's **documented default**, and it is set
+explicitly because this machine's `~/.gitconfig` overrides it to `false`, which would
+otherwise mask the SC-12 defect on this machine only.
+
+The §C oracle was re-executed in full at iteration 6 and extended from thirteen scenarios to
+seventeen, and the §C.1 mutation grid was re-executed at 11 × 17 = 187 cells, one freshly
+constructed repository per cell. The re-run is a fresh construction, not a transcription of
+the iteration-5 tables: every SC-1..SC-13 cell below was observed again rather than carried
+over, and every one is unchanged.
+
+One harness error was caught and corrected before reporting, and it is recorded because it
+would have produced a false regression report. The first run implemented the `both` mutation
+as `weak-guard` + `no-state`, which made SC-7 read `keep` and appeared to contradict the
+iteration-5 grid. The grid was right and the harness was wrong: §C.1 defines `weak-guard` as
+"S3 accepts any `-` line" but `both` as "drop S5 *and* accept any **non-empty** cherry
+output" — two different relaxations of the cherry guard, not the composition of the first two
+mutations. SC-7's cherry output is a single `+` line, which is non-empty but contains no `-`,
+so the two definitions genuinely diverge on that one cell. Corrected and re-run, `both`
+reproduces the recorded grid exactly. The name `both` invites the misreading; the row
+definitions in §C.1 are authoritative over the name.
+
+---
+
+## §B Scenario Construction Recipes (executed at authoring time)
+
+Each recipe builds an isolated repository with a `main` branch and a `feat` branch in the
+named merge state. All seventeen were executed; §C records the observed signal output.
+
+Every commit is made with an incrementing `GIT_AUTHOR_DATE`/`GIT_COMMITTER_DATE`. This is
+load-bearing rather than cosmetic: with identical metadata, commits created within the same
+second collide on SHA and the merge-base moves, which silently corrupts the matrix. SC-9 is
+the row most exposed to this — see its note below.
+
+| Id | Scenario | Construction |
+|---|---|---|
+| SC-1 | squash-merged | `feat` adds `x.txt` then `y.txt` in two commits; `main` adds both files in one commit |
+| SC-2 | rebase-merged | `feat` adds `p.txt` then `q.txt`; `main` drifts, then cherry-picks both commits individually |
+| SC-3 | true merge commit | `feat` adds `m.txt`; `main` runs `git merge --no-ff feat` |
+| SC-4 | strictly behind | `feat` created at base and left alone; `main` advances |
+| SC-5 | empty-diff branch | `feat` carries one `--allow-empty` commit; `main` advances |
+| SC-6 | partially applied | `feat` adds `a.txt` then `b.txt`; `main` adds only `a.txt` |
+| SC-7 | fully unmerged (control) | `feat` adds `z.txt`; `main` drifts independently |
+| SC-8 | **partially reverted** | `feat` adds `a.txt` then `b.txt`; `main` cherry-picks BOTH, then `git revert --no-edit HEAD` removes the `b` commit |
+| SC-9 | base is a strict superset | `feat` adds `s.txt`; `main` **independently adds `s.txt` as its own commit**, then additionally adds `extra.txt` |
+| SC-10 | **rename + re-add (squash)** | base commit holds a 10-line `old.txt`; `feat` runs `git mv old.txt new.txt` and commits, then appends a line to `new.txt` and commits — **in two commits**; `main` runs `git merge --squash feat` and commits, then re-adds `old.txt` with its original content |
+| SC-11 | **rename + re-add (cherry-pick)** | base commit holds a 10-line `old.txt`; `feat` runs `git mv old.txt new.txt`; `main` cherry-picks that commit, then re-adds `old.txt` with its original content |
+| SC-12 | **non-ASCII path removed from base** | `feat` adds `plain.txt` and `문서.txt` in one commit; `main` runs `git merge --squash feat` and commits, then `git rm 문서.txt` and commits |
+| SC-13 | **leading-colon path removed from base** | `feat` adds `plain.txt` and `:note.txt` in one commit; `main` runs `git merge --squash feat` and commits, then `git rm :note.txt` and commits. Every builder `add`/`rm` touching the hazard path runs under `git --literal-pathspecs`, so the construction itself is not subject to the defect under test |
+| SC-14 | **textconv driver collapses a changed file** | the seed commit adds `.gitattributes` containing `*.pdf diff=pdf`, and the repository sets `diff.pdf.textconv` to a script emitting a constant; `feat` adds `plain.txt` and `report.pdf` in one commit; `main` runs `git merge --squash feat` and commits, then overwrites `report.pdf` with different content and commits |
+| SC-15 | **submodule pointer moved under an ignore directive** | a second throwaway repository is built with three commits `s0`/`s1`/`s2`; the parent adds it as a submodule at `sub` pinned to `s0` (with `.gitmodules`) and commits; `feat` moves the pointer to `s1` and adds `plain.txt` in one commit — **`.gitmodules` is not touched**; `main` runs `git merge --squash feat` and commits, then moves the pointer to `s2` and commits. The ignore directive is then set, in either of two locations (see notes) |
+| P3c | **mode-only divergence** | the seed commit adds `x.txt`; `feat` chmods it to 755 and adds `plain.txt` in one commit; `main` runs `git merge --squash feat` and commits, then chmods `x.txt` back to 644 and commits. Content is byte-identical on both sides throughout |
+| P4c | **symlink/file blob-OID collision** | the seed commit adds a symlink `link.txt -> target` and a regular file `target`; `feat` replaces `link.txt` with a **regular file whose content is exactly `target`** and adds `plain.txt` in one commit; `main` runs `git merge --squash feat` and commits, then restores `link.txt` as a symlink and commits |
+
+Ten construction notes, each recording a way the recipe was got wrong before it was got
+right:
+
+- **SC-9 must NOT be built by cherry-picking `feat`'s commit.** A cherry-pick performed
+  with no elapsed time reproduces the tree, parent, message, and identity, so the two
+  commits collide on SHA, `feat` becomes a literal ancestor of `main`, the merge-base
+  moves, and the scenario degenerates into SC-4 with S1 firing. `main` must create its own
+  commit adding the same content. `spec.md` §2 finding 3 carries the same warning.
+- **SC-10's rename and its edit must be two separate commits.** The recipe's earlier wording
+  ("runs `git mv` **then** appends a line") was ambiguous between one commit and two, and the
+  two readings do not produce the same matrix row. Built as **one** commit, `feat` has a
+  single commit whose patch-id equals `main`'s squash commit, so plain `git cherry` matches
+  and **S3 fires** — contradicting §C, which records `S3=keep` for this row. Built as two,
+  no single `feat` commit equals the squash and S3 correctly does not fire. The composed
+  verdict is `notmerged` either way, so this is a matrix-fidelity issue rather than a
+  correctness one; it is recorded because a reader reproducing §C from the one-commit reading
+  will see a cell mismatch and reasonably conclude the oracle is wrong.
+- **SC-13's hazard path must be created and removed under `--literal-pathspecs`.** A builder
+  that runs a bare `git add :note.txt` or `git rm :note.txt` hits the very defect the
+  scenario exists to exercise: the pathspec is parsed as magic, the file is never staged or
+  never removed, and the scenario silently stops testing anything. The builder therefore uses
+  `git --literal-pathspecs add` / `rm`, which keeps the *construction* independent of the
+  *mechanism under test*.
+- **SC-10 and SC-11 need `old.txt` to exist at the merge-base and to be large enough for
+  rename detection to fire.** A one-line file renamed and then extended falls below git's
+  50% similarity threshold, no rename is detected, the enumeration is not folded, and the
+  scenario silently stops exercising the defect. The recipe uses ten lines; the observed
+  detection is `R086` (86% similarity).
+- **`git cherry-pick` and `git revert` take no `-q` flag.** Passing one makes the command
+  fail; with output redirected the failure is invisible and the scenario is built wrong.
+  During the iteration-3 re-run this initially produced a silently un-reverted SC-8 and
+  un-cherry-picked SC-2, both of which reported the wrong signals until the flag was
+  removed.
+- **SC-12 needs `core.quotePath` set to `true` explicitly, and needs `plain.txt` alongside
+  the non-ASCII file.** `true` is git's documented default, but a developer machine may
+  override it in `~/.gitconfig` (this one does, to `false`), in which case the non-ASCII
+  path is *not* quoted and the scenario silently stops exercising the defect. Setting it
+  per-repository restores the shipped default rather than contriving one. The second file
+  matters for a different reason: with only `문서.txt` in the list, the newline-split
+  pathspec would be a single unmatched name and `git diff --quiet` would compare nothing at
+  all — the same rc=0, but reached without demonstrating that a *partially* valid list is
+  equally unsafe. `plain.txt` is present, matches, and is identical in base, so the probe
+  genuinely runs and still returns "no difference".
+- **SC-14's `.gitattributes` must be committed at the seed, and must remain in the
+  worktree.** The attribute is read from the **checked-out** file, not from the tree under
+  judgement, so a fixture that commits `.gitattributes` and then removes it from the working
+  directory silently stops exercising the defect. Measured on the built fixture: with the
+  worktree `.gitattributes` present the unpatched comparison returns `merged`; delete it from
+  the working directory — leaving it committed and still reported by `git ls-files` — and the
+  same comparison returns `notmerged`. The `textconv` script must also be executable, and
+  `diff.pdf.textconv` must point at an absolute path, or git reports `fatal: cannot run` and
+  the driver never fires. The `.pdf` extension is not special; any extension bound by a
+  `diff=<driver>` attribute behaves identically.
+- **SC-15's `feat` commit must NOT touch `.gitmodules`.** This is the whole point of the
+  scenario and the reason the earlier study missed the exposure: when `.gitmodules` also
+  differs, that file carries the comparison and the verdict comes out correct for the wrong
+  reason. The pointer must move alone. Adding the submodule needs
+  `-c protocol.file.allow=always` on modern git, or `git submodule add` refuses a local path.
+- **SC-15's ignore directive can live in either of two places, and both were built.** Setting
+  `submodule.sub.ignore=all` in `.git/config` models an operator-set exposure; committing the
+  same key inside `.gitmodules` models one the repository ships to every clone. Both were
+  constructed and both reproduce identically — enumeration `[plain.txt]` without the flag
+  versus `[plain.txt, sub]` with it, and the composed verdict flipping accordingly. The
+  `.gitmodules` form is the one worth pinning in the run-phase fixture, because it needs no
+  local configuration and is therefore the wider exposure.
+- **P3c must chmod the file in the working tree, not only in the index.** The first build used
+  `git update-index --chmod=+x`, which changes the index without touching the file on disk;
+  the next `git checkout` then aborted with `Your local changes to the following files would
+  be overwritten by checkout: x.txt` and the scenario was never built. The recipe uses an
+  ordinary `chmod` followed by `git add`. `core.fileMode` must be left at its default
+  (`true`); a fixture that disables it makes git ignore the mode entirely and the scenario
+  stops testing anything.
+- **P4c's regular file must contain the symlink's target with no trailing newline.** A symlink
+  blob is exactly the target path, unterminated. Writing `target\n` into the regular file
+  produces a *different* blob, the two sides no longer share an OID, and the scenario silently
+  degenerates into an ordinary content difference — which every mechanism detects, so it would
+  pin nothing. Verified on the built fixture: both sides show blob
+  `1de565933b05f74c75ff9a6520af5f9f8a5a2f1d`, differing only in mode (`100644` vs `120000`).
+
+---
+
+## §C Signal Oracle (observed at authoring time)
+
+Probe commands, run once per scenario:
+
+```bash
+mb=$(git merge-base main feat)
+git branch --merged main | sed 's/^[*+ ]*//' | grep -qx feat        # S1 reachability
+git diff --quiet "$mb" feat                                         # S2 empty diff
+git cherry main feat                                                # S3 plain per-commit
+git cherry main "$(git commit-tree "$(git rev-parse feat^{tree})" -p "$mb" -m _)"   # S4 synthetic
+names=( )                                                           # S5 state check
+while IFS= read -r -d '' l; do names+=("$l"); done \
+  < <(git diff --ignore-submodules=none --no-renames --name-only -z "$mb" feat)
+[ "${#names[@]}" -eq 0 ] || git --literal-pathspecs diff --quiet --no-textconv \
+                                --ignore-submodules=none feat main -- "${names[@]}"
+```
+
+Six details of this block are load-bearing and were each got wrong before they were got
+right:
+
+- The `sed 's/^[*+ ]*//'` on S1 strips the leading indent as well as the `*`/`+` markers. A
+  pattern that strips only the markers fails to match any branch that is not the current
+  one, which reads as a false "keep" on SC-3 and SC-4.
+- `names` is built as an **array** and expanded as `"${names[@]}"`, one argument per path.
+  The earlier `names=$(...)` / `-- $names` string form is not equivalent: see §C.2.
+- The enumeration carries `-z` and the read carries `-d ''`, so the list is split on NUL.
+  The earlier newline-split form (`read -r l` over `--name-only` without `-z`) is not
+  equivalent: git C-quotes paths containing a backslash, tab, double quote, or control
+  character, and — under the default `core.quotePath=true` — any non-ASCII path, so a
+  newline split yields quoted renderings that match nothing. See §C.2 route 3.
+- The comparison carries `--literal-pathspecs`, **before** the `diff` subcommand. It is a
+  git-level option; written as `git diff --literal-pathspecs ...` git rejects the invocation
+  with a usage error. Without it a byte-perfect path whose first byte is `:` is parsed as
+  pathspec magic and matches nothing, and `:!`/`:^` forms parse as EXCLUDE and invert what
+  the probe compares. See §C.2 route 4.
+- The comparison carries `--no-textconv`, **after** the subcommand — it is a diff-level
+  option, and placed before it git exits 129 with `unknown option`. Without it a
+  `.gitattributes` `diff=<driver>` rule with a `textconv` driver makes git compare the
+  driver's *rendering* of each blob rather than the blobs, so two genuinely different files
+  report no difference on a path list that is complete and byte-perfect. See §C.2 route 5.
+- **`--ignore-submodules=none` appears twice — once on the enumeration and once on the
+  comparison — and neither occurrence is redundant.** `diff.ignoreSubmodules=all` and
+  `submodule.<name>.ignore=all` suppress a changed gitlink at *both* stages: without the flag
+  on the enumeration the submodule path never enters `names`, and without it on the comparison
+  a correct `names` is still ignored. Measured, removing it from either stage alone reproduces
+  the SC-15 false positive. It is diff-level in both positions. See §C.2 route 5.
+
+Observed verdicts. `MERGED` on S3/S4 is the **raw** history signal, before the S5
+conjunction; `OK`/`NO` is the conjunct. The composed verdict is
+`S1 OR S2 OR (S3 AND S5) OR (S4 AND S5)`.
+
+| Id | S1 | S2 | S3 | S4 | S5 | **Required predicate verdict** |
+|---|---|---|---|---|---|---|
+| SC-1 squash | keep | keep | keep | **MERGED** | OK | **merged** |
+| SC-2 rebase | keep | keep | **MERGED** | keep | OK | **merged** |
+| SC-3 merge commit | **MERGED** | **EMPTY** | keep | keep | OK | **merged** |
+| SC-4 behind | **MERGED** | **EMPTY** | keep | keep | OK | **merged** |
+| SC-5 empty diff | keep | **EMPTY** | keep | keep | OK | **merged** |
+| SC-6 partial | keep | keep | keep | keep | **NO** | **not merged** |
+| SC-7 unmerged | keep | keep | keep | keep | **NO** | **not merged** |
+| SC-8 **revert** | keep | keep | **MERGED** | keep | **NO** | **not merged** |
+| SC-9 superset | keep | keep | **MERGED** | **MERGED** | OK | **merged** |
+| SC-10 **rename+re-add (squash)** | keep | keep | keep | **MERGED** | **NO** | **not merged** |
+| SC-11 **rename+re-add (pick)** | keep | keep | **MERGED** | **MERGED** | **NO** | **not merged** |
+| SC-12 **non-ASCII removed** | keep | keep | **MERGED** | **MERGED** | **NO** | **not merged** |
+| SC-13 **leading-colon removed** | keep | keep | **MERGED** | **MERGED** | **NO** | **not merged** |
+| SC-14 **textconv driver** | keep | keep | **MERGED** | **MERGED** | **NO** | **not merged** |
+| SC-15 **submodule ignore=all** | keep | keep | **MERGED** | **MERGED** | **NO** | **not merged** |
+| P3c **mode-only divergence** | keep | keep | **MERGED** | **MERGED** | **NO** | **not merged** |
+| P4c **symlink/file OID collision** | keep | keep | **MERGED** | **MERGED** | **NO** | **not merged** |
+
+Verbatim harness output from the **iteration-6 re-run**, under the composed predicate as now
+specified (`--ignore-submodules=none --no-renames --name-only -z`, NUL split;
+`--literal-pathspecs` git-level and `--no-textconv --ignore-submodules=none` diff-level on
+the comparison). Every scenario was rebuilt from the §B recipes rather than transcribed, and
+SC-1..SC-13 are cell-for-cell identical to the iteration-5 record. Column order is
+`S1 S2 S3 S4 S5`; `Y` = fires, `.` = does not.
+
+```
+sc1    [. . . Y Y] merged     required=merged     OK  names=['x.txt', 'y.txt']
+sc2    [. . Y . Y] merged     required=merged     OK  names=['p.txt', 'q.txt']
+sc3    [Y Y . . Y] merged     required=merged     OK  names=[]
+sc4    [Y Y . . Y] merged     required=merged     OK  names=[]
+sc5    [. Y . . Y] merged     required=merged     OK  names=[]
+sc6    [. . . . .] notmerged  required=notmerged  OK  names=['a.txt', 'b.txt']
+sc7    [. . . . .] notmerged  required=notmerged  OK  names=['z.txt']
+sc8    [. . Y . .] notmerged  required=notmerged  OK  names=['a.txt', 'b.txt']
+sc9    [. . Y Y Y] merged     required=merged     OK  names=['s.txt']
+sc10   [. . . Y .] notmerged  required=notmerged  OK  names=['new.txt', 'old.txt']
+sc11   [. . Y Y .] notmerged  required=notmerged  OK  names=['new.txt', 'old.txt']
+sc12   [. . Y Y .] notmerged  required=notmerged  OK  names=['plain.txt', '문서.txt']
+sc13   [. . Y Y .] notmerged  required=notmerged  OK  names=[':note.txt', 'plain.txt']
+sc14   [. . Y Y .] notmerged  required=notmerged  OK  names=['plain.txt', 'report.pdf']
+sc15   [. . Y Y .] notmerged  required=notmerged  OK  names=['plain.txt', 'sub']
+p3c    [. . Y Y .] notmerged  required=notmerged  OK  names=['plain.txt', 'x.txt']
+p4c    [. . Y Y .] notmerged  required=notmerged  OK  names=['link.txt', 'plain.txt']
+```
+
+The four new rows all carry `S3=Y S4=Y`, which puts them in the sharpest shape the matrix
+contains: two independent history signals agree the branch is merged, and S5 is the only
+thing that can withhold the verdict. Their `names` lists are worth reading alongside the
+verdicts — every one is complete and byte-perfect, so none of the four round-trip repairs is
+what saves them:
+
+- **SC-14** — `['plain.txt', 'report.pdf']`. The changed file *is* in the list. Only the
+  comparison's diff semantics decide the verdict.
+- **SC-15** — `['plain.txt', 'sub']`. The gitlink is present **because** the enumeration
+  carries `--ignore-submodules=none`; without it the list is `['plain.txt']` and the moved
+  pointer is never mentioned. This row is the one that fails at both stages.
+- **P3c / P4c** — the diverging path is present and the comparison detects it, because
+  `git diff` compares modes. These two rows pass as specified and exist to fail a future
+  mode-blind comparison.
+
+Ground truth for the four, recorded so the verdicts are independently checkable rather than
+asserted:
+
+```
+sc14  feat:report.pdf = dcc7c925c1f3fb918a192d6f40835189490d4e4c
+      main:report.pdf = 43d844c81ab8ccc32d09beb9d70f5831d1474402      <- blobs differ
+      git diff --name-only feat main -- report.pdf   ->  report.pdf   <- still reported
+      cmp bare                                        ->  rc=0        (OK,  vacuous)
+      cmp --no-textconv                               ->  rc=1        (NO,  correct)
+
+sc15  feat:sub = 1a7d9a656cfc3f54f58da6d184dcbc0c33a29cb3
+      main:sub = 034452180de5fd3d9b2bba76a8bc15273cad6386             <- pointers differ
+      enum without --ignore-submodules=none  ->  ['plain.txt']        <- gitlink DROPPED
+      enum with    --ignore-submodules=none  ->  ['plain.txt', 'sub']
+      cmp without the flag, correct list      ->  rc=0                (OK,  vacuous)
+      cmp with    the flag, correct list      ->  rc=1                (NO,  correct)
+
+p3c   feat 100755 blob 587be6b4c3f93f93c489c0111bba5596147a26cb  x.txt
+      main 100644 blob 587be6b4c3f93f93c489c0111bba5596147a26cb  x.txt   <- ONE blob, two modes
+      git diff comparison   ->  rc=1   detects
+      blob-OID comparison   ->  EQUAL  MISSES
+
+p4c   feat 100644 blob 1de565933b05f74c75ff9a6520af5f9f8a5a2f1d  link.txt
+      main 120000 blob 1de565933b05f74c75ff9a6520af5f9f8a5a2f1d  link.txt <- ONE blob, two modes
+      git diff comparison   ->  rc=1   detects
+      blob-OID comparison   ->  EQUAL  MISSES
+```
+
+The SC-15 block also confirms the enumeration-side flag is load-bearing rather than a
+duplicate of the comparison-side one: the two `enum` lines differ, and the shorter list
+cannot be repaired by any comparison flag, because the path it omits is never passed.
+
+Two further properties of SC-14 and SC-15, measured, because they make these members harder
+to reason about than their predecessors:
+
+```
+sc14  worktree .gitattributes present  ->  unpatched cmp: merged
+      worktree .gitattributes removed  ->  unpatched cmp: notmerged
+      ...though git ls-files still reports .gitattributes as tracked
+
+sc15  directive in .git/config                    ->  enum without flag: ['plain.txt']
+      directive committed inside .gitmodules      ->  enum without flag: ['plain.txt']
+      (.git/config key unset in the second case; .gitmodules is a TRACKED file)
+```
+
+The first says the verdict depends on the state of the judging **worktree**, not only on the
+trees under comparison — a sensitivity none of the first four axes had. The second says this
+exposure does not require the operator's own configuration: a repository can commit the
+directive and ship it to every clone.
+
+SC-13's `names` list is the row worth pausing on: the enumeration emits `:note.txt`
+byte-perfectly, so nothing in the *list* is wrong. The defect lived entirely in how that
+correct list was read back, which is why neither `--no-renames` nor `-z` touched it. The
+isolated pair, in the same repository:
+
+```
+git diff --quiet feat main -- ':note.txt'                       rc=0   (OK,  vacuous)
+git --literal-pathspecs diff --quiet feat main -- ':note.txt'   rc=1   (NO,  correct)
+git diff --literal-pathspecs --quiet feat main -- ':note.txt'   usage error — git-level option
+```
+
+Retained verbatim from the iteration-4 re-run — the **encoding** axis (newline split vs
+`-z`), which iteration 5 did not re-run because it changed nothing on that axis. Each
+scenario is probed twice, both
+times with `--no-renames`: once with the output split on **newline** (the v0.3.0 form) and
+once with `-z` and the output split on **NUL** (the current form). The `names` line records
+the two path lists. This is the axis iteration 4 tests; the rename-fold axis tested at
+iteration 3 is preserved separately in the §C.1 mutation grid, where `folded-names` is a
+row.
+
+```
+sc1   nl-split   keep keep keep MERGED OK merged
+sc1   -z         keep keep keep MERGED OK merged
+sc1     names(nl-split)=[x.txt y.txt]  names(-z)=[x.txt y.txt]
+
+sc2   nl-split   keep keep MERGED keep OK merged
+sc2   -z         keep keep MERGED keep OK merged
+sc2     names(nl-split)=[p.txt q.txt]  names(-z)=[p.txt q.txt]
+
+sc3   nl-split   MERGED EMPTY keep keep OK merged
+sc3   -z         MERGED EMPTY keep keep OK merged
+sc3     names(nl-split)=[]  names(-z)=[]
+
+sc4   nl-split   MERGED EMPTY keep keep OK merged
+sc4   -z         MERGED EMPTY keep keep OK merged
+sc4     names(nl-split)=[]  names(-z)=[]
+
+sc5   nl-split   keep EMPTY keep keep OK merged
+sc5   -z         keep EMPTY keep keep OK merged
+sc5     names(nl-split)=[]  names(-z)=[]
+
+sc6   nl-split   keep keep keep keep NO notmerged
+sc6   -z         keep keep keep keep NO notmerged
+sc6     names(nl-split)=[a.txt b.txt]  names(-z)=[a.txt b.txt]
+
+sc7   nl-split   keep keep keep keep NO notmerged
+sc7   -z         keep keep keep keep NO notmerged
+sc7     names(nl-split)=[z.txt]  names(-z)=[z.txt]
+
+sc8   nl-split   keep keep MERGED keep NO notmerged
+sc8   -z         keep keep MERGED keep NO notmerged
+sc8     names(nl-split)=[a.txt b.txt]  names(-z)=[a.txt b.txt]
+
+sc9   nl-split   keep keep MERGED MERGED OK merged
+sc9   -z         keep keep MERGED MERGED OK merged
+sc9     names(nl-split)=[s.txt]  names(-z)=[s.txt]
+
+sc10  nl-split   keep keep keep MERGED NO notmerged
+sc10  -z         keep keep keep MERGED NO notmerged
+sc10    names(nl-split)=[new.txt old.txt]  names(-z)=[new.txt old.txt]
+
+sc11  nl-split   keep keep MERGED MERGED NO notmerged
+sc11  -z         keep keep MERGED MERGED NO notmerged
+sc11    names(nl-split)=[new.txt old.txt]  names(-z)=[new.txt old.txt]
+
+sc12  nl-split   keep keep MERGED MERGED OK merged
+sc12  -z         keep keep MERGED MERGED NO notmerged
+sc12    names(nl-split)=[plain.txt "\353\254\270\354\204\234.txt"]  names(-z)=[plain.txt 문서.txt]
+```
+
+(Column order per row: `S1 S2 S3 S4 S5 verdict`.)
+
+Four readings of this output:
+
+- **SC-1 through SC-11 are cell-for-cell identical in the two columns, and identical to the
+  values recorded at v0.3.0.** `-z` regresses nothing. Their `names` lists are also
+  identical, which is the reason: none of those eleven scenarios contains a path git would
+  quote, so there is nothing for the encoding to corrupt.
+- **SC-12 differs in exactly one cell — S5 — and that one cell decides the verdict.** Under
+  the newline split the path list's second element is the *quoted rendering*
+  `"\353\254\270\354\204\234.txt"`, which names no file. `git diff --quiet` therefore
+  compares only `plain.txt`, which is identical in base, and exits 0. S5 reads `OK` and both
+  history signals are granted unopposed: **merged**, a false positive on a branch whose file
+  is genuinely absent from base.
+- **SC-12 fires both S3 and S4**, which makes it the same strong shape as SC-11: two
+  independent history signals agree the branch is merged, and the enumeration is the only
+  thing preventing a wrong removal.
+- **SC-2 remains the row the state conjunct was most likely to regress**, because
+  rebase-merge detection rests on exactly the history semantic S5 narrows. It does not
+  regress under either setting: the individually replayed patches survive in base HEAD, so
+  S5 holds and the S3 verdict stands.
+
+Retained verbatim from the iteration-3 re-run — the **rename** axis (`--name-only` with
+rename detection on, "folded", versus `--no-renames`), which iteration 4 did not re-run
+because it changed nothing on that axis. It is preserved rather than replaced because it is
+the recorded evidence that `--no-renames` flips SC-10 and SC-11 and regresses SC-1..SC-9:
+
+```
+sc1   folded       S1=keep    S2=keep   S3=keep    S4=MERGED  S5=OK  => merged
+sc1   --no-renames S1=keep    S2=keep   S3=keep    S4=MERGED  S5=OK  => merged
+sc1     names(folded)=[x.txt y.txt ] names(--no-renames)=[x.txt y.txt ]
+
+sc2   folded       S1=keep    S2=keep   S3=MERGED  S4=keep    S5=OK  => merged
+sc2   --no-renames S1=keep    S2=keep   S3=MERGED  S4=keep    S5=OK  => merged
+sc2     names(folded)=[p.txt q.txt ] names(--no-renames)=[p.txt q.txt ]
+
+sc3   folded       S1=MERGED  S2=EMPTY  S3=keep    S4=keep    S5=OK  => merged
+sc3   --no-renames S1=MERGED  S2=EMPTY  S3=keep    S4=keep    S5=OK  => merged
+sc3     names(folded)=[] names(--no-renames)=[]
+
+sc4   folded       S1=MERGED  S2=EMPTY  S3=keep    S4=keep    S5=OK  => merged
+sc4   --no-renames S1=MERGED  S2=EMPTY  S3=keep    S4=keep    S5=OK  => merged
+sc4     names(folded)=[] names(--no-renames)=[]
+
+sc5   folded       S1=keep    S2=EMPTY  S3=keep    S4=keep    S5=OK  => merged
+sc5   --no-renames S1=keep    S2=EMPTY  S3=keep    S4=keep    S5=OK  => merged
+sc5     names(folded)=[] names(--no-renames)=[]
+
+sc6   folded       S1=keep    S2=keep   S3=keep    S4=keep    S5=NO  => not merged
+sc6   --no-renames S1=keep    S2=keep   S3=keep    S4=keep    S5=NO  => not merged
+sc6     names(folded)=[a.txt b.txt ] names(--no-renames)=[a.txt b.txt ]
+
+sc7   folded       S1=keep    S2=keep   S3=keep    S4=keep    S5=NO  => not merged
+sc7   --no-renames S1=keep    S2=keep   S3=keep    S4=keep    S5=NO  => not merged
+sc7     names(folded)=[z.txt ] names(--no-renames)=[z.txt ]
+
+sc8   folded       S1=keep    S2=keep   S3=MERGED  S4=keep    S5=NO  => not merged
+sc8   --no-renames S1=keep    S2=keep   S3=MERGED  S4=keep    S5=NO  => not merged
+sc8     names(folded)=[a.txt b.txt ] names(--no-renames)=[a.txt b.txt ]
+
+sc9   folded       S1=keep    S2=keep   S3=MERGED  S4=MERGED  S5=OK  => merged
+sc9   --no-renames S1=keep    S2=keep   S3=MERGED  S4=MERGED  S5=OK  => merged
+sc9     names(folded)=[s.txt ] names(--no-renames)=[s.txt ]
+
+sc10  folded       S1=keep    S2=keep   S3=keep    S4=MERGED  S5=OK  => merged
+sc10  --no-renames S1=keep    S2=keep   S3=keep    S4=MERGED  S5=NO  => not merged
+sc10    names(folded)=[new.txt ] names(--no-renames)=[new.txt old.txt ]
+
+sc11  folded       S1=keep    S2=keep   S3=MERGED  S4=MERGED  S5=OK  => merged
+sc11  --no-renames S1=keep    S2=keep   S3=MERGED  S4=MERGED  S5=NO  => not merged
+sc11    names(folded)=[new.txt ] names(--no-renames)=[new.txt old.txt ]
+```
+
+Under the folded enumeration SC-10 and SC-11's path list omits `old.txt`, S5 never examines
+the path the branch deleted, S5 reads `OK`, and the history signal is granted unopposed.
+The two axes are independent: `--no-renames` decides *which* paths are enumerated, `-z`
+decides *what form they arrive in*, and the §C.1 grid confirms each mutation flips a
+disjoint set of rows.
+
+Raw output retained for the five must-keep rows (iteration-3 re-run; hashes are from
+freshly constructed repositories, so they differ from the iteration-2 record while the
+`-`/`+` shape — which is what the guards read — is what matters):
+
+```
+### sc6
+  raw plain cherry : - e910b712441b5c3fa46b6ef4e038397b16fcd524|+ c066fd394b94381250d5ea20cdf2c23787a8eaa8|
+  raw synth cherry : + 83aa061e1be0161e040fc0c782a59411c269b6f9|
+  names            : a.txt b.txt
+  state conjunct   : NO
+### sc7
+  raw plain cherry : + a46e853312ec914c3cc9dd76d69be879582dcc79|
+  raw synth cherry : + 31b81a50c8d70917e4af5d78327dfa028028e464|
+  names            : z.txt
+  state conjunct   : NO
+### sc8
+  raw plain cherry : - f4ac9d1a06963c1589805cd8a02cd9b40da3cfcf|- 7d5687827616e801cf7c6322cc9ceb00ed82052e|
+  raw synth cherry : + a7707d8ad4f5b5314a4551f3a5e3d4c79b94ea01|
+  names            : a.txt b.txt
+  state conjunct   : NO
+### sc10
+  raw plain cherry : + 6b2ed19d91c612ad0751c8e6faaf7e4a86add2dc|+ 592764111bfb217e8ea91ffc65f8e4bb297a8ffc|
+  raw synth cherry : - cec712537b4f91f29dfb1d0ad5d78320d7e9e083|
+  names            : new.txt old.txt
+  state conjunct   : NO
+### sc11
+  raw plain cherry : - 1fa5d3634dcd1bfa1d38c21b96fbf5f37d7ea3c2|
+  raw synth cherry : - 025a5e8f75eb8c67cf41a5b1a26f257322dc818c|
+  names            : new.txt old.txt
+  state conjunct   : NO
+```
+
+Raw output for SC-12 (iteration-4 construction), recorded in the same shape:
+
+```
+### sc12
+  core.quotePath   : true                          (git's documented default)
+  main tree        : plain.txt seed.txt
+  feat tree        : plain.txt seed.txt "\353\254\270\354\204\234.txt"
+  raw plain cherry : - 17f8ea59bade9eba9d08ba7cfc9c4518b31cde0b|
+  raw synth cherry : - 35252ca72076c4ee755b469c4c74ed720393d41a|
+  names(nl-split)  : plain.txt "\353\254\270\354\204\234.txt"
+  names(-z)        : plain.txt 문서.txt
+  S5 nl-split      : git diff --quiet feat main -- plain.txt '"\353\254\270\354\204\234.txt"'  -> rc=0   (OK,  vacuous)
+  S5 -z            : git diff --quiet feat main -- plain.txt 문서.txt                          -> rc=1   (NO,  correct)
+```
+
+Note `feat`'s tree listing: `git ls-tree --name-only` quotes the path exactly as
+`--name-only` does, which is the same rendering that fails to round-trip. The two S5 lines
+are the whole defect in two commands — identical predicate, identical repository, opposite
+verdicts, differing only in how the path list was read.
+
+Four rows are load-bearing, each for a different guard:
+
+- **SC-8** — both plain-cherry lines are `-`, so the every-line-`-` guard is satisfied and a
+  history-only predicate returns merged while `b.txt` is absent from base HEAD. S5 is what
+  withholds it.
+- **SC-10** — the synth cherry is a single `-` line, so S4 fires. Only S5 withholds, and
+  only because `old.txt` is in the `names` list. Note the plain cherry is `+ | +`, so S3
+  does not fire here: SC-10 is an S4-only false positive.
+- **SC-11** — *both* cherry probes report `-`, so S3 and S4 both fire. This is the strongest
+  form of the rename defect: two independent history signals agree the branch is merged,
+  and the enumeration is the only thing standing between them and a wrong removal.
+- **SC-12** — both cherry probes again report `-`, so S3 and S4 both fire, and here the
+  enumeration is not merely incomplete but *mis-encoded*. The `names(-z)` and
+  `names(nl-split)` lines differ in one element and that element is the whole verdict.
+
+### §C.2 Why S5 fails open — the unmatched-pathspec property
+
+`git diff --quiet` treats a pathspec that matches nothing as "no difference" and exits **0**.
+It does not warn, and it does not fail. Measured:
+
+```
+git diff --quiet feat main -- no-such-path.txt   ->  rc=0    <- matches nothing
+git diff --quiet feat main -- b.txt              ->  rc=1    <- genuinely differs
+git diff        feat main -- no-such-path.txt    ->  rc=0, empty stdout (no error at all)
+```
+
+Every defect that shrinks, corrupts, or re-interprets the path list therefore lands in the
+**unsafe** direction: S5 holds, the conjunct is satisfied, and the branch is reported merged.
+A fifth route reaches the same outcome without touching the list at all — the comparison
+itself answers wrongly — and a sixth would open if the comparison mechanism were ever swapped
+for a mode-blind one. Six distinct routes were reproduced:
+
+**Route 1 — rename detection folds the deleted source path away** (the SC-10/SC-11 defect).
+`git diff --name-only` reports only a rename's destination:
+
+```
+git diff --name-status <mb> feat          ->  R086  old.txt  new.txt
+git diff --name-only <mb> feat            ->  [new.txt]              <- old.txt ABSENT
+git diff --no-renames --name-only <mb> feat -> [new.txt old.txt]     <- old.txt PRESENT
+```
+
+**Route 2 — the path list is joined into one shell string.** Passing the list as a single
+argument produces one pathspec that matches nothing, which by the property above reads as
+merged. On a repository where the correct answer is `rc=1`:
+
+```
+argv: <feat> <main> <--> <old.txt >    (list joined into one argument)   rc=0   <- WRONG
+argv: <feat> <main> <--> <old.txt>     (one argument per path)           rc=1   <- right
+```
+
+The joined form is shell-dependent, which is what makes it treacherous rather than merely
+wrong — the same `-- $names` snippet behaves differently depending on the interpreter:
+
+```
+under bash :  unquoted $n rc=1   literal rc=1     <- splits, survives by luck
+under zsh  :  unquoted $n rc=0   literal rc=1     <- does not split, silently wrong
+```
+
+**Route 3 — the path list is split on newline, so quoted paths never round-trip** (the
+SC-12 defect). `git diff --name-only` does not emit paths verbatim; it emits a C-quoted
+rendering whenever the path contains a backslash, tab, double quote, or control character,
+and — under git's documented default `core.quotePath=true` — whenever it contains any
+non-ASCII byte. Measured, by round-tripping each emitted line straight back as a pathspec
+in a repository where the correct answer is `rc=1` for every path:
+
+```
+core.quotePath=true   (git's documented default)
+  "a\\b.txt"                      rc=0   <- matched NOTHING
+  "caf\303\251.txt"               rc=0   <- matched NOTHING
+  plainname.txt                   rc=1   (matched)
+  "tab\tname.txt"                 rc=0   <- matched NOTHING
+  "\355\225\234\352\270\200.txt"  rc=0   <- matched NOTHING
+
+core.quotePath=false  (which names are STILL quoted)
+  "a\\b.txt"                      rc=0   <- backslash quoted regardless of the setting
+  café.txt                        rc=1   (unquoted under quotePath=false)
+  plainname.txt                   rc=1
+  "tab\tname.txt"                 rc=0   <- control char quoted regardless of the setting
+  한글.txt                         rc=1   (unquoted under quotePath=false)
+
+-z (NUL-delimited), quotePath=true — never quoted, round-trip correct for all five
+  a\b.txt   café.txt   plainname.txt   tab<TAB>name.txt   한글.txt      all rc=1
+```
+
+**Route 4 — the byte-perfect path is parsed as a pathspec expression, not a filename** (the
+SC-13 defect). This route is not reached by corrupting the list; it is reached with a list
+that is already correct. Git parses a pathspec's leading characters as *magic* before any
+matching occurs, so a repo-root path whose first byte is `:` names no file. Measured in a
+repository where the correct answer is `rc=1` in every row:
+
+```
+bare pathspec
+  :root.txt        rc=0   <- parsed as magic, matched NOTHING
+  :(glob)g.txt     rc=0   <- parsed as long-form :(glob) magic + path g.txt
+  :!bang.txt       rc=1   but as EXCLUDE magic -- the comparison is inverted, not matched
+  :^caret.txt      rc=1   but as EXCLUDE magic -- likewise
+  dir/:nested.txt  rc=1   safe (the colon is not the pathspec's first byte)
+  mid:colon.txt    rc=1   safe
+
+--literal-pathspecs -- all six matched as literal filenames, all rc=1
+```
+
+The two EXCLUDE rows are the subtle ones: `:!x` and `:^x` do not merely fail to match, they
+turn that element into a *negative* pathspec, so the probe ends up comparing everything
+*except* the file it needed to check. In a composed scenario with an identical sibling file
+present, that inversion yields `rc=0` and a merged false positive.
+
+The interpretation axis has exactly one open symbol class. Glob metacharacters and
+backslashes were measured to round-trip correctly even under a bare pathspec, because git's
+matcher attempts a literal comparison in addition to wildmatch — so a file literally named
+`*star.txt` is matched by the pathspec `*star.txt`. Measured in a repository where every
+glob-matchable sibling is held identical on both branches (so a spurious match cannot mask
+the result) and the correct answer is `rc=1` in every row:
+
+```
+path           bare       literal
+*star.txt      rc=1       rc=1
+?q.txt         rc=1       rc=1
+[a]x.txt       rc=1       rc=1
+a\b.txt        rc=1       rc=1
+:lead.txt      rc=0       rc=1     <- the only class the bare form leaves open
+```
+
+A leading `:` was therefore the only symbol class still open, and `--literal-pathspecs`
+closes it by disabling *all* pathspec magic rather than by enumerating hazardous symbols.
+That distinction is what makes this an axis closure rather than a fifth point patch.
+
+**Route 5 — the path list is correct and the comparison is configured not to notice** (the
+SC-14 and SC-15 defects). This route is not reached by damaging the list in any way. The list
+is complete, byte-perfect, and matched literally, and `git diff --quiet` still reports
+equality — because equality is decided under the repository's diff configuration, and that
+configuration can be narrowed.
+
+**Twenty-two configuration keys, attribute forms, and environment settings were measured**
+against an ordinary-file sharp scenario: `feat` adds `f.dat` plus `plain.txt`; `main`
+squash-merges so S3 and S4 both fire, then overwrites `f.dat` with genuinely different
+content. Required `notmerged` in every row; `MERGED` marks a configuration that makes the
+unpatched comparison report equality on a correct path list.
+
+```
+probe                                verdict   affects?
+diff.algorithm=histogram             keep      no
+diff.algorithm=patience              keep      no
+diff.algorithm=minimal               keep      no
+diff.autoRefreshIndex=false          keep      no
+core.fileMode=false                  keep      no      (affects the index, not tree-to-tree)
+core.symlinks=false                  keep      no
+diff.noprefix=true                   keep      no
+diff.renames=copies                  keep      no
+core.autocrlf=true                   keep      no      (filters do not apply tree-to-tree)
+diff.suppressBlankEmpty=true         keep      no
+diff.wsErrorHighlight=all            keep      no
+diff.context=0                       keep      no
+core.quotePath=false                 keep      no
+gitattr  f.dat -diff (binary marker) keep      no
+gitattr  f.dat binary  macro         keep      no
+gitattr  f.dat filter= clean/smudge  keep      no      (blobs are already clean)
+gitattr  f.dat text eol=lf +autocrlf keep      no
+gitattr  f.dat diff=x + diff.x.textconv   MERGED  YES  <- member 1
+diff.x.cachetextconv=true            MERGED    YES     (same member, not a distinct one)
+diff.ignoreSubmodules=all            keep      no      <- see the scope note below
+external diff driver diff.x.command  keep      no      (see below)
+GIT_EXTERNAL_DIFF env                keep      no      (see below)
+```
+
+**Scope note, and it matters — this sweep cannot find the submodule members.** The fixture
+above contains only ordinary files, and `diff.ignoreSubmodules` and `submodule.<n>.ignore`
+act exclusively on **gitlinks**. Their `keep` rows here mean "not applicable to this
+scenario", not "harmless": measured against a fixture that *does* contain a submodule
+(SC-15), both suppress the change and flip the verdict. Reading this table alone would
+therefore undercount the axis at one member. The honest total is **three members** — one
+found by this sweep and two by SC-15 — and the reason the earlier study's equivalent table
+recorded `diff.ignoreSubmodules` as a member is that it evaluated that row against a
+submodule fixture rather than a file one. A future sweep of this axis must vary the *object
+kind* (file, symlink, gitlink) as well as the configuration, or it will keep missing members
+of exactly this shape.
+
+The external-diff result is worth stating precisely, because it looked like a likely fourth
+member and is not one. The driver **does** run on the ordinary diff path, but `--quiet`
+short-circuits before consulting it:
+
+```
+git diff feat main -- f.dat                            # driver runs, prints its output
+git --literal-pathspecs diff --quiet feat main -- f.dat   rc=1   <- correct; driver never consulted
+```
+
+This is the same asymmetry as textconv in the opposite direction, and together the two bound
+what was probed: of everything measured — the twenty-two-probe file sweep above plus the
+submodule fixture — **exactly one member is comparison-side only** (textconv) and **two are
+dual-stage** (the submodule keys). The three members and their stage classification:
+
+```
+member                                    enumeration   comparison   closed by
+.gitattributes diff=X + diff.X.textconv    unaffected    SUPPRESSED   --no-textconv
+diff.ignoreSubmodules=all                  SUPPRESSED    SUPPRESSED   --ignore-submodules=none
+submodule.<name>.ignore=all                SUPPRESSED    SUPPRESSED   --ignore-submodules=none
+```
+
+Measured for member 1 (textconv), on two genuinely different blobs — note the name-listing
+path is **not** fooled, which is what makes it comparison-side only:
+
+```
+git diff --name-only            feat main -- report.pdf  ->  report.pdf              (still reported)
+git diff --name-status          feat main -- report.pdf  ->  M  report.pdf           (still reported)
+git diff --quiet                feat main -- report.pdf  ->  rc=0   <- ONLY this is fooled
+git diff --quiet --no-textconv  feat main -- report.pdf  ->  rc=1
+```
+
+Measured for members 2 and 3 (submodule ignore), which suppress one stage earlier as well:
+
+```
+git diff --no-renames --name-only -z <mb> feat                        ->  ['plain.txt']
+git diff --ignore-submodules=none --no-renames --name-only -z <mb> feat -> ['plain.txt','sub']
+comparison without --ignore-submodules=none, given the correct list   ->  rc=0
+comparison with    --ignore-submodules=none, given the correct list   ->  rc=1
+```
+
+Two properties make this route nastier than its four predecessors. Both values are read from
+the **checked-out worktree** rather than from the trees under comparison, so the verdict
+depends on checkout state — deleting the worktree's `.gitattributes` makes SC-14's false
+positive vanish while the file remains committed and tracked. And `submodule.<name>.ignore`
+is readable from `.gitmodules`, a **tracked** file, so unlike every other member of every
+axis this exposure can be shipped inside a repository with no operator configuration at all.
+
+**Route 6 — the comparison is replaced by something that cannot see a file's mode** (the P3c
+and P4c defects). This route is **not open** in the specified mechanism: `git diff` compares
+modes. It is recorded because the natural-looking repair for route 5 — comparing blob object
+IDs, which no diff configuration can influence — opens it. A symlink and a regular file whose
+content is exactly the symlink's target share **one blob OID**, and a `chmod` changes no
+content at all:
+
+```
+P3c   feat 100755 blob 587be6b4…  x.txt      main 100644 blob 587be6b4…  x.txt
+P4c   feat 100644 blob 1de56593…  link.txt   main 120000 blob 1de56593…  link.txt
+
+git diff comparison   ->  rc=1   detects both
+blob-OID comparison   ->  EQUAL  misses both
+```
+
+Unlike every member of route 5, this failure needs **no configuration whatsoever** — no
+`.gitattributes`, no config key, no tracked directive. It is therefore a strictly worse
+exposure than the one it would be adopted to fix, which is why `spec.md` §2 records the
+OID-comparison hybrid as weighed and rejected, and why AC-WSM-017 pins these two rows against
+a future mechanism swap.
+
+The second block of route 3 is the one that matters most for a future reader:
+**`core.quotePath=false` is not a fix.** It silences the non-ASCII half of the hazard and leaves the backslash and
+control-character halves intact, so a repair phrased as "set `core.quotePath=false`" would
+close part of the hole while reading as though it closed all of it. Only `-z` removes the
+round-trip hazard for every byte, under every configuration.
+
+The implementation consequence is stated in `plan.md` §D: the Go code builds `names` by
+splitting `git diff --ignore-submodules=none --no-renames --name-only -z` output on `\x00`
+(never on `\n`), passes it as a `[]string` argument list to the exec helper without ever
+reconstructing a shell string, and issues the comparison as
+`git --literal-pathspecs diff --quiet --no-textconv --ignore-submodules=none …`. The shell
+snippets in this document use `-z` with `read -r -d ''` into an array, `--literal-pathspecs`
+before the subcommand, and `--no-textconv --ignore-submodules=none` after it, for all six
+reasons.
+
+Raw output retained for the three must-keep rows:
+
+```
+### SC-6 partial
+  raw plain cherry : - cbac4fc9510a788dcbee90aab3bcbd987e3c4ebe | + c24465c5613dc4ce1f6bf9593bf29b4a17929385
+  raw synth cherry : + 8c7d8354af073122424d401e43b42ec26b62a1cb
+  state conjunct   : NO
+
+### SC-7 unmerged
+  raw plain cherry : + f23f4eb6e1a07d17defd9a302665b496fbed845d
+  raw synth cherry : + ab9244e7372d4f57f996a13a59d8ed2b4d555a81
+  state conjunct   : NO
+
+### SC-8 revert
+  raw plain cherry : - 616bf026a585f183d8c49ec58de025fb68fc4d15 | - fb4444864adbdc8bed6c4f61bd35d172551c4054
+  raw synth cherry : + 4636d524ebeb559c3b41ae48cb48804d2a5fa17a
+  state conjunct   : NO
+```
+
+SC-8 is the load-bearing row: both plain-cherry lines are `-`, so the S3 guard is satisfied
+and a history-only predicate returns merged while `b.txt` is absent from base HEAD.
+
+### §C.1 Mutation table (which mutation actually falsifies which row)
+
+Executed by simulating the predicate under each mutation, one freshly constructed
+repository per cell. This table is the authority for the falsification procedures in §D —
+an untested falsification is how an earlier iteration shipped a guard that could not be
+falsified by its own stated procedure.
+
+Verbatim output (iteration-6 re-run at **11 mutations × 17 scenarios**, every one of the 187
+cells freshly executed; the seven prior mutations reproduce the iteration-5 record on the
+columns it carried, and `no-textconv`, `no-ignoresub-cmp`, `no-ignoresub-enum`, and
+`oid-only-cmp` are the new rows). The grid runs across the full scenario set, so a mutation's
+blast radius is visible on every row rather than only on the rows it was expected to touch:
+
+```
+mutation           sc1    sc2    sc3    sc4    sc5    sc6    sc7    sc8    sc9    sc10   sc11   sc12   sc13   sc14   sc15   p3c    p4c
+baseline           MERGED MERGED MERGED MERGED MERGED keep   keep   keep   MERGED keep   keep   keep   keep   keep   keep   keep   keep
+weak-guard         MERGED MERGED MERGED MERGED MERGED keep   keep   keep   MERGED keep   keep   keep   keep   keep   keep   keep   keep
+no-state           MERGED MERGED MERGED MERGED MERGED keep   keep   MERGED MERGED MERGED MERGED MERGED MERGED MERGED MERGED MERGED MERGED
+both               MERGED MERGED MERGED MERGED MERGED MERGED MERGED MERGED MERGED MERGED MERGED MERGED MERGED MERGED MERGED MERGED MERGED
+folded-names       MERGED MERGED MERGED MERGED MERGED keep   keep   keep   MERGED MERGED MERGED keep   keep   keep   keep   keep   keep
+newline-split      MERGED MERGED MERGED MERGED MERGED keep   keep   keep   MERGED keep   keep   MERGED keep   keep   keep   keep   keep
+no-literal         MERGED MERGED MERGED MERGED MERGED keep   keep   keep   MERGED keep   keep   keep   MERGED keep   keep   keep   keep
+no-textconv        MERGED MERGED MERGED MERGED MERGED keep   keep   keep   MERGED keep   keep   keep   keep   MERGED keep   keep   keep
+no-ignoresub-cmp   MERGED MERGED MERGED MERGED MERGED keep   keep   keep   MERGED keep   keep   keep   keep   keep   MERGED keep   keep
+no-ignoresub-enum  MERGED MERGED MERGED MERGED MERGED keep   keep   keep   MERGED keep   keep   keep   keep   keep   MERGED keep   keep
+oid-only-cmp       MERGED MERGED MERGED MERGED MERGED keep   keep   keep   MERGED keep   keep   keep   keep   keep   keep   MERGED MERGED
+```
+
+Blast radius per mutation, restricted to the must-keep rows (computed from the grid above
+rather than asserted):
+
+```
+weak-guard         -> (none)
+no-state           -> sc8 sc10 sc11 sc12 sc13 sc14 sc15 p3c p4c
+both               -> sc6 sc8 sc10 sc11 sc12 sc13 sc14 sc15 p3c p4c
+folded-names       -> sc10 sc11
+newline-split      -> sc12
+no-literal         -> sc13
+no-textconv        -> sc14
+no-ignoresub-cmp   -> sc15
+no-ignoresub-enum  -> sc15
+oid-only-cmp       -> p3c p4c
+```
+
+**The SC-1..SC-13 columns are cell-for-cell identical to the iteration-5 grid** across every
+mutation that grid carried, so the two new flags and the four new scenarios regress nothing.
+The four new mutation rows leave all thirteen original columns unchanged, which is the
+evidence the flags are additive rather than behaviour-altering.
+
+**Correction to the iteration-4 grid.** That grid's `folded-names` row recorded `sc12` as
+`MERGED`, which contradicted its own summary table and the prose immediately below it (both
+of which said `keep`, and the criterion's rationale depends on `keep`). Re-measured here, the
+correct value is **`keep`**: `folded-names` retains `-z`, so SC-12's path arrives unquoted
+and S5 still withholds. The `MERGED` cell was a transcription of the *`folded-B`* variant
+(rename detection on **and** `-z` dropped) into a row labelled for the `-z`-retaining one —
+the same conflation N9 identifies in AC-WSM-006's falsification wording, surfacing a second
+time in the grid itself. Both are corrected in this revision, and the row label now states
+`-z` **retained** explicitly.
+
+The must-keep rows are SC-6, SC-7, SC-8, SC-10 through SC-15, P3c, and P4c; the remaining six
+are must-merge and read `MERGED` under every mutation, which is the sanity check on the grid
+— the mutations narrow the predicate rather than break it outright. Restricted to the
+must-keep columns plus SC-2 (the rebase row most at risk of regression); `M` = MERGED,
+`k` = keep, and a **bold** `M` marks a flip from baseline:
+
+| Mutation | SC-2 | SC-6 | SC-7 | SC-8 | SC-10 | SC-11 | SC-12 | SC-13 | SC-14 | SC-15 | P3c | P4c |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| baseline (as designed) | M | k | k | k | k | k | k | k | k | k | k | k |
+| `weak-guard` — S3 accepts *any* `-` line instead of *every* | M | k | k | k | k | k | k | k | k | k | k | k |
+| `no-state` — drop the S5 conjunct | M | k | k | **M** | **M** | **M** | **M** | **M** | **M** | **M** | **M** | **M** |
+| `both` — drop S5 *and* accept any **non-empty** cherry output | M | **M** | **M** | **M** | **M** | **M** | **M** | **M** | **M** | **M** | **M** | **M** |
+| `folded-names` — enumerate with `--name-only -z` (rename detection on, **`-z` retained**) | M | k | k | k | **M** | **M** | k | k | k | k | k | k |
+| `newline-split` — enumerate with `--no-renames --name-only` (no `-z`) and split on `\n` | M | k | k | k | k | k | **M** | k | k | k | k | k |
+| `no-literal` — enumeration unchanged; drop `--literal-pathspecs` from the comparison | M | k | k | k | k | k | k | **M** | k | k | k | k |
+| `no-textconv` — enumeration unchanged; drop `--no-textconv` from the comparison | M | k | k | k | k | k | k | k | **M** | k | k | k |
+| `no-ignoresub-cmp` — drop `--ignore-submodules=none` from the **comparison** only | M | k | k | k | k | k | k | k | k | **M** | k | k |
+| `no-ignoresub-enum` — drop `--ignore-submodules=none` from the **enumeration** only | M | k | k | k | k | k | k | k | k | **M** | k | k |
+| `oid-only-cmp` — replace the comparison with a mode-blind blob-OID comparison | M | k | k | k | k | k | k | k | k | k | **M** | **M** |
+
+Note `weak-guard` and `both` relax the cherry guard **differently** — the first accepts any
+`-` line, the second accepts any non-empty output — so `both` is not the composition of
+`weak-guard` and `no-state`. SC-7 is the cell where they diverge: its cherry output is a
+single `+` line, which is non-empty but contains no `-`. A harness that treated `both` as
+`weak-guard` + `no-state` reported SC-7 as `keep` and appeared to contradict this grid; the
+grid is correct and the row definitions here are authoritative over the row *names*.
+
+Eight consequences, which together fix the falsification procedures in §D:
+
+- Dropping S5 alone flips **only SC-8** among the original four. That makes `no-state` the
+  precise, minimal falsification for the revert criterion.
+- Under the conjunct design, weakening the cherry guard alone no longer flips SC-6 or
+  SC-7 — S5 still withholds. Their falsification therefore requires **both** mutations.
+  A single-mutation procedure for those two would pass without falsifying anything.
+- `folded-names` flips **exactly SC-10 and SC-11** and nothing else — notably **not** SC-12,
+  which is what establishes that the rename axis and the encoding axis are independent. It
+  is therefore the precise, minimal falsification for the rename half of AC-WSM-006, and it
+  is a *different* mutation from `no-state` even though both flip those rows: `no-state`
+  removes the conjunct, `folded-names` leaves the conjunct intact and starves it of the one
+  path it needed to look at. A guard test that only exercised `no-state` would pass with the
+  rename fold still present.
+- `newline-split` flips **exactly SC-12** and nothing else — notably **not** SC-10, SC-11,
+  or SC-13. It is therefore the precise, minimal falsification for the encoding axis of
+  AC-WSM-006.
+- `no-literal` flips **exactly SC-13** and nothing else — notably **not** SC-10, SC-11, or
+  SC-12. It is the precise, minimal falsification for the interpretation axis. Its row is
+  the starkest in the grid: the enumeration is untouched, so every path list is complete and
+  byte-perfect in all thirteen scenarios, and one verdict still flips. That is the whole
+  argument for why the interpretation axis is a separate guard rather than a consequence of
+  the other two.
+- `no-textconv` flips **exactly SC-14** and nothing else — notably **not** SC-15, which
+  establishes that the two comparison-semantics members are independent rather than one
+  effect with two names. It is the precise, minimal falsification for the textconv member.
+  Its row is as stark as `no-literal`'s: every path list in all seventeen scenarios is
+  complete, byte-perfect, and literally matched, and one verdict still flips — this time
+  because git's *answer* about a correct list was wrong rather than the list itself.
+- `no-ignoresub-cmp` and `no-ignoresub-enum` **both flip exactly SC-15, and only SC-15**.
+  This is the one place in the grid where two mutations share a row, and the sharing is the
+  finding rather than a defect in it: `--ignore-submodules=none` is a single guard applied at
+  two stages, and dropping it from either stage alone reproduces the false positive. If the
+  two occurrences were redundant, removing one would leave SC-15 at `keep`. They do not, so
+  both are required. This is why AC-WSM-006's fifth falsification is stated as "remove it
+  from either stage" rather than as two separate procedures.
+- `oid-only-cmp` flips **exactly P3c and P4c** and nothing else. It is the precise, minimal
+  falsification for AC-WSM-017, and it is the only mutation in the grid that does not remove
+  a flag — it swaps the comparison mechanism. It is also the only mutation whose exposure
+  needs no configuration at all: P3c and P4c differ solely in file mode under **default** git
+  settings, so a mode-blind comparison misses them in any repository.
+- **The five targeted repair mutations flip pairwise-disjoint row sets** — `{SC-10, SC-11}`,
+  `{SC-12}`, `{SC-13}`, `{SC-14}`, `{SC-15}` — and the mechanism-swap mutation flips a sixth
+  disjoint set, `{P3c, P4c}`. That disjointness is the evidence that `--no-renames`, `-z`,
+  `--literal-pathspecs`, `--no-textconv`, `--ignore-submodules=none`, and mode sensitivity
+  are six separate guards rather than six spellings of one: applying any five leaves the
+  sixth's scenario failing. It is also why AC-WSM-006 requires all five of its falsifications
+  to be run separately, and why AC-WSM-017 is a distinct criterion rather than a sixth
+  falsification on AC-WSM-006 — its falsification is a mechanism substitution, not a flag
+  removal, and its scenarios pass today.
+- **`no-state` remains a forbidden falsification for both criteria**, and its blast radius is
+  now wider than ever: it flips SC-8 and every one of SC-10 through SC-15, P3c, and P4c. A
+  procedure using it would appear to work while exercising neither the enumeration, nor the
+  comparison's diff semantics, nor its mode sensitivity — it would pass with the rename fold,
+  the newline split, the bare pathspec, the textconv collapse, the submodule suppression, and
+  a mode-blind comparison all still present.
+- SC-2 reads MERGED under every mutation, which is the sanity check on the table: it
+  confirms the mutations are narrowing the predicate rather than breaking it outright.
+
+---
+
+## §D Acceptance Criteria
+
+### Detection correctness
+
+**AC-WSM-001 — squash-merged branch is detected**
+*Given* a repository in scenario SC-1,
+*When* `IsBranchMerged("feat", "main")` is called,
+*Then* it returns `(true, nil)`.
+Run-phase judge: `go test ./internal/core/git/ -run 'IsBranchMerged.*Squash' -count=1 -v`
+**Non-vacuity guard (required).** A `-run` selector matching nothing exits 0 with
+`testing: warning: no tests to run`, which would make this criterion vacuously true.
+Measured against the pre-implementation tree, where the selector matches nothing:
+```
+$ go test ./internal/core/git/ -run 'IsBranchMerged.*Squash' -count=1 -v
+testing: warning: no tests to run
+PASS
+ok  github.com/modu-ai/moai-adk/internal/core/git  0.481s [no tests to run]
+```
+The criterion is judged by reading the `--- PASS:` lines, not the exit code. At least one
+`--- PASS:` line naming a squash-scenario test MUST be present; zero `--- PASS:` lines is a
+FAIL regardless of exit status. Record the observed count alongside the verdict.
+Falsification: delete signal S4 from the predicate; this criterion must then FAIL.
+Binds REQ-WSM-002.
+
+**AC-WSM-002 — rebase-merged branch is detected**
+*Given* a repository in scenario SC-2,
+*When* `IsBranchMerged("feat", "main")` is called,
+*Then* it returns `(true, nil)`.
+Run-phase judge: `go test ./internal/core/git/ -run 'IsBranchMerged.*Rebase' -count=1 -v`
+(non-vacuity discipline per §A. Baseline against the pre-implementation tree: `--- PASS:`
+count 0, `[no tests to run]`.)
+Falsification: delete signal S3; this criterion must then FAIL.
+Binds REQ-WSM-003.
+
+**AC-WSM-003 — empty-diff branch is detected**
+*Given* a repository in scenario SC-5,
+*When* `IsBranchMerged("feat", "main")` is called,
+*Then* it returns `(true, nil)`.
+Run-phase judge: `go test ./internal/core/git/ -run 'IsBranchMerged.*EmptyDiff' -count=1 -v`
+(non-vacuity discipline per §A. Baseline against the pre-implementation tree: `--- PASS:`
+count 0, `[no tests to run]`.)
+Falsification: delete signal S2; this criterion must then FAIL. This is the only scenario
+S2 uniquely covers, so its removal is otherwise silent.
+Binds REQ-WSM-004.
+
+**AC-WSM-004 — reachability cases are not regressed**
+*Given* repositories in scenarios SC-3 and SC-4,
+*When* `IsBranchMerged("feat", "main")` is called for each,
+*Then* both return `(true, nil)`.
+Run-phase judge: `go test ./internal/core/git/ -run 'IsBranchMerged.*Reachab' -count=1 -v`
+(non-vacuity discipline per §A; at least two `--- PASS:` lines expected, one per scenario.
+Baseline against the pre-implementation tree: `--- PASS:` count 0, `[no tests to run]`.)
+Falsification: delete signal S1; SC-3 must then FAIL (SC-4 is also covered by S2, so S1
+removal alone does not falsify it — SC-3 is the load-bearing case here).
+Binds REQ-WSM-005.
+
+**AC-WSM-005 — partially applied and fully unmerged branches are NOT reported merged**
+*Given* repositories in scenarios SC-6 and SC-7,
+*When* `IsBranchMerged("feat", "main")` is called for each,
+*Then* both return `(false, nil)`.
+A false positive on either deletes unmerged work.
+Run-phase judge: `go test ./internal/core/git/ -run 'IsBranchMerged.*(Partial|Unmerged)' -count=1 -v`
+(non-vacuity discipline per §A; at least two `--- PASS:` lines expected, one per scenario.
+Baseline against the pre-implementation tree: `--- PASS:` count 0, `[no tests to run]`.)
+Falsification (both mutations required, per §C.1): drop the S5 conjunct **and** relax S3/S4
+to accept any non-empty `git cherry` output; this criterion must then FAIL for both
+scenarios. Neither mutation alone falsifies it — verified in §C.1, where `weak-guard` and
+`no-state` each leave SC-6 and SC-7 at `keep`. Applying only one mutation and observing a
+still-passing test is not evidence the guard works. Note in particular that "treat empty
+`git cherry` output as merged" does **not** falsify the SC-7 half, because SC-7's cherry
+output is not empty — it is a single `+` line (§C raw output).
+Binds REQ-WSM-006.
+
+> SC-6 and SC-7 were separate criteria through v0.2.0. They are consolidated here because
+> they bind the same requirement and share one falsification procedure verbatim — the same
+> grounds on which AC-WSM-004 already covers SC-3 and SC-4 together. The freed slot is
+> taken by AC-WSM-006 below, which covers a scenario class that had no criterion at all.
+
+**AC-WSM-006 — a branch whose S5 conjunct cannot observe a real difference is NOT reported merged**
+*Given* repositories in scenarios SC-10, SC-11, SC-12, SC-13, SC-14, and SC-15 — in each, a
+path whose state the branch changed is absent from base HEAD, and in each the *only* thing
+that can detect this is S5 actually observing that difference: its path list being complete,
+faithfully encoded, and matched literally, **and its comparison not being narrowed by the
+repository's diff configuration**,
+*When* `IsBranchMerged("feat", "main")` is called for each,
+*Then* all six return `(false, nil)`.
+Run-phase judge:
+`go test ./internal/core/git/ -run 'IsBranchMerged.*(Rename|NonASCII|ColonPath|Textconv|Submodule)' -count=1 -v`
+(non-vacuity discipline per §A; at least six `--- PASS:` lines expected, one per scenario.)
+**The selector was widened at v0.5.0 and again at v0.6.0.** The v0.4.0 form
+`IsBranchMerged.*(Rename|NonASCII)` would not have matched a colon-scenario test, and the
+v0.5.0 form `(Rename|NonASCII|ColonPath)` would not have matched a textconv or submodule
+test — so adding scenarios required widening the selector, not only adding tests. Re-measured
+against the pre-implementation tree (`f5129374b`) in its current form:
+```
+$ go test ./internal/core/git/ -run 'IsBranchMerged.*(Rename|NonASCII|ColonPath|Textconv|Submodule)' -count=1 -v
+testing: warning: no tests to run
+PASS
+ok  	github.com/modu-ai/moai-adk/internal/core/git	0.478s [no tests to run]
+(--- PASS: line count: 0)
+```
+The widened selector is therefore non-vacuous at baseline exactly as the narrower ones were:
+it exits 0 while producing zero `--- PASS:` lines, so it genuinely fails today. §A records
+the regex check confirming the widening is real rather than cosmetic — the v0.5.0 form does
+**not** match `TestIsBranchMerged_TextconvDriverCollapsesChange` or
+`TestIsBranchMerged_SubmoduleIgnoreDirective`.
+
+This is the criterion that pins S5's ability to see what it is asked about, on **all four**
+of its axes. The four scenario groups fail through different mechanisms and no repair fixes
+another:
+
+- **SC-10 / SC-11 (completeness).** The branch renames a path that exists at the
+  merge-base, base takes the branch's work, and base then re-adds the original path, so the
+  branch's *deletion* of that path is absent from base HEAD. An implementation computing
+  S5's list with a plain `git diff --name-only` folds the rename's deleted source path away
+  (§C.2 route 1); S5 then never examines that path, holds vacuously, and the history signal
+  is granted unopposed.
+- **SC-12 (encoding).** The branch adds a non-ASCII path and base removes it after
+  squash-merging, so the branch's content is absent from base HEAD. An implementation
+  splitting the enumeration's output on newline receives that path C-quoted (§C.2 route 3);
+  the quoted rendering matches no file, so S5 compares only the paths that happen to be
+  ASCII, holds vacuously, and the history signal is again granted unopposed.
+- **SC-13 (interpretation).** The branch adds a repo-root path whose first byte is `:` and
+  base removes it after squash-merging. Here the path list is **already correct** — complete
+  and byte-perfect — and the predicate still fails, because git parses a pathspec's leading
+  characters as magic before matching (§C.2 route 4). An implementation that passes the list
+  as a bare pathspec has S5 compare only the paths that happen not to begin with `:`; it
+  holds vacuously and the history signal is granted unopposed a third time.
+- **SC-14 / SC-15 (comparison semantics).** Here the path list is **not** at fault in the way
+  the first three groups are, and the failure is one layer further down. In SC-14 the branch
+  adds a file bound by a `.gitattributes` `diff=<driver>` rule to a `textconv` driver, and
+  base overwrites it after squash-merging; the list is complete and byte-perfect, and
+  `git diff --quiet` still reports equality because it compares the driver's *rendering* of
+  each blob rather than the blobs (§C.2 route 5). In SC-15 the branch moves a submodule
+  pointer with no `.gitmodules` change, and base moves it elsewhere after squash-merging;
+  under a submodule-ignore directive the gitlink is suppressed at **both** stages — dropped
+  from the enumeration so it never reaches the comparison, and ignored by the comparison even
+  when the list is correct. An implementation issuing the comparison under the repository's
+  own diff configuration has S5 hold vacuously and the history signal granted unopposed a
+  fourth and fifth time.
+
+SC-11 through SC-15 are the sharper cases: in all five, **S3 and S4 both fire**, so S5 is the
+only thing preventing a wrong removal. SC-15 is sharper still, being the only scenario in the
+matrix whose exposure a repository can ship to every clone with no operator configuration —
+`submodule.<name>.ignore` is readable from a tracked `.gitmodules`.
+
+Falsification — **five single mutations, all required**, per §C.1:
+
+1. `folded-names` — compute the S5 path list with `git diff --name-only -z`, **retaining
+   `-z`** and changing nothing else, so that only rename detection differs. SC-10 and SC-11
+   must then report merged and this criterion must FAIL.
+2. `newline-split` — keep `--no-renames` but drop `-z` and split the output on `\n` instead
+   of `\x00`, changing nothing else. SC-12 must then report merged and this criterion must
+   FAIL.
+3. `no-literal` — leave the enumeration exactly as specified and drop `--literal-pathspecs`
+   from the S5 comparison, changing nothing else. SC-13 must then report merged and this
+   criterion must FAIL.
+4. `no-textconv` — leave the enumeration exactly as specified and drop `--no-textconv` from
+   the S5 comparison, changing nothing else. SC-14 must then report merged and this criterion
+   must FAIL.
+5. `no-ignoresub` — drop `--ignore-submodules=none` from **either** the comparison **or** the
+   enumeration, changing nothing else. SC-15 must then report merged and this criterion must
+   FAIL. Measured, **each stage alone is sufficient** to reproduce the false positive
+   (§C.1 rows `no-ignoresub-cmp` and `no-ignoresub-enum`), which is the evidence both
+   occurrences are load-bearing rather than one being a copy of the other. Running the
+   comparison-side removal alone is an acceptable discharge of this falsification, but the
+   enumeration-side removal is the more informative of the two, because it is the occurrence
+   a future edit is likelier to delete as duplication.
+
+> The `-z`-retaining clause in falsification 1 is load-bearing and was added at v0.5.0. The
+> earlier wording ("compute the S5 path list with `git diff --name-only` instead of
+> `git diff --no-renames --name-only -z`") drops **both** flags, which is a different
+> mutation: measured, renames-on-with-`-z`-retained flips SC-10 and SC-11 only, while
+> renames-on-with-`-z`-dropped flips SC-10, SC-11 **and** SC-12. An implementer following the
+> earlier wording literally would apply the second and destroy the very disjointness this
+> criterion's rationale rests on. The criterion's discriminating power was never affected —
+> both forms make it FAIL — so this is a precision fix, not a correctness one.
+
+§C.1 confirms each mutation flips **exactly** its own rows and nothing else: `folded-names`
+flips SC-10 and SC-11; `newline-split` flips SC-12; `no-literal` flips SC-13; `no-textconv`
+flips SC-14; and either submodule mutation flips SC-15. Each leaves every other scenario in
+the criterion at `keep`, and all five leave SC-2, SC-6, SC-7, and SC-8 unchanged. That
+disjointness is the reason all five mutations are required: applying only one would leave
+three axes unexercised, and the criterion would pass with a live defect present.
+
+The single deliberate exception is that the two submodule mutations flip the **same** row.
+That is not a disjointness failure — it is the evidence the flag is needed at two stages
+rather than one. If the occurrences were redundant, removing one would leave SC-15 passing.
+
+None of the five falsifications may be `no-state`. Dropping the S5 conjunct entirely flips
+SC-10 through SC-15 (§C.1), so a procedure that used it here would appear to work while never
+exercising the enumeration or the comparison at all — it would pass with the rename fold, the
+newline split, the bare pathspec, the textconv collapse, and the submodule suppression all
+still present. That is the same failure shape as the iteration-1 defect in which a stated
+falsification exercised the wrong half of a guard.
+
+> This criterion absorbed SC-12 at v0.4.0, SC-13 at v0.5.0, and SC-14 and SC-15 at v0.6.0,
+> rather than new criteria being added for each: all bind the same requirement
+> (REQ-WSM-014) through the same conjunct as SC-10 and SC-11, and the criterion's scope has
+> widened correspondingly — from "rename fold" to "path-list integrity" to "path-list
+> round-trip integrity" and now to **"S5 actually observes the difference"**, which is what
+> all six scenarios have in common. SC-15 needed no widening at all: a suppressed gitlink is
+> an under-inclusive path list, the criterion's original scope. SC-14 widened it by one
+> clause, because there the list is perfect and only the comparison is wrong.
+>
+> The cost is that one criterion now carries five falsifications, and §F's Definition of Done
+> requires each to be run separately for exactly that reason. P3c and P4c were **not** folded
+> in as a sixth and seventh scenario, even though the AC budget made that tempting: their
+> claim is different (the comparison must be mode-sensitive), their falsification is a
+> mechanism substitution rather than a flag removal, and they pass under the current design
+> rather than motivating a repair. They are AC-WSM-017. `plan.md` §B records why that
+> decision takes the SPEC one criterion over the Tier M ceiling and why the alternatives
+> were judged worse.
+Binds REQ-WSM-006, REQ-WSM-014.
+
+**AC-WSM-007 — a probe failure surfaces as an error; a verdict-carrying exit does not**
+*Given* the four cases below,
+*When* `IsBranchMerged` is called for each,
+*Then* each yields the stated outcome:
+
+| Case | Call | Expected |
+|---|---|---|
+| unknown base ref | `IsBranchMerged("feat", "no-such-base")` | non-nil error; the boolean is not used as a verdict |
+| unrelated histories (D7) | `IsBranchMerged("orphan", "main")` in a repo whose `orphan` branch shares no ancestor with `main` | `(false, nil)` — kept, no error |
+| branch with a non-empty diff vs merge-base | any of SC-1, SC-2, SC-6, SC-7 | nil error (the `git diff --quiet` rc=1 is a verdict, not a failure) |
+| branch with an empty diff vs merge-base | SC-5 | `(true, nil)` |
+
+Rows 3 and 4 are what make this criterion bind REQ-WSM-007's narrowing rather than its
+earlier over-broad form: a predicate that errors on `git diff --quiet` rc=1 fails row 3,
+and one that errors on `git merge-base` rc=1 fails row 2.
+Authoring-time evidence for the unrelated-histories row (executed):
+```
+git merge-base main orphanb   ->  rc=1, stdout=''
+```
+Run-phase judge: `go test ./internal/core/git/ -run 'IsBranchMerged.*ProbeExit' -count=1 -v`
+(non-vacuity discipline per §A; at least four `--- PASS:` lines expected, one per row of the
+table above. Baseline against the pre-implementation tree: `--- PASS:` count 0,
+`[no tests to run]`.)
+Falsification: swallow the unknown-base probe error and return `false, nil` — row 1 must
+then FAIL; treat any non-zero exit as a failure — rows 2 and 3 must then FAIL.
+Binds REQ-WSM-007.
+
+### Synthetic-object hygiene
+
+**AC-WSM-008 — the synthetic commit is deterministic**
+*Given* a repository in scenario SC-1 whose `feat` branch is unmodified between calls,
+*When* the predicate's synthetic-commit construction runs twice,
+*Then* both runs produce the same object hash and the dangling-commit count increases by
+at most one across both.
+Authoring-time evidence (executed, with identity pinned). The inputs are recorded so the
+value is independently reproducible rather than asserted — the fixture is a two-commit
+repository whose commit dates are pinned to `@1700000001` and `@1700000002`:
+```
+merge-base (parent) = 652f98d4a2806a26a2ad47397c40ed492beec65c
+feat^{tree}         = a822cc2d8c3bf904ac9faf19c2a90fc5fa119727
+message             = moai-squash-probe
+identity            = moai <moai@localhost>, GIT_AUTHOR_DATE=GIT_COMMITTER_DATE=@0 +0000
+
+run1=d4b2e2e11f29a6bdad158f627aad5509ddcaca8f
+run2=d4b2e2e11f29a6bdad158f627aad5509ddcaca8f
+dangling commits after both runs: 1
+```
+The specific hash is a property of those four inputs plus git's commit-object format; an
+implementation choosing a different fixed message or identity will produce a different but
+equally stable value. What the criterion asserts is the **determinism**, not the literal
+digest — a run-phase implementation is judged on `run1 == run2` and on the dangling count
+increasing by at most one, not on matching `d4b2e2e1…`.
+Run-phase judge: `go test ./internal/core/git/ -run 'SyntheticCommit.*Determinis' -count=1 -v`
+(non-vacuity discipline per §A. Baseline against the pre-implementation tree: `--- PASS:`
+count 0, `[no tests to run]`.)
+Falsification: unpin `GIT_COMMITTER_DATE`; the two hashes must then differ and this
+criterion must FAIL.
+Binds REQ-WSM-008.
+
+**AC-WSM-009 — no repository-wide object reclamation**
+*Given* the post-change tree,
+*When* the following runs,
+*Then* it prints `0`:
+```bash
+grep -nE '"(prune|gc)"' internal/core/git/worktree.go | grep -v '"worktree", "prune"' | wc -l
+```
+Two repairs versus the previous iteration, both verified by injection:
+- `-r` is dropped. With `-r`, grep prefixes each line with the path
+  `internal/core/git/worktree.go:`, which itself contains `worktree` — so the old exclusion
+  pattern `worktree.*prune` matched *every* line in the file containing `prune`, swallowing
+  the very calls the guard exists to catch.
+- The exclusion anchors on the literal argument pair `"worktree", "prune"` (the legitimate
+  call at worktree.go:132) rather than a loose `.*`.
+
+Falsification (executed against the baseline tree, then reverted): append
+`func probeInjected() { _, _ = execGit(nil, "", "prune") }` to `worktree.go`, then run both
+judges.
+```
+=== injected bare git prune ===
+--- BROKEN judge (previous iteration) ---   0     <- misses it
+--- REPAIRED judge ---                      1     <- catches it
+--- repaired judge, surviving line ---
+295:func probeInjected() { _, _ = execGit(nil, "", "prune") }
+=== restored ===
+git status --porcelain internal/core/git/worktree.go   -> (empty)
+repaired judge on restored tree                        -> 0
+```
+The falsification uses `git prune`, not `git gc`. `git prune` is the primary prohibition in
+REQ-WSM-009 and the one §5 decision 2 argues at length is hazardous; the previous
+iteration's `git gc` falsification passed while never exercising the broken half of the
+filter.
+Note this is a presence check, not a reachability check; AC-WSM-011's full-suite run is
+what establishes the predicate itself is reached.
+Binds REQ-WSM-009.
+
+### Preserved safety contract
+
+**AC-WSM-010 — the `--stale` two-condition gate is intact**
+*Given* a worktree whose branch is merged but whose working tree has uncommitted or
+untracked changes,
+*When* the `--stale` sweep evaluates it,
+*Then* it is kept and reported, and never removed.
+Run-phase judge: the pre-existing `TestCleanStale_KeepsDirtyWorktree` must pass unchanged.
+```bash
+go test ./internal/cli/worktree/ -run 'TestCleanStale_KeepsDirtyWorktree' -count=1 -v
+```
+**Non-vacuity guard (required).** Read the `--- PASS:` lines, not the exit code: a `-run`
+selector matching nothing exits 0 and would make this criterion vacuously true. Exactly one
+`--- PASS:` line is expected. Observed at baseline (the test exists at
+`internal/cli/worktree/clean_stale_test.go:79`):
+```
+--- PASS: TestCleanStale_KeepsDirtyWorktree (0.00s)
+ok  github.com/modu-ai/moai-adk/internal/cli/worktree  0.372s
+(--- PASS: line count: 1)
+```
+A count of 0 means the test was renamed or removed rather than passing, which is itself the
+regression this criterion exists to catch.
+Falsification: the test's `removeFunc` already fails the test on `force=true`; deleting the
+cleanliness check in `staleKeepReason` must make this criterion FAIL.
+Binds REQ-WSM-010.
+
+**AC-WSM-011 — the interface signature did not change**
+*Given* the post-change tree,
+*When* the following runs,
+*Then* both commands exit 0 with no output:
+```bash
+go build ./... && go vet ./...
+git diff --exit-code -- internal/core/git/types.go
+```
+The second command is the load-bearing one: an unchanged `types.go` is the evidence that
+no test double or call site needed editing, which is the premise of the shared-predicate
+decision (`spec.md` §5 decision 3).
+Falsification: widen the signature; the `git diff --exit-code` must then exit non-zero.
+Binds the §C constraint in `plan.md`.
+
+**AC-WSM-012 — both removal call sites stay non-forced**
+*Given* the post-change tree,
+*When* the following runs,
+*Then* it prints `2`:
+```bash
+grep -cE 'Remove\([A-Za-z_.]+, false\)' internal/cli/worktree/clean.go
+```
+Observed at baseline (executed):
+```
+89:			if err := WorktreeProvider.Remove(wt.Path, false); err != nil
+194:		if err := WorktreeProvider.Remove(c.path, false); err != nil
+count: 2      (the previous iteration's 'Remove(wt.Path, false)' literal counted only 1)
+```
+The pattern matches on the `false` argument independent of the receiver spelling, so a
+rename of the loop variable does not break the criterion, and it pins **both** non-forced
+sites — clean.go:89 (`--merged-only`) and clean.go:194 (`--stale`) — rather than only the
+first.
+Authoring-time evidence that non-forced removal is a real safety net (executed; see also
+AC-WSM-016 for the state it does *not* refuse):
+```
+[modified]        rc=128 present=YES  fatal: '...' contains modified or untracked files, use --force to delete it
+[untracked-only]  rc=128 present=YES  fatal: '...' contains modified or untracked files, use --force to delete it
+```
+Falsification: change either argument to `true`; the count must then drop to 1.
+Binds REQ-WSM-013.
+
+### Regression
+
+**AC-WSM-013 — the pre-existing predicate tests still pass**
+*Given* the post-change tree,
+*When* `go test ./internal/core/git/ -run TestWorktreeIsBranchMerged -count=1 -v` runs,
+*Then* it reports PASS, and the number of test cases run is non-zero.
+The non-zero assertion is required: `go test -run` with a selector matching nothing exits 0,
+which would make this criterion vacuously true. Confirm by reading the `--- PASS:` lines,
+not the exit code alone. Three tests currently match this selector
+(`TestWorktreeIsBranchMerged`, `TestWorktreeIsBranchMerged_NotMerged`,
+`TestWorktreeIsBranchMerged_BranchCheckedOutInWorktree`), so a count below three means
+tests were lost rather than passing.
+Binds REQ-WSM-005.
+
+**AC-WSM-014 — full suite green**
+*Given* the post-change tree,
+*When* `go test ./... -count=1` runs,
+*Then* it exits 0.
+This is a backstop, not a substitute for a per-requirement criterion: a green suite does not
+demonstrate any specific requirement holds unless a test asserts it.
+Binds all requirements.
+
+### State semantic
+
+**AC-WSM-015 — a partially reverted branch is NOT reported merged**
+*Given* a repository in scenario SC-8 — `main` cherry-picked every `feat` commit and then
+reverted one of them, so both plain-`git cherry` lines are prefixed `-` while `b.txt` is
+absent from `main`'s tree,
+*When* `IsBranchMerged("feat", "main")` is called,
+*Then* it returns `(false, nil)`.
+This criterion is what pins the **state** semantic of REQ-WSM-001 against the history
+semantic the patch-id probes implement on their own. Without it, REQ-WSM-001's wording
+("already present in the base branch") admits an implementation that only ever asks whether
+a patch-id once existed in base's history.
+Run-phase judge: `go test ./internal/core/git/ -run 'IsBranchMerged.*Revert' -count=1 -v`
+**Non-vacuity guard (required).** This is the criterion that pins the entire state
+semantic, so a vacuous pass here is the most costly of any in this document. The selector
+matches nothing against the pre-implementation tree and exits 0:
+```
+$ go test ./internal/core/git/ -run 'IsBranchMerged.*Revert' -count=1 -v
+testing: warning: no tests to run
+PASS
+ok  github.com/modu-ai/moai-adk/internal/core/git  0.204s [no tests to run]
+```
+The criterion is judged by reading the `--- PASS:` lines, not the exit code. At least one
+`--- PASS:` line naming a revert-scenario test MUST be present; zero `--- PASS:` lines is a
+FAIL regardless of exit status. Record the observed count alongside the verdict.
+Authoring-time evidence (executed):
+```
+main tree      : a.txt seed.txt
+feat tree      : a.txt b.txt seed.txt
+plain cherry   : - 616bf026a585f183d8c49ec58de025fb68fc4d15 | - fb4444864adbdc8bed6c4f61bd35d172551c4054
+names(mb..feat): a.txt b.txt
+state probe    : git diff --quiet feat main -- a.txt b.txt  ->  rc=1
+```
+Falsification (single mutation, per §C.1): drop the S5 conjunct from S3 and S4. SC-8 must
+then report merged and this criterion must FAIL. §C.1 confirms this `no-state` mutation is
+the **only** one of the five that flips SC-8: `weak-guard` and `folded-names` both leave it
+at `keep`. So a passing AC-WSM-005 alongside a failing AC-WSM-015 is the expected signature
+of exactly this defect.
+Note that `no-state` also flips SC-10 and SC-11 (§C.1), so AC-WSM-006 fails under it too.
+That is expected — removing the conjunct defeats every scenario the conjunct protects — and
+it is why AC-WSM-006 uses `folded-names` rather than `no-state` as *its* falsification:
+only `folded-names` isolates the enumeration from the conjunct.
+Binds REQ-WSM-001, REQ-WSM-014.
+
+### `--stale` sweep constraints
+
+**AC-WSM-016 — the sweep deletes no branch and performs nothing without `--yes`**
+*Given* the post-change tree,
+*When* the two checks below run,
+*Then* both hold:
+
+1. No branch-deletion call exists on the sweep path:
+```bash
+grep -cE 'DeleteBranch|"branch", "-[dD]"' internal/cli/worktree/clean.go
+```
+   must print `0`. Observed at baseline: `0`.
+2. The preview/apply split is asserted by tests that actually run:
+```bash
+go test ./internal/cli/worktree/ -run 'TestCleanStale_PreviewsByDefault|TestCleanStale_RemovesWithYes' -count=1 -v
+```
+   must report PASS for **both** named tests. Read the `--- PASS:` lines, not the exit code:
+   a `-run` selector matching nothing exits 0 and would make this vacuous. Observed at
+   baseline:
+```
+--- PASS: TestCleanStale_PreviewsByDefault (0.00s)
+--- PASS: TestCleanStale_RemovesWithYes (0.00s)
+ok  	github.com/modu-ai/moai-adk/internal/cli/worktree	3.487s
+```
+Falsification: add a branch-deletion call to `clean.go` — check 1 must then exceed `0`;
+make the sweep remove without `--yes` — `TestCleanStale_PreviewsByDefault` must then FAIL.
+Known gap this criterion does **not** cover: a clean worktree whose branch carries unpushed
+commits is removed without objection (`rc=0`, directory gone), and `git status --porcelain`
+reports it clean. That case is accepted with the branch-retention mitigation and recorded in
+`spec.md` §5 decision 3 and §4 Out of Scope — unpushed-commit detection. Check 1 above is
+what keeps the mitigation true.
+Binds REQ-WSM-011, REQ-WSM-012.
+
+### Comparison mode-sensitivity
+
+**AC-WSM-017 — a branch whose only divergence is a file mode is NOT reported merged**
+*Given* repositories in scenarios P3c and P4c — in P3c the branch chmods a file to 755 and
+base chmods it back; in P4c the branch replaces a symlink with a regular file whose content
+is exactly the symlink's target, and base restores the symlink. In both, the two sides share
+**one blob OID** and differ only in mode,
+*When* `IsBranchMerged("feat", "main")` is called for each,
+*Then* both return `(false, nil)`.
+Run-phase judge: `go test ./internal/core/git/ -run 'IsBranchMerged.*(ModeOnly|SymlinkFile)' -count=1 -v`
+(non-vacuity discipline per §A; at least two `--- PASS:` lines expected, one per scenario.)
+Measured against the pre-implementation tree (`f5129374b`):
+```
+$ go test ./internal/core/git/ -run 'IsBranchMerged.*(ModeOnly|SymlinkFile)' -count=1 -v
+testing: warning: no tests to run
+PASS
+ok  	github.com/modu-ai/moai-adk/internal/core/git	0.313s [no tests to run]
+(--- PASS: line count: 0)
+```
+
+**This criterion pins a property the specified mechanism already has.** `git diff` compares
+file modes, so both scenarios pass as designed — no flag is added for them and no repair is
+required. It exists because the property is invisible in the mechanism's spelling and is
+exactly what the most plausible future "improvement" would discard. Authoring-time ground
+truth (executed):
+```
+P3c   feat 100755 blob 587be6b4c3f93f93c489c0111bba5596147a26cb  x.txt
+      main 100644 blob 587be6b4c3f93f93c489c0111bba5596147a26cb  x.txt
+P4c   feat 100644 blob 1de565933b05f74c75ff9a6520af5f9f8a5a2f1d  link.txt
+      main 120000 blob 1de565933b05f74c75ff9a6520af5f9f8a5a2f1d  link.txt
+
+git --literal-pathspecs diff --quiet --no-textconv --ignore-submodules=none …  rc=1  detects
+blob-OID-only comparison over the same paths                                   EQUAL misses
+```
+
+Three properties make this worth a criterion of its own rather than a note:
+
+- **The exposure it guards against needs no configuration.** Every member of the
+  comparison-semantics axis requires non-default state — a committed `.gitattributes`, a
+  committed `.gitmodules` directive, or an operator config key. A mode-blind comparison
+  misses P3c and P4c in **any** repository under **default** git settings. It would be the
+  worst exposure in the SPEC.
+- **The swap it guards against is attractive, not careless.** Comparing blob object IDs is
+  the natural answer to the comparison-semantics axis — content hashes cannot be narrowed by
+  diff configuration — and it was formally proposed and studied. `spec.md` §2 records why it
+  was rejected; this criterion is what makes the rejection enforceable rather than advisory.
+- **Two of the three candidate mechanisms cannot satisfy it even in principle.**
+  `git rev-parse <rev>:<path>` returns an OID and nothing else, and
+  `git cat-file --batch-check` rejects the `%(objectmode)` atom outright, so neither can
+  report a mode. `cat-file` additionally reports `missing` for a gitlink on both sides at
+  exit 0, making two different submodule pointers compare equal.
+
+Falsification (single mutation, per §C.1): replace the S5 comparison with a mode-blind
+blob-OID comparison — two `git ls-tree -r -z --full-tree` maps keyed by path, storing only
+the OID and discarding the mode, compared over the enumerated names. P3c and P4c must then
+report merged and this criterion must FAIL. §C.1's `oid-only-cmp` row confirms this mutation
+flips **exactly** P3c and P4c and leaves all fifteen other scenarios unchanged.
+
+This falsification may **not** be `no-state`. Dropping the S5 conjunct also flips P3c and P4c
+(§C.1), so a procedure using it would pass with a mode-blind comparison still present — the
+same substitution error §D forbids for AC-WSM-006, one layer further down.
+
+> This criterion takes the SPEC to 17 acceptance criteria against a Tier M ceiling of 16.
+> The overage is declared rather than absorbed: folding P3c and P4c into AC-WSM-006 would
+> leave that criterion carrying eight scenarios and six falsifications, and merging two
+> unrelated criteria elsewhere to free a slot would break the commitment recorded at v0.4.0
+> that no consolidation would be manufactured to create one. `plan.md` §B carries the full
+> reasoning and the recommendation to tier up to L.
+Binds REQ-WSM-006, REQ-WSM-014.
+
+---
+
+## §E Quality Gates
+
+| Gate | Threshold |
+|---|---|
+| `go build ./...` | exit 0 |
+| `go vet ./...` | exit 0, no findings |
+| `golangci-lint run` | no new findings versus the pre-change baseline |
+| `go test ./... -count=1` | exit 0 |
+| `internal/core/git` coverage | not below the pre-change measured baseline |
+
+The coverage gate is expressed as a delta against a baseline measured at run-phase start,
+not against a remembered number. Measure it, record the command and its output, then
+compare.
+
+---
+
+## §F Definition of Done
+
+- [ ] AC-WSM-001 through AC-WSM-017 each PASS, with the judging command and its observed
+      output recorded. Every criterion names one: AC-WSM-001 through AC-WSM-008 plus
+      AC-WSM-010, AC-WSM-013, AC-WSM-015, AC-WSM-016 check 2 and AC-WSM-017 are judged by a
+      `go test -run` selector (thirteen distinct selectors, enumerated with their baseline
+      counts in §A); AC-WSM-009, AC-WSM-011, AC-WSM-012 and AC-WSM-016 check 1 are judged
+      by a shell command; AC-WSM-014 is the full-suite backstop.
+- [ ] For every criterion judged by a `go test -run` selector, the observed `--- PASS:`
+      line count is recorded and is non-zero (§A non-vacuity discipline). An exit code
+      alone is not an accepted verdict for any of them.
+- [ ] Each falsification procedure was performed for the guard criteria (AC-WSM-005,
+      AC-WSM-006, AC-WSM-008, AC-WSM-009, AC-WSM-015, AC-WSM-017), and each made its
+      criterion FAIL as stated. For AC-WSM-005 this means applying **both** mutations named
+      in §C.1 — a single mutation leaves it passing and proves nothing. For AC-WSM-006 it
+      means all **five** of `folded-names` (with `-z` retained), `newline-split`,
+      `no-literal`, `no-textconv`, and `no-ignoresub` (from either stage), each run
+      separately, and **not** `no-state`: the mutations flip disjoint row sets, so any one
+      alone leaves three axes unexercised. For AC-WSM-017 it means `oid-only-cmp`, and
+      **not** `no-state`.
+- [ ] The seventeen-scenario oracle in §C is reproduced by the test suite, one case per row,
+      including SC-8 (partially reverted), SC-9 (superset), SC-10 / SC-11 (rename +
+      re-add), SC-12 (non-ASCII path removed from base), SC-13 (leading-colon path removed
+      from base), SC-14 (textconv driver), SC-15 (submodule pointer under an ignore
+      directive), P3c (mode-only divergence), and P4c (symlink/file blob-OID collision). Per
+      the §B construction notes: the SC-12 fixture sets `core.quotePath true` explicitly; the
+      SC-13 fixture stages and removes its hazard path under `git --literal-pathspecs`; the
+      SC-14 fixture keeps `.gitattributes` in the **worktree** as well as committed, with an
+      executable textconv script at an absolute path; the SC-15 fixture moves the submodule
+      pointer **without touching `.gitmodules`** and places the ignore directive inside the
+      tracked `.gitmodules`; and the P4c fixture writes the symlink target with **no trailing
+      newline**, so both sides genuinely share one blob OID.
+- [ ] The S5 path list is computed with `--ignore-submodules=none --no-renames --name-only -z`,
+      split on `\x00` (never on `\n`), and passed to the exec helper as a `[]string`, never
+      as a joined shell string (§C.2 routes 1-3, 5). `core.quotePath=false` is not accepted
+      as a substitute for `-z`, and the enumeration-side `--ignore-submodules=none` is not
+      accepted as redundant with the comparison-side one.
+- [ ] The S5 comparison is issued as
+      `git --literal-pathspecs diff --quiet --no-textconv --ignore-submodules=none …`, with
+      `--literal-pathspecs` **before** the subcommand and the other two **after** it (§C.2
+      routes 4-5). Every misplacement exits 129 rather than producing a verdict, so a
+      position error is loud. `GIT_LITERAL_PATHSPECS=1` via the per-call environment hook is
+      an accepted equivalent for the first; a per-element `:(literal)` prefix is **not**
+      accepted, because it re-introduces the per-path string transformation that has failed
+      on three of the four round-trip axes.
+- [ ] The S5 comparison remains **mode-sensitive**. `git diff` satisfies this; a blob-OID
+      comparison built on `git rev-parse <rev>:<path>`, `git cat-file --batch-check`, or an
+      `ls-tree` map storing only the OID does **not**, and turns P3c and P4c into silent
+      false positives under default git configuration (§C.2 route 6). If a future change ever
+      requires an OID-based comparison, it must carry the file **mode** alongside the OID.
+- [ ] Every git invocation in the predicate runs with its **working directory at the
+      repository root** — `execGit`'s `dir` argument is `w.root`, i.e. `rev-parse
+      --show-toplevel`. The S5 enumeration emits root-relative paths while the comparison's
+      pathspecs resolve against the process cwd, so a nested cwd makes every path an
+      unmatched pathspec and S5 fails open (finding 5). `--literal-pathspecs` disables the
+      `:(top)` remedy, so this must hold at the invocation level; the argument vector alone
+      does not carry it.
+- [ ] No git invocation on the predicate's path is routed through a shell. Verified by the
+      `plan.md` §D grep, which returns no match; a shell would re-open the argv axis and
+      fail silently in the merged direction.
+- [ ] `types.go` is unmodified.
+- [ ] No `git prune` or `git gc` invocation was introduced.
+- [ ] The `@MX:ANCHOR` recording why reachability is retained alongside the patch-id probes
+      is present on the predicate.

--- a/.moai/specs/SPEC-WORKTREE-SQUASH-MERGE-001/plan.md
+++ b/.moai/specs/SPEC-WORKTREE-SQUASH-MERGE-001/plan.md
@@ -1,0 +1,575 @@
+# Implementation Plan — SPEC-WORKTREE-SQUASH-MERGE-001
+
+> Tier M. Milestones are ordered by decision-reversibility: the predicate's signal set and
+> its interface shape come first because they are the decisions most likely to change under
+> review; test scaffolding and documentation follow.
+
+---
+
+## §A Context
+
+`IsBranchMerged` answers a reachability question (`git branch --merged`) while its two
+callers need an equivalence question ("is this branch's work already in base?"). Under a
+squash-merge workflow the two diverge permanently. Full root cause, the executed detector
+matrix, and the four resolved scope decisions are in `spec.md` §1, §2, and §5.
+
+---
+
+## §B Tier Classification and Reasoning
+
+**Assigned Tier: M** (artifact set: `spec.md` + `plan.md` + `acceptance.md`, plus
+`progress.md`).
+
+The mechanical thresholds alone would suggest Tier S: the change is one production
+function in one file, well under 300 LOC, and — because the interface signature is
+unchanged — it touches no test doubles and no call sites. Tier M is assigned on the
+implementer-judgment clause of the Tier rule, for two reasons:
+
+1. The function gates a **bulk directory-deletion** command. A false positive destroys
+   unmerged user work with no undo. The behaviour therefore needs a separately reviewable
+   acceptance matrix rather than criteria folded into `spec.md` §3.
+2. The correctness argument rests on a seventeen-scenario × five-signal matrix, each cell of
+   which must be independently verifiable. Inlining that into `spec.md` §3 would obscure
+   both the requirements and the criteria.
+
+### The AC budget is exceeded at v0.6.0 — declared, not absorbed
+
+**This SPEC now carries 14 requirements and 17 acceptance criteria. The Tier M ceiling is 16
+of each, so the criterion budget is over by one.** That is stated here rather than engineered
+away, because both available ways of hitting 16 are worse than the overage:
+
+- **Cramming.** The four new scenarios could be forced into existing criteria. SC-14 and
+  SC-15 genuinely belong in AC-WSM-006 and are placed there — SC-15 is literally an
+  under-inclusive path list, which is that criterion's original scope, and SC-14 widens it by
+  one clause. But P3c and P4c are a different claim (the comparison must be mode-sensitive)
+  whose falsification is a mechanism swap rather than a flag removal, and folding them in
+  would leave AC-WSM-006 carrying eight scenarios and six falsifications. The ceiling exists
+  because an over-budget SPEC "lands hardest on the plan-auditor, which must hold every
+  requirement and criterion in view at once" — and a single criterion carrying six
+  falsifications loads the auditor *more* than a seventeenth criterion does. Cramming defeats
+  the ceiling's own purpose.
+- **Manufacturing a consolidation.** Two criteria elsewhere could be merged to free a slot;
+  AC-WSM-013 and AC-WSM-014 are the plausible pair, since the full-suite judge strictly
+  contains the pre-existing-predicate-tests judge. But this SPEC committed at v0.4.0 that
+  "no consolidation elsewhere freed a slot, and **none was manufactured to create one**", and
+  the consolidations it has performed (AC-WSM-004, AC-WSM-005) each met a stated test: same
+  requirement, shared falsification. AC-WSM-013 and AC-WSM-014 meet neither. Breaking that
+  commitment to hit a number is the same class of move as the closure sentence this revision
+  deletes — optimising the artifact's appearance against its own recorded standard.
+
+**The correct disposition is a tier-up to L** (ceiling 25/25). The judgment clause that
+carried this SPEC from Tier S to Tier M applies again unchanged in kind and larger in degree:
+the correctness argument is now five failure axes, eight guards, seventeen scenarios, a
+187-cell mutation grid, six audit iterations, and two commissioned empirical studies. The
+implementation is still one function in one file, so the mechanical thresholds still say
+Tier S — the same mismatch §B already resolves by judgment.
+
+**The tier-up is deliberately NOT taken in this revision**, and the reason is scope rather
+than disagreement. Tier L's artifact set is five files, adding `design.md` and `research.md`.
+Producing those honestly means relocating the axis map, the guard inventory, and the
+rejected-alternatives record out of `spec.md` §2 — a restructure of content that six audit
+iterations have verified in place, on a revision whose stated worst outcome is a regression
+in the SC-1..SC-13 rows. Creating two thin files that merely cross-reference §2 would satisfy
+the count while duplicating the content, which is the over-formalization the Tier taxonomy
+exists to prevent.
+
+So the overage is carried openly for one iteration, and the tier decision is left to the
+user with its cost named: **either** accept 17 criteria at Tier M as a declared exception,
+**or** authorise a Tier L migration as a separate scoped change that moves `spec.md` §2's
+design content into `design.md` and the two studies' findings into `research.md`. What is
+not acceptable is silently exceeding the budget, and this note exists so that it is not
+silent.
+
+---
+
+## §C Constraints
+
+- **The interface does not change.** `IsBranchMerged(branch, base string) (bool, error)`
+  keeps its exact signature. This is deliberate: it means no test double, no mock, and no
+  call site needs editing, and both `--stale` and `--merged-only` pick up the fix at once
+  (`spec.md` §5 decision 3).
+- **Reachability must be retained, not replaced.** `git branch --merged` is the only signal
+  that recognises a true merge commit and a strictly-behind branch. Replacing it with the
+  patch-id probes would regress two scenarios that work today.
+- **Fail-safe on error.** Any probe error propagates as an error; `staleKeepReason` turns
+  that into a keep-and-report, never a removal.
+- **No new dependency.** Plain `git` subprocesses through the existing `execGit` helper.
+- **No repository-wide object reclamation.** `git prune` and `git gc` are prohibited
+  (REQ-WSM-009).
+
+---
+
+## §D Technical Approach
+
+`IsBranchMerged` becomes an ordered OR over the standalone signals S1 and S2, followed by
+the two history signals S3 and S4, each of which is **conjoined with the state check S5**.
+It short-circuits on the first term that fires. Ordering is by cost, cheapest first, so the
+object-creating probe runs last.
+
+```
+IsBranchMerged(branch, base) -> (bool, error)
+
+  S1  reachability     git branch --merged <base>  lists <branch>          -> merged
+      (existing behaviour, including the "* "/"+ " marker stripping)
+
+      mb <- git merge-base <base> <branch>       (computed once, shared by S2..S5)
+      exit 1 with empty stdout = unrelated histories -> (false, nil), keep
+
+  S2  empty diff       git diff --quiet <mb> <branch>   (rc 0 = merged, rc 1 = continue)
+
+      names <- git diff --ignore-submodules=none --no-renames --name-only -z <mb> <branch>
+              (computed once, used by S5)
+              split the output on NUL, never on newline
+              --no-renames is REQUIRED: without it a rename reports only its destination
+              and the branch's deleted source path never enters the pathspec
+              -z is REQUIRED: without it a path containing a backslash, tab, quote, or
+              control character -- or, under the default core.quotePath=true, any
+              non-ASCII byte -- is emitted C-quoted, and the quoted form matches nothing
+              --ignore-submodules=none is REQUIRED HERE TOO, and is NOT redundant with the
+              same flag on the comparison below: diff.ignoreSubmodules=all and
+              submodule.<name>.ignore=all drop a changed gitlink from THIS enumeration, so
+              without it the submodule pointer never reaches the comparison at all
+
+  S5  state check      empty names                              -> holds
+                       git --literal-pathspecs diff --quiet --no-textconv \
+                           --ignore-submodules=none <branch> <base> -- <names as separate args>
+                       rc 0 -> holds ; rc 1 -> withholds
+                       NOT a merged verdict on its own
+                       --literal-pathspecs is REQUIRED and is a GIT-LEVEL option, so it
+                       precedes the subcommand: without it a byte-perfect path whose first
+                       byte is ':' is parsed as pathspec magic and names no file, and
+                       ':!'/':^' forms parse as EXCLUDE and invert what is compared
+                       --no-textconv is REQUIRED and is a DIFF-level option, so it follows
+                       the subcommand: without it a .gitattributes textconv driver makes
+                       git compare the driver's RENDERING of each blob rather than the
+                       blobs, and two genuinely different files report no difference
+                       --ignore-submodules=none is REQUIRED and is DIFF-level: without it a
+                       changed gitlink is ignored even when the path list names it
+
+              flag placement is loud, not silent -- every misplacement exits 129, which is
+              distinct from both verdict codes (measured):
+                git --no-textconv diff ...              -> 129 unknown option
+                git --ignore-submodules=none diff ...   -> 129 unknown option
+                git diff --literal-pathspecs ...        -> 129 usage error
+
+  S3  rebase-merge     git cherry <base> <branch>
+                       -> merged only when output is non-empty
+                          AND every line is prefixed '-'
+                          AND S5 holds
+
+  S4  squash-merge     synth <- git commit-tree <branch^{tree}> -p <mb> -m <fixed msg>
+                       git cherry <base> <synth>
+                       -> merged only when output is non-empty
+                          AND every line is prefixed '-'
+                          AND S5 holds
+
+  otherwise -> not merged
+```
+
+Eight guards carry the whole safety argument. The first three constrain the signals; the
+fourth and fifth constrain the *input* to a signal; the sixth constrains how that input is
+*read back*; and the last two constrain what git *concludes* about an input that is already
+correct — which is why each successive group was missed while only the previous one was
+under review:
+
+- **Non-empty output required (S3, S4).** Empty `git cherry` output means "no commits
+  compared"; it must never be read as a merged verdict.
+- **Every line prefixed `-` required (S3, S4).** A single `+` line means part of the branch's
+  work is absent from base. This is what keeps the partially-applied case safe.
+- **S5 must hold (S3, S4).** `git cherry` answers a history question — did an equivalent
+  patch-id ever exist in base since the merge-base. S5 answers the state question — does the
+  content survive in base HEAD. A branch whose patches were applied and then reverted
+  satisfies the first and fails the second (`spec.md` §2 SC-8). S5 is a conjunct only: it
+  can withhold a verdict, never grant one.
+- **S5's path list must be complete (`--no-renames`).** A correct conjunct fed an
+  incomplete path list returns `OK` and grants the verdict. `git diff --name-only` applies
+  rename detection by default and reports only a rename's destination, so the path the
+  branch deleted is never checked (`spec.md` §2 SC-10, SC-11).
+- **S5's path list must round-trip (`-z`).** A correct conjunct fed a *corrupted* path list
+  fails the same way as one fed an incomplete list — it returns `OK` and grants the verdict.
+  `git diff --name-only` emits a C-quoted rendering rather than the path itself whenever the
+  path contains a backslash, tab, double quote, or control character, and (under the default
+  `core.quotePath=true`) whenever it contains any non-ASCII byte. The quoted rendering
+  matches no file (`spec.md` §2 SC-12). This guard is independent of the previous one:
+  `--no-renames` decides *which* paths are enumerated, `-z` decides *what form they arrive
+  in*, and getting one right does not repair the other.
+- **S5's comparison must match literally (`--literal-pathspecs`).** A correct conjunct fed a
+  complete, byte-perfect path list *still* fails when git re-parses that list as pathspec
+  expressions rather than filenames. Git reads a pathspec's leading characters as magic
+  before matching, so a repo-root path whose first byte is `:` names no file, and `:!`/`:^`
+  forms parse as EXCLUDE and invert the comparison (`spec.md` §2 SC-13). This guard is
+  independent of the previous two: they govern the list's contents and its bytes, this one
+  governs its interpretation, and a list that is perfect on both prior axes still fails here.
+  The flag disables all pathspec magic and globbing categorically; losing glob expansion is
+  free on the safety axis, since over-matching can only add differences and an added
+  difference withholds a verdict.
+- **S5's comparison must not be narrowed by diff configuration (`--no-textconv`).** The three
+  guards above all govern the path list. This one governs the *answer*. `git diff --quiet`
+  decides equality under the repository's diff configuration, and a `.gitattributes` rule
+  binding a `textconv` driver makes it compare the driver's rendering rather than the blobs —
+  so a complete, byte-perfect, literally-matched list is judged wrongly and the branch is
+  reported merged (`spec.md` §2 SC-14). The trigger is an ordinary documented recipe
+  (`*.pdf diff=pdf` is an example in git's own `gitattributes(5)`), and the predicate runs in
+  whatever repository the user has. Note the exposure is read from the **worktree's**
+  `.gitattributes`, not from the tree under judgement, so it depends on checkout state.
+- **S5 must see a changed gitlink, at BOTH stages (`--ignore-submodules=none`, twice).**
+  `diff.ignoreSubmodules=all` and `submodule.<name>.ignore=all` suppress a moved submodule
+  pointer when the path list is built *and* when the comparison is made (`spec.md` §2 SC-15).
+  Closing one stage leaves the other open, which is why this is the only guard applied twice
+  and why the enumeration-side occurrence must not be deleted as duplication — measured,
+  removing it from either stage alone reproduces the false positive. `submodule.<name>.ignore`
+  is readable from a **tracked** `.gitmodules`, so this is the one exposure in the whole
+  design that a repository can ship to every clone without any operator configuration.
+
+Since S5 evaluates identically for S3 and S4, compute it once, after `names`, and reuse it.
+
+### The comparison must stay mode-sensitive — a property to preserve, not to add
+
+`git diff` compares file **modes** as well as content, and two scenarios in the matrix depend
+on it. A symlink and a regular file whose content is exactly the symlink's target **share one
+blob OID**, and a `chmod` changes no content at all:
+
+```
+P3c   feat 100755 blob 587be6b4…  x.txt      main 100644 blob 587be6b4…  x.txt
+P4c   feat 100644 blob 1de56593…  link.txt   main 120000 blob 1de56593…  link.txt
+```
+
+The specified mechanism already reports both correctly, so no change is required — this is
+recorded as a constraint on **future** edits. Any substitution of the comparison for
+something that compares content hashes alone (a `git rev-parse <rev>:<path>` lookup, a
+`git cat-file --batch-check` batch, or an `ls-tree` map that stores only the OID) turns P3c
+and P4c into silent fail-open false positives under **default** git configuration — no
+`.gitattributes`, no config key. That is a strictly worse exposure than any of the five axes,
+all of which require non-default state. `git cat-file --batch-check` is additionally
+disqualified: it cannot resolve a gitlink and reports `missing` for one on both sides at exit
+0, so two different submodule pointers compare equal. AC-WSM-017 exists to fail if the
+comparison is made mode-blind.
+
+### Building and passing `names` — NUL-split, and a `[]string` never a joined string
+
+Three separate obligations apply to the path list, and satisfying one does not satisfy the
+others. **How the list is built** is governed below under "splitting the enumeration
+output"; **how the list is handed to git** is governed by this subsection; **how git reads
+it back** is governed by the `--literal-pathspecs` guard above. All three failures produce a
+pathspec that matches nothing, and by `spec.md` REQ-WSM-007 that reads as merged.
+
+The path list MUST reach the exec helper as a `[]string` argument list, one element per
+path. It MUST NOT be joined into a single string and re-split, and the shell snippets in
+`spec.md` / `acceptance.md` MUST NOT be transcribed literally into Go.
+
+This is not style. `git diff --quiet` exits **0** for a pathspec that matches nothing
+(`spec.md` REQ-WSM-007), so a malformed pathspec does not fail — it reads as "no
+difference", which the predicate reads as *merged*. A joined list becomes one pathspec that
+matches nothing, and the branch is reported merged. Measured, where the correct answer is
+`rc=1`:
+
+```
+argv: <feat> <main> <--> <old.txt >   (joined into one argument)   rc=0   <- WRONG
+argv: <feat> <main> <--> <old.txt>    (one argument per path)      rc=1   <- right
+```
+
+The joined form also behaves differently per shell — `bash` word-splits an unquoted
+`$names` and survives by luck, `zsh` does not split and silently returns the wrong answer
+— which is precisely why the list must never travel through a shell string. `execGit`
+already takes variadic arguments, so the correct form is the natural one; the hazard is
+only in copying a snippet.
+
+Go's `exec.Command` passes arguments directly without shell interpretation, so the
+argument-list half of the problem is solved simply by never building a joined string.
+
+**No shell — a checked property, not an assumption.** The argv axis is closed *only* while
+every git invocation in the predicate reaches the process directly. `execGit` must continue
+to build its command with `exec.Command`/`exec.CommandContext` and an explicit argument
+slice; it must not route any invocation through `sh -c`, `bash -c`, `exec.Command("sh", ...)`,
+or any string-interpolated command line. Re-introducing a shell anywhere on this path
+re-opens the argv axis in full, and it does so silently: a shell would word-split the path
+list, and by the unmatched-pathspec property above the resulting mismatch reads as *merged*
+rather than as an error.
+
+This is stated as a constraint because the evidence base does not cover it. The measurements
+throughout these artifacts were produced with direct `subprocess` argv and no shell, which
+models the intended Go construction but does not verify it — no Go code existed when they
+were taken. The run-phase implementer therefore verifies `execGit`'s construction directly
+rather than inheriting the assumption:
+
+```bash
+grep -nE 'exec\.Command(Context)?\((ctx, )?"(sh|bash|zsh)"|"-c"' internal/core/git/*.go
+```
+
+Executed against the pre-implementation tree: **no match** (exit 1). The construction in
+place today is `exec.CommandContext(ctx, gitPath, args...)` at `manager.go:257`, which is
+already correct — so this check begins satisfied and exists to keep it that way.
+
+The check is falsifiable, verified by injection rather than asserted. Appending
+`func probeShell() { _ = exec.Command("sh", "-c", "git diff") }` to `manager.go` makes it
+report `manager.go:303: ... exec.Command("sh", "-c", "git diff")` and exit 0; reverting the
+file returns it to no-match. A guard that cannot be made to fire is not a guard.
+
+### Splitting the enumeration output — on NUL, never on newline
+
+The other half is **not** solved by `exec.Command`, and it is the half a previous version of
+this plan got wrong. That version stated that a `[]string` built from
+`strings.Split(out, "\n")` is *safe* provided empty trailing elements are dropped. **That
+claim is false**, and it is false in the unsafe direction: it endorses the exact
+construction that produces the SC-12 false positive.
+
+Dropping empty elements is necessary but nowhere near sufficient. `git diff --name-only`
+does not emit paths verbatim — it emits a **C-quoted rendering** for any path containing a
+backslash, tab, double quote, or control character, and (under git's documented default
+`core.quotePath=true`) for any non-ASCII path. Splitting that output on newline therefore
+yields elements that are *not paths*: passing `"\353\254\270\354\204\234.txt"` back as a
+pathspec matches no file, `git diff --quiet` exits 0, S5 holds vacuously, and the branch is
+reported merged while its work is absent from base. Measured, where the correct answer is
+`rc=1` in every row:
+
+```
+core.quotePath=true (git's documented default) — each --name-only line round-tripped
+  "a\\b.txt"                      rc=0   <- matched NOTHING
+  "caf\303\251.txt"               rc=0   <- matched NOTHING
+  plainname.txt                   rc=1   (matched)
+  "tab\tname.txt"                 rc=0   <- matched NOTHING
+  "\355\225\234\352\270\200.txt"  rc=0   <- matched NOTHING
+
+-z (NUL-delimited) — same five paths, round-trip correct
+  a\b.txt   café.txt   plainname.txt   tab<TAB>name.txt   한글.txt      all rc=1
+```
+
+The required construction is therefore
+`git diff --ignore-submodules=none --no-renames --name-only -z` split on `\x00` — in Go,
+`bytes.Split(out, []byte{0})` (or `strings.Split(out, "\x00")`), dropping the empty trailing
+element that a NUL terminator leaves behind. `strings.Split(out, "\n")` MUST NOT be used on
+this command's output.
+
+Do **not** substitute `core.quotePath=false` for `-z`. It suppresses quoting for non-ASCII
+paths only; backslash and control-character paths stay quoted regardless of the setting —
+measured in `acceptance.md` §C.2 route 3, second block, where `"a\\b.txt"` and
+`"tab\tname.txt"` still fail to round-trip under `quotePath=false`. The config change
+therefore closes part of the hole while reading as though it closed all of it.
+
+Exit-code handling is not uniform across probes: `git diff --quiet` uses rc `1` as a
+verdict and `git merge-base` uses rc `1` to mean unrelated histories. `spec.md` REQ-WSM-007
+carries the measured per-probe table; treating any non-zero as a failure would make S3, S4,
+and S5 unreachable.
+
+The synthetic commit in S4 pins its identity so the object is deterministic
+(REQ-WSM-008), which bounds the unreferenced-object count to the number of distinct branch
+states rather than the number of sweeps:
+
+```
+GIT_AUTHOR_NAME / GIT_COMMITTER_NAME    fixed
+GIT_AUTHOR_EMAIL / GIT_COMMITTER_EMAIL  fixed
+GIT_AUTHOR_DATE / GIT_COMMITTER_DATE    fixed ("@0 +0000")
+commit message                          fixed
+```
+
+`execGit` currently builds its environment as `os.Environ()` plus two fixed entries and
+exposes no per-call environment hook, so M2 adds one — either a variant helper or an
+optional parameter. Whichever shape is chosen must leave the existing `execGit` callers
+untouched.
+
+### Anchoring note
+
+The `@MX:ANCHOR` block on `cleanStaleWorktrees` documents the two-condition gate; it stays
+as-is. A new `@MX:ANCHOR` on the predicate should record why reachability is retained
+alongside the patch-id probes, since that is the non-obvious invariant a future edit is
+most likely to break.
+
+---
+
+## §E Milestones
+
+Ordered most-reversible-decision-first.
+
+### M1 — Predicate signal set and its guards (highest change likelihood)
+
+The decision under review here is *which* signals compose the predicate and *how* their
+guards are written. Implement `IsBranchMerged` as the composition above: S1 and S2
+standalone, S3 and S4 each conjoined with S5, with the non-empty-output and all-lines-`-`
+guards on S3 and S4, and merge-base plus `names` computed once. Retain the existing
+`git branch --merged` path and its marker-stripping helper unchanged. Apply the per-probe
+exit-code table from `spec.md` REQ-WSM-007 rather than treating non-zero as failure.
+
+Exit: the seventeen-scenario matrix in `acceptance.md` §C reproduces the expected verdict for
+every scenario, including SC-8 (partially reverted), which the history signals alone report
+as merged; SC-10 / SC-11 (rename + re-add), which they report as merged whenever the path
+enumeration is not rename-blind; SC-12 (non-ASCII path), which they report as merged
+whenever the enumeration output is split on newline instead of NUL; SC-13 (leading-colon
+path), which they report as merged whenever the comparison omits `--literal-pathspecs`, even
+though its path list is byte-perfect; SC-14 (textconv driver) and SC-15 (submodule pointer
+under an ignore directive), which they report as merged whenever the comparison is issued
+under the repository's own diff configuration; and P3c / P4c (mode-only divergence and
+symlink/file blob-OID collision), which the specified mechanism already handles and which
+fail only if the comparison is made mode-blind.
+
+### M2 — Deterministic synthetic-commit identity
+
+Add the per-call environment mechanism `execGit` lacks, and pin the six identity variables
+plus the commit message. Existing `execGit` callers must be unaffected.
+
+Exit: two successive evaluations of one unchanged branch produce the same object hash, and
+the second adds no new dangling object.
+
+### M3 — Real-repository scenario tests
+
+Add table-driven tests in `internal/core/git` using the existing `initTestRepo`, `runGit`,
+and `writeTestFile` helpers, one case per scenario in the matrix. Mock-based CLI tests
+cannot cover this: `clean_stale_test.go` stubs `IsBranchMerged` through
+`mockIsBranchMergedFunc`, so the CLI layer never exercises the real predicate.
+
+Each guard test must be falsifiable — removing the guard it protects has to make the test
+fail. `acceptance.md` §D records the falsification procedure per criterion.
+
+Exit: `go test ./internal/core/git/...` green, including the two pre-existing
+`TestWorktreeIsBranchMerged*` tests, which encode scenarios the change must not alter.
+
+### M4 — Regression and full-suite verification
+
+Run the full suite and `go vet`. Confirm the `--stale` and `--merged-only` CLI tests still
+pass unchanged, which is the evidence that the interface really did stay fixed.
+
+Exit: `go test ./...` and `go vet ./...` both clean.
+
+### M5 — Mechanical follow-through
+
+Update the `clean` command's `Long` help text only if the observed behaviour no longer
+matches its wording, and add the `@MX:ANCHOR` described in §D. No other files.
+
+---
+
+## §F Risks
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| A patch-id false positive removes a worktree holding unmerged work | **Critical** | The guards on S3/S4; the seventeen-scenario matrix, in which all eleven must-keep scenarios were observed as keep under the composed predicate; the independent working-tree-cleanliness condition, which `--stale` retains |
+| Replacing rather than extending the reachability signal regresses merge-commit and behind-branch cases | High | S1 retained verbatim; the two pre-existing `TestWorktreeIsBranchMerged*` tests cover exactly these and must keep passing |
+| `git cherry` cost grows with the number of base commits since merge-base | Low | Real, and it applies to **both** S3 and S4 — see the measured note below. Bounded in practice at roughly a quarter-second per branch on this repository; no budget is imposed, and the sweep is a user-initiated maintenance command rather than an interactive path |
+| Unreferenced objects accumulate | Low | Deterministic identity (M2) bounds them by distinct branch state; git auto-gc reclaims them; `git prune` is prohibited (REQ-WSM-009) |
+| A branch merged by individual replay and then amended is not detected | Low | Conservative false negative — the worktree is kept. Recorded in `spec.md` §2 as an accepted limitation |
+| A history signal fires on a branch whose work was reverted out of base | **Critical** | The S5 state conjunct on S3 and S4 (`spec.md` §2 SC-8). Mutation-checked: removing S5 alone flips SC-8 to merged |
+| A history signal fires on a branch whose renamed-away path base still holds | **Critical** | `--no-renames` on the S5 path enumeration (`spec.md` §2 SC-10, SC-11). Mutation-checked: the `folded-names` mutation flips exactly SC-10 and SC-11 and nothing else. The conjunct alone does not catch this — it is fed an incomplete path list and holds vacuously |
+| A history signal fires on a branch whose only absent path has a name git C-quotes | **Critical** | `-z` on the S5 enumeration plus a NUL split (`spec.md` §2 SC-12). Mutation-checked: the `newline-split` mutation flips exactly SC-12 and nothing else. Orthogonal to `--no-renames` — the rename fix left this route completely open. Note `core.quotePath=false` is **not** a mitigation: backslash and control-character paths quote regardless |
+| A history signal fires on a branch whose only absent path is parsed as pathspec magic | **Critical** | `--literal-pathspecs` as a git-level option on the S5 comparison (`spec.md` §2 SC-13). Mutation-checked: the `no-literal` mutation flips exactly SC-13 and nothing else. Orthogonal to both `--no-renames` and `-z` — the path list is already complete and byte-perfect when this one fires, which is why the two prior repairs left it open |
+| A history signal fires on a branch whose only absent path is compared under a `textconv` diff driver | **Critical** | `--no-textconv` on the S5 comparison (`spec.md` §2 SC-14). Mutation-checked: the `no-textconv` mutation flips exactly SC-14 and nothing else. Orthogonal to all three round-trip repairs — the path list is complete, byte-perfect, and literally matched when this one fires; only git's *judgement* of it is wrong. Trigger is an ordinary documented recipe, so the exposure is not exotic |
+| A history signal fires on a branch whose only absent change is a moved submodule pointer | **Critical** | `--ignore-submodules=none` on **both** the S5 enumeration and the S5 comparison (`spec.md` §2 SC-15). Mutation-checked: `no-ignoresub-cmp` and `no-ignoresub-enum` each flip exactly SC-15 on their own, which is the evidence both occurrences are needed. Uniquely, `submodule.<name>.ignore=all` is readable from a tracked `.gitmodules`, so this exposure can arrive inside the repository with no operator configuration |
+| A future edit swaps the S5 comparison for a mode-blind mechanism, and mode-only divergence is silently missed | **Critical** | `git diff` compares modes; P3c and P4c pin this (`spec.md` §2). Mutation-checked: an OID-only comparison flips exactly P3c and P4c. Worse than any axis member because it fails under **default** configuration — a symlink and a regular file with identical content share one blob OID. AC-WSM-017 is the criterion that fails if the swap is made; `plan.md` §D records why `rev-parse`, `cat-file --batch-check`, and OID-only `ls-tree` maps are all disqualified |
+| The path list is joined into one shell string, matching nothing, and reads as merged | **Critical** | Pass `names` as a `[]string` to `execGit` (§D). The failure is silent: an unmatched pathspec exits 0, so this surfaces as a wrong removal rather than an error |
+| A shell is re-introduced on the git-invocation path, silently re-opening the argv axis | **High** | `execGit` keeps its direct `exec.CommandContext` construction; the §D grep is the check, verified falsifiable by injection. Note the evidence base for every measurement in these artifacts used direct argv with no shell, so this is a constraint the implementation must hold rather than one the measurements established |
+
+### Measured note — `git cherry` cost (corrects an earlier claim)
+
+An earlier version of this plan asserted that the synthetic commit's merge-base parent
+bounds the compared range "by the branch's own divergence, not by the repository's
+history". That is **wrong**, and it was wrong for S4 as well as S3.
+
+`git cherry <upstream> <head>` computes patch-ids on *both* sides: the head side
+(`upstream..head`) and the upstream side (`head..upstream`). The synthetic parent shrinks
+only the head side, to a single commit. The upstream side is unaffected and grows with
+base's divergence since the merge-base. Measured on git 2.50.1 in a synthetic repository:
+
+```
+base commits since merge-base=50    S3 real=0.01s   S4 real=0.01s
+base commits since merge-base=200   S3 real=0.13s   S4 real=0.12s
+base commits since merge-base=800   S3 real=0.23s   S4 real=0.26s
+   (S3 upstream-side commits = 800, head-side = 1)
+```
+
+S4 tracks S3 almost exactly — the synthetic parent buys no asymptotic saving. Measured on
+this repository's real branches:
+
+```
+branch=backup-main-full-20260706   upstream-side=1143   git cherry elapsed=244ms
+branch=backup-handoff-deps-fix     upstream-side=918    git cherry elapsed=225ms
+branch=GoosLab/main-fork           upstream-side=87     git cherry elapsed=122ms
+```
+
+Practical bound for a full `--stale` sweep here: two `git cherry` calls per branch at
+roughly 0.25s each, over the 45 worktree branches in `spec.md` §1, is on the order of 20
+seconds. That is acceptable for a user-initiated maintenance command and no latency budget
+is set, but the honest statement is that the cost scales with base's history, not with the
+branch's. No acceptance criterion measures predicate latency; if a repository with a far
+longer main makes the sweep unpleasant, bounding it is follow-up work, not part of this
+change.
+
+---
+
+## §G Anti-Patterns
+
+- Using plain `git cherry` as the squash detector. Falsified — see `spec.md` §2.
+- Dropping `git branch --merged` once the patch-id probes are in place.
+- Treating empty `git cherry` output as a merged verdict.
+- Accepting a merged verdict when any `git cherry` line is prefixed `+`.
+- Reporting merged on a patch-id history signal (S3 or S4) without the S5 state conjunct.
+  This is the partially-reverted false positive; it is the one mutation that flips SC-8 on
+  its own.
+- Promoting S5 to a standalone merged signal. It is a conjunct only — it may withhold a
+  verdict, never grant one.
+- Enumerating S5's paths with `git diff --name-only` (rename detection on). This folds a
+  rename's deleted source path out of the pathspec, so S5 holds vacuously and the rename +
+  re-add false positive returns. Dropping `--no-renames` as "redundant" is the specific
+  edit AC-WSM-006's first falsification exists to fail.
+- Splitting the S5 enumeration's output on `\n` instead of `\x00`, or dropping `-z` as
+  "noise". A quoted path is not the path; it matches nothing and S5 holds vacuously. This
+  is a *different* defect from the rename fold and is not repaired by `--no-renames` —
+  it is the specific edit AC-WSM-006's second falsification exists to fail.
+- Substituting `core.quotePath=false` for `-z`. It suppresses quoting for non-ASCII paths
+  only; backslash, tab, quote, and control-character paths stay quoted under any setting.
+  The config change looks like a fix and is not one.
+- Omitting `--literal-pathspecs` from the S5 comparison, or dropping it as "redundant now
+  that the bytes are correct". Correct bytes are not the property at stake: git parses a
+  pathspec before matching it, so a byte-perfect leading-colon path still names no file.
+  This is the specific edit AC-WSM-006's third falsification exists to fail.
+- Placing `--literal-pathspecs` after the subcommand (`git diff --literal-pathspecs ...`).
+  It is a git-level option; git rejects that form with a usage error. This is the one repair
+  on this surface whose misapplication is loud rather than silent — do not "fix" the usage
+  error by deleting the flag.
+- Substituting a per-element `:(literal)` prefix for the flag. It is mechanically correct
+  but re-introduces a per-path string transformation, which is the operation that has failed
+  on three of the four round-trip axes. Prefer the flag, which touches no path.
+- Omitting `--no-textconv` from the S5 comparison, or dropping it because "the path list is
+  already correct". Correctness of the list is not the property at stake: `git diff --quiet`
+  compares a `textconv` driver's *rendering* of each blob, so two genuinely different files
+  report no difference on a perfect list. This is the specific edit AC-WSM-006's fourth
+  falsification exists to fail.
+- Dropping `--ignore-submodules=none` from the S5 **enumeration** as redundant with the same
+  flag on the comparison. It is not redundant — the two submodule-ignore keys suppress the
+  gitlink at both stages, so without the enumeration-side flag the pointer never enters
+  `names` and the comparison is never asked. Measured: removing it from *either* stage alone
+  reproduces the SC-15 false positive. This is the specific edit AC-WSM-006's fifth
+  falsification exists to fail, and it is the likeliest deletion in the whole mechanism
+  because the flag appears twice and reads as a copy-paste error.
+- Assuming a submodule exposure requires the operator's own config. `submodule.<name>.ignore`
+  is read from `.gitmodules`, a tracked file, so a repository ships it to every clone. A
+  repair reasoned as "this needs a non-default local setting, so it is rare" closes the
+  wrong member.
+- Replacing the S5 comparison with a blob-OID comparison (`git rev-parse <rev>:<path>`,
+  `git cat-file --batch-check`, or an `ls-tree` map storing only the OID). It looks stronger
+  — content hashes cannot be fooled by diff configuration — and is measurably weaker: it is
+  mode-blind, and a symlink and a regular file with identical content share one blob OID, so
+  P3c and P4c become silent false positives under **default** configuration.
+  `cat-file --batch-check` is doubly disqualified, reporting `missing` for a gitlink on both
+  sides at exit 0 so two different submodule pointers compare equal. If a future
+  comparison-side defect ever forces this route, the mechanism must carry the **mode**
+  alongside the OID; `spec.md` §2 records the full weighing.
+- Routing any git invocation through a shell (`sh -c`, `bash -c`, an interpolated command
+  string). It re-opens the argv axis in full and fails silently in the merged direction.
+- Reconstructing the path list as a single shell string, or transcribing the document's
+  shell snippets into Go. One pathspec matching nothing exits 0, which reads as merged.
+- Reading an S5 result of "no difference" as reassuring without checking that the path list
+  was non-empty and well-formed. S5 fails open: silence there is indistinguishable between
+  "the branch's work is present" and "we asked about nothing".
+- Treating every non-zero probe exit as a failure. `git diff --quiet` rc 1 and
+  `git merge-base` rc 1 are verdicts; see `spec.md` REQ-WSM-007.
+- Calling `git prune` or `git gc` to clean up the synthetic objects.
+- Weakening the working-tree-cleanliness condition on the strength of better merge
+  detection. The two conditions are independent (REQ-WSM-010).
+- Widening the interface signature. It would force edits to four test doubles for no gain.
+
+---
+
+## §H Cross-References
+
+- `spec.md` §2 — the executed detector matrix and the falsified alternative
+- `spec.md` §5 — the four resolved scope decisions
+- `acceptance.md` — per-criterion verification and falsification procedures
+- `.claude/rules/moai/core/verification-claim-integrity.md` — evidence obligations
+- `internal/cli/worktree/clean.go` — `cleanStaleWorktrees` `@MX:ANCHOR` (two-condition gate)

--- a/.moai/specs/SPEC-WORKTREE-SQUASH-MERGE-001/progress.md
+++ b/.moai/specs/SPEC-WORKTREE-SQUASH-MERGE-001/progress.md
@@ -201,6 +201,33 @@ $ golangci-lint run ./internal/core/git/  → 0 issues
 Permanent M3 code change: the determinism-test gap + `time` import (9 LOC). All
 mutations were reverted; `worktree.go` matches the M2 baseline byte-for-byte.
 
+### M4 — full-suite + interface-stability verification
+
+```
+$ go test ./... -count=1   → exit 0 (105 packages ok, 0 FAIL/panic)
+$ go vet ./...             → exit 0
+$ GOOS=windows GOARCH=amd64 go build ./...  → exit 0
+```
+
+Interface-stability evidence (the premise of the shared-predicate decision,
+spec.md §5 decision 3 — no test double, no mock, no call site needed editing):
+```
+$ git diff --exit-code 1dbf1f47c -- internal/core/git/types.go   → exit 0 (UNCHANGED)
+$ git diff --stat 1dbf1f47c -- internal/cli/worktree/clean.go    → (empty, unmodified)
+$ grep -cE 'Remove\([A-Za-z_.]+, false\)' internal/cli/worktree/clean.go   → 2 (both call sites)
+```
+The `--stale` and `--merged-only` CLI tests pass unchanged — they stub the
+predicate (`mockIsBranchMergedFunc`) so they cannot exercise the real one, but
+their continued green is the evidence that the interface the predicate satisfies
+did not change shape:
+```
+$ go test ./internal/cli/worktree/ -run 'TestCleanStale_(KeepsDirtyWorktree|PreviewsByDefault|RemovesWithYes)' -count=1 -v
+--- PASS: TestCleanStale_KeepsDirtyWorktree (0.00s)
+--- PASS: TestCleanStale_PreviewsByDefault (0.00s)
+--- PASS: TestCleanStale_RemovesWithYes (0.00s)
+```
+No code change in M4; this milestone is pure verification.
+
 ## §E.3 Run-phase Audit-Ready Signal
 
 ```yaml

--- a/.moai/specs/SPEC-WORKTREE-SQUASH-MERGE-001/progress.md
+++ b/.moai/specs/SPEC-WORKTREE-SQUASH-MERGE-001/progress.md
@@ -159,6 +159,48 @@ $ grep -nE 'exec\.Command(Context)?\((ctx, )?"(sh|bash|zsh)"|"-c"' internal/core
 (exit 1, no match)
 ```
 
+### M3 — guard falsifiability verification (acceptance.md §C.1 grid reproduced)
+
+Each guard's removal was applied as a temporary mutation to `worktree.go`,
+run against the targeted scenarios, captured, then reverted via
+`git checkout HEAD --`. Every mutation flipped EXACTLY its §C.1 blast radius
+and nothing else — the measured-disjoint property holds for this implementation.
+
+| Mutation (criterion) | Flipped rows (observed) | Disjoint? |
+|---|---|---|
+| `folded-names` — drop `--no-renames`, keep `-z` (AC-WSM-006.1) | SC-10, SC-11 | yes — SC-12-15 PASS |
+| `newline-split` — drop `-z`, split on `\n` (AC-WSM-006.2) | SC-12 | yes — SC-10/11/13-15 PASS |
+| `no-literal` — drop `--literal-pathspecs` (AC-WSM-006.3) | SC-13 | yes — SC-10-12/14/15 PASS |
+| `no-textconv` — drop `--no-textconv` (AC-WSM-006.4) | SC-14 | yes — SC-10-13/15 PASS |
+| `no-ignoresub-cmp` — drop comparison-side `--ignore-submodules=none` (AC-WSM-006.5) | SC-15 | yes — SC-10-14 PASS |
+| `no-ignoresub-enum` — drop enumeration-side `--ignore-submodules=none` | SC-15 | both stages load-bearing (each alone flips SC-15) |
+| `no-state` — drop S5 conjunct from S3+S4 (AC-WSM-015) | SC-8, SC-10-15, P3c, P4c | wide — FORBIDDEN as sole falsification for AC-WSM-005/006/017 |
+| `both` — drop S5 + accept any non-empty cherry (AC-WSM-005) | SC-6, SC-7 (+ no-state set) | the unique mutation that flips SC-6 AND SC-7 |
+| `oid-only-cmp` — replace comparison with mode-blind `ls-tree` OID maps (AC-WSM-017) | P3c, P4c | yes — SC-6-15 PASS; `git diff` is mode-sensitive |
+| unpin `GIT_COMMITTER_DATE` (AC-WSM-008) | determinism test FAIL (delta 0→2) | yes — pinned stays delta 1 |
+| inject bare `git prune` (AC-WSM-009) | grep judge 0→1 | yes — restored to 0 |
+
+Notable findings during verification:
+- The determinism test was STRENGTHENED with a >1s gap between the two
+  evaluations, because two rapid un-pinned calls land in the same wall-clock
+  second and produce the same object (delta 1) — the test as first written did
+  NOT falsify the unpin. With the gap, un-pinned → delta 2 (FAIL), pinned →
+  delta 1 (PASS). This is the load-bearing fix that makes AC-WSM-008 falsifiable.
+- The `oid-only-cmp` mutation helper initially used `ls-tree` WITHOUT `-z`, which
+  C-quoted the non-ASCII path and incidentally also flipped SC-12 — a quoting
+  artifact of the mutation, not a property of oid-only-cmp. Fixed by adding `-z`
+  to the helper; SC-12 then correctly stays at keep. This is itself evidence of
+  the encoding axis the production `-z` guard exists to close.
+
+Full suite after M3 (determinism test now sleeps 1.1s, total ~79s):
+```
+$ go test ./internal/core/git/ -count=1   → ok (PASS)
+$ go vet ./internal/core/git/             → clean
+$ golangci-lint run ./internal/core/git/  → 0 issues
+```
+Permanent M3 code change: the determinism-test gap + `time` import (9 LOC). All
+mutations were reverted; `worktree.go` matches the M2 baseline byte-for-byte.
+
 ## §E.3 Run-phase Audit-Ready Signal
 
 ```yaml

--- a/.moai/specs/SPEC-WORKTREE-SQUASH-MERGE-001/progress.md
+++ b/.moai/specs/SPEC-WORKTREE-SQUASH-MERGE-001/progress.md
@@ -228,23 +228,48 @@ $ go test ./internal/cli/worktree/ -run 'TestCleanStale_(KeepsDirtyWorktree|Prev
 ```
 No code change in M4; this milestone is pure verification.
 
+### M5 — mechanical follow-through
+
+**Help text: NO CHANGE.** The `clean` command's `Long` text and the `--stale` /
+`--merged-only` flag descriptions are stated generally — "worktrees whose
+branches have been merged into the base branch" and "no commits of its own
+beyond the base branch". Read naturally, squash-merged branches were always
+WITHIN that wording; the pre-fix implementation under-delivered against it
+(missed squash merges), and this SPEC makes the behaviour converge with the
+wording rather than diverge. The plan.md §E M5 bar is "update only if the
+observed behaviour no longer matches its wording" — it matches, so no edit.
+
+**`@MX:ANCHOR` on the predicate: present** (added in M1, lines 231-232 of
+`worktree.go`). It records the non-obvious invariant the plan §D anchoring note
+names — why reachability (S1) is retained alongside the patch-id probes (S3/S4)
+and conjoined with the state check (S5) — with a `@MX:REASON` naming the
+specific scenarios each guard protects (SC-3/SC-4 for S1; SC-8..SC-15/P3c/P4c
+for S5 via the `no-state` mutation). A future edit that drops S1 or S5 is the
+break this anchor exists to flag.
+
 ## §E.3 Run-phase Audit-Ready Signal
 
 ```yaml
-run_complete_at: 2026-08-02      # M1 complete; M2-M5 pending
-run_commit_sha: pending-backfill # M1 commit SHA backfilled after push (self-referential)
-run_status: m1-green             # M1 GREEN; M2..M5 not yet run
-ac_pass_count: 12                # AC-WSM-001..006, 007, 009, 011, 012, 013, 017 measured PASS at M1
+run_complete_at: 2026-08-02      # M1-M5 complete
+run_commit_sha: pending-backfill # run-phase terminal SHA backfilled after the branch push (self-referential)
+run_status: run-green            # all five milestones GREEN; 17/17 AC measured PASS
+ac_pass_count: 17                # AC-WSM-001..017 all measured PASS (M1-M5)
 ac_fail_count: 0
 preserve_list_post_run_count: 0  # types.go unmodified; clean.go call sites untouched
 l44_pre_commit_fetch: n/a        # 1-person OSS, branch-local
-l44_post_push_fetch: pending     # backfilled after M5 push
+l44_post_push_fetch: pending     # backfilled after branch push
 new_warnings_or_lints_introduced: 0   # golangci-lint 0 issues == baseline 0
 cross_platform_build:
   go_build_all: exit_0
   windows_amd64: exit_0
-total_run_phase_files: 3         # worktree.go, manager.go, worktree_squash_merge_test.go
-m1_to_mN_commit_strategy: per-milestone Conventional-Commit + 🗿 MoAI trailer; branch push only (repo-local PR-mandatory)
+total_run_phase_files: 3         # worktree.go, manager.go, worktree_squash_merge_test.go (clean.go help text unchanged, types.go unchanged)
+m1_to_mN_commit_strategy: per-milestone Conventional-Commit + 🗿 MoAI trailer; branch push only (repo-local PR-mandatory, no main direct push)
+run_phase_commits:               # M1..M5 commits on fix/clean-stale-squash-detect
+  m1: 20858cfc6
+  m2: b22584c7c
+  m3: 50b711eb9
+  m4: d107d40db
+  m5: pending-backfill           # self-referential; backfilled post-push
 ```
 
 ## §E.4 Sync-phase Audit-Ready Signal

--- a/.moai/specs/SPEC-WORKTREE-SQUASH-MERGE-001/progress.md
+++ b/.moai/specs/SPEC-WORKTREE-SQUASH-MERGE-001/progress.md
@@ -79,12 +79,130 @@ resolved finding was re-opened and no structural change was made beyond the two 
 
 ## §E.2 Run-phase Evidence
 
-_<pending run-phase>_
+### M1 — predicate S1-S5 composition + guards + 17-scenario suite
+
+Implementation: `internal/core/git/worktree.go` `IsBranchMerged` rewritten as
+ordered OR over S1 (reachability, retained verbatim incl. `trimBranchListMarker`),
+S2 (empty diff), (S3 rebase-merge ∧ S5), (S4 squash-merge ∧ S5). merge-base and
+`names` computed once. `internal/core/git/manager.go` gains `execGitExit`
+(exit-code-aware executor + the per-call env hook mechanism for M2); `execGit`
+unchanged. Eight guards verbatim (plan.md §D).
+
+RED captured before GREEN (TDD, acceptance.md §A non-vacuity discipline). Against
+the pre-implementation S1-only tree, the new selectors that should FAIL did fail:
+```
+--- FAIL: TestIsBranchMerged_SquashMerged    (false, want true — S4+S5 gap)
+--- FAIL: TestIsBranchMerged_RebaseMerged    (false, want true — S3+S5 gap)
+--- FAIL: TestIsBranchMerged_EmptyDiffBranch (false, want true — S2 gap)
+--- FAIL: TestIsBranchMerged_Superset        (false, want true — S3+S4+S5 gap)
+--- FAIL: TestIsBranchMerged_ProbeExit_Table/EmptyDiffMerged (false, want true)
+```
+SC-6/7/8/10-15/P3c/P4c passed coincidentally under S1-only (expected false), and
+the reachability rows (SC-3/SC-4) passed (S1 handles them). Verbatim RED output
+recorded above.
+
+GREEN — full 17-scenario suite + ProbeExit table after implementation:
+```
+$ go test ./internal/core/git/ -run 'TestIsBranchMerged_|TestSyntheticCommit' -count=1 -v
+--- PASS: TestIsBranchMerged_SquashMerged (1.10s)
+--- PASS: TestIsBranchMerged_RebaseMerged (1.02s)
+--- PASS: TestIsBranchMerged_Reachability_TrueMergeCommit (1.11s)
+--- PASS: TestIsBranchMerged_Reachability_StrictlyBehind (0.17s)
+--- PASS: TestIsBranchMerged_EmptyDiffBranch (0.23s)
+--- PASS: TestIsBranchMerged_PartiallyApplied (0.50s)
+--- PASS: TestIsBranchMerged_UnmergedControl (0.46s)
+--- PASS: TestIsBranchMerged_RevertRemovedFromBase (0.32s)
+--- PASS: TestIsBranchMerged_Superset (0.33s)
+--- PASS: TestIsBranchMerged_RenameReAddSquash (1.37s)
+--- PASS: TestIsBranchMerged_RenameReAddCherryPick (0.42s)
+--- PASS: TestIsBranchMerged_NonASCIIPathRemoved (1.41s)
+--- PASS: TestIsBranchMerged_ColonPathRemovedFromBase (0.41s)
+--- PASS: TestIsBranchMerged_TextconvDriverCollapsesChange (0.51s)
+--- PASS: TestIsBranchMerged_SubmoduleIgnoreDirective (2.86s)
+--- PASS: TestIsBranchMerged_ModeOnlyDivergence (0.59s)
+--- PASS: TestIsBranchMerged_SymlinkFileOIDCollision (0.83s)
+--- PASS: TestIsBranchMerged_ProbeExit_Table (0.93s)
+    --- PASS: .../UnknownBase (0.35s)
+    --- PASS: .../UnrelatedHistories (0.16s)
+    --- PASS: .../NonEmptyDiffNoError (0.26s)
+    --- PASS: .../EmptyDiffMerged (0.16s)
+PASS
+ok  github.com/modu-ai/moai-adk/internal/core/git  15.104s
+```
+
+AC-WSM-013 pre-existing predicate tests unchanged:
+```
+$ go test ./internal/core/git/ -run 'TestWorktreeIsBranchMerged' -count=1 -v
+--- PASS: TestWorktreeIsBranchMerged_BranchCheckedOutInWorktree (0.49s)
+--- PASS: TestWorktreeIsBranchMerged (0.34s)
+--- PASS: TestWorktreeIsBranchMerged_NotMerged (0.70s)
+PASS
+```
+
+Shell-judge ACs (acceptance.md §D):
+- AC-WSM-009 `grep ... "prune|gc" | wc -l` → `0`
+- AC-WSM-011 `git diff --exit-code -- types.go` → exit 0 (interface unchanged)
+- AC-WSM-012 `grep -cE 'Remove\([A-Za-z_.]+, false\)' clean.go` → `2`
+
+Coverage + build + vet + lint (acceptance.md §E):
+```
+$ go test -cover ./internal/core/git/...   → coverage: 85.7% of statements
+$ go build ./...                            → exit 0
+$ GOOS=windows GOARCH=amd64 go build ./...  → exit 0
+$ go vet ./internal/core/git/               → exit 0
+$ golangci-lint run ./internal/core/git/... → 0 issues. (baseline was 0; no NEW)
+```
+
+E4 no-shell grep (plan.md §D) — no match:
+```
+$ grep -nE 'exec\.Command(Context)?\((ctx, )?"(sh|bash|zsh)"|"-c"' internal/core/git/*.go
+(exit 1, no match)
+```
 
 ## §E.3 Run-phase Audit-Ready Signal
 
-_<pending run-phase>_
+```yaml
+run_complete_at: 2026-08-02      # M1 complete; M2-M5 pending
+run_commit_sha: pending-backfill # M1 commit SHA backfilled after push (self-referential)
+run_status: m1-green             # M1 GREEN; M2..M5 not yet run
+ac_pass_count: 12                # AC-WSM-001..006, 007, 009, 011, 012, 013, 017 measured PASS at M1
+ac_fail_count: 0
+preserve_list_post_run_count: 0  # types.go unmodified; clean.go call sites untouched
+l44_pre_commit_fetch: n/a        # 1-person OSS, branch-local
+l44_post_push_fetch: pending     # backfilled after M5 push
+new_warnings_or_lints_introduced: 0   # golangci-lint 0 issues == baseline 0
+cross_platform_build:
+  go_build_all: exit_0
+  windows_amd64: exit_0
+total_run_phase_files: 3         # worktree.go, manager.go, worktree_squash_merge_test.go
+m1_to_mN_commit_strategy: per-milestone Conventional-Commit + 🗿 MoAI trailer; branch push only (repo-local PR-mandatory)
+```
 
 ## §E.4 Sync-phase Audit-Ready Signal
 
 _<pending sync-phase>_
+
+## §F Phase 4 Mode Selection
+
+```yaml
+# Phase 4 Mode Selection — orchestrator decision log (SPEC-WORKTREE-SQUASH-MERGE-001)
+tier: M
+scope_files: 4            # internal/core/git/worktree.go (IsBranchMerged), manager.go (execGit env hook), new scenario test file, internal/cli/worktree/clean.go (help text M5)
+domain_count: 1           # Go internal/core/git — single domain
+language_mix: "100% Go"
+concurrency_benefit: LOW  # coding-heavy, cohesive single-function rewrite
+agent_teams_prereqs: n/a  # Mode 3 retired
+```
+
+Mode evaluation:
+- Mode 1 trivial — not selected: safety-critical predicate rewrite + 17-scenario matrix; not a typo/single-line.
+- Mode 2 background — not selected: write-capable implementation, not read-only.
+- Mode 3 agent-team — RETIRED.
+- Mode 4 parallel — not selected: single domain + coding-heavy → Anthropic coding-task parallelism caveat favors sequential.
+- Mode 5 sub-agent — SELECTED: coding-heavy cohesive function; sequential TDD cycles in one agent context.
+- Mode 6 workflow — not selected: <30 files, semantic new-logic (not a mechanical uniform transform).
+
+Decision: sub-agent (Mode 5)
+cycle_type: tdd (per `.moai/config/sections/quality.yaml` constitution.development_mode: tdd)
+
+Justification: Anthropic's coding-task parallelism caveat — most coding tasks involve fewer truly parallelizable tasks than research. This SPEC is one cohesive predicate function (`IsBranchMerged`) plus its falsifiable scenario tests; the TDD RED-GREEN-REFACTOR cycles (M1→M5) share state and build on each other, so a single sequential `manager-develop` agent in one context is correct. Implementation Kickoff Approval passed (user approved run entry 2026-08-02 after Phase 1 plan-audit PASS 0.95, independent fresh-eyes verdict in `.moai/reports/plan-audit/SPEC-WORKTREE-SQUASH-MERGE-001-2026-08-02.md`).

--- a/.moai/specs/SPEC-WORKTREE-SQUASH-MERGE-001/progress.md
+++ b/.moai/specs/SPEC-WORKTREE-SQUASH-MERGE-001/progress.md
@@ -1,0 +1,90 @@
+# Progress — SPEC-WORKTREE-SQUASH-MERGE-001
+
+## §E.1 Plan-phase Audit-Ready Signal
+
+```yaml
+plan_status: audit-ready
+plan_complete_at: 2026-08-02
+plan_revision: 4          # iteration-4 revision after plan-audit FAIL (0.79), user-override scoped to N5
+tier: M
+artifacts: [spec.md, plan.md, acceptance.md, progress.md]
+requirements: 14   # REQ-WSM-001 .. REQ-WSM-014        (Tier M cap 16)
+acceptance_criteria: 16   # AC-WSM-001 .. AC-WSM-016   (Tier M cap 16)
+open_clarifications: 0
+```
+
+Scope decisions resolved during authoring, each from executed git experiments rather than
+reasoning: the false-positive boundary (`spec.md` §5 decision 1), synthetic-object handling
+(decision 2), the `--merged-only` co-change (decision 3), and the preserved safety
+constraints (decision 4). Four falsified alternatives are recorded in `spec.md` §2 so they
+are not re-proposed: plain per-commit `git cherry` as the squash detector; history-only
+patch-id equivalence with no state check; enumerating S5's paths with rename detection on;
+and splitting the enumeration's output on newline rather than NUL.
+
+### Iteration-2 revision (plan-audit D1-D5 + D6-D8)
+
+- **D2** — REQ-WSM-007 narrowed with a measured per-probe verdict-code table; the earlier
+  wording made S3/S4 unreachable because `git diff --quiet` uses rc 1 as a verdict.
+- **D1** — added the S5 state conjunct (REQ-WSM-014): S3/S4 are no longer sufficient alone.
+  Matrix re-run at 9 scenarios × 5 signals; SC-2 (rebase) verified not to regress.
+- **D3** — AC-WSM-009's judge repaired (`-r` dropped, exclusion anchored on the literal
+  argument pair) and its falsification restated using `git prune`, then executed.
+- **D4** — the clean-worktree-with-unpushed-commits removal case recorded in §5 decision 3,
+  accepted with the branch-retention mitigation, and listed in §4 as out of scope.
+- **D5** — AC-WSM-015 (REQ-001 + REQ-014) and AC-WSM-016 (REQ-011 + REQ-012) added;
+  every requirement now has a binding criterion beyond the AC-WSM-014 catch-all.
+- **D6** — AC-WSM-012 rewritten to match on the `false` argument and pin both call sites.
+- **D7** — the unrelated-histories case folded into AC-WSM-007 as a second row.
+- **D8** — §2's no-false-positive claim explicitly scoped to the constructed matrix.
+
+Two residual risks the audit flagged are addressed rather than carried: `plan.md` §F's
+`git cherry` cost claim is corrected with measurement (the bound holds for neither S3 nor
+S4), and AC-WSM-008 now records the inputs that produce its hash.
+
+### Iteration-3 revision (plan-audit N1-N4)
+
+- **N1** — the rename-fold false positive closed: S5's enumeration takes `--no-renames`.
+  Matrix extended to 11 scenarios with SC-10 and SC-11; SC-1..SC-9 unchanged.
+- **N2** — non-vacuity guards added to AC-WSM-001, AC-WSM-010, AC-WSM-015.
+- **N3** — SC-9's construction pinned to one recipe, with the SHA-collision degeneration
+  recorded so the cherry-pick phrasing is not substituted.
+- **N4** — the S5 shell snippet rewritten as an array; `plan.md` §D gained the
+  `[]string`-not-a-joined-string subsection.
+
+### Iteration-4 revision (plan-audit N5-N6, user override)
+
+Scoped by explicit user override of the three-iteration ceiling to **one finding**. No
+resolved finding was re-opened and no structural change was made beyond the two below.
+
+- **N5** — the path-encoding false positive closed: S5's enumeration takes `-z` and its
+  output is split on NUL. `git diff --name-only` C-quotes any path containing a backslash,
+  tab, double quote, or control character — and, under the documented default
+  `core.quotePath=true`, any non-ASCII path — and the quoted rendering matches nothing,
+  which by §2 finding 5 reads as merged. Matrix extended to 12 scenarios with SC-12;
+  SC-1..SC-11 re-executed and cell-for-cell unchanged. §C.1's mutation grid re-run at
+  6 × 12; the new `newline-split` mutation flips exactly SC-12, disjoint from
+  `folded-names`, which is the evidence that `--no-renames` and `-z` are separate guards.
+  AC-WSM-006 was extended to carry both falsifications rather than a seventeenth criterion
+  being added, keeping the SPEC at the Tier M ceiling of 16.
+  The load-bearing part of this repair is a **correction**, not an addition: `plan.md` §D
+  previously stated that a path list built with `strings.Split(out, "\n")` is *safe*. That
+  claim was false in the unsafe direction — it endorsed the exact construction that
+  produces the SC-12 false positive — and leaving it in place was the stated reason the
+  override was authorized.
+- **N6** — run-phase judging commands added to AC-WSM-002 through AC-WSM-008, so §F's
+  "the judging command and its observed output recorded" requirement now holds for every
+  criterion as written rather than for a subset. All twelve `-run` selectors were executed
+  against the pre-implementation tree and their baseline `--- PASS:` counts recorded in §A
+  (nine at 0, and 3 / 1 / 2 for the three pre-existing tests).
+
+## §E.2 Run-phase Evidence
+
+_<pending run-phase>_
+
+## §E.3 Run-phase Audit-Ready Signal
+
+_<pending run-phase>_
+
+## §E.4 Sync-phase Audit-Ready Signal
+
+_<pending sync-phase>_

--- a/.moai/specs/SPEC-WORKTREE-SQUASH-MERGE-001/progress.md
+++ b/.moai/specs/SPEC-WORKTREE-SQUASH-MERGE-001/progress.md
@@ -251,7 +251,7 @@ break this anchor exists to flag.
 
 ```yaml
 run_complete_at: 2026-08-02      # M1-M5 complete
-run_commit_sha: pending-backfill # run-phase terminal SHA backfilled after the branch push (self-referential)
+run_commit_sha: 4966e6720        # run-phase terminal commit (M5); backfilled post-push per D3 self-referential exemption
 run_status: run-green            # all five milestones GREEN; 17/17 AC measured PASS
 ac_pass_count: 17                # AC-WSM-001..017 all measured PASS (M1-M5)
 ac_fail_count: 0
@@ -269,7 +269,7 @@ run_phase_commits:               # M1..M5 commits on fix/clean-stale-squash-dete
   m2: b22584c7c
   m3: 50b711eb9
   m4: d107d40db
-  m5: pending-backfill           # self-referential; backfilled post-push
+  m5: 4966e6720                  # run-phase terminal commit (M5)
 ```
 
 ## §E.4 Sync-phase Audit-Ready Signal

--- a/.moai/specs/SPEC-WORKTREE-SQUASH-MERGE-001/spec.md
+++ b/.moai/specs/SPEC-WORKTREE-SQUASH-MERGE-001/spec.md
@@ -2,7 +2,7 @@
 id: SPEC-WORKTREE-SQUASH-MERGE-001
 title: "worktree clean: detect squash-merged branches so --stale reclaims them"
 version: "0.6.1"
-status: draft
+status: in-progress
 created: 2026-08-02
 updated: 2026-08-02
 author: manager-spec

--- a/.moai/specs/SPEC-WORKTREE-SQUASH-MERGE-001/spec.md
+++ b/.moai/specs/SPEC-WORKTREE-SQUASH-MERGE-001/spec.md
@@ -1,0 +1,1200 @@
+---
+id: SPEC-WORKTREE-SQUASH-MERGE-001
+title: "worktree clean: detect squash-merged branches so --stale reclaims them"
+version: "0.6.1"
+status: draft
+created: 2026-08-02
+updated: 2026-08-02
+author: manager-spec
+priority: P1
+phase: "v3.0.x"
+module: "internal/core/git, internal/cli/worktree"
+lifecycle: spec-anchored
+tags: "worktree, git, cleanup, squash-merge, patch-id, disk-reclaim"
+tier: M
+---
+
+# SPEC-WORKTREE-SQUASH-MERGE-001 — Squash-merge detection for worktree cleanup
+
+## HISTORY
+
+| Version | Date | Change | Author |
+|---------|------|--------|--------|
+| 0.1.0 | 2026-08-02 | Initial plan-phase authoring. Root cause, detector matrix, and all four scope decisions resolved from executed git experiments. | manager-spec |
+| 0.2.0 | 2026-08-02 | Iteration-2 revision clearing plan-audit iteration 1 (FAIL, 0.62). Added the S5 state conjunct so S3/S4 are no longer sufficient alone, closing the partially-reverted false positive; re-ran the detector matrix at nine scenarios × five signals. Narrowed REQ-WSM-007 to name per-probe verdict codes. Added REQ-WSM-014. Recorded the clean-worktree-with-unpushed-commits removal case in §5 decision 3 and §4. | manager-spec |
+| 0.3.0 | 2026-08-02 | Iteration-3 revision clearing plan-audit iteration 2 (FAIL, 0.75). Closed the rename-fold false positive: the S5 path enumeration now uses `git diff --no-renames --name-only`, and the silent-failure mechanism behind it (a pathspec matching nothing makes `git diff --quiet` exit 0) is recorded in REQ-WSM-007's table and REQ-WSM-014. Matrix re-run at eleven scenarios × five signals under both settings; SC-10 (rename + re-add, squash) and SC-11 (rename + re-add, cherry-pick) added. `acceptance.md`: AC-WSM-005 consolidated to cover SC-6 and SC-7 together, AC-WSM-006 repurposed as the rename criterion, and the non-vacuity guard extended to AC-WSM-001, AC-WSM-010, and AC-WSM-015. | manager-spec |
+| 0.4.0 | 2026-08-02 | Iteration-4 revision, authorized by explicit user override of the three-iteration ceiling and **scoped to one finding**. Closed the path-encoding false positive: `git diff --name-only` C-quotes any path containing a backslash, tab, double quote, or control character — and, under git's documented default `core.quotePath=true`, any non-ASCII path — and the quoted string fed back as a pathspec matches nothing, which §2 finding 5 shows reads as merged. The S5 enumeration is now `git diff --no-renames --name-only -z` split on NUL. Matrix extended to twelve scenarios with SC-12 (non-ASCII path); SC-1..SC-11 re-run and cell-for-cell unchanged. REQ-WSM-007's table and REQ-WSM-014 record the encoding mechanism, including that `core.quotePath=false` is **not** a sufficient mitigation. `plan.md` §D's sentence asserting that a `strings.Split(out, "\n")` path list is safe — an affirmatively wrong claim — is corrected. `acceptance.md`: AC-WSM-006 extended with the `newline-split` falsification rather than adding a seventeenth criterion (Tier M AC ceiling), §C.1 grid re-run at 6 mutations × 12 scenarios, and run-phase judging commands added to AC-WSM-002..AC-WSM-008 so §F's per-criterion recording requirement holds as written. | manager-spec |
+| 0.6.0 | 2026-08-02 | Iteration-6 revision, adopting the conclusions of a commissioned OID-comparison-hybrid study. Closed the **comparison-semantics** false positive (D1/N10): S5's own notion of "difference" is configurable, so `git diff --quiet` can report equality for genuinely different content even when the path list is complete, byte-perfect, and matched literally. The S5 comparison now carries `--no-textconv` and `--ignore-submodules=none`, and the S5 **enumeration** now carries `--ignore-submodules=none` as well — the enumeration-side flag is **not** redundant, because two of the axis's three members suppress at the enumeration stage. §2's axis map gains a fifth axis with all three measured members and their stage classification. **The closure sentence at v0.5.0 ("no open axis remains — there is no sixth patch queued behind this one") is deleted**: it was false by measurement, and an affirmative false claim in the unsafe direction was the iteration-3 and iteration-5 FAIL cause. It is replaced by a bounded statement naming what was probed and what the probe found. Matrix extended to seventeen scenarios with SC-14 (textconv), SC-15 (submodule pointer under `submodule.<n>.ignore=all`), P3c (mode-only divergence), and P4c (symlink/file blob-OID collision); SC-1..SC-13 re-run and cell-for-cell unchanged. The commissioned hybrid was built, attacked, and **rejected** on measured grounds; that outcome is recorded so the option is not re-proposed a third time. `acceptance.md`: AC-WSM-006 absorbs SC-14 and SC-15 with two further falsifications, a new AC-WSM-017 pins mode sensitivity via P3c and P4c, and §C.1's grid is re-run at 11 mutations × 17 scenarios = 187 cells. | manager-spec |
+| 0.5.0 | 2026-08-02 | Iteration-5 revision, adopting the conclusions of a commissioned reformulation-viability study. Closed the pathspec-**interpretation** false positive (N8): a path whose first byte is `:` round-trips byte-perfectly under `-z` and is still parsed as pathspec magic, so S5 holds vacuously. The S5 comparison now carries `--literal-pathspecs` as a git-level option, which disables **all** pathspec magic and globbing by definition rather than enumerating hazardous symbols. Matrix extended to thirteen scenarios with SC-13 (leading-colon path); SC-1..SC-12 re-run and cell-for-cell unchanged. §2's honest-limits passage is rewritten from an instance count to the **four-axis** framing — completeness, argv, encoding, interpretation — recording that all four are now closed and that glob metacharacters and backslashes were measured to round-trip correctly, so `:` was the only open symbol class. The study built the named reformulation, attacked it, and **rejected** it on measured grounds (scenario A1b); that outcome is recorded so the option is not silently re-proposed. `plan.md` §D gains the no-shell requirement as a checked property. `acceptance.md`: AC-WSM-006 extended with the `no-literal` falsification and a widened selector rather than adding a seventeenth criterion (Tier M AC ceiling), §C.1 grid re-run at 7 mutations × 13 scenarios, SC-10's recipe disambiguated to "in two commits", and the shared `diff.ignoreSubmodules` exposure recorded as a stated limitation. | manager-spec |
+| 0.6.1 | 2026-08-02 | Pre-M1 plan-artifact pin; no mechanism change. Plan-audit iteration 6 (PASS, 0.89) reported D1 — a **sixth axis, the invocation's frame of reference**: the S5 enumeration emits repo-root-relative paths while the comparison's pathspecs resolve against the process working directory, so a cwd below the repository root turns every path into an unmatched pathspec and finding 5 reads that as merged (measured under default git configuration — no `.gitattributes`, no `.gitmodules`, no config key: `rc=1 / S5=NO` at the root, `rc=0 / S5=OK` from a subdirectory). Judged **not a live defect**: `plan.md` §C commits the implementation to the existing `execGit(ctx, w.root, …)` helper, which sets `cmd.Dir` to `repo.Root()` (`rev-parse --show-toplevel`), so the mechanism as it will be built is correct — what was missing is the **pin**, since §F pinned every property of the argument vector and nothing about the working directory. Therefore pinned rather than fixed, in exactly two additions: an `acceptance.md` §F Definition-of-Done item binding each invocation's working directory to the repository root, and a sixth row in `spec.md` §2's axis table recording the failure, the closure, and that `--literal-pathspecs` forecloses the in-band `:(top)` pathspec remedy. §2's axis count and instance count are updated to six and seven respectively; the bounded "no *known* open axis" framing is unchanged and no completeness claim is introduced. No acceptance criterion was added or altered, the seventeen-scenario matrix and the 187-cell §C.1 grid are untouched, and no measurement changes — so nothing requires re-running. | manager-spec |
+
+---
+
+## §1 Context and Problem
+
+`moai worktree clean --stale` sweeps abandoned worktrees that hold nothing to lose. Its
+second safety condition — "the branch carries no commits of its own beyond base" — is
+evaluated by `WorktreeProvider.IsBranchMerged`, whose sole implementation runs:
+
+```
+git branch --merged <base>
+```
+
+That command is a **reachability** test: a branch is listed only when its tip commit is an
+ancestor of `base`. A squash merge collapses N branch commits into ONE NEW commit on
+`base`; the original commits never become ancestors. `IsBranchMerged` therefore returns
+`false` forever for every squash-merged branch, `staleKeepReason` returns
+`"branch has commits not in <base>"`, and the worktree is silently kept. No error is
+raised, so the failure is invisible.
+
+This repository auto-merges every pull request with **squash**, so squash is the default
+merge path rather than an exception. The blind spot covers essentially every normally
+merged branch.
+
+### Observed impact
+
+Across 45 worktree branches on this repository: 4 recognized as merged by the current
+predicate, 33 actually merged but missed (squash), 8 genuinely unmerged — a reclaim rate
+near 11%. Disk held: `.claude/worktrees` 5.9G plus `~/.moai/worktrees` 1.3G.
+
+Reproduction (executed against this repository):
+
+```
+$ git branch --merged origin/main | grep -c 'fix/worktree-redesign-m0m1'
+0          # squash-merged via PR #1278, yet absent from the listing
+```
+
+### Affected call sites
+
+| Location (content anchor) | Path |
+|---|---|
+| `IsBranchMerged(branch, base string) (bool, error)` interface method | `internal/core/git/types.go` |
+| `func (w *worktreeManager) IsBranchMerged` implementation | `internal/core/git/worktree.go` |
+| `cleanMergedWorktrees` — the `--merged-only` path | `internal/cli/worktree/clean.go` |
+| `staleKeepReason` — the `--stale` path | `internal/cli/worktree/clean.go` |
+
+---
+
+## §2 Detector Evidence (executed)
+
+Seventeen merge scenarios were constructed as isolated git repositories and each was probed
+with five candidate signals. Every cell below is an observed result, not an inference.
+
+The signals:
+
+| Id | Signal | Probe |
+|---|---|---|
+| S1 | reachability | `git branch --merged <base>` lists `<branch>` |
+| S2 | empty diff | `git diff --quiet <merge-base> <branch>` reports no difference |
+| S3 | rebase-merge (history) | plain `git cherry <base> <branch>`, non-empty and every line prefixed `-` |
+| S4 | squash-merge (history) | synthetic-commit `git cherry`, non-empty and every line prefixed `-` |
+| S5 | **state reproduction** | every path the branch touched since its merge-base — enumerated with `git diff --ignore-submodules=none --no-renames --name-only -z`, so that a gitlink the branch moved is included (`--ignore-submodules=none`), a path the branch *deleted* or renamed away from is included (`--no-renames`), and every path is emitted verbatim rather than C-quoted (`-z`) — then fed back under `--literal-pathspecs` so the bytes are matched as a literal filename rather than parsed as pathspec magic, and compared under `--no-textconv --ignore-submodules=none` so the comparison cannot be configured to overlook a real difference — has identical content in base HEAD |
+
+S3 and S4 are recorded below as **raw** history signals, before the S5 conjunction; the
+composed verdict is `S1 OR S2 OR (S3 AND S5) OR (S4 AND S5)`.
+
+| Id | Scenario | S1 | S2 | S3 | S4 | S5 | Required verdict |
+|---|---|---|---|---|---|---|---|
+| SC-1 | squash-merged | keep | keep | keep | **MERGED** | **OK** | **merged** |
+| SC-2 | rebase-merged (individual replay) | keep | keep | **MERGED** | keep | **OK** | **merged** |
+| SC-3 | true merge commit | **MERGED** | **EMPTY** | keep | keep | OK | **merged** |
+| SC-4 | strictly behind base | **MERGED** | **EMPTY** | keep | keep | OK | **merged** |
+| SC-5 | empty-diff branch (empty commit only) | keep | **EMPTY** | keep | keep | OK | **merged** |
+| SC-6 | partially applied | keep | keep | keep | keep | **NO** | **not merged** |
+| SC-7 | fully unmerged (control) | keep | keep | keep | keep | **NO** | **not merged** |
+| SC-8 | **partially reverted** | keep | keep | **MERGED** | keep | **NO** | **not merged** |
+| SC-9 | base is a strict superset | keep | keep | **MERGED** | **MERGED** | OK | **merged** |
+| SC-10 | **rename + re-add, squash-merged** | keep | keep | keep | **MERGED** | **NO** | **not merged** |
+| SC-11 | **rename + re-add, cherry-picked** | keep | keep | **MERGED** | **MERGED** | **NO** | **not merged** |
+| SC-12 | **non-ASCII path removed from base** | keep | keep | **MERGED** | **MERGED** | **NO** | **not merged** |
+| SC-13 | **leading-colon path removed from base** | keep | keep | **MERGED** | **MERGED** | **NO** | **not merged** |
+| SC-14 | **textconv driver collapses a changed file** | keep | keep | **MERGED** | **MERGED** | **NO** | **not merged** |
+| SC-15 | **submodule pointer moved, `submodule.<n>.ignore=all`** | keep | keep | **MERGED** | **MERGED** | **NO** | **not merged** |
+| P3c | **mode-only divergence (chmod)** | keep | keep | **MERGED** | **MERGED** | **NO** | **not merged** |
+| P4c | **symlink/file blob-OID collision** | keep | keep | **MERGED** | **MERGED** | **NO** | **not merged** |
+
+SC-10 and SC-11 are the rename pair. In both, the branch renames a file that exists at the
+merge-base, base takes the branch's work, and base *later re-adds the original path*. The
+branch's deletion of that path therefore does not survive in base HEAD, so the required
+verdict is not-merged. Their S5 column reads `NO` **only** because the enumeration uses
+`--no-renames`; under git's default rename detection S5 reads `OK` in both rows and the
+composed verdict flips to a false positive. See finding 5 and Falsified alternative 3.
+
+SC-12 is the encoding case, and it is a *third* route to the same failure. The branch adds
+a file whose name is non-ASCII (`문서.txt`); base squash-merges the branch and then removes
+that file, so the branch's content does not survive in base HEAD and the required verdict
+is not-merged. Its S5 column reads `NO` **only** because the enumeration is NUL-delimited
+(`-z`); split on newline, the path arrives C-quoted as `"\353\254\270\354\204\234.txt"`,
+that literal matches no file, and S5 reads `OK`. Both S3 and S4 fire here, so the
+enumeration is again the only thing standing between two agreeing history signals and a
+wrong removal. See finding 6 and Falsified alternative 4.
+
+SC-13 is the *interpretation* case, and it is a fourth route to the same failure — the one
+that survives every repair above. The branch adds a repo-root file named `:note.txt`; base
+squash-merges the branch and then removes that file, so the required verdict is not-merged.
+Its path list is byte-perfect under `-z` — the enumeration emits `:note.txt` exactly — and
+the probe still fails, because git parses a leading `:` in a *pathspec* as magic before any
+matching happens. Its S5 column reads `NO` **only** because the comparison carries
+`--literal-pathspecs`; without it the pathspec names no file and S5 reads `OK`. Both S3 and
+S4 fire here as well. See finding 7 and Falsified alternative 5.
+
+SC-14 and SC-15 are the *comparison-semantics* pair, and they are a fifth route to the same
+failure — the first one that does not touch the path list at all. In SC-14 the branch adds
+`report.pdf` under a `.gitattributes` rule binding a `textconv` diff driver; base
+squash-merges and then overwrites the file with different content. The path list is complete
+and byte-perfect, and the comparison still reports equality, because the driver renders both
+blobs to the same text. In SC-15 the branch moves a submodule pointer with **no**
+`.gitmodules` change; base squash-merges and then moves the pointer elsewhere. Under
+`submodule.<name>.ignore=all` the gitlink is dropped at *both* stages — it never enters the
+enumeration, and the comparison would ignore it even if it did. Their S5 columns read `NO`
+**only** because the comparison carries `--no-textconv --ignore-submodules=none` and the
+enumeration carries `--ignore-submodules=none`. Both S3 and S4 fire in each. See finding 8
+and Falsified alternative 6.
+
+P3c and P4c are not repairs — they are **retention** rows. The design as specified already
+reports both correctly, and they are recorded because they are the only two scenarios in the
+matrix whose verdict depends on the comparison being sensitive to a file's **mode**. In P3c
+the branch chmods a file to 755 and base chmods it back; in P4c the branch replaces a symlink
+with a regular file whose content is exactly the symlink's target, and base reverts it. In
+both, the two sides share **one blob OID** and differ only in mode:
+
+```
+P3c   feat 100755 blob 587be6b4c3f93f93c489c0111bba5596147a26cb  x.txt
+      main 100644 blob 587be6b4c3f93f93c489c0111bba5596147a26cb  x.txt
+P4c   feat 100644 blob 1de565933b05f74c75ff9a6520af5f9f8a5a2f1d  link.txt
+      main 120000 blob 1de565933b05f74c75ff9a6520af5f9f8a5a2f1d  link.txt
+
+git --literal-pathspecs diff --quiet --no-textconv --ignore-submodules=none …   rc=1  (detects)
+blob-OID-only comparison over the same two paths                                EQUAL (misses)
+```
+
+`git diff` compares modes, so the specified mechanism passes both. Any future edit that
+swaps the comparison for something mode-blind — a blob-OID comparison being the obvious
+candidate, and the one an earlier proposal reached for — turns both rows into silent
+fail-open false positives under **default** git configuration, with no `.gitattributes` and
+no config key involved. That is a strictly worse exposure than any axis-5 member, all of
+which require non-default state. AC-WSM-017 exists to fail if that swap is made.
+
+Eight findings govern the design:
+
+1. **The signals are complementary, not competing.** No single signal covers all merged
+   scenarios. `git branch --merged` is the only one that recognises a true merge commit and
+   a strictly-behind branch; the synthetic-commit probe is the only one that recognises a
+   squash merge. Replacing the existing reachability test rather than extending it would
+   regress the two scenarios it already handles correctly.
+2. **S3 and S4 are history signals and are not sufficient alone.** Both ask whether an
+   equivalent patch-id existed at *some point* in base's history since the merge-base. They
+   do not ask whether the content *survives* in base HEAD. SC-8 separates the two: a
+   later revert leaves the patch-ids matched while the content is gone, and S3 fires on a
+   branch whose work is genuinely absent. S3 and S4 are therefore each conjoined with S5,
+   which asks the state question directly. S5 is never a merged verdict on its own — it is
+   only ever a conjunct, so it can withhold a verdict but never grant one.
+3. **SC-9 is pinned to one construction, and the row does not generalise.** The recorded
+   row is produced by exactly the `acceptance.md` §B recipe: base re-creates the branch's
+   change as its own commit (`main` adds `s.txt`, then additionally adds `extra.txt`).
+   That is the construction the cells describe, and it is the only one they describe.
+   The superficially similar phrasing "base cherry-picks the branch's commit and then adds
+   more" is **not** an equivalent recipe and MUST NOT be substituted: a cherry-pick
+   performed with no elapsed time reproduces the branch commit's tree, parent, message, and
+   identity, so the two commits collide on SHA, the branch becomes a literal ancestor of
+   base, the merge-base moves, and the scenario silently degenerates into SC-4 (strictly
+   behind) with S1 firing. `acceptance.md` §B carries the same warning about identical
+   commit metadata; it applies here. A superset built so that base's version of the change
+   has a *different* patch-id yields no history signal and therefore a not-merged verdict —
+   a harmless false negative, since the worktree is merely kept.
+4. **Across this seventeen-scenario matrix, no false positive survives.** The eleven
+   scenarios that must be kept (SC-6 partially applied, SC-7 fully unmerged, SC-8 partially
+   reverted, SC-10 and SC-11 rename + re-add, SC-12 non-ASCII path, SC-13 leading-colon
+   path, SC-14 textconv, SC-15 submodule-ignore, P3c mode-only, P4c symlink/file collision)
+   are reported as "keep" by the composed predicate. This statement is scoped to the
+   constructed matrix; it is not a claim of general correctness over all possible histories.
+   **This claim has been read as general and falsified five times, and the record of that is
+   the reason the scoping sentence above is load-bearing rather than decorative.** SC-8
+   exists because the earlier seven-scenario version of this claim was falsified; SC-10 and
+   SC-11 exist because the nine-scenario version was falsified the same way; SC-12 because
+   the eleven-scenario version was falsified by attacking the *output encoding* of the
+   enumeration the previous repair introduced; SC-13 because the twelve-scenario version was
+   falsified by attacking how that byte-perfect output is *parsed* when handed back; SC-14
+   and SC-15 because the thirteen-scenario version was falsified by attacking the
+   *comparison* that received a list correct on every prior axis. The first four
+   falsifications share one shape — S5's input did not name what it was supposed to name.
+   The fifth has a different shape: S5's input was correct and S5 itself was configured not
+   to notice. The axis map below records both shapes and which repair closed each.
+5. **A pathspec that matches nothing is silently read as "no difference".** `git diff
+   --quiet <a> <b> -- <pathspec-matching-nothing>` exits **0**, not non-zero (measured
+   below and recorded in REQ-WSM-007's table). S5 therefore fails *open*: any defect that
+   makes the enumerated path list under-inclusive does not surface as an error — it
+   surfaces as a merged verdict. Omission becomes a pass, in the unsafe direction. This is
+   the mechanism behind Falsified alternative 3, and it is why REQ-WSM-014 states the
+   enumeration's completeness as a requirement rather than leaving it to the mechanism.
+6. **`git diff --name-only` does not emit paths verbatim — it C-quotes them.** A path
+   containing a backslash, a tab, a double quote, or a control character is emitted inside
+   double quotes with C-style escapes, **unconditionally**; and under git's documented
+   default `core.quotePath=true`, so is any path containing a non-ASCII byte. The quoted
+   string is not the path: fed back as a pathspec it matches nothing, and by finding 5 that
+   reads as "no difference". This is a distinct defect from the rename fold — the fold
+   *omits* a path, the quoting *corrupts* one — but it lands in the same unsafe direction,
+   and it survived the `--no-renames` repair untouched because the two are orthogonal.
+   `core.quotePath=false` is **not** a sufficient mitigation: it suppresses quoting only for
+   the non-ASCII case, while backslash and control characters stay quoted regardless
+   (measured below). The mechanism that emits paths verbatim in every case is `-z`, which
+   NUL-delimits and never quotes. This is the mechanism behind Falsified alternative 4, and
+   it is why REQ-WSM-014 binds the enumeration's *encoding* alongside its completeness.
+7. **A byte-perfect path is still not a filename — git parses a pathspec before matching
+   it.** `-z` guarantees the bytes leaving the enumeration are the path's own bytes. It says
+   nothing about how those bytes are read when handed back, and git reads a pathspec's
+   leading characters as *magic* before any matching occurs. A repo-root entry whose first
+   byte is `:` is therefore parsed as a magic prefix rather than as a filename: `:root.txt`
+   and `:(glob)g.txt` match nothing, while `:!bang.txt` and `:^caret.txt` are worse than
+   unmatched — they become EXCLUDE pathspecs and silently invert what the probe compares.
+   This is a distinct defect from both the rename fold and the quoting: the fold *omits* a
+   path, the quoting *corrupts* one, and this *re-interprets* one that arrived intact.
+   Measured, in a repository where the correct answer is `rc=1` in every row:
+
+   ```
+   bare pathspec (as specified through v0.4.0)
+     :root.txt        rc=0   <- parsed as magic, matched NOTHING
+     :(glob)g.txt     rc=0   <- parsed as long-form :(glob) magic + path g.txt
+     :!bang.txt       rc=1   but as EXCLUDE magic — the probe's comparison is inverted
+     :^caret.txt      rc=1   but as EXCLUDE magic — likewise
+     dir/:nested.txt  rc=1   safe (the colon is not the pathspec's first byte)
+     mid:colon.txt    rc=1   safe
+
+   --literal-pathspecs — all six round-trip as filenames, all rc=1
+   ```
+
+   The exposure is bounded: only repo-root entries whose **first byte** is `:`, and `:` is
+   illegal in Windows filenames, so it is POSIX-only. The mechanism that closes it is
+   `--literal-pathspecs`, which disables **all** pathspec magic and globbing by definition
+   rather than enumerating hazardous symbols. This is the mechanism behind Falsified
+   alternative 5, and it is why REQ-WSM-014 binds *round-trip* fidelity rather than encoding
+   fidelity alone.
+8. **A correct path list is still not a correct answer — git's notion of "difference" is
+   itself configurable.** Findings 5 through 7 all concern the path list: whether it is
+   complete, whether its bytes survive, whether those bytes are read as a filename. This
+   finding concerns what happens *after* all three succeed. `git diff --quiet` decides
+   equality under the repository's diff configuration, and that configuration can be
+   narrowed until it reports equality for genuinely different content. Three members were
+   measured, and they do **not** act at the same stage:
+
+   ```
+   member                                  enumeration     comparison    closed by
+   .gitattributes diff=X + diff.X.textconv  unaffected      SUPPRESSED    --no-textconv
+   diff.ignoreSubmodules=all                SUPPRESSED      SUPPRESSED    --ignore-submodules=none
+   submodule.<name>.ignore=all              SUPPRESSED      SUPPRESSED    --ignore-submodules=none
+   ```
+
+   The stage classification is the load-bearing part, because it decides where the flags go.
+   textconv is **comparison-side only** — measured, the name-listing path never runs the
+   driver, so the enumeration still reports the changed file and only `--quiet` is fooled:
+
+   ```
+   git diff --name-only  feat main -- report.pdf   ->  report.pdf   (still reported)
+   git diff --quiet      feat main -- report.pdf   ->  rc=0         <- ONLY this is fooled
+   git diff --quiet --no-textconv feat main -- report.pdf -> rc=1
+   ```
+
+   The two submodule keys act at **both** stages: they drop the gitlink from
+   `git diff --name-only` itself, so the path never reaches the comparison at all. Measured
+   on SC-15, where the correct path list is `[plain.txt, sub]`:
+
+   ```
+   git diff --no-renames --name-only -z <mb> feat                        ->  [plain.txt]
+   git diff --ignore-submodules=none --no-renames --name-only -z <mb> feat -> [plain.txt, sub]
+   ```
+
+   That is why `--ignore-submodules=none` is required on the **enumeration** as well as the
+   comparison, and why removing it from either stage alone reproduces the false positive
+   (both mutations flip SC-15; `acceptance.md` §C.1). A future edit that deletes the
+   enumeration-side flag as redundant with the comparison-side one re-opens SC-15.
+
+   `submodule.<name>.ignore` matters more than its sibling because it does not need the
+   operator's own config: the key is readable from `.gitmodules`, which is a **tracked
+   file**, so a repository can ship this exposure to every clone. Measured — with
+   `.git/config` carrying no such key and the directive committed inside `.gitmodules`
+   instead, SC-15 reproduces identically. It shares textconv's worktree-state dependence:
+   both values are read from the checked-out file, not from the tree under judgement, so the
+   verdict depends on the state of the judging worktree. Removing the worktree's
+   `.gitattributes` makes SC-14's false positive vanish while the file is still committed —
+   a sensitivity none of the first four axes had. This is the mechanism behind Falsified
+   alternative 6, and it is why REQ-WSM-014 binds the *observed comparison* rather than the
+   path list alone.
+
+### Falsified alternative 1 — plain `git cherry <base> <branch>` as the squash detector
+
+Plain per-commit `git cherry` is the most plausible-looking answer and is **wrong for the
+squash case**. A squash merge collapses N commits into one, so the individual per-commit
+patch-ids never match the single squashed commit's patch-id. On the two verification
+branches it reported 8 and 2 commits respectively as "not applied" — a false negative in
+both. It is retained in this design only as the **rebase-merge** signal, where it is
+correct; it must never be used alone as the squash detector.
+
+### Falsified alternative 2 — history-only patch-id equivalence (no state check)
+
+A predicate composed of S1/S2/S3/S4 alone reports SC-8 as **merged** while `b.txt` is
+genuinely absent from base. Observed:
+
+```
+main tree      : a.txt seed.txt
+feat tree      : a.txt b.txt seed.txt
+plain cherry   : - 616bf026a585f183d8c49ec58de025fb68fc4d15 | - fb4444864adbdc8bed6c4f61bd35d172551c4054
+                 (both lines '-', so S3 fires)
+names(mb..feat): a.txt b.txt
+state probe    : git diff --quiet feat main -- a.txt b.txt  ->  rc=1  (content differs; S5 = NO)
+```
+
+Both cherry lines are prefixed `-`, so the S3 guard ("non-empty AND every line `-`") is
+satisfied and a history-only predicate returns merged. S5 is the signal that withholds the
+verdict. This is why the target semantic in REQ-WSM-001 is stated in **state** terms and
+why REQ-WSM-014 makes the conjunction binding.
+
+### Synthetic-commit mechanism (Candidate A)
+
+```
+mb=$(git merge-base <base> <branch>)
+synth=$(git commit-tree "$(git rev-parse <branch>^{tree})" -p "$mb" -m <fixed-message>)
+git cherry <base> "$synth"     # leading '-' means the patch is already present in base
+```
+
+Collapsing the branch's entire diff-versus-merge-base into one synthetic commit gives it
+the same shape as the single squashed commit on `base`, so their patch-ids match.
+Verified on this repository against a known squash-merged branch: `git cherry` emitted a
+single line prefixed `-`.
+
+### State-conjunct mechanism (S5)
+
+```
+mb=$(git merge-base <base> <branch>)
+# paths the branch touched, NUL-delimited and split on NUL — never on newline
+names=( ); while IFS= read -r -d '' p; do names+=("$p"); done \
+  < <(git diff --ignore-submodules=none --no-renames --name-only -z "$mb" <branch>)
+# when names is empty the branch touched nothing: S5 holds trivially
+# --literal-pathspecs is a GIT-LEVEL option and MUST precede the subcommand;
+# --no-textconv and --ignore-submodules=none are DIFF-level and MUST follow it
+git --literal-pathspecs diff --quiet --no-textconv --ignore-submodules=none \
+    <branch> <base> -- <names as separate arguments>
+                                                 # rc=0 -> S5 holds; rc=1 -> S5 withholds
+```
+
+`--ignore-submodules=none` appears **twice on purpose**, once per stage. It is the flag a
+future reader is most likely to delete as duplication, and deleting either occurrence
+re-opens SC-15: the two submodule-ignore keys suppress the gitlink at the enumeration stage
+*and* at the comparison stage, so closing one stage leaves the other open (finding 8;
+mutation-checked in `acceptance.md` §C.1, where `no-ignoresub-cmp` and `no-ignoresub-enum`
+each flip SC-15 on their own).
+
+Option position is not stylistic, and the three flags do not share a position.
+`--literal-pathspecs` is a **git-level** option and belongs before `diff`; `--no-textconv`
+and `--ignore-submodules=none` are **diff-level** and belong after it. Every misplacement is
+rejected outright rather than silently misread. Measured, all five forms executed:
+
+```
+git --literal-pathspecs diff --quiet --no-textconv --ignore-submodules=none feat main -- …
+                                                                       rc=1    <- correct
+git diff --ignore-submodules=none --no-renames --name-only -z <mb> feat rc=0    <- enumeration, correct
+git --no-textconv diff --quiet feat main -- report.pdf                  rc=129  unknown option
+git --ignore-submodules=none diff --quiet feat main -- report.pdf       rc=129  unknown option
+git diff --literal-pathspecs --quiet feat main -- ':note.txt'           rc=129  usage error
+```
+
+`rc=129` is distinct from both verdict codes (0 and 1), so a misplacement announces itself
+instead of degrading into a wrong verdict. This is the one property the round-trip repairs
+do **not** share: `--no-renames`, `-z`, and a joined path list all fail silently in the
+merged direction, while every flag-position error here fails loudly.
+
+The probe asks a state question: for every path the branch changed relative to its
+merge-base, is base HEAD's content identical to the branch's? A `rc=1` means at least one
+of those paths differs in base HEAD, so part of the branch's work is not present there —
+regardless of what the patch-id history says.
+
+Seven properties of this block are load-bearing, and each has a failure mode that is
+silent rather than loud when the property is *omitted*:
+
+- **`--no-renames` is required, not decorative.** `git diff --name-only` applies rename
+  detection by default (`diff.renames` has defaulted to true since git 2.9; verified unset
+  in a fresh repository, so the default applies). For a renamed path it reports only the
+  **destination**; the deleted source path is folded away and never enters the pathspec.
+  The branch's deletion of that path is then never checked. Measured, with `old.txt`
+  present at the merge-base and renamed to `new.txt` on the branch:
+
+  ```
+  git diff --name-status <mb> feat        ->  R086  old.txt  new.txt
+  git diff --name-only            <mb> feat  ->  [new.txt]            <- old.txt ABSENT
+  git diff --no-renames --name-only <mb> feat ->  [new.txt old.txt]   <- old.txt PRESENT
+  ```
+
+  A future edit that removes the flag as redundant re-opens SC-10 and SC-11 as false
+  positives. AC-WSM-006 exists to fail if it is removed.
+
+- **`-z` is required, not decorative.** Without it `git diff --name-only` C-quotes any path
+  containing a backslash, a tab, a double quote, or a control character, and — under git's
+  documented default `core.quotePath=true` — any non-ASCII path. The quoted form is a
+  different string from the path, so it matches nothing as a pathspec. Measured, by
+  round-tripping each `--name-only` line straight back as a pathspec where the correct
+  answer is `rc=1` in every row:
+
+  ```
+  core.quotePath=true (git's documented default)
+    "a\\b.txt"                      rc=0   <- matched NOTHING
+    "caf\303\251.txt"               rc=0   <- matched NOTHING
+    plainname.txt                   rc=1   (matched)
+    "tab\tname.txt"                 rc=0   <- matched NOTHING
+    "\355\225\234\352\270\200.txt"  rc=0   <- matched NOTHING
+
+  core.quotePath=false — which names are STILL quoted
+    "a\\b.txt"        <- backslash quoted regardless of quotePath
+    "tab\tname.txt"   <- control char quoted regardless of quotePath
+    café.txt          (unquoted under quotePath=false)
+    한글.txt           (unquoted under quotePath=false)
+
+  -z (NUL-delimited) — never quoted; round-trip correct for all five
+    a\b.txt   café.txt   plainname.txt   tab<TAB>name.txt   한글.txt      all rc=1
+  ```
+
+  Two consequences follow, and the second is the one a future reader is most likely to get
+  wrong. First, the defect is **not** confined to non-ASCII repositories: a backslash or a
+  control character in a path quotes on any machine, whatever the config. Second,
+  **`core.quotePath=false` is not a fix** — it silences only the non-ASCII half, leaving the
+  backslash and control-character halves intact, so a repair that merely documents the
+  config setting closes two-thirds of the hole and reads as if it closed all of it. `-z` is
+  what removes the round-trip hazard entirely. A future edit that drops `-z` as redundant
+  re-opens SC-12 as a false positive; AC-WSM-006's second falsification exists to fail if
+  it is removed.
+
+- **`--literal-pathspecs` is required, not decorative.** `-z` makes the enumeration's output
+  byte-exact; it does nothing about how those bytes are parsed when handed back. Git reads a
+  pathspec's leading characters as magic before matching, so a repo-root path beginning with
+  `:` names no file (finding 7), and `:!`/`:^` forms silently invert the comparison. The flag
+  disables all pathspec magic and all globbing, which closes the interpretation axis
+  categorically rather than symbol-by-symbol. Losing glob expansion costs nothing on the
+  safety axis: over-matching can only add differences, and an added difference withholds a
+  verdict. A future edit that drops the flag as redundant re-opens SC-13 as a false positive;
+  AC-WSM-006's third falsification exists to fail if it is removed.
+
+- **`--no-textconv` is required, not decorative.** The three prior flags all govern the path
+  list; this one governs what the comparison *does* with a correct list. A `.gitattributes`
+  rule binding a `textconv` diff driver makes `git diff --quiet` compare the driver's
+  rendering rather than the blobs, so two genuinely different files compare equal
+  (finding 8). The trigger is a documented, ordinary recipe — `*.pdf diff=pdf` with a
+  `pdftotext` driver is an example in git's own `gitattributes(5)`, and the same pattern is
+  routine for `*.docx` and image formats — and the predicate runs in whatever repository the
+  user has. A future edit that drops the flag re-opens SC-14 as a false positive;
+  AC-WSM-006's fourth falsification exists to fail if it is removed.
+
+- **`--ignore-submodules=none` is required on BOTH stages, not decorative and not
+  duplication.** `diff.ignoreSubmodules=all` and `submodule.<name>.ignore=all` suppress a
+  changed gitlink at the enumeration stage *and* at the comparison stage, so a single-stage
+  repair leaves the other stage open (finding 8). This is the only guard in the block that
+  must be applied twice, and the enumeration-side occurrence is the one most likely to be
+  deleted as redundant — it is not: without it the gitlink never enters `names`, and by the
+  fail-open property below an absent path is silently "no difference". `submodule.<name>.ignore`
+  is readable from a **tracked** `.gitmodules`, so unlike every other member of every axis
+  this exposure can arrive inside the repository rather than from operator configuration. A
+  future edit that drops either occurrence re-opens SC-15; AC-WSM-006's fifth falsification
+  exists to fail if either is removed.
+
+- **An under-inclusive pathspec fails open (finding 5).** `git diff --quiet` exits 0 when
+  the pathspec matches nothing, so the omission caused by the fold does not raise an error
+  — it reads as "no difference", which the predicate reads as merged. That is why the
+  rename fold produced a false *positive* rather than a crash.
+
+- **`names` must be passed as separate arguments, never as one reconstructed string.**
+  This is the same failure surface reached by a different route. Passing the list as a
+  single joined string yields one pathspec that matches nothing, and by the property above
+  that reads as merged. Measured on the same repository, where the correct answer is
+  `rc=1`:
+
+  ```
+  argv: <feat> <main> <--> <old.txt >     (list joined into one argument)   rc=0   <- WRONG
+  argv: <feat> <main> <--> <old.txt>      (one argument per path)           rc=1   <- right
+  ```
+
+  The joined form arises from shell word-splitting differences (`bash` splits an unquoted
+  `$names` and happens to survive; `zsh` does not split and fails), which is exactly why
+  the implementation must not route the list through a shell string at all — see
+  `plan.md` §D.
+
+The empty-`names` guard matters: with no pathspec, `git diff --quiet <branch> <base>`
+compares the whole trees and would report a difference for any branch behind an advanced
+base. Scoping to the branch's own touched paths is what makes the probe answer "is the
+branch's work present" rather than "are the trees equal".
+
+### Falsified alternative 3 — enumerating S5's paths with rename detection on
+
+Computing `names` with a plain `git diff --name-only` — the form this SPEC specified at
+v0.2.0 — is falsified by SC-10 and SC-11. Both were run under both settings:
+
+```
+scenario                       names(rename-folded)  names(--no-renames)     folded      --no-renames
+SC-10 rename + re-add, squash  [new.txt]             [new.txt old.txt]       merged      not merged
+SC-11 rename + re-add, pick    [new.txt]             [new.txt old.txt]       merged      not merged
+```
+
+Under the folded enumeration, S5 reads `OK` in both rows — it never examines `old.txt`,
+which the branch deleted and which base still holds — so the S4 signal (SC-10) and the
+S3/S4 signals (SC-11) are granted unopposed and the composed verdict is **merged** while
+the branch's deletion is genuinely absent from base. This is the same defect class as
+SC-8: a patch-id history signal fires while the content does not survive in base HEAD.
+SC-8 reached it through a revert; SC-10 and SC-11 reach it through a path the conjunct
+could not see.
+
+The repair is the `--no-renames` flag on the enumeration only. The matrix was re-run under
+both settings: SC-1 through SC-9 are **cell-for-cell identical** in the two columns, so the
+flag regresses nothing, and SC-10 and SC-11 flip from merged to not-merged. Verbatim output
+is in `acceptance.md` §C.
+
+### Falsified alternative 4 — splitting the enumeration's output on newline
+
+Splitting `git diff --no-renames --name-only` output on newline — the form this SPEC
+specified at v0.3.0 — is falsified by SC-12. Run under both splits, using the enumeration
+exactly as v0.3.0 prescribed it:
+
+```
+scenario                      names(newline-split)                       names(-z)              nl-split    -z
+SC-12 non-ASCII path removed  [plain.txt "\353\254\270\354\204\234.txt"] [plain.txt 문서.txt]    merged      not merged
+```
+
+Under the newline split the second path arrives C-quoted. That literal matches no file, so
+`git diff --quiet` compares only `plain.txt` — which *is* identical in base — and exits 0.
+S5 reads `OK`, both history signals are granted unopposed, and the composed verdict is
+**merged** while `문서.txt` is genuinely absent from base HEAD. This is the same defect
+class as SC-8 and as SC-10/SC-11, reached by a fourth route: not a revert, not a rename
+fold, not a joined shell string, but the *encoding* of the enumeration's own output.
+
+The repair is `-z` on the enumeration plus a NUL split. The full twelve-scenario matrix was
+re-run under both splits: SC-1 through SC-11 are **cell-for-cell identical**, so the flag
+regresses nothing, and SC-12 flips from merged to not-merged. Verbatim output is in
+`acceptance.md` §C.
+
+### Falsified alternative 5 — feeding the byte-perfect path list back as a bare pathspec
+
+Passing the `-z` path list to `git diff --quiet` without literal-pathspec handling — the
+form this SPEC specified at v0.4.0 — is falsified by SC-13. The enumeration is not at fault
+here and the path list is not corrupt; the same bytes are read differently on the way back:
+
+```
+scenario                        names(-z)                    bare pathspec   --literal-pathspecs
+SC-13 leading-colon path removed [:note.txt plain.txt]        merged          not merged
+```
+
+Under the bare form git parses `:note.txt` as a magic prefix rather than a filename, so it
+names no file. `git diff --quiet` compares only `plain.txt` — identical in base — and exits
+0. S5 reads `OK`, both history signals are granted unopposed, and the verdict is **merged**
+while `:note.txt` is genuinely absent from base HEAD. This is the same defect class again,
+reached by a fifth route: not a revert, not a rename fold, not a joined shell string, not
+the enumeration's output encoding, but git's *parsing* of a path list that arrived intact.
+
+The repair is `--literal-pathspecs` as a git-level option on the comparison. The full
+thirteen-scenario matrix was re-run under both forms: SC-1 through SC-12 are
+**cell-for-cell identical**, so the flag regresses nothing, and SC-13 flips from merged to
+not-merged. Verbatim output is in `acceptance.md` §C.
+
+### Falsified alternative 6 — comparing a correct path list under the repository's own diff configuration
+
+Issuing the comparison without `--no-textconv` and without `--ignore-submodules=none` — the
+form this SPEC specified at v0.5.0 — is falsified by SC-14 and SC-15. Neither the
+enumeration nor the round-trip is at fault here; on SC-14 the path list is complete and
+byte-perfect, and the comparison still reports equality:
+
+```
+scenario                             names                        v0.5.0 form   with the two flags
+SC-14 textconv driver                [plain.txt report.pdf]       merged        not merged
+SC-15 submodule ignore=all           [plain.txt] / [plain.txt sub] merged        not merged
+```
+
+On SC-14 the `.gitattributes` rule `*.pdf diff=pdf` binds a `textconv` driver; `git diff
+--quiet` compares the driver's rendering of each blob rather than the blobs themselves, both
+render to the same text, and the comparison exits 0. Ground truth is that the blobs differ:
+
+```
+feat:report.pdf = dcc7c925c1f3fb918a192d6f40835189490d4e4c
+main:report.pdf = 43d844c81ab8ccc32d09beb9d70f5831d1474402
+git --literal-pathspecs diff --quiet feat main -- report.pdf                 rc=0   <- WRONG
+git --literal-pathspecs diff --quiet --no-textconv feat main -- report.pdf   rc=1   <- right
+```
+
+On SC-15 the failure is one stage earlier as well: under `submodule.<name>.ignore=all` the
+moved gitlink never enters the path list at all, so the comparison is never asked about it.
+Ground truth is that the pointers differ:
+
+```
+feat:sub = 1a7d9a656cfc3f54f58da6d184dcbc0c33a29cb3
+main:sub = 034452180de5fd3d9b2bba76a8bc15273cad6386
+enumeration without --ignore-submodules=none  ->  [plain.txt]          <- gitlink DROPPED
+enumeration with    --ignore-submodules=none  ->  [plain.txt, sub]     <- gitlink present
+comparison without the flag, given the correct list                 rc=0   <- WRONG
+comparison with    the flag, given the correct list                 rc=1   <- right
+```
+
+S5 reads `OK` in both, both history signals are granted unopposed, and the composed verdict
+is **merged** while the branch's content is genuinely absent from base HEAD. This is the same
+defect class again, reached by a sixth route: not a revert, not a rename fold, not a joined
+shell string, not the enumeration's output encoding, not git's parsing of the path list —
+but git's *judgement* of a path list that was correct on every prior axis.
+
+The repair is `--no-textconv` and `--ignore-submodules=none` on the comparison, plus
+`--ignore-submodules=none` on the enumeration. The full seventeen-scenario matrix was re-run
+under both forms: SC-1 through SC-13 are **cell-for-cell identical**, so the flags regress
+nothing, and SC-14 and SC-15 flip from merged to not-merged. Verbatim output is in
+`acceptance.md` §C.
+
+### Six honest limits on these repairs, taken together
+
+The repairs are better read as an axis map than as a patch count, because the axis map is
+what says where the mechanism can still be attacked. Four axes concern the **path list** —
+whether it names what it should. The fifth concerns the **comparison** — whether a correct
+list is judged honestly. The sixth concerns the **invocation** — whether the two stages
+resolve paths against the same root at all:
+
+| Axis | Failure | Closed by | Falsified by |
+|---|---|---|---|
+| completeness | the rename fold hides the branch's deleted source path | `--no-renames` | SC-10, SC-11 |
+| argv | the path list is joined into one string | `[]string`, one argument per path | measured in §C.2 route 2 |
+| encoding | git C-quotes the path, so the bytes are not the path's | `-z` + NUL split | SC-12 |
+| interpretation | the bytes are correct and git parses them as magic | `--literal-pathspecs` | SC-13 |
+| **comparison semantics** | the list is correct and the comparison is configured not to notice | **`--no-textconv`** (comparison) + **`--ignore-submodules=none`** (**both** stages) | SC-14, SC-15 |
+| **frame of reference** | the list is correct and the comparison resolves it against a different root — the enumeration emits repo-root-relative paths, the pathspecs resolve against the process working directory, so a nested cwd turns every path into an unmatched pathspec and finding 5 reads that as merged | **invoking git with cwd = the repository root** (`execGit`'s `dir` argument is `w.root`, i.e. `rev-parse --show-toplevel`). The fix must be at the invocation level: `--literal-pathspecs` forecloses the in-band `:(top)` remedy by reading the magic prefix as a literal filename | measured — default configuration, cwd below the root: `rc=1 / S5=NO` at the root, `rc=0 / S5=OK` from a subdirectory. Not a live defect under the specified design, and pinned rather than patched (`acceptance.md` §F) |
+
+Three things follow, and the third is the one a reader is most likely to get wrong:
+
+- **`--literal-pathspecs` closes an axis, not a symbol.** It disables *all* pathspec magic
+  and *all* globbing by definition, rather than enumerating hazardous characters. That
+  distinction is load-bearing, because a symbol-by-symbol repair would leave the axis open
+  to whichever form went unenumerated.
+- **The interpretation axis had exactly one open symbol class.** Glob metacharacters and
+  backslashes were *measured* to round-trip correctly under a bare pathspec — git's matcher
+  attempts a literal comparison in addition to wildmatch, so a file literally named
+  `*star.txt` is matched by the pathspec `*star.txt`. Measured, where the correct answer is
+  `rc=1` in every row: `*star.txt`, `?q.txt`, `[a]x.txt`, and `a\b.txt` each return `rc=1`
+  under both the bare and the literal forms. A leading `:` was therefore the only class the
+  bare form left open, and the flag closes it along with every other magic form.
+- **The comparison-semantics axis is not closed by a single flag, because its members do not
+  share a stage.** textconv is comparison-side only; the two submodule-ignore keys suppress
+  at both stages. `--no-textconv` on the comparison plus `--ignore-submodules=none` on the
+  comparison *and* the enumeration is what covers all three. A repair that patched only the
+  comparison would close one member of three and read as though it closed the axis.
+
+**What is known about completeness, stated as a boundary rather than as a closure.** The
+previous version of this passage asserted that no open axis remained and that no sixth patch
+was queued. That sentence was **false when written** and is deleted rather than softened: a
+sixth instance was already constructible, and an affirmative claim in the unsafe direction
+is the specific error that failed this SPEC at iteration 3 and again at iteration 5. What
+can honestly be said is bounded by what was probed:
+
+- Twenty-two configuration keys, attribute forms, and environment settings were measured
+  against an ordinary-file sharp scenario (`acceptance.md` §C.2 route 5). That sweep finds
+  **one** member: the `textconv` diff driver (`diff.<d>.cachetextconv` is the same member,
+  not a distinct one). Two further members — `diff.ignoreSubmodules=all` and
+  `submodule.<name>.ignore=all` — are invisible to a file-only sweep because they act
+  exclusively on gitlinks, and were found instead by a fixture containing a submodule
+  (SC-15). **Three members total, all now closed.** The methodological lesson is recorded
+  because it is why the sweep initially undercounted: an axis sweep must vary the *object
+  kind* (file, symlink, gitlink) as well as the configuration.
+- **External diff drivers were measured NOT to be a member.** `diff.<d>.command` and
+  `GIT_EXTERNAL_DIFF` do run on the ordinary diff path, but `--quiet` short-circuits before
+  consulting them, so the comparison is unaffected. This is the same asymmetry as textconv
+  in the opposite direction, and it is recorded because it looked like a likely fourth
+  member and is not one.
+- **Whether a fourth member exists is unknown.** Territory not reached: git attribute macros
+  beyond `binary`, `diff.<d>.binary`, partial-clone / promisor object behaviour,
+  `core.hooksPath`-driven state, alternate object stores, and `GIT_ATTR_NOSYSTEM`
+  interactions. No claim is made about them either way.
+
+The honest framing is **"no *known* open axis"**, and every closure claim in this SPEC should
+be read that way. Each of the seven instances so far was found by attacking the mechanism the
+previous repair produced — the seventh, the frame-of-reference axis, at audit iteration 6 —
+and the SPEC's confidence has now been wrong twice in exactly that manner. A future revision
+that adds a seventh axis is the expected outcome of another adversarial pass, not evidence
+that this one was written carelessly.
+
+**The reformulation was built, attacked, and rejected — on measured grounds.** Earlier
+versions of this passage named a structural alternative (comparing the branch's tree against
+base's tree restricted to the branch-touched subtree, computing the intersection in-process
+so no path is ever handed back to git) and directed that a fifth patch be weighed against it
+rather than adopted reflexively. That weighing was performed as a commissioned study rather
+than left as an open question, and the outcome is recorded here so the option is not
+silently re-proposed:
+
+- Both candidates were correct on everything constructible — 12/12 scenarios, 13/13 path
+  hazards, 14/14 structural probes, and 1500/1500 differential-fuzz cases against an
+  independent oracle implemented from the definition rather than from either mechanism.
+  Invocation counts are identical (9 per branch evaluation, 8 when the touched set is
+  empty). The choice was therefore never about measured correctness; it was about which
+  residual surface is smaller.
+- **The reformulation relocates the defect class rather than eliminating it.** The pathspec
+  form needs `--no-renames` on *one* enumeration; the reformulation needs it on *two*, and
+  dropping it from the second is a silent fail-open false positive of exactly the same
+  character as the five before it. The study constructed the case (`A1b`: base squash-merges
+  the branch, then renames the branch's file away): with rename detection left on for the
+  divergence enumeration, the `f.txt → g.txt` pair folds to its destination, the
+  intersection is spuriously empty, and the verdict is merged while the branch's file is
+  absent from base HEAD. None of the twelve existing scenarios covers it. The pathspec form
+  is immune to `A1b` without any flag, because restricting the diff to `f.txt` structurally
+  prevents git from pairing it with `g.txt`.
+- **Guard count favours the reformulation; guard *maturity* favours the patch.** The
+  reformulation carries 2 silently-fatal guards against the patch's 4 — a genuine advantage,
+  and the strongest argument for it. But all four of the patch's guards are specified,
+  verified across the whole matrix, and pinned by acceptance criteria, whereas one of the
+  reformulation's two is new, unpinned, and demonstrably breakable. Trading four mature
+  guards for two of which one is immature is not obviously a gain, and it is not a gain at
+  this point in the SPEC's lifecycle.
+
+**The OID-comparison hybrid was weighed and rejected — also on measured grounds.** After the
+comparison-semantics axis was found, a second structural alternative was commissioned and
+studied: keep the enumeration exactly as it is and replace only the *comparison* with a
+blob-OID comparison, on the reasoning that object IDs are content hashes and no diff
+configuration can make two different contents hash alike. That reasoning is sound about the
+comparison and irrelevant to the enumeration, which is the half the hybrid keeps by design.
+The outcome is recorded here so the option is not proposed a third time:
+
+- **It closes one member of the axis and inherits the other two.** textconv is
+  comparison-side only, so the hybrid closes it completely and structurally. But
+  `diff.ignoreSubmodules=all` and `submodule.<name>.ignore=all` suppress at the
+  **enumeration** stage, which the hybrid retains verbatim — measured, the hybrid returns
+  the same `merged` false positive on both, identically to the unpatched form. Adopting it
+  would leave the axis open while requiring a mechanism rewrite. The two flags close all
+  three members instead.
+- **Its own defects are unconditional where the axis's are conditional.** A symlink and a
+  regular file with identical content **share one blob OID** (P4c), and a mode change leaves
+  the OID untouched (P3c), so an OID comparison that does not also carry the file mode
+  reports equality for genuinely different trees — silently, fail-open, under **default** git
+  configuration. Every comparison-semantics member requires non-default state: a committed
+  `.gitattributes`, a committed `.gitmodules` directive, or an operator config key. Trading
+  config-conditional exposure for unconditional exposure is a bad trade. Two of the three
+  mechanisms considered (`git rev-parse <rev>:<path>` and `git cat-file --batch-check`)
+  cannot report the mode at all, and `cat-file` additionally reports `missing` for a gitlink
+  on both sides at exit 0 — reading an error as agreement.
+- **Cost regresses in the case that actually runs.** The only viable mechanism (two full
+  `git ls-tree` invocations) is flat in the touched-path count and measured at ~169 ms on
+  this repository's 6,698-entry tree, against 43-87 ms for the current design at typical
+  branch sizes, crossing over only past several hundred touched paths. `--stale` pays this
+  once per registered worktree.
+- **Guard maturity, again.** The hybrid trades four mature guards for three, one of which
+  (include the mode) is new, unpinned, and demonstrably breakable. This is the same trade
+  declined for the reformulation one iteration earlier, and the case for declining is
+  stronger here because the reduction is smaller.
+
+**What the hybrid genuinely offered, recorded so it is not lost.** It passes **no path to
+git** — the two `ls-tree` invocations take only a revision, and the enumerated names are used
+solely as keys into an in-process map — so the argv, encoding, and interpretation axes are
+structurally *absent* from its comparison rather than closed by flags. That is a real
+advantage and the strongest argument in its favour. It also admits a fail-loud upgrade the
+pathspec form cannot express: assert that every enumerated name resolves in at least one of
+the two trees, and error otherwise, which would convert the fail-open-on-unmatched-name
+property into a loud failure. Neither outweighs the four points above. But if a future
+revision ever finds a **comparison-side** axis-5 member that `--no-textconv` does not cover,
+the hybrid's `ls-tree` form is the mechanism to reach for — with the mode included in the
+comparison, which P3c and P4c exist to enforce.
+
+The residual honest limit is unchanged in kind: S5 still asks git for a list of names, then
+asks git a second question phrased in terms of those names, and now also depends on git's
+answer to that second question being configured honestly. The round-trip and the comparison
+are both structural hazards. What has changed is that **both** alternatives to the current
+mechanism are no longer untested ideas — each was built, attacked, and measured to carry a
+defect of the same class in a position this matrix would not have covered.
+- The not-merged verdict on SC-10 through SC-15, P3c, and P4c is conservative by design. One
+  could argue base "re-added the file deliberately", "removed the file deliberately", "moved
+  the submodule pointer deliberately", or "reset the file mode deliberately", and that the
+  branch's content work did land. The state semantic in REQ-WSM-001 does not make that
+  distinction, and the direction it errs in is the safe one: the worktree is kept.
+
+### Known limitations (accepted)
+
+**Amended replay — a conservative false negative.** A branch merged by replaying its commits
+individually **and** subsequently amended so that neither the per-commit patch-ids nor the
+collapsed patch-id match will not be detected. The worktree is kept, which is the safe
+outcome.
+
+**`diff.ignoreSubmodules=all` — CLOSED at v0.6.0; the hedge below is retired.** Through
+v0.5.0 this was recorded as an exposure that was *stated, not verified*: the reformulation
+study's submodule probe returned the correct verdict under `diff.ignoreSubmodules=all`, but
+only because `.gitmodules` also differed and carried the comparison, so the case of a pointer
+bumped with **no** accompanying `.gitmodules` change was inferred from the enumeration's
+mechanics rather than observed.
+
+That scenario has since been constructed (SC-15) and the inference confirmed: the gitlink is
+dropped from `git diff --name-only` itself, and the comparison would ignore it independently
+even when handed a correct list. Two corrections to the v0.5.0 wording follow. First, the
+exposure hits **both** stages, not only the enumeration the earlier text named. Second, a
+**third** member exists that the earlier text did not know about — `submodule.<name>.ignore=all`,
+which is readable from a tracked `.gitmodules` and therefore does **not** require a
+non-default local config; a repository can ship it to every clone. The v0.5.0 claim that "the
+exposure does not exist under git's shipped settings" was true of `diff.ignoreSubmodules` and
+false of its sibling.
+
+The exposure is now closed by `--ignore-submodules=none` on the enumeration and on the
+comparison (finding 8), pinned by SC-15 and by AC-WSM-006's fifth falsification. What remains
+true from the earlier wording is that the exposure was never specific to this design: it is a
+property of `git diff` and applies identically to any formulation built on that enumeration,
+including both structural alternatives weighed above — the OID hybrid inherits it in full.
+
+---
+
+## §3 Requirements (GEARS)
+
+### Detection semantics
+
+**REQ-WSM-001** (Ubiquitous) — The worktree merge predicate shall report a branch as
+merged when the branch's changes relative to its merge-base with the base branch are
+present **in the base branch's HEAD tree**, irrespective of the merge strategy that placed
+them there. This is a state condition, not a history condition: an equivalent patch-id
+having existed at some point in base's history since the merge-base does not satisfy it if
+the content was subsequently removed (see §2 SC-8 and REQ-WSM-014).
+
+**REQ-WSM-002** (event-driven) — **When** a branch's entire diff relative to its merge-base
+has been applied to the base branch as a single squashed commit, the worktree merge
+predicate shall report the branch as merged.
+
+**REQ-WSM-003** (event-driven) — **When** every commit on a branch since its merge-base has
+an equivalent patch present in the base branch, the worktree merge predicate shall report
+the branch as merged.
+
+**REQ-WSM-004** (event-driven) — **When** a branch's diff relative to its merge-base with
+the base branch is empty, the worktree merge predicate shall report the branch as merged.
+
+**REQ-WSM-005** (state-driven) — **While** a branch's tip commit is an ancestor of the base
+branch, the worktree merge predicate shall report the branch as merged, preserving the
+existing reachability behaviour for true merge commits and strictly-behind branches.
+
+**REQ-WSM-006** (unwanted) — The worktree merge predicate shall not report a branch as
+merged while any part of the branch's diff relative to its merge-base is absent from the
+base branch's HEAD tree.
+
+> The state conjunct that makes REQ-WSM-002 and REQ-WSM-003 safe against a later revert is
+> stated as REQ-WSM-014 at the end of this section, where the sequential numbering puts it.
+
+**REQ-WSM-007** (event-driven) — **When** a git probe the predicate issues exits with a
+status that probe does not define as a verdict, the predicate shall return an error rather
+than a boolean verdict, so that `staleKeepReason` keeps the worktree and reports the
+failure. The verdict-carrying exit statuses are enumerated below and are the complete set;
+any status outside a probe's listed verdict column is a failure.
+
+Measured on `git version 2.50.1 (Apple Git-155)`:
+
+| Probe | Verdict-carrying exits | Meaning | Failure exits |
+|---|---|---|---|
+| `git branch --merged <base>` | `0` | listing produced (branch present or absent in it) | `128` (e.g. unknown base ref) |
+| `git merge-base <base> <branch>` | `0` merge-base found; `1` no common ancestor, empty stdout | see REQ-WSM-007 note below | `128` (e.g. unknown ref) |
+| `git diff --quiet <a> <b>` | `0` no difference; `1` difference exists | both are verdicts, not errors | `128` (e.g. unknown ref) |
+| `git diff --quiet <a> <b> -- <paths>` | `0` no difference; `1` difference exists | both are verdicts, not errors | `128` (e.g. unknown ref) |
+| `git diff --quiet <a> <b> -- <pathspec matching nothing>` | `0` | **no error is raised** — an unmatched pathspec is reported as "no difference" | (none; an unmatched pathspec never fails) |
+| `git diff --quiet <a> <b> -- <path whose first byte is ':'>` | `0` | the leading `:` is parsed as pathspec **magic**, not as a filename, so the pathspec matches nothing and reports "no difference"; `:!`/`:^` forms parse as EXCLUDE and invert what is compared | (none; the misparse never fails) |
+| `git --literal-pathspecs diff --quiet <a> <b> -- <paths>` | `0` no difference; `1` difference exists | all pathspec magic and globbing disabled — every element is matched as a literal filename | `128` (e.g. unknown ref). Note the option is **git-level**: placed after the subcommand git rejects the invocation with `129` |
+| `git --literal-pathspecs diff --quiet --no-textconv --ignore-submodules=none <a> <b> -- <paths>` | `0` no difference; `1` difference exists | the specified comparison — a `textconv` driver cannot collapse a real difference, and a changed gitlink cannot be ignored | `128` (e.g. unknown ref); `129` if either diff-level flag is placed **before** the subcommand (measured: `unknown option`) |
+| `git diff --quiet <a> <b> -- <path under a textconv diff driver>` | `0` | the driver's rendering is compared instead of the blobs, so two genuinely different files report "no difference" | (none; the collapse never fails) |
+| `git diff --quiet <a> <b> -- <changed gitlink>` under `diff.ignoreSubmodules=all` or `submodule.<n>.ignore=all` | `0` | the gitlink is ignored, so a moved submodule pointer reports "no difference" | (none; the suppression never fails) |
+| `git diff --ignore-submodules=none --no-renames --name-only -z <a> <b>` | `0` | listing produced (possibly empty), rename sources included, paths verbatim and NUL-delimited, **and a changed gitlink included** even under a repository- or operator-set submodule-ignore directive | `128` (e.g. unknown ref) |
+| `git diff --no-renames --name-only <a> <b>` | `0` | listing produced (possibly empty), rename sources included — but paths are **C-quoted** when they contain a backslash, tab, double quote, or control character, and (under default `core.quotePath=true`) when they contain any non-ASCII byte | `128` (e.g. unknown ref) |
+| `git diff --no-renames --name-only -z <a> <b>` | `0` | listing produced (possibly empty), rename sources included, paths emitted **verbatim** and NUL-delimited — never quoted, for any byte, under any `core.quotePath` value | `128` (e.g. unknown ref) |
+| `git cherry <base> <head>` | `0` | listing produced (possibly empty) | `128` (e.g. unknown ref) |
+| `git commit-tree <tree> -p <parent> -m <msg>` | `0` | object written | `128` (e.g. invalid tree) |
+
+Note on `git merge-base` exit `1`: it is a verdict meaning the two refs have no common
+ancestor (unrelated histories), and stdout is empty. It is not a failure, but it also does
+not yield a merge-base, so signals S2, S3 (state conjunct), S4, and S5 cannot be computed.
+The predicate shall treat this case as **not merged** with a nil error — the conservative
+outcome that keeps the worktree — rather than returning an error or a merged verdict.
+
+Read literally, an earlier form of this requirement ("any git probe exits non-zero →
+return an error") made S3, S4, and S5 unreachable, because `git diff --quiet` uses exit `1`
+as a verdict and every branch not caught by S2 produces it. The table above exists so the
+implementer does not have to guess which non-zero statuses are verdicts.
+
+Note on the unmatched-pathspec row: it is in the table because it is the one entry that is
+**not** a safety net. Every other row lets a mistake surface as an error; this one converts
+a mistake — an incomplete or malformed path list — into a silent merged verdict (§2
+finding 5). It is recorded so that a future reader treats an empty S5 result as suspicious
+rather than reassuring.
+
+Note on the three enumeration rows: they are all listed, rather than only the one the design
+uses, so that a future reader considering "`-z` is noise, drop it" can see from the table
+alone what breaks. Without `-z` the enumeration's output is a *quoted rendering* of the
+paths rather than the paths themselves, and by the unmatched-pathspec row above every
+quoted name silently degrades into "no difference". Note also what the non-`-z` row does
+**not** say: it does not say the hazard is scoped to non-ASCII paths, and it does not say
+`core.quotePath=false` removes it. Backslash, tab, double quote, and control characters
+quote regardless of that setting (§2 finding 6), so config alone cannot substitute for
+`-z`. The third row — the one carrying `--ignore-submodules=none` — is the form the design
+actually uses, and it is listed separately for the same reason: a reader considering "the
+comparison already has that flag, so the enumeration's copy is redundant" can see from the
+table alone that the two rows differ in whether a changed gitlink is listed at all.
+
+### Synthetic-object hygiene
+
+**REQ-WSM-008** (event-driven) — **When** the predicate creates a synthetic commit object, it
+shall pin the author and committer name, email, and date to fixed values, so that repeated
+evaluation of an unchanged branch yields a byte-identical object rather than a new one.
+
+**REQ-WSM-009** (unwanted) — The predicate shall not invoke `git prune`, `git gc`, or any
+other repository-wide object-reclamation command.
+
+### Preserved safety contract
+
+**REQ-WSM-010** (state-driven) — **While** the `--stale` sweep evaluates a worktree, both
+existing safety conditions shall be required together: the working tree is clean of
+uncommitted and untracked files, AND the branch holds no unique work beyond base. Neither
+condition may be dropped or weakened.
+
+**REQ-WSM-011** (unwanted) — The `--stale` sweep shall not delete any branch; it removes
+only the worktree directory.
+
+**REQ-WSM-012** (state-driven) — **While** the `--yes` flag is absent, the `--stale` sweep
+shall preview the removals and perform none of them.
+
+**REQ-WSM-013** (event-driven) — **When** the `--merged-only` sweep removes a worktree, it
+shall continue to call the removal with force disabled, so that git refuses removal of a
+worktree containing modified or untracked files.
+
+### State conjunct
+
+**REQ-WSM-014** (event-driven) — **When** the predicate evaluates a patch-id history signal
+(plain `git cherry` or synthetic-commit `git cherry`), it shall additionally require that
+every path the branch changed relative to its merge-base has identical content in the base
+branch's HEAD tree, and shall report merged only when both the history signal and this
+state condition hold. The state condition shall never be treated as a merged verdict on its
+own.
+
+The set of "every path the branch changed" shall be **complete**, **faithfully encoded**, and
+**matched literally**, and the comparison applied to it shall be **observed under unnarrowed
+diff semantics**. Each part is stated at the requirement layer for the same reason: the
+conjunct fails open, so a path set that is incomplete, corrupted, *or* re-interpreted — and
+equally a correct path set judged under a narrowed comparison — produces a merged verdict
+with no error (§2 findings 5 and 8). None of the four can be left implicit in the mechanism.
+
+- **Completeness.** The set shall include paths the branch **deleted**, paths the branch
+  **renamed away from**, and **gitlinks whose commit pointer the branch moved** — not only
+  the paths that exist as ordinary files on the branch after the change. A path the branch
+  removed is part of the branch's diff, so base HEAD still holding it means the branch's work
+  is not fully present; the same holds for a submodule pointer. The mechanisms satisfying
+  this are `--no-renames` and `--ignore-submodules=none` on the enumeration; §2 SC-10 and
+  SC-11 falsify any weaker rename handling, and §2 SC-15 falsifies an enumeration that omits
+  the submodule flag. A repository can suppress the gitlink through a tracked `.gitmodules`
+  directive, so this part is not satisfied by assuming default configuration.
+- **Encoding fidelity.** Each element of the set shall be the path itself, byte for byte,
+  such that passing it back as a pathspec matches the file it names. It shall **not** be a
+  quoted or escaped rendering of the path. `git diff --name-only` emits a C-quoted
+  rendering for any path containing a backslash, tab, double quote, or control character —
+  and, under git's documented default `core.quotePath=true`, for any non-ASCII path — and
+  such a rendering matches nothing (§2 finding 6). The mechanism satisfying this is `-z`
+  (NUL-delimited output, split on NUL); §2 SC-12 is the scenario that falsifies a
+  newline-split enumeration. Setting `core.quotePath=false` does **not** satisfy this
+  requirement: it suppresses quoting for non-ASCII paths only, leaving backslash and
+  control-character paths quoted, so it is not an accepted substitute for `-z`.
+- **Literal matching.** Each element shall be matched as a literal filename when it is
+  passed back, and shall **not** be parsed as a pathspec expression. Encoding fidelity alone
+  does not give this: a path whose bytes are transmitted perfectly is still re-read on the
+  way back, and git parses a pathspec's leading characters as magic before matching, so a
+  repo-root path whose first byte is `:` names no file and `:!`/`:^` forms invert the
+  comparison (§2 finding 7). The mechanism satisfying this is the git-level option
+  `--literal-pathspecs` on the comparison — or, equivalently, `GIT_LITERAL_PATHSPECS=1` in
+  the invocation's environment; §2 SC-13 is the scenario that falsifies a bare pathspec.
+  Prefixing each element with `:(literal)` also satisfies the requirement mechanically but
+  is **not** the accepted mechanism: it re-introduces a per-path string transformation,
+  which is the precise operation that has failed on three of the four axes above.
+- **Observed comparison.** The comparison applied to the path set shall report a difference
+  whenever the branch's and base's content for a named path genuinely differ, and shall not
+  be narrowed by repository or operator configuration into reporting equality. Correctness of
+  the path list does not give this: a complete, byte-perfect, literally-matched list is still
+  judged by `git diff --quiet` under the repository's diff configuration, and that
+  configuration can collapse a real difference — a `textconv` diff driver renders two
+  different blobs to the same text, and a submodule-ignore directive drops a moved gitlink
+  (§2 finding 8). The mechanisms satisfying this are `--no-textconv` and
+  `--ignore-submodules=none` on the comparison; §2 SC-14 and SC-15 are the scenarios that
+  falsify a comparison issued under the repository's own settings. The comparison shall also
+  remain sensitive to a path's **mode**: a symlink and a regular file with identical content
+  share one blob OID, so a content-hash-only comparison reports equality for genuinely
+  different trees under default configuration (§2 P3c, P4c). `git diff` satisfies this; a
+  mode-blind substitute does not.
+
+Taken together the four parts give the full mechanism: enumerate with
+`git diff --ignore-submodules=none --no-renames --name-only -z` split on NUL, and compare
+with `git --literal-pathspecs diff --quiet --no-textconv --ignore-submodules=none`.
+
+---
+
+## §4 Exclusions
+
+### Out of Scope — auxiliary merge signals
+
+- Querying the forge for merged pull requests (`gh pr list --head <branch> --state merged`).
+  It was verified accurate on the two probe branches, but it requires network access, the
+  `gh` binary, and GitHub hosting, so it is unsuitable as the default path of a local CLI.
+  It is not added as an optional flag either; that would be a separate feature.
+
+### Out of Scope — `--merged-only` safety expansion
+
+- Adding an explicit working-tree cleanliness check to the `--merged-only` path. That path
+  currently relies on git refusing a non-forced removal of a dirty worktree, which was
+  verified sufficient (see §5 decision 3). Changing its gate is a behaviour change beyond
+  this defect.
+
+### Out of Scope — unpushed-commit detection
+
+- Detecting that a worktree's branch carries commits absent from its upstream remote. A
+  clean worktree whose branch holds unpushed commits is removed by `git worktree remove`
+  without `--force` and is reported clean by `git status --porcelain`, so neither existing
+  safety condition sees it (measured in §5 decision 3). Adding an upstream-comparison gate
+  is a behaviour change to both sweep paths and belongs to a separate SPEC. The exposure is
+  bounded by REQ-WSM-011: the branch is never deleted, so the commits stay reachable by
+  branch name after the directory is removed.
+
+### Out of Scope — worktree lifecycle changes
+
+- Automatic branch deletion after worktree removal.
+- Changing the default of `--stale` from preview to apply.
+- Any change to worktree creation, entry, or the `moai worktree done` disposal contract.
+- Reclaiming the currently-held disk; this SPEC changes detection only. Running the sweep
+  is a user action taken after the fix lands.
+
+### Out of Scope — object-store maintenance
+
+- Scheduling, configuring, or invoking garbage collection. Git's own auto-gc governs
+  reclamation of the synthetic objects.
+
+---
+
+## §5 Resolved Design Decisions
+
+### Decision 1 — False-positive boundary
+
+The predicate treats "the branch's changes relative to its merge-base are present in base
+HEAD" as merged — a **state** semantic, not a history semantic. The boundary cases were
+resolved against executed results, not reasoning:
+
+| Case | Verdict | Why |
+|---|---|---|
+| Empty-diff branch (zero changes vs merge-base) | **Reclaim** | There is nothing to lose by definition. The branch itself is never deleted, so any empty commits remain reachable by branch name. |
+| Strictly behind base | **Reclaim** | Both the reachability signal and the empty-diff signal fire; this already worked before the change and must keep working. |
+| Base is a strict superset of the branch | **Reclaim** | Observed SC-9: S3 and S4 both fire and S5 holds. The branch's work is present; base merely carries more. |
+| Partially applied (some hunks landed, some did not) | **Keep** | No history signal fires and S5 withholds. Observed: plain `git cherry` returned one `-` and one `+`; the synthetic probe returned `+`; S5 = NO. |
+| **Partially reverted** (all patches applied, then some reverted) | **Keep** | The case that forced the state semantic. Observed SC-8: both plain-`git cherry` lines are `-`, so S3 fires on history alone, but S5 = NO because `b.txt` is absent from base HEAD. The conjunction withholds the verdict. |
+| **Rename + re-add** (branch renames a path; base takes the work, then re-adds the original path) | **Keep** | The case that forced the enumeration to be rename-blind. Observed SC-10 and SC-11: the branch's deletion of `old.txt` does not survive in base HEAD, so S5 = NO — but only once the path list is built with `--no-renames`. Conservative: base may have re-added the path deliberately, and the predicate does not attempt to tell the two apart. |
+| **Non-ASCII (or otherwise quoting) path removed from base** | **Keep** | The case that forced the enumeration to be NUL-delimited. Observed SC-12: the branch's `문서.txt` does not survive in base HEAD, so S5 = NO — but only once the path list is read with `-z`. Split on newline the path arrives C-quoted, matches nothing, and S5 holds vacuously. |
+| **Leading-colon path removed from base** | **Keep** | The case that forced the comparison to use literal pathspecs. Observed SC-13: the branch's `:note.txt` does not survive in base HEAD, so S5 = NO — but only once the comparison carries `--literal-pathspecs`. As a bare pathspec the byte-perfect path is parsed as magic, matches nothing, and S5 holds vacuously. |
+| **Changed file under a `textconv` diff driver** | **Keep** | The case that forced the comparison to fix its own diff semantics. Observed SC-14: the branch's `report.pdf` content does not survive in base HEAD, so S5 = NO — but only once the comparison carries `--no-textconv`. Without it the driver renders both blobs to the same text and the comparison reports equality on a correct, byte-perfect path list. |
+| **Submodule pointer moved under a submodule-ignore directive** | **Keep** | The case that forced both stages to carry `--ignore-submodules=none`. Observed SC-15: the branch's pointer move does not survive in base HEAD, so S5 = NO — but only once **both** the enumeration and the comparison carry the flag. Without it on the enumeration the gitlink never enters the path list; without it on the comparison a correct list is still ignored. |
+| **Mode-only divergence, and symlink/file blob-OID collision** | **Keep** | Not a repair — a *retention* row. Observed P3c and P4c: `git diff` compares modes, so the specified mechanism already reports both correctly. They are pinned because both sides share one blob OID, so any future swap to a mode-blind comparison turns them into silent false positives under default configuration. |
+
+Eight guards carry the safety argument, and each was checked by mutation rather than by
+reasoning (observed verdicts under each mutation are recorded in `acceptance.md` §C.1):
+
+- **Every `git cherry` line must be `-`.** A single `+` line means part of the branch's work
+  never landed.
+- **Empty `git cherry` output is not a merged verdict.** An absence of output means "no
+  commits compared" and can never be read as merged.
+- **S5 must hold alongside S3 or S4.** This is the guard SC-8 requires; the other two do not
+  catch it, because a revert leaves the patch-id history intact.
+- **S5's path list must be built rename-blind.** This is the guard SC-10 and SC-11 require.
+  It is a property of the conjunct's *input*, not of the conjunct, which is why the
+  previous three guards did not cover it: S5 was present and correct, and still returned
+  `OK`, because the path it needed to examine was never handed to it.
+- **S5's path list must be read NUL-delimited.** This is the guard SC-12 requires. It is
+  likewise a property of the input, and it is orthogonal to the previous one — the fourth
+  guard governs *which* paths are enumerated, this one governs *what form they arrive in*.
+  A rename-blind enumeration split on newline still hands S5 a quoted string that matches
+  nothing, so the fourth guard alone does not cover it.
+- **S5's comparison must match its paths literally.** This is the guard SC-13 requires. It is
+  the last of the guards that governs the path list's *round-trip*: a rename-blind,
+  NUL-delimited, byte-perfect list is still re-parsed when handed to `git diff`, and a
+  leading `:` is parsed as magic. The previous two guards cannot cover it because the list
+  they produce is already correct.
+- **S5's comparison must not be narrowed by diff configuration.** This is the guard SC-14
+  requires, and it is the first that governs neither which paths are enumerated, nor what
+  form they arrive in, nor how they are read back, but what git *concludes* about them. A
+  `textconv` diff driver makes `git diff --quiet` compare renderings rather than blobs, so a
+  correct list is judged wrongly. None of the previous guards can cover it, because there is
+  nothing wrong with the list.
+- **S5 must see a changed gitlink, at both stages.** This is the guard SC-15 requires, and it
+  is the only guard that must be applied twice: a submodule-ignore directive — settable by
+  the operator *or* shipped in a tracked `.gitmodules` — suppresses the gitlink both when the
+  path list is built and when the comparison is made. Closing one stage leaves the other
+  open.
+- **S5's comparison must be sensitive to file mode.** This is the guard P3c and P4c require.
+  It is the only guard that is already satisfied by the specified mechanism and is pinned
+  against *future* edits rather than against a present defect: `git diff` compares modes,
+  while a content-hash comparison does not, and a symlink and a regular file with identical
+  content share one blob OID.
+
+The eight guards are independent rather than redundant, and the independence was measured
+rather than argued. Removing S5 alone flips SC-8 to merged, while SC-6 and SC-7 additionally
+require the cherry guard to be relaxed before they flip — so no single mutation defeats all
+the must-keep scenarios. The five enumeration-and-comparison guards are likewise minimal and
+specific, and their blast radii are disjoint except where the mechanism itself is shared:
+dropping `--no-renames` flips exactly SC-10 and SC-11; splitting on newline instead of NUL
+flips exactly SC-12; dropping `--literal-pathspecs` flips exactly SC-13; dropping
+`--no-textconv` flips exactly SC-14; dropping `--ignore-submodules=none` from **either**
+stage flips exactly SC-15; and swapping the comparison for a mode-blind one flips exactly
+P3c and P4c. Each leaves every other row unchanged (observed across the full 11 × 17 grid;
+`acceptance.md` §C and §C.1).
+
+The one deliberate non-disjointness is worth stating rather than smoothing over: the two
+submodule mutations flip the *same* row, because they are two stages of one guard rather
+than two guards. That is the evidence the flag is needed twice — if the stages were
+redundant, removing one would leave SC-15 passing.
+
+### Decision 2 — Synthetic commit objects
+
+**Accept the dangling objects; pin the identity to bound them.** Each `git commit-tree`
+call creates one unreferenced, gc-eligible commit object; this was measured directly
+(dangling-commit count went 1 → 2 across one call). With the author and committer name,
+email, and date pinned to fixed values, two successive calls over an unchanged branch
+produced a byte-identical object hash, so the object count is bounded by the number of
+distinct branch states rather than by the number of sweeps.
+
+Explicit cleanup was rejected. Git offers no way to delete a single unreferenced object;
+the available command, `git prune`, is repository-global and would also destroy
+unreferenced objects that a concurrent session or tool is still holding. Git's own
+auto-gc reclaims them without that hazard.
+
+### Decision 3 — `--merged-only` co-change
+
+**Intended, via a single shared predicate. The two paths do not diverge.** Both commands
+ask the same question, and the `--merged-only` help text already promises to remove
+worktrees "whose branches are merged into base" — a squash-merged branch is merged, so that
+path is under-detecting today for the same reason.
+
+`cleanMergedWorktrees` calls removal with force disabled. Three worktree states were
+measured against `git worktree remove` without `--force`; the third is the one that does
+**not** refuse:
+
+```
+[modified]        rc=128 present=YES  fatal: '...' contains modified or untracked files, use --force to delete it
+[untracked-only]  rc=128 present=YES  fatal: '...' contains modified or untracked files, use --force to delete it
+[clean-unpushed]  rc=0   present=NO   (removed, no objection)
+```
+
+So the no-data-loss argument holds for uncommitted and untracked content, and **does not
+hold** for a clean worktree whose branch carries unpushed commits — precisely the state a
+broadened predicate newly admits, since a squash-merged branch's worktree is typically
+clean. `git status --porcelain` was measured to report an empty string in that state
+(`porcelain output: ''`), so the `--stale` path's independent cleanliness guard does not
+see it either. The gap exists on both paths, not just `--merged-only`.
+
+This case is **accepted, not solved**, with one mitigation named: REQ-WSM-011 forbids
+deleting the branch, so the unpushed commits remain reachable by branch name after the
+directory is removed and can be recovered with a fresh `git worktree add`. What is lost is
+the working directory, not the commits. Closing the gap properly requires an
+upstream-comparison gate on both sweep paths, which is recorded in §4 as out of scope.
+
+The residual asymmetry — `--merged-only` has no explicit porcelain check of its own — is
+likewise recorded as an out-of-scope follow-up rather than silently expanded into this
+change.
+
+### Decision 4 — Preserved constraints
+
+Recorded as binding requirements REQ-WSM-010 through REQ-WSM-013. The existing
+`@MX:ANCHOR` block on `cleanStaleWorktrees` already encodes the two-condition gate and is
+retained unchanged.
+
+---
+
+## §6 Traceability
+
+| Requirement | Artifact |
+|---|---|
+| REQ-WSM-001 .. REQ-WSM-007, REQ-WSM-014 | `internal/core/git/worktree.go` — the merge predicate |
+| REQ-WSM-008, REQ-WSM-009 | `internal/core/git/worktree.go` — synthetic commit construction |
+| REQ-WSM-010 .. REQ-WSM-012 | `internal/cli/worktree/clean.go` — `cleanStaleWorktrees`, `staleKeepReason` |
+| REQ-WSM-013 | `internal/cli/worktree/clean.go` — `cleanMergedWorktrees` |
+
+Acceptance criteria: `acceptance.md`.

--- a/internal/core/git/manager.go
+++ b/internal/core/git/manager.go
@@ -3,6 +3,7 @@ package git
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -274,6 +275,75 @@ func execGit(ctx context.Context, dir string, args ...string) (string, error) {
 	}
 
 	return strings.TrimRight(stdout.String(), "\n\r"), nil
+}
+
+// gitResult holds the result of a git subprocess whose exit code is itself a
+// verdict (SPEC-WORKTREE-SQUASH-MERGE-001 REQ-WSM-007). err is non-nil ONLY for
+// infrastructural failures (git binary missing, context cancellation); a
+// non-zero exit code is returned in exitCode for the caller to interpret per
+// the per-probe verdict table. stdout and stderr are untrimmed so the caller
+// can apply the trim policy each probe requires.
+type gitResult struct {
+	stdout   string
+	stderr   string
+	exitCode int
+}
+
+// execGitExit runs git with an optional per-call environment overlay and
+// returns the structured result. It is the per-call environment hook the
+// synthetic-commit probe (REQ-WSM-008) uses to pin author/committer identity
+// for deterministic object creation, and the exit-code-aware path the merge
+// predicate uses for probes whose non-zero exits are verdicts rather than
+// failures (git diff --quiet rc 1; git merge-base rc 1 on unrelated histories).
+//
+// The construction stays exec.CommandContext(ctx, gitPath, args...) — direct
+// argv, no shell — so the no-shell invariant on the git path is preserved
+// (plan.md §D). extraEnv is appended after GIT_TERMINAL_PROMPT=0 / LC_ALL=C;
+// passing nil yields identical behavior to execGit apart from the structured
+// return.
+func execGitExit(ctx context.Context, dir string, extraEnv []string, args ...string) (gitResult, error) {
+	gitPath, err := exec.LookPath("git")
+	if err != nil {
+		return gitResult{}, fmt.Errorf("system git lookup: %w", ErrSystemGitNotFound)
+	}
+
+	cmd := exec.CommandContext(ctx, gitPath, args...)
+	cmd.Dir = dir
+	env := append(os.Environ(), "GIT_TERMINAL_PROMPT=0", "LC_ALL=C")
+	env = append(env, extraEnv...)
+	cmd.Env = env
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if runErr := cmd.Run(); runErr != nil {
+		var exitErr *exec.ExitError
+		if errors.As(runErr, &exitErr) {
+			// Non-zero exit: a verdict for some probes, a failure for others.
+			// Surface it to the caller via exitCode without wrapping as error.
+			return gitResult{
+				stdout:   stdout.String(),
+				stderr:   stderr.String(),
+				exitCode: exitErr.ExitCode(),
+			}, nil
+		}
+		// Infrastructural failure (context cancellation, git binary gone mid-run).
+		return gitResult{}, fmt.Errorf("git %s: %w", firstArg(args), runErr)
+	}
+	return gitResult{
+		stdout:   stdout.String(),
+		stderr:   stderr.String(),
+		exitCode: 0,
+	}, nil
+}
+
+// firstArg returns args[0] or "git" when args is empty, for error messages.
+func firstArg(args []string) string {
+	if len(args) > 0 {
+		return args[0]
+	}
+	return "git"
 }
 
 // currentBranch is a package-level helper to get the current branch name.

--- a/internal/core/git/worktree.go
+++ b/internal/core/git/worktree.go
@@ -205,25 +205,264 @@ func (w *worktreeManager) DeleteBranch(name string) error {
 	return nil
 }
 
-// IsBranchMerged checks whether a branch has been fully merged into base.
+// IsBranchMerged reports whether a branch's changes relative to its merge-base
+// with base are present in base's HEAD tree, irrespective of the merge strategy
+// that placed them there (SPEC-WORKTREE-SQUASH-MERGE-001 REQ-WSM-001).
+//
+// The predicate is an ordered OR over five signals, cheapest first:
+//
+//	S1  reachability     git branch --merged <base> lists <branch>
+//	S2  empty diff       git diff --quiet <merge-base> <branch> reports none
+//	S3  rebase-merge     git cherry <base> <branch>, non-empty & all '-'
+//	S4  squash-merge     synthetic-commit git cherry, non-empty & all '-'
+//	S5  state check      every branch-touched path is identical in base HEAD
+//
+// S1 and S2 are standalone; S3 and S4 are each CONJOINED with S5, because a
+// history signal answers "did an equivalent patch-id ever exist in base" while
+// S5 answers "does the content survive in base HEAD" — a later revert leaves
+// the first true and the second false (SC-8). S5 is a conjunct only: it may
+// withhold a verdict, never grant one (REQ-WSM-014).
+//
+// This is a safety-critical predicate: it gates `moai worktree clean --stale`,
+// and a false positive destroys unmerged user work with no undo. Eight guards
+// carry the no-false-positive argument; see spec.md §2 and plan.md §D. Each
+// guard's removal flips a measured-disjoint scenario row (acceptance.md §C.1).
+//
+// @MX:ANCHOR: [AUTO] reachability (S1) is retained alongside the patch-id probes (S3/S4) and conjoined with the state check (S5)
+// @MX:REASON: S1 is the only signal that recognises a true merge commit and a strictly-behind branch; replacing it with the patch-id probes regresses SC-3 and SC-4. S5 is the only signal that withholds a verdict when a history signal fires on content base later reverted/removed; dropping it regresses SC-8 through SC-15 and P3c/P4c (acceptance.md §C.1 `no-state`). The two are independent invariants a future edit is most likely to break, so they are pinned here.
 func (w *worktreeManager) IsBranchMerged(branch, base string) (bool, error) {
 	w.logger.Debug("checking if branch merged", "branch", branch, "base", base)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	out, err := execGit(ctx, w.root, "branch", "--merged", base)
+	// S1: reachability (retained verbatim, including the marker-stripping
+	// helper). This is the only signal that recognises a true merge commit
+	// (SC-3) and a strictly-behind branch (SC-4); replacing it with the
+	// patch-id probes would regress both.
+	s1ctx, s1cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer s1cancel()
+	out, err := execGit(s1ctx, w.root, "branch", "--merged", base)
 	if err != nil {
 		return false, fmt.Errorf("check merged branches: %w", err)
 	}
-
 	for line := range strings.SplitSeq(out, "\n") {
 		name := strings.TrimSpace(trimBranchListMarker(line))
 		if name == branch {
 			return true, nil
 		}
 	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// merge-base: computed once, shared by S2..S5. Per REQ-WSM-007, rc 1 with
+	// empty stdout means the two refs share no common ancestor (unrelated
+	// histories): the conservative outcome is (false, nil) — keep the worktree.
+	mbResult, err := execGitExit(ctx, w.root, nil, "merge-base", base, branch)
+	if err != nil {
+		return false, fmt.Errorf("merge-base %s %s: %w", base, branch, err)
+	}
+	switch mbResult.exitCode {
+	case 0:
+		// found; continue
+	case 1:
+		if strings.TrimSpace(mbResult.stdout) == "" {
+			return false, nil
+		}
+		return false, fmt.Errorf("merge-base %s %s: unexpected rc=1 with output", base, branch)
+	default:
+		return false, fmt.Errorf("merge-base %s %s: %s: exit %d",
+			base, branch, strings.TrimSpace(mbResult.stderr), mbResult.exitCode)
+	}
+	mb := strings.TrimSpace(mbResult.stdout)
+
+	// S2: empty diff between merge-base and branch. rc 0 = no difference =
+	// merged; rc 1 = a difference exists = continue. Both rc 0 and rc 1 are
+	// verdicts, NOT failures (REQ-WSM-007) — treating rc 1 as an error would
+	// make every non-merged branch surface as a failure.
+	s2, err := execGitExit(ctx, w.root, nil, "diff", "--quiet", mb, branch)
+	if err != nil {
+		return false, fmt.Errorf("diff --quiet %s %s: %w", mb, branch, err)
+	}
+	switch s2.exitCode {
+	case 0:
+		return true, nil
+	case 1:
+		// difference exists; fall through to history signals
+	default:
+		return false, fmt.Errorf("diff --quiet %s %s: %s: exit %d",
+			mb, branch, strings.TrimSpace(s2.stderr), s2.exitCode)
+	}
+
+	// names: every path the branch changed since its merge-base. Computed once
+	// and reused by S5 for both S3 and S4. Three enumeration guards apply:
+	//   - --no-renames          keeps a renamed source path in the list (SC-10/11)
+	//   - -z + NUL split        keeps the bytes verbatim, not C-quoted (SC-12)
+	//   - --ignore-submodules=none keeps a moved gitlink in the list (SC-15)
+	// --ignore-submodules=none appears here AND on the comparison below; neither
+	// occurrence is redundant (spec.md §2 finding 8; AC-WSM-006 fifth
+	// falsification — removing it from either stage alone reproduces SC-15).
+	namesResult, err := execGitExit(ctx, w.root, nil,
+		"diff", "--ignore-submodules=none", "--no-renames", "--name-only", "-z", mb, branch)
+	if err != nil {
+		return false, fmt.Errorf("enumerate changed paths: %w", err)
+	}
+	if namesResult.exitCode != 0 {
+		return false, fmt.Errorf("enumerate changed paths: %s: exit %d",
+			strings.TrimSpace(namesResult.stderr), namesResult.exitCode)
+	}
+	names := splitNul(namesResult.stdout)
+
+	// S5: state check (conjunct only). Computed once, reused for S3 and S4.
+	// Never a merged verdict on its own — it may withhold, never grant.
+	stateHolds, err := stateCheck(ctx, w.root, names, branch, base)
+	if err != nil {
+		return false, err
+	}
+
+	// S3: rebase-merge history signal. Merged only when cherry output is
+	// non-empty AND every line is prefixed '-' AND S5 holds. Empty cherry
+	// output means "no commits compared" and is never a merged verdict; a
+	// single '+' line means part of the branch's work never landed.
+	s3, err := execGitExit(ctx, w.root, nil, "cherry", base, branch)
+	if err != nil {
+		return false, fmt.Errorf("cherry %s %s: %w", base, branch, err)
+	}
+	if s3.exitCode != 0 {
+		return false, fmt.Errorf("cherry %s %s: %s: exit %d",
+			base, branch, strings.TrimSpace(s3.stderr), s3.exitCode)
+	}
+	if stateHolds && cherryAllDash(s3.stdout) {
+		return true, nil
+	}
+
+	// S4: squash-merge history signal. Collapse the branch's entire
+	// diff-versus-merge-base into one synthetic commit so it has the same shape
+	// as the single squashed commit on base, then ask git cherry whether base
+	// already contains an equivalent patch.
+	treeOut, err := execGit(ctx, w.root, "rev-parse", branch+"^{tree}")
+	if err != nil {
+		return false, fmt.Errorf("resolve branch tree for synthetic commit: %w", err)
+	}
+	tree := strings.TrimSpace(treeOut)
+	synth, err := execGitExit(ctx, w.root, nil,
+		"commit-tree", tree, "-p", mb, "-m", syntheticCommitMessage)
+	if err != nil {
+		return false, fmt.Errorf("synthetic commit-tree: %w", err)
+	}
+	if synth.exitCode != 0 {
+		return false, fmt.Errorf("synthetic commit-tree: %s: exit %d",
+			strings.TrimSpace(synth.stderr), synth.exitCode)
+	}
+	synthCommit := strings.TrimSpace(synth.stdout)
+	s4, err := execGitExit(ctx, w.root, nil, "cherry", base, synthCommit)
+	if err != nil {
+		return false, fmt.Errorf("cherry %s %s: %w", base, synthCommit, err)
+	}
+	if s4.exitCode != 0 {
+		return false, fmt.Errorf("cherry %s %s: %s: exit %d",
+			base, synthCommit, strings.TrimSpace(s4.stderr), s4.exitCode)
+	}
+	if stateHolds && cherryAllDash(s4.stdout) {
+		return true, nil
+	}
+
 	return false, nil
+}
+
+// syntheticCommitMessage is the fixed commit message used by the S4
+// synthetic-commit probe. Combined with the pinned identity values (M2,
+// REQ-WSM-008), it makes the object deterministic across repeated evaluations
+// of an unchanged branch, bounding dangling objects to distinct branch states.
+const syntheticCommitMessage = "moai-squash-probe"
+
+// splitNul splits NUL-delimited `git diff -z` output into a []string, dropping
+// the empty trailing element a NUL terminator leaves behind. The result is one
+// element per path, suitable for variadic expansion. NEVER split on newline:
+// `git diff --name-only` C-quotes any path containing a backslash, tab, double
+// quote, or control character — and, under git's documented default
+// core.quotePath=true, any non-ASCII byte — and the quoted rendering matches
+// nothing as a pathspec, which by the fail-open property reads as merged
+// (spec.md §2 findings 5-6; SC-12). core.quotePath=false is NOT a substitute:
+// it leaves backslash and control-character paths quoted regardless.
+func splitNul(out string) []string {
+	if out == "" {
+		return nil
+	}
+	parts := strings.Split(out, "\x00")
+	if n := len(parts); n > 0 && parts[n-1] == "" {
+		parts = parts[:n-1]
+	}
+	return parts
+}
+
+// cherryAllDash reports whether git cherry output is non-empty AND every
+// non-blank line is prefixed '-'. Empty output is NEVER a merged verdict (it
+// means "no commits compared"); a single '+' line means part of the branch's
+// work is absent from base. This implements two of the three S3/S4 guards; the
+// third (S5 holds) is applied by the caller as a conjunct.
+func cherryAllDash(cherryOut string) bool {
+	trimmed := strings.TrimSpace(cherryOut)
+	if trimmed == "" {
+		return false
+	}
+	for _, line := range strings.Split(trimmed, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if !strings.HasPrefix(line, "-") {
+			return false
+		}
+	}
+	return true
+}
+
+// stateCheck evaluates S5: whether every path the branch changed since its
+// merge-base has identical content (and mode) in base HEAD. It is a CONJUNCT
+// ONLY — it may withhold a verdict, never grant one (REQ-WSM-014).
+//
+// When names is empty the branch touched nothing since its merge-base: S5
+// holds trivially, and scoping the later comparison to an empty pathspec would
+// instead compare the whole trees (the wrong question).
+//
+// Five guards govern S5; each has a silent fail-open failure mode when omitted
+// (spec.md §2 findings 5-8; plan.md §D):
+//   - literal matching: --literal-pathspecs is a GIT-LEVEL option and MUST
+//     precede the subcommand. It matches each path's bytes as a literal
+//     filename rather than parsing them as pathspec magic, so a repo-root path
+//     whose first byte is ':' is checked instead of naming no file (SC-13).
+//   - observed comparison: --no-textconv and --ignore-submodules=none are
+//     DIFF-LEVEL options and MUST follow the subcommand. They stop a textconv
+//     diff driver (SC-14) and a submodule ignore directive (SC-15) from
+//     collapsing a real difference.
+//   - mode sensitivity: `git diff` compares modes, so a symlink/file blob-OID
+//     collision (P4c) and a chmod-only divergence (P3c) are detected. A
+//     blob-OID substitute would not detect either.
+//
+// `names` MUST be passed as a []string (variadic to execGitExit), NEVER as a
+// joined shell string: a single pathspec matching nothing exits 0 and reads as
+// "no difference" (spec.md §2 finding 5; plan.md §D).
+func stateCheck(ctx context.Context, root string, names []string, branch, base string) (bool, error) {
+	if len(names) == 0 {
+		return true, nil
+	}
+	args := make([]string, 0, 6+len(names))
+	args = append(args, "--literal-pathspecs") // git-level: precedes subcommand
+	args = append(args, "diff", "--quiet")
+	args = append(args, "--no-textconv", "--ignore-submodules=none") // diff-level: follows subcommand
+	args = append(args, branch, base, "--")
+	args = append(args, names...) // one argument per path; never joined
+	r, err := execGitExit(ctx, root, nil, args...)
+	if err != nil {
+		return false, fmt.Errorf("state check: %w", err)
+	}
+	switch r.exitCode {
+	case 0:
+		return true, nil
+	case 1:
+		return false, nil
+	default:
+		return false, fmt.Errorf("state check: %s: exit %d", strings.TrimSpace(r.stderr), r.exitCode)
+	}
 }
 
 // trimBranchListMarker strips the leading status marker `git branch` puts on a

--- a/internal/core/git/worktree.go
+++ b/internal/core/git/worktree.go
@@ -343,7 +343,7 @@ func (w *worktreeManager) IsBranchMerged(branch, base string) (bool, error) {
 		return false, fmt.Errorf("resolve branch tree for synthetic commit: %w", err)
 	}
 	tree := strings.TrimSpace(treeOut)
-	synth, err := execGitExit(ctx, w.root, nil,
+	synth, err := execGitExit(ctx, w.root, syntheticCommitEnv(),
 		"commit-tree", tree, "-p", mb, "-m", syntheticCommitMessage)
 	if err != nil {
 		return false, fmt.Errorf("synthetic commit-tree: %w", err)
@@ -369,10 +369,39 @@ func (w *worktreeManager) IsBranchMerged(branch, base string) (bool, error) {
 }
 
 // syntheticCommitMessage is the fixed commit message used by the S4
-// synthetic-commit probe. Combined with the pinned identity values (M2,
-// REQ-WSM-008), it makes the object deterministic across repeated evaluations
-// of an unchanged branch, bounding dangling objects to distinct branch states.
+// synthetic-commit probe. Combined with the pinned identity values
+// (syntheticCommitEnv, REQ-WSM-008), it makes the object deterministic across
+// repeated evaluations of an unchanged branch, bounding dangling objects to
+// distinct branch states rather than to the number of sweeps.
 const syntheticCommitMessage = "moai-squash-probe"
+
+// syntheticCommitIdentity pins the author and committer identity so a synthetic
+// commit's object hash depends only on (tree, parent, message), not on
+// wall-clock time or the invoking user. The date is fixed to the epoch; the
+// name/email are fixed arbitrary values. Without this, repeated evaluation of
+// one unchanged branch yields a fresh object each call (measured), and the
+// dangling-commit count grows with the sweep count rather than the distinct
+// branch-state count (REQ-WSM-008; spec.md §5 decision 2).
+const (
+	syntheticAuthorName  = "moai"
+	syntheticAuthorEmail = "moai@localhost"
+	syntheticCommitDate  = "@0 +0000"
+)
+
+// syntheticCommitEnv returns the per-call environment overlay that pins the
+// synthetic commit's identity. It is passed to execGitExit's extraEnv, the
+// mechanism M1 introduced; this function supplies the M2 values. Existing
+// execGit callers are unaffected — they never pass through extraEnv.
+func syntheticCommitEnv() []string {
+	return []string{
+		"GIT_AUTHOR_NAME=" + syntheticAuthorName,
+		"GIT_AUTHOR_EMAIL=" + syntheticAuthorEmail,
+		"GIT_AUTHOR_DATE=" + syntheticCommitDate,
+		"GIT_COMMITTER_NAME=" + syntheticAuthorName,
+		"GIT_COMMITTER_EMAIL=" + syntheticAuthorEmail,
+		"GIT_COMMITTER_DATE=" + syntheticCommitDate,
+	}
+}
 
 // splitNul splits NUL-delimited `git diff -z` output into a []string, dropping
 // the empty trailing element a NUL terminator leaves behind. The result is one

--- a/internal/core/git/worktree_squash_merge_test.go
+++ b/internal/core/git/worktree_squash_merge_test.go
@@ -1,0 +1,710 @@
+package git
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// This file implements the seventeen-scenario oracle for IsBranchMerged
+// (SPEC-WORKTREE-SQUASH-MERGE-001 acceptance.md §C) plus the AC-WSM-007
+// probe-exit table and the AC-WSM-008 synthetic-commit determinism test.
+//
+// Every scenario builds a REAL isolated repository (never a mock) using the
+// package helpers initTestRepo / runGit / writeTestFile plus the construction
+// helpers below. clean_stale_test.go stubs IsBranchMerged at the CLI layer
+// (mockIsBranchMergedFunc), so the CLI layer never exercises the real
+// predicate — these tests are the only place the predicate's own behavior is
+// verified against the matrix.
+//
+// Construction dates are pinned to a monotonic counter (commitDate) so commits
+// created within the same second do not collide on SHA. This is load-bearing
+// rather than cosmetic: a SHA collision moves the merge-base and silently
+// corrupts the matrix (acceptance.md §B, SC-9 note).
+
+// commitStep is a monotonic per-builder counter feeding pinned commit dates so
+// two commits created within the same second cannot collide on SHA.
+type commitStep struct {
+	t    *testing.T
+	dir  string
+	step int
+}
+
+func newCommitStep(t *testing.T, dir string) *commitStep {
+	t.Helper()
+	return &commitStep{t: t, dir: dir}
+}
+
+// dateEnv returns the GIT_AUTHOR_DATE / GIT_COMMITTER_DATE pair for the next
+// commit, advancing the counter. Dates use the "@<epoch> +0000" form.
+func (c *commitStep) dateEnv() []string {
+	c.step++
+	d := fmt.Sprintf("@%d +0000", 1700000000+c.step)
+	return []string{
+		"GIT_AUTHOR_DATE=" + d,
+		"GIT_COMMITTER_DATE=" + d,
+	}
+}
+
+func (c *commitStep) commit(msg string) {
+	c.t.Helper()
+	runGitEnv(c.t, c.dir, c.dateEnv(), "commit", "-m", msg)
+}
+
+func (c *commitStep) commitAllowEmpty(msg string) {
+	c.t.Helper()
+	runGitEnv(c.t, c.dir, c.dateEnv(), "commit", "--allow-empty", "-m", msg)
+}
+
+// runGitEnv runs git with an extra environment overlay and fails on a non-zero
+// exit. Used for construction commits that pin identity dates.
+func runGitEnv(t *testing.T, dir string, env []string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	e := append(append([]string{}, os.Environ()...), "GIT_TERMINAL_PROMPT=0", "LC_ALL=C")
+	e = append(e, env...)
+	cmd.Env = e
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v in %s: %s: %v", args, dir, string(out), err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// runGitLiteral runs git with --literal-pathspecs as a git-level option, so a
+// path whose first byte is ':' is staged/removed as a literal filename rather
+// than parsed as pathspec magic. Used to build SC-13 without subjecting the
+// construction itself to the defect under test (acceptance.md §B SC-13 note).
+func runGitLiteral(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	return runGit(t, dir, append([]string{"--literal-pathspecs"}, args...)...)
+}
+
+// submoduleAllowFileProtocolEnv returns the env overlay that allows the file
+// transport for `git submodule add` of a local path on modern git. Set as a
+// per-call env (the documented env-equivalent of `git -c`) rather than via
+// `git config`, because protocol.file.allow is a protected key git ignores
+// from repo-local config (acceptance.md §B SC-15 note).
+func submoduleAllowFileProtocolEnv() []string {
+	return []string{
+		"GIT_CONFIG_COUNT=1",
+		"GIT_CONFIG_KEY_0=protocol.file.allow",
+		"GIT_CONFIG_VALUE_0=always",
+	}
+}
+
+// checkout switches the repo's branch (or detached ref) and fails on error.
+func checkout(t *testing.T, dir, ref string) {
+	t.Helper()
+	runGit(t, dir, "checkout", "-q", ref)
+}
+
+// assertMerged builds the scenario repo and asserts IsBranchMerged("feat","main")
+// returns the expected verdict with no error.
+func assertMerged(t *testing.T, label string, build func(*testing.T) string, want bool) {
+	t.Helper()
+	dir := build(t)
+	wm := NewWorktreeManager(dir)
+	got, err := wm.IsBranchMerged("feat", "main")
+	if err != nil {
+		t.Fatalf("%s: IsBranchMerged(feat,main) returned unexpected error: %v", label, err)
+	}
+	if got != want {
+		t.Errorf("%s: IsBranchMerged(feat,main) = %v, want %v", label, got, want)
+	}
+}
+
+// ===== Scenario builders (acceptance.md §B recipes, one per matrix row) =====
+
+// SC-1 squash-merged: feat adds x.txt then y.txt in two commits; main adds both
+// in one squash commit. Required verdict: merged (S4 + S5).
+func buildSC1Squash(t *testing.T) string {
+	dir := initTestRepo(t)
+	c := newCommitStep(t, dir)
+	runGit(t, dir, "checkout", "-q", "-b", "feat")
+	writeTestFile(t, filepath.Join(dir, "x.txt"), "x\n")
+	runGit(t, dir, "add", "x.txt")
+	c.commit("add x")
+	writeTestFile(t, filepath.Join(dir, "y.txt"), "y\n")
+	runGit(t, dir, "add", "y.txt")
+	c.commit("add y")
+	checkout(t, dir, "main")
+	runGit(t, dir, "merge", "--squash", "feat")
+	c.commit("squash feat")
+	return dir
+}
+
+// SC-2 rebase-merged: feat adds p.txt then q.txt; main drifts then cherry-picks
+// both commits individually. Required verdict: merged (S3 + S5).
+func buildSC2Rebase(t *testing.T) string {
+	dir := initTestRepo(t)
+	c := newCommitStep(t, dir)
+	runGit(t, dir, "checkout", "-q", "-b", "feat")
+	writeTestFile(t, filepath.Join(dir, "p.txt"), "p\n")
+	runGit(t, dir, "add", "p.txt")
+	pCommit := commitHash(t, dir, func() { c.commit("add p") })
+	writeTestFile(t, filepath.Join(dir, "q.txt"), "q\n")
+	runGit(t, dir, "add", "q.txt")
+	qCommit := commitHash(t, dir, func() { c.commit("add q") })
+	checkout(t, dir, "main")
+	// main drifts independently before replaying.
+	writeTestFile(t, filepath.Join(dir, "drift.txt"), "d\n")
+	runGit(t, dir, "add", "drift.txt")
+	c.commit("main drift")
+	runGitEnv(t, dir, c.dateEnv(), "cherry-pick", pCommit)
+	runGitEnv(t, dir, c.dateEnv(), "cherry-pick", qCommit)
+	return dir
+}
+
+// SC-3 true merge commit: feat adds m.txt; main runs git merge --no-ff feat.
+// Required verdict: merged (S1 + S2).
+func buildSC3MergeCommit(t *testing.T) string {
+	dir := initTestRepo(t)
+	c := newCommitStep(t, dir)
+	runGit(t, dir, "checkout", "-q", "-b", "feat")
+	writeTestFile(t, filepath.Join(dir, "m.txt"), "m\n")
+	runGit(t, dir, "add", "m.txt")
+	c.commit("add m")
+	checkout(t, dir, "main")
+	runGitEnv(t, dir, c.dateEnv(), "merge", "--no-ff", "feat", "-m", "merge feat")
+	return dir
+}
+
+// SC-4 strictly behind: feat created at base and left alone; main advances.
+// Required verdict: merged (S1 + S2).
+func buildSC4Behind(t *testing.T) string {
+	dir := initTestRepo(t)
+	c := newCommitStep(t, dir)
+	runGit(t, dir, "checkout", "-q", "-b", "feat")
+	checkout(t, dir, "main")
+	writeTestFile(t, filepath.Join(dir, "ahead.txt"), "a\n")
+	runGit(t, dir, "add", "ahead.txt")
+	c.commit("main advances")
+	return dir
+}
+
+// SC-5 empty-diff branch: feat carries one --allow-empty commit; main advances.
+// Required verdict: merged (S2).
+func buildSC5EmptyDiff(t *testing.T) string {
+	dir := initTestRepo(t)
+	c := newCommitStep(t, dir)
+	runGit(t, dir, "checkout", "-q", "-b", "feat")
+	c.commitAllowEmpty("empty commit on feat")
+	checkout(t, dir, "main")
+	writeTestFile(t, filepath.Join(dir, "ahead.txt"), "a\n")
+	runGit(t, dir, "add", "ahead.txt")
+	c.commit("main advances")
+	return dir
+}
+
+// SC-6 partially applied: feat adds a.txt then b.txt; main adds only a.txt.
+// Required verdict: not merged (S5 withholds).
+func buildSC6Partial(t *testing.T) string {
+	dir := initTestRepo(t)
+	c := newCommitStep(t, dir)
+	runGit(t, dir, "checkout", "-q", "-b", "feat")
+	writeTestFile(t, filepath.Join(dir, "a.txt"), "a\n")
+	runGit(t, dir, "add", "a.txt")
+	c.commit("add a")
+	writeTestFile(t, filepath.Join(dir, "b.txt"), "b\n")
+	runGit(t, dir, "add", "b.txt")
+	c.commit("add b")
+	checkout(t, dir, "main")
+	writeTestFile(t, filepath.Join(dir, "a.txt"), "a\n")
+	runGit(t, dir, "add", "a.txt")
+	c.commit("main adds only a")
+	return dir
+}
+
+// SC-7 fully unmerged (control): feat adds z.txt; main drifts independently.
+// Required verdict: not merged (no signal fires).
+func buildSC7Unmerged(t *testing.T) string {
+	dir := initTestRepo(t)
+	c := newCommitStep(t, dir)
+	runGit(t, dir, "checkout", "-q", "-b", "feat")
+	writeTestFile(t, filepath.Join(dir, "z.txt"), "z\n")
+	runGit(t, dir, "add", "z.txt")
+	c.commit("add z")
+	checkout(t, dir, "main")
+	writeTestFile(t, filepath.Join(dir, "drift.txt"), "d\n")
+	runGit(t, dir, "add", "drift.txt")
+	c.commit("main drift")
+	return dir
+}
+
+// SC-8 partially reverted: feat adds a.txt then b.txt; main cherry-picks BOTH,
+// then reverts the b commit. Required verdict: not merged (S5 withholds even
+// though S3 fires on history alone).
+func buildSC8Revert(t *testing.T) string {
+	dir := initTestRepo(t)
+	c := newCommitStep(t, dir)
+	runGit(t, dir, "checkout", "-q", "-b", "feat")
+	writeTestFile(t, filepath.Join(dir, "a.txt"), "a\n")
+	runGit(t, dir, "add", "a.txt")
+	aCommit := commitHash(t, dir, func() { c.commit("add a") })
+	writeTestFile(t, filepath.Join(dir, "b.txt"), "b\n")
+	runGit(t, dir, "add", "b.txt")
+	bCommit := commitHash(t, dir, func() { c.commit("add b") })
+	checkout(t, dir, "main")
+	runGitEnv(t, dir, c.dateEnv(), "cherry-pick", aCommit)
+	runGitEnv(t, dir, c.dateEnv(), "cherry-pick", bCommit)
+	// Revert the b commit (HEAD). git revert takes no -q (acceptance.md §B note).
+	runGitEnv(t, dir, c.dateEnv(), "revert", "--no-edit", "HEAD")
+	return dir
+}
+
+// SC-9 base is a strict superset: feat adds s.txt; main INDEPENDENTLY adds
+// s.txt as its own commit (NOT a cherry-pick — that would collide on SHA and
+// degenerate into SC-4), then additionally adds extra.txt.
+// Required verdict: merged (S3 + S4 + S5).
+func buildSC9Superset(t *testing.T) string {
+	dir := initTestRepo(t)
+	c := newCommitStep(t, dir)
+	runGit(t, dir, "checkout", "-q", "-b", "feat")
+	writeTestFile(t, filepath.Join(dir, "s.txt"), "s\n")
+	runGit(t, dir, "add", "s.txt")
+	c.commit("feat adds s")
+	checkout(t, dir, "main")
+	// main re-creates the same change as its own commit (different SHA).
+	writeTestFile(t, filepath.Join(dir, "s.txt"), "s\n")
+	runGit(t, dir, "add", "s.txt")
+	c.commit("main independently adds s")
+	writeTestFile(t, filepath.Join(dir, "extra.txt"), "e\n")
+	runGit(t, dir, "add", "extra.txt")
+	c.commit("main adds extra")
+	return dir
+}
+
+// SC-10 rename + re-add (squash): base holds a 10-line old.txt; feat runs
+// `git mv old.txt new.txt` and commits, then appends a line to new.txt and
+// commits — TWO commits; main squash-merges feat, then re-adds old.txt.
+// Required verdict: not merged (S5 withholds; --no-renames keeps old.txt in
+// the enumerated path list).
+func buildSC10RenameReAddSquash(t *testing.T) string {
+	dir := initTestRepo(t)
+	c := newCommitStep(t, dir)
+	// Seed a 10-line old.txt at the merge-base (>= 50% similarity for rename
+	// detection; acceptance.md §B note).
+	var sb strings.Builder
+	for i := 1; i <= 10; i++ {
+		fmt.Fprintf(&sb, "line %d\n", i)
+	}
+	writeTestFile(t, filepath.Join(dir, "old.txt"), sb.String())
+	runGit(t, dir, "add", "old.txt")
+	c.commit("seed old.txt")
+	runGit(t, dir, "checkout", "-q", "-b", "feat")
+	runGit(t, dir, "mv", "old.txt", "new.txt")
+	c.commit("rename old -> new")
+	// Append a line to new.txt in a SECOND commit (two-commit form is
+	// load-bearing; acceptance.md §B SC-10 note).
+	writeTestFile(t, filepath.Join(dir, "new.txt"), sb.String()+"appended line\n")
+	runGit(t, dir, "add", "new.txt")
+	c.commit("edit new.txt")
+	checkout(t, dir, "main")
+	runGit(t, dir, "merge", "--squash", "feat")
+	c.commit("squash feat")
+	// main re-adds old.txt with its original content.
+	writeTestFile(t, filepath.Join(dir, "old.txt"), sb.String())
+	runGit(t, dir, "add", "old.txt")
+	c.commit("main re-adds old.txt")
+	return dir
+}
+
+// SC-11 rename + re-add (cherry-pick): base holds 10-line old.txt; feat runs
+// `git mv old.txt new.txt`; main cherry-picks that commit, then re-adds old.txt.
+// Required verdict: not merged (S3 + S4 fire; S5 withholds via --no-renames).
+func buildSC11RenameReAddCherryPick(t *testing.T) string {
+	dir := initTestRepo(t)
+	c := newCommitStep(t, dir)
+	var sb strings.Builder
+	for i := 1; i <= 10; i++ {
+		fmt.Fprintf(&sb, "line %d\n", i)
+	}
+	writeTestFile(t, filepath.Join(dir, "old.txt"), sb.String())
+	runGit(t, dir, "add", "old.txt")
+	c.commit("seed old.txt")
+	runGit(t, dir, "checkout", "-q", "-b", "feat")
+	runGit(t, dir, "mv", "old.txt", "new.txt")
+	renameCommit := commitHash(t, dir, func() { c.commit("rename old -> new") })
+	checkout(t, dir, "main")
+	runGitEnv(t, dir, c.dateEnv(), "cherry-pick", renameCommit)
+	writeTestFile(t, filepath.Join(dir, "old.txt"), sb.String())
+	runGit(t, dir, "add", "old.txt")
+	c.commit("main re-adds old.txt")
+	return dir
+}
+
+// SC-12 non-ASCII path removed from base: feat adds plain.txt and 문서.txt in
+// one commit; main squash-merges, then removes 문서.txt. Required verdict: not
+// merged (S5 withholds; -z keeps the non-ASCII path round-tripping verbatim).
+func buildSC12NonASCII(t *testing.T) string {
+	dir := initTestRepo(t)
+	c := newCommitStep(t, dir)
+	// Set core.quotePath true explicitly (this machine's ~/.gitconfig overrides
+	// it to false; acceptance.md §B SC-12 note).
+	runGit(t, dir, "config", "core.quotePath", "true")
+	runGit(t, dir, "checkout", "-q", "-b", "feat")
+	writeTestFile(t, filepath.Join(dir, "plain.txt"), "plain\n")
+	writeTestFile(t, filepath.Join(dir, "문서.txt"), "doc\n")
+	runGit(t, dir, "add", "plain.txt", "문서.txt")
+	c.commit("feat adds plain + 문서")
+	checkout(t, dir, "main")
+	runGit(t, dir, "merge", "--squash", "feat")
+	c.commit("squash feat")
+	runGit(t, dir, "rm", "문서.txt")
+	c.commit("main removes 문서")
+	return dir
+}
+
+// SC-13 leading-colon path removed from base: feat adds plain.txt and :note.txt
+// in one commit; main squash-merges, then removes :note.txt. Every add/rm of
+// the hazard path runs under --literal-pathspecs so the construction is not
+// subject to the defect under test (acceptance.md §B SC-13 note).
+// Required verdict: not merged (S5 withholds; --literal-pathspecs matches the
+// leading-colon path as a literal filename).
+func buildSC13ColonPath(t *testing.T) string {
+	dir := initTestRepo(t)
+	c := newCommitStep(t, dir)
+	runGit(t, dir, "checkout", "-q", "-b", "feat")
+	writeTestFile(t, filepath.Join(dir, "plain.txt"), "plain\n")
+	writeTestFile(t, filepath.Join(dir, ":note.txt"), "note\n")
+	runGitLiteral(t, dir, "add", "plain.txt", ":note.txt")
+	c.commit("feat adds plain + :note")
+	checkout(t, dir, "main")
+	runGit(t, dir, "merge", "--squash", "feat")
+	c.commit("squash feat")
+	runGitLiteral(t, dir, "rm", ":note.txt")
+	c.commit("main removes :note")
+	return dir
+}
+
+// SC-14 textconv driver collapses a changed file: the seed adds .gitattributes
+// binding *.pdf to a textconv driver whose script emits a constant; feat adds
+// plain.txt + report.pdf; main squash-merges, then overwrites report.pdf with
+// different content. .gitattributes stays in the worktree (the attribute is
+// read from the checked-out file, not the tree under judgement; acceptance.md
+// §B SC-14 note). Required verdict: not merged (S5 withholds; --no-textconv
+// compares blobs, not the driver's rendering).
+func buildSC14Textconv(t *testing.T) string {
+	dir := initTestRepo(t)
+	c := newCommitStep(t, dir)
+	// Executable textconv script at an absolute path (git requires an absolute
+	// path or it reports "cannot run").
+	textconvPath := filepath.Join(dir, "textconv.sh")
+	writeTestFile(t, textconvPath, "#!/bin/sh\ncat >/dev/null\necho constant\n")
+	if err := os.Chmod(textconvPath, 0o755); err != nil {
+		t.Fatalf("chmod textconv: %v", err)
+	}
+	// Seed: .gitattributes + the diff driver. The attribute must remain in the
+	// worktree at judgement time.
+	writeTestFile(t, filepath.Join(dir, ".gitattributes"), "*.pdf diff=pdf\n")
+	runGit(t, dir, "add", ".gitattributes")
+	runGit(t, dir, "config", "diff.pdf.textconv", textconvPath)
+	c.commit("seed .gitattributes + textconv driver")
+	runGit(t, dir, "checkout", "-q", "-b", "feat")
+	writeTestFile(t, filepath.Join(dir, "plain.txt"), "plain\n")
+	writeTestFile(t, filepath.Join(dir, "report.pdf"), "PDF-ORIGINAL\n")
+	runGit(t, dir, "add", "plain.txt", "report.pdf")
+	c.commit("feat adds plain + report.pdf")
+	checkout(t, dir, "main")
+	runGit(t, dir, "merge", "--squash", "feat")
+	c.commit("squash feat")
+	// Overwrite report.pdf with genuinely different content. Both blobs render
+	// to "constant" under the driver, so an unpatched comparison reports equal.
+	writeTestFile(t, filepath.Join(dir, "report.pdf"), "PDF-OVERWRITTEN-DIFFERENT\n")
+	runGit(t, dir, "add", "report.pdf")
+	c.commit("main overwrites report.pdf")
+	return dir
+}
+
+// SC-15 submodule pointer moved under an ignore directive: a second throwaway
+// repo is built with commits s0/s1/s2; the parent adds it as a submodule at
+// `sub` pinned to s0; feat moves the pointer to s1 and adds plain.txt WITHOUT
+// touching .gitmodules; main squash-merges, then moves the pointer to s2. The
+// ignore directive (submodule.sub.ignore=all) is committed INSIDE .gitmodules,
+// modeling an exposure a repository ships to every clone (acceptance.md §B
+// SC-15 note). Required verdict: not merged (S5 withholds; --ignore-submodules=none
+// on BOTH enumeration and comparison is required to see the moved gitlink).
+func buildSC15Submodule(t *testing.T) string {
+	dir := initTestRepo(t)
+	c := newCommitStep(t, dir)
+
+	// Build the submodule repo fully (s0, s1, s2) BEFORE the parent adds it, so
+	// `submodule add` fetches all three commits into the parent's
+	// `.git/modules/sub` store and subsequent checkouts inside dir/sub resolve.
+	subDir := resolveSymlinks(t, t.TempDir())
+	runGit(t, subDir, "init", "-b", "main")
+	runGit(t, subDir, "config", "user.email", "sub@e.x")
+	runGit(t, subDir, "config", "user.name", "Sub")
+	writeTestFile(t, filepath.Join(subDir, "sub_file.txt"), "s0\n")
+	runGit(t, subDir, "add", "sub_file.txt")
+	runGitEnv(t, subDir, nil, "commit", "-m", "s0")
+	writeTestFile(t, filepath.Join(subDir, "sub_file.txt"), "s1\n")
+	runGit(t, subDir, "add", "sub_file.txt")
+	runGitEnv(t, subDir, nil, "commit", "-m", "s1")
+	s1 := runGit(t, subDir, "rev-parse", "main")
+	writeTestFile(t, filepath.Join(subDir, "sub_file.txt"), "s2\n")
+	runGit(t, subDir, "add", "sub_file.txt")
+	runGitEnv(t, subDir, nil, "commit", "-m", "s2")
+	s2 := runGit(t, subDir, "rev-parse", "main")
+	s0 := runGit(t, subDir, "rev-parse", "main~2")
+
+	// Parent adds the submodule. protocol.file.allow=always is needed for a
+	// local path on modern git. This pins HEAD (s2) and fetches all objects.
+	runGitEnv(t, dir, submoduleAllowFileProtocolEnv(), "submodule", "add", subDir, "sub")
+	// Move the parent's pointer from s2 back to s0 so feat can advance it to s1
+	// and main to s2, modelling the scenario's divergence.
+	runGit(t, filepath.Join(dir, "sub"), "checkout", s0)
+	// Commit the ignore directive inside the TRACKED .gitmodules so it ships to
+	// every clone with no operator config.
+	gitmodulesPath := filepath.Join(dir, ".gitmodules")
+	orig, err := os.ReadFile(gitmodulesPath)
+	if err != nil {
+		t.Fatalf("read .gitmodules: %v", err)
+	}
+	if !strings.Contains(string(orig), "ignore = all") {
+		appendLine := "\tignore = all\n"
+		if err := os.WriteFile(gitmodulesPath, append(orig, []byte(appendLine)...), 0o644); err != nil {
+			t.Fatalf("write .gitmodules: %v", err)
+		}
+	}
+	runGit(t, dir, "add", ".gitmodules", "sub")
+	c.commit("add submodule at s0 with ignore=all")
+
+	// feat moves the pointer to s1 and adds plain.txt (NO .gitmodules change).
+	runGit(t, dir, "checkout", "-q", "-b", "feat")
+	runGit(t, filepath.Join(dir, "sub"), "checkout", s1)
+	writeTestFile(t, filepath.Join(dir, "plain.txt"), "plain\n")
+	runGit(t, dir, "add", "sub", "plain.txt")
+	c.commit("feat moves submodule to s1 + adds plain")
+	checkout(t, dir, "main")
+	runGit(t, dir, "merge", "--squash", "feat")
+	c.commit("squash feat")
+	// main moves the pointer to s2.
+	runGit(t, filepath.Join(dir, "sub"), "checkout", s2)
+	runGit(t, dir, "add", "sub")
+	c.commit("main moves submodule to s2")
+	return dir
+}
+
+// P3c mode-only divergence: the seed adds x.txt; feat chmods it to 755 and adds
+// plain.txt; main squash-merges, then chmods x.txt back to 644. Content is
+// byte-identical on both sides throughout; only the mode differs. core.fileMode
+// is left at its default (true). Required verdict: not merged (S5 withholds; git
+// diff compares modes, so a mode-only change is detected).
+func buildP3cModeOnly(t *testing.T) string {
+	dir := initTestRepo(t)
+	c := newCommitStep(t, dir)
+	writeTestFile(t, filepath.Join(dir, "x.txt"), "x\n")
+	runGit(t, dir, "add", "x.txt")
+	c.commit("seed x.txt")
+	runGit(t, dir, "checkout", "-q", "-b", "feat")
+	if err := os.Chmod(filepath.Join(dir, "x.txt"), 0o755); err != nil {
+		t.Fatalf("chmod 755: %v", err)
+	}
+	writeTestFile(t, filepath.Join(dir, "plain.txt"), "plain\n")
+	runGit(t, dir, "add", "x.txt", "plain.txt")
+	c.commit("feat chmods x + adds plain")
+	checkout(t, dir, "main")
+	runGit(t, dir, "merge", "--squash", "feat")
+	c.commit("squash feat")
+	if err := os.Chmod(filepath.Join(dir, "x.txt"), 0o644); err != nil {
+		t.Fatalf("chmod 644: %v", err)
+	}
+	runGit(t, dir, "add", "x.txt")
+	c.commit("main chmods x back")
+	return dir
+}
+
+// P4c symlink/file blob-OID collision: the seed adds a symlink link.txt->target
+// and a regular file target; feat replaces link.txt with a REGULAR file whose
+// content is exactly "target" (NO trailing newline) and adds plain.txt; main
+// squash-merges, then restores link.txt as a symlink. Both sides share one blob
+// OID and differ only in mode. Required verdict: not merged (S5 withholds; git
+// diff is mode-sensitive).
+func buildP4cSymlinkFile(t *testing.T) string {
+	dir := initTestRepo(t)
+	c := newCommitStep(t, dir)
+	// Seed: symlink + its target.
+	targetPath := filepath.Join(dir, "target")
+	writeTestFile(t, targetPath, "target-content\n")
+	linkPath := filepath.Join(dir, "link.txt")
+	if err := os.Symlink("target", linkPath); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	runGit(t, dir, "add", "target", "link.txt")
+	c.commit("seed symlink + target")
+	runGit(t, dir, "checkout", "-q", "-b", "feat")
+	// Replace the symlink with a regular file whose content is EXACTLY the
+	// symlink's target with no trailing newline (so both share one blob OID).
+	if err := os.Remove(linkPath); err != nil {
+		t.Fatalf("remove symlink: %v", err)
+	}
+	if err := os.WriteFile(linkPath, []byte("target"), 0o644); err != nil {
+		t.Fatalf("write regular file: %v", err)
+	}
+	writeTestFile(t, filepath.Join(dir, "plain.txt"), "plain\n")
+	runGit(t, dir, "add", "link.txt", "plain.txt")
+	c.commit("feat replaces symlink + adds plain")
+	checkout(t, dir, "main")
+	runGit(t, dir, "merge", "--squash", "feat")
+	c.commit("squash feat")
+	// Restore link.txt as a symlink.
+	if err := os.Remove(linkPath); err != nil {
+		t.Fatalf("remove regular file: %v", err)
+	}
+	if err := os.Symlink("target", linkPath); err != nil {
+		t.Fatalf("restore symlink: %v", err)
+	}
+	runGit(t, dir, "add", "link.txt")
+	c.commit("main restores symlink")
+	return dir
+}
+
+// commitHash performs a commit via the supplied do-commit callback and returns
+// the resulting commit SHA. Used to capture cherry-pick targets before they are
+// replayed.
+func commitHash(t *testing.T, dir string, doCommit func()) string {
+	t.Helper()
+	doCommit()
+	return runGit(t, dir, "rev-parse", "HEAD")
+}
+
+// ===== Top-level tests (names match the AC-WSM-001..017 -run selectors) =====
+// The selector regex is matched as an unanchored substring of the fully
+// qualified test name, so each top-level test is named to contain its
+// criterion's keyword (Squash, Rebase, EmptyDiff, Reachab, Partial|Unmerged,
+// Rename|NonASCII|ColonPath|Textconv|Submodule, ModeOnly|SymlinkFile, ProbeExit,
+// Revert). acceptance.md §A non-vacuity discipline is judged by reading the
+// `--- PASS:` lines, not the exit code.
+
+func TestIsBranchMerged_SquashMerged(t *testing.T) {
+	assertMerged(t, "SC-1 squash", buildSC1Squash, true)
+}
+
+func TestIsBranchMerged_RebaseMerged(t *testing.T) {
+	assertMerged(t, "SC-2 rebase", buildSC2Rebase, true)
+}
+
+func TestIsBranchMerged_Reachability_TrueMergeCommit(t *testing.T) {
+	assertMerged(t, "SC-3 true merge commit", buildSC3MergeCommit, true)
+}
+
+func TestIsBranchMerged_Reachability_StrictlyBehind(t *testing.T) {
+	assertMerged(t, "SC-4 strictly behind", buildSC4Behind, true)
+}
+
+func TestIsBranchMerged_EmptyDiffBranch(t *testing.T) {
+	assertMerged(t, "SC-5 empty-diff branch", buildSC5EmptyDiff, true)
+}
+
+func TestIsBranchMerged_PartiallyApplied(t *testing.T) {
+	assertMerged(t, "SC-6 partially applied", buildSC6Partial, false)
+}
+
+func TestIsBranchMerged_UnmergedControl(t *testing.T) {
+	assertMerged(t, "SC-7 fully unmerged", buildSC7Unmerged, false)
+}
+
+func TestIsBranchMerged_RevertRemovedFromBase(t *testing.T) {
+	assertMerged(t, "SC-8 partially reverted", buildSC8Revert, false)
+}
+
+func TestIsBranchMerged_Superset(t *testing.T) {
+	assertMerged(t, "SC-9 base is strict superset", buildSC9Superset, true)
+}
+
+func TestIsBranchMerged_RenameReAddSquash(t *testing.T) {
+	assertMerged(t, "SC-10 rename+re-add (squash)", buildSC10RenameReAddSquash, false)
+}
+
+func TestIsBranchMerged_RenameReAddCherryPick(t *testing.T) {
+	assertMerged(t, "SC-11 rename+re-add (cherry-pick)", buildSC11RenameReAddCherryPick, false)
+}
+
+func TestIsBranchMerged_NonASCIIPathRemoved(t *testing.T) {
+	assertMerged(t, "SC-12 non-ASCII path removed", buildSC12NonASCII, false)
+}
+
+func TestIsBranchMerged_ColonPathRemovedFromBase(t *testing.T) {
+	assertMerged(t, "SC-13 leading-colon path removed", buildSC13ColonPath, false)
+}
+
+func TestIsBranchMerged_TextconvDriverCollapsesChange(t *testing.T) {
+	assertMerged(t, "SC-14 textconv driver", buildSC14Textconv, false)
+}
+
+func TestIsBranchMerged_SubmoduleIgnoreDirective(t *testing.T) {
+	assertMerged(t, "SC-15 submodule ignore directive", buildSC15Submodule, false)
+}
+
+func TestIsBranchMerged_ModeOnlyDivergence(t *testing.T) {
+	assertMerged(t, "P3c mode-only divergence", buildP3cModeOnly, false)
+}
+
+func TestIsBranchMerged_SymlinkFileOIDCollision(t *testing.T) {
+	assertMerged(t, "P4c symlink/file OID collision", buildP4cSymlinkFile, false)
+}
+
+// TestIsBranchMerged_ProbeExit_Table binds AC-WSM-007: the per-probe exit-code
+// table. A verdict-carrying exit (git diff --quiet rc 1, git merge-base rc 1 on
+// unrelated histories) MUST NOT surface as an error; a true failure (unknown
+// base ref) MUST surface as an error. Four subtests, one per row.
+func TestIsBranchMerged_ProbeExit_Table(t *testing.T) {
+	t.Run("UnknownBase", func(t *testing.T) {
+		dir := buildSC1Squash(t)
+		wm := NewWorktreeManager(dir)
+		_, err := wm.IsBranchMerged("feat", "no-such-base")
+		if err == nil {
+			t.Fatal("expected error for unknown base ref; got nil")
+		}
+	})
+
+	t.Run("UnrelatedHistories", func(t *testing.T) {
+		dir := initTestRepo(t)
+		// Create an orphan branch sharing no ancestor with main.
+		runGit(t, dir, "checkout", "--orphan", "orphan")
+		runGit(t, dir, "rm", "-rf", ".")
+		writeTestFile(t, filepath.Join(dir, "orphan.txt"), "o\n")
+		runGit(t, dir, "add", "orphan.txt")
+		runGit(t, dir, "config", "user.email", "o@e.x")
+		runGit(t, dir, "config", "user.name", "Orphan")
+		runGit(t, dir, "commit", "-m", "orphan seed")
+		runGit(t, dir, "checkout", "-q", "main")
+		wm := NewWorktreeManager(dir)
+		got, err := wm.IsBranchMerged("orphan", "main")
+		if err != nil {
+			t.Fatalf("unrelated histories must return (false, nil), got err: %v", err)
+		}
+		if got {
+			t.Errorf("unrelated histories must return false, got true")
+		}
+	})
+
+	t.Run("NonEmptyDiffNoError", func(t *testing.T) {
+		// A branch with a non-empty diff vs merge-base exercises the
+		// git diff --quiet rc=1 verdict path; it must not surface as an error.
+		dir := buildSC7Unmerged(t)
+		wm := NewWorktreeManager(dir)
+		_, err := wm.IsBranchMerged("feat", "main")
+		if err != nil {
+			t.Fatalf("non-empty diff must not surface rc=1 as error: %v", err)
+		}
+	})
+
+	t.Run("EmptyDiffMerged", func(t *testing.T) {
+		dir := buildSC5EmptyDiff(t)
+		wm := NewWorktreeManager(dir)
+		got, err := wm.IsBranchMerged("feat", "main")
+		if err != nil {
+			t.Fatalf("empty-diff branch: %v", err)
+		}
+		if !got {
+			t.Errorf("empty-diff branch must report merged, got false")
+		}
+	})
+}

--- a/internal/core/git/worktree_squash_merge_test.go
+++ b/internal/core/git/worktree_squash_merge_test.go
@@ -708,3 +708,48 @@ func TestIsBranchMerged_ProbeExit_Table(t *testing.T) {
 		}
 	})
 }
+
+// TestSyntheticCommit_DeterministicIdentity binds AC-WSM-008: two successive
+// evaluations of one unchanged branch produce the same synthetic-commit object
+// (so the dangling-commit count rises by at most one across both). With the
+// identity pinned (REQ-WSM-008) the second commit-tree writes the same object
+// git already has, so the delta is exactly one. Unpinning GIT_COMMITTER_DATE
+// makes each call write a distinct object → delta 2 → this test FAILs.
+func TestSyntheticCommit_DeterministicIdentity(t *testing.T) {
+	dir := buildSC1Squash(t)
+	wm := NewWorktreeManager(dir)
+
+	baseline := countDanglingCommits(t, dir)
+
+	// Two evaluations of the same unchanged branch.
+	for i := 0; i < 2; i++ {
+		merged, err := wm.IsBranchMerged("feat", "main")
+		if err != nil {
+			t.Fatalf("call %d: IsBranchMerged error: %v", i, err)
+		}
+		if !merged {
+			t.Fatalf("call %d: expected squash-merged branch to report merged", i)
+		}
+	}
+
+	after := countDanglingCommits(t, dir)
+	if delta := after - baseline; delta > 1 {
+		t.Errorf("dangling-commit delta = %d (baseline %d → after %d), want <= 1; "+
+			"the synthetic commit is not deterministic — identity is not pinned", delta, baseline, after)
+	}
+}
+
+// countDanglingCommits counts unreachable commit objects via git fsck. Used by
+// the determinism test to measure whether repeated synthetic-commit creation
+// reuses the same object (delta <= 1) or writes fresh ones each call (delta 2).
+func countDanglingCommits(t *testing.T, dir string) int {
+	t.Helper()
+	out := runGit(t, dir, "fsck", "--dangling", "--no-reflogs")
+	n := 0
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, "dangling commit ") {
+			n++
+		}
+	}
+	return n
+}

--- a/internal/core/git/worktree_squash_merge_test.go
+++ b/internal/core/git/worktree_squash_merge_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // This file implements the seventeen-scenario oracle for IsBranchMerged
@@ -721,8 +722,15 @@ func TestSyntheticCommit_DeterministicIdentity(t *testing.T) {
 
 	baseline := countDanglingCommits(t, dir)
 
-	// Two evaluations of the same unchanged branch.
+	// Two evaluations of the same unchanged branch, separated by >1s so that an
+	// UN-pinned committer date would land in a different second and produce a
+	// distinct object. With identity pinned (REQ-WSM-008) both calls write the
+	// same object git already has, so the dangling delta stays at 1; un-pinned,
+	// the second writes a fresh object and the delta rises to 2.
 	for i := 0; i < 2; i++ {
+		if i > 0 {
+			time.Sleep(1100 * time.Millisecond)
+		}
 		merged, err := wm.IsBranchMerged("feat", "main")
 		if err != nil {
 			t.Fatalf("call %d: IsBranchMerged error: %v", i, err)

--- a/internal/core/git/worktree_squash_merge_test.go
+++ b/internal/core/git/worktree_squash_merge_test.go
@@ -422,6 +422,18 @@ func buildSC14Textconv(t *testing.T) string {
 	return dir
 }
 
+// setSubmoduleGitlink stages the submodule gitlink `sub` -> sha into the
+// parent repo's index via `git update-index --cacheinfo`, bypassing git's
+// change-detection entirely. `git add sub` does not reliably stage a
+// pointer-only move under submodule.<name>.ignore=all on some platforms (the
+// gitlink silently never advances, leaving a "nothing to commit" failure or,
+// worse, a silently deformed scenario). Writing the gitlink directly is
+// cross-platform reliable. Mode 160000 is the gitlink mode. (SC-15 fixture only.)
+func setSubmoduleGitlink(t *testing.T, parentDir, sha string) {
+	t.Helper()
+	runGit(t, parentDir, "update-index", "--cacheinfo", "160000,"+sha+",sub")
+}
+
 // SC-15 submodule pointer moved under an ignore directive: a second throwaway
 // repo is built with commits s0/s1/s2; the parent adds it as a submodule at
 // `sub` pinned to s0; feat moves the pointer to s1 and adds plain.txt WITHOUT
@@ -460,6 +472,8 @@ func buildSC15Submodule(t *testing.T) string {
 	// Move the parent's pointer from s2 back to s0 so feat can advance it to s1
 	// and main to s2, modelling the scenario's divergence.
 	runGit(t, filepath.Join(dir, "sub"), "checkout", s0)
+	// Record the s0 gitlink directly; see setSubmoduleGitlink.
+	setSubmoduleGitlink(t, dir, s0)
 	// Commit the ignore directive inside the TRACKED .gitmodules so it ships to
 	// every clone with no operator config.
 	gitmodulesPath := filepath.Join(dir, ".gitmodules")
@@ -473,21 +487,22 @@ func buildSC15Submodule(t *testing.T) string {
 			t.Fatalf("write .gitmodules: %v", err)
 		}
 	}
-	runGit(t, dir, "add", ".gitmodules", "sub")
+	runGit(t, dir, "add", ".gitmodules")
 	c.commit("add submodule at s0 with ignore=all")
 
 	// feat moves the pointer to s1 and adds plain.txt (NO .gitmodules change).
 	runGit(t, dir, "checkout", "-q", "-b", "feat")
 	runGit(t, filepath.Join(dir, "sub"), "checkout", s1)
 	writeTestFile(t, filepath.Join(dir, "plain.txt"), "plain\n")
-	runGit(t, dir, "add", "sub", "plain.txt")
+	runGit(t, dir, "add", "plain.txt")
+	setSubmoduleGitlink(t, dir, s1)
 	c.commit("feat moves submodule to s1 + adds plain")
 	checkout(t, dir, "main")
 	runGit(t, dir, "merge", "--squash", "feat")
 	c.commit("squash feat")
 	// main moves the pointer to s2.
 	runGit(t, filepath.Join(dir, "sub"), "checkout", s2)
-	runGit(t, dir, "add", "sub")
+	setSubmoduleGitlink(t, dir, s2)
 	c.commit("main moves submodule to s2")
 	return dir
 }


### PR DESCRIPTION
## What

`moai worktree clean --stale` / `--merged-only` now reclaim worktrees whose branches were **squash-merged** into the base, closing a false-negative gap.

SPEC-WORKTREE-SQUASH-MERGE-001 — Tier M.

## Problem

`IsBranchMerged` answered a *reachability* question (`git branch --merged`). Its callers need an *equivalence* question: "is this branch's work already in base?". Under a squash-merge workflow the two diverge permanently, so already-squashed branches read as unmerged and their worktrees are never reclaimed.

## Fix

`IsBranchMerged` (`internal/core/git/worktree.go`) is rewritten as an ordered OR, cheapest signal first:

- **S1** reachability (`git branch --merged`) — retained verbatim
- **S2** empty diff
- **S3** rebase-merge (`git cherry`) ∧ **S5**
- **S4** squash-merge (synthetic `git commit-tree` + `git cherry`) ∧ **S5**

**S5** is a state check (the branch's touched paths survive in base HEAD) used as a conjunct only — it may withhold a verdict, never grant one. Eight guards carry the safety argument (`--no-renames`, `-z` NUL-split, `--literal-pathspecs`, `--no-textconv`, `--ignore-submodules=none` at both stages, no-shell argv, `[]string` not joined, mode-sensitive `git diff`). Interface signature is unchanged — no call site or test double edited.

## Why this is safe

This predicate gates a **bulk directory-deletion** command. A false positive destroys unmerged user work with no undo. False-positive prevention is the central invariant: every guard closes a distinct measured axis, and the synthetic-commit identity is deterministic.

## Verification

Independent two-layer review (not self-report):

- **Orchestrator batch (10/10 PASS)**: `go test ./...` exit 0 (105 packages); 17-scenario predicate suite + ProbeExit — 19 PASS / 0 FAIL; coverage **85.7%**; `go build` + `GOOS=windows` build + `go vet` exit 0; `golangci-lint` clean; no-shell grep clean; signature + call sites + `types.go` unchanged; scope = 5 files (no creep).
- **sync-auditor (PASS, harmonic mean 0.94)**: Functionality 0.95 / Security 0.95 / Craft 0.92 / Consistency 0.95. Adversarial false-positive hunt across 22 uncovered repo-state vectors found no path returning `merged=true` for unmerged work. All 8 guards confirmed implemented and falsifiable; REQ-WSM-007 per-probe exit-code table and flag placement verified.

## Files

- `internal/core/git/worktree.go` — `IsBranchMerged` S1-S5 + helpers + `@MX:ANCHOR`
- `internal/core/git/manager.go` — `execGitExit` (exit-code-aware + per-call env hook; existing `execGit` callers unaffected)
- `internal/core/git/worktree_squash_merge_test.go` — 17-scenario real-repo suite (new)
- `.moai/specs/SPEC-WORKTREE-SQUASH-MERGE-001/{spec,plan,acceptance,progress}.md` — plan-phase artifacts + run evidence

🗿 MoAI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved branch merge detection for squash merges, rebases, cherry-picks, and equivalent changes.
  * Added safeguards covering unrelated histories, partial or reverted changes, file modes, submodules, symlinks, and special paths.
  * Preserved existing command-line behavior and interfaces.

* **Bug Fixes**
  * Reduced false positives during worktree cleanup.
  * Improved handling of Git failures and unexpected repository states.

* **Tests**
  * Expanded coverage for merge scenarios, path handling, repository states, and error conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->