### PR TITLE
chore(SPEC-WORKTREE-SQUASH-MERGE-001): backfill sync_commit_sha e17653bbf

### DIFF
--- a/.moai/specs/SPEC-WORKTREE-SQUASH-MERGE-001/progress.md
+++ b/.moai/specs/SPEC-WORKTREE-SQUASH-MERGE-001/progress.md
@@ -275,9 +275,9 @@ run_phase_commits:               # M1..M5 commits on fix/clean-stale-squash-dete
 ## §E.4 Sync-phase Audit-Ready Signal
 
 ```yaml
-sync_status: audit-ready
+sync_status: COMPLETE
 sync_complete_at: 2026-08-03
-sync_commit_sha: pending-backfill-sync   # a commit cannot reference its own SHA — backfilled in a follow-up commit per the 9ec8d8464 / cdb692135 canonical pattern
+sync_commit_sha: e17653bbf            # backfilled (was pending-backfill-sync placeholder in the sync commit PR #1297 — D3 self-referential-hazard exemption); sync squash-merge subject: docs(SPEC-WORKTREE-SQUASH-MERGE-001): sync-phase close (3-phase plan→run→sync)
 run_commit_sha: 4966e6720                # run-phase terminal commit (M5); origin's squash-merge is d7506e9e4 (PR #1293)
 tier: M
 changelog_entry_position: "### Fixed 최상단 (CHANGELOG.md) — squash-merge detection is a false-negative bug fix, not a new feature"


### PR DESCRIPTION
## Backfill — `sync_commit_sha` for SPEC-WORKTREE-SQUASH-MERGE-001

The sync commit (PR #1297, squash-merge `e17653bbf`) could not reference its own SHA — a commit does not know its own hash until after it lands. This backfill PR populates `progress.md §E.4 sync_commit_sha` with the real merge SHA, matching the canonical `cdb692135` / `9ec8d8464` backfill pattern.

### Change

- `.moai/specs/SPEC-WORKTREE-SQUASH-MERGE-001/progress.md` §E.4:
  - `sync_commit_sha: pending-backfill-sync` → `sync_commit_sha: e17653bbf`
  - `sync_status: audit-ready` → `sync_status: COMPLETE`

No other file touched. The SPEC is otherwise frozen at its completed state (3-phase close done in #1297).

🗿 MoAI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the sync-phase status to indicate completion.
  * Recorded the finalized synchronization commit reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->