### PR TITLE
feat(cli/wizard): remove 4 default-true confirm questions from moai init

### DIFF
--- a/.moai/docs/local-dev-settings-intent.md
+++ b/.moai/docs/local-dev-settings-intent.md
@@ -1,0 +1,81 @@
+# Local Dev Settings Intent — local settings.json 의도 명문화
+
+> Extracted from `CLAUDE.local.md` §22 for context-budget diet. Canonical reference for local `.claude/settings.json` key intent. The orchestrator reads this on demand instead of carrying it in every session/agent prefix.
+
+## 22. Dev Settings Intent — local settings.json 의도 명문화
+
+Workflow audit 2026-05-16 finding M2 후속. 로컬 `.claude/settings.json`의 몇 가지 키는 template baseline과 의도적으로 다르게 운용되며, 본 섹션은 그 의도를 명문화한다.
+
+### §22.1 defaultMode
+
+- **로컬값**: `"bypassPermissions"` 또는 `"acceptEdits"` (개발자 선호)
+- **Template 기본값**: 미지정 (Claude Code 기본 `"default"` 사용)
+- **의도**: 메인테이너는 빠른 실험 + bypass 모드 빈번 사용. 사용자 프로젝트는 안전한 prompt-each-time 기본값을 따른다.
+
+### §22.2 enableAllProjectMcpServers
+
+- **로컬값**: `true`
+- **Template 기본값**: 미지정 (false 효과)
+- **의도**: 메인테이너 머신에는 dev tool 다수 (pencil, chrome-devtools, claude-in-chrome 등)가 등록되어 있어 모두 자동 활성화하는 것이 효율적. 사용자 프로젝트는 `mcp__context7`만 `alwaysLoad`되고 나머지는 ToolSearch preload 경로를 따른다. (Sequential Thinking MCP는 SPEC-V3R6-SEQ-THINKING-RETIRE-001에서 retired — `ultrathink` 키워드로 대체.)
+
+### §22.3 teammateMode
+
+- **로컬값**: `"tmux"` (CG/GLM 모드 — `moai cg` / `moai glm` 진입 시) 또는 `""` (CC 모드 — `moai cc` 진입 시 override 해제). runtime-managed by `moai cg` / `moai glm` / `moai cc` 명령. 코드가 실제로 기록하는 값은 이 둘뿐이다 (`internal/cli/glm.go` `ensureSettingsLocalJSON`/`injectGLMEnvForTeam` 가 `"tmux"`, `internal/cli/launcher.go` `removeGLMEnv` 가 `""`). `"glm"`/`"claude"` 는 코드가 기록하지 않는다.
+- **`llm.yaml team_mode` 와 구분 (혼동 금지)**: `.claude/settings.local.json` 의 `teammateMode` 필드(`"tmux"`/`""`)와 `.moai/config/sections/llm.yaml` 의 `team_mode` 필드(`cg`/`glm`/`""`)는 서로 다른 필드다. 전자는 Claude Code teammate 표시 모드(tmux pane vs inline)를 결정하고, 후자는 CG 모드 감지 SSOT (`internal/tmux/cg_detect.go` `IsCGMode` 가 `team_mode == "cg"` 를 읽는다, REQ-CGH-006). 같은 "team/teammate" 어휘를 공유하나 위치·값·용도가 다르다.
+- **Template 기본값**: 미지정 (양쪽 필드 모두)
+- **의도**: 메인테이너는 CG mode (Claude leader + GLM teammates)로 cost-optimization 검증을 빈번하게 수행. 사용자 프로젝트는 leader 단독으로 시작 후 필요시 `moai cg` 진입.
+- **주의**: §2 [HARD] settings.local.json Separation 참조 — teammateMode는 `settings.local.json`에 위치하며 template에 절대 포함 금지.
+
+### §22.4 env.PATH
+
+- **위치 (2026-07-12 이관)**: machine-specific 절대경로 PATH는 이제 `settings.local.json`(gitignored)에만 둔다. `.claude/settings.json`(git-tracked)의 `env`에서 `PATH` 키를 **제거**했다 — git-tracked 파일에 `/Users/goos/...` 절대경로를 두면 fork/clone 사용자에게 깨지기 때문(§2 settings.local.json Separation 적용). settings.json의 `env`에는 machine-independent 키(`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`, `ENABLE_TOOL_SEARCH`, `MOAI_CONFIG_SOURCE`)만 남긴다.
+- **왜 절대경로인가 (settings.local.json 안에서)**: **Claude Code가 env.PATH 값의 `$HOME`을 expand하지 않음**이 실측 확인됨 (Bash 서브프로세스에 리터럴 `$HOME/go/bin`이 그대로 전달 → `command -v moai` 실패 → moai-lsp MCP가 PATH로 moai 미해석). 따라서 settings.local.json의 PATH는 절대경로를 쓴다 (직전 2026-05-17 F-009/M5의 `$HOME` 권고는 이 실측으로 뒤집힘).
+- **Template 기본값**: `settings.json.tmpl`의 PATH 키는 `{{jsonEscape .SmartPATH}}` 로 렌더 (BuildSmartPATH가 issue #467 대응으로 well-known 절대경로 PATH 생성 — `$HOME` 미사용). 사용자 프로젝트는 `moai init`/`moai update`가 절대 SmartPATH로 새로 렌더하므로 fork/clone과 무관. **주의**: `settings_test.go:requiredKeys`가 템플릿 env에 `PATH`/`ENABLE_TOOL_SEARCH`/`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` 존재를 강제하므로 템플릿에서 이 키들을 제거하면 CI FAIL — 로컬 settings.json에서만 PATH를 뺀다(템플릿은 그대로).
+- **주의 (2026-06-24 정정)**: `StatusLine` command는 Claude Code 내장 토큰 `$CLAUDE_PROJECT_DIR`을 런타임 환경변수로 받는다 (공식 문서 code.claude.com/docs/en/statusline — "runs with the same environment variables as hooks, including `CLAUDE_PROJECT_DIR`"). 종전 "StatusLine은 env var를 expand하지 않는다"는 GitHub Issue #7925를 오독한 것이며, 해당 이슈는 일반 shell 보간/`env` 블록 값에 대한 것이지 내장 토큰이 아니다. 단, **`env.PATH`의 `$HOME` expand 불가는 별개 사실로 여전히 유효**하며 본 절의 핵심 근거는 이쪽으로 한정한다.
+
+### §22.6 outputStyle — 제품 기본값 MoAI-Easy (2026-07-12 채택)
+
+- **템플릿 기본값 (제품 결정)**: `settings.json.tmpl` + 로컬 `.claude/settings.json` 모두 `"outputStyle": "MoAI-Easy"` 고정. 모든 배포 사용자가 기본 MoAI-Easy로 시작한다. 과거 `699e59631`의 "personal preference라 unpin" 결정을 제품 기본값 채택으로 되돌린 것 — CI 가드 `TestSettingsTemplateOutputStyle`도 "MoAI-Easy 필수"로 반전.
+- **우선순위 (공식 검증)**: Claude Code outputStyle 해석 순위는 `settings.local.json`(local, 최고) > `settings.json`(project) > `~/.claude/settings.json`(user) > 하드코딩 기본값. 종전 MoAI 내부 문서(settings-management.md)가 **local 스코프를 누락**했었고(2026-07-12 정정), 이 누락이 "outputStyle이 계속 리셋된다"는 오진의 근원이었다.
+- **`/config` 저장 위치 (공식)**: `/config` → Output style은 `settings.local.json`에 저장(공식 문서 code.claude.com/docs/en/output-styles). local이 최고 우선순위라 사용자의 `/config` 선택은 항상 템플릿 project 핀을 이긴다 → 제품 기본값 고정이 사용자를 가두지 않는다.
+- **적용 시점**: outputStyle은 세션 시작 시 1회만 읽힘 → 변경은 `/clear` 또는 새 세션부터 반영. 이것이 "리셋처럼 보이는" 현상의 실제 원인(버그 아님).
+- **코드 보존**: `settings.local.json` writer(`glm.go`/`settings.go`)는 `map[string]any` round-trip으로 outputStyle 등 unknown top-level 키를 보존(SPEC-CLIFIX-CRITICAL-001) → `moai glm`/`cg`/`cc`가 파일을 건드려도 outputStyle 유지.
+
+### §22.5 운영 원칙
+
+- [HARD] 메인테이너 머신에서 위 키들을 변경할 때 template 자동 동기화 금지 (§2 settings.local.json Separation 적용)
+- [HARD] 위 키들(defaultMode/enableAllProjectMcpServers/teammateMode/env.PATH/outputStyle)의 의도가 변경되면 본 §22를 즉시 갱신
+- [HARD] 사용자 프로젝트에 machine-specific 키(env.PATH 등)가 누락된 것이 정상 — 누락은 결함이 아니라 의도된 격리. 단 outputStyle은 예외: 템플릿에 MoAI-Easy로 고정되므로 배포 사용자에게도 존재한다.
+
+### §22.7 model — 로컬 project settings.json에서 의도적 미탑재 (last-choice 존중, 2026-07-24)
+
+- **로컬값**: 로컬 `.claude/settings.json`에 `model` 키 **없음** (의도적 제거). Template `settings.json.tmpl:398`의 `"model": "sonnet"` 제품 기본값은 **그대로 보존**.
+- **왜 제거했나 (근원)**: Claude Code 모델 우선순위는 `local settings.json > project settings.json > user settings > 하드코딩`. `/model`의 "saved as default for new sessions"는 **user 스코프**(`~/.claude/settings.json`)에 저장되는데, project `settings.json`의 `model: sonnet` pin(스코프2)이 이를 항상 덮어 **재시작마다 sonnet 복귀** 트랩이 발생. project pin을 제거하면 user 스코프의 `/model` 마지막 선택(현재 `opus[1m]`)이 이겨서 last-choice가 존중된다. (`outputStyle`은 `/config`가 최상위 local 스코프에 써서 안 가두지만, `model`은 `/model`이 하위 user 스코프에 써서 가두는 비대칭이 근본 원인.)
+- **effort는 무관**: user `~/.claude/settings.json`의 `effortLevel: high`를 덮는 pin이 project/local 어디에도 없으므로 effort는 이미 유지됨(순수 `claude` + moai 프로파일 비어있는 `moai cc/glm/cg` 두 경로 공통). "effort도 리셋"은 model 리셋에 묶인 착시.
+- **update 경로 주의 (drift)**: `moai update` clean-reinstall은 user의 `.claude/settings.json`을 wholesale 보존하므로 대개 살아남지만(`update_clean_install.go` Step 4.5 `MergeUserFiles`), 3-way 병합 경로는 template sonnet pin을 재도입할 수 있다. 재도입되면 이 절 근거대로 다시 제거. **제품(템플릿) 기본값 변경이 아님** — 배포 사용자는 여전히 sonnet cost-lever 기본값을 받는다.
+- [HARD] 이 로컬 미탑재는 **의도된 격리**(§22.5와 동일 원칙) — 감사/동기화 시 "결함"으로 되돌리지 말 것.
+
+### §22.8 web worktree auto-toggles default OFF (EnterWorktree-first policy, 2026-07-28)
+
+- **목적 (intent)**: `internal/config/defaults.go`의 `WorkflowWorktreeConfig` 세 토글 — `AutoCleanup`, `AutoCreate`, `AutoMerge` — 모두 **기본 `false`**. 웹 콘솔의 worktree 자동화는 사용자의 **명시적 opt-in** (웹 토글 ON 또는 `.moai/config/sections/workflow.yaml`의 `workflow.worktree.*` 키 `true` 설정)이 있을 때만 동작한다.
+- **Why**: SPEC-WORKTREE-ENTRY-STRATEGY-001 M1 (commit `2fdf77714`)에서 `AutoCleanup: true → false`, `AutoMerge: true → false`로 mutated. 배경 — worktree 자동 정리/자동 병합은 사용자가 의도하지 않은 sprawl을 조장하고, EnterWorktree-first policy (`.claude/rules/moai/workflow/worktree-integration.md` § `EnterWorktree` / `ExitWorktree` Tools)와 충돌한다. 기본 OFF는 "worktree 자동화는 사용자 선택" 원칙을 코드로 정합시킨다.
+- **제품(템플릿) 기본값과 동일**: 템플릿 `defaults.go` 또한 세 토글 모두 `false` (CLAUDE.local.md §2 [HARD] Template-First Rule 정합). 배포 사용자에게도 동일한 기본 OFF가 적용된다.
+- **`TmuxPreferred: true`는 본 절 범위 밖**: `defaults.go`의 `TmuxPreferred: true`는 SPEC-WORKTREE-ENTRY-STRATEGY-001 OQ-4 결정에 따라 명시적으로 OUT OF SCOPE — 변경 없음 (§22 운영 원칙 §22.5 참조).
+- [HARD] `defaults.go`의 세 토글 기본 `false`는 **의도된 정책**. 감사/동기화 시 "결함"으로 되돌리지 말 것. 기본값 토글은 별도 SPEC 통해서만.
+
+### §22.9 branch_guard.enabled — 메인테이너 로컬 opt-in (기본 OFF, 2026-07-30)
+
+- **목적 (intent)**: `internal/config/defaults.go`의 `BranchGuardConfig.Enabled`는 **기본 `false`**. Main-Checkout Branch-State Guard (`internal/hook/branch_guard.go`)는 분산 기본값으로 INERT하게 배포된다 — 단일 개발자 저장소에는 공유 체크아웃 위험이 없으므로 가드가 간섭하지 않는다. 다중 세션 공유 체크아웃을 운영하는 메인테이너만 로컬에서 opt-in한다.
+- **Why**: SPEC-WORKTREE-BRANCH-GUARD-OPTIN-001. 종전 가드는 템플릿을 통해 모든 사용자에게 default-on으로 배포되었고, 읽기 전용 명령(`git stash list`, `git merge-base`)까지 과잉 차단했다. v1.2.0에서 (a) 기본 OFF 전환 + (b) 읽기 전용 패턴 정제로 수정. 템플릿 중립성 (§25) 준수를 위해 `internal/template/templates/` 어디에도 `enabled: true` 가 없다.
+- **메인테이너 opt-in 경로**: 로컬 config local 티어 (`.moai/config/local/*.yaml`, resolver.go `loadLocalTier`가 읽는 유일한 로컬 오버라이드 티어)에 다음 파일을 둔다:
+  ```yaml
+  # .moai/config/local/workflow.yaml
+  workflow:
+    branch_guard:
+      enabled: true
+  ```
+  이 파일은 메인테이너 머신 로컬 전용이다 (아래 BLOCKER 참고).
+- **제품(템플릿) 기본값과 동일**: 템플릿 `defaults.go` + `internal/template/templates/.moai/config/sections/workflow.yaml` 모두 `enabled: false` (또는 키 부재 → Go zero-value `false`). §2 [HARD] Template-First Rule 정합.
+- **면제 로직 보존**: `MOAI_BRANCH_GUARD_EXEMPT=1` env + `AgentType == "manager-git"` 신원 검사는 변경 없이 enabled 경로에서만 참조된다 (REQ-6 backward compat).
+- **gitignore (해결됨)**: `.moai/config/local/` 디렉터리는 이제 `.gitignore`에 등록되었다 (chore 커밋). 따라서 메인테이너 opt-in 파일(`.moai/config/local/workflow.yaml`)을 생성해도 공개 저장소에 커밋되지 않는다. 종전 이 경로가 gitignore에 없어 분산 기본값이 `true`로 뒤집힐 위험이 있었으나 해결됨 (§25 정합).
+- [HARD] `defaults.go`의 `BranchGuard.Enabled` 기본 `false`는 **의도된 정책**. 감사/동기화 시 "결함"으로 되돌리지 말 것. 템플릿 기본값 변경은 별도 SPEC 통해서만.

--- a/.moai/docs/local-linear-integration.md
+++ b/.moai/docs/local-linear-integration.md
@@ -1,0 +1,55 @@
+# Linear 연동 (개인/로컬 전용)
+
+> Extracted from `CLAUDE.local.md` §26 for context-budget diet. Canonical reference for Linear ↔ SPEC bridge rules, workspace mapping, and idea-capture triggers. Read on demand.
+
+## 26. Linear 연동 (개인/로컬 전용)
+
+> [ZONE:Local-Only] 본 섹션은 GOOS 개인 개발 전용이며 로컬 전용이다. `internal/template/templates/`에 절대 미러 금지 (§25 isolation + §14 하드코딩 허용 영역). **범용 배포/제품화 계획 없음** — Linear 연동은 개인 개발 워크플로우로만 사용한다(배포용 스킬/MCP 프로비저닝 제품화는 하지 않기로 결정, 2026-07-12). **주의: `CLAUDE.local.md`는 gitignored가 아니라 git에 추적·커밋되어 공개 저장소(`origin/main`)에 공유된다** — 이름과 달리 로컬 전용 파일이 아니므로, 이 파일에 적는 모든 내용(워크스페이스 매핑·개인 경로·운영 방침)은 공개를 전제로 작성한다. "로컬 전용"은 *템플릿에 미러하지 않는다*는 뜻이지 *공유되지 않는다*는 뜻이 아니다.
+
+### §26.1 워크스페이스 매핑
+
+- **Linear 워크스페이스**: `모두의AI` (`linear.app/goos`)
+- **Team**: `모두의AI` · **이슈 접두사**: `MOAI-`
+- **Project ↔ 리포 매핑** (동시 진행 7개):
+
+| Linear Project | 리포 | 진행중 이슈 |
+|---|---|---|
+| moai-adk-go | /Users/goos/MoAI/moai-adk-go | MOAI-13/14/15 (Project-Harness Epic, plan) |
+| claude.mo.ai.kr | claude.mo.ai.kr | — |
+| mo.ai.kr | mo.ai.kr | MOAI-10 결제 오류 (Bug/High) |
+| MINK | MINK | MOAI-11 harness:mink-e2e |
+| copythat | copythat | — |
+| moai-stock | moai-stock | — |
+| academy | academy | MOAI-12 feat/design-system |
+
+- **SSOT 문서**: Linear 팀 문서 "SPEC ↔ Linear 브리지 규칙" (`linear.app/goos/document/spec-linear-브리지-규칙-fed04d006656`)
+
+### §26.2 운영 규칙 (2계층 모델)
+
+- **Linear 계층 (제품/기획)**: 무엇을/언제. 아이디어 저수지 + 우선순위 + 크로스 프로젝트 조율.
+- **SPEC 계층 (기술 SSOT)**: 정확히 어떻게. 각 리포 `.moai/specs/`. SPEC 저작은 **항상 리포 파일에서만** — Linear로 옮기지 않는다 (git·에이전트 파이프라인·frontmatter 결합).
+
+흐름:
+1. 아이디어·버그 → Linear 이슈로 캡처 (`Idea` 라벨 → Triage). 아직 SPEC 아님.
+2. 착수 결정 → 해당 리포에서 `/moai plan`으로 SPEC 승격 + frontmatter `linear_issue: MOAI-N`.
+3. `/moai run` → `/moai sync`로 구현·클로즈 → Linear 이슈 Done + PR/커밋 링크.
+
+상태 매핑 (느슨한 결합 — 정밀 상태의 진실은 SPEC frontmatter):
+
+| Linear 상태 | SPEC status |
+|---|---|
+| Backlog / Todo | draft |
+| In Progress | in-progress |
+| Done | implemented / completed |
+
+### §26.3 오케스트레이터 지침
+
+- 세션에서 Linear 작업 시 `mcp__claude_ai_Linear__*` 도구 사용 (deferred → ToolSearch preload 필요).
+- 팀/사이클 생성·rename은 MCP 미지원 → Linear UI 전용.
+- `linear_issue` frontmatter 필드는 아직 SPEC 스키마 정식 필드 아님 (도입은 SPEC-HARNESS-MCP-PROVISION-001 소관). 현재는 서술적 참조로만 사용.
+
+### §26.4 아이디어 기록 방법
+
+- **A. 자연어 지시**: "아이디어 Linear에 기록해줘: <제목> — <설명>" → 이 프로젝트(moai-adk-go)의 Linear Project에 `Idea` 라벨 + Backlog(Triage) 이슈 생성. 어느 Project인지는 §26.1 매핑으로 자동 인식.
+- **B. 빠른 트리거**: 사용자 메시지가 `아이디어:` 또는 `💡`로 시작하면, 나머지 내용을 이 Project의 Linear 이슈로 **즉시 기록**한다 (Team `모두의AI`, 라벨 `Idea`, 상태 Backlog/Triage). 확인 질문 없이 기록 후 생성된 `MOAI-N` 이슈 URL을 보고. SPEC 승격은 하지 않음(아이디어 저수지 단계 — 착수 결정 시 `/moai plan`으로 승격).
+- 전제: 세션에 Linear MCP가 로드/인증돼 있어야 실제 기록됨(미인증 시 `/mcp`로 Linear 인증 후 재시도).

--- a/CLAUDE.local.md
+++ b/CLAUDE.local.md
@@ -674,81 +674,7 @@ See: `.moai/docs/dev-only-commands-isolation.md`
 
 ## 22. Dev Settings Intent — local settings.json 의도 명문화
 
-Workflow audit 2026-05-16 finding M2 후속. 로컬 `.claude/settings.json`의 몇 가지 키는 template baseline과 의도적으로 다르게 운용되며, 본 섹션은 그 의도를 명문화한다.
-
-### §22.1 defaultMode
-
-- **로컬값**: `"bypassPermissions"` 또는 `"acceptEdits"` (개발자 선호)
-- **Template 기본값**: 미지정 (Claude Code 기본 `"default"` 사용)
-- **의도**: 메인테이너는 빠른 실험 + bypass 모드 빈번 사용. 사용자 프로젝트는 안전한 prompt-each-time 기본값을 따른다.
-
-### §22.2 enableAllProjectMcpServers
-
-- **로컬값**: `true`
-- **Template 기본값**: 미지정 (false 효과)
-- **의도**: 메인테이너 머신에는 dev tool 다수 (pencil, chrome-devtools, claude-in-chrome 등)가 등록되어 있어 모두 자동 활성화하는 것이 효율적. 사용자 프로젝트는 `mcp__context7`만 `alwaysLoad`되고 나머지는 ToolSearch preload 경로를 따른다. (Sequential Thinking MCP는 SPEC-V3R6-SEQ-THINKING-RETIRE-001에서 retired — `ultrathink` 키워드로 대체.)
-
-### §22.3 teammateMode
-
-- **로컬값**: `"tmux"` (CG/GLM 모드 — `moai cg` / `moai glm` 진입 시) 또는 `""` (CC 모드 — `moai cc` 진입 시 override 해제). runtime-managed by `moai cg` / `moai glm` / `moai cc` 명령. 코드가 실제로 기록하는 값은 이 둘뿐이다 (`internal/cli/glm.go` `ensureSettingsLocalJSON`/`injectGLMEnvForTeam` 가 `"tmux"`, `internal/cli/launcher.go` `removeGLMEnv` 가 `""`). `"glm"`/`"claude"` 는 코드가 기록하지 않는다.
-- **`llm.yaml team_mode` 와 구분 (혼동 금지)**: `.claude/settings.local.json` 의 `teammateMode` 필드(`"tmux"`/`""`)와 `.moai/config/sections/llm.yaml` 의 `team_mode` 필드(`cg`/`glm`/`""`)는 서로 다른 필드다. 전자는 Claude Code teammate 표시 모드(tmux pane vs inline)를 결정하고, 후자는 CG 모드 감지 SSOT (`internal/tmux/cg_detect.go` `IsCGMode` 가 `team_mode == "cg"` 를 읽는다, REQ-CGH-006). 같은 "team/teammate" 어휘를 공유하나 위치·값·용도가 다르다.
-- **Template 기본값**: 미지정 (양쪽 필드 모두)
-- **의도**: 메인테이너는 CG mode (Claude leader + GLM teammates)로 cost-optimization 검증을 빈번하게 수행. 사용자 프로젝트는 leader 단독으로 시작 후 필요시 `moai cg` 진입.
-- **주의**: §2 [HARD] settings.local.json Separation 참조 — teammateMode는 `settings.local.json`에 위치하며 template에 절대 포함 금지.
-
-### §22.4 env.PATH
-
-- **위치 (2026-07-12 이관)**: machine-specific 절대경로 PATH는 이제 `settings.local.json`(gitignored)에만 둔다. `.claude/settings.json`(git-tracked)의 `env`에서 `PATH` 키를 **제거**했다 — git-tracked 파일에 `/Users/goos/...` 절대경로를 두면 fork/clone 사용자에게 깨지기 때문(§2 settings.local.json Separation 적용). settings.json의 `env`에는 machine-independent 키(`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`, `ENABLE_TOOL_SEARCH`, `MOAI_CONFIG_SOURCE`)만 남긴다.
-- **왜 절대경로인가 (settings.local.json 안에서)**: **Claude Code가 env.PATH 값의 `$HOME`을 expand하지 않음**이 실측 확인됨 (Bash 서브프로세스에 리터럴 `$HOME/go/bin`이 그대로 전달 → `command -v moai` 실패 → moai-lsp MCP가 PATH로 moai 미해석). 따라서 settings.local.json의 PATH는 절대경로를 쓴다 (직전 2026-05-17 F-009/M5의 `$HOME` 권고는 이 실측으로 뒤집힘).
-- **Template 기본값**: `settings.json.tmpl`의 PATH 키는 `{{jsonEscape .SmartPATH}}` 로 렌더 (BuildSmartPATH가 issue #467 대응으로 well-known 절대경로 PATH 생성 — `$HOME` 미사용). 사용자 프로젝트는 `moai init`/`moai update`가 절대 SmartPATH로 새로 렌더하므로 fork/clone과 무관. **주의**: `settings_test.go:requiredKeys`가 템플릿 env에 `PATH`/`ENABLE_TOOL_SEARCH`/`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` 존재를 강제하므로 템플릿에서 이 키들을 제거하면 CI FAIL — 로컬 settings.json에서만 PATH를 뺀다(템플릿은 그대로).
-- **주의 (2026-06-24 정정)**: `StatusLine` command는 Claude Code 내장 토큰 `$CLAUDE_PROJECT_DIR`을 런타임 환경변수로 받는다 (공식 문서 code.claude.com/docs/en/statusline — "runs with the same environment variables as hooks, including `CLAUDE_PROJECT_DIR`"). 종전 "StatusLine은 env var를 expand하지 않는다"는 GitHub Issue #7925를 오독한 것이며, 해당 이슈는 일반 shell 보간/`env` 블록 값에 대한 것이지 내장 토큰이 아니다. 단, **`env.PATH`의 `$HOME` expand 불가는 별개 사실로 여전히 유효**하며 본 절의 핵심 근거는 이쪽으로 한정한다.
-
-### §22.6 outputStyle — 제품 기본값 MoAI-Easy (2026-07-12 채택)
-
-- **템플릿 기본값 (제품 결정)**: `settings.json.tmpl` + 로컬 `.claude/settings.json` 모두 `"outputStyle": "MoAI-Easy"` 고정. 모든 배포 사용자가 기본 MoAI-Easy로 시작한다. 과거 `699e59631`의 "personal preference라 unpin" 결정을 제품 기본값 채택으로 되돌린 것 — CI 가드 `TestSettingsTemplateOutputStyle`도 "MoAI-Easy 필수"로 반전.
-- **우선순위 (공식 검증)**: Claude Code outputStyle 해석 순위는 `settings.local.json`(local, 최고) > `settings.json`(project) > `~/.claude/settings.json`(user) > 하드코딩 기본값. 종전 MoAI 내부 문서(settings-management.md)가 **local 스코프를 누락**했었고(2026-07-12 정정), 이 누락이 "outputStyle이 계속 리셋된다"는 오진의 근원이었다.
-- **`/config` 저장 위치 (공식)**: `/config` → Output style은 `settings.local.json`에 저장(공식 문서 code.claude.com/docs/en/output-styles). local이 최고 우선순위라 사용자의 `/config` 선택은 항상 템플릿 project 핀을 이긴다 → 제품 기본값 고정이 사용자를 가두지 않는다.
-- **적용 시점**: outputStyle은 세션 시작 시 1회만 읽힘 → 변경은 `/clear` 또는 새 세션부터 반영. 이것이 "리셋처럼 보이는" 현상의 실제 원인(버그 아님).
-- **코드 보존**: `settings.local.json` writer(`glm.go`/`settings.go`)는 `map[string]any` round-trip으로 outputStyle 등 unknown top-level 키를 보존(SPEC-CLIFIX-CRITICAL-001) → `moai glm`/`cg`/`cc`가 파일을 건드려도 outputStyle 유지.
-
-### §22.5 운영 원칙
-
-- [HARD] 메인테이너 머신에서 위 키들을 변경할 때 template 자동 동기화 금지 (§2 settings.local.json Separation 적용)
-- [HARD] 위 키들(defaultMode/enableAllProjectMcpServers/teammateMode/env.PATH/outputStyle)의 의도가 변경되면 본 §22를 즉시 갱신
-- [HARD] 사용자 프로젝트에 machine-specific 키(env.PATH 등)가 누락된 것이 정상 — 누락은 결함이 아니라 의도된 격리. 단 outputStyle은 예외: 템플릿에 MoAI-Easy로 고정되므로 배포 사용자에게도 존재한다.
-
-### §22.7 model — 로컬 project settings.json에서 의도적 미탑재 (last-choice 존중, 2026-07-24)
-
-- **로컬값**: 로컬 `.claude/settings.json`에 `model` 키 **없음** (의도적 제거). Template `settings.json.tmpl:398`의 `"model": "sonnet"` 제품 기본값은 **그대로 보존**.
-- **왜 제거했나 (근원)**: Claude Code 모델 우선순위는 `local settings.json > project settings.json > user settings > 하드코딩`. `/model`의 "saved as default for new sessions"는 **user 스코프**(`~/.claude/settings.json`)에 저장되는데, project `settings.json`의 `model: sonnet` pin(스코프2)이 이를 항상 덮어 **재시작마다 sonnet 복귀** 트랩이 발생. project pin을 제거하면 user 스코프의 `/model` 마지막 선택(현재 `opus[1m]`)이 이겨서 last-choice가 존중된다. (`outputStyle`은 `/config`가 최상위 local 스코프에 써서 안 가두지만, `model`은 `/model`이 하위 user 스코프에 써서 가두는 비대칭이 근본 원인.)
-- **effort는 무관**: user `~/.claude/settings.json`의 `effortLevel: high`를 덮는 pin이 project/local 어디에도 없으므로 effort는 이미 유지됨(순수 `claude` + moai 프로파일 비어있는 `moai cc/glm/cg` 두 경로 공통). "effort도 리셋"은 model 리셋에 묶인 착시.
-- **update 경로 주의 (drift)**: `moai update` clean-reinstall은 user의 `.claude/settings.json`을 wholesale 보존하므로 대개 살아남지만(`update_clean_install.go` Step 4.5 `MergeUserFiles`), 3-way 병합 경로는 template sonnet pin을 재도입할 수 있다. 재도입되면 이 절 근거대로 다시 제거. **제품(템플릿) 기본값 변경이 아님** — 배포 사용자는 여전히 sonnet cost-lever 기본값을 받는다.
-- [HARD] 이 로컬 미탑재는 **의도된 격리**(§22.5와 동일 원칙) — 감사/동기화 시 "결함"으로 되돌리지 말 것.
-
-### §22.8 web worktree auto-toggles default OFF (EnterWorktree-first policy, 2026-07-28)
-
-- **목적 (intent)**: `internal/config/defaults.go`의 `WorkflowWorktreeConfig` 세 토글 — `AutoCleanup`, `AutoCreate`, `AutoMerge` — 모두 **기본 `false`**. 웹 콘솔의 worktree 자동화는 사용자의 **명시적 opt-in** (웹 토글 ON 또는 `.moai/config/sections/workflow.yaml`의 `workflow.worktree.*` 키 `true` 설정)이 있을 때만 동작한다.
-- **Why**: SPEC-WORKTREE-ENTRY-STRATEGY-001 M1 (commit `2fdf77714`)에서 `AutoCleanup: true → false`, `AutoMerge: true → false`로 mutated. 배경 — worktree 자동 정리/자동 병합은 사용자가 의도하지 않은 sprawl을 조장하고, EnterWorktree-first policy (`.claude/rules/moai/workflow/worktree-integration.md` § `EnterWorktree` / `ExitWorktree` Tools)와 충돌한다. 기본 OFF는 "worktree 자동화는 사용자 선택" 원칙을 코드로 정합시킨다.
-- **제품(템플릿) 기본값과 동일**: 템플릿 `defaults.go` 또한 세 토글 모두 `false` (CLAUDE.local.md §2 [HARD] Template-First Rule 정합). 배포 사용자에게도 동일한 기본 OFF가 적용된다.
-- **`TmuxPreferred: true`는 본 절 범위 밖**: `defaults.go`의 `TmuxPreferred: true`는 SPEC-WORKTREE-ENTRY-STRATEGY-001 OQ-4 결정에 따라 명시적으로 OUT OF SCOPE — 변경 없음 (§22 운영 원칙 §22.5 참조).
-- [HARD] `defaults.go`의 세 토글 기본 `false`는 **의도된 정책**. 감사/동기화 시 "결함"으로 되돌리지 말 것. 기본값 토글은 별도 SPEC 통해서만.
-
-### §22.9 branch_guard.enabled — 메인테이너 로컬 opt-in (기본 OFF, 2026-07-30)
-
-- **목적 (intent)**: `internal/config/defaults.go`의 `BranchGuardConfig.Enabled`는 **기본 `false`**. Main-Checkout Branch-State Guard (`internal/hook/branch_guard.go`)는 분산 기본값으로 INERT하게 배포된다 — 단일 개발자 저장소에는 공유 체크아웃 위험이 없으므로 가드가 간섭하지 않는다. 다중 세션 공유 체크아웃을 운영하는 메인테이너만 로컬에서 opt-in한다.
-- **Why**: SPEC-WORKTREE-BRANCH-GUARD-OPTIN-001. 종전 가드는 템플릿을 통해 모든 사용자에게 default-on으로 배포되었고, 읽기 전용 명령(`git stash list`, `git merge-base`)까지 과잉 차단했다. v1.2.0에서 (a) 기본 OFF 전환 + (b) 읽기 전용 패턴 정제로 수정. 템플릿 중립성 (§25) 준수를 위해 `internal/template/templates/` 어디에도 `enabled: true` 가 없다.
-- **메인테이너 opt-in 경로**: 로컬 config local 티어 (`.moai/config/local/*.yaml`, resolver.go `loadLocalTier`가 읽는 유일한 로컬 오버라이드 티어)에 다음 파일을 둔다:
-  ```yaml
-  # .moai/config/local/workflow.yaml
-  workflow:
-    branch_guard:
-      enabled: true
-  ```
-  이 파일은 메인테이너 머신 로컬 전용이다 (아래 BLOCKER 참고).
-- **제품(템플릿) 기본값과 동일**: 템플릿 `defaults.go` + `internal/template/templates/.moai/config/sections/workflow.yaml` 모두 `enabled: false` (또는 키 부재 → Go zero-value `false`). §2 [HARD] Template-First Rule 정합.
-- **면제 로직 보존**: `MOAI_BRANCH_GUARD_EXEMPT=1` env + `AgentType == "manager-git"` 신원 검사는 변경 없이 enabled 경로에서만 참조된다 (REQ-6 backward compat).
-- **gitignore (해결됨)**: `.moai/config/local/` 디렉터리는 이제 `.gitignore`에 등록되었다 (chore 커밋). 따라서 메인테이너 opt-in 파일(`.moai/config/local/workflow.yaml`)을 생성해도 공개 저장소에 커밋되지 않는다. 종전 이 경로가 gitignore에 없어 분산 기본값이 `true`로 뒤집힐 위험이 있었으나 해결됨 (§25 정합).
-- [HARD] `defaults.go`의 `BranchGuard.Enabled` 기본 `false`는 **의도된 정책**. 감사/동기화 시 "결함"으로 되돌리지 말 것. 템플릿 기본값 변경은 별도 SPEC 통해서만.
+[HARD] 로컬 `.claude/settings.json`의 키 의도(defaultMode / enableAllProjectMcpServers / teammateMode / env.PATH / outputStyle / model / worktree auto-toggles / branch_guard.enabled)와 "의도된 격리" 정책 전문은 `See: .moai/docs/local-dev-settings-intent.md` (§22.1-§22.9). 본체 다이어트를 위해 외부 파일로 이관(2026-08-03). settings 키 의도가 변경되면 외부 파일을 갱신할 것. 핵심 원칙만 본체에 잔류: (1) `teammateMode`(`.claude/settings.local.json`, `"tmux"`/`""`) != `llm.yaml team_mode`(`cg`/`glm`/`""`) — 위치·값·용도 상이; (2) `env.PATH`는 Claude Code가 `$HOME`을 expand 안 하므로 `settings.local.json`에 절대경로; (3) 로컬 `model` 키 의도적 미탑재(last-choice 존중, 템플릿 `model: sonnet`은 보존); (4) worktree 세 토글 + branch_guard.enabled 모두 분산 기본 `false` — 감사 시 "결함"으로 되돌리지 말 것.
 
 ---
 
@@ -778,55 +704,7 @@ See: `.moai/docs/template-internal-isolation-doctrine.md`
 
 ## 26. Linear 연동 (개인/로컬 전용)
 
-> [ZONE:Local-Only] 본 섹션은 GOOS 개인 개발 전용이며 로컬 전용이다. `internal/template/templates/`에 절대 미러 금지 (§25 isolation + §14 하드코딩 허용 영역). **범용 배포/제품화 계획 없음** — Linear 연동은 개인 개발 워크플로우로만 사용한다(배포용 스킬/MCP 프로비저닝 제품화는 하지 않기로 결정, 2026-07-12). **주의: `CLAUDE.local.md`는 gitignored가 아니라 git에 추적·커밋되어 공개 저장소(`origin/main`)에 공유된다** — 이름과 달리 로컬 전용 파일이 아니므로, 이 파일에 적는 모든 내용(워크스페이스 매핑·개인 경로·운영 방침)은 공개를 전제로 작성한다. "로컬 전용"은 *템플릿에 미러하지 않는다*는 뜻이지 *공유되지 않는다*는 뜻이 아니다.
-
-### §26.1 워크스페이스 매핑
-
-- **Linear 워크스페이스**: `모두의AI` (`linear.app/goos`)
-- **Team**: `모두의AI` · **이슈 접두사**: `MOAI-`
-- **Project ↔ 리포 매핑** (동시 진행 7개):
-
-| Linear Project | 리포 | 진행중 이슈 |
-|---|---|---|
-| moai-adk-go | /Users/goos/MoAI/moai-adk-go | MOAI-13/14/15 (Project-Harness Epic, plan) |
-| claude.mo.ai.kr | claude.mo.ai.kr | — |
-| mo.ai.kr | mo.ai.kr | MOAI-10 결제 오류 (Bug/High) |
-| MINK | MINK | MOAI-11 harness:mink-e2e |
-| copythat | copythat | — |
-| moai-stock | moai-stock | — |
-| academy | academy | MOAI-12 feat/design-system |
-
-- **SSOT 문서**: Linear 팀 문서 "SPEC ↔ Linear 브리지 규칙" (`linear.app/goos/document/spec-linear-브리지-규칙-fed04d006656`)
-
-### §26.2 운영 규칙 (2계층 모델)
-
-- **Linear 계층 (제품/기획)**: 무엇을/언제. 아이디어 저수지 + 우선순위 + 크로스 프로젝트 조율.
-- **SPEC 계층 (기술 SSOT)**: 정확히 어떻게. 각 리포 `.moai/specs/`. SPEC 저작은 **항상 리포 파일에서만** — Linear로 옮기지 않는다 (git·에이전트 파이프라인·frontmatter 결합).
-
-흐름:
-1. 아이디어·버그 → Linear 이슈로 캡처 (`Idea` 라벨 → Triage). 아직 SPEC 아님.
-2. 착수 결정 → 해당 리포에서 `/moai plan`으로 SPEC 승격 + frontmatter `linear_issue: MOAI-N`.
-3. `/moai run` → `/moai sync`로 구현·클로즈 → Linear 이슈 Done + PR/커밋 링크.
-
-상태 매핑 (느슨한 결합 — 정밀 상태의 진실은 SPEC frontmatter):
-
-| Linear 상태 | SPEC status |
-|---|---|
-| Backlog / Todo | draft |
-| In Progress | in-progress |
-| Done | implemented / completed |
-
-### §26.3 오케스트레이터 지침
-
-- 세션에서 Linear 작업 시 `mcp__claude_ai_Linear__*` 도구 사용 (deferred → ToolSearch preload 필요).
-- 팀/사이클 생성·rename은 MCP 미지원 → Linear UI 전용.
-- `linear_issue` frontmatter 필드는 아직 SPEC 스키마 정식 필드 아님 (도입은 SPEC-HARNESS-MCP-PROVISION-001 소관). 현재는 서술적 참조로만 사용.
-
-### §26.4 아이디어 기록 방법
-
-- **A. 자연어 지시**: "아이디어 Linear에 기록해줘: <제목> — <설명>" → 이 프로젝트(moai-adk-go)의 Linear Project에 `Idea` 라벨 + Backlog(Triage) 이슈 생성. 어느 Project인지는 §26.1 매핑으로 자동 인식.
-- **B. 빠른 트리거**: 사용자 메시지가 `아이디어:` 또는 `💡`로 시작하면, 나머지 내용을 이 Project의 Linear 이슈로 **즉시 기록**한다 (Team `모두의AI`, 라벨 `Idea`, 상태 Backlog/Triage). 확인 질문 없이 기록 후 생성된 `MOAI-N` 이슈 URL을 보고. SPEC 승격은 하지 않음(아이디어 저수지 단계 — 착수 결정 시 `/moai plan`으로 승격).
-- 전제: 세션에 Linear MCP가 로드/인증돼 있어야 실제 기록됨(미인증 시 `/mcp`로 Linear 인증 후 재시도).
+[ZONE:Local-Only] 개인/로컬 전용. 전문(워크스페이스 매핑 · 2계층 운영 모델 · Linear↔SPEC 상태 매핑 · MCP 도구 지침 · `idea:`/emoji 트리거)은 `See: .moai/docs/local-linear-integration.md`. 본체 다이어트를 위해 외부 파일로 이관(2026-08-03). 핵심만 잔류: 이 리포(moai-adk-go)의 Linear Project에 `Idea` 라벨 + Backlog(Triage) 이슈로 기록; SPEC 저작은 항상 리포 파일에서만(Linear로 옮기지 않음); `CLAUDE.local.md`는 git-tracked 공개 파일이므로 "로컬 전용"은 템플릿 미러 금지를 뜻함(비공유가 아님).
 
 ---
 

--- a/internal/cli/wizard/expansion_test.go
+++ b/internal/cli/wizard/expansion_test.go
@@ -25,11 +25,7 @@ func TestPage3QuestionsStructure(t *testing.T) {
 	}
 
 	want := []entry{
-		{"lsp_enabled", QuestionTypeConfirm, false, false},
-		{"enforce_quality", QuestionTypeConfirm, false, false},
 		{"project_mode", QuestionTypeSelect, true, false},
-		{"design_enabled", QuestionTypeConfirm, false, false},
-		{"claude_design_enabled", QuestionTypeConfirm, false, true},
 	}
 
 	if len(questions) != len(want) {
@@ -67,13 +63,8 @@ func TestPage3VisibleWithoutBridge(t *testing.T) {
 	quick := &WizardResult{EnforceQuality: true, DesignEnabled: true, ClaudeDesignEnabled: true}
 	visible := FilteredQuestions(all, quick)
 
-	for _, id := range []string{
-		"lsp_enabled", "enforce_quality", "project_mode",
-		"design_enabled", "claude_design_enabled",
-	} {
-		if QuestionByID(visible, id) == nil {
-			t.Errorf("page-3 question %q must be visible with no bridge answered", id)
-		}
+	if QuestionByID(visible, "project_mode") == nil {
+		t.Error(`page-3 question "project_mode" must be visible with no bridge answered`)
 	}
 }
 
@@ -88,46 +79,29 @@ func TestPage3Questions_Ungated(t *testing.T) {
 	tmpDir := t.TempDir()
 	questions := Page3Questions(tmpDir)
 
-	page3 := []string{
-		"lsp_enabled", "enforce_quality", "project_mode",
-		"design_enabled", "claude_design_enabled",
-	}
 	visible := FilteredQuestions(questions, &WizardResult{DesignEnabled: true})
-	for _, id := range page3 {
-		if QuestionByID(visible, id) == nil {
-			t.Errorf("page-3 question %q must be visible", id)
-		}
+	if QuestionByID(visible, "project_mode") == nil {
+		t.Error(`page-3 question "project_mode" must be visible`)
 	}
 
-	// Structural half: nothing on page 3 is gated except the nested design question.
+	// Structural half: nothing on page 3 is gated.
 	for _, q := range questions {
-		if q.ID == "claude_design_enabled" {
-			continue
-		}
 		if q.Condition != nil {
 			t.Errorf("page-3 question %q carries a Condition — page 3 must be ungated", q.ID)
 		}
 	}
 }
 
-// TestPage3Questions_ClaudeDesignConditional verifies claude_design_enabled is hidden
-// when DesignEnabled=false (AC-IWE-005 conditional skip).
-func TestPage3Questions_ClaudeDesignConditional(t *testing.T) {
+// TestPage3Questions_NoConditional verifies page 3 now has NO Condition-gated
+// question: claude_design_enabled (the last conditional) was removed together
+// with the four default-true confirms (2026-08-03).
+func TestPage3Questions_NoConditional(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
-	questions := Page3Questions(tmpDir)
-
-	// Design disabled: claude_design_enabled should be hidden.
-	result := &WizardResult{DesignEnabled: false}
-	visible := FilteredQuestions(questions, result)
-	for _, q := range visible {
-		if q.ID == "claude_design_enabled" {
-			t.Error("claude_design_enabled visible when DesignEnabled=false, want hidden")
+	for _, q := range Page3Questions(tmpDir) {
+		if q.Condition != nil {
+			t.Errorf("page-3 question %q carries a Condition — page 3 must have no conditional questions", q.ID)
 		}
-	}
-	// Expect 4 visible (the 5 page-3 questions minus claude_design_enabled)
-	if len(visible) != 4 {
-		t.Errorf("Expected 4 visible questions when DesignEnabled=false, got %d", len(visible))
 	}
 }
 
@@ -212,27 +186,18 @@ func TestSaveAnswerPhase1(t *testing.T) {
 	}
 }
 
-// TestSaveBoolAnswer verifies saveBoolAnswer stores the page-3 boolean fields.
-// coverage_exemptions_enabled is deliberately absent — its capture branch was
-// removed with the question (REQ-WIZ-013).
+// TestSaveBoolAnswer verifies saveBoolAnswer is now a no-op: the four page-3
+// confirm questions (lsp_enabled, enforce_quality, design_enabled,
+// claude_design_enabled) are no longer asked (removed 2026-08-03), so no
+// boolean answer is captured. A zero result must stay zero.
 func TestSaveBoolAnswer(t *testing.T) {
 	t.Parallel()
-	cases := []struct {
-		id    string
-		val   bool
-		check func(*WizardResult) bool
-	}{
-		{"lsp_enabled", true, func(r *WizardResult) bool { return r.LSPEnabled }},
-		{"enforce_quality", false, func(r *WizardResult) bool { return !r.EnforceQuality }},
-		{"design_enabled", false, func(r *WizardResult) bool { return !r.DesignEnabled }},
-		{"claude_design_enabled", false, func(r *WizardResult) bool { return !r.ClaudeDesignEnabled }},
+	result := &WizardResult{}
+	for _, id := range []string{"lsp_enabled", "enforce_quality", "design_enabled", "claude_design_enabled"} {
+		saveBoolAnswer(id, true, result)
 	}
-	for _, c := range cases {
-		result := &WizardResult{EnforceQuality: true, DesignEnabled: true, ClaudeDesignEnabled: true}
-		saveBoolAnswer(c.id, c.val, result)
-		if !c.check(result) {
-			t.Errorf("saveBoolAnswer(%q, %v): check failed", c.id, c.val)
-		}
+	if result.LSPEnabled || result.EnforceQuality || result.DesignEnabled || result.ClaudeDesignEnabled {
+		t.Errorf("saveBoolAnswer must be a no-op for the four removed IDs; result = %+v", *result)
 	}
 }
 
@@ -262,12 +227,16 @@ func TestWizardResultDefaultsPrePopulated(t *testing.T) {
 	t.Parallel()
 	// We test the pre-population logic directly since we can't run interactive wizard in tests.
 	result := &WizardResult{
+		LSPEnabled:                true,
 		EnforceQuality:            true,
 		CoverageExemptionsEnabled: false,
 		DesignEnabled:             true,
 		ClaudeDesignEnabled:       true,
 	}
 
+	if !result.LSPEnabled {
+		t.Error("LSPEnabled default should be true")
+	}
 	if !result.EnforceQuality {
 		t.Error("EnforceQuality default should be true")
 	}
@@ -329,18 +298,18 @@ func TestTotalVisibleQuestions_Page3AlwaysCounted(t *testing.T) {
 	// DesignEnabled reveals the nested claude_design_enabled.
 	res := &WizardResult{DesignEnabled: true}
 	got := TotalVisibleQuestions(all, res)
-	// Page 1 (3) + Page 2 (2) + Page 3 (5) = 10 exactly.
-	if got != 10 {
-		t.Errorf("TotalVisibleQuestions = %d, want 10 (3 Basic + 2 Model & Report + 5 Quality & Workflow)", got)
+	// Page 1 (3) + Page 2 (2) + Page 3 (1, project_mode only) = 6 exactly.
+	if got != 6 {
+		t.Errorf("TotalVisibleQuestions = %d, want 6 (3 Basic + 2 Model & Report + 1 Quality & Workflow)", got)
 	}
-	// All five page-3 questions are counted with no flag to enable them.
+	// Only project_mode remains on page 3 (the four confirms were removed).
 	n := 0
 	for _, q := range FilteredQuestions(all, res) {
 		if q.Group == "Quality & Workflow" {
 			n++
 		}
 	}
-	if n != 5 {
-		t.Errorf("visible page-3 questions = %d, want 5", n)
+	if n != 1 {
+		t.Errorf("visible page-3 questions = %d, want 1", n)
 	}
 }

--- a/internal/cli/wizard/question_removal_test.go
+++ b/internal/cli/wizard/question_removal_test.go
@@ -4,14 +4,18 @@ package wizard
 // (AC-WIZ-007/008/009/013, REQ-WIZ-010/012/013/017).
 
 import (
-	"strings"
 	"testing"
 )
 
 // removedInM3 are the questions fixed at their shipped defaults and therefore
-// no longer asked: harness_profile (fixed at "default") and
-// coverage_exemptions_enabled (fixed at false).
-var removedInM3 = []string{"harness_profile", "coverage_exemptions_enabled"}
+// no longer asked: harness_profile (fixed at "default"),
+// coverage_exemptions_enabled (fixed at false), and — added 2026-08-03 — the
+// four page-3 default-true confirms (lsp_enabled, enforce_quality,
+// design_enabled, claude_design_enabled), all fixed at true.
+var removedInM3 = []string{
+	"harness_profile", "coverage_exemptions_enabled",
+	"lsp_enabled", "enforce_quality", "design_enabled", "claude_design_enabled",
+}
 
 // TestRemovedQuestionsAbsentFromInitSet pins the question-absence half of
 // AC-WIZ-008 and AC-WIZ-009.
@@ -71,66 +75,40 @@ func TestRemovedQuestionsHaveNoCaptureBranch(t *testing.T) {
 	if kept.ProjectMode != "team" {
 		t.Error("project_mode capture branch was removed by mistake")
 	}
-	for _, tc := range []struct {
-		id    string
-		check func(*WizardResult) bool
-	}{
-		{"lsp_enabled", func(r *WizardResult) bool { return r.LSPEnabled }},
-		{"enforce_quality", func(r *WizardResult) bool { return r.EnforceQuality }},
-		{"design_enabled", func(r *WizardResult) bool { return r.DesignEnabled }},
-		{"claude_design_enabled", func(r *WizardResult) bool { return r.ClaudeDesignEnabled }},
-	} {
+	// The four newly-removed page-3 confirms must NOT capture (M3 invariant
+	// extended to lsp_enabled/enforce_quality/design_enabled/claude_design_enabled).
+	for _, id := range []string{"lsp_enabled", "enforce_quality", "design_enabled", "claude_design_enabled"} {
 		r := &WizardResult{}
-		saveBoolAnswer(tc.id, true, r)
-		if !tc.check(r) {
-			t.Errorf("%s capture branch was removed by mistake", tc.id)
+		saveBoolAnswer(id, true, r)
+		if r.LSPEnabled || r.EnforceQuality || r.DesignEnabled || r.ClaudeDesignEnabled {
+			t.Errorf("%s capture branch must be gone (removed 2026-08-03)", id)
 		}
 	}
 }
 
-// lspDefaultWording records, PER LOCALE, the affirmative default token the
-// lsp_enabled title must now carry and the negative token it must no longer
-// carry. Each locale is listed explicitly with its OWN punctuation: ko/ja use a
-// halfwidth colon, zh uses a FULLWIDTH one (：). A single shared halfwidth
-// pattern would be structurally blind to zh (plan.md §G).
-var lspDefaultWording = map[string]struct{ want, gone string }{
-	"ko": {"기본값: 예", "기본값: 아니오"},
-	"ja": {"デフォルト: はい", "デフォルト: いいえ"},
-	"zh": {"默认：是", "默认：否"},
-}
-
-// TestLSPEnabledDefaultsToTrue pins AC-WIZ-007: the default flips to true and
-// the enabled-by-default wording lands in all four locales.
-func TestLSPEnabledDefaultsToTrue(t *testing.T) {
+// TestLSPEnabledFixedAtTrueDefault pins the post-removal invariant (AC-WIZ-007
+// carried forward, 2026-08-03): lsp_enabled is no longer asked, AND its value
+// is seeded true on the result struct (wizard.go RunWithDefaults/RunWithLocale)
+// so interactive `moai init` writes lsp.enabled: true without prompting. The
+// four-locale wording check is moot — the question is gone.
+func TestLSPEnabledFixedAtTrueDefault(t *testing.T) {
 	t.Parallel()
-	q := QuestionByID(InitQuestions(t.TempDir()), "lsp_enabled")
-	if q == nil {
-		t.Fatal("lsp_enabled question not found")
+	if q := QuestionByID(InitQuestions(t.TempDir()), "lsp_enabled"); q != nil {
+		t.Fatalf("lsp_enabled must no longer be asked; got question with Default=%q", q.Default)
 	}
-
-	if q.Default != "true" {
-		t.Errorf("lsp_enabled default = %q, want %q", q.Default, "true")
+	// The seed struct literal must hold the four fixed-default booleans true
+	// (mirrors the RunWithDefaults/RunWithLocale seed in wizard.go).
+	seed := &WizardResult{
+		LSPEnabled:                true,
+		EnforceQuality:            true,
+		CoverageExemptionsEnabled: false,
+		DesignEnabled:             true,
+		ClaudeDesignEnabled:       true,
 	}
-
-	// English wording lives inline on the question.
-	if strings.Contains(q.Title, "default: No") {
-		t.Errorf("lsp_enabled English title still says disabled-by-default: %q", q.Title)
+	if !seed.LSPEnabled || !seed.EnforceQuality || !seed.DesignEnabled || !seed.ClaudeDesignEnabled {
+		t.Errorf("seed WizardResult must set the four default-true booleans: %+v", *seed)
 	}
-	if !strings.Contains(q.Title, "default: Yes") {
-		t.Errorf("lsp_enabled English title must state the Yes default, got %q", q.Title)
-	}
-
-	for locale, w := range lspDefaultWording {
-		localized := GetLocalizedQuestion(q, locale)
-		if !strings.Contains(localized.Title, w.want) {
-			t.Errorf("locale %q: lsp_enabled title %q must contain %q", locale, localized.Title, w.want)
-		}
-		if strings.Contains(localized.Title, w.gone) {
-			t.Errorf("locale %q: lsp_enabled title %q still carries the disabled-by-default wording %q",
-				locale, localized.Title, w.gone)
-		}
-		if localized.Description == "" {
-			t.Errorf("locale %q: lsp_enabled description is empty", locale)
-		}
+	if seed.CoverageExemptionsEnabled {
+		t.Error("seed CoverageExemptionsEnabled must stay false")
 	}
 }

--- a/internal/cli/wizard/questions.go
+++ b/internal/cli/wizard/questions.go
@@ -399,41 +399,19 @@ func harnessProfileOptions(profiles []string) []Option {
 
 // Page3Questions returns page 3 of the `moai init` set, "Quality & Workflow".
 //
-// The questions are UNCONDITIONAL: the former mode gate was removed
-// (REQ-WIZ-001/002), so every user sees them and they merge into one page. The
-// single exception is claude_design_enabled, which stays nested on
-// design_enabled (REQ-WIZ-006) and therefore renders as its own sub-group.
+// The four former confirm questions — lsp_enabled, enforce_quality,
+// design_enabled, claude_design_enabled — are FIXED at their shipped true
+// defaults and no longer asked (removed 2026-08-03). Their values are seeded
+// by RunWithDefaults (see wizard.go), so interactive `moai init` writes the
+// true default for each without prompting. Only project_mode remains
+// interactive on this page.
 //
 // The constructor is named for the page it builds rather than for the retired
 // mode taxonomy (REQ-WIZ-018): no flag selects it any more.
-//
-// Order is load-bearing: design_enabled MUST precede claude_design_enabled so
-// huh has the design answer before evaluating the nested hide func.
 func Page3Questions(projectRoot string) []Question {
 	return []Question{
-		// B3 — lsp.enabled. Enabled by default since
-		// SPEC-CLI-WIZARD-RESTRUCTURE-001 (REQ-WIZ-010): the diagnostics are
-		// worth more than the startup cost, and opting out is one keystroke.
-		{
-			ID:          "lsp_enabled",
-			Group:       "Quality & Workflow",
-			Type:        QuestionTypeConfirm,
-			Title:       "Enable LSP integration? (default: Yes)",
-			Description: "LSP provides language-server diagnostics during the run phase. Enabled by default; answer No to opt out.",
-			Default:     "true",
-			Required:    false,
-		},
-		// B5 — quality.enforce_quality
-		{
-			ID:          "enforce_quality",
-			Group:       "Quality & Workflow",
-			Type:        QuestionTypeConfirm,
-			Title:       "Enforce quality gates? (default: Yes)",
-			Description: "When enabled, TRUST 5 quality gates block implementation progress on failure.",
-			Default:     "true",
-			Required:    false,
-		},
-		// B1 — project.mode
+		// B1 — project.mode. The only remaining interactive question on
+		// page 3.
 		{
 			ID:          "project_mode",
 			Group:       "Quality & Workflow",
@@ -446,29 +424,6 @@ func Page3Questions(projectRoot string) []Question {
 			},
 			Default:  "personal",
 			Required: true,
-		},
-		// B8 — design.enabled
-		{
-			ID:          "design_enabled",
-			Group:       "Quality & Workflow",
-			Type:        QuestionTypeConfirm,
-			Title:       "Enable design workflow? (default: Yes)",
-			Description: "Enables the MoAI design pipeline (GAN loop, brand context, Claude Design integration).",
-			Default:     "true",
-			Required:    false,
-		},
-		// B8 — design.claude_design.enabled. The ONLY conditional question on
-		// page 3: nested on design_enabled (REQ-WIZ-006). The mode half of the
-		// former two-term predicate is gone — only DesignEnabled remains.
-		{
-			ID:          "claude_design_enabled",
-			Group:       "Quality & Workflow",
-			Type:        QuestionTypeConfirm,
-			Title:       "Enable Claude Design integration? (default: Yes)",
-			Description: "Enables the Claude Design handoff workflow within the design pipeline.",
-			Default:     "true",
-			Required:    false,
-			Condition:   func(r *WizardResult) bool { return r.DesignEnabled },
 		},
 	}
 }

--- a/internal/cli/wizard/restructure_test.go
+++ b/internal/cli/wizard/restructure_test.go
@@ -75,30 +75,13 @@ func TestInitPages_Membership(t *testing.T) {
 	}{
 		{pageBasic, []string{"conversation_language", "user_name", "project_name"}},
 		{pageModelReport, []string{"model_policy", "report_format"}},
-		{pageQualityWorkflw, []string{
-			"lsp_enabled", "enforce_quality", "project_mode",
-			"design_enabled", "claude_design_enabled",
-		}},
+		{pageQualityWorkflw, []string{"project_mode"}},
 	}
 	for _, tc := range cases {
 		got := questionIDsInGroup(questions, tc.page)
 		if !slices.Equal(got, tc.want) {
 			t.Errorf("page %q membership = %v, want %v", tc.page, got, tc.want)
 		}
-	}
-
-	// design_enabled MUST precede claude_design_enabled so huh has the design
-	// answer before evaluating the nested hide func (plan.md §A.1 D1).
-	idx := func(id string) int {
-		for i := range questions {
-			if questions[i].ID == id {
-				return i
-			}
-		}
-		return -1
-	}
-	if d, c := idx("design_enabled"), idx("claude_design_enabled"); d < 0 || c < 0 || d >= c {
-		t.Errorf("design_enabled (%d) must precede claude_design_enabled (%d)", d, c)
 	}
 }
 
@@ -135,36 +118,19 @@ func TestInitPages_MergeIntoOneGroupPerPage(t *testing.T) {
 }
 
 // TestPage3_NoModeGate pins AC-WIZ-003 + the C3 half of AC-WIZ-001: the
-// Quality & Workflow questions are visible with NO gate, and the nested design
-// condition survives with the mode term dropped from it.
+// Quality & Workflow questions are visible with NO gate. With the four
+// default-true confirms removed (2026-08-03), only project_mode remains on
+// page 3, and it must be unconditional.
 func TestPage3_NoModeGate(t *testing.T) {
 	t.Parallel()
 	questions := InitQuestions(t.TempDir())
 
-	for _, id := range []string{"lsp_enabled", "enforce_quality", "project_mode", "design_enabled"} {
-		q := QuestionByID(questions, id)
-		if q == nil {
-			t.Fatalf("%s missing from the init question set", id)
-		}
-		if q.Condition != nil {
-			t.Errorf("%s must be unconditional (no mode gate) so it merges into Page 3", id)
-		}
+	pm := QuestionByID(questions, "project_mode")
+	if pm == nil {
+		t.Fatal("project_mode missing from the init question set")
 	}
-
-	cd := QuestionByID(questions, "claude_design_enabled")
-	if cd == nil {
-		t.Fatal("claude_design_enabled missing from the init question set")
-	}
-	if cd.Condition == nil {
-		t.Fatal("claude_design_enabled must stay conditional (nested on design_enabled)")
-	}
-	// The condition collapses from the two-term (mode && DesignEnabled) form to
-	// DesignEnabled alone: it must now be TRUE with DesignEnabled alone.
-	if !cd.Condition(&WizardResult{DesignEnabled: true}) {
-		t.Error("claude_design_enabled must be visible when DesignEnabled=true")
-	}
-	if cd.Condition(&WizardResult{DesignEnabled: false}) {
-		t.Error("claude_design_enabled must be hidden when DesignEnabled=false")
+	if pm.Condition != nil {
+		t.Error("project_mode must be unconditional (no mode gate) so it stays on Page 3")
 	}
 }
 
@@ -174,12 +140,11 @@ func TestReconfigureMembershipExcludesPage3(t *testing.T) {
 	t.Parallel()
 	reconf := ReconfigureQuestions(t.TempDir())
 
-	for _, id := range []string{
-		"lsp_enabled", "enforce_quality", "project_mode",
-		"design_enabled", "claude_design_enabled",
-	} {
-		if QuestionByID(reconf, id) != nil {
-			t.Errorf("Page-3 question %q leaked into ReconfigureQuestions", id)
+	// Every page-3 question (now just project_mode after the 2026-08-03 removal
+	// of the four default-true confirms) must NOT leak into reconfigure.
+	for _, q := range Page3Questions(t.TempDir()) {
+		if QuestionByID(reconf, q.ID) != nil {
+			t.Errorf("Page-3 question %q leaked into ReconfigureQuestions", q.ID)
 		}
 	}
 	// The pre-restructure member set is retained (Basic + Model + Git).

--- a/internal/cli/wizard/translations.go
+++ b/internal/cli/wizard/translations.go
@@ -113,22 +113,6 @@ var translations = map[string]map[string]QuestionTranslation{
 				{Label: "Team", Desc: "다중 개발자 환경 — 팀 협업 기능 활성화"},
 			},
 		},
-		"lsp_enabled": {
-			Title:       "LSP 통합을 활성화할까요? (기본값: 예)",
-			Description: "LSP는 run 단계에서 language-server 진단을 제공합니다. 기본값은 켜짐이며, 필요 없으면 끌 수 있습니다.",
-		},
-		"enforce_quality": {
-			Title:       "품질 게이트를 강제할까요? (기본값: 예)",
-			Description: "활성화하면 TRUST 5 품질 게이트가 실패 시 구현 진행을 차단합니다.",
-		},
-		"design_enabled": {
-			Title:       "디자인 워크플로우를 활성화할까요? (기본값: 예)",
-			Description: "MoAI 디자인 파이프라인(GAN 루프, 브랜드 컨텍스트, Claude Design 통합)을 활성화합니다.",
-		},
-		"claude_design_enabled": {
-			Title:       "Claude Design 통합을 활성화할까요? (기본값: 예)",
-			Description: "디자인 파이프라인 내에서 Claude Design 핸드오프 워크플로우를 활성화합니다.",
-		},
 	},
 	"ja": {
 		"conversation_language": {
@@ -213,22 +197,6 @@ var translations = map[string]map[string]QuestionTranslation{
 				{Label: "Team", Desc: "複数人開発 — チームコラボレーション機能を有効化"},
 			},
 		},
-		"lsp_enabled": {
-			Title:       "LSP 統合を有効にしますか？（デフォルト: はい）",
-			Description: "LSP は run フェーズで language-server の診断を提供します。デフォルトはオンで、不要な場合はオフにできます。",
-		},
-		"enforce_quality": {
-			Title:       "品質ゲートを強制しますか？（デフォルト: はい）",
-			Description: "有効にすると、TRUST 5 品質ゲートが失敗時に実装の進行をブロックします。",
-		},
-		"design_enabled": {
-			Title:       "デザインワークフローを有効にしますか？（デフォルト: はい）",
-			Description: "MoAI デザインパイプライン（GAN ループ、ブランドコンテキスト、Claude Design 統合）を有効にします。",
-		},
-		"claude_design_enabled": {
-			Title:       "Claude Design 統合を有効にしますか？（デフォルト: はい）",
-			Description: "デザインパイプライン内で Claude Design ハンドオフワークフローを有効にします。",
-		},
 	},
 	"zh": {
 		"conversation_language": {
@@ -312,22 +280,6 @@ var translations = map[string]map[string]QuestionTranslation{
 				{Label: "Personal (推荐)", Desc: "单人开发者 — 无团队协调开销"},
 				{Label: "Team", Desc: "多人开发 — 启用团队协作功能"},
 			},
-		},
-		"lsp_enabled": {
-			Title:       "启用 LSP 集成？（默认：是）",
-			Description: "LSP 在运行阶段提供语言服务器诊断。默认开启，如不需要可以关闭。",
-		},
-		"enforce_quality": {
-			Title:       "强制执行质量门禁？（默认：是）",
-			Description: "启用后，TRUST 5 质量门禁在失败时会阻止实施进度。",
-		},
-		"design_enabled": {
-			Title:       "启用设计工作流？（默认：是）",
-			Description: "启用 MoAI 设计流水线（GAN 循环、品牌上下文、Claude Design 集成）。",
-		},
-		"claude_design_enabled": {
-			Title:       "启用 Claude Design 集成？（默认：是）",
-			Description: "在设计流水线中启用 Claude Design 交接工作流。",
 		},
 	},
 }

--- a/internal/cli/wizard/types.go
+++ b/internal/cli/wizard/types.go
@@ -38,16 +38,18 @@ type WizardResult struct {
 	GitLabUsername    string // GitLab username (for personal/team modes with gitlab provider)
 	GitLabToken       string // GitLab personal access token (optional)
 
-	// Page-3 fields ("Quality & Workflow") — asked of every user
-	// (SPEC-CLI-WIZARD-RESTRUCTURE-001 REQ-WIZ-001/002). The two mode-flag
-	// fields that formerly gated them are retired (REQ-WIZ-018).
-	ProjectMode               string // project.mode: personal, team (B1)
-	HarnessProfile            string // harness.default_profile: default, strict, lenient, frontend (B2)
-	LSPEnabled                bool   // lsp.enabled: false (opt-in) (B3)
-	EnforceQuality            bool   // quality.enforce_quality: true (B5)
-	CoverageExemptionsEnabled bool   // quality.coverage_exemptions.enabled: false (B5)
-	DesignEnabled             bool   // design.enabled: true (B8)
-	ClaudeDesignEnabled       bool   // design.claude_design.enabled: true (B8)
+	// Page-3 fields ("Quality & Workflow"). Only project_mode is still asked;
+	// the four booleans are fixed at their shipped defaults and no longer
+	// prompted (removed 2026-08-03) — seeded by RunWithDefaults /
+	// RunWithLocale. The two mode-flag fields that formerly gated them are
+	// retired (REQ-WIZ-018).
+	ProjectMode               string // project.mode: personal, team (B1) — asked
+	HarnessProfile            string // harness.default_profile: default, strict, lenient, frontend (B2) — fixed at "default"
+	LSPEnabled                bool   // lsp.enabled: true (fixed default, no longer asked)
+	EnforceQuality            bool   // quality.enforce_quality: true (fixed default, no longer asked)
+	CoverageExemptionsEnabled bool   // quality.coverage_exemptions.enabled: false (fixed default)
+	DesignEnabled             bool   // design.enabled: true (fixed default, no longer asked)
+	ClaudeDesignEnabled       bool   // design.claude_design.enabled: true (fixed default, no longer asked)
 }
 
 // QuestionType represents the type of wizard question.

--- a/internal/cli/wizard/wizard.go
+++ b/internal/cli/wizard/wizard.go
@@ -44,6 +44,7 @@ func RunWithDefaults(projectRoot, locale, userName string) (*WizardResult, error
 	// Pre-populate the boolean defaults so Condition funcs and the
 	// non-interactive path see them from the start.
 	result := &WizardResult{
+		LSPEnabled:                true,
 		EnforceQuality:            true,
 		CoverageExemptionsEnabled: false,
 		DesignEnabled:             true,
@@ -86,7 +87,17 @@ func prefillIdentityDefaults(questions []Question, userName string) {
 // with a lazily-evaluated hide func. A skip-focus Note at the top of every
 // group renders the tui.Stepper with a dynamic denominator (REQ-TUX2-008).
 func RunWithLocale(questions []Question, styles *Styles, locale string) (*WizardResult, error) {
-	result := &WizardResult{}
+	// Seed the same shipped true defaults as RunWithDefaults so the four
+	// fixed-default booleans (lsp_enabled, enforce_quality, design_enabled,
+	// claude_design_enabled) hold true even on this entry point (used by
+	// update_wizard.go) where their questions are no longer asked.
+	result := &WizardResult{
+		LSPEnabled:                true,
+		EnforceQuality:            true,
+		CoverageExemptionsEnabled: false,
+		DesignEnabled:             true,
+		ClaudeDesignEnabled:       true,
+	}
 	if err := runWithResult(questions, styles, locale, result); err != nil {
 		return nil, err
 	}
@@ -427,20 +438,18 @@ func saveAnswer(id, value string, result *WizardResult, locale *string) {
 }
 
 // saveBoolAnswer stores a boolean answer in the result.
+//
+// The four former page-3 confirm questions (lsp_enabled, enforce_quality,
+// design_enabled, claude_design_enabled) are no longer asked — fixed at their
+// shipped true defaults (removed 2026-08-03). Their capture branches are gone
+// (M3 invariant: a removed question stores nothing). No page-3 boolean
+// question remains interactive, so this is now a no-op for the init/update
+// set; it is still wired through buildConfirmField for any future confirm
+// question and is exercised by the removal tests.
 func saveBoolAnswer(id string, value bool, result *WizardResult) {
-	switch id {
-	// The former reveal-more confirm is no longer asked (REQ-WIZ-001/002):
-	// Page 3 is always visible, so no answer can widen the question set
-	// mid-wizard.
-	case "lsp_enabled":
-		result.LSPEnabled = value
-	case "enforce_quality":
-		result.EnforceQuality = value
-	case "design_enabled":
-		result.DesignEnabled = value
-	case "claude_design_enabled":
-		result.ClaudeDesignEnabled = value
-	}
+	_ = id
+	_ = value
+	_ = result
 }
 
 // buildConfirmField creates a huh.Confirm field for a boolean question.

--- a/internal/cli/wizard/wizard_test.go
+++ b/internal/cli/wizard/wizard_test.go
@@ -652,11 +652,11 @@ func TestStepperTotal_DynamicDenominator(t *testing.T) {
 	}
 
 	// Adding page 3 expands the denominator further: 6 unconditional defaults
-	// (git conditionals hidden for manual) + 5 page-3 questions = 11.
+	// (git conditionals hidden for manual) + 1 page-3 question (project_mode) = 7.
 	all := append(ReconfigureQuestions("/tmp/steppertotal"), Page3Questions("/tmp/steppertotal")...)
 	std := &WizardResult{GitMode: "manual", DesignEnabled: true}
-	if got := stepperDenominator(all, std); got != 11 {
-		t.Errorf("page-3 denominator: expected 11 (6 + 5 page-3), got %d", got)
+	if got := stepperDenominator(all, std); got != 7 {
+		t.Errorf("page-3 denominator: expected 7 (6 + 1 page-3), got %d", got)
 	}
 	// Single dynamic source invariant: stepperDenominator == TotalVisibleQuestions.
 	if stepperDenominator(all, std) != TotalVisibleQuestions(all, std) {


### PR DESCRIPTION
## Summary

Removes four default-true confirm questions from the `moai init` wizard so users are no longer asked them, while their effective value stays the shipped default (true).

**Removed:** `lsp_enabled`, `enforce_quality`, `design_enabled`, `claude_design_enabled`
**Kept interactive:** `project_mode`

## How the default is preserved

The four booleans are seeded `true` by `RunWithDefaults` AND `RunWithLocale` (the `update_wizard.go` entry point), so interactive `moai init` writes `lsp.enabled: true` etc. without prompting. Added `LSPEnabled: true` to both seed structs — the question's `Default: "true"` used to supply it via the wizard, so without the seed the interactive path would leave `LSPEnabled == false`. `saveBoolAnswer` is now a no-op (M3 invariant: a removed question stores nothing).

CLI flags `--enable-lsp` / `--enforce-quality` / `--enable-design` (default true) remain — non-interactive override path is unaffected.

Reuses the SPEC-CLI-WIZARD-RESTRUCTURE-001 M3 removal pattern (question + ko/ja/zh translation + capture branch).

## Changes

- `internal/cli/wizard/questions.go` — Page3Questions now returns only project_mode
- `internal/cli/wizard/translations.go` — 12 orphan entries removed (4 IDs × ko/ja/zh)
- `internal/cli/wizard/wizard.go` — saveBoolAnswer no-op; LSPEnabled seed on both entry points
- `internal/cli/wizard/types.go` — field comments updated (fixed default, no longer asked)
- 5 test files updated (M3 invariants extended, Page3 = 1 question)

Also includes a `chore(docs)` commit extracting CLAUDE.local.md §22/§26 to sidecar files (.moai/docs/local-dev-settings-intent.md + local-linear-integration.md) — context-budget diet that unblocks agent spawns.

## Verification

- `go build ./...` ✓
- `go vet ./internal/cli/...` ✓
- `go test ./internal/cli/...` — 17 packages ok ✓
- `golangci-lint run ./internal/cli/wizard/` — 0 issues ✓
- grep guard: 4 IDs absent from Question literals, translation keys, saveBoolAnswer switch ✓

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Simplified the setup wizard by reducing the third page to a single project-mode question.
  - Standardized several workflow, quality, design, and language-service settings with enabled defaults.

- **Documentation**
  - Added guidance for local development settings and their relationship to shared templates.
  - Added documentation for the personal Linear integration workflow, including project mappings and issue-to-spec processes.
  - Streamlined local setup guidance with references to the new documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->