### PR TITLE
fix(profile): 프로젝트 간 프로필 침투 수정 (글로벌 last_profile 폴백 제거)

### DIFF
--- a/internal/cli/launcher.go
+++ b/internal/cli/launcher.go
@@ -138,13 +138,15 @@ func unifiedLaunchDefault(profileName, modeOverride string, extraArgs []string) 
 
 	// 3. Resolve last-used-profile fallback for bare launches (no -p flag).
 	// When profileName is empty and the default profile is unconfigured, fall
-	// back to this project's remembered profile, then to the most recently
-	// -p-launched named profile recorded in launch.yaml. Explicit -p always
-	// wins; MOAI_NO_PROFILE_FALLBACK=1 opts out of both lookups.
+	// back to this project's remembered profile (the projects[root] entry in
+	// launch.yaml). Explicit -p always wins; MOAI_NO_PROFILE_FALLBACK=1 opts
+	// out of the lookup. The global last_profile key is no longer read for
+	// resolution (project-scoped only), so a bare launch in a project with no
+	// projects[] entry resolves to default.
 	originalProfile := profileName
 	resolved := profile.ResolveLaunchProfileForProject(root, profileName)
 	if resolved != profileName && resolved != "" {
-		_, _ = fmt.Fprintf(launcherStderr, "Using last-used profile '%s' (default profile has no preferences). Use -p default to override.\n", resolved)
+		_, _ = fmt.Fprintf(launcherStderr, "Using project profile '%s' (recorded for this project). Use -p default to override.\n", resolved)
 		profileName = resolved
 	}
 
@@ -187,12 +189,12 @@ func unifiedLaunchDefault(profileName, modeOverride string, extraArgs []string) 
 
 	// 5. Record the last-used profile. Only NAMED profiles the user explicitly
 	// passed via -p are recorded — this uses originalProfile (what the user
-	// typed), not the resolved value: writing back a resolved name would
-	// promote the global fallback into a project-scoped entry the user never
-	// chose. Best-effort: a write failure is logged but never blocks the
-	// launch. This runs AFTER the directory exists (step 4.5 — the recorder
-	// refuses names with no directory) and BEFORE launchClaude, which on POSIX
-	// does syscall.Exec and replaces the process, so no code runs after it.
+	// typed), not the resolved value, so a project-scoped resolution is never
+	// promoted back into a projects[] entry the user never chose. Best-effort:
+	// a write failure is logged but never blocks the launch. This runs AFTER
+	// the directory exists (step 4.5 — the recorder refuses names with no
+	// directory) and BEFORE launchClaude, which on POSIX does syscall.Exec and
+	// replaces the process, so no code runs after it.
 	if isNamedProfile(originalProfile) {
 		if err := recordLastProfileFn(root, originalProfile); err != nil {
 			_, _ = fmt.Fprintf(launcherStderr, "Warning: failed to record last-used profile: %v\n", err)
@@ -704,17 +706,16 @@ func launchClaudeDefault(profileName string, extraArgs []string) error {
 	}
 	model = resolveMainSessionModel(model, glmBackend)
 
-	// 6b. An empty model here is not neutral: buildArgs below omits --model
-	// entirely, so Claude Code falls back to whatever `.claude/settings.json`
-	// pins (the MoAI template ships "sonnet"). That looked identical to "my
-	// profile was ignored", with nothing on stderr to distinguish the two.
-	//
-	// The common cause is a profile that was edited but never selected: the
-	// launch ledger still points elsewhere, or at a profile whose directory is
-	// gone, and profile.ResolveLaunchProfile's stale-record guard degrades to
-	// the empty base preferences. Name the resolved profile so the user can see
-	// which one was actually read.
-	if model == "" {
+	// 6b. An empty model is only worth surfacing when the user explicitly
+	// targeted a named profile (via -p or a project-scoped binding) that then
+	// yielded no model — that suggests the named profile is empty or
+	// misconfigured. For the default profile (base preferences) an empty model
+	// is the normal, intentional state: many setups deliberately omit a model
+	// pin so Claude Code falls back to the user-scope last-choice (see
+	// CLAUDE.local.md §22.7). Warning there is a false alarm, so the gate is
+	// isNamedProfile. warnNoModelResolved itself stays unconditional (its unit
+	// test calls it directly with any profileName).
+	if model == "" && isNamedProfile(profileName) {
 		warnNoModelResolved(os.Stderr, profileName)
 	}
 

--- a/internal/cli/launcher_test.go
+++ b/internal/cli/launcher_test.go
@@ -881,10 +881,13 @@ func TestApplyGLMMode_ProcessEnvIsSet(t *testing.T) {
 	}
 }
 
-// TestUnifiedLaunch_FallsBackToLastUsedProfile verifies that bare `moai cc`
-// (profileName=="") resolves to the last-used named profile when the default
-// profile is empty and launch.yaml records a last_profile entry.
-func TestUnifiedLaunch_FallsBackToLastUsedProfile(t *testing.T) {
+// TestUnifiedLaunch_GlobalLedgerDoesNotBleed verifies that bare `moai cc`
+// (profileName=="") does NOT resolve to a global last_profile entry recorded
+// for a DIFFERENT project. This is the launcher-level regression guard for the
+// cross-project bleed bug: launch.yaml has last_profile set but no projects[]
+// entry for THIS project's root, so the launch must use "" (default), not the
+// globally-recorded named profile.
+func TestUnifiedLaunch_GlobalLedgerDoesNotBleed(t *testing.T) {
 	tmpDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(tmpDir, ".moai"), 0o755); err != nil {
 		t.Fatal(err)
@@ -893,15 +896,14 @@ func TestUnifiedLaunch_FallsBackToLastUsedProfile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Profile base dir tree: empty base prefs, a real named profile, launch.yaml ledger.
+	// Profile base dir tree: a real named profile exists (so it is "usable"),
+	// and launch.yaml records it globally — but NO projects[] entry is seeded
+	// for tmpDir, so project-scoped resolution must NOT find it.
 	profileBase := t.TempDir()
 	origBase := profile.BaseDirOverride
 	defer func() { profile.BaseDirOverride = origBase }()
 	profile.BaseDirOverride = profileBase
 
-	if err := os.WriteFile(filepath.Join(profileBase, "preferences.yaml"), []byte("{}\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
 	namedDir := filepath.Join(profileBase, "moai-adk")
 	if err := os.MkdirAll(namedDir, 0o755); err != nil {
 		t.Fatal(err)
@@ -921,6 +923,10 @@ func TestUnifiedLaunch_FallsBackToLastUsedProfile(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	origRoot := findProjectRootFn
+	defer func() { findProjectRootFn = origRoot }()
+	findProjectRootFn = func() (string, error) { return tmpDir, nil }
+
 	origLaunch := launchClaudeFunc
 	defer func() { launchClaudeFunc = origLaunch }()
 
@@ -934,8 +940,8 @@ func TestUnifiedLaunch_FallsBackToLastUsedProfile(t *testing.T) {
 		t.Fatalf("unifiedLaunch error: %v", err)
 	}
 
-	if launchedProfile != "moai-adk" {
-		t.Errorf("launched profile = %q, want %q (last-used fallback)", launchedProfile, "moai-adk")
+	if launchedProfile != "" {
+		t.Errorf("launched profile = %q, want \"\" (global last_profile must not bleed into a project with no projects[] entry)", launchedProfile)
 	}
 }
 

--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -131,14 +131,15 @@ func countCommandTree(c *cobra.Command) int {
 //
 // WHY THIS IS PACKAGE-WIDE rather than per-test. unifiedLaunch step 5
 // (launcher.go) calls profile.RecordLastUsedProfile whenever it is handed a
-// named profile, which rewrites launch.yaml — the ledger a bare `moai cc` reads
-// to decide which profile to launch. Any test that reaches unifiedLaunch with a
-// name, directly (launcher_test.go TestUnifiedLaunch_Claude) or through a cobra
-// RunE (cc_test.go `-p work`), therefore writes the real ledger unless the base
-// dir is overridden. Observed consequence: `last_profile` was left pointing at
-// the fixture name `myprofile`, no such profile directory existed, the
-// stale-record guard in profile.ResolveLaunchProfile returned "", and every
-// subsequent `moai cc` silently launched with no --model at all.
+// named profile, which rewrites launch.yaml — the ledger that carries both the
+// per-project projects[] map (the live source this binary reads) and the
+// legacy last_profile key. Any test that reaches unifiedLaunch with a name,
+// directly (launcher_test.go TestUnifiedLaunch_Claude) or through a cobra
+// RunE (cc_test.go `-p work`), therefore writes the real ledger unless the
+// base dir is overridden. Observed consequence (historical): a fixture name
+// was left recorded with no matching profile directory, the stale-record
+// guard returned "", and every subsequent `moai cc` silently launched with no
+// --model at all.
 //
 // Overriding here rather than in each test is deliberate: the leak is caused by
 // a call several frames below the test body, so a test author has no local

--- a/internal/cli/profile.go
+++ b/internal/cli/profile.go
@@ -80,7 +80,11 @@ func runProfileList(cmd *cobra.Command, _ []string) error {
 }
 
 func runProfileCurrent(cmd *cobra.Command, _ []string) error {
-	_, _ = fmt.Fprintln(cmd.OutOrStdout(), profile.GetCurrentName())
+	name := profile.GetCurrentName()
+	if root, err := findProjectRootFn(); err == nil {
+		name = profile.GetCurrentNameForProject(root)
+	}
+	_, _ = fmt.Fprintln(cmd.OutOrStdout(), name)
 	return nil
 }
 

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -24,13 +24,20 @@ const (
 	// lastProfileKey is the YAML key holding the most recently -p-launched
 	// named profile. Only named profiles are recorded; "" and "default" are
 	// refused by RecordLastUsedProfile.
+	//
+	// WRITE-ONLY on this binary: the resolution path no longer reads this key.
+	// The global read was the source of cross-project profile bleed — a project
+	// with no projects[] entry inherited whichever named profile was last
+	// -p-launched in ANY project. The write is retained so an older moai binary
+	// on the same machine (which still reads last_profile for its global
+	// fallback) keeps working; this binary simply no longer reads it.
 	lastProfileKey = "last_profile"
 
 	// projectsKey is the YAML key holding the per-project profile memory: a
 	// mapping from a normalized absolute project path to the named profile
-	// last launched from that project. It sits alongside lastProfileKey, which
-	// remains the global fallback — a ledger written by this version stays
-	// readable by an older binary that knows only lastProfileKey.
+	// last launched from that project. It is the live source this binary reads
+	// at resolution time; lastProfileKey sits alongside it as a write-only
+	// legacy/downgrade-compat key.
 	projectsKey = "projects"
 
 	// claudeConfigStateFile is the Claude Code account-state file inside a
@@ -74,13 +81,15 @@ func GetCurrentName() string {
 //
 // CLAUDE_CONFIG_DIR still wins: when it is set the ledger is not consulted at
 // all, so a `moai web` launched from inside a `moai cc -p X` session keeps
-// reporting X. Only when it is unset does the ledger decide, and there the
-// project-scoped entry for projectRoot is preferred over the global
-// last_profile — so the console's read side names the same profile its write
-// side records (REQ-PM-024).
+// reporting X. Only when it is unset does the ledger decide, and the decision
+// is project-scoped: the projects[projectRoot] entry alone (REQ-PM-024). A
+// project with no projects[] entry resolves to "" → "default". The global
+// last_profile key is write-only on this binary — it no longer participates
+// in resolution, so one project's profile cannot bleed into another.
 //
-// projectRoot == "" skips the project-scoped lookup entirely, which is what
-// makes GetCurrentName a behavior-preserving wrapper.
+// projectRoot == "" skips the project-scoped lookup entirely (so the wrapper
+// resolves "default" when CLAUDE_CONFIG_DIR is unset), which is what makes
+// GetCurrentName the project-less wrapper.
 func GetCurrentNameForProject(projectRoot string) string {
 	configDir := os.Getenv(config.EnvClaudeConfigDir)
 	if configDir == "" {
@@ -228,16 +237,18 @@ func EnsureDir(name string) error {
 //
 // When profileName is non-empty (the user passed -p explicitly), it is returned
 // as-is — explicit user intent always wins. When profileName is empty (bare
-// `moai cc`/`glm`/`cg`), the function consults the last-used-profile ledger
-// (launch.yaml under GetBaseDir()) and returns the recorded named profile if
-// its directory still exists. This lets a bare launch fall back to the most
-// recently -p-launched named profile when the default profile is unconfigured.
+// `moai cc`/`glm`/`cg`), resolution is project-scoped: this wrapper forwards
+// to ResolveLaunchProfileForProject with an empty projectRoot, which skips the
+// project-scoped lookup and returns "" (default semantics). The global
+// last_profile key is write-only on this binary and no longer participates in
+// resolution — one project's profile cannot bleed into another via a shared
+// global default.
 //
 // The fallback is disabled by setting MOAI_NO_PROFILE_FALLBACK=1.
 //
-// A missing or corrupt launch.yaml, a stale last_profile entry (directory
-// absent), or a traversal-shaped name all yield "" (default semantics). The
-// function never errors — callers receive a profile name, possibly "".
+// A missing or corrupt launch.yaml, a stale project entry (directory absent),
+// or a traversal-shaped name all yield "" (default semantics). The function
+// never errors — callers receive a profile name, possibly "".
 //
 // @MX:NOTE: [AUTO] Last-used-profile fallback resolver — read-only, no error return.
 func ResolveLaunchProfile(profileName string) string {
@@ -295,15 +306,20 @@ func launchCandidateIsUsable(baseDir, name string) bool {
 // ResolveLaunchProfile. Resolution order:
 //
 //  1. explicit profileName (the user's -p) — always wins
-//  2. MOAI_NO_PROFILE_FALLBACK=1 — disables BOTH lookups below
+//  2. MOAI_NO_PROFILE_FALLBACK=1 — disables the lookup below
 //  3. projects[normalizeProjectKey(projectRoot)] — this project's memory
-//  4. last_profile — the global fallback
-//  5. "" — default semantics
+//  4. "" — default semantics
 //
-// Steps 3 and 4 each verify the candidate's directory still exists; a stale
-// project entry falls through to the global fallback rather than shadowing it.
-// projectRoot == "" skips step 3, which is what makes ResolveLaunchProfile a
-// behavior-preserving wrapper. The function never errors.
+// Step 3 verifies the candidate's directory still exists; a stale project
+// entry falls through to "" (default) rather than shadowing it. projectRoot
+// == "" skips step 3, which is what makes ResolveLaunchProfile the
+// project-less wrapper. The function never errors.
+//
+// The global last_profile key is WRITE-ONLY on this binary: an older moai
+// binary still reads it for downgrade compat, but this binary's resolution
+// path no longer does — that global read was the source of cross-project
+// profile bleed (one project's profile leaking into another via a shared
+// global default).
 func ResolveLaunchProfileForProject(projectRoot, profileName string) string {
 	// Explicit -p wins.
 	if profileName != "" {
@@ -327,10 +343,6 @@ func ResolveLaunchProfileForProject(projectRoot, profileName string) string {
 				return name
 			}
 		}
-	}
-
-	if last, ok := ledger[lastProfileKey].(string); ok && launchCandidateIsUsable(baseDir, last) {
-		return last
 	}
 
 	return ""
@@ -379,9 +391,13 @@ func RecordLastUsedProfile(name string) error {
 // RecordLastUsedProfile. It writes the name to BOTH the project-scoped entry
 // under projects: and the global last_profile key.
 //
-// Writing both is what keeps the ledger downgrade-safe: an older binary reads
-// only last_profile, so it still observes "the most recent launch wins" exactly
-// as it did before this key existed.
+// The projects: entry is the live source this binary reads at resolution time
+// (ResolveLaunchProfileForProject step 3). The last_profile write is
+// LEGACY/DOWNGRADE COMPAT only: an older moai binary on the same machine still
+// reads last_profile for its global fallback, so writing it keeps that older
+// binary's "most recent launch wins" behavior intact. This binary never reads
+// last_profile for resolution — keeping the write is pure interop hygiene, not
+// a live signal for this code.
 //
 // Beyond the name-shape checks the original carried, the profile DIRECTORY must
 // already exist (REQ-PM-011). Without that guard a name that never resolves to

--- a/internal/profile/profile_test.go
+++ b/internal/profile/profile_test.go
@@ -80,23 +80,26 @@ func TestGetCurrentName_UnrelatedPath(t *testing.T) {
 	}
 }
 
-// TestGetCurrentName_LedgerFallback verifies that when CLAUDE_CONFIG_DIR is
-// unset (the common `moai web` case — the cc/glm/cg launchers only set it when
-// spawning Claude Code), GetCurrentName consults the launch.yaml ledger and
-// returns the last-used named profile if its directory still exists, rather
-// than blindly returning "default". This keeps `moai web`'s displayed profile
-// in sync with the profile a bare `moai cc` would actually launch.
-func TestGetCurrentName_LedgerFallback(t *testing.T) {
+// TestGetCurrentName_GlobalLedgerDoesNotBleed verifies that a global
+// last_profile entry in launch.yaml does NOT leak into the project-less
+// GetCurrentName() wrapper (which forwards an empty projectRoot).
+//
+// The global last_profile key is write-only on this binary: resolution is
+// project-scoped only, so a caller with no project root (the common `moai web`
+// case where CLAUDE_CONFIG_DIR is unset) resolves to "default" regardless of
+// what the global ledger says. This is the console-side half of the
+// cross-project-bleed regression.
+func TestGetCurrentName_GlobalLedgerDoesNotBleed(t *testing.T) {
 	tmpDir := t.TempDir()
 	orig := BaseDirOverride
 	defer func() { BaseDirOverride = orig }()
 	BaseDirOverride = tmpDir
 
-	// Named profile directory must exist (stale-record guard).
+	// Named profile directory exists so the entry is not stale — the point is
+	// that even a USABLE global entry is not read.
 	if err := os.Mkdir(filepath.Join(tmpDir, "moai-adk"), 0o755); err != nil {
 		t.Fatalf("Mkdir(moai-adk): %v", err)
 	}
-	// Ledger pointing at the named profile.
 	if err := os.WriteFile(filepath.Join(tmpDir, "launch.yaml"), []byte("last_profile: moai-adk\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile(launch.yaml): %v", err)
 	}
@@ -104,8 +107,8 @@ func TestGetCurrentName_LedgerFallback(t *testing.T) {
 	t.Setenv("CLAUDE_CONFIG_DIR", "")
 
 	got := GetCurrentName()
-	if got != "moai-adk" {
-		t.Errorf("GetCurrentName() = %q, want %q (ledger fallback)", got, "moai-adk")
+	if got != "default" {
+		t.Errorf("GetCurrentName() = %q, want %q (global last_profile must not bleed into project-less resolution)", got, "default")
 	}
 }
 
@@ -251,22 +254,20 @@ func TestDelete_Success(t *testing.T) {
 	}
 }
 
-// TestResolveLaunchProfile_EmptyInputReturnsLastUsed verifies that when no -p
-// flag is given (profileName==""), ResolveLaunchProfile falls back to the
-// last_profile recorded in launch.yaml, and that the resolved profile yields
-// real preferences.
-func TestResolveLaunchProfile_EmptyInputReturnsLastUsed(t *testing.T) {
+// TestResolveLaunchProfile_EmptyInputIgnoresGlobalLedger verifies that when
+// no -p flag is given (profileName==""), ResolveLaunchProfile ("") does NOT
+// fall back to the global last_profile recorded in launch.yaml. The global
+// read was removed because it let one project's profile bleed into another;
+// with an empty projectRoot the wrapper has no project-scoped entry to consult
+// either, so it returns "" (default semantics) regardless of the global key.
+func TestResolveLaunchProfile_EmptyInputIgnoresGlobalLedger(t *testing.T) {
 	tmpDir := t.TempDir()
 	orig := BaseDirOverride
 	defer func() { BaseDirOverride = orig }()
 	BaseDirOverride = tmpDir
 
-	// Empty base preferences (the default profile is unconfigured).
-	if err := os.WriteFile(filepath.Join(tmpDir, "preferences.yaml"), []byte("{}\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	// Named profile with real preferences.
+	// Named profile directory exists so the global entry is not stale — the
+	// point is that even a USABLE global entry is no longer read.
 	namedDir := filepath.Join(tmpDir, "moai-adk")
 	if err := os.MkdirAll(namedDir, 0o755); err != nil {
 		t.Fatal(err)
@@ -274,8 +275,6 @@ func TestResolveLaunchProfile_EmptyInputReturnsLastUsed(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(namedDir, "preferences.yaml"), []byte("model: opus[1m]\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-
-	// launch.yaml ledger pointing to the named profile.
 	if err := os.WriteFile(filepath.Join(tmpDir, "launch.yaml"), []byte("last_profile: moai-adk\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -283,17 +282,8 @@ func TestResolveLaunchProfile_EmptyInputReturnsLastUsed(t *testing.T) {
 	t.Setenv("CLAUDE_CONFIG_DIR", "")
 
 	resolved := ResolveLaunchProfile("")
-	if resolved != "moai-adk" {
-		t.Fatalf("ResolveLaunchProfile('') = %q, want %q", resolved, "moai-adk")
-	}
-
-	// The resolved profile must yield real preferences.
-	prefs, err := ReadPreferences(resolved)
-	if err != nil {
-		t.Fatalf("ReadPreferences(%q) error: %v", resolved, err)
-	}
-	if prefs.Model != "opus[1m]" {
-		t.Errorf("ReadPreferences(%q).Model = %q, want %q", resolved, prefs.Model, "opus[1m]")
+	if resolved != "" {
+		t.Fatalf("ResolveLaunchProfile('') = %q, want \"\" (global last_profile must not be read for resolution)", resolved)
 	}
 }
 
@@ -318,8 +308,12 @@ func TestResolveLaunchProfile_ExplicitFlagWins(t *testing.T) {
 	}
 }
 
-// TestResolveLaunchProfile_StaleRecordIgnored verifies that a last_profile entry
-// whose directory does not exist is ignored (returns "" = default semantics).
+// TestResolveLaunchProfile_StaleRecordIgnored verifies that a last_profile
+// entry whose directory does not exist yields "" (default semantics). Since
+// the global last_profile key is no longer read for resolution at all, the
+// stale-skip guard is moot for this key — this test now pins the stronger
+// invariant that the global key simply does not participate in resolution,
+// stale or not.
 func TestResolveLaunchProfile_StaleRecordIgnored(t *testing.T) {
 	tmpDir := t.TempDir()
 	orig := BaseDirOverride
@@ -358,6 +352,70 @@ func TestResolveLaunchProfile_OptOutEnv(t *testing.T) {
 	got := ResolveLaunchProfile("")
 	if got != "" {
 		t.Errorf("ResolveLaunchProfile('') with opt-out = %q, want ''", got)
+	}
+}
+
+// TestResolveLaunchProfile_NoGlobalBleedAcrossProjects pins the user's exact
+// bug: a global last_profile recorded for one project must NOT bleed into a
+// different project that has no projects[] entry of its own. Resolution is
+// project-scoped only after the fix — the global last_profile key is write-only
+// on this binary.
+//
+// Reproduces (and pins the fix for) the on-disk state observed in
+// ~/.moai/claude-profiles/launch.yaml:
+//
+//	last_profile: moai-cowork
+//	projects:
+//	    /Users/goos/MoAI/moai-cowork: moai-cowork   # no entry for moai-adk-go
+//
+// where bare `moai glm` in moai-adk-go used to resolve to moai-cowork.
+func TestResolveLaunchProfile_NoGlobalBleedAcrossProjects(t *testing.T) {
+	tmpDir := t.TempDir()
+	orig := BaseDirOverride
+	t.Cleanup(func() { BaseDirOverride = orig })
+	BaseDirOverride = tmpDir
+
+	// Two real projects, two named profiles. Both profile directories exist so
+	// launchCandidateIsUsable never skips them — the test must fail because the
+	// global read is gone, not because of a stale guard.
+	projA := t.TempDir()
+	projB := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmpDir, "prof-x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(tmpDir, "prof-y"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(tmpDir, "prof-z"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// projects[A] = "prof-x", last_profile = "prof-y" (would have bled to B
+	// under the old global fallback).
+	ledger := "last_profile: prof-y\nprojects:\n  " + normalizeProjectKey(projA) + ": prof-x\n"
+	if err := os.WriteFile(filepath.Join(tmpDir, "launch.yaml"), []byte(ledger), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+
+	// (a) The bug: project B is NOT in the projects map → MUST resolve to ""
+	//     (default), NOT "prof-y". Under the old code this returned "prof-y".
+	if got := ResolveLaunchProfileForProject(projB, ""); got != "" {
+		t.Errorf("(a) ResolveLaunchProfileForProject(projB, \"\") = %q, want \"\" (global last_profile must not bleed into a project with no projects[] entry)", got)
+	}
+
+	// (b) Project memory still works: project A IS in the map → "prof-x".
+	if got := ResolveLaunchProfileForProject(projA, ""); got != "prof-x" {
+		t.Errorf("(b) ResolveLaunchProfileForProject(projA, \"\") = %q, want %q (project-scoped memory)", got, "prof-x")
+	}
+
+	// (c) Explicit -p always wins even when projects[A] and last_profile disagree.
+	if got := ResolveLaunchProfileForProject(projA, "prof-z"); got != "prof-z" {
+		t.Errorf("(c) ResolveLaunchProfileForProject(projA, \"prof-z\") = %q, want %q (explicit -p wins)", got, "prof-z")
+	}
+	if got := ResolveLaunchProfileForProject(projB, "prof-z"); got != "prof-z" {
+		t.Errorf("(c') ResolveLaunchProfileForProject(projB, \"prof-z\") = %q, want %q (explicit -p wins)", got, "prof-z")
 	}
 }
 

--- a/internal/profile/project_scope_test.go
+++ b/internal/profile/project_scope_test.go
@@ -105,7 +105,14 @@ func TestRecordForProject_PreservesLegacyKeys(t *testing.T) {
 
 // --- AC-PM-002 (REQ-PM-003, function layer) ---
 
-func TestResolveForProject_ProjectScopeWinsOverGlobal(t *testing.T) {
+// TestResolveForProject_ProjectScopedIsolated pins the project-scoped-only
+// resolution contract: project A resolves via its own projects[] entry, and a
+// DIFFERENT project B (not in the map) resolves to "" (default) — the global
+// last_profile key no longer participates in resolution, so it cannot bleed
+// across projects. (This is the function-layer twin of the user's
+// cross-project-bleed bug; TestResolveLaunchProfile_NoGlobalBleedAcrossProjects
+// is the named regression guard.)
+func TestResolveForProject_ProjectScopedIsolated(t *testing.T) {
 	base := pmSandboxBase(t)
 	projA := t.TempDir()
 	projB := t.TempDir()
@@ -116,13 +123,18 @@ func TestResolveForProject_ProjectScopeWinsOverGlobal(t *testing.T) {
 	if got := ResolveLaunchProfileForProject(projA, ""); got != "proj-one" {
 		t.Errorf("ResolveLaunchProfileForProject(projA, \"\") = %q, want proj-one", got)
 	}
-	if got := ResolveLaunchProfileForProject(projB, ""); got != "global-one" {
-		t.Errorf("ResolveLaunchProfileForProject(projB, \"\") = %q, want global-one", got)
+	if got := ResolveLaunchProfileForProject(projB, ""); got != "" {
+		t.Errorf("ResolveLaunchProfileForProject(projB, \"\") = %q, want \"\" (global last_profile must not bleed into a project with no projects[] entry)", got)
 	}
 }
 
 // --- AC-PM-003 (REQ-PM-004) ---
 
+// TestResolveForProject_LegacyLedgerUnchanged verifies that resolving from a
+// legacy-shape ledger (last_profile only, no projects map) does not mutate the
+// file — the read side is read-only. The resolution itself returns "" now
+// (global last_profile is write-only on this binary; root has no projects[]
+// entry), but the no-mutation contract is the actual point of this test.
 func TestResolveForProject_LegacyLedgerUnchanged(t *testing.T) {
 	base := pmSandboxBase(t)
 	root := t.TempDir()
@@ -135,11 +147,11 @@ func TestResolveForProject_LegacyLedgerUnchanged(t *testing.T) {
 		t.Fatalf("read ledger: %v", err)
 	}
 
-	if got := ResolveLaunchProfileForProject(root, ""); got != "legacy" {
-		t.Errorf("ResolveLaunchProfileForProject = %q, want legacy", got)
+	if got := ResolveLaunchProfileForProject(root, ""); got != "" {
+		t.Errorf("ResolveLaunchProfileForProject = %q, want \"\" (global last_profile no longer read)", got)
 	}
-	if got := ResolveLaunchProfile(""); got != "legacy" {
-		t.Errorf("ResolveLaunchProfile = %q, want legacy", got)
+	if got := ResolveLaunchProfile(""); got != "" {
+		t.Errorf("ResolveLaunchProfile = %q, want \"\" (global last_profile no longer read)", got)
 	}
 
 	after, err := os.ReadFile(ledgerPath)
@@ -172,7 +184,14 @@ func TestResolveForProject_OptOutDisablesBothLookups(t *testing.T) {
 
 // --- AC-PM-005 (REQ-PM-007) ---
 
-func TestForProject_EmptyRootFallsBackToGlobal(t *testing.T) {
+// TestForProject_EmptyRootResolvesDefault verifies that an empty projectRoot
+// skips the project-scoped lookup and resolves to "" (default). The global
+// last_profile key is no longer read, so even when it holds a USABLE named
+// profile ("global-one") an empty root does not bleed it in. The recording
+// half below is unchanged: RecordLastUsedProfileForProject("", ...) still
+// writes last_profile (legacy/downgrade compat) and leaves the projects map
+// untouched.
+func TestForProject_EmptyRootResolvesDefault(t *testing.T) {
 	base := pmSandboxBase(t)
 	projA := t.TempDir()
 	pmMkProfile(t, base, "proj-one")
@@ -180,15 +199,15 @@ func TestForProject_EmptyRootFallsBackToGlobal(t *testing.T) {
 	pmWriteLedger(t, base, "last_profile: global-one\nprojects:\n  "+normalizeProjectKey(projA)+": proj-one\n")
 	t.Setenv("CLAUDE_CONFIG_DIR", "")
 
-	if got := ResolveLaunchProfileForProject("", ""); got != "global-one" {
-		t.Errorf("ResolveLaunchProfileForProject(\"\", \"\") = %q, want global-one", got)
+	if got := ResolveLaunchProfileForProject("", ""); got != "" {
+		t.Errorf("ResolveLaunchProfileForProject(\"\", \"\") = %q, want \"\" (empty root + no global read → default)", got)
 	}
-	if got := GetCurrentNameForProject(""); got != "global-one" {
-		t.Errorf("GetCurrentNameForProject(\"\") = %q, want global-one", got)
+	if got := GetCurrentNameForProject(""); got != "default" {
+		t.Errorf("GetCurrentNameForProject(\"\") = %q, want %q", got, "default")
 	}
 
-	// Recording with an empty root writes last_profile only; the projects map
-	// is left untouched.
+	// Recording with an empty root writes last_profile only (legacy compat);
+	// the projects map is left untouched.
 	if err := RecordLastUsedProfileForProject("", "proj-one"); err != nil {
 		t.Fatalf("RecordLastUsedProfileForProject(\"\", ...) = %v, want nil", err)
 	}
@@ -208,14 +227,19 @@ func TestForProject_EmptyRootFallsBackToGlobal(t *testing.T) {
 
 // --- AC-PM-006 (REQ-PM-008) ---
 
+// TestResolveForProject_StaleProjectEntrySkipped verifies that a projects[]
+// entry whose target directory is gone is skipped, and resolution falls
+// through to "" (default). The global last_profile key is no longer read,
+// so the fallthrough lands at default rather than the (formerly global)
+// "alive" entry — the stale-skip behavior itself is unchanged.
 func TestResolveForProject_StaleProjectEntrySkipped(t *testing.T) {
 	base := pmSandboxBase(t)
 	projA := t.TempDir()
 	pmMkProfile(t, base, "alive")
 	pmWriteLedger(t, base, "last_profile: alive\nprojects:\n  "+normalizeProjectKey(projA)+": ghost\n")
 
-	if got := ResolveLaunchProfileForProject(projA, ""); got != "alive" {
-		t.Errorf("ResolveLaunchProfileForProject = %q, want alive (stale project entry must fall through)", got)
+	if got := ResolveLaunchProfileForProject(projA, ""); got != "" {
+		t.Errorf("ResolveLaunchProfileForProject = %q, want \"\" (stale project entry must fall through to default)", got)
 	}
 }
 
@@ -304,6 +328,11 @@ func TestHasClaudeConfig_DecidesOnClaudeJSONAlone(t *testing.T) {
 
 // --- AC-PM-019 (REQ-PM-024) ---
 
+// TestGetCurrentNameForProject_ProjectScoped verifies that the project-scoped
+// read names the project's own recorded profile, while the project-less
+// wrapper (GetCurrentName, empty root) resolves to "default" — the global
+// last_profile key no longer participates, so it cannot supply a value for a
+// caller that passes no project root.
 func TestGetCurrentNameForProject_ProjectScoped(t *testing.T) {
 	base := pmSandboxBase(t)
 	projA := t.TempDir()
@@ -315,8 +344,8 @@ func TestGetCurrentNameForProject_ProjectScoped(t *testing.T) {
 	if got := GetCurrentNameForProject(projA); got != "proj-one" {
 		t.Errorf("GetCurrentNameForProject(projA) = %q, want proj-one", got)
 	}
-	if got := GetCurrentName(); got != "global-one" {
-		t.Errorf("GetCurrentName() = %q, want global-one (the unchanged global wrapper)", got)
+	if got := GetCurrentName(); got != "default" {
+		t.Errorf("GetCurrentName() = %q, want %q (empty-root wrapper no longer reads the global key)", got, "default")
 	}
 }
 

--- a/internal/web/app.go
+++ b/internal/web/app.go
@@ -40,10 +40,11 @@ type app struct {
 	// Saving in the web console previously wrote <name>/preferences.yaml without
 	// touching the launch ledger, so the ONLY writer was `moai cc -p <name>`
 	// (launcher.go step 5). Editing a profile in the console therefore had no
-	// effect on the next launch: the ledger still pointed elsewhere, and when it
-	// pointed at a profile whose directory was gone, ResolveLaunchProfile's
-	// stale-record guard returned "" and the launch fell back to the empty base
-	// preferences — no --model, so Claude Code used the settings.json default.
+	// effect on the next launch: the project-scoped ledger entry still pointed
+	// elsewhere (or was absent), and when it pointed at a profile whose
+	// directory was gone, ResolveLaunchProfile's stale-record guard returned ""
+	// and the launch fell back to the empty base preferences — no --model, so
+	// Claude Code used the settings.json default.
 	recordLastProfile func(name string) error
 
 	// Injectable seams over the project-config write path (SPEC-WEB-CONSOLE-003).


### PR DESCRIPTION
## 문제

`moai glm`/`cc`/`cg`를 bare(프로필 미지정)로 실행할 때, **다른 프로젝트에서 마지막으로 `-p` 선택한 named profile이 침투**하는 버그.

재현: `/Users/goos/MoAI/moai-cowork`에서 `moai cc -p moai-cowork` → `launch.yaml`에 `last_profile: moai-cowork` 기록 → 이후 `/Users/goos/MoAI/moai-adk-go`에서 `moai glm` 실행 시 **moai-cowork 프로필로 실행**됨. 부수로 프로필마다 `CLAUDE_CONFIG_DIR`/신뢰 저장소가 분리되어 폴더 신뢰 다이얼로그도 매번 뜸.

## 근본 원인

`ResolveLaunchProfileForProject` 해상 4단계가 글로벌 `last_profile` 폴백:
`-p` → `MOAI_NO_PROFILE_FALLBACK` → `projects[root]` → **글로벌 `last_profile`** → default

`default`는 `RecordLastUsedProfile`이 기록을 거부해서, default를 쓰는 프로젝트는 `projects` 맵에 항목이 없어 항상 글로벌 폴백으로 떨어짐 → 타 프로젝트 프로필 침투.

## 수정

- `internal/profile/profile.go` — 글로벌 `last_profile` 폴백 **read 제거**. 프로젝트 단위 독립 해상(`-p` → opt-out → `projects[root]` → default). `last_profile` write는 레거시/다운그레이드 바이너리 호환용으로 유지.
- `internal/cli/launcher.go` — 해상 경고 "Using project profile..."로 정정; `warnNoModelResolved`를 named profile에서만 발화(default model-less는 정상, CLAUDE.local.md §22.7).
- `internal/cli/profile.go` — `moai profile current`가 현재 프로젝트 인식.
- 회귀 테스트 2종 추가: `NoGlobalBleedAcrossProjects`, `GlobalLedgerDoesNotBleed`.

## 검증

- `go test ./internal/profile/... ./internal/cli/...` GREEN
- `go vet` clean · `go build ./...` OK · `golangci-lint`(변경 패키지) 0 issues
- 워크트리(origin/main 베이스) 체리픽 후 빌드 + 회귀 테스트 2종 통과
- 실기기: `./bin/moai glm -d`에서 침투 경고·모델 경고 둘 다 사라짐 확인

## 동작 변화

- bare 실행이 default로 해상(타 프로젝트 프로필 침투 없음).
- 특정 프로필에 묶으려면 해당 프로젝트에서 `moai cc -p <name>` 1회 실행.

🗿 MoAI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Profile selection is now isolated to the current project, preventing profiles from one project affecting another.
  * Projects without a saved profile now use default behavior instead of incorrectly inheriting a global profile.
  * Empty-model warnings no longer appear for default-profile launches.
  * Current profile displays now accurately reflect project-specific settings.
  * Profile saves correctly preserve project-scoped launch preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->