### PR TITLE
chore(SPEC-SESSION-WORKTREE-001): restore progress.md §E.2-§E.4 + spec.md completed + backfill sync_commit_sha

### DIFF
--- a/.moai/specs/SPEC-SESSION-WORKTREE-001/progress.md
+++ b/.moai/specs/SPEC-SESSION-WORKTREE-001/progress.md
@@ -480,11 +480,36 @@ Both fire BEFORE the subcommand's main work (RegisterSession / QueryActiveWork).
 
 ## §E.3 Run-phase Audit-Ready Signal
 
-_<pending run-phase>_
+- run_status: audit-ready
+- run_complete_at: 2026-08-03
+- run_commit_sha: f9ee7bbd1 (PR #1305 squash merge)
+- AC summary: 24/24 PASS (AC-SW-001 through AC-SW-024)
+- Falsification round-trips on record (7):
+  1. fail-back — disabling auto-isolation produces an observable FAIL, restored produces PASS
+  2. dirty-preserve — a dirty worktree is preserved, not silently swept
+  3. clean-exit-only — cleanup fires on clean exit, not on crash/interrupt
+  4. advisory-suppression — advisory check is suppressed on the recovery-signal carve-out path
+  5. profile-dir-NOT-isolated — `moai profile` directory is correctly NOT isolated (negative test)
+  6. trigger-invariant — the isolation trigger predicate is invariant under unrelated state mutation
+  7. safe.directory-idempotency — repeated `safe.directory` writes converge (idempotent, no drift)
+- Cross-platform build: `go build ./...` exit 0 AND `GOOS=windows GOARCH=amd64 go build ./...` exit 0
+- Lint: `golangci-lint run` 0 issues
+- §25 template neutrality verified: `git diff --name-only origin/main...HEAD | grep '^internal/template/templates/'` → NONE; zero SPEC-ID / `[WT]` / `session_worktree` token leakage into the distributed template tree
+- Orchestrator independent verification: each milestone (M1-M8 + v0.2.2 inline-fix) independently re-verified by the orchestrator before §E.3 sign-off — claim/observed-output/baseline-attribution recorded per milestone in §E.2
+- Documented debt (non-blocking, transparent):
+  - `loadSessionWorktreeConfig(cmd)` unused-cmd parameter (M2-carried, info lint)
+  - AC-SW-007 regex `\[WT\]-` vs Q2 EC-3 `WT-` fallback — known text-adjustment item, not a defect (plan.md Q2 resolution justifies the bracket-fallback asymmetry)
+  - `TestDoctorGolden_{Light,Dark,NoColor}` pre-existing FAIL (M8-unrelated, stash-isolated verification confirmed unrelated)
+  - modernizer ★ suggestions (stringsseq / slicescontains / rangeint) not applied — accepted debt
 
 ## §E.4 Sync-phase Audit-Ready Signal
 
-_<pending sync-phase>_
+- sync_status: completed
+- sync_complete_at: 2026-08-03
+- sync_commit_sha: 38b8c2a29f04b66a75c62dc1bc4dd27404c54379 (PR #1306 squash merge; backfilled from D3 placeholder)
+- sync_pr_number: 1306
+- code_pr_number: 1305 (PR #1305 squash merge `f9ee7bbd1` carried the run-phase implementation)
+- note: a commit cannot reference its own SHA (physics) — the placeholder above is backfilled to the real sync-commit SHA in a follow-up commit (D3 SHA-placeholder-backfill exemption). The run-phase code already landed on main via PR #1305; this sync PR carries only the `in-progress → implemented → completed` frontmatter transition, the §E.3/§E.4 signals, and the CHANGELOG entry.
 
 ## §F Phase 4 Mode Selection
 

--- a/.moai/specs/SPEC-SESSION-WORKTREE-001/spec.md
+++ b/.moai/specs/SPEC-SESSION-WORKTREE-001/spec.md
@@ -2,7 +2,7 @@
 id: SPEC-SESSION-WORKTREE-001
 title: "Automatic worktree isolation for moai init / moai profile / moai web, with worktree-scoped git config and PR-merge auto-cleanup"
 version: "0.2.2"
-status: in-progress
+status: completed
 created: 2026-08-03
 updated: 2026-08-03
 author: manager-spec


### PR DESCRIPTION
PR #1306 (sync-phase squash merge) dropped two things from main:

1. **progress.md** — the §E.2 (M1-M8 run evidence), §E.3 (run audit-ready), §E.4 (sync signals) all regressed to the plan-phase skeleton. Restored from feat `8c958095b` (which carried the populated sections), and `sync_commit_sha` backfilled to the real PR #1306 squash SHA `38b8c2a29` (D3 placeholder → real).
2. **spec.md frontmatter** — `status: in-progress → completed` transition was also lost; main showed `in-progress`. Restored to `completed`.

This is the recovery for the squash-merge content loss. SPEC-SESSION-WORKTREE-001 3-phase close was otherwise complete (run code merged via #1305 `f9ee7bbd1`; this just restores the lifecycle signals the squash dropped).

Two commits, two files (`progress.md`, `spec.md`), no code changes.

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Finalized the session worktree specification as completed.
  * Recorded audit-ready run and sync results, including acceptance criteria, validation checks, build and lint outcomes, and completion details.
  * Removed outdated pending-status placeholders and documented non-blocking follow-up items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->