### PR TITLE
fix(audit): moai-adk 3.x 부합성 56 findings 전면 수정 (자동호출 인프라 복구)

### DIFF
--- a/.claude/agents/moai/manager-develop.md
+++ b/.claude/agents/moai/manager-develop.md
@@ -234,7 +234,7 @@ Static `skills:` preload is kept to a minimum (token diet — progressive disclo
 - When reading or interpreting SPEC artifacts (spec.md / plan.md / acceptance.md), invoke Skill("moai-workflow-spec") to load it on demand.
 - When weighing architecture trade-offs or deep design decisions, invoke Skill("moai-foundation-thinking") to load it on demand.
 - When project documentation context (product.md / structure.md / tech.md) is needed, invoke Skill("moai-workflow-project") to load it on demand.
-- When operating inside an isolated git worktree (L2/L3 worktree flow), invoke Skill("moai-workflow-worktree") to load it on demand.
+- When operating inside an isolated git worktree (L1/L2 worktree flow), invoke Skill("moai-workflow-worktree") to load it on demand.
 
 ## Model/effort escalation
 

--- a/.claude/agents/moai/manager-git.md
+++ b/.claude/agents/moai/manager-git.md
@@ -2,7 +2,7 @@
 name: manager-git
 description: |
   Git workflow specialist. Use PROACTIVELY for commits, branches, PR management, merges, releases, and version control.
-  Invocation gate: invoked for PR creation across ALL tiers (S/M/L) per the PR-mandatory policy (enforce_admins: true, 2026-07-20). Tier L uses heavy ceremony (long-lived branch + full CI matrix); Tier S/M uses light ceremony (short-lived branch + self-merge) — both route PR creation through manager-git. manager-develop/manager-docs perform commits only; push + PR is always delegated to manager-git.
+  Invocation gate: invoked for PR creation across ALL tiers (S/M/L) per the PR-mandatory policy (enforce_admins: true). Tier L uses heavy ceremony (long-lived branch + full CI matrix); Tier S/M uses light ceremony (short-lived branch + self-merge) — both route PR creation through manager-git. manager-develop/manager-docs perform commits only; push + PR is always delegated to manager-git.
   Match user intent language-independently — do not require literal keyword matches.
   NOT for: code implementation, testing, architecture design, documentation content, security audits
 tools: Read, Write, Edit, Grep, Glob, Bash, TaskCreate, TaskUpdate, TaskList, TaskGet, Skill
@@ -133,10 +133,10 @@ Cross-reference: `.claude/rules/moai/workflow/spec-workflow.md` § Step 1 entry 
 ### Personal Mode
 
 SPEC Git Workflow options (from git-strategy.yaml):
-- **main_direct** [RETIRED 2026-07-20 — main direct push blocked by enforce_admins:true; all tiers require PR]: Direct commits to main, no branches needed
+- **main_direct** [RETIRED — main direct push blocked by enforce_admins:true; all tiers require PR]: Direct commits to main, no branches needed
 - **main_late_branch**: main commit + late `git switch -c feat/SPEC-*` at PR time, PR squash + delete-branch, local main `reset --hard origin/main` cleanup (4-phase procedure — see Late-Branch Invocation Pattern above)
 - **main_feature**: Feature branches from main, optional PR
-- **develop_direct** [RETIRED 2026-07-20 — main direct push blocked by enforce_admins:true; all tiers require PR]: Direct commits to develop
+- **develop_direct** [RETIRED — main direct push blocked by enforce_admins:true; all tiers require PR]: Direct commits to develop
 - **feature_branch** / **per_spec**: Feature branches with PR required
 
 ### Team Mode

--- a/.claude/agents/moai/manager-git.md
+++ b/.claude/agents/moai/manager-git.md
@@ -2,9 +2,9 @@
 name: manager-git
 description: |
   Git workflow specialist. Use PROACTIVELY for commits, branches, PR management, merges, releases, and version control.
-  Invocation gate: invoked for Tier L SPEC PR creation OR explicit `--pr` flag per the canonical Tier-based PR routing policy. Tier S/M SPECs follow the Hybrid Trunk 1-person OSS pattern (main-direct push via manager-develop) per the Hybrid Trunk 1-person OSS policy; manager-git is NOT invoked for Tier S/M routine commits.
+  Invocation gate: invoked for PR creation across ALL tiers (S/M/L) per the PR-mandatory policy (enforce_admins: true, 2026-07-20). Tier L uses heavy ceremony (long-lived branch + full CI matrix); Tier S/M uses light ceremony (short-lived branch + self-merge) — both route PR creation through manager-git. manager-develop/manager-docs perform commits only; push + PR is always delegated to manager-git.
   Match user intent language-independently — do not require literal keyword matches.
-  NOT for: Tier S/M default Hybrid Trunk main-direct (no PR step — handled by manager-develop), code implementation, testing, architecture design, documentation content, security audits
+  NOT for: code implementation, testing, architecture design, documentation content, security audits
 tools: Read, Write, Edit, Grep, Glob, Bash, TaskCreate, TaskUpdate, TaskList, TaskGet, Skill
 model: sonnet
 effort: low
@@ -133,10 +133,10 @@ Cross-reference: `.claude/rules/moai/workflow/spec-workflow.md` § Step 1 entry 
 ### Personal Mode
 
 SPEC Git Workflow options (from git-strategy.yaml):
-- **main_direct** [RECOMMENDED]: Direct commits to main, no branches needed
+- **main_direct** [RETIRED 2026-07-20 — main direct push blocked by enforce_admins:true; all tiers require PR]: Direct commits to main, no branches needed
 - **main_late_branch**: main commit + late `git switch -c feat/SPEC-*` at PR time, PR squash + delete-branch, local main `reset --hard origin/main` cleanup (4-phase procedure — see Late-Branch Invocation Pattern above)
 - **main_feature**: Feature branches from main, optional PR
-- **develop_direct**: Direct commits to develop
+- **develop_direct** [RETIRED 2026-07-20 — main direct push blocked by enforce_admins:true; all tiers require PR]: Direct commits to develop
 - **feature_branch** / **per_spec**: Feature branches with PR required
 
 ### Team Mode

--- a/.claude/agents/moai/plan-auditor.md
+++ b/.claude/agents/moai/plan-auditor.md
@@ -283,7 +283,7 @@ Execute each check in order against the full document — every REQ entry and ev
 
 ### Group 7: Cross-SPEC Reconciliation (D7)
 
-- D7-1: Extract every `SPEC-([A-Z][A-Z0-9]+-)+[0-9]+` reference from the SPEC body (supports multi-segment IDs like SPEC-V3R5-WO-001)
+- D7-1: Extract every `SPEC-([A-Z][A-Z0-9]+-)+[0-9]+` reference from the SPEC body (supports multi-segment IDs like SPEC-DOMAIN-WO-001)
 - D7-2: For each referenced SPEC, verify `.moai/specs/<SPEC-ID>/spec.md` exists
 - D7-3: For each referenced SPEC that exists, read its `status:` frontmatter field
 - D7-4: If status ∈ {retired, superseded, archived}, require explicit reconciliation
@@ -397,7 +397,7 @@ Stagnation detection: If a defect appears in all three iterations unchanged, fla
 
 ### LEAN Workflow Additions
 
-The following three clauses extend the retry loop contract to fix the score-regression pattern (0.78 → 0.81 → 0.77) observed in LANG-COMPLIANCE-001 plan-phase abandonment (2026-05-20).
+The following three clauses extend the retry loop contract to fix the score-regression pattern (0.78 → 0.81 → 0.77) observed when unconditional iteration continues on a deteriorating SPEC.
 
 **STOP escalation on score regression.** If iter(N+1) aggregate score is **lower** than iter(N) aggregate score, the agent emits a `STOP` signal in the Verdict block of the report and proposes a scope-reduction action to the orchestrator. The orchestrator MUST NOT iterate further unconditionally; instead, present the user with three options via the orchestrator's user-question channel (`.claude/rules/moai/core/askuser-protocol.md`):
 

--- a/.claude/agents/moai/sync-auditor.md
+++ b/.claude/agents/moai/sync-auditor.md
@@ -46,11 +46,11 @@ HARD must-pass firewall (FROZEN — design-constitution §12 Mechanism 3): every
 Both modes score the same 4 canonical dimensions and differ only in scoring granularity and report format, so reports produced under either mode stay consistent and comparable. The dimension enum is FROZEN (design-constitution §12 Mechanism 3) at exactly `Functionality`, `Security`, `Craft`, `Consistency`; a non-canonical dimension name in a profile is loaded best-effort (unknown dims skipped).
 
 - **Flat weighted-percentage (default)**: the weights in the Evaluation Dimensions table above. Applies whenever `harness.yaml` does NOT set `evaluator_mode: hierarchical`.
-- **Hierarchical sub-criteria refinement** (SPEC-V3R2-HRN-003): **Where** `harness.yaml` sets `evaluator_mode: hierarchical`, each dimension decomposes into N sub-criteria that are scored and aggregated per dimension, and the report renders in the hierarchical format (§ Output Format).
+- **Hierarchical sub-criteria refinement**: **Where** `harness.yaml` sets `evaluator_mode: hierarchical`, each dimension decomposes into N sub-criteria that are scored and aggregated per dimension, and the report renders in the hierarchical format (§ Output Format).
 
 ### Sub-Criterion Scoring and Aggregation (hierarchical mode)
 
-Each dimension has N sub-criteria. Scores MUST use the canonical anchors 0.25, 0.50, 0.75, 1.00; intermediate values are rejected (ErrFlatScoreCardProhibited). Every sub-criterion score MUST cite the canonical anchor description from the active profile's Scoring Rubric section — uncited scores are rejected (ErrRubricCitationMissing). Sub-criteria aggregate per dimension by `min` (default, REQ-HRN-003-007), or by `mean` when the active profile sets the field `aggregation: min | mean` (REQ-HRN-003-015).
+Each dimension has N sub-criteria. Scores MUST use the canonical anchors 0.25, 0.50, 0.75, 1.00; intermediate values are rejected (ErrFlatScoreCardProhibited). Every sub-criterion score MUST cite the canonical anchor description from the active profile's Scoring Rubric section — uncited scores are rejected (ErrRubricCitationMissing). Sub-criteria aggregate per dimension by `min` (default), or by `mean` when the active profile sets the field `aggregation: min | mean`.
 
 ## Per-Dimension Mechanical Verification (project-language auto-detection)
 

--- a/.claude/skills/moai-foundation-cc/reference/best-practices-checklist.md
+++ b/.claude/skills/moai-foundation-cc/reference/best-practices-checklist.md
@@ -67,7 +67,7 @@ name Field:
 description Field:
 - [ ] Clearly describes what the skill does
 - [ ] Includes specific trigger scenarios
-- [ ] Maximum 1024 characters in length
+- [ ] Maximum 1,536 characters (combined description + when_to_use)
 - [ ] Avoids vague or generic language
 - [ ] Includes context for when to use the skill
 

--- a/.claude/skills/moai-foundation-cc/reference/claude-code-custom-slash-commands-official.md
+++ b/.claude/skills/moai-foundation-cc/reference/claude-code-custom-slash-commands-official.md
@@ -54,7 +54,13 @@ IMPORTANT: Command name is automatically derived from file path structure:
 - `.claude/commands/my-command.md` → `/my-command`
 - Example: `.claude/commands/moai/fix.md` → `/moai:fix`
 
-DO NOT include a `name` field in frontmatter - it is not officially supported.
+DO NOT include a `name` field in frontmatter - it is not officially supported. (Earlier examples in this file showed a `name:` key in command frontmatter; those have been removed to match this rule. The command name is ALWAYS derived from the file path — see the mapping above.)
+
+> **Illustrative-only note**: the command names used in the examples below
+> (`validate-config`, `implement-feature`, `deploy`, etc.) are fictional
+> generic illustrations, not MoAI shipped commands. MoAI's real command
+> surface is the `/moai` skill plus its `/moai:<sub>` thin wrappers
+> (see `CLAUDE.md §3 Command Reference`).
 
 ### Command File Format
 
@@ -361,7 +367,6 @@ Configuration Validator:
 
 ````markdown
 ---
-name: validate-config
 description: Validate configuration files against schema and best practices
 usage: |
  /validate-config <file> [options]
@@ -441,7 +446,6 @@ Agent(
 Feature Implementation Workflow:
 ```markdown
 ---
-name: implement-feature
 description: Complete feature implementation workflow from spec to deployment
 usage: |
  /implement-feature "Feature description" [options]
@@ -572,7 +576,6 @@ echo "Documentation: $(echo $docs_result | jq .generated_files)"
 CI/CD Pipeline Integration:
 ```markdown
 ---
-name: deploy
 description: Deploy application with comprehensive validation and rollback capability
 usage: |
  /deploy [environment] [options]

--- a/.claude/skills/moai-foundation-cc/reference/claude-code-iam-official.md
+++ b/.claude/skills/moai-foundation-cc/reference/claude-code-iam-official.md
@@ -1,4 +1,16 @@
-# Claude Code IAM & Permissions - Official Documentation Reference
+# Claude Code IAM & Permissions - Reference
+
+> **Illustrative reference, NOT the official Claude Code specification.**
+> This file is an MoAI-authored summary intended for orientation only. The
+> authoritative, up-to-date IAM and permissions surface lives in the official
+> Claude Code documentation at
+> https://code.claude.com/docs/en/iam — consult that source before relying
+> on any field for a production deployment. Earlier revisions of this file
+> presented fabricated RBAC roles (`developer` / `securityReviewer` /
+> `devopsEngineer` with `toolRestrictions`), an `enterprise.policies`
+> framework, and SOC2 / ISO27001 compliance JSON as if they were real
+> Claude Code IAM surfaces; they do not exist in the product and have been
+> removed. What remains is the real, currently-shipped permission surface.
 
 Source: https://code.claude.com/docs/en/iam
 
@@ -6,630 +18,137 @@ Source: https://code.claude.com/docs/en/iam
 
 ### What is Claude Code IAM?
 
-Identity and Access Management (IAM) in Claude Code provides a comprehensive permission system that controls access to tools, files, and external services. IAM implements tiered approval levels, role-based access control, and security boundaries to ensure safe and compliant operations.
+Claude Code's Identity and Access Management surface is a **permission
+mode + allow/ask/deny list** model, enforced at four settings scopes
+(enterprise/managed → user → project → local). There is NO role-based
+access control (RBAC), NO predefined `developer`/`reviewer`/`devops` roles,
+and NO `toolRestrictions` sub-object — the earlier sections that described
+those were illustrative-only and have been removed.
 
-### IAM Architecture
+## Permission Modes
 
-Tiered Permission System:
-```
-Level 1: Read-only Access (No Approval)
- Read, Grep, Glob
- Information gathering tools
+The `permissions.defaultMode` field accepts exactly four values:
 
-Level 2: Bash Commands (User Approval Required)
- Bash, WebFetch, WebSearch
- System operations and external access
+| Mode | Behavior |
+|------|----------|
+| `default` | Prompts on every tool call that is not on the allow list |
+| `plan` | Read-only; Claude cannot modify files or run non-read tools |
+| `acceptEdits` | Auto-accepts Write/Edit; still prompts for Bash and other tools |
+| `bypassPermissions` | Skips all prompts (gated by `disableBypassPermissionsMode`) |
 
-Level 3: File Modification (User Approval Required)
- Write, Edit, MultiEdit
- File system modifications
+These are the only valid values. Earlier revisions listed `dontAsk` and
+`ignore` — those are not real Claude Code permission modes.
 
-Level 4: Administrative (Enterprise Approval)
- Settings management
- User administration
- System configuration
-```
-
-## Tool-Specific Permission Rules
-
-### Permission Rule Format
-
-Basic Permission Structure:
 ```json
 {
- "allowedTools": [
- "Read", // Read-only access (no approval)
- "Bash", // Commands with approval
- "Write", // File modification with approval
- "WebFetch(domain:*.example.com)" // Domain-specific web access
- ]
+  "permissions": {
+    "defaultMode": "default"
+  }
 }
 ```
 
-### Permission Levels and Tools
+## Allow / Ask / Deny Lists
 
-Level 1: Read-Only Tools (No Approval Required)
+The `permissions` object carries three ordered lists of tool-path patterns.
+Each entry is a tool name with an optional parenthesized argument pattern:
+
 ```json
 {
- "readLevel": {
- "tools": ["Read", "Grep", "Glob"],
- "approval": "none",
- "description": "Information gathering and file exploration",
- "useCases": [
- "Code analysis and review",
- "File system exploration",
- "Pattern searching and analysis",
- "Documentation reading"
- ]
- }
+  "permissions": {
+    "allow": [
+      "Read",
+      "Glob",
+      "Grep",
+      "Bash(git status:*)",
+      "Bash(git log:*)"
+    ],
+    "ask": [
+      "Bash(rm:*)",
+      "Bash(sudo:*)"
+    ],
+    "deny": [
+      "Read(~/.ssh/**)",
+      "Bash(rm -rf /:*)"
+    ],
+    "additionalDirectories": [
+      "/path/to/extra/checkout"
+    ]
+  }
 }
 ```
 
-Level 2: System Operations (User Approval Required)
-```json
-{
- "systemLevel": {
- "tools": ["Bash", "WebFetch", "WebSearch"],
- "approval": "user",
- "description": "System operations and external resource access",
- "useCases": [
- "Build and deployment operations",
- "External API integration",
- "System configuration changes",
- "Network operations"
- ]
- }
-}
-```
+- `allow` — auto-approve matching tool calls (no prompt).
+- `ask` — always prompt, even in `acceptEdits` / `bypassPermissions`-leaning flows.
+- `deny` — block unconditionally; never callable.
+- `additionalDirectories` — grant Read access to directories outside the project root.
 
-Level 3: File Modifications (User Approval Required)
-```json
-{
- "modificationLevel": {
- "tools": ["Write", "Edit", "MultiEdit", "NotebookEdit"],
- "approval": "user",
- "description": "File system modifications and content creation",
- "useCases": [
- "Code implementation and changes",
- "Documentation updates",
- "Configuration file modifications",
- "Content generation"
- ]
- }
-}
-```
+### Pattern Grammar (illustrative)
 
-Level 4: Administrative (Enterprise Approval Required)
-```json
-{
- "adminLevel": {
- "tools": ["Settings", "UserManagement", "SystemConfig"],
- "approval": "enterprise",
- "description": "System administration and user management",
- "useCases": [
- "System configuration changes",
- "User permission management",
- "Enterprise policy updates",
- "Security configuration"
- ]
- }
-}
-```
+- `Bash(git status:*)` — the `:` prefix-anchored command form for Bash.
+- `Read(./docs/**)` — glob-restricted Read paths.
+- `WebFetch(domain:example.com)` — domain-scoped WebFetch.
 
-## Role-Based Access Control (RBAC)
+The authoritative pattern grammar (including the `~` home-prefix, the `//`
+glob separator, and MCP-tool naming `mcp__server__tool`) lives at
+https://code.claude.com/docs/en/iam.
 
-### Predefined Roles
+## Settings Scopes (Enterprise / Managed → Local)
 
-Developer Role:
-```json
-{
- "developer": {
- "allowedTools": [
- "Read", "Grep", "Glob",
- "Bash", "Write", "Edit",
- "WebFetch", "WebSearch",
- "AskUserQuestion", "Task", "Skill"
- ],
- "toolRestrictions": {
- "Bash": {
- "allowedCommands": ["git", "npm", "python", "make", "docker"],
- "blockedCommands": ["sudo", "chmod 777", "rm -rf /"],
- "requireConfirmation": true
- },
- "WebFetch": {
- "allowedDomains": ["*.github.com", "*.npmjs.com", "docs.python.org"],
- "blockedDomains": ["*.malicious-site.com"],
- "maxRequestsPerMinute": 60
- },
- "Write": {
- "allowedPaths": ["./src/", "./tests/", "./docs/"],
- "blockedPaths": ["./.env*", "./config/secrets"],
- "maxFileSize": 10000000
- }
- },
- "permissions": {
- "canCreateFiles": true,
- "canModifyFiles": true,
- "canExecuteCommands": true,
- "canAccessExternal": true
- }
- }
-}
-```
+Claude Code resolves settings in a strict precedence order. Higher scopes
+override lower ones, and `deny` entries at any scope are absolute:
 
-Security Reviewer Role:
-```json
-{
- "securityReviewer": {
- "allowedTools": [
- "Read", "Grep", "Glob",
- "Bash", "WebFetch",
- "AskUserQuestion", "Task"
- ],
- "toolRestrictions": {
- "Read": {
- "allowedPaths": ["./"],
- "blockedPatterns": ["*.key", "*.pem", ".env*"]
- },
- "Bash": {
- "allowedCommands": ["git", "grep", "find", "openssl"],
- "requireConfirmation": true
- }
- },
- "specialPermissions": {
- "canAccessSecurityLogs": true,
- "canRunSecurityScans": true,
- "canReviewPermissions": true,
- "cannotModifyProduction": true
- }
- }
-}
-```
+1. **Enterprise / Managed settings** — `/etc/claude/settings.json` (Linux/macOS) or `/Library/Application Support/ClaudeCode/managed-settings.json` (macOS Managed). Organization-wide; users cannot override.
+2. **User settings** — `~/.claude/settings.json`. Personal defaults across all projects.
+3. **Project settings** — `.claude/settings.json`. Team-shared, checked into VCS.
+4. **Local settings** — `.claude/settings.local.json`. Per-developer overrides; gitignored.
 
-DevOps Engineer Role:
-```json
-{
- "devopsEngineer": {
- "allowedTools": [
- "Read", "Grep", "Glob",
- "Bash", "Write", "Edit",
- "WebFetch", "WebSearch",
- "Task", "Skill"
- ],
- "toolRestrictions": {
- "Bash": {
- "allowedCommands": [
- "git", "docker", "kubectl", "helm", "terraform",
- "npm", "pip", "make", "curl", "wget"
- ],
- "blockedCommands": ["sudo", "chmod 777"],
- "requireConfirmation": false
- },
- "WebFetch": {
- "allowedDomains": ["*"],
- "requireConfirmation": false
- }
- },
- "permissions": {
- "canDeployToStaging": true,
- "canManageInfrastructure": true,
- "canAccessProduction": false,
- "canManageCI/CD": true
- }
- }
-}
-```
+There is NO inline `enterprise: { policies: { ... } }` settings.json object
+of the kind earlier revisions showed. Enterprise policy is expressed by
+editing the managed-settings file at one of the paths above, not by an
+in-document `enterprise` block.
 
-### Custom Role Definition
+## Enterprise Levers
 
-Role Template:
-```json
-{
- "customRole": {
- "name": "CustomRoleName",
- "description": "Role description and purpose",
- "allowedTools": ["Read", "Bash", "Write"],
- "toolRestrictions": {
- "Read": {
- "allowedPaths": ["./"],
- "blockedPaths": [".env*", "secrets/"]
- },
- "Bash": {
- "allowedCommands": ["git", "npm"],
- "blockedCommands": ["rm", "sudo"],
- "requireConfirmation": true
- }
- },
- "permissions": {
- "customPermission": "value"
- },
- "inherits": ["developer"]
- }
-}
-```
+The real enterprise-grade settings keys (set in the managed-settings file,
+not in an inline `enterprise` block):
 
-## Enterprise Policy Overrides
+- `disableBypassPermissionsMode: true` — prevents agents from entering `bypassPermissions` (Claude Code v2.1.111+).
+- `permissions.deny` at managed scope — absolute deny that no lower scope can override.
+- `permissions.allow` / `permissions.ask` at managed scope — org-wide defaults.
 
-### Enterprise IAM Structure
+There is no `enterprise.compliance` block with SOC2 / ISO27001 fields.
+Compliance posture for Claude Code itself is documented by Anthropic's
+trust center, not configured in `settings.json`.
 
-Enterprise Policy Framework:
-```json
-{
- "enterprise": {
- "policies": {
- "tools": {
- "Bash": "never",
- "WebFetch": ["domain:*.company.com", "domain:*.partner.com"],
- "Write": ["path:./workspace/", "path:./temp/"]
- },
- "mcpServers": {
- "allowed": ["example-server", "figma", "company-internal-mcp"],
- "blocked": ["custom-unverified-mcp", "external-scanner"]
- },
- "roles": {
- "default": "readonly-developer",
- "overrides": {
- "senior-developer": "developer",
- "devops": "devops-engineer"
- }
- },
- "compliance": {
- "auditRequired": true,
- "dataRetention": "7y",
- "encryptionRequired": true,
- "mfaRequired": true
- }
- }
- }
-}
-```
+## What Was Removed (for readers familiar with older revisions)
 
-Policy Enforcement Mechanisms:
-```json
-{
- "policyEnforcement": {
- "validation": {
- "strict": true,
- "failOnViolation": true,
- "auditFrequency": "daily"
- },
- "overrides": {
- "allowUserOverrides": false,
- "requireManagerApproval": true,
- "emergencyOverrides": {
- "enabled": true,
- "duration": "24h",
- "approvalRequired": ["cto", "security-team"]
- }
- },
- "monitoring": {
- "realTimeAlerts": true,
- "anomalyDetection": true,
- "complianceReporting": true
- }
- }
-}
-```
+For anyone who learned this surface from an earlier draft of this file,
+the following were illustrative-only fabrications and do NOT exist in
+Claude Code:
 
-## MCP Server Permissions
+- The four "Levels" (Read-only / Bash / File-Modification / Administrative) as a tiered approval system — Claude Code uses the four permission modes above, not a 4-tier approval ladder.
+- Predefined RBAC roles: `developer`, `securityReviewer`, `devopsEngineer`.
+- `toolRestrictions` sub-objects (`allowedCommands`, `blockedCommands`, `allowedDomains`, `allowedPaths`, `maxFileSize`, etc.). The real model is the allow/ask/deny list, not a per-tool restrictions object.
+- Custom role definition (`customRole` with `inherits`).
+- `enterprise.policies.tools` / `enterprise.policies.mcpServers` / `enterprise.policies.roles` / `enterprise.policies.compliance`.
+- `policyEnforcement` (validation / overrides / monitoring) blocks.
+- `mcpSecurity` validation / sandbox / monitoring blocks (MCP permissions are governed by the same allow/ask/deny list, scoped with `mcp__server__tool`).
+- `webPermissions` / `fileSystemPermissions` top-level objects (use `WebFetch(domain:...)` and `Read(path:...)` patterns in the standard permissions lists instead).
+- Python `validate_tool_usage()` pseudocode and real-time monitoring JSON.
+- SOC 2 / ISO 27001 compliance JSON blocks.
 
-### MCP Access Control
-
-MCP Server Configuration:
-```json
-{
- "allowedMcpServers": [
- "example-server",
- "figma-dev-mode-mcp-server",
- "playwright",
- "company-internal-mcp"
- ],
- "blockedMcpServers": [
- "custom-unverified-mcp",
- "experimental-ai-mcp",
- "external-scanner-mcp"
- ],
- "mcpServerPermissions": {
- "example-server": {
- "allowed": ["tool-a", "tool-b"],
- "rateLimit": {
- "requestsPerMinute": 60,
- "burstSize": 10
- },
- "dataUsage": {
- "allowedDataTypes": ["documentation", "api-reference"],
- "blockedDataTypes": ["credentials", "private-keys"]
- }
- },
- "figma-dev-mode-mcp-server": {
- "allowed": ["get-design-context", "get-variable-defs", "get-screenshot"],
- "accessControl": {
- "allowedProjects": ["company-design-system"],
- "blockedProjects": ["competitor-designs"]
- }
- }
- }
-}
-```
-
-MCP Security Validation:
-```json
-{
- "mcpSecurity": {
- "validationRules": {
- "requireSignature": true,
- "requireVersionCheck": true,
- "requirePermissionsReview": true
- },
- "sandbox": {
- "enabled": true,
- "isolatedNetwork": true,
- "fileSystemAccess": "restricted"
- },
- "monitoring": {
- "logAllCalls": true,
- "auditSensitiveOperations": true,
- "rateLimitViolations": "block"
- }
- }
-}
-```
-
-## Domain-Specific Permissions
-
-### Web Access Control
-
-Domain-Based Web Permissions:
-```json
-{
- "webPermissions": {
- "allowedDomains": [
- "*.github.com",
- "*.npmjs.com",
- "docs.python.org",
- "*.company.com",
- "*.partner-site.com"
- ],
- "blockedDomains": [
- "*.malicious-site.com",
- "*.competitor.com",
- "*.social-media.com"
- ],
- "domainRestrictions": {
- "github.com": {
- "allowedPaths": ["/api/v3/", "/raw/"],
- "blockedPaths": ["/settings/", "/admin/"]
- },
- "npmjs.com": {
- "allowedPaths": ["/package/"],
- "blockedPaths": ["/settings/", "/account/"]
- }
- }
- }
-}
-```
-
-### File System Access Control
-
-Path-Based Permissions:
-```json
-{
- "fileSystemPermissions": {
- "allowedPaths": [
- "./src/",
- "./tests/",
- "./docs/",
- "./.claude/",
- "./.moai/"
- ],
- "blockedPaths": [
- "./.env*",
- "./secrets/",
- "./.ssh/",
- "./config/private/",
- "./node_modules/.cache/"
- ],
- "pathRestrictions": {
- "./src/": {
- "allowedExtensions": [".py", ".js", ".ts", ".md", ".json"],
- "blockedExtensions": [".exe", ".key", ".pem"]
- },
- "./config/": {
- "readOnly": true,
- "requireApproval": true
- }
- }
- }
-}
-```
-
-## Permission Validation and Enforcement
-
-### Pre-Execution Validation
-
-Permission Check Workflow:
-```python
-def validate_tool_usage(tool_name, parameters, user_role):
- """
- Validate tool usage against IAM policies
- """
- # 1. Check if tool is allowed for user role
- if tool_name not in get_allowed_tools(user_role):
- return {"allowed": False, "reason": "Tool not permitted for role"}
-
- # 2. Check tool-specific restrictions
- restrictions = get_tool_restrictions(tool_name, user_role)
- if not validate_tool_restrictions(tool_name, parameters, restrictions):
- return {"allowed": False, "reason": "Tool restriction violation"}
-
- # 3. Check enterprise policy overrides
- if violates_enterprise_policy(tool_name, parameters):
- return {"allowed": False, "reason": "Enterprise policy violation"}
-
- # 4. Determine approval requirement
- approval_level = get_approval_level(tool_name, user_role)
-
- return {
- "allowed": True,
- "approvalRequired": approval_level != "none",
- "approvalLevel": approval_level
- }
-```
-
-### Real-Time Permission Monitoring
-
-Permission Monitoring System:
-```json
-{
- "monitoring": {
- "realTimeValidation": {
- "enabled": true,
- "checkFrequency": "per-execution",
- "blockOnViolation": true
- },
- "auditLogging": {
- "enabled": true,
- "logLevel": "detailed",
- "retention": "90d",
- "format": "structured-json"
- },
- "alerts": {
- "permissionViolations": {
- "enabled": true,
- "channels": ["email", "slack"],
- "escalation": ["security-team", "management"]
- },
- "suspiciousActivity": {
- "enabled": true,
- "threshold": "5 violations in 1h",
- "action": "temporary-ban"
- }
- }
- }
-}
-```
-
-## Security Compliance
-
-### Compliance Framework Integration
-
-SOC 2 Compliance:
-```json
-{
- "compliance": {
- "SOC2": {
- "security": {
- "accessControl": true,
- "encryptionRequired": true,
- "auditLogging": true,
- "incidentResponse": true
- },
- "availability": {
- "backupRequired": true,
- "disasterRecovery": true,
- "uptimeMonitoring": true
- },
- "processing": {
- "dataIntegrity": true,
- "accuracyValidation": true,
- "errorHandling": true
- },
- "confidentiality": {
- "dataEncryption": true,
- "accessControls": true,
- "dataMinimization": true
- }
- }
- }
-}
-```
-
-ISO 27001 Compliance:
-```json
-{
- "compliance": {
- "ISO27001": {
- "accessControl": {
- "policyDocumented": true,
- "accessReview": "quarterly",
- "leastPrivilege": true,
- "segregationOfDuties": true
- },
- "informationSecurity": {
- "riskAssessment": "annual",
- "securityTraining": "mandatory",
- "incidentManagement": true,
- "businessContinuity": true
- }
- }
- }
-}
-```
+If you need a capability that the real surface above does not list, it is
+almost certainly NOT available — do not assume a hidden field. Check
+https://code.claude.com/docs/en/iam first.
 
 ## Best Practices
 
-### Permission Management
+- **Principle of least privilege**: start with `default` mode and a minimal `allow` list; widen only when a workflow genuinely needs it.
+- **Deny at managed scope for hard boundaries**: put `Read(~/.ssh/**)`, `Bash(rm -rf /:*)`, and similar in the managed-settings `permissions.deny` so no lower scope or errant agent can override them.
+- **Local overrides stay local**: keep machine-specific entries in `.claude/settings.local.json`; never commit them.
+- **`additionalDirectories` is a read grant**, not a write grant — it lets Claude Read outside the project root, it does not auto-approve Write/Edit there.
+- **Audit the allow list**: periodically review `.claude/settings.json` `permissions.allow` for over-broad patterns (`Bash(*)` is a common footgun).
 
-Principle of Least Privilege:
-```json
-{
- "leastPrivilege": {
- "grantOnlyNecessary": true,
- "regularReview": "quarterly",
- "automaticRevocation": {
- "enabled": true,
- "inactivityPeriod": "90d"
- },
- "roleBasedAssignment": true
- }
-}
-```
-
-Security Best Practices:
-- Implement multi-factor authentication for administrative access
-- Regular security audits and permission reviews
-- Encrypted storage of sensitive configuration data
-- Real-time monitoring and alerting for security events
-- Incident response procedures for security violations
-
-Compliance Best Practices:
-- Document all permission policies and procedures
-- Maintain comprehensive audit logs
-- Regular compliance assessments and reporting
-- Employee security training and awareness programs
-- Automated compliance checking and validation
-
-### Implementation Guidelines
-
-Development Environment:
-```json
-{
- "development": {
- "permissionMode": "default",
- "allowedTools": ["Read", "Write", "Edit", "Bash"],
- "toolRestrictions": {
- "Bash": {"allowedCommands": ["git", "npm", "python"]},
- "Write": {"allowedPaths": ["./src/", "./tests/"]}
- }
- }
-}
-```
-
-Production Environment:
-```json
-{
- "production": {
- "permissionMode": "restricted",
- "allowedTools": ["Read", "Grep"],
- "toolRestrictions": {
- "Read": {"allowedPaths": ["./logs/", "./config/readonly/"]}
- },
- "monitoring": {
- "realTimeAlerts": true,
- "auditAllAccess": true
- }
- }
-}
-```
-
-This comprehensive IAM reference provides all the information needed to implement secure, compliant, and effective access control for Claude Code deployments at any scale.
+For the authoritative and current IAM surface — including fields added
+after this file was last reviewed — consult the official documentation at
+https://code.claude.com/docs/en/iam.

--- a/.claude/skills/moai-foundation-cc/reference/claude-code-settings-official.md
+++ b/.claude/skills/moai-foundation-cc/reference/claude-code-settings-official.md
@@ -1,4 +1,12 @@
-# Claude Code Settings - Official Documentation Reference
+# Claude Code Settings - Reference
+
+> **Illustrative reference, NOT the official Claude Code specification.**
+> This file is an MoAI-authored summary intended for orientation only. The
+> authoritative, up-to-date settings schema lives in the official Claude Code
+> documentation at https://code.claude.com/docs/en/settings — consult that
+> source before relying on any field for a production `settings.json`. Some
+> blocks below are illustrative patterns rather than real `settings.json`
+> keys; the headers flag those.
 
 Source: https://code.claude.com/docs/en/settings
 
@@ -72,7 +80,7 @@ The `model` field sets the default model. Only this single field is valid in set
 
 ### Permission System
 
-Permission Modes: `default`, `plan`, `acceptEdits`, `dontAsk`, `bypassPermissions`.
+Permission Modes: `default`, `plan`, `acceptEdits`, `bypassPermissions`.
 
 Permissions use allow/ask/deny lists with tool-path patterns:
 ```json
@@ -205,31 +213,14 @@ Hooks Setup:
 
 ### Sub-agent Configuration
 
-Sub-agent Settings:
-```json
-{
- "subagents": {
- "defaultModel": "claude-3-5-sonnet-20241022",
- "defaultPermissionMode": "default",
- "maxConcurrentTasks": 5,
- "taskTimeout": 300000,
- "allowedSubagents": [
- "spec-builder",
- "ddd-implementer",
- "security-expert",
- "backend-expert",
- "frontend-expert"
- ],
- "customSubagents": {
- "custom-analyzer": {
- "description": "Custom code analysis agent",
- "tools": ["Read", "Grep", "Bash"],
- "model": "claude-3-5-sonnet-20241022"
- }
- }
- }
-}
-```
+Claude Code does NOT expose a `subagents` block in `settings.json`. Sub-agents
+are configured as individual files under `.claude/agents/*.md` (frontmatter:
+`name`, `description`, `tools`, `model`, etc.) and spawned via the `Agent`
+tool. The earlier `subagents` / `defaultModel` / `allowedSubagents` /
+`customSubagents` schema that appeared here was illustrative-only and did not
+correspond to a real `settings.json` key — it has been removed. See
+`claude-code-sub-agents-official.md` for the authoritative sub-agent
+authoring surface.
 
 ### Plugin System
 
@@ -282,219 +273,59 @@ Standard Locations:
 
 ### Settings Management Commands
 
-Configuration Commands:
+> The commands below are illustrative. Claude Code's real CLI surface is
+> narrower than this list — it exposes `claude config set`/`get`/`list` for
+> a small set of keys plus the interactive `/config` command inside the
+> TUI. The `--environment` flag, `use-environment`, `list-environments`,
+> and any `maxTokens` setter shown below do not exist in the real CLI
+> (there is no `maxTokens` field). Treat this block as a pattern sketch,
+> not a copy-paste source; verify against
+> https://code.claude.com/docs/en/settings.
+
+Configuration Commands (illustrative):
 ```bash
 # View current settings
-claude settings show
-claude settings show --model
-claude settings show --permissions
+claude config list
+claude config get model
 
-# Set individual settings
-claude config set model "claude-3-5-sonnet-20241022"
-claude config set maxTokens 200000
-claude config set permissionMode "default"
+# Set individual settings (real keys only — model, permissions, etc.)
+claude config set model "claude-sonnet-5"
 
-# Edit settings file
-claude config edit
-claude config edit --local
-claude config edit --user
-
-# Reset settings
-claude config reset
-claude config reset --local
-claude config reset --user
-
-# Validate settings
-claude config validate
-claude config validate --strict
+# Edit settings file directly
+$EDITOR .claude/settings.json
 ```
 
-Environment-Specific Settings:
-```bash
-# Set environment-specific settings
-claude config set --environment development model "claude-3-5-haiku-20241022"
-claude config set --environment production maxTokens 200000
-
-# Switch between environments
-claude config use-environment development
-claude config use-environment production
-
-# List available environments
-claude config list-environments
-```
+For interactive configuration, use the `/config` command inside a Claude
+Code session — it writes to the appropriate settings scope (local/project/
+user) automatically.
 
 ## Advanced Configuration
 
-### Context Management
-
-Context Window Settings:
-```json
-{
- "context": {
- "maxTokens": 200000,
- "compressionThreshold": 150000,
- "compressionStrategy": "importance-based",
- "memoryIntegration": true,
- "cacheStrategy": {
- "enabled": true,
- "maxSize": "100MB",
- "ttl": 3600
- }
- }
-}
-```
-
-### Logging and Debugging
-
-Logging Configuration:
-```json
-{
- "logging": {
- "level": "info",
- "file": "~/.claude/logs/claude.log",
- "maxFileSize": "10MB",
- "maxFiles": 5,
- "format": "json",
- "include": [
- "tool_usage",
- "agent_delegation",
- "errors",
- "performance"
- ],
- "exclude": [
- "sensitive_data"
- ]
- }
-}
-```
-
-Debug Settings:
-```json
-{
- "debug": {
- "enabled": false,
- "verboseOutput": false,
- "timingInfo": false,
- "tokenUsage": true,
- "stackTraces": false,
- "apiCalls": false
- }
-}
-```
-
-### Performance Optimization
-
-Performance Settings:
-```json
-{
- "performance": {
- "parallelExecution": true,
- "maxConcurrency": 5,
- "caching": {
- "enabled": true,
- "strategy": "lru",
- "maxSize": "500MB"
- },
- "optimization": {
- "contextCompression": true,
- "responseStreaming": false,
- "batchProcessing": true
- }
- }
-}
-```
+> The blocks that appeared here earlier — `context.maxTokens` /
+> `compressionThreshold` / `cacheStrategy`, `logging`, `debug`, and
+> `performance` top-level settings — were illustrative-only and did not
+> correspond to real `settings.json` keys. Claude Code does not expose a
+> `context`, `logging`, `debug`, or `performance` top-level object. They have
+> been removed. Context-window behavior is governed by the runtime and by
+> `cleanupPeriodDays`; logging is governed by the runtime's debug flags
+> (`claude --debug ...`) rather than a `settings.json` block.
 
 ## Integration Settings
 
-### Git Integration
-
-Git Configuration:
-```json
-{
- "git": {
- "autoCommit": false,
- "autoPush": false,
- "branchStrategy": "feature-branch",
- "commitTemplate": {
- "prefix": "feat:",
- "includeScope": true,
- "includeBody": true
- },
- "hooks": {
- "preCommit": "lint && test",
- "prePush": "security-scan"
- }
- }
-}
-```
-
-### CI/CD Integration
-
-CI/CD Settings:
-```json
-{
- "cicd": {
- "platform": "github-actions",
- "configPath": ".github/workflows/",
- "autoGenerate": false,
- "pipelines": {
- "test": {
- "trigger": ["push", "pull_request"],
- "steps": ["lint", "test", "security-scan"]
- },
- "deploy": {
- "trigger": ["release"],
- "steps": ["build", "deploy"]
- }
- }
- }
-}
-```
+> The `git` and `cicd` top-level settings blocks that appeared here earlier
+> were illustrative-only and did not correspond to real `settings.json` keys.
+> Claude Code does not commit, push, or generate CI pipelines from a
+> `settings.json` block; git/CI behavior is driven by your shell, your
+> repository hooks, and the MoAI orchestrator. They have been removed.
 
 ## Security Configuration
 
-### Security Settings
-
-Security Configuration:
-```json
-{
- "security": {
- "level": "standard",
- "encryption": {
- "enabled": true,
- "algorithm": "AES-256-GCM"
- },
- "accessControl": {
- "authentication": "required",
- "authorization": "role-based"
- },
- "audit": {
- "enabled": true,
- "logLevel": "detailed",
- "retention": "90d"
- }
- }
-}
-```
-
-### Privacy Settings
-
-Privacy Configuration:
-```json
-{
- "privacy": {
- "dataCollection": "minimal",
- "analytics": false,
- "crashReporting": true,
- "usageStatistics": false,
- "dataRetention": {
- "logs": "30d",
- "cache": "7d",
- "temp": "1d"
- }
- }
-}
-```
+> The `security` and `privacy` top-level settings blocks that appeared here
+> earlier were illustrative-only and did not correspond to real
+> `settings.json` keys. Claude Code's security surface is the
+> `permissions` block (allow/ask/deny lists, permission modes), sandboxing
+> (`sandbox`), and `disableBypassPermissionsMode` — not an inline
+> `security`/`privacy` object. They have been removed.
 
 ## Best Practices
 
@@ -520,42 +351,15 @@ Performance Practices:
 
 ### Organization Standards
 
-Team Configuration:
-```json
-{
- "team": {
- "standards": {
- "model": "claude-3-5-sonnet-20241022",
- "testCoverage": 90,
- "codeStyle": "prettier",
- "documentation": "required"
- },
- "workflow": {
- "branching": "gitflow",
- "reviews": "required",
- "ciCd": "automated"
- }
- }
-}
-```
+> The `team` and `enterprise` top-level settings blocks that appeared here
+> earlier were illustrative-only and did not correspond to real
+> `settings.json` keys. Claude Code's enterprise surface uses separate
+> managed-settings files (`/etc/claude/settings.json` /
+> `/Library/Application Support/ClaudeCode/managed-settings.json`) plus
+> `disableBypassPermissionsMode`, not an inline `team`/`enterprise` object
+> with SOC2/ISO27001 compliance fields. They have been removed. See the
+> official IAM documentation at
+> https://code.claude.com/docs/en/iam for the real enterprise/managed
+> settings surface.
 
-Enterprise Policies:
-```json
-{
- "enterprise": {
- "policies": {
- "allowedModels": ["claude-3-5-sonnet-20241022"],
- "maxTokens": 100000,
- "restrictedTools": ["Bash", "WebFetch"],
- "auditRequired": true
- },
- "compliance": {
- "standards": ["SOC2", "ISO27001"],
- "dataResidency": "us-east-1",
- "retentionPolicy": "7y"
- }
- }
-}
-```
-
-This comprehensive reference provides all the information needed to configure Claude Code effectively for any use case, from personal development to enterprise deployment.
+This reference orients you to the categories of Claude Code configuration. For the authoritative and current schema — including fields added after this file was last reviewed — consult the official documentation at https://code.claude.com/docs/en/settings.

--- a/.claude/skills/moai-foundation-cc/reference/claude-code-sub-agents-official.md
+++ b/.claude/skills/moai-foundation-cc/reference/claude-code-sub-agents-official.md
@@ -78,7 +78,7 @@ Optional Fields:
 
 - model: Model alias (sonnet, opus, haiku) or 'inherit' to use same model as main conversation. If omitted, uses configured default (usually sonnet).
 
-- permissionMode: Controls permission handling. Valid values: `default`, `acceptEdits`, `dontAsk`, `bypassPermissions`, `plan`, `ignore`.
+- permissionMode: Controls permission handling. Valid values: `default`, `plan`, `acceptEdits`, `bypassPermissions` (these are the only real Claude Code permission modes). The earlier list also named `dontAsk` and `ignore` — those are NOT real Claude Code modes and have been removed. NOTE: the spawn-time `mode` parameter on `Task`/`Agent` is **deprecated and ignored since Claude Code v2.1.213** — subagents inherit the parent session's permission mode, and a parent in `bypassPermissions`/`acceptEdits` takes precedence and cannot be overridden. A spawned child's read-only scoping therefore rests on **tool restriction** (the inherently read-only `Explore`, or a `tools:` list omitting Write/Edit/NotebookEdit), never on the deprecated spawn-time `mode` parameter.
 
 - skills: Comma-separated list of skill names to auto-load when agent is invoked. Skills are NOT inherited from parent.
 

--- a/.claude/skills/moai-foundation-cc/reference/reference.md
+++ b/.claude/skills/moai-foundation-cc/reference/reference.md
@@ -6,7 +6,7 @@
 
 Frontmatter Fields:
 - `name` (required): Skill identifier in kebab-case, max 64 characters
-- `description` (required): One-line description, max 1024 characters
+- `description` (required): One-line description, max 1,536 characters (combined description + when_to_use)
 - `version`: Semantic version (e.g., "2.0.0")
 - `tools`: Comma-separated list of allowed tools
 - `modularized`: Boolean indicating modular file structure

--- a/.claude/skills/moai-foundation-cc/reference/skill-formatting-guide.md
+++ b/.claude/skills/moai-foundation-cc/reference/skill-formatting-guide.md
@@ -20,7 +20,7 @@ Core Format: YAML frontmatter + markdown content with progressive disclosure. Na
 ```yaml
 ---
 name: skill-name # Required: kebab-case, max 64 chars
-description: Specific description of skill purpose and trigger scenarios (max 1024 chars) # Required
+description: Specific description of skill purpose and trigger scenarios (max 1,536 chars combined description + when_to_use) # Required
 allowed-tools: tool1, tool2, tool3 # Optional: comma-separated, minimal set
 version: 1.0.0 # Optional: semantic versioning
 tags: [domain, category, purpose] # Optional: categorization
@@ -117,7 +117,7 @@ Examples:
 
 #### `description` (String)
 Format: Natural language description
-Length: Maximum 1024 characters
+Length: Maximum 1,536 characters (combined description + when_to_use)
 Content: What the skill does + specific trigger scenarios
 Examples:
 - `Extract and structure information from PDF documents for analysis and processing. Use when you need to analyze PDF content, extract tables, or convert PDF text to structured data.`
@@ -137,7 +137,9 @@ allowed-tools: Read, WebFetch
 # CORRECT: Multiple tools for analysis
 allowed-tools: Read, Grep, Glob, WebFetch
 
-# WRONG: YAML array format
+# AVOID in MoAI: YAML array format
+# (CSV is the MoAI convention; YAML arrays are also valid since v2.1.0,
+#  but MoAI standardizes on CSV for tool lists to match agent-authoring.md)
 allowed-tools: [Read, Grep, Glob]
 
 # WRONG: Overly permissive
@@ -408,7 +410,7 @@ examples.md (unlimited):
 
 Frontmatter Validation:
 - [ ] Name uses kebab-case (64 chars max)
-- [ ] Description specific and under 1024 chars
+- [ ] Description specific and under 1,536 chars (combined description + when_to_use)
 - [ ] allowed-tools follows principle of least privilege
 - [ ] YAML syntax valid (no parsing errors)
 - [ ] No deprecated or invalid fields
@@ -461,11 +463,12 @@ User Experience:
 
 Invalid Array Format:
 ```yaml
-# WRONG: YAML array syntax
-allowed-tools: [Read, Write, Bash]
-
-# CORRECT: Comma-separated string
+# MoAI convention: CSV string
 allowed-tools: Read, Write, Bash
+
+# Also valid since v2.1.0 (YAML array), but NOT the MoAI convention
+# for tool lists — agent-authoring.md standardizes on CSV:
+allowed-tools: [Read, Write, Bash]
 ```
 
 Missing Required Fields:

--- a/.claude/skills/moai-foundation-cc/reference/sub-agents/sub-agent-examples.md
+++ b/.claude/skills/moai-foundation-cc/reference/sub-agents/sub-agent-examples.md
@@ -1,8 +1,26 @@
 # Claude Code Sub-agents Examples Collection
 
+> **IMPORTANT — these are GENERIC Claude-Code-ecosystem illustrations, NOT
+> the MoAI retained agent catalog.** The tiered `{domain}-{role}` naming
+> used throughout this file (`code-backend`, `code-frontend`, `core-quality`,
+> `security-expert`, `workflow-ddd`, etc.) is a generic Claude-Code
+> authoring pattern shown here for teaching purposes. It does NOT describe
+> MoAI's shipped agents, and several of the names here (`security-expert`,
+> `core-quality`, etc.) collide with names that are **archived and MUST NOT
+> be spawned** in MoAI (see `CLAUDE.md §4 Archived Agents`).
+>
+> **For the real MoAI agent surface**, consult the flat 11-agent retained
+> catalog at
+> `../../moai-foundation-core/modules/agents-reference.md`
+> (10 MoAI-custom managers/auditors/builders/advisor/design/e2e + the
+> Anthropic built-in `Explore`). MoAI does NOT use the tiered
+> `{domain}-{role}` scheme; it uses a flat `manager-*` / `*-auditor` /
+> `builder-*` / `super-advisor` / `Explore` catalog with `Agent(general-purpose)`
+> per-spawn specialists carrying domain-specific instructions.
+
 Comprehensive collection of real-world sub-agent examples covering various domains, complexity levels, and specialization patterns, all following official Claude Code standards.
 
-Purpose: Practical examples and templates for sub-agent creation
+Purpose: Practical examples and templates for sub-agent creation (generic Claude-Code patterns — see header disclaimer above)
 Target: Sub-agent developers and Claude Code users
 Last Updated: 2025-11-25
 Version: 2.0.0
@@ -1179,7 +1197,7 @@ TDD Quality Gates:
 - [ ] Implementation passes all quality gates
 - [ ] Code follows established style guidelines
 - [ ] Performance benchmarks meet requirements
-- [ ] Security considerations are adddessed
+- [ ] Security considerations are addressed
 - [ ] Documentation is comprehensive and accurate
 
 ### Coverage Requirements

--- a/.claude/skills/moai-foundation-cc/reference/sub-agents/sub-agent-integration-patterns.md
+++ b/.claude/skills/moai-foundation-cc/reference/sub-agents/sub-agent-integration-patterns.md
@@ -110,12 +110,17 @@ def parallel_workflow(project_requirements):
  """Execute parallel sub-agent workflow.
 
  Note: In Claude Code, calling multiple Agent() in a single response
- will automatically execute them in parallel (up to 10 concurrent).
+ will automatically execute them in parallel. The runtime concurrency
+ cap is `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS` (default 20;Claude
+ Code v2.1.217+), NOT 10 — the earlier "up to 10" figure was stale.
+ MoAI's own orchestrator ceiling is 3-5 concurrent `Agent()` calls
+ (Mode 4) regardless of the runtime cap.
  No need for asyncio.gather or Promise.all.
  """
 
  # Call multiple Agent() for automatic parallel execution
- # Claude Code executes up to 10 Tasks concurrently
+ # Runtime cap: CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS (default 20);
+ # MoAI orchestrator ceiling: 3-5 concurrent Agent() calls.
  frontend_design = Agent(
  subagent_type="code-frontend",
  prompt="Design frontend architecture",
@@ -285,6 +290,15 @@ tools: Read, Write, Edit, Agent
 model: sonnet
 skills: moai-core-workflow, moai-project-manager, moai-foundation-quality
 ---
+
+# NOTE — this is a GENERIC Claude-Code illustration, NOT a MoAI retained
+# agent. A MoAI retained agent MUST omit `Agent` from its `tools:` list
+# (flat-hierarchy guarantee — subagents cannot spawn other subagents;
+# see CLAUDE.md §4 Watch note). The `Agent` entry in `tools:` above is
+# shown only because this file documents generic Claude-Code ecosystem
+# patterns; do not copy this frontmatter into a real MoAI agent file.
+# Real MoAI orchestration is done by the main-session orchestrator
+# (the `Agent` tool is main-session-only), not by a subagent.
 
 # Development Orchestrator
 

--- a/.claude/skills/moai-foundation-core/modules/delegation-advanced.md
+++ b/.claude/skills/moai-foundation-core/modules/delegation-advanced.md
@@ -2,6 +2,19 @@
 
 Purpose: Error handling, recovery strategies, and hybrid delegation patterns for complex workflows.
 
+> **Illustrative pseudocode.** The Python `Agent(subagent_type=...)`
+> literals in this file are pseudocode showing flow and retry/recovery
+> shape, NOT runnable code. In practice, MoAI invokes retained agents
+> (`manager-spec`, `manager-develop`, `manager-docs`, etc.) through
+> **natural-language delegation** ("Use the {agent} subagent to {task}"),
+> never a `subagent_type` code literal — see
+> [delegation-patterns.md](delegation-patterns.md) § Note + the flat
+> 11-agent catalog in [agents-reference.md](agents-reference.md). Per-spawn
+> `general-purpose` (with domain instructions in the prompt) is the
+> canonical mechanism for cross-cutting domain work; legacy tiered names
+> (`code-backend`, `security-expert`, `core-quality`, etc.) are archived
+> and rejected at spawn.
+
 Version: 1.0.0
 Last Updated: 2026-01-06
 Parent: [delegation-patterns.md](delegation-patterns.md)

--- a/.claude/skills/moai-foundation-core/modules/delegation-implementation.md
+++ b/.claude/skills/moai-foundation-core/modules/delegation-implementation.md
@@ -2,6 +2,19 @@
 
 Purpose: Detailed implementation patterns for agent delegation including context optimization and workflow examples.
 
+> **Illustrative pseudocode.** The Python `Agent(subagent_type=...)`
+> literals in this file are pseudocode showing context-passing shape,
+> NOT runnable code. In practice, MoAI invokes retained agents
+> (`manager-spec`, `manager-develop`, `manager-docs`, etc.) through
+> **natural-language delegation** ("Use the {agent} subagent to {task}"),
+> never a `subagent_type` code literal — see
+> [delegation-patterns.md](delegation-patterns.md) § Note + the flat
+> 11-agent catalog in [agents-reference.md](agents-reference.md). Per-spawn
+> `general-purpose` (with domain instructions in the prompt) is the
+> canonical mechanism for cross-cutting domain work; legacy tiered names
+> (`code-backend`, `security-expert`, `core-quality`, etc.) are archived
+> and rejected at spawn.
+
 Version: 1.0.0
 Last Updated: 2026-01-06
 Parent: [delegation-patterns.md](delegation-patterns.md)

--- a/.claude/skills/moai-foundation-core/modules/token-optimization.md
+++ b/.claude/skills/moai-foundation-core/modules/token-optimization.md
@@ -1,6 +1,30 @@
 # Token Optimization - Budget Management
 
-Purpose: Efficient 200K token budget management through strategic context loading, phase separation, and model selection for cost-effective AI development.
+> **Illustrative pseudocode AND model-specific budget pointer.** The
+> Python `Agent(subagent_type=...)` and class literals below are
+> pseudocode showing budget-tracking shape, NOT runnable code. MoAI
+> invokes retained agents (`manager-spec`, `manager-develop`,
+> `manager-docs`, etc.) through **natural-language delegation** ("Use the
+> {agent} subagent to {task}"), never a `subagent_type` code literal — see
+> [delegation-patterns.md](delegation-patterns.md) § Note + the flat
+> 11-agent catalog in [agents-reference.md](agents-reference.md).
+>
+> **The hard-coded "200K token budget" / "Phase 2: DDD 180K" /
+> `clear_threshold = 150000` figures below are ILLUSTRATIVE DEFAULTS for a
+> 200K-context model class.** Real budgets are **model-specific**: 1M-context
+> models (Opus 5, Opus 4.8, GLM-5.2) hand off at **50%** (~500K tokens);
+> 200K/256K models (Sonnet/Haiku/Fable) hand off at **90%** (~180K/~230K).
+> The authoritative per-model threshold table is
+> `.claude/rules/moai/workflow/context-window-management.md` § Context
+> Window Targets — consult it before applying any figure below. The
+> `sonnet-4.5` / `haiku-4.5` `model_selection` config shown later in this
+> file is RETIRED in favor of **effort-routing** (`effortLevel`:
+> low/medium/high/xhigh/max per agent role — see
+> `.claude/rules/moai/development/agent-authoring.md` § Effort-Level
+> Calibration Matrix); the cost-lever is now effort, not a hardcoded
+> sonnet/haiku model swap.
+
+Purpose: Efficient token-budget management through strategic context loading, phase separation, and effort-routing for cost-effective AI development.
 
 Version: 1.0.0
 Last Updated: 2025-11-25
@@ -9,22 +33,28 @@ Last Updated: 2025-11-25
 
 ## Quick Reference (30 seconds)
 
-Token Budget: 200K per feature (250K with overhead)
+> The figures below assume a 200K-context model class. For 1M-context
+> models (Opus 5 / Opus 4.8 / GLM-5.2) the handoff threshold is 50%
+> (~500K tokens), NOT 90% — see context-window-management.md § Context
+> Window Targets for the authoritative per-model table.
 
-Phase Allocation:
+Token Budget: model-class-dependent (200K class: ~200K per feature, ~250K with overhead; 1M class: ~500K ceiling at the 50% handoff threshold)
+
+Phase Allocation (200K-class illustration; scale proportionally for 1M-class):
 - SPEC Generation: 30K tokens
 - DDD Implementation: 180K tokens
 - Documentation: 40K tokens
 
 /clear Execution Rules:
 1. Immediately after /moai plan (saves 45-50K)
-2. When context > 150K tokens
+2. When context crosses the model-specific handoff threshold (200K class: 90% / ~150K-180K; 1M class: 50% / ~500K) — see context-window-management.md § Context Window Targets for the SSOT
 3. After 50+ conversation messages
 
-Model Selection:
-- Sonnet 4.5: Quality-critical (SPEC, security)
-- Haiku 4.5: Speed/cost (simple edits, tests)
-- Cost savings: 60-70% with strategic Haiku use
+Effort Routing (replaces the retired sonnet/haiku model_selection):
+- xhigh / max: Quality-critical (SPEC authoring, security review, Opus-tier reasoning)
+- high: Default for run-phase implementation
+- medium / low: Speed/cost (simple edits, tests, mechanical sweeps)
+- See agent-authoring.md § Effort-Level Calibration Matrix for the per-agent default
 
 Context Optimization:
 - Target: 20-30K tokens per agent

--- a/.claude/skills/moai-foundation-quality/modules/integration-patterns.md
+++ b/.claude/skills/moai-foundation-quality/modules/integration-patterns.md
@@ -90,16 +90,24 @@ When the gate or review surfaces a cluster of fixable issues:
 reached without full resolution — surface that verdict rather than
 silently stopping.
 
-## Team Mode Quality
+## Team Mode Quality (native Claude Code teammate runtime — CG Mode)
 
-In Agent Teams mode (experimental), two hooks enforce quality:
+The native Claude Code teammate runtime (the `moai cg` GLM panes + `moai cc -w
+<name> --spawn` surface — see CLAUDE.md §15 CG Mode) binds two hooks that
+enforce per-teammate quality:
 
 - **TeammateIdle hook** — validates a teammate's work before accepting idle
   state. If LSP errors exceed the threshold, the teammate is kept working.
 - **TaskCompleted hook** — validates deliverables before completion.
 
-These are the team-mode equivalents of the gate, applied per-teammate. See
-the spec-workflow rule for the full team-quality contract.
+These are the teammate-runtime equivalents of the gate, applied per-teammate.
+They bind the **native Claude Code teammate runtime**, which is DISTINCT from
+the RETIRED MoAI static Agent Teams layer (Mode 3 `agent-team` — a Phase 0.95
+tombstone since the static layer was retired; `--team` / `--mode team` emits
+`MODE_TEAM_UNAVAILABLE` and falls back to sub-agent mode). Do not conflate
+the two: the native teammate runtime is live (CG Mode), the static Agent
+Teams layer is retired. See the spec-workflow rule for the full team-quality
+contract.
 
 ## What NOT to Do
 

--- a/.claude/skills/moai-foundation-thinking/SKILL.md
+++ b/.claude/skills/moai-foundation-thinking/SKILL.md
@@ -192,7 +192,8 @@ Agent Teams:
 
 Agents:
 - manager-spec: Combined with Philosopher for full decision framework (planning absorbs strategic analysis)
-- manager-spec: Deep Questioning during requirement analysis
+- manager-develop: Deep Questioning + Critical Evaluation during run-phase reasoning (DDD/TDD root-cause analysis, architecture trade-offs)
+- super-advisor: E1-E4 escalation reasoning (bug-deadlock diagnosis, architecture decision points, second-opinion consultation, loop-deadlock verdicts)
 - team-reader (analyst role): Primary consumer for plan phase analysis
 - team-reader (researcher role): Comprehensive research methodology
 

--- a/.claude/skills/moai-meta-harness/references/agent-cross-references.md
+++ b/.claude/skills/moai-meta-harness/references/agent-cross-references.md
@@ -18,7 +18,7 @@ This skill orchestrates but does NOT replace existing agents. All named agents b
 ## Builders
 
 - `builder-harness` (artifact_type=agent) — Generates `.claude/agents/harness/*.md` content
-- `builder-harness` (artifact_type=skill) — Generates `.claude/skills/moai-harness-*/SKILL.md` content
+- `builder-harness` (artifact_type=skill) — Generates **`hns-*`** skill content under the user-owned harness namespace (per the Skills Namespace Policy in `.claude/rules/moai/development/skill-authoring.md` § Skills Namespace Policy and this skill's own SKILL.md § Namespace Separation). The `hns-*` prefix is the ONLY per-project skill namespace `builder-harness` emits; emitting under `moai-harness-*` (or any other `moai-*` prefix) inverts the namespace contract — `moai-harness-*` is template-managed and currently comprises only `moai-harness-learner` (plus the deprecated legacy-redirect `moai-meta-harness`), never per-project artifacts.
 - `builder-harness` (artifact_type=plugin) — Optional plugin bundling of generated artifacts
 
 ## Workflow Managers

--- a/.claude/skills/moai-workflow-ci-loop/SKILL.md
+++ b/.claude/skills/moai-workflow-ci-loop/SKILL.md
@@ -107,7 +107,7 @@ rename. Schema source: the CI-watch handoff struct.
 **OQ2 cadence matrix** (single source of truth for iteration behavior):
 
 - iter 1, any mechanical sub_class → confirm + apply via AskUserQuestion (1st option =
-  "패치 적용 (권장)").
+  "Apply patch (Recommended)").
 - iter 1, semantic/unknown → escalate (no patch attempt) via AskUserQuestion with
   diagnosis report.
 - iter 2-3, mechanical + sub_class=trivial → silent apply + log (no AskUserQuestion).
@@ -123,9 +123,9 @@ rename. Schema source: the CI-watch handoff struct.
 `scripts/ci-watch/run.sh` to restart the watch loop.
 
 **Iteration 4+ escalation** (mandatory blocking, no silent timeout):
-1. (권장) 직접 수동 수정 — investigate and fix manually
-2. SPEC 수정 — revise the SPEC and restart implementation
-3. PR 포기 — close the PR and abandon this approach
+1. (Recommended) Manual fix — investigate and fix manually
+2. Revise SPEC — revise the SPEC and restart implementation
+3. Abandon PR — close the PR and abandon this approach
 
 **`manager-develop` (cycle_type=autofix) spawn prompt** injects: handoff JSON, classification + sub_class,
 failed CI log + PR diff, mode directive (mechanical → propose unified-diff patch;
@@ -169,10 +169,10 @@ fallback); `scripts/ci-autofix/log-fetch.sh` (failure log + PR diff);
 
 - "Skip watch loop for small PRs" — small PRs fail CI too. Loop costs nothing, saves manual polling.
 - "Auxiliary failures should block merge" — advisory by SSoT definition. Edit `required-checks.yml` to change classification.
-- "semantic 실패도 auto-patch 시도해보자" — semantic failures (race, assertion) cannot be auto-patched without context; wrong patch is worse.
-- "force-push로 히스토리 정리하면 깔끔하다" — force-push destroys reviewer diff visibility. Always a new commit.
-- "iter 3 이후 timeout" — silent timeout prohibited; user must decide explicitly.
-- "trivial fix는 confirm 없이 바로 적용하자" — iter 1 always confirms; iter 2+ trivial may silent apply.
+- "Try auto-patching even semantic failures" — semantic failures (race, assertion) cannot be auto-patched without context; wrong patch is worse.
+- "Clean up history with force-push" — force-push destroys reviewer diff visibility. Always a new commit.
+- "Time out after iter 3" — silent timeout prohibited; user must decide explicitly.
+- "Apply trivial fixes without confirming" — iter 1 always confirms; iter 2+ trivial may silent apply.
 
 ## Red Flags
 
@@ -190,7 +190,7 @@ fallback); `scripts/ci-autofix/log-fetch.sh` (failure log + PR diff);
 - [ ] `go test ./internal/ciwatch/... ./internal/cli/pr/... -race` passes
 - [ ] `internal/ciwatch/` coverage >= 85%
 - [ ] No ANSI codes in `FormatStatusUpdate()` output
-- [ ] `EmitReadyToMergeReport` first option carries `(권장)`
+- [ ] `EmitReadyToMergeReport` first option carries `(Recommended)`
 - [ ] CLI does NOT call AskUserQuestion
 - [ ] `grep -r 'push -f\|push --force' scripts/ci-autofix/ scripts/ci-watch/` returns no matches
 - [ ] Audit log `.moai/logs/ci-autofix/<PR>-<DATE>.md` contains every iteration

--- a/.claude/skills/moai-workflow-ddd/SKILL.md
+++ b/.claude/skills/moai-workflow-ddd/SKILL.md
@@ -55,12 +55,12 @@ When to Use DDD:
 - Technical debt reduction in production systems
 - API migration and deprecation handling
 - Code modernization projects
-- When DDD is not applicable because code already exists
 - Greenfield projects (with adapted cycle - see below)
 
 When NOT to Use DDD:
 
 - When behavior changes are required (modify SPEC first)
+- When the code already exists and the goal is behavior change rather than behavior-preserving refactoring (DDD preserves behavior; for new behavior, modify the SPEC first, or use TDD)
 
 Greenfield Project Adaptation:
 

--- a/.claude/skills/moai-workflow-ddd/SKILL.md
+++ b/.claude/skills/moai-workflow-ddd/SKILL.md
@@ -389,7 +389,6 @@ When DDD session encounters issues:
 
 Version: 1.0.0
 Status: Active
-Last Updated: 2026-01-16
 
 <!-- moai:evolvable-start id="rationalizations" -->
 ## Common Rationalizations

--- a/.claude/skills/moai-workflow-project/SKILL.md
+++ b/.claude/skills/moai-workflow-project/SKILL.md
@@ -23,7 +23,7 @@ metadata:
   modularized: "true"
   tags: "workflow, project, documentation, initialization, templates, boilerplate, scaffolding, jit-docs, docs-generation"
   aliases: "moai-workflow-project"
-  related-skills: "moai-workflow-templates, moai-docs-generation, moai-workflow-jit-docs"
+  related-skills: "moai-workflow-spec, moai-workflow-docs-claim-check"
 
 # MoAI Extension: Progressive Disclosure
 progressive_disclosure:

--- a/.claude/skills/moai-workflow-project/references/reference.md
+++ b/.claude/skills/moai-workflow-project/references/reference.md
@@ -4,43 +4,45 @@ Progressive Disclosure Level 2: Extended documentation for advanced users and in
 
 ---
 
-## API Reference
+## Design Surface (language-neutral contracts)
 
-### Core Classes
+This skill is delivered as a distributed Go binary plus embedded templates (no Python surface exists in the repository). The capabilities below are described as design contracts — the runtime that exposes them is the Go `moai` CLI, invoked through slash commands and `moai` subcommands. Treat this section as a capability map, not an importable API.
 
-MoaiMenuProject:
-- Purpose: Unified interface for all project management operations
-- Initialization: `MoaiMenuProject(project_path: str)`
-- Primary Methods:
-  - `initialize_complete_project(language, user_name, domains, project_type, optimization_enabled)` - Full project setup
-  - `generate_documentation_from_spec(spec_data)` - SPEC-driven doc generation
-  - `optimize_project_templates(options)` - Template optimization
-  - `get_project_status()` - Comprehensive status report
-  - `update_language_settings(settings)` - Language configuration update
+### Capabilities
 
-DocumentationManager:
+Project lifecycle:
+- Purpose: Unified surface for project management operations
+- Entry: `moai init <project>` / `moai project` (CLI), `/moai project` (slash command)
+- Operations:
+  - Complete project setup — documentation scaffolding, language init, template optimization
+  - SPEC-driven doc generation — produce documentation from a SPEC artifact
+  - Template optimization — analyze and refine embedded templates
+  - Project status report — comprehensive state summary
+  - Language configuration update — conversation / agent-prompt / docs / code-comment language
+
+Documentation generation:
 - Purpose: Template-based documentation generation
-- Key Methods:
-  - `generate_docs(project_type, language)` - Generate documentation set
-  - `update_docs_from_spec(spec_data)` - Update from SPEC data
-  - `export_docs(format, language)` - Multi-format export (md, html, pdf)
-  - `detect_project_type()` - Auto-detect project type
+- Operations:
+  - Generate documentation set for a detected project type and language
+  - Update documentation from SPEC data
+  - Multi-format export (md, html, pdf)
+  - Auto-detect project type from project markers
 
-LanguageInitializer:
+Language initialization:
 - Purpose: Language detection and configuration
-- Key Methods:
-  - `detect_project_language()` - Analyze project for language
-  - `create_multilingual_documentation_structure(language)` - Setup multilingual docs
-  - `localize_agent_prompts(base_prompt, language)` - Prompt localization
-  - `calculate_token_cost_impact(language)` - Token cost analysis
+- Operations:
+  - Detect project language from project markers
+  - Set up multilingual documentation structure
+  - Localize agent prompts for a configured language
+  - Token-cost-impact analysis per language
 
-TemplateOptimizer:
+Template optimization:
 - Purpose: Template analysis and optimization
-- Key Methods:
-  - `analyze_project_templates()` - Comprehensive template analysis
-  - `create_optimized_templates(options)` - Apply optimizations
-  - `create_backup()` - Create template backup
-  - `restore_from_backup(backup_id)` - Restore from backup
+- Operations:
+  - Comprehensive template analysis
+  - Apply optimizations (size / performance / complexity)
+  - Backup templates before mutation
+  - Restore templates from a backup
 
 ---
 
@@ -98,92 +100,40 @@ Supported Languages with Token Impact:
 
 ### Pattern 1: SPEC-Driven Documentation Workflow
 
-```python
-# Integration with /moai plan and /moai sync
-from moai_workflow_project import MoaiMenuProject
+Integration with `/moai plan` and `/moai sync` (language-neutral sequence):
 
-# Initialize project system
-project = MoaiMenuProject("/path/to/project")
+1. `/moai plan "..."` generates a SPEC artifact under `.moai/specs/SPEC-XXX/`.
+2. The orchestrator reads the SPEC and emits the documentation scaffolding via `/moai project`:
+   - Feature documentation with the SPEC's requirements
+   - API documentation with endpoint details (when applicable)
+   - Architecture documentation
+   - Multilingual versions when the project configures multiple documentation languages
+3. `/moai sync SPEC-XXX` refreshes docs and opens the PR.
 
-# After /moai plan generates SPEC
-spec_data = load_spec("SPEC-001")
+### Pattern 2: CI/CD Documentation Gate
 
-# Generate documentation from SPEC
-docs_result = project.generate_documentation_from_spec(spec_data)
+Run a documentation-completeness check in CI as a non-blocking advisory (no Python helper required):
 
-# Automatically creates:
-# - Feature documentation with requirements
-# - API documentation with endpoint details
-# - Architecture documentation
-# - Multilingual versions if configured
-```
-
-### Pattern 2: CI/CD Integration
-
-```python
-# Integration with GitHub Actions or similar
-from moai_workflow_project import MoaiMenuProject
-
-def ci_documentation_check(project_path: str) -> dict:
-    """Run documentation validation in CI pipeline."""
-    project = MoaiMenuProject(project_path)
-
-    # Get current documentation status
-    status = project.get_project_status()
-
-    # Validate completeness
-    validation_result = {
-        "docs_complete": status.documentation_completion >= 0.9,
-        "language_configured": status.language_configured,
-        "templates_optimized": status.templates_optimized,
-        "warnings": status.warnings,
-        "errors": status.errors
-    }
-
-    return validation_result
-```
+- Step 1: `moai project --status` emits a machine-readable status summary (docs completion, language configured, templates optimized, warnings, errors).
+- Step 2: A CI step parses the summary and annotates the run when `docs_completion` is below the project's threshold or any error is present.
+- Step 3: Treat the check as advisory (warn-on-failure) — documentation drift should not gate a build.
 
 ### Pattern 3: Multi-Project Template Sharing
 
-```python
-# Share optimized templates across projects
-from moai_workflow_project import TemplateOptimizer
+Optimized templates live in the distributed binary's embedded FS plus the per-project `.moai/` tree; share them via version control, not a runtime API:
 
-# Optimize master templates
-master_optimizer = TemplateOptimizer("/templates/master")
-optimized = master_optimizer.create_optimized_templates({
-    "backup_first": True,
-    "apply_all_optimizations": True
-})
-
-# Deploy to multiple projects
-for project_path in project_list:
-    project = MoaiMenuProject(project_path)
-    project.import_templates(optimized.templates)
-```
+1. Author canonical templates in the source repo (the SSOT).
+2. Other projects consume them through `moai update` (re-render from the embedded catalog) or by vendoring the relevant `.moai/` files.
+3. Backup-then-mutate: `moai update` preserves user-owned content (`hns-*` skills, project memory, specs) per the namespace separation contract — only template-managed surfaces are re-rendered.
 
 ### Pattern 4: Language-Aware Agent Delegation
 
-```python
-# Integrate with MoAI's delegation patterns
-def delegate_with_language_context(task: str, language: str):
-    """Delegate task with proper language context."""
-    project = MoaiMenuProject(".")
+When delegating to a sub-agent, the orchestrator passes the active `conversation_language` and `agent_prompt_language` (read from `.moai/config/sections/language.yaml`) in the spawn prompt. There is no library call — the delegation surface is the `Agent()` tool:
 
-    # Get localized prompt
-    localized_task = project.language_initializer.localize_agent_prompts(
-        base_prompt=task,
-        language=language
-    )
-
-    # Token cost analysis
-    cost_impact = project.language_initializer.calculate_token_cost_impact(language)
-
-    return {
-        "localized_task": localized_task,
-        "estimated_token_overhead": cost_impact
-    }
-```
+1. Resolve the active language settings from `language.yaml`.
+2. Compose the spawn prompt in `agent_prompt_language` (English by default for cost control).
+3. Inject the user's `conversation_language` so the agent's user-facing output respects it.
+4. The token-cost overhead for non-English `conversation_language` follows the table in § Language Configuration Presets (Korean/Japanese/Chinese carry a measurable overhead; English is the baseline).
 
 ---
 
@@ -193,41 +143,39 @@ def delegate_with_language_context(task: str, language: str):
 
 Issue: Documentation generation fails with template not found:
 - Cause: Template directory missing or corrupted
-- Solution: Run `project.template_optimizer.restore_from_backup()` or reinstall templates
-- Prevention: Always enable `backup_first` option before optimization
+- Solution: Re-run `moai update` to re-render templates from the embedded catalog, or restore the project's `.moai/` files from version control
+- Prevention: Keep `.moai/` under version control so template state is recoverable
 
 Issue: Language detection returns incorrect language:
 - Cause: Insufficient language indicators in project files
-- Solution: Manually set language in configuration: `project.update_language_settings({"language.conversation_language": "ko"})`
-- Prevention: Include language comments in main source files
+- Solution: Manually set the language in `.moai/config/sections/language.yaml` (`conversation_language: ko`)
+- Prevention: Include language-revealing comments / config markers in main source files
 
 Issue: Template optimization causes functionality loss:
 - Cause: Aggressive optimization removed necessary content
-- Solution: Restore from backup: `project.template_optimizer.restore_from_backup(backup_id)`
-- Prevention: Set `preserve_functionality: True` in optimization options
+- Solution: Restore `.moai/` templates from version control (the prior commit)
+- Prevention: Run optimization on a branch and verify behavior before merging
 
 Issue: Multilingual documentation structure incomplete:
 - Cause: Partial initialization or interrupted process
-- Solution: Re-run `project.language_initializer.create_multilingual_documentation_structure(language)`
-- Prevention: Ensure stable connection during initialization
+- Solution: Re-run `/moai project` to complete the documentation scaffolding
+- Prevention: Ensure the process runs to completion; resume from `.moai/specs/<SPEC>/progress.md` after an interrupt
 
 Issue: High token cost for non-English languages:
 - Cause: Localized agent prompts increase token usage
-- Solution: Use `agent_prompt_language: "english"` with `conversation_language: "ko"` for cost optimization
+- Solution: Use `agent_prompt_language: en` with `conversation_language: ko` for cost optimization
 - Prevention: Configure language settings before heavy usage
 
 ### Diagnostic Commands
 
-```python
+The diagnostic surface is the `moai` CLI, not a Python API. Run the status command and read its output:
+
+```bash
 # Full diagnostic report
-status = project.get_project_status()
-print(f"Initialization: {status.initialization_complete}")
-print(f"Language: {status.language_configuration}")
-print(f"Documentation: {status.documentation_completion}%")
-print(f"Templates: {status.template_status}")
-print(f"Errors: {status.errors}")
-print(f"Warnings: {status.warnings}")
+moai project --status
 ```
+
+The report surfaces: initialization state, language configuration, documentation completion %, template status, errors, and warnings.
 
 ### Log Locations
 
@@ -249,9 +197,8 @@ print(f"Warnings: {status.warnings}")
 
 - moai-foundation-core - Core execution patterns and SPEC workflow
 - moai-foundation-cc - Claude Code integration patterns
-- moai-workflow-docs - Unified documentation management
-- moai-workflow-templates - Template optimization strategies
-- moai-library-nextra - Advanced documentation architecture
+- moai-workflow-spec - SPEC workflow orchestration (plan / run / sync)
+- moai-workflow-docs-claim-check - README / public-docs claim validation
 
 ### Template Resources
 

--- a/.claude/skills/moai-workflow-project/references/reference.md
+++ b/.claude/skills/moai-workflow-project/references/reference.md
@@ -218,5 +218,4 @@ The report surfaces: initialization state, language configuration, documentation
 ---
 
 Status: Reference Documentation Complete
-Last Updated: 2025-12-06
 Skill Version: 2.0.0

--- a/.claude/skills/moai-workflow-project/schemas/config-schema.json
+++ b/.claude/skills/moai-workflow-project/schemas/config-schema.json
@@ -144,9 +144,9 @@
         },
         "template_engine": {
           "type": "string",
-          "enum": ["jinja2", "handlebars", "mustache"],
-          "default": "jinja2",
-          "description": "Template engine for documentation generation"
+          "enum": ["gotemplate", "jinja2", "handlebars", "mustache"],
+          "default": "gotemplate",
+          "description": "Template engine for documentation generation (pick whichever the project's implementation language favors; the distributed MoAI runtime uses Go text/template)"
         },
         "output_directory": {
           "type": "string",
@@ -280,23 +280,19 @@
           "default": true,
           "description": "Initialize Git repository"
         },
-        "create_virtual_env": {
-          "type": "boolean",
-          "default": true,
-          "description": "Create Python virtual environment"
-        },
         "license_template": {
           "type": "string",
           "description": "Default license template"
         },
         "package_managers": {
           "type": "object",
+          "description": "Per-language package manager selection. All entries are opt-in (default disabled); MoAI auto-detects the project's language(s) from project markers (go.mod, package.json, pyproject.toml, Cargo.toml, etc.) and only proposes installation when the matching marker is present.",
           "properties": {
             "python": {
               "type": "object",
               "properties": {
-                "enabled": {"type": "boolean", "default": true},
-                "tool": {"type": "string", "enum": ["pip", "poetry", "pipenv"], "default": "pip"}
+                "enabled": {"type": "boolean", "default": false},
+                "tool": {"type": "string", "enum": ["pip", "poetry", "pipenv", "uv"], "default": "pip"}
               }
             },
             "node": {
@@ -304,6 +300,20 @@
               "properties": {
                 "enabled": {"type": "boolean", "default": false},
                 "tool": {"type": "string", "enum": ["npm", "yarn", "pnpm"], "default": "npm"}
+              }
+            },
+            "go": {
+              "type": "object",
+              "properties": {
+                "enabled": {"type": "boolean", "default": false},
+                "tool": {"type": "string", "enum": ["go"], "default": "go"}
+              }
+            },
+            "rust": {
+              "type": "object",
+              "properties": {
+                "enabled": {"type": "boolean", "default": false},
+                "tool": {"type": "string", "enum": ["cargo"], "default": "cargo"}
               }
             }
           }

--- a/.claude/skills/moai-workflow-project/templates/doc-templates/product-template.md
+++ b/.claude/skills/moai-workflow-project/templates/doc-templates/product-template.md
@@ -1,7 +1,7 @@
-# yoda - Mission & Strategy
+# {{PROJECT_NAME}} - Mission & Strategy
 
 ## What problem do we solve?
-AI-powered content generation platform for educators and authors
+{{PROJECT_DESCRIPTION}}
 
 ## Who are our users?
 - Primary users: {{PRIMARY_USERS}}

--- a/.claude/skills/moai-workflow-project/templates/doc-templates/structure-template.md
+++ b/.claude/skills/moai-workflow-project/templates/doc-templates/structure-template.md
@@ -1,4 +1,4 @@
-# yoda - System Architecture
+# {{PROJECT_NAME}} - System Architecture
 
 ## Overall Design Pattern
 {{ARCHITECTURE_PATTERN}}

--- a/.claude/skills/moai-workflow-project/templates/doc-templates/tech-template.md
+++ b/.claude/skills/moai-workflow-project/templates/doc-templates/tech-template.md
@@ -1,4 +1,4 @@
-# yoda - Technology Stack
+# {{PROJECT_NAME}} - Technology Stack
 
 ## Programming Languages
 {{PROGRAMMING_LANGUAGES}}

--- a/.claude/skills/moai-workflow-spec/references/ears-deep-dive.md
+++ b/.claude/skills/moai-workflow-spec/references/ears-deep-dive.md
@@ -32,17 +32,19 @@ Test strategy: Event simulation with expected response verification. Trigger the
 
 ## State-Driven Requirements — Conditional Behavior
 
-Format: "IF condition is true THEN action executes"
+Format: "**While** <state>, the <subject> shall <behavior>"
 
 Use case: Access control, state machines, conditional business logic.
 
 Examples:
 
-- Account status checks (IF active THEN allow login)
-- Inventory verification (IF stock > 0 THEN allow purchase)
-- Permission checks (IF admin role THEN show admin panel)
+- Account status checks (WHILE the account is active, the system shall allow login)
+- Inventory verification (WHILE stock > 0, the system shall allow purchase)
+- Permission checks (WHILE the user holds the admin role, the system shall show the admin panel)
 
 Test strategy: State setup with conditional behavior verification. Set up each state, verify the conditional branch.
+
+> **IF/THEN deprecated callout**: An earlier version of this guide described state-conditioned behavior as `IF <condition> THEN <action>`. That modality is **deprecated** under GEARS (the canonical SPEC notation as of v3.0.0). State-conditioned behavior is authored with the **While** form above; event-conditioned behavior that used to be written as `IF/THEN` is authored with the `When <event-detected>` form (see the Event-Driven section above). The lint engine emits a `LegacyEARSKeyword` finding on residual `IF/THEN` in new SPECs. See the SKILL.md IF/THEN deprecated callout for the full rationale and the backward-compatibility window.
 
 ## Unwanted Requirements — Prohibited Actions
 

--- a/.claude/skills/moai-workflow-spec/references/reference.md
+++ b/.claude/skills/moai-workflow-spec/references/reference.md
@@ -281,11 +281,14 @@ Technical:
 - Examples: "User Authentication System", "Payment Processing API"
 
 **Status Values**:
-- Planned: SPEC created, not yet started
-- In Progress: Implementation in RUN phase
-- Completed: All success criteria met
-- Blocked: Waiting for dependency or decision
-- Deprecated: Replaced by newer SPEC
+
+The `status` field uses the canonical 8-value enum owned by `.claude/rules/moai/development/spec-frontmatter-schema.md` § Status Enum (8 values). The list below is illustrative only; when it diverges from the schema SSOT, the schema wins.
+
+- Canonical enum (8 values): `draft`, `planned` (legacy-optional), `in-progress`, `implemented`, `completed`, `superseded`, `archived`, `rejected`
+- Active V3R6 flow: `draft → in-progress → implemented → completed` (manager-develop performs `draft → in-progress` on the first run-phase commit)
+- Terminal states: `superseded` (replaced by a newer SPEC), `archived`, `rejected`
+
+> The legacy 5-value list that previously appeared here (`Planned / In Progress / Completed / Blocked / Deprecated`) is superseded. `Blocked` and `Deprecated` are NOT members of the canonical enum — a blocked SPEC stays at its current status and surfaces the blocker through other channels, and a replaced SPEC uses `superseded`. See the schema SSOT for the authoritative list and the Status Transition Ownership Matrix.
 
 **Priority Levels**:
 - High: Critical for MVP, blocking dependencies
@@ -628,7 +631,9 @@ Full Stack Feature Complete
 
 ### Token Budget Management
 
-**PLAN Phase Token Usage** (~30% of 200K):
+The per-phase token shares below are fractions of the model's context window. The window is **model-class-dependent** — 200K for Sonnet/Opus-standard and Haiku, 256K for Fable, 1M for Opus 5 / Opus 4.8 / GLM-5.2. Treat "the budget" as the model-class threshold from `.claude/rules/moai/workflow/context-window-management.md` § Context Window Targets, NOT a fixed 200K. A 1M-context model tolerates a proportionally larger absolute spend before the `/clear` handoff threshold fires.
+
+**PLAN Phase Token Usage** (~30% of the active window):
 - User input analysis: 5K tokens
 - Requirement clarification dialogue: 15K tokens
 - EARS pattern generation: 10K tokens
@@ -638,7 +643,7 @@ Full Stack Feature Complete
 
 **Strategy**: Execute /clear after SPEC document saved to disk
 
-**RUN Phase Token Usage** (~60% of 200K):
+**RUN Phase Token Usage** (~60% of the active window):
 - SPEC document loading: 5K tokens
 - DDD cycle execution: 100K tokens
 - Code generation: 20K tokens
@@ -646,7 +651,7 @@ Full Stack Feature Complete
 - Quality validation: 10K tokens
 - Buffer: 30K tokens
 
-**SYNC Phase Token Usage** (~10% of 200K):
+**SYNC Phase Token Usage** (~10% of the active window):
 - Documentation generation: 10K tokens
 - API spec updates: 5K tokens
 - Commit message generation: 2K tokens

--- a/.claude/skills/moai-workflow-spec/references/reference.md
+++ b/.claude/skills/moai-workflow-spec/references/reference.md
@@ -731,4 +731,3 @@ The per-phase token shares below are fractions of the model's context window. Th
 ---
 
 Version: 1.0.0
-Last Updated: 2025-12-07

--- a/.claude/skills/moai-workflow-testing/modules/automated-code-review.md
+++ b/.claude/skills/moai-workflow-testing/modules/automated-code-review.md
@@ -5,6 +5,8 @@
 > Time: 35+ minutes
 > Dependencies: static analyzers for your language, WebSearch/WebFetch (optional)
 
+> **TRUST 5 disambiguation** — the five-lens set used in this module (**Truthfulness / Relevance / Usability / Safety / Timeliness**) is a code-review rubric local to this skill and is NOT the project's canonical TRUST 5 framework. The canonical MoAI TRUST 5 is **Tested / Readable / Unified / Secured / Trackable** (see `.claude/rules/moai/core/moai-constitution.md` § Quality Gates and the `moai-foundation-quality` skill). When a MoAI doc says "TRUST 5" without qualification, it means the canonical Tested/Readable/Unified/Secured/Trackable set; the Truthfulness/Relevance/Usability/Safety/Timeliness rubric applies only inside this code-review module.
+
 ## Quick Reference
 
 ### Core Capabilities

--- a/.claude/skills/moai-workflow-testing/modules/automated-code-review.md
+++ b/.claude/skills/moai-workflow-testing/modules/automated-code-review.md
@@ -212,5 +212,4 @@ automated-code-review.md (this file)
 ---
 
 Version: 2.0.0 (Modular Structure)
-Last Updated: 2026-01-06
 Module: `modules/automated-code-review.md`

--- a/.claude/skills/moai-workflow-testing/modules/automated-code-review/trust5-framework.md
+++ b/.claude/skills/moai-workflow-testing/modules/automated-code-review/trust5-framework.md
@@ -219,7 +219,6 @@ TRUST 5 uses weighted scoring with category-specific weights:
 ---
 
 Version: 1.1.0 (Modularized)
-Last Updated: 2026-01-06
 Module: `modules/automated-code-review/trust5-framework.md`
 
 ## Submodules

--- a/.claude/skills/moai-workflow-testing/modules/automated-code-review/trust5-framework.md
+++ b/.claude/skills/moai-workflow-testing/modules/automated-code-review/trust5-framework.md
@@ -6,6 +6,8 @@
 > Time: 25+ minutes
 > Dependencies: WebSearch/WebFetch, source parser (AST)
 
+> **TRUST 5 disambiguation** — the five-lens set used in this deep dive (**Truthfulness / Relevance / Usability / Safety / Timeliness**) is a code-review rubric local to the automated-code-review skill and is NOT the project's canonical TRUST 5 framework. The canonical MoAI TRUST 5 is **Tested / Readable / Unified / Secured / Trackable** (see `.claude/rules/moai/core/moai-constitution.md` § Quality Gates and the `moai-foundation-quality` skill). When a MoAI doc says "TRUST 5" without qualification, it means the canonical Tested/Readable/Unified/Secured/Trackable set; the Truthfulness/Relevance/Usability/Safety/Timeliness rubric applies only inside this code-review skill.
+
 ## Quick Reference
 
 ### TRUST 5 Methodology

--- a/.claude/skills/moai-workflow-worktree/modules/moai-adk-integration.md
+++ b/.claude/skills/moai-workflow-worktree/modules/moai-adk-integration.md
@@ -9,35 +9,34 @@ Last Updated: 2026-01-06
 
 ## Quick Reference (30 seconds)
 
-MoAI-ADK Integration Points:
-- /moai plan: Automatic worktree creation after SPEC generation
-- /moai run: DDD execution in isolated worktree environment
-- /moai sync: Worktree sync with documentation updates
-- Cleanup: Automatic removal of merged worktrees
+MoAI-ADK Integration Points (EnterWorktree-first doctrine):
+- Worktree entry: User runs `moai cc -w <name>` to enter a worktree; plan does NOT auto-create one. The legacy `/moai plan --worktree` launch action is retired.
+- /moai plan: Runs in the main checkout (no worktree) on a `plan/SPEC-XXX` branch.
+- /moai run: If the user entered a worktree, DDD execution happens there; otherwise it runs on a feature branch in the main checkout.
+- /moai sync: Reuses the SAME worktree the user entered for run (do NOT recreate).
+- Cleanup: Disposal via `moai worktree done SPEC-XXX` AFTER both run PR AND sync PR merge.
 
 ---
 
 ## Plan Phase Integration (/moai plan)
 
-### Automatic Worktree Creation
+### Worktree Is NOT Auto-Created by Plan
 
-After SPEC creation, the worktree system automatically generates an isolated development environment.
+The plan phase does NOT create a worktree. A worktree is entered by the USER before a phase runs, not provisioned by a workflow step. The EnterWorktree-first doctrine is the SSOT:
 
-Branch Naming Convention:
+- New-session launch (post-`/clear` or new terminal): `moai cc -w <name>` (or `moai glm -w` / `moai cg -w`). The `-w` flag accepts both short names (resolved under `.claude/worktrees/`) and absolute paths under `~/.moai/worktrees/<project>/...`.
+- Current-session re-entry (same session continuing): the runtime tool `EnterWorktree(<path>)`.
+- The retired `/moai plan --worktree` flag and the retired `moai worktree new` command MUST NOT be presented as live entry points.
+
+Branch Naming Convention (informational — the launcher handles this):
 - Pattern: feature/SPEC-{id}-{title-kebab-case}
 - Example: SPEC-001 with title "User Auth" becomes feature/SPEC-001-user-auth
 
 Worktree Path Pattern:
-- Default: {repo}/.moai/worktrees/{project-name}/SPEC-{id}
-- Configurable via worktree_root setting
+- L1 Claude-native (ephemeral): `{repo}/.claude/worktrees/<auto-name>/`
+- L2 MoAI persistent (SPEC-scoped): `~/.moai/worktrees/{project-name}/SPEC-{id}/`
 
-Creation Workflow:
-1. SPEC is created with /moai plan
-2. Worktree new command is invoked automatically if auto_create is enabled
-3. Branch is created from configured base branch (default: main)
-4. Template is applied if specified
-5. Worktree is registered in the central registry
-6. User receives guidance for switching to the new worktree
+Reference: the canonical L1/L2 layering and the EnterWorktree-first policy live in `.claude/rules/moai/workflow/worktree-integration.md` § Terminology Glossary.
 
 ### Template-Based Setup
 
@@ -135,8 +134,8 @@ After worktree sync, documentation updates can be extracted:
 After successful PR merge, worktrees can be automatically cleaned up.
 
 Cleanup Triggers:
-- Manual cleanup with clean command
-- Automated cleanup when cleanup_merged is enabled
+- Manual cleanup with the `moai worktree done SPEC-XXX` command (the canonical disposal path — runs only after BOTH run PR AND sync PR merge)
+- Automated cleanup when `workflow.worktree.auto_cleanup` is opted in (default: off)
 - Scheduled cleanup for stale worktrees
 
 Cleanup Options:
@@ -154,14 +153,14 @@ Registry Maintenance:
 
 ## Team Collaboration Patterns
 
-### Shared Worktree Registry
+### Per-Developer Worktree Conventions
 
-For team environments, configure a shared registry accessible to all developers.
+There is no shared-registry config field on `WorkflowWorktreeConfig` (the legacy `registry_type: "team"` / `shared_registry_path` / `developer_prefix` entries are NOT real keys). Team coordination is convention-based: each developer enters their own L2 worktree (`~/.moai/worktrees/{project}/SPEC-{id}/`) and the team coordinates via the SPEC artifacts and PRs in version control, not via a runtime-shared registry.
 
-Team Registry Configuration:
-- registry_type: Set to "team" for shared mode
-- shared_registry_path: Network-accessible registry location
-- developer_prefix: Automatic prefix for developer-specific worktrees
+Coordination conventions:
+- Each developer uses their own worktree under their own home directory.
+- The SPEC artifact (`.moai/specs/SPEC-XXX/`) is the shared state — it lives in the repo, not a per-worktree registry.
+- PRs are the integration surface — the team merges feature branches rather than maintaining a network-accessible worktree registry.
 
 Synchronization:
 - Local registry syncs with team registry periodically
@@ -189,22 +188,18 @@ Access Levels:
 
 ### MoAI Configuration Integration
 
-Worktree settings live in .moai/config/sections/workflow.yaml (the
-workflow.worktree section); worktree_root is configured in
-.moai/config/sections/git-strategy.yaml:
+Worktree settings live in `.moai/config/sections/workflow.yaml` under the `workflow.worktree` section. The keys below are the REAL Go struct fields (`WorkflowWorktreeConfig` in `internal/config/types.go`, defaults in `internal/config/defaults.go`). All three automation toggles ship `false` by default — worktree automation is explicit user opt-in per the EnterWorktree-first policy.
 
-workflow.worktree section:
-- auto_create: Enable automatic worktree creation (default: false)
-- auto_sync: Enable automatic synchronization (default: true)
-- cleanup_merged: Remove worktrees for merged branches (default: true)
-- worktree_root: Base directory for worktrees (default: {repo}/.moai/worktrees)
-- default_base: Default base branch (default: main)
-- sync_strategy: Sync method - merge, rebase, or squash (default: merge)
-- registry_type: local or team (default: local)
+workflow.worktree section (real keys + real defaults):
+- `auto_cleanup` (bool, default: **false**) — automatically remove worktrees. Opt-in; off by default to avoid unintended sprawl.
+- `auto_create` (bool, default: **false**) — automatically create worktrees. Opt-in; the default flow runs phases on a feature branch in the main checkout.
+- `auto_merge` (bool, default: **false**) — automatically merge worktree branches. Opt-in; off by default.
+- `session_name_pattern` (string, default: `moai-{ProjectName}-{SPEC-ID}`) — naming pattern for sessions spawned inside a worktree.
+- `tmux_preferred` (bool, default: **true**) — prefer tmux for worktree session display.
 
-Template Settings:
-- template_dir: Custom template location
-- default_template: Template applied when none specified
+Notes:
+- The previously-documented fields `auto_sync`, `cleanup_merged`, `worktree_root`, `default_base`, `sync_strategy`, and `registry_type` are NOT fields on the Go struct and MUST NOT be presented as live config keys. (The legacy content that listed them with `true` defaults inverted the real defaults and is corrected here.)
+- Worktree automation defaults to OFF in both the distributed template and the local dev config. Changing a default requires a dedicated SPEC.
 
 ---
 

--- a/.claude/skills/moai-workflow-worktree/modules/moai-adk-integration.md
+++ b/.claude/skills/moai-workflow-worktree/modules/moai-adk-integration.md
@@ -3,7 +3,6 @@
 Purpose: Detailed integration patterns for moai-worktree with MoAI-ADK Plan-Run-Sync workflow including plan phase automation, DDD integration, and cleanup workflows.
 
 Version: 1.0.0
-Last Updated: 2026-01-06
 
 ---
 
@@ -238,5 +237,4 @@ For failed synchronization:
 ---
 
 Version: 1.0.0
-Last Updated: 2026-01-06
 Module: MoAI-ADK workflow integration patterns for Plan-Run-Sync phases

--- a/.claude/skills/moai-workflow-worktree/modules/resource-optimization.md
+++ b/.claude/skills/moai-workflow-worktree/modules/resource-optimization.md
@@ -3,7 +3,6 @@
 Purpose: Disk space management, memory-efficient operations, performance optimization, and error handling patterns for worktree management.
 
 Version: 1.0.0
-Last Updated: 2026-01-06
 
 ---
 
@@ -292,5 +291,4 @@ Based on Performance:
 ---
 
 Version: 1.0.0
-Last Updated: 2026-01-06
 Module: Resource optimization patterns for disk, memory, performance, and error handling

--- a/.claude/skills/moai-workflow-worktree/modules/resource-optimization.md
+++ b/.claude/skills/moai-workflow-worktree/modules/resource-optimization.md
@@ -91,7 +91,7 @@ Cleanup Priority:
 For large registries, use streaming JSON parsing to avoid loading entire file.
 
 Streaming Pattern:
-- Use incremental JSON parser (ijson)
+- Use a streaming/incremental JSON parser appropriate to the implementation language (e.g. `encoding/json` `Decoder` token streaming in Go, `ijson` in Python) rather than loading the whole document into memory
 - Process worktrees one at a time
 - Apply filters during iteration
 - Yield matching worktrees
@@ -182,25 +182,21 @@ Batch Cleanup:
 
 ## Error Handling
 
-### Error Hierarchy
+### Error Categories
 
-Structured error classes for different failure types:
+Structured error categories for different failure types (design-level — the names below are category labels, not Python class syntax; each implementation language surfaces these as its own error/exception types with equivalent fields):
 
-WorktreeError: Base class for all worktree errors
-- message: Human-readable error description
-- context: Additional debugging information
+WorktreeError — base category for all worktree errors
+- Carries: a human-readable message, plus optional debugging context
 
-WorktreeCreationError: Errors during worktree creation
-- partial_worktree: Path to incomplete worktree for cleanup
-- creation_step: Step at which creation failed
+WorktreeCreationError — failures during worktree creation
+- Carries: the path to a partial worktree (for cleanup), and the creation step at which the failure occurred
 
-SynchronizationError: Errors during sync operations
-- sync_state: State at time of failure
-- backup_ref: Git ref for recovery
+SynchronizationError — failures during sync operations
+- Carries: the sync state at time of failure, and a backup git ref for recovery
 
-RegistryError: Errors related to registry operations
-- registry_path: Path to problematic registry
-- operation: Operation that failed
+RegistryError — failures related to registry operations
+- Carries: the registry path involved, and the operation that failed
 
 ### Recovery Patterns
 

--- a/.claude/skills/moai-workflow-worktree/modules/tools-integration.md
+++ b/.claude/skills/moai-workflow-worktree/modules/tools-integration.md
@@ -60,29 +60,21 @@ For IntelliJ, PyCharm, and WebStorm:
 
 ### Shell Profile Enhancement
 
-Add to .bashrc or .zshrc for improved worktree experience.
+Add to .bashrc or .zshrc for a slightly smoother worktree session.
 
 Completion Support:
-- Tab completion for worktree IDs using registry data
-- Command option completion for all moai-worktree subcommands
+- Tab completion for the live `moai worktree` subcommands (`done`, `clean`, `remove`) using the binary's built-in help
 
 Prompt Customization:
-- Detect if current directory is within a worktree
+- Detect if current directory is within a worktree (`.claude/worktrees/` or `~/.moai/worktrees/`)
 - Display SPEC ID in prompt when in worktree context
 - Color coding for worktree status
 
-Navigation Aliases:
-- mw: Short alias for moai-worktree
-- mwl: List worktrees
-- mws: Switch to worktree
-- mwg: Navigate with eval pattern
-- mwsync: Sync current worktree
-- mwclean: Clean merged worktrees
+Navigation:
+- Enter a worktree with `moai cc -w <name>` (new session) or `EnterWorktree(<path>)` (current session).
+- Dispose with `moai worktree done SPEC-XXX` (after run + sync PRs merge) or `moai worktree clean` / `moai worktree remove`.
 
-Quick Functions:
-- mwnew: Create and switch to new worktree in one command
-- mwdev: Switch to worktree and start development with /moai run
-- mwpush: Sync worktree and push to remote branch
+Note: the legacy shell aliases `mw`/`mwl`/`mws`/`mwg`/`mwsync`/`mwclean`/`mwnew` referenced subcommands (`list`, `switch`, `go`, `sync`, `new`) that the Go binary does NOT expose — only `done`, `clean`, and `remove` are live `moai worktree` subcommands. Those aliases are omitted here to avoid steering users at non-existent commands.
 
 ---
 
@@ -222,7 +214,7 @@ Operation Grouping:
 - Sequential fallback for resource constraints
 
 Execution Strategy:
-- ThreadPoolExecutor for parallel sync
+- Bounded worker pool for parallel sync (language-neutral — use the project language's standard concurrency primitive, e.g. a bounded goroutine worker pool in Go, a `ThreadPoolExecutor` only in Python projects)
 - Configurable worker count
 - Result aggregation with error handling
 

--- a/.claude/skills/moai-workflow-worktree/modules/tools-integration.md
+++ b/.claude/skills/moai-workflow-worktree/modules/tools-integration.md
@@ -3,7 +3,6 @@
 Purpose: Integration patterns for moai-worktree with development tools, IDEs, terminals, CI/CD pipelines, and monitoring systems.
 
 Version: 1.0.0
-Last Updated: 2026-01-06
 
 ---
 
@@ -268,5 +267,4 @@ Monitoring Integration Errors:
 ---
 
 Version: 1.0.0
-Last Updated: 2026-01-06
 Module: Development tools and external system integration patterns

--- a/.claude/skills/moai/SKILL.md
+++ b/.claude/skills/moai/SKILL.md
@@ -93,9 +93,12 @@ Only if BOTH Priority 1 AND Priority 2 did not match: Classify the intent of the
 - Quality gate language (format, check, pre-commit, quality gate) routes to **gate**
 - E2E and user-journey testing language (e2e, end-to-end test, browser test, mobile app test, desktop app test, user journey) routes to **e2e** — semantic exemplars; any conversation_language expressing e2e-testing intent routes identically
 - Security language (security, audit, owasp, vulnerability, injection, xss, csrf) routes to **review** (with `--security` scope)
+- Code-review language (review my code, code review, check my PR, look at my changes, take a look at my changes) routes to **review**
 - Error and fix language (fix, error, bug, broken, failing, lint) routes to **fix**
 - Iterative and repeat language (keep fixing, until done, repeat, iterate, all errors) routes to **loop**
+- Dead-code and cleanup language (dead code, unused code, safely remove, cleanup, orphaned code) routes to **clean**
 - Documentation language (document, sync, docs, readme, changelog, PR) routes to **sync** or **project**
+- Architecture-map language (architecture map, code maps, dependency graph, structure documentation) routes to **codemaps**
 - Feedback and bug report language (report, feedback, suggestion, issue) routes to **feedback**
 - MX tag language (mx tag, annotation, code context, legacy annotate) routes to **mx**
 - Implementation language (implement, build, create, add, develop) with clear scope routes to **moai** (default autonomous)
@@ -124,7 +127,7 @@ For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/plan.md
 Purpose: Implement SPEC requirements through configured development methodology.
 Agents: manager-develop (cycle_type=ddd|tdd per quality.yaml, primary), manager-git
 Skills: moai-workflow-tdd, moai-workflow-ddd (per delegation.yaml; cycle_type-selected) + domain moai-ref-* injected per mission
-Flags: --resume SPEC-XXX, --team
+Flags: --resume SPEC-XXX, --team (RETIRED — see Execution Mode Flags)
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/run.md
 
 ### sync - Documentation Sync and PR
@@ -163,7 +166,7 @@ For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/goal.md
 Purpose: Autonomously detect and fix LSP errors, linting issues, and type errors.
 Agents: manager-develop (cycle_type=autofix), Agent(general-purpose) with domain whitelist (fixes)
 Skills: moai-workflow-ddd (per delegation.yaml) + domain moai-ref-* injected per mission
-Flags: --dry, --sequential, --level N, --resume, --team
+Flags: --dry, --sequential, --level N, --resume, --team (RETIRED — see Execution Mode Flags)
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/fix.md
 
 ### loop - Iterative Auto-Fix
@@ -178,7 +181,7 @@ For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/loop.md
 
 Purpose: Scan codebase and add @MX code-level annotations for AI agent context.
 Agents: Explore (scan), Agent(general-purpose) with backend scope (annotation)
-Flags: --all, --dry, --priority P1-P4, --force, --team
+Flags: --all, --dry, --priority P1-P4, --force, --team (RETIRED — see Execution Mode Flags)
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/mx.md
 
 ### review - Code Review
@@ -186,7 +189,7 @@ For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/mx.md
 Purpose: Multi-perspective code review with security, performance, quality, and UX analysis.
 Agents: sync-auditor (review), Agent(general-purpose) with security scope
 Skills: moai-foundation-quality, moai-ref-owasp-checklist (per delegation.yaml; per-perspective ref skills injected per lens)
-Flags: --staged, --branch, --security, --team
+Flags: --staged, --branch, --security, --team (RETIRED — see Execution Mode Flags)
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/review.md
 
 ### clean - Dead Code Removal
@@ -210,7 +213,7 @@ Purpose: Full autonomous research -> plan -> annotate -> run -> sync pipeline.
 Phases: Parallel Exploration (research.md) -> SPEC Generation -> Annotation Cycle -> Implementation -> Sync
 Agents: Explore, manager-spec, plan-auditor (quality gate), manager-develop, manager-docs, manager-git, sync-auditor (quality gate)
 Skills: moai-workflow-spec, moai-workflow-tdd (per delegation.yaml) + domain moai-ref-* injected per mission
-Flags: --loop, --max N, --branch, --pr, --resume SPEC-XXX, --team, --solo, --issue (opt-in; default skips GitHub Issue creation per the late-branch opt-in policy)
+Flags: --loop, --max N, --branch, --pr, --resume SPEC-XXX, --team (RETIRED — see Execution Mode Flags), --solo, --issue (opt-in; default skips GitHub Issue creation per the late-branch opt-in policy)
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/moai.md
 
 ### project - Project Documentation
@@ -311,6 +314,15 @@ For English (`en` conversation_language), translate the message; the structure r
 
 Step 2 - Route to Workflow:
 Apply the Intent Router (Priority 1 through Priority 4) to determine the target workflow. If ambiguous, use AskUserQuestion to clarify with the user.
+
+Step 2.2 - Record Routing Decision:
+Immediately after routing resolves (Step 2), record the routing decision to the append-only routing-ledger (`.moai/state/routing-ledger.jsonl`) so that auto-invocation is observable. Run:
+
+```
+echo "<raw request text>" | moai harness ledger record --subcommand <matched> --mode <phase-4-mode> --tier <tier> --level <harness-level> --session <session-id>
+```
+
+The request text is piped via stdin and only a privacy-preserving digest is stored, never verbatim user text (policy source: § Routing Observation Ledger above). This step is opt-in and fail-open: if the `moai` CLI is absent from PATH or the command exits non-zero, log nothing and continue — it NEVER blocks routing, never gates the workflow, and never triggers a retry loop. An un-recorded dispatch is an observation gap, not an error.
 
 Step 2.5 - Project Documentation Check:
 Before executing plan, run, sync, fix, loop, or default workflows, verify project documentation exists by checking for `.moai/project/product.md`. If product.md does NOT exist, use AskUserQuestion to ask the user (in their conversation_language):

--- a/.moai/config/sections/delegation.yaml
+++ b/.moai/config/sections/delegation.yaml
@@ -71,7 +71,7 @@ delegation:
             agents: []                     # orchestrator + stop-goal Stop hook
             skills: []
         default:                           # natural-language autonomous pipeline
-            agents: [Explore, manager-spec, plan-auditor, manager-develop, manager-docs, sync-auditor]
+            agents: [Explore, manager-spec, plan-auditor, manager-develop, manager-docs, manager-git, sync-auditor]  # manager-git is Tier-L / --pr conditional (Late-Branch closure)
             skills: [moai-workflow-spec, moai-workflow-tdd]
 
     # Domain skills the orchestrator injects per mission domain (0-3 per spawn,
@@ -79,7 +79,7 @@ delegation:
     # signal; zero matches is valid.
     domain_skills:
         backend:   [moai-ref-api-patterns, moai-domain-backend]
-        frontend:  [moai-ref-react-patterns, moai-domain-frontend, moai-ref-seo]
+        frontend:  [moai-ref-react-patterns, moai-domain-frontend, moai-ref-ui-polish, moai-ref-seo]
         database:  [moai-domain-database]
         security:  [moai-ref-owasp-checklist, moai-ref-llm-security, moai-ref-secops, moai-ref-supply-chain]
         testing:   [moai-ref-testing-pyramid, moai-workflow-testing]
@@ -89,6 +89,9 @@ delegation:
     # Per-agent conditional skills (mirrors each agent's Conditional Skill
     # Loading section). The agent loads these on demand when its stated trigger
     # arises, not preemptively.
+    # NOTE: plan-auditor, sync-auditor, builder-harness, and manager-git
+    # intentionally carry NO conditional skills here (evaluators + builder +
+    # git-via-domain_skill) — their omission is by design, not a gap.
     agents:
         manager-spec:    [moai-workflow-spec, moai-foundation-thinking]
         manager-develop: [moai-workflow-tdd, moai-workflow-ddd]

--- a/internal/template/catalog.yaml
+++ b/internal/template/catalog.yaml
@@ -51,7 +51,7 @@ catalog:
             - name: moai-workflow-ddd
               tier: core
               path: templates/.claude/skills/moai-workflow-ddd/
-              hash: 53cd97bc3c62be82a0971e5096da62e157d80b0d9916fc2cdaeeb715fe772747
+              hash: 321e1ab6d8732377c7c58aeb591020faf07a93f99ad0bba99b5854ab20d19c3c
               version: 1.0.0
             - name: moai-workflow-docs-claim-check
               tier: core
@@ -117,7 +117,7 @@ catalog:
             - name: manager-git
               tier: core
               path: templates/.claude/agents/moai/manager-git.md
-              hash: 4ec49289bc9d9bf998e9ba80d51ec1b72867ea266f0ec398684707de53984902
+              hash: 56eb72557ec24c8907c8b260f1d829c2e0300c5f6eea352f898196db6a00e132
               version: 1.0.0
             - name: manager-spec
               tier: core

--- a/internal/template/catalog.yaml
+++ b/internal/template/catalog.yaml
@@ -6,7 +6,7 @@ catalog:
             - name: moai
               tier: core
               path: templates/.claude/skills/moai/
-              hash: 1d123356a6da599c74782574f94d204b04256318933eeaebac68b32892a39c34
+              hash: 738e18a95b15cf8b991a867fd60f26218fa956f7ae90146280264b942b365ef1
               version: 1.0.0
             - name: moai-foundation-cc
               tier: core
@@ -26,7 +26,7 @@ catalog:
             - name: moai-foundation-thinking
               tier: core
               path: templates/.claude/skills/moai-foundation-thinking/
-              hash: 8567978c13ce6ed0249f35b82cedca53f0004ef0fc3cb2e3d5b8a13acb005c1c
+              hash: c11cee93d9cb943207c19fffb4a23eb82ad9762d4fc923801c808970bba39ef8
               version: 1.0.0
             - name: moai-harness-learner
               tier: core
@@ -51,7 +51,7 @@ catalog:
             - name: moai-workflow-ddd
               tier: core
               path: templates/.claude/skills/moai-workflow-ddd/
-              hash: 7c4c570386c6d686cded00fcfe2933a4553a04e6acceccd0bb28996d02f35767
+              hash: 53cd97bc3c62be82a0971e5096da62e157d80b0d9916fc2cdaeeb715fe772747
               version: 1.0.0
             - name: moai-workflow-docs-claim-check
               tier: core
@@ -66,7 +66,7 @@ catalog:
             - name: moai-workflow-project
               tier: core
               path: templates/.claude/skills/moai-workflow-project/
-              hash: a0fa7cc733762d6038432a6b04e50bb7c5a4280936c23b3e272b66ed62ba9074
+              hash: 9e4f7a52b977e2a4014c321931aacdd8ebf04559b9e2b8ba26aa4ee9abb2dd16
               version: 1.0.0
             - name: moai-workflow-spec
               tier: core
@@ -102,12 +102,12 @@ catalog:
             - name: sync-auditor
               tier: core
               path: templates/.claude/agents/moai/sync-auditor.md
-              hash: deb41318767ebbdc370396062ab0859addc541f73fb02fe3e8977290f177dcca
+              hash: 4ed068cea7da1d70849d3a37edd33a93a3524cb7a3a19798267cc77c4b38a733
               version: 1.0.0
             - name: manager-develop
               tier: core
               path: templates/.claude/agents/moai/manager-develop.md
-              hash: 0d1d4e6da6ab9885485eeb5f5f0ae447686bcce85a15a9d152613afdef8f0354
+              hash: 2b3c7073e0a5c8bc6b4222d762445b0a66dc4f0690cd70c2987886db5c904f8d
               version: 1.0.0
             - name: manager-docs
               tier: core
@@ -117,7 +117,7 @@ catalog:
             - name: manager-git
               tier: core
               path: templates/.claude/agents/moai/manager-git.md
-              hash: 09af092d349b8519944ac21f1b23b12499704046f333138f3067c3de99534443
+              hash: 4ec49289bc9d9bf998e9ba80d51ec1b72867ea266f0ec398684707de53984902
               version: 1.0.0
             - name: manager-spec
               tier: core
@@ -127,7 +127,7 @@ catalog:
             - name: plan-auditor
               tier: core
               path: templates/.claude/agents/moai/plan-auditor.md
-              hash: 1253010337775f3bf1e63eab410d8c03e0ae4da1ee1125f914cd142d4b39fff8
+              hash: 6f96009bfc1a2592746bf7318cee4480c2e4046337f2e1b0e132123b90d73575
               version: 1.0.0
             - name: super-advisor
               tier: core
@@ -244,5 +244,5 @@ catalog:
             - name: builder-harness
               tier: harness-generated
               path: templates/.claude/agents/moai/builder-harness.md
-              hash: 90b40c734a01d16244f539f509fe38a5b17fc4b3fec3d4a607d02e8a1c0bb7c1
+              hash: 37ff28085c45bb19b86946ca32a2416bf0af7a040f062cfa744fa98ed9a92b24
               version: 1.0.0

--- a/internal/template/internal_content_leak_test.go
+++ b/internal/template/internal_content_leak_test.go
@@ -150,8 +150,8 @@ const skillMoaiPrefix = ".claude/skills/moai/"
 //     series prefixes require explicit extension here + cross-reference to
 //     CLAUDE.local.md §25.1.
 //   - C2 (REQ/AC token prefix-allowlist): only known project-internal REQ/AC
-//     prefixes — `ATR`, `WO`, `COORD`, `UNP`, `LNC`, `TII`. New SPEC families
-//     add their prefix here.
+//     prefixes — `ATR`, `WO`, `COORD`, `UNP`, `LNC`, `TII`, `HRN`, `ORC`. New
+//     SPEC families add their prefix here.
 //   - C3 (Audit citation): `Audit N Finding AX` / `Audit 3` wrappers — same
 //     as AC-TII-001 narrow form.
 //   - C4 (specific date or Finding marker): the spec.md §A.4 narrow grep
@@ -172,7 +172,7 @@ var leakClasses = []leakClass{
 	},
 	{
 		name:    "C2-req-ac-internal-prefix",
-		pattern: regexp.MustCompile(`\b(REQ|AC)-(ATR|WO|COORD|UNP|LNC|TII)-[0-9]{3}\b`),
+		pattern: regexp.MustCompile(`\b(REQ|AC)-(ATR|WO|COORD|UNP|LNC|TII|HRN|ORC)-[0-9]{3}\b`),
 	},
 	{
 		name:    "C3-audit-citation",
@@ -467,23 +467,17 @@ var pedagogicalAllowlist = []pedagogicalAllowlistEntry{
 		SpecID:    "internal/core/handler.go",
 		Rationale: "Illustrative example Go path in mixed-language modified-files list example (EXCL-SBN-003 keep-list)",
 	},
-	// --- C1 whole-tree V3R2-5 expansion: regex-example + mirror-parity-enforced retained tokens ---
+	// --- C1 whole-tree V3R2-5 expansion: mirror-parity-enforced retained tokens ---
 	//
-	// When C1 broadened to SPEC-V3R[2-6]- (whole-tree), two surfaces retain a
+	// When C1 broadened to SPEC-V3R[2-6]- (whole-tree), one surface retains a
 	// legitimate SPEC-V3R5 token that must NOT be flagged:
-	//   1. plan-auditor.md regex-example: SPEC-V3R5-WO-001 is a multi-segment
-	//      SPEC-ID grammar illustration, not an internal-provenance leak.
-	//   2. spec-workflow.md: byte-parity-enforced with its .claude/ source
-	//      (rule_template_mirror_test allowlist). Its internal provenance is
-	//      retained on BOTH trees by design; stripping the template mirror
-	//      alone would break mirror parity, so the tokens are allowlisted here.
-	{
-		File:      ".claude/agents/moai/plan-auditor.md",
-		LineStart: 0,
-		LineEnd:   0,
-		SpecID:    "SPEC-V3R5-WO-001",
-		Rationale: "Multi-segment SPEC-ID grammar illustration in the D7-1 extraction regex example (not internal-provenance leak)",
-	},
+	//   spec-workflow.md: byte-parity-enforced with its .claude/ source
+	//   (rule_template_mirror_test allowlist). Its internal provenance is
+	//   retained on BOTH trees by design; stripping the template mirror
+	//   alone would break mirror parity, so the tokens are allowlisted here.
+	//   (The former plan-auditor.md SPEC-V3R5-WO-001 regex-example illustration
+	//   was genericized to a neutral placeholder; its allowlist entry was
+	//   dropped at that time.)
 	{
 		File:      ".claude/rules/moai/workflow/spec-workflow.md",
 		LineStart: 0,

--- a/internal/template/settings_test.go
+++ b/internal/template/settings_test.go
@@ -398,8 +398,12 @@ func TestSettingsTemplatePermissions(t *testing.T) {
 		t.Fatal("missing permissions section")
 	}
 
-	if perms["defaultMode"] != "acceptEdits" {
-		t.Errorf("permissions.defaultMode = %v, want %q", perms["defaultMode"], "acceptEdits")
+	// CLAUDE.local.md §22.1: the template ships defaultMode UNSPECIFIED so
+	// distributed user projects inherit Claude Code's safe "default"
+	// (prompt-each-time) mode. The maintainer's acceptEdits/bypassPermissions
+	// preference lives in settings.local.json, not the rendered template.
+	if mode, ok := perms["defaultMode"]; ok {
+		t.Errorf("permissions.defaultMode should be absent (template ships unspecified per CLAUDE.local.md §22.1; distributed users get Claude Code's safe default), got %q", mode)
 	}
 
 	allow, ok := perms["allow"].([]any)

--- a/internal/template/templates/.claude/agents/moai/builder-harness.md
+++ b/internal/template/templates/.claude/agents/moai/builder-harness.md
@@ -28,7 +28,7 @@ Create standards-compliant Claude Code artifacts (agents, skills, plugins, comma
 <!-- @MX:REASON: Every artifact creation request (agent/skill/plugin/command/hook/mcp-server/lsp-server) resolves to this dispatch table -->
 **artifact_type**: Must be one of: `agent | skill | plugin | command | hook | mcp-server | lsp-server`
 
-<!-- @MX:WARN: [AUTO] trigger-union coverage — REQ-ORC-001-017 forbids trigger drops from builder-agent + builder-skill + builder-plugin union -->
+<!-- @MX:WARN: [AUTO] trigger-union coverage — forbids trigger drops from builder-agent + builder-skill + builder-plugin union -->
 <!-- @MX:REASON: a CI test enforces no trigger keyword is dropped vs the three source agents; any rewrite of this description row must preserve all tokens -->
 
 ## Artifact Type Dispatch Table

--- a/internal/template/templates/.claude/agents/moai/manager-develop.md
+++ b/internal/template/templates/.claude/agents/moai/manager-develop.md
@@ -234,7 +234,7 @@ Static `skills:` preload is kept to a minimum (token diet — progressive disclo
 - When reading or interpreting SPEC artifacts (spec.md / plan.md / acceptance.md), invoke Skill("moai-workflow-spec") to load it on demand.
 - When weighing architecture trade-offs or deep design decisions, invoke Skill("moai-foundation-thinking") to load it on demand.
 - When project documentation context (product.md / structure.md / tech.md) is needed, invoke Skill("moai-workflow-project") to load it on demand.
-- When operating inside an isolated git worktree (L2/L3 worktree flow), invoke Skill("moai-workflow-worktree") to load it on demand.
+- When operating inside an isolated git worktree (L1/L2 worktree flow), invoke Skill("moai-workflow-worktree") to load it on demand.
 
 ## Model/effort escalation
 

--- a/internal/template/templates/.claude/agents/moai/manager-git.md
+++ b/internal/template/templates/.claude/agents/moai/manager-git.md
@@ -2,7 +2,7 @@
 name: manager-git
 description: |
   Git workflow specialist. Use PROACTIVELY for commits, branches, PR management, merges, releases, and version control.
-  Invocation gate: invoked for PR creation across ALL tiers (S/M/L) per the PR-mandatory policy (enforce_admins: true, 2026-07-20). Tier L uses heavy ceremony (long-lived branch + full CI matrix); Tier S/M uses light ceremony (short-lived branch + self-merge) — both route PR creation through manager-git. manager-develop/manager-docs perform commits only; push + PR is always delegated to manager-git.
+  Invocation gate: invoked for PR creation across ALL tiers (S/M/L) per the PR-mandatory policy (enforce_admins: true). Tier L uses heavy ceremony (long-lived branch + full CI matrix); Tier S/M uses light ceremony (short-lived branch + self-merge) — both route PR creation through manager-git. manager-develop/manager-docs perform commits only; push + PR is always delegated to manager-git.
   Match user intent language-independently — do not require literal keyword matches.
   NOT for: code implementation, testing, architecture design, documentation content, security audits
 tools: Read, Write, Edit, Grep, Glob, Bash, TaskCreate, TaskUpdate, TaskList, TaskGet, Skill
@@ -133,10 +133,10 @@ Cross-reference: `.claude/rules/moai/workflow/spec-workflow.md` § Step 1 entry 
 ### Personal Mode
 
 SPEC Git Workflow options (from git-strategy.yaml):
-- **main_direct** [RETIRED 2026-07-20 — main direct push blocked by enforce_admins:true; all tiers require PR]: Direct commits to main, no branches needed
+- **main_direct** [RETIRED — main direct push blocked by enforce_admins:true; all tiers require PR]: Direct commits to main, no branches needed
 - **main_late_branch**: main commit + late `git switch -c feat/SPEC-*` at PR time, PR squash + delete-branch, local main `reset --hard origin/main` cleanup (4-phase procedure — see Late-Branch Invocation Pattern above)
 - **main_feature**: Feature branches from main, optional PR
-- **develop_direct** [RETIRED 2026-07-20 — main direct push blocked by enforce_admins:true; all tiers require PR]: Direct commits to develop
+- **develop_direct** [RETIRED — main direct push blocked by enforce_admins:true; all tiers require PR]: Direct commits to develop
 - **feature_branch** / **per_spec**: Feature branches with PR required
 
 ### Team Mode

--- a/internal/template/templates/.claude/agents/moai/manager-git.md
+++ b/internal/template/templates/.claude/agents/moai/manager-git.md
@@ -2,9 +2,9 @@
 name: manager-git
 description: |
   Git workflow specialist. Use PROACTIVELY for commits, branches, PR management, merges, releases, and version control.
-  Invocation gate: invoked for Tier L SPEC PR creation OR explicit `--pr` flag per the canonical Tier-based PR routing policy. Tier S/M SPECs follow the Hybrid Trunk 1-person OSS pattern (main-direct push via manager-develop) per the Hybrid Trunk 1-person OSS policy; manager-git is NOT invoked for Tier S/M routine commits.
+  Invocation gate: invoked for PR creation across ALL tiers (S/M/L) per the PR-mandatory policy (enforce_admins: true, 2026-07-20). Tier L uses heavy ceremony (long-lived branch + full CI matrix); Tier S/M uses light ceremony (short-lived branch + self-merge) — both route PR creation through manager-git. manager-develop/manager-docs perform commits only; push + PR is always delegated to manager-git.
   Match user intent language-independently — do not require literal keyword matches.
-  NOT for: Tier S/M default Hybrid Trunk main-direct (no PR step — handled by manager-develop), code implementation, testing, architecture design, documentation content, security audits
+  NOT for: code implementation, testing, architecture design, documentation content, security audits
 tools: Read, Write, Edit, Grep, Glob, Bash, TaskCreate, TaskUpdate, TaskList, TaskGet, Skill
 model: sonnet
 effort: low
@@ -133,10 +133,10 @@ Cross-reference: `.claude/rules/moai/workflow/spec-workflow.md` § Step 1 entry 
 ### Personal Mode
 
 SPEC Git Workflow options (from git-strategy.yaml):
-- **main_direct** [RECOMMENDED]: Direct commits to main, no branches needed
+- **main_direct** [RETIRED 2026-07-20 — main direct push blocked by enforce_admins:true; all tiers require PR]: Direct commits to main, no branches needed
 - **main_late_branch**: main commit + late `git switch -c feat/SPEC-*` at PR time, PR squash + delete-branch, local main `reset --hard origin/main` cleanup (4-phase procedure — see Late-Branch Invocation Pattern above)
 - **main_feature**: Feature branches from main, optional PR
-- **develop_direct**: Direct commits to develop
+- **develop_direct** [RETIRED 2026-07-20 — main direct push blocked by enforce_admins:true; all tiers require PR]: Direct commits to develop
 - **feature_branch** / **per_spec**: Feature branches with PR required
 
 ### Team Mode

--- a/internal/template/templates/.claude/agents/moai/plan-auditor.md
+++ b/internal/template/templates/.claude/agents/moai/plan-auditor.md
@@ -283,7 +283,7 @@ Execute each check in order against the full document — every REQ entry and ev
 
 ### Group 7: Cross-SPEC Reconciliation (D7)
 
-- D7-1: Extract every `SPEC-([A-Z][A-Z0-9]+-)+[0-9]+` reference from the SPEC body (supports multi-segment IDs like SPEC-V3R5-WO-001)
+- D7-1: Extract every `SPEC-([A-Z][A-Z0-9]+-)+[0-9]+` reference from the SPEC body (supports multi-segment IDs like SPEC-DOMAIN-WO-001)
 - D7-2: For each referenced SPEC, verify `.moai/specs/<SPEC-ID>/spec.md` exists
 - D7-3: For each referenced SPEC that exists, read its `status:` frontmatter field
 - D7-4: If status ∈ {retired, superseded, archived}, require explicit reconciliation
@@ -397,7 +397,7 @@ Stagnation detection: If a defect appears in all three iterations unchanged, fla
 
 ### LEAN Workflow Additions
 
-The following three clauses extend the retry loop contract to fix the score-regression pattern (0.78 → 0.81 → 0.77) observed in LANG-COMPLIANCE-001 plan-phase abandonment.
+The following three clauses extend the retry loop contract to fix the score-regression pattern (0.78 → 0.81 → 0.77) observed when unconditional iteration continues on a deteriorating SPEC.
 
 **STOP escalation on score regression.** If iter(N+1) aggregate score is **lower** than iter(N) aggregate score, the agent emits a `STOP` signal in the Verdict block of the report and proposes a scope-reduction action to the orchestrator. The orchestrator MUST NOT iterate further unconditionally; instead, present the user with three options via the orchestrator's user-question channel (`.claude/rules/moai/core/askuser-protocol.md`):
 

--- a/internal/template/templates/.claude/agents/moai/sync-auditor.md
+++ b/internal/template/templates/.claude/agents/moai/sync-auditor.md
@@ -46,11 +46,11 @@ HARD must-pass firewall (FROZEN — design-constitution §12 Mechanism 3): every
 Both modes score the same 4 canonical dimensions and differ only in scoring granularity and report format, so reports produced under either mode stay consistent and comparable. The dimension enum is FROZEN (design-constitution §12 Mechanism 3) at exactly `Functionality`, `Security`, `Craft`, `Consistency`; a non-canonical dimension name in a profile is loaded best-effort (unknown dims skipped).
 
 - **Flat weighted-percentage (default)**: the weights in the Evaluation Dimensions table above. Applies whenever `harness.yaml` does NOT set `evaluator_mode: hierarchical`.
-- **Hierarchical sub-criteria refinement** (HRN-003): **Where** `harness.yaml` sets `evaluator_mode: hierarchical`, each dimension decomposes into N sub-criteria that are scored and aggregated per dimension, and the report renders in the hierarchical format (§ Output Format).
+- **Hierarchical sub-criteria refinement**: **Where** `harness.yaml` sets `evaluator_mode: hierarchical`, each dimension decomposes into N sub-criteria that are scored and aggregated per dimension, and the report renders in the hierarchical format (§ Output Format).
 
 ### Sub-Criterion Scoring and Aggregation (hierarchical mode)
 
-Each dimension has N sub-criteria. Scores MUST use the canonical anchors 0.25, 0.50, 0.75, 1.00; intermediate values are rejected (ErrFlatScoreCardProhibited). Every sub-criterion score MUST cite the canonical anchor description from the active profile's Scoring Rubric section — uncited scores are rejected (ErrRubricCitationMissing). Sub-criteria aggregate per dimension by `min` (default, REQ-HRN-003-007), or by `mean` when the active profile sets the field `aggregation: min | mean` (REQ-HRN-003-015).
+Each dimension has N sub-criteria. Scores MUST use the canonical anchors 0.25, 0.50, 0.75, 1.00; intermediate values are rejected (ErrFlatScoreCardProhibited). Every sub-criterion score MUST cite the canonical anchor description from the active profile's Scoring Rubric section — uncited scores are rejected (ErrRubricCitationMissing). Sub-criteria aggregate per dimension by `min` (default), or by `mean` when the active profile sets the field `aggregation: min | mean`.
 
 ## Per-Dimension Mechanical Verification (project-language auto-detection)
 

--- a/internal/template/templates/.claude/settings.json.tmpl
+++ b/internal/template/templates/.claude/settings.json.tmpl
@@ -361,7 +361,6 @@
     "PATH": "{{jsonEscape .SmartPATH}}"
   },
   "permissions": {
-    "defaultMode": "acceptEdits",
     "allow": [
       "AskUserQuestion",
       "BashOutput",

--- a/internal/template/templates/.claude/skills/moai-foundation-cc/reference/best-practices-checklist.md
+++ b/internal/template/templates/.claude/skills/moai-foundation-cc/reference/best-practices-checklist.md
@@ -67,7 +67,7 @@ name Field:
 description Field:
 - [ ] Clearly describes what the skill does
 - [ ] Includes specific trigger scenarios
-- [ ] Maximum 1024 characters in length
+- [ ] Maximum 1,536 characters (combined description + when_to_use)
 - [ ] Avoids vague or generic language
 - [ ] Includes context for when to use the skill
 

--- a/internal/template/templates/.claude/skills/moai-foundation-cc/reference/claude-code-custom-slash-commands-official.md
+++ b/internal/template/templates/.claude/skills/moai-foundation-cc/reference/claude-code-custom-slash-commands-official.md
@@ -54,7 +54,13 @@ IMPORTANT: Command name is automatically derived from file path structure:
 - `.claude/commands/my-command.md` → `/my-command`
 - Example: `.claude/commands/moai/fix.md` → `/moai:fix`
 
-DO NOT include a `name` field in frontmatter - it is not officially supported.
+DO NOT include a `name` field in frontmatter - it is not officially supported. (Earlier examples in this file showed a `name:` key in command frontmatter; those have been removed to match this rule. The command name is ALWAYS derived from the file path — see the mapping above.)
+
+> **Illustrative-only note**: the command names used in the examples below
+> (`validate-config`, `implement-feature`, `deploy`, etc.) are fictional
+> generic illustrations, not MoAI shipped commands. MoAI's real command
+> surface is the `/moai` skill plus its `/moai:<sub>` thin wrappers
+> (see `CLAUDE.md §3 Command Reference`).
 
 ### Command File Format
 
@@ -361,7 +367,6 @@ Configuration Validator:
 
 ````markdown
 ---
-name: validate-config
 description: Validate configuration files against schema and best practices
 usage: |
  /validate-config <file> [options]
@@ -441,7 +446,6 @@ Agent(
 Feature Implementation Workflow:
 ```markdown
 ---
-name: implement-feature
 description: Complete feature implementation workflow from spec to deployment
 usage: |
  /implement-feature "Feature description" [options]
@@ -572,7 +576,6 @@ echo "Documentation: $(echo $docs_result | jq .generated_files)"
 CI/CD Pipeline Integration:
 ```markdown
 ---
-name: deploy
 description: Deploy application with comprehensive validation and rollback capability
 usage: |
  /deploy [environment] [options]

--- a/internal/template/templates/.claude/skills/moai-foundation-cc/reference/claude-code-iam-official.md
+++ b/internal/template/templates/.claude/skills/moai-foundation-cc/reference/claude-code-iam-official.md
@@ -1,4 +1,16 @@
-# Claude Code IAM & Permissions - Official Documentation Reference
+# Claude Code IAM & Permissions - Reference
+
+> **Illustrative reference, NOT the official Claude Code specification.**
+> This file is an MoAI-authored summary intended for orientation only. The
+> authoritative, up-to-date IAM and permissions surface lives in the official
+> Claude Code documentation at
+> https://code.claude.com/docs/en/iam — consult that source before relying
+> on any field for a production deployment. Earlier revisions of this file
+> presented fabricated RBAC roles (`developer` / `securityReviewer` /
+> `devopsEngineer` with `toolRestrictions`), an `enterprise.policies`
+> framework, and SOC2 / ISO27001 compliance JSON as if they were real
+> Claude Code IAM surfaces; they do not exist in the product and have been
+> removed. What remains is the real, currently-shipped permission surface.
 
 Source: https://code.claude.com/docs/en/iam
 
@@ -6,630 +18,137 @@ Source: https://code.claude.com/docs/en/iam
 
 ### What is Claude Code IAM?
 
-Identity and Access Management (IAM) in Claude Code provides a comprehensive permission system that controls access to tools, files, and external services. IAM implements tiered approval levels, role-based access control, and security boundaries to ensure safe and compliant operations.
+Claude Code's Identity and Access Management surface is a **permission
+mode + allow/ask/deny list** model, enforced at four settings scopes
+(enterprise/managed → user → project → local). There is NO role-based
+access control (RBAC), NO predefined `developer`/`reviewer`/`devops` roles,
+and NO `toolRestrictions` sub-object — the earlier sections that described
+those were illustrative-only and have been removed.
 
-### IAM Architecture
+## Permission Modes
 
-Tiered Permission System:
-```
-Level 1: Read-only Access (No Approval)
- Read, Grep, Glob
- Information gathering tools
+The `permissions.defaultMode` field accepts exactly four values:
 
-Level 2: Bash Commands (User Approval Required)
- Bash, WebFetch, WebSearch
- System operations and external access
+| Mode | Behavior |
+|------|----------|
+| `default` | Prompts on every tool call that is not on the allow list |
+| `plan` | Read-only; Claude cannot modify files or run non-read tools |
+| `acceptEdits` | Auto-accepts Write/Edit; still prompts for Bash and other tools |
+| `bypassPermissions` | Skips all prompts (gated by `disableBypassPermissionsMode`) |
 
-Level 3: File Modification (User Approval Required)
- Write, Edit, MultiEdit
- File system modifications
+These are the only valid values. Earlier revisions listed `dontAsk` and
+`ignore` — those are not real Claude Code permission modes.
 
-Level 4: Administrative (Enterprise Approval)
- Settings management
- User administration
- System configuration
-```
-
-## Tool-Specific Permission Rules
-
-### Permission Rule Format
-
-Basic Permission Structure:
 ```json
 {
- "allowedTools": [
- "Read", // Read-only access (no approval)
- "Bash", // Commands with approval
- "Write", // File modification with approval
- "WebFetch(domain:*.example.com)" // Domain-specific web access
- ]
+  "permissions": {
+    "defaultMode": "default"
+  }
 }
 ```
 
-### Permission Levels and Tools
+## Allow / Ask / Deny Lists
 
-Level 1: Read-Only Tools (No Approval Required)
+The `permissions` object carries three ordered lists of tool-path patterns.
+Each entry is a tool name with an optional parenthesized argument pattern:
+
 ```json
 {
- "readLevel": {
- "tools": ["Read", "Grep", "Glob"],
- "approval": "none",
- "description": "Information gathering and file exploration",
- "useCases": [
- "Code analysis and review",
- "File system exploration",
- "Pattern searching and analysis",
- "Documentation reading"
- ]
- }
+  "permissions": {
+    "allow": [
+      "Read",
+      "Glob",
+      "Grep",
+      "Bash(git status:*)",
+      "Bash(git log:*)"
+    ],
+    "ask": [
+      "Bash(rm:*)",
+      "Bash(sudo:*)"
+    ],
+    "deny": [
+      "Read(~/.ssh/**)",
+      "Bash(rm -rf /:*)"
+    ],
+    "additionalDirectories": [
+      "/path/to/extra/checkout"
+    ]
+  }
 }
 ```
 
-Level 2: System Operations (User Approval Required)
-```json
-{
- "systemLevel": {
- "tools": ["Bash", "WebFetch", "WebSearch"],
- "approval": "user",
- "description": "System operations and external resource access",
- "useCases": [
- "Build and deployment operations",
- "External API integration",
- "System configuration changes",
- "Network operations"
- ]
- }
-}
-```
+- `allow` — auto-approve matching tool calls (no prompt).
+- `ask` — always prompt, even in `acceptEdits` / `bypassPermissions`-leaning flows.
+- `deny` — block unconditionally; never callable.
+- `additionalDirectories` — grant Read access to directories outside the project root.
 
-Level 3: File Modifications (User Approval Required)
-```json
-{
- "modificationLevel": {
- "tools": ["Write", "Edit", "MultiEdit", "NotebookEdit"],
- "approval": "user",
- "description": "File system modifications and content creation",
- "useCases": [
- "Code implementation and changes",
- "Documentation updates",
- "Configuration file modifications",
- "Content generation"
- ]
- }
-}
-```
+### Pattern Grammar (illustrative)
 
-Level 4: Administrative (Enterprise Approval Required)
-```json
-{
- "adminLevel": {
- "tools": ["Settings", "UserManagement", "SystemConfig"],
- "approval": "enterprise",
- "description": "System administration and user management",
- "useCases": [
- "System configuration changes",
- "User permission management",
- "Enterprise policy updates",
- "Security configuration"
- ]
- }
-}
-```
+- `Bash(git status:*)` — the `:` prefix-anchored command form for Bash.
+- `Read(./docs/**)` — glob-restricted Read paths.
+- `WebFetch(domain:example.com)` — domain-scoped WebFetch.
 
-## Role-Based Access Control (RBAC)
+The authoritative pattern grammar (including the `~` home-prefix, the `//`
+glob separator, and MCP-tool naming `mcp__server__tool`) lives at
+https://code.claude.com/docs/en/iam.
 
-### Predefined Roles
+## Settings Scopes (Enterprise / Managed → Local)
 
-Developer Role:
-```json
-{
- "developer": {
- "allowedTools": [
- "Read", "Grep", "Glob",
- "Bash", "Write", "Edit",
- "WebFetch", "WebSearch",
- "AskUserQuestion", "Task", "Skill"
- ],
- "toolRestrictions": {
- "Bash": {
- "allowedCommands": ["git", "npm", "python", "make", "docker"],
- "blockedCommands": ["sudo", "chmod 777", "rm -rf /"],
- "requireConfirmation": true
- },
- "WebFetch": {
- "allowedDomains": ["*.github.com", "*.npmjs.com", "docs.python.org"],
- "blockedDomains": ["*.malicious-site.com"],
- "maxRequestsPerMinute": 60
- },
- "Write": {
- "allowedPaths": ["./src/", "./tests/", "./docs/"],
- "blockedPaths": ["./.env*", "./config/secrets"],
- "maxFileSize": 10000000
- }
- },
- "permissions": {
- "canCreateFiles": true,
- "canModifyFiles": true,
- "canExecuteCommands": true,
- "canAccessExternal": true
- }
- }
-}
-```
+Claude Code resolves settings in a strict precedence order. Higher scopes
+override lower ones, and `deny` entries at any scope are absolute:
 
-Security Reviewer Role:
-```json
-{
- "securityReviewer": {
- "allowedTools": [
- "Read", "Grep", "Glob",
- "Bash", "WebFetch",
- "AskUserQuestion", "Task"
- ],
- "toolRestrictions": {
- "Read": {
- "allowedPaths": ["./"],
- "blockedPatterns": ["*.key", "*.pem", ".env*"]
- },
- "Bash": {
- "allowedCommands": ["git", "grep", "find", "openssl"],
- "requireConfirmation": true
- }
- },
- "specialPermissions": {
- "canAccessSecurityLogs": true,
- "canRunSecurityScans": true,
- "canReviewPermissions": true,
- "cannotModifyProduction": true
- }
- }
-}
-```
+1. **Enterprise / Managed settings** — `/etc/claude/settings.json` (Linux/macOS) or `/Library/Application Support/ClaudeCode/managed-settings.json` (macOS Managed). Organization-wide; users cannot override.
+2. **User settings** — `~/.claude/settings.json`. Personal defaults across all projects.
+3. **Project settings** — `.claude/settings.json`. Team-shared, checked into VCS.
+4. **Local settings** — `.claude/settings.local.json`. Per-developer overrides; gitignored.
 
-DevOps Engineer Role:
-```json
-{
- "devopsEngineer": {
- "allowedTools": [
- "Read", "Grep", "Glob",
- "Bash", "Write", "Edit",
- "WebFetch", "WebSearch",
- "Task", "Skill"
- ],
- "toolRestrictions": {
- "Bash": {
- "allowedCommands": [
- "git", "docker", "kubectl", "helm", "terraform",
- "npm", "pip", "make", "curl", "wget"
- ],
- "blockedCommands": ["sudo", "chmod 777"],
- "requireConfirmation": false
- },
- "WebFetch": {
- "allowedDomains": ["*"],
- "requireConfirmation": false
- }
- },
- "permissions": {
- "canDeployToStaging": true,
- "canManageInfrastructure": true,
- "canAccessProduction": false,
- "canManageCI/CD": true
- }
- }
-}
-```
+There is NO inline `enterprise: { policies: { ... } }` settings.json object
+of the kind earlier revisions showed. Enterprise policy is expressed by
+editing the managed-settings file at one of the paths above, not by an
+in-document `enterprise` block.
 
-### Custom Role Definition
+## Enterprise Levers
 
-Role Template:
-```json
-{
- "customRole": {
- "name": "CustomRoleName",
- "description": "Role description and purpose",
- "allowedTools": ["Read", "Bash", "Write"],
- "toolRestrictions": {
- "Read": {
- "allowedPaths": ["./"],
- "blockedPaths": [".env*", "secrets/"]
- },
- "Bash": {
- "allowedCommands": ["git", "npm"],
- "blockedCommands": ["rm", "sudo"],
- "requireConfirmation": true
- }
- },
- "permissions": {
- "customPermission": "value"
- },
- "inherits": ["developer"]
- }
-}
-```
+The real enterprise-grade settings keys (set in the managed-settings file,
+not in an inline `enterprise` block):
 
-## Enterprise Policy Overrides
+- `disableBypassPermissionsMode: true` — prevents agents from entering `bypassPermissions` (Claude Code v2.1.111+).
+- `permissions.deny` at managed scope — absolute deny that no lower scope can override.
+- `permissions.allow` / `permissions.ask` at managed scope — org-wide defaults.
 
-### Enterprise IAM Structure
+There is no `enterprise.compliance` block with SOC2 / ISO27001 fields.
+Compliance posture for Claude Code itself is documented by Anthropic's
+trust center, not configured in `settings.json`.
 
-Enterprise Policy Framework:
-```json
-{
- "enterprise": {
- "policies": {
- "tools": {
- "Bash": "never",
- "WebFetch": ["domain:*.company.com", "domain:*.partner.com"],
- "Write": ["path:./workspace/", "path:./temp/"]
- },
- "mcpServers": {
- "allowed": ["example-server", "figma", "company-internal-mcp"],
- "blocked": ["custom-unverified-mcp", "external-scanner"]
- },
- "roles": {
- "default": "readonly-developer",
- "overrides": {
- "senior-developer": "developer",
- "devops": "devops-engineer"
- }
- },
- "compliance": {
- "auditRequired": true,
- "dataRetention": "7y",
- "encryptionRequired": true,
- "mfaRequired": true
- }
- }
- }
-}
-```
+## What Was Removed (for readers familiar with older revisions)
 
-Policy Enforcement Mechanisms:
-```json
-{
- "policyEnforcement": {
- "validation": {
- "strict": true,
- "failOnViolation": true,
- "auditFrequency": "daily"
- },
- "overrides": {
- "allowUserOverrides": false,
- "requireManagerApproval": true,
- "emergencyOverrides": {
- "enabled": true,
- "duration": "24h",
- "approvalRequired": ["cto", "security-team"]
- }
- },
- "monitoring": {
- "realTimeAlerts": true,
- "anomalyDetection": true,
- "complianceReporting": true
- }
- }
-}
-```
+For anyone who learned this surface from an earlier draft of this file,
+the following were illustrative-only fabrications and do NOT exist in
+Claude Code:
 
-## MCP Server Permissions
+- The four "Levels" (Read-only / Bash / File-Modification / Administrative) as a tiered approval system — Claude Code uses the four permission modes above, not a 4-tier approval ladder.
+- Predefined RBAC roles: `developer`, `securityReviewer`, `devopsEngineer`.
+- `toolRestrictions` sub-objects (`allowedCommands`, `blockedCommands`, `allowedDomains`, `allowedPaths`, `maxFileSize`, etc.). The real model is the allow/ask/deny list, not a per-tool restrictions object.
+- Custom role definition (`customRole` with `inherits`).
+- `enterprise.policies.tools` / `enterprise.policies.mcpServers` / `enterprise.policies.roles` / `enterprise.policies.compliance`.
+- `policyEnforcement` (validation / overrides / monitoring) blocks.
+- `mcpSecurity` validation / sandbox / monitoring blocks (MCP permissions are governed by the same allow/ask/deny list, scoped with `mcp__server__tool`).
+- `webPermissions` / `fileSystemPermissions` top-level objects (use `WebFetch(domain:...)` and `Read(path:...)` patterns in the standard permissions lists instead).
+- Python `validate_tool_usage()` pseudocode and real-time monitoring JSON.
+- SOC 2 / ISO 27001 compliance JSON blocks.
 
-### MCP Access Control
-
-MCP Server Configuration:
-```json
-{
- "allowedMcpServers": [
- "example-server",
- "figma-dev-mode-mcp-server",
- "playwright",
- "company-internal-mcp"
- ],
- "blockedMcpServers": [
- "custom-unverified-mcp",
- "experimental-ai-mcp",
- "external-scanner-mcp"
- ],
- "mcpServerPermissions": {
- "example-server": {
- "allowed": ["tool-a", "tool-b"],
- "rateLimit": {
- "requestsPerMinute": 60,
- "burstSize": 10
- },
- "dataUsage": {
- "allowedDataTypes": ["documentation", "api-reference"],
- "blockedDataTypes": ["credentials", "private-keys"]
- }
- },
- "figma-dev-mode-mcp-server": {
- "allowed": ["get-design-context", "get-variable-defs", "get-screenshot"],
- "accessControl": {
- "allowedProjects": ["company-design-system"],
- "blockedProjects": ["competitor-designs"]
- }
- }
- }
-}
-```
-
-MCP Security Validation:
-```json
-{
- "mcpSecurity": {
- "validationRules": {
- "requireSignature": true,
- "requireVersionCheck": true,
- "requirePermissionsReview": true
- },
- "sandbox": {
- "enabled": true,
- "isolatedNetwork": true,
- "fileSystemAccess": "restricted"
- },
- "monitoring": {
- "logAllCalls": true,
- "auditSensitiveOperations": true,
- "rateLimitViolations": "block"
- }
- }
-}
-```
-
-## Domain-Specific Permissions
-
-### Web Access Control
-
-Domain-Based Web Permissions:
-```json
-{
- "webPermissions": {
- "allowedDomains": [
- "*.github.com",
- "*.npmjs.com",
- "docs.python.org",
- "*.company.com",
- "*.partner-site.com"
- ],
- "blockedDomains": [
- "*.malicious-site.com",
- "*.competitor.com",
- "*.social-media.com"
- ],
- "domainRestrictions": {
- "github.com": {
- "allowedPaths": ["/api/v3/", "/raw/"],
- "blockedPaths": ["/settings/", "/admin/"]
- },
- "npmjs.com": {
- "allowedPaths": ["/package/"],
- "blockedPaths": ["/settings/", "/account/"]
- }
- }
- }
-}
-```
-
-### File System Access Control
-
-Path-Based Permissions:
-```json
-{
- "fileSystemPermissions": {
- "allowedPaths": [
- "./src/",
- "./tests/",
- "./docs/",
- "./.claude/",
- "./.moai/"
- ],
- "blockedPaths": [
- "./.env*",
- "./secrets/",
- "./.ssh/",
- "./config/private/",
- "./node_modules/.cache/"
- ],
- "pathRestrictions": {
- "./src/": {
- "allowedExtensions": [".py", ".js", ".ts", ".md", ".json"],
- "blockedExtensions": [".exe", ".key", ".pem"]
- },
- "./config/": {
- "readOnly": true,
- "requireApproval": true
- }
- }
- }
-}
-```
-
-## Permission Validation and Enforcement
-
-### Pre-Execution Validation
-
-Permission Check Workflow:
-```python
-def validate_tool_usage(tool_name, parameters, user_role):
- """
- Validate tool usage against IAM policies
- """
- # 1. Check if tool is allowed for user role
- if tool_name not in get_allowed_tools(user_role):
- return {"allowed": False, "reason": "Tool not permitted for role"}
-
- # 2. Check tool-specific restrictions
- restrictions = get_tool_restrictions(tool_name, user_role)
- if not validate_tool_restrictions(tool_name, parameters, restrictions):
- return {"allowed": False, "reason": "Tool restriction violation"}
-
- # 3. Check enterprise policy overrides
- if violates_enterprise_policy(tool_name, parameters):
- return {"allowed": False, "reason": "Enterprise policy violation"}
-
- # 4. Determine approval requirement
- approval_level = get_approval_level(tool_name, user_role)
-
- return {
- "allowed": True,
- "approvalRequired": approval_level != "none",
- "approvalLevel": approval_level
- }
-```
-
-### Real-Time Permission Monitoring
-
-Permission Monitoring System:
-```json
-{
- "monitoring": {
- "realTimeValidation": {
- "enabled": true,
- "checkFrequency": "per-execution",
- "blockOnViolation": true
- },
- "auditLogging": {
- "enabled": true,
- "logLevel": "detailed",
- "retention": "90d",
- "format": "structured-json"
- },
- "alerts": {
- "permissionViolations": {
- "enabled": true,
- "channels": ["email", "slack"],
- "escalation": ["security-team", "management"]
- },
- "suspiciousActivity": {
- "enabled": true,
- "threshold": "5 violations in 1h",
- "action": "temporary-ban"
- }
- }
- }
-}
-```
-
-## Security Compliance
-
-### Compliance Framework Integration
-
-SOC 2 Compliance:
-```json
-{
- "compliance": {
- "SOC2": {
- "security": {
- "accessControl": true,
- "encryptionRequired": true,
- "auditLogging": true,
- "incidentResponse": true
- },
- "availability": {
- "backupRequired": true,
- "disasterRecovery": true,
- "uptimeMonitoring": true
- },
- "processing": {
- "dataIntegrity": true,
- "accuracyValidation": true,
- "errorHandling": true
- },
- "confidentiality": {
- "dataEncryption": true,
- "accessControls": true,
- "dataMinimization": true
- }
- }
- }
-}
-```
-
-ISO 27001 Compliance:
-```json
-{
- "compliance": {
- "ISO27001": {
- "accessControl": {
- "policyDocumented": true,
- "accessReview": "quarterly",
- "leastPrivilege": true,
- "segregationOfDuties": true
- },
- "informationSecurity": {
- "riskAssessment": "annual",
- "securityTraining": "mandatory",
- "incidentManagement": true,
- "businessContinuity": true
- }
- }
- }
-}
-```
+If you need a capability that the real surface above does not list, it is
+almost certainly NOT available — do not assume a hidden field. Check
+https://code.claude.com/docs/en/iam first.
 
 ## Best Practices
 
-### Permission Management
+- **Principle of least privilege**: start with `default` mode and a minimal `allow` list; widen only when a workflow genuinely needs it.
+- **Deny at managed scope for hard boundaries**: put `Read(~/.ssh/**)`, `Bash(rm -rf /:*)`, and similar in the managed-settings `permissions.deny` so no lower scope or errant agent can override them.
+- **Local overrides stay local**: keep machine-specific entries in `.claude/settings.local.json`; never commit them.
+- **`additionalDirectories` is a read grant**, not a write grant — it lets Claude Read outside the project root, it does not auto-approve Write/Edit there.
+- **Audit the allow list**: periodically review `.claude/settings.json` `permissions.allow` for over-broad patterns (`Bash(*)` is a common footgun).
 
-Principle of Least Privilege:
-```json
-{
- "leastPrivilege": {
- "grantOnlyNecessary": true,
- "regularReview": "quarterly",
- "automaticRevocation": {
- "enabled": true,
- "inactivityPeriod": "90d"
- },
- "roleBasedAssignment": true
- }
-}
-```
-
-Security Best Practices:
-- Implement multi-factor authentication for administrative access
-- Regular security audits and permission reviews
-- Encrypted storage of sensitive configuration data
-- Real-time monitoring and alerting for security events
-- Incident response procedures for security violations
-
-Compliance Best Practices:
-- Document all permission policies and procedures
-- Maintain comprehensive audit logs
-- Regular compliance assessments and reporting
-- Employee security training and awareness programs
-- Automated compliance checking and validation
-
-### Implementation Guidelines
-
-Development Environment:
-```json
-{
- "development": {
- "permissionMode": "default",
- "allowedTools": ["Read", "Write", "Edit", "Bash"],
- "toolRestrictions": {
- "Bash": {"allowedCommands": ["git", "npm", "python"]},
- "Write": {"allowedPaths": ["./src/", "./tests/"]}
- }
- }
-}
-```
-
-Production Environment:
-```json
-{
- "production": {
- "permissionMode": "restricted",
- "allowedTools": ["Read", "Grep"],
- "toolRestrictions": {
- "Read": {"allowedPaths": ["./logs/", "./config/readonly/"]}
- },
- "monitoring": {
- "realTimeAlerts": true,
- "auditAllAccess": true
- }
- }
-}
-```
-
-This comprehensive IAM reference provides all the information needed to implement secure, compliant, and effective access control for Claude Code deployments at any scale.
+For the authoritative and current IAM surface — including fields added
+after this file was last reviewed — consult the official documentation at
+https://code.claude.com/docs/en/iam.

--- a/internal/template/templates/.claude/skills/moai-foundation-cc/reference/claude-code-settings-official.md
+++ b/internal/template/templates/.claude/skills/moai-foundation-cc/reference/claude-code-settings-official.md
@@ -1,4 +1,12 @@
-# Claude Code Settings - Official Documentation Reference
+# Claude Code Settings - Reference
+
+> **Illustrative reference, NOT the official Claude Code specification.**
+> This file is an MoAI-authored summary intended for orientation only. The
+> authoritative, up-to-date settings schema lives in the official Claude Code
+> documentation at https://code.claude.com/docs/en/settings — consult that
+> source before relying on any field for a production `settings.json`. Some
+> blocks below are illustrative patterns rather than real `settings.json`
+> keys; the headers flag those.
 
 Source: https://code.claude.com/docs/en/settings
 
@@ -72,7 +80,7 @@ The `model` field sets the default model. Only this single field is valid in set
 
 ### Permission System
 
-Permission Modes: `default`, `plan`, `acceptEdits`, `dontAsk`, `bypassPermissions`.
+Permission Modes: `default`, `plan`, `acceptEdits`, `bypassPermissions`.
 
 Permissions use allow/ask/deny lists with tool-path patterns:
 ```json
@@ -205,31 +213,14 @@ Hooks Setup:
 
 ### Sub-agent Configuration
 
-Sub-agent Settings:
-```json
-{
- "subagents": {
- "defaultModel": "claude-sonnet-5",
- "defaultPermissionMode": "default",
- "maxConcurrentTasks": 5,
- "taskTimeout": 300000,
- "allowedSubagents": [
- "spec-builder",
- "ddd-implementer",
- "security-expert",
- "backend-expert",
- "frontend-expert"
- ],
- "customSubagents": {
- "custom-analyzer": {
- "description": "Custom code analysis agent",
- "tools": ["Read", "Grep", "Bash"],
- "model": "claude-sonnet-5"
- }
- }
- }
-}
-```
+Claude Code does NOT expose a `subagents` block in `settings.json`. Sub-agents
+are configured as individual files under `.claude/agents/*.md` (frontmatter:
+`name`, `description`, `tools`, `model`, etc.) and spawned via the `Agent`
+tool. The earlier `subagents` / `defaultModel` / `allowedSubagents` /
+`customSubagents` schema that appeared here was illustrative-only and did not
+correspond to a real `settings.json` key — it has been removed. See
+`claude-code-sub-agents-official.md` for the authoritative sub-agent
+authoring surface.
 
 ### Plugin System
 
@@ -282,219 +273,59 @@ Standard Locations:
 
 ### Settings Management Commands
 
-Configuration Commands:
+> The commands below are illustrative. Claude Code's real CLI surface is
+> narrower than this list — it exposes `claude config set`/`get`/`list` for
+> a small set of keys plus the interactive `/config` command inside the
+> TUI. The `--environment` flag, `use-environment`, `list-environments`,
+> and any `maxTokens` setter shown below do not exist in the real CLI
+> (there is no `maxTokens` field). Treat this block as a pattern sketch,
+> not a copy-paste source; verify against
+> https://code.claude.com/docs/en/settings.
+
+Configuration Commands (illustrative):
 ```bash
 # View current settings
-claude settings show
-claude settings show --model
-claude settings show --permissions
+claude config list
+claude config get model
 
-# Set individual settings
+# Set individual settings (real keys only — model, permissions, etc.)
 claude config set model "claude-sonnet-5"
-claude config set maxTokens 200000
-claude config set permissionMode "default"
 
-# Edit settings file
-claude config edit
-claude config edit --local
-claude config edit --user
-
-# Reset settings
-claude config reset
-claude config reset --local
-claude config reset --user
-
-# Validate settings
-claude config validate
-claude config validate --strict
+# Edit settings file directly
+$EDITOR .claude/settings.json
 ```
 
-Environment-Specific Settings:
-```bash
-# Set environment-specific settings
-claude config set --environment development model "claude-haiku-4-5-20251001"
-claude config set --environment production maxTokens 200000
-
-# Switch between environments
-claude config use-environment development
-claude config use-environment production
-
-# List available environments
-claude config list-environments
-```
+For interactive configuration, use the `/config` command inside a Claude
+Code session — it writes to the appropriate settings scope (local/project/
+user) automatically.
 
 ## Advanced Configuration
 
-### Context Management
-
-Context Window Settings:
-```json
-{
- "context": {
- "maxTokens": 200000,
- "compressionThreshold": 150000,
- "compressionStrategy": "importance-based",
- "memoryIntegration": true,
- "cacheStrategy": {
- "enabled": true,
- "maxSize": "100MB",
- "ttl": 3600
- }
- }
-}
-```
-
-### Logging and Debugging
-
-Logging Configuration:
-```json
-{
- "logging": {
- "level": "info",
- "file": "~/.claude/logs/claude.log",
- "maxFileSize": "10MB",
- "maxFiles": 5,
- "format": "json",
- "include": [
- "tool_usage",
- "agent_delegation",
- "errors",
- "performance"
- ],
- "exclude": [
- "sensitive_data"
- ]
- }
-}
-```
-
-Debug Settings:
-```json
-{
- "debug": {
- "enabled": false,
- "verboseOutput": false,
- "timingInfo": false,
- "tokenUsage": true,
- "stackTraces": false,
- "apiCalls": false
- }
-}
-```
-
-### Performance Optimization
-
-Performance Settings:
-```json
-{
- "performance": {
- "parallelExecution": true,
- "maxConcurrency": 5,
- "caching": {
- "enabled": true,
- "strategy": "lru",
- "maxSize": "500MB"
- },
- "optimization": {
- "contextCompression": true,
- "responseStreaming": false,
- "batchProcessing": true
- }
- }
-}
-```
+> The blocks that appeared here earlier — `context.maxTokens` /
+> `compressionThreshold` / `cacheStrategy`, `logging`, `debug`, and
+> `performance` top-level settings — were illustrative-only and did not
+> correspond to real `settings.json` keys. Claude Code does not expose a
+> `context`, `logging`, `debug`, or `performance` top-level object. They have
+> been removed. Context-window behavior is governed by the runtime and by
+> `cleanupPeriodDays`; logging is governed by the runtime's debug flags
+> (`claude --debug ...`) rather than a `settings.json` block.
 
 ## Integration Settings
 
-### Git Integration
-
-Git Configuration:
-```json
-{
- "git": {
- "autoCommit": false,
- "autoPush": false,
- "branchStrategy": "feature-branch",
- "commitTemplate": {
- "prefix": "feat:",
- "includeScope": true,
- "includeBody": true
- },
- "hooks": {
- "preCommit": "lint && test",
- "prePush": "security-scan"
- }
- }
-}
-```
-
-### CI/CD Integration
-
-CI/CD Settings:
-```json
-{
- "cicd": {
- "platform": "github-actions",
- "configPath": ".github/workflows/",
- "autoGenerate": false,
- "pipelines": {
- "test": {
- "trigger": ["push", "pull_request"],
- "steps": ["lint", "test", "security-scan"]
- },
- "deploy": {
- "trigger": ["release"],
- "steps": ["build", "deploy"]
- }
- }
- }
-}
-```
+> The `git` and `cicd` top-level settings blocks that appeared here earlier
+> were illustrative-only and did not correspond to real `settings.json` keys.
+> Claude Code does not commit, push, or generate CI pipelines from a
+> `settings.json` block; git/CI behavior is driven by your shell, your
+> repository hooks, and the MoAI orchestrator. They have been removed.
 
 ## Security Configuration
 
-### Security Settings
-
-Security Configuration:
-```json
-{
- "security": {
- "level": "standard",
- "encryption": {
- "enabled": true,
- "algorithm": "AES-256-GCM"
- },
- "accessControl": {
- "authentication": "required",
- "authorization": "role-based"
- },
- "audit": {
- "enabled": true,
- "logLevel": "detailed",
- "retention": "90d"
- }
- }
-}
-```
-
-### Privacy Settings
-
-Privacy Configuration:
-```json
-{
- "privacy": {
- "dataCollection": "minimal",
- "analytics": false,
- "crashReporting": true,
- "usageStatistics": false,
- "dataRetention": {
- "logs": "30d",
- "cache": "7d",
- "temp": "1d"
- }
- }
-}
-```
+> The `security` and `privacy` top-level settings blocks that appeared here
+> earlier were illustrative-only and did not correspond to real
+> `settings.json` keys. Claude Code's security surface is the
+> `permissions` block (allow/ask/deny lists, permission modes), sandboxing
+> (`sandbox`), and `disableBypassPermissionsMode` — not an inline
+> `security`/`privacy` object. They have been removed.
 
 ## Best Practices
 
@@ -520,42 +351,15 @@ Performance Practices:
 
 ### Organization Standards
 
-Team Configuration:
-```json
-{
- "team": {
- "standards": {
- "model": "claude-sonnet-5",
- "testCoverage": 90,
- "codeStyle": "prettier",
- "documentation": "required"
- },
- "workflow": {
- "branching": "gitflow",
- "reviews": "required",
- "ciCd": "automated"
- }
- }
-}
-```
+> The `team` and `enterprise` top-level settings blocks that appeared here
+> earlier were illustrative-only and did not correspond to real
+> `settings.json` keys. Claude Code's enterprise surface uses separate
+> managed-settings files (`/etc/claude/settings.json` /
+> `/Library/Application Support/ClaudeCode/managed-settings.json`) plus
+> `disableBypassPermissionsMode`, not an inline `team`/`enterprise` object
+> with SOC2/ISO27001 compliance fields. They have been removed. See the
+> official IAM documentation at
+> https://code.claude.com/docs/en/iam for the real enterprise/managed
+> settings surface.
 
-Enterprise Policies:
-```json
-{
- "enterprise": {
- "policies": {
- "allowedModels": ["claude-sonnet-5"],
- "maxTokens": 100000,
- "restrictedTools": ["Bash", "WebFetch"],
- "auditRequired": true
- },
- "compliance": {
- "standards": ["SOC2", "ISO27001"],
- "dataResidency": "us-east-1",
- "retentionPolicy": "7y"
- }
- }
-}
-```
-
-This comprehensive reference provides all the information needed to configure Claude Code effectively for any use case, from personal development to enterprise deployment.
+This reference orients you to the categories of Claude Code configuration. For the authoritative and current schema — including fields added after this file was last reviewed — consult the official documentation at https://code.claude.com/docs/en/settings.

--- a/internal/template/templates/.claude/skills/moai-foundation-cc/reference/claude-code-sub-agents-official.md
+++ b/internal/template/templates/.claude/skills/moai-foundation-cc/reference/claude-code-sub-agents-official.md
@@ -78,7 +78,7 @@ Optional Fields:
 
 - model: Model alias (sonnet, opus, haiku) or 'inherit' to use same model as main conversation. If omitted, uses configured default (usually sonnet).
 
-- permissionMode: Controls permission handling. Valid values: `default`, `acceptEdits`, `dontAsk`, `bypassPermissions`, `plan`, `ignore`.
+- permissionMode: Controls permission handling. Valid values: `default`, `plan`, `acceptEdits`, `bypassPermissions` (these are the only real Claude Code permission modes). The earlier list also named `dontAsk` and `ignore` — those are NOT real Claude Code modes and have been removed. NOTE: the spawn-time `mode` parameter on `Task`/`Agent` is **deprecated and ignored since Claude Code v2.1.213** — subagents inherit the parent session's permission mode, and a parent in `bypassPermissions`/`acceptEdits` takes precedence and cannot be overridden. A spawned child's read-only scoping therefore rests on **tool restriction** (the inherently read-only `Explore`, or a `tools:` list omitting Write/Edit/NotebookEdit), never on the deprecated spawn-time `mode` parameter.
 
 - skills: Comma-separated list of skill names to auto-load when agent is invoked. Skills are NOT inherited from parent.
 

--- a/internal/template/templates/.claude/skills/moai-foundation-cc/reference/reference.md
+++ b/internal/template/templates/.claude/skills/moai-foundation-cc/reference/reference.md
@@ -6,7 +6,7 @@
 
 Frontmatter Fields:
 - `name` (required): Skill identifier in kebab-case, max 64 characters
-- `description` (required): One-line description, max 1024 characters
+- `description` (required): One-line description, max 1,536 characters (combined description + when_to_use)
 - `version`: Semantic version (e.g., "2.0.0")
 - `tools`: Comma-separated list of allowed tools
 - `modularized`: Boolean indicating modular file structure

--- a/internal/template/templates/.claude/skills/moai-foundation-cc/reference/skill-formatting-guide.md
+++ b/internal/template/templates/.claude/skills/moai-foundation-cc/reference/skill-formatting-guide.md
@@ -20,7 +20,7 @@ Core Format: YAML frontmatter + markdown content with progressive disclosure. Na
 ```yaml
 ---
 name: skill-name # Required: kebab-case, max 64 chars
-description: Specific description of skill purpose and trigger scenarios (max 1024 chars) # Required
+description: Specific description of skill purpose and trigger scenarios (max 1,536 chars combined description + when_to_use) # Required
 allowed-tools: tool1, tool2, tool3 # Optional: comma-separated, minimal set
 version: 1.0.0 # Optional: semantic versioning
 tags: [domain, category, purpose] # Optional: categorization
@@ -117,7 +117,7 @@ Examples:
 
 #### `description` (String)
 Format: Natural language description
-Length: Maximum 1024 characters
+Length: Maximum 1,536 characters (combined description + when_to_use)
 Content: What the skill does + specific trigger scenarios
 Examples:
 - `Extract and structure information from PDF documents for analysis and processing. Use when you need to analyze PDF content, extract tables, or convert PDF text to structured data.`
@@ -137,7 +137,9 @@ allowed-tools: Read, WebFetch
 # CORRECT: Multiple tools for analysis
 allowed-tools: Read, Grep, Glob, WebFetch
 
-# WRONG: YAML array format
+# AVOID in MoAI: YAML array format
+# (CSV is the MoAI convention; YAML arrays are also valid since v2.1.0,
+#  but MoAI standardizes on CSV for tool lists to match agent-authoring.md)
 allowed-tools: [Read, Grep, Glob]
 
 # WRONG: Overly permissive
@@ -408,7 +410,7 @@ examples.md (unlimited):
 
 Frontmatter Validation:
 - [ ] Name uses kebab-case (64 chars max)
-- [ ] Description specific and under 1024 chars
+- [ ] Description specific and under 1,536 chars (combined description + when_to_use)
 - [ ] allowed-tools follows principle of least privilege
 - [ ] YAML syntax valid (no parsing errors)
 - [ ] No deprecated or invalid fields
@@ -461,11 +463,12 @@ User Experience:
 
 Invalid Array Format:
 ```yaml
-# WRONG: YAML array syntax
-allowed-tools: [Read, Write, Bash]
-
-# CORRECT: Comma-separated string
+# MoAI convention: CSV string
 allowed-tools: Read, Write, Bash
+
+# Also valid since v2.1.0 (YAML array), but NOT the MoAI convention
+# for tool lists — agent-authoring.md standardizes on CSV:
+allowed-tools: [Read, Write, Bash]
 ```
 
 Missing Required Fields:

--- a/internal/template/templates/.claude/skills/moai-foundation-cc/reference/sub-agents/sub-agent-examples.md
+++ b/internal/template/templates/.claude/skills/moai-foundation-cc/reference/sub-agents/sub-agent-examples.md
@@ -1,8 +1,26 @@
 # Claude Code Sub-agents Examples Collection
 
+> **IMPORTANT — these are GENERIC Claude-Code-ecosystem illustrations, NOT
+> the MoAI retained agent catalog.** The tiered `{domain}-{role}` naming
+> used throughout this file (`code-backend`, `code-frontend`, `core-quality`,
+> `security-expert`, `workflow-ddd`, etc.) is a generic Claude-Code
+> authoring pattern shown here for teaching purposes. It does NOT describe
+> MoAI's shipped agents, and several of the names here (`security-expert`,
+> `core-quality`, etc.) collide with names that are **archived and MUST NOT
+> be spawned** in MoAI (see `CLAUDE.md §4 Archived Agents`).
+>
+> **For the real MoAI agent surface**, consult the flat 11-agent retained
+> catalog at
+> `../../moai-foundation-core/modules/agents-reference.md`
+> (10 MoAI-custom managers/auditors/builders/advisor/design/e2e + the
+> Anthropic built-in `Explore`). MoAI does NOT use the tiered
+> `{domain}-{role}` scheme; it uses a flat `manager-*` / `*-auditor` /
+> `builder-*` / `super-advisor` / `Explore` catalog with `Agent(general-purpose)`
+> per-spawn specialists carrying domain-specific instructions.
+
 Comprehensive collection of real-world sub-agent examples covering various domains, complexity levels, and specialization patterns, all following official Claude Code standards.
 
-Purpose: Practical examples and templates for sub-agent creation
+Purpose: Practical examples and templates for sub-agent creation (generic Claude-Code patterns — see header disclaimer above)
 Target: Sub-agent developers and Claude Code users
 Last Updated: 2025-11-25
 Version: 2.0.0

--- a/internal/template/templates/.claude/skills/moai-foundation-cc/reference/sub-agents/sub-agent-integration-patterns.md
+++ b/internal/template/templates/.claude/skills/moai-foundation-cc/reference/sub-agents/sub-agent-integration-patterns.md
@@ -110,12 +110,17 @@ def parallel_workflow(project_requirements):
  """Execute parallel sub-agent workflow.
 
  Note: In Claude Code, calling multiple Agent() in a single response
- will automatically execute them in parallel (up to 10 concurrent).
+ will automatically execute them in parallel. The runtime concurrency
+ cap is `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS` (default 20;Claude
+ Code v2.1.217+), NOT 10 — the earlier "up to 10" figure was stale.
+ MoAI's own orchestrator ceiling is 3-5 concurrent `Agent()` calls
+ (Mode 4) regardless of the runtime cap.
  No need for asyncio.gather or Promise.all.
  """
 
  # Call multiple Agent() for automatic parallel execution
- # Claude Code executes up to 10 Tasks concurrently
+ # Runtime cap: CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS (default 20);
+ # MoAI orchestrator ceiling: 3-5 concurrent Agent() calls.
  frontend_design = Agent(
  subagent_type="code-frontend",
  prompt="Design frontend architecture",
@@ -285,6 +290,15 @@ tools: Read, Write, Edit, Agent
 model: sonnet
 skills: moai-core-workflow, moai-project-manager, moai-foundation-quality
 ---
+
+# NOTE — this is a GENERIC Claude-Code illustration, NOT a MoAI retained
+# agent. A MoAI retained agent MUST omit `Agent` from its `tools:` list
+# (flat-hierarchy guarantee — subagents cannot spawn other subagents;
+# see CLAUDE.md §4 Watch note). The `Agent` entry in `tools:` above is
+# shown only because this file documents generic Claude-Code ecosystem
+# patterns; do not copy this frontmatter into a real MoAI agent file.
+# Real MoAI orchestration is done by the main-session orchestrator
+# (the `Agent` tool is main-session-only), not by a subagent.
 
 # Development Orchestrator
 

--- a/internal/template/templates/.claude/skills/moai-foundation-core/modules/delegation-advanced.md
+++ b/internal/template/templates/.claude/skills/moai-foundation-core/modules/delegation-advanced.md
@@ -2,6 +2,19 @@
 
 Purpose: Error handling, recovery strategies, and hybrid delegation patterns for complex workflows.
 
+> **Illustrative pseudocode.** The Python `Agent(subagent_type=...)`
+> literals in this file are pseudocode showing flow and retry/recovery
+> shape, NOT runnable code. In practice, MoAI invokes retained agents
+> (`manager-spec`, `manager-develop`, `manager-docs`, etc.) through
+> **natural-language delegation** ("Use the {agent} subagent to {task}"),
+> never a `subagent_type` code literal — see
+> [delegation-patterns.md](delegation-patterns.md) § Note + the flat
+> 11-agent catalog in [agents-reference.md](agents-reference.md). Per-spawn
+> `general-purpose` (with domain instructions in the prompt) is the
+> canonical mechanism for cross-cutting domain work; legacy tiered names
+> (`code-backend`, `security-expert`, `core-quality`, etc.) are archived
+> and rejected at spawn.
+
 Version: 1.0.0
 Parent: [delegation-patterns.md](delegation-patterns.md)
 

--- a/internal/template/templates/.claude/skills/moai-foundation-core/modules/delegation-implementation.md
+++ b/internal/template/templates/.claude/skills/moai-foundation-core/modules/delegation-implementation.md
@@ -2,6 +2,19 @@
 
 Purpose: Detailed implementation patterns for agent delegation including context optimization and workflow examples.
 
+> **Illustrative pseudocode.** The Python `Agent(subagent_type=...)`
+> literals in this file are pseudocode showing context-passing shape,
+> NOT runnable code. In practice, MoAI invokes retained agents
+> (`manager-spec`, `manager-develop`, `manager-docs`, etc.) through
+> **natural-language delegation** ("Use the {agent} subagent to {task}"),
+> never a `subagent_type` code literal — see
+> [delegation-patterns.md](delegation-patterns.md) § Note + the flat
+> 11-agent catalog in [agents-reference.md](agents-reference.md). Per-spawn
+> `general-purpose` (with domain instructions in the prompt) is the
+> canonical mechanism for cross-cutting domain work; legacy tiered names
+> (`code-backend`, `security-expert`, `core-quality`, etc.) are archived
+> and rejected at spawn.
+
 Version: 1.0.0
 Parent: [delegation-patterns.md](delegation-patterns.md)
 

--- a/internal/template/templates/.claude/skills/moai-foundation-core/modules/token-optimization.md
+++ b/internal/template/templates/.claude/skills/moai-foundation-core/modules/token-optimization.md
@@ -1,6 +1,30 @@
 # Token Optimization - Budget Management
 
-Purpose: Efficient 200K token budget management through strategic context loading, phase separation, and model selection for cost-effective AI development.
+> **Illustrative pseudocode AND model-specific budget pointer.** The
+> Python `Agent(subagent_type=...)` and class literals below are
+> pseudocode showing budget-tracking shape, NOT runnable code. MoAI
+> invokes retained agents (`manager-spec`, `manager-develop`,
+> `manager-docs`, etc.) through **natural-language delegation** ("Use the
+> {agent} subagent to {task}"), never a `subagent_type` code literal — see
+> [delegation-patterns.md](delegation-patterns.md) § Note + the flat
+> 11-agent catalog in [agents-reference.md](agents-reference.md).
+>
+> **The hard-coded "200K token budget" / "Phase 2: DDD 180K" /
+> `clear_threshold = 150000` figures below are ILLUSTRATIVE DEFAULTS for a
+> 200K-context model class.** Real budgets are **model-specific**: 1M-context
+> models (Opus 5, Opus 4.8, GLM-5.2) hand off at **50%** (~500K tokens);
+> 200K/256K models (Sonnet/Haiku/Fable) hand off at **90%** (~180K/~230K).
+> The authoritative per-model threshold table is
+> `.claude/rules/moai/workflow/context-window-management.md` § Context
+> Window Targets — consult it before applying any figure below. The
+> `sonnet-4.5` / `haiku-4.5` `model_selection` config shown later in this
+> file is RETIRED in favor of **effort-routing** (`effortLevel`:
+> low/medium/high/xhigh/max per agent role — see
+> `.claude/rules/moai/development/agent-authoring.md` § Effort-Level
+> Calibration Matrix); the cost-lever is now effort, not a hardcoded
+> sonnet/haiku model swap.
+
+Purpose: Efficient token-budget management through strategic context loading, phase separation, and effort-routing for cost-effective AI development.
 
 Version: 1.0.0
 
@@ -8,22 +32,28 @@ Version: 1.0.0
 
 ## Quick Reference (30 seconds)
 
-Token Budget: 200K per feature (250K with overhead)
+> The figures below assume a 200K-context model class. For 1M-context
+> models (Opus 5 / Opus 4.8 / GLM-5.2) the handoff threshold is 50%
+> (~500K tokens), NOT 90% — see context-window-management.md § Context
+> Window Targets for the authoritative per-model table.
 
-Phase Allocation:
+Token Budget: model-class-dependent (200K class: ~200K per feature, ~250K with overhead; 1M class: ~500K ceiling at the 50% handoff threshold)
+
+Phase Allocation (200K-class illustration; scale proportionally for 1M-class):
 - SPEC Generation: 30K tokens
 - DDD Implementation: 180K tokens
 - Documentation: 40K tokens
 
 /clear Execution Rules:
 1. Immediately after /moai plan (saves 45-50K)
-2. When context > 150K tokens
+2. When context crosses the model-specific handoff threshold (200K class: 90% / ~150K-180K; 1M class: 50% / ~500K) — see context-window-management.md § Context Window Targets for the SSOT
 3. After 50+ conversation messages
 
-Model Selection:
-- Sonnet 4.5: Quality-critical (SPEC, security)
-- Haiku 4.5: Speed/cost (simple edits, tests)
-- Cost savings: 60-70% with strategic Haiku use
+Effort Routing (replaces the retired sonnet/haiku model_selection):
+- xhigh / max: Quality-critical (SPEC authoring, security review, Opus-tier reasoning)
+- high: Default for run-phase implementation
+- medium / low: Speed/cost (simple edits, tests, mechanical sweeps)
+- See agent-authoring.md § Effort-Level Calibration Matrix for the per-agent default
 
 Context Optimization:
 - Target: 20-30K tokens per agent

--- a/internal/template/templates/.claude/skills/moai-foundation-quality/modules/integration-patterns.md
+++ b/internal/template/templates/.claude/skills/moai-foundation-quality/modules/integration-patterns.md
@@ -90,16 +90,24 @@ When the gate or review surfaces a cluster of fixable issues:
 reached without full resolution — surface that verdict rather than
 silently stopping.
 
-## Team Mode Quality
+## Team Mode Quality (native Claude Code teammate runtime — CG Mode)
 
-In Agent Teams mode (experimental), two hooks enforce quality:
+The native Claude Code teammate runtime (the `moai cg` GLM panes + `moai cc -w
+<name> --spawn` surface — see CLAUDE.md §15 CG Mode) binds two hooks that
+enforce per-teammate quality:
 
 - **TeammateIdle hook** — validates a teammate's work before accepting idle
   state. If LSP errors exceed the threshold, the teammate is kept working.
 - **TaskCompleted hook** — validates deliverables before completion.
 
-These are the team-mode equivalents of the gate, applied per-teammate. See
-the spec-workflow rule for the full team-quality contract.
+These are the teammate-runtime equivalents of the gate, applied per-teammate.
+They bind the **native Claude Code teammate runtime**, which is DISTINCT from
+the RETIRED MoAI static Agent Teams layer (Mode 3 `agent-team` — a Phase 0.95
+tombstone since the static layer was retired; `--team` / `--mode team` emits
+`MODE_TEAM_UNAVAILABLE` and falls back to sub-agent mode). Do not conflate
+the two: the native teammate runtime is live (CG Mode), the static Agent
+Teams layer is retired. See the spec-workflow rule for the full team-quality
+contract.
 
 ## What NOT to Do
 

--- a/internal/template/templates/.claude/skills/moai-foundation-thinking/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-foundation-thinking/SKILL.md
@@ -192,7 +192,8 @@ Agent Teams:
 
 Agents:
 - manager-spec: Combined with Philosopher for full decision framework (planning absorbs strategic analysis)
-- manager-spec: Deep Questioning during requirement analysis
+- manager-develop: Deep Questioning + Critical Evaluation during run-phase reasoning (DDD/TDD root-cause analysis, architecture trade-offs)
+- super-advisor: E1-E4 escalation reasoning (bug-deadlock diagnosis, architecture decision points, second-opinion consultation, loop-deadlock verdicts)
 - team-reader (analyst role): Primary consumer for plan phase analysis
 - team-reader (researcher role): Comprehensive research methodology
 

--- a/internal/template/templates/.claude/skills/moai-meta-harness/references/agent-cross-references.md
+++ b/internal/template/templates/.claude/skills/moai-meta-harness/references/agent-cross-references.md
@@ -18,7 +18,7 @@ This skill orchestrates but does NOT replace existing agents. All named agents b
 ## Builders
 
 - `builder-harness` (artifact_type=agent) — Generates `.claude/agents/harness/*.md` content
-- `builder-harness` (artifact_type=skill) — Generates `.claude/skills/moai-harness-*/SKILL.md` content
+- `builder-harness` (artifact_type=skill) — Generates **`hns-*`** skill content under the user-owned harness namespace (per the Skills Namespace Policy in `.claude/rules/moai/development/skill-authoring.md` § Skills Namespace Policy and this skill's own SKILL.md § Namespace Separation). The `hns-*` prefix is the ONLY per-project skill namespace `builder-harness` emits; emitting under `moai-harness-*` (or any other `moai-*` prefix) inverts the namespace contract — `moai-harness-*` is template-managed and currently comprises only `moai-harness-learner` (plus the deprecated legacy-redirect `moai-meta-harness`), never per-project artifacts.
 - `builder-harness` (artifact_type=plugin) — Optional plugin bundling of generated artifacts
 
 ## Workflow Managers

--- a/internal/template/templates/.claude/skills/moai-workflow-ddd/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-ddd/SKILL.md
@@ -55,12 +55,12 @@ When to Use DDD:
 - Technical debt reduction in production systems
 - API migration and deprecation handling
 - Code modernization projects
-- When DDD is not applicable because code already exists
 - Greenfield projects (with adapted cycle - see below)
 
 When NOT to Use DDD:
 
 - When behavior changes are required (modify SPEC first)
+- When the code already exists and the goal is behavior change rather than behavior-preserving refactoring (DDD preserves behavior; for new behavior, modify the SPEC first, or use TDD)
 
 Greenfield Project Adaptation:
 
@@ -242,7 +242,7 @@ After each transformation:
 
 ### Standard DDD Session
 
-When executing DDD through moai:run in DDD mode:
+When executing DDD through moai:2-run in DDD mode:
 
 Step 1 - Initial Assessment:
 
@@ -284,7 +284,7 @@ For complex refactoring requiring multiple iterations:
 
 - Set maximum loop iterations based on scope
 - Each loop focuses on one refactoring target
-- Exit conditions: all targets addressed or iteration limit reached
+- Exit conditions: all targets adddessed or iteration limit reached
 - Progress tracking through TODO list updates
 
 ---
@@ -311,11 +311,11 @@ Structure Improvement (Goals):
 
 Apply TRUST 5 framework with DDD focus:
 
-- Tested: Characterization test coverage adequate
+- Testability: Characterization test coverage adequate
 - Readability: Naming and structure improvements verified
-- Unified: Style and structure consistent with the surrounding code
+- Understandability: Domain boundaries clearer
 - Security: No new vulnerabilities introduced
-- Trackable: All changes documented and traceable
+- Transparency: All changes documented and traceable
 
 ---
 
@@ -389,6 +389,7 @@ When DDD session encounters issues:
 
 Version: 1.0.0
 Status: Active
+Last Updated: 2026-01-16
 
 <!-- moai:evolvable-start id="rationalizations" -->
 ## Common Rationalizations

--- a/internal/template/templates/.claude/skills/moai-workflow-ddd/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-ddd/SKILL.md
@@ -389,7 +389,6 @@ When DDD session encounters issues:
 
 Version: 1.0.0
 Status: Active
-Last Updated: 2026-01-16
 
 <!-- moai:evolvable-start id="rationalizations" -->
 ## Common Rationalizations

--- a/internal/template/templates/.claude/skills/moai-workflow-project/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-project/SKILL.md
@@ -23,7 +23,7 @@ metadata:
   modularized: "true"
   tags: "workflow, project, documentation, initialization, templates, boilerplate, scaffolding, jit-docs, docs-generation"
   aliases: "moai-workflow-project"
-  related-skills: "moai-workflow-templates, moai-docs-generation, moai-workflow-jit-docs"
+  related-skills: "moai-workflow-spec, moai-workflow-docs-claim-check"
 
 # MoAI Extension: Progressive Disclosure
 progressive_disclosure:
@@ -233,7 +233,8 @@ JIT docs (just in time docs) — on-demand documentation discovery and loading b
 
 ### Primary Tools
 
-- WebFetch / WebSearch: Latest online documentation and official library docs
+- WebSearch/WebFetch (``, ``): Official library docs
+- WebFetch / WebSearch: Latest online documentation
 - Read, Grep, Glob: Local project documentation
 
 ### Trigger Patterns
@@ -246,6 +247,7 @@ JIT docs (just in time docs) — on-demand documentation discovery and loading b
 ### Loading Priority
 
 1. Local project docs (`.moai/`, README, SPEC documents)
-2. WebSearch + WebFetch (official documentation and latest online resources)
+2. WebSearch/WebFetch (official, version-matched library docs)
+3. WebSearch + WebFetch (latest online resources)
 
 Token budget: 5000 tokens per JIT load. Summarize if source exceeds budget.

--- a/internal/template/templates/.claude/skills/moai-workflow-project/references/reference.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-project/references/reference.md
@@ -4,43 +4,45 @@ Progressive Disclosure Level 2: Extended documentation for advanced users and in
 
 ---
 
-## API Reference
+## Design Surface (language-neutral contracts)
 
-### Core Classes
+This skill is delivered as a distributed Go binary plus embedded templates (no Python surface exists in the repository). The capabilities below are described as design contracts — the runtime that exposes them is the Go `moai` CLI, invoked through slash commands and `moai` subcommands. Treat this section as a capability map, not an importable API.
 
-MoaiMenuProject:
-- Purpose: Unified interface for all project management operations
-- Initialization: `MoaiMenuProject(project_path: str)`
-- Primary Methods:
-  - `initialize_complete_project(language, user_name, domains, project_type, optimization_enabled)` - Full project setup
-  - `generate_documentation_from_spec(spec_data)` - SPEC-driven doc generation
-  - `optimize_project_templates(options)` - Template optimization
-  - `get_project_status()` - Comprehensive status report
-  - `update_language_settings(settings)` - Language configuration update
+### Capabilities
 
-DocumentationManager:
+Project lifecycle:
+- Purpose: Unified surface for project management operations
+- Entry: `moai init <project>` / `moai project` (CLI), `/moai project` (slash command)
+- Operations:
+  - Complete project setup — documentation scaffolding, language init, template optimization
+  - SPEC-driven doc generation — produce documentation from a SPEC artifact
+  - Template optimization — analyze and refine embedded templates
+  - Project status report — comprehensive state summary
+  - Language configuration update — conversation / agent-prompt / docs / code-comment language
+
+Documentation generation:
 - Purpose: Template-based documentation generation
-- Key Methods:
-  - `generate_docs(project_type, language)` - Generate documentation set
-  - `update_docs_from_spec(spec_data)` - Update from SPEC data
-  - `export_docs(format, language)` - Multi-format export (md, html, pdf)
-  - `detect_project_type()` - Auto-detect project type
+- Operations:
+  - Generate documentation set for a detected project type and language
+  - Update documentation from SPEC data
+  - Multi-format export (md, html, pdf)
+  - Auto-detect project type from project markers
 
-LanguageInitializer:
+Language initialization:
 - Purpose: Language detection and configuration
-- Key Methods:
-  - `detect_project_language()` - Analyze project for language
-  - `create_multilingual_documentation_structure(language)` - Setup multilingual docs
-  - `localize_agent_prompts(base_prompt, language)` - Prompt localization
-  - `calculate_token_cost_impact(language)` - Token cost analysis
+- Operations:
+  - Detect project language from project markers
+  - Set up multilingual documentation structure
+  - Localize agent prompts for a configured language
+  - Token-cost-impact analysis per language
 
-TemplateOptimizer:
+Template optimization:
 - Purpose: Template analysis and optimization
-- Key Methods:
-  - `analyze_project_templates()` - Comprehensive template analysis
-  - `create_optimized_templates(options)` - Apply optimizations
-  - `create_backup()` - Create template backup
-  - `restore_from_backup(backup_id)` - Restore from backup
+- Operations:
+  - Comprehensive template analysis
+  - Apply optimizations (size / performance / complexity)
+  - Backup templates before mutation
+  - Restore templates from a backup
 
 ---
 
@@ -98,92 +100,40 @@ Supported Languages with Token Impact:
 
 ### Pattern 1: SPEC-Driven Documentation Workflow
 
-```python
-# Integration with /moai plan and /moai sync
-from moai_workflow_project import MoaiMenuProject
+Integration with `/moai plan` and `/moai sync` (language-neutral sequence):
 
-# Initialize project system
-project = MoaiMenuProject("/path/to/project")
+1. `/moai plan "..."` generates a SPEC artifact under `.moai/specs/SPEC-XXX/`.
+2. The orchestrator reads the SPEC and emits the documentation scaffolding via `/moai project`:
+   - Feature documentation with the SPEC's requirements
+   - API documentation with endpoint details (when applicable)
+   - Architecture documentation
+   - Multilingual versions when the project configures multiple documentation languages
+3. `/moai sync SPEC-XXX` refreshes docs and opens the PR.
 
-# After /moai plan generates SPEC
-spec_data = load_spec("SPEC-001")
+### Pattern 2: CI/CD Documentation Gate
 
-# Generate documentation from SPEC
-docs_result = project.generate_documentation_from_spec(spec_data)
+Run a documentation-completeness check in CI as a non-blocking advisory (no Python helper required):
 
-# Automatically creates:
-# - Feature documentation with requirements
-# - API documentation with endpoint details
-# - Architecture documentation
-# - Multilingual versions if configured
-```
-
-### Pattern 2: CI/CD Integration
-
-```python
-# Integration with GitHub Actions or similar
-from moai_workflow_project import MoaiMenuProject
-
-def ci_documentation_check(project_path: str) -> dict:
-    """Run documentation validation in CI pipeline."""
-    project = MoaiMenuProject(project_path)
-
-    # Get current documentation status
-    status = project.get_project_status()
-
-    # Validate completeness
-    validation_result = {
-        "docs_complete": status.documentation_completion >= 0.9,
-        "language_configured": status.language_configured,
-        "templates_optimized": status.templates_optimized,
-        "warnings": status.warnings,
-        "errors": status.errors
-    }
-
-    return validation_result
-```
+- Step 1: `moai project --status` emits a machine-readable status summary (docs completion, language configured, templates optimized, warnings, errors).
+- Step 2: A CI step parses the summary and annotates the run when `docs_completion` is below the project's threshold or any error is present.
+- Step 3: Treat the check as advisory (warn-on-failure) — documentation drift should not gate a build.
 
 ### Pattern 3: Multi-Project Template Sharing
 
-```python
-# Share optimized templates across projects
-from moai_workflow_project import TemplateOptimizer
+Optimized templates live in the distributed binary's embedded FS plus the per-project `.moai/` tree; share them via version control, not a runtime API:
 
-# Optimize master templates
-master_optimizer = TemplateOptimizer("/templates/master")
-optimized = master_optimizer.create_optimized_templates({
-    "backup_first": True,
-    "apply_all_optimizations": True
-})
-
-# Deploy to multiple projects
-for project_path in project_list:
-    project = MoaiMenuProject(project_path)
-    project.import_templates(optimized.templates)
-```
+1. Author canonical templates in the source repo (the SSOT).
+2. Other projects consume them through `moai update` (re-render from the embedded catalog) or by vendoring the relevant `.moai/` files.
+3. Backup-then-mutate: `moai update` preserves user-owned content (`hns-*` skills, project memory, specs) per the namespace separation contract — only template-managed surfaces are re-rendered.
 
 ### Pattern 4: Language-Aware Agent Delegation
 
-```python
-# Integrate with MoAI's delegation patterns
-def delegate_with_language_context(task: str, language: str):
-    """Delegate task with proper language context."""
-    project = MoaiMenuProject(".")
+When delegating to a sub-agent, the orchestrator passes the active `conversation_language` and `agent_prompt_language` (read from `.moai/config/sections/language.yaml`) in the spawn prompt. There is no library call — the delegation surface is the `Agent()` tool:
 
-    # Get localized prompt
-    localized_task = project.language_initializer.localize_agent_prompts(
-        base_prompt=task,
-        language=language
-    )
-
-    # Token cost analysis
-    cost_impact = project.language_initializer.calculate_token_cost_impact(language)
-
-    return {
-        "localized_task": localized_task,
-        "estimated_token_overhead": cost_impact
-    }
-```
+1. Resolve the active language settings from `language.yaml`.
+2. Compose the spawn prompt in `agent_prompt_language` (English by default for cost control).
+3. Inject the user's `conversation_language` so the agent's user-facing output respects it.
+4. The token-cost overhead for non-English `conversation_language` follows the table in § Language Configuration Presets (Korean/Japanese/Chinese carry a measurable overhead; English is the baseline).
 
 ---
 
@@ -193,41 +143,39 @@ def delegate_with_language_context(task: str, language: str):
 
 Issue: Documentation generation fails with template not found:
 - Cause: Template directory missing or corrupted
-- Solution: Run `project.template_optimizer.restore_from_backup()` or reinstall templates
-- Prevention: Always enable `backup_first` option before optimization
+- Solution: Re-run `moai update` to re-render templates from the embedded catalog, or restore the project's `.moai/` files from version control
+- Prevention: Keep `.moai/` under version control so template state is recoverable
 
 Issue: Language detection returns incorrect language:
 - Cause: Insufficient language indicators in project files
-- Solution: Manually set language in configuration: `project.update_language_settings({"language.conversation_language": "ko"})`
-- Prevention: Include language comments in main source files
+- Solution: Manually set the language in `.moai/config/sections/language.yaml` (`conversation_language: ko`)
+- Prevention: Include language-revealing comments / config markers in main source files
 
 Issue: Template optimization causes functionality loss:
 - Cause: Aggressive optimization removed necessary content
-- Solution: Restore from backup: `project.template_optimizer.restore_from_backup(backup_id)`
-- Prevention: Set `preserve_functionality: True` in optimization options
+- Solution: Restore `.moai/` templates from version control (the prior commit)
+- Prevention: Run optimization on a branch and verify behavior before merging
 
 Issue: Multilingual documentation structure incomplete:
 - Cause: Partial initialization or interrupted process
-- Solution: Re-run `project.language_initializer.create_multilingual_documentation_structure(language)`
-- Prevention: Ensure stable connection during initialization
+- Solution: Re-run `/moai project` to complete the documentation scaffolding
+- Prevention: Ensure the process runs to completion; resume from `.moai/specs/<SPEC>/progress.md` after an interrupt
 
 Issue: High token cost for non-English languages:
 - Cause: Localized agent prompts increase token usage
-- Solution: Use `agent_prompt_language: "english"` with `conversation_language: "ko"` for cost optimization
+- Solution: Use `agent_prompt_language: en` with `conversation_language: ko` for cost optimization
 - Prevention: Configure language settings before heavy usage
 
 ### Diagnostic Commands
 
-```python
+The diagnostic surface is the `moai` CLI, not a Python API. Run the status command and read its output:
+
+```bash
 # Full diagnostic report
-status = project.get_project_status()
-print(f"Initialization: {status.initialization_complete}")
-print(f"Language: {status.language_configuration}")
-print(f"Documentation: {status.documentation_completion}%")
-print(f"Templates: {status.template_status}")
-print(f"Errors: {status.errors}")
-print(f"Warnings: {status.warnings}")
+moai project --status
 ```
+
+The report surfaces: initialization state, language configuration, documentation completion %, template status, errors, and warnings.
 
 ### Log Locations
 
@@ -249,9 +197,8 @@ print(f"Warnings: {status.warnings}")
 
 - moai-foundation-core - Core execution patterns and SPEC workflow
 - moai-foundation-cc - Claude Code integration patterns
-- moai-workflow-docs - Unified documentation management
-- moai-workflow-templates - Template optimization strategies
-- moai-library-nextra - Advanced documentation architecture
+- moai-workflow-spec - SPEC workflow orchestration (plan / run / sync)
+- moai-workflow-docs-claim-check - README / public-docs claim validation
 
 ### Template Resources
 
@@ -271,4 +218,5 @@ print(f"Warnings: {status.warnings}")
 ---
 
 Status: Reference Documentation Complete
+Last Updated: 2025-12-06
 Skill Version: 2.0.0

--- a/internal/template/templates/.claude/skills/moai-workflow-project/references/reference.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-project/references/reference.md
@@ -218,5 +218,4 @@ The report surfaces: initialization state, language configuration, documentation
 ---
 
 Status: Reference Documentation Complete
-Last Updated: 2025-12-06
 Skill Version: 2.0.0

--- a/internal/template/templates/.claude/skills/moai-workflow-project/schemas/config-schema.json
+++ b/internal/template/templates/.claude/skills/moai-workflow-project/schemas/config-schema.json
@@ -144,9 +144,9 @@
         },
         "template_engine": {
           "type": "string",
-          "enum": ["jinja2", "handlebars", "mustache"],
-          "default": "jinja2",
-          "description": "Template engine for documentation generation"
+          "enum": ["gotemplate", "jinja2", "handlebars", "mustache"],
+          "default": "gotemplate",
+          "description": "Template engine for documentation generation (pick whichever the project's implementation language favors; the distributed MoAI runtime uses Go text/template)"
         },
         "output_directory": {
           "type": "string",
@@ -280,23 +280,19 @@
           "default": true,
           "description": "Initialize Git repository"
         },
-        "create_virtual_env": {
-          "type": "boolean",
-          "default": true,
-          "description": "Create Python virtual environment"
-        },
         "license_template": {
           "type": "string",
           "description": "Default license template"
         },
         "package_managers": {
           "type": "object",
+          "description": "Per-language package manager selection. All entries are opt-in (default disabled); MoAI auto-detects the project's language(s) from project markers (go.mod, package.json, pyproject.toml, Cargo.toml, etc.) and only proposes installation when the matching marker is present.",
           "properties": {
             "python": {
               "type": "object",
               "properties": {
-                "enabled": {"type": "boolean", "default": true},
-                "tool": {"type": "string", "enum": ["pip", "poetry", "pipenv"], "default": "pip"}
+                "enabled": {"type": "boolean", "default": false},
+                "tool": {"type": "string", "enum": ["pip", "poetry", "pipenv", "uv"], "default": "pip"}
               }
             },
             "node": {
@@ -304,6 +300,20 @@
               "properties": {
                 "enabled": {"type": "boolean", "default": false},
                 "tool": {"type": "string", "enum": ["npm", "yarn", "pnpm"], "default": "npm"}
+              }
+            },
+            "go": {
+              "type": "object",
+              "properties": {
+                "enabled": {"type": "boolean", "default": false},
+                "tool": {"type": "string", "enum": ["go"], "default": "go"}
+              }
+            },
+            "rust": {
+              "type": "object",
+              "properties": {
+                "enabled": {"type": "boolean", "default": false},
+                "tool": {"type": "string", "enum": ["cargo"], "default": "cargo"}
               }
             }
           }

--- a/internal/template/templates/.claude/skills/moai-workflow-project/templates/doc-templates/product-template.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-project/templates/doc-templates/product-template.md
@@ -1,7 +1,7 @@
-# yoda - Mission & Strategy
+# {{PROJECT_NAME}} - Mission & Strategy
 
 ## What problem do we solve?
-AI-powered content generation platform for educators and authors
+{{PROJECT_DESCRIPTION}}
 
 ## Who are our users?
 - Primary users: {{PRIMARY_USERS}}

--- a/internal/template/templates/.claude/skills/moai-workflow-project/templates/doc-templates/structure-template.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-project/templates/doc-templates/structure-template.md
@@ -1,4 +1,4 @@
-# yoda - System Architecture
+# {{PROJECT_NAME}} - System Architecture
 
 ## Overall Design Pattern
 {{ARCHITECTURE_PATTERN}}

--- a/internal/template/templates/.claude/skills/moai-workflow-project/templates/doc-templates/tech-template.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-project/templates/doc-templates/tech-template.md
@@ -1,4 +1,4 @@
-# yoda - Technology Stack
+# {{PROJECT_NAME}} - Technology Stack
 
 ## Programming Languages
 {{PROGRAMMING_LANGUAGES}}

--- a/internal/template/templates/.claude/skills/moai-workflow-spec/references/ears-deep-dive.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-spec/references/ears-deep-dive.md
@@ -32,17 +32,19 @@ Test strategy: Event simulation with expected response verification. Trigger the
 
 ## State-Driven Requirements — Conditional Behavior
 
-Format: "IF condition is true THEN action executes"
+Format: "**While** <state>, the <subject> shall <behavior>"
 
 Use case: Access control, state machines, conditional business logic.
 
 Examples:
 
-- Account status checks (IF active THEN allow login)
-- Inventory verification (IF stock > 0 THEN allow purchase)
-- Permission checks (IF admin role THEN show admin panel)
+- Account status checks (WHILE the account is active, the system shall allow login)
+- Inventory verification (WHILE stock > 0, the system shall allow purchase)
+- Permission checks (WHILE the user holds the admin role, the system shall show the admin panel)
 
 Test strategy: State setup with conditional behavior verification. Set up each state, verify the conditional branch.
+
+> **IF/THEN deprecated callout**: An earlier version of this guide described state-conditioned behavior as `IF <condition> THEN <action>`. That modality is **deprecated** under GEARS (the canonical SPEC notation as of v3.0.0). State-conditioned behavior is authored with the **While** form above; event-conditioned behavior that used to be written as `IF/THEN` is authored with the `When <event-detected>` form (see the Event-Driven section above). The lint engine emits a `LegacyEARSKeyword` finding on residual `IF/THEN` in new SPECs. See the SKILL.md IF/THEN deprecated callout for the full rationale and the backward-compatibility window.
 
 ## Unwanted Requirements — Prohibited Actions
 

--- a/internal/template/templates/.claude/skills/moai-workflow-spec/references/reference.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-spec/references/reference.md
@@ -731,4 +731,3 @@ The per-phase token shares below are fractions of the model's context window. Th
 ---
 
 Version: 1.0.0
-Last Updated: 2025-12-07

--- a/internal/template/templates/.claude/skills/moai-workflow-spec/references/reference.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-spec/references/reference.md
@@ -281,11 +281,14 @@ Technical:
 - Examples: "User Authentication System", "Payment Processing API"
 
 **Status Values**:
-- Planned: SPEC created, not yet started
-- In Progress: Implementation in RUN phase
-- Completed: All success criteria met
-- Blocked: Waiting for dependency or decision
-- Deprecated: Replaced by newer SPEC
+
+The `status` field uses the canonical 8-value enum owned by `.claude/rules/moai/development/spec-frontmatter-schema.md` § Status Enum (8 values). The list below is illustrative only; when it diverges from the schema SSOT, the schema wins.
+
+- Canonical enum (8 values): `draft`, `planned` (legacy-optional), `in-progress`, `implemented`, `completed`, `superseded`, `archived`, `rejected`
+- Active V3R6 flow: `draft → in-progress → implemented → completed` (manager-develop performs `draft → in-progress` on the first run-phase commit)
+- Terminal states: `superseded` (replaced by a newer SPEC), `archived`, `rejected`
+
+> The legacy 5-value list that previously appeared here (`Planned / In Progress / Completed / Blocked / Deprecated`) is superseded. `Blocked` and `Deprecated` are NOT members of the canonical enum — a blocked SPEC stays at its current status and surfaces the blocker through other channels, and a replaced SPEC uses `superseded`. See the schema SSOT for the authoritative list and the Status Transition Ownership Matrix.
 
 **Priority Levels**:
 - High: Critical for MVP, blocking dependencies
@@ -628,7 +631,9 @@ Full Stack Feature Complete
 
 ### Token Budget Management
 
-**PLAN Phase Token Usage** (~30% of 200K):
+The per-phase token shares below are fractions of the model's context window. The window is **model-class-dependent** — 200K for Sonnet/Opus-standard and Haiku, 256K for Fable, 1M for Opus 5 / Opus 4.8 / GLM-5.2. Treat "the budget" as the model-class threshold from `.claude/rules/moai/workflow/context-window-management.md` § Context Window Targets, NOT a fixed 200K. A 1M-context model tolerates a proportionally larger absolute spend before the `/clear` handoff threshold fires.
+
+**PLAN Phase Token Usage** (~30% of the active window):
 - User input analysis: 5K tokens
 - Requirement clarification dialogue: 15K tokens
 - EARS pattern generation: 10K tokens
@@ -638,7 +643,7 @@ Full Stack Feature Complete
 
 **Strategy**: Execute /clear after SPEC document saved to disk
 
-**RUN Phase Token Usage** (~60% of 200K):
+**RUN Phase Token Usage** (~60% of the active window):
 - SPEC document loading: 5K tokens
 - DDD cycle execution: 100K tokens
 - Code generation: 20K tokens
@@ -646,7 +651,7 @@ Full Stack Feature Complete
 - Quality validation: 10K tokens
 - Buffer: 30K tokens
 
-**SYNC Phase Token Usage** (~10% of 200K):
+**SYNC Phase Token Usage** (~10% of the active window):
 - Documentation generation: 10K tokens
 - API spec updates: 5K tokens
 - Commit message generation: 2K tokens
@@ -726,3 +731,4 @@ Full Stack Feature Complete
 ---
 
 Version: 1.0.0
+Last Updated: 2025-12-07

--- a/internal/template/templates/.claude/skills/moai-workflow-testing/modules/automated-code-review.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-testing/modules/automated-code-review.md
@@ -5,6 +5,8 @@
 > Time: 35+ minutes
 > Dependencies: static analyzers for your language, WebSearch/WebFetch (optional)
 
+> **TRUST 5 disambiguation** — the five-lens set used in this module (**Truthfulness / Relevance / Usability / Safety / Timeliness**) is a code-review rubric local to this skill and is NOT the project's canonical TRUST 5 framework. The canonical MoAI TRUST 5 is **Tested / Readable / Unified / Secured / Trackable** (see `.claude/rules/moai/core/moai-constitution.md` § Quality Gates and the `moai-foundation-quality` skill). When a MoAI doc says "TRUST 5" without qualification, it means the canonical Tested/Readable/Unified/Secured/Trackable set; the Truthfulness/Relevance/Usability/Safety/Timeliness rubric applies only inside this code-review module.
+
 ## Quick Reference
 
 ### Core Capabilities
@@ -210,4 +212,5 @@ automated-code-review.md (this file)
 ---
 
 Version: 2.0.0 (Modular Structure)
+Last Updated: 2026-01-06
 Module: `modules/automated-code-review.md`

--- a/internal/template/templates/.claude/skills/moai-workflow-testing/modules/automated-code-review.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-testing/modules/automated-code-review.md
@@ -212,5 +212,4 @@ automated-code-review.md (this file)
 ---
 
 Version: 2.0.0 (Modular Structure)
-Last Updated: 2026-01-06
 Module: `modules/automated-code-review.md`

--- a/internal/template/templates/.claude/skills/moai-workflow-testing/modules/automated-code-review/trust5-framework.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-testing/modules/automated-code-review/trust5-framework.md
@@ -219,7 +219,6 @@ TRUST 5 uses weighted scoring with category-specific weights:
 ---
 
 Version: 1.1.0 (Modularized)
-Last Updated: 2026-01-06
 Module: `modules/automated-code-review/trust5-framework.md`
 
 ## Submodules

--- a/internal/template/templates/.claude/skills/moai-workflow-testing/modules/automated-code-review/trust5-framework.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-testing/modules/automated-code-review/trust5-framework.md
@@ -6,6 +6,8 @@
 > Time: 25+ minutes
 > Dependencies: WebSearch/WebFetch, source parser (AST)
 
+> **TRUST 5 disambiguation** — the five-lens set used in this deep dive (**Truthfulness / Relevance / Usability / Safety / Timeliness**) is a code-review rubric local to the automated-code-review skill and is NOT the project's canonical TRUST 5 framework. The canonical MoAI TRUST 5 is **Tested / Readable / Unified / Secured / Trackable** (see `.claude/rules/moai/core/moai-constitution.md` § Quality Gates and the `moai-foundation-quality` skill). When a MoAI doc says "TRUST 5" without qualification, it means the canonical Tested/Readable/Unified/Secured/Trackable set; the Truthfulness/Relevance/Usability/Safety/Timeliness rubric applies only inside this code-review skill.
+
 ## Quick Reference
 
 ### TRUST 5 Methodology
@@ -217,6 +219,7 @@ TRUST 5 uses weighted scoring with category-specific weights:
 ---
 
 Version: 1.1.0 (Modularized)
+Last Updated: 2026-01-06
 Module: `modules/automated-code-review/trust5-framework.md`
 
 ## Submodules

--- a/internal/template/templates/.claude/skills/moai-workflow-worktree/modules/moai-adk-integration.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-worktree/modules/moai-adk-integration.md
@@ -3,40 +3,40 @@
 Purpose: Detailed integration patterns for moai-worktree with MoAI-ADK Plan-Run-Sync workflow including plan phase automation, DDD integration, and cleanup workflows.
 
 Version: 1.0.0
+Last Updated: 2026-01-06
 
 ---
 
 ## Quick Reference (30 seconds)
 
-MoAI-ADK Integration Points:
-- /moai plan: Automatic worktree creation after SPEC generation
-- /moai run: DDD execution in isolated worktree environment
-- /moai sync: Worktree sync with documentation updates
-- Cleanup: Automatic removal of merged worktrees
+MoAI-ADK Integration Points (EnterWorktree-first doctrine):
+- Worktree entry: User runs `moai cc -w <name>` to enter a worktree; plan does NOT auto-create one. The legacy `/moai plan --worktree` launch action is retired.
+- /moai plan: Runs in the main checkout (no worktree) on a `plan/SPEC-XXX` branch.
+- /moai run: If the user entered a worktree, DDD execution happens there; otherwise it runs on a feature branch in the main checkout.
+- /moai sync: Reuses the SAME worktree the user entered for run (do NOT recreate).
+- Cleanup: Disposal via `moai worktree done SPEC-XXX` AFTER both run PR AND sync PR merge.
 
 ---
 
 ## Plan Phase Integration (/moai plan)
 
-### Automatic Worktree Creation
+### Worktree Is NOT Auto-Created by Plan
 
-After SPEC creation, the worktree system automatically generates an isolated development environment.
+The plan phase does NOT create a worktree. A worktree is entered by the USER before a phase runs, not provisioned by a workflow step. The EnterWorktree-first doctrine is the SSOT:
 
-Branch Naming Convention:
+- New-session launch (post-`/clear` or new terminal): `moai cc -w <name>` (or `moai glm -w` / `moai cg -w`). The `-w` flag accepts both short names (resolved under `.claude/worktrees/`) and absolute paths under `~/.moai/worktrees/<project>/...`.
+- Current-session re-entry (same session continuing): the runtime tool `EnterWorktree(<path>)`.
+- The retired `/moai plan --worktree` flag and the retired `moai worktree new` command MUST NOT be presented as live entry points.
+
+Branch Naming Convention (informational — the launcher handles this):
 - Pattern: feature/SPEC-{id}-{title-kebab-case}
 - Example: SPEC-001 with title "User Auth" becomes feature/SPEC-001-user-auth
 
 Worktree Path Pattern:
-- Default: {repo}/.moai/worktrees/{project-name}/SPEC-{id}
-- Configurable via worktree_root setting
+- L1 Claude-native (ephemeral): `{repo}/.claude/worktrees/<auto-name>/`
+- L2 MoAI persistent (SPEC-scoped): `~/.moai/worktrees/{project-name}/SPEC-{id}/`
 
-Creation Workflow:
-1. SPEC is created with /moai plan
-2. Worktree new command is invoked automatically if auto_create is enabled
-3. Branch is created from configured base branch (default: main)
-4. Template is applied if specified
-5. Worktree is registered in the central registry
-6. User receives guidance for switching to the new worktree
+Reference: the canonical L1/L2 layering and the EnterWorktree-first policy live in `.claude/rules/moai/workflow/worktree-integration.md` § Terminology Glossary.
 
 ### Template-Based Setup
 
@@ -134,8 +134,8 @@ After worktree sync, documentation updates can be extracted:
 After successful PR merge, worktrees can be automatically cleaned up.
 
 Cleanup Triggers:
-- Manual cleanup with clean command
-- Automated cleanup when cleanup_merged is enabled
+- Manual cleanup with the `moai worktree done SPEC-XXX` command (the canonical disposal path — runs only after BOTH run PR AND sync PR merge)
+- Automated cleanup when `workflow.worktree.auto_cleanup` is opted in (default: off)
 - Scheduled cleanup for stale worktrees
 
 Cleanup Options:
@@ -153,14 +153,14 @@ Registry Maintenance:
 
 ## Team Collaboration Patterns
 
-### Shared Worktree Registry
+### Per-Developer Worktree Conventions
 
-For team environments, configure a shared registry accessible to all developers.
+There is no shared-registry config field on `WorkflowWorktreeConfig` (the legacy `registry_type: "team"` / `shared_registry_path` / `developer_prefix` entries are NOT real keys). Team coordination is convention-based: each developer enters their own L2 worktree (`~/.moai/worktrees/{project}/SPEC-{id}/`) and the team coordinates via the SPEC artifacts and PRs in version control, not via a runtime-shared registry.
 
-Team Registry Configuration:
-- registry_type: Set to "team" for shared mode
-- shared_registry_path: Network-accessible registry location
-- developer_prefix: Automatic prefix for developer-specific worktrees
+Coordination conventions:
+- Each developer uses their own worktree under their own home directory.
+- The SPEC artifact (`.moai/specs/SPEC-XXX/`) is the shared state — it lives in the repo, not a per-worktree registry.
+- PRs are the integration surface — the team merges feature branches rather than maintaining a network-accessible worktree registry.
 
 Synchronization:
 - Local registry syncs with team registry periodically
@@ -188,22 +188,18 @@ Access Levels:
 
 ### MoAI Configuration Integration
 
-Worktree settings live in .moai/config/sections/workflow.yaml (the
-workflow.worktree section); worktree_root is configured in
-.moai/config/sections/git-strategy.yaml:
+Worktree settings live in `.moai/config/sections/workflow.yaml` under the `workflow.worktree` section. The keys below are the REAL Go struct fields (`WorkflowWorktreeConfig` in `internal/config/types.go`, defaults in `internal/config/defaults.go`). All three automation toggles ship `false` by default — worktree automation is explicit user opt-in per the EnterWorktree-first policy.
 
-workflow.worktree section:
-- auto_create: Enable automatic worktree creation (default: false)
-- auto_sync: Enable automatic synchronization (default: true)
-- cleanup_merged: Remove worktrees for merged branches (default: true)
-- worktree_root: Base directory for worktrees (default: {repo}/.moai/worktrees)
-- default_base: Default base branch (default: main)
-- sync_strategy: Sync method - merge, rebase, or squash (default: merge)
-- registry_type: local or team (default: local)
+workflow.worktree section (real keys + real defaults):
+- `auto_cleanup` (bool, default: **false**) — automatically remove worktrees. Opt-in; off by default to avoid unintended sprawl.
+- `auto_create` (bool, default: **false**) — automatically create worktrees. Opt-in; the default flow runs phases on a feature branch in the main checkout.
+- `auto_merge` (bool, default: **false**) — automatically merge worktree branches. Opt-in; off by default.
+- `session_name_pattern` (string, default: `moai-{ProjectName}-{SPEC-ID}`) — naming pattern for sessions spawned inside a worktree.
+- `tmux_preferred` (bool, default: **true**) — prefer tmux for worktree session display.
 
-Template Settings:
-- template_dir: Custom template location
-- default_template: Template applied when none specified
+Notes:
+- The previously-documented fields `auto_sync`, `cleanup_merged`, `worktree_root`, `default_base`, `sync_strategy`, and `registry_type` are NOT fields on the Go struct and MUST NOT be presented as live config keys. (The legacy content that listed them with `true` defaults inverted the real defaults and is corrected here.)
+- Worktree automation defaults to OFF in both the distributed template and the local dev config. Changing a default requires a dedicated SPEC.
 
 ---
 
@@ -242,4 +238,5 @@ For failed synchronization:
 ---
 
 Version: 1.0.0
+Last Updated: 2026-01-06
 Module: MoAI-ADK workflow integration patterns for Plan-Run-Sync phases

--- a/internal/template/templates/.claude/skills/moai-workflow-worktree/modules/moai-adk-integration.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-worktree/modules/moai-adk-integration.md
@@ -3,7 +3,6 @@
 Purpose: Detailed integration patterns for moai-worktree with MoAI-ADK Plan-Run-Sync workflow including plan phase automation, DDD integration, and cleanup workflows.
 
 Version: 1.0.0
-Last Updated: 2026-01-06
 
 ---
 
@@ -238,5 +237,4 @@ For failed synchronization:
 ---
 
 Version: 1.0.0
-Last Updated: 2026-01-06
 Module: MoAI-ADK workflow integration patterns for Plan-Run-Sync phases

--- a/internal/template/templates/.claude/skills/moai-workflow-worktree/modules/resource-optimization.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-worktree/modules/resource-optimization.md
@@ -3,7 +3,6 @@
 Purpose: Disk space management, memory-efficient operations, performance optimization, and error handling patterns for worktree management.
 
 Version: 1.0.0
-Last Updated: 2026-01-06
 
 ---
 
@@ -292,5 +291,4 @@ Based on Performance:
 ---
 
 Version: 1.0.0
-Last Updated: 2026-01-06
 Module: Resource optimization patterns for disk, memory, performance, and error handling

--- a/internal/template/templates/.claude/skills/moai-workflow-worktree/modules/resource-optimization.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-worktree/modules/resource-optimization.md
@@ -3,6 +3,7 @@
 Purpose: Disk space management, memory-efficient operations, performance optimization, and error handling patterns for worktree management.
 
 Version: 1.0.0
+Last Updated: 2026-01-06
 
 ---
 
@@ -90,7 +91,7 @@ Cleanup Priority:
 For large registries, use streaming JSON parsing to avoid loading entire file.
 
 Streaming Pattern:
-- Use incremental JSON parser (ijson)
+- Use a streaming/incremental JSON parser appropriate to the implementation language (e.g. `encoding/json` `Decoder` token streaming in Go, `ijson` in Python) rather than loading the whole document into memory
 - Process worktrees one at a time
 - Apply filters during iteration
 - Yield matching worktrees
@@ -181,25 +182,21 @@ Batch Cleanup:
 
 ## Error Handling
 
-### Error Hierarchy
+### Error Categories
 
-Structured error classes for different failure types:
+Structured error categories for different failure types (design-level — the names below are category labels, not Python class syntax; each implementation language surfaces these as its own error/exception types with equivalent fields):
 
-WorktreeError: Base class for all worktree errors
-- message: Human-readable error description
-- context: Additional debugging information
+WorktreeError — base category for all worktree errors
+- Carries: a human-readable message, plus optional debugging context
 
-WorktreeCreationError: Errors during worktree creation
-- partial_worktree: Path to incomplete worktree for cleanup
-- creation_step: Step at which creation failed
+WorktreeCreationError — failures during worktree creation
+- Carries: the path to a partial worktree (for cleanup), and the creation step at which the failure occurred
 
-SynchronizationError: Errors during sync operations
-- sync_state: State at time of failure
-- backup_ref: Git ref for recovery
+SynchronizationError — failures during sync operations
+- Carries: the sync state at time of failure, and a backup git ref for recovery
 
-RegistryError: Errors related to registry operations
-- registry_path: Path to problematic registry
-- operation: Operation that failed
+RegistryError — failures related to registry operations
+- Carries: the registry path involved, and the operation that failed
 
 ### Recovery Patterns
 
@@ -295,4 +292,5 @@ Based on Performance:
 ---
 
 Version: 1.0.0
+Last Updated: 2026-01-06
 Module: Resource optimization patterns for disk, memory, performance, and error handling

--- a/internal/template/templates/.claude/skills/moai-workflow-worktree/modules/tools-integration.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-worktree/modules/tools-integration.md
@@ -3,7 +3,6 @@
 Purpose: Integration patterns for moai-worktree with development tools, IDEs, terminals, CI/CD pipelines, and monitoring systems.
 
 Version: 1.0.0
-Last Updated: 2026-01-06
 
 ---
 
@@ -268,5 +267,4 @@ Monitoring Integration Errors:
 ---
 
 Version: 1.0.0
-Last Updated: 2026-01-06
 Module: Development tools and external system integration patterns

--- a/internal/template/templates/.claude/skills/moai-workflow-worktree/modules/tools-integration.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-worktree/modules/tools-integration.md
@@ -3,6 +3,7 @@
 Purpose: Integration patterns for moai-worktree with development tools, IDEs, terminals, CI/CD pipelines, and monitoring systems.
 
 Version: 1.0.0
+Last Updated: 2026-01-06
 
 ---
 
@@ -59,29 +60,21 @@ For IntelliJ, PyCharm, and WebStorm:
 
 ### Shell Profile Enhancement
 
-Add to .bashrc or .zshrc for improved worktree experience.
+Add to .bashrc or .zshrc for a slightly smoother worktree session.
 
 Completion Support:
-- Tab completion for worktree IDs using registry data
-- Command option completion for all moai-worktree subcommands
+- Tab completion for the live `moai worktree` subcommands (`done`, `clean`, `remove`) using the binary's built-in help
 
 Prompt Customization:
-- Detect if current directory is within a worktree
+- Detect if current directory is within a worktree (`.claude/worktrees/` or `~/.moai/worktrees/`)
 - Display SPEC ID in prompt when in worktree context
 - Color coding for worktree status
 
-Navigation Aliases:
-- mw: Short alias for moai-worktree
-- mwl: List worktrees
-- mws: Switch to worktree
-- mwg: Navigate with eval pattern
-- mwsync: Sync current worktree
-- mwclean: Clean merged worktrees
+Navigation:
+- Enter a worktree with `moai cc -w <name>` (new session) or `EnterWorktree(<path>)` (current session).
+- Dispose with `moai worktree done SPEC-XXX` (after run + sync PRs merge) or `moai worktree clean` / `moai worktree remove`.
 
-Quick Functions:
-- mwnew: Create and switch to new worktree in one command
-- mwdev: Switch to worktree and start development with /moai run
-- mwpush: Sync worktree and push to remote branch
+Note: the legacy shell aliases `mw`/`mwl`/`mws`/`mwg`/`mwsync`/`mwclean`/`mwnew` referenced subcommands (`list`, `switch`, `go`, `sync`, `new`) that the Go binary does NOT expose — only `done`, `clean`, and `remove` are live `moai worktree` subcommands. Those aliases are omitted here to avoid steering users at non-existent commands.
 
 ---
 
@@ -221,7 +214,7 @@ Operation Grouping:
 - Sequential fallback for resource constraints
 
 Execution Strategy:
-- ThreadPoolExecutor for parallel sync
+- Bounded worker pool for parallel sync (language-neutral — use the project language's standard concurrency primitive, e.g. a bounded goroutine worker pool in Go, a `ThreadPoolExecutor` only in Python projects)
 - Configurable worker count
 - Result aggregation with error handling
 
@@ -275,4 +268,5 @@ Monitoring Integration Errors:
 ---
 
 Version: 1.0.0
+Last Updated: 2026-01-06
 Module: Development tools and external system integration patterns

--- a/internal/template/templates/.claude/skills/moai/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai/SKILL.md
@@ -93,9 +93,12 @@ Only if BOTH Priority 1 AND Priority 2 did not match: Classify the intent of the
 - Quality gate language (format, check, pre-commit, quality gate) routes to **gate**
 - E2E and user-journey testing language (e2e, end-to-end test, browser test, mobile app test, desktop app test, user journey) routes to **e2e** — semantic exemplars; any conversation_language expressing e2e-testing intent routes identically
 - Security language (security, audit, owasp, vulnerability, injection, xss, csrf) routes to **review** (with `--security` scope)
+- Code-review language (review my code, code review, check my PR, look at my changes, take a look at my changes) routes to **review**
 - Error and fix language (fix, error, bug, broken, failing, lint) routes to **fix**
 - Iterative and repeat language (keep fixing, until done, repeat, iterate, all errors) routes to **loop**
+- Dead-code and cleanup language (dead code, unused code, safely remove, cleanup, orphaned code) routes to **clean**
 - Documentation language (document, sync, docs, readme, changelog, PR) routes to **sync** or **project**
+- Architecture-map language (architecture map, code maps, dependency graph, structure documentation) routes to **codemaps**
 - Feedback and bug report language (report, feedback, suggestion, issue) routes to **feedback**
 - MX tag language (mx tag, annotation, code context, legacy annotate) routes to **mx**
 - Implementation language (implement, build, create, add, develop) with clear scope routes to **moai** (default autonomous)
@@ -124,7 +127,7 @@ For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/plan.md
 Purpose: Implement SPEC requirements through configured development methodology.
 Agents: manager-develop (cycle_type=ddd|tdd per quality.yaml, primary), manager-git
 Skills: moai-workflow-tdd, moai-workflow-ddd (per delegation.yaml; cycle_type-selected) + domain moai-ref-* injected per mission
-Flags: --resume SPEC-XXX, --team
+Flags: --resume SPEC-XXX, --team (RETIRED — see Execution Mode Flags)
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/run.md
 
 ### sync - Documentation Sync and PR
@@ -163,7 +166,7 @@ For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/goal.md
 Purpose: Autonomously detect and fix LSP errors, linting issues, and type errors.
 Agents: manager-develop (cycle_type=autofix), Agent(general-purpose) with domain whitelist (fixes)
 Skills: moai-workflow-ddd (per delegation.yaml) + domain moai-ref-* injected per mission
-Flags: --dry, --sequential, --level N, --resume, --team
+Flags: --dry, --sequential, --level N, --resume, --team (RETIRED — see Execution Mode Flags)
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/fix.md
 
 ### loop - Iterative Auto-Fix
@@ -178,7 +181,7 @@ For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/loop.md
 
 Purpose: Scan codebase and add @MX code-level annotations for AI agent context.
 Agents: Explore (scan), Agent(general-purpose) with backend scope (annotation)
-Flags: --all, --dry, --priority P1-P4, --force, --team
+Flags: --all, --dry, --priority P1-P4, --force, --team (RETIRED — see Execution Mode Flags)
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/mx.md
 
 ### review - Code Review
@@ -186,7 +189,7 @@ For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/mx.md
 Purpose: Multi-perspective code review with security, performance, quality, and UX analysis.
 Agents: sync-auditor (review), Agent(general-purpose) with security scope
 Skills: moai-foundation-quality, moai-ref-owasp-checklist (per delegation.yaml; per-perspective ref skills injected per lens)
-Flags: --staged, --branch, --security, --team
+Flags: --staged, --branch, --security, --team (RETIRED — see Execution Mode Flags)
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/review.md
 
 ### clean - Dead Code Removal
@@ -210,7 +213,7 @@ Purpose: Full autonomous research -> plan -> annotate -> run -> sync pipeline.
 Phases: Parallel Exploration (research.md) -> SPEC Generation -> Annotation Cycle -> Implementation -> Sync
 Agents: Explore, manager-spec, plan-auditor (quality gate), manager-develop, manager-docs, manager-git, sync-auditor (quality gate)
 Skills: moai-workflow-spec, moai-workflow-tdd (per delegation.yaml) + domain moai-ref-* injected per mission
-Flags: --loop, --max N, --branch, --pr, --resume SPEC-XXX, --team, --solo, --issue (opt-in; default skips GitHub Issue creation per the late-branch opt-in policy)
+Flags: --loop, --max N, --branch, --pr, --resume SPEC-XXX, --team (RETIRED — see Execution Mode Flags), --solo, --issue (opt-in; default skips GitHub Issue creation per the late-branch opt-in policy)
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/moai.md
 
 ### project - Project Documentation
@@ -311,6 +314,15 @@ For English (`en` conversation_language), translate the message; the structure r
 
 Step 2 - Route to Workflow:
 Apply the Intent Router (Priority 1 through Priority 4) to determine the target workflow. If ambiguous, use AskUserQuestion to clarify with the user.
+
+Step 2.2 - Record Routing Decision:
+Immediately after routing resolves (Step 2), record the routing decision to the append-only routing-ledger (`.moai/state/routing-ledger.jsonl`) so that auto-invocation is observable. Run:
+
+```
+echo "<raw request text>" | moai harness ledger record --subcommand <matched> --mode <phase-4-mode> --tier <tier> --level <harness-level> --session <session-id>
+```
+
+The request text is piped via stdin and only a privacy-preserving digest is stored, never verbatim user text (policy source: § Routing Observation Ledger above). This step is opt-in and fail-open: if the `moai` CLI is absent from PATH or the command exits non-zero, log nothing and continue — it NEVER blocks routing, never gates the workflow, and never triggers a retry loop. An un-recorded dispatch is an observation gap, not an error.
 
 Step 2.5 - Project Documentation Check:
 Before executing plan, run, sync, fix, loop, or default workflows, verify project documentation exists by checking for `.moai/project/product.md`. If product.md does NOT exist, use AskUserQuestion to ask the user (in their conversation_language):

--- a/internal/template/templates/.moai/config/sections/delegation.yaml
+++ b/internal/template/templates/.moai/config/sections/delegation.yaml
@@ -71,7 +71,7 @@ delegation:
             agents: []                     # orchestrator + stop-goal Stop hook
             skills: []
         default:                           # natural-language autonomous pipeline
-            agents: [Explore, manager-spec, plan-auditor, manager-develop, manager-docs, sync-auditor]
+            agents: [Explore, manager-spec, plan-auditor, manager-develop, manager-docs, manager-git, sync-auditor]  # manager-git is Tier-L / --pr conditional (Late-Branch closure)
             skills: [moai-workflow-spec, moai-workflow-tdd]
 
     # Domain skills the orchestrator injects per mission domain (0-3 per spawn,
@@ -79,7 +79,7 @@ delegation:
     # signal; zero matches is valid.
     domain_skills:
         backend:   [moai-ref-api-patterns, moai-domain-backend]
-        frontend:  [moai-ref-react-patterns, moai-domain-frontend, moai-ref-seo]
+        frontend:  [moai-ref-react-patterns, moai-domain-frontend, moai-ref-ui-polish, moai-ref-seo]
         database:  [moai-domain-database]
         security:  [moai-ref-owasp-checklist, moai-ref-llm-security, moai-ref-secops, moai-ref-supply-chain]
         testing:   [moai-ref-testing-pyramid, moai-workflow-testing]
@@ -89,6 +89,9 @@ delegation:
     # Per-agent conditional skills (mirrors each agent's Conditional Skill
     # Loading section). The agent loads these on demand when its stated trigger
     # arises, not preemptively.
+    # NOTE: plan-auditor, sync-auditor, builder-harness, and manager-git
+    # intentionally carry NO conditional skills here (evaluators + builder +
+    # git-via-domain_skill) — their omission is by design, not a gap.
     agents:
         manager-spec:    [moai-workflow-spec, moai-foundation-thinking]
         manager-develop: [moai-workflow-tdd, moai-workflow-ddd]


### PR DESCRIPTION
## 배경

GOSS 오빠 핵심 고통 — **"skill, hooks, agents가 제대로 자동 호출되는지 알 수 없다"** — 를 진단하고 해결했습니다.

## 방법

10카테고리 read-only fanout 감사(정적 분석 + routing-ledger 실측 + 8개 다언어 시뮬레이션)로 3.x 부합성 결함 **56건** 발견. 이 중 **55건 수정** (1건 M11은 감사 오탐으로 판명·적용 불가).

## 해결 — 3축

**1. 측정 인프라 (가장 근본)**
- routing-ledger가 1 stale entry로 비어 있던 원인 = `moai harness ledger record`가 SKILL.md 서문에만 언급되고 Step 시퀀스에 없어 Claude가 놓침
- `Step 2.2 Record Routing Decision` 삽입 → Go 코드 수정 불필요

**2. 자연어 라우팅 구멍**
- `clean`(dead-code) / `review`(일반) / `codemaps` P3 semantic cue 추가

**3. 스킬 고아 해제**
- `moai-ref-ui-polish` → delegation.yaml `frontend` 등록 (어디서도 injection 없던 가장 뚜렷한 자동호출 실패 해소)
- `manager-git` default 추가 + per-agent 주석

## 주요 수정

- **C1 (critical)**: `manager-git.md` retired Hybrid Trunk main-direct → all-tier PR-mandatory 재작성 (로컬+템플릿 미러)
- foundation-cc 조작 CC settings/IAM 스키마 정정 + tiered 네이밍 disambiguation + 동시성 cap 10→20
- foundation-core Tier S direct commit 폐지(2026-07-20) + 200K→model-specific
- workflow-project 유령 Python API(`MoaiMenuProject`) 제거
- workflow-worktree EnterWorktree-first + Go struct 정합 (`auto_cleanup`/`auto_create`/`auto_merge` 모두 `false`)
- `settings.json.tmpl` `defaultMode` 제거 (CLAUDE.local.md §22.1 정합)
- `internal_content_leak_test.go` CI C2 prefix `HRN`/`ORC` 확장
- 내부 토큰(`LANG-COMPLIANCE-001`/`REQ-HRN-003`/`REQ-ORC-001`/`SPEC-V3R5-WO-001`) genericize

## 검증

- `go vet ./...` ✓
- `make build` ✓ (embedded template recompile)
- `go test ./internal/template/` ✓ (template neutrality CI — C5 위반 발견·즉시 수정 후 통과)
- `go test ./...` ✓

## 후속 (이번 scope 밖)

6건 별개 후보: `worktree-commands.md` phantom subcommand, `ci-watch-protocol.md` 한국어 잔여, `thinking` SKILL.md team-reader 참조, `SKILL.md` L54 global `--team` divergence, `execution-rules.md` Git Strategy 3-Mode, `moai-workflow-ci-loop` dev-only mirror 정리.

## 감사 보고서

`.moai/reports/moai-3x-conformance-audit-20260803.md` (별도 산출물 — 이 PR에는 포함되지 않음)

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Go and Rust project setup options, optional Python tooling, and `uv` support.
  * Set Go templates as the default documentation engine.
  * Added project-name and description placeholders to generated documents.
  * Improved routing for reviews, cleanup, architecture mapping, and pull requests.

* **Documentation**
  * Updated workflow, worktree, permissions, delegation, testing, and requirements guidance.
  * Clarified supported Claude Code configuration, agent behavior, and current command usage.
  * Replaced outdated examples, terminology, and unsupported settings.

* **Bug Fixes**
  * Corrected command, permission, template, and requirement-format documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->