### PR TITLE
fix(launcher): resume 런치 시 settings.local.json defaultMode 덮어쓰기 방지

### DIFF
--- a/internal/cli/launcher.go
+++ b/internal/cli/launcher.go
@@ -628,18 +628,18 @@ func launchClaudeDefault(profileName string, extraArgs []string) error {
 		return fmt.Errorf("claude not found in PATH. Install Claude Code first")
 	}
 
-	// 3. Read profile preferences and sync to project config
+	// 3. Read profile preferences and sync to project config. The
+	// permissions.defaultMode sync to settings.local.json is deferred until the
+	// resume/continue mode is known (step 5b below): a session-resume launch
+	// must not rewrite a defaultMode the user set by hand.
 	prefs, _ := profile.ReadPreferences(profileName)
+	var settingsLocalPath string
 	if root, err := findProjectRoot(); err == nil {
 		moaiDir := filepath.Join(root, ".moai")
 		if info, err := os.Stat(moaiDir); err == nil && info.IsDir() {
 			_ = profile.SyncToProjectConfig(root, prefs)
 		}
-		// Sync permission mode preference to settings.local.json permissions.defaultMode
-		settingsLocalPath := filepath.Join(root, defs.ClaudeDir, defs.SettingsLocalJSON)
-		if err := syncPermissionModeToSettingsLocal(settingsLocalPath, prefs.PermissionMode); err != nil {
-			_, _ = fmt.Fprintf(os.Stderr, "Warning: failed to sync permission mode setting: %v\n", err)
-		}
+		settingsLocalPath = filepath.Join(root, defs.ClaudeDir, defs.SettingsLocalJSON)
 	}
 
 	// 4. Read project settings.local.json for DO_CLAUDE_* flags (overrides profile)
@@ -693,6 +693,18 @@ func launchClaudeDefault(profileName string, extraArgs []string) error {
 			} else {
 				passThrough = append(passThrough, arg)
 			}
+		}
+	}
+
+	// 5b. Sync the profile permission-mode preference to settings.local.json
+	// ONLY on a fresh-session launch. A resume (--continue / DO_CLAUDE_CONTINUE)
+	// launch reopens an existing session rather than applying new settings, so
+	// rewriting permissions.defaultMode there would clobber a value the user
+	// edited by hand. cont is fully resolved by now (settings DO_CLAUDE_CONTINUE
+	// plus the -c/--continue arg parsed in the loop above).
+	if !cont && settingsLocalPath != "" {
+		if err := syncPermissionModeToSettingsLocal(settingsLocalPath, prefs.PermissionMode); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "Warning: failed to sync permission mode setting: %v\n", err)
 		}
 	}
 


### PR DESCRIPTION
## 현상

`moai cc/glm/cg`로 claude를 띄울 때 — resume(`--continue` / `DO_CLAUDE_CONTINUE=true`) 런치를 포함해 — 프로필의 `permissions.defaultMode`가 매번 `.claude/settings.local.json`에 다시 쓰인다. 사용자가 settings.local.json에서 직접 잡은 권한 모드가 프로필 값으로 덮어씌워진다. "moai가 claude 설정을 맘대로 바꾼다"의 가장 직접적 경로.

## 원인

`launchClaudeDefault`(`internal/cli/launcher.go`)가 3단계에서 `syncPermissionModeToSettingsLocal`을 호출해 defaultMode를 동기화하는데, 이 시점에는 아직 resume 여부(`cont`)를 모른다. `cont`는 settings의 `DO_CLAUDE_CONTINUE`(line 663) + args의 `-c`/`--continue`(line 682) 파싱 후에야 결정된다. 즉 resume인지 알기도 전에 설정을 써버린다.

## 수정 (최소, 1지점)

- 3단계: `syncPermissionMode` 호출을 빼고 `settingsLocalPath`만 함수 스코프에 저장.
- args 파싱 완료 후(신규 5b): `cont`가 완전히 결정된 뒤 `if !cont && settingsLocalPath != ""` 로 감싸서 동기화 실행.
- 결과: resume/continue 런치에서는 defaultMode 쓰기를 생략. 새 세션 런치의 기존 동작은 변경 없음.

## 점검 배경 (profile bleed와의 구분)

- profile bleed(다른 프로필 설정 끌어오기) → PR #1303 으로 이미 해결됨(MERGED). 글로벌 `last_profile` 읽기 폴백 제거.
- 이 PR은 bleed가 아니라 "같은 프로필 안에서 resume 런치가 사용자 편집 설정을 덮어쓰는" 별개 경로를 막는 것.

## 검증

- `go build ./internal/cli/...` ok
- 좁힌 테스트 `go test ./internal/cli/ -run 'PermissionMode|SettingsLocal|SyncPermission|Continue'` PASS
- 전체 회귀 `go test ./internal/cli/...` exit 0
- `go vet ./internal/cli/...` exit 0
- `golangci-lint run ./internal/cli/...` 0 issues

## 영향 범위

`launchClaudeDefault`의 defaultMode 동기화 시점만. teammateMode/GLM env 쓰기(glm.go), 다른 settings 키는 변경 없음.

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved permission mode synchronization when launching sessions.
  * Preserved local settings during session-resume launches.
  * Continued applying project preference synchronization as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->