### PR TITLE
chore(SPEC-UPDATE-TEMPLATE-BASE-SNAPSHOT-001): backfill sync_commit_sha

### DIFF
--- a/.moai/specs/SPEC-UPDATE-TEMPLATE-BASE-SNAPSHOT-001/progress.md
+++ b/.moai/specs/SPEC-UPDATE-TEMPLATE-BASE-SNAPSHOT-001/progress.md
@@ -141,7 +141,7 @@ m1_to_mN_commit_strategy: single-PR squash (Route B Tier L per repo-local-pr-pol
 ## §E.4 Sync-phase Audit-Ready Signal
 
 sync_complete_at: 2026-08-03
-sync_commit_sha: "pending-backfill-after-merge"
+sync_commit_sha: "12dc0c17b"
 sync_status: green
 sync_auditor_verdict: PASS
 sync_auditor_harmonic_mean: 0.952


### PR DESCRIPTION
Mechanical post-merge backfill of `sync_commit_sha` in `progress.md` §E.4: `pending-backfill-after-merge` → `12dc0c17b` (the squash-merge SHA of #1315). Per spec-frontmatter-schema.md D3 (SHA-placeholder backfill exemption) — a sync commit cannot reference its own SHA, so the placeholder is completed in this follow-up. No code/behavior change. 🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the sync-phase audit record with the finalized synchronization commit identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->