### PR TITLE
chore(SPEC-RALPH-CONFIG-REDESIGN-001): backfill sync_commit_sha

### DIFF
--- a/.moai/specs/SPEC-RALPH-CONFIG-REDESIGN-001/progress.md
+++ b/.moai/specs/SPEC-RALPH-CONFIG-REDESIGN-001/progress.md
@@ -109,7 +109,7 @@ m1_to_mN_commit_strategy: per-milestone conventional commits (M1 carries draftâ†
 
 sync_status: audit-ready
 sync_complete_at: 2026-08-04
-sync_commit_sha: "pending-backfill"
+sync_commit_sha: "b73d13e44870b16c95db830ca705158a69872a4a"
 changelog_entry_position: CHANGELOG.md `### Changed` (1 entry, single SPEC-ID occurrence)
 frontmatter_status_transitions:
   spec_md: in-progress -> implemented -> completed  # 3-phase close merged into this sync commit


### PR DESCRIPTION
## Backfill sync_commit_sha for SPEC-RALPH-CONFIG-REDESIGN-001

This chore PR replaces the `sync_commit_sha` placeholder in `.moai/specs/SPEC-RALPH-CONFIG-REDESIGN-001/progress.md` with the real merge commit SHA from the sync-phase PR.

### Change

- Replaces `sync_commit_sha: "pending-backfill"` with `sync_commit_sha: "b73d13e44870b16c95db830ca705158a69872a4a"`

### Context

A sync commit cannot know its own SHA (self-reference problem). The placeholder is documented in the sync commit (§E.4) and is backfilled in a follow-up commit after the sync PR merges — the same pattern used by SPEC-UPDATE-TEMPLATE-BASE-SNAPSHOT-001 and SPEC-INFINITE-GOAL-001.

### Auto-Merge

This is a Tier S chore PR (single-line SHA backfill). It should auto-merge on green CI + up-to-date base.

---
🤖 MoAI