### PR TITLE
fix(web): agentfm model badge matches the docs cost-color matrix

### DIFF
--- a/internal/harness/v4manifest/schema.go
+++ b/internal/harness/v4manifest/schema.go
@@ -73,11 +73,12 @@ var validModels = map[string]bool{
 	ModelOpus:    true,
 }
 
-// modelColors maps each model tier to its render glyph, mirroring the LLM
-// profile matrix (llm.yaml profiles). The agentfm badge derives its color from
-// the agent's resolved model (the llm matrix SSOT) rather than the manual
-// name→tier table: opus (deep reasoning) → 🔴, sonnet → 🟠, haiku → 🔵,
-// inherit/unknown → 🩵 (light/default).
+// modelColors maps each model tier to its base render glyph (a model-tier
+// primitive). NOTE: the moai-web agentfm badge no longer uses this model-only
+// map — it renders ModelCellColor(model, effort), the docs cost-color matrix
+// (docs-site what-is-moai-adk.md: opus+high→🔴, opus+medium→🟠, opus+low→🔵,
+// sonnet→🩵, inherit/haiku→⚪). ModelColor stays as the model-tier fallback
+// primitive (tested; used when effort is not part of the display).
 var modelColors = map[string]string{
 	ModelOpus:    "🔴",
 	ModelSonnet:  "🟠",
@@ -94,6 +95,30 @@ func ModelColor(model string) string {
 		return g
 	}
 	return "🩵"
+}
+
+// ModelCellColor returns the docs cost-color matrix glyph for a (model, effort)
+// cell — source of truth is docs-site what-is-moai-adk.md ("비용 색상"):
+// opus+high/xhigh→🔴, opus+medium→🟠, opus+low→🔵, sonnet→🩵, inherit/haiku/
+// unknown→⚪. The agentfm badge renders this so its colors match the docs cost
+// legend. effort=max is handled by the caller (the agentfm "custom" badge)
+// before this is reached, so max falls to the model's default branch here.
+func ModelCellColor(model, effort string) string {
+	switch model {
+	case ModelOpus:
+		switch effort {
+		case EffortHigh, EffortXhigh:
+			return "🔴"
+		case EffortLow:
+			return "🔵"
+		default: // medium, empty, unknown — the default-profile column
+			return "🟠"
+		}
+	case ModelSonnet:
+		return "🩵"
+	default: // haiku, inherit, unknown — cheapest tier (docs: inherit → ⚪)
+		return "⚪"
+	}
 }
 
 // ModelColorRank returns a sort rank for a model tier (lower = more expensive =

--- a/internal/harness/v4manifest/tier_test.go
+++ b/internal/harness/v4manifest/tier_test.go
@@ -238,6 +238,30 @@ func TestModelColor_UnknownReturnsDefault(t *testing.T) {
 	}
 }
 
+// TestModelCellColor verifies the docs cost-color matrix (what-is-moai-adk.md
+// "비용 색상") the agentfm badge renders: opus+high→🔴, opus+medium→🟠,
+// opus+low→🔵, sonnet→🩵, inherit/haiku→⚪.
+func TestModelCellColor(t *testing.T) {
+	cases := []struct {
+		model, effort, glyph string
+	}{
+		{ModelOpus, EffortHigh, "🔴"},
+		{ModelOpus, EffortXhigh, "🔴"},
+		{ModelOpus, EffortMedium, "🟠"},
+		{ModelOpus, EffortLow, "🔵"},
+		{ModelSonnet, EffortLow, "🩵"},
+		{ModelSonnet, EffortHigh, "🩵"},
+		{ModelHaiku, EffortLow, "⚪"},
+		{ModelInherit, "", "⚪"},
+		{"", "", "⚪"},
+	}
+	for _, tc := range cases {
+		if got := ModelCellColor(tc.model, tc.effort); got != tc.glyph {
+			t.Errorf("ModelCellColor(%q, %q) = %q, want %q", tc.model, tc.effort, got, tc.glyph)
+		}
+	}
+}
+
 // TestModelColorRank verifies the model-derived sort rank used by the agentfm
 // row ordering: opus=0, sonnet=1, haiku=2, inherit/unknown=3.
 func TestModelColorRank(t *testing.T) {

--- a/internal/web/agentfm.go
+++ b/internal/web/agentfm.go
@@ -109,18 +109,18 @@ func applyPerfTierEdits(projectRoot, perfTier string) error {
 // agentBadgeInfo carries the M5 model-badge display data for one agent row
 // (SPEC-WEBCONF-SIMPLIFY-001 M5, REQ-WC-006/007/008, design.md §E).
 type agentBadgeInfo struct {
-	Glyph      string // emoji glyph (🔴🟠🔵🩵) derived from the model, or "custom"
+	Glyph      string // docs cost-color glyph (🔴🟠🔵🩵⚪) from (model,effort), or "custom"
 	TooltipKey string // fieldDesc.agentfm.model.<model> / fieldDesc.agentfm.custom i18n key
 	HasBadge   bool   // false only when the row carries no usable model state
 	IsCustom   bool   // true when effort=max (AC-WC-018 neutral "custom" badge)
 }
 
 // agentTierBadge computes the display-only badge for an agent row. The badge
-// color is derived from the agent's resolved model (the llm.yaml profile-matrix
-// SSOT via agentResolvedModel) — NOT the manual name→tier table — so the badge
-// tracks the model the matrix actually assigns: opus → 🔴, sonnet → 🟠,
-// haiku → 🔵, inherit/unknown → 🩵. When the agent's current effort is the
-// override sentinel `max`, the badge is a neutral "custom" marker (AC-WC-018).
+// color is the docs cost-color matrix for the agent's (model, effort) cell
+// (ModelCellColor — what-is-moai-adk.md "비용 색상"): opus+high→🔴, opus+medium→
+// 🟠, opus+low→🔵, sonnet→🩵, inherit/haiku→⚪. When the agent's current effort
+// is the override sentinel `max`, the badge is a neutral "custom" marker
+// (AC-WC-018).
 //
 // The tooltip key reuses the existing model-selector i18n entries
 // (fieldDesc.agentfm.model.<model>). The name parameter is retained so call
@@ -131,7 +131,7 @@ func agentTierBadge(name, model, effort string) agentBadgeInfo {
 		return agentBadgeInfo{Glyph: "custom", TooltipKey: "fieldDesc.agentfm.custom", HasBadge: true, IsCustom: true}
 	}
 	return agentBadgeInfo{
-		Glyph:      v4manifest.ModelColor(model),
+		Glyph:      v4manifest.ModelCellColor(model, effort),
 		TooltipKey: "fieldDesc.agentfm.model." + model,
 		HasBadge:   true,
 	}

--- a/internal/web/console_ux_fix_test.go
+++ b/internal/web/console_ux_fix_test.go
@@ -332,7 +332,7 @@ func agentFMSectionCount(t *testing.T, body string) int {
 // frontmatter), so it must NOT be treated as a manual override. Only `effort: max`
 // still marks a row CUSTOM.
 func TestAgentTierBadgeInheritIsDefault(t *testing.T) {
-	// inherit → the inherit glyph (🩵), the default model badge — NOT the CUSTOM pill.
+	// inherit → the inherit cost color (⚪), the default model badge — NOT the CUSTOM pill.
 	for _, name := range []string{"manager-spec", "manager-develop", "manager-docs"} {
 		b := agentTierBadge(name, v4manifest.ModelInherit, v4manifest.EffortXhigh)
 		if b.IsCustom {
@@ -341,8 +341,8 @@ func TestAgentTierBadgeInheritIsDefault(t *testing.T) {
 		if !b.HasBadge {
 			t.Errorf("%s (model=inherit): expected a badge", name)
 		}
-		if want := v4manifest.ModelColor(v4manifest.ModelInherit); b.Glyph != want {
-			t.Errorf("%s (model=inherit): glyph = %q, want the inherit glyph %q", name, b.Glyph, want)
+		if want := v4manifest.ModelCellColor(v4manifest.ModelInherit, v4manifest.EffortXhigh); b.Glyph != want {
+			t.Errorf("%s (model=inherit): glyph = %q, want the inherit cost color %q", name, b.Glyph, want)
 		}
 	}
 
@@ -355,9 +355,9 @@ func TestAgentTierBadgeInheritIsDefault(t *testing.T) {
 	}
 }
 
-// TestAgentTierBadgeGlyphConsistency verifies the badge is model-derived and
-// consistent: with the shipped `model: inherit` frontmatter, EVERY seeded core
-// agent renders the inherit glyph (🩵) — no mixed CUSTOM/glyph rows.
+// TestAgentTierBadgeGlyphConsistency verifies the badge is consistent: with the
+// shipped `model: inherit` frontmatter, EVERY seeded core agent renders the
+// inherit cost color (⚪) — no mixed CUSTOM/glyph rows.
 func TestAgentTierBadgeGlyphConsistency(t *testing.T) {
 	root := t.TempDir()
 	for _, name := range []string{"manager-spec", "manager-develop", "manager-docs", "manager-git"} {
@@ -368,8 +368,8 @@ func TestAgentTierBadgeGlyphConsistency(t *testing.T) {
 	if strings.Contains(body, "agentfm-badge--custom") {
 		t.Error("a CUSTOM badge renders for shipped `model: inherit` agents")
 	}
-	want := v4manifest.ModelColor(v4manifest.ModelInherit)
+	want := v4manifest.ModelCellColor(v4manifest.ModelInherit, "")
 	if !strings.Contains(body, want) {
-		t.Errorf("inherit glyph %q missing from the render — all seeded agents share model=inherit", want)
+		t.Errorf("inherit cost color %q missing from the render — all seeded agents share model=inherit", want)
 	}
 }

--- a/internal/web/m5_agentfm_test.go
+++ b/internal/web/m5_agentfm_test.go
@@ -17,30 +17,32 @@ import (
 // agent's effort file). M1 supplied TierForAgent/TierColor/TierSuggestedModelEffort;
 // M5 wires them into the agentFMRow render.
 
-// TestM5AgentTierBadgeModelGlyphMap verifies the badge is model-derived: each
-// model tier maps to its glyph (opus → 🔴, sonnet → 🟠, haiku → 🔵, inherit → 🩵)
-// and every model yields a non-custom badge.
+// TestM5AgentTierBadgeModelGlyphMap verifies the badge renders the docs
+// cost-color matrix (what-is-moai-adk.md "비용 색상") for the agent's (model,
+// effort) cell: opus+high→🔴, opus+medium→🟠, opus+low→🔵, sonnet→🩵,
+// inherit/haiku→⚪. Every non-max cell yields a non-custom badge.
 func TestM5AgentTierBadgeModelGlyphMap(t *testing.T) {
 	cases := []struct {
-		model string
-		glyph string
+		model, effort, glyph string
 	}{
-		{v4manifest.ModelOpus, "🔴"},
-		{v4manifest.ModelSonnet, "🟠"},
-		{v4manifest.ModelHaiku, "🔵"},
-		{v4manifest.ModelInherit, "🩵"},
+		{v4manifest.ModelOpus, v4manifest.EffortHigh, "🔴"},
+		{v4manifest.ModelOpus, v4manifest.EffortMedium, "🟠"},
+		{v4manifest.ModelOpus, v4manifest.EffortLow, "🔵"},
+		{v4manifest.ModelSonnet, v4manifest.EffortLow, "🩵"},
+		{v4manifest.ModelInherit, "", "⚪"},
+		{v4manifest.ModelHaiku, v4manifest.EffortLow, "⚪"},
 	}
 	for _, tc := range cases {
-		b := agentTierBadge("any-agent", tc.model, "")
+		b := agentTierBadge("any-agent", tc.model, tc.effort)
 		if !b.HasBadge {
-			t.Errorf("model=%s: expected a badge, got none", tc.model)
+			t.Errorf("model=%s effort=%s: expected a badge, got none", tc.model, tc.effort)
 			continue
 		}
 		if b.IsCustom {
-			t.Errorf("model=%s: unexpected custom badge (no max effort set)", tc.model)
+			t.Errorf("model=%s effort=%s: unexpected custom badge (no max effort set)", tc.model, tc.effort)
 		}
 		if b.Glyph != tc.glyph {
-			t.Errorf("model=%s: glyph = %q, want %q", tc.model, b.Glyph, tc.glyph)
+			t.Errorf("model=%s effort=%s: glyph = %q, want %q", tc.model, tc.effort, b.Glyph, tc.glyph)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

The agentfm model badge now uses the **docs cost-color matrix** instead of a model-tier-only color, so the console matches `what-is-moai-adk.md`.

## Why

The badge previously derived color from the model tier only (`ModelColor`: opus→🔴, sonnet→🟠, haiku→🔵, inherit→🩵). That does **not** match the docs cost-color matrix, which is keyed on the **(model, effort)** cell:

| docs cell | color |
|---|---|
| opus + high | 🔴 |
| opus + medium | 🟠 |
| opus + low | 🔵 |
| sonnet | 🩵 |
| inherit | ⚪ |

So e.g. `manager-git` (sonnet) showed 🟠 in the console but the docs say sonnet→🩵, and inherit showed 🩵 while the docs use ⚪.

## Change

- Add `ModelCellColor(model, effort)` in `v4manifest/schema.go` implementing the docs matrix (the `(model, effort)` cost cell → glyph). `effort=max` is still handled by the caller's "custom" badge.
- Point the agentfm badge at it (`agentfm.go`); `effort` was already a parameter of `agentTierBadge`.
- `ModelColor` is kept as the model-tier primitive (still tested).
- Migrate the badge tests to `(model, effort)` cost-cell combos; add `TestModelCellColor`.

## Test plan
- [x] `go test ./internal/harness/v4manifest/... ./internal/web/...` — green
- [x] `go vet ./...` — clean
- [x] `go build ./...` — exit 0
- [ ] CI green on this PR

🗿 MoAI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated agent badges to reflect both model and effort level.
  * Added additional cost-color indicators, including light-blue and white glyphs.
  * Improved color handling for Opus effort tiers and inherited model settings.

* **Documentation**
  * Clarified that badge colors represent model-and-effort combinations rather than resolved models alone.

* **Tests**
  * Expanded coverage for model, effort, inherited, and unknown-value combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->