### PR TITLE
chore: backfill sync/run_commit_sha (3 SPECs) + fix internal/cli/CLAUDE.md C-HRA-008 stale test ref

### DIFF
--- a/.moai/specs/SPEC-AUTONOMY-TIERS-001/progress.md
+++ b/.moai/specs/SPEC-AUTONOMY-TIERS-001/progress.md
@@ -93,7 +93,7 @@ m1_to_mN_commit_strategy: one commit per milestone, explicit pathspec (no git ad
 
 ```yaml
 sync_complete_at: 2026-08-04
-sync_commit_sha: "pending-backfill"   # self-referential; a commit cannot know its own SHA — backfilled in a follow-up commit (D3 pattern, same as SPEC-INFINITE-GOAL-001 / SPEC-STOPCHAIN-TRIM-001)
+sync_commit_sha: "4ab512c89"   # backfilled post-merge (Automerge: feat(SPEC-AUTONOMY-TIERS-001))
 sync_status: complete
 frontmatter_status_transitions:
   spec.md: "in-progress → implemented → completed"

--- a/.moai/specs/SPEC-GOAL-HTML-FLOW-001/progress.md
+++ b/.moai/specs/SPEC-GOAL-HTML-FLOW-001/progress.md
@@ -97,7 +97,7 @@ plan_auditor_verdict: pending
 
 ```yaml
 run_complete_at: 2026-08-04
-run_commit_sha: "pending-backfill-m6"
+run_commit_sha: "d1fcf09b0"   # backfilled post-merge (PR #1335 squash)
 run_status: audit-ready
 ac_pass_count: 11
 ac_fail_count: 0

--- a/.moai/specs/SPEC-GOAL-HTML-FLOW-001/progress.md
+++ b/.moai/specs/SPEC-GOAL-HTML-FLOW-001/progress.md
@@ -117,7 +117,7 @@ m1_to_mN_commit_strategy: per-milestone conventional commits with 🗿 MoAI trai
 
 ```yaml
 sync_complete_at: 2026-08-04
-sync_commit_sha: "pending-backfill-sync"
+sync_commit_sha: "535a88710"
 sync_status: audit-ready
 sync_phase_close: "3-phase close (plan→run→sync) — completed transition rides this sync commit"
 changelog_entry_added: true   # CHANGELOG.md [Unreleased] → ### Added
@@ -139,8 +139,6 @@ canary_compliance_check:
   spec_lint_clean: true             # 0 errors on spec.md
   status_git_consistency: resolved  # the pre-sync warning (in-progress vs git-implied implemented) is resolved by this commit's completed transition
 ```
-
-sync_commit_sha: "pending-backfill-sync"
 
 ## §F Phase 4 Mode Selection
 

--- a/.moai/specs/SPEC-INFINITE-GOAL-001/progress.md
+++ b/.moai/specs/SPEC-INFINITE-GOAL-001/progress.md
@@ -58,7 +58,7 @@ AC-011 (arm-time fail-closed) + AC-005 (wall-clock run-time bound) + AC-006 (sta
 
 ```yaml
 run_complete_at: "2026-08-04"
-run_commit_sha: "pending-backfill-M8"   # self-referential; backfilled post-merge
+run_commit_sha: "adc867545"   # backfilled post-merge (PR #1317 squash)
 run_status: "audit-ready"
 ac_pass_count: 11
 ac_fail_count: 0
@@ -97,7 +97,7 @@ spec_lint_clean: true   # moai spec lint (§6 MP-3 tags comma-quoted-string) —
 
 ```yaml
 sync_complete_at: 2026-08-04
-sync_commit_sha: "pending-backfill"   # self-referential; a commit cannot know its own SHA — backfilled in a follow-up commit (D3 pattern)
+sync_commit_sha: "80643b61e"   # backfilled post-merge (PR #1320 squash)
 sync_status: complete
 frontmatter_status_transitions:
   spec.md: "in-progress → implemented → completed"

--- a/internal/cli/CLAUDE.md
+++ b/internal/cli/CLAUDE.md
@@ -8,7 +8,7 @@ This package is the boundary between the user's terminal and every backing subsy
 
 ## Conventions
 
-- **Subagent boundary (C-HRA-008 / REQ-PGN-012)**: CLI code MUST NOT call `AskUserQuestion` or `mcp__askuser__*`. The CLI runs in subagent context — orchestrator owns user interaction. Replace any interactive prompt with positional arguments + `--flag` defaults + structured stderr errors. Static guard pattern: `TestNew_NoAskUserQuestion` (see `worktree/new_test.go`) — every interactive-shaped subcommand needs the equivalent grep-based test.
+- **Subagent boundary (C-HRA-008 / REQ-PGN-012)**: CLI code MUST NOT call `AskUserQuestion` or `mcp__askuser__*`. The CLI runs in subagent context — orchestrator owns user interaction. Replace any interactive prompt with positional arguments + `--flag` defaults + structured stderr errors. Static guard pattern: `TestWeb_NoAskUserQuestion` (see `web_test.go`) — every interactive-shaped subcommand needs the equivalent grep-based test.
 - **Cobra subcommand registration**: Add new subcommands via `xxxCmd := &cobra.Command{...}` then `rootCmd.AddCommand(xxxCmd)` in the package's `init()` or in `root.go`. Never declare two subcommands with the same `Use:` prefix — cobra panics at runtime. The pattern catches `harness-classify`-style multi-word names colliding with existing `harness` namespace.
 - **Exit code discipline**: `os.Exit(0)` success, `os.Exit(1)` user error, `os.Exit(2)` system error. Never `panic()` — wrap upstream errors and report to stderr.
 - **Output streams**: stdout = structured machine-readable output (JSON when `--json`, plain text otherwise). stderr = human progress messages, warnings, errors. Never mix.
@@ -28,7 +28,7 @@ This package is the boundary between the user's terminal and every backing subsy
 
 - Root CLAUDE.md §4 (Agent Catalog), §14 (Parallel Execution Safeguards § Background Agent Write Restriction)
 - CLAUDE.local.md §13 (GLM integration test isolation), §14 (Hardcoding prevention), §22 (settings.local.json separation)
-- `internal/cli/worktree/new_test.go` — `TestNew_NoAskUserQuestion` canonical static guard
+- `internal/cli/web_test.go` — `TestWeb_NoAskUserQuestion` canonical static guard
 - `internal/cli/harness/route_test.go` — `TestPropose_NoAskUserQuestion` second canonical instance
 - `internal/cli/spawn.go` — `--spawn` flag stripping, shell-quoted command reconstruction, tmux new-window invocation
 - `internal/config/envkeys.go` — canonical env var constants (use these, never inline strings)


### PR DESCRIPTION
Backfills pending sync_commit_sha and run_commit_sha fields across 3 SPEC progress.md files:

- SPEC-GOAL-HTML-FLOW-001: sync_commit_sha → 535a88710, run_commit_sha → d1fcf09b0
- SPEC-INFINITE-GOAL-001: run_commit_sha → adc867545, sync_commit_sha → 80643b61e
- SPEC-AUTONOMY-TIERS-001: sync_commit_sha → 4ab512c89

Also fixes stale test reference in internal/cli/CLAUDE.md (C-HRA-008):
- Retired worktree/new_test.go → canonical web_test.go

All changes are SHA field backfills (D3-exempt progress.md §E.3/§E.4) plus a 2-line doc fix. No code changes, no spec body changes.

🗿 MoAI