### PR TITLE
docs: commit pending analysis reports + SPEC-CONFIG-DEAD-SWEEP-001 draft

### DIFF
--- a/.moai/reports/moai-cli-logic-analysis-20260804.html
+++ b/.moai/reports/moai-cli-logic-analysis-20260804.html
@@ -1,0 +1,1284 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MoAI CLI 로직 분석 — init · update · web</title>
+<script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css">
+<style>
+  :root {
+    --coral: #cc785c;
+    --coral-dark: #7a3e2a;
+    --paper: #faf8f5;
+    --paper-2: #fffdf9;
+    --ink: #1f1d1b;
+    --muted: #6b6358;
+    --border: #e8e2d8;
+    --border-strong: #d4cab9;
+    --code-bg: #2d2a26;
+    --code-ink: #f5f0e8;
+    --soft-coral: #f5ebe0;
+    --ok: #4a7c4e;
+    --warn: #b87333;
+    --danger: #a04545;
+  }
+  * { box-sizing: border-box; }
+  html, body {
+    margin: 0;
+    padding: 0;
+    background: var(--paper);
+    color: var(--ink);
+    font-family: 'Pretendard', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+    line-height: 1.7;
+    font-size: 16px;
+    -webkit-font-smoothing: antialiased;
+  }
+  .wrap {
+    max-width: 1080px;
+    margin: 0 auto;
+    padding: 48px 32px 96px;
+  }
+  header.report-head {
+    background: linear-gradient(135deg, #fffdf9 0%, #f5ebe0 100%);
+    border: 1px solid var(--border-strong);
+    border-radius: 14px;
+    padding: 36px 40px;
+    margin-bottom: 36px;
+    box-shadow: 0 2px 8px rgba(122, 62, 42, 0.06);
+  }
+  header.report-head h1 {
+    margin: 0 0 6px;
+    font-size: 28px;
+    color: var(--coral-dark);
+    letter-spacing: -0.01em;
+    font-weight: 800;
+  }
+  header.report-head .sub {
+    color: var(--muted);
+    font-size: 15px;
+    margin-bottom: 4px;
+  }
+  header.report-head .meta {
+    color: var(--coral);
+    font-size: 13px;
+    font-weight: 600;
+    margin-bottom: 18px;
+    letter-spacing: 0.02em;
+  }
+  header.report-head .exec {
+    background: var(--paper-2);
+    border-left: 3px solid var(--coral);
+    padding: 14px 18px;
+    border-radius: 0 8px 8px 0;
+    font-size: 15px;
+    color: var(--ink);
+  }
+  h2 {
+    font-size: 22px;
+    color: var(--coral-dark);
+    margin: 56px 0 18px;
+    padding-bottom: 10px;
+    border-bottom: 2px solid var(--soft-coral);
+    font-weight: 700;
+    letter-spacing: -0.01em;
+  }
+  h3 {
+    font-size: 18px;
+    color: var(--ink);
+    margin: 32px 0 12px;
+    font-weight: 700;
+  }
+  h4 {
+    font-size: 15px;
+    color: var(--coral-dark);
+    margin: 24px 0 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  p { margin: 10px 0; }
+  ul, ol { padding-left: 24px; }
+  li { margin: 4px 0; }
+  code {
+    font-family: 'Goorm Sans Code', 'SF Mono', 'Fira Code', Consolas, monospace;
+    background: var(--soft-coral);
+    color: var(--coral-dark);
+    padding: 1px 6px;
+    border-radius: 4px;
+    font-size: 0.88em;
+    word-break: break-word;
+  }
+  pre {
+    background: var(--code-bg);
+    color: var(--code-ink);
+    padding: 16px 20px;
+    border-radius: 8px;
+    overflow-x: auto;
+    font-size: 13px;
+    line-height: 1.6;
+  }
+  pre code {
+    background: transparent;
+    color: inherit;
+    padding: 0;
+  }
+  .toc {
+    background: var(--paper-2);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 20px 28px;
+    margin-bottom: 40px;
+  }
+  .toc h3 { margin-top: 0; color: var(--coral-dark); }
+  .toc ol { margin: 0; columns: 2; column-gap: 32px; }
+  .toc li { break-inside: avoid; margin: 3px 0; }
+  .toc a {
+    color: var(--ink);
+    text-decoration: none;
+    border-bottom: 1px dotted var(--border-strong);
+  }
+  .toc a:hover { color: var(--coral); border-bottom-color: var(--coral); }
+  .card {
+    background: var(--paper-2);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 28px 32px;
+    margin: 24px 0;
+    box-shadow: 0 1px 4px rgba(31, 29, 27, 0.04);
+  }
+  .card.coral {
+    border-top: 3px solid var(--coral);
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 16px 0;
+    font-size: 14px;
+    background: var(--paper-2);
+    border-radius: 8px;
+    overflow: hidden;
+    border: 1px solid var(--border);
+  }
+  th {
+    background: var(--soft-coral);
+    color: var(--coral-dark);
+    text-align: left;
+    padding: 10px 14px;
+    font-weight: 700;
+    font-size: 13px;
+    border-bottom: 1px solid var(--border-strong);
+  }
+  td {
+    padding: 9px 14px;
+    border-bottom: 1px solid var(--border);
+    vertical-align: top;
+  }
+  tr:last-child td { border-bottom: none; }
+  td code, th code { font-size: 12px; }
+  .pill {
+    display: inline-block;
+    padding: 2px 10px;
+    border-radius: 12px;
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+  }
+  .pill.write { background: #fde3e3; color: #a04545; }
+  .pill.read { background: #e3eafd; color: #2a4a9e; }
+  .pill.both { background: #f5ebe0; color: #7a3e2a; }
+  .pill.none { background: var(--border); color: var(--muted); }
+  .pill.ok { background: #e3f5e3; color: var(--ok); }
+  .pill.warn { background: #fdf0e3; color: var(--warn); }
+  .pill.danger { background: #fde3e3; color: var(--danger); }
+  .mermaid {
+    background: var(--paper-2);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 24px;
+    margin: 20px 0;
+    text-align: center;
+    overflow-x: auto;
+  }
+  .step-list {
+    counter-reset: step;
+    list-style: none;
+    padding-left: 0;
+  }
+  .step-list > li {
+    counter-increment: step;
+    position: relative;
+    padding: 12px 16px 12px 56px;
+    margin: 8px 0;
+    background: var(--paper-2);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+  }
+  .step-list > li::before {
+    content: counter(step);
+    position: absolute;
+    left: 14px;
+    top: 12px;
+    width: 30px;
+    height: 30px;
+    background: var(--coral);
+    color: #fff;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
+    font-size: 14px;
+  }
+  .step-list .loc {
+    display: block;
+    font-size: 12px;
+    color: var(--muted);
+    margin-top: 3px;
+    font-family: 'Goorm Sans Code', monospace;
+  }
+  .callout {
+    border-left: 3px solid var(--coral);
+    background: var(--soft-coral);
+    padding: 12px 18px;
+    border-radius: 0 8px 8px 0;
+    margin: 16px 0;
+    font-size: 14px;
+  }
+  .callout.warn { border-left-color: var(--warn); background: #fdf0e3; }
+  .callout.danger { border-left-color: var(--danger); background: #fde3e3; }
+  .callout strong { color: var(--coral-dark); }
+  .grid-2 {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+  }
+  .insight {
+    background: var(--paper-2);
+    border: 1px solid var(--border);
+    border-left: 3px solid var(--coral);
+    border-radius: 0 8px 8px 0;
+    padding: 16px 20px;
+    margin: 12px 0;
+  }
+  .insight h4 { margin: 0 0 6px; text-transform: none; letter-spacing: 0; color: var(--coral-dark); }
+  hr { border: none; border-top: 1px solid var(--border); margin: 40px 0; }
+  .footer-note {
+    color: var(--muted);
+    font-size: 13px;
+    margin-top: 48px;
+    padding-top: 20px;
+    border-top: 1px solid var(--border);
+  }
+  @media (max-width: 720px) {
+    .wrap { padding: 24px 16px 48px; }
+    .toc ol { columns: 1; }
+    .grid-2 { grid-template-columns: 1fr; }
+  }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<header class="report-head">
+  <h1>MoAI CLI 로직 분석 — init · update · web</h1>
+  <div class="sub">moai-adk-go 최상위 명령 3종의 진입 구조, 실행 흐름, 공유 하위 시스템 의존 관계 정리</div>
+  <div class="meta">2026-08-04 · 분석 대상: internal/cli · internal/template · internal/update · internal/web · internal/manifest · internal/config · internal/profile</div>
+  <div class="exec">
+    <strong>요약.</strong>
+    <code>moai init</code>는 임베디드 템플릿을 새 프로젝트 트리에 배포하고 manifest·profile·config를 최초로 쓰는 <em>스캐폴딩 명령</em>이다.
+    <code>moai update</code>는 두 축으로 나뉜다. 하나는 GitHub Releases에서 최신 바이너리를 받아 체크섬 검증 후 원자적 교체하는 <em>바이너리 자기 갱신</em>(<code>internal/update/</code>), 다른 하나는 새 버전 템플릿을 기존 프로젝트에 3-way 병합으로 동기화하는 <em>템플릿 동기화</em>(<code>update_template_sync.go</code> + <code>update/</code> 서브패키지)이다.
+    <code>moai web</code>은 루프백 전용 HTTP 서버로 profile·config 섹션을 편집하는 <em>브라우저 기반 설정 에디터</em>로, 외부 DB나 인증 없이 동작한다.
+    세 명령은 <code>template.Deployer/Renderer</code>, <code>config.Loader/Manager</code>, <code>profile</code> 스토어, <code>manifest.Manager</code> 네 하위 시스템을 각자의 목적에 맞게 읽거나 쓴다. init/update는 템플릿·manifest에 쓰기 접근하지만 web은 그렇지 않고, profile·config는 셋 모두가 공유한다.
+  </div>
+</header>
+
+<nav class="toc">
+  <h3>목차</h3>
+  <ol>
+    <li><a href="#arch">전체 아키텍처 관계도</a></li>
+    <li><a href="#init">moai init — 프로젝트 스캐폴딩</a></li>
+    <li><a href="#update">moai update — 자기 갱신 + 템플릿 동기화</a></li>
+    <li><a href="#web">moai web — 브라우저 설정 에디터</a></li>
+    <li><a href="#shared">공유 인프라 심층</a></li>
+    <li><a href="#principles">핵심 설계 원칙</a></li>
+    <li><a href="#appendix">부록: 파일 인덱스</a></li>
+  </ol>
+</nav>
+
+<!-- ===================== ARCHITECTURE ===================== -->
+<section id="arch">
+<h2>1. 전체 아키텍처 관계도</h2>
+
+<p>세 명령 모두 <code>internal/cli/root.go</code>의 <code>rootCmd</code> 아래 cobra 서브커맨드로 등록된다. <code>init</code>과 <code>update</code>는 <code>GroupID:"project"</code>, <code>web</code>은 <code>GroupID:"tools"</code>로 분류된다. 각 명령의 RunE 함수는 얇은 CLI 진입점 역할만 하고, 실제 로직은 <code>internal/core/project</code>, <code>internal/update</code>, <code>internal/web</code> 같은 별도 패키지가 소유한다.</p>
+
+<div class="mermaid">
+graph TD
+    REX["rootCmd (root.go:18)<br/>Execute → InitDependencies → runFang"]
+
+    subgraph CMDS["최상위 명령"]
+        INIT["moai init<br/>GroupID=project<br/>runInit (init.go:315)"]
+        UPD["moai update<br/>GroupID=project<br/>runUpdate (update.go:136)"]
+        WEB["moai web<br/>GroupID=tools<br/>runWeb (web.go:71)"]
+    end
+
+    REX --> INIT
+    REX --> UPD
+    REX --> WEB
+
+    subgraph TPL["template subsystem"]
+        EMB["embed.go:42<br/>//go:embed all:templates<br/>+ catalog.yaml"]
+        CAT["catalog.yaml<br/>core / harness-generated /<br/>optional-pack"]
+        RND["Renderer.Render<br/>renderer.go:70"]
+        SLIM["SlimFS<br/>slim_fs.go:214<br/>non-core 숨김"]
+        DEP["Deployer.Deploy<br/>deployer.go:100<br/>render → atomicWrite → Track"]
+    end
+
+    subgraph CFG["config subsystem"]
+        LDR["Loader.Load<br/>loader.go:31<br/>sections 병합"]
+        MGR["ConfigManager<br/>manager.go:58<br/>Load/LoadRaw/SetSection/Save"]
+        ENV["applyEnvOverrides<br/>MOAI_DEVELOPMENT_MODE 등"]
+    end
+
+    subgraph PROF["profile subsystem"]
+        PRF["preferences.go<br/>~/.moai/claude-profiles"]
+        SYC["sync.go:17<br/>SyncToProjectConfig"]
+    end
+
+    subgraph MAN["manifest subsystem"]
+        MLM["Manager<br/>manifest.go:69<br/>Load/Track/Save/DetectChanges"]
+        MF[".moai/manifest.json<br/>triple-hash ADR-007"]
+    end
+
+    subgraph BIN["internal/update (바이너리)"]
+        CHK["checker.CheckLatest<br/>GitHub Releases API"]
+        UPD2["updater.Download/Replace<br/>체크섬 검증 + 원자 교체"]
+    end
+
+    INIT -->|"임베디드 로드"| EMB
+    INIT -->|"slim 기본 / --all 전체"| SLIM
+    INIT -->|"렌더 + 배포"| DEP
+    INIT -->|"Track + Save"| MLM
+    INIT -->|"profile 동기화"| SYC
+
+    UPD -->|"바이너리 갱신"| CHK
+    CHK --> UPD2
+    UPD -->|"forceUpdate=true 배포"| DEP
+    UPD -->|"3-way 병합 base"| EMB
+    UPD -->|"provenance 조회"| MLM
+    UPD -->|"config 보존/편집"| MGR
+    UPD -->|"profile 동기화"| SYC
+
+    WEB -->|"config 읽기/쓰기"| MGR
+    WEB -->|"profile CRUD"| PRF
+    WEB -.->|"template 미접근"| DEP
+    WEB -.->|"manifest 미접근"| MLM
+
+    EMB --> CAT
+    RND --> DEP
+    SLIM --> DEP
+    SYC --> MGR
+    LDR --> MGR
+    MGR --> ENV
+
+    classDef cmd fill:#cc785c,stroke:#7a3e2a,color:#fff,font-weight:bold
+    classDef sub fill:#fffdf9,stroke:#cc785c,color:#1f1d1b
+    classDef bin fill:#e6fcf5,stroke:#0c8599,color:#1f1d1b
+    class INIT,UPD,WEB cmd
+    class TPL,CFG,PROF,MAN sub
+    class BIN bin
+</div>
+
+<h3>하위 시스템 접근 매트릭스</h3>
+<p>각 명령이 네 공유 하위 시스템을 어떻게 다루는지 정리한 표이다. <span class="pill write">쓰기</span> <span class="pill read">읽기</span> <span class="pill both">둘 다</span> <span class="pill none">미접근</span></p>
+
+<table>
+<thead>
+<tr><th>하위 시스템</th><th>moai init</th><th>moai update</th><th>moai web</th><th>주요 진입점</th></tr>
+</thead>
+<tbody>
+<tr>
+  <td><strong>template</strong><br/><code>Deployer / Renderer / catalog</code></td>
+  <td><span class="pill write">쓰기</span><br/>임베디드 템플릿 배포</td>
+  <td><span class="pill both">둘 다</span><br/>forceUpdate 배포 + 병합 base</td>
+  <td><span class="pill none">미접근</span></td>
+  <td><code>template.EmbeddedTemplates</code>, <code>Deployer.Deploy</code></td>
+</tr>
+<tr>
+  <td><strong>config</strong><br/><code>Loader / ConfigManager</code></td>
+  <td><span class="pill write">쓰기</span><br/>템플릿 배포 후 profile 패치</td>
+  <td><span class="pill both">둘 다</span><br/>3-way 병합 보존 + <code>-c</code> 편집</td>
+  <td><span class="pill both">둘 다</span><br/>quality/git_convention 편집</td>
+  <td><code>config.NewConfigManager</code>, <code>LoadRaw</code></td>
+</tr>
+<tr>
+  <td><strong>profile</strong><br/><code>preferences / sync</code></td>
+  <td><span class="pill both">둘 다</span><br/>wizard prefill + 동기화</td>
+  <td><span class="pill both">둘 다</span><br/>동일 흐름 + <code>--profile</code></td>
+  <td><span class="pill both">둘 다</span><br/>CRUD + /save 영속화</td>
+  <td><code>profile.ReadPreferences</code>, <code>SyncToProjectConfig</code></td>
+</tr>
+<tr>
+  <td><strong>manifest</strong><br/><code>Manager / hasher</code></td>
+  <td><span class="pill write">쓰기</span><br/>최초 triple-hash 기록</td>
+  <td><span class="pill both">둘 다</span><br/>provenance 조회 + 재기록</td>
+  <td><span class="pill none">미접근</span></td>
+  <td><code>manifest.NewManager</code>, <code>Track</code></td>
+</tr>
+</tbody>
+</table>
+
+<div class="callout">
+<strong>관계의 핵심.</strong> init은 "처음 쓰는 주체", update는 "이전 상태를 읽고 새 상태로 병합하는 주체", web은 "이미 존재하는 config/profile만 편집하는 주체"로 역할이 분명히 나뉜다. web이 template·manifest에 손대지 않는다는 점은 의도적인 경계 설계다 — 브라우저 편집이 템플릿 무결성이나 배포 이력을 건드리지 않는다.
+</div>
+</section>
+
+<!-- ===================== INIT ===================== -->
+<section id="init">
+<h2>2. moai init — 프로젝트 스캐폴딩</h2>
+
+<div class="card coral">
+<h3>목적</h3>
+<p>Cobra 서브커맨드로 새 MoAI 프로젝트를 스캐폴딩한다. 프로젝트 루트를 결정하고, 인터랙티브 위자드(또는 플래그 전용 모드)를 돌린 뒤, 임베디드 템플릿을 배포한다. 기본은 core-only slim 모드이고 <code>--all</code> 플래그로 전체 배포할 수 있다. <code>.moai/manifest.json</code>을 쓰고, git hook을 설치하며, post-init 안내를 출력한다. <code>PhaseExecutor</code>(detect → methodology → validate → init)로 흐름을 조립한다.</p>
+<p><strong>진입점:</strong> <code>internal/cli/init.go:45</code> <code>initCmd</code> · PreRunE=<code>validateInitFlags</code> · RunE=<code>runInit</code>(init.go:315) · 오케스트레이터 <code>PhaseExecutor.Execute</code>(phase.go:57) → <code>projectInitializer.Init</code>(initializer.go:117)</p>
+</div>
+
+<h3>플래그</h3>
+<table>
+<thead><tr><th>플래그</th><th>용도</th></tr></thead>
+<tbody>
+<tr><td><code>--root</code></td><td>프로젝트 루트 디렉터리. positional arg보다 우선.</td></tr>
+<tr><td><code>--name</code></td><td>프로젝트 이름. 미지정 시 arg명 또는 dir basename.</td></tr>
+<tr><td><code>--language</code></td><td>1차 프로그래밍 언어. 미지정 시 detector 자동 감지, fallback Go.</td></tr>
+<tr><td><code>--framework</code></td><td>프레임워크명. 미지정 시 자동 감지 또는 none.</td></tr>
+<tr><td><code>--mode</code></td><td>개발 방법론 <code>ddd|tdd</code>. PreRunE 검증. 기본 <code>tdd</code>.</td></tr>
+<tr><td><code>--git-mode</code></td><td><code>manual|personal|team</code>. 미지정 시 <code>detectGitConfig</code>가 채움.</td></tr>
+<tr><td><code>--git-provider</code></td><td><code>github|gitlab</code>. 미지정 시 origin host로 감지, fallback github.</td></tr>
+<tr><td><code>--github-username</code></td><td>personal/team 모드용. <code>isValidGitHubUsername</code> 검증.</td></tr>
+<tr><td><code>--gitlab-instance-url</code></td><td>self-hosted GitLab URL. <code>validateHTTPSURL</code> 검증(plaintext http 거부).</td></tr>
+<tr><td><code>--non-interactive</code></td><td>위자드 건너뛰고 플래그/기본값 사용. CI/스크립트용.</td></tr>
+<tr><td><code>--force</code></td><td>기존 <code>.moai/</code> 재초기화(백업 후). 없으면 <code>ErrProjectExists</code>.</td></tr>
+<tr><td><code>--no-hooks</code></td><td>pre-push/pre-commit git hook 설치 건너뜀.</td></tr>
+<tr><td><code>--all</code></td><td>모든 catalog 항목 배포(core + optional_packs + harness_generated). slim bypass.</td></tr>
+<tr><td><code>--project-mode</code></td><td><code>personal|team</code>. <code>project.yaml</code> mode 키로 기록.</td></tr>
+<tr><td><code>--enable-lsp</code></td><td>LSP 통합 토글. 등록 default false지만 runInit가 true seed. <code>Changed()</code>로 명시 여부 판별.</td></tr>
+<tr><td><code>--enforce-quality</code></td><td>quality 게이트 강제. default true.</td></tr>
+<tr><td><code>--model-policy</code></td><td><code>high|medium|low</code>(legacy max → high). <code>llm.yaml</code> performance_tier로 영속.</td></tr>
+<tr><td><code>--high / --medium-alias / --low</code></td><td><code>--model-policy</code>의 1-cycle deprecated alias.</td></tr>
+<tr><td><code>--profile</code></td><td><code>high|medium|low</code>. per-agent model+effort profile, <code>llm.profile</code>로 영속. wizard보다 항상 우선.</td></tr>
+</tbody>
+</table>
+
+<div class="callout warn">
+<strong>미사용 플래그.</strong> <code>--harness-profile</code>는 여전히 등록되지만 <code>writeHarnessProfileYAML</code>이 RETIRED(C36/REQ-WIZ-012)되어 사실상 dead flag다. 추후 제거 예정(C37 M7)인지는 <em>(미검증)</em>이다.
+</div>
+
+<h3>실행 흐름도</h3>
+<div class="mermaid">
+graph TD
+    U["moai init name/. /  no-arg"] --> PRE["PreRunE: validateInitFlags<br/>closed-set 플래그 검증"]
+    PRE -->|"위반"| EXIT1["exit 1 usage error"]
+    PRE -->|"통과"| RUN["runInit (init.go:315)"]
+
+    RUN --> WC["newWarnCollector + defer emitSummary"]
+    WC --> SW["loadSessionWorktreeConfig<br/>기본 OFF → byte-identical"]
+    SW --> GITCK["exec.LookPath git 확인"]
+    GITCK -->|"git 없음"| WARN["GitInstallHint 경고"]
+    GITCK -->|"ok"| ROOT["ProjectRoot 결정"]
+    WARN --> ROOT
+
+    ROOT --> RDecide{"루트 결정"}
+    RDecide -->|"--root"| R1["root = --root"]
+    RDecide -->|"positional != '.'"| R2["filepath.Abs + MkdirAll<br/>dir name = projectName"]
+    RDecide -->|"'.' / no-arg"| R3["root = os.Getwd"]
+
+    R1 --> OPTS["InitOptions 조립"]
+    R2 --> OPTS
+    R3 --> OPTS
+
+    OPTS --> GITDET["detectGitConfig<br/>git remote → manual/personal<br/>origin host → github/gitlab"]
+    GITDET --> PROF["profile 로드 + 자동 setup 프롬프트"]
+
+    PROF --> INTER{"nonInteractive OR<br/>!isatty?"}
+    INTER -->|"interactive TTY"| WIZ["runWizardFn<br/>RunWithDefaults 3-page 폼"]
+    INTER -->|"non-interactive"| DEF["기본값 확정<br/>git-provider=github, DevMode=tdd"]
+
+    WIZ -->|"ErrCancelled"| CANC["exit 0 cancelled"]
+    WIZ -->|"ok"| WIZAPPLY["applyWizardPage3ToOpts<br/>flag-over-wizard"]
+    WIZAPPLY --> DEF
+
+    DEF --> CAT["template.LoadEmbeddedCatalog"]
+    CAT -->|"실패"| CATFAIL["CATALOG_LOAD_FAILED"]
+    CAT -->|"성공"| DIST{"shouldDistributeAll?<br/>--all OR MOAI_DISTRIBUTE_ALL=1"}
+    DIST -->|"yes 전체"| DALL["NewDeployerWithRenderer"]
+    DIST -->|"no slim 기본"| DSLIM["NewSlimDeployerWithRenderer<br/>SlimFS hides tier != core"]
+    DSLIM --> SLIMNOTICE["emitSlimModeNotice stdout"]
+    DALL --> EXEC["PhaseExecutor.Execute"]
+    SLIMNOTICE --> EXEC
+
+    EXEC --> P1["Phase1 Detect<br/>언어/프레임워크/타입 (non-fatal)"]
+    P1 --> P2["Phase2 Methodology<br/>DevMode 이미 tdd → 검증 분기"]
+    P2 --> P3["Phase3 Validate (idempotency 게이트)"]
+    P3 -->|".moai/ 존재 + !Force"| EXIST["ErrProjectExists<br/>runInit hint: moai update / --force"]
+    EXIST --> FAIL["초기화 실패 exit"]
+    P3 -->|"존재 + --Force"| BACKUP["BackupExistingProject"]
+    P3 -->|"valid / backed up"| P4["Phase4 initializer.Init"]
+
+    P4 --> S1["Step1 createMoAIDirs"]
+    S1 --> S2["Step2 createClaudeDirs"]
+    S2 --> S3["Step3 deployTemplates<br/>TemplateContext → Deployer.Deploy<br/>walk → render .tmpl → atomicWrite → Track"]
+    S3 --> S3C["Step3c writeReportConfig<br/>report.yaml"]
+    S3C --> S3D["Step3d WritePhase1Configs<br/>project/lsp/quality/design yaml 패치"]
+    S3D --> S4["Step4 createClaudeMD<br/>배포됐으면 skip else stub"]
+    S4 --> S5["Step5 initManifest<br/>Version + DeployedAt → Save"]
+    S5 --> S6["Step6 configureShellEnv<br/>.zshenv PATH 추가"]
+
+    S6 --> POST["runInit 후처리"]
+    POST --> POST2["profile.SyncToProjectConfig<br/>+ ApplyPerformanceTier / ApplyProfile"]
+    POST2 --> POST3["deploy.ScaffoldEvolutionDir<br/>+ ensureGlobalSettingsEnv"]
+    POST3 --> POST4["installPrePush/PreCommitHookOptional<br/>unless --no-hooks"]
+    POST4 --> POST5["writeTemplateSnapshotBestEffort<br/>.moai/cache/template-snapshot BASE"]
+    POST5 --> CARD["buildInitSuccessCard → stderr"]
+    CARD --> SUM["defer emitSummary"]
+    SUM --> OK["exit 0"]
+
+    classDef decision fill:#fde68a,stroke:#b45309
+    classDef term fill:#bbf7d0,stroke:#15803d
+    class RDecide,INTER,DIST,P3 decision
+    class OK,CANC,EXIT1,FAIL,CATFAIL term
+</div>
+
+<h3>상세 단계</h3>
+<ol class="step-list">
+<li><strong>PreRunE 플래그 검증</strong><span class="loc">internal/cli/init.go:187-266 validateInitFlags</span>
+모든 closed-set 플래그(<code>--mode</code>, <code>--git-mode</code>, <code>--git-provider</code>, <code>--model-policy</code>, <code>--profile</code>, <code>--project-mode</code>, <code>--github-username</code>, <code>--gitlab-instance-url</code>)를 검증한다. 위반 시 non-zero exit + usage error.</li>
+<li><strong>출력 게이트웨이 + warn collector 세팅</strong><span class="loc">internal/cli/init.go:321-322 · init_warnings.go</span>
+<code>newWarnCollector</code>가 <code>printer.Printer</code>를 wrap한다. stdout=데이터, stderr=진행/경고(REQ-CTX-012/016). <code>defer p.emitSummary</code>가 종료 시 stderr에 경고 요약 패널을 한 번 렌더한다.</li>
+<li><strong>session-worktree 자동 진입</strong><span class="loc">internal/cli/init.go:337-351 · session_worktree.go</span>
+기본 OFF(REQ-SW-001)면 <code>wtPath=""</code>로 byte-identical하다. 성공 시 <code>os.Chdir(wtPath)</code>. <code>defer cleanupSessionWorktree</code>가 clean-exit/preserve/dirty-guard에 따라 worktree를 회수한다.</li>
+<li><strong>git 설치 확인 + 프로젝트 root 결정</strong><span class="loc">internal/cli/init.go:355-400</span>
+<code>--root</code>가 최우선. positional arg(<code>"."</code> 제외)면 <code>filepath.Abs</code> → <code>MkdirAll(0755)</code>, 디렉터리명을 projectName으로. macOS <code>filepath.Join</code> 함정 방지용 <code>filepath.Abs</code> 사용.</li>
+<li><strong>InitOptions 조립 + git 자동 감지</strong><span class="loc">internal/cli/init.go:404-445 · init_gitdetect.go:52</span>
+플래그 → opts. <code>git-mode/git-provider</code>가 비어있으면 <code>detectGitConfig</code> 호출. remote 없으면 manual, ≥1 remote면 personal, origin host가 github.com이면 github, 아니면 gitlab. 플래그가 항상 우선(detection은 빈 값만 채움).</li>
+<li><strong>profile 로드 + 자동 setup 프롬프트</strong><span class="loc">internal/cli/init.go:450-491</span>
+<code>profile.GetCurrentName()</code>. TTY + 비인터랙티브 아닐 때 <code>profile.IsSetup</code> false면 <code>huh.NewConfirm</code>로 setup 의사 확인. <code>profile.ReadPreferences</code>로 UserName/ConvLang/Git/Code/Doc lang를 opts에 prefill.</li>
+<li><strong>인터랙티브 위자드 분기</strong><span class="loc">internal/cli/init.go:493-553 · wizard/wizard.go:35</span>
+<code>!nonInteractive && isInteractiveStdin</code>일 때 <code>uikit.PrintBanner</code> 후 <code>runWizardFn</code>. 단일 3-페이지 폼(Basic/Model&Report/Quality&Workflow, REQ-WIZ-018). 취소(<code>ErrCancelled</code>)면 exit 0으로 간주.</li>
+<li><strong>기본값 확정</strong><span class="loc">internal/cli/init.go:555-568</span>
+<code>GitProvider</code> 빈 값 → <code>github</code>. <code>DevelopmentMode</code> 빈 값 → <code>tdd</code>(명시적 세팅으로 fallback 회피).</li>
+<li><strong>의존성 조립 + slim/all deployer 선택</strong><span class="loc">internal/cli/init.go:571-602 · shouldDistributeAll (298)</span>
+<code>shouldDistributeAll</code>(<code>--all</code> 또는 <code>MOAI_DISTRIBUTE_ALL=1|true</code>)면 <code>NewDeployerWithRenderer</code>(전체), 아니면 <code>NewSlimDeployerWithRenderer</code>(core-tier 필터) + <code>emitSlimModeNotice</code>.</li>
+<li><strong>PhaseExecutor.Execute — Phase 1 Detect</strong><span class="loc">phase.go:57-72 · phaseDetect (141)</span>
+<code>detector.DetectLanguages/Frameworks/ProjectType</code>. 실패는 non-fatal. <code>applyDetectedDefaults</code>가 ProjectName/Language(Go fallback)/ConvLang=en 등 기본값 채움.</li>
+<li><strong>Phase 2 Methodology</strong><span class="loc">phase.go:78-105</span>
+<code>opts.DevelopmentMode</code>가 이미 <code>tdd</code>로 세팅되어 명시적 모드 검증 분기로 진입.</li>
+<li><strong>Phase 3 Validate (idempotency 게이트)</strong><span class="loc">phase.go:169-192 · validator.go:69-104</span>
+<code>.moai/</code>가 이미 존재하면 <code>result.Valid=false</code> + "project already initialized". <code>opts.Force</code>면 <code>BackupExistingProject</code> 후 통과, 아니면 <code>ErrProjectExists</code>.</li>
+<li><strong>Phase 4 Init — Step 1/2 디렉터리 생성</strong><span class="loc">initializer.go:265 createMoAIDirs · 277 createClaudeDirs</span>
+<code>.moai/{config/sections, specs, reports, state, logs}</code> + <code>.claude/{agents/{core,expert,meta,harness}, skills, commands/moai, rules/moai, output-styles}</code>를 <code>MkdirAll</code>.</li>
+<li><strong>Init Step 3 — template 배포</strong><span class="loc">initializer.go:290-328 · deployer.go:100</span>
+<code>TemplateContext</code>를 <code>WithGoBinPath/WithHomeDir/WithResolvedMoaiPath/WithSmartPATH/WithPlatform/WithVersion</code>로 빌드. <code>Deployer.Deploy</code>가 embedded FS walk → <code>.tmpl</code>은 렌더 후 접미사 제거 → <code>atomicWriteFile</code>(.moai-tmp rename). 기존 파일은 manifest provenance 조회해 UserModified/UserCreated 건너뛰고 template_managed만 overwrite.</li>
+<li><strong>Init Step 3c/3d — report.yaml + Page-3 yaml 패치</strong><span class="loc">initializer.go:468 · initializer_expansion.go:30</span>
+<code>writeReportConfig</code>(format=html+md 기본). <code>WritePhase1Configs</code>가 project/lsp/quality/design yaml을 배포된 템플릿 위에 in-place 패치(REQ-WIZ-021).</li>
+<li><strong>Init Step 4/5/6 — CLAUDE.md·manifest·shell</strong><span class="loc">initializer.go:487/527/566</span>
+<code>createClaudeMD</code>: 배포된 CLAUDE.md 있으면 skip(REQ-E-034), 없으면 minimal stub. <code>initManifest</code>: Version + DeployedAt(RFC3339) 세팅 후 atomic Save. <code>configureShellEnv</code>: shell config에 PATH 추가.</li>
+<li><strong>runInit 후처리 — profile/tier 영속</strong><span class="loc">internal/cli/init.go:656-691</span>
+<code>profile.SyncToProjectConfig</code>. <code>resolveModelPolicy</code>로 perfTier 결정 → <code>ApplyPerformanceTier</code>(llm.yaml). <code>--profile</code> → <code>ApplyProfile</code>(llm.profile).</li>
+<li><strong>runInit 후처리 — evolution/settings/hooks/advisory</strong><span class="loc">internal/cli/init.go:697-716</span>
+<code>ScaffoldEvolutionDir</code>(<code>.moai/evolution/{telemetry,learnings,new-skills}</code>). <code>ensureGlobalSettingsEnv</code>. hook 설치(<code>--no-hooks</code> 시 skip). <code>emitWorktreeAdvisory</code>.</li>
+<li><strong>runInit 종료 — 지연 update notice + snapshot + 성공 카드</strong><span class="loc">internal/cli/init.go:627/651-653/721-728 · init_update_notice.go:77</span>
+<code>startDeferredUpdateNotice</code> goroutine(check-only, 1초 grace). <code>writeTemplateSnapshotBestEffort</code>로 3-way merge용 BASE 캡처. <code>buildInitSuccessCard</code> stderr 출력.</li>
+</ol>
+
+<h3>영속성 (읽기/쓰기 파일)</h3>
+<table>
+<thead><tr><th>경로</th><th>구분</th><th>내용</th></tr></thead>
+<tbody>
+<tr><td><code>.moai/{config/sections,specs,reports,state,logs}/</code></td><td>쓰기</td><td>디렉터리 생성 (createMoAIDirs)</td></tr>
+<tr><td><code>.claude/{agents/{core,expert,meta,harness},skills,commands/moai,rules/moai,output-styles}/</code></td><td>쓰기</td><td>디렉터리 생성 (createClaudeDirs)</td></tr>
+<tr><td><code>.claude/settings.json</code></td><td>쓰기</td><td><code>settings.json.tmpl</code> 렌더 (Platform 조건부, GoBinPath posixPath)</td></tr>
+<tr><td><code>.moai/status_line.sh</code></td><td>쓰기</td><td><code>status_line.sh.tmpl</code> 렌더</td></tr>
+<tr><td><code>.moai/config/sections/*.yaml</code></td><td>쓰기</td><td>deployer 배포 + Step 3c/3d 패치</td></tr>
+<tr><td><code>CLAUDE.md</code></td><td>쓰기</td><td>deployer 배포(우선) 또는 minimal stub</td></tr>
+<tr><td><code>.moai/manifest.json</code></td><td>쓰기</td><td>version + DeployedAt, track된 모든 배포 파일 해시</td></tr>
+<tr><td><code>.moai/evolution/{telemetry,learnings,new-skills}/</code></td><td>쓰기</td><td>ScaffoldEvolutionDir</td></tr>
+<tr><td><code>.moai/cache/template-snapshot/sections/</code></td><td>쓰기</td><td>rendered BASE snapshot (update_snapshot_hook.go)</td></tr>
+<tr><td><code>.git/hooks/pre-push</code>, <code>pre-commit</code></td><td>쓰기</td><td>hook 설치</td></tr>
+<tr><td><code>~/.zshenv</code> 등 shell config</td><td>쓰기</td><td>CLAUDE_DISABLE_PATH_WARNING + PATH (configureShellEnv)</td></tr>
+<tr><td><code>~/.claude/settings.json</code></td><td>쓰기</td><td>ensureGlobalSettingsEnv (env 변수 병합)</td></tr>
+<tr><td><code>~/.moai/claude-profiles/&lt;name&gt;/preferences.yaml</code></td><td>읽기</td><td>profile.ReadPreferences</td></tr>
+<tr><td><code>catalog.yaml</code> (embedded)</td><td>읽기</td><td>LoadEmbeddedCatalog</td></tr>
+</tbody>
+</table>
+
+<h3>핵심 함수</h3>
+<table>
+<thead><tr><th>함수</th><th>위치</th><th>역할</th></tr></thead>
+<tbody>
+<tr><td><code>runInit</code></td><td>init.go:315</td><td>RunE 진입점. warn collector·session-worktree·root 결정·wizard 분기·deployer 선택·PhaseExecutor.Execute·모든 후처리를 순차 스크립트로 꿰는 ~416줄 메인 오케스트레이터.</td></tr>
+<tr><td><code>validateInitFlags</code></td><td>init.go:187</td><td>PreRunE. 모든 closed-set 플래그 검증.</td></tr>
+<tr><td><code>shouldDistributeAll</code></td><td>init.go:298</td><td><code>--all</code> 또는 <code>MOAI_DISTRIBUTE_ALL</code>로 slim 기본값 opt-out 여부 결정.</td></tr>
+<tr><td><code>applyWizardPage3ToOpts</code></td><td>init.go:146</td><td>Page-3 위자드 답변을 opts에 반영하되 <code>Flags().Changed(name)</code>로 명시적 플래그 우선(REQ-WIZ-020).</td></tr>
+<tr><td><code>detectGitConfig</code></td><td>init_gitdetect.go:52</td><td>git remote 목록과 origin URL host로 git-mode·provider 자동 감지.</td></tr>
+<tr><td><code>PhaseExecutor.Execute</code></td><td>phase.go:57</td><td>5-페이즈 오케스트레이터: Detect → Methodology → Validate → Init → Complete.</td></tr>
+<tr><td><code>projectInitializer.Init</code></td><td>initializer.go:117</td><td>실제 스캐폴딩: 디렉터리 → template 배포 → yaml 패치 → CLAUDE.md → manifest → shell config.</td></tr>
+<tr><td><code>deployer.Deploy</code></td><td>deployer.go:100</td><td>embedded FS walk·.tmpl 렌더·경로 보호·atomicWriteFile·manifest.Track.</td></tr>
+<tr><td><code>SlimFS</code></td><td>slim_fs.go:214</td><td>catalog tier != TierCore인 항목을 Open/Stat/ReadDir에서 숨기는 fs.FS wrapper.</td></tr>
+<tr><td><code>phaseValidate</code></td><td>phase.go:169</td><td><code>.moai/</code> 존재 시 <code>ErrProjectExists</code>. <code>--force</code> 시 백업 후 통과.</td></tr>
+</tbody>
+</table>
+
+<h3>주요 분기와 엣지 케이스</h3>
+<div class="grid-2">
+<div class="insight">
+<h4>slim vs <code>--all</code></h4>
+<p><code>shouldDistributeAll</code>이 <code>--all</code> 또는 <code>MOAI_DISTRIBUTE_ALL=1|true</code>면 full deployer, 아니면 slim(core-tier만, optional_packs/harness_generated 제외). slim 모드에서 <code>SlimFS</code>가 non-core 엔트리를 fs.FS 수준에서 숨긴다.</p>
+</div>
+<div class="insight">
+<h4>idempotency 게이트</h4>
+<p><code>.moai/</code> 존재 + <code>!Force</code>면 <code>ErrProjectExists</code> 리턴. runInit가 에러 메시지에 "moai update" 힌트와 "--force" 안내를 추가. <code>--force</code>는 <code>BackupExistingProject</code> 후 통과.</p>
+</div>
+<div class="insight">
+<h4>wizard vs 플래그 우선순위</h4>
+<p><code>applyWizardPage3ToOpts</code>는 <code>Changed(name)</code>으로 명시적 플래그 우선. ConvLang/UserName은 wizard가 profile보다 우선하지만 빈 값이면 profile fallback. <code>--profile</code>은 wizard보다 항상 우선(REQ-MPM-016).</p>
+</div>
+<div class="insight">
+<h4>deployer 기존 파일 보호</h4>
+<p>UserModified/UserCreated은 skip, template_managed만 overwrite. manifest 미등록 기존 파일은 user_created로 track 후 skip(deployer.go:169-185). CLI 경로는 항상 non-nil deployer라 <code>generateConfigsFallback</code>은 사실상 도달 불가(C32).</p>
+</div>
+</div>
+</section>
+
+<!-- ===================== UPDATE ===================== -->
+<section id="update">
+<h2>3. moai update — 자기 갱신 + 템플릿 동기화</h2>
+
+<div class="card coral">
+<h3>목적</h3>
+<p><code>moai update</code>는 두 축으로 구성된다. (1) <strong>바이너리 자기 갱신</strong> — <code>internal/update/</code> 패키지가 GitHub Releases API로 최신 버전을 조회하고, 플랫폼 바이너리를 다운로드해 SHA256 체크섬으로 검증한 뒤 실행 중인 moai 바이너리를 원자적 교체한다. 실패 시 타임스탬프 백업에서 롤백한다. (2) <strong>템플릿 동기화</strong> — <code>update_template_sync.go</code>와 <code>update/</code> 서브패키지가 새 버전 템플릿을 기존 프로젝트에 3-way YAML 병합으로 동기화한다.</p>
+<p><strong>진입점:</strong> <code>internal/cli/update.go:39</code> <code>updateCmd</code> · PreRunE=<code>validateUpdateFlags</code> · RunE=<code>runUpdate</code>(update.go:136) · 템플릿 동기화 본체 <code>update_template_sync.go:49</code> <code>runTemplateSyncWithReporter</code></p>
+</div>
+
+<h3 id="update-binary">3.1 바이너리 자동 업데이트 (internal/update/)</h3>
+
+<p>이 절반은 GitHub Releases에서 최신 바이너리를 조회·다운로드·검증·교체하는 파이프라인이다. 핵심 설계 원칙은 <strong>체크섬 없는 다운로드를 원천 차단</strong>하는 것이다 (CWE-345 방어).</p>
+
+<div class="mermaid">
+graph TD
+    Start["moai update 또는<br/>SessionStart 자동갱신"] --> Src{"업데이트 소스"}
+    Src -->|"MOAI_UPDATE_SOURCE=local"| Local["local.CheckLatest<br/>~/.moai/releases/version.json<br/>+ .sha256 사이드카"]
+    Src -->|"기본 GitHub 원격"| CacheChk{"캐시 조회<br/>~/.moai/cache/update_check.json<br/>TTL 1시간"}
+    CacheChk -->|"히트 + Available false"| NoUpd1["갱신 없음 즉시 종료"]
+    CacheChk -->|"미스/만료"| GH["checker.CheckLatest<br/>GET api.github.com/.../releases"]
+
+    Local --> Cmp
+    GH --> Build["buildVersionInfo<br/>archive 자산 + checksums.txt 매칭"]
+    Build -->|"checksums.txt 부재"| ErrCS1["ErrChecksumUnavailable"]
+    Build --> DLCS["downloadChecksumWithRetry<br/>3회, 2s 지수 백오프"]
+    DLCS -->|"3회 전부 실패"| ErrCS2["ErrChecksumUnavailable"]
+    DLCS -->|"성공"| CSFound["Checksum 확보"]
+
+    CSFound --> Cmp["compareSemver<br/>go-v/v 제거 후 비교"]
+    Cmp -->|"같거나 오래됨"| NoUpd2["갱신 불가<br/>cache.Set Available=false"]
+    Cmp -->|"확실히 최신"| CheckFlag{"--check 플래그?"}
+    CheckFlag -->|"yes"| PrintInfo["Latest version 출력<br/>설치 없음, return nil"]
+    CheckFlag -->|"no"| Backup["rollback.CreateBackup<br/>binary.backup.UNIX-ts"]
+
+    Backup --> Download["updater.Download<br/>Checksum 공백이면 즉시 거부"]
+    Download -->|"HTTP GET 자산"| Temp[".moai-download-*.tmp<br/>io.MultiWriter 파일+sha256"]
+    Temp --> Verify{"sha256 일치?"}
+    Verify -->|"불일치"| ErrMM["ErrChecksumMismatch<br/>temp 제거"]
+    Verify -->|"일치"| Extract["extractBinary<br/>tar.gz 또는 zip → .moai-extracted-*.tmp"]
+    Extract --> Validate["validateBinaryFormat<br/>ELF/Mach-O/PE 승인<br/>gzip/zip 거부"]
+    Validate --> Replace["updater.Replace<br/>Unix: os.Rename 원자적<br/>Windows: 두 단계 rename-away"]
+
+    Replace -->|"실패"| Rollback["attemptRollback<br/>rollback.Restore 백업"]
+    Download -->|"실패"| Rollback
+    Rollback -->|"복구 성공"| FailErr["래핑된 에러 반환<br/>바이너리 원상복구"]
+    Rollback -->|"복구 실패"| Manual["합성 에러 + 백업 경로<br/>수동 복구 안내"]
+    Replace -->|"성공"| Done["UpdateResult<br/>PreviousVersion → NewVersion"]
+    Done --> CacheSet["cache.Set Available + LatestInfo"]
+    CacheSet --> Reexec{"실행 컨텍스트"}
+    Reexec -->|"moai update CLI"| ReExec["reexecNewBinary<br/>syscall.Exec<br/>MOAI_SKIP_BINARY_UPDATE=1"]
+    Reexec -->|"SessionStart 훅"| SysMsg["SystemMessage<br/>터미널 재시작 안내"]
+
+    classDef danger fill:#fde3e3,stroke:#a04545
+    classDef ok fill:#bbf7d0,stroke:#15803d
+    classDef decision fill:#fde68a,stroke:#b45309
+    class ErrCS1,ErrCS2,ErrMM danger
+    class NoUpd1,NoUpd2,Done ok
+    class Src,CacheChk,Cmp,CheckFlag,Verify,Reexec decision
+</div>
+
+<h4>체크섬 강제 3중 게이트</h4>
+<div class="callout danger">
+<strong>CWE-345 봉쇄.</strong> 체크섬 검증은 세 지점에서 강제된다:
+<ol style="margin:8px 0 0;">
+<li><code>checksumsURL</code> 부재 → <code>ErrChecksumUnavailable</code> (checker.go:160)</li>
+<li><code>downloadChecksumWithRetry</code> 3회 전부 실패 → <code>ErrChecksumUnavailable</code> (checker.go:167)</li>
+<li><code>Download</code> 진입 시 <code>Checksum</code> 공백 → <code>ErrChecksumUnavailable</code> (updater.go:53, HTTP 발행 전)</li>
+</ol>
+<code>buildVersionInfo</code>는 <code>@MX:ANCHOR</code> + 회귀 테스트(<code>TestCheckLatestChecksumDownloadFailureAborts</code>)로 "절대 빈 Checksum을 생산하지 않는다"는 계약을 고정한다.
+</div>
+
+<h4>핵심 함수 (바이너리 절반)</h4>
+<table>
+<thead><tr><th>함수</th><th>위치</th><th>역할</th></tr></thead>
+<tbody>
+<tr><td><code>checker.CheckLatest</code></td><td>checker.go:59</td><td>GitHub Releases API GET → releaseResponse 파싱(단일/배열 분기) → <code>buildVersionInfo</code>로 VersionInfo 생성.</td></tr>
+<tr><td><code>buildVersionInfo</code></td><td>checker.go:128</td><td><code>@MX:ANCHOR</code>. 아카이브 자산/체크섬 URL 매칭 + 체크섬 강제 게이트. 빈 Checksum 생산 경로 봉쇄.</td></tr>
+<tr><td><code>downloadChecksumWithRetry</code></td><td>checker.go:195</td><td>3회 재시도, 2s 기본 지수 백오프(2s→4s→8s)로 checksums.txt에서 SHA256 추출.</td></tr>
+<tr><td><code>updaterImpl.Download</code></td><td>updater.go:49</td><td>Checksum 공백이면 다운로드 자체 거부. HTTP GET → temp 파일 + 스트리밍 sha256 → 검증 → 아카이브 추출.</td></tr>
+<tr><td><code>updaterImpl.Replace</code></td><td>updater.go:126</td><td><code>validateBinaryFormat</code>(ELF/Mach-O/PE만 승인) + chmod 0o755 + 원자적 <code>os.Rename</code>. Windows는 두 단계 rename-away.</td></tr>
+<tr><td><code>orchestratorImpl.Update</code></td><td>orchestrator.go:32</td><td>IsUpdateAvailable → CreateBackup → Download → Replace 4단계. 실패 시 <code>attemptRollback</code>으로 자동 복구.</td></tr>
+<tr><td><code>Cache.Get / Set</code></td><td>cache.go:50/78</td><td><code>@MX:ANCHOR</code>. <code>~/.moai/cache/update_check.json</code> 파일 캐시, TTL 1시간.</td></tr>
+<tr><td><code>autoUpdateHandler.Handle</code></td><td>auto_update.go:69</td><td>SessionStart 발화. 25s timeout, 에러는 전부 <code>slog.Debug</code>로 삼키고 세션을 블록하지 않음.</td></tr>
+<tr><td><code>reexecNewBinary</code></td><td>update.go:716</td><td>성공적 교체 후 새 바이너리로 전환. <code>MOAI_SKIP_BINARY_UPDATE=1</code> 세팅(루프 방지). Unix=<code>syscall.Exec</code>, Windows=자식 spawn+<code>os.Exit(0)</code>.</td></tr>
+</tbody>
+</table>
+
+<div class="callout warn">
+<strong>잠재 위험 (미검증).</strong>
+<ul style="margin:4px 0 0;">
+<li><code>localChecker.CheckLatest</code>가 <code>.sha256</code> 사이드카 부재 시 Checksum을 빈 문자열로 남길 수 있고, <code>localUpdater.Download</code>는 <code>file://</code> 경로만 반환해 체크섬 게이트를 우회한다 — 로컬 경로에서는 체크섬 검증이 전혀 수행되지 않는다.</li>
+<li>SessionStart 자동갱신의 25s timeout과 수동 <code>runBinaryUpdateStep</code>의 120s timeout이 다르다. 느린 GitHub 다운로드 시 25s에서 잘릴 수 있다.</li>
+<li><code>UpdateResult</code>의 <code>FilesUpdated/FilesMerged/FilesConflicted/FilesSkipped</code> 필드가 바이너리 절반에서 전혀 채워지지 않는다(dead field, 템플릿 절반과 타입 공유로 인한 구조적 부채).</li>
+</ul>
+</div>
+
+<hr>
+
+<h3 id="update-template">3.2 템플릿 동기화 (update_template_sync.go + update/ 서브패키지)</h3>
+
+<p>바이너리 갱신 후(또는 <code>--templates-only</code> 시), 임베디드 템플릿을 기존 프로젝트에 동기화한다. 핵심은 <strong>사용자 수정을 보존하는 3-way 병합</strong>과 <strong>user-owned namespace 보호</strong>다.</p>
+
+<div class="mermaid">
+graph TD
+    SyncEntry["runTemplateSyncWithProgress<br/>update_template_sync.go:526"] --> VerMatch{"packageVersion == projectVersion<br/>AND not force?"}
+    VerMatch -->|"yes"| UpToDate["Already up to date<br/>syncSkipped=true"]
+    VerMatch -->|"no"| Analyze["AnalyzeMergeChanges<br/>Classify via IsUserOwnedNamespace<br/>FileAnalysis: risk/strategy"]
+
+    Analyze --> Confirm{"--yes 또는<br/>사전 확인?"}
+    Confirm -->|"취소"| Cancel["Merge cancelled<br/>syncSkipped=true"]
+    Confirm -->|"진행"| Steps["5단계 배포 테이블"]
+
+    Steps --> S1["1. Backup<br/>BackupMoaiConfig<br/>.moai-backups/stamp/<br/>+ .template-defaults BASE<br/>+ backupUserOwnedNamespace<br/>+ verifyNamespaceBackupCoverage"]
+    S1 --> S2["2. Validate Templates<br/>deployer.ValidateAll<br/>렌더 사전 검증"]
+    S2 --> S3["3. Clean Managed Paths<br/>guardFirstDestructiveStep<br/>in-memory-only 디스크 백업<br/>→ CleanMoaiManagedPaths<br/>recoveryGuard 진입"]
+    S3 --> S4["4. Deploy Templates<br/>deployer.Deploy<br/>.tmpl 렌더링 + manifest 등록"]
+    S4 --> S5["5. Restore Settings<br/>RestoreMoaiConfig<br/>MergeYAML3Way new/old/base<br/>node-tree 주석·순서 보존<br/>+ MergeGitignoreFile<br/>+ MergeUserFiles 3-way"]
+    S5 --> Outcome["renderUpdateOutcome"]
+
+    Outcome --> Post1["archiveLegacySkills 14개 ID<br/>.moai/archive/skills/v2.16/"]
+    Post1 --> Post2["ScaffoldEvolutionDir<br/>+ profile.SyncToProjectConfig"]
+    Post2 --> Post3["ensureGlobalSettingsEnv<br/>+ 훅 설치 + worktree 권고"]
+    Post3 --> EndSync["종료"]
+
+    UpToDate --> PostArchive{"syncSkipped?"}
+    PostArchive -->|"yes"| ProfPersist["--profile만 persist"]
+    ProfPersist --> EndSync
+    Cancel --> PostArchive
+
+    classDef destructive fill:#fde3e3,stroke:#a04545
+    classDef protect fill:#fff4e6,stroke:#e8590c
+    classDef skip fill:#e6fcf5,stroke:#0c8599
+    class S3,S4 destructive
+    class S1 protect
+    class UpToDate,ProfPersist skip
+</div>
+
+<h4>update/ 서브패키지 단계별 역할</h4>
+<table>
+<thead><tr><th>서브패키지</th><th>주요 함수</th><th>산출물</th></tr></thead>
+<tbody>
+<tr><td><code>update/plan</code></td><td><code>AnalyzeFiles</code>, <code>IsUserOwnedNamespace</code>, <code>IsMoaiManaged</code>, <code>Classify</code></td><td>FileAnalysis[](risk/strategy/hasConflicts). user-owned vs template-managed 분류 SSOT.</td></tr>
+<tr><td><code>update/merge</code></td><td><code>AnalyzeMergeChanges</code>, <code>MergeUserFiles</code>, <code>MergeGitignoreFile</code></td><td>3-way 병합 분석 + 사용자 파일(settings.json/status_line.sh/.gitignore) 병합.</td></tr>
+<tr><td><code>update/deploy</code></td><td><code>CleanMoaiManagedPaths</code>, <code>ScaffoldEvolutionDir</code></td><td>파괴적 정리 + 진화 디렉토리 보존적 생성.</td></tr>
+<tr><td><code>update/backup</code></td><td><code>BackupMoaiConfig</code>, <code>RestoreMoaiConfig</code>, <code>MergeYAML3Way</code></td><td>백업·복원·node-tree 3-way YAML 머지(주석·키 순서·quote 스타일 보존, issue #1243).</td></tr>
+<tr><td><code>update/report</code></td><td><code>renderUpdateOutcome</code>, <code>EmitHooksReviewGuidance</code></td><td>결과 요약 + 훅 검토 권고.</td></tr>
+<tr><td><code>update/class.go</code></td><td><code>Classify</code></td><td>단일 분류 진입점(REQ-TUX3-001 SSOT). 우선순위: user-owned &gt; conflict &gt; !exists &gt; update.</td></tr>
+</tbody>
+</table>
+
+<h4>네임스페이스 보호 (CLAUDE.local.md §24)</h4>
+<div class="callout">
+<strong>user-owned vs template-managed 분리.</strong>
+<p>분류는 두 술어로 동작한다:</p>
+<ul style="margin:4px 0 0;">
+<li><code>plan.IsUserOwnedNamespace</code> (엄격, plan.go:152) — <code>.claude/skills/{hns-,harness-,my-harness-}*</code>, <code>.claude/agents/harness/</code>, <code>.moai/harness/</code>, <code>.claude/commands/harness/</code>, <code>.claude/workflows/{hns-,harness-}*.js</code>, 그리고 moai/manager/expert/builder/evaluator 접두 아닌 항목을 user-owned로 분류. <strong>이 파일들은 절대 덮어쓰지 않는다.</strong></li>
+<li><code>isUserOwnedNamespaceConservative</code> (보수적 상위집합) — 백업 단계에서 사용. 모호한 <code>moai-</code> 접두도 일단 백업한다.</li>
+</ul>
+<p>백업은 보수적으로(모호하면 백업), 분류·검증은 엄격하게(명확한 user-owned만 보호). <code>verifyNamespaceBackupCoverage</code>(update_namespace_protect.go:293)가 파괴 작업 전 모든 user-owned 파일이 백업됐는지 검증 → 누락 시 <code>UPDATE_USER_NAMESPACE_VIOLATION</code> 센티널로 abort(REQ-SEC-006).</p>
+</div>
+
+<h4>update 플래그</h4>
+<table>
+<thead><tr><th>플래그</th><th>용도</th></tr></thead>
+<tbody>
+<tr><td><code>--version &lt;tag&gt;</code></td><td>명시적 GitHub release tag 설치. semver 게이트 우회 강제 설치. <code>tagCharsetRegexp</code>로 경로순회 방어.</td></tr>
+<tr><td><code>--check</code></td><td>최신 바이너리 존재 여부 informational 조회. 설치·템플릿 동기화 미수행.</td></tr>
+<tr><td><code>-c / --config</code></td><td>템플릿 동기화 없이 <code>runInitWizard(cmd, true)</code> 재구성 마법사 실행.</td></tr>
+<tr><td><code>--shell-env</code></td><td>shell config에 PATH·CLAUDE_* 환경변수 기록. 템플릿 동기화 미수행.</td></tr>
+<tr><td><code>--force</code></td><td>버전 매칭 스킵 + 백업/머지 강제 + archive drift overwrite.</td></tr>
+<tr><td><code>--yes</code></td><td>CI/CD 모드. 모든 프롬프트 자동 확인.</td></tr>
+<tr><td><code>--templates-only</code></td><td>바이너리 업데이트 스킵, 템플릿 동기화만. <code>--binary</code>와 상호배타.</td></tr>
+<tr><td><code>--binary</code></td><td>바이너리만 업데이트, 템플릿 동기화 스킵. 프로젝트 마커 게이트 면제.</td></tr>
+<tr><td><code>--dry-run</code></td><td>파일시스템 변경 없이 계획만 출력(REQ-RIL2-026).</td></tr>
+<tr><td><code>--restore &lt;dir&gt;</code></td><td>이전 update 백업 디렉토리를 트리에 적용(lockout escape).</td></tr>
+<tr><td><code>--verbose</code></td><td>diagnostic 모드. 3-strike 노이즈 억제 우회.</td></tr>
+<tr><td><code>--profile {max,medium,low}</code></td><td>모델+effort 프로필 override를 <code>llm.profile</code>에 persist.</td></tr>
+<tr><td><code>--no-hooks</code></td><td>pre-push·pre-commit 훅 설치 스킵.</td></tr>
+</tbody>
+</table>
+
+<h4>상호배타 매트릭스</h4>
+<table>
+<thead><tr><th></th><th><code>--check</code></th><th><code>--templates-only</code></th><th><code>--restore</code></th><th><code>--dry-run</code></th></tr></thead>
+<tbody>
+<tr><td><strong><code>--version</code></strong></td><td><span class="pill danger">충돌</span></td><td><span class="pill danger">충돌</span></td><td><span class="pill danger">충돌</span></td><td><span class="pill danger">충돌</span></td></tr>
+<tr><td><strong><code>--binary</code></strong></td><td><span class="pill ok">허용</span></td><td><span class="pill danger">충돌</span></td><td>—</td><td>—</td></tr>
+<tr><td><strong><code>--force</code></strong></td><td><span class="pill ok">허용</span></td><td><span class="pill ok">허용</span></td><td>—</td><td>—</td></tr>
+<tr><td><strong><code>--yes</code></strong></td><td><span class="pill ok">허용</span></td><td><span class="pill ok">허용</span></td><td>—</td><td>—</td></tr>
+</tbody>
+</table>
+
+<h4>특수 분기</h4>
+<div class="grid-2">
+<div class="insight">
+<h4><code>--dry-run</code> (REQ-RIL2-026)</h4>
+<p>파일시스템 기록 0. <code>detectV2Fingerprint</code>/<code>isMoAIProject</code>/<code>runCleanReinstall(DryRun:true)</code>/<code>runV3ResidueCleanup(dryRun:true)</code> 모두 dryRun 분기에서 기록하지 않는다.</p>
+</div>
+<div class="insight">
+<h4><code>--restore</code> (lockout escape)</h4>
+<p>마커 게이트 이전에 분기(REQ-UDS-022). <code>system.yaml</code>이 파괴된 트리 복구용. <code>backup_metadata.json</code> 마커 필수. <code>restoreFixedPointPasses=2</code>로 byte-idempotent 보장(REQ-UDS-023).</p>
+</div>
+<div class="insight">
+<h4>v2 → v3 clean reinstall</h4>
+<p><code>detectV2Fingerprint</code>(3 신호: system.yaml 버전, <code>.agency/</code> 존재, DeprecatedPaths) && <code>isMoAIProject</code>면 <code>runCleanReinstall</code> 7단계 수행 후 조기 종료. PRESERVE 인벤토리 → 백업 → REMOVE → 재배포 → MERGE-back → 무결성 해시 검증.</p>
+</div>
+<div class="insight">
+<h4>version-match skip 최적화</h4>
+<p><code>packageVersion==projectVersion && !force</code>면 70-80% 빠른 스킵. 단 <code>--profile</code> 명시 시 <code>llm.yaml</code> 영속은 skip 분기 안에서도 수행. <code>syncSkipped=true</code>면 post-sync 아카이브도 스킵(REQ-UAC-004).</p>
+</div>
+</div>
+
+<h4>MergeYAML3Way 의사결정</h4>
+<div class="callout">
+<strong>node-tree 3-way 병합 규칙</strong> (backup/node_merge.go:215):
+<ul style="margin:4px 0 0;">
+<li><code>systemFields</code>(template_version, version)는 항상 new 값</li>
+<li><code>old == base</code> → new 값 (사용자가 수정 안 한 키는 새 템플릿으로)</li>
+<li><code>old != base</code> → old 보존 (사용자가 수정한 키는 유지)</li>
+<li>old-only 키는 보존 후 stderr advisory (REQ-UYP-006/007)</li>
+<li>Multi-document 입력 거부 (REQ-UYP-015)</li>
+<li>2-space 들여쓰기 (REQ-UYP-004)</li>
+</ul>
+실패 시 2-way <code>MergeYAMLDeep</code> 폴백 + <code>recordMergeFallback</code>(3-strike 노이즈 억제, update_noise.go).
+</div>
+</section>
+
+<!-- ===================== WEB ===================== -->
+<section id="web">
+<h2>4. moai web — 브라우저 설정 에디터</h2>
+
+<div class="card coral">
+<h3>목적</h3>
+<p>브라우저 기반 MoAI Web Console(설정 에디터)을 띄우는 thin CLI 진입점. 루프백 전용 HTTP 서버를 띄워 profile preferences와 프로젝트 <code>.moai/config</code> 섹션을 CRUD한다. 터미널 profile wizard와 동일한 검증/영속화 경로를 재사용한다. <strong>외부 DB·인증·네트워크 노출 없음.</strong></p>
+<p><strong>진입점:</strong> <code>internal/cli/web.go:32</code> <code>newWebCmd</code> → <code>runWeb</code>(web.go:71) → <code>web.Run</code>(server.go:87) → <code>(*Server).ListenAndServe</code>(server.go:193)</p>
+</div>
+
+<h3>플래그</h3>
+<table>
+<thead><tr><th>플래그</th><th>기본값</th><th>용도</th></tr></thead>
+<tbody>
+<tr><td><code>--port &lt;int&gt;</code></td><td>3041</td><td><code>127.0.0.1</code>에 바인드할 TCP 포트.</td></tr>
+<tr><td><code>--no-open</code></td><td>false</td><td>서버 기동 후 브라우저 자동 오픈 억제(REQ-WC-004).</td></tr>
+<tr><td><code>--no-reuse</code></td><td>false</td><td>stale moai 인스턴스 포트 회수 금지 — 충돌 시 에러로 종료.</td></tr>
+</tbody>
+</table>
+
+<h3>라이프사이클 흐름도</h3>
+<div class="mermaid">
+graph TD
+    CLI["moai web CLI<br/>web.go:71 runWeb"] --> ROOT["findProjectRootFn<br/>프로젝트 루트 해석"]
+    ROOT -->|"실패"| EXIT1["wrapped error → exit 1"]
+    ROOT -->|"성공"| WT["session-worktree 자동 진입<br/>enterSessionWorktree + Chdir"]
+    WT --> PORT["ensurePortFree<br/>web_port.go:76"]
+    PORT --> NOREUSE{"--no-reuse?"}
+    NOREUSE -->|"true"| SKIP["회수 스킵 → web.Run 위임"]
+    NOREUSE -->|"false"| CHK{"isPortInUse?<br/>127.0.0.1 bind 시도"}
+    CHK -->|"free"| SKIP
+    CHK -->|"held"| HOLDER["findPortHolder<br/>lsof + ps"]
+    HOLDER --> ISMOAI{"holder == moai?"}
+    ISMOAI -->|"unknown/실패"| SKIP
+    ISMOAI -->|"비moai"| ERRPORT["에러: 비moai 프로세스<br/>→ --port 제안 → exit 1"]
+    ISMOAI -->|"moai"| KILL["SIGTERM + poll 3s<br/>killProcessImpl"]
+    KILL --> SKIP
+
+    SKIP --> RUN["web.Run cfg<br/>server.go:87"]
+    RUN --> NEWSRV["NewServer<br/>ProjectRoot 검증 + newApp + routes"]
+    NEWSRV --> BIND["bind 127.0.0.1 전용<br/>server.go:167"]
+    BIND -->|"EADDRINUSE"| EXIT2["bind error → exit 1"]
+    BIND -->|"성공"| BROWSER["tryOpenBrowser<br/>open/rundll32/xdg-open<br/>non-fatal"]
+    BROWSER --> SERVE["httpSrv.Serve 고루틴<br/>+ signal.NotifyContext<br/>SIGINT/SIGTERM"]
+
+    SERVE --> ROUTES["hostCheckMiddleware 게이트<br/>app.go:164"]
+    ROUTES --> R1["GET /<br/>handleIndex<br/>폼 읽기 + 렌더"]
+    ROUTES --> R2["POST /save<br/>handleSave<br/>7 validator + 7단계 영속화"]
+    ROUTES --> R3["GET /specs<br/>handleBoard<br/>읽기전용 SPEC 보드"]
+    ROUTES --> R4["POST /profile/create"]
+    ROUTES --> R5["POST /profile/delete"]
+    ROUTES --> R6["POST /__shutdown__"]
+    ROUTES --> R7["/static/*<br/>embed.FileServer"]
+
+    SERVE -->|"sigCtx.Done OR<br/>triggerShutdown"| DRAIN["httpSrv.Shutdown<br/>5s drain"]
+    DRAIN --> EXIT0["nil 반환 → exit 0"]
+
+    classDef decision fill:#fde68a,stroke:#b45309
+    classDef term fill:#bbf7d0,stroke:#15803d
+    class NOREUSE,CHK,ISMOAI decision
+    class EXIT1,EXIT2,EXIT0 term
+</div>
+
+<h3>라우트 맵</h3>
+<table>
+<thead><tr><th>Method</th><th>Path</th><th>Handler</th><th>용도</th></tr></thead>
+<tbody>
+<tr><td>GET</td><td><code>/</code></td><td><code>handleIndex</code></td><td>폼 읽기 + 페이지 렌더. profile 이름 검증(REQ-SEC-001) 후 모든 read seam 실행.</td></tr>
+<tr><td>POST</td><td><code>/save</code></td><td><code>handleSave</code></td><td>7 validator 병합 atomic reject + 7단계 순차 영속화. 유일한 디스크 쓰기 경로(<code>@MX:WARN</code>).</td></tr>
+<tr><td>GET</td><td><code>/specs</code></td><td><code>handleBoard</code></td><td>읽기 전용 SPEC 대시보드. 쓰기/명령실행/status 전이 없음.</td></tr>
+<tr><td>POST</td><td><code>/profile/create</code></td><td><code>handleProfileCreate</code></td><td>이름 검증(default/순회 거부) 후 <code>createProfile</code>(MkdirAll, env 무접점).</td></tr>
+<tr><td>POST</td><td><code>/profile/delete</code></td><td><code>handleProfileDelete</code></td><td>default·현재 active 프로필 삭제 거부 후 <code>profile.Delete</code> 위임.</td></tr>
+<tr><td>POST</td><td><code>/__shutdown__</code></td><td><code>handleShutdown</code></td><td>응답 200 먼저 작성 후 고루틴에서 <code>triggerShutdown</code> 호출(동기 호출 시 교착).</td></tr>
+<tr><td>GET</td><td><code>/static/*</code></td><td>embed FileServer</td><td>정적 자산 서빙.</td></tr>
+</tbody>
+</table>
+
+<h3>요청 시퀀스 다이어그램 (profile/config save)</h3>
+<div class="mermaid">
+sequenceDiagram
+    autonumber
+    participant B as Browser
+    participant MW as hostCheckMiddleware
+    participant H as handleSave
+    participant V as Validators (7개 병합)
+    participant P as Persistence (7단계)
+
+    B->>MW: POST /save (form data)
+    MW->>MW: Host 헤더 loopback 검사 (DNS-rebinding 차단)
+    MW->>MW: Sec-Fetch-Site: same-origin 강제 (CSRF 차단)
+    MW->>H: 검증 통과 시 핸들러로 전달
+
+    H->>H: bindForm + parseProjectNestedForm<br/>+ parseSchemaForm + parseGLMKeyForm<br/>+ parsePerfTierForm + parseAgentFMForm
+    H->>V: 7개 validator 병합 호출
+    Note over V: validatePrefs<br/>validateProjectConfig<br/>validateProjectNestedConfig<br/>schemaErrs / agentErrs<br/>perfTierErrs / glmKeyErrs
+    V-->>H: 검증 결과
+
+    alt 하나라도 실패 (atomic reject)
+        H-->>B: 400 + per-field 에러와 함께 재렌더<br/>영속상태 불변 (EC-2)
+    else 전부 통과
+        H->>P: 7단계 순차 영속화 시작
+        P->>P: 1. writePreferences (profile 스토어)
+        P->>P: 2. recordLastProfile (launch ledger, advisory)
+        P->>P: 3. syncToProject (user/language.yaml)
+        P->>P: 4. writeProjectConfig (quality/git_convention)
+        P->>P: 5. writeProjectNestedConfig (6 큐레이티드 필드)
+        P->>P: 6. applySchemaEdits (10섹션)
+        P->>P: 7. applyPerfTierEdits + patchAgentFM + glmcred.Save
+        P-->>H: 성공
+        H-->>B: 200 redirect
+    end
+</div>
+
+<h3>영속성</h3>
+<table>
+<thead><tr><th>경로</th><th>구분</th><th>내용</th></tr></thead>
+<tbody>
+<tr><td><code>~/.moai/claude-profiles/&lt;name&gt;/preferences.yaml</code></td><td>읽기/쓰기</td><td>profile.ReadPreferences/WritePreferences</td></tr>
+<tr><td><code>.moai/config/sections/user.yaml</code>, <code>language.yaml</code></td><td>쓰기</td><td>profile.SyncToProjectConfig (profile 항목 동기화)</td></tr>
+<tr><td><code>.moai/config/sections/quality.yaml</code></td><td>읽기/쓰기</td><td>writeProjectConfig (development_mode) + writeProjectNestedConfig</td></tr>
+<tr><td><code>.moai/config/sections/git-convention.yaml</code></td><td>읽기/쓰기</td><td>writeProjectConfig (convention) + writeProjectNestedConfig</td></tr>
+<tr><td><code>.moai/config/sections/{workflow,harness,ralph,feedback,observability,security}.yaml</code></td><td>읽기/쓰기</td><td>settings.ApplySchemaEdits yamlpatch seam (주석 보존)</td></tr>
+<tr><td><code>.moai/config/sections/git-strategy.yaml</code>, <code>llm.yaml</code></td><td>읽기/쓰기</td><td>ApplySchemaEdits typed 경로 + agentfm llm.agent_overrides</td></tr>
+<tr><td><code>~/.moai/.env.glm</code></td><td>읽기/쓰기</td><td>glmcred.Save (GLM API key)</td></tr>
+<tr><td><code>~/.moai/claude-profiles/</code> launch ledger</td><td>쓰기</td><td>profile.RecordLastUsedProfileForProject (advisory)</td></tr>
+</tbody>
+</table>
+
+<div class="callout warn">
+<strong>쓰기 금지 섹션 (REQ-WC11-018).</strong>
+<code>state/system/project/cache/sunset/tool-policy/lsp/mx</code> 및 미지명 섹션, 폐선 <code>db/research</code>는 웹에서 편집하지 않는다. 유일한 영속화 패턴은 config-manager typed 경로 또는 settings/yamlpatch seam이며, 웹 레이어에서 <code>yaml.Marshal/os.WriteFile</code> 직접 호출은 금지 안티패턴(REQ-WC-007/REQ-WC3-008)이다.
+</div>
+
+<h3>보안 모델</h3>
+<div class="grid-2">
+<div class="insight">
+<h4>루프백 전용 바인드</h4>
+<p><code>bind</code>(server.go:167)가 <code>127.0.0.1:&lt;port&gt;</code>만 허용. <code>0.0.0.0</code> 바인드는 금지(REQ-WC-002). bind가 유일한 주소 구성 지점이다.</p>
+</div>
+<div class="insight">
+<h4>2-layer 쓰기 안전</h4>
+<p><code>hostCheckMiddleware</code>(app.go:164)가 POST/PUT/PATCH에 대해: (1) Host 헤더 loopback 검사(DNS-rebinding 차단, REQ-WC-009), (2) <code>Sec-Fetch-Site: same-origin</code> 강제(CSRF 차단, REQ-SEC-002). GET은 게이트 안 함. per-process CSRF 토큰 인프라는 의도적 미사용.</p>
+</div>
+<div class="insight">
+<h4>profile 이름 순회 가드</h4>
+<p><code>IsValidProfileName</code>이 slash/backslash/선행점/절대경로 거부. GET/POST 양 경로에서 게이트 → <code>../../etc</code> 순회 차단(REQ-SEC-001/REQ-WC11-034). default·active 프로필 삭제 거부는 웹 전용 경계 로직.</p>
+</div>
+<div class="insight">
+<h4>GLM key anti-leak</h4>
+<p>GLM key는 schema FieldDef 집합에서 의도적 배제(D-2). <code>computeGLMKeyHint</code>가 뷰모델 진입 전 trailing-4로 truncate. full key는 절대 뷰모델 진입 안 함(REQ-GKI-004). line-break in body → reject, surrounding whitespace → trim, empty → preserve.</p>
+</div>
+</div>
+
+<div class="callout">
+<strong>atomic reject (EC-2).</strong> 7개 validator 중 하나라도 실패하면 영속상태 불변, 폼 per-field 에러와 함께 400 재렌더. <strong>empty=preserve (EC-1)</strong>: 빈 제출값은 기존값 유지. 이 두 계약이 "부분 저장"을 원천 차단한다.
+</div>
+</section>
+
+<!-- ===================== SHARED INFRA ===================== -->
+<section id="shared">
+<h2>5. 공유 인프라 심층</h2>
+
+<h3>5.1 template 시스템 (embed + catalog + Deployer + Renderer + slim)</h3>
+<p>임베디드 템플릿은 컴파일 시점에 바이너리에 포함된다. <code>internal/template/embed.go</code>가 <code>//go:embed all:templates</code> + <code>//go:embed catalog.yaml</code>으로 FS를 삽입하며, generated .go 파일은 없다. <code>EmbeddedTemplates()</code>가 <code>fs.Sub(embeddedRaw, "templates")</code>로 prefix를 벗겨 배포 타깃 경로와 1:1로 맞춘다.</p>
+
+<table>
+<thead><tr><th>함수/타입</th><th>위치</th><th>역할</th></tr></thead>
+<tbody>
+<tr><td><code>EmbeddedTemplates</code></td><td>embed.go:42</td><td><code>fs.Sub</code>로 prefix 벗긴 fs.FS 반환. init/update가 템플릿 소스로 사용.</td></tr>
+<tr><td><code>LoadEmbeddedCatalog</code></td><td>catalog_loader.go:113 · embed_catalog.go:29</td><td>catalog.yaml을 <code>*Catalog{Core, OptionalPacks, HarnessGenerated}</code>로 파싱. tiers = core / harness-generated / optional-pack:&lt;name&gt;.</td></tr>
+<tr><td><code>SlimFS</code></td><td>slim_fs.go:214</td><td>raw embed를 denySet(non-core entry)로 감싸 core만 보이게 하는 read-only FS 래퍼.</td></tr>
+<tr><td><code>Deployer.Deploy</code></td><td>deployer.go:100</td><td>walk → .tmpl 렌더 → provenance 조회 → atomicWriteFile → <code>m.Track</code>.</td></tr>
+<tr><td><code>Renderer.Render</code></td><td>renderer.go:70</td><td>text/template + missingkey=error + posixPath/jsonEscape funcs. 렌더 후 미전개 토큰 잔존 스캔(<code>claudeCodePassthroughTokens</code> 예외).</td></tr>
+<tr><td><code>NewTemplateContext</code></td><td>context.go:85</td><td>With* option 패턴으로 ~30 필드 구성.</td></tr>
+</tbody>
+</table>
+
+<h3>5.2 config 시스템 (sections + loader + manager + env overrides)</h3>
+<p><code>.moai/config/sections/*.yaml</code>을 섹션별로 파싱해 병합한다. 각 load 함수는 컴파일 기본값으로 wrapper를 시드한 뒤 사용자 YAML로 partial-override한다(사용자가 생략한 키는 기본값 유지).</p>
+
+<table>
+<thead><tr><th>함수/타입</th><th>위치</th><th>역할</th></tr></thead>
+<tbody>
+<tr><td><code>Loader.Load</code></td><td>loader.go:31</td><td>sections/*.yaml을 <code>loadYAMLFile</code>로 각각 파싱. 각 <code>loadXxxSection</code>은 wrapper를 기본값으로 시드 → partial-override.</td></tr>
+<tr><td><code>ConfigManager.Load</code></td><td>manager.go:58</td><td><code>Loader.Load</code> + <code>applyEnvOverrides</code> + Validate. 쓰기 의도가 없을 때 사용.</td></tr>
+<tr><td><code>ConfigManager.LoadRaw</code></td><td>manager.go:96</td><td>Validate 생략. profile/web/update 동기화가 사용(쓰기 의도용).</td></tr>
+<tr><td><code>ConfigManager.Save</code></td><td>manager.go:166</td><td>각 섹션 파일을 temp+rename atomic 쓰기. git_strategy은 dirty 플래그로 쓰기 격리.</td></tr>
+<tr><td><code>applyEnvOverrides</code></td><td>manager.go:393</td><td><code>MOAI_DEVELOPMENT_MODE</code>→Quality, <code>MOAI_LOG_LEVEL</code>→System, <code>MOAI_NO_COLOR</code>→System, <code>MOAI_CONFIG_DIR</code>→configDir 오버라이드.</td></tr>
+</tbody>
+</table>
+
+<div class="callout warn">
+<strong>(미구현 env)</strong> <code>MOAI_USER_NAME</code> / <code>MOAI_CONVERSATION_LANG</code>은 현재 코드에서 읽지 않는다. user name과 conversation language는 <code>.moai/config/sections/user.yaml</code> / <code>language.yaml</code>에서만 온다.
+</div>
+
+<h3>5.3 profile 시스템</h3>
+<p><code>~/.moai/claude-profiles/&lt;name&gt;/preferences.yaml</code>에 사용자 선호를 저장한다. init/update/web 세 명령 모두 이 스토어를 공유한다.</p>
+
+<table>
+<thead><tr><th>함수/타입</th><th>위치</th><th>역할</th></tr></thead>
+<tbody>
+<tr><td><code>ReadPreferences / WritePreferences</code></td><td>preferences.go:117/166</td><td>preferences.yaml 영속화. <code>IsValidProfileName</code> traversal 가드 이중 방어.</td></tr>
+<tr><td><code>SyncToProjectConfig</code></td><td>sync.go:17</td><td>비어있지 않은 prefs만 user/language 섹션에 SetSection → Save. statusline.yaml은 직접 write.</td></tr>
+<tr><td><code>GetCurrentNameForProject</code></td><td>profile.go:93</td><td><code>CLAUDE_CONFIG_DIR</code> 우선, 아니면 launch.yaml <code>projects[normalizeProjectKey]</code> 조회. 부재/오염 → 'default'.</td></tr>
+<tr><td><code>RecordLastUsedProfileForProject</code></td><td>—</td><td>launch ledger에 projects[normalizedPath] + legacy last_profile 기록.</td></tr>
+</tbody>
+</table>
+
+<h3>5.4 manifest 시스템</h3>
+<p><code>.moai/manifest.json</code>에 triple-hash(ADR-007)로 각 배포 파일의 provenance를 기록한다. init이 최초로 쓰고, update가 읽어 3-way 병합 base로 사용하며 drift를 감지한다.</p>
+
+<table>
+<thead><tr><th>함수/타입</th><th>위치</th><th>역할</th></tr></thead>
+<tbody>
+<tr><td><code>Manager.Load</code></td><td>manifest.go:69</td><td><code>.moai/manifest.json</code> 로드. corrupt 시 <code>.corrupt</code> 백업.</td></tr>
+<tr><td><code>Manager.Track</code></td><td>manifest.go:130</td><td>파일별 FileEntry{TemplateHash, DeployedHash, CurrentHash, Provenance} 등록.</td></tr>
+<tr><td><code>Manager.Save</code></td><td>manifest.go:102</td><td>atomic write.</td></tr>
+<tr><td><code>Manager.DetectChanges</code></td><td>manifest.go:166</td><td>CurrentHash 비교로 사용자 수정을 user_modified로 감지.</td></tr>
+<tr><td><code>HashFile / HashBytes</code></td><td>hasher.go:16/40</td><td>streaming SHA-256 → "sha256:&lt;hex&gt;" 포맷.</td></tr>
+</tbody>
+</table>
+</section>
+
+<!-- ===================== PRINCIPLES ===================== -->
+<section id="principles">
+<h2>6. 핵심 설계 원칙</h2>
+
+<div class="insight">
+<h4>① thin CLI entry → internal/ 패키지가 로직 소유</h4>
+<p><code>web.go:71 runWeb</code>은 session-worktree 진입 + findProjectRoot + ensurePortFree 후 <code>web.Run</code>에 블로킹 위임한다. 템플릿·manifest를 건드리지 않는다. init의 <code>runInit</code>도 PhaseExecutor에 실제 스캐폴딩을 위임한다. CLI 진입점은 얇고, 도메인 로직은 별도 패키지가 소유하는 구조가 세 명령에 일관되게 적용된다.</p>
+</div>
+
+<div class="insight">
+<h4>② 동일 검증 경로를 터미널 wizard와 web console이 공유</h4>
+<p>web의 <code>handleSave</code>는 terminal profile wizard와 동일한 <code>profile.ReadPreferences/WritePreferences</code>, <code>SyncToProjectConfig</code>, <code>settings.*OptionValues()</code> 스키마 SSOT를 재사용한다(AP-2). 핸드 미러 금지. profile 이름 검증(<code>IsValidProfileName</code>)도 양쪽에서 동일 술어를 쓴다. 이로써 두 진입점에서 영속화되는 데이터의 무결성이 보장된다.</p>
+</div>
+
+<div class="insight">
+<h4>③ namespace isolation doctrine (user-owned vs template-managed)</h4>
+<p><code>hns-*</code>, <code>harness-*</code>, <code>my-harness-*</code> 접두의 파일과 <code>.claude/agents/harness/</code>, <code>.moai/harness/</code> 등은 user-owned로 분류해 <code>moai update</code>가 절대 덮어쓰지 않는다(CLAUDE.local.md §24). 반면 <code>moai*</code> 접두의 template-managed 파일은 forceUpdate로 덮어쓴다. 백업은 보수적(모호하면 백업), 분류·검증은 엄격하게 동작해 안전망을 만든다.</p>
+</div>
+
+<div class="insight">
+<h4>④ slim 기본값 + <code>--all</code> opt-in</h4>
+<p>init은 기본적으로 core-tier만 배포하는 slim 모드로 동작한다(SPEC-V3R4-CATALOG-002). <code>--all</code> 플래그 또는 <code>MOAI_DISTRIBUTE_ALL=1</code> 환경변수로만 전체 배포(opt-in). 이는 새 프로젝트의 초기 풋프린트를 줄이고, 사용자가 필요한 optional pack만 나중에 추가할 수 있게 한다. <code>SlimFS</code>가 fs.FS 수준에서 non-core 엔트리를 숨겨 실수로 배포되는 일을 막는다.</p>
+</div>
+
+<div class="insight">
+<h4>⑤ 체크섬 강제 자기 갱신 (CWE-345 봉쇄)</h4>
+<p>바이너리 자동 업데이트는 체크섬 없는 다운로드를 세 지점에서 원천 차단한다: checksums.txt 부재, 다운로드 실패, Checksum 공백. <code>buildVersionInfo</code>는 <code>@MX:ANCHOR</code> + 회귀 테스트로 "절대 빈 Checksum을 생산하지 않는다"는 계약을 고정한다. 다운로드 후에도 스트리밍 SHA256을 재계산해 매직 바이트로 포맷을 검증하고, ELF/Mach-O/PE만 승인한다. 실패 시 자동 롤백.</p>
+</div>
+
+<div class="insight">
+<h4>⑥ 루프백 전용 no-auth web</h4>
+<p><code>moai web</code>은 외부 인프라(DB, 인증 서버) 없이 동작한다. <code>127.0.0.1</code> 전용 바인드 + Host 헤더 loopback 검사(DNS-rebinding 차단) + <code>Sec-Fetch-Site: same-origin</code> 강제(CSRF 차단) 2-layer로 보안을 유지한다. per-process CSRF 토큰은 의도적 미사용 — 루프백 + same-origin이면 충분하다는 설계 판단이다. atomic reject(EC-2)와 empty=preserve(EC-1)로 부분 저장을 원천 차단한다.</p>
+</div>
+</section>
+
+<!-- ===================== APPENDIX ===================== -->
+<section id="appendix">
+<h2>7. 부록: 파일 인덱스</h2>
+
+<p>본 보고서 전체에서 참조된 파일의 역할을 정리한 인덱스다.</p>
+
+<h3>init 관련</h3>
+<table>
+<thead><tr><th>파일</th><th>역할</th></tr></thead>
+<tbody>
+<tr><td><code>internal/cli/init.go</code></td><td>initCmd cobra 정의, validateInitFlags, runInit 메인 오케스트레이터</td></tr>
+<tr><td><code>internal/cli/init_warnings.go</code></td><td>warnCollector, emitSummary</td></tr>
+<tr><td><code>internal/cli/init_gitdetect.go</code></td><td>detectGitConfig (git-mode/provider 자동 감지)</td></tr>
+<tr><td><code>internal/cli/init_update_notice.go</code></td><td>startDeferredUpdateNotice (check-only goroutine)</td></tr>
+<tr><td><code>internal/cli/update_snapshot_hook.go</code></td><td>writeTemplateSnapshotBestEffort (3-way BASE 캡처)</td></tr>
+<tr><td><code>internal/cli/session_worktree.go</code></td><td>enterSessionWorktree / cleanupSessionWorktree</td></tr>
+<tr><td><code>internal/cli/wizard/wizard.go</code></td><td>RunWithDefaults (3-page 폼)</td></tr>
+<tr><td><code>internal/core/project/phase.go</code></td><td>PhaseExecutor.Execute (5-페이즈 오케스트레이터)</td></tr>
+<tr><td><code>internal/core/project/initializer.go</code></td><td>projectInitializer.Init (실제 스캐폴딩)</td></tr>
+<tr><td><code>internal/core/project/validator.go</code></td><td>Validate (idempotency 게이트), BackupExistingProject</td></tr>
+<tr><td><code>internal/core/project/initializer_expansion.go</code></td><td>WritePhase1Configs (Page-3 yaml 패치)</td></tr>
+</tbody>
+</table>
+
+<h3>update 관련</h3>
+<table>
+<thead><tr><th>파일</th><th>역할</th></tr></thead>
+<tbody>
+<tr><td><code>internal/cli/update.go</code></td><td>updateCmd, validateUpdateFlags, runUpdate 메인 분기</td></tr>
+<tr><td><code>internal/cli/update_template_sync.go</code></td><td>runTemplateSyncWithReporter/WithProgress (템플릿 동기화 본체)</td></tr>
+<tr><td><code>internal/cli/update_version.go</code></td><td>runVersionBranch, installVersionTag (--version 분기)</td></tr>
+<tr><td><code>internal/cli/update_restore.go</code></td><td>runUpdateRestore, checkProjectMarker (--restore, 마커 게이트)</td></tr>
+<tr><td><code>internal/cli/update_clean_install.go</code></td><td>runCleanReinstall (v2→v3 7단계)</td></tr>
+<tr><td><code>internal/cli/update_preserve_inventory.go</code></td><td>buildPreserveInventory</td></tr>
+<tr><td><code>internal/cli/update_namespace_protect.go</code></td><td>backupUserOwnedNamespace, verifyNamespaceBackupCoverage</td></tr>
+<tr><td><code>internal/cli/update_disk_backup.go</code></td><td>guardFirstDestructiveStep (in-memory-only 디스크 백업)</td></tr>
+<tr><td><code>internal/cli/update_deny_migration.go</code></td><td>stripRetiredV2DenyEntries</td></tr>
+<tr><td><code>internal/cli/update_residue_cleanup.go</code></td><td>runV3ResidueCleanup</td></tr>
+<tr><td><code>internal/cli/update_recovery_manifest.go</code></td><td>renderRecoveryManifest (파괴 영역 실패 시)</td></tr>
+<tr><td><code>internal/cli/update_cleanup.go</code></td><td>acquireUpdateLock, cleanStaleLock</td></tr>
+<tr><td><code>internal/cli/update_noise.go</code></td><td>recordMergeFallback (3-strike 노이즈 억제)</td></tr>
+<tr><td><code>internal/cli/update_wizard.go</code></td><td>runInitWizard (-c 재구성 마법사)</td></tr>
+<tr><td><code>internal/cli/update/plan/plan.go</code></td><td>IsUserOwnedNamespace, IsMoaiManaged, AnalyzeFiles</td></tr>
+<tr><td><code>internal/cli/update/merge/merge.go</code></td><td>AnalyzeMergeChanges, MergeUserFiles, MergeGitignoreFile</td></tr>
+<tr><td><code>internal/cli/update/deploy/deploy.go</code></td><td>CleanMoaiManagedPaths, ScaffoldEvolutionDir</td></tr>
+<tr><td><code>internal/cli/update/backup/backup.go</code></td><td>BackupMoaiConfig, RestoreMoaiConfig</td></tr>
+<tr><td><code>internal/cli/update/backup/merge.go</code></td><td>MergeYAML3Way (node-tree 3-way)</td></tr>
+<tr><td><code>internal/cli/update/backup/node_merge.go</code></td><td>mergeMappingNode3Way (주석·순서 보존)</td></tr>
+<tr><td><code>internal/cli/update/backup/restore.go</code></td><td>RestoreFromBackupDir, RestoreTargetContained</td></tr>
+<tr><td><code>internal/cli/update/class.go</code></td><td>Classify (단일 분류 SSOT)</td></tr>
+<tr><td><code>internal/cli/v2_detection.go</code></td><td>detectV2Fingerprint, isMoAIProject</td></tr>
+<tr><td><code>internal/update/orchestrator.go</code></td><td>orchestratorImpl.Update (4단계 + 자동 롤백)</td></tr>
+<tr><td><code>internal/update/checker.go</code></td><td>CheckLatest, buildVersionInfo, downloadChecksumWithRetry, compareSemver</td></tr>
+<tr><td><code>internal/update/updater.go</code></td><td>Download (스트리밍 sha256), Replace, validateBinaryFormat, extractBinary</td></tr>
+<tr><td><code>internal/update/rollback.go</code></td><td>CreateBackup, Restore (타임스탬프 백업)</td></tr>
+<tr><td><code>internal/update/cache.go</code></td><td>Cache.Get/Set (~/.moai/cache/update_check.json, 1h TTL)</td></tr>
+<tr><td><code>internal/update/local.go</code></td><td>localChecker/localUpdater (MOAI_UPDATE_SOURCE=local)</td></tr>
+<tr><td><code>internal/hook/auto_update.go</code></td><td>autoUpdateHandler.Handle (SessionStart 자동갱신)</td></tr>
+</tbody>
+</table>
+
+<h3>web 관련</h3>
+<table>
+<thead><tr><th>파일</th><th>역할</th></tr></thead>
+<tbody>
+<tr><td><code>internal/cli/web.go</code></td><td>newWebCmd, runWeb (thin 진입점)</td></tr>
+<tr><td><code>internal/cli/web_port.go</code></td><td>ensurePortFree, isPortInUse</td></tr>
+<tr><td><code>internal/cli/web_port_posix.go</code></td><td>findPortHolderImpl, killProcessImpl (lsof + ps)</td></tr>
+<tr><td><code>internal/web/server.go</code></td><td>Run, NewServer, ListenAndServe, bind</td></tr>
+<tr><td><code>internal/web/app.go</code></td><td>newApp, routes, hostCheckMiddleware</td></tr>
+<tr><td><code>internal/web/handlers.go</code></td><td>handleIndex, handleSave, handleShutdown, bindForm</td></tr>
+<tr><td><code>internal/web/profile_crud.go</code></td><td>handleProfileCreate, handleProfileDelete</td></tr>
+<tr><td><code>internal/web/projectconfig.go</code></td><td>readProjectConfig, writeProjectConfig</td></tr>
+<tr><td><code>internal/web/schemaform.go</code></td><td>parseSchemaForm, applySchemaCurrent</td></tr>
+<tr><td><code>internal/web/glmkey.go</code></td><td>computeGLMKeyHint (bounded disclosure)</td></tr>
+<tr><td><code>internal/web/validate.go</code></td><td>validatePrefs (스키마 SSOT 재사용)</td></tr>
+<tr><td><code>internal/web/board.go</code></td><td>handleBoard (읽기전용 SPEC 대시보드)</td></tr>
+<tr><td><code>internal/web/browser.go</code></td><td>openDefaultBrowser (크로스플랫폼)</td></tr>
+</tbody>
+</table>
+
+<h3>공유 하위 시스템</h3>
+<table>
+<thead><tr><th>파일</th><th>역할</th></tr></thead>
+<tbody>
+<tr><td><code>internal/template/embed.go</code></td><td>//go:embed all:templates + catalog.yaml, EmbeddedTemplates</td></tr>
+<tr><td><code>internal/template/catalog_loader.go</code></td><td>LoadCatalog, LoadEmbeddedCatalog</td></tr>
+<tr><td><code>internal/template/embed_catalog.go</code></td><td>NewSlimDeployerWithRenderer, NewDeployerWithRenderer</td></tr>
+<tr><td><code>internal/template/slim_fs.go</code></td><td>SlimFS (non-core 숨김)</td></tr>
+<tr><td><code>internal/template/deployer.go</code></td><td>Deployer.Deploy, atomicWriteFile</td></tr>
+<tr><td><code>internal/template/renderer.go</code></td><td>Renderer.Render, 미전개 토큰 검증</td></tr>
+<tr><td><code>internal/template/context.go</code></td><td>NewTemplateContext (~30 필드)</td></tr>
+<tr><td><code>internal/template/settings.go</code></td><td>BuildSmartPATH</td></tr>
+<tr><td><code>internal/config/manager.go</code></td><td>ConfigManager.Load/LoadRaw/Save, applyEnvOverrides</td></tr>
+<tr><td><code>internal/config/loader.go</code></td><td>Loader.Load (sections 병합, partial-override)</td></tr>
+<tr><td><code>internal/config/envkeys.go</code></td><td>환경변수명 SSOT (EnvSkipBinaryUpdate 등)</td></tr>
+<tr><td><code>internal/config/profile.go</code></td><td>IsValidProfile, NormalizeProfile</td></tr>
+<tr><td><code>internal/profile/preferences.go</code></td><td>ReadPreferences, WritePreferences</td></tr>
+<tr><td><code>internal/profile/sync.go</code></td><td>SyncToProjectConfig</td></tr>
+<tr><td><code>internal/profile/profile.go</code></td><td>GetCurrentNameForProject, IsValidProfileName</td></tr>
+<tr><td><code>internal/manifest/manifest.go</code></td><td>Manager.Load/Track/Save/DetectChanges</td></tr>
+<tr><td><code>internal/manifest/hasher.go</code></td><td>HashFile, HashBytes (streaming SHA-256)</td></tr>
+<tr><td><code>internal/cli/root.go</code></td><td>rootCmd, Execute, InitDependencies</td></tr>
+<tr><td><code>internal/cli/deps.go</code></td><td>EnsureUpdate, buildAutoUpdateFunc (Composition Root)</td></tr>
+</tbody>
+</table>
+
+<div class="footer-note">
+본 보고서는 5명 deep-reader의 구조화된 분석 결과를 종합한 것이다. file:line 참조는 독자 검증 가능한 상태이며, 일부 주장은 <em>(미검증)</em> 표시로 원문 분석가가 불확실성을 명시한 항목이다. Mermaid 다이어그램은 각 reader의 초안을 정제하여 일관된 노드 ID와 coral 테마로 통일했다.
+</div>
+
+</section>
+
+</div>
+
+<script>
+mermaid.initialize({
+  startOnLoad: true,
+  theme: 'base',
+  securityLevel: 'loose',
+  themeVariables: {
+    primaryColor: '#cc785c',
+    primaryTextColor: '#1f1d1b',
+    primaryBorderColor: '#7a3e2a',
+    lineColor: '#8a8275',
+    secondaryColor: '#f5ebe0',
+    tertiaryColor: '#fffdf9',
+    background: '#fffdf9',
+    mainBkg: '#fffdf9',
+    secondBkg: '#f5ebe0',
+    fontFamily: 'Pretendard, system-ui, sans-serif',
+    fontSize: '14px',
+    nodeBorder: '#cc785c',
+    clusterBkg: '#faf8f5',
+    clusterBorder: '#d4cab9',
+    edgeLabelBackground: '#fffdf9'
+  },
+  flowchart: {
+    curve: 'basis',
+    padding: 16,
+    nodeSpacing: 40,
+    rankSpacing: 40
+  }
+});
+</script>
+</body>
+</html>

--- a/.moai/reports/moai-local-self-evolution-design-20260804.html
+++ b/.moai/reports/moai-local-self-evolution-design-20260804.html
@@ -1,0 +1,625 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>LSEL — 로컬 자가 진화 루프 설계 제안 (moai-adk-go)</title>
+<style>
+  :root {
+    --bg: #faf8f4;
+    --surface: #ffffff;
+    --ink: #2a2724;
+    --ink-soft: #5c544c;
+    --ink-faint: #8a8178;
+    --line: #e6dfd3;
+    --line-strong: #d4cab8;
+    --coral: #c2623a;
+    --coral-soft: #f5e8df;
+    --frozen: #a23a2e;
+    --frozen-bg: #f7e7e3;
+    --evol: #2f6d43;
+    --evol-bg: #e6f0e7;
+    --warn: #8a5a00;
+    --warn-bg: #fbf0d8;
+    --code-bg: #211e1a;
+    --code-ink: #f3ede2;
+  }
+  * { box-sizing: border-box; }
+  html { -webkit-text-size-adjust: 100%; }
+  body {
+    margin: 0; padding: 0;
+    background: var(--bg);
+    color: var(--ink);
+    font-family: "Pretendard","Apple SD Gothic Neo","Noto Sans KR",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+    font-size: 16px; line-height: 1.75;
+    word-break: keep-all;
+  }
+  .wrap { max-width: 940px; margin: 0 auto; padding: 0 28px; }
+  header.report-head {
+    background: linear-gradient(180deg,#f3ece0 0%,var(--bg) 100%);
+    border-bottom: 1px solid var(--line);
+    padding: 56px 0 40px;
+  }
+  .eyebrow {
+    font-size: 13px; letter-spacing: 0.14em; text-transform: uppercase;
+    color: var(--coral); font-weight: 700; margin-bottom: 14px;
+  }
+  h1 { font-size: 34px; line-height: 1.3; margin: 0 0 12px; letter-spacing: -0.01em; }
+  .subtitle { font-size: 17px; color: var(--ink-soft); margin: 0; max-width: 70ch; }
+  .meta-row {
+    margin-top: 26px; display: flex; flex-wrap: wrap; gap: 8px;
+    font-size: 13px; color: var(--ink-faint);
+  }
+  .pill {
+    background: var(--surface); border: 1px solid var(--line-strong);
+    border-radius: 999px; padding: 4px 12px;
+  }
+  main { padding: 44px 0 80px; }
+  section { margin: 0 0 52px; scroll-margin-top: 24px; }
+  h2 {
+    font-size: 24px; margin: 0 0 18px; padding-bottom: 10px;
+    border-bottom: 2px solid var(--line-strong); letter-spacing: -0.01em;
+  }
+  h2 .num {
+    display: inline-block; min-width: 38px; color: var(--coral);
+    font-variant-numeric: tabular-nums; font-weight: 800;
+  }
+  h3 { font-size: 18px; margin: 28px 0 10px; color: var(--ink); }
+  p { margin: 0 0 14px; }
+  ul, ol { margin: 0 0 16px; padding-left: 22px; }
+  li { margin: 0 0 8px; }
+  li::marker { color: var(--coral); }
+  strong { color: var(--ink); font-weight: 700; }
+  code, .mono {
+    font-family: "Goorm Sans Code","JetBrains Mono","SF Mono",Menlo,Consolas,monospace;
+    font-size: 0.88em; background: var(--coral-soft); color: #6e3a22;
+    padding: 1px 6px; border-radius: 4px; word-break: break-all;
+  }
+  pre {
+    background: var(--code-bg); color: var(--code-ink);
+    padding: 18px 20px; border-radius: 10px; overflow-x: auto;
+    font-size: 13.5px; line-height: 1.65; margin: 0 0 16px;
+  }
+  pre code { background: none; color: inherit; padding: 0; }
+  .callout {
+    border-left: 4px solid var(--coral); background: var(--surface);
+    padding: 16px 20px; border-radius: 0 8px 8px 0; margin: 0 0 16px;
+    box-shadow: 0 1px 0 var(--line);
+  }
+  .callout.warn { border-left-color: var(--warn); background: var(--warn-bg); }
+  .callout.frozen { border-left-color: var(--frozen); background: var(--frozen-bg); }
+  .callout h4 { margin: 0 0 8px; font-size: 14px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--ink-soft); }
+  table { width: 100%; border-collapse: collapse; margin: 0 0 16px; font-size: 14.5px; }
+  th, td { text-align: left; vertical-align: top; padding: 10px 12px; border-bottom: 1px solid var(--line); }
+  th { background: #f1e9da; font-weight: 700; font-size: 13px; color: var(--ink-soft); }
+  tr:last-child td { border-bottom: none; }
+  .badge {
+    display: inline-block; font-size: 11.5px; font-weight: 800; letter-spacing: 0.06em;
+    padding: 2px 9px; border-radius: 4px; text-transform: uppercase; white-space: nowrap;
+  }
+  .badge.frozen { background: var(--frozen-bg); color: var(--frozen); border: 1px solid #e3c4bc; }
+  .badge.evol { background: var(--evol-bg); color: var(--evol); border: 1px solid #bcd9c2; }
+  .stage {
+    background: var(--surface); border: 1px solid var(--line); border-radius: 10px;
+    padding: 18px 20px; margin: 0 0 14px; box-shadow: 0 1px 0 var(--line);
+  }
+  .stage-head { display: flex; align-items: baseline; gap: 12px; margin-bottom: 8px; flex-wrap: wrap;}
+  .stage-head .stage-num {
+    font-family: "Goorm Sans Code",monospace; font-weight: 800; color: var(--coral);
+    background: var(--coral-soft); border-radius: 4px; padding: 1px 8px; font-size: 13px;
+  }
+  .stage-head h3 { margin: 0; font-size: 17px; }
+  .stage dl { margin: 8px 0 0; display: grid; grid-template-columns: 92px 1fr; gap: 4px 14px; font-size: 14px; }
+  .stage dt { color: var(--ink-faint); font-weight: 700; font-size: 12.5px; text-transform: uppercase; letter-spacing: 0.05em; padding-top: 2px; }
+  .stage dd { margin: 0; }
+  .loop-diagram {
+    background: var(--surface); border: 1px solid var(--line); border-radius: 10px;
+    padding: 22px; margin: 0 0 20px; overflow-x: auto; text-align: center;
+  }
+  .loop-diagram pre { display: inline-block; text-align: left; margin: 0; background: none; color: var(--ink); font-size: 13px; }
+  .stat-grid { display: grid; grid-template-columns: repeat(auto-fit,minmax(150px,1fr)); gap: 12px; margin: 0 0 18px; }
+  .stat { background: var(--surface); border: 1px solid var(--line); border-radius: 8px; padding: 14px 16px; }
+  .stat .v { font-size: 24px; font-weight: 800; color: var(--coral); line-height: 1.1; font-variant-numeric: tabular-nums; }
+  .stat .l { font-size: 12.5px; color: var(--ink-faint); margin-top: 4px; }
+  .toc {
+    background: var(--surface); border: 1px solid var(--line); border-radius: 10px;
+    padding: 20px 24px; margin: 0 0 44px;
+  }
+  .toc ol { margin: 0; columns: 2; column-gap: 32px; }
+  .toc li { break-inside: avoid; }
+  .toc a { color: var(--ink); text-decoration: none; }
+  .toc a:hover { color: var(--coral); text-decoration: underline; }
+  .lens-card { border: 1px solid var(--line); border-radius: 10px; padding: 16px 20px; margin: 0 0 14px; background: var(--surface); }
+  .lens-card .lt { font-size: 13px; font-weight: 800; color: var(--coral); text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 6px; }
+  .critique-verdict { font-style: italic; color: var(--ink-soft); border-left: 3px solid var(--ink-faint); padding-left: 12px; margin: 0 0 14px; }
+  .risk { display: grid; grid-template-columns: 1fr; gap: 4px; padding: 10px 0; border-bottom: 1px dashed var(--line); }
+  .risk:last-child { border-bottom: none; }
+  .risk .rt { font-weight: 700; }
+  .risk .rt .tag { font-size: 11px; font-weight: 700; color: var(--warn); background: var(--warn-bg); padding: 1px 7px; border-radius: 3px; margin-right: 6px; }
+  footer.report-foot { border-top: 1px solid var(--line); padding: 32px 0 60px; color: var(--ink-faint); font-size: 13px; }
+  .ref-list { font-size: 13.5px; }
+  .ref-list li { margin-bottom: 10px; }
+  .ref-list .pub { color: var(--ink-faint); }
+  details summary { cursor: pointer; font-weight: 700; color: var(--coral); padding: 8px 0; }
+  details[open] summary { margin-bottom: 8px; }
+  @media (max-width: 680px) {
+    h1 { font-size: 26px; }
+    .toc ol { columns: 1; }
+    .stage dl { grid-template-columns: 1fr; }
+    .stage dt { padding-top: 0; }
+  }
+  @media print {
+    body { background: #fff; font-size: 11pt; }
+    .callout, .stage, .stat, .lens-card, .toc { box-shadow: none; }
+    section { page-break-inside: avoid; }
+  }
+</style>
+</head>
+<body>
+
+<header class="report-head">
+  <div class="wrap">
+    <div class="eyebrow">MoAI-ADK · 로컬 자가 진화 설계 제안</div>
+    <h1>LSEL — 로컬 자가 진화 루프<br>doctrine은 건드리지 않고 PROPOSE→APPLY 경계를 닫는 설계</h1>
+    <p class="subtitle">앞선 감사가 증명한 끊긴 자가 학습 루프를, 배포되는 moai 자산에는 한 줄도 손대지 않고 사용자 소유 영역에서만 기계적으로 닫는 설계. 5개 연구 렌즈(논문·베스트 프랙티스)와 2회 적대적 비평을 거쳐 종합한 업데이트 제안.</p>
+    <div class="meta-row">
+      <span class="pill">2026-08-04</span>
+      <span class="pill">보고서 v1</span>
+      <span class="pill">대상 리포: moai-adk-go (dogfood)</span>
+      <span class="pill">ultracode 워크플로우 9 에이전트</span>
+      <span class="pill">사용자 언어: ko</span>
+      <span class="pill" style="border-color:var(--coral);color:var(--coral);font-weight:700">v2 정정 반영 (config sections · lsel 경로)</span>
+    </div>
+  </div>
+</header>
+
+<main class="wrap">
+
+<nav class="toc">
+  <strong>목차</strong>
+  <ol>
+    <li><a href="#exec">요약 (Executive Summary)</a></li>
+    <li><a href="#problem">문제: 관측은 대규모로, 적용 경계는 죽어 있다</a></li>
+    <li><a href="#research">연구 근거 (논문·베스트 프랙티스 5개 렌즈)</a></li>
+    <li><a href="#principle">설계 원칙: 고정 헌법, 사용자 소유 닫기</a></li>
+    <li><a href="#surface">서피스 분류 — FROZEN vs EVOLVABLE</a></li>
+    <li><a href="#loop">7단계 루프</a></li>
+    <li><a href="#guardrails">가드레일 (강화된 불변량)</a></li>
+    <li><a href="#artifacts">새 산출물</a></li>
+    <li><a href="#data">데이터 소스 매핑</a></li>
+    <li><a href="#roadmap">구현 로드맵 (5단계)</a></li>
+    <li><a href="#critique">적대적 비평과 mustFix</a></li>
+    <li><a href="#risks">위험과 완화</a></li>
+    <li><a href="#caveats">솔직한 한계 — 이 설계가 풀지 않는 것</a></li>
+    <li><a href="#refs">참고문헌</a></li>
+  </ol>
+</nav>
+
+<!-- ============================ 1. EXEC SUMMARY ============================ -->
+<section id="exec">
+  <h2><span class="num">01</span>요약 (Executive Summary)</h2>
+
+  <div class="stat-grid">
+    <div class="stat"><div class="v">110,403</div><div class="l">usage-log 이벤트 (live)</div></div>
+    <div class="stat"><div class="v">569</div><div class="l">lessons-inbox stub / 25일</div></div>
+    <div class="stat"><div class="v">0</div><div class="l">drain 처리 (ZERO)</div></div>
+    <div class="stat"><div class="v">0</div><div class="l">Applier.Apply 실행 이력</div></div>
+    <div class="stat"><div class="v">72</div><div class="l">방치된 제안 draft</div></div>
+    <div class="stat"><div class="v">6</div><div class="l">진화 가능(evolvable) 서피스</div></div>
+  </div>
+
+  <p>본 설계는 moai-adk-go 저장소에서 자가 진화 루프가 스스로 돌아가도록 만들면서, <strong>배포되는 moai 자산에는 한 줄도 손대지 않는 것</strong>을 목표로 한다. 사전 감사가 증명했듯 관측 절반은 이미 대규모로 동작한다. <code>usage-log</code> 11만 이벤트, <code>lessons-inbox</code> 569건, <code>tier-promotions</code> 159행이 살아 있다. 그러나 자가 학습을 선언한 모든 루프는 같은 한 지점에서 끊긴다. <strong>제안에서 적용으로 넘어가는 경계(PROPOSE→APPLY)</strong>다. Go로 짠 <code>Applier.Apply</code>는 한 번도 실행된 적 없고 <code>manifest.jsonl</code>은 존재하지 않는다. <code>CuratorDispatch</code>는 프로덕션 호출자가 0명이며, 드레인은 헌법(constitution) 문단으로만 존재하고 Go 코드는 0건이다. 결과적으로 실제 개선은 모델이 중개한다 — 에이전트가 SPEC 작업 중 doctrine을 읽고 <code>feedback_*.md</code>를 손으로 옮기는 식이다. 기계적 피드백 신호에서 나온 것이 아니다.</p>
+
+  <p>본 설계는 이 경계를 <strong>사용자 소유 영역 안에서만</strong> 닫는다. 핵심은 동결된 Go applier를 우회하는 병렬 사용자 소유 applier를 세우는 것이다. 동결된 applier를 켜면 <code>@MX</code> 주석이 배포용 에이전트 서피스로 주입되어 doctrine 훼손이 된다. 그래서 켜지 않고 우회한다. 루프는 여섯 진화 가능 영역에만 쓴다.</p>
+
+  <p>이 설계는 다섯 연구 렌즈에 근거한다. ExpeL·Voyager·Generative-Agents·Reflexion의 2단계 메모리, Constitutional AI와 MemGPT의 안전 자기 수정, Thompson sampling의 개인화가 그것이다. 두 차례 적대적 비평은 같은 치명적 결함을 찾아냈다 — <strong>동결 영역 허용 목록(allowlist) 정규식이 진화 가능한 git 추적 스킬 파일 안에 들어 있어서, 루프가 자기 수갑을 스스로 풀 수 있었다는 점</strong>이다. 종합된 설계(본 제안)는 허용 목록을 동결 메타 파일로 옮기고, 강제 게이트 대상에 집행 메타 파일을 추가하며, 루프가 실제로 발화하도록 기계적 트리거를 단다. 그리고 이 설계가 닫는 것은 <strong>사용자 로컬 루프이지, 감사가 지적한 배포 서피스 경로가 아님</strong>을 솔직히 밝힌다.</p>
+</section>
+
+<!-- ============================ 2. PROBLEM ============================ -->
+<section id="problem">
+  <h2><span class="num">02</span>문제: 관측은 대규모로, 적용 경계는 죽어 있다</h2>
+
+  <p>이 설계의 출발점은 앞선 감사의 증거 기반 발견이다. 모든 선언된 자가 학습 루프가 <strong>동일한 한 지점 — PROPOSE→APPLY seam —</strong>에서 끊긴다.</p>
+
+  <div class="callout frozen">
+    <h4>감사 핵심 발견 (관측 vs 적용)</h4>
+    <ul>
+      <li><strong>Applier.Apply 한 번도 실행 안 됨</strong> — <code>manifest.jsonl</code> 부재, <code>snapshots/</code> 빔. 유일한 프로덕션 호출자는 opt-in <code>moai harness execute</code>인데 호출된 적 없음.</li>
+      <li><strong>CuratorDispatch 프로덕션 호출자 0</strong> — 72개 draft가 어디로도 가지 않음. 자기 헤더가 "INERT 상태를 구동하는 caller"라고 선언하지만 grep 하면 본인+테스트뿐.</li>
+      <li><strong>drain = constitution 문단, Go 코드 0건</strong> — <code>moai-constitution.md:147</code>이 언급하는 "drain-marking mechanism"은 전 리포 grep 0 hits.</li>
+      <li><strong>lessons-inbox 554~569 stubs / 25일 / ZERO drained</strong> — 파일에 닿는 비테스트 Go 코드는 writer(<code>failure_observer.go:129</code>) 단 하나.</li>
+      <li><strong>inbox 노이즈 과점</strong> — 약 63%가 <code>tool_failure:Bash:UnknownFailure</code> (타임아웃·샌드박스 위반 노이즈).</li>
+      <li><strong>delegation.yaml 재귀 분석 = 문장뿐</strong> — CLAUDE.md §4가 선언하지만 이 파일을 쓰는 코드 0건. 매 변경이 사람 손편집.</li>
+      <li><strong>실제 개선은 model-mediated</strong> — 에이전트가 SPEC 작업 중 doctrine에서 <code>feedback_*.md</code>·<code>@MX</code> 태그를 손으로 옮김. 기계적 신호가 아님.</li>
+      <li><strong>근원</strong> — observation-first 빌드; 적용 닫기는 명시적으로 연기됨(<code>applier.go:22 enableTriggerInjectionWrites=false</code> + <code>@MX:TODO "Phase 4"</code>).</li>
+    </ul>
+  </div>
+
+  <p>요약하면 관측 절반은 살아 있고, 적용 절반은 코드가 있어도 한 번도 실행된 적 없다. 본 설계의 임무는 <strong>이 끊긴 seam을, moai doctrine은 절대 수정하지 않으면서, 기계적으로 닫는 것</strong>이다.</p>
+</section>
+
+<!-- ============================ 3. RESEARCH ============================ -->
+<section id="research">
+  <h2><span class="num">03</span>연구 근거 (논문·베스트 프랙티스 5개 렌즈)</h2>
+
+  <p>웹 조사로 5개 렌즈에서 논문과 실무 베스트 프랙티스를 수집했다. 각 렌즈의 핵심 통찰과 MoAI 적용점을 아래에 정리한다.</p>
+
+  <div class="lens-card">
+    <div class="lt">Lens 1 · 학술 — 경험적 학습·자기 개선 LLM 에이전트</div>
+    <p>비모수적 루프 골격(ACT→OBSERVE→REFLECT→STORE→RETRIEVE)이 Reflexion·ExpeL·Voyager·Generative Agents에서 동일하다. 구조적 교훈 두 가지: (1) <strong>2단계 저장 분리</strong> — 원시 에피소드 추적(Tier 1, bounded, recency 가중) vs 정제된 교차-작업 통찰/스킬(Tier 2, 정제·재사용). 이것이 MoAI의 <code>lessons-inbox</code>(Tier 1) vs <code>feedback_*.md</code>(Tier 2)에 그대로 대응한다. (2) <strong>검색(retrieval)이 모든 논문의 병목</strong>이며, 지배적 실패 양상도 공유된다 — 비정제 축적→노이즈→잘못된 교훈 검색→에이전트가 잘못된 자기 진단으로 재행동. Voyager는 <strong>실행 가능한 코드</strong>를 재사용 산출물로 저장하며 합성성(스킬이 스킬을 호출)을 갖는다 — 사용자 소유 <code>hns-*</code> 스킬 서피스로 가장 직접 이식 가능한 패턴. 모든 in-context 방식이 모수 갱신을 피한다(ExpeL이 명시). MoAI도 같은 제약 아래 있으므로 자가 개선은 <strong>반드시 프롬프트 시점/in-context</strong>여야 하며, 파인튜닝이 아니다.</p>
+  </div>
+
+  <div class="lens-card">
+    <div class="lt">Lens 2 · 실무 — 코딩 에이전트 자기 개선</div>
+    <p>모든 주요 코딩 에이전트가 같은 2단계 메모리 형태로 수렴한다: 손으로 저술된 항상 로드되는 <strong>짧은 지시 파일</strong>(CLAUDE.md / AGENTS.md / .cursorrules / .clinerules) + 학습·축적된 주제 파일 색인 저장(필요시 검색). MoAI의 쌍(<code>CLAUDE.local.md</code> + <code>memory/MEMORY.md</code> + <code>feedback_*.md</code>)은 <strong>이미 이 형태다 — 격차는 발화 규율이지 아키텍처가 아니다.</strong> 이식 가능한 규칙 3가지: (1) 캡처는 싸고 진짜 어려운 건 사람 게이트 + 위생(CodeRabbit의 명시적 영수증 + approval_delay + 분기별 "축적 대신 갱신" 스윕); (2) <strong>결정적 훅(hook) &gt; 자연어 규칙</strong> — 고정된 생명주기 지점에서 일어나야 하는 행동은 규칙(무시 가능)이 아니라 훅(무조건 실행)으로; (3) 규칙 파일 자기편집은 위험한 방향 — 에이전트가 저술한 학습은 <strong>별도의 학습 저장소로, 사람 게이트 아래로</strong>, 결코 규칙 파일에 조용히 되돌려 쓰지 않는다.</p>
+  </div>
+
+  <div class="lens-card">
+    <div class="lt">Lens 3 · 메모리 아키텍처 — 장기 horizon 에이전트</div>
+    <p>메모리는 모든 진지한 설계에서 <strong>계층 시스템</strong>이다: 작은 용량 제한 hot tier(MemGPT core memory, MoAI ≤50 active <code>feedback_*.md</code>) 뒤에 큰 cold tier(MemGPT archival, MoAI <code>memory/_archive/</code>). 검색은 lookup이 아니라 <strong>점수 함수</strong>다 — Generative Agents의 <code>recency×importance×relevance</code> 공식이 정규 형태. 정제(consolidation)는 별도 <strong>정책 층</strong>(Vectorize의 4개 레버: importance-gate / merge / decay / evict)이지 부수작이 아니다. 성찰(reflection)은 시계가 아니라 <strong>임계치 발화</strong>(누적 중요도 ~150). 실패가 최고 신호 쓰기 트리거(Reflexion). 결정적으로: 중요도는 쓰기 시점에 게이트로 할당되며, 축출 ≠ 보관 — 보관은 성능용, 하드 삭제는 규정 준수용. MoAI의 "삭제 말고 보관" 규칙이 옳음이 입증된다; 50-파일 한도는 <strong>축출 대상이 아니라 계층화 임계값</strong>이다.</p>
+  </div>
+
+  <div class="lens-card">
+    <div class="lt">Lens 4 · 안전한 자기 수정 — 가드레일</div>
+    <p>보편적 안전 자기편집 형태는 단일 가드가 아니라 <strong>파이프라인</strong>이다: PROPOSE(격리된 shadow) → SELF-CRITIQUE(고정 헌법 대비) → MECHANICAL VERIFY(환경이 진리) → APPROVE(사람, tier-gated) → PROMOTE(명시적 병합, 불변 버전) → MONITOR → ROLLBACK. 단일 하중 구조 속성은 CAI의 것이다: <strong>헌법은 쓰기 영역 밖에 있어야 한다</strong> — 모델은 산출물을 수정하지 원칙을 수정하지 않는다; 루프가 자신을 검사하는 규칙을 편집할 수 있으면 비판은 공허해진다. 가역성이 감시 무게를 라우팅하는 마스터 축이다(비가역→동기 승인; 가역→비동기 감시/카나리). 따라서 모든 편집을 가역-by-구조로 만들면(git 버전 관리, 불변 ID, doctrine과 분리) 대부분의 자기편집이 동기 게이트에서 카나리로 강등된다. 능력/임계치 조건부 게이팅(CSA if-then)이 평면 신뢰도 임계값보다 낫다.</p>
+  </div>
+
+  <div class="lens-card">
+    <div class="lt">Lens 5 · 개인화 — 로컬 적응형 설정</div>
+    <p>세 피드백 채널을 가차별 가중해야 한다: 수동/비의도적 암시(도구 승인 클릭)는 풍부하지만 약하다; <strong>의도적 암시</strong>(Ctrl+G 계획 편집, 'Other' 자유형 덮어쓰기, 추천 거부)는 드물지만 강하다 — posterior 가중 5~10배. 신뢰도는 호환되는 세 방식(Thompson sampling 베이지안 사후 분산; 선호별 LLM-판사 강도 점수; 기대-후회-감소 vs bother-cost 임계값)으로 추적되며, 견고한 시스템은 세 가지 모두 쓴다. 콜드 스타트는 보편적으로 동일하게 풀린다: <strong>모집단/템플릿 기본값으로 폴백</strong>, 관측이 쌓일 때만 개인 모델로 이동 — 작은 관측 예산이 존재하기 전에는 개인화하지 않는다. 묻기-vs-추론 결정은 정보가치 문제이며, c는 컨텍스트 크기 + warm-cache 가치와 함께 올라야 한다(cache-aware-execution directive 1과 통합). 추천이 매 세션 뒤집히는 것("UI thrashing")은 신뢰를 갉아먹으므로 <strong>히스테리시스</strong>가 일급 요구사항이다.</p>
+  </div>
+</section>
+
+<!-- ============================ 4. PRINCIPLE ============================ -->
+<section id="principle">
+  <h2><span class="num">04</span>설계 원칙: 고정 헌법, 사용자 소유 닫기</h2>
+
+  <p>루프는 일곱 단계로 된다. <strong>OBSERVE</strong>는 이미 돌아가는 훅을 그대로 쓰되 의도적 암시 신호를 <code>signals.jsonl</code>에 추가로 담는다. 의도적 암시란 Ctrl+G 계획 편집, AskUserQuestion 'Other' 덮어쓰기, 추천 거부 같은 사용자의 의도적 행위로, 수동 승인보다 5~10배 높은 가중치를 받는다. <strong>CLUSTER</strong>는 <code>lessons-inbox</code>를 동반 오프셋(companion offset) 방식으로 드레인해 25일치 백로그를 후보 주제 파일로 바꾼다. 단 드레인 전에 기계적 심각도 필터가 Bash 타임아웃과 샌드박스 위반 노이즈를 거른다. 그래야 569건 중 약 63%를 차지하는 노이즈가 교훈으로 둔갑하지 않는다.</p>
+
+  <p><strong>PROPOSE</strong>는 동결 doctrine에 대한 Constitutional AI식 자기 비판을 동반한 그림자 제안을 만든다. 제안을 쓰기 전에 관련 <code>feedback_*.md</code>를 먼저 검색하는 것도 잊지 않는다. <strong>APPROVE</strong>는 기존 AskUserQuestion Tier-4 흐름에 영향 반경 기준 에스컬레이션을 더한다. INVARANTS 커널, 보안 검증 예외 구간, 고정산입(high-fan-in) 참조, Bash 위험 경로, 그리고 허용 목록·applier·curator 스킬 본문·훅 스크립트 같은 집행 메타 파일까지는 제안자 신뢰도와 무관하게 사람 승인을 강제한다. <strong>APPLY</strong>가 진짜 경계 닫기다. 사용자 소유 applier가 동결 영역 허용 목록으로 검증된 경로에만 쓴다. 허용 목록 자체는 진화 가능 영역 밖 동결 메타 파일에 둬서 루프가 스스로 고칠 수 없게 한다. 적용마다 <code>lsel-&lt;proposal-id&gt;</code> 태그가 붙은 git 커밋이므로 되돌리기는 <code>git revert</code> 한 줄이다. <strong>REMEMBER</strong>는 <code>feedback_*.md</code>를 자동 메모리에 써서 <code>/clear</code> 너머로 기억한다. <strong>VERIFY</strong>는 <code>/moai gate</code> 의무 상위 집합을 돌려 통과 못 하면 되돌린다. 단 타임아웃 같은 불안정 신호에는 한 번 재시도해서, 옳은 제안이 노이즈에 의해 잘못 뒤집히지 않게 한다.</p>
+
+  <div class="callout">
+    <h4>핵심 불변량 — 허용 목록은 진화 가능 영역 밖에 존재한다</h4>
+    <p>비평이 지적한 대로 허용 목록이 <code>hns-lsel-applier/SKILL.md</code> 안에 있으면, 제안 A가 정규식을 넓히고 제안 B가 doctrine을 쓰는 경로가 열린다. 그래서 허용 목록은 <strong>동결 메타 파일로 옮기고</strong>, 집행 메타 파일은 영향 반경 기준 강제 게이트 목록에 넣어 사람 승인 없이는 고칠 수 없게 한다. 루프가 발화하는 것도 기계적으로 만든다 — SessionStart 훅이 백로그 재고 임계치를 넘기면 시스템 알림을 띄우고, 예정된 <code>/loop</code> 레시피는 기본으로 켠다. 사람이 호출할 때만 도는 구조는 감사가 지적한 "기능은 있으나 호출되지 않는다"는 실패를 그대로 되풀이하기 때문이다.</p>
+  </div>
+
+  <div class="loop-diagram">
+<pre>
+         ┌───────── OBSERVE (live: usage-log / lessons-inbox / tier-promotions / @MX / signals.jsonl)
+         │
+         ▼
+       CLUSTER ── companion-offset drain + 기계적 심각도 필터 + 중요도 게이트 + SessionStart 기계적 발화
+         │
+         ▼
+       PROPOSE ── shadow 제안 + CAI 자기 비판 + retrieval-before-propose (Reflexion)
+         │
+         ▼
+       APPROVE ── 기존 Tier-4 AskUserQuestion + CSA 영향반경 에스컬레이션 + Learnings-Added 영수증
+         │
+         ▼
+   ┌─►  APPLY  ── 동결 메타 allowlist 검증 → 6 영역에만 write → lsel-&lt;id&gt; 커밋 (feature 브랜치 + PR)
+   │     │
+   │     ▼
+   │   VERIFY  ── /moai gate 의무 상위집합 + flaky 재시도 정책 ── FAIL ──┐
+   │     │                                                            │
+   │     │ PASS                                                       │ 자동 되돌리기
+   │     ▼                                                            │
+   │  REMEMBER ── feedback_*.md + MEMORY.md 색인 + memory_type 라우팅 ◄┘
+   │     │
+   └─ 주기적 reflection (월 1회, 임계치 발화): 세부 주제 → 추상 원칙 합성, 원본은 cold tier로
+</pre>
+  </div>
+</section>
+
+<!-- ============================ 5. SURFACE ============================ -->
+<section id="surface">
+  <h2><span class="num">05</span>서피스 분류 — FROZEN vs EVOLVABLE</h2>
+
+  <p>설계의 나침반은 "어디에 써도 되는가"다. 사용자 제약에 따라 서피스를 둘로 나눈다. <span class="badge frozen">FROZEN</span>은 절대 수정 금지(배포 자산), <span class="badge evol">EVOLVABLE</span>은 학습이 쓸 수 있는 사용자 소유 영역이다.</p>
+
+  <table>
+    <thead><tr><th>서피스</th><th>분류</th><th>역할</th></tr></thead>
+    <tbody>
+      <tr><td><code>.claude/rules/moai/**</code></td><td><span class="badge frozen">FROZEN</span></td><td>template-managed doctrine (규칙)</td></tr>
+      <tr><td><code>CLAUDE.md</code></td><td><span class="badge frozen">FROZEN</span></td><td>배포되는 핵심 지시</td></tr>
+      <tr><td><code>internal/template/templates/**</code></td><td><span class="badge frozen">FROZEN</span></td><td>16-언어 배포 소스</td></tr>
+      <tr><td><code>.claude/agents/moai/**</code> (retained 11)</td><td><span class="badge frozen">FROZEN</span></td><td>template-managed 에이전트</td></tr>
+      <tr><td><code>moai*</code> / <code>moai-*</code> skills</td><td><span class="badge frozen">FROZEN</span></td><td>template-managed 스킬</td></tr>
+      <tr><td><code>.moai/config/sections/**</code> <span style="color:var(--ink-faint);font-size:12px">(template-managed 파일)</span></td><td><span class="badge evol">EVOLVABLE</span> <span style="font-size:11px;color:var(--ink-faint)">merge-managed</span></td><td><strong>3-way merge</strong> — user가 추가한 키/값 보존(<code>backup.go:50</code> + <code>MergeYAML3Way</code> + <code>node_merge.go</code> "old≠base→user"). <strong>v2 정정</strong>: FROZEN이 아님. 단 <strong>template에 없는 새 section 파일</strong>(<code>lsel.yaml</code> 등)은 <code>deploy.go:113</code> 전체 삭제 + template 기준 복원이므로 update 시 손실 — 새 파일은 피함</td></tr>
+      <tr><td><code>applier.go</code>, <code>curator_dispatch.go</code></td><td><span class="badge frozen">FROZEN</span></td><td>동결 Go applier — <strong>켜지 않고 우회</strong></td></tr>
+      <tr><td><code>[ZONE:Frozen]</code> 표식 + <strong>신규 동결 allowlist 메타 파일</strong></td><td><span class="badge frozen">FROZEN</span></td><td>허용 목록 자체는 쓰기 영역 밖 (자가-수정 불가)</td></tr>
+      <tr><td><code>CLAUDE.local.md</code></td><td><span class="badge evol">EVOLVABLE</span></td><td>로컬 dev 가이드 (git-tracked, 미배포). INVARANTS 커널 + §28 자가진화 운용 지시</td></tr>
+      <tr><td><code>.claude/settings.local.json</code></td><td><span class="badge evol">EVOLVABLE</span></td><td>개인 런타임 설정 (runtime-managed, never templated)</td></tr>
+      <tr><td><code>memory/</code> (feedback_*.md + MEMORY.md)</td><td><span class="badge evol">EVOLVABLE</span></td><td>auto-memor 교훈 저장 (Tier-2 정제 통찰)</td></tr>
+      <tr><td><code>.claude/agents/harness/**</code> + <code>hns-*</code> skills</td><td><span class="badge evol">EVOLVABLE</span></td><td>user-owned harness namespace (§24 보호)</td></tr>
+      <tr><td><code>.moai/lessons-inbox.jsonl</code></td><td><span class="badge evol">EVOLVABLE</span></td><td>Tier-1 원시 추적 (drain 대상)</td></tr>
+      <tr><td><code>.moai/state/</code> + 신규 <code>.moai/state/lsel/</code></td><td><span class="badge evol">EVOLVABLE</span></td><td>세션/핸드오프/골 + 루프 자체 상태</td></tr>
+    </tbody>
+  </table>
+
+  <div class="callout warn">
+    <h4>정직한 경계 — git-tracked 서피스는 repo 독자에게 보인다</h4>
+    <p><code>CLAUDE.local.md</code>와 <code>hns-*</code> 스킬은 git-tracked 되어 공개 OSS 저장소로 push된다. 루프 학습이 <code>hns-lsel-*</code>에 닿으면 <strong>템플릿 사용자에게는 보이지 않지만</strong>(<code>split_namespace_test.go</code>가 leak을 막는다) 저장소를 읽는 사람에게는 보인다. 분산 격리는 유지되되 저장소 공개 서피스는 그렇지 않다는 점을 설계는 분명히 한다. <code>CLAUDE.local.md</code>에 SPEC-ID/SHA가 새어나가는 것은 CI 가드(<code>internal_content_leak_test.go</code> 확장)로 막는다.</p>
+  </div>
+</section>
+
+<!-- ============================ 6. LOOP ============================ -->
+<section id="loop">
+  <h2><span class="num">06</span>7단계 루프</h2>
+
+  <div class="stage">
+    <div class="stage-head"><span class="stage-num">1</span><h3>OBSERVE — 관측</h3></div>
+    <p>이미 돌아가는 관측 절반을 그대로 재사용한다. <code>usage-log.jsonl</code>(110K events), <code>lessons-inbox.jsonl</code>(569 stubs), <code>tier-promotions.jsonl</code>(159 rows), <code>@MX</code> 라이브 그래프(1583 lines) 모두 기존 훅으로 계속 축적. <strong>새로 추가</strong>: 의도적 암시 이벤트(Ctrl+G 계획 편집, 'Other' 자유형 덮어쓰기, 추천 거부, 옵션 설명 중 거부)를 <code>.moai/state/lsel/signals.jsonl</code>에 append — 이들은 수동 승인보다 posterior 가중이 5~10배 높다. 추가로 drain-후보 시점에 <code>verified: true|false</code> 결과 태그를 붙여 ExpeL식 성공/실패 페어링을 가능하게 한다.</p>
+    <dl>
+      <dt>서피스</dt><dd><code>usage-log</code> + <code>lessons-inbox</code> + <code>tier-promotions</code> (read-only 재사용) + <code>.moai/state/lsel/signals.jsonl</code> (신규 append-only)</dd>
+      <dt>도구</dt><dd>기존 훅(변경 없음). <code>signals.jsonl</code>은 <code>settings.local.json</code>에 등록된 사용자 소유 PostToolUse 훅 + 세션 override 수를 내보내는 SessionEnd 훅. (선택) 주간 <code>/loop</code> 읽기 전용 레시피로 관측량 스냅샷.</dd>
+    </dl>
+  </div>
+
+  <div class="stage">
+    <div class="stage-head"><span class="stage-num">2</span><h3>CLUSTER — 군집·드레인</h3></div>
+    <p>헌법이 이름만 붙이고 구현하지 않은 드레인(drain-marking = 0 Go grep hits). <code>lessons-inbox</code> stub을 <code>event_key</code>로 묶고, 빈도를 세고, 단일 발생 노이즈를 버리고, Generative-Agents식 1~10 중요도 등급으로 생존자를 게이트한다(빈도는 프록시지만 빈번-노이즈와 중요를 뒤섞는 결함이 있어 기계적 심각도 힌트로 보강). inbox-쓰기 시점에 coarse 심각도 힌트를 밀어 넣어 명백히 저가치인 stub이 군집화를 건너뛰게 한다. 드레인은 <code>drain-offset.json</code>(동반 오프셋)으로 소비된 stub을 표시한다(append-only inbox 보존). 25일 백로그를 후보 <code>feedback_*.md</code> 주제로 바꾼다.</p>
+    <dl>
+      <dt>서피스</dt><dd><code>lessons-inbox</code> 읽기; <code>.moai/state/lsel/clusters.json</code>(transient) + <code>.moai/state/lsel/drain-offset.json</code>(내구성 동반 오프셋). 후보 주제는 PROPOSE를 기다리며, 아직 <code>memory/</code>에 쓰지 않는다.</dd>
+      <dt>도구</dt><dd><code>hns-lsel-curator</code> 스킬. <code>/moai:harness lsel drain</code> 또는 주간 <code>/loop</code> 레시피로 발화. Go 코드 추가 없음 — 동결 <code>curator_dispatch.go</code>는 그대로 두고, JSONL 위에서 모델이 매개하는 스킬.</dd>
+    </dl>
+  </div>
+
+  <div class="stage">
+    <div class="stage-head"><span class="stage-num">3</span><h3>PROPOSE — 그림자 제안</h3></div>
+    <p>생존한 군집(또는 사후가 수축한 설정/개인화 신호)마다 PROPOSAL 페이로드를 초안한다: <code>{proposal_id, target_surface ∈ 6 evolvable, diff.patch, rationale, WHY-not-just-WHAT, prediction(반증 가능 기대 효과), verify_command, blast_radius, memory_type: semantic|procedural|episodic}</code>. 결정적으로 제안자는 초안 전에 <strong>관련 <code>feedback_*.md</code>를 먼저 검색</strong>하고(Reflexion), 동결 doctrine 대비 CAI식 자기 비판을 내보낸다. 자기 비판이 깨끗해질 때까지 제안은 막힌다. 이것이 <code>CuratorDispatch.Prepare()</code>가 비계만 짓고 연결하지 않은, 빠진 PROPOSE다.</p>
+    <dl>
+      <dt>서피스</dt><dd><code>.moai/state/lsel/proposals/&lt;proposal-id&gt;/{proposal.md, diff.patch, self-critique.md}</code> — <strong>shadow 파일만, 라이브 config 절대 아님</strong>. LangWatch dev→staging→prod 격리 반영.</dd>
+      <dt>도구</dt><dd><code>hns-lsel-curator</code> 스킬 + 초안용 <code>Agent(general-purpose)</code> + 검색된 메모리 컨텍스트. 동결 <code>CuratorDispatch.Prepare()</code>는 참조 전용, 절대 호출 안 함.</dd>
+    </dl>
+  </div>
+
+  <div class="stage">
+    <div class="stage-head"><span class="stage-num">4</span><h3>APPROVE — 승인</h3></div>
+    <p>오케스트레이터가 대기 중 제안을 <strong>기존 AskUserQuestion Tier-4</strong> harness-학습 흐름으로 표시. 능력 조건부 에스컬레이션(CSA if-then): <code>CLAUDE.local.md</code> INVARANTS 커널, 보안/검증 예외 구간, HIGH-fan-in 참조, Bash 위험 경로, <strong>집행 메타 파일(allowlist·applier/curator 스킬 본문·훅 스크립트·<code>settings.local.json</code> 훅 등록 서브블록)</strong>을 건드리는 제안은 제안자 신뢰도와 무관하게 동기 AskUserQuestion 강제. 루틴 <code>memory/</code>/<code>feedback</code>/<code>permissions.allow</code> 편집은 가벼운 카나리 경로. 각 승인 라운드는 사용자 응답에 CodeRabbit식 "Learnings Added" 영수증을 싣는다. bother-cost 정지 규칙: 기대 후회 감소 &gt; 중단 비용일 때만 묻되, <strong>강제 게이트는 bother-cost 면제</strong>.</p>
+    <dl>
+      <dt>서피스</dt><dd>AskUserQuestion(오케스트레이터 채널 독점) + <code>.moai/state/lsel/proposals/&lt;id&gt;/decision.json</code>(승인/거부/연기 + 사유의 내구성 기록).</dd>
+      <dt>도구</dt><dd>기존 <code>moai-harness-learner</code> 스킬 + askuser-protocol별 ToolSearch preload. 새 승인 메커니즘 없음 — 기존 것 재사용.</dd>
+    </dl>
+  </div>
+
+  <div class="stage">
+    <div class="stage-head"><span class="stage-num">5</span><h3>APPLY — 적용 (진짜 경계 닫기)</h3></div>
+    <p>새 사용자 소유 applier(<code>hns-lsel-applier</code> 스킬 + <code>.moai/hooks/lsel-apply.sh</code>, <code>settings.local.json</code> 등록)가 승인된 제안을 읽고, <strong>동결 영역 허용 목록 정규식</strong>으로 대상 경로를 검증(6 evolvable 서피스만 — 그 외 경로는 hard reject, <code>.moai/logs/lsel-reject.log</code>에 기록)하고 Edit/Write/git으로 쓴다. 동결 Go applier(<code>enableTriggerInjectionWrites=false</code>)는 <strong>결코 건드리지 않는다</strong> — 켜면 배포 서피스로 주입되므로, 병렬 경로로 우회한다. 모든 적용은 <code>lsel-&lt;proposal-id&gt;</code> 태그의 git 커밋(불변 버전 ID)이라 되돌리기는 <code>git revert &lt;tag&gt;</code> 한 줄. PR 의무 체제(§23)에 맞춰 feature 브랜치 + PR(Tier S 셀프 머지).</p>
+    <dl>
+      <dt>서피스</dt><dd>오직 6 evolvable 서피스(allowlist 강제). manifest는 <code>.moai/state/lsel/apply-ledger.jsonl</code>에 기록 — 동결 applier가 만들지 못한 manifest가 마침내 실재(사용자 소유 영역에서).</dd>
+      <dt>도구</dt><dd><code>hns-lsel-applier</code> 스킬(APPROVE 후 오케스트레이터 호출) + allowlist 가드. <code>branch_guard.go</code>의 경로-allowlist + 예외 패턴을 아키텍처 참조로(모양만 재사용, 코드 아님).</dd>
+    </dl>
+  </div>
+
+  <div class="stage">
+    <div class="stage-head"><span class="stage-num">6</span><h3>REMEMBER — 기억</h3></div>
+    <p>적용된 모든 제안은 <code>feedback_*.md</code> 주제 파일(category + 잘못된 패턴 + 올바른 접근 + WHY + surface 태그 + prediction + <code>verified:pending</code>)과 MEMORY.md 색인 한 줄을 쓴다 — Self-Refine에는 없고 ExpeL이 하중이라 증명한 교차-세션 저장. <strong>거부/되돌려진 제안도 <code>verified:false</code> 교훈을 쓴다</strong>(제안자가 같은 편집 부류를 재시도하지 않게). <code>memory_type</code> 라벨(CoALA)이 절차적 교훈은 <code>hns-*</code> 스킬로, 의미론적 사실은 <code>feedback_*.md</code>로 라우팅. 무장된 제안은 (재사용하는) <code>handoff/pending.json</code>을 타서 <code>/clear</code> 도중에도 다음 세션에서 이어진다.</p>
+    <dl>
+      <dt>서피스</dt><dd><code>memory/feedback_*.md</code> + <code>MEMORY.md</code> 색인 + <code>memory/_archive/</code>(cold tier, 삭제 불가) + <code>.moai/state/handoff/pending.json</code>(재사용).</dd>
+      <dt>도구</dt><dd>Claude Code 네이티브 auto-memory + <code>hns-lsel-applier</code>가 최종 apply 단계로 주제 파일 작성. MemGPT식 promote-on-retrieval-hit 페이징.</dd>
+    </dl>
+  </div>
+
+  <div class="stage">
+    <div class="stage-head"><span class="stage-num">7</span><h3>VERIFY — 검증</h3></div>
+    <p>적용 후 제안의 <code>verify_command</code> + <strong>의무 <code>/moai gate</code> 상위집합</code></strong>(lint+format+type+test)을 실행. 증거는 기존 verification-batch 계약대로 <code>.moai/state/verify/&lt;session&gt;/</code>에 지속(요약이 아니라 verbatim 출력 — verification-claim-integrity §2 귀속). 검증이 실패하면 <code>git revert lsel-&lt;proposal-id&gt;</code>로 자동 되돌리고, 제안의 <code>feedback_*.md</code>는 <code>verified:false</code> 표시되며 거부는 Reflexion 교훈이 된다. <strong>타임아웃 같은 불안정 신호에는 한 번 재시도</strong>하고 두 번째 비-타임아웃 실패에서만 되돌린다. 느린 주기로 임계치가 쌓이면(시계 아님) 세부 주제 파일 여러 개에서 추상 원칙 주제 파일 하나를 합성하고 원본은 cold tier로 내리는 정기 REFLECTION 패스.</p>
+    <dl>
+      <dt>서피스</dt><dd><code>.moai/state/verify/&lt;session&gt;/</code>(증거) + <code>apply-ledger.jsonl</code>(결과 행: applied→verified|reverted) + <code>memory/</code>(verified 태그 갱신 + reflection 합성 원칙 파일).</dd>
+      <dt>도구</dt><dd><code>/moai gate</code> + verification-batch 단일 턴 패턴 + <code>go test -run &lt;pattern&gt;</code>. reflection 패스는 월간 <code>/loop</code> 레시피 또는 <code>/moai:harness lsel reflect</code>.</dd>
+    </dl>
+  </div>
+</section>
+
+<!-- ============================ 7. GUARDRAILS ============================ -->
+<section id="guardrails">
+  <h2><span class="num">07</span>가드레일 (강화된 불변량)</h2>
+
+  <p>두 차례 적대적 비평이 v1 설계의 치명적 결함(self-amending allowlist 등)을 찾아낸 뒤 강화된 불변량 집합이다.</p>
+
+  <ul>
+    <li><strong>동결 영역 허용 목록 (핵심 불변량, CAI 고정 헌법의 구조화)</strong> — applier는 모든 쓰기 대상을 6 evolvable 서피스 경로 패턴에만 매칭하는 positive allowlist 정규식으로 검증. 그 외 경로( <code>.claude/rules/moai/**</code>, <code>CLAUDE.md</code>, <code>internal/template/templates/**</code>, retained agents, <code>moai-*</code> skills, <code>.moai/config/sections/**</code> 전부)는 hard reject되고 <code>.moai/logs/lsel-reject.log</code>에 기록. "doctrine 절대 안 건드림"은 열망이 아니라 경로-메커니즘 보장. <strong>허용 목록 자체는 6 evolvable 영역 밖 동결 메타 파일에 존재</strong>(루프가 자기 수갑을 못 풀게).</li>
+    <li><strong>네임스페이스 분리 (§24)</strong> — 모든 신규 산출물은 <code>hns-*</code> / <code>.claude/agents/harness/</code> / <code>.moai/state/lsel/</code> 아래. 로컬 CI 테스트(<code>split_namespace_test.go</code> + <code>internal_content_leak_test.go</code> 미러)가 <code>internal/template/templates/</code>로의 leak을 단언.</li>
+    <li><strong>동결 Go applier는 동결된 채로</strong> — <code>enableTriggerInjectionWrites</code>는 false로 잔존. 루프는 병렬 사용자 소유 applier로 우회. 감사가 증명한 끊긴 seam은 unfreeze가 아니라 bypass로 닫는다.</li>
+    <li><strong>불변 버전 ID + 즉시 롤백 (LangWatch)</strong> — 적용마다 <code>lsel-&lt;proposal-id&gt;</code> 태그 git 커밋. 롤백은 <code>git revert &lt;tag&gt;</code>. PR 의무 체제에 맞춰 feature 브랜치 + PR(Tier S 셀프 머지).</li>
+    <li><strong>능력 조건부 에스컬레이션 (CSA if-then)</strong> — INVARANTS 커널, 보안/검증 예외, HIGH-fan-in 참조, Bash 위험 경로, <strong>집행 메타 파일</strong>을 건드리면 제안자 신뢰도와 무관하게 AskUserQuestion 강제. <code>permissions.allow</code> 추가는 명시적으로 보안-예외 구간으로 분류(매 라인 동기 승인).</li>
+    <li><strong>강제 게이트는 bother-cost 면제</strong> (명시 조항) — bother-cost 정지 규칙은 루틴 tier에만 적용. 그렇지 않으면 큰 컨텍스트 무인 루프가 INVARANTS 편집 게이트를 억제하고 커널이 조용히 편집 가능해진다.</li>
+    <li><strong>적용 전 자기 비판 (CAI)</strong> — PROPOSE는 동결 doctrine 대비 자기 비판을 내보내고 비판이 깨끗해질 때까지 제안을 막는다. 검사 대상 헌법은 쓰기 영역 밖(allowlist 보장)이라 비판이 공허해지지 않는다.</li>
+    <li><strong>승격 전 기계적 검증 (Voyager)</strong> — 제안자의 "그럴듯함"은 가설; <code>/moai gate</code> + 테스트 + LSP가 진리. <strong>제안자 자작 verify만으로는 순환 논리</strong>이므로 <code>/moai gate</code>를 의무로 더한다. 증거는 verbatim으로 <code>.moai/state/verify/&lt;session&gt;/</code>에 지속.</li>
+    <li><strong>하드 거부 / 킬 스위치</strong> — <code>/moai:harness lsel veto</code>가 대기 제안을 전부 버리고 최근 N개 <code>lsel-*</code> 커밋을 known-good baseline로 되돌린다(단 destructive-primitive이므로 <strong>확인 수반</strong>, 무조건 자동이 아님).</li>
+    <li><strong>거부 교훈이 루프를 닫는다 (Reflexion)</strong> — 비판·승인·검증이 거부한 제안마다 <code>verified:false</code> 교훈을 써서 제안자가 다음 제안 전에 검색. 쓰기 범위를 넓히지 않고 메모리에서 개선.</li>
+    <li><strong>정제가 공유 실패 양상을 막는다 (Generative-Agents + Vectorize)</strong> — drain의 중요도 게이트가 저가치 군집을 <code>feedback_*.md</code>가 되기 전에 거부. <code>verified:true</code> 교훈이 명시적 조정 없이 최신 미검증 것으로 조용히 대체되지 않음. 보관-삭제-말고 로 50-파일 한도를 축출이 아닌 계층화 임계값으로 유지.</li>
+    <li><strong>읽기 전용 목표 커널 (Datagrid)</strong> — <code>CLAUDE.local.md</code> 상단의 짧은 INVARANTS 블록이 학습이 절대 덮어쓰면 안 되는 사용자 하드 선호(template-first, PR 의용, settings.local.json 커밋 금지)를 닻. 자기편집-가드레일-제거에 대한 로컬 킬 스위치.</li>
+    <li><strong>settings.local.json 등록은 비-템플릿</strong> — lsel 훅은 <code>.claude/settings.local.json</code>(§2 HARD, never templated)에 등록되어 스킬 파일이 우연히 미러되어도 배포로 leak되지 않는다. 훅 스크립트 자체는 <code>.moai/hooks/</code> 아래(template-managed <code>.claude/hooks/moai/</code>가 아닌 사용자 소유).</li>
+  </ul>
+</section>
+
+<!-- ============================ 8. ARTIFACTS ============================ -->
+<section id="artifacts">
+  <h2><span class="num">08</span>새 산출물</h2>
+  <p>산출물은 <strong>두 부류</strong>로 나뉜다 (<span style="color:var(--coral);font-weight:700">v2 정정</span> — namespace 정체성 혼란 수정). <strong>(A) 메커니즘 스킬</strong>은 prototype→graduate 경로를 따른다: 단계1은 <code>hns-lsel-*</code>(이 리포 dogfood, GOOS가 생성, 배포 X, <code>split_namespace_test.go</code>가 template 누출 차단), 검증 후 <code>moai-lsel-*</code> + <code>internal/template/templates/</code>로 승격(별도 SPEC, 16-언어 배포 = doctrine 일부). <strong>(B) 학습 산출물·상태</strong>는 영구 user-owned(template 불가, §24 보호). 단계1(dogfood) 기준 산출물:</p>
+  <table>
+    <thead><tr><th>유형</th><th>경로</th><th>목적</th></tr></thead>
+    <tbody>
+      <tr><td>메커니즘 (A) <span style="font-size:11px;color:var(--ink-faint)">hns→moai 승격</span></td><td><code>.claude/skills/hns-lsel-curator/SKILL.md</code></td><td>CLUSTER+PROPOSE 엔진: companion-offset drain, 중요도 게이트, 자기 비판 동반 shadow 제안 초안, 초안 전 검색. <strong>검증 후 moai-lsel-* + template로 승격</strong></td></tr>
+      <tr><td>메커니즘 (A) <span style="font-size:11px;color:var(--ink-faint)">hns→moai 승격</span></td><td><code>.claude/skills/hns-lsel-applier/SKILL.md</code></td><td>APPLY 엔진: 승인된 제안 읽기, 동결 allowlist 검증, 6 영역에만 쓰기, <code>lsel-&lt;id&gt;</code> 커밋, verify 후 실패 시 자동 되돌리기, <code>feedback_*.md</code> 작성. <strong>검증 후 moai-lsel-* + template로 승격</strong></td></tr>
+      <tr><td>user-owned agent</td><td><code>.claude/agents/harness/hns-lsel-curator-specialist.md</code></td><td>(선택) 대규모 drain/reflection 패스 전문가. 11 retained가 아닌 user-owned namespace</td></tr>
+      <tr><td>shell hook (사용자 소유)</td><td><code>.moai/hooks/lsel-apply.sh</code> + <code>lsel-signal-capture.sh</code></td><td>신호 캡처(PostToolUse → signals.jsonl) + 기계적 apply 재생(승인된 <code>decision.json</code>만 재생, 두 번째 apply 경로 아님)</td></tr>
+      <tr><td>shadow 제안</td><td><code>.moai/state/lsel/proposals/&lt;id&gt;/{proposal.md,diff.patch,self-critique.md,decision.json}</code></td><td>PROPOSE staging. 라이브 config는 오직 명시적 PROMOTE(=APPLY)로만 변경</td></tr>
+      <tr><td>불변 감사 원장</td><td><code>.moai/state/lsel/apply-ledger.jsonl</code></td><td>적용/되돌려진 제안마다 한 행. 동결 applier가 만들지 못한 manifest가 실재</td></tr>
+      <tr><td>루프 상태</td><td><code>.moai/state/lsel/{drain-offset.json,signals.jsonl,clusters.json}</code></td><td>동반 오프셋 drain 표시 / 의도적 암시 고가중 캡처 / transient 군집</td></tr>
+      <tr><td>로컬 가이드 수정</td><td><code>CLAUDE.local.md §28</code> (신규 섹션 + INVARANTS 커널)</td><td>루프를 발화하는 항상-로드 로컬 지시. 약 40 로컬 줄, shipped-doctrine 변경 0</td></tr>
+      <tr><td>거부 감사 로그</td><td><code>.moai/logs/lsel-reject.log</code></td><td>모든 allowlist 거부 기록 — 동결 영역 가드가 발화한 증거</td></tr>
+      <tr><td>CI 가드</td><td><code>.github/workflows/</code> (lsel-leak + CLAUDE.local.md internal-marker)</td><td><code>internal_content_leak_test.go</code> 확장 — <code>CLAUDE.local.md</code>의 SPEC-ID/SHA leak 차단 + lsel→template leak 차단</td></tr>
+    </tbody>
+  </table>
+</section>
+
+<!-- ============================ 9. DATA MAPPING ============================ -->
+<section id="data">
+  <h2><span class="num">09</span>데이터 소스 매핑</h2>
+  <p>이미 돌아가는 관측 데이터를 루프로 연결하고, 각각이 어떤 감사 격차를 닫는지.</p>
+  <table>
+    <thead><tr><th>기존 소스 (live)</th><th>루프로 흘러감</th><th>닫는 격차</th></tr></thead>
+    <tbody>
+      <tr><td><code>usage-log.jsonl</code> (110,403 events)</td><td>OBSERVE 수동 신호 + CLUSTER 빈도 힌트 + Thompson 사후</td><td>"관측에 소비자가 없다" — 빈도는 중요도 게이트로, 수용/거부 패턴은 auto-tune 사후로</td></tr>
+      <tr><td><code>lessons-inbox.jsonl</code> (569 stubs, 25일, ZERO drained)</td><td>CLUSTER drain 표적 → REMEMBER <code>feedback_*.md</code></td><td><strong>drain actor = doctrine 문단, Go 코드 0</strong> — companion-offset로 마침내 drain</td></tr>
+      <tr><td><code>tier-promotions.jsonl</code> (159 rows)</td><td>PROPOSE 신뢰도 + 개인화 사후</td><td>"72 draft가 어디로도 가지 않는다" — 승격 이력이 실제 사용자 수용 신호</td></tr>
+      <tr><td><code>@MX</code> 그래프 (1583 lines)</td><td>OBSERVE + REMEMBER 검색 색인 (<strong>읽기 전용</strong>)</td><td>"MX validator가 metrics+slog에만 쓴다" — 동결 applier는 안 켜고 그래프를 검색 색인으로 읽음</td></tr>
+      <tr><td>routing-ledger + 'Other' override + Ctrl+G 편집</td><td>OBSERVE 의도적 암시 고가중 신호 (signals.jsonl)</td><td>추천 거부가 선호 신호로 가중되지 않는다 — 5~10배 posterior</td></tr>
+      <tr><td><code>feedback_*.md</code> (140) + MEMORY.md</td><td>REMEMBER 저장 + PROPOSE 검색(초안 전)</td><td>"retrieval-before-propose 없다" — 오늘은 손저술, 루프가 읽고 쓴다</td></tr>
+      <tr><td><code>handoff/pending.json</code> + auto-memory</td><td>REMEMBER 교차-세션 지속</td><td>Self-Refine 막다른 길(교차-작업 저장 없음) — 기존 <code>/clear</code> 기질 재사용</td></tr>
+      <tr><td><code>memory/_archive/</code> (cold tier)</td><td>REMEMBER cold tier + promote-on-retrieval-hit</td><td>"오래됐지만 관련 있는 교훈이 묻힌다" — 검색 hit 시 그 세션에 페이지백</td></tr>
+    </tbody>
+  </table>
+</section>
+
+<!-- ============================ 10. ROADMAP ============================ -->
+<section id="roadmap">
+  <h2><span class="num">10</span>구현 로드맵 (5단계)</h2>
+
+  <div class="stage">
+    <div class="stage-head"><span class="stage-num">P1</span><h3>Drain 닫기 (가장 싼 격차, apply 아직 없음)</h3></div>
+    <p><code>hns-lsel-curator</code> SKILL.md에 drain + cluster + importance-gate; <code>drain-offset.json</code> 동반 오프셋 표시; 569-stub 백로그의 첫 실제 drain → 후보 <code>feedback_*.md</code> 주제. <strong>APPLY는 아직 넣지 않는다</strong> — 관측·군집·기억만 닫는 가장 싼 단계.</p>
+    <p><strong>활용:</strong> 기존 inbox 스키마, 기존 auto-memory, SPEC-HARNESS-RATCHET-REWIRE-001 D3 동반 오프셋 권고, 기존 Lessons Protocol. <strong>닫는 격차:</strong> "drain-marking mechanism = Go 코드 0 / constitution 문단만" — 모델이 JSONL 위에서 매개하므로 Go 변경 0, user-owned 서피스만.</p>
+  </div>
+
+  <div class="stage">
+    <div class="stage-head"><span class="stage-num">P2</span><h3>PROPOSE shadow (비계만 있고 inert인 절반)</h3></div>
+    <p><code>hns-lsel-curator</code> 확장: shadow 제안을 <code>.moai/state/lsel/proposals/&lt;id&gt;/</code>에 자기 비판 동반 초안; 기존 <code>moai-harness-learner</code> AskUserQuestion Tier-4 흐름으로 표시(<strong>Tier-4 발화가 실제 연결돼 있는지 먼저 검증</strong>); <code>CLAUDE.local.md §28</code> + INVARANTS 커널 추가.</p>
+    <p><strong>활용:</strong> 기존 <code>moai-harness-learner</code>, <code>CuratorDispatch.Prepare()</code> 비계를 참조 형태(읽기 전용), 기존 ToolSearch + AskUserQuestion 채널. <strong>닫는 격차:</strong> "72 draft가 어디로도 가지 않는다 / CuratorDispatch 호출자 0" — PROPOSE 절반에 마침내 소비자. §28 활용 비용 약 40 로컬 줄, doctrine 변경 0.</p>
+  </div>
+
+  <div class="stage">
+    <div class="stage-head"><span class="stage-num">P3</span><h3>APPLY 닫기 (진짜 seam, bypass로)</h3></div>
+    <p><code>hns-lsel-applier</code> SKILL.md에 동결 영역 allowlist; <code>lsel-apply.sh</code>; <code>apply-ledger.jsonl</code>; <code>lsel-&lt;id&gt;</code> 태그 git 커밋의 첫 실제 승격 제안. <strong>출하 전 rollback 리허설 AC</strong>: <code>lsel</code> + 수동 편집이 섞인 <code>CLAUDE.local.md</code> 이력에서 <code>git revert</code>가 충돌 없이 되돌아가는지 입증.</p>
+    <p><strong>활용:</strong> <code>branch_guard.go</code> 경로-allowlist + 예외 패턴(모양 재사용), 기존 verification-batch, 기존 <code>/moai gate</code>, git revert 불변 버전. <strong>닫는 격차:</strong> "<code>applier.go enableTriggerInjectionWrites=false</code> + manifest 부재" — 감사의 중심 발견. <strong>BY BYPASS로 닫는다</strong>: 동결 Go applier는 동결 채로(배포 서피스에 씀), 병렬 사용자 소유 applier가 6 영역에만 써서 루프를 닫는다. manifest.jsonl이 마침내 실재 — 사용자 소유 원장에서.</p>
+  </div>
+
+  <div class="stage">
+    <div class="stage-head"><span class="stage-num">P4</span><h3>VERIFY + reflection (공유 실패 양상에 대한 정제)</h3></div>
+    <p>적용 후 <code>verify_command</code> 연결 + 실패 시 자동 되돌리기; 정기 reflection 패스(월간 <code>/loop</code> 레시피)가 세부 군집에서 원칙 <code>feedback</code> 파일 합성; <code>memory_type</code> 라벨링(CoALA); decay 가중 검색으로 오래된 교훈이 top-5에서 빠짐.</p>
+    <p><strong>닫는 격차:</strong> "정제/decay/가지치기 없음 → 비정제 축적 → 잘못된 교훈 검색" — 모든 논문이 다르게 공격하는 지배적 실패 양상. 이 단계 없으면 루프는 부패하고, 있으면 저장은 썩지 않고 복리된다.</p>
+  </div>
+
+  <div class="stage">
+    <div class="stage-head"><span class="stage-num">P5</span><h3>개인화 + 신호 캡처 (일반화 층)</h3></div>
+    <p><code>signals.jsonl</code> 의도적 암시 캡처(PostToolUse 훅 연결); Thompson sampling 사후로 evolvable 서피스 설정(effort, model, harness level) auto-tune, 템플릿 기본값을 제약 있는 안전 fallback arm으로; UI-thrashing 방지 hysteresis margin; bother-cost 게이트된 ask 주기(cache-aware-execution directive 1 통합). <strong>단, 정적 기본값 대비 override율을 이름 붙인 시뮬레이션 하네스에서 낮추지 못하면 배포하지 않는다.</strong></p>
+    <p><strong>닫는 격차:</strong> "추천 = 정적 템플릿 기본값, 관측이 대규모로 돌아도 개인화 안 됨". 이기해야 할 귀무가설은 정적 템플릿 기본값이다.</p>
+  </div>
+</section>
+
+<!-- ============================ 11. CRITIQUE ============================ -->
+<section id="critique">
+  <h2><span class="num">11</span>적대적 비평과 mustFix</h2>
+  <p>두 독립 렌즈가 v1 설계를 공격했다. 둘 다 같은 치명적 결함(self-amending allowlist)을 찾았고, 종합 설계는 이를 반영해 강화됐다. 아래는 원 비평의 요지와 잔존 mustFix.</p>
+
+  <h3>렌즈 A — Doctrine 침해 & 안전</h3>
+  <p class="critique-verdict">bypass-the-frozen-applier 본능은 옳고 동결 allowlist는 올바른 핵심 불변량이다 — 그러나 v1은 그 allowlist를 진화 가능·git 추적 스킬 파일 안에 뒀어서 가드가 자가-수정 가능했다. 모델 전용(비기계적) 자기 비판, 선택적 루프 트리거(감사 실패 재현), CI 가드 없는 <code>CLAUDE.local.md</code> leak 서피스와 합쳐져 침입 가능하고 기본 미발화. mustFix #1/#2/#5/#6 출하 전 차단.</p>
+  <details open>
+    <summary>mustFix (A) — 모두 종합 설계에 반영</summary>
+    <ul>
+      <li><strong>허용 목록을 쓰기 영역 밖으로</strong>: <code>hns-lsel-applier/SKILL.md</code>(진화 가능·git 추적)에 두지 말고, 6 evolvable 영역 밖 동결 메타 파일의 상수로. <em>가장 하중 큰 수정.</em></li>
+      <li><strong>집행 메타 파일을 CSA 강제 게이트 목록에 추가</strong>: allowlist, applier/curator 스킬 본문, 훅 스크립트, <code>settings.local.json</code> 훅 등록 서브블록. 어떤 tier·신뢰도든 동기 AskUserQuestion 강제.</li>
+      <li><strong>강제 게이트는 bother-cost 면제</strong>(명시 조항).</li>
+      <li><strong><code>CLAUDE.local.md</code> internal-marker CI 가드</strong>: <code>internal_content_leak_test.go</code>를 <code>internal/template/templates/</code>뿐 아니라 실제 repo <code>CLAUDE.local.md</code>로 확장. SPEC-ID/SHA/내부 경로 차단.</li>
+      <li><strong>훅 applier는 승인된 큐만 소비</strong>: <code>lsel-apply.sh</code>는 이미 기록된 <code>decision.json</code>을 재생만, 새 apply를 만들지 않음.</li>
+      <li><strong>drain/propose 주기의 기계적 트리거</strong>: SessionStart 훅이 백로그 재고 &gt; 임계치면 알림, 또는 기본 켜짐 예정 <code>/loop</code>. §28 넛지는 불충분(모델이 읽는 문장).</li>
+      <li><strong><code>settings.local.json</code> 훅 등록 서브블록 보호</strong>: applier가 lsel 훅 등록을 제거/무력화하는 편집 거부(INVARANTS와 동일 meta-보호).</li>
+      <li><strong>§23 PR 의무 하에 APPLY git 위상 명확화</strong>: feature 브랜치 커밋 + PR(Tier S 셀프 머지), main-checked-out 트리 아님. rollback 리허설 AC 추가.</li>
+    </ul>
+  </details>
+
+  <h3>렌즈 B — 실제 실효</h3>
+  <p class="critique-verdict">doctrine 격리 축은 강하(경로-allowlist가 실제로 doctrine 쓰기를 막음, bypass 추론 건전). 그러나 실제 실효 축에서 <strong>이전 실패의 형태를 되풀이</strong>한다: OBSERVE 이후 모든 단계가 "오케스트레이터가 불리면 한다"(doctrine, not mechanism), 복제하는 기존 <code>moai harness execute</code> 경로의 69 보류 제안을 무시, drain이 기계적 트리거·기계적 중요도 임계 없이 362개 Bash 노이즈를 승격. Stop/예정 훅이 CLUSTER를, <code>lsel-apply.sh</code>가 (선택 아닌) 주 APPLY 경로로 발화하지 않으면 inbox는 또 550 un-drained stub을 쌓고 루프는 advisory로 잔존.</p>
+  <details open>
+    <summary>mustFix (B) — 모두 종합 설계에 반영</summary>
+    <ul>
+      <li><strong>CLUSTER를 기계적 트리거로</strong>: Stop 훅 또는 예정 <code>/loop</code>가 <code>wc -l inbox &gt; offset + N</code>일 때 <code>hns-lsel-curator drain</code> 발화. 없으면 570-stub 백로그가 스스로 drain되지 않는다.</li>
+      <li><strong>APPLY를 기계적 트리거로, 또는 반자율-전용 명시</strong>: <code>lsel-apply.sh</code>를 (선택이 아닌) 주 경로로(승인 decision.json 쓰기 시 PostToolUse, 또는 SessionEnd flush). 아니면 APPLY가 오케스트레이터 매개이고 루프는 닫힌 자가 진화가 아니라 "제안 표시 도우미"라고 솔직히 선언.</li>
+      <li><strong>P1 drain 전에 노이즈 과점 inbox 수정</strong>: inbox-쓰기 시점에 기계적 심각도 힌트(또는 이벤트 allowlist·요약 길이 바닥·반복 PID 검출 같은 기계적 임계). 그렇지 않으면 첫 drain이 362 타임아웃을 교훈으로 바꾼다.</li>
+      <li><strong>기존 <code>moai harness apply/execute/propose</code> CLI와 69 보류 제안 조율</strong>: 기존 opt-in <code>execute</code> 경로를 구동하고 병렬 applier를 폐기하거나, 같은 SPEC에서 분산 dead verb를 명시 폐기. 69가 썩는 동안 병렬 경로를 짓는 건 CLI 서피스에서 감사 발견의 되풀이다.</li>
+      <li><strong>"OBSERVE unchanged" vs "verified 결과 태그" 모순 해결</strong>: 결과 태그를 담는 side file 명시(또는 writer 훅 수정하고 "unchanged" 주장 삭제). ExpeL 성공/실패 페어링은 하중이므로 under-specified로 둘 수 없다.</li>
+      <li><strong>독립 verify 상위집합 의무</strong>: 제안자 자작 <code>verify_command</code>만으로는 순환. 모든 제안 verify는 고정 <code>/moai gate</code>를 포함.</li>
+      <li><strong>lsel-leak neutrality 가드를 CI로</strong>, "로컬 테스트"가 아닌. 정확한 워크플로 파일명·트리거 명시.</li>
+      <li><strong><code>permissions.allow</code> 추가를 보안-예외로 명시 분류</strong>, 매 라인 AskUserQuestion 강제.</li>
+      <li><strong><code>lsel-apply.sh</code> git 작업의 primary-checkout vs worktree 명시</strong>: primary면 main-checkout-branch-guard 존중(HEAD 재판독·pathspec 스테이징), worktree면 제안 생명주기가 worktree 경로 휴대.</li>
+    </ul>
+  </details>
+</section>
+
+<!-- ============================ 12. RISKS ============================ -->
+<section id="risks">
+  <h2><span class="num">12</span>위험과 완화</h2>
+  <p>비평의 mustFix를 접은 위험 중심 정리. 각 위험 옆 완화.</p>
+  <div class="risk"><div class="rt"><span class="tag">위험</span>자가-수정 가능 allowlist → doctrine 침입</div><div><strong>완화</strong>: allowlist를 6 evolvable 영역 밖 동결 메타 파일로 이동. 집행 메타 파일은 CSA 강제 게이트 대상.</div></div>
+  <div class="risk"><div class="rt"><span class="tag">위험</span>집행 메타 파일(allowlist·스킬 본문·훅·등록) 자가편집</div><div><strong>완화</strong>: 영향 반경 기준 강제 게이트 추가, 제안자 신뢰도와 무관 동기 승인.</div></div>
+  <div class="risk"><div class="rt"><span class="tag">위험</span>기계적 트리거 부재 → 루프 기본 미발화 (감사 실패 재현)</div><div><strong>완화</strong>: SessionStart 백로그 점검 + 기본 켜짐 <code>/loop</code>. §28 넛지는 보조일 뿐.</div></div>
+  <div class="risk"><div class="rt"><span class="tag">위험</span>노이즈 과점 inbox (63% Bash 타임아웃) → 노이즈가 교훈으로 둔갑</div><div><strong>완화</strong>: 쓰기 시점 기계적 심각도 필터 + drain 전 중요도 게이트.</div></div>
+  <div class="risk"><div class="rt"><span class="tag">위험</span><code>permissions.allow</code> 자가편집 = 권한 상승 원시</div><div><strong>완화</strong>: 보안-예외 구간 명시 분류, 매 라인 동기 승인.</div></div>
+  <div class="risk"><div class="rt"><span class="tag">위험</span>강제 게이트 vs bother-cost 충돌 (큰 컨텍스트서 커널 조용히 편집)</div><div><strong>완화</strong>: 강제 게이트 bother-cost 면제 명시 조항.</div></div>
+  <div class="risk"><div class="rt"><span class="tag">위험</span><code>lsel-apply.sh</code> 경로 우회 (승인 없는 apply)</div><div><strong>완화</strong>: <code>decision.json</code> 재생 전용, 새 apply 생성 금지.</div></div>
+  <div class="risk"><div class="rt"><span class="tag">위험</span>flaky verify(타임아웃)가 옳은 제안을 잘못 되돌림</div><div><strong>완화</strong>: 타임아웃 1회 재시도 정책 + <code>/moai gate</code> 상위집합 의무.</div></div>
+  <div class="risk"><div class="rt"><span class="tag">위험</span>git 위상 불명 (main-checked-out 충돌)</div><div><strong>완화</strong>: feature 브랜치 + PR(Tier S) + rollback 리허설 AC.</div></div>
+  <div class="risk"><div class="rt"><span class="tag">위험</span>분산 dead apply 버튼(<code>moai harness execute/apply</code>) 잔존</div><div><strong>완화</strong>: 본 설계는 GOOS 기계 우회만, 분산 죽은 서피스는 동반 SPEC이 폐기/구동하도록 남겨둠. (아래 한계 참조)</div></div>
+  <div class="risk"><div class="rt"><span class="tag">위험</span>auto-revert N 범위 되돌리기가 비-lsel 작업 흡수</div><div><strong>완화</strong>: 킬 스위치는 확인 수반 destructive-primitive; <code>git revert</code> per-tag가 기본.</div></div>
+  <div class="risk"><div class="rt"><span class="tag">위험</span><code>memory/</code> 다중-작성자 경쟁 (동일 주제 파일 clobber)</div><div><strong>완화</strong>: 세션 범위 파일명·잠금 설계 필요 (P1 설계 시 보강).</div></div>
+</section>
+
+<!-- ============================ 13. CAVEATS ============================ -->
+<section id="caveats">
+  <h2><span class="num">13</span>솔직한 한계 — 이 설계가 풀지 않는 것</h2>
+  <p>이 설계를 "감사가 지적한 자가 학습 루프를 닫았다"고 내세우는 것 자체가 관찰되지 않은 완료 주장이 된다. 설계가 풀지 않는 것을 명시한다.</p>
+  <ul>
+    <li><strong>사용자 로컬 루프를 닫는다, 감사가 지적한 배포 서피스 경로가 아니다.</strong> 동결 Go applier는 동결 채로 남고, 배포 사용자 16언어 모두의 <code>moai harness apply</code> 버튼은 별도 SPEC이 폐기하거나 구동하지 않는 한 여전히 죽어 있다. 사용자 로컬 닫기를 감사 닫기인 양 내세우지 않는다.</li>
+    <li><strong>doctrine을 진화시키지 않는다.</strong> doctrine은 루프가 검사하지만 고칠 수 없는 고정 헌법이다. 프로젝트 학습이 doctrine 수준 변경을 요구하면, 여전히 Template-First 주기를 거치는 정상 SPEC이 템플릿 원본을 고쳐야 한다.</li>
+    <li><strong>PROPOSE의 자기 비판은 모델이 수행한다. 기계적 doctrine 검사기가 아니다.</strong> 모델은 합리화할 수 있으며, 고정 헌법은 규칙을 고치지 못하게 막을 뿐 잘못 읽는 것까지는 막지 않는다. 실제 안전성 무게는 동결 allowlist와 <code>/moai gate</code> 검증이라는 기계적 바닥이 지탱한다. 자기 비판은 가벼운 안쪽 문이다.</li>
+    <li><strong>P5 개인화는 영원히 오지 않을 수 있다.</strong> 정적 기본값 대비 override율을 이름 붙인 시뮬레이션 하네스에서 낮추지 못하면 배포하지 않는다는 조건이 달려 있는데, 시뮬레이션 하네스가 아직 지정돼 있지 않다. 일반화 층은 조건부지 보장이 아니다.</li>
+    <li><strong>루프 개선은 컨텍스트 안에서만 일어난다.</strong> 오케스트레이터 모델을 파인튜닝하지 않는다(ExpeEl의 API 전용 모델 제약). 모든 자가 개선은 다음 턴 컨텍스트에 주입되는 검색된 텍스트이지, 모수 갱신이 아니다.</li>
+    <li><strong><code>hns-*</code> 스킬은 git 추적되어 공개 OSS 저장소로 push된다.</strong> 루프 학습이 <code>hns-lsel-*</code>에 닿으면 템플릿 사용자에게는 보이지 않지만(split_namespace_test.go) 저장소를 읽는 사람에게는 보인다.</li>
+    <li><strong>apply-ledger·상태 파일은 gitignored 기계 로컬이다.</strong> 동결 applier가 만들지 못한 불변 감사 원장은 실재하지만, 내구성은 로컬 상태가 살아 있는 한에서 성립. <code>moai clean</code>이 상태를 지우는 동안 <code>lsel-*</code> 커밋은 브랜치 위에 남는다. 뒤섞인 이력에서 선택 되돌리기는 운용상 아프다.</li>
+    <li><strong>루프 자체의 콜드 스타트.</strong> 지금부터 P2 전까지 <code>CLAUDE.local.md §28</code>은 존재하지 않고 루프 발화는 0이다. P2 이후에도 루프를 실제로 돌리는 건 기계적 트리거(SessionStart 백로그 점검 + 기본 켜짐 <code>/loop</code>)이며, §28의 "같은 실수를 두 번 하면 feedback_*.md를 쓴다"는 알림은 모델이 읽는 문장이지 탐지기가 아니다.</li>
+    <li><strong>기존 <code>moai harness apply/execute/propose</code> CLI는 배포 사용자 전원에게 죽은 apply 버튼으로 배포된다.</strong> 본 설계는 GOOS의 기계를 우회로 고칠 뿐, 분산된 죽은 서피스는 동반 SPEC이 폐기하거나 구동하도록 남겨둔다. 죽은 버튼을 아는 채로 배포하는 것 자체가 느린 doctrine 침식이며, 본 설계가 해결하지 않는 것이다.</li>
+  </ul>
+</section>
+
+<!-- ============================ 14. REFS ============================ -->
+<section id="refs">
+  <h2><span class="num">14</span>참고문헌</h2>
+  <p class="ref-list">웹 조사에서 확인된 논문·실무 자료. 설계 근거(groundedIn) 매핑의 원천.</p>
+  <ul class="ref-list">
+    <li><strong>Reflexion</strong> <span class="pub">— Shinn et al., NeurIPS 2023.</span> 언어적 강화: 실패에 대한 자기-성찰을 다음 시도를 위해 저장; bounded 에피소드 버퍼. → PROPOSE retrieval-before-propose, REMEMBER <code>verified:false</code> 교훈.</li>
+    <li><strong>Voyager</strong> <span class="pub">— Wang et al., NeurIPS 2023.</span> 기계 실행 검증 후에만 스킬 라이브러리 진입; 합성적 스킬. → VERIFY(도구가 진리), <code>hns-*</code> 스킬 라이브러리.</li>
+    <li><strong>Generative Agents</strong> <span class="pub">— Park et al., UIST 2023.</span> recency×importance×relevance 검색; 성찰은 임계치 발화(누적 중요도 ~150). → CLUSTER 중요도 게이트, 정기 REFLECTION, decay 가중 검색.</li>
+    <li><strong>ExpeL</strong> <span class="pub">— Zhao et al., AAAI 2024.</span> 성공 vs 실패 궤적 대조로 교차-작업 통찰 추출; 2단계(원시 추적 vs 정제 통찰) 분리. → <code>verified:true|false</code> 결과 태그, Tier-1/Tier-2 분리.</li>
+    <li><strong>Self-Refine</strong> <span class="pub">— Madaan et al., NeurIPS 2023.</span> 작업 내 반영+정제(지속 저장 없음). → <strong>반패턴으로 명시 거부</strong>: 세션 내 전용 <code>/moai-fix</code> 재시도 루프 금지, REMEMBER 의무화.</li>
+    <li><strong>MemGPT</strong> <span class="pub">— Packer et al., 2023.</span> 계층 가상 메모리, 고정 hot tier + cold tier 주문형 페이징. → ≤50 active <code>feedback_*.md</code>(hot) + <code>memory/_archive/</code>(cold), promote-on-retrieval-hit.</li>
+    <li><strong>CoALA</strong> <span class="pub">— 2023.</span> 4개 메모리 유형(working/semantic/episodic/procedural)의 서로 다른 쓰기·검색 트리거. → <code>memory_type</code> 라벨 라우팅(절차적→<code>hns-*</code>, 의미론적→<code>feedback</code>).</li>
+    <li><strong>Constitutional AI</strong> <span class="pub">— Anthropic.</span> 고정 헌법 대비 자기 비판-후-수정; 모델은 산출물을 수정, 원칙은 수정 안 함. → 동결 allowlist = 고정 헌법, PROPOSE 자기 비판.</li>
+    <li><strong>LangWatch</strong> 프롬프트/설정 버전 관리 — 불변 버전 ID, dev→staging→prod 승격, 즉시 롤백. → shadow 제안 + <code>lsel-&lt;id&gt;</code> 불변 커밋 + <code>git revert</code>.</li>
+    <li><strong>Galileo</strong> HITL 감시 — 가역성 축이 감시 무게 라우팅(비가역→동기, 가역→비동기 카나리). → 가역-by-구조가 대부분 편집을 동기 게이트에서 카나리로 강등.</li>
+    <li><strong>CSA Recursive Self-Improvement Security</strong> — Zero-Trust 파이프라인, 최소 권한, 능력 조건부 if-then 게이트. → CSA 에스컬레이션(INVARANTS/보안/HIGH-fan-in/집행 메타).</li>
+    <li><strong>CodeRabbit Learnings</strong> — "Learnings Added" 영수증, approval_delay, 사용 추적(Active/Never Used), 분기별 "축적 대신 갱신" 스윕. → 승인 영수증, <code>CLAUDE.local.md §28</code> 위생 주기.</li>
+    <li><strong>Devin Knowledge</strong> — 검색-트리거 항목(트리거 설명+내용); 저장 전 편집. → <code>feedback_*.md</code>의 트리거 조건, progressive disclosure.</li>
+    <li><strong>HumanLayer / Anthropic context engineering</strong> — CLAUDE.md는 최고 레버리지이고 짧아야; 포인터로 progressive disclosure; <strong>훅 &gt; 규칙</strong>(고정 생명주기 강제). → INVARANTS 커널 짧게, 결정적 보장은 <code>settings.local.json</code> 훅.</li>
+    <li><strong>Vectorize / Hindsight</strong> 4-레버 정제 — importance / merge / decay / evict; 축출은 성능이 아닌 규정 준수 도구. → CLUSTER 4단계 패스, 보관-삭제-말고.</li>
+    <li><strong>Thompson sampling contextual bandits</strong> <span class="pub">— Agrawal &amp; Goyal; Deb et al. RLJ 2025.</span> 사후 분산 = 신뢰도; 제약 기본값 = 안전 fallback arm. → P5 auto-tune, 콜드 스타트 = 템플릿 기본값.</li>
+    <li><strong>Bother-cost preference elicitation</strong> <span class="pub">— Le et al., AAMAS 2018; Gajos 2005.</span> 기대 후회 감소 &gt; 중단 비용일 때만 묻기. → APPROVE ask 주기, cache-aware-execution directive 1 통합.</li>
+    <li><strong>Intentional implicit feedback</strong> <span class="pub">— arXiv:2502.09869.</span> 의도적 행동(계획 편집, 'Other' 덮어쓰기)은 수동 암시와 별개 고가중 채널. → <code>signals.jsonl</code> 5~10배 posterior.</li>
+    <li><strong>Claude Code / Cursor / Cline / Continue</strong> 등 코딩 에이전트 메모리 실무 — CLAUDE.md/AGENTS.md/.cursorrules + topic-file 색인 저장의 보편적 2단계 형태. → MoAI 쌍이 이미 이 형태임 확인(격차 = 발화 규율).</li>
+  </ul>
+  <p class="ref-list" style="color:var(--ink-faint);font-size:12.5px;">참고: 개인화 렌즈의 매핑은 구조적 유추이며, 검증된 디자인이 아닌 잘 근거된 가설임(렌즈 5 honest caveat). 모든 URL은 워크플로우 research 에이전트가 WebSearch/WebFetch로 확인했으나, 본 보고서에는 핵심 출처를 제목-출처로만 표기한다.</p>
+</section>
+
+</main>
+
+<footer class="report-foot">
+  <div class="wrap">
+    <p><strong>LSEL — Local Self-Evolution Loop 설계 제안</strong> · moai-adk-go · 2026-08-04</p>
+    <p>본 보고서는 ultracode 워크플로우(9 에이전트: research 5 병렬 → design 1 → critique 2 병렬 → synthesize 1)의 산출이다. 모든 설계 결정은 사용자 제약(moai doctrine 절대 수정 금지 / 학습은 user-owned 영역에만)과 앞선 자가 학습 감사의 증거 기반 발견에 근거한다. 본 문서 자체는 제안(proposal)이며 구현이 아니다 — 구현은 본 로드맵을 SPEC으로 옮기는 후속 작업에서 이뤄진다.</p>
+    <p style="color:var(--ink-faint);">산출 위치: <code>.moai/reports/moai-local-self-evolution-design-20260804.html</code></p>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/.moai/reports/moai-pipeline-audit-20260802.html
+++ b/.moai/reports/moai-pipeline-audit-20260802.html
@@ -1,0 +1,452 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>MoAI plan/run/sync 파이프라인 전수 검증 + 최종 업데이트 계획</title>
+<link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+<link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.css">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Serif+KR:wght@600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+<style>
+:root{
+  --ivory:#FAF9F5; --paper:#FFFFFF; --slate:#141413;
+  --clay:#D97757; --clay-d:#B85C3E; --oat:#E3DACC; --olive:#788C5D;
+  --g100:#F0EEE6; --g300:#D1CFC5; --g500:#87867F; --g700:#3D3D3A;
+  --sans:"Pretendard",system-ui,-apple-system,sans-serif;
+  --serif:"Noto Serif KR",ui-serif,Georgia,serif;
+  --mono:"JetBrains Mono",ui-monospace,"SF Mono",monospace;
+  --max-width:860px; --radius-panel:12px; --radius-row:8px;
+  --border:1.5px solid var(--g300);
+}
+*{box-sizing:border-box}
+body{margin:0;background:var(--ivory);color:var(--slate);font-family:var(--sans);
+     font-size:16px;line-height:1.75;-webkit-font-smoothing:antialiased}
+.wrap{max-width:var(--max-width);margin:0 auto;padding:56px 24px 96px}
+h1,h2,h3{font-family:var(--serif);line-height:1.35;letter-spacing:-.01em}
+h1{font-size:31px;margin:0 0 10px}
+h2{font-size:22px;margin:52px 0 6px;padding-bottom:8px;border-bottom:2px solid var(--oat)}
+h3{font-size:17px;margin:30px 0 8px}
+p{margin:12px 0}
+code{font-family:var(--mono);font-size:.87em;background:var(--g100);
+     padding:1px 5px;border-radius:4px;border:1px solid var(--g300)}
+a{color:var(--clay);text-decoration-thickness:1px;text-underline-offset:3px}
+a:hover{color:var(--clay-d)}
+.page-head{border-bottom:3px solid var(--clay);padding-bottom:20px;margin-bottom:8px}
+.meta{color:var(--g500);font-size:13.5px;font-family:var(--mono);margin:0}
+.tier{display:inline-block;background:var(--oat);color:var(--g700);font-size:11.5px;
+      font-family:var(--mono);padding:2px 9px;border-radius:99px;margin-left:8px;vertical-align:2px}
+/* plain-language lead */
+.lead{background:var(--g100);border-left:4px solid var(--olive);
+      padding:14px 18px;border-radius:0 var(--radius-row) var(--radius-row) 0;
+      margin:14px 0 22px;font-size:15px;color:var(--g700)}
+.lead b{color:var(--slate)}
+/* KPI strip */
+.kpis{display:grid;grid-template-columns:repeat(4,1fr);gap:12px;margin:26px 0 8px}
+.kpi{background:var(--paper);border:var(--border);border-radius:var(--radius-panel);
+     padding:16px 14px;text-align:center}
+.kpi .v{font-family:var(--serif);font-size:27px;font-weight:700;line-height:1.15;display:block}
+.kpi .l{font-size:11.5px;color:var(--g500);margin-top:6px;display:block;letter-spacing:.02em}
+.kpi.alert .v{color:var(--clay)}
+.kpi.ok .v{color:var(--olive)}
+/* tables */
+table{width:100%;border-collapse:collapse;margin:16px 0;font-size:14.5px;
+      background:var(--paper);border:var(--border);border-radius:var(--radius-panel);overflow:hidden}
+th{background:var(--g100);text-align:left;padding:10px 13px;font-weight:600;
+   font-size:13px;color:var(--g700);border-bottom:var(--border)}
+td{padding:10px 13px;border-bottom:1px solid var(--g300);vertical-align:top}
+tr:last-child td{border-bottom:none}
+td.num,th.num{text-align:right;font-family:var(--mono);font-size:13.5px}
+.zero{color:var(--clay);font-weight:600}
+/* SVG chart holder */
+figure{margin:22px 0;background:var(--paper);border:var(--border);
+       border-radius:var(--radius-panel);padding:20px 18px 14px}
+figcaption{font-size:12.5px;color:var(--g500);margin-top:10px;text-align:center}
+/* milestones */
+.ms{position:relative;padding-left:30px;margin:22px 0}
+.ms::before{content:"";position:absolute;left:9px;top:6px;bottom:6px;width:2px;background:var(--oat)}
+.m{position:relative;margin-bottom:22px}
+.m::before{content:"";position:absolute;left:-26px;top:6px;width:14px;height:14px;
+           border-radius:50%;background:var(--paper);border:3px solid var(--clay)}
+.m.later::before{border-color:var(--g300)}
+.m h3{margin:0 0 4px}
+.m .tag{font-family:var(--mono);font-size:11px;color:var(--g500)}
+.m ol{margin:8px 0 0;padding-left:20px;font-size:14.5px}
+.m ol li{margin:4px 0}
+/* risks */
+.risks{display:grid;grid-template-columns:1fr 1fr;gap:12px;margin:16px 0}
+.risk{background:var(--paper);border:var(--border);border-left:4px solid var(--clay);
+      border-radius:var(--radius-row);padding:13px 15px;font-size:14px}
+.risk .rid{font-family:var(--mono);font-size:11.5px;color:var(--clay);font-weight:600}
+.risk .fix{color:var(--g700);font-size:13.5px;margin-top:6px}
+.risk .fix b{color:var(--olive)}
+/* metrics */
+.metric-row{display:grid;grid-template-columns:16px 1fr auto auto;gap:12px;align-items:center;
+            background:var(--paper);border:var(--border);border-radius:var(--radius-row);
+            padding:11px 14px;margin-bottom:8px;font-size:14.5px}
+.dot{width:11px;height:11px;border-radius:50%}
+.dot.unmet{background:var(--clay)}
+.dot.met{background:var(--olive)}
+.metric-row .now{font-family:var(--mono);font-size:13px;color:var(--g500)}
+.metric-row .tgt{font-family:var(--mono);font-size:13px;color:var(--olive);font-weight:500}
+/* worked example */
+.ex{border:1.5px dashed var(--g300);border-radius:var(--radius-row);
+    padding:14px 17px;margin:16px 0;background:var(--paper);font-size:14.5px}
+.ex .h{font-size:11.5px;font-family:var(--mono);color:var(--olive);
+       letter-spacing:.06em;margin-bottom:6px}
+.ex pre{font-family:var(--mono);font-size:12.5px;background:var(--g100);
+        padding:10px 12px;border-radius:6px;overflow-x:auto;margin:8px 0;
+        border:1px solid var(--g300);line-height:1.6}
+/* mermaid */
+pre.mermaid{background:var(--paper);border:var(--border);border-radius:var(--radius-panel);
+            padding:18px;text-align:center;font-family:var(--mono);font-size:12px;
+            overflow-x:auto;margin:20px 0}
+noscript p{background:var(--g100);border-left:4px solid var(--g500);padding:12px 16px;
+           font-size:14px;border-radius:0 var(--radius-row) var(--radius-row) 0}
+.selfcheck{background:var(--paper);border:2px solid var(--olive);
+           border-radius:var(--radius-panel);padding:18px 22px;margin:26px 0}
+.selfcheck h3{margin-top:0;color:var(--olive)}
+.selfcheck ul{margin:8px 0 0;padding-left:20px;font-size:14.5px}
+.selfcheck li{margin:6px 0}
+.gap{background:var(--g100);border:var(--border);border-radius:var(--radius-row);
+     padding:14px 18px;font-size:14px;color:var(--g700);margin:18px 0}
+footer{margin-top:60px;padding-top:18px;border-top:var(--border);
+       font-size:12.5px;color:var(--g500);font-family:var(--mono)}
+@media (max-width:640px){
+  .kpis{grid-template-columns:repeat(2,1fr)}
+  .risks{grid-template-columns:1fr}
+  .wrap{padding:36px 16px 64px}
+}
+@media print{
+  body{background:#fff}
+  .wrap{max-width:none}
+  h2{page-break-after:avoid}
+  table,figure,.risk,.m{page-break-inside:avoid}
+}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<header class="page-head">
+  <h1>MoAI plan / run / sync 파이프라인 전수 검증<br>+ 최종 업데이트 계획</h1>
+  <p class="meta">2026-08-02 · 검증 대상 3,180줄 + 세션 트랜스크립트 761개<span class="tier">basic tier</span></p>
+</header>
+
+<div class="lead">
+  <b>한 줄 요약 —</b> 병렬 처리 설계는 이미 파이프라인 안에 <b>10곳</b> 들어가 있습니다.
+  그런데 전부 “써도 된다(<code>MAY</code>)”로만 적혀 있고, 그 문장이 각 단계에 들어가야만 읽히는 파일 안에 숨어 있어서
+  <b>실제로는 거의 발동되지 않습니다</b>. 스크립트로 만들어둔 2개는 세션 761개 동안 <b>한 번도 실행된 적이 없습니다</b>.
+</div>
+
+<div class="kpis">
+  <div class="kpi alert"><span class="v">0</span><span class="l">팬아웃 스크립트 실행</span></div>
+  <div class="kpi alert"><span class="v">0</span><span class="l">verify 스냅샷 기록</span></div>
+  <div class="kpi"><span class="v">10</span><span class="l">잠자는 팬아웃 지점</span></div>
+  <div class="kpi"><span class="v">3</span><span class="l">확정 결함</span></div>
+</div>
+
+<h2>1. 이 검증이 무엇을 했나</h2>
+
+<div class="lead">
+  <b>팬아웃 (fan-out)</b> — 일을 여러 조각으로 나눠 여러 일꾼에게 <b>동시에</b> 맡기는 방식입니다.
+  혼자 8칸을 순서대로 하면 8칸만큼 걸리지만, 4명이 2칸씩 나눠 하면 2칸만큼만 걸립니다.
+  MoAI 파이프라인에도 이 장치가 준비돼 있는지, 그리고 <b>실제로 돌아가고 있는지</b>를 확인한 것이 이번 검증입니다.
+</div>
+
+<table>
+  <tr><th>대상</th><th class="num">규모</th></tr>
+  <tr><td>plan 서브스킬 3파일</td><td class="num">863줄</td></tr>
+  <tr><td>run 서브스킬 4파일</td><td class="num">1,115줄</td></tr>
+  <tr><td>sync 서브스킬 4파일</td><td class="num">1,202줄</td></tr>
+  <tr><td>Phase 총계 (plan 15 + run 20 + sync 14)</td><td class="num">49</td></tr>
+  <tr><td>세션 트랜스크립트</td><td class="num">761개</td></tr>
+</table>
+
+<h2>2. 파이프라인 전체 지도</h2>
+
+<div class="lead">
+  아래 그림에서 <b>주황 테두리</b>가 병렬 처리 장치가 준비된 지점입니다.
+  전부 준비만 돼 있고 실제로는 켜지지 않은 상태입니다.
+</div>
+
+<pre class="mermaid">
+flowchart TD
+  P[plan · 15 Phase] --> R[run · 20 Phase]
+  R --> S[sync · 14 Phase]
+
+  P -.잠김.-> P1[research 렌즈 · 스크립트<br/>실행 0회]
+  P -.잠김.-> P2[감사 렌즈 4종<br/>증거만 수집, 판정 못함]
+
+  R -.잠김.-> R1[MX 스캔 샤딩]
+  R -.잠김.-> R2[RED 드래프터 풀]
+  R -.잠김.-> R3[품질 4차원 · 스크립트<br/>실행 0회]
+  R -.잠김.-> R4[MX 태그 샤딩]
+
+  S -.잠김.-> S1[품질 4차원 · 스크립트]
+  S -.잠김.-> S2[MX 스캔 샤딩]
+  S -.잠김.-> S3[테스트 드래프터]
+  S -.잠김.-> S4[문서 5-드래프터 풀]
+
+  classDef dormant fill:#F0EEE6,stroke:#D97757,stroke-width:2px;
+  class P1,P2,R1,R2,R3,R4,S1,S2,S3,S4 dormant;
+</pre>
+
+<noscript>
+  <p>흐름 요약: plan(15 Phase) → run(20 Phase) → sync(14 Phase) 순서로 진행됩니다.
+  각 단계에 병렬 처리 지점이 준비돼 있습니다 — plan 2곳(research 렌즈, 감사 렌즈 4종),
+  run 4곳(MX 스캔 샤딩, RED 드래프터 풀, 품질 4차원, MX 태그 샤딩),
+  sync 4곳(품질 4차원, MX 스캔 샤딩, 테스트 드래프터, 문서 5-드래프터 풀).
+  총 10곳이며 전부 잠긴(미발동) 상태입니다.</p>
+</noscript>
+
+<h2>3. 검증 결과 — 미검증 3건 전부 확정</h2>
+
+<h3>V1. 팬아웃 10개는 거의 발동되지 않았다</h3>
+
+<div class="lead">
+  세션 기록 761개를 뒤져 <b>스크립트가 실제로 지정되어 실행된 적이 있는지</b>를 셌습니다.
+  “문서에 이름이 언급됐다”가 아니라 <b>실행 인자로 넘어갔는지</b>를 본 것이 핵심입니다.
+</div>
+
+<table>
+  <tr><th>항목</th><th class="num">실측</th></tr>
+  <tr><td><code>plan-research-fanout.js</code> 실행 지정</td><td class="num zero">0회</td></tr>
+  <tr><td><code>sync-audit-4dim.js</code> 실행 지정</td><td class="num zero">0회</td></tr>
+  <tr><td>Workflow 도구 자체 호출 (전부 일회성 ad-hoc 스크립트)</td><td class="num">102회</td></tr>
+  <tr><td>Phase 4 모드 선택 기록 SPEC</td><td class="num">166건</td></tr>
+  <tr><td>└ 순차(sub-agent) 선택</td><td class="num">66</td></tr>
+  <tr><td>└ 병렬(parallel/workflow) 선택</td><td class="num">7</td></tr>
+</table>
+
+<div class="ex">
+  <div class="h">실제로 돌린 판정 명령</div>
+  <pre>grep -c 'scriptPath[^"]*"[^"]*plan-research-fanout' *.jsonl → 0
+grep -c 'scriptPath[^"]*"[^"]*sync-audit-4dim'      *.jsonl → 0
+grep -ho '"name":"Workflow"' *.jsonl | wc -l          → 102</pre>
+  Workflow 도구는 102번 쓰였지만, 실제 지정된 스크립트는 모델-effort 설계·템플릿 리뷰·스킬 감사 같은
+  <b>일회성 작업</b>이었습니다. 파이프라인에 붙어 있는 두 스크립트는 그중에 없었습니다.
+</div>
+
+<figure>
+<svg viewBox="0 0 620 150" width="100%" height="150" role="img" aria-label="모드 선택 분포 막대 그래프">
+  <text x="0" y="16" font-family="Pretendard,sans-serif" font-size="12" fill="#87867F">Phase 4 모드 선택 분포 (166 SPEC 중 기록된 것)</text>
+  <text x="0" y="52" font-family="Pretendard,sans-serif" font-size="13" fill="#141413">순차 sub-agent</text>
+  <rect x="130" y="38" width="440" height="20" rx="4" fill="#788C5D"/>
+  <text x="578" y="53" font-family="JetBrains Mono,monospace" font-size="12" fill="#3D3D3A">66</text>
+  <text x="0" y="92" font-family="Pretendard,sans-serif" font-size="13" fill="#141413">병렬 parallel</text>
+  <rect x="130" y="78" width="47" height="20" rx="4" fill="#D97757"/>
+  <text x="185" y="93" font-family="JetBrains Mono,monospace" font-size="12" fill="#3D3D3A">7</text>
+  <text x="0" y="132" font-family="Pretendard,sans-serif" font-size="13" fill="#141413">스크립트 팬아웃</text>
+  <rect x="130" y="118" width="3" height="20" rx="1.5" fill="#D1CFC5"/>
+  <text x="142" y="133" font-family="JetBrains Mono,monospace" font-size="12" fill="#D97757">0</text>
+</svg>
+<figcaption>병렬 경로는 준비돼 있으나 선택 비중이 10% 미만이고, 스크립트 팬아웃은 0</figcaption>
+</figure>
+
+<h3>V2. 증거 스냅샷 CLI는 만들어졌지만 한 번도 호출되지 않았다</h3>
+
+<div class="lead">
+  <b>스냅샷 (snapshot)</b> — 테스트·린트 같은 검사 결과를 한 번 재두고, 코드가 그대로면
+  다음 단계에서 <b>다시 재지 않고 그 값을 그대로 쓰는</b> 장치입니다.
+  MoAI에는 <code>moai verify</code>라는 이름으로 이미 Go 코드까지 구현돼 있습니다.
+</div>
+
+<table>
+  <tr><th>항목</th><th>실측</th></tr>
+  <tr><td>스냅샷 저장 디렉터리 <code>.moai/state/verify/snapshots/</code></td><td class="zero">부재 → 기록 0회</td></tr>
+  <tr><td>“이 스냅샷을 써라”는 지시가 적힌 곳</td><td>3곳 (run P15 · sync P1 · sync P7)</td></tr>
+  <tr><td>스냅샷 키 구성 (<code>internal/verify/key.go:32</code>)</td><td><code>HEAD-SHA : sha256(작업트리 상태)</code></td></tr>
+  <tr><td>유효 시간(TTL) 기본값</td><td>10분</td></tr>
+</table>
+
+<div class="ex">
+  <div class="h">추가로 발견한 구조적 결함</div>
+  키에 <b>HEAD-SHA(마지막 커밋 번호)</b>가 들어 있습니다. 그래서 <b>커밋을 한 번만 해도 키가 바뀌어</b> 스냅샷이 무효가 됩니다.
+  <pre>run Phase 15  → 스냅샷 기록
+run Phase 19  → 커밋 (여기서 키가 바뀜)
+sync Phase 1  → 스냅샷 조회 → 항상 불일치(miss)</pre>
+  즉 문서에 적힌 3개 소비 지점 중 <b>run → sync 홉 2개는 구조적으로 절대 성립하지 않습니다.</b>
+  성립 가능한 유일한 구간은 <code>sync Phase 1 → sync Phase 7</code>(사이에 커밋이 없음)입니다.
+</div>
+
+<h3>V3. plan 감사와 run 감사는 캐시를 공유하지 않는다</h3>
+
+<div class="lead">
+  plan에서 문서 감사를 통과했는데 run에 들어가자마자 <b>또 감사를 받는지</b>를 확인했습니다.
+  run 쪽에는 “24시간 안에 같은 문서면 감사 생략” 캐시가 있는데, 이 캐시를 <b>누가 채우는지</b>가 관건이었습니다.
+</div>
+
+<table>
+  <tr><th>항목</th><th class="num">실측</th></tr>
+  <tr><td>스트림 A — plan 단계 감사 리포트 (<code>-review-N.md</code>)</td><td class="num">124건</td></tr>
+  <tr><td>스트림 B — run 게이트 감사 리포트 (<code>-YYYY-MM-DD.md</code>)</td><td class="num">60건</td></tr>
+  <tr><td>캐시 키(<code>plan_artifact_hash</code>) 보유 — B스트림</td><td class="num">7 / 60</td></tr>
+  <tr><td>캐시 키 보유 — A스트림</td><td class="num">4 / 124</td></tr>
+  <tr><td>실제 캐시 적중 <code>audit_cache_hit: true</code></td><td class="num">7건</td></tr>
+  <tr><td>캐시 불발 <code>audit_cache_hit: false</code></td><td class="num">3건</td></tr>
+</table>
+
+<p><code>plan-auditor</code>의 리포트 출력 서식에 <code>plan_artifact_hash</code> 필드가 <b>아예 없습니다</b>.
+그래서 plan에서 아무리 통과해도 run 쪽 캐시는 비어 있고, <b>run 진입 시 감사를 다시 받습니다.</b>
+현재 캐시는 “같은 run을 다시 돌릴 때”만 작동합니다.</p>
+
+<h2>4. 확정된 결함 3건</h2>
+
+<table>
+  <tr><th>ID</th><th>결함</th><th>근거 위치</th></tr>
+  <tr>
+    <td><b>D-1</b></td>
+    <td>재감사 범위가 문서 3곳 중 1곳에서 어긋남 — 2곳은 “바뀐 결함만”, 1곳은 “전체 재감사”</td>
+    <td><code>plan-auditor.md:375</code> · <code>run/phase-execution.md:162</code> ↔ <code>plan-auditor.md:392</code></td>
+  </tr>
+  <tr>
+    <td><b>D-2</b></td>
+    <td>팬아웃 10곳이 전부 <code>MAY</code>이고, 그 문장이 해당 단계에 들어가야만 읽히는 파일에 매몰됨</td>
+    <td><code>run.md:98-112</code> (서브스킬 on-demand 로딩)</td>
+  </tr>
+  <tr>
+    <td><b>D-3</b></td>
+    <td>10개 팬아웃 어디에도 발견을 <b>반증</b>하는 단계가 없음 — 전부 “증거 수집 → 판정”</td>
+    <td><code>sync-audit-4dim.js</code> 포함 전 지점</td>
+  </tr>
+</table>
+
+<div class="ex">
+  <div class="h">D-2가 왜 치명적인가 (원리)</div>
+  MoAI는 각 단계에 <b>진입한 뒤에야</b> 그 단계의 지침 파일을 읽습니다(<code>run.md:98-112</code>).
+  팬아웃을 쓸지 말지 판단할 근거가 그 파일 안에 있으므로 —
+  <pre>Phase 9 진입 → 파일 읽음 → "샤딩 해도 됩니다" 발견
+              → 그런데 이미 Phase 9 안이라 계획을 다시 짤 여지가 없음</pre>
+  준비는 됐는데 <b>제때 보이지 않아</b> 안 쓰이는 구조입니다.
+</div>
+
+<h2>5. 최종 업데이트 계획</h2>
+
+<div class="lead">
+  순서가 중요합니다. <b>M1은 문서만 고치는 작업이라 위험이 0</b>이고, 나머지 셋의 전제가 됩니다.
+  M1의 첫 항목(인덱스)을 두 번째 항목(승격)보다 먼저 하는 것도 같은 이유입니다 — 보이게 만든 뒤에 켜야 합니다.
+</div>
+
+<div class="ms">
+
+  <div class="m">
+    <h3>M1 — 활성화</h3>
+    <p class="tag">문서만 · 위험 0 · 새 코드 0줄</p>
+    <ol>
+      <li>팬아웃 인덱스 표를 <code>plan.md</code>/<code>run.md</code>/<code>sync.md</code> 라우터에 각 1개 추가 <b>(D-2 해소 전제)</b></li>
+      <li>팬아웃 10곳 <code>MAY</code> → 조건 충족 시 실행으로 승격 (기존 fail-open 폴백 문장 유지)</li>
+      <li><code>plan-auditor.md:392</code> 재감사 범위 모순 정정 <b>(D-1)</b></li>
+      <li>Tier 크기 예산 추가 — S: REQ/AC ≤ 8 · M: ≤ 16 · L: ≤ 25</li>
+    </ol>
+  </div>
+
+  <div class="m later">
+    <h3>M2 — 스냅샷 실효화</h3>
+    <p class="tag">문서 + CLI 판단 1건</p>
+    <ol>
+      <li>키 정책 결정 — 커밋으로 무효화되는 현행 키를 유지할지, <code>HEAD</code> 동일 + 작업트리 clean 조건에서만 완화할지</li>
+      <li>plan 팬아웃 렌즈 → <code>verify record</code> 훅 추가</li>
+      <li>run Section C 사전점검 → <code>verify check</code> 훅 추가 (재측정 금지)</li>
+      <li>run Phase 19 커밋 직후 재기록 훅 추가 (끊긴 sync 홉 복구)</li>
+    </ol>
+  </div>
+
+  <div class="m later">
+    <h3>M3 — 감사 구조 완성</h3>
+    <p class="tag">스크립트 1개 신설</p>
+    <ol>
+      <li><code>plan-audit-4dim.js</code> 신설 — <code>sync-audit-4dim.js</code> 복제 후 차원만 교체</li>
+      <li>필수통과 항목(MP-1~7)을 grep 배치로 선처리 — 에이전트 불필요</li>
+      <li>반증 단계를 공통 패턴으로 신설, blocking 등급에만 적용 <b>(D-3)</b></li>
+    </ol>
+  </div>
+
+  <div class="m later">
+    <h3>M4 — 감사 스트림 통합</h3>
+    <p class="tag">필드 추가만</p>
+    <ol>
+      <li><code>plan-auditor</code> 출력 서식에 <code>plan_artifact_hash</code> 필드 추가</li>
+      <li>plan Phase 11 통과 시 run 게이트 일자 리포트도 함께 기록 → run Phase 1 캐시 적중</li>
+    </ol>
+  </div>
+
+</div>
+
+<h2>6. 리스크</h2>
+
+<div class="risks">
+  <div class="risk">
+    <div class="rid">R-1</div>
+    <code>MAY</code>→실행 승격이 오케스트레이터의 판단 부담을 늘림
+    <div class="fix"><b>완화 —</b> M1-1(인덱스)을 M1-2(승격)보다 먼저 적용해, 판단 근거를 미리 보이게 함</div>
+  </div>
+  <div class="risk">
+    <div class="rid">R-2</div>
+    스냅샷 키 완화가 낡은 증거를 인용할 위험
+    <div class="fix"><b>완화 —</b> HEAD 동일 <b>AND</b> 작업트리 clean인 경우에만 허용</div>
+  </div>
+  <div class="risk">
+    <div class="rid">R-3</div>
+    반증 단계가 감사 라운드 비용을 늘림
+    <div class="fix"><b>완화 —</b> blocking 등급만 반증, optional 등급은 제외</div>
+  </div>
+  <div class="risk">
+    <div class="rid">R-4</div>
+    감사 스트림 통합이 두 리포트의 계약을 변경
+    <div class="fix"><b>완화 —</b> 필드 추가만 수행 — 기존 소비자에 영향 없음</div>
+  </div>
+</div>
+
+<h2>7. 성공 지표</h2>
+
+<div class="metric-row"><span class="dot unmet"></span><span>팬아웃 스크립트 실행 횟수</span><span class="now">현재 0</span><span class="tgt">목표 &gt; 0</span></div>
+<div class="metric-row"><span class="dot unmet"></span><span>스냅샷 파일 생성 + 적중 관측</span><span class="now">현재 0</span><span class="tgt">목표 ≥ 1</span></div>
+<div class="metric-row"><span class="dot unmet"></span><span>plan → run 감사 중복</span><span class="now">현재 기본 발생</span><span class="tgt">목표 0</span></div>
+<div class="metric-row"><span class="dot unmet"></span><span><code>plan-auditor.md</code> 재감사 모순</span><span class="now">현재 1건</span><span class="tgt">목표 0건</span></div>
+<div class="metric-row"><span class="dot unmet"></span><span>Tier L SPEC 요구사항 개수</span><span class="now">상한 없음 (관측 50)</span><span class="tgt">목표 ≤ 25</span></div>
+
+<h2>8. 아직 확인하지 못한 것</h2>
+
+<div class="gap">
+  <b>①</b> 인라인 <code>MAY</code> 8곳의 정확한 발동 횟수 — 기록 의무가 없어 키워드 흔적(shard 0 · drafter 2 · lens 8 · 4dim 2)이
+  <b>약한 증거</b>에 그칩니다. 정확한 집계는 트랜스크립트의 동시 스폰 패턴 분석이 필요합니다.<br>
+  <b>②</b> 스냅샷 키 완화의 안전성 — “HEAD 동일 + clean tree” 조건이 충분한지는 코드 레벨 검토를 하지 않았습니다.<br>
+  <b>③</b> M2-1은 CLI 동작 변경을 수반하므로 별도 SPEC 대상입니다.
+</div>
+
+<div class="selfcheck">
+  <h3>직접 확인해 보실 수 있는 것</h3>
+  <ul>
+    <li><b>팬아웃이 켜졌는지</b> — <code>ls .moai/state/verify/snapshots/</code>가 “디렉터리 없음”이 아니게 되면 M2가 작동 중입니다.</li>
+    <li><b>모순이 남았는지</b> — <code>grep -n "Full audit" .claude/agents/moai/plan-auditor.md</code>가 0건이면 D-1 해소.</li>
+    <li><b>인덱스가 붙었는지</b> — <code>grep -c "Fan-Out Index" .claude/skills/moai/workflows/*.md</code>가 3이면 M1-1 완료.</li>
+  </ul>
+</div>
+
+<footer>
+  MoAI-ADK · plan/run/sync pipeline audit · 2026-08-02<br>
+  본문 수치는 전부 실행된 명령의 출력이며, 추정치는 §8에 분리 기재했습니다.<br>
+  agent-context용 lean 사본: <code>.moai/reports/moai-pipeline-audit-20260802.md</code>
+</footer>
+
+</div>
+
+<script type="module">
+  import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+  mermaid.initialize({
+    startOnLoad: true,
+    theme: "base",
+    themeVariables: {
+      primaryColor:      "#FAF9F5",
+      primaryTextColor:  "#141413",
+      primaryBorderColor:"#D97757",
+      lineColor:         "#87867F",
+      secondaryColor:    "#E3DACC",
+      tertiaryColor:     "#F0EEE6"
+    }
+  });
+</script>
+</body>
+</html>

--- a/.moai/reports/mx-system-analysis-activation-20260804.html
+++ b/.moai/reports/mx-system-analysis-activation-20260804.html
@@ -1,0 +1,510 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MX 시스템 종합 분석 · 활성화 연구 — 2026-08-04</title>
+<style>
+  :root{
+    --bg:#faf8f5; --card:#ffffff; --ink:#2b2724; --muted:#6f6760;
+    --line:#e8e1d8; --coral:#cc785c; --coral-d:#b5644a; --coral-bg:#f7ede7;
+    --green:#5b8a6a; --amber:#c79a3a; --red:#b5544a; --blue:#4a6fa5;
+    --p0:#b5544a; --p1:#cc785c; --p2:#c79a3a; --p3:#6f6760;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);
+    font-family:"Pretendard","Pretendard Variable",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Apple SD Gothic Neo","Malgun Gothic",sans-serif;
+    line-height:1.7;font-size:15.5px;-webkit-font-smoothing:antialiased}
+  code,pre,.mono{font-family:"Goorm Sans Code","JetBrains Mono",ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:.9em}
+  .wrap{max-width:1080px;margin:0 auto;padding:0 28px 120px}
+  header.hero{background:linear-gradient(135deg,#2b2724 0%,#3a322c 100%);color:#f5efe9;padding:54px 0 46px;margin-bottom:0}
+  header.hero .wrap{padding:0 28px}
+  .eyebrow{color:var(--coral);font-size:.78rem;letter-spacing:.18em;text-transform:uppercase;font-weight:600;margin-bottom:10px}
+  h1{font-size:2.15rem;line-height:1.25;margin:0 0 14px;font-weight:800;letter-spacing:-.01em}
+  .hero .meta{color:#c4b9ad;font-size:.92rem;display:flex;flex-wrap:wrap;gap:8px 22px;margin-top:18px}
+  .hero .meta b{color:#f5efe9;font-weight:600}
+  .tldr{background:rgba(204,120,92,.14);border-left:3px solid var(--coral);padding:16px 20px;border-radius:0 8px 8px 0;margin-top:26px;font-size:.96rem}
+  .tldr b{color:#f0c9b8}
+  h2{font-size:1.5rem;margin:54px 0 6px;padding-top:28px;border-top:2px solid var(--line);font-weight:750;letter-spacing:-.01em}
+  h2:first-of-type{border-top:none;padding-top:0}
+  h2 .n{color:var(--coral);font-variant-numeric:tabular-nums}
+  h3{font-size:1.13rem;margin:30px 0 8px;font-weight:700}
+  h4{font-size:1rem;margin:22px 0 6px;font-weight:700;color:var(--coral-d)}
+  p{margin:8px 0}
+  ul,ol{margin:10px 0;padding-left:22px}
+  li{margin:5px 0}
+  .lead{color:var(--muted);font-size:.98rem;margin-top:0}
+  /* stat cards */
+  .stats{display:grid;grid-template-columns:repeat(4,1fr);gap:14px;margin:22px 0}
+  .stat{background:var(--card);border:1px solid var(--line);border-radius:10px;padding:16px 16px 14px}
+  .stat .v{font-size:1.85rem;font-weight:800;color:var(--coral);line-height:1;letter-spacing:-.02em;font-variant-numeric:tabular-nums}
+  .stat .l{font-size:.82rem;color:var(--muted);margin-top:7px;font-weight:500}
+  .stat .s{font-size:.72rem;color:var(--muted);margin-top:3px}
+  /* tables */
+  table{border-collapse:collapse;width:100%;margin:14px 0;font-size:.92rem;background:var(--card);border:1px solid var(--line);border-radius:8px;overflow:hidden}
+  th,td{padding:9px 13px;text-align:left;border-bottom:1px solid var(--line);vertical-align:top}
+  th{background:#f3ede6;font-weight:700;font-size:.84rem;color:#5a524b}
+  tr:last-child td{border-bottom:none}
+  td code,th code{background:#f3ede6;padding:1px 5px;border-radius:4px;font-size:.86em;color:var(--coral-d)}
+  td.num{font-variant-numeric:tabular-nums;text-align:right}
+  /* tag distribution bars */
+  .dist{margin:16px 0}
+  .dist-row{display:grid;grid-template-columns:110px 1fr 70px;align-items:center;gap:12px;margin:8px 0;font-size:.9rem}
+  .dist-row .lab{font-weight:600}
+  .dist-row .lab code{background:#f3ede6;padding:2px 7px;border-radius:5px;color:var(--coral-d)}
+  .bar{height:22px;background:#f0e9e1;border-radius:5px;overflow:hidden;position:relative}
+  .bar > span{display:block;height:100%;border-radius:5px;transition:width .4s}
+  .dist-row .cnt{font-variant-numeric:tabular-nums;text-align:right;color:var(--muted);font-weight:600}
+  .c-anchor{background:#4a6fa5}.c-note{background:#5b8a6a}.c-warn{background:#c79a3a}
+  .c-todo{background:#b5544a}.c-debt{background:#8a5cb5}.c-legacy{background:#6f6760}
+  /* cards */
+  .grid2{display:grid;grid-template-columns:1fr 1fr;gap:16px;margin:16px 0}
+  .card{background:var(--card);border:1px solid var(--line);border-radius:10px;padding:18px 20px}
+  .card h4{margin-top:0}
+  .card.ref{border-left:3px solid var(--coral)}
+  .card.ref .src{font-size:.8rem;color:var(--muted);margin-bottom:4px;font-weight:600}
+  .card.ref a{color:var(--coral-d);text-decoration:none;font-weight:600;word-break:break-word}
+  .card.ref a:hover{text-decoration:underline}
+  .tag{display:inline-block;font-size:.72rem;padding:2px 9px;border-radius:20px;font-weight:700;letter-spacing:.02em;margin-right:5px;vertical-align:middle}
+  .tag.acad{background:#e8eff7;color:#3a5a8a}.tag.ind{background:#e7f1ea;color:#3a6a4a}
+  .tag.bp{background:#f7ede7;color:var(--coral-d)}.tag.std{background:#f0e9f5;color:#6a4a8a}
+  /* verdict pills */
+  .pill{display:inline-block;padding:2px 10px;border-radius:14px;font-size:.78rem;font-weight:700}
+  .pill.good{background:#e7f1ea;color:#3a6a4a}.pill.warn{background:#faf2e0;color:#8a6a1a}
+  .pill.bad{background:#f7e7e5;color:#8a3a32}.pill.neutral{background:#eee8e0;color:#5a524b}
+  /* priority matrix */
+  .pri{display:grid;grid-template-columns:64px 1fr 110px 110px;gap:0;border:1px solid var(--line);border-radius:10px;overflow:hidden;margin:16px 0;background:var(--card)}
+  .pri-h{display:contents}
+  .pri-h > div{background:#f3ede6;font-weight:700;font-size:.8rem;padding:10px 14px;color:#5a524b}
+  .pri-r{display:contents}
+  .pri-r > div{padding:13px 14px;border-top:1px solid var(--line);font-size:.9rem}
+  .pri-lvl{font-weight:800;font-size:.95rem;text-align:center;display:flex;align-items:center;justify-content:center}
+  .lvl-p0{background:var(--p0);color:#fff}.lvl-p1{background:var(--p1);color:#fff}
+  .lvl-p2{background:var(--p2);color:#fff}.lvl-p3{background:var(--p3);color:#fff}
+  .impact-h,.impact-l{display:flex;align-items:center}
+  .dot{width:10px;height:10px;border-radius:50%;display:inline-block;margin-right:6px}
+  .callout{background:var(--coral-bg);border:1px solid #e8d5c9;border-radius:8px;padding:14px 18px;margin:16px 0;font-size:.93rem}
+  .callout.info{background:#eaf1f7;border-color:#cfdee9}
+  .quote{border-left:3px solid var(--coral);padding:4px 16px;color:#5a524b;font-style:italic;margin:14px 0;background:#f7f2ed;border-radius:0 6px 6px 0}
+  pre{background:#2b2724;color:#f0e9e1;padding:14px 16px;border-radius:8px;overflow-x:auto;font-size:.84rem;margin:12px 0}
+  pre .c{color:#c79a3a}.pre .k{color:#7aa6c9}
+  .footnote{font-size:.82rem;color:var(--muted);margin-top:6px}
+  .src-list{font-size:.85rem;color:var(--muted)}
+  .src-list li{margin:4px 0}
+  .src-list a{color:var(--coral-d)}
+  .check{color:var(--green);font-weight:700}.cross{color:var(--red);font-weight:700}
+  hr{border:none;border-top:1px solid var(--line);margin:34px 0}
+  .nav{position:sticky;top:0;background:rgba(250,248,245,.92);backdrop-filter:blur(8px);border-bottom:1px solid var(--line);padding:10px 0;z-index:10;font-size:.84rem}
+  .nav .wrap{padding:0 28px;display:flex;flex-wrap:wrap;gap:4px 18px}
+  .nav a{color:var(--muted);text-decoration:none;font-weight:600}
+  .nav a:hover{color:var(--coral)}
+  @media(max-width:760px){
+    .stats{grid-template-columns:repeat(2,1fr)}
+    .grid2{grid-template-columns:1fr}
+    .pri{grid-template-columns:50px 1fr;font-size:.84rem}
+    .pri-r .impact-h,.pri-r .impact-l,.pri-h .impact-h,.pri-h .impact-l{display:none}
+    h1{font-size:1.6rem}
+  }
+</style>
+</head>
+<body>
+
+<div class="nav"><div class="wrap">
+  <a href="#summary">요약</a><a href="#inventory">실체</a><a href="#diag">4축 진단</a>
+  <a href="#research">외부 자료</a><a href="#compare">표준 비교</a><a href="#proposals">개선 제안</a>
+  <a href="#ontology">온톨로지</a><a href="#conclusion">결론</a>
+</div></div>
+
+<header class="hero">
+  <div class="wrap">
+    <div class="eyebrow">MX TAG System · 종합 진단 + 활성화 연구</div>
+    <h1>@MX 태그 시스템: 전면 분석과 활성화를 위한 근거 연구</h1>
+    <div class="meta">
+      <span><b>대상:</b> moai-adk-go MX 시스템 전체</span>
+      <span><b>일자:</b> 2026-08-04</span>
+      <span><b>방법:</b> 코드·프로토콜·문서 전수 분석 + 외부 논문·BP·블로그 수집</span>
+    </div>
+    <div class="tldr">
+      <b>TL;DR —</b> MX는 "문서만 있는 프로토콜"이 아니라 <b>~4,500 LOC의 Go 구현체(scanner·validator·sidecar index·complexity 측정)</b>와 <b>1,567개 실제 태그</b>를 갖춘 활성 시스템이다. 설계 철학은 2026년 외부 표준(Brad Murry <i>Agent Annotation Standard</i>, Anthropic <i>context engineering</i>, 학계 <i>SATD</i> 연구)과 <b>정확히 정합</b>한다. 핵심 개선점은 기능 부재가 아니라 <b>① index 신선도 ② DEBT·TODO 과소태깅 ③ 배포 비대칭(mx.yaml 미배포)</b> 세 가지 운영 갭이다.
+    </div>
+  </div>
+</header>
+
+<div class="wrap">
+
+<section id="summary">
+<h2><span class="n">0.</span> 핵심 수치 한눈에 보기</h2>
+<p class="lead">모든 수치는 <code>moai mx query</code> 실측 · <code>grep</code> 전수 집계 · Explore 에이전트 인벤토리를 교차 검증한 값이다(2026-08-04 기준).</p>
+
+<div class="stats">
+  <div class="stat"><div class="v">1,567</div><div class="l">실제 @MX 태그</div><div class="s">419개 Go 파일 · grep 전수</div></div>
+  <div class="stat"><div class="v">803</div><div class="l">sidecar index 태그</div><div class="s">scan 2026-07-29 스냅샷</div></div>
+  <div class="stat"><div class="v">~4,500</div><div class="l">MX 전용 Go LOC</div><div class="s">internal/mx + hook/mx + cli</div></div>
+  <div class="stat"><div class="v">16</div><div class="l">지원 언어</div><div class="s">warn_patterns · comment map</div></div>
+</div>
+
+<h3>태그 유형별 분포 <span style="font-size:.78rem;color:var(--muted);font-weight:500">(index 기준)</span></h3>
+<div class="dist">
+  <div class="dist-row"><span class="lab"><code>@MX:NOTE</code></span><div class="bar"><span class="c-note" style="width:100%"></span></div><span class="cnt">385</span></div>
+  <div class="dist-row"><span class="lab"><code>@MX:ANCHOR</code></span><div class="bar"><span class="c-anchor" style="width:89%"></span></div><span class="cnt">343</span></div>
+  <div class="dist-row"><span class="lab"><code>@MX:WARN</code></span><div class="bar"><span class="c-warn" style="width:17%"></span></div><span class="cnt">65</span></div>
+  <div class="dist-row"><span class="lab"><code>@MX:DEBT</code></span><div class="bar"><span class="c-debt" style="width:1.3%"></span></div><span class="cnt">5</span></div>
+  <div class="dist-row"><span class="lab"><code>@MX:LEGACY</code></span><div class="bar"><span class="c-legacy" style="width:0.8%"></span></div><span class="cnt">3</span></div>
+  <div class="dist-row"><span class="lab"><code>@MX:TODO</code></span><div class="bar"><span class="c-todo" style="width:0.5%"></span></div><span class="cnt">2</span></div>
+</div>
+<p class="footnote">sub-line 집계(grep, 프로덕션 Go non-test): <code>@MX:REASON</code> 464 · <code>@MX:SPEC</code> 57 · <code>@MX:UPGRADE</code> 10 · <code>@MX:CEILING</code> 2 · <code>[AUTO]</code> 접두사 광범위 사용.</p>
+</section>
+
+<section id="inventory">
+<h2><span class="n">1.</span> MX 시스템 실체 — 인벤토리</h2>
+<p class="lead">MX는 단순한 주석 규칙이 아니라 <b>프로토콜 계층 + 기계적 구현 계층</b>의 이중 구조다. 아래는 전체 구성요소다.</p>
+
+<table>
+<tr><th>계층</th><th>구성요소</th><th>규모</th><th>역할</th></tr>
+<tr><td rowspan="2"><b>프로토콜</b></td><td><code>mx-tag-protocol.md</code></td><td>205줄</td><td>SSOT — 5 타입 + 7 sub-key, lifecycle, per-file limits, 언어별 주석 문법</td></tr>
+<tr><td><code>references/mx-tag.md</code> + <code>workflows/mx.md</code></td><td>124 + 251줄</td><td>BNF 문법, fan-in 측정법, 3-Pass scan 파이프라인, 16언어 탐지표</td></tr>
+<tr><td rowspan="4"><b>Go 구현</b></td><td><code>internal/mx/</code></td><td>13파일 ~3,200 LOC</td><td>scanner, tag model, sidecar manager, fan-in(LSP+textual), danger-category, spec-association</td></tr>
+<tr><td><code>internal/hook/mx/</code></td><td>8파일 ~1,300 LOC</td><td>PostToolUse validator + complexity 측정(tree-sitter CGO 경로)</td></tr>
+<tr><td><code>internal/cli/mx*.go</code></td><td>3파일</td><td><code>moai mx scan</code> / <code>moai mx query</code> 하위명령</td></tr>
+<tr><td><code>internal/web/mx_rawview</code></td><td>테스트 포함</td><td>웹 콘솔 MX raw-view 핸들러</td></tr>
+<tr><td rowspan="2"><b>설정·산출</b></td><td><code>mx.yaml</code></td><td>258줄</td><td>16언어 warn_patterns, 임계값(fan_in:3, complexity:15), limits, danger_categories</td></tr>
+<tr><td><code>.moai/state/mx-index.json</code></td><td>303 KB / 803태그</td><td>sidecar index(<code>moai mx query</code>가 읽음)</td></tr>
+<tr><td><b>SPEC</b></td><td>SPEC-MX-001 / SPEC-V3R2-SPC-004</td><td>2건</td><td>MX-001(template-only 원설계) → V3R2-SPC-004(Go 구현 추가)</td></tr>
+<tr><td><b>문서</b></td><td>docs-site 4개국어 · README 4개국어</td><td>—</td><td><code>advanced/mx-tags.md</code>(개념) + <code>utility-commands/moai-mx.md</code>(명령)</td></tr>
+</table>
+
+<div class="callout info">
+<b>검증 포인트</b> — SPEC-MX-001의 <code>plan.md</code>는 "template-only, No Go source code changes required"라고 선언했지만, 실제로는 후속 SPEC(<code>SPEC-V3R2-SPC-004</code>)이 ~4,500 LOC의 Go 구현을 추가했다. <b>SPEC 설계 의도와 산출물 사이에 간극</b>이 있다(§2.4에서 재검토).
+</div>
+</section>
+
+<section id="diag">
+<h2><span class="n">2.</span> 4축 종합 진단</h2>
+<p class="lead">프로토콜 · CLI·scanner · 태그 커버리지 · 문서·배포 네 축으로 나눠 현 상태와 개선점을 진단한다.</p>
+
+<h3>2.1 프로토콜 축 <span class="pill good">견고</span></h3>
+<p><code>mx-tag-protocol.md</code>는 단일 SSOT로 타입·생명주기·제한·문법을 일관되게 정의한다. 특히 <code>@MX:DEBT</code>의 <b>CEILING + UPGRADE 트리플릿</b>과 <b>"UPGRADE 없으면 rotRisk"</b> 규칙은 단순 주석 규칙을 넘어 자체 정정 메커니즘이다.</p>
+<ul>
+  <li><span class="check">강점:</span> DEBT는 TODO와 명확히 구분됨(완료된 코드의 의도적 단순화 vs 미완료 작업). 자동 승격(WARN) 규칙이 DEBT엔 적용되지 않아 <b>거짓 위험 신호를 차단</b>.</li>
+  <li><span class="cross">갭:</span> <code>note_per_file: 10</code>, <code>todo_per_file: 5</code> 한도가 <code>mx.yaml</code>엔 있으나 <b>프로토콜 본문엔 누락</b> — 문서·설정 간 미세 드리프트.</li>
+  <li><span class="cross">갭:</span> broken SPEC link → <code>@MX:LEGACY</code> 전환 규칙(<code>references/mx-tag.md</code>)이 있으나, 실제 LEGACY 태그가 3개뿐이라 규칙이 실제 작동했는지 검증 부족.</li>
+</ul>
+
+<h3>2.2 CLI · scanner 축 <span class="pill good">구현 풍부</span> <span class="pill warn">복잡도 주의</span></h3>
+<p><code>moai mx scan</code>은 한 패스에 <code>.moai/state/mx-index.json</code>을 빌드하고, <code>moai mx query</code>가 이를 읽어 <code>--kind</code>, <code>--danger</code>, <code>--fan-in-min</code>, <code>--spec</code>, <code>--since</code> 필터로 조회한다.</p>
+<ul>
+  <li><span class="check">강점:</span> DEBT rotRisk가 <b>실제로 동작</b>함을 검증(<code>scanner_debt_test.go:57</code> → <code>"rotRisk":"no-trigger"</code> 출력). LSP 기반 fan-in + textual fallback 이중 경로로 환경 의존성 흡수.</li>
+  <li><span class="cross">갭 (P0):</span> <b>index 신선도</b> — grep 전수 1,567태그 vs index 803태그 = <b>764개 누락</b>. 마지막 scan이 2026-07-29로, 그 후 추가된 태그가 index에 반영되지 않았다. <code>moai mx query</code>가 stale index를 반환하면 rotRisk·fan-in 신호가 왜곡된다.</li>
+  <li><span class="cross">갭 (P2):</span> <code>internal/mx/resolver.go</code>가 "placeholder for full fan-in per SPC-004"로 표시 — 일부 해석 경로 미완료. CGO tree-sitter 의존성(complexity 측정)이 빌드 복잡도를 높임(<code>measure_nocgo.go</code> 폴백 존재).</li>
+  <li><span class="cross">갭 (P2):</span> <code>internal/astgrep/</code> analyzer가 validator에 "currently unused"로 주석 표시 — 연동 미흡.</li>
+</ul>
+
+<h3>2.3 태그 커버리지 · 품질 축 <span class="pill bad">과소태깅</span></h3>
+<p>가장 뚜렷한 개선 기회다. ANCHOR(343)·NOTE(385)는 풍부하지만 <b>TODO(2)·DEBT(5)는 극단적으로 부족</b>하다.</p>
+<ul>
+  <li><b>SATD 연구 대비 과소:</b> 학계 연구(arXiv 2601.06266)는 LLM 생성 코드의 <b>SATD(self-admitted technical debt) 빈도가 85→90%</b>라고 보고한다. 419개 파일에 DEBT 1개(프로덕션 non-test)는 실제 부채 규모와 심하게 불일치 — <b>태깅이 현실을 반영하지 못함</b>.</li>
+  <li><b>DEBT sub-line 불일치:</b> <code>@MX:UPGRADE</code> 10개 vs <code>@MX:CEILING</code> 2개(grep). DEBT-CEILING-UPGRADE 트리플릿이 깨진 경우가 대부분 → rotRisk 후보 다수. 실측 index의 DEBT 5개 중 4개가 test fixture이므로 <b>프로덕션 DEBT 사실상 1개</b>(<code>internal/config/cache_config.go</code>, CEILING/UPGRADE 없음 → rot).</li>
+  <li><b>SPEC 연결 약함:</b> <code>spec_associations</code> 85/803 = <b>10.6%</b>. <code>@MX:SPEC</code> sub-line이 있어도 연결되지 않은 태그가 다수.</li>
+  <li><span class="check">긍정:</span> <code>@MX:REASON</code> 464개 — WARN/ANCHOR 필수 필수 필드가 잘 준수됨(강제 메커니즘 작동).</li>
+</ul>
+
+<h3>2.4 문서 · 배포 축 <span class="pill good">품질 양호</span> <span class="pill warn">배포 비대칭</span></h3>
+<p>docs-site 4개국어 페이지(<code>advanced/mx-tags.md</code> 개념 + <code>utility-commands/moai-mx.md</code> 명령)는 구조화·현지화가 잘 돼 있다.</p>
+<ul>
+  <li><span class="cross">갭 (P1) — 배포 비대칭:</span> MX 프로토콜(규칙·스킬·명령)은 template로 배포되지만 <b><code>mx.yaml</code>은 repo-local only</b>(template tree에 없음). 외부 사용자는 16언어 warn_patterns·임계값·danger_categories 없이 MX를 사용하게 된다. Go scanner는 <code>moai</code> binary에 내장되어 배포되지만, <b>config 없이는 기본값으로만 동작</b>.</li>
+  <li><span class="cross">갭 (P2) — 문서 미설명:</span> scanner 고급 기능(rotRisk 산출 로직, LSP fan-in 작동 조건, CGO complexity 경로)이 docs-site에 설명되지 않음. README FAQ "왜 모든 함수에 @MX 태그가 없나요?"는 있으나, <b>scan 자동화 시점·index 갱신 주기</b>는 미기술.</li>
+  <li><span class="check">강점:</span> CHANGELOG에 실제 <code>@MX:ANCHOR → @MX:NOTE</code> 강등 보정 사례(SPEC-HOOK-TRACE-FLUSH-001, 허위 fan_in=24 → 실측 0)가 기록되어 있어 <b>프로토콜이 스스로에게 적용됨(self-dogfood)</b>을 입증.</li>
+</ul>
+</section>
+
+<section id="research">
+<h2><span class="n">3.</span> 외부 자료 — 코드 주석 설계 × 에이전트 코드 이해 교차점</h2>
+<p class="lead">MX가 두 영역(코드에 맥락을 새기는 접근 + 에이전트가 코드를 탐색하는 접경)의 교차점에 있다는 전제로, 4개 카테고리의 근거를 수집했다. 모든 URL은 2026-08-04에 접근을 검증했다.</p>
+
+<h3>3.1 In-context annotation 계열 — MX의 직접 동류</h3>
+<div class="grid2">
+  <div class="card ref">
+    <div class="src">블로그 · 2026-01 · <span class="tag std">표준 제안</span></div>
+    <h4><a href="https://bradmurry.com/software/ai-annotations/" target="_blank" rel="noopener">AI Annotations: Embedding Context in Your Codebase — Brad Murry</a></h4>
+    <p><code>@!</code> 접두사로 semantic metadata를 코드에 직접 내장하는 <b>Agent Annotation Standard</b> 제안. Toon Format 속성(JSON/YAML보다 간결), inline + block(<code>@!begin</code>/<code>@!end</code>) 문법. 핵심 keys: <code>readonly</code>, <code>link</code>, <code>todo</code>, <code>canon</code>, <code>metadata</code>.</p>
+    <p class="footnote"><b>MX와의 관계:</b> 거의 동일 철학("annotate once, every agent benefits" · git-versioned · in-source synchronization). MX가 <b>타입화 + lifecycle rule + sidecar index</b>로 더 정교함(§4 비교표).</p>
+  </div>
+  <div class="card ref">
+    <div class="src">블로그 · <span class="tag ind">산업</span></div>
+    <h4><a href="https://www.verdent.ai/guides/llm-knowledge-base-coding-agents" target="_blank" rel="noopener">LLM Knowledge Base for Coding Agents: Beyond RAG — Verdent</a></h4>
+    <p>전통적 RAG를 넘어 코딩 에이전트가 <b>세션 간 맥락을 누적</b>하는 knowledge base 패턴. MX sidecar index가 "코드에 내장된 knowledge base"로 기능하는 방식과 정합.</p>
+  </div>
+</div>
+
+<h3>3.2 Context engineering — just-in-time retrieval × progressive disclosure</h3>
+<div class="grid2">
+  <div class="card ref">
+    <div class="src">Anthropic Engineering · <span class="tag bp">권위 BP</span></div>
+    <h4><a href="https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents" target="_blank" rel="noopener">Effective context engineering for AI agents — Anthropic</a></h4>
+    <p>context engineering = "최소의 고신호 토큰 집합을 큐레이션". <b>just-in-time retrieval</b>(가벼운 식별자로 runtime에 동적 로드)과 <b>progressive disclosure</b>(탐색을 통한 점진적 발견)가 핵심. Claude Code는 CLAUDE.md를 up-front, glob/grep을 just-in-time으로 사용.</p>
+    <p class="footnote"><b>MX 정합:</b> <code>@MX</code> 주석은 "synchronized in-source context", <code>moai mx query</code>는 "just-in-time retrieval"(파일 경로라는 가벼운 식별자로 sidecar에서 동적 로드) — Anthropic이 설명하는 하이브리드 모델 그 자체.</p>
+  </div>
+  <div class="card ref">
+    <div class="src">Martin Fowler · <span class="tag bp">BP</span></div>
+    <h4><a href="https://martinfowler.com/articles/exploring-gen-ai/context-engineering-coding-agents.html" target="_blank" rel="noopener">Context Engineering for Coding Agents — Martin Fowler</a></h4>
+    <p>코딩 에이전트에 API·도구 접근을 언제·어떻게 열어줄지, 맥락을 어떻게 구조화할지에 대한 심층 가이드.</p>
+  </div>
+</div>
+<p class="footnote">참고: <a href="https://arxiv.org/html/2508.08322v1" target="_blank" rel="noopener">Context Engineering for Multi-Agent LLM Code Assistants (arXiv 2508.08322)</a> · <a href="https://rhonabwy.com/2026/02/15/navigation-notes-agentic-coding/" target="_blank" rel="noopener">Navigation Notes – Agentic Coding</a> · <a href="https://sourcegraph.com/blog/lessons-from-building-ai-coding-assistants-context-retrieval-and-evaluation" target="_blank" rel="noopener">Sourcegraph — Context Retrieval & Evaluation</a></p>
+
+<h3>3.3 RACG · codebase indexing — sidecar index의 학술 근거</h3>
+<div class="grid2">
+  <div class="card ref">
+    <div class="src">논문 서베이 · arXiv 2510.04905 · <span class="tag acad">학술</span></div>
+    <h4><a href="https://arxiv.org/html/2510.04905v1" target="_blank" rel="noopener">Retrieval-Augmented Code Generation: A Survey (2025)</a></h4>
+    <p>repository-level code generation을 위한 RACG 연구 종합 서베이. 코드베이스 인덱싱·검색 전략의 학술적 기준점.</p>
+  </div>
+  <div class="card ref">
+    <div class="src">도구 · MCP 통합 · <span class="tag ind">산업</span></div>
+    <h4><a href="https://docs.rs/project-rag" target="_blank" rel="noopener">project_rag — Rust library + MCP server</a></h4>
+    <p>RAG 기반 semantic code search의 MCP 서버 구현. 에이전트 프레임워크에 플러그인 가능 — MX sidecar query와 유사한 인터페이스 패턴.</p>
+  </div>
+</div>
+<p class="footnote">참고: <a href="https://cocoindex.io/blogs/index-code-base-for-rag/" target="_blank" rel="noopener">CocoIndex — Real-Time Codebase Indexing (tree-sitter)</a> · <a href="https://github.com/rawveg/code-rag" target="_blank" rel="noopener">code-rag — semantic code search</a> · <a href="https://github.com/codefuse-ai/awesome-code-llm" target="_blank" rel="noopener">Awesome Code LLM (TMLR)</a></p>
+
+<h3>3.4 SATD — <code>@MX:DEBT</code> 태그의 학술 근거 <span class="tag acad">핵심</span></h3>
+<p>MX의 DEBT 태그 설계는 <b>self-admitted technical debt(SATD)</b> 연구 라인과 정확히 정합한다. 이는 MX 설계의 가장 강력한 학술 뒷받침이다.</p>
+<div class="grid2">
+  <div class="card ref">
+    <div class="src">논문 · arXiv 2601.06266 · <span class="tag acad">학술</span></div>
+    <h4><a href="https://arxiv.org/html/2601.06266v1" target="_blank" rel="noopener">Self-Admitted Technical Debt in LLM Software (2025)</a></h4>
+    <p>LLM 시대 SATD 최초 실증 연구. <b>SATD 빈도가 ML/non-ML 코드 대비 LLM 코드에서 85→90%로 상승</b>. MX DEBT 태깅 과소(1개)는 이 연구가 예측하는 실제 부채 규모와 불일치.</p>
+  </div>
+  <div class="card ref">
+    <div class="src">논문 · ACM 3756681.3756976 · <span class="tag acad">학술</span></div>
+    <h4><a href="https://dl.acm.org/doi/full/10.1145/3756681.3756976" target="_blank" rel="noopener">Technical Debt Across LLM Systems — Aljohani et al. (2025)</a></h4>
+    <p>LLM 특화 SATD의 기원·빈도·완화 전략 대규모 실증.</p>
+  </div>
+  <div class="card ref">
+    <div class="src">논문 · ScienceDirect · <span class="tag acad">학술</span></div>
+    <h4><a href="https://www.sciencedirect.com/science/article/pii/S0950584925002010" target="_blank" rel="noopener">SALA — LLM-based SATD Classification (Fontana et al. 2025)</a></h4>
+    <p>LLM 기반 binary·다중클래스 SATD 탐지. <b>fine-tuned LLM이 전통 text-mining을 크게 상회</b> → MX scanner가 자동 DEBT 탐지를 강화할 근거.</p>
+  </div>
+  <div class="card ref">
+    <div class="src">논문 · TU Delft · <span class="tag acad">학술</span></div>
+    <h4><a href="https://repository.tudelft.nl/file/File_3e2c9abd-0903-47f7-9a83-d55dc0ae425a" target="_blank" rel="noopener">Impact of SATD on LLM Code Completion</a></h4>
+    <p>The Heap(Java 500만 파일) 기반 — SATD가 <b>LLM 코드 생성 성능을 측정가능하게 저하</b>시킴 → 부채 태깅·관리가 에이전트 품질에 직결됨.</p>
+  </div>
+</div>
+<p class="footnote">추가: <a href="https://posl.ait.kyushu-u.ac.jp/~kamei/publications/Sierra_JSS2019.pdf" target="_blank" rel="noopener">Sierra et al. — A Survey of SATD (JSS 2019)</a> · <a href="https://arxiv.org/html/2502.08172v1" target="_blank" rel="noopener">Intention Is All You Need (arXiv 2502.08172)</a> · <a href="https://www.zhiqiangqiao.com/blog/documentation-and-comments/" target="_blank" rel="noopener">The Theory of Layered Documentation</a></p>
+</section>
+
+<section id="compare">
+<h2><span class="n">4.</span> MX vs Agent Annotation Standard — 표준 비교</h2>
+<p class="lead">Brad Murry의 <code>@!</code> 표준(2026-01)은 MX와 가장 가까운 독립 제안이다. 두 접근을 비교해 MX의 설계 위치를 확인한다.</p>
+
+<table>
+<tr><th>차원</th><th>MX TAG (<code>@MX:</code>)</th><th>Agent Annotation Standard (<code>@!</code>)</th><th>평가</th></tr>
+<tr><td><b>접두사</b></td><td><code>@MX:TYPE:</code></td><td><code>@!key value</code></td><td>MX가 더 엄격(타입 강제)</td></tr>
+<tr><td><b>태그 의미론</b></td><td>5 타입(NOTE/WARN/ANCHOR/TODO/DEBT) + 7 sub-key</td><td>범용 key-value(readonly/todo/canon/metadata…)</td><td>MX가 <b>생명주기·강제 필드</b>로 더 정교</td></tr>
+<tr><td><b>속성 형식</b></td><td>sub-line(<code>@MX:REASON:</code> 등)</td><td>Toon Format <code>(k: v)</code></td><td>@!가 한 줄에 더 간결; MX는 가독성 중시</td></tr>
+<tr><td><b>기계적 도구</b></td><td><code>moai mx scan/query</code> sidecar index + validator</td><td>Python parser 예시만(표준 레지스트리 미정)</td><td><b>MX가 도구ing 선순위</b> (실측·rotRisk 산출)</td></tr>
+<tr><td><b>자동 승격/강등</b></td><td>TODO→WARN(3회 미해결), ANCHOR 강등(fan_in&lt;3), DEBT rotRisk</td><td>없음(정적 주석)</td><td>MX만 <b>자체 정정 메커니즘</b></td></tr>
+<tr><td><b>범용성</b></td><td>MoAI 생태계 결합</td><td>언어·도구 독립</td><td>@!가 이식성 우위</td></tr>
+</table>
+<div class="callout">
+<b>결론:</b> MX는 "단순 주석 표준"이 아니라 <b>타입화 + 생명주기 + 기계적 sidecar + 자체 정정</b>을 갖춘 <b>도구-지원 annotation 시스템</b>이다. 외부 표준(@!) 대비 <b>기능적 우위</b>가 명확하며, 설계 철학은 Anthropic context engineering·SATD 연구와 정합한다. 즉 <b>MX는 이미 업계·학계 흐름의 선두에 있는 설계</b>다.
+</div>
+</section>
+
+<section id="proposals">
+<h2><span class="n">5.</span> 개선 제안 — 우선순위 매트릭스</h2>
+<p class="lead">사용자 선택(보고서 후 선택 반영)에 대비해, 개선을 영향도×비용으로 우선순위화했다. P0는 "낮은 비용·높은 영향"의 빠른 승리다.</p>
+
+<div class="pri">
+  <div class="pri-h"><div>우선</div><div>개선 항목</div><div class="impact-h">영향</div><div class="impact-l">비용</div></div>
+
+  <div class="pri-r">
+    <div class="pri-lvl lvl-p0">P0</div>
+    <div><b>index 신선도 자동화</b> — grep 1,567 vs index 803(764 누락). SessionStart 또는 PostToolUse 후 <code>moai mx scan</code> 자동 트리거, 또는 <code>query</code> 시 mtime 기반 lazy re-scan. <span class="footnote">근거: Anthropic just-in-time retrieval — stale index는 신호 왜곡.</span></div>
+    <div class="impact-h"><span class="dot" style="background:var(--red)"></span>높음</div>
+    <div class="impact-l"><span class="dot" style="background:var(--green)"></span>낮음</div>
+  </div>
+
+  <div class="pri-r">
+    <div class="pri-lvl lvl-p0">P0</div>
+    <div><b>DEBT rot 실제 처리</b> — <code>cache_config.go</code> DEBT에 CEILING/UPGRADE 보강 또는 제거. 프로덕션 DEBT 사실상 1개이므로 즉시 해결 가능. <span class="footnote">근거: SATD rot — UPGRADE 없는 DEBT는 조용히 부패.</span></div>
+    <div class="impact-h"><span class="dot" style="background:var(--red)"></span>높음</div>
+    <div class="impact-l"><span class="dot" style="background:var(--green)"></span>낮음</div>
+  </div>
+
+  <div class="pri-r">
+    <div class="pri-lvl lvl-p1">P1</div>
+    <div><b>mx.yaml 배포 비대칭 해소</b> — template tree에 <code>mx.yaml.tmpl</code> 추가(또는 binary 기본값 내장). 외부 사용자가 16언어 warn_patterns·임계값 없이 MX를 쓰는 문제. <span class="footnote">template neutrality 가드(C1-C8) 준수 필요.</span></div>
+    <div class="impact-h"><span class="dot" style="background:var(--red)"></span>높음</div>
+    <div class="impact-l"><span class="dot" style="background:var(--amber)"></span>중간</div>
+  </div>
+
+  <div class="pri-r">
+    <div class="pri-lvl lvl-p1">P1</div>
+    <div><b>TODO/DEBT 과소태깅 해소</b> — SATD 빈도(85-90%) 대비 DEBT 1개·TODO 2개. 태깅 가이드라인 강화 또는 자동 탐지(salad/sala 접근) 도입 검토. <span class="footnote">근거: arXiv 2601.06266 LLM-SATD 빈도.</span></div>
+    <div class="impact-h"><span class="dot" style="background:var(--coral)"></span>중간</div>
+    <div class="impact-l"><span class="dot" style="background:var(--amber)"></span>중간</div>
+  </div>
+
+  <div class="pri-r">
+    <div class="pri-lvl lvl-p1">P1</div>
+    <div><b>SPEC 연결 강화</b> — <code>spec_associations</code> 10.6%(85/803). <code>@MX:SPEC</code> sub-line이 있어도 연결 누락. <code>spec_association.go</code> 검증·자동 연결 강화.</div>
+    <div class="impact-h"><span class="dot" style="background:var(--coral)"></span>중간</div>
+    <div class="impact-l"><span class="dot" style="background:var(--amber)"></span>중간</div>
+  </div>
+
+  <div class="pri-r">
+    <div class="pri-lvl lvl-p2">P2</div>
+    <div><b>프로토콜-설정 드리프트 정합</b> — <code>note_per_file</code>/<code>todo_per_file</code> 한도가 프로토콜 본문에 누락. <code>mx-tag-protocol.md</code> ↔ <code>mx.yaml</code> 단일 원천 통일.</div>
+    <div class="impact-h"><span class="dot" style="background:var(--amber)"></span>낮음</div>
+    <div class="impact-l"><span class="dot" style="background:var(--green)"></span>낮음</div>
+  </div>
+
+  <div class="pri-r">
+    <div class="pri-lvl lvl-p2">P2</div>
+    <div><b>SPEC-MX-001 현실화</b> — "no Go changes" 선언 vs 실제 ~4,500 LOC Go 구현. SPEC 산출물 기준 업데이트 또는 V3R2-SPC-004로 승계 명시.</div>
+    <div class="impact-h"><span class="dot" style="background:var(--amber)"></span>낮음</div>
+    <div class="impact-l"><span class="dot" style="background:var(--green)"></span>낮음</div>
+  </div>
+
+  <div class="pri-r">
+    <div class="pri-lvl lvl-p2">P2</div>
+    <div><b>scanner 고급 기능 문서화</b> — rotRisk 산출, LSP fan-in 조건, CGO complexity 경로, scan 자동화 시점을 docs-site에 추가. README FAQ 보강.</div>
+    <div class="impact-h"><span class="dot" style="background:var(--coral)"></span>중간</div>
+    <div class="impact-l"><span class="dot" style="background:var(--amber)"></span>중간</div>
+  </div>
+
+  <div class="pri-r">
+    <div class="pri-lvl lvl-p3">P3</div>
+    <div><b>@! 표준 상호운용성 검토(선택)</b> — Brad Murry <code>@!</code> 표준과의 매핑·마이그레이션 경로 문서화. 생태계 확장 시 고려.</div>
+    <div class="impact-h"><span class="dot" style="background:var(--amber)"></span>낮음</div>
+    <div class="impact-l"><span class="dot" style="background:var(--coral)"></span>높음</div>
+  </div>
+
+  <div class="pri-r">
+    <div class="pri-lvl lvl-p3">P3</div>
+    <div><b>성능·복잡도 경감</b> — scanner.go(399 LOC) 분할, LSP+textual 이중 fan-in 단순화, astgrep analyzer 연동 완료 또는 제거. 장기 개편.</div>
+    <div class="impact-h"><span class="dot" style="background:var(--amber)"></span>낮음</div>
+    <div class="impact-l"><span class="dot" style="background:var(--red)"></span>높음</div>
+  </div>
+</div>
+</section>
+
+<section id="ontology">
+<h2><span class="n">6.</span> 추가 축 — 온톨로지(Ontology) 도입 검토</h2>
+<p class="lead">사용자 제안으로 탐색한 추가 방향. MX 태그 체계를 <b>의미론적 온톨로지</b>로 발전시키는 가능성을, 기회·위험·진화 경로로 검토했다.</p>
+
+<h3>6.1 MX의 현재 의미론적 위치</h3>
+<p>메타데이터 체계는 일반적으로 <b>controlled vocabulary → taxonomy → ontology → knowledge graph</b> 스펙트럼을 따라 성숙한다. MX의 현재 위치:</p>
+<table>
+<tr><th>단계</th><th>정의</th><th>MX 해당 여부</th></tr>
+<tr><td><b>Controlled vocabulary</b></td><td>통제된 용어 집합</td><td><span class="pill good">해당</span> NOTE/WARN/ANCHOR/TODO/DEBT 5 타입</td></tr>
+<tr><td><b>Taxonomy</b></td><td>계층 분류 + 속성</td><td><span class="pill good">해당</span> sub-key(SPEC/REASON/CEILING/UPGRADE), lifecycle 단계, priority P1-P5</td></tr>
+<tr><td><b>Ontology</b></td><td>개체·관계·제약의 형식 모델</td><td><span class="pill neutral">부분</span> fan-in 관계·강등 규칙은 있으나, 태그 간 시맨틱 관계·계층 미형식화</td></tr>
+<tr><td><b>Knowledge graph</b></td><td>그래프 구조 + 추론</td><td><span class="pill warn">미해당</span> sidecar index는 flat 태그 목록(JSON), 그래프·추론 없음</td></tr>
+</table>
+<p class="footnote">결론: MX는 <b>taxonomy 상단 ~ ontology 하단</b>에 위치. 온톨로지 도입은 "새 기능 추가"가 아니라 "이미 어렴풋이 있는 의미론을 형식화"하는 방향이다.</p>
+
+<h3>6.2 온톨로지 도입 스펙트럼 (3단계)</h3>
+<div class="grid2">
+  <div class="card">
+    <h4>A. Lightweight relation layer <span class="pill good">권장 후보</span></h4>
+    <p>태그 간 시맨틱 관계와 계층만 sidecar index에 추가. <b>RDF/OWL 스택 없이</b> 기존 JSON 확장.</p>
+    <ul>
+      <li>관계 필드: <code>implies</code>(WARN→주의), <code>demotes_to</code>(ANCHOR→NOTE), <code>relates</code>(SPEC↔태그)</li>
+      <li>계층: <code>Risk</code> 상위 타입 아래 <code>WARN</code>/<code>DEBT</code>, <code>Intent</code> 아래 <code>NOTE</code>/<code>ANCHOR</code></li>
+      <li>검증: "정의되지 않은 규칙" 탐지 (DLT Hub: taxonomy가 verification bar를 높임)</li>
+    </ul>
+    <p class="footnote">비용: 중간 · 영향: 높음 · MX 단순성 보존</p>
+  </div>
+  <div class="card">
+    <h4>B. Formal ontology (OWL 경량)</h4>
+    <p>OWL/Turtle로 MX 타입·관계를 형식화. 추론 엔진(DLV, HermiT) 옵션.</p>
+    <ul>
+      <li>MX 타입 → OWL class, sub-key → property</li>
+      <li>추론: "UPGRADE 없는 DEBT → rotRisk"를 OWL 규칙으로 인코딩 (이미 scanner가 함 → 이중화)</li>
+    </ul>
+    <p class="footnote">비용: 높음 · 영향: 중간 · <b>이미 scanner가 추론을 수행 중이므로 중복 위험</b></p>
+  </div>
+</div>
+<div class="card" style="margin-top:14px">
+  <h4>C. Full knowledge graph + GraphRAG <span class="pill warn">장기</span></h4>
+  <p>코드 엔티티(함수·클래스·모듈·SPEC)를 노드, 호출·의존·태깅을 엣지로 하는 코드 지식 그래프 구축. Neo4j 등 그래프 DB + GraphRAG로 에이전트 검색.</p>
+  <p class="footnote">비용: 매우 높음(신규 스택) · 영향: 잠재 큼 · 현재 MX의 "in-source + grep/query" 단순성과 <b>철학 충돌</b>(Anthropic: smallest set of high-signal tokens). 별도 대규모 SPEC 필요.</p>
+</div>
+
+<h3>6.3 외부 근거</h3>
+<div class="grid2">
+  <div class="card ref">
+    <div class="src">논문 · arXiv 2505.14394 · <span class="tag acad">학술</span></div>
+    <h4><a href="https://arxiv.org/html/2505.14394v1" target="_blank" rel="noopener">Knowledge Graph Based Repository-Level Code Generation (2025)</a></h4>
+    <p>코드베이스를 지식 그래프로 표현해 LLM이 <b>컨벤션에 정합한 코드</b>를 생성. MX sidecar → 코드 KG 진화의 직접 근거.</p>
+  </div>
+  <div class="card ref">
+    <div class="src">논문 · arXiv 2604.00555 · <span class="tag acad">학술</span></div>
+    <h4><a href="https://arxiv.org/html/2604.00555v5" target="_blank" rel="noopener">Neurosymbolic 3-Layer Ontology (Role/Domain/Interaction)</a></h4>
+    <p>LLM 에이전트 grounding을 위한 3층 온톨로지. 패턴매칭과 도메인 정확 추론 사이 시맨틱 갭 해소.</p>
+  </div>
+  <div class="card ref">
+    <div class="src">Semantic Web Journal · <span class="tag acad">학술</span></div>
+    <h4><a href="https://www.semantic-web-journal.net/system/files/swj3871.pdf" target="_blank" rel="noopener">Agentic AI for Ontology Grounding (Sadruddin et al. 2025)</a></h4>
+    <p>LLM이 발견한 스키마를 형식 온톨로지에 grounding — <b>taxonomy→ontology 진화 경로</b>의 모델.</p>
+  </div>
+  <div class="card ref">
+    <div class="src">블로그 · <span class="tag bp">BP</span></div>
+    <h4><a href="https://dlthub.com/blog/ontology-engineering" target="_blank" rel="noopener">Ontology Engineering — DLT Hub</a></h4>
+    <p><b>taxonomy가 verification bar를 높인다</b> — LLM이 미정의 규칙을 탐지·거부. MX가 이미 taxonomy로 이 역할을 부분 수행 중.</p>
+  </div>
+</div>
+<p class="footnote">참고: <a href="https://enterprise-knowledge.com/ontology-and-knowledge-graph-in-the-age-of-ai-and-agents/" target="_blank" rel="noopener">Enterprise Knowledge — Ontology & KG in the Age of AI Agents</a> · <a href="https://deepsense.ai/resource/ontology-driven-knowledge-graph-for-graphrag/" target="_blank" rel="noopener">deepsense.ai — Ontology-Driven KG for GraphRAG</a> · <a href="https://neo4j.com/videos/going-meta-s03e07-a-series-on-semantics-knowledge-graphs-and-all-things-ai/" target="_blank" rel="noopener">Neo4j Going Meta — Agent Skills for Ontologies</a> · <a href="https://en.wikipedia.org/wiki/Web_Ontology_Language" target="_blank" rel="noopener">OWL — Wikipedia</a></p>
+
+<div class="callout">
+<b>균형 잡힌 평가 (push back 포함).</b> 온톨로지 도입은 매력적이지만 <b>세 가지 경고</b>가 있다: (1) MX의 현재 가치는 "in-source 주석 + grep/query"라는 <b>극단적 단순성</b>에 있고, Anthropic context engineering 원칙("smallest set of high-signal tokens")과 정합한다 — 무거운 온톨로지 스택은 이를 훼손할 수 있다. (2) scanner가 이미 rotRisk·강등 등 "추론"을 수행 중이므로, OWL 추론 엔진은 <b>중복</b>이다. (3) RDF/OWL 도입은 새 의존성·학습곡선·유지비를 발생시킨다. <br><br>
+<b>실용적 추천:</b> 온톨로지로의 점프(C)보다 <b>단계 A(lightweight relation layer)</b> — sidecar index에 관계 필드·계층만 추가해 검증 능력을 높이되, MX의 단순성·grep 친화성은 보존. 형식 OWL(B)과 코드 KG(C)는 A의 가치가 입증된 후 별도 SPEC으로.
+</div>
+</section>
+
+<section id="conclusion">
+<h2><span class="n">7.</span> 결론 및 다음 단계</h2>
+
+<div class="callout info">
+<b>핵심 결론.</b> MX는 과소평가된 시스템이다. 외부에서는 "주석 규칙 정도"로 보일 수 있으나, 실제로는 <b>타입화된 annotation + 생명주기 엔진 + sidecar index + 자체 정정(강등/rotRisk) + 16언어 scanner</b>를 갖춘 도구-지원 시스템이다. 설계 철학은 2026년 외부 표준(Brad Murry <code>@!</code>, Anthropic context engineering)과 학계 SATD·RACG 연구와 정합하며, 기능적 우위까지 보유한다. <b>MX는 "활성화가 필요한 미완 프로토콜"이 아니라 "이미 선두에 있으나 운영 갭이 있는 성숙 시스템"</b>이다.
+</div>
+
+<h3>활성화를 위한 3가지 즉시 실행점</h3>
+<ol>
+  <li><b>신호 신뢰성 확보(P0):</b> index 신선도 자동화 + DEBT rot 처리 — <code>moai mx query</code>가 항상 최신·정확한 신호를 반환하도록. 이것이 MX "활성화"의 전제 조건이다.</li>
+  <li><b>현실 반영(P1):</b> TODO/DEBT 과소태깅 해소 + SPEC 연결 강화 — 태그 분포가 실제 부채·의존성 규모를 반영하도록. SATD 연구가 예측하는 빈도에 근접.</li>
+  <li><b>배포 완결성(P1):</b> mx.yaml template 배포 — 외부 사용자가 16언어 설정 없이 MX를 쓰는 갭을 메움. 분산 일관성 확보.</li>
+</ol>
+
+<h3>다음 단계</h3>
+<p>본 보고서는 <b>분석 + 외부 근거 + 우선순위 제안</b>까지를 산출한다(사용자 선택: 보고서 후 선택 반영). 후속으로 <code>AskUserQuestion</code> 게이트에서 반영할 항목을 선택받은 뒤, 승인된 범위만 <b>SPEC 주기(또는 직접 수정)</b>로 반영한다. P0 두 건은 단일 커밋·단일 세션으로 즉시 해결 가능한 빠른 승리다.</p>
+
+<hr>
+<p class="footnote"><b>방법론:</b> 본 보고서의 모든 수치는 <code>moai mx query --format json</code> 실측 + <code>grep</code> 전수 집계 + Explore 에이전트 인벤토리를 교차 검증했다. 외부 자료 URL은 2026-08-04에 접근을 검증했다. verification-claim-integrity: 추정치가 아닌 관측값만을 주장으로 사용했다.</p>
+
+<h3>Sources</h3>
+<ul class="src-list">
+  <li><a href="https://bradmurry.com/software/ai-annotations/" target="_blank" rel="noopener">bradmurry.com — AI Annotations (Agent Annotation Standard)</a></li>
+  <li><a href="https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents" target="_blank" rel="noopener">anthropic.com — Effective context engineering for AI agents</a></li>
+  <li><a href="https://martinfowler.com/articles/exploring-gen-ai/context-engineering-coding-agents.html" target="_blank" rel="noopener">martinfowler.com — Context Engineering for Coding Agents</a></li>
+  <li><a href="https://www.verdent.ai/guides/llm-knowledge-base-coding-agents" target="_blank" rel="noopener">verdent.ai — LLM Knowledge Base for Coding Agents</a></li>
+  <li><a href="https://arxiv.org/html/2508.08322v1" target="_blank" rel="noopener">arXiv 2508.08322 — Context Engineering for Multi-Agent LLM Code Assistants</a></li>
+  <li><a href="https://arxiv.org/html/2510.04905v1" target="_blank" rel="noopener">arXiv 2510.04905 — Retrieval-Augmented Code Generation: A Survey</a></li>
+  <li><a href="https://docs.rs/project-rag" target="_blank" rel="noopener">docs.rs — project_rag (MCP server)</a></li>
+  <li><a href="https://arxiv.org/html/2601.06266v1" target="_blank" rel="noopener">arXiv 2601.06266 — Self-Admitted Technical Debt in LLM Software</a></li>
+  <li><a href="https://dl.acm.org/doi/full/10.1145/3756681.3756976" target="_blank" rel="noopener">ACM — Technical Debt Across LLM Systems (Aljohani et al. 2025)</a></li>
+  <li><a href="https://www.sciencedirect.com/science/article/pii/S0950584925002010" target="_blank" rel="noopener">ScienceDirect — SALA: LLM-based SATD Classification</a></li>
+  <li><a href="https://repository.tudelft.nl/file/File_3e2c9abd-0903-47f7-9a83-d55dc0ae425a" target="_blank" rel="noopener">TU Delft — Impact of SATD on LLM Code Completion</a></li>
+  <li><a href="https://arxiv.org/html/2502.08172v1" target="_blank" rel="noopener">arXiv 2502.08172 — Intention Is All You Need</a></li>
+  <li><a href="https://posl.ait.kyushu-u.ac.jp/~kamei/publications/Sierra_JSS2019.pdf" target="_blank" rel="noopener">JSS 2019 — A Survey of Self-Admitted Technical Debt</a></li>
+  <li><a href="https://cocoindex.io/blogs/index-code-base-for-rag/" target="_blank" rel="noopener">cocoindex.io — Real-Time Codebase Indexing</a></li>
+  <li><a href="https://sourcegraph.com/blog/lessons-from-building-ai-coding-assistants-context-retrieval-and-evaluation" target="_blank" rel="noopener">sourcegraph.com — Context Retrieval & Evaluation</a></li>
+</ul>
+</section>
+
+</div>
+</body>
+</html>

--- a/.moai/specs/SPEC-CONFIG-DEAD-SWEEP-001/acceptance.md
+++ b/.moai/specs/SPEC-CONFIG-DEAD-SWEEP-001/acceptance.md
@@ -1,0 +1,96 @@
+# Acceptance — SPEC-CONFIG-DEAD-SWEEP-001
+
+## §D. AC Matrix
+
+| AC ID | REQ | Severity | Summary |
+|-------|-----|----------|---------|
+| AC-CDS-001 | REQ-CDS-003 | MUST | cache.yaml removed from local + template |
+| AC-CDS-002 | REQ-CDS-003 | MUST | LoadCacheConfig removed; CacheConfig struct removed if orphaned |
+| AC-CDS-003 | REQ-CDS-004 | MUST | research.yaml removed from local + template |
+| AC-CDS-004 | REQ-CDS-004 | MUST | cfg.Research loader + Research field removed |
+| AC-CDS-005 | REQ-CDS-005 | MUST | state_dir key + State.StateDir field removed; hardcoded literal unchanged |
+| AC-CDS-006 | REQ-CDS-003 | MUST | ValidSessionTTLs still resolves the TTL list for the web seam |
+| AC-CDS-007 | REQ-CDS-007 | MUST | go build ./... && go test ./... exit 0 |
+| AC-CDS-008 | REQ-CDS-007 | MUST | moai update still merges remaining sections (smoke test) |
+| AC-CDS-009 | REQ-CDS-008 | MUST | template-neutrality-check CI green |
+| AC-CDS-010 | REQ-CDS-006 | SHOULD | stale comments at loader.go:345 and audit_registry.go:75 corrected |
+
+## §D.1 AC Definitions (Given-When-Then)
+
+### AC-CDS-001 — cache.yaml removed
+**Given** the template source tree and the local project,
+**When** a search runs for `cache.yaml` under `internal/template/templates/.moai/config/sections/` and `.moai/config/sections/`,
+**Then** neither path exists.
+
+### AC-CDS-002 — LoadCacheConfig + CacheConfig removed
+**Given** the post-removal source tree,
+**When** `grep -rn "LoadCacheConfig\|CacheConfig\b" internal/ cmd/ pkg/ | grep -v _test.go` runs,
+**Then** zero matches (excluding the ValidSessionTTLs stub, which MUST NOT reference the CacheConfig type).
+
+### AC-CDS-003 — research.yaml removed
+**Given** the template source tree and the local project,
+**When** a search runs for `research.yaml` under both config/sections paths,
+**Then** neither path exists.
+
+### AC-CDS-004 — Research loader + field removed
+**Given** the post-removal source tree,
+**When** `grep -rEn "cfg\.Research|researchFileWrapper" internal/ cmd/ pkg/ | grep -v _test.go` runs,
+**Then** zero matches. (The `ResearchConfig` type alternative is dropped from the pattern: the type itself MAY remain if referenced elsewhere — a residual type reference is not a death signal for the loader+field removal.)
+
+### AC-CDS-005 — state_dir field removed, literal preserved
+**Given** the post-removal source tree,
+**When** `grep -n "StateDir" internal/config/types.go internal/config/defaults.go` runs,
+**Then** the `State.StateDir` field and its default-population line are absent;
+**And when** `grep -n "\.moai/state" internal/cli/state.go internal/worktree/state_guard.go` runs,
+**Then** the hardcoded literal `.moai/state` is still present in both files (SSOT preserved);
+**And when** `grep -rn "cfg\.State\.StateDir\|\.State\.StateDir" internal/ cmd/ pkg/ | grep -v _test.go` runs,
+**Then** zero matches.
+
+### AC-CDS-006 — ValidSessionTTLs still resolves the TTL list
+**Given** the post-extraction source tree,
+**When** the test that calls `config.ValidSessionTTLs()` runs — located at run-phase via `grep -rn 'ValidSessionTTLs' --include='*_test.go' internal/` (known callers today: `internal/config/cache_config_test.go::TestValidSessionTTLs` and `internal/settings/schema_sections_test.go` which asserts session_ttl option parity against `config.ValidSessionTTLs()`) —
+**Then** the test still passes, confirming the TTL select options populate (non-empty list returned by `config.ValidSessionTTLs()`). The pass predicate is the green test run, not a fixed test name.
+
+### AC-CDS-007 — build + test green
+**Given** the post-removal source tree,
+**When** `go build ./...` runs,
+**Then** exit 0;
+**And when** `go test ./...` runs,
+**Then** exit 0.
+
+### AC-CDS-008 — moai update smoke test
+**Given** a `/tmp/test-project` initialized from the rebuilt template,
+**When** `moai update` runs against the project,
+**Then** exit 0;
+**And** the remaining section files (e.g., `quality.yaml`, `language.yaml`, `system.yaml`, `ralph.yaml`) are present and merged correctly (no error about missing `cache.yaml` / `research.yaml`).
+
+### AC-CDS-009 — template-neutrality CI green
+**Given** the PR is open against main,
+**When** the `template-neutrality-check.yaml` workflow runs,
+**Then** exit 0 (deleted template files trivially pass; no new content-class violations introduced).
+
+### AC-CDS-010 — stale comments corrected
+**Given** the post-fix source tree,
+**When** `sed -n '345p' internal/config/loader.go` runs,
+**Then** the line no longer contains "Legacy sub-system" and instead describes `learning` as live (consumed at cli/hook.go:551-1106);
+**And when** `sed -n '75p' internal/config/audit_registry.go` runs,
+**Then** the line no longer contains "no Go loader yet" and instead reads "partial direct-read".
+
+## §D.2 Severity Definitions
+
+- **MUST** — blocks run-phase completion; failure aborts the run.
+- **SHOULD** — fixed in the same PR if cheap; otherwise recorded as `@MX:DEBT` with a follow-up SPEC.
+
+## §D.3 Indirect Verification
+
+- `golangci-lint run` exit code is NOT a load-bearing AC (repo carries baseline warnings); recorded as a sanity check, not a gate.
+- The `ValidSessionTTLs` web-settings test may not exist as a named `TestSchema*`; run-phase must locate the actual test that exercises the dropdown (grep `ValidSessionTTLs` call sites in `_test.go`).
+
+## §D.4 Closure Gate
+
+All MUST ACs MUST be PASS. The run-phase §E.2 evidence block MUST cite the verbatim command + output for each AC (verification-claim-integrity.md §2).
+
+## §D.5 Forward-Looking Checks
+
+- After merge, `moai spec audit` MUST classify this SPEC as `era_final: true` (V3R6, 3-phase close) — not grandfather.
+- A follow-up SPEC may be opened if the grep at §D.1 AC-CDS-005 reveals a previously-hidden reader of `cfg.State.StateDir` post-merge (defensive; not expected).

--- a/.moai/specs/SPEC-CONFIG-DEAD-SWEEP-001/plan.md
+++ b/.moai/specs/SPEC-CONFIG-DEAD-SWEEP-001/plan.md
@@ -1,0 +1,104 @@
+# Plan — SPEC-CONFIG-DEAD-SWEEP-001
+
+## §A. Context
+
+Three dead non-ralph config surfaces are removed in a behavior-preserving sweep. Evidence verified 2026-08-04 via grep across `internal/`, `cmd/`, `pkg/` (non-test). The ralph half of the sweep is owned by `SPEC-RALPH-CONFIG-REDESIGN-001` (§H of spec.md).
+
+**One reversal-likely design decision is lead-loaded into M2** (state_dir option a vs b). Mechanical removals are deferred to M3-M4.
+
+## §B. Known Issues
+
+- **ValidSessionTTLs is live.** The task brief said "remove LoadCacheConfig/ValidSessionTTLs" but `internal/settings/schema_sections.go:328` consumes `config.ValidSessionTTLs()` for the web settings dropdown. **Resolution:** extract `ValidSessionTTLs` to a standalone constant slice (or a smaller stub file) so the seam stays live; delete only `LoadCacheConfig`, the `CacheConfig` struct, and the file-loading registration. This is a deviation from the brief's literal "remove ValidSessionTTLs" wording, taken on the evidence.
+- **`loader.go:345` "learning is legacy" comment is wrong.** Verified: `learning` is LIVE at `internal/cli/hook.go:551-1106`. Fix the comment, do not remove the sub-system.
+- **`audit_registry.go:75` observability comment is wrong.** Verified: `observability_master.go:85` reads `enabled` live. Fix to "partial direct-read".
+
+## §C. Pre-flight (before M1)
+
+- Confirm no new consumers of `cfg.Research`, `cfg.State.StateDir`, or `LoadCacheConfig` have landed since 2026-08-04 (re-run the grep at run-phase start — `feedback_defect_claim_verification.md`).
+- Confirm `make build` baseline is green.
+- Confirm `go test ./...` baseline is green.
+
+## §D. Constraints
+
+- Template-First: `internal/template/templates/.moai/config/sections/` edited first, `make build`, local sync.
+- `ValidSessionTTLs` extraction MUST land in the same commit as the cache_config.go slim-down (no intermediate broken state).
+- No behavior change to `moai update`, `moai web`, statusline, or `findStateDir()`.
+
+## §E. Self-Verification (plan-phase)
+
+- [ ] SPEC ID regex PASS (executed at authoring: `SPEC-CONFIG-DEAD-SWEEP-001` matched `^SPEC(-[A-Z][A-Z0-9]*)+-[0-9]{3}$`).
+- [ ] Frontmatter 12 canonical fields present.
+- [ ] Out of Scope section carries ≥1 `### Out of Scope — <topic>` H3 with `-` bullets.
+- [ ] Every REQ uses a GEARS pattern (Ubiquitous / When / Where).
+- [ ] Every AC in acceptance.md is Given-When-Then and binary-testable.
+- [ ] No implementation detail (function names are cited as evidence, not prescribed as design).
+
+## §F. Milestones
+
+### M1 — Template-First deletion of cache.yaml + research.yaml
+
+- Delete `internal/template/templates/.moai/config/sections/cache.yaml`.
+- Delete `internal/template/templates/.moai/config/sections/research.yaml`.
+- Run `make build` to regenerate the embedded FS.
+- Verify the catalog/manifest (if section files are registered in a catalog) no longer references them; if it does, remove the registration.
+
+### M2 — state_dir design decision (option a) + removal
+
+**Decision: option (a) — remove the dead field, keep the hardcoded literal as SSOT.**
+
+Tradeoff documented:
+- **Option (a) (chosen):** smallest diff; `findStateDir()` and `state_guard.go` already hardcode `.moai/state/` and that is the de-facto SSOT. Cost: the YAML key disappears, so any user who set `state.state_dir` to a custom path silently loses that knob (but it never worked anyway — zero readers).
+- **Option (b) (rejected):** wire `findStateDir()` and `state_guard.go` to read from `cfg.State.StateDir`. Higher risk (changes runtime path resolution), more code, and only useful if there is evidence users want a custom state dir — none found.
+
+Concrete changes:
+- `internal/config/types.go:562` — remove `StateDir string yaml:"state_dir"` from the `StateConfig` struct.
+- `internal/config/defaults.go:620` — remove the `StateDir: DefaultStateDir,` line.
+- `internal/config/defaults.go:150` — keep `DefaultStateDir` constant IF other code reads it; otherwise remove. (Run-phase grep for `DefaultStateDir` consumers decides.)
+- `internal/template/templates/.moai/config/sections/state.yaml` — remove the `state_dir:` key line.
+- `.moai/config/sections/state.yaml` (local) — same.
+- `internal/cli/state.go:210-211` and `internal/worktree/state_guard.go:25` — UNCHANGED (hardcoded literal stays as SSOT).
+
+### M3 — Slim cache_config.go (extract ValidSessionTTLs)
+
+- Create or inline a standalone constant slice for the TTL options (e.g., in `internal/config/cache_config.go` as a package-level `var validSessionTTLs = [...]string{...}` exposed via `ValidSessionTTLs()`). The accessor MUST survive.
+- Remove `LoadCacheConfig` (cache_config.go:136), the `CacheConfig` struct type if orphaned after ValidSessionTTLs extraction, and any file-loader registration.
+- Remove `internal/template/templates/.moai/config/sections/cache.yaml` (already in M1).
+- Remove `.moai/config/sections/cache.yaml` (local).
+- Remove the `cache` section entry from any loader map (e.g., `loader.go` section-file registration if present).
+
+### M4 — Remove research.yaml loader + types
+
+- `internal/config/loader.go:277-284` — remove the `researchFileWrapper` load + writeback.
+- `internal/config/types.go` — remove the `Research` field from the root `Config` struct (and the `ResearchConfig` type if orphaned).
+- `internal/config/defaults.go` — remove the `Research:` default initialization if present.
+- Remove `.moai/config/sections/research.yaml` (local).
+- Remove the `research` row from `internal/template/templates/.claude/rules/moai/core/settings-management.md` (the settings-management doc enumerates section files).
+- Remove the `cache` and `research` rows from the same doc if they were listed.
+
+### M5 — Stale comment fixes (fold-in)
+
+- `internal/config/loader.go:345` — change "Legacy sub-system (out-of-scope)" to "Live sub-system — consumed at internal/cli/hook.go:551-1106".
+- `internal/config/audit_registry.go:75` — change "no Go loader yet" to "partial direct-read (observability_master.go:85 reads `enabled` live)".
+
+### M6 — Verify
+
+- `go build ./...` exits 0.
+- `go test ./...` exits 0.
+- `golangci-lint run` exits 0 (or baseline warnings unchanged).
+- Re-run the grep trio to confirm zero remaining readers of removed symbols.
+- `moai update` smoke test on a `/tmp/test-project` — confirm remaining sections merge cleanly.
+
+## §G. Anti-Patterns
+
+- **AP-1: blanket delete ValidSessionTTLs** — would silently empty the web settings dropdown. Forbidden.
+- **AP-2: edit local before template** — violates Template-First (CLAUDE.local.md §2).
+- **AP-3: remove `learning` because the stale comment said "legacy"** — the comment is wrong; `learning` is LIVE. Only the comment is fixed.
+- **AP-4: cross into ralph.yaml** — collision with `SPEC-RALPH-CONFIG-REDESIGN-001`. Stay in the three named files.
+- **AP-5: skip `make build` after template edits** — embedded FS goes stale; the deleted files would still ship in the binary.
+
+## §H. Cross-References
+
+- `acceptance.md` — AC-CDS-001..010.
+- `SPEC-RALPH-CONFIG-REDESIGN-001/plan.md` — the ralph half; sequence or isolate.
+- `feedback_defect_claim_verification.md` — re-run the grep at run-phase start.
+- `CLAUDE.local.md` §2 (Template-First), §25 (Template Internal-Content Isolation).

--- a/.moai/specs/SPEC-CONFIG-DEAD-SWEEP-001/progress.md
+++ b/.moai/specs/SPEC-CONFIG-DEAD-SWEEP-001/progress.md
@@ -1,0 +1,17 @@
+# Progress — SPEC-CONFIG-DEAD-SWEEP-001
+
+## §E.1 Plan-phase Audit-Ready Signal
+
+_status: plan-phase artifacts authored 2026-08-04; awaiting plan-auditor verdict._
+
+## §E.2 Run-phase Evidence
+
+_<pending run-phase>_
+
+## §E.3 Run-phase Audit-Ready Signal
+
+_<pending run-phase>_
+
+## §E.4 Sync-phase Audit-Ready Signal
+
+_<pending sync-phase>_

--- a/.moai/specs/SPEC-CONFIG-DEAD-SWEEP-001/spec.md
+++ b/.moai/specs/SPEC-CONFIG-DEAD-SWEEP-001/spec.md
@@ -1,0 +1,138 @@
+---
+id: SPEC-CONFIG-DEAD-SWEEP-001
+title: "Remove dead non-ralph config (cache.yaml, research.yaml, state.state_dir) with zero Go runtime consumers"
+version: 0.1.0
+status: draft
+created: 2026-08-04
+updated: 2026-08-04
+author: manager-spec
+priority: P1
+phase: "v3.x target"
+module: config-dead-sweep
+lifecycle: spec-first
+tags: "dead-config, cache-yaml, research-yaml, state-dir, template-neutrality, config-honesty"
+tier: S
+related_specs: [SPEC-RALPH-CONFIG-REDESIGN-001, SPEC-CONFIG-KEY-HONESTY-001]
+---
+
+# SPEC-CONFIG-DEAD-SWEEP-001 — Remove dead non-ralph config (cache/research/state_dir)
+
+## HISTORY
+
+- 2026-08-04 — Initial draft. Codifies the non-ralph half of the dead-config sweep identified during the ralph.yaml redesign investigation. ralph.yaml keys (including `stale_seconds`) are owned by `SPEC-RALPH-CONFIG-REDESIGN-001` — the two SPECs partition the dead-config space so run-phases do not collide on `ralph.yaml`. Cross-reference added in §H.
+
+## §A. User Story
+
+**As a** MoAI user editing `.moai/config/sections/*.yaml` files expecting my edits to take effect,
+**I want** the dead config files and keys that have ZERO Go runtime consumers removed from both the local project and the distributed template,
+**so that** the configuration surface is honest — every YAML key a user can edit is actually read by running code, and the template no longer ships misleading knobs.
+
+**Outcome hypotheses:**
+- The verification-claim-integrity hazard ("users edit a file expecting effect") is eliminated for the three named dead surfaces.
+- Template shrinks by 2 dead section files (`cache.yaml`, `research.yaml`) and 1 dead key (`state.state_dir`).
+- `LoadCacheConfig` orphan code and the `cfg.Research`/`cfg.State.StateDir` dead fields are removed, reducing reader cognitive load and lint noise.
+
+## §B. Context and Background
+
+Investigation across `internal/`, `cmd/`, `pkg/` (grep, non-test) established three dead non-ralph config surfaces. Each is documented with its evidence below.
+
+### §B.1 `cache.yaml` — orphaned loader
+
+`internal/config/cache_config.go:15-29` carries an explicit `@MX:DEBT` marker:
+
+> `LoadCacheConfig now has no caller. Only ValidSessionTTLs survives, consumed by the moai web settings seam for the session_ttl select options; cache.yaml itself round-trips through that seam without any code acting on its values.`
+
+The cache_control injector that once consumed this file was removed (moai does not own the API call path; see `cache-aware-execution.md`). The file exists in BOTH:
+- Local: `.moai/config/sections/cache.yaml`
+- Template: `internal/template/templates/.moai/config/sections/cache.yaml`
+
+**Live sub-surface:** `ValidSessionTTLs()` (cache_config.go:76) IS consumed by `internal/settings/schema_sections.go:328` for the web settings dropdown. This accessor MUST be preserved (or extracted to a standalone constant) — removing it would break the web settings seam. Everything else in cache_config.go (`LoadCacheConfig`, the `CacheConfig` struct, the file loader registration) is dead.
+
+### §B.2 `research.yaml` — zero consumers
+
+`internal/config/loader.go:277` loads the file into `cfg.Research` via a `researchFileWrapper`, but the `Research` field has ZERO runtime readers across Go and agent code (`budget_cap_tokens` / `target_score` are unused). Local + template files both exist.
+
+### §B.3 `state.state_dir` — dead field, hardcoded constant is the SSOT
+
+`internal/config/types.go:562` carries `StateDir string yaml:"state_dir"`. A grep across `internal/`, `cmd/`, `pkg/` for any reader of the field value (`cfg.State.StateDir` / `.State.StateDir`) returned ZERO matches. The actual path resolution is:
+- `internal/cli/state.go:210-211` — `findStateDir()` walks up the tree looking for the hardcoded literal `.moai/state/`.
+- `internal/worktree/state_guard.go:25` — hardcodes `StateDirRel=".moai/state"`.
+- `internal/config/defaults.go:150` — `DefaultStateDir = ".moai/state"` constant (used only to populate the dead field at `defaults.go:620`).
+
+**Design decision (see plan.md §F M2):** Option (a) — remove the `state_dir` key from `state.yaml` + the `cfg.State.StateDir` field + its default-population line. Keep the hardcoded literal in `findStateDir()`/`state_guard.go` as the SSOT. Tradeoff documented in plan.md.
+
+### §B.4 Stale comment fixes (fold-in)
+
+Two comments actively mislead readers and contradict the verified liveness of their targets:
+- `internal/config/loader.go:345` marks `learning` as "Legacy sub-system (out-of-scope)" but it is LIVE — consumed at `internal/cli/hook.go:551-1106`.
+- `internal/config/audit_registry.go:75` says observability="no Go loader yet" but `internal/config/observability_master.go:85` reads the `enabled` key live — should read "partial direct-read".
+
+## §C. Requirements (GEARS)
+
+### REQ-CDS-001 (Ubiquitous)
+The MoAI config loader shall expose only configuration keys that have at least one live Go runtime consumer (read by non-test code in `internal/`, `cmd/`, or `pkg/`).
+
+### REQ-CDS-002 (Ubiquitous)
+The MoAI distributed template (`internal/template/templates/.moai/config/sections/`) shall not ship YAML section files whose entire content has zero runtime effect.
+
+### REQ-CDS-003 (Event-detected)
+**When** `LoadCacheConfig` has no caller and `cache.yaml` has no runtime consumer, the maintainer shall remove the `cache.yaml` file (local + template), the `LoadCacheConfig` function, the `CacheConfig` struct type if orphaned, and any loader registration, while preserving `ValidSessionTTLs()` (extracting it to a standalone constant if needed) because it is consumed by the web settings seam at `internal/settings/schema_sections.go:328`.
+
+### REQ-CDS-004 (Event-detected)
+**When** `cfg.Research` has zero runtime readers across Go and agent code, the maintainer shall remove the `research.yaml` file (local + template), the `Research` loader code at `internal/config/loader.go:277-284`, and the `Research` field/type if orphaned.
+
+### REQ-CDS-005 (Event-detected)
+**When** `cfg.State.StateDir` has zero runtime readers and the path is hardcoded as the literal `.moai/state/` in `findStateDir()` and `state_guard.go`, the maintainer shall remove the `state_dir` key from `state.yaml`, the `State.StateDir` field at `internal/config/types.go:562`, and its default-population at `internal/config/defaults.go:620`, while leaving the hardcoded literal as the single source of truth.
+
+### REQ-CDS-006 (Ubiquitous)
+The maintainer shall correct the two stale comments: `loader.go:345` (`learning` is LIVE, consumed at `cli/hook.go:551-1106`) and `audit_registry.go:75` (observability is "partial direct-read" via `observability_master.go:85`, not "no Go loader yet").
+
+### REQ-CDS-007 (Capability gate)
+**Where** the project is rebuilt after removal, `go build ./...` and `go test ./...` shall both exit 0, and `moai update` shall continue to merge the remaining sections correctly (RestoreMoaiConfig unaffected).
+
+### REQ-CDS-008 (Capability gate)
+**Where** `template-neutrality-check.yaml` CI guard runs, the removed template files shall not leave behind any forbidden content class (internal SPEC IDs, REQ tokens, commit SHAs) — either cleanly deleted or verified clean before deletion.
+
+## §D. Constraints
+
+- **Template-First:** edits to `internal/template/templates/.moai/config/sections/` happen in the template source first, then `make build` regenerates the embedded FS, then the local copy is synced.
+- **No behavior change:** the user-visible behavior of `moai update`, `moai web`, the statusline cache-hit signal, and `findStateDir()` MUST be unchanged.
+- **`ValidSessionTTLs` is load-bearing:** removing it would break the web settings seam — extraction (not deletion) is mandatory.
+- **Non-ralph scope only:** this SPEC MUST NOT touch `ralph.yaml` or any ralph.* key — that surface is owned by `SPEC-RALPH-CONFIG-REDESIGN-001`.
+
+## §E. Out of Scope
+
+### Out of Scope — ralph.yaml and all ralph.* keys
+
+- `ralph.yaml` (local + template) — owned by `SPEC-RALPH-CONFIG-REDESIGN-001`.
+- `ralph.stale_seconds`, `Session.StaleSeconds`, the stale_seconds injection pipeline — all ralph.yaml keys are out of scope here.
+
+### Out of Scope — deeper state_dir redesign
+
+- Wiring `findStateDir()` to read from `cfg.State.StateDir` (option (b) in the design decision) is out of scope; the smaller option (a) is chosen.
+
+### Out of Scope — usage-log migration
+
+- Migrating any consumer to read from `cfg.State.StateDir` if one is discovered post-removal is a follow-up concern, not part of this sweep.
+
+### Out of Scope — other dead-config surfaces not listed
+
+- Any dead config surface other than cache.yaml, research.yaml, and state.state_dir is out of scope (e.g., dead workflow.yaml keys, dead harness.yaml keys). Each deserves its own SPEC.
+
+## §F. Acceptance Criteria Summary
+
+See `acceptance.md` for the full AC matrix (AC-CDS-001 through AC-CDS-010). Every AC maps to a REQ above and is Given-When-Then binary-testable.
+
+## §G. Risks
+
+- **ValidSessionTTLs breakage:** if the extraction is botched, the web settings dropdown empties. Mitigation: AC-CDS-006 asserts the seam still resolves the TTL list after extraction.
+- **Hidden reader of state_dir:** a reader not caught by the grep (e.g., reflectively, or in a vendor path) would regress. Mitigation: AC-CDS-007 asserts `go build ./...` and `go test ./...` green post-removal.
+- **Template-neutrality CI regression:** the removed template files might carry SPEC IDs in comments. Mitigation: AC-CDS-009 asserts the CI guard is green; deleted files trivially pass.
+
+## §H. Cross-References
+
+- **`SPEC-RALPH-CONFIG-REDESIGN-001`** — owns the ralph half of this dead-config sweep. Run-phases of the two SPECs are partitioned: this SPEC touches only `cache.yaml`/`research.yaml`/`state.yaml`; that SPEC touches only `ralph.yaml`. Run them in separate worktrees or sequence them to avoid PR-scope collision.
+- **`SPEC-CONFIG-KEY-HONESTY-001`** — predecessor; established the "every key must have a consumer" invariant this SPEC operationalizes for three named surfaces.
+- `.claude/rules/moai/core/verification-claim-integrity.md` §1.1 surface 3 — the defect-claim hazard this SPEC addresses (users editing dead config expecting effect).
+- `CLAUDE.local.md` §2 [HARD] Template-First Rule — governs the template edit → `make build` → local sync order.
+- `CLAUDE.local.md` §25 Template Internal-Content Isolation — governs what the removed template files may carry.


### PR DESCRIPTION
## Summary

This PR commits 5 pending untracked items from the primary working tree:

### Analysis Reports (4)
- **moai-cli-logic-analysis-20260804.html** - CLI logic analysis
- **moai-local-self-evolution-design-20260804.html** - Local self-evolution design
- **moai-pipeline-audit-20260802.html** - Pipeline audit
- **mx-system-analysis-activation-20260804.html** - MX system analysis activation

These 4 analysis reports join the existing tracked `.moai/reports/` set.

### Draft SPEC (1)
- **SPEC-CONFIG-DEAD-SWEEP-001** - Remove dead non-ralph config (cache.yaml, research.yaml, state.state_dir)

This is a draft SPEC (status: draft, P1) for sweeping non-ralph config with zero Go runtime consumers, authored by manager-spec.

## Ceremony
- **Tier**: S (light ceremony)
- **Approvals**: 0 required
- **Merge method**: Squash

## Context
- All files were already present on disk as untracked items
- No content modifications were made
- Two commits separate the reports from the SPEC for clean history

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Korean HTML reports covering command behavior, pipeline auditing, system analysis, security, lifecycle workflows, and recommended improvements.
  * Added a detailed design report for a controlled local self-evolution workflow, including approval, rollback, and verification guidance.
* **Specifications**
  * Added requirements, implementation plans, acceptance criteria, and progress tracking for removing obsolete configuration while preserving active behavior and validation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->