### PR TITLE
docs(SPEC-GOAL-HTML-FLOW-001): document HTML-first goal flow — render verb + dashboard + roadmap (4-locale)

### DIFF
--- a/docs-site/content/en/advanced/autonomous-loops.md
+++ b/docs-site/content/en/advanced/autonomous-loops.md
@@ -58,6 +58,8 @@ moai goal clear                         # remove the condition (end loop)
 
 At session start, `PruneOrphans` cleans up orphan goals. This mechanism was implemented in SPEC-GOAL-ENGINE-001 (CLOSED).
 
+To render the current loop state as a static HTML dashboard, use `moai goal render` — see [/moai goal - Goal Dashboard](/en/utility-commands/moai-goal/) for details.
+
 ### `/moai loop` — Ralph Engine (diagnostic-driven preset)
 
 {{< icon arrow-right >}} `/moai loop` is a deterministic loop that scans the issue queue found by diagnostic tools, fixes each issue, and repeats until the queue drains or diagnostics are clean. It is a preset on top of the goal engine.

--- a/docs-site/content/en/utility-commands/moai-goal.md
+++ b/docs-site/content/en/utility-commands/moai-goal.md
@@ -42,8 +42,12 @@ Prints the active session's goal (or, with `--all`, all sessions' goals) — the
 Releases the active session's goal (deletes the state file). The Stop hook sees no armed goal and stops blocking. This is how the orchestrator ends the loop after judging a model condition satisfied.
 
 {{< callout type="info" >}}
-**There is no `resume` verb.** The once-discussed `resume` verb (restoring a released goal from an archive) does not exist in the current CLI — `moai goal --help` lists only `arm` / `status` / `clear`. Because `clear` **deletes** the state file (it does not tombstone to an archive), there is no original left to restore.
+**There is no `resume` verb.** The once-discussed `resume` verb (restoring a released goal from an archive) does not exist in the current CLI — `moai goal --help` shows no `resume`, only `arm` / `status` / `clear` / `render`. Because `clear` **deletes** the state file (it does not tombstone to an archive), there is no original left to restore.
 {{< /callout >}}
+
+### `/moai goal render` — dashboard HTML render
+
+Renders the active session's goal state as a **self-contained HTML dashboard** to `.moai/state/goal/<session-id>.html`. It is idempotent — re-running overwrites the same path. It can be invoked both as a slash command (`/moai goal render`) and as a terminal CLI (`moai goal render`); both call the same `goal.RenderDashboard`. If no goal is armed, it exits with a non-zero code and prints the session id to stderr without writing any HTML. Adding the `--json` flag emits `{action, session_id, path, bytes}`. See the [Goal Dashboard](#goal-dashboard) section below for what gets rendered and the security properties.
 
 ## Progression modes (autonomous / semi-autonomous)
 
@@ -79,6 +83,45 @@ The evaluator runs at the end of every turn. Prefer `go test -run <pattern>` ove
 | `/moai loop` | Diagnostic fix loop (preset) | Issue queue drained + diagnostics clean (0 errors / tests pass / coverage) |
 
 If the end state can be expressed as a condition expression, `/moai goal` is right; if it is "get rid of every problem the tools find," `/moai loop` is right.
+
+## Goal Dashboard
+
+The `render` verb renders the current session's goal state as a single static HTML dashboard at `.moai/state/goal/<session-id>.html`. The file depends on no external JS/CSS framework or CDN — it uses inline CSS only — so it opens directly in a browser offline and survives email attachment and Slack drag-and-drop without breaking.
+
+```mermaid
+flowchart TD
+    A["/moai goal render<br/>or moai goal render"] --> B["goal.LoadGoal"]
+    B --> C{"armed goal exists?"}
+    C -- "no" --> D["exit non-zero<br/>stderr: session id<br/>no HTML written"]
+    C -- "yes" --> E["goal.RenderDashboard"]
+    E --> F["write dashboard HTML file<br/>(overwrite, idempotent)"]
+    F --> G["open offline in a browser"]
+```
+
+{{< callout type="info" >}}
+**Self-contained HTML**: there are no external resources, so it opens even when the network is down. The goal state at render time is fully serialized inside the file.
+{{< /callout >}}
+
+**What the dashboard shows**: in the v3.1 CLI the verdict argument is always passed as `nil`, so the dashboard renders the following sections together with a "no verdict yet" placeholder.
+
+- **Header** — session id, lifecycle state (`armed` / `satisfied` / `ceiling-exit` / `cleared`), turns used vs. ceiling, progression mode (`autonomous` / `semi-autonomous`), generation timestamp
+- **Condition declaration** — the goal condition text shown verbatim inside a bordered block
+- **Declared Conditions table** — each condition listed in a table. Mechanical conditions are shown as `<command> (expect exit N)`; model-evaluated conditions are shown as the claim text verbatim
+- **Verdict placeholder** — a "no verdict yet" placeholder in the slots for the turn/ceiling line, the failed-conditions table, and the 5-section ceiling verdict (Claim / Evidence / Baseline-attribution / Gaps / Residual-risk)
+
+**XSS auto-escape**: every untrusted field is rendered via the Go standard library `html/template` `{{.Field}}` syntax and auto-escaped. Even if a `<script>` payload is placed inside the condition text or condition values, it is converted to HTML entities and not executed. Goal conditions can mix shell-command strings and free text, so this auto-escape is a meaningful security property.
+
+**Sibling HTML cleanup tied to `clear`**: `moai goal clear` deletes the sibling `<session>.html` dashboard file alongside the state file (`<session>.json`). In addition, `PruneOrphans` moves orphaned `.html` files together with `.json` files into the `consumed/` archive directory (best-effort). This keeps stale dashboards from piling up in the state directory.
+
+## Roadmap
+
+{{< icon clock muted >}} These are surfaces whose renderer is ready but which are not yet wired into the v3.1 CLI; they are scheduled for v3.2 wiring. Running `moai goal render` today does not show the three below.
+
+- {{< icon clock muted >}} **Verdict-section population** — the turn/ceiling line, the failed-conditions table, and the 5-section ceiling verdict (Claim / Evidence / Baseline-attribution / Gaps / Residual-risk). The renderer fills these sections when the evaluator passes a non-nil verdict, but the v3.1 CLI always passes `nil`, so the "no verdict yet" placeholder is shown. This wiring is scheduled to arrive in v3.2 together with a LIVE board where the Stop hook refreshes the dashboard every turn.
+- {{< icon clock muted >}} **Plan HTML report** — a separate renderer, `RenderPlanHTML`, that writes plan-phase artifacts (goal + 8-field autonomy contract + verdict score + milestones) to `.moai/reports/plan-html/<SPEC-ID>-plan.html`. v3.1 ships no CLI wrapper and no production caller, so this path is not populated.
+- {{< icon clock muted >}} **Re-arm UI** — three conditional dashboard views: a re-arm indicator on `/clear`, a "re-armed under a new id" view, and a D8 infinite-goal rejection banner. The renderer exists, but no production caller constructs this context, so the v3.1 CLI passes `nil`.
+
+The re-arm mechanics themselves (session-handoff embed + re-arm on `/clear` + infinite-goal rejection defense) already shipped under a prior SPEC — what is "unwired" in this roadmap is ONLY the surfacing of that mechanics state onto the dashboard UI.
 
 ## Related documents
 

--- a/docs-site/content/ja/advanced/autonomous-loops.md
+++ b/docs-site/content/ja/advanced/autonomous-loops.md
@@ -58,6 +58,8 @@ moai goal clear                         # 条件削除 (ループ終了)
 
 セッション開始時に`PruneOrphans`が孤立goalをクリーンアップします。このメカニズムはSPEC-GOAL-ENGINE-001 (CLOSED)で実装されました。
 
+現在のループ状態を静的HTMLダッシュボードとしてレンダリングするには `moai goal render` を使います — 詳細は [/moai goal - ゴールダッシュボード](/ja/utility-commands/moai-goal/) を参照してください。
+
 ### `/moai loop` — Ralph Engine (診断駆動プリセット)
 
 {{< icon arrow-right >}} `/moai loop`は診断ツールが見つけたイシューキューをスキャンし、各イシューを修正し、キューが空になるか診断がクリーンになるまで繰り返す決定論的ループです。これはgoalエンジン上のプリセットです。

--- a/docs-site/content/ja/utility-commands/moai-goal.md
+++ b/docs-site/content/ja/utility-commands/moai-goal.md
@@ -42,8 +42,12 @@ draft: false
 アクティブセッションの goal を解除します (状態ファイル削除)。Stop フックは arm された goal がないことを見てブロッキングを止めます。オーケストレーターがモデル条件を充足と判定した後にループを終える方法です。
 
 {{< callout type="info" >}}
-**`resume` 動詞は提供されません。** かつて議論されていた `resume` (解除された goal をアーカイブから復元する) 動詞は現在の CLI にはありません。`moai goal --help` は `arm` / `status` / `clear` のみを列挙します。`clear` が状態ファイルを **削除** するため (アーカイブに tombstone しない)、復元する原本が残りません。
+**`resume` 動詞は提供されません。** かつて議論されていた `resume` (解除された goal をアーカイブから復元する) 動詞は現在の CLI にはありません。`moai goal --help` にも `resume` は含まれず、`arm` / `status` / `clear` / `render` のみが表示されます。`clear` が状態ファイルを **削除** するため (アーカイブに tombstone しない)、復元する原本が残りません。
 {{< /callout >}}
+
+### `/moai goal render` — ダッシュボードHTMLレンダ
+
+アクティブセッションのgoal状態を **自己完結型HTMLダッシュボード** としてレンダリングし、`.moai/state/goal/<session-id>.html`に書き出します。冪等(idempotent)なので再実行すると同じパスを上書きします。スラッシュコマンド(`/moai goal render`)とターミナルCLI(`moai goal render`)の両方から呼び出せ、どちらも同じ `goal.RenderDashboard` を呼び出します。armされたgoalがない場合は、非ゼロ終了コードとともにセッションidをstderrに出力し、HTMLは書き出しません。`--json` フラグを付けると `{action, session_id, path, bytes}` を出力します。レンダリングされる内容とセキュリティ属性は下の [ゴールダッシュボード](#ゴールダッシュボード) セクションを参照してください。
 
 ## 進行モード (自律 / 半自律)
 
@@ -79,6 +83,45 @@ draft: false
 | `/moai loop` | 診断修正ループ (プリセット) | 課題キュー空 + 診断クリーン (0 エラー / テスト通過 / カバレッジ) |
 
 終わりの状態を条件式で表現できるなら `/moai goal`、「ツールが見つける問題を全部なくして」なら `/moai loop` が適しています。
+
+## ゴールダッシュボード
+
+`render` 動詞は現在のセッションのgoal状態を静的HTMLダッシュボード1つにレンダリングし、`.moai/state/goal/<session-id>.html` に書き出します。このファイルは外部JS・CSSフレームワークやCDNに依存せずインラインCSSのみを使うため、ブラウザでオフラインのまま直接開け、メール添付やSlackのドラッグ&ドロップでも壊れません。
+
+```mermaid
+flowchart TD
+    A["/moai goal render<br/>または moai goal render"] --> B["goal.LoadGoal"]
+    B --> C{"armされたgoalがあるか?"}
+    C -- "いいえ" --> D["exit non-zero<br/>stderr: セッション id<br/>HTML未作成"]
+    C -- "はい" --> E["goal.RenderDashboard"]
+    E --> F["ダッシュボードHTMLファイル書き込み<br/>(上書き、冪等)"]
+    F --> G["ブラウザでオフライン表示"]
+```
+
+{{< callout type="info" >}}
+**自己完結型HTML**: 外部リソースがないためネットワークが切れても開けます。レンダリング時点のgoal状態がファイル内に完全に直列化されます。
+{{< /callout >}}
+
+**ダッシュボードに表示される内容**: v3.1 CLIでは評価器(verdict)引数が常に `nil` で渡されるため、ダッシュボードは「まだ判定なし」プレースホルダとともに以下の項目をレンダリングします。
+
+- **ヘッダ** — セッションid、ライフサイクル状態 (`armed` / `satisfied` / `ceiling-exit` / `cleared`)、ターン使用量/上限、進行モード (`autonomous` / `semi-autonomous`)、生成タイムスタンプ
+- **条件宣言部** — goal条件テキストを枠線ブロック内にそのまま表示
+- **宣言された条件表 (Declared Conditions)** — 各conditionを表で並べます。機械的条件は `<コマンド> (expect exit N)` 形式で、モデル評価条件は主張(claim)テキストをそのまま表示
+- **判定プレースホルダ** — turn/上限行、失敗した条件表、5-セクション天井判定 (Claim / Evidence / Baseline-attribution / Gaps / Residual-risk) が入る枠に「まだ判定なし」を表示
+
+**XSS自動エスケープ**: 信頼できないすべてのフィールドはGo標準ライブラリ `html/template` の `{{.Field}}` 構文でレンダリングされ、自動エスケープされます。条件テキストや条件値に `<script>` ペイロードが入ってもHTMLエンティティに変換され実行されません。goal条件にはシェルコマンド文字列と自由テキストが混ざり得るため、この自動エスケープは意味のあるセキュリティ属性です。
+
+**`clear` と連動する兄弟HTMLクリーンアップ**: `moai goal clear` は状態ファイル(`<session>.json`)とともに兄弟の `<session>.html` ダッシュボードファイルも削除します。さらに `PruneOrphans` が孤立した `.html` を `.json` とともに `consumed/` アーカイブディレクトリへ移動します (best-effort)。これにより状態ディレクトリに古いダッシュボードが蓄積しません。
+
+## ロードマップ
+
+{{< icon clock muted >}} レンダラは準備済みだがv3.1 CLIでは未接続、v3.2での接続が予定されているサーフェスです。今 `moai goal render` を実行しても以下の3つは表示されません。
+
+- {{< icon clock muted >}} **判定セクションの有効化** — turn/上限行、失敗した条件表、5-セクション天井判定 (Claim / Evidence / Baseline-attribution / Gaps / Residual-risk)。レンダラは評価器がnon-nil verdictを渡せばこれらのセクションを埋めますが、v3.1 CLIは常に `nil` を渡すため「まだ判定なし」プレースホルダが表示されます。この接続はv3.2で毎ターンのStopフックがダッシュボードを自動更新するLIVEボードとともに導入予定です。
+- {{< icon clock muted >}} **計画HTMLレポート** — plan-phase産出物 (goal + 8-フィールド自律性契約 + 判定スコア + マイルストン) を `.moai/reports/plan-html/<SPEC-ID>-plan.html` に書き出す別のレンダラ `RenderPlanHTML` です。v3.1にはCLIラッパーとプロダクション呼び出し元がないため、このパスは埋まりません。
+- {{< icon clock muted >}} **再武装 (re-arm) UI** — `/clear` 時の再武装表示、新しいidで再武装されたことの表示、D8無限goal拒否バナーの3つの条件付きダッシュボードビューです。レンダラは存在しますがプロダクションでこのコンテキストを構成する呼び出し元がないため、v3.1 CLIは `nil` を渡します。
+
+再武装メカニズム自体 (セッションハンドオフ埋め込み + `/clear` 時の再武装 + 無限goal拒否防御) は以前のSPECで既に出荷されています — このロードマップで「未接続」なのは、そのメカニズム状態をダッシュボードUIに **表面化** する部分のみです。
 
 ## 関連ドキュメント
 

--- a/docs-site/content/ko/advanced/autonomous-loops.md
+++ b/docs-site/content/ko/advanced/autonomous-loops.md
@@ -58,6 +58,8 @@ moai goal clear                         # 조건 제거 (루프 종료)
 
 세션이 시작될 때 `PruneOrphans`가 남겨진 고아 goal을 정리합니다. 이 메커니즘은 SPEC-GOAL-ENGINE-001(CLOSED)에서 구현했습니다.
 
+현재 루프 상태를 정적 HTML 대시보드로 렌더하려면 `moai goal render`를 쓰세요 — 자세한 내용은 [/moai goal - 목표 대시보드](/ko/utility-commands/moai-goal/)를 참고하세요.
+
 ### `/moai loop` — Ralph Engine (진단 기반 프리셋)
 
 {{< icon arrow-right >}} `/moai loop`는 진단 도구가 찾아낸 이슈 큐를 훑어 하나씩 고치고, 큐가 비거나 진단이 깨끗해질 때까지 반복하는 결정론적 루프입니다. goal 엔진 위에 얹힌 프리셋이기도 합니다.

--- a/docs-site/content/ko/utility-commands/moai-goal.md
+++ b/docs-site/content/ko/utility-commands/moai-goal.md
@@ -42,8 +42,12 @@ draft: false
 활성 세션의 goal을 해제합니다 (상태 파일 삭제). Stop 훅은 arm된 goal이 없음을 보고 블로킹을 멈춥니다. 오케스트레이터가 모델 조건을 충족했다고 판정해 루프를 끝낼 때 씁니다.
 
 {{< callout type="info" >}}
-**`resume` 동사는 없습니다.** 한때 이야기되던 `resume` (해제한 goal을 아카이브에서 되살리는 동사) 은 지금 CLI에 들어 있지 않습니다. `moai goal --help`도 `arm` / `status` / `clear`만 보여 줍니다. `clear`가 상태 파일을 아카이브로 남기지 않고 아예 **삭제**하기 때문에, 되살릴 원본 자체가 없습니다.
+**`resume` 동사는 없습니다.** 한때 이야기되던 `resume` (해제한 goal을 아카이브에서 되살리는 동사) 은 지금 CLI에 들어 있지 않습니다. `moai goal --help`에도 `resume`은 빠져 있고 `arm` / `status` / `clear` / `render`만 보입니다. `clear`가 상태 파일을 아카이브로 남기지 않고 아예 **삭제**하기 때문에, 되살릴 원본 자체가 없습니다.
 {{< /callout >}}
+
+### `/moai goal render` — 대시보드 HTML 렌더
+
+활성 세션의 goal 상태를 **자체 완결형 HTML 대시보드**로 렌더해 `.moai/state/goal/<session-id>.html`에 씁니다. 멱등(idempotent)이라 다시 실행하면 같은 경로를 덮어씁니다. 슬래시 커맨드(`/moai goal render`)와 터미널 CLI(`moai goal render`) 양쪽으로 모두 호출할 수 있고, 둘 다 같은 `goal.RenderDashboard`를 호출합니다. arm된 goal이 없으면 0이 아닌 종료 코드와 함께 세션 id를 stderr로 출력하고 HTML을 쓰지 않습니다. `--json` 플래그를 붙이면 `{action, session_id, path, bytes}`를 내보냅니다. 렌더링되는 내용과 보안 속성은 아래 [목표 대시보드](#목표-대시보드) 섹션을 참고하세요.
 
 ## 진행 모드 (자율 / 반자율)
 
@@ -79,6 +83,45 @@ draft: false
 | `/moai loop` | 진단 수정 루프 (프리셋) | 이슈 큐 비움 + 진단 클린 (0 에러 / 테스트 통과 / 커버리지) |
 
 끝 상태를 조건식으로 표현할 수 있다면 `/moai goal`, "도구가 찾는 문제를 전부 없애줘"라면 `/moai loop`가 맞습니다.
+
+## 목표 대시보드
+
+`render` 동사는 현재 세션의 goal 상태를 정적 HTML 대시보드 하나로 렌더해 `.moai/state/goal/<session-id>.html`에 씁니다. 이 파일은 외부 JS·CSS 프레임워크나 CDN에 의존하지 않고 인라인 CSS만 쓰기 때문에 브라우저로 오프라인에서 바로 열리며, 이메일 첨부나 슬랙 드래그앤드롭으로도 깨지지 않습니다.
+
+```mermaid
+flowchart TD
+    A["/moai goal render<br/>또는 moai goal render"] --> B["goal.LoadGoal"]
+    B --> C{"arm된 goal이 있는가?"}
+    C -- "아니오" --> D["exit non-zero<br/>stderr: 세션 id<br/>HTML 미작성"]
+    C -- "예" --> E["goal.RenderDashboard"]
+    E --> F["대시보드 HTML 파일 기록<br/>(덮어쓰기, 멱등)"]
+    F --> G["브라우저로 오프라인 열기"]
+```
+
+{{< callout type="info" >}}
+**자체 완결형 HTML**: 외부 리소스가 없어 네트워크가 끊겨도 열립니다. 렌더 시점의 goal 상태가 파일 안에 완전히 직렬화됩니다.
+{{< /callout >}}
+
+**대시보드에 표시되는 내용**: v3.1 CLI에서 평가기(verdict) 인자는 항상 `nil`로 전달되므로, 대시보드는 "아직 판정 없음" 자리표시자와 함께 다음 항목들을 렌더합니다.
+
+- **머리글** — 세션 id, 라이프사이클 상태 (`armed` / `satisfied` / `ceiling-exit` / `cleared`), 턴 사용량/상한, 진행 모드 (`autonomous` / `semi-autonomous`), 생성 타임스탬프
+- **조건 선언부** — goal 조건 텍스트를 테두리 블록 안에 그대로 표시
+- **선언된 조건 표 (Declared Conditions)** — 각 condition을 표로 나열. 기계적 조건은 `<명령어> (expect exit N)` 형태로, 모델 평가 조건은 주장(claim) 텍스트 그대로 표시
+- **판정 자리표시자** — turn/상한 줄, 실패한 조건 표, 5-섹션 천장 판정 (Claim / Evidence / Baseline-attribution / Gaps / Residual-risk)이 들어갈 자리에 "아직 판정 없음" 표시
+
+**XSS 자동 이스케이프**: 모든 신뢰할 수 없는 필드는 Go 표준 라이브러리 `html/template`의 `{{.Field}}` 문법으로 렌더되어 자동 이스케이프됩니다. 조건 텍스트나 조건 값에 `<script>` 페이로드가 들어가도 HTML 엔티티로 변환되어 실행되지 않습니다. goal 조건에는 셸 명령 문자열과 자유 텍스트가 섞여 들어갈 수 있으므로, 이 자동 이스케이프는 의미 있는 보안 속성입니다.
+
+**`clear`와 연계된 형제 HTML 정리**: `moai goal clear`는 상태 파일(`<session>.json`)과 함께 형제 `<session>.html` 대시보드 파일도 삭제합니다. 또한 `PruneOrphans`가 고아가 된 `.html`을 `.json`과 함께 `consumed/` 아카이브 디렉터리로 옮깁니다 (best-effort). 덕분에 상태 디렉터리에 오래된 대시보드가 쌓이지 않습니다.
+
+## 로드맵
+
+{{< icon clock muted >}} 렌더러는 준비됐지만 v3.1 CLI에서는 아직 연결되지 않은, v3.2 연결이 예정된 표면들입니다. 지금 `moai goal render`를 실행해도 아래 세 가지는 보이지 않습니다.
+
+- {{< icon clock muted >}} **판정 섹션 활성화** — 턴/상한 줄, 실패한 조건 표, 5-섹션 천장 판정 (Claim / Evidence / Baseline-attribution / Gaps / Residual-risk). 렌더러는 평가기가 non-nil verdict를 넘기면 이 섹션들을 채우지만, v3.1 CLI는 항상 `nil`을 넘기므로 "아직 판정 없음" 자리표시자가 보입니다. 이 연결은 v3.2의 턴마다 Stop 훅이 대시보드를 자동 갱신하는 LIVE 보드와 함께 들어올 예정입니다.
+- {{< icon clock muted >}} **계획 HTML 리포트** — plan-phase 산출물 (goal + 8-필드 자율성 계약 + 판정 점수 + 마일스톤)을 `.moai/reports/plan-html/<SPEC-ID>-plan.html`에 쓰는 별도의 렌더러 `RenderPlanHTML`입니다. v3.1에는 CLI 래퍼와 프로덕션 호출자가 없어 이 경로가 채워지지 않습니다.
+- {{< icon clock muted >}} **재무장 (re-arm) UI** — `/clear` 시 재무장 표시, 새 id로 재무장됨 보기, D8 무한 goal 거절 배너 등 세 가지 조건부 대시보드 보기입니다. 렌더러는 있지만 프로덕션에서 이 컨텍스트를 구성하는 호출자가 없어 v3.1 CLI는 `nil`을 넘깁니다.
+
+재무장 메커니즘 자체 (세션 핸드오프 임베드 + `/clear` 시 재무장 + 무한 goal 거절 방어)는 앞선 SPEC에서 이미 출하됐습니다 — 이 로드맵에서 "미연결"인 것은 그 메커니즘 상태를 대시보드 UI에 **표면화**하는 부분만 해당합니다.
 
 ## 관련 문서
 

--- a/docs-site/content/zh/advanced/autonomous-loops.md
+++ b/docs-site/content/zh/advanced/autonomous-loops.md
@@ -58,6 +58,8 @@ moai goal clear                         # 删除条件 (结束循环)
 
 会话开始时 `PruneOrphans` 清理孤立 goal。此机制在 SPEC-GOAL-ENGINE-001 (CLOSED)中实现。
 
+要用静态 HTML 仪表板渲染当前循环状态,可使用 `moai goal render` —— 详见 [/moai goal - 目标看板](/zh/utility-commands/moai-goal/)。
+
 ### `/moai loop` — Ralph Engine (诊断驱动预设)
 
 {{< icon arrow-right >}} `/moai loop` 是扫描诊断工具找到的问题队列、修复每个问题、重复直到队列清空或诊断干净的确定性循环。它是 goal 引擎上的预设。

--- a/docs-site/content/zh/utility-commands/moai-goal.md
+++ b/docs-site/content/zh/utility-commands/moai-goal.md
@@ -42,8 +42,12 @@ draft: false
 解除活跃会话的 goal(删除状态文件)。Stop 钩子见到没有 arm 的 goal 便停止阻断。这是编排器判定模型条件已满足后结束循环的方法。
 
 {{< callout type="info" >}}
-**不提供 `resume` 动词。** 以前讨论过的 `resume`(从归档恢复已解除的 goal)动词目前不在 CLI 中 —— `moai goal --help` 只列出 `arm` / `status` / `clear`。因为 `clear` 会 **删除** 状态文件(而非归档为 tombstone),所以不留下可恢复的原件。
+**不提供 `resume` 动词。** 以前讨论过的 `resume`(从归档恢复已解除的 goal)动词目前不在 CLI 中 —— `moai goal --help` 中也找不到 `resume`,只列出 `arm` / `status` / `clear` / `render`。因为 `clear` 会 **删除** 状态文件(而非归档为 tombstone),所以不留下可恢复的原件。
 {{< /callout >}}
+
+### `/moai goal render` — 仪表板 HTML 渲染
+
+将活跃会话的 goal 状态渲染为 **自包含 HTML 仪表板**,写入 `.moai/state/goal/<session-id>.html`。它是幂等的(idempotent),重复执行会覆盖同一路径。可通过斜杠命令(`/moai goal render`)和终端 CLI(`moai goal render`)两种方式调用,两者都调用相同的 `goal.RenderDashboard`。若没有 arm 的 goal,则以非零退出码将 session id 输出到 stderr,且不写入 HTML。加 `--json` 标志会输出 `{action, session_id, path, bytes}`。关于渲染内容和安全属性,请参见下方 [目标看板](#目标看板) 章节。
 
 ## 进行模式(自主 / 半自主)
 
@@ -79,6 +83,45 @@ draft: false
 | `/moai loop` | 诊断修复循环(预设) | 清空问题队列 + 诊断干净(0 错误 / 测试通过 / 覆盖率) |
 
 若终态能用条件式表达则用 `/moai goal`,若是"把工具找到的问题全部消除"则 `/moai loop` 更合适。
+
+## 目标看板
+
+`render` 动词将当前会话的 goal 状态渲染为一个静态 HTML 仪表板,写入 `.moai/state/goal/<session-id>.html`。该文件不依赖外部 JS·CSS 框架或 CDN,仅使用内联 CSS,因此可在浏览器中离线直接打开;作为邮件附件或 Slack 拖拽分享也不会破损。
+
+```mermaid
+flowchart TD
+    A["/moai goal render<br/>或 moai goal render"] --> B["goal.LoadGoal"]
+    B --> C{"存在 arm 的 goal?"}
+    C -- "否" --> D["exit non-zero<br/>stderr: session id<br/>不写入 HTML"]
+    C -- "是" --> E["goal.RenderDashboard"]
+    E --> F["写入仪表板 HTML 文件<br/>(覆盖,幂等)"]
+    F --> G["浏览器离线打开"]
+```
+
+{{< callout type="info" >}}
+**自包含 HTML**:无外部资源,即使断网也能打开。渲染时刻的 goal 状态被完整序列化进文件。
+{{< /callout >}}
+
+**仪表板显示的内容**:由于 v3.1 CLI 始终向评估器(verdict)传入 `nil` 参数,仪表板在显示"尚无判定"占位符的同时渲染以下内容。
+
+- **页眉** — 会话 id、生命周期状态(`armed` / `satisfied` / `ceiling-exit` / `cleared`)、回合用量/上限、进行模式(`autonomous` / `semi-autonomous`)、生成时间戳
+- **条件声明部** — goal 条件文本原样显示在有边框的块中
+- **已声明条件表** (Declared Conditions) — 各 condition 以表格列出。机械条件以 `<命令> (expect exit N)` 形式显示;模型评估条件以主张(claim)文本原样显示
+- **判定占位符** — 在回合/上限行、失败条件表、5 段上限判定(Claim / Evidence / Baseline-attribution / Gaps / Residual-risk)所在位置显示"尚无判定"
+
+**XSS 自动转义**:所有不可信字段通过 Go 标准库 `html/template` 的 `{{.Field}}` 语法渲染,自动进行 HTML 转义。即便条件文本或条件值中嵌入 `<script>` 载荷,也会被转换为 HTML 实体而不执行。goal 条件中可能混入 shell 命令字符串与自由文本,因此此自动转义是有意义的安全属性。
+
+**`clear` 联动的兄弟 HTML 清理**:`moai goal clear` 在删除状态文件(`<session>.json`)的同时也删除兄弟 `<session>.html` 仪表板文件。此外 `PruneOrphans` 会将孤立的 `.html` 与 `.json` 一并移入 `consumed/` 归档目录(best-effort)。因此状态目录不会堆积过期的仪表板文件。
+
+## 路线图
+
+{{< icon clock muted >}} 渲染器已就绪,但在 v3.1 CLI 中尚未连接,计划于 v3.2 连接的表面。现在运行 `moai goal render` 看不到以下三项。
+
+- {{< icon clock muted >}} **判定段激活** — 回合/上限行、失败条件表、5 段上限判定(Claim / Evidence / Baseline-attribution / Gaps / Residual-risk)。当评估器传入 non-nil verdict 时,渲染器会填充这些段;但 v3.1 CLI 始终传入 `nil`,因此显示"尚无判定"占位符。该连接计划与 v3.2 中 Stop 钩子每回合自动更新仪表板的 LIVE 看板一同落地。
+- {{< icon clock muted >}} **计划 HTML 报告** — 独立渲染器 `RenderPlanHTML`,将 plan 阶段产物(goal + 8 字段自主性契约 + 判定分数 + 里程碑)写入 `.moai/reports/plan-html/<SPEC-ID>-plan.html`。v3.1 中无 CLI 包装器和生产调用者,因此该路径不会被填充。
+- {{< icon clock muted >}} **重新武装 UI** (re-arm) — `/clear` 时显示重新武装、以新 id 重新武装的视图、D8 无限 goal 拒绝横幅等三种条件化的仪表板视图。渲染器已就绪,但生产中没有构造此上下文的调用者,因此 v3.1 CLI 传入 `nil`。
+
+重新武装机制本身(会话交接嵌入 + `/clear` 时重新武装 + 无限 goal 拒绝防护)已在先前 SPEC 中发布 — 本路线图中"未连接"的部分仅指将该机制状态 **表面化** 到仪表板 UI 的部分。
 
 ## 相关文档
 


### PR DESCRIPTION
## What Changed

4-locale docs extension for SPEC-GOAL-HTML-FLOW-001 (status: completed). This documents the HTML-first `/moai goal` flow that shipped in v3.1 across the docs-site's 4 locales (ko canonical, en/ja/zh derived).

## Live vs Roadmap (Honest Framing)

The documentation accurately reflects what is wired in the v3.1 binary vs what is renderer-ready-but-not-wired (v3.2 roadmap):

**LIVE in v3.1:**
- The `render` verb (`moai goal render` / `/moai goal render`)
- Goal dashboard skeleton (header / condition / Declared Conditions table / "no verdict yet" placeholder)
- XSS auto-escape via `html/template`
- Sibling `.html` cleanup on `clear`/`PruneOrphans`

**Roadmap (v3.2):**
- Verdict-section population (the v3.1 CLI always passes a nil verdict)
- Plan HTML report (`RenderPlanHTML` — no production caller in v3.1)
- Re-arm UI (renderer exists, no production caller)

## Scope

8 files across 4 locales (ko/en/ja/zh):

**`utility-commands/moai-goal.md` (4 locales):**
- Added the `render` verb documentation
- Added "Goal Dashboard" section
- Added "Roadmap" section

**`advanced/autonomous-loops.md` (4 locales):**
- Added one-line cross-reference to `moai goal render`

## Verification

Locale parity + hugo-build + i18n gates verified locally before PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented the new `moai goal render` command and its slash-command usage.
  * Added guidance for generating self-contained, offline HTML dashboards showing the current goal loop state.
  * Clarified output behavior, JSON responses, error handling, safe content escaping, and dashboard cleanup.
  * Updated documentation in English, Japanese, Korean, and Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->