### PR TITLE
fix(SPEC-INFINITE-GOAL-001): D1 cost-cap-alone reject + D2 model-only stagnation skip

### DIFF
--- a/.moai/specs/SPEC-INFINITE-GOAL-001/acceptance.md
+++ b/.moai/specs/SPEC-INFINITE-GOAL-001/acceptance.md
@@ -16,7 +16,7 @@
 | AC-INFINITE-GOAL-008 | REQ-006 | `/clear` re-arms embedded goal under new session-id | MUST | plan M6 |
 | AC-INFINITE-GOAL-009 | REQ-007 | ac_converge "Max 20" — OQ-1 option (b) doc-only correction | MUST | plan M7 |
 | AC-INFINITE-GOAL-010 | cross-ref (deny/ask surface — cross-cuts `SPEC-STOPCHAIN-TRIM-001` REQ-007/AC-006) | armed infinite goal does NOT weaken deny/ask | MUST | plan M8 |
-| AC-INFINITE-GOAL-011 | REQ-004 | `--max-turns 0` with NEITHER `--max-duration` NOR `--cost-cap` rejected at arm time | MUST | plan M1+M4 |
+| AC-INFINITE-GOAL-011 | REQ-004 | `--max-turns 0` without `--max-duration` rejected at arm time (`--cost-cap` does NOT satisfy the bound) | MUST | plan M1+M4 |
 
 ### §D.1 Severity model
 
@@ -132,13 +132,13 @@ returns at least one match — i.e. a single line that names BOTH the cap AND th
 
 #### AC-INFINITE-GOAL-011 — Arm-time reject for unbounded infinite arm (REQ-4 arm-time enforcement, D1)
 
-**Given** the `/moai goal` arm verb (`internal/cli/goal.go` `runGoalArm`) invoked with `--max-turns 0` AND NEITHER `--max-duration` NOR `--cost-cap` supplied.
+**Given** the `/moai goal` arm verb (`internal/cli/goal.go` `runGoalArm`) invoked with `--max-turns 0` AND `--max-duration` NOT supplied — regardless of whether `--cost-cap` is supplied (cost-cap is recorded-only and does not satisfy the bound).
 
 **When** the arm command runs.
 
-**Then** the arm command REJECTS the invocation (fail-closed): non-zero exit code AND a stderr message naming the missing bound (e.g. "`--max-turns 0` requires at least one real bound: `--max-duration <seconds>` or `--cost-cap <N>`"). No goal state file is written. **While** `--max-turns 0` is supplied WITH at least one real bound, the arm succeeds (covered by AC-005).
+**Then** the arm command REJECTS the invocation (fail-closed): non-zero exit code AND a stderr message naming `--max-duration` as the required real bound (e.g. "`--max-turns 0` requires `--max-duration <seconds>` as the real bound (cost-cap is recorded-only and does not satisfy the requirement)"). No goal state file is written. **While** `--max-turns 0` is supplied WITH `--max-duration <D>`, the arm succeeds (covered by AC-005).
 
-**Test shape:** Go unit test — invoke `runGoalArm` with `--max-turns 0` alone, assert non-zero exit + stderr contains the missing-bound message + no goal file written. Negative case: invoke with `--max-turns 0 --max-duration 3600`, assert exit 0 + goal file written (this is the AC-005 positive path, cross-referenced).
+**Test shape:** Go unit test covering THREE cases — (1) `--max-turns 0` alone → non-zero exit + stderr + no goal file; (2) `--max-turns 0 --cost-cap 100` (no `--max-duration`) → non-zero exit + stderr + no goal file (the NEW D1 rejection case: cost-cap alone does NOT satisfy the bound); (3) `--max-turns 0 --max-duration 3600` → exit 0 + goal file written (AC-005 positive path, cross-referenced).
 
 ### §D.3 Indirect verification
 

--- a/.moai/specs/SPEC-INFINITE-GOAL-001/spec.md
+++ b/.moai/specs/SPEC-INFINITE-GOAL-001/spec.md
@@ -2,7 +2,7 @@
 id: SPEC-INFINITE-GOAL-001
 title: "Remove the /moai goal 1M cap — infinite auto-compact-driven autonomy with real bounds"
 version: 0.1.0
-status: completed
+status: in-progress
 created: 2026-08-03
 updated: 2026-08-04
 author: manager-spec
@@ -13,6 +13,7 @@ lifecycle: spec-anchored
 tags: "goal-engine, auto-compact, max-turns, block-cap, statusline, session-start, handoff-rearm, ac-converge, autonomy-epic"
 tier: M
 related_specs: [SPEC-AUDIT-SNAPSHOT-001, SPEC-STOPCHAIN-TRIM-001]
+amendment_of: SPEC-INFINITE-GOAL-001
 ---
 
 # SPEC-INFINITE-GOAL-001 — Remove the goal 1M cap (infinite auto-compact autonomy)
@@ -20,6 +21,16 @@ related_specs: [SPEC-AUDIT-SNAPSHOT-001, SPEC-STOPCHAIN-TRIM-001]
 ## HISTORY
 
 - 2026-08-03 — Initial draft. Codifies §3.2 (v2) of the autonomy-workflow redesign report (`moai-autonomy-workflow-redesign-20260803.html`) + §1.2 (run-phase goal bottleneck) + the C2 finding that the 1M number is NOT a hard cap. Third and final P0 of the autonomy-workflow-epic; proceeds after `SPEC-STOPCHAIN-TRIM-001` completes. The HTML-dashboard aspect of §3.2 is split off to a separate P1 (`SPEC-GOAL-HTML-FLOW`); this SPEC focuses solely on the loop-continuation mechanics that make an armed goal run effectively unbounded.
+
+## Amendments
+
+### Amendment 1 — D1/D2 defect alignment (2026-08-04)
+
+- **Prior status**: `completed`
+- **prior_completed_sha**: `80643b61e` (PR #1320 — `sync(SPEC-INFINITE-GOAL-001): 3-phase close (in-progress→completed)`)
+- **Rationale**: Code-review of the shipped REQ-004 implementation found two defects. The spec's prior REQ-004 / AC-011 / §D constraint #3 wording contradicted (a) the code's own §D.5 admission that `cost-cap` is recorded-only (not enforced), and (b) `.claude/skills/moai/workflows/run.md`'s statement that `ac_converge` retains model-type conditions. The amendment makes spec ↔ code ↔ run.md consistent: wall-clock `max-duration` is the REQUIRED real termination bound; `cost-cap` is RECORDED-ONLY (does not satisfy the bound); the mechanical-fingerprint stagnation guard applies only to goals carrying at least one mechanical condition (model-only goals like `ac_converge` skip stagnation and are bounded by wall-clock + `MaxTurns`).
+- **Scope**: REQ-INFINITE-GOAL-004 (3 clauses — bound definition, arm-time enforcement, stagnation scope), §D constraint #3, AC-INFINITE-GOAL-011 (Given + Then + Test shape), and the AC matrix row for AC-011. The companion code fix (D1: cost-cap-alone reject; D2: model-only stagnation skip) is handled separately by manager-develop — this amendment touches SPEC artifacts ONLY.
+- **Untouched**: REQ-001/002/003/005/006/007, AC-001 through AC-010, §D.1/§D.2/§D.3/§D.4/§D.5/§D.6, §D constraints #1/#2/#4-#7, §A/§B/§E/§F/§G/§H — all unchanged.
 
 ## §A. User Story
 
@@ -84,11 +95,11 @@ related_specs: [SPEC-AUDIT-SNAPSHOT-001, SPEC-STOPCHAIN-TRIM-001]
 
 ### REQ-INFINITE-GOAL-004 — Real termination bounds (wall-clock + cost) + arm-time enforcement
 
-**When** `Ceiling.MaxTurns == 0` (infinite turns), the goal SHALL be bounded by at least one of: (a) a goal-level `max-duration` (wall-clock seconds since `CreatedAt`, the arm-time field at `internal/goal/schema.go:94`), OR (b) a goal-level `cost cap` (max model invocations OR max cumulative token spend), recorded in `Ceiling` alongside `MaxTurns`. The bound SHALL fire a verdict indistinguishable from the MaxTurns ceiling firing today (5-section Claim/Evidence/Baseline/Gaps/Residual-risk verdict at `evaluate.go`). Per OQ-2 resolution, wall-clock (`max-duration`) is the M4-default PRIMARY bound (it needs only `time.Since(armTime)`, and `CreatedAt` is already persisted); `cost cap` is a documented FOLLOW-UP because `Eval` and `Ceiling` carry NO invocation/token accounting today.
+**When** `Ceiling.MaxTurns == 0` (infinite turns), the goal SHALL be bounded by a goal-level `max-duration` (wall-clock seconds since `CreatedAt`, the arm-time field at `internal/goal/schema.go:94`), which is the REQUIRED real termination bound. The bound SHALL fire a verdict indistinguishable from the MaxTurns ceiling firing today (5-section Claim/Evidence/Baseline/Gaps/Residual-risk verdict at `evaluate.go`). Per OQ-2 resolution, wall-clock (`max-duration`) is the M4-default PRIMARY bound (it needs only `time.Since(armTime)`, and `CreatedAt` is already persisted). A goal-level `cost cap` (max model invocations OR max cumulative token spend) MAY additionally be recorded in `Ceiling` alongside `MaxTurns`, but it is RECORDED-ONLY — it is NOT a standalone real bound, and supplying `--cost-cap` does NOT by itself satisfy the real-bound requirement (enforcement of cost-cap is a documented FOLLOW-UP per OQ-2 because `Eval` and `Ceiling` carry NO invocation/token accounting today). An infinite goal (`--max-turns 0`) MUST carry `--max-duration`; a `--cost-cap` MAY additionally be recorded but does not substitute for the wall-clock bound.
 
-**When** the arm verb (`internal/cli/goal.go` `runGoalArm`) is invoked with `--max-turns 0` AND neither `--max-duration` nor `--cost-cap` is supplied, the arm command SHALL REJECT the invocation (fail-closed): non-zero exit + a stderr message naming the missing bound. **While** both `--max-turns 0` AND at least one real bound (`--max-duration` OR `--cost-cap`) are supplied, the infinite loop is bounded. Reject is chosen over a silent wall-clock default-fallback because it is the safer posture for a safety-critical bound: a goal that silently falls back to an arbitrary wall-clock value hides the bound from the user; an explicit reject surfaces it at arm time. This closes the arm-time enforcement gap: without it, a `--max-turns 0` goal armed without any real bound AND making non-stagnant progress runs unbounded (the stagnation guard at `evaluate.go:106-121` `isStagnant` only fires on N consecutive NO-change turns; a goal making REAL progress never triggers it).
+**When** the arm verb (`internal/cli/goal.go` `runGoalArm`) is invoked with `--max-turns 0` AND `--max-duration` is NOT supplied, the arm command SHALL REJECT the invocation (fail-closed): non-zero exit + a stderr message naming `--max-duration` as the required bound. A `--cost-cap` alone does NOT satisfy the real-bound requirement (cost-cap is recorded-only). **While** both `--max-turns 0` AND `--max-duration <D>` are supplied, the infinite loop is bounded. Reject is chosen over a silent wall-clock default-fallback because it is the safer posture for a safety-critical bound: a goal that silently falls back to an arbitrary wall-clock value hides the bound from the user; an explicit reject surfaces it at arm time. This closes the arm-time enforcement gap: without it, a `--max-turns 0` goal armed without any real bound AND making non-stagnant progress runs unbounded (the stagnation guard at `evaluate.go:106-121` `isStagnant` only fires on N consecutive NO-change turns; a goal making REAL progress never triggers it).
 
-**The stagnation guard at `evaluate.go:84, 106-121, 153-161` (DefaultStagnationThreshold=3) SHALL be strengthened** so that "N consecutive turns with NO mechanical-condition change" halts the loop. The mechanical-condition change is defined as a diff in: test count, test pass/fail tally, OR the SHA of a bounded file set DERIVED from the mechanical conditions' commands at evaluation time (no schema change — the target-file set is NOT a new `Ceiling` field; it is derived from the condition commands' paths). "Same note 3 times" (today's heuristic) is replaced by this mechanical comparison.
+**The stagnation guard at `evaluate.go:84, 106-121, 153-161` (DefaultStagnationThreshold=3) SHALL be strengthened** so that "N consecutive turns with NO mechanical-condition change" halts the loop. The mechanical-condition change is defined as a diff in: test count, test pass/fail tally, OR the SHA of a bounded file set DERIVED from the mechanical conditions' commands at evaluation time (no schema change — the target-file set is NOT a new `Ceiling` field; it is derived from the condition commands' paths). "Same note 3 times" (today's heuristic) is replaced by this mechanical comparison. This stagnation guard applies ONLY to goals that carry at least one mechanical condition; a model-only goal (all conditions are `ConditionModel`, e.g. `ac_converge`) SHALL skip stagnation detection entirely — it is bounded by wall-clock `max-duration` and `MaxTurns` only — because model conditions are transcript-judged and yield no reliable mechanical fingerprint (cross-ref §D constraint #3).
 
 ### REQ-INFINITE-GOAL-005 — SessionStart(compact) re-inject
 
@@ -112,7 +123,7 @@ Option B (SPEC-id keying instead of session-id keying) is REJECTED because it in
 
 1. **auto-compact is the pressure-relief, not `/clear`** (from §3.2 + verification-claim-integrity): when a goal is armed, `/clear` doctrine is suppressed (REQ-3); auto-compact handles context reclamation. The `stop-goal` hook decides only block/continue; it does NOT decide auto-compact. "Yielding to auto-compact" is NOT a forced `/clear` halt (the doctrine change here is precisely that suppression).
 2. **auto-compact thrashing guard respected**: each goal iteration MUST keep its context footprint small (sub-agent delegation, file-redirect bounded tail, targeted mechanical commands). A single large output that immediately re-inflates the context triggers the runtime's thrashing guard and halts the loop — this is a runtime invariant, not a bug.
-3. **model conditions break under auto-compact** (verbatim evidence is summarized away): `ac_converge`'s model-condition shape is therefore migrated to mechanical conditions (test count, file hash, exit code). REQ-INFINITE-GOAL-004's stagnation guard encodes this.
+3. **model conditions break under auto-compact** (verbatim evidence is summarized away): `ac_converge` retains model-type conditions per `.claude/skills/moai/workflows/run.md` (its predicates are all model conditions judged from the transcript). Therefore a goal whose conditions are ALL model-type is NOT subject to the mechanical-fingerprint stagnation guard — it skips stagnation and is bounded by wall-clock `max-duration` + `MaxTurns`. The stagnation guard applies only to goals carrying at least one mechanical condition.
 4. **3 caps explicit**: `MaxTurns` (REQ-1), `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP` (REQ-2), `/clear` doctrine (REQ-3). The 1M number alone is NOT modified by this SPEC — modifying only `Default1MContextTokens` is meaningless and a mis-user hazard (a user would believe the cap was raised while the 3 real caps still terminate the loop).
 5. **Backward compatibility**: `--max-turns` unspecified = `30` (today). `/clear` directive suppressed ONLY when a goal is armed. REQ-5 / REQ-6 hooks are no-ops when no goal is armed.
 6. **MP-3 lesson**: `tags` is a comma-separated quoted string (not a YAML array). Self-verified via `moai spec lint` before returning.
@@ -157,4 +168,4 @@ Option B (SPEC-id keying instead of session-id keying) is REJECTED because it in
 - AC-INFINITE-GOAL-008 (REQ-6): `/clear` re-arms the embedded goal under the new session-id.
 - AC-INFINITE-GOAL-009 (REQ-7): `ac_converge` "Max 20" — OQ-1 resolved to option (b) doc-only correction (run.md states the actual 30-turn execution).
 - AC-INFINITE-GOAL-010 (deny/ask cross-ref): armed infinite goal does NOT weaken deny/ask rules.
-- AC-INFINITE-GOAL-011 (REQ-4 arm-time enforcement): `--max-turns 0` with NEITHER `--max-duration` NOR `--cost-cap` is REJECTED at arm time (non-zero exit + stderr naming the missing bound).
+- AC-INFINITE-GOAL-011 (REQ-4 arm-time enforcement): `--max-turns 0` without `--max-duration` is rejected at arm time (`--cost-cap` does NOT satisfy the bound).

--- a/internal/cli/goal.go
+++ b/internal/cli/goal.go
@@ -250,17 +250,22 @@ func runGoalArm(cmd *cobra.Command, args []string, sessionFlag string, jsonOutpu
 		}
 	}
 
-	// AC-011 fail-closed: --max-turns 0 (infinite) with NEITHER --max-duration
-	// NOR --cost-cap is rejected at arm time. No goal state file is written.
-	if maxTurns == 0 && maxDuration <= 0 && costCap <= 0 {
+	// AC-011 fail-closed (SPEC-INFINITE-GOAL-001 REQ-004 / D1): --max-turns 0
+	// (infinite) REQUIRES --max-duration <seconds> as the real wall-clock bound.
+	// --cost-cap is RECORDED-ONLY (enforcement is a follow-up, per flag help and
+	// SPEC §D.5) and does NOT satisfy the real-bound requirement — so
+	// cost-cap-alone is REJECTED. An infinite goal without a real bound would
+	// run unbounded (the stagnation guard only fires on N consecutive no-change
+	// turns with >=1 mechanical condition; real progress never triggers it, and
+	// a model-only goal skips stagnation entirely per D2). No goal state file
+	// is written on reject.
+	if maxTurns == 0 && maxDuration <= 0 {
 		_, _ = fmt.Fprintln(cmd.ErrOrStderr(),
-			"goal arm: --max-turns 0 (infinite) requires at least one real bound: "+
-				"--max-duration <seconds> or --cost-cap <N>. An infinite goal "+
-				"without a real bound would run unbounded (the stagnation guard "+
-				"only fires on N consecutive no-change turns; real progress never "+
-				"triggers it). Re-run with --max-duration <seconds> (wall-clock "+
-				"primary, OQ-2) or --cost-cap <N>.")
-		return fmt.Errorf("goal arm: --max-turns 0 requires a real bound (--max-duration or --cost-cap)")
+			"goal arm: --max-turns 0 (infinite) requires --max-duration <seconds> "+
+				"as the real wall-clock bound. --cost-cap is recorded-only and does "+
+				"NOT satisfy this requirement (it does not bound the goal). Re-run "+
+				"with --max-duration <seconds>.")
+		return fmt.Errorf("goal arm: --max-turns 0 requires --max-duration <seconds> as the real bound (cost-cap is recorded-only)")
 	}
 
 	sessionID, warn := resolveArmSessionID(sessionFlag)

--- a/internal/cli/goal_infinite_test.go
+++ b/internal/cli/goal_infinite_test.go
@@ -109,13 +109,19 @@ func TestAC011_ArmRejectsUnboundedInfinite(t *testing.T) {
 }
 
 // TestAC011_ArmAcceptsBoundedInfinite asserts the positive path: --max-turns 0
-// WITH --max-duration (or --cost-cap) arms successfully (exit 0 + goal written).
-// This is the AC-005 positive companion.
+// WITH --max-duration arms successfully (exit 0 + goal written). This is the
+// AC-005 positive companion.
+//
+// SPEC-INFINITE-GOAL-001 D1 amendment: --cost-cap is NO LONGER a real bound
+// (it is recorded-only, per flag help and SPEC §D.5). The cost-cap-alone
+// positive case that used to live here encoded the OLD defective behavior and
+// has been moved to TestAC011_ArmRejectsCostCapOnlyInfinite (cost-cap-alone is
+// now REJECTED).
 func TestAC011_ArmAcceptsBoundedInfinite(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("CLAUDE_PROJECT_DIR", tmp)
 
-	// wall-clock bound
+	// wall-clock bound (--max-duration is the REQUIRED real bound per REQ-004)
 	out, exitErr := driveGoalArmExec(t, []string{
 		"--session", "ac011-dur",
 		"--max-turns", "0",
@@ -128,18 +134,38 @@ func TestAC011_ArmAcceptsBoundedInfinite(t *testing.T) {
 	if g := loadArmedGoal(t, tmp, "ac011-dur"); g == nil {
 		t.Fatalf("AC-011 positive (--max-duration): no goal file written (out=%q)", out)
 	}
+}
 
-	// cost-cap bound
-	out2, exitErr2 := driveGoalArmExec(t, []string{
-		"--session", "ac011-cost",
+// TestAC011_ArmRejectsCostCapOnlyInfinite asserts the D1 fail-closed gate:
+// --max-turns 0 with --cost-cap but WITHOUT --max-duration is REJECTED.
+// --cost-cap is recorded-only (SPEC §D.5) and does NOT satisfy the real-bound
+// requirement of REQ-004. AC-011 case (2).
+func TestAC011_ArmRejectsCostCapOnlyInfinite(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("CLAUDE_PROJECT_DIR", tmp)
+
+	out, exitErr := driveGoalArmExec(t, []string{
+		"--session", "ac011-costcap-only",
 		"--max-turns", "0",
-		"--cost-cap", "1000",
+		"--cost-cap", "100",
 		"echo hi exits 0",
 	})
-	if exitErr2 != nil {
-		t.Fatalf("AC-011 positive (--cost-cap): unexpected error %v (out=%q)", exitErr2, out2)
+	if exitErr == nil {
+		t.Fatalf("AC-011 (2): goal arm --max-turns 0 --cost-cap 100 (no --max-duration): "+
+			"expected non-zero exit, got nil (out=%q)", out)
 	}
-	if g := loadArmedGoal(t, tmp, "ac011-cost"); g == nil {
-		t.Fatalf("AC-011 positive (--cost-cap): no goal file written (out=%q)", out2)
+	// stderr MUST name --max-duration as the REQUIRED real bound. It MUST NOT
+	// accept cost-cap as satisfaction (cost-cap is recorded-only).
+	lower := strings.ToLower(out)
+	if !strings.Contains(lower, "max-duration") {
+		t.Errorf("AC-011 (2): stderr must name --max-duration as the required real bound; got %q", out)
+	}
+	if !strings.Contains(lower, "cost-cap") {
+		t.Errorf("AC-011 (2): stderr must mention --cost-cap (to explain it does not satisfy); got %q", out)
+	}
+
+	// No goal state file may be written on a rejected arm.
+	if g := loadArmedGoal(t, tmp, "ac011-costcap-only"); g != nil {
+		t.Errorf("AC-011 (2): a goal file was written despite the reject (goal=%+v)", g)
 	}
 }

--- a/internal/goal/evaluate.go
+++ b/internal/goal/evaluate.go
@@ -126,7 +126,19 @@ func lastProgress(g *Goal) string {
 // bounded file-set SHA) when present; it falls back to the legacy Note when
 // Fingerprint is empty (backward compat with pre-M4 / ceiling / satisfied
 // entries). N consecutive identical signatures → stagnation.
+//
+// SPEC-INFINITE-GOAL-001 D2: the stagnation guard applies ONLY to goals with
+// >=1 mechanical condition. A model-only goal has no reliable mechanical
+// fingerprint, so identical progress Notes would spuriously trigger stagnation;
+// model-only goals are bounded by wall-clock max-duration + MaxTurns per
+// REQ-004. This gate inspects the static g.Conditions types, so it is available
+// at the stagnation check site (which runs BEFORE the per-turn eval loop that
+// computes the L344 hasMechanical local).
 func (e *Eval) isStagnant(g *Goal) bool {
+	// D2: model-only goals skip stagnation (no reliable mechanical fingerprint).
+	if !hasMechanicalConditions(g) {
+		return false
+	}
 	n := e.StagnationThreshold
 	if n == 0 {
 		n = DefaultStagnationThreshold
@@ -146,6 +158,20 @@ func (e *Eval) isStagnant(g *Goal) bool {
 		}
 	}
 	return true
+}
+
+// hasMechanicalConditions reports whether the goal declares any Tier-1
+// (mechanical) condition. Used by isStagnant to gate the stagnation guard to
+// mechanical-bearing goals only (D2). This is structurally identical to the
+// existing Goal.HasModelConditions predicate style (schema.go L131) and inspects
+// the static g.Conditions types — available at the stagnation check site.
+func hasMechanicalConditions(g *Goal) bool {
+	for _, c := range g.Conditions {
+		if c.Type == ConditionMechanical {
+			return true
+		}
+	}
+	return false
 }
 
 // stagnationKey returns the per-turn signature used by isStagnant: the

--- a/internal/goal/evaluate_infinite_test.go
+++ b/internal/goal/evaluate_infinite_test.go
@@ -54,6 +54,59 @@ func TestAC001_EvaluatorSkipsCeilingAtMaxTurnsZero(t *testing.T) {
 	// If we reached turn 50 still blocked, the ceiling (30) never fired — PASS.
 }
 
+// TestStagnation_SkipsModelOnlyGoal asserts the D2 fix: a model-only goal
+// (no ConditionMechanical) skips the stagnation guard. A model-only goal has
+// no reliable mechanical fingerprint, so identical progress Notes would
+// spuriously trigger stagnation. After D2, isStagnant returns false for a
+// model-only goal even with N (>= DefaultStagnationThreshold) identical
+// progress entries.
+//
+// Model-only goals are bounded by wall-clock max-duration + MaxTurns per
+// REQ-004 (the stagnation guard applies ONLY to goals with >=1 mechanical
+// condition).
+func TestStagnation_SkipsModelOnlyGoal(t *testing.T) {
+	g := NewGoal("s-model-only", "model claim only", []Condition{
+		{Type: ConditionModel, Claim: "all AC rows show PASS in the transcript"},
+	})
+	g.Ceiling.MaxTurns = 100
+	// Pre-populate progress with N identical entries — under the OLD code this
+	// would trigger stagnation; under D2 the model-only gate skips it.
+	for i := 0; i < DefaultStagnationThreshold; i++ {
+		g.Progress = append(g.Progress, ProgressEntry{
+			Turn: i + 1,
+			Note: "identical-model-note",
+		})
+	}
+	e := &Eval{Runner: neverSatisfiedRunner{}}
+	if e.isStagnant(g) {
+		t.Fatal("D2: isStagnant must return FALSE for a model-only goal " +
+			"(stagnation guard applies only to goals with >=1 mechanical condition)")
+	}
+}
+
+// TestStagnation_FiresOnMechanicalGoal confirms the AC-006 positive path is
+// preserved: a goal with >=1 mechanical condition AND N identical mechanical
+// fingerprints still triggers stagnation (D2 does not weaken the mechanical
+// path).
+func TestStagnation_FiresOnMechanicalGoal(t *testing.T) {
+	g := NewGoal("s-mech", "converge", []Condition{
+		{Type: ConditionMechanical, Cmd: "false", ExpectExit: 0},
+	})
+	g.Ceiling.MaxTurns = 100
+	for i := 0; i < DefaultStagnationThreshold; i++ {
+		g.Progress = append(g.Progress, ProgressEntry{
+			Turn:        i + 1,
+			Note:        "same",
+			Fingerprint: "1:abc|fs=empty",
+		})
+	}
+	e := &Eval{Runner: neverSatisfiedRunner{}}
+	if !e.isStagnant(g) {
+		t.Fatal("AC-006: isStagnant must return TRUE for a mechanical goal " +
+			"with N identical fingerprints")
+	}
+}
+
 // TestAC002_EvaluatorFiresCeilingAtDefaultMaxTurns asserts the backward-compat
 // half: with MaxTurns == 30 the ceiling fires at turn 30.
 func TestAC002_EvaluatorFiresCeilingAtDefaultMaxTurns(t *testing.T) {


### PR DESCRIPTION
## Summary

Aligns the shipped REQ-004 implementation with its own §D.5 admission (cost-cap is recorded-only) and with `run.md` (ac_converge retains model-type conditions). Two surgical fixes + an in-place SPEC amendment (review-followup-fix epic, Wave 1).

## D1 (`internal/cli/goal.go`)

The AC-011 fail-closed arm-time gate now requires `--max-duration` — the condition changed from `maxTurns==0 && maxDuration<=0 && costCap<=0` to `maxTurns==0 && maxDuration<=0`, so `--max-turns 0 --cost-cap 100` (no max-duration) is now **REJECTED** (cost-cap is recorded-only and does not bound the goal).

## D2 (`internal/goal/evaluate.go`)

`isStagnant` now early-returns false for model-only goals via a new `hasMechanicalConditions(g)` predicate — model-only goals (e.g. `ac_converge`) skip stagnation and rely on wall-clock `max-duration` + `MaxTurns`.

## SPEC amendment (`f329ce7c9`)

REQ-004 (bound/arm-time/stagnation clauses) + §D constraint #3 + AC-011 wording aligned (prior_completed_sha `80643b61e`).

## Verification

- **TDD**: RED→GREEN, verbatim RED evidence captured
- **AC-011**: three cases pass
- **AC-006**: mechanical-stagnation regression green
- **Build**: `go build ./...` + `GOOS=windows GOARCH=amd64 go build ./...` exit 0
- **Lint**: `golangci-lint run` — 0 issues
- **Coverage** (changed surface):
  - `runGoalArm`: 90.9%
  - `isStagnant`: 92.9%
  - `hasMechanicalConditions`: 100%

## Scope

4 files (+131/-21). No unrelated changes.

## Note

SPEC status is `in-progress` (amendment); re-close to `completed` via a follow-up sync after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Infinite goals now require a positive `--max-duration` when `--max-turns 0` is used.
  * Model-only goals are bounded by time and turn limits without triggering stagnation detection.

* **Bug Fixes**
  * Cost caps no longer incorrectly satisfy infinite-goal safety requirements.
  * Invalid configurations are rejected without writing goal state.
  * Stagnation detection remains active for goals with mechanical conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->