### PR TITLE
chore(SPEC-ORCH-GIT-RELAX-001): backfill sync_commit_sha (53572e4b6)

### DIFF
--- a/.moai/specs/SPEC-ORCH-GIT-RELAX-001/progress.md
+++ b/.moai/specs/SPEC-ORCH-GIT-RELAX-001/progress.md
@@ -197,7 +197,7 @@ notes: >
 
 ```yaml
 sync_complete_at: 2026-08-05
-sync_commit_sha: "pending-backfill-sync"   # D3 exemption — orchestrator backfills post-merge (Route B squash: final SHA = merged-to-main SHA)
+sync_commit_sha: "53572e4b6"   # backfilled post-merge — sync PR #1351 squash on main (2026-08-04)
 run_commit_sha: "898d2b854"                # M4 run-phase tip; squash-landed on main as 876e9936142a (PR #1347)
 run_pr: 1347
 sync_status: audit-ready


### PR DESCRIPTION
Replace the progress.md §E.4 `sync_commit_sha` D3 placeholder with the real sync-PR merge SHA.

- **What**: 1-line metadata backfill — `pending-backfill-sync` → `53572e4b6` (sync PR #1351 squash on main, 2026-08-04).
- **Why**: a sync commit cannot reference its own SHA (known only after merge); the placeholder was the sanctioned D3 self-referential-hazard workaround. This follow-up completes the traceability for the now-closed SPEC.
- **Audit-clean throughout**: the placeholder was non-empty, so era H-4 classification held and `moai spec audit` showed 0 drift for this SPEC. No code, template, or doctrine changes.

This PR is itself an **orchestrator-direct Tier S** operation — self-demonstrating the capability SPEC-ORCH-GIT-RELAX-001 enables (orchestrator-direct push+PR with the Pre-Spawn Sync Check; on this checkout `Workflow.BranchGuard.Enabled=false` so no sentinel is needed).

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the synchronization record with the confirmed merged commit reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->