### PR TITLE
chore: backfill sync_commit_sha (5 recent-epic SPECs)

### DIFF
--- a/.moai/specs/SPEC-FOURDIM-PHANTOM-001/progress.md
+++ b/.moai/specs/SPEC-FOURDIM-PHANTOM-001/progress.md
@@ -129,7 +129,7 @@ m1_to_mN_commit_strategy: single M1 commit (draft → in-progress); SHA backfill
 
 ```yaml
 sync_complete_at: 2026-08-05
-sync_commit_sha: pending-backfill-sync
+sync_commit_sha: a098aac98
 sync_status: audit-ready
 spec_status_transition: in-progress → implemented → completed (3-phase close on the single sync commit)
 frontmatter_status_transitions:

--- a/.moai/specs/SPEC-INFINITE-GOAL-001/progress.md
+++ b/.moai/specs/SPEC-INFINITE-GOAL-001/progress.md
@@ -97,7 +97,7 @@ spec_lint_clean: true   # moai spec lint (§6 MP-3 tags comma-quoted-string) —
 
 ```yaml
 sync_complete_at: 2026-08-04
-sync_commit_sha: "pending-backfill-reclose"   # self-referential placeholder for the re-close sync commit (D3 workaround) — prior close SHA was 80643b61e (PR #1320 squash, retained in HISTORY ## Amendments prior_completed_sha); this sync commit carries the in-progress → completed re-close for the D1/D2 amendment fix (PR #1342 squash e06396158)
+sync_commit_sha: "a1c86176c"   # self-referential placeholder for the re-close sync commit (D3 workaround) — prior close SHA was 80643b61e (PR #1320 squash, retained in HISTORY ## Amendments prior_completed_sha); this sync commit carries the in-progress → completed re-close for the D1/D2 amendment fix (PR #1342 squash e06396158)
 sync_status: complete
 frontmatter_status_transitions:
   spec.md: "in-progress → implemented → completed"

--- a/.moai/specs/SPEC-LSEL-LOCAL-EVOLUTION-001/progress.md
+++ b/.moai/specs/SPEC-LSEL-LOCAL-EVOLUTION-001/progress.md
@@ -199,7 +199,7 @@ M1 DoD met: AC-LSEL-009 PASS + AC-LSEL-010 PASS; `drain-offset.json` advanced; c
 ```yaml
 sync_complete_at: "2026-08-04"
 sync_status: "completed"
-sync_commit_sha: "pending-backfill-<sync-commit>"
+sync_commit_sha: "701426ca2"
 close_subject: "docs(SPEC-LSEL-LOCAL-EVOLUTION-001): sync-phase artifacts (3-phase close)"
 phase_close_kind: "3-phase close (plan→run→sync — MX Tag is a cross-cutting sync concern, not a separate phase)"
 run_phase_terminal_sha: "9ede1bfad"   # M4 terminal run-phase commit (backfilled into §E.3)

--- a/.moai/specs/SPEC-MX-ASSOCIATION-001/progress.md
+++ b/.moai/specs/SPEC-MX-ASSOCIATION-001/progress.md
@@ -63,7 +63,7 @@ Run-phase independently verified by the orchestrator (8/8 verification matrix PA
 ```yaml
 sync_status: audit-ready
 sync_complete_at: 2026-08-04
-sync_commit_sha: "pending-backfill"
+sync_commit_sha: "1670507f2"
 ```
 
 ## §F Phase 4 Mode Selection

--- a/.moai/specs/SPEC-SYNC-AUDIT-FALSIFICATION-001/progress.md
+++ b/.moai/specs/SPEC-SYNC-AUDIT-FALSIFICATION-001/progress.md
@@ -21,7 +21,7 @@ _run-phase landed at commit `de672622d` — `.claude/agents/moai/sync-auditor.md
 
 ```yaml
 sync_complete_at: 2026-08-04
-sync_commit_sha: pending-backfill-close
+sync_commit_sha: 1579687e6
 sync_status: completed
 b12_self_test_a: pass   # pre-emission grep: grep -c 'SPEC-SYNC-AUDIT-FALSIFICATION' CHANGELOG.md == 0 pre-emission
 b12_self_test_b: pass   # AC count match: acceptance.md not present (Tier M skeleton carried inline AC summary in spec.md §H); CHANGELOG entry references the 5 AC-SAF IDs verbatim


### PR DESCRIPTION
High-value backfill subset (`/moai goal` remaining-chores sweep). Fills `sync_commit_sha` for 5 recent-epic SPECs:

| SPEC | sync_commit_sha | merge PR |
|---|---|---|
| SPEC-FOURDIM-PHANTOM-001 | `a098aac98` | #1350 |
| SPEC-MX-ASSOCIATION-001 | `1670507f2` | #1321 |
| SPEC-SYNC-AUDIT-FALSIFICATION-001 | `1579687e6` | #1344 |
| SPEC-INFINITE-GOAL-001 | `a1c86176c` | #1343 |
| SPEC-LSEL-LOCAL-EVOLUTION-001 | `701426ca2` | #1346 |

Doc-only (progress.md SHA traceability). Committed via documented `SKIP_MOAI_PRECOMMIT=1` bypass (the heavy pre-commit gate runs `go test`, irrelevant to SHA fields, and hit a commit-reentrancy lock race); CI re-gates this PR. ~26 older/low-signal SPECs deferred to a dedicated backfill session.

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated synchronization audit records with the corresponding completed commit references.
  * Replaced pending placeholders across five specification progress records to accurately reflect sync completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->