### PR TITLE
chore(SPEC-PROJECT-NAVIGATOR-001): backfill sync_commit_sha

### DIFF
--- a/.moai/specs/SPEC-PROJECT-NAVIGATOR-001/progress.md
+++ b/.moai/specs/SPEC-PROJECT-NAVIGATOR-001/progress.md
@@ -40,7 +40,7 @@ _<pending run-phase>_
 
 ```yaml
 sync_complete_at: 2026-08-05
-sync_commit_sha: pending-backfill-sync
+sync_commit_sha: 2c87d195f
 sync_status: completed
 changelog_entry_position: CHANGELOG.md [Unreleased] / Added (top of section)
 frontmatter_status_transitions:


### PR DESCRIPTION
Backfills `sync_commit_sha: 2c87d195f` in `SPEC-PROJECT-NAVIGATOR-001/progress.md` §E.4 — the squash-merge commit of #1354. Resolves the `pending-backfill-sync` placeholder left by the 3-phase close (per the #1353 batch-backfill pattern).

No code change — 1-line SPEC-progress field update.

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project synchronization record to reflect the latest completed revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->