### PR TITLE
chore: backfill sync_commit_sha (SPEC-AUTONOMY-TIERS-001)

### DIFF
--- a/.moai/specs/SPEC-AUTONOMY-TIERS-001/spec.md
+++ b/.moai/specs/SPEC-AUTONOMY-TIERS-001/spec.md
@@ -5,7 +5,7 @@ version: 0.1.0
 status: completed
 created: 2026-08-04
 updated: 2026-08-05
-sync_commit_sha: pending-backfill-sync
+sync_commit_sha: 519b848fb
 author: manager-spec
 priority: P1
 phase: "v3.x target"


### PR DESCRIPTION
Backfills `sync_commit_sha` for SPEC-AUTONOMY-TIERS-001 with the PR #1341 squash SHA (`519b848fb`). The placeholder `pending-backfill-sync` was left after the amendment merge; #1341 carried CHANGELOG so the squash is the single delivery. `moai spec audit` MUST-FIX = 0 (only this placeholder field remained).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated synchronization metadata to reference the latest commit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->