### PR TITLE
chore(SPEC-PROJECT-NAVIGATOR-002): backfill sync_commit_sha (927e268c9)

### DIFF
--- a/.moai/specs/SPEC-PROJECT-NAVIGATOR-002/progress.md
+++ b/.moai/specs/SPEC-PROJECT-NAVIGATOR-002/progress.md
@@ -87,7 +87,7 @@ residual_debt:
 ```yaml
 sync_status: audit-ready
 sync_complete_at: 2026-08-05
-sync_commit_sha: pending-backfill-002-sync   # self-referential-hazard placeholder — orchestrator backfills the real SHA in a follow-up commit (spec-frontmatter-schema.md D3 exemption)
+sync_commit_sha: 927e268c9   # backfilled from squash-merge of #1361 (spec-frontmatter-schema.md D3 exemption — self-referential-hazard workaround)
 changelog_entry_position: top-of-unreleased   # single entry, above SPEC-PROJECT-NAVIGATOR-001
 frontmatter_status_transitions:
   spec_md: "in-progress → implemented → completed"   # 3-phase close merged into the single sync commit per spec-frontmatter-schema.md Status Transition Ownership Matrix


### PR DESCRIPTION
Backfills the `sync_commit_sha` placeholder in `SPEC-PROJECT-NAVIGATOR-002/progress.md` §E.4 with the real squash-merge SHA of #1361.

D3 exemption (spec-frontmatter-schema.md) self-referential-hazard workaround — a sync commit cannot reference its own SHA until it lands, so the placeholder is mechanically completed in this follow-up commit.

- Squash SHA: `927e268c9` (PR #1361)
- Single file, 1-line change (Tier S)

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project progress tracking to record the completed synchronization commit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->