### PR TITLE
chore(settings): 무효한 Glob/Grep/Write deny 규칙 제거 + 재발 방지 지침

### DIFF
--- a/.claude/rules/moai/core/settings-management.md
+++ b/.claude/rules/moai/core/settings-management.md
@@ -206,6 +206,17 @@ Example:
 }
 ```
 
+#### File-tool category matching (no Glob/Grep/Write deny rules)
+
+Claude Code's permission check matches file tools by **category**, not by individual tool name. A single rule covers the whole category:
+
+- A **`Read(...)`** rule matches ALL file-reading tools (Read, Glob, Grep). A `Read` deny rule also blocks the Edit tool on the matching paths.
+- An **`Edit(...)`** rule matches ALL file-editing tools (Edit, Write, MultiEdit).
+
+Because the category is the unit of matching, `Glob(...)`, `Grep(...)`, and `Write(...)` deny/ask/allow rules are **no-ops** — they match nothing. Claude Code emits a "not matched by file permission checks" warning on load when such rules are present. Do NOT emit them from settings generators; a single `Read(...)` or `Edit(...)` rule per secret path is sufficient and is the only effective form.
+
+Reference: https://code.claude.com/docs/en/settings ("Permission rules" + "Permission rule syntax").
+
 ## Quality Configuration
 
 Quality gates in quality.yaml:

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -481,24 +481,12 @@
           "Edit(~/.aws/**)",
           "Edit(~/.config/gcloud/**)",
           "Edit(~/.ssh/**)",
-          "Glob(./secrets/**)",
-          "Glob(~/.aws/**)",
-          "Glob(~/.config/gcloud/**)",
-          "Glob(~/.ssh/**)",
-          "Grep(./secrets/**)",
-          "Grep(~/.aws/**)",
-          "Grep(~/.config/gcloud/**)",
-          "Grep(~/.ssh/**)",
           "Read(./.env)",
           "Read(./.env.*)",
           "Read(./secrets/**)",
           "Read(~/.aws/**)",
           "Read(~/.config/gcloud/**)",
-          "Read(~/.ssh/**)",
-          "Write(./secrets/**)",
-          "Write(~/.aws/**)",
-          "Write(~/.config/gcloud/**)",
-          "Write(~/.ssh/**)"
+          "Read(~/.ssh/**)"
     ]
   },
   "attribution": {

--- a/internal/template/templates/.claude/rules/moai/core/settings-management.md
+++ b/internal/template/templates/.claude/rules/moai/core/settings-management.md
@@ -206,6 +206,17 @@ Example:
 }
 ```
 
+#### File-tool category matching (no Glob/Grep/Write deny rules)
+
+Claude Code's permission check matches file tools by **category**, not by individual tool name. A single rule covers the whole category:
+
+- A **`Read(...)`** rule matches ALL file-reading tools (Read, Glob, Grep). A `Read` deny rule also blocks the Edit tool on the matching paths.
+- An **`Edit(...)`** rule matches ALL file-editing tools (Edit, Write, MultiEdit).
+
+Because the category is the unit of matching, `Glob(...)`, `Grep(...)`, and `Write(...)` deny/ask/allow rules are **no-ops** — they match nothing. Claude Code emits a "not matched by file permission checks" warning on load when such rules are present. Do NOT emit them from settings generators; a single `Read(...)` or `Edit(...)` rule per secret path is sufficient and is the only effective form.
+
+Reference: https://code.claude.com/docs/en/settings ("Permission rules" + "Permission rule syntax").
+
 ## Quality Configuration
 
 Quality gates in quality.yaml:


### PR DESCRIPTION
## What
Claude Code 2.1.222부터 매 세션 시작 시 뜨던 `Permission deny rule: Glob(...)/Grep(...)/Write(...) is not matched by file permission checks` 경고 8건의 원인을 제거하고, 동일 회귀를 막는 지침을 codify합니다.

## Root cause
Claude Code의 파일 권한 검사는 **도구 카테고리 단위**로 동작합니다 (공식 문서: https://code.claude.com/docs/en/settings):
- `Read(...)` 규칙 = 모든 파일 읽기 도구 (Read/Glob/Grep). Read deny는 Edit까지 차단.
- `Edit(...)` 규칙 = 모든 편집 도구 (Edit/Write/MultiEdit).

따라서 `Glob/Grep/Write` deny 규칙은 매칭 메커니즘에 존재하지 않아 **no-op**이며, CC 2.1.222부터 로드 시 경고를 발생시킵니다.

**회귀 이력**: `f30f0ac0f`가 한때 정리했으나 `519b848fb` (SPEC-AUTONOMY-TIERS-001)가 deny 블록 재정렬 중 LOCAL settings.json에 재도입했습니다.

## Changes
| 파일 | 변경 |
|---|---|
| `.claude/settings.json` | 무효 deny 12줄 제거 (Glob/Grep/Write × secrets/aws/ssh/gcloud). `Read/Edit` 규칙은 유지 |
| `.claude/rules/moai/core/settings-management.md` | Permission Rule Syntax 절에 file-tool category matching 서브섹션 추가 |
| `internal/template/templates/.../settings-management.md` | 동일 내용 2면 mirror |

## Security impact
**없음** — 비밀 경로 보호는 동일하게 유지됩니다. `Read` deny가 matching path의 Edit까지 차단하고, `Edit` deny가 Write/MultiEdit까지 커버하므로 보호망에 변화가 없습니다. 단지 CC 2.1.222+의 no-op 규칙 경고만 제거됩니다.

## Verification
- `python3 -m json.tool .claude/settings.json` → valid
- 무효 deny 규칙 grep → 0
- local↔template 2면 parity diff → identical
- §25 neutrality grep (SPEC-ID/SHA/날짜) → no internal-content leak (generic prose only)
- `go test ./internal/template/...` → ok (mirror parity + neutrality 가드 통과)
- `make build` → 성공

Ref: https://code.claude.com/docs/en/settings

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on how file-access permission categories are matched.
  * Clarified which permission rules are effective and should be configured.

* **Security**
  * Restricted sensitive environment, secrets, cloud, and SSH paths to read-only access.
  * Removed ineffective and unnecessary permission declarations for these paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->