### PR TITLE
fix: post-#1360 audit residuals (loop.md default, TodoWrite/EARS sweep, profile msg)

### DIFF
--- a/.claude/skills/moai/workflows/loop.md
+++ b/.claude/skills/moai/workflows/loop.md
@@ -8,10 +8,10 @@ description: >
   snapshot-based resume. Use when a bounded project-wide fix sweep is needed.
 user-invocable: false
 metadata:
-  version: "2.6.0"
+  version: "2.6.1"
   category: "workflow"
   status: "active"
-  updated: "2026-07-12"
+  updated: "2026-08-05"
   tags: "loop, goal-preset, sweep, scan-lens, diagnostics, testing, coverage"
 
 # MoAI Extension: Progressive Disclosure
@@ -99,7 +99,7 @@ Before arming the goal preset, the scan stage builds a **FINITE** issue queue fr
 
 ## Supported Flags
 
-- --max N (alias --max-iterations): Maximum iteration count. When absent, the effective default is ralph.yaml `loop.max_iterations` (shipped 10) per the Iteration-Ceiling Precedence rule (see § Ceiling-Exit Verdict Contract) — not a freestanding 100 default.
+- --max N (alias --max-iterations): Maximum iteration count. When absent, the effective default is ralph.yaml `loop.max_iterations` (shipped 5) per the Iteration-Ceiling Precedence rule (see § Ceiling-Exit Verdict Contract) — not a freestanding 100 default.
 - --auto-fix: Enable auto-fix (default Level 1)
 - --sequential (alias --seq): Sequential diagnostics instead of parallel
 - --errors (alias --errors-only): Fix errors only, skip warnings
@@ -376,5 +376,5 @@ All fixes within the loop follow CLAUDE.md Section 7 Safe Development Protocol:
 
 ---
 
-Version: 2.6.0
-Updated: 2026-07-12. Redefined `/moai loop` as a **goal preset** — a project-wide improvement sweep built ON the goal engine. Added the Goal-Preset Composition section (delegates the iterate-until-done decision to the goal engine via `stop-goal`), the Scan Stage finite-issue-queue section (default LSP + lint + test + review lenses [security, @MX], opt-in `--lens clean|simplify|coverage`, no-invented-improvements HARD boundary, empty-queue immediate exit), the /moai review + /moai fix layering section, and the additive `sweep-residue` exit_kind value. PRESERVED: the mechanical predicate + independent final pass (Step 1/1.5), the ceiling-exit 5-section verdict contract with `.moai/state/loop-verdict-<id>.json` persistence, the iteration-ceiling precedence rule, and the memory-pressure guard. Previous: 2.3.0 (2026-07-09) replaced sentinel-string success-exit with mechanical predicate; 2.2.0 (2026-03-02) expanded Language-Specific Commands to 16 languages.
+Version: 2.6.1
+Updated: 2026-08-05. Corrected the ralph.yaml `loop.max_iterations` shipped default 10→5 to match the code SSOT (`internal/config/defaults.go` `DefaultMaxIterations = 5`); the key-name ralph-plane transition at lines 232/275 was already complete. Previous: 2.6.0 (2026-07-12) Redefined `/moai loop` as a **goal preset** — a project-wide improvement sweep built ON the goal engine. Added the Goal-Preset Composition section (delegates the iterate-until-done decision to the goal engine via `stop-goal`), the Scan Stage finite-issue-queue section (default LSP + lint + test + review lenses [security, @MX], opt-in `--lens clean|simplify|coverage`, no-invented-improvements HARD boundary, empty-queue immediate exit), the /moai review + /moai fix layering section, and the additive `sweep-residue` exit_kind value. PRESERVED: the mechanical predicate + independent final pass (Step 1/1.5), the ceiling-exit 5-section verdict contract with `.moai/state/loop-verdict-<id>.json` persistence, the iteration-ceiling precedence rule, and the memory-pressure guard. Previous: 2.3.0 (2026-07-09) replaced sentinel-string success-exit with mechanical predicate; 2.2.0 (2026-03-02) expanded Language-Specific Commands to 16 languages.

--- a/docs-site/content/en/advanced/hooks-guide.md
+++ b/docs-site/content/en/advanced/hooks-guide.md
@@ -444,7 +444,7 @@ ralph:
 
 **Saved content:**
 - Current active SPEC state (ID, phase, progress)
-- In-progress task list (TodoWrite)
+- In-progress task list (TaskCreate/TaskUpdate/TaskList/TaskGet)
 - Completed task list
 - Modified file list
 - Git state info (branch, uncommitted changes)

--- a/docs-site/content/en/advanced/settings-json.md
+++ b/docs-site/content/en/advanced/settings-json.md
@@ -258,7 +258,7 @@ The list of commands **allowed to run immediately** without user confirmation.
 | Code quality | `ruff`, `black`, `prettier`, `eslint` | 6+ |
 | Exploration tools | `ls`, `find`, `tree`, `cat`, `head` | 10+ |
 | GitHub CLI | `gh issue`, `gh pr`, `gh repo view` | 2 |
-| Other | `AskUserQuestion`, `Task`, `Skill`, `TodoWrite` | 4 |
+| Other | `AskUserQuestion`, `Task`, `Skill`, `TaskCreate/TaskUpdate/TaskList/TaskGet` | 4 |
 
 **allow format examples:**
 

--- a/docs-site/content/en/getting-started/introduction.md
+++ b/docs-site/content/en/getting-started/introduction.md
@@ -51,7 +51,7 @@ The biggest problem with **vibe coding** (Vibe Coding) is **context loss**:
 
 - **Saves requirements as a file** for permanent preservation
 - Even if the session ends, you can **resume work** just by reading the SPEC
-- Defines things clearly, **without ambiguity**, in the EARS format
+- Defines things clearly, **without ambiguity**, in the GEARS format
 - Since you do not repeat the same explanation, you **save tokens** too
 
 {{< callout type="info" >}}
@@ -212,7 +212,7 @@ MoAI-ADK follows a 3-phase development workflow. The run-phase methodology is se
 
 ```mermaid
 flowchart TD
-    A["Phase 1: SPEC<br/>/moai plan"] -->|"Define requirements in EARS format"| B{"Methodology selection"}
+    A["Phase 1: SPEC<br/>/moai plan"] -->|"Define requirements in GEARS format"| B{"Methodology selection"}
     B -->|"New project (TDD)"| C["Phase 2: TDD<br/>/moai run"]
     B -->|"Existing project (DDD)"| D["Phase 2: DDD<br/>/moai run"]
     C -->|"RED → GREEN → REFACTOR"| E["Phase 3: Docs<br/>/moai sync"]

--- a/docs-site/content/en/getting-started/quickstart.md
+++ b/docs-site/content/en/getting-started/quickstart.md
@@ -65,7 +65,7 @@ Run `/moai project` after initial project setup or after major structural change
 
 ### Step 3: Create a SPEC Document
 
-Create a SPEC document for your first feature. It uses the EARS format to define clear requirements.
+Create a SPEC document for your first feature. It uses the GEARS format to define clear requirements.
 
 {{< callout type="info" >}}
 **Why do you need a SPEC?**
@@ -81,7 +81,7 @@ The biggest problem with **vibe coding** (Vibe Coding) is **context loss**:
 | Problem | How the SPEC solves it |
 |------|-----------------|
 | Context loss | Requirements **saved as files**, preserved permanently |
-| Ambiguous requirements | Clearly structured in the **EARS format** |
+| Ambiguous requirements | Clearly structured in the **GEARS format** |
 | Communication errors | Completion conditions stated as **acceptance criteria** |
 | No progress tracking | Work units managed by **SPEC ID** |
 
@@ -96,7 +96,7 @@ This command does the following:
 
 ```mermaid
 flowchart TB
-    A["Requirements input"] --> B["EARS-format analysis"]
+    A["Requirements input"] --> B["GEARS-format analysis"]
     B --> C["SPEC document generation"]
     C --> D["SPEC-AUTH-001 saved"]
     D --> E["Requirements verification"]
@@ -260,7 +260,7 @@ sequenceDiagram
     Project-->>Dev: product/structure/tech.md
 
     Dev->>Plan: Enter feature requirements
-    Plan->>Plan: Analyze in EARS format
+    Plan->>Plan: Analyze in GEARS format
     Plan-->>Dev: SPEC-AUTH-001 document
 
     Note over Dev: Run /clear

--- a/docs-site/content/ja/advanced/hooks-guide.md
+++ b/docs-site/content/ja/advanced/hooks-guide.md
@@ -444,7 +444,7 @@ ralph:
 
 **保存内容:**
 - 現在のアクティブ SPEC 状態 (ID、ステップ、進行率)
-- 進行中の作業一覧 (TodoWrite)
+- 進行中の作業一覧 (TaskCreate/TaskUpdate/TaskList/TaskGet)
 - 完了した作業一覧
 - 修正されたファイル一覧
 - Git 状態情報 (ブランチ、コミットされていない変更)

--- a/docs-site/content/ja/advanced/settings-json.md
+++ b/docs-site/content/ja/advanced/settings-json.md
@@ -258,7 +258,7 @@ Claude Code を開くときの基本権限モードです。有効な値は次�
 | コード品質 | `ruff`, `black`, `prettier`, `eslint` | 6 個+ |
 | 探索ツール | `ls`, `find`, `tree`, `cat`, `head` | 10 個+ |
 | GitHub CLI | `gh issue`, `gh pr`, `gh repo view` | 2 個 |
-| その他 | `AskUserQuestion`, `Task`, `Skill`, `TodoWrite` | 4 個 |
+| その他 | `AskUserQuestion`, `Task`, `Skill`, `TaskCreate/TaskUpdate/TaskList/TaskGet` | 4 個 |
 
 **allow 形式の例:**
 

--- a/docs-site/content/ja/getting-started/introduction.md
+++ b/docs-site/content/ja/getting-started/introduction.md
@@ -51,7 +51,7 @@ MoAI-ADK は **SPEC ベースの TDD/DDD** 方法論を基盤とし、**TRUST 5*
 
 - 要件を **ファイルに保存** して永久保存
 - セッションが切れても SPEC を読めば **続けて作業** 可能
-- EARS 形式で **曖昧さなく** 明確に定義
+- GEARS 形式で **曖昧さなく** 明確に定義
 - 同じ説明を繰り返さないので **トークンも節約** されます
 
 {{< callout type="info" >}}
@@ -212,7 +212,7 @@ MoAI-ADK は 3 段階の開発ワークフローに従います。Run ステッ�
 
 ```mermaid
 flowchart TD
-    A["Phase 1: SPEC<br/>/moai plan"] -->|"EARS 形式で要件を定義"| B{"方法論の選択"}
+    A["Phase 1: SPEC<br/>/moai plan"] -->|"GEARS 形式で要件を定義"| B{"方法論の選択"}
     B -->|"新規プロジェクト (TDD)"| C["Phase 2: TDD<br/>/moai run"]
     B -->|"既存プロジェクト (DDD)"| D["Phase 2: DDD<br/>/moai run"]
     C -->|"RED → GREEN → REFACTOR"| E["Phase 3: Docs<br/>/moai sync"]

--- a/docs-site/content/ja/getting-started/quickstart.md
+++ b/docs-site/content/ja/getting-started/quickstart.md
@@ -65,7 +65,7 @@ flowchart TB
 
 ### ステップ 3: SPEC 文書の生成
 
-最初の機能に対する SPEC 文書を生成します。EARS 形式を使って明確な要件を定義します。
+最初の機能に対する SPEC 文書を生成します。GEARS 形式を使って明確な要件を定義します。
 
 {{< callout type="info" >}}
 **なぜ SPEC が必要なのか?**
@@ -81,7 +81,7 @@ flowchart TB
 | 問題 | SPEC の解決方法 |
 |------|-----------------|
 | コンテキストの喪失 | 要件を **ファイルとして保存** し永久保存 |
-| 曖昧な要件 | **EARS 形式** で明確に構造化 |
+| 曖昧な要件 | **GEARS 形式** で明確に構造化 |
 | コミュニケーションエラー | **受け入れ基準** で完了条件を明示 |
 | 進捗の追跡不能 | **SPEC ID** で作業単位を管理 |
 
@@ -96,7 +96,7 @@ flowchart TB
 
 ```mermaid
 flowchart TB
-    A["要件の入力"] --> B["EARS 形式の分析"]
+    A["要件の入力"] --> B["GEARS 形式の分析"]
     B --> C["SPEC 文書の生成"]
     C --> D["SPEC-001 の保存"]
     D --> E["要件の検証"]
@@ -260,7 +260,7 @@ sequenceDiagram
     Project-->>Dev: product/structure/tech.md
 
     Dev->>Plan: 機能要件の入力
-    Plan->>Plan: EARS 形式で分析
+    Plan->>Plan: GEARS 形式で分析
     Plan-->>Dev: SPEC-001 文書
 
     Note over Dev: /clear を実行

--- a/docs-site/content/ko/advanced/hooks-guide.md
+++ b/docs-site/content/ko/advanced/hooks-guide.md
@@ -444,7 +444,7 @@ ralph:
 
 **저장 내용:**
 - 현재 활성 SPEC 상태 (ID, 단계, 진행률)
-- 진행 중인 작업 목록 (TodoWrite)
+- 진행 중인 작업 목록 (TaskCreate/TaskUpdate/TaskList/TaskGet)
 - 완료된 작업 목록
 - 수정된 파일 목록
 - Git 상태 정보 (브랜치, 커밋되지 않은 변경)

--- a/docs-site/content/ko/advanced/settings-json.md
+++ b/docs-site/content/ko/advanced/settings-json.md
@@ -258,7 +258,7 @@ Claude Code를 열 때의 기본 권한 모드입니다. 유효한 값은 다음
 | 코드 품질 | `ruff`, `black`, `prettier`, `eslint` | 6개+ |
 | 탐색 도구 | `ls`, `find`, `tree`, `cat`, `head` | 10개+ |
 | GitHub CLI | `gh issue`, `gh pr`, `gh repo view` | 2개 |
-| 기타 | `AskUserQuestion`, `Task`, `Skill`, `TodoWrite` | 4개 |
+| 기타 | `AskUserQuestion`, `Task`, `Skill`, `TaskCreate/TaskUpdate/TaskList/TaskGet` | 4개 |
 
 **allow 형식 예시:**
 

--- a/docs-site/content/ko/getting-started/introduction.md
+++ b/docs-site/content/ko/getting-started/introduction.md
@@ -51,7 +51,7 @@ MoAI-ADK는 **SPEC 기반 TDD/DDD** 방법론을 따르며, **TRUST 5** 품질 �
 
 - 요구사항을 **파일로 저장**하여 영구 보존
 - 세션이 끊겨도 SPEC만 읽으면 **이어서 작업** 가능
-- EARS 형식으로 **모호함 없이** 명확하게 정의
+- GEARS 형식으로 **모호함 없이** 명확하게 정의
 - 같은 설명을 반복하지 않으니 **토큰도 절약**됩니다
 
 {{< callout type="info" >}}
@@ -212,7 +212,7 @@ MoAI-ADK는 3단계 개발 워크플로우를 따릅니다. Run 단계의 방법
 
 ```mermaid
 flowchart TD
-    A["Phase 1: SPEC<br/>/moai plan"] -->|"EARS 형식으로 요구사항 정의"| B{"방법론 선택"}
+    A["Phase 1: SPEC<br/>/moai plan"] -->|"GEARS 형식으로 요구사항 정의"| B{"방법론 선택"}
     B -->|"신규 프로젝트 (TDD)"| C["Phase 2: TDD<br/>/moai run"]
     B -->|"기존 프로젝트 (DDD)"| D["Phase 2: DDD<br/>/moai run"]
     C -->|"RED → GREEN → REFACTOR"| E["Phase 3: Docs<br/>/moai sync"]

--- a/docs-site/content/ko/getting-started/quickstart.md
+++ b/docs-site/content/ko/getting-started/quickstart.md
@@ -65,7 +65,7 @@ flowchart TB
 
 ### 3단계: SPEC 문서 생성
 
-첫 기능의 SPEC 문서를 만듭니다. EARS 형식으로 요구사항을 명확하게 정의합니다.
+첫 기능의 SPEC 문서를 만듭니다. GEARS 형식으로 요구사항을 명확하게 정의합니다.
 
 {{< callout type="info" >}}
 **SPEC이 왜 필요한가요?**
@@ -81,7 +81,7 @@ flowchart TB
 | 문제 | SPEC의 해결 방법 |
 |------|-----------------|
 | 맥락 유실 | 요구사항을 **파일로 저장**하여 영구 보존 |
-| 모호한 요구사항 | **EARS 형식**으로 명확하게 구조화 |
+| 모호한 요구사항 | **GEARS 형식**으로 명확하게 구조화 |
 | 커뮤니케이션 오류 | **인수 기준**으로 완료 조건 명시 |
 | 진행 상황 추적 불가 | **SPEC ID**로 작업 단위 관리 |
 
@@ -96,7 +96,7 @@ flowchart TB
 
 ```mermaid
 flowchart TB
-    A["요구사항 입력"] --> B["EARS 형식 분석"]
+    A["요구사항 입력"] --> B["GEARS 형식 분석"]
     B --> C["SPEC 문서 생성"]
     C --> D["SPEC-AUTH-001 저장"]
     D --> E["요구사항 검증"]
@@ -260,7 +260,7 @@ sequenceDiagram
     Project-->>Dev: product/structure/tech.md
 
     Dev->>Plan: 기능 요구사항 입력
-    Plan->>Plan: EARS 형식으로 분석
+    Plan->>Plan: GEARS 형식으로 분석
     Plan-->>Dev: SPEC-AUTH-001 문서
 
     Note over Dev: /clear 실행

--- a/docs-site/content/zh/advanced/hooks-guide.md
+++ b/docs-site/content/zh/advanced/hooks-guide.md
@@ -447,7 +447,7 @@ ralph:
 
 **保存内容：**
 - 当前活动 SPEC 状态（ID、阶段、进度）
-- 进行中的任务列表（TodoWrite）
+- 进行中的任务列表（TaskCreate/TaskUpdate/TaskList/TaskGet）
 - 已完成的任务列表
 - 已修改的文件列表
 - Git 状态信息（分支、未提交的变更）

--- a/docs-site/content/zh/advanced/settings-json.md
+++ b/docs-site/content/zh/advanced/settings-json.md
@@ -258,7 +258,7 @@ Claude 工作时是否在 spinner 中显示提示。设为 `false` 禁用提示�
 | 代码质量 | `ruff`, `black`, `prettier`, `eslint` | 6 个以上 |
 | 探索工具 | `ls`, `find`, `tree`, `cat`, `head` | 10 个以上 |
 | GitHub CLI | `gh issue`, `gh pr`, `gh repo view` | 2 个 |
-| 其他 | `AskUserQuestion`, `Task`, `Skill`, `TodoWrite` | 4 个 |
+| 其他 | `AskUserQuestion`, `Task`, `Skill`, `TaskCreate/TaskUpdate/TaskList/TaskGet` | 4 个 |
 
 **allow 格式示例：**
 

--- a/docs-site/content/zh/getting-started/introduction.md
+++ b/docs-site/content/zh/getting-started/introduction.md
@@ -51,7 +51,7 @@ MoAI-ADK 以 **基于 SPEC 的 TDD/DDD** 方法论为基础,并通过 **TRUST 5*
 
 - 将需求 **保存为文件** 永久保留
 - 即使会话中断,只要读 SPEC 就能 **接着工作**
-- 用 EARS 格式 **无歧义地** 明确定义
+- 用 GEARS 格式 **无歧义地** 明确定义
 - 无需重复相同说明,因此 **也节省 token**
 
 {{< callout type="info" >}}
@@ -212,7 +212,7 @@ MoAI-ADK 遵循 3 阶段开发工作流。Run 阶段的方法论依项目状态�
 
 ```mermaid
 flowchart TD
-    A["Phase 1: SPEC<br/>/moai plan"] -->|"用 EARS 格式定义需求"| B{"方法论选择"}
+    A["Phase 1: SPEC<br/>/moai plan"] -->|"用 GEARS 格式定义需求"| B{"方法论选择"}
     B -->|"新项目 (TDD)"| C["Phase 2: TDD<br/>/moai run"]
     B -->|"既有项目 (DDD)"| D["Phase 2: DDD<br/>/moai run"]
     C -->|"RED → GREEN → REFACTOR"| E["Phase 3: Docs<br/>/moai sync"]

--- a/docs-site/content/zh/getting-started/quickstart.md
+++ b/docs-site/content/zh/getting-started/quickstart.md
@@ -65,7 +65,7 @@ flowchart TB
 
 ### 第 3 步：生成 SPEC 文档
 
-为第一个功能生成 SPEC 文档。使用 EARS 格式定义明确的需求。
+为第一个功能生成 SPEC 文档。使用 GEARS 格式定义明确的需求。
 
 {{< callout type="info" >}}
 **为什么需要 SPEC？**
@@ -81,7 +81,7 @@ flowchart TB
 | 问题 | SPEC 的解决方式 |
 |------|-----------------|
 | 上下文丢失 | 将需求**保存为文件**，永久留存 |
-| 需求含糊 | 用 **EARS 格式**明确结构化 |
+| 需求含糊 | 用 **GEARS 格式**明确结构化 |
 | 沟通错误 | 用**验收标准**明示完成条件 |
 | 无法追踪进度 | 用 **SPEC ID** 管理工作单元 |
 
@@ -96,7 +96,7 @@ flowchart TB
 
 ```mermaid
 flowchart TB
-    A["输入需求"] --> B["EARS 格式分析"]
+    A["输入需求"] --> B["GEARS 格式分析"]
     B --> C["生成 SPEC 文档"]
     C --> D["保存 SPEC-001"]
     D --> E["验证需求"]
@@ -260,7 +260,7 @@ sequenceDiagram
     Project-->>Dev: product/structure/tech.md
 
     Dev->>Plan: 输入功能需求
-    Plan->>Plan: 以 EARS 格式分析
+    Plan->>Plan: 以 GEARS 格式分析
     Plan-->>Dev: SPEC-001 文档
 
     Note over Dev: 执行 /clear

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -47,13 +47,13 @@ var updateCmd = &cobra.Command{
 
 // validateUpdateFlags validates update flag values before execution.
 // SPEC-MODEL-PROFILE-MATRIX-001 (REQ-MPM-015/017): an out-of-set --profile value
-// exits non-zero with a usage error naming the closed set {max, medium, low}.
+// exits non-zero with a usage error naming the closed set {high, medium, low}.
 // SPEC-UPDATE-VERSION-FLAG-001 (REQ-UVF-007 / AC-UVF-007): the --version flag's
 // mutual-exclusion matrix is enforced before any network call.
 func validateUpdateFlags(cmd *cobra.Command, _ []string) error {
 	profileFlag := getStringFlag(cmd, "profile")
 	if profileFlag != "" && !config.IsValidProfile(profileFlag) {
-		return fmt.Errorf("invalid --profile value %q: must be one of: max, medium, low", profileFlag)
+		return fmt.Errorf("invalid --profile value %q: must be one of: high, medium, low", profileFlag)
 	}
 	// SPEC-UPDATE-VERSION-FLAG-001 REQ-UVF-007: --version mutual-exclusion matrix.
 	if err := validateUpdateVersionConflicts(
@@ -86,7 +86,7 @@ func init() {
 	// SPEC-MODEL-PROFILE-MATRIX-001 (REQ-MPM-015/017): --profile override. When
 	// provided, persists the value to llm.profile (no agent frontmatter mutation).
 	// The retired --plan-type flag is no longer exposed.
-	updateCmd.Flags().String("profile", "", "Override the model+effort profile: max, medium, or low (persists to llm.yaml profile)")
+	updateCmd.Flags().String("profile", "", "Override the model+effort profile: high, medium, or low (persists to llm.yaml profile)")
 
 	// SPEC-UPDATE-VERSION-FLAG-001 (REQ-UVF-001): --version <tag> installs a
 	// specific GitHub release tag (stable / rc / previous version) of the moai
@@ -610,7 +610,7 @@ func applyUpdateProfile(projectRoot, profileFlag string) error {
 		return nil
 	}
 	if !config.IsValidProfile(profileFlag) {
-		return fmt.Errorf("invalid --profile value %q: must be one of: max, medium, low", profileFlag)
+		return fmt.Errorf("invalid --profile value %q: must be one of: high, medium, low", profileFlag)
 	}
 	if err := template.ApplyProfile(projectRoot, profileFlag); err != nil {
 		return fmt.Errorf("persist profile: %w", err)

--- a/internal/config/profile.go
+++ b/internal/config/profile.go
@@ -4,7 +4,7 @@ package config
 // enum, its effective-default resolution (with the legacy performance_tier
 // read-time alias), the {model, effort} pair type, and per-agent-override
 // validation. The profile selects the active per-agent-group model+effort
-// column {max, medium, low}, replacing the retired plan_type × tier axis.
+// column {high, medium, low}, replacing the retired plan_type × tier axis.
 
 import "strings"
 
@@ -155,7 +155,7 @@ var retainedAgentNames = map[string]bool{
 // validateProfile checks the llm.profile value against the closed set
 // (REQ-MPM-008). An empty value is the effective default (medium) and is not an
 // error. A non-empty out-of-set value returns a ValidationError naming the
-// offending value AND the closed set {max, medium, low}.
+// offending value AND the closed set {high, medium, low}.
 func validateProfile(cfg *Config) []ValidationError {
 	p := strings.TrimSpace(cfg.LLM.Profile)
 	if p == "" || IsValidProfile(p) {

--- a/internal/template/templates/.claude/skills/moai/workflows/loop.md
+++ b/internal/template/templates/.claude/skills/moai/workflows/loop.md
@@ -8,10 +8,10 @@ description: >
   snapshot-based resume. Use when a bounded project-wide fix sweep is needed.
 user-invocable: false
 metadata:
-  version: "2.6.0"
+  version: "2.6.1"
   category: "workflow"
   status: "active"
-  updated: "2026-07-12"
+  updated: "2026-08-05"
   tags: "loop, goal-preset, sweep, scan-lens, diagnostics, testing, coverage"
 
 # MoAI Extension: Progressive Disclosure
@@ -99,7 +99,7 @@ Before arming the goal preset, the scan stage builds a **FINITE** issue queue fr
 
 ## Supported Flags
 
-- --max N (alias --max-iterations): Maximum iteration count. When absent, the effective default is ralph.yaml `loop.max_iterations` (shipped 10) per the Iteration-Ceiling Precedence rule (see § Ceiling-Exit Verdict Contract) — not a freestanding 100 default.
+- --max N (alias --max-iterations): Maximum iteration count. When absent, the effective default is ralph.yaml `loop.max_iterations` (shipped 5) per the Iteration-Ceiling Precedence rule (see § Ceiling-Exit Verdict Contract) — not a freestanding 100 default.
 - --auto-fix: Enable auto-fix (default Level 1)
 - --sequential (alias --seq): Sequential diagnostics instead of parallel
 - --errors (alias --errors-only): Fix errors only, skip warnings
@@ -376,5 +376,5 @@ All fixes within the loop follow CLAUDE.md Section 7 Safe Development Protocol:
 
 ---
 
-Version: 2.6.0
-Changes: Redefined `/moai loop` as a **goal preset** — a project-wide improvement sweep built ON the goal engine. Added the Goal-Preset Composition section (delegates the iterate-until-done decision to the goal engine via `stop-goal`), the Scan Stage finite-issue-queue section (default LSP + lint + test + review lenses [security, @MX], opt-in `--lens clean|simplify|coverage`, no-invented-improvements HARD boundary, empty-queue immediate exit), the /moai review + /moai fix layering section, and the additive `sweep-residue` exit_kind value. PRESERVED: the mechanical predicate + independent final pass (Step 1/1.5), the ceiling-exit 5-section verdict contract with `.moai/state/loop-verdict-<id>.json` persistence, the iteration-ceiling precedence rule, and the memory-pressure guard. Previous: 2.3.0 replaced sentinel-string success-exit with mechanical predicate; 2.2.0 expanded Language-Specific Commands to 16 languages.
+Version: 2.6.1
+Changes: Corrected the ralph.yaml `loop.max_iterations` shipped default 10→5 to match the code SSOT (`internal/config/defaults.go` `DefaultMaxIterations = 5`); the key-name ralph-plane transition at lines 232/275 was already complete. Previous: 2.6.0 Redefined `/moai loop` as a **goal preset** — a project-wide improvement sweep built ON the goal engine. Added the Goal-Preset Composition section (delegates the iterate-until-done decision to the goal engine via `stop-goal`), the Scan Stage finite-issue-queue section (default LSP + lint + test + review lenses [security, @MX], opt-in `--lens clean|simplify|coverage`, no-invented-improvements HARD boundary, empty-queue immediate exit), the /moai review + /moai fix layering section, and the additive `sweep-residue` exit_kind value. PRESERVED: the mechanical predicate + independent final pass (Step 1/1.5), the ceiling-exit 5-section verdict contract with `.moai/state/loop-verdict-<id>.json` persistence, the iteration-ceiling precedence rule, and the memory-pressure guard. Previous: 2.3.0 replaced sentinel-string success-exit with mechanical predicate; 2.2.0 expanded Language-Specific Commands to 16 languages.


### PR DESCRIPTION
## Summary

Residuals from the ko docs-site audit (#1360), intentionally out of its scope. Three logical commits:

1. **fix(skill): loop.md ralph.max_iterations shipped default 10→5** — the workflow skill stated the default as 10, but the code SSOT (`internal/config/defaults.go` `DefaultMaxIterations = 5`) is 5. The ralph-plane key-name transition at lines 232/275 was already complete; only the default value at line 102 was stale. Applied to deployed skill + template source (version 2.6.0→2.6.1). `make build` verified catalog.yaml is unaffected (skill hash is SKILL.md-scoped, not workflows/).

2. **docs(site): TodoWrite + EARS sweep, 4 locales** —
   - TodoWrite (deprecated CC v2.1.142) → `TaskCreate`/`TaskUpdate`/`TaskList`/`TaskGet` in `settings-json.md` (allow-list table) + `hooks-guide.md` (PreCompact list), 4 locales. Authoritative deprecation note in `tools-reference.md` left unchanged.
   - EARS → GEARS (canonical since v3.0.0) on `introduction.md` + `quickstart.md`, 4 locales. Legacy-context EARS refs in `moai-plan.md` / `spec-based-dev.md` untouched.
   - The `utility-commands/moai.md` HARD TodoWrite block was already corrected in #1360, so only settings-json + hooks-guide remained.

3. **fix(cli): update --profile error/help → {high, medium, low}** — after the max→high rename, `update.go`'s `--profile` error (×2), flag help, and comment still advertised `{max, medium, low}`; now `{high, medium, low}` (matching the sibling `validateProfile` and `init_test.go`). `profile.go` stale comments (×2) corrected for SSOT consistency. Behavior unchanged — `IsValidProfile` still accepts `max` as a read-time legacy alias via `NormalizeProfile`; only advertised/help text changes.

## Verification (clean worktree at HEAD, isolated from local WIP)
- `go build ./...` OK
- `go test ./internal/template/...` ok (18.5s) — commit 1
- `go test ./internal/config/...` ok — commit 3 (profile.go)
- `go test ./internal/cli/ -run 'Profile|Update'` ok (8.9s) — commit 3 (update.go)
- grep-verified: 0 standalone EARS / 0 TodoWrite in scope; `tools-reference.md:46` untouched; only 19 intended files in the diff.

Note: `utility-commands/moai.md` TodoWrite block was a stale-local phantom (already fixed upstream in #1360) — caught by verifying against `origin/main` before editing.

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated multilingual guides to use the GEARS terminology consistently.
  - Replaced outdated task-list tool references with the current task management tools.
  - Corrected workflow documentation to reflect the shipped iteration limit and latest metadata.

- **Bug Fixes**
  - Corrected the documented default maximum iteration count from 10 to 5.
  - Renamed the `max` profile option to `high` across CLI guidance, validation, and error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->