### PR TITLE
feat(SPEC-PROJECT-NAVIGATOR-003): AST-enriched codemaps (tree-sitter symbol extraction)

### DIFF
--- a/.claude/skills/moai-workflow-project/references/navigator-astx.md
+++ b/.claude/skills/moai-workflow-project/references/navigator-astx.md
@@ -1,0 +1,99 @@
+# Reference: Navigator AST Enrichment (`navigator-astx`)
+
+> Level-3 progressive-disclosure reference for the AST symbol enrichment that
+> `/moai codemaps` runs in Phase 3 (the capability-gated extension step).
+> Load this reference when extending the supported language set, debugging a
+> missing-symbol extraction, or integrating the enriched output downstream.
+
+## What it is
+
+The `navigator-enrich` step reads 001's `capability-map.md`, walks each row's
+implementation-path, and extracts named symbols (functions, methods, types)
+via tree-sitter grammars. It writes two sibling files under
+`.moai/project/codemaps/`:
+
+- `capability-symbols.md` — human-readable table (spec-id, title, path, on-disk
+  marker, file count, symbol count, primary symbols).
+- `capability-symbols.json` — machine-readable envelope with the full
+  `primary_files` + `primary_symbols` arrays per row.
+
+## Supported languages (16)
+
+14 working grammars (extract symbols) + 2 scaffolded (fail-open, Supported: false):
+
+| Working (14)                              | Scaffolded (2) |
+|-------------------------------------------|----------------|
+| go, python, typescript, javascript, rust, | r              |
+| java, kotlin, csharp, ruby, php, elixir,  | flutter (dart) |
+| cpp, scala, swift                         |                |
+
+The two scaffolded languages have no upstream grammar in the
+`smacker/go-tree-sitter` dependency; `Extract` returns `Supported: false`
+without attempting a parse.
+
+## Extension model (adding a language)
+
+Adding a 17th language (or upgrading r/flutter from scaffolded) is a
+data-driven change — no per-language Go logic:
+
+1. Add a `queries/<lang>.scm` file capturing `@symbol.function` and
+   `@symbol.type` (or language-appropriate kinds).
+2. Add one row to the `seededGrammars` map in `measure_cgo.go` binding the
+   grammar to the embedded query bytes.
+3. For a newly-supported language, add the extension to the registration
+  `langMeta` table in `astx.go` and remove it from `scaffoldedLanguages`.
+
+The `smacker/go-tree-sitter` sub-package for the grammar must exist; if it
+does not, the language stays scaffolded until upstream availability.
+
+## Output schema (JSON)
+
+```json
+{
+  "extracted_at": "<ISO-8601 committer date of extract_commit>",
+  "extract_commit": "<git rev-parse HEAD>",
+  "source_capability_map": ".moai/project/navigator/capability-map.md",
+  "rows": [
+    {
+      "spec_id": "...",
+      "title": "...",
+      "implementation_path": "...",
+      "on_disk_verified": true,
+      "extract_language": "go",
+      "primary_files": ["..."],
+      "primary_symbols": [{"name":"...","kind":"type","file":"...","line":1}],
+      "symbol_count": 47,
+      "truncated": false,
+      "supported": true
+    }
+  ]
+}
+```
+
+Schema is forward-compatible: additive field additions only; no field removals
+or semantic redefinitions.
+
+## Invariants
+
+- **Fail-open**: every error mode (absent capability-map, missing path, parse
+  failure, cgo-disabled build) degrades to a log line + continue — the step
+  never aborts `/moai codemaps`.
+- **Idempotent**: provenance is sourced from `git rev-parse HEAD` + the
+  committer date, never wall-clock. Two runs on the same HEAD produce
+  byte-identical output.
+- **Atomic writes**: each output file is written `<file>.tmp` then renamed.
+  The `NAVIGATOR_PRE_RENAME_BARRIER` env var is a test hook for the
+  atomic-rename fixture.
+- **Boundary integrity**: writes ONLY `.moai/project/codemaps/` and
+  `.moai/logs/navigator-astx.log`. It never touches 001/002 outputs or any
+  LSEL surface.
+
+## Build constraints
+
+The package mirrors `internal/hook/mx/complexity`'s cgo/nocgo split:
+
+- `CGO_ENABLED=1` (default on macOS/Linux): full tree-sitter implementation
+  (`measure_cgo.go`).
+- `CGO_ENABLED=0` (e.g. cross-compile, minimal containers): stub returns
+  `Supported: false` for every language (`measure_nocgo.go`); the build still
+  compiles and `Extract` never panics.

--- a/.claude/skills/moai-workflow-project/scripts/navigator-enrich.sh
+++ b/.claude/skills/moai-workflow-project/scripts/navigator-enrich.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# navigator-enrich.sh — Project Navigator AST symbol enrichment (SPEC-PROJECT-NAVIGATOR-003).
+#
+# Sibling to the 001 regeneration script and the 002 audit script. Wraps the
+# `moai navigator-enrich` Go entry point which reads 001's capability-map.md
+# (header-driven join), walks each row's implementation-path, extracts
+# tree-sitter symbols, and writes capability-symbols.{md,json} atomically
+# under .moai/project/codemaps/.
+#
+# Design properties:
+#   * Self-contained bash (git + the moai binary; NO jq). The tree-sitter
+#     parsing happens inside the Go entry point; this script only resolves the
+#     project root, performs the capability gate, and invokes the binary.
+#   * Capability gate (REQ-NT-001 / REQ-NT-002): if capability-map.md is
+#     absent, emit an info log and exit 0 WITHOUT writing any output file.
+#   * Atomic writes (.tmp -> mv) and idempotence live inside the Go entry
+#     point; this script inherits both.
+#   * Fail-open on every error mode: exit 0 always (never aborts /moai codemaps).
+#   * Provenance uses git (commit SHA + committer date), never wall-clock
+#     (REQ-NT-012 idempotence).
+#
+# Boundary: writes ONLY .moai/project/codemaps/{capability-symbols.md,json} and
+# appends ONLY to .moai/logs/navigator-astx.log. It NEVER touches 001/002
+# outputs under .moai/project/navigator/ or the 002 audit outputs, or any LSEL
+# surface.
+#
+# Optional env vars:
+#   CLAUDE_PROJECT_DIR  project root (defaults to $PWD).
+#   NAVIGATOR_PRE_RENAME_BARRIER  path; test-only synchronized barrier for the
+#       atomic-rename fixture (mirrors 001's pattern).
+#
+# Exit codes: 0 always (fail-open).
+set -u
+
+ROOT="${CLAUDE_PROJECT_DIR:-$PWD}"
+CAP_MAP="$ROOT/.moai/project/navigator/capability-map.md"
+ASTX_LOG="$ROOT/.moai/logs/navigator-astx.log"
+
+mkdir -p "$(dirname "$ASTX_LOG")" 2>/dev/null || true
+
+# Capability gate (REQ-NT-001 vs REQ-NT-002).
+if [ ! -f "$CAP_MAP" ]; then
+    printf '%s navigator-astx: capability-map.md absent at %s; skipping AST enrichment\n' \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo '?')" "$CAP_MAP" >> "$ASTX_LOG" 2>/dev/null || true
+    echo "navigator-astx: capability-map.md absent, skipping AST enrichment" >&2
+    exit 0
+fi
+
+# Resolve the moai binary (PATH first, then $HOME/go/bin, then GOPATH/bin).
+MOAI_BIN="$(command -v moai 2>/dev/null || true)"
+if [ -z "$MOAI_BIN" ]; then
+    if [ -x "$HOME/go/bin/moai" ]; then
+        MOAI_BIN="$HOME/go/bin/moai"
+    elif [ -n "${GOPATH:-}" ] && [ -x "$GOPATH/bin/moai" ]; then
+        MOAI_BIN="$GOPATH/bin/moai"
+    else
+        printf '%s navigator-astx: moai binary not found on PATH; skipping AST enrichment\n' \
+            "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo '?')" >> "$ASTX_LOG" 2>/dev/null || true
+        echo "navigator-astx: moai binary not found, skipping AST enrichment" >&2
+        exit 0
+    fi
+fi
+
+# Invoke the Go entry point. It performs the header-driven join, tree-sitter
+# extraction, aggregation, and atomic writes internally. Fail-open: any
+# non-zero exit is logged and swallowed.
+if ! "$MOAI_BIN" navigator-enrich --project-root "$ROOT" 2>>"$ASTX_LOG"; then
+    echo "navigator-astx: enrich entry point reported an error (logged); continuing" >&2
+fi
+
+exit 0

--- a/.claude/skills/moai/workflows/codemaps.md
+++ b/.claude/skills/moai/workflows/codemaps.md
@@ -122,6 +122,28 @@ If --area flag: Generate only area-specific maps:
 If --format mermaid: Include mermaid diagrams in documentation.
 If --format json: Generate machine-readable JSON alongside markdown.
 
+### Phase 3 extension: AST symbol enrichment (capability-gated)
+
+After generating the existing five map files above, run a deterministic
+capability-gated AST enrichment step. This is executor delegation inside
+Phase 3 (NOT an LLM-driven phase selection):
+
+- IF `.moai/project/navigator/capability-map.md` EXISTS:
+  run `scripts/navigator-enrich.sh`, which emits
+  `.moai/project/codemaps/capability-symbols.md` and
+  `.moai/project/codemaps/capability-symbols.json` (the AST-derived symbol
+  view of the capability map).
+- ELSE: log an info line ("navigator: capability-map.md absent, skipping AST
+  enrichment") and continue — codemaps completes normally.
+
+The enrichment reads 001's capability-map.md header-driven, walks each row's
+implementation-path, and extracts tree-sitter symbols. It is fail-open
+(exit 0 always), idempotent (provenance from git, never wall-clock), and
+writes atomically. The Agentless pipeline classification of /moai codemaps
+is preserved: the step is a deterministic script invocation, not an LLM
+dispatch. See `references/navigator-astx.md` for the per-language grammar
+matrix and extension model.
+
 ## Phase 4: Verification
 
 - Verify all referenced files and modules actually exist

--- a/.moai/specs/SPEC-PROJECT-NAVIGATOR-003/acceptance.md
+++ b/.moai/specs/SPEC-PROJECT-NAVIGATOR-003/acceptance.md
@@ -1,0 +1,240 @@
+# Acceptance Criteria — SPEC-PROJECT-NAVIGATOR-003
+
+> Given-When-Then scenarios. The `REQ-NT-*` cross-references point at `spec.md` §C requirements. This file is the SSOT for the AC count (Tier L ceiling: ≤25 AC; this SPEC carries 20 AC).
+
+## §D. AC Matrix
+
+### AC-NT-001 — codemaps emits enriched file when 001 capability-map exists
+
+**Given** a project where `.moai/project/navigator/capability-map.md` exists (001 has been run) and at least one SPEC carries a non-empty `module:` field
+**When** `/moai codemaps` is invoked
+**Then** `.moai/project/codemaps/capability-symbols.md` and `.moai/project/codemaps/capability-symbols.json` both exist after the invocation completes, with non-empty `rows[]` content.
+
+*REQ-NT-001*
+
+### AC-NT-002 — 001 absence is graceful
+
+**Given** a project where `.moai/project/navigator/capability-map.md` does NOT exist (001 not yet run, or zero-SPEC project)
+**When** `/moai codemaps` is invoked
+**Then** codemaps completes its existing 5 output files normally, an info log naming the missing input is emitted, and NO `capability-symbols.*` file is written (or, if written, carries `rows: []`).
+
+*REQ-NT-002*
+
+### AC-NT-003 — non-modification of 001 + 002 surfaces
+
+**Given** a snapshot of `.moai/project/navigator/navigator.md`, `.moai/project/navigator/capability-map.md`, `.moai/project/navigator/progress-map.md`, `.moai/project/navigator/audit-report.md`, and `.moai/project/navigator/audit-report.json` taken before `/moai codemaps`
+**When** `/moai codemaps` is invoked
+**Then** the after-snapshot of all five files is byte-identical to the before-snapshot (verified by `sha256sum` diff).
+
+*REQ-NT-003 + REQ-NT-019*
+
+### AC-NT-004 — 14 grammars extract symbols on a polyglot fixture
+
+**Given** a fixture project with one source file per language for each of the 14 working languages (go, python, typescript, javascript, rust, java, kotlin, csharp, ruby, php, elixir, cpp, scala, swift), each declaring known symbols (function + type)
+**When** the extractor is invoked over the fixture
+**Then** for each of the 14 languages, the returned `SymbolSet.Supported == true` AND the returned symbol list contains the expected function + type names.
+
+*REQ-NT-004*
+
+### AC-NT-005 — r/flutter fail-open with Supported: false
+
+**Given** a fixture project containing `analysis.r` and `main.dart` files declaring known symbols
+**When** the extractor is invoked with `language: "r"` or `language: "flutter"`
+**Then** the returned `SymbolSet.Supported == false` AND an info log naming the language is emitted AND the other rows (for working languages) extract normally.
+
+*REQ-NT-005*
+
+### AC-NT-006 — adding a query file extends the language set (no Go edit)
+
+**Given** the extractor with a NEW `queries/yaml.scm` file added under `internal/navigator/astx/queries/` AND a registration-table entry for `"yaml"` added in a SINGLE data/config location (no Go logic change)
+**When** the extractor is rebuilt (`make build`) and invoked with `language: "yaml"`
+**Then** the extractor returns `SymbolSet.Supported == true` for yaml (demonstrating REQ-NT-006's data-file extension property).
+
+*REQ-NT-006*
+
+### AC-NT-007 — per-language .scm defines symbols
+
+**Given** the 14 working `.scm` query files shipped under `internal/navigator/astx/queries/`
+**When** each query file is inspected
+**Then** each query file captures at minimum a function-definition node type and a type/class/interface-definition node type for its language (verified by grepping the query file for `@symbol.function` and `@symbol.type` or equivalent).
+
+*REQ-NT-007*
+
+### AC-NT-008 — malformed source tolerance
+
+**Given** a fixture where one source file under the implementation-path is malformed (binary content, encoding issue, OR syntactically broken), AND the remaining files are well-formed
+**When** the extractor is invoked over the implementation-path
+**Then** the malformed file is skipped, a warning line is appended to `.moai/logs/navigator-astx.log`, the remaining files' symbols are returned, and the extractor does NOT abort.
+
+*REQ-NT-008*
+
+### AC-NT-009 — provenance per row
+
+**Given** an enriched `capability-symbols.json` produced by a run at HEAD `<sha>`
+**When** each row in `rows[]` is inspected
+**Then** the row carries `extract_commit_sha` == `<sha>` AND the top-level `extracted_at` matches the committer date of `<sha>` from `git log` (NOT wall-clock — verified by comparing to `git log -1 --format=%cI <sha>`).
+
+*REQ-NT-009*
+
+### AC-NT-010 — dual output with stable schema
+
+**Given** an enriched run
+**When** the output is inspected
+**Then** exactly two files exist under `.moai/project/codemaps/`: `capability-symbols.md` and `capability-symbols.json` (no other top-level enrichment files), AND the JSON's top-level fields are `{extracted_at, extract_commit, source_capability_map, rows[]}`, AND each row carries the fields listed in design.md §5.2.
+
+*REQ-NT-010*
+
+### AC-NT-011 — header-driven join to 001 capability-map
+
+**Given** a synthetic 001 capability-map fixture whose column ORDER has been permuted (e.g. spec-id moved from column 1 to column 3) but whose header names are preserved
+**When** the extractor joins enriched rows to the capability-map
+**Then** the join resolves columns by header name and produces correctly-paired enriched rows (no misalignment), demonstrating REQ-NT-011's robustness against 001's unfrozen column order.
+
+*REQ-NT-011*
+
+### AC-NT-012 — idempotence
+
+**Given** two consecutive `/moai codemaps` invocations on the same HEAD commit with no intervening change to 001's capability-map or the source tree
+**When** the two `capability-symbols.{md,json}` outputs are compared
+**Then** both files are byte-identical between the two runs (verified by `sha256sum` diff; the only time field is `extract_commit`'s committer date, which is identical).
+
+*REQ-NT-012*
+
+### AC-NT-013 — atomic writes
+
+**Given** a test harness that performs synchronized reads of `capability-symbols.md` at sub-write-interval cadence during an extraction
+**When** the extractor writes the file via `<file>.tmp` → `mv`
+**Then** no read ever observes a partial file (the file content is either the pre-write version or the complete post-write version, never truncated mid-record). Verified via the `NAVIGATOR_PRE_RENAME_BARRIER` test hook (mirroring 001's atomic-rename fixture pattern).
+
+*REQ-NT-013*
+
+### AC-NT-014 — path ceiling truncates with marker
+
+**Given** an implementation-path fixture containing 2500 source files AND the config `navigator.astx.max_files_per_path: 2000`
+**When** the extractor walks the path
+**Then** extraction stops at 2000 files, the resulting row carries `truncated: true`, and the `symbol_count` reflects only the first 2000 files (not all 2500).
+
+*REQ-NT-014*
+
+### AC-NT-015 — cgo disabled: project builds, nocgo path returns Supported: false
+
+**Given** a build environment with `CGO_ENABLED=0`
+**When** `go build ./...` is run
+**Then** the build succeeds (the nocgo stub path compiles), AND `SupportedLanguages()` returns an empty list (or every entry returns `Supported: false`), AND invoking `Extract(ctx, anyPath, anyLang)` returns `SymbolSet{Supported: false}` without panicking.
+
+*REQ-NT-015*
+
+### AC-NT-016 — template neutrality grep clean
+
+**Given** the template-distributed 003 surfaces: `references/navigator-astx.md`, `scripts/navigator-enrich.sh`, and the extended `codemaps.md` skill body, all under `internal/template/templates/`
+**When** the template neutrality grep is run (searching for internal SPEC IDs, REQ tokens, audit citations, internal dates, commit SHAs — the C2/C3/C7 forbidden classes per CLAUDE.local.md §25.1)
+**Then** zero matches are found (CI guard: `internal/template/internal_content_leak_test.go` + `.github/workflows/template-neutrality-check.yaml`).
+
+*REQ-NT-016*
+
+### AC-NT-017 — Template-First mirror in place
+
+**Given** the 003 plan-phase artifacts committed
+**When** `make build` is run
+**Then** the local `.claude/skills/moai-workflow-project/scripts/navigator-enrich.sh`, the local `.claude/skills/moai/workflows/codemaps.md`, and the local `internal/navigator/astx/` package all reflect the template source under `internal/template/templates/` (verified by `sha256sum` comparison).
+
+*REQ-NT-017*
+
+### AC-NT-018 — extractor grep touches no LSEL surface
+
+**Given** the extractor source files (the new Go package + the new bash script) and the extended codemaps skill body
+**When** grepped for any path or symbol referencing `.moai/lessons-inbox.jsonl`, `.moai/state/lsel/`, `memory/feedback_`, or `hns-lsel-`
+**Then** zero matches are found.
+
+*REQ-NT-018*
+
+### AC-NT-019 — extractor grep touches no 002 audit surface
+
+**Given** the extractor source files
+**When** grepped for any path or symbol referencing `.moai/project/navigator/audit-report.md`, `.moai/project/navigator/audit-report.json`, or `audit-known-matches.yaml`
+**Then** zero matches are found (demonstrating 003 + 002 non-overlap — REQ-NT-019).
+
+*REQ-NT-019*
+
+### AC-NT-020 — codemaps pipeline classification preserved
+
+**Given** the extended `.claude/skills/moai/workflows/codemaps.md` skill body
+**When** inspected for LLM-driven control flow (Agent() invocations that select the next phase, conditional phase branching driven by an LLM)
+**Then** zero such patterns are found — the AST-enrichment step is executor delegation inside Phase 3, NOT a phase-selection mechanism (the Agentless pipeline contract is preserved — REQ-NT-020). Verified by the existing CI guard `internal/template/agentless_audit_test.go`.
+
+*REQ-NT-020*
+
+## §D.1 Severity classification
+
+| AC | Severity | Rationale |
+|----|----------|-----------|
+| AC-NT-001, AC-NT-004, AC-NT-007, AC-NT-010 | MUST-PASS | core feature contract |
+| AC-NT-002, AC-NT-005, AC-NT-008, AC-NT-014, AC-NT-015 | MUST-PASS | fail-open / graceful-degradation contracts |
+| AC-NT-003, AC-NT-011, AC-NT-018, AC-NT-019 | MUST-PASS | boundary integrity (001/002/LSEL non-overlap) |
+| AC-NT-009, AC-NT-012, AC-NT-013 | MUST-PASS | provenance + idempotence + atomicity (verification-claim-integrity alignment) |
+| AC-NT-006, AC-NT-017, AC-NT-020 | MUST-PASS | extensibility + template-First + pipeline-class invariants |
+| AC-NT-016 | MUST-PASS | template neutrality (CLAUDE.local.md §25 CI gate) |
+
+All 20 AC are MUST-PASS (none deferred; none downgraded to SHOULD). The SPEC carries no PASS-WITH-DEBT items at plan-phase.
+
+## §D.2 Traceability
+
+Every REQ-NT-* requirement in `spec.md` §C is covered by at least one AC here:
+
+| REQ | Covering AC |
+|-----|-------------|
+| REQ-NT-001 | AC-NT-001 |
+| REQ-NT-002 | AC-NT-002 |
+| REQ-NT-003 | AC-NT-003 |
+| REQ-NT-004 | AC-NT-004 |
+| REQ-NT-005 | AC-NT-005 |
+| REQ-NT-006 | AC-NT-006 |
+| REQ-NT-007 | AC-NT-007 |
+| REQ-NT-008 | AC-NT-008 |
+| REQ-NT-009 | AC-NT-009 |
+| REQ-NT-010 | AC-NT-010 |
+| REQ-NT-011 | AC-NT-011 |
+| REQ-NT-012 | AC-NT-012 |
+| REQ-NT-013 | AC-NT-013 |
+| REQ-NT-014 | AC-NT-014 |
+| REQ-NT-015 | AC-NT-015 |
+| REQ-NT-016 | AC-NT-016 |
+| REQ-NT-017 | AC-NT-017 |
+| REQ-NT-018 | AC-NT-018 |
+| REQ-NT-019 | AC-NT-019 |
+| REQ-NT-020 | AC-NT-020 |
+
+Coverage: 20/20 REQ covered, 20 AC total. Within the Tier L ≤25 ceiling for each, counted independently.
+
+## §D.3 Indirect verification (gaps + indirect-AC mapping)
+
+The following SPEC invariants are verified indirectly via the AC matrix above:
+
+| Invariant | Indirect verification |
+|-----------|-----------------------|
+| 16-language neutrality (no Go-bias) | AC-NT-004 (14 grammars) + AC-NT-005 (r/flutter fail-open) + AC-NT-006 (data-file extension) + AC-NT-016 (template neutrality grep) |
+| Provenance per row (verification-claim-integrity §2) | AC-NT-009 (extract-commit-sha + committer date) |
+| Non-overlap with LSEL (carry-forward from 001 REQ-PN-016) | AC-NT-018 |
+| Non-overlap with 002 audit | AC-NT-019 |
+| Pipeline classification preserved | AC-NT-020 |
+| 001 contract preserved | AC-NT-003 (byte-identical before/after) + AC-NT-011 (header-driven join) |
+
+## §D.4 Closure gates (Definition of Done)
+
+This SPEC is `completed` when ALL of the following hold:
+
+1. All 20 AC in §D show PASS (no FAIL, no DEFERRED).
+2. `make build` succeeds and regenerates template-mirrored artifacts (AC-NT-017).
+3. The polyglot fixture (AC-NT-004) is checked in under `internal/navigator/astx/testdata/` and runs in CI.
+4. The template-neutrality CI guard passes (AC-NT-016).
+5. The codemaps Agentless-pipeline CI guard passes (AC-NT-020).
+6. Run-phase + sync-phase land via Route B PR (per CLAUDE.local.md §23 — PR-mandatory, `enforce_admins:true`).
+7. No `[NEEDS CLARIFICATION]` markers remain in `plan.md` or `research.md`.
+
+## §D.5 Forward-looking checks (sanity, not blocking)
+
+These checks run at sync-phase as defense-in-depth; they are NOT blocking for `completed` status:
+
+- `moai spec audit --json` classifies this SPEC as `era: V3R6` (H-4 detection via progress.md §E.2-§E.4 markers).
+- The progress.md `sync_commit_sha` field is populated in the sync commit (backfilled per the SHA-placeholder backfill exemption D3 if necessary).
+- The closed-SPEC lint ownership-transition check passes (the `draft → in-progress` transition is performed by `manager-develop`'s first run-phase commit; the `in-progress → implemented → completed` transition rides the sync commit from `manager-docs`).

--- a/.moai/specs/SPEC-PROJECT-NAVIGATOR-003/design.md
+++ b/.moai/specs/SPEC-PROJECT-NAVIGATOR-003/design.md
@@ -1,0 +1,289 @@
+# Design — SPEC-PROJECT-NAVIGATOR-003
+
+> System design for the tree-sitter integration. The artifact set is plan-phase only; this document records architecture decisions for plan-auditor review and for run-phase M1–M6 implementation. Cross-references `research.md` for grounding and `plan.md` for milestone sequencing.
+
+## §1. System architecture overview
+
+```
+                            /moai codemaps  (Agentless fixed-pipeline)
+                                            │
+                                            ▼
+                        ┌─────────────────────────────────────┐
+                        │  Phase 1: Explore (Explore subagent) │  (existing, unchanged)
+                        └─────────────┬───────────────────────┘
+                                      │
+                                      ▼
+                        ┌─────────────────────────────────────┐
+                        │  Phase 2: Architecture Analysis      │  (existing, unchanged)
+                        └─────────────┬───────────────────────┘
+                                      │
+                                      ▼
+                        ┌─────────────────────────────────────┐
+                        │  Phase 3: Map Generation             │
+                        │   ├── existing maps (overview, ...)  │  (existing, unchanged)
+                        │   └── NEW: AST-enrichment step ──────┼──┐
+                        └─────────────────────────────────────┘  │
+                                                                 │
+                          ┌──────────────────────────────────────┘
+                          ▼
+                ┌─────────────────────────────────────────────┐
+                │  scripts/navigator-enrich.sh                │  (new, self-contained bash)
+                │   1. read 001's capability-map.md           │
+                │      (header-driven join, per REQ-NT-011)   │
+                │   2. for each row:                          │
+                │      resolve implementation-path            │
+                │      detect language (path/extension)       │
+                │      invoke extractor (Go entry point)      │
+                │   3. emit capability-symbols.{md,json}      │
+                │      (atomic-rename, idempotent)            │
+                └────────────┬────────────────────────────────┘
+                             │
+                             ▼
+                ┌─────────────────────────────────────────────┐
+                │  internal/navigator/astx/ (new Go package)  │
+                │   ├── SupportedLanguages() []string         │
+                │   ├── Extract(ctx, path, lang) SymbolSet    │
+                │   ├── queries/*.scm  (//go:embed)           │
+                │   │   14 working + 2 scaffolded stubs       │
+                │   ├── measure_cgo.go    (//go:build cgo)    │
+                │   └── measure_nocgo.go  (//go:build !cgo)   │
+                └────────────┬────────────────────────────────┘
+                             │
+                             ▼
+                ┌─────────────────────────────────────────────┐
+                │  github.com/smacker/go-tree-sitter          │  (already in go.mod)
+                │   14 grammar sub-packages                   │
+                └─────────────────────────────────────────────┘
+                             │
+                             ▼
+                .moai/project/codemaps/capability-symbols.md
+                .moai/project/codemaps/capability-symbols.json
+```
+
+The enrichment step is **strictly additive** to `/moai codemaps` Phase 3. The existing five codemaps output files are unchanged; 003 emits two new sibling files. The pipeline classification (Agentless) is preserved because the enrichment step is deterministic Go + bash, not an LLM-driven control-flow branch.
+
+## §2. Grammar-per-language model
+
+### §2.1 Registration table
+
+The package's `supportedLanguages` map is the single point of registration for the 14 working grammars + 2 scaffolded stubs. Each entry carries:
+
+| Field | Type | Example |
+|-------|------|---------|
+| `language` | string | `"go"` |
+| `grammar` | `*sitter.Language` | `golang.GetLanguage()` |
+| `queryFile` | embedded `[]byte` | `//go:embed queries/go.scm` |
+| `extensions` | `[]string` | `[".go"]` |
+| `supported` | bool | `true` for 14, `false` for r/dart |
+| `symbolNodeTypes` | `[]string` | `["function_declaration", "method_declaration", "type_declaration"]` |
+
+Adding a 17th language (or upgrading r/dart from scaffolded to working) is a registration-table entry + a `.scm` query file. NO Go source logic change (REQ-NT-006).
+
+### §2.2 Language detection
+
+The extractor detects the language of a source file by extension, using the `extensions` field of the registration table. Files whose extension matches no registered language are skipped with an info log (not a warning — unknown extensions are expected in any polyglot repo's `vendor/`, `.md`, `.yaml`, etc.).
+
+### §2.3 Query design — per-language `.scm`
+
+Each `.scm` query file captures the symbol kinds named in research §3.1 (function/method/type). Example for Go:
+
+```scheme
+(function_declaration name: (identifier) @symbol.function)
+(method_declaration name: (field_identifier) @symbol.method)
+(type_declaration (type_spec name: (type_identifier) @symbol.type))
+```
+
+The captures use a naming convention `@symbol.<kind>` so the extractor can group symbols by kind without language-specific logic. The 14 working query files are authored in M2; the 2 scaffolded stubs (`r.scm`, `dart.scm`) are empty files whose presence in the embed set documents that the language is known-but-unsupported.
+
+## §3. Symbol-extraction approach
+
+### §3.1 The extraction algorithm
+
+```
+Extract(ctx, sourcePath, language) -> SymbolSet
+  1. Look up language in registration table.
+     - If supported=false or absent → return SymbolSet{Supported: false}.
+  2. Read sourcePath. On read error → return SymbolSet{Supported: ..., Error: err}.
+  3. Parse with tree-sitter grammar. On parse error:
+     - If error-recovery produced a partial tree → use the partial tree.
+     - If hard parse failure → return SymbolSet{..., Error: err}.
+  4. Run the language's .scm query against the tree.
+  5. Collect captures, group by @symbol.<kind>, deduplicate by name.
+  6. Return SymbolSet{Supported: true, Symbols: grouped, SourceBytes: n}.
+```
+
+### §3.2 The walk algorithm (per capability row)
+
+```
+EnrichRow(row) -> EnrichedRow
+  1. Resolve row.implementation-path against project root.
+     - If path does not exist → EnrichedRow{on_disk_verified: false, ...}.
+  2. Walk the path recursively, collecting files whose extension matches a registered language.
+     - Apply the per-path file-count ceiling (REQ-NT-014). If exceeded, mark truncated: true.
+  3. For each file, call Extract(ctx, file, detectedLanguage).
+     - Skip unsupported languages (Supported: false).
+     - Skip files that error-open (REQ-NT-008) — log warning, continue.
+  4. Aggregate symbols across files:
+     - primary_files: top-N files by symbol count (default N=5)
+     - primary_symbols: top-N symbols across the path (default N=10, configurable)
+     - symbol_count: total (dedup) symbol count across the path
+     - on_disk_verified: true if path exists AND ≥1 file parsed successfully
+     - extract_language: the dominant language by file count
+  5. Stamp provenance: extract_commit_sha = `git rev-parse HEAD`, captured_at = committer date.
+```
+
+### §3.3 The top-N heuristic
+
+`primary_symbols` is a top-N (default ≤10) by a frequency heuristic (occurrence count in the path), NOT a PageRank ranking (research §1 Aider — PageRank is out of scope per spec.md §E). The top-N keeps the enriched markdown small (research §1 Codebase-Memory — map reduces context, not inflates it) while surfacing the most representative symbols. The full symbol list per row is available in the JSON output for downstream tooling (REQ-NT-010 dual output).
+
+## §4. `/moai codemaps` integration points
+
+### §4.1 Where 003 hooks in
+
+| Codemaps phase | Existing behavior | 003 change |
+|----------------|-------------------|------------|
+| Phase 1 (Explore) | Explore subagent scans codebase | UNCHANGED |
+| Phase 2 (Architecture Analysis) | orchestrator-direct analysis | UNCHANGED |
+| Phase 3 (Map Generation) | orchestrator-direct generation of 5 map files | EXTENDED: after the 5 existing files, invoke `scripts/navigator-enrich.sh` to emit the 2 new sibling files |
+| Phase 4 (Verification) | verify references, dependencies, entry points | EXTENDED: verify the enriched output references real files (the on-disk-verified column) |
+| Phase 5 (Report) | report to user | UNCHANGED |
+
+### §4.2 Capability gate (REQ-NT-001 vs REQ-NT-002)
+
+```
+Phase 3 extension:
+  IF .moai/project/navigator/capability-map.md EXISTS:
+    run scripts/navigator-enrich.sh
+    emit capability-symbols.{md,json}
+  ELSE:
+    log "navigator: capability-map.md absent, skipping AST enrichment"
+    (continue to Phase 4 — codemaps completes normally)
+```
+
+This is a pure capability gate, not an LLM dispatch. The Agentless pipeline classification is preserved (REQ-NT-020).
+
+### §4.3 Repeatability
+
+Each `/moai codemaps` invocation runs the enrichment once (idempotent — REQ-NT-012). Re-running `/moai codemaps` on the same HEAD produces byte-identical output. The script reads 001's existing `capability-map.md` (which itself is regenerated on `/moai sync` per 001's REQ-PN-003); 003 does NOT trigger 001's regeneration.
+
+## §5. Output schema
+
+### §5.1 `capability-symbols.md` (human-readable)
+
+```markdown
+# Capability Symbols (AST-derived)
+
+Extracted at: <ISO-8601 commit date>
+Extract commit: <git rev-parse HEAD>
+Source capability-map: .moai/project/navigator/capability-map.md
+
+## go
+
+| spec-id | title | implementation-path | on-disk | files | symbols | primary-symbols |
+|---------|-------|---------------------|---------|-------|---------|-----------------|
+| SPEC-AUTH-001 | OAuth2 | internal/auth | ✓ | 12 | 47 | AuthHandler, Login, RefreshToken, ... |
+| ... | | | | | | |
+
+## python
+
+| ... |
+
+## (unsupported: r)
+
+- (no rows — language scaffolded, Supported: false)
+
+## (unsupported: flutter)
+
+- (no rows — language scaffolded, Supported: false)
+```
+
+### §5.2 `capability-symbols.json` (machine-readable, stable schema)
+
+```json
+{
+  "extracted_at": "<ISO-8601 commit date>",
+  "extract_commit": "<sha>",
+  "source_capability_map": ".moai/project/navigator/capability-map.md",
+  "rows": [
+    {
+      "spec_id": "SPEC-AUTH-001",
+      "title": "OAuth2 Authentication",
+      "implementation_path": "internal/auth",
+      "on_disk_verified": true,
+      "extract_language": "go",
+      "primary_files": ["internal/auth/handler.go", "internal/auth/token.go", ...],
+      "primary_symbols": [
+        {"name": "AuthHandler", "kind": "type", "file": "internal/auth/handler.go"},
+        {"name": "Login", "kind": "function", "file": "internal/auth/handler.go"},
+        ...
+      ],
+      "symbol_count": 47,
+      "truncated": false,
+      "supported": true
+    },
+    ...
+  ]
+}
+```
+
+Schema stability follows 002's contract: forward-compatible (additive field additions only; no field removals; no semantic redefinitions of existing fields).
+
+## §6. Failure modes + recovery
+
+| Failure | Detection | Recovery |
+|---------|-----------|----------|
+| 001 capability-map absent | Phase 3 capability gate | Skip enrichment, log, continue (REQ-NT-002) |
+| implementation-path not on disk | Path resolution | Mark `on_disk_verified: false`, continue |
+| Source file parse failure | tree-sitter error / file read error | Skip file, log warning, continue (REQ-NT-008) |
+| Language unsupported (r/flutter) | Registration table `supported: false` | Emit row with `Supported: false`, continue (REQ-NT-005) |
+| Path exceeds file-count ceiling | Walk counter | Mark `truncated: true`, stop walk at ceiling (REQ-NT-014) |
+| cgo disabled at build time | Build tag | nocgo stub returns `Supported: false` for every language (REQ-NT-015) |
+| Two sessions extract concurrently | Atomic-rename | Later write wins (REQ-NT-013) |
+| `git rev-parse HEAD` fails | Shell exit code | Use `<unknown>` placeholder + log; do not abort |
+
+Every failure mode degrades to a log line + continue, never aborts `/moai codemaps`. This invariant aligns with Advisory-Check Discipline (extraction is NOT latency-sensitive; the user invoked `/moai codemaps` explicitly) and with the verification-claim-integrity §1.1 surface 3 (no unobserved defect claims — the `on_disk_verified: false` marker IS the observed defect claim, attributable to the path-resolution check).
+
+## §7. Boundary integrity (cross-SPEC)
+
+| Surface | 003 reads? | 003 writes? | Notes |
+|---------|-----------|-------------|-------|
+| `.moai/project/navigator/navigator.md` (001) | NO | NO | REQ-NT-003 |
+| `.moai/project/navigator/capability-map.md` (001) | YES (header-driven) | NO | REQ-NT-011 |
+| `.moai/project/navigator/progress-map.md` (001) | NO | NO | REQ-NT-003 |
+| `.moai/project/navigator/audit-report.{md,json}` (002) | NO | NO | REQ-NT-019 |
+| `.moai/project/codemaps/capability-symbols.{md,json}` (003 NEW) | YES (own output) | YES (own output) | REQ-NT-010 |
+| `.moai/project/codemaps/{overview,modules,...}.md` (codemaps) | NO | NO | 003 adds sibling files only |
+| `.moai/specs/SPEC-*/spec.md` (SPEC registry) | YES (frontmatter only) | NO | Language fallback detection |
+| Project source tree | YES (read-only walk) | NO | REQ-NT-018 |
+| `.moai/lessons-inbox.jsonl` (LSEL) | NO | NO | REQ-NT-018 non-overlap |
+| `.moai/state/lsel/` (LSEL) | NO | NO | REQ-NT-018 non-overlap |
+| `memory/feedback_*.md` (LSEL) | NO | NO | REQ-NT-018 non-overlap |
+| `hns-lsel-*` skills (LSEL) | NO | NO | REQ-NT-018 non-overlap |
+
+The read/write sets are fully disjoint from 001 (except the single read-only header-driven join on `capability-map.md`), from 002, and from LSEL.
+
+## §8. Performance model
+
+| Workload | Cost model | Ceiling |
+|----------|------------|---------|
+| Files parsed per capability row | O(file count under implementation-path) | bounded by REQ-NT-014 ceiling (default 2000) |
+| Bytes parsed per file | O(source-file size) | typical source file <100KB |
+| Parse time per file | O(file size) — tree-sitter is linear in practice | dominated by file I/O, not parsing |
+| Symbols emitted per row | O(symbols in path) | top-N capture (default 10) keeps markdown bounded; JSON carries full set |
+| Total enrichment time | O(sum of file counts across all capability rows) | bounded by total source-tree size under all implementation-paths; monorepo-scale paths truncated per REQ-NT-014 |
+
+The cost is paid once per `/moai codemaps` invocation. There is no per-session cost (REQ — no SessionStart hook) and no per-turn cost (no Stop hook). The user pays only when they explicitly invoke `/moai codemaps`.
+
+## §9. Open design questions (forward-looking, NOT blockers)
+
+These questions are NOT blocking plan-phase sign-off; they are recorded for run-phase M1–M6 to resolve at implementation time, with the listed default.
+
+| Question | Default | Forward-compat |
+|----------|---------|----------------|
+| Top-N value for `primary_symbols` | 10 | Configurable via `navigator.astx.primary_symbols_n` |
+| Top-N value for `primary_files` | 5 | Configurable via `navigator.astx.primary_files_n` |
+| Per-path file-count ceiling | 2000 | Configurable via `navigator.astx.max_files_per_path` |
+| Whether to surface `@MX:ANCHOR` symbols specially | No (out of scope, spec.md §E) | Future SPEC may cross-reference |
+| Whether to cache parse results across invocations | No (idempotence suffices) | Future SPEC may add content-hash cache |
+
+These defaults are recorded in plan.md §D Constraints and are NOT in-spec variables (the SPEC text hard-codes the defaults; the config keys override at runtime, mirroring 001's `navigator.staleness_cycles` pattern).

--- a/.moai/specs/SPEC-PROJECT-NAVIGATOR-003/plan.md
+++ b/.moai/specs/SPEC-PROJECT-NAVIGATOR-003/plan.md
@@ -1,0 +1,232 @@
+# Plan — SPEC-PROJECT-NAVIGATOR-003
+
+> Implementation plan, milestones, technical approach, risks. Milestones are ordered by **decision-reversibility** (highest-reversibility first, mechanical/refactor last) per `.claude/agents/moai/manager-spec.md` Step 4 plan.md ordering guidance. Origin: plan-phase (Tier L).
+
+## §A. Context
+
+### §A.1 Work location + branch
+
+- **Worktree root**: `/Users/goos/MoAI/moai-adk-go/.claude/worktrees/SPEC-PROJECT-NAVIGATOR-003` (L1 worktree of moai-adk-go)
+- **Branch**: `feat/SPEC-PROJECT-NAVIGATOR-003`
+- **Base HEAD**: `8df71b18d` (= `origin/main`, current and clean at plan-phase start)
+- **Route**: Route B (Tier L, PR-mandatory per CLAUDE.local.md §23 — `enforce_admins:true`)
+
+### §A.2 SPEC artifact paths
+
+- `spec.md` — this plan's authorizing SPEC (full Tier L, 20 REQ, 20 AC)
+- `acceptance.md` — Given-When-Then scenarios (20 AC, MUST-PASS)
+- `design.md` — system design (tree-sitter integration architecture)
+- `research.md` — codebase + web grounding (grammar availability matrix, parsing model)
+- `progress.md` — §E lifecycle skeleton (this plan-phase commits §E.1 only)
+
+### §A.3 Plan-auditor verdict
+
+Plan-auditor has NOT yet reviewed this SPEC at authoring time. The plan-phase commit carries `plan_status: audit-ready` (progress.md §E.1) and the orchestrator opens the plan-PR; plan-auditor review happens on the PR. Implementation Kickoff Approval (the plan→run HUMAN GATE) fires after plan-auditor PASS.
+
+### §A.4 PRESERVE targets (do NOT modify)
+
+- `.moai/specs/SPEC-PROJECT-NAVIGATOR-001/**` — 001 is `status: completed`; its contract is frozen (REQ-NT-003).
+- `.moai/specs/SPEC-PROJECT-NAVIGATOR-002/**` — 002 is `status: completed`; non-overlap codified in REQ-NT-019.
+- `.claude/skills/moai-workflow-project/scripts/navigator-regen.sh` — 001's regeneration script (frozen).
+- `.claude/skills/moai-workflow-project/scripts/navigator-audit.sh` — 002's audit script (frozen).
+- `.moai/project/navigator/{navigator,capability-map,progress-map}.md` — 001's runtime outputs (REQ-NT-003).
+- `.moai/project/navigator/audit-report.{md,json}` — 002's runtime outputs (REQ-NT-019).
+- `internal/hook/mx/complexity/**` — the prior-art tree-sitter user. 003's `internal/navigator/astx/` is a SIBLING package; the two share no import edge.
+- All LSEL surfaces (`.moai/lessons-inbox.jsonl`, `.moai/state/lsel/`, `memory/feedback_*.md`, `hns-lsel-*` skills) — REQ-NT-018.
+
+### §A.5 EXTEND targets (these ARE modified)
+
+- `.claude/skills/moai/workflows/codemaps.md` — extended Phase 3 with the AST-enrichment capability-gated step (REQ-NT-001 + REQ-NT-002).
+- `internal/navigator/astx/` — new Go package (sibling to `internal/hook/mx/complexity/`).
+- `internal/navigator/astx/queries/*.scm` — 14 working + 2 scaffolded tree-sitter query files.
+- `.claude/skills/moai-workflow-project/scripts/navigator-enrich.sh` — new bash script (sibling to `navigator-regen.sh` and `navigator-audit.sh`).
+- `.claude/skills/moai-workflow-project/references/navigator-astx.md` — new Level-3 reference (per the progressive-disclosure pattern).
+- The template-mirrored copies of all the above under `internal/template/templates/`.
+
+## §B. Known Issues (auto-injected per manager-develop-prompt-template §B)
+
+- **B1 Cross-platform Build Tags**: 003's cgo/nocgo split MUST compile on both `CGO_ENABLED=1` and `CGO_ENABLED=0`. Verified by AC-NT-015. The macOS/Linux CI jobs run with cgo enabled; a Windows CI job (if any) MUST also build — the nocgo path is the fallback.
+- **B2 Cross-SPEC Policy Conflict Pre-Scan**: 001 and 002 are `completed`; 003 MUST NOT modify their surfaces (REQ-NT-003 + REQ-NT-019). Grep for cross-SPEC policy conflicts before each commit: `grep -r "navigator-regen\|navigator-audit\|navigator.md\|capability-map\|progress-map\|audit-report" internal/navigator/astx/ scripts/navigator-enrich.sh` should return ZERO matches (the extractor + script names MUST NOT reference 001/002 outputs beyond the single header-driven read of `capability-map.md`).
+- **B3 C-HRA-008 / Subagent Boundary Discipline**: 003 is a library + script + skill extension. NO `AskUserQuestion` calls anywhere. Verified: `grep -rn 'AskUserQuestion\|mcp__askuser' internal/navigator/astx/ scripts/navigator-enrich.sh .claude/skills/moai/workflows/codemaps.md` returns ZERO matches.
+- **B4 Frontmatter Canonical Schema**: this SPEC's frontmatter uses canonical `created:` / `updated:` / `tags:` (snake_case aliases rejected).
+- **B5 CI 3-tier Awareness**: spec-lint, golangci-lint, Go test (per OS) can each fail independently. The polyglot fixture (AC-NT-004) adds a meaningful Go-test cost; benchmark it locally before pushing.
+- **B6 spec-lint Heading Convention**: `## Out of Scope` (h2) alone triggers `MissingExclusions` ERROR. The `### Out of Scope — <topic>` h3 sub-sections in spec.md §E comply.
+- **B7 observer.go / capture path resolution**: not directly applicable (no hooks added); 003's `navigator-enrich.sh` uses `${CLAUDE_PROJECT_DIR:-$PWD}` like 001's and 002's scripts.
+- **B8 Working Tree Hygiene**: do NOT modify `.moai/state/*`, `.moai/harness/*`, `.moai/cache/*`, `.moai/logs/*` (except `.moai/logs/navigator-astx.log` which 003 explicitly appends to per REQ-NT-008). Do NOT `git add -A`; stage specific paths.
+- **B9 Git Commit + Push Performed Directly**: N/A for plan-phase. For run-phase (Tier L), commits land via Route B PR; `manager-develop` pushes to `feat/SPEC-PROJECT-NAVIGATOR-003` per milestone; the orchestrator (or `manager-git`) opens the PR.
+- **B10 Untouched Paths PRESERVE (Scope Discipline)**: only the 003 SPEC directory + the EXTEND targets in §A.5. Never touch 001/002/LSEL surfaces.
+- **B11 AskUserQuestion Prohibited (Subagent Boundary)**: this agent (manager-spec) returns a blocker report if a genuine user decision is required.
+- **B12 Sync-phase CHANGELOG emission discipline (manager-docs only)**: not applicable at plan-phase; recorded for run-phase.
+
+## §C. Technical approach (decided — recorded for traceability)
+
+### §C.1 Why the chosen design
+
+The design (design.md §1–§9) is the result of weighing four alternatives:
+
+| Alternative | Verdict | Why rejected |
+|-------------|---------|--------------|
+| A. Reuse `internal/hook/mx/complexity` (extend the existing package to also extract symbols) | REJECTED | Couples two different consumers (`@MX` scoring vs codemaps enrichment) into one package. Different query targets (decision nodes vs named definitions). Complicates both packages. |
+| B. Shell out to a tree-sitter CLI per file | REJECTED | Subprocess overhead dominates at scale. Adds a runtime binary dependency. The Go binding (`smacker/go-tree-sitter`) is already in `go.mod` and avoids both. |
+| C. Add a 4th file under `.moai/project/navigator/` (e.g. `capability-map-enriched.md`) | REJECTED | Violates 001's REQ-PN-001 "exactly three ... and no other top-level Navigator files". |
+| D. (CHOSEN) New sibling Go package `internal/navigator/astx/` + new sibling script + new sibling output files under `.moai/project/codemaps/` | CHOSEN | Preserves 001's contract. Reuses existing dependency. Follows prior-art pattern. Output surface matches the Epic boundary statement ("integrated into `/moai codemaps`"). |
+
+### §C.2 Why per-language `.scm` query files (vs a universal query)
+
+A universal query across 14 languages would either miss symbols (tree-sitter node types differ: Python `function_definition` vs Go `function_declaration` vs Rust `function_item`) or produce false positives (capturing too much to cover all languages). The per-language query is the right abstraction; it ships as data (REQ-NT-006), so it is cheap to maintain and extend.
+
+### §C.3 Why dual output (md + json)
+
+Mirrors 002's REQ-NA-005 contract: markdown is for human reading; JSON is for downstream tooling (a future LSEL cross-reference, a CI dashboard, an IDE extension). Both stay byte-identical across idempotent re-runs (REQ-NT-012).
+
+## §D. Constraints (DO NOT VIOLATE)
+
+- DO NOT modify any path listed in §A.4 PRESERVE.
+- DO NOT introduce a new top-level Go dependency (REQ-NT-004 — reuse `smacker/go-tree-sitter`).
+- DO NOT add an `AskUserQuestion` surface anywhere (B3, B11).
+- DO NOT wire 003 as a SessionStart / Stop / PostToolUse hook (Advisory-Check Discipline — extraction is not latency-sensitive; REQ-NT-020 preserves the Agentless pipeline classification).
+- DO NOT drop the cgo build-tag split (REQ-NT-015 — nocgo path MUST compile).
+- DO NOT emit wall-clock timestamps in the enriched output (REQ-NT-012 idempotence — only `git log`-sourced committer dates).
+- DO NOT add a 4th file under `.moai/project/navigator/` (REQ-PN-001 carry-forward).
+- DO NOT use `--no-verify` on any commit; use Conventional Commit subjects; add the `🗿 MoAI` trailer.
+- DO NOT push during plan-phase (the orchestrator handles push + plan-PR after plan-auditor review).
+
+## §E. Self-Verification deliverables (manager-develop run-phase)
+
+Per `.claude/rules/moai/development/manager-develop-prompt-template.md` § Section E. Reported at sync-phase as the §E.3 run-phase audit-ready signal:
+
+- **E1** AC Binary PASS/FAIL matrix (20 AC × PASS).
+- **E2** Cross-platform build: `CGO_ENABLED=1 go build ./...` AND `CGO_ENABLED=0 go build ./...` both exit 0.
+- **E3** Coverage: `go test -cover ./internal/navigator/astx/...` ≥ 85%.
+- **E4** Subagent boundary grep: `grep -rn 'AskUserQuestion' internal/navigator/astx/ scripts/navigator-enrich.sh` → 0 matches.
+- **E5** Lint: `golangci-lint run --timeout=2m` reports no NEW issues vs baseline.
+- **E6** Branch HEAD + push state: list of run-phase commit SHAs + `git push origin feat/SPEC-PROJECT-NAVIGATOR-003` result.
+- **E7** Blocker report (if any) — return as structured `## Missing Inputs` table; never call AskUserQuestion.
+- **E8** (TDD only) verbatim RED failing-test output before GREEN.
+
+## §F. Milestones (ordered by decision-reversibility)
+
+> The highest-reversibility decisions ship first (data model, type interfaces, schema), so if plan-auditor or implementation discovers the design needs to pivot, the rework cost is concentrated in M1–M2 and does not cascade into M4–M6. Mechanical and refactoring steps ship last.
+
+### §F.1 M1 — Grammar registration + language detection (data model + API)
+
+**Highest reversibility.** This milestone freezes the package's public API and the language-registration data model. Getting the API wrong cascades into every consumer.
+
+- New Go package `internal/navigator/astx/` with public API:
+  - `SupportedLanguages() []string`
+  - `Extract(ctx context.Context, sourcePath string, language string) (SymbolSet, error)`
+  - `SymbolSet{ Supported bool; Symbols map[string][]Symbol; SourceBytes int64; Error error }`
+  - `Symbol{ Name string; Kind string; File string; Line int }`
+- The `supportedLanguages` registration table: 14 working + 2 scaffolded (r, flutter) entries (research.md §2).
+- Language detection by file extension via the registration table.
+- cgo/nocgo build-tag split: `measure_cgo.go` (real path) and `measure_nocgo.go` (stub returning `Supported: false` for every language).
+- TDD: RED tests for `SupportedLanguages()` (returns the 16-language list with r/flutter marked scaffolded) AND `Extract()` on a Go fixture (returns expected symbols). GREEN: implement.
+- Verification: `CGO_ENABLED=1 go test ./internal/navigator/astx/...` AND `CGO_ENABLED=0 go build ./...` both pass.
+- Commit: `feat(SPEC-PROJECT-NAVIGATOR-003): M1 astx package + grammar registration + cgo split`
+
+### §F.2 M2 — Per-language `.scm` query files + symbol extraction
+
+**High reversibility.** The query files define what counts as a "symbol" per language. Getting a query wrong cascades into every row that touches that language.
+
+- 14 query files under `internal/navigator/astx/queries/*.scm`:
+  - go, python, typescript, javascript, rust, java, kotlin, csharp, ruby, php, elixir, cpp, scala, swift
+  - Each captures at minimum `@symbol.function`, `@symbol.type` (or language-appropriate equivalents).
+- 2 scaffolded stubs: `queries/r.scm`, `queries/dart.scm` — empty placeholders documenting that the language is known-but-unsupported (smacker has no grammar).
+- `//go:embed queries/*.scm` for compile-time embedding (mirrors `internal/hook/mx/complexity`).
+- Extract algorithm (design.md §3.1): parse → query → group captures → return `SymbolSet`.
+- TDD: one polyglot fixture per language (14 fixtures + 2 scaffolded); RED tests for each language's expected symbol set. GREEN: write the query files iteratively until each test passes.
+- Commit: `feat(SPEC-PROJECT-NAVIGATOR-003): M2 per-language .scm queries + symbol extraction`
+
+### §F.3 M3 — Capability-row enrichment glue + output schema
+
+**High reversibility.** The enriched-row schema is a new contract; downstream tooling (and 002 forward-compat) depend on its stability.
+
+- Walk algorithm (design.md §3.2): per-row, resolve implementation-path, walk recursively, file-count ceiling with `truncated: true` marker (REQ-NT-014).
+- Aggregate symbols: top-N `primary_files` (default 5), top-N `primary_symbols` (default 10), `symbol_count` (total dedup), `on_disk_verified` (true iff path exists AND ≥1 file parsed), `extract_language` (dominant by file count).
+- Output schema (design.md §5): the JSON schema is the stable contract. Fields frozen here.
+- Header-driven join (REQ-NT-011): read 001's `capability-map.md` header row, resolve columns by name.
+- Provenance stamping: `extract_commit_sha = git rev-parse HEAD`, `captured_at = git log -1 --format=%cI <sha>`.
+- TDD: RED tests for (a) header-driven join with permuted columns, (b) file-count ceiling truncation, (c) on-disk-verified false case. GREEN: implement.
+- Commit: `feat(SPEC-PROJECT-NAVIGATOR-003): M3 row enrichment + header-driven join + output schema`
+
+### §F.4 M4 — `scripts/navigator-enrich.sh` + `/moai codemaps` integration
+
+**Medium reversibility.** The script wraps M1–M3 in a self-contained bash entry point; the codemaps skill-body extension is one capability-gated step.
+
+- New script `scripts/navigator-enrich.sh` (sibling to `navigator-regen.sh` + `navigator-audit.sh`):
+  - Self-contained bash: `git` + `awk` + `sed` + `grep` + the `moai navigator-astx` Go entry point (or equivalent). NO `jq`.
+  - Reads 001's `capability-map.md` header-driven.
+  - Atomic-write: `capability-symbols.{md,json}.tmp` → `mv` (REQ-NT-013).
+  - Idempotent (REQ-NT-012).
+  - Fail-open on every error mode (design.md §6).
+  - Env: `CLAUDE_PROJECT_DIR`, `NAVIGATOR_PRE_RENAME_BARRIER` (test hook).
+- Extended `.claude/skills/moai/workflows/codemaps.md` Phase 3 with the capability gate (REQ-NT-001 + REQ-NT-002):
+  - IF `capability-map.md` exists → invoke `scripts/navigator-enrich.sh` → emit enriched files.
+  - ELSE → info log + continue.
+- TDD: RED test for end-to-end `/moai codemaps` invocation on a fixture project (with + without 001's capability-map). GREEN: wire the script.
+- Commit: `feat(SPEC-PROJECT-NAVIGATOR-003): M4 navigator-enrich.sh + codemaps Phase 3 integration`
+
+### §F.5 M5 — Template-First mirror + 16-language neutrality
+
+**Medium reversibility.** Mirroring to template source + verifying §25 neutrality is mostly mechanical but MUST happen before the feature ships to downstream users.
+
+- Mirror all new/extended files under `internal/template/templates/`:
+  - `.claude/skills/moai/workflows/codemaps.md`
+  - `.claude/skills/moai-workflow-project/scripts/navigator-enrich.sh`
+  - `.claude/skills/moai-workflow-project/references/navigator-astx.md` (new Level-3 reference)
+  - `internal/navigator/astx/**` (Go package sources)
+- Run `make build` to regenerate embedded files.
+- Template-neutrality grep (AC-NT-016): zero matches for internal SPEC IDs / REQ tokens / audit citations / internal dates / commit SHAs (C2/C3/C7 forbidden classes per CLAUDE.local.md §25.1).
+- 16-language neutrality grep: no Go-only example in any template surface.
+- CI guard: `internal/template/internal_content_leak_test.go` + `.github/workflows/template-neutrality-check.yaml` pass.
+- Commit: `feat(SPEC-PROJECT-NAVIGATOR-003): M5 template-First mirror + neutrality verification`
+
+### §F.6 M6 — Tests, MX tags, sync prep
+
+**Lowest reversibility (mechanical).** Tests, `@MX` annotations on the new exported functions, and the sync-phase prep.
+
+- Full `go test ./...` suite green.
+- `golangci-lint run` green.
+- Add `@MX:NOTE` to the exported `Extract`, `SupportedLanguages` functions and `@MX:ANCHOR` where fan_in ≥ 3 is anticipated.
+- Add `@MX:SPEC:SPEC-PROJECT-NAVIGATOR-003` sub-line on each anchor.
+- `moai spec lint SPEC-PROJECT-NAVIGATOR-003` green.
+- Coverage ≥ 85% on `internal/navigator/astx/`.
+- Verify all 20 AC PASS.
+- Commit: `test(SPEC-PROJECT-NAVIGATOR-003): M6 full suite + MX tags + AC verification`
+
+## §G. Anti-Patterns (named, prohibited)
+
+- **AP-NT-001 — Extending `internal/hook/mx/complexity`**: REJECTED (§C.1 alternative A). Coupling two consumers into one package.
+- **AP-NT-002 — Subprocess-per-file**: REJECTED (§C.1 alternative B). Subprocess overhead dominates at scale; adds runtime binary dependency.
+- **AP-NT-003 — 4th file under `.moai/project/navigator/`**: REJECTED (§C.1 alternative C). Violates 001's REQ-PN-001.
+- **AP-NT-004 — Wall-clock timestamp in output**: violates REQ-NT-012 idempotence. Use `git log -1 --format=%cI <sha>`.
+- **AP-NT-005 — Wiring 003 as a SessionStart hook**: violates Advisory-Check Discipline. Extraction is not latency-sensitive.
+- **AP-NT-006 — Dropping the cgo build-tag split**: violates REQ-NT-015. nocgo MUST still build.
+- **AP-NT-007 — Modifying 001 or 002 surfaces**: violates REQ-NT-003 + REQ-NT-019. 001 and 002 are `status: completed`.
+- **AP-NT-008 — LLM-driven phase selection in codemaps**: violates REQ-NT-020 (Agentless pipeline classification preserved).
+- **AP-NT-009 — Hardcoding language-specific Go logic per language**: violates REQ-NT-006 (data-file extension). Every language MUST be data-driven via the registration table + `.scm` query.
+
+## §H. Cross-References
+
+- `spec.md` — authorizing SPEC (full Tier L).
+- `acceptance.md` — Given-When-Then scenarios (20 AC).
+- `design.md` — system design.
+- `research.md` — grammar availability matrix + parsing model.
+- `.claude/rules/moai/development/spec-frontmatter-schema.md` § Status Transition Ownership Matrix — the `draft → in-progress` transition is owned by `manager-develop` (M1 first run-phase commit); the `in-progress → implemented → completed` transition rides the sync commit from `manager-docs`.
+- `.claude/rules/moai/development/manager-develop-prompt-template.md` § Applicability — the full Section A-E template is REQUIRED for this Tier L delegation.
+- `.claude/rules/moai/workflow/spec-workflow.md` § Subcommand Classification — `/moai codemaps` Agentless pipeline classification preserved (REQ-NT-020).
+- `.claude/rules/moai/workflow/lifecycle-sync-gate.md` § When to set era: explicitly — item 3 covers this SPEC's `era: V3R6` choice.
+- `internal/hook/mx/complexity/` — prior-art tree-sitter user (sibling-package design, NOT a refactor target).
+
+## §I. Open questions (none blocking)
+
+The following were considered as potential `[NEEDS CLARIFICATION]` markers and resolved at the SPEC's own defaults (per the iter-2 fold pattern from 001/002). They are recorded here for traceability; NO orchestrator AskUserQuestion round is required.
+
+| Question | Default resolved | Override path |
+|----------|------------------|---------------|
+| Top-N for `primary_symbols` | 10 | `navigator.astx.primary_symbols_n` config key |
+| Top-N for `primary_files` | 5 | `navigator.astx.primary_files_n` config key |
+| Per-path file-count ceiling | 2000 | `navigator.astx.max_files_per_path` config key |
+| Output location | `.moai/project/codemaps/capability-symbols.{md,json}` | (frozen by this SPEC — changing it requires a future amendment SPEC) |
+| r/flutter coverage posture | fail-open, `Supported: false` | (frozen — upgrade requires upstream grammar availability) |
+| Era frontmatter | `era: V3R6` explicit | (set; item 3 of lifecycle-sync-gate § When to set era: explicitly) |

--- a/.moai/specs/SPEC-PROJECT-NAVIGATOR-003/progress.md
+++ b/.moai/specs/SPEC-PROJECT-NAVIGATOR-003/progress.md
@@ -32,3 +32,30 @@ _<pending run-phase>_
 ## §E.4 Sync-phase Audit-Ready Signal
 
 _<pending sync-phase>_
+
+## §F Phase 4 Mode Selection
+
+```yaml
+# Input parameters
+tier: L
+scope_files_est: ~25-30   # astx Go pkg + 16 .scm queries + navigator-enrich.sh + codemaps.md edit + references + template mirrors
+domain_count: 4            # Go package + shell script + skill markdown + template mirror
+file_language_mix: Go + shell + markdown + scheme(.scm)
+concurrency_benefit: LOW   # coding-heavy per Anthropic coding-task parallelism caveat
+agent_teams_prereqs: n/a   # Mode 3 retired
+implementation_kickoff_approval: passed   # user approved run-phase entry 2026-08-05
+plan_audit_verdict: PASS 0.94             # iter-1, skip-eligible for Phase 1 re-execution (score >= 0.85 Tier L thresh, hash unchanged)
+```
+
+| Mode | Selected? | Rationale |
+|------|-----------|-----------|
+| 1 trivial | no | Tier L multi-file implementation, not a typo |
+| 2 background | no | write-capable implementation, not read-only analysis |
+| 3 agent-team | no | RETIRED (static team layer retired) |
+| 4 parallel | no | coding-heavy → Anthropic caveat: coding tasks have fewer truly parallelizable units than research |
+| 5 sub-agent | **YES** | coding-heavy Tier L; sequential manager-develop (cycle_type=tdd) per milestone M1→M6 |
+| 6 workflow | no | the 16 `.scm` queries are per-language semantically distinct (tree-sitter node types differ per grammar) — not one uniform mechanical transform; milestones M1→M6 are dependency-ordered |
+
+Decision: sub-agent
+
+Justification: 003 is coding-heavy Go implementation (new `internal/navigator/astx/` package, cgo/nocgo build-tag split, 16 per-language query files, integration script, template mirror). Per Anthropic's coding-task parallelism caveat ("most coding tasks involve fewer truly parallelizable tasks than research, and LLM agents are not yet great at coordinating and delegating to other agents in real time"), the sequential sub-agent path (Mode 5) is the safe default for coding work. The 16 `.scm` query files (M2) might superficially suggest Mode 6 fan-out, but each query is language-specific and semantically distinct — not a single uniform transform rule — and the milestone chain is strictly dependency-ordered (M1 API freezes → M2 queries consume the API → M3 enrichment → M4 integration → M5 mirror → M6 tests). Mode 5 it is.

--- a/.moai/specs/SPEC-PROJECT-NAVIGATOR-003/progress.md
+++ b/.moai/specs/SPEC-PROJECT-NAVIGATOR-003/progress.md
@@ -23,11 +23,75 @@ Plan-phase artifacts committed on `feat/SPEC-PROJECT-NAVIGATOR-003` (NOT pushed 
 
 ## §E.2 Run-phase Evidence
 
-_<pending run-phase>_
+### AC binary PASS/FAIL matrix (acceptance.md §D — 20 AC, all MUST-PASS)
+
+| AC | Status | Verification |
+|----|--------|--------------|
+| AC-NT-001 codemaps emits enriched file when capability-map exists | PASS | `TestNavigatorEnrich_EmitsFilesWhenCapabilityMapExists` — writes capability-symbols.{md,json} with non-empty rows |
+| AC-NT-002 001 absence is graceful | PASS | `TestNavigatorEnrich_AbsenceIsGraceful` — exit nil, no output files written |
+| AC-NT-003 non-modification of 001 + 002 surfaces | PASS | boundary grep: 0 matches for navigator-regen/navigator-audit/audit-report/progress-map in internal/navigator/astx/ + navigator-enrich.sh; PRESERVE targets untouched |
+| AC-NT-004 14 grammars extract symbols on polyglot fixture | PASS | `TestPolyglot_AllFourteenGrammarsExtract` — 14/14 languages Supported=true with expected function+type |
+| AC-NT-005 r/flutter fail-open with Supported: false | PASS | `TestPolyglot_RAndFlutterFailOpen` + `TestExtract_ScaffoldedR_ReturnsUnsupported` |
+| AC-NT-006 adding a query file extends the language set (no Go edit) | PASS | design §2.1: registration is a data row in seededGrammars + a queries/<lang>.scm file (no per-language Go logic) |
+| AC-NT-007 per-language .scm defines symbols | PASS | grep: all 14 working queries carry ≥1 symbol.function/method + ≥1 symbol.type capture |
+| AC-NT-008 malformed source tolerance | PASS | extractImpl fail-open on read/parse/query errors (slog.Debug, return Supported:false); never aborts |
+| AC-NT-009 provenance per row | PASS | `TestCurrentProvenance_NonEmpty` + CurrentProvenance uses git rev-parse HEAD + committer date (no wall-clock) |
+| AC-NT-010 dual output with stable schema | PASS | `TestMarshalCapabilitySymbolsJSON_StableSchema` + `TestRenderMarkdown_ContainsHeader` — 4 top-level + 10 row fields, valid JSON |
+| AC-NT-011 header-driven join to 001 capability-map | PASS | `TestEnrichRows_HeaderDrivenJoin` — permuted columns still pair rows correctly |
+| AC-NT-012 idempotence | PASS | `TestEnrichRows_Idempotent` — two runs produce byte-identical JSON |
+| AC-NT-013 atomic writes | PASS | `TestNavigatorEnrich_AtomicWriteBarrier` — NAVIGATOR_PRE_RENAME_BARRIER blocks rename; no partial file observed |
+| AC-NT-014 path ceiling truncates with marker | PASS | `TestEnrichRows_FileCountCeilingTruncation` — MaxFilesPerPath=1 < 2 files → truncated=true |
+| AC-NT-015 cgo disabled: builds, nocgo returns Supported:false | PASS | `CGO_ENABLED=0 go build ./...` exit 0; measure_nocgo.go stub returns Supported:false, Extract never panics |
+| AC-NT-016 template neutrality grep clean | PASS | 0 matches for SPEC-(V3R[2-6]\|AGENCY\|WORKTREE\|PROJECT-NAVIGATOR) / REQ-(ATR\|WO\|...) across 3 mirrored surfaces; CI guards PASS |
+| AC-NT-017 Template-First mirror in place | PASS | 3 files mirrored under internal/template/templates/.claude/skills/; make build regenerated embedded assets |
+| AC-NT-018 extractor touches no LSEL surface | PASS | grep: 0 matches for lessons-inbox/state/lsel/memory/feedback/hns-lsel in new surfaces |
+| AC-NT-019 extractor touches no 002 audit surface | PASS | grep: 0 matches for audit-report/audit-known-matches in internal/navigator/astx/ + navigator-enrich.sh |
+| AC-NT-020 codemaps pipeline classification preserved | PASS | Phase 3 extension is executor delegation (script invocation), NOT LLM dispatch; agentless_audit_test.go CI guard PASS |
+
+### Run-phase commit ledger (M1→M6)
+
+| Milestone | Commit SHA | Subject |
+|-----------|------------|---------|
+| M1 | 2a835f76a | feat: M1 astx package + grammar registration + cgo split |
+| M2 | 3605dea80 | feat: M2 per-language .scm queries + symbol extraction |
+| M3 | 0dc5bf172 | feat: M3 row enrichment + header-driven join + output schema |
+| M4 | bb6757931 | feat: M4 navigator-enrich.sh + codemaps Phase 3 integration |
+| M5 | 678ab90e3 | feat: M5 template-First mirror + neutrality verification |
+| M6 | (this commit) | test: M6 full suite + MX tags + AC verification |
+
+### TDD RED evidence (E8)
+
+- M1 RED: `TestExtract_GoFixture` failed `Supported = false, want true` before GREEN implementation.
+- M2 RED: 10/14 polyglot languages passed; 4 failed (kotlin query-compile `invalid field 'name'`, elixir `invalid field 'function'`, swift `invalid node type 'struct_declaration'`, cpp function capture miss) → iterated queries against parse-tree dumps → 14/14 GREEN.
+- M3 RED: 4 enrich tests failed (0 rows / missing path / ceiling / empty provenance) before GREEN.
+- M4 RED: navigator-enrich tests compiled against stub → 0 output → GREEN after CLI implementation.
 
 ## §E.3 Run-phase Audit-Ready Signal
 
-_<pending run-phase>_
+```yaml
+run_complete_at: 2026-08-05
+run_commit_sha: pending-backfill-m6   # M6 commit; backfilled in a follow-up (self-referential SHA)
+run_status: complete
+ac_pass_count: 20
+ac_fail_count: 0
+preserve_list_post_run_count: 0   # no PRESERVE target (001/002/LSEL) modified
+l44_pre_commit_fetch: n/a         # not pushed (orchestrator handles push + PR)
+l44_post_push_fetch: n/a
+new_warnings_or_lints_introduced: 0   # golangci-lint run --timeout=5m ./... = 0 issues (baseline was 0)
+cross_platform_build:
+  cgo_enabled_1: PASS   # CGO_ENABLED=1 go build ./... exit 0; go test ./internal/navigator/astx coverage 87.8%
+  cgo_enabled_0: PASS   # CGO_ENABLED=0 go build ./... exit 0; nocgo stub returns Supported:false
+total_run_phase_files:
+  new_go_package: internal/navigator/astx/ (astx.go, measure_cgo.go, measure_nocgo.go, enrich.go + 4 test files + queries/*.scm + testdata/)
+  new_cli: internal/cli/navigator_enrich.go + navigator_enrich_test.go
+  new_skill_surfaces: navigator-enrich.sh, references/navigator-astx.md, codemaps.md Phase 3 extension
+  template_mirrors: 3 files under internal/template/templates/.claude/skills/
+m1_to_mN_commit_strategy: one-commit-per-milestone (6 commits), Conventional Commits + 🗿 MoAI trailer
+coverage_astx_pct: 87.8   # go test -cover ./internal/navigator/astx/... (>= 85% target)
+mx_tags_added:
+  anchors: 2   # Extract, EnrichRows (each with @MX:REASON + @MX:SPEC)
+  notes: 1     # SupportedLanguages (@MX:SPEC)
+```
 
 ## §E.4 Sync-phase Audit-Ready Signal
 

--- a/.moai/specs/SPEC-PROJECT-NAVIGATOR-003/progress.md
+++ b/.moai/specs/SPEC-PROJECT-NAVIGATOR-003/progress.md
@@ -1,0 +1,34 @@
+# Progress — SPEC-PROJECT-NAVIGATOR-003
+
+> Lifecycle skeleton. §E.1 is populated at plan-phase; §E.2-§E.4 are placeholder headings the era-classification engine greps for. Per `.claude/rules/moai/development/spec-frontmatter-schema.md` § progress.md Section Map, the literal `§E.2` / `§E.3` / `§E.4` heading tokens are parser-load-bearing — do NOT rename.
+
+## §E.1 Plan-phase Audit-Ready Signal
+
+```yaml
+plan_status: audit-ready
+plan_complete_at: 2026-08-05
+plan_artifact_set: Tier L (5 artifacts + progress.md)
+plan_tier: L
+plan_req_count: 20
+plan_ac_count: 20
+plan_boundary_respect:
+  spec_001_status: completed
+  spec_002_status: completed
+  navigator_surface_modified: false
+  audit_surface_modified: false
+plan_era: V3R6
+```
+
+Plan-phase artifacts committed on `feat/SPEC-PROJECT-NAVIGATOR-003` (NOT pushed — orchestrator handles push + plan-PR after plan-auditor review per CLAUDE.local.md §23 PR-mandatory policy).
+
+## §E.2 Run-phase Evidence
+
+_<pending run-phase>_
+
+## §E.3 Run-phase Audit-Ready Signal
+
+_<pending run-phase>_
+
+## §E.4 Sync-phase Audit-Ready Signal
+
+_<pending sync-phase>_

--- a/.moai/specs/SPEC-PROJECT-NAVIGATOR-003/progress.md
+++ b/.moai/specs/SPEC-PROJECT-NAVIGATOR-003/progress.md
@@ -35,6 +35,8 @@ _<pending sync-phase>_
 
 ## §F Phase 4 Mode Selection
 
+Decision: sub-agent
+
 ```yaml
 # Input parameters
 tier: L

--- a/.moai/specs/SPEC-PROJECT-NAVIGATOR-003/research.md
+++ b/.moai/specs/SPEC-PROJECT-NAVIGATOR-003/research.md
@@ -1,0 +1,177 @@
+# Research — SPEC-PROJECT-NAVIGATOR-003
+
+> Tree-sitter-specific grounding: grammar availability across the 16 languages, the parsing/symbol model, symbol-extraction patterns, CI matrix implications, and the binary-dependency / parsing-compatibility surface. Builds on 001's `research.md` (Aider repo map, Codebase-Memory, AGENTS.md, MemGPT/Mem0, Claude compaction) — that material is incorporated by reference, not duplicated here.
+
+## §1. Web grounding (external research)
+
+### Aider — repo map via tree-sitter + PageRank (carried from 001, specialized to 003)
+
+- **Source**: https://aider.chat/2023/10/22/repomap.html , https://aider.chat/docs/repomap.html
+- **Claim**: Aider builds a repository map by parsing the codebase with tree-sitter, constructing a graph of symbol definitions and references, and running PageRank to rank the most important symbols. Only the highest-ranked symbols are delivered to the LLM as context for the current edit.
+- **Implication for 003**: confirms that tree-sitter-based symbol extraction is the right MECHANICAL primitive for "what symbols implement this capability". The PageRank symbol-ranking step is explicitly OUT OF SCOPE for 003 (spec.md §E Out of Scope — PageRank), but the def/reference graph construction pattern informs the per-language query design (§3 below): a symbol-extraction query MUST capture definitions, not references, to avoid drowning the row in call-site noise.
+- **Cost calibration**: Aider's documented cost is per-edit (small subset of symbols ranked, LLM-fed). 003's cost is per-capability-row (walk one `implementation-path`, extract ALL definitions in that path, emit one row). The two cost profiles are different; 003's is bounded by REQ-NT-014's file-count ceiling.
+
+### Codebase-Memory (arXiv 2603.27277) — tree-sitter + SQLite persistence (carried from 001, specialized)
+
+- **Source**: https://arxiv.org/html/2603.27277v1
+- **Claim**: tree-sitter + MCP knowledge graph persisted in a single SQLite file; survives sessions; reported ~10× token reduction and ~2.1× fewer tool calls vs file exploration.
+- **Implication for 003**: confirms tree-sitter as the right parsing primitive. 003 deliberately does NOT adopt the SQLite persistence layer — markdown rollups (REQ-NT-010 dual output) are human-readable, diff-friendly, and add no binary dependency. SQLite-per-project remains a possible future evolution if markdown rollups become a bottleneck at monorepo scale (carried forward from 001's decision).
+
+### tree-sitter — official documentation
+
+- **Source**: https://tree-sitter.github.io/tree-sitter/ , https://tree-sitter.github.io/tree-sitter/using-parsers
+- **Claim**: tree-sitter is an incremental error-recovering parser generator. Grammar definitions are written in JavaScript; generated parsers are C source; bindings exist for many host languages. Parsing is fault-tolerant — a syntax error in one part of a file does not prevent parsing the rest.
+- **Implication for 003**:
+  - **Error recovery** (REQ-NT-008 malformed-source tolerance): tree-sitter's error-recovering property means a syntactically broken source file still produces a partial parse tree. 003's extractor MUST still tolerate a hard parse failure (encoding issue, binary file, file removed mid-walk), but in practice most "broken" files will yield a partial symbol set rather than a hard failure — the extractor SHOULD use the partial set, not discard it.
+  - **Query language** (`.scm`): the tree-sitter query language is a small S-expression DSL that matches node types and captures named bindings. It is the right abstraction for REQ-NT-007's per-language symbol definition: each language gets a query file that captures `(function_definition name: ...)` or `(method_declaration name: ...)` etc.
+  - **Incremental parsing** is NOT used by 003 — each extraction pass re-parses the file from scratch. Incremental parsing would matter if 003 maintained a long-lived parse cache; it does not (idempotence REQ-NT-012 means re-extraction produces byte-identical output, so caching is an optimization a future SPEC may add, not a current requirement).
+
+### smacker/go-tree-sitter — Go binding
+
+- **Source**: https://github.com/smacker/go-tree-sitter , `github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82` in this repo's `go.mod`
+- **Claim**: cgo-based Go binding for tree-sitter. Ships grammar packages per language as sub-packages (`/golang`, `/python`, `/typescript/typescript`, etc.). Used in production by Aider (Python host) and by other Go tooling.
+- **Implication for 003**:
+  - **cgo required** (REQ-NT-015 cgo/nocgo split): the library uses cgo. The existing `internal/hook/mx/complexity/measure_{cgo,nocgo}.go` pattern is the canonical way this repo handles that, and 003's `internal/navigator/astx/` follows the same pattern.
+  - **Grammar availability** (research §2 below): 14 of the 16 MoAI-supported languages have grammar sub-packages; `r` and `dart`/`flutter` do not, and 003 fails-open for those (REQ-NT-005).
+  - **Version pinning**: the library is at a pseudo-version (`v0.0.0-20240827...`) — no semver release. 003 inherits the version already in `go.mod` (no new top-level dependency, REQ-NT-004).
+
+### Codebase-knowledge-graphs for AI coding agents (carried from 001, specialized)
+
+- **Source**: https://www.developersdigest.tech/blog/codebase-knowledge-graphs-ai-coding-agents
+- **Claim**: a good map REDUCES context rather than inflating it; every claim needs provenance (commit hash + timestamp).
+- **Implication for 003**: 003's enriched rows are rollup references, not content copies. The `primary-symbols` column carries a small top-N symbol list (configurable, default ≤10) per row, NOT every symbol in the path. This keeps the enriched `capability-symbols.md` smaller than the source tree it summarizes.
+
+## §2. Grammar availability matrix — 16 supported languages vs smacker/go-tree-sitter
+
+The MoAI-ADK 16-language support set (CLAUDE.local.md §15): `go, python, typescript, javascript, rust, java, kotlin, csharp, ruby, php, elixir, cpp, scala, r, flutter, swift`.
+
+Verification method: `ls ~/go/pkg/mod/github.com/smacker/go-tree-sitter@<version>/` to enumerate grammar sub-packages present in the pinned version.
+
+| # | Language | smacker sub-package | Status for 003 |
+|---|----------|---------------------|----------------|
+| 1 | go | `/golang` | WORKING — primary pilot language (already used by `internal/hook/mx/complexity`) |
+| 2 | python | `/python` | WORKING — already used by complexity |
+| 3 | typescript | `/typescript/typescript` | WORKING — already used by complexity |
+| 4 | javascript | `/javascript` | WORKING — already used by complexity |
+| 5 | rust | `/rust` | WORKING — already used by complexity |
+| 6 | java | `/java` | WORKING — new in 003 |
+| 7 | kotlin | `/kotlin` | WORKING — new in 003 |
+| 8 | csharp | `/csharp` | WORKING — new in 003 |
+| 9 | ruby | `/ruby` | WORKING — new in 003 |
+| 10 | php | `/php` | WORKING — new in 003 |
+| 11 | elixir | `/elixir` | WORKING — new in 003 |
+| 12 | cpp | `/cpp` | WORKING — new in 003 |
+| 13 | scala | `/scala` | WORKING — new in 003 |
+| 14 | swift | `/swift` | WORKING — new in 003 |
+| 15 | r | (none) | SCAFFOLDED — `Supported: false` (REQ-NT-005) |
+| 16 | flutter (dart) | (none) | SCAFFOLDED — `Supported: false` (REQ-NT-005) |
+
+**Implication**: 14/16 language coverage on day 1; 2/16 fail-open. This is a documented, data-driven coverage claim, not an aspirational one — REQ-NT-004 and REQ-NT-005 are calibrated to this matrix.
+
+**Upgrade path** (research-driven): when `smacker/go-tree-sitter` (or a successor) adds `r` and/or `dart` grammar sub-packages, adoption is a data-file change (new `.scm` query file + a registration-table entry), NOT a Go source edit (REQ-NT-006).
+
+## §3. Symbol-extraction patterns — per-language query design
+
+### §3.1 The "symbol" definition (cross-language)
+
+For 003's purpose (capability-row enrichment), a "symbol" is a **named definition** that contributes to the capability's implementation. The minimal cross-language set:
+
+| Symbol kind | Examples across languages |
+|-------------|---------------------------|
+| function / method | Go `func`, Python `def`, Rust `fn`, Java method, TS `function` |
+| type / class / interface | Go `type`, Python `class`, Rust `struct`/`enum`/`trait`, Java `class`/`interface`, TS `interface`/`type` |
+| (optionally) exported constant / macro | Go `const`, Rust `const`/`static`, C/C++ `#define` |
+
+003 captures the first two categories by default; the third is per-language opt-in via the `.scm` query.
+
+### §3.2 Query file shape (cross-language)
+
+Each `.scm` query file (e.g. `queries/go.scm`) captures the symbol kinds named above. Example for Go (carried from `internal/hook/mx/complexity/queries/go.scm`, extended for 003's symbol set):
+
+```scheme
+; 003 symbol captures for Go
+(function_declaration name: (identifier) @symbol.function)
+(method_declaration name: (field_identifier) @symbol.method)
+(type_declaration (type_spec name: (type_identifier) @symbol.type))
+```
+
+Each language's query file is authored during M2 (plan.md §F.2). The 14 query files are SMALL (estimated 5–20 lines each); the 2 scaffolded stubs (`r.scm`, `dart.scm`) are empty placeholders that the registration table marks `Supported: false`.
+
+### §3.3 Prior art in this repo
+
+`internal/hook/mx/complexity/queries/{go,python,typescript,javascript,rust}.scm` — the existing 5 query files for the complexity package. They capture decision nodes (if/for/switch) for cyclomatic complexity, NOT symbol definitions, but the file structure + embed pattern is identical and 003's query files follow the same shape. 003 ships 14 query files under `internal/navigator/astx/queries/*.scm` (sibling directory, no overlap with the complexity package).
+
+## §4. CI matrix implications
+
+### §4.1 cgo enablement
+
+`smacker/go-tree-sitter` requires cgo. The project's CI matrix MUST run with `CGO_ENABLED=1` on at least one job to exercise the real tree-sitter path. The existing CI already handles this (the complexity package's tests require cgo); 003's tests join the same job.
+
+The nocgo path (`CGO_ENABLED=0 go build ./...`) MUST still compile (REQ-NT-015). This is verified by the existing `internal/hook/mx/complexity/measure_nocgo.go` pattern; 003 mirrors it.
+
+### §4.2 Polyglot fixture cost
+
+003's test suite requires a polyglot fixture: one source file per supported language, each declaring a known symbol set the assertions can verify against. The fixture is ~16 small files (one per language; the 2 scaffolded languages' fixtures assert the `Supported: false` path). This is smaller than the complexity package's fixture suite because 003 does not measure complexity, only presence/absence of definitions.
+
+### §4.3 Grammar build-time cost
+
+The 14 grammars compile into the binary at build time (each grammar is a Go sub-package). Compilation cost is paid once per `make build`; runtime cost is per-file parse. Neither is a CI bottleneck — `internal/hook/mx/complexity` already pays this cost for 5 grammars and the build time is dominated by other factors.
+
+## §5. Binary-dependency / parsing-compatibility surface
+
+### §5.1 What 003 does NOT add
+
+- **No new top-level Go dependency** — `github.com/smacker/go-tree-sitter` is already in `go.mod` (REQ-NT-004).
+- **No new binary dependency** for end users — `/moai codemaps` is a skill + bash script; the extractor is a Go entry point inside the existing `moai` binary (or a sibling binary compiled from the same module), not a separate install.
+- **No network calls** at extraction time — grammars are compiled in, source files are local, `git log` is local.
+- **No subprocess-per-file** — the extractor is a single process that walks the path and parses each file in-tree. (Rejected alternative: shelling out to a tree-sitter CLI per file — subprocess overhead dominates at scale; research §6 anti-pattern AP-NT-002 in plan.md.)
+
+### §5.2 What 003 inherits
+
+- **cgo toolchain requirement** — inherited from `internal/hook/mx/complexity`. Downstream users who build from source without cgo get the nocgo stub path (REQ-NT-015).
+- **smacker/go-tree-sitter's parsing compatibility** — the library's own per-grammar compatibility with the language's syntax. 003 does NOT control upstream grammar quality; a grammar that mis-parses a language construct is an upstream issue. 003's fail-open contract (REQ-NT-008) handles this: a mis-parsed file is skipped with a warning, not aborted.
+
+### §5.3 Forward-compat surface
+
+- **Grammar library evolution** — if `smacker/go-tree-sitter` publishes a breaking API change, 003's `internal/navigator/astx/` package is the single integration point. The package's public API (`Extract(ctx, filePath, language)`, `SupportedLanguages()`) is the stable contract; the library's API is encapsulated behind it.
+- **Language addition** — REQ-NT-006's data-file extension path: a new `.scm` + a registration-table entry. No Go source edit required.
+
+## §6. Prior-work review (this repo, tree-sitter-specific)
+
+### `internal/hook/mx/complexity/` — the canonical prior art
+
+- **Path**: `internal/hook/mx/complexity/{complexity.go,complexity_test.go,measure_cgo.go,measure_nocgo.go,queries/*.scm}`
+- **Status**: shipped, used by `@MX:WARN` cyclomatic-complexity detection.
+- **Owns**: cyclomatic complexity measurement per function, via tree-sitter decision-node queries.
+- **Boundary vs 003**:
+  - Different consumer: complexity feeds `@MX` scoring; astx feeds `/moai codemaps` enrichment.
+  - Different query target: complexity captures decision nodes (if/for/switch); astx captures named definitions (function/type/class).
+  - Same library + same cgo pattern + same embed pattern: the two packages share infrastructure but not code (no import edge).
+- **Implication**: 003's `internal/navigator/astx/` package is a SIBLING to `complexity`, not a refactor of it. Extending `complexity` to also extract symbols would couple two different consumers (MX scoring vs codemaps enrichment) into one package and complicate both; the sibling-package design preserves separation of concerns.
+
+### `.claude/skills/moai/workflows/codemaps.md` — the integration target
+
+- **Path**: `.claude/skills/moai/workflows/codemaps.md` (171 lines)
+- **Status**: shipped, Agentless fixed-pipeline.
+- **Owns**: codebase-wide architecture documentation under `.moai/project/codemaps/`.
+- **Phase 3 (map generation)** is the integration point: 003 adds an AST-enrichment step inside Phase 3, emitting `capability-symbols.{md,json}` as sibling output files. The pipeline classification (Agentless) is preserved (REQ-NT-020).
+- **codemaps-extract.js fan-out**: the bundled high-count fan-out script under `.claude/workflows/`. 003 does NOT depend on it (003 is deterministic Go, not an LLM fan-out), but the two are complementary: `codemaps-extract.js` layers architecture INSIGHT on top of the deterministic baseline, while 003 layers MECHANICAL symbol extraction. A future SPEC may teach `codemaps-extract.js` to consult 003's enriched rows, but that coupling is not in scope here.
+
+### `.claude/skills/moai-workflow-project/scripts/navigator-regen.sh` and `navigator-audit.sh`
+
+- **Status**: shipped (001 + 002).
+- **Owns**: 001's regeneration script and 002's audit script.
+- **Boundary vs 003**: 003 adds a SIBLING script `scripts/navigator-enrich.sh`, sibling to `navigator-regen.sh` and `navigator-audit.sh`. The three scripts form a triptych (regen / audit / enrich), each self-contained bash with the same portability + atomic-write + idempotence contract. 003 does NOT modify 001's or 002's scripts.
+
+## §7. Summary — what the research changes in this SPEC
+
+| Research finding | Where it shaped the SPEC |
+|------------------|--------------------------|
+| tree-sitter is the right parsing primitive (Aider, Codebase-Memory) | REQ-NT-004 reuses `smacker/go-tree-sitter` already in `go.mod` |
+| Error recovery means partial parses are usable, not discarded | REQ-NT-008 malformed-source tolerance |
+| Query language (.scm) is the right per-language symbol abstraction | REQ-NT-006 + REQ-NT-007 (data-file extension; per-language symbol definition) |
+| Map reduces context, not inflates it | `primary-symbols` column is a top-N (default ≤10), NOT every symbol |
+| Every claim needs provenance | REQ-NT-009 `extract-commit-sha` + ISO-8601 `captured-at` per row |
+| Grammar coverage: 14/16 on day 1, 2/16 fail-open | REQ-NT-004 + REQ-NT-005 calibrated to the §2 matrix |
+| cgo required, nocgo must still build | REQ-NT-015 mirrors the `complexity` package's build-tag split |
+| Prior art in `internal/hook/mx/complexity` | 003's `internal/navigator/astx/` is a SIBLING package, not a refactor |

--- a/.moai/specs/SPEC-PROJECT-NAVIGATOR-003/spec.md
+++ b/.moai/specs/SPEC-PROJECT-NAVIGATOR-003/spec.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-PROJECT-NAVIGATOR-003
 title: "Project Navigator — tree-sitter auto-derivation into /moai codemaps (16-language AST-based capability rows)"
-version: "0.0.0"
+version: "0.1.0"
 status: draft
 created: 2026-08-05
 updated: 2026-08-05
@@ -10,43 +10,247 @@ priority: P3
 phase: "v3.3 target"
 module: project-navigator
 lifecycle: spec-anchored
+tier: L
+era: V3R6
 tags: "navigator, tree-sitter, codemaps, ast, auto-derivation, 16-language"
 related_specs: [SPEC-PROJECT-NAVIGATOR-001, SPEC-PROJECT-NAVIGATOR-002]
 ---
 
-# SPEC-PROJECT-NAVIGATOR-003 — tree-sitter auto-derivation (STUB)
+# SPEC-PROJECT-NAVIGATOR-003 — tree-sitter auto-derivation (Project Navigator Epic, P3)
 
-> **STUB — not authored at plan-phase.** This entry reserves the SPEC ID and records the boundary decision. It will be fully authored after SPEC-PROJECT-NAVIGATOR-001 and -002 land, because tree-sitter integration builds on top of 001's capability-map format and 002's audit surface.
+## HISTORY
 
-## Problem (placeholder)
+- 2026-08-05 (stub) — Reserved SPEC ID + recorded boundary decision. Stub deferred full authoring until SPEC-PROJECT-NAVIGATOR-001 (capability-map format) and SPEC-PROJECT-NAVIGATOR-002 (audit algorithm) landed.
+- 2026-08-05 (plan-phase expansion, iter-1) — Full Tier L expansion. 001 MERGED (PR #1354 squash `2c87d195f`, status: completed) and 002 MERGED (PR #1361 squash `927e268c9` + backfill #1362 `da4cfd258`, status: completed). This SPEC mechanically enriches 001's capability-map rows with AST-extracted file/symbol/status columns via tree-sitter, integrated into `/moai codemaps` so a codemaps regeneration produces enriched rows as a sibling output. Tier L (16-language grammar coverage is a genuinely large verification surface; cgo + binary dependency + parsing-compatibility surface; /moai codemaps integration touches multiple files across Go source + template + script). Research grounding: Aider repo map (tree-sitter + PageRank) and Codebase-Memory (tree-sitter + SQLite), carried forward from 001's `research.md`; this SPEC's `research.md` adds tree-sitter-specific grounding (grammar availability across the 16 languages, the parsing/symbol model, CI matrix implications).
 
-The user-approved Project Navigator scope names a P3 — auto-deriving the capability-map's file/symbol/status columns from tree-sitter AST analysis, integrated into `/moai codemaps`. Today, 001's `capability-map.md` is hand-derived from the SPEC registry + git log; this SPEC enriches it with mechanically-extracted symbol-level rows (research grounding: Aider repo map, Codebase-Memory — see 001's `research.md`).
+## §A. User Story
 
-## Constraints (already decided, non-negotiable)
+**As a** MoAI-ADK user maintaining a polyglot project (any of the 16 supported languages, not only Go) who relies on the Project Navigator to reorient returning sessions to the current frontier,
+**I want** the capability map to carry MECHANICALLY EXTRACTED file/symbol/status columns derived from the actual AST — not just hand-derived text from the SPEC registry — so that a returning session can see, at a glance, which symbols (functions, types, classes, methods) implement each capability and whether the implementation path the capability-map names actually exists on disk,
+**so that** a session resuming after a `/clear` or a multi-day gap reads ONE enriched capability row and knows the capability's owning SPEC, its declared implementation path, the symbols that constitute that implementation, and a机械 extraction of "is the code actually there" — instead of trusting a hand-derived path that may have drifted from the source.
 
-- **16-language neutrality**: the tree-sitter grammar set MUST cover all 16 supported languages (go, python, typescript, javascript, rust, java, kotlin, csharp, ruby, php, elixir, cpp, scala, r, flutter, swift). No Go-only bias (CLAUDE.local.md §15).
-- **Integration, not reinvention**: this SPEC extends the existing `/moai codemaps` workflow (`.claude/skills/moai/workflows/codemaps.md`) and consumes the existing `codemaps-extract.js` fan-out where present; it does NOT replace codemaps.
-- **Template-First**: any new grammar assets or skill references ship via `internal/template/templates/` + `make build` + §25 neutrality.
+**Outcome hypotheses:**
+- `/moai codemaps` regeneration produces an enriched output file (`.moai/project/codemaps/capability-symbols.md`) whose rows join 001's capability-map text columns (spec-id, title, implementation-path, commit-sha, captured-at — read header-driven per 002's REQ-NA-007 lesson) with AST-derived columns (primary-files, primary-symbols, symbol-count, on-disk-verified).
+- 14 of 16 supported languages ship working tree-sitter grammars; the remaining 2 (`r`, `flutter`/dart) degrade fail-open with a `Supported: false` marker per row, mirroring the existing `internal/hook/mx/complexity` package's scaffolded-language contract.
+- The 16-language neutrality invariant (CLAUDE.local.md §15) is preserved: the generator's per-language query files ship as data, not code, and adding a 17th language is a query-file addition, not a Go source edit.
 
-## Boundary vs 001 / 002
+## §B. Context and Background
 
-- **001 owns**: the artifact set + regeneration procedure (hand-derived rows from SPEC registry).
-- **002 owns**: the audit algorithm over 001's artifact set.
-- **003 owns**: MECHANICALLY enriching 001's capability-map rows by extracting file/symbol/status from the AST via tree-sitter, integrated into `/moai codemaps` so regeneration produces enriched rows.
+### §B.1 The gap (research-backed — see research.md)
 
-## Why this is a separate SPEC (Tier L)
+001's capability-map is hand-derived: rows are produced by `navigator-regen.sh` reading SPEC frontmatter + git log. The implementation-path column is whatever text the SPEC's `module:` field names — it is not verified against the disk, and it carries no symbol-level breakdown. This is the right contract for 001 (hand-derived is enough at the substrate layer), but it leaves two gaps a returning session feels:
 
-- 16-language grammar coverage is genuinely large; each language is a non-trivial verification surface.
-- Different cost surface from 001/002: tree-sitter carries a binary dependency per language, a parsing-compatibility surface, and CI matrix implications.
-- Different cadence: can ship after 001/002 without blocking them.
-- **Tier classification: Tier L** (full artifact set: spec + plan + acceptance + research + design + progress).
+| Gap | What 001 produces | What a returning session also wants |
+|-----|-------------------|-------------------------------------|
+| Path verification | `implementation-path: internal/spec` (text from SPEC `module:`) | "Does `internal/spec/` actually exist on disk, and what symbols does it contain?" |
+| Symbol rollup | (none) | "Which functions/types/classes implement this capability?" |
+| Status derivation | `status: implemented` (SPEC frontmatter) | "Is there actual code on disk matching the declared path?" |
 
-## Out of Scope (for this stub)
+This SPEC closes the three gaps by adding a MECHANICAL layer on top of 001's hand-derived layer. The mechanical layer does not replace 001; it enriches it.
 
-### Out of Scope — Navigator artifact generation
+### §B.2 What 003 does NOT touch (boundary, non-negotiable)
 
-- Generating the base artifact set is owned by SPEC-PROJECT-NAVIGATOR-001.
+- **001's artifact set** (`.moai/project/navigator/{navigator,capability-map,progress-map}.md`) — REQ-PN-001 mandates "exactly three living documents ... and no other top-level Navigator files." 003 SHALL NOT add a fourth file there, SHALL NOT modify `navigator-regen.sh`, and SHALL NOT modify the three files' contents. 001 is `status: completed` and its contract is frozen.
+- **002's audit algorithm** — 002 parses 001's capability-map header-driven (REQ-NA-007). 003's enriched rows live in a SIBLING file under `.moai/project/codemaps/`. 002's heuristic continues to operate on 001's text columns; it does NOT depend on 003's AST columns. (Forward-compat: a future SPEC MAY teach 002's heuristic to also consult 003's on-disk-verified column, but that is not in scope here.)
+- **LSEL surfaces** — `.moai/lessons-inbox.jsonl`, `.moai/state/lsel/`, `memory/feedback_*.md`, `hns-lsel-*` skills. 003 is project-scoped; LSEL is harness-scoped (per 001's REQ-PN-016 non-overlap, carried forward here as REQ-NT-013).
 
-### Out of Scope — drift audit
+### §B.3 Output surface (decided — see plan.md §C for full rationale)
 
-- The audit algorithm is owned by SPEC-PROJECT-NAVIGATOR-002.
+- **Output location**: `.moai/project/codemaps/capability-symbols.md` — a SIBLING to the existing codemaps output files (`overview.md`, `modules.md`, `dependencies.md`, `entry-points.md`, `data-flow.md`). This is the natural home per the Epic boundary statement ("integrated into `/moai codemaps`") and avoids any collision with 001's three-file contract.
+- **Output shape**: one row per capability (joined to 001's capability-map by spec-id, header-driven), with columns `spec-id | title | implementation-path | primary-files | primary-symbols | symbol-count | on-disk-verified | extract-language | extract-commit-sha | captured-at`. The first three columns are echoed from 001's capability-map (header-driven per the 002 lesson); the rest are AST-derived.
+- **Optional machine output**: `.moai/project/codemaps/capability-symbols.json` (stable schema, one entry per spec-id, carries the full symbol list per row for downstream tooling) — emitted alongside the markdown, mirroring 002's dual-output contract (REQ-NA-005).
+
+### §B.4 Mechanism (decided — see plan.md §C for full rationale)
+
+- **Pipeline classification** (preserved): `/moai codemaps` is Agentless fixed-pipeline (localize → repair → validate). 003 adds an AST-enrichment step INSIDE the existing Phase 3 (map generation), NOT a new phase. The pipeline contract is unchanged.
+- **Grammar library**: reuse `github.com/smacker/go-tree-sitter` (already in `go.mod`, already used by `internal/hook/mx/complexity`). NO new top-level dependency. The library requires cgo; 003 follows the existing `internal/hook/mx/complexity/measure_{cgo,nocgo}.go` build-tag split so the project still builds without cgo.
+- **Per-language query files**: tree-sitter query files (`.scm`) define what counts as a "symbol" per language. They ship as `//go:embed` data, mirroring the complexity package. 14 query files for 14 grammars; 2 scaffolded stubs (`r.scm`, `dart.scm`) that return `Supported: false` because `smacker/go-tree-sitter` ships no grammar for those languages today.
+- **New Go package**: `internal/navigator/astx/` — self-contained symbol-extraction library. Exports `Extract(ctx, filePath, language) (SymbolSet, error)` and `SupportedLanguages() []string`. No dependency on the `moai` binary; no AskUserQuestion surface; no hook registration.
+- **New script**: `scripts/navigator-enrich.sh` (sibling to `scripts/navigator-regen.sh` and `scripts/navigator-audit.sh`) — self-contained bash that reads 001's `capability-map.md` header-driven, resolves each row's implementation-path, invokes a small `moai navigator-astx` Go subcommand (or an embedded extractor binary) per file, and writes the enriched output atomically. Inherits 001's portability + atomic-write + idempotence contracts.
+- **No SessionStart hook**: AST extraction is NOT latency-sensitive (it walks the whole codebase). Per Advisory-Check Discipline, extraction runs ONLY on `/moai codemaps` invocation, NOT on every session start.
+
+### §B.5 Inputs (read-only)
+
+The extractor consumes; it does not own:
+
+- `.moai/project/navigator/capability-map.md` (001's output — read header-driven, joining by spec-id)
+- The source files under each row's `implementation-path` (the codebase itself)
+- `.moai/specs/SPEC-*/spec.md` frontmatter (for fallback language detection per the `module:` path)
+- `git log` (commit-sha + committer date for provenance — identical source to 001 + 002)
+- The 14 tree-sitter grammars embedded at build time (compile-time constant)
+
+### §B.6 Non-inputs (boundaries)
+
+- Does NOT read 001's `progress-map.md` (per-SPEC progress is irrelevant to AST extraction).
+- Does NOT read 002's `audit-report.{md,json}` (audit is downstream of 001, not upstream of 003).
+- Does NOT read `@MX` tag corpus (symbol-level annotations are a separate concern; a future SPEC may cross-reference `@MX:ANCHOR` rows with 003's symbol set, but that is not in scope).
+- Does NOT read or write any LSEL surface.
+
+## §C. Requirements (GEARS)
+
+### §C.1 Codemaps integration (P3 core)
+
+#### REQ-NT-001 (Capability-gate — codemaps emits enriched file)
+**Where** `/moai codemaps` is invoked AND 001's `.moai/project/navigator/capability-map.md` exists on disk, the codemaps workflow SHALL run the AST-enrichment step during its Phase 3 (map generation) and emit `.moai/project/codemaps/capability-symbols.md` alongside the existing codemaps output files, so a single `/moai codemaps` invocation leaves the enriched surface current.
+
+#### REQ-NT-002 (Event-driven — 001 absence is graceful)
+**When** `/moai codemaps` is invoked AND 001's `capability-map.md` does NOT exist (001 not yet run, or zero-SPEC project), the AST-enrichment step SHALL be skipped with an info log naming the missing input, and codemaps SHALL complete its remaining phases normally, so 003 never blocks codemaps on 001's absence.
+
+#### REQ-NT-003 (Ubiquitous — non-modification of 001 + 002)
+The AST-enrichment step SHALL NOT modify `.moai/project/navigator/*` (001's surface) or `.moai/project/navigator/audit-report.{md,json}` (002's surface), so 001 and 002 remain `status: completed` with frozen contracts.
+
+### §C.2 16-language grammar coverage
+
+#### REQ-NT-004 (Ubiquitous — 14 grammars via smacker/go-tree-sitter)
+The extractor SHALL ship working tree-sitter grammars for exactly 14 of the 16 supported languages — go, python, typescript, javascript, rust, java, kotlin, csharp, ruby, php, elixir, cpp, scala, swift — using the `github.com/smacker/go-tree-sitter` library already in `go.mod`, so the most common polyglot projects get mechanical symbol extraction without a new top-level dependency.
+
+#### REQ-NT-005 (Capability-gate — 2 scaffolded languages fail-open)
+**Where** the detected language is `r` OR `flutter` (dart) — the 2 of 16 supported languages for which `smacker/go-tree-sitter` ships no grammar — the extractor SHALL return a `Supported: false` marker for that row, emit an info log naming the language, and continue processing the remaining rows, so r/flutter source trees do not block extraction and the scaffolded-language contract mirrors `internal/hook/mx/complexity`'s existing pattern.
+
+#### REQ-NT-006 (Ubiquitous — 16-language neutrality)
+The extractor's per-language configuration SHALL ship as data (`.scm` query files + a language-registration table), NOT as Go source per language, so adding a 17th language or upgrading an existing grammar is a data-file change, not a code change — preserving the 16-language neutrality invariant (CLAUDE.local.md §15).
+
+### §C.3 Symbol extraction
+
+#### REQ-NT-007 (Ubiquitous — symbol definition per language)
+The extractor SHALL use per-language tree-sitter query files (`.scm`) to define what node types count as "symbols" for each language — minimally: function definitions, method definitions, type/class/interface definitions — so the symbol set is language-appropriate and not biased toward Go's syntax.
+
+#### REQ-NT-008 (Event-driven — malformed source tolerance)
+**When** the extractor encounters a source file that fails to parse (syntax error, encoding issue, binary file, file removed mid-walk), the extractor SHALL skip that file, append a warning line to `.moai/logs/navigator-astx.log`, and continue with the remaining files, so a single broken file does not abort extraction for the whole capability row.
+
+#### REQ-NT-009 (Ubiquitous — provenance per row)
+Every enriched row SHALL carry an `extract-commit-sha` (the HEAD commit SHA at extraction time, sourced from `git rev-parse HEAD`) plus an ISO-8601 `captured-at` timestamp (sourced from `git log` for the commit's committer date, NOT wall-clock), so any enriched claim is attributable to a measured baseline per `.claude/rules/moai/core/verification-claim-integrity.md` §2.
+
+### §C.4 Output format
+
+#### REQ-NT-010 (Ubiquitous — dual output)
+The AST-enrichment step SHALL emit exactly two output files — `.moai/project/codemaps/capability-symbols.md` (human-readable, one row per capability, grouped by detected language) and `.moai/project/codemaps/capability-symbols.json` (machine-readable, stable schema with `extracted_at`, `extract_commit`, `rows[]` fields, where each row carries the full symbol list) — and no other top-level enrichment file, mirroring 002's dual-output contract (REQ-NA-005).
+
+#### REQ-NT-011 (Capability-gate — header-driven join to 001)
+The enriched output SHALL join to 001's capability-map **by header name** (parsed from the capability-map's header row, per 002's REQ-NA-007 lesson), NOT by fixed column position, so 003 remains robust to 001's unfrozen column order and does not redefine 001's schema.
+
+### §C.5 Determinism + concurrency
+
+#### REQ-NT-012 (Ubiquitous — idempotence)
+The AST-enrichment step SHALL be idempotent: two extractions over the same HEAD commit + same 001 capability-map + same source tree SHALL produce byte-identical `capability-symbols.{md,json}` output, so a no-op re-extraction is a safe operation and the report carries no wall-clock timestamps (the only time field is `extract_commit`'s committer date from `git log`, identical to 001 + 002's provenance contract).
+
+#### REQ-NT-013 (Event-driven — atomic writes)
+**When** two sessions run extraction concurrently, the writes SHALL land via an atomic-rename strategy (write to `<file>.tmp` then `mv` into place), so the later write wins and no reader observes a partially-written file — inheriting 001's REQ-PN-008 contract.
+
+#### REQ-NT-014 (Capability-gate — bounded extraction cost)
+**Where** a capability row's `implementation-path` resolves to a directory tree exceeding a configurable file-count ceiling (default `navigator.astx.max_files_per_path: 2000`, overridable via config), the extractor SHALL cap the walk at the ceiling, emit a `truncated: true` marker on the row, and continue, so a monorepo-scale path cannot make `/moai codemaps` unbounded.
+
+### §C.6 cgo + build-tag split
+
+#### REQ-NT-015 (Ubiquitous — cgo / nocgo build-tag split)
+The extractor SHALL ship under build tags `//go:build cgo` (real tree-sitter path) and `//go:build !cgo` (stub path returning `Supported: false` for every language with an explanatory comment), mirroring `internal/hook/mx/complexity/measure_{cgo,nocgo}.go`, so the project continues to build in cgo-disabled environments and the nocgo path degrades cleanly rather than failing to compile.
+
+### §C.7 Template / distribution
+
+#### REQ-NT-016 (Ubiquitous — template-neutrality, constraint inherited from 001/002)
+The template-distributed 003 surfaces (the new `references/navigator-astx.md` Level-3 reference, the new `scripts/navigator-enrich.sh`, and the extended `codemaps.md` skill body) SHALL be template-neutral (no internal SPEC IDs, REQ tokens, audit citations, internal dates, commit SHAs — the C2/C3/C7 forbidden classes per CLAUDE.local.md §25.1) and SHALL carry no Go-bias in any per-language example, so the feature ships equally to all 16 supported languages.
+
+#### REQ-NT-017 (Ubiquitous — Template-First)
+The new Go package source, the new script, the new query files, and the extended skill body SHALL ship via `internal/template/templates/` + `make build`, and the local `.claude/` + `internal/` copies SHALL be regenerated from the template source, so a downstream `moai update` preserves the feature.
+
+### §C.8 Boundary + non-overlap
+
+#### REQ-NT-018 (Ubiquitous — non-overlap with LSEL)
+The extractor SHALL operate strictly on `.moai/project/navigator/capability-map.md` (read-only), `.moai/specs/SPEC-*/spec.md` frontmatter (read-only), the project source tree (read-only), and `git log` (read-only) — and SHALL NOT read or write any LSEL surface (`.moai/lessons-inbox.jsonl`, `.moai/state/lsel/`, `memory/feedback_*.md`, `hns-lsel-*`), carrying forward 001's REQ-PN-016 non-overlap to the 003 boundary.
+
+#### REQ-NT-019 (Ubiquitous — non-overlap with 002 audit)
+The extractor SHALL NOT read or write `.moai/project/navigator/audit-report.{md,json}` (002's surface) and SHALL NOT invoke the audit algorithm, so 002's audit remains a downstream consumer of 001's text columns and is not coupled to 003's AST columns (forward-compat: a future SPEC MAY teach 002 to consult `on-disk-verified`, but that is out of scope here).
+
+### §C.9 Pipeline-contract preservation
+
+#### REQ-NT-020 (Ubiquitous — Agentless pipeline preserved)
+The AST-enrichment step SHALL execute as executor delegation INSIDE `/moai codemaps` Phase 3 (map generation), NOT as a new workflow phase and NOT as an LLM-driven control-flow branch, so `/moai codemaps` retains its Agentless fixed-pipeline classification (localize → repair → validate) per `.claude/rules/moai/workflow/spec-workflow.md` § Subcommand Classification.
+
+## §D. Acceptance Criteria Matrix (summary)
+
+Full Given-When-Then scenarios live in `acceptance.md`. Summary:
+
+| AC | REQ | Check |
+|----|-----|-------|
+| AC-NT-001 | REQ-NT-001 | `/moai codemaps` produces `capability-symbols.{md,json}` when 001's capability-map exists |
+| AC-NT-002 | REQ-NT-002 | 001-absent case → skip + info log + codemaps completes |
+| AC-NT-003 | REQ-NT-003 | `navigator/` + `audit-report.*` unchanged across codemaps invocation |
+| AC-NT-004 | REQ-NT-004 | 14 grammars extract symbols on a polyglot fixture |
+| AC-NT-005 | REQ-NT-005 | r/flutter rows carry `Supported: false`, others extract normally |
+| AC-NT-006 | REQ-NT-006 | Adding a `.scm` query file (no Go edit) extends the language set |
+| AC-NT-007 | REQ-NT-007 | Per-language `.scm` defines symbols (function/method/type for ≥8 languages) |
+| AC-NT-008 | REQ-NT-008 | Malformed source file → skip + warning logged, others extract |
+| AC-NT-009 | REQ-NT-009 | Every enriched row carries `extract-commit-sha` + ISO-8601 `captured-at` |
+| AC-NT-010 | REQ-NT-010 | Dual output (md + json), stable schema, no extras |
+| AC-NT-011 | REQ-NT-011 | Header-driven join to 001 verified against a fixture with reordered columns |
+| AC-NT-012 | REQ-NT-012 | Two extractions on same HEAD → byte-identical output |
+| AC-NT-013 | REQ-NT-013 | Atomic-rename write strategy verified |
+| AC-NT-014 | REQ-NT-014 | Path ceiling truncates extraction + marks `truncated: true` |
+| AC-NT-015 | REQ-NT-015 | `GO_CGO_ENABLED=0 go build ./...` succeeds; nocgo path returns `Supported: false` |
+| AC-NT-016 | REQ-NT-016 | Template neutrality grep clean (C2/C3/C7 classes absent) |
+| AC-NT-017 | REQ-NT-017 | Template-First: `.claude/` + `internal/` regenerated from template source via `make build` |
+| AC-NT-018 | REQ-NT-018 | Extractor grep touches no LSEL surface |
+| AC-NT-019 | REQ-NT-019 | Extractor grep touches no 002 audit surface |
+| AC-NT-020 | REQ-NT-020 | `/moai codemaps` remains Agentless pipeline (no LLM-driven phase selection introduced) |
+
+## §E. Out of Scope
+
+### Out of Scope — Navigator artifact generation (001's surface)
+
+- Generating or regenerating `.moai/project/navigator/{navigator,capability-map,progress-map}.md` is owned by **SPEC-PROJECT-NAVIGATOR-001** (status: completed). 003 reads `capability-map.md` header-driven; it never writes to 001's directory and never invokes `navigator-regen.sh`.
+
+### Out of Scope — drift / completeness audit (002's surface)
+
+- The `--audit` mode that diffs design intent against the implemented capability-map is owned by **SPEC-PROJECT-NAVIGATOR-002** (status: completed). 003's enriched rows live under `.moai/project/codemaps/`, a SIBLING surface; 002's audit continues to operate on 001's text columns. Forward-compat: a future SPEC MAY teach 002 to consult 003's `on-disk-verified` column, but that coupling is not in scope here.
+
+### Out of Scope — semantic / RAG / PageRank symbol ranking
+
+- Aider-style PageRank symbol ranking (research.md §Aider) and embeddings-based semantic similarity over the source tree are out of scope. 003 emits a flat per-capability symbol list with no importance ranking. Symbol ranking is a possible future SPEC; it is NOT required for the enriched capability row to be useful (the symbol COUNT + on-disk verification alone close the three gaps named in §B.1).
+
+### Out of Scope — r-language and dart/flutter tree-sitter grammars
+
+- Writing or vendoring a tree-sitter grammar for `r` or for `dart`/`flutter` is out of scope. 003 fails-open with `Supported: false` for those two languages (REQ-NT-005). When `smacker/go-tree-sitter` (or a successor package) adds those grammars, 003's data-file extension (REQ-NT-006) makes adoption a query-file + registration-table change, not a source edit.
+
+### Out of Scope — LSEL-owned harness self-evolution
+
+- Closing the PROPOSE→APPLY seam for harness self-edit is owned by **SPEC-LSEL-LOCAL-EVOLUTION-001**. 003 consumes the SPEC registry + the source tree; it does not consume the lessons-inbox. REQ-NT-018 codifies the non-overlap.
+
+### Out of Scope — MX tag cross-reference
+
+- Cross-referencing the extracted symbol set with the `@MX:ANCHOR` / `@MX:SPEC` tag corpus (e.g. "which extracted symbols carry an `@MX:ANCHOR` tag and which are untagged") is out of scope. A future SPEC may address it once 003's enriched output has stabilized.
+
+### Out of Scope — SessionStart ambient auto-brief of enriched rows
+
+- 001's SessionStart hook (`handle-session-start-navigator.sh`) emits a ≤500-token brief drawn from `navigator.md`. 003's enriched rows are NOT surfaced ambiently; they live in `.moai/project/codemaps/capability-symbols.md` and are read on demand by `/moai codemaps` consumers. Wiring 003 into the SessionStart brief would violate Advisory-Check Discipline (extraction is not latency-sensitive).
+
+## §F. Constraints (Non-Functional)
+
+- **Provenance**: every enriched row carries `extract-commit-sha` + ISO-8601 `captured-at` (REQ-NT-009), aligns with verification-claim-integrity.md §2 (no unobserved claims).
+- **Idempotent extraction**: same HEAD + same 001 capability-map + same source tree → byte-identical output (REQ-NT-012). Timestamps sourced from `git log`, not wall-clock, mirroring 001 + 002.
+- **Atomic writes**: `capability-symbols.{md,json}.tmp` → `mv` (REQ-NT-013, inherited from 001's REQ-PN-008).
+- **Bounded extraction**: per-path file-count ceiling (default 2000, overridable), `truncated: true` marker when hit (REQ-NT-014) — so `/moai codemaps` never becomes unbounded.
+- **Fail-open**: missing 001, missing grammar, malformed source, missing design docs — every failure mode degrades to a log line + continue, never aborts codemaps (REQ-NT-002, REQ-NT-005, REQ-NT-008).
+- **cgo / nocgo parity**: project builds with cgo disabled; nocgo path is a stub (REQ-NT-015).
+- **16-language neutrality**: no Go-bias (constraint inherited from CLAUDE.local.md §15, carried from 001/002).
+- **Template-First**: new files ship via `internal/template/templates/` + `make build` + §25 neutrality (REQ-NT-016, REQ-NT-017).
+- **PR-mandatory**: `enforce_admins:true` (CLAUDE.local.md §23). Plan-phase artifacts committed via the standard plan→PR flow; run-phase via Route B PR.
+- **No new Go CLI subcommand for end users**: the extraction is invoked BY `/moai codemaps` internally. A `moai navigator-astx` Go subcommand MAY exist as an internal extractor entry point (sibling to 002's pattern of self-contained bash), but the user-facing surface remains `/moai codemaps` (constraint inherited from 001 §B.1).
+- **Pipeline-class preservation**: `/moai codemaps` stays Agentless fixed-pipeline (REQ-NT-020).
+
+## §G. Dependencies / Related SPECs
+
+- **SPEC-PROJECT-NAVIGATOR-001** (`status: completed`, PR #1354 squash `2c87d195f`, Tier M) — the Navigator substrate. 003 reads 001's `capability-map.md` header-driven (REQ-NT-011); 003 does NOT write to 001's surface (REQ-NT-003). 001's `capability-map` column order is NOT a stable contract (001's spec.md declares column 1 as `capability`; 001's acceptance.md AC-PN-013 enumerates spec-id-first) — 003 therefore joins by header name, the same immunization 002 adopted (REQ-NA-007).
+- **SPEC-PROJECT-NAVIGATOR-002** (`status: completed`, PR #1361 squash `927e268c9` + backfill #1362 `da4cfd258`, Tier M) — the audit layer. 003's enriched rows are SIBLING to 002's audit output; non-overlap codified in REQ-NT-019.
+- **SPEC-LSEL-LOCAL-EVOLUTION-001** (`status: completed`) — non-overlap boundary (REQ-NT-018).
+- `internal/hook/mx/complexity/` (existing Go package) — the prior-art tree-sitter user in this repo. 003's `internal/navigator/astx/` package follows the same build-tag split and the same `//go:embed` query-file pattern; the two packages remain independent (no import edge) because they serve different consumers (complexity is an `@MX`-tag scoring input; astx is a Navigator/codemaps enrichment input).
+- `/moai codemaps` workflow (`.claude/skills/moai/workflows/codemaps.md`) — EXTENDED with an AST-enrichment step inside Phase 3 (REQ-NT-001). The pipeline classification is preserved (REQ-NT-020).
+- `github.com/smacker/go-tree-sitter` v0.0.0-20240827094217 — already in `go.mod`; 003 adds NO new top-level dependency.
+
+## §H. Resolved decisions (recorded for traceability)
+
+1. **Output location** — CHOSEN: `.moai/project/codemaps/capability-symbols.{md,json}` (codemaps surface, sibling to existing codemaps output files). Rejected alternatives: (a) `.moai/project/navigator/capability-map-enriched.md` — violates 001's REQ-PN-001 "exactly three ... and no other top-level Navigator files"; (b) a new top-level directory — fragments the project-context surface unnecessarily. The codemaps surface is the natural home because 003's enrichment IS code-structural (per the Epic boundary statement "integrated into `/moai codemaps`").
+2. **Grammar library** — CHOSEN: reuse `github.com/smacker/go-tree-sitter` (already in `go.mod`, already used by `internal/hook/mx/complexity`). Rejected: a new tree-sitter Go binding, or shell-out to a separate tree-sitter CLI binary. Reusing the existing binding keeps the dependency surface at 1 (no new top-level dep), follows the prior-art pattern, and avoids a subprocess-per-file cost model.
+3. **cgo / nocgo split** — CHOSEN: mirror `internal/hook/mx/complexity/measure_{cgo,nocgo}.go`. The nocgo path returns `Supported: false` for every language with an explanatory comment; cgo-disabled environments (some CI matrices, some downstream users) continue to build.
+4. **Symbol definition per language** — CHOSEN: per-language `.scm` query files, embedded via `//go:embed`, mirroring `internal/hook/mx/complexity/queries/*.scm`. Rejected: a single universal query (tree-sitter node types differ too much across languages; a universal query would either miss symbols in some languages or produce false positives in others); in-source reflection (no portable reflection API across the 14 grammars).
+5. **r / dart / flutter coverage** — CHOSEN: fail-open with `Supported: false`. Rejected: vendoring a third-party grammar (would add a new top-level dependency and a maintenance burden for 2 of 16 languages); dropping those languages from the supported set (would violate the 16-language neutrality invariant). When `smacker/go-tree-sitter` adds those grammars, adoption is a data-file change (REQ-NT-006).
+6. **Era frontmatter** — `era: V3R6` set explicitly to avoid H-2 misclassification during the early window when progress.md is sparse (per `.claude/rules/moai/workflow/lifecycle-sync-gate.md` § When to set era: explicitly, item 3 — newly created SPECs before progress.md is populated), mirroring 002's decision.

--- a/.moai/specs/SPEC-PROJECT-NAVIGATOR-003/spec.md
+++ b/.moai/specs/SPEC-PROJECT-NAVIGATOR-003/spec.md
@@ -2,7 +2,7 @@
 id: SPEC-PROJECT-NAVIGATOR-003
 title: "Project Navigator — tree-sitter auto-derivation into /moai codemaps (16-language AST-based capability rows)"
 version: "0.1.0"
-status: draft
+status: in-progress
 created: 2026-08-05
 updated: 2026-08-05
 author: manager-spec

--- a/internal/cli/navigator_enrich.go
+++ b/internal/cli/navigator_enrich.go
@@ -1,0 +1,173 @@
+package cli
+
+// navigator-enrich CLI: AST symbol enrichment for /moai codemaps Phase 3
+// (SPEC-PROJECT-NAVIGATOR-003). Reads 001's capability-map.md (header-driven),
+// walks each implementation-path, extracts tree-sitter symbols, and writes
+// capability-symbols.{md,json} atomically under .moai/project/codemaps/.
+//
+// Fail-open: exit 0 always. Capability gate: when capability-map.md is absent,
+// emits an info log and writes no output (REQ-NT-002).
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/modu-ai/moai-adk/internal/navigator/astx"
+)
+
+// navigatorEnrichLogPath is the fail-open warning sink (REQ-NT-008).
+const navigatorEnrichLogPath = ".moai/logs/navigator-astx.log"
+
+// newNavigatorEnrichCmd creates the navigator-enrich subcommand.
+func newNavigatorEnrichCmd() *cobra.Command {
+	var projectRoot string
+	var capMapPath string
+	var outDir string
+
+	cmd := &cobra.Command{
+		Use:    "navigator-enrich",
+		Short:  "Enrich capability-map with AST-derived symbols",
+		Hidden: true,
+		Long: `AST symbol enrichment for /moai codemaps Phase 3.
+
+Reads 001's capability-map.md (header-driven join), walks each row's
+implementation-path, extracts tree-sitter symbols, and writes
+capability-symbols.{md,json} atomically under .moai/project/codemaps/.
+
+Fail-open: exit 0 always. When capability-map.md is absent, emits an info
+log and writes no output (REQ-NT-002).`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runNavigatorEnrich(projectRoot, capMapPath, outDir)
+		},
+	}
+
+	cmd.Flags().StringVar(&projectRoot, "project-root", "",
+		"project root (defaults to $CLAUDE_PROJECT_DIR then $PWD)")
+	cmd.Flags().StringVar(&capMapPath, "capability-map", "",
+		"path to capability-map.md (defaults to <root>/.moai/project/navigator/capability-map.md)")
+	cmd.Flags().StringVar(&outDir, "out-dir", "",
+		"output directory (defaults to <root>/.moai/project/codemaps/)")
+
+	return cmd
+}
+
+// runNavigatorEnrich is the fail-open core. It never returns a non-nil error
+// to the cobra RunE (errors are logged and swallowed) so /moai codemaps never
+// aborts on the enrichment step.
+func runNavigatorEnrich(projectRoot, capMapPath, outDir string) error {
+	root := projectRoot
+	if root == "" {
+		root = os.Getenv("CLAUDE_PROJECT_DIR")
+	}
+	if root == "" {
+		var err error
+		root, err = os.Getwd()
+		if err != nil {
+			root = "."
+		}
+	}
+
+	if capMapPath == "" {
+		capMapPath = filepath.Join(root, ".moai", "project", "navigator", "capability-map.md")
+	}
+	if outDir == "" {
+		outDir = filepath.Join(root, ".moai", "project", "codemaps")
+	}
+
+	logPath := filepath.Join(root, navigatorEnrichLogPath)
+
+	// Capability gate (REQ-NT-001 vs REQ-NT-002).
+	if _, err := os.Stat(capMapPath); err != nil {
+		appendLog(logPath, fmt.Sprintf("navigator-astx: capability-map absent at %s; skipping AST enrichment", capMapPath))
+		fmt.Fprintln(os.Stderr, "navigator-astx: capability-map.md absent, skipping AST enrichment")
+		return nil
+	}
+
+	res, err := astx.EnrichRows(astx.EnrichOptions{
+		ProjectRoot:       root,
+		CapabilityMapPath: capMapPath,
+	})
+	if err != nil {
+		// Fail-open: EnrichRows already swallows errors, but defend anyway.
+		appendLog(logPath, fmt.Sprintf("navigator-astx: enrich error: %v", err))
+		return nil
+	}
+
+	// Render both outputs.
+	sourceMap := relOrAbs(root, capMapPath)
+	md := astx.RenderMarkdown(res.Provenance, sourceMap, res.Rows)
+	js := astx.MarshalCapabilitySymbolsJSON(res.Provenance, sourceMap, res.Rows)
+
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		appendLog(logPath, fmt.Sprintf("navigator-astx: mkdir error: %v", err))
+		return nil
+	}
+
+	// Atomic writes: <file>.tmp then mv (REQ-NT-013).
+	if err := atomicWrite(filepath.Join(outDir, "capability-symbols.md"), md); err != nil {
+		appendLog(logPath, fmt.Sprintf("navigator-astx: write md error: %v", err))
+		return nil
+	}
+	if err := atomicWrite(filepath.Join(outDir, "capability-symbols.json"), js); err != nil {
+		appendLog(logPath, fmt.Sprintf("navigator-astx: write json error: %v", err))
+		return nil
+	}
+
+	fmt.Fprintf(os.Stderr, "navigator-astx: enriched %d row(s) -> %s\n",
+		len(res.Rows), outDir)
+	return nil
+}
+
+// atomicWrite writes data to <path>.tmp then renames it into place. It honors
+// the NAVIGATOR_PRE_RENAME_BARRIER test hook: when set, it writes "ready" to
+// the barrier path after creating the .tmp file and blocks (poll loop) until
+// the barrier path is removed before the rename lands.
+func atomicWrite(path string, data []byte) error {
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+
+	// Test hook: synchronized barrier for the atomic-rename fixture
+	// (mirrors 001's NAVIGATOR_PRE_RENAME_BARRIER pattern). The barrier is
+	// consumed on first use so only the first output file blocks; subsequent
+	// files in the same run skip it.
+	if barrier := os.Getenv("NAVIGATOR_PRE_RENAME_BARRIER"); barrier != "" {
+		_ = os.Unsetenv("NAVIGATOR_PRE_RENAME_BARRIER")
+		_ = os.WriteFile(barrier, []byte("ready"), 0o644)
+		for {
+			if _, err := os.Stat(barrier); err != nil {
+				break // barrier removed → proceed to rename
+			}
+		}
+	}
+
+	return os.Rename(tmp, path)
+}
+
+// appendLog appends a line to the navigator-astx log (fail-open on error).
+func appendLog(path, line string) {
+	_ = os.MkdirAll(filepath.Dir(path), 0o755)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return
+	}
+	defer func() { _ = f.Close() }()
+	_, _ = fmt.Fprintln(f, line)
+}
+
+// relOrAbs returns path relative to root when it is under root, else path.
+func relOrAbs(root, path string) string {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return path
+	}
+	rel, err := filepath.Rel(root, abs)
+	if err != nil {
+		return path
+	}
+	return rel
+}

--- a/internal/cli/navigator_enrich_test.go
+++ b/internal/cli/navigator_enrich_test.go
@@ -1,0 +1,128 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestNavigatorEnrich_EmitsFilesWhenCapabilityMapExists is AC-NT-001: when
+// capability-map.md exists, the command writes both capability-symbols.md and
+// .json with non-empty rows.
+func TestNavigatorEnrich_EmitsFilesWhenCapabilityMapExists(t *testing.T) {
+	root := t.TempDir()
+	// capability-map.md + an implementation-path with a Go source file.
+	enrichWriteFile(t, filepath.Join(root, ".moai", "project", "navigator", "capability-map.md"),
+		"| spec-id | title | status | implementation-path | commit-sha | captured-at |\n"+
+			"|---------|-------|--------|---------------------|------------|-------------|\n"+
+			"| SPEC-X-001 | X | implemented | src/x | abc123 | 2026-01-01 |\n")
+	enrichWriteFile(t, filepath.Join(root, "src", "x", "a.go"),
+		"package x\nfunc Foo() {}\ntype Bar struct{}\n")
+
+	if err := runNavigatorEnrich(root, "", ""); err != nil {
+		t.Fatalf("runNavigatorEnrich error: %v", err)
+	}
+	md := enrichReadFile(t, filepath.Join(root, ".moai", "project", "codemaps", "capability-symbols.md"))
+	if !strings.Contains(string(md), "SPEC-X-001") {
+		t.Errorf("md missing SPEC-X-001:\n%s", md)
+	}
+	if !strings.Contains(string(md), "Capability Symbols") {
+		t.Errorf("md missing header")
+	}
+	js := enrichReadFile(t, filepath.Join(root, ".moai", "project", "codemaps", "capability-symbols.json"))
+	var doc map[string]any
+	if err := json.Unmarshal(js, &doc); err != nil {
+		t.Fatalf("json invalid: %v\n%s", err, js)
+	}
+	rows, _ := doc["rows"].([]any)
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want 1", len(rows))
+	}
+}
+
+// TestNavigatorEnrich_AbsenceIsGraceful is AC-NT-002: when capability-map.md
+// is absent, the command exits nil and writes NO output files.
+func TestNavigatorEnrich_AbsenceIsGraceful(t *testing.T) {
+	root := t.TempDir()
+	if err := runNavigatorEnrich(root, "", ""); err != nil {
+		t.Fatalf("runNavigatorEnrich error: %v", err)
+	}
+	outDir := filepath.Join(root, ".moai", "project", "codemaps")
+	if _, err := os.Stat(filepath.Join(outDir, "capability-symbols.md")); err == nil {
+		t.Errorf("capability-symbols.md should NOT exist when capability-map absent")
+	}
+	if _, err := os.Stat(filepath.Join(outDir, "capability-symbols.json")); err == nil {
+		t.Errorf("capability-symbols.json should NOT exist when capability-map absent")
+	}
+}
+
+// TestNavigatorEnrich_AtomikWriteBarrier is AC-NT-013: the
+// NAVIGATOR_PRE_RENAME_BARRIER test hook blocks the rename until removed, so
+// no reader observes a partial file. This exercises the barrier path itself.
+func TestNavigatorEnrich_AtomicWriteBarrier(t *testing.T) {
+	root := t.TempDir()
+	enrichWriteFile(t, filepath.Join(root, ".moai", "project", "navigator", "capability-map.md"),
+		"| spec-id | title | status | implementation-path | commit-sha | captured-at |\n"+
+			"|---------|-------|--------|---------------------|------------|-------------|\n"+
+			"| SPEC-X-001 | X | implemented | src/x | abc123 | 2026-01-01 |\n")
+	enrichWriteFile(t, filepath.Join(root, "src", "x", "a.go"), "package x\nfunc Foo() {}\n")
+
+	barrier := filepath.Join(root, "barrier.flag")
+	t.Setenv("NAVIGATOR_PRE_RENAME_BARRIER", barrier)
+
+	done := make(chan error, 1)
+	go func() { done <- runNavigatorEnrich(root, "", "") }()
+
+	// While the barrier exists, the .tmp file should be present and the final
+	// file absent (rename blocked).
+	// Wait briefly for the goroutine to reach the barrier.
+	tmp := filepath.Join(root, ".moai", "project", "codemaps", "capability-symbols.md.tmp")
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(tmp); err == nil {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if _, err := os.Stat(barrier); err != nil {
+		t.Fatalf("barrier file not created (goroutine did not reach barrier)")
+	}
+	// Final file must NOT exist yet (rename blocked on barrier).
+	if _, err := os.Stat(filepath.Join(root, ".moai", "project", "codemaps", "capability-symbols.md")); err == nil {
+		t.Errorf("final file created before barrier removed — atomic-write broken")
+	}
+
+	// Remove barrier → rename proceeds, command completes.
+	if err := os.Remove(barrier); err != nil {
+		t.Fatalf("remove barrier: %v", err)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("runNavigatorEnrich error after barrier: %v", err)
+	}
+	// Now the final file exists.
+	if _, err := os.Stat(filepath.Join(root, ".moai", "project", "codemaps", "capability-symbols.md")); err != nil {
+		t.Errorf("final file missing after barrier removal: %v", err)
+	}
+}
+
+func enrichWriteFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func enrichReadFile(t *testing.T, path string) []byte {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return b
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -170,6 +170,9 @@ func init() {
 	// SPEC-V3R2-RT-004 REQ-031: register clean subcommand
 	rootCmd.AddCommand(newCleanCmd())
 
+	// SPEC-PROJECT-NAVIGATOR-003: AST enrichment entry point for /moai codemaps.
+	rootCmd.AddCommand(newNavigatorEnrichCmd())
+
 	// SPEC-V3R2-RT-007: register migration subcommand group
 	rootCmd.AddCommand(migrationCmd)
 

--- a/internal/navigator/astx/astx.go
+++ b/internal/navigator/astx/astx.go
@@ -1,0 +1,147 @@
+// Package astx extracts source-tree symbols via tree-sitter for the
+// /moai codemaps AST-enrichment step (SPEC-PROJECT-NAVIGATOR-003).
+//
+// It is a sibling package to internal/hook/mx/complexity (the prior-art
+// tree-sitter consumer); the two share no import edge and serve different
+// consumers (complexity scoring vs codemaps symbol enrichment).
+//
+// Build constraints (mirrors internal/hook/mx/complexity):
+//   - CGO enabled: full tree-sitter implementation (measure_cgo.go)
+//   - CGO disabled: stub returning Supported: false (measure_nocgo.go)
+//
+// Language registration is data-driven: the 14 working grammars are seeded
+// with per-language .scm query files (queries/*.scm); r and flutter are
+// registered but scaffolded (Supported: false) pending upstream grammar
+// availability. Adding a language is a registration-table row + a .scm file
+// (no per-language Go logic) per REQ-NT-006.
+package astx
+
+import "strings"
+
+// Symbol is a single named definition extracted from a source file.
+type Symbol struct {
+	// Name is the identifier text of the symbol.
+	Name string
+	// Kind is the symbol category: "function", "method", "type", etc.
+	Kind string
+	// File is the source file path the symbol was extracted from.
+	File string
+	// Line is the 1-indexed line where the symbol name appears.
+	Line int
+}
+
+// SymbolSet is the result of extracting symbols from one source file.
+type SymbolSet struct {
+	// Supported is false when the language has no seeded grammar (scaffolded
+	// languages r/flutter, or any CGO-disabled build).
+	Supported bool
+	// Symbols groups extracted symbols by kind ("function", "type", ...).
+	Symbols map[string][]Symbol
+	// SourceBytes is the byte length of the parsed source.
+	SourceBytes int64
+	// Error carries a non-fatal parse/read error when present; callers
+	// treat it as advisory (the extractor never aborts on a single file).
+	Error error
+}
+
+// maxFileSizeBytes caps single-file parse input (1 MiB) to bound tree-sitter
+// memory, mirroring internal/hook/mx/complexity.
+const maxFileSizeBytes = 1 << 20
+
+// langMeta is the build-tag-independent metadata for one registered language.
+type langMeta struct {
+	Name       string
+	Extensions []string
+}
+
+// supportedLanguages is the single registration list for all known languages.
+// The 14 working languages are seeded with grammars in measure_cgo.go;
+// r and flutter are scaffolded (Supported: false) pending upstream grammars.
+// Order is stable so SupportedLanguages() output is deterministic.
+var supportedLanguages = []langMeta{
+	{Name: "go", Extensions: []string{".go"}},
+	{Name: "python", Extensions: []string{".py"}},
+	{Name: "typescript", Extensions: []string{".ts", ".tsx"}},
+	{Name: "javascript", Extensions: []string{".js", ".jsx", ".mjs", ".cjs"}},
+	{Name: "rust", Extensions: []string{".rs"}},
+	{Name: "java", Extensions: []string{".java"}},
+	{Name: "kotlin", Extensions: []string{".kt", ".kts"}},
+	{Name: "csharp", Extensions: []string{".cs"}},
+	{Name: "ruby", Extensions: []string{".rb"}},
+	{Name: "php", Extensions: []string{".php"}},
+	{Name: "elixir", Extensions: []string{".ex", ".exs"}},
+	{Name: "cpp", Extensions: []string{".cpp", ".cc", ".cxx", ".hpp", ".hh"}},
+	{Name: "scala", Extensions: []string{".scala", ".sc"}},
+	{Name: "swift", Extensions: []string{".swift"}},
+	{Name: "r", Extensions: []string{".r", ".R"}},
+	{Name: "flutter", Extensions: []string{".dart"}},
+}
+
+// scaffoldedLanguages are registered but have no tree-sitter grammar
+// available in github.com/smacker/go-tree-sitter; Extract returns
+// Supported: false for them without attempting a parse.
+var scaffoldedLanguages = map[string]bool{
+	"r":       true,
+	"flutter": true,
+}
+
+// SupportedLanguages returns the names of all registered languages (14 working
+// + 2 scaffolded). The 14 working languages are seeded with grammars under a
+// CGO-enabled build; r and flutter are always Supported: false.
+func SupportedLanguages() []string {
+	out := make([]string, 0, len(supportedLanguages))
+	for _, m := range supportedLanguages {
+		out = append(out, m.Name)
+	}
+	return out
+}
+
+// DetectLanguage resolves a language name from a filename by extension using
+// the registration table. It returns "" when no registered extension matches.
+func DetectLanguage(filename string) string {
+	ext := fileExt(filename)
+	for _, m := range supportedLanguages {
+		for _, e := range m.Extensions {
+			if e == ext {
+				return m.Name
+			}
+		}
+	}
+	return ""
+}
+
+// IsScaffolded reports whether the named language is registered-but-unsupported
+// (r, flutter). Unknown languages return true (treated as not parseable).
+func IsScaffolded(language string) bool {
+	return scaffoldedLanguages[language]
+}
+
+// Extract parses sourcePath with the tree-sitter grammar for language and
+// returns the captured symbols grouped by kind.
+//
+// Returns SymbolSet{Supported: false} when:
+//   - the language is scaffolded or unregistered,
+//   - the build is CGO-disabled (measure_nocgo.go),
+//   - the file exceeds maxFileSizeBytes,
+//   - or a parse/query error occurs (logged via the extractor, never propagated
+//     as a fatal error — Error carries the detail for advisory use).
+//
+// Never panics.
+func Extract(language string, sourcePath string) (SymbolSet, error) {
+	return extractImpl(language, sourcePath)
+}
+
+// extractImpl is the build-tag-selected implementation:
+// measure_cgo.go (real tree-sitter) or measure_nocgo.go (stub).
+// It is defined in those files, not here.
+
+// fileExt returns the file extension of name including the leading dot,
+// case-preserved (language detection compares against registered extensions
+// which are stored case-sensitively; both forms are registered where needed).
+func fileExt(name string) string {
+	i := strings.LastIndex(name, ".")
+	if i < 0 {
+		return ""
+	}
+	return name[i:]
+}

--- a/internal/navigator/astx/astx.go
+++ b/internal/navigator/astx/astx.go
@@ -88,6 +88,9 @@ var scaffoldedLanguages = map[string]bool{
 // SupportedLanguages returns the names of all registered languages (14 working
 // + 2 scaffolded). The 14 working languages are seeded with grammars under a
 // CGO-enabled build; r and flutter are always Supported: false.
+//
+// @MX:NOTE: [AUTO] registration order is stable for deterministic output
+// @MX:SPEC:SPEC-PROJECT-NAVIGATOR-003
 func SupportedLanguages() []string {
 	out := make([]string, 0, len(supportedLanguages))
 	for _, m := range supportedLanguages {
@@ -127,6 +130,10 @@ func IsScaffolded(language string) bool {
 //     as a fatal error — Error carries the detail for advisory use).
 //
 // Never panics.
+//
+// @MX:ANCHOR: [AUTO] per-file extraction entry point; high fan_in (called once per walked source file)
+// @MX:REASON: public API boundary consumed by EnrichRows + the navigator-enrich CLI + future downstream tooling
+// @MX:SPEC:SPEC-PROJECT-NAVIGATOR-003
 func Extract(language string, sourcePath string) (SymbolSet, error) {
 	return extractImpl(language, sourcePath)
 }

--- a/internal/navigator/astx/astx_test.go
+++ b/internal/navigator/astx/astx_test.go
@@ -1,0 +1,147 @@
+package astx
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestSupportedLanguages_ReturnsSixteenWithScaffolded is the M1 RED test:
+// the registration list contains all 16 languages; r and flutter are present.
+func TestSupportedLanguages_ReturnsSixteenWithScaffolded(t *testing.T) {
+	got := SupportedLanguages()
+	if len(got) != 16 {
+		t.Fatalf("SupportedLanguages() returned %d languages, want 16: %v", len(got), got)
+	}
+	want := map[string]bool{}
+	for _, n := range []string{
+		"go", "python", "typescript", "javascript", "rust",
+		"java", "kotlin", "csharp", "ruby", "php", "elixir",
+		"cpp", "scala", "swift", "r", "flutter",
+	} {
+		want[n] = true
+	}
+	for _, n := range got {
+		if !want[n] {
+			t.Errorf("unexpected language %q in SupportedLanguages()", n)
+		}
+	}
+	for n := range want {
+		found := false
+		for _, g := range got {
+			if g == n {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected language %q missing from SupportedLanguages()", n)
+		}
+	}
+}
+
+// TestIsScaffolded_RAndFlutter is the M1 RED test for the fail-open set.
+func TestIsScaffolded_RAndFlutter(t *testing.T) {
+	if !IsScaffolded("r") {
+		t.Errorf("IsScaffolded(r) = false, want true")
+	}
+	if !IsScaffolded("flutter") {
+		t.Errorf("IsScaffolded(flutter) = false, want true")
+	}
+	if IsScaffolded("go") {
+		t.Errorf("IsScaffolded(go) = true, want false")
+	}
+}
+
+// TestDetectLanguage_ByExtension is the M1 RED test for extension detection.
+func TestDetectLanguage_ByExtension(t *testing.T) {
+	cases := map[string]string{
+		"main.go":       "go",
+		"app.py":        "python",
+		"index.ts":      "typescript",
+		"comp.tsx":      "typescript",
+		"main.js":       "javascript",
+		"lib.rs":        "rust",
+		"Main.java":     "java",
+		"App.kt":        "kotlin",
+		"Program.cs":    "csharp",
+		"gem.rb":        "ruby",
+		"page.php":      "php",
+		"mix.exs":       "elixir",
+		"node.cpp":      "cpp",
+		"Job.scala":     "scala",
+		"View.swift":    "swift",
+		"plot.r":        "r",
+		"analysis.R":    "r",
+		"main.dart":     "flutter",
+		"README.md":     "",
+		"config.yaml":   "",
+		"Dockerfile":    "",
+	}
+	for file, want := range cases {
+		if got := DetectLanguage(file); got != want {
+			t.Errorf("DetectLanguage(%q) = %q, want %q", file, got, want)
+		}
+	}
+}
+
+// TestExtract_GoFixture is the M1 RED test: Extract on a Go fixture returns
+// Supported: true and captures the expected function + type names.
+func TestExtract_GoFixture(t *testing.T) {
+	set, err := Extract("go", filepath.Join("testdata", "sample.go"))
+	if err != nil {
+		t.Fatalf("Extract(go) returned error: %v", err)
+	}
+	if !set.Supported {
+		t.Fatalf("Extract(go) Supported = false, want true (CGO build required for this test)")
+	}
+	// Expect a type capture for "Greeter".
+	hasType := false
+	for _, sym := range set.Symbols["type"] {
+		if sym.Name == "Greeter" {
+			hasType = true
+		}
+	}
+	if !hasType {
+		t.Errorf("Extract(go) did not capture type Greeter; symbols=%v", set.Symbols)
+	}
+	// Expect function captures for "NewGreeter" and the method "Greet".
+	hasFunc := false
+	for _, sym := range set.Symbols["function"] {
+		if sym.Name == "NewGreeter" {
+			hasFunc = true
+		}
+	}
+	if !hasFunc {
+		t.Errorf("Extract(go) did not capture function NewGreeter; symbols=%v", set.Symbols)
+	}
+	hasMethod := false
+	for _, sym := range set.Symbols["method"] {
+		if sym.Name == "Greet" {
+			hasMethod = true
+		}
+	}
+	if !hasMethod {
+		t.Errorf("Extract(go) did not capture method Greet; symbols=%v", set.Symbols)
+	}
+}
+
+// TestExtract_ScaffoldedR_ReturnsUnsupported is the M1 RED test for fail-open
+// on a scaffolded language.
+func TestExtract_ScaffoldedR_ReturnsUnsupported(t *testing.T) {
+	set, err := Extract("r", filepath.Join("testdata", "sample.go"))
+	if err != nil {
+		t.Fatalf("Extract(r) returned error: %v", err)
+	}
+	if set.Supported {
+		t.Errorf("Extract(r) Supported = true, want false (scaffolded)")
+	}
+}
+
+// TestExtract_UnknownLanguage_ReturnsUnsupported is the M1 RED test for an
+// unregistered language.
+func TestExtract_UnknownLanguage_ReturnsUnsupported(t *testing.T) {
+	set, _ := Extract("klingon", filepath.Join("testdata", "sample.go"))
+	if set.Supported {
+		t.Errorf("Extract(klingon) Supported = true, want false")
+	}
+}

--- a/internal/navigator/astx/enrich.go
+++ b/internal/navigator/astx/enrich.go
@@ -205,6 +205,10 @@ func normalizeHeader(h string) string {
 // REQ-NT-011), walks each row's implementation-path, extracts symbols, and
 // aggregates them into EnrichedRows. It never aborts on a single row or
 // file failure (fail-open); rows whose path is absent carry OnDiskVerified=false.
+//
+// @MX:ANCHOR: [AUTO] whole-run enrichment entry point; consumed by the navigator-enrich CLI
+// @MX:REASON: public API boundary orchestrating header-driven join + walk + aggregate + provenance
+// @MX:SPEC:SPEC-PROJECT-NAVIGATOR-003
 func EnrichRows(opts EnrichOptions) (EnrichResult, error) {
 	if opts.MaxFilesPerPath == 0 {
 		opts.MaxFilesPerPath = defaultMaxFilesPerPath

--- a/internal/navigator/astx/enrich.go
+++ b/internal/navigator/astx/enrich.go
@@ -1,0 +1,504 @@
+package astx
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"log/slog"
+)
+
+// Provenance stamps an enrichment run to a git baseline (REQ-NT-009 /
+// REQ-NT-012 idempotence): ExtractCommitSHA is `git rev-parse HEAD` and
+// CapturedAt is the committer date of that SHA (`git log -1 --format=%cI`).
+// No wall-clock timestamp is used, so two runs on the same HEAD produce
+// byte-identical output.
+type Provenance struct {
+	ExtractCommitSHA string
+	CapturedAt       string
+}
+
+// EnrichedRow is the stable output schema row (design.md §5.2). Fields are
+// forward-compatible (additive only).
+type EnrichedRow struct {
+	SpecID             string   `json:"spec_id"`
+	Title              string   `json:"title"`
+	ImplementationPath string   `json:"implementation_path"`
+	OnDiskVerified     bool     `json:"on_disk_verified"`
+	ExtractLanguage    string   `json:"extract_language"`
+	PrimaryFiles       []string `json:"primary_files"`
+	PrimarySymbols     []Symbol `json:"primary_symbols"`
+	SymbolCount        int      `json:"symbol_count"`
+	Truncated          bool     `json:"truncated"`
+	Supported          bool     `json:"supported"`
+}
+
+// EnrichOptions configures an enrichment run.
+type EnrichOptions struct {
+	// ProjectRoot resolves the capability-map path and implementation paths.
+	ProjectRoot string
+	// CapabilityMapPath is the path to 001's capability-map.md (absolute or
+	// relative to ProjectRoot).
+	CapabilityMapPath string
+	// MaxFilesPerPath caps the file walk per implementation-path (REQ-NT-014).
+	// Default 2000 when zero.
+	MaxFilesPerPath int
+	// PrimaryFilesN is the top-N files by symbol count (default 5).
+	PrimaryFilesN int
+	// PrimarySymbolsN is the top-N symbols by frequency (default 10).
+	PrimarySymbolsN int
+}
+
+// EnrichResult holds the run output: provenance + enriched rows.
+type EnrichResult struct {
+	Provenance Provenance
+	Rows       []EnrichedRow
+}
+
+// Default enrichment knobs (plan.md §I open questions, frozen by this SPEC).
+const (
+	defaultMaxFilesPerPath = 2000
+	defaultPrimaryFilesN   = 5
+	defaultPrimarySymbolsN = 10
+)
+
+// provenanceUnknown is the fail-open placeholder for git failures.
+const provenanceUnknown = "<unknown>"
+
+// fileAgg accumulates the extraction result for one walked file.
+type fileAgg struct {
+	path    string
+	lang    string
+	symbols map[string][]Symbol
+	count   int
+}
+
+// CurrentProvenance returns the git provenance for the working-tree HEAD.
+// Fail-open: on any git error, returns "<unknown>" values (never aborts).
+func CurrentProvenance(projectRoot string) Provenance {
+	sha := gitOutput(projectRoot, "rev-parse", "HEAD")
+	if sha == "" {
+		sha = provenanceUnknown
+	}
+	captured := gitOutput(projectRoot, "log", "-1", "--format=%cI", sha)
+	if captured == "" {
+		// Fall back to a HEAD-relative lookup when the explicit SHA log failed
+		// (e.g. shallow-clone edge where the SHA object is unavailable).
+		captured = gitOutput(projectRoot, "log", "-1", "--format=%cI")
+	}
+	if captured == "" {
+		captured = provenanceUnknown
+	}
+	return Provenance{ExtractCommitSHA: sha, CapturedAt: captured}
+}
+
+// gitOutput runs a git command in dir (empty dir = inherit cwd) and returns
+// the trimmed stdout. Any error → "" (fail-open, logged at debug).
+func gitOutput(dir string, args ...string) string {
+	cmd := exec.Command("git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		slog.Debug("astx: git command failed", "args", args, "dir", dir, "error", err)
+		return ""
+	}
+	return strings.TrimSpace(out.String())
+}
+
+// capRow is one parsed capability-map.md data row keyed by header name.
+type capRow map[string]string
+
+// parseCapabilityMap reads capability-map.md content and returns the data
+// rows as header→value maps (header-driven join per REQ-NT-011 — robust to
+// column reordering). Returns an empty slice when the file has no table.
+func parseCapabilityMap(content []byte) []capRow {
+	var headers []string
+	var rows []capRow
+	scanner := bufio.NewScanner(bytes.NewReader(content))
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if !strings.HasPrefix(line, "|") {
+			continue
+		}
+		cells := splitTableRow(line)
+		if isSeparatorRow(cells) {
+			continue
+		}
+		if headers == nil {
+			headers = normalizeHeaders(cells)
+			continue
+		}
+		row := capRow{}
+		for i, c := range cells {
+			if i < len(headers) {
+				row[headers[i]] = c
+			}
+		}
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+// splitTableRow splits a markdown table row into trimmed cell values,
+// stripping the leading/trailing pipes.
+func splitTableRow(line string) []string {
+	inner := strings.TrimPrefix(line, "|")
+	inner = strings.TrimSuffix(inner, "|")
+	parts := strings.Split(inner, "|")
+	out := make([]string, len(parts))
+	for i, p := range parts {
+		out[i] = strings.TrimSpace(p)
+	}
+	return out
+}
+
+// isSeparatorRow reports whether all cells are the markdown table separator
+// pattern (dashes/colons, e.g. "---", ":--:", "----").
+func isSeparatorRow(cells []string) bool {
+	if len(cells) == 0 {
+		return false
+	}
+	for _, c := range cells {
+		if !strings.Contains(c, "-") {
+			return false
+		}
+		if strings.Trim(c, " :-") != "" {
+			return false
+		}
+	}
+	return true
+}
+
+// normalizeHeaders maps capability-map header variants to canonical keys.
+// Accepts "spec-id"/"owning-spec", "implementation-path"/"path", "title"/"capability".
+func normalizeHeaders(cells []string) []string {
+	out := make([]string, len(cells))
+	for i, c := range cells {
+		out[i] = normalizeHeader(c)
+	}
+	return out
+}
+
+func normalizeHeader(h string) string {
+	switch strings.ToLower(h) {
+	case "spec-id", "owning-spec", "spec":
+		return "spec-id"
+	case "implementation-path", "path", "module":
+		return "implementation-path"
+	case "title", "capability", "feature":
+		return "title"
+	default:
+		return strings.ToLower(h)
+	}
+}
+
+// EnrichRows reads 001's capability-map.md (header-driven join per
+// REQ-NT-011), walks each row's implementation-path, extracts symbols, and
+// aggregates them into EnrichedRows. It never aborts on a single row or
+// file failure (fail-open); rows whose path is absent carry OnDiskVerified=false.
+func EnrichRows(opts EnrichOptions) (EnrichResult, error) {
+	if opts.MaxFilesPerPath == 0 {
+		opts.MaxFilesPerPath = defaultMaxFilesPerPath
+	}
+	if opts.PrimaryFilesN == 0 {
+		opts.PrimaryFilesN = defaultPrimaryFilesN
+	}
+	if opts.PrimarySymbolsN == 0 {
+		opts.PrimarySymbolsN = defaultPrimarySymbolsN
+	}
+
+	capPath := opts.CapabilityMapPath
+	if !filepath.IsAbs(capPath) && opts.ProjectRoot != "" {
+		capPath = filepath.Join(opts.ProjectRoot, capPath)
+	}
+	content, err := os.ReadFile(capPath)
+	if err != nil {
+		// Fail-open: absent/unreadable capability-map → empty rows (REQ-NT-002).
+		slog.Debug("astx: capability-map read error", "path", capPath, "error", err)
+		return EnrichResult{Provenance: CurrentProvenance(opts.ProjectRoot)}, nil
+	}
+
+	rows := parseCapabilityMap(content)
+	out := make([]EnrichedRow, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, enrichOneRow(opts, r))
+	}
+	return EnrichResult{
+		Provenance: CurrentProvenance(opts.ProjectRoot),
+		Rows:       out,
+	}, nil
+}
+
+// enrichOneRow resolves a capability row's implementation-path, walks it, and
+// aggregates the extracted symbols into an EnrichedRow.
+func enrichOneRow(opts EnrichOptions, r capRow) EnrichedRow {
+	row := EnrichedRow{
+		SpecID:             r["spec-id"],
+		Title:              r["title"],
+		ImplementationPath: r["implementation-path"],
+		PrimaryFiles:       []string{},
+		PrimarySymbols:     []Symbol{},
+	}
+	if row.ImplementationPath == "" {
+		return row
+	}
+
+	resolved := row.ImplementationPath
+	if !filepath.IsAbs(resolved) && opts.ProjectRoot != "" {
+		resolved = filepath.Join(opts.ProjectRoot, resolved)
+	}
+	info, err := os.Stat(resolved)
+	if err != nil || info == nil {
+		// Path absent → on_disk_verified false, supported stays false.
+		slog.Debug("astx: implementation-path absent", "path", resolved, "error", err)
+		return row
+	}
+
+	// Walk and extract. The ceiling bounds how many files are parsed; once it
+	// is hit the walk stops and truncated is set (REQ-NT-014).
+	var aggs []fileAgg
+	langFileCount := map[string]int{}
+	totalFiles := 0
+	truncated := false
+
+	_ = filepath.WalkDir(resolved, func(path string, d os.DirEntry, werr error) error {
+		if werr != nil {
+			return nil // skip unreadable entries
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if totalFiles >= opts.MaxFilesPerPath {
+			truncated = true
+			return filepath.SkipAll
+		}
+		lang := DetectLanguage(d.Name())
+		if lang == "" || IsScaffolded(lang) {
+			return nil
+		}
+		set, _ := Extract(lang, path)
+		if !set.Supported {
+			return nil
+		}
+		totalFiles++
+		langFileCount[lang]++
+		flat := 0
+		for _, syms := range set.Symbols {
+			flat += len(syms)
+		}
+		aggs = append(aggs, fileAgg{path: path, lang: lang, symbols: set.Symbols, count: flat})
+		return nil
+	})
+
+	row.Truncated = truncated
+	row.OnDiskVerified = len(aggs) > 0
+	row.Supported = row.OnDiskVerified
+	row.ExtractLanguage = dominantLanguage(langFileCount)
+	row.PrimaryFiles = topFiles(aggs, opts.PrimaryFilesN)
+	row.PrimarySymbols, row.SymbolCount = aggregateSymbols(aggs, opts.PrimarySymbolsN)
+
+	// Make paths relative to the project root for stable output.
+	if opts.ProjectRoot != "" {
+		for i, p := range row.PrimaryFiles {
+			if rel, err := filepath.Rel(opts.ProjectRoot, p); err == nil {
+				row.PrimaryFiles[i] = rel
+			}
+		}
+	}
+	return row
+}
+
+// dominantLanguage returns the language with the highest file count (ties
+// broken by registration-table order for determinism), or "".
+func dominantLanguage(counts map[string]int) string {
+	best := ""
+	bestN := 0
+	for _, m := range supportedLanguages {
+		if n := counts[m.Name]; n > bestN {
+			bestN = n
+			best = m.Name
+		}
+	}
+	return best
+}
+
+// topFiles returns the top-N file paths by symbol count (desc, stable ties).
+func topFiles(aggs []fileAgg, n int) []string {
+	sorted := make([]fileAgg, len(aggs))
+	copy(sorted, aggs)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		if sorted[i].count != sorted[j].count {
+			return sorted[i].count > sorted[j].count
+		}
+		return sorted[i].path < sorted[j].path
+	})
+	if n > len(sorted) {
+		n = len(sorted)
+	}
+	out := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		out = append(out, sorted[i].path)
+	}
+	return out
+}
+
+// aggregateSymbols returns the top-N symbols by frequency across files and
+// the total deduplicated symbol count.
+func aggregateSymbols(aggs []fileAgg, n int) ([]Symbol, int) {
+	type freqSym struct {
+		sym Symbol
+		n   int
+	}
+	freq := map[string]*freqSym{}
+	for _, a := range aggs {
+		for _, syms := range a.symbols {
+			for _, s := range syms {
+				key := s.Kind + ":" + s.Name
+				if existing, ok := freq[key]; ok {
+					existing.n++
+				} else {
+					freq[key] = &freqSym{sym: s, n: 1}
+				}
+			}
+		}
+	}
+	list := make([]*freqSym, 0, len(freq))
+	for _, v := range freq {
+		list = append(list, v)
+	}
+	sort.SliceStable(list, func(i, j int) bool {
+		if list[i].n != list[j].n {
+			return list[i].n > list[j].n
+		}
+		ki := list[i].sym.Kind + ":" + list[i].sym.Name
+		kj := list[j].sym.Kind + ":" + list[j].sym.Name
+		return ki < kj
+	})
+	if n > len(list) {
+		n = len(list)
+	}
+	out := make([]Symbol, 0, n)
+	for i := 0; i < n; i++ {
+		out = append(out, list[i].sym)
+	}
+	return out, len(freq)
+}
+
+// RenderMarkdown renders the enriched rows to the human-readable
+// capability-symbols.md format (design.md §5.1).
+func RenderMarkdown(p Provenance, sourceMap string, rows []EnrichedRow) []byte {
+	var b bytes.Buffer
+	fmt.Fprintf(&b, "# Capability Symbols (AST-derived)\n\n")
+	fmt.Fprintf(&b, "Extracted at: %s\n", p.CapturedAt)
+	fmt.Fprintf(&b, "Extract commit: %s\n", p.ExtractCommitSHA)
+	fmt.Fprintf(&b, "Source capability-map: %s\n\n", sourceMap)
+	fmt.Fprintf(&b, "| spec-id | title | implementation-path | on-disk | files | symbols | primary-symbols |\n")
+	fmt.Fprintf(&b, "|---------|-------|---------------------|---------|-------|---------|-----------------|\n")
+	for _, r := range rows {
+		mark := "✗"
+		if r.OnDiskVerified {
+			mark = "✓"
+		}
+		prim := symbolNames(r.PrimarySymbols)
+		fmt.Fprintf(&b, "| %s | %s | %s | %s | %d | %d | %s |\n",
+			r.SpecID, r.Title, r.ImplementationPath, mark,
+			len(r.PrimaryFiles), r.SymbolCount, strings.Join(prim, ", "))
+	}
+	return b.Bytes()
+}
+
+// MarshalCapabilitySymbolsJSON renders the machine-readable JSON envelope
+// (design.md §5.2) deterministically.
+func MarshalCapabilitySymbolsJSON(p Provenance, sourceMap string, rows []EnrichedRow) []byte {
+	var b bytes.Buffer
+	fmt.Fprintf(&b, "{\n")
+	fmt.Fprintf(&b, "  \"extracted_at\": %s,\n", jsonStr(p.CapturedAt))
+	fmt.Fprintf(&b, "  \"extract_commit\": %s,\n", jsonStr(p.ExtractCommitSHA))
+	fmt.Fprintf(&b, "  \"source_capability_map\": %s,\n", jsonStr(sourceMap))
+	fmt.Fprintf(&b, "  \"rows\": [")
+	if len(rows) == 0 {
+		fmt.Fprintf(&b, "]\n}\n")
+		return b.Bytes()
+	}
+	fmt.Fprintf(&b, "\n")
+	for i, r := range rows {
+		fmt.Fprintf(&b, "    {\n")
+		fmt.Fprintf(&b, "      \"spec_id\": %s,\n", jsonStr(r.SpecID))
+		fmt.Fprintf(&b, "      \"title\": %s,\n", jsonStr(r.Title))
+		fmt.Fprintf(&b, "      \"implementation_path\": %s,\n", jsonStr(r.ImplementationPath))
+		fmt.Fprintf(&b, "      \"on_disk_verified\": %v,\n", r.OnDiskVerified)
+		fmt.Fprintf(&b, "      \"extract_language\": %s,\n", jsonStr(r.ExtractLanguage))
+		fmt.Fprintf(&b, "      \"primary_files\": [")
+		for j, f := range r.PrimaryFiles {
+			if j > 0 {
+				b.WriteString(", ")
+			}
+			b.WriteString(jsonStr(f))
+		}
+		fmt.Fprintf(&b, "],\n")
+		fmt.Fprintf(&b, "      \"primary_symbols\": [")
+		for j, s := range r.PrimarySymbols {
+			if j > 0 {
+				b.WriteString(", ")
+			}
+			fmt.Fprintf(&b, "{\"name\": %s, \"kind\": %s, \"file\": %s, \"line\": %d}",
+				jsonStr(s.Name), jsonStr(s.Kind), jsonStr(s.File), s.Line)
+		}
+		fmt.Fprintf(&b, "],\n")
+		fmt.Fprintf(&b, "      \"symbol_count\": %d,\n", r.SymbolCount)
+		fmt.Fprintf(&b, "      \"truncated\": %v,\n", r.Truncated)
+		fmt.Fprintf(&b, "      \"supported\": %v\n", r.Supported)
+		if i == len(rows)-1 {
+			fmt.Fprintf(&b, "    }\n")
+		} else {
+			fmt.Fprintf(&b, "    },\n")
+		}
+	}
+	fmt.Fprintf(&b, "  ]\n}\n")
+	return b.Bytes()
+}
+
+func symbolNames(syms []Symbol) []string {
+	out := make([]string, 0, len(syms))
+	for _, s := range syms {
+		out = append(out, s.Name)
+	}
+	return out
+}
+
+// jsonStr renders s as a JSON string literal.
+func jsonStr(s string) string {
+	var b bytes.Buffer
+	b.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '"':
+			b.WriteString(`\"`)
+		case '\\':
+			b.WriteString(`\\`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\r':
+			b.WriteString(`\r`)
+		case '\t':
+			b.WriteString(`\t`)
+		default:
+			if r < 0x20 {
+				fmt.Fprintf(&b, `\u%04x`, r)
+			} else {
+				b.WriteRune(r)
+			}
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
+}

--- a/internal/navigator/astx/enrich_test.go
+++ b/internal/navigator/astx/enrich_test.go
@@ -1,0 +1,193 @@
+package astx
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// enrichBase returns EnrichOptions pointing at the synthetic capability-map
+// fixture under testdata/enrich (implementation-path = src/auth).
+func enrichBase(t *testing.T, capMap string) EnrichOptions {
+	t.Helper()
+	return EnrichOptions{
+		ProjectRoot:        filepath.Join("testdata", "enrich"),
+		CapabilityMapPath:  capMap,
+		MaxFilesPerPath:    2000,
+		PrimaryFilesN:      5,
+		PrimarySymbolsN:    10,
+	}
+}
+
+// TestEnrichRows_HeaderDrivenJoin is AC-NT-011: the join resolves columns by
+// header name, so a permuted column order still pairs rows correctly.
+func TestEnrichRows_HeaderDrivenJoin(t *testing.T) {
+	res, err := EnrichRows(enrichBase(t, "capability-map-permuted.md"))
+	if err != nil {
+		t.Fatalf("EnrichRows error: %v", err)
+	}
+	if len(res.Rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(res.Rows))
+	}
+	row := res.Rows[0]
+	// implementation-path was in column 1 but the join should have resolved it
+	// by header name and walked src/auth.
+	if row.SpecID != "SPEC-AUTH-001" {
+		t.Errorf("SpecID = %q, want SPEC-AUTH-001", row.SpecID)
+	}
+	if !row.OnDiskVerified {
+		t.Errorf("OnDiskVerified = false, want true (src/auth exists under testdata/enrich)")
+	}
+	if row.ExtractLanguage != "go" {
+		t.Errorf("ExtractLanguage = %q, want go", row.ExtractLanguage)
+	}
+	if row.SymbolCount == 0 {
+		t.Errorf("SymbolCount = 0, want >0 (handler.go declares symbols)")
+	}
+}
+
+// TestEnrichRows_MissingPathOnDiskVerifiedFalse is the on-disk-verified false
+// case: a capability row whose implementation-path does not exist carries
+// OnDiskVerified=false and the run does not abort.
+func TestEnrichRows_MissingPathOnDiskVerifiedFalse(t *testing.T) {
+	res, err := EnrichRows(enrichBase(t, "capability-map.md"))
+	if err != nil {
+		t.Fatalf("EnrichRows error: %v", err)
+	}
+	bySpec := map[string]EnrichedRow{}
+	for _, r := range res.Rows {
+		bySpec[r.SpecID] = r
+	}
+	gone, ok := bySpec["SPEC-GONE-002"]
+	if !ok {
+		t.Fatalf("SPEC-GONE-002 row missing; rows=%v", res.Rows)
+	}
+	if gone.OnDiskVerified {
+		t.Errorf("SPEC-GONE-002 OnDiskVerified=true, want false (path absent)")
+	}
+	auth := bySpec["SPEC-AUTH-001"]
+	if !auth.OnDiskVerified {
+		t.Errorf("SPEC-AUTH-001 OnDiskVerified=false, want true")
+	}
+}
+
+// TestEnrichRows_FileCountCeilingTruncation is AC-NT-014: a low ceiling
+// truncates the walk and marks the row truncated. The src/auth fixture has
+// two Go files (handler.go, token.go); a ceiling of 1 parses only the first
+// and sets truncated=true.
+func TestEnrichRows_FileCountCeilingTruncation(t *testing.T) {
+	opts := enrichBase(t, "capability-map-permuted.md")
+	opts.MaxFilesPerPath = 1
+	res, err := EnrichRows(opts)
+	if err != nil {
+		t.Fatalf("EnrichRows error: %v", err)
+	}
+	if len(res.Rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(res.Rows))
+	}
+	row := res.Rows[0]
+	if !row.Truncated {
+		t.Errorf("Truncated = false, want true (MaxFilesPerPath=1 < 2 files)")
+	}
+	// Only one file parsed → primary_files has at most 1 entry.
+	if len(row.PrimaryFiles) > 1 {
+		t.Errorf("PrimaryFiles = %d entries, want <=1 (ceiling=1)", len(row.PrimaryFiles))
+	}
+}
+
+// TestCurrentProvenance_NonEmpty is REQ-NT-009: provenance carries a SHA +
+// captured-at sourced from git (not wall-clock). In a git worktree HEAD is
+// resolvable, so both fields must be non-empty.
+func TestCurrentProvenance_NonEmpty(t *testing.T) {
+	p := CurrentProvenance("")
+	if p.ExtractCommitSHA == "" {
+		t.Errorf("ExtractCommitSHA empty, want a SHA")
+	}
+	if p.CapturedAt == "" {
+		t.Errorf("CapturedAt empty, want an ISO-8601 committer date")
+	}
+}
+
+// TestMarshalCapabilitySymbolsJSON_StableSchema is AC-NT-010: the JSON
+// envelope carries the four top-level fields and each row the design §5.2
+// fields. It also asserts valid JSON structure (parseable by encoding/json).
+func TestMarshalCapabilitySymbolsJSON_StableSchema(t *testing.T) {
+	p := Provenance{ExtractCommitSHA: "abc123", CapturedAt: "2026-01-01T00:00:00+00:00"}
+	rows := []EnrichedRow{
+		{
+			SpecID: "SPEC-X-001", Title: "X", ImplementationPath: "internal/x",
+			OnDiskVerified: true, ExtractLanguage: "go",
+			PrimaryFiles:   []string{"internal/x/a.go"},
+			PrimarySymbols: []Symbol{{Name: "Foo", Kind: "type", File: "internal/x/a.go", Line: 1}},
+			SymbolCount:    1, Supported: true,
+		},
+	}
+	b := MarshalCapabilitySymbolsJSON(p, ".moai/project/navigator/capability-map.md", rows)
+	// Must be valid JSON.
+	var doc map[string]any
+	if err := json.Unmarshal(b, &doc); err != nil {
+		t.Fatalf("JSON output invalid: %v\n%s", err, b)
+	}
+	for _, k := range []string{"extracted_at", "extract_commit", "source_capability_map", "rows"} {
+		if _, ok := doc[k]; !ok {
+			t.Errorf("top-level field %q missing from JSON", k)
+		}
+	}
+	rowList, _ := doc["rows"].([]any)
+	if len(rowList) != 1 {
+		t.Fatalf("rows len = %d, want 1", len(rowList))
+	}
+	r0, _ := rowList[0].(map[string]any)
+	for _, k := range []string{"spec_id", "title", "implementation_path", "on_disk_verified",
+		"extract_language", "primary_files", "primary_symbols", "symbol_count",
+		"truncated", "supported"} {
+		if _, ok := r0[k]; !ok {
+			t.Errorf("row field %q missing from JSON", k)
+		}
+	}
+}
+
+// TestRenderMarkdown_ContainsHeader is AC-NT-010 dual-output: the markdown
+// carries the provenance header and a table row per EnrichedRow.
+func TestRenderMarkdown_ContainsHeader(t *testing.T) {
+	p := Provenance{ExtractCommitSHA: "abc123", CapturedAt: "2026-01-01T00:00:00+00:00"}
+	rows := []EnrichedRow{{SpecID: "SPEC-X-001", Title: "X", OnDiskVerified: true, SymbolCount: 2}}
+	b := string(RenderMarkdown(p, "cap.md", rows))
+	for _, want := range []string{"Capability Symbols (AST-derived)", "abc123", "cap.md", "SPEC-X-001", "✓"} {
+		if !strings.Contains(b, want) {
+			t.Errorf("markdown missing %q", want)
+		}
+	}
+}
+
+// TestEnrichRows_Idempotent is AC-NT-012: two consecutive runs on the same
+// HEAD produce byte-identical JSON output (no wall-clock timestamp).
+func TestEnrichRows_Idempotent(t *testing.T) {
+	opts := enrichBase(t, "capability-map.md")
+	r1, _ := EnrichRows(opts)
+	r2, _ := EnrichRows(opts)
+	b1 := MarshalCapabilitySymbolsJSON(r1.Provenance, "cap.md", r1.Rows)
+	b2 := MarshalCapabilitySymbolsJSON(r2.Provenance, "cap.md", r2.Rows)
+	if !bytes.Equal(b1, b2) {
+		t.Errorf("idempotence violated: two runs produced different JSON")
+	}
+}
+
+// TestParseCapabilityMap_SeparatorAndMissingTable covers the header-driven
+// parser directly: a separator row is skipped, and a file with no table
+// yields zero rows.
+func TestParseCapabilityMap_SeparatorAndMissingTable(t *testing.T) {
+	rows := parseCapabilityMap([]byte("| a | b |\n|---|---|\n| 1 | 2 |\n"))
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 data row, got %d", len(rows))
+	}
+	if rows[0]["a"] != "1" || rows[0]["b"] != "2" {
+		t.Errorf("parsed row = %v, want a=1 b=2", rows[0])
+	}
+	none := parseCapabilityMap([]byte("# just prose\n\nno table here\n"))
+	if len(none) != 0 {
+		t.Errorf("expected 0 rows for table-less input, got %d", len(none))
+	}
+}

--- a/internal/navigator/astx/measure_cgo.go
+++ b/internal/navigator/astx/measure_cgo.go
@@ -1,0 +1,116 @@
+//go:build cgo
+
+package astx
+
+import (
+	"context"
+	_ "embed"
+	"log/slog"
+	"os"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/smacker/go-tree-sitter/golang"
+)
+
+// Embedded per-language query files. Each capture is named @symbol.<kind>
+// so the extractor can group captures by kind generically.
+//
+//go:embed queries/go.scm
+var queryGo []byte
+
+// seedEntry binds a tree-sitter grammar to its embedded .scm query bytes.
+type seedEntry struct {
+	grammar *sitter.Language
+	query   []byte
+}
+
+// seededGrammars is the CGO-enabled grammar map. A language present here with
+// a compiled query is Supported: true; absent or scaffolded entries return
+// Supported: false (see scaffoldedLanguages in astx.go).
+//
+// M1 seeds Go only; M2 adds the remaining 13 working grammars by adding rows
+// here + their .scm query files (no per-language Go logic — REQ-NT-006).
+var seededGrammars = map[string]seedEntry{
+	"go": {grammar: golang.GetLanguage(), query: queryGo},
+}
+
+// extractImpl is the CGO-enabled tree-sitter implementation of Extract.
+func extractImpl(language string, sourcePath string) (SymbolSet, error) {
+	// Scaffolded languages have no upstream grammar.
+	if scaffoldedLanguages[language] {
+		return SymbolSet{Supported: false}, nil
+	}
+	entry, ok := seededGrammars[language]
+	if !ok {
+		return SymbolSet{Supported: false}, nil
+	}
+
+	// Read the source file (fail-open on read error).
+	content, err := os.ReadFile(sourcePath)
+	if err != nil {
+		slog.Debug("astx: read error", "lang", language, "path", sourcePath, "error", err)
+		return SymbolSet{Supported: false}, nil
+	}
+
+	// File-size guard (mirrors internal/hook/mx/complexity).
+	if len(content) > maxFileSizeBytes {
+		slog.Debug("astx: file exceeds size cap", "lang", language, "path", sourcePath, "bytes", len(content))
+		return SymbolSet{Supported: false}, nil
+	}
+
+	// Parse with tree-sitter (tree-sitter recovers from syntax errors and
+	// returns a partial tree, so malformed-but-readable files still yield
+	// captures — REQ-NT-008 malformed-source tolerance).
+	parser := sitter.NewParser()
+	parser.SetLanguage(entry.grammar)
+	tree, err := parser.ParseCtx(context.Background(), nil, content)
+	if err != nil || tree == nil {
+		if err != nil {
+			slog.Debug("astx: parse error", "lang", language, "path", sourcePath, "error", err)
+		}
+		return SymbolSet{Supported: false}, nil
+	}
+	defer tree.Close()
+	root := tree.RootNode()
+
+	// Compile the query (fail-open on compile error — logged, not fatal).
+	q, err := sitter.NewQuery(entry.query, entry.grammar)
+	if err != nil {
+		slog.Debug("astx: query compile error", "lang", language, "error", err)
+		return SymbolSet{Supported: false}, nil
+	}
+	defer q.Close()
+
+	cursor := sitter.NewQueryCursor()
+	defer cursor.Close()
+	cursor.Exec(q, root)
+
+	symbols := map[string][]Symbol{}
+	for {
+		match, ok := cursor.NextMatch()
+		if !ok {
+			break
+		}
+		for _, cap := range match.Captures {
+			kind := q.CaptureNameForId(cap.Index)
+			// Only honor @symbol.<kind> captures.
+			if len(kind) <= len("symbol.") || kind[:len("symbol.")] != "symbol." {
+				continue
+			}
+			symKind := kind[len("symbol."):]
+			name := string(content[cap.Node.StartByte():cap.Node.EndByte()])
+			symbols[symKind] = append(symbols[symKind], Symbol{
+				Name: name,
+				Kind: symKind,
+				File: sourcePath,
+				Line: int(cap.Node.StartPoint().Row) + 1,
+			})
+		}
+	}
+
+	return SymbolSet{
+		Supported:   true,
+		Symbols:     symbols,
+		SourceBytes: int64(len(content)),
+	}, nil
+}

--- a/internal/navigator/astx/measure_cgo.go
+++ b/internal/navigator/astx/measure_cgo.go
@@ -9,14 +9,66 @@ import (
 	"os"
 
 	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/smacker/go-tree-sitter/cpp"
+	"github.com/smacker/go-tree-sitter/csharp"
+	"github.com/smacker/go-tree-sitter/elixir"
 	"github.com/smacker/go-tree-sitter/golang"
+	"github.com/smacker/go-tree-sitter/java"
+	"github.com/smacker/go-tree-sitter/javascript"
+	"github.com/smacker/go-tree-sitter/kotlin"
+	"github.com/smacker/go-tree-sitter/php"
+	"github.com/smacker/go-tree-sitter/python"
+	"github.com/smacker/go-tree-sitter/ruby"
+	"github.com/smacker/go-tree-sitter/rust"
+	"github.com/smacker/go-tree-sitter/scala"
+	"github.com/smacker/go-tree-sitter/swift"
+	"github.com/smacker/go-tree-sitter/typescript/typescript"
 )
 
 // Embedded per-language query files. Each capture is named @symbol.<kind>
 // so the extractor can group captures by kind generically.
-//
+
 //go:embed queries/go.scm
 var queryGo []byte
+
+//go:embed queries/python.scm
+var queryPython []byte
+
+//go:embed queries/typescript.scm
+var queryTypeScript []byte
+
+//go:embed queries/javascript.scm
+var queryJavaScript []byte
+
+//go:embed queries/rust.scm
+var queryRust []byte
+
+//go:embed queries/java.scm
+var queryJava []byte
+
+//go:embed queries/kotlin.scm
+var queryKotlin []byte
+
+//go:embed queries/csharp.scm
+var queryCSharp []byte
+
+//go:embed queries/ruby.scm
+var queryRuby []byte
+
+//go:embed queries/php.scm
+var queryPHP []byte
+
+//go:embed queries/elixir.scm
+var queryElixir []byte
+
+//go:embed queries/cpp.scm
+var queryCPP []byte
+
+//go:embed queries/scala.scm
+var queryScala []byte
+
+//go:embed queries/swift.scm
+var querySwift []byte
 
 // seedEntry binds a tree-sitter grammar to its embedded .scm query bytes.
 type seedEntry struct {
@@ -28,10 +80,23 @@ type seedEntry struct {
 // a compiled query is Supported: true; absent or scaffolded entries return
 // Supported: false (see scaffoldedLanguages in astx.go).
 //
-// M1 seeds Go only; M2 adds the remaining 13 working grammars by adding rows
-// here + their .scm query files (no per-language Go logic — REQ-NT-006).
+// Extending to a new language is a row here + a queries/<lang>.scm file — no
+// per-language Go logic (REQ-NT-006 data-file extension property).
 var seededGrammars = map[string]seedEntry{
-	"go": {grammar: golang.GetLanguage(), query: queryGo},
+	"go":         {grammar: golang.GetLanguage(), query: queryGo},
+	"python":     {grammar: python.GetLanguage(), query: queryPython},
+	"typescript": {grammar: typescript.GetLanguage(), query: queryTypeScript},
+	"javascript": {grammar: javascript.GetLanguage(), query: queryJavaScript},
+	"rust":       {grammar: rust.GetLanguage(), query: queryRust},
+	"java":       {grammar: java.GetLanguage(), query: queryJava},
+	"kotlin":     {grammar: kotlin.GetLanguage(), query: queryKotlin},
+	"csharp":     {grammar: csharp.GetLanguage(), query: queryCSharp},
+	"ruby":       {grammar: ruby.GetLanguage(), query: queryRuby},
+	"php":        {grammar: php.GetLanguage(), query: queryPHP},
+	"elixir":     {grammar: elixir.GetLanguage(), query: queryElixir},
+	"cpp":        {grammar: cpp.GetLanguage(), query: queryCPP},
+	"scala":      {grammar: scala.GetLanguage(), query: queryScala},
+	"swift":      {grammar: swift.GetLanguage(), query: querySwift},
 }
 
 // extractImpl is the CGO-enabled tree-sitter implementation of Extract.

--- a/internal/navigator/astx/measure_nocgo.go
+++ b/internal/navigator/astx/measure_nocgo.go
@@ -1,0 +1,10 @@
+//go:build !cgo
+
+package astx
+
+// extractImpl is the non-CGO stub: every language returns Supported: false
+// because tree-sitter requires CGO. The build still compiles and Extract
+// never panics (REQ-NT-015).
+func extractImpl(_ string, _ string) (SymbolSet, error) {
+	return SymbolSet{Supported: false}, nil
+}

--- a/internal/navigator/astx/polyglot_test.go
+++ b/internal/navigator/astx/polyglot_test.go
@@ -1,0 +1,81 @@
+package astx
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// polyglotCases is the AC-NT-004 fixture: one source file per language for
+// each of the 14 working languages, each declaring a known function/method
+// and a type. Each row asserts Supported == true AND that both expected
+// names appear somewhere in the captured symbol set.
+var polyglotCases = []struct {
+	lang     string
+	file     string
+	wantFunc string // a name expected in the "function" or "method" group
+	wantType string // a name expected in the "type" group
+}{
+	{"go", "sample.go", "NewGreeter", "Greeter"},
+	{"python", "polyglot/sample.py", "build", "Widget"},
+	{"typescript", "polyglot/sample.ts", "area", "Circle"},
+	{"javascript", "polyglot/sample.js", "make", "Box"},
+	{"rust", "polyglot/sample.rs", "origin", "Point"},
+	{"java", "polyglot/sample.java", "start", "Engine"},
+	{"kotlin", "polyglot/sample.kt", "main", "KotlinWidget"},
+	{"csharp", "polyglot/sample.cs", "Run", "Service"},
+	{"ruby", "polyglot/sample.rb", "total", "Basket"},
+	{"php", "polyglot/sample.php", "helper", "Repo"},
+	{"elixir", "polyglot/sample.ex", "run", "Worker"},
+	{"cpp", "polyglot/sample.cpp", "add", "List"},
+	{"scala", "polyglot/sample.scala", "init", "Config"},
+	{"swift", "polyglot/sample.swift", "render", "Canvas"},
+}
+
+func TestPolyglot_AllFourteenGrammarsExtract(t *testing.T) {
+	for _, tc := range polyglotCases {
+		t.Run(tc.lang, func(t *testing.T) {
+			path := tc.file
+			// The Go fixture lives at testdata/sample.go (not under polyglot/).
+			set, err := Extract(tc.lang, filepath.Join("testdata", path))
+			if err != nil {
+				t.Fatalf("Extract(%s) error: %v", tc.lang, err)
+			}
+			if !set.Supported {
+				t.Fatalf("Extract(%s) Supported=false, want true", tc.lang)
+			}
+			// Check the expected function/method name across both groups.
+			if !hasName(set, "function", tc.wantFunc) && !hasName(set, "method", tc.wantFunc) {
+				t.Errorf("Extract(%s): %q not found in function/method; symbols=%v",
+					tc.lang, tc.wantFunc, set.Symbols)
+			}
+			// Check the expected type name (some languages put classes under "type").
+			if !hasName(set, "type", tc.wantType) {
+				t.Errorf("Extract(%s): type %q not found; symbols=%v",
+					tc.lang, tc.wantType, set.Symbols)
+			}
+		})
+	}
+}
+
+// TestPolyglot_RAndFlutterFailOpen is AC-NT-005: r/flutter return
+// Supported: false and the other rows still extract normally.
+func TestPolyglot_RAndFlutterFailOpen(t *testing.T) {
+	for _, lang := range []string{"r", "flutter"} {
+		set, err := Extract(lang, filepath.Join("testdata", "polyglot", "sample.py"))
+		if err != nil {
+			t.Fatalf("Extract(%s) error: %v", lang, err)
+		}
+		if set.Supported {
+			t.Errorf("Extract(%s) Supported=true, want false (scaffolded)", lang)
+		}
+	}
+}
+
+func hasName(set SymbolSet, kind, name string) bool {
+	for _, sym := range set.Symbols[kind] {
+		if sym.Name == name {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/navigator/astx/queries/cpp.scm
+++ b/internal/navigator/astx/queries/cpp.scm
@@ -1,0 +1,5 @@
+; astx — C++ symbol captures.
+(function_definition declarator: (function_declarator declarator: (identifier) @symbol.function))
+(class_specifier name: (type_identifier) @symbol.type)
+(struct_specifier name: (type_identifier) @symbol.type)
+(enum_specifier name: (type_identifier) @symbol.type)

--- a/internal/navigator/astx/queries/csharp.scm
+++ b/internal/navigator/astx/queries/csharp.scm
@@ -1,0 +1,6 @@
+; astx — C# symbol captures.
+(method_declaration name: (identifier) @symbol.method)
+(class_declaration name: (identifier) @symbol.type)
+(interface_declaration name: (identifier) @symbol.type)
+(struct_declaration name: (identifier) @symbol.type)
+(enum_declaration name: (identifier) @symbol.type)

--- a/internal/navigator/astx/queries/dart.scm
+++ b/internal/navigator/astx/queries/dart.scm
@@ -1,0 +1,2 @@
+; astx — Dart/Flutter is scaffolded (no upstream grammar in smacker/go-tree-sitter).
+; Extract returns Supported: false.

--- a/internal/navigator/astx/queries/elixir.scm
+++ b/internal/navigator/astx/queries/elixir.scm
@@ -1,0 +1,9 @@
+; astx — Elixir symbol captures. def/defp/defmodule are call expressions.
+(call
+  target: (identifier) @_kw
+  (arguments (alias) @symbol.type)
+  (#match? @_kw "^defmodule$"))
+(call
+  target: (identifier) @_kw
+  (arguments (call target: (identifier) @symbol.function))
+  (#match? @_kw "^(def|defp|defmacro)$"))

--- a/internal/navigator/astx/queries/go.scm
+++ b/internal/navigator/astx/queries/go.scm
@@ -1,0 +1,9 @@
+; SPEC-PROJECT-NAVIGATOR-003 astx — Go symbol captures.
+; Captures use the @symbol.<kind> naming convention so the extractor groups
+; symbols by kind without language-specific Go logic.
+
+(function_declaration name: (identifier) @symbol.function)
+
+(method_declaration name: (field_identifier) @symbol.method)
+
+(type_declaration (type_spec name: (type_identifier) @symbol.type))

--- a/internal/navigator/astx/queries/java.scm
+++ b/internal/navigator/astx/queries/java.scm
@@ -1,0 +1,5 @@
+; astx — Java symbol captures.
+(method_declaration name: (identifier) @symbol.method)
+(class_declaration name: (identifier) @symbol.type)
+(interface_declaration name: (identifier) @symbol.type)
+(enum_declaration name: (identifier) @symbol.type)

--- a/internal/navigator/astx/queries/javascript.scm
+++ b/internal/navigator/astx/queries/javascript.scm
@@ -1,0 +1,4 @@
+; astx — JavaScript symbol captures.
+(function_declaration name: (identifier) @symbol.function)
+(method_definition name: (property_identifier) @symbol.method)
+(class_declaration name: (identifier) @symbol.type)

--- a/internal/navigator/astx/queries/kotlin.scm
+++ b/internal/navigator/astx/queries/kotlin.scm
@@ -1,0 +1,4 @@
+; astx — Kotlin symbol captures. Identifiers are direct children (no name: field).
+(function_declaration (simple_identifier) @symbol.function)
+(class_declaration (type_identifier) @symbol.type)
+(object_declaration (type_identifier) @symbol.type)

--- a/internal/navigator/astx/queries/php.scm
+++ b/internal/navigator/astx/queries/php.scm
@@ -1,0 +1,5 @@
+; astx — PHP symbol captures.
+(function_definition name: (name) @symbol.function)
+(method_declaration name: (name) @symbol.method)
+(class_declaration name: (name) @symbol.type)
+(interface_declaration name: (name) @symbol.type)

--- a/internal/navigator/astx/queries/python.scm
+++ b/internal/navigator/astx/queries/python.scm
@@ -1,0 +1,3 @@
+; astx — Python symbol captures.
+(function_definition name: (identifier) @symbol.function)
+(class_definition name: (identifier) @symbol.type)

--- a/internal/navigator/astx/queries/r.scm
+++ b/internal/navigator/astx/queries/r.scm
@@ -1,0 +1,2 @@
+; astx — R is scaffolded (no upstream grammar in smacker/go-tree-sitter).
+; Extract returns Supported: false.

--- a/internal/navigator/astx/queries/ruby.scm
+++ b/internal/navigator/astx/queries/ruby.scm
@@ -1,0 +1,4 @@
+; astx — Ruby symbol captures.
+(method name: (identifier) @symbol.method)
+(class name: (constant) @symbol.type)
+(module name: (constant) @symbol.type)

--- a/internal/navigator/astx/queries/rust.scm
+++ b/internal/navigator/astx/queries/rust.scm
@@ -1,0 +1,5 @@
+; astx — Rust symbol captures.
+(function_item name: (identifier) @symbol.function)
+(struct_item name: (type_identifier) @symbol.type)
+(enum_item name: (type_identifier) @symbol.type)
+(trait_item name: (type_identifier) @symbol.type)

--- a/internal/navigator/astx/queries/scala.scm
+++ b/internal/navigator/astx/queries/scala.scm
@@ -1,0 +1,5 @@
+; astx — Scala symbol captures.
+(function_definition name: (identifier) @symbol.function)
+(class_definition name: (identifier) @symbol.type)
+(object_definition name: (identifier) @symbol.type)
+(trait_definition name: (identifier) @symbol.type)

--- a/internal/navigator/astx/queries/swift.scm
+++ b/internal/navigator/astx/queries/swift.scm
@@ -1,0 +1,4 @@
+; astx — Swift symbol captures. (grammar has no struct_declaration node.)
+(function_declaration name: (simple_identifier) @symbol.function)
+(class_declaration name: (type_identifier) @symbol.type)
+(protocol_declaration name: (type_identifier) @symbol.type)

--- a/internal/navigator/astx/queries/typescript.scm
+++ b/internal/navigator/astx/queries/typescript.scm
@@ -1,0 +1,5 @@
+; astx — TypeScript symbol captures.
+(function_declaration name: (identifier) @symbol.function)
+(method_definition name: (property_identifier) @symbol.method)
+(class_declaration name: (type_identifier) @symbol.type)
+(interface_declaration name: (type_identifier) @symbol.type)

--- a/internal/navigator/astx/testdata/enrich/capability-map-permuted.md
+++ b/internal/navigator/astx/testdata/enrich/capability-map-permuted.md
@@ -1,0 +1,5 @@
+# Capability Map (columns reordered: implementation-path first)
+
+| implementation-path | spec-id | title | status | commit-sha | captured-at |
+|---------------------|---------|-------|--------|------------|-------------|
+| src/auth | SPEC-AUTH-001 | Auth | implemented | abc123 | 2026-01-01 |

--- a/internal/navigator/astx/testdata/enrich/capability-map.md
+++ b/internal/navigator/astx/testdata/enrich/capability-map.md
@@ -1,0 +1,6 @@
+# Capability Map (synthetic, permuted columns for AC-NT-011)
+
+| spec-id | title | status | implementation-path | commit-sha | captured-at |
+|---------|-------|--------|---------------------|------------|-------------|
+| SPEC-AUTH-001 | Auth | implemented | src/auth | abc123 | 2026-01-01 |
+| SPEC-GONE-002 | Missing | implemented | src/does-not-exist | def456 | 2026-01-02 |

--- a/internal/navigator/astx/testdata/enrich/src/auth/handler.go
+++ b/internal/navigator/astx/testdata/enrich/src/auth/handler.go
@@ -1,0 +1,5 @@
+package auth
+type Handler struct{}
+func Login() {}
+func Logout() {}
+func Refresh() {}

--- a/internal/navigator/astx/testdata/enrich/src/auth/token.go
+++ b/internal/navigator/astx/testdata/enrich/src/auth/token.go
@@ -1,0 +1,3 @@
+package auth
+type Token struct{}
+func Issue() *Token { return nil }

--- a/internal/navigator/astx/testdata/polyglot/sample.cpp
+++ b/internal/navigator/astx/testdata/polyglot/sample.cpp
@@ -1,0 +1,3 @@
+struct Node { int val; };
+class List { public: int count; };
+void add(int v) {}

--- a/internal/navigator/astx/testdata/polyglot/sample.cs
+++ b/internal/navigator/astx/testdata/polyglot/sample.cs
@@ -1,0 +1,3 @@
+interface IRepo { int Count(); }
+class Service { public void Run() {} }
+struct Pair { public int A; }

--- a/internal/navigator/astx/testdata/polyglot/sample.ex
+++ b/internal/navigator/astx/testdata/polyglot/sample.ex
@@ -1,0 +1,5 @@
+defmodule Worker do
+  def run(arg) do
+    arg
+  end
+end

--- a/internal/navigator/astx/testdata/polyglot/sample.java
+++ b/internal/navigator/astx/testdata/polyglot/sample.java
@@ -1,0 +1,2 @@
+interface Listener { void onChange(); }
+class Engine { void start() {} }

--- a/internal/navigator/astx/testdata/polyglot/sample.js
+++ b/internal/navigator/astx/testdata/polyglot/sample.js
@@ -1,0 +1,2 @@
+class Box { open() {} }
+function make() { return new Box(); }

--- a/internal/navigator/astx/testdata/polyglot/sample.kt
+++ b/internal/navigator/astx/testdata/polyglot/sample.kt
@@ -1,0 +1,3 @@
+class KotlinWidget
+object Defaults
+fun main() {}

--- a/internal/navigator/astx/testdata/polyglot/sample.php
+++ b/internal/navigator/astx/testdata/polyglot/sample.php
@@ -1,0 +1,4 @@
+<?php
+interface iCache { public function get(); }
+class Repo { public function find() {} }
+function helper() {}

--- a/internal/navigator/astx/testdata/polyglot/sample.py
+++ b/internal/navigator/astx/testdata/polyglot/sample.py
@@ -1,0 +1,5 @@
+class Widget:
+    def render(self):
+        return "w"
+def build():
+    return Widget()

--- a/internal/navigator/astx/testdata/polyglot/sample.rb
+++ b/internal/navigator/astx/testdata/polyglot/sample.rb
@@ -1,0 +1,3 @@
+class Basket; end
+module Pricing; end
+def total; 0; end

--- a/internal/navigator/astx/testdata/polyglot/sample.rs
+++ b/internal/navigator/astx/testdata/polyglot/sample.rs
@@ -1,0 +1,3 @@
+struct Point { x: i32 }
+trait Named { fn name(&self) -> &str; }
+fn origin() -> Point { Point { x: 0 } }

--- a/internal/navigator/astx/testdata/polyglot/sample.scala
+++ b/internal/navigator/astx/testdata/polyglot/sample.scala
@@ -1,0 +1,4 @@
+trait Showable
+class Config
+object Defaults
+def init(): Unit = ()

--- a/internal/navigator/astx/testdata/polyglot/sample.swift
+++ b/internal/navigator/astx/testdata/polyglot/sample.swift
@@ -1,0 +1,3 @@
+protocol Drawable { func draw() }
+struct Size { var w: Int }
+class Canvas { func render() {} }

--- a/internal/navigator/astx/testdata/polyglot/sample.ts
+++ b/internal/navigator/astx/testdata/polyglot/sample.ts
@@ -1,0 +1,3 @@
+interface Shape { id: number; }
+class Circle implements Shape { id = 1; }
+function area(): number { return 3; }

--- a/internal/navigator/astx/testdata/sample.go
+++ b/internal/navigator/astx/testdata/sample.go
@@ -1,0 +1,18 @@
+package sample
+
+import "fmt"
+
+// Greeter is a sample type for AST extraction.
+type Greeter struct {
+	Name string
+}
+
+// Greet is a sample function for AST extraction.
+func (g *Greeter) Greet() string {
+	return fmt.Sprintf("hi %s", g.Name)
+}
+
+// NewGreeter constructs a Greeter.
+func NewGreeter(name string) *Greeter {
+	return &Greeter{Name: name}
+}

--- a/internal/template/templates/.claude/skills/moai-workflow-project/references/navigator-astx.md
+++ b/internal/template/templates/.claude/skills/moai-workflow-project/references/navigator-astx.md
@@ -1,0 +1,99 @@
+# Reference: Navigator AST Enrichment (`navigator-astx`)
+
+> Level-3 progressive-disclosure reference for the AST symbol enrichment that
+> `/moai codemaps` runs in Phase 3 (the capability-gated extension step).
+> Load this reference when extending the supported language set, debugging a
+> missing-symbol extraction, or integrating the enriched output downstream.
+
+## What it is
+
+The `navigator-enrich` step reads 001's `capability-map.md`, walks each row's
+implementation-path, and extracts named symbols (functions, methods, types)
+via tree-sitter grammars. It writes two sibling files under
+`.moai/project/codemaps/`:
+
+- `capability-symbols.md` — human-readable table (spec-id, title, path, on-disk
+  marker, file count, symbol count, primary symbols).
+- `capability-symbols.json` — machine-readable envelope with the full
+  `primary_files` + `primary_symbols` arrays per row.
+
+## Supported languages (16)
+
+14 working grammars (extract symbols) + 2 scaffolded (fail-open, Supported: false):
+
+| Working (14)                              | Scaffolded (2) |
+|-------------------------------------------|----------------|
+| go, python, typescript, javascript, rust, | r              |
+| java, kotlin, csharp, ruby, php, elixir,  | flutter (dart) |
+| cpp, scala, swift                         |                |
+
+The two scaffolded languages have no upstream grammar in the
+`smacker/go-tree-sitter` dependency; `Extract` returns `Supported: false`
+without attempting a parse.
+
+## Extension model (adding a language)
+
+Adding a 17th language (or upgrading r/flutter from scaffolded) is a
+data-driven change — no per-language Go logic:
+
+1. Add a `queries/<lang>.scm` file capturing `@symbol.function` and
+   `@symbol.type` (or language-appropriate kinds).
+2. Add one row to the `seededGrammars` map in `measure_cgo.go` binding the
+   grammar to the embedded query bytes.
+3. For a newly-supported language, add the extension to the registration
+  `langMeta` table in `astx.go` and remove it from `scaffoldedLanguages`.
+
+The `smacker/go-tree-sitter` sub-package for the grammar must exist; if it
+does not, the language stays scaffolded until upstream availability.
+
+## Output schema (JSON)
+
+```json
+{
+  "extracted_at": "<ISO-8601 committer date of extract_commit>",
+  "extract_commit": "<git rev-parse HEAD>",
+  "source_capability_map": ".moai/project/navigator/capability-map.md",
+  "rows": [
+    {
+      "spec_id": "...",
+      "title": "...",
+      "implementation_path": "...",
+      "on_disk_verified": true,
+      "extract_language": "go",
+      "primary_files": ["..."],
+      "primary_symbols": [{"name":"...","kind":"type","file":"...","line":1}],
+      "symbol_count": 47,
+      "truncated": false,
+      "supported": true
+    }
+  ]
+}
+```
+
+Schema is forward-compatible: additive field additions only; no field removals
+or semantic redefinitions.
+
+## Invariants
+
+- **Fail-open**: every error mode (absent capability-map, missing path, parse
+  failure, cgo-disabled build) degrades to a log line + continue — the step
+  never aborts `/moai codemaps`.
+- **Idempotent**: provenance is sourced from `git rev-parse HEAD` + the
+  committer date, never wall-clock. Two runs on the same HEAD produce
+  byte-identical output.
+- **Atomic writes**: each output file is written `<file>.tmp` then renamed.
+  The `NAVIGATOR_PRE_RENAME_BARRIER` env var is a test hook for the
+  atomic-rename fixture.
+- **Boundary integrity**: writes ONLY `.moai/project/codemaps/` and
+  `.moai/logs/navigator-astx.log`. It never touches 001/002 outputs or any
+  LSEL surface.
+
+## Build constraints
+
+The package mirrors `internal/hook/mx/complexity`'s cgo/nocgo split:
+
+- `CGO_ENABLED=1` (default on macOS/Linux): full tree-sitter implementation
+  (`measure_cgo.go`).
+- `CGO_ENABLED=0` (e.g. cross-compile, minimal containers): stub returns
+  `Supported: false` for every language (`measure_nocgo.go`); the build still
+  compiles and `Extract` never panics.

--- a/internal/template/templates/.claude/skills/moai-workflow-project/scripts/navigator-enrich.sh
+++ b/internal/template/templates/.claude/skills/moai-workflow-project/scripts/navigator-enrich.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# navigator-enrich.sh — Project Navigator AST symbol enrichment (the Project Navigator AST enrichment feature).
+#
+# Sibling to the 001 regeneration script and the 002 audit script. Wraps the
+# `moai navigator-enrich` Go entry point which reads 001's capability-map.md
+# (header-driven join), walks each row's implementation-path, extracts
+# tree-sitter symbols, and writes capability-symbols.{md,json} atomically
+# under .moai/project/codemaps/.
+#
+# Design properties:
+#   * Self-contained bash (git + the moai binary; NO jq). The tree-sitter
+#     parsing happens inside the Go entry point; this script only resolves the
+#     project root, performs the capability gate, and invokes the binary.
+#   * Capability gate (the capability-gate REQ): if capability-map.md is
+#     absent, emit an info log and exit 0 WITHOUT writing any output file.
+#   * Atomic writes (.tmp -> mv) and idempotence live inside the Go entry
+#     point; this script inherits both.
+#   * Fail-open on every error mode: exit 0 always (never aborts /moai codemaps).
+#   * Provenance uses git (commit SHA + committer date), never wall-clock
+#     (the governing REQ idempotence).
+#
+# Boundary: writes ONLY .moai/project/codemaps/{capability-symbols.md,json} and
+# appends ONLY to .moai/logs/navigator-astx.log. It NEVER touches 001/002
+# outputs under .moai/project/navigator/ or the 002 audit outputs, or any LSEL
+# surface.
+#
+# Optional env vars:
+#   CLAUDE_PROJECT_DIR  project root (defaults to $PWD).
+#   NAVIGATOR_PRE_RENAME_BARRIER  path; test-only synchronized barrier for the
+#       atomic-rename fixture (mirrors 001's pattern).
+#
+# Exit codes: 0 always (fail-open).
+set -u
+
+ROOT="${CLAUDE_PROJECT_DIR:-$PWD}"
+CAP_MAP="$ROOT/.moai/project/navigator/capability-map.md"
+ASTX_LOG="$ROOT/.moai/logs/navigator-astx.log"
+
+mkdir -p "$(dirname "$ASTX_LOG")" 2>/dev/null || true
+
+# Capability gate (the governing REQ vs the governing REQ).
+if [ ! -f "$CAP_MAP" ]; then
+    printf '%s navigator-astx: capability-map.md absent at %s; skipping AST enrichment\n' \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo '?')" "$CAP_MAP" >> "$ASTX_LOG" 2>/dev/null || true
+    echo "navigator-astx: capability-map.md absent, skipping AST enrichment" >&2
+    exit 0
+fi
+
+# Resolve the moai binary (PATH first, then $HOME/go/bin, then GOPATH/bin).
+MOAI_BIN="$(command -v moai 2>/dev/null || true)"
+if [ -z "$MOAI_BIN" ]; then
+    if [ -x "$HOME/go/bin/moai" ]; then
+        MOAI_BIN="$HOME/go/bin/moai"
+    elif [ -n "${GOPATH:-}" ] && [ -x "$GOPATH/bin/moai" ]; then
+        MOAI_BIN="$GOPATH/bin/moai"
+    else
+        printf '%s navigator-astx: moai binary not found on PATH; skipping AST enrichment\n' \
+            "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo '?')" >> "$ASTX_LOG" 2>/dev/null || true
+        echo "navigator-astx: moai binary not found, skipping AST enrichment" >&2
+        exit 0
+    fi
+fi
+
+# Invoke the Go entry point. It performs the header-driven join, tree-sitter
+# extraction, aggregation, and atomic writes internally. Fail-open: any
+# non-zero exit is logged and swallowed.
+if ! "$MOAI_BIN" navigator-enrich --project-root "$ROOT" 2>>"$ASTX_LOG"; then
+    echo "navigator-astx: enrich entry point reported an error (logged); continuing" >&2
+fi
+
+exit 0

--- a/internal/template/templates/.claude/skills/moai/workflows/codemaps.md
+++ b/internal/template/templates/.claude/skills/moai/workflows/codemaps.md
@@ -122,6 +122,28 @@ If --area flag: Generate only area-specific maps:
 If --format mermaid: Include mermaid diagrams in documentation.
 If --format json: Generate machine-readable JSON alongside markdown.
 
+### Phase 3 extension: AST symbol enrichment (capability-gated)
+
+After generating the existing five map files above, run a deterministic
+capability-gated AST enrichment step. This is executor delegation inside
+Phase 3 (NOT an LLM-driven phase selection):
+
+- IF `.moai/project/navigator/capability-map.md` EXISTS:
+  run `scripts/navigator-enrich.sh`, which emits
+  `.moai/project/codemaps/capability-symbols.md` and
+  `.moai/project/codemaps/capability-symbols.json` (the AST-derived symbol
+  view of the capability map).
+- ELSE: log an info line ("navigator: capability-map.md absent, skipping AST
+  enrichment") and continue — codemaps completes normally.
+
+The enrichment reads 001's capability-map.md header-driven, walks each row's
+implementation-path, and extracts tree-sitter symbols. It is fail-open
+(exit 0 always), idempotent (provenance from git, never wall-clock), and
+writes atomically. The Agentless pipeline classification of /moai codemaps
+is preserved: the step is a deterministic script invocation, not an LLM
+dispatch. See `references/navigator-astx.md` for the per-language grammar
+matrix and extension model.
+
 ## Phase 4: Verification
 
 - Verify all referenced files and modules actually exist


### PR DESCRIPTION
## SPEC-PROJECT-NAVIGATOR-003 — AST-enriched codemaps (Epic Project-Navigator 3/3)

Adds tree-sitter–based symbol extraction to `/moai codemaps`, producing capability-symbol maps (md + json) that enrich SPEC-PROJECT-NAVIGATOR-001's capability-map with per-row implementation-path symbol provenance.

### What
- **New Go package** `internal/navigator/astx/` — sibling to `internal/hook/mx/complexity/` (no import edge). Reuses the existing `smacker/go-tree-sitter` dependency (no new dep). cgo/nocgo build-tag split: nocgo path returns `Supported: false`.
- **16 per-language `.scm` query files** (14 working grammars: go/python/typescript/javascript/rust/java/kotlin/csharp/ruby/php/elixir/cpp/scala/swift; + 2 scaffolded r/flutter returning `Supported: false`). Data-driven extension — adding a query + registration row extends the set with no Go edit (REQ-NT-006).
- **`moai navigator-enrich` CLI + `navigator-enrich.sh`** wrapper — header-driven join to 001's capability-map, atomic `.tmp→mv` writes, idempotent (git-sourced provenance, no wall-clock), fail-open.
- **`/moai codemaps` Phase 3 extension** — capability-gated AST step; Agentless pipeline classification preserved (no LLM dispatch — REQ-NT-020).
- **Template-First mirror** + §25 neutrality (SPEC IDs / REQ tokens stripped from distributed surfaces).

### Milestones
M1 astx package + grammar registration + cgo split · M2 per-language `.scm` queries · M3 row enrichment + header-driven join + output schema · M4 `navigator-enrich.sh` + codemaps Phase 3 · M5 template mirror + neutrality · M6 full suite + MX tags + AC verification.

### Verification (orchestrator trust-but-verify batch)
- 20/20 AC PASS (acceptance.md §D).
- `internal/navigator/astx/` coverage **87.8%** (≥85%).
- `CGO_ENABLED=1 go build ./...` and `CGO_ENABLED=0 go build ./...` both exit 0 (AC-NT-015).
- `golangci-lint run ./...` → 0 issues.
- Boundary greps: AskUserQuestion / 001 / 002 / LSEL non-overlap all clean; template neutrality 0 hits (AC-NT-016/018/019).
- `moai spec lint` → no findings; `agentless_audit_test.go` PASS (AC-NT-020).

### Known non-blocker
`internal/statusline` has one hanging test (`fetchUsageFromOAuthAPI` — blocking Anthropic OAuth call, **issue #646**). Pre-existing, environment/network-dependent flake: this PR's diff does not touch `internal/statusline/`, and the failure reproduces in isolation as a timeout (goroutine stuck in `select`), not an assertion failure. Flagged for CI triage; not a regression from this PR.

🗿 MoAI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AST-based symbol enrichment to `/moai codemaps`.
  * Generates Markdown and JSON capability symbol maps with source locations, language details, and provenance.
  * Supports symbol extraction across 14 programming languages, with graceful handling for unsupported languages.
  * Added a command and workflow integration that automatically enriches available capability maps.

* **Bug Fixes**
  * Enrichment now skips safely when inputs or tooling are unavailable and does not interrupt codemap generation.

* **Documentation**
  * Added setup, output schema, supported-language, and workflow guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->