### PR TITLE
chore(SPEC-PROJECT-NAVIGATOR-003): backfill sync_commit_sha (223442321)

### DIFF
--- a/.moai/specs/SPEC-PROJECT-NAVIGATOR-003/progress.md
+++ b/.moai/specs/SPEC-PROJECT-NAVIGATOR-003/progress.md
@@ -97,7 +97,7 @@ mx_tags_added:
 
 ```yaml
 sync_complete_at: 2026-08-05
-sync_commit_sha: pending-backfill-sync   # self-referential — backfilled in a follow-up per D3
+sync_commit_sha: 223442321   # sync squash commit (PR #1367); backfilled per D3
 sync_status: complete
 changelog_entry_position: top-of-unreleased-added   # SPEC-PROJECT-NAVIGATOR-003 entry in [Unreleased] ### Added
 frontmatter_status_transitions:


### PR DESCRIPTION
Mechanical SHA backfill: replace `pending-backfill-sync` in `progress.md §E.4` with the merged sync squash commit `223442321` (PR #1367). D3 self-referential-hazard exemption — same pattern as 001 #1354 / 002 #1362. 1-file, 1-line change. Completes the SPEC-PROJECT-NAVIGATOR-003 close (drift-detector clean).

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the audit record with the completed synchronization commit reference.
  * Retained the existing completed status and associated metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->