### PR TITLE
docs(site): _index pillar emojis -> icon shortcodes (4 locale)

### DIFF
--- a/docs-site/content/en/_index.md
+++ b/docs-site/content/en/_index.md
@@ -16,11 +16,11 @@ MoAI-ADK (Agentic Development Kit) is a strategic orchestration framework for Cl
 
 ## Three Core Values of MoAI 3.0
 
-- **🪙 Tokenomics** — Reduces inference costs by 60-70% through context dieting and prompt caching. See [Multi-LLM](/multi-llm), [Cost Optimization](/cost-optimization), and [Advanced/Tokenomics Overview](/advanced/tokenomics-overview).
+- **{{< icon flash primary >}} Tokenomics** — Reduces inference costs by 60-70% through context dieting and prompt caching. See [Multi-LLM](/multi-llm), [Cost Optimization](/cost-optimization), and [Advanced/Tokenomics Overview](/advanced/tokenomics-overview).
 
-- **🧠 Agentic Loop Engineering** — An autonomous improvement cycle where loops work on their own and observations accumulate so harness guidance evolves (recursive self-learning). See [Self-Evolving Systems](/advanced/self-evolving), [Autonomous Loops](/advanced/autonomous-loops), and [Decision Memory](/advanced/decision-memory).
+- **{{< icon rotate primary >}} Agentic Loop Engineering** — An autonomous improvement cycle where loops work on their own and observations accumulate so harness guidance evolves (recursive self-learning). See [Self-Evolving Systems](/advanced/self-evolving), [Autonomous Loops](/advanced/autonomous-loops), and [Decision Memory](/advanced/decision-memory).
 
-- **🛡️ Agentic Harness** — Composable execution environment with skills, hooks, and MCP for extensible agent orchestration. See [Core Concepts](/core-concepts), [Workflow Commands](/workflow-commands), and [Agent Guide](/advanced/agent-guide).
+- **{{< icon package primary >}} Agentic Harness** — Composable execution environment with skills, hooks, and MCP for extensible agent orchestration. See [Core Concepts](/core-concepts), [Workflow Commands](/workflow-commands), and [Agent Guide](/advanced/agent-guide).
 
 ## Key Features
 

--- a/docs-site/content/ja/_index.md
+++ b/docs-site/content/ja/_index.md
@@ -14,11 +14,11 @@ MoAI-ADK (Agentic Development Kit) は、Claude Code 用の戦略的オーケス
 
 ## MoAI 3.0の3つのコアバリュー
 
-- **🪙 トークノミクス** — コンテキストダイエットとプロンプトキャッシングで推論コストを60-70%削減します。[マルチ LLM](/multi-llm)、[コスト最適化](/cost-optimization)、[高度な使い方/トークノミクス概要](/advanced/tokenomics-overview)を参照してください。
+- **{{< icon flash primary >}} トークノミクス** — コンテキストダイエットとプロンプトキャッシングで推論コストを60-70%削減します。[マルチ LLM](/multi-llm)、[コスト最適化](/cost-optimization)、[高度な使い方/トークノミクス概要](/advanced/tokenomics-overview)を参照してください。
 
-- **🧠 エージェンティック・ループ・エンジニアリング** — 意思決定メモリと自律エージェントシステムで自律改善ループを実現します。[自己進化システム](/advanced/self-evolving)、[自律ループ](/advanced/autonomous-loops)、[意思決定メモリ](/advanced/decision-memory)を参照してください。
+- **{{< icon rotate primary >}} エージェンティック・ループ・エンジニアリング** — 意思決定メモリと自律エージェントシステムで自律改善ループを実現します。[自己進化システム](/advanced/self-evolving)、[自律ループ](/advanced/autonomous-loops)、[意思決定メモリ](/advanced/decision-memory)を参照してください。
 
-- **🛡️ エージェント型ハーネス** — スキル、フック、MCPで構成可能な実行環境で拡張可能なエージェントオーケストレーションを提供します。[コアコンセプト](/core-concepts)、[ワークフローコマンド](/workflow-commands)、[エージェントガイド](/advanced/agent-guide)を参照してください。
+- **{{< icon package primary >}} エージェント型ハーネス** — スキル、フック、MCPで構成可能な実行環境で拡張可能なエージェントオーケストレーションを提供します。[コアコンセプト](/core-concepts)、[ワークフローコマンド](/workflow-commands)、[エージェントガイド](/advanced/agent-guide)を参照してください。
 
 ## 主な機能
 

--- a/docs-site/content/ko/_index.md
+++ b/docs-site/content/ko/_index.md
@@ -17,11 +17,11 @@ MoAI-ADK(Agentic Development Kit)는 Claude Code를 위한 전략적 오케스�
 
 ## MoAI 3.0의 세 가지 핵심 가치
 
-- **🪙 토크노믹스** — 컨텍스트 다이어트와 프롬프트 캐싱으로 추론 비용을 60-70% 절감합니다. [멀티 LLM](/multi-llm), [비용 최적화](/cost-optimization), [심화 학습/토크노믹스 개요](/advanced/tokenomics-overview)를 참조하세요.
+- **{{< icon flash primary >}} 토크노믹스** — 컨텍스트 다이어트와 프롬프트 캐싱으로 추론 비용을 60-70% 절감합니다. [멀티 LLM](/multi-llm), [비용 최적화](/cost-optimization), [심화 학습/토크노믹스 개요](/advanced/tokenomics-overview)를 참조하세요.
 
-- **🧠 에이전틱 루프 엔지니어링** — 루프가 스스로 일하고, 그렇게 쌓인 관찰이 하네스 지침을 다시 다듬는 자율 개선 사이클입니다(재귀적 자가 학습). [자가 진화 시스템](/advanced/self-evolving), [자율 루프](/advanced/autonomous-loops), [의사 결정 메모리](/advanced/decision-memory)를 참조하세요.
+- **{{< icon rotate primary >}} 에이전틱 루프 엔지니어링** — 루프가 스스로 일하고, 그렇게 쌓인 관찰이 하네스 지침을 다시 다듬는 자율 개선 사이클입니다(재귀적 자가 학습). [자가 진화 시스템](/advanced/self-evolving), [자율 루프](/advanced/autonomous-loops), [의사 결정 메모리](/advanced/decision-memory)를 참조하세요.
 
-- **🛡️ 에이전틱 하네스** — 스킬·후크·MCP를 조합해 실행 환경을 직접 짜고, 에이전트 오케스트레이션을 필요한 만큼 넓힙니다. [핵심 개념](/core-concepts), [워크플로우 명령어](/workflow-commands), [에이전트 가이드](/advanced/agent-guide)를 참조하세요.
+- **{{< icon package primary >}} 에이전틱 하네스** — 스킬·후크·MCP를 조합해 실행 환경을 직접 짜고, 에이전트 오케스트레이션을 필요한 만큼 넓힙니다. [핵심 개념](/core-concepts), [워크플로우 명령어](/workflow-commands), [에이전트 가이드](/advanced/agent-guide)를 참조하세요.
 
 ## 주요 기능
 

--- a/docs-site/content/zh/_index.md
+++ b/docs-site/content/zh/_index.md
@@ -14,11 +14,11 @@ MoAI-ADK (Agentic Development Kit) 是 Claude Code 的战略编排框架。
 
 ## MoAI 3.0 的三大核心价值
 
-- **🪙 代币经济学** — 通过上下文瘦身和提示缓存将推理成本降低60-70%。参见[多 LLM](/multi-llm)、[成本优化](/cost-optimization)和[高级/代币经济学概述](/advanced/tokenomics-overview)。
+- **{{< icon flash primary >}} 代币经济学** — 通过上下文瘦身和提示缓存将推理成本降低60-70%。参见[多 LLM](/multi-llm)、[成本优化](/cost-optimization)和[高级/代币经济学概述](/advanced/tokenomics-overview)。
 
-- **🧠 智能体循环工程** — 通过决策记忆和自主智能体系统实现自主改进循环。参见[自进化系统](/advanced/self-evolving)、[自主循环](/advanced/autonomous-loops)和[决策记忆](/advanced/decision-memory)。
+- **{{< icon rotate primary >}} 智能体循环工程** — 通过决策记忆和自主智能体系统实现自主改进循环。参见[自进化系统](/advanced/self-evolving)、[自主循环](/advanced/autonomous-loops)和[决策记忆](/advanced/decision-memory)。
 
-- **🛡️ 代理型线束** — 通过技能、钩子和 MCP 提供可组合的执行环境，实现可扩展的智能体编排。参见[核心概念](/core-concepts)、[工作流命令](/workflow-commands)和[智能体指南](/advanced/agent-guide)。
+- **{{< icon package primary >}} 代理型线束** — 通过技能、钩子和 MCP 提供可组合的执行环境，实现可扩展的智能体编排。参见[核心概念](/core-concepts)、[工作流命令](/workflow-commands)和[智能体指南](/advanced/agent-guide)。
 
 ## 主要特性
 


### PR DESCRIPTION
## Summary

Audit item 6 (LOW): the 3 brand-pillar emojis on the landing `_index` pages are decorative content emojis that §17.1 (Claude Warm Editorial) says to replace with inline-SVG `{{< icon >}}` shortcodes. Converted across all 4 locales.

**Mapping** (semantic; the available icon set has no coin/shield glyphs):
| emoji | pillar | shortcode | rationale |
|---|---|---|---|
| 🪙 | tokenomics | `flash primary` | efficiency / cost |
| 🧠 | agentic **loop** | `rotate primary` | loop, literal match |
| 🛡️ | agentic **harness** | `package primary` | container / harness |

All three use the `primary` (coral) variant, matching the existing `{{< icon book primary >}}` convention already in `en/_index.md` and the single-accent design system.

Design judgment (the emojis are on-brand); icon choice is reviewable — flash/rotate/package are the closest semantic fits from the available set.

## Verification
- Each `_index.md` had exactly 1 of each emoji (pillar lines only) — global replace was safe (no collateral).
- grep-verified: 0 emoji residuals; 3 new shortcodes per locale (ko/en +2 pre-existing book icons = 5).

Closes audit item 6 from `project_docs_ko_audit_findings` (item 5 page-count parity already resolved).

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the three core-value icons across English, Japanese, Korean, and Chinese documentation pages.
  * Replaced emoji with consistent flash, rotate, and package icons while preserving existing descriptions and links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->