### PR TITLE
docs(SPEC-MOAI-MCP-SERVER-001): backfill sync_commit_sha 93b7adf84

### DIFF
--- a/.moai/specs/SPEC-MOAI-MCP-SERVER-001/progress.md
+++ b/.moai/specs/SPEC-MOAI-MCP-SERVER-001/progress.md
@@ -171,7 +171,7 @@ _Run-phase NOT complete — M1+M2 are the first two of M1–M4; §E.3 stays pend
 
 - sync_status: ready
 - sync_complete_at: 2026-08-06T04:31:33Z
-- sync_commit_sha: _pending-backfill-SPEC-MOAI-MCP-SERVER-001-sync_
+- sync_commit_sha: 93b7adf84 (PR #1378 squash-merge onto main; 3-phase close, merged 2026-08-06 by app/github-actions auto-merge)
 - changelog_entry_position: [Unreleased] / Added (first entry, above SPEC-PROJECT-NAVIGATOR-003)
 - ac_count_at_sync: 24/24 PASS (acceptance.md SSOT)
 - frontmatter_status_transition: spec.md in-progress → completed (2026-08-06)


### PR DESCRIPTION
Post-merge SHA backfill for **PR #1378** (SPEC-MOAI-MCP-SERVER-001, 3-phase close).

## What

Fills the `progress.md §E.4` `sync_commit_sha` placeholder with the squash-merge SHA of #1378.

```diff
-- sync_commit_sha: _pending-backfill-SPEC-MOAI-MCP-SERVER-001-sync_
+- sync_commit_sha: 93b7adf84 (PR #1378 squash-merge onto main; 3-phase close, merged 2026-08-06 by app/github-actions auto-merge)
```

## Why

A sync commit cannot reference its own SHA — the hash is unknown until the commit lands. The established pattern writes a `pending-backfill-*` placeholder in the phase's own commit and backfills the real SHA in a follow-up (SHA-backfill exemption D3, `.claude/rules/moai/development/spec-frontmatter-schema.md`).

#1378 merged at 2026-08-06T04:49:17Z as squash `93b7adf84`; this PR completes the bookkeeping so `moai spec audit` shows 0 drift on this SPEC.

## Scope

1 file, 1 line. No code, no template, no behavior change.

## Verification

- `git grep 93b7adf84` → exactly 1 hit (the §E.4 line)
- `git grep pending-backfill` → 0 hits (placeholder fully retired for this SPEC)

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the synchronization record to reflect the merged commit status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->