### PR TITLE
fix(cli): bound statusline data collection with a render budget

### DIFF
--- a/internal/cli/statusline.go
+++ b/internal/cli/statusline.go
@@ -6,12 +6,18 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/modu-ai/moai-adk/internal/config"
 	"github.com/modu-ai/moai-adk/internal/statusline"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
+
+// statuslineRenderBudget caps the data-collection phase of a statusline render.
+// Claude Code hides the statusline when the command does not return promptly, so
+// slow collectors are cancelled rather than allowed to overrun.
+const statuslineRenderBudget = 800 * time.Millisecond
 
 // StatuslineCmd is the statusline command.
 var StatuslineCmd = &cobra.Command{
@@ -38,7 +44,15 @@ func runStatusline(cmd *cobra.Command, _ []string) error {
 	}
 
 	out := cmd.OutOrStdout()
-	ctx := context.Background()
+
+	// Bound the whole collection pipeline: Claude Code drops the statusline when
+	// the command overruns its render budget, and the usage collector's Anthropic
+	// OAuth call can block for seconds (5s per-attempt timeout plus 2s/4s/8s
+	// retry backoff on 429). Collectors treat a cancelled context as a soft
+	// failure and leave their segment empty, so expiry degrades the statusline
+	// instead of losing it. See issue #646.
+	ctx, cancel := context.WithTimeout(context.Background(), statuslineRenderBudget)
+	defer cancel()
 
 	// Get project root for git and version detection (error ignored: empty root is valid)
 	projectRoot, _ := findProjectRootFn() //nolint:errcheck // empty root is acceptable fallback


### PR DESCRIPTION
## 문제

`moai statusline`이 응답하지 않아 Claude Code statusline이 빈 상태로 표시됐습니다.

- `moai statusline` 직접 실행 시 5초 / 10초 / 15초 전부 타임아웃(exit 124), 출력 0바이트
- 끝나지 않은 `moai statusline` 프로세스가 9개 이상 누적

## 원인

`runStatusline`이 `context.Background()`(타임아웃 없음)를 수집 파이프라인에 넘깁니다. usage collector는 Anthropic OAuth API를 호출하는데, 429 응답 시 시도당 5초 타임아웃 + 2초/4초/8초 백오프 재시도가 붙어 최대 수십 초 블로킹됩니다.

`builder.go`에는 이미 이 문제에 대한 부분 방어가 있습니다 — stdin으로 `rate_limits`가 오면 usage 수집을 건너뜁니다(issue #646). 하지만 `rate_limits`가 없는 경로에서는 여전히 블로킹 호출로 들어갑니다.

## 변경

수집 컨텍스트를 800ms로 제한합니다 (약 3줄 + named const).

만료 시 동작은 이미 graceful합니다:
- 각 collector는 에러를 `slog.Debug`로 남기고 결과를 nil로 둡니다 → 해당 세그먼트만 비어 렌더됨
- `Build`는 에러를 반환하지 않으므로 `renderSimpleFallback()`("moai")로 떨어지지 않습니다

즉 예산 초과는 **statusline 소실**이 아니라 **세그먼트 하나 생략**으로 degrade됩니다.

## 검증

| 항목 | 이전 | 이후 |
|---|---|---|
| `.moai/status_line.sh` 실행 | 15s+ 타임아웃, 출력 없음 | 0.25s, 정상 렌더 (3회 측정: 0.25 / 0.27 / 0.26) |
| 누적 `moai statusline` 프로세스 | 9 | 0 |

```
go build ./...              OK
go vet ./internal/cli/      OK
go test ./internal/cli/... ./internal/statusline/...   all ok
```

Refs #646

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added an 800 ms time limit for statusline updates.
  * Prevented slow data collection from blocking rendering, while preserving fallback behavior when updates cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->