### PR TITLE
docs(goal-html): move 3 v3.1 renderer surfaces from roadmap to live (4-locale)

### DIFF
--- a/docs-site/content/en/cli-reference/goal.md
+++ b/docs-site/content/en/cli-reference/goal.md
@@ -15,7 +15,7 @@ This is the programmatic MoAI counterpart of the native `/goal` (a user-only TUI
 | `moai goal arm "<condition>"` | Register + arm a goal on the active session (`moai goal "<condition>"` is also an arm alias). Arm-only — it starts no work by itself |
 | `moai goal status` | Print the goal status of the active session (use `--all` to list every session) |
 | `moai goal clear` | Clear the goal of the active session |
-| `moai goal render` | Render the active session's goal dashboard as a self-contained HTML file (saved next to `.moai/state/goal/`). Exits non-zero when no goal is armed |
+| `moai goal render` | Render the active session's goal dashboard as a self-contained HTML file (saved next to `.moai/state/goal/`). Exits non-zero when no goal is armed. Starting in v3.1 (PR #1388) the dashboard surfaces the verdict section (loaded from the sidecar at ceiling exit) and the re-arm conditional views — see the [/moai goal dashboard section](/en/utility-commands/moai-goal#goal-dashboard) for detail |
 
 ## Common flags
 

--- a/docs-site/content/en/utility-commands/moai-goal.md
+++ b/docs-site/content/en/utility-commands/moai-goal.md
@@ -47,7 +47,7 @@ Releases the active session's goal (deletes the state file). The Stop hook sees 
 
 ### `/moai goal render` — dashboard HTML render
 
-Renders the active session's goal state as a **self-contained HTML dashboard** to `.moai/state/goal/<session-id>.html`. It is idempotent — re-running overwrites the same path. It can be invoked both as a slash command (`/moai goal render`) and as a terminal CLI (`moai goal render`); both call the same `goal.RenderDashboard`. If no goal is armed, it exits with a non-zero code and prints the session id to stderr without writing any HTML. Adding the `--json` flag emits `{action, session_id, path, bytes}`. See the [Goal Dashboard](#goal-dashboard) section below for what gets rendered and the security properties.
+Renders the active session's goal state as a **self-contained HTML dashboard** to `.moai/state/goal/<session-id>.html`. It is idempotent — re-running overwrites the same path. It can be invoked both as a slash command (`/moai goal render`) and as a terminal CLI (`moai goal render`); both call the same `goal.RenderDashboardReArm`. If no goal is armed, it exits with a non-zero code and prints the session id to stderr without writing any HTML. Adding the `--json` flag emits `{action, session_id, path, bytes}`. See the [Goal Dashboard](#goal-dashboard) section below for what gets rendered and the security properties.
 
 ## Progression modes (autonomous / semi-autonomous)
 
@@ -93,7 +93,7 @@ flowchart TD
     A["/moai goal render<br/>or moai goal render"] --> B["goal.LoadGoal"]
     B --> C{"armed goal exists?"}
     C -- "no" --> D["exit non-zero<br/>stderr: session id<br/>no HTML written"]
-    C -- "yes" --> E["goal.RenderDashboard"]
+    C -- "yes" --> E["goal.RenderDashboardReArm"]
     E --> F["write dashboard HTML file<br/>(overwrite, idempotent)"]
     F --> G["open offline in a browser"]
 ```
@@ -102,12 +102,13 @@ flowchart TD
 **Self-contained HTML**: there are no external resources, so it opens even when the network is down. The goal state at render time is fully serialized inside the file.
 {{< /callout >}}
 
-**What the dashboard shows**: in the v3.1 CLI the verdict argument is always passed as `nil`, so the dashboard renders the following sections together with a "no verdict yet" placeholder.
+**What the dashboard shows**: starting in v3.1 (PR #1388) the renderer is wired into production, so the verdict and re-arm state are actually surfaced on the dashboard.
 
 - **Header** — session id, lifecycle state (`armed` / `satisfied` / `ceiling-exit` / `cleared`), turns used vs. ceiling, progression mode (`autonomous` / `semi-autonomous`), generation timestamp
 - **Condition declaration** — the goal condition text shown verbatim inside a bordered block
 - **Declared Conditions table** — each condition listed in a table. Mechanical conditions are shown as `<command> (expect exit N)`; model-evaluated conditions are shown as the claim text verbatim
-- **Verdict placeholder** — a "no verdict yet" placeholder in the slots for the turn/ceiling line, the failed-conditions table, and the 5-section ceiling verdict (Claim / Evidence / Baseline-attribution / Gaps / Residual-risk)
+- **Verdict section (active at ceiling exit)** — the `stop-goal` evaluator writes the 5-section ceiling verdict (Claim / Evidence / Baseline-attribution / Gaps / Residual-risk) to the sidecar `.moai/state/goal/<sid>.verdict.json` ONLY on the exit turn (turn ceiling / stagnation guard / wall-clock ceiling). `moai goal render` loads this sidecar at render time and fills in the turn/ceiling line, the failed-conditions table, and the 5-section verdict. If you render after a non-exit turn, the "no verdict yet" placeholder is shown (the sidecar is written only on exit).
+- **Re-arm conditional views** — at render time the dashboard auto-constructs three conditional views from the pending/active state: (1) a will-rearm indicator on `/clear`, (2) a "re-armed under a new id" view, (3) a D8 infinite-goal rejection banner. Each view is hidden when its condition does not apply.
 
 **XSS auto-escape**: every untrusted field is rendered via the Go standard library `html/template` `{{.Field}}` syntax and auto-escaped. Even if a `<script>` payload is placed inside the condition text or condition values, it is converted to HTML entities and not executed. Goal conditions can mix shell-command strings and free text, so this auto-escape is a meaningful security property.
 
@@ -115,13 +116,13 @@ flowchart TD
 
 ## Roadmap
 
-{{< icon clock muted >}} These are surfaces whose renderer is ready but which are not yet wired into the v3.1 CLI; they are scheduled for v3.2 wiring. Running `moai goal render` today does not show the three below.
+{{< icon clock muted >}} The renderer is ready but will be wired in a later release.
 
-- {{< icon clock muted >}} **Verdict-section population** — the turn/ceiling line, the failed-conditions table, and the 5-section ceiling verdict (Claim / Evidence / Baseline-attribution / Gaps / Residual-risk). The renderer fills these sections when the evaluator passes a non-nil verdict, but the v3.1 CLI always passes `nil`, so the "no verdict yet" placeholder is shown. This wiring is scheduled to arrive in v3.2 together with a LIVE board where the Stop hook refreshes the dashboard every turn.
-- {{< icon clock muted >}} **Plan HTML report** — a separate renderer, `RenderPlanHTML`, that writes plan-phase artifacts (goal + 8-field autonomy contract + verdict score + milestones) to `.moai/reports/plan-html/<SPEC-ID>-plan.html`. v3.1 ships no CLI wrapper and no production caller, so this path is not populated.
-- {{< icon clock muted >}} **Re-arm UI** — three conditional dashboard views: a re-arm indicator on `/clear`, a "re-armed under a new id" view, and a D8 infinite-goal rejection banner. The renderer exists, but no production caller constructs this context, so the v3.1 CLI passes `nil`.
+- {{< icon clock muted >}} **LIVE dashboard (per-turn auto-refresh)** — today `moai goal render` renders a static snapshot of the moment it is invoked. In a later release the `stop-goal` Stop hook will rewrite the `.html` file at the end of every turn, so refreshing the browser shows progress in real time as a LIVE board.
 
-The re-arm mechanics themselves (session-handoff embed + re-arm on `/clear` + infinite-goal rejection defense) already shipped under a prior SPEC — what is "unwired" in this roadmap is ONLY the surfacing of that mechanics state onto the dashboard UI.
+{{< callout type="info" >}}
+**Re-arm mechanism already shipped**: the re-arm logic itself (session-handoff embed + re-arm on `/clear` + D8 infinite-goal rejection defense) already shipped under SPEC-INFINITE-GOAL-001. What is new in v3.1 (PR #1388) is ONLY the surfacing of that mechanism state onto the dashboard UI.
+{{< /callout >}}
 
 ## Related documents
 

--- a/docs-site/content/en/workflow-commands/moai-plan.md
+++ b/docs-site/content/en/workflow-commands/moai-plan.md
@@ -558,6 +558,31 @@ When MoAI asks via `AskUserQuestion`, 5 principles guide recommendation placemen
 **Internals**: the 5 principles are specified in `.claude/rules/moai/core/askuser-protocol.md` § Recommendation Placement Principles, and rendered in `moai.md`. The capture hook is implemented in `internal/hook/user_decision_capture.go` and supports schema-tolerant parsing and domain classification. The decay policy follows the power-law function `(age+1)^(-0.5)` with α=0.5 fixed (Standard tier). For the full architecture and acceptance criteria, see the project's SPEC documents.
 {{< /callout >}}
 
+## Plan HTML report (v3.1+)
+
+Starting in v3.1 (PR #1388), the terminal CLI `moai plan` gains a `render-html` subcommand. It produces a single plan-phase HTML report from already-authored SPEC artifacts and writes it to `.moai/reports/plan-html/<SPEC-ID>-plan.html`.
+
+```bash
+moai plan render-html SPEC-AUTH-001
+# → .moai/reports/plan-html/SPEC-AUTH-001-plan.html
+```
+
+**Input and output**:
+
+- **Input** — the `.moai/specs/<SPEC-ID>/` directory and, if present, the most recent plan-audit review file (`.moai/reports/plan-audit/<SPEC-ID>-review-<N>.md`).
+- **Output** — a single self-contained HTML file with no external JS/CSS dependencies. The goal declaration, the 8-field autonomy contract, (when a review exists) the audit verdict score, and the milestones are packed into one file that opens in an offline browser.
+
+**Failure modes**:
+
+- If the SPEC directory is missing, it exits non-zero with the SPEC-ID on stderr and writes no HTML.
+- If the plan-audit review file is missing or unparseable, it renders with an "audit verdict unavailable" placeholder and **exits 0** (fail-open).
+
+{{< callout type="info" >}}
+**Distinct from the `/moai plan` slash command**: the `/moai plan` slash command routes through the Claude Code skill system to author SPEC artifacts, while the `moai plan render-html` CLI is a Go binary subcommand that emits an HTML report from already-authored artifacts.
+{{< /callout >}}
+
+Pass `--json` to emit `{action, spec_id, path, bytes}` JSON.
+
 ## Related documents
 
 - [SPEC-Based Development](/en/core-concepts/spec-based-dev) - detailed EARS format explanation

--- a/docs-site/content/ja/cli-reference/goal.md
+++ b/docs-site/content/ja/cli-reference/goal.md
@@ -15,7 +15,7 @@ draft: false
 | `moai goal arm "<condition>"` | アクティブセッションにゴールを登録 + arm (`moai goal "<condition>"` も arm のエイリアス)。arm 専用 — これ自体は作業を開始しない |
 | `moai goal status` | アクティブセッションのゴール状態を出力 (`--all` で全セッションを一覧) |
 | `moai goal clear` | アクティブセッションのゴールを解除 |
-| `moai goal render` | アクティブセッションのゴールダッシュボードを self-contained HTML ファイルにレンダリング (`.moai/state/goal/` 配下に保存)。arm された goal がない場合は非 0 の終了コードで終了 |
+| `moai goal render` | アクティブセッションのゴールダッシュボードを self-contained HTML ファイルにレンダリング (`.moai/state/goal/` 配下に保存)。arm された goal がない場合は非 0 の終了コードで終了。v3.1(PR #1388)からダッシュボードに判定セクション (天井 exit 時にサイドカーからロード) と再武装条件付きビューが表示されます — 詳細は [/moai goal ダッシュボードセクション](/ja/utility-commands/moai-goal#ゴールダッシュボード) を参照 |
 
 ## 共通フラグ
 

--- a/docs-site/content/ja/utility-commands/moai-goal.md
+++ b/docs-site/content/ja/utility-commands/moai-goal.md
@@ -47,7 +47,7 @@ draft: false
 
 ### `/moai goal render` — ダッシュボードHTMLレンダ
 
-アクティブセッションのgoal状態を **自己完結型HTMLダッシュボード** としてレンダリングし、`.moai/state/goal/<session-id>.html`に書き出します。冪等(idempotent)なので再実行すると同じパスを上書きします。スラッシュコマンド(`/moai goal render`)とターミナルCLI(`moai goal render`)の両方から呼び出せ、どちらも同じ `goal.RenderDashboard` を呼び出します。armされたgoalがない場合は、非ゼロ終了コードとともにセッションidをstderrに出力し、HTMLは書き出しません。`--json` フラグを付けると `{action, session_id, path, bytes}` を出力します。レンダリングされる内容とセキュリティ属性は下の [ゴールダッシュボード](#ゴールダッシュボード) セクションを参照してください。
+アクティブセッションのgoal状態を **自己完結型HTMLダッシュボード** としてレンダリングし、`.moai/state/goal/<session-id>.html`に書き出します。冪等(idempotent)なので再実行すると同じパスを上書きします。スラッシュコマンド(`/moai goal render`)とターミナルCLI(`moai goal render`)の両方から呼び出せ、どちらも同じ `goal.RenderDashboardReArm` を呼び出します。armされたgoalがない場合は、非ゼロ終了コードとともにセッションidをstderrに出力し、HTMLは書き出しません。`--json` フラグを付けると `{action, session_id, path, bytes}` を出力します。レンダリングされる内容とセキュリティ属性は下の [ゴールダッシュボード](#ゴールダッシュボード) セクションを参照してください。
 
 ## 進行モード (自律 / 半自律)
 
@@ -93,7 +93,7 @@ flowchart TD
     A["/moai goal render<br/>または moai goal render"] --> B["goal.LoadGoal"]
     B --> C{"armされたgoalがあるか?"}
     C -- "いいえ" --> D["exit non-zero<br/>stderr: セッション id<br/>HTML未作成"]
-    C -- "はい" --> E["goal.RenderDashboard"]
+    C -- "はい" --> E["goal.RenderDashboardReArm"]
     E --> F["ダッシュボードHTMLファイル書き込み<br/>(上書き、冪等)"]
     F --> G["ブラウザでオフライン表示"]
 ```
@@ -102,12 +102,13 @@ flowchart TD
 **自己完結型HTML**: 外部リソースがないためネットワークが切れても開けます。レンダリング時点のgoal状態がファイル内に完全に直列化されます。
 {{< /callout >}}
 
-**ダッシュボードに表示される内容**: v3.1 CLIでは評価器(verdict)引数が常に `nil` で渡されるため、ダッシュボードは「まだ判定なし」プレースホルダとともに以下の項目をレンダリングします。
+**ダッシュボードに表示される内容**: v3.1(PR #1388)からレンダラがプロダクションに接続され、判定・再武装状態が実際にダッシュボードに表示されます。
 
 - **ヘッダ** — セッションid、ライフサイクル状態 (`armed` / `satisfied` / `ceiling-exit` / `cleared`)、ターン使用量/上限、進行モード (`autonomous` / `semi-autonomous`)、生成タイムスタンプ
 - **条件宣言部** — goal条件テキストを枠線ブロック内にそのまま表示
 - **宣言された条件表 (Declared Conditions)** — 各conditionを表で並べます。機械的条件は `<コマンド> (expect exit N)` 形式で、モデル評価条件は主張(claim)テキストをそのまま表示
-- **判定プレースホルダ** — turn/上限行、失敗した条件表、5-セクション天井判定 (Claim / Evidence / Baseline-attribution / Gaps / Residual-risk) が入る枠に「まだ判定なし」を表示
+- **判定セクション (天井 exit 時に有効化)** — `stop-goal` 評価器は、ターン上限・停滞ガード・壁時計上限に達する exit ターンに限り、サイドカー `.moai/state/goal/<sid>.verdict.json` に5-セクション天井判定 (Claim / Evidence / Baseline-attribution / Gaps / Residual-risk) を書き出します。`moai goal render` はレンダリング時点でこのサイドカーを読み込み、ターン/上限行・失敗した条件表・5-セクション判定をすべて埋めます。判定サイドカーが存在しない通常ターンの後にレンダリングすると「まだ判定なし」プレースホルダが表示されます (サイドカーは exit ターンにしか書かれないため)。
+- **再武装 (re-arm) 条件付きビュー** — レンダー時点の保留/アクティブ状態から3つの条件付きビューを自動で構成して表示します: (1) `/clear` 時に保留中のgoalが再武装されることを示す表示、(2) 新しいidで再武装されたことの表示、(3) D8 無限goal拒否バナー。該当しないビューは非表示になります。
 
 **XSS自動エスケープ**: 信頼できないすべてのフィールドはGo標準ライブラリ `html/template` の `{{.Field}}` 構文でレンダリングされ、自動エスケープされます。条件テキストや条件値に `<script>` ペイロードが入ってもHTMLエンティティに変換され実行されません。goal条件にはシェルコマンド文字列と自由テキストが混ざり得るため、この自動エスケープは意味のあるセキュリティ属性です。
 
@@ -115,13 +116,13 @@ flowchart TD
 
 ## ロードマップ
 
-{{< icon clock muted >}} レンダラは準備済みだがv3.1 CLIでは未接続、v3.2での接続が予定されているサーフェスです。今 `moai goal render` を実行しても以下の3つは表示されません。
+{{< icon clock muted >}} レンダラは準備済みだが、後続リリースで接続されるサーフェスです。
 
-- {{< icon clock muted >}} **判定セクションの有効化** — turn/上限行、失敗した条件表、5-セクション天井判定 (Claim / Evidence / Baseline-attribution / Gaps / Residual-risk)。レンダラは評価器がnon-nil verdictを渡せばこれらのセクションを埋めますが、v3.1 CLIは常に `nil` を渡すため「まだ判定なし」プレースホルダが表示されます。この接続はv3.2で毎ターンのStopフックがダッシュボードを自動更新するLIVEボードとともに導入予定です。
-- {{< icon clock muted >}} **計画HTMLレポート** — plan-phase産出物 (goal + 8-フィールド自律性契約 + 判定スコア + マイルストン) を `.moai/reports/plan-html/<SPEC-ID>-plan.html` に書き出す別のレンダラ `RenderPlanHTML` です。v3.1にはCLIラッパーとプロダクション呼び出し元がないため、このパスは埋まりません。
-- {{< icon clock muted >}} **再武装 (re-arm) UI** — `/clear` 時の再武装表示、新しいidで再武装されたことの表示、D8無限goal拒否バナーの3つの条件付きダッシュボードビューです。レンダラは存在しますがプロダクションでこのコンテキストを構成する呼び出し元がないため、v3.1 CLIは `nil` を渡します。
+- {{< icon clock muted >}} **LIVEダッシュボード (毎ターン自動更新)** — 現在は `moai goal render` を呼び出した時点の静的スナップショットをレンダリングします。後続リリースでは `stop-goal` Stopフックが毎ターン終了時に `.html` ファイルを自動的に再書き込みし、ブラウザをリロードすれば進行状況がリアルタイムで見えるLIVEボードになる予定です。
 
-再武装メカニズム自体 (セッションハンドオフ埋め込み + `/clear` 時の再武装 + 無限goal拒否防御) は以前のSPECで既に出荷されています — このロードマップで「未接続」なのは、そのメカニズム状態をダッシュボードUIに **表面化** する部分のみです。
+{{< callout type="info" >}}
+**再武装メカニズムは既に出荷済み**: 再武装ロジック自体 (セッションハンドオフ埋め込み + `/clear` 時の再武装 + D8 無限goal拒否防御) は以前の SPEC-INFINITE-GOAL-001 で既に出荷されています。v3.1(PR #1388)で新しく入ったのは、そのメカニズム状態をダッシュボードUIに **表面化** する部分のみです。
+{{< /callout >}}
 
 ## 関連ドキュメント
 

--- a/docs-site/content/ja/workflow-commands/moai-plan.md
+++ b/docs-site/content/ja/workflow-commands/moai-plan.md
@@ -559,6 +559,31 @@ MoAI が `AskUserQuestion` で質問するとき、推奨配置を案内する 5
 **内部動作**: 5 つの原則は `.claude/rules/moai/core/askuser-protocol.md` § Recommendation Placement Principles に明細化されており、`moai.md` にレンダリングされます。キャプチャフックは `internal/hook/user_decision_capture.go` に実装されており schema 許容パースとドメイン分類をサポートします。減衰ポリシーは power-law 関数 `(age+1)^(-0.5)` に従い α=0.5 固定 (Standard tier)。全体のアーキテクチャと受け入れ基準はプロジェクトの SPEC ドキュメントを参照してください。
 {{< /callout >}}
 
+## 計画HTMLレポート (v3.1+)
+
+v3.1(PR #1388)から、ターミナルCLI `moai plan` に `render-html` サブコマンドが追加されました。既に作成済みのSPEC産出物からplan-phase HTMLレポートを1つ生成し、`.moai/reports/plan-html/<SPEC-ID>-plan.html` に書き出します。
+
+```bash
+moai plan render-html SPEC-AUTH-001
+# → .moai/reports/plan-html/SPEC-AUTH-001-plan.html
+```
+
+**入力と出力**:
+
+- **入力** — `.moai/specs/<SPEC-ID>/` ディレクトリと、存在すれば最新のplan-auditレビューファイル (`.moai/reports/plan-audit/<SPEC-ID>-review-<N>.md`)。
+- **出力** — 外部JS・CSSに依存しない自己完結型HTMLファイル1つ。goal宣言部・8-フィールド自律性契約・(レビューがあれば)監査判定スコア・マイルストンを1ファイルにまとめ、オフラインのブラウザでそのまま開けます。
+
+**失敗モード**:
+
+- SPECディレクトリが存在しない場合、0以外の終了コードとともにstderrにSPEC-IDを出力し、HTMLは書き出しません。
+- plan-auditレビューファイルが存在しない・パースできない場合、「監査判定を利用できません」プレースホルダを入れて **exit 0** でレンダリングします (fail-open)。
+
+{{< callout type="info" >}}
+**`/moai plan` スラッシュコマンドとは別物です**: `/moai plan` スラッシュコマンドがClaude Codeスキルシステムを経由してSPEC産出物を作成するのに対し、`moai plan render-html` CLIは既に作成済みの産出物からHTMLレポートを抽出するGoバイナリのサブコマンドです。
+{{< /callout >}}
+
+`--json` フラグを付けると `{action, spec_id, path, bytes}` JSONを出力します。
+
 ## 関連ドキュメント
 
 - [SPEC ベース開発](/core-concepts/spec-based-dev) - EARS 形式の詳細説明

--- a/docs-site/content/ko/cli-reference/goal.md
+++ b/docs-site/content/ko/cli-reference/goal.md
@@ -15,7 +15,7 @@ draft: false
 | `moai goal arm "<condition>"` | 활성 세션에 목표 등록 + arm (`moai goal "<condition>"` 도 arm 별칭). arm-only — 그 자체로는 작업을 시작하지 않는다 |
 | `moai goal status` | 활성 세션의 목표 상태 출력 (`--all` 로 전 세션 나열) |
 | `moai goal clear` | 활성 세션의 목표 해제 |
-| `moai goal render` | 활성 세션의 목표 대시보드를 self-contained HTML 파일로 렌더 (`.moai/state/goal/` 옆에 저장). arm 된 goal이 없으면 0이 아닌 종료 코드로 끝남 |
+| `moai goal render` | 활성 세션의 목표 대시보드를 self-contained HTML 파일로 렌더 (`.moai/state/goal/` 옆에 저장). arm 된 goal이 없으면 0이 아닌 종료 코드로 끝남. v3.1(PR #1388)부터 판정 섹션(천장 exit 시 사이드카에서 로드)과 재무장 조건부 보기가 대시보드에 표시됩니다 — 자세한 내용은 [/moai goal 대시보드 섹션](/utility-commands/moai-goal#목표-대시보드)을 참고하세요 |
 
 ## 공통 플래그
 

--- a/docs-site/content/ko/utility-commands/moai-goal.md
+++ b/docs-site/content/ko/utility-commands/moai-goal.md
@@ -47,7 +47,7 @@ draft: false
 
 ### `/moai goal render` — 대시보드 HTML 렌더
 
-활성 세션의 goal 상태를 **자체 완결형 HTML 대시보드**로 렌더해 `.moai/state/goal/<session-id>.html`에 씁니다. 멱등(idempotent)이라 다시 실행하면 같은 경로를 덮어씁니다. 슬래시 커맨드(`/moai goal render`)와 터미널 CLI(`moai goal render`) 양쪽으로 모두 호출할 수 있고, 둘 다 같은 `goal.RenderDashboard`를 호출합니다. arm된 goal이 없으면 0이 아닌 종료 코드와 함께 세션 id를 stderr로 출력하고 HTML을 쓰지 않습니다. `--json` 플래그를 붙이면 `{action, session_id, path, bytes}`를 내보냅니다. 렌더링되는 내용과 보안 속성은 아래 [목표 대시보드](#목표-대시보드) 섹션을 참고하세요.
+활성 세션의 goal 상태를 **자체 완결형 HTML 대시보드**로 렌더해 `.moai/state/goal/<session-id>.html`에 씁니다. 멱등(idempotent)이라 다시 실행하면 같은 경로를 덮어씁니다. 슬래시 커맨드(`/moai goal render`)와 터미널 CLI(`moai goal render`) 양쪽으로 모두 호출할 수 있고, 둘 다 같은 `goal.RenderDashboardReArm`를 호출합니다. arm된 goal이 없으면 0이 아닌 종료 코드와 함께 세션 id를 stderr로 출력하고 HTML을 쓰지 않습니다. `--json` 플래그를 붙이면 `{action, session_id, path, bytes}`를 내보냅니다. 렌더링되는 내용과 보안 속성은 아래 [목표 대시보드](#목표-대시보드) 섹션을 참고하세요.
 
 ## 진행 모드 (자율 / 반자율)
 
@@ -93,7 +93,7 @@ flowchart TD
     A["/moai goal render<br/>또는 moai goal render"] --> B["goal.LoadGoal"]
     B --> C{"arm된 goal이 있는가?"}
     C -- "아니오" --> D["exit non-zero<br/>stderr: 세션 id<br/>HTML 미작성"]
-    C -- "예" --> E["goal.RenderDashboard"]
+    C -- "예" --> E["goal.RenderDashboardReArm"]
     E --> F["대시보드 HTML 파일 기록<br/>(덮어쓰기, 멱등)"]
     F --> G["브라우저로 오프라인 열기"]
 ```
@@ -102,12 +102,13 @@ flowchart TD
 **자체 완결형 HTML**: 외부 리소스가 없어 네트워크가 끊겨도 열립니다. 렌더 시점의 goal 상태가 파일 안에 완전히 직렬화됩니다.
 {{< /callout >}}
 
-**대시보드에 표시되는 내용**: v3.1 CLI에서 평가기(verdict) 인자는 항상 `nil`로 전달되므로, 대시보드는 "아직 판정 없음" 자리표시자와 함께 다음 항목들을 렌더합니다.
+**대시보드에 표시되는 내용**: v3.1(PR #1388)부터 렌더러가 프로덕션에 연결되어, 판정·재무장 상태가 실제 대시보드에 표시됩니다.
 
 - **머리글** — 세션 id, 라이프사이클 상태 (`armed` / `satisfied` / `ceiling-exit` / `cleared`), 턴 사용량/상한, 진행 모드 (`autonomous` / `semi-autonomous`), 생성 타임스탬프
 - **조건 선언부** — goal 조건 텍스트를 테두리 블록 안에 그대로 표시
 - **선언된 조건 표 (Declared Conditions)** — 각 condition을 표로 나열. 기계적 조건은 `<명령어> (expect exit N)` 형태로, 모델 평가 조건은 주장(claim) 텍스트 그대로 표시
-- **판정 자리표시자** — turn/상한 줄, 실패한 조건 표, 5-섹션 천장 판정 (Claim / Evidence / Baseline-attribution / Gaps / Residual-risk)이 들어갈 자리에 "아직 판정 없음" 표시
+- **판정 섹션 (천장 exit 시 활성화)** — `stop-goal` 평가기가 턴 상한·정체 가드·벽시계 상한에 닿는 exit 턴에 한해 사이드카 `.moai/state/goal/<sid>.verdict.json` 에 5-섹션 천장 판정 (Claim / Evidence / Baseline-attribution / Gaps / Residual-risk) 을 기록합니다. `moai goal render`는 렌더 시점에 이 사이드카를 불러와 턴/상한 줄, 실패한 조건 표, 5-섹션 판정을 모두 채워 넣습니다. 판정 사이드카가 없는 일반 턴 다음에 렌더하면 "아직 판정 없음" 자리표시자가 표시됩니다 (사이드카는 exit 턴에만 기록되므로).
+- **재무장 (re-arm) 조건부 보기** — 렌더 시점의 보류/활성 상태에서 세 가지 조건부 보기를 자동으로 구성해 표시합니다: (1) `/clear` 시 보류 중인 goal이 재무장될 것이라는 표시, (2) 새 id로 재무장됨 보기, (3) D8 무한 goal 거절 배너. 조건이 해당하지 않으면 각 보기는 숨겨집니다.
 
 **XSS 자동 이스케이프**: 모든 신뢰할 수 없는 필드는 Go 표준 라이브러리 `html/template`의 `{{.Field}}` 문법으로 렌더되어 자동 이스케이프됩니다. 조건 텍스트나 조건 값에 `<script>` 페이로드가 들어가도 HTML 엔티티로 변환되어 실행되지 않습니다. goal 조건에는 셸 명령 문자열과 자유 텍스트가 섞여 들어갈 수 있으므로, 이 자동 이스케이프는 의미 있는 보안 속성입니다.
 
@@ -115,13 +116,13 @@ flowchart TD
 
 ## 로드맵
 
-{{< icon clock muted >}} 렌더러는 준비됐지만 v3.1 CLI에서는 아직 연결되지 않은, v3.2 연결이 예정된 표면들입니다. 지금 `moai goal render`를 실행해도 아래 세 가지는 보이지 않습니다.
+{{< icon clock muted >}} 렌더러는 준비됐지만 후속 릴리즈에서 연결될 표면입니다.
 
-- {{< icon clock muted >}} **판정 섹션 활성화** — 턴/상한 줄, 실패한 조건 표, 5-섹션 천장 판정 (Claim / Evidence / Baseline-attribution / Gaps / Residual-risk). 렌더러는 평가기가 non-nil verdict를 넘기면 이 섹션들을 채우지만, v3.1 CLI는 항상 `nil`을 넘기므로 "아직 판정 없음" 자리표시자가 보입니다. 이 연결은 v3.2의 턴마다 Stop 훅이 대시보드를 자동 갱신하는 LIVE 보드와 함께 들어올 예정입니다.
-- {{< icon clock muted >}} **계획 HTML 리포트** — plan-phase 산출물 (goal + 8-필드 자율성 계약 + 판정 점수 + 마일스톤)을 `.moai/reports/plan-html/<SPEC-ID>-plan.html`에 쓰는 별도의 렌더러 `RenderPlanHTML`입니다. v3.1에는 CLI 래퍼와 프로덕션 호출자가 없어 이 경로가 채워지지 않습니다.
-- {{< icon clock muted >}} **재무장 (re-arm) UI** — `/clear` 시 재무장 표시, 새 id로 재무장됨 보기, D8 무한 goal 거절 배너 등 세 가지 조건부 대시보드 보기입니다. 렌더러는 있지만 프로덕션에서 이 컨텍스트를 구성하는 호출자가 없어 v3.1 CLI는 `nil`을 넘깁니다.
+- {{< icon clock muted >}} **LIVE 대시보드 (턴마다 자동 갱신)** — 현재는 `moai goal render`를 호출한 시점의 정적 스냅샷을 렌더합니다. 후속 릴리즈에서는 `stop-goal` Stop 훅이 매 턴을 마칠 때마다 `.html` 파일을 자동으로 다시 써서, 브라우저를 새로고침하면 진행 상황이 실시간으로 보이는 LIVE 보드로 바뀔 예정입니다.
 
-재무장 메커니즘 자체 (세션 핸드오프 임베드 + `/clear` 시 재무장 + 무한 goal 거절 방어)는 앞선 SPEC에서 이미 출하됐습니다 — 이 로드맵에서 "미연결"인 것은 그 메커니즘 상태를 대시보드 UI에 **표면화**하는 부분만 해당합니다.
+{{< callout type="info" >}}
+**재무장 메커니즘은 이미 출하됨**: 재무장 로직 자체(세션 핸드오프 임베드 + `/clear` 시 재무장 + D8 무한 goal 거절 방어)는 앞선 SPEC-INFINITE-GOAL-001에서 이미 출하됐습니다. v3.1(PR #1388)에서 새로 들어온 것은 그 메커니즘 상태를 대시보드 UI에 **표면화**하는 부분만 해당합니다.
+{{< /callout >}}
 
 ## 관련 문서
 

--- a/docs-site/content/ko/workflow-commands/moai-plan.md
+++ b/docs-site/content/ko/workflow-commands/moai-plan.md
@@ -560,6 +560,31 @@ MoAI가 `AskUserQuestion`으로 물을 때는 추천을 어디에 놓을지 정�
 **내부 동작**: 다섯 가지 원칙의 명세는 `.claude/rules/moai/core/askuser-protocol.md` § Recommendation Placement Principles에 있고, `moai.md`로 렌더링됩니다. 캡처 훅은 `internal/hook/user_decision_capture.go`에 있으며 schema 허용 파싱과 도메인 분류를 지원합니다. 감쇠 정책은 power-law 함수 `(age+1)^(-0.5)`를 따르고 α는 0.5로 고정입니다(Standard tier). 전체 아키텍처와 수용 기준은 프로젝트의 SPEC 문서를 참조하세요.
 {{< /callout >}}
 
+## 계획 HTML 리포트 (v3.1+)
+
+v3.1(PR #1388)부터 터미널 CLI `moai plan`에 `render-html` 하위 명령어가 추가됐습니다. 이 CLI는 이미 작성된 SPEC 산출물에서 plan-phase HTML 리포트 하나를 만들어 `.moai/reports/plan-html/<SPEC-ID>-plan.html` 에 씁니다.
+
+```bash
+moai plan render-html SPEC-AUTH-001
+# → .moai/reports/plan-html/SPEC-AUTH-001-plan.html
+```
+
+**입력과 출력**:
+
+- **입력** — `.moai/specs/<SPEC-ID>/` 디렉터리와, 있다면 가장 최근의 plan-audit 리뷰 파일(`.moai/reports/plan-audit/<SPEC-ID>-review-<N>.md`).
+- **출력** — 외부 JS·CSS에 의존하지 않는 자체 완결형 HTML 하나. goal 선언부·8-필드 자율성 계약·(리뷰가 있으면) 감사 판정 점수·마일스톤을 한 파일에 정리해 오프라인 브라우저로 바로 열립니다.
+
+**실패 모드**:
+
+- SPEC 디렉터리가 없으면 0이 아닌 종료 코드와 함께 stderr에 SPEC-ID를 출력하고 HTML을 쓰지 않습니다.
+- plan-audit 리뷰 파일이 없거나 파싱할 수 없으면 "감사 판정을 사용할 수 없음" 자리표시자를 넣고 **exit 0**으로 렌드합니다 (fail-open).
+
+{{< callout type="info" >}}
+**`/moai plan` 슬래시 커맨드와 다릅니다**: `/moai plan` 슬래시 커맨드가 Claude Code 스킬 시스템을 거쳐 SPEC 산출물을 저작한다면, `moai plan render-html` CLI는 이미 저작된 산출물에서 HTML 리포트를 뽑아내는 Go 바이너리 하위 명령어입니다.
+{{< /callout >}}
+
+`--json` 플래그를 붙이면 `{action, spec_id, path, bytes}` JSON을 내보냅니다.
+
 ## 관련 문서
 
 - [SPEC 기반 개발](/core-concepts/spec-based-dev) - EARS 형식 상세 설명

--- a/docs-site/content/zh/cli-reference/goal.md
+++ b/docs-site/content/zh/cli-reference/goal.md
@@ -15,7 +15,7 @@ draft: false
 | `moai goal arm "<condition>"` | 向活动会话注册 + arm 目标(`moai goal "<condition>"` 也是 arm 的别名)。arm-only —— 其自身不会启动任何工作 |
 | `moai goal status` | 输出活动会话的目标状态(用 `--all` 列出所有会话) |
 | `moai goal clear` | 解除活动会话的目标 |
-| `moai goal render` | 将活动会话的目标仪表盘渲染为 self-contained HTML 文件(保存到 `.moai/state/goal/` 旁)。如果没有已 arm 的 goal,以非零退出码结束 |
+| `moai goal render` | 将活动会话的目标仪表盘渲染为 self-contained HTML 文件(保存到 `.moai/state/goal/` 旁)。如果没有已 arm 的 goal,以非零退出码结束。从 v3.1(PR #1388)起,仪表盘会显示判定段(天花板 exit 时从 sidecar 加载)和重新武装条件视图 — 详情参见 [/moai goal 仪表盘章节](/zh/utility-commands/moai-goal#目标看板) |
 
 ## 公共标志
 

--- a/docs-site/content/zh/utility-commands/moai-goal.md
+++ b/docs-site/content/zh/utility-commands/moai-goal.md
@@ -47,7 +47,7 @@ draft: false
 
 ### `/moai goal render` — 仪表板 HTML 渲染
 
-将活跃会话的 goal 状态渲染为 **自包含 HTML 仪表板**,写入 `.moai/state/goal/<session-id>.html`。它是幂等的(idempotent),重复执行会覆盖同一路径。可通过斜杠命令(`/moai goal render`)和终端 CLI(`moai goal render`)两种方式调用,两者都调用相同的 `goal.RenderDashboard`。若没有 arm 的 goal,则以非零退出码将 session id 输出到 stderr,且不写入 HTML。加 `--json` 标志会输出 `{action, session_id, path, bytes}`。关于渲染内容和安全属性,请参见下方 [目标看板](#目标看板) 章节。
+将活跃会话的 goal 状态渲染为 **自包含 HTML 仪表板**,写入 `.moai/state/goal/<session-id>.html`。它是幂等的(idempotent),重复执行会覆盖同一路径。可通过斜杠命令(`/moai goal render`)和终端 CLI(`moai goal render`)两种方式调用,两者都调用相同的 `goal.RenderDashboardReArm`。若没有 arm 的 goal,则以非零退出码将 session id 输出到 stderr,且不写入 HTML。加 `--json` 标志会输出 `{action, session_id, path, bytes}`。关于渲染内容和安全属性,请参见下方 [目标看板](#目标看板) 章节。
 
 ## 进行模式(自主 / 半自主)
 
@@ -93,7 +93,7 @@ flowchart TD
     A["/moai goal render<br/>或 moai goal render"] --> B["goal.LoadGoal"]
     B --> C{"存在 arm 的 goal?"}
     C -- "否" --> D["exit non-zero<br/>stderr: session id<br/>不写入 HTML"]
-    C -- "是" --> E["goal.RenderDashboard"]
+    C -- "是" --> E["goal.RenderDashboardReArm"]
     E --> F["写入仪表板 HTML 文件<br/>(覆盖,幂等)"]
     F --> G["浏览器离线打开"]
 ```
@@ -102,12 +102,13 @@ flowchart TD
 **自包含 HTML**:无外部资源,即使断网也能打开。渲染时刻的 goal 状态被完整序列化进文件。
 {{< /callout >}}
 
-**仪表板显示的内容**:由于 v3.1 CLI 始终向评估器(verdict)传入 `nil` 参数,仪表板在显示"尚无判定"占位符的同时渲染以下内容。
+**仪表板显示的内容**:从 v3.1(PR #1388)起,渲染器已接入生产,判定与重新武装状态会真正显示在仪表板上。
 
 - **页眉** — 会话 id、生命周期状态(`armed` / `satisfied` / `ceiling-exit` / `cleared`)、回合用量/上限、进行模式(`autonomous` / `semi-autonomous`)、生成时间戳
 - **条件声明部** — goal 条件文本原样显示在有边框的块中
 - **已声明条件表** (Declared Conditions) — 各 condition 以表格列出。机械条件以 `<命令> (expect exit N)` 形式显示;模型评估条件以主张(claim)文本原样显示
-- **判定占位符** — 在回合/上限行、失败条件表、5 段上限判定(Claim / Evidence / Baseline-attribution / Gaps / Residual-risk)所在位置显示"尚无判定"
+- **判定段(天花板 exit 时激活)** — `stop-goal` 评估器仅在到达回合上限/停滞守卫/壁钟上限的 exit 回合向 sidecar `.moai/state/goal/<sid>.verdict.json` 写入 5 段上限判定(Claim / Evidence / Baseline-attribution / Gaps / Residual-risk)。`moai goal render` 在渲染时读取该 sidecar,填入回合/上限行、失败条件表和 5 段判定。若在非 exit 回合之后渲染,则显示"尚无判定"占位符(sidecar 只在 exit 回合写入)。
+- **重新武装 (re-arm) 条件视图** — 渲染时从待办/活动状态自动构造三个条件视图:(1) `/clear` 时将重新武装待办 goal 的指示、(2) 以新 id 重新武装的视图、(3) D8 无限 goal 拒绝横幅。条件不成立时各视图隐藏。
 
 **XSS 自动转义**:所有不可信字段通过 Go 标准库 `html/template` 的 `{{.Field}}` 语法渲染,自动进行 HTML 转义。即便条件文本或条件值中嵌入 `<script>` 载荷,也会被转换为 HTML 实体而不执行。goal 条件中可能混入 shell 命令字符串与自由文本,因此此自动转义是有意义的安全属性。
 
@@ -115,13 +116,13 @@ flowchart TD
 
 ## 路线图
 
-{{< icon clock muted >}} 渲染器已就绪,但在 v3.1 CLI 中尚未连接,计划于 v3.2 连接的表面。现在运行 `moai goal render` 看不到以下三项。
+{{< icon clock muted >}} 渲染器已就绪,但将在后续版本接入。
 
-- {{< icon clock muted >}} **判定段激活** — 回合/上限行、失败条件表、5 段上限判定(Claim / Evidence / Baseline-attribution / Gaps / Residual-risk)。当评估器传入 non-nil verdict 时,渲染器会填充这些段;但 v3.1 CLI 始终传入 `nil`,因此显示"尚无判定"占位符。该连接计划与 v3.2 中 Stop 钩子每回合自动更新仪表板的 LIVE 看板一同落地。
-- {{< icon clock muted >}} **计划 HTML 报告** — 独立渲染器 `RenderPlanHTML`,将 plan 阶段产物(goal + 8 字段自主性契约 + 判定分数 + 里程碑)写入 `.moai/reports/plan-html/<SPEC-ID>-plan.html`。v3.1 中无 CLI 包装器和生产调用者,因此该路径不会被填充。
-- {{< icon clock muted >}} **重新武装 UI** (re-arm) — `/clear` 时显示重新武装、以新 id 重新武装的视图、D8 无限 goal 拒绝横幅等三种条件化的仪表板视图。渲染器已就绪,但生产中没有构造此上下文的调用者,因此 v3.1 CLI 传入 `nil`。
+- {{< icon clock muted >}} **LIVE 仪表板(每回合自动刷新)** — 当前 `moai goal render` 渲染的是调用时刻的静态快照。后续版本中,`stop-goal` Stop 钩子将在每个回合结束时自动重写 `.html` 文件,刷新浏览器即可实时看到进展,变成 LIVE 看板。
 
-重新武装机制本身(会话交接嵌入 + `/clear` 时重新武装 + 无限 goal 拒绝防护)已在先前 SPEC 中发布 — 本路线图中"未连接"的部分仅指将该机制状态 **表面化** 到仪表板 UI 的部分。
+{{< callout type="info" >}}
+**重新武装机制已发布**:重新武装逻辑本身(会话交接嵌入 + `/clear` 时重新武装 + D8 无限 goal 拒绝防护)已在先前的 SPEC-INFINITE-GOAL-001 中发布。v3.1(PR #1388)新增的只是将该机制状态 **表面化** 到仪表板 UI 的部分。
+{{< /callout >}}
 
 ## 相关文档
 

--- a/docs-site/content/zh/workflow-commands/moai-plan.md
+++ b/docs-site/content/zh/workflow-commands/moai-plan.md
@@ -555,6 +555,31 @@ WHEN input is null is detected, the system shall return an error.
 **内部机制**: 5 项原则在 `.claude/rules/moai/core/askuser-protocol.md` § Recommendation Placement Principles 中规格化,并渲染到 `moai.md`。捕获钩子实现于 `internal/hook/user_decision_capture.go`,支持 schema 宽容解析与域分类。衰减策略遵循 power-law 函数 `(age+1)^(-0.5)`,α=0.5 固定(Standard tier)。完整架构与验收标准请参阅项目的 SPEC 文档。
 {{< /callout >}}
 
+## 计划 HTML 报告 (v3.1+)
+
+从 v3.1(PR #1388)起,终端 CLI `moai plan` 新增了 `render-html` 子命令。它从已编写的 SPEC 产物生成一份 plan 阶段 HTML 报告,写入 `.moai/reports/plan-html/<SPEC-ID>-plan.html`。
+
+```bash
+moai plan render-html SPEC-AUTH-001
+# → .moai/reports/plan-html/SPEC-AUTH-001-plan.html
+```
+
+**输入与输出**:
+
+- **输入** — `.moai/specs/<SPEC-ID>/` 目录,以及(若存在)最近的 plan-audit 审查文件(`.moai/reports/plan-audit/<SPEC-ID>-review-<N>.md`)。
+- **输出** — 一份不依赖外部 JS/CSS 的自包含 HTML 文件。goal 声明、8 字段自主性契约、(有审查时)审计判定分数、里程碑打包到一个文件中,可在离线浏览器直接打开。
+
+**失败模式**:
+
+- SPEC 目录缺失时,以非零退出码向 stderr 输出 SPEC-ID,不写入 HTML。
+- plan-audit 审查文件缺失或无法解析时,以"审计判定不可用"占位符渲染并 **exit 0**(fail-open)。
+
+{{< callout type="info" >}}
+**与 `/moai plan` 斜杠命令不同**:`/moai plan` 斜杠命令通过 Claude Code 技能系统编写 SPEC 产物,而 `moai plan render-html` CLI 是一个 Go 二进制子命令,从已编写的产物生成 HTML 报告。
+{{< /callout >}}
+
+加 `--json` 标志可输出 `{action, spec_id, path, bytes}` JSON。
+
 ## 相关文档
 
 - [基于 SPEC 的开发](/core-concepts/spec-based-dev) - EARS 格式详解


### PR DESCRIPTION
## What

docs-site (adk.mo.ai.kr) follow-up for **SPEC-GOAL-HTML-WIRING-001**. Code PR #1388 wires the 3 previously-inert goal-HTML renderer surfaces to production callers; the public docs listed them as **ROADMAP**. This PR moves them to **LIVE** across 4 locales.

## Surfaces moved roadmap → live (v3.1, PR #1388)

1. **Verdict section** — `moai goal render` now loads the ceiling-exit verdict sidecar (`.moai/state/goal/<sid>.verdict.json`) and renders the 5-section verdict (Claim / Evidence / Baseline-attribution / Gaps / Residual-risk), the turn/ceiling line, and the failed-conditions table.
2. **Plan-HTML report** — documents the new `moai plan render-html <SPEC-ID>` CLI → `.moai/reports/plan-html/<SPEC-ID>-plan.html`.
3. **Re-arm UI** — 3 conditional dashboard views (will-rearm on `/clear`, re-armed-under-new-id, D8 infinite-goal rejection banner).

The roadmap keeps ONLY the **c2 LIVE board** (per-turn auto-refresh by the Stop hook), deferred to a later release.

## Version correction

The next release is **v3.1** (not v3.2). Every stale `v3.2` reference in the touched files is eliminated, and `goal.RenderDashboard` is corrected to `goal.RenderDashboardReArm` (the symbol #1388 actually calls).

## Files (12, 4-locale parity)

| page | ko (canonical) | en / ja / zh (derived) |
|---|---|---|
| `utility-commands/moai-goal.md` | roadmap→live reframe | derived |
| `workflow-commands/moai-plan.md` | new `render-html` subsection | derived |
| `cli-reference/goal.md` | light-touch cross-link | derived |

## ⛔ Merge dependency

**Merge this docs PR AFTER code PR #1388.** These docs describe behavior #1388 introduces; merging docs first would publish documentation for unmerged code.

## Verification

- `hugo --quiet` → exit 0, 0 warnings
- 4-locale section parity: moai-goal 13§ / moai-plan 49§ / goal 6§ (all locales)
- `v3.2` remnant grep → 0; Mermaid TD-only; no body emoji (icon shortcodes)
- Behavioral claims grounded in #1388 code: `LoadVerdict` / `RenderDashboardReArm` / `ReArmContext` (`internal/cli/goal.go`), `render-html` → `planhtml.RenderPlanHTML` (`internal/cli/plan.go`)

docs-only — no code changes.

🗿 MoAI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Documented the `moai plan render-html` command for generating self-contained offline HTML reports, including JSON output and failure behavior.
  - Updated goal dashboard documentation to cover verdict sections, conditional re-arm views, sidecar handling, and infinite-goal rejection behavior.

- **Documentation**
  - Added and updated CLI and workflow guidance across English, Japanese, Korean, and Chinese documentation.
  - Clarified distinctions between CLI commands and slash commands, and updated the roadmap to reflect released dashboard capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->