### PR TITLE
docs(SPEC-GOAL-HTML-WIRING-001): backfill sync_commit_sha 7901fd704

### DIFF
--- a/.moai/specs/SPEC-GOAL-HTML-WIRING-001/progress.md
+++ b/.moai/specs/SPEC-GOAL-HTML-WIRING-001/progress.md
@@ -164,7 +164,7 @@ m1_to_mN_commit_strategy: per-milestone Conventional Commit (5 commits + plan-ph
 
 ```yaml
 sync_complete_at: 2026-08-07
-sync_commit_sha: 6622de0f6   # backfilled from sync commit 6622de0f6 (was pending-backfill-sync-wiring-001 placeholder)
+sync_commit_sha: 7901fd704   # main merge SHA of #1388 (squash); backfilled from 6622de0f6 (in-branch sync commit)
 sync_status: audit-ready
 ac_pass_count: 13
 ac_fail_count: 0


### PR DESCRIPTION
This backfills the #1388 main merge SHA (7901fd704) into progress.md `sync_commit_sha`.

- **Before**: `sync_commit_sha: 6622de0f6` (in-branch sync commit — a pre-merge placeholder)
- **After**: `sync_commit_sha: 7901fd704` (main merge SHA of #1388 squash)

The `run_commit_sha` field (line 149) is intentionally unchanged — it remains `3ed9d364c` (the M5 final commit on feat/SPEC-GOAL-HTML-WIRING-001).

**Scope**: docs-only, no code changes.