### PR TITLE
docs(SPEC-AUDIT-MULTI-MODEL-001): backfill sync_commit_sha db48a6c68

### DIFF
--- a/.moai/specs/SPEC-AUDIT-MULTI-MODEL-001/progress.md
+++ b/.moai/specs/SPEC-AUDIT-MULTI-MODEL-001/progress.md
@@ -166,7 +166,7 @@ Full-suite green: `go test ./... → exit 0`. Lint clean: `golangci-lint run →
 
 ```yaml
 sync_complete_at: "2026-08-07"
-sync_commit_sha: "pending-backfill-sync"   # self-referential-hazard workaround per spec-frontmatter-schema.md D3 — a commit cannot know its own SHA until it lands; backfilled in a follow-up commit after the sync PR merges (same pattern as SPEC-PROJECT-NAVIGATOR-003 #1366)
+sync_commit_sha: "db48a6c68"   # backfilled — squash merge of PR #1386 (self-referential-hazard workaround per spec-frontmatter-schema.md D3)
 sync_status: "PASS"
 sync_phase_route: "B (PR-mandatory — this repo's enforce_admins: true branch-protection override)"
 sync_commit_subject: "docs(SPEC-AUDIT-MULTI-MODEL-001): sync-phase artifacts + 3-phase close"


### PR DESCRIPTION
3-phase close SHA backfill (spec-frontmatter-schema.md D3 self-referential-hazard workaround).

PR #1386 (Tier L, run+sync combined) squash-merged as `db48a6c68`, landing the sync-phase artifacts + the `implemented → completed` transition. The `sync_commit_sha` field could not reference its own SHA within that commit, so it was written as `pending-backfill-sync` and is backfilled here in a follow-up Tier S commit.

```diff
- sync_commit_sha: "pending-backfill-sync"
+ sync_commit_sha: "db48a6c68"
```

docs-only (progress.md §E.4, 1 line). No code/template changes.

🗿 MoAI