### PR TITLE
docs(SPEC-SESSION-WORKTREE-001): backfill sync_commit_sha 38b8c2a29

### DIFF
--- a/.moai/specs/SPEC-SESSION-WORKTREE-001/progress.md
+++ b/.moai/specs/SPEC-SESSION-WORKTREE-001/progress.md
@@ -506,7 +506,7 @@ Both fire BEFORE the subcommand's main work (RegisterSession / QueryActiveWork).
 
 - sync_status: completed
 - sync_complete_at: 2026-08-03
-- sync_commit_sha: pending-backfill-SPEC-SESSION-WORKTREE-001-001
+- sync_commit_sha: 38b8c2a29f04b66a75c62dc1bc4dd27404c54379 (PR #1306 squash merge; backfilled from D3 placeholder)
 - sync_pr_number: 1306
 - code_pr_number: 1305 (PR #1305 squash merge `f9ee7bbd1` carried the run-phase implementation)
 - note: a commit cannot reference its own SHA (physics) — the placeholder above is backfilled to the real sync-commit SHA in a follow-up commit (D3 SHA-placeholder-backfill exemption). The run-phase code already landed on main via PR #1305; this sync PR carries only the `in-progress → implemented → completed` frontmatter transition, the §E.3/§E.4 signals, and the CHANGELOG entry.


### PR DESCRIPTION
## 무엇

`SPEC-SESSION-WORKTREE-001/progress.md` §E.4의 `sync_commit_sha`가 D3 플레이스홀더(`pending-backfill-SPEC-SESSION-WORKTREE-001-001`)로 남아 있어 실제 SHA로 채웁니다. 1파일 1줄 변경입니다.

## 근거

해당 SPEC의 sync-phase 산출물은 `38b8c2a29`로 착륙했습니다:

```
38b8c2a29 2026-08-02 docs(SPEC-SESSION-WORKTREE-001): sync-phase artifacts (3-phase close) (#1306)
  .moai/specs/SPEC-SESSION-WORKTREE-001/progress.md | 29 +++++-
  .moai/specs/SPEC-SESSION-WORKTREE-001/spec.md     |  2 +-
  CHANGELOG.md                                      |  2 ++
```

## 출처

정체된 `chore/backfill-sw-sync` 브랜치(main보다 81커밋 뒤)에서 회수했습니다. 그 브랜치는 이 백필 외에 낡은 `.claude/settings.json` 재정렬도 함께 들고 있었는데, 현재 main과 실제로 다른 건 이 한 줄뿐이라 그것만 분리해 올립니다. 나머지는 폐기 예정입니다.

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the sync-phase audit record with the finalized commit reference for PR `#1306`.
  * No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->