### PR TITLE
fix: unrot the harness seed fixture + enforce SemVer 2.0.0 version grammar

### DIFF
--- a/CLAUDE.local.md
+++ b/CLAUDE.local.md
@@ -229,6 +229,33 @@ test(settings): add TestEnsureGlobalSettingsEnv test cases
 - Runtime Access: `pkg/version/version.go` via `git describe`
 - Config Display: `.moai/config/sections/system.yaml` (updated by release process)
 
+### [HARD] Pre-release Versioning — SemVer 2.0.0
+
+Canonical pre-release form: **`vX.Y.Z-rc.N`** (dot before the number, `N` starting at `0`).
+
+```
+v3.1.0-rc.0   v3.1.0-rc.1   ...   v3.1.0-rc.10      → then v3.1.0
+```
+
+The dot is not cosmetic. SemVer splits a pre-release on `.` and compares each
+identifier separately, comparing a purely numeric identifier **numerically**.
+So `rc.9 < rc.10` orders correctly. The older undotted form (`rc9`, `rc10`) is a
+single alphanumeric identifier and compares ASCII-lexically, which puts `rc10`
+*before* `rc9` — the failure surfaces only once a line reaches its tenth
+candidate, which is exactly when a release is least forgiving.
+
+Rules:
+
+- [HARD] New pre-release tags use `-rc.N`. A numeric identifier carries no
+  leading zero (`rc.1`, never `rc.01`) — SemVer forbids it and
+  `scripts/release.sh` rejects it.
+- Legacy undotted tags (`v3.0.0-rc12` and the eleven before it) stay valid and
+  are NOT retagged; `scripts/release.sh` still accepts that form so the existing
+  history remains reproducible. Do not author new tags in it.
+- Enforcement lives in `scripts/release.sh` Validation 1, which implements the
+  official SemVer 2.0.0 grammar (pre-release + optional build metadata).
+- Local testing needs no tag at all — see Build Version Injection below.
+
 ### Build Version Injection
 
 Version is injected at build time using ldflags:
@@ -238,8 +265,20 @@ Version is injected at build time using ldflags:
 go build -ldflags="-X github.com/modu-ai/moai-adk/pkg/version.Version=v1.0.0"
 
 # Makefile handles this automatically
-make build VERSION=1.0.0
+make build VERSION=v1.0.0
 ```
+
+**Local pre-release testing needs no git tag.** `VERSION` is injected via ldflags
+at build time, so a release candidate can be built and installed locally without
+tagging, pushing, or invoking `scripts/release.sh`:
+
+```bash
+make build   VERSION=v3.1.0-rc.0   # bin/moai
+make install VERSION=v3.1.0-rc.0   # $GOPATH/bin/moai
+make release-local VERSION=v3.1.0-rc.0   # dist copy + version.json
+```
+
+Tagging is a separate, remote-facing act performed only by the release harness.
 
 ### Files Requiring Version Sync
 

--- a/internal/cli/hook_harness_eligibility_test.go
+++ b/internal/cli/hook_harness_eligibility_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // seedEventLines writes a usage-log.jsonl under dir/.moai/harness/ containing
@@ -24,12 +25,20 @@ func seedEventLines(t *testing.T, dir string, events []map[string]string) {
 	if err := os.MkdirAll(logDir, 0o755); err != nil {
 		t.Fatalf("mkdir usage-log dir: %v", err)
 	}
+	// The seeded timestamp MUST fall inside the observer's retention window
+	// (harness.defaultRetentionDays = 30): any handler that records an event
+	// first runs Retention.PruneStaleEntries, which moves out-of-window lines
+	// out of usage-log.jsonl into learning-history/archive/. A frozen literal
+	// timestamp silently ages past the cutoff and makes the fixture vanish
+	// before the classifier ever sees it, so derive it from the current clock
+	// (same convention as seedUsageLog in hook_harness_classify_chain_test.go).
+	ts := time.Now().UTC().Add(-24 * time.Hour).Format(time.RFC3339)
 	var b strings.Builder
 	for _, e := range events {
 		// Build a minimal valid usage-log line. defaultConfidence is 1.0 and
 		// the aggregator derives Count from line multiplicity.
 		line := map[string]any{
-			"timestamp":      "2026-07-09T10:00:00Z",
+			"timestamp":      ts,
 			"event_type":     e["event_type"],
 			"subject":        e["subject"],
 			"context_hash":   e["context_hash"],

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -71,9 +71,20 @@ done
 
 [[ -n "$VERSION" ]] || die "Version argument required (e.g., v2.15.0). Try --help."
 
-# ─── Validation 1: Version format (SemVer with v prefix) ────────────────────
-if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
-    die "Invalid version format: $VERSION (expected: vX.Y.Z or vX.Y.Z-preN)"
+# ─── Validation 1: Version format (SemVer 2.0.0 with v prefix) ─────────────
+# The pre-release and build-metadata groups below are the official SemVer 2.0.0
+# grammar, not a loose approximation. A pre-release is a dot-separated series of
+# identifiers; a numeric identifier carries no leading zero, so `rc.01` is
+# rejected while `rc.1` is accepted. This matters for ordering: SemVer compares
+# dot-separated numeric identifiers NUMERICALLY, so `rc.9` precedes `rc.10`,
+# whereas the older undotted `rc9` / `rc10` form compares as a single
+# alphanumeric identifier and sorts ASCII-lexically (`rc10` before `rc9`).
+#
+# The canonical pre-release form for this project is `-rc.N` (see
+# CLAUDE.local.md §5 Pre-release Versioning). The undotted legacy form stays
+# ACCEPTED so the historical `v3.0.0-rc12` line of tags remains valid input.
+if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+    die "Invalid version format: $VERSION (expected SemVer 2.0.0: vX.Y.Z, or vX.Y.Z-rc.N for a pre-release)"
 fi
 
 log_info "Release version: ${BOLD}$VERSION${NC}"


### PR DESCRIPTION
## Summary

Two independent fixes: a test on `main` that started failing on a calendar date, and the version grammar the release script enforces.

## 1. `TestRunHarnessObserveStop_ProposeChainAutoRuns` — red on `main`

This was blocking PR #1411, but it is not that PR's fault: it reproduces on clean `main`.

**Root cause is time, not code.** `seedEventLines` hardcoded `"timestamp": "2026-07-09T10:00:00Z"`. `Observer.RecordExtendedEvent` runs `PruneStaleEntries(30 days)` *before* the classify chain, so as of 2026-08-08 the entire fixture was past the retention cutoff and got archived to `learning-history/archive/`. The classifier then saw only the `session_stop::` event the handler had just written — ineligible for promotion, so `promoCount == 0`, so the `promoCount > 0` guard skipped `generateProposals`, and the missing `proposals/` directory surfaced three layers away from the cause.

Both hypotheses we started with were wrong: eligibility was fine (`eligible=true`, `tier=rule`) and the high-water map was empty. A probe printed the actual fixture state and settled it, and a round-trip confirmed sufficiency — seeding at `now-24h` passes, re-aging to `now-31d` reproduces the verbatim original failure, with zero production-code change either way.

The fix is ten lines in one test helper: derive the seed timestamp from the clock instead of freezing it, matching the sibling seeder `seedUsageLog`, which uses the same `now-24h` and is exactly why it never rotted. **No assertion was touched and no production code changed** — 30-day retention pruning is intended behavior and a real usage log carries recent events. Only the fixture had aged out.

## 2. SemVer 2.0.0 version grammar

`scripts/release.sh` Validation 1 accepted any `-[0-9A-Za-z.-]+` suffix, including forms SemVer rejects: a leading-zero numeric identifier (`rc.01`) or an empty one (`rc.`). It now implements the official SemVer 2.0.0 grammar for pre-release plus optional build metadata.

The canonical pre-release form is now **`vX.Y.Z-rc.N`**, and the dot is load-bearing. SemVer compares dot-separated numeric identifiers *numerically*, so `rc.9` precedes `rc.10`. The older undotted `rc9`/`rc10` form is a single alphanumeric identifier compared ASCII-lexically, which puts `rc10` **before** `rc9` — a fault that only surfaces at a line's tenth candidate, when a release is least forgiving.

The legacy form stays accepted so the existing `v3.0.0-rc1..rc12` tag line remains valid input; only new tags use the dotted form. `CLAUDE.local.md` §5 documents the convention and records that local pre-release testing needs no git tag at all, since `VERSION` is ldflags-injected.

## Verification

- `go test ./internal/cli/ -run 'TestRunHarnessObserveStop_'` → 14/14 pass, no sibling regressed
- `go test ./...` → 108 packages ok, zero assertion failures
- `go vet ./...` clean · `golangci-lint run` clean
- Regex verified under bash 3.2 across 10 cases: `vX.Y.Z`, `-rc.0`, `-rc.10`, legacy `-rc12`, `+build.5` accepted; `-rc.01`, `rc.`, trailing `-`, missing `v`, two-segment rejected
- `scripts/release.sh v3.1.0-rc.0 --dry-run` passes Validation 1
- `make build/install/release-local VERSION=v3.1.0-rc.0` → binary reports `v3.1.0-rc.0`

## Note

Two `internal/statusline` / `internal/cli` tests time out in a sandboxed environment — they make a live HTTPS call to `api.anthropic.com` from `fetchUsageFromOAuthAPI`. Pre-existing and unrelated (reproduced with the change stashed out), but it means "main is green" holds only where the network is reachable.

🗿 MoAI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for SemVer 2.0.0 release-candidate versions using dotted `-rc.N` tags.
  * Continued support for legacy undotted release-candidate tags.
  * Improved handling of local release-candidate builds and installations.

* **Bug Fixes**
  * Improved release validation for structured pre-release and build metadata.
  * Fixed time-sensitive harness test data to remain valid during retention checks.

* **Documentation**
  * Clarified versioning, build, and tagging guidance for releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->