### PR TITLE
chore(SPEC-FACTORY-MODE-001): backfill sync_commit_sha + factory codemap entry

### DIFF
--- a/.moai/project/codemaps/modules.md
+++ b/.moai/project/codemaps/modules.md
@@ -153,6 +153,12 @@
 **핵심**: `moai goal arm|status|clear`, Condition {Mechanical,Model}, Stop-hook 평가 계약
 **상태**: `.moai/state/goal/<session-id>.json` (세션별)
 
+### internal/factory
+**역할**: Factory 모드 상태 — `moai cc -f` / `moai glm -f`가 여는 plan→run→verify→sync 체인의 세션 기록과 중복 억제
+**핵심**: `record.go` (세션 레코드 기록, `validateSessionID`가 경로 조작 차단, 파일 0600), `revision.go` (`Matches`/`RevisionMatch`/`SuppressStep0551` — 모든 실패 모드가 "검사 수행"으로 수렴하는 fail-safe, rung은 allow-list)
+**상태**: 세션 ID 파생 경로의 레코드 파일 + `revision.json`
+**진입점**: `internal/cli/factory.go` (플래그 파싱, env 진입/복원), `internal/cli/launcher_blockcap_infinite.go` (Stop-hook block cap 상향)
+
 ### internal/hook
 **역할**: 컴파일된 훅 시스템 + main-checkout branch-state guard
 **이벤트**: 30개 EventType (SessionStart, PostToolUse, Stop, etc), 35개 `handle-*.sh` 래퍼

--- a/.moai/specs/SPEC-FACTORY-MODE-001/progress.md
+++ b/.moai/specs/SPEC-FACTORY-MODE-001/progress.md
@@ -1127,6 +1127,8 @@ m1_to_mN_commit_strategy: one commit per milestone on feat/factory-mode (M1…M5
 
 The pre-SPEC coverage baseline `7171880a9` predates the branch and was NOT rewritten by the rebase — it remains an ancestor of `HEAD` (`git merge-base --is-ancestor 7171880a9 HEAD` → exit 0) and is carried forward unchanged.
 
+**Where these SHAs resolve after the merge.** PR #1416 landed on `main` as a **squash** commit, `e6b5ccc45` — the repository's configured merge method. Every post-rebase SHA in the ledger above is therefore branch-local: measured, `git merge-base --is-ancestor 4461bc7a4 origin/main` returns exit 1, and `git rev-list --count e6b5ccc45 ^5a929480a` returns `1`, so the twelve branch commits collapsed into one on `main`. This is a structural property of squash merging, not a defect and not a repeat of the rebase drift repaired above: the per-milestone commits are preserved in full on PR #1416, which is where a reader should go to inspect them individually. The single SHA that resolves on `main` is `e6b5ccc45`, and that is the value recorded as `sync_commit_sha` in §E.4 below.
+
 ### The three defects and their dispositions
 
 | # | Defect | Ours? | Disposition | Evidence |
@@ -1156,7 +1158,7 @@ This section is written on the assumption that a sync-phase auditor treats it as
 
 ```yaml
 sync_complete_at: 2026-08-09
-sync_commit_sha: pending-backfill-sync   # a commit cannot know its own hash; backfilled after this commit lands
+sync_commit_sha: e6b5ccc45   # the squash-merge commit on main (PR #1416); backfilled after the merge landed
 sync_status: audit-ready-with-two-gaps
 sync_auditor_verdict: PASS
 sync_auditor_weighted_mean: 0.885        # against a 0.85 threshold


### PR DESCRIPTION
Post-merge backfill for #1416.

## sync_commit_sha

Set to `e6b5ccc45` — the squash commit on `main` — rather than the branch-local sync commit `4461bc7a4`.

```
$ git merge-base --is-ancestor 4461bc7a4 origin/main ; echo $?
1
$ git rev-list --count e6b5ccc45 ^5a929480a
1
```

The twelve branch commits collapsed into one on `main`. Recording the branch-local SHA would have recreated the dead-SHA defect that #1416's own sync commit repaired — the value was checked before writing rather than carried forward from the placeholder's neighbourhood.

## Milestone-ledger note

Records where the per-milestone SHAs resolve after the squash: they are branch-local and preserved in full on #1416, while `e6b5ccc45` is the single SHA that resolves on `main`. This is a structural property of squash merging, not drift, and the note exists so a later reader does not mistake it for the latter.

## codemaps

Adds the `internal/factory` entry, deferred from #1416's approved sync scope. Function names (`Matches`, `RevisionMatch`, `SuppressStep0551`, `validateSessionID`) verified against the source rather than copied from the SPEC.

Not touched: `internal/cli`'s `~48개` fan-out figure — that counts the packages `internal/cli` depends on, not the repository's package total, so the 48→49 correction applied to `structure.md` does not apply to it.

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded Factory mode documentation to cover session tracking, duplicate-step handling, revision checks, session ID validation, state files, and CLI entry points.
  - Updated project progress records to reflect the latest merged changes and synchronization status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->