### PR TITLE
fix(workflows): make the sync-audit-4dim schemas valid JSON Schema

### DIFF
--- a/.claude/workflows/sync-audit-4dim.js
+++ b/.claude/workflows/sync-audit-4dim.js
@@ -69,18 +69,70 @@ const DIMENSIONS = ['Functionality', 'Security', 'Craft', 'Consistency']
 // Schema-forced output: the verdict computation consumes typed fields, so the Context + Judge
 // outputs are schema-shaped (arithmetic needs structure). Explorer narrative in the sibling
 // plan-research-fanout.js is markdown by contrast — that asymmetry is deliberate.
+// These MUST be real JSON Schema. `agent({schema})` validates them under strict mode,
+// where a bare field name at the top level is an unknown keyword and the call throws
+// before any agent runs — so a shape-object sketch here disables the whole fan-out.
 const CONTEXT_SCHEMA = {
-  spec_id: 'string — the audited SPEC id',
-  acceptance_criteria: ['string — one AC statement per entry'],
-  changed_files: ['string — repo-relative path touched by this SPEC'],
-  test_command: 'string — the command that runs this SPEC test suite',
+  type: 'object',
+  properties: {
+    spec_id: { type: 'string', description: 'the audited SPEC id' },
+    acceptance_criteria: {
+      type: 'array',
+      description: 'one AC statement per entry',
+      items: { type: 'string' },
+    },
+    changed_files: {
+      type: 'array',
+      description: 'repo-relative paths this SPEC touches',
+      items: { type: 'string' },
+    },
+    test_command: { type: 'string', description: 'the command that runs this SPEC test suite' },
+  },
+  required: ['spec_id', 'acceptance_criteria', 'changed_files', 'test_command'],
+  additionalProperties: false,
 }
 
+// `score` is nullable on purpose: the judge prompt instructs a judge that cannot evaluate
+// its dimension to return null rather than fabricate a number, and the Verdict phase reads
+// a non-numeric score as a missing judge (INCOMPLETE). A non-nullable number here would
+// force the fabrication the prompt forbids. anyOf rather than a union `type` keeps the
+// range constraint unambiguous under strict validation.
 const JUDGE_SCHEMA = {
-  dimension: 'string — one of Functionality/Security/Craft/Consistency',
-  score: 'number 0..1 — quality score for this dimension (0 = hard fail, 1 = flawless)',
-  findings: [{ severity: 'critical|major|minor', summary: 'string', file: 'string', evidence: 'string — command run + verbatim output' }],
-  evidence_gaps: ['string — a check the judge could NOT run and why (evidence absent != pass)'],
+  type: 'object',
+  properties: {
+    dimension: {
+      type: 'string',
+      enum: ['Functionality', 'Security', 'Craft', 'Consistency'],
+    },
+    score: {
+      anyOf: [
+        { type: 'number', minimum: 0, maximum: 1 },
+        { type: 'null' },
+      ],
+      description: 'quality score for this dimension (0 = hard fail, 1 = flawless); null when the dimension could not be evaluated at all',
+    },
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          severity: { type: 'string', enum: ['critical', 'major', 'minor'] },
+          summary: { type: 'string' },
+          file: { type: 'string' },
+          evidence: { type: 'string', description: 'the command run PLUS its verbatim output — never a summary' },
+        },
+        required: ['severity', 'summary', 'file', 'evidence'],
+        additionalProperties: false,
+      },
+    },
+    evidence_gaps: {
+      type: 'array',
+      description: 'a check the judge could NOT run, and why (evidence absent != pass)',
+      items: { type: 'string' },
+    },
+  },
+  required: ['dimension', 'score', 'findings', 'evidence_gaps'],
+  additionalProperties: false,
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/template/templates/.claude/workflows/sync-audit-4dim.js
+++ b/internal/template/templates/.claude/workflows/sync-audit-4dim.js
@@ -69,18 +69,70 @@ const DIMENSIONS = ['Functionality', 'Security', 'Craft', 'Consistency']
 // Schema-forced output: the verdict computation consumes typed fields, so the Context + Judge
 // outputs are schema-shaped (arithmetic needs structure). Explorer narrative in the sibling
 // plan-research-fanout.js is markdown by contrast — that asymmetry is deliberate.
+// These MUST be real JSON Schema. `agent({schema})` validates them under strict mode,
+// where a bare field name at the top level is an unknown keyword and the call throws
+// before any agent runs — so a shape-object sketch here disables the whole fan-out.
 const CONTEXT_SCHEMA = {
-  spec_id: 'string — the audited SPEC id',
-  acceptance_criteria: ['string — one AC statement per entry'],
-  changed_files: ['string — repo-relative path touched by this SPEC'],
-  test_command: 'string — the command that runs this SPEC test suite',
+  type: 'object',
+  properties: {
+    spec_id: { type: 'string', description: 'the audited SPEC id' },
+    acceptance_criteria: {
+      type: 'array',
+      description: 'one AC statement per entry',
+      items: { type: 'string' },
+    },
+    changed_files: {
+      type: 'array',
+      description: 'repo-relative paths this SPEC touches',
+      items: { type: 'string' },
+    },
+    test_command: { type: 'string', description: 'the command that runs this SPEC test suite' },
+  },
+  required: ['spec_id', 'acceptance_criteria', 'changed_files', 'test_command'],
+  additionalProperties: false,
 }
 
+// `score` is nullable on purpose: the judge prompt instructs a judge that cannot evaluate
+// its dimension to return null rather than fabricate a number, and the Verdict phase reads
+// a non-numeric score as a missing judge (INCOMPLETE). A non-nullable number here would
+// force the fabrication the prompt forbids. anyOf rather than a union `type` keeps the
+// range constraint unambiguous under strict validation.
 const JUDGE_SCHEMA = {
-  dimension: 'string — one of Functionality/Security/Craft/Consistency',
-  score: 'number 0..1 — quality score for this dimension (0 = hard fail, 1 = flawless)',
-  findings: [{ severity: 'critical|major|minor', summary: 'string', file: 'string', evidence: 'string — command run + verbatim output' }],
-  evidence_gaps: ['string — a check the judge could NOT run and why (evidence absent != pass)'],
+  type: 'object',
+  properties: {
+    dimension: {
+      type: 'string',
+      enum: ['Functionality', 'Security', 'Craft', 'Consistency'],
+    },
+    score: {
+      anyOf: [
+        { type: 'number', minimum: 0, maximum: 1 },
+        { type: 'null' },
+      ],
+      description: 'quality score for this dimension (0 = hard fail, 1 = flawless); null when the dimension could not be evaluated at all',
+    },
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          severity: { type: 'string', enum: ['critical', 'major', 'minor'] },
+          summary: { type: 'string' },
+          file: { type: 'string' },
+          evidence: { type: 'string', description: 'the command run PLUS its verbatim output — never a summary' },
+        },
+        required: ['severity', 'summary', 'file', 'evidence'],
+        additionalProperties: false,
+      },
+    },
+    evidence_gaps: {
+      type: 'array',
+      description: 'a check the judge could NOT run, and why (evidence absent != pass)',
+      items: { type: 'string' },
+    },
+  },
+  required: ['dimension', 'score', 'findings', 'evidence_gaps'],
+  additionalProperties: false,
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## The defect

`CONTEXT_SCHEMA` and `JUDGE_SCHEMA` in `sync-audit-4dim.js` were shape-object sketches — a field name mapped to a prose description — not JSON Schema. `agent({schema})` validates under strict mode, where a bare top-level field name is an unknown keyword, so the call threw **before any agent ran**:

```
TypeError: agent({schema}) received an invalid JSON Schema:
strict mode: unknown keyword: "spec_id"
```

The failure is total rather than partial: the `FO-SYNC-1` parallel 4-dimension quality read has never executed. Because the template source was byte-identical to the local copy (`diff` → no output), every distributed project carries the same dead fan-out and silently falls back to the cold `sync-auditor`. The fallback is why this went unnoticed — sync still produced a verdict, just never the parallel one.

Found while running `/moai sync` for SPEC-FACTORY-MODE-001 (#1416), where the launch failed on the first call.

## The fix

Both schemas rewritten as real JSON Schema with `type` / `properties` / `required` / `additionalProperties: false`.

`score` is nullable via `anyOf` rather than a union `type`. This is load-bearing, not stylistic: the judge prompt instructs a judge that cannot evaluate its dimension to return `null` instead of fabricating a number, and the Verdict phase reads a non-numeric score as a missing judge (`INCOMPLETE`). A non-nullable number would have forced exactly the fabrication the prompt forbids. `anyOf` also keeps the 0..1 range constraint unambiguous under strict validation.

## Verification

A throwaway probe workflow carrying these exact schemas — two trivial cheap agents, one per schema:

```json
{"context_ok": true, "judge_ok": true,
 "ctx": {"spec_id": "PROBE-000", "acceptance_criteria": ["probe"],
         "changed_files": ["probe.go"], "test_command": "go test ./..."},
 "judge": {"dimension": "Craft", "score": 0.5, "findings": [],
           "evidence_gaps": ["probe run, nothing measured"]}}
```

2 agents, 0 errors. The same call site that previously threw before running anything now runs and returns schema-conformant objects; the numeric `0.5` confirms the nullable branch does not reject a real score. The probe script was deleted after the run.

Template-First cycle observed: template source edited, mirrored to the local copy (`diff` → identical), `make build` run (produced no further diff), and `go test ./internal/template/...` → `ok 19.673s` with the mirror-parity guards passing.

## Not fixed here

The judge prompt's closing line still says "Return an object with EXACTLY: ..." — accurate but now redundant beside an enforced schema. Left alone: it costs nothing and rewording prompt text in the same commit as a schema repair would blur what this change is.

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of audit context and evaluation results.
  * Added stricter checks for required fields, permitted values, numeric ranges, and array contents.
  * Evaluation scores can now be marked as unavailable when a dimension cannot be assessed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->