### PR TITLE
chore(codemaps): correct the stale package count in the verification section

### DIFF
--- a/.moai/project/codemaps/modules.md
+++ b/.moai/project/codemaps/modules.md
@@ -240,7 +240,9 @@
 ## 검증
 
 **순환 의존성**: 0개 (검증됨)  
-**패키지 수**: 46 internal 디렉터리 (318 subpackage) + 2 pkg (`models`, `version`) + 1 cmd = 49개 경로
+**패키지 수**: 49 internal 디렉터리 (323 중첩 디렉터리) + 2 pkg (`models`, `version`) + 1 cmd = 52개 경로
+
+> 실측 명령: `ls -d internal/*/ | wc -l` → 49, `find internal -type d -mindepth 2 | wc -l` → 323. 종전 표기(46 / 318)는 갱신이 밀린 값이며, 세 패키지 차이 중 `internal/factory` 하나만 SPEC-FACTORY-MODE-001이 추가한 것이고 나머지 둘은 그 이전부터 있었다. `structure.md` 71행의 같은 수치도 함께 갱신했다.
 
 ---
 


### PR DESCRIPTION
Follow-up to #1417, which added the `internal/factory` module entry but missed a second stale figure further down the same file.

The verification section still read `46 internal 디렉터리 (318 subpackage) ... = 49개 경로`.

Re-measured rather than carried forward:

```
$ ls -d internal/*/ | wc -l
49
$ find internal -type d -mindepth 2 | wc -l
323
```

Now `49 / 323 / 52 paths`, matching `structure.md:71`, which #1416's sync commit already corrected to the same measured figures. The note records that only one of the three-package gap (`internal/factory`) belongs to SPEC-FACTORY-MODE-001; the other two predate it.

Not touched: `internal/cli`'s `~48개` fan-out figure on line 18. That counts the packages `internal/cli` depends on, not the repository's package total, so the 46→49 correction does not apply to it.

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documented package and directory counts.
  * Added measurement commands and clarified discrepancies in the totals.
  * Synchronized related structural references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->