### PR TITLE
feat(SPEC-HARNESS-LEARNING-EVO-001): routing-ledger instrumentation (L1)

### DIFF
--- a/.moai/specs/SPEC-HARNESS-LEARNING-EVO-001/acceptance.md
+++ b/.moai/specs/SPEC-HARNESS-LEARNING-EVO-001/acceptance.md
@@ -1,0 +1,174 @@
+# SPEC-HARNESS-LEARNING-EVO-001 — Acceptance Criteria (L1)
+
+Every criterion below names the command that decides it, and that command actually decides it. Budget: 16 criteria (Tier M ceiling 16).
+
+## §A. Verification conventions
+
+- **Go-test criteria** are decided by the named test function's pass/fail, run with `-count=1`.
+- **Grep criteria** are decided by the exact command's match count; a criterion asserting absence names the expected empty output.
+- No criterion reads `.moai/state/routing-ledger.jsonl` or `.moai/evolution/telemetry/*.jsonl` as live content. Those files are gitignored runtime state, gate-dependent, and empty in CI. See `plan.md` §G AP-5.
+- A criterion that inspects source text rather than behavior is marked as such and is paired with a behavioral assertion; source inspection alone never decides a criterion.
+
+## §B. Store lifecycle
+
+### AC-HLE-001 — create-if-absent creates once, preserves content, and never reroutes; Record still does
+- **Given** a temp state dir with no pending row for session `S`
+- **When** `Store.RecordIfAbsent` is called twice for `S`, then once more after two delegations and one evidence ref have been appended
+- **Then** exactly one pending file exists for `S`, its delegations and evidence refs are unchanged by the third call, and the ledger file has zero rows; and **when** the pre-existing `Store.Record` is called for `S`, exactly one ledger row with `outcome: "reroute"` is appended, as before this SPEC
+- **Command**: `go test ./internal/harness/routing/ -run 'TestRecordIfAbsent_Lifecycle|TestRecord_StillReroutesSelf' -count=1`
+- **Covers**: REQ-HLE-003, REQ-HLE-004
+
+### AC-HLE-002 — seam I/O stays bounded, and the sweep is not on the per-prompt path
+- **Given** a temp state dir holding 5 foreign pending files, and a temp telemetry dir holding day-files for today, yesterday, and three earlier days
+- **When** `Store.RecordIfAbsent` runs for a fresh session, and separately the session evidence load runs
+- **Then** no foreign pending file is read, modified, or removed and no ledger row is appended by `RecordIfAbsent` (the sweep did not run on this path), while the same fixture under `Store.Record` does sweep; and the evidence load returns records from exactly the today and yesterday files, never from the three earlier ones
+- **Command**: `go test ./internal/harness/routing/ -run TestRecordIfAbsent_NoSweepOnCreatePath -count=1` and `go test ./internal/telemetry/ -run TestLoadBySession_TwoDayWindow -count=1`
+- **Covers**: REQ-HLE-015
+- **Note**: "bounded" is decided by these two behavioral proxies, not by a syscall counter. See §F R4.
+
+### AC-HLE-003 — the create-if-absent path inherits both sweep guards unchanged
+- **Given** two foreign pending rows — one aged past `routing.StalenessThreshold` (24h) with its session absent from `active-sessions.json`, and one aged past the threshold with its session listed live
+- **When** the dispatch path that does sweep (`Store.Record`) runs for a third session
+- **Then** the first foreign row is finalized as `abort` and removed, and the live-listed row is left untouched, demonstrating that both the age guard and the liveness guard still gate the sweep
+- **Command**: `go test ./internal/harness/routing/ -run TestSweepStale_AgeAndLivenessGuards -count=1`
+- **Covers**: REQ-HLE-004
+
+### AC-HLE-004 — annotate patches without creating or finalizing, and is reachable from the CLI
+- **Given** a pending row for `S` with an empty `matched_subcommand`
+- **When** `Store.Annotate` is called with subcommand `plan`, tier `M`, and an empty mode; and separately `moai harness ledger annotate --session S --subcommand run --tier L` is invoked against a temp root
+- **Then** the pending row shows the patched values, its `mode_selected` is unchanged by the empty field, no ledger row is appended, annotating a session with no pending row is a no-op that creates nothing, and the CLI invocation exits 0 with the annotated values present
+- **Command**: `go test ./internal/harness/routing/ -run TestAnnotate -count=1` and `go test ./internal/cli/ -run TestHarnessLedgerAnnotateCmd -count=1`
+- **Covers**: REQ-HLE-005
+
+### AC-HLE-005 — schema version is unchanged and pre-existing rows still parse
+- **Given** a fixture ledger of rows written before this SPEC
+- **When** the routing reader reads them
+- **Then** every row parses, `schema_version` is 1 on every row the store writes, and no field was removed or renamed
+- **Command**: `go test ./internal/harness/routing/ -run 'TestSchemaVersionStable|TestReader' -count=1`
+- **Covers**: REQ-HLE-014
+
+## §C. Mechanical seams
+
+### AC-HLE-006 — a prompt creates a pending row mechanically
+- **Given** a temp project root with both harness observation gates open and no pending row
+- **When** the UserPromptSubmit handler is invoked with a `HookInput` carrying a prompt and a session id
+- **Then** a pending row exists for that session whose `request_digest` is the digest of the prompt and whose `request_class` is the classifier's output
+- **Command**: `go test ./internal/hook/ -run TestRoutingSeam_UserPromptSubmit_CreatesPending -count=1`
+- **Covers**: REQ-HLE-001, REQ-HLE-002
+
+### AC-HLE-007 — no verbatim prompt text is persisted
+- **Given** the seam-A test above, run with the distinctive prompt literal `ZZQX-CANARY-PROMPT`
+- **When** the handler completes
+- **Then** no file anywhere under the temp state dir contains that literal
+- **Command**: `go test ./internal/hook/ -run TestRoutingSeam_NoRawPromptPersisted -count=1`
+- **Covers**: REQ-HLE-016
+
+### AC-HLE-008 — repeated prompts do not reroute
+- **Given** an open pending row for session `S`
+- **When** the UserPromptSubmit handler is invoked three more times for `S`
+- **Then** the ledger has zero rows and the pending row still exists
+- **Command**: `go test ./internal/hook/ -run TestRoutingSeam_MultiTurnNoReroute -count=1`
+- **Covers**: REQ-HLE-003
+
+### AC-HLE-009 — subcommand is set from a literal prefix only, and only once
+- **Given** three prompts submitted to one session in order — `"/moai plan add auth"`, `"please run the auth work"`, `"/moai run SPEC-X"` — and separately a fresh session receiving only `"please plan the auth work"`
+- **When** each is submitted to the handler
+- **Then** the first session's `matched_subcommand` is `"plan"` after all three prompts (the natural-language prompt set nothing; the second literal did not overwrite the first), and the fresh session's `matched_subcommand` is empty
+- **Command**: `go test ./internal/hook/ -run TestRoutingSeam_LiteralSubcommandFirstWriterWins -count=1`
+- **Covers**: REQ-HLE-006
+
+### AC-HLE-010 — the delegation records `agent_type` verbatim, including non-catalog values
+- **Given** two SubagentStop inputs for an open pending row — one with `agent_type: "manager-develop"` and one with `agent_type: "audit-hle"` (the observed named-spawn shape from `spec.md` §A.5 caveat 2)
+- **When** the seam runs for each
+- **Then** the pending row's `delegations` has length 2 with `agent` values `"manager-develop"` and `"audit-hle"` respectively — the second stored verbatim and neither normalized to, nor replaced by, the input's `subject` field
+- **Command**: `go test ./internal/hook/ -run TestRoutingSeam_SubagentStop_AgentTypeVerbatim -count=1`
+- **Covers**: REQ-HLE-007
+
+### AC-HLE-011 — an absent identity is recorded under a distinguishable marker, not an empty string
+- **Given** a SubagentStop input whose `agent_type` is absent (the shape of the 842 rows measured in `spec.md` §A.5 caveat 1)
+- **When** the seam runs
+- **Then** a delegation entry is appended whose `agent` value is a non-empty marker distinct from every retained-catalog name, and the entry is countable as unattributed rather than indistinguishable from an attributed one
+- **Command**: `go test ./internal/hook/ -run TestRoutingSeam_AbsentAgentTypeMarker -count=1`
+- **Covers**: REQ-HLE-008
+
+### AC-HLE-012 — an unobservable outcome is recorded as unknown, not success
+- **Given** a SubagentStop input carrying no outcome-bearing signal
+- **When** the seam runs
+- **Then** the appended delegation's outcome is the explicit unknown marker and its blocker is null; the string `success` does not appear in the entry
+- **Command**: `go test ./internal/hook/ -run TestRoutingSeam_UnknownOutcomeNotSuccess -count=1`
+- **Covers**: REQ-HLE-009
+
+### AC-HLE-013 — the Bash evidence record is reachable in production wiring, and written exactly once
+- **Given** a temp project root with the learning gate open
+- **When** the harness-observe handler is invoked with a Bash PostToolUse payload carrying a test command and a passing result, and separately with an Edit payload that the `Write|Edit|MultiEdit` post-tool handler also processes
+- **Then** the Bash invocation produces exactly one telemetry record with `is_test_pass` set (the path `spec.md` §A.6 measured as unreachable now executes), and the Edit invocation produces exactly one telemetry record in total across both handlers — no duplicate
+- **Command**: `go test ./internal/cli/ -run TestHarnessObserve_BashEvidenceRecorded -count=1` and `go test ./internal/hook/ -run TestEvidenceRecord_NoDoubleWriteOnEdit -count=1`
+- **Covers**: REQ-HLE-011
+
+### AC-HLE-014 — a terminal signal closes the row, and a row accumulates delegations end to end
+- **Given** a temp project root with gates open
+- **When** the seam sequence is driven in order — UserPromptSubmit, two SubagentStop invocations, then the Stop path with an observed test-pass signal on the session evidence path; and again with an observed test-fail signal
+- **Then** the ledger gains exactly one finalized row per run, with `outcome: "success"` and `"fail"` respectively, a non-empty `evidence_refs`, a `delegations` array of length 2, and the pending file removed
+- **Command**: `go test ./internal/cli/ -run TestRoutingLedger_TerminalCloseEndToEnd -count=1`
+- **Covers**: REQ-HLE-010
+- **Note**: this criterion drives the production handler functions against a temp root; it does not prove that Claude Code invokes those handlers in a live session. See §F R1.
+
+### AC-HLE-015 — every seam is fail-open
+- **Given** a state dir made unwritable, and separately a malformed pending file
+- **When** each of the three seams runs
+- **Then** each returns without error, the handler's own output is unaffected, and a diagnostic was written to the sink
+- **Command**: `go test ./internal/hook/ -run TestRoutingSeam_FailOpen -count=1`
+- **Covers**: REQ-HLE-012
+
+### AC-HLE-016 — a closed gate writes nothing
+- **Given** a temp project root with the hook opt-in gate closed, and separately with the learning gate closed
+- **When** all three seams run
+- **Then** the state dir contains no ledger file and no pending file in both configurations
+- **Command**: `go test ./internal/hook/ -run TestRoutingSeam_GatedOffWritesNothing -count=1`
+- **Covers**: REQ-HLE-013
+
+## §D. Quality gate
+
+- `go build ./...` exits 0, and `GOOS=windows GOARCH=amd64 go build ./...` exits 0.
+- `go test ./... -count=1` exits 0 (full suite, not the affected packages alone).
+- `golangci-lint run` reports no new finding against the pre-change baseline.
+- `moai spec lint .moai/specs/SPEC-HARNESS-LEARNING-EVO-001/spec.md --strict` exits 0.
+- `git diff --name-only origin/main...HEAD | grep -cE '^(internal/template/templates/|\.claude/skills/|\.claude/lsel/)'` returns `0` — no template, frozen-skill, or frozen-allowlist path is touched.
+- `grep -rn 'delegation.yaml' internal/ --include='*.go' | grep -v _test` returns no output — this SPEC introduces neither a reader nor a writer for the map.
+- `grep -rn 'AskUserQuestion' internal/hook/routing_ledger.go` returns no output.
+
+## §E. Definition of Done
+
+- All 16 criteria pass, each cited with its command and observed output.
+- The traceability matrix in §G shows every requirement covered.
+- The falsification review named in `spec.md` §E is scheduled, not performed — it needs 50 finalized rows, which do not exist at merge time.
+
+## §F. Residual risk
+
+- **R1 — the live-session path is not mechanically verifiable.** AC-HLE-014 drives the production handler functions directly against a temp root. It cannot prove that Claude Code invokes those hooks in a real session, because that depends on the runtime's hook dispatch, on `settings.json` registration, and on the fail-closed opt-in gate being enabled locally. No CI-runnable criterion covers that link. It must be confirmed by a manual dogfood check — enable the opt-in, run one real `/moai` dispatch with at least one subagent, and read the resulting ledger row — and that check is stated here as manual rather than dressed up as an automated criterion.
+- **R2 — the gate ships closed.** Every L1 path is inert for distributed users by default. "No rows appeared" is therefore ambiguous until the gate state is checked; a reader must not infer breakage from an empty ledger.
+- **R3 — the terminal signal source rests on one unobserved premise.** REQ-HLE-011's chosen restoration path assumes the Bash PostToolUse payload delivered on the matcher-null observe wrapper carries `tool_input.command` and `tool_response`. The wrapper's registration for Bash is verified (`matcher: null`); the payload content on that specific channel is not runtime-observed in this repository. `plan.md` §F M0 gates the milestone on a probe that settles it, with a declared fallback.
+- **R4 — "bounded I/O" is decided by proxies.** AC-HLE-002 asserts sweep absence on the create path and a two-day evidence read window. Neither counts syscalls, so a future edit could add a read on a seam path without failing this criterion.
+- **R5 — first-writer-wins mislabels multi-subcommand sessions.** A session running `/moai plan` then `/moai run` finalizes as one row labelled `plan` (REQ-HLE-006). Every delegation spawned during the run phase is then attributed to `plan`. The alternative (last-writer-wins) relabels delegations that were observed under the first label, so both are approximations; the split into per-subcommand rows is deferred (`spec.md` §G).
+- **R6 — agent identity is a mixed population.** 30.3% of observed `agent_type` values are absent and a further large share are spawn names rather than agent types (`spec.md` §A.5). This SPEC records the field verbatim and pushes the discrimination downstream; that is a deliberate boundary, and it is why `spec.md` §E F1/F2 exist.
+
+## §G. Traceability matrix
+
+| REQ | Criteria |
+|---|---|
+| REQ-HLE-001 | AC-HLE-006 |
+| REQ-HLE-002 | AC-HLE-006 |
+| REQ-HLE-003 | AC-HLE-001, AC-HLE-008 |
+| REQ-HLE-004 | AC-HLE-001, AC-HLE-003 |
+| REQ-HLE-005 | AC-HLE-004 |
+| REQ-HLE-006 | AC-HLE-009 |
+| REQ-HLE-007 | AC-HLE-010 |
+| REQ-HLE-008 | AC-HLE-011 |
+| REQ-HLE-009 | AC-HLE-012 |
+| REQ-HLE-010 | AC-HLE-014 |
+| REQ-HLE-011 | AC-HLE-013 |
+| REQ-HLE-012 | AC-HLE-015 |
+| REQ-HLE-013 | AC-HLE-016 |
+| REQ-HLE-014 | AC-HLE-005 |
+| REQ-HLE-015 | AC-HLE-002 |
+| REQ-HLE-016 | AC-HLE-007 |

--- a/.moai/specs/SPEC-HARNESS-LEARNING-EVO-001/plan.md
+++ b/.moai/specs/SPEC-HARNESS-LEARNING-EVO-001/plan.md
@@ -1,0 +1,182 @@
+# SPEC-HARNESS-LEARNING-EVO-001 — Implementation Plan (L1)
+
+> Derived from `spec.md`. Ordered by decision-reversibility: the two contested design decisions come first (§E), then the seam semantics and store API, then the mechanical wiring.
+
+## §A. Context and measured baseline
+
+### A.1 Baseline commands (re-runnable)
+
+All figures were measured against the **primary checkout** `/Users/goos/MoAI/moai-adk-go` on 2026-08-09. They are not reproducible from this worktree: `.moai/state/`, `.moai/harness/`, and `.moai/evolution/` are gitignored runtime state and are absent here. Re-run from the primary checkout; the figures drift upward as the observer keeps writing, and small drift is expected rather than a discrepancy.
+
+| Claim | Command | Observed |
+|---|---|---|
+| Ledger effectively empty | `wc -l < .moai/state/routing-ledger.jsonl` | 4 rows |
+| No delegation ever recorded | `jq -c '.delegations \| length' .moai/state/routing-ledger.jsonl \| sort \| uniq -c` | `4  0` |
+| Outcomes never terminal | `jq -r .outcome .moai/state/routing-ledger.jsonl \| sort \| uniq -c` | `3 abort`, `1 reroute` |
+| Sibling observer is not starved | `wc -l < .moai/harness/usage-log.jsonl` | 109,236 rows |
+| Nothing writes the map | `grep -rn 'delegation.yaml' internal/ --include='*.go' \| grep -v _test` | 0 matches |
+| Proposal ladder works | `ls .moai/harness/proposals \| wc -l` ; `wc -l < .moai/harness/learning-history/tier-promotions.jsonl` | 73 dirs ; 175 rows |
+| Agent identity is observable | `grep '"subagent_stop"' .moai/harness/usage-log.jsonl \| jq -r '.agent_type // "(none)"' \| sort \| uniq -c \| sort -rn` | 2,783 rows; 1,941 (69.7%) attributed; 842 `(none)`; retained-catalog names lead the distribution |
+| Terminal signal population is empty | `cat .moai/evolution/telemetry/usage-*.jsonl \| jq -s '[.[] \| select(.is_test_pass == true or .is_test_fail == true)] \| length'` | `0` |
+| Root cause is hook registration | `jq -r '.hooks.PostToolUse[] \| {matcher, cmds:[.hooks[].command]}' .claude/settings.json` | `handle-post-tool.sh` registered for `Write\|Edit\|MultiEdit` only; `handle-harness-observe.sh` for `matcher: null` |
+
+### A.2 Existing plumbing this SPEC builds on
+
+| Surface | Path | Role here |
+|---|---|---|
+| Ledger schema + finalize | `internal/harness/routing/types.go` | `Row`, `PendingRow`, `Delegation`, `EvidenceRef`, `PendingRow.Finalize` — consumed unchanged |
+| Pending store | `internal/harness/routing/pending.go` | `Record` (sweeps + reroutes self), `sweepStale` (age + liveness guards), `AppendEvidence`, `AppendDelegation`, `FinalizeOnStop` |
+| Reader | `internal/harness/routing/reader.go` | `NewReader(path).Read(filter)` — not used by L1; the L2 consumer's entry point |
+| CLI ledger verbs | `internal/cli/harness_ledger.go` | `record` / `evidence` / `list`; registered by `newHarnessLedgerCmd()` at `internal/cli/harness_route.go:144` |
+| Stop finalizer | `internal/cli/hook.go` `finalizeRoutingLedgerOnStop` | gate 0 (`isHookOptInEnabled`, fail-closed) → gate 1 (`isHarnessLearningEnabled`, fail-open) → finalize |
+| Evidence writer | `internal/hook/evidence_writer.go` | `buildEvidenceRecord` / `buildBashRecord` / `classifyTestCommand`; reached only from `logEvidence` (`internal/hook/post_tool.go:224`) |
+| Session evidence load | `internal/telemetry/recorder.go` `LoadBySession` | reads exactly two whole day-files (today + yesterday) |
+| Observe channel | `internal/cli/hook.go` `runHarnessObserve` | PostToolUse handler behind `handle-harness-observe.sh` (`matcher: null`); today records only `Subject = ToolName` |
+| Hook input | `internal/hook/types.go` | `Prompt`, `SessionID`, `AgentType`, `AgentName`, `AgentID`, `ToolInput`, `ToolResponse` |
+
+## §B. Known issues the plan must not reintroduce
+
+- **B1 — reroute flood.** `Store.Record` finalizes the session's own prior pending row as `reroute` (`rerouteSelf`). A hook calling `Record` on every user prompt would close a pending row every turn, reproducing exactly the `reroute`-only ledger observed today. This is why REQ-HLE-003/004 exist.
+- **B2 — sweep on the hot path.** `sweepStale` does an `os.ReadDir` plus one `loadPending` read per foreign pending file plus a liveness lookup. Under `Record` it runs once per dispatch; wiring it into a per-prompt `RecordIfAbsent` would convert it into a per-prompt cost. REQ-HLE-015 forbids that.
+- **B3 — frozen/template surface.** `.claude/settings.json` is rendered from `internal/template/templates/.claude/settings.json.tmpl`, and `.claude/skills/moai/SKILL.md` is both a frozen pattern and template-managed. Editing either drags in the Template-First cycle (`make build` + mirror) and the §25 internal-content isolation doctrine. §E D2 chooses a path that avoids both.
+- **B4 — inert by default.** Gate 0 is fail-closed and default OFF. Every L1 path ships inert for distributed users; the repository must opt in to gather data. This is correct behavior, not a defect — but it means "no rows appeared" is ambiguous unless the gate state is checked first.
+- **B5 — reading the wrong identity field.** The derived `subject` field is `unknown` on all 2,783 observed `subagent_stop` rows. `agent_type` is the populated field. A seam reading `subject` would produce a ledger full of `unknown` delegations that looks structurally healthy.
+
+## §C. Pre-flight
+
+1. Confirm the worktree is `feat/harness-learning-evo` and `git status` is clean of foreign edits.
+2. `go build ./...` and `GOOS=windows GOARCH=amd64 go build ./...` green before the first edit (baseline attribution).
+3. `golangci-lint run --timeout=2m 2>&1 | tail -5` — record the pre-existing baseline so NEW findings are separable.
+4. Record the primary checkout's current ledger row count and telemetry test-signal count so a post-change delta is attributable.
+
+## §D. Constraints
+
+- Additive only within ledger schema v1 (REQ-HLE-014).
+- Fail-open on every hook seam; gates re-checked at each seam, matching `finalizeRoutingLedgerOnStop`'s existing pattern.
+- No `AskUserQuestion` in any new file (subagent boundary; `internal/harness/routing/subagent_boundary_test.go` already guards the routing package).
+- No template edits, no `.claude/settings.json` edit, no `delegation.yaml` read or write, no frozen-allowlist edit.
+- Do not touch runtime-managed files (`.moai/harness/*`, `.moai/state/*`, `.moai/evolution/*`).
+
+## §E. Decisions carried into audit
+
+Two decisions are contested and are stated here rather than buried in a milestone.
+
+### D1 — `matched_subcommand` write policy: **first-writer-wins**
+
+A session running `/moai plan` and then `/moai run` produces both literals against one pending row, because the row only finalizes on a terminal signal. `Store.Annotate`'s stated semantics (REQ-HLE-005) is that a non-empty value overwrites, so the seam must state its own policy explicitly.
+
+**Chosen: first-writer-wins.** Delegations accumulated before the second literal arrived were spawned under the first subcommand; overwriting the label retroactively re-attributes observations that were never made under the new label. It also keeps the seam idempotent, which is the same invariant REQ-HLE-003 protects. The cost is that a plan-then-run session attributes its run-phase delegations to `plan` — recorded as residual risk R5 and as the driver for the deferred per-subcommand row split (`spec.md` §G). The downstream consumer must therefore treat one row as one subcommand observation, which `SPEC-HARNESS-LEARNING-EVO-002` states explicitly.
+
+### D2 — terminal-signal source: extend the observe handler, do not edit settings
+
+`spec.md` §A.6 establishes that `buildBashRecord` is unreachable because `handle-post-tool.sh` is registered for `Write|Edit|MultiEdit` only. Three paths were considered.
+
+| Option | Verdict |
+|---|---|
+| **(a)** Add `Bash` to the `handle-post-tool.sh` matcher | Rejected as first choice. `.claude/settings.json` is rendered from `internal/template/templates/.claude/settings.json.tmpl`, so this triggers the Template-First cycle and the §25 neutrality doctrine — exactly what REQ-HLE-011's boundary exists to avoid. It also switches the whole Stop evidence gate on for every distributed user, a blast radius far beyond this SPEC. |
+| **(b)** Derive the signal from the harness-observe channel as it stands | **Refuted by inspection.** `runHarnessObserve` (`internal/cli/hook.go`) builds `harness.Event{EventType: agent_invocation, Subject: hookInput.ToolName}` and discards `ToolInput` and `ToolResponse` entirely. The channel *is* registered for Bash (`matcher: null`), but the handler carries neither the command text nor the outcome. Option (b) as originally framed does not work. |
+| **(c)** Extend `runHarnessObserve` to also assemble the evidence record, scoped to Bash | **Chosen.** The wrapper already receives the full Bash PostToolUse payload; only the handler discards it. Calling the existing `buildEvidenceRecord` path for `ToolName == "Bash"` is a pure Go change — no `settings.json` edit, no template edit, so REQ-HLE-011's boundary holds. Scoping to Bash also avoids a double write, since `Write`/`Edit` are already covered by `handle-post-tool.sh`. Requires exporting a small entry point from package `hook`, because `buildEvidenceRecord` and `logEvidence` are unexported. |
+
+**Unverified premise, gated by M0.** Option (c) assumes the Bash PostToolUse payload delivered on the matcher-null wrapper carries `tool_input.command` and `tool_response`. Registration for Bash is verified; the payload content on that channel is a documented Claude Code contract but was not runtime-observed here. M0 settles it before M4 is written. **If M0 falsifies the premise, fall back to option (a)** and pay the Template-First cost explicitly: edit `internal/template/templates/.claude/settings.json.tmpl`, run `make build`, mirror to `.claude/settings.json`, and re-check §25 neutrality — and state in the run-phase report that REQ-HLE-011's no-template boundary was traded away deliberately, not overlooked.
+
+## §F. Milestones
+
+Ordered by decision-reversibility. M0 and M1 carry the decisions most likely to change; M4 is mechanical.
+
+### M0 — Probe the terminal-signal premise (gate on §E D2)
+
+- Enable the local hook opt-in gate, run a single Bash test command in a live session, and capture what the harness-observe wrapper actually receives (the wrapper's stdin, or an equivalent instrumented capture in the handler).
+- **Decision gate**: does the captured payload carry a non-empty `tool_input.command` and a `tool_response`?
+  - **Yes** → proceed with option (c); M4 seam C is a Go-only change.
+  - **No** → proceed with option (a); add the Template-First steps to M4 and record the boundary trade in `progress.md`.
+- Do not begin M4 before this gate resolves. M1-M3 are independent of it and may proceed in parallel.
+
+### M1 — Seam semantics and store API (highest change-likelihood)
+
+The genuinely contested design decision: what a pending row's lifecycle is under mechanical emission.
+
+- Add `Store.RecordIfAbsent(PendingRow) error` — creates a pending row only when the session has none; a no-op otherwise. **Does not run `sweepStale`** (REQ-HLE-015, B2) and never calls `rerouteSelf` (REQ-HLE-004).
+- Add `Store.Annotate(sessionID string, patch RoutingPatch) error` — patches routing metadata onto an existing pending row; no create, no finalize; empty fields leave existing values untouched (REQ-HLE-005).
+- `RoutingPatch` is a new value type in `routing/types.go` carrying the six annotatable fields as optional values.
+- `Store.Record` is left untouched — sweep, reroute-on-redispatch, and both sweep guards keep their current behavior, which AC-HLE-001 and AC-HLE-003 pin.
+- Add `moai harness ledger annotate` to `internal/cli/harness_ledger.go`, flag set mirroring `record` minus stdin.
+
+**Why first:** every later milestone binds to this API, and a wrong lifecycle choice here reproduces B1 invisibly.
+
+### M2 — Delegation identity and outcome contract
+
+- Define the absent-identity marker as an exported constant in `routing/types.go` — a non-empty sentinel distinct from every retained-catalog agent name (REQ-HLE-008). It must be recognizable downstream, so it is a declared constant, not an ad-hoc string at the call site.
+- Define the unknown-outcome marker likewise (REQ-HLE-009), reusing the existing outcome vocabulary where one already fits.
+- Record in the package doc comment that `agent` holds `agent_type` verbatim and may be a spawn name rather than an agent type (`spec.md` §A.5 caveat 2), so a future reader does not mistake the field for a validated enum.
+
+### M3 — Bash evidence reachability
+
+Chosen path per §E D2 option (c), subject to M0.
+
+- Export a minimal entry point from package `hook` (e.g. `hook.LogEvidenceFor(input)`) wrapping the existing `logEvidence`, so `internal/cli` can call the assembled-record path without duplicating classification logic.
+- In `runHarnessObserve`, after the existing gate checks, call it **only when `hookInput.ToolName == "Bash"`** — the Write/Edit/MultiEdit cases stay owned by `handle-post-tool.sh`, so no record is written twice (REQ-HLE-011, AC-HLE-013).
+- Leave the existing `harness.Event` recording untouched; this is additive.
+
+### M4 — L1 wiring: the three mechanical seams
+
+New file `internal/hook/routing_ledger.go` holding the seam helpers, so the three handler files take minimal diffs.
+
+- **Seam A — UserPromptSubmit.** Gate 0 → gate 1 → `RecordIfAbsent` with digest/class derived from `input.Prompt`; `matched_subcommand` set from a literal `/moai <sub>` prefix only when currently empty (REQ-HLE-002/003/006, §E D1).
+- **Seam B — SubagentStop.** Gate 0 → gate 1 → `AppendDelegation{Agent: agentTypeOrMarker(input), Outcome: observedOutcomeOrUnknown(input), Blocker: nil}` (REQ-HLE-007/008/009).
+- **Seam C — Stop.** In `internal/cli/hook.go`, immediately before `finalizeRoutingLedgerOnStop`, append a terminal `gate_exit` evidence ref when `telemetry.LoadBySession` reports an observed test pass or fail for the session (REQ-HLE-010). Absence of a signal appends nothing.
+- All three swallow errors into the diagnostic sink (REQ-HLE-012) and no-op when either gate is closed (REQ-HLE-013).
+
+### M5 — Verification and dogfood
+
+- Full-suite run plus the §D quality gate of `acceptance.md`.
+- Manual dogfood check for R1: enable the opt-in, run one real `/moai` dispatch with at least one subagent, read the resulting ledger row, and record the observed row in `progress.md` §E.2. This is the only evidence that the live hook dispatch reaches the seams, and it is manual by construction.
+
+## §G. Anti-patterns
+
+- **AP-1 — reroute-per-prompt.** Calling `Store.Record` from the UserPromptSubmit seam. Reproduces the observed failure exactly and looks like success (rows appear).
+- **AP-2 — sweep-per-prompt.** Calling `sweepStale` from `RecordIfAbsent` "for symmetry with `Record`". Converts a once-per-dispatch directory scan into a once-per-prompt one (B2).
+- **AP-3 — inferred success.** Defaulting a stopping subagent's delegation outcome to `success` because no failure was seen. Absence of a failure signal is not evidence of success.
+- **AP-4 — instruction patch.** "Fixing" emission by strengthening the wording in `.claude/skills/moai/SKILL.md`. That is the mechanism that already failed (`spec.md` §A.2), and it drags in the frozen/template surface.
+- **AP-5 — live-data AC.** Writing an acceptance criterion that reads `.moai/state/routing-ledger.jsonl` or `.moai/evolution/telemetry/*.jsonl` and asserts content. Both are gitignored runtime state, gate-dependent, and empty in CI.
+- **AP-6 — reading `subject`.** Taking the delegation's agent from the derived `subject` field, which is `unknown` on 100% of observed rows (B5).
+- **AP-7 — silent identity normalization.** Mapping an unrecognized `agent_type` onto a catalog name, or dropping the entry, at the seam. The seam records verbatim; discrimination is the consumer's job.
+- **AP-8 — double evidence write.** Calling the evidence path from the observe handler for `Write`/`Edit` as well as `Bash`, producing two telemetry records for one tool call.
+
+## §H. Deferred / follow-up (not in this SPEC)
+
+- The L2 analyzer — `SPEC-HARNESS-LEARNING-EVO-002`.
+- Ledger schema v2 with an injected-skills field, which would unlock skill-level proposals.
+- Per-subcommand row splitting, which would retire the first-writer-wins approximation (§E D1).
+- Widening the Bash evidence path beyond the observe-channel carve-out (i.e. option (a) on its own merits), which would switch the Stop evidence gate on for distributed users.
+
+## §I. File inventory (run phase)
+
+| Path | Change |
+|---|---|
+| `internal/harness/routing/types.go` | edit — `RoutingPatch`, absent-identity + unknown-outcome constants |
+| `internal/harness/routing/pending.go` | edit — `RecordIfAbsent`, `Annotate` |
+| `internal/harness/routing/pending_test.go` | edit — lifecycle, sweep-guard, and no-sweep-on-create tests |
+| `internal/cli/harness_ledger.go` | edit — `annotate` verb |
+| `internal/cli/harness_route.go` | (no change — `newHarnessLedgerCmd()` is already registered at line 144; the new verb attaches inside the ledger command) |
+| `internal/hook/evidence_writer.go` | edit — exported entry point wrapping `logEvidence` |
+| `internal/hook/routing_ledger.go` | new — three seam helpers + gates |
+| `internal/hook/routing_ledger_test.go` | new |
+| `internal/hook/user_prompt_submit.go` | edit — seam A call |
+| `internal/hook/subagent_stop.go` | edit — seam B call |
+| `internal/cli/hook.go` | edit — Bash carve-out in `runHarnessObserve`; seam C before the finalizer |
+| `internal/cli/hook_test.go` | edit — observe-channel Bash evidence + end-to-end terminal close |
+| `internal/telemetry/recorder_test.go` | edit — two-day window assertion |
+
+Roughly 13 files, of which 9 are edits. No template files, no `.claude/` files (unless M0 forces option (a), which adds `internal/template/templates/.claude/settings.json.tmpl` and its mirror).
+
+## §J. Tier classification
+
+**Tier M.** Per `.claude/rules/moai/workflow/spec-workflow.md` § SPEC Complexity Tier, the scope-based table places Tier M at 300-1000 LOC and 5-15 files affected; this SPEC's inventory is ~13 files and the change is well under 1000 LOC of production code. The requirement and acceptance-criterion counts (16 and 16) sit exactly at the Tier M ceiling, which is the binding constraint that motivated the split from the original 33/36 SPEC. Tier M carries the 3-artifact set (spec.md + plan.md + acceptance.md) plus `progress.md`, and a plan-auditor PASS threshold of 0.80.
+
+## §K. Cross-references
+
+- `SPEC-HARNESS-LEARNING-EVO-002` — the L2 consumer of the rows this SPEC produces
+- `.moai/reports/moai-autonomy-workflow-redesign-20260803.html` §2.5, §5 row P3
+- `.claude/rules/moai/workflow/spec-workflow.md` § SPEC Complexity Tier — the REQ/AC budget that forced the split
+- `.claude/rules/moai/core/verification-claim-integrity.md` — the §E falsification discipline and the M0 probe gate
+- `CLAUDE.local.md` §2 (Template-First), §25 (template isolation) — the cost §E D2 option (c) avoids

--- a/.moai/specs/SPEC-HARNESS-LEARNING-EVO-001/progress.md
+++ b/.moai/specs/SPEC-HARNESS-LEARNING-EVO-001/progress.md
@@ -100,6 +100,19 @@ Every row was decided by running its own command in this worktree at `637f9a65f`
 
 Coverage on the touched packages: `internal/harness/routing` 88.5%, `internal/hook` 83.9%, `internal/telemetry` 82.7%, `internal/cli` 76.5%. The first three clear the 85% package target or sit near it; `internal/cli` is a large pre-existing package whose baseline this SPEC did not move materially.
 
+`go test -race ./internal/harness/routing/ ./internal/telemetry/ -count=1` also passes, which is the meaningful race surface here — the new store operations are the only concurrency-adjacent code this SPEC adds.
+
+### One observed failure, diagnosed and attributed
+
+`internal/cli/wizard` `TestUnifiedForm_ManualModeSkipsConditionals` failed **once**, during the multi-package coverage run (`go test -cover ./internal/harness/... ./internal/hook/... ./internal/cli/...`). It is not attributable to this SPEC, and the reason is structural rather than a judgement call:
+
+- It does not reproduce. `-count=5`, `-count=20`, and `-race` on the package all pass, as does the package alone under `-cover`.
+- The package is `internal/cli/wizard`, which this SPEC does not touch and which does not reach the routing seams.
+- The mechanism is a fixed wall-clock deadline in the test's own driver: `execBoundedCmd` (`internal/cli/wizard/unified_form_test.go:60`) waits **50 ms** for a bubbletea command and returns `nil` on timeout, silently dropping the message. Under the contention of a multi-package coverage run a command can exceed 50 ms, a state transition is lost, and the form never reaches `StateCompleted` — exactly the assertion that failed.
+- The same multi-package coverage command run against the pre-SPEC base commit `5a929480a` (extracted via `git archive` into a scratch tree) also reported `FAIL github.com/modu-ai/moai-adk/internal/cli`, so the baseline is not clean under that load either.
+
+The full suite without coverage instrumentation — `go test ./... -count=1`, the §D gate command — exits 0 with zero `FAIL` lines.
+
 ### Gaps — what was NOT verified
 
 - **The live hook-dispatch link (R1).** No CI-runnable assertion covers "Claude Code actually invokes these handlers in a real session". The M0 probe proves the *payload* reaches a matcher-null PostToolUse wrapper; it does not exercise the UserPromptSubmit or SubagentStop wrappers, nor the seams behind them. The manual dogfood check named in `plan.md` §F M5 — enable the opt-in, run one real `/moai` dispatch with a subagent, read the resulting row — was **not performed**, because it requires enabling a fail-closed gate in the primary checkout, which is outside this worktree's write boundary.

--- a/.moai/specs/SPEC-HARNESS-LEARNING-EVO-001/progress.md
+++ b/.moai/specs/SPEC-HARNESS-LEARNING-EVO-001/progress.md
@@ -13,11 +13,128 @@ _<pending plan-audit>_
 
 ## §E.2 Run-phase Evidence
 
-_<pending run-phase>_
+### M0 — the terminal-signal probe (plan.md §E D2 decision gate)
+
+**Verdict: option (c). The premise held; no `settings.json` or template edit was needed.**
+
+The primary checkout's wrapper could not be instrumented (that would write outside this worktree), so the probe used a throwaway project with a `.claude/settings.json` registering a single PostToolUse entry with **no matcher** — structurally identical to how `handle-harness-observe.sh` is registered — pointing at a capture script that appends raw stdin to a file.
+
+Command (Claude Code 2.1.226):
+
+```
+claude -p "Run exactly this shell command with the Bash tool and nothing else: echo M0PROBE-OK" \
+  --permission-mode acceptEdits --model claude-haiku-4-5-20251001
+```
+
+Observed payload, verbatim (one JSONL line, pretty-printed here):
+
+```json
+{
+  "session_id": "f7a781f1-728c-478e-aa35-bdce34fb406c",
+  "cwd": "/private/tmp/.../m0probe",
+  "permission_mode": "acceptEdits",
+  "hook_event_name": "PostToolUse",
+  "tool_name": "Bash",
+  "tool_input": { "command": "echo M0PROBE-OK", "description": "Run the specified echo command" },
+  "tool_response": { "stdout": "M0PROBE-OK", "stderr": "", "interrupted": false, "isImage": false, "noOutputExpected": false },
+  "tool_use_id": "toolu_01NpG6muqBX19PUbqpookSFz",
+  "duration_ms": 462
+}
+```
+
+Both fields the gate asks about — `tool_input.command` and `tool_response` — are present and non-empty. `runHarnessObserve` discards them at the **handler**, exactly as plan.md §E D2's refutation of option (b) states; the wrapper does receive them.
+
+Two observations the plan did not anticipate, recorded because they change what the code can rely on:
+
+1. **The payload arrives flat snake_case, not nested camelCase.** `normalizeHookInput` returns unchanged when `session_id` is present, so this is the already-flat pass-through path. plan.md §A.2's implication that camelCase is the native shape does not match 2.1.226 on this channel. The observed shape is pinned in `internal/cli/hook_routing_ledger_test.go` `bashPostToolPayload`.
+2. **`tool_response` carries no `exit_code`.** A second probe on a failing in-workspace command (`grep NOPE_ZZZ data.txt`) returned `{"stdout":"","stderr":"","interrupted":false,"isImage":false,"returnCodeInterpretation":"No matches found","noOutputExpected":false}`. `classifyTestCommand` tries `deriveFromExitCode` first and falls back to `deriveFromOutputText`; with no exit-code key the structured path cannot fire on this channel, so pass/fail rests on the output-text heuristic. This does not block option (c) — REQ-HLE-010's "absence appends nothing" already covers the ambiguous case — but it is recorded as residual risk R7 below.
+
+Third probe, recorded so a later reader does not misread an empty capture as a falsified premise: a Bash call **blocked by permissions** fires no PostToolUse at all (the capture file was never created).
+
+### Milestone commits
+
+| Milestone | Commit | Content |
+|---|---|---|
+| M1 + M2 | `038bcc4fc` | `RecordIfAbsent` / `Annotate` / `RoutingPatch`, identity + outcome markers, `ledger annotate` verb |
+| M3 | `631c9aa1c` | `hook.LogBashEvidence` + the Bash carve-out in `runHarnessObserve` |
+| M4 | `637f9a65f` | the three seams, gate deduplication into package `hook`, handler wiring |
+
+### AC PASS/FAIL matrix
+
+Every row was decided by running its own command in this worktree at `637f9a65f`. `ok <pkg> <t>` is the verbatim `go test` tail.
+
+| AC | Status | Deciding command | Observed |
+|---|---|---|---|
+| AC-HLE-001 | PASS | `go test ./internal/harness/routing/ -run 'TestRecordIfAbsent_Lifecycle\|TestRecord_StillReroutesSelf' -count=1` | `ok …/internal/harness/routing 0.344s` |
+| AC-HLE-002 | PASS | `go test ./internal/harness/routing/ -run TestRecordIfAbsent_NoSweepOnCreatePath -count=1` ; `go test ./internal/telemetry/ -run TestLoadBySession_TwoDayWindow -count=1` | `ok …/routing 0.345s` ; `ok …/telemetry 0.343s` |
+| AC-HLE-003 | PASS | `go test ./internal/harness/routing/ -run TestSweepStale_AgeAndLivenessGuards -count=1` | `ok …/routing 0.329s` |
+| AC-HLE-004 | PASS | `go test ./internal/harness/routing/ -run TestAnnotate -count=1` ; `go test ./internal/cli/ -run TestHarnessLedgerAnnotateCmd -count=1` | `ok …/routing 0.335s` ; `ok …/cli 1.420s` |
+| AC-HLE-005 | PASS | `go test ./internal/harness/routing/ -run 'TestSchemaVersionStable\|TestReader' -count=1` | `ok …/routing 0.343s` |
+| AC-HLE-006 | PASS | `go test ./internal/hook/ -run TestRoutingSeam_UserPromptSubmit_CreatesPending -count=1` | `ok …/hook 0.570s` |
+| AC-HLE-007 | PASS | `go test ./internal/hook/ -run TestRoutingSeam_NoRawPromptPersisted -count=1` | `ok …/hook 0.760s` |
+| AC-HLE-008 | PASS | `go test ./internal/hook/ -run TestRoutingSeam_MultiTurnNoReroute -count=1` | `ok …/hook 0.653s` |
+| AC-HLE-009 | PASS | `go test ./internal/hook/ -run TestRoutingSeam_LiteralSubcommandFirstWriterWins -count=1` | `ok …/hook 0.676s` |
+| AC-HLE-010 | PASS | `go test ./internal/hook/ -run TestRoutingSeam_SubagentStop_AgentTypeVerbatim -count=1` | `ok …/hook 0.671s` |
+| AC-HLE-011 | PASS | `go test ./internal/hook/ -run TestRoutingSeam_AbsentAgentTypeMarker -count=1` | `ok …/hook 0.745s` |
+| AC-HLE-012 | PASS | `go test ./internal/hook/ -run TestRoutingSeam_UnknownOutcomeNotSuccess -count=1` | `ok …/hook 0.575s` |
+| AC-HLE-013 | PASS | `go test ./internal/cli/ -run TestHarnessObserve_BashEvidenceRecorded -count=1` ; `go test ./internal/hook/ -run TestEvidenceRecord_NoDoubleWriteOnEdit -count=1` | `ok …/cli 0.947s` ; `ok …/hook 0.622s` |
+| AC-HLE-014 | PASS (bounded — see R1) | `go test ./internal/cli/ -run TestRoutingLedger_TerminalCloseEndToEnd -count=1` | `ok …/cli 1.091s` |
+| AC-HLE-015 | PASS | `go test ./internal/hook/ -run TestRoutingSeam_FailOpen -count=1` | `ok …/hook 0.651s` |
+| AC-HLE-016 | PASS | `go test ./internal/hook/ -run TestRoutingSeam_GatedOffWritesNothing -count=1` | `ok …/hook 0.648s` |
+
+**AC-HLE-014 is bounded, not unconditional.** It drives the production handler functions against a temp root and proves the seam sequence closes a row end to end. It does NOT prove Claude Code invokes those handlers in a live session — the R1 gap in `acceptance.md` §F. That link is unverified here; see the Gaps section below.
+
+### §D quality gate
+
+| Check | Command | Observed |
+|---|---|---|
+| Build | `go build ./...` | exit 0 |
+| Cross-platform build | `GOOS=windows GOARCH=amd64 go build ./...` | exit 0 |
+| Full suite | `go test ./... -count=1` | exit 0, 0 `FAIL` lines |
+| Vet | `go vet ./...` | exit 0, no output |
+| Lint | `golangci-lint run --timeout=6m` | `0 issues.` (pre-change baseline was also `0 issues.`) |
+| SPEC lint | `moai spec lint …/spec.md --strict` | `✓ No findings — all SPEC documents are valid` |
+| No template / frozen-skill / frozen-allowlist path | `git diff --name-only 5a929480a...HEAD \| grep -cE '^(internal/template/templates/\|\.claude/skills/\|\.claude/lsel/)'` | `0` |
+| No delegation.yaml reader or writer | `grep -rn 'delegation.yaml' internal/ --include='*.go' \| grep -v _test` | no output |
+| No AskUserQuestion in the seam file | `grep -rn 'AskUserQuestion' internal/hook/routing_ledger.go` | no output |
+
+Coverage on the touched packages: `internal/harness/routing` 88.5%, `internal/hook` 83.9%, `internal/telemetry` 82.7%, `internal/cli` 76.5%. The first three clear the 85% package target or sit near it; `internal/cli` is a large pre-existing package whose baseline this SPEC did not move materially.
+
+### Gaps — what was NOT verified
+
+- **The live hook-dispatch link (R1).** No CI-runnable assertion covers "Claude Code actually invokes these handlers in a real session". The M0 probe proves the *payload* reaches a matcher-null PostToolUse wrapper; it does not exercise the UserPromptSubmit or SubagentStop wrappers, nor the seams behind them. The manual dogfood check named in `plan.md` §F M5 — enable the opt-in, run one real `/moai` dispatch with a subagent, read the resulting row — was **not performed**, because it requires enabling a fail-closed gate in the primary checkout, which is outside this worktree's write boundary.
+- **A live `is_test_fail` signal end to end.** The failing direction is covered by unit tests driving the production path with a fixture, but no observed live run has produced `is_test_fail` through the restored carve-out.
+- **The falsification review (`spec.md` §E F1/F2).** Needs 50 finalized rows, which do not exist at merge time. Scheduled, not performed — as `acceptance.md` §E already states.
+
+### Residual risk
+
+R1-R6 stand as written in `acceptance.md` §F. One is added by the M0 measurement:
+
+- **R7 — the terminal signal rests on an output-text heuristic, not a structured exit code.** The observe channel's `tool_response` carries no `exit_code`, so `deriveFromExitCode` cannot fire and pass/fail detection falls to `deriveFromOutputText`'s marker matching (`ok  \t`, `--- FAIL`, `test result:`, and a `passed`/`failed` word count). A test runner whose output matches none of those yields no signal, the row stays pending, and it closes later as `abort` via the stale sweep rather than as `fail`. The live yield of terminal `success`/`fail` rows may therefore be lower than the code path suggests, and that will only be measurable once rows accumulate.
 
 ## §E.3 Run-phase Audit-Ready Signal
 
-_<pending run-phase>_
+```yaml
+run_complete_at: 2026-08-10
+run_commit_sha: 637f9a65f
+run_status: audit-ready
+ac_pass_count: 16
+ac_fail_count: 0
+preserve_list_post_run_count: 0
+new_warnings_or_lints_introduced: 0
+cross_platform_build:
+  darwin_amd64: pass
+  windows_amd64: pass
+total_run_phase_files: 15
+m1_to_mN_commit_strategy: "four milestones in three commits — M1+M2 share 038bcc4fc because the identity markers live in the same file as the store types; M3 is 631c9aa1c; M4 is 637f9a65f. M0 produced no commit: it is a probe, and its result is recorded in §E.2 rather than in code."
+```
+
+Notes for the auditor:
+
+- **M0 changed nothing in the plan.** The probe confirmed option (c), so the declared option (a) fallback — a `settings.json.tmpl` edit plus `make build`, plus the §25 neutrality re-check — was never entered. No template file, frozen skill, or frozen allowlist was touched.
+- **One deviation from `plan.md` §I's file inventory.** The inventory anticipated edits to `internal/cli/hook_test.go` and `internal/telemetry/recorder_test.go`; the CLI-side tests landed in a new file `internal/cli/hook_routing_ledger_test.go` instead, because `hook_test.go` is a small unrelated file and appending an unrelated 300-line fixture set to it would have obscured both. The telemetry edit landed as planned.
+- **One addition beyond the inventory**, made to avoid a defect rather than for tidiness: the two observation gates existed only in `internal/cli`, which `internal/hook` cannot import. Copying them would have created two truth tables that could drift — and a drift between them is exactly the class of failure this SPEC is repairing elsewhere. The implementations moved down into `internal/hook` (`HarnessLearningEnabled`, `HookObserveOptInEnabled`) and the CLI functions became thin delegating wrappers, so every existing call site and test is unchanged.
+- **`Store.LoadPending` was exported**, which `plan.md` §I did not list. The first-writer-wins policy (REQ-HLE-006, §E D1) requires the seam to ask "is this field still empty?", and §E D1 explicitly places that policy at the seam rather than in the store — so the seam needs a read primitive. Baking the policy into `Annotate` was the alternative and was rejected for that reason.
 
 ## §E.4 Sync-phase Audit-Ready Signal
 

--- a/.moai/specs/SPEC-HARNESS-LEARNING-EVO-001/progress.md
+++ b/.moai/specs/SPEC-HARNESS-LEARNING-EVO-001/progress.md
@@ -1,0 +1,24 @@
+# SPEC-HARNESS-LEARNING-EVO-001 — Progress
+
+## §E.1 Plan-phase Audit-Ready Signal
+
+- Artifacts: `spec.md`, `plan.md`, `acceptance.md`, `progress.md` authored at `status: draft`, Tier M.
+- Scope: **L1 only** (instrumentation repair). The L2 analyzer was split out to `SPEC-HARNESS-LEARNING-EVO-002`; L3 (application to `delegation.yaml`) remains an explicit non-goal with its three-surface rationale.
+- Split rationale: the v0.1.0 SPEC carried 33 requirements and 36 acceptance criteria, over the ceiling at Tier M (16/16) and Tier L (25/25). Per `.claude/rules/moai/workflow/spec-workflow.md` § SPEC Complexity Tier, exceeding either ceiling is a signal to split, not to relax the budget.
+- Requirements: 16 GEARS requirements (REQ-HLE-001..016); 16 acceptance criteria with 100% requirement coverage (`acceptance.md` §G). Both counts are exactly at the Tier M ceiling.
+- Material changes on new measurement: agent identity now reads `agent_type` rather than the derived `subject` (`spec.md` §A.5), and the terminal-signal source changed after the root cause of the empty signal population was determined to be hook registration (`spec.md` §A.6, `plan.md` §E D2).
+- Open decisions carried into audit: the `matched_subcommand` write policy (`plan.md` §E D1 — first-writer-wins) and the terminal-signal source (`plan.md` §E D2 — option (c), gated by the M0 probe with option (a) as the declared fallback).
+
+_<pending plan-audit>_
+
+## §E.2 Run-phase Evidence
+
+_<pending run-phase>_
+
+## §E.3 Run-phase Audit-Ready Signal
+
+_<pending run-phase>_
+
+## §E.4 Sync-phase Audit-Ready Signal
+
+_<pending sync-phase>_

--- a/.moai/specs/SPEC-HARNESS-LEARNING-EVO-001/spec.md
+++ b/.moai/specs/SPEC-HARNESS-LEARNING-EVO-001/spec.md
@@ -1,0 +1,113 @@
+---
+id: SPEC-HARNESS-LEARNING-EVO-001
+title: "Routing-ledger instrumentation repair (L1) — mechanical emission of delegation observations"
+version: "0.2.0"
+status: draft
+created: 2026-08-09
+updated: 2026-08-09
+author: manager-spec
+priority: P3
+phase: "v3.2 target"
+module: "internal/harness/routing"
+lifecycle: spec-anchored
+tags: "harness-learning, routing-ledger, instrumentation, mechanical-emission, hook-seams, meta-context-engineering, autonomy-epic"
+tier: M
+related_specs: [SPEC-HARNESS-LEARNING-EVO-002, SPEC-HARNESS-EVOLVE-001, SPEC-V3R6-HARNESS-PROPOSAL-GEN-001, SPEC-HARNESS-LOOP-REPAIR-001, SPEC-LSEL-LOCAL-EVOLUTION-001]
+---
+
+# SPEC-HARNESS-LEARNING-EVO-001 — Routing-ledger instrumentation repair (L1)
+
+## HISTORY
+
+- 2026-08-09 — Initial draft. P3 of the MoAI autonomy/workflow redesign roadmap (`.moai/reports/moai-autonomy-workflow-redesign-20260803.html` §5), applying §2.5 "Meta Context Engineering" (OpenReview P1jHroBS5E): the harness learning subsystem is MoAI's lower-level optimizer, evolving the delegation map from observed run outcomes instead of hand-tuned YAML.
+- 2026-08-09 — v0.2.0. **Split**: the original single SPEC carried 33 requirements and 36 acceptance criteria, over the Tier ceiling at both M (16/16) and L (25/25). Per `.claude/rules/moai/workflow/spec-workflow.md` § SPEC Complexity Tier ("Exceeding either ceiling is a signal to tier up or to split the SPEC, not to relax the budget"), the SPEC is split along the L1/L2 line it already drew in §C. This SPEC retains **L1 only** (instrumentation). The L2 analyzer moves to `SPEC-HARNESS-LEARNING-EVO-002`. Two requirements changed materially on new measurement: agent identity (§A.5) and the terminal-signal source (§A.6).
+
+## §A. Context — the measured starting state
+
+Six measurements establish the baseline. Every command is named in `plan.md` §A.1 so it can be re-run; measurements were taken against the **primary checkout** at `/Users/goos/MoAI/moai-adk-go` (the runtime state files below are gitignored and absent in the worktree where this SPEC is authored).
+
+- **A.1 — the observation channel is dry.** `.moai/state/routing-ledger.jsonl` holds 4 rows. Every row has `delegations: []` (length 0); outcomes are `abort` (3) and `reroute` (1). Not one successfully-routed delegation has ever been recorded. The sibling generated-artifact observer log `.moai/harness/usage-log.jsonl` holds 109,236 rows over the same period. The asymmetry is specific to the routing ledger, not to the harness.
+- **A.2 — the emission is instruction-dependent.** The only prescribed producer is the orchestrator invoking `moai harness ledger record` / `... evidence`, per `.claude/skills/moai/SKILL.md`. No Go code path emits either call. An instruction that must be remembered every dispatch is not emitted reliably, and the ledger's own contents are the evidence.
+- **A.3 — nothing writes the target file.** `grep -rn 'delegation.yaml' internal/ --include='*.go' | grep -v _test` returns zero matches. The learning loop declared in `.moai/config/sections/delegation.yaml`'s own header (`observe: routing-ledger`, `propose_via: harness-tier-ladder`, `auto_apply: false`) has a dry observe channel.
+- **A.4 — the proposal ladder itself works.** `internal/harness/proposalgen/` generates drafts; 73 proposal directories exist and `learning-history/tier-promotions.jsonl` carries 175 rows. Its input is `usage-log.jsonl` patterns, which carry no notion of delegation routing — which is why the consumer is a separate SPEC (`SPEC-HARNESS-LEARNING-EVO-002`) rather than an extension of the mapper.
+- **A.5 — agent identity IS observable, with two caveats.** Of 2,783 `subagent_stop` rows in `usage-log.jsonl`, 1,941 (69.7%) carry a non-empty `agent_type`, and its values include exactly the identities `delegation.yaml` designates: `manager-spec` 281, `manager-develop` 277, `plan-auditor` 201, `Explore` 129, `manager-docs` 122, `manager-git` 74, `sync-auditor` 31, `super-advisor` 7. The derived `subject` field is `unknown` on all 2,783 rows and is the wrong field to read. **Caveat 1**: 842 rows (30.3%) carry no `agent_type` at all. **Caveat 2**: a *named* spawn puts the NAME in `agent_type`, not the agent type — directly observed in this session, where a spawn of `subagent_type: plan-auditor` with `name: audit-hle` produced `{"event_type":"subagent_stop","subject":"unknown","agent_type":"audit-hle","agent_id":"aaudit-hle-19009f7b26a36428"}`. The long tail confirms it: `general-purpose` 204, `workflow-subagent` 186, plus ~140 distinct one- and two-occurrence values that are spawn names (`lens-*`, `rev-*`, `humanize-*`, `audit-*`) or user-owned harness specialists (`hns-*-specialist`, `cli-template-specialist`).
+- **A.6 — the terminal signal population is empty, and the root cause is hook registration.** Across every file in `.moai/evolution/telemetry/`, the count of records with `is_test_pass` or `is_test_fail` set is **0**. The cause is not classifier failure, decode failure, or a gate: `buildEvidenceRecord` (`internal/hook/evidence_writer.go:290`) is reached only from `logEvidence` (`internal/hook/post_tool.go:224`), which runs in the `moai hook post-tool` handler behind `handle-post-tool.sh` — and that wrapper is registered for `matcher: "Write|Edit|MultiEdit"` only. `buildBashRecord` (line 309) is therefore unreachable from the shipped hook wiring; execution never arrives. Confirmed by direct experiment: running `go test ./internal/harness/routing/...` left the day's telemetry file unchanged at 4,025 bytes, and every one of its records carries `tool_name: null` with `path_kind: docs-only` (file-edit records only).
+
+The blocker is therefore **data starvation, not a missing algorithm**, and it has two distinct causes: routing rows are never created mechanically (A.2), and the terminal signal that would close them is never produced (A.6).
+
+## §B. User Story
+
+As the maintainer of MoAI's harness, I want the routing ledger to accumulate rows that record which agents were actually spawned for which subcommand and how the run ended — derived mechanically from hook input rather than from an instruction the orchestrator must remember — so that a downstream analyzer has real observations to reason over instead of an empty file.
+
+## §C. Scope boundary
+
+- **In scope (L1 — instrumentation repair).** Make routing-ledger rows accumulate with useful content: a pending row created per routed session, `delegations[]` carrying real entries keyed on the observed agent identity, a terminal machine signal closing rows as `success`/`fail` rather than only `reroute`/`abort`, and the Stop-hook finalizer verified end to end.
+- **Out of scope (L2 — the analyzer).** Reading finalized rows, aggregating delegation patterns, and emitting delegation-map amendment proposals belong to `SPEC-HARNESS-LEARNING-EVO-002`. That SPEC consumes the rows this one produces, but is testable against fixtures without this SPEC being complete, so it is a sibling and not a dependency.
+- **Out of scope (L3 — application).** See §G.
+
+## §D. Requirements
+
+Notation: GEARS. `REQ-HLE-0xx`. Budget: 16 requirements (Tier M ceiling 16).
+
+### D.1 — Emission mechanics
+
+- **REQ-HLE-001** — The routing observation subsystem shall derive every ledger field it can from hook input rather than from an orchestrator instruction. An instruction-dependent emission path shall be treated as a fallback, never as the primary producer.
+- **REQ-HLE-002** — **When** a user prompt is submitted and both harness observation gates are open, the UserPromptSubmit hook shall ensure a pending routing row exists for the session, deriving `request_digest` and `request_class` from the prompt text through the existing `routing.RequestDigest` / `routing.ClassifyRequest` functions, and persisting no verbatim prompt text.
+- **REQ-HLE-003** — **While** a pending routing row already exists for the session, the UserPromptSubmit hook shall leave that row in place and shall not finalize it as `reroute`. A multi-turn pipeline spans many prompts, and a per-prompt reroute would close a row that has not finished being observed.
+- **REQ-HLE-004** — The routing store shall expose a create-if-absent recording operation distinct from the existing reroute-on-record operation, and that operation shall inherit both existing safety guards of the stale sweep unchanged: the 24-hour age guard (`routing.StalenessThreshold`) and the `active-sessions.json` liveness guard (`isSessionLive`). Together these are what protect a concurrent session's in-flight pending row from a false abort; pending files are per-session so they never contend, and the ledger is opened O_APPEND-only.
+- **REQ-HLE-005** — The routing store shall expose an annotation operation that patches routing metadata (`matched_subcommand`, `mode_selected`, `tier`, `harness_level`, `clarify_rounds`, `model_class`) onto an existing pending row without creating a row and without finalizing one; a supplied empty value shall leave the existing field unchanged. The operation shall also be reachable as a CLI verb alongside the existing `record` / `evidence` verbs.
+- **REQ-HLE-006** — **When** a submitted prompt begins with a literal `/moai <subcommand>` form, the UserPromptSubmit hook shall set `matched_subcommand` from that literal token **only if the field is currently empty** (first-writer-wins); a prompt carrying a different literal subcommand on a row already labelled shall leave the existing label unchanged. Otherwise the hook shall leave `matched_subcommand` empty for later annotation, and shall not guess a subcommand from natural-language text.
+
+### D.2 — Delegation and outcome observation
+
+- **REQ-HLE-007** — **When** a subagent stops and both harness observation gates are open, the SubagentStop hook shall append one `Delegation` entry to the session's pending routing row whose `agent` value is taken from the hook input's `agent_type` field verbatim, without normalization, mapping, or substitution of the derived `subject` field.
+- **REQ-HLE-008** — **When** a stopping subagent supplies no `agent_type` value, the SubagentStop hook shall still append the delegation entry, recording the absent identity under an explicit distinguishable marker that is not the empty string, so that an unattributed delegation is countable and never silently indistinguishable from an attributed one.
+- **REQ-HLE-009** — **When** no observable outcome signal is available for a stopping subagent, the SubagentStop hook shall record the delegation with an explicit unknown-outcome marker and a null blocker rather than inferring success.
+- **REQ-HLE-010** — **When** the Stop hook observes a terminal machine signal already classified by the existing session evidence path (an observed test pass or test failure for the session), it shall append a corresponding terminal `gate_exit` evidence reference to the pending routing row before running the existing finalizer, so that rows can close as `success` or `fail`. Absence of a signal shall append nothing; absence is not failure.
+- **REQ-HLE-011** — The system shall restore production reachability of the Bash evidence-record path (`buildBashRecord`), which §A.6 measured as unreachable from the shipped hook wiring, without which REQ-HLE-010 observes an empty signal population. The restoration shall be scoped so that no evidence record is written twice for a single tool call.
+
+### D.3 — Safety, budget, and boundaries
+
+- **REQ-HLE-012** — Every L1 emission path shall be fail-open: an error in recording, annotating, or appending shall be written to the hook's diagnostic sink and swallowed, and shall never block prompt submission, subagent shutdown, or session end.
+- **REQ-HLE-013** — **While** either harness observation gate is closed (the fail-closed hook opt-in, or the fail-open learning switch), no L1 emission path shall write to the ledger, to a pending row, or to any other file.
+- **REQ-HLE-014** — The routing ledger shall not gain a schema-breaking field in this SPEC; `schema_version` shall remain 1 and every existing consumer shall continue to parse existing rows unchanged.
+- **REQ-HLE-015** — Each L1 seam shall keep its total filesystem read count bounded and declared, covering every read on the seam path — the pending-row read and write, the stale sweep's directory scan and its per-foreign-file reads, and the session evidence path's two whole-file telemetry reads — so that the touched hook stays within the 5-second MoAI hook budget. The create-if-absent operation shall not run the stale sweep on every invocation; the sweep shall remain bounded to the dispatch path so that per-prompt emission does not convert a once-per-dispatch directory scan into a once-per-prompt one.
+- **REQ-HLE-016** — No raw user prompt text shall be persisted by any path introduced here; only the existing digest and coarse class shall be stored.
+
+## §E. Central assumption and its falsification
+
+The design rests on one assumption: **`delegations[]` measures delegation-map adherence.** The two caveats in §A.5 are the sharp edges.
+
+The assumption is falsified by either of the following, observed after the ledger has accumulated at least 50 finalized rows:
+
+- **F1 — the observation is an artifact.** The observed `agent_type` set is dominated by values that are not retained-catalog agent names (spawn names, `general-purpose`, `workflow-subagent`, user-owned harness specialists), so `delegations[]` measures spawn labelling rather than delegation-map adherence. Bound: fewer than half of the recorded delegation entries carry a retained-catalog name.
+- **F2 — attribution is too sparse.** The share of delegation entries recorded under the absent-identity marker (REQ-HLE-008) stays at or above the 30.3% measured in §A.5, meaning nearly a third of every subcommand's observation is unattributable and no per-agent count can be trusted.
+
+Recording these here is deliberate: both are outcomes this instrumentation can produce while working exactly as specified, and neither is a bug in the code.
+
+## §F. Downstream consumer
+
+`SPEC-HARNESS-LEARNING-EVO-002` reads the rows this SPEC produces and emits delegation-map amendment proposals through the existing Tier-4 approval gate. The coupling is one-directional and non-blocking: 002 is testable against synthetic fixtures generated from `routing.PendingRow.Finalize()`, so it neither waits on this SPEC nor gates it. The row shape is the contract between them, and REQ-HLE-014 freezes it.
+
+## §G. Exclusions
+
+### Out of Scope — the delegation analyzer (L2)
+
+- No aggregation of finalized rows, no threshold logic, no proposal emission, and no read of `.moai/config/sections/delegation.yaml`. All of it belongs to `SPEC-HARNESS-LEARNING-EVO-002`.
+
+### Out of Scope — automated application to delegation.yaml (L3)
+
+- No automated writer for `.moai/config/sections/delegation.yaml`. Three independent surfaces agree that this file requires human approval: `.claude/lsel/frozen-allowlist.json` lists `^\.moai/config/sections/` among its frozen patterns; the file's own `auto_apply: false` key; and the Tier-4 gate language of the roadmap report. This is a deliberate design boundary, not an oversight.
+- No modification of `.claude/lsel/frozen-allowlist.json` to make the file writable.
+
+### Out of Scope — ledger schema migration
+
+- No `schema_version: 2`. Every change here is additive within the existing row shape. Extending the row to record injected skills — which would unlock skill-level proposals — is recorded as a follow-up in `plan.md` §H.
+
+### Out of Scope — backfill of historical data
+
+- The four existing rows are left untouched. They predate the repaired instrumentation and carry no delegation content to recover.
+
+### Out of Scope — per-subcommand row splitting
+
+- A session that runs `/moai plan` then `/moai run` produces one row labelled by the first subcommand (REQ-HLE-006). Splitting such a session into one row per subcommand is a schema and lifecycle change deferred to a follow-up; the mislabel consequence is recorded in `acceptance.md` §F.

--- a/.moai/specs/SPEC-HARNESS-LEARNING-EVO-001/spec.md
+++ b/.moai/specs/SPEC-HARNESS-LEARNING-EVO-001/spec.md
@@ -2,9 +2,9 @@
 id: SPEC-HARNESS-LEARNING-EVO-001
 title: "Routing-ledger instrumentation repair (L1) — mechanical emission of delegation observations"
 version: "0.2.0"
-status: draft
+status: in-progress
 created: 2026-08-09
-updated: 2026-08-09
+updated: 2026-08-10
 author: manager-spec
 priority: P3
 phase: "v3.2 target"

--- a/.moai/specs/SPEC-HARNESS-LEARNING-EVO-002/acceptance.md
+++ b/.moai/specs/SPEC-HARNESS-LEARNING-EVO-002/acceptance.md
@@ -1,0 +1,174 @@
+# SPEC-HARNESS-LEARNING-EVO-002 — Acceptance Criteria (L2)
+
+Every criterion below names the command that decides it, and that command actually decides it. Budget: 16 criteria (Tier M ceiling 16).
+
+## §A. Verification conventions
+
+- **Go-test criteria** are decided by the named test function's pass/fail, run with `-count=1`.
+- **Grep criteria** are decided by the exact command's match count; a criterion asserting absence names the expected empty output.
+- All analyzer criteria assert against synthetic fixtures under `internal/harness/delegationmap/testdata/`, never against live ledger content — the live ledger is gitignored runtime state, is gate-dependent, and is empty in CI. See `plan.md` §G AP-3.
+- Fixtures are **generated**, not hand-written. AC-HLA-001 pins the generation path; a hand-authored JSONL fixture would silently drift from the row shape the producer actually emits.
+
+## §B. Fixture integrity and reading
+
+### AC-HLA-001 — fixtures are produced by the real finalize transform
+- **Given** a fixture generator that constructs `routing.PendingRow` values and calls `PendingRow.Finalize(outcome)` to obtain each row
+- **When** the generator writes every fixture under `testdata/` and the test re-runs it
+- **Then** the committed fixtures are byte-identical to the regenerated output, and at least one fixture in the suite is produced through `Finalize()` rather than hand-authored JSON — so a dropped or mis-mapped field in the 15-field-plus-outcome transform fails this criterion instead of passing invisibly
+- **Command**: `go test ./internal/harness/delegationmap/ -run TestFixtures_GeneratedViaFinalize -count=1`
+- **Covers**: REQ-HLA-002 (row-shape fidelity)
+
+### AC-HLA-002 — the analyzer reads through the routing reader, and refuses an oversized ledger
+- **Given** the `delegationmap` package source, and separately a fixture ledger whose size exceeds the declared maximum
+- **When** the package is searched for an independently-declared ledger path literal, and the analyzer is run against the oversized fixture
+- **Then** the literal `routing-ledger.jsonl` appears nowhere in the package outside test fixtures, and the oversized run returns an empty finding list with a machine-readable size reason and no error
+- **Command**: `grep -rn 'routing-ledger.jsonl' internal/harness/delegationmap/ --include='*.go' | grep -v _test` → expected: no output; and `go test ./internal/harness/delegationmap/ -run TestAnalyze_OversizedLedgerRefused -count=1`
+- **Covers**: REQ-HLA-001
+
+### AC-HLA-003 — per-subcommand aggregation is correct
+- **Given** the fixture `aggregate_basic.jsonl` with 8 `plan` rows in which `manager-spec` appears 8 times and `Explore` 3 times
+- **When** the aggregator runs
+- **Then** the `plan` stat reports 8 qualifying rows, `manager-spec` count 8, and `Explore` count 3
+- **Command**: `go test ./internal/harness/delegationmap/ -run TestAggregate_Basic -count=1`
+- **Covers**: REQ-HLA-002
+
+### AC-HLA-004 — reroute and abort rows are excluded and reported separately
+- **Given** the fixture `reroute_abort_only.jsonl` containing only `reroute` and `abort` rows
+- **When** the analyzer runs
+- **Then** qualifying rows is 0 for every subcommand, no finding is produced, and the reroute and abort counts appear in the result
+- **Command**: `go test ./internal/harness/delegationmap/ -run TestAnalyze_RerouteAbortExcluded -count=1`
+- **Covers**: REQ-HLA-003
+
+## §C. Identity discrimination
+
+### AC-HLA-005 — a non-catalog agent value never produces an undesignated-agent finding
+- **Given** the fixture `non_catalog_agents.jsonl` with 10 qualifying `run` rows in which `general-purpose`, `workflow-subagent`, `hns-oss-docs-locale-translator-specialist`, and the spawn name `audit-hle` each appear in 9 of 10 rows (well clear of both thresholds)
+- **When** the analyzer runs against a fixture delegation map that designates none of them
+- **Then** no `undesignated_agent` finding names any of the four values, each is present in the result classified as non-catalog, and the run still emits findings for any retained-catalog agent that qualifies — proving the suppression is by classification and not by an empty result
+- **Command**: `go test ./internal/harness/delegationmap/ -run TestAnalyze_NonCatalogNeverUndesignated -count=1`
+- **Covers**: REQ-HLA-004
+
+### AC-HLA-006 — unattributed delegations are counted and reported, never treated as an agent
+- **Given** the fixture `unattributed_share.jsonl` with 10 qualifying `plan` rows in which 4 delegation entries carry the absent-identity marker defined by the producer SPEC
+- **When** the analyzer runs
+- **Then** the `plan` stat reports an unattributed share of 4 entries, the marker appears in no per-agent count and in no finding's agent field, and the unattributed share is present on every emitted proposal for `plan`
+- **Command**: `go test ./internal/harness/delegationmap/ -run TestAnalyze_UnattributedShareReported -count=1`
+- **Covers**: REQ-HLA-005
+
+## §D. Thresholds and proposal kinds
+
+### AC-HLA-007 — both thresholds suppress a proposal
+- **Given** the fixture `below_min_rows.jsonl` with 4 qualifying `plan` rows against `MinQualifyingRows = 5`, and the fixture `stray_agent.jsonl` with 10 qualifying `run` rows in which an undesignated retained-catalog agent appears once (support 0.10, below `MinSupportRatio = 0.60`)
+- **When** the analyzer runs against each
+- **Then** the first yields an empty finding list with a result reason naming the row threshold, and the second yields no finding naming the stray agent
+- **Command**: `go test ./internal/harness/delegationmap/ -run 'TestAnalyze_BelowMinRows|TestAnalyze_StrayRowSuppressed' -count=1`
+- **Covers**: REQ-HLA-006
+
+### AC-HLA-008 — both proposal kinds are produced, and only those two
+- **Given** the fixture `two_kinds.jsonl` plus a fixture delegation map, arranged so one undesignated retained-catalog agent clears both thresholds for `run` and one designated agent that is not in the conditional-exclusion set is observed zero times for `sync`
+- **When** the analyzer runs
+- **Then** exactly two findings are produced, one of kind `undesignated_agent` and one of kind `designated_never_spawned`, and the `Kind` enum admits no third value
+- **Command**: `go test ./internal/harness/delegationmap/ -run TestAnalyze_TwoKindsOnly -count=1`
+- **Covers**: REQ-HLA-007
+
+### AC-HLA-009 — conditionally-invoked designations are excluded from designated-never-spawned
+- **Given** the fixture `conditional_designations.jsonl` with 12 qualifying `sync` rows in which `sync-auditor` never appears, and 12 qualifying `plan` rows in which `plan-auditor` never appears, against a fixture map designating both
+- **When** the analyzer runs
+- **Then** no `designated_never_spawned` finding names `sync-auditor` or `plan-auditor`, the exclusion set is a declared value carrying a rule citation per entry, and a third designated agent absent from the exclusion set and observed zero times in the same fixture still produces its finding
+- **Command**: `go test ./internal/harness/delegationmap/ -run TestAnalyze_ConditionalDesignationsExcluded -count=1`
+- **Covers**: REQ-HLA-008
+
+## §E. Emission and isolation
+
+### AC-HLA-010 — the delegation map is read, and never written
+- **Given** a fixture `delegation.yaml` with known designated agents, made read-only for the duration of the test
+- **When** the analyzer runs against it
+- **Then** the designated set is resolved correctly, the analyzer succeeds, and the file's modification time and bytes are unchanged
+- **Command**: `go test ./internal/harness/delegationmap/ -run TestMapReader_ReadOnly -count=1`
+- **Covers**: REQ-HLA-009
+
+### AC-HLA-011 — the pattern-key namespace is isolated, and the event-type SSOT is untouched
+- **Given** the analyzer's emitted candidates for `two_kinds.jsonl`, and `internal/harness/types.go`
+- **When** each `pattern_key` is tested against the existing proposalgen actionable-pattern regex, and the SSOT file is searched for the new namespace token
+- **Then** every key starts with `delegation_map:` and none matches the existing regex; `delegation_map` does not appear in `internal/harness/types.go`; and `PatternBearingEventTypes()` returns the same members as before the change
+- **Command**: `go test ./internal/harness/delegationmap/ -run TestPatternKey_NamespaceIsolated -count=1`; `grep -c 'delegation_map' internal/harness/types.go` → expected `0`; and `go test ./internal/harness/ -run TestPatternBearingEventTypes -count=1`
+- **Covers**: REQ-HLA-010, REQ-HLA-011
+
+### AC-HLA-012 — each proposal carries its evidence
+- **Given** a written draft directory from the `two_kinds.jsonl` run
+- **When** its `proposal.json` and `spec.md` are read
+- **Then** both carry the observation count, the support ratio, the qualifying-row count for the subcommand, the unattributed share, and the proposal kind
+- **Command**: `go test ./internal/harness/delegationmap/ -run TestProposal_CarriesEvidence -count=1`
+- **Covers**: REQ-HLA-012
+
+### AC-HLA-013 — the analyzer is deterministic and idempotent
+- **Given** the `two_kinds.jsonl` fixture
+- **When** the analyzer runs twice into the same output directory
+- **Then** the candidate slices are equal element-for-element in the same order, and the second run leaves every written file byte-identical
+- **Command**: `go test ./internal/harness/delegationmap/ -run TestAnalyze_DeterministicIdempotent -count=1`
+- **Covers**: REQ-HLA-013
+
+### AC-HLA-014 — absent, empty, and malformed inputs degrade gracefully
+- **Given** three inputs — a non-existent path, an empty file, and `all_malformed.jsonl`
+- **When** the analyzer runs on each
+- **Then** each returns an empty finding list, a non-empty machine-readable reason, a malformed-line count matching the fixture, and no error
+- **Command**: `go test ./internal/harness/delegationmap/ -run TestAnalyze_GracefulNoOp -count=1`
+- **Covers**: REQ-HLA-014
+
+### AC-HLA-015 — the CLI verb exposes dry-run and JSON
+- **Given** a temp root with a fixture ledger and map
+- **When** `moai harness delegation analyze --json --dry-run` runs
+- **Then** it exits 0, emits a parseable JSON result on stdout, and creates no directory under the proposals path
+- **Command**: `go test ./internal/cli/ -run TestHarnessDelegationAnalyzeCmd -count=1`
+- **Covers**: REQ-HLA-015
+
+### AC-HLA-016 — the boundary holds: no map write, no allowlist edit, no prompt, no skill proposal
+- **Given** the whole non-test Go tree, the branch diff against its merge base, and every fixture in `testdata/`
+- **When** each is inspected
+- **Then** the only occurrences of `delegation.yaml` are in the read-only loader with no `os.WriteFile` / `os.Create` targeting it; `.claude/lsel/frozen-allowlist.json` is absent from the changed-file list and still contains `^\.moai/config/sections/`; `AskUserQuestion` appears in none of the new files; and no finding carries a skill field, the `Finding` type declaring none
+- **Command**: `grep -rn 'delegation.yaml' internal/ --include='*.go' | grep -v _test` → expected: only `internal/harness/delegationmap/mapreader.go`; `git diff --name-only origin/main...HEAD | grep -c 'frozen-allowlist.json'` → expected `0`; `grep -c 'moai/config/sections' .claude/lsel/frozen-allowlist.json` → expected `≥ 1`; `grep -rn 'AskUserQuestion' internal/harness/delegationmap/ internal/cli/harness_delegation.go` → expected: no output; and `go test ./internal/harness/delegationmap/ -run TestAnalyze_NoSkillProposals -count=1`
+- **Covers**: REQ-HLA-016
+
+## §F. Quality gate
+
+- `go build ./...` exits 0, and `GOOS=windows GOARCH=amd64 go build ./...` exits 0.
+- `go test ./... -count=1` exits 0 (full suite, not the affected packages alone).
+- `golangci-lint run` reports no new finding against the pre-change baseline.
+- `moai spec lint .moai/specs/SPEC-HARNESS-LEARNING-EVO-002/spec.md --strict` exits 0.
+- `git diff --name-only origin/main...HEAD | grep -cE '^(internal/template/templates/|\.claude/skills/)'` returns `0`.
+
+## §G. Definition of Done
+
+- All 16 criteria pass, each cited with its command and observed output.
+- The traceability matrix in §H shows every requirement covered.
+- The falsification review named in `spec.md` §E is scheduled, not performed — its window opens at 50 qualifying rows, which do not exist at merge time.
+
+## §H. Residual risk
+
+- **R1 — thresholds are guesses.** `MinQualifyingRows = 5` and `MinSupportRatio = 0.60` are chosen by analogy to the existing `proposalgen` constant, not from data. They are the most likely thing to be wrong, and they can only be validated after the producer SPEC has generated real rows.
+- **R2 — the catalog membership test is a snapshot.** REQ-HLA-004's discrimination depends on the retained-agent catalog (`CLAUDE.md` §4). A catalog change that this package does not track would silently reclassify observations. The membership source and its staleness exposure are recorded in `plan.md` §E D2.
+- **R3 — the exclusion set can become a silent allowlist.** REQ-HLA-008's exclusion suppresses real findings by design. Each entry carries a rule citation for exactly this reason, but nothing mechanically re-checks that the cited rule still makes the invocation conditional.
+- **R4 — the memory bound is a size guard, not streaming.** `routing.Reader.Read` materializes the whole filtered row set; adding a streaming variant would have made this SPEC depend on a change in its sibling, which the fixture-based strategy exists to avoid. REQ-HLA-001's declared maximum caps the exposure rather than removing it (`plan.md` §E D1).
+- **R5 — spawn-name collisions inflate catalog counts.** A spawn *named* exactly like a retained agent is indistinguishable from a type spawn, so per-agent counts may include named spawns of a different underlying type. The direction of the error is toward over-counting a designated agent, which suppresses `designated_never_spawned` rather than fabricating `undesignated_agent` — the safer direction, but not a neutral one.
+- **R6 — F3 is bounded but slow.** The falsifier needs 10 proposals through a human gate; until the window closes, the central assumption stays unfalsified rather than confirmed.
+
+## §I. Traceability matrix
+
+| REQ | Criteria |
+|---|---|
+| REQ-HLA-001 | AC-HLA-002 |
+| REQ-HLA-002 | AC-HLA-001, AC-HLA-003 |
+| REQ-HLA-003 | AC-HLA-004 |
+| REQ-HLA-004 | AC-HLA-005 |
+| REQ-HLA-005 | AC-HLA-006 |
+| REQ-HLA-006 | AC-HLA-007 |
+| REQ-HLA-007 | AC-HLA-008 |
+| REQ-HLA-008 | AC-HLA-009 |
+| REQ-HLA-009 | AC-HLA-010, AC-HLA-016 |
+| REQ-HLA-010 | AC-HLA-011 |
+| REQ-HLA-011 | AC-HLA-011 |
+| REQ-HLA-012 | AC-HLA-012 |
+| REQ-HLA-013 | AC-HLA-013 |
+| REQ-HLA-014 | AC-HLA-014 |
+| REQ-HLA-015 | AC-HLA-015 |
+| REQ-HLA-016 | AC-HLA-016 |

--- a/.moai/specs/SPEC-HARNESS-LEARNING-EVO-002/plan.md
+++ b/.moai/specs/SPEC-HARNESS-LEARNING-EVO-002/plan.md
@@ -1,0 +1,157 @@
+# SPEC-HARNESS-LEARNING-EVO-002 — Implementation Plan (L2)
+
+> Derived from `spec.md`. Ordered by decision-reversibility: the contract and the two contested decisions first, the mechanical wiring last.
+
+## §A. Context and measured baseline
+
+### A.1 Baseline commands (re-runnable)
+
+All figures were measured against the **primary checkout** `/Users/goos/MoAI/moai-adk-go` on 2026-08-09. They are not reproducible from this worktree: `.moai/state/`, `.moai/harness/`, and `.moai/evolution/` are gitignored runtime state and absent here. Small upward drift on re-run is expected.
+
+| Claim | Command | Observed |
+|---|---|---|
+| The observe channel is empty | `wc -l < .moai/state/routing-ledger.jsonl` ; `jq -c '.delegations \| length' … \| sort \| uniq -c` | 4 rows; `4  0` |
+| The proposal writer and layout work | `ls .moai/harness/proposals \| wc -l` ; `wc -l < .moai/harness/learning-history/tier-promotions.jsonl` | 73 dirs ; 175 rows |
+| Agent identity is a mixed population | `grep '"subagent_stop"' .moai/harness/usage-log.jsonl \| jq -r '.agent_type // "(none)"' \| sort \| uniq -c \| sort -rn` | 2,783 rows; 1,941 attributed (69.7%); 842 `(none)`; `general-purpose` 204, `workflow-subagent` 186, ~140 one/two-occurrence spawn names |
+| Nothing writes the map | `grep -rn 'delegation.yaml' internal/ --include='*.go' \| grep -v _test` | 0 matches |
+| Two designations are conditional | `.moai/config/sections/delegation.yaml` `sync: agents: [manager-docs, sync-auditor]`, `plan: agents: [manager-spec, plan-auditor, Explore]` | both present |
+
+### A.2 Existing plumbing this SPEC builds on
+
+| Surface | Path | Role here |
+|---|---|---|
+| Reader | `internal/harness/routing/reader.go` | `NewReader(path).Read(Filter)` — the only ledger entry point; returns `([]Row, skipped int, error)` |
+| Row shape + finalize | `internal/harness/routing/types.go` | `Row`, `PendingRow.Finalize(outcome)` — the fixture generator's source of truth |
+| Proposal writer + layout | `internal/harness/proposalgen/{scaffolder,layout}.go` | `WriteProposals`, `ProposalDir`, `ListDraftIDs` — reused as-is |
+| Event-type SSOT | `internal/harness/types.go` | `PatternBearingEventTypes()` — read for the isolation assertion, never extended |
+| Delegation map | `.moai/config/sections/delegation.yaml` | `delegation.subcommands.<name>.agents` — read-only source of the designated set |
+| Harness CLI parent | `internal/cli/harness_route.go` | `newHarnessRouteCmd`'s `AddCommand` block (the `ledger` verb is registered at line 144); the new `delegation` verb attaches here |
+| Retained agent catalog | `CLAUDE.md` §4 | the 12-member membership test for REQ-HLA-004 |
+
+## §B. Known issues the plan must not reintroduce
+
+- **B1 — namespace capture.** Adding a `delegation_map` member to `harness.PatternBearingEventTypes()` would silently widen the *observer's* event taxonomy and the proposalgen format regex derived from it. Forbidden by REQ-HLA-011.
+- **B2 — identity naivety.** Treating every observed `agent_type` value as an agent name produces `undesignated_agent` findings for `general-purpose`, `workflow-subagent`, harness specialists, and ~140 spawn names — a proposal stream that is 100% noise on the measured population (§A.1).
+- **B3 — absence-reasoning without exclusions.** `designated_never_spawned` reasons from absence. `sync-auditor` runs only at harness `thorough`; `plan-auditor` is skipped by the Plan Audit Gate skip-eligibility path. Without REQ-HLA-008 the analyzer reports prescribed behavior as a defect.
+- **B4 — fixture drift.** Hand-written JSONL fixtures encode the author's belief about the row shape, not the producer's actual output. `PendingRow.Finalize` maps 15 fields plus the outcome and normalizes two nil slices; a dropped or mis-mapped field would be invisible to every hand-written fixture. AC-HLA-001 pins generation through `Finalize()`.
+- **B5 — silent map mutation.** Any code path that opens `delegation.yaml` for writing, including a "harmless" comment or formatting rewrite.
+
+## §C. Pre-flight
+
+1. Confirm the worktree is `feat/harness-learning-evo` and `git status` is clean of foreign edits.
+2. `go build ./...` and `GOOS=windows GOARCH=amd64 go build ./...` green before the first edit (baseline attribution).
+3. `golangci-lint run --timeout=2m 2>&1 | tail -5` — record the pre-existing baseline so NEW findings are separable.
+4. `grep -rn 'delegation.yaml' internal/ --include='*.go' | grep -v _test` — record the 0-match starting state so the post-change single-match (the read-only loader) is attributable.
+
+## §D. Constraints
+
+- Read-only against `delegation.yaml`; no write path, ever (REQ-HLA-009, B5).
+- No `AskUserQuestion` in the new package or the new CLI file; a boundary grep test mirrors `internal/harness/routing/subagent_boundary_test.go`.
+- No template edits, no `.claude/skills/` edits, no frozen-allowlist edit.
+- Do not extend `harness.PatternBearingEventTypes()` and do not route through `proposalgen.MapPromotions`.
+- Do not touch runtime-managed files (`.moai/harness/*`, `.moai/state/*`).
+
+## §E. Decisions carried into audit
+
+### D1 — reader contract: accept the materializing read, bound it by size
+
+The original SPEC carried two requirements that contradicted each other: "read through the existing routing reader" and "stream the ledger line by line and hold no whole-file buffer". `internal/harness/routing/reader.go:31` is `func (r *Reader) Read(f Filter) ([]Row, int, error)` — it materializes a slice, and no streaming variant exists.
+
+**Chosen: relax to the reader's real contract, with a declared size bound.** Adding a streaming variant to `routing.Reader` would place a change to the producer's package inside this SPEC's milestone set, which makes this SPEC depend on its sibling and destroys the fixture-based independence that lets the two proceed in either order. Instead REQ-HLA-001 keeps the existing `Read` call, forbids retaining per-row state beyond the aggregate, and adds a declared maximum ledger size above which the analyzer declines the read and returns a machine-readable reason. The exposure is capped rather than removed (residual risk R4). Revisit if a real ledger ever approaches the bound; a streaming variant is then a change to the producer's package, correctly scoped as its own SPEC.
+
+### D2 — catalog membership source
+
+REQ-HLA-004's discrimination needs the retained-agent catalog. Two sources exist: the prose list in `CLAUDE.md` §4, and the union of agent names in `delegation.yaml`'s own `subcommands.*.agents`.
+
+**Chosen: a declared constant in the package, seeded from `CLAUDE.md` §4, with the delegation map used only to resolve *designations* (not membership).** Deriving membership from the map would make the discrimination circular — an agent absent from every designation could never be found undesignated, which is precisely the finding the analyzer exists to produce. The cost is a snapshot that can go stale against a catalog change (residual risk R2); the constant carries a comment naming its source so a catalog edit has somewhere to land.
+
+### D3 — F3 bounding
+
+The original falsifier ("every proposal surfaced at the Tier-4 gate is rejected") was universally quantified over an unbounded stream with no N and no termination condition, so it could never be discharged. `spec.md` §E bounds it: a review window that opens at 50 qualifying rows and closes after the first 10 proposals reach the gate, with a ≥8-of-10 rejection threshold.
+
+## §F. Milestones
+
+Ordered by decision-reversibility. M1 carries the contract every later milestone binds to; M5 is mechanical.
+
+### M1 — Types, thresholds, and generated fixtures (highest change-likelihood)
+
+Authored before any analyzer logic, so the contract is reviewable on its own and L2 is testable without waiting for real data.
+
+- New package `internal/harness/delegationmap/`.
+- `types.go`: `SubcommandStat` (qualifying rows, per-agent counts, unattributed count, reroute/abort counts), `Finding` (kind, subcommand, agent, observation count, support ratio, qualifying rows, unattributed share), `Result` (findings, reason, malformed lines, evaluated subcommands).
+- `Kind` enum: `undesignated_agent`, `designated_never_spawned` — and no third value (REQ-HLA-007).
+- Declared constants with stated rationale: `MinQualifyingRows = 5`, `MinSupportRatio = 0.60` (mirroring the `proposalgen` precedent of a single declared constant rather than config-driven tuning), `MaxLedgerBytes` (§E D1), the retained-catalog membership set (§E D2), and the conditional-invocation exclusion set with a rule citation per entry (REQ-HLA-008).
+- `testdata/` fixtures **generated** by a Go generator that builds `routing.PendingRow` values and calls `Finalize()` (B4, AC-HLA-001): below-threshold, at-threshold, undesignated-agent, designated-never-spawned, conditional-designations, non-catalog-agents, unattributed-share, reroute/abort-only, malformed-line, oversized, and empty.
+
+**Why first:** every later milestone binds to these types and constants, and the two contested decisions (§E D1, D2) are both encoded here.
+
+### M2 — Aggregation and identity discrimination
+
+- `aggregate.go`: consume rows via `routing.NewReader(...).Read(routing.Filter{})`, fold into `SubcommandStat`, retaining no per-row state (REQ-HLA-001/002/003).
+- Apply the size guard before the read; on exceed, return the empty result with the size reason.
+- Classify each observed `agent` value into catalog / non-catalog / unattributed (REQ-HLA-004/005). The classification is total — every value lands in exactly one bucket, and none is dropped.
+
+### M3 — Map reader and finding production
+
+- `mapreader.go`: read-only YAML load of `.moai/config/sections/delegation.yaml` into `map[string][]string` (subcommand → designated agents). Read path only (REQ-HLA-009).
+- `analyze.go`: apply thresholds, apply the conditional-invocation exclusion, produce `Finding`s (REQ-HLA-006/007/008).
+
+### M4 — Proposal emission
+
+- `proposal.go`: build `proposalgen.ProposalCandidate` values with `PatternKey = "delegation_map:<subcommand>:<sha256(kind|subcommand|agent)[:8]>"` and `DraftID = "PROPOSAL-" + sha256(patternKey)[:8]`, then emit via `proposalgen.WriteProposals(proposalgen.ProposalDir(root), candidates)` (REQ-HLA-010/011/012/013).
+- Body rendering carries the observation count, support ratio, qualifying-row count, unattributed share, and kind, plus the explicit statement that application requires the Tier-4 approval gate.
+
+**Namespace note:** `delegation_map` is not a member of `PatternBearingEventTypes()`, so `proposalgen.MapPromotions`'s format regex rejects it by construction — which is the desired isolation, and the reason the analyzer bypasses the mapper rather than extending it (B1).
+
+### M5 — CLI surface
+
+- `moai harness delegation analyze [--json] [--dry-run] [--limit N] [--ledger PATH] [--map PATH]` in a new `internal/cli/harness_delegation.go`, registered in the existing `AddCommand` block of `internal/cli/harness_route.go` alongside `newHarnessLedgerCmd()` (REQ-HLA-015).
+- Boundary grep test mirroring the routing package's `subagent_boundary_test.go`.
+
+## §G. Anti-patterns
+
+- **AP-1 — event-type widening.** Adding `delegation_map` to `PatternBearingEventTypes()` to make the existing mapper accept the new keys (B1).
+- **AP-2 — naive identity.** Emitting an `undesignated_agent` finding for any observed value that is not in the map, without the catalog-membership test (B2).
+- **AP-3 — live-data AC.** Writing an acceptance criterion that reads `.moai/state/routing-ledger.jsonl` and asserts content. The file is gitignored runtime state, gate-dependent, and empty in CI.
+- **AP-4 — hand-written fixtures.** Authoring `testdata/*.jsonl` by hand instead of generating through `PendingRow.Finalize()` (B4).
+- **AP-5 — silent map write.** Any code path that opens `delegation.yaml` for writing, including a "harmless" comment or formatting rewrite (B5).
+- **AP-6 — exclusion creep.** Adding an entry to the conditional-invocation exclusion set without a rule citation, turning a justified carve-out into an allowlist that suppresses real findings (residual risk R3).
+- **AP-7 — circular membership.** Deriving the retained-agent catalog from the delegation map, which makes an undesignated agent undiscoverable by construction (§E D2).
+
+## §H. Deferred / follow-up (not in this SPEC)
+
+- Ledger schema v2 with an injected-skills field, which would unlock skill-level proposals.
+- Threshold tuning driven by real data once the `spec.md` §E review window has run.
+- A streaming variant of `routing.Reader`, correctly scoped as a change to the producer's package (§E D1).
+- Wiring analyzer findings into `moai harness propose` as a second source, rather than a separate verb.
+
+## §I. File inventory (run phase)
+
+| Path | Change |
+|---|---|
+| `internal/harness/delegationmap/types.go` | new — stats, findings, kinds, declared constants |
+| `internal/harness/delegationmap/aggregate.go` | new |
+| `internal/harness/delegationmap/mapreader.go` | new — the only `delegation.yaml` reference in the tree |
+| `internal/harness/delegationmap/analyze.go` | new |
+| `internal/harness/delegationmap/proposal.go` | new |
+| `internal/harness/delegationmap/*_test.go` | new |
+| `internal/harness/delegationmap/subagent_boundary_test.go` | new — mirrors the routing package's boundary grep |
+| `internal/harness/delegationmap/fixturegen_test.go` | new — generates `testdata/` through `PendingRow.Finalize()` |
+| `internal/harness/delegationmap/testdata/*.jsonl` | new fixtures (generated) |
+| `internal/cli/harness_delegation.go` | new — CLI verb |
+| `internal/cli/harness_route.go` | edit — one `AddCommand` line |
+
+Roughly 11 files, of which 1 is an edit. No template files, no `.claude/` files.
+
+## §J. Tier classification
+
+**Tier M.** Per `.claude/rules/moai/workflow/spec-workflow.md` § SPEC Complexity Tier, the scope-based table places Tier M at 300-1000 LOC and 5-15 files affected; this SPEC's inventory is ~11 files, single-domain (Go, one new package plus one registration line), and well under 1000 LOC. The requirement and acceptance-criterion counts (16 and 16) sit exactly at the Tier M ceiling, which is the binding constraint that motivated the split from the original 33/36 SPEC. Tier M carries the 3-artifact set (spec.md + plan.md + acceptance.md) plus `progress.md`, and a plan-auditor PASS threshold of 0.80.
+
+## §K. Cross-references
+
+- `SPEC-HARNESS-LEARNING-EVO-001` — the L1 producer of the rows this analyzer reads (sibling, not a dependency; see `spec.md` §F)
+- `.moai/reports/moai-autonomy-workflow-redesign-20260803.html` §2.5, §5 row P3
+- `.claude/rules/moai/workflow/spec-workflow.md` § SPEC Complexity Tier (the budget that forced the split), § Plan Audit Gate skip policy (the `plan-auditor` conditional-invocation citation), § Mode Dispatch (the `sync-auditor` harness-level citation)
+- `.claude/rules/moai/workflow/skill-routing.md` — the consumer of `delegation.yaml`
+- `.claude/rules/moai/core/verification-claim-integrity.md` — the `spec.md` §E falsification discipline
+- `CLAUDE.md` §4 — the retained agent catalog seeding the membership constant (§E D2)

--- a/.moai/specs/SPEC-HARNESS-LEARNING-EVO-002/progress.md
+++ b/.moai/specs/SPEC-HARNESS-LEARNING-EVO-002/progress.md
@@ -1,0 +1,23 @@
+# SPEC-HARNESS-LEARNING-EVO-002 — Progress
+
+## §E.1 Plan-phase Audit-Ready Signal
+
+- Artifacts: `spec.md`, `plan.md`, `acceptance.md`, `progress.md` authored at `status: draft`, Tier M.
+- Scope: **L2 only** (the delegation-map analyzer). Split from `SPEC-HARNESS-LEARNING-EVO-001` v0.1.0, which carried 33 requirements and 36 acceptance criteria — over the ceiling at Tier M (16/16) and Tier L (25/25). L1 (instrumentation) stays in the sibling; L3 (application to `delegation.yaml`) remains an explicit non-goal with its three-surface rationale.
+- Requirements: 16 GEARS requirements (REQ-HLA-001..016); 16 acceptance criteria with 100% requirement coverage (`acceptance.md` §I). Both counts are exactly at the Tier M ceiling.
+- Sibling relationship: `SPEC-HARNESS-LEARNING-EVO-001` is listed under `related_specs`, deliberately **not** `depends_on` — the fixture-based test strategy makes this SPEC runnable without the sibling reaching `status: completed`, and a `depends_on` entry would impose a Depends_on Pre-flight gate that the design does not need.
+- Open decisions carried into audit: the reader contract (`plan.md` §E D1 — accept the materializing read, bound it by a declared max size, rather than adding a streaming variant that would create a dependency on the sibling), the catalog-membership source (`plan.md` §E D2 — a declared constant seeded from `CLAUDE.md` §4, not derived from the delegation map), and the two threshold constants (`plan.md` §F M1).
+
+_<pending plan-audit>_
+
+## §E.2 Run-phase Evidence
+
+_<pending run-phase>_
+
+## §E.3 Run-phase Audit-Ready Signal
+
+_<pending run-phase>_
+
+## §E.4 Sync-phase Audit-Ready Signal
+
+_<pending sync-phase>_

--- a/.moai/specs/SPEC-HARNESS-LEARNING-EVO-002/spec.md
+++ b/.moai/specs/SPEC-HARNESS-LEARNING-EVO-002/spec.md
@@ -1,0 +1,132 @@
+---
+id: SPEC-HARNESS-LEARNING-EVO-002
+title: "Delegation-map analyzer (L2) — proposals from observed routing-ledger rows"
+version: "0.1.0"
+status: draft
+created: 2026-08-09
+updated: 2026-08-09
+author: manager-spec
+priority: P3
+phase: "v3.2 target"
+module: "internal/harness/delegationmap"
+lifecycle: spec-anchored
+tags: "harness-learning, delegation-map, analyzer, proposalgen, meta-context-engineering, autonomy-epic"
+tier: M
+related_specs: [SPEC-HARNESS-LEARNING-EVO-001, SPEC-V3R6-HARNESS-PROPOSAL-GEN-001, SPEC-HARNESS-EVOLVE-001, SPEC-LSEL-LOCAL-EVOLUTION-001]
+---
+
+# SPEC-HARNESS-LEARNING-EVO-002 — Delegation-map analyzer (L2)
+
+## HISTORY
+
+- 2026-08-09 — Initial draft. Split from `SPEC-HARNESS-LEARNING-EVO-001` v0.1.0, which carried 33 requirements and 36 acceptance criteria — over the ceiling at Tier M (16/16) and Tier L (25/25). Per `.claude/rules/moai/workflow/spec-workflow.md` § SPEC Complexity Tier ("Exceeding either ceiling is a signal to tier up or to split the SPEC, not to relax the budget"), the SPEC was split along the L1/L2 line it already drew. This SPEC carries **L2 only** — the analyzer. Two requirements are shaped by measurements taken during the split: agent identity is a mixed population (§A.2) and two designated agents are conditionally invoked (§A.3).
+
+## §A. Context
+
+### A.1 — the consumer of a channel that is being repaired
+
+`.moai/config/sections/delegation.yaml` declares a learning loop in its own header: `observe: routing-ledger`, `propose_via: harness-tier-ladder`, `auto_apply: false`. The observe channel is empty (4 rows, every one with `delegations: []`), and `SPEC-HARNESS-LEARNING-EVO-001` repairs it. This SPEC builds the missing consumer: read finalized rows, aggregate delegation patterns per subcommand, and emit proposals in the existing `proposalgen` directory shape whose content is a concrete delegation-map amendment.
+
+The two SPECs are siblings, not a dependency chain. This one is testable end to end against synthetic fixtures generated from `routing.PendingRow.Finalize()` — a function that exists unchanged today — so it neither waits on nor gates its sibling. The finalized row shape is the contract between them, and `SPEC-HARNESS-LEARNING-EVO-001` REQ-HLE-014 freezes it at `schema_version: 1`.
+
+### A.2 — the observed agent-identity population is mixed
+
+Measured against the primary checkout on 2026-08-09: of 2,783 `subagent_stop` rows in `.moai/harness/usage-log.jsonl`, 1,941 (69.7%) carry a non-empty `agent_type`. The distribution leads with exactly the identities `delegation.yaml` designates — `manager-spec` 281, `manager-develop` 277, `plan-auditor` 201, `Explore` 129, `manager-docs` 122, `manager-git` 74, `sync-auditor` 31, `super-advisor` 7 — but three other populations are mixed in:
+
+- **Absent** — 842 rows (30.3%) carry no identity at all.
+- **Non-catalog agent types** — `general-purpose` 204, `workflow-subagent` 186, plus user-owned harness specialists (`hns-*-specialist`, `cli-template-specialist`) and the runtime built-in `claude-code-guide`. These are real agents; none is a member of the 12-agent retained catalog the delegation map designates from.
+- **Spawn names** — a named spawn puts the NAME in `agent_type`. Directly observed: a spawn of `subagent_type: plan-auditor` with `name: audit-hle` produced `agent_type: "audit-hle"`. The long tail holds roughly 140 such values (`lens-*`, `rev-*`, `humanize-*`, `audit-*`).
+
+The consequence for this SPEC is a mechanical discrimination rule: only a value that exactly matches a retained-catalog name is comparable against the delegation map. Everything else must be recorded and classified, never treated as an agent the map failed to designate.
+
+### A.3 — two designated agents are conditionally invoked
+
+`delegation.yaml` designates `sync-auditor` for `sync` and `plan-auditor` for `plan`. Both are legitimately absent from many runs:
+
+- `sync-auditor` runs at harness level `thorough` only (`CLAUDE.md` §6; `.claude/rules/moai/workflow/spec-workflow.md` § Mode Dispatch auto-selection).
+- `plan-auditor` is skipped by the skip-eligibility path in `.claude/rules/moai/workflow/spec-workflow.md` § Plan Audit Gate skip policy whenever the cached verdict is PASS at or above the tier threshold with an unchanged artifact hash.
+
+A `designated_never_spawned` proposal reasons from absence, so without an explicit exclusion it would fire on both — reporting as a defect the exact behavior the rules prescribe.
+
+## §B. User Story
+
+As the maintainer of MoAI's harness, I want the delegation map revised from what the pipeline actually did — which agents were really spawned for which subcommand, and how those runs ended — rather than from my recollection, so that `delegation.yaml` stops drifting from reality and every proposed amendment arrives with an observation count behind it.
+
+## §C. Scope boundary
+
+- **In scope (L2).** Reading finalized routing-ledger rows, aggregating per subcommand, applying thresholds, resolving the designated agent set from `delegation.yaml` read-only, and emitting proposals through the existing `proposalgen` writer and directory layout. A CLI verb with a dry-run mode.
+- **Out of scope (L1).** Creating rows, appending delegations, and closing rows on a terminal signal belong to `SPEC-HARNESS-LEARNING-EVO-001`.
+- **Out of scope (L3).** Applying a proposal to `delegation.yaml`. See §G.
+
+## §D. Requirements
+
+Notation: GEARS. `REQ-HLA-0xx`. Budget: 16 requirements (Tier M ceiling 16).
+
+### D.1 — Reading and aggregation
+
+- **REQ-HLA-001** — The analyzer shall consume ledger rows through the existing `routing.Reader` and shall not open the ledger by an independently-declared path literal. It shall retain no per-row state beyond the running aggregate. **Where** the ledger file exceeds a declared maximum size, the analyzer shall decline to read it and return the empty result with a machine-readable reason rather than performing an unbounded read.
+- **REQ-HLA-002** — The analyzer shall aggregate, per matched subcommand, the set of agents observed in `delegations[]` together with each agent's observation count and the count of rows for that subcommand. It shall treat one finalized row as exactly one subcommand observation, matching the first-writer-wins labelling its sibling SPEC records.
+- **REQ-HLA-003** — The analyzer shall count toward its aggregation only rows whose outcome is `success` or `fail`, and shall report `reroute` and `abort` counts separately as routing-instability context that does not by itself produce a proposal.
+
+### D.2 — Identity discrimination
+
+- **REQ-HLA-004** — The analyzer shall compare an observed agent value against the delegation map only **when** that value exactly matches a member of the retained agent catalog; every other value shall be recorded and classified as non-catalog, and shall never produce an *undesignated-agent* proposal. A value that names a spawn, a non-catalog agent type, or a user-owned harness specialist is not evidence that the map omitted a designation.
+- **REQ-HLA-005** — The analyzer shall count delegation entries carrying the absent-identity marker as unattributed observations, shall exclude them from every per-agent count, and shall report the unattributed share per subcommand so a reviewer can judge how much of the population the finding rests on.
+
+### D.3 — Thresholds and proposal kinds
+
+- **REQ-HLA-006** — **While** a subcommand has fewer finalized qualifying rows than the minimum-observation threshold, or **while** an observed agent's support ratio for that subcommand is below the confidence threshold, the analyzer shall emit no proposal for that subcommand or agent respectively, so that a single stray row cannot produce a proposal.
+- **REQ-HLA-007** — The analyzer shall emit two proposal kinds and no others: an *undesignated-agent* proposal, where a retained-catalog agent clears both thresholds for a subcommand but is absent from that subcommand's designated agent list; and a *designated-never-spawned* proposal, where a designated agent is observed in zero qualifying rows for a subcommand that itself clears the minimum-observation threshold.
+- **REQ-HLA-008** — The analyzer shall exclude conditionally-invoked designations from *designated-never-spawned* proposals, using a declared exclusion set in which each entry cites the rule that makes its invocation conditional. `sync-auditor` and `plan-auditor` shall be members of that set.
+
+### D.4 — Emission and isolation
+
+- **REQ-HLA-009** — The analyzer shall read `.moai/config/sections/delegation.yaml` to resolve the designated agent list, shall open it read-only, and shall never write it.
+- **REQ-HLA-010** — The analyzer shall key each proposal with a `pattern_key` in the reserved namespace `delegation_map:<subcommand>:<discriminator>`, which shall not collide with the existing `tool_failure:` / `agent_invocation:` and other event-type-prefixed namespaces.
+- **REQ-HLA-011** — The analyzer shall not extend `harness.PatternBearingEventTypes()` and shall not route its candidates through `proposalgen.MapPromotions`; it shall construct its own candidates and emit them through the existing proposal writer and directory-layout accessor.
+- **REQ-HLA-012** — Each emitted proposal shall carry the observation count, the support ratio, the qualifying-row count for its subcommand, the unattributed share, and the proposal kind, so a reviewer can judge the amendment without re-reading the ledger.
+- **REQ-HLA-013** — The analyzer shall be deterministic: two runs over the same input shall produce the same candidate set in the same order, and re-running over an unchanged input shall not churn already-written draft directories.
+- **REQ-HLA-014** — **When** the ledger is absent, empty, entirely malformed, or over the size limit, the analyzer shall return an empty result with a machine-readable reason and shall exit successfully.
+- **REQ-HLA-015** — A CLI verb shall expose the analyzer with a dry-run mode that performs no filesystem write and a structured JSON result on standard output.
+- **REQ-HLA-016** — The analyzer shall not modify `.claude/lsel/frozen-allowlist.json` and shall not remove `^\.moai/config/sections/` from its frozen patterns; shall not invoke `AskUserQuestion`; and shall not emit a skill-level proposal, because the schema-v1 ledger records no skill-injection field.
+
+## §E. Central assumption and its falsification
+
+The design rests on one assumption: **ledger-observed delegation patterns carry enough signal to justify a delegation-map amendment.** It is not yet testable, because the data does not exist — which is why `SPEC-HARNESS-LEARNING-EVO-001` precedes it in practice even though it does not gate it.
+
+The assumption is falsified by any of the following, each bounded so it can actually be discharged. The review window opens once the ledger holds at least 50 qualifying rows and closes after the first 10 proposals reach the Tier-4 gate.
+
+- **F1 — no stable pattern.** For every subcommand clearing the minimum-observation threshold, no retained-catalog agent reaches the support-ratio threshold; the observed agent distribution is flat. The map cannot be evolved from a signal that does not concentrate.
+- **F2 — the map is already right.** The analyzer emits zero proposals of either kind across the whole catalogue, meaning the hand-tuned map already matches observed behavior and the automation buys nothing.
+- **F3 — proposals are systematically rejected.** Of the first 10 proposals surfaced at the Tier-4 gate within the review window, at least 8 are rejected by the reviewer — the signal is real but is not a valid basis for amendment.
+- **F4 — the observation is unattributable.** The unattributed share (REQ-HLA-005) stays at or above the 30.3% measured in §A.2 across every subcommand clearing the threshold, so no per-agent count can carry a proposal.
+
+Recording the falsifiers here is deliberate: F2 in particular is a *successful* outcome for the harness and a *negative* one for this SPEC, and the two must not be confused at review time.
+
+## §F. Upstream producer
+
+`SPEC-HARNESS-LEARNING-EVO-001` produces the rows this analyzer reads. The coupling is one-directional and non-blocking; that SPEC is listed under `related_specs` rather than `depends_on` deliberately, because a `depends_on` entry would gate this SPEC's run-phase entry on the sibling reaching `status: completed` (`.claude/rules/moai/workflow/spec-workflow.md` § Depends_on Pre-flight Check), which the fixture-based test strategy makes unnecessary.
+
+## §G. Exclusions
+
+### Out of Scope — instrumentation (L1)
+
+- No hook seams, no store API changes, no changes to how rows are created, annotated, or finalized. All of it belongs to `SPEC-HARNESS-LEARNING-EVO-001`.
+
+### Out of Scope — automated application to delegation.yaml (L3)
+
+- No automated writer for `.moai/config/sections/delegation.yaml`. Three independent surfaces agree that this file requires human approval: `.claude/lsel/frozen-allowlist.json` lists `^\.moai/config/sections/` among its frozen patterns; the file's own `auto_apply: false` key; and the Tier-4 gate language of the roadmap report. This is a deliberate design boundary, not an oversight or an unfinished edge.
+- No modification of the frozen allowlist to make the file writable.
+- No new approval gate: the existing Tier-4 `AskUserQuestion` flow applies unchanged, and no component introduced here invokes it.
+
+### Out of Scope — skill-level delegation proposals
+
+- No proposal of the form "subcommand X should add skill Y". The schema-v1 ledger row has no skill field, so a skill amendment cannot be grounded in observation. Extending the row schema to record injected skills is a candidate follow-up, recorded in `plan.md` §H.
+
+### Out of Scope — the usage-log / proposalgen tier ladder
+
+- `internal/harness/proposalgen/mapper.go`, the tier-promotion path, and `usage-log.jsonl` semantics are consumed as they are. The analyzer reuses the proposal *writer* and *layout*, not the promotion mapper.
+
+### Out of Scope — threshold tuning from real data
+
+- `MinQualifyingRows` and `MinSupportRatio` ship as declared constants chosen by analogy to the existing `proposalgen` precedent. Re-tuning them against real observations is deferred until the §E review window has run.

--- a/internal/cli/harness_ledger.go
+++ b/internal/cli/harness_ledger.go
@@ -52,8 +52,79 @@ Outcome is never accepted as an input on the write surfaces — it derives from
 machine evidence only (record and evidence carry no outcome-input flag).`,
 	}
 	cmd.AddCommand(newHarnessLedgerRecordCmd())
+	cmd.AddCommand(newHarnessLedgerAnnotateCmd())
 	cmd.AddCommand(newHarnessLedgerEvidenceCmd())
 	cmd.AddCommand(newHarnessLedgerListCmd())
+	return cmd
+}
+
+// newHarnessLedgerAnnotateCmd is `moai harness ledger annotate`
+// (SPEC-HARNESS-LEARNING-EVO-001 REQ-HLE-005).
+//
+// It patches routing metadata onto an existing pending row. Unlike `record` it
+// creates no row and finalizes none, which is what makes it safe to call from a
+// per-prompt path: `record` reroutes the session's own prior row, so calling it
+// once per turn would close a row every turn.
+//
+// Like `record` and `evidence`, it carries no --outcome flag — outcome derives
+// from machine evidence only.
+func newHarnessLedgerAnnotateCmd() *cobra.Command {
+	var (
+		subcommand string
+		mode       string
+		tier       string
+		level      string
+		clarify    int
+		sessionID  string
+		modelClass string
+	)
+	cmd := &cobra.Command{
+		Use:   "annotate",
+		Short: "Patch routing metadata onto an existing pending row",
+		Long: `Patch routing metadata (subcommand, mode, tier, harness level, clarify
+rounds, model class) onto the session's existing pending routing row.
+
+Creates nothing and finalizes nothing: a session with no pending row is a silent
+no-op. A flag left unset leaves the existing value untouched, so a later
+annotation never erases an earlier one by omission.
+
+Outcome is never accepted as an input here; it derives from machine evidence
+only (the un-fakeable-outcome contract).`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			root, err := resolveProjectRoot(cmd)
+			if err != nil {
+				return err
+			}
+			// Gate 1 (learning, fail-open): explicit disable => no-op.
+			if !isHarnessLearningEnabled(root) {
+				return nil
+			}
+			patch := routing.RoutingPatch{
+				MatchedSubcommand: optStr(subcommand),
+				ModeSelected:      optStr(mode),
+				Tier:              optStr(tier),
+				HarnessLevel:      optStr(level),
+				ModelClass:        optStr(modelClass),
+			}
+			// clarify-rounds is only patched when the flag was explicitly given,
+			// so an unset flag cannot silently reset a recorded count to zero.
+			if cmd.Flags().Changed("clarify-rounds") {
+				patch.ClarifyRounds = &clarify
+			}
+			if err := routing.NewStore(routingStateDir(root)).Annotate(sessionID, patch); err != nil {
+				return fmt.Errorf("ledger annotate: %w", err)
+			}
+			return nil
+		},
+	}
+	f := cmd.Flags()
+	f.StringVar(&subcommand, "subcommand", "", "matched /moai subcommand (plan|run|sync|...)")
+	f.StringVar(&mode, "mode", "", "Phase 0.95 mode (trivial|background|parallel|sub-agent|workflow)")
+	f.StringVar(&tier, "tier", "", "SPEC tier (S|M|L)")
+	f.StringVar(&level, "level", "", "harness level (minimal|standard|thorough)")
+	f.IntVar(&clarify, "clarify-rounds", 0, "clarification round count (patched only when set)")
+	f.StringVar(&sessionID, "session", "", "session id (empty => degraded single-session key)")
+	f.StringVar(&modelClass, "model-class", "", "model class (opus|fable|sonnet|glm|haiku|unknown)")
 	return cmd
 }
 

--- a/internal/cli/harness_ledger_test.go
+++ b/internal/cli/harness_ledger_test.go
@@ -233,3 +233,61 @@ func TestLedgerRecord_LearningDisabledNoOp(t *testing.T) {
 		t.Fatal("learning-disabled record must not create a pending row")
 	}
 }
+
+// TestHarnessLedgerAnnotateCmd covers the `moai harness ledger annotate` verb
+// (SPEC-HARNESS-LEARNING-EVO-001 AC-HLE-004, REQ-HLE-005): it patches an
+// existing pending row through the live command tree, creates nothing when no
+// row exists, and — like record and evidence — exposes no --outcome flag.
+func TestHarnessLedgerAnnotateCmd(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+
+	// A pending row with an empty matched_subcommand, seeded through the store.
+	store := routing.NewStore(filepath.Join(root, ".moai", "state"))
+	if err := store.RecordIfAbsent(routing.PendingRow{
+		SessionID:     "ann-s1",
+		RequestDigest: routing.RequestDigest("seed"),
+		RequestClass:  "feature",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	an := newHarnessRouterCmd()
+	an.SetArgs([]string{"ledger", "annotate", "--project-root", root, "--session", "ann-s1", "--subcommand", "run", "--tier", "L"})
+	an.SetOut(&bytes.Buffer{})
+	an.SetErr(&bytes.Buffer{})
+	if err := an.Execute(); err != nil {
+		t.Fatalf("ledger annotate: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(root, ".moai", "state", "routing-pending-ann-s1.json"))
+	if err != nil {
+		t.Fatalf("pending row must still exist after annotate: %v", err)
+	}
+	if !bytes.Contains(data, []byte(`"matched_subcommand":"run"`)) {
+		t.Fatalf("annotate did not patch matched_subcommand: %s", data)
+	}
+	if !bytes.Contains(data, []byte(`"tier":"L"`)) {
+		t.Fatalf("annotate did not patch tier: %s", data)
+	}
+	if ledgerRowCount(t, root) != 0 {
+		t.Fatal("annotate must not finalize anything into the ledger")
+	}
+
+	// No pending row -> silent no-op, nothing created.
+	ghost := newHarnessRouterCmd()
+	ghost.SetArgs([]string{"ledger", "annotate", "--project-root", root, "--session", "ann-ghost", "--subcommand", "plan"})
+	ghost.SetOut(&bytes.Buffer{})
+	ghost.SetErr(&bytes.Buffer{})
+	if err := ghost.Execute(); err != nil {
+		t.Fatalf("annotate with no pending row must be a silent no-op, got %v", err)
+	}
+	if pendingFileExists(root, "ann-ghost") {
+		t.Fatal("annotate must not fabricate a pending row")
+	}
+
+	// The un-fakeable-outcome contract extends to this write surface.
+	if newHarnessLedgerAnnotateCmd().Flags().Lookup("outcome") != nil {
+		t.Error("`ledger annotate` MUST NOT expose an --outcome flag (un-fakeable outcome contract)")
+	}
+}

--- a/internal/cli/hook.go
+++ b/internal/cli/hook.go
@@ -719,6 +719,26 @@ func runHarnessObserve(cmd *cobra.Command, _ []string) error {
 		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "harness-observe: event recording failed: %v\n", err)
 	}
 
+	// SPEC-HARNESS-LEARNING-EVO-001 REQ-HLE-011: Bash evidence carve-out.
+	//
+	// buildBashRecord is unreachable from the shipped hook wiring — its only
+	// caller runs behind handle-post-tool.sh, which is registered for
+	// Write|Edit|MultiEdit only — so the terminal test-pass / test-fail signal
+	// the Stop seam reads was never produced. This wrapper is registered with no
+	// matcher and does receive the full Bash payload, so routing Bash through the
+	// evidence path here restores reachability with no settings.json edit.
+	//
+	// Scoped to Bash: Write/Edit stay owned by handle-post-tool.sh, so no tool
+	// call produces two evidence records.
+	//
+	// Gated on the hook opt-in as well as the learning gate. The usage-log write
+	// above intentionally keeps its pre-existing single-gate behavior; this NEW
+	// write is a distinct emission path and REQ-HLE-013 requires it to stay inert
+	// while either observation gate is closed.
+	if hookInput.ToolName == "Bash" && isHookOptInEnabled(root) {
+		hook.LogBashEvidence(hookInput)
+	}
+
 	return nil
 }
 

--- a/internal/cli/hook.go
+++ b/internal/cli/hook.go
@@ -560,24 +560,10 @@ func runSecurityCommit(cmd *cobra.Command, args []string) error {
 // The gate is intentionally fail-open so that a corrupted or missing config
 // does not silently disable the observer. Explicit `false` is required to
 // suppress observation, matching the EARS state-driven semantics of REQ-HRN-FND-009.
+// The truth table above is implemented once, in package hook, so the CLI
+// handlers and the routing seams cannot drift apart on what "enabled" means.
 func isHarnessLearningEnabled(projectRoot string) bool {
-	configPath := filepath.Join(projectRoot, ".moai", "config", "sections", "harness.yaml")
-	data, err := os.ReadFile(configPath)
-	if err != nil {
-		return true
-	}
-	var doc struct {
-		Learning struct {
-			Enabled *bool `yaml:"enabled,omitempty"`
-		} `yaml:"learning,omitempty"`
-	}
-	if err := yaml.Unmarshal(data, &doc); err != nil {
-		return true
-	}
-	if doc.Learning.Enabled == nil {
-		return true
-	}
-	return *doc.Learning.Enabled
+	return hook.HarnessLearningEnabled(projectRoot)
 }
 
 // isHookOptInEnabled reports whether the SPEC-V3R6-HOOK-OBSERVE-OPT-IN-001
@@ -598,23 +584,10 @@ func isHarnessLearningEnabled(projectRoot string) bool {
 // Fail-CLOSED semantics intentionally differ from isHarnessLearningEnabled —
 // HOI is an opt-in toggle whose default state is OFF (REQ-HOI-001 default false).
 // See SPEC-V3R6-HOOK-OBSERVE-OPT-IN-001 §A.3 cohabitation contract.
+// The truth table above is implemented once, in package hook, so the CLI
+// handlers and the routing seams cannot drift apart on what "enabled" means.
 func isHookOptInEnabled(projectRoot string) bool {
-	configPath := filepath.Join(projectRoot, ".moai", "config", "sections", "system.yaml")
-	data, err := os.ReadFile(configPath)
-	if err != nil {
-		return false
-	}
-	var doc struct {
-		Hook struct {
-			OptIn struct {
-				Enabled bool `yaml:"enabled"`
-			} `yaml:"opt_in"`
-		} `yaml:"hook"`
-	}
-	if err := yaml.Unmarshal(data, &doc); err != nil {
-		return false
-	}
-	return doc.Hook.OptIn.Enabled
+	return hook.HookObserveOptInEnabled(projectRoot)
 }
 
 // runHarnessObserve reads PostToolUse hook stdin JSON and records event to usage-log.jsonl.
@@ -833,6 +806,14 @@ func runHarnessObserveStop(cmd *cobra.Command, _ []string) error {
 	// finalizer. Downstream of the EXISTING HOI (gate 0) + learning (gate 1) gates
 	// already applied above. Finalizes a pending routing row into the ledger only
 	// when its machine evidence derives a terminal outcome; no-op otherwise.
+	// Routing-ledger seam C (SPEC-HARNESS-LEARNING-EVO-001 REQ-HLE-010). Runs
+	// immediately BEFORE the finalizer: when the session evidence path observed a
+	// terminal test pass or fail, it appends the matching terminal gate_exit ref
+	// so the finalizer below can close the row as success or fail rather than
+	// only as reroute or abort. Absence appends nothing, and the finalizer then
+	// leaves the row pending exactly as before.
+	hook.RoutingSeamStopEvidence(root, hookInput.SessionID)
+
 	finalizeRoutingLedgerOnStop(root, hookInput.SessionID, cmd.ErrOrStderr())
 
 	return nil

--- a/internal/cli/hook_routing_ledger_test.go
+++ b/internal/cli/hook_routing_ledger_test.go
@@ -1,0 +1,238 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/modu-ai/moai-adk/internal/config"
+	"github.com/modu-ai/moai-adk/internal/telemetry"
+)
+
+// bashPostToolPayload is the VERBATIM shape Claude Code 2.1.226 delivers to a
+// matcher-null PostToolUse hook for a Bash call, captured by the M0 probe
+// (plan.md §F M0). It is reproduced here rather than invented so that a runtime
+// wire-format change shows up as a failing test rather than as a silently empty
+// telemetry file.
+//
+// Two properties of the real payload are load-bearing and easy to get wrong:
+//   - it arrives FLAT snake_case, not nested camelCase;
+//   - tool_response carries stdout/stderr but NO exit_code field, so pass/fail
+//     detection falls through to the output-text heuristic.
+func bashPostToolPayload(command, stdout string) string {
+	payload := map[string]any{
+		"session_id":      "sess-bash-1",
+		"cwd":             "/tmp/probe",
+		"permission_mode": "acceptEdits",
+		"hook_event_name": "PostToolUse",
+		"tool_name":       "Bash",
+		"tool_input": map[string]any{
+			"command":     command,
+			"description": "run the test suite",
+		},
+		"tool_response": map[string]any{
+			"stdout":           stdout,
+			"stderr":           "",
+			"interrupted":      false,
+			"isImage":          false,
+			"noOutputExpected": false,
+		},
+		"tool_use_id": "toolu_01probe",
+		"duration_ms": 462,
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		panic(err)
+	}
+	return string(data)
+}
+
+// readTelemetryRecords returns every usage record written under root today.
+func readTelemetryRecords(t *testing.T, root string) []telemetry.UsageRecord {
+	t.Helper()
+	day := time.Now().UTC().Format("2006-01-02")
+	path := filepath.Join(root, ".moai", "evolution", "telemetry", "usage-"+day+".jsonl")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatalf("read telemetry: %v", err)
+	}
+	var out []telemetry.UsageRecord
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var rec telemetry.UsageRecord
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			t.Fatalf("parse telemetry line %q: %v", line, err)
+		}
+		out = append(out, rec)
+	}
+	return out
+}
+
+// TestHarnessObserve_BashEvidenceRecorded is the AC-HLE-013 positive half
+// (REQ-HLE-011): the Bash evidence-record path, measured as unreachable from the
+// shipped hook wiring, now executes on the matcher-null observe channel.
+//
+// The handle-post-tool.sh wrapper is registered for Write|Edit|MultiEdit only, so
+// its Bash branch never runs in production. The observe wrapper IS registered for
+// every tool; this test drives that handler with the real Bash payload and
+// asserts a telemetry record with is_test_pass actually lands.
+func TestHarnessObserve_BashEvidenceRecorded(t *testing.T) {
+	root := t.TempDir()
+	writeHarnessYAML(t, root, "learning:\n  enabled: true\n")
+	writeConfig(t, root, "system.yaml", "hook:\n  opt_in:\n    enabled: true\n")
+	t.Setenv(config.EnvClaudeProjectDir, root)
+	t.Chdir(root)
+
+	cmd := &cobra.Command{}
+	withStdin(t, bashPostToolPayload("go test ./...", "ok  \tgithub.com/x/y\t0.42s\n"), func() {
+		if err := runHarnessObserve(cmd, nil); err != nil {
+			t.Fatalf("runHarnessObserve returned error: %v", err)
+		}
+	})
+
+	recs := readTelemetryRecords(t, root)
+	if len(recs) != 1 {
+		t.Fatalf("got %d telemetry records, want exactly 1 (the Bash evidence record)", len(recs))
+	}
+	if !recs[0].IsTestPass {
+		t.Errorf("is_test_pass = false; the observed passing test result must set it (record: %+v)", recs[0])
+	}
+	if recs[0].IsTestFail {
+		t.Errorf("is_test_fail must not be set on a passing run (record: %+v)", recs[0])
+	}
+	if recs[0].SessionID != "sess-bash-1" {
+		t.Errorf("session_id = %q, want sess-bash-1 (session correlation is what the Stop seam reads)", recs[0].SessionID)
+	}
+}
+
+// TestHarnessObserve_BashEvidenceTestFail pins the failing-run direction. The
+// real payload carries no exit_code (M0 probe), so this exercises the
+// output-text fallback rather than the structured exit-code path.
+func TestHarnessObserve_BashEvidenceTestFail(t *testing.T) {
+	root := t.TempDir()
+	writeHarnessYAML(t, root, "learning:\n  enabled: true\n")
+	writeConfig(t, root, "system.yaml", "hook:\n  opt_in:\n    enabled: true\n")
+	t.Setenv(config.EnvClaudeProjectDir, root)
+	t.Chdir(root)
+
+	cmd := &cobra.Command{}
+	withStdin(t, bashPostToolPayload("go test ./...", "--- FAIL: TestX (0.01s)\nFAIL\n"), func() {
+		if err := runHarnessObserve(cmd, nil); err != nil {
+			t.Fatalf("runHarnessObserve returned error: %v", err)
+		}
+	})
+
+	recs := readTelemetryRecords(t, root)
+	if len(recs) != 1 {
+		t.Fatalf("got %d telemetry records, want exactly 1", len(recs))
+	}
+	if !recs[0].IsTestFail || recs[0].IsTestPass {
+		t.Errorf("want is_test_fail=true is_test_pass=false, got %+v", recs[0])
+	}
+}
+
+// TestHarnessObserve_NonTestBashWritesNoEvidence keeps the write-volume
+// discipline visible: a non-test Bash command produces no evidence record, so
+// the carve-out cannot quietly turn every shell call into a telemetry line.
+func TestHarnessObserve_NonTestBashWritesNoEvidence(t *testing.T) {
+	root := t.TempDir()
+	writeHarnessYAML(t, root, "learning:\n  enabled: true\n")
+	writeConfig(t, root, "system.yaml", "hook:\n  opt_in:\n    enabled: true\n")
+	t.Setenv(config.EnvClaudeProjectDir, root)
+	t.Chdir(root)
+
+	cmd := &cobra.Command{}
+	withStdin(t, bashPostToolPayload("ls -la", "total 0\n"), func() {
+		if err := runHarnessObserve(cmd, nil); err != nil {
+			t.Fatalf("runHarnessObserve returned error: %v", err)
+		}
+	})
+
+	if recs := readTelemetryRecords(t, root); len(recs) != 0 {
+		t.Fatalf("non-test Bash must write no evidence record, got %d: %+v", len(recs), recs)
+	}
+}
+
+// TestHarnessObserve_NonBashToolWritesNoEvidence is the AC-HLE-013 no-double-write
+// half as seen from the observe channel: Edit and Write are already owned by
+// handle-post-tool.sh, so the observe handler must NOT also record evidence for
+// them. Without this scoping every Edit would produce two telemetry records
+// (plan.md §G AP-8).
+func TestHarnessObserve_NonBashToolWritesNoEvidence(t *testing.T) {
+	root := t.TempDir()
+	writeHarnessYAML(t, root, "learning:\n  enabled: true\n")
+	writeConfig(t, root, "system.yaml", "hook:\n  opt_in:\n    enabled: true\n")
+	t.Setenv(config.EnvClaudeProjectDir, root)
+	t.Chdir(root)
+
+	payload := `{"session_id":"sess-edit","hook_event_name":"PostToolUse","tool_name":"Edit",` +
+		`"tool_input":{"file_path":"/tmp/probe/main.go"},"tool_response":{"stdout":""}}`
+
+	cmd := &cobra.Command{}
+	withStdin(t, payload, func() {
+		if err := runHarnessObserve(cmd, nil); err != nil {
+			t.Fatalf("runHarnessObserve returned error: %v", err)
+		}
+	})
+
+	if recs := readTelemetryRecords(t, root); len(recs) != 0 {
+		t.Fatalf("observe channel must not record evidence for Edit (handle-post-tool.sh owns it), got %d: %+v", len(recs), recs)
+	}
+}
+
+// TestHarnessObserve_BashEvidenceGated pins REQ-HLE-013 for the carve-out: with
+// either observation gate closed, no telemetry file is written at all.
+func TestHarnessObserve_BashEvidenceGated(t *testing.T) {
+	cases := []struct {
+		name       string
+		systemYAML string
+		harnessYML string
+	}{
+		{
+			name:       "hook opt-in closed",
+			systemYAML: "hook:\n  opt_in:\n    enabled: false\n",
+			harnessYML: "learning:\n  enabled: true\n",
+		},
+		{
+			name:       "hook opt-in absent (fail-closed default)",
+			systemYAML: "other: 1\n",
+			harnessYML: "learning:\n  enabled: true\n",
+		},
+		{
+			name:       "learning closed",
+			systemYAML: "hook:\n  opt_in:\n    enabled: true\n",
+			harnessYML: "learning:\n  enabled: false\n",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeHarnessYAML(t, root, tc.harnessYML)
+			writeConfig(t, root, "system.yaml", tc.systemYAML)
+			t.Setenv(config.EnvClaudeProjectDir, root)
+			t.Chdir(root)
+
+			cmd := &cobra.Command{}
+			withStdin(t, bashPostToolPayload("go test ./...", "ok  \tpkg\t0.1s\n"), func() {
+				if err := runHarnessObserve(cmd, nil); err != nil {
+					t.Fatalf("runHarnessObserve returned error: %v", err)
+				}
+			})
+
+			if recs := readTelemetryRecords(t, root); len(recs) != 0 {
+				t.Fatalf("a closed gate must write no evidence record, got %d: %+v", len(recs), recs)
+			}
+		})
+	}
+}

--- a/internal/cli/hook_routing_ledger_test.go
+++ b/internal/cli/hook_routing_ledger_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -11,6 +12,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/modu-ai/moai-adk/internal/config"
+	"github.com/modu-ai/moai-adk/internal/harness/routing"
+	"github.com/modu-ai/moai-adk/internal/hook"
 	"github.com/modu-ai/moai-adk/internal/telemetry"
 )
 
@@ -235,4 +238,109 @@ func TestHarnessObserve_BashEvidenceGated(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestRoutingLedger_TerminalCloseEndToEnd — AC-HLE-014 (REQ-HLE-010).
+//
+// Drives the seam sequence in production order — UserPromptSubmit, two
+// SubagentStop invocations, then the Stop path with an observed test signal —
+// and asserts the row closes as success or fail with its delegations intact.
+//
+// Scope caveat, stated rather than implied: this drives the production handler
+// functions against a temp root. It does NOT prove that Claude Code invokes
+// those handlers in a live session — that depends on the runtime's hook
+// dispatch, on settings.json registration, and on the fail-closed opt-in gate
+// being enabled locally. No CI-runnable assertion can cover that link
+// (acceptance.md §F R1); it needs a manual dogfood check.
+func TestRoutingLedger_TerminalCloseEndToEnd(t *testing.T) {
+	cases := []struct {
+		name        string
+		stdout      string
+		wantOutcome routing.Outcome
+	}{
+		{"observed test pass closes success", "ok  \tgithub.com/x/y\t0.42s\n", routing.OutcomeSuccess},
+		{"observed test fail closes fail", "--- FAIL: TestX (0.01s)\nFAIL\n", routing.OutcomeFail},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeConfig(t, root, "system.yaml", "hook:\n  opt_in:\n    enabled: true\n")
+			writeConfig(t, root, "harness.yaml", "learning:\n  enabled: true\n")
+			t.Setenv(config.EnvClaudeProjectDir, root)
+
+			const sessionID = "e2e-sess"
+
+			// Seam A — a prompt creates the pending row.
+			hook.RoutingSeamUserPromptSubmit(&hook.HookInput{
+				SessionID: sessionID, Prompt: "/moai run SPEC-X", CWD: root,
+			})
+
+			// Seam B — two subagents stop.
+			hook.RoutingSeamSubagentStop(&hook.HookInput{SessionID: sessionID, AgentType: "manager-develop", CWD: root})
+			hook.RoutingSeamSubagentStop(&hook.HookInput{SessionID: sessionID, AgentType: "plan-auditor", CWD: root})
+
+			// The terminal machine signal arrives through the restored Bash
+			// evidence path — the same route production uses, not a hand-written
+			// telemetry file.
+			t.Chdir(root)
+			cmd := &cobra.Command{}
+			withStdin(t, bashPostToolPayloadFor(sessionID, "go test ./...", tc.stdout), func() {
+				if err := runHarnessObserve(cmd, nil); err != nil {
+					t.Fatalf("runHarnessObserve: %v", err)
+				}
+			})
+
+			// Seam C + the existing finalizer, in the Stop path's order.
+			hook.RoutingSeamStopEvidence(root, sessionID)
+			finalizeRoutingLedgerOnStop(root, sessionID, &bytes.Buffer{})
+
+			rows, _, err := routing.NewReader(filepath.Join(root, ".moai", "state", routing.LedgerFileName)).Read(routing.Filter{})
+			if err != nil {
+				t.Fatalf("read ledger: %v", err)
+			}
+			if len(rows) != 1 {
+				t.Fatalf("got %d ledger rows, want exactly 1 finalized row", len(rows))
+			}
+			r := rows[0]
+			if r.Outcome != tc.wantOutcome {
+				t.Errorf("outcome = %q, want %q", r.Outcome, tc.wantOutcome)
+			}
+			if len(r.EvidenceRefs) == 0 {
+				t.Error("evidence_refs is empty; the terminal signal must be recorded on the row")
+			}
+			if len(r.Delegations) != 2 {
+				t.Fatalf("delegations = %d, want 2 — this is the field that was empty on every pre-SPEC row", len(r.Delegations))
+			}
+			if r.Delegations[0].Agent != "manager-develop" || r.Delegations[1].Agent != "plan-auditor" {
+				t.Errorf("delegation agents = %q/%q, want manager-develop/plan-auditor",
+					r.Delegations[0].Agent, r.Delegations[1].Agent)
+			}
+			if r.MatchedSubcommand != "run" {
+				t.Errorf("matched_subcommand = %q, want run", r.MatchedSubcommand)
+			}
+			if pendingFileExists(root, sessionID) {
+				t.Error("the finalized pending file must be removed")
+			}
+		})
+	}
+}
+
+// bashPostToolPayloadFor is bashPostToolPayload with a caller-chosen session id,
+// so the evidence record correlates with the routing row under test.
+func bashPostToolPayloadFor(sessionID, command, stdout string) string {
+	payload := map[string]any{
+		"session_id":      sessionID,
+		"hook_event_name": "PostToolUse",
+		"tool_name":       "Bash",
+		"tool_input":      map[string]any{"command": command},
+		"tool_response": map[string]any{
+			"stdout": stdout, "stderr": "", "interrupted": false,
+		},
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		panic(err)
+	}
+	return string(data)
 }

--- a/internal/harness/routing/pending.go
+++ b/internal/harness/routing/pending.go
@@ -136,6 +136,18 @@ func (s *Store) RecordIfAbsent(row PendingRow) error {
 	return s.writePending(row)
 }
 
+// LoadPending returns the session's pending row. The bool is false (with a nil
+// error) when the session has no pending row.
+//
+// The seams need to READ current state to decide, not only to write: the
+// first-writer-wins subcommand policy (REQ-HLE-006) asks "is this field still
+// empty?", and that question belongs to the seam rather than to the store —
+// baking the policy into Annotate would make the store the owner of a decision
+// the SPEC deliberately places at the call site.
+func (s *Store) LoadPending(sessionID string) (PendingRow, bool, error) {
+	return s.loadPending(s.pendingPath(sessionID))
+}
+
 // Annotate patches routing metadata onto an existing pending row (REQ-HLE-005).
 // It creates nothing and finalizes nothing: a session with no pending row is a
 // silent no-op, because annotation describes an observation already in flight

--- a/internal/harness/routing/pending.go
+++ b/internal/harness/routing/pending.go
@@ -67,6 +67,24 @@ func (s *Store) pendingPath(sessionID string) string {
 // FOREIGN rows as abort and (2) rerouting this session's own prior pending row
 // (REQ-HEV-011). Dispatch-time defaults are filled here.
 func (s *Store) Record(row PendingRow) error {
+	s.applyDispatchDefaults(&row)
+
+	// (1) Age-guarded, liveness-guarded stale sweep of FOREIGN rows.
+	if err := s.sweepStale(row.SessionID); err != nil {
+		return err
+	}
+	// (2) Same-session reroute (age-independent — REQ-HEV-010 precedence: the
+	//     current session's own row is ALWAYS rerouted, never swept).
+	if err := s.rerouteSelf(row.SessionID); err != nil {
+		return err
+	}
+	// (3) Persist the fresh pending row.
+	return s.writePending(row)
+}
+
+// applyDispatchDefaults fills the dispatch-time defaults shared by Record and
+// RecordIfAbsent (schema version, timestamps, model class, non-nil slices).
+func (s *Store) applyDispatchDefaults(row *PendingRow) {
 	row.SchemaVersion = SchemaVersion
 	if row.CreatedAt.IsZero() {
 		row.CreatedAt = s.now().UTC()
@@ -83,18 +101,61 @@ func (s *Store) Record(row PendingRow) error {
 	if row.EvidenceRefs == nil {
 		row.EvidenceRefs = []EvidenceRef{}
 	}
+}
 
-	// (1) Age-guarded, liveness-guarded stale sweep of FOREIGN rows.
-	if err := s.sweepStale(row.SessionID); err != nil {
-		return err
+// RecordIfAbsent creates a pending row for row.SessionID only when the session
+// has none; when a row already exists it is a pure no-op that preserves the
+// existing row's content untouched (REQ-HLE-003, REQ-HLE-004).
+//
+// It differs from Record in the two ways that matter, and both are deliberate:
+//
+//   - it never calls rerouteSelf. Record's reroute-on-redispatch is correct for
+//     an explicit re-dispatch, but this operation runs once per user prompt, and
+//     a multi-turn pipeline spans many prompts — rerouting there would close a
+//     row every turn and produce exactly the reroute-only ledger this SPEC exists
+//     to repair (plan.md §G AP-1).
+//   - it never calls sweepStale. The sweep costs an os.ReadDir plus one read per
+//     foreign pending file; on a per-prompt path that converts a once-per-dispatch
+//     directory scan into a once-per-prompt one (REQ-HLE-015, plan.md §G AP-2).
+//     The sweep stays bounded to the dispatch path, where Record still runs it.
+//
+// Record is left untouched, so the dispatch path keeps both sweep guards.
+func (s *Store) RecordIfAbsent(row PendingRow) error {
+	path := s.pendingPath(row.SessionID)
+	existing, ok, err := s.loadPending(path)
+	if err != nil {
+		// A malformed own-pending file is dropped so a fresh row can replace it,
+		// mirroring rerouteSelf's handling — but WITHOUT finalizing anything,
+		// because an unparseable row has no content worth appending to the ledger.
+		_ = os.Remove(path)
+	} else if ok {
+		_ = existing // present -> no-op; content is preserved verbatim.
+		return nil
 	}
-	// (2) Same-session reroute (age-independent — REQ-HEV-010 precedence: the
-	//     current session's own row is ALWAYS rerouted, never swept).
-	if err := s.rerouteSelf(row.SessionID); err != nil {
-		return err
-	}
-	// (3) Persist the fresh pending row.
+	s.applyDispatchDefaults(&row)
 	return s.writePending(row)
+}
+
+// Annotate patches routing metadata onto an existing pending row (REQ-HLE-005).
+// It creates nothing and finalizes nothing: a session with no pending row is a
+// silent no-op, because annotation describes an observation already in flight
+// and fabricating a row for it would invent an observation that never happened.
+// Patch fields that are nil (or empty) leave the existing value untouched.
+func (s *Store) Annotate(sessionID string, patch RoutingPatch) error {
+	if patch.IsEmpty() {
+		return nil
+	}
+	pending, ok, err := s.loadPending(s.pendingPath(sessionID))
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	if !patch.apply(&pending) {
+		return nil
+	}
+	return s.writePending(pending)
 }
 
 // AppendEvidence appends a machine evidence ref to the session's pending row.

--- a/internal/harness/routing/pending_test.go
+++ b/internal/harness/routing/pending_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -370,5 +371,297 @@ func TestNoVerbatimInStoreFiles(t *testing.T) {
 		if bytes.Contains(data, []byte(sentinel)) {
 			t.Fatalf("verbatim request text leaked into %s", e.Name())
 		}
+	}
+}
+
+// ─────────────────────────────────────────────────────────────
+// SPEC-HARNESS-LEARNING-EVO-001 M1 — create-if-absent + annotate
+// ─────────────────────────────────────────────────────────────
+
+// TestRecordIfAbsent_Lifecycle pins the create-once semantics (AC-HLE-001,
+// REQ-HLE-003/004): the second and third calls are no-ops that must NOT clobber
+// content accumulated in between, and no call ever appends a ledger row.
+func TestRecordIfAbsent_Lifecycle(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	s := NewStore(dir)
+
+	if err := s.RecordIfAbsent(recordRow("sess-L", "plan")); err != nil {
+		t.Fatal(err)
+	}
+	// Second call for the same session: must be a no-op.
+	if err := s.RecordIfAbsent(recordRow("sess-L", "run")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Accumulate content, then call a third time.
+	if err := s.AppendDelegation("sess-L", Delegation{Agent: "manager-develop", Outcome: "success"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AppendDelegation("sess-L", Delegation{Agent: "plan-auditor", Outcome: "success"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AppendEvidence("sess-L", EvidenceRef{Kind: KindGateExit, Value: "0"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RecordIfAbsent(recordRow("sess-L", "sync")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Exactly one pending file for the session, content preserved.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pendingCount := 0
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), pendingPrefix) && strings.HasSuffix(e.Name(), pendingSuffix) {
+			pendingCount++
+		}
+	}
+	if pendingCount != 1 {
+		t.Fatalf("got %d pending files, want exactly 1", pendingCount)
+	}
+
+	p, ok, err := s.loadPending(s.pendingPath("sess-L"))
+	if err != nil || !ok {
+		t.Fatalf("load pending: ok=%v err=%v", ok, err)
+	}
+	if len(p.Delegations) != 2 {
+		t.Fatalf("delegations = %d, want 2 (third RecordIfAbsent must not clobber)", len(p.Delegations))
+	}
+	if len(p.EvidenceRefs) != 1 {
+		t.Fatalf("evidence_refs = %d, want 1 (third RecordIfAbsent must not clobber)", len(p.EvidenceRefs))
+	}
+	// The first writer's subcommand survives; later calls do not relabel.
+	if p.MatchedSubcommand != "plan" {
+		t.Fatalf("matched_subcommand = %q, want %q (create-once)", p.MatchedSubcommand, "plan")
+	}
+	if rows := readLedger(t, dir); len(rows) != 0 {
+		t.Fatalf("RecordIfAbsent must never append a ledger row, got %d: %+v", len(rows), rows)
+	}
+}
+
+// TestRecord_StillReroutesSelf pins that the pre-existing dispatch path is
+// unchanged by this SPEC (AC-HLE-001, REQ-HLE-004). RecordIfAbsent must not have
+// been implemented by weakening Record.
+func TestRecord_StillReroutesSelf(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	s := NewStore(dir)
+
+	if err := s.Record(recordRow("sess-R", "plan")); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Record(recordRow("sess-R", "run")); err != nil {
+		t.Fatal(err)
+	}
+	rows := readLedger(t, dir)
+	if len(rows) != 1 || rows[0].Outcome != OutcomeReroute {
+		t.Fatalf("Record must still reroute the prior row, got %+v", rows)
+	}
+}
+
+// TestRecordIfAbsent_NoSweepOnCreatePath is the behavioral proxy for
+// REQ-HLE-015 / AC-HLE-002: five stale, dead foreign rows are left completely
+// untouched by RecordIfAbsent, while the same fixture under Record sweeps them.
+// The contrast is what makes this a proof of absence rather than of nothing.
+func TestRecordIfAbsent_NoSweepOnCreatePath(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+
+	seed := func(dir string) []string {
+		names := make([]string, 0, 5)
+		for _, id := range []string{"f1", "f2", "f3", "f4", "f5"} {
+			writeForeignPending(t, dir, id, now.Add(-48*time.Hour)) // stale by age
+			names = append(names, id)
+		}
+		return names
+	}
+
+	t.Run("RecordIfAbsent does not sweep", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		foreign := seed(dir)
+		before := make(map[string][]byte, len(foreign))
+		for _, id := range foreign {
+			data, err := os.ReadFile(filepath.Join(dir, pendingPrefix+id+pendingSuffix))
+			if err != nil {
+				t.Fatal(err)
+			}
+			before[id] = data
+		}
+
+		s := NewStore(dir).WithClock(fixedClock(now))
+		if err := s.RecordIfAbsent(recordRow("fresh", "run")); err != nil {
+			t.Fatal(err)
+		}
+
+		for _, id := range foreign {
+			data, err := os.ReadFile(filepath.Join(dir, pendingPrefix+id+pendingSuffix))
+			if err != nil {
+				t.Fatalf("foreign pending %s must not be removed: %v", id, err)
+			}
+			if !bytes.Equal(data, before[id]) {
+				t.Fatalf("foreign pending %s must not be modified", id)
+			}
+		}
+		if rows := readLedger(t, dir); len(rows) != 0 {
+			t.Fatalf("RecordIfAbsent must not append abort rows (sweep did not run), got %d", len(rows))
+		}
+	})
+
+	t.Run("Record still sweeps the same fixture", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		seed(dir)
+		s := NewStore(dir).WithClock(fixedClock(now))
+		if err := s.Record(recordRow("fresh", "run")); err != nil {
+			t.Fatal(err)
+		}
+		rows := readLedger(t, dir)
+		if len(rows) != 5 {
+			t.Fatalf("Record must sweep all 5 stale foreign rows, got %d", len(rows))
+		}
+		for _, r := range rows {
+			if r.Outcome != OutcomeAbort {
+				t.Fatalf("swept row outcome = %q, want abort", r.Outcome)
+			}
+		}
+	})
+}
+
+// TestSweepStale_AgeAndLivenessGuards pins BOTH sweep guards on the dispatch
+// path (AC-HLE-003, REQ-HLE-004). These are what protect a concurrent
+// same-checkout session's in-flight row from a false abort.
+func TestSweepStale_AgeAndLivenessGuards(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	now := time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+
+	// Both foreign rows are aged PAST the threshold; only liveness separates them.
+	writeForeignPending(t, dir, "aged-dead", now.Add(-25*time.Hour))
+	writeForeignPending(t, dir, "aged-live", now.Add(-25*time.Hour))
+	if err := os.WriteFile(filepath.Join(dir, activeSessionsFile),
+		[]byte(`[{"session_id":"aged-live","pid":4242}]`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := NewStore(dir).WithClock(fixedClock(now))
+	if err := s.Record(recordRow("third", "run")); err != nil {
+		t.Fatal(err)
+	}
+
+	rows := readLedger(t, dir)
+	if len(rows) != 1 {
+		t.Fatalf("exactly one row must be swept, got %d: %+v", len(rows), rows)
+	}
+	if rows[0].SessionID != "aged-dead" || rows[0].Outcome != OutcomeAbort {
+		t.Fatalf("swept row = %+v; want session=aged-dead outcome=abort", rows[0])
+	}
+	if pendingExists(dir, "aged-dead") {
+		t.Fatal("age guard passed + not live -> pending file must be removed")
+	}
+	if !pendingExists(dir, "aged-live") {
+		t.Fatal("liveness guard must protect the live-listed row regardless of age")
+	}
+}
+
+// TestAnnotate covers the patch-only operation (AC-HLE-004, REQ-HLE-005):
+// patches an existing row, leaves empty fields untouched, creates nothing, and
+// finalizes nothing.
+func TestAnnotate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("patches set fields and leaves empty ones untouched", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		s := NewStore(dir)
+		if err := s.RecordIfAbsent(PendingRow{SessionID: "an-1"}); err != nil {
+			t.Fatal(err)
+		}
+		// Seed a mode so the later empty-mode patch has something to preserve.
+		mode := "sub-agent"
+		if err := s.Annotate("an-1", RoutingPatch{ModeSelected: &mode}); err != nil {
+			t.Fatal(err)
+		}
+		sub, tier := "plan", "M"
+		if err := s.Annotate("an-1", RoutingPatch{MatchedSubcommand: &sub, Tier: &tier}); err != nil {
+			t.Fatal(err)
+		}
+
+		p, ok, err := s.loadPending(s.pendingPath("an-1"))
+		if err != nil || !ok {
+			t.Fatalf("load pending: ok=%v err=%v", ok, err)
+		}
+		if p.MatchedSubcommand != "plan" {
+			t.Errorf("matched_subcommand = %q, want plan", p.MatchedSubcommand)
+		}
+		if p.Tier == nil || *p.Tier != "M" {
+			t.Errorf("tier = %v, want M", p.Tier)
+		}
+		if p.ModeSelected == nil || *p.ModeSelected != "sub-agent" {
+			t.Errorf("mode_selected = %v; an unset patch field must leave the existing value untouched", p.ModeSelected)
+		}
+		if rows := readLedger(t, dir); len(rows) != 0 {
+			t.Fatalf("Annotate must not append a ledger row, got %d", len(rows))
+		}
+	})
+
+	t.Run("no pending row is a no-op that creates nothing", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		s := NewStore(dir)
+		sub := "run"
+		if err := s.Annotate("ghost", RoutingPatch{MatchedSubcommand: &sub}); err != nil {
+			t.Fatalf("annotate with no pending row must be a silent no-op, got %v", err)
+		}
+		if pendingExists(dir, "ghost") {
+			t.Fatal("Annotate must not fabricate a pending row")
+		}
+		if rows := readLedger(t, dir); len(rows) != 0 {
+			t.Fatalf("Annotate must not append a ledger row, got %d", len(rows))
+		}
+	})
+}
+
+// TestSchemaVersionStable pins REQ-HLE-014 / AC-HLE-005: this SPEC is additive
+// within schema v1. A ledger fixture written before it still parses, and every
+// row the store writes carries schema_version 1.
+func TestSchemaVersionStable(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	// A pre-SPEC ledger fixture (schema v1, no fields from this SPEC).
+	legacy := `{"schema_version":1,"ts":"2026-07-01T00:00:00Z","session_id":"legacy-1","model_class":"unknown",` +
+		`"request_digest":"sha256:abcdef123456","request_class":"feature","matched_subcommand":"plan",` +
+		`"mode_selected":null,"tier":null,"harness_level":null,"clarify_rounds":0,"outcome":"abort",` +
+		`"loop_iterations":0,"goal_converged":null,"convergence_class":null,"delegations":[],"evidence_refs":[]}` + "\n"
+	if err := os.WriteFile(filepath.Join(dir, LedgerFileName), []byte(legacy), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := NewStore(dir)
+	if err := s.RecordIfAbsent(recordRow("new-1", "run")); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AppendEvidence("new-1", EvidenceRef{Kind: KindGateExit, Value: "0", Terminal: true, Ref: "go test"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.FinalizeOnStop("new-1", nil); err != nil {
+		t.Fatal(err)
+	}
+
+	rows := readLedger(t, dir)
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2 (legacy + new); a legacy row failing to parse would show here", len(rows))
+	}
+	for _, r := range rows {
+		if r.SchemaVersion != 1 {
+			t.Errorf("row %s schema_version = %d, want 1", r.SessionID, r.SchemaVersion)
+		}
+	}
+	if rows[0].SessionID != "legacy-1" || rows[0].MatchedSubcommand != "plan" {
+		t.Errorf("legacy row did not round-trip: %+v", rows[0])
 	}
 }

--- a/internal/harness/routing/types.go
+++ b/internal/harness/routing/types.go
@@ -90,14 +90,104 @@ type EvidenceRef struct {
 	Terminal bool         `json:"terminal,omitempty"`
 }
 
+// AgentUnattributed is the marker recorded in Delegation.Agent when the stopping
+// subagent supplied no agent identity at all (REQ-HLE-008). It is deliberately
+// NOT the empty string: an unattributed delegation must stay countable, and an
+// empty value is indistinguishable from an attributed one that serialized badly.
+// The angle brackets keep it outside the space of real agent and spawn names, so
+// no consumer can mistake it for one.
+const AgentUnattributed = "<unattributed>"
+
+// OutcomeUnknownDelegation is the marker recorded in Delegation.Outcome when no
+// outcome signal was observable for a stopping subagent (REQ-HLE-009). Absence
+// of a failure signal is not evidence of success, so the seam records this
+// rather than inferring "success" — see plan.md §G AP-3.
+//
+// It is a Delegation-level marker and intentionally distinct from the row-level
+// Outcome enum above: a delegation whose outcome was never observed must not be
+// confusable with a row that terminated.
+const OutcomeUnknownDelegation = "unknown"
+
 // Delegation is one subagent delegation trajectory entry (REQ-HEV-004, design
 // delta A4). Blocker carries the structured blocker category when the delegation
 // returned a blocker report (a structurally observable artifact); null otherwise.
+//
+// Agent holds the hook input's agent_type VERBATIM (REQ-HLE-007) — it is not a
+// validated enum. Two observed shapes make that explicit:
+//
+//   - a named spawn puts the spawn NAME in agent_type, not the agent type, so a
+//     value like "audit-hle" is a legitimate recording of a plan-auditor spawn;
+//   - roughly a third of observed subagent_stop events carry no agent_type, and
+//     those are recorded as AgentUnattributed.
+//
+// Normalizing an unrecognized value onto a catalog name, or dropping the entry,
+// is prohibited at the seam (plan.md §G AP-7): discrimination is the consumer's
+// job, and doing it here would erase the distinction the consumer needs.
 type Delegation struct {
 	Agent     string  `json:"agent"`
 	CycleType string  `json:"cycle_type,omitempty"`
 	Outcome   string  `json:"outcome"`
 	Blocker   *string `json:"blocker"`
+}
+
+// RoutingPatch carries the six annotatable routing-metadata fields as optional
+// values (REQ-HLE-005). A nil field means "leave the existing value untouched";
+// only non-nil fields are written. Pointer-optionality is what makes the
+// distinction expressible at all — a plain string cannot separate "clear this"
+// from "do not touch this".
+type RoutingPatch struct {
+	MatchedSubcommand *string
+	ModeSelected      *string
+	Tier              *string
+	HarnessLevel      *string
+	ClarifyRounds     *int
+	ModelClass        *string
+}
+
+// IsEmpty reports whether the patch would change nothing.
+func (p RoutingPatch) IsEmpty() bool {
+	return p.MatchedSubcommand == nil &&
+		p.ModeSelected == nil &&
+		p.Tier == nil &&
+		p.HarnessLevel == nil &&
+		p.ClarifyRounds == nil &&
+		p.ModelClass == nil
+}
+
+// apply writes the patch's non-nil fields onto row and reports whether anything
+// changed. An empty string in a non-nil field is treated as "unset" and leaves
+// the existing value alone, matching REQ-HLE-005's stated semantics that a
+// supplied empty value is not a clear operation.
+func (p RoutingPatch) apply(row *PendingRow) bool {
+	changed := false
+	if p.MatchedSubcommand != nil && *p.MatchedSubcommand != "" {
+		row.MatchedSubcommand = *p.MatchedSubcommand
+		changed = true
+	}
+	if p.ModeSelected != nil && *p.ModeSelected != "" {
+		v := *p.ModeSelected
+		row.ModeSelected = &v
+		changed = true
+	}
+	if p.Tier != nil && *p.Tier != "" {
+		v := *p.Tier
+		row.Tier = &v
+		changed = true
+	}
+	if p.HarnessLevel != nil && *p.HarnessLevel != "" {
+		v := *p.HarnessLevel
+		row.HarnessLevel = &v
+		changed = true
+	}
+	if p.ClarifyRounds != nil {
+		row.ClarifyRounds = *p.ClarifyRounds
+		changed = true
+	}
+	if p.ModelClass != nil && *p.ModelClass != "" {
+		row.ModelClass = *p.ModelClass
+		changed = true
+	}
+	return changed
 }
 
 // Row is a finalized routing-ledger row (schema v1, spec.md §D.1). Every field

--- a/internal/hook/evidence_writer.go
+++ b/internal/hook/evidence_writer.go
@@ -446,3 +446,29 @@ func extractTestPackage(command string) string {
 	}
 	return arg
 }
+
+// LogBashEvidence records the evidence for a Bash PostToolUse event from a
+// caller outside this package (SPEC-HARNESS-LEARNING-EVO-001 REQ-HLE-011).
+//
+// It exists because the assembled-record path was unreachable in production:
+// buildBashRecord is only ever reached from logEvidence, which runs inside the
+// `moai hook post-tool` handler behind handle-post-tool.sh — and that wrapper is
+// registered for Write|Edit|MultiEdit only. The Bash branch there never executes,
+// so the terminal test-pass / test-fail signal population stayed empty. The
+// always-on harness-observe wrapper IS registered for every tool and does receive
+// the full Bash payload; routing it through here restores reachability without
+// editing settings.json or the template it is rendered from.
+//
+// Scoped to Bash on purpose. Write and Edit are already covered by
+// handle-post-tool.sh, so recording them here as well would write two telemetry
+// records for one tool call. A non-Bash input is a silent no-op rather than an
+// error, so the caller needs no tool-name branch of its own.
+//
+// Best-effort and fail-open, matching logEvidence: errors are logged, never
+// returned, and the observing hook is never blocked.
+func LogBashEvidence(input *HookInput) {
+	if input == nil || input.ToolName != "Bash" {
+		return
+	}
+	logEvidence(input)
+}

--- a/internal/hook/evidence_writer_test.go
+++ b/internal/hook/evidence_writer_test.go
@@ -534,3 +534,60 @@ func TestEvidenceGate_ActivatesInProduction(t *testing.T) {
 		}
 	})
 }
+
+// --- SPEC-HARNESS-LEARNING-EVO-001 M3: Bash carve-out reachability ---
+
+// TestEvidenceRecord_NoDoubleWriteOnEdit is the AC-HLE-013 no-duplicate half.
+//
+// After the Bash carve-out, two handlers observe tool calls: handle-post-tool.sh
+// (Write|Edit|MultiEdit) and handle-harness-observe.sh (every tool). An Edit is
+// seen by both, so the carve-out MUST decline it — otherwise one Edit would
+// produce two telemetry records (plan.md §G AP-8). This drives both sides for a
+// single Edit and asserts the total is exactly one.
+func TestEvidenceRecord_NoDoubleWriteOnEdit(t *testing.T) {
+	root := newMoaiTempRoot(t)
+	in := fileInput("Edit", "sess-nodup", "internal/hook/x.go")
+	in.CWD = root
+
+	// Side 1 — the post-tool handler's evidence path (owns Write/Edit/MultiEdit).
+	logEvidence(in)
+	// Side 2 — the observe channel's carve-out, which sees the same Edit.
+	LogBashEvidence(in)
+
+	recs, err := telemetry.LoadBySession(root, "sess-nodup")
+	if err != nil {
+		t.Fatalf("LoadBySession: %v", err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("got %d records for one Edit, want exactly 1 (the carve-out must decline non-Bash)", len(recs))
+	}
+}
+
+// TestLogBashEvidence_RecordsBash confirms the exported entry point actually
+// reaches the assembled-record path for Bash — the reachability this SPEC
+// restores. Without this, TestEvidenceRecord_NoDoubleWriteOnEdit would also pass
+// for a function that does nothing at all.
+func TestLogBashEvidence_RecordsBash(t *testing.T) {
+	root := newMoaiTempRoot(t)
+	in := bashInput("sess-carveout", "go test ./...", []byte(`{"stdout":"ok  \tpkg\t0.1s\n"}`))
+	in.CWD = root
+
+	LogBashEvidence(in)
+
+	recs, err := telemetry.LoadBySession(root, "sess-carveout")
+	if err != nil {
+		t.Fatalf("LoadBySession: %v", err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("got %d records, want 1 (the Bash evidence path must be reachable)", len(recs))
+	}
+	if !recs[0].IsTestPass {
+		t.Errorf("IsTestPass = false; the output-text pass marker must be honored: %+v", recs[0])
+	}
+}
+
+// TestLogBashEvidence_NilInputIsNoOp guards the fail-open contract at the seam
+// boundary: a nil input must not panic the observing hook.
+func TestLogBashEvidence_NilInputIsNoOp(t *testing.T) {
+	LogBashEvidence(nil) // must not panic
+}

--- a/internal/hook/routing_ledger.go
+++ b/internal/hook/routing_ledger.go
@@ -1,0 +1,310 @@
+// Package hook — routing_ledger.go
+//
+// The three mechanical seams that make the routing observation ledger accumulate
+// rows without an orchestrator instruction (SPEC-HARNESS-LEARNING-EVO-001 L1).
+//
+// The ledger's observe channel was dry not because the algorithm was missing but
+// because nothing emitted into it: the only prescribed producer was the
+// orchestrator remembering to invoke `moai harness ledger record` on every
+// dispatch. An instruction that must be remembered every turn is not emitted
+// reliably, and the ledger's own contents were the evidence — four rows, none
+// carrying a single delegation.
+//
+// Each seam therefore derives what it can from hook input:
+//
+//	Seam A (UserPromptSubmit) — ensure a pending row exists for the session
+//	Seam B (SubagentStop)     — append one delegation entry per stopping subagent
+//	Seam C (Stop)             — append a terminal gate_exit ref when the session
+//	                            evidence path observed a test pass or fail
+//
+// All three are fail-open (REQ-HLE-012) and inert while either observation gate
+// is closed (REQ-HLE-013). None of them can block a prompt, a subagent shutdown,
+// or session end.
+package hook
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/modu-ai/moai-adk/internal/harness/routing"
+	"github.com/modu-ai/moai-adk/internal/telemetry"
+)
+
+// moaiSubcommandPrefix is the literal token a prompt must start with for the
+// seam to read a subcommand from it. Anything else is left unlabelled — the seam
+// never guesses a subcommand from natural-language text (REQ-HLE-006).
+const moaiSubcommandPrefix = "/moai "
+
+// routingSeamSink receives fail-open diagnostics. It is nil in production (the
+// seams stay silent on the hook's own output) and set by tests.
+var (
+	routingSeamSinkMu sync.RWMutex
+	routingSeamSink   io.Writer
+)
+
+// SetRoutingSeamSinkForTesting redirects seam diagnostics to w. Passing nil
+// restores the silent production default.
+func SetRoutingSeamSinkForTesting(w io.Writer) {
+	routingSeamSinkMu.Lock()
+	defer routingSeamSinkMu.Unlock()
+	routingSeamSink = w
+}
+
+// seamDiag writes a fail-open diagnostic. It never returns an error, because no
+// caller of a seam has anywhere to put one.
+func seamDiag(format string, args ...any) {
+	routingSeamSinkMu.RLock()
+	sink := routingSeamSink
+	routingSeamSinkMu.RUnlock()
+	if sink == nil {
+		return
+	}
+	_, _ = fmt.Fprintf(sink, format+"\n", args...)
+}
+
+// HarnessLearningEnabled reports whether the harness learning subsystem is
+// enabled for the project at projectRoot, reading `learning.enabled` from
+// `.moai/config/sections/harness.yaml`.
+//
+// Fail-OPEN: a missing file, an unreadable file, a parse error, or an absent key
+// all yield true. Only an explicit `false` disables observation, so a corrupted
+// config cannot silently switch the observer off.
+func HarnessLearningEnabled(projectRoot string) bool {
+	data, err := os.ReadFile(filepath.Join(projectRoot, ".moai", "config", "sections", "harness.yaml"))
+	if err != nil {
+		return true
+	}
+	var doc struct {
+		Learning struct {
+			Enabled *bool `yaml:"enabled,omitempty"`
+		} `yaml:"learning,omitempty"`
+	}
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return true
+	}
+	if doc.Learning.Enabled == nil {
+		return true
+	}
+	return *doc.Learning.Enabled
+}
+
+// HookObserveOptInEnabled reports whether the hook observe-opt-in master toggle
+// (`hook.opt_in.enabled` in `.moai/config/sections/system.yaml`) is on.
+//
+// Fail-CLOSED, deliberately opposite to HarnessLearningEnabled: this is an
+// opt-in toggle whose default state is OFF, so a missing file, an unreadable
+// file, a parse error, or an absent key all yield false. Every L1 emission path
+// therefore ships inert to distributed users.
+func HookObserveOptInEnabled(projectRoot string) bool {
+	data, err := os.ReadFile(filepath.Join(projectRoot, ".moai", "config", "sections", "system.yaml"))
+	if err != nil {
+		return false
+	}
+	var doc struct {
+		Hook struct {
+			OptIn struct {
+				Enabled bool `yaml:"enabled"`
+			} `yaml:"opt_in"`
+		} `yaml:"hook"`
+	}
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return false
+	}
+	return doc.Hook.OptIn.Enabled
+}
+
+// routingSeamStoreAt applies both gates for an already-resolved project root and
+// returns the store to write through, or nil when the seam must stay inert
+// (REQ-HLE-013).
+func routingSeamStoreAt(root string) *routing.Store {
+	if root == "" {
+		return nil
+	}
+	if !HookObserveOptInEnabled(root) { // gate 0 — fail-CLOSED, default OFF
+		return nil
+	}
+	if !HarnessLearningEnabled(root) { // gate 1 — fail-open, default ON
+		return nil
+	}
+	return routing.NewStore(filepath.Join(root, ".moai", "state"))
+}
+
+// routingSeamStore resolves the project root from hook input and applies both
+// gates. Used by the seams that only ever see a HookInput.
+func routingSeamStore(input *HookInput) (*routing.Store, string) {
+	if input == nil {
+		return nil, ""
+	}
+	root := resolveProjectRoot(input)
+	return routingSeamStoreAt(root), root
+}
+
+// literalSubcommand extracts the subcommand from a prompt that begins with the
+// literal `/moai <sub>` form, and returns "" for anything else.
+//
+// Only the literal prefix counts. Reading a subcommand out of natural language
+// would attribute delegations to a subcommand the user never invoked, and the
+// mislabel would be indistinguishable downstream from a real one.
+func literalSubcommand(prompt string) string {
+	trimmed := strings.TrimLeft(prompt, " \t\n")
+	rest, ok := strings.CutPrefix(trimmed, moaiSubcommandPrefix)
+	if !ok {
+		return ""
+	}
+	fields := strings.Fields(rest)
+	if len(fields) == 0 {
+		return ""
+	}
+	sub := fields[0]
+	// A flag is not a subcommand (`/moai --help`).
+	if strings.HasPrefix(sub, "-") {
+		return ""
+	}
+	return sub
+}
+
+// RoutingSeamUserPromptSubmit is seam A (REQ-HLE-001/002/003/006/016).
+//
+// It ensures a pending row exists for the session, deriving the digest and the
+// coarse class from the prompt through the existing routing functions — the raw
+// prompt text is never persisted.
+//
+// It uses RecordIfAbsent rather than Record on purpose. Record reroutes the
+// session's own prior pending row, which is right for an explicit re-dispatch
+// but wrong here: this runs once per prompt, a multi-turn pipeline spans many
+// prompts, and rerouting every turn would close rows that have not finished
+// being observed — reproducing the reroute-only ledger this SPEC repairs.
+//
+// The subcommand label follows first-writer-wins: a prompt carrying a literal
+// `/moai <sub>` sets the label only while it is still empty. Overwriting it
+// later would retroactively re-attribute delegations that were spawned under the
+// first subcommand, so the earlier label stands and the mislabel of a
+// plan-then-run session is accepted as a known approximation.
+func RoutingSeamUserPromptSubmit(input *HookInput) {
+	store, _ := routingSeamStore(input)
+	if store == nil {
+		return
+	}
+
+	if err := store.RecordIfAbsent(routing.PendingRow{
+		SessionID:     input.SessionID,
+		RequestDigest: routing.RequestDigest(input.Prompt),
+		RequestClass:  routing.ClassifyRequest(input.Prompt),
+	}); err != nil {
+		seamDiag("routing seam A: record: %v", err)
+		return
+	}
+
+	sub := literalSubcommand(input.Prompt)
+	if sub == "" {
+		return
+	}
+	pending, ok, err := store.LoadPending(input.SessionID)
+	if err != nil {
+		seamDiag("routing seam A: load pending: %v", err)
+		return
+	}
+	if !ok || pending.MatchedSubcommand != "" {
+		return // first-writer-wins: an existing label is never relabelled
+	}
+	if err := store.Annotate(input.SessionID, routing.RoutingPatch{MatchedSubcommand: &sub}); err != nil {
+		seamDiag("routing seam A: annotate subcommand: %v", err)
+	}
+}
+
+// RoutingSeamSubagentStop is seam B (REQ-HLE-007/008/009).
+//
+// It appends one delegation entry per stopping subagent, taking the agent
+// identity from agent_type VERBATIM. The derived subject field is deliberately
+// not consulted: it reads `unknown` on every observed subagent_stop event, so a
+// seam reading it would fill the ledger with unknowns that look structurally
+// healthy.
+//
+// Two absences are recorded rather than inferred away. An absent agent_type
+// becomes routing.AgentUnattributed so the delegation stays countable, and an
+// unobservable outcome becomes routing.OutcomeUnknownDelegation with a null
+// blocker — never "success", because no failure signal is not the same as a
+// success signal.
+func RoutingSeamSubagentStop(input *HookInput) {
+	store, _ := routingSeamStore(input)
+	if store == nil {
+		return
+	}
+
+	agent := input.AgentType
+	if agent == "" {
+		agent = routing.AgentUnattributed
+	}
+
+	if err := store.AppendDelegation(input.SessionID, routing.Delegation{
+		Agent:   agent,
+		Outcome: routing.OutcomeUnknownDelegation,
+		Blocker: nil,
+	}); err != nil {
+		seamDiag("routing seam B: append delegation: %v", err)
+	}
+}
+
+// RoutingSeamStopEvidence is seam C (REQ-HLE-010).
+//
+// When the session evidence path has already classified a terminal machine
+// signal — an observed test pass or test fail for this session — it appends a
+// matching terminal gate_exit reference so the row can close as success or fail
+// rather than only as reroute or abort.
+//
+// Absence appends nothing. A session with no observed test signal leaves the row
+// pending, which is correct: absence of a signal is not a failure, and inventing
+// a terminal ref here would fabricate the very outcome the ledger exists to
+// observe.
+//
+// A fail signal wins over a pass signal in the same session. A run that produced
+// both ended with something broken, and recording it as a success would be the
+// more damaging of the two errors.
+// The project root is passed in rather than re-resolved from hook input: the
+// Stop handler has already resolved it, and re-deriving it here could pick a
+// different directory when CLAUDE_PROJECT_DIR is unset — the seam would then
+// look for evidence in one tree while the finalizer closes a row in another.
+func RoutingSeamStopEvidence(root, sessionID string) {
+	store := routingSeamStoreAt(root)
+	if store == nil {
+		return
+	}
+
+	records, err := telemetry.LoadBySession(root, sessionID)
+	if err != nil {
+		seamDiag("routing seam C: load session evidence: %v", err)
+		return
+	}
+
+	sawPass, sawFail := false, false
+	for _, r := range records {
+		if r.IsTestFail {
+			sawFail = true
+		}
+		if r.IsTestPass {
+			sawPass = true
+		}
+	}
+	if !sawPass && !sawFail {
+		return // no observable terminal signal — append nothing
+	}
+
+	ref := routing.EvidenceRef{
+		Kind:     routing.KindGateExit,
+		Value:    "0",
+		Ref:      "session test evidence",
+		Terminal: true,
+	}
+	if sawFail {
+		ref.Value = "1"
+	}
+	if err := store.AppendEvidence(sessionID, ref); err != nil {
+		seamDiag("routing seam C: append evidence: %v", err)
+	}
+}

--- a/internal/hook/routing_ledger_test.go
+++ b/internal/hook/routing_ledger_test.go
@@ -1,0 +1,319 @@
+package hook
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/modu-ai/moai-adk/internal/harness/routing"
+)
+
+// newRoutingSeamRoot builds a temp project root with BOTH harness observation
+// gates open, and points CLAUDE_PROJECT_DIR at it.
+//
+// Every gate-open fixture sets hook.opt_in.enabled explicitly. Relying on the
+// default would silently exercise the dormant path — that gate is fail-CLOSED,
+// so an omitted key means OFF and every assertion below would pass vacuously.
+func newRoutingSeamRoot(t *testing.T) string {
+	t.Helper()
+	return newRoutingSeamRootWith(t,
+		"hook:\n  opt_in:\n    enabled: true\n",
+		"learning:\n  enabled: true\n",
+	)
+}
+
+func newRoutingSeamRootWith(t *testing.T, systemYAML, harnessYAML string) string {
+	t.Helper()
+	root := t.TempDir()
+	dir := filepath.Join(root, ".moai", "config", "sections")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "system.yaml"), []byte(systemYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "harness.yaml"), []byte(harnessYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CLAUDE_PROJECT_DIR", root)
+	return root
+}
+
+func seamStore(root string) *routing.Store {
+	return routing.NewStore(filepath.Join(root, ".moai", "state"))
+}
+
+func seamPending(t *testing.T, root, sessionID string) routing.PendingRow {
+	t.Helper()
+	p, ok, err := seamStore(root).LoadPending(sessionID)
+	if err != nil {
+		t.Fatalf("load pending: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected a pending row for session %q, found none", sessionID)
+	}
+	return p
+}
+
+func seamLedgerRows(t *testing.T, root string) []routing.Row {
+	t.Helper()
+	path := filepath.Join(root, ".moai", "state", routing.LedgerFileName)
+	rows, _, err := routing.NewReader(path).Read(routing.Filter{})
+	if err != nil {
+		t.Fatalf("read ledger: %v", err)
+	}
+	return rows
+}
+
+// TestRoutingSeam_UserPromptSubmit_CreatesPending — AC-HLE-006 (REQ-HLE-001/002):
+// a prompt creates a pending row mechanically, with the digest and class derived
+// through the existing functions rather than supplied by an instruction.
+func TestRoutingSeam_UserPromptSubmit_CreatesPending(t *testing.T) {
+	root := newRoutingSeamRoot(t)
+	const prompt = "add OAuth2 support to the session layer"
+
+	RoutingSeamUserPromptSubmit(&HookInput{SessionID: "seam-a1", Prompt: prompt, CWD: root})
+
+	p := seamPending(t, root, "seam-a1")
+	if p.RequestDigest != routing.RequestDigest(prompt) {
+		t.Errorf("request_digest = %q, want %q", p.RequestDigest, routing.RequestDigest(prompt))
+	}
+	if p.RequestClass != routing.ClassifyRequest(prompt) {
+		t.Errorf("request_class = %q, want %q", p.RequestClass, routing.ClassifyRequest(prompt))
+	}
+	if p.SessionID != "seam-a1" {
+		t.Errorf("session_id = %q, want seam-a1", p.SessionID)
+	}
+}
+
+// TestRoutingSeam_NoRawPromptPersisted — AC-HLE-007 (REQ-HLE-016): the canary
+// literal must not reach disk anywhere under the state dir.
+func TestRoutingSeam_NoRawPromptPersisted(t *testing.T) {
+	root := newRoutingSeamRoot(t)
+	const canary = "ZZQX-CANARY-PROMPT"
+
+	RoutingSeamUserPromptSubmit(&HookInput{SessionID: "seam-priv", Prompt: canary + " please implement it", CWD: root})
+
+	stateDir := filepath.Join(root, ".moai", "state")
+	entries, err := os.ReadDir(stateDir)
+	if err != nil {
+		t.Fatalf("read state dir: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("expected the seam to have written something; an empty state dir makes this assertion vacuous")
+	}
+	for _, e := range entries {
+		data, err := os.ReadFile(filepath.Join(stateDir, e.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if bytes.Contains(data, []byte(canary)) {
+			t.Fatalf("verbatim prompt text leaked into %s", e.Name())
+		}
+	}
+}
+
+// TestRoutingSeam_MultiTurnNoReroute — AC-HLE-008 (REQ-HLE-003): the seam runs
+// once per prompt, and a multi-turn pipeline spans many prompts. Repeated
+// prompts must not close the row.
+func TestRoutingSeam_MultiTurnNoReroute(t *testing.T) {
+	root := newRoutingSeamRoot(t)
+	in := &HookInput{SessionID: "seam-multi", Prompt: "keep going", CWD: root}
+
+	RoutingSeamUserPromptSubmit(in)
+	RoutingSeamUserPromptSubmit(in)
+	RoutingSeamUserPromptSubmit(in)
+	RoutingSeamUserPromptSubmit(in)
+
+	if rows := seamLedgerRows(t, root); len(rows) != 0 {
+		t.Fatalf("got %d ledger rows, want 0 — a per-prompt reroute is the exact failure this SPEC repairs: %+v", len(rows), rows)
+	}
+	seamPending(t, root, "seam-multi") // still open
+}
+
+// TestRoutingSeam_LiteralSubcommandFirstWriterWins — AC-HLE-009 (REQ-HLE-006,
+// plan.md §E D1): the subcommand is taken from a literal `/moai <sub>` prefix
+// only, and only by the first writer.
+func TestRoutingSeam_LiteralSubcommandFirstWriterWins(t *testing.T) {
+	root := newRoutingSeamRoot(t)
+
+	for _, prompt := range []string{
+		"/moai plan add auth",
+		"please run the auth work",
+		"/moai run SPEC-X",
+	} {
+		RoutingSeamUserPromptSubmit(&HookInput{SessionID: "seam-sub", Prompt: prompt, CWD: root})
+	}
+	if got := seamPending(t, root, "seam-sub").MatchedSubcommand; got != "plan" {
+		t.Errorf("matched_subcommand = %q, want %q — the natural-language prompt must set nothing and the second literal must not relabel", got, "plan")
+	}
+
+	// A fresh session that never carries a literal prefix stays unlabelled: the
+	// seam must not guess a subcommand from natural-language text.
+	RoutingSeamUserPromptSubmit(&HookInput{SessionID: "seam-nl", Prompt: "please plan the auth work", CWD: root})
+	if got := seamPending(t, root, "seam-nl").MatchedSubcommand; got != "" {
+		t.Errorf("matched_subcommand = %q, want empty — natural language must not be guessed into a subcommand", got)
+	}
+}
+
+// TestRoutingSeam_SubagentStop_AgentTypeVerbatim — AC-HLE-010 (REQ-HLE-007):
+// agent_type is recorded verbatim, including a named-spawn value that is not a
+// retained-catalog agent name, and the derived subject field is never used.
+func TestRoutingSeam_SubagentStop_AgentTypeVerbatim(t *testing.T) {
+	root := newRoutingSeamRoot(t)
+	RoutingSeamUserPromptSubmit(&HookInput{SessionID: "seam-b1", Prompt: "/moai run SPEC-X", CWD: root})
+
+	RoutingSeamSubagentStop(&HookInput{SessionID: "seam-b1", AgentType: "manager-develop", CWD: root})
+	// The observed named-spawn shape: subagent_type plan-auditor spawned with
+	// name audit-hle reports agent_type "audit-hle".
+	RoutingSeamSubagentStop(&HookInput{SessionID: "seam-b1", AgentType: "audit-hle", AgentName: "audit-hle", CWD: root})
+
+	dels := seamPending(t, root, "seam-b1").Delegations
+	if len(dels) != 2 {
+		t.Fatalf("got %d delegations, want 2", len(dels))
+	}
+	if dels[0].Agent != "manager-develop" {
+		t.Errorf("delegations[0].agent = %q, want manager-develop", dels[0].Agent)
+	}
+	if dels[1].Agent != "audit-hle" {
+		t.Errorf("delegations[1].agent = %q, want audit-hle stored verbatim (no normalization onto a catalog name)", dels[1].Agent)
+	}
+}
+
+// TestRoutingSeam_AbsentAgentTypeMarker — AC-HLE-011 (REQ-HLE-008): an absent
+// identity is recorded under a distinguishable marker so it stays countable.
+func TestRoutingSeam_AbsentAgentTypeMarker(t *testing.T) {
+	root := newRoutingSeamRoot(t)
+	RoutingSeamUserPromptSubmit(&HookInput{SessionID: "seam-b2", Prompt: "/moai run SPEC-X", CWD: root})
+
+	RoutingSeamSubagentStop(&HookInput{SessionID: "seam-b2", CWD: root}) // no agent_type at all
+
+	dels := seamPending(t, root, "seam-b2").Delegations
+	if len(dels) != 1 {
+		t.Fatalf("got %d delegations, want 1 — an unattributed delegation must still be appended", len(dels))
+	}
+	if dels[0].Agent == "" {
+		t.Fatal("agent is empty; an absent identity must be distinguishable from an attributed one")
+	}
+	if dels[0].Agent != routing.AgentUnattributed {
+		t.Errorf("agent = %q, want the declared marker %q", dels[0].Agent, routing.AgentUnattributed)
+	}
+}
+
+// TestRoutingSeam_UnknownOutcomeNotSuccess — AC-HLE-012 (REQ-HLE-009): with no
+// observable outcome, the entry records the unknown marker and a null blocker.
+// Absence of a failure signal is not evidence of success (plan.md §G AP-3).
+func TestRoutingSeam_UnknownOutcomeNotSuccess(t *testing.T) {
+	root := newRoutingSeamRoot(t)
+	RoutingSeamUserPromptSubmit(&HookInput{SessionID: "seam-b3", Prompt: "/moai run SPEC-X", CWD: root})
+
+	RoutingSeamSubagentStop(&HookInput{SessionID: "seam-b3", AgentType: "manager-docs", CWD: root})
+
+	dels := seamPending(t, root, "seam-b3").Delegations
+	if len(dels) != 1 {
+		t.Fatalf("got %d delegations, want 1", len(dels))
+	}
+	if dels[0].Outcome != routing.OutcomeUnknownDelegation {
+		t.Errorf("outcome = %q, want %q", dels[0].Outcome, routing.OutcomeUnknownDelegation)
+	}
+	if dels[0].Outcome == "success" {
+		t.Error("an unobserved outcome must never be recorded as success")
+	}
+	if dels[0].Blocker != nil {
+		t.Errorf("blocker = %v, want null", *dels[0].Blocker)
+	}
+
+	// Belt and braces: the literal must not appear anywhere in the entry.
+	data, err := os.ReadFile(filepath.Join(root, ".moai", "state", "routing-pending-seam-b3.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), `"outcome":"success"`) {
+		t.Fatalf("the pending row claims success for an unobserved delegation: %s", data)
+	}
+}
+
+// TestRoutingSeam_FailOpen — AC-HLE-015 (REQ-HLE-012): every seam returns
+// without error and writes a diagnostic when the state dir cannot be written or
+// the pending file is malformed. The seams return nothing, so "returns without
+// error" is a structural property; what this test proves is that they neither
+// panic nor abort the handler.
+func TestRoutingSeam_FailOpen(t *testing.T) {
+	t.Run("unwritable state dir", func(t *testing.T) {
+		root := newRoutingSeamRoot(t)
+		// Make .moai/state a regular FILE so every write beneath it fails.
+		if err := os.WriteFile(filepath.Join(root, ".moai", "state"), []byte("not a dir"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		var sink bytes.Buffer
+		SetRoutingSeamSinkForTesting(&sink)
+		t.Cleanup(func() { SetRoutingSeamSinkForTesting(nil) })
+
+		in := &HookInput{SessionID: "seam-fo1", Prompt: "/moai run SPEC-X", AgentType: "manager-develop", CWD: root}
+		RoutingSeamUserPromptSubmit(in)
+		RoutingSeamSubagentStop(in)
+		RoutingSeamStopEvidence(root, in.SessionID)
+
+		if sink.Len() == 0 {
+			t.Fatal("a failing seam must surface a diagnostic to the sink")
+		}
+	})
+
+	t.Run("malformed pending file", func(t *testing.T) {
+		root := newRoutingSeamRoot(t)
+		stateDir := filepath.Join(root, ".moai", "state")
+		if err := os.MkdirAll(stateDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(stateDir, "routing-pending-seam-fo2.json"), []byte("{not json"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		var sink bytes.Buffer
+		SetRoutingSeamSinkForTesting(&sink)
+		t.Cleanup(func() { SetRoutingSeamSinkForTesting(nil) })
+
+		in := &HookInput{SessionID: "seam-fo2", Prompt: "/moai run SPEC-X", AgentType: "manager-develop", CWD: root}
+		RoutingSeamUserPromptSubmit(in) // drops the malformed file and starts fresh
+		RoutingSeamSubagentStop(in)
+		RoutingSeamStopEvidence(root, in.SessionID)
+
+		// The handler survived; a usable row exists again.
+		seamPending(t, root, "seam-fo2")
+	})
+}
+
+// TestRoutingSeam_GatedOffWritesNothing — AC-HLE-016 (REQ-HLE-013): with either
+// gate closed, no ledger file and no pending file appear.
+func TestRoutingSeam_GatedOffWritesNothing(t *testing.T) {
+	cases := []struct {
+		name        string
+		systemYAML  string
+		harnessYAML string
+	}{
+		{"hook opt-in closed", "hook:\n  opt_in:\n    enabled: false\n", "learning:\n  enabled: true\n"},
+		{"hook opt-in absent (fail-closed default)", "other: 1\n", "learning:\n  enabled: true\n"},
+		{"learning closed", "hook:\n  opt_in:\n    enabled: true\n", "learning:\n  enabled: false\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := newRoutingSeamRootWith(t, tc.systemYAML, tc.harnessYAML)
+			in := &HookInput{SessionID: "seam-gated", Prompt: "/moai run SPEC-X", AgentType: "manager-develop", CWD: root}
+
+			RoutingSeamUserPromptSubmit(in)
+			RoutingSeamSubagentStop(in)
+			RoutingSeamStopEvidence(root, in.SessionID)
+
+			stateDir := filepath.Join(root, ".moai", "state")
+			entries, err := os.ReadDir(stateDir)
+			if err == nil && len(entries) > 0 {
+				names := make([]string, 0, len(entries))
+				for _, e := range entries {
+					names = append(names, e.Name())
+				}
+				t.Fatalf("a closed gate must write nothing, found: %v", names)
+			}
+		})
+	}
+}

--- a/internal/hook/subagent_stop.go
+++ b/internal/hook/subagent_stop.go
@@ -48,6 +48,14 @@ func (h *subagentStopHandler) Handle(ctx context.Context, input *HookInput) (*Ho
 	// [HARD] This package does not call AskUserQuestion. Errors emit to slog only.
 	h.dispatchCapture(input)
 
+	// Routing-ledger seam B (SPEC-HARNESS-LEARNING-EVO-001 REQ-HLE-007).
+	// Appends one delegation entry to the session's pending routing row, taking
+	// the agent identity from agent_type verbatim. Fail-open and inert while
+	// either harness observation gate is closed. Placed before the Windows
+	// early-return below so the observation is platform-independent — the return
+	// there is about tmux cleanup, which has nothing to do with this.
+	RoutingSeamSubagentStop(input)
+
 	// On Windows, tmux is not available - no-op
 	if runtime.GOOS == "windows" {
 		slog.Debug("tmux cleanup skipped on Windows")

--- a/internal/hook/user_prompt_submit.go
+++ b/internal/hook/user_prompt_submit.go
@@ -89,6 +89,13 @@ func (h *userPromptSubmitHandler) Handle(ctx context.Context, input *HookInput) 
 		"prompt_preview", preview,
 	)
 
+	// Routing-ledger seam A (SPEC-HARNESS-LEARNING-EVO-001 REQ-HLE-002).
+	// Ensures a pending routing row exists for the session, derived from hook
+	// input rather than from an orchestrator instruction. Fail-open and inert
+	// while either harness observation gate is closed; it never affects the
+	// output below.
+	RoutingSeamUserPromptSubmit(input)
+
 	// Build session title (errors are silently ignored, falls back to empty title)
 	title := h.buildSessionTitle(ctx, input.CWD, input.TranscriptPath)
 

--- a/internal/telemetry/recorder_test.go
+++ b/internal/telemetry/recorder_test.go
@@ -383,3 +383,63 @@ func TestRecordSkillUsage_AllOutcomeTypes(t *testing.T) {
 		}
 	}
 }
+
+// TestLoadBySession_TwoDayWindow pins the bounded read window of the session
+// evidence path (SPEC-HARNESS-LEARNING-EVO-001 REQ-HLE-015, AC-HLE-002).
+//
+// This is a CHARACTERIZATION test, not a RED-GREEN one: LoadBySession already
+// reads exactly today + yesterday, and this test exists so a later edit cannot
+// widen that window — which would put an unbounded per-day read on the Stop seam
+// path — without a failing test to say so.
+func TestLoadBySession_TwoDayWindow(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	dir := filepath.Join(root, ".moai", "evolution", "telemetry")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	const sessionID = "sess-window"
+	write := func(dayOffset int, marker string) {
+		day := time.Now().UTC().AddDate(0, 0, dayOffset).Format("2006-01-02")
+		rec := UsageRecord{
+			Timestamp: time.Now().UTC().AddDate(0, 0, dayOffset),
+			SessionID: sessionID,
+			SkillID:   marker,
+		}
+		line, err := json.Marshal(rec)
+		if err != nil {
+			t.Fatal(err)
+		}
+		path := filepath.Join(dir, "usage-"+day+".jsonl")
+		if err := os.WriteFile(path, append(line, '\n'), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	write(0, "today")
+	write(-1, "yesterday")
+	write(-2, "two-days-ago")
+	write(-3, "three-days-ago")
+	write(-4, "four-days-ago")
+
+	got, err := LoadBySession(root, sessionID)
+	if err != nil {
+		t.Fatalf("LoadBySession: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d records, want 2 (today + yesterday only)", len(got))
+	}
+	seen := map[string]bool{}
+	for _, r := range got {
+		seen[r.SkillID] = true
+	}
+	if !seen["today"] || !seen["yesterday"] {
+		t.Fatalf("window must cover today and yesterday, got %v", seen)
+	}
+	for _, beyond := range []string{"two-days-ago", "three-days-ago", "four-days-ago"} {
+		if seen[beyond] {
+			t.Fatalf("read window leaked beyond two days: %s was read", beyond)
+		}
+	}
+}


### PR DESCRIPTION
Roadmap P3 of the autonomy/workflow redesign: evolve the delegation map from routing-ledger observations. This PR lands **L1 (instrumentation)** only. L2 (the analyzer) is SPEC-HARNESS-LEARNING-EVO-002, planned in this PR but not implemented.

## Why the ledger was empty

The routing ledger held 4 rows over a month, all `reroute`/`abort` with zero delegations. Two independent causes, both measured rather than assumed:

**1. `Store.Record` closes the caller's own prior row.** It calls `rerouteSelf` (`internal/harness/routing/pending.go`), so a per-prompt hook calling `Record` would close a row every turn — reproducing the exact ledger this SPEC repairs, while *looking* successful because row count rises. Fixed by splitting create-if-absent and annotate into separate operations; `Record` keeps its existing semantics for explicit re-dispatch.

**2. Bash tool calls produced no evidence records at all.** The `PostToolUse` matcher for the telemetry hook is `Write|Edit|MultiEdit`, so `buildEvidenceRecord` was unreachable for Bash — not a classification, decode, or gate failure. Measured: 0 test-pass/fail signals across 37,107 telemetry records. Fixed by routing through the always-on observe channel scoped to `ToolName == "Bash"`, which keeps `settings.json` and the template surface untouched and avoids a double write with the existing handler.

## Design premise was probed, not assumed

The fix in (2) rests on the observe channel's Bash payload carrying `tool_input.command` and `tool_response`. That was verified against a live headless session with a matcher-less hook before implementing. Two findings the plan did not anticipate are recorded rather than buried:

- The payload arrives flat snake_case; the observed shape is now pinned as a test fixture so a wire-format change fails a test instead of silently emptying telemetry.
- `tool_response` carries no `exit_code`, so `deriveFromExitCode` cannot fire on this channel and pass/fail rests on the output-text heuristic. Filed as residual risk R7; markers were **not** added speculatively for runners not observed.

## Agent identity

Delegation attribution uses `agent_type`, populated on 1,940 of 2,779 `subagent_stop` rows with the retained-catalog agent names. Two encoded caveats: ~30% of rows carry no value (recorded distinguishably, not as `""`), and a named spawn puts the spawn *name* in that field, so only exact retained-catalog matches are treated as agent types.

## Scope boundary

L3 (automated application of delegation-map changes) is **out of scope by design**, not by omission. `delegation.yaml` stays behind the existing Tier-4 approval gate; `.claude/lsel/frozen-allowlist.json` is unmodified.

## Verification

`go build ./...`, `GOOS=windows go build ./...`, `go vet ./...` all exit 0. `golangci-lint run` reports 0 issues, matching the pre-change baseline (zero-new, not merely zero). 16/16 acceptance criteria pass, each decided by its own command with output recorded in `progress.md`.

Two caveats stated plainly:

- **`internal/cli` and `internal/statusline` time out locally** under the full suite. This reproduces identically at the pre-SPEC base commit (`TestRunStatusline_NilDeps` hangs ~10m), so it is pre-existing and not attributable to this change. CI is the arbiter.
- **AC-HLE-014 is bounded.** It drives the production handlers end to end against a temp root and proves the seam sequence closes a row with delegations intact — it does not prove Claude Code invokes those handlers in a live session (residual risk R1).

Coverage on touched packages: `internal/harness/routing` 88.5%, `internal/hook` 83.9%, `internal/telemetry` 82.7%, `internal/cli` 76.5`%`. Three miss their target; these are whole-package figures on large pre-existing packages and no before/after delta was measured, so this PR claims neither improvement nor regression.

## Two deviations from the plan

- The two observation gates moved from `internal/cli` into `internal/hook` (`hook` cannot import `cli`, and duplicating two truth tables would create the silent-drift failure class this SPEC repairs elsewhere). CLI functions are now thin wrappers; call sites unchanged.
- `Store.LoadPending` was exported so the seam can ask whether a field is still empty, keeping the first-writer-wins decision at the seam rather than moving it into the store.

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `harness ledger annotate` for updating routing metadata without creating or finalizing sessions.
  - Routing activity now captures pending sessions, delegations, outcomes, subcommands, and Bash test evidence.
  - Added configuration gates and fail-open behavior so hook processing remains uninterrupted.
  - Preserved compatibility with existing ledger records and sensitive prompt data.

- **Documentation**
  - Added specifications, acceptance criteria, implementation plans, progress tracking, and requirement traceability for routing analytics and delegation analysis.

- **Tests**
  - Added broad coverage for lifecycle behavior, evidence recording, gating, privacy, compatibility, and end-to-end outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->