### PR TITLE
docs(emoji): replace decorative body emoji in section _index pages with icon shortcodes (4 locales)

### DIFF
--- a/docs-site/content/en/advanced/_index.md
+++ b/docs-site/content/en/advanced/_index.md
@@ -4,7 +4,7 @@ weight: 100
 draft: false
 ---
 
-{{< callout type="info" >}}{{< icon flash primary >}} <strong>Belongs to</strong>: 🪙 Tokenomics · 🧠 Agentic Loop Engineering · 🛡️ Agentic Harness
+{{< callout type="info" >}}{{< icon flash primary >}} <strong>Belongs to</strong>: Tokenomics · Agentic Loop Engineering · Agentic Harness
 {{< /callout >}}
 <!-- @value: tokenomics, self-learning, agentic-harness -->
 

--- a/docs-site/content/en/claude-code/_index.md
+++ b/docs-site/content/en/claude-code/_index.md
@@ -5,7 +5,7 @@ draft: false
 description: "A 4-group learning path for understanding Claude Code from scratch — the platform on which MoAI-ADK's three core values (Tokenomics, Agentic Loop Engineering, Agentic Harness) stand."
 ---
 
-{{< callout type="info" >}}{{< icon flash primary >}} <strong>Belongs to</strong>: 🛡️ Agentic Harness · 🧠 Agentic Loop Engineering
+{{< callout type="info" >}}{{< icon flash primary >}} <strong>Belongs to</strong>: Agentic Harness · Agentic Loop Engineering
 {{< /callout >}}
 <!-- @value: agentic-harness, self-learning -->
 

--- a/docs-site/content/en/cli-reference/_index.md
+++ b/docs-site/content/en/cli-reference/_index.md
@@ -5,7 +5,7 @@ draft: false
 description: "Detailed reference for the terminal moai CLI commands."
 ---
 
-{{< callout type="info" >}}{{< icon flash primary >}} <strong>Belongs to</strong>: 🪙 Tokenomics · 🧠 Agentic Loop Engineering · 🛡️ Agentic Harness
+{{< callout type="info" >}}{{< icon flash primary >}} <strong>Belongs to</strong>: Tokenomics · Agentic Loop Engineering · Agentic Harness
 {{< /callout >}}
 <!-- @value: tokenomics, self-learning, agentic-harness -->
 

--- a/docs-site/content/en/core-concepts/_index.md
+++ b/docs-site/content/en/core-concepts/_index.md
@@ -4,7 +4,7 @@ weight: 20
 draft: false
 ---
 
-{{< callout type="info" >}}{{< icon flash primary >}} <strong>Belongs to</strong>: 🛡️ Agentic Harness
+{{< callout type="info" >}}{{< icon flash primary >}} <strong>Belongs to</strong>: Agentic Harness
 {{< /callout >}}
 <!-- @value: agentic-harness -->
 

--- a/docs-site/content/en/cost-optimization/_index.md
+++ b/docs-site/content/en/cost-optimization/_index.md
@@ -4,7 +4,7 @@ weight: 70
 draft: false
 ---
 
-{{< callout type="info" >}}{{< icon flash primary >}} <strong>Belongs to</strong>: 🪙 Tokenomics
+{{< callout type="info" >}}{{< icon flash primary >}} <strong>Belongs to</strong>: Tokenomics
 {{< /callout >}}
 <!-- @value: tokenomics -->
 

--- a/docs-site/content/en/getting-started/_index.md
+++ b/docs-site/content/en/getting-started/_index.md
@@ -5,7 +5,7 @@ weight: 10
 draft: false
 ---
 
-{{< callout type="info" >}}{{< icon flash primary >}} <strong>Belongs to</strong>: 🪙 Tokenomics · 🧠 Agentic Loop Engineering · 🛡️ Agentic Harness
+{{< callout type="info" >}}{{< icon flash primary >}} <strong>Belongs to</strong>: Tokenomics · Agentic Loop Engineering · Agentic Harness
 {{< /callout >}}
 <!-- @value: tokenomics, self-learning, agentic-harness -->
 

--- a/docs-site/content/en/guides/_index.md
+++ b/docs-site/content/en/guides/_index.md
@@ -5,7 +5,7 @@ weight: 85
 draft: false
 ---
 
-{{< callout type="info" >}}{{< icon flash primary >}} <strong>Belongs to</strong>: 🪙 Tokenomics · 🧠 Agentic Loop Engineering
+{{< callout type="info" >}}{{< icon flash primary >}} <strong>Belongs to</strong>: Tokenomics · Agentic Loop Engineering
 {{< /callout >}}
 <!-- @value: tokenomics, self-learning -->
 

--- a/docs-site/content/en/multi-llm/_index.md
+++ b/docs-site/content/en/multi-llm/_index.md
@@ -4,7 +4,7 @@ weight: 60
 draft: false
 ---
 
-{{< callout type="info" >}}{{< icon flash primary >}} <strong>Belongs to</strong>: 🪙 Tokenomics
+{{< callout type="info" >}}{{< icon flash primary >}} <strong>Belongs to</strong>: Tokenomics
 {{< /callout >}}
 <!-- @value: tokenomics -->
 

--- a/docs-site/content/en/utility-commands/_index.md
+++ b/docs-site/content/en/utility-commands/_index.md
@@ -4,7 +4,7 @@ weight: 40
 draft: false
 ---
 
-{{< callout type="info" >}}{{< icon flash primary >}} <strong>Belongs to</strong>: 🧠 Agentic Loop Engineering · 🛡️ Agentic Harness
+{{< callout type="info" >}}{{< icon flash primary >}} <strong>Belongs to</strong>: Agentic Loop Engineering · Agentic Harness
 {{< /callout >}}
 <!-- @value: self-learning, agentic-harness -->
 

--- a/docs-site/content/en/workflow-commands/_index.md
+++ b/docs-site/content/en/workflow-commands/_index.md
@@ -4,7 +4,7 @@ weight: 30
 draft: false
 ---
 
-{{< callout type="info" >}}{{< icon flash primary >}} <strong>Belongs to</strong>: 🛡️ Agentic Harness
+{{< callout type="info" >}}{{< icon flash primary >}} <strong>Belongs to</strong>: Agentic Harness
 {{< /callout >}}
 <!-- @value: agentic-harness -->
 

--- a/docs-site/content/ja/advanced/_index.md
+++ b/docs-site/content/ja/advanced/_index.md
@@ -4,7 +4,7 @@ weight: 100
 draft: false
 ---
 
-{{< callout type="info" >}}{{< icon flash primary >}} <strong>所属バリュー</strong>: 🪙 トークノミクス · 🧠 エージェンティック・ループ・エンジニアリング · 🛡️ エージェンティック・ハーネス
+{{< callout type="info" >}}{{< icon flash primary >}} <strong>所属バリュー</strong>: トークノミクス · エージェンティック・ループ・エンジニアリング · エージェンティック・ハーネス
 {{< /callout >}}
 <!-- @value: tokenomics, self-learning, agentic-harness -->
 

--- a/docs-site/content/ja/claude-code/_index.md
+++ b/docs-site/content/ja/claude-code/_index.md
@@ -5,7 +5,7 @@ draft: false
 description: "MoAI-ADK の 3 つの核心 (トークノミクス・エージェンティックループエンジニアリング・エージェンティックハーネス) が立脚するプラットフォーム、Claude Code を基礎から理解する 4 グループの学習パス。"
 ---
 
-{{< callout type="info" >}}{{< icon flash primary >}} <strong>所属バリュー</strong>: 🛡️ エージェント型ハーネス · 🧠 エージェンティック・ループ・エンジニアリング
+{{< callout type="info" >}}{{< icon flash primary >}} <strong>所属バリュー</strong>: エージェント型ハーネス · エージェンティック・ループ・エンジニアリング
 {{< /callout >}}
 <!-- @value: agentic-harness, self-learning -->
 

--- a/docs-site/content/ja/cli-reference/_index.md
+++ b/docs-site/content/ja/cli-reference/_index.md
@@ -5,7 +5,7 @@ draft: false
 description: "ターミナルで実行する moai CLI コマンドの詳細リファレンス。"
 ---
 
-{{< callout type="info" >}}{{< icon flash primary >}} <strong>所属バリュー</strong>: 🪙 トークノミクス · 🧠 エージェンティック・ループ・エンジニアリング · 🛡️ エージェント型ハーネス
+{{< callout type="info" >}}{{< icon flash primary >}} <strong>所属バリュー</strong>: トークノミクス · エージェンティック・ループ・エンジニアリング · エージェント型ハーネス
 {{< /callout >}}
 <!-- @value: tokenomics, self-learning, agentic-harness -->
 

--- a/docs-site/content/ja/core-concepts/_index.md
+++ b/docs-site/content/ja/core-concepts/_index.md
@@ -4,7 +4,7 @@ weight: 20
 draft: false
 ---
 
-{{< callout type="info" >}}{{< icon flash primary >}} <strong>所属バリュー</strong>: 🛡️ エージェント型ハーネス
+{{< callout type="info" >}}{{< icon flash primary >}} <strong>所属バリュー</strong>: エージェント型ハーネス
 {{< /callout >}}
 <!-- @value: agentic-harness -->
 

--- a/docs-site/content/ja/cost-optimization/_index.md
+++ b/docs-site/content/ja/cost-optimization/_index.md
@@ -4,7 +4,7 @@ weight: 70
 draft: false
 ---
 
-{{< callout type="info" >}}{{< icon flash primary >}} <strong>所属バリュー</strong>: 🪙 トークノミクス
+{{< callout type="info" >}}{{< icon flash primary >}} <strong>所属バリュー</strong>: トークノミクス
 {{< /callout >}}
 <!-- @value: tokenomics -->
 

--- a/docs-site/content/ja/getting-started/_index.md
+++ b/docs-site/content/ja/getting-started/_index.md
@@ -5,7 +5,7 @@ weight: 10
 draft: false
 ---
 
-{{< callout type="info" >}}{{< icon flash primary >}} <strong>所属バリュー</strong>: 🪙 トークノミクス · 🧠 エージェンティック・ループ・エンジニアリング · 🛡️ エージェント型ハーネス
+{{< callout type="info" >}}{{< icon flash primary >}} <strong>所属バリュー</strong>: トークノミクス · エージェンティック・ループ・エンジニアリング · エージェント型ハーネス
 {{< /callout >}}
 <!-- @value: tokenomics, self-learning, agentic-harness -->
 

--- a/docs-site/content/ja/guides/_index.md
+++ b/docs-site/content/ja/guides/_index.md
@@ -5,7 +5,7 @@ weight: 85
 draft: false
 ---
 
-{{< callout type="info" >}}{{< icon flash primary >}} <strong>所属バリュー</strong>: 🪙 トークノミクス · 🧠 エージェンティック・ループ・エンジニアリング
+{{< callout type="info" >}}{{< icon flash primary >}} <strong>所属バリュー</strong>: トークノミクス · エージェンティック・ループ・エンジニアリング
 {{< /callout >}}
 <!-- @value: tokenomics, self-learning -->
 

--- a/docs-site/content/ja/multi-llm/_index.md
+++ b/docs-site/content/ja/multi-llm/_index.md
@@ -4,7 +4,7 @@ weight: 60
 draft: false
 ---
 
-{{< callout type="info" >}}{{< icon flash primary >}} <strong>所属バリュー</strong>: 🪙 トークノミクス
+{{< callout type="info" >}}{{< icon flash primary >}} <strong>所属バリュー</strong>: トークノミクス
 {{< /callout >}}
 <!-- @value: tokenomics -->
 

--- a/docs-site/content/ja/utility-commands/_index.md
+++ b/docs-site/content/ja/utility-commands/_index.md
@@ -4,7 +4,7 @@ weight: 40
 draft: false
 ---
 
-{{< callout type="info" >}}{{< icon flash primary >}} <strong>所属バリュー</strong>: 🧠 エージェンティック・ループ・エンジニアリング · 🛡️ エージェント型ハーネス
+{{< callout type="info" >}}{{< icon flash primary >}} <strong>所属バリュー</strong>: エージェンティック・ループ・エンジニアリング · エージェント型ハーネス
 {{< /callout >}}
 <!-- @value: self-learning, agentic-harness -->
 

--- a/docs-site/content/ja/workflow-commands/_index.md
+++ b/docs-site/content/ja/workflow-commands/_index.md
@@ -4,7 +4,7 @@ weight: 30
 draft: false
 ---
 
-{{< callout type="info" >}}{{< icon flash primary >}} <strong>所属バリュー</strong>: 🛡️ エージェント型ハーネス
+{{< callout type="info" >}}{{< icon flash primary >}} <strong>所属バリュー</strong>: エージェント型ハーネス
 {{< /callout >}}
 <!-- @value: agentic-harness -->
 

--- a/docs-site/content/ko/advanced/_index.md
+++ b/docs-site/content/ko/advanced/_index.md
@@ -4,7 +4,7 @@ weight: 100
 draft: false
 ---
 
-{{< callout type="info" >}}{{< icon flash primary >}} <strong>소속 가치</strong>: 🪙 토크노믹스 · 🧠 에이전틱 루프 엔지니어링 · 🛡️ 에이전틱 하네스
+{{< callout type="info" >}}{{< icon flash primary >}} <strong>소속 가치</strong>: 토크노믹스 · 에이전틱 루프 엔지니어링 · 에이전틱 하네스
 {{< /callout >}}
 <!-- @value: tokenomics, self-learning, agentic-harness -->
 

--- a/docs-site/content/ko/claude-code/_index.md
+++ b/docs-site/content/ko/claude-code/_index.md
@@ -5,7 +5,7 @@ draft: false
 description: "MoAI-ADK의 세 가지 핵심(토크노믹스·에이전틱 루프 엔지니어링·에이전틱 하네스)의 기반이 되는 플랫폼, Claude Code를 처음부터 이해하는 4그룹 학습 경로."
 ---
 
-{{< callout type="info" >}}{{< icon flash primary >}} <strong>소속 가치</strong>: 🛡️ 에이전틱 하네스 · 🧠 에이전틱 루프 엔지니어링
+{{< callout type="info" >}}{{< icon flash primary >}} <strong>소속 가치</strong>: 에이전틱 하네스 · 에이전틱 루프 엔지니어링
 {{< /callout >}}
 <!-- @value: agentic-harness, self-learning -->
 

--- a/docs-site/content/ko/cli-reference/_index.md
+++ b/docs-site/content/ko/cli-reference/_index.md
@@ -5,7 +5,7 @@ draft: false
 description: "터미널에서 실행하는 moai CLI 커맨드의 상세 레퍼런스."
 ---
 
-{{< callout type="info" >}}{{< icon flash primary >}} <strong>소속 가치</strong>: 🪙 토크노믹스 · 🧠 에이전틱 루프 엔지니어링 · 🛡️ 에이전틱 하네스
+{{< callout type="info" >}}{{< icon flash primary >}} <strong>소속 가치</strong>: 토크노믹스 · 에이전틱 루프 엔지니어링 · 에이전틱 하네스
 {{< /callout >}}
 <!-- @value: tokenomics, self-learning, agentic-harness -->
 

--- a/docs-site/content/ko/core-concepts/_index.md
+++ b/docs-site/content/ko/core-concepts/_index.md
@@ -4,7 +4,7 @@ weight: 20
 draft: false
 ---
 
-{{< callout type="info" >}}{{< icon flash primary >}} <strong>소속 가치</strong>: 🛡️ 에이전틱 하네스
+{{< callout type="info" >}}{{< icon flash primary >}} <strong>소속 가치</strong>: 에이전틱 하네스
 {{< /callout >}}
 <!-- @value: agentic-harness -->
 

--- a/docs-site/content/ko/cost-optimization/_index.md
+++ b/docs-site/content/ko/cost-optimization/_index.md
@@ -4,7 +4,7 @@ weight: 70
 draft: false
 ---
 
-{{< callout type="info" >}}{{< icon flash primary >}} <strong>소속 가치</strong>: 🪙 토크노믹스
+{{< callout type="info" >}}{{< icon flash primary >}} <strong>소속 가치</strong>: 토크노믹스
 {{< /callout >}}
 <!-- @value: tokenomics -->
 

--- a/docs-site/content/ko/getting-started/_index.md
+++ b/docs-site/content/ko/getting-started/_index.md
@@ -5,7 +5,7 @@ weight: 10
 draft: false
 ---
 
-{{< callout type="info" >}}{{< icon flash primary >}} <strong>소속 가치</strong>: 🪙 토크노믹스 · 🧠 에이전틱 루프 엔지니어링 · 🛡️ 에이전틱 하네스
+{{< callout type="info" >}}{{< icon flash primary >}} <strong>소속 가치</strong>: 토크노믹스 · 에이전틱 루프 엔지니어링 · 에이전틱 하네스
 {{< /callout >}}
 <!-- @value: tokenomics, self-learning, agentic-harness -->
 

--- a/docs-site/content/ko/guides/_index.md
+++ b/docs-site/content/ko/guides/_index.md
@@ -5,7 +5,7 @@ weight: 85
 draft: false
 ---
 
-{{< callout type="info" >}}{{< icon flash primary >}} <strong>소속 가치</strong>: 🪙 토크노믹스 · 🧠 에이전틱 루프 엔지니어링
+{{< callout type="info" >}}{{< icon flash primary >}} <strong>소속 가치</strong>: 토크노믹스 · 에이전틱 루프 엔지니어링
 {{< /callout >}}
 <!-- @value: tokenomics, agent-loop -->
 

--- a/docs-site/content/ko/multi-llm/_index.md
+++ b/docs-site/content/ko/multi-llm/_index.md
@@ -4,7 +4,7 @@ weight: 60
 draft: false
 ---
 
-{{< callout type="info" >}}{{< icon flash primary >}} <strong>소속 가치</strong>: 🪙 토크노믹스
+{{< callout type="info" >}}{{< icon flash primary >}} <strong>소속 가치</strong>: 토크노믹스
 {{< /callout >}}
 <!-- @value: tokenomics -->
 

--- a/docs-site/content/ko/utility-commands/_index.md
+++ b/docs-site/content/ko/utility-commands/_index.md
@@ -4,7 +4,7 @@ weight: 40
 draft: false
 ---
 
-{{< callout type="info" >}}{{< icon flash primary >}} <strong>소속 가치</strong>: 🧠 에이전틱 루프 엔지니어링 · 🛡️ 에이전틱 하네스
+{{< callout type="info" >}}{{< icon flash primary >}} <strong>소속 가치</strong>: 에이전틱 루프 엔지니어링 · 에이전틱 하네스
 {{< /callout >}}
 <!-- @value: agentic-loop-engineering, agentic-harness -->
 

--- a/docs-site/content/ko/workflow-commands/_index.md
+++ b/docs-site/content/ko/workflow-commands/_index.md
@@ -4,7 +4,7 @@ weight: 30
 draft: false
 ---
 
-{{< callout type="info" >}}{{< icon flash primary >}} <strong>소속 가치</strong>: 🛡️ 에이전틱 하네스
+{{< callout type="info" >}}{{< icon flash primary >}} <strong>소속 가치</strong>: 에이전틱 하네스
 {{< /callout >}}
 <!-- @value: agentic-harness -->
 

--- a/docs-site/content/zh/advanced/_index.md
+++ b/docs-site/content/zh/advanced/_index.md
@@ -4,7 +4,7 @@ weight: 100
 draft: false
 ---
 
-{{< callout type="info" >}}{{< icon flash primary >}} <strong>所属价值</strong>: 🪙 代币经济学 · 🧠 智能体循环工程 · 🛡️ 智能体 Harness
+{{< callout type="info" >}}{{< icon flash primary >}} <strong>所属价值</strong>: 代币经济学 · 智能体循环工程 · 智能体 Harness
 {{< /callout >}}
 <!-- @value: tokenomics, self-learning, agentic-harness -->
 

--- a/docs-site/content/zh/claude-code/_index.md
+++ b/docs-site/content/zh/claude-code/_index.md
@@ -5,7 +5,7 @@ draft: false
 description: "从零理解 MoAI-ADK 三大核心（代币经济学·智能体循环工程·智能体挽具）所依托的平台 Claude Code 的四组学习路径。"
 ---
 
-{{< callout type="info" >}}{{< icon flash primary >}} <strong>所属价值</strong>: 🛡️ 代理型线束 · 🧠 智能体循环工程
+{{< callout type="info" >}}{{< icon flash primary >}} <strong>所属价值</strong>: 代理型线束 · 智能体循环工程
 {{< /callout >}}
 <!-- @value: agentic-harness, self-learning -->
 

--- a/docs-site/content/zh/cli-reference/_index.md
+++ b/docs-site/content/zh/cli-reference/_index.md
@@ -5,7 +5,7 @@ draft: false
 description: "在终端中运行的 moai CLI 命令的详细参考。"
 ---
 
-{{< callout type="info" >}}{{< icon flash primary >}} <strong>所属价值</strong>: 🪙 代币经济学 · 🧠 智能体循环工程 · 🛡️ 代理型线束
+{{< callout type="info" >}}{{< icon flash primary >}} <strong>所属价值</strong>: 代币经济学 · 智能体循环工程 · 代理型线束
 {{< /callout >}}
 <!-- @value: tokenomics, self-learning, agentic-harness -->
 

--- a/docs-site/content/zh/core-concepts/_index.md
+++ b/docs-site/content/zh/core-concepts/_index.md
@@ -4,7 +4,7 @@ weight: 20
 draft: false
 ---
 
-{{< callout type="info" >}}{{< icon flash primary >}} <strong>所属价值</strong>: 🛡️ 代理型线束
+{{< callout type="info" >}}{{< icon flash primary >}} <strong>所属价值</strong>: 代理型线束
 {{< /callout >}}
 <!-- @value: agentic-harness -->
 

--- a/docs-site/content/zh/cost-optimization/_index.md
+++ b/docs-site/content/zh/cost-optimization/_index.md
@@ -4,7 +4,7 @@ weight: 70
 draft: false
 ---
 
-{{< callout type="info" >}}{{< icon flash primary >}} <strong>所属价值</strong>: 🪙 代币经济学
+{{< callout type="info" >}}{{< icon flash primary >}} <strong>所属价值</strong>: 代币经济学
 {{< /callout >}}
 <!-- @value: tokenomics -->
 

--- a/docs-site/content/zh/getting-started/_index.md
+++ b/docs-site/content/zh/getting-started/_index.md
@@ -5,7 +5,7 @@ weight: 10
 draft: false
 ---
 
-{{< callout type="info" >}}{{< icon flash primary >}} <strong>所属价值</strong>: 🪙 代币经济学 · 🧠 智能体循环工程 · 🛡️ 代理型线束
+{{< callout type="info" >}}{{< icon flash primary >}} <strong>所属价值</strong>: 代币经济学 · 智能体循环工程 · 代理型线束
 {{< /callout >}}
 <!-- @value: tokenomics, self-learning, agentic-harness -->
 

--- a/docs-site/content/zh/guides/_index.md
+++ b/docs-site/content/zh/guides/_index.md
@@ -5,7 +5,7 @@ weight: 85
 draft: false
 ---
 
-{{< callout type="info" >}}{{< icon flash primary >}} <strong>所属价值</strong>: 🪙 代币经济学 · 🧠 智能体循环工程
+{{< callout type="info" >}}{{< icon flash primary >}} <strong>所属价值</strong>: 代币经济学 · 智能体循环工程
 {{< /callout >}}
 <!-- @value: tokenomics, self-learning -->
 

--- a/docs-site/content/zh/multi-llm/_index.md
+++ b/docs-site/content/zh/multi-llm/_index.md
@@ -4,7 +4,7 @@ weight: 60
 draft: false
 ---
 
-{{< callout type="info" >}}{{< icon flash primary >}} <strong>所属价值</strong>: 🪙 代币经济学
+{{< callout type="info" >}}{{< icon flash primary >}} <strong>所属价值</strong>: 代币经济学
 {{< /callout >}}
 <!-- @value: tokenomics -->
 

--- a/docs-site/content/zh/utility-commands/_index.md
+++ b/docs-site/content/zh/utility-commands/_index.md
@@ -4,7 +4,7 @@ weight: 40
 draft: false
 ---
 
-{{< callout type="info" >}}{{< icon flash primary >}} <strong>所属价值</strong>: 🧠 智能体循环工程 · 🛡️ 代理型线束
+{{< callout type="info" >}}{{< icon flash primary >}} <strong>所属价值</strong>: 智能体循环工程 · 代理型线束
 {{< /callout >}}
 <!-- @value: self-learning, agentic-harness -->
 

--- a/docs-site/content/zh/workflow-commands/_index.md
+++ b/docs-site/content/zh/workflow-commands/_index.md
@@ -4,7 +4,7 @@ weight: 30
 draft: false
 ---
 
-{{< callout type="info" >}}{{< icon flash primary >}} <strong>所属价值</strong>: 🛡️ 代理型线束
+{{< callout type="info" >}}{{< icon flash primary >}} <strong>所属价值</strong>: 代理型线束
 {{< /callout >}}
 <!-- @value: agentic-harness -->
 


### PR DESCRIPTION
## What
Follows up #1422 (P0 converted 8 files). Converts the remaining **decorative body emoji** in the 10 section `_index.md` callouts across all 4 locales (40 files) to the established `{{< icon >}}` shortcode system, per `.claude/rules/...` §17.1 (Claude Warm Editorial: light-only, icon-shortcodes over body emoji).

## Scope — 40 files, 4-locale symmetric
10 sections × 4 locales (`ko/en/ja/zh`), 1 line each: `advanced/`, `cli-reference/`, `claude-code/`, `core-concepts/`, `cost-optimization/`, `getting-started/`, `guides/`, `multi-llm/`, `utility-commands/`, `workflow-commands/` `_index.md`.

Removed per locale: 🪙×6 + 🧠×6 + 🛡️×7 = 19 (decorative callout bullets). The callouts already carry `{{< icon flash primary >}}` + an `@value` HTML comment with full metadata, so **no information is lost** — the emoji was pure decoration.

## What is KEPT (deliberately, not touched)
- **Statusline UI reproduction** (`advanced/statusline.md`, ~71 emoji): 🤖🧠♻️🔅🗿⏳💬🪫🔋📁🔀💾💌🛡⚠️🛑📋📬📫📪📭 — the page documents "this is what the statusline renders"; replacing would falsify the docs.
- **Code-block reproductions** (faq/settings-json/agent-view): branding + TUI spinner glyphs inside fences.
- **Typographic symbols**: ✓ ✗ ✂ (✂ = handoff cut-line marker).
- **Load-bearing legend dots** (`what-is-moai-adk.md` 🔴🔵🟠🩵⚪): the sole data in a cost column with an explicit legend mapping to `moai model profile` tiers. The icon set has no colored-circle equivalent, and they are semantic data, not decoration.

## Verify (mandatory exit gate — `hns-oss-docs-verify`)
- `hugo --minify --gc` → exit 0, **0 warnings, 0 errors**; sitemap present
- 4-locale parity: 124 `.md` files per locale, 980 `##` headings per locale (identical)
- URL blacklist clean; no Mermaid LR/RL; no new `{{< icon >}}` names outside icon.html's case list
- decorative-emoji: 784 → 708 (only KEEP-category remain)

## Note for review
The colored-dot legend in `what-is-moai-adk.md` was a close call — KEPT as load-bearing. If text labels (`opus+high` etc.) are preferred over dots, that is a separate follow-up.

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified “Belongs to” and related informational callouts across the English, Japanese, Korean, and Chinese documentation.
  * Removed decorative emoji prefixes from topic labels while preserving the existing text, links, and structure.
  * Standardized selected Chinese labels with plain text or a consistent icon treatment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->