### PR TITLE
docs(SPEC-CODEX-PHASE2-001): plan-phase artifacts for the codex Phase 2 tool surface

### DIFF
--- a/.moai/specs/SPEC-CODEX-PHASE2-001/acceptance.md
+++ b/.moai/specs/SPEC-CODEX-PHASE2-001/acceptance.md
@@ -1,0 +1,104 @@
+# Acceptance — SPEC-CODEX-PHASE2-001
+
+> Every criterion is binary-testable: a Go test, a command exit code, or a grep with a stated expected count. Criteria are written as Given-When-Then; the GEARS requirements they verify live in `spec.md` §D.
+
+## Severity legend
+
+- **MUST** — blocks Definition of Done.
+- **SHOULD** — non-blocking; a miss is recorded as debt with a rationale.
+
+## §A. AC Matrix
+
+### M1 — Reusable session + model/effort SSOT
+
+**AC-CX2-001** (MUST, REQ-CX2-001) — *Given* a canned session runner that answers `initialize`, `thread/start`, and two successive turns, *When* the caller issues a second turn on the returned session handle, *Then* the exchange contains exactly one `initialize` and one `thread/start`, both turns carry the same `threadId`, and both return their result.
+
+**AC-CX2-002** (MUST, REQ-CX2-001) — *Given* the refactored session, *When* `go test ./internal/cli/... -run 'Codex|ReviewGate'` runs, *Then* every pre-existing codex and review-gate test passes unmodified in its assertions, demonstrating the two existing `runCodexReviewRPC` callers are behaviorally unchanged.
+
+**AC-CX2-003** (MUST, REQ-CX2-002) — *Given* a codex request with no explicit model, *When* the request params are captured at the transport seam, *Then* they carry the model resolved by `template.ResolveAgentModelEffort`; and *Given* an explicit `model` argument, *Then* the transmitted params carry that value — the current drop at `buildCodexReviewParams` (`mcp_codex.go:433`) is closed.
+
+**AC-CX2-004** (MUST, REQ-CX2-002) — *Given* the M1 tree, *When* `go test ./internal/cli/ -run TestMCPAudit_NoDirectFrontmatterRead` runs, *Then* it passes, and a companion test asserts the resolver is invoked on the codex path, so the guard can no longer pass vacuously.
+
+### M2 — Job registry
+
+**AC-CX2-005** (MUST, REQ-CX2-003) — *Given* a writable temporary project root, *When* a background task is started, *Then* exactly one file appears under `.moai/state/codex-jobs/`, and its JSON decodes with a non-empty job id, a status, creation and update timestamps, a `threadId`, a mode, and a request summary.
+
+**AC-CX2-006** (MUST, REQ-CX2-004) — *Given* a job progressing through its lifecycle, *When* each transition is written, *Then* the recorded status is one of `queued`/`running`/`completed`/`failed`/`cancelled` at every read, and no read observes a truncated or partially-written file.
+
+**AC-CX2-007** (MUST, REQ-CX2-004) — *Given* a project root whose `.moai/state/` cannot be written, *When* a background task is requested, *Then* the tool returns a structured error result, the test process does not panic, and the server remains able to serve a subsequent tool call.
+
+**AC-CX2-008** (MUST, REQ-CX2-005) — *Given* a job record produced with credential-shaped values present in the environment and in the request, *When* the record file is read, *Then* it contains no API key, no token, and no serialized environment block, verified by asserting the absence of the seeded sentinel values.
+
+### M3 — `codex_task`
+
+**AC-CX2-009** (MUST, REQ-CX2-006) — *Given* a canned codex session that completes a turn, *When* `codex_task` is invoked with `background` false, *Then* the result carries the task output; and *When* invoked with `background` true, *Then* the result carries a job id that resolves to an existing job record.
+
+**AC-CX2-010** (MUST, REQ-CX2-007) — *Given* a project with the write opt-in absent (the distributed default), *When* `codex_task` is invoked with `write` true, *Then* the turn is not run in a writing mode and the result states that the write request was not honored; and *Given* the opt-in enabled, *Then* the writing mode is requested.
+
+**AC-CX2-011** (MUST, REQ-CX2-008) — *Given* a recorded prior thread for the project, *When* `codex_task` runs with `resume_last`, *Then* the transmitted `threadId` equals the recorded one and no new `thread/start` is issued; and *Given* no recorded thread, *Then* a new thread is opened and the result states that no prior thread was resumed.
+
+### M4 — Job control
+
+**AC-CX2-012** (MUST, REQ-CX2-009) — *Given* an existing job, *When* `codex_job_status` is invoked with its id, *Then* the record is returned; and *Given* an unknown id, *Then* a structured not-found result is returned with `IsError` set rather than a Go error that aborts the call.
+
+**AC-CX2-013** (MUST, REQ-CX2-010) — *Given* a job in a terminal status, *When* `codex_job_result` is invoked, *Then* the recorded output is returned; and *Given* a running job, *Then* the current status is returned and the call completes without waiting for the turn.
+
+**AC-CX2-014** (MUST, REQ-CX2-011) — *Given* a running job backed by a canned session, *When* `codex_job_cancel` is invoked, *Then* the M0-confirmed interrupt request is sent on that job's session, the job's recorded status becomes `cancelled`, and *When* the process does not exit within the grace window, *Then* it is terminated and the call still returns within a bounded time.
+
+**AC-CX2-015** (MUST, REQ-CX2-012) — *Given* a job record naming a pid the server did not spawn, *When* `codex_job_cancel` is invoked for it, *Then* no signal is sent to that pid and the tool returns a structured refusal — asserted by a test that records signal attempts rather than by observing a live process.
+
+### Cross-cutting
+
+**AC-CX2-016** (MUST, REQ-CX2-013/014/015) — *Given* the completed tree, *When* the following batch runs, *Then* every command meets its stated expectation:
+
+```bash
+# tool registration + schema (expect 4 new tool names present)
+grep -c 'codex_task\|codex_job_status\|codex_job_result\|codex_job_cancel' internal/cli/mcp_server.go   # >= 4
+
+# subagent boundary (expect no output)
+grep -rn 'AskUserQuestion\|mcp__askuser' internal/cli/mcp_codex*.go internal/cli/codex_*.go \
+  | grep -v '_test.go' | grep -v '//'
+
+# no template surface touched (expect empty)
+git status --porcelain internal/template/templates/
+
+# cross-platform build (expect exit 0 twice)
+go build ./... && GOOS=windows GOARCH=amd64 go build ./...
+```
+
+## §B. Edge cases (negative tests, MUST)
+
+- Codex binary absent from PATH: every new tool returns a structured fail-open result; none panics, and none blocks the caller.
+- Codex spawns but the session closes before the handshake completes: the tool returns a structured result naming the failure; no goroutine leaks past the test.
+- Two concurrent background tasks in the same project: two distinct job ids, two distinct record files, neither overwriting the other.
+- A job record file that is present but malformed JSON: `codex_job_status` reports it as unreadable rather than crashing the server.
+- Cancel invoked on an already-terminal job: returns the terminal status and sends nothing.
+
+## §C. Definition of Done
+
+- Every MUST criterion above passes with cited command output.
+- `go test ./...` passes; `go build ./...` and `GOOS=windows GOARCH=amd64 go build ./...` both exit 0.
+- `internal/cli` package coverage is at or above its pre-change level.
+- `golangci-lint run` introduces no new findings against the pre-change baseline.
+- Both `[NEEDS CLARIFICATION]` markers in `plan.md` §D M0 are resolved and the resolutions are recorded before run-phase entry.
+- `git status --porcelain internal/template/templates/` is empty.
+
+## §D. Traceability
+
+| REQ | AC |
+|---|---|
+| REQ-CX2-001 | AC-CX2-001, AC-CX2-002 |
+| REQ-CX2-002 | AC-CX2-003, AC-CX2-004 |
+| REQ-CX2-003 | AC-CX2-005 |
+| REQ-CX2-004 | AC-CX2-006, AC-CX2-007 |
+| REQ-CX2-005 | AC-CX2-008 |
+| REQ-CX2-006 | AC-CX2-009 |
+| REQ-CX2-007 | AC-CX2-010 |
+| REQ-CX2-008 | AC-CX2-011 |
+| REQ-CX2-009 | AC-CX2-012 |
+| REQ-CX2-010 | AC-CX2-013 |
+| REQ-CX2-011 | AC-CX2-014 |
+| REQ-CX2-012 | AC-CX2-015 |
+| REQ-CX2-013 | AC-CX2-016 |
+| REQ-CX2-014 | AC-CX2-016 |
+| REQ-CX2-015 | AC-CX2-016 |

--- a/.moai/specs/SPEC-CODEX-PHASE2-001/plan.md
+++ b/.moai/specs/SPEC-CODEX-PHASE2-001/plan.md
@@ -1,0 +1,101 @@
+# Plan — SPEC-CODEX-PHASE2-001
+
+> Implementation plan for the Codex Phase 2 tool surface. Milestones are ordered by **decision-reversibility**: the protocol probe and the two open design forks come first, because everything downstream is shaped by their answers; the mechanical registration work is last.
+
+## §A. Context
+
+- **Baseline tree**: `origin/main` at `e55b48def`. Note the local checkout was 14 commits behind at authoring time — the delivered-state analysis in `spec.md` §A was made against `origin/main`, not the local `HEAD`.
+- **Primary file**: `internal/cli/mcp_codex.go` (730 lines on `origin/main`).
+- **Registration site**: `internal/cli/mcp_server.go` `registerMoaiMCPTools` (L105-242); codex tools currently at L191-208.
+- **Second consumer of the client**: `internal/cli/codex_review_gate.go` `HandleCodexReviewGate` (L66-110) — it calls `runCodexReviewRPC` with a 900 s context and must keep working unchanged.
+- **Existing test surface** (extend, do not replace): `mcp_codex_test.go`, `codex_review_rpc_test.go`, `codex_rpc_error_test.go`, `codex_review_gate_test.go`, `codex_review_gate_live_test.go`, `mcp_audit_test.go`.
+
+### §A.1 PRESERVE list
+
+- `runCodexReviewRPC`'s existing behavior for its two current callers (review-gate ALLOW/BLOCK, `codex_audit`).
+- `inconclusiveReview` / `VerdictInconclusive` fail-open semantics.
+- `readCodexReviewGateEnabled`'s nested `workflow.codex.review_gate.enabled` key path and its fail-closed truth table (`mcp_codex.go:708-729`) — an earlier revision read this at the top level and the toggle could never read true; do not "simplify" it back.
+- `TestReviewGateReaders_AgreeWithConfigLoader` and `TestMCPAudit_NoDirectFrontmatterRead`.
+- Every file outside `internal/cli/` and `internal/config/`.
+
+## §B. Known issues carried into this plan
+
+- **B1 — the predecessor's deferral list is stale.** Anyone re-reading `SPEC-MOAI-MCP-SERVER-001/spec.md:47` will see "native Go JSON-RPC client" listed as deferred. It is substantially delivered. Work from `spec.md` §A of *this* SPEC.
+- **B2 — the `model` parameter is a live bug, not a missing feature.** `codex_audit` advertises `model` and silently drops it (`buildCodexReviewParams`, `mcp_codex.go:433`). M1 fixes it; the fix changes what is sent to codex, so the review-gate tests are in the blast radius.
+- **B3 — the SSOT guard passes vacuously.** `TestMCPAudit_NoDirectFrontmatterRead` greps `mcp_codex.go` for frontmatter reads and finds none because nothing is resolved at all. After M1 the guard must still pass *and* a positive test must assert the resolver is actually called.
+- **B4 — undocumented protocol.** `turn/interrupt` and any write-mode flag are assumed, not observed. M0 exists to convert them into observations or to force a scope change.
+- **B5 — cross-platform.** Process termination in cancellation is platform-sensitive; `GOOS=windows GOARCH=amd64 go build ./...` must pass.
+
+## §C. Pre-flight
+
+```bash
+git fetch origin && git rev-parse --short origin/main
+go build ./... && GOOS=windows GOARCH=amd64 go build ./...
+go test ./internal/cli/... 2>&1 | tail -20
+golangci-lint run --timeout=2m 2>&1 | tail -5
+codex --version || echo "codex absent — live probes skip, fail-open paths still testable"
+```
+
+## §D. Milestones
+
+### M0 — Protocol probe and design-fork resolution (lead; most likely to change)
+
+Everything below M0 assumes answers M0 produces. Do not start M1 before M0 closes.
+
+1. Probe `codex app-server` against a pinned codex-cli version for: (a) whether a `turn/interrupt`-equivalent method exists and its params; (b) whether a second `turn/start` on an existing `threadId` is accepted after a turn completes; (c) whether the turn request carries a model/effort field and under what name; (d) whether a write/sandbox mode is expressible per-turn.
+2. Record each observed request/response verbatim. An unobserved method does not become a requirement — if (a) is absent, REQ-CX2-011 degrades to process-termination-only and `acceptance.md` AC-CX2-011 is amended before run-phase.
+3. Resolve the two open forks below.
+
+**[NEEDS CLARIFICATION: background job execution model]** — a background job can be (i) a goroutine inside the long-lived `moai mcp-server` process holding the codex subprocess, or (ii) a detached codex subprocess that survives an mcp-server restart. (i) makes cancellation and pid ownership trivial but loses every in-flight job when the server exits; (ii) survives restarts but needs pid reattachment and makes REQ-CX2-012's ownership check the load-bearing safety property. The record shape in REQ-CX2-003 differs between them. Recommendation: (i) — it matches the single-process lifetime the server already has and keeps the first delivery honest; (ii) is a later upgrade if job durability is actually wanted.
+
+**[NEEDS CLARIFICATION: write-mode opt-in surface]** — REQ-CX2-007 needs a named opt-in. Candidates: a new `workflow.codex.task.allow_write` key following the existing `workflow.codex.review_gate.enabled` shape (`mcp_codex.go:708`), or an environment variable in `envkeys.go`. Recommendation: the config key, because it mirrors a pattern already in the tree and is inspectable by `codex_setup`. Either way the distributed default is false.
+
+### M1 — Reusable session handle + model/effort SSOT wiring
+
+REQ-CX2-001, REQ-CX2-002. Split `runCodexReviewRPC` so the handshake (`initialize` → `thread/start` → `threadId`) is reachable as a reusable session, with `runCodexReviewRPC` retained as a thin caller so both existing consumers are untouched. Wire `template.ResolveAgentModelEffort` into the codex path and stop dropping the resolved value in `buildCodexReviewParams`. Add a positive test asserting the resolver is called (B3).
+
+### M2 — Job registry
+
+REQ-CX2-003, REQ-CX2-004, REQ-CX2-005. Per-job JSON files under `.moai/state/codex-jobs/`, atomic write per transition, structured error on an unwritable state directory, no secrets in the record. Follows the `.moai/state/audit-multi/<session>.json` precedent (`internal/cli/mcp_convergence.go:73`).
+
+### M3 — `codex_task`
+
+REQ-CX2-006, REQ-CX2-007, REQ-CX2-008. Foreground and background forms, the write opt-in gate, and `resume_last` thread reuse on top of M1's session handle.
+
+### M4 — Job control tools
+
+REQ-CX2-009, REQ-CX2-010, REQ-CX2-011, REQ-CX2-012. Status, result, and cancel; cancellation sends the M0-confirmed interrupt method, then terminates the process this server spawned for that job, and only that process.
+
+### M5 — Registration, boundary, and hardcoding sweep
+
+REQ-CX2-013, REQ-CX2-014, REQ-CX2-015. Tool registration with JSON Schema and read-only hints, the AskUserQuestion boundary grep, constants placement, and confirmation that `internal/template/templates/` is untouched.
+
+**Critical path**: M0 → M1 → M2 → M3 → M4 → M5. M2 may proceed in parallel with M1 once M0's execution-model fork is resolved, since the record shape does not depend on the session refactor.
+
+## §E. Self-verification
+
+Per milestone, report the §E attribution triple — the command, its verbatim output, and the HEAD SHA the evidence was captured against — per `.claude/rules/moai/development/manager-develop-prompt-template.md` § Section E.
+
+```bash
+go test ./internal/cli/... -run 'Codex|MCP'
+go test ./... && go build ./... && GOOS=windows GOARCH=amd64 go build ./...
+go test -cover ./internal/cli/...
+grep -rn 'AskUserQuestion\|mcp__askuser' internal/cli/mcp_codex*.go internal/cli/codex_*.go | grep -v '_test.go' | grep -v '//'
+git status --porcelain internal/template/templates/    # expect empty
+golangci-lint run --timeout=2m
+```
+
+## §F. Anti-patterns
+
+- **AP-1 — re-implementing the transport.** The NDJSON conn, the id matching, the error arm, and the turn loop exist (`spec.md` §A.1). Extend them; do not write a second client.
+- **AP-2 — changing `runCodexReviewRPC`'s contract for its existing callers.** The Stop gate's fail-open depends on the `(ReviewOutput, error)` pair where the output is always usable.
+- **AP-3 — specifying `codex_transfer` opportunistically.** It is excluded with a stated re-entry condition (`spec.md` § Out of Scope — `codex_transfer`). Adding it mid-run reopens a decision that was made deliberately.
+- **AP-4 — turning cancellation into a process sweep.** Kill only the pid this server spawned for that job (REQ-CX2-012). A pattern-matched `pkill codex` would kill a developer's interactive session.
+- **AP-5 — making the write gate default-on for convenience during development.** The distributed default is false; a local opt-in belongs in local config, not in the code default.
+- **AP-6 — quietly fixing `synthesizeReviewOutput` while nearby.** Findings extraction is out of scope; a verdict-parsing change here would ride into the review gate untested against its own criteria.
+
+## §G. Cross-references
+
+- `spec.md` §A — the verified delivered/remaining split (read before touching `mcp_codex.go`).
+- `acceptance.md` — AC-CX2-001..016.
+- `internal/cli/CLAUDE.md` — CLI module conventions (subagent boundary, exit codes, absolute paths).

--- a/.moai/specs/SPEC-CODEX-PHASE2-001/progress.md
+++ b/.moai/specs/SPEC-CODEX-PHASE2-001/progress.md
@@ -1,0 +1,20 @@
+# Progress — SPEC-CODEX-PHASE2-001
+
+## §E.1 Plan-phase Audit-Ready Signal
+
+- plan_status: audit-ready
+- tier: M
+- artifacts: spec.md + plan.md + acceptance.md (Tier M set)
+- open blockers: 2 `[NEEDS CLARIFICATION]` markers in `plan.md` §D M0 (background job execution model; write-mode opt-in surface) — both must be resolved before Implementation Kickoff Approval.
+
+## §E.2 Run-phase Evidence
+
+_<pending run-phase>_
+
+## §E.3 Run-phase Audit-Ready Signal
+
+_<pending run-phase>_
+
+## §E.4 Sync-phase Audit-Ready Signal
+
+_<pending sync-phase>_

--- a/.moai/specs/SPEC-CODEX-PHASE2-001/spec.md
+++ b/.moai/specs/SPEC-CODEX-PHASE2-001/spec.md
@@ -1,0 +1,171 @@
+---
+id: SPEC-CODEX-PHASE2-001
+title: "Codex Phase 2 — task delegation + job lifecycle tools over the delivered app-server JSON-RPC session client"
+version: "0.1.0"
+status: draft
+created: 2026-08-10
+updated: 2026-08-10
+author: manager-spec
+priority: P2
+phase: "v3.2 target"
+module: internal/cli
+lifecycle: spec-anchored
+tier: M
+tags: "codex, mcp, json-rpc, job-lifecycle, fail-open, model-effort-ssot"
+depends_on: [SPEC-MOAI-MCP-SERVER-001]
+---
+
+# SPEC-CODEX-PHASE2-001 — Codex Phase 2 MCP tool surface
+
+## HISTORY
+
+- 2026-08-10 (plan-phase, iter-1) — Initial Tier M authoring. Picks up the follow-up SPEC that `SPEC-MOAI-MCP-SERVER-001` (status: `completed`) declared in its `spec.md:47` and `design.md:81` Out-of-Scope entries. **The declared deferral list is stale**: one of its four items (the native Go JSON-RPC client for `codex app-server`) was substantially delivered afterwards by PR #1430 (`d39e3cdc6`, `fix(codex-gate): speak the real app-server JSON-RPC protocol so the gate can actually BLOCK`). §A.1 below records the verified delivered/remaining split against `origin/main`; this SPEC scopes only the genuinely-missing remainder.
+
+## §A. Verified baseline — what already exists
+
+Every claim in this section was read from `origin/main` (`e55b48def`), not from the predecessor SPEC's prose. The predecessor's deferral list is treated as a hypothesis, and it did not survive contact with the tree.
+
+### §A.1 Delivered — the native app-server JSON-RPC session client
+
+`internal/cli/mcp_codex.go` on `origin/main` (730 lines) already carries a real, session-oriented JSON-RPC client for `codex app-server`. It is not a stub and it is not a shellout-with-one-line-of-JSON:
+
+| Capability | Location (`internal/cli/mcp_codex.go`, `origin/main`) |
+|---|---|
+| Session-spawn seam + production runner (stdin/stdout pipes, stderr discarded) | `codexSessionRunner` / `realCodexSessionRunner.start` — L188-216 |
+| NDJSON connection with a concurrent reader goroutine (8 MB scanner buffer) | `realCodexConn.readLoop` — L229-242 |
+| `send` / `recv` / `close` (stdin close, 3 s wait, then kill) | L244-269 |
+| Request framing | `writeCodexRequest` — L362-369 |
+| id-matched response await, JSON-RPC `error` arm surfaced verbatim | `awaitCodexResponse` — L374-395; `codexIDMatches` (int **and** string ids) — L398-411 |
+| Mandatory handshake: `initialize` (with `clientInfo`) → `thread/start` → `threadId` | `runCodexReviewRPC` L313-340; `extractThreadID` L414-427 |
+| Protocol-correct param shaping (`threadId` injection; internally-tagged `target`; `turn/start` `input[]` wrapping) | `buildCodexReviewParams` L433-446; `coerceCodexReviewTarget` L453-463 |
+| Asynchronous notification stream read until `turn/completed` | `awaitCodexTurnReview` L468-508 |
+| Verdict synthesis from codex's free-form review prose | `codexFindingBullet` L536; `synthesizeReviewOutput` L543-554 |
+
+The transport, the handshake, the framing, the id matching, the error arm, and the async turn loop are therefore **NOT in scope** for this SPEC. Re-specifying them would be a defect.
+
+### §A.2 Not delivered — verified by absence
+
+`git grep` over `origin/main` (Go, Markdown, and JSON sources) returns **zero** matches for every one of: `codex_task`, `codex_job_status`, `codex_job_result`, `codex_job_cancel`, `codex_transfer`, `turn/interrupt`, `resume_last`, `.moai/state/codex-jobs`. Tool registration in `internal/cli/mcp_server.go` `registerMoaiMCPTools` (L105-242) carries exactly two codex tools — `codex_audit` (L191-199) and `codex_setup` (L204-208).
+
+### §A.3 Three verified structural gaps in the delivered client
+
+These are the parts of the client that a task/job surface actually needs and that the review-gate use case never exercised:
+
+- **G1 — the session is single-shot and synchronous.** `runCodexReviewRPC` (L306) opens a session, drives one turn, and `defer conn.close()` (L311) tears the subprocess down on return. The `threadId` obtained at L337 is a local variable, discarded on return. There is no way to issue a second turn on the same thread, and no way to start a turn that outlives the call.
+- **G2 — there is no cancellation path.** The only bound is the caller's `context` deadline (the Stop hook pins `config.DefaultCodexReviewGateTimeout` = 900 s, `internal/config/defaults.go:264`, applied at `internal/cli/codex_review_gate.go:87`). No `turn/interrupt` method constant exists, and `close()` is a blunt stdin-close-then-kill.
+- **G3 — the `model` argument is inert.** `codex_audit` declares a `model` parameter (`mcp_server.go:197`) and `handleCodexAudit` reads it into `params["model"]` (`mcp_codex.go:586`, `:596`), but `buildCodexReviewParams` (L433) constructs a **fresh** map containing only `threadId` plus `target`/`input` — the model value is dropped and never reaches codex. The codex path also never calls the model/effort SSOT, unlike the GLM sibling which resolves through `template.ResolveAgentModelEffort` at `internal/cli/mcp_glm.go:134`. The existing guard `TestMCPAudit_NoDirectFrontmatterRead` (`internal/cli/mcp_audit_test.go:146`) passes on `mcp_codex.go` only because that file reads no frontmatter at all — passing by abstinence, not by wiring.
+
+## §B. User Story
+
+**As a** MoAI orchestrator (or an external MCP host) that wants to delegate a bounded coding or investigation task to codex and keep working while it runs,
+
+**I want** a `codex_task` tool that drives a codex turn with my prompt, plus a job surface (`codex_job_status` / `codex_job_result` / `codex_job_cancel`) backed by a durable per-job record,
+
+**so that** the `/codex:rescue` capability is reachable declaratively from the same local stdio server as `codex_audit`, a long task does not block the calling turn, and a task that goes wrong can be stopped rather than waited out.
+
+## §C. Scope Summary
+
+This SPEC delivers four new MCP tools and the session/job plumbing they require, on top of the client verified in §A.1. It closes G1 (thread reuse + detached turns), G2 (`turn/interrupt` cancellation), and G3 (model/effort SSOT wiring), because each is a precondition of a usable task surface rather than a separable cleanup.
+
+### Out of Scope — `codex_transfer`
+
+- `codex_transfer` is **excluded**, and this is a deliberate reversal of the expectation set by the predecessor's deferral list rather than an oversight.
+- The predecessor already deferred it twice on the grounds that it is undocumented and version-coupled (`SPEC-MOAI-MCP-SERVER-001/design.md:81`), and the tree carries zero references to it (§A.2) — there is no method name, no param shape, and no observed response to specify against.
+- PR #1430 is the evidence that specifying against an unobserved codex method is expensive: four protocol facts (mandatory `initialize`, required `threadId`, internally-tagged `target`, async NDJSON completion) had to be discovered by hand-probing codex-cli 0.146.1 because the documented surface was wrong. Writing requirements for `codex_transfer` today would be an unverified-premise claim of exactly that shape.
+- It blocks nothing: the `/codex:rescue` replacement is `codex_task`, which is in scope here.
+- **Re-entry condition**: a `codex_transfer` SPEC becomes writable once the method, its params, and its result are observed against a pinned codex-cli version and recorded in a research artifact.
+
+### Out of Scope — structured findings extraction
+
+- `synthesizeReviewOutput` (`mcp_codex.go:543`) always returns `Findings: []Finding{}` and derives a coarse `pass`/`fail` from a finding-bullet regex. Populating the `Finding` array (severity / file / line / confidence) and replacing the regex heuristic is an **audit-quality** improvement to the already-shipped `codex_audit` surface, not a task-surface requirement.
+- It is left to a follow-up SPEC so that this one does not carry a second, independently-riskier verdict-parsing change alongside the job lifecycle.
+
+### Out of Scope — CLI mirrors of the new tools
+
+- No `moai codex task` / `moai codex jobs` Cobra subcommand is added. The tools are MCP-only in this SPEC, matching the `verify_snapshot` / `verify_trend` MCP-first precedent recorded as DQ-1 in the predecessor's `design.md:235`.
+
+### Out of Scope — convergence and gate behavior
+
+- `audit_multi` convergence (`internal/cli/mcp_convergence.go`), the `audit_model` / `audit_gate` config semantics, and the Stop-hook review gate's ALLOW/BLOCK contract (`internal/cli/codex_review_gate.go:50-109`) are untouched. The gate keeps calling `runCodexReviewRPC` and keeps its fail-open behavior.
+
+### Out of Scope — new template or distributed config surface
+
+- No file is added or modified under `internal/template/templates/`. The new tools introduce no `.claude/` or `.moai/` template artifact; job records live in `.moai/state/`, which is runtime state and already gitignored (`.gitignore:207`, `:275`). Thresholds land in `internal/config/defaults.go` and env names, if any, in `internal/config/envkeys.go` — both Go, neither a template surface. Template-First mirroring and §25 neutrality therefore do not apply to this SPEC.
+
+## §D. Requirements (GEARS)
+
+> Domain prefix `REQ-CX2-NNN`. Every requirement resting on existing code cites the verified `origin/main` location from §A.
+
+### M1 — Reusable session + model/effort SSOT (closes G1 partially, G3)
+
+**REQ-CX2-001** (Ubiquitous) The codex session client shall expose a reusable session handle that retains the `threadId` obtained from `thread/start`, so that a second turn can be issued on the same thread without repeating the `initialize` + `thread/start` handshake.
+
+**REQ-CX2-002** (State-driven) **While** resolving the codex model and effort for a request, the codex backend shall resolve through `template.ResolveAgentModelEffort` — the same interpreter the GLM sibling uses at `internal/cli/mcp_glm.go:134` — and shall carry the resolved value into the params actually transmitted to codex, and shall not read agent frontmatter or `llm.agent_overrides` directly.
+
+### M2 — Job registry (durable record)
+
+**REQ-CX2-003** (Event-driven) **When** a codex task is started in background mode, the server shall create a job record at `.moai/state/codex-jobs/<job-id>.json` carrying at minimum: job id, status, creation and last-update timestamps, the codex `threadId`, the requested mode, and a summary of the request.
+
+**REQ-CX2-004** (Ubiquitous) A job record's `status` shall be one of `queued`, `running`, `completed`, `failed`, `cancelled`; each transition shall be written atomically, and **where** the state directory is unwritable the tool shall return a structured error result rather than panicking or aborting the server process.
+
+**REQ-CX2-005** (Unwanted) A job record shall not contain codex credentials, API keys, resolved secret values, or a copy of the process environment.
+
+### M3 — `codex_task`
+
+**REQ-CX2-006** (Event-driven) **When** `codex_task` is invoked, the server shall drive a codex `turn/start` carrying the caller's prompt, returning the completed task output when `background` is false and a job id when `background` is true.
+
+**REQ-CX2-007** (Capability gate) **Where** the caller requests `write`, the tool shall permit codex to modify the working tree only when the project has explicitly opted in; otherwise it shall run the turn in a non-writing mode and shall state in its result that the write request was not honored. The distributed default shall be opt-out (no writes).
+
+**REQ-CX2-008** (State-driven) **While** `resume_last` is set, `codex_task` shall reuse the most recently recorded `threadId` for the project instead of opening a new thread; **when** no such thread is recorded, it shall open a new thread and report in its result that no prior thread was resumed.
+
+### M4 — Job control
+
+**REQ-CX2-009** (Event-driven) **When** `codex_job_status` is invoked with a job id, the server shall return that job's record, and **when** the id is unknown it shall return a structured not-found result rather than an error that aborts the tool call.
+
+**REQ-CX2-010** (Event-driven) **When** `codex_job_result` is invoked for a job that has reached a terminal status, the server shall return the recorded task output; for a non-terminal job it shall return the current status without blocking the caller.
+
+**REQ-CX2-011** (Event-driven) **When** `codex_job_cancel` is invoked for a running job, the server shall send `turn/interrupt` on that job's session, and **when** the codex process does not exit within a bounded grace window, shall terminate the process it spawned and record the job as `cancelled`.
+
+**REQ-CX2-012** (Unwanted) `codex_job_cancel` shall not signal or terminate any process the server did not itself spawn for that job.
+
+### Cross-cutting
+
+**REQ-CX2-013** (Ubiquitous) The four new tools shall be registered in `registerMoaiMCPTools` (`internal/cli/mcp_server.go:105`) with a declared JSON Schema for their inputs, and the read-only tools among them shall carry the read-only hint annotation, consistent with the existing tool surface.
+
+**REQ-CX2-014** (Unwanted) None of the new tools or their supporting code shall invoke `AskUserQuestion` or emit a free-form user-facing question; a missing input, an unknown job, or a refused write is returned as a structured result for the orchestrator to translate.
+
+**REQ-CX2-015** (Capability gate) **Where** this SPEC introduces a threshold, timeout, or environment-variable name, it shall be defined as a constant in `internal/config/defaults.go` or `internal/config/envkeys.go` respectively, and no file shall be added or modified under `internal/template/templates/`.
+
+## §E. Acceptance Criteria
+
+Enumerated as `AC-CX2-001..016` in `acceptance.md`, bound to milestones M1-M4 plus cross-cutting.
+
+## §F. Constraints (non-functional)
+
+- **C1 — fail-open preserved.** A missing, unauthenticated, hung, or protocol-rejecting codex never hard-blocks: the existing `inconclusiveReview` / `VerdictInconclusive` path (`mcp_codex.go:82`, `:108`) and the Stop gate's ALLOW-on-inconclusive behavior (`codex_review_gate.go:96-109`) are unchanged by this SPEC.
+- **C2 — subagent boundary.** MCP tools return structured results; the orchestrator owns all user interaction.
+- **C3 — secret hygiene.** No codex credential is written into a job record, a `.mcp.json` entry, or any tool result. Codex auth material stays in `~/.moai/.env.codex`.
+- **C4 — model/effort SSOT.** `template.ResolveAgentModelEffort` is the sole interpreter; the existing guard `TestMCPAudit_NoDirectFrontmatterRead` (`mcp_audit_test.go:146`) must keep passing, and must now pass because the resolver is wired rather than because nothing is read.
+- **C5 — same-core-two-surfaces.** Job and session logic is written once; no logic is forked between an MCP handler and any future CLI mirror.
+- **C6 — no distributed-surface expansion.** No new template file, no new third-party `.mcp.json` entry.
+- **C7 — no regression in the review gate.** `runCodexReviewRPC`'s existing call sites (`handleCodexAudit`, `HandleCodexReviewGate`) keep their current behavior and signature semantics.
+
+## §G. Dependencies
+
+- `SPEC-MOAI-MCP-SERVER-001` (`status: completed`) — delivers the server scaffold, the tool registration surface, `ReviewOutput`, the fail-open contract, and the session client of §A.1.
+- Existing packages: `internal/cli` (`mcp_codex.go`, `mcp_server.go`, `codex_review_gate.go`, `session.go` `resolveProjectDir`), `internal/config` (defaults/envkeys), `internal/template` (`ResolveAgentModelEffort`, `profile_matrix.go:385`).
+- Runtime, optional: the `codex` CLI binary. Absent codex leaves every new tool on the fail-open path.
+
+## §H. Risks
+
+- **R1 — codex app-server remains experimental and undocumented.** `turn/interrupt`, thread reuse, and any write-mode flag are asserted from the same undocumented surface that PR #1430 had to hand-probe. Mitigation: an M0-style probe against a pinned codex-cli version precedes the requirements that depend on a method name; fail-open covers a method that does not exist.
+- **R2 — a long-lived codex subprocess outliving its caller.** Background jobs hold a subprocess whose lifetime is no longer bounded by a single tool call. Mitigation: a bounded job-level ceiling reusing the `DefaultCodexReviewGateTimeout` precedent, plus REQ-CX2-011 cancellation and REQ-CX2-012 pid ownership.
+- **R3 — write-mode blast radius.** `codex_task` with writes lets an external MCP host mutate the working tree through moai. Mitigation: REQ-CX2-007 opt-in with a distributed default of no writes.
+- **R4 — job-record concurrency.** Two sessions on the same checkout share `.moai/state/codex-jobs/`. Mitigation: per-job files (no shared index), atomic write per REQ-CX2-004.
+
+## §I. Cross-References
+
+- Predecessor: `.moai/specs/SPEC-MOAI-MCP-SERVER-001/` — `spec.md:45-47` (Out of Scope — Codex Phase 2 tools), `design.md:79-82` (out-of-scope tools).
+- Baseline commit: PR #1430 `d39e3cdc6` — the app-server JSON-RPC protocol fix that delivered §A.1.
+- Sibling: `SPEC-AUDIT-MULTI-MODEL-001` — convergence, untouched here.
+- Schema SSOT: `.claude/rules/moai/development/spec-frontmatter-schema.md`.


### PR DESCRIPTION
## What

Plan-phase artifacts (`spec.md` / `plan.md` / `acceptance.md` / `progress.md`) for
the follow-up SPEC that `SPEC-MOAI-MCP-SERVER-001` deferred and that was never
written: `codex_task` plus the job-lifecycle tools.

Tier M · 15 REQ / 16 AC · `status: draft` · no template surface touched.

## Why the deferred scope was re-derived, not copied

The predecessor's deferral list named four items. Read against the tree, one of
them is already built: `internal/cli/mcp_codex.go` carries a real session-oriented
JSON-RPC client for `codex app-server` (handshake, NDJSON framing, id-matched
await, async turn loop), landed by #1430. Re-specifying it would have been a
defect, so the transport is explicitly out of scope.

What the review-gate use case never exercised is specified instead — three gaps
verified by reading:

- **G1** single-shot sessions — `runCodexReviewRPC` tears the subprocess down on
  return and discards the `threadId`.
- **G2** no cancellation path — no `turn/interrupt`; the only bound is the caller's
  context deadline.
- **G3** the `model` argument is inert — `buildCodexReviewParams` builds a fresh map
  holding only `threadId` plus `target`/`input`, so a declared `model` never reaches
  codex. The existing frontmatter guard passes on this file by abstinence, not by
  wiring.

## Out of scope (stated, with rationale)

- `codex_transfer` — undocumented and version-coupled; zero references in the tree.
  Re-entry condition: observe the method, params, and result against a pinned
  codex-cli version first.
- Structured findings extraction, CLI mirrors, convergence/gate behavior, template
  changes.

## Notes

Plan-phase only — no implementation. `M0` in the plan is a protocol probe before any
requirement that depends on an undocumented method name, following the lesson from
#1430.

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a specification for reusable Codex sessions, model and effort selection, background jobs, task execution, job controls, write-mode gating, and resume support.
  * Added detailed acceptance criteria, including security, lifecycle, cross-platform, edge-case, and completion requirements.
  * Added an implementation plan with milestones, verification steps, risks, and known issues.
  * Added progress tracking for completed planning work and outstanding blockers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->