### PR TITLE
chore(SPEC-HARNESS-TOKEN-OPT-001): 3-phase close + lsel-leak-guard go-version fix

### DIFF
--- a/.github/workflows/lsel-leak-guard.yaml
+++ b/.github/workflows/lsel-leak-guard.yaml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.23'
+          go-version-file: go.mod
       - name: Run LSEL leak guard (extended internal_content_leak_test + split_namespace_test)
         run: |
           go test ./internal/template/... -run 'TestLSELLeakPositiveControl|TestTemplateNoInternalContentLeak|TestSplitHarnessNamespaceNoLeak' -v

--- a/.moai/specs/SPEC-HARNESS-TOKEN-OPT-001/progress.md
+++ b/.moai/specs/SPEC-HARNESS-TOKEN-OPT-001/progress.md
@@ -150,11 +150,11 @@ m1_to_mN_commit_strategy: per-milestone commits not yet staged; orchestrator hol
 
 ```yaml
 sync_complete_at: 2026-08-11
-sync_commit_sha: pending-backfill
+sync_commit_sha: 6422046bb
 sync_status: audit-ready
 changelog_entry_position: CHANGELOG.md [Unreleased] ### Changed
 frontmatter_status_transitions:
-  spec_md: draft -> implemented
+  spec_md: draft -> implemented -> completed
   plan_md: no frontmatter (Tier M authoring choice; only spec.md carries frontmatter per FrontmatterSchemaRule)
   acceptance_md: no frontmatter (Tier M authoring choice)
   progress_md: §E.4 populated by manager-docs (this commit)

--- a/.moai/specs/SPEC-HARNESS-TOKEN-OPT-001/spec.md
+++ b/.moai/specs/SPEC-HARNESS-TOKEN-OPT-001/spec.md
@@ -2,7 +2,7 @@
 id: SPEC-HARNESS-TOKEN-OPT-001
 title: "Harness Token/Time Optimization — paths-scoping, SSOT consolidation, and A9 default inversion"
 version: "1.0.0"
-status: implemented
+status: completed
 created: "2026-08-11"
 updated: "2026-08-11"
 author: GOOS


### PR DESCRIPTION
Post-merge backfill for #1443.

(1) SPEC 3-phase close (implemented→completed + sync_commit_sha=6422046bb).

(2) lsel-leak-guard CI fix — root cause of the failing non-required check on #1443 (go.mod `tool` directive needs Go 1.24+; this job pinned 1.23; now uses go-version-file: go.mod).

Closes #1443 cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated checks to use the Go version declared by the project configuration.
  - Completed the harness token optimization specification and recorded its associated commit.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->