### PR TITLE
chore(SPEC-GATE-ASTGREP-REPAIR-001): backfill sync_commit_sha

### DIFF
--- a/.moai/specs/SPEC-GATE-ASTGREP-REPAIR-001/progress.md
+++ b/.moai/specs/SPEC-GATE-ASTGREP-REPAIR-001/progress.md
@@ -207,7 +207,7 @@ m1_to_mN_commit_strategy: per-milestone commits (ff5812b28 M0+M1, c4ca4c74b M2, 
 
 ```yaml
 sync_complete_at: 2026-08-11
-sync_commit_sha: pending-backfill-sync  # self-referential-hazard — a commit cannot reference its own SHA; backfilled in a follow-up commit after the sync PR merges (per spec-frontmatter-schema.md D3)
+sync_commit_sha: 4d0d7ebb8  # self-referential-hazard — a commit cannot reference its own SHA; backfilled in a follow-up commit after the sync PR merges (per spec-frontmatter-schema.md D3)
 sync_status: audit-ready
 changelog_entry_position: CHANGELOG.md [Unreleased] > ### Fixed  # single entry, top of Fixed section
 frontmatter_status_transitions:


### PR DESCRIPTION
Backfills the sync_commit_sha placeholder in progress.md §E.4 with the PR #1445 squash merge SHA (4d0d7ebb8).

Markdown-only; no code change. 🗯

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the audit record with the completed synchronization commit reference.
  * Retained the existing self-referential hazard note.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->