### PR TITLE
chore: backfill sync_commit_sha for #1448 (FACTORY-BOOTSTRAP + EPIC-STATUS)

### DIFF
--- a/.moai/specs/SPEC-EPIC-STATUS-001/progress.md
+++ b/.moai/specs/SPEC-EPIC-STATUS-001/progress.md
@@ -91,7 +91,7 @@ m1_to_mN_commit_strategy: per-milestone Conventional Commits `feat(SPEC-EPIC-STA
 
 ```yaml
 sync_complete_at: 2026-08-12
-sync_commit_sha: pending-backfill-sync   # self-referential-hazard workaround (spec-frontmatter-schema.md D3); backfilled in a follow-up commit
+sync_commit_sha: 6da952899be8b2ceafe7bb87aa6af41b8c32dd0c   # self-referential-hazard workaround (spec-frontmatter-schema.md D3); backfilled in a follow-up commit
 sync_status: audit-ready
 run_commit_sha: 4aa9178c3                # final run-phase commit (M5 factory-notice touchpoint)
 frontmatter_status_transitions:

--- a/.moai/specs/SPEC-FACTORY-BOOTSTRAP-001/progress.md
+++ b/.moai/specs/SPEC-FACTORY-BOOTSTRAP-001/progress.md
@@ -180,7 +180,7 @@ blocker_report: none
 ```yaml
 sync_status: audit-ready
 sync_complete_at: 2026-08-11
-sync_commit_sha: pending-backfill-sync
+sync_commit_sha: 6da952899be8b2ceafe7bb87aa6af41b8c32dd0c
 run_commit_sha: 89227add0
 changelog_entry_position: top of [Unreleased] → Added (English-only CHANGELOG.md)
 frontmatter_status_transitions:


### PR DESCRIPTION
D3 SHA-placeholder backfill. Both SPEC-FACTORY-BOOTSTRAP-001 and SPEC-EPIC-STATUS-001 reached completed status in PR #1448 (squash commit 6da952899be8b2ceafe7bb87aa6af41b8c32dd0c). This commit populates the real SHA in each SPEC's progress.md §E.4 sync_commit_sha field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project progress records to reflect the completed synchronization commit.
  * Replaced pending synchronization placeholders with the finalized commit reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->