### PR TITLE
docs(SPEC-CONFIG-ATOMIC-WRITE-001): post-merge SHA backfill → 67c264888

### DIFF
--- a/.moai/specs/SPEC-CONFIG-ATOMIC-WRITE-001/spec.md
+++ b/.moai/specs/SPEC-CONFIG-ATOMIC-WRITE-001/spec.md
@@ -6,7 +6,7 @@ status: completed
 created: 2026-08-12
 updated: 2026-08-12
 run_commit_sha: 78acfb714
-sync_commit_sha: pending-backfill-sync
+sync_commit_sha: 67c264888
 author: manager-spec
 priority: P0
 phase: "v3.0.2 target"


### PR DESCRIPTION
Post-merge `sync_commit_sha` backfill for SPEC-CONFIG-ATOMIC-WRITE-001 (PR #1458 squash merge `67c264888`). `pending-backfill-sync` placeholder → real SHA. Doc-only (1 line). Per spec-frontmatter-schema.md D3 self-referential-hazard workaround. 🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the specification’s synchronization reference to the latest commit identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->