### PR TITLE
chore(specs): backfill sync_commit_sha — SPEC-MCP-DEFAULT-ON-001 (d21b76ebb)

### DIFF
--- a/.moai/specs/SPEC-MCP-DEFAULT-ON-001/progress.md
+++ b/.moai/specs/SPEC-MCP-DEFAULT-ON-001/progress.md
@@ -63,7 +63,7 @@ m1_to_mN_commit_strategy: per-milestone conventional commits (M2 2b380941e, M3 b
 ## §E.4 Sync-phase Audit-Ready Signal
 
 sync_complete_at: 2026-08-12
-sync_commit_sha: pending-backfill-sync  # self-referential-hazard placeholder per spec-frontmatter-schema.md D3 — a commit cannot know its own SHA until after it lands; backfilled in a follow-up chore(specs) commit
+sync_commit_sha: d21b76ebb  # PR #1464 squash-merge onto main (SPEC-MCP-DEFAULT-ON-001 sync-phase, merged 2026-08-12) — durable main commit representing the merged SPEC work (D3 self-referential-hazard backfill)
 sync_status: audit-ready
 run_baseline_squash_sha: ac3e38a0b  # PR #1455 squash onto main (2026-08-12) — durable main commit representing the merged plan+amendment+run work this sync commit closes
 changelog_entry_position: CHANGELOG.md `[Unreleased]` → `### Added` (SPEC-MCP-DEFAULT-ON-001 bullet)


### PR DESCRIPTION
D3 self-referential-hazard backfill. PR #1464 (the SPEC-MCP-DEFAULT-ON-001 sync-phase close) squash-merged onto main as `d21b76ebb`. The sync commit itself could not reference its own SHA until it landed, so progress.md §E.4 carried a `pending-backfill-sync` placeholder — this PR backfills the real SHA.

Markdown-only change (0 Go files). Closes the 3-phase lifecycle for SPEC-MCP-DEFAULT-ON-001.

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the synchronization progress record with the merged commit reference and corresponding audit note.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->