### PR TITLE
docs(llm.yaml): annotate GLM reasoning effort mapping under profile

### DIFF
--- a/internal/template/templates/.moai/config/sections/llm.yaml
+++ b/internal/template/templates/.moai/config/sections/llm.yaml
@@ -11,6 +11,16 @@ llm:
   # Absent or empty resolves to medium (backward compatible). The superseded
   # top-column name "max" is still READ as an alias for "high", but is never
   # written back.
+  #
+  # Under a GLM backend (team_mode: glm/cg), z.ai exposes only a 3-state
+  # reasoning control (no "medium" level). The agent effort from the profile
+  # column above collapses onto it:
+  #   effort low          -> thinking off (fastest, no reasoning)
+  #   effort medium/high  -> reasoning_effort=high
+  #   effort xhigh/max    -> reasoning_effort=max
+  # So under GLM, profile "medium" and "high" converge (both reach
+  # reasoning_effort=high); the code-producing run-phase agent runs at
+  # reasoning_effort=max regardless (coding-task recommendation).
   profile: "medium"
 
   # Legacy performance tier (read-time alias only — `profile` supersedes it).


### PR DESCRIPTION
## What

Adds a comment block under the `profile` field in the distributed `llm.yaml` documenting how the Claude effort vocabulary collapses onto z.ai's 3-state reasoning control under a GLM backend.

## Why

Under a GLM backend (`team_mode: glm/cg`), the shipped default `profile: "medium"` is confusing — z.ai has no "medium" reasoning level, so "medium" maps non-obviously to `reasoning_effort=high`. A reader of `llm.yaml` previously had to find the overlay source (`CollapseClaudeEffortToGLM`) to know what their profile resolves to. This surfaces the mapping inline.

## Mapping documented

| Claude effort | GLM reasoning state |
|---|---|
| low | thinking off (no reasoning) |
| medium / high | reasoning_effort=high |
| xhigh / max | reasoning_effort=max |

Under GLM, profile `medium` and `high` converge (both reach `reasoning_effort=high`); the code-producing run-phase agent (`manager-develop`) runs at `reasoning_effort=max` regardless (coding-task override).

## Scope

- **No code or behavior change** — comment only.
- Default profile stays `medium` (DECISION-002).
- Template SSOT only (`internal/template/templates/.moai/config/sections/llm.yaml`); `make build` re-embeds. Catalog is unaffected (config/sections yamls are not catalog-tracked).

## Verification

- `TestCollapseClaudeEffortToGLM`, `TestIsGLMBackend`, `TestDefaultModelPolicyIsMedium`, `TestResolveGLMReasoning_CodingMaxOverride`, `TestSessionGLMReasoningStateForEffort` — all PASS (the mapping in the comment matches the code's tested behavior).
- `strings bin/moai | grep "Under a GLM backend"` → embedded (4 matches).
- Neutrality: no SPEC-ID / commit-SHA / date in the comment.

Pre-existing baseline failure `TestHookWrapperConventions` (expects hook timeout 5, gets 10 from PR #1473) is unrelated — this PR touches a yaml comment only; Go files touched: 0.

🗿 MoAI