### PR TITLE
chore(SPEC-MCP-CONSOLE-001): backfill sync_commit_sha 4389caffd

### DIFF
--- a/.moai/specs/SPEC-MCP-CONSOLE-001/progress.md
+++ b/.moai/specs/SPEC-MCP-CONSOLE-001/progress.md
@@ -142,7 +142,7 @@ m1_to_mN_commit_strategy: per-milestone commits (M1..M4 already committed at 913
 ## §E.4 Sync-phase Audit-Ready Signal
 
 sync_complete_at: 2026-08-13
-sync_commit_sha: pending-backfill-sync
+sync_commit_sha: 4389caffd
 sync_status: ready
 b12_self_test_a:
   changelog_duplicate_guard: PASS (`grep -c 'SPEC-MCP-CONSOLE-001' CHANGELOG.md` → 0 pre-emission, 1 post-emission)


### PR DESCRIPTION
This is the D3 backfill follow-up to PR #1479 (squash-merged 4389caffd).

The sync_commit_sha placeholder in progress.md §E.4 is now backfilled with the real close SHA.

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the synchronization audit record to reflect the completed commit reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->