### PR TITLE
docs(claude-md): diet 337→181 lines (G1) + agent-count drift fix

### DIFF
--- a/.claude/rules/moai/development/agent-authoring.md
+++ b/.claude/rules/moai/development/agent-authoring.md
@@ -125,9 +125,9 @@ The `memory` field enables cross-session learning for agents. Three scope levels
 
 ## Agent Categories
 
-The MoAI agent catalog consists of exactly **11 retained agents** (10 MoAI-custom + 1 Anthropic built-in `Explore`), aligned with CLAUDE.md §4. The v2 architecture (SPEC-AGENT-ARCH-V2-001) added `super-advisor` (on-demand high-reasoning consultation) and `manager-design` (Claude Design collaboration) to the former 8-agent catalog. Previously-listed manager and expert agents beyond this set were archived during the catalog consolidation. Domain expertise formerly delivered by those static agents is now delivered through per-spawn `Agent(general-purpose)` parameter injection — see § Per-Spawn Domain Specialization below and `.claude/rules/moai/workflow/archived-agent-rejection.md` §C for the full archived-name enumeration and migration table.
+The MoAI agent catalog consists of exactly **12 retained agents** (11 MoAI-custom + 1 Anthropic built-in `Explore`), aligned with CLAUDE.md §4. The v2 architecture (SPEC-AGENT-ARCH-V2-001) added `super-advisor` (on-demand high-reasoning consultation) and `manager-design` (Claude Design collaboration) to the former 8-agent catalog; `manager-lead` (hierarchical-team Tier L coordination) was added later per the hierarchical-team SPEC. Previously-listed manager and expert agents beyond this set were archived during the catalog consolidation. Domain expertise formerly delivered by those static agents is now delivered through per-spawn `Agent(general-purpose)` parameter injection — see § Per-Spawn Domain Specialization below and `.claude/rules/moai/workflow/archived-agent-rejection.md` §C for the full archived-name enumeration and migration table.
 
-### Retained MoAI-custom Agents (10)
+### Retained MoAI-custom Agents (11)
 
 Coordinate the SPEC plan/design/run/sync/audit lifecycle:
 
@@ -280,7 +280,7 @@ START
   ├── Is this work recurring across SPEC sessions
   │   AND with substantially the same instructions each time?
   │   ├── YES → Author a static agent file under .claude/agents/moai/
-  │   │         (subject to the 11-agent retention ceiling per the
+  │   │         (subject to the 12-agent retention ceiling per the
   │   │         canonical agent catalog policy — exceeding the ceiling
   │   │         requires a dedicated revision SPEC)
   │   └── NO  → Use per-spawn Agent(general-purpose) injection
@@ -302,7 +302,7 @@ For the canonical per-spawn `Agent(general-purpose, ...)` spawn pattern with per
 - **Authoring a static agent file for one-off domain work** — if the spawn instructions vary substantially per invocation, the file is dead weight and trains the orchestrator to spawn an under-instructed agent
 - **Embedding domain knowledge in agent body** — domain knowledge belongs in the active conversation context (per-spawn prompt) where the orchestrator can tailor it to the current task; embedding it in agent body traps it behind explicit invocation
 - **Re-introducing archived agent files** — the 12 agents archived offline during the catalog consolidation MUST NOT be reintroduced under `.claude/agents/` without a dedicated revival SPEC justifying the recurrence criterion; see `.claude/rules/moai/workflow/archived-agent-rejection.md` § Anti-Patterns
-- **Adding a new MoAI-custom agent without a SPEC** — the 11-agent retention ceiling is an architectural invariant; new agent additions must justify the "keep spawning the same worker" criterion via a SPEC that documents recurrence evidence
+- **Adding a new MoAI-custom agent without a SPEC** — the 12-agent retention ceiling is an architectural invariant; new agent additions must justify the "keep spawning the same worker" criterion via a SPEC that documents recurrence evidence
 
 ## Extension-Mechanism Context-Cost Ladder
 

--- a/.claude/rules/moai/development/agent-patterns.md
+++ b/.claude/rules/moai/development/agent-patterns.md
@@ -231,7 +231,7 @@ The orchestrator composes the domain instructions inline at delegation time rath
 
 ### When to Author a Static Agent File Instead
 
-Reserve `.claude/agents/*.md` static files for agents meeting Anthropic's "keep spawning the same kind of worker with the same instructions" criterion. The 10 MoAI-custom retained agents (`manager-spec`, `manager-develop`, `manager-design`, `manager-docs`, `manager-git`, `plan-auditor`, `sync-auditor`, `super-advisor`, `builder-harness`, `e2e-tester`) all satisfy this criterion via recurring SPEC-phase invocations. Domain-specific work that does NOT recur with identical instructions across SPEC sessions belongs in per-spawn pattern, not in a static file.
+Reserve `.claude/agents/*.md` static files for agents meeting Anthropic's "keep spawning the same kind of worker with the same instructions" criterion. The 11 MoAI-custom retained agents (`manager-spec`, `manager-develop`, `manager-design`, `manager-docs`, `manager-git`, `plan-auditor`, `sync-auditor`, `super-advisor`, `builder-harness`, `e2e-tester`, `manager-lead`) all satisfy this criterion via recurring SPEC-phase invocations. Domain-specific work that does NOT recur with identical instructions across SPEC sessions belongs in per-spawn pattern, not in a static file.
 
 See `.claude/rules/moai/development/agent-authoring.md` § Static Agent File vs Per-Spawn Specialization Decision Tree for the authoring decision tree.
 
@@ -266,7 +266,7 @@ Agent(subagent_type: "Explore", prompt: "<investigation task description>")
 
 ## Orchestrator 4-Loop Mechanism → Catalog Mapping
 
-The MoAI orchestrator operates a 4-Loop mechanism (plan → decompose → direct → collect) that maps each loop step to specific 11-agent catalog roles. This mapping is the architectural rationale for the catalog composition (per SPEC-AGENT-ARCH-V2-001 SSOT §03/§06 M4).
+The MoAI orchestrator operates a 4-Loop mechanism (plan → decompose → direct → collect) that maps each loop step to specific 12-agent catalog roles. This mapping is the architectural rationale for the catalog composition (per SPEC-AGENT-ARCH-V2-001 SSOT §03/§06 M4).
 
 | Loop step | Korean | Catalog roles invoked | Example |
 |-----------|--------|----------------------|---------|
@@ -299,7 +299,7 @@ The v2 agent architecture (SPEC-AGENT-ARCH-V2-001) explicitly rejected 4 alterna
 
 **Rejected approach**: Pin concrete model IDs (e.g., `model: opus`) in agent frontmatter to control per-agent model selection at the file level.
 
-**Why rejected**: The `[1m]` entitlement inheritance bug (Anthropic issues #45847 / #51060 / #36670) — a frontmatter model pin breaks `[1m]` entitlement flow from the parent session, causing spawn failures. The v2 design uses `model: inherit` (all 10 MoAI-custom agents) + per-spawn runtime-arg injection for tier-dependent model selection instead. See `.claude/rules/moai/development/model-policy.md` § Inherit-by-Default Convention.
+**Why rejected**: The `[1m]` entitlement inheritance bug (Anthropic issues #45847 / #51060 / #36670) — a frontmatter model pin breaks `[1m]` entitlement flow from the parent session, causing spawn failures. The v2 design uses `model: inherit` (all 11 MoAI-custom agents) + per-spawn runtime-arg injection for tier-dependent model selection instead. See `.claude/rules/moai/development/model-policy.md` § Inherit-by-Default Convention.
 
 ### 4. Time-루프 에이전트 (Time-loop Agent)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,41 +6,29 @@ You are **Master Agent MoAI** — the master orchestrator whose mission is the u
 
 ### HARD Rules (Mandatory)
 
-- [ZONE:Evolvable] [HARD] Language-Aware Responses: All user-facing responses MUST be in user's conversation_language
-- [ZONE:Evolvable] [HARD] Parallel Execution: Execute all independent tool calls in parallel when no dependencies exist
-- [ZONE:Evolvable] [HARD] User Response Format: Use plain Markdown for all user-facing responses (XML tags are reserved for internal agent-to-agent data transfer)
-- [ZONE:Evolvable] [HARD] Markdown Output: Use Markdown for all user-facing communication
-- [ZONE:Frozen] [HARD] AskUserQuestion-Only Interaction: ALL questions directed at the user MUST go through AskUserQuestion (See Section 8)
-- [ZONE:Frozen] [HARD] Deferred Tool Preload: AskUserQuestion, TaskCreate/Update/List/Get are deferred tools — schema is NOT loaded at session start. Call ToolSearch BEFORE first use to load schemas. Calling without schema produces InputValidationError. (See Section 8 Deferred Tool Preload Protocol)
-- [ZONE:Evolvable] [HARD] Context-First Discovery: Conduct Socratic interview via AskUserQuestion when context is insufficient before executing non-trivial tasks (See Section 7)
-- [ZONE:Evolvable] [HARD] Approach-First Development: Explain approach and get approval before writing code (See Section 7)
-- [ZONE:Evolvable] [HARD] Multi-File Decomposition: Split work when modifying 3+ files (See Section 7)
-- [ZONE:Evolvable] [HARD] Post-Implementation Review: List potential issues and suggest tests after coding (See Section 7)
-- [ZONE:Evolvable] [HARD] Reproduction-First Bug Fix: Write reproduction test before fixing bugs (See Section 7)
+[ZONE] tags and full rule text live in `.claude/rules/moai/core/moai-constitution.md` (always-loaded) + `.claude/rules/moai/core/zone-registry.md`. The binding mandates:
 
-Core principles (1-4) and six Agent Core Behaviors (consolidated cross-cutting rules) are defined in .claude/rules/moai/core/moai-constitution.md. Development safeguards (5-9) are detailed in Section 7.
+- **Output discipline** — user-facing responses in `conversation_language`, plain Markdown (XML reserved for agent-to-agent); independent tool calls run in parallel.
+- **Interaction** — all user questions via AskUserQuestion; preload its schema via `ToolSearch` before first use (§8).
+- **Dev safeguards (§7)** — Context-First Discovery, Approach-First Development, Multi-File Decomposition, Post-Implementation Review, Reproduction-First Bug Fix.
 
-### Recommendations
-
-- Agent delegation recommended for complex tasks requiring specialized expertise
-- Direct tool usage permitted for simpler operations
-- Appropriate Agent Selection: Optimal agent matched to each task
+Core principles (1-4) + six Agent Core Behaviors: `.claude/rules/moai/core/moai-constitution.md`. Delegate complex tasks to specialized agents; direct tool use for simpler ops; match agent to task.
 
 ---
 
 ## 2. Request Processing Pipeline
 
-**Analyze-First** is the default main-session orchestration behavior: every request — in any input language (any `conversation_language`), with or without a `/moai` subcommand — flows through one ordered pipeline. It begins with intent analysis: classify meaning, language-independent, never gated on English keyword matching. The structured Intent Router (P1 subcommand fast-path + P3 semantic classification) lives in the `/moai` skill (`.claude/skills/moai/SKILL.md`); this section defines the pipeline the router plugs into.
+**Analyze-First** is the default main-session orchestration behavior: every request — in any input language, with or without a `/moai` subcommand — flows through one ordered pipeline, beginning with intent analysis (classify meaning, language-independent, never keyword-gated). The structured Intent Router (P1 subcommand fast-path + P3 semantic classification) lives in the `/moai` skill (`.claude/skills/moai/SKILL.md`).
 
 Five ordered stages:
 
-- ① **Intent analysis** — classify the request's intent regardless of input language (any `conversation_language`; language-independent, not keyword-gated). Technology signals are context for stage ③ only, never the routing gate.
-- ② **Context-sufficiency check** — when context is insufficient, run the Rule 5 Context-First Discovery `AskUserQuestion` rounds (§7) before proceeding.
-- ③ **Execution-plan composition** — compose the skill / agent / dynamic-workflow chain and select the Phase 0.95 orchestration mode (unchanged; see `.claude/rules/moai/workflow/orchestration-mode-selection.md`). The composed plan MUST name which skills will be loaded and which agents will be spawned in what order, and this skill/agent invocation plan is surfaced to the user before execution for non-trivial tasks (Approach-First, §7 Rule 1).
-- ④ **Approval gates** — unchanged, including the **Implementation Kickoff Approval** human gate at the plan→run boundary (§8); the gate also offers an autonomous-vs-semi-autonomous progression-mode axis (a post-approval progression choice, never a gate bypass).
-- ⑤ **Execute → verify → iterate** — run the plan, verify against acceptance criteria, iterate; when a goal is armed (`/moai goal`), the goal evaluator is the termination judge.
+- ① **Intent analysis** — classify intent language-independently (not keyword-gated; tech signals are context for ③ only).
+- ② **Context-sufficiency check** — if insufficient, run the Rule 5 Context-First Discovery `AskUserQuestion` rounds (§7).
+- ③ **Execution-plan composition** — compose the skill/agent/dynamic-workflow chain + select the Phase 0.95 mode (`orchestration-mode-selection.md`); the plan names skills/agents/order and is surfaced before execution (Approach-First, §7 Rule 1).
+- ④ **Approval gates** — incl. the **Implementation Kickoff Approval** human gate at plan→run (§8); offers an autonomous-vs-semi-autonomous progression axis (post-approval, never a bypass).
+- ⑤ **Execute → verify → iterate** — verify vs acceptance criteria; an armed `/moai goal` is the termination judge.
 
-Report: consolidate agent results and format the response in the user's `conversation_language`.
+Report: consolidate agent results in the user's `conversation_language`.
 
 ---
 
@@ -48,103 +36,39 @@ Report: consolidate agent results and format the response in the user's `convers
 
 ### Unified Skill: /moai
 
-Single entry point for all MoAI development workflows.
-
-Subcommands: plan, run, sync, project, fix, loop, mx, feedback, review, clean, codemaps, gate, e2e, harness, goal
-Default (natural language): Routes to autonomous workflow (plan -> run -> sync pipeline)
-
-`/moai loop` and `/moai fix` are goal-preset siblings built on the goal engine: `/moai loop` is the goal preset for a bounded project-wide improvement sweep (scan a finite issue queue, then delegate iterate-until-done to the goal engine), and `/moai fix` is the one-shot turn-based preset.
+Single entry point for all MoAI development workflows. Subcommands: plan, run, sync, project, fix, loop, mx, feedback, review, clean, codemaps, gate, e2e, harness, goal. Default (natural language): autonomous workflow (plan -> run -> sync pipeline). `/moai loop` (bounded project-wide improvement sweep → goal engine) and `/moai fix` (one-shot turn-based) are goal-preset siblings built on the goal engine.
 
 ---
 
 ## 4. Agent Catalog
 
-The MoAI agent catalog consists of exactly **12 retained agents** (11 MoAI-custom + 1 Anthropic built-in `Explore`). The catalog is aligned with Anthropic's published best practices: "Subagents cannot spawn other subagents" (claude.com/docs/en/sub-agents — historical default; see the Watch note below for the v2.1.219 nesting update), "Start with 3-5 teammates for most workflows" (claude.com/docs/en/agent-teams), and "Define a custom subagent when you keep spawning the same kind of worker" (claude.com/docs/en/best-practices).
+The MoAI agent catalog consists of exactly **12 retained agents** (11 MoAI-custom + 1 Anthropic built-in `Explore`), aligned with Anthropic's best practices (sub-agents, agent-teams, best-practices docs).
 
-> **Watch (Claude Code 2.1.219)**: Subagent nesting is **enabled by default** on v2.1.219+ — the changelog states subagents can spawn nested subagents up to depth 3 by default; set `CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH=1` to disable nesting. The former "defaults to off" claim applied only to v2.1.217–2.1.218. Caveat: the depth-3 ceiling and env-propagation behavior are changelog-sourced, not observed — the empirical evidence covers a single depth-1 nested spawn with the depth env unset. For an `Agent`-carrying subagent, **omitting the `Agent` tool from its `tools` list is the sole remaining flat-hierarchy guarantee**; every retained MoAI agent except `manager-lead` (including `sync-auditor`, whose former read-only nesting pilot is retired) omits `Agent`, so the flat hierarchy holds by tool omission. `manager-lead` is the sole Agent-carrier among retained agents — the flat hierarchy is opened exactly one layer deep there, and the depth-2 seal (leaf workers `manager-lead` spawns omit `Agent` from their own `tools:` lists, enforced by the `manager_lead_depth_test.go` CI guard per the hierarchical-team SPEC depth-2 requirement) is the active flat-hierarchy guarantee for that single carve-out. The `Agent(agent_type)` parenthesized allowlist is a main-thread (`claude --agent`) feature — inside a subagent definition it is ignored. Separately, the Task/Agent spawn-time `mode` parameter is deprecated and **ignored** since v2.1.213 (changelog/doc-sourced, not runtime-observed): subagents inherit the parent session's permission mode, and a parent in `bypassPermissions`/`acceptEdits` takes precedence and cannot be overridden — a spawned child's read-only scoping therefore rests on **tool restriction** (the inherently read-only `Explore`, or a `tools:` list omitting Write/Edit/NotebookEdit), never on the deprecated spawn-time permission-mode parameter. See `code.claude.com/docs/en/sub-agents` § Spawn nested subagents.
->
-> **Supersession note (amended for SPEC-HIERARCHICAL-TEAM-001)**: the paragraph above partially supersedes the nesting encoding of SPEC-SUBAGENT-NESTING-DOCTRINE-001 (its "shipped default stays flat via the runtime env-default-off" premise is stale as of v2.1.219); that SPEC's own artifacts are not rewritten. The active flat-hierarchy guarantee for the single `manager-lead` Agent-carrier carve-out is the depth-2 seal established by SPEC-HIERARCHICAL-TEAM-001 REQ-LEAD-001 / REQ-DEPTH-001 (leaf workers omit `Agent`; CI guard at `internal/template/manager_lead_depth_test.go`).
+> **Watch (Claude Code 2.1.219)**: subagent nesting is enabled by default (depth 3; `CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH=1` disables). MoAI's flat hierarchy holds by configuration — every retained agent except `manager-lead` omits the `Agent` tool. `manager-lead` is the sole Agent-carrier, opened one layer deep and depth-2 sealed (its leaf workers omit `Agent`, enforced by `manager_lead_depth_test.go`). The spawn-time `mode` parameter is deprecated/ignored since v2.1.213 (subagents inherit the parent's permission mode). Full nesting note + nesting-doctrine supersession: `.claude/rules/moai/development/agent-authoring.md` + `agent-patterns.md`.
 
 ### Selection Decision Tree
 
-1. Read-only codebase exploration? Use the `Explore` subagent (Anthropic built-in)
-2. External documentation or API research? Use WebSearch, WebFetch, Context7 MCP tools
-3. SPEC plan-phase authoring? Use the `manager-spec` subagent
-4. Run-phase implementation (DDD/TDD/autofix)? Use the `manager-develop` subagent with the appropriate `cycle_type`
-5. Sync-phase documentation? Use the `manager-docs` subagent
-6. PR creation per Tier-based routing (Tier L OR explicit `--pr`)? Use the `manager-git` subagent
-7. Plan-phase independent audit (bias prevention)? Use the `plan-auditor` subagent
-8. Sync-phase quality 4-dimension scoring? Use the `sync-auditor` subagent
-9. Dynamic specialist generation (project-specific harness)? Use the `builder-harness` subagent
-10. On-demand high-reasoning consultation / second opinion (E1-E4 escalation)? Use the `super-advisor` subagent
-11. Design-phase collaboration (Claude Design bidirectional sync, UI-surfaced SPECs)? Use the `manager-design` subagent
-12. E2E test execution across web/mobile/desktop (journey scripting, CLI-first suite runs)? Use the `e2e-tester` subagent
-13. Multi-milestone Tier L coordination (≥3 milestones AND ≥10 files AND cross-domain fan-out)? Use the `manager-lead` subagent (the sole Agent-carrier among retained agents; depth-2 sealed per the hierarchical-team SPEC depth-2 requirement)
+1. Read-only exploration / external doc research → `Explore` / WebSearch+Context7
+2. SPEC plan / run / sync → `manager-spec` / `manager-develop` / `manager-docs`
+3. PR creation (Tier L OR `--pr`) → `manager-git`
+4. Independent audit: plan-phase / sync-quality → `plan-auditor` / `sync-auditor`
+5. Harness specialist → `builder-harness`; high-reasoning consult (E1-E4) → `super-advisor`
+6. Design collaboration → `manager-design`; E2E tests → `e2e-tester`
+7. Multi-milestone Tier L (≥3 milestones AND ≥10 files) → `manager-lead` (sole Agent-carrier, depth-2 sealed)
 
-### Retained Agents (12 total)
-
-| Agent | Class | Phase scope | Reference |
-|-------|-------|-------------|-----------|
-| `manager-spec` | core/manager | Plan-phase artifact authoring (spec/plan/acceptance/research/design) | `.claude/agents/moai/manager-spec.md` |
-| `manager-develop` | core/manager | Run-phase implementation (cycle_type ∈ {ddd, tdd, autofix}) | `.claude/agents/moai/manager-develop.md` |
-| `manager-docs` | core/manager | Sync-phase documentation (CHANGELOG, README, frontmatter transitions) | `.claude/agents/moai/manager-docs.md` |
-| `manager-git` | core/manager | PR creation per Tier-based routing + Late-Branch closure | `.claude/agents/moai/manager-git.md` |
-| `plan-auditor` | meta/evaluator | Independent plan-phase audit, bias prevention, GEARS compliance | `.claude/agents/moai/plan-auditor.md` |
-| `sync-auditor` | meta/evaluator | Independent skeptical quality assessment, 4-dimension scoring | `.claude/agents/moai/sync-auditor.md` |
-| `builder-harness` | builder | Dynamic project-specific harness specialist generation | `.claude/agents/moai/builder-harness.md` |
-| `super-advisor` | meta/advisor | On-demand high-reasoning consultation (non-binding prescriptions, E1-E4 escalation) | `.claude/agents/moai/super-advisor.md` |
-| `manager-design` | core/manager | Design-phase collaboration (Claude Design bidirectional sync, D1-D5 pipeline) | `.claude/agents/moai/manager-design.md` |
-| `e2e-tester` | core/specialist | E2E test execution (web/mobile/desktop journey scripting, CLI-first runs, artifact management) | `.claude/agents/moai/e2e-tester.md` |
-| `manager-lead` | core/manager | Hierarchical-team Tier L coordination (worktree-isolated leaf-worker fan-out + per-milestone Context-Folding + peer cross-validation + schema-driven fan-out reduce; sole Agent-carrier, depth-2 sealed) | `.claude/agents/moai/manager-lead.md` |
-| `Explore` | Anthropic built-in | Read-only codebase exploration (no MoAI file — invoked directly) | claude.com/docs/en/sub-agents |
-
-### Archived Agents (legacy references rejected at spawn)
-
-The following agent names are **archived** and MUST NOT be spawned: `manager-strategy`, `manager-quality`, `manager-brain`, `manager-project`, `claude-code-guide`, `researcher`, `expert-backend`, `expert-frontend`, `expert-security`, `expert-devops`, `expert-performance`, `expert-refactoring`.
-
-When a paste-ready resume message or `Agent()` invocation references one of these archived agents, the orchestrator MUST reject the spawn and consult the migration table at `.claude/rules/moai/workflow/archived-agent-rejection.md`. The retained-agent replacement pattern (per-spawn `Agent(general-purpose)` with domain-specific instructions, or routing to one of the 12 retained agents above) is documented there. For migration of references to the 12 archived agents, see `.claude/rules/moai/workflow/archived-agent-rejection.md`.
-
-Note on `claude-code-guide`: the archived entry refers to the former MoAI-custom agent file of that name. It is distinct from the official Claude Code built-in helper agent that is also named `claude-code-guide` and ships with the runtime — that built-in is a separate, valid agent and invoking it does NOT trigger archived-agent rejection. The rejection binds only the MoAI-custom file.
-
-### Dynamic Team Generation (RETIRED)
-
-The MoAI Agent Teams static-orchestration layer is RETIRED. Mode 3 (`agent-team`) is a Phase 0.95 tombstone; a forced `--team` / `--mode team` emits `MODE_TEAM_UNAVAILABLE` and falls back to sub-agent mode (Mode 5). The former `workflow.yaml` team role-profile config and env-var gate were removed. The native Claude Code teammate runtime (`moai cg` GLM panes, `worktree --team`, `~/.claude/teams/`) is unaffected — see `.claude/rules/moai/core/glm-web-tooling.md` § CG Mode.
-
-For agent creation guidelines, use the `builder-harness` subagent or see `.claude/rules/moai/development/agent-authoring.md`.
-
-### Delegation Map
-
-The orchestrator consults `.moai/config/sections/delegation.yaml` — the SSOT of default skill/agent designations per subcommand plus per-domain skill sets. When composing an execution plan (§2 Analyze-First), it reads the map to select which agents to spawn and injects `At start, invoke Skill("<name>") for <reason>` lines per `.claude/rules/moai/workflow/skill-routing.md`. The map is continuously improved via recursive self-analysis: routing-ledger observation → harness learning Tier-ladder proposals → user-approved (`AskUserQuestion`) updates to `delegation.yaml`. The map is a default, not a gate — the orchestrator may deviate when a mission's context warrants.
+**Retained agents (12)**: `manager-spec`, `manager-develop`, `manager-docs`, `manager-git`, `plan-auditor`, `sync-auditor`, `builder-harness`, `super-advisor`, `manager-design`, `e2e-tester`, `manager-lead` (11 MoAI-custom) + Anthropic built-in `Explore`. Class / phase scope / reference per agent: `.claude/agents/moai/*.md` + `.moai/config/sections/delegation.yaml`. Archived names (`manager-strategy`, `manager-quality`, `expert-*`, etc.) MUST NOT be spawned — reject and consult `.claude/rules/moai/workflow/archived-agent-rejection.md` §C (the built-in `claude-code-guide` is distinct, NOT rejected). Agent Teams static orchestration is RETIRED (Mode 3 tombstone; `--team` → `MODE_TEAM_UNAVAILABLE` → sub-agent fallback; native `moai cg`/`worktree --team` unaffected). Agent authoring: `.claude/rules/moai/development/agent-authoring.md`.
 
 ---
 
 ## 5. SPEC-Based Workflow
 
-MoAI uses DDD and TDD as its development methodologies, selected via quality.yaml.
-
-### MoAI Command Flow
-
-- /moai plan "description" → manager-spec subagent
-- /moai run SPEC-XXX → manager-develop subagent (cycle_type per quality.yaml development_mode)
-- /moai sync SPEC-XXX → manager-docs subagent
-
-### Agent Chain for SPEC Execution
-
-Phases: plan (manager-spec) → plan-audit (plan-auditor) → run (manager-develop, cycle_type ∈ {ddd, tdd, autofix}; domain-specific work spawns `Agent(general-purpose)` with domain whitelist per `archived-agent-rejection.md` §C) → sync (manager-docs) → sync-audit (sync-auditor) → [optional Tier L OR `--pr`] PR (manager-git). For detailed phase specs, team-based parallel execution, and Late-Branch closure, see `.claude/rules/moai/workflow/spec-workflow.md`.
-
-### MX Tag Integration
-
-All phases include @MX code annotation management (plan: identify targets; run: create/update; sync: validate + add missing). Tag types: `@MX:NOTE` (context/intent), `@MX:WARN` (danger zone, requires @MX:REASON), `@MX:ANCHOR` (invariant contract, high fan_in), `@MX:TODO` (incomplete, resolved in GREEN). Details: `.claude/rules/moai/workflow/mx-tag-protocol.md`.
+MoAI uses DDD and TDD as its development methodologies, selected via quality.yaml. **Command flow**: `/moai plan "desc"` → manager-spec · `/moai run SPEC-XXX` → manager-develop · `/moai sync SPEC-XXX` → manager-docs. **Agent chain**: plan (manager-spec) → plan-audit (plan-auditor) → run (manager-develop, cycle_type ∈ {ddd, tdd, autofix}) → sync (manager-docs) → sync-audit (sync-auditor) → [optional Tier L OR `--pr`] PR (manager-git). Detailed phase specs + Late-Branch closure: `.claude/rules/moai/workflow/spec-workflow.md`. All phases manage @MX code annotations (`@MX:NOTE`/`@MX:WARN`/`@MX:ANCHOR`/`@MX:TODO`); details: `.claude/rules/moai/workflow/mx-tag-protocol.md`.
 
 ---
 
 ## 6. Quality Gates
 
-For TRUST 5 framework details, see .claude/rules/moai/core/moai-constitution.md
-
-MoAI-ADK uses a 3-level harness system for adaptive quality depth: **minimal** (fast validation), **standard** (default checks), **thorough** (full sync-auditor + TRUST 5). Harness level is auto-determined by the Complexity Estimator based on SPEC scope; sync-auditor provides independent skeptical assessment with 4-dimension scoring (Functionality/Security/Craft/Consistency).
-
-LSP quality gates apply phase-specific thresholds — plan: capture LSP baseline; run: zero errors/type-errors/lint-errors required; sync: zero errors, max 10 warnings, clean LSP. For configuration and threshold details, see `.claude/rules/moai/workflow/spec-workflow.md` (harness/LSP routing) + `.moai/config/sections/harness.yaml`, `.moai/config/evaluator-profiles/`, `.moai/config/sections/quality.yaml`; the LSP threshold values themselves live in `.moai/config/sections/lsp.yaml` (the LSP-gate SSOT).
+For TRUST 5 framework details, see `.claude/rules/moai/core/moai-constitution.md`. MoAI-ADK uses a 3-level harness system for adaptive quality depth: **minimal** (fast validation), **standard** (default checks), **thorough** (full sync-auditor + TRUST 5); harness level is auto-determined by the Complexity Estimator based on SPEC scope, and sync-auditor provides independent skeptical assessment with 4-dimension scoring (Functionality/Security/Craft/Consistency). LSP quality gates apply phase-specific thresholds — plan: capture LSP baseline; run: zero errors/type-errors/lint-errors; sync: zero errors, max 10 warnings, clean LSP. Configuration: `spec-workflow.md` (harness/LSP routing) + `.moai/config/sections/{harness,quality,lsp}.yaml` + `.moai/config/evaluator-profiles/` (LSP threshold values live in `lsp.yaml` — the LSP-gate SSOT).
 
 ---
 
@@ -159,21 +83,9 @@ The five development safeguards (HARD Rules) ensure code quality and prevent reg
 - **Rule 2 — Multi-File Change Decomposition**: When modifying 3+ files, split into logical units (TodoList), execute file-by-file, analyze dependencies before parallel execution, report progress per unit.
 - **Rule 3 — Post-Implementation Review**: After coding, provide potential-issue list (edge cases, error/concurrency scenarios), suggested test cases, known limitations/assumptions, additional-validation recommendations.
 - **Rule 4 — Reproduction-First Bug Fixing**: Write a failing reproduction test first; confirm it fails; challenge the diagnosed root cause once ("How do we know this is the cause, not a symptom?"); fix minimally; verify the test passes.
-- **Rule 5 — Context-First Discovery**: When intent is unclear, conduct a Socratic interview before execution. Trigger conditions, the discovery process (ToolSearch preload → AskUserQuestion rounds → 100% clarity → explicit confirmation), exceptions, and constraints are the SSOT at `.claude/rules/moai/core/askuser-protocol.md` § Ambiguity Triggers and Exceptions + § Socratic Interview Structure.
-  - When the domain is unfamiliar and unknown-unknowns are suspected, run an OPTIONAL Blind Spot Pass before plan-phase entry (SSOT: `.claude/rules/moai/core/askuser-protocol.md` § Blind Spot Pass).
-  - Classify ambiguity with the Known-Knowns / Known-Unknowns / Unknown-Knowns / Unknown-Unknowns 4-quadrant lens; suspected Unknown-Unknowns route to a Blind Spot Pass (same SSOT § Ambiguity Triggers and Exceptions).
+- **Rule 5 — Context-First Discovery**: When intent is unclear, conduct a Socratic interview before execution. Trigger conditions, discovery process, exceptions, and the 4-quadrant Unknowns lens are the SSOT at `.claude/rules/moai/core/askuser-protocol.md` § Ambiguity Triggers and Exceptions + § Socratic Interview Structure (+ optional Blind Spot Pass for suspected unknown-unknowns).
 
-Rule sequencing: Rule 5 (Discovery — establishes WHAT) executes BEFORE Rule 1 (Approach-First — explains HOW).
-
-### Language-Specific Guidelines
-
-The quality gate auto-detects the project language and runs the appropriate toolchain:
-- **Go**: `go vet` → `golangci-lint` → `go test`
-- **Node.js**: `eslint` → `npm test`
-- **Python**: `ruff` → `pytest`
-- **Rust**: `cargo clippy` → `cargo test`
-
-The four toolchains above are illustrative examples, not an exhaustive or privileged list — all 16 supported languages (go, python, typescript, javascript, rust, java, kotlin, csharp, ruby, php, elixir, cpp, scala, r, flutter, swift) are detected equally via project markers, each running its own standard lint/format/test toolchain. Tools that are not installed are skipped gracefully. Projects with no recognized language marker pass the gate silently.
+Rule sequencing: Rule 5 (Discovery — establishes WHAT) executes BEFORE Rule 1 (Approach-First — explains HOW). The quality gate auto-detects the project language and runs its standard lint/format/test toolchain (Go: `go vet`→`golangci-lint`→`go test`; illustrative — all 16 supported languages detected equally via project markers; missing tools skipped gracefully).
 
 ---
 
@@ -181,11 +93,11 @@ The four toolchains above are illustrative examples, not an exhaustive or privil
 
 [ZONE:Frozen] [HARD] Every question directed at the user MUST be asked via AskUserQuestion. Free-form prose questions in response text are prohibited.
 
-[ZONE:Frozen] [HARD] `AskUserQuestion`, `TaskCreate`, `TaskUpdate`, `TaskList`, `TaskGet` are **deferred tools** — schemas NOT loaded at session start. Call `ToolSearch(query: "select:AskUserQuestion,TaskCreate,TaskUpdate,TaskList,TaskGet", max_results: 5)` before first use.
+[ZONE:Frozen] [HARD] `AskUserQuestion`, `TaskCreate`, `TaskUpdate`, `TaskList`, `TaskGet` are **deferred tools** — schemas NOT loaded at session start; call `ToolSearch(query: "select:AskUserQuestion,TaskCreate,TaskUpdate,TaskList,TaskGet", max_results: 5)` before first use.
 
-[ZONE:Evolvable] [HARD] Native-UTF-8 tool-call payloads: every tool-call payload carrying `conversation_language` text (AskUserQuestion questions/options, Bash commands, Write/Edit content) MUST be written as native UTF-8. Hand-authored `\uXXXX` escape sequences are PROHIBITED — they corrupt the JSON into an `InputValidationError` / `Invalid tool parameters`, and the failure is self-reinforcing (one `\uXXXX` run in context seeds the next). SSOT: `.claude/rules/moai/core/askuser-protocol.md` § Non-ASCII Tool-Call Encoding (mechanism + recovery + pre-emit self-check).
+[ZONE:Evolvable] [HARD] Native-UTF-8 tool-call payloads: every tool-call payload carrying `conversation_language` text (AskUserQuestion questions/options, Bash commands, Write/Edit content) MUST be native UTF-8 — hand-authored `\uXXXX` escapes are PROHIBITED (they corrupt the JSON into `InputValidationError`, self-reinforcing). SSOT: `askuser-protocol.md` § Non-ASCII Tool-Call Encoding.
 
-The AskUserQuestion channel rules (Socratic interview limits, recommended-option label, anti-patterns, pre-response self-check) are the SSOT at `.claude/rules/moai/core/askuser-protocol.md`. The orchestrator–subagent interaction boundary (subagents return blocker reports instead of prompting; MoAI bridges AskUserQuestion + TaskList in team mode) is at `.claude/rules/moai/core/agent-common-protocol.md` § User Interaction Boundary.
+The AskUserQuestion channel rules (Socratic interview limits, recommended-option label, anti-patterns, pre-response self-check) are the SSOT at `.claude/rules/moai/core/askuser-protocol.md`. The orchestrator–subagent boundary (subagents return blocker reports instead of prompting): `.claude/rules/moai/core/agent-common-protocol.md` § User Interaction Boundary.
 
 ---
 
@@ -196,26 +108,13 @@ User and language configuration:
 @.moai/config/sections/user.yaml
 @.moai/config/sections/language.yaml
 
-MoAI-ADK uses Claude Code's official rules system at `.claude/rules/moai/` (core / workflow / development / language / design rule categories). Design System Configuration (absorbed from agency) lives in `.moai/config/sections/design.yaml`, `.moai/project/brand/`, `.moai/config/sections/constitution.yaml`, `.moai/config/sections/harness.yaml`, `.moai/config/evaluator-profiles/`. Legacy .agency/ directories are archived via `moai migrate agency`.
-
-Language rules:
-- User Responses: Always in user's conversation_language
-- Internal Agent Communication: English
-- Code Comments: Per code_comments setting (default: English)
-- Commands, Agents, Skills Instructions: Always English
-- Memory files (MEMORY.md + topic files): Always English — see `.claude/rules/moai/workflow/moai-memory.md` § Rules
+MoAI-ADK uses Claude Code's official rules system at `.claude/rules/moai/` (core / workflow / development / language / design categories). Design System Configuration lives in `.moai/config/sections/{design,constitution,harness}.yaml`, `.moai/project/brand/`, `.moai/config/evaluator-profiles/`; legacy `.agency/` archived via `moai migrate agency`. Language rules: user responses in `conversation_language`; internal agent comms + Commands/Agents/Skills instructions always English; code comments per `code_comments` (default English); memory files always English (`moai-memory.md` § Rules).
 
 ---
 
 ## 10. Web Search Protocol
 
-For anti-hallucination policy, see .claude/rules/moai/core/moai-constitution.md
-
-Execution: (1) Initial Search via WebSearch with targeted queries → (2) URL Validation via WebFetch to verify each URL → (3) Response Construction including only verified URLs with sources. Never generate URLs not found in WebSearch results, never present uncertain information as fact, never omit the "Sources:" section when WebSearch was used. The full anti-hallucination and URL-verification policy is the SSOT at `.claude/rules/moai/core/moai-constitution.md`.
-
-> **GLM-backend routing**: under `moai glm` or the GLM panes of `moai cg`, WebSearch and WebFetch route to the z.ai MCP tools instead of the built-in tools — see `.claude/rules/moai/core/glm-web-tooling.md` for the HARD routing table.
-
-For research-heavy questions, the bundled `/deep-research <question>` workflow fans out multiple web searches, cross-checks sources, votes on contested claims, and returns a cited report (manual invocation only since Claude Code v2.1.218 — Claude no longer launches it on its own; requires WebSearch; spends meaningfully more tokens; the AskUserQuestion boundary holds — collect the question before launch). See `.claude/rules/moai/workflow/dynamic-workflows.md`.
+For anti-hallucination policy, see `.claude/rules/moai/core/moai-constitution.md`. Execution: (1) WebSearch with targeted queries → (2) URL validation via WebFetch → (3) response including only verified URLs with sources. Never generate URLs not found in WebSearch results, never present uncertain info as fact, never omit "Sources:" when WebSearch was used. **GLM-backend routing**: under `moai glm` / GLM panes of `moai cg`, WebSearch+WebFetch route to the z.ai MCP tools (`.claude/rules/moai/core/glm-web-tooling.md`). The bundled `/deep-research <question>` workflow fans out searches, cross-checks, votes, returns a cited report (manual only since v2.1.218; requires WebSearch; the AskUserQuestion boundary holds): `.claude/rules/moai/workflow/dynamic-workflows.md`.
 
 ---
 
@@ -223,105 +122,50 @@ For research-heavy questions, the bundled `/deep-research <question>` workflow f
 
 > Canonical rule: detailed recovery flows live in `.claude/rules/moai/core/agent-common-protocol.md` § Error Recovery Pattern and individual agent definitions.
 
-### Error Recovery
-
-- **Agent / Integration-DevOps errors**: `ARCHIVED_AGENT_REJECTED` on archived-agent reference — consult `archived-agent-rejection.md` §C; spawn `Agent(general-purpose)` (diagnostics/infra) or `Agent(Explore)` (read-only)
-- **Token limit / Permission / MoAI-ADK errors**: /clear + paste-ready resume per `session-handoff.md`; permission → review settings.json; MoAI-ADK → /moai feedback
-
-Resume interrupted agent work using agentId (e.g., "Resume agent abc123 and continue the analysis").
+**Error Recovery**: `ARCHIVED_AGENT_REJECTED` on archived-agent reference → consult `archived-agent-rejection.md` §C; spawn `Agent(general-purpose)` (diagnostics/infra) or `Agent(Explore)` (read-only). Token-limit / Permission / MoAI-ADK errors → /clear + paste-ready resume per `session-handoff.md`; permission → review settings.json; MoAI-ADK → /moai feedback. Resume interrupted agent work using agentId (e.g., "Resume agent abc123 and continue the analysis").
 
 ---
 
 ## 12. MCP Servers & Deep Analysis Modes
 
-MoAI-ADK integrates MCP servers and deep-analysis modes:
-
-- **UltraThink** (`ultrathink` keyword) / **Adaptive Thinking** (Opus 4.7+, including Opus 5 and 4.8): the `ultrathink` keyword sets `effort: xhigh` and triggers Adaptive Thinking (dynamically allocated reasoning tokens, no fixed budget_tokens; controlled by effort level high/xhigh/max, not budget_tokens). See Skill("moai-foundation-thinking").
-- **Context7**: Up-to-date library documentation lookup (resolve-library-id, get-library-docs).
-- **claude-in-chrome**: Browser automation for web-based tasks.
-- **Dynamic Workflows / ultracode**: `/effort ultracode` combines xhigh effort with automatic workflow orchestration (Claude Code v2.1.154+). See .claude/rules/moai/workflow/dynamic-workflows.md.
-
-For MCP configuration and usage patterns, see .claude/rules/moai/core/settings-management.md.
+- **UltraThink** (`ultrathink` keyword) / **Adaptive Thinking** (Opus 4.7+, incl. Opus 5/4.8): sets `effort: xhigh` + Adaptive Thinking (dynamically allocated reasoning tokens, no fixed budget_tokens). See Skill("moai-foundation-thinking").
+- **Context7**: up-to-date library docs (resolve-library-id, get-library-docs). **claude-in-chrome**: browser automation.
+- **Dynamic Workflows / ultracode**: `/effort ultracode` combines xhigh effort with workflow orchestration (v2.1.154+). MCP config: `.claude/rules/moai/core/settings-management.md`. See `.claude/rules/moai/workflow/dynamic-workflows.md`.
 
 ---
 
 ## 13. Progressive Disclosure System
 
-> Canonical rule: see `.claude/rules/moai/development/skill-authoring.md` § Progressive Disclosure for the 3-level token budget spec (Level 1: metadata ~100 tokens always listed; Level 2: body ~5K tokens on invocation; Level 3: bundled on-demand; 67% initial-token reduction), skill-listing / post-compaction budget (`skillListingBudgetFraction`), and trigger configuration schema.
+> Canonical rule: see `.claude/rules/moai/development/skill-authoring.md` § Progressive Disclosure for the 3-level token budget spec (L1 metadata ~100 tokens always listed; L2 body ~5K on invocation; L3 bundled on-demand; 67% initial-token reduction), skill-listing / post-compaction budget (`skillListingBudgetFraction`), and trigger configuration schema.
 
 ---
 
 ## 14. Parallel Execution Safeguards
 
-For core principles, see `.claude/rules/moai/core/moai-constitution.md`. Operational safeguards: file-write-conflict prevention (dependency graphs before parallel execution), agent tool requirements (Read/Write/Edit/Grep/Glob/Bash/TaskCreate/Update/List/Get), loop prevention (max 3 retries), platform compatibility (prefer Edit over sed/awk), team file ownership (per-teammate patterns).
-- **Background Agent Execution (background-default aligned)**: [ZONE:Evolvable] [HARD] As of Claude Code v2.1.198, subagents run in the background by default; the runtime chooses foreground only when it needs the result before continuing, and a background subagent still surfaces every permission prompt in the main session (naming the asking subagent since v2.1.186; Esc denies just that one call). MoAI aligns with this runtime default rather than forcing write-capable agents to the foreground, and does not set the `background:` frontmatter field. The retained safeguard is concurrency, not backgrounding: MoAI does not run two write-capable agents concurrently, and orchestrator work concurrent with a write-capable agent is read-only.
-- **Subagent concurrency caps (v2.1.217; per-session cap removed v2.1.224)**: [ZONE:Evolvable] The runtime caps that bound subagent fan-out are distinct from the nesting *depth* cap (`CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH`, §4 Watch note): `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS` (default 20; ultracode sessions exempt) bounds how many subagents run at once. The per-session total cap (`CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION`, default 200) was removed in v2.1.224 — long-running sessions no longer refuse new agents; the concurrency and depth limits still apply. MoAI's own 3-5 concurrent `Agent()` ceiling (Mode 4) sits well under the runtime cap.
-
-Per the worktree-opt-in policy, L2/L3 worktree usage is user opt-in; L1 `Agent(isolation: "worktree")` is Claude Code runtime autonomous (MoAI does not mandate isolation). For the decision tree and per-role guidance, see `.claude/rules/moai/workflow/worktree-integration.md` § Terminology Glossary.
+For core principles, see `.claude/rules/moai/core/moai-constitution.md`. Operational safeguards: file-write-conflict prevention (dependency graphs before parallel execution), agent tool requirements (Read/Write/Edit/Grep/Glob/Bash/TaskCreate/Update/List/Get), loop prevention (max 3 retries), platform compatibility (prefer Edit over sed/awk), team file ownership (per-teammate patterns). **Background + concurrency (v2.1.198/217/224)**: [ZONE:Evolvable] [HARD] subagents run in the background by default (the runtime chooses foreground only when it needs the result; every permission prompt still surfaces in the main session); MoAI does not set `background:` — the retained safeguard is concurrency, not backgrounding (never run two write-capable agents concurrently; concurrent orchestrator work stays read-only). Runtime fan-out caps (distinct from nesting depth, §4): `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS` (default 20) per-turn; per-session total cap removed v2.1.224; MoAI's own ceiling is 3-5 (Mode 4). Detail: `agent-common-protocol.md` § Background Agent Execution. L2/L3 worktree usage is user opt-in; L1 `Agent(isolation: "worktree")` is runtime autonomous: `worktree-integration.md` § Terminology Glossary.
 
 ---
 
 ## 15. Agent Teams (RETIRED) + CG Mode
 
-**Agent Teams RETIRED** — the static-orchestration layer is gone. Mode 3 (`agent-team`) is a Phase 0.95 tombstone; forced `--team` / `--mode team` emits `MODE_TEAM_UNAVAILABLE` and falls back to sub-agent mode. Practical multi-agent surface: Mode 4 (parallel fan-out) + Mode 5 (sequential sub-agent). See `spec-workflow.md` § Agent Teams Variant — RETIRED. Native teammate runtime (`moai cg`, `worktree --team`) unaffected — CG Mode below is preserved.
-
-### CG Mode (Claude + GLM Cost Optimization)
-
-MoAI-ADK supports CG Mode for 60-70% cost reduction on implementation-heavy tasks via tmux Agent Teams:
-
-```
-┌─────────────────────────────────────────────────────────────┐
-│  LEADER (Claude, current tmux pane)                         │
-│  - Orchestrates workflow (no GLM env)                        │
-│  - Delegates tasks via Agent Teams                           │
-│  - Reviews results                                           │
-└──────────────────────┬──────────────────────────────────────┘
-                       │ Agent Teams (tmux panes)
-                       ▼
-┌─────────────────────────────────────────────────────────────┐
-│  TEAMMATES (GLM, new tmux panes)                            │
-│  - Inherit GLM env from tmux session                        │
-│  - Execute implementation tasks                              │
-│  - Full access to codebase                                   │
-└─────────────────────────────────────────────────────────────┘
-```
-
-**Activation**: `moai cg` (requires tmux). **Use for**: implementation-heavy SPECs (run phase), code generation, test writing, doc generation. **Avoid**: planning/architecture (needs Opus reasoning), security reviews, complex debugging.
-
-> Dynamic Workflows (a third orchestration primitive — JS scripts orchestrating dozens-to-hundreds of subagents, intermediate results in script variables) and `/effort ultracode` are documented in `.claude/rules/moai/workflow/dynamic-workflows.md` and `.claude/rules/moai/workflow/goal-directive.md` (requires Claude Code v2.1.154+). Workflow subagents cannot prompt the user.
+**Agent Teams RETIRED** — Mode 3 (`agent-team`) is a tombstone; `--team` / `--mode team` → `MODE_TEAM_UNAVAILABLE` → sub-agent fallback. Practical multi-agent surface: Mode 4 (parallel fan-out) + Mode 5 (sequential). See `spec-workflow.md` § Agent Teams Variant — RETIRED. **CG Mode** (`moai cg`, requires tmux): Claude leader orchestrates, GLM teammate panes execute implementation tasks for 60-70% cost reduction. **Use for**: implementation-heavy SPECs (run phase), code/test/doc generation. **Avoid**: planning/architecture (needs Opus), security, complex debugging. Routing: `glm-web-tooling.md` § CG Mode. Dynamic Workflows + `/effort ultracode`: `dynamic-workflows.md` + `goal-directive.md` (workflow subagents cannot prompt the user).
 
 ---
 
 ## 16. Context Search Protocol
 
-> Canonical rule: see `.claude/rules/moai/workflow/context-window-management.md` for context window thresholds (1M = 50%, 200K = 90%) and `.claude/rules/moai/workflow/session-handoff.md` for paste-ready resume message format.
+> Canonical rule: see `.claude/rules/moai/workflow/context-window-management.md` for thresholds (1M = 50%, 200K = 90%) and `session-handoff.md` for the paste-ready resume format.
 
-MoAI searches previous Claude Code sessions when context is needed to continue work on existing tasks or discussions. **Search when**: user references past work without sufficient context, mentions a SPEC-ID not loaded in current context, asks to resume/continue previous work, or explicitly requests to find previous discussions. **Skip when**: relevant SPEC/code is already in current session, user references content present in conversation, or duplication would add no value.
-
-**Process**: (1) check current session first (skip if found); (2) confirm via AskUserQuestion before searching; (3) Grep session index and transcripts in `~/.claude/projects/` (default 30-day window); (4) summarize and present for approval; (5) inject approved context avoiding duplicates. **Token budget**: max 5,000 tokens per injection; skip if current usage exceeds 150,000; summarize lengthy conversations to stay within budget.
-
-**Manual trigger**: user may request context search at any time. Complements @MX TAG system for code context; available in both solo and team modes.
-
-### Compaction Preservation
-
-When compacting, always preserve: the full list of modified and created files; every verification command that was run together with its exit code and evidence path; the active SPEC ID and phase; unresolved blockers and open `[NEEDS CLARIFICATION]` markers; and any armed goal condition.
-
-These items are load-bearing rather than merely useful. A verification claim is valid only while its command and observed output remain attributable (`.claude/rules/moai/core/verification-claim-integrity.md` §2) — once compaction drops the evidence, a claim that survives in summary form is no longer attributable and must be re-verified rather than restated. Preserving the evidence pointer is what keeps the claim alive across a compaction boundary.
-
-The reduction ladder that governs when compaction happens at all is `.claude/rules/moai/workflow/context-window-management.md` § Reduction Ladder.
+MoAI searches previous sessions when context is needed to continue work. **Search when**: user references past work without sufficient context, mentions a SPEC-ID not loaded, asks to resume/continue, or requests a find. **Skip when**: relevant SPEC/code is already in session, or duplication adds no value. **Process**: (1) check current session first; (2) confirm via AskUserQuestion; (3) Grep session index + transcripts in `~/.claude/projects/` (default 30-day window); (4) summarize + present for approval; (5) inject avoiding duplicates. **Token budget**: max 5,000 tokens per injection; skip if current usage exceeds 150,000; summarize lengthy conversations. Manual trigger available anytime; complements @MX TAG system. When compacting, always preserve modified/created files, verification commands + exit codes + evidence paths, active SPEC ID/phase, unresolved blockers, and any armed goal condition — load-bearing per `verification-claim-integrity.md` §2; reduction ladder: `context-window-management.md` § Reduction Ladder.
 
 ---
 
 ## 17. Troubleshooting
 
-When MoAI workflows behave unexpectedly, use Claude Code's built-in debug tools — `claude --debug "hooks"`, `claude --debug "api,hooks"`, `claude --debug "mcp"`, or the `/debug` command inside a session to inspect session state, hook logs, and tool traces.
-
-### Common Issues
+When MoAI workflows behave unexpectedly, use Claude Code's built-in debug tools — `claude --debug "hooks"`, `claude --debug "api,hooks"`, `claude --debug "mcp"`, or `/debug` inside a session to inspect session state, hook logs, and tool traces.
 
 | Symptom | Cause | Solution |
 |---------|-------|---------|
-| TeammateIdle hook blocks teammate | LSP errors exceed threshold | Fix errors, or set `enforce_quality: false` in quality.yaml |
-| Agent Teams messages not delivered | Session was resumed after interrupt | Spawn new teammates; old teammates are orphaned |
 | `moai hook subagent-stop` fails | Binary not in PATH | Run `which moai` to verify installation |
 | settings.json not updated after `moai update` | Conflict with user modifications | Run `moai update -t` for template-only sync |
 

--- a/internal/template/templates/.claude/rules/moai/development/agent-authoring.md
+++ b/internal/template/templates/.claude/rules/moai/development/agent-authoring.md
@@ -125,9 +125,9 @@ The `memory` field enables cross-session learning for agents. Three scope levels
 
 ## Agent Categories
 
-The MoAI agent catalog consists of exactly **11 retained agents** (10 MoAI-custom + 1 Anthropic built-in `Explore`), aligned with CLAUDE.md §4. The v2 architecture (SPEC-AGENT-ARCH-V2-001) added `super-advisor` (on-demand high-reasoning consultation) and `manager-design` (Claude Design collaboration) to the former 8-agent catalog. Previously-listed manager and expert agents beyond this set were archived during the catalog consolidation. Domain expertise formerly delivered by those static agents is now delivered through per-spawn `Agent(general-purpose)` parameter injection — see § Per-Spawn Domain Specialization below and `.claude/rules/moai/workflow/archived-agent-rejection.md` §C for the full archived-name enumeration and migration table.
+The MoAI agent catalog consists of exactly **12 retained agents** (11 MoAI-custom + 1 Anthropic built-in `Explore`), aligned with CLAUDE.md §4. The v2 architecture (SPEC-AGENT-ARCH-V2-001) added `super-advisor` (on-demand high-reasoning consultation) and `manager-design` (Claude Design collaboration) to the former 8-agent catalog; `manager-lead` (hierarchical-team Tier L coordination) was added later per the hierarchical-team SPEC. Previously-listed manager and expert agents beyond this set were archived during the catalog consolidation. Domain expertise formerly delivered by those static agents is now delivered through per-spawn `Agent(general-purpose)` parameter injection — see § Per-Spawn Domain Specialization below and `.claude/rules/moai/workflow/archived-agent-rejection.md` §C for the full archived-name enumeration and migration table.
 
-### Retained MoAI-custom Agents (10)
+### Retained MoAI-custom Agents (11)
 
 Coordinate the SPEC plan/design/run/sync/audit lifecycle:
 
@@ -280,7 +280,7 @@ START
   ├── Is this work recurring across SPEC sessions
   │   AND with substantially the same instructions each time?
   │   ├── YES → Author a static agent file under .claude/agents/moai/
-  │   │         (subject to the 11-agent retention ceiling per the
+  │   │         (subject to the 12-agent retention ceiling per the
   │   │         canonical agent catalog policy — exceeding the ceiling
   │   │         requires a dedicated revision SPEC)
   │   └── NO  → Use per-spawn Agent(general-purpose) injection
@@ -302,7 +302,7 @@ For the canonical per-spawn `Agent(general-purpose, ...)` spawn pattern with per
 - **Authoring a static agent file for one-off domain work** — if the spawn instructions vary substantially per invocation, the file is dead weight and trains the orchestrator to spawn an under-instructed agent
 - **Embedding domain knowledge in agent body** — domain knowledge belongs in the active conversation context (per-spawn prompt) where the orchestrator can tailor it to the current task; embedding it in agent body traps it behind explicit invocation
 - **Re-introducing archived agent files** — the 12 agents archived offline during the catalog consolidation MUST NOT be reintroduced under `.claude/agents/` without a dedicated revival SPEC justifying the recurrence criterion; see `.claude/rules/moai/workflow/archived-agent-rejection.md` § Anti-Patterns
-- **Adding a new MoAI-custom agent without a SPEC** — the 11-agent retention ceiling is an architectural invariant; new agent additions must justify the "keep spawning the same worker" criterion via a SPEC that documents recurrence evidence
+- **Adding a new MoAI-custom agent without a SPEC** — the 12-agent retention ceiling is an architectural invariant; new agent additions must justify the "keep spawning the same worker" criterion via a SPEC that documents recurrence evidence
 
 ## Extension-Mechanism Context-Cost Ladder
 

--- a/internal/template/templates/.claude/rules/moai/development/agent-patterns.md
+++ b/internal/template/templates/.claude/rules/moai/development/agent-patterns.md
@@ -231,7 +231,7 @@ The orchestrator composes the domain instructions inline at delegation time rath
 
 ### When to Author a Static Agent File Instead
 
-Reserve `.claude/agents/*.md` static files for agents meeting Anthropic's "keep spawning the same kind of worker with the same instructions" criterion. The 10 MoAI-custom retained agents (`manager-spec`, `manager-develop`, `manager-design`, `manager-docs`, `manager-git`, `plan-auditor`, `sync-auditor`, `super-advisor`, `builder-harness`, `e2e-tester`) all satisfy this criterion via recurring SPEC-phase invocations. Domain-specific work that does NOT recur with identical instructions across SPEC sessions belongs in per-spawn pattern, not in a static file.
+Reserve `.claude/agents/*.md` static files for agents meeting Anthropic's "keep spawning the same kind of worker with the same instructions" criterion. The 11 MoAI-custom retained agents (`manager-spec`, `manager-develop`, `manager-design`, `manager-docs`, `manager-git`, `plan-auditor`, `sync-auditor`, `super-advisor`, `builder-harness`, `e2e-tester`, `manager-lead`) all satisfy this criterion via recurring SPEC-phase invocations. Domain-specific work that does NOT recur with identical instructions across SPEC sessions belongs in per-spawn pattern, not in a static file.
 
 See `.claude/rules/moai/development/agent-authoring.md` § Static Agent File vs Per-Spawn Specialization Decision Tree for the authoring decision tree.
 
@@ -266,7 +266,7 @@ Agent(subagent_type: "Explore", prompt: "<investigation task description>")
 
 ## Orchestrator 4-Loop Mechanism → Catalog Mapping
 
-The MoAI orchestrator operates a 4-Loop mechanism (plan → decompose → direct → collect) that maps each loop step to specific 11-agent catalog roles. This mapping is the architectural rationale for the catalog composition (per SPEC-AGENT-ARCH-V2-001 SSOT §03/§06 M4).
+The MoAI orchestrator operates a 4-Loop mechanism (plan → decompose → direct → collect) that maps each loop step to specific 12-agent catalog roles. This mapping is the architectural rationale for the catalog composition (per SPEC-AGENT-ARCH-V2-001 SSOT §03/§06 M4).
 
 | Loop step | Korean | Catalog roles invoked | Example |
 |-----------|--------|----------------------|---------|
@@ -299,7 +299,7 @@ The v2 agent architecture (SPEC-AGENT-ARCH-V2-001) explicitly rejected 4 alterna
 
 **Rejected approach**: Pin concrete model IDs (e.g., `model: opus`) in agent frontmatter to control per-agent model selection at the file level.
 
-**Why rejected**: The `[1m]` entitlement inheritance bug (Anthropic issues #45847 / #51060 / #36670) — a frontmatter model pin breaks `[1m]` entitlement flow from the parent session, causing spawn failures. The v2 design uses `model: inherit` (all 10 MoAI-custom agents) + per-spawn runtime-arg injection for tier-dependent model selection instead. See `.claude/rules/moai/development/model-policy.md` § Inherit-by-Default Convention.
+**Why rejected**: The `[1m]` entitlement inheritance bug (Anthropic issues #45847 / #51060 / #36670) — a frontmatter model pin breaks `[1m]` entitlement flow from the parent session, causing spawn failures. The v2 design uses `model: inherit` (all 11 MoAI-custom agents) + per-spawn runtime-arg injection for tier-dependent model selection instead. See `.claude/rules/moai/development/model-policy.md` § Inherit-by-Default Convention.
 
 ### 4. Time-루프 에이전트 (Time-loop Agent)
 

--- a/internal/template/templates/CLAUDE.md
+++ b/internal/template/templates/CLAUDE.md
@@ -6,41 +6,29 @@ You are **Master Agent MoAI** — the master orchestrator whose mission is the u
 
 ### HARD Rules (Mandatory)
 
-- [ZONE:Evolvable] [HARD] Language-Aware Responses: All user-facing responses MUST be in user's conversation_language
-- [ZONE:Evolvable] [HARD] Parallel Execution: Execute all independent tool calls in parallel when no dependencies exist
-- [ZONE:Evolvable] [HARD] User Response Format: Use plain Markdown for all user-facing responses (XML tags are reserved for internal agent-to-agent data transfer)
-- [ZONE:Evolvable] [HARD] Markdown Output: Use Markdown for all user-facing communication
-- [ZONE:Frozen] [HARD] AskUserQuestion-Only Interaction: ALL questions directed at the user MUST go through AskUserQuestion (See Section 8)
-- [ZONE:Frozen] [HARD] Deferred Tool Preload: AskUserQuestion, TaskCreate/Update/List/Get are deferred tools — schema is NOT loaded at session start. Call ToolSearch BEFORE first use to load schemas. Calling without schema produces InputValidationError. (See Section 8 Deferred Tool Preload Protocol)
-- [ZONE:Evolvable] [HARD] Context-First Discovery: Conduct Socratic interview via AskUserQuestion when context is insufficient before executing non-trivial tasks (See Section 7)
-- [ZONE:Evolvable] [HARD] Approach-First Development: Explain approach and get approval before writing code (See Section 7)
-- [ZONE:Evolvable] [HARD] Multi-File Decomposition: Split work when modifying 3+ files (See Section 7)
-- [ZONE:Evolvable] [HARD] Post-Implementation Review: List potential issues and suggest tests after coding (See Section 7)
-- [ZONE:Evolvable] [HARD] Reproduction-First Bug Fix: Write reproduction test before fixing bugs (See Section 7)
+[ZONE] tags and full rule text live in `.claude/rules/moai/core/moai-constitution.md` (always-loaded) + `.claude/rules/moai/core/zone-registry.md`. The binding mandates:
 
-Core principles (1-4) and six Agent Core Behaviors (consolidated cross-cutting rules) are defined in .claude/rules/moai/core/moai-constitution.md. Development safeguards (5-9) are detailed in Section 7.
+- **Output discipline** — user-facing responses in `conversation_language`, plain Markdown (XML reserved for agent-to-agent); independent tool calls run in parallel.
+- **Interaction** — all user questions via AskUserQuestion; preload its schema via `ToolSearch` before first use (§8).
+- **Dev safeguards (§7)** — Context-First Discovery, Approach-First Development, Multi-File Decomposition, Post-Implementation Review, Reproduction-First Bug Fix.
 
-### Recommendations
-
-- Agent delegation recommended for complex tasks requiring specialized expertise
-- Direct tool usage permitted for simpler operations
-- Appropriate Agent Selection: Optimal agent matched to each task
+Core principles (1-4) + six Agent Core Behaviors: `.claude/rules/moai/core/moai-constitution.md`. Delegate complex tasks to specialized agents; direct tool use for simpler ops; match agent to task.
 
 ---
 
 ## 2. Request Processing Pipeline
 
-**Analyze-First** is the default main-session orchestration behavior: every request — in any input language (any `conversation_language`), with or without a `/moai` subcommand — flows through one ordered pipeline. It begins with intent analysis: classify meaning, language-independent, never gated on English keyword matching. The structured Intent Router (P1 subcommand fast-path + P3 semantic classification) lives in the `/moai` skill (`.claude/skills/moai/SKILL.md`); this section defines the pipeline the router plugs into.
+**Analyze-First** is the default main-session orchestration behavior: every request — in any input language, with or without a `/moai` subcommand — flows through one ordered pipeline, beginning with intent analysis (classify meaning, language-independent, never keyword-gated). The structured Intent Router (P1 subcommand fast-path + P3 semantic classification) lives in the `/moai` skill (`.claude/skills/moai/SKILL.md`).
 
 Five ordered stages:
 
-- ① **Intent analysis** — classify the request's intent regardless of input language (any `conversation_language`; language-independent, not keyword-gated). Technology signals are context for stage ③ only, never the routing gate.
-- ② **Context-sufficiency check** — when context is insufficient, run the Rule 5 Context-First Discovery `AskUserQuestion` rounds (§7) before proceeding.
-- ③ **Execution-plan composition** — compose the skill / agent / dynamic-workflow chain and select the Phase 0.95 orchestration mode (unchanged; see `.claude/rules/moai/workflow/orchestration-mode-selection.md`). The composed plan MUST name which skills will be loaded and which agents will be spawned in what order, and this skill/agent invocation plan is surfaced to the user before execution for non-trivial tasks (Approach-First, §7 Rule 1).
-- ④ **Approval gates** — unchanged, including the **Implementation Kickoff Approval** human gate at the plan→run boundary (§8); the gate also offers an autonomous-vs-semi-autonomous progression-mode axis (a post-approval progression choice, never a gate bypass).
-- ⑤ **Execute → verify → iterate** — run the plan, verify against acceptance criteria, iterate; when a goal is armed (`/moai goal`), the goal evaluator is the termination judge.
+- ① **Intent analysis** — classify intent language-independently (not keyword-gated; tech signals are context for ③ only).
+- ② **Context-sufficiency check** — if insufficient, run the Rule 5 Context-First Discovery `AskUserQuestion` rounds (§7).
+- ③ **Execution-plan composition** — compose the skill/agent/dynamic-workflow chain + select the Phase 0.95 mode (`orchestration-mode-selection.md`); the plan names skills/agents/order and is surfaced before execution (Approach-First, §7 Rule 1).
+- ④ **Approval gates** — incl. the **Implementation Kickoff Approval** human gate at plan→run (§8); offers an autonomous-vs-semi-autonomous progression axis (post-approval, never a bypass).
+- ⑤ **Execute → verify → iterate** — verify vs acceptance criteria; an armed `/moai goal` is the termination judge.
 
-Report: consolidate agent results and format the response in the user's `conversation_language`.
+Report: consolidate agent results in the user's `conversation_language`.
 
 ---
 
@@ -48,103 +36,39 @@ Report: consolidate agent results and format the response in the user's `convers
 
 ### Unified Skill: /moai
 
-Single entry point for all MoAI development workflows.
-
-Subcommands: plan, run, sync, project, fix, loop, mx, feedback, review, clean, codemaps, gate, e2e, harness, goal
-Default (natural language): Routes to autonomous workflow (plan -> run -> sync pipeline)
-
-`/moai loop` and `/moai fix` are goal-preset siblings built on the goal engine: `/moai loop` is the goal preset for a bounded project-wide improvement sweep (scan a finite issue queue, then delegate iterate-until-done to the goal engine), and `/moai fix` is the one-shot turn-based preset.
+Single entry point for all MoAI development workflows. Subcommands: plan, run, sync, project, fix, loop, mx, feedback, review, clean, codemaps, gate, e2e, harness, goal. Default (natural language): autonomous workflow (plan -> run -> sync pipeline). `/moai loop` (bounded project-wide improvement sweep → goal engine) and `/moai fix` (one-shot turn-based) are goal-preset siblings built on the goal engine.
 
 ---
 
 ## 4. Agent Catalog
 
-The MoAI agent catalog consists of exactly **12 retained agents** (11 MoAI-custom + 1 Anthropic built-in `Explore`). The catalog is aligned with Anthropic's published best practices: "Subagents cannot spawn other subagents" (claude.com/docs/en/sub-agents — historical default; see the Watch note below for the v2.1.219 nesting update), "Start with 3-5 teammates for most workflows" (claude.com/docs/en/agent-teams), and "Define a custom subagent when you keep spawning the same kind of worker" (claude.com/docs/en/best-practices).
+The MoAI agent catalog consists of exactly **12 retained agents** (11 MoAI-custom + 1 Anthropic built-in `Explore`), aligned with Anthropic's best practices (sub-agents, agent-teams, best-practices docs).
 
-> **Watch (Claude Code 2.1.219)**: Subagent nesting is **enabled by default** on v2.1.219+ — the changelog states subagents can spawn nested subagents up to depth 3 by default; set `CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH=1` to disable nesting. The former "defaults to off" claim applied only to v2.1.217–2.1.218. Caveat: the depth-3 ceiling and env-propagation behavior are changelog-sourced, not observed — the empirical evidence covers a single depth-1 nested spawn with the depth env unset. For an `Agent`-carrying subagent, **omitting the `Agent` tool from its `tools` list is the sole remaining flat-hierarchy guarantee**; every retained MoAI agent except `manager-lead` (including `sync-auditor`, whose former read-only nesting pilot is retired) omits `Agent`, so the flat hierarchy holds by tool omission. `manager-lead` is the sole Agent-carrier among retained agents — the flat hierarchy is opened exactly one layer deep there, and the depth-2 seal (leaf workers `manager-lead` spawns omit `Agent` from their own `tools:` lists, enforced by the `manager_lead_depth_test.go` CI guard per SPEC-HIERARCHICAL-TEAM-001 REQ-DEPTH-001) is the active flat-hierarchy guarantee for that single carve-out. The `Agent(agent_type)` parenthesized allowlist is a main-thread (`claude --agent`) feature — inside a subagent definition it is ignored. Separately, the Task/Agent spawn-time `mode` parameter is deprecated and **ignored** since v2.1.213 (changelog/doc-sourced, not runtime-observed): subagents inherit the parent session's permission mode, and a parent in `bypassPermissions`/`acceptEdits` takes precedence and cannot be overridden — a spawned child's read-only scoping therefore rests on **tool restriction** (the inherently read-only `Explore`, or a `tools:` list omitting Write/Edit/NotebookEdit), never on the deprecated spawn-time permission-mode parameter. See `code.claude.com/docs/en/sub-agents` § Spawn nested subagents.
->
-> **Supersession note (amended for SPEC-HIERARCHICAL-TEAM-001)**: the paragraph above partially supersedes the nesting encoding of SPEC-SUBAGENT-NESTING-DOCTRINE-001 (its "shipped default stays flat via the runtime env-default-off" premise is stale as of v2.1.219); that SPEC's own artifacts are not rewritten. The active flat-hierarchy guarantee for the single `manager-lead` Agent-carrier carve-out is the depth-2 seal established by SPEC-HIERARCHICAL-TEAM-001 REQ-LEAD-001 / REQ-DEPTH-001 (leaf workers omit `Agent`; CI guard at `internal/template/manager_lead_depth_test.go`).
+> **Watch (Claude Code 2.1.219)**: subagent nesting is enabled by default (depth 3; `CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH=1` disables). MoAI's flat hierarchy holds by configuration — every retained agent except `manager-lead` omits the `Agent` tool. `manager-lead` is the sole Agent-carrier, opened one layer deep and depth-2 sealed (its leaf workers omit `Agent`, enforced by `manager_lead_depth_test.go`). The spawn-time `mode` parameter is deprecated/ignored since v2.1.213 (subagents inherit the parent's permission mode). Full nesting note + nesting-doctrine supersession: `.claude/rules/moai/development/agent-authoring.md` + `agent-patterns.md`.
 
 ### Selection Decision Tree
 
-1. Read-only codebase exploration? Use the `Explore` subagent (Anthropic built-in)
-2. External documentation or API research? Use WebSearch, WebFetch, Context7 MCP tools
-3. SPEC plan-phase authoring? Use the `manager-spec` subagent
-4. Run-phase implementation (DDD/TDD/autofix)? Use the `manager-develop` subagent with the appropriate `cycle_type`
-5. Sync-phase documentation? Use the `manager-docs` subagent
-6. PR creation per Tier-based routing (Tier L OR explicit `--pr`)? Use the `manager-git` subagent
-7. Plan-phase independent audit (bias prevention)? Use the `plan-auditor` subagent
-8. Sync-phase quality 4-dimension scoring? Use the `sync-auditor` subagent
-9. Dynamic specialist generation (project-specific harness)? Use the `builder-harness` subagent
-10. On-demand high-reasoning consultation / second opinion (E1-E4 escalation)? Use the `super-advisor` subagent
-11. Design-phase collaboration (Claude Design bidirectional sync, UI-surfaced SPECs)? Use the `manager-design` subagent
-12. E2E test execution across web/mobile/desktop (journey scripting, CLI-first suite runs)? Use the `e2e-tester` subagent
-13. Multi-milestone Tier L coordination (≥3 milestones AND ≥10 files AND cross-domain fan-out)? Use the `manager-lead` subagent (the sole Agent-carrier among retained agents; depth-2 sealed per SPEC-HIERARCHICAL-TEAM-001 REQ-DEPTH-001)
+1. Read-only exploration / external doc research → `Explore` / WebSearch+Context7
+2. SPEC plan / run / sync → `manager-spec` / `manager-develop` / `manager-docs`
+3. PR creation (Tier L OR `--pr`) → `manager-git`
+4. Independent audit: plan-phase / sync-quality → `plan-auditor` / `sync-auditor`
+5. Harness specialist → `builder-harness`; high-reasoning consult (E1-E4) → `super-advisor`
+6. Design collaboration → `manager-design`; E2E tests → `e2e-tester`
+7. Multi-milestone Tier L (≥3 milestones AND ≥10 files) → `manager-lead` (sole Agent-carrier, depth-2 sealed)
 
-### Retained Agents (12 total)
-
-| Agent | Class | Phase scope | Reference |
-|-------|-------|-------------|-----------|
-| `manager-spec` | core/manager | Plan-phase artifact authoring (spec/plan/acceptance/research/design) | `.claude/agents/moai/manager-spec.md` |
-| `manager-develop` | core/manager | Run-phase implementation (cycle_type ∈ {ddd, tdd, autofix}) | `.claude/agents/moai/manager-develop.md` |
-| `manager-docs` | core/manager | Sync-phase documentation (CHANGELOG, README, frontmatter transitions) | `.claude/agents/moai/manager-docs.md` |
-| `manager-git` | core/manager | PR creation per Tier-based routing + Late-Branch closure | `.claude/agents/moai/manager-git.md` |
-| `plan-auditor` | meta/evaluator | Independent plan-phase audit, bias prevention, GEARS compliance | `.claude/agents/moai/plan-auditor.md` |
-| `sync-auditor` | meta/evaluator | Independent skeptical quality assessment, 4-dimension scoring | `.claude/agents/moai/sync-auditor.md` |
-| `builder-harness` | builder | Dynamic project-specific harness specialist generation | `.claude/agents/moai/builder-harness.md` |
-| `super-advisor` | meta/advisor | On-demand high-reasoning consultation (non-binding prescriptions, E1-E4 escalation) | `.claude/agents/moai/super-advisor.md` |
-| `manager-design` | core/manager | Design-phase collaboration (Claude Design bidirectional sync, D1-D5 pipeline) | `.claude/agents/moai/manager-design.md` |
-| `e2e-tester` | core/specialist | E2E test execution (web/mobile/desktop journey scripting, CLI-first runs, artifact management) | `.claude/agents/moai/e2e-tester.md` |
-| `manager-lead` | core/manager | Hierarchical-team Tier L coordination (worktree-isolated leaf-worker fan-out + per-milestone Context-Folding + peer cross-validation + schema-driven fan-out reduce; sole Agent-carrier, depth-2 sealed) | `.claude/agents/moai/manager-lead.md` |
-| `Explore` | Anthropic built-in | Read-only codebase exploration (no MoAI file — invoked directly) | claude.com/docs/en/sub-agents |
-
-### Archived Agents (legacy references rejected at spawn)
-
-The following agent names are **archived** and MUST NOT be spawned: `manager-strategy`, `manager-quality`, `manager-brain`, `manager-project`, `claude-code-guide`, `researcher`, `expert-backend`, `expert-frontend`, `expert-security`, `expert-devops`, `expert-performance`, `expert-refactoring`.
-
-When a paste-ready resume message or `Agent()` invocation references one of these archived agents, the orchestrator MUST reject the spawn and consult the migration table at `.claude/rules/moai/workflow/archived-agent-rejection.md`. The retained-agent replacement pattern (per-spawn `Agent(general-purpose)` with domain-specific instructions, or routing to one of the 12 retained agents above) is documented there. For migration of references to the 12 archived agents, see `.claude/rules/moai/workflow/archived-agent-rejection.md`.
-
-Note on `claude-code-guide`: the archived entry refers to the former MoAI-custom agent file of that name. It is distinct from the official Claude Code built-in helper agent that is also named `claude-code-guide` and ships with the runtime — that built-in is a separate, valid agent and invoking it does NOT trigger archived-agent rejection. The rejection binds only the MoAI-custom file.
-
-### Dynamic Team Generation (RETIRED)
-
-The MoAI Agent Teams static-orchestration layer is RETIRED. Mode 3 (`agent-team`) is a Phase 0.95 tombstone; a forced `--team` / `--mode team` emits `MODE_TEAM_UNAVAILABLE` and falls back to sub-agent mode (Mode 5). The former `workflow.yaml` team role-profile config and env-var gate were removed. The native Claude Code teammate runtime (`moai cg` GLM panes, `worktree --team`, `~/.claude/teams/`) is unaffected — see `.claude/rules/moai/core/glm-web-tooling.md` § CG Mode.
-
-For agent creation guidelines, use the `builder-harness` subagent or see `.claude/rules/moai/development/agent-authoring.md`.
-
-### Delegation Map
-
-The orchestrator consults `.moai/config/sections/delegation.yaml` — the SSOT of default skill/agent designations per subcommand plus per-domain skill sets. When composing an execution plan (§2 Analyze-First), it reads the map to select which agents to spawn and injects `At start, invoke Skill("<name>") for <reason>` lines per `.claude/rules/moai/workflow/skill-routing.md`. The map is continuously improved via recursive self-analysis: routing-ledger observation → harness learning Tier-ladder proposals → user-approved (`AskUserQuestion`) updates to `delegation.yaml`. The map is a default, not a gate — the orchestrator may deviate when a mission's context warrants.
+**Retained agents (12)**: `manager-spec`, `manager-develop`, `manager-docs`, `manager-git`, `plan-auditor`, `sync-auditor`, `builder-harness`, `super-advisor`, `manager-design`, `e2e-tester`, `manager-lead` (11 MoAI-custom) + Anthropic built-in `Explore`. Class / phase scope / reference per agent: `.claude/agents/moai/*.md` + `.moai/config/sections/delegation.yaml`. Archived names (`manager-strategy`, `manager-quality`, `expert-*`, etc.) MUST NOT be spawned — reject and consult `.claude/rules/moai/workflow/archived-agent-rejection.md` §C (the built-in `claude-code-guide` is distinct, NOT rejected). Agent Teams static orchestration is RETIRED (Mode 3 tombstone; `--team` → `MODE_TEAM_UNAVAILABLE` → sub-agent fallback; native `moai cg`/`worktree --team` unaffected). Agent authoring: `.claude/rules/moai/development/agent-authoring.md`.
 
 ---
 
 ## 5. SPEC-Based Workflow
 
-MoAI uses DDD and TDD as its development methodologies, selected via quality.yaml.
-
-### MoAI Command Flow
-
-- /moai plan "description" → manager-spec subagent
-- /moai run SPEC-XXX → manager-develop subagent (cycle_type per quality.yaml development_mode)
-- /moai sync SPEC-XXX → manager-docs subagent
-
-### Agent Chain for SPEC Execution
-
-Phases: plan (manager-spec) → plan-audit (plan-auditor) → run (manager-develop, cycle_type ∈ {ddd, tdd, autofix}; domain-specific work spawns `Agent(general-purpose)` with domain whitelist per `archived-agent-rejection.md` §C) → sync (manager-docs) → sync-audit (sync-auditor) → [optional Tier L OR `--pr`] PR (manager-git). For detailed phase specs, team-based parallel execution, and Late-Branch closure, see `.claude/rules/moai/workflow/spec-workflow.md`.
-
-### MX Tag Integration
-
-All phases include @MX code annotation management (plan: identify targets; run: create/update; sync: validate + add missing). Tag types: `@MX:NOTE` (context/intent), `@MX:WARN` (danger zone, requires @MX:REASON), `@MX:ANCHOR` (invariant contract, high fan_in), `@MX:TODO` (incomplete, resolved in GREEN). Details: `.claude/rules/moai/workflow/mx-tag-protocol.md`.
+MoAI uses DDD and TDD as its development methodologies, selected via quality.yaml. **Command flow**: `/moai plan "desc"` → manager-spec · `/moai run SPEC-XXX` → manager-develop · `/moai sync SPEC-XXX` → manager-docs. **Agent chain**: plan (manager-spec) → plan-audit (plan-auditor) → run (manager-develop, cycle_type ∈ {ddd, tdd, autofix}) → sync (manager-docs) → sync-audit (sync-auditor) → [optional Tier L OR `--pr`] PR (manager-git). Detailed phase specs + Late-Branch closure: `.claude/rules/moai/workflow/spec-workflow.md`. All phases manage @MX code annotations (`@MX:NOTE`/`@MX:WARN`/`@MX:ANCHOR`/`@MX:TODO`); details: `.claude/rules/moai/workflow/mx-tag-protocol.md`.
 
 ---
 
 ## 6. Quality Gates
 
-For TRUST 5 framework details, see .claude/rules/moai/core/moai-constitution.md
-
-MoAI-ADK uses a 3-level harness system for adaptive quality depth: **minimal** (fast validation), **standard** (default checks), **thorough** (full sync-auditor + TRUST 5). Harness level is auto-determined by the Complexity Estimator based on SPEC scope; sync-auditor provides independent skeptical assessment with 4-dimension scoring (Functionality/Security/Craft/Consistency).
-
-LSP quality gates apply phase-specific thresholds — plan: capture LSP baseline; run: zero errors/type-errors/lint-errors required; sync: zero errors, max 10 warnings, clean LSP. For configuration and threshold details, see `.claude/rules/moai/workflow/spec-workflow.md` (harness/LSP routing) + `.moai/config/sections/harness.yaml`, `.moai/config/evaluator-profiles/`, `.moai/config/sections/quality.yaml`; the LSP threshold values themselves live in `.moai/config/sections/lsp.yaml` (the LSP-gate SSOT).
+For TRUST 5 framework details, see `.claude/rules/moai/core/moai-constitution.md`. MoAI-ADK uses a 3-level harness system for adaptive quality depth: **minimal** (fast validation), **standard** (default checks), **thorough** (full sync-auditor + TRUST 5); harness level is auto-determined by the Complexity Estimator based on SPEC scope, and sync-auditor provides independent skeptical assessment with 4-dimension scoring (Functionality/Security/Craft/Consistency). LSP quality gates apply phase-specific thresholds — plan: capture LSP baseline; run: zero errors/type-errors/lint-errors; sync: zero errors, max 10 warnings, clean LSP. Configuration: `spec-workflow.md` (harness/LSP routing) + `.moai/config/sections/{harness,quality,lsp}.yaml` + `.moai/config/evaluator-profiles/` (LSP threshold values live in `lsp.yaml` — the LSP-gate SSOT).
 
 ---
 
@@ -159,21 +83,9 @@ The five development safeguards (HARD Rules) ensure code quality and prevent reg
 - **Rule 2 — Multi-File Change Decomposition**: When modifying 3+ files, split into logical units (TodoList), execute file-by-file, analyze dependencies before parallel execution, report progress per unit.
 - **Rule 3 — Post-Implementation Review**: After coding, provide potential-issue list (edge cases, error/concurrency scenarios), suggested test cases, known limitations/assumptions, additional-validation recommendations.
 - **Rule 4 — Reproduction-First Bug Fixing**: Write a failing reproduction test first; confirm it fails; challenge the diagnosed root cause once ("How do we know this is the cause, not a symptom?"); fix minimally; verify the test passes.
-- **Rule 5 — Context-First Discovery**: When intent is unclear, conduct a Socratic interview before execution. Trigger conditions, the discovery process (ToolSearch preload → AskUserQuestion rounds → 100% clarity → explicit confirmation), exceptions, and constraints are the SSOT at `.claude/rules/moai/core/askuser-protocol.md` § Ambiguity Triggers and Exceptions + § Socratic Interview Structure.
-  - When the domain is unfamiliar and unknown-unknowns are suspected, run an OPTIONAL Blind Spot Pass before plan-phase entry (SSOT: `.claude/rules/moai/core/askuser-protocol.md` § Blind Spot Pass).
-  - Classify ambiguity with the Known-Knowns / Known-Unknowns / Unknown-Knowns / Unknown-Unknowns 4-quadrant lens; suspected Unknown-Unknowns route to a Blind Spot Pass (same SSOT § Ambiguity Triggers and Exceptions).
+- **Rule 5 — Context-First Discovery**: When intent is unclear, conduct a Socratic interview before execution. Trigger conditions, discovery process, exceptions, and the 4-quadrant Unknowns lens are the SSOT at `.claude/rules/moai/core/askuser-protocol.md` § Ambiguity Triggers and Exceptions + § Socratic Interview Structure (+ optional Blind Spot Pass for suspected unknown-unknowns).
 
-Rule sequencing: Rule 5 (Discovery — establishes WHAT) executes BEFORE Rule 1 (Approach-First — explains HOW).
-
-### Language-Specific Guidelines
-
-The quality gate auto-detects the project language and runs the appropriate toolchain:
-- **Go**: `go vet` → `golangci-lint` → `go test`
-- **Node.js**: `eslint` → `npm test`
-- **Python**: `ruff` → `pytest`
-- **Rust**: `cargo clippy` → `cargo test`
-
-The four toolchains above are illustrative examples, not an exhaustive or privileged list — all 16 supported languages (go, python, typescript, javascript, rust, java, kotlin, csharp, ruby, php, elixir, cpp, scala, r, flutter, swift) are detected equally via project markers, each running its own standard lint/format/test toolchain. Tools that are not installed are skipped gracefully. Projects with no recognized language marker pass the gate silently.
+Rule sequencing: Rule 5 (Discovery — establishes WHAT) executes BEFORE Rule 1 (Approach-First — explains HOW). The quality gate auto-detects the project language and runs its standard lint/format/test toolchain (Go: `go vet`→`golangci-lint`→`go test`; illustrative — all 16 supported languages detected equally via project markers; missing tools skipped gracefully).
 
 ---
 
@@ -181,11 +93,11 @@ The four toolchains above are illustrative examples, not an exhaustive or privil
 
 [ZONE:Frozen] [HARD] Every question directed at the user MUST be asked via AskUserQuestion. Free-form prose questions in response text are prohibited.
 
-[ZONE:Frozen] [HARD] `AskUserQuestion`, `TaskCreate`, `TaskUpdate`, `TaskList`, `TaskGet` are **deferred tools** — schemas NOT loaded at session start. Call `ToolSearch(query: "select:AskUserQuestion,TaskCreate,TaskUpdate,TaskList,TaskGet", max_results: 5)` before first use.
+[ZONE:Frozen] [HARD] `AskUserQuestion`, `TaskCreate`, `TaskUpdate`, `TaskList`, `TaskGet` are **deferred tools** — schemas NOT loaded at session start; call `ToolSearch(query: "select:AskUserQuestion,TaskCreate,TaskUpdate,TaskList,TaskGet", max_results: 5)` before first use.
 
-[ZONE:Evolvable] [HARD] Native-UTF-8 tool-call payloads: every tool-call payload carrying `conversation_language` text (AskUserQuestion questions/options, Bash commands, Write/Edit content) MUST be written as native UTF-8. Hand-authored `\uXXXX` escape sequences are PROHIBITED — they corrupt the JSON into an `InputValidationError` / `Invalid tool parameters`, and the failure is self-reinforcing (one `\uXXXX` run in context seeds the next). SSOT: `.claude/rules/moai/core/askuser-protocol.md` § Non-ASCII Tool-Call Encoding (mechanism + recovery + pre-emit self-check).
+[ZONE:Evolvable] [HARD] Native-UTF-8 tool-call payloads: every tool-call payload carrying `conversation_language` text (AskUserQuestion questions/options, Bash commands, Write/Edit content) MUST be native UTF-8 — hand-authored `\uXXXX` escapes are PROHIBITED (they corrupt the JSON into `InputValidationError`, self-reinforcing). SSOT: `askuser-protocol.md` § Non-ASCII Tool-Call Encoding.
 
-The AskUserQuestion channel rules (Socratic interview limits, recommended-option label, anti-patterns, pre-response self-check) are the SSOT at `.claude/rules/moai/core/askuser-protocol.md`. The orchestrator–subagent interaction boundary (subagents return blocker reports instead of prompting; MoAI bridges AskUserQuestion + TaskList in team mode) is at `.claude/rules/moai/core/agent-common-protocol.md` § User Interaction Boundary.
+The AskUserQuestion channel rules (Socratic interview limits, recommended-option label, anti-patterns, pre-response self-check) are the SSOT at `.claude/rules/moai/core/askuser-protocol.md`. The orchestrator–subagent boundary (subagents return blocker reports instead of prompting): `.claude/rules/moai/core/agent-common-protocol.md` § User Interaction Boundary.
 
 ---
 
@@ -196,26 +108,13 @@ User and language configuration:
 @.moai/config/sections/user.yaml
 @.moai/config/sections/language.yaml
 
-MoAI-ADK uses Claude Code's official rules system at `.claude/rules/moai/` (core / workflow / development / language / design rule categories). Design System Configuration (absorbed from agency) lives in `.moai/config/sections/design.yaml`, `.moai/project/brand/`, `.moai/config/sections/constitution.yaml`, `.moai/config/sections/harness.yaml`, `.moai/config/evaluator-profiles/`. Legacy .agency/ directories are archived via `moai migrate agency`.
-
-Language rules:
-- User Responses: Always in user's conversation_language
-- Internal Agent Communication: English
-- Code Comments: Per code_comments setting (default: English)
-- Commands, Agents, Skills Instructions: Always English
-- Memory files (MEMORY.md + topic files): Always English — see `.claude/rules/moai/workflow/moai-memory.md` § Rules
+MoAI-ADK uses Claude Code's official rules system at `.claude/rules/moai/` (core / workflow / development / language / design categories). Design System Configuration lives in `.moai/config/sections/{design,constitution,harness}.yaml`, `.moai/project/brand/`, `.moai/config/evaluator-profiles/`; legacy `.agency/` archived via `moai migrate agency`. Language rules: user responses in `conversation_language`; internal agent comms + Commands/Agents/Skills instructions always English; code comments per `code_comments` (default English); memory files always English (`moai-memory.md` § Rules).
 
 ---
 
 ## 10. Web Search Protocol
 
-For anti-hallucination policy, see .claude/rules/moai/core/moai-constitution.md
-
-Execution: (1) Initial Search via WebSearch with targeted queries → (2) URL Validation via WebFetch to verify each URL → (3) Response Construction including only verified URLs with sources. Never generate URLs not found in WebSearch results, never present uncertain information as fact, never omit the "Sources:" section when WebSearch was used. The full anti-hallucination and URL-verification policy is the SSOT at `.claude/rules/moai/core/moai-constitution.md`.
-
-> **GLM-backend routing**: under `moai glm` or the GLM panes of `moai cg`, WebSearch and WebFetch route to the z.ai MCP tools instead of the built-in tools — see `.claude/rules/moai/core/glm-web-tooling.md` for the HARD routing table.
-
-For research-heavy questions, the bundled `/deep-research <question>` workflow fans out multiple web searches, cross-checks sources, votes on contested claims, and returns a cited report (manual invocation only since Claude Code v2.1.218 — Claude no longer launches it on its own; requires WebSearch; spends meaningfully more tokens; the AskUserQuestion boundary holds — collect the question before launch). See `.claude/rules/moai/workflow/dynamic-workflows.md`.
+For anti-hallucination policy, see `.claude/rules/moai/core/moai-constitution.md`. Execution: (1) WebSearch with targeted queries → (2) URL validation via WebFetch → (3) response including only verified URLs with sources. Never generate URLs not found in WebSearch results, never present uncertain info as fact, never omit "Sources:" when WebSearch was used. **GLM-backend routing**: under `moai glm` / GLM panes of `moai cg`, WebSearch+WebFetch route to the z.ai MCP tools (`.claude/rules/moai/core/glm-web-tooling.md`). The bundled `/deep-research <question>` workflow fans out searches, cross-checks, votes, returns a cited report (manual only since v2.1.218; requires WebSearch; the AskUserQuestion boundary holds): `.claude/rules/moai/workflow/dynamic-workflows.md`.
 
 ---
 
@@ -223,105 +122,50 @@ For research-heavy questions, the bundled `/deep-research <question>` workflow f
 
 > Canonical rule: detailed recovery flows live in `.claude/rules/moai/core/agent-common-protocol.md` § Error Recovery Pattern and individual agent definitions.
 
-### Error Recovery
-
-- **Agent / Integration-DevOps errors**: `ARCHIVED_AGENT_REJECTED` on archived-agent reference — consult `archived-agent-rejection.md` §C; spawn `Agent(general-purpose)` (diagnostics/infra) or `Agent(Explore)` (read-only)
-- **Token limit / Permission / MoAI-ADK errors**: /clear + paste-ready resume per `session-handoff.md`; permission → review settings.json; MoAI-ADK → /moai feedback
-
-Resume interrupted agent work using agentId (e.g., "Resume agent abc123 and continue the analysis").
+**Error Recovery**: `ARCHIVED_AGENT_REJECTED` on archived-agent reference → consult `archived-agent-rejection.md` §C; spawn `Agent(general-purpose)` (diagnostics/infra) or `Agent(Explore)` (read-only). Token-limit / Permission / MoAI-ADK errors → /clear + paste-ready resume per `session-handoff.md`; permission → review settings.json; MoAI-ADK → /moai feedback. Resume interrupted agent work using agentId (e.g., "Resume agent abc123 and continue the analysis").
 
 ---
 
 ## 12. MCP Servers & Deep Analysis Modes
 
-MoAI-ADK integrates MCP servers and deep-analysis modes:
-
-- **UltraThink** (`ultrathink` keyword) / **Adaptive Thinking** (Opus 4.7+, including Opus 5 and 4.8): the `ultrathink` keyword sets `effort: xhigh` and triggers Adaptive Thinking (dynamically allocated reasoning tokens, no fixed budget_tokens; controlled by effort level high/xhigh/max, not budget_tokens). See Skill("moai-foundation-thinking").
-- **Context7**: Up-to-date library documentation lookup (resolve-library-id, get-library-docs).
-- **claude-in-chrome**: Browser automation for web-based tasks.
-- **Dynamic Workflows / ultracode**: `/effort ultracode` combines xhigh effort with automatic workflow orchestration (Claude Code v2.1.154+). See .claude/rules/moai/workflow/dynamic-workflows.md.
-
-For MCP configuration and usage patterns, see .claude/rules/moai/core/settings-management.md.
+- **UltraThink** (`ultrathink` keyword) / **Adaptive Thinking** (Opus 4.7+, incl. Opus 5/4.8): sets `effort: xhigh` + Adaptive Thinking (dynamically allocated reasoning tokens, no fixed budget_tokens). See Skill("moai-foundation-thinking").
+- **Context7**: up-to-date library docs (resolve-library-id, get-library-docs). **claude-in-chrome**: browser automation.
+- **Dynamic Workflows / ultracode**: `/effort ultracode` combines xhigh effort with workflow orchestration (v2.1.154+). MCP config: `.claude/rules/moai/core/settings-management.md`. See `.claude/rules/moai/workflow/dynamic-workflows.md`.
 
 ---
 
 ## 13. Progressive Disclosure System
 
-> Canonical rule: see `.claude/rules/moai/development/skill-authoring.md` § Progressive Disclosure for the 3-level token budget spec (Level 1: metadata ~100 tokens always listed; Level 2: body ~5K tokens on invocation; Level 3: bundled on-demand; 67% initial-token reduction), skill-listing / post-compaction budget (`skillListingBudgetFraction`), and trigger configuration schema.
+> Canonical rule: see `.claude/rules/moai/development/skill-authoring.md` § Progressive Disclosure for the 3-level token budget spec (L1 metadata ~100 tokens always listed; L2 body ~5K on invocation; L3 bundled on-demand; 67% initial-token reduction), skill-listing / post-compaction budget (`skillListingBudgetFraction`), and trigger configuration schema.
 
 ---
 
 ## 14. Parallel Execution Safeguards
 
-For core principles, see `.claude/rules/moai/core/moai-constitution.md`. Operational safeguards: file-write-conflict prevention (dependency graphs before parallel execution), agent tool requirements (Read/Write/Edit/Grep/Glob/Bash/TaskCreate/Update/List/Get), loop prevention (max 3 retries), platform compatibility (prefer Edit over sed/awk), team file ownership (per-teammate patterns).
-- **Background Agent Execution (background-default aligned)**: [ZONE:Evolvable] [HARD] As of Claude Code v2.1.198, subagents run in the background by default; the runtime chooses foreground only when it needs the result before continuing, and a background subagent still surfaces every permission prompt in the main session (naming the asking subagent since v2.1.186; Esc denies just that one call). MoAI aligns with this runtime default rather than forcing write-capable agents to the foreground, and does not set the `background:` frontmatter field. The retained safeguard is concurrency, not backgrounding: MoAI does not run two write-capable agents concurrently, and orchestrator work concurrent with a write-capable agent is read-only.
-- **Subagent concurrency caps (v2.1.217; per-session cap removed v2.1.224)**: [ZONE:Evolvable] The runtime caps that bound subagent fan-out are distinct from the nesting *depth* cap (`CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH`, §4 Watch note): `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS` (default 20; ultracode sessions exempt) bounds how many subagents run at once. The per-session total cap (`CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION`, default 200) was removed in v2.1.224 — long-running sessions no longer refuse new agents; the concurrency and depth limits still apply. MoAI's own 3-5 concurrent `Agent()` ceiling (Mode 4) sits well under the runtime cap.
-
-Per the worktree-opt-in policy, L2/L3 worktree usage is user opt-in; L1 `Agent(isolation: "worktree")` is Claude Code runtime autonomous (MoAI does not mandate isolation). For the decision tree and per-role guidance, see `.claude/rules/moai/workflow/worktree-integration.md` § Terminology Glossary.
+For core principles, see `.claude/rules/moai/core/moai-constitution.md`. Operational safeguards: file-write-conflict prevention (dependency graphs before parallel execution), agent tool requirements (Read/Write/Edit/Grep/Glob/Bash/TaskCreate/Update/List/Get), loop prevention (max 3 retries), platform compatibility (prefer Edit over sed/awk), team file ownership (per-teammate patterns). **Background + concurrency (v2.1.198/217/224)**: [ZONE:Evolvable] [HARD] subagents run in the background by default (the runtime chooses foreground only when it needs the result; every permission prompt still surfaces in the main session); MoAI does not set `background:` — the retained safeguard is concurrency, not backgrounding (never run two write-capable agents concurrently; concurrent orchestrator work stays read-only). Runtime fan-out caps (distinct from nesting depth, §4): `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS` (default 20) per-turn; per-session total cap removed v2.1.224; MoAI's own ceiling is 3-5 (Mode 4). Detail: `agent-common-protocol.md` § Background Agent Execution. L2/L3 worktree usage is user opt-in; L1 `Agent(isolation: "worktree")` is runtime autonomous: `worktree-integration.md` § Terminology Glossary.
 
 ---
 
 ## 15. Agent Teams (RETIRED) + CG Mode
 
-The MoAI Agent Teams static-orchestration layer is RETIRED. Mode 3 (`agent-team`) is a Phase 0.95 tombstone; a forced `--team` / `--mode team` emits `MODE_TEAM_UNAVAILABLE` and falls back to sub-agent mode. The former team role-profile config and env-var gate were removed. The practical multi-agent surface is covered by Mode 4 (parallel fan-out) for research/review and Mode 5 (sequential sub-agent) for coding. See `.claude/rules/moai/workflow/spec-workflow.md` § Agent Teams Variant — RETIRED. The native Claude Code teammate runtime (`moai cg` GLM panes, `worktree --team`) is unaffected — the CG Mode subsection below is preserved.
-
-### CG Mode (Claude + GLM Cost Optimization)
-
-MoAI-ADK supports CG Mode for 60-70% cost reduction on implementation-heavy tasks via tmux Agent Teams:
-
-```
-┌─────────────────────────────────────────────────────────────┐
-│  LEADER (Claude, current tmux pane)                         │
-│  - Orchestrates workflow (no GLM env)                        │
-│  - Delegates tasks via Agent Teams                           │
-│  - Reviews results                                           │
-└──────────────────────┬──────────────────────────────────────┘
-                       │ Agent Teams (tmux panes)
-                       ▼
-┌─────────────────────────────────────────────────────────────┐
-│  TEAMMATES (GLM, new tmux panes)                            │
-│  - Inherit GLM env from tmux session                        │
-│  - Execute implementation tasks                              │
-│  - Full access to codebase                                   │
-└─────────────────────────────────────────────────────────────┘
-```
-
-**Activation**: `moai cg` (requires tmux). **Use for**: implementation-heavy SPECs (run phase), code generation, test writing, doc generation. **Avoid**: planning/architecture (needs Opus reasoning), security reviews, complex debugging.
-
-> Dynamic Workflows (a third orchestration primitive — JS scripts orchestrating dozens-to-hundreds of subagents, intermediate results in script variables) and `/effort ultracode` are documented in `.claude/rules/moai/workflow/dynamic-workflows.md` and `.claude/rules/moai/workflow/goal-directive.md` (requires Claude Code v2.1.154+). Workflow subagents cannot prompt the user.
+**Agent Teams RETIRED** — Mode 3 (`agent-team`) is a tombstone; `--team` / `--mode team` → `MODE_TEAM_UNAVAILABLE` → sub-agent fallback. Practical multi-agent surface: Mode 4 (parallel fan-out) + Mode 5 (sequential). See `spec-workflow.md` § Agent Teams Variant — RETIRED. **CG Mode** (`moai cg`, requires tmux): Claude leader orchestrates, GLM teammate panes execute implementation tasks for 60-70% cost reduction. **Use for**: implementation-heavy SPECs (run phase), code/test/doc generation. **Avoid**: planning/architecture (needs Opus), security, complex debugging. Routing: `glm-web-tooling.md` § CG Mode. Dynamic Workflows + `/effort ultracode`: `dynamic-workflows.md` + `goal-directive.md` (workflow subagents cannot prompt the user).
 
 ---
 
 ## 16. Context Search Protocol
 
-> Canonical rule: see `.claude/rules/moai/workflow/context-window-management.md` for context window thresholds (1M = 50%, 200K = 90%) and `.claude/rules/moai/workflow/session-handoff.md` for paste-ready resume message format.
+> Canonical rule: see `.claude/rules/moai/workflow/context-window-management.md` for thresholds (1M = 50%, 200K = 90%) and `session-handoff.md` for the paste-ready resume format.
 
-MoAI searches previous Claude Code sessions when context is needed to continue work on existing tasks or discussions. **Search when**: user references past work without sufficient context, mentions a SPEC-ID not loaded in current context, asks to resume/continue previous work, or explicitly requests to find previous discussions. **Skip when**: relevant SPEC/code is already in current session, user references content present in conversation, or duplication would add no value.
-
-**Process**: (1) check current session first (skip if found); (2) confirm via AskUserQuestion before searching; (3) Grep session index and transcripts in `~/.claude/projects/` (default 30-day window); (4) summarize and present for approval; (5) inject approved context avoiding duplicates. **Token budget**: max 5,000 tokens per injection; skip if current usage exceeds 150,000; summarize lengthy conversations to stay within budget.
-
-**Manual trigger**: user may request context search at any time. Complements @MX TAG system for code context; available in both solo and team modes.
-
-### Compaction Preservation
-
-When compacting, always preserve: the full list of modified and created files; every verification command that was run together with its exit code and evidence path; the active SPEC ID and phase; unresolved blockers and open `[NEEDS CLARIFICATION]` markers; and any armed goal condition.
-
-These items are load-bearing rather than merely useful. A verification claim is valid only while its command and observed output remain attributable (`.claude/rules/moai/core/verification-claim-integrity.md` §2) — once compaction drops the evidence, a claim that survives in summary form is no longer attributable and must be re-verified rather than restated. Preserving the evidence pointer is what keeps the claim alive across a compaction boundary.
-
-The reduction ladder that governs when compaction happens at all is `.claude/rules/moai/workflow/context-window-management.md` § Reduction Ladder.
+MoAI searches previous sessions when context is needed to continue work. **Search when**: user references past work without sufficient context, mentions a SPEC-ID not loaded, asks to resume/continue, or requests a find. **Skip when**: relevant SPEC/code is already in session, or duplication adds no value. **Process**: (1) check current session first; (2) confirm via AskUserQuestion; (3) Grep session index + transcripts in `~/.claude/projects/` (default 30-day window); (4) summarize + present for approval; (5) inject avoiding duplicates. **Token budget**: max 5,000 tokens per injection; skip if current usage exceeds 150,000; summarize lengthy conversations. Manual trigger available anytime; complements @MX TAG system. When compacting, always preserve modified/created files, verification commands + exit codes + evidence paths, active SPEC ID/phase, unresolved blockers, and any armed goal condition — load-bearing per `verification-claim-integrity.md` §2; reduction ladder: `context-window-management.md` § Reduction Ladder.
 
 ---
 
 ## 17. Troubleshooting
 
-When MoAI workflows behave unexpectedly, use Claude Code's built-in debug tools — `claude --debug "hooks"`, `claude --debug "api,hooks"`, `claude --debug "mcp"`, or the `/debug` command inside a session to inspect session state, hook logs, and tool traces.
-
-### Common Issues
+When MoAI workflows behave unexpectedly, use Claude Code's built-in debug tools — `claude --debug "hooks"`, `claude --debug "api,hooks"`, `claude --debug "mcp"`, or `/debug` inside a session to inspect session state, hook logs, and tool traces.
 
 | Symptom | Cause | Solution |
 |---------|-------|---------|
-| TeammateIdle hook blocks teammate | LSP errors exceed threshold | Fix errors, or set `enforce_quality: false` in quality.yaml |
-| Agent Teams messages not delivered | Session was resumed after interrupt | Spawn new teammates; old teammates are orphaned |
 | `moai hook subagent-stop` fails | Binary not in PATH | Run `which moai` to verify installation |
 | settings.json not updated after `moai update` | Conflict with user modifications | Run `moai update -t` for template-only sync |
 


### PR DESCRIPTION
## Summary

Diets `CLAUDE.md` from **337 → 181 lines** per the official <200-line guidance ("bloated CLAUDE.md files cause Claude to ignore instructions"), and fixes the agent-catalog count drift as a prerequisite. All changes are markdown-only (0 Go files).

## Changes

**Drift fix (prerequisite)** — `agent-authoring.md` + `agent-patterns.md` (main + template):
- `11/10 → 12 retained` (11 MoAI-custom + Explore); `manager-lead` added to enumerations + retention-ceiling refs, matching `CLAUDE.md` §4.

**CLAUDE.md diet (main + template, parity)**:
- §4: removed the verbose 12-agent catalog **table** (agent names preserved inline; routing via the decision tree + `delegation.yaml`). Condensed the nesting Watch note.
- §1/§5/§7/§9/§15/§16/§17: condensed duplicated/detailed content to one-line pointers.
- **Preserved verbatim** (CLAUDE.md-unique SSOT): §7 Rules 1-4 expansions (proportionality test, Ctrl+G), `@import`, token budgets (5,000 / 150,000).
- Template synced → `main ↔ template` identical; the one real SPEC-ID neutralized → **0 real SPEC/REQ matches** in the distributed template.

## Decisions (surfaced — 2 deviations from the plan)

- **§1 HARD list**: the plan proposed gutting it to a one-line pointer, but measurement showed only 3/6 distinctive rules live in `moai-constitution.md` (Approach-First / Reproduction-First / Deferred-Tool-Preload do not). Kept a condensed 3-bullet grouping instead of a single pointer.
- **Catalog table removal**: the plan's per-section line targets (§4→26) were arithmetically infeasible while preserving the table + decision tree + §7 Rules. Per maintainer decision, the table was cut to reach <200 (agent names + routing preserved via the decision tree + delegation.yaml).

## Verification

| check | result |
|---|---|
| `wc -l CLAUDE.md` ≤200 | **181** ✓ |
| `diff CLAUDE.md template` | identical ✓ |
| `make build` | exit 0 ✓ |
| template real SPEC/REQ/SHA | **0** ✓ |
| drift fix (12 retained + manager-lead) | ✓ |
| `go test ./internal/template/... ./internal/config/...` | all pass ✓ |
| embed in `bin/moai` | confirmed ✓ |

🗿 MoAI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated AI assistant guidance to reflect the expanded retained-agent catalog and revised routing rules.
  - Clarified the Analyze-First workflow, approval sequencing, tool requirements, nesting safeguards, and recovery procedures.
  - Consolidated orchestration, quality, configuration, search, MCP, concurrency, and troubleshooting guidance into centralized references.
  - Updated project templates so newly generated projects use the latest workflow and agent documentation.
  - Removed outdated, duplicated, and retired workflow guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->