### PR TITLE
feat(mcp): wire missing tools + add usage guidance

### DIFF
--- a/.claude/agents/moai/manager-develop.md
+++ b/.claude/agents/moai/manager-develop.md
@@ -211,6 +211,14 @@ When run-phase reveals a need to modify SPEC body content (e.g., a REQ wording i
 
 See `.claude/rules/moai/development/spec-frontmatter-schema.md` § Status Transition Ownership Matrix for the schema-level SSOT covering all 7 canonical transitions and the canonical commit subject patterns per transition.
 
+## MCP Tools
+
+This agent carries verification + goal MCP tools in its `tools:` list. Prefer the MCP tool over the equivalent Bash CLI (`moai verify check`, `moai goal status`):
+
+- `mcp__moai__verify_snapshot` — read or record the per-key verification snapshot (the evidence baseline for a claim). Call AFTER running a verification command to persist the observed output, keyed by HEAD:digest.
+- `mcp__moai__verify_trend` — read the per-key verification check history (the trend). Call to compare the current run vs prior runs.
+- `mcp__moai__goal_status` — read the armed-goal state for this session. Call to check whether an autonomous goal is armed and how close it is to convergence.
+
 ## Conditional Skill Loading
 
 Static `skills:` preload is kept to a minimum (token diet — progressive disclosure covers the rest); load the following skills on demand with the `Skill` tool:

--- a/.claude/agents/moai/manager-docs.md
+++ b/.claude/agents/moai/manager-docs.md
@@ -110,6 +110,13 @@ When sync-phase reveals a need to modify SPEC body content — for example: a sc
 
 See `.claude/rules/moai/development/spec-frontmatter-schema.md` § Status Transition Ownership Matrix for the schema-level SSOT covering all 7 canonical transitions and the canonical commit subject patterns per transition.
 
+## MCP Tools
+
+This agent carries SPEC-lifecycle MCP tools in its `tools:` list (prefer MCP over the Bash CLI):
+
+- `mcp__moai__spec_progress` — list SPEC documents + frontmatter under the project root. Call to inventory the SPEC catalog before sync.
+- `mcp__moai__spec_audit` — run the SPEC lifecycle audit (era classification + drift detection). Call to confirm drift-clean before closing a SPEC.
+
 ## Conditional Skill Loading
 
 Static `skills:` preload is kept to a minimum (token diet — progressive disclosure covers the rest); load the following skills on demand with the `Skill` tool:

--- a/.claude/agents/moai/manager-lead.md
+++ b/.claude/agents/moai/manager-lead.md
@@ -140,6 +140,13 @@ OUT OF SCOPE:
 - Domain consultation (backend / frontend / devops) → leaf worker spawned as `Agent(general-purpose)` with domain whitelist per `archived-agent-rejection.md` §C rows 7-10.
 - E1-E4 escalation → orchestrator spawns `super-advisor`; manager-lead returns its spawn-context to the orchestrator rather than self-escalating.
 
+## MCP Tools
+
+This agent carries session + goal MCP tools in its `tools:` list (prefer MCP over the Bash CLI):
+
+- `mcp__moai__session_list` — list active moai sessions (optionally filtered by SPEC). Call to detect concurrent sessions on the same SPEC before fanning out leaf workers (race avoidance).
+- `mcp__moai__goal_status` — read the armed-goal state. Call to check convergence status of an autonomous goal driving the multi-milestone run.
+
 ## Conditional Skill Loading
 
 Static `skills:` preload is kept to a minimum (token diet). Load on demand with the `Skill` tool:

--- a/.claude/agents/moai/manager-spec.md
+++ b/.claude/agents/moai/manager-spec.md
@@ -216,6 +216,14 @@ See `.claude/rules/moai/development/spec-frontmatter-schema.md` § Status Transi
 - Intermediate: Balanced explanations, confirm complex decisions only
 - Expert: Concise responses, auto-proceed with standard patterns
 
+## MCP Tools
+
+This agent carries SPEC-lifecycle MCP tools in its `tools:` list (prefer MCP over the Bash CLI):
+
+- `mcp__moai__spec_progress` — list SPEC documents + frontmatter. Call to inventory the catalog and pick the next SPEC.
+- `mcp__moai__spec_audit` — run the SPEC lifecycle audit (era classification + drift). Call to confirm a SPEC's era and close-debt status before authoring.
+- `mcp__moai__spec_drift` — read modern-era V3R6 drift findings. Call to confirm zero MUST-FIX drift before close.
+
 ## Conditional Skill Loading
 
 Static `skills:` preload is kept to a minimum (token diet — progressive disclosure covers the rest); load the following skills on demand with the `Skill` tool:

--- a/.claude/agents/moai/plan-auditor.md
+++ b/.claude/agents/moai/plan-auditor.md
@@ -4,7 +4,7 @@ description: |
   Independent plan-phase document auditor. Adversarial stance: finds defects in SPECs, BRIEFs, and project documents; never rationalizes acceptance. Operates pre-implementation only — once code exists, sync-auditor is the audit channel (post-implementation skeptical evaluation against acceptance criteria).
   Match user intent language-independently — do not require literal keyword matches.
   NOT for: post-implementation code audit (sync-auditor), code implementation, code review, documentation writing, git operations, running tests
-tools: Read, Grep, Glob, Bash, Write, Edit, TaskCreate, TaskUpdate, TaskList, TaskGet, Skill, mcp__moai__audit_multi, mcp__moai__spec_audit, mcp__moai__spec_drift, mcp__moai__codex_audit
+tools: Read, Grep, Glob, Bash, Write, Edit, TaskCreate, TaskUpdate, TaskList, TaskGet, Skill, mcp__moai__audit_multi, mcp__moai__spec_audit, mcp__moai__spec_drift, mcp__moai__codex_audit, mcp__moai__glm_audit
 model: inherit
 effort: medium
 color: red
@@ -160,6 +160,22 @@ Classify every non-must-pass finding as one of:
 Carry the classification in the `## Defects Found` list so the orchestrator can route on it: blocking findings are fixed before the verdict is revisited; optional findings are surfaced and left to the orchestrator's discretion.
 
 The verdict remains anchored to the M5 must-pass firewall and the rubric scores. **A long list of optional findings does not by itself justify a FAIL**, and it must not be used to manufacture one. Routing every optional finding into a revision produces speculative requirements, premature abstraction, and acceptance criteria for cases the SPEC never claimed — the same over-engineering the Enforce Simplicity core behavior forbids (`.claude/rules/moai/core/moai-constitution.md` § Agent Core Behaviors #4).
+
+## MCP Audit Tools (cross-model second opinion)
+
+This auditor carries single- and multi-backend audit MCP tools in its `tools:` list. Use them BEFORE reaching the primary verdict when the project config requests a cross-backend second opinion:
+
+- `mcp__moai__audit_multi` — multi-auditor convergence engine (claude anchor + optional codex/glm backends). Default path when `audit_model: multi`.
+- `mcp__moai__codex_audit` — codex-backend single audit (`native` or `adversarial` mode).
+- `mcp__moai__glm_audit` — GLM (z.ai) backend single audit.
+
+Single-backend audit mode (per the project's `audit_model`):
+- `codex+glm` (default) — converge both backends via `mcp__moai__audit_multi`; most robust.
+- `glm` — GLM only; call `mcp__moai__glm_audit` directly.
+- `codex` — codex only; call `mcp__moai__codex_audit` directly.
+- `none` — Claude-only audit (the classic plan-auditor role); no MCP backend call.
+
+All backends are fail-open: when a backend is unavailable, its tool returns `inconclusive` (never a Go error), so a missing codex/glm never blocks the audit.
 
 ## Verification Execution Mandate
 

--- a/.claude/agents/moai/super-advisor.md
+++ b/.claude/agents/moai/super-advisor.md
@@ -10,7 +10,7 @@ description: |
   second opinion before an irreversible delegation or escalation.
   Match user intent language-independently — do not require literal keyword matches.
   NOT for: gate verdicts (plan-auditor/sync-auditor own binding PASS/FAIL judgment); NOT for: implementation (use manager-develop); NOT for: SPEC body authoring (use manager-spec)
-tools: Read, Grep, Glob, Bash, WebFetch, Skill, TaskCreate, TaskUpdate, TaskList, TaskGet, mcp__moai__spec_audit, mcp__moai__verify_trend
+tools: Read, Grep, Glob, Bash, WebFetch, Skill, TaskCreate, TaskUpdate, TaskList, TaskGet, mcp__moai__spec_audit, mcp__moai__verify_trend, mcp__moai__codex_task, mcp__moai__codex_setup, mcp__moai__codex_job_status, mcp__moai__codex_job_result, mcp__moai__codex_job_cancel
 model: inherit
 effort: high
 color: yellow
@@ -93,6 +93,25 @@ A super-advisor prescription is structured:
 
 The orchestrator reads the prescription, may accept / modify / reject it, and owns the
 resulting decision.
+
+## MCP Tools
+
+This agent carries SPEC, verification, and codex-delegation MCP tools in its `tools:` list (prefer MCP over the Bash CLI):
+
+- `mcp__moai__spec_audit` — SPEC lifecycle audit (era + drift). Call to ground a prescription in the SPEC's actual lifecycle state.
+- `mcp__moai__verify_trend` — per-key verification check history. Call to see whether a verification dimension is improving or regressing.
+
+### Codex delegation (background second opinion)
+
+This agent is the natural consumer of the codex delegation family — background cross-model delegation for a high-reasoning second opinion:
+
+- `mcp__moai__codex_setup` — probe the local codex install (LookPath + version + auth provider). Call FIRST to confirm codex is available before delegating.
+- `mcp__moai__codex_task` — delegate a coding or investigation task to codex (sync or background). Use for a second opinion the orchestrator folds into its prescription.
+- `mcp__moai__codex_job_status` — read a background codex job's status/record. Poll until terminal.
+- `mcp__moai__codex_job_result` — read a background codex job's completed output.
+- `mcp__moai__codex_job_cancel` — stop a running background codex job (turn/interrupt, then terminate if needed).
+
+codex is OPTIONAL and fail-open: when unavailable, `codex_setup` reports absent and `codex_task` yields `inconclusive` (never a Go error). Never block a prescription on codex availability.
 
 ## Conditional Skill Loading
 

--- a/.claude/agents/moai/sync-auditor.md
+++ b/.claude/agents/moai/sync-auditor.md
@@ -6,7 +6,7 @@ description: |
   Operates post-implementation only — once code exists and acceptance criteria are testable. Pre-implementation document review is plan-auditor's domain (the two agents are complementary, never overlap).
   Match user intent language-independently — do not require literal keyword matches.
   NOT for: SPEC plan-phase audit (that is plan-auditor's domain; sync-auditor is post-implementation only), code implementation, architecture design, documentation writing, git operations
-tools: Read, Grep, Glob, Bash, TaskCreate, TaskUpdate, TaskList, TaskGet, Skill, mcp__moai__audit_multi, mcp__moai__verify_trend, mcp__moai__audit_cache, mcp__moai__glm_audit
+tools: Read, Grep, Glob, Bash, TaskCreate, TaskUpdate, TaskList, TaskGet, Skill, mcp__moai__audit_multi, mcp__moai__verify_trend, mcp__moai__audit_cache, mcp__moai__glm_audit, mcp__moai__codex_audit
 model: inherit
 effort: medium
 color: red
@@ -139,6 +139,22 @@ The contract carries per-criterion state: `passed` (met in a previous iteration 
 The former opt-in nesting pilot (this agent carrying `Agent` in `tools`, with flat shipped behavior resting on the runtime depth-env default being off) is **retired**. On Claude Code v2.1.219+ subagent nesting is enabled by default (changelog-sourced), and the spawn-time permission-mode parameter is deprecated and ignored since v2.1.213 (changelog/doc-sourced, not runtime-observed) — so both of the pilot's safety premises (shipped-default-flat via the env default; read-only children via the spawn-time mode parameter) no longer hold. `Agent` is removed from this agent's `tools` frontmatter, restoring the flat-hierarchy guarantee by tool omission — the same sole guarantee every other retained agent relies on. Read-only child scoping, where ever needed at the orchestrator level, rests on tool restriction (`Explore`, or a `tools:` list omitting Write/Edit), never on the deprecated spawn-time permission-mode parameter.
 
 Evidence gathering for the 4 scoring dimensions runs sequentially within this agent. The user-interaction boundary is unchanged: no `sync-auditor` path invokes `AskUserQuestion` or `mcp__askuser`.
+
+## MCP Audit Tools (cross-model second opinion)
+
+This auditor carries single- and multi-backend audit MCP tools in its `tools:` list. Use them before scoring when the project config requests a cross-backend second opinion:
+
+- `mcp__moai__audit_multi` — multi-auditor convergence engine (claude anchor + optional codex/glm backends). Default path when `audit_model: multi`.
+- `mcp__moai__codex_audit` — codex-backend single audit (`native` or `adversarial` mode).
+- `mcp__moai__glm_audit` — GLM (z.ai) backend single audit.
+
+Single-backend audit mode (per the project's `audit_model`):
+- `codex+glm` (default) — converge both backends via `mcp__moai__audit_multi`; most robust.
+- `glm` — GLM only; call `mcp__moai__glm_audit` directly.
+- `codex` — codex only; call `mcp__moai__codex_audit` directly.
+- `none` — Claude-only audit (the classic sync-auditor role); no MCP backend call.
+
+All backends are fail-open: when a backend is unavailable, its tool returns `inconclusive` (never a Go error), so a missing codex/glm never blocks the audit.
 
 ## Conditional Skill Loading
 

--- a/.claude/rules/moai/core/agent-common-protocol.md
+++ b/.claude/rules/moai/core/agent-common-protocol.md
@@ -270,6 +270,8 @@ Avoid:
 | Run system commands | Bash | — |
 | Explore codebase | Agent(Explore) | Multiple sequential Grep calls |
 
+**MCP-over-CLI preference**: where an `mcp__moai__*` tool exists for a capability already in the agent's `tools:` list (e.g. `mcp__moai__spec_audit`, `mcp__moai__verify_snapshot`, `mcp__moai__session_list`), the agent SHOULD prefer the MCP tool over the equivalent Bash CLI (`moai spec audit`, `moai verify check`, `moai session list`). Both back the same implementation; the MCP path returns structured output, avoids shell-quoting hazards, and is lower-latency inside a subagent where Bash may be restricted. Use the Bash CLI only when the MCP tool is absent or the capability is not in the agent's `tools:` list. Full tool catalogue + consumers: `.claude/rules/moai/core/moai-mcp-tools.md`.
+
 ### Bash Timeout
 
 The Bash tool supports an optional `timeout` parameter (milliseconds):

--- a/.claude/rules/moai/core/moai-mcp-tools.md
+++ b/.claude/rules/moai/core/moai-mcp-tools.md
@@ -1,0 +1,88 @@
+# moai-mcp Tool Catalogue
+
+> Single source of truth for the 17 tools exposed by the self-hosted `moai` MCP
+> server (`.mcp.json` → `{command: "moai", args: ["mcp-server"]}`). Each tool is
+> prefixed `mcp__moai__` at the call site. This rule tells agents and the
+> orchestrator WHEN to prefer an MCP tool over its CLI/slash equivalent.
+>
+> Wiring parity (local ↔ template) and per-agent `tools:` lists are owned by the
+> agent definitions; this file owns the capability map + the MCP-over-CLI rule.
+
+## MCP-over-CLI rule
+
+Prefer the MCP tool when it is in the calling agent's `tools:` list. The MCP path
+and the Bash CLI back the SAME implementation; the MCP path returns structured
+output, avoids shell-quoting hazards, and is lower-latency inside a subagent
+where Bash may be restricted. Use the Bash CLI only when the MCP tool is absent
+from the agent's `tools:` list, or when orchestrating from the main session and
+the CLI form reads more naturally inline.
+
+## Tool catalogue (17 tools)
+
+### SPEC lifecycle
+
+| Tool | Purpose | Consumer | CLI equivalent |
+|------|---------|----------|----------------|
+| `mcp__moai__spec_progress` | List SPEC docs + frontmatter | manager-spec, manager-docs | `moai spec list` |
+| `mcp__moai__spec_audit` | SPEC lifecycle audit (era + drift) | manager-spec, manager-docs, plan-auditor, super-advisor | `moai spec audit` |
+| `mcp__moai__spec_drift` | Modern-era V3R6 drift findings | manager-spec, plan-auditor | `moai spec audit` (drift view) |
+
+### Verification snapshots
+
+| Tool | Purpose | Consumer | CLI equivalent |
+|------|---------|----------|----------------|
+| `mcp__moai__verify_snapshot` | Read/record per-key verification snapshot | manager-develop | `moai verify check` |
+| `mcp__moai__verify_trend` | Per-key verification check history | manager-develop, sync-auditor, super-advisor | `moai verify check` |
+
+### Goal + session (autonomous loop)
+
+| Tool | Purpose | Consumer | CLI equivalent |
+|------|---------|----------|----------------|
+| `mcp__moai__goal_arm` | Arm a condition-declared goal | **orchestrator main session ONLY** — wired to NO agent (arming an autonomous loop is an orchestrator concern) | `moai goal arm` / `/moai goal` |
+| `mcp__moai__goal_status` | Read armed-goal state | manager-develop, manager-lead | `moai goal status` |
+| `mcp__moai__session_list` | List active moai sessions | manager-lead | `moai session list` |
+
+### Cross-model audit (second opinion)
+
+| Tool | Purpose | Consumer | CLI equivalent |
+|------|---------|----------|----------------|
+| `mcp__moai__audit_multi` | Multi-auditor convergence (claude + codex + glm) | plan-auditor, sync-auditor | — (MCP-only convergence entry) |
+| `mcp__moai__codex_audit` | codex backend single audit (native/adversarial) | plan-auditor, sync-auditor | — |
+| `mcp__moai__glm_audit` | GLM (z.ai) backend single audit | plan-auditor, sync-auditor | — |
+| `mcp__moai__audit_cache` | plan-audit PASS cache (compute_hash/lookup/store, process-shared) | sync-auditor | `moai audit cache` (none — MCP-only) |
+
+Single-backend audit mode is selected per the project's `audit_model`:
+`codex+glm` (default, converge via `audit_multi`) | `glm` | `codex` | `none`
+(Claude-only, no backend call). All backends are fail-open: an unavailable
+backend returns `inconclusive`, never a Go error.
+
+### Codex delegation (background jobs)
+
+| Tool | Purpose | Consumer | CLI equivalent |
+|------|---------|----------|----------------|
+| `mcp__moai__codex_task` | Delegate a coding/investigation task to codex (sync or background) | super-advisor | `moai codex task` |
+| `mcp__moai__codex_setup` | Probe local codex install (LookPath + version + auth) | super-advisor | `moai codex setup` |
+| `mcp__moai__codex_job_status` | Read a background codex job's status/record | super-advisor | `moai codex job status` |
+| `mcp__moai__codex_job_result` | Read a background codex job's output | super-advisor | `moai codex job result` |
+| `mcp__moai__codex_job_cancel` | Stop a running background codex job | super-advisor | `moai codex job cancel` |
+
+The codex delegation family is wired into `super-advisor` because the on-demand
+high-reasoning consultation agent is the natural consumer of background
+cross-model delegation: it arms a codex task via `codex_task`, polls completion
+via `codex_job_status`/`codex_job_result`, and cancels via `codex_job_cancel`.
+`codex_setup` probes whether codex is available before delegating. codex is
+OPTIONAL: a missing or unavailable codex yields a fail-open `inconclusive`, never
+a hard error.
+
+## Unwired-by-design
+
+`goal_arm` is intentionally wired to NO agent. Arming an autonomous loop is an
+orchestrator concern (preserves the orchestrator-only arming surface and the
+flat hierarchy invariant). Agents that need a goal's state read `goal_status`;
+only the orchestrator arms.
+
+---
+
+Classification: Evolvable reference rule — the MCP tool surface map. Update this
+file whenever a tool is added/removed/renamed on the `moai mcp-server` (the Go
+producer lives in `internal/cli/mcp_server.go`).

--- a/internal/cli/mcp_server.go
+++ b/internal/cli/mcp_server.go
@@ -196,12 +196,13 @@ func registerMoaiMCPTools(s *server.MCPServer, projectDir string) {
 	// --- audit_cache → runtime.AuditCache (audit_cache.go:50) ---
 	add("audit_cache", mcp.NewTool(
 		"audit_cache",
-		mcp.WithDescription("Operate the plan-audit PASS cache (read-only reuse): compute_hash a SPEC dir, or lookup a cached verdict. Wraps runtime.AuditCache ComputeHash/Lookup."),
-		mcp.WithString("op", mcp.Required(), mcp.Description("Operation: 'compute_hash' or 'lookup'.")),
+		mcp.WithDescription("Operate the plan-audit PASS cache (process-shared): compute_hash a SPEC dir, lookup a cached verdict, or store a PASS verdict. Wraps runtime.AuditCache ComputeHash/Lookup/Store. NOTE: cache is in-memory per moai mcp-server process; the plan-audit gate (separate process) does not populate it."),
+		mcp.WithString("op", mcp.Required(), mcp.Description("Operation: 'compute_hash', 'lookup', or 'store'.")),
 		mcp.WithString("spec_dir", mcp.Description("SPEC directory (for op=compute_hash).")),
-		mcp.WithString("spec_id", mcp.Description("SPEC id (for op=lookup).")),
-		mcp.WithString("hash", mcp.Description("Plan-artifact hash (for op=lookup).")),
-		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithString("spec_id", mcp.Description("SPEC id (for op=lookup, op=store).")),
+		mcp.WithString("hash", mcp.Description("Plan-artifact hash (for op=lookup, op=store).")),
+		mcp.WithString("auditor_version", mcp.Description("Auditor identifier (for op=store).")),
+		mcp.WithString("report_path", mcp.Description("Audit report path (for op=store).")),
 	), handleAuditCache)
 
 	// --- M2 codex backend (design.md §3 M2) ---
@@ -550,10 +551,23 @@ func handleSpecDrift(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolRes
 	}), nil
 }
 
-// handleAuditCache wraps runtime.AuditCache ComputeHash/Lookup (audit_cache.go).
-// The cache is in-memory, per server process (read-only reuse — design.md §3).
+// moaiAuditCache is the process-shared AuditCache backing the audit_cache MCP
+// tool. It persists across calls within ONE moai mcp-server process so that a
+// store in one call is visible to a lookup in a later call (the prior per-call
+// NewInMemoryCache made lookup ALWAYS return hit:false).
+//
+// @MX:DEBT: single-process in-memory cache only
+// @MX:CEILING: single moai mcp-server process lifetime, sequential calls
+// @MX:UPGRADE: the plan-audit gate (audit_gate.go) runs in a separate /moai run
+//   process and does NOT populate this cache; true cross-process verdict reuse
+//   requires lookup to read the durable daily-report cache (AuditReporter).
+// @MX:REASON: [AUTO] fan_in >= 3 (compute_hash/lookup/store ops + tests)
+var moaiAuditCache = runtime.NewInMemoryCache()
+
+// handleAuditCache wraps runtime.AuditCache ComputeHash/Lookup/Store over the
+// process-shared moaiAuditCache. The store op lets a caller record a PASS
+// verdict that a later lookup (same moai mcp-server process) returns as a hit.
 func handleAuditCache(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	cache := runtime.NewInMemoryCache()
 	op := req.GetString("op", "")
 	switch op {
 	case "compute_hash":
@@ -561,7 +575,7 @@ func handleAuditCache(_ context.Context, req mcp.CallToolRequest) (*mcp.CallTool
 		if specDir == "" {
 			return toolErr("audit_cache", fmt.Errorf("op=compute_hash requires spec_dir")), nil
 		}
-		hash, err := cache.ComputeHash(specDir)
+		hash, err := moaiAuditCache.ComputeHash(specDir)
 		if err != nil {
 			return toolErr("audit_cache", err), nil
 		}
@@ -569,10 +583,25 @@ func handleAuditCache(_ context.Context, req mcp.CallToolRequest) (*mcp.CallTool
 	case "lookup":
 		specID := req.GetString("spec_id", "")
 		hash := req.GetString("hash", "")
-		entry, ok := cache.Lookup(specID, hash, time.Now())
+		entry, ok := moaiAuditCache.Lookup(specID, hash, time.Now())
 		return toolJSON("audit_cache", map[string]any{"op": op, "hit": ok, "entry": entry}), nil
+	case "store":
+		// Record a PASS verdict so a later lookup (same process) returns a hit.
+		// Only PASS verdicts are cached (audit_cache.go Store guards on VerdictPass).
+		specID := req.GetString("spec_id", "")
+		hash := req.GetString("hash", "")
+		if specID == "" || hash == "" {
+			return toolErr("audit_cache", fmt.Errorf("op=store requires spec_id and hash")), nil
+		}
+		moaiAuditCache.Store(specID, hash, &runtime.AuditResult{
+			Verdict:        runtime.VerdictPass,
+			AuditAt:        time.Now(),
+			AuditorVersion: req.GetString("auditor_version", ""),
+			ReportPath:     req.GetString("report_path", ""),
+		})
+		return toolJSON("audit_cache", map[string]any{"op": op, "stored": true, "spec_id": specID, "hash": hash}), nil
 	default:
-		return toolErr("audit_cache", fmt.Errorf("unknown op %q (want compute_hash|lookup)", op)), nil
+		return toolErr("audit_cache", fmt.Errorf("unknown op %q (want compute_hash|lookup|store)", op)), nil
 	}
 }
 

--- a/internal/cli/mcp_server_test.go
+++ b/internal/cli/mcp_server_test.go
@@ -350,6 +350,76 @@ func TestMoaiMCPServer_ErrorPaths(t *testing.T) {
 	}
 }
 
+// TestMoaiMCPServer_AuditCacheStoreLookup proves the process-shared cache works
+// end-to-end: lookup before store misses, store records a PASS verdict, and
+// lookup after store hits. This is the regression guard for the prior defect
+// where handleAuditCache created a fresh InMemoryCache per call and lookup
+// ALWAYS returned hit:false (CODE-01).
+func TestMoaiMCPServer_AuditCacheStoreLookup(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("CLAUDE_PROJECT_DIR", tmp)
+
+	srv := newMoaiMCPServer()
+	ctx := context.Background()
+	c, err := client.NewInProcessClient(srv)
+	if err != nil {
+		t.Fatalf("NewInProcessClient: %v", err)
+	}
+	defer closeInProcessClient(c)
+	if _, err := c.Initialize(ctx, mcp.InitializeRequest{}); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+
+	// Unique key so the process-shared cache is not polluted by other tests.
+	const sid, h = "SPEC-HIT-DEMO-001", "deadbeef"
+
+	// lookup before store → must miss (no stale PASS recorded).
+	resMiss, err := c.CallTool(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{Name: "audit_cache", Arguments: map[string]any{"op": "lookup", "spec_id": sid, "hash": h}},
+	})
+	if err != nil || resMiss == nil || resMiss.IsError {
+		t.Fatalf("lookup-before-store: err=%v res=%v", err, resMiss)
+	}
+	if m := auditCacheJSON(t, resMiss); m["hit"] != false {
+		t.Errorf("lookup before store: expected hit=false, got %v", m["hit"])
+	}
+
+	// store a PASS verdict.
+	resStore, err := c.CallTool(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{Name: "audit_cache", Arguments: map[string]any{"op": "store", "spec_id": sid, "hash": h, "auditor_version": "plan-auditor", "report_path": "/tmp/r.md"}},
+	})
+	if err != nil || resStore == nil || resStore.IsError {
+		t.Fatalf("store: err=%v res=%v", err, resStore)
+	}
+
+	// lookup after store → must HIT (proves the shared cache works end-to-end).
+	resHit, err := c.CallTool(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{Name: "audit_cache", Arguments: map[string]any{"op": "lookup", "spec_id": sid, "hash": h}},
+	})
+	if err != nil || resHit == nil || resHit.IsError {
+		t.Fatalf("lookup-after-store: err=%v res=%v", err, resHit)
+	}
+	if m := auditCacheJSON(t, resHit); m["hit"] != true {
+		t.Errorf("lookup after store: expected hit=true (shared cache broken), got %v", m["hit"])
+	}
+}
+
+// auditCacheJSON extracts the structured object an audit_cache handler returned.
+// toolJSON uses mcp.NewToolResultStructured, so the payload lives in
+// StructuredContent (the text Content is just a "<tool>: ok" fallback).
+func auditCacheJSON(t *testing.T, res *mcp.CallToolResult) map[string]any {
+	t.Helper()
+	b, err := json.Marshal(res.StructuredContent)
+	if err != nil {
+		t.Fatalf("audit_cache: marshal structured %v: %v", res.StructuredContent, err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("audit_cache: unmarshal %s: %v", string(b), err)
+	}
+	return m
+}
+
 // TestMoaiMCPServer_BranchCoverage closes the remaining handler branches toward
 // the mcp_server.go ≥85% coverage target (E3): the verify_snapshot record path,
 // the goal_arm error/reject branches, and the goal_status empty-session fallback.

--- a/internal/template/catalog.yaml
+++ b/internal/template/catalog.yaml
@@ -102,17 +102,17 @@ catalog:
             - name: sync-auditor
               tier: core
               path: templates/.claude/agents/moai/sync-auditor.md
-              hash: dfe6158e740aa69eaf2a3823d38c8ff3ba8e7e47852bf74f5deb6a290d8d5b94
+              hash: a501f340ca3181feaeab56104fa56319650f066a8e0cdd5172f50c637be17607
               version: 1.0.0
             - name: manager-develop
               tier: core
               path: templates/.claude/agents/moai/manager-develop.md
-              hash: e74e29fd9be9541b115bd8370f9d2cbb9aba26b3e258526d968b965984b5d68d
+              hash: 7872f2400dde416da12dc6c9d7842c1b2778798ced25d10c5a36ecff2c0bd90e
               version: 1.0.0
             - name: manager-docs
               tier: core
               path: templates/.claude/agents/moai/manager-docs.md
-              hash: f11fbd534b54b3cacb73995814757b6cdd8a9dd9be88f7a5f417212ce93ffc58
+              hash: 27d6252a33131be637294ddced274213bb817012747731d08844becd7a3b7954
               version: 1.0.0
             - name: manager-git
               tier: core
@@ -122,22 +122,22 @@ catalog:
             - name: manager-lead
               tier: core
               path: templates/.claude/agents/moai/manager-lead.md
-              hash: de3ad0406df0c93757bb80106915b8854cf01b38208167e5e70e38938637beae
+              hash: ae431d953c9c6afd1e8731cb7c067b37b52e0289cc63831f317b63e2b86e85c5
               version: 1.0.0
             - name: manager-spec
               tier: core
               path: templates/.claude/agents/moai/manager-spec.md
-              hash: 738069d7bf362b62a8314906b53660735ed1ec64459b1a481282dfd7dc9d8c80
+              hash: 96b4099da6b52fc895136d27ed7647ff80e0824a81002e18d5326523f0d7edd9
               version: 1.0.0
             - name: plan-auditor
               tier: core
               path: templates/.claude/agents/moai/plan-auditor.md
-              hash: 6c65d50b8ab26bd382601c472a6342a38d0a2d7c910d5e4122e92d6c0e850fd4
+              hash: af86f96e11937e394212db7726b41424c7e2366f5b7e2089b54e6e10b0faa324
               version: 1.0.0
             - name: super-advisor
               tier: core
               path: templates/.claude/agents/moai/super-advisor.md
-              hash: d532a648857ccba5c00f03da88e5f120a3362c4f2f31751acdb252b34d894111
+              hash: 22c2f7df94abe0dfd3935b2db793703acc16c1f0d5673b4d28b8edbd5f0652af
               version: 1.0.0
             - name: manager-design
               tier: core

--- a/internal/template/templates/.claude/agents/moai/manager-develop.md
+++ b/internal/template/templates/.claude/agents/moai/manager-develop.md
@@ -212,6 +212,14 @@ When run-phase reveals a need to modify SPEC body content (e.g., a REQ wording i
 
 See `.claude/rules/moai/development/spec-frontmatter-schema.md` § Status Transition Ownership Matrix for the schema-level SSOT covering all 7 canonical transitions and the canonical commit subject patterns per transition.
 
+## MCP Tools
+
+This agent carries verification + goal MCP tools in its `tools:` list. Prefer the MCP tool over the equivalent Bash CLI (`moai verify check`, `moai goal status`):
+
+- `mcp__moai__verify_snapshot` — read or record the per-key verification snapshot (the evidence baseline for a claim). Call AFTER running a verification command to persist the observed output, keyed by HEAD:digest.
+- `mcp__moai__verify_trend` — read the per-key verification check history (the trend). Call to compare the current run vs prior runs.
+- `mcp__moai__goal_status` — read the armed-goal state for this session. Call to check whether an autonomous goal is armed and how close it is to convergence.
+
 ## Conditional Skill Loading
 
 Static `skills:` preload is kept to a minimum (token diet — progressive disclosure covers the rest); load the following skills on demand with the `Skill` tool:

--- a/internal/template/templates/.claude/agents/moai/manager-docs.md
+++ b/internal/template/templates/.claude/agents/moai/manager-docs.md
@@ -110,6 +110,13 @@ When sync-phase reveals a need to modify SPEC body content — for example: a sc
 
 See `.claude/rules/moai/development/spec-frontmatter-schema.md` § Status Transition Ownership Matrix for the schema-level SSOT covering all 7 canonical transitions and the canonical commit subject patterns per transition.
 
+## MCP Tools
+
+This agent carries SPEC-lifecycle MCP tools in its `tools:` list (prefer MCP over the Bash CLI):
+
+- `mcp__moai__spec_progress` — list SPEC documents + frontmatter under the project root. Call to inventory the SPEC catalog before sync.
+- `mcp__moai__spec_audit` — run the SPEC lifecycle audit (era classification + drift detection). Call to confirm drift-clean before closing a SPEC.
+
 ## Conditional Skill Loading
 
 Static `skills:` preload is kept to a minimum (token diet — progressive disclosure covers the rest); load the following skills on demand with the `Skill` tool:

--- a/internal/template/templates/.claude/agents/moai/manager-lead.md
+++ b/internal/template/templates/.claude/agents/moai/manager-lead.md
@@ -140,6 +140,13 @@ OUT OF SCOPE:
 - Domain consultation (backend / frontend / devops) → leaf worker spawned as `Agent(general-purpose)` with domain whitelist per `archived-agent-rejection.md` §C rows 7-10.
 - E1-E4 escalation → orchestrator spawns `super-advisor`; manager-lead returns its spawn-context to the orchestrator rather than self-escalating.
 
+## MCP Tools
+
+This agent carries session + goal MCP tools in its `tools:` list (prefer MCP over the Bash CLI):
+
+- `mcp__moai__session_list` — list active moai sessions (optionally filtered by SPEC). Call to detect concurrent sessions on the same SPEC before fanning out leaf workers (race avoidance).
+- `mcp__moai__goal_status` — read the armed-goal state. Call to check convergence status of an autonomous goal driving the multi-milestone run.
+
 ## Conditional Skill Loading
 
 Static `skills:` preload is kept to a minimum (token diet). Load on demand with the `Skill` tool:

--- a/internal/template/templates/.claude/agents/moai/manager-spec.md
+++ b/internal/template/templates/.claude/agents/moai/manager-spec.md
@@ -216,6 +216,14 @@ See `.claude/rules/moai/development/spec-frontmatter-schema.md` § Status Transi
 - Intermediate: Balanced explanations, confirm complex decisions only
 - Expert: Concise responses, auto-proceed with standard patterns
 
+## MCP Tools
+
+This agent carries SPEC-lifecycle MCP tools in its `tools:` list (prefer MCP over the Bash CLI):
+
+- `mcp__moai__spec_progress` — list SPEC documents + frontmatter. Call to inventory the catalog and pick the next SPEC.
+- `mcp__moai__spec_audit` — run the SPEC lifecycle audit (era classification + drift). Call to confirm a SPEC's era and close-debt status before authoring.
+- `mcp__moai__spec_drift` — read modern-era V3R6 drift findings. Call to confirm zero MUST-FIX drift before close.
+
 ## Conditional Skill Loading
 
 Static `skills:` preload is kept to a minimum (token diet — progressive disclosure covers the rest); load the following skills on demand with the `Skill` tool:

--- a/internal/template/templates/.claude/agents/moai/plan-auditor.md
+++ b/internal/template/templates/.claude/agents/moai/plan-auditor.md
@@ -4,7 +4,7 @@ description: |
   Independent plan-phase document auditor. Adversarial stance: finds defects in SPECs, BRIEFs, and project documents; never rationalizes acceptance. Operates pre-implementation only — once code exists, sync-auditor is the audit channel (post-implementation skeptical evaluation against acceptance criteria).
   Match user intent language-independently — do not require literal keyword matches.
   NOT for: post-implementation code audit (sync-auditor), code implementation, code review, documentation writing, git operations, running tests
-tools: Read, Grep, Glob, Bash, Write, Edit, TaskCreate, TaskUpdate, TaskList, TaskGet, Skill, mcp__moai__audit_multi, mcp__moai__spec_audit, mcp__moai__spec_drift, mcp__moai__codex_audit
+tools: Read, Grep, Glob, Bash, Write, Edit, TaskCreate, TaskUpdate, TaskList, TaskGet, Skill, mcp__moai__audit_multi, mcp__moai__spec_audit, mcp__moai__spec_drift, mcp__moai__codex_audit, mcp__moai__glm_audit
 model: inherit
 effort: medium
 color: red
@@ -160,6 +160,22 @@ Classify every non-must-pass finding as one of:
 Carry the classification in the `## Defects Found` list so the orchestrator can route on it: blocking findings are fixed before the verdict is revisited; optional findings are surfaced and left to the orchestrator's discretion.
 
 The verdict remains anchored to the M5 must-pass firewall and the rubric scores. **A long list of optional findings does not by itself justify a FAIL**, and it must not be used to manufacture one. Routing every optional finding into a revision produces speculative requirements, premature abstraction, and acceptance criteria for cases the SPEC never claimed — the same over-engineering the Enforce Simplicity core behavior forbids (`.claude/rules/moai/core/moai-constitution.md` § Agent Core Behaviors #4).
+
+## MCP Audit Tools (cross-model second opinion)
+
+This auditor carries single- and multi-backend audit MCP tools in its `tools:` list. Use them BEFORE reaching the primary verdict when the project config requests a cross-backend second opinion:
+
+- `mcp__moai__audit_multi` — multi-auditor convergence engine (claude anchor + optional codex/glm backends). Default path when `audit_model: multi`.
+- `mcp__moai__codex_audit` — codex-backend single audit (`native` or `adversarial` mode).
+- `mcp__moai__glm_audit` — GLM (z.ai) backend single audit.
+
+Single-backend audit mode (per the project's `audit_model`):
+- `codex+glm` (default) — converge both backends via `mcp__moai__audit_multi`; most robust.
+- `glm` — GLM only; call `mcp__moai__glm_audit` directly.
+- `codex` — codex only; call `mcp__moai__codex_audit` directly.
+- `none` — Claude-only audit (the classic plan-auditor role); no MCP backend call.
+
+All backends are fail-open: when a backend is unavailable, its tool returns `inconclusive` (never a Go error), so a missing codex/glm never blocks the audit.
 
 ## Verification Execution Mandate
 

--- a/internal/template/templates/.claude/agents/moai/super-advisor.md
+++ b/internal/template/templates/.claude/agents/moai/super-advisor.md
@@ -10,7 +10,7 @@ description: |
   second opinion before an irreversible delegation or escalation.
   Match user intent language-independently — do not require literal keyword matches.
   NOT for: gate verdicts (plan-auditor/sync-auditor own binding PASS/FAIL judgment); NOT for: implementation (use manager-develop); NOT for: SPEC body authoring (use manager-spec)
-tools: Read, Grep, Glob, Bash, WebFetch, Skill, TaskCreate, TaskUpdate, TaskList, TaskGet, mcp__moai__spec_audit, mcp__moai__verify_trend
+tools: Read, Grep, Glob, Bash, WebFetch, Skill, TaskCreate, TaskUpdate, TaskList, TaskGet, mcp__moai__spec_audit, mcp__moai__verify_trend, mcp__moai__codex_task, mcp__moai__codex_setup, mcp__moai__codex_job_status, mcp__moai__codex_job_result, mcp__moai__codex_job_cancel
 model: inherit
 effort: high
 color: yellow
@@ -93,6 +93,25 @@ A super-advisor prescription is structured:
 
 The orchestrator reads the prescription, may accept / modify / reject it, and owns the
 resulting decision.
+
+## MCP Tools
+
+This agent carries SPEC, verification, and codex-delegation MCP tools in its `tools:` list (prefer MCP over the Bash CLI):
+
+- `mcp__moai__spec_audit` — SPEC lifecycle audit (era + drift). Call to ground a prescription in the SPEC's actual lifecycle state.
+- `mcp__moai__verify_trend` — per-key verification check history. Call to see whether a verification dimension is improving or regressing.
+
+### Codex delegation (background second opinion)
+
+This agent is the natural consumer of the codex delegation family — background cross-model delegation for a high-reasoning second opinion:
+
+- `mcp__moai__codex_setup` — probe the local codex install (LookPath + version + auth provider). Call FIRST to confirm codex is available before delegating.
+- `mcp__moai__codex_task` — delegate a coding or investigation task to codex (sync or background). Use for a second opinion the orchestrator folds into its prescription.
+- `mcp__moai__codex_job_status` — read a background codex job's status/record. Poll until terminal.
+- `mcp__moai__codex_job_result` — read a background codex job's completed output.
+- `mcp__moai__codex_job_cancel` — stop a running background codex job (turn/interrupt, then terminate if needed).
+
+codex is OPTIONAL and fail-open: when unavailable, `codex_setup` reports absent and `codex_task` yields `inconclusive` (never a Go error). Never block a prescription on codex availability.
 
 ## Conditional Skill Loading
 

--- a/internal/template/templates/.claude/agents/moai/sync-auditor.md
+++ b/internal/template/templates/.claude/agents/moai/sync-auditor.md
@@ -6,7 +6,7 @@ description: |
   Operates post-implementation only — once code exists and acceptance criteria are testable. Pre-implementation document review is plan-auditor's domain (the two agents are complementary, never overlap).
   Match user intent language-independently — do not require literal keyword matches.
   NOT for: SPEC plan-phase audit (that is plan-auditor's domain; sync-auditor is post-implementation only), code implementation, architecture design, documentation writing, git operations
-tools: Read, Grep, Glob, Bash, TaskCreate, TaskUpdate, TaskList, TaskGet, Skill, mcp__moai__audit_multi, mcp__moai__verify_trend, mcp__moai__audit_cache, mcp__moai__glm_audit
+tools: Read, Grep, Glob, Bash, TaskCreate, TaskUpdate, TaskList, TaskGet, Skill, mcp__moai__audit_multi, mcp__moai__verify_trend, mcp__moai__audit_cache, mcp__moai__glm_audit, mcp__moai__codex_audit
 model: inherit
 effort: medium
 color: red
@@ -139,6 +139,22 @@ The contract carries per-criterion state: `passed` (met in a previous iteration 
 The former opt-in nesting pilot (this agent carrying `Agent` in `tools`, with flat shipped behavior resting on the runtime depth-env default being off) is **retired**. On Claude Code v2.1.219+ subagent nesting is enabled by default (changelog-sourced), and the spawn-time permission-mode parameter is deprecated and ignored since v2.1.213 (changelog/doc-sourced, not runtime-observed) — so both of the pilot's safety premises (shipped-default-flat via the env default; read-only children via the spawn-time mode parameter) no longer hold. `Agent` is removed from this agent's `tools` frontmatter, restoring the flat-hierarchy guarantee by tool omission — the same sole guarantee every other retained agent relies on. Read-only child scoping, where ever needed at the orchestrator level, rests on tool restriction (`Explore`, or a `tools:` list omitting Write/Edit), never on the deprecated spawn-time permission-mode parameter.
 
 Evidence gathering for the 4 scoring dimensions runs sequentially within this agent. The user-interaction boundary is unchanged: no `sync-auditor` path invokes `AskUserQuestion` or `mcp__askuser`.
+
+## MCP Audit Tools (cross-model second opinion)
+
+This auditor carries single- and multi-backend audit MCP tools in its `tools:` list. Use them before scoring when the project config requests a cross-backend second opinion:
+
+- `mcp__moai__audit_multi` — multi-auditor convergence engine (claude anchor + optional codex/glm backends). Default path when `audit_model: multi`.
+- `mcp__moai__codex_audit` — codex-backend single audit (`native` or `adversarial` mode).
+- `mcp__moai__glm_audit` — GLM (z.ai) backend single audit.
+
+Single-backend audit mode (per the project's `audit_model`):
+- `codex+glm` (default) — converge both backends via `mcp__moai__audit_multi`; most robust.
+- `glm` — GLM only; call `mcp__moai__glm_audit` directly.
+- `codex` — codex only; call `mcp__moai__codex_audit` directly.
+- `none` — Claude-only audit (the classic sync-auditor role); no MCP backend call.
+
+All backends are fail-open: when a backend is unavailable, its tool returns `inconclusive` (never a Go error), so a missing codex/glm never blocks the audit.
 
 ## Conditional Skill Loading
 

--- a/internal/template/templates/.claude/rules/moai/core/agent-common-protocol.md
+++ b/internal/template/templates/.claude/rules/moai/core/agent-common-protocol.md
@@ -270,6 +270,8 @@ Avoid:
 | Run system commands | Bash | — |
 | Explore codebase | Agent(Explore) | Multiple sequential Grep calls |
 
+**MCP-over-CLI preference**: where an `mcp__moai__*` tool exists for a capability already in the agent's `tools:` list (e.g. `mcp__moai__spec_audit`, `mcp__moai__verify_snapshot`, `mcp__moai__session_list`), the agent SHOULD prefer the MCP tool over the equivalent Bash CLI (`moai spec audit`, `moai verify check`, `moai session list`). Both back the same implementation; the MCP path returns structured output, avoids shell-quoting hazards, and is lower-latency inside a subagent where Bash may be restricted. Use the Bash CLI only when the MCP tool is absent or the capability is not in the agent's `tools:` list. Full tool catalogue + consumers: `.claude/rules/moai/core/moai-mcp-tools.md`.
+
 ### Bash Timeout
 
 The Bash tool supports an optional `timeout` parameter (milliseconds):

--- a/internal/template/templates/.claude/rules/moai/core/moai-mcp-tools.md
+++ b/internal/template/templates/.claude/rules/moai/core/moai-mcp-tools.md
@@ -1,0 +1,88 @@
+# moai-mcp Tool Catalogue
+
+> Single source of truth for the 17 tools exposed by the self-hosted `moai` MCP
+> server (`.mcp.json` → `{command: "moai", args: ["mcp-server"]}`). Each tool is
+> prefixed `mcp__moai__` at the call site. This rule tells agents and the
+> orchestrator WHEN to prefer an MCP tool over its CLI/slash equivalent.
+>
+> Wiring parity (local ↔ template) and per-agent `tools:` lists are owned by the
+> agent definitions; this file owns the capability map + the MCP-over-CLI rule.
+
+## MCP-over-CLI rule
+
+Prefer the MCP tool when it is in the calling agent's `tools:` list. The MCP path
+and the Bash CLI back the SAME implementation; the MCP path returns structured
+output, avoids shell-quoting hazards, and is lower-latency inside a subagent
+where Bash may be restricted. Use the Bash CLI only when the MCP tool is absent
+from the agent's `tools:` list, or when orchestrating from the main session and
+the CLI form reads more naturally inline.
+
+## Tool catalogue (17 tools)
+
+### SPEC lifecycle
+
+| Tool | Purpose | Consumer | CLI equivalent |
+|------|---------|----------|----------------|
+| `mcp__moai__spec_progress` | List SPEC docs + frontmatter | manager-spec, manager-docs | `moai spec list` |
+| `mcp__moai__spec_audit` | SPEC lifecycle audit (era + drift) | manager-spec, manager-docs, plan-auditor, super-advisor | `moai spec audit` |
+| `mcp__moai__spec_drift` | Modern-era V3R6 drift findings | manager-spec, plan-auditor | `moai spec audit` (drift view) |
+
+### Verification snapshots
+
+| Tool | Purpose | Consumer | CLI equivalent |
+|------|---------|----------|----------------|
+| `mcp__moai__verify_snapshot` | Read/record per-key verification snapshot | manager-develop | `moai verify check` |
+| `mcp__moai__verify_trend` | Per-key verification check history | manager-develop, sync-auditor, super-advisor | `moai verify check` |
+
+### Goal + session (autonomous loop)
+
+| Tool | Purpose | Consumer | CLI equivalent |
+|------|---------|----------|----------------|
+| `mcp__moai__goal_arm` | Arm a condition-declared goal | **orchestrator main session ONLY** — wired to NO agent (arming an autonomous loop is an orchestrator concern) | `moai goal arm` / `/moai goal` |
+| `mcp__moai__goal_status` | Read armed-goal state | manager-develop, manager-lead | `moai goal status` |
+| `mcp__moai__session_list` | List active moai sessions | manager-lead | `moai session list` |
+
+### Cross-model audit (second opinion)
+
+| Tool | Purpose | Consumer | CLI equivalent |
+|------|---------|----------|----------------|
+| `mcp__moai__audit_multi` | Multi-auditor convergence (claude + codex + glm) | plan-auditor, sync-auditor | — (MCP-only convergence entry) |
+| `mcp__moai__codex_audit` | codex backend single audit (native/adversarial) | plan-auditor, sync-auditor | — |
+| `mcp__moai__glm_audit` | GLM (z.ai) backend single audit | plan-auditor, sync-auditor | — |
+| `mcp__moai__audit_cache` | plan-audit PASS cache (compute_hash/lookup/store, process-shared) | sync-auditor | `moai audit cache` (none — MCP-only) |
+
+Single-backend audit mode is selected per the project's `audit_model`:
+`codex+glm` (default, converge via `audit_multi`) | `glm` | `codex` | `none`
+(Claude-only, no backend call). All backends are fail-open: an unavailable
+backend returns `inconclusive`, never a Go error.
+
+### Codex delegation (background jobs)
+
+| Tool | Purpose | Consumer | CLI equivalent |
+|------|---------|----------|----------------|
+| `mcp__moai__codex_task` | Delegate a coding/investigation task to codex (sync or background) | super-advisor | `moai codex task` |
+| `mcp__moai__codex_setup` | Probe local codex install (LookPath + version + auth) | super-advisor | `moai codex setup` |
+| `mcp__moai__codex_job_status` | Read a background codex job's status/record | super-advisor | `moai codex job status` |
+| `mcp__moai__codex_job_result` | Read a background codex job's output | super-advisor | `moai codex job result` |
+| `mcp__moai__codex_job_cancel` | Stop a running background codex job | super-advisor | `moai codex job cancel` |
+
+The codex delegation family is wired into `super-advisor` because the on-demand
+high-reasoning consultation agent is the natural consumer of background
+cross-model delegation: it arms a codex task via `codex_task`, polls completion
+via `codex_job_status`/`codex_job_result`, and cancels via `codex_job_cancel`.
+`codex_setup` probes whether codex is available before delegating. codex is
+OPTIONAL: a missing or unavailable codex yields a fail-open `inconclusive`, never
+a hard error.
+
+## Unwired-by-design
+
+`goal_arm` is intentionally wired to NO agent. Arming an autonomous loop is an
+orchestrator concern (preserves the orchestrator-only arming surface and the
+flat hierarchy invariant). Agents that need a goal's state read `goal_status`;
+only the orchestrator arms.
+
+---
+
+Classification: Evolvable reference rule — the MCP tool surface map. Update this
+file whenever a tool is added/removed/renamed on the `moai mcp-server` (the Go
+producer lives in `internal/cli/mcp_server.go`).


### PR DESCRIPTION
## Summary

Two-part fix for moai-mcp tool wiring and documentation gaps:

### Group 1 — MCP Tools Wiring
- **plan-auditor + sync-auditor**: Each now carries BOTH `codex_audit` + `glm_audit` tools (previously split asymmetricly — plan-auditor had only glm_audit, sync-auditor had only codex_audit)
- **super-advisor**: Wired 5 codex_* tools (codex_task, codex_setup, codex_job_status, codex_job_result, codex_job_cancel) — these were exposed by the MCP server but had no consumer routing
- **manager-develop, manager-docs, manager-lead, manager-spec**: Each gained a "## MCP Tools" section documenting when to call its already-wired tools (verify_snapshot/trend/goal_status, spec_progress/audit/drift, session_list)

### Group 2 — Documentation & Guidance
- **NEW rule** `.claude/rules/moai/core/moai-mcp-tools.md`: Complete catalogue of all 17 MCP tools with per-tool consumer (agent/orchestrator), CLI/slash mapping, and goal_arm=orchestrator-only designation
- **agent-common-protocol.md**: Added MCP-over-CLI preference rule — prefer the `mcp__moai__*` tool over Bash CLI when it's in the agent's `tools:` list

### Template Parity
All `.claude/` changes mirrored to `internal/template/templates/.claude/` (verified parity 9/9). `catalog.yaml` regenerated via `make build`.

## Context
Closes the "wired-but-undocumented" gap — tools exposed by `mcp_server` are now properly routed to consumers and documented with usage guidance.

## Notes
- Race recovery: 3 local files were reverted mid-session by a concurrent CLAUDE.md diet process and re-applied before commit
- The audit_cache MCP defect fix (process-shared cache + store op) was completed in a prior session and is already committed

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for storing and retrieving audit results during the same MCP server session.
  * Expanded cross-model audit and delegated analysis capabilities, including job handling and fallback behavior.

* **Documentation**
  * Documented MCP tools for specification tracking, verification, audits, goals, sessions, and delegated analysis.
  * Added guidance to prefer MCP tools over equivalent command-line workflows.

* **Chores**
  * Updated supported agent template metadata and documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->