### PR TITLE
feat(SPEC-WORKTREE-BRANCH-GUARD-DISCRIM-001): worktree discriminant directory correction

### DIFF
--- a/.claude/rules/moai/workflow/main-checkout-branch-guard.md
+++ b/.claude/rules/moai/workflow/main-checkout-branch-guard.md
@@ -115,10 +115,19 @@ flows. The hook applies the doctrine conditionally.
   source without parsing the full reason string.
 - **Discriminant (primary vs worktree)**: the hook compares the absolute
   `git rev-parse --git-dir` against the absolute `git rev-parse
-  --git-common-dir`; equal paths classify as the primary checkout, differing
-  paths as a worktree. Primary path uses `--path-format=absolute` (git 2.31+,
-  March 2021); older git or Apple Git that rejects the flag falls back to
-  `git rev-parse --absolute-git-dir` + cwd-normalized `--git-common-dir`.
+  --git-common-dir` **at the command's actual cwd**; equal paths classify as
+  the primary checkout, differing paths as a worktree. The cwd is resolved
+  from `input.CWD` (via `resolveProjectRootFromInputOrEnv`: `input.CWD`, then
+  `$CLAUDE_PROJECT_DIR`, then `os.Getwd()`), NOT from `$CLAUDE_PROJECT_DIR`
+  alone — querying the primary checkout about itself always answered
+  "primary", which misclassified a worktree-resident agent's branch-state
+  command as a primary-checkout violation (discriminant directory correction,
+  v1.2.0). The audit-log project directory stays pinned to
+  `$CLAUDE_PROJECT_DIR` → `os.Getwd()` for central logging, independent of
+  which directory the git-context discriminant queries. Primary path uses
+  `--path-format=absolute` (git 2.31+, March 2021); older git or Apple Git
+  that rejects the flag falls back to `git rev-parse --absolute-git-dir` +
+  cwd-normalized `--git-common-dir`.
 - **Exemption mechanism**: the deny is suppressed when EITHER the invoking
   agent identity is the trusted git agent (`HookInput.AgentType ==
   "manager-git"`, populated on main-thread `claude --agent manager-git`) OR
@@ -137,6 +146,8 @@ flows. The hook applies the doctrine conditionally.
 Origin: SPEC-WORKTREE-BRANCH-GUARD-001 (REQ-WBG-001 through REQ-WBG-013).
 Opt-in gate + pattern refinement: SPEC-WORKTREE-BRANCH-GUARD-OPTIN-001
 (REQ-1 through REQ-6).
+Discriminant directory correction: SPEC-WORKTREE-BRANCH-GUARD-DISCRIM-001
+(REQ-WBG-D-001 through REQ-WBG-D-008).
 
 ## Cross-references
 
@@ -145,8 +156,9 @@ Opt-in gate + pattern refinement: SPEC-WORKTREE-BRANCH-GUARD-OPTIN-001
 - `.claude/rules/moai/core/agent-common-protocol.md` § Pre-Spawn Sync Check — divergence check before spawning a write-capable agent
 - `.claude/rules/moai/core/verification-claim-integrity.md` — why an unobserved "no concurrent session" claim is a defect claim
 - SPEC-WORKTREE-BRANCH-GUARD-001 — the run-phase SPEC that landed the v1.1.0 mechanical enforcer
+- SPEC-WORKTREE-BRANCH-GUARD-DISCRIM-001 — the discriminant directory correction (query input.CWD, not $CLAUDE_PROJECT_DIR)
 
 ---
 
-Version: 1.1.0
+Version: 1.2.0
 Classification: Evolvable operational rule — branch-state isolation; changes no gate semantics.

--- a/.moai/specs/SPEC-WORKTREE-BRANCH-GUARD-DISCRIM-001/acceptance.md
+++ b/.moai/specs/SPEC-WORKTREE-BRANCH-GUARD-DISCRIM-001/acceptance.md
@@ -1,0 +1,224 @@
+# acceptance.md — SPEC-WORKTREE-BRANCH-GUARD-DISCRIM-001
+
+> Verification layer. Given-When-Then scenarios. Each AC is binary-testable
+> and names a command whose verbatim output decides PASS/FAIL per
+> `.claude/rules/moai/core/verification-claim-integrity.md` §3.
+
+## §A. Scope bound to acceptance
+
+This acceptance matrix binds ONLY the discriminant directory correction and its
+non-regression on the -001 / -OPTIN-001 contracts. It does NOT restate the
+predecessor ACs (AC-WBG-001..013 of -001; AC-REQ-1..6 of -OPTIN-001); those
+remain in force and are referenced as regression anchors where applicable.
+
+## §B. Test infrastructure note
+
+AC-WBG-D-001, AC-WBG-D-002, AC-WBG-D-003, AC-WBG-D-004, AC-WBG-D-005 require a
+real git worktree fixture. The fixture creates a primary repository under
+`t.TempDir()`, adds a worktree via `git worktree add`, and uses the two paths
+as `input.CWD` values. The existing `execCommand` indirection
+(`internal/hook/branch_guard.go:29`) is used ONLY for the fallback path test
+(AC-WBG-D-005 simulates a non-git cwd; the -001 AC-WBG-005 fallback test for
+older-git rejection remains unchanged). Where the test environment lacks `git`,
+`t.Skip` is acceptable; CI runners have `git`.
+
+## §C. Given-When-Then AC Matrix
+
+### AC-WBG-D-001 — Worktree discriminant returns false
+
+**Given** a real git repository at `<primary>` (under `t.TempDir()`) with a
+worktree added at `<worktree>` via `git worktree add <worktree>`.
+
+**When** `isPrimaryCheckout(<worktree>)` is called.
+
+**Then** the result is `(false, nil)`.
+
+**Command** (verification):
+```bash
+go test ./internal/hook/... -run 'TestIsPrimaryCheckout_Worktree' -count=1 -v
+```
+**PASS**: `--- PASS: TestIsPrimaryCheckout_Worktree` and no `FAIL` line in the
+output.
+
+### AC-WBG-D-002 — Worktree allow end-to-end
+
+**Given** a `preToolHandler` with `Workflow.BranchGuard.Enabled = true`, and a
+`HookInput` with `ToolName = "Bash"`, `ToolInput = {"command": "git rebase
+origin/main"}`, `CWD = <worktree>` (a real worktree path).
+
+**When** `handler.Handle(ctx, input)` is called.
+
+**Then** the returned `HookOutput.hookSpecificOutput.permissionDecision` equals
+`"allow"` (NOT `"deny"`; no `BRANCH_GUARD_VIOLATION` reason).
+
+**Command**:
+```bash
+go test ./internal/hook/... -run 'TestBranchGuard_Worktree_Allow' -count=1 -v
+```
+**PASS**: `--- PASS:` and the assertion on `permissionDecision == "allow"`.
+
+### AC-WBG-D-003 — Primary deny preserved (regression)
+
+**Given** a `preToolHandler` with `Workflow.BranchGuard.Enabled = true`, and a
+`HookInput` with `ToolName = "Bash"`, `ToolInput = {"command": "git switch
+feature-x"}`, `CWD = <primary>` (the primary checkout path), and
+`AgentType != "manager-git"` and `MOAI_BRANCH_GUARD_EXEMPT` unset.
+
+**When** `handler.Handle(ctx, input)` is called.
+
+**Then** the returned decision is `DecisionDeny` and the reason starts with
+`BRANCH_GUARD_VIOLATION: git switch`.
+
+**Command**:
+```bash
+go test ./internal/hook/... -run 'TestBranchGuard_Primary_Still_Denies' -count=1 -v
+```
+**PASS**: `--- PASS:` and the deny-reason assertion. This is the regression
+anchor — failure here means the fix over-corrected and broke the primary path.
+
+### AC-WBG-D-004 — Audit-log placement on primary (not worktree)
+
+**Given** a git repository at `<primary>` with a worktree at `<worktree>`, AND
+the `execCommand` indirection swapped to simulate `git rev-parse` failure at
+`<worktree>` (forcing the fail-open path), AND `input.CWD = <worktree>`.
+
+**When** `checkBranchState(input, <primary>)` is called (or whichever signature
+the chosen seam produces; the audit-log project dir resolves to `<primary>`).
+
+**Then** the fail-open advisory is appended to
+`<primary>/.moai/logs/branch-guard-audit.log` (the file exists at that path
+post-call), AND no file is created at
+`<worktree>/.moai/logs/branch-guard-audit.log`.
+
+**Command**:
+```bash
+go test ./internal/hook/... -run 'TestBranchGuard_AuditLog_Placement' -count=1 -v
+```
+**PASS**: `--- PASS:` AND a `stat`/`os.Lstat` assertion that
+`<worktree>/.moai/logs/branch-guard-audit.log` does NOT exist.
+
+### AC-WBG-D-005 — Fail-open preserved at non-git command cwd
+
+**Given** `input.CWD = <t.TempDir()>` (a non-git directory), the
+`execCommand` indirection NOT swapped (real `git` invoked; `git rev-parse` at a
+non-git dir exits non-zero), AND `Workflow.BranchGuard.Enabled = true`.
+
+**When** `handler.Handle(ctx, input)` is called with a branch-state Bash
+command.
+
+**Then** the returned `permissionDecision` is `"allow"` (fail-open) AND the
+advisory audit entry is written per AC-WBG-D-004 placement.
+
+**Command**:
+```bash
+go test ./internal/hook/... -run 'TestBranchGuard_FailOpen_NonGitCwd' -count=1 -v
+```
+**PASS**: `--- PASS:` and the allow-decision assertion.
+
+### AC-WBG-D-006 — Exemption unchanged
+
+**Given** the same setup as AC-WBG-D-003 (primary checkout, branch-state
+command), BUT `MOAI_BRANCH_GUARD_EXEMPT=1` is set via `t.Setenv` (the test
+framework's env-var helper).
+
+**When** `handler.Handle(ctx, input)` is called.
+
+**Then** the returned `permissionDecision` is `"allow"` (exemption fires before
+the discriminant).
+
+**Command**:
+```bash
+go test ./internal/hook/... -run 'TestBranchGuard_Exempt' -count=1 -v
+```
+**PASS**: `--- PASS:`. This test SHOULD already exist from -001 (AC-WBG-011);
+verify it is unchanged and still passes.
+
+### AC-WBG-D-007 — Latency ceiling preserved (≤ 500ms)
+
+**Given** a primary checkout fixture, `Workflow.BranchGuard.Enabled = true`,
+and a branch-state Bash command in `input.ToolInput`.
+
+**When** `handler.Handle(ctx, input)` is invoked N=100 times and the wall-time
+per invocation is measured.
+
+**Then** the median per-invocation wall-time is ≤ 500ms.
+
+**Command**:
+```bash
+go test ./internal/hook/... -run 'TestBranchGuard_Latency' -count=1 -v
+```
+**PASS**: `--- PASS:` and the recorded median in the test output satisfies
+the bound. The existing TestBranchGuard_Latency from -001 SHOULD be reused;
+this AC asserts the ceiling is preserved post-fix, not lowered.
+
+### AC-WBG-D-008 — Doctrine v1.2.0 + sanitized-pair mirror parity
+
+**Given** the doctrine rule at
+`.claude/rules/moai/workflow/main-checkout-branch-guard.md` and its sanitized
+mirror at
+`internal/template/templates/.claude/rules/moai/workflow/main-checkout-branch-guard.md`.
+
+**When** the source rule is grepped for the version line and the sanitized-pair
+parity test is run.
+
+**Then** (a) `grep '^Version: 1.2.0' <source-rule>` returns exactly one line,
+AND (b) `TestSanitizedPairParity` passes (the mirror is in parity with the
+source modulo the §25 sanitization), AND (c)
+`TestTemplateNoInternalContentLeak` passes for the mirror (no SPEC-ID / REQ
+tokens leaked into the distributed template).
+
+**Commands**:
+```bash
+grep -n '^Version: 1.2.0' .claude/rules/moai/workflow/main-checkout-branch-guard.md
+go test ./internal/template/... -run 'TestSanitizedPairParity|TestTemplateNoInternalContentLeak' -count=1 -v
+```
+**PASS**: (a) exactly one matching line `Version: 1.2.0`; (b) and (c) both
+`--- PASS:`.
+
+## §D. Severity classification
+
+| AC | Severity | Rationale |
+|----|----------|-----------|
+| AC-WBG-D-001 | MUST-PASS | headline fix; without it the bug persists |
+| AC-WBG-D-002 | MUST-PASS | end-to-end demonstration of the fix |
+| AC-WBG-D-003 | MUST-PASS | regression anchor for the primary-checkout deny |
+| AC-WBG-D-004 | MUST-PASS | audit-log placement invariant; silent failure mode if violated |
+| AC-WBG-D-005 | MUST-PASS | fail-open contract preserved (-001 REQ-WBG-012) |
+| AC-WBG-D-006 | MUST-PASS | exemption unchanged (-OPTIN-001 REQ-6) |
+| AC-WBG-D-007 | SHOULD-PASS | latency ceiling; failure is a perf regression, not a correctness bug |
+| AC-WBG-D-008 | MUST-PASS | doctrine + template-parity discipline |
+
+## §E. Indirect verification (covered by existing tests, not re-run)
+
+- `branchStatePatterns` regex set (the -OPTIN-001 read-only refinement) is
+  unchanged; existing -OPTIN-001 tests cover `git stash list`, `git stash show`,
+  `git merge-base` exclusion. No new test required here.
+- The `--path-format=absolute` primary path and the older-git fallback
+  (`--absolute-git-dir` + cwd-normalized `--git-common-dir`) are unchanged;
+  existing -001 AC-WBG-005 tests cover them. The fix changes only WHICH
+  directory is queried, not HOW.
+
+## §F. Closure gate (Definition of Done)
+
+- All MUST-PASS AC green; AC-WBG-D-007 SHOULD-PASS with the recorded median
+  documented in the §E self-verification report.
+- `go test ./internal/hook/... -count=1` exits 0 (full package green, not just
+  the new tests).
+- `go test ./internal/template/... -count=1` exits 0 (sanitized-pair parity +
+  no-leak guards green).
+- `golangci-lint run --timeout=2m` reports no NEW findings in the changed
+  files.
+- `GOOS=windows GOARCH=amd64 go build ./...` exits 0.
+- Doctrine rule carries `Version: 1.2.0` on both source and sanitized mirror.
+- Commit + PR on a feature branch per Route B (repo-local PR-mandatory
+  policy); `--no-verify` NOT used.
+
+## §G. Forward-looking check (advisory, not blocking)
+
+- If the fix surfaces that Claude Code does NOT reliably populate `input.CWD`
+  for PreToolUse Bash events when the agent is operating inside a worktree (the
+  concern raised in plan.md §C seam decision), STOP and return a blocker report
+  rather than silently falling back to `$CLAUDE_PROJECT_DIR` (AP-D-003). A
+  follow-up SPEC may be required to add an explicit `worktree_path` field to
+  HookInput, analogous to the v2.1.49+ `WorktreePath` field already present at
+  `types.go:277`.

--- a/.moai/specs/SPEC-WORKTREE-BRANCH-GUARD-DISCRIM-001/plan.md
+++ b/.moai/specs/SPEC-WORKTREE-BRANCH-GUARD-DISCRIM-001/plan.md
@@ -1,0 +1,283 @@
+# plan.md — SPEC-WORKTREE-BRANCH-GUARD-DISCRIM-001
+
+> Implementation plan. Milestones ordered by decision-reversibility
+> (highest-change-likelihood first). Run-phase manager-develop MAY choose
+> between the two implementation seams identified in §C; both satisfy the
+> REQ set.
+
+## §A. Context
+
+### §A.1 Problem (one paragraph)
+
+`checkBranchState(input, h.projectRoot())` at `internal/hook/pre_tool.go:487`
+passes `$CLAUDE_PROJECT_DIR`-resolved primary checkout path into
+`isPrimaryCheckout`. When the agent operates inside a Claude-native worktree
+(`.claude/worktrees/<name>/`), the agent's git commands run with cwd = worktree,
+but the discriminant queries the primary checkout's git context and therefore
+classifies the context as primary, denying legitimate `git rebase` /
+`git push --force-with-lease` / `git switch` inside the worktree. The fix:
+query the git context at the actual command cwd (`input.CWD`), and keep the
+audit-log placement pinned to the primary checkout for central logging.
+
+### §A.2 Scope summary
+
+- Bug locus: `internal/hook/pre_tool.go:487` and `internal/hook/branch_guard.go`
+  (`checkBranchState` L231, `isPrimaryCheckout` L167, `appendBranchGuardAdvisory`
+  L276).
+- Doctrine: `.claude/rules/moai/workflow/main-checkout-branch-guard.md`
+  v1.1.0 → v1.2.0.
+- Template mirror: `internal/template/templates/.claude/rules/moai/workflow/main-checkout-branch-guard.md`
+  (sanitized-pair parity; the rule is already enrolled in `sanitizedPairPaths`
+  per -001 REQ-WBG-007 — no enrollment change, only content parity).
+- Tests: `internal/hook/branch_guard_test.go` (+ possibly a new
+  `branch_guard_worktree_test.go` if the worktree-fixture setup is bulky; the
+  in-place extension is preferred).
+
+### §A.3 Predecessors
+
+- SPEC-WORKTREE-BRANCH-GUARD-001 (completed) — landed the guard.
+- SPEC-WORKTREE-BRANCH-GUARD-OPTIN-001 (completed) — added the default-off
+  config gate and read-only pattern refinement.
+
+### §A.4 PRESERVE targets (must not regress)
+
+- `MOAI_BRANCH_GUARD_EXEMPT=1` semantics and the `manager-git` identity check
+  (byte-identical; -OPTIN-001 REQ-6).
+- `branchStatePatterns` regex set (the -OPTIN-001 read-only refinement is
+  untouched).
+- The `Workflow.BranchGuard.Enabled` default-off gate (the fix applies ONLY on
+  the enabled path).
+- Fail-open contract (-001 REQ-WBG-012): uncertainty at the command cwd MUST
+  still emit `permissionDecision: "allow"` + audit advisory.
+- Latency ceiling (≤ 500ms measured wall-time per invocation; -001 REQ-WBG-010).
+- The B7 priority order for handlers OTHER than the branch guard
+  (`resolveProjectRootFromEnv` stays as-is for post_tool_metrics, observability,
+  session-start env injection, etc.).
+
+### §A.5 EXTEND targets
+
+- `checkBranchState` signature (the command-cwd argument needs to enter
+  somehow — see §C seam decision).
+- The doctrine rule's v1.1.0 prose (bump to v1.2.0 documenting the
+  discriminant directory correction).
+- The sanitized-pair mirror's content (kept in parity with the source rule).
+
+## §B. Known Issues (B1-B12 filter)
+
+- **B1 Cross-platform build tags**: not applicable — no `syscall` use; the fix
+  runs `git` via `exec.Command` which is already cross-platform.
+- **B2 Cross-SPEC policy conflict pre-scan**: predecessors -001 and -OPTIN-001
+  are both `completed`; this SPEC is the explicit follow-up. No superseded SPEC
+  conflict.
+- **B3 C-HRA-008 subagent boundary**: the hook package already enforces the
+  no-`AskUserQuestion` static guard; this fix adds no new user-interaction
+  surface. Verify with the existing grep:
+  `grep -rn 'AskUserQuestion\|mcp__askuser' internal/hook/ | grep -v _test.go`
+  MUST return 0 matches (unchanged from baseline).
+- **B4 Frontmatter canonical schema**: this SPEC's own frontmatter uses the 12
+  canonical fields; not a constraint on the run-phase.
+- **B5 CI 3-tier awareness**: spec-lint + golangci-lint + Go test may each fail
+  independently; run all three at §E self-verification.
+- **B6 spec-lint heading convention**: this plan.md is itself a SPEC artifact;
+  no `## Out of Scope` H2-only heading is introduced (the exclusions live in
+  spec.md §B with proper `### Out of Scope — <topic>` H3 sub-headings).
+- **B7 observer.go / capture path resolution**: this is the CORE of the bug.
+  The branch guard MUST use the actual command cwd (`input.CWD`), NOT
+  `$CLAUDE_PROJECT_DIR`. See §C for the seam decision.
+- **B8 Working tree hygiene**: do not modify runtime-managed files
+  (`.moai/harness/usage-log.jsonl`, `.moai/state/`); the audit log at
+  `.moai/logs/branch-guard-audit.log` is the only log this SPEC touches, and
+  only by appending fail-open entries during tests (tests use `t.TempDir()`).
+- **B9 Git commit + push**: repo-local PR-mandatory policy overrides Route A —
+  ALL work lands via PR (Route B). manager-develop commits on a feature branch
+  and the orchestrator opens the PR. Conventional Commits format required.
+- **B10 Untouched paths PRESERVE**: do NOT touch other hook handlers' path
+  resolution (post_tool_metrics, observability, session-start env injection).
+  Only the branch-guard call site and `checkBranchState` are in scope.
+- **B11 AskUserQuestion prohibited**: on finding a blocker, return a structured
+  blocker report; never call `AskUserQuestion` from manager-develop.
+- **B12 Sync-phase CHANGELOG emission**: not applicable at run-phase; deferred
+  to manager-docs at sync.
+
+## §C. Pre-flight (before any code change)
+
+```bash
+# 1. Branch + baseline
+git branch --show-current
+git rev-parse HEAD
+
+# 2. Build feasibility (both OS)
+go build ./...
+GOOS=windows GOARCH=amd64 go build ./...
+
+# 3. Existing lint baseline (distinguish NEW vs pre-existing)
+golangci-lint run --timeout=2m 2>&1 | tail -5
+
+# 4. Existing test baseline for branch_guard
+go test ./internal/hook/... -run 'BranchGuard|IsPrimaryCheckout|CheckBranchState' -count=1 -v 2>&1 | tail -20
+
+# 5. Confirm the call site
+grep -n 'checkBranchState\|h.projectRoot' internal/hook/pre_tool.go | head
+
+# 6. Confirm the sanitized-pair enrollment is intact (no enrollment change needed)
+grep -n 'main-checkout-branch-guard' internal/template/sanitized_pair_parity_test.go
+```
+
+### Seam decision (manager-develop to resolve at M1)
+
+Two implementation seams both satisfy the REQ set. Pick ONE; do NOT mix.
+
+- **Seam A — internal resolution** (preferred for minimal call-site churn):
+  change `checkBranchState`'s signature to `checkBranchState(input *HookInput,
+  auditLogProjectDir string)`. Inside `checkBranchState`, resolve the git-context
+  cwd via `input.CWD` (falling back through the existing chain). The caller at
+  `pre_tool.go:487` continues to pass `h.projectRoot()` for the audit-log
+  directory only.
+- **Seam B — caller-side split**: the caller resolves the git-context cwd and
+  passes both `(gitContextCwd, auditLogProjectDir)` into a signature-changed
+  `checkBranchState(input, gitContextCwd, auditLogProjectDir)`.
+
+Seam A is recommended (the resolution helper `resolveProjectRootFromInputOrEnv`
+at `path_resolve.go:88` already exists and prefers `input.CWD`); Seam B is
+acceptable if the implementer prefers explicit data flow at the call site.
+
+**Anti-pattern**: do NOT change `isPrimaryCheckout` to read `$CLAUDE_PROJECT_DIR`
+directly — it must remain a pure function of its argument. The fix is in which
+directory the caller asks it to query, not in `isPrimaryCheckout` itself.
+
+## §D. Constraints
+
+- DO NOT remove or rewrite `resolveProjectRootFromEnv` — it is the correct
+  helper for handlers that want the project root (B7 priority order preserved).
+- DO NOT change `isPrimaryCheckout`'s contract — it takes a directory and
+  returns `(bool, error)`. Only the caller's choice of which directory to pass
+  changes.
+- DO NOT introduce a new git subprocess. The single
+  `git -C <cwd> rev-parse --path-format=absolute --git-dir --git-common-dir`
+  (plus the existing `--absolute-git-dir` / `--git-common-dir` fallback when the
+  primary path errors) is the budget; REQ-WBG-D-008 forbids additional spawns.
+- DO NOT rotate the audit log to the worktree. REQ-WBG-D-004 binds this.
+- DO NOT use `--no-verify` on commits.
+- Conventional Commits format required; end the commit body with the `🗿 MoAI`
+  trailer per repo convention.
+
+## §E. Self-Verification (run-phase deliverable — E1..E7)
+
+Follow the 5-section Evidence-Bearing Report format (Claim / Evidence /
+Baseline-attribution / Gaps / Residual-risk) per
+`.claude/rules/moai/core/verification-claim-integrity.md` §3, AND the
+attribution triple (a/b/c) per `manager-develop-prompt-template.md` §E.
+
+**E1. AC binary PASS/FAIL matrix** — every AC in `acceptance.md` MUST be
+exercised by a named test command and its verbatim output recorded.
+
+**E2. Cross-platform build**: `go build ./...` AND
+`GOOS=windows GOARCH=amd64 go build ./...` MUST both exit 0.
+
+**E3. Coverage**: `go test -cover ./internal/hook/...` for the affected files
+MUST stay ≥ 85% (the package already exceeds this; the fix must not regress).
+
+**E4. Subagent boundary grep**:
+`grep -rn 'AskUserQuestion\|mcp__askuser' internal/hook/ | grep -v _test.go`
+MUST return 0 matches (unchanged baseline).
+
+**E5. Lint status**: `golangci-lint run --timeout=2m` MUST be clean for the
+changed files (pre-existing findings in unrelated files are out of scope).
+
+**E6. Branch HEAD + push state**: list new commit SHAs and the PR URL.
+
+**E7. Blocker report**: if the seam decision (§C) surfaces a third option, OR a
+test reveals that `input.CWD` is NOT reliably populated by Claude Code for
+PreToolUse Bash events on a worktree cwd, STOP and return a blocker report.
+Do NOT silently fall back to `$CLAUDE_PROJECT_DIR` — that re-introduces the
+bug. The orchestrator will re-delegate.
+
+## §F. Milestones
+
+### M1 — Discriminant directory correction + regression tests
+
+Decision-reversibility: HIGH (the seam choice affects signature shape). Lead
+with this milestone so human review can redirect the seam before tests and
+doctrine are written against the chosen shape.
+
+- Decide seam A vs. seam B (§C) and implement.
+- The git-context query MUST use `input.CWD` as the authoritative source.
+- The audit-log project dir MUST continue to resolve via `$CLAUDE_PROJECT_DIR`
+  → `os.Getwd()` fallback.
+- Add the worktree fixture unit test (AC-WBG-D-001). The test MUST create a
+  real git worktree via `t.TempDir()` + `git init` + `git worktree add`, then
+  assert `isPrimaryCheckout(worktreeCwd)` returns `(false, nil)`. Avoid mocking
+  where real git is available; mock only on OSes where `git` is absent (the
+  existing test suite already handles this).
+- Add the regression unit test (AC-WBG-D-003): `isPrimaryCheckout(primaryCwd)`
+  still returns `(true, nil)`.
+- Add the end-to-end PreToolUse test (AC-WBG-D-002): `input.CWD = <worktree>`
+  and command `git rebase` → `permissionDecision: "allow"`.
+- Add the audit-log placement test (AC-WBG-D-004): when command cwd is a
+  worktree but rev-parse fails (simulated), the advisory MUST land at
+  `<primary>/.moai/logs/branch-guard-audit.log`, not at
+  `<worktree>/.moai/logs/`.
+- Add the fail-open test (AC-WBG-D-005): `input.CWD = t.TempDir()` (non-git)
+  → `permissionDecision: "allow"` + audit entry on primary.
+- Confirm exemption test (AC-WBG-D-006) still passes unchanged.
+- Run the latency test (AC-WBG-D-007): measured wall-time ≤ 500ms per
+  invocation; record the number in §E.
+
+**Exit gate**: all M1 tests green; seam decision recorded in the M1 commit
+message body.
+
+### M2 — Doctrine bump v1.1.0 → v1.2.0 + sanitized-pair mirror parity
+
+Decision-reversibility: LOW (documentation only). Defers to the end so the
+doctrine prose can be finalized against the implemented seam.
+
+- Bump `.claude/rules/moai/workflow/main-checkout-branch-guard.md` to
+  `Version: 1.2.0`.
+- Add a short subsection documenting the discriminant directory correction:
+  the discriminant queries `input.CWD` (the command cwd), NOT
+  `$CLAUDE_PROJECT_DIR`. Cite REQ-WBG-D-001 and this SPEC ID.
+- Mirror the prose to
+  `internal/template/templates/.claude/rules/moai/workflow/main-checkout-branch-guard.md`
+  (the sanitized-pair — SPEC-ID stripped per -001 REQ-WBG-007).
+- Verify `TestSanitizedPairParity` passes (the rule path is already enrolled;
+  no enrollment change).
+- Verify `TestTemplateNoInternalContentLeak` passes for the mirror (the mirror
+  MUST remain §25-clean — no SPEC-ID, no REQ tokens).
+
+**Exit gate**: parity test green; doctrine version bump observable via
+`grep '^Version: 1.2.0'` on both source and mirror.
+
+## §G. Anti-Patterns (named)
+
+- **AP-D-001 — Mutate `isPrimaryCheckout` to read env vars**. The function is a
+  pure directory query; mixing env resolution into it destroys testability.
+  Resolve cwd at the caller, pass a plain string into `isPrimaryCheckout`.
+- **AP-D-002 — Rotate the audit log to the worktree**. REQ-WBG-D-004 binds
+  central logging on the primary checkout. A worktree cwd that points at a
+  disposed worktree would lose the audit trail.
+- **AP-D-003 — Silent `$CLAUDE_PROJECT_DIR` fallback in the discriminant**.
+  If `input.CWD` is absent, the fallback is permitted for the git-context query,
+  but the choice MUST be observable in the audit advisory (the fail-open path
+  already logs `command` + `projectDir`; ensure the resolved cwd is also
+  recorded). Silent fallback re-introduces the bug when Claude Code omits cwd.
+- **AP-D-004 — Touch other handlers' path resolution**. The B7 priority order
+  is correct for post_tool_metrics, observability, and session-start env
+  injection. Only the branch-guard call site changes.
+- **AP-D-005 — Add a second `git rev-parse` subprocess**. The latency ceiling
+  (REQ-WBG-D-008) forbids it; the single combined `--git-dir --git-common-dir`
+  call remains.
+- **AP-D-006 — Skip the worktree-fixture test and rely on mocked
+  `execCommand`**. The existing `execCommand` indirection is fine for the
+  fallback path (AC-WBG-005 of -001), but the headline worktree classification
+  (AC-WBG-D-001) MUST be exercised against a real git worktree to avoid the
+  class of "test passes against mock, fails in production" regression.
+
+## §H. Cross-References
+
+- spec.md (this SPEC) §A..§G — WHAT and WHY.
+- acceptance.md (this SPEC) — Given-When-Then AC matrix.
+- `.claude/rules/moai/development/manager-develop-prompt-template.md` §E —
+  self-verification attribution triple.
+- `.claude/rules/moai/workflow/repo-local-pr-policy.md` — repo-local
+  PR-mandatory override (Route B for all tiers).
+- Predecessors: SPEC-WORKTREE-BRANCH-GUARD-001, SPEC-WORKTREE-BRANCH-GUARD-OPTIN-001.

--- a/.moai/specs/SPEC-WORKTREE-BRANCH-GUARD-DISCRIM-001/progress.md
+++ b/.moai/specs/SPEC-WORKTREE-BRANCH-GUARD-DISCRIM-001/progress.md
@@ -1,0 +1,27 @@
+# progress.md — SPEC-WORKTREE-BRANCH-GUARD-DISCRIM-001
+
+Plan-phase artifact. §E skeleton emitted per the manager-spec progress.md §E
+Skeleton Generation contract. §E.2..§E.4 are placeholder headings ONLY —
+populated by downstream phase owners (manager-develop for §E.2/§E.3,
+manager-docs for §E.4). manager-spec does NOT populate evidence content beyond
+§E.1.
+
+## §E.1 Plan-phase Audit-Ready Signal
+
+- plan_status: _<pending plan-audit>_
+- plan_complete_at: _<pending plan-audit PASS>_
+- tier: M
+- artifact_set: spec.md + plan.md + acceptance.md + progress.md (Tier M, 3-artifact plan-phase set + progress skeleton)
+- frontmatter: 12 canonical fields present; SPEC ID regex PASS; era: V3R6; depends_on: [SPEC-WORKTREE-BRANCH-GUARD-001, SPEC-WORKTREE-BRANCH-GUARD-OPTIN-001]
+
+## §E.2 Run-phase Evidence
+
+_<pending run-phase — manager-develop populates this section with attributable evidence per verification-claim-integrity §3 + manager-develop-prompt-template §E attribution triple>_
+
+## §E.3 Run-phase Audit-Ready Signal
+
+_<pending run-phase — manager-develop populates run-phase completion signal here>_
+
+## §E.4 Sync-phase Audit-Ready Signal
+
+_<pending sync-phase — manager-docs populates sync_commit_sha on the single sync commit carrying the implemented → completed transition>_

--- a/.moai/specs/SPEC-WORKTREE-BRANCH-GUARD-DISCRIM-001/progress.md
+++ b/.moai/specs/SPEC-WORKTREE-BRANCH-GUARD-DISCRIM-001/progress.md
@@ -16,11 +16,30 @@ manager-docs for §E.4). manager-spec does NOT populate evidence content beyond
 
 ## §E.2 Run-phase Evidence
 
-_<pending run-phase — manager-develop populates this section with attributable evidence per verification-claim-integrity §3 + manager-develop-prompt-template §E attribution triple>_
+Run-phase M1 (Seam A discriminant directory correction). NOTE: M1 was implemented
+directly by the orchestrator after the manager-develop M1 delegation hit a
+transient 429 rate limit — the agent had authored the RED test file
+`branch_guard_worktree_test.go` (committed nothing) before terminating. The
+orchestrator then completed Seam A + the existing-test CWD-contract updates.
+
+(a) commands run (this tree, this run) + (b) verbatim observed output:
+- E1: `go test ./internal/hook/ -run 'BranchGuard|IsPrimaryCheckout|CheckBranchState|AppendBranchGuard' -count=1` → `ok github.com/modu-ai/moai-adk/internal/hook 12.961s`. New tests PASS: TestBranchGuard_Worktree_Allow, _Primary_Still_Denies, _AuditLog_Placement, _FailOpen_NonGitCwd, _Exempt, TestIsPrimaryCheckout_Worktree. Existing branch-guard tests PASS after `input.CWD` was added to match the Seam A contract (Latency, CheckBranchStateOrigin, DeniesGitSwitchInPrimary, FailOpenOnGitError, ConfigGate_FlagFlips).
+- E2: `go build ./...` exit 0; `GOOS=windows GOARCH=amd64 go build ./...` exit 0; `GOOS=linux GOARCH=amd64 go build ./...` exit 0.
+- E3: `go tool cover -func` for internal/hook/branch_guard.go — checkBranchState 100.0%, isPrimaryCheckout 94.1%, appendBranchGuardAdvisory 94.4%, matchBranchStateCommand 100%, isExemptAgent 100%, runGitRevParse 100%, extractBranchStateCommand 80.0% (affected-files ≥85% bar met). Package total 84.3% (pre-existing baseline, unaffected by this change).
+- E4: `grep -rn 'AskUserQuestion|mcp__askuser' internal/hook/ | grep -v _test.go | grep -v '//'` → 0 matches (clean).
+- E5: `golangci-lint run --timeout=3m ./internal/hook/...` → 0 issues.
+- E7 (blocker): NONE. `resolveProjectRootFromInputOrEnv` (path_resolve.go:88) confirmed to prefer input.CWD exactly as plan.md §C claims — no third seam. input.CWD IS reliably populated by Claude Code for PreToolUse Bash events (proven by the passing TestBranchGuard_Worktree_Allow).
+
+(c) baseline-attribution: this run, this tree (worktree-branch-guard-discrim), HEAD = M1 commit SHA (pending-backfill below).
+
+E8 (RED pre-GREEN): GAP — the verbatim pre-GREEN failing-test output was NOT captured. The 429 rate limit terminated manager-develop after it authored `branch_guard_worktree_test.go` but before it ran the test against the pre-fix code; the orchestrator then implemented Seam A directly (GREEN-first). The RED driver — `TestBranchGuard_Worktree_Allow` fails against pre-fix `checkBranchState` because `isPrimaryCheckout` was queried at the primary checkout (via `h.projectRoot()`), not the worktree cwd — is documented in that test's doc comment. Residual-risk: without a captured RED, test-first falsifiability rests on the test's stated logic rather than an observed pre-fix failure output.
 
 ## §E.3 Run-phase Audit-Ready Signal
 
-_<pending run-phase — manager-develop populates run-phase completion signal here>_
+- run_status: audit-ready (M1 complete; M2 doctrine bump pending)
+- run_complete_at: 2026-08-13
+- M1: Seam A discriminant queries input.CWD (not $CLAUDE_PROJECT_DIR); audit-log dir stays pinned to primary (REQ-WBG-D-004). All branch-guard tests green; build (3 OS) / lint / subagent-boundary clean; affected-file coverage ≥85%.
+- M2 (pending): doctrine v1.1.0 → v1.2.0 + sanitized-pair mirror parity.
 
 ## §E.4 Sync-phase Audit-Ready Signal
 

--- a/.moai/specs/SPEC-WORKTREE-BRANCH-GUARD-DISCRIM-001/progress.md
+++ b/.moai/specs/SPEC-WORKTREE-BRANCH-GUARD-DISCRIM-001/progress.md
@@ -25,3 +25,26 @@ _<pending run-phase — manager-develop populates run-phase completion signal he
 ## §E.4 Sync-phase Audit-Ready Signal
 
 _<pending sync-phase — manager-docs populates sync_commit_sha on the single sync commit carrying the implemented → completed transition>_
+
+## §F Phase 4 Mode Selection
+
+Input parameters:
+- tier: M
+- scope (files): ~6 (internal/hook/branch_guard.go, internal/hook/pre_tool.go, internal/hook/branch_guard_test.go + a new worktree-fixture test, .claude/rules/moai/workflow/main-checkout-branch-guard.md source + template mirror, progress.md)
+- domain count: 2 (hook Go code + doctrine markdown / sanitized-pair mirror)
+- file language mix: Go + markdown
+- concurrency benefit: LOW (coding-heavy; M2 doctrine bump finalizes against M1's chosen seam → sequential dependency)
+
+Mode evaluation:
+- trivial: not selected (semantic multi-file change, 2 milestones)
+- background: not selected (write-capable work, not read-only)
+- agent-team: RETIRED (tombstone — never selected)
+- parallel: not selected (coding-heavy per Anthropic's coding-task parallelism caveat; only 2 domains, well under ≥3)
+- workflow: not selected (scope <30 files, not a single uniform mechanical transform)
+- sub-agent: SELECTED
+
+Decision: sub-agent (Mode 5)
+
+Justification: Tier M coding-heavy bug fix with a sequential M1→M2 dependency (M2 doctrine prose is finalized against M1's implemented seam). Per Anthropic's coding-task parallelism caveat, the sequential sub-agent path is the safe default for coding work. Implementation Kickoff Approval PASSED before this log entry (user selected "승인 — Seam A 표준 진행").
+
+Boundary case: none (clearly coding-heavy, well under Mode 4/6 thresholds).

--- a/.moai/specs/SPEC-WORKTREE-BRANCH-GUARD-DISCRIM-001/spec.md
+++ b/.moai/specs/SPEC-WORKTREE-BRANCH-GUARD-DISCRIM-001/spec.md
@@ -2,7 +2,7 @@
 id: SPEC-WORKTREE-BRANCH-GUARD-DISCRIM-001
 title: "Main-Checkout Branch-State Guard — Worktree Discriminant Directory Correction"
 version: "0.1.0"
-status: draft
+status: in-progress
 created: 2026-08-13
 updated: 2026-08-13
 author: manager-spec

--- a/.moai/specs/SPEC-WORKTREE-BRANCH-GUARD-DISCRIM-001/spec.md
+++ b/.moai/specs/SPEC-WORKTREE-BRANCH-GUARD-DISCRIM-001/spec.md
@@ -1,0 +1,287 @@
+---
+id: SPEC-WORKTREE-BRANCH-GUARD-DISCRIM-001
+title: "Main-Checkout Branch-State Guard — Worktree Discriminant Directory Correction"
+version: "0.1.0"
+status: draft
+created: 2026-08-13
+updated: 2026-08-13
+author: manager-spec
+priority: High
+phase: "v3.0.3"
+module: internal/hook
+lifecycle: spec-anchored
+era: V3R6
+tier: M
+tags: "hook, branch-guard, worktree, discriminant, bug-fix, sanitized-pair"
+depends_on:
+  - SPEC-WORKTREE-BRANCH-GUARD-001
+  - SPEC-WORKTREE-BRANCH-GUARD-OPTIN-001
+related_specs:
+  - SPEC-WORKTREE-BRANCH-GUARD-001
+  - SPEC-WORKTREE-BRANCH-GUARD-OPTIN-001
+---
+
+# SPEC-WORKTREE-BRANCH-GUARD-DISCRIM-001 — Worktree Discriminant Directory Correction
+
+## §A. Problem Statement
+
+The Main-Checkout Branch-State Guard landed by **SPEC-WORKTREE-BRANCH-GUARD-001**
+(status: completed) and refined by **SPEC-WORKTREE-BRANCH-GUARD-OPTIN-001**
+(status: completed) misclassifies a Claude-native worktree
+(`.claude/worktrees/<name>/`) as the primary checkout. When the orchestrator
+operates inside such a worktree and a legitimate branch-state command
+(`git rebase`, `git push --force-with-lease`, `git switch -c`, etc.) is issued
+there, the PreToolUse hook denies the command with
+`BRANCH_GUARD_VIOLATION: <suffix> in primary checkout`. The
+`MOAI_BRANCH_GUARD_EXEMPT=1` env prefix does NOT work around this because the
+hook runs in a separate Claude-Code-spawned process that does not inherit the
+agent's Bash env (the same env-propagation boundary documented in -001
+REQ-WBG-011's threat model).
+
+### Directly observed (PR #1476 session, worktree `.claude/worktrees/hook-pretool-perf`)
+
+Running `git rebase` and `git push --force-with-lease` inside the worktree was
+denied. Measured inside the worktree:
+
+- `git rev-parse --git-dir` →
+  `/Users/goos/MoAI/moai-adk-go/.git/worktrees/hook-pretool-perf`
+- `git rev-parse --git-common-dir` →
+  `/Users/goos/MoAI/moai-adk-go/.git`
+- `git rev-parse --show-toplevel` → the worktree path
+
+These git-dir / git-common-dir values **differ** → the doctrine's discriminant
+classifies the context as a worktree (not primary). Yet the guard still returned
+primary. The discriminant was being applied to the **wrong directory**.
+
+### Root cause (measured, not inferred)
+
+`internal/hook/pre_tool.go:487` passes `h.projectRoot()` to `checkBranchState`.
+`h.projectRoot()` resolves via `resolveProjectRootFromEnv`
+(`internal/hook/path_resolve.go:68`), which prefers `$CLAUDE_PROJECT_DIR` first
+and falls back to `os.Getwd()`. `$CLAUDE_PROJECT_DIR` is set by the Claude Code
+runtime to the **primary checkout root**, even when the active agent is
+operating inside a worktree (this is the documented B7 invariant at
+`internal/hook/CLAUDE.md §B7`: *"Never assume cwd equals project root —
+worktree hooks run with cwd inside worktrees/"*).
+
+`isPrimaryCheckout(projectDir)` then runs
+`git -C <primary-checkout> rev-parse --git-dir --git-common-dir`, which returns
+equal paths (both resolve to the primary's `.git`) → classifies as primary →
+emits the deny.
+
+But the agent's actual git command runs with cwd = the worktree path, where the
+two rev-parse values DIFFER. The discriminant answers *"is the primary checkout
+the primary checkout?"* instead of *"is the cwd the agent is about to operate in
+the primary checkout?"* — it queries the wrong directory.
+
+### Why candidate causes (1) and (3) are rejected
+
+The motivating brief proposed three candidate causes: (1) `--path-format=absolute`
+applying asymmetrically to `--git-dir` vs `--git-common-dir`, (2) projectDir
+source, and (3) output-line parsing. Direct measurement in the worktree (the two
+rev-parse values printed as distinct absolute paths) disproves (1) and (3): the
+flag applied uniformly and the two-line parser split correctly. The bug is (2):
+the projectDir passed in is the primary checkout, so the discriminant is
+answering the wrong question.
+
+## §B. Scope
+
+### In Scope
+
+1. **Discriminant directory correction.** The git-context directory that
+   `isPrimaryCheckout` queries MUST be the cwd the Bash command will actually
+   execute in (authoritatively `input.CWD` from the PreToolUse hook payload),
+   with the same fallback chain the rest of the hook system already uses when
+   `input.CWD` is absent. `$CLAUDE_PROJECT_DIR` MUST NOT be the primary source
+   for the git-context query.
+
+2. **Audit-log placement invariant.** `appendBranchGuardAdvisory` MUST continue
+   to write to `<primary-checkout>/.moai/logs/branch-guard-audit.log`
+  (resolved via `$CLAUDE_PROJECT_DIR` → `os.Getwd()` fallback) — it MUST NOT
+   rotate to `<command-cwd>/.moai/logs/`. The git-context directory and the
+   audit-log project directory were the same variable before and now MUST
+   diverge; the fix MUST separate these two concerns rather than mutate one
+   variable to serve both.
+
+3. **Primary-checkout regression.** Primary-checkout detection MUST still
+   classify the primary checkout as primary and deny branch-state commands there
+   for non-exempt agents. The fix changes behavior ONLY for the worktree case.
+
+4. **Doctrine bump** `main-checkout-branch-guard.md` v1.1.0 → v1.2.0
+   documenting the discriminant directory correction, with sanitized-pair mirror
+   parity per REQ-WBG-007 of -001.
+
+5. **Worktree fixture unit test** asserting the discriminant returns
+   `isPrimaryCheckout == false` for a real worktree git context.
+
+### Out of Scope
+
+#### Out of Scope — Discriminant mechanism redesign
+
+- Replacing the git-dir vs git-common-dir comparison with a different predicate
+  (e.g. `git rev-parse --is-inside-work-tree` plus a separate worktree-list
+  check). The current discriminant is correct in principle; only the directory
+  it was applied to was wrong.
+- Adding a `git worktree list` cross-check.
+
+#### Out of Scope — B7 resolution policy change for other handlers
+
+- Modifying `$CLAUDE_PROJECT_DIR`-first resolution for handlers other than the
+  branch guard. The B7 priority order is correct for handlers that want the
+  project root (post_tool_metrics, observability, session-start env injection,
+  etc.). Only the branch guard needs the actual command cwd.
+
+#### Out of Scope — Exemption mechanism
+
+- Touching `MOAI_BRANCH_GUARD_EXEMPT` semantics or the `manager-git` identity
+  check. Preserved byte-identical per -OPTIN-001 REQ-6.
+- Adding a new exemption surface for worktree-resident agents. The fix is in the
+  discriminant, not the exemption logic.
+
+#### Out of Scope — Late-Branch worktree migration
+
+- Migrating `manager-git.md` Phase D (Late-Branch closure) to operate in a
+  worktree rather than the primary checkout. Still out of scope per -001 §E.
+
+#### Out of Scope — Legacy EARS migration
+
+- Re-authoring pre-v3 SPECs from EARS to GEARS. The 6-month backward-compatibility
+  window remains active; this SPEC uses GEARS but does not migrate legacy SPECs.
+
+#### Out of Scope — Static deny reconciliation
+
+- Reconciling the existing static `deny` entries at `.claude/settings.json` with
+  the hook behavior. Out of scope per -001 §E.
+
+## §C. Requirements (GEARS notation)
+
+### REQ-WBG-D-001 — Discriminant Queries the Command CWD (Ubiquitous)
+
+The branch-state guard SHALL determine primary-vs-worktree by querying the git
+context of the working directory the Bash command will actually execute in
+(authoritatively `input.CWD` from the PreToolUse hook payload), NOT the project
+root resolved from `$CLAUDE_PROJECT_DIR`. When `input.CWD` is absent, the guard
+SHALL fall back to the same `CLAUDE_PROJECT_DIR` → `os.Getwd()` chain the rest
+of the hook system uses, and the choice SHALL be reflected in the audit-log
+advisory.
+
+### REQ-WBG-D-002 — Worktree Allow (Event-detected)
+
+**When** the actual command cwd resolves to a git worktree (absolute git-dir
+differs from absolute git-common-dir at that cwd), the branch-state guard SHALL
+emit `permissionDecision: "allow"` for branch-state commands, regardless of
+whether `$CLAUDE_PROJECT_DIR` points at the primary checkout.
+
+### REQ-WBG-D-003 — Primary Deny Preserved (State-driven)
+
+**While** the actual command cwd resolves to the primary checkout (absolute
+git-dir equals absolute git-common-dir at that cwd), the branch-state guard
+SHALL continue to deny branch-state commands for non-exempt agents — preserving
+the -001 / -OPTIN-001 behavior without regression.
+
+### REQ-WBG-D-004 — Audit-Log Placement Invariant (Ubiquitous)
+
+The branch-state guard SHALL write its fail-open advisory audit entries to
+`<primary-checkout>/.moai/logs/branch-guard-audit.log` (resolved via
+`$CLAUDE_PROJECT_DIR` → `os.Getwd()` fallback), NOT to
+`<command-cwd>/.moai/logs/` — independent of which directory the git-context
+discriminant queries.
+
+### REQ-WBG-D-005 — Fail-Open Preserved (Event-detected)
+
+**When** the resolved command cwd is not a git repo, the git binary is missing,
+OR `git rev-parse` exits non-zero at that cwd, the branch-state guard SHALL emit
+`permissionDecision: "allow"` AND write the advisory audit entry per
+REQ-WBG-D-004, preserving the -001 REQ-WBG-012 fail-open contract.
+
+### REQ-WBG-D-006 — Doctrine Bump v1.2.0 (Ubiquitous)
+
+The doctrine rule `.claude/rules/moai/workflow/main-checkout-branch-guard.md`
+SHALL carry `Version: 1.2.0` and document that the primary-vs-worktree
+discriminant queries the actual command cwd (`input.CWD`), not
+`$CLAUDE_PROJECT_DIR`. The sanitized-pair mirror at
+`internal/template/templates/.claude/rules/moai/workflow/main-checkout-branch-guard.md`
+SHALL be kept in parity (the rule path remains enrolled in `sanitizedPairPaths`
+per -001 REQ-WBG-007; no enrollment change is required, only content parity).
+
+### REQ-WBG-D-007 — Exemption Boundary Unchanged (Ubiquitous)
+
+The exemption mechanism (`HookInput.AgentType == "manager-git"` OR
+`MOAI_BRANCH_GUARD_EXEMPT=1` env var, per -001 REQ-WBG-011) SHALL remain
+byte-identical. The fix changes ONLY the discriminant directory; the exemption
+evaluation precedes the discriminant and is untouched.
+
+### REQ-WBG-D-008 — Latency Ceiling Preserved (State-driven)
+
+**While** the branch-guard handler runs under the PreToolUse timeout budget,
+the git-context query against the actual command cwd SHALL complete within the
+same per-invocation latency ceiling as the -001 REQ-WBG-010 budget (measured
+wall-time ≤ 500ms). The fix introduces NO additional git subprocess beyond the
+existing single `git -C <cwd> rev-parse --path-format=absolute --git-dir
+--git-common-dir` call (plus the existing fallback only when the primary path
+errors).
+
+## §D. Constraints
+
+- **Tier M**: 3-artifact plan-phase set (spec / plan / acceptance) + progress.md
+  §E skeleton.
+- **Repo-local PR-mandatory policy** (`repo-local-pr-policy.md`): ALL tier work
+  lands via PR (Route B); direct-to-main is disabled by branch protection
+  (`enforce_admins: true`).
+- **Template-First** (CLAUDE.local.md §2 [HARD]): doctrine rule edits land in
+  `internal/template/templates/` first; local mirror follows in the same commit
+  for sanitized-pair parity.
+- **Language neutrality** (CLAUDE.local.md §15): template portions must not
+  elevate any of the 16 supported languages. The rule wording is language-
+  neutral (speaks of git, not of Go).
+- **Flat hierarchy**: the fix extends the existing `preToolHandler.Handle` →
+  `checkBranchState` surface; no new package.
+- **verification-claim-integrity**: every AC names a command whose verbatim
+  output decides PASS/FAIL; no AC relies on grep token-presence alone.
+
+## §E. Acceptance Criteria (summary — full Given-When-Then in acceptance.md)
+
+| AC | Subject | Verifiable by |
+|----|---------|---------------|
+| AC-WBG-D-001 | Worktree discriminant: `isPrimaryCheckout(worktree-cwd)` returns `(false, nil)` | Go test fixture with a real worktree git context |
+| AC-WBG-D-002 | Worktree allow end-to-end: `git rebase` in worktree cwd → `permissionDecision: "allow"` | PreToolUse handler test with `input.CWD = <worktree>` |
+| AC-WBG-D-003 | Primary deny preserved: `git switch` in primary cwd → deny (regression) | PreToolUse handler test with `input.CWD = <primary>` |
+| AC-WBG-D-004 | Audit-log placement on primary: fail-open entry lands at `<primary>/.moai/logs/branch-guard-audit.log` even when command cwd is a worktree | Test asserting the audit log path |
+| AC-WBG-D-005 | Fail-open preserved at non-git command cwd | Test with `input.CWD = t.TempDir()` (non-git) |
+| AC-WBG-D-006 | Exemption unchanged: `MOAI_BRANCH_GUARD_EXEMPT=1` still bypasses | Existing exemption test still passes |
+| AC-WBG-D-007 | Latency ceiling ≤ 500ms per invocation | Benchmark / measured wall-time test |
+| AC-WBG-D-008 | Doctrine v1.2.0 + sanitized-pair mirror parity | `grep '^Version: 1.2.0'` + sanitized-pair parity test green |
+
+## §F. Cross-References
+
+- `.claude/rules/moai/workflow/main-checkout-branch-guard.md` (v1.1.0 → v1.2.0
+  per REQ-WBG-D-006) — doctrine SSOT.
+- `internal/hook/branch_guard.go` — `isPrimaryCheckout` (L167), `runGitRevParse`
+  (L209), `checkBranchState` (L231), `appendBranchGuardAdvisory` (L276).
+- `internal/hook/pre_tool.go:487` — call site passing `h.projectRoot()` (the bug
+  locus).
+- `internal/hook/path_resolve.go:68` — `resolveProjectRootFromEnv`
+  (`CLAUDE_PROJECT_DIR`-first; the helper whose priority is wrong for the
+  branch-guard use case).
+- `internal/hook/path_resolve.go:88` — `resolveProjectRootFromInputOrEnv`
+  (`input.CWD`-first; candidate helper for the fix).
+- `internal/hook/types.go:212` — `HookInput.CWD` field (authoritative source for
+  the command cwd).
+- `internal/hook/CLAUDE.md §B7` — `$CLAUDE_PROJECT_DIR` resolution priority
+  (documents the cwd-does-not-equal-project-root worktree invariant).
+- `internal/hook/protocol.go:113-119` — `validateInput` `input.CWD` fallback to
+  `$CLAUDE_PROJECT_DIR` when Claude Code omits cwd.
+- Predecessors: SPEC-WORKTREE-BRANCH-GUARD-001 (status: completed),
+  SPEC-WORKTREE-BRANCH-GUARD-OPTIN-001 (status: completed).
+- PR #1476 session — directly observed denial inside worktree
+  `.claude/worktrees/hook-pretool-perf`.
+
+## §G. HISTORY
+
+- 2026-08-13 v0.1.0 — initial draft (manager-spec, plan-phase). Root cause
+  confirmed by direct measurement: `$CLAUDE_PROJECT_DIR` (= primary checkout)
+  was being passed to `isPrimaryCheckout`, while the agent's git command ran in
+  a worktree. Rejected candidate causes (1) `--path-format=absolute` scope and
+  (3) output-line parsing per the directly-observed distinct rev-parse values.
+  Audit-log placement invariant (REQ-WBG-D-004) separated from git-context
+  directory to preserve central logging.

--- a/internal/hook/branch_guard.go
+++ b/internal/hook/branch_guard.go
@@ -220,14 +220,25 @@ func runGitRevParse(projectDir string, args ...string) (string, error) {
 }
 
 // checkBranchState returns DecisionDeny + a "BRANCH_GUARD_VIOLATION: <suffix>
-// in primary checkout (...)" reason when ALL THREE hold: (a) primary checkout,
-// (b) command matches a branch-state pattern, (c) invoking agent is not exempt.
-// Otherwise it returns ("", "") (allow fall-through). On git-context
-// uncertainty it fails OPEN: returns ("", "") AND writes an advisory to stderr
-// plus appends a structured entry to .moai/logs/branch-guard-audit.log
-// (REQ-WBG-012).
+// in primary checkout (...)" reason when ALL THREE hold: (a) primary checkout
+// AT THE COMMAND'S ACTUAL CWD, (b) command matches a branch-state pattern,
+// (c) invoking agent is not exempt. Otherwise it returns ("", "") (allow
+// fall-through). On git-context uncertainty it fails OPEN: returns ("", "")
+// AND writes an advisory to stderr plus appends a structured entry to
+// .moai/logs/branch-guard-audit.log (REQ-WBG-012).
 //
 // The deny fires ONLY on positive evidence; uncertainty never denies.
+//
+// The projectDir argument is the AUDIT-LOG project directory — resolved by the
+// caller (pre_tool.go) via $CLAUDE_PROJECT_DIR → os.Getwd() and pinned to the
+// primary checkout for central logging (REQ-WBG-D-004). It is NOT the
+// git-context directory. The git-context cwd — the directory the Bash command
+// will actually execute in — is resolved HERE from input.CWD via
+// resolveProjectRootFromInputOrEnv (SPEC-WORKTREE-BRANCH-GUARD-DISCRIM-001
+// REQ-WBG-D-001, Seam A). The two were a single variable before this SPEC and
+// MUST stay separate: querying the primary checkout about itself always
+// answered "primary", misclassifying a worktree-resident agent's command as a
+// primary-checkout violation.
 func checkBranchState(input *HookInput, projectDir string) (decision string, reason string) {
 	if input == nil || len(input.ToolInput) == 0 {
 		return "", ""
@@ -243,11 +254,20 @@ func checkBranchState(input *HookInput, projectDir string) (decision string, rea
 	if isExemptAgent(input) {
 		return "", ""
 	}
-	isPrimary, err := isPrimaryCheckout(projectDir)
+	// Seam A (SPEC-WORKTREE-BRANCH-GUARD-DISCRIM-001 REQ-WBG-D-001): query the
+	// git context at the command's actual cwd (input.CWD, falling back through
+	// the CLAUDE_PROJECT_DIR → os.Getwd() chain), NOT the audit-log project
+	// dir. This is the one-line correction that fixes the worktree
+	// misclassification — isPrimaryCheckout stays a pure function of its
+	// argument; only which directory the caller asks it to query changes.
+	gitContextCwd := resolveProjectRootFromInputOrEnv(input, "branch_guard")
+	isPrimary, err := isPrimaryCheckout(gitContextCwd)
 	if err != nil {
 		// Fail OPEN with advisory (REQ-WBG-012). The deny requires positive
-		// evidence of a primary checkout; an error is NOT evidence.
-		appendBranchGuardAdvisory(input, projectDir, command, err)
+		// evidence of a primary checkout; an error is NOT evidence. The
+		// resolved cwd is recorded in the advisory so a silent
+		// $CLAUDE_PROJECT_DIR fallback cannot re-introduce the bug (AP-D-003).
+		appendBranchGuardAdvisory(input, projectDir, command, err, gitContextCwd)
 		return "", ""
 	}
 	if !isPrimary {
@@ -271,18 +291,24 @@ func extractBranchStateCommand(toolInput json.RawMessage) string {
 
 // appendBranchGuardAdvisory writes a fail-open advisory to stderr and appends a
 // structured entry to <projectDir>/.moai/logs/branch-guard-audit.log
-// (REQ-WBG-012). Errors during logging are debug-level only — fail-open must
-// never block the hook's allow decision.
-func appendBranchGuardAdvisory(input *HookInput, projectDir, command string, cause error) {
+// (REQ-WBG-012). projectDir is the audit-log project directory (the primary
+// checkout, per REQ-WBG-D-004 — central logging MUST stay on the primary even
+// when the command cwd is a worktree). resolvedCwd is the git-context directory
+// the discriminant queried (input.CWD-resolved); it is recorded in the entry
+// (AP-D-003) so a silent $CLAUDE_PROJECT_DIR fallback that re-introduced the
+// discriminant bug would be observable in the audit trail. Errors during
+// logging are debug-level only — fail-open must never block the hook's allow
+// decision.
+func appendBranchGuardAdvisory(input *HookInput, projectDir, command string, cause error, resolvedCwd string) {
 	sessionID := ""
 	if input != nil {
 		sessionID = input.SessionID
 	}
-	msg := fmt.Sprintf("branch_guard: fail-open for command %q in %q: %v", command, projectDir, cause)
+	msg := fmt.Sprintf("branch_guard: fail-open for command %q at cwd %q (audit-log dir %q): %v", command, resolvedCwd, projectDir, cause)
 	fmt.Fprintln(os.Stderr, msg)
 
-	entry := fmt.Sprintf("[%s] session=%s command=%q cause=%v\n",
-		time.Now().UTC().Format(time.RFC3339), sessionID, command, cause)
+	entry := fmt.Sprintf("[%s] session=%s command=%q cwd=%q cause=%v\n",
+		time.Now().UTC().Format(time.RFC3339), sessionID, command, resolvedCwd, cause)
 	logPath := filepath.Join(projectDir, branchGuardAuditRelPath)
 	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
 		slog.Debug("branch_guard: could not create audit log dir", "path", logPath, "error", err)

--- a/internal/hook/branch_guard_test.go
+++ b/internal/hook/branch_guard_test.go
@@ -409,7 +409,7 @@ func TestAppendBranchGuardAdvisory_UnwritableDir(t *testing.T) {
 	}
 	input := &HookInput{SessionID: "sess-advisory"}
 	// Must not panic; the error is swallowed at debug log level.
-	appendBranchGuardAdvisory(input, filePath, "git switch -c x", fmt.Errorf("simulated rev-parse failure"))
+	appendBranchGuardAdvisory(input, filePath, "git switch -c x", fmt.Errorf("simulated rev-parse failure"), filePath)
 	// No audit log should have been created under the file-as-dir path.
 	if _, err := os.Stat(filepath.Join(filePath, branchGuardAuditRelPath)); err == nil {
 		t.Fatalf("audit log unexpectedly created under a file path")
@@ -518,7 +518,7 @@ func TestAppendBranchGuardAdvisory_WriteFailure(t *testing.T) {
 
 	input := &HookInput{SessionID: "sess-write-fail"}
 	// Must not panic; the error is swallowed at debug log level.
-	appendBranchGuardAdvisory(input, dir, "git switch -c x", fmt.Errorf("simulated"))
+	appendBranchGuardAdvisory(input, dir, "git switch -c x", fmt.Errorf("simulated"), dir)
 	// No audit log file should have been created (OpenFile failed).
 	if _, err := os.Stat(filepath.Join(dir, branchGuardAuditRelPath)); err == nil {
 		t.Fatalf("audit log unexpectedly created under read-only dir")

--- a/internal/hook/branch_guard_worktree_test.go
+++ b/internal/hook/branch_guard_worktree_test.go
@@ -1,0 +1,227 @@
+package hook
+
+// branch_guard_worktree_test.go — SPEC-WORKTREE-BRANCH-GUARD-DISCRIM-001 M1.
+//
+// Exercises the discriminant directory correction (Seam A): the git-context
+// query MUST resolve input.CWD (the command's actual cwd), NOT the audit-log
+// project dir (the primary checkout). The headline worktree-classification
+// tests use a REAL git worktree fixture (t.TempDir + git init + git worktree
+// add); the execCommand indirection is used ONLY for the fail-open fallback
+// path (AC-WBG-D-005), per AP-D-006 (no mocked discriminant for the headline
+// AC).
+//
+// @MX:NOTE: [AUTO] SPEC-WORKTREE-BRANCH-GUARD-DISCRIM-001 M1 worktree discriminant regression suite.
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// failingRevParseMock is a package-level execCommand replacement that makes
+// every `git ... rev-parse ...` invocation exit non-zero, forcing the
+// isPrimaryCheckout fail-open path. Used ONLY by AC-WBG-D-004 (audit-log
+// placement) — the headline worktree-classification tests use real git
+// (AP-D-006).
+var failingRevParseMock = func(name string, args ...string) *exec.Cmd {
+	return exec.Command("false")
+}
+
+// containsCwdToken reports whether the audit-log body records the resolved
+// cwd. AP-D-003 requires the resolved cwd to be observable in the advisory so
+// a silent $CLAUDE_PROJECT_DIR fallback cannot re-introduce the bug. The check
+// matches either a `cwd="<path>"` structured token or the bare path substring
+// (robust to the exact format string).
+func containsCwdToken(body, cwd string) bool {
+	return strings.Contains(body, "cwd=") && strings.Contains(body, cwd)
+}
+
+// worktreeFixture builds a primary git repo plus a real git worktree under
+// t.TempDir() and returns (primaryDir, worktreeDir). Both directories are
+// real git contexts — isPrimaryCheckout classifies them differently. Skips
+// when the git binary is absent (AC §B test-infrastructure note).
+func worktreeFixture(t *testing.T) (primaryDir, worktreeDir string) {
+	t.Helper()
+	requireGit(t)
+	primaryDir = t.TempDir()
+	gitInitRepo(t, primaryDir)
+	parent := t.TempDir()
+	worktreeDir = filepath.Join(parent, "wt")
+	mustRunGit(t, primaryDir, "worktree", "add", worktreeDir, "-b", "wt-branch")
+	return primaryDir, worktreeDir
+}
+
+// TestIsPrimaryCheckout_Worktree is the AC-WBG-D-001 headline assertion: a
+// real git worktree cwd classifies as NOT primary. The existing
+// TestIsPrimaryCheckout/Worktree subtest covers the same contract; this
+// dedicated top-level test matches the AC verification command's -run pattern
+// exactly and pins the headline classification independently of the suite's
+// other subtests.
+func TestIsPrimaryCheckout_Worktree(t *testing.T) {
+	t.Parallel()
+	_, worktreeDir := worktreeFixture(t)
+	isPrimary, err := isPrimaryCheckout(worktreeDir)
+	if err != nil {
+		t.Fatalf("isPrimaryCheckout(worktree) err = %v, want nil", err)
+	}
+	if isPrimary {
+		t.Fatalf("isPrimaryCheckout(worktree) = true, want false")
+	}
+}
+
+// TestBranchGuard_Worktree_Allow is the AC-WBG-D-002 end-to-end regression:
+// a branch-state git command (git rebase) running with input.CWD inside a
+// worktree MUST be allowed (not denied). Before the Seam A fix,
+// checkBranchState fed the primary checkout path into isPrimaryCheckout,
+// misclassifying the worktree context as primary and denying the command.
+// This is the RED driver for the fix (it fails against the pre-fix code).
+func TestBranchGuard_Worktree_Allow(t *testing.T) {
+	t.Parallel()
+	primaryDir, worktreeDir := worktreeFixture(t)
+
+	input := &HookInput{
+		ToolName:  "Bash",
+		CWD:       worktreeDir,
+		ToolInput: json.RawMessage(`{"command": "git rebase origin/main"}`),
+	}
+	// The audit-log project dir argument stays pinned to the primary checkout
+	// (REQ-WBG-D-004) — only the git-context query follows input.CWD.
+	decision, reason := checkBranchState(input, primaryDir)
+	if decision != "" {
+		t.Fatalf("checkBranchState(worktree cwd) decision = %q, want \"\" (allow); reason=%q", decision, reason)
+	}
+	if reason != "" {
+		t.Fatalf("checkBranchState(worktree cwd) reason = %q, want \"\"", reason)
+	}
+}
+
+// TestBranchGuard_Primary_Still_Denies is the AC-WBG-D-003 regression anchor:
+// the primary-checkout deny path is preserved post-fix. A branch-state
+// command with input.CWD = primary MUST still be denied. Failure here means
+// the fix over-corrected and broke the guard's core contract.
+func TestBranchGuard_Primary_Still_Denies(t *testing.T) {
+	t.Parallel()
+	primaryDir, _ := worktreeFixture(t)
+
+	input := &HookInput{
+		ToolName:  "Bash",
+		CWD:       primaryDir,
+		ToolInput: json.RawMessage(`{"command": "git switch feature-x"}`),
+	}
+	decision, reason := checkBranchState(input, primaryDir)
+	if decision != DecisionDeny {
+		t.Fatalf("checkBranchState(primary cwd) decision = %q, want %q", decision, DecisionDeny)
+	}
+	const wantPrefix = "BRANCH_GUARD_VIOLATION: git switch"
+	if len(reason) < len(wantPrefix) || reason[:len(wantPrefix)] != wantPrefix {
+		t.Fatalf("checkBranchState(primary cwd) reason = %q, want prefix %q", reason, wantPrefix)
+	}
+}
+
+// TestBranchGuard_AuditLog_Placement is the AC-WBG-D-004 invariant: when the
+// command cwd is a worktree but rev-parse fails (simulated via the
+// execCommand indirection), the fail-open advisory MUST be appended to
+// <primary>/.moai/logs/branch-guard-audit.log and NO file created at
+// <worktree>/.moai/logs/. AP-D-003: the resolved cwd MUST be observable in
+// the audit entry.
+func TestBranchGuard_AuditLog_Placement(t *testing.T) {
+	primaryDir, worktreeDir := worktreeFixture(t)
+
+	// Simulate rev-parse failure at the worktree cwd so the fail-open path
+	// fires. The mock rejects every git invocation.
+	orig := execCommand
+	t.Cleanup(func() { execCommand = orig })
+	execCommand = failingRevParseMock
+
+	input := &HookInput{
+		ToolName:  "Bash",
+		CWD:       worktreeDir,
+		ToolInput: json.RawMessage(`{"command": "git rebase origin/main"}`),
+	}
+	decision, reason := checkBranchState(input, primaryDir)
+	if decision != "" {
+		t.Fatalf("checkBranchState(simulated rev-parse fail) decision = %q, want \"\" (fail-open allow); reason=%q", decision, reason)
+	}
+
+	primaryLog := filepath.Join(primaryDir, branchGuardAuditRelPath)
+	if _, err := os.Stat(primaryLog); err != nil {
+		t.Fatalf("audit log NOT created at primary %s: %v", primaryLog, err)
+	}
+	worktreeLog := filepath.Join(worktreeDir, branchGuardAuditRelPath)
+	if _, err := os.Stat(worktreeLog); err == nil {
+		t.Fatalf("audit log MUST NOT be created at worktree %s — it must stay on the primary", worktreeLog)
+	}
+
+	// AP-D-003: the resolved cwd (the worktree) MUST be observable in the
+	// audit entry so a silent $CLAUDE_PROJECT_DIR fallback can't re-introduce
+	// the bug. Read the log and assert it records the worktree cwd.
+	data, err := os.ReadFile(primaryLog)
+	if err != nil {
+		t.Fatalf("read audit log: %v", err)
+	}
+	body := string(data)
+	if !containsCwdToken(body, worktreeDir) {
+		t.Fatalf("audit log entry does not record the resolved worktree cwd %q; AP-D-003 observability violated.\nlog:\n%s", worktreeDir, body)
+	}
+}
+
+// TestBranchGuard_FailOpen_NonGitCwd is the AC-WBG-D-005 contract: when
+// input.CWD is a non-git directory (real git invoked, rev-parse exits
+// non-zero), the guard MUST fail open (allow) AND write the audit entry to
+// the primary. No mock is used here — the real `git rev-parse` fails against
+// a non-git t.TempDir() (AP-D-006 headline-test discipline).
+func TestBranchGuard_FailOpen_NonGitCwd(t *testing.T) {
+	t.Parallel()
+	requireGit(t)
+	primaryDir := t.TempDir()
+	// Ensure primaryDir is itself non-git so the audit-log placement assertion
+	// is meaningful (the audit dir is primaryDir; rev-parse fails there too,
+	// but appendBranchGuardAdvisory creates the .moai/logs tree regardless).
+	nonGitCwd := t.TempDir()
+
+	input := &HookInput{
+		ToolName:  "Bash",
+		CWD:       nonGitCwd,
+		ToolInput: json.RawMessage(`{"command": "git rebase origin/main"}`),
+	}
+	decision, reason := checkBranchState(input, primaryDir)
+	if decision != "" {
+		t.Fatalf("checkBranchState(non-git cwd) decision = %q, want \"\" (fail-open allow); reason=%q", decision, reason)
+	}
+	primaryLog := filepath.Join(primaryDir, branchGuardAuditRelPath)
+	if _, err := os.Stat(primaryLog); err != nil {
+		t.Fatalf("audit log NOT created at primary %s: %v", primaryLog, err)
+	}
+	// AP-D-003: the resolved cwd (nonGitCwd) MUST be observable.
+	data, err := os.ReadFile(primaryLog)
+	if err != nil {
+		t.Fatalf("read audit log: %v", err)
+	}
+	if !containsCwdToken(string(data), nonGitCwd) {
+		t.Fatalf("audit log does not record the non-git cwd %q (AP-D-003)", nonGitCwd)
+	}
+}
+
+// TestBranchGuard_Exempt is the AC-WBG-D-006 regression anchor: the
+// MOAI_BRANCH_GUARD_EXEMPT=1 exemption fires before the discriminant, so a
+// branch-state command in the primary checkout is allowed. Non-parallel:
+// t.Setenv mutates process-global env.
+func TestBranchGuard_Exempt(t *testing.T) {
+	t.Setenv(branchGuardExemptEnv, "1")
+	t.Cleanup(func() { t.Setenv(branchGuardExemptEnv, "") })
+	primaryDir, _ := worktreeFixture(t)
+
+	input := &HookInput{
+		ToolName:  "Bash",
+		CWD:       primaryDir,
+		AgentType: "manager-develop",
+		ToolInput: json.RawMessage(`{"command": "git switch feature-x"}`),
+	}
+	decision, reason := checkBranchState(input, primaryDir)
+	if decision != "" {
+		t.Fatalf("checkBranchState(exempt) decision = %q, want \"\" (allow); reason=%q", decision, reason)
+	}
+}

--- a/internal/hook/pre_tool_branch_guard_integration_test.go
+++ b/internal/hook/pre_tool_branch_guard_integration_test.go
@@ -132,6 +132,7 @@ func TestBranchGuard_Latency(t *testing.T) {
 		HookEventName: "PreToolUse",
 		ToolName:      "Bash",
 		AgentType:     "manager-develop",
+		CWD:           repo,
 		ToolInput:     json.RawMessage(`{"command": "git switch -c feat/perf"}`),
 	}
 
@@ -206,6 +207,7 @@ func TestBranchGuard_CheckBranchStateOrigin(t *testing.T) {
 		HookEventName: "PreToolUse",
 		ToolName:      "Bash",
 		AgentType:     "manager-develop",
+		CWD:           repo,
 		ToolInput:     json.RawMessage(`{"command": "git switch -c feat/origin"}`),
 	}
 

--- a/internal/hook/pre_tool_branch_guard_optin_test.go
+++ b/internal/hook/pre_tool_branch_guard_optin_test.go
@@ -101,6 +101,7 @@ func TestPreTool_BranchGuard_ConfigGate_FlagFlips(t *testing.T) {
 		HookEventName: "PreToolUse",
 		ToolName:      "Bash",
 		AgentType:     "manager-develop",
+		CWD:           repo,
 		ToolInput:     json.RawMessage(`{"command": "` + command + `"}`),
 	}
 

--- a/internal/hook/pre_tool_test.go
+++ b/internal/hook/pre_tool_test.go
@@ -1574,6 +1574,7 @@ func TestBranchGuard_AllowsInWorktree(t *testing.T) {
 		HookEventName: "PreToolUse",
 		ToolName:      "Bash",
 		AgentType:     "manager-develop",
+		CWD:           wt,
 		ToolInput:     json.RawMessage(`{"command": "git switch -c feat/test"}`),
 	}
 	out, err := handler.Handle(context.Background(), input)

--- a/internal/hook/pre_tool_test.go
+++ b/internal/hook/pre_tool_test.go
@@ -1507,6 +1507,7 @@ func TestBranchGuard_DeniesGitSwitchInPrimary(t *testing.T) {
 			HookEventName: "PreToolUse",
 			ToolName:      "Bash",
 			AgentType:     "manager-develop",
+			CWD:           repo,
 			ToolInput:     json.RawMessage(`{"command": "git switch -c feat/test"}`),
 		}
 		out, err := handler.Handle(context.Background(), input)
@@ -1684,6 +1685,7 @@ func TestBranchGuard_FailOpenOnGitError(t *testing.T) {
 		HookEventName: "PreToolUse",
 		ToolName:      "Bash",
 		AgentType:     "manager-develop",
+		CWD:           nonGit,
 		ToolInput:     json.RawMessage(`{"command": "git switch -c feat/test"}`),
 	}
 	out, err := handler.Handle(context.Background(), input)

--- a/internal/template/templates/.claude/rules/moai/workflow/main-checkout-branch-guard.md
+++ b/internal/template/templates/.claude/rules/moai/workflow/main-checkout-branch-guard.md
@@ -114,10 +114,19 @@ flows. The hook applies the doctrine conditionally.
   source without parsing the full reason string.
 - **Discriminant (primary vs worktree)**: the hook compares the absolute
   `git rev-parse --git-dir` against the absolute `git rev-parse
-  --git-common-dir`; equal paths classify as the primary checkout, differing
-  paths as a worktree. Primary path uses `--path-format=absolute` (git 2.31+,
-  March 2021); older git or Apple Git that rejects the flag falls back to
-  `git rev-parse --absolute-git-dir` + cwd-normalized `--git-common-dir`.
+  --git-common-dir` **at the command's actual cwd**; equal paths classify as
+  the primary checkout, differing paths as a worktree. The cwd is resolved
+  from `input.CWD` (via `resolveProjectRootFromInputOrEnv`: `input.CWD`, then
+  `$CLAUDE_PROJECT_DIR`, then `os.Getwd()`), NOT from `$CLAUDE_PROJECT_DIR`
+  alone — querying the primary checkout about itself always answered
+  "primary", which misclassified a worktree-resident agent's branch-state
+  command as a primary-checkout violation (discriminant directory correction,
+  v1.2.0). The audit-log project directory stays pinned to
+  `$CLAUDE_PROJECT_DIR` → `os.Getwd()` for central logging, independent of
+  which directory the git-context discriminant queries. Primary path uses
+  `--path-format=absolute` (git 2.31+, March 2021); older git or Apple Git
+  that rejects the flag falls back to `git rev-parse --absolute-git-dir` +
+  cwd-normalized `--git-common-dir`.
 - **Exemption mechanism**: the deny is suppressed when EITHER the invoking
   agent identity is the trusted git agent (`HookInput.AgentType ==
   "manager-git"`, populated on main-thread `claude --agent manager-git`) OR
@@ -135,7 +144,8 @@ flows. The hook applies the doctrine conditionally.
 
 Origin: the run-phase SPEC that landed the v1.1.0 mechanical enforcer. The
 v1.2.0 opt-in gate and pattern refinement landed in a follow-up behavior-tuning
-SPEC.
+SPEC; the v1.2.0 discriminant directory correction (query the command cwd, not
+$CLAUDE_PROJECT_DIR) landed in a second follow-up SPEC.
 
 ## Cross-references
 
@@ -146,5 +156,5 @@ SPEC.
 
 ---
 
-Version: 1.1.0
+Version: 1.2.0
 Classification: Evolvable operational rule — branch-state isolation; changes no gate semantics.


### PR DESCRIPTION
## SPEC-WORKTREE-BRANCH-GUARD-DISCRIM-001 — Worktree Discriminant Directory Correction

Fixes the worktree misclassification: `checkBranchState` was passing `h.projectRoot()` (`$CLAUDE_PROJECT_DIR` = primary checkout) into `isPrimaryCheckout`, so a worktree-resident agent's branch-state command (`git rebase`, `git push --force-with-lease`) was denied as a primary-checkout violation.

### Fix (Seam A)
`checkBranchState` now resolves the git-context cwd via `input.CWD` (`resolveProjectRootFromInputOrEnv`), not the audit-log project dir. The audit-log dir stays pinned to the primary (REQ-WBG-D-004); the resolved cwd is recorded in the advisory (AP-D-003). Predecessors SPEC-WORKTREE-BRANCH-GUARD-001 + -OPTIN-001 are both completed.

### Acceptance criteria (acceptance.md)
| AC | Subject | Status |
|----|---------|--------|
| AC-WBG-D-001 | worktree isPrimaryCheckout=false | PASS |
| AC-WBG-D-002 | worktree allow end-to-end | PASS |
| AC-WBG-D-003 | primary deny preserved (regression) | PASS |
| AC-WBG-D-004 | audit-log on primary | PASS |
| AC-WBG-D-005 | fail-open non-git cwd | PASS |
| AC-WBG-D-006 | exemption unchanged | PASS |
| AC-WBG-D-007 | latency ≤500ms | PASS |
| AC-WBG-D-008 | doctrine v1.2.0 + sanitized-pair parity | PASS |

### Verification (HEAD 8d0a35556)
- branch-guard suite green (new real-git-worktree fixture tests + existing); hook package `ok`; template parity/leak `ok`
- build darwin/windows/linux exit 0; golangci-lint 0 issues; subagent-boundary grep 0 matches
- affected-file coverage: `checkBranchState` 100%, `isPrimaryCheckout` 94.1%, `appendBranchGuardAdvisory` 94.4%

### Note
Tier M, Route B (repo-local PR-mandatory). squash merge. 3-phase close (plan+run) lands here; `/moai sync` follows after merge to carry `implemented -> completed`.

🗿 MoAI