### PR TITLE
fix(svg-infographic): align local SKILL.md to template parity

### DIFF
--- a/.claude/skills/moai-domain-svg-infographic/SKILL.md
+++ b/.claude/skills/moai-domain-svg-infographic/SKILL.md
@@ -101,7 +101,7 @@ written; that ordering is the whole method.
 
 ## The numeric layout pass
 
-Build one table before authoring. Four owned columns per box — `id`, `x`, `y`,
+Build one table before authoring. Five owned columns per box — `id`, `x`, `y`,
 `w`, `h` — and nothing else is typed by hand. Every other number in the file is
 derived from those.
 
@@ -183,9 +183,9 @@ language only. Rewrite the label.
 ## Linting the source
 
 ```bash
-node scripts/check-svg.mjs diagram.svg          # human-readable diagnostics
-node scripts/check-svg.mjs diagram.svg --json   # machine-readable
-node scripts/check-svg.mjs diagram.svg --strict # warnings also fail
+node ${CLAUDE_SKILL_DIR}/scripts/check-svg.mjs diagram.svg          # human-readable diagnostics
+node ${CLAUDE_SKILL_DIR}/scripts/check-svg.mjs diagram.svg --json   # machine-readable
+node ${CLAUDE_SKILL_DIR}/scripts/check-svg.mjs diagram.svg --strict # warnings also fail
 ```
 
 Every diagnostic carries `file:line:column`, a stable code, and a message. The
@@ -215,8 +215,8 @@ report it as a manual check — never as a lint result.
 ## Rendering and verifying the PNG
 
 ```bash
-node scripts/render.mjs diagram.svg --out diagram.png            # 2x default
-node scripts/render.mjs diagram.svg --out diagram.png --scale 3
+node ${CLAUDE_SKILL_DIR}/scripts/render.mjs diagram.svg --out diagram.png            # 2x default
+node ${CLAUDE_SKILL_DIR}/scripts/render.mjs diagram.svg --out diagram.png --scale 3
 ```
 
 The renderer resolves a Chromium-family executable from `CHROME_PATH`, then from


### PR DESCRIPTION
## Summary

Restores byte-identical parity between local and template copies of .

## Changes

- **Absolute script paths**: Restored  prefix for  and  (local had relative )
- **Column count correction**: "Four owned columns" → "Five owned columns" (id, x, y, w, h = 5 columns; local was incorrect)

## Impact

- 1 file changed: 
- +6/-6 lines (Go 0 additions)
- No functional changes to scripts, only documentation parity

🗿 MoAI