### PR TITLE
chore(ci): harden .github config — label parity, enforce_admins, dead output cleanup

### DIFF
--- a/.github/actions/detect-language/action.yml
+++ b/.github/actions/detect-language/action.yml
@@ -20,16 +20,16 @@ runs:
         LANG_FILE=$(find . \( \
             -name "*.go" -o -name "*.py" -o -name "*.ts" -o -name "*.js" \
             -o -name "*.rs" -o -name "*.java" -o -name "*.kt" -o -name "*.cs" \
-            -o -name "*.rb" -o -name "*.php" -o -name "*.ex" -o -name "*.cpp" \
+            -o -name "*.rb" -o -name "*.php" -o -name "*.ex" -o -name "*.exs" -o -name "*.cpp" \
             -o -name "*.scala" -o -name "*.r" -o -name "*.dart" -o -name "*.swift" \
           \) \
           -not -path './node_modules/*' \
           -not -path './vendor/*' \
           -not -path './.git/*' \
           -print -quit 2>/dev/null)
-        LANG_COUNT="${LANG_FILE##*.}"
+        LANG_EXT="${LANG_FILE##*.}"
 
-        case "$LANG_COUNT" in
+        case "$LANG_EXT" in
           go) echo "language=go" >> $GITHUB_OUTPUT ;;
           py) echo "language=python" >> $GITHUB_OUTPUT ;;
           ts) echo "language=typescript" >> $GITHUB_OUTPUT ;;

--- a/.github/branch-protection.json.gtmpl
+++ b/.github/branch-protection.json.gtmpl
@@ -3,7 +3,7 @@
     "strict": true,
     "contexts": [{{range $i, $c := .Contexts}}{{if $i}}, {{end}}{{printf "%q" $c}}{{end}}]
   },
-  "enforce_admins": false,
+  "enforce_admins": true,
   "required_pull_request_reviews": {
     "dismiss_stale_reviews": true,
     "require_code_owner_reviews": false,

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,7 +26,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     labels:
       - "dependencies"
       - "area:ci"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -103,6 +103,10 @@
   color: "d876e3"
   description: "Test addition or improvement"
 
+- name: "type:performance"
+  color: "16b863"
+  description: "Performance improvement"
+
 # --- priority:* (required) ---
 - name: "priority:P0"
   color: "b60205"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -144,6 +144,11 @@ autolabeler:
       - '/^test(\(.+\))?!?:/i'
     files:
       - '**/*_test.go'
+  - label: 'type:performance'
+    title:
+      - '/^perf(\(.+\))?!?:/i'
+    branch:
+      - '/^perf\/.+/'
   - label: 'breaking'
     title:
       - '/^[a-z]+(\(.+\))?!:/i'

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -98,14 +98,24 @@ jobs:
         if: steps.checks.outputs.should_merge == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_BRANCH: ${{ steps.pr.outputs.branch }}
         run: |
           PR_NUMBER="${{ steps.pr.outputs.number }}"
-          echo "Auto-merging PR #$PR_NUMBER..."
+          echo "Auto-merging PR #$PR_NUMBER ($PR_BRANCH)..."
 
-          # Try squash merge first
-          if gh pr merge "$PR_NUMBER" --squash --delete-branch; then
+          # Release/hotfix PRs preserve individual SPEC history via --merge.
+          # All other branches use --squash (Enhanced GitHub Flow §18.3).
+          if [[ "$PR_BRANCH" == release/* || "$PR_BRANCH" == hotfix/* ]]; then
+            MERGE_FLAG="--merge"
+            echo "Using --merge (release/hotfix branch — preserve history)"
+          else
+            MERGE_FLAG="--squash"
+            echo "Using --squash (feature branch — squash WIP commits)"
+          fi
+
+          if gh pr merge "$PR_NUMBER" $MERGE_FLAG --delete-branch; then
             echo "Successfully merged PR #$PR_NUMBER"
           else
             echo "Merge failed, trying with --auto for deferred merge..."
-            gh pr merge "$PR_NUMBER" --squash --delete-branch --auto || true
+            gh pr merge "$PR_NUMBER" $MERGE_FLAG --delete-branch --auto || true
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,26 +42,12 @@ jobs:
     timeout-minutes: 5
     outputs:
       go_code: ${{ steps.f.outputs.go_code }}
-      docs_only: ${{ steps.f.outputs.docs_only }}
     steps:
       - uses: actions/checkout@v7
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: f
         with:
           filters: |
-            docs_only:
-              - '**.md'
-              - '.github/**'
-              - '.moai/specs/**'
-              - '.moai/docs/**'
-              - '.moai/reports/**'
-              - '.moai/research/**'
-              - '.claude/rules/**'
-              - '.claude/skills/**'
-              - 'docs-site/**'
-              - 'CHANGELOG.md'
-              - 'LICENSE'
-              - 'NOTICE'
             go_code:
               - '**/*.go'
               - 'go.mod'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,26 +32,12 @@ jobs:
     # Only needed for PR context; push/schedule bypass via analyze job conditions
     outputs:
       go_code: ${{ steps.f.outputs.go_code }}
-      docs_only: ${{ steps.f.outputs.docs_only }}
     steps:
       - uses: actions/checkout@v7
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: f
         with:
           filters: |
-            docs_only:
-              - '**.md'
-              - '.github/**'
-              - '.moai/specs/**'
-              - '.moai/docs/**'
-              - '.moai/reports/**'
-              - '.moai/research/**'
-              - '.claude/rules/**'
-              - '.claude/skills/**'
-              - 'docs-site/**'
-              - 'CHANGELOG.md'
-              - 'LICENSE'
-              - 'NOTICE'
             go_code:
               - '**/*.go'
               - 'go.mod'

--- a/.github/workflows/docs-i18n-check.yml
+++ b/.github/workflows/docs-i18n-check.yml
@@ -10,8 +10,10 @@ name: docs i18n parity check
 #     job log, and produces a sticky comment summary — but does NOT block
 #     the merge. This gives contributors visibility into the 35 existing
 #     drifts without blocking routine work.
-#   Phase 2 (after baseline is cleared): flip DOCS_I18N_STRICT=1 to block
-#     further regressions.
+#   Phase 2 (flip trigger: scripts/docs-i18n-check.sh reports 0 ERROR drifts
+#     on main — track via the check-output.txt "❌ ERROR" count): set the PR
+#     and push `strict` decisions to `true` in the "Determine strictness" step
+#     below, enforcing DOCS_I18N_STRICT=1 to block further regressions.
 #
 # Manual runs are always strict so maintainers can validate a fix set
 # before flipping the env flag globally.

--- a/.github/workflows/spec-lint.yml
+++ b/.github/workflows/spec-lint.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      # Version alignment with ci.yml: actions/checkout@v5, actions/setup-go@v6.
+      # Version alignment with ci.yml: actions/checkout@v7, actions/setup-go@v7.
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:

--- a/internal/cli/branch_protection.go
+++ b/internal/cli/branch_protection.go
@@ -81,7 +81,7 @@ const branchProtectionTemplate = `{
     "strict": true,
     "contexts": [{{range $i, $c := .Contexts}}{{if $i}}, {{end}}{{printf "%q" $c}}{{end}}]
   },
-  "enforce_admins": false,
+  "enforce_admins": true,
   "required_pull_request_reviews": {
     "dismiss_stale_reviews": true,
     "require_code_owner_reviews": false,

--- a/internal/template/templates/.github/actions/detect-language/action.yml
+++ b/internal/template/templates/.github/actions/detect-language/action.yml
@@ -20,16 +20,16 @@ runs:
         LANG_FILE=$(find . \( \
             -name "*.go" -o -name "*.py" -o -name "*.ts" -o -name "*.js" \
             -o -name "*.rs" -o -name "*.java" -o -name "*.kt" -o -name "*.cs" \
-            -o -name "*.rb" -o -name "*.php" -o -name "*.ex" -o -name "*.cpp" \
+            -o -name "*.rb" -o -name "*.php" -o -name "*.ex" -o -name "*.exs" -o -name "*.cpp" \
             -o -name "*.scala" -o -name "*.r" -o -name "*.dart" -o -name "*.swift" \
           \) \
           -not -path './node_modules/*' \
           -not -path './vendor/*' \
           -not -path './.git/*' \
           -print -quit 2>/dev/null)
-        LANG_COUNT="${LANG_FILE##*.}"
+        LANG_EXT="${LANG_FILE##*.}"
 
-        case "$LANG_COUNT" in
+        case "$LANG_EXT" in
           go) echo "language=go" >> $GITHUB_OUTPUT ;;
           py) echo "language=python" >> $GITHUB_OUTPUT ;;
           ts) echo "language=typescript" >> $GITHUB_OUTPUT ;;

--- a/internal/template/templates/.github/branch-protection.json.gtmpl
+++ b/internal/template/templates/.github/branch-protection.json.gtmpl
@@ -3,7 +3,7 @@
     "strict": true,
     "contexts": [{{range $i, $c := .Contexts}}{{if $i}}, {{end}}{{printf "%q" $c}}{{end}}]
   },
-  "enforce_admins": false,
+  "enforce_admins": true,
   "required_pull_request_reviews": {
     "dismiss_stale_reviews": true,
     "require_code_owner_reviews": false,

--- a/internal/template/templates/.github/labels.yml
+++ b/internal/template/templates/.github/labels.yml
@@ -82,6 +82,10 @@
   color: "d876e3"
   description: "Test addition or improvement"
 
+- name: "type:performance"
+  color: "16b863"
+  description: "Performance improvement"
+
 # ============================================================================
 # priority:*
 # ============================================================================


### PR DESCRIPTION
## Summary

Harden `.github/` configuration from a full audit. This is a Tier S chore cleanup with 9 improvement items.

## Changes

1. **Label parity** — added missing `type:performance` label (referenced by release-drafter.yml but undefined)
2. **Autolabeler** — added `perf:` mapping in release-drafter.yml
3. **detect-language action** — added `.exs` Elixir detection, renamed `LANG_COUNT`→`LANG_EXT`
4. **Branch protection** — `enforce_admins: false`→`true` (aligns with CLAUDE.local.md §18 policy)
5. **spec-lint workflow** — fixed stale comment (`@v5/@v6` → `@v7`)
6. **auto-merge workflow** — route release/hotfix PRs to `--merge`, others to `--squash`
7. **docs-i18n-check workflow** — documented Phase 2 flip trigger
8. **ci/codeql workflows** — removed unused `docs_only` output + filter
9. **dependabot** — github-actions PR limit 5→10

## Testing

- Local verification: `go vet`, `actionlint`, `make build` all passed
- Only Go change: `branch_protection.go` (constant value, no test references)

## Merge Strategy

Squash merge (chore branch per PULL_REQUEST_TEMPLATE §18.3).