### PR TITLE
fix(config): audit parity accepts template source as fallback for llm.yaml (#1499 regression)

### DIFF
--- a/internal/config/audit_registry.go
+++ b/internal/config/audit_registry.go
@@ -154,15 +154,26 @@ func ScanYAMLOrphans(sectionsDir string, registry map[string]string, exceptions 
 }
 
 // ScanOrphanStructs returns a list of registry keys whose yaml files are absent
-// from the given sectionsDir. This detects registry entries that have no matching
-// yaml file on disk (the "orphan struct" direction of the parity check).
+// from ALL of the given section directories (the union of on-disk yaml basenames
+// across every dir is treated as "present"). This detects registry entries that
+// have no matching yaml file on disk (the "orphan struct" direction of the parity
+// check).
+//
+// Callers pass the runtime sections dir first, then fallback sources. A per-machine
+// section (e.g. llm.yaml, whose tracked runtime copy was removed by #1499 and whose
+// template default lives at internal/template/templates/.moai/config/sections/) is
+// passed as a second dir so the registry entry is satisfied by the template source
+// rather than flagged as an orphan against a runtime tree that no longer carries it.
 //
 // REQ-V3R2-RT-005-008, REQ-V3R2-RT-005-021
-func ScanOrphanStructs(sectionsDir string, registry map[string]string) []string {
-	// Build set of yaml basenames present on disk
-	entries, err := os.ReadDir(sectionsDir)
+func ScanOrphanStructs(sectionsDirs []string, registry map[string]string) []string {
+	// Build set of yaml basenames present across ALL given dirs (union).
 	present := map[string]bool{}
-	if err == nil {
+	for _, dir := range sectionsDirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
 		for _, entry := range entries {
 			if entry.IsDir() {
 				continue

--- a/internal/config/audit_test.go
+++ b/internal/config/audit_test.go
@@ -26,6 +26,10 @@ func TestAuditParity(t *testing.T) {
 	}
 	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..")
 	sectionsDir := filepath.Join(repoRoot, ".moai", "config", "sections")
+	// templateSectionsDir is the SSOT for shipped section defaults. Per-machine
+	// sections whose tracked runtime copy was removed (llm.yaml, #1499) live here,
+	// so the orphan-struct check accepts the template source as a fallback presence.
+	templateSectionsDir := filepath.Join(repoRoot, "internal", "template", "templates", ".moai", "config", "sections")
 
 	if _, err := os.Stat(sectionsDir); os.IsNotExist(err) {
 		t.Fatalf("sections dir %s not found — the tracked project config tree is missing", sectionsDir)
@@ -41,8 +45,10 @@ func TestAuditParity(t *testing.T) {
 		t.Errorf("orphan yaml file (no Go struct mapping): %s (add to audit_registry.go or YAMLAuditExceptions)", base+".yaml")
 	}
 
-	// 2. Check for orphan structs (registry entries with no yaml on disk)
-	orphanStructs := ScanOrphanStructs(sectionsDir, registry)
+	// 2. Check for orphan structs (registry entries with no yaml on disk).
+	// Pass both the runtime sections dir and the template source: per-machine
+	// sections (llm.yaml, #1499) are satisfied by the template default.
+	orphanStructs := ScanOrphanStructs([]string{sectionsDir, templateSectionsDir}, registry)
 	for _, orphan := range orphanStructs {
 		t.Errorf("registry maps %s → struct but no %s.yaml found in %s", orphan, orphan, sectionsDir)
 	}
@@ -132,7 +138,7 @@ func TestAuditParity_OrphanStructFails(t *testing.T) {
 	}
 	// No yaml files in sectionsDir — all registry entries should be reported as orphan structs
 
-	orphans := ScanOrphanStructs(sectionsDir, GetYAMLToStructRegistry())
+	orphans := ScanOrphanStructs([]string{sectionsDir}, GetYAMLToStructRegistry())
 	// At least some orphan structs expected when yaml dir is empty
 	if len(orphans) == 0 {
 		t.Errorf("ScanOrphanStructs() returned no orphans for empty sections dir, expected at least one registered section to be reported")


### PR DESCRIPTION
## Problem (main regression)

`#1499` moved `.moai/config/sections/llm.yaml` to per-machine `.gitignore` and deleted the tracked runtime copy. `TestAuditParity`'s `ScanOrphanStructs` checked only the runtime sections dir, so on a fresh CI checkout (no `moai init/update`) the registry's `llm → LLMConfig` mapping found no yaml on disk and the test failed (`audit_test.go:47`).

This broke **main** and blocked **#1492** and **#1496** — their changes are unrelated, but CI was BLOCKED by this `TestAuditParity` failure carried via update-branch.

## Fix

`ScanOrphanStructs` now takes `[]string` (union of present yaml across dirs); `TestAuditParity` passes the template source (`internal/template/templates/.moai/config/sections`) as a fallback, matching #1499's intent that the template default carries per-machine sections. `OrphanStructFails` still passes a single empty dir, preserving the orphan-detection contract.

## Verification (RED→GREEN, no false PASS)

- **RED reproduced**: `TestAuditParity` FAIL with `llm.yaml` absent — byte-identical to the CI failure
- **GREEN**: `TestAuditParity` + 8 variants PASS under CI conditions (`llm.yaml` absent, template source present)
- `./internal/config/...` full green; `go vet` + `go build ./...` clean

## After merge

#1492 and #1496 need `update-branch` then auto-merge.

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration auditing when section files are split across multiple directories.
  * Missing or unreadable directories no longer prevent valid fallback files from being recognized.
  * Registry checks now more reliably identify only entries without corresponding configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->