### PR TITLE
fix(template): harden hook commands against missing script

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,8 @@
         "matcher": "startup|resume|clear|compact|fork",
         "hooks": [
           {
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-session-start.sh\"",
+            "command": "bash",
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-session-start.sh"],
             "timeout": 30,
             "type": "command"
           }
@@ -18,7 +19,8 @@
         "matcher": "manual|auto",
         "hooks": [
           {
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-compact.sh\"",
+            "command": "bash",
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-compact.sh"],
             "timeout": 30,
             "type": "command"
           }
@@ -29,7 +31,8 @@
       {
         "hooks": [
           {
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-session-end.sh\"",
+            "command": "bash",
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-session-end.sh"],
             "timeout": 10,
             "type": "command"
           }
@@ -40,7 +43,8 @@
       {
         "hooks": [
           {
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-pre-tool.sh\"",
+            "command": "bash",
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-pre-tool.sh"],
             "timeout": 10,
             "type": "command"
           }
@@ -50,7 +54,8 @@
       {
         "hooks": [
           {
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-pre-tool.sh\"",
+            "command": "bash",
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-pre-tool.sh"],
             "timeout": 10,
             "type": "command"
           }
@@ -62,18 +67,21 @@
       {
         "hooks": [
           {
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-post-tool.sh\"",
+            "command": "bash",
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-post-tool.sh"],
             "timeout": 10,
             "type": "command",
             "async": true
           },
           {
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/status-transition-ownership.sh\"",
+            "command": "bash",
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/status-transition-ownership.sh"],
             "timeout": 5,
             "type": "command"
           },
           {
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-security-scan.sh\"",
+            "command": "bash",
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-security-scan.sh"],
             "timeout": 5,
             "type": "command",
             "async": true
@@ -84,7 +92,8 @@
       {
         "hooks": [
           {
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-harness-observe.sh\"",
+            "command": "bash",
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-harness-observe.sh"],
             "timeout": 5,
             "type": "command",
             "async": true
@@ -96,45 +105,53 @@
       {
         "hooks": [
           {
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-stop.sh\"",
+            "command": "bash",
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-stop.sh"],
             "timeout": 5,
             "type": "command",
             "async": true
           },
           {
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/sync-phase-quality-gate.sh\"",
+            "command": "bash",
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/sync-phase-quality-gate.sh"],
             "timeout": 60,
             "type": "command"
           },
           {
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-stop-goal.sh\"",
+            "command": "bash",
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-stop-goal.sh"],
             "timeout": 120,
             "type": "command"
           },
           {
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-security-turn.sh\"",
+            "command": "bash",
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-security-turn.sh"],
             "timeout": 5,
             "type": "command",
             "async": true
           },
           {
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-security-commit.sh\"",
+            "command": "bash",
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-security-commit.sh"],
             "timeout": 5,
             "type": "command",
             "async": true
           },
           {
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-codex-review-gate.sh\"",
+            "command": "bash",
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-codex-review-gate.sh"],
             "timeout": 900,
             "type": "command"
           },
           {
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-multi-review-gate.sh\"",
+            "command": "bash",
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-multi-review-gate.sh"],
             "timeout": 900,
             "type": "command"
           },
           {
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-harness-observe-stop.sh\"",
+            "command": "bash",
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-harness-observe-stop.sh"],
             "timeout": 5,
             "type": "command",
             "async": true
@@ -146,12 +163,14 @@
       {
         "hooks": [
           {
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-subagent-stop.sh\"",
+            "command": "bash",
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-subagent-stop.sh"],
             "timeout": 5,
             "type": "command"
           },
           {
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-harness-observe-subagent-stop.sh\"",
+            "command": "bash",
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-harness-observe-subagent-stop.sh"],
             "timeout": 5,
             "type": "command",
             "async": true
@@ -163,7 +182,8 @@
       {
         "hooks": [
           {
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-post-tool-failure.sh\"",
+            "command": "bash",
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-post-tool-failure.sh"],
             "timeout": 5,
             "type": "command"
           }
@@ -174,7 +194,8 @@
       {
         "hooks": [
           {
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-subagent-start.sh\"",
+            "command": "bash",
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-subagent-start.sh"],
             "timeout": 5,
             "type": "command"
           }
@@ -185,12 +206,14 @@
       {
         "hooks": [
           {
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-user-prompt-submit.sh\"",
+            "command": "bash",
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-user-prompt-submit.sh"],
             "timeout": 5,
             "type": "command"
           },
           {
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-harness-observe-user-prompt-submit.sh\"",
+            "command": "bash",
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-harness-observe-user-prompt-submit.sh"],
             "timeout": 5,
             "type": "command",
             "async": true
@@ -202,7 +225,8 @@
       {
         "hooks": [
           {
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-teammate-idle.sh\"",
+            "command": "bash",
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-teammate-idle.sh"],
             "timeout": 60,
             "type": "command"
           }
@@ -213,7 +237,8 @@
       {
         "hooks": [
           {
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-task-completed.sh\"",
+            "command": "bash",
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-task-completed.sh"],
             "timeout": 60,
             "type": "command"
           }
@@ -225,7 +250,8 @@
         "matcher": "project_settings|local_settings|skills",
         "hooks": [
           {
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-config-change.sh\"",
+            "command": "bash",
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-config-change.sh"],
             "timeout": 5,
             "type": "command"
           }
@@ -237,7 +263,8 @@
         "matcher": "rate_limit|authentication_failed|billing_error|max_output_tokens",
         "hooks": [
           {
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-stop-failure.sh\"",
+            "command": "bash",
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-stop-failure.sh"],
             "timeout": 5,
             "type": "command"
           }
@@ -249,7 +276,8 @@
         "matcher": "manual|auto",
         "hooks": [
           {
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-post-compact.sh\"",
+            "command": "bash",
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-post-compact.sh"],
             "timeout": 5,
             "type": "command"
           }
@@ -260,7 +288,8 @@
       {
         "hooks": [
           {
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-instructions-loaded.sh\"",
+            "command": "bash",
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-instructions-loaded.sh"],
             "timeout": 5,
             "type": "command",
             "async": true
@@ -272,7 +301,8 @@
       {
         "hooks": [
           {
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-cwd-changed.sh\"",
+            "command": "bash",
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-cwd-changed.sh"],
             "timeout": 5,
             "type": "command"
           }
@@ -283,7 +313,8 @@
       {
         "hooks": [
           {
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-file-changed.sh\"",
+            "command": "bash",
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-file-changed.sh"],
             "timeout": 5,
             "type": "command"
           }
@@ -295,7 +326,8 @@
       {
         "hooks": [
           {
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-permission-denied.sh\"",
+            "command": "bash",
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-permission-denied.sh"],
             "timeout": 5,
             "type": "command"
           }
@@ -306,7 +338,8 @@
       {
         "hooks": [
           {
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/moai/handle-permission-request.sh\"",
+            "command": "bash",
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-permission-request.sh"],
             "timeout": 5,
             "type": "command"
           }

--- a/internal/template/agent_model_matcher_test.go
+++ b/internal/template/agent_model_matcher_test.go
@@ -181,10 +181,12 @@ func TestHookWrapperConventions(t *testing.T) {
 		if h.Type != "command" || h.Command != "bash" {
 			t.Errorf("hook invocation: got type=%q command=%q, want type=command command=bash", h.Type, h.Command)
 		}
-		if len(h.Args) != 1 {
-			t.Fatalf("hook args: got %d, want 1", len(h.Args))
+		// Guarded exec form: args = ["-c", "<missing-script guard>", "<wrapper>"].
+		// The wrapper path is the final args element.
+		if len(h.Args) != 3 || h.Args[0] != "-c" {
+			t.Fatalf("hook args: got %v, want guarded exec form [\"-c\", guard, path]", h.Args)
 		}
-		arg := h.Args[0]
+		arg := h.Args[2]
 		// (a) points at a shell wrapper under the moai hook directory.
 		if !strings.HasSuffix(arg, ".sh") || !strings.Contains(arg, "/.claude/hooks/moai/") {
 			t.Errorf("hook arg %q does not point at a .claude/hooks/moai/*.sh wrapper", arg)

--- a/internal/template/review_gate_registration_test.go
+++ b/internal/template/review_gate_registration_test.go
@@ -36,11 +36,14 @@ type stopHookEntry struct {
 	Timeout float64  `json:"timeout"`
 }
 
-// script returns the hook script basename this entry invokes.
+// script returns the hook script basename this entry invokes. It reads the
+// LAST args element so the same extraction covers: the guarded exec form
+// (args = ["-c", "<guard>", "<path>"] — path is last), the legacy exec form
+// (args = ["<path>"]), and the shell form (args empty → fall back to command).
 func (e stopHookEntry) script() string {
 	target := e.Command
 	if len(e.Args) > 0 {
-		target = e.Args[0]
+		target = e.Args[len(e.Args)-1]
 	}
 	target = strings.Trim(target, `"`)
 	return filepath.Base(target)

--- a/internal/template/settings_test.go
+++ b/internal/template/settings_test.go
@@ -258,9 +258,11 @@ func TestSettingsTemplateHookExecForm(t *testing.T) {
 			if strings.Contains(output, `"command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks`) {
 				t.Error("hook command still uses the shell-form quoted path")
 			}
-			// The exec form is present for a representative hook.
-			if !strings.Contains(output, `"args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-session-start.sh"]`) {
-				t.Error("session-start hook is missing the exec-form args array")
+			// The guarded exec form carries the session-start script path as
+			// the final args element: args = ["-c", "<missing-script guard>",
+			// "<path>"]. The path still ends the array, anchored by "]".
+			if !strings.Contains(output, `"${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-session-start.sh"]`) {
+				t.Error("session-start hook is missing the exec-form script path in args")
 			}
 		})
 	}
@@ -289,13 +291,25 @@ func TestSettingsTemplateHookExecForm(t *testing.T) {
 					count++
 					if h.Command != "bash" {
 						t.Errorf("%s: command = %q, want \"bash\" (exec form)", event, h.Command)
-					}
-					if len(h.Args) != 1 {
-						t.Errorf("%s: args = %v, want exactly one script path", event, h.Args)
 						continue
 					}
-					if !strings.HasPrefix(h.Args[0], "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/") {
-						t.Errorf("%s: args[0] = %q, want a ${CLAUDE_PROJECT_DIR}-rooted hook path", event, h.Args[0])
+					// Guarded exec form: args = ["-c", "<missing-script guard>",
+					// "<script-path>"]. The guard lets a hook degrade to a silent
+					// exit 0 (with an optional trace appended to
+					// .moai/logs/hook-missing.log) when its script has vanished —
+					// e.g. the session's worktree was removed mid-session — instead
+					// of producing a noisy "No such file or directory" on every
+					// hook fire.
+					if len(h.Args) != 3 || h.Args[0] != "-c" {
+						t.Errorf("%s: args = %v, want guarded exec form [\"-c\", guard, path]", event, h.Args)
+						continue
+					}
+					if !strings.Contains(h.Args[1], "hook missing") {
+						t.Errorf("%s: args[1] = %q, want a missing-script guard", event, h.Args[1])
+					}
+					path := h.Args[2]
+					if !strings.HasPrefix(path, "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/") {
+						t.Errorf("%s: args[2] = %q, want a ${CLAUDE_PROJECT_DIR}-rooted hook path", event, path)
 					}
 				}
 			}
@@ -628,7 +642,8 @@ func TestSettingsTemplateNewHookStructure(t *testing.T) {
 				t.Fatalf("%q: hook entry is not an object, got %T", ne.event, hooksArr[0])
 			}
 
-			// Exec form: command is the interpreter, the script path is args[0].
+			// Exec form: command is the interpreter. The script path rides as
+			// the final args element in the guarded form (args[2]).
 			command, ok := hookEntry["command"].(string)
 			if !ok {
 				t.Fatalf("%q: missing or non-string 'command' field", ne.event)
@@ -637,11 +652,11 @@ func TestSettingsTemplateNewHookStructure(t *testing.T) {
 				t.Errorf("%q: command = %q, want \"bash\" (exec form)", ne.event, command)
 			}
 			rawArgs, ok := hookEntry["args"].([]any)
-			if !ok || len(rawArgs) != 1 {
-				t.Fatalf("%q: args = %v, want exactly one script path", ne.event, hookEntry["args"])
+			if !ok || len(rawArgs) != 3 {
+				t.Fatalf("%q: args = %v, want guarded exec form [\"-c\", guard, path]", ne.event, hookEntry["args"])
 			}
-			if arg, _ := rawArgs[0].(string); !strings.Contains(arg, ne.scriptName) {
-				t.Errorf("%q: args[0] %q does not contain expected script name %q", ne.event, arg, ne.scriptName)
+			if arg, _ := rawArgs[2].(string); !strings.Contains(arg, ne.scriptName) {
+				t.Errorf("%q: args[2] %q does not contain expected script name %q", ne.event, arg, ne.scriptName)
 			}
 
 			// Verify timeout. SPEC-HOOK-OFFICIAL-COMPLIANCE-001 M4 (REQ-HOC-010)
@@ -726,18 +741,18 @@ func TestSettingsTemplateNewHooksPlatformCompatibility(t *testing.T) {
 
 					// Exec form renders identically on every platform: the
 					// command is the bash interpreter and the script path rides
-					// in args, so there is no per-OS branch to assert.
+					// as the final args element, so there is no per-OS branch.
 					if command != "bash" {
 						t.Errorf("%s/%s: command = %q, want \"bash\" (exec form)", platform, ne.event, command)
 					}
 					rawArgs, ok := hookEntry["args"].([]any)
-					if !ok || len(rawArgs) != 1 {
-						t.Fatalf("%s/%s: args = %v, want exactly one script path", platform, ne.event, hookEntry["args"])
+					if !ok || len(rawArgs) != 3 {
+						t.Fatalf("%s/%s: args = %v, want guarded exec form [\"-c\", guard, path]", platform, ne.event, hookEntry["args"])
 					}
-					arg := rawArgs[0].(string)
+					arg := rawArgs[2].(string)
 					expected := "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/" + ne.scriptName
 					if arg != expected {
-						t.Errorf("%s/%s: args[0] = %q, want %q", platform, ne.event, arg, expected)
+						t.Errorf("%s/%s: args[2] = %q, want %q", platform, ne.event, arg, expected)
 					}
 				})
 			}

--- a/internal/template/templates/.claude/settings.json.tmpl
+++ b/internal/template/templates/.claude/settings.json.tmpl
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "command": "bash",
-            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-session-start.sh"],
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-session-start.sh"],
             "timeout": 30,
             "type": "command"
           }
@@ -20,7 +20,7 @@
         "hooks": [
           {
             "command": "bash",
-            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-compact.sh"],
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-compact.sh"],
             "timeout": 30,
             "type": "command"
           }
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "command": "bash",
-            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-session-end.sh"],
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-session-end.sh"],
             "timeout": 10,
             "type": "command"
           }
@@ -44,7 +44,7 @@
         "hooks": [
           {
             "command": "bash",
-            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-pre-tool.sh"],
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-pre-tool.sh"],
             "timeout": 10,
             "type": "command"
           }
@@ -55,7 +55,7 @@
         "hooks": [
           {
             "command": "bash",
-            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-pre-tool.sh"],
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-pre-tool.sh"],
             "timeout": 10,
             "type": "command"
           }
@@ -68,35 +68,35 @@
         "hooks": [
           {
             "command": "bash",
-            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-post-tool.sh"],
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-post-tool.sh"],
             "timeout": 10,
             "type": "command",
             "async": true
           },
           {
             "command": "bash",
-            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/status-transition-ownership.sh"],
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/status-transition-ownership.sh"],
             "if": "Write(**/.moai/specs/**)",
             "timeout": 5,
             "type": "command"
           },
           {
             "command": "bash",
-            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/status-transition-ownership.sh"],
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/status-transition-ownership.sh"],
             "if": "Edit(**/.moai/specs/**)",
             "timeout": 5,
             "type": "command"
           },
           {
             "command": "bash",
-            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/status-transition-ownership.sh"],
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/status-transition-ownership.sh"],
             "if": "MultiEdit(**/.moai/specs/**)",
             "timeout": 5,
             "type": "command"
           },
           {
             "command": "bash",
-            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-security-scan.sh"],
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-security-scan.sh"],
             "timeout": 5,
             "type": "command",
             "async": true
@@ -108,7 +108,7 @@
         "hooks": [
           {
             "command": "bash",
-            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-harness-observe.sh"],
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-harness-observe.sh"],
             "timeout": 5,
             "type": "command",
             "async": true
@@ -121,52 +121,52 @@
         "hooks": [
           {
             "command": "bash",
-            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-stop.sh"],
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-stop.sh"],
             "timeout": 5,
             "type": "command",
             "async": true
           },
           {
             "command": "bash",
-            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/sync-phase-quality-gate.sh"],
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/sync-phase-quality-gate.sh"],
             "timeout": 60,
             "type": "command"
           },
           {
             "command": "bash",
-            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-stop-goal.sh"],
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-stop-goal.sh"],
             "timeout": 120,
             "type": "command"
           },
           {
             "command": "bash",
-            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-security-turn.sh"],
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-security-turn.sh"],
             "timeout": 5,
             "type": "command",
             "async": true
           },
           {
             "command": "bash",
-            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-security-commit.sh"],
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-security-commit.sh"],
             "timeout": 5,
             "type": "command",
             "async": true
           },
           {
             "command": "bash",
-            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-codex-review-gate.sh"],
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-codex-review-gate.sh"],
             "timeout": 900,
             "type": "command"
           },
           {
             "command": "bash",
-            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-multi-review-gate.sh"],
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-multi-review-gate.sh"],
             "timeout": 900,
             "type": "command"
           }{{ if .HookOptIn.Enabled }},
           {
             "command": "bash",
-            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-harness-observe-stop.sh"],
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-harness-observe-stop.sh"],
             "timeout": 5,
             "type": "command",
             "async": true
@@ -179,20 +179,20 @@
         "hooks": [
           {
             "command": "bash",
-            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-subagent-stop.sh"],
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-subagent-stop.sh"],
             "timeout": 5,
             "type": "command"
           }{{ if .HookOptIn.Enabled }},
           {
             "command": "bash",
-            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-harness-observe-subagent-stop.sh"],
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-harness-observe-subagent-stop.sh"],
             "timeout": 5,
             "type": "command",
             "async": true
           }{{ end }},
           {
             "command": "bash",
-            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/chain-event.sh"],
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/chain-event.sh"],
             "timeout": 5,
             "type": "command"
           }
@@ -204,7 +204,7 @@
         "hooks": [
           {
             "command": "bash",
-            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-post-tool-failure.sh"],
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-post-tool-failure.sh"],
             "timeout": 5,
             "type": "command"
           }
@@ -216,7 +216,7 @@
         "hooks": [
           {
             "command": "bash",
-            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-subagent-start.sh"],
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-subagent-start.sh"],
             "timeout": 5,
             "type": "command"
           }
@@ -228,13 +228,13 @@
         "hooks": [
           {
             "command": "bash",
-            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-user-prompt-submit.sh"],
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-user-prompt-submit.sh"],
             "timeout": 5,
             "type": "command"
           }{{ if .HookOptIn.Enabled }},
           {
             "command": "bash",
-            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-harness-observe-user-prompt-submit.sh"],
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-harness-observe-user-prompt-submit.sh"],
             "timeout": 5,
             "type": "command",
             "async": true
@@ -247,7 +247,7 @@
         "hooks": [
           {
             "command": "bash",
-            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-teammate-idle.sh"],
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-teammate-idle.sh"],
             "timeout": 60,
             "type": "command"
           }
@@ -259,7 +259,7 @@
         "hooks": [
           {
             "command": "bash",
-            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-task-completed.sh"],
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-task-completed.sh"],
             "timeout": 60,
             "type": "command"
           }
@@ -272,7 +272,7 @@
         "hooks": [
           {
             "command": "bash",
-            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-config-change.sh"],
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-config-change.sh"],
             "timeout": 5,
             "type": "command"
           }
@@ -285,7 +285,7 @@
         "hooks": [
           {
             "command": "bash",
-            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-stop-failure.sh"],
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-stop-failure.sh"],
             "timeout": 5,
             "type": "command"
           }
@@ -298,7 +298,7 @@
         "hooks": [
           {
             "command": "bash",
-            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-post-compact.sh"],
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-post-compact.sh"],
             "timeout": 5,
             "type": "command"
           }
@@ -310,7 +310,7 @@
         "hooks": [
           {
             "command": "bash",
-            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-instructions-loaded.sh"],
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-instructions-loaded.sh"],
             "timeout": 5,
             "type": "command",
             "async": true
@@ -323,7 +323,7 @@
         "hooks": [
           {
             "command": "bash",
-            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-cwd-changed.sh"],
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-cwd-changed.sh"],
             "timeout": 5,
             "type": "command"
           }
@@ -335,7 +335,7 @@
         "hooks": [
           {
             "command": "bash",
-            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-file-changed.sh"],
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-file-changed.sh"],
             "timeout": 5,
             "type": "command"
           }
@@ -348,7 +348,7 @@
         "hooks": [
           {
             "command": "bash",
-            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-permission-denied.sh"],
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-permission-denied.sh"],
             "timeout": 5,
             "type": "command"
           }
@@ -360,7 +360,7 @@
         "hooks": [
           {
             "command": "bash",
-            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-permission-request.sh"],
+            "args": ["-c", "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0", "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-permission-request.sh"],
             "timeout": 5,
             "type": "command"
           }


### PR DESCRIPTION
## Problem

When a session's worktree is removed mid-session, every hook script under `${CLAUDE_PROJECT_DIR}` vanishes. The previous exec-form registration ran `bash <missing-path>`, which exited non-zero and produced a noisy `No such file or directory` on **every** hook fire for the rest of the session's lifetime (Stop, PreToolUse, PostToolUse, ...). Non-blocking, but extremely noisy.

## Fix

Wrap every hook command in a missing-script guard. The 3-element exec form `["-c", "<guard>", "<path>"]` runs bash with the script path as `$0`:

- **present** → `exec bash "$0"` (inherits stdin, runs exactly as before)
- **missing** → silent exit 0, with a one-line trace appended to `.moai/logs/hook-missing.log` (timestamp + missing path) so the degradation is observable post-hoc without being noisy

The guard string is identical for every hook (the script path rides on `$0`, not embedded in the guard), so there is no per-hook escaping risk. stdin is preserved because `exec` inherits the parent's stdin fd.

### Guard form

```json
{
  "command": "bash",
  "args": [
    "-c",
    "[ -f \"$0\" ] && exec bash \"$0\"; d=\"${0%/.claude/hooks/moai/*}\"; mkdir -p \"$d/.moai/logs\" 2>/dev/null; printf \"%s %s\\n\" \"$(date -u +%FT%TZ)\" \"hook missing: $0\" >> \"$d/.moai/logs/hook-missing.log\" 2>/dev/null; exit 0",
    "${CLAUDE_PROJECT_DIR}/.claude/hooks/moai/handle-stop.sh"
  ]
}
```

Why the `$0` positional trick (over embedding the path inside the `-c` string):
- keeps `${CLAUDE_PROJECT_DIR}` only in `args[2]` — same position class as the original `args[0]`
- no runtime-expansion-in-string dependency
- guard string byte-identical across all hooks (DRY — no per-hook escaping surface)

## Scope

**All hook entries**, not Stop-only:
- 36 entries in `internal/template/templates/.claude/settings.json.tmpl` (SessionStart, PreCompact, SessionEnd, PreToolUse×2, PostToolUse×5+conditional, Stop×7+conditional, SubagentStop, PostToolUseFailure, SubagentStart, UserPromptSubmit+conditional, TeammateIdle, TaskCompleted, ConfigChange, StopFailure, PostCompact, InstructionsLoaded, CwdChanged, FileChanged, PermissionDenied, PermissionRequest)
- mirrored to the repo's own `.claude/settings.json` (33 entries — these were converted from the stale shell form to the guarded exec form)

The exec form's three stated properties (`hooks-system.md` § Path Syntax Rules) are preserved:
- no shell-profile corruption (`bash -c` does not source profiles)
- no exec-bit dependency
- identical rendering across platforms

## Proof

Verified before commit (worktree state):

```
# missing script → exit 0, 0 stderr bytes, 1 line in hook-missing.log
$ bash -c '<guard>' /nonexistent/handle-stop.sh </dev/null
$ echo "exit=$?"
exit=0
$ cat .moai/logs/hook-missing.log | wc -l
1

# present script → exit 0, stdin JSON forwarded intact
$ echo '{"hook_event_name":"Stop"}' | bash -c '<guard>' ./handle-stop.sh
$ echo "exit=$?"   # wrapper's own output preserved
exit=0

# pre-guard behavior reproduced: exit 127 + "No such file or directory"
$ bash /nonexistent/handle-stop.sh; echo "exit=$?"
bash: /nonexistent/handle-stop.sh: No such file or directory
exit=127
```

## Verification

| check | result |
|---|---|
| `go vet ./...` | clean |
| `go test ./internal/template/...` | PASS |
| full `go test ./...` | PASS |
| `make build` | succeeded |
| `TestSettingsTemplateValidJSON` (darwin/linux/windows) | PASS |
| rendered settings.json JSON-valid (Go renderer, 3 platforms) | PASS |
| Neutrality §25 (no SPEC IDs / commit SHAs / macOS-bias paths / CLAUDE.local refs in the guard) | clean |

## Test contract update

3 test files updated to recognize the guarded exec form (`args` is now `["-c", guard, path]` with the script path as the final element, instead of the legacy single-element `[path]`):

- `internal/template/settings_test.go` — `TestSettingsTemplateHookExecForm`, `TestSettingsTemplateNewHookStructure`, `TestSettingsTemplateNewHooksPlatformCompatibility`
- `internal/template/agent_model_matcher_test.go` — `TestHookWrapperConventions`
- `internal/template/review_gate_registration_test.go` — `stopHookEntry.script()` now reads the LAST args element (backward-compatible: works for the guarded 3-element form, the legacy 1-element form, AND the shell form)

These are contract evolution, not a forced broken form — all three stated exec-form properties (no profile sourcing, no exec-bit dependency, cross-platform) are preserved by the guarded form.

## Constraints honored

- `${CLAUDE_PROJECT_DIR}` remains the path base (no hardcoded absolute / main-checkout path)
- hook scripts (`handle-*.sh`) NOT changed
- JSON stays valid (template renders + embeds)
- Neutrality §25 — guard carries no SPEC IDs, REQ tokens, commit SHAs, macOS-bias paths, or CLAUDE.local references

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lifecycle hook execution across supported project events.
  * Missing hooks now fail gracefully without interrupting workflows.
  * Added timestamped logging for missing hook scripts.
  * Preserved existing hook behavior, event mappings, timeouts, and asynchronous settings.
* **Compatibility**
  * Hook execution now supports guarded shell commands while retaining compatibility with legacy and direct invocation formats.
* **Tests**
  * Expanded validation for hook fallback behavior, project-rooted paths, and supported execution formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->