### PR TITLE
chore(version): align ldflags fallback and project config to v3.1.0-rc.2

### DIFF
--- a/.moai/config/sections/system.yaml
+++ b/.moai/config/sections/system.yaml
@@ -43,9 +43,9 @@ github:
     enable_trust_5: true
     spec_git_workflow: feature_branch
 moai:
-    template_version: v3.0.1
+    template_version: v3.1.0-rc.2
     update_check_frequency: daily
-    version: v3.0.1
+    version: v3.1.0-rc.2
     version_check:
         cache_ttl_hours: 24
         enabled: true

--- a/internal/cli/testdata/doctor-dark.golden
+++ b/internal/cli/testdata/doctor-dark.golden
@@ -14,7 +14,7 @@
 │    STATUS  CHECK                  MESSAGE                                                                                                            │
 │    warn    MoAI Config            .moai/ directory not found (run 'moai init')                                                                       │
 │    warn    Claude Config          .claude/ directory not found                                                                                       │
-│    ok      MoAI Version           moai-adk v3.0.1                                                                                                    │
+│    ok      MoAI Version           moai-adk v3.1.0-rc.2                                                                                               │
 │    ok      Binary Freshness       development build (no commit metadata)                                                                             │
 │    ok      MCP Scope Duplicates   no MCP configuration found (project or global)                                                                     │
 │    warn    Constitution Registry  zone-registry.md not found at ".claude/rules/moai/core/zone-registry.md" — run `moai constitution list` to verify  │

--- a/internal/cli/testdata/doctor-light.golden
+++ b/internal/cli/testdata/doctor-light.golden
@@ -14,7 +14,7 @@
 │    STATUS  CHECK                  MESSAGE                                                                                                            │
 │    warn    MoAI Config            .moai/ directory not found (run 'moai init')                                                                       │
 │    warn    Claude Config          .claude/ directory not found                                                                                       │
-│    ok      MoAI Version           moai-adk v3.0.1                                                                                                    │
+│    ok      MoAI Version           moai-adk v3.1.0-rc.2                                                                                               │
 │    ok      Binary Freshness       development build (no commit metadata)                                                                             │
 │    ok      MCP Scope Duplicates   no MCP configuration found (project or global)                                                                     │
 │    warn    Constitution Registry  zone-registry.md not found at ".claude/rules/moai/core/zone-registry.md" — run `moai constitution list` to verify  │

--- a/internal/cli/testdata/doctor-nocolor.golden
+++ b/internal/cli/testdata/doctor-nocolor.golden
@@ -14,7 +14,7 @@
 │    STATUS  CHECK                  MESSAGE                                                                                                            │
 │    warn    MoAI Config            .moai/ directory not found (run 'moai init')                                                                       │
 │    warn    Claude Config          .claude/ directory not found                                                                                       │
-│    ok      MoAI Version           moai-adk v3.0.1                                                                                                    │
+│    ok      MoAI Version           moai-adk v3.1.0-rc.2                                                                                               │
 │    ok      Binary Freshness       development build (no commit metadata)                                                                             │
 │    ok      MCP Scope Duplicates   no MCP configuration found (project or global)                                                                     │
 │    warn    Constitution Registry  zone-registry.md not found at ".claude/rules/moai/core/zone-registry.md" — run `moai constitution list` to verify  │

--- a/internal/cli/testdata/status-dark.golden
+++ b/internal/cli/testdata/status-dark.golden
@@ -3,7 +3,7 @@
 ## Project
 
 - **Project**: my-test-project
-- **ADK**: moai-adk v3.0.1
+- **ADK**: moai-adk v3.1.0-rc.2
 
 ## Configuration
 

--- a/internal/cli/testdata/status-light.golden
+++ b/internal/cli/testdata/status-light.golden
@@ -3,7 +3,7 @@
 ## Project
 
 - **Project**: my-test-project
-- **ADK**: moai-adk v3.0.1
+- **ADK**: moai-adk v3.1.0-rc.2
 
 ## Configuration
 

--- a/internal/cli/testdata/status-nocolor.golden
+++ b/internal/cli/testdata/status-nocolor.golden
@@ -3,7 +3,7 @@
 ## Project
 
 - **Project**: my-test-project
-- **ADK**: moai-adk v3.0.1
+- **ADK**: moai-adk v3.1.0-rc.2
 
 ## Configuration
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -5,7 +5,7 @@ import "fmt"
 // Build-time variables injected via -ldflags.
 // Default version for RC/test builds (overridden by -ldflags in production)
 var (
-	Version = "v3.0.1"
+	Version = "v3.1.0-rc.2"
 	Commit  = "none"
 	Date    = "unknown"
 )


### PR DESCRIPTION
## What

Bumps two version sources to `v3.1.0-rc.2`:

- `pkg/version/version.go` — the ldflags fallback (`Version = "v3.0.1"` → `"v3.1.0-rc.2"`)
- `.moai/config/sections/system.yaml` — `moai.version` + `moai.template_version`

## Why

Three independent version sources had drifted apart:

| Source | Value before |
|---|---|
| `git describe --tags --abbrev=0` (what `make build` stamps) | `v3.1.0-rc.0` — `v3.1.0-rc.1` is not an ancestor of HEAD |
| `pkg/version.Version` (ldflags-less builds: `go install ./cmd/moai`) | `v3.0.1` |
| `.moai/config/sections/system.yaml` (what the statusline reads) | `v3.0.1` |

`internal/cli/update/backup/merge.go` always takes the new value for the system
fields, so `moai update` writes whatever the running binary reports back into
`system.yaml`. A binary built without ldflags therefore pushed the stale
`v3.0.1` fallback into the project config, and `internal/statusline/version.go`
— which prefers `moai.template_version` — displayed it.

A `v3.1.0-rc.2` tag is pushed alongside this change so `git describe` agrees too.

## Verification

- `go vet ./...` — clean
- `go test ./pkg/version/... ./internal/config/... ./internal/statusline/... ./internal/template/...` — all `ok`

Full-suite verification is left to CI.

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Release**
  - Updated the application version to **v3.1.0-rc.2**.
  - Updated the displayed template version to match the new release candidate.
  - Updated diagnostic and status displays to show the new version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->