### PR TITLE
docs(SPEC-UPDATE-DOC-DRIFT-001): v0.3.0 staleness rewrite — retire 4, re-anchor 3, keep 5 live

### DIFF
--- a/.moai/specs/SPEC-UPDATE-DOC-DRIFT-001/acceptance.md
+++ b/.moai/specs/SPEC-UPDATE-DOC-DRIFT-001/acceptance.md
@@ -1,5 +1,10 @@
 # SPEC-UPDATE-DOC-DRIFT-001 — Acceptance Criteria
 
+Rewritten at v0.3.0 against worktree HEAD **`7f61332ef`** (branch `docs/spec-doc-drift-rewrite`,
+based on `origin/main`). The v0.2.0 baseline `d5336214e` is **not an ancestor of this tree** —
+`git merge-base --is-ancestor d5336214e HEAD` exits `1` — so no v0.2.0 figure was carried over.
+Every baseline below was observed by running the stated command on this tree.
+
 ## §A Discipline
 
 1. **Every AC states a command runnable as written from the repository root, and its expected
@@ -9,246 +14,301 @@
 2. **Every documentation AC is paired with a code-fact AC.** This SPEC's subject is documentation
    correctness, which makes the vacuity hazard acute: a criterion phrased as "the file no longer
    contains string X" is satisfied by *deleting a sentence* without correcting anything. Each
-   documentation criterion below is therefore accompanied by a sibling criterion asserting the code
-   fact the corrected prose must now agree with, and each pair states its **falsification** — what
-   would have to be true for the criterion to fail.
+   documentation criterion is therefore accompanied by a sibling criterion asserting the code fact
+   the corrected prose must agree with, and each pair states its **falsification** — what would have
+   to be true for the criterion to fail.
 
-3. **`go test -run <pattern>` exits 0 on zero matches.** Every `-run` AC therefore additionally
-   requires the verbatim `--- PASS: <exact test name>` line. Vacuity baseline recorded at HEAD
-   `d5336214e`:
+3. **Absence is never asserted alone.** Every removal count (`expect 0`) is paired, in the same
+   criterion, with a replacement count (`expect >= 1`) over the same scope. A tree where both are `0`
+   fails: that is deletion, not correction.
 
-   ```
-   $ go test -run 'TestUpdateDryRunHelpTextMatchesBehavior' ./internal/cli/ ; echo "exit=$?"
-   ok  	github.com/modu-ai/moai-adk/internal/cli	4.690s [no tests to run]
-   exit=0
-   ```
-
-   An AC whose only assertion is `exit 0` would pass against a tree with no test at all, and is
-   rejected.
-
-4. **Baselines are observed, and attributed to the code baseline `d5336214e`.** Every baseline in §B
-   was produced by running the stated command in the worktree `.claude/worktrees/epic-update-config`,
-   branch `plan/epic-update-config-audit`. The worktree HEAD at the plan-audit revision is
-   **`145e601c9`** — a descendant of `d5336214e` that changes SPEC documents only:
-   `git merge-base --is-ancestor d5336214e HEAD` exits `0`,
-   `git diff --name-only d5336214e HEAD | grep -cv '\.md$'` prints `0`, and
-   `git diff --stat d5336214e HEAD -- '*.go'` is empty. No Go source differs between the two, so
-   every `file:line` and count below is attributable to `d5336214e`. Authoring happened at
-   `7225a8b7a` on the same branch; the sibling SPECs' recorded `main` HEAD `1d4e4f7da` was a stale
-   divergent branch (spec.md §A.6 drift 1). Each AC carries its observed pre-change baseline so a
-   reviewer can distinguish a real change from a no-op.
+4. **Baselines are observed and attributed to `7f61332ef`.** Each AC carries its measured
+   pre-change baseline so a reviewer can distinguish a real change from a no-op. Criteria whose
+   baseline already equals the expected value are labelled **preservation guards** and never counted
+   as change detectors.
 
 5. **`git stash` is prohibited.** This checkout is shared with concurrent sessions and `git stash` is
-   repository-global. Falsification uses a scratch copy under `/tmp` or `t.TempDir()`, never a tree
-   mutation.
+   repository-global. Falsification uses a scratch copy under `/tmp`, never a tree mutation.
 
-6. **All fixtures use `t.TempDir()`** and touch no path outside it (NFR-UDD-001).
+6. **A command that cannot observe its own expectation is not an AC.** Clause 1 requires a command;
+   this clause requires the command to be *capable of seeing* what the criterion claims. Five failure
+   shapes are excluded by construction, four inherited from the v0.2.0 plan-audit and one added here:
+   arithmetically unsatisfiable counts (`grep -c` over one line cannot exceed `1`); a printed line
+   paired with a prose judgment and no predicate; an expectation outside the command's window; a
+   guard that goes inert once its change is committed; and — new at v0.3.0 — a predicate defeated by
+   quotation (clause 8).
 
-7. **A command that cannot observe its own expectation is not an AC.** Clause 1 requires a command;
-   this clause requires the command to be *capable of seeing* what the criterion claims. It is the
-   clause the sibling SPECs carry (`SPEC-CONFIG-KEY-HONESTY-001` §A clause 7;
-   `SPEC-UPDATE-REINSTALL-LOOP-002` §A clause 5) and it is the one this SPEC most needed: the
-   plan-audit found 13 of 23 criteria non-discriminating, of which 5 are the intentional code-fact
-   pairings of clause 2 — leaving 8 genuine defects plus one unobserved baseline. Three failure
-   shapes were found and each is now excluded by construction:
+7. **`go test -run <pattern>` exits 0 on zero matches.** Any `-run` criterion therefore additionally
+   requires the verbatim `--- PASS: <exact test name>` line. This SPEC adds no test of its own
+   (§B M1 is retired), so the rule binds only AC-UDD-001's regression guard.
 
-   - **Arithmetically unsatisfiable** — `grep -c` over a one-line input cannot print `>= 2`
-     (AC-UDD-020). Counting *distinct tokens* (`grep -o | sort -u | wc -l`) is the form that can.
-   - **No predicate** — a command that prints a line and an expectation phrased as a prose judgment
-     about that line asserts nothing mechanically (AC-UDD-009, AC-UDD-010). Every such criterion now
-     uses the AC-UDD-007 pattern: removal-count `0` **and** replacement-count `>= 1`, so neither
-     deletion nor omission passes.
-   - **Expectation outside the command's window** — an expected fact at `:79` cannot be observed by a
-     command that prints `:41-70` (AC-UDD-019). The window is widened, or the fact gets its own
-     command.
+8. **Corrections state the current truth; they do not quote the retracted claim** *(new at v0.3.0)*.
+   This clause exists because the tree demonstrated the hazard. The 2026-08-01 in-place correction to
+   `CLAUDE.local.md` §2.2 retracts its predecessor **by quoting it** — "종전 이 절은 `…로더 부재 →
+   … 항상 컴파일 기본값 false`라고 적었으나 두 주장 모두 현재 main에서 거짓이다". The retraction is
+   correct prose and a defeated predicate: `grep -c '로더 부재' CLAUDE.local.md` still prints `1`, so
+   the v0.2.0 criterion expecting `0` fails against a tree where the requirement is satisfied. An
+   absence-grep cannot distinguish an assertion from its quoted retraction.
 
-   Two further shapes are excluded: a criterion whose predicate cannot distinguish the SPEC's own
-   edits from the effect it measures (AC-UDD-023 — a delta, not an absolute), and a criterion that
-   becomes inert once the change is committed (AC-UDD-021 — a baseline-relative diff, not an
-   unstaged-only one).
-
-   **Known residue, recorded rather than silently carried.** AC-UDD-006's `E4` token remains loose
-   (a two-character match), and its "no proposal to implement/deprecate/delete" half is unverified
-   prose. That is the residue of plan-audit defect D14, deferred to the next revision along with D13,
-   D15 and D17; it is named here so the clause is not read as claiming coverage it does not have.
+   The resolution is a constraint on the edit, not a cleverer regex — §2.2 is a single physical line,
+   so every line-scoped carve-out is degenerate on it. The M5 rewrite therefore **removes the
+   quotation** and states the mechanism directly, keeping only the dated marker and the
+   `v3.0.1`-vs-`main` release-version distinction (which is a substantive fact, not a quotation).
+   With the quotation gone, the removal counts in AC-UDD-014 are decidable again.
 
 ## §B Acceptance criteria
 
-### M1 — `--dry-run` contract
+### M5 — `CLAUDE.local.md` §2.2 ast-grep gate (REQ-UDD-002, REQ-UDD-003)
 
-> **The A-vs-B decision is settled: option B — preserve non-mutation and make the renderer
-> reachable.** The three criteria below are written against that decision, not against an open
-> choice. See spec.md §A.5 and plan.md §F.1 for the measured basis: the non-mutating plan renderer
-> already exists (`internal/cli/update_clean_install.go:186-198`) and is already wired
-> (`internal/cli/update.go:360`); the remaining work narrows an early return, it does not build a
-> renderer.
+> **Section-range anchor.** All §2.2 criteria extract the section by content anchor, never by line
+> number (`:141` at v0.2.0 is `:146` today — the consolidation moved it):
+>
+> ```bash
+> R='/§2.2 astgrep-rules/,/^### \[HARD\] settings.local.json/p'
+> ```
+>
+> Observed at `7f61332ef`: the range resolves to 3 lines (the section body, a blank line, and the
+> terminating heading). Residual coupling, recorded not hidden: if §2.2 is ever moved out from under
+> the `### [HARD] settings.local.json` heading, this anchor must move with it.
 
-#### AC-UDD-001 (documentation) — the help text keeps its install promise, and the promise is now met
-
-```bash
-sed -n '69p' internal/cli/update.go | grep -c 'install'
-sed -n '69p' internal/cli/update.go | grep -c 'archive'
-```
-
-Expected: both counts `1`. Under option B the registered description retains **both** words because
-the flag now previews both halves; AC-UDD-002 is what makes the retained promise true.
-
-Baseline at HEAD `d5336214e`: both counts are already `1` —
-
-```
-$ sed -n '69p' internal/cli/update.go
-	updateCmd.Flags().Bool("dry-run", false, "Show planned archive and install operations without modifying the filesystem")
-```
-
-This criterion is therefore a **preservation guard**, not a change detector, and it is deliberately
-paired: it fails if a future implementer resolves the mismatch by silently reverting to option A
-(dropping `install` from the text) after option B was chosen. The change detection lives in
-AC-UDD-002; the two must both hold.
-
-**Falsification**: fails if either word is removed from the description, or if the flag is deleted —
-removal is not in scope.
-
-#### AC-UDD-002 (code fact) — the dry-run branch reaches the plan renderer, and still mutates nothing
+#### AC-UDD-014 (documentation) — §2.2 states the default without quoting the retracted claim
 
 ```bash
-go test -run 'TestUpdateDryRunRendersCleanReinstallPlan' -count=1 -v ./internal/cli/
-go test -run 'TestUpdateDryRunNoMutation' -count=1 -v ./internal/cli/
-grep -n -A2 'Placement is deliberate' internal/cli/update.go
+R='/§2.2 astgrep-rules/,/^### \[HARD\] settings.local.json/p'
+grep -c '로더 부재' CLAUDE.local.md
+grep -c '항상 컴파일 기본값 false' CLAUDE.local.md
+sed -n "$R" CLAUDE.local.md | grep -cE '권고 모드|advisory|WarnOnlyMode'
 ```
 
-Expected, all three:
+Expected: `0`, `0`, `>= 1`. The first two enforce §A clause 8 — the retracted claim is not quoted —
+and the third is the replacement assertion: the section still states the gate's actual default. A
+tree where all three are `0` fails.
 
-1. A verbatim `--- PASS: TestUpdateDryRunRendersCleanReinstallPlan` line, from a test that runs
-   `moai update --dry-run` against a `t.TempDir()` fixture carrying a v2 fingerprint and asserts the
-   captured output contains the literal `[clean-reinstall] DRY-RUN — no filesystem mutations performed`
-   emitted at `update_clean_install.go:187`. This is the reachability assertion: at baseline the line
-   is never printed because `update.go:294` returns first.
-2. A verbatim `--- PASS: TestUpdateDryRunNoMutation` line, from a test that snapshots the fixture
-   tree (path set **and** per-file content hash), runs the same dry-run, and asserts the snapshot is
-   unchanged. This is the criterion that proves the renderer's own prologue —
-   `buildPreserveInventory` / `computeInventoryHashes` at `update_clean_install.go:179` and
-   `scanDeprecatedPaths` at `:189` — writes nothing, which the plan-audit explicitly left unverified
-   (its §4 gap 1).
-3. The placement-rationale comment survives, anchored on its content token rather than a line number:
+Baseline at `7f61332ef`: `1`, `1`, `1`. The first two are the quotation inside the 2026-08-01
+retraction; the third is already satisfied and is a **preservation guard** (§A clause 4) — it fails
+only if the M5 rewrite deletes the default statement while removing the quotation.
 
-   ```
-   312:	// Placement is deliberate: after the --binary / --dry-run early-returns (so
-   313-	// a dry run never mutates) but BEFORE the version-match short-circuit
-   ```
+**Falsification**: fails if the quotation survives (counts stay `1`), or if the rewrite removes the
+quotation *and* the default statement together, leaving the gate's existence unmentioned (plan.md
+AP-1).
 
-Baseline at HEAD `d5336214e`: neither test exists — both `-run` selectors match nothing, which §A
-clause 3 rejects as a pass, and the `--- PASS:` requirement is what converts that into a failure. The
-comment grep already prints the two lines above.
-
-**Falsification**: assertion 2 fails if the plan-construction path writes anything inside the fixture
-— a temp file, a lock file, a cache entry, a backup directory. Assertion 1 fails if the
-reachability fix is omitted or reverted. Assertion 3 fails if an implementer relocates the early
-return past `update.go:306-326` (`stripRetiredV2DenyEntries`, which rewrites `settings.json`) —
-the option the sibling `SPEC-UPDATE-REINSTALL-LOOP-002` plan.md §E M4 records as a **confirmed
-defect**. The two SPECs must not push this early return in opposite directions.
-
-#### AC-UDD-003 — the settled decision and its basis are recorded
+#### AC-UDD-015 (code fact) — loader present, `gate.yaml` shipped, default enabled
 
 ```bash
-P=.moai/specs/SPEC-UPDATE-DOC-DRIFT-001/progress.md
-sed -n '/^## §E.2 Run-phase Evidence/,/^## §E.3/p' "$P" | grep -cE 'option B|reachab'
-sed -n '/^## §E.2 Run-phase Evidence/,/^## §E.3/p' "$P" | grep -c 'update_clean_install.go'
+grep -rn 'loadGateSection' internal/config/ | grep -c 'loader\.go\|loader_gate\.go'
+ls internal/template/templates/.moai/config/sections/gate.yaml .moai/config/sections/gate.yaml
+grep -n -A5 'AstGrepGate: AstGrepGateConfig' internal/config/defaults.go
 ```
 
-Expected: both counts `>= 1`, with the surrounding `progress.md` §E.2 text naming the chosen option
-(B), the rejected option (A — narrow the text), the reason (the renderer already exists and is
-already wired, so B's cost is a local re-ordering rather than new construction), and the run-phase
-observation that the reachability change landed.
+Expected: the first prints `>= 2` (declaration + call site), `ls` succeeds on both paths, and the
+default block shows `Enabled: true`.
 
-**The `sed` window is load-bearing.** The decision is *also* recorded at plan-phase in §E.1 and in
-plan.md §F.1, so an unscoped whole-file `grep` over `progress.md` would print `>= 1` before
-run-phase does anything — the criterion would pass against an empty §E.2. Extracting §E.2 is what
-makes the count discriminating (§A clause 7).
+Baseline (verbatim, `7f61332ef`):
 
-Baseline at HEAD `145e601c9`: §E.2 is the placeholder `_<pending run-phase>_`, so both scoped counts
-are `0`, while the unscoped counts are already non-zero — which is the failure this window avoids.
+```
+$ grep -rn 'loadGateSection' internal/config/ | grep -c 'loader\.go\|loader_gate\.go'
+3
+$ ls internal/template/templates/.moai/config/sections/gate.yaml .moai/config/sections/gate.yaml
+.moai/config/sections/gate.yaml
+internal/template/templates/.moai/config/sections/gate.yaml
+$ grep -n -A5 'AstGrepGate: AstGrepGateConfig' internal/config/defaults.go
+438:		AstGrepGate: AstGrepGateConfig{
+439-			Enabled:      true,
+440-			BlockOnError: false,
+441-			WarnOnlyMode: true,
+```
 
-### M2 — §22.8 worktree toggles
+This is a **regression guard** for the discharged half of REQ-UDD-002, retained at v0.3.0 rather than
+retired with it: it fails if `loadGateSection` is removed, `gate.yaml` is unshipped, or the default
+flips to `false` — any of which would make the *original* §2.2 text correct again and this SPEC's
+whole M5 direction wrong.
 
-#### AC-UDD-004 (documentation) — §22.8 states per-toggle reader status
+#### AC-UDD-016 (documentation) — §2.2 states the gate's invocation scope
 
 ```bash
-sed -n '/§22.8 web worktree/,/§22.9/p' CLAUDE.local.md \
-  | grep -cE 'auto_cleanup|auto_merge|auto_create|AutoCleanup|AutoMerge|AutoCreate'
-sed -n '/§22.8 web worktree/,/§22.9/p' CLAUDE.local.md | grep -c 'worktree_advisory'
+R='/§2.2 astgrep-rules/,/^### \[HARD\] settings.local.json/p'
+sed -n "$R" CLAUDE.local.md | grep -cE 'git commit|IsGitCommit'
+sed -n "$R" CLAUDE.local.md | grep -cE 'IsAutonomyTierCommitGateOff|autonomy|자율성 티어'
 ```
 
-Expected: the first count `>= 2` (unchanged — the toggles are still named), and the second count
-`>= 1`, with the surrounding prose stating that `auto_cleanup` and `auto_merge` have no production
-reader and that `auto_create` is read only at `internal/cli/worktree_advisory.go` to select advisory
-wording.
+Expected: both `>= 1`. The corrected text names both conjuncts of the trigger condition — `git commit`
+Bash invocations, and the autonomy-tier opt-out — so a reader can bound a default-on gate's blast
+radius.
 
-Baseline at HEAD `d5336214e`: the first count is `2`; the second is `0`. The section describes all
-three as governing web-console worktree automation and gives no reader status.
+Baseline at `7f61332ef`: `0` and `0`. §2.2 gives no invocation scope at all.
 
-**Falsification**: fails if §22.8 still asserts that setting any of the three to `true` enables
-behaviour, or if the toggles are simply removed from the section (which would satisfy an
-absence-only grep while destroying the `[HARD]` protection on the `false` defaults — plan.md §F.2).
+**Falsification**: fails if the correction states default-on without the scope qualifier (plan.md
+AP-2), or if it names only `git commit` and omits the autonomy-tier conjunct that spec.md §A.8 drift
+2 records as new since v0.2.0.
 
-#### AC-UDD-005 (code fact) — the reader inventory §22.8 now states is the measured one
-
-The load-bearing assertion is **mechanical**, because the previous "exactly the following sites"
-enumeration was incomplete and therefore already failed at baseline (it omitted
-`internal/cli/worktree/errors.go`, the `defaults.go:543-544` comment lines, and several
-`worktree/new.go`, `worktree_advisory.go` and `internal/github/*` lines). Asserting field *reads*
-directly is both shorter and exhaustive:
+#### AC-UDD-017 (code fact) — the gate is invoked only under the two-conjunct condition
 
 ```bash
-grep -rn 'Worktree\.AutoCleanup\|Worktree\.AutoMerge' --include='*.go' internal cmd pkg \
-  | grep -v '_test.go' | wc -l
-grep -rn 'Worktree\.AutoCreate' --include='*.go' internal cmd pkg | grep -v '_test.go'
+grep -n -A2 'IsGitCommit(command)' internal/hook/pre_tool.go
 ```
 
-Expected: the first prints `0` — no production code reads `Workflow.Worktree.AutoCleanup` or
-`Workflow.Worktree.AutoMerge` through the config struct, which is precisely the claim §22.8's
-corrected text makes. The second prints exactly one line,
-`internal/cli/worktree_advisory.go:60:	return cfg.Workflow.Worktree.AutoCreate`, the single
-production read, reached from `:29` to select advisory wording.
+Expected: the quality gate is constructed inside a branch conditioned on **both**
+`quality.IsGitCommit(command)` and `!config.IsAutonomyTierCommitGateOff(...)`, so the scope AC-UDD-016
+asserts is the scope the code implements.
 
-Baseline (verbatim, observed at HEAD `145e601c9`, code baseline `d5336214e`):
+Baseline (verbatim, `7f61332ef`):
 
 ```
-$ grep -rn 'Worktree\.AutoCleanup\|Worktree\.AutoMerge' --include='*.go' internal cmd pkg | grep -v '_test.go' | wc -l
+447:		if quality.IsGitCommit(command) && !config.IsAutonomyTierCommitGateOff(config.AutonomyTier()) {
+448:			gate := quality.NewQualityGate(h.loadGateConfig())
+449-			passed, output := gate.Run(ctx)
+```
+
+**Falsification**: fails if either conjunct is removed, which would make AC-UDD-016's required text
+an overstatement or an understatement of the real trigger.
+
+#### AC-UDD-018 (documentation) — §2.2 records that the suppression check blocks unconditionally
+
+```bash
+R='/§2.2 astgrep-rules/,/^### \[HARD\] settings.local.json/p'
+sed -n "$R" CLAUDE.local.md | grep -cE 'suppression|sg-independent|억제 정책'
+sed -n "$R" CLAUDE.local.md | grep -cE 'WarnOnlyMode와 무관|WarnOnlyMode 와 무관|무관하게 차단|unconditional'
+sed -n "$R" CLAUDE.local.md | grep -c '차단(blocking)만이'
+```
+
+Expected: `>= 1`, `>= 1`, `0`. The first two are the replacement assertions — the section names the
+sg-independent suppression-policy check and states that its block does not depend on `WarnOnlyMode`.
+The third removes the false claim that blocking is reachable only via a `gate.yaml` opt-in. Under
+§A clause 8 the third is decidable because the rewrite does not quote what it retracts.
+
+Baseline at `7f61332ef`: `0`, `0`, `1`.
+
+**Falsification**: fails if §2.2 keeps "차단(blocking)만이 `gate.yaml` opt-in이다" (third count stays
+`1`); fails if that clause is deleted without stating what *can* block (first two stay `0`); and
+fails if the correction claims the whole gate blocks unconditionally, since the required token pairs
+the unconditional block with the named suppression check rather than with the gate as a whole.
+
+#### AC-UDD-019 (code fact) — the suppression check is sg-independent, blocks, and is not gated by `WarnOnlyMode`
+
+```bash
+sed -n '41,90p' internal/hook/quality/astgrep_gate.go \
+  | grep -nE 'Suppression policy check|ast-grep scan|WarnOnlyMode|ErrScannerUnavailable|return false'
+```
+
+Expected, in this relative order: the step-1 banner, a `return false` path, the step-2 banner, the
+`WarnOnlyMode` field assignment, and the `ErrScannerUnavailable` branch. The **ordering is the
+assertion**: `return false` precedes every appearance of `WarnOnlyMode`, which is what makes "the
+suppression block is not gated by `WarnOnlyMode`" a measured fact rather than a reading.
+
+Baseline (verbatim, `7f61332ef`):
+
+```
+$ sed -n '41,90p' internal/hook/quality/astgrep_gate.go \
+    | grep -nE 'Suppression policy check|ast-grep scan|WarnOnlyMode|ErrScannerUnavailable|return false'
+6:	// ── 1. Suppression policy check (sg-independent, pure-Go) ─────────────────
+20:		return false, strings.TrimSpace(sb.String())
+23:	// ── 2. ast-grep scan (depends on sg CLI) ─────────────────────────────────
+28:		WarnOnlyMode: cfg.WarnOnlyMode,
+39:		if errors.Is(err, astgrep.ErrScannerUnavailable) {
+```
+
+Relative lines 6/20/23/28/39 are absolute 46/60/63/68/79. The window `41,90` is chosen to contain the
+`ErrScannerUnavailable` branch at `:79`; the v0.2.0 window `41,70` could not see it, which §A clause 6
+rejects.
+
+**Falsification**: fails if `WarnOnlyMode` appears before the `return false` hit — i.e. the
+suppression block becomes conditional — in which case §2.2's "blocking is opt-in" text would be true
+and AC-UDD-018's correction wrong. Also fails if step 1 is removed or made sg-dependent.
+
+#### AC-UDD-020 — §2.2's unaffected content is preserved
+
+```bash
+R='/§2.2 astgrep-rules/,/^### \[HARD\] settings.local.json/p'
+sed -n "$R" CLAUDE.local.md | grep -oE 'dogfood|sgconfig\.yml|utils' | sort -u | wc -l
+```
+
+Expected: `3` — all three preserved topics survive the rewrite: the dogfood-experimental rationale
+for not mirroring the language subdirectory tree, the `sgconfig.yml` `utils` ruleDir issue, and the
+deferral of the 16-language ruleset. None of the findings touches them.
+
+Baseline at `7f61332ef`: `3` — a **preservation guard**.
+
+Counting *distinct matched tokens* rather than matching lines is required: §2.2 is one physical line,
+so `grep -c` is bounded above by `1` and any threshold above that is unreachable in every possible
+tree (§A clause 6).
+
+**Falsification**: fails at `2` or below if the rewrite drops any of the three topics. §C.2 exercises
+this against a deleted copy.
+
+### M2 — `.moai/docs/local-dev-settings-intent.md` §22.8 worktree toggles (REQ-UDD-004)
+
+> **Re-anchored at v0.3.0.** `CLAUDE.local.md` has no §22: `grep -n '§22' CLAUDE.local.md` returns
+> one line, `:506`, the References entry. The content lives at
+> `.moai/docs/local-dev-settings-intent.md:58`, still under its `### §22.8 …` heading.
+>
+> ```bash
+> W='/§22.8 web worktree/,/^### §22\.9/p'
+> ```
+>
+> Observed at `7f61332ef`: the range resolves to 13 lines.
+
+#### AC-UDD-004 (documentation) — §22.8 states the measured reader status of each toggle
+
+```bash
+W='/§22.8 web worktree/,/^### §22\.9/p'
+F=.moai/docs/local-dev-settings-intent.md
+sed -n "$W" "$F" | grep 'auto_cleanup' | grep -c '없다'
+sed -n "$W" "$F" | grep -c 'session_worktree'
+sed -n "$W" "$F" | grep -cE 'auto_cleanup|auto_merge|auto_create'
+```
+
+Expected: `0`, `>= 1`, `>= 2`. The first removes the false claim — no line may name `auto_cleanup`
+and assert it has no reader. The second is the replacement assertion: the section cites the actual
+reader site (`internal/cli/session_worktree.go`, and/or `session_worktree_prmerge.go`). The third is
+a preservation guard: all three toggles are still named, so the correction is not a deletion.
+
+Baseline at `7f61332ef`: `1`, `0`, `3`.
+
+**Falsification**: fails if `auto_cleanup` is still described as unread; fails if the correction
+removes the `auto_cleanup` bullet instead of correcting it (second count stays `0`); and fails if the
+section is trimmed to fewer than two named toggles, which would destroy the `[HARD]` protection the
+section places on the `false` defaults.
+
+#### AC-UDD-005 (code fact) — the reader inventory §22.8 must state
+
+```bash
+grep -rn 'Worktree\.AutoCleanup' --include='*.go' internal cmd pkg | grep -v '_test.go'
+grep -rn 'Worktree\.AutoMerge'   --include='*.go' internal cmd pkg | grep -v '_test.go' | wc -l
+grep -rn 'Worktree\.AutoCreate'  --include='*.go' internal cmd pkg | grep -v '_test.go'
+```
+
+Expected: the first prints **two** lines (`session_worktree.go`, `session_worktree_prmerge.go`), the
+second prints `0`, and the third prints exactly one line (`worktree_advisory.go`).
+
+Baseline (verbatim, `7f61332ef`):
+
+```
+$ grep -rn 'Worktree\.AutoCleanup' --include='*.go' internal cmd pkg | grep -v '_test.go'
+internal/cli/session_worktree.go:584:	if cfg == nil || !cfg.Workflow.Worktree.AutoCleanup {
+internal/cli/session_worktree_prmerge.go:122:	if cfg == nil || !cfg.Workflow.Worktree.AutoCleanup {
+$ grep -rn 'Worktree\.AutoMerge' --include='*.go' internal cmd pkg | grep -v '_test.go' | wc -l
 0
 $ grep -rn 'Worktree\.AutoCreate' --include='*.go' internal cmd pkg | grep -v '_test.go'
 internal/cli/worktree_advisory.go:60:	return cfg.Workflow.Worktree.AutoCreate
 ```
 
-The selector prefix `Worktree.` is what makes this discriminating: a bare `AutoMerge` match is a
-homonym — `internal/github/pr_merger.go` carries an unrelated `AutoMerge` PR-merge option, and
-`internal/cli/worktree/errors.go:56,60` carries `NewAutoMergeBlockedError`. Neither touches the
-config key, and neither should make this criterion fail.
+The `Worktree.` selector prefix is what makes this discriminating: bare `AutoMerge` is a homonym
+(`internal/github/pr_merger.go` PR-merge options, `internal/cli/worktree/errors.go`
+`NewAutoMergeBlockedError`), and none of those touch the config key.
 
-The broad survey grep is retained as a **context command**, not as a criterion — its output is
-recorded in spec.md §A.2 as an abbreviated extract, and the abbreviation is now declared there:
+**Falsification**: fails if the `AutoCleanup` count returns to `0` — the state the v0.2.0 baseline
+recorded — in which case §22.8's *original* text was right and REQ-UDD-004's inverted correction is
+wrong. This is the criterion that keeps the polarity inversion measured rather than assumed. It also
+fails if `AutoMerge` gains a reader, which would make the surviving half of the sentence false too.
 
-```bash
-grep -rn 'AutoCleanup\|AutoCreate\|AutoMerge' --include='*.go' internal cmd pkg \
-  | grep -v '_test.go' | grep -v main-fork
-```
+#### AC-UDD-006 — **RETIRED at v0.3.0** (REQ-UDD-005 retired)
 
-**Falsification**: fails if a production reader for `AutoCleanup` or `AutoMerge` has appeared — the
-first count moves off `0` — which would mean `SPEC-CONFIG-KEY-HONESTY-001` wired them and §22.8's
-corrected text is already stale, exactly the reconciliation REQ-UDD-005 exists to catch. It also
-fails if the `AutoCreate` read is removed, leaving §22.8 asserting a reader that no longer exists.
+The E4 cross-reference this criterion required is present:
+`grep -c 'CONFIG-KEY-HONESTY' .moai/docs/local-dev-settings-intent.md` → `2` (`:60`, `:65`), and
+`SPEC-CONFIG-KEY-HONESTY-001` is `status: completed`. The obligation is discharged; the criterion is
+retained here as a record, not as an open gate.
 
-#### AC-UDD-006 — the correction proposes no triage and records the E4 dependency
-
-```bash
-sed -n '/§22.8 web worktree/,/§22.9/p' CLAUDE.local.md | grep -cE 'CONFIG-KEY-HONESTY|E4'
-```
-
-Expected: a count `>= 1` — §22.8 cross-references the sibling SPEC that owns the triage — and the
-section contains no proposal to implement, deprecate, or delete the keys (spec.md §C).
-
-Baseline: count `0`; the section carries no cross-reference to the owning SPEC.
-
-### M3 — `internal/config/CLAUDE.md` env overrides
+### M3 — `internal/config/CLAUDE.md` env overrides (REQ-UDD-008, REQ-UDD-009, REQ-UDD-010)
 
 #### AC-UDD-007 (documentation) — the priority order names only implemented overrides
 
@@ -257,11 +317,9 @@ grep -c 'MOAI_USER_NAME\|MOAI_CONVERSATION_LANG' internal/config/CLAUDE.md
 grep -cE 'MOAI_DEVELOPMENT_MODE|MOAI_LOG_LEVEL|MOAI_LOG_FORMAT|MOAI_NO_COLOR' internal/config/CLAUDE.md
 ```
 
-Expected: the first count is `0` (the two unimplemented names are gone), and the second is `>= 1`
-(the implemented set is named in their place). A tree where both counts are `0` fails — that is
-deletion, not correction.
+Expected: `0`, then `>= 1`. A tree where both are `0` fails — that is deletion, not correction.
 
-Baseline at HEAD `d5336214e`: first count `2`, second count `0`.
+Baseline at `7f61332ef`: `2`, `0`.
 
 **Falsification**: fails if the two names are removed without the implemented set replacing them, or
 if the file still asserts a priority order the code does not implement.
@@ -269,23 +327,22 @@ if the file still asserts a priority order the code does not implement.
 #### AC-UDD-008 (code fact) — `applyEnvOverrides` reads exactly the documented set
 
 ```bash
-grep -n -A14 'func applyEnvOverrides' internal/config/manager.go
+grep -n -A13 'func applyEnvOverrides' internal/config/manager.go
 grep -c 'MOAI_USER_NAME\|MOAI_CONVERSATION_LANG' internal/config/envkeys.go
 ```
 
 Expected: `applyEnvOverrides` reads exactly `EnvDevelopmentMode`, `EnvLogLevel`, `EnvLogFormat`,
-`EnvNoColor` — four overrides, no more — and the `grep -c` over `envkeys.go` prints `0` (exit 1),
-confirming neither name is declared.
+`EnvNoColor` — four, no more — and the `envkeys.go` count prints `0` (exit 1).
 
-Baseline (verbatim, HEAD `d5336214e`):
+Baseline (verbatim, `7f61332ef`):
 
 ```
-393:func applyEnvOverrides(cfg *Config) {
-394-	if mode := os.Getenv(EnvDevelopmentMode); mode != "" { ... }
-397-	if level := os.Getenv(EnvLogLevel); level != "" { ... }
-400-	if format := os.Getenv(EnvLogFormat); format != "" { ... }
-403-	if noColor := os.Getenv(EnvNoColor); noColor == "true" || noColor == "1" { ... }
-406-}
+398:func applyEnvOverrides(cfg *Config) {
+399-	if mode := os.Getenv(EnvDevelopmentMode); mode != "" { … }
+402-	if level := os.Getenv(EnvLogLevel); level != "" { … }
+405-	if format := os.Getenv(EnvLogFormat); format != "" { … }
+408-	if noColor := os.Getenv(EnvNoColor); noColor == "true" || noColor == "1" { … }
+411-}
 
 $ grep -c 'MOAI_USER_NAME\|MOAI_CONVERSATION_LANG' internal/config/envkeys.go
 0
@@ -293,45 +350,25 @@ exit=1
 ```
 
 **Falsification**: fails if `envkeys.go` gains either constant — which would mean the correction
-direction was wrong and `internal/config/CLAUDE.md` was right after all. This is the criterion that
-makes the F4 resolution measured rather than assumed-by-recency (plan.md §G AP-3).
+direction is inverted and `internal/config/CLAUDE.md` was right. This is what makes the contradiction
+resolved by measurement rather than by recency (plan.md AP-3).
 
-#### AC-UDD-009 (code fact) — the `envkeys.go` convention example names a real constant
+#### AC-UDD-009 (documentation) — the `envkeys.go` convention example names a real constant
 
 ```bash
 grep -c 'EnvUserName' internal/config/CLAUDE.md
 grep -c 'EnvDevelopmentMode' internal/config/CLAUDE.md
-grep -c 'EnvDevelopmentMode = "MOAI_DEVELOPMENT_MODE"' internal/config/envkeys.go
+grep -c 'EnvDevelopmentMode *= *"MOAI_DEVELOPMENT_MODE"' internal/config/envkeys.go
 ```
 
-Expected: `0`, then `>= 1`, then `1`. The convention bullet no longer cites the constant `envkeys.go`
-does not declare, **and** it cites one it does, **and** that citation is confirmed against the
-declaration site. A tree where the first two are both `0` fails — that is deletion of the example,
-not correction of it.
+Expected: `0`, `>= 1`, `1`. The bullet stops citing a constant `envkeys.go` does not declare, cites
+one it does, and that citation is confirmed at the declaration site. A tree where the first two are
+both `0` fails — that is deletion of the example, not correction of it.
 
-Baseline (verbatim, observed at HEAD `145e601c9`, code baseline `d5336214e`):
+Baseline at `7f61332ef`: `1`, `0`, `1`.
 
-```
-$ grep -c 'EnvUserName' internal/config/CLAUDE.md
-1
-$ grep -c 'EnvDevelopmentMode' internal/config/CLAUDE.md
-0
-$ grep -c 'EnvDevelopmentMode = "MOAI_DEVELOPMENT_MODE"' internal/config/envkeys.go
-1
-```
-
-**Why this replaces the previous form.** The earlier criterion ran `grep -n 'envkeys.go'` (which
-merely prints the bullet, asserting nothing) paired with the `envkeys.go` declaration count (already
-`1` at baseline). Both halves were satisfied by the *uncorrected* file, so `internal/config/CLAUDE.md:13`
-could keep citing `EnvUserName = "MOAI_USER_NAME"` forever and the criterion would still pass. The
-removal/replacement pair above is the AC-UDD-007 pattern, which cannot pass without the edit
-(§A clause 7).
-
-The `envkeys.go` convention itself — constants live in `envkeys.go`; no inline `os.Getenv("MOAI_*")`
-— is correct and is preserved; only the worked example changes.
-
-**Falsification**: fails if the example is deleted rather than replaced (first count `0`, second
-count `0`), or if `EnvUserName` survives anywhere in the file.
+**Falsification**: fails if the example is deleted rather than replaced, or if `EnvUserName` survives
+anywhere in the file.
 
 #### AC-UDD-010 (documentation) — the test instruction is scoped to implemented overrides
 
@@ -342,79 +379,43 @@ sed -n "${L}p" internal/config/CLAUDE.md | grep -c 'MOAI_USER_NAME\|MOAI_CONVERS
 sed -n "${L}p" internal/config/CLAUDE.md | grep -cE 'MOAI_DEVELOPMENT_MODE|MOAI_LOG_LEVEL|MOAI_LOG_FORMAT|MOAI_NO_COLOR'
 ```
 
-Expected: `$L` resolves to a single line number, the second count is `0`, and the third is `>= 1` —
-the bullet carrying the `t.Setenv` instruction no longer names an unimplemented variable, and does
-name the implemented set the instruction's "this priority" now refers to. An agent following the
-instruction literally therefore writes a test that can pass.
+Expected: `$L` resolves to a single line number, the second count is `0`, the third is `>= 1`. The
+bullet carrying the `t.Setenv` instruction no longer names an unimplemented variable and does name
+the implemented set that "this priority" now refers to, so an agent following the instruction
+literally writes a test that can pass.
 
-Baseline (verbatim, observed at HEAD `145e601c9`, code baseline `d5336214e`):
+Baseline at `7f61332ef`: `line=12`, `1`, `0`. The instruction shares line 12 with the priority
+sentence, so the antecedent of "this priority" is an unimplemented behaviour.
 
-```
-line=12
-1
-0
-```
+**Falsification**: fails if the two unimplemented names leave the file but the `t.Setenv` bullet is
+left pointing at "this priority" with no implemented antecedent (third count stays `0`). Also fails
+if `$L` resolves to more than one line, meaning the instruction was duplicated and the scoping is
+ambiguous.
 
-The instruction shares line 12 with the priority-order sentence naming `MOAI_USER_NAME` /
-`MOAI_CONVERSATION_LANG`, so the antecedent of "this priority" is an unimplemented behaviour.
+### M4 — nonexistent paths: `config.yaml` and `.agency/` (REQ-UDD-006, REQ-UDD-007)
 
-**Why this replaces the previous form.** The earlier criterion ran `grep -n -B2 -A2 't.Setenv'` and
-expected the prose judgment "the instruction is scoped to the implemented override set". A command
-that prints the unmodified line can be reported as having produced its expected output, because the
-expectation was never mechanical (§A clause 7). Resolving the line number and asserting the
-removal/replacement counts *on that line* is what makes REQ-UDD-010 enforceable.
-
-**Falsification**: fails if the two unimplemented names are removed from the file but the
-`t.Setenv` bullet is left pointing at "this priority" with no implemented antecedent — the third
-count stays `0`. It also fails if `$L` resolves to more than one line, which would mean the
-instruction was duplicated and the scoping is ambiguous.
-
-### M4 — nonexistent `config.yaml`
-
-#### AC-UDD-011 (documentation) — no instruction file names the nonexistent path
+#### AC-UDD-011 (documentation) — no instruction file names the nonexistent `config.yaml`
 
 ```bash
-grep -n 'config/config.yaml' CLAUDE.local.md
-grep -nE 'config\.yaml.{0,2} \(main\)|Main .?config\.yaml' internal/config/CLAUDE.md
+grep -c 'config/config.yaml' CLAUDE.local.md
+grep -cE 'config\.yaml.{0,2} \(main\)|Main .?config\.yaml' internal/config/CLAUDE.md
+sed -n '/^## 9\. Configuration System/,/^## 10\./p' CLAUDE.local.md | grep -c 'sections/\*.yaml'
 ```
 
-Expected: both produce no output (each exits 1). `CLAUDE.local.md` §9 describes the actual
-`sections/*.yaml` layout, and `internal/config/CLAUDE.md` no longer asserts an aggregating main file
-**at either of its two sites**.
+Expected: `0`, `0`, `>= 1`. The two removals are paired with the replacement assertion that §9 still
+describes the actual `sections/*.yaml` layout.
 
-Baseline (verbatim, observed at HEAD `145e601c9`, code baseline `d5336214e`):
+Baseline at `7f61332ef`: `1`, `2`, `2`. The `CLAUDE.local.md` count dropped from the v0.2.0 figure of
+`2` because the §5 site left with the consolidation — it is now AC-UDD-013's target, not this one's.
+The third is a **preservation guard**.
 
-```
-$ grep -c 'config/config.yaml' CLAUDE.local.md
-2                    # :250 (§5 release checklist), :415 (§9 "Main configuration file")
-$ grep -cE 'config\.yaml.{0,2} \(main\)|Main .?config\.yaml' internal/config/CLAUDE.md
-2                    # :5 and :11
-```
+The `internal/config/CLAUDE.md` regex is deliberately wide (`.{0,2}` for code-span backticks): `:5`
+writes the claim as `` `config.yaml` (main) ``, which a pattern assuming a bare adjacent token cannot
+see, and REQ-UDD-006 names both `:5` and `:11`. Narrowing the regex would silently re-exempt `:5`.
 
-**Two corrections are folded into this criterion, and the second reverses the first.**
-
-The originally-recorded second figure of `2` was mis-attributed: it was never observed, and the
-narrow regex `config\.yaml \(main\)` genuinely prints `1`, because
-`internal/config/CLAUDE.md:5` writes the claim as `` `config.yaml` (main) `` — with backticks — so a
-pattern assuming a bare token adjacent to a space does not match it. Correcting the *number* to `1`
-was accurate for that regex.
-
-But correcting the number silently narrowed the *criterion*: REQ-UDD-006 and plan.md §F.4 both name
-`internal/config/CLAUDE.md:5` **and** `:11`, so a criterion that can only see `:11` verifies half the
-requirement, and `:5` could stay uncorrected while this AC passed. The regex is therefore widened to
-tolerate the backticks (`.{0,2}` for the code-span delimiters, `.?` for the leading one), which
-restores the criterion to the scope its requirement states — and the correct observed baseline for
-the widened form is `2`:
-
-```
-$ grep -nE 'config\.yaml.{0,2} \(main\)|Main .?config\.yaml' internal/config/CLAUDE.md
-5:...the layered configuration tree under `.moai/config/` — `config.yaml` (main) plus `sections/*.yaml`...
-11:- **Section-file layout (CLAUDE.local.md §9)**: ... Main `config.yaml` aggregates references. ...
-```
-
-**Falsification**: fails if either site survives. It also fails if a future author reverts to the
-narrow regex, which would silently re-exempt `:5` — the widened pattern is the criterion, not an
-implementation detail of it.
+**Falsification**: fails if any of the three sites survives, if §9's layout description is deleted
+along with the wrong sentence, or if a future author narrows the regex — the wide pattern is the
+criterion, not an implementation detail of it.
 
 #### AC-UDD-012 (code fact) — the path is absent at both the local and the template location
 
@@ -424,487 +425,364 @@ ls internal/template/templates/.moai/config/config.yaml ; echo "template exit=$?
 ls .moai/config/
 ```
 
-Expected: both `ls` commands print `No such file or directory` and exit non-zero, and
-`ls .moai/config/` lists exactly `astgrep-rules`, `evaluator-profiles`, `sections`.
+Expected: both `ls` print `No such file or directory` and exit non-zero, and `ls .moai/config/` lists
+exactly `astgrep-rules`, `evaluator-profiles`, `sections`.
 
-Baseline (verbatim, HEAD `d5336214e`) — this is the measured fact the corrected prose must agree with,
-and the template-path half is spec.md §A.6 drift 3:
+Baseline (verbatim, `7f61332ef`):
 
 ```
 ls: .moai/config/config.yaml: No such file or directory
+local exit=1
 ls: internal/template/templates/.moai/config/config.yaml: No such file or directory
+template exit=1
 astgrep-rules  evaluator-profiles  sections
 ```
 
 **Falsification**: fails if either file has since been created — in which case the documentation was
-right and the fix direction is inverted. The criterion is what prevents "the docs were wrong" from
-being assumed rather than measured.
+right and the fix direction is inverted.
 
-#### AC-UDD-013 (documentation) — the §5 release checklist entry is performable
-
-```bash
-sed -n '/Files Requiring Version Sync/,/Release Process/p' CLAUDE.local.md \
-  | grep -E '^\-' | while read -r _ p _; do ls "$p" >/dev/null 2>&1 || echo "MISSING: $p"; done
-```
-
-Expected: no `MISSING:` line — every path the §5 checklist names resolves to an existing file, so
-every checklist line is performable by a releaser.
-
-Baseline: the loop prints `MISSING: internal/template/templates/.moai/config/config.yaml`. This is the
-release-process consequence of §A.3, distinct from the §9 documentation inaccuracy.
-
-**Falsification**: fails if the entry is deleted without determining what does carry the shipped
-version (plan.md §F.4 note) — a checklist that silently stops covering the version-bearing file is a
-regression, not a fix.
-
-### M5 — §2.2 ast-grep gate
-
-> **Section-range anchor (replaces `sed -n '141p'` in AC-UDD-014c / 016 / 018 / 020).** The four
-> criteria below previously used `sed -n '141p' CLAUDE.local.md` as their **sole** locator, which
-> plan.md D6 forbids ("use `file:line` only as a locating aid, never as the sole matcher") and which
-> M5 itself breaks: M5 is the largest text rewrite in the SPEC and is required to state five distinct
-> facts, so the corrected §2.2 will almost certainly span more than one line — at which point a
-> single-line extractor silently stops seeing most of the section. All four now extract the section
-> by content anchor:
->
-> ```bash
-> sed -n '/§2.2 astgrep-rules/,/^### \[HARD\] settings.local.json/p' CLAUDE.local.md
-> ```
->
-> Observed at HEAD `145e601c9`: `grep -n '§2.2 astgrep-rules' CLAUDE.local.md` → `141:`, and the
-> terminating anchor `### [HARD] settings.local.json Separation` is at `:143`, so the range currently
-> resolves to lines 141-143 (the section body, a blank line, and the next heading) and yields the
-> same counts as the retired single-line form — while remaining correct after a multi-line rewrite.
-> Line numbers below are retained as locating aids only.
->
-> Residual coupling, recorded not hidden: the range's terminating anchor is still bound to the
-> document's structure. If §2.2 is ever moved out from under the `### [HARD] settings.local.json`
-> heading, the anchor must move with it.
-
-#### AC-UDD-014 (documentation) — §2.2 states the gate's actual default
+#### AC-UDD-025 (documentation, new at v0.3.0) — the `.agency/` template-source instruction is removed
 
 ```bash
-grep -c '로더 부재' CLAUDE.local.md
-grep -c '항상 컴파일 기본값 false' CLAUDE.local.md
-sed -n '/§2.2 astgrep-rules/,/^### \[HARD\] settings.local.json/p' CLAUDE.local.md \
-  | grep -cE 'advisory|기본 ON|warn_only'
+grep -c 'internal/template/templates/.agency' CLAUDE.local.md
+grep -c '\.agency' CLAUDE.local.md
+grep -cE 'migrate agency|레거시|legacy' CLAUDE.local.md
 ```
 
-Expected: the first two counts are `0` (the two false mechanism claims are gone) and the third is
-`>= 1` (the corrected text states the gate is on by default in advisory mode). A tree where all three
-are `0` fails — that is deletion, not correction.
+Expected: `0`, `>= 1`, `>= 1`. The nonexistent template-source path is gone; `.agency/` is still
+mentioned (it is live in the code); and the surviving mention describes it in the direction the code
+implements — a legacy layout read *out of* a user project by `moai migrate agency` — rather than as a
+template-managed output directory.
 
-Baseline (observed at HEAD `145e601c9`, code baseline `d5336214e`): `1`, `1`, `0` respectively.
+Baseline at `7f61332ef`: `1`, `4`, `0`.
 
-**Falsification**: fails if the false mechanism parenthetical is removed while the section still
-concludes the gate is off by default, or if the whole gate discussion is deleted from §2.2 (the
-dogfood-mirroring rationale that §2.2 legitimately owns would be lost — AC-UDD-020).
+The second count is a **deletion guard**, not a change detector: silently dropping every `.agency/`
+mention would satisfy the first count while removing a fact contributors still need.
 
-#### AC-UDD-015 (code fact) — loader present, `gate.yaml` shipped, default enabled
+**Falsification**: fails if `:88` keeps naming `internal/template/templates/.agency/`; fails if the
+`[HARD]` Template-First rule keeps instructing that new `.agency/` files be mirrored (first count
+non-zero); and fails if `.agency/` is scrubbed entirely (second count `0`) or retained without the
+directional correction (third count `0`).
+
+#### AC-UDD-026 (code fact, new at v0.3.0) — `.agency/` is inbound-only and has no template source
 
 ```bash
-grep -rn 'loadGateSection' internal/config/
-ls internal/template/templates/.moai/config/sections/gate.yaml .moai/config/sections/gate.yaml
-grep -n -A5 'AstGrepGate: AstGrepGateConfig' internal/config/defaults.go
+ls -d .agency internal/template/templates/.agency
+grep -rn '"\.agency"' --include='*.go' internal | grep -v '_test.go' | wc -l
+grep -rn '"\.agency"' --include='*.go' internal | grep -v '_test.go'
 ```
 
-Expected: all three of §2.2's false claims are contradicted by the tree — `loadGateSection` is
-declared and called; both `gate.yaml` files exist; the compiled default is `Enabled: true`.
+Expected: both `ls` fail; the count is `>= 3`; and every printed site is a *read* of a path inside a
+user project — migration source, v2 fingerprint detection, residue cleanup — with no write into a
+template tree.
 
-Baseline (verbatim, HEAD `d5336214e`):
+Baseline (verbatim, `7f61332ef`):
 
 ```
-internal/config/loader_gate.go:20:func (l *Loader) loadGateSection(dir string, cfg *Config) {
-internal/config/loader.go:89:	l.loadGateSection(sectionsDir, cfg)
-
-internal/template/templates/.moai/config/sections/gate.yaml
-.moai/config/sections/gate.yaml
-
-318:		AstGrepGate: AstGrepGateConfig{
-319-			Enabled:      true,
-320-			BlockOnError: false,
-321-			WarnOnlyMode: true,
+ls: .agency: No such file or directory
+ls: internal/template/templates/.agency: No such file or directory
+       5
+internal/cli/update_residue_cleanup.go:84:	if _, agencyStatErr := os.Stat(filepath.Join(projectRoot, ".agency")); agencyStatErr == nil {
+internal/cli/v2_detection.go:282:	agencyDir := filepath.Join(projectRoot, ".agency")
+internal/cli/migrate_agency.go:200:	agencyDir := filepath.Join(r.projectRoot, ".agency")
+internal/cli/migrate_agency.go:472:	techPrefPath := filepath.Join(r.projectRoot, ".agency", "context", "tech-preferences.md")
+internal/defs/dirs.go:134:		Path:            ".agency",
 ```
 
-The shipped `gate.yaml` sets `ast_grep_gate.enabled: true` explicitly, so the default holds via two
-independent paths.
+The threshold is `>= 3` rather than `== 5` deliberately: the criterion asserts that `.agency/` is
+read from user projects in several places, not that exactly five call sites exist. Pinning the exact
+count would make an unrelated refactor fail a documentation criterion.
 
-**Falsification**: fails if `loadGateSection` is removed, `gate.yaml` is unshipped, or the default
-flips to `false` — any of which would make §2.2's original text correct and this SPEC's correction
-wrong. This is the pairing that prevents "the doc is stale" from being asserted rather than measured.
+**Falsification**: fails if `internal/template/templates/.agency/` is created — in which case the
+Template-First rule was right and AC-UDD-025's correction is wrong. This is the pairing that keeps
+"the instruction is unperformable" measured rather than asserted.
 
-#### AC-UDD-016 (documentation) — §2.2 states the gate's invocation scope
+#### AC-UDD-013 (documentation) — the version-sync checklist entry is performable
 
 ```bash
-sed -n '/§2.2 astgrep-rules/,/^### \[HARD\] settings.local.json/p' CLAUDE.local.md \
-  | grep -cE 'git commit|IsGitCommit'
+F=.moai/docs/version-management.md
+grep -c 'internal/template/templates/.moai/config/config.yaml' "$F"
+grep -c '\.moai/config/sections/system.yaml' "$F"
+grep -cE '\{\{\.Version\}\}|render-time|렌더' "$F"
 ```
 
-Expected: count `>= 1` — the corrected text names the gate's narrow trigger (`git commit` Bash
-invocations), so the correction does not imply the gate fires on every tool call.
+Expected: `0`, `>= 1`, `>= 1`. The unperformable entry is removed; the entry that *is* performable
+(`.moai/config/sections/system.yaml`, which exists and carries `version: v3.1.0-rc.2`) is preserved;
+and a note records that the template side needs no manual bump because it is render-time-injected.
 
-Baseline (observed at HEAD `145e601c9`): count `0`; §2.2 gives no invocation scope at all.
+Baseline at `7f61332ef`: `1`, `2`, `0`.
 
-**Falsification**: fails if the correction states default-on without the scope qualifier, which
-trades one wrong instruction for another (plan.md §G AP-2).
+**Falsification**: fails if the entry is deleted with no note, leaving a reader to assume the
+template version is unmanaged (third count `0`); fails if the `system.yaml` line is removed with it
+(second count `0`); and fails if the entry is replaced by another template path rather than removed —
+which is caught by AC-UDD-027, since no such path exists.
 
-#### AC-UDD-017 (code fact) — the gate is invoked only on `git commit`
+#### AC-UDD-027 (code fact, new at v0.3.0) — the template version is render-time-injected
 
 ```bash
-grep -n -B2 -A2 'IsGitCommit' internal/hook/pre_tool.go
+ls internal/template/templates/.moai/config/sections/system.yaml
+grep -n -A2 '^moai:' internal/template/templates/.moai/config/sections/system.yaml.tmpl
 ```
 
-Expected: the quality gate is constructed inside an `if quality.IsGitCommit(command)` branch, so the
-scope the corrected §2.2 asserts is the scope the code implements.
+Expected: the `ls` fails — there is no hand-bumped template `system.yaml` — and the `.tmpl` shows
+`version: "{{.Version}}"`, confirming the value is substituted when the template is rendered.
 
-Baseline (HEAD `d5336214e`):
+Baseline (verbatim, `7f61332ef`):
 
 ```
-430:		if quality.IsGitCommit(command) {
-431:			gate := quality.NewQualityGate(h.loadGateConfig())
+ls: internal/template/templates/.moai/config/sections/system.yaml: No such file or directory
+4:moai:
+5-  # MoAI-ADK version
+6-  version: "{{.Version}}"
 ```
 
-#### AC-UDD-018 (documentation) — §2.2 records the sg-independent blocking path
+**Falsification**: fails if a literal template `system.yaml` appears, or if the `.tmpl` stops using
+the `{{.Version}}` substitution — either of which would mean a template-side manual bump *is*
+required and AC-UDD-013's removal is wrong. This is the measurement plan.md AP-6 demands before any
+replacement path is asserted.
+
+### M1 — `--dry-run` contract (REQ-UDD-011, REQ-UDD-012, REQ-UDD-013 — all retired)
+
+#### AC-UDD-001 (regression guard) — the flag's promise is kept and still met
 
 ```bash
-sed -n '/§2.2 astgrep-rules/,/^### \[HARD\] settings.local.json/p' CLAUDE.local.md \
-  | grep -cE 'suppression|sg-independent|sg 없이'
+grep -n 'Show planned archive and install operations' internal/cli/update.go
+grep -c 'emitDryRunReinstallPlan' internal/cli/update.go
+go test -run 'TestUpdateDryRun_EmitsCleanReinstallPlan' -count=1 -v ./internal/cli/ 2>&1 | grep -E '^--- (PASS|FAIL)'
 ```
 
-Expected: count `>= 1`, with the surrounding text stating that the suppression-policy check runs in
-pure Go and can return a blocking result even when `sg` is absent, and that the sg-dependent scan
-degrades gracefully.
+Expected: the help text still promises both halves; `emitDryRunReinstallPlan` is referenced `>= 2`
+times (definition + the call inside the dry-run branch); and the sibling SPEC's reachability test
+prints a verbatim `--- PASS: TestUpdateDryRun_EmitsCleanReinstallPlan` line. Per §A clause 7 the
+`--- PASS:` line is required, because `-run` exits `0` on zero matches.
 
-Baseline (observed at HEAD `145e601c9`): count `0`; §2.2 asserts the opposite — that impact requires
-an explicit `moai ast-grep` invocation with `sg` installed.
-
-**Falsification**: fails if §2.2 retains the "sg 설치 시에만" claim, or if it drops the claim without
-stating what can actually block.
-
-#### AC-UDD-019 (code fact) — the suppression check is sg-independent and can block
-
-```bash
-sed -n '41,85p' internal/hook/quality/astgrep_gate.go \
-  | grep -nE 'Suppression policy check|ast-grep scan|ErrScannerUnavailable|return false'
-grep -n -A2 'ErrScannerUnavailable' internal/hook/quality/astgrep_gate.go
-```
-
-Expected, from the first command: four relative-line hits in this order — the step-1 banner, a
-`return false, ...` path, the step-2 banner, and the `ErrScannerUnavailable` branch. The ordering is
-the assertion: step 1 (`checkSuppressionPairing` over `walkSourceFiles`) executes and can block
-*before* any `sg` invocation. From the second: the `ErrScannerUnavailable` branch returns `true`
-(graceful degradation, not a block).
-
-Baseline (verbatim, observed at HEAD `145e601c9`, code baseline `d5336214e`):
+Baseline (verbatim, `7f61332ef`):
 
 ```
-$ sed -n '41,85p' internal/hook/quality/astgrep_gate.go \
-    | grep -nE 'Suppression policy check|ast-grep scan|ErrScannerUnavailable|return false'
-6:	// ── 1. Suppression policy check (sg-independent, pure-Go) ─────────────────
-20:		return false, strings.TrimSpace(sb.String())
-23:	// ── 2. ast-grep scan (depends on sg CLI) ─────────────────────────────────
-39:		if errors.Is(err, astgrep.ErrScannerUnavailable) {
-```
-
-Relative line 39 is absolute line **79**.
-
-**Why the window moved from `41,70` to `41,85`.** The retired command printed `:41-70`, but half of
-its stated expectation — "step 2 returns `true` on `ErrScannerUnavailable`" — lives at `:79`, outside
-that window. The command could not observe what the criterion claimed (§A clause 7), and the
-"baseline" block recorded beneath it was not the command's output: it was an edited composite that
-included the `ErrScannerUnavailable` line the command never printed, which §A clause 4 forbids. The
-window is widened to cover `:79`, the baseline is replaced with the actual observed output, and the
-`ErrScannerUnavailable` branch additionally gets its own command so the `return true` half is
-asserted rather than inferred.
-
-**Falsification**: fails if step 1 is removed or made sg-dependent — the step-1 banner or the
-`return false` hit disappears, or their order inverts relative to the step-2 banner — in which case
-§2.2's original impact claim becomes true and AC-UDD-018's correction is wrong. It also fails if the
-`ErrScannerUnavailable` branch starts returning `false`, which would make the sg-dependent scan
-blocking and contradict AC-UDD-018's "degrades gracefully" half.
-
-#### AC-UDD-020 — §2.2's unaffected content is preserved
-
-```bash
-sed -n '/§2.2 astgrep-rules/,/^### \[HARD\] settings.local.json/p' CLAUDE.local.md \
-  | grep -oE 'dogfood|sgconfig\.yml|utils' | sort -u | wc -l
-```
-
-Expected: `3` — all three preserved topics are still named: the dogfood-experimental rationale for
-not mirroring the language subdirectory tree, the `sgconfig.yml` `utils` ruleDir issue, and (via the
-same sentence) the deferral of the 16-language ruleset. None of the five findings touches them, so
-all three must survive the M5 rewrite.
-
-Baseline (verbatim, observed at HEAD `145e601c9`, code baseline `d5336214e`):
-
-```
-$ sed -n '/§2.2 astgrep-rules/,/^### \[HARD\] settings.local.json/p' CLAUDE.local.md \
-    | grep -oE 'dogfood|sgconfig\.yml|utils' | sort -u | wc -l
+$ grep -n 'Show planned archive and install operations' internal/cli/update.go
+81:	updateCmd.Flags().Bool("dry-run", false, "Show planned archive and install operations without modifying the filesystem")
+$ grep -c 'emitDryRunReinstallPlan' internal/cli/update.go
 3
+$ grep -n 'func TestUpdateDryRun_EmitsCleanReinstallPlan' internal/cli/update_dry_run_reach_test.go
+186:func TestUpdateDryRun_EmitsCleanReinstallPlan(t *testing.T) {
 ```
 
-**This criterion was previously impossible to satisfy, and its recorded baseline was false.** The
-retired form was `sed -n '141p' … | grep -cE 'dogfood|sgconfig\.yml|utils'` expecting `>= 2`.
-`grep -c` counts *matching lines*, not matches; its input was exactly one line, so its output is
-bounded above by `1` and the expectation `>= 2` is unreachable in every possible tree — including a
-perfectly corrected one. The recorded baseline "count `>= 2` at HEAD `d5336214e` (present today)"
-was therefore never observed; the command actually prints `1`:
+All three already hold — this is a **preservation guard** for a retired requirement, not a change
+detector. It fails if a future change drops `install` from the help text (reverting to option A), or
+removes the reachability wiring the sibling landed.
 
-```
-$ sed -n '141p' CLAUDE.local.md | grep -cE 'dogfood|sgconfig\.yml|utils'
-1
-```
+#### AC-UDD-002, AC-UDD-003 — **RETIRED at v0.3.0**
 
-Counting **distinct matched tokens** (`grep -o | sort -u | wc -l`) is the form that expresses the
-intent — three topics preserved — and it is satisfiable, discriminating, and independent of how many
-lines the rewritten section occupies. This is the §A clause 7 arithmetically-unsatisfiable shape.
-
-**Falsification**: fails at `2` or below if the M5 rewrite drops any of the three topics — which is
-the deletion hazard plan.md AP-1 names. §C.2 exercises exactly this against a deleted copy.
+AC-UDD-002 specified two bespoke tests (`TestUpdateDryRunRendersCleanReinstallPlan`,
+`TestUpdateDryRunNoMutation`) for an implementation this SPEC no longer performs. The reachability
+half is covered by AC-UDD-001's use of the sibling's existing test; the no-mutation half is the
+sibling's own guarantee, recorded at `internal/cli/update.go:551-555`. AC-UDD-003 required
+`progress.md` §E.2 to record the option-B execution — the execution happened in
+`SPEC-UPDATE-REINSTALL-LOOP-002`, whose `progress.md` carries it, so requiring a second record here
+would be a claim about work this SPEC did not do.
 
 ### Cross-cutting
+
+#### AC-UDD-024 (new at v0.3.0) — the duplicate ownership is resolved on both sides
+
+```bash
+grep -c 'SPEC-UPDATE-DOC-DRIFT-001' .moai/specs/SPEC-INTERNAL-ARCH-001/spec.md
+grep -c 'REQ-ARCH-006' .moai/specs/SPEC-UPDATE-DOC-DRIFT-001/spec.md
+```
+
+Expected: both `>= 1`. This SPEC records the resolution (spec.md §A.7) and `SPEC-INTERNAL-ARCH-001`
+carries the reciprocal cross-reference marking REQ-ARCH-006 superseded.
+
+Baseline at `7f61332ef`: `0` and `>= 1` after this rewrite — the first count is the open half.
+
+**This criterion is expected to fail until the owner of `SPEC-INTERNAL-ARCH-001` applies the
+cross-reference.** That is the intended state, not a defect in the criterion: this rewrite
+deliberately does not edit that SPEC (spec.md §A.7, §C), and a criterion that passed anyway would
+assume away the very thing it exists to detect. It is the only AC in this SPEC that is red by
+construction at plan-phase.
+
+**Falsification**: fails if either side lacks the cross-reference. Passes only when both SPECs agree
+on who owns the `internal/config/CLAUDE.md` env-var fix.
 
 #### AC-UDD-021 — no template-tree file is modified
 
 ```bash
-git diff --stat d5336214e..HEAD -- internal/template/templates/
-git log --oneline d5336214e..HEAD -- internal/template/templates/ | wc -l
+git diff --stat 7f61332ef..HEAD -- internal/template/templates/
+git log --oneline 7f61332ef..HEAD -- internal/template/templates/ | wc -l
 git diff --stat -- internal/template/templates/
 ```
 
-Expected: the first produces **no output**, the second prints `0`, and the third produces no output.
-`internal/template/templates/**` is untouched relative to the code baseline (NFR-UDD-002). Both
-target files are repo-local maintainer documentation and are never mirrored.
+Expected: the first produces no output, the second prints `0`, the third produces no output
+(NFR-UDD-002). The baseline-relative form is required because the run-phase workflow commits its
+edits — an unstaged-only check falls silent at exactly the moment the constraint is violated.
 
-Baseline (verbatim, observed at HEAD `145e601c9`, code baseline `d5336214e`):
+Baseline at `7f61332ef` (the baseline commit itself): all three empty / `0`.
 
-```
-$ git diff --stat d5336214e..HEAD -- internal/template/templates/
-$ git log --oneline d5336214e..HEAD -- internal/template/templates/ | wc -l
-0
-$ git diff --stat -- internal/template/templates/
-```
-
-**Why the baseline-relative form was added.** The retired criterion ran only
-`git diff --stat -- internal/template/templates/`, which sees **unstaged** changes. The run-phase
-workflow commits its edits, so an implementer who modified a template file and committed it would
-leave that command printing nothing — the guard would fall silent at exactly the moment
-NFR-UDD-002 was violated. Comparing against `d5336214e` (and counting commits that touched the
-path) closes the window; the unstaged check is retained as the third command so an in-flight
-modification is caught before it is committed.
-
-The supporting fact that neither target file ships is unchanged:
+Supporting fact, that none of the four target files is mirrored:
 
 ```
+$ ls internal/template/templates/.moai/docs/
+agent-lint.md  generic-patterns-guide.md
 $ find internal/template/templates -name 'CLAUDE.md'
 internal/template/templates/CLAUDE.md
 $ ls internal/template/templates/internal
 ls: internal/template/templates/internal: No such file or directory
 ```
 
-**Falsification**: fails if any template-tree file is modified, whether the change is committed or
-not.
+**Falsification**: fails if any template-tree file is modified, committed or not.
 
-#### AC-UDD-022 — the build is clean and this SPEC's change surface is green
+#### AC-UDD-022 — the module still builds and vets clean
 
 ```bash
 go build ./... && echo "build=0"
 go vet ./... && echo "vet=0"
-go test -count=1 ./internal/cli/ ./internal/config/ ./internal/hook/quality/
 ```
 
-Expected: `build=0`, `vet=0`, and three `ok` lines.
+Expected: `build=0` and `vet=0`.
 
-Baseline (verbatim, observed at HEAD `145e601c9`, code baseline `d5336214e`):
+Baseline (observed, `7f61332ef`): `build=0`, `vet=0`.
 
-```
-build=0
-vet=0
-ok  	github.com/modu-ai/moai-adk/internal/cli	156.762s
-ok  	github.com/modu-ai/moai-adk/internal/config	1.884s
-ok  	github.com/modu-ai/moai-adk/internal/hook/quality	4.174s
-```
+The v0.2.0 form also ran three test packages. That scope is dropped at v0.3.0 because this SPEC now
+edits **no Go file at all** — every code-touching requirement (REQ-UDD-011/012/013) is retired — so
+binding a documentation SPEC's Definition of Done to any test suite would gate closure on conditions
+unrelated to it. `go build` / `go vet` are retained as the cheap whole-module guard that a markdown
+edit did not somehow break the tree. AC-UDD-023 is the criterion that makes "edits no Go file"
+mechanical rather than asserted.
 
-**The recorded "green" of the retired form was never observed, and the full suite is not green.**
-The retired criterion was `go build ./... && go vet ./... && go test -count=1 ./...` with the
-baseline "green at HEAD `d5336214e` (plan.md §C pre-flight)". Run, the full suite exits **1**:
+Recorded as known and out of scope, carried forward from v0.2.0 so it is not rediscovered as new:
+`TestBranchGuard_Latency` in `internal/hook` is load-sensitive and fails under a parallel full-suite
+run while passing alone. It is not diagnosed here.
 
-```
-FAIL	github.com/modu-ai/moai-adk/internal/hook	32.712s
---- FAIL: TestBranchGuard_Latency (1.84s)
-    pre_tool_branch_guard_integration_test.go:166: iteration 4: checkBranchState took 515.368334ms, ceiling 500ms
-```
-
-Re-run alone, the same test passes (`ok … 1.554s`) — it is a **load-sensitive performance test**,
-failing only under the parallel full-suite run. Since `d5336214e`→HEAD changes SPEC documents only,
-it was equally flaky at `d5336214e`, so the recorded baseline could not have been observed.
-
-The scope is narrowed to the three packages this SPEC's change surface touches, which keeps the
-criterion deterministic. `internal/hook` is deliberately **excluded** from the test scope while
-`go build ./...` and `go vet ./...` still cover it — this SPEC edits no Go file in that package, and
-binding a documentation SPEC's Definition of Done to an unrelated timing flake would make closure
-non-deterministic for reasons that have nothing to do with the SPEC.
-
-Recorded as known, not silently dropped: `TestBranchGuard_Latency`'s load sensitivity is a
-pre-existing condition outside this SPEC's scope (spec.md §C names no `internal/hook` Go change). It
-is not diagnosed here — see the residual-risk note in `progress.md` §E.1.
-
-**Falsification**: fails if any of the three packages regresses, or if `go build` / `go vet` breaks
-anywhere in the module — the two whole-module commands are retained precisely so narrowing the test
-scope does not narrow the build/vet scope.
-
-#### AC-UDD-023 — the test run itself creates and modifies nothing
+#### AC-UDD-023 (rewritten at v0.3.0) — this SPEC modifies no Go file
 
 ```bash
-mkdir -p /tmp/udd-verify
-git status --porcelain > /tmp/udd-verify/before.txt
-go test -count=1 ./internal/cli/ ./internal/config/
-git status --porcelain > /tmp/udd-verify/after.txt
-diff /tmp/udd-verify/before.txt /tmp/udd-verify/after.txt
+git diff --name-only 7f61332ef..HEAD | grep -c '\.go$'
+git diff --name-only 7f61332ef..HEAD | grep -vc '^\.moai/specs/\|^CLAUDE\.local\.md$\|^internal/config/CLAUDE\.md$\|^\.moai/docs/'
 ```
 
-Expected: the tests pass and `diff` produces **no output** and exits `0` — the test run added,
-removed, or modified no tracked or untracked path (NFR-UDD-001).
+Expected: `0` and `0`. No Go file differs from the baseline, and every changed path lies inside this
+SPEC's declared write surface: its own SPEC directory, the two always-loaded instruction files, and
+the two re-anchored `.moai/docs/` targets.
 
-Baseline (observed at HEAD `145e601c9`): `diff` exits `0` with no output.
+Baseline at `7f61332ef` (the baseline commit itself): `0` and `0`.
 
-**Why a delta replaces the absolute check.** The retired criterion asserted that
-`git status --porcelain` "reports no files created or modified by the test run", but the command it
-ran was a bare `git status --porcelain` — an **absolute** emptiness check. This SPEC's run-phase
-edits `CLAUDE.local.md`, `internal/config/CLAUDE.md`, and `progress.md` by definition, so at the
-moment the criterion is evaluated the working tree is necessarily non-empty and the criterion would
-fail for a reason entirely unrelated to NFR-UDD-001. The predicate could not distinguish "a test
-wrote a file" from "the SPEC edited a file" — the very quantities it exists to separate. The
-before/after difference measures only the test run's own effect and is unaffected by the SPEC's
-edits (§A clause 7).
+**Why this replaces the v0.2.0 form.** That criterion snapshotted `git status --porcelain` before and
+after a test run to prove tests wrote nothing outside `t.TempDir()`. With no tests added, it measures
+nothing. The scope constraint — a documentation SPEC that touches only documentation — is the
+property actually worth asserting, and a baseline-relative name-diff asserts it without depending on
+whether the edits are committed yet.
 
-**Falsification**: fails if any test writes outside `t.TempDir()` — a stray fixture, a cache entry,
-or a modified tracked file appears in `after.txt` and not in `before.txt`.
+**Falsification**: fails if any Go file is edited, or if the SPEC's edits reach a path outside the
+five declared prefixes.
 
 ## §C Falsification procedures
 
-Each new guard must be shown to FAIL against uncorrected content. `git stash` is prohibited
-(§A clause 5); falsification uses a scratch copy under `/tmp`.
+Each guard must be shown to FAIL against uncorrected content. `git stash` is prohibited (§A clause 5);
+falsification uses a scratch copy under `/tmp`.
 
 ### C-1 — the documentation criteria actually fail against the current text
 
 ```bash
 mkdir -p /tmp/udd-falsify
-cp CLAUDE.local.md internal/config/CLAUDE.md /tmp/udd-falsify/
-# AC-UDD-014a / AC-UDD-007 / AC-UDD-011 (local half) against the UNCORRECTED copies
-grep -c '로더 부재' /tmp/udd-falsify/CLAUDE.local.md
-grep -c 'MOAI_USER_NAME\|MOAI_CONVERSATION_LANG' /tmp/udd-falsify/CLAUDE.md
-grep -c 'config/config.yaml' /tmp/udd-falsify/CLAUDE.local.md
-# AC-UDD-011 (widened regex, D5) and AC-UDD-009 (removal half, D3)
-grep -cE 'config\.yaml.{0,2} \(main\)|Main .?config\.yaml' /tmp/udd-falsify/CLAUDE.md
-grep -c 'EnvUserName' /tmp/udd-falsify/CLAUDE.md
+cp CLAUDE.local.md /tmp/udd-falsify/CLAUDE.local.md
+cp internal/config/CLAUDE.md /tmp/udd-falsify/config-CLAUDE.md
+cp .moai/docs/version-management.md .moai/docs/local-dev-settings-intent.md /tmp/udd-falsify/
+grep -c '로더 부재' /tmp/udd-falsify/CLAUDE.local.md                                      # AC-UDD-014
+grep -c 'config/config.yaml' /tmp/udd-falsify/CLAUDE.local.md                             # AC-UDD-011
+grep -c 'internal/template/templates/.agency' /tmp/udd-falsify/CLAUDE.local.md            # AC-UDD-025
+grep -c 'MOAI_USER_NAME\|MOAI_CONVERSATION_LANG' /tmp/udd-falsify/config-CLAUDE.md        # AC-UDD-007
+grep -c 'EnvUserName' /tmp/udd-falsify/config-CLAUDE.md                                   # AC-UDD-009
+grep -cE 'config\.yaml.{0,2} \(main\)|Main .?config\.yaml' /tmp/udd-falsify/config-CLAUDE.md  # AC-UDD-011
+grep -c 'internal/template/templates/.moai/config/config.yaml' /tmp/udd-falsify/version-management.md  # AC-UDD-013
+grep 'auto_cleanup' /tmp/udd-falsify/local-dev-settings-intent.md | grep -c '없다'        # AC-UDD-004
 ```
 
-Expected: `1`, `2`, `2`, `2`, `1` — each criterion's expected post-fix value (`0`) is contradicted,
-proving the criteria are load-bearing rather than trivially satisfied. A run producing `0` on any
-line would mean that criterion passes against the defective tree and detects nothing.
+Expected: `1`, `1`, `1`, `2`, `1`, `2`, `1`, `1` — every criterion's expected post-fix value (`0`) is
+contradicted, proving each is load-bearing rather than trivially satisfied. Any line printing `0`
+would mean that criterion passes against the defective tree and detects nothing.
 
-Observed at HEAD `145e601c9`: `1`, `2`, `2`, `2`, `1`.
+Observed at `7f61332ef`: `1`, `1`, `1`, `2`, `1`, `2`, `1`, `1`.
 
-The last two lines were added with the criteria they falsify. The fourth exercises AC-UDD-011's
-**widened** regex, whose whole purpose is to see `internal/config/CLAUDE.md:5` — the narrow form
-returns `1` here and would leave `:5`'s falsification unproven. The fifth exercises AC-UDD-009's
-removal half, which did not previously have a falsifiable command at all.
+The `internal/config/CLAUDE.md` copy is renamed to `config-CLAUDE.md` in the scratch directory so it
+cannot collide with `CLAUDE.local.md`'s basename or with a stray `CLAUDE.md`; the v0.2.0 procedure
+copied both into one directory and then grepped `/tmp/udd-falsify/CLAUDE.md`, whose provenance was
+ambiguous.
 
 ### C-2 — the deletion-vacuity hazard is actually excluded
 
 ```bash
 mkdir -p /tmp/udd-falsify
-sed '141s/.*/> **§2.2 astgrep-rules 로컬 전용 예외**: (removed)/' CLAUDE.local.md \
-  > /tmp/udd-falsify/deleted.md
+L=$(grep -n '§2.2 astgrep-rules' CLAUDE.local.md | cut -d: -f1)
+sed "${L}s|.*|> **§2.2 astgrep-rules 로컬 전용 예외**: (removed)|" CLAUDE.local.md > /tmp/udd-falsify/deleted.md
 R='/§2.2 astgrep-rules/,/^### \[HARD\] settings.local.json/p'
-sed -n "$R" /tmp/udd-falsify/deleted.md | grep -cE 'advisory|기본 ON|warn_only'
+sed -n "$R" /tmp/udd-falsify/deleted.md | grep -cE '권고 모드|advisory|WarnOnlyMode'
+sed -n "$R" /tmp/udd-falsify/deleted.md | grep -cE 'suppression|sg-independent|억제 정책'
 sed -n "$R" /tmp/udd-falsify/deleted.md | grep -oE 'dogfood|sgconfig\.yml|utils' | sort -u | wc -l
 ```
 
-Expected: `0` and `0` — a deletion-only "fix" fails AC-UDD-014's positive half (which requires
-`>= 1`) and AC-UDD-020 (which requires `3`) simultaneously. A run where AC-UDD-014 passes against
-this deleted copy means the criterion is an absence-only grep and the vacuity hazard is unguarded
-(plan.md §G AP-8).
+Expected: `0`, `0`, `0` — a deletion-only "fix" simultaneously fails AC-UDD-014's positive half
+(`>= 1`), AC-UDD-018's positive half (`>= 1`), and AC-UDD-020 (`3`). If AC-UDD-014 passed against
+this deleted copy, it would be an absence-only grep and the vacuity hazard would be unguarded
+(plan.md AP-8).
 
-Observed at HEAD `145e601c9`:
-
-```
-$ sed -n "$R" /tmp/udd-falsify/deleted.md | grep -cE 'advisory|기본 ON|warn_only'
-0
-$ sed -n "$R" /tmp/udd-falsify/deleted.md | grep -oE 'dogfood|sgconfig\.yml|utils' | sort -u | wc -l
-0
-```
-
-**The extractor was updated with the criteria it falsifies.** This procedure previously used
-`sed -n '141p'`, matching the criteria's retired single-line locator. Now that AC-UDD-014c and
-AC-UDD-020 anchor on the section range, the falsification must use the same range — otherwise it
-would demonstrate a contradiction against commands no criterion runs. The `sed` deletion preserves
-the `§2.2 astgrep-rules` start anchor and leaves the `### [HARD] settings.local.json` terminator in
-place, so the range still resolves (3 lines) on the mutated copy and the counts are genuine
-observations rather than extraction failures.
+The line number is resolved by `grep` rather than hardcoded, so the procedure survives the next time
+the file is consolidated — the hardcoded `141` in the v0.2.0 form now points at an unrelated line.
 
 ### C-3 — the code-fact pairing catches an inverted fix direction
 
 ```bash
-# in a scratch copy only: simulate envkeys.go gaining the constant
 cp internal/config/envkeys.go /tmp/udd-falsify/envkeys.go
 printf '\nconst EnvUserName = "MOAI_USER_NAME"\n' >> /tmp/udd-falsify/envkeys.go
 grep -c 'MOAI_USER_NAME' /tmp/udd-falsify/envkeys.go
 ```
 
 Expected: `1` — AC-UDD-008's expected `0` is contradicted, so the criterion would fail and flag that
-`internal/config/CLAUDE.md` was right after all. This proves the F4 resolution rests on the
-measurement rather than on which file is more recent.
+`internal/config/CLAUDE.md` was right after all. This proves the contradiction is resolved by
+measurement, not by which file is more recent (plan.md AP-3).
 
-### C-4 — the dry-run no-mutation guard is load-bearing
-
-Two runs against a scratch copy carrying a deliberately-mutating dry-run stub (one that writes a
-single file inside the fixture before returning). `git stash` is prohibited (§A clause 5); use a
-scratch `git worktree` or `go test -overlay`.
+### C-4 (new at v0.3.0) — the polarity inversion is measured, not assumed
 
 ```bash
-# Run 1 — the real guard (tree-snapshot comparison) against the mutating stub
-go test -run 'TestUpdateDryRunNoMutation' -count=1 -v ./internal/cli/ 2>&1 | grep -E '^--- (FAIL|PASS)'
-
-# Run 2 — the guard weakened to a bare `err == nil` check, same mutating stub
-go test -run 'TestUpdateDryRunNoMutation' -count=1 -v ./internal/cli/ 2>&1 | grep -E '^--- (FAIL|PASS)'
+grep -rn 'Worktree\.AutoCleanup' --include='*.go' internal cmd pkg | grep -v '_test.go' | wc -l
+sed -n '578,590p' internal/cli/session_worktree.go
 ```
 
-Expected, stated as two separate observed lines rather than as a negated sentence:
+Expected: the count is `2`, and the printed context shows the read gating disposal — an early
+`return` when the toggle is `false` — rather than selecting between two advisory strings.
 
-| Run | Guard | Expected line |
-|---|---|---|
-| 1 | real (tree-snapshot comparison) | `--- FAIL: TestUpdateDryRunNoMutation` |
-| 2 | weakened (`err == nil` only) | `--- PASS: TestUpdateDryRunNoMutation` |
+Observed at `7f61332ef`:
 
-The pair is what proves the load-bearing assertion is the tree comparison: the real guard catches
-the mutating stub, and removing *that specific assertion* is sufficient to let it through. If run 2
-also prints `--- FAIL`, some other assertion is doing the work and the tree comparison is not the
-guard it is claimed to be. If run 1 prints `--- PASS`, the stub is not actually mutating and the
-procedure proves nothing — check the stub first.
+```
+2
+	if cfg == nil || !cfg.Workflow.Worktree.AutoCleanup {
+		// REQ-SW-008: default-manual — auto_cleanup is OFF (the distributed
+		// default per CLAUDE.local.md §22.8). The worktree PERSISTS after exit;
+		// the user disposes explicitly via `moai worktree done` / `remove`.
+		return
+	}
+```
 
-**Why this replaces the previous wording.** The retired form read "**FAIL** is no longer produced …
-i.e. the weakened guard passes where the real guard fails" — a double negative over an unstated
-second run, from which the pass/fail direction of either run could not be read off directly. It also
-named no observable line, so at plan-phase the command prints `no tests to run` and exits `0`
-(§A clause 3), which is neither of the two outcomes the procedure distinguishes.
-
-**Precondition**: both runs require `TestUpdateDryRunNoMutation` to exist (AC-UDD-002 assertion 2).
-Until run-phase creates it, C-4 is not executable — that is expected, not a pass.
+This is the procedure that justifies inverting REQ-UDD-004 rather than executing it as v0.2.0 wrote
+it. Had the count been `0`, the v0.2.0 correction would have been right and the inversion wrong. It
+is run *before* the M2 edit, not after.
 
 ## §D Definition of Done
 
-- All of AC-UDD-001 through AC-UDD-023 produce their stated observable output.
-- All four falsification procedures C-1 through C-4 produce their stated contradiction against
-  uncorrected content — C-4 as the two-run pair, both lines observed.
+- AC-UDD-004, 005, 007, 008, 009, 010, 011, 012, 013, 014, 015, 016, 017, 018, 019, 020, 021, 022,
+  023, 025, 026, 027 produce their stated observable output.
+- AC-UDD-001 holds as a preservation guard (the retired M1 has not regressed).
+- AC-UDD-024 is **expected red at plan-phase** and closes only when the owner of
+  `SPEC-INTERNAL-ARCH-001` applies the reciprocal cross-reference. Closing this SPEC with AC-UDD-024
+  red is permitted, provided the open half is named in `progress.md` §E.1 rather than silently
+  passed.
+- AC-UDD-002, AC-UDD-003, AC-UDD-006 are retired; their retirement evidence is recorded above and
+  is not re-litigated.
+- Falsification procedures C-1 through C-4 produce their stated contradictions.
 - Every documentation correction cites the `file:line` or content-anchored symbol it was verified
   against (NFR-UDD-004).
-- `internal/template/templates/**` is unmodified relative to `d5336214e` (AC-UDD-021).
-- The M1 `--dry-run` resolution is **option B** (settled at plan-phase; see spec.md §A.5, plan.md
-  §F.1). §E.2 records its execution and the observed reachability evidence — not a re-litigation of
-  the choice. The M2 `[HARD]`-marker decision remains open and MUST be recorded in `progress.md`
-  §E.2 with its rationale, not resolved implicitly.
-- No criterion is closed on a command that cannot observe its own expectation (§A clause 7).
+- No Go file is modified (AC-UDD-023) and `internal/template/templates/**` is unmodified relative to
+  `7f61332ef` (AC-UDD-021).
+- No criterion is closed on a command that cannot observe its own expectation (§A clause 6), and no
+  correction retracts a claim by quoting it (§A clause 8).
 - `progress.md` §E.2 cites the observed command output for every claim, per
   `.claude/rules/moai/core/verification-claim-integrity.md`.

--- a/.moai/specs/SPEC-UPDATE-DOC-DRIFT-001/plan.md
+++ b/.moai/specs/SPEC-UPDATE-DOC-DRIFT-001/plan.md
@@ -1,186 +1,244 @@
 # SPEC-UPDATE-DOC-DRIFT-001 — Implementation Plan
 
-Milestones are ordered by **decision-reversibility**: the two milestones carrying genuine decisions
-(M1 the `--dry-run` contract choice, M2 the E4 reconciliation dependency) come first, and the
-mechanical text corrections that carry no open decision come last.
+Rewritten at v0.3.0. Milestones are ordered by **decision-reversibility**: the milestones carrying
+genuine judgment calls come first, the mechanical text corrections last. The v0.2.0 M1 (`--dry-run`)
+is retired and recorded at §F.0 rather than deleted, so a reader of this plan can see why it is gone.
 
 ## §A Context
 
-**Code baseline** `d5336214e`; **worktree HEAD at the plan-audit revision** `145e601c9`, branch
-`plan/epic-update-config-audit`, in the worktree `.claude/worktrees/epic-update-config`, merged with
-`origin/main`. `145e601c9` is a descendant of `d5336214e` that changes SPEC documents only —
-`git merge-base --is-ancestor d5336214e HEAD` exits `0`,
-`git diff --name-only d5336214e HEAD | grep -cv '\.md$'` prints `0`, and
-`git diff --stat d5336214e HEAD -- '*.go'` is empty — so every `file:line` in these artifacts is
-attributable to the code baseline. This SPEC was authored at `7225a8b7a` on the same branch and the
-five sibling SPECs recorded the divergent local branch `main` (`1d4e4f7da`); that divergence is now
-resolved and all six share `d5336214e` — see spec.md §A.6 drift 1.
+**Baseline** worktree HEAD `7f61332ef`, branch `docs/spec-doc-drift-rewrite`, based on `origin/main`.
 
-Every `file:line` reference in spec.md §A was verified against this tree while authoring. Three
-drifts were found and recorded rather than silently folded in (spec.md §A.6): the baseline-HEAD
-difference, F1 being false in three ways rather than two, and F3's template-tree path being absent
-as well as the local one.
+The v0.2.0 baseline `d5336214e` is **not an ancestor of this tree** —
+`git merge-base --is-ancestor d5336214e HEAD` exits `1` — so no v0.2.0 `file:line`, count, or
+verbatim output was carried into v0.3.0. Everything in spec.md §A and acceptance.md §B was
+re-observed here. Five cited files moved line numbers; four drifts are recorded at spec.md §A.8, one
+of which (drift 3) reverses the direction of a correction this plan previously specified.
 
-Two properties this plan depends on:
+Three properties this plan depends on:
 
-- **The two target files are repo-local, not shipped.** `internal/template/templates/` contains
-  exactly one `CLAUDE.md` and no `internal/` subtree, so neither `CLAUDE.local.md` nor
-  `internal/config/CLAUDE.md` reaches a downstream user. Every edit in this SPEC is contributor-facing
-  and agent-facing only.
-- **Both files are always-loaded.** They enter every session's context before work begins, which is
-  why a wrong sentence is an input rather than a stale comment (spec.md §A opening).
+- **The always-loaded surface shrank.** `CLAUDE.local.md` was consolidated: former §18-§27 were
+  externalized into `.moai/docs/*.md` and the file now runs §1-§17 plus a `## References` table
+  (511 lines). Two of this SPEC's targets moved out with that change (spec.md §A.0), and the
+  requirements that follow them carry a reduced-severity note: a `.moai/docs/` file is read on
+  demand, not injected into every session.
+- **None of the four target files is shipped.** `internal/template/templates/` contains exactly one
+  `CLAUDE.md`, no `internal/` subtree, and a `.moai/docs/` holding only `agent-lint.md` and
+  `generic-patterns-guide.md`. Every edit here is contributor-facing and agent-facing only.
+- **This SPEC now touches no Go file.** Every code-touching requirement is retired (§F.0), so the
+  change surface is markdown in five path prefixes. AC-UDD-023 makes that mechanical.
 
 ## §B Known issues carried into this SPEC
 
-1. **E4 dependency is one-directional and unsequenced.** `SPEC-CONFIG-KEY-HONESTY-001` §A.6 owns the
-   worktree-key triage; M2's §22.8 text depends on its outcome. The two SPECs may land in either
-   order — M2 records the reconciliation obligation (REQ-UDD-005) rather than blocking on E4.
-2. **The `--dry-run` escalation path is now unlikely but not closed.** The v0.1.0 draft treated
-   "the plan cannot be constructed without entering the mutating path" as a plausible outcome. The
-   probe recorded in §F M1 shows the non-mutating renderer already exists, so the escalation is now
-   a narrow residual: it fires only if the renderer's prologue turns out to write. REQ-UDD-013 still
-   routes that finding to E1 and collapses M1 to the narrow-the-text option, and AC-UDD-002
-   assertion 2 is what would detect it.
-3. **This checkout is shared with concurrent sessions.** `git stash` is prohibited. Falsification for
-   documentation criteria uses a scratch copy under `t.TempDir()` or `/tmp`, never a tree mutation.
-4. **Documentation ACs are vulnerable to vacuous satisfaction.** A criterion phrased as "the file no
-   longer contains string X" is satisfiable by deletion without correction. Every documentation AC in
-   acceptance.md is therefore paired with a code-fact assertion (acceptance.md §A clause 2).
-
-5. **Pairing is necessary but not sufficient — the command must also be able to observe its own
-   expectation.** The plan-audit found this the dominant defect class here: a `grep -c` over a
-   one-line input asked for `>= 2`; two criteria printed a line and expected a prose judgment about
-   it; one expected a fact at `:79` from a command printing `:41-70`; one guard went inert once its
-   change was committed; one could not separate the test run's writes from the SPEC's own edits.
-   acceptance.md §A clause 7 states the rule and names the criteria rewritten under it.
+1. **The `auto_cleanup` correction is the opposite of what v0.2.0 specified.** Two production readers
+   appeared since the v0.2.0 baseline. Executing the v0.2.0 M2 text as written would write a false
+   statement into the doc. §F.2 is rewritten against the measurement, and acceptance.md §C-4 is run
+   *before* the edit rather than after.
+2. **A correction that quotes what it retracts defeats its own acceptance criterion.** The
+   2026-08-01 fix to §2.2 is correct prose whose quoted retraction leaves `grep -c '로더 부재'` at
+   `1`. acceptance.md §A clause 8 states the resulting constraint on the M5 edit: state the truth,
+   do not quote the retracted claim.
+3. **The duplicate with `SPEC-INTERNAL-ARCH-001` REQ-ARCH-006 is resolved on one side only.** That
+   SPEC is under concurrent review in this session; editing it would race another agent. §F.6 reports
+   rather than edits, and AC-UDD-024 is red by construction until its owner acts.
+4. **This checkout is shared with concurrent sessions.** `git stash` is prohibited. Falsification
+   uses a scratch copy under `/tmp`, never a tree mutation.
+5. **Documentation ACs are vulnerable to vacuous satisfaction.** Every removal count is paired with a
+   replacement count over the same scope (acceptance.md §A clause 3), and every documentation
+   criterion is paired with a code-fact criterion (clause 2).
 
 ## §C Pre-flight
 
 ```bash
-git rev-parse --short HEAD                       # expect 145e601c9 or a recorded successor
-git merge-base --is-ancestor d5336214e HEAD      # expect exit 0 (code baseline still applies)
-git diff --name-only d5336214e HEAD | grep -cv '\.md$'   # expect 0 (SPEC docs only)
-git branch --show-current                        # expect plan/epic-update-config-audit
-go build ./... && go vet ./...
-go test -count=1 ./internal/cli/ ./internal/config/ ./internal/hook/quality/
+git rev-parse --short HEAD                    # expect 7f61332ef or a recorded successor
+git branch --show-current                     # expect docs/spec-doc-drift-rewrite
+git diff --name-only 7f61332ef..HEAD | grep -c '\.go$'   # expect 0 (no Go change in this SPEC)
+go build ./... && go vet ./...                # expect exit 0, exit 0
 ```
 
-The test scope deliberately excludes `./internal/hook/...`: `TestBranchGuard_Latency` there is a
-load-sensitive performance test that fails under a parallel full-suite run and passes alone (see
-acceptance.md AC-UDD-022). This SPEC edits no Go file in that package, so binding pre-flight to that
-flake would gate a documentation SPEC on an unrelated timing condition. `go build` / `go vet` still
-cover the whole module.
+No test package is in pre-flight scope. This SPEC edits no Go file, so binding it to any suite would
+gate a documentation change on unrelated conditions — in particular on `TestBranchGuard_Latency` in
+`internal/hook`, a load-sensitive performance test that fails under a parallel full-suite run and
+passes alone (acceptance.md AC-UDD-022). `go build` / `go vet` still cover the whole module.
 
 ## §D Constraints
 
-- **D1 — no template-tree edits.** `internal/template/templates/**` is untouched (NFR-UDD-002).
-  Neither target file is mirrored there, and neither shall be made to be.
-- **D2 — no code changes in this Epic.** Plan-phase artefacts only. M1's behavioural half, if the
-  extend option is selected, is a run-phase decision recorded in this plan, not performed.
+- **D1 — no template-tree edits.** `internal/template/templates/**` is untouched (NFR-UDD-002). None
+  of the four target files is mirrored there, and none shall be made to be.
+- **D2 — no code changes.** Documentation only. The behavioural half of the former M1 was landed by
+  a sibling SPEC (§F.0) and is not re-performed here.
 - **D3 — cite the verification site.** Every correction names the `file:line` or content-anchored
-  symbol it was verified against (NFR-UDD-004), so a future reader re-verifies rather than re-derives.
+  symbol it was verified against (NFR-UDD-004).
 - **D4 — correct, do not merely delete.** Removing an offending sentence without stating the true
-  mechanism satisfies a grep and leaves the reader with no guidance. Each correction states what the
-  code actually does.
-- **D5 — do not overclaim in the opposite direction.** §A.1's correction must state the gate's
-  narrow invocation scope (`git commit` only) alongside its default-on status; a correction that
-  implies the gate fires on every tool call is a new error, not a fix.
-- **D6 — line numbers drift.** Anchor every criterion on a content token where one exists; use
-  `file:line` only as a locating aid, never as the sole matcher.
+  mechanism satisfies a grep and leaves the reader with nothing.
+- **D5 — do not overclaim in the opposite direction.** §2.2's correction must carry the invocation
+  scope (both conjuncts) alongside the blocking statement; a correction implying the gate fires on
+  every tool call is a new error, not a fix.
+- **D6 — do not retract by quotation.** Stating the current mechanism is the correction; quoting the
+  superseded claim re-introduces its tokens and defeats the criterion (acceptance.md §A clause 8).
+- **D7 — line numbers drift.** Anchor every criterion on a content token; use `file:line` only as a
+  locating aid. The v0.3.0 rewrite exists largely because v0.2.0's anchors did not survive one
+  consolidation.
 
 ## §E Self-verification
 
 Each milestone closes only when its acceptance.md criteria print the stated observable output. §E of
-`progress.md` carries the run-phase evidence.
+`progress.md` carries the run-phase evidence. AC-UDD-024 is the single criterion permitted to close
+red, and only with its open half named in `progress.md` §E.1.
 
 ## §F Milestones
 
-### M1 — `--dry-run` contract resolution: option B (REQ-UDD-011, REQ-UDD-012, REQ-UDD-013)
+### §F.0 — Retired milestone: the `--dry-run` contract (former M1)
 
-The only milestone with a behavioural face. **The decision is settled — option B.**
+Kept as a record so the retirement is auditable rather than silent.
 
-**The mismatch.** The help text (`internal/cli/update.go:69`) promises "planned archive **and
-install** operations"; the handler (`:294-304`) early-returns into `dryRunArchiveLegacySkills`,
-which previews archiving only.
+v0.2.0 settled the A-vs-B choice as **option B** — make the existing non-mutating clean-reinstall
+plan renderer reachable — and specified the constraint that the `--dry-run` early return must not
+move past `stripRetiredV2DenyEntries`, which rewrites `settings.json`.
 
-**The probe this plan previously only recommended has been run, and it reverses the cost table.**
-The v0.1.0 table charged option B with "real implementation work, and its feasibility is unverified"
-— a cost asserted without measurement, which is the shape
-`.claude/rules/moai/core/verification-claim-integrity.md` §1.1 surface 3 forbids. Measured:
+That work landed, in `SPEC-UPDATE-REINSTALL-LOOP-002` (status `completed`) as REQ-RIL2-024/025/026,
+under exactly that constraint:
 
-- `internal/cli/update_clean_install.go:50-53` declares `CleanReinstallOptions.DryRun`
-  ("when true, emit planned actions but make no filesystem mutations", REQ-VVCR-028).
-- `internal/cli/update_clean_install.go:184-198` is a complete non-mutating plan renderer: it prints
-  `[clean-reinstall] DRY-RUN — no filesystem mutations performed`, the would-back-up count, the
-  would-remove count (`scanDeprecatedPaths` at `:189`), and the agency-migration line, then
-  `return result, nil` at `:197` — before any mutation.
-- `internal/cli/update.go:359-360` already wires `DryRun: getBoolFlag(cmd, "dry-run")` into
-  `runCleanReinstall`.
+```
+$ sed -n '344,355p' internal/cli/update.go
+344:		// SPEC-UPDATE-REINSTALL-LOOP-002 REQ-RIL2-024/025 (M4): the v2
+345:		// fingerprint is computed HERE — inside the dry-run branch, above the
+346:		// deny-rule migration below — so the clean-reinstall and
+347:		// residue-cleanup plans become reachable from `moai update --dry-run`.
+353:		// The early return itself does NOT move (REQ-RIL2-026): it stays
+354:		// ABOVE stripRetiredV2DenyEntries, which rewrites settings.json.
+355:		return emitDryRunReinstallPlan(cmd.Context(), cwd, getBoolFlag(cmd, "force"), out, th)
+```
 
-The renderer is unreachable for exactly one reason: the CLI's `--dry-run` early return at `:294`
-fires before the v2-detection block at `:328`.
+REQ-UDD-011 and REQ-UDD-012 are satisfied; REQ-UDD-013, whose content was to escalate to that same
+sibling if the plan could not be rendered without mutation, is moot. AC-UDD-001 remains as a
+regression guard; AC-UDD-002 and AC-UDD-003 are retired.
 
-| Option | Change | Actual cost | What is lost |
-|---|---|---|---|
-| A — narrow the text | Rewrite the description to "Show planned archive operations without modifying the filesystem". | One line, no behaviour change. | The highest-consequence operation — clean reinstall replacing the user's tree — stays unpreviewable. |
-| **B — make the renderer reachable** *(chosen)* | Hoist v2 detection above the `--dry-run` branch; that branch renders the resulting plan and returns. | A local re-ordering. The renderer and its wiring already exist — nothing new is written. | Nothing. |
+The v0.2.0 worry that the two SPECs might push the early return in opposite directions did not
+materialise — worth recording, because the coordination cost was paid in specification and the
+outcome confirms it was not wasted.
 
-**Implementation constraint (load-bearing).** The `--dry-run` early return is **not** relocated past
-`:306-326`. That block calls `stripRetiredV2DenyEntries`, which rewrites `settings.json`; moving the
-return past it would put a mutation on the dry-run path and reverse the `:312` rationale ("so a dry
-run never mutates"). Detection is hoisted *above* the branch; the branch keeps returning before any
-mutating call. The sibling `SPEC-UPDATE-REINSTALL-LOOP-002` plan.md §E M4 reached the same
-resolution independently and records the relocate-the-return variant as a **confirmed defect** — the
-two SPECs must not push this early return in opposite directions.
+### M2 — §22.8 worktree-toggle status, polarity inverted (REQ-UDD-004)
 
-**What remains verified only by reading, not by running.** The renderer's prologue —
-`buildPreserveInventory` / `computeInventoryHashes` (`:179`) and `scanDeprecatedPaths` (`:189`) — was
-read and contains no write call, but was not executed. AC-UDD-002 assertion 2 (tree-snapshot
-comparison over a `t.TempDir()` fixture) is the criterion that settles it.
+**First, because it is the milestone whose direction changed and the one that is easiest to get
+wrong.** Executing the v0.2.0 text here would introduce a falsehood.
 
-**Escalation, unchanged in substance and now much less likely.** If run-phase finds the plan cannot
-be rendered without mutation, that is a finding about clean-reinstall's structure, not about the
-flag: report it to `SPEC-UPDATE-REINSTALL-LOOP-002` per REQ-UDD-013 and fall back to A with the
-reason recorded.
+Target: `.moai/docs/local-dev-settings-intent.md:58-65` (§22.8), which received this content when
+`CLAUDE.local.md` §18-§27 were externalized. `CLAUDE.local.md:506` is the References entry pointing
+at it.
 
-**Deliverable**: the help text keeps both halves of its promise and the behaviour now meets it; the
-execution evidence is recorded in `progress.md` §E.2 (AC-UDD-003).
+**Run acceptance.md §C-4 before editing.** It re-measures the reader count and prints the reader's
+context. If `Worktree.AutoCleanup` returns `0` production readers, the v0.2.0 correction was right,
+this inversion is wrong, and the milestone stops for re-specification.
 
-### M2 — §22.8 worktree-toggle reconciliation (REQ-UDD-004, REQ-UDD-005)
+The measured state (spec.md §A.2):
 
-The second decision, and the one with a cross-SPEC dependency.
+| Toggle | Production readers | What the read does |
+|---|---|---|
+| `auto_cleanup` | 2 — `session_worktree.go:584`, `session_worktree_prmerge.go:122` | **gates disposal**: `false` returns early and the worktree persists |
+| `auto_merge` | 0 | — |
+| `auto_create` | 1 — `worktree_advisory.go:60` | selects between two advisory sentences |
 
-`CLAUDE.local.md` §22.8 currently presents three toggles as an opt-in policy under a `[HARD]` marker.
-Measured, only `auto_create` has a production reader, and that read selects advisory wording rather
-than gating creation (spec.md §A.2).
+The current text says `auto_merge` / `auto_cleanup` have no reader and that no code path consumes
+them. Half of that is now false, which is the worst available state: a reader who spot-checks
+`auto_merge`, finds the doc right, and extends the confidence to `auto_cleanup`.
 
-**The correction states reader status, not triage.** The §22.8 text must say which toggles are read
-and what the read does — `auto_cleanup` and `auto_merge` unread; `auto_create` read at
-`internal/cli/worktree_advisory.go:29`/`:60` to select between two advisory sentences. It must not
-propose implementing, deprecating, or removing them; that is `SPEC-CONFIG-KEY-HONESTY-001` §A.6 /
-REQ-CKH-009 territory (spec.md §C).
+**The judgment call, surfaced rather than resolved here.** The shipped default for `auto_cleanup`
+remains `false` while it now gates real behaviour. Whether that combination is itself a defect is
+`SPEC-CONFIG-KEY-HONESTY-001` territory (spec.md §C) — this milestone records the reader status and
+takes no position. The `[HARD] … 의도된 정책` marker protecting the `false` defaults from being
+"corrected" back to `true` by a future audit is a real protection and is preserved; what changes is
+only the reader-status sentence beneath it. AC-UDD-004's third count is the guard that the marker's
+subject matter is not deleted along with the wrong sentence.
 
-**The dependency, and why it is not a blocker.** E4's triage may reclassify these keys (wire / mark
-reserved / delete). REQ-UDD-005 makes the reconciliation an obligation rather than a sequencing
-constraint: whichever SPEC lands second re-checks the §22.8 text against the other's outcome. Landing
-this SPEC first leaves §22.8 accurate as of today and flagged for re-check; landing E4 first lets M2
-write the final text directly.
+The two reader sites carry comments citing `CLAUDE.local.md §22.8`. Those still resolve through the
+References table (spec.md §A.0), so they are left alone — see §G AP-11.
 
-**Decision to surface at review**: whether the `[HARD] ... 의도된 정책. 감사/동기화 시 "결함"으로
-되돌리지 말 것` marker survives. The marker protects the `false` defaults from being "corrected" back
-to `true` by a future audit — a real protection worth keeping — but it currently sits attached to a
-policy claim that overstates enforcement. Options are to keep the marker scoped narrowly to the
-defaults themselves, or to move it to whatever E4 records. Not resolved here.
+### M5 — §2.2 ast-grep gate: the second correction (REQ-UDD-002, REQ-UDD-003)
+
+**Second, because it is the largest rewrite and carries the D6 constraint.**
+
+Target: `CLAUDE.local.md:146` (§2.2 — `:141` at v0.2.0). The section is one physical line.
+
+Its four original false claims were retracted in place on 2026-08-01, so the falsehood halves of both
+requirements are discharged (spec.md §A.1). Three things remain to do, and one thing not to do.
+
+**(a) Remove the quotation, keep the substance.** The retraction quotes its predecessor —
+"종전 이 절은 `…로더 부재 → … 항상 컴파일 기본값 false`라고 적었으나 두 주장 모두 … 거짓이다" — which
+leaves both retracted tokens in the file (D6). The corrected section states the mechanism directly.
+The dated marker and the `v3.0.1`-vs-`main` release-version distinction are **substantive and are
+kept**: they record that released `v3.0.1` genuinely has no loader (issue #1265) and that the
+resolution is a release, not a code change. That is a fact about two trees, not a quotation.
+
+**(b) State the invocation scope, both conjuncts** (REQ-UDD-002). The gate is evaluated at
+`internal/hook/pre_tool.go:447` under
+`quality.IsGitCommit(command) && !config.IsAutonomyTierCommitGateOff(config.AutonomyTier())`. The
+second conjunct is new since v0.2.0 (spec.md §A.8 drift 2); naming only `git commit` would be
+incomplete on this tree.
+
+**(c) Correct the new misstatement** (REQ-UDD-003). The current text concludes that blocking is
+reachable only via a `gate.yaml` opt-in. It is not: `RunAstGrepGateV2` step 1
+(`internal/hook/quality/astgrep_gate.go:46-61`) walks source files in pure Go and returns `false` at
+`:60` whenever a suppression-policy violation is found — `WarnOnlyMode` is passed only into the
+step-2 scanner config at `:68` and does not reach that return. The corrected text states: the
+suppression-policy check is sg-independent and blocks irrespective of `WarnOnlyMode`; the
+sg-dependent scan degrades gracefully when `sg` is absent (`ErrScannerUnavailable` → pass, `:79`).
+
+**What not to do.** The dogfood-experimental rationale, the `sgconfig.yml` `utils` ruleDir issue, and
+the 16-language-ruleset deferral are untouched by any finding and are preserved (AC-UDD-020).
+
+### M4 — nonexistent paths: `config.yaml` and `.agency/` (REQ-UDD-006)
+
+**Third: mechanical for `config.yaml`, one judgment call for `.agency/`.**
+
+`config.yaml` — three sites, unchanged in substance since v0.1.0, at two files:
+
+- `CLAUDE.local.md:328` (§9) — stop calling `.moai/config/config.yaml` the "Main configuration file";
+  describe the `sections/*.yaml`-only layout that the same section already describes four lines
+  below, so the file stops contradicting itself.
+- `internal/config/CLAUDE.md:5` and `:11` — the same claim (`` `config.yaml` (main) plus
+  `sections/*.yaml` ``; "Main `config.yaml` aggregates references"), corrected identically.
+
+`.agency/` — four sites in `CLAUDE.local.md`, newly folded into this requirement at v0.3.0:
+
+- `:88` names `internal/template/templates/.agency/` as a template-source directory. It does not
+  exist.
+- `:94`, `:106`, `:108` instruct, inside a `[HARD]` Template-First rule, that new `.agency/` files be
+  mirrored into that directory, and that a pre-commit check verify the mirror. Both are
+  unperformable.
+
+**The judgment call: how much to keep.** `.agency/` is live in the code but **inbound only** — a
+legacy layout read *out of* a user project by `moai migrate agency` (`migrate_agency.go:200`), the v2
+fingerprint detector (`v2_detection.go:282`), and residue cleanup (`update_residue_cleanup.go:84`),
+with a `internal/defs/dirs.go:134` entry. Deleting every mention would remove a fact contributors
+still need; keeping the Template-First arm asserts a direction that never existed. The correction
+therefore **keeps** `.agency/` and **re-describes** it as legacy-inbound, removing it from the
+template-source list and from the mirror instruction. AC-UDD-025's second and third counts are the
+guards on each half of that.
+
+### M4b — the version-sync checklist, re-anchored (REQ-UDD-007)
+
+Target moved: `CLAUDE.local.md` §5 is now a three-line pointer, and the *Files Requiring Version
+Sync* list lives at `.moai/docs/version-management.md:66-78`.
+
+`:78` names `internal/template/templates/.moai/config/config.yaml (moai.version)` — the file
+AC-UDD-012 shows does not exist. The line is unperformable: a releaser skips it silently or creates a
+config file nothing loads.
+
+**The replacement was measured before being specified** (§G AP-6). There is no
+`internal/template/templates/.moai/config/sections/system.yaml` either; the template ships
+`system.yaml.tmpl` with `version: "{{.Version}}"` at `:6`, injected at render time. So the template
+side carries **no** hand-bumped version, and the correct edit is deletion of `:78` plus a one-line
+note recording the render-time injection — not substitution of another path, which would re-create
+the defect at a new location. `:77` (`.moai/config/sections/system.yaml`) is correct and stays.
 
 ### M3 — `internal/config/CLAUDE.md` env-override correction (REQ-UDD-008, REQ-UDD-009, REQ-UDD-010)
 
-Mechanical once the contradiction is resolved, and the resolution direction is already measured.
+**Last among the edits: fully mechanical, direction already measured, no open decision.**
 
-`internal/config/CLAUDE.md:12` claims `MOAI_USER_NAME` / `MOAI_CONVERSATION_LANG` override file
-values; `:13` cites `EnvUserName` as the `envkeys.go` convention example. Neither constant exists
-(`grep -n 'MOAI_USER_NAME\|MOAI_CONVERSATION_LANG' internal/config/envkeys.go` → no output), and
-`applyEnvOverrides` (`internal/config/manager.go:393-406`) reads exactly four names.
-`CLAUDE.local.md` §9 already states this correctly.
+`:12` claims `MOAI_USER_NAME` / `MOAI_CONVERSATION_LANG` override file values; `:13` cites
+`EnvUserName` as the `envkeys.go` worked example. Neither constant exists, and `applyEnvOverrides`
+(`internal/config/manager.go:398-411`) reads exactly four names. `CLAUDE.local.md` §9 already states
+this correctly, so the contradiction is resolved against the code, not by recency (§G AP-3).
 
 Three edits:
 
@@ -188,107 +246,76 @@ Three edits:
    (`MOAI_DEVELOPMENT_MODE`, `MOAI_LOG_LEVEL`, `MOAI_LOG_FORMAT`, `MOAI_NO_COLOR`, plus
    `MOAI_CONFIG_DIR` for the config-directory location), citing `applyEnvOverrides` as the site.
 2. **`:13` convention example** — replace `EnvUserName = "MOAI_USER_NAME"` with a constant
-   `envkeys.go` actually declares (e.g. `EnvDevelopmentMode = "MOAI_DEVELOPMENT_MODE"`). The
-   convention itself (constants live in `envkeys.go`; no inline `os.Getenv("MOAI_*")`) is correct and
-   is preserved.
+   `envkeys.go` declares; `EnvDevelopmentMode = "MOAI_DEVELOPMENT_MODE"` is confirmed present. The
+   convention itself — constants live in `envkeys.go`, no inline `os.Getenv("MOAI_*")` — is correct
+   and preserved.
 3. **`:12` test instruction** — scope "Tests MUST verify this priority via `t.Setenv` + fixture file
-   combinations" to the implemented set, so following it literally cannot produce an unpassable test
-   (REQ-UDD-010).
+   combinations" to the implemented set.
 
 Edit 3 is the one that matters beyond accuracy: as written, the instruction directs an agent toward
 either a failing test or an unrequested env-override implementation.
 
-### M4 — nonexistent `config.yaml` references (REQ-UDD-006, REQ-UDD-007)
+### M6 — report the unresolved half of the duplicate (REQ-UDD-014)
 
-Mechanical. Three sites, on two files, asserting a file that exists at neither the local nor the
-template path (spec.md §A.3, §A.6 drift 3).
+Not an edit. `SPEC-INTERNAL-ARCH-001` REQ-ARCH-006 claims the same fix M3 performs; spec.md §A.7
+resolves ownership in favour of this SPEC and states the three reasons.
 
-- `CLAUDE.local.md:415` (§9) — stop calling `.moai/config/config.yaml` the "Main configuration
-  file"; describe the actual `sections/*.yaml` layout.
-- `CLAUDE.local.md:250` (§5, *Files Requiring Version Sync*) — remove the
-  `internal/template/templates/.moai/config/config.yaml` entry or replace it with the file that
-  actually carries the shipped version. This is the release-process consequence: the line as written
-  is unperformable.
-- `internal/config/CLAUDE.md:5` and `:11` — the same claim ("`config.yaml` (main) plus
-  `sections/*.yaml`"; "Main `config.yaml` aggregates references"), corrected identically.
-
-**Note for M4's replacement text**: determine what does carry the shipped version before rewriting
-the §5 entry — `.moai/config/sections/system.yaml` (`moai.version`) is the adjacent line and the
-likely answer, but the run-phase edit should verify rather than assume, since asserting the wrong
-replacement re-creates the defect in a new location.
-
-### M5 — §2.2 ast-grep gate correction (REQ-UDD-002, REQ-UDD-003)
-
-Largest text rewrite, but no open decision — the correct statement is fully determined by the
-measurements in spec.md §A.1.
-
-`CLAUDE.local.md:141` currently asserts four things, all false: loader absent, `gate.yaml` absent,
-compiled default `false`, and impact confined to explicit `moai ast-grep` with `sg` installed.
-
-The corrected statement must carry all four true facts **and** the scope narrowing (D5):
-
-- The loader exists: `internal/config/loader_gate.go:20` `loadGateSection`, called from
-  `internal/config/loader.go:89`.
-- `gate.yaml` is shipped (template + local) and sets `ast_grep_gate.enabled: true`.
-- The compiled default is `Enabled: true, BlockOnError: false, WarnOnlyMode: true`
-  (`internal/config/defaults.go:318-322`) — on, in advisory mode.
-- The gate is evaluated on `git commit` Bash invocations only
-  (`internal/hook/pre_tool.go:430-431`, `quality.IsGitCommit`), **not** on every tool call.
-- The suppression-policy check (`internal/hook/quality/astgrep_gate.go` step 1) is sg-independent
-  pure Go and can return a blocking result; the sg-dependent scan (step 2) degrades gracefully when
-  `sg` is absent and cannot block under `WarnOnlyMode: true`.
-
-Everything else in §2.2 — the dogfood-experimental rationale for not mirroring the language
-subdirectory tree, the `sgconfig.yml` `utils` ruleDir issue, the deferral of the 16-language ruleset
-to a follow-up SPEC — is unaffected by these findings and is preserved verbatim.
+The reciprocal edit — marking REQ-ARCH-006 superseded and pointing AC-ARCH-007 here — belongs to that
+SPEC's owner and is **not** made from this worktree: that SPEC is under concurrent review in this
+session (§B.3). This milestone's deliverable is the report, and AC-UDD-024 is the detector that keeps
+the open half visible instead of assumed away. Closing this SPEC with AC-UDD-024 red is permitted,
+provided `progress.md` §E.1 names it.
 
 ## §G Anti-patterns
 
 - **AP-1 — deleting the offending sentence instead of correcting it.** A grep-satisfying deletion
   leaves the reader with no statement of the actual mechanism, which is worse than a wrong one in the
-  §2.2 case because the gate's existence then goes entirely unmentioned (D4).
-- **AP-2 — overcorrecting §2.2 into "the gate fires on every tool call".** It fires on `git commit`
-  only. A correction that drops the scope qualifier trades one wrong instruction for another (D5).
-- **AP-3 — resolving the F4 contradiction by recency.** `CLAUDE.local.md` §9 wins because
-  `envkeys.go` and `applyEnvOverrides` say so, not because it was written later. The measurement is
-  the arbiter.
-- **AP-4 — re-specifying the worktree-key triage in M2.** §22.8's correction states reader status.
-  Implement / deprecate / mark is E4's decision (spec.md §C).
-- **AP-5 — reopening or silently re-deciding the `--dry-run` option.** The A-vs-B choice is settled
-  as **B** at plan-phase (§F M1, spec.md §A.5), on a probe whose evidence is recorded. Re-deciding it
-  inside an implementation commit — in particular quietly falling back to A by dropping `install`
-  from the help text — hides the reversal; AC-UDD-001 is the guard against exactly that.
-- **AP-9 — implementing option B by relocating the `--dry-run` early return.** The return must not
-  move past `update.go:306-326`, which rewrites `settings.json`. Hoist detection above the branch
-  instead. This is the variant `SPEC-UPDATE-REINSTALL-LOOP-002` plan.md §E M4 records as a confirmed
-  defect; an implementation that moves the return is wrong whether or not a test catches it.
-- **AP-10 — costing an option without probing it.** The v0.1.0 cost table charged option B with
-  "feasibility is unverified" and used that unverified cost as the reason to prefer A, while the
-  probe that would settle it was one `sed` away in a file the SPEC already cited. Asserting a cost is
-  a claim like any other (`verification-claim-integrity.md` §1.1 surface 3).
-- **AP-6 — asserting a replacement path in M4 without checking it.** Replacing one nonexistent path
-  with another unverified one reproduces the defect.
-- **AP-7 — mirroring either file into the template tree.** Both are repo-local; a mirror violates the
-  isolation doctrine (NFR-UDD-002, spec.md §C).
-- **AP-8 — an AC that only greps for absence.** Every documentation criterion pairs with a code-fact
-  criterion (acceptance.md §A clause 2); an absence-only criterion is satisfied by deletion.
+  §2.2 case because the gate's existence then goes unmentioned entirely (D4).
+- **AP-2 — overcorrecting §2.2 into "the gate fires on every tool call".** It fires under two
+  conjuncts. Dropping the scope qualifier trades one wrong instruction for another (D5).
+- **AP-3 — resolving the env-var contradiction by recency.** `CLAUDE.local.md` §9 wins because
+  `envkeys.go` and `applyEnvOverrides` say so, not because it was written later.
+- **AP-4 — re-specifying the worktree-key triage in M2.** The correction states reader status.
+  Implement / deprecate / mark is `SPEC-CONFIG-KEY-HONESTY-001` territory (spec.md §C).
+- **AP-6 — asserting a replacement path without checking it.** Replacing one nonexistent path with
+  another unverified one reproduces the defect. M4b's deletion-plus-note is the measured outcome of
+  actually looking.
+- **AP-7 — mirroring any target file into the template tree.** All four are repo-local (NFR-UDD-002).
+- **AP-8 — an AC that only greps for absence.** Every removal count is paired with a replacement
+  count (acceptance.md §A clause 3).
+- **AP-11 — sweeping the retired `§18`-`§27` citations** *(new at v0.3.0)*. 44 Go comments and 8
+  rule/doc sites cite the retired section numbers. They still resolve: the `## References` table
+  preserves the §-number → file mapping and the receiving files keep their §-numbered headings. This
+  was measured before it could be proposed as a defect, which is the point — a repo-wide sweep on a
+  false premise is a large, confident, wrong change.
+- **AP-12 — carrying a v0.2.0 figure into a v0.3.0 claim** *(new at v0.3.0)*. The old baseline is not
+  an ancestor of this tree. Every number in these artifacts was re-observed; drift 3 shows what
+  happens when one is not — the correction it specified would have written a falsehood.
+- **AP-13 — editing `SPEC-INTERNAL-ARCH-001` from this worktree** *(new at v0.3.0)*. It is under
+  concurrent review. §F.6 reports; it does not reach across.
 
 ## §H Cross-references
 
 - `.claude/rules/moai/core/verification-claim-integrity.md` — every claim in `progress.md` §E must
   cite an observed command.
-- `CLAUDE.local.md` §2.2 (M5), §5 (M4), §9 (M4), §22.8 (M2), §25 (template isolation — NFR-UDD-002).
+- `CLAUDE.local.md` §2 / §2.2 (M5), §9 (M4), §2 Template-First `.agency/` arm (M4), `## References`
+  table (context for the re-anchored targets).
 - `internal/config/CLAUDE.md` — M3 and M4 target; repo-local, not shipped.
-- `internal/config/loader_gate.go`, `internal/config/defaults.go:318-322`,
-  `internal/hook/pre_tool.go:430-431`, `internal/hook/quality/astgrep_gate.go` — M5 evidence sites.
-- `internal/config/envkeys.go`, `internal/config/manager.go:393-406` — M3 evidence sites.
-- `internal/cli/update.go:69` (help text), `:294-304` (dry-run early return), `:306-326`
-  (retired-deny-rule migration — mutates, must stay after the return), `:312-313` (placement
-  rationale), `:328` (v2-detection block start), `:359-360` (`runCleanReinstall` call + `DryRun`
-  wiring); `internal/cli/update_clean_install.go:50-53` (`CleanReinstallOptions.DryRun`),
-  `:179` / `:184-198` (the non-mutating plan renderer and its prologue);
-  `internal/cli/update_archive.go:339-353` — M1 evidence sites.
-- `internal/cli/worktree_advisory.go:29`, `:60` — M2's single production `AutoCreate` read.
-- `SPEC-CONFIG-KEY-HONESTY-001` §A.6 — M2's reconciliation dependency.
-- `SPEC-UPDATE-REINSTALL-LOOP-002` plan.md §E M4 — the sibling's identical `--dry-run` resolution and
-  its recorded rejected alternative; also M1's escalation target (REQ-UDD-013).
+- `.moai/docs/local-dev-settings-intent.md` §22.8 — M2 target (received `CLAUDE.local.md` §22).
+- `.moai/docs/version-management.md` §*Files Requiring Version Sync* — M4b target (received §5).
+- `internal/config/loader_gate.go:20`, `internal/config/loader.go:89`,
+  `internal/config/defaults.go:438-442`, `internal/hook/pre_tool.go:447-448`,
+  `internal/hook/quality/astgrep_gate.go:46-79` — M5 evidence sites.
+- `internal/config/envkeys.go`, `internal/config/manager.go:398-411` — M3 evidence sites.
+- `internal/cli/session_worktree.go:584`, `internal/cli/session_worktree_prmerge.go:122`,
+  `internal/cli/worktree_advisory.go:60` — M2 evidence sites.
+- `internal/cli/migrate_agency.go:200`, `internal/cli/v2_detection.go:282`,
+  `internal/cli/update_residue_cleanup.go:84`, `internal/defs/dirs.go:134` — M4's `.agency/`
+  direction evidence.
+- `internal/template/templates/.moai/config/sections/system.yaml.tmpl:6` — M4b's render-time
+  injection evidence.
+- `internal/cli/update.go:81`, `:344-355`, `:546-600`; `internal/cli/update_dry_run_reach_test.go:186`
+  — §F.0 retirement evidence.
+- `SPEC-UPDATE-REINSTALL-LOOP-002` (completed) — landed the retired M1.
+- `SPEC-CONFIG-KEY-HONESTY-001` (completed) — discharged REQ-UDD-005.
+- `SPEC-INTERNAL-ARCH-001` REQ-ARCH-006 / AC-ARCH-007 — the duplicate resolved at spec.md §A.7.

--- a/.moai/specs/SPEC-UPDATE-DOC-DRIFT-001/spec.md
+++ b/.moai/specs/SPEC-UPDATE-DOC-DRIFT-001/spec.md
@@ -1,19 +1,19 @@
 ---
 id: SPEC-UPDATE-DOC-DRIFT-001
 title: "always-loaded instruction drift: maintainer documentation that asserts a mechanism the code contradicts is not a stale comment — it is an input that misdirects every agent session"
-version: "0.2.0"
+version: "0.3.0"
 status: draft
 created: 2026-07-31
-updated: 2026-07-31
+updated: 2026-08-14
 author: manager-spec
 priority: P2
-phase: "v3.0.2"
+phase: "v3.1.0 target"
 module: "docs"
 lifecycle: spec-anchored
 era: V3R6
 tier: M
-tags: "documentation, drift, claude-local, instruction-correctness, always-loaded, dry-run, flag-contract, config, update"
-related_specs: [SPEC-UPDATE-REINSTALL-LOOP-002, SPEC-UPDATE-DATA-SURVIVAL-001, SPEC-CONFIG-TIER-PERSIST-001, SPEC-CONFIG-KEY-HONESTY-001, SPEC-UPDATE-CI-GUARD-001]
+tags: "documentation, drift, claude-local, instruction-correctness, always-loaded, config, envkeys, agency"
+related_specs: [SPEC-UPDATE-REINSTALL-LOOP-002, SPEC-UPDATE-DATA-SURVIVAL-001, SPEC-CONFIG-TIER-PERSIST-001, SPEC-CONFIG-KEY-HONESTY-001, SPEC-UPDATE-CI-GUARD-001, SPEC-INTERNAL-ARCH-001]
 depends_on: []
 ---
 
@@ -23,8 +23,9 @@ depends_on: []
 
 | Version | Date | Change |
 |---------|------|--------|
-| 0.1.0 | 2026-07-31 | Initial draft. Epic SPEC 6 of 6 — the closing SPEC of the four-lens audit of `moai update` / `.moai/config`. Findings F1-F5 each re-verified while authoring; F1 found false in three independent ways rather than the two supplied; F3 found false at the template path as well as the local path; F1's user-impact claim independently disproved. Three drifts recorded (§A.6). |
-| 0.2.0 | 2026-07-31 | Plan-audit revision (iteration 1 verdict **FAIL, 0.65** against the Tier M threshold 0.80; Must-Pass 7/7 PASS — the failure was entirely in verification design, Testability 0.50). D1-D11 resolved, D12 folded into D1's edit, D16 resolved; D13-D15 and D17 deferred. **§A.5's option-B cost framing was found inverted and is rewritten against measurement**: the non-mutating clean-reinstall renderer already exists (`update_clean_install.go:186-198`) and is already wired (`update.go:360`), so option B is a local re-ordering, not new construction — the `--dry-run` decision is settled as **option B**, preserving non-mutation. §A.5's `:305-325` citation corrected to `:306-326` (deny-rule migration) / `:328` (clean-reinstall detection). §A.2's output block declared abbreviated and its unrelated-symbol enumeration completed. `acceptance.md` gained §A clause 7 (anti-vacuity); ten criteria rewritten under it. |
+| 0.1.0 | 2026-07-31 | Initial draft. Epic SPEC 6 of 6 — the closing SPEC of the four-lens audit of `moai update` / `.moai/config`. Findings F1-F5 each re-verified while authoring; F1 found false in three independent ways rather than the two supplied; F3 found false at the template path as well as the local path. Three drifts recorded (§A.6). |
+| 0.2.0 | 2026-07-31 | Plan-audit revision (iteration 1 verdict **FAIL, 0.65**; Testability 0.50). D1-D11 resolved, D12 folded into D1, D16 resolved; D13-D15 and D17 deferred. §A.5's option-B cost framing found inverted and rewritten against measurement; the `--dry-run` decision settled as **option B**. `acceptance.md` gained §A clause 7 (anti-vacuity); ten criteria rewritten under it. |
+| 0.3.0 | 2026-08-14 | **Staleness rewrite.** Every one of REQ-UDD-001..013 re-measured against worktree HEAD `7f61332ef` (branch `docs/spec-doc-drift-rewrite`); the v0.2.0 baseline `d5336214e` is **not an ancestor of this tree** (`git merge-base --is-ancestor` exits `1`), so every v0.2.0 `file:line` and count was re-observed rather than carried over. Since v0.2.0, `CLAUDE.local.md` was consolidated: former §18-§27 were externalized into `.moai/docs/*.md` and the file now runs §1-§17 plus a `## References` table (511 lines). **Retired with evidence (4)**: REQ-UDD-005 (E4 landed and the reconciliation was performed), REQ-UDD-011 and REQ-UDD-012 (option B was implemented by the sibling E1 as REQ-RIL2-024/025/026, with the early-return constraint honoured), REQ-UDD-013 (its escalation target is moot). **Re-anchored (3)**: REQ-UDD-004 to `.moai/docs/local-dev-settings-intent.md`, REQ-UDD-007 to `.moai/docs/version-management.md`, and REQ-UDD-002/003's site from `CLAUDE.local.md:141` to `:146`. **Kept live, narrowed (2)**: REQ-UDD-002 and REQ-UDD-003 — §2.2 gained a dated correction on 2026-08-01 that retracts all four false claims, so the falsehood half of each is discharged; what survives is a *new* misstatement (§A.1) and two unmet positive obligations. **Kept live (5)**: REQ-UDD-001, REQ-UDD-006 (with `.agency/` folded in as its concrete target), REQ-UDD-008, REQ-UDD-009, REQ-UDD-010. **REQ-UDD-004's polarity inverted**: two production readers for `auto_cleanup` have appeared since v0.2.0, so the drift is no longer "the doc claims an enforcement that does not exist" but its mirror image. **`REQ-ARCH-006` duplicate resolved** in favour of this SPEC (§A.7). |
 
 ## §A Problem / Motivation
 
@@ -36,491 +37,499 @@ That loading property is the whole reason this is a SPEC rather than a cleanup c
 statement inside an always-loaded instruction file is not a stale comment sitting unread next to the
 code it describes. It is an **input**: it enters the model's context before any work begins, it is
 read as authoritative project doctrine, and it actively steers work in the wrong direction. A
-maintainer who reads "the gate is off by default" does not think to check whether the gate fires. An
-agent that reads the same sentence has no independent reason to check either — the instruction file
-is precisely the surface it is told to trust.
+maintainer who reads "nothing here can block a commit" does not think to check whether something
+blocks. An agent that reads the same sentence has no independent reason to check either — the
+instruction file is precisely the surface it is told to trust.
 
-Two of the five findings below are not merely wrong but wrong in a way that would suppress
-investigation: §A.1 states a mechanism that would make a whole subsystem inert (so nobody looks at
-it), and §A.4 is a direct contradiction between two files that are *both* always-loaded, so whichever
-one a reader happens to weight wins silently.
+**Baseline.** Worktree HEAD `7f61332ef`, branch `docs/spec-doc-drift-rewrite`, based on `origin/main`.
+Every figure below was observed on this tree while authoring v0.3.0. The v0.2.0 baseline `d5336214e`
+is not an ancestor of it, so nothing was carried over.
 
-Sibling SPECs own adjacent halves and are not restated here: `SPEC-CONFIG-KEY-HONESTY-001` (E4) owns
-the code-and-config layer of unread config keys; `SPEC-UPDATE-REINSTALL-LOOP-002` (E1) owns whether
-the clean-reinstall loop should trigger; `SPEC-UPDATE-CI-GUARD-001` (E5) owns CI guard pattern design.
-**This SPEC owns exactly one thing: making the documentation say what the code does.**
+### A.0 What the always-loaded surface is, after the consolidation
 
-Every finding below was re-verified while authoring. Where the verification contradicted the
-finding as supplied, the contradiction is recorded rather than silently corrected (§A.6).
+The v0.1.0/v0.2.0 drafts treated `CLAUDE.local.md` §1-§27 as one always-loaded body. That is no
+longer the shape of the file. Since v0.2.0 the maintainer guide was consolidated: §18-§27 were
+externalized into `.moai/docs/*.md`, and the file now runs §1-§17 plus a `## References` table that
+maps each retired §-number to the file that received its content. `wc -l CLAUDE.local.md` → `511`.
 
-### A.1 `CLAUDE.local.md` §2.2 is wrong three times over about the ast-grep gate (F1)
+Two consequences bind this SPEC's requirements:
 
-`CLAUDE.local.md:141` (§2.2) states that the ast-grep pre-tool gate is off by default, giving as the
-mechanism: `ast-grep pre-tool gate는 기본 OFF(`gate.yaml`/`gate` 로더 부재 → `AstGrepGate.Enabled`
-항상 컴파일 기본값 false)`, and concludes `실제 영향은 명시적 `moai ast-grep` CLI 경로 + `sg` 설치
-시에만 발생`.
+- **The always-loaded surface is now `CLAUDE.local.md` (§1-§17 + References) and
+  `internal/config/CLAUDE.md`.** The externalized `.moai/docs/*.md` files are load-on-demand
+  pointers, read when a task reaches for them. Drift there is still a defect — the always-loaded
+  file cites them as authoritative — but it is a *reference* defect, not an *input* defect, and
+  requirements re-anchored into `.moai/docs/` carry that reduced severity explicitly (REQ-UDD-004,
+  REQ-UDD-007).
+- **§-number citations elsewhere in the repo still resolve.** 44 Go comments plus 8 rule/doc sites
+  cite `CLAUDE.local.md §18`-`§27`. They are *not* dangling: the `## References` table preserves the
+  §-number → file mapping (`§22 Dev Settings Intent → .moai/docs/local-dev-settings-intent.md`), and
+  the receiving files retain their original §-numbered headings (`local-dev-settings-intent.md:58`
+  is still headed `### §22.8 …`). This was checked before it was assumed, precisely so a
+  repo-wide "stale citation" sweep is not proposed on a false premise. See §C.
 
-Four claims are packed into that sentence. **All four are false at HEAD.**
+### A.1 `CLAUDE.local.md` §2.2 was corrected in place, and the correction introduced one new error (F1, narrowed)
 
-**(a) The loader is not absent.** `internal/config/loader_gate.go:20` declares
-`func (l *Loader) loadGateSection(dir string, cfg *Config)`, and `internal/config/loader.go:89`
-calls it:
+At `CLAUDE.local.md:146` (§2.2 — the section moved from `:141` during the consolidation) the four
+false claims the v0.1.0 draft found are **gone**. A dated in-place correction was added on
+2026-08-01:
 
 ```
-$ grep -rn 'loadGateSection' internal/config/
-internal/config/loader_gate.go:14:// loadGateSection loads the gate configuration section from gate.yaml.
+$ grep -c '2026-08-01 정정' CLAUDE.local.md
+1
+```
+
+It states that the loader exists (`internal/config/loader_gate.go`, called from
+`internal/config/loader.go` `Loader.Load`) and that the real compiled default is
+`AstGrepGate{Enabled: true, BlockOnError: false, WarnOnlyMode: true}`. Both re-verified:
+
+```
+$ grep -rn 'loadGateSection' internal/config/ | grep -v '^.*://'
 internal/config/loader_gate.go:20:func (l *Loader) loadGateSection(dir string, cfg *Config) {
 internal/config/loader.go:89:	l.loadGateSection(sectionsDir, cfg)
+internal/config/slice.go:35:	"gate":          (*Loader).loadGateSection,
+
+$ grep -n -A5 'AstGrepGate: AstGrepGateConfig' internal/config/defaults.go
+438:		AstGrepGate: AstGrepGateConfig{
+439-			Enabled:      true,
+440-			BlockOnError: false,
+441-			WarnOnlyMode: true,
+442-		},
 ```
 
-The file's own header comment (`loader_gate.go:5-12`) states verbatim that it was added *because*
-"no loader path read gate.yaml, so the ast-grep pre-tool gate (AstGrepGate.Enabled) had no path to
-true" — §2.2 is a description of the state that existed **before this file landed**, preserved
-unamended after the condition it describes was removed.
+(The `defaults.go` site moved from `:316-322` to `:438-442`; the values are unchanged.)
 
-**(b) `gate.yaml` is not absent — it is shipped.** Both the template source and the local project
-carry it:
+**The two false-claim requirements are therefore discharged** — REQ-UDD-002's "shall not assert the
+absence of `loadGateSection` / of a shipped `gate.yaml` / a compiled default of `false`" clause, and
+REQ-UDD-003's "shall not state that impact requires an explicit `moai ast-grep` invocation with `sg`
+installed" clause. Neither claim survives (`grep -oE 'sg 설치|moai ast-grep' <the section>` → no
+match).
 
-```
-$ ls internal/template/templates/.moai/config/sections/gate.yaml .moai/config/sections/gate.yaml
-internal/template/templates/.moai/config/sections/gate.yaml
-.moai/config/sections/gate.yaml
-```
+**What survives is a new misstatement of the same class.** The correction concludes:
 
-and its shipped content sets the gate on explicitly (`gate.yaml:13-25`): `gate.enabled: true`,
-`ast_grep_gate.enabled: true`, `block_on_error: false`, `warn_only_mode: true`.
+> 실제 기본값은 … `AstGrepGate{Enabled: true, BlockOnError: false, WarnOnlyMode: true}` — 즉
+> **차단 없는 권고 모드로 켜져 있고**, 차단(blocking)만이 `gate.yaml` opt-in이다.
 
-**(c) The compiled default is `true`, not `false`.** `internal/config/defaults.go:316-322`:
-
-```go
-// The ast-grep sub-gate is ON by default in advisory mode (findings
-// reported, commits never blocked); blocking is opt-in via gate.yaml.
-AstGrepGate: AstGrepGateConfig{
-	Enabled:      true,
-	BlockOnError: false,
-	WarnOnlyMode: true,
-},
-```
-
-So the gate is on in **advisory mode** by default — the opposite of §2.2's "always compiled default
-false".
-
-**(d) The impact is not confined to an explicit CLI path with `sg` installed.** This claim required
-its own check rather than inheritance from (a)-(c), and it does not survive. `RunAstGrepGateV2`
-(`internal/hook/quality/astgrep_gate.go:41`) runs **two** steps, and only the second depends on `sg`:
-
-```go
-// ── 1. Suppression policy check (sg-independent, pure-Go) ─────────────────
-sourceFiles := walkSourceFiles(projectDir)
-for _, fp := range sourceFiles {
-	allViolations = append(allViolations, checkSuppressionPairing(fp)...)
-}
-if len(allViolations) > 0 {
-	...
-	return false, strings.TrimSpace(sb.String())      // ← blocks, with sg absent
-}
-// ── 2. ast-grep scan (depends on sg CLI) ─────────────────────────────────
-```
-
-Step 1 walks every source file in pure Go and can return `false` — a **block** — with `sg` nowhere on
-the system. Step 2 degrades gracefully when `sg` is missing (`ErrScannerUnavailable` → pass), and
-`WarnOnlyMode: true` prevents step 2 from blocking even when it does find something. So the one path
-that can actually block a commit is the one §2.2 asserts cannot run at all.
-
-**The precise scope, stated so this SPEC does not overclaim in the other direction.** The gate is not
-invoked on every tool call: `internal/hook/pre_tool.go:430-431` gates it on
-`quality.IsGitCommit(command)`, so it fires on `git commit` Bash invocations only. That is a
-meaningful narrowing of blast radius — and it is also not what §2.2 says. The correct statement is
-"on by default in advisory mode, evaluated at `git commit`, whose sg-independent suppression-policy
-check can block"; §2.2 says "inert".
-
-This is the highest-severity finding in the SPEC. A maintainer reading §2.2 concludes the subsystem
-cannot fire, and therefore has no reason to investigate a commit that is unexpectedly blocked by it.
-
-### A.2 `CLAUDE.local.md` §22.8 presents three toggles as policy; two have no reader (F2)
-
-§22.8 presents `AutoCleanup`, `AutoCreate`, and `AutoMerge` as an intentional default-OFF **policy** —
-"웹 콘솔의 worktree 자동화는 사용자의 **명시적 opt-in** ... 있을 때만 동작한다" — and marks it
-`[HARD] ... 의도된 정책. 감사/동기화 시 "결함"으로 되돌리지 말 것`. The prose implies all three gate
-behaviour, and that setting one to `true` turns something on.
-
-Measured at HEAD. The survey grep returns 33 lines; the block below is an **abbreviated extract**,
-not verbatim output — it collapses contiguous line ranges and omits the unrelated-symbol hits
-enumerated in the paragraph that follows:
+"Blocking is opt-in only" is false. `RunAstGrepGateV2` runs two steps, and step 1's block is
+unconditional on `WarnOnlyMode`:
 
 ```
-$ grep -rn 'AutoCleanup\|AutoCreate\|AutoMerge' --include='*.go' internal cmd pkg \
-    | grep -v '_test.go' | grep -v main-fork          # abbreviated: 33 lines total
-internal/config/types.go:485-487        (declarations)
-internal/config/defaults.go:545-547     (defaults, all three false)
-internal/cli/worktree_advisory.go:29    autoCreate := readWorktreeAutoCreate(projectRoot)
-internal/cli/worktree_advisory.go:60    return cfg.Workflow.Worktree.AutoCreate
+$ sed -n '41,62p' internal/hook/quality/astgrep_gate.go
+41:func RunAstGrepGateV2(ctx context.Context, projectDir string, cfg *AstGrepGateConfig) (bool, string) {
+42:	if cfg == nil || !cfg.Enabled {
+43:		return true, ""
+44:	}
+46:	// ── 1. Suppression policy check (sg-independent, pure-Go) ─────────────────
+48:	sourceFiles := walkSourceFiles(projectDir)
+53:	if len(allViolations) > 0 {
+60:		return false, strings.TrimSpace(sb.String())
+61:	}
+63:	// ── 2. ast-grep scan (depends on sg CLI) ─────────────────────────────────
 ```
 
-The decisive assertion is not this survey but the **selector-scoped** count, which is exhaustive and
-is what AC-UDD-005 asserts:
+`WarnOnlyMode` is passed only into the step-2 scanner config (`:66-71`); the step-1 `return false` at
+`:60` is reached whenever `cfg.Enabled` is true and any suppression-policy violation is found — which
+is the shipped default. So a maintainer whose commit is refused by the gate reads §2.2, concludes
+blocking requires an opt-in they never made, and looks elsewhere. This is the same failure the
+original §2.2 caused, one correction later.
+
+**The scope qualifier is also still absent.** The gate is not evaluated on every tool call:
 
 ```
-$ grep -rn 'Worktree\.AutoCleanup\|Worktree\.AutoMerge' --include='*.go' internal cmd pkg | grep -v '_test.go' | wc -l
-0
-$ grep -rn 'Worktree\.AutoCreate' --include='*.go' internal cmd pkg | grep -v '_test.go'
-internal/cli/worktree_advisory.go:60:	return cfg.Workflow.Worktree.AutoCreate
+$ grep -n -B2 -A2 'IsGitCommit(command)' internal/hook/pre_tool.go
+447:		if quality.IsGitCommit(command) && !config.IsAutonomyTierCommitGateOff(config.AutonomyTier()) {
+448:			gate := quality.NewQualityGate(h.loadGateConfig())
 ```
 
-Only `AutoCreate` is read in production, and per `SPEC-CONFIG-KEY-HONESTY-001` §A.6 that read
-selects between two advisory sentences — it does not gate worktree creation. `AutoCleanup` and
-`AutoMerge` have zero production readers. The remaining survey hits are unrelated symbols and
-comments, all of which the `Worktree.`-prefixed selector correctly excludes as homonyms:
-`worktree/done.go:29,31` `AutoCleanupFlag` (a CLI flag name), `worktree/new.go:439,457,458,459`
-`ShouldAutoMerge` (a `--no-merge` flag helper), `worktree/errors.go:56,60`
-`NewAutoMergeBlockedError` (a worktree error constructor), `worktree_advisory.go:48,51` (the
-`readWorktreeAutoCreate` doc comment and signature), `defaults.go:543-544` (the mutation-rationale
-comment), the `internal/github/` `AutoMerge` fields at `pr_merger.go:12,13,54,55,113,116,117,159,164,230`
-and `errors.go:34,35` (PR-merge options), and `pkg/models/config.go:172` (a separate model struct).
+(The site moved from `:430-431` to `:447-448`, and gained a second conjunct — an autonomy-tier
+opt-out — that did not exist at v0.2.0.) §2.2 states no invocation scope at all
+(`grep -cE 'git commit|IsGitCommit'` over the section → `0`), so a reader has no way to bound the
+blast radius of a default-on gate.
 
-Setting `auto_cleanup: true` or `auto_merge: true` in `workflow.yaml` therefore changes nothing —
-while §22.8 tells the reader it is the opt-in switch.
+REQ-UDD-002 and REQ-UDD-003 are therefore **kept live and narrowed** to these two residuals.
 
-**Boundary — the sharpest in this SPEC.** `SPEC-CONFIG-KEY-HONESTY-001` §A.6 already owns the
-**code-and-config** layer of this finding: the unread keys themselves, and the triage of whether to
-implement, deprecate, or mark them. This SPEC owns **only the documentation defect** — that §22.8
-asserts an enforcement that does not exist — and the obligation to reconcile the prose with whatever
-E4's triage decides. It does not re-specify the key triage, propose wiring, or take a position on
-which triage class the keys land in. See §C.
+### A.2 `CLAUDE.local.md` §22.8 moved to `.moai/docs/`, and its claim inverted under it (F2, re-anchored)
 
-### A.3 `CLAUDE.local.md` §5 and §9 reference a file that exists at neither path (F3)
+§22.8 no longer exists in `CLAUDE.local.md`: `grep -n '§22' CLAUDE.local.md` returns one line, `:506`,
+which is the References entry pointing at `.moai/docs/local-dev-settings-intent.md`. The content is
+there, still under its original heading at `:58`.
 
-Both sections point at `config.yaml`:
+The relocated text was itself updated to state per-toggle reader status — which is what REQ-UDD-004
+asked for — and cites `SPEC-CONFIG-KEY-HONESTY-001` M5 as the source, discharging REQ-UDD-005's
+reconciliation obligation. `local-dev-settings-intent.md:62-63`:
 
-```
-$ grep -n 'config/config.yaml' CLAUDE.local.md
-250:- internal/template/templates/.moai/config/config.yaml (moai.version)
-415:**Project config** (`.moai/config/config.yaml`):
-```
+> - `auto_create`: 프로덕션 리더가 **있다** — `internal/cli/worktree_advisory.go::readWorktreeAutoCreate`가
+>   읽는다. 단, 이 리더는 두 `fmt.Fprintln` 문구 중 하나를 고르는 용도일 뿐 …
+> - `auto_merge` / `auto_cleanup`: 프로덕션 리더가 **없다** (declared but not read). 어떤 코드 경로도
+>   이 값을 소비하지 않는다.
 
-Line 415 (§9) calls it the "Main configuration file". Line 250 (§5, *Files Requiring Version Sync*)
-lists the template-tree path among the files a release must bump.
-
-Neither path resolves:
+**The `auto_cleanup` half is now false, and false in the direction that matters.** Two production
+readers exist:
 
 ```
-$ ls .moai/config/config.yaml
+$ grep -rn 'Worktree\.AutoCleanup\|Worktree\.AutoMerge' --include='*.go' internal cmd pkg | grep -v '_test.go'
+internal/cli/session_worktree.go:584:	if cfg == nil || !cfg.Workflow.Worktree.AutoCleanup {
+internal/cli/session_worktree_prmerge.go:122:	if cfg == nil || !cfg.Workflow.Worktree.AutoCleanup {
+```
+
+Neither is advisory wording. `session_worktree.go:584` sits inside `cleanupSessionWorktree`, and the
+read gates disposal outright — `false` returns early and the worktree persists, `true` disposes it.
+`auto_cleanup` is now a behaviour-gating key. `auto_merge` remains unread
+(`grep -rn 'Worktree\.AutoMerge' … | grep -v '_test.go'` → no output, exit `1`), so the sentence is
+half true, which is the worst available state: a reader who checks one key and finds the doc right
+extends that confidence to the other.
+
+**The polarity of the defect has inverted.** At v0.2.0 the doc claimed an enforcement that did not
+exist; today it claims an absence that does not hold. The requirement's force is unchanged — the
+documented reader status must be the measured one — but its target text and its expected correction
+are the opposite of what v0.2.0 specified, which is why the requirement is re-stated rather than
+carried.
+
+**Severity, stated honestly.** This text is no longer always-loaded (§A.0). It is read when a task
+reaches for the settings-intent doctrine — which is exactly when the reader is deciding whether a
+`false` default is intentional. Lower exposure, undiminished consequence at the moment of use.
+
+An adjacent observation, recorded and deliberately not made a requirement: both reader sites carry a
+comment citing `CLAUDE.local.md §22.8`. Those citations resolve through the References table (§A.0),
+so they are stale-looking but navigable, and rewriting 44+ such Go comments is a separate scope (§C).
+
+### A.3 The nonexistent `config.yaml` survives at three sites, and `.agency/` joins it (F3, kept live)
+
+`.moai/config/config.yaml` still does not exist, at either path, and is still named as the main
+configuration file:
+
+```
+$ ls .moai/config/config.yaml internal/template/templates/.moai/config/config.yaml
 ls: .moai/config/config.yaml: No such file or directory
-$ ls internal/template/templates/.moai/config/config.yaml
 ls: internal/template/templates/.moai/config/config.yaml: No such file or directory
-$ ls .moai/config/
-astgrep-rules  evaluator-profiles  sections
+
+$ grep -n 'config/config.yaml' CLAUDE.local.md
+328:**Project config** (`.moai/config/config.yaml`):
+
+$ grep -nE 'config\.yaml.{0,2} \(main\)|Main .?config\.yaml' internal/config/CLAUDE.md
+5:…the layered configuration tree under `.moai/config/` — `config.yaml` (main) plus `sections/*.yaml`…
+11:- **Section-file layout (CLAUDE.local.md §9)**: … Main `config.yaml` aggregates references. …
 ```
 
-**This is worse than a stale local-path reference, and the template path was checked rather than
-assumed symmetric.** §5 is a release checklist. It instructs the releaser to bump `moai.version` in a
-file that does not exist, so the step is unperformable: a releaser either silently skips it (and the
-checklist has a dead line that erodes trust in the rest) or creates the file to satisfy it (and
-introduces a config file nothing loads). The §9 claim compounds it by naming a nonexistent file as
-the *main* config, when the actual layout is `sections/*.yaml` only.
+Three sites, down from four: the §5 release-checklist site left `CLAUDE.local.md` with the
+consolidation and is now REQ-UDD-007's re-anchored target (§A.4). The remaining `CLAUDE.local.md:328`
+sits under §9 and calls the nonexistent file "Main configuration file" — with the actual
+`sections/*.yaml` layout described immediately below it, so the file contradicts itself within four
+lines.
 
-`internal/config/CLAUDE.md:5` repeats the same claim ("`config.yaml` (main) plus `sections/*.yaml`")
-and `:11` says "Main `config.yaml` aggregates references" — so the nonexistent file is asserted on
-two always-loaded surfaces.
+**A second instance of the same requirement, not previously named.** `CLAUDE.local.md` instructs, in
+a `[HARD]` Template-First rule, that new files under `.agency/` be added to the template tree first:
 
-### A.4 `internal/config/CLAUDE.md` and `CLAUDE.local.md` §9 directly contradict each other (F4)
+```
+$ grep -n '\.agency' CLAUDE.local.md
+88:internal/template/templates/.agency/
+94:When adding new files to `.claude/`, `.moai/`, or `.agency/`:
+106:- New agency files (`.agency/`)
+108:**Verification**: Before committing, check that every new file under `.claude/`, `.moai/`, or `.agency/` has a corresponding file in `internal/template/templates/`.
 
-`internal/config/CLAUDE.md:12` states the configuration priority order:
+$ ls -d .agency internal/template/templates/.agency
+ls: .agency: No such file or directory
+ls: internal/template/templates/.agency: No such file or directory
+```
+
+`:88` names a template-source directory that does not exist, and `:94`/`:106`/`:108` instruct an
+agent to mirror files into it — an unperformable instruction inside a `[HARD]` rule, which is the
+strongest form of the defect this SPEC exists to remove.
+
+The direction of the correction is measured, not assumed. `.agency/` is alive in the code, but
+**inbound only**: it is a legacy layout that `moai migrate agency` reads *out of* a user's project
+(`internal/cli/migrate_agency.go:200`, `internal/cli/v2_detection.go:282`,
+`internal/cli/update_residue_cleanup.go:84`, `internal/defs/dirs.go:134`). Nothing ships into it.
+So the Template-First rule's `.agency/` arm is not merely pointing at a missing directory — it names
+a direction that never existed.
+
+### A.4 The §5 release checklist moved to `.moai/docs/version-management.md`, and its unperformable line moved with it (F3b, re-anchored)
+
+`CLAUDE.local.md` §5 is now a three-line pointer; the *Files Requiring Version Sync* list lives at
+`.moai/docs/version-management.md:66-78`. The unperformable entry survived the move verbatim:
+
+```
+$ sed -n '76,78p' .moai/docs/version-management.md
+**Configuration Files:**
+- .moai/config/sections/system.yaml (moai.version)
+- internal/template/templates/.moai/config/config.yaml (moai.version)
+```
+
+`:77` is correct — `.moai/config/sections/system.yaml` exists and carries `version: v3.1.0-rc.2`.
+`:78` names the file §A.3 just showed does not exist, so the checklist line is unperformable: a
+releaser either skips it silently or creates a config file nothing loads.
+
+**The replacement was measured rather than guessed** (plan.md AP-6). There is no
+`internal/template/templates/.moai/config/sections/system.yaml` either — the template ships
+`system.yaml.tmpl`, whose version field is a render-time substitution:
+
+```
+$ grep -n -A2 '^moai:' internal/template/templates/.moai/config/sections/system.yaml.tmpl
+4:moai:
+5-  # MoAI-ADK version
+6-  version: "{{.Version}}"
+```
+
+So the template side carries no hand-bumped version at all: it is injected when `moai init` /
+`moai update` renders the template. The correct edit is **deletion of `:78`**, with a one-line note
+recording that the template side is render-time-injected and needs no manual bump — not substitution
+of another path, which would re-create the defect in a new location.
+
+### A.5 `--dry-run` reached the plan renderer — the sibling SPEC implemented option B (F5, retired)
+
+REQ-UDD-011 and REQ-UDD-012 are **satisfied**, and were satisfied by
+`SPEC-UPDATE-REINSTALL-LOOP-002` (status `completed`) rather than by this SPEC. The v2 fingerprint is
+now computed *inside* the dry-run branch:
+
+```
+$ sed -n '344,355p' internal/cli/update.go
+344:		// SPEC-UPDATE-REINSTALL-LOOP-002 REQ-RIL2-024/025 (M4): the v2
+345:		// fingerprint is computed HERE — inside the dry-run branch, above the
+346:		// deny-rule migration below — so the clean-reinstall and
+347:		// residue-cleanup plans become reachable from `moai update --dry-run`.
+353:		// The early return itself does NOT move (REQ-RIL2-026): it stays
+354:		// ABOVE stripRetiredV2DenyEntries, which rewrites settings.json.
+355:		return emitDryRunReinstallPlan(cmd.Context(), cwd, getBoolFlag(cmd, "force"), out, th)
+```
+
+`emitDryRunReinstallPlan` (`internal/cli/update.go:546-600`) renders the clean-reinstall plan for a
+v2 fingerprint and the residue-cleanup plan otherwise, and its doc comment records that it writes
+nothing. The help text keeps both halves of its promise
+(`internal/cli/update.go:81` — "Show planned archive and install operations without modifying the
+filesystem"), and the promise is now met. A reachability test exists
+(`internal/cli/update_dry_run_reach_test.go:186` `TestUpdateDryRun_EmitsCleanReinstallPlan`).
+
+This is option B, implemented under exactly the constraint this SPEC and its sibling both imposed:
+the early return did not move past `stripRetiredV2DenyEntries`. The v0.2.0 concern that the two
+SPECs might push the return in opposite directions did not materialise. REQ-UDD-013, whose only
+content was routing an escalation to that sibling, is moot.
+
+### A.6 `internal/config/CLAUDE.md` still contradicts `CLAUDE.local.md` §9 (F4, kept live)
+
+This is the one finding that has not moved at all. `internal/config/CLAUDE.md:12` still states:
 
 > **Configuration priority order**: (1) Environment variables (`MOAI_USER_NAME`,
-> `MOAI_CONVERSATION_LANG`, ...) override file values. ... Tests MUST verify this priority via
+> `MOAI_CONVERSATION_LANG`, ...) override file values. … Tests MUST verify this priority via
 > `t.Setenv` + fixture file combinations.
 
-and `:13` instructs that these names live as constants in `envkeys.go`, giving
-`EnvUserName = "MOAI_USER_NAME"` as the worked example.
-
-`CLAUDE.local.md` §9 states the opposite in an explicit NOTE:
-
-> `MOAI_USER_NAME` / `MOAI_CONVERSATION_LANG` are **NOT currently implemented** — no code in
-> `internal/`/`pkg/`/`cmd/` reads them.
-
-**Both files are loaded as project instructions.** The contradiction was resolved against the code
-rather than by assuming the more recent file wins:
+and `:13` still gives `EnvUserName = "MOAI_USER_NAME"` as the `envkeys.go` worked example. Neither
+name is implemented:
 
 ```
-$ grep -n 'MOAI_USER_NAME\|MOAI_CONVERSATION_LANG' internal/config/envkeys.go
-(no output)
+$ grep -c 'MOAI_USER_NAME\|MOAI_CONVERSATION_LANG' internal/config/envkeys.go
+0                                              # exit 1
+
+$ grep -n -A13 'func applyEnvOverrides' internal/config/manager.go
+398:func applyEnvOverrides(cfg *Config) {
+399-	if mode := os.Getenv(EnvDevelopmentMode); mode != "" { … }
+402-	if level := os.Getenv(EnvLogLevel); level != "" { … }
+405-	if format := os.Getenv(EnvLogFormat); format != "" { … }
+408-	if noColor := os.Getenv(EnvNoColor); noColor == "true" || noColor == "1" { … }
+411-}
 ```
 
-`envkeys.go` declares `EnvConfigDir`, `EnvDevelopmentMode`, `EnvLogLevel`, `EnvLogFormat`,
-`EnvNoColor`, and many others — but no `EnvUserName` and no `EnvConversationLang`. And
-`applyEnvOverrides` (`internal/config/manager.go:393-406`) reads exactly four:
+(`applyEnvOverrides` moved from `:393-406` to `:398-411`; the four overrides are unchanged.)
+`CLAUDE.local.md` §9 states the correct fact, so two always-loaded files contradict each other and
+whichever a reader weights wins silently. The contradiction is resolved against the code, not by
+recency.
 
-```go
-func applyEnvOverrides(cfg *Config) {
-	if mode := os.Getenv(EnvDevelopmentMode); mode != "" { ... }
-	if level := os.Getenv(EnvLogLevel); level != "" { ... }
-	if format := os.Getenv(EnvLogFormat); format != "" { ... }
-	if noColor := os.Getenv(EnvNoColor); noColor == "true" || noColor == "1" { ... }
-}
-```
+The second-order defect is unchanged and is the sharpest thing in this SPEC: `:12` does not merely
+misstate, it *instructs* — "Tests MUST verify this priority via `t.Setenv`". For an unimplemented
+variable that is an instruction to write a test that cannot pass, or to implement the override so it
+can, which is an unrequested behaviour change originating in a documentation error.
 
-**`CLAUDE.local.md` §9 is correct; `internal/config/CLAUDE.md:12-13` is wrong** — and the example it
-chose to illustrate the `envkeys.go` convention is one of the two names the file does not contain.
+### A.7 Duplicate ownership with `SPEC-INTERNAL-ARCH-001` REQ-ARCH-006 — resolved in favour of this SPEC
 
-**The second-order defect.** `:12` does not merely misstate a fact; it issues an instruction:
-"Tests MUST verify this priority via `t.Setenv` + fixture file combinations." For an unimplemented
-variable that is an instruction to write a test that cannot pass. An agent following the file
-literally would either write a failing test or, worse, implement the env override to make the test
-pass — an unrequested behaviour change originating in a documentation error.
+`SPEC-INTERNAL-ARCH-001` (status `draft`, Tier L, P1) carries `REQ-ARCH-006` at `spec.md:82`, which
+claims the same fix: document the implemented override set, and stop citing `MOAI_USER_NAME` /
+`MOAI_CONVERSATION_LANG` or an `EnvUserName` constant. Its `AC-ARCH-007a` is a single grep over all
+three tokens.
 
-**Who a fix reaches.** `internal/config/CLAUDE.md` is git-tracked but **not** shipped: the template
-tree contains exactly one `CLAUDE.md` (`internal/template/templates/CLAUDE.md`), and there is no
-`internal/template/templates/internal/` directory. It is therefore repo-local maintainer
-documentation, like `CLAUDE.local.md` — its audience is moai-adk-go contributors and every agent
-session in this repository, not downstream users. Both fixes are repo-local; neither ships.
+**Resolution: this SPEC owns the fix (REQ-UDD-008, REQ-UDD-009, REQ-UDD-010).
+`SPEC-INTERNAL-ARCH-001` REQ-ARCH-006 is superseded and should be reduced to a cross-reference.**
+Three reasons, in order of weight:
 
-### A.5 `--dry-run` cannot preview the operation most worth previewing (F5)
+1. **Landing latency.** `SPEC-INTERNAL-ARCH-001` is Tier L with `depends_on: [SPEC-INTERNAL-TEST-001]`
+   and a `REQ-ARCH-007` cross-cutting behaviour-preservation invariant binding every milestone. Its
+   M6 is a one-commit doc fix, but it can only land inside that SPEC's lifecycle, behind a large
+   behaviour-preserving refactor. This SPEC has no `depends_on` and is doc-only. A two-line
+   correction to an always-loaded file should not wait on a refactor Epic.
+2. **Coverage.** `AC-ARCH-007a` is an absence-grep over three tokens plus a prose clause. It does not
+   cover REQ-UDD-010 — the `t.Setenv` instruction scoping — at all, and it has no positive
+   replacement assertion, so it is satisfiable by deleting the bullet. Assigning ownership to the
+   coarser requirement would silently drop the second-order defect (§A.6), which is the part of this
+   finding that can cause an unrequested code change.
+3. **Subject fit.** An instruction file directing an agent toward an unpassable test is an
+   always-loaded-instruction hazard, which is this SPEC's declared subject; it is not an architecture
+   concern.
 
-The flag's registered help text (`internal/cli/update.go:69`):
+**Left undone deliberately, and named so it is not lost:** the reciprocal edit to
+`SPEC-INTERNAL-ARCH-001` — marking REQ-ARCH-006 superseded and pointing AC-ARCH-007 here — is *not*
+made by this rewrite. That SPEC is under concurrent review in this session, and editing another
+agent's artifact would race it. The owner of `SPEC-INTERNAL-ARCH-001` must apply the cross-reference;
+until they do, the duplicate is resolved on one side only. AC-UDD-024 is the guard that detects the
+still-unresolved half rather than assuming it away.
 
-```go
-updateCmd.Flags().Bool("dry-run", false, "Show planned archive and install operations without modifying the filesystem")
-```
+### A.8 Drift recorded while rewriting
 
-The handler (`internal/cli/update.go:293-304` — the comment at `:293`, the branch at `:294-304`) is
-an early return placed *before* every mutating step that follows it:
+Four discrepancies between the v0.2.0 artifacts and the tree measured at `7f61332ef`.
 
-```go
-// --dry-run: print planned operations without mutating the filesystem
-if getBoolFlag(cmd, "dry-run") {
-	cwd, err := os.Getwd()
-	...
-	emitWorktreeAdvisory(out, cwd)
-	return dryRunArchiveLegacySkills(cwd, out)
-}
-```
+**Drift 1 — the v0.2.0 baseline is not an ancestor of this tree.**
+`git merge-base --is-ancestor d5336214e HEAD` exits `1`. Every `file:line`, count, and verbatim
+output in v0.2.0 was therefore unattributable here and was re-observed rather than carried. Line
+numbers moved in five cited files (`CLAUDE.local.md` §2.2 `:141`→`:146`; `defaults.go`
+`:316-322`→`:438-442`; `pre_tool.go` `:430-431`→`:447-448`; `manager.go` `:393-406`→`:398-411`;
+`update.go` help text `:69`→`:81`).
 
-`dryRunArchiveLegacySkills` (`internal/cli/update_archive.go:339-353`) iterates `legacySkillIDs`,
-prints one `[dry-run] archive: <id>` line per legacy skill present, and returns. It previews the
-**archive** half only.
+**Drift 2 — the `pre_tool.go` gate condition gained a conjunct.** `:447` now reads
+`if quality.IsGitCommit(command) && !config.IsAutonomyTierCommitGateOff(config.AutonomyTier())`. The
+autonomy-tier opt-out did not exist at v0.2.0. §A.1's scope statement is written against the current
+two-conjunct form; a correction to §2.2 that names only `git commit` would be incomplete on this tree.
 
-**What actually sits after the early return, measured.** The early return closes at `:304`. What
-follows is *not* the clean-reinstall path:
+**Drift 3 — `auto_cleanup` gained two production readers, inverting F2 (§A.2).** The v0.2.0 baseline
+recorded `grep -rn 'Worktree\.AutoCleanup\|Worktree\.AutoMerge' … | wc -l` → `0`; measured here it is
+`2`. This reverses the direction of REQ-UDD-004's correction and is the single most consequential
+finding of the rewrite: had REQ-UDD-004 been executed as written in v0.2.0, it would have written a
+false statement into the doc.
 
-```
-$ sed -n '306,313p;328,329p;359,360p' internal/cli/update.go
-306:	// Retired-deny-rule migration on the v3 path (issue #1101 follow-up). The
-...
-312:	// Placement is deliberate: after the --binary / --dry-run early-returns (so
-313:	// a dry run never mutates) but BEFORE the version-match short-circuit
-328:	// SPEC-V3R6-V2-V3-CLEAN-REINSTALL-001 REQ-VVCR-002: detect v2 fingerprint
-329:	// and short-circuit to the clean-reinstall code path when the project is
-359:			result, runErr := runCleanReinstall(ctx, cwd, CleanReinstallOptions{
-360:				DryRun: getBoolFlag(cmd, "dry-run"),
-```
-
-`:306-326` is the **retired-deny-rule migration**, which mutates — it calls
-`stripRetiredV2DenyEntries(cwd, out)`, rewriting `settings.json`. The clean-reinstall *detection*
-begins at `:328` and calls `runCleanReinstall` at `:359`. The comment at `:312` records that the
-early-return placement is deliberate: a dry run must not reach that mutating migration. That
-reasoning is sound and this SPEC preserves it.
-
-The defect is the **contract**: the help text promises "archive **and install** operations", and the
-install half is never previewed. `moai update --dry-run` on a v2 project prints legacy-skill
-archiving and says nothing about the clean reinstall that is about to replace the user's tree.
-
-**This is the one finding with both a documentation face and a behavioural face, and the scope is
-narrow deliberately.** This SPEC owns the **contract mismatch** — the help text and the behaviour
-must agree. It does not own whether clean-reinstall should trigger at all; that is
-`SPEC-UPDATE-REINSTALL-LOOP-002` (§C).
-
-#### The install half is unreachable by *placement*, not by construction — and the renderer already exists
-
-An earlier draft of this section stated that "the install half is unreachable by construction" and
-that extending the flag "requires constructing the plan without executing it — the plan-construction
-path would have to be separable from the mutation path, which is real work and may not belong in
-this Epic at all". **Both statements are false, and the second is inverted.** The probe this SPEC's
-own plan recommended was run, and it found the separation already built:
-
-```
-$ sed -n '50,53p;184,198p' internal/cli/update_clean_install.go
- 50:type CleanReinstallOptions struct {
- 51:	// DryRun: when true, emit planned actions but make no filesystem mutations.
- 52:	// REQ-VVCR-028.
- 53:	DryRun bool
-...
-184:	// Dry-run early return — emit planned actions and stop before any
-185:	// filesystem mutation.
-186:	if opts.DryRun {
-187:		… "[clean-reinstall] DRY-RUN — no filesystem mutations performed"
-188:		… "Would back up %d files into .moai/backups/v2-to-v3-<stamp>/"
-190:		… "Would remove %d deprecated paths"
-194:		… "Would auto-invoke `moai migrate agency` for .agency/ contents"
-197:		return result, nil
-198:	}
-```
-
-A non-mutating clean-reinstall plan renderer exists at `update_clean_install.go:186-198`
-(REQ-VVCR-028), and `update.go:360` already wires `DryRun: getBoolFlag(cmd, "dry-run")` into
-`runCleanReinstall`. The renderer is unreachable for one reason only: the CLI's own `--dry-run`
-early return at `:294` fires before the v2-detection block at `:328` is reached. Nothing needs to be
-built; the plumbing has to reach code that is already written and already wired.
-
-The cost comparison the earlier draft rested on was therefore backwards — it charged the option that
-requires a local re-ordering with the cost of an unbuilt subsystem.
-
-#### Decision — option B, settled
-
-| Option | Change | Actual cost | What is lost |
-|---|---|---|---|
-| A — narrow the text | Rewrite the description to "Show planned archive operations…". | One line. | The highest-consequence operation stays unpreviewable — a user running `--dry-run` before a v2 update still learns nothing about the reinstall about to replace their tree. |
-| **B — make the renderer reachable** *(chosen)* | Hoist v2 detection above the `--dry-run` branch and have that branch render the resulting plan and return. | A local re-ordering. The renderer (`update_clean_install.go:186-198`) and its wiring (`update.go:360`) already exist. | Nothing. |
-
-**Option B is the resolution, and it preserves non-mutation rather than trading it away.** The
-implementation constraint is explicit: the `--dry-run` early return is **not** relocated past
-`:306-326`. Moving it there would put `stripRetiredV2DenyEntries` — a `settings.json` rewrite — on
-the dry-run path, contradicting the `:312` rationale that a dry run never mutates. Detection is
-hoisted *above* the branch instead; the branch itself keeps returning before any mutating call.
-
-This matches the sibling `SPEC-UPDATE-REINSTALL-LOOP-002` plan.md §E M4, which reached the same
-resolution independently and records the relocate-the-return variant as a **confirmed defect**. The
-two SPECs must not push this early return in opposite directions.
-
-Residual verification owed to run-phase, not assumed here: that the renderer's prologue —
-`buildPreserveInventory` / `computeInventoryHashes` (`:179`) and `scanDeprecatedPaths` (`:189`) —
-performs no filesystem write. The code path was read, not executed. AC-UDD-002 assertion 2 is the
-criterion that settles it, and REQ-UDD-013 routes the finding to E1 if it turns out the plan cannot
-be rendered without mutation.
-
-### A.6 Drift recorded while authoring
-
-Three discrepancies between the findings as supplied and the tree measured while authoring. None
-reverses a finding; each strengthens or narrows one, and each is recorded rather than silently folded
-in.
-
-**Drift 1 — RESOLVED: all six SPECs now share baseline `d5336214e`.** As recorded at authoring time,
-this SPEC was written in the worktree `.claude/worktrees/epic-update-config` on branch
-`plan/epic-update-config-audit` at HEAD `7225a8b7a`, while the five sibling SPECs recorded
-verification against the divergent local branch `main` at `1d4e4f7da`. The two trees differed by
-three files:
-
-```
- internal/cli/update_clean_install.go               | 11 ++-
- .../cli/update_clean_install_merge_notice_test.go  | 85 ++++++++++++++++++++++
- internal/hook/pre_tool.go                          | 53 ++++++++------
-```
-
-`pre_tool.go` was the only one touching a file this SPEC cites, and its delta was a refactor — lazy
-project-root resolution via a `projectRootResolver` embed — leaving the `AstGrepGate` config mapping
-(`:661-672`) and the `IsGitCommit` gating (`:430-431`) unchanged, so §A.1's conclusions held on both
-trees.
-
-The divergence no longer exists. The Epic branch has since been merged with `origin/main`, producing
-**baseline HEAD `d5336214e`** (`git rev-list --count HEAD..origin/main` → 0). `1d4e4f7da` is not an
-ancestor of that merge — it was a stale divergent local branch, never the trunk — while both
-`7225a8b7a` and `9426bf49b` are ancestors of `d5336214e`. All six Epic SPECs are therefore
-re-attributed to the single baseline `d5336214e`, and every acceptance criterion below records that
-tree. Every baseline figure in this SPEC was re-observed at `d5336214e`; the only change is
-AC-UDD-011's `internal/config/CLAUDE.md` count, corrected from a mis-recorded `2` to the measured
-`1` (see that criterion).
-
-**Drift 2 — F1 is false in three ways, not two.** The finding as supplied named two false halves
-(loader absent; compiled default false). Measured, `gate.yaml` **is shipped** in both the template
-tree and the local project, and sets `ast_grep_gate.enabled: true` explicitly — so the "gate.yaml
-부재" half of §2.2's parenthetical is independently false as well. §A.1 records all three, plus the
-fourth (impact claim) which the finding flagged for separate verification and which also fails.
-
-**Drift 3 — F3's template-tree path is also absent.** The finding as supplied asserted only that
-`.moai/config/config.yaml` does not exist and directed that the template path be checked rather than
-assumed. Checked: `internal/template/templates/.moai/config/config.yaml` does not exist either. §5's
-release checklist therefore names an unbumpable file, which is a release-process consequence and not
-merely a local-path inaccuracy. §A.3 is written against the stronger measured fact.
+**Drift 4 — several v0.2.0 acceptance criteria are now unsatisfiable as written, independent of the
+requirement they serve.** AC-UDD-014 expected `grep -c '로더 부재' CLAUDE.local.md` → `0`; measured
+it is `1`, because the 2026-08-01 correction **quotes the retracted claim** in order to retract it
+("종전 이 절은 … 라고 적었으나 두 주장 모두 현재 main에서 거짓이다"). An absence-grep cannot
+distinguish an assertion from its quoted retraction. This is a general hazard for
+documentation-correctness ACs and is now excluded by construction in `acceptance.md` §A clause 8.
 
 ## §B Requirements (GEARS)
+
+Retired requirements keep their IDs and are recorded in place with the evidence that discharged them;
+they are never renumbered or silently deleted.
 
 ### B.1 Always-loaded instruction correctness
 
 **REQ-UDD-001** — **Where** an always-loaded instruction file (`CLAUDE.local.md`,
 `internal/config/CLAUDE.md`) states a mechanism, the stated mechanism shall match the code at the
 cited site. **When** a reader follows the stated mechanism to the code, the code shall exhibit the
-stated behaviour.
+stated behaviour. **Where** an always-loaded file delegates a topic to a `.moai/docs/*.md` file via
+the `## References` table, that delegated file shall be held to the same correctness standard at the
+point of use.
 
-**REQ-UDD-002** — `CLAUDE.local.md` §2.2 shall state the ast-grep pre-tool gate's actual default —
-enabled in advisory mode — and shall not assert the absence of `loadGateSection`, the absence of a
-shipped `gate.yaml`, or a compiled default of `false`. The corrected text shall name the gate's
-actual invocation scope (evaluated on `git commit` per `internal/hook/pre_tool.go:430-431`) so the
-correction does not overstate the blast radius in the opposite direction.
+**REQ-UDD-002** *(narrowed at v0.3.0)* — `CLAUDE.local.md` §2.2 shall name the ast-grep gate's actual
+invocation scope: evaluated on `git commit` Bash invocations, and additionally suppressed when the
+autonomy tier disables the commit gate (`internal/hook/pre_tool.go:447`,
+`quality.IsGitCommit` && `!config.IsAutonomyTierCommitGateOff`). **Where** §2.2 states the gate's
+default, it shall not do so without the scope qualifier, so the correction does not imply the gate
+fires on every tool call.
 
-**REQ-UDD-003** — **Where** §2.2 describes the gate's user-visible impact, it shall record that the
-suppression-policy check (`internal/hook/quality/astgrep_gate.go`, step 1) is sg-independent and can
-return a blocking result, and shall not state that impact requires an explicit `moai ast-grep`
-invocation with `sg` installed.
+> *Discharged at v0.3.0*: the clause forbidding assertion of an absent `loadGateSection`, an absent
+> shipped `gate.yaml`, or a compiled default of `false`. All three claims were retracted by the
+> 2026-08-01 in-place correction (§A.1). AC-UDD-015 is retained as the regression guard.
+
+**REQ-UDD-003** *(narrowed and sharpened at v0.3.0)* — §2.2 shall state that the suppression-policy
+check (`internal/hook/quality/astgrep_gate.go` step 1) is sg-independent pure Go and returns a
+blocking result **irrespective of `WarnOnlyMode`**, and shall not state or imply that blocking is
+reachable only via a `gate.yaml` opt-in. **Where** §2.2 describes the sg-dependent scan (step 2), it
+shall state that it degrades gracefully when `sg` is absent.
+
+> *Discharged at v0.3.0*: the clause forbidding the claim that impact requires an explicit
+> `moai ast-grep` invocation with `sg` installed. That claim was retracted (§A.1).
+> *Added at v0.3.0*: the `WarnOnlyMode`-irrespective half, which the 2026-08-01 correction newly
+> contradicts.
 
 ### B.2 Documented policy versus code reachability
 
-**REQ-UDD-004** — **Where** `CLAUDE.local.md` §22.8 describes `workflow.worktree.*` toggles as an
-opt-in policy, the description shall state each toggle's actual production reader status:
-`auto_cleanup` and `auto_merge` unread, `auto_create` read only to select advisory wording.
+**REQ-UDD-004** *(re-anchored and polarity-inverted at v0.3.0)* — **Where**
+`.moai/docs/local-dev-settings-intent.md` §22.8 states the production-reader status of the
+`workflow.worktree.*` toggles, that status shall be the measured one: `auto_cleanup` **is** read, at
+`internal/cli/session_worktree.go:584` and `internal/cli/session_worktree_prmerge.go:122`, and the
+read gates worktree disposal rather than selecting advisory wording; `auto_merge` has no production
+reader; `auto_create` is read at `internal/cli/worktree_advisory.go:60` and selects advisory wording
+only. The section shall not assert that no code path consumes `auto_cleanup`.
 
-**REQ-UDD-005** — The §22.8 correction shall be reconciled with whatever triage class
-`SPEC-CONFIG-KEY-HONESTY-001` §A.6 assigns to those keys, and shall not itself propose implementing,
-deprecating, or removing them. **Where** E4's triage lands after this SPEC's edit, the §22.8 text
-shall be re-checked against that outcome rather than left asserting a status E4 has changed.
+**REQ-UDD-005** — **RETIRED at v0.3.0.** The reconciliation with `SPEC-CONFIG-KEY-HONESTY-001` §A.6
+that this requirement made an obligation has been performed: that SPEC reached `status: completed`
+(v0.3.0, 2026-08-12), and `.moai/docs/local-dev-settings-intent.md:60,65` cites its M5 as the source
+of the recorded toggle status and of the template/`defaults.go` alignment. The obligation is
+discharged; the residual factual error in the reconciled text is REQ-UDD-004's, not this
+requirement's. AC-UDD-006 is retired with it.
 
 ### B.3 References to nonexistent paths
 
-**REQ-UDD-006** — An always-loaded instruction file shall not name a configuration file path that
-does not exist. `CLAUDE.local.md` §9, `CLAUDE.local.md` §5, and `internal/config/CLAUDE.md` shall
-stop describing `.moai/config/config.yaml` (or its template-tree counterpart) as the main
-configuration file.
+**REQ-UDD-006** *(targets enumerated at v0.3.0)* — An always-loaded instruction file shall not name a
+path that does not exist, and shall not instruct a reader to write to one. Three concrete targets:
 
-**REQ-UDD-007** — **Where** `CLAUDE.local.md` §5 lists files requiring a version bump at release, the
-list shall contain only files that exist, so every checklist line is performable. The
-`internal/template/templates/.moai/config/config.yaml` entry shall be removed or replaced with the
-file that actually carries the shipped version.
+1. `CLAUDE.local.md:328` (§9) shall stop describing `.moai/config/config.yaml` as the project's main
+   configuration file, and shall describe the actual `sections/*.yaml`-only layout.
+2. `internal/config/CLAUDE.md:5` and `:11` shall stop asserting an aggregating main `config.yaml`.
+3. `CLAUDE.local.md:88`, `:94`, `:106`, `:108` shall stop naming `internal/template/templates/.agency/`
+   as a template-source directory and shall stop instructing that new `.agency/` files be mirrored
+   into it. **Where** `.agency/` is retained in the document at all, it shall be described as what
+   the code implements — a legacy layout read *out of* a user project by `moai migrate agency` and
+   the v2 fingerprint detector — not as a template-managed output directory.
+
+**REQ-UDD-007** *(re-anchored at v0.3.0)* — **Where** `.moai/docs/version-management.md` §*Files
+Requiring Version Sync* lists files requiring a version bump at release, the list shall contain only
+files that exist, so every checklist line is performable. The
+`internal/template/templates/.moai/config/config.yaml (moai.version)` entry at `:78` shall be
+**removed**, and shall not be replaced by another template path: the template side carries no
+hand-bumped version, because `internal/template/templates/.moai/config/sections/system.yaml.tmpl:6`
+renders `version: "{{.Version}}"` at deploy time. **Where** the removal would leave a reader assuming
+the template version is unmanaged, a one-line note shall record the render-time injection.
 
 ### B.4 Contradiction between two always-loaded files
 
 **REQ-UDD-008** — Two always-loaded instruction files shall not assert contradictory facts about the
-same mechanism. `internal/config/CLAUDE.md`'s configuration-priority statement shall be corrected to
-match the implemented override set — `MOAI_DEVELOPMENT_MODE`, `MOAI_LOG_LEVEL`, `MOAI_LOG_FORMAT`,
-`MOAI_NO_COLOR` (per `applyEnvOverrides`), plus `MOAI_CONFIG_DIR` for the config-directory location —
-and shall stop citing `MOAI_USER_NAME` / `MOAI_CONVERSATION_LANG` as implemented overrides.
+same mechanism. `internal/config/CLAUDE.md:12`'s configuration-priority statement shall be corrected
+to match the implemented override set — `MOAI_DEVELOPMENT_MODE`, `MOAI_LOG_LEVEL`, `MOAI_LOG_FORMAT`,
+`MOAI_NO_COLOR` (per `applyEnvOverrides`, `internal/config/manager.go:398-411`), plus
+`MOAI_CONFIG_DIR` for the config-directory location — and shall stop citing `MOAI_USER_NAME` /
+`MOAI_CONVERSATION_LANG` as implemented overrides.
 
-**REQ-UDD-009** — **Where** `internal/config/CLAUDE.md` illustrates the `envkeys.go` constant
-convention, the example shall name a constant that `envkeys.go` actually declares.
+**REQ-UDD-009** — **Where** `internal/config/CLAUDE.md:13` illustrates the `envkeys.go` constant
+convention, the example shall name a constant that `envkeys.go` actually declares. The convention
+itself — constants live in `envkeys.go`, no inline `os.Getenv("MOAI_*")` — is correct and shall be
+preserved; only the worked example changes.
 
 **REQ-UDD-010** — An instruction file shall not require a test whose subject is unimplemented.
-`internal/config/CLAUDE.md`'s "Tests MUST verify this priority via `t.Setenv` + fixture file
+`internal/config/CLAUDE.md:12`'s "Tests MUST verify this priority via `t.Setenv` + fixture file
 combinations" shall be scoped to the implemented override set, so following the instruction literally
-does not produce an unpassable test or an unrequested behaviour change.
+produces neither an unpassable test nor an unrequested behaviour change.
+
+**REQ-UDD-014** *(new at v0.3.0)* — **Where** this SPEC takes ownership of a fix another SPEC also
+claims, the superseded requirement shall be reduced to a cross-reference by that SPEC's owner, so the
+duplicate is not resolved on one side only. `SPEC-INTERNAL-ARCH-001` REQ-ARCH-006 / AC-ARCH-007 is
+the instance (§A.7). This SPEC shall not edit that SPEC; it shall detect and report the unresolved
+state.
 
 ### B.5 Flag contract agreement
 
-**REQ-UDD-011** — The `--dry-run` flag's registered help text and its actual behaviour shall agree.
-**Where** the flag previews only archive operations, the help text shall not promise install
-operations; **where** the help text promises install operations, the flag shall render the
-clean-reinstall plan without mutating the filesystem.
+**REQ-UDD-011** — **RETIRED at v0.3.0, satisfied.** The `--dry-run` help text and behaviour agree.
+`internal/cli/update.go:81` promises "planned archive and install operations"; the dry-run branch at
+`:332-355` computes the v2 fingerprint in place and returns `emitDryRunReinstallPlan` (`:546-600`),
+which renders the clean-reinstall or residue-cleanup plan without mutating. Implemented by
+`SPEC-UPDATE-REINSTALL-LOOP-002` REQ-RIL2-024/025 (§A.5). AC-UDD-001 is retained as a regression
+guard; AC-UDD-002's bespoke tests are retired in favour of the sibling's
+`TestUpdateDryRun_EmitsCleanReinstallPlan`.
 
-**REQ-UDD-012** — The choice between narrowing the help text and extending the flag shall be recorded
-as an explicit decision with its trade-off, not resolved implicitly during implementation. **Where**
-the extend option is selected, the plan-construction path shall be demonstrated to perform no
-filesystem mutation, preserving the `internal/cli/update.go:312` placement rationale.
+**REQ-UDD-012** — **RETIRED at v0.3.0, satisfied.** The A-vs-B choice was recorded as an explicit
+decision at v0.2.0 (option B) and executed under the stated constraint: the early return did not
+move past `stripRetiredV2DenyEntries`, as `internal/cli/update.go:353-354` records verbatim
+(REQ-RIL2-026). The demonstration obligation this requirement attached to option B is discharged by
+the sibling's own no-mutation guarantee, documented at `internal/cli/update.go:551-555`.
 
-*Decision recorded (v0.2.0): **option B** — make the existing non-mutating renderer reachable
-(§A.5). The demonstration obligation this requirement attaches to option B is therefore live, and is
-discharged by AC-UDD-002 assertion 2. The reachability fix hoists v2 detection above the `--dry-run`
-branch; it does **not** relocate the early return past `internal/cli/update.go:306-326`, which would
-place a `settings.json` rewrite on the dry-run path and reverse the `:312` rationale.*
-
-**REQ-UDD-013** — This SPEC shall not change whether clean-reinstall triggers, nor its sequencing.
-**Where** work on REQ-UDD-011 reveals that the plan cannot be constructed without entering the
-mutating path, that finding shall be reported to `SPEC-UPDATE-REINSTALL-LOOP-002` rather than
-resolved here.
+**REQ-UDD-013** — **RETIRED at v0.3.0, moot.** Its content was to route a REQ-UDD-011 escalation to
+`SPEC-UPDATE-REINSTALL-LOOP-002` if the plan could not be rendered without mutation. That SPEC
+reached `status: completed` having rendered the plan without mutation, so the escalation has no
+subject.
 
 ### B.6 Non-functional
 
 **NFR-UDD-001** — Every test added by this SPEC shall confine its filesystem writes to `t.TempDir()`.
 
-**NFR-UDD-002** — No file under `internal/template/templates/**` shall be modified by this SPEC.
-`CLAUDE.local.md` and `internal/config/CLAUDE.md` are repo-local maintainer documentation and are
-never mirrored into the template tree (per the template isolation doctrine, `CLAUDE.local.md` §25).
+**NFR-UDD-002** *(extended at v0.3.0)* — No file under `internal/template/templates/**` shall be
+modified by this SPEC. `CLAUDE.local.md`, `internal/config/CLAUDE.md`, and the two re-anchored
+`.moai/docs/` targets are repo-local maintainer documentation and are never mirrored — verified:
+`ls internal/template/templates/.moai/docs/` lists exactly `agent-lint.md` and
+`generic-patterns-guide.md`, and neither `version-management.md` nor `local-dev-settings-intent.md`
+is present.
 
 **NFR-UDD-003** — Go sources added by this SPEC shall use `snake_case.go` filenames, wrap errors with
 `fmt.Errorf("...: %w", err)`, and carry English comments and godoc.
@@ -534,47 +543,56 @@ re-deriving the measurement.
 ### Out of Scope — the worktree-key triage
 
 - Deciding whether `workflow.worktree.auto_cleanup` / `auto_merge` / `auto_create` should be
-  implemented, deprecated, marked reserved, or removed; adding readers for them; and any change to
-  `internal/config/defaults.go` or `internal/config/types.go` on their account. Owned by
-  `SPEC-CONFIG-KEY-HONESTY-001` §A.6 / REQ-CKH-009. This SPEC corrects only the §22.8 prose and
-  reconciles it with E4's outcome (REQ-UDD-005).
+  implemented, deprecated, marked reserved, or removed; adding or removing readers for them; and any
+  change to `internal/config/defaults.go` or `internal/config/types.go` on their account. Owned by
+  `SPEC-CONFIG-KEY-HONESTY-001` (now `completed`). REQ-UDD-004 corrects only the recorded reader
+  status.
+- In particular: the fact that `auto_cleanup` acquired behaviour-gating readers while the shipped
+  default remains `false` may be a config-honesty question. This SPEC records the reader status and
+  raises no position on it.
 
-### Out of Scope — clean-reinstall behaviour
+### Out of Scope — clean-reinstall and `--dry-run` behaviour
 
 - Whether the clean-reinstall loop should trigger, its v2-fingerprint detection, its sequencing, and
-  its interaction with `isMoAIProject`. Owned by `SPEC-UPDATE-REINSTALL-LOOP-002`. REQ-UDD-011 binds
-  the `--dry-run` **contract** only; REQ-UDD-013 routes any deeper finding to E1.
+  the `--dry-run` reachability implementation. Owned by `SPEC-UPDATE-REINSTALL-LOOP-002`, which
+  landed it (§A.5). This SPEC retains only regression guards.
+
+### Out of Scope — repo-wide `§`-citation rewriting
+
+- Rewriting the 44 Go comments and 8 rule/doc sites that cite the retired `CLAUDE.local.md`
+  `§18`-`§27` numbers. Measured before being proposed: those citations still resolve, because the
+  `## References` table preserves the §-number → file mapping and the receiving `.moai/docs/*.md`
+  files retain their original §-numbered headings. They are stale-looking, not dangling, so no defect
+  is claimed and no sweep is specified here.
+
+### Out of Scope — editing `SPEC-INTERNAL-ARCH-001`
+
+- Marking `REQ-ARCH-006` superseded, or amending `AC-ARCH-007`, inside `SPEC-INTERNAL-ARCH-001`.
+  That SPEC is under concurrent review; its owner applies the reciprocal cross-reference.
+  REQ-UDD-014 and AC-UDD-024 detect and report the unresolved half rather than editing across the
+  boundary.
 
 ### Out of Scope — CI guard pattern design
 
 - Extending, generalising, or restructuring the leak-detection or neutrality patterns, coverage
-  gating, and the `paths-filter` gating set. Owned by `SPEC-UPDATE-CI-GUARD-001` (E5). This SPEC adds
-  no CI workflow change and no guard-pattern change.
-
-### Out of Scope — merge behaviour and merge-base provenance
-
-- The three-way merge's zero-value skip, `ValuesEqual` semantics, `systemFields` depth, and merge
-  atomicity. Owned by `SPEC-UPDATE-YAML-PRESERVE-001`.
-- The provenance of the merge base (base drawn from the new template rather than a snapshot of the
-  old one). Owned by the unwritten `SPEC-UPDATE-TEMPLATE-BASE-SNAPSHOT-001`.
+  gating, and the `paths-filter` gating set. Owned by `SPEC-UPDATE-CI-GUARD-001`. This SPEC adds no
+  CI workflow change and no guard-pattern change.
 
 ### Out of Scope — template mirroring of maintainer documentation
 
-- Mirroring `CLAUDE.local.md` or `internal/config/CLAUDE.md` into `internal/template/templates/**`.
-  Both are repo-local maintainer documentation; a template mirror would violate the template
-  internal-content isolation doctrine (`CLAUDE.local.md` §25). Verified: the template tree contains
-  exactly one `CLAUDE.md` (`internal/template/templates/CLAUDE.md`) and no
-  `internal/template/templates/internal/` directory, so neither file ships today and neither shall be
-  made to (NFR-UDD-002).
+- Mirroring `CLAUDE.local.md`, `internal/config/CLAUDE.md`, `.moai/docs/version-management.md`, or
+  `.moai/docs/local-dev-settings-intent.md` into `internal/template/templates/**`. All four are
+  repo-local; a mirror would violate the template internal-content isolation doctrine (NFR-UDD-002).
 
-### Out of Scope — code changes in this Epic
+### Out of Scope — implementing the two unimplemented env vars
 
-- No code changes. This Epic's six SPECs are plan-phase artefacts only; run-phase implementation is a
-  separate, separately-approved step. REQ-UDD-011's behavioural half, if the extend option is chosen
-  at the plan.md §F.5 decision point, is a run-phase decision **recorded** here, not performed here.
+- Adding `MOAI_USER_NAME` / `MOAI_CONVERSATION_LANG` overrides to `envkeys.go` or
+  `applyEnvOverrides`. REQ-UDD-008/009/010 correct the documentation to match the code; the reverse
+  direction, if ever wanted, is a separate SPEC.
 
 ### Out of Scope — a general documentation audit
 
-- Auditing `CLAUDE.local.md` sections other than §2.2, §5, §9, and §22.8, or `internal/config/CLAUDE.md`
-  statements other than the configuration-priority and `envkeys.go`-convention bullets. This SPEC
-  fixes the five measured drifts; a general sweep is a separate scope.
+- Auditing `CLAUDE.local.md` sections other than §2 (Template-First / §2.2), §9, and the References
+  table, `.moai/docs/` files other than the two re-anchored targets, or `internal/config/CLAUDE.md`
+  statements other than the `config.yaml`, configuration-priority, and `envkeys.go`-convention
+  bullets. This SPEC fixes the measured drifts; a general sweep is a separate scope.


### PR DESCRIPTION
## What

`SPEC-UPDATE-DOC-DRIFT-001` was authored 2026-07-31 and never revisited. Since then `CLAUDE.local.md` was consolidated — former §18-§27 were externalized into `.moai/docs/*.md`, and the file now runs §1-§17 plus a `## References` table — which left several of the SPEC's requirements pointing at sections that no longer exist, and one claim was fixed in place without the SPEC noticing.

Every one of `REQ-UDD-001..013` was re-measured against this tree rather than carried over; the v0.2.0 baseline `d5336214e` is not an ancestor of this branch, so no prior `file:line` or count was trusted.

## Disposition

- **Retired with evidence (4)** — `REQ-UDD-005`, `REQ-UDD-011`, `REQ-UDD-012`, `REQ-UDD-013`. The `--dry-run` contract pair was satisfied by the sibling `SPEC-UPDATE-REINSTALL-LOOP-002` (`REQ-RIL2-024/025/026`); `REQ-UDD-013`'s escalation target is moot because that SPEC reached `completed`.
- **Re-anchored (3)** — `REQ-UDD-004` → `.moai/docs/local-dev-settings-intent.md`, `REQ-UDD-007` → `.moai/docs/version-management.md`, and `REQ-UDD-002/003`'s site moved `CLAUDE.local.md:141` → `:146`.
- **Kept live, narrowed (2)** — `REQ-UDD-002` / `REQ-UDD-003`. §2.2 gained a dated 2026-08-01 correction retracting all four false claims, so the falsehood half is discharged; a new misstatement plus two unmet positive obligations survive.
- **Kept live (5)** — `REQ-UDD-001`, `REQ-UDD-006` (with the `.agency/` phantom-path instance folded in as its concrete target), `REQ-UDD-008`, `REQ-UDD-009`, `REQ-UDD-010`.
- **Polarity inverted** — `REQ-UDD-004`: two production readers for `auto_cleanup` have appeared since v0.2.0, so the drift is now the mirror image of what was recorded.
- **Duplicate resolved** — `SPEC-INTERNAL-ARCH-001` `REQ-ARCH-006` claims the same `internal/config/CLAUDE.md` envkeys fix. Ownership assigned to this SPEC (§A.7). That SPEC is deliberately not edited here; the unresolved state is detected and reported instead.

## Scope

`status: draft` is preserved — this is a plan-phase rewrite, not a close. SPEC documents only; no Go code, templates, or CHANGELOG entries.

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the v0.3.0 specifications, acceptance criteria, and implementation plan to align with current behavior.
  * Clarified requirements for command output, configuration overrides, worktree settings, path handling, version display, and documentation scope.
  * Added measurable baselines, expected outputs, preservation checks, and safeguards against ambiguous or vacuous validation.
  * Documented completed and retired requirements, exclusions, constraints, and unresolved ownership considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->