### PR TITLE
fix(hook): emit the kanban bootstrap notice only on a genuinely new session

### DIFF
--- a/internal/hook/session_start.go
+++ b/internal/hook/session_start.go
@@ -353,7 +353,14 @@ func (h *sessionStartHandler) Handle(ctx context.Context, input *HookInput) (*Ho
 	// already draws: agent_prompt_language (English) for the agent-facing copy,
 	// conversation_language for the operator-facing one. The two copies differ
 	// only in prose — commands, run id, and socket path are identical in both.
-	if notice := kanbanBootstrapNotice(langEnglish); notice != "" {
+	//
+	// The notice is a BOOTSTRAP announcement, so it belongs to a genuinely new
+	// session and nothing else. SessionStart also fires on resume, clear, and
+	// compact, where the kanban env is still set and the notice would therefore
+	// re-emit — telling the operator to open four terminals they already opened,
+	// for a run already under way. Those three sources are skipped; see
+	// kanbanBootstrapNoticeForSource for the empty-source case.
+	if notice := kanbanBootstrapNoticeForSource(input.Source, langEnglish); notice != "" {
 		if out.HookSpecificOutput == nil {
 			out.HookSpecificOutput = &HookSpecificOutput{
 				HookEventName: string(EventSessionStart),

--- a/internal/hook/session_start_kanban.go
+++ b/internal/hook/session_start_kanban.go
@@ -47,6 +47,28 @@ func kanbanBootstrapNotice(lang string) string {
 	return kanbanLeadNotice(os.Getenv(config.EnvMoaiKanbanID), lang)
 }
 
+// kanbanBootstrapNoticeForSource returns the announcement only for a genuinely
+// new session, and "" for every SessionStart that merely re-enters an existing
+// one.
+//
+// SessionStart fires on four sources: startup, resume, clear, and compact. The
+// kanban environment is process-level and survives all four, so an ungated
+// notice re-announces the bootstrap on every resume — instructing the operator
+// to open four companion terminals that are already open, for a run already in
+// progress. Only startup is the moment the instruction is actionable.
+//
+// An empty source is treated as startup. Claude Code always populates the
+// field, so an empty value means a caller that predates it or a test
+// constructing the input by hand; emitting there keeps the prior behaviour
+// instead of silently suppressing the notice for them.
+func kanbanBootstrapNoticeForSource(source, lang string) string {
+	switch source {
+	case "resume", "clear", "compact":
+		return ""
+	}
+	return kanbanBootstrapNotice(lang)
+}
+
 // kanbanLeadNotice is the lead branch. It carries, in order: (a) the run id;
 // (b) the four companion launch lines, each carrying -k; (c) the leader socket
 // path; (d) an inbound-automation notice; (e) the SPEC identifier (only when

--- a/internal/hook/session_start_kanban_surface_test.go
+++ b/internal/hook/session_start_kanban_surface_test.go
@@ -110,3 +110,61 @@ func TestSessionStartNonKanbanSystemMessageUnaffected(t *testing.T) {
 		t.Errorf("non-kanban session got a kanban SystemMessage: %q", out.SystemMessage)
 	}
 }
+
+// TestSessionStartKanbanNoticeOnlyOnNewSession pins the bootstrap notice to a
+// genuinely new session.
+//
+// SessionStart fires on four sources, and the kanban environment survives all
+// of them, so an ungated notice re-announced the bootstrap on every resume: the
+// operator was told to open four companion terminals that were already open,
+// for a run already in progress. The instruction is only actionable at startup.
+//
+// The empty source is asserted to still emit. Claude Code always populates the
+// field, so an empty value means a caller that predates it — including the
+// other cases in this file, which construct HookInput without one.
+func TestSessionStartKanbanNoticeOnlyOnNewSession(t *testing.T) {
+	for _, tc := range []struct {
+		source string
+		want   bool
+	}{
+		{source: "startup", want: true},
+		{source: "", want: true},
+		{source: "resume", want: false},
+		{source: "clear", want: false},
+		{source: "compact", want: false},
+	} {
+		t.Run("source="+tc.source, func(t *testing.T) {
+			clearKanbanEnv(t)
+			t.Setenv(config.EnvMoaiKanban, "1")
+			t.Setenv(config.EnvMoaiKanbanID, "tjpyre")
+
+			projectDir := newKanbanProjectDir(t)
+			out, err := NewSessionStartHandler(nil).Handle(context.Background(), &HookInput{
+				SessionID:  "uuid-kanban-surface-gate",
+				CWD:        projectDir,
+				ProjectDir: projectDir,
+				Source:     tc.source,
+			})
+			if err != nil {
+				t.Fatalf("Handle: %v", err)
+			}
+
+			got := strings.Contains(out.SystemMessage, "Kanban Mode")
+			if got != tc.want {
+				t.Errorf("source %q: notice emitted = %v, want %v.\nSystemMessage: %q",
+					tc.source, got, tc.want, out.SystemMessage)
+			}
+
+			// The model-facing channel is gated by the same predicate; a
+			// suppressed notice must not survive on either surface.
+			ac := ""
+			if out.HookSpecificOutput != nil {
+				ac = out.HookSpecificOutput.AdditionalContext
+			}
+			if gotAC := strings.Contains(ac, "Kanban Mode"); gotAC != tc.want {
+				t.Errorf("source %q: AdditionalContext carried notice = %v, want %v",
+					tc.source, gotAC, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

SessionStart fires on four sources — `startup`, `resume`, `clear`, `compact` — and the kanban environment is process-level, so it survives all four. The bootstrap notice was ungated.

Every resume therefore re-announced the bootstrap: the operator was told to open four companion terminals that were **already open**, for a run **already under way**. The instruction is only actionable at startup.

## How

`kanbanBootstrapNoticeForSource(source, lang)` gates the announcement on `input.Source`.

An empty source **still emits**. Claude Code always populates the field, so an empty value means a caller that predates it or a test constructing the input by hand; suppressing there would silently change their behaviour.

Both surfaces are gated by the same predicate, so a suppressed notice cannot survive on the model-facing `additionalContext` channel while being hidden from the operator's `systemMessage`.

## Relationship to #1514

#1514 landed the two-channel delivery and the per-audience language split. This is the remaining half: **when** the notice fires. Nothing from #1514 is reverted — the gate is applied on top of its i18n call sites rather than by restoring an older revision of these files.

## Verification

```
go build ./internal/hook/   → OK
go vet   ./internal/hook/   → OK

go test ./internal/hook/ -run TestSessionStartKanban -count=1
  --- PASS: TestSessionStartKanbanNoticeOnlyOnNewSession
      --- PASS: source=startup   (emits)
      --- PASS: source=          (emits)
      --- PASS: source=resume    (suppressed)
      --- PASS: source=clear     (suppressed)
      --- PASS: source=compact   (suppressed)
  ok  github.com/modu-ai/moai-adk/internal/hook  0.520s
```

Full package, with the kanban environment unset:

```
env -u MOAI_KANBAN -u MOAI_KANBAN_ID -u MOAI_KANBAN_LABEL \
    -u MOAI_KANBAN_SETTINGS_INJECTED -u MOAI_KANBAN_LEAD_ADDR \
    go test ./internal/hook/ -count=1
  ok  github.com/modu-ai/moai-adk/internal/hook  0.418s
```

## CORRECTION — retracting a claim this PR made earlier

An earlier revision of this description, **and the commit message**, stated that
`TestSessionStartAdditionalContextSkippedOnEmptySessionID` and `TestSessionStartHandler_Handle`
fail on a clean `a301ef6f8` and are pre-existing.

**That claim is wrong and is withdrawn.** Both tests pass. They failed only because the
measuring session was itself a kanban session, so `MOAI_KANBAN`, `MOAI_KANBAN_ID`,
`MOAI_KANBAN_SETTINGS_INJECTED` and `MOAI_KANBAN_LEAD_ADDR` were inherited into the test
process and poisoned them. The baseline run that appeared to confirm the claim carried the
same pollution, so it reproduced the artefact rather than establishing the fact.

Measured both ways in the same worktree, same commit:

```
# inherited kanban env (how the retracted claim was measured)
go test ./internal/hook/ -run 'TestSessionStartAdditionalContextSkippedOnEmptySessionID|TestSessionStartHandler_Handle' -count=1
  --- FAIL: TestSessionStartAdditionalContextSkippedOnEmptySessionID
  --- FAIL: TestSessionStartHandler_Handle
  FAIL

# kanban env unset
env -u MOAI_KANBAN -u MOAI_KANBAN_ID -u MOAI_KANBAN_LABEL \
    -u MOAI_KANBAN_SETTINGS_INJECTED -u MOAI_KANBAN_LEAD_ADDR \
  go test ./internal/hook/ -run '...same two...' -count=1
  ok  github.com/modu-ai/moai-adk/internal/hook  0.418s
```

The commit message still carries the retracted sentence; it is left in history rather than
force-pushed away, and this note is the correction of record. There are no known pre-existing
failures on this base.

🗿 MoAI