### PR TITLE
test: isolate kanban launcher env vars in block-cap/notice/autonomy tests

### DIFF
--- a/internal/cli/launcher_blockcap_infinite_test.go
+++ b/internal/cli/launcher_blockcap_infinite_test.go
@@ -47,11 +47,37 @@ func TestAC003_BlockCapDoctrineClauseSpecific(t *testing.T) {
 	}
 }
 
+// clearKanbanLauncherEnv unsets every kanban signal variable plus the runtime
+// block-cap key so the inject's negative controls below start from a
+// known-absent state. A session running these tests inside Kanban Mode carries
+// the launcher-injected MOAI_KANBAN* variables in its ambient env, and the
+// inject's kanban branch is unconditional on them — without this isolation the
+// "no signal → env unchanged" controls fail on the developer's own machine.
+// t.Setenv registers the restore, so the process env is returned to its prior
+// value when the test ends. Same pattern as clearKanbanEnv in
+// internal/hook/session_start_kanban_test.go.
+func clearKanbanLauncherEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{
+		config.EnvMoaiKanban,
+		config.EnvMoaiKanbanID,
+		config.EnvMoaiKanbanSpec,
+		config.EnvMoaiKanbanLabel,
+		config.EnvMoaiKanbanSettingsInjected,
+		config.EnvMoaiKanbanLeadAddr,
+		config.EnvClaudeCodeStopHookBlockCap,
+	} {
+		t.Setenv(key, "")
+		_ = os.Unsetenv(key)
+	}
+}
+
 // TestAC003_LauncherInjectsRaisedBlockCapForInfiniteGoal asserts the launcher
 // env builder injects CLAUDE_CODE_STOP_HOOK_BLOCK_CAP=<raised> when an armed
 // MaxTurns==0 goal exists for the resolving session, and leaves the env
 // unchanged when no such goal exists (backward compat).
 func TestAC003_LauncherInjectsRaisedBlockCapForInfiniteGoal(t *testing.T) {
+	clearKanbanLauncherEnv(t)
 	tmp := t.TempDir()
 	ctx := context.Background()
 
@@ -116,6 +142,7 @@ func armInfiniteGoalFixture(t *testing.T, projectRoot, sessionID string, maxTurn
 //
 // Non-parallel by construction: t.Setenv mutates process-global state.
 func TestACFM022a_KanbanRaisesBlockCapUnconditionally(t *testing.T) {
+	clearKanbanLauncherEnv(t)
 	tmp := t.TempDir()
 	ctx := context.Background()
 	base := []string{"PATH=/usr/bin", "HOME=/tmp"}
@@ -169,6 +196,7 @@ func TestACFM022a_KanbanCapReplacesPreexistingEntry(t *testing.T) {
 //
 // Non-parallel by construction: t.Setenv mutates process-global state.
 func TestKanbanCompanionRaisesBlockCap(t *testing.T) {
+	clearKanbanLauncherEnv(t)
 	tmp := t.TempDir()
 	ctx := context.Background()
 	base := []string{"PATH=/usr/bin", "HOME=/tmp"}

--- a/internal/config/autonomy_test.go
+++ b/internal/config/autonomy_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"os"
 	"testing"
 )
 
@@ -30,6 +31,14 @@ func TestAutonomyTierReader(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.set {
 				t.Setenv(EnvAutonomyTier, tc.env)
+			} else {
+				// The kanban launcher exports MOAI_AUTONOMY_TIER into the
+				// sessions it starts, so on a Kanban Mode developer machine
+				// the ambient env would otherwise make the "unset" case read
+				// a real tier. t.Setenv registers the restore; the unset
+				// makes "not set" distinct from "set to empty".
+				t.Setenv(EnvAutonomyTier, "")
+				_ = os.Unsetenv(EnvAutonomyTier)
 			}
 			got := AutonomyTier()
 			if got != tc.want {

--- a/internal/hook/session_start_additional_context_test.go
+++ b/internal/hook/session_start_additional_context_test.go
@@ -139,6 +139,13 @@ func TestSessionStartAdditionalContextSkippedOnEmptySessionID(t *testing.T) {
 	// SPEC-STEERING-ALIGN-GUARDRAIL-HOOK-001 — the test isolates the env.
 	t.Setenv("ANTHROPIC_BASE_URL", "")
 
+	// Isolate the kanban PROCESS env too: a session launched by the kanban
+	// launcher carries MOAI_KANBAN_* variables, and kanbanBootstrapNotice()
+	// would append its notice to AdditionalContext even with an empty
+	// SessionID. Same isolation as the kanban notice tests in
+	// session_start_kanban_test.go.
+	clearKanbanEnv(t)
+
 	projectDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(projectDir, ".moai", "state"), 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)

--- a/internal/hook/session_start_test.go
+++ b/internal/hook/session_start_test.go
@@ -66,6 +66,14 @@ func TestSessionStartHandler_Handle(t *testing.T) {
 	// isolate the env, not weaken the SUT.
 	t.Setenv("ANTHROPIC_BASE_URL", "")
 
+	// Isolate the kanban PROCESS env as well: a session launched by the
+	// kanban launcher carries MOAI_KANBAN_* variables, and
+	// kanbanBootstrapNotice() injects its notice into AdditionalContext even
+	// when SessionID/ProjectDir is empty — breaking the "nil config" and
+	// "empty project config" subtests below. Same isolation as the kanban
+	// notice tests in session_start_kanban_test.go.
+	clearKanbanEnv(t)
+
 	tests := []struct {
 		name         string
 		cfg          *config.Config


### PR DESCRIPTION
## Summary

A session started by the kanban launcher carries `MOAI_KANBAN*`, `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP`, and `MOAI_AUTONOMY_TIER` in its ambient process env. Six tests read those keys from the surrounding environment instead of a controlled one, so `go test ./...` inside a Kanban Mode session reported false failures that CI (clean env) never saw. Multiple companion sessions hit the same defect independently today.

Fix is test-side only (the launcher is correct): each affected test explicitly unsets the variables via `t.Setenv(key, "")` + `os.Unsetenv(key)` — keeping "not set" distinct from "set to empty" — while `t.Setenv` still registers the restore.

### Touched tests (6)

| Package | Test | Leak path |
|---|---|---|
| `internal/hook` | `TestSessionStartAdditionalContextSkippedOnEmptySessionID` | kanban bootstrap notice leaked into `AdditionalContext` with empty SessionID |
| `internal/hook` | `TestSessionStartHandler_Handle` (nil-config / empty-project subtests) | same notice path with empty ProjectDir |
| `internal/cli` | `TestAC003_LauncherInjectsRaisedBlockCapForInfiniteGoal` | unconditional kanban branch fired on ambient `MOAI_KANBAN`/`MOAI_KANBAN_LABEL`, breaking both negative controls |
| `internal/cli` | `TestACFM022a_KanbanRaisesBlockCapUnconditionally` | same — negative control |
| `internal/cli` | `TestKanbanCompanionRaisesBlockCap` | same — negative control |
| `internal/config` | `TestAutonomyTierReader` | "unset → semi-auto" case read ambient `MOAI_AUTONOMY_TIER` |

### Implementation notes

- `internal/hook`: reuses the existing `clearKanbanEnv` helper (`session_start_kanban_test.go`) — no new helper.
- `internal/cli`: adds `clearKanbanLauncherEnv` in the existing test file (no new files, avoiding overlap with the concurrent SPEC-KANBAN-TODO-CLI-001 work in `internal/cli`).
- `internal/config`: the `set=false` case now unsets `EnvAutonomyTier` per-subtest.

## Verification

- **Polluted env (kanban vars live, no `env -u`)**: all 6 tests PASS — `go test ./internal/hook/ ./internal/cli/ ./internal/config/ -run '<the six>' -count=1 -v` → all `--- PASS`.
- **Clean env (vars removed)**: `internal/hook` ok, `internal/config` ok, `internal/cli` fails only on the pre-existing `TestHandleCodexReviewGate_LiveCodexBlocksInjectionAndKey` (fails on origin/main too — not introduced here).
- `go vet ./internal/hook/ ./internal/cli/ ./internal/config/` → clean.

## Notes for the reviewer

- `TestNavigatorEnrich_AtomicWriteBarrier` (`internal/cli`) flaked twice under full-suite runs in this session (passed 5/5 in isolation and in the clean-env full run). Pre-existing cross-test interference, unrelated to this change — flagging for awareness only.

🗿 MoAI