### PR TITLE
feat(SPEC-KANBAN-TODO-CLI-001): moai todo CLI with lock-guarded backlog store

### DIFF
--- a/.claude/skills/moai/workflows/todo.md
+++ b/.claude/skills/moai/workflows/todo.md
@@ -14,27 +14,35 @@ it and the lead dispatches it to the `plan` session.
 The queue is deliberately thin. It records *what the operator wants next*, and
 nothing that a SPEC, a git history, or a board would record better.
 
-State lives at `.moai/state/kanban/backlog.json`. It is project-local and is not
-committed.
+State lives at `.moai/state/kanban/backlog.json` (project-local, not committed).
+Do not read or write that file directly — run the `moai todo` commands: they
+hold a cross-process lock across every mutation, so concurrent sessions cannot
+lose cards or collide ids.
 
-## Verbs
+## Commands
 
-| Invocation | Effect |
+When the operator says `/moai todo "<description>"`, run
+`moai todo add "<description>"`; a bare `/moai todo` runs `moai todo list`.
+
+| Command | Effect |
 |---|---|
-| `/moai todo "<description>"` | Append an item to the queue. Prints the item and its position. |
-| `/moai todo` | List the queue, in order, with positions. |
-| `/moai todo done <n>` | Remove item `n` (it was completed elsewhere, or is no longer wanted). Prints what was removed. |
-| `/moai todo next` | Present the queue through `AskUserQuestion` so the operator picks the next card. |
+| `moai todo add "<text>"` | Append an item under the lock. Prints the issued id (`t<n>`) and its queue position. |
+| `moai todo list` | Render the queue, lock-free. `--json` emits the structured records. |
+| `moai todo done <n>` | Remove the addressed row under the lock. A bare `<n>` means `t<n>`; the explicit id (`moai todo done t3`) is the preferred form because positions move. |
+| `moai todo next` | Print the queued items oldest-first — read-only candidates. |
+| `moai todo next <n> [--spec <SPEC-ID>]` | Mark the addressed item `picked` (attaching `spec_id` when given) as one locked write. |
 
-Any other argument form is treated as a description — `/moai todo fix the flaky
-CI cache` adds an item rather than erroring, because the cost of a wrong guess
-here is one line the operator can delete.
+The queue is never mutated through any other surface. A missing backlog file is
+an empty queue, never an error; a malformed file is reported and left untouched.
 
-## Record shape
+## Reading the records
+
+`moai todo list --json` emits the file's records:
 
 ```json
 {
   "version": 1,
+  "last_seq": 12,
   "items": [
     {
       "id": "t1",
@@ -47,25 +55,20 @@ here is one line the operator can delete.
 }
 ```
 
-- `id` — short, stable, assigned on append. Never reused after removal.
-- `spec_id` — filled in when the item is picked and a SPEC is authored for it.
-  Until then it is `null`, which is what distinguishes a backlog item from a card
-  already on the board.
+- `id` — assigned on append, never reused after removal (`last_seq` is the
+  persisted high-water mark that guarantees it).
+- `spec_id` — filled in when the item is picked; until then it is `null`, which
+  is what distinguishes a backlog item from a card already on the board.
 - `state` — `queued` | `picked` | `dropped`. A picked item stays in the file so
   the operator can see what is in flight; it is removed when its card reaches
   `done`.
 
-Write the file atomically (write a sibling temp file, then rename) so a crash
-mid-write cannot truncate the queue. A missing file is an empty queue, not an
-error. A malformed file is reported and left untouched — never silently reset,
-because the operator's intent is the one thing here that cannot be regenerated.
-
 ## Picking the next card
 
-`/moai todo next` (and the lead's own post-`/clear` opening move) presents the
-queue through `AskUserQuestion` — one option per queued item, capped at the four
-the tool allows, oldest first, with the remainder summarized in the response body
-so nothing is hidden behind the cap.
+`moai todo next` (and the lead's own post-`/clear` opening move) presents the
+queued items through `AskUserQuestion` — one option per queued item, capped at
+the four the tool allows, oldest first, with the remainder summarized in the
+response body so nothing is hidden behind the cap.
 
 [HARD] The pick is the operator's. Do not preselect, do not reorder by inferred
 priority, and do not append a "start the top one" default. Where the queue is
@@ -81,14 +84,13 @@ authorization never covered. See `kanban-dispatch.md` § Batch admission.
 
 Once picked:
 
-1. Mark the item `picked`.
+1. Record it with `moai todo next <n> --spec <SPEC-ID>` (one locked write).
 2. Dispatch to the `plan` session per `kanban-dispatch.md` — the card enters the
    `plan` column, and SPEC authoring happens there, not here.
-3. Record the SPEC ID onto the item as soon as the plan session reports one.
 
 ## Outside Kanban Mode
 
-`/moai todo` works in an ordinary session too — it is just a queue. What it will
+`moai todo` works in an ordinary session too — it is just a queue. What it will
 not do is dispatch: with no companion sessions there is nobody to instruct, so
 the queue is read and written and the operator drives the work themselves.
 

--- a/.moai/specs/SPEC-KANBAN-TODO-CLI-001/acceptance.md
+++ b/.moai/specs/SPEC-KANBAN-TODO-CLI-001/acceptance.md
@@ -1,0 +1,112 @@
+---
+id: SPEC-KANBAN-TODO-CLI-001
+title: "Acceptance — moai todo CLI subcommand with lock-guarded backlog store"
+version: "0.1.1"
+status: in-progress
+created: 2026-08-14
+updated: 2026-08-14
+author: manager-spec
+priority: P1
+phase: "v3.1.0 target"
+module: internal/kanban
+lifecycle: spec-anchored
+tags: "kanban, cli, backlog, concurrency, acceptance"
+tier: M
+---
+
+# acceptance.md — SPEC-KANBAN-TODO-CLI-001
+
+Verification layer. Each entry is an `AC-XXX` labeled **Given-When-Then** scenario, binary-testable. The GEARS obligation lives in the requirement layer (`spec.md` §C `REQ-TODO-001`…`REQ-TODO-016`); nothing here restates a GEARS requirement, and no Given-When-Then scenario is presented as one.
+
+## §A Coverage matrix (REQ → AC)
+
+16 REQs covered by 15 ACs (Tier M AC ceiling). Grouping is by shared verification command; every REQ maps to at least one AC. REQ numbering per spec.md §F History v0.1.1 consolidation map.
+
+| REQ | AC | REQ | AC | REQ | AC |
+|-----|----|-----|----|-----|----|
+| 001 | AC-TODO-001 | 007 | AC-TODO-007 | 013 | AC-TODO-013 |
+| 002 | AC-TODO-001 | 008 | AC-TODO-008 | 014 | AC-TODO-014 |
+| 003 | AC-TODO-003 | 009 | AC-TODO-008 | 015 | AC-TODO-015 |
+| 004 | AC-TODO-004 | 010 | AC-TODO-009 | 016 | AC-TODO-016 |
+| 005 | AC-TODO-005, AC-TODO-006 | 011 | AC-TODO-010 | | |
+| 006 | AC-TODO-007 | 012 | AC-TODO-011, AC-TODO-012 | | |
+
+## §B Acceptance criteria
+
+### AC-TODO-001 — concurrent `add` loses nothing (REQ-TODO-001, REQ-TODO-002)
+
+**Given** a temp-dir backlog with the `moai todo` command wired, **When** 8 concurrent `moai todo add "card N"` processes run simultaneously, **Then** a subsequent `moai todo list --json` reports exactly 8 items, each carrying the text it was added with, and each `add` printed its issued id and queue position.
+
+### AC-TODO-003 — `list` is lock-free and structured (REQ-TODO-003)
+
+**Given** a backlog holding queued and picked items, **When** `moai todo list` runs while `backlog.lock` is held by another process, **Then** the command succeeds and renders the queue without acquiring the lock; **and when** `moai todo list --json` runs, **Then** stdout is valid JSON carrying the full record shape.
+
+### AC-TODO-004 — `done` removes by id under lock (REQ-TODO-004)
+
+**Given** a backlog holding item `t3`, **When** `moai todo done 3` runs, **Then** the row `t3` is absent from the file after the command and the exit code is 0; **and when** `moai todo done t3` runs against a queue lacking `t3`, **Then** the command exits non-zero with the miss reported.
+
+### AC-TODO-005 — bare `next` is read-only (REQ-TODO-005)
+
+**Given** a backlog holding items added in known order, **When** `moai todo next` runs, **Then** the items are printed oldest-first and the backlog file is byte-identical before and after (no state change, no `picked` transition).
+
+### AC-TODO-006 — `next <n> [--spec]` is one locked write (REQ-TODO-005)
+
+**Given** a backlog holding queued item `t2`, **When** `moai todo next 2 --spec SPEC-X-001` runs, **Then** exactly item `t2` carries `state: "picked"` and `spec_id: "SPEC-X-001"` after the command, and no other row changed — a single mutation observable in one file write.
+
+### AC-TODO-007 — lock serialization, bounded retry, named-path error (REQ-TODO-006, REQ-TODO-007)
+
+**Given** `backlog.lock` held by a foreign process, **When** `moai todo add "x"` runs, **Then** the command retries within the bounded window (~1 s: 25 ms × 40) and then exits non-zero with an error message containing the literal lock artifact path `.moai/state/kanban/backlog.lock` (or the temp-dir equivalent); **and when** two mutating verbs run concurrently, **Then** both complete with correct results — the loser serialized by the retry, not corrupted (composes with AC-TODO-001).
+
+### AC-TODO-008 — ids unique, monotonic, never reused (REQ-TODO-008, REQ-TODO-009)
+
+**Given** 8 concurrent adds (AC-TODO-001 fixture), **When** ids are collected, **Then** all 8 are distinct and drawn from one monotonic `t<n>` sequence; **given** a version-1 file with no high-water field and max id `t19`, **When** the store first loads and then writes, **Then** the next issued id is `t20` and the persisted file carries the derived high-water mark; **and given** `t20` is subsequently removed via `done`, **When** the next `add` runs, **Then** the issued id is `t21`, not `t20` — removal never enables reuse.
+
+### AC-TODO-009 — writes are atomic temp+rename (REQ-TODO-010)
+
+**Given** any mutating verb, **When** it completes, **Then** the backlog file is valid parseable JSON ending in a newline, the write went through `internal/atomicfile` (same-directory temp + rename — verified by the store's unit test asserting the `atomicfile.Replace` call path, not by grep of production source), and no `.tmp` residue remains in the directory.
+
+### AC-TODO-010 — no lead-role guard (REQ-TODO-011)
+
+**Given** a process holding no lead role / kanban identity, **When** it runs `moai todo add "x"` against a temp-dir backlog, **Then** the write succeeds — the backlog applies no `requireLeadRole`-equivalent gate (explicit contrast test; board files remain untouched by this SPEC).
+
+### AC-TODO-011 — missing file is an empty queue (REQ-TODO-012)
+
+**Given** no backlog file exists, **When** `moai todo list`, `moai todo next`, or `moai todo add "first"` run, **Then** the first two report an empty queue and exit 0, and the third creates a valid version-1 file containing exactly one item — none of the three errors.
+
+### AC-TODO-012 — malformed file reported, never reset (REQ-TODO-012)
+
+**Given** a backlog file containing invalid JSON, **When** each verb runs, **Then** every verb exits non-zero with the parse error reported, and the file is byte-identical (checksummed before and after) — no silent recovery path exists.
+
+### AC-TODO-013 — version-1 record shape preserved, change additive only (REQ-TODO-013)
+
+**Given** a production-shaped version-1 file (`{"version":1,"items":[{"id","text","added_at","spec_id","state"}]}`, states `queued`/`picked`/`dropped`), **When** the store round-trips it (load → any mutation → write), **Then** every pre-existing item retains all five fields with unchanged values, `version` remains `1`, no per-item field is added, and the only top-level addition is the high-water mark.
+
+### AC-TODO-014 — CLI no-prompt static guard (REQ-TODO-014)
+
+**Given** the built `internal/cli` package, **When** the todo-command static guard test runs (the `TestNew_NoAskUserQuestion` grep-based pattern scoped to the todo command surface), **Then** it passes — zero `AskUserQuestion`/interactive-prompt references in the todo command path, and the guard fails if one is introduced (negative control asserted in test).
+
+### AC-TODO-015 — skill shrunk, twins delta-matched, template neutral (REQ-TODO-015)
+
+**Given** the run-phase edits, **When** the shrunk local skill is inspected, **Then** it retains the queue philosophy, the boundaries, the kanban-dispatch cross-reference, and the [HARD] operator-selection rule, and no longer contains Read→Write file-manipulation or temp-file/rename instructions (absence verified by grep for the removed instruction tokens); **and when** the template twin is diffed against the local twin, **Then** the same delta is present on both; **and when** `MOAI_TEMPLATE_LEAK_STRICT=1 go test ./internal/template/...` runs, **Then** it exits 0 — no SPEC IDs and no internal dates in the template twin; **and** `make build` regenerated `catalog.yaml` is committed (mirror-parity CI green).
+
+### AC-TODO-016 — Windows compile gate covers the test layer (REQ-TODO-016)
+
+**Given** the completed implementation, **When** `GOOS=windows GOARCH=amd64 go build ./...` AND `GOOS=windows GOARCH=amd64 go vet ./...` run, **Then** both exit 0 with exit codes cited verbatim in the run-phase evidence — the vet result is the load-bearing half because `go build` never compiles `_test.go`.
+
+## §C Edge cases (binary coverage demanded by §B)
+
+- Empty-text add (`moai todo add ""`) → rejected with usage error, exit non-zero, no file write.
+- `done`/`next <n>` with an out-of-range `<n>` → non-zero, miss reported, file untouched.
+- `--spec` value not matching `^SPEC(-[A-Z][A-Z0-9]*)+-[0-9]{3}$` → accepted verbatim (store is not a SPEC registry; validation is out of scope) but recorded as-is — no normalization.
+- Backlog file with `last_seq` smaller than a present id (hand-edited) → next issued id is still greater than every present id (high-water = max(persisted, max-present)).
+
+## §D Quality gates
+
+- Package coverage ≥ 85% for the new store and CLI files (`go test -cover ./internal/kanban/... ./internal/cli/...`, cited output).
+- Full-suite rule: `go test ./...` green (affected-package-only self-report insufficient — template-mirror CI precedent).
+- Lint: zero NEW findings vs the §C pre-flight baseline (`golangci-lint run`).
+- MX tags: new exported store functions are `@MX:ANCHOR` candidates per plan.md §F; the locked-mutation path carries `@MX:WARN` (concurrency pattern).
+
+## §E Definition of Done
+
+All 15 ACs PASS with attributed evidence (command + verbatim output + tree SHA), the four milestones in plan.md §F complete, frontmatter transitions owned per the Status Transition Ownership Matrix, and no production file `.moai/state/kanban/backlog.json` was mutated by tests or run-phase commands.

--- a/.moai/specs/SPEC-KANBAN-TODO-CLI-001/plan.md
+++ b/.moai/specs/SPEC-KANBAN-TODO-CLI-001/plan.md
@@ -1,0 +1,139 @@
+---
+id: SPEC-KANBAN-TODO-CLI-001
+title: "Plan — moai todo CLI subcommand with lock-guarded backlog store"
+version: "0.1.1"
+status: in-progress
+created: 2026-08-14
+updated: 2026-08-14
+author: manager-spec
+priority: P1
+phase: "v3.1.0 target"
+module: internal/kanban
+lifecycle: spec-anchored
+tags: "kanban, cli, backlog, concurrency, plan"
+tier: M
+---
+
+# plan.md — SPEC-KANBAN-TODO-CLI-001
+
+## §A Context
+
+Kanban card t12. The `/moai todo` skill currently instructs the model to Read→Write `.moai/state/kanban/backlog.json` directly; with five concurrent sessions on one checkout that window is minutes wide and resolves to last-writer-wins (2026-08-14 incident: 3 cards lost, t4/t5/t6 ID collision — research.md §2). This SPEC replaces the model-driven cycle with a real `moai todo` Go CLI backed by a lock-guarded store.
+
+Evidence base: `research.md` (all claims command-attributed; nothing re-derived here). Affected surfaces:
+
+- New: `internal/kanban/backlog_store.go` (or similarly named), `internal/cli/todo.go` (+ `_test.go` files).
+- Modified: `internal/cli/root.go` (register `newTodoCmd()`), `.claude/skills/moai/workflows/todo.md` (shrink), `internal/template/templates/.claude/skills/moai/workflows/todo.md` (same delta), regenerated `internal/template/catalog.yaml` via `make build`.
+- Preserved: `internal/kanban/board*.go` (board store, `requireLeadRole`, WIP surfaces — untouched per spec.md §D), `internal/atomicfile` (consumed as-is), `internal/session` (consumed as pattern reference only).
+
+Tier M (spec frontmatter `tier: M`). REQ count is 16 — at the Tier M ceiling. The SPEC was authored at 19 REQs by the first delegation; plan-audit iteration 1 (D2) routed the over-budget set to consolidation, resolved at v0.1.1 by merging three pairs (005+006, 013+014, 017+018 — grouping, no scope loss; spec.md §F History carries the old→new map). AC count is 15 (`AC-TODO-001`, `AC-TODO-003` … `AC-TODO-016`; `AC-TODO-002` was never defined — no filler inserted, count labels corrected), within the Tier M ceiling via REQs that share one verification command.
+
+## §B Known Issues
+
+- **B1 (cross-platform build tags)**: the lock substrate already carries the Unix/Windows split (`board_lock_unix.go` / Windows atomic-create counterpart). The backlog store inherits it by reuse — NO new platform files are authored here. The Windows claim discipline is AC-TODO-016: `GOOS=windows go build` alone never covers `_test.go`; `GOOS=windows go vet` is the gate.
+- **B2 (working-tree hygiene)**: five sessions share this checkout (kanban mode). Run phase MUST NOT touch `.moai/state/kanban/backlog.json` (production data) except through read-only observation; tests use `t.TempDir()`.
+- **B3 (subagent boundary)**: no AskUserQuestion in `internal/cli` — enforced by the existing static-guard test pattern (`TestNew_NoAskUserQuestion`, research.md §9); a todo-specific guard test is AC-TODO-014.
+- **B4 (template mirror hazard)**: the twins are currently byte-identical (research.md §8), so there is no intentionally-neutralized variant to restore — but the rule stands: apply the SAME delta to both, never `cp` one over the other, and verify with `MOAI_TEMPLATE_LEAK_STRICT=1 go test` (neutrality: no SPEC IDs, no internal dates in the shrunk skill).
+- **B5 (catalog regeneration)**: after editing the template twin, `make build` regenerates `internal/template/catalog.yaml` — that regeneration must be committed with the template change (prior mirror-commit CI failure precedent).
+
+## §C Pre-flight (run phase, before M1)
+
+```bash
+git branch --show-current && git rev-parse HEAD     # Late-Branch: branch/worktree setup is the run session's act (§F Phase 13 note)
+go build ./... && GOOS=windows GOARCH=amd64 go build ./...
+golangci-lint run --timeout=2m 2>&1 | tail -5       # baseline for NEW-vs-pre-existing classification
+grep -rn 'Backlog' internal/kanban/*.go | head      # expected: only ColumnBacklog (name space still free)
+moai todo 2>&1 | head -3                            # expected: Unknown command "todo" (the RED baseline)
+```
+
+## §D Constraints & Design Decisions
+
+Each decision is stated with its justification. Decisions (a)–(h) correspond to the dispatch contract; no open clarification markers remain — spec.md already binds each of them to a REQ, so re-opening any here would contradict the authored requirements.
+
+### D-a Lock substrate — reuse `internal/kanban`, path-parameterized
+
+**Decision**: reuse the in-package `internal/kanban` lock substrate — `acquireBoardLockImpl(lockPath)` is path-parameterized (flock Unix / atomic-create Windows, `BoardLockOwner{PID, CreatedAt}` recorded in the artifact) — pointed at a sibling artifact `.moai/state/kanban/backlog.lock`, acquired through a bounded-retry wrapper mirroring `acquireBoardLockSerialized` (25 ms × 40 ≈ 1 s). `internal/session` `Registry.withLock` is a **pattern reference only** (lock → read → mutate-callback → atomic write → release; reads lock-free): importing `internal/session` from a kanban-scoped store would be a reverse dependency, and its in-process path-keyed mutex layer is registry-specific (research.md §5).
+
+**Why this seam and not another**: the substrate is in-package, already cross-platform, already carries owner identity for diagnostics, and SPEC-KANBAN-BOARD-001 has production-tested it. `internal/lockfile` is in-process-only and explicitly excluded by the substrate's own header. A new lock package would duplicate a reviewed concurrency primitive. Binds REQ-TODO-006/007.
+
+### D-b No lead-role guard — deliberate
+
+**Decision**: backlog writes do NOT apply `requireLeadRole`. The board guard exists because the board has exactly one writer (the lead); the backlog is the operator's queue and any session may append, pick, or complete (spec.md REQ-TODO-011, research.md §4). Stated explicitly so the plan-auditor reads the asymmetry as designed, not as an omission.
+
+### D-c ID issuance inside the lock, persisted high-water mark
+
+**Decision**: ids are issued inside the locked mutation from an additive top-level field `last_seq` (integer). When `last_seq` is absent (a version-1 file predating the field), the store derives it from the maximum present item id on first load and persists it on first write (REQ-TODO-009). Schema handling: **additive within version 1** — no version bump, no new per-item fields (spec.md §E keeps this an explicit out-of-scope).
+
+**Why persisted, not derived**: `done` removes rows, so max-present-id derivation alone would reuse ids of removed items — exactly the t4/t5/t6 collision the incident recorded. The high-water mark must survive removals, therefore it must live in the file.
+
+### D-d Verb semantics, no-prompt constraint
+
+**Decision**: four verbs, none prompts (REQ-TODO-014; `internal/cli/CLAUDE.md` forbids AskUserQuestion in CLI; static guard test pattern `TestNew_NoAskUserQuestion` → AC-TODO-014).
+
+| Verb | Lock | Behavior |
+|---|---|---|
+| `add "<text>"` | write | Append under lock; print issued id + queue position (REQ-TODO-002). |
+| `list` | none | Render queue lock-free; `--json` emits structured records (REQ-TODO-003). |
+| `done <n>` | write | Remove addressed row under lock; bare `<n>` normalized to id `t<n>`; explicit id is the preferred form because positions shift under concurrent adds (REQ-TODO-004). |
+| `next` (bare) | none | Read-only oldest-first candidate listing for the lead's own AskUserQuestion channel — the pick stays the operator's act ([HARD] in the skill, "The lead never picks for the operator", research.md §10) (REQ-TODO-005). |
+| `next <n> [--spec <SPEC-ID>]` | write | Mark addressed item `picked` + attach `spec_id` as ONE locked write (REQ-TODO-005). |
+
+**Why `next <n>` is a locked write and not scope creep**: without it, the picked/spec_id transition remains a model-driven read-modify-write — the residual race this card exists to kill. It is bound by the second When-branch of REQ-TODO-005 in the authored spec; keeping `next` read-only would strand that branch without an owner. Not an open clarification item: the requirement is already dispatched scope.
+
+### D-e File contract preserved verbatim
+
+Missing file = empty queue (`list`/`next` report empty, `add` creates a version-1 file, never an error). Malformed file = error reported, file left byte-identical, never silently reset — the operator's queued intent is the one thing that cannot be regenerated (REQ-TODO-012, contract lines carried verbatim from the current skill, research.md §2).
+
+### D-f Windows posture
+
+The substrate's platform split is inherited by reuse (D-a). Stale-lock posture: bounded retry (~1 s) then a clear error naming the lock artifact path. Automatic stale-lock detection/clearing is OUT of scope at this tier — documented limitation, spec.md §E (on Unix the kernel releases flock on holder death, so the stale artifact case is a Windows-substrate concern only).
+
+### D-g Atomic write
+
+Persistence goes through `internal/atomicfile` (`Replace`; same-directory temp + rename, `ReadFile` absorbs the Windows delete-pending window on the read side — research.md §7). Same shape as `writeBoardAtomic`: `MarshalIndent` + trailing `\n`, temp in the target directory.
+
+### D-h Skill shrink + template mirror
+
+Local `.claude/skills/moai/workflows/todo.md` shrinks to "run the command": keep the queue philosophy, the boundaries, the kanban-dispatch cross-reference, and the [HARD] operator-selection rule; remove the direct Read→Write instructions and the temp-file/rename guidance (now internal to the store). The SAME delta — not a verbatim `cp` — is applied to the template twin `internal/template/templates/.claude/skills/moai/workflows/todo.md` (twins currently byte-identical, research.md §8; the no-verbatim-cp rule guards against overwriting intentionally-neutralized variants if one diverges before run phase). Template neutrality: no SPEC IDs, no internal dates in the shrunk skill body. Run phase MUST `make build` (re-embed + commit regenerated `catalog.yaml`).
+
+### D-i Hard constraints (from spec.md §D)
+
+- No new module dependencies: `internal/kanban` + `internal/atomicfile` only.
+- Board surfaces (`board.go`, `board_store.go`, `board_recover.go`) untouched.
+- Any new env-var names → constants in `internal/config/envkeys.go` (none anticipated).
+
+## §E Self-Verification (plan phase)
+
+- Frontmatter: all 12 canonical fields present, canonical names (no snake_case aliases), `phase: "v3.1.0 target"` (release target, not a lifecycle token).
+- SPEC ID pre-write self-check executed as Bash: `PASS` (research.md §11).
+- Requirements: 16, GEARS notation, mirroring spec.md's existing structure (Ubiquitous / When / Where).
+- Out of Scope: spec.md §E carries four `### Out of Scope —` H3 sub-headings with bullets (satisfies `OutOfScopeRule`).
+- AC coverage: 15 ACs cover all 16 REQs (acceptance.md §A coverage matrix; merged REQs map to two ACs each, grouping noted per AC).
+
+## §F Milestones (ordered by decision-reversibility — data-model decisions first)
+
+Data-model and lock-contract decisions are the ones a reviewer is most likely to overturn; they come first so review concentrates where change is likeliest. Mechanical steps (mirror, docs, verification sweep) come last.
+
+- **M1 — Backlog store + lock + ID issuance** (D-a, D-b, D-c, D-e, D-g): new store file in `internal/kanban`; locked mutation path (serialize → load → mutate → atomic write → release-with-error-join); lock-free load; `last_seq` high-water mark with derive-on-absent; missing/malformed contracts. TDD: RED tests first (concurrent add, ID uniqueness, malformed untouched). Highest change-likelihood: schema field name (`last_seq`) and the derive-on-absent rule.
+- **M2 — CLI verbs** (D-d, D-i): `newTodoCmd()` in `internal/cli/todo.go`, registered in `root.go`; `add` / `list --json` / `done` / `next` (bare + `<n> [--spec]`); exit codes 0/1/2; no-prompt static guard test.
+- **M3 — Skill shrink + template mirror** (D-h): same delta to both twins; `make build`; commit regenerated `catalog.yaml`; `MOAI_TEMPLATE_LEAK_STRICT=1 go test` neutrality gate.
+- **M4 — Cross-platform + full-suite verification**: `GOOS=windows go build ./...` AND `GOOS=windows go vet ./...` (exit codes cited); full `go test ./...` (full-suite rule: affected-package-only self-report is insufficient); lint NEW-vs-baseline classification.
+
+**Phase 13 note (branch/worktree setup)**: deferred to the run session per Late-Branch policy — this shared checkout carries five concurrent kanban sessions and plan phase performs NO git state changes. The run session creates the feature branch / PR per the repo-local all-tier PR policy (`.claude/rules/moai/workflow/repo-local-pr-policy.md`; `main` is protected, Route A disabled). Implementation Kickoff Approval still gates run-phase entry.
+
+## §G Anti-Patterns
+
+- **AP-PL-001 — REQ count over Tier M ceiling (RESOLVED)**: the first delegation authored 19 REQs vs the 16 ceiling. Plan-audit iteration 1 (D2) flagged it as blocking; resolved at v0.1.1 via the **consolidation route** (the auditor's option b, chosen because no user-override channel exists for this session and the merged pairs are true groupings — both behaviors preserved verbatim in each merged REQ): 005+006 → 005 (two When-branches), 013+014 → 012 (two When-branches), 017+018 → 015 (skill + template mirror in one REQ). No scope dropped; every AC stays mapped. Old→new numbering map in spec.md §F History.
+- **AP-PL-002 — Applying `requireLeadRole` "for consistency"**: the board guard welded onto the backlog would break every non-lead append — the primary use case (D-b).
+- **AP-PL-003 — Deriving ids from max-present-id at issue time**: regresses to id reuse after `done` (the incident's exact failure shape). The persisted high-water mark is the fix, not an optimization.
+- **AP-PL-004 — Silent malformed-file recovery**: any "repair on load" path violates REQ-TODO-014 and destroys the one artifact that cannot be regenerated.
+- **AP-PL-005 — Verbatim `cp` of the shrunk skill to the template twin**: apply the same delta; `cp` overwrites intentionally-neutralized variants when they exist (B4).
+- **AP-PL-006 — Windows claim on `go build` alone**: never compile-verifies `_test.go`; `GOOS=windows go vet` is the claim gate (CLAUDE.local.md §6).
+
+## §H Cross-References
+
+- `spec.md` §C/§D/§E — requirements, constraints, exclusions this plan implements.
+- `research.md` — verified evidence for every decision above (§2 incident, §4 substrate, §5 pattern, §7 atomicfile, §8 twins, §9 CLI conventions, §10 dispatch-rule verb fit).
+- SPEC-KANBAN-BOARD-001 — substrate provenance; its plan/acceptance conventions mirrored here.
+- `.claude/rules/moai/workflow/kanban-dispatch.md` § Entry into the board — the operator-act doctrine the verbs serve.
+- `.moai/docs/git-local-workflow-doctrine.md` + `repo-local-pr-policy.md` — all-tier PR route (Route A disabled in this repo).

--- a/.moai/specs/SPEC-KANBAN-TODO-CLI-001/progress.md
+++ b/.moai/specs/SPEC-KANBAN-TODO-CLI-001/progress.md
@@ -1,0 +1,141 @@
+---
+id: SPEC-KANBAN-TODO-CLI-001
+title: "Progress — moai todo CLI subcommand with lock-guarded backlog store"
+version: "0.1.1"
+status: in-progress
+created: 2026-08-14
+updated: 2026-08-14
+author: manager-spec
+priority: P1
+phase: "v3.1.0 target"
+module: internal/kanban
+lifecycle: spec-anchored
+tags: "kanban, cli, backlog, concurrency, progress"
+tier: M
+---
+
+# progress.md — SPEC-KANBAN-TODO-CLI-001
+
+## Authoring record
+
+This is the **second delegation** of this plan phase. The first agent (kanban card t12 dispatch, 2026-08-14) delivered `spec.md` + `research.md` and then failed on autocompact thrashing before writing plan.md / acceptance.md / progress.md. This delegation verified the two surviving artifacts structurally (both complete, not truncated) and authored the remaining three. No SPEC body content from the first delegation was rewritten.
+
+## Phase 1 — exploration SKIP rationale
+
+Deep exploration was performed inline by the orchestrator **before delegation** and is fully recorded in `research.md` (12 evidence sections, every claim command-attributed: the missing CLI verb, the incident file, the lock substrate reads, the atomicfile exports, the twin diff, the CLI conventions, the dispatch-rule verb fit). Re-running an exploration pass here would duplicate verified evidence against a context budget that already consumed the previous agent — SKIP, evidence cited, not assumed.
+
+## Decision Point 1 — satisfied by dispatch
+
+The operator picked card t12 from the backlog queue and the kanban lead dispatched to plan per `.claude/rules/moai/workflow/kanban-dispatch.md` § The dispatch cycle. Entry into the board is the operator's act; this SPEC is the plan-phase product of that pick. The run session still faces **Implementation Kickoff Approval** before run-phase entry — nothing here pre-authorizes it.
+
+## §E.1 Plan-phase Audit-Ready Signal
+
+Plan-phase artifacts authored: `spec.md`, `plan.md`, `acceptance.md`, `research.md`, `progress.md` (Tier M set + research.md carried from the first delegation; `progress.md` at every tier).
+
+- Requirements: 16 (`REQ-TODO-001` … `REQ-TODO-016`) — within the Tier M ceiling of 16 (post-v0.1.1 consolidation, spec.md §F History; originally authored at 19, see plan.md §G AP-PL-001).
+- Acceptance criteria: 15 (`AC-TODO-001`, `AC-TODO-003` … `AC-TODO-016`; `AC-TODO-002` never defined — count labels corrected at v0.1.1) — within the Tier M ceiling; all 16 REQs covered (post-v0.1.1 consolidation, spec.md §F History) via acceptance.md §A matrix.
+- Milestones: 4 (M1 store/lock/ids → M2 CLI verbs → M3 skill+mirror → M4 cross-platform verification), ordered by decision-reversibility per plan.md §F.
+- Design decisions (a)–(h) from the dispatch contract: all stated and justified in plan.md §D; zero open clarification markers (each decision is bound to an authored REQ).
+- Branch/worktree setup: deferred to the run session (Late-Branch policy; shared 5-session checkout; plan phase performs no git state changes) — plan.md §F Phase 13 note.
+
+plan_status: audit-ready
+plan_complete_at: 2026-08-14
+
+### Plan-audit verdict (plan phase closed)
+
+- Iteration 1 (2026-08-14): FAIL 0.90 — `.moai/reports/plan-audit/SPEC-KANBAN-TODO-CLI-001-review-1.md` (blocking: D1 AC-count misstatement, D2 REQ 19 > Tier M ceiling 16; optional: D3 negated marker token).
+- Remediation: v0.1.1 — REQ consolidation 19→16 (spec.md §F History), count labels + coverage matrix rebuilt, token reworded, sibling frontmatter versions aligned.
+- Iteration 2 (2026-08-14): **PASS 0.95** (Tier M threshold 0.80) — `.moai/reports/plan-audit/SPEC-KANBAN-TODO-CLI-001-review-2.md`; D1/D2/D3 RESOLVED with mechanical evidence; D4/D5 optional observations (D5 closed, D4 accepted as lint-surface artifact).
+- Plan phase CLOSED. Next: Implementation Kickoff Approval (run-session human gate) → `/moai run SPEC-KANBAN-TODO-CLI-001`, M1 (store/lock/ids) first per plan.md §F ordering.
+
+## §F Phase 4 Mode Selection
+
+Input parameters: tier=M; scope ≈ 6 files (1 new store file + tests, CLI verb file + tests in M2, 2 skill twins + catalog.yaml in M3); domains = 2 (Go source, skill/template markdown); language mix = Go + markdown; concurrency benefit LOW (coding-heavy, sequential dependencies M1→M2→M3); Agent Teams prereqs N/A (Mode 3 retired).
+
+| Mode | Selected | Rationale |
+|------|----------|-----------|
+| 1 trivial | no | New concurrency-bearing store, not a typo fix |
+| 2 background | no | Write-capable implementation work |
+| 3 agent-team | no | RETIRED |
+| 4 parallel | no | Coding-heavy per Anthropic's coding-task parallelism caveat |
+| 5 sub-agent | YES | Sequential per-milestone delegation; M1 first (semi-autonomous progression — orchestrator stops after M1 for lead evidence review) |
+| 6 workflow | no | Not ≥30-file mechanical transformation |
+
+Decision: sub-agent
+Justification: single-package Go implementation with tight sequential dependencies between milestones; one manager-develop delegation per milestone (Mode 5). Progression mode: semi-autonomous — the kanban lead directed an M1 stop-point for evidence review, so M2/M3/M4 await the lead's go decision. Implementation Kickoff Approval passed (operator, via kanban lead dispatch 2026-08-14); plan-audit PASS 0.95 ≥ Tier M threshold 0.80 with artifacts unchanged since (skip-eligible Phase 1 re-execution).
+
+## §E.2 Run-phase Evidence
+
+**Baseline-attribution**: all evidence below was captured by the orchestrator (run session, worktree `kanban-todo-cli`, branch `worktree-kanban-todo-cli`) against the tree `origin/main b73c81ab5` + the M1 working files (`internal/kanban/backlog_store.go` + 2 test files), before the M1 commit. Two manager-develop delegations died on autocompact context thrashing (delegation 1 after authoring the RED test file; delegation 2 after implementing to green, dying mid-coverage-measurement); the orchestrator then verified every claim directly — no §E row below is a delegation self-report.
+
+All `go test` invocations use the shell-builtin env scrub `unset MOAI_KANBAN MOAI_KANBAN_ID MOAI_KANBAN_LABEL MOAI_KANBAN_LEAD_ADDR MOAI_KANBAN_SETTINGS_INJECTED CLAUDE_CODE_STOP_HOOK_BLOCK_CAP && go test …` — the `env -u` wrapper form is rejected by the worktree guard hook in worktree-isolated sessions (verified; lesson recorded in memory).
+
+### M1 — Backlog store + lock + ID issuance (COMPLETE)
+
+Deliverables: `internal/kanban/backlog_store.go` (292 lines), `internal/kanban/backlog_store_test.go` (531 lines, 15 tests), `internal/kanban/backlog_store_errors_test.go` (151 lines).
+
+**E8 — RED (TDD, verbatim pre-GREEN).** Inherited RED state was the test file against no implementation (compile failure), observed by the orchestrator:
+
+```
+$ unset MOAI_KANBAN … && go test ./internal/kanban/ -run TestNonexistent -count=1
+internal/kanban/backlog_store_test.go:377:35: too many errors
+FAIL	github.com/modu-ai/moai-adk/internal/kanban [build failed]
+FAIL
+```
+
+**E1 — M1 test matrix (store-level AC slice).**
+
+```
+$ unset MOAI_KANBAN … && go test ./internal/kanban/... -count=1 -cover
+ok  	github.com/modu-ai/moai-adk/internal/kanban	24.727s	coverage: 87.3% of statements
+```
+
+All 15 tests in `backlog_store_test.go` pass (plus the error-path suite), covering: lock acquire/release incl. bounded-retry timeout naming `backlog.lock` (`TestBacklogLock_TimeoutNamesLockPath`); ID issuance under lock (`TestBacklogIDIssuedUnderLock_SequentialMutations`, `TestBacklogMutate_LoserSerializedNotFailed`); `last_seq` high-water surviving removal — done t20 then add → t21 (`TestBacklogHighWater_SurvivesRemoval`); derive-on-absent (`TestBacklogHighWater_DeriveOnAbsent`); hand-edited low `last_seq` guard (`TestBacklogHighWater_HandEditedLowSeq`); malformed file byte-identical (`TestBacklogMalformed_ReportedEverywhereFileUntouched`); missing file = empty queue (`TestBacklogLoad_MissingFileIsEmptyQueue`, `TestBacklogAdd_CreatesVersion1File`); round-trip field preservation (`TestBacklogRoundTrip_PreservesFieldsAndVersion`); no .tmp residue (`TestBacklogWrite_NoTmpResidue`); concurrent add unique IDs (`TestBacklogConcurrentAdd_UniqueIDs`); no lead-role guard (`TestBacklogStore_NoLeadRoleGuard`). CLI-process-level ACs (AC-TODO-001, 003–006) are **M2-pending**, not FAIL.
+
+**E2 — Cross-platform.**
+
+```
+$ go build ./...                                        → exit 0
+$ GOOS=windows GOARCH=amd64 go build ./...              → exit 0
+$ GOOS=windows GOARCH=amd64 go vet ./internal/kanban/... → exit 0 (echo ALL_BUILDS_VET_OK)
+```
+
+**E3 — Coverage.** `go test -cover ./internal/kanban/...` → `coverage: 87.3% of statements` (≥85% target; see E1 output — package-level).
+
+**E4 — Full suite (attribution per failure, all baseline-verified by file-removal A/B):**
+
+```
+$ unset MOAI_KANBAN … && go test ./... -count=1
+```
+
+Failing packages: `internal/cli`, `internal/config`, `internal/hook` (+ `internal/spec` in one run, see below). Per-failure attribution, each verified by re-running with the M1 files moved aside (A/B):
+
+- `internal/cli`: `--- FAIL: TestHandleCodexReviewGate_LiveCodexBlocksInjectionAndKey` — the known pre-existing origin/main failure (lead-confirmed). Sole cli failure. Baseline.
+- `internal/config`: `--- FAIL: TestAutonomyTierReader` — fails identically with M1 files removed → pre-existing baseline, not this SPEC.
+- `internal/hook`: `--- FAIL: TestPreTool_AstGrepSkipReasonSurfaces` ("SystemMessage is empty: the ast-grep skip reason was dropped somewhere in the three-frame chain") — fails identically with M1 files removed → pre-existing baseline, not this SPEC.
+- `internal/spec`: failed once under full-suite parallel load (85.9s), passed in two isolated re-runs with the SPEC dir present (`ok … 38.040s`, `ok … 45.995s`) → flaky under load, not deterministically broken by this SPEC's directory.
+
+All other packages green. No failure attributable to M1.
+
+**E5 — Lint.**
+
+```
+$ golangci-lint run --timeout=2m
+0 issues.
+```
+
+Baseline was also `0 issues.` — zero NEW findings.
+
+**E6 — Commit.** M1 commit lands on `worktree-kanban-todo-cli` with this progress update and the SPEC artifacts (frontmatter `status: draft → in-progress` on all four documents). Not pushed — PR/push awaits the kanban lead's M1 verdict per the semi-autonomous progression.
+
+**Gaps.** (1) Per-file coverage of `backlog_store.go` alone was not measured (delegation 2 died mid-measurement; package-level 87.3% cited instead). (2) `internal/spec` flakiness under full-suite parallel load is observed, not root-caused — outside this SPEC's scope. (3) RED evidence is the compile-failure form; a behavioral (assertion-level) RED capture was lost with delegation 1's context.
+
+**Residual-risk.** (1) The `internal/cli`/`internal/config`/`internal/hook` baseline failures were verified in THIS worktree; CI on the eventual PR runs on a clean runner where worktree-cwd-dependent behavior may differ. (2) M2's CLI verbs will exercise the store through real process concurrency (8-process `add`), a stronger test than the in-process concurrency test here.
+
+## §E.3 Run-phase Audit-Ready Signal
+
+_<pending run-phase>_
+
+## §E.4 Sync-phase Audit-Ready Signal
+
+_<pending sync-phase>_

--- a/.moai/specs/SPEC-KANBAN-TODO-CLI-001/progress.md
+++ b/.moai/specs/SPEC-KANBAN-TODO-CLI-001/progress.md
@@ -191,9 +191,11 @@ $ go tool cover -func=… | grep -E 'todo\.go:|backlog_store\.go:'
 
 Lead verdict on M2: **PASS** (2026-08-14; lead filled the binary-smoke gap personally: built binary `moai todo add "첫 카드"` → `t1 1` exit 0; 12 OS processes concurrent add → 12/12 items, 12 unique gapless ids, `last_seq: 12`; high-water live check `t1 t2 t3` → `done 3` → add → `t1 t2 t4` — no t3 reuse). M3 instruction: same-direct treatment, with the explicit warning NOT to `cp` the template twin (neutralized-variant hazard — CI catches SPEC-IDs/dates but not internal-vocabulary leaks).
 
-**Pre-edit state (measured before writing)**: `diff .claude/skills/moai/workflows/todo.md internal/template/templates/.claude/skills/moai/workflows/todo.md` → **byte-identical twins** (105 lines each). With no neutralized variant to preserve in THIS tree, applying the same rewrite to both files IS the same delta; the no-cp rule is honored in its substance (the variant check was performed, not assumed — research.md §8's claim re-verified on the actual M3 tree).
+**Pre-edit state (measured before writing)**: `diff .claude/skills/moai/workflows/todo.md internal/template/templates/.claude/skills/moai/workflows/todo.md` → **byte-identical twins**. With no neutralized variant to preserve in THIS tree, applying the same rewrite to both files IS the same delta; the no-cp rule is honored in its substance (the variant check was performed, not assumed — research.md §8's claim re-verified on the actual M3 tree).
 
-**The delta (REQ-TODO-015 / D-h)**: shrink to "run the command" form. Preserved: queue philosophy ("one line of intent", "deliberately thin"), the operator-act header + kanban-dispatch cross-reference, the record-shape explanation (now framed as reading `list --json` output, with `last_seq` documented), the [HARD] operator-selection rule verbatim in intent, Boundaries, Outside-Kanban-Mode, all three cross-references. Removed: the direct file-manipulation instructions (the verbs table's model-driven Read→Write semantics, "Write the file atomically (write a sibling temp file, then rename)…"), and the obsolete "any other argument form is treated as a description" rule (the real CLI takes explicit subcommands). Added: the mapping table of the five real CLI invocations and the "do not read or write the file directly" instruction (the whole point of M1+M2). 105 → 119 lines.
+**Line-count correction (M4, lead-requested)**: the original M3 report's "105 → 119 lines" mixed a measured pre-edit value with an UNMEASURED post-edit estimate — the 119 was never observed and is wrong. The measured three-point facts (each attributed to its tree, `wc -l`): worktree base `b73c81ab5` todo.md = **105**; post-M3 twins = **107**; origin/main at M4 time = **112** (main advanced past this branch's base and touched todo.md, +7 vs base). Net: **112 → 107 (−5) against current origin/main** (the merge-relevant frame); 105 → 107 (+2) against this branch's base. The shrink direction holds — the earlier "grew to 119" claim is retracted. The upstream todo.md change also means the twins may conflict at PR-merge time; flagged to the lead at M4.
+
+**The delta (REQ-TODO-015 / D-h)**: shrink to "run the command" form. Preserved: queue philosophy ("one line of intent", "deliberately thin"), the operator-act header + kanban-dispatch cross-reference, the record-shape explanation (now framed as reading `list --json` output, with `last_seq` documented), the [HARD] operator-selection rule verbatim in intent, Boundaries, Outside-Kanban-Mode, all three cross-references. Removed: the direct file-manipulation instructions (the verbs table's model-driven Read→Write semantics, "Write the file atomically (write a sibling temp file, then rename)…"), and the obsolete "any other argument form is treated as a description" rule (the real CLI takes explicit subcommands). Added: the mapping table of the five real CLI invocations and the "do not read or write the file directly" instruction (the whole point of M1+M2). Line counts: see the M4 correction above (112 → 107 against origin/main).
 
 **AC-TODO-015 verification (each command + output)**:
 
@@ -225,6 +227,42 @@ Docs-vs-verbs cross-check (lead checklist item 5): cobra `Use:` strings in todo.
 **Gaps.** (1) The shrunk skill's behavioral effect (the model actually running `moai todo` instead of Read→Write) is verified by document inspection, not by an A/B model run — the skill-ab-testing methodology was out of M3's milestone scope (plan.md §F keeps M3 a documentation delta). (2) No 4-locale surface touched: the todo skill exists only in English (verified — no `todo.*.md` locale twins exist to mirror).
 
 **Residual-risk.** The catalog-parity conclusion holds for THIS template state; if a future change adds workflow skills to the catalog's hash subject set, the B5 commit obligation revives for future edits of this file.
+
+### M4 — Cross-platform + full-suite verification (COMPLETE; orchestrator-direct)
+
+Lead verdict on M3: **PASS** (2026-08-14; lead re-measured: `cmp -s` twins identical at 107 lines, SPEC-ID regex `SPEC-[A-Z0-9-]+-[0-9]{3}` → 0 matches — the `<SPEC-ID>` placeholder in command syntax is not a violation —, catalog workflows-path entries 0, docs↔verbs match). One numeric correction requested and applied above (the unmeasured "119" line-count claim retracted; three-point measured values recorded with tree attribution).
+
+**E2 — Cross-platform (exit codes cited verbatim; note the vet gate is FULL-REPO this time, stronger than M2's package-scoped run):**
+
+```
+$ go build ./...                          → BUILD_UNIX_EXIT=0
+$ GOOS=windows GOARCH=amd64 go build ./... → BUILD_WIN_EXIT=0
+$ GOOS=windows GOARCH=amd64 go vet ./...   → VET_WIN_EXIT=0
+```
+
+**E4 — Full suite** (`unset MOAI_KANBAN … && go test ./... -count=1`):
+
+Exactly three failing tests, all previously A/B-attributed to baseline in M1 (files-removed reruns: each fails identically with the M1/M2 files absent):
+
+- `TestHandleCodexReviewGate_LiveCodexBlocksInjectionAndKey` (internal/cli) — the lead-declared known origin/main failure (t20; PR #1527 addresses it per lead).
+- `TestAutonomyTierReader` (internal/config) — A/B'd in M1.
+- `TestPreTool_AstGrepSkipReasonSurfaces` (internal/hook) — A/B'd in M1.
+
+`internal/spec` (flaky in one M1 run) passed this run. **Zero NEW failures** — the lead's "A/B any failure beyond the known one" instruction did not trigger. All other packages green.
+
+**E5 — Lint.**
+
+```
+$ golangci-lint run --timeout=5m → "0 issues." LINT_EXIT=0
+```
+
+Baseline (pre-M1, same tree family) was also "0 issues." — zero NEW findings across the entire SPEC's diff.
+
+**E6 — Commit.** This M4 correction+evidence commit rides the same branch; push remains withheld for the lead's push/PR instruction.
+
+**Gaps.** (1) The upstream todo.md change (origin/main advanced +7 lines past this branch's base) means a PR merge may conflict on the twins — resolution belongs to the merge step, flagged to the lead. (2) The M1 A/B attributions for the config/hook failures were performed against THIS worktree's base; the lead's note that #1527 addresses the cli one (and likely the config one, `TestAutonomyTierReader`, per the lead's M2 message) is their attribution on main — not re-measured here.
+
+**Residual-risk.** CI on the eventual PR runs on a clean runner against current origin/main: the 3 known failures' behavior there is governed by main's state (post-#1527), not this branch's base.
 
 ## §E.3 Run-phase Audit-Ready Signal
 

--- a/.moai/specs/SPEC-KANBAN-TODO-CLI-001/progress.md
+++ b/.moai/specs/SPEC-KANBAN-TODO-CLI-001/progress.md
@@ -132,6 +132,61 @@ Baseline was also `0 issues.` — zero NEW findings.
 
 **Residual-risk.** (1) The `internal/cli`/`internal/config`/`internal/hook` baseline failures were verified in THIS worktree; CI on the eventual PR runs on a clean runner where worktree-cwd-dependent behavior may differ. (2) M2's CLI verbs will exercise the store through real process concurrency (8-process `add`), a stronger test than the in-process concurrency test here.
 
+### M2 — CLI verbs (COMPLETE; orchestrator-direct per lead instruction after M1 PASS)
+
+Lead verdict on M1: **PASS** (2026-08-14, lead re-measured independently: the 3 evidence-test cluster green, coverage 87.3% reproduced, `GOOS=windows go vet` exit 0, and the source-level check that `rec.LastSeq++` exists only inside the `Mutate` callback — no issuance path outside the lock). M2 instruction: **implement directly, do not delegate** (2/2 manager-develop autocompact deaths vs. the surviving orchestrator-finished tail; M2 is low-uncertainty wiring over the finished store API).
+
+Deliverables: `internal/cli/todo.go` (226 lines — `newTodoCmd` + `add`/`list --json`/`done <n>`/`next [<n>] [--spec]`, registered via `init()`; exit 0/1; stdout structured, stderr human), `internal/cli/todo_test.go` (13 tests + re-exec helper).
+
+**E8 — RED (TDD, verbatim pre-GREEN).** Test file written first; captured against the no-implementation tree:
+
+```
+$ unset MOAI_KANBAN … && go vet ./internal/cli/
+internal/cli/todo_test.go:15:2: "path/filepath" imported and not used
+internal/cli/todo_test.go:29:9: undefined: newTodoCmd
+internal/cli/todo_test.go:44:33: undefined: todoBacklogPath
+…
+```
+
+One behavioral test fix mid-green: the 8-process helper initially reported ids via `t.Logf`, whose output the non-`-v` helper run drops — the id-parse assertion failed (`distinct issued ids printed = 0`); fixed by printing to process stdout. The helper then runs the FULL cobra verb (not `store.Add` directly), so AC-TODO-001's "concurrent `moai todo add` processes" is exercised on the binary's own code path.
+
+**E1 — M2 test matrix.**
+
+```
+$ unset MOAI_KANBAN … && go test ./internal/cli/ -run 'TestTodo' -count=3
+ok  	github.com/modu-ai/moai-adk/internal/cli	10.086s
+```
+
+13/13 pass ×3 consecutive runs: AC-TODO-001 (`TestTodoConcurrentAdd_8Processes` — 8 OS processes through the cobra `add` verb; `list --json` then reports 8 items with all texts, 8 distinct ids), AC-TODO-003 (`TestTodoList_LockFreeWhileForeignProcessHoldsLock` — foreign process parks inside `Mutate` holding `backlog.lock`; `list` succeeds; `TestTodoList_JSONStructured` — valid JSON, full record shape), AC-TODO-004 (`TestTodoDone_RemovesByID`, `TestTodoDone_MissReportedFileUntouched` — byte-identical on miss), AC-TODO-005 (`TestTodoNextBare_ReadOnlyOldestFirst` — oldest-first, file byte-identical), AC-TODO-006 (`TestTodoNextPick_OneLockedWrite` — exactly t2 `picked` + `spec_id: SPEC-X-001`, others untouched), AC-TODO-014 (`TestTodoCmd_NoAskUserQuestion` — static grep guard + negative control asserting the detector flags a synthetic violation), plus the acceptance §C edges: empty-text add rejected with no file write, out-of-range `done`/`next` miss reported + file byte-identical. M3/M4 ACs (015 skill/mirror, 016 full cross-platform sweep) remain pending.
+
+**E2 — Cross-platform.**
+
+```
+$ go build ./...                                          → exit 0
+$ GOOS=windows GOARCH=amd64 go build ./...                → exit 0
+$ GOOS=windows GOARCH=amd64 go vet ./internal/cli/... ./internal/kanban/... → exit 0 (BUILDS_VET_OK)
+```
+
+**E3 — Coverage (per AC §D "new store and CLI files").**
+
+```
+$ go test ./internal/cli/ ./internal/kanban/ -coverprofile=/tmp/t12-m2-cover.out
+$ go tool cover -func=… | grep -E 'todo\.go:|backlog_store\.go:'
+→ new-file avg: 94.1% over 20 funcs (todo.go: 75–100% per func incl. todoBacklogPath/done/normalize/init at 100%; backlog_store.go: Load/Add/acquireLock/normalize at 100%, Mutate 92.3%)
+```
+
+(internal/cli package-level shows 77.0% — the package aggregate over hundreds of pre-existing files; the AC's target is the new files, which the per-func profile above measures.)
+
+**E4 — Suite.** `./internal/kanban/...` ok (87.3%); `./internal/cli` fails only on the known pre-existing `TestHandleCodexReviewGate_LiveCodexBlocksInjectionAndKey` (M1-attributed baseline; lead notes PR #1527/t20 addresses it). No other failures.
+
+**E5 — Lint.** `golangci-lint run --timeout=2m` → `0 issues.` (unchanged baseline).
+
+**E6 — Commit.** M2 commit on `worktree-kanban-todo-cli` (this progress update rides it). Not pushed — awaiting lead M2 verdict per semi-autonomous progression.
+
+**Gaps.** (1) No built-binary smoke run (`moai todo` via the compiled binary) — the cobra surface is exercised in-process and through re-exec helpers of the same test binary; the binary wiring is init()-registration verified by compile. (2) `internal/cli` package-level coverage (77.0%) is below 85% but that aggregate is dominated by pre-existing files outside this SPEC's scope.
+
+**Residual-risk.** (1) The 8-process test's uniqueness assertion parses each helper's stdout (`t<n> <pos>`); a future output-format change to `add` needs the test's parser kept in step. (2) `resolveProjectDir()` (CLAUDE_PROJECT_DIR → cwd) is the path anchor; a caller invoking `moai todo` from outside the project without CLAUDE_PROJECT_DIR will target that outside directory's `.moai/state` — same behavior as the session/goal commands, noted not changed.
+
 ## §E.3 Run-phase Audit-Ready Signal
 
 _<pending run-phase>_

--- a/.moai/specs/SPEC-KANBAN-TODO-CLI-001/progress.md
+++ b/.moai/specs/SPEC-KANBAN-TODO-CLI-001/progress.md
@@ -264,6 +264,24 @@ Baseline (pre-M1, same tree family) was also "0 issues." — zero NEW findings a
 
 **Residual-risk.** CI on the eventual PR runs on a clean runner against current origin/main: the 3 known failures' behavior there is governed by main's state (post-#1527), not this branch's base.
 
+### Post-M4 — rebase + push + draft PR (lead-instructed)
+
+M4 verdict: **PASS**. Lead approved option (b): rebase onto origin/main, with the upstream +7-line todo.md change identified as `b689f492c` (#1526) — a batch-admission policy clause appended after the [HARD] block, which must SURVIVE the M3 shrink (it is queue policy, not file-manipulation guidance).
+
+**Rebase (measured)**: `git rebase origin/main` (24e2bd402) completed with NO manual conflicts — git's 3-way merge produced the intended union: the M3 rewrite WITH the upstream batch-admission paragraph (lines 78–83) and its `kanban-dispatch.md` § Batch admission cross-reference intact on both twins. Neither side was wholesale-adopted; both survive. New chain: `c839a9a4e`(M1) `99dc73916`(M2) `4deaf395c`(M3) `1f591cbeb`(M4).
+
+```
+$ cmp -s <local twin> <template twin> && echo TWINS_IDENTICAL   → TWINS_IDENTICAL (114 lines = 107 + upstream 7)
+$ go build ./...                                                 → BUILD_OK
+$ MOAI_TEMPLATE_LEAK_STRICT=1 go test ./internal/template/...    → ok 24.176s
+$ unset … && go test ./... -count=1 → --- FAIL ×2 (TestHandleCodexReviewGate…, TestPreTool_AstGrepSkipReasonSurfaces)
+$ go build / GOOS=windows build / GOOS=windows go vet ./...      → 0 / 0 / 0
+```
+
+**TestAutonomyTierReader resolved by #1527** exactly as the lead predicted — known failures 3 → 2 at rebase. Zero NEW failures on the rebased tree.
+
+**Push + PR**: branch `worktree-kanban-todo-cli` pushed; **draft PR #1529** opened (per the repo's draft-first discipline so auto-merge does not decide timing). PR body carries the milestone evidence summary + the known-failure table with per-failure attribution. Awaiting the lead's verification + undraft verdict. CodeRabbit review-limit caveat noted (row state ≠ verdict; read the comment body).
+
 ## §E.3 Run-phase Audit-Ready Signal
 
 _<pending run-phase>_

--- a/.moai/specs/SPEC-KANBAN-TODO-CLI-001/progress.md
+++ b/.moai/specs/SPEC-KANBAN-TODO-CLI-001/progress.md
@@ -187,6 +187,45 @@ $ go tool cover -func=… | grep -E 'todo\.go:|backlog_store\.go:'
 
 **Residual-risk.** (1) The 8-process test's uniqueness assertion parses each helper's stdout (`t<n> <pos>`); a future output-format change to `add` needs the test's parser kept in step. (2) `resolveProjectDir()` (CLAUDE_PROJECT_DIR → cwd) is the path anchor; a caller invoking `moai todo` from outside the project without CLAUDE_PROJECT_DIR will target that outside directory's `.moai/state` — same behavior as the session/goal commands, noted not changed.
 
+### M3 — Skill shrink + template mirror (COMPLETE; orchestrator-direct)
+
+Lead verdict on M2: **PASS** (2026-08-14; lead filled the binary-smoke gap personally: built binary `moai todo add "첫 카드"` → `t1 1` exit 0; 12 OS processes concurrent add → 12/12 items, 12 unique gapless ids, `last_seq: 12`; high-water live check `t1 t2 t3` → `done 3` → add → `t1 t2 t4` — no t3 reuse). M3 instruction: same-direct treatment, with the explicit warning NOT to `cp` the template twin (neutralized-variant hazard — CI catches SPEC-IDs/dates but not internal-vocabulary leaks).
+
+**Pre-edit state (measured before writing)**: `diff .claude/skills/moai/workflows/todo.md internal/template/templates/.claude/skills/moai/workflows/todo.md` → **byte-identical twins** (105 lines each). With no neutralized variant to preserve in THIS tree, applying the same rewrite to both files IS the same delta; the no-cp rule is honored in its substance (the variant check was performed, not assumed — research.md §8's claim re-verified on the actual M3 tree).
+
+**The delta (REQ-TODO-015 / D-h)**: shrink to "run the command" form. Preserved: queue philosophy ("one line of intent", "deliberately thin"), the operator-act header + kanban-dispatch cross-reference, the record-shape explanation (now framed as reading `list --json` output, with `last_seq` documented), the [HARD] operator-selection rule verbatim in intent, Boundaries, Outside-Kanban-Mode, all three cross-references. Removed: the direct file-manipulation instructions (the verbs table's model-driven Read→Write semantics, "Write the file atomically (write a sibling temp file, then rename)…"), and the obsolete "any other argument form is treated as a description" rule (the real CLI takes explicit subcommands). Added: the mapping table of the five real CLI invocations and the "do not read or write the file directly" instruction (the whole point of M1+M2). 105 → 119 lines.
+
+**AC-TODO-015 verification (each command + output)**:
+
+```
+$ diff .claude/skills/moai/workflows/todo.md internal/template/templates/.claude/skills/moai/workflows/todo.md && echo TWINS_STILL_IDENTICAL
+TWINS_STILL_IDENTICAL                                    ← same delta on both twins
+
+$ grep -n 'SPEC-KANBAN\|SPEC-TODO\|2026-' <both twins>
+(no matches; exit 1)                                     ← no SPEC ids, no internal dates
+
+$ grep -nE 'Write the file|temp file|then rename|Read.*backlog\.json.*Write' <both twins>
+(no matches; exit 1)                                     ← removed instruction tokens absent (grep-for-removals clause)
+
+$ make build → "catalog.yaml updated successfully (12407 bytes)", MAKE_EXIT=0
+$ git status --porcelain internal/template/catalog.yaml
+(no output)                                              ← regenerated catalog is byte-identical: the catalog's
+                                                           hash subject set does not include workflow skills (grep 'todo'
+                                                           in catalog.yaml → no entry). B5's hazard does not arise this
+                                                           time; recorded as verified-absent, not assumed-absent.
+
+$ MOAI_TEMPLATE_LEAK_STRICT=1 go test ./internal/template/... -count=1
+ok  	github.com/modu-ai/moai-adk/internal/template	44.167s  ← neutrality gate (CI-equivalent strict mode) exit 0
+```
+
+Docs-vs-verbs cross-check (lead checklist item 5): cobra `Use:` strings in todo.go (`add <text>`, `list`, `done <n>`, `next [<n>]`) vs the skill's command table — all five documented invocations match the implemented surface (grep output captured above).
+
+**Working-tree hygiene note**: the full-suite runs from M2 verification had rewritten `SPEC-HOOK-PRETOOL-PERF-001/{baseline,postchange}.md` in place (the known fixture-rewrite side effect); both were `git checkout --`-restored before the M3 commit — only the intended paths are in it.
+
+**Gaps.** (1) The shrunk skill's behavioral effect (the model actually running `moai todo` instead of Read→Write) is verified by document inspection, not by an A/B model run — the skill-ab-testing methodology was out of M3's milestone scope (plan.md §F keeps M3 a documentation delta). (2) No 4-locale surface touched: the todo skill exists only in English (verified — no `todo.*.md` locale twins exist to mirror).
+
+**Residual-risk.** The catalog-parity conclusion holds for THIS template state; if a future change adds workflow skills to the catalog's hash subject set, the B5 commit obligation revives for future edits of this file.
+
 ## §E.3 Run-phase Audit-Ready Signal
 
 _<pending run-phase>_

--- a/.moai/specs/SPEC-KANBAN-TODO-CLI-001/research.md
+++ b/.moai/specs/SPEC-KANBAN-TODO-CLI-001/research.md
@@ -1,0 +1,77 @@
+# research.md — SPEC-KANBAN-TODO-CLI-001
+
+Verified evidence gathered during plan phase (2026-08-14). Every claim below names the command or file read that produced it. Nothing here is inferred from text patterns alone.
+
+## 1. The CLI subcommand does not exist
+
+- `moai todo` → `Unknown command "todo"` (orchestrator probe, twice, 2026-08-14).
+- `ls internal/cli/todo*.go` → no matches (re-confirmed this session). No `newTodoCmd` factory exists; `internal/cli/root.go` registers sibling commands via `rootCmd.AddCommand(newXxxCmd())` factories (`newConstitutionCmd()`, `newStateCmd()`, `newChainCmd()`, `newHarnessRouterCmd()`, …) — a `newTodoCmd()` registered there is the repo convention for the new verb.
+- `grep -n 'Backlog' internal/kanban/*.go` → only `ColumnBacklog` (the board column enum). No backlog-store symbols exist yet; the name space is free.
+
+## 2. The current surface races (the motivating incident)
+
+- `.moai/state/kanban/backlog.json` (read in full, 2026-08-14): card t12 records the incident — "3 cards lost + t4/t5/t6 ID collision". Observable in the same file: t4 is absent while t13–t19 exist; id sequence is non-monotonic (t1, t2, t10, t5, t8, t6, t7, t11, t12, t13–t19). t6 and t7 both carry `[DROPPED — …]` prefixes — post-hoc human repair of collided entries.
+- `.claude/skills/moai/workflows/todo.md` instructs the model to Read and Write `backlog.json` directly, with "Write the file atomically (write a sibling temp file, then rename)". The rename protects a crash mid-write; it does not close the minutes-wide read→write window between sessions. Five sessions share this checkout (kanban mode), so concurrent model writers are the normal case, not an edge.
+- Skill contract lines preserved verbatim into REQ-TODO-013/014: "A missing file is an empty queue, not an error. A malformed file is reported and left untouched — never silently reset, because the operator's intent is the one thing here that cannot be regenerated." Also: ids are "never reused after removal"; `picked` items persist; `done` removes the row.
+
+## 3. Record shape (load compatibility is mandatory)
+
+Production file (`.moai/state/kanban/backlog.json`, v1):
+
+```json
+{"version":1,"items":[{"id":"t1","text":"…","added_at":"<RFC3339>","spec_id":null,"state":"picked"}]}
+```
+
+`state` observed values: `queued`, `picked`, `dropped`. `spec_id` is `null` or a SPEC-ID string. The store must read this shape unchanged; the only permitted change is the additive high-water mark (plan.md §D decision c).
+
+## 4. Lock substrate — internal/kanban (the recommended reuse)
+
+Read in full this session:
+
+- `internal/kanban/board_lock.go` (137 lines): `acquireBoardLockImpl(lockPath)` is **path-parameterized** — the substrate is not board-specific. `BoardLockOwner{PID, CreatedAt}` recorded in the artifact at acquisition. Header states the substrate "reuses the repository's existing cross-process per-scope lock PATTERN (internal/spec/lock.go and its platform counterparts: flock on Unix, atomic-create on Windows); internal/lockfile's in-process mutex is neither used nor upgraded."
+- `internal/kanban/board_lock_unix.go` (56 lines, read in full): `unix.Open(O_CREAT|O_RDWR|O_CLOEXEC, 0o644)` → `flock(LOCK_EX|LOCK_NB)` → on failure close fd + `ErrBoardLockHeld` (loser writes nothing to the artifact); on success `ftruncate(0)` + write owner record. Kernel releases the flock when the fd closes (incl. process death), so a dead Unix holder blocks nothing — the stale-lock requirement is a Windows-substrate concern (board_lock_clear_windows.go exists for the board).
+- `internal/kanban/board_store.go` (290 lines, read in full): `acquireBoardLockSerialized` = 25 ms × 40 retries ≈ 1 s bounded window, then surfaces the error — "two concurrent transitions must BOTH reach the admission decision in turn… The window is bounded so a genuinely stuck holder surfaces as an error instead of a hang." `WriteBoardState` shape: `requireLeadRole` → serialized acquire → defer release with error join ("mutation landed but lock release failed" — Windows release removes the artifact) → `LoadBoard` (absent = empty board legal; unreadable = `ErrBoardUnknown`, repairs nothing) → mutate callback → validation sweep → `writeBoardAtomic` (`MarshalIndent` + `\n`, `os.CreateTemp(dir, ".board-*.tmp")`, `atomicfile.Replace`).
+- `internal/kanban/board.go`: `LoadBoard` reads via `atomicfile.ReadFile` (absorbs the Windows delete-pending window on the read side); "the read path performs no repair — recovery is an explicit operator-visible act, never a fallback a read takes (AP-21)."
+
+The backlog reuses the **substrate** (path-parameterized acquire + serialized wrapper + atomic write), not `WriteBoardState` itself: the board entry point is welded to `requireLeadRole`, which the backlog must NOT apply (plan.md §D decision b).
+
+## 5. Lock substrate — internal/session/registry.go (pattern reference, not the substrate)
+
+`Registry.withLock` (registry.go ~449–533, read earlier this session): MkdirAll parent → in-process path-keyed mutex (NB-flock kernel-fairness starvation guard, REQ-CFS3-001) → jittered NB-flock retry to a deadline (`ErrLockTimeout`) → read → mutate callback → `sort.Slice` (deterministic output) → `writeAtomic` → release. Reads (`Query`) bypass the lock — eventual consistency (AP-MSC-002). The in-process mutex layer is registry-specific; importing `internal/session` from `internal/kanban` would be a reverse dependency. The backlog takes the **shape** (lock → read → mutate → atomic write → release; reads lock-free) from here and the **substrate** from internal/kanban.
+
+## 6. Path layout — backlog and board are different directories
+
+- Board: `boardDirSegments = []string{".moai", "state", "kanban-board"}` (board.go) — deliberately distinct from the session record's `stateDirSegments` (AP-24).
+- Backlog: `.moai/state/kanban/` (the existing production file's directory). The new lock artifact is a sibling: `.moai/state/kanban/backlog.lock`. No board path constant is reused or changed.
+
+## 7. atomicfile surface (verified exports)
+
+`internal/atomicfile/replace.go`: `Replace(oldpath, newpath string) error`, `ReadFile(path string) ([]byte, error)` (with `read_unix.go`/`read_windows.go` platform split absorbing the Windows delete-pending race), `Claim(path, perm) error`. Same-directory temp + rename; rename(2) is atomic only within one filesystem (AP-20 / REQ-KB-018 precedent).
+
+## 8. Template twin status
+
+`diff .claude/skills/moai/workflows/todo.md internal/template/templates/.claude/skills/moai/workflows/todo.md` → **identical** (and both clean in `git status`). So today there is no intentionally-neutralized divergence between the twins (the hazard memory warns about from other rules); run phase applies the SAME delta to both and re-verifies with `MOAI_TEMPLATE_LEAK_STRICT=1 go test` (template neutrality: no SPEC ids, no internal dates — the shrunk skill must not cite SPEC-KANBAN-TODO-CLI-001). `make build` re-embeds templates (`//go:embed all:templates` in `internal/template/embed.go`; catalog.yaml regeneration must be committed).
+
+## 9. CLI conventions (internal/cli/CLAUDE.md, read earlier)
+
+- No-prompt static guard: "every interactive-shaped subcommand needs the equivalent grep-based test" — `TestNew_NoAskUserQuestion` precedent.
+- Cobra registration via `newXxxCmd()` factory + `rootCmd.AddCommand` (duplicate `Use:` panics at runtime).
+- Exit codes 0/1/2; stdout structured for `--json`, stderr human-readable; `filepath.Abs` for user paths; env names as constants in `internal/config/envkeys.go`.
+- Cross-platform claim discipline (CLAUDE.local.md §6): `GOOS=windows go build ./...` does NOT compile `_test.go`; the claim "compiles on Windows" requires `GOOS=windows go vet ./...` with cited exit code. This becomes a run-phase AC.
+
+## 10. kanban-dispatch.md dependency on these verbs
+
+`.claude/rules/moai/workflow/kanban-dispatch.md` (template copy re-read this session) names `/moai todo` as THE entry mechanism: "`/moai todo \"<description>\"` appends an item… `/moai todo` alone lists the queue. After a `/clear`, the lead presents the queue through `AskUserQuestion` and the operator picks." The shrunk skill keeps pointing at this rule; the verbs must therefore support exactly: append, list, present-for-selection (read-only `next`), and pick (`next <n> [--spec]`). The rule's "The lead never picks for the operator" is why REQ-TODO-005 keeps bare `next` read-only.
+
+## 11. SPEC ID pre-write self-check (executed)
+
+```bash
+ID="SPEC-KANBAN-TODO-CLI-001"
+[[ "$ID" =~ ^SPEC(-[A-Z][A-Z0-9]*)+-[0-9]{3}$ ]] && echo PASS || echo FAIL
+```
+
+Verbatim output: `PASS`. Existing `SPEC-KANBAN-*` directories (BOARD / BOOTSTRAP / RENAME / WORKTREE-001) contain no TODO-CLI — id is unique.
+
+## 12. Release-target basis for `phase`
+
+Recent main commit `2c40e8106` "chore(version): align ldflags fallback and project config to v3.1.0-rc.2" — the next unreleased version is v3.1.0, hence `phase: "v3.1.0 target"` (phase is a release target, never a lifecycle stage token).

--- a/.moai/specs/SPEC-KANBAN-TODO-CLI-001/spec.md
+++ b/.moai/specs/SPEC-KANBAN-TODO-CLI-001/spec.md
@@ -1,0 +1,110 @@
+---
+id: SPEC-KANBAN-TODO-CLI-001
+title: "moai todo CLI subcommand with lock-guarded backlog store"
+version: "0.1.1"
+status: in-progress
+created: 2026-08-14
+updated: 2026-08-14
+author: manager-spec
+priority: P1
+phase: "v3.1.0 target"
+module: internal/kanban
+lifecycle: spec-anchored
+tags: kanban, cli, backlog, concurrency
+tier: M
+---
+
+# SPEC-KANBAN-TODO-CLI-001 — moai todo CLI subcommand with lock-guarded backlog store
+
+## §A Background
+
+`/moai todo` is the operator's entry mechanism into the kanban board (`.claude/rules/moai/workflow/kanban-dispatch.md` § Entry into the board is an operator act). Today no `moai todo` CLI subcommand exists (verified: `moai todo` → `Unknown command "todo"`; zero `todo*.go` files in `internal/cli/`). The skill document (`.claude/skills/moai/workflows/todo.md`) therefore instructs the model to Read and Write `.moai/state/kanban/backlog.json` directly.
+
+With five concurrent sessions on one checkout, the gap between a session's Read and its Write is measured in minutes. Every concurrent writer resolves to last-writer-wins. On 2026-08-14 this produced a real incident: 3 cards lost and an ID collision cluster (t4 absent from the queue; visible non-monotonic id sequence t1, t2, t10, t5, t8, t6, t7, t11, t12, t13–t19). The skill's "temp file + rename" instruction protects only against a crash mid-write; it does nothing about the read-modify-write race.
+
+The fix is not a new design: the repository already owns the pattern. `internal/kanban` (SPEC-KANBAN-BOARD-001) carries a path-parameterized cross-process lock substrate (flock on Unix, atomic-create on Windows) and a guarded write path (lock → load → mutate → atomic replace); `internal/session/registry.go` `Registry.withLock` is the same shape. This SPEC applies that substrate to the backlog queue and replaces the skill's model-driven Read→Write cycle with a real `moai todo` CLI.
+
+## §B Goals
+
+- Eliminate the backlog read-modify-write race across concurrent sessions.
+- Issue item ids under the lock so concurrent adds cannot collide and removed ids are never reused.
+- Keep the on-disk backlog record load-compatible with the existing version-1 file.
+- Reduce the todo skill to a "run the command" form and mirror the delta to the template source.
+
+## §C Requirements (GEARS)
+
+### C.1 Command surface
+
+- **REQ-TODO-001** (Ubiquitous) The `moai todo` command shall expose the verbs `add`, `list`, `done`, and `next` operating on the backlog queue at `.moai/state/kanban/backlog.json`.
+- **REQ-TODO-002** (Event-driven) **When** the operator runs `moai todo add "<text>"`, the command shall append the item to the queue under the lock and print the issued id and its queue position.
+- **REQ-TODO-003** (Event-driven) **When** the operator runs `moai todo list`, the command shall render the queue without taking the lock and shall support a `--json` flag emitting the structured records.
+- **REQ-TODO-004** (Event-driven) **When** the operator runs `moai todo done <n>`, the command shall remove the addressed row from the queue under the lock; a bare `<n>` argument shall be normalized to the item id `t<n>` (explicit id addressing is the preferred form because queue positions move under concurrent adds).
+- **REQ-TODO-005** (Event-driven) **When** the operator runs `moai todo next` with no argument, the command shall print the queued items oldest-first as read-only candidates — the selection among them remains the operator's act performed through the lead session's question channel; **and when** the operator runs `moai todo next <n> [--spec <SPEC-ID>]`, the command shall mark the addressed item `picked` (attaching `spec_id` when given) as a single locked write.
+
+### C.2 Store and concurrency
+
+- **REQ-TODO-006** (Ubiquitous) The backlog store shall serialize each entire read-modify-write of the backlog file under a cross-process lock spanning load, mutate, and atomic write.
+- **REQ-TODO-007** (Ubiquitous) The backlog store shall reuse the `internal/kanban` lock substrate with a sibling lock artifact at `.moai/state/kanban/backlog.lock`, acquired with a bounded retry window (~1 s) before contention surfaces as an explicit error naming the lock artifact path.
+- **REQ-TODO-008** (Ubiquitous) The backlog store shall issue every new item id under the lock from a persisted high-water mark, such that ids are unique under concurrent adds and never reused after a row's removal (`done` removes rows, so max-present-id derivation alone would regress).
+- **REQ-TODO-009** (Capability gate) **Where** the backlog file predates the high-water field, the store shall derive the initial high-water mark from the maximum existing item id, preserving load compatibility with version-1 files.
+- **REQ-TODO-010** (Ubiquitous) The backlog store shall persist writes through same-directory temp file plus atomic rename (the `internal/atomicfile` substrate).
+- **REQ-TODO-011** (Ubiquitous) The backlog store shall not apply the board's lead-role guard: the backlog is the operator's queue and any session may write it. (Deliberate contrast with `internal/kanban/board_store.go` `requireLeadRole`, which exists because the board has exactly one writer; the backlog has many.)
+
+### C.3 File contracts (preserved verbatim from the todo skill)
+
+- **REQ-TODO-012** (Event-driven) **When** the backlog file is absent, every verb shall treat the queue as empty — `list` and `next` report an empty queue, and `add` creates a version-1 file — never an error; **and when** the backlog file is malformed, every verb shall report the error and leave the file untouched, never silently resetting it, because the operator's queued intent is the one thing here that cannot be regenerated.
+
+### C.4 Record shape
+
+- **REQ-TODO-013** (Ubiquitous) The backlog store shall preserve the existing version-1 record shape — `{"version":1,"items":[{"id","text","added_at","spec_id","state"}]}` with `state ∈ {queued, picked, dropped}` — changing it only additively (the high-water mark, per REQ-TODO-009).
+
+### C.5 CLI discipline
+
+- **REQ-TODO-014** (Ubiquitous) The `moai todo` command shall not prompt: it is headless-safe, asks no questions, and follows the `internal/cli` conventions (structured stdout for `--json`, human-readable stderr, exit 0/1/2, no AskUserQuestion anywhere in the package).
+
+### C.6 Skill and template surfaces
+
+- **REQ-TODO-015** (Ubiquitous) The todo skill (`.claude/skills/moai/workflows/todo.md`) shall be reduced to a "run the command" form — the queue philosophy, the boundaries, the kanban-dispatch cross-reference, and the [HARD] operator-selection rule are preserved, and the direct Read→Write instructions and the temp-file/rename guidance are removed — and the same skill delta shall be applied to the template twin (`internal/template/templates/.claude/skills/moai/workflows/todo.md`) and re-embedded via `make build`, keeping template neutrality (no SPEC ids, no internal dates).
+
+### C.7 Platform
+
+- **REQ-TODO-016** (Ubiquitous) The backlog store shall compile and behave on Windows through the lock substrate's platform split (flock on Unix, atomic-create on Windows), verified by `GOOS=windows` build and vet.
+
+## §D Constraints
+
+- No new module dependencies; the substrate is in-package (`internal/kanban`) plus `internal/atomicfile`.
+- The kanban board state store (`board.json`, `WriteBoardState`, `requireLeadRole`) is NOT touched by this SPEC.
+- Environment variable names, if any, must be constants in `internal/config/envkeys.go` per repo hardcoding policy.
+
+## §E Out of Scope
+
+### Out of Scope — Stale-lock automatic clearing
+
+- Automatic stale-lock detection/clearing for `backlog.lock` is NOT built here. Contention beyond the bounded retry window surfaces as an explicit error naming the lock path; clearing a stale artifact is a deliberate operator-visible act (the board's `ClearStaleBoardLock` pattern shows the shape a future SPEC would reuse).
+- On Unix the flock substrate releases automatically when the holder process dies, so the stale artifact case is a Windows-substrate concern deferred with this boundary.
+
+### Out of Scope — Kanban board state store changes
+
+- `internal/kanban` board surfaces (`board.go`, `board_store.go`, `board_recover.go`, WIP limits, role guards) are untouched. The backlog queue is a separate file with separate ownership rules (REQ-TODO-011).
+
+### Out of Scope — Backlog schema redesign
+
+- No version bump and no new per-item fields. The only schema change is the additive high-water mark (REQ-TODO-009); everything else stays load-compatible with the existing production file.
+
+### Out of Scope — Skill workflow redesign
+
+- The todo skill is shrunk, not redesigned. Queue philosophy, boundaries, and the operator-selection [HARD] rule survive verbatim in intent; no new workflow behavior is added to the skill.
+
+## §F History
+
+| Version | Date | Author | Change |
+|---------|------|--------|--------|
+| 0.1.0 | 2026-08-14 | manager-spec | Initial plan-phase draft (kanban card t12). |
+| 0.1.1 | 2026-08-14 | manager-spec | Plan-audit D2 consolidation: 19 → 16 REQs. Merged pairs: 005+006 → 005 (two When-branches, `next` read-only + `next <n>` pick), 013+014 → 012 (two When-branches, missing/malformed file contract), 017+018 → 015 (skill shrink + template mirror, both surfaces in one REQ). Renumbered: 007-012 → 006-011, 015-016 → 013-014, 019 → 016. All behaviors preserved verbatim; AC set unchanged (15). |
+
+## §G Cross-References
+
+- Kanban card t12 (`.moai/state/kanban/backlog.json`) — motivating incident and scope source.
+- SPEC-KANBAN-BOARD-001 — the lock substrate and guarded-write precedent this SPEC reuses.
+- `.claude/rules/moai/workflow/kanban-dispatch.md` § Entry into the board — the operator-act doctrine the verbs serve.
+- `.claude/skills/moai/workflows/todo.md` — the surface being shrunk (current local and template twins are byte-identical, verified by diff).

--- a/internal/cli/todo.go
+++ b/internal/cli/todo.go
@@ -1,0 +1,225 @@
+// todo.go — SPEC-KANBAN-TODO-CLI-001 M2: the `moai todo` command surface.
+//
+// Thin cobra wiring over internal/kanban.BacklogStore: every mutation
+// delegates to the store's locked Mutate path, reads go through the
+// lock-free Load. The verbs serve the kanban dispatch protocol's entry rule
+// (`/moai todo` is the operator's act — the lead never picks for the
+// operator): `add` and `done` mutate, `list` and bare `next` observe, and
+// `next <n> [--spec]` records the operator's pick as one locked write.
+//
+// SUBAGENT BOUNDARY (C-HRA-008 / REQ-TODO-014): this command never prompts.
+// It is headless-safe: positional arguments + flags in, one structured
+// stdout line out, human-readable errors on stderr, exit 0/1.
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/modu-ai/moai-adk/internal/kanban"
+)
+
+// todoBacklogPath returns the backlog file location under root — the same
+// .moai/state/kanban/backlog.json the todo skill and the dispatch protocol
+// name (REQ-TODO-001).
+func todoBacklogPath(root string) string {
+	return filepath.Join(root, ".moai", "state", "kanban", "backlog.json")
+}
+
+// newTodoCmd creates the `moai todo` parent command.
+func newTodoCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "todo",
+		Short: "Operate the kanban backlog queue",
+		Long: `Operate the kanban backlog queue at .moai/state/kanban/backlog.json.
+
+The backlog is the operator's queue: entry into the board is the operator's
+act (add), and picking the next card is the operator's act too (next <n>).
+Mutations serialize on a sibling cross-process lock; reads are lock-free.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+		GroupID: "tools",
+	}
+	cmd.AddCommand(newTodoAddCmd(), newTodoListCmd(), newTodoDoneCmd(), newTodoNextCmd())
+	return cmd
+}
+
+// newTodoAddCmd — `moai todo add "<text>"` (REQ-TODO-002): append under the
+// lock, print the issued id and its 1-based queue position.
+func newTodoAddCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "add <text>",
+		Short: "Append a card to the backlog queue",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			text := args[0]
+			if strings.TrimSpace(text) == "" {
+				return fmt.Errorf("todo add: text must be non-empty")
+			}
+			store := kanban.NewBacklogStore(todoBacklogPath(resolveProjectDir()))
+			item, pos, err := store.Add(text)
+			if err != nil {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Error: %v\n", err)
+				return err
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s %d\n", item.ID, pos)
+			return nil
+		},
+	}
+}
+
+// newTodoListCmd — `moai todo list [--json]` (REQ-TODO-003): render the
+// queue lock-free; --json emits the structured records.
+func newTodoListCmd() *cobra.Command {
+	var jsonOutput bool
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "Render the backlog queue (lock-free)",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			store := kanban.NewBacklogStore(todoBacklogPath(resolveProjectDir()))
+			rec, err := store.Load()
+			if err != nil {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Error: %v\n", err)
+				return err
+			}
+			out := cmd.OutOrStdout()
+			if jsonOutput {
+				data, err := json.Marshal(rec)
+				if err != nil {
+					return err
+				}
+				_, _ = fmt.Fprintln(out, string(data))
+				return nil
+			}
+			if len(rec.Items) == 0 {
+				_, _ = fmt.Fprintln(out, "queue is empty")
+				return nil
+			}
+			for _, it := range rec.Items {
+				_, _ = fmt.Fprintf(out, "%s\t%s\t%s\n", it.ID, it.State, it.Text)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false,
+		"Emit the backlog records as JSON on stdout")
+	return cmd
+}
+
+// newTodoDoneCmd — `moai todo done <n>` (REQ-TODO-004): remove the
+// addressed row under the lock. A bare <n> is normalized to the item id
+// t<n>; the explicit id is the preferred form because queue positions move
+// under concurrent adds.
+func newTodoDoneCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "done <n>",
+		Short: "Remove a card from the backlog queue by id",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id := normalizeTodoRef(args[0])
+			store := kanban.NewBacklogStore(todoBacklogPath(resolveProjectDir()))
+			if err := store.Mutate(func(rec *kanban.BacklogRecord) error {
+				for i, it := range rec.Items {
+					if it.ID == id {
+						rec.Items = append(rec.Items[:i], rec.Items[i+1:]...)
+						return nil
+					}
+				}
+				// Refused mutation: Mutate writes nothing, so the file stays
+				// byte-identical on a miss.
+				return fmt.Errorf("no backlog item %s", id)
+			}); err != nil {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Error: %v\n", err)
+				return err
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "done %s\n", id)
+			return nil
+		},
+	}
+}
+
+// newTodoNextCmd — `moai todo next [<n>] [--spec <SPEC-ID>]` (REQ-TODO-005).
+// Bare: print the queued items oldest-first as read-only candidates — the
+// pick stays the operator's act. With <n>: mark the addressed item picked
+// (attaching spec_id when given) as a single locked write.
+func newTodoNextCmd() *cobra.Command {
+	var specID string
+	cmd := &cobra.Command{
+		Use:   "next [<n>]",
+		Short: "List queued cards (bare) or pick one (<n>)",
+		Long: `Bare ` + "`moai todo next`" + ` prints the queued items oldest-first as
+read-only candidates — the selection remains the operator's act performed
+through the lead session's question channel. ` + "`moai todo next <n> [--spec <SPEC-ID>]`" + `
+marks the addressed item picked (attaching spec_id when given) as one
+locked write.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			store := kanban.NewBacklogStore(todoBacklogPath(resolveProjectDir()))
+			out := cmd.OutOrStdout()
+
+			if len(args) == 0 {
+				rec, err := store.Load()
+				if err != nil {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Error: %v\n", err)
+					return err
+				}
+				queued := 0
+				for _, it := range rec.Items {
+					if it.State != kanban.BacklogStateQueued {
+						continue
+					}
+					queued++
+					_, _ = fmt.Fprintf(out, "%s\t%s\n", it.ID, it.Text)
+				}
+				if queued == 0 {
+					_, _ = fmt.Fprintln(out, "queue is empty")
+				}
+				return nil
+			}
+
+			id := normalizeTodoRef(args[0])
+			if err := store.Mutate(func(rec *kanban.BacklogRecord) error {
+				for i := range rec.Items {
+					if rec.Items[i].ID == id {
+						rec.Items[i].State = kanban.BacklogStatePicked
+						if specID != "" {
+							// Recorded as-is: the store is not a SPEC registry;
+							// normalization is out of scope (acceptance.md §C).
+							spec := specID
+							rec.Items[i].SpecID = &spec
+						}
+						return nil
+					}
+				}
+				return fmt.Errorf("no backlog item %s", id)
+			}); err != nil {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Error: %v\n", err)
+				return err
+			}
+			_, _ = fmt.Fprintf(out, "picked %s\n", id)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&specID, "spec", "",
+		"SPEC-ID to attach when picking (recorded verbatim)")
+	return cmd
+}
+
+// normalizeTodoRef maps a bare <n> argument to the item id t<n>; an explicit
+// id (t<n>) passes through unchanged (REQ-TODO-004's normalization rule).
+func normalizeTodoRef(arg string) string {
+	if !strings.HasPrefix(arg, "t") {
+		return "t" + arg
+	}
+	return arg
+}
+
+func init() {
+	rootCmd.AddCommand(newTodoCmd())
+}

--- a/internal/cli/todo_test.go
+++ b/internal/cli/todo_test.go
@@ -1,0 +1,454 @@
+// todo_test.go — SPEC-KANBAN-TODO-CLI-001 M2 acceptance tests (CLI verbs).
+//
+// Covers the CLI-process-level ACs the store-level M1 suite defers:
+// AC-TODO-001 (concurrent add loses nothing), AC-TODO-003 (list lock-free
+// + --json), AC-TODO-004 (done by id under lock), AC-TODO-005 (bare next
+// read-only), AC-TODO-006 (next <n> --spec one locked write), AC-TODO-014
+// (no-prompt static guard), plus the acceptance.md §C edge cases.
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/modu-ai/moai-adk/internal/kanban"
+)
+
+// runTodo executes the todo cobra command against args and returns
+// (stdout, stderr, error). Exit-code semantics: a non-nil error is the
+// command's failure (cobra maps it to exit 1).
+func runTodo(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	cmd := newTodoCmd()
+	var out, errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return out.String(), errBuf.String(), err
+}
+
+// todoFixture prepares a project dir whose backlog the command resolves via
+// CLAUDE_PROJECT_DIR, and returns the store for seeding/verification.
+func todoFixture(t *testing.T) (root string, store *kanban.BacklogStore) {
+	t.Helper()
+	root = t.TempDir()
+	t.Setenv("CLAUDE_PROJECT_DIR", root)
+	store = kanban.NewBacklogStore(todoBacklogPath(root))
+	return root, store
+}
+
+func TestTodoAdd_PrintsIDAndPosition(t *testing.T) {
+	_, store := todoFixture(t)
+
+	out, _, err := runTodo(t, "add", "first card")
+	if err != nil {
+		t.Fatalf("add first: %v", err)
+	}
+	if got := strings.TrimSpace(out); got != "t1 1" {
+		t.Errorf("first add output = %q, want %q", got, "t1 1")
+	}
+
+	out, _, err = runTodo(t, "add", "second card")
+	if err != nil {
+		t.Fatalf("add second: %v", err)
+	}
+	if got := strings.TrimSpace(out); got != "t2 2" {
+		t.Errorf("second add output = %q, want %q", got, "t2 2")
+	}
+
+	rec, err := store.Load()
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if rec.Version != 1 || len(rec.Items) != 2 {
+		t.Errorf("record = version %d, %d items; want version 1, 2 items", rec.Version, len(rec.Items))
+	}
+}
+
+func TestTodoAdd_EmptyText_RejectedNoWrite(t *testing.T) {
+	root, _ := todoFixture(t)
+
+	_, _, err := runTodo(t, "add", "")
+	if err == nil {
+		t.Fatal("empty-text add must fail")
+	}
+	if _, statErr := os.Stat(todoBacklogPath(root)); !os.IsNotExist(statErr) {
+		t.Errorf("backlog file must not exist after rejected add (stat err = %v)", statErr)
+	}
+}
+
+func TestTodoList_EmptyQueueIsNotAnError(t *testing.T) {
+	_, _ = todoFixture(t)
+
+	out, _, err := runTodo(t, "list")
+	if err != nil {
+		t.Fatalf("list on missing file: %v", err)
+	}
+	if !strings.Contains(out, "empty") {
+		t.Errorf("empty-queue render = %q, want it to report the empty queue", out)
+	}
+}
+
+func TestTodoList_JSONStructured(t *testing.T) {
+	_, _ = todoFixture(t)
+	if _, _, err := runTodo(t, "add", "alpha"); err != nil {
+		t.Fatalf("seed add: %v", err)
+	}
+	if _, _, err := runTodo(t, "add", "beta"); err != nil {
+		t.Fatalf("seed add: %v", err)
+	}
+	if _, _, err := runTodo(t, "next", "1", "--spec", "SPEC-X-001"); err != nil {
+		t.Fatalf("seed pick: %v", err)
+	}
+
+	out, _, err := runTodo(t, "list", "--json")
+	if err != nil {
+		t.Fatalf("list --json: %v", err)
+	}
+	if !json.Valid([]byte(out)) {
+		t.Fatalf("list --json output is not valid JSON: %q", out)
+	}
+	var rec kanban.BacklogRecord
+	if err := json.Unmarshal([]byte(out), &rec); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(rec.Items) != 2 || rec.Items[0].State != kanban.BacklogStatePicked {
+		t.Errorf("json items = %+v; want 2 items with t1 picked", rec.Items)
+	}
+}
+
+// TestTodoList_LockFreeWhileForeignProcessHoldsLock — AC-TODO-003: list
+// succeeds while backlog.lock is held by a separate OS process (the helper
+// parks inside a Mutate, holding the lock for ~1.2s).
+func TestTodoList_LockFreeWhileForeignProcessHoldsLock(t *testing.T) {
+	if runtimeIsWindowsForTodo() {
+		t.Skip("helper re-exec exercised on unix; windows covered by GOOS=windows build/vet")
+	}
+	root, store := todoFixture(t)
+	if _, _, err := runTodo(t, "add", "held card"); err != nil {
+		t.Fatalf("seed add: %v", err)
+	}
+
+	helper := exec.Command(os.Args[0], "-test.run=TestTodoHelperProcess", "--")
+	helper.Env = append(os.Environ(),
+		"MOAI_TODO_HELPER=hold-lock",
+		"CLAUDE_PROJECT_DIR="+root,
+	)
+	if err := helper.Start(); err != nil {
+		t.Fatalf("start lock-holder: %v", err)
+	}
+	defer func() { _ = helper.Wait() }()
+
+	// Let the helper acquire the lock before listing.
+	time.Sleep(400 * time.Millisecond)
+
+	out, _, err := runTodo(t, "list")
+	if err != nil {
+		t.Fatalf("list must succeed while a foreign process holds backlog.lock: %v", err)
+	}
+	if !strings.Contains(out, "held card") {
+		t.Errorf("list output = %q, want the seeded card rendered", out)
+	}
+	if _, err := store.Load(); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+}
+
+func TestTodoDone_RemovesByID(t *testing.T) {
+	_, store := todoFixture(t)
+	for _, text := range []string{"one", "two", "three"} {
+		if _, _, err := runTodo(t, "add", text); err != nil {
+			t.Fatalf("seed add: %v", err)
+		}
+	}
+
+	if _, _, err := runTodo(t, "done", "3"); err != nil {
+		t.Fatalf("done 3: %v", err)
+	}
+	rec, err := store.Load()
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(rec.Items) != 2 {
+		t.Fatalf("items after done = %d, want 2", len(rec.Items))
+	}
+	for _, it := range rec.Items {
+		if it.ID == "t3" {
+			t.Errorf("t3 still present after done")
+		}
+	}
+}
+
+func TestTodoDone_MissReportedFileUntouched(t *testing.T) {
+	_, _ = todoFixture(t)
+	if _, _, err := runTodo(t, "add", "only"); err != nil {
+		t.Fatalf("seed add: %v", err)
+	}
+	root := os.Getenv("CLAUDE_PROJECT_DIR")
+	real := todoBacklogPath(root)
+	before, err := os.ReadFile(real)
+	if err != nil {
+		t.Fatalf("read before: %v", err)
+	}
+
+	_, _, err = runTodo(t, "done", "t3")
+	if err == nil {
+		t.Fatal("done on a missing id must fail")
+	}
+	after, err := os.ReadFile(real)
+	if err != nil {
+		t.Fatalf("read after: %v", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Error("file changed on a missed done; must be byte-identical")
+	}
+}
+
+func TestTodoNextBare_ReadOnlyOldestFirst(t *testing.T) {
+	root, _ := todoFixture(t)
+	for _, text := range []string{"oldest", "middle", "newest"} {
+		if _, _, err := runTodo(t, "add", text); err != nil {
+			t.Fatalf("seed add: %v", err)
+		}
+	}
+	real := todoBacklogPath(root)
+	before, err := os.ReadFile(real)
+	if err != nil {
+		t.Fatalf("read before: %v", err)
+	}
+
+	out, _, err := runTodo(t, "next")
+	if err != nil {
+		t.Fatalf("bare next: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("bare next printed %d lines, want 3: %q", len(lines), out)
+	}
+	if !strings.Contains(lines[0], "oldest") || !strings.Contains(lines[2], "newest") {
+		t.Errorf("bare next order wrong: %q", lines)
+	}
+
+	after, err := os.ReadFile(real)
+	if err != nil {
+		t.Fatalf("read after: %v", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Error("bare next must leave the backlog byte-identical")
+	}
+}
+
+func TestTodoNextPick_OneLockedWrite(t *testing.T) {
+	_, store := todoFixture(t)
+	for _, text := range []string{"one", "two", "three"} {
+		if _, _, err := runTodo(t, "add", text); err != nil {
+			t.Fatalf("seed add: %v", err)
+		}
+	}
+
+	if _, _, err := runTodo(t, "next", "2", "--spec", "SPEC-X-001"); err != nil {
+		t.Fatalf("next 2 --spec: %v", err)
+	}
+	rec, err := store.Load()
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	picked := 0
+	for _, it := range rec.Items {
+		if it.State == kanban.BacklogStatePicked {
+			picked++
+			if it.ID != "t2" {
+				t.Errorf("picked item = %s, want t2", it.ID)
+			}
+			if it.SpecID == nil || *it.SpecID != "SPEC-X-001" {
+				t.Errorf("picked spec_id = %v, want SPEC-X-001", it.SpecID)
+			}
+		} else if it.State != kanban.BacklogStateQueued {
+			t.Errorf("item %s state = %s, want untouched queued", it.ID, it.State)
+		}
+	}
+	if picked != 1 {
+		t.Errorf("picked count = %d, want exactly 1", picked)
+	}
+}
+
+func TestTodoNext_OutOfRangeFileUntouched(t *testing.T) {
+	root, _ := todoFixture(t)
+	if _, _, err := runTodo(t, "add", "only"); err != nil {
+		t.Fatalf("seed add: %v", err)
+	}
+	real := todoBacklogPath(root)
+	before, err := os.ReadFile(real)
+	if err != nil {
+		t.Fatalf("read before: %v", err)
+	}
+
+	_, _, err = runTodo(t, "next", "99")
+	if err == nil {
+		t.Fatal("next on a missing id must fail")
+	}
+	after, err := os.ReadFile(real)
+	if err != nil {
+		t.Fatalf("read after: %v", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Error("file changed on a missed next; must be byte-identical")
+	}
+}
+
+// TestTodoConcurrentAdd_8Processes — AC-TODO-001: 8 concurrent `todo add`
+// processes against one backlog lose nothing and mint 8 distinct ids.
+func TestTodoConcurrentAdd_8Processes(t *testing.T) {
+	if runtimeIsWindowsForTodo() {
+		t.Skip("helper re-exec exercised on unix; windows covered by GOOS=windows build/vet")
+	}
+	root, _ := todoFixture(t)
+
+	const n = 8
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	outputs := make([]string, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			cmd := exec.Command(os.Args[0], "-test.run=TestTodoHelperProcess", "--")
+			cmd.Env = append(os.Environ(),
+				"MOAI_TODO_HELPER=add",
+				"CLAUDE_PROJECT_DIR="+root,
+				"MOAI_TODO_HELPER_TEXT=card "+string(rune('A'+i)),
+			)
+			out, err := cmd.CombinedOutput()
+			errs[i] = err
+			outputs[i] = string(out)
+		}(i)
+	}
+	wg.Wait()
+
+	seen := make(map[string]bool)
+	for i := 0; i < n; i++ {
+		if errs[i] != nil {
+			t.Fatalf("concurrent add %d failed: %v: %s", i, errs[i], outputs[i])
+		}
+	}
+	for i := 0; i < n; i++ {
+		for _, field := range strings.Fields(outputs[i]) {
+			if strings.HasPrefix(field, "t") && !seen[field] {
+				seen[field] = true
+			}
+		}
+	}
+	if len(seen) != n {
+		t.Errorf("distinct issued ids printed = %d, want %d (got %v)", len(seen), n, seen)
+	}
+
+	stdout, _, err := runTodo(t, "list", "--json")
+	if err != nil {
+		t.Fatalf("list --json: %v", err)
+	}
+	var rec kanban.BacklogRecord
+	if err := json.Unmarshal([]byte(stdout), &rec); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(rec.Items) != n {
+		t.Fatalf("items after 8 concurrent adds = %d, want %d", len(rec.Items), n)
+	}
+	texts := make(map[string]bool)
+	for _, it := range rec.Items {
+		texts[it.Text] = true
+	}
+	for i := 0; i < n; i++ {
+		want := "card " + string(rune('A'+i))
+		if !texts[want] {
+			t.Errorf("text %q missing from the queue", want)
+		}
+	}
+}
+
+// TestTodoHelperProcess is the re-exec helper backing the cross-process
+// tests above (same idiom as internal/kanban/board_lock_cross_test.go).
+func TestTodoHelperProcess(t *testing.T) {
+	mode := os.Getenv("MOAI_TODO_HELPER")
+	if mode == "" {
+		return // normal test run, not a helper invocation
+	}
+	root := os.Getenv("CLAUDE_PROJECT_DIR")
+	if root == "" {
+		os.Exit(4)
+	}
+	store := kanban.NewBacklogStore(todoBacklogPath(root))
+	_ = store
+
+	switch mode {
+	case "add":
+		// Run the FULL cobra verb (not store.Add directly) so the
+		// concurrency test exercises the same code path the built binary
+		// serves — AC-TODO-001's "concurrent `moai todo add` processes".
+		cmd := newTodoCmd()
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetArgs([]string{"add", os.Getenv("MOAI_TODO_HELPER_TEXT")})
+		if err := cmd.Execute(); err != nil {
+			t.Logf("helper add: %v", err)
+			os.Exit(3)
+		}
+		// Print to the process stdout directly — t.Logf output is dropped
+		// when the helper runs without -v, and the parent parses this line.
+		fmt.Print(out.String())
+	case "hold-lock":
+		err := store.Mutate(func(rec *kanban.BacklogRecord) error {
+			time.Sleep(1200 * time.Millisecond)
+			return nil
+		})
+		if err != nil {
+			t.Logf("helper hold-lock: %v", err)
+			os.Exit(3)
+		}
+	default:
+		os.Exit(4)
+	}
+	os.Exit(0)
+}
+
+func runtimeIsWindowsForTodo() bool {
+	return os.PathSeparator == '\\'
+}
+
+// TestTodoCmd_NoAskUserQuestion — AC-TODO-014: the todo command surface
+// carries zero interactive-prompt references (static guard, the
+// TestNew_NoAskUserQuestion idiom scoped to todo.go), with a negative
+// control proving the guard detects an introduced reference.
+func TestTodoCmd_NoAskUserQuestion(t *testing.T) {
+	data, err := os.ReadFile("todo.go")
+	if err != nil {
+		t.Fatalf("read todo.go: %v", err)
+	}
+	if reason, bad := todoPromptGuard(string(data)); bad {
+		t.Errorf("todo.go must stay prompt-free: %s", reason)
+	}
+
+	// Negative control: the guard must flag a synthetic violation.
+	if _, bad := todoPromptGuard("x := AskUserQuestion()"); !bad {
+		t.Error("guard must detect an AskUserQuestion reference (negative control)")
+	}
+}
+
+// todoPromptGuard reports whether source contains an interactive-prompt
+// reference. Split out so the negative control exercises the same predicate
+// the guard uses.
+func todoPromptGuard(source string) (reason string, bad bool) {
+	for _, token := range []string{"AskUserQuestion", "mcp__askuser"} {
+		if strings.Contains(source, token) {
+			return "found " + token, true
+		}
+	}
+	return "", false
+}

--- a/internal/kanban/backlog_store.go
+++ b/internal/kanban/backlog_store.go
@@ -141,9 +141,7 @@ func (s *BacklogStore) Mutate(mutate func(*BacklogRecord) error) (err error) {
 		return err
 	}
 	defer func() {
-		if relErr := lock.Release(); relErr != nil && err == nil {
-			err = fmt.Errorf("mutate backlog %s: mutation landed but lock release failed: %w", s.path, relErr)
-		}
+		err = joinBacklogReleaseErr(err, lock.Release(), s.path)
 	}()
 
 	rec, err := s.load()
@@ -157,6 +155,23 @@ func (s *BacklogStore) Mutate(mutate func(*BacklogRecord) error) (err error) {
 	// the written high-water mark must clear every present id.
 	normalizeBacklogRecord(rec)
 	return s.writeAtomic(rec)
+}
+
+// joinBacklogReleaseErr folds a lock-release failure into the mutation's own
+// result. It JOINS rather than overwrites, and joins in both directions: a
+// release failure that arrives alongside a mutation failure is the dangerous
+// case, not the harmless one. Reporting only the mutation error there hides a
+// wedged lock behind an unrelated message — on Windows release removes the
+// artifact, so the survivor blocks every later writer while the operator
+// retries against what looks like a transient mutation fault.
+//
+// Returns nil only when both are nil, so the caller's `err` stays clean on the
+// success path.
+func joinBacklogReleaseErr(mutErr, relErr error, path string) error {
+	if relErr == nil {
+		return mutErr
+	}
+	return errors.Join(mutErr, fmt.Errorf("mutate backlog %s: lock release failed: %w", path, relErr))
 }
 
 // @MX:ANCHOR: [AUTO] Add — the id-issuing append every add-path verb calls

--- a/internal/kanban/backlog_store.go
+++ b/internal/kanban/backlog_store.go
@@ -1,0 +1,292 @@
+// backlog_store.go — the lock-guarded backlog queue store
+// (SPEC-KANBAN-TODO-CLI-001 REQ-TODO-006..013, M1).
+//
+// The backlog is the OPERATOR's queue, not the board's: any session may
+// append, pick, or complete a card, so this store deliberately applies NO
+// sole-writer role guard (the explicit contrast with board_store.go — the
+// board has exactly one writer, the lead; the backlog has every writer).
+// What it does share with the board is the concurrency substrate: mutations
+// serialize on a sibling advisory lock (backlog.lock, the same
+// path-parameterized flock/atomic-create split the board lock uses) across
+// the entire read-modify-write, and land through the same-directory temp +
+// atomic rename. Reads are lock-free.
+//
+// Ids are issued INSIDE the locked mutation from the persisted high-water
+// mark `last_seq`. The mark — never max-present-id — decides the next id,
+// because `done` removes rows and a derived mark would reuse the removed
+// card's id (the t4/t5/t6 collision this SPEC exists to kill).
+package kanban
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/modu-ai/moai-adk/internal/atomicfile"
+)
+
+// backlogLockFileName names the lock artifact sibling to the backlog file.
+const backlogLockFileName = "backlog.lock"
+
+// backlogVersion is the record schema version. The schema is ADDITIVE within
+// version 1: `last_seq` was appended as a top-level field with no version
+// bump, and no per-item field may ever be added (spec.md §E out-of-scope).
+const backlogVersion = 1
+
+// BacklogState is a queue item's lifecycle state.
+type BacklogState string
+
+const (
+	// BacklogStateQueued marks a card waiting in the queue.
+	BacklogStateQueued BacklogState = "queued"
+	// BacklogStatePicked marks a card chosen for a SPEC (spec_id attached).
+	BacklogStatePicked BacklogState = "picked"
+	// BacklogStateDropped marks a card the operator discarded.
+	BacklogStateDropped BacklogState = "dropped"
+)
+
+// BacklogItem is one queued card. The five fields are the frozen per-item
+// contract (REQ-TODO-013): SpecID is a pointer so an absent spec id
+// round-trips as JSON null, not as an omitted key.
+type BacklogItem struct {
+	ID      string       `json:"id"`
+	Text    string       `json:"text"`
+	AddedAt string       `json:"added_at"`
+	SpecID  *string      `json:"spec_id"`
+	State   BacklogState `json:"state"`
+}
+
+// BacklogRecord is the backlog file's document shape. LastSeq is the
+// persisted id high-water mark — additive top-level, absent in files that
+// predate the field (derived from max present id on load).
+type BacklogRecord struct {
+	Version int           `json:"version"`
+	LastSeq int           `json:"last_seq"`
+	Items   []BacklogItem `json:"items"`
+}
+
+// BacklogStore guards one backlog file. Load is lock-free; every mutation
+// goes through Mutate, which holds the sibling lock across the whole
+// read-modify-write.
+type BacklogStore struct {
+	path string
+}
+
+// NewBacklogStore returns a store over the backlog file at path.
+func NewBacklogStore(path string) *BacklogStore {
+	return &BacklogStore{path: path}
+}
+
+// Path returns the backlog file's path.
+func (s *BacklogStore) Path() string { return s.path }
+
+// LockPath returns the sibling lock artifact's path (diagnostics and tests).
+func (s *BacklogStore) LockPath() string {
+	return filepath.Join(filepath.Dir(s.path), backlogLockFileName)
+}
+
+// @MX:ANCHOR: [AUTO] Load — the lock-free read every backlog verb renders from
+// @MX:REASON: expected fan_in >= 3 (M2 list/next/done verbs + tests); the sole load path on the file
+//
+// Load reads the backlog file without taking the lock. A missing file is an
+// empty queue, never an error (REQ-TODO-012). A malformed file surfaces as a
+// parse error with the file untouched — there is no repair-on-load path; the
+// operator's queued intent is the one thing that cannot be regenerated.
+func (s *BacklogStore) Load() (*BacklogRecord, error) {
+	rec, err := s.load()
+	if err != nil {
+		return nil, err
+	}
+	return rec, nil
+}
+
+// load is Load without the record copy — the shared read both the lock-free
+// verbs and the locked mutation path call.
+func (s *BacklogStore) load() (*BacklogRecord, error) {
+	raw, err := atomicfile.ReadFile(s.path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return &BacklogRecord{Version: backlogVersion, Items: []BacklogItem{}}, nil
+		}
+		return nil, fmt.Errorf("load backlog %s: %w", s.path, err)
+	}
+	var rec BacklogRecord
+	if err := json.Unmarshal(raw, &rec); err != nil {
+		return nil, fmt.Errorf("load backlog %s: parsing: %w", s.path, err)
+	}
+	normalizeBacklogRecord(&rec)
+	return &rec, nil
+}
+
+// @MX:WARN: [AUTO] Mutate — cross-process lock held across the entire read-modify-write
+// @MX:REASON: a mutation that loads or writes outside the lock reintroduces the lost-update race this SPEC kills (REQ-TODO-006/008)
+//
+// Mutate is THE guarded mutation entry point: it acquires the sibling lock,
+// loads the record, applies mutate in place, and atomically writes the
+// result. Returning an error from mutate aborts with the file unchanged.
+// Ids must be issued from rec.LastSeq inside the callback — the high-water
+// mark is normalized (max of persisted and max-present) before mutate runs,
+// so a version-1 file predating last_seq or a hand-edited low value both
+// resolve before issuance. Release errors are JOINED into the result rather
+// than discarded: on Windows release removes the artifact, so a silent
+// release failure would block every later writer.
+func (s *BacklogStore) Mutate(mutate func(*BacklogRecord) error) (err error) {
+	lock, err := s.acquireLock()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if relErr := lock.Release(); relErr != nil && err == nil {
+			err = fmt.Errorf("mutate backlog %s: mutation landed but lock release failed: %w", s.path, relErr)
+		}
+	}()
+
+	rec, err := s.load()
+	if err != nil {
+		return err
+	}
+	if err := mutate(rec); err != nil {
+		return fmt.Errorf("mutate backlog %s: mutation refused: %w", s.path, err)
+	}
+	// Re-normalize post-mutate: a callback may append or rewrite items, and
+	// the written high-water mark must clear every present id.
+	normalizeBacklogRecord(rec)
+	return s.writeAtomic(rec)
+}
+
+// @MX:ANCHOR: [AUTO] Add — the id-issuing append every add-path verb calls
+// @MX:REASON: expected fan_in >= 3 (M2 add verb, tests, future importers); the only id issuer, and issuance outside the lock would mint duplicates
+//
+// Add appends text as a new queued card and returns the issued item with its
+// 1-based position among the queued cards. The id comes from the persisted
+// high-water mark inside the locked mutation, so a removed card's id is
+// never reused (REQ-TODO-008).
+func (s *BacklogStore) Add(text string) (*BacklogItem, int, error) {
+	var item BacklogItem
+	var pos int
+	err := s.Mutate(func(rec *BacklogRecord) error {
+		rec.LastSeq++
+		item = BacklogItem{
+			ID:      fmt.Sprintf("t%d", rec.LastSeq),
+			Text:    text,
+			AddedAt: time.Now().UTC().Format(time.RFC3339),
+			State:   BacklogStateQueued,
+		}
+		rec.Items = append(rec.Items, item)
+		pos = 0
+		for _, it := range rec.Items {
+			if it.State == BacklogStateQueued {
+				pos++
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+	return &item, pos, nil
+}
+
+// acquireBacklogLockSerialized acquires the backlog's sibling lock, retrying
+// contention for the same bounded window as the board lock (25ms x 40 ~ 1s):
+// a mutation racing a short-lived holder serializes behind it instead of
+// failing, while a genuinely stuck holder surfaces as an error rather than a
+// hang. The timeout error names the lock artifact so the operator can act on
+// the right file.
+func (s *BacklogStore) acquireLock() (*BoardLock, error) {
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o755); err != nil {
+		return nil, fmt.Errorf("mutate backlog %s: creating dir: %w", s.path, err)
+	}
+	var lastErr error
+	for attempt := 0; attempt <= boardLockRetries; attempt++ {
+		impl, err := acquireBoardLockImpl(s.LockPath())
+		if err == nil {
+			return &BoardLock{path: s.LockPath(), impl: impl}, nil
+		}
+		if !IsBoardLockHeld(err) {
+			return nil, fmt.Errorf("mutate backlog %s: lock %s: %w", s.path, s.LockPath(), err)
+		}
+		lastErr = err
+		time.Sleep(boardLockRetryDelay)
+	}
+	return nil, fmt.Errorf("mutate backlog %s: lock %s: %w", s.path, s.LockPath(), lastErr)
+}
+
+// writeAtomic persists rec through the same-directory temp + atomic rename
+// (REQ-TODO-010): the rename must stay inside one filesystem to be atomic,
+// and no temp residue may survive the write.
+func (s *BacklogStore) writeAtomic(rec *BacklogRecord) error {
+	dir := filepath.Dir(s.path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("write backlog %s: creating dir: %w", s.path, err)
+	}
+	encoded, err := json.MarshalIndent(rec, "", "  ")
+	if err != nil {
+		return fmt.Errorf("write backlog %s: encoding: %w", s.path, err)
+	}
+	encoded = append(encoded, '\n')
+
+	tmp, err := os.CreateTemp(dir, ".backlog-*.tmp")
+	if err != nil {
+		return fmt.Errorf("write backlog %s: creating temp file: %w", s.path, err)
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(encoded); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("write backlog %s: writing temp file: %w", s.path, err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("write backlog %s: closing temp file: %w", s.path, err)
+	}
+	if err := atomicfile.Replace(tmpName, s.path); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("write backlog %s: replacing backlog file: %w", s.path, err)
+	}
+	return nil
+}
+
+// normalizeBacklogRecord establishes the invariants every in-memory record
+// holds: version 1, a non-nil item slice, and a high-water mark that clears
+// every present id (max of persisted and max-present — REQ-TODO-009's
+// derive-on-absent and the hand-edited-low-value guard in one rule).
+func normalizeBacklogRecord(rec *BacklogRecord) {
+	if rec.Version == 0 {
+		rec.Version = backlogVersion
+	}
+	if rec.Items == nil {
+		rec.Items = []BacklogItem{}
+	}
+	if max := maxPresentBacklogSeq(rec.Items); max > rec.LastSeq {
+		rec.LastSeq = max
+	}
+}
+
+// maxPresentBacklogSeq returns the highest numeric suffix among t<N> ids.
+func maxPresentBacklogSeq(items []BacklogItem) int {
+	max := 0
+	for _, it := range items {
+		if n, ok := parseBacklogSeq(it.ID); ok && n > max {
+			max = n
+		}
+	}
+	return max
+}
+
+// parseBacklogSeq extracts N from an id of the form t<N> (N > 0).
+func parseBacklogSeq(id string) (int, bool) {
+	if !strings.HasPrefix(id, "t") {
+		return 0, false
+	}
+	n, err := strconv.Atoi(id[1:])
+	if err != nil || n <= 0 {
+		return 0, false
+	}
+	return n, true
+}

--- a/internal/kanban/backlog_store_errors_test.go
+++ b/internal/kanban/backlog_store_errors_test.go
@@ -1,0 +1,151 @@
+// backlog_store_errors_test.go — supplementary error-path coverage for the
+// M1 backlog store (SPEC-KANBAN-TODO-CLI-001). The behavioral contract lives
+// in backlog_store_test.go; these tests exercise the error branches that the
+// happy-path contract cannot reach (unreadable file, lock/lock-dir failures,
+// unwritable target dir, schema normalization of minimal files, and the id
+// parser's refusals).
+package kanban
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestBacklogLoad_PathIsDirectorySurfacesReadError — a backlog path that is
+// a directory is a read error, distinct from the missing-file empty queue.
+func TestBacklogLoad_PathIsDirectorySurfacesReadError(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	store := NewBacklogStore(filepath.Join(dir, "backlog.json"))
+	if err := os.Mkdir(store.Path(), 0o755); err != nil {
+		t.Fatalf("seed directory-at-path: %v", err)
+	}
+	if _, err := store.Load(); err == nil {
+		t.Fatal("Load(directory path) err = nil, want read error")
+	}
+}
+
+// TestBacklogMutate_CallbackRefusalLeavesFileUnchanged — a refusing mutate
+// callback aborts with the file untouched.
+func TestBacklogMutate_CallbackRefusalLeavesFileUnchanged(t *testing.T) {
+	t.Parallel()
+	store := newTestBacklogStore(t)
+
+	refused := os.ErrPermission
+	if err := store.Mutate(func(rec *BacklogRecord) error { return refused }); err == nil {
+		t.Fatal("Mutate(refusing callback) err = nil, want refusal")
+	}
+	if _, statErr := os.Stat(store.Path()); statErr == nil {
+		t.Fatal("backlog file appeared despite refused mutation")
+	}
+}
+
+// TestBacklogMutate_ParentIsFileFailsBeforeLock — a store path beneath a
+// regular file cannot have its directory created, so the mutation fails
+// before the lock is ever attempted.
+func TestBacklogMutate_ParentIsFileFailsBeforeLock(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	blocker := filepath.Join(dir, "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0o644); err != nil {
+		t.Fatalf("seed blocker file: %v", err)
+	}
+	store := NewBacklogStore(filepath.Join(blocker, "backlog.json"))
+
+	if _, _, err := store.Add("unwritable"); err == nil {
+		t.Fatal("Add(beneath a file) err = nil, want dir-creation error")
+	}
+}
+
+// TestBacklogMutate_LockPathIsDirectorySurfacesNonLockError — a lock
+// artifact path occupied by a directory is an acquisition failure that is
+// NOT contention (no bounded retry), surfaced immediately.
+func TestBacklogMutate_LockPathIsDirectorySurfacesNonLockError(t *testing.T) {
+	t.Parallel()
+	store := newTestBacklogStore(t)
+	if err := os.MkdirAll(store.LockPath(), 0o755); err != nil {
+		t.Fatalf("seed directory-at-lock-path: %v", err)
+	}
+
+	if _, _, err := store.Add("blocked by dir"); err == nil {
+		t.Fatal("Add(lock path is a directory) err = nil, want acquisition error")
+	} else if IsBoardLockHeld(err) {
+		t.Fatalf("err = %v, want a non-contention acquisition failure", err)
+	}
+}
+
+// TestBacklogWrite_UnwritableDirFailsTempCreation — the mutation callback
+// itself revokes the directory's write bit, so the write path fails at temp
+// file creation while the lock is already held: the error surfaces and no
+// residue is left beyond the lock artifact.
+func TestBacklogWrite_UnwritableDirFailsTempCreation(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("read-only directory does not block the root user")
+	}
+	t.Parallel()
+	store := newTestBacklogStore(t)
+	dir := filepath.Dir(store.Path())
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+	err := store.Mutate(func(rec *BacklogRecord) error {
+		return os.Chmod(dir, 0o500)
+	})
+	if err == nil {
+		t.Fatal("Mutate(read-only dir) err = nil, want temp-creation error")
+	}
+	for _, name := range readBacklogDirNames(t, store) {
+		if name != "backlog.lock" {
+			t.Fatalf("backlog dir holds leaked file %q after failed write", name)
+		}
+	}
+}
+
+// TestBacklogNormalize_MinimalFiles — a file carrying neither version nor
+// items normalizes to a writable version-1 record with an empty item slice.
+func TestBacklogNormalize_MinimalFiles(t *testing.T) {
+	t.Parallel()
+
+	noItems := newTestBacklogStore(t)
+	seedBacklogFile(t, noItems, `{"version":1,"last_seq":4}`)
+	if err := noItems.Mutate(func(rec *BacklogRecord) error { return nil }); err != nil {
+		t.Fatalf("Mutate(no items key): %v", err)
+	}
+	rec, err := noItems.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if rec.Items == nil || len(rec.Items) != 0 {
+		t.Fatalf("Items = %v, want normalized empty non-nil slice", rec.Items)
+	}
+	if rec.LastSeq != 4 {
+		t.Fatalf("LastSeq = %d, want preserved 4", rec.LastSeq)
+	}
+
+	noVersion := newTestBacklogStore(t)
+	seedBacklogFile(t, noVersion, `{"items":[]}`)
+	if err := noVersion.Mutate(func(rec *BacklogRecord) error { return nil }); err != nil {
+		t.Fatalf("Mutate(no version key): %v", err)
+	}
+	rec, err = noVersion.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if rec.Version != 1 {
+		t.Fatalf("Version = %d, want normalized 1", rec.Version)
+	}
+}
+
+// TestParseBacklogSeq_Refusals — ids that are not t<N> with N > 0 are not
+// sequence numbers and never feed the high-water mark.
+func TestParseBacklogSeq_Refusals(t *testing.T) {
+	t.Parallel()
+	for _, id := range []string{"", "t", "x5", "tabc", "t0", "t-3", "T7"} {
+		if n, ok := parseBacklogSeq(id); ok {
+			t.Fatalf("parseBacklogSeq(%q) = %d, true; want refusal", id, n)
+		}
+	}
+	if n, ok := parseBacklogSeq("t42"); !ok || n != 42 {
+		t.Fatalf("parseBacklogSeq(t42) = %d, %v; want 42, true", n, ok)
+	}
+}

--- a/internal/kanban/backlog_store_errors_test.go
+++ b/internal/kanban/backlog_store_errors_test.go
@@ -7,8 +7,10 @@
 package kanban
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -147,5 +149,53 @@ func TestParseBacklogSeq_Refusals(t *testing.T) {
 	}
 	if n, ok := parseBacklogSeq("t42"); !ok || n != 42 {
 		t.Fatalf("parseBacklogSeq(t42) = %d, %v; want 42, true", n, ok)
+	}
+}
+
+// TestJoinBacklogReleaseErr_BothFailuresSurvive — the regression this exists
+// for: when the mutation fails AND the lock release fails, BOTH must reach the
+// caller. The prior guard (`relErr != nil && err == nil`) dropped the release
+// error in exactly that case, so a wedged lock — the artifact that blocks every
+// later writer on Windows — surfaced as an ordinary mutation fault.
+func TestJoinBacklogReleaseErr_BothFailuresSurvive(t *testing.T) {
+	t.Parallel()
+	mutErr := errors.New("mutation refused")
+	relErr := errors.New("close: bad file descriptor")
+
+	got := joinBacklogReleaseErr(mutErr, relErr, "/tmp/backlog.json")
+	if got == nil {
+		t.Fatal("joinBacklogReleaseErr(mut, rel) = nil; want both errors")
+	}
+	if !errors.Is(got, mutErr) {
+		t.Errorf("mutation error did not survive the join: %v", got)
+	}
+	if !errors.Is(got, relErr) {
+		t.Errorf("release error did not survive the join: %v", got)
+	}
+	if !strings.Contains(got.Error(), "lock release failed") {
+		t.Errorf("joined error does not name the release failure: %v", got)
+	}
+}
+
+// TestJoinBacklogReleaseErr_SingleAndCleanPaths — the other three combinations.
+// A clean release must not manufacture an error, and either failure alone must
+// pass through identifiably.
+func TestJoinBacklogReleaseErr_SingleAndCleanPaths(t *testing.T) {
+	t.Parallel()
+	mutErr := errors.New("mutation refused")
+	relErr := errors.New("close: bad file descriptor")
+
+	if got := joinBacklogReleaseErr(nil, nil, "/tmp/backlog.json"); got != nil {
+		t.Errorf("both-clean returned %v; want nil", got)
+	}
+	if got := joinBacklogReleaseErr(mutErr, nil, "/tmp/backlog.json"); !errors.Is(got, mutErr) {
+		t.Errorf("mutation-only returned %v; want the mutation error", got)
+	}
+	got := joinBacklogReleaseErr(nil, relErr, "/tmp/backlog.json")
+	if !errors.Is(got, relErr) {
+		t.Errorf("release-only returned %v; want the release error", got)
+	}
+	if !strings.Contains(got.Error(), "lock release failed") {
+		t.Errorf("release-only error does not name the failure: %v", got)
 	}
 }

--- a/internal/kanban/backlog_store_test.go
+++ b/internal/kanban/backlog_store_test.go
@@ -1,0 +1,531 @@
+// backlog_store_test.go — the lock-guarded backlog queue store
+// (SPEC-KANBAN-TODO-CLI-001 REQ-TODO-006..013, M1).
+//
+// Store-level slices of AC-TODO-007..013. The CLI-process-level ACs
+// (AC-TODO-001, AC-TODO-003..006) land with M2's command wiring; here the
+// same behaviors are proven against the store the verbs will call.
+package kanban
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// newTestBacklogStore builds a store over a temp-dir backlog file.
+func newTestBacklogStore(t *testing.T) *BacklogStore {
+	t.Helper()
+	return NewBacklogStore(filepath.Join(t.TempDir(), "backlog.json"))
+}
+
+// seedBacklogFile writes raw bytes as the backlog file and returns its
+// checksum for byte-identity assertions.
+func seedBacklogFile(t *testing.T, store *BacklogStore, content string) string {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(store.Path()), 0o755); err != nil {
+		t.Fatalf("seed backlog dir: %v", err)
+	}
+	if err := os.WriteFile(store.Path(), []byte(content), 0o644); err != nil {
+		t.Fatalf("seed backlog file: %v", err)
+	}
+	return checksumBacklogFile(t, store)
+}
+
+// checksumBacklogFile digests the backlog file bytes.
+func checksumBacklogFile(t *testing.T, store *BacklogStore) string {
+	t.Helper()
+	raw, err := os.ReadFile(store.Path())
+	if err != nil {
+		t.Fatalf("read backlog file for checksum: %v", err)
+	}
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:])
+}
+
+// readBacklogDirNames lists the backlog directory's entry names.
+func readBacklogDirNames(t *testing.T, store *BacklogStore) []string {
+	t.Helper()
+	entries, err := os.ReadDir(filepath.Dir(store.Path()))
+	if err != nil {
+		t.Fatalf("read backlog dir: %v", err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	return names
+}
+
+// productionShapedBacklog is a version-1 record WITHOUT last_seq: three
+// items, all three states, spec_id null and non-null — the load-compat
+// fixture for REQ-TODO-009/013.
+const productionShapedBacklog = `{
+  "version": 1,
+  "items": [
+    {
+      "id": "t2",
+      "text": "Rework the auth middleware error paths",
+      "added_at": "2026-08-14T01:02:03Z",
+      "spec_id": null,
+      "state": "queued"
+    },
+    {
+      "id": "t5",
+      "text": "Audit the session registry locking",
+      "added_at": "2026-08-14T01:03:04Z",
+      "spec_id": "SPEC-KANBAN-TODO-CLI-001",
+      "state": "picked"
+    },
+    {
+      "id": "t19",
+      "text": "Retire the legacy flag",
+      "added_at": "2026-08-14T01:04:05Z",
+      "spec_id": null,
+      "state": "dropped"
+    }
+  ]
+}
+`
+
+// TestBacklogLoad_MissingFileIsEmptyQueue — REQ-TODO-012 missing half: an
+// absent backlog file is an empty queue, never an error.
+func TestBacklogLoad_MissingFileIsEmptyQueue(t *testing.T) {
+	t.Parallel()
+	store := newTestBacklogStore(t)
+
+	rec, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load(missing file) error = %v, want empty queue", err)
+	}
+	if rec.Version != 1 {
+		t.Fatalf("Version = %d, want 1", rec.Version)
+	}
+	if len(rec.Items) != 0 {
+		t.Fatalf("Items = %d, want 0", len(rec.Items))
+	}
+}
+
+// TestBacklogAdd_CreatesVersion1File — REQ-TODO-012: add against a missing
+// file creates a valid version-1 file containing exactly one item.
+func TestBacklogAdd_CreatesVersion1File(t *testing.T) {
+	t.Parallel()
+	store := newTestBacklogStore(t)
+
+	item, pos, err := store.Add("first card")
+	if err != nil {
+		t.Fatalf("Add(missing file) error = %v, want file created", err)
+	}
+	if item.ID != "t1" {
+		t.Fatalf("first issued id = %q, want t1", item.ID)
+	}
+	if item.Text != "first card" {
+		t.Fatalf("item.Text = %q, want %q", item.Text, "first card")
+	}
+	if item.State != BacklogStateQueued {
+		t.Fatalf("item.State = %q, want %q", item.State, BacklogStateQueued)
+	}
+	if item.SpecID != nil {
+		t.Fatalf("item.SpecID = %v, want nil", item.SpecID)
+	}
+	if item.AddedAt == "" {
+		t.Fatal("item.AddedAt empty, want RFC3339 timestamp")
+	}
+	if _, err := time.Parse(time.RFC3339, item.AddedAt); err != nil {
+		t.Fatalf("item.AddedAt %q is not RFC3339: %v", item.AddedAt, err)
+	}
+	if pos != 1 {
+		t.Fatalf("queue position = %d, want 1", pos)
+	}
+
+	raw, err := os.ReadFile(store.Path())
+	if err != nil {
+		t.Fatalf("read created file: %v", err)
+	}
+	var probe struct {
+		Version int            `json:"version"`
+		LastSeq int            `json:"last_seq"`
+		Items   []BacklogItem  `json:"items"`
+	}
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		t.Fatalf("created file is not valid JSON: %v\n%s", err, raw)
+	}
+	if probe.Version != 1 {
+		t.Fatalf("created file version = %d, want 1", probe.Version)
+	}
+	if probe.LastSeq != 1 {
+		t.Fatalf("created file last_seq = %d, want 1", probe.LastSeq)
+	}
+	if len(probe.Items) != 1 || probe.Items[0].ID != "t1" {
+		t.Fatalf("created file items = %+v, want exactly [t1]", probe.Items)
+	}
+	if raw[len(raw)-1] != '\n' {
+		t.Fatal("created file does not end in a newline")
+	}
+}
+
+// TestBacklogLock_TimeoutNamesLockPath — REQ-TODO-006/007: a foreign holder
+// beyond the bounded retry window surfaces as an explicit error naming the
+// lock artifact path.
+func TestBacklogLock_TimeoutNamesLockPath(t *testing.T) {
+	t.Parallel()
+	store := newTestBacklogStore(t)
+
+	impl, err := acquireBoardLockImpl(store.LockPath())
+	if err != nil {
+		t.Fatalf("hold foreign lock: %v", err)
+	}
+	foreign := &BoardLock{path: store.LockPath(), impl: impl}
+	defer func() { _ = foreign.Release() }()
+
+	start := time.Now()
+	_, _, err = store.Add("blocked card")
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("Add under a held lock err = nil, want bounded-retry timeout")
+	}
+	if !IsBoardLockHeld(err) {
+		t.Fatalf("err = %v, want the lock-held sentinel", err)
+	}
+	if !strings.Contains(err.Error(), store.LockPath()) {
+		t.Fatalf("err %q does not name the lock artifact path %q", err, store.LockPath())
+	}
+	if elapsed < 500*time.Millisecond {
+		t.Fatalf("Add returned after %v, before the ~1s bounded window elapsed", elapsed)
+	}
+	// The failed mutation must not have created or altered the backlog file.
+	if _, statErr := os.Stat(store.Path()); statErr == nil {
+		t.Fatal("backlog file appeared despite lock timeout")
+	}
+}
+
+// TestBacklogMutate_LoserSerializedNotFailed — AC-TODO-007's composition
+// half at store level: a mutation racing a short-lived holder retries within
+// the window and completes once the holder releases.
+func TestBacklogMutate_LoserSerializedNotFailed(t *testing.T) {
+	t.Parallel()
+	store := newTestBacklogStore(t)
+
+	impl, err := acquireBoardLockImpl(store.LockPath())
+	if err != nil {
+		t.Fatalf("hold foreign lock: %v", err)
+	}
+	foreign := &BoardLock{path: store.LockPath(), impl: impl}
+	go func() {
+		time.Sleep(80 * time.Millisecond)
+		_ = foreign.Release()
+	}()
+
+	item, _, err := store.Add("waiting card")
+	if err != nil {
+		t.Fatalf("Add racing a short holder failed: %v, want serialized success", err)
+	}
+	if item.ID != "t1" {
+		t.Fatalf("issued id = %q, want t1", item.ID)
+	}
+}
+
+// TestBacklogIDIssuedUnderLock_SequentialMutations — REQ-TODO-008: ids come
+// from last_seq read inside the locked mutation; two sequential adds yield
+// t1 then t2 with no reuse.
+func TestBacklogIDIssuedUnderLock_SequentialMutations(t *testing.T) {
+	t.Parallel()
+	store := newTestBacklogStore(t)
+
+	first, _, err := store.Add("one")
+	if err != nil {
+		t.Fatalf("first Add: %v", err)
+	}
+	second, _, err := store.Add("two")
+	if err != nil {
+		t.Fatalf("second Add: %v", err)
+	}
+	if first.ID != "t1" || second.ID != "t2" {
+		t.Fatalf("issued ids = %q, %q; want t1, t2", first.ID, second.ID)
+	}
+
+	rec, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if rec.LastSeq != 2 {
+		t.Fatalf("persisted last_seq = %d, want 2", rec.LastSeq)
+	}
+}
+
+// TestBacklogHighWater_SurvivesRemoval — REQ-TODO-008: `done` removes rows,
+// so the persisted high-water mark — not max-present-id — decides the next
+// id. Remove t20, the next add issues t21, never t20 again.
+func TestBacklogHighWater_SurvivesRemoval(t *testing.T) {
+	t.Parallel()
+	store := newTestBacklogStore(t)
+	seedBacklogFile(t, store, `{
+  "version": 1,
+  "last_seq": 19,
+  "items": [
+    {"id": "t20", "text": "to be removed", "added_at": "2026-08-14T02:00:00Z", "spec_id": null, "state": "queued"}
+  ]
+}
+`)
+
+	if err := store.Mutate(func(rec *BacklogRecord) error {
+		kept := rec.Items[:0]
+		for _, it := range rec.Items {
+			if it.ID != "t20" {
+				kept = append(kept, it)
+			}
+		}
+		rec.Items = kept
+		return nil
+	}); err != nil {
+		t.Fatalf("Mutate(remove t20): %v", err)
+	}
+
+	item, _, err := store.Add("after removal")
+	if err != nil {
+		t.Fatalf("Add after removal: %v", err)
+	}
+	if item.ID != "t21" {
+		t.Fatalf("id after removing t20 = %q, want t21 — removal never enables reuse", item.ID)
+	}
+}
+
+// TestBacklogHighWater_DeriveOnAbsent — REQ-TODO-009: a version-1 file
+// predating last_seq derives the initial mark from the maximum existing item
+// id (t19 here) and persists it on the first write; the next issued id is t20.
+func TestBacklogHighWater_DeriveOnAbsent(t *testing.T) {
+	t.Parallel()
+	store := newTestBacklogStore(t)
+	seedBacklogFile(t, store, productionShapedBacklog)
+
+	item, _, err := store.Add("derived mark")
+	if err != nil {
+		t.Fatalf("Add over derive-on-absent file: %v", err)
+	}
+	if item.ID != "t20" {
+		t.Fatalf("id after deriving from max t19 = %q, want t20", item.ID)
+	}
+
+	rec, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if rec.LastSeq != 20 {
+		t.Fatalf("persisted last_seq = %d, want 20 (derived then advanced)", rec.LastSeq)
+	}
+}
+
+// TestBacklogHighWater_HandEditedLowSeq — acceptance.md §C bullet 4: a
+// hand-edited last_seq BELOW a present id must not mint a duplicate; the
+// effective mark is max(persisted, max-present).
+func TestBacklogHighWater_HandEditedLowSeq(t *testing.T) {
+	t.Parallel()
+	store := newTestBacklogStore(t)
+	seedBacklogFile(t, store, `{
+  "version": 1,
+  "last_seq": 3,
+  "items": [
+    {"id": "t10", "text": "hand edited high", "added_at": "2026-08-14T03:00:00Z", "spec_id": null, "state": "queued"}
+  ]
+}
+`)
+
+	item, _, err := store.Add("must clear t10")
+	if err != nil {
+		t.Fatalf("Add over hand-edited file: %v", err)
+	}
+	if item.ID != "t11" {
+		t.Fatalf("id = %q, want t11 (greater than every present id)", item.ID)
+	}
+
+	rec, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if rec.LastSeq != 11 {
+		t.Fatalf("persisted last_seq = %d, want 11", rec.LastSeq)
+	}
+	seen := map[string]bool{}
+	for _, it := range rec.Items {
+		if seen[it.ID] {
+			t.Fatalf("duplicate id %q after hand-edited regression", it.ID)
+		}
+		seen[it.ID] = true
+	}
+}
+
+// TestBacklogMalformed_ReportedEverywhereFileUntouched — REQ-TODO-012
+// malformed half: every path reports the parse error and leaves the file
+// byte-identical; no verb resets, no silent repair exists.
+func TestBacklogMalformed_ReportedEverywhereFileUntouched(t *testing.T) {
+	t.Parallel()
+	store := newTestBacklogStore(t)
+	before := seedBacklogFile(t, store, `{"version":1,"items":[ TRUNCATED`)
+
+	if _, err := store.Load(); err == nil {
+		t.Fatal("Load(malformed) err = nil, want parse error")
+	}
+	if _, _, err := store.Add("into malformed"); err == nil {
+		t.Fatal("Add(malformed) err = nil, want parse error")
+	}
+	if err := store.Mutate(func(rec *BacklogRecord) error { return nil }); err == nil {
+		t.Fatal("Mutate(malformed) err = nil, want parse error")
+	}
+
+	if after := checksumBacklogFile(t, store); after != before {
+		t.Fatal("malformed backlog file changed after failed verbs — never silently reset")
+	}
+}
+
+// TestBacklogRoundTrip_PreservesFieldsAndVersion — REQ-TODO-013: a
+// production-shaped version-1 file survives load → mutate → write with every
+// pre-existing item's five fields unchanged, version still 1, no new per-item
+// field, and last_seq as the only top-level addition.
+func TestBacklogRoundTrip_PreservesFieldsAndVersion(t *testing.T) {
+	t.Parallel()
+	store := newTestBacklogStore(t)
+	seedBacklogFile(t, store, productionShapedBacklog)
+
+	if _, _, err := store.Add("new row"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	raw, err := os.ReadFile(store.Path())
+	if err != nil {
+		t.Fatalf("read round-tripped file: %v", err)
+	}
+	var probe struct {
+		Version int           `json:"version"`
+		LastSeq int           `json:"last_seq"`
+		Items   []map[string]any `json:"items"`
+	}
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		t.Fatalf("round-tripped file is not valid JSON: %v", err)
+	}
+	if probe.Version != 1 {
+		t.Fatalf("version = %d, want 1 (no version bump)", probe.Version)
+	}
+	if probe.LastSeq != 20 {
+		t.Fatalf("last_seq = %d, want 20", probe.LastSeq)
+	}
+	if len(probe.Items) != 4 {
+		t.Fatalf("items = %d, want 4 (3 preserved + 1 added)", len(probe.Items))
+	}
+
+	wantFields := map[string]bool{"id": true, "text": true, "added_at": true, "spec_id": true, "state": true}
+	for i, item := range probe.Items {
+		if len(item) != len(wantFields) {
+			t.Fatalf("item[%d] fields = %v, want exactly %v (no per-item addition)", i, item, wantFields)
+		}
+		for k := range item {
+			if !wantFields[k] {
+				t.Fatalf("item[%d] carries new field %q", i, k)
+			}
+		}
+	}
+	if probe.Items[0]["id"] != "t2" || probe.Items[0]["state"] != "queued" || probe.Items[0]["spec_id"] != nil {
+		t.Fatalf("item t2 not preserved verbatim: %v", probe.Items[0])
+	}
+	if probe.Items[1]["id"] != "t5" || probe.Items[1]["state"] != "picked" || probe.Items[1]["spec_id"] != "SPEC-KANBAN-TODO-CLI-001" {
+		t.Fatalf("item t5 not preserved verbatim: %v", probe.Items[1])
+	}
+	if probe.Items[2]["id"] != "t19" || probe.Items[2]["state"] != "dropped" {
+		t.Fatalf("item t19 not preserved verbatim: %v", probe.Items[2])
+	}
+}
+
+// TestBacklogWrite_NoTmpResidue — REQ-TODO-010: the atomic write leaves the
+// backlog file and its lock sibling — nothing else; no .tmp residue.
+func TestBacklogWrite_NoTmpResidue(t *testing.T) {
+	t.Parallel()
+	store := newTestBacklogStore(t)
+
+	if _, _, err := store.Add("residue probe"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	allowed := map[string]bool{"backlog.json": true, "backlog.lock": true}
+	for _, name := range readBacklogDirNames(t, store) {
+		if !allowed[name] {
+			t.Fatalf("backlog dir holds leaked file %q — the temp must be renamed away", name)
+		}
+	}
+}
+
+// TestBacklogConcurrentAdd_UniqueIDs — REQ-TODO-008 store-level slice of
+// AC-TODO-001/008: concurrent adds through the store all land, all ids are
+// distinct, and every text survives.
+func TestBacklogConcurrentAdd_UniqueIDs(t *testing.T) {
+	t.Parallel()
+	store := newTestBacklogStore(t)
+
+	const adds = 8
+	ids := make([]string, adds)
+	errs := make([]error, adds)
+	var wg sync.WaitGroup
+	for i := 0; i < adds; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			item, _, err := store.Add(fmt.Sprintf("card %d", i))
+			ids[i], errs[i] = item.ID, err
+		}(i)
+	}
+	wg.Wait()
+
+	seen := map[string]bool{}
+	for i := 0; i < adds; i++ {
+		if errs[i] != nil {
+			t.Fatalf("concurrent Add %d failed: %v", i, errs[i])
+		}
+		if seen[ids[i]] {
+			t.Fatalf("duplicate id %q across concurrent adds", ids[i])
+		}
+		seen[ids[i]] = true
+	}
+
+	rec, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load after concurrent adds: %v", err)
+	}
+	if len(rec.Items) != adds {
+		t.Fatalf("items = %d, want %d — concurrent adds lost rows", len(rec.Items), adds)
+	}
+	if rec.LastSeq != adds {
+		t.Fatalf("last_seq = %d, want %d", rec.LastSeq, adds)
+	}
+	texts := map[string]bool{}
+	for _, it := range rec.Items {
+		texts[it.Text] = true
+	}
+	for i := 0; i < adds; i++ {
+		if !texts[fmt.Sprintf("card %d", i)] {
+			t.Fatalf("text %q lost across concurrent adds", fmt.Sprintf("card %d", i))
+		}
+	}
+}
+
+// TestBacklogStore_NoLeadRoleGuard — REQ-TODO-011: the backlog applies no
+// requireLeadRole-equivalent gate. This test process declares no role and
+// holds no kanban identity at all; the write must succeed anyway (explicit
+// contrast with the board's sole-writer guard — board files untouched).
+func TestBacklogStore_NoLeadRoleGuard(t *testing.T) {
+	t.Parallel()
+	store := newTestBacklogStore(t)
+
+	item, _, err := store.Add("anonymous writer")
+	if err != nil {
+		t.Fatalf("Add without any role declaration: %v — the backlog is the operator's queue, any session may write", err)
+	}
+	if item.ID != "t1" {
+		t.Fatalf("issued id = %q, want t1", item.ID)
+	}
+	if IsNotSoleWriter(err) {
+		t.Fatal("backlog write hit the board's sole-writer refusal")
+	}
+}

--- a/internal/template/templates/.claude/skills/moai/workflows/todo.md
+++ b/internal/template/templates/.claude/skills/moai/workflows/todo.md
@@ -14,27 +14,35 @@ it and the lead dispatches it to the `plan` session.
 The queue is deliberately thin. It records *what the operator wants next*, and
 nothing that a SPEC, a git history, or a board would record better.
 
-State lives at `.moai/state/kanban/backlog.json`. It is project-local and is not
-committed.
+State lives at `.moai/state/kanban/backlog.json` (project-local, not committed).
+Do not read or write that file directly — run the `moai todo` commands: they
+hold a cross-process lock across every mutation, so concurrent sessions cannot
+lose cards or collide ids.
 
-## Verbs
+## Commands
 
-| Invocation | Effect |
+When the operator says `/moai todo "<description>"`, run
+`moai todo add "<description>"`; a bare `/moai todo` runs `moai todo list`.
+
+| Command | Effect |
 |---|---|
-| `/moai todo "<description>"` | Append an item to the queue. Prints the item and its position. |
-| `/moai todo` | List the queue, in order, with positions. |
-| `/moai todo done <n>` | Remove item `n` (it was completed elsewhere, or is no longer wanted). Prints what was removed. |
-| `/moai todo next` | Present the queue through `AskUserQuestion` so the operator picks the next card. |
+| `moai todo add "<text>"` | Append an item under the lock. Prints the issued id (`t<n>`) and its queue position. |
+| `moai todo list` | Render the queue, lock-free. `--json` emits the structured records. |
+| `moai todo done <n>` | Remove the addressed row under the lock. A bare `<n>` means `t<n>`; the explicit id (`moai todo done t3`) is the preferred form because positions move. |
+| `moai todo next` | Print the queued items oldest-first — read-only candidates. |
+| `moai todo next <n> [--spec <SPEC-ID>]` | Mark the addressed item `picked` (attaching `spec_id` when given) as one locked write. |
 
-Any other argument form is treated as a description — `/moai todo fix the flaky
-CI cache` adds an item rather than erroring, because the cost of a wrong guess
-here is one line the operator can delete.
+The queue is never mutated through any other surface. A missing backlog file is
+an empty queue, never an error; a malformed file is reported and left untouched.
 
-## Record shape
+## Reading the records
+
+`moai todo list --json` emits the file's records:
 
 ```json
 {
   "version": 1,
+  "last_seq": 12,
   "items": [
     {
       "id": "t1",
@@ -47,25 +55,20 @@ here is one line the operator can delete.
 }
 ```
 
-- `id` — short, stable, assigned on append. Never reused after removal.
-- `spec_id` — filled in when the item is picked and a SPEC is authored for it.
-  Until then it is `null`, which is what distinguishes a backlog item from a card
-  already on the board.
+- `id` — assigned on append, never reused after removal (`last_seq` is the
+  persisted high-water mark that guarantees it).
+- `spec_id` — filled in when the item is picked; until then it is `null`, which
+  is what distinguishes a backlog item from a card already on the board.
 - `state` — `queued` | `picked` | `dropped`. A picked item stays in the file so
   the operator can see what is in flight; it is removed when its card reaches
   `done`.
 
-Write the file atomically (write a sibling temp file, then rename) so a crash
-mid-write cannot truncate the queue. A missing file is an empty queue, not an
-error. A malformed file is reported and left untouched — never silently reset,
-because the operator's intent is the one thing here that cannot be regenerated.
-
 ## Picking the next card
 
-`/moai todo next` (and the lead's own post-`/clear` opening move) presents the
-queue through `AskUserQuestion` — one option per queued item, capped at the four
-the tool allows, oldest first, with the remainder summarized in the response body
-so nothing is hidden behind the cap.
+`moai todo next` (and the lead's own post-`/clear` opening move) presents the
+queued items through `AskUserQuestion` — one option per queued item, capped at
+the four the tool allows, oldest first, with the remainder summarized in the
+response body so nothing is hidden behind the cap.
 
 [HARD] The pick is the operator's. Do not preselect, do not reorder by inferred
 priority, and do not append a "start the top one" default. Where the queue is
@@ -81,14 +84,13 @@ authorization never covered. See `kanban-dispatch.md` § Batch admission.
 
 Once picked:
 
-1. Mark the item `picked`.
+1. Record it with `moai todo next <n> --spec <SPEC-ID>` (one locked write).
 2. Dispatch to the `plan` session per `kanban-dispatch.md` — the card enters the
    `plan` column, and SPEC authoring happens there, not here.
-3. Record the SPEC ID onto the item as soon as the plan session reports one.
 
 ## Outside Kanban Mode
 
-`/moai todo` works in an ordinary session too — it is just a queue. What it will
+`moai todo` works in an ordinary session too — it is just a queue. What it will
 not do is dispatch: with no companion sessions there is nobody to instruct, so
 the queue is read and written and the operator drives the work themselves.
 


### PR DESCRIPTION
## Summary

Kanban card t12. Replaces the `/moai todo` skill's model-driven Read→Write cycle on `.moai/state/kanban/backlog.json` with a real `moai todo` CLI backed by a lock-guarded store — killing the read-modify-write race that lost 3 cards and collided t4/t5/t6 ids on 2026-08-14.

- **M1 `internal/kanban/backlog_store.go`** — reuses the board lock substrate (path-parameterized flock/atomic-create, bounded 25ms×40 retry) on sibling `backlog.lock`; ids issued INSIDE the locked mutation from the persisted `last_seq` high-water mark (derive-on-absent from max present id; `max(persisted, max-present)`; removal never lowers it — `done t20` then `add` → `t21`); writes via `internal/atomicfile` same-dir temp + rename; no lead-role guard (the backlog is the operator's queue); missing file = empty queue, malformed file reported and never reset.
- **M2 `internal/cli/todo.go`** — cobra verbs `add "<text>"` (prints id + queue position) / `list [--json]` (lock-free) / `done <n>` (bare `<n>` → `t<n>`, miss leaves the file byte-identical) / `next` (bare: oldest-first read-only) / `next <n> [--spec <SPEC-ID>]` (picked + spec_id as ONE locked write). No prompts anywhere (static guard + negative control).
- **M3 skill shrink + template mirror** — `.claude/skills/moai/workflows/todo.md` reduced to run-the-command form on both twins (pre-edit `diff` proved byte-identical twins; same rewrite = same delta, no `cp`); Read→Write + temp-file/rename instructions removed; queue philosophy, [HARD] operator-selection rule, boundaries, and the upstream #1526 batch-admission clause all preserved (rebase merge kept both sides). `MOAI_TEMPLATE_LEAK_STRICT=1` gate green.
- **M4 verification sweep** — see below.

## Verification evidence (per-milestone, commands + verbatim outputs in `.moai/specs/SPEC-KANBAN-TODO-CLI-001/progress.md` §E.2)

- `go test ./internal/kanban/... -count=1 -cover` → `ok ... coverage: 87.3%`
- New-file coverage (AC §D target): `todo.go` + `backlog_store.go` average **94.1%** over 20 functions
- Concurrency: 8 OS processes through the full cobra `add` verb → 8/8 items, 8 unique gapless ids; lead-verified on the built binary with 12 processes → 12/12, `last_seq: 12`; live high-water check `t1 t2 t3` → `done 3` → `add` → `t1 t2 t4`
- `GOOS=windows GOARCH=amd64 go build ./...` → exit 0; **full-repo `GOOS=windows GOARCH=amd64 go vet ./...` → exit 0** (the gate that actually compiles `_test.go`)
- `golangci-lint run` → `0 issues.` (zero NEW findings across the whole SPEC diff)
- Full suite (rebased on 24e2bd402): zero NEW failures — known pre-existing failures listed below

## Known pre-existing test failures (NOT from this PR, with attribution)

| Test | Package | Attribution |
|---|---|---|
| `TestHandleCodexReviewGate_LiveCodexBlocksInjectionAndKey` | internal/cli | Declared known origin/main failure by the kanban lead; verified failing on the pre-implementation base with this PR's files absent |
| `TestPreTool_AstGrepSkipReasonSurfaces` | internal/hook | A/B-verified on the pre-implementation base (fails identically with this PR's files removed); touches the internal/hook ast-grep reason chain, which this PR does not modify |

`TestAutonomyTierReader` (internal/config) failed on the old base and is resolved by #1527 now in this branch's base — the known set dropped 3 → 2 at rebase.

## Notes

- All test runs scrub the kanban companion env vars (`MOAI_KANBAN*`, `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP`) that otherwise leak into `go test` children as ~6 false failures.
- The todo skill's behavioral effect (model running `moai todo` instead of Read→Write) gets live verification by the kanban lead post-merge.

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `moai todo` CLI for adding, listing, completing, and selecting backlog items.
  * Supports text or JSON listing, persistent item IDs, optional SPEC ID attachment, and queue states.
  * Added safe concurrent updates with locking, atomic saves, retry handling, and malformed-file protection.
  * Supports existing backlog formats and operates without role restrictions.

* **Documentation**
  * Added specifications, implementation plans, research, progress tracking, acceptance criteria, and synchronized workflow guidance.

* **Tests**
  * Added comprehensive coverage for CLI behavior, concurrency, persistence, validation, locking, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->