### PR TITLE
fix(config): restore system.yaml version to rc.2, matching pkg/version

### DIFF
--- a/.moai/config/sections/system.yaml
+++ b/.moai/config/sections/system.yaml
@@ -43,9 +43,9 @@ github:
     enable_trust_5: true
     spec_git_workflow: feature_branch
 moai:
-    template_version: v3.1.0-rc.5
+    template_version: v3.1.0-rc.2
     update_check_frequency: daily
-    version: v3.1.0-rc.5
+    version: v3.1.0-rc.2
     version_check:
         cache_ttl_hours: 24
         enabled: true


### PR DESCRIPTION
## Problem

`main` is self-contradictory on version:

| Surface | Value |
|---|---|
| `.moai/config/sections/system.yaml` → `moai.version` / `moai.template_version` | `v3.1.0-rc.5` |
| `pkg/version/version.go` → `Version` | `v3.1.0-rc.2` |
| newest git tag | `v3.1.0-rc.2` |

PR #1526 bumped the config fields to rc.5 while its own commit body records that `pkg/version/version.go` and its six paired golden fixtures were **intentionally excluded**.

## Why revert rather than complete the bump

- The rc.5 edit to `pkg/version/version.go` **does not exist anywhere**: `git log --all -S'rc.5' -- pkg/version/version.go` returns nothing, and no branch or stash carries it.
- **No `v3.1.0-rc.3` or `-rc.4` was ever released** — tags stop at `rc.2` — so there is no basis for the two-step jump.
- Both fields are rendered from `{{.Version}}` in `internal/template/templates/.moai/config/sections/system.yaml.tmpl`, so their value **tracks** `pkg/version`; it should never lead it.

A real version bump belongs to the release process, where `version.go`, the goldens, and the tag move as one unit.

## Change

Two lines in `.moai/config/sections/system.yaml`: `v3.1.0-rc.5` → `v3.1.0-rc.2`.

## Verification

- `grep -rn "rc\.5" --include='*.go' --include='*.yaml' --include='*.golden' .` → 0 hits after the change
- `go test ./internal/statusline/... ./internal/config/...` → all `ok` (statusline reads `moai.template_version`; config owns the section loader)
- Golden fixtures untouched — they render from `pkg/version`, which is unchanged at rc.2 and now agrees with the config

Closes kanban card t13.

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application template and version identifiers.
  * Daily update-check frequency remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->