### PR TITLE
fix(kanban): join board lock release errors in both directions

### DIFF
--- a/internal/kanban/board_lock_join_test.go
+++ b/internal/kanban/board_lock_join_test.go
@@ -1,0 +1,64 @@
+// board_lock_join_test.go — regression coverage for the board-store lock
+// release fold (joinBoardReleaseErr). The two guarded board entry points
+// (WriteBoardState, RecoverBoard) share the fold, so its four-combination
+// contract is exercised directly here rather than through the entry points —
+// the release path closes a file descriptor, which a test cannot fail on
+// demand (same constraint that shaped the backlog_store precedent).
+package kanban
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestJoinBoardReleaseErr_BothFailuresSurvive — the regression this exists
+// for: when the mutation fails AND the lock release fails, BOTH must reach the
+// caller. The prior guard (`relErr != nil && err == nil`) dropped the release
+// error in exactly that case, so a wedged lock — the artifact that blocks
+// every later writer on Windows — surfaced as an ordinary mutation fault.
+// Both guarded entry points share the fold, so both op prefixes are checked.
+func TestJoinBoardReleaseErr_BothFailuresSurvive(t *testing.T) {
+	t.Parallel()
+	mutErr := errors.New("mutation refused")
+	relErr := errors.New("close: bad file descriptor")
+
+	for _, op := range []string{"write board state", "recover board"} {
+		got := joinBoardReleaseErr(mutErr, relErr, op)
+		if got == nil {
+			t.Fatalf("joinBoardReleaseErr(mut, rel, %q) = nil; want both errors", op)
+		}
+		if !errors.Is(got, mutErr) {
+			t.Errorf("%s: mutation error did not survive the join: %v", op, got)
+		}
+		if !errors.Is(got, relErr) {
+			t.Errorf("%s: release error did not survive the join: %v", op, got)
+		}
+		if !strings.Contains(got.Error(), op+": lock release failed") {
+			t.Errorf("%s: joined error does not name the entry point and release failure: %v", op, got)
+		}
+	}
+}
+
+// TestJoinBoardReleaseErr_SingleAndCleanPaths — the other three combinations.
+// A clean release must not manufacture an error, and either failure alone must
+// pass through identifiably.
+func TestJoinBoardReleaseErr_SingleAndCleanPaths(t *testing.T) {
+	t.Parallel()
+	mutErr := errors.New("mutation refused")
+	relErr := errors.New("close: bad file descriptor")
+
+	if got := joinBoardReleaseErr(nil, nil, "write board state"); got != nil {
+		t.Errorf("both-clean returned %v; want nil", got)
+	}
+	if got := joinBoardReleaseErr(mutErr, nil, "write board state"); !errors.Is(got, mutErr) {
+		t.Errorf("mutation-only returned %v; want the mutation error", got)
+	}
+	got := joinBoardReleaseErr(nil, relErr, "recover board")
+	if !errors.Is(got, relErr) {
+		t.Errorf("release-only returned %v; want the release error", got)
+	}
+	if !strings.Contains(got.Error(), "recover board: lock release failed") {
+		t.Errorf("release-only error does not name the entry point: %v", got)
+	}
+}

--- a/internal/kanban/board_recover.go
+++ b/internal/kanban/board_recover.go
@@ -70,11 +70,11 @@ func RecoverBoard(root, sessionID string) (result *RecoveryResult, err error) {
 	if err != nil {
 		return nil, fmt.Errorf("recover board: %w", err)
 	}
-	// See WriteBoardState: release errors are joined, not discarded (F5).
+	// See WriteBoardState: release errors are joined, not discarded (F5) —
+	// including a release failure arriving alongside a recovery failure, which
+	// is the dangerous case, not the harmless one.
 	defer func() {
-		if relErr := lock.Release(); relErr != nil && err == nil {
-			err = fmt.Errorf("recover board: verdict delivered but lock release failed: %w", relErr)
-		}
+		err = joinBoardReleaseErr(err, lock.Release(), "recover board")
 	}()
 
 	raw, err := os.ReadFile(BoardPath(root))

--- a/internal/kanban/board_store.go
+++ b/internal/kanban/board_store.go
@@ -143,15 +143,14 @@ func WriteBoardState(root, sessionID string, mutate func(*BoardState) error) (er
 	if err != nil {
 		return fmt.Errorf("write board state: %w", err)
 	}
-	// Release errors are JOINED into the result rather than discarded: on
-	// Windows release removes the artifact, so a failed removal after a
-	// successful write would silently block every later writer (sync-audit
-	// F5). The mutation has landed; surfacing the release failure keeps the
-	// block visible instead of quiet.
+	// Release errors are JOINED into the result rather than discarded (see
+	// joinBoardReleaseErr): on Windows release removes the artifact, so a
+	// failed removal would silently block every later writer (sync-audit F5).
+	// The join runs in BOTH directions — a release failure arriving alongside
+	// a mutation failure must survive too, or the wedged lock hides behind an
+	// unrelated refusal message.
 	defer func() {
-		if relErr := lock.Release(); relErr != nil && err == nil {
-			err = fmt.Errorf("write board state: mutation landed but lock release failed: %w", relErr)
-		}
+		err = joinBoardReleaseErr(err, lock.Release(), "write board state")
 	}()
 
 	st, err := LoadBoard(root)
@@ -188,6 +187,26 @@ func WriteBoardState(root, sessionID string, mutate func(*BoardState) error) (er
 	}
 
 	return writeBoardAtomic(root, st)
+}
+
+// joinBoardReleaseErr folds a board-lock release failure into the mutation's
+// own result. It JOINS rather than overwrites, and joins in both directions: a
+// release failure that arrives alongside a mutation failure is the dangerous
+// case, not the harmless one. Reporting only the mutation error there hides a
+// wedged lock behind an unrelated message — on Windows release removes the
+// artifact, so the survivor blocks every later writer while the operator
+// retries against what looks like a transient mutation fault.
+//
+// op names the calling entry point ("write board state" / "recover board") so
+// the joined release error reads as that site's own.
+//
+// Returns nil only when both are nil, so the caller's `err` stays clean on the
+// success path.
+func joinBoardReleaseErr(mutErr, relErr error, op string) error {
+	if relErr == nil {
+		return mutErr
+	}
+	return errors.Join(mutErr, fmt.Errorf("%s: lock release failed: %w", op, relErr))
 }
 
 // writeBoardAtomic persists st through the same-directory temp + atomic


### PR DESCRIPTION
## Failure mode

Both guarded board entry points — `WriteBoardState` (`internal/kanban/board_store.go`) and `RecoverBoard` (`internal/kanban/board_recover.go`) — guarded the deferred board-lock release with:

```go
if relErr := lock.Release(); relErr != nil && err == nil {
```

so when the mutation ALSO failed, the release error was silently discarded. On Windows, release removes the lock artifact: a dropped release failure leaves the artifact in place, wedging every later writer, while the operator reads an ordinary mutation error and retries into a store nothing can enter. Both sites already carried comments promising "release errors are joined, not discarded (F5)" — the code contradicted its own documented contract.

## Fix

Fold the release result through a shared `joinBoardReleaseErr(mutErr, relErr, op)`, mirroring the `backlog_store.go` `Mutate` precedent (PR #1529): joins in both directions, returns nil only when both inputs are nil. **Helper decision**: the two board sites share ONE helper parameterized by the entry-point prefix (`"write board state"` / `"recover board"`) — the fold logic is identical and the only per-site variance is the prefix, so two separate helpers would be copy-paste bodies differing in one literal. The message wording converges to `"<op>: lock release failed: %w"` (the precedent's neutral phrasing) because the old site-specific qualifiers ("mutation landed", "verdict delivered") would be FALSE in the both-fail case the fix exists to surface. `backlog_store.go`'s own helper is untouched (formats a path into its message; separate concern, out of scope).

The stale-promising comments at both sites now describe the actual both-direction join.

## Tests

`internal/kanban/board_lock_join_test.go` — the precedent's four-combination shape (both-fail / mutation-only / release-only / both-clean), asserted over both op prefixes:

- `TestJoinBoardReleaseErr_BothFailuresSurvive` — both errors survive the join (`errors.Is` on each) with the entry-point prefix named
- `TestJoinBoardReleaseErr_SingleAndCleanPaths` — clean release manufactures nothing; either failure alone passes through identifiably

Tested through the extracted fold rather than the entry points, same as the precedent: the Unix release path closes a function-local file descriptor, which a test cannot fail on demand from outside the function.

### RED (fix reverted locally, not committed)

```
internal/kanban/board_lock_join_test.go:27:10: undefined: joinBoardReleaseErr
internal/kanban/board_lock_join_test.go:51:12: undefined: joinBoardReleaseErr
internal/kanban/board_lock_join_test.go:54:12: undefined: joinBoardReleaseErr
internal/kanban/board_lock_join_test.go:57:9: undefined: joinBoardReleaseErr
FAIL\tgithub.com/modu-ai/moai-adk/internal/kanban [build failed]
```

### GREEN

```
--- PASS: TestJoinBoardReleaseErr_BothFailuresSurvive (0.00s)
--- PASS: TestJoinBoardReleaseErr_SingleAndCleanPaths (0.00s)
ok  \tgithub.com/modu-ai/moai-adk/internal/kanban\t0.490s
```

## Verification

| Check | Result |
|---|---|
| `go build ./...` | exit 0 |
| `go vet ./internal/kanban/...` | exit 0 |
| `GOOS=windows go vet ./internal/kanban/...` | exit 0 |
| `golangci-lint run ./internal/kanban/...` | `0 issues.` exit 0 |
| `go test ./internal/kanban/ -count=1` | `ok ... 25.6s` exit 0 |
| `gofmt -l` on the 3 touched files | empty (all formatted) |

Baseline note: `backlog_store_test.go` is unformatted on `main` (pre-existing, NOT touched by this PR — only the 3 files above are in the diff).

Draft on purpose — lead reads the evidence before undrafting.

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved board recovery and state-saving error handling.
  * Reports both the primary operation failure and any board-lock release failure, ensuring no error details are lost.
  * Preserves the original operation error while adding context for lock-release issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->