### PR TITLE
fix(ci): gate auto-merge on head-SHA freshness and CodeRabbit verdict

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -147,8 +147,9 @@ jobs:
           HEAD_SHA: ${{ steps.head.outputs.sha }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           REPO: ${{ github.repository }}
-          # Highest risk level still allowed to auto-merge: low | moderate | high.
-          # Defaults to the conservative "low"; set the repository variable
+          # Highest risk level still allowed to auto-merge, on CodeRabbit's
+          # ladder: minimal | low | moderate | high. Defaults to "low", which
+          # admits minimal and low. Set the repository variable
           # AUTOMERGE_MAX_MERGE_RISK to widen it without editing this workflow.
           MAX_RISK: ${{ vars.AUTOMERGE_MAX_MERGE_RISK || 'low' }}
         run: |
@@ -220,9 +221,12 @@ jobs:
                 exit 0 ;;
           esac
 
+          # Observed ladder across PRs #1524-#1535: minimal, low, moderate, high.
+          # Anything outside it ranks 0 and withholds the merge, so a level this
+          # workflow has never seen is treated as unsafe rather than assumed low.
           rank() {
             case "$1" in
-              low) echo 1 ;; moderate) echo 2 ;; high) echo 3 ;; *) echo 0 ;;
+              minimal) echo 1 ;; low) echo 2 ;; moderate) echo 3 ;; high) echo 4 ;; *) echo 0 ;;
             esac
           }
 

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -51,7 +51,40 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
+      # Guard (a) — head SHA re-verification.
+      # workflow_run carries the commit CI actually ran against. If the PR head
+      # moved since then, that CI result no longer describes what we would be
+      # merging, and merging anyway strands the newer commit outside main.
+      # Any uncertainty (API failure, empty value) withholds the merge.
+      - name: Verify PR head still matches the CI-tested commit
+        id: head
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TESTED_SHA: ${{ github.event.workflow_run.head_sha }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          CURRENT_SHA="$(gh pr view "$PR_NUMBER" --json headRefOid --jq '.headRefOid' 2>/dev/null || true)"
+
+          echo "CI tested : ${TESTED_SHA:-<empty>}"
+          echo "PR head   : ${CURRENT_SHA:-<empty>}"
+
+          if [ -z "$TESTED_SHA" ] || [ -z "$CURRENT_SHA" ]; then
+            echo "::warning::Could not resolve both SHAs - withholding merge"
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$TESTED_SHA" != "$CURRENT_SHA" ]; then
+            echo "::notice::PR head moved after CI ran - withholding merge"
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "sha=$CURRENT_SHA" >> "$GITHUB_OUTPUT"
+          echo "ok=true" >> "$GITHUB_OUTPUT"
+
       - name: Check all required CI checks passed
+        if: steps.head.outputs.ok == 'true'
         id: checks
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -94,8 +127,127 @@ jobs:
           echo "Timeout waiting for checks, skipping auto-merge"
           echo "should_merge=false" >> "$GITHUB_OUTPUT"
 
+      # Guard (b)+(c) — CodeRabbit gate.
+      # CodeRabbit reports through a commit status named "CodeRabbit" and writes
+      # its verdict into the walkthrough comment, between the
+      # final_review_risk_start/end markers, in the shape:
+      #   **Merge Risk:** _<emoji> Moderate_ - up to `<head sha prefix>`
+      # The trailing prefix says which commit the verdict covers, so a verdict
+      # left over from an earlier push can be told apart from a current one.
+      #
+      # Merge proceeds only when the verdict is present, current, and no worse
+      # than AUTOMERGE_MAX_MERGE_RISK. Every other outcome - status still
+      # pending at timeout, comment missing, marker block absent, unparseable
+      # level, stale prefix, API error - withholds the merge.
+      - name: Wait for CodeRabbit and read its Merge Risk verdict
+        id: coderabbit
+        if: steps.head.outputs.ok == 'true' && steps.checks.outputs.should_merge == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ steps.head.outputs.sha }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          REPO: ${{ github.repository }}
+          # Highest risk level still allowed to auto-merge: low | moderate | high.
+          # Defaults to the conservative "low"; set the repository variable
+          # AUTOMERGE_MAX_MERGE_RISK to widen it without editing this workflow.
+          MAX_RISK: ${{ vars.AUTOMERGE_MAX_MERGE_RISK || 'low' }}
+        run: |
+          echo "ok=false" >> "$GITHUB_OUTPUT"
+
+          # --- (b) wait for the CodeRabbit commit status to settle -----------
+          MAX_WAIT=60   # 60 x 15s = 15 minutes
+          WAIT=0
+          STATE=""
+
+          while [ "$WAIT" -lt "$MAX_WAIT" ]; do
+            STATE="$(gh api "repos/$REPO/commits/$HEAD_SHA/status" \
+              --jq '[.statuses[] | select(.context == "CodeRabbit")] | last | .state // ""' \
+              2>/dev/null || true)"
+
+            case "$STATE" in
+              success)          echo "CodeRabbit status: success"; break ;;
+              failure|error)    echo "::notice::CodeRabbit status is '$STATE' - withholding merge"; exit 0 ;;
+              *)                echo "CodeRabbit status: '${STATE:-<absent>}' - waiting ($WAIT/$MAX_WAIT)" ;;
+            esac
+
+            sleep 15
+            WAIT=$((WAIT + 1))
+          done
+
+          if [ "$STATE" != "success" ]; then
+            echo "::notice::Timed out waiting for CodeRabbit - withholding merge"
+            exit 0
+          fi
+
+          # --- (c) read the verdict out of the walkthrough comment -----------
+          BODY="$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+            --jq '[ .[]
+                    | select(.user.login | ascii_downcase | startswith("coderabbitai"))
+                    | .body
+                    | select(contains("final_review_risk_start")) ] | last // ""' \
+            2>/dev/null || true)"
+
+          if [ -z "$BODY" ]; then
+            echo "::notice::No CodeRabbit verdict comment found - withholding merge"
+            exit 0
+          fi
+
+          RISK_LINE="$(printf '%s\n' "$BODY" \
+            | sed -n '/final_review_risk_start/,/final_review_risk_end/p' \
+            | grep -m1 'Merge Risk:' || true)"
+
+          if [ -z "$RISK_LINE" ]; then
+            echo "::notice::Verdict block present but no Merge Risk line - withholding merge"
+            exit 0
+          fi
+
+          echo "Verdict line: $RISK_LINE"
+
+          LEVEL="$(printf '%s\n' "$RISK_LINE" \
+            | sed -E 's/.*Merge Risk:[^_]*_[^A-Za-z]*([A-Za-z]+).*/\1/' \
+            | tr '[:upper:]' '[:lower:]')"
+          COVERED="$(printf '%s\n' "$RISK_LINE" \
+            | sed -nE 's/.*up to `([0-9a-f]+)`.*/\1/p')"
+
+          # Freshness: the verdict must cover the commit we are about to merge.
+          if [ -z "$COVERED" ]; then
+            echo "::notice::Verdict carries no covered-commit prefix - withholding merge"
+            exit 0
+          fi
+          case "$HEAD_SHA" in
+            "$COVERED"*) echo "Verdict covers $COVERED - current" ;;
+            *)  echo "::notice::Verdict covers $COVERED but head is $HEAD_SHA - stale, withholding merge"
+                exit 0 ;;
+          esac
+
+          rank() {
+            case "$1" in
+              low) echo 1 ;; moderate) echo 2 ;; high) echo 3 ;; *) echo 0 ;;
+            esac
+          }
+
+          LEVEL_RANK="$(rank "$LEVEL")"
+          MAX_RANK="$(rank "$MAX_RISK")"
+
+          if [ "$LEVEL_RANK" -eq 0 ] || [ "$MAX_RANK" -eq 0 ]; then
+            echo "::notice::Unrecognised risk level (verdict='$LEVEL', ceiling='$MAX_RISK') - withholding merge"
+            exit 0
+          fi
+
+          echo "Merge Risk: $LEVEL (ceiling: $MAX_RISK)"
+
+          if [ "$LEVEL_RANK" -gt "$MAX_RANK" ]; then
+            echo "::notice::Risk '$LEVEL' exceeds ceiling '$MAX_RISK' - withholding merge"
+            exit 0
+          fi
+
+          echo "ok=true" >> "$GITHUB_OUTPUT"
+
       - name: Auto merge PR
-        if: steps.checks.outputs.should_merge == 'true'
+        if: >
+          steps.checks.outputs.should_merge == 'true' &&
+          steps.head.outputs.ok == 'true' &&
+          steps.coderabbit.outputs.ok == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_BRANCH: ${{ steps.pr.outputs.branch }}
@@ -113,9 +265,11 @@ jobs:
             echo "Using --squash (feature branch — squash WIP commits)"
           fi
 
+          # No --auto fallback: a deferred merge lands at a later moment, against
+          # whatever the head is by then, without re-running the guards above.
+          # A failed merge here is left for a human rather than deferred.
           if gh pr merge "$PR_NUMBER" $MERGE_FLAG --delete-branch; then
             echo "Successfully merged PR #$PR_NUMBER"
           else
-            echo "Merge failed, trying with --auto for deferred merge..."
-            gh pr merge "$PR_NUMBER" $MERGE_FLAG --delete-branch --auto || true
+            echo "::notice::Merge command failed - leaving PR #$PR_NUMBER open for review"
           fi


### PR DESCRIPTION
## 왜

`.github/workflows/auto-merge.yml` 은 CI 결론 하나만 보고 머지했습니다. #1532 에서 두 가지가 동시에 드러났습니다.

- 머지된 커밋이 **그 시점의 PR head 가 아니었습니다.** CI 가 검사한 커밋과 머지된 커밋이 달라, 나중에 푸시된 커밋이 어느 브랜치에도 없는 상태로 남았습니다(#1533 계열).
- 머지 시각 `02:38:53Z`, CodeRabbit 리뷰 제출 시각 `02:42:48Z` — **머지가 4분 빨랐습니다.** 게이트가 경고를 무시한 게 아니라, 경고를 볼 구조 자체가 없었습니다.

브랜치 보호 설정으로는 막히지 않습니다. 실측 결과 `strict: false`, `required_approving_review_count: 0`, required contexts 5개에 **CodeRabbit 이 포함돼 있지 않습니다.** 그래서 이 PR 은 리포 전역 설정을 건드리지 않고 워크플로 한 파일만 고칩니다.

## 무엇을

세 개의 가드를 추가하고, 지연 머지 폴백 하나를 제거했습니다. **모든 실패 방향은 "머지하지 않음"** 입니다.

### (a) head SHA 재확인

머지 직전 `gh pr view --json headRefOid` 로 현재 head 를 다시 읽어 `github.event.workflow_run.head_sha` 와 비교합니다. 다르면 그 CI 결과는 다른 커밋을 설명하는 것이므로 머지하지 않습니다.

### (b) CodeRabbit 완료 대기

CodeRabbit 은 체크런이 아니라 **커밋 status(`context: "CodeRabbit"`)** 로 붙습니다. 이 status 가 `success` 가 될 때까지 최대 15분(15초 × 60회) 기다립니다.

### (c) Merge Risk 판독 + 신선도 확인

CodeRabbit 은 walkthrough 코멘트의 `final_review_risk_start` / `final_review_risk_end` 마커 사이에 판정을 씁니다. 실측 형태:

```
**Merge Risk:** _🟡 Moderate_ · up to `14288`
```

끝의 `up to` 값은 **그 판정이 어느 커밋까지 커버하는지**를 담은 head SHA 접두사입니다. 이 값을 현재 head 와 대조해, 이전 푸시에 대한 묵은 판정이 통과하는 경로를 막습니다. 그다음 등급을 `AUTOMERGE_MAX_MERGE_RISK` 와 비교합니다.

### `--auto` 폴백 제거

직접 머지가 실패하면 `gh pr merge --auto` 로 지연 머지하던 경로를 없앴습니다. 지연 머지는 **나중 시점에, 그때의 head 에 대해** 실행되며 위 가드를 다시 거치지 않습니다. 실패는 사람에게 남깁니다.

## 어떤 입력에서 머지가 막히는가

| 상황 | 결과 |
|---|---|
| `workflow_run.head_sha` ≠ 현재 `headRefOid` | 가드 (a) → `ok=false`, 머지 없음 |
| 두 SHA 중 하나라도 조회 실패/공백 | 가드 (a) → 머지 없음 |
| CodeRabbit status 가 `failure` / `error` | 가드 (b) → 머지 없음 |
| 15분 안에 status 가 `success` 로 안 감 | 가드 (b) 타임아웃 → 머지 없음 |
| CodeRabbit 판정 코멘트 없음 | 가드 (c) → 머지 없음 |
| 마커 블록은 있는데 `Merge Risk:` 줄 없음 | 가드 (c) → 머지 없음 |
| 등급 문자열이 관측된 사다리 밖 | 가드 (c) → 머지 없음 |
| `up to` 접두사 없음 | 가드 (c) → 머지 없음 |
| `up to` 접두사가 현재 head 와 불일치(묵은 판정) | 가드 (c) → 머지 없음 |
| 등급이 `AUTOMERGE_MAX_MERGE_RISK` 초과 | 가드 (c) → 머지 없음 |
| 위 전부 통과 | 머지 진행 |

`if` 조건은 세 개가 모두 참일 때만 머지 스텝을 실행합니다:
`steps.checks.outputs.should_merge == 'true' && steps.head.outputs.ok == 'true' && steps.coderabbit.outputs.ok == 'true'`

## 임계값과 실제 분포 — 게이트는 자동화를 멈추지 않습니다

기본값은 `low` 입니다. CodeRabbit 등급 사다리는 **minimal → low → moderate → high** 이고, 기본값 `low` 는 **minimal 과 low 를 통과**시킵니다.

최근 PR 10건을 이 워크플로의 파서로 직접 훑은 실측 분포입니다.

| PR | Merge Risk | 기본 임계값 `low` 에서 |
|---|---|---|
| #1535 | minimal | 통과 |
| #1534 | minimal | 통과 |
| #1533 | low | 통과 |
| #1532 | moderate | 보류 |
| #1531 | minimal | 통과 |
| #1530 | minimal | 통과 |
| #1529 | moderate | 보류 |
| #1527 | **판정 없음** | 보류 |
| #1526 | moderate | 보류 |
| #1524 | high | 보류 |

분포: minimal 4 / low 1 / moderate 3 / high 1 / 없음 1.

판정이 있는 9건 중 **5건이 정상 통과**합니다. 이 게이트는 auto-merge 를 상시 정지시키는 것이 아니라 **위험한 것만 골라 막습니다** — 원래 의도 그대로입니다.

임계값은 워크플로에 하드코딩하지 않고 저장소 변수로 뺐습니다:

```yaml
MAX_RISK: ${{ vars.AUTOMERGE_MAX_MERGE_RISK || 'low' }}
```

- 기본값 `low` — minimal + low 통과. 위 표본에서 5/9 통과.
- 넓히려면 파일 수정 없이 리포 변수만: `gh variable set AUTOMERGE_MAX_MERGE_RISK --body moderate` (그러면 8/9 통과)
- 변수가 오타거나 사다리 밖 값이면 등급 비교가 성립하지 않으므로 **머지하지 않습니다** (fail-closed).

> **이 PR 리뷰 중 잡힌 결함 하나.** 등급 사다리를 처음에 표본 2건(#1532·#1529)만 보고 만들었는데 둘 다 Moderate 라, `rank()` 에 `low/moderate/high` 세 개만 넣고 `minimal` 을 빠뜨렸습니다. 그 상태였다면 minimal 4건이 전부 "등급 불명 → 보류" 로 떨어져, **표본에서 가장 안전한 PR 들이 오히려 다 막혔을** 겁니다. fail-closed 방향이라 위험한 것이 새어 나가지는 않지만 잘못된 동작입니다. 표본을 10건으로 넓혀 재측정한 뒤 커밋 `e3a2ef4ec` 에서 고쳤습니다.

## 덤 — #1527 형태(CodeRabbit 이 리뷰를 못 한 PR)도 함께 막힙니다

표본의 #1527 은 **판정 자체가 없습니다.** CodeRabbit 이 rate limit 등으로 리뷰를 완료하지 못했는데도 체크 행은 통과로 보이던 사례입니다.

이 PR 의 fail-closed 설계에서 "판정 코멘트 없음 → 머지 안 함" 이므로, head SHA 문제를 고치면서 **이 경로까지 같이 닫힙니다.** 별도 작업이 필요 없습니다.

## 검증

워크플로는 `go test` 로 잡히지 않아 다음으로 확인했습니다.

**1) YAML 파싱 + 스텝 구조**

```
YAML OK; steps = 7
['Get PR number', 'Skip if not open or already merged', 'Checkout repository',
 'Verify PR head still matches the CI-tested commit',
 'Check all required CI checks passed',
 'Wait for CodeRabbit and read its Merge Risk verdict', 'Auto merge PR']
```

**2) 모든 `run:` 블록 `bash -n`**

```
  [PASS] Get PR number
  [PASS] Skip if not open or already merged
  [PASS] Verify PR head still matches the CI-tested commit
  [PASS] Check all required CI checks passed
  [PASS] Wait for CodeRabbit and read its Merge Risk verdict
  [PASS] Auto merge PR
exit=0
```

**3) 가드 (c) 파서를 실제 PR 데이터로 재생**

문법만 맞고 파싱이 헛도는 경우를 배제하기 위해, 워크플로에 넣은 것과 같은 `gh api` + `sed` 파이프라인을 실제 코멘트에 돌렸습니다.

```
# 현재 head 로 실행 (통과해야 하는 경우)
LINE : **Merge Risk:** _🟡 Moderate_ · up to `14288`
LEVEL: 'moderate'   COVER: '14288'   FRESH: yes   STATUS: success

# 일부러 다른 SHA 로 실행 (묵은 판정으로 막혀야 하는 경우)
COVER: '14288'   FRESH: no

# 다른 PR 표본 (#1529)
LINE : **Merge Risk:** _🟡 Moderate_ · up to `d4e4b`
LEVEL: 'moderate'   COVER: 'd4e4b'   FRESH: yes
```

**4) 수정된 `rank()` 게이트를 10건 분포에 재생**

```
ceiling = low (rank 2)

#1535    minimal      MERGE
#1534    minimal      MERGE
#1533    low          MERGE
#1532    moderate     WITHHELD (above ceiling)
#1531    minimal      MERGE
#1530    minimal      MERGE
#1529    moderate     WITHHELD (above ceiling)
#1527    NONE         WITHHELD
#1526    moderate     WITHHELD (above ceiling)
#1524    high         WITHHELD (above ceiling)
```

**검증되지 않은 부분(미검증)**: 워크플로를 `workflow_run` 이벤트로 실제 발화시킨 end-to-end 실행은 아직 없습니다. 이 PR 이 머지된 후 다음 PR 이 첫 실전 실행이 됩니다. 대기 루프의 타임아웃 값(15분)이 CodeRabbit 의 실제 소요 시간에 충분한지도 실측 표본이 없습니다 — 부족하면 타임아웃 → 머지 보류이므로 안전 방향으로 실패합니다.

## draft 로 여는 이유

이 PR 자체가 auto-merge 대상입니다. 아직 **옛 게이트가 살아 있어서**, 리드가 증거를 읽기 전에 자기 자신을 머지해 버릴 수 있습니다. 검토가 끝난 뒤 ready 로 전환해 주세요.

🗿 MoAI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved auto-merge safeguards by verifying that the latest commit passed CI before merging.
  * Added validation of automated risk assessments and their freshness.
  * Prevented merges when risk exceeds the configured threshold.
  * Failed merge attempts now remain open for review instead of using a fallback merge option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->