### PR TITLE
docs(skill): split /moai todo verbs into slash and CLI-only surfaces

### DIFF
--- a/.claude/skills/moai/SKILL.md
+++ b/.claude/skills/moai/SKILL.md
@@ -78,7 +78,7 @@ The `--team` / `--solo` flags are forced overrides onto the catalog; the flag-fr
 - **e2e** (aliases: e2e-test, end-to-end): Multi-platform end-to-end testing (web/mobile/desktop) with project-type auto-detection and CLI-first toolchain selection
 - **harness** (aliases: hrn): harness lifecycle management — learning-lifecycle verbs (status / apply / rollback &lt;date&gt; / disable) + v4-lifecycle verbs (list / edit / remove / doctor), all dispatching through the unified `moai harness` Go-binary Cobra subcommand tree; the slash command is the documented user-facing entry point
 - **goal**: Condition-declared universal agentic loop — arm a completion condition (`/moai goal "<condition>"`), check status, clear, or resume; evaluated each turn-end by the `stop-goal` Stop hook
-- **todo** (aliases: backlog): Backlog queue — add an item (`/moai todo "<description>"`), list the queue, pick the next card (`next`), or remove one (`done <n>`); the operator's entry point into the kanban board
+- **todo** (aliases: backlog): Backlog queue — the slash surface covers two acts: add an item (`/moai todo "<description>"`) and list the queue (bare `/moai todo`). Picking the next card and removing one are CLI-only verbs, run as `moai todo next [<n>]` and `moai todo done <n>`; the operator's entry point into the kanban board
 
 ### Priority 2: SPEC-ID Detection
 
@@ -166,7 +166,7 @@ For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/goal.md
 ### todo - Backlog Queue
 
 Purpose: Hold what the operator wants to work on next. `backlog` has no owning session, so admission to the board is always an operator act — this is that surface.
-Verbs: `/moai todo "<description>"` (append), bare `/moai todo` (list), `next` (pick via AskUserQuestion), `done <n>` (remove).
+Verbs — slash surface: `/moai todo "<description>"` (append), bare `/moai todo` (list). CLI only: `moai todo next` (print queued cards; `moai todo next <n> [--spec <SPEC-ID>]` marks one picked — the pick itself is presented through AskUserQuestion), `moai todo done <n>` (remove).
 State: `.moai/state/kanban/backlog.json` — project-local, not committed, atomic writes.
 The pick is the operator's: never preselect, never reorder by inferred priority, never auto-populate from TODO comments or issues.
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/todo.md

--- a/internal/template/catalog.yaml
+++ b/internal/template/catalog.yaml
@@ -6,7 +6,7 @@ catalog:
             - name: moai
               tier: core
               path: templates/.claude/skills/moai/
-              hash: 5edfdaed1ff9ded83fa662873c2f12386e556ed1eb8b51a24b6e62d343b20f6a
+              hash: a25bad843f7715f9b62e040d2c120eec1085df8ca8f3aa616153fe616b6bebb9
               version: 1.0.0
             - name: moai-foundation-cc
               tier: core

--- a/internal/template/templates/.claude/skills/moai/SKILL.md
+++ b/internal/template/templates/.claude/skills/moai/SKILL.md
@@ -78,7 +78,7 @@ The `--team` / `--solo` flags are forced overrides onto the catalog; the flag-fr
 - **e2e** (aliases: e2e-test, end-to-end): Multi-platform end-to-end testing (web/mobile/desktop) with project-type auto-detection and CLI-first toolchain selection
 - **harness** (aliases: hrn): harness lifecycle management — learning-lifecycle verbs (status / apply / rollback &lt;date&gt; / disable) + v4-lifecycle verbs (list / edit / remove / doctor), all dispatching through the unified `moai harness` Go-binary Cobra subcommand tree; the slash command is the documented user-facing entry point
 - **goal**: Condition-declared universal agentic loop — arm a completion condition (`/moai goal "<condition>"`), check status, clear, or resume; evaluated each turn-end by the `stop-goal` Stop hook
-- **todo** (aliases: backlog): Backlog queue — add an item (`/moai todo "<description>"`), list the queue, pick the next card (`next`), or remove one (`done <n>`); the operator's entry point into the kanban board
+- **todo** (aliases: backlog): Backlog queue — the slash surface covers two acts: add an item (`/moai todo "<description>"`) and list the queue (bare `/moai todo`). Picking the next card and removing one are CLI-only verbs, run as `moai todo next [<n>]` and `moai todo done <n>`; the operator's entry point into the kanban board
 
 ### Priority 2: SPEC-ID Detection
 
@@ -166,7 +166,7 @@ For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/goal.md
 ### todo - Backlog Queue
 
 Purpose: Hold what the operator wants to work on next. `backlog` has no owning session, so admission to the board is always an operator act — this is that surface.
-Verbs: `/moai todo "<description>"` (append), bare `/moai todo` (list), `next` (pick via AskUserQuestion), `done <n>` (remove).
+Verbs — slash surface: `/moai todo "<description>"` (append), bare `/moai todo` (list). CLI only: `moai todo next` (print queued cards; `moai todo next <n> [--spec <SPEC-ID>]` marks one picked — the pick itself is presented through AskUserQuestion), `moai todo done <n>` (remove).
 State: `.moai/state/kanban/backlog.json` — project-local, not committed, atomic writes.
 The pick is the operator's: never preselect, never reorder by inferred priority, never auto-populate from TODO comments or issues.
 For detailed orchestration: Read ${CLAUDE_SKILL_DIR}/workflows/todo.md


### PR DESCRIPTION
## What

`.claude/skills/moai/SKILL.md` listed the four `todo` verbs (`add` / `list` / `next` / `done`) in one run, without saying which surface each belongs to. Only `add` and `list` are reachable as `/moai todo …`; `next` and `done` are terminal CLI verbs (`moai todo next`, `moai todo done <n>`).

Two lines corrected, in the local skill and its template mirror:

- the subcommand-catalog bullet (`- **todo** (aliases: backlog): …`)
- the `### todo - Backlog Queue` → `Verbs:` line

`catalog.yaml` regenerated via `make build`.

## What this does NOT do

- No slash wiring is added — `next` / `done` stay CLI-only, per the operator's decision.
- `workflows/todo.md` is untouched; its command table was already correct.

## Verification

- `MOAI_TEMPLATE_LEAK_STRICT=1 go test ./...` — two failures, both reproduced on `main` without this change (pre-existing, environment-dependent): `TestPreTool_AstGrepSkipReasonSurfaces` (internal/hook) and `TestHandleCodexReviewGate_LiveCodexBlocksInjectionAndKey` (internal/cli, live codex backend). Template-neutrality checks pass.
- `grep -rn "moai todo" docs-site/ README*.md` — the 4-locale docs already state the corrected contract explicitly ("Removing an item and picking the next card are not verbs on the slash surface"), so the skill was the only surface out of step. No docs edits needed.

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified todo workflow documentation by distinguishing slash-command actions from CLI-only operations.
  * Documented how to select and complete todo items, including optional SPEC association when selecting an item.
* **Chores**
  * Updated the internal catalog metadata to reflect the latest documentation changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->