### PR TITLE
feat(kanban): name the lead session so it survives /clear

### DIFF
--- a/internal/cli/cc.go
+++ b/internal/cli/cc.go
@@ -117,6 +117,9 @@ func runCC(cmd *cobra.Command, args []string) error {
 	case kanbanBranchLead:
 		defer enterKanbanMode(specID)()
 		recordKanbanSession(specID, kanban.BackendClaude, kanban.RoleLead)
+		// A lead launched bare has only an AI-generated title, which claude
+		// discards on /clear; naming it explicitly is what survives.
+		filteredArgs = append(filteredArgs, leadNameArgs(filteredArgs)...)
 		settingsFlag, settingsCleanup := prepareKanbanSettings(filteredArgs)
 		if len(settingsFlag) > 0 {
 			filteredArgs = append(filteredArgs, settingsFlag...)

--- a/internal/cli/glm.go
+++ b/internal/cli/glm.go
@@ -185,6 +185,8 @@ func runGLM(cmd *cobra.Command, args []string) error {
 	case kanbanBranchLead:
 		defer enterKanbanMode(specID)()
 		recordKanbanSession(specID, kanban.BackendGLM, kanban.RoleLead)
+		// See cc.go: glm mirrors the lead branch exactly.
+		filteredArgs = append(filteredArgs, leadNameArgs(filteredArgs)...)
 		settingsFlag, settingsCleanup := prepareKanbanSettings(filteredArgs)
 		if len(settingsFlag) > 0 {
 			filteredArgs = append(filteredArgs, settingsFlag...)

--- a/internal/cli/kanban.go
+++ b/internal/cli/kanban.go
@@ -270,6 +270,60 @@ func parseCompanionLabel(args []string) (label string, ok bool) {
 	return "", false
 }
 
+// operatorSuppliedName reports whether the operator named this session
+// themselves, in any of the four forms claude accepts (`--name v`, `--name=v`,
+// `-n v`, `-n=v`), before the pass-through marker.
+//
+// It is deliberately NOT parseCompanionLabel: that function matches the
+// companion SHAPE, so a lead the operator named `board-watch` reads as "no
+// name present" there. The question here is only whether a name exists at all,
+// because the operator's choice wins over any moai-supplied one.
+//
+// The `--` discipline matches operatorSuppliedSettings and parseKanbanFlag:
+// nothing past the marker is read — a `--name` after `--` is the backend's
+// argument, already destined for claude unchanged.
+func operatorSuppliedName(args []string) bool {
+	for _, arg := range args {
+		switch {
+		case arg == "--":
+			return false
+		case arg == nameFlagLong || arg == nameFlagShort:
+			return true
+		case strings.HasPrefix(arg, nameFlagLong+"="):
+			return true
+		case strings.HasPrefix(arg, nameFlagShort+"="):
+			return true
+		}
+	}
+	return false
+}
+
+// leadNameArgs returns the `--name lead-<run-id>` pair to append to a lead
+// session's argv, or nil when the lead should carry no injected name.
+//
+// The injection exists because claude keeps an EXPLICIT name across /clear and
+// discards an AI-generated title. A companion is already explicitly named — the
+// SessionStart notice prints `--name <role>-<run-id>` and the operator pastes
+// it — so only the lead, launched as a bare `moai cc -k`, loses its identity on
+// every clear and has to be renamed by hand.
+//
+// The run id is read from the environment enterKanbanMode has just published,
+// which is this file's established carrier for the kanban signal; callers
+// therefore invoke this AFTER entering kanban mode. Two self-gates make the
+// call site unconditional: an operator-supplied name wins (nothing is
+// injected), and an absent run id yields nothing rather than the nonsense name
+// `lead-`.
+func leadNameArgs(args []string) []string {
+	if operatorSuppliedName(args) {
+		return nil
+	}
+	runID := os.Getenv(config.EnvMoaiKanbanID)
+	if runID == "" {
+		return nil
+	}
+	return []string{nameFlagLong, kanban.LeadLabel(runID)}
+}
+
 // rejectKanbanOnCG returns the sentinel-bearing error when a kanban token
 // appears in a `moai cg` invocation, and nil otherwise.
 func rejectKanbanOnCG(args []string) error {

--- a/internal/cli/kanban_lead_name_test.go
+++ b/internal/cli/kanban_lead_name_test.go
@@ -1,0 +1,126 @@
+package cli
+
+// kanban_lead_name_test.go pins the lead-session name injection: a lead
+// launched as a bare `moai cc -k` carries only an AI-generated title, which
+// claude discards on /clear, so the launcher supplies an explicit
+// `--name lead-<run-id>` instead. The operator's own name always wins.
+
+import (
+	"os"
+	"testing"
+
+	"github.com/modu-ai/moai-adk/internal/config"
+	"github.com/modu-ai/moai-adk/internal/kanban"
+)
+
+// TestOperatorSuppliedName covers every form claude accepts for a session name,
+// plus the two cases that must read as "no name": absent entirely, and present
+// only past the pass-through marker.
+func TestOperatorSuppliedName(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{"absent", []string{"-p", "work"}, false},
+		{"empty", nil, false},
+		{"--name value", []string{"--name", "board-watch"}, true},
+		{"--name=value", []string{"--name=board-watch"}, true},
+		{"-n value", []string{"-n", "board-watch"}, true},
+		{"-n=value", []string{"-n=board-watch"}, true},
+		{"companion-shape name still counts", []string{"--name", "run-abc123"}, true},
+		{"past the pass-through marker is not ours", []string{"--", "--name", "x"}, false},
+		{"before the marker still counts", []string{"--name", "x", "--", "--print"}, true},
+		// A bare `--name` with no following token is still an operator name
+		// declaration: moai must not append a second one and hand claude two.
+		{"dangling --name", []string{"--name"}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			if got := operatorSuppliedName(c.args); got != c.want {
+				t.Errorf("operatorSuppliedName(%q) = %v, want %v", c.args, got, c.want)
+			}
+		})
+	}
+}
+
+// TestLeadNameArgs_InjectsWhenUnnamed is the core case: a bare lead gets an
+// explicit name derived from the run id enterKanbanMode published.
+func TestLeadNameArgs_InjectsWhenUnnamed(t *testing.T) {
+	clearAllKanbanEnv(t)
+	t.Setenv(config.EnvMoaiKanbanID, "abc123")
+
+	got := leadNameArgs([]string{"-p", "work"})
+	want := []string{"--name", "lead-abc123"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("leadNameArgs = %q, want %q", got, want)
+	}
+}
+
+// TestLeadNameArgs_NeverOverridesOperatorName is the requirement that an
+// operator who named their lead by hand keeps that name — in every form.
+func TestLeadNameArgs_NeverOverridesOperatorName(t *testing.T) {
+	clearAllKanbanEnv(t)
+	t.Setenv(config.EnvMoaiKanbanID, "abc123")
+
+	for _, args := range [][]string{
+		{"--name", "board-watch"},
+		{"--name=board-watch"},
+		{"-n", "board-watch"},
+		{"-n=board-watch"},
+	} {
+		if got := leadNameArgs(args); got != nil {
+			t.Errorf("leadNameArgs(%q) = %q, want nil (operator name wins)", args, got)
+		}
+	}
+}
+
+// TestLeadNameArgs_NoRunIDNoName is the fail-open gate: without a run id the
+// injection is skipped rather than producing the nonsense name `lead-`.
+func TestLeadNameArgs_NoRunIDNoName(t *testing.T) {
+	clearAllKanbanEnv(t)
+
+	if got := leadNameArgs(nil); got != nil {
+		t.Errorf("leadNameArgs with no run id = %q, want nil", got)
+	}
+}
+
+// TestLeadNameArgs_LabelIsNotCompanionShape guards the reclassification hazard:
+// the injected name must never satisfy the companion-shape discriminator, or a
+// re-parse of the argv would route the lead down the companion branch.
+func TestLeadNameArgs_LabelIsNotCompanionShape(t *testing.T) {
+	clearAllKanbanEnv(t)
+	t.Setenv(config.EnvMoaiKanbanID, "abc123")
+
+	args := leadNameArgs(nil)
+	if len(args) != 2 {
+		t.Fatalf("leadNameArgs = %q, want a --name pair", args)
+	}
+	if _, _, isCompanion := kanban.SplitCompanionLabel(args[1]); isCompanion {
+		t.Errorf("injected lead label %q reads as a companion label", args[1])
+	}
+	if _, ok := parseCompanionLabel(args); ok {
+		t.Errorf("injected lead label %q is picked up by parseCompanionLabel", args[1])
+	}
+}
+
+// TestLeadNameArgs_UsesRunIDFromEnterKanbanMode wires the helper to the real
+// producer rather than a hand-set variable, so a change to where the run id is
+// published breaks this test instead of passing silently.
+func TestLeadNameArgs_UsesRunIDFromEnterKanbanMode(t *testing.T) {
+	clearAllKanbanEnv(t)
+	restore := enterKanbanMode("")
+	defer restore()
+
+	runID := os.Getenv(config.EnvMoaiKanbanID)
+	if runID == "" {
+		t.Fatal("enterKanbanMode published no run id")
+	}
+	args := leadNameArgs(nil)
+	if len(args) != 2 || args[1] != kanban.LeadLabel(runID) {
+		t.Errorf("leadNameArgs = %q, want [--name %s]", args, kanban.LeadLabel(runID))
+	}
+}

--- a/internal/kanban/bootstrap.go
+++ b/internal/kanban/bootstrap.go
@@ -64,6 +64,16 @@ func CompanionLabel(role, runID string) string {
 	return role + "-" + runID
 }
 
+// LeadLabel joins the lead role and a run id into the label a lead session is
+// launched under, in the same `<role>-<run-id>` form CompanionLabel produces.
+//
+// The label deliberately never satisfies SplitCompanionLabel: RoleLead is
+// absent from CompanionRoles, so a session launched under this name is never
+// reclassified as a companion by the shape discriminator.
+func LeadLabel(runID string) string {
+	return RoleLead + "-" + runID
+}
+
 // SplitCompanionLabel splits a `<role>-<run-id>` label into its parts and
 // reports whether the value has the companion shape at all.
 //

--- a/internal/kanban/bootstrap_test.go
+++ b/internal/kanban/bootstrap_test.go
@@ -143,3 +143,19 @@ func TestCompanionLabelRoundTrips(t *testing.T) {
 		}
 	}
 }
+
+// TestLeadLabelIsNotACompanion pins the property the launcher's name injection
+// relies on: the lead label shares the `<role>-<run-id>` form but is never
+// recognized as a companion, because RoleLead is absent from CompanionRoles.
+func TestLeadLabelIsNotACompanion(t *testing.T) {
+	t.Parallel()
+
+	runID := NewRunID()
+	label := LeadLabel(runID)
+	if want := RoleLead + "-" + runID; label != want {
+		t.Errorf("LeadLabel(%q) = %q, want %q", runID, label, want)
+	}
+	if _, _, ok := SplitCompanionLabel(label); ok {
+		t.Errorf("LeadLabel(%q) = %q reads as a companion label", runID, label)
+	}
+}


### PR DESCRIPTION
## Problem

A kanban **lead** loses its session name on every `/clear`; companions do not.

Claude Code's documented behavior (`code.claude.com/docs/en/sessions`, `/clear`):

> You keep a name you set with `--name` or `/rename` in the new conversation, but not an AI-generated session title

So an explicit name survives and a generated title does not. Companions are launched from the SessionStart notice (`internal/hook/session_start_kanban.go:119`), which prints `moai cc -k --name <role>-<run-id>` — an explicit name. The lead is launched as a bare `moai cc -k`, so it only ever had a generated title.

`grep -rn 'append.*"--name"' internal/ --include='*.go'` returned no matches before this change: nothing in the codebase supplied a name.

## Change

Both lead branches (`cc.go`, `glm.go`) append `--name lead-<run-id>`, reusing the run id `enterKanbanMode` publishes at `internal/cli/kanban.go` rather than minting a second one.

- `kanban.LeadLabel(runID)` — `<role>-<run-id>` form, same as `CompanionLabel`, but never satisfies `SplitCompanionLabel` because `RoleLead` is absent from `CompanionRoles`. The injected name therefore cannot reclassify a lead as a companion.
- `operatorSuppliedName(args)` — mirrors the existing `operatorSuppliedSettings` precedent, including its `--` pass-through discipline.
- `leadNameArgs(args)` — two self-gates keep the call site unconditional: an operator-supplied name wins, and an absent run id yields no flag rather than the nonsense name `lead-`.

### Operator-supplied `--name` is never overwritten

`parseCompanionLabel` matches only the companion *shape*, so a lead named `board-watch` reads as "no name" there. `operatorSuppliedName` asks the different question — does a name exist at all — across all four forms claude accepts (`--name v`, `--name=v`, `-n v`, `-n=v`), plus a dangling `--name` with no value. A name past `--` is the backend's own argument and is left alone. Covered by `TestOperatorSuppliedName` and `TestLeadNameArgs_NeverOverridesOperatorName`.

`moai glm -k` gets the same treatment — its lead branch mirrors `cc` exactly and has the identical problem.

## Verification

`go build ./...`, `go vet ./...`, `go test ./...` all run. Three test failures reproduce **identically on the unmodified baseline** (measured by stashing this change and re-running), and none of them reach the new code:

- `TestHandleCodexReviewGate_LiveCodexBlocksInjectionAndKey` — live codex verdict
- `TestNavigatorEnrich_AtomicWriteBarrier` — goroutine barrier
- `TestPreTool_AstGrepSkipReasonSurfaces` — `internal/hook`

`gofmt -l` flags `kanban.go` and `glm.go`, both in regions this PR does not touch (pre-existing const alignment / import ordering); left alone per scope discipline.

## Out of scope

t21 (lead env run-id vs session suffix mismatch) is untouched — whether that mismatch comes from relaunch is unobserved.

🗿 MoAI