### PR TITLE
fix(ci): bound branch-guard latency by percentile and vet _test.go cross-platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,10 @@ jobs:
   # hour, blocking any caller holding a `gh pr checks --watch`.
   # Cross-platform runtime coverage (macOS + Windows race + MX validator) moved
   # to release time via .github/workflows/release-pr-multi-os.yml (full 3-OS
-  # matrix on `release/*` → main PRs). Cross-compilation build coverage stays on
-  # every PR via the `build` job below.
+  # matrix on `release/*` → main PRs). Cross-compilation coverage stays on every
+  # PR via the `build` job below, which both builds the binary and vets the
+  # packages (the vet step is what compiles _test.go for each target platform —
+  # `go build ./cmd/moai/` does not).
   test:
     name: Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -347,6 +349,20 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+
+      # `go build ./cmd/moai/` below does NOT compile _test.go files, so before
+      # this step the test tier compiled for NO platform on a PR: the test job
+      # is ubuntu-only, and cross-compilation coverage stopped at non-test
+      # sources. A test file that only builds on POSIX therefore reached main
+      # green and broke the Windows leg at release time.
+      # `go vet` type-checks the test files too, and cross-compiles on this same
+      # ubuntu runner in seconds — no extra runner, no runtime execution.
+      - name: Vet cross-platform (compiles _test.go, which `go build` does not)
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: "0"
+        run: go vet ./...
 
       - name: Cross-compile binary
         env:

--- a/internal/hook/pre_tool_branch_guard_integration_test.go
+++ b/internal/hook/pre_tool_branch_guard_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -21,9 +22,10 @@ import (
 //     arm: a future widening of IsGitCommit to match branch-state commands
 //     MUST make this test FAIL.
 //   * TestBranchGuard_Latency                    — REQ-WBG-010 / AC-WBG-010
-//     arm 1: 100 consecutive synthetic `git switch` events each complete
-//     in <= 500ms (10x headroom under the 5s PreToolUse budget). Internal
-//     for-loop, NOT a Benchmark, NOT -benchtime.
+//     arm 1: over 100 consecutive synthetic `git switch` events, the p95
+//     invocation stays under the steady-state ceiling and NO single
+//     invocation reaches the 5s PreToolUse budget. Internal for-loop, NOT
+//     a Benchmark, NOT -benchtime.
 //   * TestBranchGuard_CheckBranchStateOrigin     — AC-WBG-010 arm 2: with
 //     branchStatePatterns blanked, the same `git switch` event returns
 //     allow — proving the deny originates from checkBranchState, NOT from
@@ -110,12 +112,42 @@ func TestBranchGuard_QualityGateNotInvoked(t *testing.T) {
 }
 
 // TestBranchGuard_Latency proves REQ-WBG-010 / AC-WBG-010 arm 1: 100
-// consecutive synthetic `git switch` PreToolUse events each complete well
-// under the 5s PreToolUse budget — 500ms on POSIX (10x headroom), 2.5s on
-// Windows where each git.exe spawn is far more expensive (2x headroom). The
-// internal for-loop is NOT a Benchmark and NOT -benchtime — the test asserts
-// a per-invocation ceiling, not an average. It prints `per-invocation: <X>ms`
-// so the bound is mechanically observable in test output.
+// consecutive synthetic `git switch` PreToolUse events complete well under the
+// 5s PreToolUse budget. The internal for-loop is NOT a Benchmark and NOT
+// -benchtime — the test asserts latency bounds, not a throughput average. It
+// prints the p95 / worst / avg so the bounds are mechanically observable in
+// test output.
+//
+// Both bounds are stated as a fraction of that 5s budget, because the budget —
+// not any absolute millisecond figure — is what the guard actually owes:
+//
+//   - p95 <= 20% of budget (1s POSIX; 50% / 2.5s on Windows). The regression
+//     detector. A real regression — a network call, an unbounded scan, a full
+//     `git status` added to checkBranchState — makes EVERY invocation slow, so
+//     it moves the whole distribution and trips p95. Scheduler jitter moves ONE
+//     sample and does not.
+//   - worst < 100% of budget (5s). The contract itself: no single invocation
+//     may consume the whole PreToolUse budget, because one that does stalls the
+//     user's session.
+//
+// Two things were wrong with the earlier form. It asserted 500ms on every one
+// of the 100 samples, which is a max-of-100 assertion and amplifies tail risk
+// 100x. And 500ms was not the 10x headroom its comment claimed: checkBranchState
+// spawns `git rev-parse` subprocesses, so its cost is process-spawn dominated
+// and tracks machine load, not repository size. Measured on macOS under a
+// realistic multi-session load, four consecutive runs gave avg 135-188ms,
+// p95 240-440ms, worst 308-694ms — the old ceiling was breached in two of the
+// four, and p95 sat within ~1.1x of it in the worst. The bound was red on
+// healthy code.
+//
+// What 1s still catches: any change that moves typical cost past a second —
+// network I/O, a repository walk, an added `git status`. What it deliberately
+// does not catch: a 2x slowdown inside the existing spawn-bound cost, which is
+// indistinguishable from load on this measurement. Catching that needs a
+// baseline comparison, not a fixed ceiling.
+//
+// Windows keeps the higher 50% fraction: each git.exe spawn is far more
+// expensive there (issue #1225 observed 872ms against the old 500ms bound).
 //
 // The latency is measured at the checkBranchState layer (the new deny path
 // documented in REQ-WBG-010), NOT through the full Handle pipeline, because
@@ -138,43 +170,49 @@ func TestBranchGuard_Latency(t *testing.T) {
 
 	const iterations = 100
 
-	// Windows pays a much higher per-process cost for each git.exe spawn than
-	// POSIX does (issue #1225 observed a 872ms worst case there against a 500ms
-	// ceiling, while POSIX stays in the low tens of milliseconds). The ceiling
-	// exists to bound the deny decision well under the 5s PreToolUse budget, so
-	// relaxing it on Windows keeps that guarantee — 2.5s is still 2x headroom —
-	// without turning runner-scheduling jitter into a red build.
-	perCallCeiling := 500 * time.Millisecond
+	// The PreToolUse budget the guard must fit inside. Both ceilings below are
+	// fractions of it.
+	const hookBudget = 5 * time.Second
+
+	steadyCeiling := hookBudget / 5 // 20% — 1s on POSIX
 	if runtime.GOOS == "windows" {
-		perCallCeiling = 2500 * time.Millisecond
+		steadyCeiling = hookBudget / 2 // 50% — 2.5s, per issue #1225 spawn cost
 	}
 
-	var worst time.Duration
+	samples := make([]time.Duration, 0, iterations)
 	var total time.Duration
 	for i := 0; i < iterations; i++ {
 		start := time.Now()
 		decision, _ := checkBranchState(input, repo)
 		elapsed := time.Since(start)
-		if elapsed > worst {
-			worst = elapsed
-		}
+		samples = append(samples, elapsed)
 		total += elapsed
 		if decision != DecisionDeny {
 			t.Fatalf("iteration %d: checkBranchState decision = %q, want %q "+
 				"(latency measurement requires the deny to actually fire)", i, decision, DecisionDeny)
 		}
-		if elapsed > perCallCeiling {
-			t.Fatalf("iteration %d: checkBranchState took %v, ceiling %v "+
-				"(REQ-WBG-010 requires <= the per-OS ceiling per invocation)", i, elapsed, perCallCeiling)
-		}
 	}
 
+	sorted := slices.Clone(samples)
+	slices.Sort(sorted)
+	// p95 over 100 samples: the 95th-smallest, i.e. index 94.
+	p95 := sorted[(len(sorted)*95)/100-1]
+	worst := sorted[len(sorted)-1]
 	avg := total / iterations
-	t.Logf("per-invocation: worst=%v avg=%v (over %d iterations, ceiling %v)",
-		worst.Round(time.Microsecond), avg.Round(time.Microsecond), iterations, perCallCeiling)
 
-	if worst > perCallCeiling {
-		t.Fatalf("worst per-invocation latency %v exceeds ceiling %v", worst, perCallCeiling)
+	t.Logf("per-invocation: p95=%v worst=%v avg=%v (over %d iterations, steady ceiling %v, budget %v)",
+		p95.Round(time.Microsecond), worst.Round(time.Microsecond), avg.Round(time.Microsecond),
+		iterations, steadyCeiling, hookBudget)
+
+	if p95 > steadyCeiling {
+		t.Fatalf("p95 per-invocation latency %v exceeds steady-state ceiling %v "+
+			"(REQ-WBG-010: a shifted distribution means checkBranchState itself got more expensive)",
+			p95, steadyCeiling)
+	}
+	if worst >= hookBudget {
+		t.Fatalf("worst per-invocation latency %v reaches the %v PreToolUse budget "+
+			"(REQ-WBG-010: no single deny decision may consume the whole hook budget)",
+			worst, hookBudget)
 	}
 }
 


### PR DESCRIPTION
Two CI-reliability cards (t2 + t10) in one branch — both are about coverage the build claims but does not have.

## t2 — `TestBranchGuard_Latency` was red on healthy code

The test asserted a 500ms POSIX ceiling on **every one** of 100 samples. That is a max-of-100 assertion: it amplifies tail risk 100x, so one scheduler hiccup reddens the build while telling us nothing about the guard.

The 500ms figure was also not the "10x headroom" its comment claimed. `checkBranchState` spawns `git rev-parse` subprocesses, so its cost is **process-spawn dominated** and tracks machine load, not repository size. Measured here on macOS under a realistic multi-session load, four consecutive runs:

| run | avg | p95 | worst |
|---|---|---|---|
| 1 | 185ms | 440ms | 694ms |
| 2 | 135ms | 240ms | 308ms |
| 3 | 147ms | 300ms | 453ms |
| 4 | 188ms | 420ms | 563ms |
| 5 (after change) | 256ms | 514ms | 724ms |

The old ceiling was breached in three of those five, on unmodified code.

### The new bounds

Both are stated as a fraction of the 5s PreToolUse budget, because the budget — not any absolute millisecond figure — is what the guard actually owes:

- **p95 ≤ 20% of budget** (1s POSIX; 50% / 2.5s on Windows, keeping the higher `git.exe` spawn cost of #1225). The regression detector.
- **worst < 100% of budget** (5s). The contract itself, asserted per-sample.

### What the new bound still catches

A genuine regression — a network call, a repository walk, an added `git status` inside `checkBranchState` — makes **every** invocation slow, so it moves the whole distribution and trips p95. Scheduler jitter moves one sample and does not. The 5s arm independently catches any single call that would stall the user's session.

### What it deliberately does not catch

A 2x slowdown *inside* the existing spawn-bound cost (~150ms → ~300ms). On this measurement that is indistinguishable from machine load. Catching it needs a recorded baseline to compare against, not a fixed ceiling — that would be a different mechanism, and I did not want to ship a number implying coverage it does not have.

## t10 — the test tier compiled for no platform on a PR

The absence of a Windows runtime-test leg on PRs is a deliberate cost tradeoff (documented in `ci.yml`, moved to `release-pr-multi-os.yml`) and is **not** touched here.

The narrow gap is that the same comment claimed cross-compilation build coverage stays on every PR — but the `build` job runs `go build ./cmd/moai/`, which does **not** compile `_test.go` files, and the `test` job is ubuntu-only. So the test tier compiled for no platform at all. A test file that only builds on POSIX reached main green and broke the Windows leg at release time (SPEC-KANBAN-BOARD-001 F2).

`go vet ./...` type-checks the test files. Added to the `build` job with the matrix `GOOS`/`GOARCH`, it cross-compiles on the existing ubuntu runner in seconds — no new runner, no runtime execution — and covers all five matrix legs rather than Windows alone, at no extra cost. The stale comment is corrected too.

## Verification

- `GOOS=windows go vet ./...` — **exit 0, no output**, both on today's main and on this branch. The F2 finding has since been fixed in the tree, so the gate lands green rather than reddening main.
- All five build-matrix legs vet clean: `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64`.
- `go vet ./...` clean; `gofmt` clean; `ci.yml` parses as YAML.
- `go test ./... -count=1`: 116 packages ok, 4 failures — **all four baselined against unmodified main code and none attributable to this change**:
  - `internal/hook TestPreTool_AstGrepSkipReasonSurfaces` — fails identically with this branch's test file reverted to main. Pre-existing.
  - `internal/cli TestHandleCodexReviewGate_LiveCodexBlocksInjectionAndKey` — fails on baseline; depends on a live codex verdict.
  - `internal/harness TestRecordEvent100Sequential` — passes in isolation, fails only under full-suite load.
  - `internal/statusline TestBuilderNormalizesMode` — passes in isolation, fails only under full-suite load.

The last two are the same fragility class this PR fixes in `TestBranchGuard_Latency`: absolute timing assertions that measure machine load. Flagging, not fixing, here.

🗿 MoAI
