### PR TITLE
fix(kanban): adopt the lead run id from an operator-supplied session name

### DIFF
--- a/internal/cli/cc.go
+++ b/internal/cli/cc.go
@@ -115,7 +115,13 @@ func runCC(cmd *cobra.Command, args []string) error {
 	label, isCompanion := parseCompanionLabel(filteredArgs)
 	switch resolveKanbanBranch(kanbanEnabled, isCompanion) {
 	case kanbanBranchLead:
-		defer enterKanbanMode(specID)()
+		// An operator-supplied `lead-<run-id>` name carries the run id this
+		// session already belongs to — a relaunch of an existing lead, or a
+		// board whose companions are already open. Adopting it is what keeps
+		// the session name, MOAI_KANBAN_ID, the leader socket path, and the
+		// companion commands the SessionStart notice prints on one run.
+		leadLabel, _ := parseLeadLabel(filteredArgs)
+		defer enterKanbanMode(specID, leadLabel)()
 		recordKanbanSession(specID, kanban.BackendClaude, kanban.RoleLead)
 		// A lead launched bare has only an AI-generated title, which claude
 		// discards on /clear; naming it explicitly is what survives.

--- a/internal/cli/cc_test.go
+++ b/internal/cli/cc_test.go
@@ -547,7 +547,7 @@ func TestEnterKanbanMode_RestoresPriorValue(t *testing.T) {
 	t.Setenv(config.EnvMoaiKanban, "prior-kanban")
 	t.Setenv(config.EnvMoaiKanbanSpec, "SPEC-PRIOR")
 
-	restore := enterKanbanMode("SPEC-PLACEHOLDER")
+	restore := enterKanbanMode("SPEC-PLACEHOLDER", "")
 	if got := os.Getenv(config.EnvMoaiKanban); got != "1" {
 		t.Errorf("inside Kanban Mode %s = %q, want %q", config.EnvMoaiKanban, got, "1")
 	}
@@ -569,7 +569,7 @@ func TestEnterKanbanMode_RestoresPriorValue(t *testing.T) {
 // without inventing a SPEC identifier the operator never supplied.
 func TestEnterKanbanMode_WithoutSpecLeavesSpecVarUntouched(t *testing.T) {
 	_ = os.Unsetenv(config.EnvMoaiKanbanSpec)
-	restore := enterKanbanMode("")
+	restore := enterKanbanMode("", "")
 	defer restore()
 
 	if got := os.Getenv(config.EnvMoaiKanban); got != "1" {

--- a/internal/cli/glm.go
+++ b/internal/cli/glm.go
@@ -183,7 +183,9 @@ func runGLM(cmd *cobra.Command, args []string) error {
 	label, isCompanion := parseCompanionLabel(filteredArgs)
 	switch resolveKanbanBranch(kanbanEnabled, isCompanion) {
 	case kanbanBranchLead:
-		defer enterKanbanMode(specID)()
+		// See cc.go: the operator's lead run id is adopted rather than replaced.
+		leadLabel, _ := parseLeadLabel(filteredArgs)
+		defer enterKanbanMode(specID, leadLabel)()
 		recordKanbanSession(specID, kanban.BackendGLM, kanban.RoleLead)
 		// See cc.go: glm mirrors the lead branch exactly.
 		filteredArgs = append(filteredArgs, leadNameArgs(filteredArgs)...)

--- a/internal/cli/kanban.go
+++ b/internal/cli/kanban.go
@@ -86,7 +86,10 @@ func parseKanbanFlag(args []string) (spec string, enabled bool, rest []string) {
 //
 // Callers must defer the returned function so it also runs on the error path; a
 // restore that only runs on success is the same leak with a narrower trigger.
-func enterKanbanMode(specID string) func() {
+// leadLabel is the operator-supplied `lead-<run-id>` name for this session when
+// there is one, and "" otherwise. Its run id is ADOPTED rather than replaced —
+// see leadRunID.
+func enterKanbanMode(specID, leadLabel string) func() {
 	restoreKanban := captureEnvState(config.EnvMoaiKanban)
 	restoreSpec := captureEnvState(config.EnvMoaiKanbanSpec)
 	restoreID := captureEnvState(config.EnvMoaiKanbanID)
@@ -94,7 +97,7 @@ func enterKanbanMode(specID string) func() {
 	restoreTier := seedAutonomyTier()
 
 	_ = os.Setenv(config.EnvMoaiKanban, "1")
-	runID := kanban.NewRunID()
+	runID := leadRunID(leadLabel)
 	_ = os.Setenv(config.EnvMoaiKanbanID, runID)
 	if specID != "" {
 		_ = os.Setenv(config.EnvMoaiKanbanSpec, specID)
@@ -112,6 +115,30 @@ func enterKanbanMode(specID string) func() {
 		restoreSpec()
 		restoreKanban()
 	}
+}
+
+// leadRunID resolves the run id a lead session publishes: the one embedded in
+// an operator-supplied `lead-<run-id>` name when there is one, a fresh mint
+// otherwise.
+//
+// Adoption is what makes the lead branch symmetric with the companion branch,
+// which derives its id from its label for exactly this reason. Minting
+// unconditionally left the session's name and MOAI_KANBAN_ID free to disagree,
+// and the SessionStart notice reads only the latter — so a session the operator
+// named `lead-X` announced companion commands for a freshly minted run Y, and a
+// copied command opened a companion that no lead was listening to.
+//
+// The shape guard is kanban.SplitLeadLabel and it admits exactly what the
+// companion side admits: a name like `lead-notarunid` is adopted, because
+// `notarunid` is a well-shaped run id as far as the id grammar is concerned.
+// Anything that is not — `board-watch`, `lead-`, `lead-ABC`, `lead-a-b` — falls
+// back to minting rather than publishing a malformed id. Tightening the lead
+// side alone would reintroduce an asymmetry of its own.
+func leadRunID(leadLabel string) string {
+	if runID, ok := kanban.SplitLeadLabel(leadLabel); ok {
+		return runID
+	}
+	return kanban.NewRunID()
 }
 
 // seedAutonomyTier publishes the autonomy tier Kanban Mode runs at, and returns
@@ -242,6 +269,38 @@ const (
 // and normalizeWorktreeFlag: iterate, break at the pass-through marker, and read
 // nothing beyond it. args is returned to the caller untouched.
 func parseCompanionLabel(args []string) (label string, ok bool) {
+	return parseNamedLabel(args, func(candidate string) bool {
+		_, _, isCompanion := kanban.SplitCompanionLabel(candidate)
+		return isCompanion
+	})
+}
+
+// parseLeadLabel reports the `lead-<run-id>` label in args, if any.
+//
+// It is parseCompanionLabel's counterpart and exists for the launcher to read
+// back a run id the operator embedded in the session name, so the lead branch
+// can adopt it instead of minting a second one (see leadRunID).
+//
+// A lead label never satisfies the companion discriminator — RoleLead is absent
+// from kanban.CompanionRoles — so the two parsers can never both match the same
+// name, and recognizing a lead name here cannot reroute the session down the
+// companion branch.
+func parseLeadLabel(args []string) (label string, ok bool) {
+	return parseNamedLabel(args, func(candidate string) bool {
+		_, isLead := kanban.SplitLeadLabel(candidate)
+		return isLead
+	})
+}
+
+// parseNamedLabel returns the first `--name` / `-n` value before the
+// pass-through marker that accept admits.
+//
+// The scan is shared by parseCompanionLabel and parseLeadLabel because the two
+// differ only in which shape they admit. The four name forms claude accepts and
+// the `--` discipline are identical for both, and keeping one copy per role is
+// how the two would drift — which is the class of defect this whole change is
+// repairing.
+func parseNamedLabel(args []string, accept func(candidate string) bool) (label string, ok bool) {
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
 		if arg == "--" {
@@ -263,7 +322,7 @@ func parseCompanionLabel(args []string) (label string, ok bool) {
 			continue
 		}
 
-		if _, _, isCompanion := kanban.SplitCompanionLabel(candidate); isCompanion {
+		if accept(candidate) {
 			return candidate, true
 		}
 	}

--- a/internal/cli/kanban_autonomy_test.go
+++ b/internal/cli/kanban_autonomy_test.go
@@ -20,7 +20,7 @@ func TestKanbanModeSeedsFullyAutonomousTier(t *testing.T) {
 		name  string
 		enter func() func()
 	}{
-		{"lead", func() func() { return enterKanbanMode("SPEC-KANBAN-001") }},
+		{"lead", func() func() { return enterKanbanMode("SPEC-KANBAN-001", "") }},
 		{"companion", func() func() { return enterKanbanCompanionMode("plan-tjlgt1") }},
 	}
 
@@ -57,7 +57,7 @@ func TestKanbanModePreservesExplicitTier(t *testing.T) {
 		t.Run(tier, func(t *testing.T) {
 			t.Setenv(config.EnvAutonomyTier, tier)
 
-			restore := enterKanbanMode("")
+			restore := enterKanbanMode("", "")
 			if got := os.Getenv(config.EnvAutonomyTier); got != tier {
 				t.Errorf("explicit tier %q was overwritten with %q", tier, got)
 			}
@@ -79,7 +79,7 @@ func TestKanbanModeTreatsBlankTierAsUnset(t *testing.T) {
 		t.Run("blank="+blank, func(t *testing.T) {
 			t.Setenv(config.EnvAutonomyTier, blank)
 
-			restore := enterKanbanMode("")
+			restore := enterKanbanMode("", "")
 			if got := os.Getenv(config.EnvAutonomyTier); got != config.AutonomyTierFullyAutonomous {
 				t.Errorf("blank tier %q left as %q, want it filled in with %q", blank, got, config.AutonomyTierFullyAutonomous)
 			}

--- a/internal/cli/kanban_bootstrap_test.go
+++ b/internal/cli/kanban_bootstrap_test.go
@@ -76,7 +76,7 @@ func TestEnterKanbanModeSetsRunID(t *testing.T) {
 		_ = os.Unsetenv(key)
 	}
 
-	restore := enterKanbanMode("SPEC-EXAMPLE-001")
+	restore := enterKanbanMode("SPEC-EXAMPLE-001", "")
 
 	runID := os.Getenv(config.EnvMoaiKanbanID)
 	if runID == "" {

--- a/internal/cli/kanban_dispatch_test.go
+++ b/internal/cli/kanban_dispatch_test.go
@@ -66,7 +66,7 @@ func TestDispatchOutcome_LeadEnvState(t *testing.T) {
 	if resolveKanbanBranch(true, false) != kanbanBranchLead {
 		t.Fatal("expected lead branch")
 	}
-	restore := enterKanbanMode("SPEC-FOO-001")
+	restore := enterKanbanMode("SPEC-FOO-001", "")
 	defer restore()
 
 	if os.Getenv(config.EnvMoaiKanban) == "" {

--- a/internal/cli/kanban_lead_name_test.go
+++ b/internal/cli/kanban_lead_name_test.go
@@ -107,12 +107,123 @@ func TestLeadNameArgs_LabelIsNotCompanionShape(t *testing.T) {
 	}
 }
 
+// TestEnterKanbanMode_AdoptsOperatorLeadRunID is the assertion whose ABSENCE let
+// the divergence ship green: the prior suite checked only that leadNameArgs
+// returned nil for an operator-named lead, never that the run id the launcher
+// published matched the one in that name. It did not — the launcher minted a
+// fresh id beside it, and the SessionStart notice, which reads the environment,
+// then printed companion commands for a run the session was not on.
+//
+// Everything downstream of the mint is asserted, not just the id itself: the
+// leader socket path is derived from the same value and is what a companion
+// would address.
+func TestEnterKanbanMode_AdoptsOperatorLeadRunID(t *testing.T) {
+	clearAllKanbanEnv(t)
+
+	args := []string{"--name", "lead-abc123"}
+	label, ok := parseLeadLabel(args)
+	if !ok {
+		t.Fatalf("parseLeadLabel(%q) did not recognize the lead name", args)
+	}
+	restore := enterKanbanMode("", label)
+	defer restore()
+
+	if got := os.Getenv(config.EnvMoaiKanbanID); got != "abc123" {
+		t.Errorf("%s = %q, want %q (the id from the operator's name)", config.EnvMoaiKanbanID, got, "abc123")
+	}
+	if got, want := os.Getenv(config.EnvMoaiKanbanLeadAddr), "/tmp/moai-kanban-abc123"; got != want {
+		t.Errorf("%s = %q, want %q", config.EnvMoaiKanbanLeadAddr, got, want)
+	}
+	// The operator's name still wins — adoption must not also inject a second
+	// --name and hand claude two.
+	if got := leadNameArgs(args); got != nil {
+		t.Errorf("leadNameArgs(%q) = %q, want nil (operator name wins)", args, got)
+	}
+}
+
+// TestEnterKanbanMode_MintsWithoutLeadName is the other half of the contract: a
+// lead with no usable name in argv still gets a run id, so the bare
+// `moai cc -k` launch is unchanged by adoption.
+func TestEnterKanbanMode_MintsWithoutLeadName(t *testing.T) {
+	for _, c := range []struct {
+		name  string
+		label string
+	}{
+		{"no name at all", ""},
+		{"non-lead name", "board-watch"},
+		{"lead prefix with no id", "lead-"},
+		{"uppercase is not a run id shape", "lead-ABC123"},
+		{"a second hyphen is not a run id shape", "lead-a-b"},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			clearAllKanbanEnv(t)
+			restore := enterKanbanMode("", c.label)
+			defer restore()
+
+			if got := os.Getenv(config.EnvMoaiKanbanID); got == "" {
+				t.Errorf("%s is empty, want a freshly minted run id", config.EnvMoaiKanbanID)
+			}
+		})
+	}
+}
+
+// TestParseLeadLabel covers the four name forms claude accepts and the shapes
+// that must NOT read as a lead label.
+func TestParseLeadLabel(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"--name value", []string{"--name", "lead-abc123"}, "lead-abc123"},
+		{"--name=value", []string{"--name=lead-abc123"}, "lead-abc123"},
+		{"-n value", []string{"-n", "lead-abc123"}, "lead-abc123"},
+		{"-n=value", []string{"-n=lead-abc123"}, "lead-abc123"},
+		{"absent", []string{"-p", "work"}, ""},
+		{"a non-lead name is not ours", []string{"--name", "board-watch"}, ""},
+		{"a companion name is not ours", []string{"--name", "run-abc123"}, ""},
+		{"past the pass-through marker is not ours", []string{"--", "--name", "lead-abc123"}, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := parseLeadLabel(c.args)
+			if c.want == "" {
+				if ok {
+					t.Errorf("parseLeadLabel(%q) = %q, want no match", c.args, got)
+				}
+				return
+			}
+			if !ok || got != c.want {
+				t.Errorf("parseLeadLabel(%q) = %q/%v, want %q/true", c.args, got, ok, c.want)
+			}
+		})
+	}
+}
+
+// TestLeadLabelNeverReadsAsCompanion guards the branch that would be broken by
+// recognizing lead names: resolveKanbanBranch must still route a lead-named
+// `-k` launch down the lead branch, not the companion one.
+func TestLeadLabelNeverReadsAsCompanion(t *testing.T) {
+	t.Parallel()
+
+	args := []string{"--name", "lead-abc123"}
+	if _, isCompanion := parseCompanionLabel(args); isCompanion {
+		t.Fatalf("parseCompanionLabel(%q) matched a lead name", args)
+	}
+	if branch := resolveKanbanBranch(true, false); branch != kanbanBranchLead {
+		t.Errorf("resolveKanbanBranch = %v, want the lead branch", branch)
+	}
+}
+
 // TestLeadNameArgs_UsesRunIDFromEnterKanbanMode wires the helper to the real
 // producer rather than a hand-set variable, so a change to where the run id is
 // published breaks this test instead of passing silently.
 func TestLeadNameArgs_UsesRunIDFromEnterKanbanMode(t *testing.T) {
 	clearAllKanbanEnv(t)
-	restore := enterKanbanMode("")
+	restore := enterKanbanMode("", "")
 	defer restore()
 
 	runID := os.Getenv(config.EnvMoaiKanbanID)

--- a/internal/hook/session_start_kanban.go
+++ b/internal/hook/session_start_kanban.go
@@ -104,10 +104,21 @@ func kanbanLeadNotice(runID, lang string) string {
 	}
 	m := kanbanMessagesFor(lang)
 
-	// (a) run id, and (b) why bootstrap is manual — stated rather than left to
-	// be discovered.
-	blocks := []string{
+	// (a) the run id and the session name that must accompany it, printed
+	// together so a disagreement between them is visible HERE — at the moment
+	// the notice is emitted — rather than later, when a copied command opens a
+	// companion on a run no lead is listening to. The launcher now adopts an
+	// operator-supplied `lead-<run-id>` name (internal/cli/kanban.go leadRunID)
+	// so the two agree by construction; this line is what makes a residual
+	// disagreement self-announcing instead of silent.
+	identity := []string{
 		fmt.Sprintf(m.leadHeader, runID),
+		fmt.Sprintf(m.leadIdentity, kanban.LeadLabel(runID)),
+	}
+
+	// (b) why bootstrap is manual — stated rather than left to be discovered.
+	blocks := []string{
+		strings.Join(identity, "\n"),
 		m.leadManual,
 	}
 

--- a/internal/hook/session_start_kanban_i18n.go
+++ b/internal/hook/session_start_kanban_i18n.go
@@ -34,6 +34,7 @@ const langEnglish = "en"
 // operator reads as separate lines.
 type kanbanMessages struct {
 	leadHeader     string // run id
+	leadIdentity   string // lead label
 	leadManual     string
 	glmSubstitute  string
 	leaderSocket   string // socket path
@@ -52,7 +53,8 @@ type kanbanMessages struct {
 // configuration, not for some population of unsupported locales.
 var kanbanLocales = map[string]kanbanMessages{
 	langEnglish: {
-		leadHeader: "Kanban Mode: run %s, lead session.",
+		leadHeader:   "Kanban Mode: run %s, lead session.",
+		leadIdentity: "This session should be named %s. If its name differs, the launch commands below belong to another run — relaunch with that name rather than copying them.",
 		leadManual: "This session drives the kanban chain.\n" +
 			"The four companions below are launched by hand, one per new terminal, " +
 			"because a session cannot launch another session.",
@@ -65,7 +67,8 @@ var kanbanLocales = map[string]kanbanMessages{
 		companionJoin:  "Kanban Mode: joined run %s.",
 	},
 	"ko": {
-		leadHeader: "칸반 모드: run %s, 리더 세션.",
+		leadHeader:   "칸반 모드: run %s, 리더 세션.",
+		leadIdentity: "이 세션의 이름은 %s 여야 합니다. 이름이 다르면 아래 실행 명령은 다른 run 의 것이니, 복사하지 말고 해당 이름으로 다시 띄우세요.",
 		leadManual: "이 세션이 칸반 체인을 주도합니다.\n" +
 			"아래 네 개의 동반 세션은 터미널을 하나씩 새로 열어 직접 실행하세요 — 세션은 다른 세션을 띄울 수 없습니다.",
 		glmSubstitute:  "동반 세션을 GLM 백엔드로 돌리려면 'moai cc -k --name ...' 대신 'moai glm -k --name ...' 을 사용하세요.",
@@ -77,7 +80,8 @@ var kanbanLocales = map[string]kanbanMessages{
 		companionJoin:  "칸반 모드: run %s 에 합류했습니다.",
 	},
 	"ja": {
-		leadHeader: "かんばんモード: run %s、リーダーセッション。",
+		leadHeader:   "かんばんモード: run %s、リーダーセッション。",
+		leadIdentity: "このセッションの名前は %s である必要があります。名前が異なる場合、以下の起動コマンドは別の run のものなので、コピーせずにその名前で起動し直してください。",
 		leadManual: "このセッションがかんばんチェーンを進行します。\n" +
 			"以下の 4 つの併走セッションは、ターミナルを 1 つずつ新規に開いて手動で起動してください — セッションが別のセッションを起動することはできません。",
 		glmSubstitute:  "併走セッションを GLM バックエンドで動かす場合は、'moai cc -k --name ...' の代わりに 'moai glm -k --name ...' を使用してください。",
@@ -89,7 +93,8 @@ var kanbanLocales = map[string]kanbanMessages{
 		companionJoin:  "かんばんモード: run %s に参加しました。",
 	},
 	"zh": {
-		leadHeader: "看板模式：run %s，主导会话。",
+		leadHeader:   "看板模式：run %s，主导会话。",
+		leadIdentity: "本会话的名称应为 %s。若名称不同，下面的启动命令属于另一个 run，请不要复制，改用该名称重新启动。",
 		leadManual: "本会话负责推进整条看板链路。\n" +
 			"下面四个协同会话需要各自新开一个终端手动启动 —— 会话无法启动另一个会话。",
 		glmSubstitute:  "如需让某个协同会话运行在 GLM 后端，请将 'moai cc -k --name ...' 换成 'moai glm -k --name ...'。",

--- a/internal/hook/session_start_kanban_i18n_test.go
+++ b/internal/hook/session_start_kanban_i18n_test.go
@@ -24,6 +24,7 @@ func TestKanbanLocalesCoverEveryField(t *testing.T) {
 	for lang, m := range kanbanLocales {
 		fields := map[string]string{
 			"leadHeader":     m.leadHeader,
+			"leadIdentity":   m.leadIdentity,
 			"leadManual":     m.leadManual,
 			"glmSubstitute":  m.glmSubstitute,
 			"leaderSocket":   m.leaderSocket,
@@ -38,10 +39,12 @@ func TestKanbanLocalesCoverEveryField(t *testing.T) {
 				t.Errorf("locale %q: field %s is empty", lang, name)
 			}
 		}
-		// The three format-bearing fields must keep their verb, or the run id
-		// and socket path silently vanish from that locale's notice.
+		// The format-bearing fields must keep their verb, or the run id, the
+		// lead label, and the socket path silently vanish from that locale's
+		// notice.
 		for name, value := range map[string]string{
 			"leadHeader":    m.leadHeader,
+			"leadIdentity":  m.leadIdentity,
 			"leaderSocket":  m.leaderSocket,
 			"specLine":      m.specLine,
 			"companionJoin": m.companionJoin,

--- a/internal/hook/session_start_kanban_test.go
+++ b/internal/hook/session_start_kanban_test.go
@@ -231,6 +231,30 @@ func TestKanbanLeadNoticeCompanionLinesCarryF(t *testing.T) {
 	}
 }
 
+// TestKanbanLeadNoticeNamesTheLeadSession is the self-announcing property: the
+// notice prints the session name that belongs to the run it is announcing, so
+// an operator whose terminal carries a different name sees the disagreement at
+// the moment the notice appears — rather than discovering it later, when a
+// copied companion command opens a session no lead is listening to.
+//
+// The launcher now adopts an operator-supplied `lead-<run-id>` name, so the two
+// agree by construction; this line is the residual backstop, and it is printed
+// in every locale because the label is a protocol token, not prose.
+func TestKanbanLeadNoticeNamesTheLeadSession(t *testing.T) {
+	for _, lang := range []string{langEnglish, "ko", "ja", "zh"} {
+		t.Run(lang, func(t *testing.T) {
+			clearKanbanEnv(t)
+			t.Setenv(config.EnvMoaiKanban, "1")
+			t.Setenv(config.EnvMoaiKanbanID, "xyz789")
+
+			got := kanbanLeadNotice("xyz789", lang)
+			if want := kanban.LeadLabel("xyz789"); !strings.Contains(got, want) {
+				t.Errorf("lead notice does not name the lead session %q:\n%s", want, got)
+			}
+		})
+	}
+}
+
 // TestKanbanCompanionNoticeRoleless is AC-FB-016: the companion notice is
 // join-only and role-less — it names the run and does NOT contain the word
 // "companion" or the prior-art "as the X companion" clause. (A role name like

--- a/internal/kanban/bootstrap.go
+++ b/internal/kanban/bootstrap.go
@@ -89,6 +89,26 @@ func SplitCompanionLabel(label string) (role, runID string, ok bool) {
 	return role, runID, true
 }
 
+// SplitLeadLabel splits a `lead-<run-id>` label into its run id and reports
+// whether the value has the lead shape at all. It is the lead-side counterpart
+// of SplitCompanionLabel, and admits exactly the same run-id shape.
+//
+// It exists so the launcher can ADOPT the run id an operator embedded in a name
+// it was handed, rather than minting a second one beside it. A lead has two
+// id-bearing surfaces — the session name and MOAI_KANBAN_ID — and without this
+// splitter nothing joins them: the SessionStart notice composes its companion
+// launch commands from the environment id, so a session named `lead-X` can
+// print commands belonging to run Y, and anyone who copies one opens an orphan.
+// The companion branch already derives its id from its label and states that it
+// does so precisely so the two can never disagree; this restores the symmetry.
+func SplitLeadLabel(label string) (runID string, ok bool) {
+	role, runID, found := strings.Cut(label, "-")
+	if !found || role != RoleLead || !isRunIDShape(runID) {
+		return "", false
+	}
+	return runID, true
+}
+
 func isCompanionRole(role string) bool {
 	for _, r := range CompanionRoles {
 		if role == r {

--- a/internal/kanban/bootstrap_test.go
+++ b/internal/kanban/bootstrap_test.go
@@ -159,3 +159,73 @@ func TestLeadLabelIsNotACompanion(t *testing.T) {
 		t.Errorf("LeadLabel(%q) = %q reads as a companion label", runID, label)
 	}
 }
+
+// TestSplitLeadLabelRoundTrip pins the property the launcher's run-id adoption
+// relies on: whatever LeadLabel writes, SplitLeadLabel reads back unchanged.
+func TestSplitLeadLabelRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	runID := NewRunID()
+	got, ok := SplitLeadLabel(LeadLabel(runID))
+	if !ok || got != runID {
+		t.Errorf("SplitLeadLabel(LeadLabel(%q)) = %q/%v, want %q/true", runID, got, ok, runID)
+	}
+}
+
+// TestSplitLeadLabelRejectsNonLeadShapes covers what must NOT be adopted as a
+// lead run id. The admitted shape is deliberately identical to the companion
+// side's: `lead-notarunid` IS accepted, because `notarunid` is a well-formed
+// run id as far as the grammar is concerned, exactly as `run-notarunid` is
+// accepted as a companion. Tightening one side alone is how the two branches
+// drift apart.
+func TestSplitLeadLabelRejectsNonLeadShapes(t *testing.T) {
+	t.Parallel()
+
+	for _, c := range []struct {
+		label string
+		want  string // "" means reject
+	}{
+		{"lead-abc123", "abc123"},
+		{"lead-notarunid", "notarunid"},
+		{"", ""},
+		{"lead", ""},
+		{"lead-", ""},
+		{"lead-ABC123", ""},
+		{"lead-a-b", ""},
+		{"lead-a_b", ""},
+		{"leader-abc123", ""},
+		{"run-abc123", ""},
+		{"board-watch", ""},
+	} {
+		got, ok := SplitLeadLabel(c.label)
+		if c.want == "" {
+			if ok {
+				t.Errorf("SplitLeadLabel(%q) = %q, want reject", c.label, got)
+			}
+			continue
+		}
+		if !ok || got != c.want {
+			t.Errorf("SplitLeadLabel(%q) = %q/%v, want %q/true", c.label, got, ok, c.want)
+		}
+	}
+}
+
+// TestSplitLeadLabelAndCompanionAreDisjoint is the branch-safety property: no
+// label can satisfy both discriminators, so recognizing a lead name can never
+// reroute a lead session down the companion branch.
+func TestSplitLeadLabelAndCompanionAreDisjoint(t *testing.T) {
+	t.Parallel()
+
+	runID := NewRunID()
+	labels := []string{LeadLabel(runID)}
+	for _, role := range CompanionRoles {
+		labels = append(labels, CompanionLabel(role, runID))
+	}
+	for _, label := range labels {
+		_, isLead := SplitLeadLabel(label)
+		_, _, isCompanion := SplitCompanionLabel(label)
+		if isLead && isCompanion {
+			t.Errorf("label %q satisfies both discriminators", label)
+		}
+	}
+}


### PR DESCRIPTION
Card **t21**. Root-cause report: `.moai/reports/backlog/t21-kanban-runid-investigation.md`.

## The defect

A lead session carries its run id on **two** surfaces and nothing joined them.

| Surface | Value came from |
|---|---|
| Session identity (`--name lead-<id>`) | the operator's argv |
| Run id (`MOAI_KANBAN_ID`, the leader socket, everything the notice prints) | `NewRunID()` — a fresh mint on every launch |

`enterKanbanMode` minted unconditionally. `leadNameArgs` returned `nil` when the operator supplied a name — moai declined to *add* a name, but never *adopted* the id embedded in the one it was handed. The SessionStart notice composes its companion launch commands from the environment id, so a session named `lead-tjqim9` printed `moai cc -k --name plan-tjr8zx`, and anyone who copied that line opened a companion on a run no lead was listening to.

Measured live on two independent lead processes (report §E5/§E6): both were named with an id 8-9 hours older than the one their environment carried.

The companion branch cannot diverge this way — `enterKanbanCompanionMode` derives its id from its label, *"so the two can never disagree"*. **The asymmetry was the defect.**

## The fix

**F1 — make the lead branch symmetric with the companion branch.**
- `kanban.SplitLeadLabel`, the counterpart of `SplitCompanionLabel`, admitting *exactly* the same run-id shape.
- `enterKanbanMode(specID, leadLabel)` adopts the run id from a `lead-<run-id>` name, minting only when no lead-shaped name is present.
- Both launchers pass it. **`glm.go` needed the same change** — it mirrors `cc.go` exactly, and was measured rather than assumed.
- The four-form `--name` scan is now shared between `parseCompanionLabel` and the new `parseLeadLabel`, so the two shapes cannot drift apart again.

**F2 — assert the environment, not the return value.** The prior suite passed because it checked only that `leadNameArgs` returned `nil`; the published id was never inspected. That is precisely why the divergence shipped green. The tests now assert `MOAI_KANBAN_ID` *and* the leader socket path both carry the id from the operator's name.

**F4 — make a residual disagreement self-announcing.** The lead notice now prints the session name that belongs to the run it is announcing, in all four locales. An operator whose terminal name differs sees it when the notice appears, not when a copied command opens an orphan.

### Shape guard

`SplitLeadLabel` admits what the companion side admits. `lead-notarunid` **is** adopted — `notarunid` is a well-formed run id as far as the grammar is concerned, exactly as `run-notarunid` is accepted as a companion. Rejected (falls back to minting): `board-watch`, `lead-`, `lead-ABC123`, `lead-a-b`. Tightening the lead side alone would reintroduce an asymmetry of its own.

`resolveKanbanBranch` routing is unchanged: `RoleLead` is absent from `CompanionRoles`, so no label can satisfy both discriminators — pinned by a new disjointness test.

## Deliberately NOT in this PR

**F3 — persisting the run id across a lead restart.** A relaunched lead still mints a fresh id and orphans companions launched from the previous notice (report §C4). That is a *separate* defect path, it does not explain the observed symptom, and it reintroduces exactly the state file `NewRunID`'s doc comment avoids. It deserves its own decision, not a ride-along. **Follow-up.**

## Verification

- `go build ./...`, `go vet ./...` — clean
- `golangci-lint run ./internal/cli/... ./internal/kanban/... ./internal/hook/...` — 0 issues
- `go test ./internal/kanban/ -count=1` — ok
- `go test ./internal/cli/ -count=1 -run 'Kanban|LeadName|LeadLabel|OperatorSuppliedName|ParseLeadLabel'` — ok

Two `gofmt -l` hits in the touched files (`internal/cli/kanban.go` const alignment, `internal/cli/glm.go` import order) were confirmed **pre-existing on `origin/main`** and left alone.

🗿 MoAI