### PR TITLE
fix(hook): carry the permission decision through the handler merge

### DIFF
--- a/internal/cli/hook_pretool_ask_wire_test.go
+++ b/internal/cli/hook_pretool_ask_wire_test.go
@@ -1,0 +1,145 @@
+// End-to-end wire-format regression test for the PreToolUse "ask" verdict.
+//
+// "deny" already had CLI-level coverage (hook_protocol_fix_test.go); "ask" had
+// none, which is why the registry merge could drop it and the suite stayed
+// green for the whole life of the defect. This test pins "ask" the same way
+// "deny" is pinned: real protocol, real registry, real handler, assertion on
+// the JSON that actually reaches stdout.
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// runPreToolHookCLI feeds payload to the `moai hook pre-tool` subcommand with
+// the real wiring and returns the JSON object written to stdout.
+func runPreToolHookCLI(t *testing.T, payload string) map[string]any {
+	t.Helper()
+
+	origDeps := deps
+	t.Cleanup(func() { deps = origDeps })
+	InitDependencies()
+
+	swapStdinString(t, payload)
+
+	origStdout := os.Stdout
+	rOut, wOut, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = wOut
+
+	var runErr error
+	found := false
+	for _, cmd := range hookCmd.Commands() {
+		if cmd.Name() == "pre-tool" {
+			found = true
+			cmd.SetContext(context.Background())
+			runErr = cmd.RunE(cmd, []string{})
+			break
+		}
+	}
+	_ = wOut.Close()
+	os.Stdout = origStdout
+
+	if !found {
+		t.Fatal("pre-tool subcommand not found")
+	}
+	if runErr != nil {
+		t.Fatalf("RunE returned error: %v", runErr)
+	}
+
+	out, err := io.ReadAll(rOut)
+	if err != nil {
+		t.Fatalf("read captured stdout: %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.NewDecoder(strings.NewReader(strings.TrimSpace(string(out)))).Decode(&decoded); err != nil {
+		t.Fatalf("decode stdout %q: %v", string(out), err)
+	}
+	return decoded
+}
+
+// hookSpecific pulls hookSpecificOutput out of a decoded hook response.
+func hookSpecific(t *testing.T, decoded map[string]any) map[string]any {
+	t.Helper()
+
+	hso, ok := decoded["hookSpecificOutput"].(map[string]any)
+	if !ok {
+		t.Fatalf("hookSpecificOutput missing or not an object in %v", decoded)
+	}
+	return hso
+}
+
+// TestHookPreToolCLI_AskReachesTheWire is the end-to-end counterpart of the
+// registry-level tests: an AskPatterns-matching file edit must emit
+// permissionDecision "ask" with a reason on stdout. Before the merge fix this
+// emitted "allow", so every one of the 27 file patterns was silently
+// unguarded.
+func TestHookPreToolCLI_AskReachesTheWire(t *testing.T) {
+	// Not parallel: swaps global deps, os.Stdin, os.Stdout, and cwd.
+	dir := t.TempDir()
+	t.Setenv("CLAUDE_PROJECT_DIR", dir)
+	t.Chdir(dir)
+
+	payload, err := json.Marshal(map[string]any{
+		"hook_event_name": "PreToolUse",
+		"session_id":      "wire-ask-file",
+		"cwd":             dir,
+		"tool_name":       "Edit",
+		"tool_input": map[string]string{
+			"file_path":  filepath.Join(dir, "package.json"),
+			"old_string": "a",
+			"new_string": "b",
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	hso := hookSpecific(t, runPreToolHookCLI(t, string(payload)))
+
+	if got := hso["permissionDecision"]; got != "ask" {
+		t.Errorf("permissionDecision = %v, want \"ask\" (the ask verdict never reached the wire)", got)
+	}
+	if reason, _ := hso["permissionDecisionReason"].(string); reason == "" {
+		t.Error("permissionDecisionReason is empty on the wire; the dialog would explain nothing")
+	}
+}
+
+// TestHookPreToolCLI_AskBashReachesTheWire pins the Bash half of the same
+// contract: `git reset --hard` is an AskBashPatterns entry and was equally
+// downgraded to "allow" on the wire.
+func TestHookPreToolCLI_AskBashReachesTheWire(t *testing.T) {
+	// Not parallel: swaps global deps, os.Stdin, os.Stdout, and cwd.
+	dir := t.TempDir()
+	t.Setenv("CLAUDE_PROJECT_DIR", dir)
+	t.Chdir(dir)
+
+	payload, err := json.Marshal(map[string]any{
+		"hook_event_name": "PreToolUse",
+		"session_id":      "wire-ask-bash",
+		"cwd":             dir,
+		"tool_name":       "Bash",
+		"tool_input":      map[string]string{"command": "git reset --hard HEAD~1"},
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	hso := hookSpecific(t, runPreToolHookCLI(t, string(payload)))
+
+	if got := hso["permissionDecision"]; got != "ask" {
+		t.Errorf("permissionDecision = %v, want \"ask\" for `git reset --hard`", got)
+	}
+	if reason, _ := hso["permissionDecisionReason"].(string); reason == "" {
+		t.Error("permissionDecisionReason is empty on the wire for the ask-bash path")
+	}
+}

--- a/internal/hook/registry.go
+++ b/internal/hook/registry.go
@@ -175,6 +175,8 @@ func (r *registry) Dispatch(ctx context.Context, event EventType, input *HookInp
 //   - updatedInput / updatedToolOutput / updatedMCPToolOutput: last-non-nil wins.
 //   - continue:false (the only meaningful value) + stopReason propagate once set.
 //   - retry propagates when any handler sets it.
+//   - permissionDecision follows a precedence ladder (deny > ask > allow), NOT
+//     a last-writer-wins copy — see mergePermissionDecision.
 func mergeHandlerOutput(merged, output *HookOutput) {
 	if output == nil {
 		return
@@ -233,6 +235,58 @@ func mergeHandlerOutput(merged, output *HookOutput) {
 	}
 	if len(src.MxTags) > 0 {
 		dst.MxTags = append(dst.MxTags, src.MxTags...)
+	}
+
+	mergePermissionDecision(dst, src)
+}
+
+// permissionDecisionRank orders permission decisions by how restrictive they
+// are, so the merge can keep the most restrictive one a handler produced.
+// An unset decision ranks below every explicit decision.
+func permissionDecisionRank(decision string) int {
+	switch decision {
+	case DecisionDeny:
+		return 3
+	case DecisionAsk:
+		return 2
+	case DecisionAllow:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// mergePermissionDecision folds a handler's permission verdict into the merged
+// output using a precedence ladder rather than a field copy:
+//
+//	deny > ask > allow > unset
+//
+// A blind copy would be wrong here in both directions. Dispatch pre-seeds the
+// merged output with the event default — already "allow" for PreToolUse under
+// the autonomous permission modes — so without an explicit ladder a handler's
+// "ask" is discarded and the pre-seeded "allow" reaches the wire. Conversely,
+// copying unconditionally would let a later handler's "allow" clobber an
+// earlier handler's "ask" or "deny".
+//
+// The reason travels with the decision: an "ask" whose
+// permissionDecisionReason was dropped shows the user a confirmation dialog
+// that explains nothing.
+//
+// The PermissionRequest decision object (decision.behavior, which has no "ask"
+// behavior) follows the same ladder so a second handler cannot silently
+// downgrade an earlier "deny".
+func mergePermissionDecision(dst, src *HookSpecificOutput) {
+	if permissionDecisionRank(src.PermissionDecision) > permissionDecisionRank(dst.PermissionDecision) {
+		dst.PermissionDecision = src.PermissionDecision
+		dst.PermissionDecisionReason = src.PermissionDecisionReason
+	}
+
+	if src.Decision == nil {
+		return
+	}
+	if dst.Decision == nil ||
+		permissionDecisionRank(src.Decision.Behavior) > permissionDecisionRank(dst.Decision.Behavior) {
+		dst.Decision = src.Decision
 	}
 }
 

--- a/internal/hook/registry_permission_merge_test.go
+++ b/internal/hook/registry_permission_merge_test.go
@@ -1,0 +1,260 @@
+// Regression tests for the permission-decision merge in registry.Dispatch.
+//
+// The defect these pin: Dispatch pre-seeds the merged output with the event
+// default — already permissionDecision "allow" for PreToolUse under the
+// autonomous permission modes — and mergeHandlerOutput copied every
+// hookSpecificOutput field EXCEPT PermissionDecision. A handler's "ask" was
+// therefore dropped on the floor and the pre-seeded "allow" reached the wire,
+// silently downgrading all 27 AskPatterns and all 10 AskBashPatterns.
+//
+// It shipped green because every pre-existing "ask" assertion called
+// preToolHandler.Handle directly and never crossed registry.Dispatch: the
+// producer was tested, the consumer was not. These tests cross Dispatch.
+package hook
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+)
+
+// dispatchPreTool runs a real preToolHandler through a real registry and
+// returns the dispatched output — the consumer-side path the handler-level
+// tests never exercised.
+func dispatchPreTool(t *testing.T, projectDir string, input *HookInput) *HookOutput {
+	t.Helper()
+
+	cfg := &mockConfigProvider{cfg: newTestConfig()}
+	reg := NewRegistry(cfg)
+	reg.Register(&preToolHandler{
+		cfg:        cfg,
+		policy:     DefaultSecurityPolicy(),
+		projectDir: projectDir,
+	})
+
+	got, err := reg.Dispatch(context.Background(), EventPreToolUse, input)
+	if err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if got == nil || got.HookSpecificOutput == nil {
+		t.Fatal("Dispatch returned nil output or nil HookSpecificOutput")
+	}
+	return got
+}
+
+// TestDispatch_PreToolUse_AskPatternSurvivesMerge asserts a file-pattern "ask"
+// reaches the dispatched output with its reason intact. Before the merge fix
+// this returned "allow".
+func TestDispatch_PreToolUse_AskPatternSurvivesMerge(t *testing.T) {
+	t.Parallel()
+
+	projectDir := t.TempDir()
+	toolInput, err := json.Marshal(map[string]string{
+		"file_path":  filepath.Join(projectDir, "package.json"),
+		"old_string": "a",
+		"new_string": "b",
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	got := dispatchPreTool(t, projectDir, &HookInput{
+		SessionID:     "sess-dispatch-ask-file",
+		CWD:           projectDir,
+		HookEventName: "PreToolUse",
+		ToolName:      "Edit",
+		ToolInput:     json.RawMessage(toolInput),
+	})
+
+	if got.HookSpecificOutput.PermissionDecision != DecisionAsk {
+		t.Errorf("permissionDecision = %q, want %q (the handler's ask was lost in the merge)",
+			got.HookSpecificOutput.PermissionDecision, DecisionAsk)
+	}
+	if got.HookSpecificOutput.PermissionDecisionReason == "" {
+		t.Error("permissionDecisionReason is empty; an ask without a reason shows the user a dialog that explains nothing")
+	}
+}
+
+// TestDispatch_PreToolUse_AskBashPatternSurvivesMerge asserts the Bash side of
+// the same defect: `git reset --hard` is an AskBashPattern and was equally
+// downgraded to "allow".
+func TestDispatch_PreToolUse_AskBashPatternSurvivesMerge(t *testing.T) {
+	t.Parallel()
+
+	projectDir := t.TempDir()
+	toolInput, err := json.Marshal(map[string]string{
+		"command": "git reset --hard HEAD~1",
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	got := dispatchPreTool(t, projectDir, &HookInput{
+		SessionID:     "sess-dispatch-ask-bash",
+		CWD:           projectDir,
+		HookEventName: "PreToolUse",
+		ToolName:      "Bash",
+		ToolInput:     json.RawMessage(toolInput),
+	})
+
+	if got.HookSpecificOutput.PermissionDecision != DecisionAsk {
+		t.Errorf("permissionDecision = %q, want %q for `git reset --hard`",
+			got.HookSpecificOutput.PermissionDecision, DecisionAsk)
+	}
+	if got.HookSpecificOutput.PermissionDecisionReason == "" {
+		t.Error("permissionDecisionReason is empty for the ask-bash path")
+	}
+}
+
+// TestDispatch_PreToolUse_DenyStillShortCircuits guards the decision that was
+// already correct: deny short-circuits before the merge and must stay that way.
+func TestDispatch_PreToolUse_DenyStillShortCircuits(t *testing.T) {
+	t.Parallel()
+
+	projectDir := t.TempDir()
+	toolInput, err := json.Marshal(map[string]string{
+		"file_path":  filepath.Join(projectDir, ".git", "config"),
+		"old_string": "a",
+		"new_string": "b",
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	got := dispatchPreTool(t, projectDir, &HookInput{
+		SessionID:     "sess-dispatch-deny",
+		CWD:           projectDir,
+		HookEventName: "PreToolUse",
+		ToolName:      "Edit",
+		ToolInput:     json.RawMessage(toolInput),
+	})
+
+	if got.HookSpecificOutput.PermissionDecision != DecisionDeny {
+		t.Errorf("permissionDecision = %q, want %q", got.HookSpecificOutput.PermissionDecision, DecisionDeny)
+	}
+}
+
+// TestMergeHandlerOutput_PermissionPrecedence pins the ladder itself:
+// deny > ask > allow > unset, with the reason travelling alongside the
+// decision. A blind field copy would let a later handler's allow clobber an
+// earlier handler's ask — this is why the fix is a ladder and not a copy.
+func TestMergeHandlerOutput_PermissionPrecedence(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		dst        string
+		dstReason  string
+		src        string
+		srcReason  string
+		want       string
+		wantReason string
+	}{
+		{
+			name: "ask beats the pre-seeded allow", dst: DecisionAllow, src: DecisionAsk,
+			srcReason: "critical config file", want: DecisionAsk, wantReason: "critical config file",
+		},
+		{
+			name: "allow never clobbers an earlier ask", dst: DecisionAsk, dstReason: "keep me",
+			src: DecisionAllow, want: DecisionAsk, wantReason: "keep me",
+		},
+		{
+			name: "allow never clobbers an earlier deny", dst: DecisionDeny, dstReason: "protected",
+			src: DecisionAllow, want: DecisionDeny, wantReason: "protected",
+		},
+		{
+			name: "ask never clobbers an earlier deny", dst: DecisionDeny, dstReason: "protected",
+			src: DecisionAsk, srcReason: "confirm", want: DecisionDeny, wantReason: "protected",
+		},
+		{
+			name: "deny beats an earlier ask", dst: DecisionAsk, dstReason: "confirm",
+			src: DecisionDeny, srcReason: "protected", want: DecisionDeny, wantReason: "protected",
+		},
+		{
+			name: "an unset src leaves the accumulator untouched", dst: DecisionAsk, dstReason: "confirm",
+			src: "", want: DecisionAsk, wantReason: "confirm",
+		},
+		{
+			name: "an explicit allow fills an unset accumulator", dst: "", src: DecisionAllow,
+			want: DecisionAllow, wantReason: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			merged := &HookOutput{HookSpecificOutput: &HookSpecificOutput{
+				HookEventName:            "PreToolUse",
+				PermissionDecision:       tt.dst,
+				PermissionDecisionReason: tt.dstReason,
+			}}
+			output := &HookOutput{HookSpecificOutput: &HookSpecificOutput{
+				HookEventName:            "PreToolUse",
+				PermissionDecision:       tt.src,
+				PermissionDecisionReason: tt.srcReason,
+			}}
+
+			mergeHandlerOutput(merged, output)
+
+			if got := merged.HookSpecificOutput.PermissionDecision; got != tt.want {
+				t.Errorf("permissionDecision = %q, want %q", got, tt.want)
+			}
+			if got := merged.HookSpecificOutput.PermissionDecisionReason; got != tt.wantReason {
+				t.Errorf("permissionDecisionReason = %q, want %q", got, tt.wantReason)
+			}
+		})
+	}
+}
+
+// TestMergeHandlerOutput_PermissionRequestDecision covers the sibling field the
+// same omission pattern left uncopied: hookSpecificOutput.decision.behavior,
+// used by PermissionRequest (which has no "ask" behavior — only allow/deny).
+//
+// This was NOT reachable as a live defect: defaultOutputForEvent returns a bare
+// &HookOutput{} for PermissionRequest, so the nil-HookSpecificOutput
+// early-assign branch carried the whole object through, and only one handler is
+// registered for the event. It was sound by accident on two counts. The ladder
+// now covers it explicitly, and these cases pin it.
+func TestMergeHandlerOutput_PermissionRequestDecision(t *testing.T) {
+	t.Parallel()
+
+	t.Run("decision survives into a non-nil accumulator", func(t *testing.T) {
+		t.Parallel()
+
+		merged := &HookOutput{HookSpecificOutput: &HookSpecificOutput{HookEventName: "PermissionRequest"}}
+		output := &HookOutput{HookSpecificOutput: &HookSpecificOutput{
+			HookEventName: "PermissionRequest",
+			Decision:      &PermissionRequestDecision{Behavior: DecisionDeny},
+		}}
+
+		mergeHandlerOutput(merged, output)
+
+		if merged.HookSpecificOutput.Decision == nil {
+			t.Fatal("decision was dropped by the merge")
+		}
+		if got := merged.HookSpecificOutput.Decision.Behavior; got != DecisionDeny {
+			t.Errorf("decision.behavior = %q, want %q", got, DecisionDeny)
+		}
+	})
+
+	t.Run("allow never clobbers an earlier deny", func(t *testing.T) {
+		t.Parallel()
+
+		merged := &HookOutput{HookSpecificOutput: &HookSpecificOutput{
+			HookEventName: "PermissionRequest",
+			Decision:      &PermissionRequestDecision{Behavior: DecisionDeny},
+		}}
+		output := &HookOutput{HookSpecificOutput: &HookSpecificOutput{
+			HookEventName: "PermissionRequest",
+			Decision:      &PermissionRequestDecision{Behavior: DecisionAllow},
+		}}
+
+		mergeHandlerOutput(merged, output)
+
+		if got := merged.HookSpecificOutput.Decision.Behavior; got != DecisionDeny {
+			t.Errorf("decision.behavior = %q, want %q", got, DecisionDeny)
+		}
+	})
+}


### PR DESCRIPTION
## The defect

`registry.Dispatch` pre-seeds its merged output with the event default — already `permissionDecision: "allow"` for PreToolUse under the autonomous permission modes — and `mergeHandlerOutput` copied every `hookSpecificOutput` field **except** `PermissionDecision` / `PermissionDecisionReason`. A handler's `"ask"` was dropped on the floor and the pre-seeded `"allow"` reached the wire.

Only `"deny"` survived, because deny short-circuits (`isBlockDecision`) before the merge runs.

**Blast radius**: every `ask` verdict the PreToolUse hook can produce — 27 `AskPatterns` file patterns (`package.json`, `Dockerfile`, `.github/workflows/*`, `terraform/*.tf`, `k8s/*`, `Jenkinsfile`, lock files, …) and 10 `AskBashPatterns` commands (`git reset --hard`, `git clean -fd`, force-push, `prisma migrate reset`, …). All documented as requiring confirmation; none actually required it.

The omission predates the `mergeHandlerOutput` refactor that broadened the merge without adding the permission fields — a long-standing latent defect, not a recent regression.

## The fix

A **precedence ladder** (`deny > ask > allow > unset`), not a field copy. A blind copy would be wrong in the other direction: it would let a later handler's `allow` clobber an earlier handler's `ask` or `deny`. The reason travels with the decision — an `ask` with an empty `permissionDecisionReason` shows a dialog that explains nothing.

The sibling `PermissionRequest` `decision.behavior` field had the same omission. It was **not** a live defect: `defaultOutputForEvent` returns a bare `&HookOutput{}` there, so the nil-`HookSpecificOutput` early-assign branch carried the object through, and only one handler is registered for the event — sound by accident on two counts. It now follows the same ladder explicitly, with regression cases.

## The tests are the real fix

This shipped green because **every** `ask` assertion called `preToolHandler.Handle` directly and never crossed `registry.Dispatch`: the producer was tested, the consumer was not. `deny` had both handler-level and end-to-end coverage, which is exactly why `deny` stayed correct while `ask` rotted unnoticed.

Added, and each verified to **fail** with the fix removed:

1. `internal/hook` registry-level — `Dispatch(EventPreToolUse, …)` with an `AskPatterns` file, asserting `"ask"` **and** a non-empty reason
2. `internal/hook` registry-level — the same for `git reset --hard` (`AskBashPatterns`)
3. `internal/hook` — a 7-case precedence table pinning the ladder in both directions
4. `internal/hook` — `PermissionRequest` `decision.behavior` cases
5. `internal/cli` — wire-format assertions on the JSON reaching stdout, pinning `ask` end-to-end the way `deny` already is

A deny-still-short-circuits guard is included so the path that was already correct stays that way.

## ⚠️ Behaviour change users will notice

**This will start surfacing permission dialogs that have been silently suppressed for a long time.** Editing `package.json`, a `Dockerfile`, a workflow file, or running `git reset --hard` will now prompt for confirmation where it previously proceeded without asking.

That is the correct, documented behaviour and the whole point of the fix — but it is a visible change, it will look sudden, and it may be mistaken for a new bug. Under `defaultMode: bypassPermissions` the difference is starkest: an unattended agent could previously force-push or hard-reset with no gate at all.

## Verification

- `go test ./internal/hook/ ./internal/cli/ -count=1` — green apart from two failures reproduced identically on unmodified `main` (`TestPreTool_AstGrepSkipReasonSurfaces`, `TestHandleCodexReviewGate_LiveCodexBlocksInjectionAndKey`)
- `go vet ./...` — clean; `golangci-lint run` on both packages — 0 issues
- Probes re-run against a freshly built binary: `ask` now reaches the wire with its reason for both the file and Bash paths; `deny` unchanged; ordinary edits and commands still `allow`

🗿 MoAI
