### PR TITLE
fix(cli): poll barrier flag directly in atomic-write barrier test (t24)

### DIFF
--- a/internal/cli/navigator_enrich.go
+++ b/internal/cli/navigator_enrich.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -132,16 +133,25 @@ func atomicWrite(path string, data []byte) error {
 	}
 
 	// Test hook: synchronized barrier for the atomic-rename fixture
-	// (mirrors 001's NAVIGATOR_PRE_RENAME_BARRIER pattern). The barrier is
-	// consumed on first use so only the first output file blocks; subsequent
-	// files in the same run skip it.
+	// (mirrors 001's NAVIGATOR_PRE_RENAME_BARRIER pattern). The barrier is a
+	// process-global one-shot latch: os.Unsetenv consumes it, so only the
+	// first output file blocks and any second concurrent caller would
+	// silently skip it (single-caller today, test-only).
 	if barrier := os.Getenv("NAVIGATOR_PRE_RENAME_BARRIER"); barrier != "" {
 		_ = os.Unsetenv("NAVIGATOR_PRE_RENAME_BARRIER")
 		_ = os.WriteFile(barrier, []byte("ready"), 0o644)
-		for {
+		// Bounded wait: sleep per iteration plus an overall ceiling so a
+		// test that fails before removing the barrier cannot strand a
+		// CPU-burning goroutine (and race t.TempDir cleanup) for the rest
+		// of the package run. Passing runs remove the barrier within
+		// milliseconds; the 5s ceiling only fires on an already-failing
+		// test, after which the rename proceeds and the goroutine exits.
+		deadline := time.Now().Add(5 * time.Second)
+		for time.Now().Before(deadline) {
 			if _, err := os.Stat(barrier); err != nil {
 				break // barrier removed → proceed to rename
 			}
+			time.Sleep(time.Millisecond)
 		}
 	}
 

--- a/internal/cli/navigator_enrich_test.go
+++ b/internal/cli/navigator_enrich_test.go
@@ -78,17 +78,26 @@ func TestNavigatorEnrich_AtomicWriteBarrier(t *testing.T) {
 
 	// While the barrier exists, the .tmp file should be present and the final
 	// file absent (rename blocked).
-	// Wait briefly for the goroutine to reach the barrier.
-	tmp := filepath.Join(root, ".moai", "project", "codemaps", "capability-symbols.md.tmp")
+	// Poll the barrier flag itself — the goroutine's own "I reached the
+	// barrier" signal, written AFTER the .tmp file — so the unsynchronized
+	// window between .tmp creation and barrier creation cannot be observed.
+	// Polling the .tmp file instead raced the goroutine's schedule and failed
+	// ~5-7% of isolated runs (t24 investigation).
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		if _, err := os.Stat(tmp); err == nil {
+		if _, err := os.Stat(barrier); err == nil {
 			break
 		}
 		time.Sleep(5 * time.Millisecond)
 	}
 	if _, err := os.Stat(barrier); err != nil {
-		t.Fatalf("barrier file not created (goroutine did not reach barrier)")
+		t.Fatalf("barrier flag not created within 2s deadline (goroutine did not reach barrier): %v", err)
+	}
+	// The .tmp file is written before the barrier flag, so it provably exists
+	// while the barrier is held (rename blocked).
+	tmp := filepath.Join(root, ".moai", "project", "codemaps", "capability-symbols.md.tmp")
+	if _, err := os.Stat(tmp); err != nil {
+		t.Errorf("tmp file missing while barrier held: %v", err)
 	}
 	// Final file must NOT exist yet (rename blocked on barrier).
 	if _, err := os.Stat(filepath.Join(root, ".moai", "project", "codemaps", "capability-symbols.md")); err == nil {


### PR DESCRIPTION
## Summary

Fixes the independent ~5-7% flake in `TestNavigatorEnrich_AtomicWriteBarrier` (card t24). The card's original premise — cross-test interference — was overturned by the investigation report (`.moai/reports/backlog/t24-test-interference-investigation.md`): the test fails 3/60 in complete isolation, with nothing else in the package executing.

## Root cause

`atomicWrite` performs, in order: (1) write `.tmp`, (2) unset env, (3) write barrier flag, (4) spin until barrier removed, (5) rename. The test polled for **step 1** and then asserted **step 3** had already happened. The window between the two writes is unsynchronized; when the 5ms poll tick lands inside it, the test sees `tmp` present, `barrier` absent, and fails. Every observed failure landed on exactly that assert (7/100 on `3b9b3bf99`), all completing in 0.14-0.34s — the 2s deadline never expired.

## Fix (test-only, primary)

Poll the barrier flag itself in the deadline loop — it is the goroutine's own "I reached the barrier" signal and is written after `.tmp`, so polling it closes the window completely. Deadline expiry is now the failure condition. The `.tmp`-present invariant is still asserted afterwards (it provably holds by write ordering). The production `.tmp` → barrier → rename ordering is **unchanged** — it is exactly what this test exists to verify.

## Secondary (production, test-hook path only)

The spin loop had no sleep and no ceiling, so a `t.Fatalf` stranded a CPU-burning goroutine for the rest of the package run and raced `t.TempDir` cleanup (observed as `TempDir RemoveAll cleanup: directory not empty`). Now: 1ms sleep per iteration + 5s overall ceiling.

**Why 5s:** passing runs hold the barrier for milliseconds (full test duration observed at 0.06-0.34s), and the test's own deadline is 2s — the ceiling can only fire on a test that has *already* failed, where it converts an unbounded spin into a bounded one and lets the goroutine proceed to the rename and exit.

Tertiary (comment only): the `os.Unsetenv` self-consumption makes the barrier a process-global one-shot latch; documented in place, no redesign.

## Verification

- `go test ./internal/cli/ -run TestNavigatorEnrich_AtomicWriteBarrier -count=200` (unloaded): **exit 0, zero failures** — baseline on unmodified `3b9b3bf99` was 7/100.
- `gofmt -l` clean, `go vet ./internal/cli/` clean, all 3 navigator-enrich tests pass at `-count=5`.
- Full suite left to CI on this PR head, per lead instruction (local box is under a no-full-suite directive today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-saving reliability by preventing indefinite waits during atomic writes.
  * Added a timeout so file operations can proceed if the synchronization barrier is not removed.
  * Enhanced validation of temporary-file handling during interrupted or delayed writes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->