### PR TITLE
docs(agent): give manager-kanban a final-output contract and a neither-role fallback

### DIFF
--- a/.claude/agents/moai/manager-kanban.md
+++ b/.claude/agents/moai/manager-kanban.md
@@ -59,7 +59,64 @@ Below this threshold the orchestrator drives Mode 5 directly (single sequential 
 - **Per-milestone Context-Folding** — REUSE existing primitives. No new Go mechanism, hook, or CLI. The fold procedure composes `/compact` (existing slash command) + file-redirect to `.moai/state/verify/<session>/` (existing convention) + `progress.md` §E.2 fold-row append (existing row format). See § Context-Folding Procedure below.
 - **Peer cross-validation orchestration** — when a leaf worker marks an AC PASS at Tier M/L, manager-kanban spawns a second read-only `Agent(general-purpose)` (NOT the author, with `tools:` omitting Write/Edit/NotebookEdit) to re-run the acceptance.md §D Given-When-Then commands and return PASS / PARTIAL / FAIL. Tier S ACs skip peer cross-validation.
 - **Schema-driven fan-out reduce** — when ≥3 explorer agents are warranted (e.g. multi-domain research ahead of milestone M1), consume the existing `plan-research-fanout` skill's fixed-heading markdown schema verbatim (do NOT re-derive per spawn, do NOT author a parallel schema). Cross-explorer contradictions are annotated as a named section in the merged result, never silently discarded.
-- **Blocker-report returns** — manager-kanban NEVER invokes the orchestrator-exclusive user-question tool. On unresolved input, on peer FAIL/PARTIAL that the author contests, or on `/compact` unavailable in subagent context, return a structured blocker report per `.claude/rules/moai/core/agent-common-protocol.md` § Blocker Report Format; the orchestrator runs the AskUser round and re-delegates.
+- **Blocker-report returns** — manager-kanban NEVER invokes the orchestrator-exclusive user-question tool. On unresolved input, on peer FAIL/PARTIAL that the author contests, on `/compact` unavailable in subagent context, or when **the delegated work satisfies neither role's entry conditions** (below), return a structured blocker report per `.claude/rules/moai/core/agent-common-protocol.md` § Blocker Report Format; the orchestrator runs the AskUser round and re-delegates.
+
+  The neither-role case: the delegation meets neither Role A's three-part threshold (§ Condition-Triggered Entry — ≥3 milestones AND ≥10 files AND cross-domain) nor Role B's entry (a SessionStart context declaring Kanban Mode with the `lead` role). Name in the blocker report what was delegated, which of Role A's three predicates it fails, and that Role B's entry is unavailable — a subagent spawn carries no SessionStart context, so Role B's condition cannot be satisfied from one. Returning that blocker report IS the correct outcome here; proceeding under a role whose entry was not met, and ending the turn with nothing, are both wrong.
+
+## Output Format
+
+Every invocation ends in one of the shapes below. Ending a turn with an empty response is not one of them — produce the applicable shape before the turn ends.
+
+This contract is modelled on `plan-auditor.md` (a named output path, plus a mandated string for the cannot-proceed path) rather than on `sync-auditor.md` (a response-body skeleton). sync-auditor returns a body because it carries no Write tool and must not attempt a file write; that reason does not apply here. This agent carries Write, and it is the only retained agent carrying `Agent` — a result that exists only in a response body can take an entire leaf-worker sub-tree with it. A file is the artifact that outlives the turn, so Role A's deliverable is a file wherever one is possible.
+
+### Role A — in-session fan-out
+
+Write the consolidated report to `.moai/reports/kanban/{SPEC-ID}-M{n}.md` at each milestone boundary, **before** the fold's `/compact` step (Step 3 of § Context-Folding Procedure). A compact that runs first takes an unwritten report with it.
+
+```
+# Kanban Milestone Report: {SPEC-ID} M{n}
+
+## AC Matrix
+| AC-id | Verdict | Peer verdict | Evidence path |
+|-------|---------|--------------|---------------|
+| {id}  | PASS | FAIL | GAP | PASS | PARTIAL | FAIL | n/a | .moai/state/verify/{session}/M{n}.{id}.log |
+
+## Leaf Workers
+| Worker | Scope | Worktree branch | Outcome |
+
+## Contradictions
+{the named section from § Schema-Driven Fan-Out Reduce, or "none"}
+
+## Gaps
+{what was NOT verified — an AC whose evidence could not be populated is GAP, never PASS}
+```
+
+Return in the response body: the report path, the milestone, and one line per AC carrying its verdict. The file is the deliverable; the body is the pointer to it.
+
+### Role B — cross-session dispatch
+
+Role B writes no report file, and this is by construction rather than by omission: `kanban-dispatch.md` § Boundaries states that no board state store exists — column position is held by the lead within a card's run and re-derived from SPEC status after a `/clear`. The deliverable is the dispatch itself plus what was read to justify it.
+
+Return in the response body, per card acted on:
+
+```
+card: {id} | {from-column} -> {to-column}
+dispatched to: {session-name}   (or: not dispatched — {reason})
+evidence read: {path}, {what it showed}
+operator action requested: /clear {session-name}   (or: none)
+```
+
+A card that did NOT advance is reported with the same shape and the reason it stayed — a column that did not move is a result, not silence.
+
+### Cannot proceed
+
+Return a structured blocker report per § Core Capabilities → Blocker-report returns. When even that is not possible — the SPEC directory is absent, or the delegation named no work — return the single line:
+
+```
+KANBAN BLOCKED: {one-line reason}
+```
+
+and stop. A blocker report and this line are both complete outcomes; an empty response is not.
 
 ## Depth-2 Seal (LOAD-BEARING)
 

--- a/internal/template/catalog.yaml
+++ b/internal/template/catalog.yaml
@@ -122,7 +122,7 @@ catalog:
             - name: manager-kanban
               tier: core
               path: templates/.claude/agents/moai/manager-kanban.md
-              hash: b57454e1489da9ff0f10e6155b90eaea5d4d2ae0a1fd81501e1685017db072d9
+              hash: 4be1c61fda8fa853a1f17e4c55f557835f8143c2b241049d902dfcad132f876b
               version: 1.0.0
             - name: manager-spec
               tier: core

--- a/internal/template/templates/.claude/agents/moai/manager-kanban.md
+++ b/internal/template/templates/.claude/agents/moai/manager-kanban.md
@@ -59,7 +59,64 @@ Below this threshold the orchestrator drives Mode 5 directly (single sequential 
 - **Per-milestone Context-Folding** — REUSE existing primitives. No new Go mechanism, hook, or CLI. The fold procedure composes `/compact` (existing slash command) + file-redirect to `.moai/state/verify/` (existing convention) + `progress.md` §E.2 fold-row append (existing row format). See § Context-Folding Procedure below.
 - **Peer cross-validation orchestration** — when a leaf worker marks an AC PASS at Tier M/L, manager-kanban spawns a second read-only `Agent(general-purpose)` (NOT the author, with `tools:` omitting Write/Edit/NotebookEdit) to re-run the acceptance.md §D Given-When-Then commands and return PASS / PARTIAL / FAIL. Tier S ACs skip peer cross-validation.
 - **Schema-driven fan-out reduce** — when ≥3 explorer agents are warranted (e.g. multi-domain research ahead of milestone M1), consume the existing `plan-research-fanout` skill's fixed-heading markdown schema verbatim (do NOT re-derive per spawn, do NOT author a parallel schema). Cross-explorer contradictions are annotated as a named section in the merged result, never silently discarded.
-- **Blocker-report returns** — manager-kanban NEVER invokes the orchestrator-exclusive user-question tool. On unresolved input, on peer FAIL/PARTIAL that the author contests, or on `/compact` unavailable in subagent context, return a structured blocker report per `.claude/rules/moai/core/agent-common-protocol.md` § Blocker Report Format; the orchestrator runs the AskUser round and re-delegates.
+- **Blocker-report returns** — manager-kanban NEVER invokes the orchestrator-exclusive user-question tool. On unresolved input, on peer FAIL/PARTIAL that the author contests, on `/compact` unavailable in subagent context, or when **the delegated work satisfies neither role's entry conditions** (below), return a structured blocker report per `.claude/rules/moai/core/agent-common-protocol.md` § Blocker Report Format; the orchestrator runs the AskUser round and re-delegates.
+
+  The neither-role case: the delegation meets neither Role A's three-part threshold (§ Condition-Triggered Entry — ≥3 milestones AND ≥10 files AND cross-domain) nor Role B's entry (a SessionStart context declaring Kanban Mode with the `lead` role). Name in the blocker report what was delegated, which of Role A's three predicates it fails, and that Role B's entry is unavailable — a subagent spawn carries no SessionStart context, so Role B's condition cannot be satisfied from one. Returning that blocker report IS the correct outcome here; proceeding under a role whose entry was not met, and ending the turn with nothing, are both wrong.
+
+## Output Format
+
+Every invocation ends in one of the shapes below. Ending a turn with an empty response is not one of them — produce the applicable shape before the turn ends.
+
+This contract is modelled on `plan-auditor.md` (a named output path, plus a mandated string for the cannot-proceed path) rather than on `sync-auditor.md` (a response-body skeleton). sync-auditor returns a body because it carries no Write tool and must not attempt a file write; that reason does not apply here. This agent carries Write, and it is the only retained agent carrying `Agent` — a result that exists only in a response body can take an entire leaf-worker sub-tree with it. A file is the artifact that outlives the turn, so Role A's deliverable is a file wherever one is possible.
+
+### Role A — in-session fan-out
+
+Write the consolidated report to `.moai/reports/kanban/<SPEC-ID>-M<n>.md` at each milestone boundary, **before** the fold's `/compact` step (Step 3 of § Context-Folding Procedure). A compact that runs first takes an unwritten report with it.
+
+```
+# Kanban Milestone Report: <SPEC-ID> M<n>
+
+## AC Matrix
+| AC-id | Verdict | Peer verdict | Evidence path |
+|-------|---------|--------------|---------------|
+| <id>  | PASS | FAIL | GAP | PASS | PARTIAL | FAIL | n/a | .moai/state/verify/<session>/M<n>.<AC-id>.log |
+
+## Leaf Workers
+| Worker | Scope | Worktree branch | Outcome |
+
+## Contradictions
+<the named section from § Schema-Driven Fan-Out Reduce, or "none">
+
+## Gaps
+<what was NOT verified — an AC whose evidence could not be populated is GAP, never PASS>
+```
+
+Return in the response body: the report path, the milestone, and one line per AC carrying its verdict. The file is the deliverable; the body is the pointer to it.
+
+### Role B — cross-session dispatch
+
+Role B writes no report file, and this is by construction rather than by omission: `kanban-dispatch.md` § Boundaries states that no board state store exists — column position is held by the lead within a card's run and re-derived from SPEC status after a `/clear`. The deliverable is the dispatch itself plus what was read to justify it.
+
+Return in the response body, per card acted on:
+
+```
+card: <id> | <from-column> -> <to-column>
+dispatched to: <session-name>   (or: not dispatched — <reason>)
+evidence read: <path>, <what it showed>
+operator action requested: /clear <session-name>   (or: none)
+```
+
+A card that did NOT advance is reported with the same shape and the reason it stayed — a column that did not move is a result, not silence.
+
+### Cannot proceed
+
+Return a structured blocker report per § Core Capabilities → Blocker-report returns. When even that is not possible — the SPEC directory is absent, or the delegation named no work — return the single line:
+
+```
+KANBAN BLOCKED: <one-line reason>
+```
+
+and stop. A blocker report and this line are both complete outcomes; an empty response is not.
 
 ## Depth-2 Seal (LOAD-BEARING)
 


### PR DESCRIPTION
Card **t23 follow-up**. Investigation: `.moai/reports/backlog/t23-agent-idle-investigation.md`.

Implements **R2** and **R3** from that report, and nothing beyond them.

## What this does not do

It does **not** fix the root cause. The report deliberately left that undetermined between a definition defect and a runtime defect, and it names the single measurement that would settle it — reading the incident transcript for the actual `subagent_type`, the response body, and whether a nested `Agent` call occurred. That measurement was not made here, and no hypothesis about the cause is written into the agent file as if it were established.

Both edits are loss mitigation that is safe under either answer. Neither guarantees recovery: an agent that ends a turn empty *before* writing its file loses the work either way (report §5-4).

## The problem, as measured

Subagent delegations have finished with an empty response body. `subagent_stop` fired normally each time (report §E3) — the agent did not die, it finished a turn with nothing in it. Nothing was lost only because the spawn prompts named a file the agent had to write.

`manager-kanban` is one of **nine** retained agents with no final-output contract, so contract absence is not unique to it. What *is* unique: it is the only one of the nine that also carries the `Agent` tool (report §E1), so a lost report can take an entire leaf-worker sub-tree with it.

## R2 — Output Format contract

**Chosen model: `plan-auditor`, not `sync-auditor`** — the PR body is asked to say why.

`sync-auditor` specifies a response-body skeleton and states its own reason (`sync-auditor.md:126`): it has no Write tool under `permissionMode: plan` and must not attempt a file write. **That reason does not apply here** — `manager-kanban` carries Write. And because it is the sole `Agent`-carrier, a result living only in a response body is exactly the thing that can vanish with a whole sub-tree. `plan-auditor`'s model fits: a named output path (`plan-auditor.md:357-359`) *plus* a mandated string for the cannot-proceed path (`plan-auditor.md:452`). The property that matters is the second one — **finishing with nothing is not a permitted outcome**.

The contract is role-split, because the two roles differ in whether a file is even possible:

| | Deliverable | Why |
|---|---|---|
| **Role A** (in-session fan-out) | `.moai/reports/kanban/<SPEC-ID>-M<n>.md` + a pointer in the body | Has Write; a file outlives the turn. Written **before** the fold's `/compact` step — a compact that runs first takes an unwritten report with it. |
| **Role B** (cross-session dispatch) | response body only | Not an omission: `kanban-dispatch.md` § Boundaries states **no board state store exists** — column position is held by the lead within a card's run and re-derived from SPEC status after a `/clear`. There is nothing to write to. |
| **Cannot proceed** | blocker report, or the single line `KANBAN BLOCKED: <reason>` | Both are complete outcomes. An empty response is not. |

Role B also reports a card that did **not** advance, with the reason it stayed — a column that did not move is a result, not silence.

## R3 — neither-role fallback

`manager-kanban.md:62` listed three blocker-report triggers (unresolved input / peer FAIL contested / `/compact` unavailable). "The delegation fits neither of my roles" was not among them, so that situation had **no defined behaviour at all**.

Added as a fourth trigger: when the work meets neither Role A's three-part threshold (≥3 milestones AND ≥10 files AND cross-domain) nor Role B's entry, return a blocker report naming what was delegated, which of Role A's predicates it fails, and that Role B's entry is unavailable — **a subagent spawn carries no SessionStart context, so Role B's condition cannot be satisfied from one** (report §E5, measured).

The clause states that returning the blocker report *is* the correct outcome, and that both proceeding under an unmet role and ending the turn with nothing are wrong. It does **not** assert that this gap caused the empty turns.

## Template-First

The mirror carries **thirteen intentional neutralizations** on this file (`Tier L` → `large-scope`, `Mode 7` → `a new mode`, version pins and internal citations stripped). A verbatim `cp` would overwrite all of them, so the delta was re-applied by hand and the added text was checked to introduce no SPEC IDs, REQ tokens, dates, or internal citations. `catalog.yaml` regenerated by `make build`.

## Verification

- `make build` — ok (catalog.yaml hash updated for this file only)
- `MOAI_TEMPLATE_LEAK_STRICT=1 go test ./internal/template/ -count=1` — **ok, 103.9s** (neutrality + mirror parity)

Per the lead's standing instruction, the local full suite was **not** run; CI is the baseline. This change touches only markdown and a regenerated catalog hash — no Go source.

🗿 MoAI