### PR TITLE
fix(hook): scope branch-guard scan to the command; correct the exemption doctrine

### DIFF
--- a/.claude/rules/moai/workflow/main-checkout-branch-guard.md
+++ b/.claude/rules/moai/workflow/main-checkout-branch-guard.md
@@ -130,9 +130,36 @@ flows. The hook applies the doctrine conditionally.
   cwd-normalized `--git-common-dir`.
 - **Exemption mechanism**: the deny is suppressed when EITHER the invoking
   agent identity is the trusted git agent (`HookInput.AgentType ==
-  "manager-git"`, populated on main-thread `claude --agent manager-git`) OR
-  the sentinel environment variable `MOAI_BRANCH_GUARD_EXEMPT=1` is set by
-  the orchestrator when spawning that agent for Late-Branch closure.
+  "manager-git"`) OR the sentinel environment variable
+  `MOAI_BRANCH_GUARD_EXEMPT=1` is present. Both axes are implemented and each
+  fires on its own — but each is read from a different place, and **neither is
+  reachable from inside a tool-spawned subagent**:
+  - `AgentType` arrives in the hook payload, and Claude Code populates
+    `agent_type` for a main-thread `claude --agent manager-git` launch. A
+    subagent spawned through the Agent tool sends no `agent_type` on
+    PreToolUse, so the identity axis cannot fire for it.
+  - The sentinel is read from the hook process's own environment. The hook
+    runs as a separate process spawned **before** the guarded command executes,
+    so an `export MOAI_BRANCH_GUARD_EXEMPT=1` inside that command never reaches
+    it. The variable must be present in the environment Claude Code itself was
+    launched with.
+
+  Exporting the sentinel inside the command being guarded is therefore a no-op.
+  A `manager-git` subagent that needs to mutate branch state has two working
+  routes: do the work in a worktree (`git -C <worktree>`, which the discriminant
+  correctly classifies as non-primary), or have the operator launch the session
+  with the sentinel already in its environment. Reading a `BRANCH_GUARD_VIOLATION`
+  as "the exemption is broken" is a misdiagnosis — the axes work; the values were
+  never delivered.
+
+- **Scan scope**: the pattern set is matched against the command with quoted
+  spans collapsed to a placeholder word, so a match reflects the command being
+  invoked rather than text carried as data. `moai todo add "… git switch …"` is
+  allowed because the command being run is `moai todo add`; `git switch main`
+  and `git checkout -b "feat/x"` both still deny, the latter because the
+  placeholder preserves the operand after `-b`. A git invocation hidden inside a
+  shell wrapper (`bash -c "git switch main"`) is not matched — under-matching an
+  obfuscated form is the correct direction to err for a fail-open guard.
 - **Fail-open norm**: the deny fires ONLY on positive evidence (primary
   checkout confirmed AND a branch-state pattern matched AND the agent is not
   exempt). Any uncertainty — not a git repo, missing git binary, `git
@@ -160,5 +187,5 @@ Discriminant directory correction: SPEC-WORKTREE-BRANCH-GUARD-DISCRIM-001
 
 ---
 
-Version: 1.2.0
+Version: 1.3.0
 Classification: Evolvable operational rule — branch-state isolation; changes no gate semantics.

--- a/internal/hook/branch_guard.go
+++ b/internal/hook/branch_guard.go
@@ -21,10 +21,24 @@ import (
 	gitcore "github.com/modu-ai/moai-adk/internal/core/git"
 )
 
-// branchGuardExemptEnv is the sentinel env var the orchestrator sets when
-// spawning Agent(manager-git, ...) for Late-Branch closure work. Closes the
-// gap that HookInput.AgentType is populated only for main-thread `claude
-// --agent` invocations (REQ-WBG-011b).
+// branchGuardExemptEnv is the sentinel env var that exempts a session from the
+// guard, complementing the AgentType identity axis (REQ-WBG-011b).
+//
+// Reachability — both axes are read from what arrives at THIS process, and a
+// tool-spawned subagent can supply neither:
+//
+//   - AgentType arrives only in the hook payload, and Claude Code populates
+//     agent_type for a main-thread `claude --agent <name>` launch. A subagent
+//     spawned through the Agent tool sends no agent_type on PreToolUse, so the
+//     identity axis cannot fire for it.
+//   - This env var is read from the hook process's own environment. The hook
+//     runs as a separate process spawned BEFORE the guarded command executes,
+//     so an `export` inside that command cannot reach it. The variable must be
+//     present in the environment Claude Code itself was launched with.
+//
+// Exporting the sentinel inside the command being guarded is therefore a no-op,
+// and was mistaken for a broken exemption. Neither axis is defective; both are
+// simply unreachable from inside a guarded command.
 const branchGuardExemptEnv = "MOAI_BRANCH_GUARD_EXEMPT"
 
 // branchGuardAuditRelPath is the fail-open advisory log path, relative to the
@@ -117,12 +131,52 @@ var branchStatePatterns = func() []branchStatePattern {
 	return out
 }()
 
+// quotedArgumentPattern matches a single- or double-quoted span in a shell
+// command. Leftmost-first alternation handles the nested case correctly: in
+// `echo "it's fine"` the double-quoted span starts first and swallows the
+// apostrophe, so the trailing text is not mistaken for an open single quote.
+var quotedArgumentPattern = regexp.MustCompile(`'[^']*'|"[^"]*"`)
+
+// quotedArgumentPlaceholder is what a quoted span collapses to. It is a single
+// non-flag word surrounded by spaces, chosen so the substitution preserves the
+// SHAPE of the command while discarding the span's contents:
+//
+//   - non-flag, so `git checkout -b "feat/x"` still presents an operand after
+//     `-b` and keeps matching. Blanking the span outright would have silently
+//     un-guarded every branch-state command whose branch name was quoted;
+//   - surrounded by spaces, so the tokens on either side cannot fuse into a new
+//     word that matches by accident.
+const quotedArgumentPlaceholder = " X "
+
+// substituteQuotedArguments replaces every quoted span with a placeholder word
+// so branch-state patterns match the command being RUN rather than text carried
+// as data inside an argument.
+//
+// Without this, the pattern scan matched anywhere in the command string. A
+// `moai todo add "… git switch …"` call was denied because the guarded text sat
+// inside a quoted argument that would never execute — the command actually
+// being run was `moai todo add`. Any command whose arguments quoted git prose
+// was refused the same way.
+//
+// Residual (accepted): a command that passes git through a shell wrapper —
+// `bash -c "git switch main"` — no longer matches, because the git invocation
+// is inside the discarded span. The guard is opt-in, advisory in spirit, and
+// fails open on every uncertainty, so under-matching a deliberately obfuscated
+// form is the correct direction to err. The Claude Code worktree isolation
+// guard refuses that same shape independently.
+func substituteQuotedArguments(command string) string {
+	return quotedArgumentPattern.ReplaceAllString(command, quotedArgumentPlaceholder)
+}
+
 // matchBranchStateCommand returns the deny-reason suffix of the first
 // branch-state pattern matching command, and a bool indicating whether any
-// pattern matched. Used by checkBranchState (M2) and by M1 pattern-set tests.
+// pattern matched. Quoted arguments collapse to a placeholder first
+// (substituteQuotedArguments) so a match reflects the command being invoked,
+// not its data. Used by checkBranchState (M2) and by M1 pattern-set tests.
 func matchBranchStateCommand(command string) (string, bool) {
+	scanned := substituteQuotedArguments(command)
 	for _, p := range branchStatePatterns {
-		if p.re.MatchString(command) {
+		if p.re.MatchString(scanned) {
 			return p.suffix, true
 		}
 	}
@@ -266,4 +320,3 @@ func appendBranchGuardAdvisory(input *HookInput, projectDir, command string, cau
 		slog.Debug("branch_guard: could not write audit log entry", "path", logPath, "error", err)
 	}
 }
-

--- a/internal/hook/branch_guard_quoted_test.go
+++ b/internal/hook/branch_guard_quoted_test.go
@@ -1,0 +1,129 @@
+package hook
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestSubstituteQuotedArguments_CollapsesSpans pins the helper's own contract: a
+// quoted span collapses to a single non-flag placeholder word, and unquoted text
+// is untouched. The placeholder — rather than blank whitespace — is what keeps a
+// quoted branch name from un-guarding its command, and the surrounding spaces
+// are what stop neighbouring tokens from fusing into an accidental match.
+func TestSubstituteQuotedArguments_CollapsesSpans(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		command string
+		want    string
+	}{
+		{"no quotes untouched", "git switch main", "git switch main"},
+		{"double-quoted span collapsed", `moai todo add "git switch main"`, "moai todo add  X "},
+		{"single-quoted span collapsed", `moai todo add 'git switch main'`, "moai todo add  X "},
+		{"apostrophe inside double quotes", `echo "it's fine"`, "echo  X "},
+		{"unpaired quote left alone", `git switch main # don't`, `git switch main # don't`},
+		{"tokens do not fuse across a span", `a"x"b`, "a X b"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := substituteQuotedArguments(tc.command); got != tc.want {
+				t.Fatalf("substituteQuotedArguments(%q) = %q, want %q", tc.command, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBranchStatePatterns_QuotedArgumentsAreData is the regression arm for the
+// scan-scope defect: branch-state text carried inside a quoted argument is data,
+// not a command, and must not match. The command actually being invoked in each
+// case is `moai todo add`, `git commit`, or `echo` — none of which change branch
+// state.
+func TestBranchStatePatterns_QuotedArgumentsAreData(t *testing.T) {
+	t.Parallel()
+	cases := []string{
+		`moai todo add "document why git switch main is refused"`,
+		`moai todo add 'git checkout -b feat/x should be denied'`,
+		`git commit -m "revert the git switch main change"`,
+		`git commit -m "explain git reset --hard in the runbook"`,
+		`echo "git stash"`,
+		`gh pr create --body "the guard denies git rebase in the primary checkout"`,
+	}
+	for _, command := range cases {
+		command := command
+		t.Run(command, func(t *testing.T) {
+			t.Parallel()
+			suffix, matched := matchBranchStateCommand(command)
+			if matched {
+				t.Fatalf("matchBranchStateCommand(%q) = (%q, true), want false — quoted text is data, not a command", command, suffix)
+			}
+		})
+	}
+}
+
+// TestBranchStatePatterns_RealCommandsStillDenyAroundQuotes is the falsification
+// arm for the test above. Blanking quoted spans must not blunt the guard: a real
+// branch-state invocation still matches, including when it sits beside or after
+// a quoted argument. A helper that blanked too much would vacuously pass the
+// data table above; this pins the deny side.
+func TestBranchStatePatterns_RealCommandsStillDenyAroundQuotes(t *testing.T) {
+	t.Parallel()
+	cases := []string{
+		`git switch main`,
+		`git switch "main"`,
+		`git checkout -b "feat/quoted-branch"`,
+		`git commit -m "wip" && git switch main`,
+		`git branch -D 'old-feature'`,
+		`git reset --hard origin/main`,
+	}
+	for _, command := range cases {
+		command := command
+		t.Run(command, func(t *testing.T) {
+			t.Parallel()
+			if _, matched := matchBranchStateCommand(command); !matched {
+				t.Fatalf("matchBranchStateCommand(%q) = false, want true — real branch-state command must still deny", command)
+			}
+		})
+	}
+}
+
+// TestCheckBranchState_ExemptionAxesAreIndependent verifies each documented
+// exemption axis fires ON ITS OWN when its value reaches the hook, so a failure
+// observed in production is attributable to the value not arriving rather than
+// to the axis being unimplemented.
+//
+// The axes are read from different places and a tool-spawned subagent can supply
+// neither: agent_type arrives in the payload only for a main-thread
+// `claude --agent` launch, and the env var is read from the hook process's own
+// environment, which an `export` inside the guarded command cannot reach.
+func TestCheckBranchState_ExemptionAxesAreIndependent(t *testing.T) {
+	command := `{"command":"git branch -D feature/x"}`
+
+	t.Run("AgentTypeAxis_alone_exempts", func(t *testing.T) {
+		t.Setenv(branchGuardExemptEnv, "")
+		input := &HookInput{AgentType: "manager-git", ToolInput: json.RawMessage(command)}
+		if !isExemptAgent(input) {
+			t.Fatalf("agent_type=manager-git alone did not exempt; the identity axis is unreachable in code, not just in the payload")
+		}
+	})
+
+	t.Run("EnvAxis_alone_exempts", func(t *testing.T) {
+		t.Setenv(branchGuardExemptEnv, "1")
+		input := &HookInput{AgentType: "", ToolInput: json.RawMessage(command)}
+		if !isExemptAgent(input) {
+			t.Fatalf("%s=1 alone did not exempt; the env axis is unreachable in code, not just in the process environment", branchGuardExemptEnv)
+		}
+	})
+
+	t.Run("NeitherAxis_leaves_command_matchable", func(t *testing.T) {
+		t.Setenv(branchGuardExemptEnv, "")
+		input := &HookInput{AgentType: "manager-develop", ToolInput: json.RawMessage(command)}
+		if isExemptAgent(input) {
+			t.Fatalf("neither axis supplied but isExemptAgent returned true")
+		}
+		if _, matched := matchBranchStateCommand("git branch -D feature/x"); !matched {
+			t.Fatalf("branch-state command no longer matches; the deny path would be vacuous")
+		}
+	})
+}

--- a/internal/template/templates/.claude/rules/moai/workflow/main-checkout-branch-guard.md
+++ b/internal/template/templates/.claude/rules/moai/workflow/main-checkout-branch-guard.md
@@ -129,9 +129,36 @@ flows. The hook applies the doctrine conditionally.
   cwd-normalized `--git-common-dir`.
 - **Exemption mechanism**: the deny is suppressed when EITHER the invoking
   agent identity is the trusted git agent (`HookInput.AgentType ==
-  "manager-git"`, populated on main-thread `claude --agent manager-git`) OR
-  the sentinel environment variable `MOAI_BRANCH_GUARD_EXEMPT=1` is set by
-  the orchestrator when spawning that agent for Late-Branch closure.
+  "manager-git"`) OR the sentinel environment variable
+  `MOAI_BRANCH_GUARD_EXEMPT=1` is present. Both axes are implemented and each
+  fires on its own — but each is read from a different place, and **neither is
+  reachable from inside a tool-spawned subagent**:
+  - `AgentType` arrives in the hook payload, and Claude Code populates
+    `agent_type` for a main-thread `claude --agent manager-git` launch. A
+    subagent spawned through the Agent tool sends no `agent_type` on
+    PreToolUse, so the identity axis cannot fire for it.
+  - The sentinel is read from the hook process's own environment. The hook
+    runs as a separate process spawned **before** the guarded command executes,
+    so an `export MOAI_BRANCH_GUARD_EXEMPT=1` inside that command never reaches
+    it. The variable must be present in the environment Claude Code itself was
+    launched with.
+
+  Exporting the sentinel inside the command being guarded is therefore a no-op.
+  A `manager-git` subagent that needs to mutate branch state has two working
+  routes: do the work in a worktree (`git -C <worktree>`, which the discriminant
+  correctly classifies as non-primary), or have the operator launch the session
+  with the sentinel already in its environment. Reading a `BRANCH_GUARD_VIOLATION`
+  as "the exemption is broken" is a misdiagnosis — the axes work; the values were
+  never delivered.
+
+- **Scan scope**: the pattern set is matched against the command with quoted
+  spans collapsed to a placeholder word, so a match reflects the command being
+  invoked rather than text carried as data. `moai todo add "… git switch …"` is
+  allowed because the command being run is `moai todo add`; `git switch main`
+  and `git checkout -b "feat/x"` both still deny, the latter because the
+  placeholder preserves the operand after `-b`. A git invocation hidden inside a
+  shell wrapper (`bash -c "git switch main"`) is not matched — under-matching an
+  obfuscated form is the correct direction to err for a fail-open guard.
 - **Fail-open norm**: the deny fires ONLY on positive evidence (primary
   checkout confirmed AND a branch-state pattern matched AND the agent is not
   exempt). Any uncertainty — not a git repo, missing git binary, `git
@@ -156,5 +183,5 @@ $CLAUDE_PROJECT_DIR) landed in a second follow-up SPEC.
 
 ---
 
-Version: 1.2.0
+Version: 1.3.0
 Classification: Evolvable operational rule — branch-state isolation; changes no gate semantics.


### PR DESCRIPTION
Card t34. Two findings, root-caused separately. One turned out to be a code defect; the other turned out to be a documentation defect with working code behind it.

## Finding 1 — the exemptions are unreachable, not broken (rule fix, no code change)

Probing the hook directly separates the axes:

| Probe | Payload / env | Result |
|---|---|---|
| baseline | neither axis | `deny` — `BRANCH_GUARD_VIOLATION: git branch` |
| identity axis | `"agent_type":"manager-git"` in payload | `allow` |
| env axis | `MOAI_BRANCH_GUARD_EXEMPT=1` in the hook process env | `allow` |

Both axes fire on their own. The code is correct; delivery is what fails, and it fails for a different reason per axis:

- **`AgentType`** arrives in the hook payload. Claude Code populates `agent_type` for a main-thread `claude --agent <name>` launch; a subagent spawned through the Agent tool sends none on PreToolUse. In `internal/hook/types.go` the field sits with the SessionStart group and is documented as "custom agent name if --agent flag used".
- **The env sentinel** is read from the hook process's own environment. The hook is a separate process spawned *before* the guarded command runs, so an `export` of it inside that command sets it in a process the hook never sees.

That combination explains the reported symptom exactly: a manager-git subagent exported the sentinel, supplied neither reachable value, and was denied. It then worked around the deny with `git -C <worktree>`, which succeeds because a worktree's git-dir differs from its git-common-dir — the discriminant working as designed, not a second bug.

So the honest fix is the rule, which described exemptions a subagent cannot use. It now states each axis's reachability and names the two routes that do work: run the work in a worktree, or launch the session with the sentinel already in its environment. A unit test pins each axis independently, so a future failure is attributable to delivery rather than to an unimplemented axis.

## Finding 2 — the scan was not scoped to the command (code fix)

`moai todo add "… git switch …"` was denied: the command being run was `moai todo add`, and the match came from data inside a quoted argument that would never execute.

Quoted spans now collapse to a placeholder before pattern matching. **The placeholder is a word, not whitespace, and that is load-bearing** — the first attempt blanked the span and silently un-guarded every branch-state command with a quoted branch name, because `git checkout -b "feat/x"` lost the operand the pattern requires after `-b`. The regression test caught it before it shipped; the falsification arm of that test is what pins it.

End-to-end against the reinstalled binary:

| Command | Before | After |
|---|---|---|
| `moai todo add "… git switch main …"` | deny | **allow** |
| `git commit -m "revert the git switch main change"` | deny | **allow** |
| `git switch main` | deny | deny |
| `git checkout -b "feat/quoted"` | deny | deny |
| `git switch main` with cwd `/tmp` (non-git) | allow | allow (fail-open) |

Residual, accepted and documented: a git invocation hidden inside a shell wrapper no longer matches, since it lives inside the discarded span. For a fail-open, opt-in guard, under-matching a deliberately obfuscated form is the correct direction to err, and the Claude Code worktree isolation guard refuses that shape independently.

## Invariants held

- Fail-open unchanged — deny still requires primary checkout **and** a pattern match **and** non-exempt; every uncertainty path still allows with a stderr advisory and an audit-log line (the non-git-cwd row above exercises it).
- Opt-in default unchanged — `Workflow.BranchGuard.Enabled` still ships false, and the guard is inert for anyone who never opted in. This change touches only the matching step *inside* the enabled path.

## Verification

Reduced profile per the lead's load directive — targeted tests, scoped vet/lint, CI as the full baseline.

- `go test ./internal/hook/ -run 'BranchGuard|BranchState|SubstituteQuoted|IsExemptAgent|CheckBranchState' -count=1` → `ok 28.209s`
- `go vet ./internal/hook/` → clean; `golangci-lint run ./internal/hook/...` → `0 issues.`
- `gofmt` clean on both changed Go files
- Binary reinstalled with the clean rm-then-cp form, `moai version` exit 0; the table above is from that binary
- **Not run**: the full `go test` sweep — the machine is at load average ~370 and four lanes running full suites is the cause. CI is the baseline. Recorded as a gap, not a pass.
- One observation for the load card: `TestBranchGuard_Latency` failed in a batch run and passed alone, with no code change between the two.

Two "command-injection (high)" advisories fired during editing. Both point at prose lines in the doc comment describing process ordering. This file spawns no shell.

🗿 MoAI
