### PR TITLE
docs(kanban): dispatch in the operator's language; keep verification load lane-local

### DIFF
--- a/.claude/rules/moai/core/agent-common-protocol-reference.md
+++ b/.claude/rules/moai/core/agent-common-protocol-reference.md
@@ -154,3 +154,33 @@ turn where deferred tools may be needed. See
 - `.claude/rules/moai/workflow/cache-aware-execution.md` — prompt-cache-aware
   ordering (stagger-spawn for parallel same-type agents, gate placement,
   session-loaded file edit timing).
+
+---
+
+## Pre-Edit Sync Check — rationale and enforcement record
+
+> Relocated verbatim from `agent-common-protocol.md` § Pre-Edit Sync Check (Direct-Edit Race Mitigation) to keep the always-loaded file within its size budget. The binding gate (TRIGGER / CHECK / DECIDE / RE-CHECK) and the sweep prohibition remain inline there; this section carries the incident record, the failure analysis of the previous version, and the enforcement-placement assessment.
+
+### Incident record (why the rule is binding)
+
+On 2026-08-15, five Claude sessions worked the same shared primary checkout simultaneously. 104 uncommitted files accumulated there; **73 of them existed on no branch at all** and had to be rescued into PR #1526 by hand. The destructive mechanism is ordinary: a concurrent `git add -A && commit` in one session sweeps another session's uncommitted work into a commit that was never meant to carry it; a branch switch or stash strands it outright. A rule without the incident attached gets skipped; this one has the receipts.
+
+### Why the previous version of this check failed
+
+Two distinct failure modes — they need different fixes:
+
+1. **Nothing executed it.** The check was procedural prose in this rule file. No hook fires it, no tool result reminds the agent of it, and a "run three probes before your first edit" instruction competes with task momentum — and loses. This was the dominant failure on 2026-08-15: the procedure was directionally correct and was simply never run.
+2. **It sampled at the wrong moment.** Even perfectly executed, a once-per-task check cannot see a session that starts mid-task, and the destruction mechanism is not the edit — it is the OTHER session's `git add -A` at commit time. The previous text placed all discipline on the editor and none on the sweeper.
+
+The rewrite addresses both: the decision procedure is compressed into a moment-of-edit gate an agent can actually run, and a sweep prohibition binds the commit-side primitive that does the damage.
+
+### Enforcement assessment — why there is no PreToolUse-on-Edit/Write advisory hook
+
+A per-edit advisory hook was considered and declined (2026-08-15):
+
+- **Measured cost**: the branch-guard PreToolUse hook — the closest comparable, it spawns git subprocesses — averages 135-256ms per invocation. `Edit`/`Write` is the most frequent mutation in a coding session; a per-edit advisory multiplies that tax across every edit of every concurrent session — the exact multi-session load pattern that pushed the box over during the incident day.
+- **Wrong sampling rate**: the probe's answer changes on the scale of minutes (sessions start and stop), not edits. Paying per-edit for a per-task answer taxes the wrong frequency.
+- **Wrong target**: the edit is not the destructive primitive; the sweep is. If mechanical enforcement is ever wanted, the cheap and mechanism-adjacent placement is the commit-time Bash surface — extend the branch-guard hook family to warn on `git add -A` / `git add .` / `git commit -a` in the primary checkout (rare, once per task) — not on every Edit/Write.
+- **Detection is already ambient**: the SessionStart signal carries foreign-session awareness to every session at zero per-edit cost; the procedure is the decision layer on top of it.
+
+If a per-edit nudge is ever re-proposed, the only defensible variant is stateful: fire the probe on the FIRST `Edit`/`Write` of a session (or serve it from a short-TTL cache), never per edit.

--- a/.claude/rules/moai/core/agent-common-protocol.md
+++ b/.claude/rules/moai/core/agent-common-protocol.md
@@ -65,15 +65,7 @@ The `sync-phase-quality-gate.sh` row above describes the Stop hook in the sync-p
 
 **Recovery-Signal Carve-Out** — anti-death-spiral policy guidance for Stop/PostToolUse hooks. The canonical doctrine lives at `.claude/rules/moai/workflow/runtime-recovery-doctrine.md` §4 (SSOT); this subsection is the render surface.
 
-[ZONE:Evolvable] **While** a turn's `stopReason` or surrounding context indicates the turn is itself a **recovery signal** — i.e., the turn is recovering from a sync failure, a compact, a `prompt_too_long` (PTL), a `max_output_tokens` exhaustion, or a `media_size` / `compact-failure` — Stop/PostToolUse hooks SHOULD exit 0 (allow the turn to end / the tool call to proceed) rather than exit 2 (block), so that recovery turns are NOT placed into the `error → stop-hook-blocks → retry → error` loop that book1 ch06 names the **death-spiral**.
-
-This carve-out is **policy guidance** (a SHOULD recommendation), NOT a mechanically-enforced gate:
-
-- The current `sync-phase-quality-gate.sh` (Stop) and `status-transition-ownership.sh` (PostToolUse) hooks receive PostToolUse/Stop JSON but do not parse a recovery signal from `stopReason` or turn context; they therefore cannot mechanically distinguish a recovery turn from a normal turn.
-- Mechanical enforcement of this carve-out is deferred to a future runtime-layer SPEC that would add `stopReason` parsing.
-- The carve-out does NOT weaken the hooks' gate function on non-recovery turns — the gates still exit 2 (block) on genuine gate failures during normal turns. The carve-out only says recovery turns SHOULD defer to the recovery.
-
-Determining "is this a recovery turn?" is the mechanical step the current hooks cannot take. See the SSOT doctrine (`runtime-recovery-doctrine.md` §4) for the full scope binding, the named-hook list (`sync-phase-quality-gate.sh`, `status-transition-ownership.sh`), and the reason this is documentation-only at this layer.
+[ZONE:Evolvable] **While** a turn's `stopReason` or surrounding context indicates the turn is itself a **recovery signal** (recovering from a sync failure, a compact, a `prompt_too_long` (PTL), a `max_output_tokens` exhaustion, or a `media_size` / `compact-failure`), Stop/PostToolUse hooks SHOULD exit 0 rather than exit 2, so recovery turns are NOT placed into the `error → stop-hook-blocks → retry → error` **death-spiral** loop. This is a SHOULD (policy guidance), not a mechanical gate — the current hooks do not parse `stopReason`, enforcement is deferred to a future runtime-layer SPEC, and the gates still block normally on non-recovery turns. Full scope binding and named-hook list: `runtime-recovery-doctrine.md` §4.
 
 ### Blocker Report Format
 
@@ -445,16 +437,7 @@ Resume Pattern (L2/L3 worktree as race-elimination alternative).
 
 [ZONE:Evolvable] [HARD] The Pre-Spawn Sync Check above binds only the spawn boundary. **Direct main-session edits to shared working-tree paths (Edit/Write/Bash in the orchestrator session — the MoAI-Easy hands-on style and any direct edit) bypass the spawn gate**, so a foreign active session goes undetected while the orchestrator's uncommitted work sits in a tree that every concurrent session can mutate. To close that gap, the orchestrator MUST run the parallel-session detection **before a non-trivial direct edit** to shared paths, not only before a write-agent spawn.
 
-**Incident record (why this rule is binding).** On 2026-08-15, five Claude sessions worked the same shared primary checkout simultaneously. 104 uncommitted files accumulated there; **73 of them existed on no branch at all** and had to be rescued into PR #1526 by hand. The destructive mechanism is ordinary: a concurrent `git add -A && commit` in one session sweeps another session's uncommitted work into a commit that was never meant to carry it; a branch switch or stash strands it outright. A rule without the incident attached gets skipped; this one has the receipts.
-
-#### Why the previous version of this check failed
-
-Two distinct failure modes — they need different fixes:
-
-1. **Nothing executed it.** The check was procedural prose in this rule file. No hook fires it, no tool result reminds the agent of it, and a "run three probes before your first edit" instruction competes with task momentum — and loses. This was the dominant failure on 2026-08-15: the procedure was directionally correct and was simply never run.
-2. **It sampled at the wrong moment.** Even perfectly executed, a once-per-task check cannot see a session that starts mid-task, and the destruction mechanism is not the edit — it is the OTHER session's `git add -A` at commit time. The previous text placed all discipline on the editor and none on the sweeper.
-
-The rewrite below addresses both: the decision procedure is compressed into a moment-of-edit gate an agent can actually run (§ The rule, at the moment of the edit), and a sweep prohibition binds the commit-side primitive that does the damage (§ The sweep prohibition).
+The incident record (the multi-session shared-checkout loss that made this rule binding), the failure analysis of the previous version, and the enforcement-placement assessment live in `agent-common-protocol-reference.md` § Pre-Edit Sync Check — rationale and enforcement record. Inline here: the binding gate (below) and the sweep prohibition — the moment-of-edit gate an agent can actually run, plus the commit-side primitive that does the damage.
 
 #### The rule, at the moment of the edit
 
@@ -482,7 +465,7 @@ git fetch origin main 2>&1; git rev-list --count --left-right origin/main...HEAD
 | ≥1 live foreign session | **ISOLATE before editing**: `moai cc -w <name>` / `EnterWorktree(<path>)` / `Agent(isolation: "worktree")`. If isolation is impossible, surface via `AskUserQuestion` (isolate / wait / abort) |
 | `N 0` / `N M` divergence | STOP; `AskUserQuestion` (rebase / inspect / abort) per the Pre-Spawn Sync Check matrix |
 
-> **Stale-registry caveat**: the active-sessions registry can hold dead-PID entries (the session registry is not a reliable emptiness signal). A foreign entry's liveness is probed with `kill -0 <pid>`; a confirmed-dead entry is ignored. When liveness is indeterminate, treat it as live and isolate anyway (false positive is cheap; false negative corrupts the tree). The conservative predicate (ANY live-or-indeterminate foreign entry ⇒ isolate) is reused from `.claude/rules/moai/workflow/worktree-integration.md` § Parallel-Session Branch Conflict Auto-Isolation.
+> **Stale-registry caveat**: registry entries can hold dead PIDs (the registry is not a reliable emptiness signal). Probe each foreign entry's liveness with `kill -0 <pid>`; ignore confirmed-dead, treat indeterminate as live and isolate anyway. ANY live-or-indeterminate foreign entry ⇒ isolate (`worktree-integration.md` § Parallel-Session Branch Conflict Auto-Isolation).
 
 **RE-CHECK** — the probe decays. Re-run it before ANY commit in the shared checkout, and after any long pause in the task (a session that starts mid-task is invisible to a task-start probe).
 
@@ -490,18 +473,7 @@ git fetch origin main 2>&1; git rev-list --count --left-right origin/main...HEAD
 
 [ZONE:Evolvable] [HARD] In the primary checkout, NEVER `git add -A`, `git add .`, or `git commit -a`. Stage by explicit pathspec (`git add <path> …`), and re-read `git status --short` immediately before staging so another session's files are visible and excluded. This binds the actual destruction primitive from the incident record; it is the commit-side half of this rule and applies **even when the pre-edit probe found no foreign session** — a session can arrive after the probe, and the sweep is what turns its presence into lost work.
 
-#### Enforcement assessment — why there is no PreToolUse-on-Edit/Write advisory hook
-
-A per-edit advisory hook was considered and declined (2026-08-15):
-
-- **Measured cost**: the branch-guard PreToolUse hook — the closest comparable, it spawns git subprocesses — averages 135-256ms per invocation. `Edit`/`Write` is the most frequent mutation in a coding session; a per-edit advisory multiplies that tax across every edit of every concurrent session — the exact multi-session load pattern that pushed the box over during the incident day.
-- **Wrong sampling rate**: the probe's answer changes on the scale of minutes (sessions start and stop), not edits. Paying per-edit for a per-task answer taxes the wrong frequency.
-- **Wrong target**: the edit is not the destructive primitive; the sweep is. If mechanical enforcement is ever wanted, the cheap and mechanism-adjacent placement is the commit-time Bash surface — extend the branch-guard hook family to warn on `git add -A` / `git add .` / `git commit -a` in the primary checkout (rare, once per task) — not on every Edit/Write.
-- **Detection is already ambient**: the SessionStart signal below carries foreign-session awareness to every session at zero per-edit cost; this procedure is the decision layer on top of it.
-
-If a per-edit nudge is ever re-proposed, the only defensible variant is stateful: fire the probe on the FIRST `Edit`/`Write` of a session (or serve it from a short-TTL cache), never per edit.
-
-**Ambient signal.** The SessionStart hook already provides ambient foreign-session awareness: `internal/hook/session_start.go` Step 3 reads the registry (`session.QueryActiveWork`) and emits a `<system-reminder>` listing foreign active sessions via `session.FormatStderrReminder`. The session-start ambient signal is the always-on detection layer; this Pre-Edit Sync Check is the decision layer that turns detection into isolation.
+**Ambient signal.** The SessionStart hook already lists foreign active sessions via a `<system-reminder>` (`internal/hook/session_start.go` Step 3) — that is the always-on detection layer; this Pre-Edit Sync Check is the decision layer that turns detection into isolation.
 
 ## Time Estimation
 

--- a/.claude/rules/moai/core/agent-common-protocol.md
+++ b/.claude/rules/moai/core/agent-common-protocol.md
@@ -122,6 +122,7 @@ The **ledger-closure invariant** (externally grounded in `github.com/wquguru/har
 
 Output language rules:
 - Analysis, documentation, reports: User's conversation_language
+- Cross-session messages a human observes (a kanban dispatch the operator watches): User's conversation_language; identifiers, paths, commands, and flags stay verbatim. An `Agent()` subagent prompt reaches no human and stays English
 - Code examples and syntax: Always English
 - Code comments: Per code_comments setting in language.yaml (default: English)
 - Commit messages: Per git_commit_messages setting in language.yaml

--- a/.claude/rules/moai/workflow/kanban-dispatch.md
+++ b/.claude/rules/moai/workflow/kanban-dispatch.md
@@ -77,6 +77,19 @@ Each instruction carries, at minimum: the card, the SPEC ID once one exists, the
 
 **`sync → done` is the same act with the dispatch removed.** No session occupies `done`, so the lead reads the sync session's completion evidence and records the terminal transition itself.
 
+### Dispatch language
+
+[HARD] A dispatch is written in the operator's `conversation_language`. The operator watches it scroll past, which makes it user-facing output rather than internal agent traffic.
+
+This is a classification, not an exemption from the language rules, and it needs no change to either of them:
+
+- `agent-common-protocol.md` § Language Handling already opens with the opposite of an English default — agents receive and respond in the configured `conversation_language`. What it fixes to English is code, identifiers, and names. A dispatch is prose, so the rule was never against it; it simply did not name cross-session messages in its list.
+- `moai-constitution.md` § Response Language reserves English for internal agent communication, but the axis that clause sits on is stated one line above it: user-facing responses go in the operator's language. A message a human reads is user-facing by that rule's own criterion, so putting a dispatch in the operator's language applies the constitution rather than carving an exception out of it.
+
+The carve-out is narrow, and the boundary is **who reads it**. An `Agent()` subagent prompt reaches no human and stays English.
+
+What stays verbatim in every language: SPEC IDs, command names and their flags, file paths, session names, and technical identifiers. Those are addresses rather than prose, and a translated address does not resolve.
+
 ## Completion is read, never trusted
 
 [HARD] The lead advances a card on **evidence it read**, not on a companion's reply. Reply routing between sessions is not guaranteed to arrive, and a reply is a claim rather than an observation.
@@ -159,6 +172,22 @@ Two properties make the shared checkout the wrong place for a card:
 - A card outlives a phase. Its worktree spans run through sync, which is why disposal is triggered by the merge rather than by the phase finishing.
 
 Where a companion reports having worked in the shared checkout instead, that is a fault to report, not a detail to tidy up afterwards.
+
+## Verification load is lane-local
+
+Sessions share one machine as surely as they share one checkout, and verification is where that sharing goes wrong. Measured on a day when it did: load average reached 413, a neighbouring workspace's build took two and a half minutes, and its browser tests timed out — not because anything was wrong with them, but because four lanes were each running the full test suite at once and a full suite there takes five to ten minutes.
+
+[HARD] **Lane-local verification is scoped to the card.** A lane runs the tests its own change can affect, then pushes and lets CI run the full suite.
+
+CI is not the fallback here; it is the better evidence. It runs the full suite in a clean environment against the actual pull-request head. A full-suite run on a loaded developer machine measures the machine — a test that fails in a crowded batch and passes alone has told you about contention, not about the code, and reading it as a code signal sends the lane chasing a defect that is not there.
+
+[HARD] **Never spawn background load.** The same incident had a second cause: a verification recipe started eight spin loops to test behaviour under CPU contention and placed its kill line *after* the long test command. The agent finished before reaching it, and twelve spinners ran orphaned for thirty-seven minutes.
+
+Where a verification genuinely needs contention, the load must be cleanup-guaranteed — kills registered with the test framework's cleanup hook, or a `timeout` wrapper that bounds the process from outside. A trailing `kill` is not cleanup; it is a line the process may never reach, and every path that ends early leaves the load running.
+
+**A verification recipe that spawns processes is itself a hazard, and gets reviewed as one.** The fault above belongs to the dispatcher who wrote and approved the recipe, not to the lane that ran it as given — a lane executing an approved recipe is doing what it was told, and a rule that blames the executor teaches the wrong actor to be careful.
+
+The same day supplied the reason contention and flakiness feed each other: a failing test left an unbounded spin-loop goroutine running, which burned a core for the remainder of that package's run and slowed every test after it. Load makes tests fail; failing tests can generate load.
 
 ### The env-isolated verification form
 

--- a/internal/template/templates/.claude/rules/moai/core/agent-common-protocol-reference.md
+++ b/internal/template/templates/.claude/rules/moai/core/agent-common-protocol-reference.md
@@ -154,3 +154,33 @@ turn where deferred tools may be needed. See
 - `.claude/rules/moai/workflow/cache-aware-execution.md` — prompt-cache-aware
   ordering (stagger-spawn for parallel same-type agents, gate placement,
   session-loaded file edit timing).
+
+---
+
+## Pre-Edit Sync Check — rationale and enforcement record
+
+> Relocated verbatim from `agent-common-protocol.md` § Pre-Edit Sync Check (Direct-Edit Race Mitigation) to keep the always-loaded file within its size budget. The binding gate (TRIGGER / CHECK / DECIDE / RE-CHECK) and the sweep prohibition remain inline there; this section carries the incident record, the failure analysis of the previous version, and the enforcement-placement assessment.
+
+### Incident record (why the rule is binding)
+
+In the recorded incident, five Claude sessions worked the same shared primary checkout simultaneously. 104 uncommitted files accumulated there; **73 of them existed on no branch at all** and had to be rescued into a pull request by hand. The destructive mechanism is ordinary: a concurrent `git add -A && commit` in one session sweeps another session's uncommitted work into a commit that was never meant to carry it; a branch switch or stash strands it outright. A rule without the incident attached gets skipped; this one has the receipts.
+
+### Why the previous version of this check failed
+
+Two distinct failure modes — they need different fixes:
+
+1. **Nothing executed it.** The check was procedural prose in this rule file. No hook fires it, no tool result reminds the agent of it, and a "run three probes before your first edit" instruction competes with task momentum — and loses. This was the dominant failure in the recorded incident: the procedure was directionally correct and was simply never run.
+2. **It sampled at the wrong moment.** Even perfectly executed, a once-per-task check cannot see a session that starts mid-task, and the destruction mechanism is not the edit — it is the OTHER session's `git add -A` at commit time. The previous text placed all discipline on the editor and none on the sweeper.
+
+The rewrite addresses both: the decision procedure is compressed into a moment-of-edit gate an agent can actually run, and a sweep prohibition binds the commit-side primitive that does the damage.
+
+### Enforcement assessment — why there is no PreToolUse-on-Edit/Write advisory hook
+
+A per-edit advisory hook was considered and declined:
+
+- **Measured cost**: the branch-guard PreToolUse hook — the closest comparable, it spawns git subprocesses — averages 135-256ms per invocation. `Edit`/`Write` is the most frequent mutation in a coding session; a per-edit advisory multiplies that tax across every edit of every concurrent session — the exact multi-session load pattern that pushed the box over during the incident day.
+- **Wrong sampling rate**: the probe's answer changes on the scale of minutes (sessions start and stop), not edits. Paying per-edit for a per-task answer taxes the wrong frequency.
+- **Wrong target**: the edit is not the destructive primitive; the sweep is. If mechanical enforcement is ever wanted, the cheap and mechanism-adjacent placement is the commit-time Bash surface — extend the branch-guard hook family to warn on `git add -A` / `git add .` / `git commit -a` in the primary checkout (rare, once per task) — not on every Edit/Write.
+- **Detection is already ambient**: the SessionStart signal carries foreign-session awareness to every session at zero per-edit cost; the procedure is the decision layer on top of it.
+
+If a per-edit nudge is ever re-proposed, the only defensible variant is stateful: fire the probe on the FIRST `Edit`/`Write` of a session (or serve it from a short-TTL cache), never per edit.

--- a/internal/template/templates/.claude/rules/moai/core/agent-common-protocol.md
+++ b/internal/template/templates/.claude/rules/moai/core/agent-common-protocol.md
@@ -122,6 +122,7 @@ The **ledger-closure invariant** (externally grounded in `github.com/wquguru/har
 
 Output language rules:
 - Analysis, documentation, reports: User's conversation_language
+- Cross-session messages a human observes (a kanban dispatch the operator watches): User's conversation_language; identifiers, paths, commands, and flags stay verbatim. An `Agent()` subagent prompt reaches no human and stays English
 - Code examples and syntax: Always English
 - Code comments: Per code_comments setting in language.yaml (default: English)
 - Commit messages: Per git_commit_messages setting in language.yaml

--- a/internal/template/templates/.claude/rules/moai/core/agent-common-protocol.md
+++ b/internal/template/templates/.claude/rules/moai/core/agent-common-protocol.md
@@ -65,15 +65,7 @@ The `sync-phase-quality-gate.sh` row above describes the Stop hook in the sync-p
 
 **Recovery-Signal Carve-Out** — anti-death-spiral policy guidance for Stop/PostToolUse hooks. The canonical doctrine lives at `.claude/rules/moai/workflow/runtime-recovery-doctrine.md` §4 (SSOT); this subsection is the render surface.
 
-[ZONE:Evolvable] **While** a turn's `stopReason` or surrounding context indicates the turn is itself a **recovery signal** — i.e., the turn is recovering from a sync failure, a compact, a `prompt_too_long` (PTL), a `max_output_tokens` exhaustion, or a `media_size` / `compact-failure` — Stop/PostToolUse hooks SHOULD exit 0 (allow the turn to end / the tool call to proceed) rather than exit 2 (block), so that recovery turns are NOT placed into the `error → stop-hook-blocks → retry → error` loop that book1 ch06 names the **death-spiral**.
-
-This carve-out is **policy guidance** (a SHOULD recommendation), NOT a mechanically-enforced gate:
-
-- The current `sync-phase-quality-gate.sh` (Stop) and `status-transition-ownership.sh` (PostToolUse) hooks receive PostToolUse/Stop JSON but do not parse a recovery signal from `stopReason` or turn context; they therefore cannot mechanically distinguish a recovery turn from a normal turn.
-- Mechanical enforcement of this carve-out is deferred to a future runtime-layer SPEC that would add `stopReason` parsing.
-- The carve-out does NOT weaken the hooks' gate function on non-recovery turns — the gates still exit 2 (block) on genuine gate failures during normal turns. The carve-out only says recovery turns SHOULD defer to the recovery.
-
-Determining "is this a recovery turn?" is the mechanical step the current hooks cannot take. See the SSOT doctrine (`runtime-recovery-doctrine.md` §4) for the full scope binding, the named-hook list (`sync-phase-quality-gate.sh`, `status-transition-ownership.sh`), and the reason this is documentation-only at this layer.
+[ZONE:Evolvable] **While** a turn's `stopReason` or surrounding context indicates the turn is itself a **recovery signal** (recovering from a sync failure, a compact, a `prompt_too_long` (PTL), a `max_output_tokens` exhaustion, or a `media_size` / `compact-failure`), Stop/PostToolUse hooks SHOULD exit 0 rather than exit 2, so recovery turns are NOT placed into the `error → stop-hook-blocks → retry → error` **death-spiral** loop. This is a SHOULD (policy guidance), not a mechanical gate — the current hooks do not parse `stopReason`, enforcement is deferred to a future runtime-layer SPEC, and the gates still block normally on non-recovery turns. Full scope binding and named-hook list: `runtime-recovery-doctrine.md` §4.
 
 ### Blocker Report Format
 
@@ -445,16 +437,7 @@ Resume Pattern (L2/L3 worktree as race-elimination alternative).
 
 [ZONE:Evolvable] [HARD] The Pre-Spawn Sync Check above binds only the spawn boundary. **Direct main-session edits to shared working-tree paths (Edit/Write/Bash in the orchestrator session — the MoAI-Easy hands-on style and any direct edit) bypass the spawn gate**, so a foreign active session goes undetected while the orchestrator's uncommitted work sits in a tree that every concurrent session can mutate. To close that gap, the orchestrator MUST run the parallel-session detection **before a non-trivial direct edit** to shared paths, not only before a write-agent spawn.
 
-**Incident record (why this rule is binding).** In the recorded incident, five Claude sessions worked the same shared primary checkout simultaneously. 104 uncommitted files accumulated there; **73 of them existed on no branch at all** and had to be rescued into a pull request by hand. The destructive mechanism is ordinary: a concurrent `git add -A && commit` in one session sweeps another session's uncommitted work into a commit that was never meant to carry it; a branch switch or stash strands it outright. A rule without the incident attached gets skipped; this one has the receipts.
-
-#### Why the previous version of this check failed
-
-Two distinct failure modes — they need different fixes:
-
-1. **Nothing executed it.** The check was procedural prose in this rule file. No hook fires it, no tool result reminds the agent of it, and a "run three probes before your first edit" instruction competes with task momentum — and loses. This was the dominant failure in the recorded incident: the procedure was directionally correct and was simply never run.
-2. **It sampled at the wrong moment.** Even perfectly executed, a once-per-task check cannot see a session that starts mid-task, and the destruction mechanism is not the edit — it is the OTHER session's `git add -A` at commit time. The previous text placed all discipline on the editor and none on the sweeper.
-
-The rewrite below addresses both: the decision procedure is compressed into a moment-of-edit gate an agent can actually run (§ The rule, at the moment of the edit), and a sweep prohibition binds the commit-side primitive that does the damage (§ The sweep prohibition).
+The incident record (the multi-session shared-checkout loss that made this rule binding), the failure analysis of the previous version, and the enforcement-placement assessment live in `agent-common-protocol-reference.md` § Pre-Edit Sync Check — rationale and enforcement record. Inline here: the binding gate (below) and the sweep prohibition — the moment-of-edit gate an agent can actually run, plus the commit-side primitive that does the damage.
 
 #### The rule, at the moment of the edit
 
@@ -482,7 +465,7 @@ git fetch origin main 2>&1; git rev-list --count --left-right origin/main...HEAD
 | ≥1 live foreign session | **ISOLATE before editing**: `moai cc -w <name>` / `EnterWorktree(<path>)` / `Agent(isolation: "worktree")`. If isolation is impossible, surface via `AskUserQuestion` (isolate / wait / abort) |
 | `N 0` / `N M` divergence | STOP; `AskUserQuestion` (rebase / inspect / abort) per the Pre-Spawn Sync Check matrix |
 
-> **Stale-registry caveat**: the active-sessions registry can hold dead-PID entries (the session registry is not a reliable emptiness signal). A foreign entry's liveness is probed with `kill -0 <pid>`; a confirmed-dead entry is ignored. When liveness is indeterminate, treat it as live and isolate anyway (false positive is cheap; false negative corrupts the tree). The conservative predicate (ANY live-or-indeterminate foreign entry ⇒ isolate) is reused from `.claude/rules/moai/workflow/worktree-integration.md` § Parallel-Session Branch Conflict Auto-Isolation.
+> **Stale-registry caveat**: registry entries can hold dead PIDs (the registry is not a reliable emptiness signal). Probe each foreign entry's liveness with `kill -0 <pid>`; ignore confirmed-dead, treat indeterminate as live and isolate anyway. ANY live-or-indeterminate foreign entry ⇒ isolate (`worktree-integration.md` § Parallel-Session Branch Conflict Auto-Isolation).
 
 **RE-CHECK** — the probe decays. Re-run it before ANY commit in the shared checkout, and after any long pause in the task (a session that starts mid-task is invisible to a task-start probe).
 
@@ -490,18 +473,7 @@ git fetch origin main 2>&1; git rev-list --count --left-right origin/main...HEAD
 
 [ZONE:Evolvable] [HARD] In the primary checkout, NEVER `git add -A`, `git add .`, or `git commit -a`. Stage by explicit pathspec (`git add <path> …`), and re-read `git status --short` immediately before staging so another session's files are visible and excluded. This binds the actual destruction primitive from the incident record; it is the commit-side half of this rule and applies **even when the pre-edit probe found no foreign session** — a session can arrive after the probe, and the sweep is what turns its presence into lost work.
 
-#### Enforcement assessment — why there is no PreToolUse-on-Edit/Write advisory hook
-
-A per-edit advisory hook was considered and declined:
-
-- **Measured cost**: the branch-guard PreToolUse hook — the closest comparable, it spawns git subprocesses — averages 135-256ms per invocation. `Edit`/`Write` is the most frequent mutation in a coding session; a per-edit advisory multiplies that tax across every edit of every concurrent session — the exact multi-session load pattern that pushed the box over during the incident day.
-- **Wrong sampling rate**: the probe's answer changes on the scale of minutes (sessions start and stop), not edits. Paying per-edit for a per-task answer taxes the wrong frequency.
-- **Wrong target**: the edit is not the destructive primitive; the sweep is. If mechanical enforcement is ever wanted, the cheap and mechanism-adjacent placement is the commit-time Bash surface — extend the branch-guard hook family to warn on `git add -A` / `git add .` / `git commit -a` in the primary checkout (rare, once per task) — not on every Edit/Write.
-- **Detection is already ambient**: the SessionStart signal below carries foreign-session awareness to every session at zero per-edit cost; this procedure is the decision layer on top of it.
-
-If a per-edit nudge is ever re-proposed, the only defensible variant is stateful: fire the probe on the FIRST `Edit`/`Write` of a session (or serve it from a short-TTL cache), never per edit.
-
-**Ambient signal.** The SessionStart hook already provides ambient foreign-session awareness: `internal/hook/session_start.go` Step 3 reads the registry (`session.QueryActiveWork`) and emits a `<system-reminder>` listing foreign active sessions via `session.FormatStderrReminder`. The session-start ambient signal is the always-on detection layer; this Pre-Edit Sync Check is the decision layer that turns detection into isolation.
+**Ambient signal.** The SessionStart hook already lists foreign active sessions via a `<system-reminder>` (`internal/hook/session_start.go` Step 3) — that is the always-on detection layer; this Pre-Edit Sync Check is the decision layer that turns detection into isolation.
 
 ## Time Estimation
 

--- a/internal/template/templates/.claude/rules/moai/workflow/kanban-dispatch.md
+++ b/internal/template/templates/.claude/rules/moai/workflow/kanban-dispatch.md
@@ -77,6 +77,19 @@ Each instruction carries, at minimum: the card, the SPEC ID once one exists, the
 
 **`sync → done` is the same act with the dispatch removed.** No session occupies `done`, so the lead reads the sync session's completion evidence and records the terminal transition itself.
 
+### Dispatch language
+
+[HARD] A dispatch is written in the operator's `conversation_language`. The operator watches it scroll past, which makes it user-facing output rather than internal agent traffic.
+
+This is a classification, not an exemption from the language rules, and it needs no change to either of them:
+
+- `agent-common-protocol.md` § Language Handling already opens with the opposite of an English default — agents receive and respond in the configured `conversation_language`. What it fixes to English is code, identifiers, and names. A dispatch is prose, so the rule was never against it; it simply did not name cross-session messages in its list.
+- `moai-constitution.md` § Response Language reserves English for internal agent communication, but the axis that clause sits on is stated one line above it: user-facing responses go in the operator's language. A message a human reads is user-facing by that rule's own criterion, so putting a dispatch in the operator's language applies the constitution rather than carving an exception out of it.
+
+The carve-out is narrow, and the boundary is **who reads it**. An `Agent()` subagent prompt reaches no human and stays English.
+
+What stays verbatim in every language: SPEC IDs, command names and their flags, file paths, session names, and technical identifiers. Those are addresses rather than prose, and a translated address does not resolve.
+
 ## Completion is read, never trusted
 
 [HARD] The lead advances a card on **evidence it read**, not on a companion's reply. Reply routing between sessions is not guaranteed to arrive, and a reply is a claim rather than an observation.
@@ -159,6 +172,22 @@ Two properties make the shared checkout the wrong place for a card:
 - A card outlives a phase. Its worktree spans run through sync, which is why disposal is triggered by the merge rather than by the phase finishing.
 
 Where a companion reports having worked in the shared checkout instead, that is a fault to report, not a detail to tidy up afterwards.
+
+## Verification load is lane-local
+
+Sessions share one machine as surely as they share one checkout, and verification is where that sharing goes wrong. Measured on a day when it did: load average reached 413, a neighbouring workspace's build took two and a half minutes, and its browser tests timed out — not because anything was wrong with them, but because four lanes were each running the full test suite at once and a full suite there takes five to ten minutes.
+
+[HARD] **Lane-local verification is scoped to the card.** A lane runs the tests its own change can affect, then pushes and lets CI run the full suite.
+
+CI is not the fallback here; it is the better evidence. It runs the full suite in a clean environment against the actual pull-request head. A full-suite run on a loaded developer machine measures the machine — a test that fails in a crowded batch and passes alone has told you about contention, not about the code, and reading it as a code signal sends the lane chasing a defect that is not there.
+
+[HARD] **Never spawn background load.** The same incident had a second cause: a verification recipe started eight spin loops to test behaviour under CPU contention and placed its kill line *after* the long test command. The agent finished before reaching it, and twelve spinners ran orphaned for thirty-seven minutes.
+
+Where a verification genuinely needs contention, the load must be cleanup-guaranteed — kills registered with the test framework's cleanup hook, or a `timeout` wrapper that bounds the process from outside. A trailing `kill` is not cleanup; it is a line the process may never reach, and every path that ends early leaves the load running.
+
+**A verification recipe that spawns processes is itself a hazard, and gets reviewed as one.** The fault above belongs to the dispatcher who wrote and approved the recipe, not to the lane that ran it as given — a lane executing an approved recipe is doing what it was told, and a rule that blames the executor teaches the wrong actor to be careful.
+
+The same day supplied the reason contention and flakiness feed each other: a failing test left an unbounded spin-loop goroutine running, which burned a core for the remainder of that package's run and slowed every test after it. Load makes tests fail; failing tests can generate load.
 
 ### The env-isolated verification form
 


### PR DESCRIPTION
Cards t19 and t37. Both land in `.claude/rules/moai/workflow/kanban-dispatch.md`, so one branch and one PR.

> **Stacked on #1542 — merge after it.** This branch is based on #1542's head (`3fd1f6f08`), not on `main`, because #1542 adds three sections to the same file and is still open. The diff here is the two new sections only; the base comparison will look right once #1542 lands.

## t19 — dispatch language: the carve-out holds, and the constitution stays untouched

The card asked for an analysis before an edit, so here is the analysis and the verdict.

**Verdict: the carve-out holds. It is a classification, not a repeal, and it required no change to either language rule.**

**`agent-common-protocol.md` § Language Handling does not oppose it.** Its opening HARD line is the opposite of an English default:

> All agents receive and respond in user's configured conversation_language.

What that section fixes to English is code examples, skill names, technical identifiers, and function/variable/class names — addresses, not prose. So there was nothing to repeal here. The only real gap is that the enumeration never named cross-session messages, so this PR adds exactly one row for that case. That is the single line the card permitted, and it is genuinely needed: without it a dispatch matches none of the listed categories.

**`moai-constitution.md` § Response Language is the only clause that could bind**, via:

> Internal agent communication uses English

But the axis that clause sits on is defined one line above it — *"All user-facing responses MUST be in the user's conversation_language"* — with the three bullets reading as a pair: respond to the user in their language, and use English for the traffic they do not see. The distinction being drawn is **user-facing vs not-user-facing**, not "session-to-session vs in-session". A dispatch the operator watches scroll past is user-facing by the constitution's own criterion.

So classifying a human-observed dispatch as `conversation_language` **applies** that rule rather than contradicting it. No edit to `moai-constitution.md`, which is what the blast-radius constraint wanted anyway. (`CLAUDE.md` §9 carries the same "internal agent comms always English" phrasing on the same axis, and is unaffected for the same reason.)

**The boundary is who reads it.** An `Agent()` subagent prompt reaches no human and stays English. That line is written into the rule so the carve-out cannot be widened by analogy later.

**What stays verbatim in every language**: SPEC IDs, command names and their flags, file paths, session names, and technical identifiers — addresses, and a translated address does not resolve.

## t37 — verification load discipline

Written down with the numbers, since this is the card the incident earned.

Measured: load average reached 413; a neighbouring workspace's build took two and a half minutes and its browser tests timed out. Two causes, both recorded:

1. **Four lanes each running the full suite concurrently**, where a full suite takes five to ten minutes. The rule is now that lane-local verification is scoped to the card, with CI as the *stronger* evidence rather than the fallback — CI runs the full suite in a clean environment against the actual pull-request head, while a full-suite run on a loaded box measures the box. A test that fails in a crowded batch and passes alone has reported contention, not a defect.
2. **A verification recipe that spawned eight spin loops** and put its kill line *after* the long test command. The agent ended before reaching it and twelve spinners ran orphaned for thirty-seven minutes. Load a verification genuinely needs must be cleanup-guaranteed — cleanup-hook-registered kills or a `timeout` wrapper — never a trailing `kill` the process may never reach. A recipe that spawns processes is reviewed as a hazard in its own right.

**Attribution is explicit in the rule**: the fault belongs to the dispatcher who wrote and approved the recipe, not to the lane that ran it as given. A rule that blames the executor teaches the wrong actor to be careful.

Also folded in the finding that explains why this presented as test interference: a failing test left an unbounded spin-loop goroutine burning a core for the rest of that package's run. Load makes tests fail; failing tests can generate load.

## Template-First

Mirror delta re-applied by hand to both files, not copied. The added prose carries no internal references (no PR numbers, dates, SPEC IDs, or SHAs), so both trees stay byte-identical.

## Verification

Per the load directive — the strict template test only, no full sweep, no repeated timing runs.

- `MOAI_TEMPLATE_LEAK_STRICT=1 go test ./internal/template/ -count=1` → `ok 67.635s`
- `diff` of each rule against its mirror → identical
- `make build` regenerated `catalog.yaml` with no content change (rules are not a catalog input, so nothing to stage)

No Go code changed, so no vet or lint run was applicable.

🗿 MoAI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified cross-session communication language requirements while preserving technical identifiers.
  - Added guidance for detecting and handling stale or indeterminate sessions.
  - Documented pre-edit synchronization safeguards and their rationale.
  - Added lane-local verification expectations, including scoped testing, cleanup requirements, and CI-based full-suite validation.
  - Clarified that internal subagent prompts remain in English.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->