### PR TITLE
test: budget-relative latency bounds for observer + async recorder (t36)

### DIFF
--- a/internal/harness/observer_test.go
+++ b/internal/harness/observer_test.go
@@ -3,7 +3,9 @@ package harness
 
 import (
 	"encoding/json"
+	"math"
 	"runtime"
+	"slices"
 	"testing"
 	"time"
 )
@@ -132,16 +134,44 @@ func TestRecordEventWritesJSONL(t *testing.T) {
 	}
 }
 
-// TestRecordEvent100Sequential verifies that 100 consecutive RecordEvent calls each complete within 100ms.
-// REQ-HL-001: observer must not block the parent tool call.
+// TestRecordEvent100Sequential verifies that 100 consecutive RecordEvent calls
+// stay well inside the 5s hook budget. REQ-HL-001: observer must not block the
+// parent tool call. Internal for-loop, NOT a Benchmark — the test asserts
+// latency bounds over the steady-state samples, not a throughput average. It
+// logs p95 / worst / avg so the bounds are mechanically observable in output.
+//
+// Both bounds are stated as a fraction of the 5s hook budget, because the
+// budget — not any absolute millisecond figure — is what RecordEvent actually
+// owes (same rationale as TestBranchGuard_Latency in PR #1541):
+//
+//   - p95 <= 20% of budget (1s POSIX). The regression detector. A real
+//     regression — an fsync per write, a whole-file rewrite per append, a
+//     network call — makes EVERY write slow, so it moves the whole
+//     distribution and trips p95. Scheduler jitter moves ONE sample and does
+//     not.
+//   - worst < 100% of budget (5s). The contract itself: no single write may
+//     consume the whole hook budget, because one that does stalls the user's
+//     tool call.
+//
+// What was wrong with the earlier form: it asserted <=100ms on EVERY one of
+// the 100 samples — a max-of-100 assertion that amplifies tail risk 100x and
+// measures machine load as much as the code (a loaded box breached it on
+// healthy code; see the load incidents of 2026-08-15).
+//
+// What p95 still catches: any change that moves typical write cost past a
+// second. What it deliberately does not catch: a 2x slowdown inside the
+// existing write cost, which is indistinguishable from load on this
+// measurement — catching that needs a recorded baseline, which the verify
+// snapshot store cannot honestly provide (keys bind to exact tree state, so
+// a previous-commit baseline is unreachable by construction).
+//
+// Windows keeps the existing skip: on GitHub-hosted Windows runners + race
+// detector + antivirus, file-write latency reliably exceeded even generous
+// ceilings in past observations (CIAUT Wave 6); the budget fractions were
+// not measured there.
 func TestRecordEvent100Sequential(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		// On the Windows GitHub-hosted runners + race detector + antivirus combination,
-		// file write latency reliably exceeds 100ms (observed in CIAUT Wave 6 closure;
-		// warmup 5 fix alone is insufficient). This test performs perf verification only
-		// on Linux/macOS. Windows-specific stabilization is handled in a separate SPEC
-		// (e.g., SPEC-V3R3-WIN-FLAKY-001).
-		t.Skip("Windows VM file-write latency가 100ms 한도를 안정적으로 위반 — Linux/macOS에서만 검증")
+		t.Skip("Windows runner file-write latency is unmeasured against budget fractions — Linux/macOS only")
 	}
 	t.Parallel()
 
@@ -149,12 +179,14 @@ func TestRecordEvent100Sequential(t *testing.T) {
 	obs := NewObserver(dir + "/usage-log.jsonl")
 
 	const count = 100
-	// Initial calls warm the OS file cache (on Windows/race-detector environments,
-	// the first writes may be slow due to antivirus/file-system caching).
-	// The 100ms limit is verified only against the steady state after warmup.
+	// Initial calls warm the OS file cache; bounds are verified only against
+	// the steady-state samples after warmup.
 	const warmup = 5
-	limit := 100 * time.Millisecond
 
+	const hookBudget = 5 * time.Second
+	steadyCeiling := hookBudget / 5 // 20% — 1s on POSIX
+
+	samples := make([]time.Duration, 0, count-warmup)
 	for i := range count {
 		start := time.Now()
 		if err := obs.RecordEvent(EventTypeMoaiSubcommand, "test-subject", "hash"); err != nil {
@@ -163,11 +195,40 @@ func TestRecordEvent100Sequential(t *testing.T) {
 		if i < warmup {
 			continue
 		}
-		elapsed := time.Since(start)
-		if elapsed > limit {
-			t.Errorf("RecordEvent %d번째: %v > %v (100ms 한도 초과)", i, elapsed, limit)
-		}
+		samples = append(samples, time.Since(start))
 	}
+
+	p95 := percentileDuration(samples, 0.95)
+	var worst time.Duration
+	var total time.Duration
+	for _, s := range samples {
+		if s > worst {
+			worst = s
+		}
+		total += s
+	}
+	t.Logf("steady-state samples=%d p95=%v worst=%v avg=%v",
+		len(samples), p95, worst, total/time.Duration(len(samples)))
+
+	if p95 > steadyCeiling {
+		t.Errorf("p95 RecordEvent latency %v > %v (20%% of the 5s hook budget) — "+
+			"a whole-distribution slowdown; if this is red, typical writes got slower, "+
+			"not one unlucky sample", p95, steadyCeiling)
+	}
+	if worst >= hookBudget {
+		t.Errorf("worst RecordEvent latency %v >= %v (the full hook budget) — "+
+			"a single write can stall the parent tool call", worst, hookBudget)
+	}
+}
+
+// percentileDuration returns the p-th percentile of a non-empty sample set
+// (nearest-rank method: the ceil(p·n)-th smallest value). Panics on empty
+// input — callers must supply at least one sample.
+func percentileDuration(samples []time.Duration, p float64) time.Duration {
+	sorted := slices.Clone(samples)
+	slices.Sort(sorted)
+	rank := max(int(math.Ceil(p*float64(len(sorted)))), 1)
+	return sorted[rank-1]
 }
 
 // TestRecordEventAppends verifies that new events are appended to an existing file.

--- a/internal/telemetry/async_recorder_test.go
+++ b/internal/telemetry/async_recorder_test.go
@@ -7,21 +7,37 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	"runtime"
-	"sync"
 	"testing"
 	"time"
 )
 
-// TestAsyncRecorder_NonBlockingUnderLoad verifies that Record() returns quickly
-// even under heavy parallel load, and that all records are persisted after Close.
-func TestAsyncRecorder_NonBlockingUnderLoad(t *testing.T) {
-	// On Windows CI runners the goroutine scheduler granularity is much coarser
-	// than on Linux/macOS, so latency-based assertions fail consistently.
-	// Verify the non-blocking invariant on other OSes instead.
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping on Windows: scheduler granularity causes flaky latency assertions")
-	}
+// TestAsyncRecorder_RecordReturnsFastSequential verifies the caller-path
+// contract of Record(): it is a select/default channel send (async_recorder.go)
+// — microseconds, never disk I/O — and every call returns either nil or
+// ErrRecordDropped. Persistence after Close is asserted on the same run.
+//
+// What was wrong with the earlier form (TestAsyncRecorder_NonBlockingUnderLoad):
+// it spawned 1000 concurrent goroutines and counted calls exceeding 100ms —
+// measuring the Go scheduler under self-induced load, not the recorder. The
+// recorder's own cost (a channel send) is nanoseconds; the scheduler storm was
+// the entire signal, which is why it passed alone and failed on a loaded box.
+//
+// The sequential shape below catches the real regression class — Record
+// growing synchronous work (a disk write per call, a mutex-held flush, a
+// network call): 2000 sequential channel sends complete in well under 10ms
+// even on a loaded box, while 2000 synchronous disk writes take seconds. The
+// 2s total bound therefore sits ~3 orders of magnitude above healthy cost —
+// too far for load noise to bridge, close enough that the regression class
+// trips it. This is an absolute bound stated as an average; there is no
+// natural budget to make it relative to.
+//
+// What it deliberately does NOT catch: a blocking send (`r.ch <- rec` without
+// the select/default) — with a live consumer goroutine a blocking send still
+// makes progress, so only a stalled consumer exposes it, and stalling the
+// consumer deterministically needs an injection seam the recorder does not
+// expose. If that invariant ever matters enough to test, add the seam first;
+// a goroutine storm does not test it either.
+func TestAsyncRecorder_RecordReturnsFastSequential(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -29,45 +45,44 @@ func TestAsyncRecorder_NonBlockingUnderLoad(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	const bufSize = 200
-	const numRecords = 1000
+	// Small buffer so both return paths (accepted / dropped) are likely
+	// exercised across the run; drops are permitted, blocking is not.
+	const bufSize = 8
+	const numRecords = 2000
+	// 1ms average per call. A channel send costs ~100ns; synchronous disk
+	// writes cost ~ms each. The bound separates the two by ~3 orders of
+	// magnitude on both sides.
+	const totalBound = 2 * time.Second
 
 	rec := NewAsyncRecorder(dir, bufSize)
 
 	ts := time.Date(2026, 4, 15, 10, 0, 0, 0, time.UTC)
-
-	var wg sync.WaitGroup
-	slowCalls := 0
-	var slowMu sync.Mutex
-
-	for i := 0; i < numRecords; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			r := UsageRecord{
-				Timestamp: ts,
-				SkillID:   "test-skill",
-				SessionID: "sess-load-test",
-				Outcome:   OutcomeUnknown,
-			}
-			start := time.Now()
-			_ = rec.Record(r)
-			elapsed := time.Since(start)
-			// Threshold set to 100ms to accommodate goroutine scheduling latency in CI (especially Windows).
-			// Core invariant: Record() returns immediately without waiting for disk I/O (channel send or drop).
-			if elapsed > 100*time.Millisecond {
-				slowMu.Lock()
-				slowCalls++
-				slowMu.Unlock()
-			}
-		}()
+	r := UsageRecord{
+		Timestamp: ts,
+		SkillID:   "test-skill",
+		SessionID: "sess-sequential-test",
+		Outcome:   OutcomeUnknown,
 	}
-	wg.Wait()
 
-	// More records than the buffer size, so some may be dropped — but blocking must not occur.
-	// Slow calls must be <= 5% of total (allows CI scheduling jitter).
-	if slowCalls > numRecords*5/100 {
-		t.Errorf("too many slow calls: %d/%d (>100ms)", slowCalls, numRecords)
+	start := time.Now()
+	dropped := 0
+	for i := range numRecords {
+		if err := rec.Record(r); err != nil {
+			if !errors.Is(err, ErrRecordDropped) {
+				t.Fatalf("Record %d returned unexpected error: %v", i, err)
+			}
+			dropped++
+		}
+	}
+	elapsed := time.Since(start)
+	t.Logf("%d sequential Record calls: total=%v avg=%s dropped=%d/%d",
+		numRecords, elapsed, elapsed/time.Duration(numRecords), dropped, numRecords)
+
+	if elapsed > totalBound {
+		t.Errorf("%d sequential Record calls took %v (> %v, ~1ms/call average) — "+
+			"Record() must be a channel send, not synchronous work; "+
+			"this indicates Record grew disk I/O or a lock on the caller path",
+			numRecords, elapsed, totalBound)
 	}
 
 	// Close after all records are processed.
@@ -78,7 +93,7 @@ func TestAsyncRecorder_NonBlockingUnderLoad(t *testing.T) {
 		t.Fatalf("Close: %v", err)
 	}
 
-	// Verify that some records were written to file (drop policy may keep less than total).
+	// Verify that records were written to file (drop policy may keep less than total).
 	telDir := filepath.Join(dir, ".moai", "evolution", "telemetry")
 	entries, err := os.ReadDir(telDir)
 	if err != nil {


### PR DESCRIPTION
## Summary

Kanban card **t36**. Three tests were reported asserting absolute wall-clock ceilings — measuring machine load as much as code. Two of the three carry real timing assertions and are reshaped here into the **percentile-of-budget** form PR #1541 established for `TestBranchGuard_Latency`. The third (`TestBuilderNormalizesMode`) turned out to have **no timing assertion at all** — details below.

A recorded-baseline mechanism (via the `verify` snapshot store) was evaluated and **rejected** as infeasible:

- `verify.Key` binds each snapshot to exact tree state (`HEAD` + porcelain-v2 + `git diff HEAD` digest, `internal/verify/key.go:32`) — the store is *designed* to make a changed tree miss, which is precisely the lookup a timing baseline needs to hit. A previous-commit baseline is unreachable by construction.
- Snapshots live in gitignored per-machine state (`.moai/state/verify/snapshots/`, `internal/verify/store.go:15`) — CI never sees a dev-machine baseline, and committing one ratchets on whichever machine last recorded it.
- The schema has no machine-provenance field — a cross-machine baseline could not even be *detected*, let alone normalized.

## Change 1 — `TestRecordEvent100Sequential` (internal/harness)

| | old | new |
|---|---|---|
| bound | every one of 100 writes ≤ 100ms | p95 ≤ 20% of the 5s hook budget (1s); worst < 100% of budget |
| failure mode | max-of-100 → 100x tail-risk amplification; red on healthy code under load | scheduler jitter moves one sample; a regression moves the distribution |
| warmup | 5 writes | kept |

Measured on this PR head: `p95=151µs worst=2.9ms avg=120µs` — ~6600x margin under the p95 bound.

**Catches**: any change that makes *every* write slow — fsync per write, whole-file rewrite per append, network on the write path.
**Does not catch**: a 2x slowdown inside the existing write cost — indistinguishable from load on this measurement (same concession #1541 documents).

Windows skip kept: the budget fractions are unmeasured on Windows runners.

## Change 2 — `TestAsyncRecorder_NonBlockingUnderLoad` → `TestAsyncRecorder_RecordReturnsFastSequential` (internal/telemetry)

| | old | new |
|---|---|---|
| shape | 1000 concurrent goroutines, count calls >100ms, fail if >5% | 2000 **sequential** Record calls under a 2s total bound (~1ms/call avg) |
| what it measured | the Go scheduler under self-induced load | the recorder's caller path |

`Record()` is a select/default channel send (`internal/telemetry/async_recorder.go:55`) — nanoseconds, never disk I/O. Measured here: 2000 calls in 22.8ms (11µs avg, 87x margin), both return paths exercised (1928 drops accepted as `ErrRecordDropped`, no other error). Close-flush persistence assertion kept from the old test.

**Catches**: Record growing synchronous caller-path work (disk write, lock-held flush) — the bound separates healthy cost from the regression class by ~3 orders of magnitude in both directions.
**Does not catch**: a blocking send (`r.ch <- rec` without select/default) while the consumer is healthy — a blocking send still makes progress; only a *stalled* consumer exposes it, and deterministic consumer-stall needs an injection seam the recorder does not expose. The deleted goroutine storm did not test this either.

Windows skip dropped: its rationale was scheduler granularity in the deleted goroutine census. CI on this PR head is the check for that decision.

The 1000-goroutine load generator is deleted outright — this test no longer contributes to machine load (pays into the 2026-08-15 load incident follow-up).

## Non-change — `TestBuilderNormalizesMode` (internal/statusline)

The card named it, but it carries **zero timing assertions** — it is pure output-equivalence (minimal/compact ≡ default, verbose ≡ full), verified end to end, and no test in the package asserts an elapsed ceiling on `Build`. Its full-suite failure (observed 2026-07-26, `FAIL (8.49s)`) is real but has a different mechanism, found during this card's bounded investigation:

- `New(Options{...})` with no `GitProvider` **auto-opens the real repository** at cwd (`internal/statusline/builder.go:82-96`).
- Each compared `Build` call runs `CollectGitStatus` — a live `CurrentBranch()` + `Status()` read of the **shared moai-adk-go checkout**.
- Under `go test ./...`, parallel packages (`internal/worktree`, `internal/hook`, …) mutate that checkout's git state *between* the test's five `Build` calls, so the rendered git segment differs and the equivalence assertion fails with `minimal should produce same output as default`.

Proposed separate card: inject a fixed stub `GitProvider` (the file already has `slowGitProvider` as a template) so all five Build calls render identical git segments. Not folded here — t36 stays two tests.

## Test plan

- [x] `go vet ./internal/harness/ ./internal/telemetry/` — clean
- [x] `go test ./internal/harness/ -run TestRecordEvent100Sequential -count=1` — PASS (evidence above)
- [x] `go test ./internal/telemetry/ -run TestAsyncRecorder -count=1 -v` — all 3 PASS (evidence above)
- [ ] CI on this PR head (the load-clean measurement environment)

Draft, no auto-merge — lead review gate.

🗿 MoAI