### PR TITLE
fix(statusline): bound usage fetch phase against unbounded Retry-After (#1467)

### DIFF
--- a/internal/statusline/builder_test.go
+++ b/internal/statusline/builder_test.go
@@ -419,20 +419,30 @@ func TestBuilderNormalizesMode(t *testing.T) {
 		ContextWindow: &ContextWindowInfo{Used: 50000, Total: 200000},
 	}
 
+	// Inject a no-usage stub: without it New() auto-creates a usage collector
+	// pointed at the real home directory, which reads the host's keychain and
+	// issues a live OAuth API call with a deadline-less context — the hang in
+	// issue #1467 (readOAuthToken tries the macOS keychain first, so a temp
+	// HomeDir does not isolate it).
+	noUsage := &mockUsageProvider{data: nil}
+
 	// Builder created with "minimal" should behave as ModeDefault
 	builderMinimal := New(Options{
-		Mode:    "minimal",
-		NoColor: true,
+		Mode:          "minimal",
+		NoColor:       true,
+		UsageProvider: noUsage,
 	})
 	// Builder created with "compact" should also behave as ModeDefault
 	builderCompact := New(Options{
-		Mode:    ModeCompact,
-		NoColor: true,
+		Mode:          ModeCompact,
+		NoColor:       true,
+		UsageProvider: noUsage,
 	})
 	// Builder created with "default"
 	builderDefault := New(Options{
-		Mode:    ModeDefault,
-		NoColor: true,
+		Mode:          ModeDefault,
+		NoColor:       true,
+		UsageProvider: noUsage,
 	})
 
 	gotMinimal, err := builderMinimal.Build(context.Background(), makeStdinJSON(input))
@@ -460,13 +470,15 @@ func TestBuilderNormalizesMode(t *testing.T) {
 
 	// Builder created with "verbose" should behave as ModeFull("full")
 	builderVerbose := New(Options{
-		Mode:    "verbose",
-		NoColor: true,
+		Mode:          "verbose",
+		NoColor:       true,
+		UsageProvider: noUsage,
 	})
 	// Builder created with "full"
 	builderFull := New(Options{
-		Mode:    ModeFull,
-		NoColor: true,
+		Mode:          ModeFull,
+		NoColor:       true,
+		UsageProvider: noUsage,
 	})
 
 	gotVerbose, err := builderVerbose.Build(context.Background(), makeStdinJSON(input))

--- a/internal/statusline/usage.go
+++ b/internal/statusline/usage.go
@@ -28,6 +28,14 @@ const (
 
 	// haikuProbeModel is the cheapest model used for rate-limit header probing.
 	haikuProbeModel = "claude-haiku-4-5-20251001"
+
+	// usageFetchTimeout bounds the entire usage network phase (Haiku probe +
+	// OAuth endpoint fallback, including 429 retries). Without it a deadline-less
+	// caller context lets the retry loop honor a server-controlled Retry-After
+	// of arbitrary length (issue #1467). The production statusline sits under a
+	// tighter render budget (internal/cli statuslineRenderBudget); this bound
+	// protects every other caller.
+	usageFetchTimeout = 3 * time.Second
 )
 
 // UsageProvider collects API usage information (REQ-V3-API-001).
@@ -45,7 +53,8 @@ type usageCacheFile struct {
 }
 
 // usageCollector collects and caches Anthropic API usage.
-// 5-minute TTL, 300ms timeout, graceful degradation (REQ-V3-API-002~005, REQ-V3-API-009).
+// 5-minute TTL, usageFetchTimeout-bounded network phase, graceful degradation
+// (REQ-V3-API-002~005, REQ-V3-API-009).
 type usageCollector struct {
 	mu                  sync.RWMutex
 	cache               *usageCacheFile
@@ -56,6 +65,10 @@ type usageCollector struct {
 	client              *http.Client
 	homeDir             string
 	keychainReaderFn    func() (string, error) // Override for testing
+	// messagesURL and oauthURL override the production API endpoints for
+	// testing (zero value falls back to the constants above).
+	messagesURL string
+	oauthURL    string
 }
 
 // NewUsageCollector creates a new UsageProvider.
@@ -109,11 +122,17 @@ func (u *usageCollector) CollectUsage(ctx context.Context) (*UsageResult, error)
 	// Strategy: Try Haiku probe (response headers) first, fall back to OAuth endpoint.
 	// The OAuth /api/oauth/usage endpoint has a known persistent 429 issue (Issue #31021),
 	// so we prefer extracting rate limit data from Messages API response headers.
-	apiResp, err := u.fetchUsageFromHeaders(ctx, token)
+	// The whole network phase is bounded by usageFetchTimeout: the 429 retry loop
+	// honors server-controlled Retry-After values, which must never outlive this
+	// deadline even when the caller passed a deadline-less context (issue #1467).
+	fetchCtx, cancelFetch := context.WithTimeout(ctx, usageFetchTimeout)
+	defer cancelFetch()
+
+	apiResp, err := u.fetchUsageFromHeaders(fetchCtx, token)
 	if err != nil {
 		slog.Debug("haiku probe failed, trying oauth endpoint", "error", err)
 		// Fallback: try the OAuth usage endpoint
-		apiResp, err = u.fetchUsageFromOAuthAPI(ctx, token)
+		apiResp, err = u.fetchUsageFromOAuthAPI(fetchCtx, token)
 	}
 	if err != nil {
 		slog.Debug("all usage fetch methods failed", "error", err)
@@ -439,7 +458,11 @@ type usagePeriodData struct {
 //	anthropic-ratelimit-unified-5h-reset: 2026-03-10T20:00:00Z (ISO 8601)
 //	anthropic-ratelimit-unified-7d-reset: 2026-03-15T07:00:00Z (ISO 8601)
 func (u *usageCollector) fetchUsageFromHeaders(ctx context.Context, token string) (*oauthUsageResponse, error) {
-	return u.fetchUsageFromHeadersWithURL(ctx, anthropicMessagesURL, token)
+	apiURL := u.messagesURL
+	if apiURL == "" {
+		apiURL = anthropicMessagesURL
+	}
+	return u.fetchUsageFromHeadersWithURL(ctx, apiURL, token)
 }
 
 // fetchUsageFromHeadersWithURL extracts 5H/7D usage from Messages API response headers.
@@ -525,8 +548,13 @@ func (u *usageCollector) fetchUsageFromOAuthAPI(ctx context.Context, token strin
 	var lastErr error
 	backoff := 2 * time.Second
 
+	oauthURL := u.oauthURL
+	if oauthURL == "" {
+		oauthURL = anthropicOAuthUsageURL
+	}
+
 	for attempt := range maxRetries {
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, anthropicOAuthUsageURL, nil)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, oauthURL, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/statusline/usage_test.go
+++ b/internal/statusline/usage_test.go
@@ -1143,3 +1143,47 @@ func TestExponentialBackoff_ProgressiveCooldown(t *testing.T) {
 		t.Error("should not be in cooldown (count=5 → 16m, elapsed=20m)")
 	}
 }
+
+// TestCollectUsage_BoundedWithoutCallerDeadline reproduces issue #1467: with a
+// deadline-less context (context.Background(), as passed by builder tests), the
+// OAuth 429 retry loop used to honor a server-controlled Retry-After of
+// arbitrary length. CollectUsage must bound its own network phase and degrade
+// gracefully regardless of the caller's context.
+func TestCollectUsage_BoundedWithoutCallerDeadline(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Every endpoint is rate-limited with an absurd Retry-After and no
+		// rate-limit headers: the Haiku probe fails and the OAuth fallback
+		// enters its retry loop.
+		w.Header().Set("Retry-After", "3600")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	collector := &usageCollector{
+		cachePath:           filepath.Join(t.TempDir(), "usage.json"),
+		client:              server.Client(),
+		ttl:                 time.Minute,
+		failureCooldownBase: time.Minute,
+		failureCooldownMax:  time.Minute,
+		keychainReaderFn:    func() (string, error) { return "test-token", nil },
+		messagesURL:         server.URL,
+		oauthURL:            server.URL,
+	}
+
+	start := time.Now()
+	result, err := collector.CollectUsage(context.Background())
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("CollectUsage should degrade gracefully (nil, nil), got error: %v", err)
+	}
+	if result != nil {
+		t.Errorf("result = %+v, want nil (no usage available)", result)
+	}
+	if elapsed >= usageFetchTimeout+2*time.Second {
+		t.Errorf("CollectUsage took %v, want bounded under %v (unbounded Retry-After wait, issue #1467)",
+			elapsed, usageFetchTimeout)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #1467.

`CollectUsage` stalled indefinitely in credential-bearing but network-restricted environments because the OAuth 429 retry loop honors server-controlled `Retry-After` values under a caller-supplied context — and builder tests pass `context.Background()`. `http.Client.Timeout` never covered the backoff `select`, so a single `Retry-After: 3600` response meant an hour-long stall, surfacing as the 10m test timeout in `TestBuilderNormalizesMode`.

Three layers:

1. **Bound the network phase** (`usage.go`): `CollectUsage` wraps the Haiku probe + OAuth fallback (incl. 429 retries) in `context.WithTimeout(ctx, usageFetchTimeout = 3s)`. Production impact is nil in practice — the statusline entry already sits under the 800ms render budget (#646), which dominates the new bound. This protects *every* caller, not just the tests.
2. **Hermetic test** (`builder_test.go`): `TestBuilderNormalizesMode` injects a no-usage `mockUsageProvider`, so it no longer auto-creates a collector against the real home directory. Note: `readOAuthToken` tries the macOS keychain *first*, so redirecting `HomeDir` does not isolate a test — stub injection is the only hermetic option.
3. **Repro test** (`usage_test.go`): `TestCollectUsage_BoundedWithoutCallerDeadline` drives a fake 429 + `Retry-After: 3600` server through new URL seam fields (`messagesURL` / `oauthURL`, zero value → production constants; mirrors the existing `fetchUsageFromHeadersWithURL` precedent) and asserts `CollectUsage` returns `nil, nil` within the bound.

## Root-cause evidence

Repro run before the fix, `-timeout 15s` — goroutine dump pinned the stall exactly where the issue reported it:

```
statusline.(*usageCollector).fetchUsageFromOAuthAPI ... usage.go:593
statusline.(*usageCollector).CollectUsage         ... usage.go:128
FAIL github.com/modu-ai/moai-adk/internal/statusline 15.764s
```

After the fix: `--- PASS: TestCollectUsage_BoundedWithoutCallerDeadline (3.01s)`.

## Test plan

- [x] `go vet ./internal/statusline/` — clean
- [x] Repro test RED pre-fix (stuck in `fetchUsageFromOAuthAPI` select), PASS post-fix (3.01s)
- [x] `go test ./internal/statusline/ -count=1` — ok (full package)
- [ ] CI on this PR head

## Note for reviewers

The other ~40 builder-test call sites still auto-create a real collector; with the new bound their worst case is 3s, and on credential-less CI the token lookup short-circuits before any network. Fully stubbing every site is possible follow-up work but was left out to keep this diff scoped to the issue. (Separately, #1551 proposed a stub `GitProvider` card for the same test's output-equivalence flakiness — different mechanism, also still open.)

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved status-line usage checks to stop waiting after a short timeout, including during retries.
  * Prevented excessive retry delays when usage services respond with rate-limit errors.
  * Usage information now degrades gracefully when service requests cannot complete.
* **Tests**
  * Added coverage for timeout and rate-limit scenarios.
  * Improved mode comparison tests for more consistent, isolated results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->