### PR TITLE
docs(docs-site): point the home install chip at adk.mo.ai.kr and drop its pill border

### DIFF
--- a/docs-site/layouts/index.html
+++ b/docs-site/layouts/index.html
@@ -40,7 +40,7 @@
             </div>
             <div class="cw-home-install">
               <span class="dollar">$</span>
-              <code id="cw-install-cmd">curl -fsSL https://raw.githubusercontent.com/modu-ai/moai-adk/main/install.sh | bash</code>
+              <code id="cw-install-cmd">curl -fsSL https://adk.mo.ai.kr/install.sh | bash</code>
               <button type="button" class="cw-home-copy" data-copy-target="#cw-install-cmd" aria-label="설치 명령 복사">
                 <svg class="cw-copy-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
                 <svg class="cw-copy-check" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" hidden><path d="M20 6L9 17l-5-5"/></svg>

--- a/docs-site/static/moai-docs-layout.css
+++ b/docs-site/static/moai-docs-layout.css
@@ -1394,6 +1394,13 @@ main.docs-main .doc-layout--2col {
   font-family: inherit;
   font-size: inherit;
   padding: 0;
+  /* The global `code` rule in moai-brand.css (FROZEN) paints a 1px border and
+     a radius, which renders as a pill drawn around the install command inside
+     the dark chip. background and padding were already reset here; the border
+     was not. moai-docs-layout.css loads after moai-brand.css, so clearing it
+     here leaves the frozen file untouched. */
+  border: 0;
+  border-radius: 0;
 }
 .cw-home-install svg { flex: none; }
 .cw-home-copy { flex: none; display: inline-flex; align-items: center; justify-content: center; background: none; border: 0; color: #9fa0a0; cursor: pointer; padding: 2px; border-radius: 4px; transition: color 150ms; }


### PR DESCRIPTION
Two small fixes to the install chip on the docs home.

## The address

The chip advertised the `raw.githubusercontent.com` URL while all four READMEs advertise `adk.mo.ai.kr/install.sh` — two install commands for the same product. Until today the short one 404'd, so the long one was the only working copy.

That is no longer true. The site now serves the Hugo build and `/install.sh` returns the script. Verified end to end:

```
curl -fsSL https://adk.mo.ai.kr/install.sh   → 200, application/x-sh, 10,867 B
diff against repo-root install.sh            → byte-identical
bash install.sh --install-dir <tmp>          → exit 0, binary runs
```

## The border

`moai-brand.css` is FROZEN and its global `code` rule paints a `1px` border plus a radius, which rendered as a pill drawn around the command inside the dark chip. The local `.cw-home-install code` override had already reset `background` and `padding` but not the border. `moai-docs-layout.css` loads after the frozen file, so the reset goes there and leaves it untouched.

## Verification

| Check | Result |
|---|---|
| `hugo --gc --minify` | exit 0 |
| Install command, ko/en/ja/zh | `adk.mo.ai.kr/install.sh` in all four |
| `raw.githubusercontent` remaining | 0 |
| v3.1 Kanban banner + image | still rendered in all four locales |

The last row is the one that mattered: the first attempt at this edit was made against a pre-merge working copy and would have deleted the banner that #1554 had just landed. Redone on top of `3b56d859f`.

🗿 MoAI