### PR TITLE
chore(local): normalise the dogfood ruleset, keep three orphans, ignore browser output

### DIFF
--- a/.claude/rules/local/ci-autofix-protocol.md
+++ b/.claude/rules/local/ci-autofix-protocol.md
@@ -1,12 +1,12 @@
 ---
-description: CI auto-fix loop protocol — HARD invocation contract for moai-workflow-ci-loop skill (auto-fix phase). Auto-loaded when the ci-loop skill is active.
-paths: ".claude/skills/moai-workflow-ci-loop/SKILL.md"
+description: CI auto-fix loop protocol — HARD invocation contract for hns-workflow-ci-loop skill (auto-fix phase). Auto-loaded when the ci-loop skill is active.
+paths: ".claude/skills/hns-workflow-ci-loop/SKILL.md"
 ---
 
 # CI Auto-Fix Protocol Rule
 
 > This file is the single source of truth for the CI auto-fix loop invocation rules.
-> Cross-referenced by: SKILL.md, moai-workflow-ci-loop (unified watch + autofix skill).
+> Cross-referenced by: SKILL.md, hns-workflow-ci-loop (unified watch + autofix skill).
 
 ---
 

--- a/.claude/rules/local/ci-watch-protocol.md
+++ b/.claude/rules/local/ci-watch-protocol.md
@@ -1,12 +1,12 @@
 ---
-description: CI watch loop protocol — HARD invocation contract for moai-workflow-ci-loop skill (watch phase). Auto-loaded on /moai sync and moai pr watch invocations.
-paths: ".claude/skills/moai-workflow-ci-loop/SKILL.md,scripts/ci-watch/run.sh"
+description: CI watch loop protocol — HARD invocation contract for hns-workflow-ci-loop skill (watch phase). Auto-loaded on /moai sync and moai pr watch invocations.
+paths: ".claude/skills/hns-workflow-ci-loop/SKILL.md,scripts/ci-watch/run.sh"
 ---
 
 # CI Watch Protocol Rule
 
 > This file is the single source of truth for CI watch loop invocation rules.
-> Cross-referenced by: SKILL.md, moai-workflow-ci-loop (unified watch + autofix skill).
+> Cross-referenced by: SKILL.md, hns-workflow-ci-loop (unified watch + autofix skill).
 
 ---
 
@@ -101,7 +101,7 @@ The `(권장)` label MUST be on the first option per `.claude/rules/moai/core/as
 
 ## T3 Handoff Format
 
-On exit 2, stdout contains JSON (see `.claude/skills/moai-workflow-ci-loop/SKILL.md` (the **Handoff schema on exit 2** marker)):
+On exit 2, stdout contains JSON (see `.claude/skills/hns-workflow-ci-loop/SKILL.md` (the **Handoff schema on exit 2** marker)):
 
 ```json
 {

--- a/.claude/skills/hns-workflow-ci-loop/SKILL.md
+++ b/.claude/skills/hns-workflow-ci-loop/SKILL.md
@@ -29,7 +29,7 @@ progressive_disclosure:
   level2_tokens: 5000
 ---
 
-# CI Loop (`moai-workflow-ci-loop`)
+# CI Loop (`hns-workflow-ci-loop`)
 
 Unified CI watch + auto-fix loop. The orchestrator invokes this skill after `/moai sync`
 Phase 4 (`gh pr create`) returns a PR number. The skill polls required checks, classifies

--- a/.claude/skills/hns-workflow-ci-loop/SKILL.md
+++ b/.claude/skills/hns-workflow-ci-loop/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: moai-workflow-ci-loop
+name: hns-workflow-ci-loop
 description: >
   Unified CI watch + auto-fix loop skill. Polls gh pr checks after /moai sync PR creation,
   classifies required vs auxiliary failures, attempts safe automated patches (max 3 iterations),

--- a/.claude/skills/moai-domain-html-report/references/craft-fundamentals.md
+++ b/.claude/skills/moai-domain-html-report/references/craft-fundamentals.md
@@ -1,0 +1,70 @@
+# Craft Fundamentals — html-report
+
+Production rules for every mode, adapted from the `design-artifact` skill
+(plannotator/effective-html). The **design tokens are fixed** — see § Design
+Tokens in `SKILL.md` (ivory / clay / Pretendard). This document is *craft*, not
+a new look: spacing, numerals, neutrals, copy, structure, and avoiding the
+generic-AI layout. Nothing here changes a token.
+
+---
+
+## Spacing belongs to the layout, not the elements
+
+Sibling groups use flex/grid plus `gap`; per-element margins scatter and collapse
+unpredictably. Broad content — tables, code blocks, diagrams — sits in its own
+container with `overflow-x: auto` so horizontal scroll never leaks to the page
+body. This is why the mode skeletons reach for `gap`, not per-card `margin`.
+
+## Numerals stack in tabular columns
+
+Wherever numbers line up — KPI cards, financial tables, velocity bars — switch on
+`font-variant-numeric: tabular-nums`. Proportional digits make a financial
+statement twitch; tabular digits align by place value.
+
+## Neutrals are choices
+
+A dead-center mid-grey (`#808080`) announces that nobody thought about it. Tint
+the neutral faintly toward the accent instead. This skill's greyscale
+(`--g100` / `--g300` / `--g500` / `--g700`) is already warm-tinted to sit with
+`--clay`; use it deliberately rather than reaching for a raw grey.
+
+## Copy is a material, not garnish
+
+Stand on the reader's side: name things as people know them, not as the backend
+does (someone manages *notifications*, never *webhook config*). Verbs stay
+active; every control declares its exact effect. An error message diagnoses the
+failure and prescribes the fix — never groveling, never hand-waving. Precision
+outperforms wit.
+
+## Make structure mean something
+
+Numbering (01 / 02 / 03), eyebrows, dividers, and labels earn their place by
+asserting something true about the content. Numbered markers are honest only
+when order is real information — a procedure, a dated timeline the reader
+follows in sequence. Do not deploy them as decoration.
+
+## Dodge the telltale AI layout
+
+The token palette (warm ivory ground, clay accent) sits inside the territory
+`design-artifact` flags as the generic-AI look; this skill keeps it by policy
+("Claude style"). What you control is the *layout*: avoid the remaining clichés
+— universal center alignment, `rounded-lg` sprayed on every surface, rounded
+cards each wearing an accent bar, decorative emoji as section markers (prefer
+inline SVG or typographic markers), a gradient hero floating on white. A
+pinned-down direction is executed faithfully; absent one, spend the freedom on
+composition, not on the cliché.
+
+## Engineer it soundly
+
+Non-void elements closed, attributes double-quoted, keyboard focus visible,
+`prefers-reduced-motion` respected. When the rendering question is
+structural-diagram vs quantitative-chart, the answer is in `SKILL.md`
+§ Diagram Policy — this file does not override it.
+
+---
+
+## Cross-references
+
+- `SKILL.md` § Design Tokens — the fixed palette (the authority; this file never changes a token)
+- `SKILL.md` § Diagram Policy — model selection + the zero-JS rendering rule
+- `SKILL.md` § Audience Tiers — what depth each tier adds (craft is orthogonal to tier)

--- a/.claude/skills/moai-meta-harness/references/hierarchical-scoring.md
+++ b/.claude/skills/moai-meta-harness/references/hierarchical-scoring.md
@@ -1,0 +1,36 @@
+# Phase 3b — Hierarchical Scoring
+
+When `harness.yaml` sets `evaluator_mode: hierarchical` (the hierarchical-scoring policy), the Sprint Contract evaluation uses 4-dimension × sub-criteria hierarchical scoring instead of flat 0-100 integers.
+
+## Flat Mode vs Hierarchical Mode
+
+| Aspect | Flat Mode (default) | Hierarchical Mode |
+|--------|---------------------|-----------------------------|
+| Score type | Integer 0-100 | Float anchor: 0.25 / 0.50 / 0.75 / 1.00 |
+| Criteria granularity | Per-dimension | Per sub-criterion within dimension |
+| Aggregation | Implicit average | `min` (default) or `mean` per profile |
+| Citation | Optional | Required (ErrRubricCitationMissing if absent) |
+| Must-pass | Security hard threshold | Per `must_pass_dimensions` in profile |
+
+## Active Profile Loading
+
+1. Check SPEC frontmatter `evaluator_profile` field.
+2. If present: load `.moai/config/evaluator-profiles/{evaluator_profile}.md`
+3. If absent: load `.moai/config/evaluator-profiles/{harness.default_profile}.md`
+4. If profile file not found: fall back to built-in defaults (Functionality / Security / Craft / Consistency)
+
+Profiles are parsed by `internal/harness.ParseRubricMarkdown()`. Unknown dimension names are skipped (lenient parsing) to support non-canonical profiles like `frontend.md`. Validate() enforces that exactly 4 canonical dimensions are present after parsing.
+
+## When to Enable Hierarchical Mode
+
+Hierarchical mode is recommended when:
+
+- Sub-criteria need independent visibility (e.g., "Security → input validation" vs "Security → secret management")
+- Project has compliance requirements requiring per-criterion audit trail
+- Evaluator leniency is a concern (citation requirement reduces drift)
+
+Flat mode is sufficient for:
+
+- Simple harnesses with limited domain scope
+- Projects where the 4-dimension aggregate is the primary signal
+- Initial harness generation before profiles are tuned

--- a/.git_hooks/pre-commit
+++ b/.git_hooks/pre-commit
@@ -1,0 +1,73 @@
+#!/bin/sh
+# MoAI-ADK pre-commit hook — fast subset (gofmt + go vet) + heavy gate (moai gate)
+# Bypass via: SKIP_MOAI_PRECOMMIT=1 git commit
+# Heavy gate (vet + lint + test, 16-language detection) runs in your shell, outside the 5s hook budget.
+set -eu
+
+if [ "${SKIP_MOAI_PRECOMMIT:-0}" = "1" ]; then
+    printf '[pre-commit] SKIP_MOAI_PRECOMMIT=1 -- bypass requested\n' >&2
+    exit 0
+fi
+
+# Staged Go files (Added / Copied / Modified; deletions excluded via ACM).
+STAGED_GO="$(git diff --cached --name-only --diff-filter=ACM | grep '\.go$' || true)"
+
+# --- Fast subset: gofmt + go vet on staged Go files (sub-second; skipped when none staged) ---
+if [ -n "$STAGED_GO" ]; then
+    # gofmt format check. Skipped when gofmt is not on PATH (non-Go environment).
+    if command -v gofmt >/dev/null 2>&1; then
+        NEED_FMT="$(
+            printf '%s\n' "$STAGED_GO" | while IFS= read -r f; do
+                [ -n "$f" ] || continue
+                gofmt -l "$f" 2>/dev/null || true
+            done
+        )"
+        if [ -n "$NEED_FMT" ]; then
+            printf '\n[pre-commit] FAILED: the following staged files need formatting:\n%s\n' "$NEED_FMT" >&2
+            printf '[pre-commit] Hint: gofmt -w <files> && git add <files>\n' >&2
+            printf '[pre-commit] Override: SKIP_MOAI_PRECOMMIT=1 git commit\n' >&2
+            exit 1
+        fi
+    fi
+
+    # go vet on the affected packages. Skipped when go is not on PATH (non-Go environment).
+    if command -v go >/dev/null 2>&1; then
+        PKGS="$(
+            printf '%s\n' "$STAGED_GO" | while IFS= read -r f; do
+                [ -n "$f" ] || continue
+                printf './%s\n' "$(dirname "$f")"
+            done | sort -u
+        )"
+        if [ -n "$PKGS" ]; then
+            # Optional Go build tags (.moai/config/build-tags, first non-comment
+            # non-blank line) so projects requiring non-default tags (e.g. goolm)
+            # are vetted under them.
+            BT_TAGS=""
+            if [ -f .moai/config/build-tags ]; then
+                _bt_line="$(sed -e 's/#.*//' .moai/config/build-tags | awk 'NF{print; exit}')" || true
+                [ -n "$_bt_line" ] && BT_TAGS="-tags=$_bt_line"
+            fi
+            # shellcheck disable=SC2086
+            if ! go vet $BT_TAGS $PKGS >/dev/null 2>&1; then
+                printf '\n[pre-commit] FAILED: go vet reported issues in the staged packages.\n' >&2
+                printf '[pre-commit] Hint: run go vet on the affected packages, fix, then re-commit.\n' >&2
+                printf '[pre-commit] Override: SKIP_MOAI_PRECOMMIT=1 git commit\n' >&2
+                exit 1
+            fi
+        fi
+    fi
+fi
+
+# --- Heavy gate: vet + lint + test via 'moai gate' (16-language toolchain detection) ---
+# Runs in the user's shell, outside Claude Code's 5s PreToolUse hook budget.
+# Skipped when moai is not on PATH so non-moai downstream projects pass silently.
+if command -v moai >/dev/null 2>&1; then
+    if ! moai gate; then
+        printf '\n[pre-commit] FAILED: moai gate reported errors above.\n' >&2
+        printf '[pre-commit] Hint: address the reported issues, then re-commit.\n' >&2
+        printf '[pre-commit] Override: SKIP_MOAI_PRECOMMIT=1 git commit\n' >&2
+        exit 1
+    fi
+fi
+
+exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -295,6 +295,20 @@ docs-site.hextra.backup/
 # run and must not be tracked. The journey scripts themselves (e2e/cli/*.sh) are.
 e2e/.runs/
 
+# Browser-driven output: screenshots the e2e suite captures, the page bundles it
+# writes under e2e/web/, and the Playwright MCP server's scratch directory.
+# 21 MB of it accumulated by 2026-08-15, all of it re-derivable by re-running the
+# suite, and all of it one `git add -A` away from a commit nobody intended.
+# Deliberately narrow: e2e/cli/*.sh and any curated fixture stay tracked.
+e2e/screenshots/
+e2e/web/
+.playwright-mcp/
+
+# Ad-hoc screenshots dropped at the repository root by a capture tool. A curated
+# image belongs under assets/images/ or docs-site/static/, both of which stay
+# tracked; a stray PNG at the root is a leftover.
+/*.png
+
 # Local-only sibling checkout + prompt-theme dir (never committed)
 main-fork/
 .omp/

--- a/.moai/astgrep-rules/go/hardcoding.yml
+++ b/.moai/astgrep-rules/go/hardcoding.yml
@@ -1,31 +1,23 @@
----
-id: go-no-raw-getenv
-language: go
-severity: warning
-message: Use config.Env* constants instead of raw os.Getenv() string literals. See
-  internal/config/envkeys.go for defined constants.
-note: 하드코딩된 환경변수 이름은 오타나 변경 시 컴파일 오류 없이 실패합니다. config 패키지의 상수를 사용하세요.
-rule:
-  pattern: os.Getenv("$LITERAL")
-fix: ''
+# Go hardcoding-detection rules.
+#
+# These rules detect common hardcoding anti-patterns in Go source code.
+# Severity levels:
+#   - error: intended to block a commit in a quality gate
+#   - warning: intended to be reported without blocking
 ---
 id: go-no-hardcoded-api-url
 language: go
 severity: warning
-message: Extract API URL to a package-level constant. Hardcoded URLs reduce maintainability
-  and make version updates error-prone.
-note: API URL을 코드에 직접 작성하면 URL 변경 시 모든 사용처를 찾아서 수정해야 합니다. 패키지 수준 상수로 추출하세요.
+message: "Extract the API URL to a package-level constant or configuration value. Hardcoded URLs reduce maintainability and make environment changes error-prone."
+note: "A literal API endpoint embedded in source cannot be changed per environment without a recompile. Move it to a constant, an environment variable, or a configuration file."
 rule:
-  pattern: '"https://api.$$$REST"'
-fix: ''
+  kind: interpreted_string_literal
+  regex: '^"https://api\.'
 ---
 id: go-no-duplicate-coverage-threshold
 language: go
 severity: warning
-message: Use config.DefaultTestCoverageTarget instead of defining a local coverage
-  threshold constant. Single source of truth prevents drift.
-note: 커버리지 임계값을 각 패키지에서 정의하면 값이 달라질 수 있습니다. config.DefaultTestCoverageTarget을 사용하여
-  단일 원천을 유지하세요.
+message: "Use a shared coverage-threshold constant instead of redefining the value locally. A single source of truth prevents drift across packages."
+note: "Duplicating a numeric quality threshold in more than one place lets the copies drift apart. Define it once and reference it."
 rule:
   pattern: const $NAME = 85.0
-fix: ''

--- a/.moai/astgrep-rules/security/crypto.yml
+++ b/.moai/astgrep-rules/security/crypto.yml
@@ -1,24 +1,19 @@
+# Weak-cryptography detection (CWE-327).
+#
+# Detects use of the MD5 hash constructor, which is unsuitable for any security
+# purpose (it is vulnerable to collision attacks). This is deliberately narrow:
+# it flags the constructor call, not incidental references, so a clean sample
+# using a strong hash produces zero findings.
+#
+# Languages not yet listed are equal-priority future additions.
 ---
 id: sec-weak-hash-md5
 language: go
 severity: error
-message: MD5는 보안 용도로 사용하기에 취약한 해시 알고리즘입니다. crypto/sha256 이상을 사용하세요.
-note: MD5는 충돌 공격에 취약합니다. 암호화 용도에는 SHA-256, SHA-512 또는 bcrypt(패스워드)를 사용하세요.
+message: "MD5 is unsuitable for security use. Use crypto/sha256 or stronger, or bcrypt/argon2 for password hashing."
+note: "MD5 is vulnerable to collision attacks and must not be used for integrity or authentication. Use SHA-256/SHA-512 for hashing, or a password-hashing function such as bcrypt or argon2 for passwords."
+metadata:
+  owasp: "A02:2021 - Cryptographic Failures"
+  cwe: "CWE-327"
 rule:
   pattern: md5.New()
-metadata:
-  owasp: A02:2021 - Cryptographic Failures
-  cwe: CWE-327
----
-id: sec-tls-insecure-skip-verify
-language: go
-severity: error
-message: 'InsecureSkipVerify: true는 TLS 인증서 검증을 비활성화합니다. 중간자 공격에 취약합니다.'
-note: 프로덕션 코드에서 InsecureSkipVerify를 절대 사용하지 마세요. 자체 서명 인증서가 필요하다면 custom RootCAs를
-  설정하세요.
-rule:
-  pattern: "&tls.Config{\n  $$$FIELDS,\n  InsecureSkipVerify: true,\n  $$$MORE,\n\
-    }\n"
-metadata:
-  owasp: A02:2021 - Cryptographic Failures
-  cwe: CWE-295

--- a/.moai/astgrep-rules/security/injection.yml
+++ b/.moai/astgrep-rules/security/injection.yml
@@ -1,37 +1,62 @@
+# Command-injection detection (CWE-78).
+#
+# Detects the canonical shell-execution constructs where an unvalidated value
+# can reach a shell interpreter: Go's exec.Command("sh", "-c", ...), Python's
+# subprocess shell=True / os.system, and Node's child_process.exec. Each rule
+# is scoped to the specific dangerous call so a benign, argument-list-based
+# invocation (which does not spawn a shell) is not flagged.
+#
+# Every language below carries the identical pattern-family with equal
+# opportunity. Languages not yet listed are equal-priority future additions.
 ---
-id: sec-sql-injection-fmt-sprintf
+id: sec-command-injection-shell
 language: go
 severity: error
-message: fmt.Sprintf()로 SQL 쿼리를 생성하면 SQL 인젝션 취약점이 발생합니다.
-note: 사용자 입력을 SQL 쿼리에 직접 삽입하지 마세요. 파라미터화된 쿼리(?, $1 등)를 사용하고 드라이버의 인수 전달 기능을 활용하세요.
-rule:
-  pattern: 'fmt.Sprintf("$$$SQL_PARTS %s $$$MORE", $USER_INPUT)
-
-    '
+message: "A shell command is built with exec.Command(\"sh\", \"-c\", ...). If any argument derives from external input, this is a command-injection risk."
+note: "Passing a value to sh -c lets shell metacharacters execute. Prefer exec.Command with an explicit argument list and no shell, and validate any external input against an allowlist."
 metadata:
-  owasp: A03:2021 - Injection
-  cwe: CWE-89
----
-id: sec-command-injection-exec-command
-language: go
-severity: error
-message: exec.Command에 사용자 입력이 직접 전달될 수 있습니다. 명령어 인젝션 위험이 있습니다.
-note: 사용자 입력을 exec.Command 인수로 전달할 때는 반드시 화이트리스트 검증을 수행하세요. shell 확장을 피하고 인수를 개별적으로
-  전달하세요.
+  owasp: "A03:2021 - Injection"
+  cwe: "CWE-78"
 rule:
   pattern: exec.Command("sh", "-c", $CMD)
-metadata:
-  owasp: A03:2021 - Injection
-  cwe: CWE-78
 ---
-id: sec-path-traversal-join-user-input
-language: go
+id: sec-command-injection-shell
+language: python
 severity: error
-message: filepath.Join에 사용자 입력이 직접 사용됩니다. 경로 순회 공격이 가능합니다.
-note: filepath.Clean()과 filepath.Abs()를 사용하고, 결과 경로가 허용된 베이스 디렉토리 내에 있는지 strings.HasPrefix로
-  검증하세요.
-rule:
-  pattern: filepath.Join($BASE, $USER_INPUT)
+message: "A shell command is executed with shell=True or os.system. If any argument derives from external input, this is a command-injection risk."
+note: "shell=True and os.system route the command through a shell, so metacharacters execute. Pass an argument list without shell=True and validate any external input against an allowlist."
 metadata:
-  owasp: A03:2021 - Injection
-  cwe: CWE-22
+  owasp: "A03:2021 - Injection"
+  cwe: "CWE-78"
+rule:
+  any:
+    - pattern: subprocess.call($CMD, shell=True)
+    - pattern: subprocess.run($CMD, shell=True)
+    - pattern: subprocess.Popen($CMD, shell=True)
+    - pattern: os.system($CMD)
+---
+id: sec-command-injection-exec
+language: javascript
+severity: error
+message: "A shell command is executed with child_process.exec. If any argument derives from external input, this is a command-injection risk."
+note: "child_process.exec runs the command through a shell, so metacharacters execute. Prefer child_process.execFile or spawn with an explicit argument list, and validate any external input against an allowlist."
+metadata:
+  owasp: "A03:2021 - Injection"
+  cwe: "CWE-78"
+rule:
+  any:
+    - pattern: child_process.exec($CMD)
+    - pattern: cp.exec($CMD)
+---
+id: sec-command-injection-exec
+language: typescript
+severity: error
+message: "A shell command is executed with child_process.exec. If any argument derives from external input, this is a command-injection risk."
+note: "child_process.exec runs the command through a shell, so metacharacters execute. Prefer child_process.execFile or spawn with an explicit argument list, and validate any external input against an allowlist."
+metadata:
+  owasp: "A03:2021 - Injection"
+  cwe: "CWE-78"
+rule:
+  any:
+    - pattern: child_process.exec($CMD)
+    - pattern: cp.exec($CMD)

--- a/.moai/astgrep-rules/sgconfig.yml
+++ b/.moai/astgrep-rules/sgconfig.yml
@@ -1,19 +1,14 @@
-# ast-grep 프로젝트 설정 파일 (config-mode SSOT for `sg scan --config`)
+# ast-grep project configuration for the MoAI curated ruleset.
 #
-# ruleDirs는 이 파일 위치 기준 상대경로로 해석된다. 여기에는 실제 로드 가능한
-# (valid rule) 디렉터리만 나열한다 — 나머지 언어 디렉터리(cpp/csharp/... 데모
-# 스캐폴드·빈 stub)는 invalid rule로 config-mode 전체 스캔을 실패시키므로
-# 16-언어 룰셋 정식화 백로그가 정리하기 전까지 제외한다.
+# ruleDirs lists ONLY directories that ship at least one production-vetted rule.
+# Every rule under these directories has been verified against a positive fixture
+# (it matches its intended construct) and a negative fixture (a clean sample
+# produces zero findings).
 #
-# ast-grep config-mode globs limitation (observed on ast-grep 0.40.5, 2026-08-11):
-# ast-grep does NOT support a `globs:` exclusion field in sgconfig.yml
-# config-mode — adding it silently breaks the scan (0 matches for every rule,
-# including non-excluded files). Path exclusion for worktree duplicates,
-# vendor/, *_test.go, and testdata/ is therefore applied at the gate layer
-# (internal/hook/quality/astgrep_gate.go filterExcludedPaths), after the
-# scanner returns findings. When a future ast-grep release adds config-mode
-# globs support, these exclusions MAY migrate back here; until then, do NOT
-# add a `globs:` key to this file.
+# Language coverage is intentionally partial and treated with equal opportunity:
+# a language that does not yet appear in a rule directory is an equal-priority
+# future addition, never an unsupported one. New languages are added by shipping
+# a vetted rule for that language under the relevant directory.
 ruleDirs:
   - go
   - security


### PR DESCRIPTION
Clears the last of the working-tree residue in the maintainer checkout so `scripts/release.sh` — which dies on any dirty tree — can run for v3.1.0. Three unrelated pieces, all local-checkout only.

## 1. Ruleset normalisation, recovered

#1557 moved the ast-grep rules with `git mv` from HEAD. That carried the *committed* content and silently left behind the uncommitted edits sitting on top of five of them. Recovered here:

- rule messages rewritten from Korean to English
- rationale comments added to each rule
- `sgconfig.yml` prose reframed so a language absent from `ruleDirs` reads as an equal-priority future addition rather than an unsupported one

Verified after restoring, not assumed:

```
$ moai ast-grep --rules-dir .moai/astgrep-rules
internal/harness/routing/pending.go:252: [go-error-not-wrapped] …
```

## 2. Three files that were only ever untracked

| File | Why it belongs tracked |
|---|---|
| `.git_hooks/pre-commit` | `.git_hooks/pre-push` is already tracked |
| `.claude/skills/moai-domain-html-report/references/craft-fundamentals.md` | sits beside already-tracked `references/fonts.md` and the mode templates |
| `.claude/skills/moai-meta-harness/references/hierarchical-scoring.md` | sits beside already-tracked references in the same directory |

Tracking is what makes them survivable. `moai update` deletes from these directories; a tracked file comes back with `git restore`, an untracked one is simply gone — which is exactly how twelve local-only files were lost on 2026-08-15.

**Caveat recorded, not resolved**: `hierarchical-scoring.md` overlaps `hrn-003-hierarchical-scoring.md`, which is tracked and has *different* content (SHA-256 compared, not eyeballed). Whether the new file supersedes the old is not mine to decide, so both are kept and the question is left visible for whoever wrote them.

## 3. Browser output ignored

`e2e/screenshots/`, `e2e/web/`, `.playwright-mcp/` and stray root PNGs had reached **21 MB**, all re-derivable by re-running the suite, all one `git add -A` away from a commit nobody intended.

The patterns are deliberately narrow: `e2e/cli/*.sh` and curated fixtures stay tracked, and `/*.png` is root-anchored (0 tracked PNGs at the root — checked).

## What is deliberately NOT done

`.moai/reports/` is **not** blanket-ignored. 48 files under it are already tracked, HTML included, so reports in this repository are a curated corpus rather than build output. Widening the pattern would have contradicted that convention — and would not have untracked anything, since ignore rules do not apply to tracked files.

The four report entries still showing in `git status` (`backlog/`, `release/`, `webredesign/`, two `diagram-*.html`) are left for their author to keep or discard. They do not block the release: the remaining decision is whether they join the tracked corpus, not whether they are junk.

No Go code changes.

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for accessible HTML reports, layout, visual design, and user-facing copy.
  * Documented hierarchical scoring, rubric validation, citation requirements, and fallback behavior.
  * Updated workflow naming and clarified security rule configuration.

* **Bug Fixes**
  * Improved detection of hardcoded API URLs, weak hashing, and shell command injection across multiple languages.
  * Removed an outdated TLS security check.

* **Developer Experience**
  * Added pre-commit validation for formatting, static analysis, and project gates.
  * Expanded ignore rules for generated screenshots and web artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->