### PR TITLE
fix(install): resolve the latest version without the rate-limited REST API

### DIFF
--- a/docs-site/static/install.sh
+++ b/docs-site/static/install.sh
@@ -97,8 +97,13 @@ get_latest_version() {
             --connect-timeout 5 --max-time 10 "$latest_url" 2>/dev/null || true)
     elif command -v wget &> /dev/null; then
         # wget reports the redirect chain on stderr; the last Location wins.
+        # Matched case-insensitively on the field rather than by a fixed-indent
+        # prefix: HTTP header names are case-insensitive, wget's -S indentation
+        # is not contractual, and a CRLF response leaves a trailing \r glued to
+        # the URL that would otherwise travel into the version string.
         resolved=$(wget --max-redirect=10 --spider -S --timeout=5 --tries=1 "$latest_url" 2>&1 \
-            | awk '/^  Location: /{print $2}' | tail -n 1 || true)
+            | awk 'tolower($1) == "location:" { u = $2; sub(/\r$/, "", u); print u }' \
+            | tail -n 1 || true)
         [ -n "$resolved" ] || resolved="$latest_url"
     else
         print_error "Neither curl nor wget found. Please install one of them."

--- a/docs-site/static/install.sh
+++ b/docs-site/static/install.sh
@@ -90,11 +90,14 @@ get_latest_version() {
     local latest_url="https://github.com/modu-ai/moai-adk/releases/latest"
     local resolved=""
 
+    # Bounded: a lookup that hangs is indistinguishable to the user from an
+    # installer that has crashed, and this step only reads a redirect header.
     if command -v curl &> /dev/null; then
-        resolved=$(curl -fsSLI -o /dev/null -w '%{url_effective}' "$latest_url" 2>/dev/null || true)
+        resolved=$(curl -fsSLI -o /dev/null -w '%{url_effective}' \
+            --connect-timeout 5 --max-time 10 "$latest_url" 2>/dev/null || true)
     elif command -v wget &> /dev/null; then
         # wget reports the redirect chain on stderr; the last Location wins.
-        resolved=$(wget --max-redirect=10 --spider -S "$latest_url" 2>&1 \
+        resolved=$(wget --max-redirect=10 --spider -S --timeout=5 --tries=1 "$latest_url" 2>&1 \
             | awk '/^  Location: /{print $2}' | tail -n 1 || true)
         [ -n "$resolved" ] || resolved="$latest_url"
     else
@@ -113,7 +116,7 @@ get_latest_version() {
     if [ -z "$VERSION" ]; then
         print_error "Could not determine the latest version from GitHub"
         print_info "GitHub may be unreachable from this network. You can:"
-        echo "  1. Install a specific version: $0 3.1.0"
+        echo "  1. Install a specific version: $0 --version 3.1.0"
         echo "  2. Install from source: go install github.com/modu-ai/moai-adk/cmd/moai@latest"
         exit 1
     fi

--- a/docs-site/static/install.sh
+++ b/docs-site/static/install.sh
@@ -70,23 +70,50 @@ detect_platform() {
 }
 
 # Get latest Go edition version from GitHub
+#
+# Resolved from the /releases/latest redirect rather than the REST API. Two
+# reasons, both of which bit real installs:
+#
+#   1. api.github.com allows 60 unauthenticated requests per hour per IP. Behind
+#      a shared address — an office, a CI runner, a developer who has been
+#      working with `gh` — that budget is routinely spent, and the API then
+#      answers with a JSON error carrying no tag_name. The old code read the
+#      empty result as "no releases exist" and told the user the project had
+#      never shipped. The redirect is not part of the API and is not rate
+#      limited.
+#
+#   2. The old code asked for /releases (the list) and took the first entry,
+#      which is the most recently *created* release — a draft or a release
+#      candidate, if one exists. /releases/latest is the endpoint that actually
+#      means "latest stable": GitHub excludes drafts and prereleases from it.
 get_latest_version() {
-    local version_url="https://api.github.com/repos/modu-ai/moai-adk/releases"
+    local latest_url="https://github.com/modu-ai/moai-adk/releases/latest"
+    local resolved=""
 
     if command -v curl &> /dev/null; then
-        # Try go-v* tags first, then fall back to v* tags
-        VERSION=$(curl -s "$version_url" | grep -o '"tag_name":\s*"[^"]*"' | head -n 1 | sed -E 's/.*"([^"]+)".*/\1/' | sed 's/^go-//' | sed 's/^v//')
+        resolved=$(curl -fsSLI -o /dev/null -w '%{url_effective}' "$latest_url" 2>/dev/null || true)
     elif command -v wget &> /dev/null; then
-        VERSION=$(wget -qO- "$version_url" | grep -o '"tag_name":\s*"[^"]*"' | head -n 1 | sed -E 's/.*"([^"]+)".*/\1/' | sed 's/^go-//' | sed 's/^v//')
+        # wget reports the redirect chain on stderr; the last Location wins.
+        resolved=$(wget --max-redirect=10 --spider -S "$latest_url" 2>&1 \
+            | awk '/^  Location: /{print $2}' | tail -n 1 || true)
+        [ -n "$resolved" ] || resolved="$latest_url"
     else
         print_error "Neither curl nor wget found. Please install one of them."
         exit 1
     fi
 
+    # .../releases/tag/v3.1.0 -> 3.1.0
+    case "$resolved" in
+        */tag/*) VERSION="${resolved##*/tag/}" ;;
+        *)       VERSION="" ;;
+    esac
+    VERSION="${VERSION#go-}"
+    VERSION="${VERSION#v}"
+
     if [ -z "$VERSION" ]; then
-        print_error "Failed to fetch latest Go edition version from GitHub"
-        print_info "No releases found. You can:"
-        echo "  1. Install a specific version: $0 --version 2.0.0"
+        print_error "Could not determine the latest version from GitHub"
+        print_info "GitHub may be unreachable from this network. You can:"
+        echo "  1. Install a specific version: $0 3.1.0"
         echo "  2. Install from source: go install github.com/modu-ai/moai-adk/cmd/moai@latest"
         exit 1
     fi

--- a/install.sh
+++ b/install.sh
@@ -97,8 +97,13 @@ get_latest_version() {
             --connect-timeout 5 --max-time 10 "$latest_url" 2>/dev/null || true)
     elif command -v wget &> /dev/null; then
         # wget reports the redirect chain on stderr; the last Location wins.
+        # Matched case-insensitively on the field rather than by a fixed-indent
+        # prefix: HTTP header names are case-insensitive, wget's -S indentation
+        # is not contractual, and a CRLF response leaves a trailing \r glued to
+        # the URL that would otherwise travel into the version string.
         resolved=$(wget --max-redirect=10 --spider -S --timeout=5 --tries=1 "$latest_url" 2>&1 \
-            | awk '/^  Location: /{print $2}' | tail -n 1 || true)
+            | awk 'tolower($1) == "location:" { u = $2; sub(/\r$/, "", u); print u }' \
+            | tail -n 1 || true)
         [ -n "$resolved" ] || resolved="$latest_url"
     else
         print_error "Neither curl nor wget found. Please install one of them."

--- a/install.sh
+++ b/install.sh
@@ -90,11 +90,14 @@ get_latest_version() {
     local latest_url="https://github.com/modu-ai/moai-adk/releases/latest"
     local resolved=""
 
+    # Bounded: a lookup that hangs is indistinguishable to the user from an
+    # installer that has crashed, and this step only reads a redirect header.
     if command -v curl &> /dev/null; then
-        resolved=$(curl -fsSLI -o /dev/null -w '%{url_effective}' "$latest_url" 2>/dev/null || true)
+        resolved=$(curl -fsSLI -o /dev/null -w '%{url_effective}' \
+            --connect-timeout 5 --max-time 10 "$latest_url" 2>/dev/null || true)
     elif command -v wget &> /dev/null; then
         # wget reports the redirect chain on stderr; the last Location wins.
-        resolved=$(wget --max-redirect=10 --spider -S "$latest_url" 2>&1 \
+        resolved=$(wget --max-redirect=10 --spider -S --timeout=5 --tries=1 "$latest_url" 2>&1 \
             | awk '/^  Location: /{print $2}' | tail -n 1 || true)
         [ -n "$resolved" ] || resolved="$latest_url"
     else
@@ -113,7 +116,7 @@ get_latest_version() {
     if [ -z "$VERSION" ]; then
         print_error "Could not determine the latest version from GitHub"
         print_info "GitHub may be unreachable from this network. You can:"
-        echo "  1. Install a specific version: $0 3.1.0"
+        echo "  1. Install a specific version: $0 --version 3.1.0"
         echo "  2. Install from source: go install github.com/modu-ai/moai-adk/cmd/moai@latest"
         exit 1
     fi

--- a/install.sh
+++ b/install.sh
@@ -70,23 +70,50 @@ detect_platform() {
 }
 
 # Get latest Go edition version from GitHub
+#
+# Resolved from the /releases/latest redirect rather than the REST API. Two
+# reasons, both of which bit real installs:
+#
+#   1. api.github.com allows 60 unauthenticated requests per hour per IP. Behind
+#      a shared address — an office, a CI runner, a developer who has been
+#      working with `gh` — that budget is routinely spent, and the API then
+#      answers with a JSON error carrying no tag_name. The old code read the
+#      empty result as "no releases exist" and told the user the project had
+#      never shipped. The redirect is not part of the API and is not rate
+#      limited.
+#
+#   2. The old code asked for /releases (the list) and took the first entry,
+#      which is the most recently *created* release — a draft or a release
+#      candidate, if one exists. /releases/latest is the endpoint that actually
+#      means "latest stable": GitHub excludes drafts and prereleases from it.
 get_latest_version() {
-    local version_url="https://api.github.com/repos/modu-ai/moai-adk/releases"
+    local latest_url="https://github.com/modu-ai/moai-adk/releases/latest"
+    local resolved=""
 
     if command -v curl &> /dev/null; then
-        # Try go-v* tags first, then fall back to v* tags
-        VERSION=$(curl -s "$version_url" | grep -o '"tag_name":\s*"[^"]*"' | head -n 1 | sed -E 's/.*"([^"]+)".*/\1/' | sed 's/^go-//' | sed 's/^v//')
+        resolved=$(curl -fsSLI -o /dev/null -w '%{url_effective}' "$latest_url" 2>/dev/null || true)
     elif command -v wget &> /dev/null; then
-        VERSION=$(wget -qO- "$version_url" | grep -o '"tag_name":\s*"[^"]*"' | head -n 1 | sed -E 's/.*"([^"]+)".*/\1/' | sed 's/^go-//' | sed 's/^v//')
+        # wget reports the redirect chain on stderr; the last Location wins.
+        resolved=$(wget --max-redirect=10 --spider -S "$latest_url" 2>&1 \
+            | awk '/^  Location: /{print $2}' | tail -n 1 || true)
+        [ -n "$resolved" ] || resolved="$latest_url"
     else
         print_error "Neither curl nor wget found. Please install one of them."
         exit 1
     fi
 
+    # .../releases/tag/v3.1.0 -> 3.1.0
+    case "$resolved" in
+        */tag/*) VERSION="${resolved##*/tag/}" ;;
+        *)       VERSION="" ;;
+    esac
+    VERSION="${VERSION#go-}"
+    VERSION="${VERSION#v}"
+
     if [ -z "$VERSION" ]; then
-        print_error "Failed to fetch latest Go edition version from GitHub"
-        print_info "No releases found. You can:"
-        echo "  1. Install a specific version: $0 --version 2.0.0"
+        print_error "Could not determine the latest version from GitHub"
+        print_info "GitHub may be unreachable from this network. You can:"
+        echo "  1. Install a specific version: $0 3.1.0"
         echo "  2. Install from source: go install github.com/modu-ai/moai-adk/cmd/moai@latest"
         exit 1
     fi


### PR DESCRIPTION
Fixes the one-line installer at `https://adk.mo.ai.kr/install.sh` reporting that no release exists, minutes after v3.1.0 shipped with all six platform archives attached.

## Two defects, both observed rather than reasoned about

**Rate limiting.** The installer asked `api.github.com/repos/modu-ai/moai-adk/releases` without authentication. That budget is 60 requests per hour per IP — routinely spent behind an office address, a CI runner, or a developer who has been driving `gh`. On exhaustion the API returns a JSON error carrying no `tag_name`, so `VERSION` came back empty and the script printed:

```
[ERROR] Failed to fetch latest Go edition version from GitHub
[INFO] No releases found.
```

Measured at the time of failure:

```
$ curl -s https://api.github.com/rate_limit
"core": { "limit": 60, "remaining": 0, "used": 60 }
```

The release was fine. The installer simply could not see it, and then said something it had no way of knowing.

**Wrong endpoint.** `/releases` returns releases in creation order, so `head -n 1` picks the most recently *created* release — a draft or a release candidate if one exists. That was not hypothetical: an untagged draft holding **v2.2.0** archives was sitting in this repository's release list while that code was live.

## The fix

Resolve the `/releases/latest` redirect instead:

```
https://github.com/modu-ai/moai-adk/releases/latest  ->  .../releases/tag/v3.1.0
```

It is not part of the REST API and carries no rate limit, and GitHub excludes drafts and prereleases from it — so it means *latest stable*, not *newest row*. The `curl` branch uses `-I` with `%{url_effective}`; the `wget` branch reads the final `Location` from the redirect chain.

## Verification

Run against the **failing** condition, not a healthy one — the IP's quota still exhausted:

```
[SUCCESS] Latest Go edition version: 3.1.0
VERSION=3.1.0
```

The old code exits with "No releases found" under exactly these conditions.

The archives were also confirmed reachable end to end: all six platform URLs return 200, and the darwin_arm64 archive downloads, extracts, and reports `moai-adk 3.1.0`.

## Also corrected

The error path no longer claims that no release exists — a statement the installer is not in a position to make. It now reports that GitHub could not be reached and offers a pinned-version install.

## Scope

`install.sh` and `docs-site/static/install.sh` were byte-identical before this change and remain so; the docs-site copy is what the site serves. Shell only — no Go code.

Note for the deploy path: this project cannot be deployed with `vercel --prod` from the CLI. Hugo reads per-page git metadata, and the CLI archive upload carries no `.git`, so the build fails with `failed to load Git data`. It has to land through the git integration, which is why this is a PR rather than a direct push.

🗿 MoAI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the installation script’s ability to identify the latest release.
  * Added support for environments using either `curl` or `wget`.
  * Added bounded request handling to prevent stalled version checks.
  * Improved version parsing and error reporting when the latest release cannot be determined.
  * Preserved existing guidance for completing installation when automatic detection fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->