### PR TITLE
docs(readme): correct three shipped-capability claims across all four locales

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -214,8 +214,6 @@ plan → run → sync。Tier S/M/Lサイズ分類が検証深度とPRルーテ�
 
 **worktree隔離**. SPEC ごとに独立した作業ツリーを用意する。`moai cc -w <名前>` で入り、`--spawn` を付けると現在のセッションを保ったまま新しいウィンドウで開く。
 
-**トレンドMCPツール**. 配布用 `.mcp.json` テンプレートは、シークレット不要で動く3つのサーバー(`context7` ライブラリドキュメント · `chrome-devtools` ブラウザ自動化 · `playwright` エンドツーエンドテスト)を既定で同梱し、`moai mcp add|remove|list` CLI で追加サーバー(Semgrep, GitHub, Postgres, Sentry, Codecov)をオプトインする際はリテラルのシークレットではなく `${VAR}` 環境変数参照トークンを使う。オプトインレシピの一覧は `.moai/docs/mcp-recipes.md` にある。
-
 ---
 
 ## インフラが3つすべてを支える
@@ -287,7 +285,7 @@ claude        # launch Claude Code inside the project
 
 ## リファレンス
 
-### /moai スラッシュコマンド（15）
+### /moai スラッシュコマンド（16）
 
 | サブコマンド | 役割 |
 |------------|------|
@@ -296,7 +294,7 @@ claude        # launch Claude Code inside the project
 | `goal` / `loop` / `fix` | 宣言的 goal ループ · 反復修正 · シングルパス修正 |
 | `review` / `gate` / `clean` | コードレビュー（`--deep`でマルチエージェントの敵対的脆弱性スキャン） · pre-commit 品質ゲート · デッドコード削除 |
 | `mx` / `codemaps` / `feedback` | @MX アノテーション · アーキテクチャ docs · GitHub issue 報告 |
-| `e2e` | マルチプラットフォーム E2E テスト（Web/モバイル/デスクトップ、CLI 優先） |
+| `e2e` / `todo` | マルチプラットフォーム E2E テスト（Web/モバイル/デスクトップ、CLI 優先） · カンバンのバックログキュー |
 | *(自然言語)* | Analyze-First ルーティング: 自律的な plan → run → sync パイプライン |
 
 > **退役した 4 サブコマンド**: `design` · `brain` · `coverage` · `security`（SPEC-SUBCOMMAND-RETIRE-001、status: completed）。`security` は `moai-ref-owasp-checklist` + `moai-ref-llm-security` スキルに置き換わり、`e2e` は E2E-REVIVAL で復活して現在アクティブである。
@@ -321,7 +319,7 @@ claude        # launch Claude Code inside the project
 | `moai preference <list\|decay-scan\|toggle>` | 決定メモリ管理 |
 | `moai web` | Web Console — 5 画面（Overview · Kanban · Specs · Monitor · Settings）、10 タブ設定 |
 
-> 全 36 コマンド: [CLI Reference](https://adk.mo.ai.kr/ja/cli-reference)
+> コマンド全一覧: [CLI Reference](https://adk.mo.ai.kr/ja/cli-reference)
 
 ### MCP サーバー
 
@@ -395,7 +393,7 @@ flowchart TD
 | CWD 衝突解決 | `(worktree_path, session_id)` の組が再利用パスを区別 |
 | 深さ上限（depth ceiling） | ネスト複雑度を制限 |
 
-> **現在の状態**: Origin-Trail Chain は **Phase 1**（`internal/chain/` — append-only ストア層）です。`--kanban`/`-k` ランチャースイッチ、`moai chain` CLI、マルチセッションボードカラムは後続フェーズで計画されています。
+> **現在利用可能**: `moai cc -k` / `moai glm -k` がリードと4つの同伴セッションを起動し、`moai chain <status|lineage|back|list|prune>` が系譜を読み、`moai todo <add|list|next|done>` が `backlog` カラムを操作します。起動手順は上の「v3.1 の新機能 — カンバンモード」節にあります。
 
 > 詳細: [カンバンモードガイド](https://adk.mo.ai.kr/ja/advanced/kanban-mode)
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -193,7 +193,7 @@ claude        # 또는 moai cc — 프로젝트 안에서 Claude Code 실행
 
 ### 단일 진입점 `/moai`
 
-자연어와 15개 서브커맨드가 같은 파이프라인으로 들어간다. `/moai plan`, `/moai run`, `/moai sync`가 SPEC 파이프라인의 주축이고, `goal`, `loop`, `fix`, `review`, `gate`, `clean`, `codemaps`, `e2e`, `mx`, `feedback`, `project`, `harness`가 주변을 채운다.
+자연어와 16개 서브커맨드가 같은 파이프라인으로 들어간다. `/moai plan`, `/moai run`, `/moai sync`가 SPEC 파이프라인의 주축이고, `goal`, `loop`, `fix`, `review`, `gate`, `clean`, `codemaps`, `e2e`, `mx`, `feedback`, `project`, `harness`, `todo`가 주변을 채운다.
 
 ### MCP 서버
 
@@ -230,7 +230,7 @@ SPEC마다 독립된 작업 트리를 준다. `moai cc -w <이름>`으로 진입
 | CWD 충돌 해결 | `(worktree_path, session_id)` 쌍으로 재사용 경로를 구분 |
 | 깊이 상한 | 중첩 복잡도를 제한 |
 
-> **현재 상태**: Origin-Trail Chain은 **Phase 1**(`internal/chain/` — append-only 저장소 계층)에 머물러 있습니다. `--kanban`/`-k` 런처 스위치, `moai chain` CLI, 다중 세션 보드 컬럼은 후속 phase 예정입니다.
+> **지금 쓸 수 있습니다**: `moai cc -k` / `moai glm -k`로 리드와 네 개의 동반 세션을 띄우고, `moai chain <status|lineage|back|list|prune>`으로 계보를 읽고, `moai todo <add|list|next|done>`으로 `backlog` 컬럼을 운영합니다. 실행 순서는 위 "v3.1 새 기능 — 칸반 모드" 절에 있습니다.
 
 > 자세히: [칸반 모드 가이드](https://adk.mo.ai.kr/ko/advanced/kanban-mode)
 

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ Natural language works too. `/moai "fix the login bug"` triggers intent analysis
 
 ## Reference
 
-### /moai Slash Commands (15)
+### /moai Slash Commands (16)
 
 | Subcommand | Role |
 |------------|------|
@@ -298,7 +298,7 @@ Natural language works too. `/moai "fix the login bug"` triggers intent analysis
 | `goal` / `loop` / `fix` | Declarative goal loops · iterative fixes · single-pass fixes |
 | `review` / `gate` / `clean` | Code review (`--deep` for multi-agent adversarial vulnerability scan) · pre-commit quality gates · dead code removal |
 | `mx` / `codemaps` / `feedback` | @MX annotations · architecture docs · GitHub issue reporting |
-| `e2e` | Multi-platform E2E tests (web/mobile/desktop, CLI-first) |
+| `e2e` / `todo` | Multi-platform E2E tests (web/mobile/desktop, CLI-first) · Kanban backlog queue |
 | *(natural language)* | Analyze-First routing: autonomous plan → run → sync pipeline |
 
 > **4 Retired Subcommands**: `design` · `brain` · `coverage` · `security` (SPEC-SUBCOMMAND-RETIRE-001, status: completed). `security` was replaced by the `moai-ref-owasp-checklist` + `moai-ref-llm-security` skills; `e2e` was revived by E2E-REVIVAL and is currently active.
@@ -323,7 +323,7 @@ Natural language works too. `/moai "fix the login bug"` triggers intent analysis
 | `moai preference <list\|decay-scan\|toggle>` | Decision memory management |
 | `moai web` | Web Console — 5 screens (Overview · Kanban · Specs · Monitor · Settings), 10-tab settings |
 
-> Full 36 commands: [CLI Reference](https://adk.mo.ai.kr/en/cli-reference)
+> Full command list: [CLI Reference](https://adk.mo.ai.kr/en/cli-reference)
 
 ### MCP Server
 
@@ -397,7 +397,7 @@ flowchart TD
 | CWD-collision resolution | `(worktree_path, session_id)` pair disambiguates reused paths |
 | Depth ceiling | Caps nesting complexity |
 
-> **Current status**: Origin-Trail Chain is at **Phase 1** (`internal/chain/` — append-only store layer). The `--kanban`/`-k` launcher switch, `moai chain` CLI, and multi-session board columns are planned for later phases.
+> **Available now**: `moai cc -k` / `moai glm -k` launch the lead and the four companion sessions, `moai chain <status|lineage|back|list|prune>` reads the lineage, and `moai todo <add|list|next|done>` operates the `backlog` column. The launch sequence is in the "New in v3.1 — Kanban Mode" section above.
 
 > Details: [Kanban Mode Guide](https://adk.mo.ai.kr/en/advanced/kanban-mode)
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -220,8 +220,6 @@ plan → run → sync。Tier S/M/L 大小分类决定验证深度和 PR 路由�
 
 **worktree 隔离**. 为每个 SPEC 准备独立的工作树。用 `moai cc -w <名称>` 进入，加上 `--spawn` 则在保留当前会话的同时于新窗口中打开。
 
-**趋势 MCP 工具**. 分发的 `.mcp.json` 模板默认内置三个无需密钥即可运行的服务器(`context7` 库文档 · `chrome-devtools` 浏览器自动化 · `playwright` 端到端测试)，使用 `moai mcp add|remove|list` CLI 添加可选服务器(Semgrep、GitHub、Postgres、Sentry、Codecov)时使用 `${VAR}` 环境变量引用令牌而非字面密钥。完整的可选配方见 `.moai/docs/mcp-recipes.md`。
-
 ---
 
 ## 基础设施支撑这三者
@@ -293,7 +291,7 @@ claude        # launch Claude Code inside the project
 
 ## 参考
 
-### /moai 斜杠命令（15 个）
+### /moai 斜杠命令（16 个）
 
 | 子命令 | 职责 |
 |------------|------|
@@ -302,7 +300,7 @@ claude        # launch Claude Code inside the project
 | `goal` / `loop` / `fix` | 声明式 goal 循环 · 迭代修复 · 单次修复 |
 | `review` / `gate` / `clean` | 代码审查（`--deep` 多智能体对抗式漏洞扫描） · pre-commit 质量门控 · 死代码移除 |
 | `mx` / `codemaps` / `feedback` | @MX 注解 · 架构文档 · GitHub issue 报告 |
-| `e2e` | 多平台 E2E 测试（Web/移动/桌面，CLI 优先） |
+| `e2e` / `todo` | 多平台 E2E 测试（Web/移动/桌面，CLI 优先） · 看板 backlog 队列 |
 | *（自然语言）* | Analyze-First 路由：自主 plan → run → sync 流水线 |
 
 > **已退役（Retired）的 4 个子命令**：`design` · `brain` · `coverage` · `security`（SPEC-SUBCOMMAND-RETIRE-001，status: completed）。`security` 由 `moai-ref-owasp-checklist` + `moai-ref-llm-security` 技能替代，`e2e` 经 E2E-REVIVAL 复活为现役。
@@ -327,7 +325,7 @@ claude        # launch Claude Code inside the project
 | `moai preference <list\|decay-scan\|toggle>` | 决策记忆管理 |
 | `moai web` | Web 控制台 —— 5 个页面（Overview · Kanban · Specs · Monitor · Settings）、10 个设置标签 |
 
-> 全部 36 个命令：[CLI Reference](https://adk.mo.ai.kr/zh/cli-reference)
+> 完整命令列表：[CLI Reference](https://adk.mo.ai.kr/zh/cli-reference)
 
 ### MCP 服务器
 
@@ -401,7 +399,7 @@ flowchart TD
 | CWD 冲突解决 | `(worktree_path, session_id)` 对消除复用路径的歧义 |
 | 深度上限 | 限制嵌套复杂度 |
 
-> **当前状态**：Origin-Trail Chain 处于 **Phase 1**（`internal/chain/` — append-only 存储层）。`--kanban`/`-k` 启动器开关、`moai chain` CLI 和多会话看板列计划在后续阶段实现。
+> **现已可用**：`moai cc -k` / `moai glm -k` 启动主导会话与四个伴随会话，`moai chain <status|lineage|back|list|prune>` 读取谱系，`moai todo <add|list|next|done>` 操作 `backlog` 列。启动顺序见上文“v3.1 新功能 —— 看板模式”一节。
 
 > 详情：[看板模式指南](https://adk.mo.ai.kr/zh/advanced/kanban-mode)
 


### PR DESCRIPTION
The card said "8 README defects confirmed" but listed only one. The other seven were not recoverable from `.moai/reports/backlog/`, `.moai/reports/`, the kanban backlog queue, or the last 15 merged PRs — so this PR carries what an independent audit of the four files actually measured, and the report back to the lead classifies each finding rather than padding to eight.

## Fixed (4 locales, this PR)

**1. Kanban "later phases" self-contradiction** — the named defect.

`README.md:400` and its three counterparts said the `--kanban`/`-k` launcher switch, the `moai chain` CLI, and the multi-session board columns were "planned for later phases". The same file, at line 62-103, documents the launch sequence for all three. Verified against the installed `3.1.0` binary (`ed04e40e6`):

- `moai cc --help` → `-k, --kanban [SPEC-ID]`, plus `-k --name <role>-<run-id>` for the four companion roles
- `moai chain --help` → `status`, `lineage`, `back`, `list`, `prune`
- `moai todo --help` → `add`, `list`, `done`, `next`

The linked docs-site guide (`advanced/kanban-mode.md`) was already rewritten and carries no such claim, so the README was the last place holding it.

**2. Slash-command count and the missing `todo` row.** The table said 15 and omitted `todo` — while the same README uses `/moai todo` in its v3.1 section and links its docs page. There are 16; `todo` is listed now.

**3. "Full 36 commands".** `moai --help` reports 47 entries; 45 excluding the `help` and `completion` cobra built-ins. Dropped the count rather than substituting a number with the same failure mode.

**4. Stale MCP paragraph carried only by ja and zh.** `README.ja.md:217` and `README.zh.md:223` claimed the distributed `.mcp.json` bundles three third-party servers by default and opts into five more. English (canonical) had already dropped this. `internal/template/templates/.mcp.json` contains exactly one entry (`moai`), which is what the MCP Server section of those same two files says four screens further down.

## Found, not fixed — reported to the lead instead

- **`moai mcp add|remove|list` is unreachable.** All four locales document it as the way to activate the four disabled MCP entries, and add that "users never hand-edit `.mcp.json`". `newMCPCmd()` exists at `internal/cli/mcp.go:60` but is referenced only by its own test — it is never registered on the root command, and `moai mcp` errors with `Unknown command`. That is a one-line Go fix, not a docs fix; rewriting the README to describe hand-editing would document the bug as the feature.
- **`README.ko.md` is a structural fork** — 11 H2 against 14, and an entirely different section set. Pre-existing and unchanged here (`origin/main` measures the same 11 vs 14), so this PR is parity-neutral.
- **ja's Cost section diverges from en/zh** — an extra intro H3, no `DeepSWE Benchmark` heading, and Verification Economy / Budget Defense split into two H3s.
- **`kanban_chain` reads `plan → run → verify → sync`** in the reference section while the board columns are `plan → run → review → sync`. The CLI help itself carries both, so the README is not wrong relative to the code — the inconsistency is upstream.

## Verification

- URL blacklist grep over the four READMEs → no matches
- `grep -c '^## '` → en/ja/zh 14, ko 11 — identical to `origin/main`, so unchanged by this PR
- docs-site untouched, so the hugo build gate is unaffected
- No template mirror: the READMEs are repo-root only, absent from `internal/template/templates/`

🗿 MoAI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README files across supported languages to reflect 16 `/moai` commands.
  * Added documentation for the `todo` Kanban backlog command and revived `e2e` command.
  * Clarified that Kanban Mode is available, including launch, workflow, and backlog operations.
  * Removed outdated trend tool references and fixed command-count descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->