### PR TITLE
docs(readme): say the companion sessions are launched by hand

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -393,7 +393,7 @@ flowchart TD
 | CWD 衝突解決 | `(worktree_path, session_id)` の組が再利用パスを区別 |
 | 深さ上限（depth ceiling） | ネスト複雑度を制限 |
 
-> **現在利用可能**: `moai cc -k` / `moai glm -k` がリードと4つの同伴セッションを起動し、`moai chain <status|lineage|back|list|prune>` が系譜を読み、`moai todo <add|list|next|done>` が `backlog` カラムを操作します。起動手順は上の「v3.1 の新機能 — カンバンモード」節にあります。
+> **現在利用可能**: `moai cc -k`（または `moai glm -k`）がリードを起動し、`-k --name <role>-<run-id>` で同伴セッションを1つずつ参加させます — ターミナルごとに1つ、手で起動します。`moai chain <status|lineage|back|list|prune>` が系譜を読み、`moai todo <add|list|next|done>` が `backlog` カラムを操作します。起動手順は上の「v3.1 の新機能 — カンバンモード」節にあります。
 
 > 詳細: [カンバンモードガイド](https://adk.mo.ai.kr/ja/advanced/kanban-mode)
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -230,7 +230,7 @@ SPEC마다 독립된 작업 트리를 준다. `moai cc -w <이름>`으로 진입
 | CWD 충돌 해결 | `(worktree_path, session_id)` 쌍으로 재사용 경로를 구분 |
 | 깊이 상한 | 중첩 복잡도를 제한 |
 
-> **지금 쓸 수 있습니다**: `moai cc -k` / `moai glm -k`로 리드와 네 개의 동반 세션을 띄우고, `moai chain <status|lineage|back|list|prune>`으로 계보를 읽고, `moai todo <add|list|next|done>`으로 `backlog` 컬럼을 운영합니다. 실행 순서는 위 "v3.1 새 기능 — 칸반 모드" 절에 있습니다.
+> **지금 쓸 수 있습니다**: `moai cc -k`(또는 `moai glm -k`)로 리드를 띄우고, `-k --name <role>-<run-id>`로 동반 세션을 하나씩 붙입니다 — 터미널당 하나씩 손으로 띄웁니다. `moai chain <status|lineage|back|list|prune>`으로 계보를 읽고, `moai todo <add|list|next|done>`으로 `backlog` 컬럼을 운영합니다. 실행 순서는 위 "v3.1 새 기능 — 칸반 모드" 절에 있습니다.
 
 > 자세히: [칸반 모드 가이드](https://adk.mo.ai.kr/ko/advanced/kanban-mode)
 

--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ flowchart TD
 | CWD-collision resolution | `(worktree_path, session_id)` pair disambiguates reused paths |
 | Depth ceiling | Caps nesting complexity |
 
-> **Available now**: `moai cc -k` / `moai glm -k` launch the lead and the four companion sessions, `moai chain <status|lineage|back|list|prune>` reads the lineage, and `moai todo <add|list|next|done>` operates the `backlog` column. The launch sequence is in the "New in v3.1 — Kanban Mode" section above.
+> **Available now**: `moai cc -k` (or `moai glm -k`) starts the lead and `-k --name <role>-<run-id>` joins each companion — launched by hand, one per terminal. `moai chain <status|lineage|back|list|prune>` reads the lineage, and `moai todo <add|list|next|done>` operates the `backlog` column. The launch sequence is in the "New in v3.1 — Kanban Mode" section above.
 
 > Details: [Kanban Mode Guide](https://adk.mo.ai.kr/en/advanced/kanban-mode)
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -399,7 +399,7 @@ flowchart TD
 | CWD 冲突解决 | `(worktree_path, session_id)` 对消除复用路径的歧义 |
 | 深度上限 | 限制嵌套复杂度 |
 
-> **现已可用**：`moai cc -k` / `moai glm -k` 启动主导会话与四个伴随会话，`moai chain <status|lineage|back|list|prune>` 读取谱系，`moai todo <add|list|next|done>` 操作 `backlog` 列。启动顺序见上文“v3.1 新功能 —— 看板模式”一节。
+> **现已可用**：`moai cc -k`（或 `moai glm -k`）启动主导会话，`-k --name <role>-<run-id>` 逐个加入伴随会话 —— 每个终端一个，由人手动启动。`moai chain <status|lineage|back|list|prune>` 读取谱系，`moai todo <add|list|next|done>` 操作 `backlog` 列。启动顺序见上文“v3.1 新功能 —— 看板模式”一节。
 
 > 详情：[看板模式指南](https://adk.mo.ai.kr/zh/advanced/kanban-mode)
 


### PR DESCRIPTION
Follow-up to #1561, which merged while this correction was being applied.

CodeRabbit's review of #1561 flagged that the replacement callout reads as though the launcher starts all five sessions:

> The README may imply that Kanban launches all companion sessions automatically, although the launch switches start only the lead session and the companions require separate launches.

That is right, and it contradicts the v3.1 section two hundred lines earlier in the same file, which states plainly that companion sessions are launched by hand, one per terminal, and that a session never spawns a peer.

Reworded in all four locales: `moai cc -k` (or `moai glm -k`) starts the lead, and `-k --name <role>-<run-id>` joins each companion — launched by hand, one per terminal.

Verified against `moai cc --help` on the installed `3.1.0` binary, which documents the two forms separately: `-k, --kanban [SPEC-ID]` to enter as the lead, and `-k --name <role>-<run-id>` to join an existing run as a companion.

## Verification

- Four files, one line each; `git diff origin/main --stat` → 4 insertions, 4 deletions
- `grep -c '^## '` unchanged: en/ja/zh 14, ko 11 — parity-neutral
- docs-site untouched

🗿 MoAI
