### PR TITLE
fix(ci): stop the release provenance gate failing on checks that matched

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,11 @@ jobs:
           ANNOTATION="$(git for-each-ref "refs/tags/${TAG}" --format='%(contents)')"
 
           # Check 2 — provenance trailer written by scripts/release.sh.
-          if ! printf '%s\n' "${ANNOTATION}" | grep -qxF 'Released-via: harness:release'; then
+          # No `grep -q` in any pipeline below: -q exits on first match and
+          # closes the pipe, the producer dies of SIGPIPE (141), and pipefail
+          # then reports failure for a check that MATCHED. Redirect instead so
+          # grep consumes all of its input.
+          if ! printf '%s\n' "${ANNOTATION}" | grep -xF 'Released-via: harness:release' >/dev/null; then
             fail "check 2 (provenance trailer): tag annotation has no 'Released-via: harness:release' line."
           fi
 
@@ -97,14 +101,14 @@ jobs:
 
           # Check 5 — CHANGELOG.md at the tagged commit has this version's section.
           VERSION_NO_V="${TAG#v}"
-          if ! git show "${TAG_COMMIT}:CHANGELOG.md" | grep -qE "^## \[${VERSION_NO_V}\]"; then
+          if ! git show "${TAG_COMMIT}:CHANGELOG.md" | grep -E "^## \[${VERSION_NO_V}\]" >/dev/null; then
             fail "check 5 (CHANGELOG): CHANGELOG.md at ${TAG_COMMIT} has no '## [${VERSION_NO_V}]' section."
           fi
 
           # Check 6 — version SSOT (.moai/config/sections/system.yaml stores the
           # v-prefixed form, e.g. `version: v3.0.1`).
           SSOT_PATH='.moai/config/sections/system.yaml'
-          if ! git show "${TAG_COMMIT}:${SSOT_PATH}" | grep -qE "^[[:space:]]*version:[[:space:]]*${TAG}[[:space:]]*$"; then
+          if ! git show "${TAG_COMMIT}:${SSOT_PATH}" | grep -E "^[[:space:]]*version:[[:space:]]*${TAG}[[:space:]]*$" >/dev/null; then
             ACTUAL="$(git show "${TAG_COMMIT}:${SSOT_PATH}" | sed -n 's/^[[:space:]]*version:[[:space:]]*//p' | head -n1)"
             fail "check 6 (version SSOT): ${SSOT_PATH} at ${TAG_COMMIT} has version='${ACTUAL}', expected '${TAG}'."
           fi

--- a/internal/template/release_workflow_pipefail_test.go
+++ b/internal/template/release_workflow_pipefail_test.go
@@ -8,11 +8,22 @@
 // pipeline reports 141 even though the match SUCCEEDED, and the surrounding
 // `if ! <pipeline>; then fail ...` fires on a passing check.
 //
-// The hazard is size-dependent: it stays invisible while the producer's output
-// fits the ~64KB pipe buffer, and becomes deterministic once it does not.
-// CHANGELOG.md crossed that line (416KB at the time of writing), which is why
-// check 5 was the one that broke — but checks 2 and 6 had the identical shape
-// and would have broken as soon as their inputs grew.
+// What decides whether it fires is NOT the total input size — it is how much
+// the producer still has left to write at the moment grep exits. If that
+// remainder fits the ~64KB pipe buffer the producer completes and exits 0; if
+// it does not, the producer blocks on a pipe that is about to close and dies.
+//
+// Measured on the v3.1.0 release, which is where this was found:
+//
+//	check 5  CHANGELOG.md, 416,407 B, match at line 8      -> ~416KB left  -> 141
+//	check 2  tag annotation, 271,034 B, match at line 288  -> 82 B left    -> 0
+//	check 6  system.yaml, 1,894 B                          -> < 1 KB left  -> 0
+//
+// So check 2 survives a 271KB input purely because its provenance trailer sits
+// three lines from the end. That is a property of the data, not of the code:
+// move the trailer earlier — or let anything grow below the match — and the
+// same line fails the same way. Checks 2 and 6 are fixed here for that reason,
+// not because they were observed failing.
 //
 // Sentinel on failure: PIPEFAIL_SIGPIPE_HAZARD
 //
@@ -124,6 +135,14 @@ func TestPipefailSigpipeMechanism(t *testing.T) {
 			script:   "set -o pipefail; " + producer + " | grep '^no-such-line$' >/dev/null",
 			wantExit: 1,
 			why:      "the fix must not turn every check into a pass",
+		},
+		{
+			name:     "quiet grep survives when the match is near the end",
+			script:   "set -o pipefail; " + producer + " | grep -q '^500000$'",
+			wantExit: 0,
+			why: "this is why check 2 passed on a 271KB tag annotation: its trailer sits 82 bytes " +
+				"from the end, so the producer had nothing left to block on. Total input size is " +
+				"not the variable — what is left to write after the match is",
 		},
 	}
 

--- a/internal/template/release_workflow_pipefail_test.go
+++ b/internal/template/release_workflow_pipefail_test.go
@@ -47,6 +47,7 @@
 package template_test
 
 import (
+	"context"
 	"errors"
 	"os"
 	"os/exec"
@@ -56,16 +57,71 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 // releaseWorkflowRelPath is the repo-relative path of the release workflow
 // whose provenance gate carries the seven checks.
 const releaseWorkflowRelPath = ".github/workflows/release.yml"
 
-// quietGrepAfterPipe matches a pipe feeding a grep that carries -q in any flag
-// cluster (-q, -qE, -qxF, ...). The pipe is the load-bearing part: without an
-// upstream producer there is nothing for grep's early exit to kill.
-var quietGrepAfterPipe = regexp.MustCompile(`\|\s*grep\s+-[A-Za-z]*q`)
+// pipeIntoGrep finds a pipe feeding a grep and captures everything after it.
+// The pipe is the load-bearing part: without an upstream producer there is
+// nothing for grep's early exit to kill, so `grep -q file` is safe.
+var pipeIntoGrep = regexp.MustCompile(`\|\s*grep\s+(\S.*)$`)
+
+// shortOptsTakingValue are grep's single-letter options whose value follows,
+// either glued to the option or as the next token. Anything after one of them
+// in the same cluster is that value, not another option.
+const shortOptsTakingValue = "efmABCD"
+
+// longOptsTakingValue are the --name forms whose value follows as a separate
+// token when not given as --name=value.
+var longOptsTakingValue = map[string]bool{
+	"regexp": true, "file": true, "max-count": true,
+	"after-context": true, "before-context": true, "context": true,
+}
+
+// isQuietGrep reports whether a grep invocation suppresses output, which is
+// what makes it exit early and kill its producer. It walks the option tokens
+// rather than pattern-matching the line, because quiet has three spellings
+// (`-q`, a cluster containing q, `--quiet`/`--silent`) and because an option's
+// own value must not be read as more options — `grep -e -q` searches for the
+// literal string "-q" and is NOT quiet.
+func isQuietGrep(args []string) bool {
+	for i := 0; i < len(args); i++ {
+		tok := args[i]
+
+		switch {
+		case tok == "--":
+			return false // everything after this is the pattern
+		case strings.HasPrefix(tok, "--"):
+			name := tok[2:]
+			if eq := strings.IndexByte(name, '='); eq >= 0 {
+				name = name[:eq]
+			} else if longOptsTakingValue[name] {
+				i++ // its value is the next token
+			}
+			if name == "quiet" || name == "silent" {
+				return true
+			}
+		case strings.HasPrefix(tok, "-") && len(tok) > 1:
+			for j := 1; j < len(tok); j++ {
+				if tok[j] == 'q' {
+					return true
+				}
+				if strings.IndexByte(shortOptsTakingValue, tok[j]) >= 0 {
+					if j == len(tok)-1 {
+						i++ // the value is the next token
+					}
+					break // the rest of this cluster is the value
+				}
+			}
+		default:
+			return false // the pattern; options are done
+		}
+	}
+	return false
+}
 
 func TestReleaseWorkflowNoQuietGrepUnderPipefail(t *testing.T) {
 	t.Parallel()
@@ -80,7 +136,8 @@ func TestReleaseWorkflowNoQuietGrepUnderPipefail(t *testing.T) {
 
 	var offenders []string
 	for i, line := range strings.Split(string(data), "\n") {
-		if quietGrepAfterPipe.MatchString(line) {
+		m := pipeIntoGrep.FindStringSubmatch(line)
+		if m != nil && isQuietGrep(strings.Fields(m[1])) {
 			offenders = append(offenders, strings.TrimSpace(line)+"  ("+releaseWorkflowRelPath+":"+strconv.Itoa(i+1)+")")
 		}
 	}
@@ -91,6 +148,47 @@ func TestReleaseWorkflowNoQuietGrepUnderPipefail(t *testing.T) {
 			"so pipefail reports 141 for a pipeline whose match SUCCEEDED and the check fails on a passing release.\n"+
 			"Fix: drop -q and redirect instead (`| grep -E 'pat' >/dev/null`) so grep consumes all input.\n"+
 			"Offending lines:\n  %s", releaseWorkflowRelPath, strings.Join(offenders, "\n  "))
+	}
+}
+
+// TestIsQuietGrep pins the detector itself. A guard that silently misses a
+// spelling is worse than no guard, because the green run reads as coverage.
+func TestIsQuietGrep(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		args string
+		want bool
+		why  string
+	}{
+		{"-q 'pat'", true, "the plain form"},
+		{"-qE 'pat'", true, "q in a cluster"},
+		{"-qxF 'pat'", true, "q first in a longer cluster"},
+		{"-Eq 'pat'", true, "q last in a cluster"},
+		{"-E -q 'pat'", true, "q as its own token after another option"},
+		{"--quiet 'pat'", true, "the long form"},
+		{"--silent 'pat'", true, "the long form's synonym"},
+		{"-i --quiet 'pat'", true, "long form after a short one"},
+
+		{"-E 'pat'", false, "no quiet anywhere"},
+		{"-c 'pat'", false, "-c counts, it does not suppress early"},
+		{"-e -q", false, "-q is -e's pattern, not an option"},
+		{"-e 'pat' -q", true, "-e consumed its value, so this -q is an option"},
+		{"-f patterns.txt -q", true, "-f consumed its value"},
+		{"-m 1 -q", true, "-m consumed its numeric value"},
+		{"-- -q", false, "-- ends options; -q is the pattern"},
+		{"'q' file", false, "a pattern that happens to be q"},
+		{"--regexp -q", false, "--regexp consumed -q as its value"},
+		{"--regexp=-q --quiet", true, "--regexp took its value inline, so --quiet still counts"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.args, func(t *testing.T) {
+			t.Parallel()
+			if got := isQuietGrep(strings.Fields(tc.args)); got != tc.want {
+				t.Errorf("isQuietGrep(%q) = %v, want %v — %s", tc.args, got, tc.want, tc.why)
+			}
+		})
 	}
 }
 
@@ -156,12 +254,25 @@ func TestPipefailSigpipeMechanism(t *testing.T) {
 	}
 }
 
+// bashDeadline bounds each shell so a wedged pipe cannot hold the job open
+// until the 30-minute CI timeout. The scripts here finish in well under a
+// second, so this is a backstop rather than a budget: it is set generously
+// because these tests run alongside the rest of the suite, and a deadline
+// tight enough to trip under load would report contention as a defect.
+const bashDeadline = 60 * time.Second
+
 // runBashExitCode runs script under bash and returns its exit code. A failure
 // to start bash at all is fatal; a non-zero exit is a result, not an error.
 func runBashExitCode(t *testing.T, script string) int {
 	t.Helper()
 
-	err := exec.Command("bash", "-c", script).Run()
+	ctx, cancel := context.WithTimeout(context.Background(), bashDeadline)
+	defer cancel()
+
+	err := exec.CommandContext(ctx, "bash", "-c", script).Run()
+	if ctx.Err() != nil {
+		t.Fatalf("script exceeded %s and was killed — treat as a hang, not a verdict: %s", bashDeadline, script)
+	}
 	if err == nil {
 		return 0
 	}

--- a/internal/template/release_workflow_pipefail_test.go
+++ b/internal/template/release_workflow_pipefail_test.go
@@ -1,0 +1,155 @@
+// release_workflow_pipefail_test.go: CI guard against the `grep -q` SIGPIPE
+// hazard in .github/workflows/release.yml.
+//
+// The release provenance gate runs its seven checks in one `set -euo pipefail`
+// step. Under pipefail a pipeline reports the rightmost non-zero exit, and
+// `grep -q` exits the moment it matches — closing the pipe while the upstream
+// producer is still writing. The producer then dies of SIGPIPE (141), so the
+// pipeline reports 141 even though the match SUCCEEDED, and the surrounding
+// `if ! <pipeline>; then fail ...` fires on a passing check.
+//
+// The hazard is size-dependent: it stays invisible while the producer's output
+// fits the ~64KB pipe buffer, and becomes deterministic once it does not.
+// CHANGELOG.md crossed that line (416KB at the time of writing), which is why
+// check 5 was the one that broke — but checks 2 and 6 had the identical shape
+// and would have broken as soon as their inputs grew.
+//
+// Sentinel on failure: PIPEFAIL_SIGPIPE_HAZARD
+//
+// Design notes:
+//   - TestReleaseWorkflowNoQuietGrepUnderPipefail is the enforcing guard: it
+//     reads the workflow and rejects any `| grep -q`. It fails on the
+//     pre-fix file and passes on the fixed one.
+//   - TestPipefailSigpipeMechanism is the evidence behind that guard. It
+//     demonstrates the failure and its remedy on a synthetic pipeline, so the
+//     rule above is not taken on trust. It passes both before and after the
+//     workflow fix because it tests the shell mechanism, not the file.
+//   - A `grep -q` that is NOT fed by a pipe (a file argument, a here-string)
+//     has no upstream producer to kill and is therefore safe. The guard
+//     anchors on the pipe for that reason.
+//   - This lives under internal/template/ (NOT internal/template/templates/)
+//     alongside branch_protection_parity_test.go, the existing precedent for
+//     asserting on .github/ content, and reuses its
+//     findProjectRootForMirrorTest helper. _test.go files are not
+//     user-distributed template content, so the template-neutrality CI guard
+//     does not apply.
+package template_test
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// releaseWorkflowRelPath is the repo-relative path of the release workflow
+// whose provenance gate carries the seven checks.
+const releaseWorkflowRelPath = ".github/workflows/release.yml"
+
+// quietGrepAfterPipe matches a pipe feeding a grep that carries -q in any flag
+// cluster (-q, -qE, -qxF, ...). The pipe is the load-bearing part: without an
+// upstream producer there is nothing for grep's early exit to kill.
+var quietGrepAfterPipe = regexp.MustCompile(`\|\s*grep\s+-[A-Za-z]*q`)
+
+func TestReleaseWorkflowNoQuietGrepUnderPipefail(t *testing.T) {
+	t.Parallel()
+
+	root := findProjectRootForMirrorTest(t)
+	path := filepath.Join(root, releaseWorkflowRelPath)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", releaseWorkflowRelPath, err)
+	}
+
+	var offenders []string
+	for i, line := range strings.Split(string(data), "\n") {
+		if quietGrepAfterPipe.MatchString(line) {
+			offenders = append(offenders, strings.TrimSpace(line)+"  ("+releaseWorkflowRelPath+":"+strconv.Itoa(i+1)+")")
+		}
+	}
+
+	if len(offenders) > 0 {
+		t.Errorf("PIPEFAIL_SIGPIPE_HAZARD: %s pipes into `grep -q` inside a `set -o pipefail` step.\n"+
+			"`grep -q` exits on first match and closes the pipe; the upstream producer dies of SIGPIPE (141),\n"+
+			"so pipefail reports 141 for a pipeline whose match SUCCEEDED and the check fails on a passing release.\n"+
+			"Fix: drop -q and redirect instead (`| grep -E 'pat' >/dev/null`) so grep consumes all input.\n"+
+			"Offending lines:\n  %s", releaseWorkflowRelPath, strings.Join(offenders, "\n  "))
+	}
+}
+
+func TestPipefailSigpipeMechanism(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("mechanism demo needs a POSIX shell with seq; the enforcing guard above is platform-neutral")
+	}
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available; the enforcing guard above is platform-neutral")
+	}
+	if _, err := exec.LookPath("seq"); err != nil {
+		t.Skip("seq not available; the enforcing guard above is platform-neutral")
+	}
+
+	// 500k lines is far past the ~64KB pipe buffer, so the producer cannot
+	// finish before grep's early exit closes the pipe. The match is on the
+	// first line, which makes that exit immediate.
+	const producer = "seq 1 500000"
+
+	tests := []struct {
+		name     string
+		script   string
+		wantExit int
+		why      string
+	}{
+		{
+			name:     "quiet grep reports SIGPIPE despite matching",
+			script:   "set -o pipefail; " + producer + " | grep -q '^1$'",
+			wantExit: 141,
+			why:      "this is the defect: the pattern matched, yet the pipeline reports failure",
+		},
+		{
+			name:     "consuming grep reports the match",
+			script:   "set -o pipefail; " + producer + " | grep '^1$' >/dev/null",
+			wantExit: 0,
+			why:      "this is the fix: without -q grep reads all input, so the producer never sees SIGPIPE",
+		},
+		{
+			name:     "consuming grep still reports a genuine miss",
+			script:   "set -o pipefail; " + producer + " | grep '^no-such-line$' >/dev/null",
+			wantExit: 1,
+			why:      "the fix must not turn every check into a pass",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := runBashExitCode(t, tc.script); got != tc.wantExit {
+				t.Errorf("exit code = %d, want %d\nscript: %s\nwhy this matters: %s", got, tc.wantExit, tc.script, tc.why)
+			}
+		})
+	}
+}
+
+// runBashExitCode runs script under bash and returns its exit code. A failure
+// to start bash at all is fatal; a non-zero exit is a result, not an error.
+func runBashExitCode(t *testing.T, script string) int {
+	t.Helper()
+
+	err := exec.Command("bash", "-c", script).Run()
+	if err == nil {
+		return 0
+	}
+
+	if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
+		return exitErr.ExitCode()
+	}
+	t.Fatalf("run bash: %v", err)
+	return -1
+}


### PR DESCRIPTION
## This already cost us a release

**v3.1.0 did not go out through GoReleaser.** The gate failed, `release` (which declares `needs: verify-provenance`) was skipped, and the release was published by hand. The release object looks healthy — author `GoosLab`, seven assets attached — which is exactly why it went unnoticed. This was not a warning; it was release automation being bypassed end to end.

Run [31891095330](https://github.com/modu-ai/moai-adk/actions/runs/31891095330) names the check:

```
##[error]RELEASE_PROVENANCE_GATE: check 5 (CHANGELOG): CHANGELOG.md at
ed04e40e6fd8a078dd2de242b55839e268725ca6 has no '## [3.1.0]' section.
```

That commit's `CHANGELOG.md` **does** have the section, at line 8:

```
$ git show ed04e40e6fd8a078dd2de242b55839e268725ca6:CHANGELOG.md | grep -nE '^## \[3\.1\.0\]'
8:## [3.1.0] - 2026-08-15
```

The gate failed a check that matched.

## Why

`grep -q` under the step's `set -euo pipefail`:

1. `grep -q` exits the instant it matches, closing the read end of the pipe.
2. The producer, still writing, dies of `SIGPIPE` → 141.
3. `pipefail` makes the pipeline report the rightmost non-zero status — 141.
4. `if ! <pipeline>; then fail ...` reads that as the check failing.

`set -e` is suppressed inside an `if` condition; `pipefail` is not. That is what turns a successful match into a failed release.

## What actually decides whether it fires

Not total input size — **how much the producer still has to write when grep exits.** If that remainder exceeds the ~64KB pipe buffer the producer blocks on a pipe about to close and dies; if it fits, the producer completes and exits 0.

Measured on the real v3.1.0 tag:

| check | input | size | match at | left to write | exit |
|---|---|---|---|---|---|
| 5 (L100) | `CHANGELOG.md` | 416,407 B | line 8 | ~416 KB | **141** |
| 2 (L81) | tag annotation | 271,034 B | line 288 of 291 | **82 B** | 0 |
| 6 (L107) | `system.yaml` | 1,894 B | — | < 1 KB | 0 |

> An earlier revision of this PR said checks 2 and 6 pass "because their inputs are small". Measuring the real tag disproved it — 271KB is not small. Check 2 survives **only** because the provenance trailer sits three lines from the end, which is a property of the tag's text rather than of the check. Move the trailer earlier, or let anything grow below it, and `grep -qxF` fails the same way `grep -qE` did. Commit 1687c1cb1 corrects the record.

That is the reason all three lines are fixed here, not only the one observed failing.

## The fix

Drop `-q` and redirect instead, so grep reads all of its input and the producer never meets a closed pipe. Exit semantics unchanged — 0 on match, 1 on miss.

```diff
-if ! git show "${TAG_COMMIT}:CHANGELOG.md" | grep -qE "^## \[${VERSION_NO_V}\]"; then
+if ! git show "${TAG_COMMIT}:CHANGELOG.md" | grep -E "^## \[${VERSION_NO_V}\]" >/dev/null; then
```

`grep -q` reading a file or a here-string is safe — no upstream producer to kill — so only the piped forms changed. Rejected alternatives: process substitution changes the structure for no gain; clearing `pipefail` for the step would discard the safety net protecting the other six checks.

## Acceptance: does `release` actually run now?

The gate's only trigger is a `v*` tag push, so it cannot be exercised without publishing. What is verifiable without one is the thing `needs: verify-provenance` keys on — **the gate step's exit code against the real v3.1.0 tag and commit**, since that is precisely the input that produced the skipped `release` job.

Running the step's seven checks against `refs/tags/v3.1.0` and `ed04e40e6`, under `set -euo pipefail`, with only the three grep forms swapped:

| form | gate exit | consequence for `release` |
|---|---|---|
| before (`grep -q`) | **1** — `check 5 (CHANGELOG)` | skipped ← what happened |
| after (this PR) | **0** — `all 7 checks passed` | runs |

Same tag, same commit, same seven checks; the grep form is the only variable. Negative controls hold: an absent CHANGELOG version and a mismatched SSOT version each still fail their check, so the fix does not turn the gate into a rubber stamp.

## Test

`internal/template/release_workflow_pipefail_test.go`, beside `branch_protection_parity_test.go` (the existing precedent for asserting on `.github/` content):

- `TestReleaseWorkflowNoQuietGrepUnderPipefail` — the enforcing guard. Rejects any `| grep -q` in the workflow and names the offending lines. Written first; it failed on the pre-fix file, listing exactly lines 81, 100, and 107.
- `TestPipefailSigpipeMechanism` — the mechanism in executable form, so the guard is not taken on trust: 141 for the quiet form, 0 for the consuming form, **1 for a genuine miss** (the fix must not pass everything), and **0 for a quiet grep matching near the end** — the case that explains why check 2 survived 271KB.

`go test ./internal/template/ -count=1` → ok (20.6s); `go vet` clean; `gofmt` clean.

## Out of scope

`ci.yml:121` — same latent shape, handled separately in its own card. `release-pr-multi-os.yml:92,148` — same shape, owned by the CI de-duplication PR. `spec-status-auto-sync.yml` uses `grep -q` but sets no `pipefail` and its producer is `echo`; harmless.

🗿 MoAI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release validation checks to prevent false failures when shell pipelines run with strict error handling.
  * Preserved existing matching behavior for changelog and version consistency checks.

* **Tests**
  * Added automated coverage to detect unsafe release workflow patterns and verify correct handling of pipeline failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->