### PR TITLE
ci(release): drop the duplicate ubuntu race run from release PR verification

### DIFF
--- a/.github/workflows/release-pr-multi-os.yml
+++ b/.github/workflows/release-pr-multi-os.yml
@@ -40,8 +40,17 @@ jobs:
         run: echo "proceed=true" >> $GITHUB_OUTPUT
 
   # ---------------------------------------------------------------------------
-  # Full 3-OS matrix test: macOS + Windows (ubuntu already covered by main CI)
-  # Only runs for release/* branch PRs or manual workflow_dispatch
+  # Full 3-OS matrix test. Only runs for release/* branch PRs or manual
+  # workflow_dispatch.
+  #
+  # ubuntu-latest stays in the matrix even though ci.yml also runs the race
+  # detector on ubuntu. ci.yml's `Race Test` job is advisory by construction —
+  # its check name is deliberately absent from branch protection, so a race
+  # failure there is visible but does not block a merge. This job reports
+  # through `Release PR Multi-OS Gate`, which IS a required check, so the
+  # ubuntu leg here is the only ubuntu race run that can stop a release.
+  # Dropping it would silently demote ubuntu race coverage to advisory at
+  # exactly the moment it matters most.
   # ---------------------------------------------------------------------------
   full-matrix-test:
     name: Release Verify (${{ matrix.os }})
@@ -86,10 +95,18 @@ jobs:
       # Ubuntu and Debian ship /usr/bin/sg as a newgrp alternative, so `sg`
       # being on PATH proves nothing about what it is. Assert the binary is
       # ast-grep — a silent substitution is the failure this step prevents.
+      #
+      # `grep -i ... >/dev/null` rather than `grep -qi`: `shell: bash` runs the
+      # step under `-eo pipefail`, and `grep -q` closes the pipe at the first
+      # match, so a producer with more to write dies of SIGPIPE and the
+      # pipeline resolves to 141 even though the match succeeded. Redirecting
+      # instead keeps grep reading to EOF, so the exit status means what it
+      # reads as. `sg --version` prints one short line and so does not trip
+      # this today; the form is fixed because the next producer might.
       - name: Verify `sg` resolves to ast-grep
         shell: bash
         run: |
-          if ! sg --version 2>&1 | grep -qi 'ast-grep'; then
+          if ! sg --version 2>&1 | grep -i 'ast-grep' >/dev/null; then
             echo "FAIL: 'sg' on PATH is not ast-grep — the rewrite guards cannot run."
             echo "resolved to: $(command -v sg || echo '<not found>')"
             sg --version 2>&1 || true
@@ -111,113 +128,21 @@ jobs:
         run: go test -race -timeout 25m ./...
 
   # ---------------------------------------------------------------------------
-  # Release Range Verify (Wave 3 2026-06-24): for release/* → main PRs, confirm
-  # the accumulated release range (since the last tag) builds and tests green —
-  # NOT just the tip commit. ci.yml/test verify the PR diff; this job verifies
-  # the full release window so a mid-range regression is not hidden by a clean
-  # tip.
-  # ---------------------------------------------------------------------------
-  release-range-verify:
-    name: Release Range Verify
-    needs: detect-release
-    if: needs.detect-release.outputs.proceed == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 0  # need full history for git describe + range log
-
-      - name: Setup Go
-        uses: actions/setup-go@v7
-        with:
-          go-version-file: go.mod
-          cache: true
-
-      # Same ast-grep dependency as the per-OS leg above: this job runs the
-      # full `go test -race ./...` over the release range, which includes the
-      # guards that shell out to `sg`.
-      - name: Install ast-grep (provides `sg`)
-        run: npm install -g @ast-grep/cli@0.40.5
-
-      - name: Verify `sg` resolves to ast-grep
-        shell: bash
-        run: |
-          if ! sg --version 2>&1 | grep -qi 'ast-grep'; then
-            echo "FAIL: 'sg' on PATH is not ast-grep — the rewrite guards cannot run."
-            echo "resolved to: $(command -v sg || echo '<not found>')"
-            sg --version 2>&1 || true
-            exit 1
-          fi
-          echo "PASS: $(sg --version)"
-
-      - name: Print commit range since last tag
-        id: range
-        shell: bash
-        run: |
-          set -euo pipefail
-          # Resolve the most recent tag. If no tag exists yet (early repo),
-          # git describe exits 128 — fall back to full history.
-          RANGE=""
-          if LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null); then
-            RANGE="${LAST_TAG}..HEAD"
-            echo "Last tag: ${LAST_TAG}"
-          else
-            echo "No previous tag found — using full history as the release range."
-            # Empty RANGE base → git log with empty range degrades to full HEAD history
-            # when we pass just the rev range; use --all alternative below for safety.
-            RANGE=""
-          fi
-
-          echo "::group::Commit range (${RANGE:-full history})"
-          if [ -n "${RANGE}" ]; then
-            git log "${RANGE}" --oneline
-            COMMIT_COUNT=$(git rev-list --count "${RANGE}")
-          else
-            git log --oneline
-            COMMIT_COUNT=$(git rev-list --count HEAD)
-          fi
-          echo "::endgroup::"
-
-          echo "Commit count in release range: ${COMMIT_COUNT}"
-          echo "commit_count=${COMMIT_COUNT}" >> $GITHUB_OUTPUT
-          echo "last_tag=${LAST_TAG:-none}" >> $GITHUB_OUTPUT
-
-      - name: Run go build (release range)
-        shell: bash
-        run: |
-          set -euo pipefail
-          go build ./...
-
-      # Same -timeout rationale as the per-OS leg above.
-      - name: Run go test with race detector (release range)
-        shell: bash
-        run: |
-          set -euo pipefail
-          go test -race -timeout 25m ./...
-
-  # ---------------------------------------------------------------------------
-  # Summary gate: ensures all OS jobs + release range verify passed (or were
-  # skipped for non-release PRs).
+  # Summary gate: ensures all OS legs passed (or were skipped for non-release
+  # PRs). This is the required check that branch protection gates a release PR
+  # on, so the OS matrix above is what actually blocks a bad release.
   # ---------------------------------------------------------------------------
   release-pr-gate:
     name: Release PR Multi-OS Gate
-    needs: [full-matrix-test, release-range-verify]
+    needs: [full-matrix-test]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Verify all OS + release range passed
+      - name: Verify all OS legs passed
         run: |
           if [ "${{ needs.full-matrix-test.result }}" = "failure" ]; then
             echo "::error::Release PR multi-OS verification FAILED on at least one OS"
             exit 1
           fi
-          if [ "${{ needs.release-range-verify.result }}" = "failure" ]; then
-            echo "::error::Release Range Verify FAILED (build or tests broke inside the release window)"
-            exit 1
-          fi
           echo "✓ Release PR multi-OS verification PASSED (or skipped for non-release PR)"
-          echo "✓ Release Range Verify PASSED (or skipped for non-release PR)"


### PR DESCRIPTION
## What this removes

`release-range-verify` is deleted, and `release-pr-gate` no longer waits on it.

## Why — the job did not do what its name said

The job's own comment claimed it verified "the accumulated release range (since the last tag) ... NOT just the tip commit". Its steps were:

| Step | What it actually did |
|---|---|
| `Checkout code` | `actions/checkout@v7`, `fetch-depth: 0`, **no `ref:` override** — on a `pull_request` event this is the PR merge ref, the same tree every other job checks out |
| `Setup Go` / `Install ast-grep` / `Verify sg` | identical to the `full-matrix-test` ubuntu leg |
| `Print commit range since last tag` | `git describe --tags --abbrev=0` then `git log <tag>..HEAD --oneline` — **prints only** |
| `Run go build (release range)` | `go build ./...` at HEAD |
| `Run go test with race detector (release range)` | `go test -race -timeout 25m ./...` at HEAD |

No step ever checked out an intermediate commit. The "range" existed only in the `git log` output. The verification it performed was the ubuntu leg of `full-matrix-test`, byte for byte, with a `git log` and a `go build ./...` in front of it — and `go build` is already covered by ci.yml's cross-compilation `Build` matrix and by `go vet ./...`, which is what compiles `_test.go` per target.

## Measurement

v3.1.0 release PR #1555, successful runs `31888268855` (Multi-OS) and `31888268858` (CI):

```
Multi-OS │ Release Verify (windows-latest)   796s
         │ Release Verify (ubuntu-latest)    550s   ← ubuntu race
         │ Release Range Verify              549s   ← ubuntu race, removed here
         │ Release Verify (macos-latest)     506s
         │ Detect / Gate                     3s / 4s
CI       │ Race Test                         565s   ← ubuntu race, advisory
         │ Test (ubuntu-latest)              300s
         │ Lint 155s · Build ×5 76–89s · Integration ×3 43–76s
```

The same `go test -race ./...` ran on ubuntu three times: **1,664 runner-seconds, of which 549 bought nothing.**

The duplication only fires on `release/*` PRs — `detect-release` gates the workflow with `if: startsWith(github.head_ref, 'release/')`, so ordinary PRs skip it in 6–8s.

## Honest limitation — this is cost, not latency

Wall-clock is set by the windows leg at 796s, so the workflow still takes **~800s instead of 815s**. What this buys is runner minutes and queue occupancy, not a shorter wait for a release. PR #1555 ran this workflow six times (790s–1365s each), so the saving is real in aggregate — but anyone hoping this shortens release-day feedback should know the actual target is the **windows leg at 796s**, which this PR does not touch.

## Why `ubuntu-latest` stays in the matrix

An earlier draft of this change also trimmed the matrix to `[macos-latest, windows-latest]`, on the strength of the job comment at line 43 — *"macOS + Windows (ubuntu already covered by main CI)"*. Checking branch protection first showed that would have been wrong:

```
$ gh api repos/modu-ai/moai-adk/branches/main/protection --jq '.required_status_checks.contexts'
["Test (ubuntu-latest)","Lint","Build (linux/amd64)","Analyze (Go) (go)","Release PR Multi-OS Gate"]
```

ci.yml's `Race Test` **is** the ubuntu race coverage on every PR, but its check name is deliberately absent from that list — its own comment says so: *"non-blocking because 'Race Test' is a NEW check name NOT in branch-protection required checks"*. It is visible and advisory; it cannot stop a merge.

`Release PR Multi-OS Gate` **is** required, and it reports this workflow. That makes the ubuntu leg here the only ubuntu race run that can block a release. Trimming it would have quietly demoted ubuntu race coverage to advisory at exactly the moment it matters most.

So the code was right and the comment was wrong. The comment is corrected to state the real reason ubuntu is in the matrix, rather than the matrix being trimmed to match a stale comment.

## Secondary — a latent SIGPIPE defect in the same file

Found by the lane fixing the release provenance gate (#1563), where the same construct was failing in production rather than lying dormant.

`shell: bash` runs a step under `--noprofile --norc -eo pipefail`. `grep -q` exits at its first match and closes the pipe, so a producer with more to write dies of SIGPIPE, and under `pipefail` the pipeline resolves to **141** even though the match succeeded. Reproduced locally on this tree:

```
$ bash --noprofile --norc -eo pipefail -c 'git log --oneline | grep -qi "readme"'
exit 141
$ bash --noprofile --norc -eo pipefail -c 'git log --oneline | grep -i "readme" >/dev/null'
exit 0
```

Two call sites existed in this file:

- **line 92**, in the surviving `full-matrix-test` job — **fixed here** (`grep -qi` → `grep -i ... >/dev/null`, which keeps grep reading to EOF; exit semantics are unchanged).
- **line 148**, in `release-range-verify` — **resolved by the job deletion**, no separate fix needed.

`sg --version` prints a single short line, so the producer finishes inside the pipe buffer and neither site trips today. The form is corrected because that guarantee rests on output length rather than on anything the check controls.

`ci.yml:121` carries the same construct and is **not** touched here — it is assigned to the lane handling #1563.

## Follow-up observations (not in this PR)

- `release-pr-multi-os.yml` has no paths-filter, so a docs-only `release/*` PR still runs the full ~13-minute matrix. Low priority given how rarely release PRs are docs-only.
- ast-grep is `npm install -g`'d six times per release PR (3 OS legs + range-verify + ci.yml `test` + ci.yml `test-race`); ~10–20s each. After this PR, five.
- On a release PR, ci.yml's advisory `Race Test` (565s) still duplicates the blocking ubuntu leg. Gating it with `if: !startsWith(github.head_ref, 'release/')` would save another ~565s with no loss of gate strength — but that edit lands in `ci.yml`, outside this PR's file scope.

## Verification

```
$ python3 -c "import yaml; d=yaml.safe_load(open('.github/workflows/release-pr-multi-os.yml')); ..."
jobs: ['detect-release', 'full-matrix-test', 'release-pr-gate']
matrix: ['ubuntu-latest', 'macos-latest', 'windows-latest']
gate needs: ['full-matrix-test']

$ grep -rn "release-range-verify\|Release Range Verify" .github/
(no matches — no dangling reference)
```

The required check name `Release PR Multi-OS Gate` is unchanged, so branch protection needs no edit.

Scope: one file, +25 / −100.

🗿 MoAI
