### PR TITLE
fix(test): re-aim two guards at the paths #1557 moved them to

### DIFF
--- a/internal/astgrep/gar_rule_test.go
+++ b/internal/astgrep/gar_rule_test.go
@@ -14,7 +14,7 @@ import (
 
 // This file is the SPEC-GATE-ASTGREP-REPAIR-001 regression guard for the
 // refined `go-error-not-wrapped` ast-grep rule. It exercises the REAL shipped
-// rule file (.moai/config/astgrep-rules/go/error-handling.yml) via the same
+// rule file (.moai/astgrep-rules/go/error-handling.yml) via the same
 // `sg scan --config` path the quality gate uses at commit time, and asserts
 // the three D1 acceptance criteria (AC-GAR-001/002/003).
 //
@@ -32,7 +32,9 @@ func requireSG(t *testing.T) {
 
 // projectRoot returns the repository root (the directory containing go.mod).
 // The testdata fixtures live under the astgrep package directory; the rule
-// file lives at <repo-root>/.moai/config/astgrep-rules/go/error-handling.yml.
+// file lives at <repo-root>/.moai/astgrep-rules/go/error-handling.yml — it
+// moved out of .moai/config/ in #1557, because `moai update` wipes
+// .moai/config/ wholesale and was deleting the local-only rules on every run.
 func projectRoot(t *testing.T) string {
 	t.Helper()
 	wd, err := os.Getwd()
@@ -61,7 +63,7 @@ func projectRoot(t *testing.T) string {
 func realRuleFile(t *testing.T) string {
 	t.Helper()
 	root := projectRoot(t)
-	p := filepath.Join(root, ".moai", "config", "astgrep-rules", "go", "error-handling.yml")
+	p := filepath.Join(root, ".moai", "astgrep-rules", "go", "error-handling.yml")
 	if _, err := os.Stat(p); err != nil {
 		t.Fatalf("shipped rule file not found: %s", p)
 	}

--- a/internal/spec/drift_doctrine_test.go
+++ b/internal/spec/drift_doctrine_test.go
@@ -38,7 +38,9 @@ func TestCloseSubjectDoctrineAmendment(t *testing.T) {
 	root := findRepoRoot(t)
 
 	files := []string{
-		filepath.Join(root, ".claude", "rules", "moai", "workflow", "lifecycle-sync-gate.md"),
+		// lifecycle-sync-gate.md moved out of .claude/rules/moai/ in #1557:
+		// `moai update` wipes that root wholesale, deleting local-only rules.
+		filepath.Join(root, ".claude", "rules", "local", "lifecycle-sync-gate.md"),
 		filepath.Join(root, ".claude", "rules", "moai", "development", "spec-frontmatter-schema.md"),
 	}
 


### PR DESCRIPTION
## main's Go suite is red, and has been since #1557

Two tests resolve paths that #1557 moved. `Test (ubuntu-latest)` is a required status check, so this blocks **every** PR that touches Go — it surfaced on #1563 (an unrelated workflow fix), not because that PR broke anything.

```
$ go test ./internal/astgrep/... -count=1        # at b1a5897f0 (main)
--- FAIL: TestGAR_AC001_NegativeReturnsNotMatched
--- FAIL: TestGAR_AC002_RealErrorReturnStillMatched
--- FAIL: TestGAR_AC003_AutofixDoesNotTouchNegatives
    gar_rule_test.go:126: shipped rule file not found:
      <root>/.moai/config/astgrep-rules/go/error-handling.yml

$ go test ./internal/spec/... -run TestCloseSubjectDoctrineAmendment -count=1
--- FAIL: TestCloseSubjectDoctrineAmendment/lifecycle-sync-gate.md
    read .../rules/moai/workflow/lifecycle-sync-gate.md: no such file or directory
```

The two were never hiding each other. `go test ./...` runs each package independently and no `-failfast` is configured anywhere in `.github/workflows/` or the `Makefile`, so both faults reported side by side the first time the real suite ran — visible together in one job log:

```
16:11:08  --- FAIL: TestGAR_AC001/AC002/AC003
16:11:08  FAIL  github.com/modu-ai/moai-adk/internal/astgrep  0.069s
16:14:26  --- FAIL: TestCloseSubjectDoctrineAmendment
16:14:26  FAIL  github.com/modu-ai/moai-adk/internal/spec     4.153s
```

What hid them was not Go's execution order but the stub job: the real suite had not run on main since the commit that broke it. Two CI rounds were spent here because the first pass fixed only what had been read out of that log, not because the second fault was invisible. The lesson is about method, not tooling — **when a commit moves paths, sweep every move exhaustively before fixing any of them, and never read one package turning green as the completion signal.**

## Cause

**ed04e40e6 (#1557)** moved local-only files out of the roots `moai update` wipes. Both moves were correct — `moai update` `os.RemoveAll`s `.moai/config/` and `.claude/rules/moai/` wholesale before redeploying, so anything local-only living there was being deleted on every run. What the commit missed was the two tests that resolve those paths.

| moved by #1557 | test still reading the old path |
|---|---|
| `.moai/config/astgrep-rules/` → `.moai/astgrep-rules/` | `internal/astgrep/gar_rule_test.go:64` |
| `.claude/rules/moai/workflow/lifecycle-sync-gate.md` → `.claude/rules/local/` | `internal/spec/drift_doctrine_test.go:41` |

Both files are intact at their new locations and still carry exactly what the tests assert. Only the constants were stale.

## Why it went unnoticed for four merges

The `Test` job is gated on the `go_code` paths-filter:

```yaml
go_code:
  - '**/*.go'
  - 'go.mod'
  - 'go.sum'
  - 'Makefile'
  - '.github/workflows/ci.yml'
  - '.github/workflows/codeql.yml'
```

**Neither `.moai/**` nor `.claude/**` is in that list — and those are exactly the trees these two tests read.** So #1557, which changed no `.go` file, read as "no Go changes". The complementary stub job then reported the required `Test (ubuntu-latest)` context green without running anything, and every main commit since happened to be non-Go and did the same:

| main commit | `Test (ubuntu-latest)` steps | what ran |
|---|---|---|
| `ed04e40e6` (#1557, the moves) | 3 | stub |
| `8592997e4` (#1558) | 3 | stub |
| `2ce06b439` (#1559) | 3 | stub |
| `ffb0d2439` (#1562) | 3 | stub |
| this PR | **13** | the real suite |

The real job has thirteen steps; the stub has three — `Set up job` / `Skip (no Go changes)` / `Complete job`. **The Go suite had not run on main since the commit that broke it.**

To be precise about where the hole is: the duplicate job name is deliberate and correct. A required context must be reported on every PR, which means both jobs have to render the same name, and skipping the Go suite on a genuinely docs-only PR is the right behaviour. The gap is one level up — the filter does not cover the trees a Go test reads. Renaming the jobs would break required-check matching and fix nothing. Widening the filter is the actual repair, filed separately rather than folded into a green-restoring PR.

## The fix

Two constants, plus the comments that repeated them.

```diff
-p := filepath.Join(root, ".moai", "config", "astgrep-rules", "go", "error-handling.yml")
+p := filepath.Join(root, ".moai", "astgrep-rules", "go", "error-handling.yml")

-filepath.Join(root, ".claude", "rules", "moai", "workflow", "lifecycle-sync-gate.md"),
+filepath.Join(root, ".claude", "rules", "local", "lifecycle-sync-gate.md"),
```

One commit each, so either can be reverted alone.

## Verification

```
before:  --- FAIL ×3  internal/astgrep   (shipped rule file not found)
         --- FAIL ×1  internal/spec      (no such file or directory)
after:   ok  github.com/modu-ai/moai-adk/internal/astgrep  0.529s
         ok  github.com/modu-ai/moai-adk/internal/spec     0.430s
```

The tests **execute** rather than skip — `-v` shows `--- PASS` for each of the three GAR cases and for both `TestCloseSubjectDoctrineAmendment` subtests, and `sg` resolves to ast-grep 0.40.5, the version CI pins:

```
--- PASS: TestGAR_AC001_NegativeReturnsNotMatched (0.02s)
--- PASS: TestGAR_AC002_RealErrorReturnStillMatched (0.01s)
--- PASS: TestGAR_AC003_AutofixDoesNotTouchNegatives (0.03s)
--- PASS: TestCloseSubjectDoctrineAmendment (0.00s)
```

`go vet` and `gofmt` clean. This PR changes `.go` files, so it matches `go_code` and the **real** Test job runs on it — a thirteen-step `Test (ubuntu-latest)` here is itself the evidence, and a three-step one would mean the stub answered again.

## Deliberately not fixed

- **The remaining `.moai/config/astgrep-rules` references are not breakage.** `grep -rn "config/astgrep-rules" --include="*.go"` returns **37** hits across 17 files, and they are the `RulesDir` default (`cli/gate.go`, `cli/astgrep.go`, `cli/astedit.go`, `astgrep/scanner.go`, `hook/quality/astgrep_gate.go`, `hook/security/rules.go`) plus the fixtures asserting on it — config strings written and read back, never resolved against the filesystem, so they pass and will keep passing. **Exactly two call sites actually opened a file at an old path, and both are fixed here**; a grep count reads as 37 problems where there were 2. The default being stale is real but separate, filed on its own (backlog t50).
- `rule_seed_test.go:74-98` — five more stale `.moai/config/astgrep-rules/<lang>` paths. They pass today by skipping on a missing directory, so correcting them would start new checks. Not something to mix into a PR whose job is restoring green.
- `drift_doctrine_test.go:42` — `spec-frontmatter-schema.md` sits beside the line changed above but was never moved by #1557 and resolves correctly. Left alone.
- The `go_code` filter's `.moai/**` and `.claude/**` blind spot — the root cause of the silent green, filed on its own.

`.moai/config/sections/gate.yaml` was checked too: #1557 updated `rules_dir` to `.moai/astgrep-rules` correctly, so the quality gate itself was never broken.

🗿 MoAI

