### PR TITLE
fix(cli): register moai mcp on root, and guard the registration

### DIFF
--- a/internal/cli/mcp_test.go
+++ b/internal/cli/mcp_test.go
@@ -29,6 +29,8 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 // baselineProjectMCP is the distributed 3-entry default seeded into each test
@@ -420,9 +422,12 @@ func TestMCP_Add_HTTPType(t *testing.T) {
 	}
 }
 
-// TestNewMCPCmd_Registered verifies the cobra command tree wiring. The
-// `moai mcp` parent + add/remove/list children MUST all be registered.
-func TestNewMCPCmd_Registered(t *testing.T) {
+// TestNewMCPCmd_FactoryChildren verifies that the factory attaches its three
+// children. It builds the command directly, so it says NOTHING about whether
+// root ever registers it — that gap is what let `moai mcp` ship unreachable
+// while this test passed. TestMCPCmdRegisteredOnRoot below covers the wiring;
+// keep both, they answer different questions.
+func TestNewMCPCmd_FactoryChildren(t *testing.T) {
 	t.Parallel()
 	cmd := newMCPCmd()
 	subs := cmd.Commands()
@@ -444,6 +449,47 @@ func TestNewMCPCmd_Registered(t *testing.T) {
 		}
 		if !found {
 			t.Errorf("subcommand %q not registered under moai mcp: %v", required, names)
+		}
+	}
+}
+
+// TestMCPCmdRegisteredOnRoot walks the real root command tree and asserts that
+// `moai mcp` is reachable from it with its three verbs.
+//
+// This is the guard the package was missing. newMCPCmd() existed and was fully
+// tested, but nothing added it to rootCmd, so `moai mcp` answered
+// `Unknown command "mcp" for "moai"` while README and the docs-site told users
+// to activate MCP entries with `moai mcp add <name>`. A factory-only test
+// cannot see that, because it never asks who calls the factory. Deleting the
+// AddCommand line in root.go must fail this test.
+func TestMCPCmdRegisteredOnRoot(t *testing.T) {
+	t.Parallel()
+
+	var mcp *cobra.Command
+	for _, c := range rootCmd.Commands() {
+		if c.Name() == "mcp" {
+			mcp = c
+			break
+		}
+	}
+	if mcp == nil {
+		names := make([]string, 0, len(rootCmd.Commands()))
+		for _, c := range rootCmd.Commands() {
+			names = append(names, c.Name())
+		}
+		t.Fatalf("`moai mcp` is not registered on rootCmd — README and docs-site "+
+			"document `moai mcp add <name>` as the way to enable MCP entries, so an "+
+			"unregistered factory makes a documented surface unreachable. "+
+			"Add newMCPCmd() in root.go next to newMCPServerCmd(). Registered: %v", names)
+	}
+
+	registered := map[string]bool{}
+	for _, sub := range mcp.Commands() {
+		registered[sub.Name()] = true
+	}
+	for _, verb := range []string{"add", "remove", "list"} {
+		if !registered[verb] {
+			t.Errorf("verb %q missing from the registered `moai mcp` tree: %v", verb, registered)
 		}
 	}
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -226,6 +226,14 @@ func init() {
 	// registering the subcommand does NOT provision any entry.
 	rootCmd.AddCommand(newMCPServerCmd())
 
+	// Register the `moai mcp` entry-management subtree (add / remove / list).
+	// Distinct from `mcp-server` above: that one RUNS the server, this one
+	// edits .mcp.json entries through the atomic-RMW seam. Both README and the
+	// docs-site tell users to activate the disabled entries with
+	// `moai mcp add <name>`, so leaving the factory unregistered made a
+	// documented surface unreachable. TestMCPCmdRegisteredOnRoot guards it.
+	rootCmd.AddCommand(newMCPCmd())
+
 	// SPEC-DIVECC-INVENTORY-VIEW-001: register inventory subcommand — a
 	// read-only unified view composing sessions / worktrees / harnesses.
 	rootCmd.AddCommand(newInventoryCmd())


### PR DESCRIPTION
Found while auditing the four READMEs in #1561: all of them tell users to enable the disabled MCP entries with `moai mcp add <name>`, and add that users "never hand-edit `.mcp.json`". Neither was true — `moai mcp` did not exist as a runnable command.

```
$ moai mcp
  ERROR  Unknown command "mcp" for "moai"

$ grep -rn 'newMCPCmd' --include='*.go' .
  internal/cli/mcp.go:60        (definition)
  internal/cli/mcp_test.go:427  (its own test)
  → zero registrations on root
```

`newMCPCmd()` builds a complete `add` / `remove` / `list` tree over the same atomic-RMW seam the GLM tools CLI uses, and fourteen tests cover its behaviour. Nothing added it to `rootCmd`. The command was written, tested, documented, and unreachable.

## Why the tests did not catch it

`TestNewMCPCmd_Registered` — the name promises registration coverage — called `newMCPCmd()` directly and asserted the factory's own children. It never asked *who calls the factory*, so it passed identically whether or not root registered anything. That is the actual defect worth fixing: a one-line omission stayed invisible because the test that would have caught it was testing the wrong side of the boundary.

Two changes:

- Renamed it to `TestNewMCPCmd_FactoryChildren`, so its name matches what it checks. It still earns its place — factory wiring and root wiring are different questions.
- Added `TestMCPCmdRegisteredOnRoot`, which walks the real `rootCmd` tree, finds `mcp`, and asserts its three verbs.

## Verified the guard fails for the right reason

With the `AddCommand` line removed:

```
--- PASS: TestNewMCPCmd_FactoryChildren (0.00s)
--- FAIL: TestMCPCmdRegisteredOnRoot (0.00s)
    mcp_test.go:480: `moai mcp` is not registered on rootCmd — README and docs-site
    document `moai mcp add <name>` as the way to enable MCP entries, so an
    unregistered factory makes a documented surface unreachable.
    Add newMCPCmd() in root.go next to newMCPServerCmd(). Registered: [agent
    ast-edit ast-grep cc cg chain clean config constitution doctor epic gate
    github glm goal handoff harness hook init inventory loop lsp mcp-server ...]
```

The old test passing beside the new one failing is the gap itself, reproduced. Line restored afterwards; the diff below is the restored state.

## All three verbs work end to end

Built from this branch, run against a scratch project root so no tracked `.mcp.json` was touched:

```
$ moai mcp add probe-tool --command npx --args -y --args probe-mcp
$ moai mcp list --json
{ "scope": "project", "count": 1,
  "entries": [ { "name": "probe-tool", "type": "stdio",
                 "entry": { "args": ["-y","probe-mcp"], "command": "npx" } } ] }
$ moai mcp remove probe-tool
$ moai mcp list
scope: project
count: 0
```

And against this checkout's real `.mcp.json`, `moai mcp list` reports the four entries actually present.

## Placement

Registered immediately after `newMCPServerCmd()`, following that command's pattern exactly — no `GroupID`, so `mcp` lands beside `mcp-server` in the ungrouped help block. They are siblings, not parent and child: `mcp-server` *runs* the server, `mcp` *edits* entries. The help-order tests assert within-group ordering and membership stability, so an ungrouped addition leaves them untouched.

## Scope

The READMEs are deliberately untouched. The docs described the intended behaviour correctly and the code had not caught up; rewriting them to describe hand-editing `.mcp.json` would have frozen the bug as the specification.

## Verification

- `go build ./...` clean
- `go vet ./internal/cli/` clean; `GOOS=windows go vet ./internal/cli/` clean
- `gofmt -l` on both changed files: no output
- `go test ./internal/cli/ -run MCP -count=1` — all 16 pass, including the new guard
- `go test ./internal/cli/... -count=1` — every subpackage passes

**One pre-existing failure, out of scope and reported rather than touched:** `TestHandleCodexReviewGate_LiveCodexBlocksInjectionAndKey` fails with `expected BLOCK ...; got decision="" err=<nil>`. It is a live integration test that shells out to the real `codex` binary and asserts the model returns BLOCK on an injection + AWS-key fixture; it skips when codex is absent, so CI never runs it. It reproduces in isolation on a run touching nothing in this diff, and this change adds a cobra registration and a test — no path to the codex gate. The test's own comment says a non-BLOCK is "a real result — report it", so: reported. I did not reproduce it on the base commit, so I am not claiming it as pre-existing on evidence, only that this change cannot plausibly cause it.

🗿 MoAI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `moai mcp` command to the CLI.
  * Added commands for managing MCP entries: `add`, `remove`, and `list`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->