### PR TITLE
fix(install): resolve the latest version in install.ps1 without the REST API

### DIFF
--- a/docs-site/static/install.ps1
+++ b/docs-site/static/install.ps1
@@ -135,30 +135,69 @@ function Get-Platform {
 }
 
 # Get latest Go edition version
+#
+# Resolved from the /releases/latest redirect rather than the REST API, matching
+# get_latest_version in install.sh. Two reasons, both of which bit real installs:
+#
+#   1. api.github.com allows 60 unauthenticated requests per hour per IP. Behind
+#      a shared address — an office, a CI runner, a developer who has been
+#      working with `gh` — that budget is routinely spent, and the API then
+#      answers with a JSON error object carrying no tag_name. The old code read
+#      the empty result as "no releases exist" and told the user the project had
+#      never shipped. The redirect is not part of the API and is not rate
+#      limited.
+#
+#   2. The old code asked for /releases (the list) and took the first entry,
+#      which is the most recently *created* release — a draft or a release
+#      candidate, if one exists. /releases/latest is the endpoint that actually
+#      means "latest stable": GitHub excludes drafts and prereleases from it.
 function Get-LatestVersion {
-    $versionUrl = "https://api.github.com/repos/modu-ai/moai-adk/releases"
+    $latestUrl = "https://github.com/modu-ai/moai-adk/releases/latest"
+    $resolved = ""
 
     try {
-        $response = Invoke-RestMethod -Uri $versionUrl -Method Get
-        # Find the latest release (accept both v* and go-v* tags)
-        $goRelease = $response | Where-Object { $_.tag_name -like "v*" -or $_.tag_name -like "go-v*" } | Select-Object -First 1
+        # Bounded: a lookup that hangs is indistinguishable to the user from an
+        # installer that has crashed, and this step only reads a redirect header.
+        $response = Invoke-WebRequest -Uri $latestUrl -Method Head `
+            -MaximumRedirection 10 -UseBasicParsing -TimeoutSec 10 -ErrorAction Stop
 
-        if (-not $goRelease) {
-            Print-Error "No releases found"
-            Print-Info "You can:"
-            Write-Host "  1. Install a specific version: .\install.ps1 -version 2.0.0"
-            Write-Host "  2. Install from source: go install github.com/modu-ai/moai-adk/cmd/moai@latest"
-            exit 1
+        # The resolved URI is exposed in a different place per edition, and the
+        # script supports 5.1 upward: Windows PowerShell 5.1 returns a
+        # System.Net.HttpWebResponse (ResponseUri), PowerShell 6+ returns a
+        # System.Net.Http.HttpResponseMessage (RequestMessage.RequestUri).
+        # Probed rather than assumed so neither edition throws on the other's
+        # property name.
+        $base = $response.BaseResponse
+        if ($base.PSObject.Properties['RequestMessage']) {
+            $resolved = [string]$base.RequestMessage.RequestUri.AbsoluteUri
         }
-
-        $version = $goRelease.tag_name -replace '^go-v', '' -replace '^v', ''
-        Print-Success "Latest Go edition version: $version"
-        return $version
+        elseif ($base.PSObject.Properties['ResponseUri']) {
+            $resolved = [string]$base.ResponseUri.AbsoluteUri
+        }
     }
     catch {
-        Print-Error "Failed to fetch latest Go edition version from GitHub: $_"
+        # Leave $resolved empty and fall through to the shared failure message,
+        # so an unreachable host and an unparseable redirect are reported the
+        # same way rather than one of them surfacing a raw exception.
+        $resolved = ""
+    }
+
+    # .../releases/tag/v3.1.0 -> 3.1.0
+    $version = ""
+    if ($resolved -match '/tag/(?<tag>[^/?#]+)') {
+        $version = $Matches['tag'] -replace '^go-', '' -replace '^v', ''
+    }
+
+    if ([string]::IsNullOrEmpty($version)) {
+        Print-Error "Could not determine the latest version from GitHub"
+        Print-Info "GitHub may be unreachable from this network. You can:"
+        Write-Host "  1. Install a specific version: .\install.ps1 -version 3.1.0"
+        Write-Host "  2. Install from source: go install github.com/modu-ai/moai-adk/cmd/moai@latest"
         exit 1
     }
+
+    Print-Success "Latest Go edition version: $version"
+    return $version
 }
 
 # Download binary

--- a/install.ps1
+++ b/install.ps1
@@ -135,30 +135,69 @@ function Get-Platform {
 }
 
 # Get latest Go edition version
+#
+# Resolved from the /releases/latest redirect rather than the REST API, matching
+# get_latest_version in install.sh. Two reasons, both of which bit real installs:
+#
+#   1. api.github.com allows 60 unauthenticated requests per hour per IP. Behind
+#      a shared address — an office, a CI runner, a developer who has been
+#      working with `gh` — that budget is routinely spent, and the API then
+#      answers with a JSON error object carrying no tag_name. The old code read
+#      the empty result as "no releases exist" and told the user the project had
+#      never shipped. The redirect is not part of the API and is not rate
+#      limited.
+#
+#   2. The old code asked for /releases (the list) and took the first entry,
+#      which is the most recently *created* release — a draft or a release
+#      candidate, if one exists. /releases/latest is the endpoint that actually
+#      means "latest stable": GitHub excludes drafts and prereleases from it.
 function Get-LatestVersion {
-    $versionUrl = "https://api.github.com/repos/modu-ai/moai-adk/releases"
+    $latestUrl = "https://github.com/modu-ai/moai-adk/releases/latest"
+    $resolved = ""
 
     try {
-        $response = Invoke-RestMethod -Uri $versionUrl -Method Get
-        # Find the latest release (accept both v* and go-v* tags)
-        $goRelease = $response | Where-Object { $_.tag_name -like "v*" -or $_.tag_name -like "go-v*" } | Select-Object -First 1
+        # Bounded: a lookup that hangs is indistinguishable to the user from an
+        # installer that has crashed, and this step only reads a redirect header.
+        $response = Invoke-WebRequest -Uri $latestUrl -Method Head `
+            -MaximumRedirection 10 -UseBasicParsing -TimeoutSec 10 -ErrorAction Stop
 
-        if (-not $goRelease) {
-            Print-Error "No releases found"
-            Print-Info "You can:"
-            Write-Host "  1. Install a specific version: .\install.ps1 -version 2.0.0"
-            Write-Host "  2. Install from source: go install github.com/modu-ai/moai-adk/cmd/moai@latest"
-            exit 1
+        # The resolved URI is exposed in a different place per edition, and the
+        # script supports 5.1 upward: Windows PowerShell 5.1 returns a
+        # System.Net.HttpWebResponse (ResponseUri), PowerShell 6+ returns a
+        # System.Net.Http.HttpResponseMessage (RequestMessage.RequestUri).
+        # Probed rather than assumed so neither edition throws on the other's
+        # property name.
+        $base = $response.BaseResponse
+        if ($base.PSObject.Properties['RequestMessage']) {
+            $resolved = [string]$base.RequestMessage.RequestUri.AbsoluteUri
         }
-
-        $version = $goRelease.tag_name -replace '^go-v', '' -replace '^v', ''
-        Print-Success "Latest Go edition version: $version"
-        return $version
+        elseif ($base.PSObject.Properties['ResponseUri']) {
+            $resolved = [string]$base.ResponseUri.AbsoluteUri
+        }
     }
     catch {
-        Print-Error "Failed to fetch latest Go edition version from GitHub: $_"
+        # Leave $resolved empty and fall through to the shared failure message,
+        # so an unreachable host and an unparseable redirect are reported the
+        # same way rather than one of them surfacing a raw exception.
+        $resolved = ""
+    }
+
+    # .../releases/tag/v3.1.0 -> 3.1.0
+    $version = ""
+    if ($resolved -match '/tag/(?<tag>[^/?#]+)') {
+        $version = $Matches['tag'] -replace '^go-', '' -replace '^v', ''
+    }
+
+    if ([string]::IsNullOrEmpty($version)) {
+        Print-Error "Could not determine the latest version from GitHub"
+        Print-Info "GitHub may be unreachable from this network. You can:"
+        Write-Host "  1. Install a specific version: .\install.ps1 -version 3.1.0"
+        Write-Host "  2. Install from source: go install github.com/modu-ai/moai-adk/cmd/moai@latest"
         exit 1
     }
+
+    Print-Success "Latest Go edition version: $version"
+    return $version
 }
 
 # Download binary


### PR DESCRIPTION
Follow-up to #1559, which fixed the two shell installers and left the two PowerShell ones behind.

## The gap

#1559 touched exactly two files:

```
$ git show --stat --format="" 2ce06b439
 docs-site/static/install.sh | 49 +++++++++++++++++++++++++++++++-------
 install.sh                  | 49 +++++++++++++++++++++++++++++++-------
```

`install.ps1` and `docs-site/static/install.ps1` still carried the logic that commit removed:

```powershell
$versionUrl = "https://api.github.com/repos/modu-ai/moai-adk/releases"
$response = Invoke-RestMethod -Uri $versionUrl -Method Get
$goRelease = $response | Where-Object { $_.tag_name -like "v*" -or $_.tag_name -like "go-v*" } |
             Select-Object -First 1
```

Both failure modes #1559 documented were therefore still live on Windows.

**Rate limiting.** Unauthenticated `api.github.com` allows 60 requests per hour per IP. Past that it answers with a JSON *object* carrying `message`, not an array of releases. `Where-Object` finds no `tag_name` in it, `-not $goRelease` is true, and the installer prints "No releases found" — telling the user the project has never shipped. Reproduced by feeding the observed rate-limit response shape to the old filter:

```
$ pwsh -NoProfile -c '$ratelimited = @{ message = "API rate limit exceeded ..." } | ...'
--- rate-limited 응답을 구 로직에 투입 ---
OLD RESULT: <No releases found> -> exit 1
```

**Wrong endpoint.** `/releases` returns releases in creation order, so `Select-Object -First 1` takes the most recently *created* release rather than the latest stable one.

## The fix follows install.sh rather than re-deriving one

Both installers now resolve a version identically: HEAD `/releases/latest`, read the resolved URI, take the segment after `/tag/`, strip a `go-` then a `v` prefix, and fall through to one shared failure message when nothing parses. Timeouts are bounded for the reason the shell version bounds them — a lookup that hangs is indistinguishable from a crashed installer.

One thing install.sh never has to handle: the resolved URI lives in a different property per PowerShell edition.

| Edition | `BaseResponse` type | Property |
|---|---|---|
| Windows PowerShell 5.1 | `System.Net.HttpWebResponse` | `.ResponseUri` |
| PowerShell 6+ | `System.Net.Http.HttpResponseMessage` | `.RequestMessage.RequestUri` |

The script's header declares "Requires PowerShell 5.1 or later", and its platform detection already branches on `$IsWindows` being null (lines 248/267) — i.e. it genuinely runs under both. So the property is probed rather than assumed, and neither edition throws on the other's name.

## Verification

Ran against the live repository with PowerShell 7.5.4:

```
$ pwsh -NoProfile -c '. ./install.ps1; $v = Get-LatestVersion; Write-Host "NEW RESULT: $v"'
[SUCCESS] Latest Go edition version: 3.1.0
NEW RESULT: 3.1.0

$ pwsh -NoProfile -c '[System.Management.Automation.Language.Parser]::ParseFile(...)'
PARSE OK: 0 errors
```

Edition-shape probe, confirming which branch PowerShell 7 takes:

```
BaseResponse type: System.Net.Http.HttpResponseMessage
has RequestMessage: True
has ResponseUri:    False
resolved: https://github.com/modu-ai/moai-adk/releases/tag/v3.1.0
```

The two copies are byte-identical, as they were before this change (`diff -q` clean).

`.github/workflows/test-install.yml` greps `install.ps1` for `IsWindows`, `GetTempPath`, and `MOAI_INSTALL_DIR`; all three survive (2 / 1 / 3 occurrences). None of them live in the edited function.

## What is NOT verified

**The 5.1 branch is not executed here.** It is written from the documented response type, but this machine has no Windows PowerShell. Only the 6+ branch was run. That is the residual risk of this PR, and it is the branch that matters most on the target platform — a Windows box on stock PowerShell 5.1 takes the untested path.

**A draft release does not discriminate the fix.** The obvious test — "does the old code pick the v3.1.1 draft?" — does not reproduce, because GitHub excludes drafts from unauthenticated responses. Measured with the old logic verbatim while that draft existed:

```
entries: 30
  v3.1.0  draft=False prerelease=False
  v3.0.1  draft=False prerelease=False
  ...
OLD RESULT: 3.1.0
```

Same answer as the new code. The draft is invisible to an anonymous installer, so it was never the live hazard — the rate limit was, which is why that is what the reproduction above exercises.

Worth noting for a separate day: `v3.0.0-rc12` is recorded with `prerelease=False`. The "excludes prereleases" half of the `/releases/latest` guarantee only helps if release candidates are actually flagged as prereleases, and in this repository they have not been.

## Left alone deliberately — install.bat has the same defect

`install.bat:58` shells out to the identical one-liner:

```bat
for /f "tokens=*" %%i in ('powershell -Command "$releases = Invoke-RestMethod -Uri https://api.github.com/repos/modu-ai/moai-adk/releases; $goRelease = $releases ^| Where-Object { ... } ^| Select-Object -First 1; ..."') do (
```

Not fixed here. cmd.exe quoting and `for /f` escaping cannot be verified from this machine, and an unverified edit to a Windows entry point is worse than the bug it would replace. Filing it as a follow-up rather than shipping a change nobody has run.

🗿 MoAI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the installer’s ability to identify the latest stable release.
  * Added compatibility across supported PowerShell versions.
  * Improved handling and messaging for release lookup or version-detection failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->