### PR TITLE
fix(profile): match the launch ledger by directory, not by path spelling

### DIFF
--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -275,6 +275,48 @@ func normalizeProjectKey(projectRoot string) string {
 	return cleaned
 }
 
+// lookupProjectKey finds the ledger key that names the SAME directory as key,
+// returning the stored key and whether one was found.
+//
+// An exact string match wins. When it misses, the map is scanned and each
+// candidate is compared with os.SameFile — the filesystem itself decides
+// whether two spellings name one directory, rather than this code guessing a
+// per-OS case rule.
+//
+// The case-variant miss is the failure this exists for. On macOS and Windows
+// the filesystem is case-insensitive, so `cd /Users/x/moai/repo` and
+// `cd /Users/x/MoAI/repo` open the same directory, but os.Getwd reports back
+// whichever spelling the shell used and filepath.EvalSymlinks does NOT
+// canonicalize case. The two spellings therefore hash to different ledger keys,
+// the lookup misses, and the launch silently falls back to the default profile
+// — which stores its transcripts elsewhere, so `--continue` / `--resume` find
+// no prior session. os.SameFile keeps the lookup correct on case-sensitive
+// filesystems too, where two same-spelled-but-differently-cased directories can
+// genuinely both exist and must NOT be conflated.
+func lookupProjectKey(projects map[string]any, key string) (string, bool) {
+	if key == "" || projects == nil {
+		return "", false
+	}
+	if _, ok := projects[key]; ok {
+		return key, true
+	}
+
+	info, err := os.Stat(key)
+	if err != nil {
+		return "", false
+	}
+	for candidate := range projects {
+		candidateInfo, err := os.Stat(candidate)
+		if err != nil {
+			continue
+		}
+		if os.SameFile(info, candidateInfo) {
+			return candidate, true
+		}
+	}
+	return "", false
+}
+
 // loadLaunchLedger reads and decodes the ledger as a generic map so unknown and
 // legacy keys are tolerated rather than rejected. A missing or corrupt file
 // yields an error the callers translate into "no fallback".
@@ -339,8 +381,10 @@ func ResolveLaunchProfileForProject(projectRoot, profileName string) string {
 
 	if key := normalizeProjectKey(projectRoot); key != "" {
 		if projects, ok := ledger[projectsKey].(map[string]any); ok {
-			if name, ok := projects[key].(string); ok && launchCandidateIsUsable(baseDir, name) {
-				return name
+			if stored, found := lookupProjectKey(projects, key); found {
+				if name, ok := projects[stored].(string); ok && launchCandidateIsUsable(baseDir, name) {
+					return name
+				}
 			}
 		}
 	}
@@ -435,6 +479,13 @@ func RecordLastUsedProfileForProject(projectRoot, name string) error {
 		projects, ok := existing[projectsKey].(map[string]any)
 		if !ok {
 			projects = make(map[string]any)
+		}
+		// Reuse the key already recorded for this directory when one exists.
+		// Writing the caller's spelling instead would leave two entries naming
+		// one project, and the pair drifts apart on the next launch from the
+		// other spelling.
+		if stored, found := lookupProjectKey(projects, key); found {
+			key = stored
 		}
 		projects[key] = name
 		existing[projectsKey] = projects

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/modu-ai/moai-adk/internal/config"
@@ -305,7 +306,20 @@ func lookupProjectKey(projects map[string]any, key string) (string, bool) {
 	if err != nil {
 		return "", false
 	}
+
+	// Sorted, not map order. A ledger written before this fix can already hold
+	// two spellings of one directory, and Go randomizes map iteration — scanning
+	// unordered would hand back either entry from run to run, so a project with
+	// duplicates would resolve to a different profile (and a different
+	// transcript store) on each launch. Sorting makes the winner the same every
+	// time, and the write side collapses the duplicate on the next launch.
+	candidates := make([]string, 0, len(projects))
 	for candidate := range projects {
+		candidates = append(candidates, candidate)
+	}
+	sort.Strings(candidates)
+
+	for _, candidate := range candidates {
 		candidateInfo, err := os.Stat(candidate)
 		if err != nil {
 			continue

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -319,16 +319,47 @@ func lookupProjectKey(projects map[string]any, key string) (string, bool) {
 	}
 	sort.Strings(candidates)
 
+	var matched string
+	var conflict string
 	for _, candidate := range candidates {
 		candidateInfo, err := os.Stat(candidate)
 		if err != nil {
 			continue
 		}
-		if os.SameFile(info, candidateInfo) {
-			return candidate, true
+		if !os.SameFile(info, candidateInfo) {
+			continue
+		}
+		if matched == "" {
+			matched = candidate
+			continue
+		}
+		// A second entry for the same directory. Sorting already fixed WHICH one
+		// wins, but when the two name different profiles the winner is stable and
+		// still possibly not the one the user meant — and nothing in the ledger
+		// records which was written last. Only the user can say, so say so once
+		// rather than routing them somewhere silently.
+		if asString(projects[candidate]) != asString(projects[matched]) && conflict == "" {
+			conflict = candidate
 		}
 	}
-	return "", false
+
+	if conflict != "" {
+		fmt.Fprintf(os.Stderr,
+			"Warning: %s records %q twice for one directory, under different profiles (%q vs %q).\n"+
+				"Using %q. Remove the stale entry from %s to silence this.\n",
+			launchLedgerFile, key,
+			asString(projects[matched]), asString(projects[conflict]),
+			asString(projects[matched]), filepath.Join(GetBaseDir(), launchLedgerFile))
+	}
+
+	return matched, matched != ""
+}
+
+// asString reads a ledger value as a string, yielding "" for a non-string entry
+// rather than panicking on a hand-edited or downgrade-written ledger.
+func asString(v any) string {
+	s, _ := v.(string)
+	return s
 }
 
 // loadLaunchLedger reads and decodes the ledger as a generic map so unknown and

--- a/internal/profile/project_key_casing_test.go
+++ b/internal/profile/project_key_casing_test.go
@@ -1,6 +1,7 @@
 package profile
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -167,4 +168,73 @@ func TestLookupProjectKey_DuplicateEntriesResolveDeterministically(t *testing.T)
 			t.Fatalf("iteration %d: got (%q, %v), want the stable (%q, true)", i, got, ok, first)
 		}
 	}
+}
+
+// TestLookupProjectKey_ConflictingDuplicatesWarn asserts the user is told when
+// one directory carries two entries naming different profiles. Sorting makes the
+// pick stable, but stability is not correctness — nothing in the ledger says
+// which entry was meant, so the ambiguity is surfaced instead of hidden.
+func TestLookupProjectKey_ConflictingDuplicatesWarn(t *testing.T) {
+	pmSandboxBase(t)
+
+	root := pmProjectDir(t)
+	variant, sameDir := caseVariantOf(t, root)
+	if !sameDir {
+		t.Skip("case-sensitive filesystem: a case-variant path names a different directory here")
+	}
+	lookup := filepath.Join(filepath.Dir(root), "MoAI-adk-go")
+	if _, err := os.Stat(lookup); err != nil {
+		t.Skipf("third case spelling does not resolve here: %v", err)
+	}
+
+	t.Run("conflicting values warn", func(t *testing.T) {
+		stderr := captureStderr(t, func() {
+			if _, found := lookupProjectKey(map[string]any{root: "profile-a", variant: "profile-b"}, lookup); !found {
+				t.Fatal("lookup found nothing")
+			}
+		})
+		for _, want := range []string{"profile-a", "profile-b", launchLedgerFile} {
+			if !strings.Contains(stderr, want) {
+				t.Errorf("warning missing %q; got: %s", want, stderr)
+			}
+		}
+	})
+
+	t.Run("agreeing values stay silent", func(t *testing.T) {
+		stderr := captureStderr(t, func() {
+			if _, found := lookupProjectKey(map[string]any{root: "profile-a", variant: "profile-a"}, lookup); !found {
+				t.Fatal("lookup found nothing")
+			}
+		})
+		if stderr != "" {
+			t.Errorf("duplicates naming ONE profile are unambiguous and must not warn; got: %s", stderr)
+		}
+	})
+}
+
+// captureStderr redirects os.Stderr for the duration of fn and returns what was
+// written. The pipe is drained on a goroutine so a warning larger than the pipe
+// buffer cannot deadlock the test.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	orig := os.Stderr
+	os.Stderr = w
+	done := make(chan string, 1)
+	go func() {
+		var b strings.Builder
+		_, _ = io.Copy(&b, r)
+		done <- b.String()
+	}()
+
+	fn()
+
+	os.Stderr = orig
+	_ = w.Close()
+	out := <-done
+	_ = r.Close()
+	return out
 }

--- a/internal/profile/project_key_casing_test.go
+++ b/internal/profile/project_key_casing_test.go
@@ -1,0 +1,138 @@
+package profile
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// pmProjectDir makes a project directory whose NAME carries letters. The bare
+// t.TempDir() leaf is digits ("001"), which has no case variant, so a test
+// built on it would skip everywhere rather than exercise the fold.
+func pmProjectDir(t *testing.T) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "moai-adk-go")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("create project dir: %v", err)
+	}
+	return dir
+}
+
+// caseVariantOf returns a spelling of path whose last element differs only in
+// case, plus whether the filesystem actually resolves it to the same directory.
+// On a case-sensitive filesystem the variant names nothing, so the caller skips
+// the case-fold assertions rather than asserting behavior the platform cannot
+// exhibit.
+func caseVariantOf(t *testing.T, path string) (string, bool) {
+	t.Helper()
+	dir, base := filepath.Split(path)
+	variant := filepath.Join(dir, strings.ToUpper(base))
+	if variant == path {
+		variant = filepath.Join(dir, strings.ToLower(base))
+	}
+	if variant == path {
+		return "", false
+	}
+
+	original, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %q: %v", path, err)
+	}
+	varied, err := os.Stat(variant)
+	if err != nil {
+		return "", false // case-sensitive filesystem
+	}
+	return variant, os.SameFile(original, varied)
+}
+
+// TestResolveLaunchProfileForProject_CaseVariantPath is the regression guard for
+// the silent profile split: entering the project through a differently-cased
+// path made the ledger lookup miss, the launch fell back to the default
+// profile, and that profile's separate transcript store left --continue /
+// --resume with no prior session to find.
+func TestResolveLaunchProfileForProject_CaseVariantPath(t *testing.T) {
+	base := pmSandboxBase(t)
+	pmMkProfile(t, base, "moai-adk")
+
+	root := pmProjectDir(t)
+	variant, sameDir := caseVariantOf(t, root)
+	if !sameDir {
+		t.Skip("case-sensitive filesystem: a case-variant path names a different directory here")
+	}
+
+	pmWriteLedger(t, base, "projects:\n    "+root+": moai-adk\n")
+
+	if got := ResolveLaunchProfileForProject(root, ""); got != "moai-adk" {
+		t.Fatalf("exact-spelling lookup: got %q, want %q", got, "moai-adk")
+	}
+	if got := ResolveLaunchProfileForProject(variant, ""); got != "moai-adk" {
+		t.Fatalf("case-variant lookup %q: got %q, want %q", variant, got, "moai-adk")
+	}
+}
+
+// TestRecordLastUsedProfileForProject_CaseVariantReusesKey asserts the write
+// side keeps ONE entry per directory. A second entry under the other spelling
+// would drift from the first on the next launch, re-opening the split this fix
+// closes.
+func TestRecordLastUsedProfileForProject_CaseVariantReusesKey(t *testing.T) {
+	base := pmSandboxBase(t)
+	pmMkProfile(t, base, "moai-adk")
+
+	root := pmProjectDir(t)
+	variant, sameDir := caseVariantOf(t, root)
+	if !sameDir {
+		t.Skip("case-sensitive filesystem: a case-variant path names a different directory here")
+	}
+
+	if err := RecordLastUsedProfileForProject(root, "moai-adk"); err != nil {
+		t.Fatalf("record with exact spelling: %v", err)
+	}
+	if err := RecordLastUsedProfileForProject(variant, "moai-adk"); err != nil {
+		t.Fatalf("record with case-variant spelling: %v", err)
+	}
+
+	ledger := pmReadLedger(t, base)
+	projects, ok := ledger["projects"].(map[string]any)
+	if !ok {
+		t.Fatalf("projects map absent from ledger: %#v", ledger)
+	}
+	if len(projects) != 1 {
+		t.Fatalf("want one entry for one directory, got %d: %#v", len(projects), projects)
+	}
+}
+
+// TestLookupProjectKey_DistinctDirectoriesDoNotMatch is the falsification pass:
+// the fallback must widen the lookup to other spellings of the SAME directory
+// and to nothing else. Without this, a scan that matched loosely would hand a
+// project another project's profile.
+func TestLookupProjectKey_DistinctDirectoriesDoNotMatch(t *testing.T) {
+	recorded := pmProjectDir(t)
+	other := pmProjectDir(t)
+
+	projects := map[string]any{recorded: "moai-adk"}
+
+	if got, found := lookupProjectKey(projects, recorded); !found || got != recorded {
+		t.Fatalf("same directory: got (%q, %v), want (%q, true)", got, found, recorded)
+	}
+	if got, found := lookupProjectKey(projects, other); found {
+		t.Fatalf("distinct directory %q matched key %q", other, got)
+	}
+}
+
+// TestLookupProjectKey_MissingDirectoryDoesNotMatch covers the deleted-project
+// case: a key that no longer stats must not be scanned into a false match, and
+// a lookup for a vanished root must miss rather than pick an arbitrary entry.
+func TestLookupProjectKey_MissingDirectoryDoesNotMatch(t *testing.T) {
+	live := pmProjectDir(t)
+	gone := filepath.Join(t.TempDir(), "removed")
+
+	projects := map[string]any{gone: "ghost", live: "moai-adk"}
+
+	if _, found := lookupProjectKey(projects, filepath.Join(t.TempDir(), "also-removed")); found {
+		t.Fatal("a lookup for a nonexistent directory must miss")
+	}
+	if got, found := lookupProjectKey(projects, live); !found || got != live {
+		t.Fatalf("live directory: got (%q, %v), want (%q, true)", got, found, live)
+	}
+}

--- a/internal/profile/project_key_casing_test.go
+++ b/internal/profile/project_key_casing_test.go
@@ -136,3 +136,35 @@ func TestLookupProjectKey_MissingDirectoryDoesNotMatch(t *testing.T) {
 		t.Fatalf("live directory: got (%q, %v), want (%q, true)", got, found, live)
 	}
 }
+
+// TestLookupProjectKey_DuplicateEntriesResolveDeterministically covers the
+// ledger a pre-fix launcher could already have written: two spellings of one
+// directory, each naming a different profile. Go randomizes map iteration, so
+// an unordered scan would pick either one from run to run and the project would
+// alternate between two transcript stores — the very split this fix closes.
+func TestLookupProjectKey_DuplicateEntriesResolveDeterministically(t *testing.T) {
+	root := pmProjectDir(t)
+	variant, sameDir := caseVariantOf(t, root)
+	if !sameDir {
+		t.Skip("case-sensitive filesystem: a case-variant path names a different directory here")
+	}
+
+	// A lookup by a THIRD spelling so neither entry wins by exact match.
+	lookup := filepath.Join(filepath.Dir(root), "MoAI-adk-go")
+	if _, err := os.Stat(lookup); err != nil {
+		t.Skipf("third case spelling does not resolve here: %v", err)
+	}
+
+	projects := map[string]any{root: "profile-a", variant: "profile-b"}
+
+	first, found := lookupProjectKey(projects, lookup)
+	if !found {
+		t.Fatal("duplicate-entry lookup found nothing")
+	}
+	for i := range 50 {
+		got, ok := lookupProjectKey(projects, lookup)
+		if !ok || got != first {
+			t.Fatalf("iteration %d: got (%q, %v), want the stable (%q, true)", i, got, ok, first)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

Entering a project through a differently-cased path silently sent the launch to the **default** profile, and with it to a different transcript store — so `moai cc -c` / `-r` found no prior session and the project's history looked lost.

`launch.yaml` records a project under the spelling the launcher saw:

```yaml
projects:
    /Users/goos/MoAI/moai-adk-go: moai-adk
```

On a case-insensitive filesystem `cd .../moai/moai-adk-go` and `cd .../MoAI/moai-adk-go` open the same directory, but `os.Getwd` returns whichever spelling the shell used and `filepath.EvalSymlinks` does **not** canonicalize case. Two spellings, two keys, lookup miss.

## Fix

`lookupProjectKey` falls back to `os.SameFile` when the exact string misses — the filesystem decides whether two spellings name one directory, instead of this code guessing a per-OS case rule. Case-sensitive filesystems keep working: there `moai/` and `MoAI/` really are two directories and `SameFile` says no.

The write side reuses an already-recorded spelling, so one directory never accumulates two entries that later drift apart.

## Verification

A/B against the pre-fix binary:

```
=== PWD=/Users/goos/moai/moai-adk-go  (lowercase) ===
  old: default        <- the split
  new: moai-adk
=== PWD=/Users/goos/MoAI/moai-adk-go  (canonical) ===
  old: moai-adk
  new: moai-adk
```

`go test ./internal/profile/ ./internal/cli/` — ok. Four new tests:

| Test | Guards |
|---|---|
| `CaseVariantPath` | case-variant path resolves to the same profile |
| `CaseVariantReusesKey` | one directory keeps one ledger entry |
| `DistinctDirectoriesDoNotMatch` | a genuinely different directory never matches |
| `MissingDirectoryDoesNotMatch` | a deleted path matches nothing |

The two case-fold tests skip on a case-sensitive filesystem rather than assert behavior the platform cannot exhibit.

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project profile recognition for paths that differ only by letter casing.
  * Prevented duplicate project entries when equivalent path spellings are used.
  * Ensured distinct or missing directories are not incorrectly treated as the same project.
  * Made matching deterministic when multiple equivalent entries exist.
  * Added warnings for conflicting profiles and safely handled invalid project data.

* **Tests**
  * Added coverage for case variants, duplicate entries, conflicting profiles, distinct directories, and missing directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->