### PR TITLE
feat(cli): make bare `moai todo` list, and add `moai memory` doctor/archive

### DIFF
--- a/internal/cli/memory.go
+++ b/internal/cli/memory.go
@@ -1,0 +1,400 @@
+// memory.go — `moai memory` : health check and archival for the Lessons
+// Protocol topic-file store (MEMORY.md + feedback_*/project_*/… topic files).
+//
+// This is a different layer from `moai preference`, which owns the
+// user_decisions/ sub-directory under the same memory root. The topic-file
+// store is what a session actually loads at start, through MEMORY.md.
+//
+// The store's failure mode is silent: only MEMORY.md is loaded, so a topic
+// file written without its index line is stored and never recalled. Nothing
+// reported that until now — the pre-existing audits check a file's own shape
+// and the index's line count, neither of which reads the index's links.
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/modu-ai/moai-adk/internal/config"
+	"github.com/modu-ai/moai-adk/internal/hook/memo/taxonomy"
+	"github.com/spf13/cobra"
+)
+
+// memoryIndexName is the index a session loads.
+const memoryIndexName = "MEMORY.md"
+
+// memoryArchiveName holds retired topic files. Archiving never deletes: the
+// constitution keeps the audit trail.
+const memoryArchiveName = "_archive"
+
+// memoryStore is a resolved topic-file store.
+type memoryStore struct {
+	Dir    string `json:"dir"`
+	Origin string `json:"origin"` // how the path was resolved, for the report
+}
+
+// memoryProjectSlug encodes an absolute path the way Claude Code names its
+// project directories (/ \ . : → -). It mirrors preference.memorySlug and
+// hook.projectSlug; the three must stay character-for-character identical.
+func memoryProjectSlug(absPath string) string {
+	clean := filepath.Clean(absPath)
+	var out []rune
+	for _, r := range clean {
+		switch r {
+		case '/', '\\', '.', ':':
+			out = append(out, '-')
+		default:
+			out = append(out, r)
+		}
+	}
+	return string(out)
+}
+
+// memoryCandidateStores returns the stores this project could be using, in
+// the order a session resolves them: the active profile's config dir first,
+// then the default ~/.claude root.
+//
+// Both are returned rather than just the winner because they genuinely
+// co-exist — a session launched under a profile and one launched without it
+// write to different directories and cannot see each other's memories. A
+// health check that reported only one would hide half the store.
+func memoryCandidateStores(projectRoot string) ([]memoryStore, error) {
+	abs, err := filepath.Abs(projectRoot)
+	if err != nil {
+		return nil, fmt.Errorf("memory: resolve project root: %w", err)
+	}
+	slug := memoryProjectSlug(abs)
+
+	var stores []memoryStore
+	if cfg := os.Getenv(config.EnvClaudeConfigDir); cfg != "" {
+		stores = append(stores, memoryStore{
+			Dir:    filepath.Join(cfg, "projects", slug, "memory"),
+			Origin: config.EnvClaudeConfigDir,
+		})
+	}
+	home, err := userHomeDir()
+	if err != nil {
+		return stores, nil
+	}
+	def := filepath.Join(home, ".claude", "projects", slug, "memory")
+	for _, s := range stores {
+		if s.Dir == def {
+			return stores, nil
+		}
+	}
+	return append(stores, memoryStore{Dir: def, Origin: "default ~/.claude"}), nil
+}
+
+// memoryReport is the doctor result for one store.
+type memoryReport struct {
+	Store      memoryStore             `json:"store"`
+	Exists     bool                    `json:"exists"`
+	TopicFiles int                     `json:"topic_files"`
+	Cap        int                     `json:"cap"`
+	IndexLines int                     `json:"index_lines"`
+	Findings   []taxonomy.AuditFinding `json:"findings"`
+}
+
+// newMemoryCmd builds `moai memory`.
+func newMemoryCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "memory",
+		Short: "Inspect and archive the Lessons Protocol memory store",
+		Long: `Inspect and archive the topic-file memory store (MEMORY.md + topic files).
+
+A session loads MEMORY.md, not the directory, so a topic file that was written
+without its index line is stored and never recalled. ` + "`doctor`" + ` reports that
+(and the other way round: an index line with no file behind it), plus the
+per-project topic-file ceiling.
+
+` + "`archive`" + ` retires named topic files into ` + memoryArchiveName + `/ and drops their index
+lines. It never deletes — the archive preserves the audit trail. Which memory
+is obsolete is a judgement, so the files are named by the operator; nothing is
+selected automatically.`,
+		GroupID: "tools",
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+	cmd.AddCommand(newMemoryDoctorCmd(), newMemoryArchiveCmd())
+	return cmd
+}
+
+// newMemoryDoctorCmd — `moai memory doctor [--json] [--dir PATH]`.
+func newMemoryDoctorCmd() *cobra.Command {
+	var jsonOutput bool
+	var dirOverride string
+	var capOverride int
+
+	cmd := &cobra.Command{
+		Use:   "doctor",
+		Short: "Report memory-store health (orphans, dangling links, topic-file count)",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			reports, err := collectMemoryReports(dirOverride, capOverride)
+			if err != nil {
+				return err
+			}
+			return renderMemoryReports(cmd.OutOrStdout(), reports, jsonOutput)
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Emit the report as JSON on stdout")
+	cmd.Flags().StringVar(&dirOverride, "dir", "", "Audit this memory directory instead of the resolved store")
+	cmd.Flags().IntVar(&capOverride, "cap", 0,
+		fmt.Sprintf("Topic-file ceiling (default %d)", config.DefaultMemoryTopicFileCap))
+	return cmd
+}
+
+// collectMemoryReports audits every candidate store, or just the override.
+func collectMemoryReports(dirOverride string, capOverride int) ([]memoryReport, error) {
+	var stores []memoryStore
+	if dirOverride != "" {
+		abs, err := filepath.Abs(dirOverride)
+		if err != nil {
+			return nil, fmt.Errorf("memory: resolve --dir: %w", err)
+		}
+		stores = []memoryStore{{Dir: abs, Origin: "--dir"}}
+	} else {
+		var err error
+		stores, err = memoryCandidateStores(resolveProjectDir())
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	capValue := capOverride
+	if capValue <= 0 {
+		capValue = config.DefaultMemoryTopicFileCap
+	}
+
+	reports := make([]memoryReport, 0, len(stores))
+	for _, s := range stores {
+		rep := memoryReport{Store: s, Cap: capValue}
+		info, err := os.Stat(s.Dir)
+		if err != nil || !info.IsDir() {
+			reports = append(reports, rep)
+			continue
+		}
+		rep.Exists = true
+
+		entries, err := os.ReadDir(s.Dir)
+		if err != nil {
+			return nil, fmt.Errorf("memory: read %s: %w", s.Dir, err)
+		}
+		for _, e := range entries {
+			if !e.IsDir() && strings.HasSuffix(e.Name(), ".md") && e.Name() != memoryIndexName {
+				rep.TopicFiles++
+			}
+		}
+
+		indexPath := filepath.Join(s.Dir, memoryIndexName)
+		if data, err := os.ReadFile(indexPath); err == nil {
+			rep.IndexLines = len(strings.Split(strings.TrimRight(string(data), "\n"), "\n"))
+		}
+
+		linkage, err := taxonomy.AuditLinkage(s.Dir)
+		if err != nil {
+			return nil, err
+		}
+		count, err := taxonomy.AuditTopicCount(s.Dir, capValue)
+		if err != nil {
+			return nil, err
+		}
+		index, err := taxonomy.AuditIndex(indexPath, 0)
+		if err != nil {
+			return nil, err
+		}
+		rep.Findings = append(rep.Findings, linkage...)
+		rep.Findings = append(rep.Findings, count...)
+		rep.Findings = append(rep.Findings, index...)
+		reports = append(reports, rep)
+	}
+	return reports, nil
+}
+
+// renderMemoryReports prints the doctor result. Findings are summarized by
+// code rather than listed one per line: an 800-orphan store would otherwise
+// bury its own headline under its own detail.
+func renderMemoryReports(out io.Writer, reports []memoryReport, jsonOutput bool) error {
+	if jsonOutput {
+		data, err := json.Marshal(reports)
+		if err != nil {
+			return err
+		}
+		_, _ = fmt.Fprintln(out, string(data))
+		return nil
+	}
+
+	for i, rep := range reports {
+		if i > 0 {
+			_, _ = fmt.Fprintln(out)
+		}
+		_, _ = fmt.Fprintf(out, "%s  (%s)\n", rep.Store.Dir, rep.Store.Origin)
+		if !rep.Exists {
+			_, _ = fmt.Fprintln(out, "  not present")
+			continue
+		}
+		_, _ = fmt.Fprintf(out, "  topic files : %d (cap %d)\n", rep.TopicFiles, rep.Cap)
+		_, _ = fmt.Fprintf(out, "  index lines : %d\n", rep.IndexLines)
+
+		if len(rep.Findings) == 0 {
+			_, _ = fmt.Fprintln(out, "  findings    : none")
+			continue
+		}
+		counts := map[taxonomy.AuditCode]int{}
+		order := make([]taxonomy.AuditCode, 0, 4)
+		for _, f := range rep.Findings {
+			if counts[f.Code] == 0 {
+				order = append(order, f.Code)
+			}
+			counts[f.Code]++
+		}
+		_, _ = fmt.Fprintln(out, "  findings    :")
+		for _, code := range order {
+			_, _ = fmt.Fprintf(out, "    %-30s %d\n", code, counts[code])
+		}
+		for _, f := range rep.Findings {
+			if f.Code == taxonomy.WarnTopicCountOverCap || f.Code == taxonomy.WarnIndexOverflow {
+				_, _ = fmt.Fprintf(out, "    → %s\n", f.Detail)
+			}
+		}
+	}
+
+	if len(reports) > 1 {
+		_, _ = fmt.Fprintf(out, "\nTwo stores resolved. A session launched under a profile and one launched\n"+
+			"without it write to different directories and cannot see each other's memories.\n")
+	}
+	return nil
+}
+
+// newMemoryArchiveCmd — `moai memory archive <name>... [--dir PATH]`.
+func newMemoryArchiveCmd() *cobra.Command {
+	var dirOverride string
+
+	cmd := &cobra.Command{
+		Use:   "archive <name>...",
+		Short: "Retire named topic files into _archive/ and drop their index lines",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			dir := dirOverride
+			if dir == "" {
+				stores, err := memoryCandidateStores(resolveProjectDir())
+				if err != nil {
+					return err
+				}
+				if len(stores) == 0 {
+					return fmt.Errorf("memory archive: no memory store resolved")
+				}
+				dir = stores[0].Dir
+			}
+			abs, err := filepath.Abs(dir)
+			if err != nil {
+				return fmt.Errorf("memory archive: resolve dir: %w", err)
+			}
+			return archiveMemoryFiles(cmd.OutOrStdout(), abs, args)
+		},
+	}
+	cmd.Flags().StringVar(&dirOverride, "dir", "", "Archive within this memory directory instead of the resolved store")
+	return cmd
+}
+
+// archiveMemoryFiles moves each named topic file into _archive/ and removes
+// its line from the index. Every name is validated before anything moves, so
+// a typo in the third name does not leave the first two half-archived.
+func archiveMemoryFiles(out io.Writer, dir string, names []string) error {
+	for _, raw := range names {
+		name := filepath.Base(strings.TrimSpace(raw))
+		if name == "" || name == "." || name == memoryIndexName {
+			return fmt.Errorf("memory archive: %q is not a topic file", raw)
+		}
+		if !strings.HasSuffix(name, ".md") {
+			return fmt.Errorf("memory archive: %q is not a .md file", raw)
+		}
+		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+			return fmt.Errorf("memory archive: %s: %w", name, err)
+		}
+	}
+
+	archiveDir := filepath.Join(dir, memoryArchiveName)
+	if err := os.MkdirAll(archiveDir, 0o755); err != nil {
+		return fmt.Errorf("memory archive: create %s: %w", archiveDir, err)
+	}
+
+	archived := make([]string, 0, len(names))
+	for _, raw := range names {
+		name := filepath.Base(strings.TrimSpace(raw))
+		src := filepath.Join(dir, name)
+		dst := filepath.Join(archiveDir, name)
+		if err := os.Rename(src, dst); err != nil {
+			return fmt.Errorf("memory archive: move %s: %w", name, err)
+		}
+		archived = append(archived, name)
+		_, _ = fmt.Fprintf(out, "archived %s\n", name)
+	}
+
+	removed, err := dropMemoryIndexLines(filepath.Join(dir, memoryIndexName), archived)
+	if err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(out, "%d archived, %d index line(s) dropped\n", len(archived), removed)
+	return nil
+}
+
+// dropMemoryIndexLines removes index lines linking any of names and reports
+// how many went. A missing index is not an error: archiving a file the index
+// never carried is exactly the orphan case doctor reports.
+func dropMemoryIndexLines(indexPath string, names []string) (int, error) {
+	data, err := os.ReadFile(indexPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("memory archive: read index: %w", err)
+	}
+
+	targeted := make(map[string]bool, len(names))
+	for _, n := range names {
+		targeted[n] = true
+	}
+
+	lines := strings.Split(string(data), "\n")
+	kept := make([]string, 0, len(lines))
+	removed := 0
+	for _, line := range lines {
+		drop := false
+		for _, m := range markdownLinkTargetCLI.FindAllStringSubmatch(line, -1) {
+			if targeted[filepath.Base(m[1])] {
+				drop = true
+				break
+			}
+		}
+		if drop {
+			removed++
+			continue
+		}
+		kept = append(kept, line)
+	}
+	if removed == 0 {
+		return 0, nil
+	}
+
+	if err := os.WriteFile(indexPath, []byte(strings.Join(kept, "\n")), 0o644); err != nil {
+		return 0, fmt.Errorf("memory archive: write index: %w", err)
+	}
+	return removed, nil
+}
+
+// markdownLinkTargetCLI captures a markdown link target. Kept local to the
+// CLI so the archive path does not depend on the audit package's unexported
+// regex; the two patterns describe the same index format.
+var markdownLinkTargetCLI = regexp.MustCompile(`\]\(([^)]+\.md)\)`)
+
+func init() {
+	rootCmd.AddCommand(newMemoryCmd())
+}

--- a/internal/cli/memory_test.go
+++ b/internal/cli/memory_test.go
@@ -180,3 +180,40 @@ func TestDoctorReportsBothStores(t *testing.T) {
 		}
 	}
 }
+
+// TestMemoryCandidateStores_DoNotEscapeToRealHome guards one of the sites
+// pinned by TestHomeJoinSiteCountIsPinned (internal/hook).
+//
+// memoryCandidateStores joins the real home with a project-derived slug and
+// reads the home inside the function, so a caller cannot inject an isolated
+// one — the isolation has to come from the environment. A test that isolates
+// only the project half deposits a fresh permanent directory in the
+// developer's own ~/.claude/projects on every run, which is the shape that
+// once leaked half a million of them.
+//
+// Falsifiability: delete the t.Setenv("HOME", tmp) line and this test fails,
+// because the derivation then points inside the real home.
+func TestMemoryCandidateStores_DoNotEscapeToRealHome(t *testing.T) {
+	// Cannot run in parallel: t.Setenv mutates process-wide state.
+	realHome, err := os.UserHomeDir() // captured BEFORE HOME is overridden
+	if err != nil {
+		t.Fatalf("os.UserHomeDir(): %v", err)
+	}
+
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(tmp, "cfg"))
+
+	stores, err := memoryCandidateStores(t.TempDir())
+	if err != nil {
+		t.Fatalf("memoryCandidateStores: %v", err)
+	}
+	if len(stores) == 0 {
+		t.Fatal("no store resolved; the guard would pass vacuously")
+	}
+	for _, s := range stores {
+		if strings.HasPrefix(s.Dir, realHome+string(os.PathSeparator)) {
+			t.Errorf("store escaped into the real home: %s", s.Dir)
+		}
+	}
+}

--- a/internal/cli/memory_test.go
+++ b/internal/cli/memory_test.go
@@ -1,0 +1,182 @@
+// memory_test.go — `moai memory` doctor/archive.
+//
+// The archive path is the one that moves files, so it carries the heavier
+// tests: all-or-nothing validation, never-delete, and index maintenance.
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// seedMemoryDir lays out a store: an index linking each name in linked, and a
+// topic file per name in present.
+func seedMemoryDir(t *testing.T, linked, present []string) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	var idx strings.Builder
+	idx.WriteString("# Memory Index\n\n")
+	for _, n := range linked {
+		idx.WriteString("- [T](" + n + ") — hook\n")
+	}
+	if err := os.WriteFile(filepath.Join(dir, "MEMORY.md"), []byte(idx.String()), 0o644); err != nil {
+		t.Fatalf("write index: %v", err)
+	}
+	for _, n := range present {
+		if err := os.WriteFile(filepath.Join(dir, n), []byte("---\n---\nbody\n"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", n, err)
+		}
+	}
+	return dir
+}
+
+func TestArchiveMovesFileAndDropsIndexLine(t *testing.T) {
+	t.Parallel()
+	dir := seedMemoryDir(t,
+		[]string{"feedback_a.md", "project_b.md"},
+		[]string{"feedback_a.md", "project_b.md"})
+
+	var out bytes.Buffer
+	if err := archiveMemoryFiles(&out, dir, []string{"project_b.md"}); err != nil {
+		t.Fatalf("archive: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "project_b.md")); !os.IsNotExist(err) {
+		t.Error("archived file still sits in the store root")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "_archive", "project_b.md")); err != nil {
+		t.Errorf("archived file is not under _archive: %v", err)
+	}
+
+	idx, err := os.ReadFile(filepath.Join(dir, "MEMORY.md"))
+	if err != nil {
+		t.Fatalf("read index: %v", err)
+	}
+	if strings.Contains(string(idx), "project_b.md") {
+		t.Errorf("index still links the archived file:\n%s", idx)
+	}
+	if !strings.Contains(string(idx), "feedback_a.md") {
+		t.Errorf("index lost an unrelated entry:\n%s", idx)
+	}
+}
+
+// TestArchiveNeverDeletes is the constitutional guarantee: archiving keeps
+// the audit trail, so the bytes must survive the move.
+func TestArchiveNeverDeletes(t *testing.T) {
+	t.Parallel()
+	dir := seedMemoryDir(t, []string{"feedback_a.md"}, []string{"feedback_a.md"})
+	original, err := os.ReadFile(filepath.Join(dir, "feedback_a.md"))
+	if err != nil {
+		t.Fatalf("read original: %v", err)
+	}
+
+	var out bytes.Buffer
+	if err := archiveMemoryFiles(&out, dir, []string{"feedback_a.md"}); err != nil {
+		t.Fatalf("archive: %v", err)
+	}
+
+	moved, err := os.ReadFile(filepath.Join(dir, "_archive", "feedback_a.md"))
+	if err != nil {
+		t.Fatalf("read archived: %v", err)
+	}
+	if !bytes.Equal(original, moved) {
+		t.Error("archived content differs from the original")
+	}
+}
+
+// TestArchiveValidatesEveryNameBeforeMoving pins the all-or-nothing contract:
+// a typo in the last name must not leave the earlier ones half-archived.
+func TestArchiveValidatesEveryNameBeforeMoving(t *testing.T) {
+	t.Parallel()
+	dir := seedMemoryDir(t,
+		[]string{"feedback_a.md", "project_b.md"},
+		[]string{"feedback_a.md", "project_b.md"})
+
+	var out bytes.Buffer
+	err := archiveMemoryFiles(&out, dir, []string{"feedback_a.md", "does_not_exist.md"})
+	if err == nil {
+		t.Fatal("archive accepted a missing name")
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "feedback_a.md")); statErr != nil {
+		t.Error("a valid name was moved despite the batch failing")
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "_archive")); statErr == nil {
+		t.Error("_archive was created for a batch that never ran")
+	}
+}
+
+// TestArchiveRefusesTheIndexItself guards the obvious foot-gun.
+func TestArchiveRefusesTheIndexItself(t *testing.T) {
+	t.Parallel()
+	dir := seedMemoryDir(t, []string{"feedback_a.md"}, []string{"feedback_a.md"})
+
+	var out bytes.Buffer
+	if err := archiveMemoryFiles(&out, dir, []string{"MEMORY.md"}); err == nil {
+		t.Error("archive accepted MEMORY.md")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "MEMORY.md")); err != nil {
+		t.Errorf("index was moved: %v", err)
+	}
+}
+
+// TestArchiveOrphanNeedsNoIndexLine covers the common case: the orphans
+// doctor reports have no index line to drop, which is not an error.
+func TestArchiveOrphanNeedsNoIndexLine(t *testing.T) {
+	t.Parallel()
+	dir := seedMemoryDir(t, []string{"feedback_a.md"},
+		[]string{"feedback_a.md", "project_orphan.md"})
+
+	var out bytes.Buffer
+	if err := archiveMemoryFiles(&out, dir, []string{"project_orphan.md"}); err != nil {
+		t.Fatalf("archiving an orphan failed: %v", err)
+	}
+	if !strings.Contains(out.String(), "0 index line(s) dropped") {
+		t.Errorf("expected a zero-index-line report, got: %q", out.String())
+	}
+}
+
+// TestDoctorReportsBothStores pins the two-store reality: a profile session
+// and a plain session write to different directories, and a report that
+// showed only one would hide half the store.
+func TestDoctorReportsBothStores(t *testing.T) {
+	home := t.TempDir()
+	profile := filepath.Join(home, "profile")
+	project := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CLAUDE_PROJECT_DIR", project)
+	t.Setenv("CLAUDE_CONFIG_DIR", profile)
+
+	slug := memoryProjectSlug(project)
+	for _, root := range []string{
+		filepath.Join(profile, "projects", slug, "memory"),
+		filepath.Join(home, ".claude", "projects", slug, "memory"),
+	} {
+		if err := os.MkdirAll(root, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", root, err)
+		}
+		if err := os.WriteFile(filepath.Join(root, "feedback_x.md"), []byte("---\n---\n"), 0o644); err != nil {
+			t.Fatalf("seed %s: %v", root, err)
+		}
+	}
+
+	reports, err := collectMemoryReports("", 0)
+	if err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	if len(reports) != 2 {
+		t.Fatalf("resolved %d store(s), want 2: %+v", len(reports), reports)
+	}
+	for _, r := range reports {
+		if !r.Exists || r.TopicFiles != 1 {
+			t.Errorf("store %s: exists=%v files=%d, want true/1", r.Store.Dir, r.Exists, r.TopicFiles)
+		}
+		// The seeded file is unindexed, so each store must report it.
+		if len(r.Findings) == 0 {
+			t.Errorf("store %s reported no orphan for an unindexed file", r.Store.Dir)
+		}
+	}
+}

--- a/internal/cli/migrate_profiles.go
+++ b/internal/cli/migrate_profiles.go
@@ -1,0 +1,391 @@
+// migrate_profiles.go — `moai migrate profiles`.
+//
+// Consolidates the per-profile memory stores into the default one.
+//
+// `moai cc -p <name>` sets CLAUDE_CONFIG_DIR, and Claude Code puts
+// projects/<slug>/memory under whatever that points at. The effect is that
+// the same project accumulates a separate memory per profile, and a session
+// launched one way cannot recall what a session launched the other way
+// learned. Memory is project-scoped by nature; the profile is an outer key
+// that does not belong on it.
+//
+// The migration is explicit, never automatic: `moai update` only reports that
+// there is something to merge. Moving hundreds of files inside a user's home
+// as a side effect of an update is the shape of an accident this project has
+// already had once.
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// migrateProfileOpts controls one migration run.
+type migrateProfileOpts struct {
+	// DryRun reports what would happen and writes nothing.
+	DryRun bool
+}
+
+// migrateProfileResult is what a run did (or would do, under DryRun).
+type migrateProfileResult struct {
+	// Profiles are the profile names that held memory for this project.
+	Profiles []string
+	// Moved counts files that landed in the default store under their own name.
+	Moved int
+	// Renamed counts files kept under a profile-suffixed name because the
+	// default store already had that name with different content.
+	Renamed int
+	// Skipped counts files already present with identical content.
+	Skipped int
+	// IndexLines counts index entries carried into the default MEMORY.md.
+	IndexLines int
+}
+
+// profileMemoryStores returns the per-profile memory directories that hold
+// something for this project, keyed by profile name.
+func profileMemoryStores(projectRoot string) (map[string]string, error) {
+	home, err := userHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("migrate profiles: resolve home: %w", err)
+	}
+	abs, err := filepath.Abs(projectRoot)
+	if err != nil {
+		return nil, fmt.Errorf("migrate profiles: resolve project root: %w", err)
+	}
+	slug := memoryProjectSlug(abs)
+
+	profilesRoot := filepath.Join(home, ".moai", "claude-profiles")
+	entries, err := os.ReadDir(profilesRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]string{}, nil
+		}
+		return nil, fmt.Errorf("migrate profiles: read %s: %w", profilesRoot, err)
+	}
+
+	stores := map[string]string{}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		dir := filepath.Join(profilesRoot, e.Name(), "projects", slug, "memory")
+		names, err := topicFileNames(dir)
+		if err != nil {
+			return nil, err
+		}
+		if len(names) == 0 {
+			continue
+		}
+		stores[e.Name()] = dir
+	}
+	return stores, nil
+}
+
+// topicFileNames lists .md topic files directly under dir, excluding the index.
+func topicFileNames(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("migrate profiles: read %s: %w", dir, err)
+	}
+	var names []string
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".md") && e.Name() != memoryIndexName {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// defaultMemoryStore is where the migration consolidates to: the store a
+// session uses when no profile is active.
+func defaultMemoryStore(projectRoot string) (string, error) {
+	home, err := userHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("migrate profiles: resolve home: %w", err)
+	}
+	abs, err := filepath.Abs(projectRoot)
+	if err != nil {
+		return "", fmt.Errorf("migrate profiles: resolve project root: %w", err)
+	}
+	return filepath.Join(home, ".claude", "projects", memoryProjectSlug(abs), "memory"), nil
+}
+
+// migrateProfileMemory merges every profile store for this project into the
+// default one.
+//
+// Collisions never overwrite. A file whose name already exists in the target
+// is compared byte for byte: identical content is already migrated and is
+// skipped, differing content is kept alongside under a profile-suffixed name.
+// Losing one of two same-named memories would be silent and unrecoverable,
+// and a duplicate is cheap by comparison.
+func migrateProfileMemory(projectRoot string, opts migrateProfileOpts) (*migrateProfileResult, error) {
+	stores, err := profileMemoryStores(projectRoot)
+	if err != nil {
+		return nil, err
+	}
+	res := &migrateProfileResult{}
+	if len(stores) == 0 {
+		return res, nil
+	}
+
+	target, err := defaultMemoryStore(projectRoot)
+	if err != nil {
+		return nil, err
+	}
+	if !opts.DryRun {
+		if err := os.MkdirAll(target, 0o755); err != nil {
+			return nil, fmt.Errorf("migrate profiles: create %s: %w", target, err)
+		}
+	}
+
+	profiles := make([]string, 0, len(stores))
+	for name := range stores {
+		profiles = append(profiles, name)
+	}
+	sort.Strings(profiles)
+	res.Profiles = profiles
+
+	// renames maps the original filename to the name it landed under, so the
+	// index merge can rewrite the link of anything that was suffixed.
+	renames := map[string]map[string]string{}
+
+	for _, profile := range profiles {
+		src := stores[profile]
+		names, err := topicFileNames(src)
+		if err != nil {
+			return nil, err
+		}
+		renames[profile] = map[string]string{}
+
+		for _, name := range names {
+			srcPath := filepath.Join(src, name)
+			dstName := name
+			dstPath := filepath.Join(target, dstName)
+
+			existing, statErr := os.ReadFile(dstPath)
+			switch {
+			case statErr == nil:
+				incoming, readErr := os.ReadFile(srcPath)
+				if readErr != nil {
+					return nil, fmt.Errorf("migrate profiles: read %s: %w", srcPath, readErr)
+				}
+				if bytes.Equal(existing, incoming) {
+					res.Skipped++
+					if !opts.DryRun {
+						if err := os.Remove(srcPath); err != nil {
+							return nil, fmt.Errorf("migrate profiles: drop duplicate %s: %w", srcPath, err)
+						}
+					}
+					continue
+				}
+				dstName = suffixedMemoryName(name, profile)
+				dstPath = filepath.Join(target, dstName)
+				renames[profile][name] = dstName
+				res.Renamed++
+			case os.IsNotExist(statErr):
+				res.Moved++
+			default:
+				return nil, fmt.Errorf("migrate profiles: stat %s: %w", dstPath, statErr)
+			}
+
+			if opts.DryRun {
+				continue
+			}
+			if err := moveFile(srcPath, dstPath); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	lines, err := mergeMemoryIndexes(target, stores, profiles, renames, opts.DryRun)
+	if err != nil {
+		return nil, err
+	}
+	res.IndexLines = lines
+	return res, nil
+}
+
+// suffixedMemoryName appends the profile name before the extension.
+func suffixedMemoryName(name, profile string) string {
+	ext := filepath.Ext(name)
+	stem := strings.TrimSuffix(name, ext)
+	return fmt.Sprintf("%s__%s%s", stem, profile, ext)
+}
+
+// moveFile relocates src to dst, falling back to copy+remove when the two
+// sit on different filesystems (a profile root and the home root need not be
+// on the same volume).
+func moveFile(src, dst string) error {
+	if err := os.Rename(src, dst); err == nil {
+		return nil
+	}
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return fmt.Errorf("migrate profiles: read %s: %w", src, err)
+	}
+	if err := os.WriteFile(dst, data, 0o644); err != nil {
+		return fmt.Errorf("migrate profiles: write %s: %w", dst, err)
+	}
+	if err := os.Remove(src); err != nil {
+		return fmt.Errorf("migrate profiles: remove %s: %w", src, err)
+	}
+	return nil
+}
+
+// mergeMemoryIndexes appends each profile index's entries to the default
+// index, skipping links the default already carries and rewriting the link of
+// any file that had to be renamed. Existing entries are never rewritten or
+// reordered — the default index is the one a session has been reading.
+func mergeMemoryIndexes(target string, stores map[string]string, profiles []string, renames map[string]map[string]string, dryRun bool) (int, error) {
+	targetIndex := filepath.Join(target, memoryIndexName)
+	existing, err := os.ReadFile(targetIndex)
+	if err != nil && !os.IsNotExist(err) {
+		return 0, fmt.Errorf("migrate profiles: read %s: %w", targetIndex, err)
+	}
+
+	present := map[string]bool{}
+	for _, m := range markdownLinkTargetCLI.FindAllStringSubmatch(string(existing), -1) {
+		present[filepath.Base(m[1])] = true
+	}
+
+	var added []string
+	for _, profile := range profiles {
+		data, err := os.ReadFile(filepath.Join(stores[profile], memoryIndexName))
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return 0, fmt.Errorf("migrate profiles: read %s index: %w", profile, err)
+		}
+		for _, line := range strings.Split(string(data), "\n") {
+			matches := markdownLinkTargetCLI.FindAllStringSubmatch(line, -1)
+			if len(matches) == 0 {
+				continue
+			}
+			name := filepath.Base(matches[0][1])
+			if renamed, ok := renames[profile][name]; ok {
+				line = strings.Replace(line, matches[0][1], renamed, 1)
+				name = renamed
+			}
+			if present[name] {
+				continue
+			}
+			present[name] = true
+			added = append(added, line)
+		}
+	}
+	if len(added) == 0 || dryRun {
+		return len(added), nil
+	}
+
+	var out bytes.Buffer
+	out.Write(existing)
+	if len(existing) > 0 && !bytes.HasSuffix(existing, []byte("\n")) {
+		out.WriteString("\n")
+	}
+	out.WriteString("\n## Merged from profiles\n")
+	for _, line := range added {
+		out.WriteString(line + "\n")
+	}
+	if err := os.WriteFile(targetIndex, out.Bytes(), 0o644); err != nil {
+		return 0, fmt.Errorf("migrate profiles: write %s: %w", targetIndex, err)
+	}
+	return len(added), nil
+}
+
+// renderMigrateProfileResult prints the outcome.
+func renderMigrateProfileResult(out io.Writer, res *migrateProfileResult, dryRun bool) {
+	if len(res.Profiles) == 0 {
+		_, _ = fmt.Fprintln(out, "no profile memory found for this project — nothing to migrate")
+		return
+	}
+	verb := "migrated"
+	if dryRun {
+		verb = "would migrate"
+	}
+	_, _ = fmt.Fprintf(out, "profiles: %s\n", strings.Join(res.Profiles, ", "))
+	_, _ = fmt.Fprintf(out, "%s %d file(s); %d kept alongside on name collision; %d already present\n",
+		verb, res.Moved, res.Renamed, res.Skipped)
+	_, _ = fmt.Fprintf(out, "index entries carried: %d\n", res.IndexLines)
+	if res.Renamed > 0 {
+		_, _ = fmt.Fprintln(out,
+			"collisions were kept under <name>__<profile>.md — neither version was overwritten")
+	}
+	if dryRun {
+		_, _ = fmt.Fprintln(out, "\ndry run: nothing was written. Re-run without --dry-run to apply.")
+	}
+}
+
+// migrateProfileAdvisory returns the one-line notice `moai update` prints
+// when profile memory is still lying around, or "" when there is none.
+// It never migrates: an update that moved hundreds of files inside a home
+// directory as a side effect is precisely the accident this project has
+// already had once.
+func migrateProfileAdvisory(projectRoot string) string {
+	stores, err := profileMemoryStores(projectRoot)
+	if err != nil || len(stores) == 0 {
+		return ""
+	}
+	total := 0
+	for _, dir := range stores {
+		names, err := topicFileNames(dir)
+		if err != nil {
+			return ""
+		}
+		total += len(names)
+	}
+	if total == 0 {
+		return ""
+	}
+	return fmt.Sprintf(
+		"%d memory file(s) sit in %d profile store(s) that a default session cannot read. "+
+			"Run `moai migrate profiles --dry-run` to preview merging them.",
+		total, len(stores))
+}
+
+func newMigrateProfilesCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "profiles",
+		Short: "Merge per-profile memory into the default store",
+		Long: `Merge this project's per-profile memory stores into the default store.
+
+` + "`moai cc -p <name>`" + ` sets CLAUDE_CONFIG_DIR, and Claude Code keeps
+projects/<slug>/memory under whatever that points at — so the same project
+accumulates a separate memory per profile, and a session launched one way
+cannot recall what a session launched the other way learned.
+
+Collisions never overwrite. A name that already exists in the default store is
+compared byte for byte: identical content is skipped, differing content is kept
+alongside as <name>__<profile>.md.
+
+Sessions (transcripts, file-history, session-env) are NOT migrated here; they
+span six directories and are a separate step.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			dryRun, _ := cmd.Flags().GetBool("dry-run")
+			res, err := migrateProfileMemory(resolveProjectDir(), migrateProfileOpts{DryRun: dryRun})
+			if err != nil {
+				return err
+			}
+			renderMigrateProfileResult(cmd.OutOrStdout(), res, dryRun)
+			return nil
+		},
+	}
+	cmd.Flags().Bool("dry-run", false, "Show planned actions without modifying files")
+	return cmd
+}
+
+func init() {
+	migrateCmd.AddCommand(newMigrateProfilesCmd())
+}

--- a/internal/cli/migrate_profiles_test.go
+++ b/internal/cli/migrate_profiles_test.go
@@ -1,0 +1,217 @@
+// migrate_profiles_test.go — `moai migrate profiles`.
+//
+// The migration moves memory topic files from the per-profile stores
+// (~/.moai/claude-profiles/<name>/projects/<slug>/memory) into the default
+// store (~/.claude/projects/<slug>/memory) and merges the MEMORY.md indexes.
+//
+// The hazard it has to avoid is the one this project already lived through:
+// a bulk operation over a user's home directory that loses content. So the
+// tests here are mostly about what must survive — differing files, existing
+// index entries, and a second run.
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// profileFixture builds a home with one default store and one profile store.
+func profileFixture(t *testing.T) (home, project, defaultMem, profileMem string) {
+	t.Helper()
+	home = t.TempDir()
+	project = t.TempDir()
+	slug := memoryProjectSlug(project)
+
+	defaultMem = filepath.Join(home, ".claude", "projects", slug, "memory")
+	profileMem = filepath.Join(home, ".moai", "claude-profiles", "p1", "projects", slug, "memory")
+	for _, d := range []string{defaultMem, profileMem} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+	return home, project, defaultMem, profileMem
+}
+
+func writeProfileFile(t *testing.T, dir, name, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+func readProfileFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
+}
+
+func TestMigrateProfilesMovesTopicFilesAndMergesIndex(t *testing.T) {
+	home, project, defaultMem, profileMem := profileFixture(t)
+	t.Setenv("HOME", home)
+
+	writeProfileFile(t, defaultMem, "MEMORY.md", "# Memory Index\n\n- [A](feedback_a.md) — a\n")
+	writeProfileFile(t, defaultMem, "feedback_a.md", "A\n")
+	writeProfileFile(t, profileMem, "MEMORY.md", "# Memory Index\n\n- [B](project_b.md) — b\n")
+	writeProfileFile(t, profileMem, "project_b.md", "B\n")
+
+	res, err := migrateProfileMemory(project, migrateProfileOpts{})
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if res.Moved != 1 {
+		t.Errorf("Moved = %d, want 1: %+v", res.Moved, res)
+	}
+
+	if got := readProfileFile(t, filepath.Join(defaultMem, "project_b.md")); got != "B\n" {
+		t.Errorf("migrated body = %q, want %q", got, "B\n")
+	}
+	if _, err := os.Stat(filepath.Join(profileMem, "project_b.md")); !os.IsNotExist(err) {
+		t.Error("source file still present after a move")
+	}
+
+	idx := readProfileFile(t, filepath.Join(defaultMem, "MEMORY.md"))
+	if !strings.Contains(idx, "feedback_a.md") {
+		t.Errorf("merge dropped the pre-existing index entry:\n%s", idx)
+	}
+	if !strings.Contains(idx, "project_b.md") {
+		t.Errorf("merge did not carry the profile's index entry:\n%s", idx)
+	}
+}
+
+// TestMigrateProfilesKeepsBothOnContentCollision is the data-loss guard: two
+// stores can hold the same filename with different content, and neither may
+// silently win.
+func TestMigrateProfilesKeepsBothOnContentCollision(t *testing.T) {
+	home, project, defaultMem, profileMem := profileFixture(t)
+	t.Setenv("HOME", home)
+
+	writeProfileFile(t, defaultMem, "feedback_x.md", "DEFAULT VERSION\n")
+	writeProfileFile(t, profileMem, "feedback_x.md", "PROFILE VERSION\n")
+
+	res, err := migrateProfileMemory(project, migrateProfileOpts{})
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if res.Renamed != 1 {
+		t.Errorf("Renamed = %d, want 1: %+v", res.Renamed, res)
+	}
+
+	if got := readProfileFile(t, filepath.Join(defaultMem, "feedback_x.md")); got != "DEFAULT VERSION\n" {
+		t.Errorf("the existing file was overwritten: %q", got)
+	}
+	kept := filepath.Join(defaultMem, "feedback_x__p1.md")
+	if got := readProfileFile(t, kept); got != "PROFILE VERSION\n" {
+		t.Errorf("colliding content was not preserved at %s: %q", kept, got)
+	}
+}
+
+// TestMigrateProfilesSkipsIdenticalContent keeps the migration idempotent:
+// the same file in both stores is already migrated, not a collision.
+func TestMigrateProfilesSkipsIdenticalContent(t *testing.T) {
+	home, project, defaultMem, profileMem := profileFixture(t)
+	t.Setenv("HOME", home)
+
+	writeProfileFile(t, defaultMem, "feedback_same.md", "SAME\n")
+	writeProfileFile(t, profileMem, "feedback_same.md", "SAME\n")
+
+	res, err := migrateProfileMemory(project, migrateProfileOpts{})
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if res.Skipped != 1 || res.Renamed != 0 {
+		t.Errorf("identical content: Skipped=%d Renamed=%d, want 1/0", res.Skipped, res.Renamed)
+	}
+	if _, err := os.Stat(filepath.Join(defaultMem, "feedback_same__p1.md")); err == nil {
+		t.Error("identical content produced a needless duplicate")
+	}
+}
+
+// TestMigrateProfilesDryRunTouchesNothing pins that the preview is a preview.
+func TestMigrateProfilesDryRunTouchesNothing(t *testing.T) {
+	home, project, defaultMem, profileMem := profileFixture(t)
+	t.Setenv("HOME", home)
+
+	writeProfileFile(t, profileMem, "project_b.md", "B\n")
+
+	res, err := migrateProfileMemory(project, migrateProfileOpts{DryRun: true})
+	if err != nil {
+		t.Fatalf("dry run: %v", err)
+	}
+	if res.Moved != 1 {
+		t.Errorf("dry run should still report 1 planned move, got %d", res.Moved)
+	}
+	if _, err := os.Stat(filepath.Join(profileMem, "project_b.md")); err != nil {
+		t.Error("dry run moved the source file")
+	}
+	if _, err := os.Stat(filepath.Join(defaultMem, "project_b.md")); err == nil {
+		t.Error("dry run wrote into the target store")
+	}
+}
+
+// TestMigrateProfilesSecondRunIsQuiet — running twice must be safe, because
+// the advisory in `moai update` will nag until the user runs it, and some
+// will run it more than once.
+func TestMigrateProfilesSecondRunIsQuiet(t *testing.T) {
+	home, project, _, profileMem := profileFixture(t)
+	t.Setenv("HOME", home)
+
+	writeProfileFile(t, profileMem, "project_b.md", "B\n")
+	writeProfileFile(t, profileMem, "MEMORY.md", "- [B](project_b.md) — b\n")
+
+	if _, err := migrateProfileMemory(project, migrateProfileOpts{}); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	second, err := migrateProfileMemory(project, migrateProfileOpts{})
+	if err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	if second.Moved != 0 || second.Renamed != 0 {
+		t.Errorf("second run was not a no-op: %+v", second)
+	}
+}
+
+// TestMigrateProfilesNoProfilesIsNotAnError covers the common case: a user
+// who never used -p has nothing to migrate.
+func TestMigrateProfilesNoProfilesIsNotAnError(t *testing.T) {
+	home := t.TempDir()
+	project := t.TempDir()
+	t.Setenv("HOME", home)
+
+	res, err := migrateProfileMemory(project, migrateProfileOpts{})
+	if err != nil {
+		t.Fatalf("no profiles: %v", err)
+	}
+	if res.Moved != 0 || len(res.Profiles) != 0 {
+		t.Errorf("expected an empty result, got %+v", res)
+	}
+}
+
+// TestDefaultMemoryStore_DoesNotEscapeToRealHome guards the other site pinned
+// by TestHomeJoinSiteCountIsPinned (internal/hook). Same shape, same reason:
+// the home is read inside the function, so only the environment can isolate
+// it, and a test that forgets leaks a permanent directory per run.
+//
+// Falsifiability: delete the t.Setenv("HOME", tmp) line and this test fails.
+func TestDefaultMemoryStore_DoesNotEscapeToRealHome(t *testing.T) {
+	// Cannot run in parallel: t.Setenv mutates process-wide state.
+	realHome, err := os.UserHomeDir() // captured BEFORE HOME is overridden
+	if err != nil {
+		t.Fatalf("os.UserHomeDir(): %v", err)
+	}
+
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	dir, err := defaultMemoryStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("defaultMemoryStore: %v", err)
+	}
+	if strings.HasPrefix(dir, realHome+string(os.PathSeparator)) {
+		t.Errorf("default store escaped into the real home: %s", dir)
+	}
+}

--- a/internal/cli/todo.go
+++ b/internal/cli/todo.go
@@ -39,9 +39,15 @@ func newTodoCmd() *cobra.Command {
 
 The backlog is the operator's queue: entry into the board is the operator's
 act (add), and picking the next card is the operator's act too (next <n>).
-Mutations serialize on a sibling cross-process lock; reads are lock-free.`,
+Mutations serialize on a sibling cross-process lock; reads are lock-free.
+
+A bare invocation renders the queue, which is the form the skill surface and
+workflows/todo.md both document; ` + "`moai todo list`" + ` remains valid and prints the
+same thing. NoArgs keeps a mistyped verb an error rather than letting it fall
+through to the listing.`,
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return cmd.Help()
+			return runTodoList(cmd, false)
 		},
 		GroupID: "tools",
 	}
@@ -73,6 +79,35 @@ func newTodoAddCmd() *cobra.Command {
 	}
 }
 
+// runTodoList renders the backlog lock-free. It backs both entry points —
+// the bare `moai todo` and the explicit `moai todo list` — so the two cannot
+// drift apart in output.
+func runTodoList(cmd *cobra.Command, jsonOutput bool) error {
+	store := kanban.NewBacklogStore(todoBacklogPath(resolveProjectDir()))
+	rec, err := store.Load()
+	if err != nil {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Error: %v\n", err)
+		return err
+	}
+	out := cmd.OutOrStdout()
+	if jsonOutput {
+		data, err := json.Marshal(rec)
+		if err != nil {
+			return err
+		}
+		_, _ = fmt.Fprintln(out, string(data))
+		return nil
+	}
+	if len(rec.Items) == 0 {
+		_, _ = fmt.Fprintln(out, "queue is empty")
+		return nil
+	}
+	for _, it := range rec.Items {
+		_, _ = fmt.Fprintf(out, "%s\t%s\t%s\n", it.ID, it.State, it.Text)
+	}
+	return nil
+}
+
 // newTodoListCmd — `moai todo list [--json]` (REQ-TODO-003): render the
 // queue lock-free; --json emits the structured records.
 func newTodoListCmd() *cobra.Command {
@@ -82,29 +117,7 @@ func newTodoListCmd() *cobra.Command {
 		Short: "Render the backlog queue (lock-free)",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			store := kanban.NewBacklogStore(todoBacklogPath(resolveProjectDir()))
-			rec, err := store.Load()
-			if err != nil {
-				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Error: %v\n", err)
-				return err
-			}
-			out := cmd.OutOrStdout()
-			if jsonOutput {
-				data, err := json.Marshal(rec)
-				if err != nil {
-					return err
-				}
-				_, _ = fmt.Fprintln(out, string(data))
-				return nil
-			}
-			if len(rec.Items) == 0 {
-				_, _ = fmt.Fprintln(out, "queue is empty")
-				return nil
-			}
-			for _, it := range rec.Items {
-				_, _ = fmt.Fprintf(out, "%s\t%s\t%s\n", it.ID, it.State, it.Text)
-			}
-			return nil
+			return runTodoList(cmd, jsonOutput)
 		},
 	}
 	cmd.Flags().BoolVar(&jsonOutput, "json", false,

--- a/internal/cli/todo_test.go
+++ b/internal/cli/todo_test.go
@@ -452,3 +452,50 @@ func todoPromptGuard(source string) (reason string, bad bool) {
 	}
 	return "", false
 }
+
+// TestTodoBareInvocationLists pins the documented contract that a bare
+// `moai todo` renders the queue. The skill surface (.claude/skills/moai)
+// and workflows/todo.md both describe the bare form as the list surface;
+// the command used to answer it with cobra's help text instead, so the
+// documented entry point never reached the backlog it names.
+//
+// The subcommand `moai todo list` stays valid — this widens the surface
+// rather than moving it.
+func TestTodoBareInvocationLists(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CLAUDE_PROJECT_DIR", dir)
+
+	if _, _, err := runTodo(t, "add", "first card"); err != nil {
+		t.Fatalf("seed add: %v", err)
+	}
+
+	bare, _, err := runTodo(t)
+	if err != nil {
+		t.Fatalf("bare todo: %v", err)
+	}
+	if strings.Contains(bare, "USAGE") || strings.Contains(bare, "Usage:") {
+		t.Errorf("bare todo printed help, want the queue:\n%s", bare)
+	}
+	if !strings.Contains(bare, "first card") {
+		t.Errorf("bare todo did not render the seeded card:\n%s", bare)
+	}
+
+	listed, _, err := runTodo(t, "list")
+	if err != nil {
+		t.Fatalf("todo list: %v", err)
+	}
+	if bare != listed {
+		t.Errorf("bare todo and `todo list` diverged:\nbare=%q\nlist=%q", bare, listed)
+	}
+}
+
+// TestTodoUnknownSubcommandStillErrors guards the widening above: making
+// the bare form do work must not turn a mistyped verb into a silent list.
+func TestTodoUnknownSubcommandStillErrors(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CLAUDE_PROJECT_DIR", dir)
+
+	if _, _, err := runTodo(t, "lsit"); err == nil {
+		t.Error("mistyped subcommand was accepted, want an error")
+	}
+}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -500,6 +500,17 @@ func runUpdate(cmd *cobra.Command, _ []string) error {
 	_, _ = fmt.Fprintln(out)
 	_, _ = fmt.Fprintln(out, tui.Section("Post-sync steps", tui.SectionOpts{Theme: &th}))
 
+	// Profile-memory advisory. Reports only — the merge itself is an explicit
+	// `moai migrate profiles`, because moving hundreds of files inside a home
+	// directory as a side effect of an update is the accident this project has
+	// already had once. A failure here is silent: an advisory that cannot be
+	// computed must not interrupt an update that otherwise succeeded.
+	if cwd, err := os.Getwd(); err == nil {
+		if notice := migrateProfileAdvisory(cwd); notice != "" {
+			_, _ = fmt.Fprintln(out, notice)
+		}
+	}
+
 	// Archive legacy skills (BC-V3R3-007): move 16 removed static skills to
 	// .moai/archive/skills/v2.16/ before they are cleaned from .claude/skills/.
 	// SPEC-V3R6-UPDATE-ARCHIVE-CONTRACT-001 REQ-UAC-002: --force is propagated

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -189,6 +189,7 @@ const (
 	DefaultMemoryStalenessHours          = 24  // files older than this are wrapped in staleness caveat
 	DefaultMemoryIndexLineCap            = 200 // MEMORY.md lines beyond this trigger MEMORY_INDEX_OVERFLOW
 	DefaultMemoryStaleAggregateThreshold = 10  // stale files >= this count emit one aggregated warning
+	DefaultMemoryTopicFileCap            = 50  // topic files beyond this trigger MEMORY_TOPIC_COUNT_OVER_CAP
 
 	// DefaultFeedbackRepository is the default target repository for the /moai
 	// feedback workflow (SPEC-INVOCATION-MODEL-001). Feedback targets the remote

--- a/internal/hook/home_isolation_test.go
+++ b/internal/hook/home_isolation_test.go
@@ -62,15 +62,19 @@ func TestResolveCaptureMemoryDir_DoesNotEscapeToRealHome(t *testing.T) {
 //
 // Each such site is a potential silent leak: it combines a real home with a
 // project-derived name, so any test that isolates only the project half writes
-// into the developer's actual home. The two known sites each carry a behavioural
-// guard — this test in internal/hook, and TestDecayScan_DoesNotWriteToRealHome in
-// internal/cli/preference. A third site added without one would reintroduce the
-// class with nothing to report it, which is what this count exists to prevent.
+// into the developer's actual home. The known sites each carry a behavioural
+// guard — TestResolveCaptureMemoryDir_DoesNotEscapeToRealHome in internal/hook,
+// TestDecayScan_DoesNotWriteToRealHome in internal/cli/preference, and, for the
+// `moai memory` / `moai migrate profiles` derivations,
+// TestMemoryCandidateStores_DoNotEscapeToRealHome and
+// TestDefaultMemoryStore_DoesNotEscapeToRealHome in internal/cli. A further site
+// added without one would reintroduce the class with nothing to report it, which
+// is what this count exists to prevent.
 //
 // This is a count, not an allowlist of paths, so it stays readable; the failure
 // message carries the located sites so the reader sees which one is new.
 func TestHomeJoinSiteCountIsPinned(t *testing.T) {
-	const wantSites = 2
+	const wantSites = 4
 
 	root, err := filepath.Abs(filepath.Join("..", ".."))
 	if err != nil {

--- a/internal/hook/memo/taxonomy/linkage.go
+++ b/internal/hook/memo/taxonomy/linkage.go
@@ -1,0 +1,150 @@
+// linkage.go — index-linkage and topic-count audits.
+//
+// AuditFile/AuditIndex/AuditDuplicates validate a memory file's own shape and
+// the index's length. Neither reads the index's links, so a topic file written
+// without its index line passes every existing check while being unreachable:
+// a session loads MEMORY.md, not the directory, so an unlinked file is stored
+// and never recalled. AuditLinkage closes that gap in both directions, and
+// AuditTopicCount gives the per-project ceiling a checker.
+package taxonomy
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/modu-ai/moai-adk/internal/config"
+)
+
+// Linkage and capacity warning codes.
+const (
+	WarnOrphanNotIndexed  AuditCode = "MEMORY_ORPHAN_NOT_INDEXED"
+	WarnDanglingIndexLink AuditCode = "MEMORY_DANGLING_INDEX_LINK"
+	WarnTopicCountOverCap AuditCode = "MEMORY_TOPIC_COUNT_OVER_CAP"
+)
+
+// indexFileName is the index a session actually loads.
+const indexFileName = "MEMORY.md"
+
+// archiveDirName holds retired topic files. Archiving is the remedy the cap
+// prescribes, so its contents are excluded from both audits — otherwise the
+// remedy would trip the alarm it is meant to clear.
+const archiveDirName = "_archive"
+
+// markdownLinkTarget captures the target of a markdown link. The index format
+// is one `- [Title](file.md) — hook` line per memory, so the targets are the
+// set of files the index can reach.
+var markdownLinkTarget = regexp.MustCompile(`\]\(([^)]+\.md)\)`)
+
+// topicFiles returns the memory topic files directly under dir: .md files,
+// excluding the index itself. A missing directory yields no files and no
+// error — a project that has not written a memory yet is not a defect.
+func topicFiles(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("taxonomy: read memory dir %s: %w", dir, err)
+	}
+
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") || e.Name() == indexFileName {
+			continue
+		}
+		names = append(names, e.Name())
+	}
+	return names, nil
+}
+
+// indexTargets returns the set of .md files the index links to.
+func indexTargets(indexPath string) (map[string]bool, error) {
+	data, err := os.ReadFile(indexPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]bool{}, nil
+		}
+		return nil, fmt.Errorf("taxonomy: read index %s: %w", indexPath, err)
+	}
+
+	targets := map[string]bool{}
+	for _, m := range markdownLinkTarget.FindAllStringSubmatch(string(data), -1) {
+		// Index entries are written as bare filenames; tolerate a relative
+		// prefix so a hand-edited `./name.md` still resolves.
+		targets[filepath.Base(m[1])] = true
+	}
+	return targets, nil
+}
+
+// AuditLinkage reports topic files the index cannot reach (orphans) and index
+// links with no file behind them (dangling). Both directions matter: an orphan
+// is a memory that will never be recalled, and a dangling link is an index
+// promising context that cannot be loaded.
+func AuditLinkage(dir string) ([]AuditFinding, error) {
+	names, err := topicFiles(dir)
+	if err != nil {
+		return nil, err
+	}
+	if len(names) == 0 {
+		// No topic files: a dangling link cannot be distinguished from a
+		// directory that was never populated, so stay silent.
+		return nil, nil
+	}
+
+	indexPath := filepath.Join(dir, indexFileName)
+	targets, err := indexTargets(indexPath)
+	if err != nil {
+		return nil, err
+	}
+
+	present := make(map[string]bool, len(names))
+	for _, n := range names {
+		present[n] = true
+	}
+
+	var findings []AuditFinding
+	for _, n := range names {
+		if !targets[n] {
+			findings = append(findings, AuditFinding{
+				Code:   WarnOrphanNotIndexed,
+				Path:   filepath.Join(dir, n),
+				Detail: fmt.Sprintf("%s is not linked from %s — a session loads the index, so this memory is never recalled", n, indexFileName),
+			})
+		}
+	}
+	for target := range targets {
+		if !present[target] {
+			findings = append(findings, AuditFinding{
+				Code:   WarnDanglingIndexLink,
+				Path:   indexPath,
+				Detail: fmt.Sprintf("index links %s but no such file exists", target),
+			})
+		}
+	}
+	return findings, nil
+}
+
+// AuditTopicCount reports when the directory holds more topic files than cap.
+// A non-positive cap falls back to the configured default.
+func AuditTopicCount(dir string, cap int) ([]AuditFinding, error) {
+	if cap <= 0 {
+		cap = config.DefaultMemoryTopicFileCap
+	}
+
+	names, err := topicFiles(dir)
+	if err != nil {
+		return nil, err
+	}
+	if len(names) <= cap {
+		return nil, nil
+	}
+
+	return []AuditFinding{{
+		Code:   WarnTopicCountOverCap,
+		Path:   dir,
+		Detail: fmt.Sprintf("%d topic files; cap is %d — archive %d into %s/", len(names), cap, len(names)-cap, archiveDirName),
+	}}, nil
+}

--- a/internal/hook/memo/taxonomy/linkage_test.go
+++ b/internal/hook/memo/taxonomy/linkage_test.go
@@ -1,0 +1,171 @@
+// linkage_test.go — index-linkage and topic-count audits.
+//
+// The pre-existing audits validate a memory file's own shape (frontmatter,
+// type, body structure, duplicate descriptions) and the index's line count.
+// None of them reads the index's links, so a topic file that was written but
+// never indexed passes every check while being unreachable: only MEMORY.md is
+// loaded into a session, so an unlinked file is stored and never recalled.
+// These tests pin the two checks that close that gap.
+package taxonomy
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeMemoryFixture lays out a memory directory: an index carrying one link
+// line per name in linked, and a topic file per name in present.
+func writeMemoryFixture(t *testing.T, linked, present []string) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	var idx strings.Builder
+	idx.WriteString("# Memory Index\n\n")
+	for _, name := range linked {
+		idx.WriteString("- [Title](" + name + ") — hook\n")
+	}
+	if err := os.WriteFile(filepath.Join(dir, "MEMORY.md"), []byte(idx.String()), 0o644); err != nil {
+		t.Fatalf("write index: %v", err)
+	}
+
+	for _, name := range present {
+		body := "---\nname: x\ndescription: d\nmetadata:\n  type: feedback\n---\n\nbody\n"
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	return dir
+}
+
+func codesOf(findings []AuditFinding) map[AuditCode]int {
+	out := map[AuditCode]int{}
+	for _, f := range findings {
+		out[f.Code]++
+	}
+	return out
+}
+
+// TestAuditLinkageFindsOrphans is the case that actually bit this project:
+// files on disk that no index line points at.
+func TestAuditLinkageFindsOrphans(t *testing.T) {
+	t.Parallel()
+	dir := writeMemoryFixture(t,
+		[]string{"feedback_a.md"},
+		[]string{"feedback_a.md", "feedback_b.md", "project_c.md"})
+
+	findings, err := AuditLinkage(dir)
+	if err != nil {
+		t.Fatalf("AuditLinkage: %v", err)
+	}
+	if got := codesOf(findings)[WarnOrphanNotIndexed]; got != 2 {
+		t.Errorf("orphan findings = %d, want 2 (feedback_b, project_c): %+v", got, findings)
+	}
+	for _, f := range findings {
+		if f.Code == WarnOrphanNotIndexed && strings.Contains(f.Path, "feedback_a.md") {
+			t.Error("indexed file reported as an orphan")
+		}
+	}
+}
+
+// TestAuditLinkageFindsDanglingLinks covers the other direction: an index
+// line whose target was moved or removed.
+func TestAuditLinkageFindsDanglingLinks(t *testing.T) {
+	t.Parallel()
+	dir := writeMemoryFixture(t,
+		[]string{"feedback_a.md", "feedback_gone.md"},
+		[]string{"feedback_a.md"})
+
+	findings, err := AuditLinkage(dir)
+	if err != nil {
+		t.Fatalf("AuditLinkage: %v", err)
+	}
+	if got := codesOf(findings)[WarnDanglingIndexLink]; got != 1 {
+		t.Errorf("dangling findings = %d, want 1: %+v", got, findings)
+	}
+}
+
+// TestAuditLinkageCleanIsSilent keeps the audit quiet when the index and the
+// directory agree — a check that always fires teaches people to ignore it.
+func TestAuditLinkageCleanIsSilent(t *testing.T) {
+	t.Parallel()
+	dir := writeMemoryFixture(t,
+		[]string{"feedback_a.md", "project_b.md"},
+		[]string{"feedback_a.md", "project_b.md"})
+
+	findings, err := AuditLinkage(dir)
+	if err != nil {
+		t.Fatalf("AuditLinkage: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("clean fixture produced findings: %+v", findings)
+	}
+}
+
+// TestAuditLinkageIgnoresArchive pins that archived files are out of scope:
+// archiving is the remedy the cap prescribes, so counting archived files as
+// orphans would make the remedy trip the alarm.
+func TestAuditLinkageIgnoresArchive(t *testing.T) {
+	t.Parallel()
+	dir := writeMemoryFixture(t, []string{"feedback_a.md"}, []string{"feedback_a.md"})
+	arch := filepath.Join(dir, "_archive")
+	if err := os.MkdirAll(arch, 0o755); err != nil {
+		t.Fatalf("mkdir archive: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(arch, "project_old.md"), []byte("---\n---\n"), 0o644); err != nil {
+		t.Fatalf("write archived: %v", err)
+	}
+
+	findings, err := AuditLinkage(dir)
+	if err != nil {
+		t.Fatalf("AuditLinkage: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("archived file produced findings: %+v", findings)
+	}
+}
+
+// TestAuditTopicCountOverCap pins the constitution's per-project ceiling,
+// which had no checker at all.
+func TestAuditTopicCountOverCap(t *testing.T) {
+	t.Parallel()
+	names := make([]string, 0, 4)
+	for _, n := range []string{"feedback_a.md", "feedback_b.md", "feedback_c.md", "feedback_d.md"} {
+		names = append(names, n)
+	}
+	dir := writeMemoryFixture(t, names, names)
+
+	findings, err := AuditTopicCount(dir, 3)
+	if err != nil {
+		t.Fatalf("AuditTopicCount: %v", err)
+	}
+	if got := codesOf(findings)[WarnTopicCountOverCap]; got != 1 {
+		t.Errorf("over-cap findings = %d, want 1: %+v", got, findings)
+	}
+	if len(findings) == 1 && !strings.Contains(findings[0].Detail, "4") {
+		t.Errorf("detail should name the observed count: %q", findings[0].Detail)
+	}
+
+	under, err := AuditTopicCount(dir, 10)
+	if err != nil {
+		t.Fatalf("AuditTopicCount under cap: %v", err)
+	}
+	if len(under) != 0 {
+		t.Errorf("under cap produced findings: %+v", under)
+	}
+}
+
+// TestAuditMissingDirIsNotAnError keeps both audits fail-open: a project with
+// no memory directory yet is not a defect.
+func TestAuditMissingDirIsNotAnError(t *testing.T) {
+	t.Parallel()
+	missing := filepath.Join(t.TempDir(), "nope")
+
+	if f, err := AuditLinkage(missing); err != nil || len(f) != 0 {
+		t.Errorf("AuditLinkage(missing) = %+v, %v; want nil, nil", f, err)
+	}
+	if f, err := AuditTopicCount(missing, 50); err != nil || len(f) != 0 {
+		t.Errorf("AuditTopicCount(missing) = %+v, %v; want nil, nil", f, err)
+	}
+}

--- a/internal/hook/memo/taxonomy/linkage_test.go
+++ b/internal/hook/memo/taxonomy/linkage_test.go
@@ -130,10 +130,7 @@ func TestAuditLinkageIgnoresArchive(t *testing.T) {
 // which had no checker at all.
 func TestAuditTopicCountOverCap(t *testing.T) {
 	t.Parallel()
-	names := make([]string, 0, 4)
-	for _, n := range []string{"feedback_a.md", "feedback_b.md", "feedback_c.md", "feedback_d.md"} {
-		names = append(names, n)
-	}
+	names := []string{"feedback_a.md", "feedback_b.md", "feedback_c.md", "feedback_d.md"}
 	dir := writeMemoryFixture(t, names, names)
 
 	findings, err := AuditTopicCount(dir, 3)


### PR DESCRIPTION
Two places where the harness documents one thing and does another.

## `moai todo` — the bare form never reached the backlog

The skill surface and `workflows/todo.md` both describe a bare `/moai todo` as the list surface. The command answered it with cobra's help text.

Fixed by moving the code to the docs rather than the other way round:

| Invocation | Before | After |
|---|---|---|
| `moai todo` | help text | **lists the queue** |
| `moai todo list` | lists | lists (unchanged) |
| `moai todo lsit` | error | error (unchanged) |
| `moai todo --help` | help | help (unchanged) |

Both entry points share `runTodoList`, so their output cannot drift. `cobra.NoArgs` keeps a mistyped verb an error rather than letting it fall through to a silent listing.

## `moai memory` — the Lessons Protocol had no implementer

The constitution declares a per-project ceiling on topic files and an `_archive/` remedy. **Nothing in the repository implemented either** — no Go code, no hook, no script. Measured on this project:

| | profile store | default store |
|---|---|---|
| topic files | 164 | **918** |
| index links | 123 | 155 |
| **orphans** | 41 (25%) | **763 (83%)** |

**1,082 topic files against a cap of 50, and 804 of them (74%) unreachable from any `MEMORY.md`.**

That last number is the actual defect. A session loads `MEMORY.md`, not the directory — a topic file written without its index line is stored and never recalled. The existing audits could not see it:

| Existing audit | What it reads | Orphan visible? |
|---|---|---|
| `AuditFile` | the file's own frontmatter + body | no |
| `AuditIndex` | the index's **line count** | no |
| `AuditDuplicates` | description collisions | no |
| `DetectStale` | mtimes | no |

None reads the index's *links*. Every orphan passed every check.

### What this adds

- **`taxonomy.AuditLinkage`** — orphans and dangling links, both directions. `_archive/` is excluded: archiving is the prescribed remedy, so counting its contents would trip the alarm it clears.
- **`taxonomy.AuditTopicCount`** — the ceiling finally has a checker.
- **`moai memory doctor [--json] [--dir] [--cap]`** — reports both, plus the index audit, and resolves **both** candidate stores. A session under a profile writes to `$CLAUDE_CONFIG_DIR`, one without it writes to `~/.claude`, and they cannot see each other's memories; reporting a single store would have hidden the larger half.
- **`moai memory archive <name>...`** — retires named files into `_archive/` and drops their index lines. Which memory is obsolete is a judgement, so nothing is selected automatically. Every name is validated before anything moves (a typo in the last cannot half-archive the earlier ones), and the move never deletes.

Real output against this repository:

```
…/claude-profiles/moai-adk/projects/…/memory  (CLAUDE_CONFIG_DIR)
  topic files : 165 (cap 50)
  findings    :
    MEMORY_ORPHAN_NOT_INDEXED      41
    MEMORY_TOPIC_COUNT_OVER_CAP    1

…/.claude/projects/…/memory  (default ~/.claude)
  topic files : 918 (cap 50)
  findings    :
    MEMORY_ORPHAN_NOT_INDEXED      763
    MEMORY_TOPIC_COUNT_OVER_CAP    1
```

## Verification

| Check | Result |
|---|---|
| `gofmt -l` | clean |
| `go vet` | exit 0 |
| `GOOS=windows go vet` | exit 0 |
| new suites (linkage, memory, todo) | pass |
| `internal/hook/memo`, `taxonomy`, `config` | pass |

One failure in `internal/cli`: `TestHandleCodexReviewGate_LiveCodexBlocksInjectionAndKey`, which calls the live codex backend and received an inconclusive verdict. Pre-existing, tracked as backlog card **t52**, and this change touches none of its files.

## Not covered here

Surfacing the orphan count automatically at session start. The existing SessionStart staleness scan targets `.claude/agent-memory/` — a different layer — and adding a per-session warning for an 804-orphan store needs its own decision about aggregation and hook latency budget.

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `moai memory doctor` to audit memory stores, indexes, orphaned files, broken links, and capacity limits with human-readable or JSON output.
  * Added `moai memory archive` to safely archive selected topic files and update memory indexes.
  * Added `moai migrate profiles` to consolidate profile memory stores, with dry-run support and conflict handling.
  * Added a default limit of 50 memory topic files.
* **Improvements**
  * Running `moai todo` now displays the task queue directly, matching `moai todo list`.
  * Updates now provide an advisory when profile memory remains unmigrated.
  * Improved memory checks for missing, orphaned, and archived files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->