### PR TITLE
feat(statusline): session identity line, board workload, and open forge counts

### DIFF
--- a/internal/cli/statusline.go
+++ b/internal/cli/statusline.go
@@ -18,6 +18,15 @@ import (
 // render budget so a slow or rate-limited collector cannot stall the status bar.
 const statuslineRenderBudget = 800 * time.Millisecond
 
+// statuslineRefreshGitHub and statuslineBoardRoot back the detached refresh
+// entry point. The statusline render path never calls the network; when its
+// GitHub cache ages out it re-invokes this binary with these flags and returns
+// immediately, so the fetch happens in a child that nothing waits on.
+var (
+	statuslineRefreshGitHub bool
+	statuslineBoardRoot     string
+)
+
 // StatuslineCmd is the statusline command.
 var StatuslineCmd = &cobra.Command{
 	Use:    "statusline",
@@ -27,12 +36,29 @@ var StatuslineCmd = &cobra.Command{
 	RunE:   runStatusline,
 }
 
+func init() {
+	StatuslineCmd.Flags().BoolVar(&statuslineRefreshGitHub, "refresh-github", false,
+		"Refresh the cached GitHub issue/PR counts and exit (internal; spawned by the render path)")
+	StatuslineCmd.Flags().StringVar(&statuslineBoardRoot, "board-root", "",
+		"Project root holding .moai/state (internal; used with --refresh-github)")
+	_ = StatuslineCmd.Flags().MarkHidden("refresh-github")
+	_ = StatuslineCmd.Flags().MarkHidden("board-root")
+}
+
 // runStatusline renders a statusline string suitable for Claude Code's status bar.
 //
 // @MX:ANCHOR: statusline CLI entry point (fan_in >= 3: shell wrapper, direct CLI, tests)
 // @MX:REASON: public entry point for statusline rendering — cwd guard is critical for stability
 // @MX:SPEC: SPEC-V3R3-STATUSLINE-FALLBACK-001
 func runStatusline(cmd *cobra.Command, _ []string) error {
+	// Detached refresh entry point: fetch the GitHub counts, write the cache,
+	// and exit without rendering. Errors are swallowed — a failed refresh must
+	// leave the status bar showing the previous value, not a failure.
+	if statuslineRefreshGitHub {
+		_ = statusline.RefreshGitHubCounts(cmd.Context(), statuslineBoardRoot)
+		return nil
+	}
+
 	// AC-SF-006: cwd guard — deleted directory fallback
 	// os.Getwd() may succeed on macOS even with deleted cwd, so also check with os.Stat()
 	if wd, err := os.Getwd(); err != nil || !dirExists(wd) {

--- a/internal/statusline/backlog.go
+++ b/internal/statusline/backlog.go
@@ -1,0 +1,70 @@
+package statusline
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// BacklogCounts is the kanban backlog reduced to what a glance needs: how much
+// work is in flight and how much is waiting. Dropped items are deliberately not
+// counted — they are history, and a number that only ever grows is noise.
+type BacklogCounts struct {
+	Picked    int  // state == "picked" — admitted to the board, in flight
+	Queued    int  // state == "queued" — waiting for the operator to pick
+	Available bool // false when no backlog file could be read
+}
+
+// backlogFileSnippet is the minimal subset of backlog.json the statusline
+// reads. Only the per-item state is load-bearing.
+type backlogFileSnippet struct {
+	Items []struct {
+		State string `json:"state"`
+	} `json:"items"`
+}
+
+// resolveBoardRoot returns the directory holding the project's kanban state.
+//
+// This is NOT always the session's working directory. `.moai/state/` is
+// gitignored, so it exists only in the primary checkout — a session working
+// inside a worktree finds nothing there. Claude Code hands us the primary's
+// path as `worktree.original_cwd`, so the worktree case is resolved from the
+// payload rather than by shelling out to git, which would put a subprocess on
+// every status render.
+func resolveBoardRoot(input *StdinData) string {
+	if input != nil && input.Worktree != nil && input.Worktree.OriginalCwd != "" {
+		return input.Worktree.OriginalCwd
+	}
+	return resolveProjectDir(input)
+}
+
+// resolveBacklogCounts reads .moai/state/kanban/backlog.json under boardRoot and
+// counts items by state. Best-effort + fail-open: an absent file, a read error,
+// or a parse error all yield Available=false and render nothing. Constant-cost
+// (one read of one small file) per statusline render — it must never grow with
+// the number of cards in a way that puts the render on a slow path.
+func resolveBacklogCounts(boardRoot string) BacklogCounts {
+	if boardRoot == "" {
+		return BacklogCounts{}
+	}
+	path := filepath.Join(boardRoot, ".moai", "state", "kanban", "backlog.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return BacklogCounts{} // absent or unreadable → nothing to show
+	}
+	var s backlogFileSnippet
+	if err := json.Unmarshal(data, &s); err != nil {
+		return BacklogCounts{} // corrupt → nothing to show (fail-open)
+	}
+
+	counts := BacklogCounts{Available: true}
+	for _, item := range s.Items {
+		switch item.State {
+		case "picked":
+			counts.Picked++
+		case "queued":
+			counts.Queued++
+		}
+	}
+	return counts
+}

--- a/internal/statusline/builder.go
+++ b/internal/statusline/builder.go
@@ -232,7 +232,14 @@ func (b *defaultBuilder) collectAll(ctx context.Context, input *StdinData) *Stat
 	// own directory: `.moai/state/` is gitignored, so a worktree session would
 	// otherwise find nothing. Fail-open — an unreadable backlog renders nothing.
 	if input != nil {
-		data.Backlog = resolveBacklogCounts(resolveBoardRoot(input))
+		boardRoot := resolveBoardRoot(input)
+		data.Backlog = resolveBacklogCounts(boardRoot)
+
+		// GitHub counts are read from cache only — the render path never calls
+		// the network. When the cache has aged out, a detached child is asked
+		// to refresh it and this render proceeds with the previous value.
+		data.GitHub = resolveGitHubCounts(boardRoot)
+		maybeRefreshGitHubCounts(boardRoot)
 	}
 
 	// SPEC-INFINITE-GOAL-001 REQ-3: resolve whether an armed goal exists for

--- a/internal/statusline/builder.go
+++ b/internal/statusline/builder.go
@@ -228,6 +228,13 @@ func (b *defaultBuilder) collectAll(ctx context.Context, input *StdinData) *Stat
 		}
 	}
 
+	// Kanban backlog counts. Read from the board root rather than the session's
+	// own directory: `.moai/state/` is gitignored, so a worktree session would
+	// otherwise find nothing. Fail-open — an unreadable backlog renders nothing.
+	if input != nil {
+		data.Backlog = resolveBacklogCounts(resolveBoardRoot(input))
+	}
+
 	// SPEC-INFINITE-GOAL-001 REQ-3: resolve whether an armed goal exists for
 	// this session so the renderer can suppress the /clear directive markers
 	// while a goal is armed. Best-effort + fail-open + constant-cost (one small

--- a/internal/statusline/builder.go
+++ b/internal/statusline/builder.go
@@ -217,6 +217,17 @@ func (b *defaultBuilder) collectAll(ctx context.Context, input *StdinData) *Stat
 		data.Directory = extractProjectDirectory(input)
 	}
 
+	// Session identity: explicit name, plus the agent the session runs as.
+	// Claude Code drops its own prompt-bar name chip after /clear even though
+	// the explicit name is retained, so the operator loses the only on-screen
+	// identity cue. Rendering it here keeps it visible for the session's life.
+	if input != nil {
+		data.SessionName = input.SessionName
+		if input.Agent != nil {
+			data.AgentName = input.Agent.Name
+		}
+	}
+
 	// SPEC-INFINITE-GOAL-001 REQ-3: resolve whether an armed goal exists for
 	// this session so the renderer can suppress the /clear directive markers
 	// while a goal is armed. Best-effort + fail-open + constant-cost (one small

--- a/internal/statusline/forge.go
+++ b/internal/statusline/forge.go
@@ -1,0 +1,189 @@
+package statusline
+
+import (
+	"context"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// A forge is whatever hosts the issues and the change requests for this
+// checkout. Everything around the count — the cache, the TTL, the detached
+// refresh, the binary-name guard — behaves the same whichever one answers, so
+// the forges are a table of a binary name and two argument lists rather than an
+// interface whose implementations would each duplicate the rest to vary three
+// strings.
+
+// gitlabPageSize bounds how many items `glab` enumerates in one call. GitLab
+// paginates and this asks for a single page, so a project with more open items
+// than this reports the page rather than the true count — the same trade the
+// GitHub path already makes with its own limit, and the same reason: a status
+// bar wants a number now, not an accurate number later.
+const gitlabPageSize = "100"
+
+// forgeSpec names one hosting service and how to ask it for open counts.
+type forgeSpec struct {
+	// name is the token that selects this forge explicitly in config.
+	name string
+	// bin is the CLI that answers. Absent from PATH means no counts, which
+	// renders as nothing rather than as an error.
+	bin string
+	// issueArgs and prArgs each end in a jq filter that reduces the listing to
+	// a bare integer, so the caller parses one number whichever forge answered.
+	issueArgs []string
+	prArgs    []string
+}
+
+var forgeGitHub = forgeSpec{
+	name: "github",
+	bin:  "gh",
+	issueArgs: []string{"issue", "list", "--state", "open",
+		"--limit", githubListLimit, "--json", "number", "--jq", "length"},
+	prArgs: []string{"pr", "list", "--state", "open",
+		"--limit", githubListLimit, "--json", "number", "--jq", "length"},
+}
+
+// forgeGitLab differs from GitHub in two ways that are easy to get wrong.
+//
+// Open is glab's default for both listings, so no state flag is passed: `gh`
+// needs `--state open` to widen from its own default, while giving glab a state
+// flag would narrow rather than widen.
+//
+// The long-form `--output` is used deliberately. Its short form is not stable
+// across glab's own subcommands — on `mr list` `-F` abbreviates `--output`,
+// while on `issue list` `-F` abbreviates `--output-format`, which selects
+// details/ids/urls and would not produce JSON at all.
+var forgeGitLab = forgeSpec{
+	name: "gitlab",
+	bin:  "glab",
+	issueArgs: []string{"issue", "list",
+		"--per-page", gitlabPageSize, "--output", "json", "--jq", "length"},
+	prArgs: []string{"mr", "list",
+		"--per-page", gitlabPageSize, "--output", "json", "--jq", "length"},
+}
+
+// argsFor returns the argument list for one kind of item. Anything that is not
+// a change request is treated as an issue, so a caller cannot silently ask for
+// a listing that does not exist.
+func (f forgeSpec) argsFor(kind string) []string {
+	if kind == "pr" {
+		return f.prArgs
+	}
+	return f.issueArgs
+}
+
+// resolveForge picks the forge for a checkout: an explicit config value wins,
+// otherwise the remote's host decides. The second return is false when no forge
+// applies, which renders nothing rather than guessing.
+//
+// An unrecognised override yields no forge rather than falling back to
+// detection. A typo should show an absent segment — a visible symptom the
+// operator can trace to the value they just typed — rather than quietly
+// counting against whatever the hostname happened to suggest.
+func resolveForge(remoteURL, override string) (forgeSpec, bool) {
+	switch strings.ToLower(strings.TrimSpace(override)) {
+	case forgeGitHub.name:
+		return forgeGitHub, true
+	case forgeGitLab.name:
+		return forgeGitLab, true
+	case "none", "off":
+		return forgeSpec{}, false
+	case "":
+		return forgeFromRemote(remoteURL)
+	default:
+		return forgeSpec{}, false
+	}
+}
+
+// forgeFromRemote maps a remote URL's host onto a forge.
+//
+// Only the public hosts are recognised. A self-hosted instance answers on a
+// name that carries no signal — a company GitLab at git.example.com is
+// indistinguishable from a company GitHub Enterprise at the same shape of
+// address — so those resolve to no forge and wait for the config override
+// rather than being guessed at.
+func forgeFromRemote(remoteURL string) (forgeSpec, bool) {
+	switch remoteHost(remoteURL) {
+	case "github.com", "www.github.com":
+		return forgeGitHub, true
+	case "gitlab.com", "www.gitlab.com":
+		return forgeGitLab, true
+	}
+	return forgeSpec{}, false
+}
+
+// remoteHost extracts the host from a git remote URL.
+//
+// Two forms reach here and only one is a URL. `https://host/o/r.git` and
+// `ssh://git@host/o/r.git` parse; `git@host:o/r.git` is scp-like syntax that
+// url.Parse reads as a path with no host, so it is split by hand. The
+// discriminator is the scheme separator rather than the colon, because the
+// URL form carries a colon too.
+func remoteHost(raw string) string {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return ""
+	}
+
+	if !strings.Contains(s, "://") {
+		colon := strings.Index(s, ":")
+		if colon <= 0 {
+			return ""
+		}
+		hostPart := s[:colon]
+		if at := strings.LastIndex(hostPart, "@"); at >= 0 {
+			hostPart = hostPart[at+1:]
+		}
+		return strings.ToLower(hostPart)
+	}
+
+	u, err := url.Parse(s)
+	if err != nil {
+		return ""
+	}
+	return strings.ToLower(u.Hostname())
+}
+
+// forgeOverride reads statusline.forge from the project's statusline.yaml.
+//
+// A local shape rather than the full config loader, matching how this package
+// already reads llm.yaml: an absent, unreadable, or malformed file yields an
+// empty override and detection decides instead.
+func forgeOverride(boardRoot string) string {
+	if boardRoot == "" {
+		return ""
+	}
+	data, err := os.ReadFile(filepath.Join(boardRoot, ".moai", "config", "sections", "statusline.yaml"))
+	if err != nil {
+		return ""
+	}
+	var parsed struct {
+		Statusline struct {
+			Forge string `yaml:"forge"`
+		} `yaml:"statusline"`
+	}
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(parsed.Statusline.Forge)
+}
+
+// originRemoteURL reports the origin remote of a checkout, or "" when there is
+// no repository, no origin, or no git.
+//
+// This shells out rather than reusing the package's git.Repository adapter
+// because it runs only in the detached refresh child, where one more process is
+// already the cost of the operation. The render path never calls it.
+func originRemoteURL(ctx context.Context, dir string) string {
+	cmd := exec.CommandContext(ctx, "git", "remote", "get-url", "origin")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/internal/statusline/forge_test.go
+++ b/internal/statusline/forge_test.go
@@ -1,0 +1,235 @@
+package statusline
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Forge selection is the one part of the counts feature that can be verified
+// without the forge: which command gets built, and from what. The fetch itself
+// needs the CLI and a repository on that host, so these tests cover everything
+// up to the exec boundary and stop there deliberately.
+
+func TestRemoteHost(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"https", "https://github.com/modu-ai/moai-adk.git", "github.com"},
+		{"https no suffix", "https://gitlab.com/group/proj", "gitlab.com"},
+		{"ssh scheme", "ssh://git@github.com/o/r.git", "github.com"},
+		{"ssh scheme with port", "ssh://git@git.example.com:2222/o/r.git", "git.example.com"},
+		// scp-like: url.Parse reads this as a path with no host, so it is
+		// split by hand. This is the default form `git clone git@...` writes.
+		{"scp-like", "git@github.com:modu-ai/moai-adk.git", "github.com"},
+		{"scp-like no user", "github.com:o/r.git", "github.com"},
+		{"uppercase is normalised", "https://GitHub.COM/o/r", "github.com"},
+		{"empty", "", ""},
+		{"whitespace only", "   ", ""},
+		{"no host at all", "/local/path/repo.git", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := remoteHost(tt.raw); got != tt.want {
+				t.Errorf("remoteHost(%q) = %q, want %q", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestForgeFromRemote(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		raw      string
+		wantName string
+		wantOK   bool
+	}{
+		{"https://github.com/o/r.git", "github", true},
+		{"git@gitlab.com:g/p.git", "gitlab", true},
+		// A self-hosted instance carries no signal in its name: a company
+		// GitLab and a company GitHub Enterprise look identical here, so
+		// neither is guessed and the config override decides.
+		{"https://git.example.com/g/p.git", "", false},
+		{"https://bitbucket.org/o/r.git", "", false},
+		{"", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.raw, func(t *testing.T) {
+			t.Parallel()
+			got, ok := forgeFromRemote(tt.raw)
+			if ok != tt.wantOK {
+				t.Fatalf("forgeFromRemote(%q) ok = %v, want %v", tt.raw, ok, tt.wantOK)
+			}
+			if ok && got.name != tt.wantName {
+				t.Errorf("forgeFromRemote(%q) = %q, want %q", tt.raw, got.name, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestResolveForge(t *testing.T) {
+	t.Parallel()
+
+	const ghRemote = "https://github.com/o/r.git"
+
+	tests := []struct {
+		name     string
+		remote   string
+		override string
+		wantName string
+		wantOK   bool
+	}{
+		{"detection when no override", ghRemote, "", "github", true},
+		{"override beats detection", ghRemote, "gitlab", "gitlab", true},
+		{"override is case insensitive", ghRemote, "GitLab", "gitlab", true},
+		{"override is trimmed", ghRemote, "  gitlab  ", "gitlab", true},
+		{"none disables the segment", ghRemote, "none", "", false},
+		{"off disables the segment", ghRemote, "off", "", false},
+		// A typo must show an absent segment rather than quietly counting
+		// against whatever the hostname suggested — a visible symptom the
+		// operator can trace back to the value they just typed.
+		{"unknown override does not fall back", ghRemote, "githbu", "", false},
+		{"override rescues a self-hosted host", "https://git.example.com/g/p.git", "gitlab", "gitlab", true},
+		{"no remote and no override", "", "", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := resolveForge(tt.remote, tt.override)
+			if ok != tt.wantOK {
+				t.Fatalf("resolveForge(%q, %q) ok = %v, want %v", tt.remote, tt.override, ok, tt.wantOK)
+			}
+			if ok && got.name != tt.wantName {
+				t.Errorf("resolveForge(%q, %q) = %q, want %q", tt.remote, tt.override, got.name, tt.wantName)
+			}
+		})
+	}
+}
+
+// The two CLIs disagree about defaults in a way that inverts the fix: `gh`
+// lists closed items unless told `--state open`, while `glab` already defaults
+// to open and would be narrowed by a state flag. Copying one command's shape
+// onto the other silently returns the wrong number rather than failing.
+func TestForgeArgs_StateHandlingDiffers(t *testing.T) {
+	t.Parallel()
+
+	for _, kind := range []string{"issue", "pr"} {
+		gh := strings.Join(forgeGitHub.argsFor(kind), " ")
+		if !strings.Contains(gh, "--state open") {
+			t.Errorf("gh %s args must name the open state: %q", kind, gh)
+		}
+
+		gl := strings.Join(forgeGitLab.argsFor(kind), " ")
+		if strings.Contains(gl, "--state") || strings.Contains(gl, "--closed") ||
+			strings.Contains(gl, "--merged") || strings.Contains(gl, "--all") {
+			t.Errorf("glab %s args must not pass a state flag; open is its default: %q", kind, gl)
+		}
+	}
+}
+
+// glab's short flags are not stable across its own subcommands: on `mr list`
+// -F abbreviates --output, but on `issue list` -F abbreviates --output-format,
+// which selects details/ids/urls and yields no JSON at all.
+func TestForgeArgs_GitLabUsesLongFormOutput(t *testing.T) {
+	t.Parallel()
+
+	for _, kind := range []string{"issue", "pr"} {
+		args := forgeGitLab.argsFor(kind)
+		joined := strings.Join(args, " ")
+		if !strings.Contains(joined, "--output json") {
+			t.Errorf("glab %s args must request JSON by long-form flag: %q", kind, joined)
+		}
+		for _, a := range args {
+			if a == "-F" || a == "-O" {
+				t.Errorf("glab %s args must not use a short output flag: %q", kind, joined)
+			}
+		}
+	}
+}
+
+// Every forge must reduce its listing to a bare integer, because the caller
+// parses one number without knowing which CLI answered.
+func TestForgeArgs_AllEndInACount(t *testing.T) {
+	t.Parallel()
+
+	for _, f := range []forgeSpec{forgeGitHub, forgeGitLab} {
+		for _, kind := range []string{"issue", "pr"} {
+			args := f.argsFor(kind)
+			if n := len(args); n < 2 || args[n-2] != "--jq" || args[n-1] != "length" {
+				t.Errorf("%s %s args must end in --jq length, got %v", f.name, kind, args)
+			}
+		}
+	}
+}
+
+func TestForgeArgs_PRAndIssueDiffer(t *testing.T) {
+	t.Parallel()
+
+	if strings.Join(forgeGitHub.argsFor("pr"), " ") == strings.Join(forgeGitHub.argsFor("issue"), " ") {
+		t.Error("gh pr and issue args are identical; one of them counts the wrong thing")
+	}
+	// GitLab names them merge requests, which is the whole reason the two
+	// argument lists exist rather than one with a substituted noun.
+	if forgeGitLab.argsFor("pr")[0] != "mr" {
+		t.Errorf("glab change requests are `mr`, got %q", forgeGitLab.argsFor("pr")[0])
+	}
+	// An unrecognised kind must not silently produce a change-request listing.
+	if strings.Join(forgeGitHub.argsFor("anything-else"), " ") != strings.Join(forgeGitHub.argsFor("issue"), " ") {
+		t.Error("an unknown kind must fall back to the issue listing")
+	}
+}
+
+func TestForgeOverride(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body string // empty means: write no file
+		want string
+	}{
+		{"reads the key", "statusline:\n  forge: gitlab\n", "gitlab"},
+		{"trims whitespace", "statusline:\n  forge: \"  gitlab  \"\n", "gitlab"},
+		{"absent key yields empty", "statusline:\n  theme: catppuccin-mocha\n", ""},
+		{"malformed yaml fails open", "statusline:\n  forge: [", ""},
+		{"missing file fails open", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			root := t.TempDir()
+			if tt.body != "" {
+				dir := filepath.Join(root, ".moai", "config", "sections")
+				if err := os.MkdirAll(dir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(dir, "statusline.yaml"), []byte(tt.body), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			if got := forgeOverride(root); got != tt.want {
+				t.Errorf("forgeOverride = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestForgeOverride_EmptyRootIsANoOp(t *testing.T) {
+	t.Parallel()
+
+	if got := forgeOverride(""); got != "" {
+		t.Errorf("forgeOverride(\"\") = %q, want empty", got)
+	}
+}

--- a/internal/statusline/github.go
+++ b/internal/statusline/github.go
@@ -1,0 +1,180 @@
+package statusline
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// GitHubCountsTTL is how long a fetched count is served before a refresh is
+// triggered. It trades staleness for calls: open issue and PR counts move on
+// the scale of hours, and a shorter window would spend the API budget of every
+// concurrent session on numbers that did not change.
+const GitHubCountsTTL = 10 * time.Minute
+
+// githubFetchBudget bounds the detached refresh. `gh` can hang on a captive
+// portal or a stalled TLS handshake; without a ceiling that child would
+// outlive the session that spawned it.
+const githubFetchBudget = 20 * time.Second
+
+// githubListLimit caps how many items `gh` enumerates per call. Repositories
+// with more open items than this report the cap rather than the true count —
+// an acceptable trade for a status bar, and far below any real backlog.
+const githubListLimit = "1000"
+
+// GitHubCounts is the repository's open work, as of the last successful fetch.
+type GitHubCounts struct {
+	OpenIssues int   `json:"open_issues"`
+	OpenPRs    int   `json:"open_prs"`
+	Available  bool  `json:"-"`          // false when no cache could be read
+	FetchedAt  int64 `json:"fetched_at"` // unix seconds; 0 when never fetched
+}
+
+// githubCachePath returns where the counts cache lives for a board root.
+func githubCachePath(boardRoot string) string {
+	return filepath.Join(boardRoot, ".moai", "state", "github", "counts.json")
+}
+
+// resolveGitHubCounts reads the cached counts. Best-effort + fail-open: an
+// absent, unreadable, or corrupt cache yields Available=false and renders
+// nothing. Constant-cost — one read of one small file per statusline render.
+//
+// This NEVER calls the network. The render path only reads; refreshing is the
+// detached child's job (see maybeRefreshGitHubCounts).
+func resolveGitHubCounts(boardRoot string) GitHubCounts {
+	if boardRoot == "" {
+		return GitHubCounts{}
+	}
+	data, err := os.ReadFile(githubCachePath(boardRoot))
+	if err != nil {
+		return GitHubCounts{}
+	}
+	var c GitHubCounts
+	if err := json.Unmarshal(data, &c); err != nil {
+		return GitHubCounts{}
+	}
+	c.Available = true
+	return c
+}
+
+// isSelfInvocable reports whether path names the moai binary — the only
+// executable safe to re-invoke with `statusline --refresh-github`.
+//
+// Under `go test` the executable is the test binary, and handing it these
+// arguments re-runs the whole suite — recursively, once per render, until the
+// machine gives out. Any other host (a renamed binary, an embedding) degrades
+// to a stale count, which is the right way to fail.
+//
+// Kept as a named predicate rather than an inline condition so the guard can be
+// tested directly: exercising it through the spawn path would mean a broken
+// guard turns its own regression test into the fork bomb it exists to prevent.
+func isSelfInvocable(path string) bool {
+	base := filepath.Base(path)
+	return base == "moai" || base == "moai.exe"
+}
+
+// maybeRefreshGitHubCounts triggers a background refresh when the cache is
+// missing or older than GitHubCountsTTL, and returns immediately either way.
+// The caller keeps rendering the previous value — stale-while-revalidate, so a
+// slow network degrades freshness rather than the status bar.
+//
+// The stampede guard is the cache file's own timestamp: the child rewrites it
+// with a fresh FetchedAt before it starts fetching, so every render between the
+// spawn and the result sees a fresh cache and spawns nothing.
+func maybeRefreshGitHubCounts(boardRoot string) {
+	if boardRoot == "" {
+		return
+	}
+	cur := resolveGitHubCounts(boardRoot)
+	if cur.Available && time.Since(time.Unix(cur.FetchedAt, 0)) < GitHubCountsTTL {
+		return
+	}
+
+	self, err := os.Executable()
+	if err != nil {
+		return
+	}
+	if !isSelfInvocable(self) {
+		return
+	}
+	cmd := exec.Command(self, "statusline", "--refresh-github", "--board-root", boardRoot)
+	// Detach from this process's streams. A child holding the render's stdout
+	// keeps the pipe open, which makes whatever is reading it wait for a
+	// process it never knew about.
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = nil, nil, nil
+	if err := cmd.Start(); err != nil {
+		return
+	}
+	// Release rather than Wait: this is fire-and-forget, and the child bounds
+	// itself with githubFetchBudget.
+	_ = cmd.Process.Release()
+}
+
+// RefreshGitHubCounts fetches open issue and PR counts with `gh` and writes the
+// cache under boardRoot. It is the detached child's entry point, never called
+// on the render path.
+//
+// The timestamp is written BEFORE the fetch so concurrent renders stop spawning
+// refreshes immediately, and the previous counts are preserved so a failed
+// fetch degrades to a stale number rather than a blank segment.
+func RefreshGitHubCounts(ctx context.Context, boardRoot string) error {
+	if boardRoot == "" {
+		return nil
+	}
+
+	prev := resolveGitHubCounts(boardRoot)
+	prev.FetchedAt = time.Now().Unix()
+	if err := writeGitHubCache(boardRoot, prev); err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, githubFetchBudget)
+	defer cancel()
+
+	issues, errIssues := ghCount(ctx, boardRoot, "issue")
+	prs, errPRs := ghCount(ctx, boardRoot, "pr")
+	if errIssues != nil || errPRs != nil {
+		return nil // keep the stale-but-timestamped cache; try again next TTL
+	}
+
+	return writeGitHubCache(boardRoot, GitHubCounts{
+		OpenIssues: issues,
+		OpenPRs:    prs,
+		FetchedAt:  time.Now().Unix(),
+	})
+}
+
+// ghCount runs `gh <kind> list` and returns how many open items it reported.
+func ghCount(ctx context.Context, boardRoot, kind string) (int, error) {
+	cmd := exec.CommandContext(ctx, "gh", kind, "list",
+		"--state", "open", "--limit", githubListLimit, "--json", "number", "--jq", "length")
+	cmd.Dir = boardRoot
+	out, err := cmd.Output()
+	if err != nil {
+		return 0, err
+	}
+	return strconv.Atoi(strings.TrimSpace(string(out)))
+}
+
+// writeGitHubCache writes the cache atomically so a render never reads a
+// half-written file.
+func writeGitHubCache(boardRoot string, c GitHubCounts) error {
+	path := githubCachePath(boardRoot)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.Marshal(c)
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}

--- a/internal/statusline/github.go
+++ b/internal/statusline/github.go
@@ -115,13 +115,25 @@ func maybeRefreshGitHubCounts(boardRoot string) {
 	_ = cmd.Process.Release()
 }
 
-// RefreshGitHubCounts fetches open issue and PR counts with `gh` and writes the
-// cache under boardRoot. It is the detached child's entry point, never called
-// on the render path.
+// RefreshGitHubCounts fetches open issue and change-request counts from the
+// checkout's forge and writes the cache under boardRoot. It is the detached
+// child's entry point, never called on the render path.
 //
 // The timestamp is written BEFORE the fetch so concurrent renders stop spawning
 // refreshes immediately, and the previous counts are preserved so a failed
 // fetch degrades to a stale number rather than a blank segment.
+//
+// Forge resolution happens here rather than in the caller because it costs a
+// `git remote` call, and the render path is the one place that must stay a
+// single file read.
+//
+// @MX:DEBT: this entry point, its cache path, and GitHubCounts still say
+// "github" now that GitLab is served by the same code
+// @MX:CEILING: two forges — the shape is identical, so the name misleads a
+// reader without misleading the code
+// @MX:UPGRADE: rename to Forge* when a third forge lands, or when the cache
+// file is next versioned for another reason (renaming it alone would orphan
+// every existing cache to buy nothing)
 func RefreshGitHubCounts(ctx context.Context, boardRoot string) error {
 	if boardRoot == "" {
 		return nil
@@ -136,8 +148,16 @@ func RefreshGitHubCounts(ctx context.Context, boardRoot string) error {
 	ctx, cancel := context.WithTimeout(ctx, githubFetchBudget)
 	defer cancel()
 
-	issues, errIssues := ghCount(ctx, boardRoot, "issue")
-	prs, errPRs := ghCount(ctx, boardRoot, "pr")
+	forge, ok := resolveForge(originRemoteURL(ctx, boardRoot), forgeOverride(boardRoot))
+	if !ok {
+		return nil // no forge for this checkout; the segment stays absent
+	}
+	if _, err := exec.LookPath(forge.bin); err != nil {
+		return nil // the forge's CLI is not installed; keep rendering the stale count
+	}
+
+	issues, errIssues := forgeCount(ctx, boardRoot, forge, "issue")
+	prs, errPRs := forgeCount(ctx, boardRoot, forge, "pr")
 	if errIssues != nil || errPRs != nil {
 		return nil // keep the stale-but-timestamped cache; try again next TTL
 	}
@@ -149,10 +169,11 @@ func RefreshGitHubCounts(ctx context.Context, boardRoot string) error {
 	})
 }
 
-// ghCount runs `gh <kind> list` and returns how many open items it reported.
-func ghCount(ctx context.Context, boardRoot, kind string) (int, error) {
-	cmd := exec.CommandContext(ctx, "gh", kind, "list",
-		"--state", "open", "--limit", githubListLimit, "--json", "number", "--jq", "length")
+// forgeCount runs one listing and returns how many open items it reported.
+// Every forge's argument list ends in a filter that collapses the listing to a
+// bare integer, so this parses one number without knowing which CLI answered.
+func forgeCount(ctx context.Context, boardRoot string, forge forgeSpec, kind string) (int, error) {
+	cmd := exec.CommandContext(ctx, forge.bin, forge.argsFor(kind)...)
 	cmd.Dir = boardRoot
 	out, err := cmd.Output()
 	if err != nil {

--- a/internal/statusline/github_test.go
+++ b/internal/statusline/github_test.go
@@ -1,0 +1,200 @@
+package statusline
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The GitHub counts are the one segment backed by a network call, so what
+// matters is the behaviour when that call has not happened, has failed, or has
+// left a damaged file behind. The render path must never be what notices.
+
+func TestResolveGitHubCounts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		body       string // empty means: write no file at all
+		wantIssues int
+		wantPRs    int
+		wantAvail  bool
+	}{
+		{
+			name:       "valid cache",
+			body:       `{"open_issues":7,"open_prs":3,"fetched_at":1700000000}`,
+			wantIssues: 7, wantPRs: 3, wantAvail: true,
+		},
+		{
+			name:      "zero counts are still a real answer",
+			body:      `{"open_issues":0,"open_prs":0,"fetched_at":1700000000}`,
+			wantAvail: true,
+		},
+		{name: "corrupt json fails open", body: `{"open_issues":`},
+		{name: "never fetched fails open"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			root := t.TempDir()
+			if tt.body != "" {
+				dir := filepath.Join(root, ".moai", "state", "github")
+				if err := os.MkdirAll(dir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(dir, "counts.json"), []byte(tt.body), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			got := resolveGitHubCounts(root)
+			if got.Available != tt.wantAvail {
+				t.Errorf("Available = %v, want %v", got.Available, tt.wantAvail)
+			}
+			if got.OpenIssues != tt.wantIssues || got.OpenPRs != tt.wantPRs {
+				t.Errorf("issues/prs = %d/%d, want %d/%d",
+					got.OpenIssues, got.OpenPRs, tt.wantIssues, tt.wantPRs)
+			}
+		})
+	}
+}
+
+func TestWriteGitHubCache_RoundTrips(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	want := GitHubCounts{OpenIssues: 12, OpenPRs: 4, FetchedAt: 1700000000}
+	if err := writeGitHubCache(root, want); err != nil {
+		t.Fatal(err)
+	}
+
+	got := resolveGitHubCounts(root)
+	if !got.Available || got.OpenIssues != want.OpenIssues ||
+		got.OpenPRs != want.OpenPRs || got.FetchedAt != want.FetchedAt {
+		t.Errorf("round trip = %+v, want %+v", got, want)
+	}
+}
+
+// A fresh cache must not trigger a refresh. That guard is what keeps a render
+// running every few hundred milliseconds from spawning a process each time —
+// without it this feature becomes a fork bomb with a status bar attached.
+func TestMaybeRefreshGitHubCounts_FreshCacheSpawnsNothing(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	if err := writeGitHubCache(root, GitHubCounts{OpenIssues: 1, FetchedAt: time.Now().Unix()}); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.Stat(githubCachePath(root))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	maybeRefreshGitHubCounts(root)
+
+	after, err := os.Stat(githubCachePath(root))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !after.ModTime().Equal(before.ModTime()) {
+		t.Error("fresh cache was rewritten; the TTL guard did not hold")
+	}
+}
+
+// The binary-name guard is the one that keeps a `go test` run from re-invoking
+// its own test binary with these arguments — which re-runs the whole suite,
+// once per render, recursively. It is exercised directly rather than through
+// maybeRefreshGitHubCounts because a regression there would make this test the
+// fork bomb instead of catching it.
+func TestIsSelfInvocable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"/Users/x/go/bin/moai", true},
+		{"moai", true},
+		// Bare, because filepath.Base is separator-aware per OS: a
+		// backslash path only splits on Windows, so asserting one here
+		// would test the host rather than the guard.
+		{"moai.exe", true},
+		{"/tmp/go-build123/b001/statusline.test", false}, // the `go test` case
+		{"/usr/local/bin/moai-adk", false},               // a renamed host
+		{"/usr/local/bin/claude", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			t.Parallel()
+			if got := isSelfInvocable(tt.path); got != tt.want {
+				t.Errorf("isSelfInvocable(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+// The guard must hold for the binary this suite actually runs as, otherwise
+// every other test in this file is passing for the wrong reason.
+func TestIsSelfInvocable_RejectsThisTestBinary(t *testing.T) {
+	t.Parallel()
+
+	self, err := os.Executable()
+	if err != nil {
+		t.Skipf("executable path unavailable: %v", err)
+	}
+	if isSelfInvocable(self) {
+		t.Fatalf("test binary %q classified as self-invocable; a refresh would re-run this suite", self)
+	}
+}
+
+// An empty board root means we could not work out where state lives. Spawning
+// a refresh against "" would run `gh` in whatever directory the process happens
+// to be in, so the guard is a real one rather than defensive noise.
+func TestMaybeRefreshGitHubCounts_EmptyRootIsANoOp(t *testing.T) {
+	t.Parallel()
+
+	maybeRefreshGitHubCounts("") // must not panic and must not spawn
+
+	if got := resolveGitHubCounts(""); got.Available {
+		t.Errorf("empty root must yield no counts, got %+v", got)
+	}
+}
+
+func TestRenderSessionLine_GitHubCounts(t *testing.T) {
+	t.Parallel()
+
+	d := namedData()
+	d.GitHub = GitHubCounts{OpenIssues: 7, OpenPRs: 3, Available: true}
+
+	got := NewRenderer("default", true, nil).renderSessionLine(d)
+	if !strings.Contains(got, "🐛 7 / 📥 3") {
+		t.Errorf("github segment missing from %q", got)
+	}
+
+	d.GitHub = GitHubCounts{} // never fetched
+	got = NewRenderer("default", true, nil).renderSessionLine(d)
+	if strings.Contains(got, "🐛") {
+		t.Errorf("unfetched counts must render nothing, got %q", got)
+	}
+}
+
+func TestRenderSessionLine_GitHubSegmentDisablable(t *testing.T) {
+	t.Parallel()
+
+	d := namedData()
+	d.GitHub = GitHubCounts{OpenIssues: 7, OpenPRs: 3, Available: true}
+
+	got := NewRenderer("default", true, map[string]bool{SegmentGitHub: false}).renderSessionLine(d)
+	if strings.Contains(got, "🐛") {
+		t.Errorf("disabled github segment still rendered: %q", got)
+	}
+	if !strings.Contains(got, "🔄 12 / ⤵️ 26") {
+		t.Errorf("backlog must survive disabling the github segment: %q", got)
+	}
+}

--- a/internal/statusline/renderer.go
+++ b/internal/statusline/renderer.go
@@ -326,6 +326,18 @@ func (r *Renderer) renderBarsInline(data *StatusData, width int) string {
 func (r *Renderer) renderDirGitLine(data *StatusData) string {
 	var segs []string
 
+	// Session identity at the L3 head: name first, then the agent it runs as.
+	// Both are omitted when absent, so an unnamed ordinary session renders
+	// exactly as before.
+	if r.isSegmentEnabled(SegmentSession) {
+		if data.SessionName != "" {
+			segs = append(segs, fmt.Sprintf("🏷️ %s", data.SessionName))
+		}
+		if data.AgentName != "" {
+			segs = append(segs, fmt.Sprintf("👤 %s", data.AgentName))
+		}
+	}
+
 	// Directory (layout v3 amend: L3 head — placed before repo_branch)
 	if r.isSegmentEnabled(SegmentDirectory) && data.Directory != "" {
 		segs = append(segs, fmt.Sprintf("📁 %s", data.Directory))

--- a/internal/statusline/renderer.go
+++ b/internal/statusline/renderer.go
@@ -170,10 +170,16 @@ func (r *Renderer) renderSessionLine(data *StatusData) string {
 		}
 	}
 
-	// Backlog: ▶ in flight, ⏸ waiting to be picked. Symbols rather than words
+	// Backlog: 🔄 in flight, ⤵️ waiting in the queue. Symbols rather than words
 	// because this binary ships to users of every supported language.
 	if r.isSegmentEnabled(SegmentBacklog) && data.Backlog.Available {
-		segs = append(segs, fmt.Sprintf("📋 ▶%d ⏸%d", data.Backlog.Picked, data.Backlog.Queued))
+		segs = append(segs, fmt.Sprintf("🔄 %d / ⤵️ %d", data.Backlog.Picked, data.Backlog.Queued))
+	}
+
+	// GitHub: 🐛 open issues, 📥 open pull requests. Served from cache, so this
+	// is a file read even when the network is down.
+	if r.isSegmentEnabled(SegmentGitHub) && data.GitHub.Available {
+		segs = append(segs, fmt.Sprintf("🐛 %d / 📥 %d", data.GitHub.OpenIssues, data.GitHub.OpenPRs))
 	}
 
 	return r.joinSegments(segs)

--- a/internal/statusline/renderer.go
+++ b/internal/statusline/renderer.go
@@ -146,6 +146,20 @@ func (r *Renderer) renderDefaultV3(data *StatusData) string {
 func (r *Renderer) renderInfoLine(data *StatusData, withPrefix bool) string {
 	var segs []string
 
+	// Session identity leads the line: name first, then the agent it runs as.
+	// It sits ahead of the model because it answers "which session am I looking
+	// at", which is what the operator scans for first when several are open.
+	// Both are omitted when absent, so an unnamed ordinary session renders
+	// exactly as before.
+	if r.isSegmentEnabled(SegmentSession) {
+		if data.SessionName != "" {
+			segs = append(segs, fmt.Sprintf("🏷️ %s", data.SessionName))
+		}
+		if data.AgentName != "" {
+			segs = append(segs, fmt.Sprintf("👤 %s", data.AgentName))
+		}
+	}
+
 	// Model
 	if r.isSegmentEnabled(SegmentModel) && data.Metrics.Available && data.Metrics.Model != "" {
 		segs = append(segs, fmt.Sprintf("🤖 %s", data.Metrics.Model))
@@ -325,18 +339,6 @@ func (r *Renderer) renderBarsInline(data *StatusData, width int) string {
 //   - PR segment last position with new format "💌 PR #N (⌥state)" (CH7, CH8)
 func (r *Renderer) renderDirGitLine(data *StatusData) string {
 	var segs []string
-
-	// Session identity at the L3 head: name first, then the agent it runs as.
-	// Both are omitted when absent, so an unnamed ordinary session renders
-	// exactly as before.
-	if r.isSegmentEnabled(SegmentSession) {
-		if data.SessionName != "" {
-			segs = append(segs, fmt.Sprintf("🏷️ %s", data.SessionName))
-		}
-		if data.AgentName != "" {
-			segs = append(segs, fmt.Sprintf("👤 %s", data.AgentName))
-		}
-	}
 
 	// Directory (layout v3 amend: L3 head — placed before repo_branch)
 	if r.isSegmentEnabled(SegmentDirectory) && data.Directory != "" {

--- a/internal/statusline/renderer.go
+++ b/internal/statusline/renderer.go
@@ -112,6 +112,15 @@ func (r *Renderer) joinSegments(segments []string) string {
 func (r *Renderer) renderDefaultV3(data *StatusData) string {
 	var lines []string
 
+	// L0: who this session is and what work is on the board. Kept apart from
+	// the model line because it answers a different question — identity and
+	// workload, not capability — and because the operator scans for it first
+	// when several sessions are open. Renders nothing when there is no
+	// identity and no backlog, so an ordinary session keeps the old layout.
+	if l0 := r.renderSessionLine(data); l0 != "" {
+		lines = append(lines, l0)
+	}
+
 	// L1: model, Claude version, MoAI version, session time, output style
 	l1 := r.renderInfoLine(data, false)
 	if l1 != "" {
@@ -143,14 +152,15 @@ func (r *Renderer) renderDefaultV3(data *StatusData) string {
 // renderInfoLine renders the L1 info line (shared by default/full).
 // withPrefix=true: full mode format ("Claude v...", "MoAI v...")
 // withPrefix=false: default mode format ("v...")
-func (r *Renderer) renderInfoLine(data *StatusData, withPrefix bool) string {
+// renderSessionLine renders the identity/workload line: which session this is,
+// what agent it acts as, and how much work is in flight versus waiting.
+//
+// Every segment is omitted when its source is absent, so a session with no
+// name, no agent and no readable backlog produces an empty line, which the
+// caller then drops entirely.
+func (r *Renderer) renderSessionLine(data *StatusData) string {
 	var segs []string
 
-	// Session identity leads the line: name first, then the agent it runs as.
-	// It sits ahead of the model because it answers "which session am I looking
-	// at", which is what the operator scans for first when several are open.
-	// Both are omitted when absent, so an unnamed ordinary session renders
-	// exactly as before.
 	if r.isSegmentEnabled(SegmentSession) {
 		if data.SessionName != "" {
 			segs = append(segs, fmt.Sprintf("🏷️ %s", data.SessionName))
@@ -159,6 +169,18 @@ func (r *Renderer) renderInfoLine(data *StatusData, withPrefix bool) string {
 			segs = append(segs, fmt.Sprintf("👤 %s", data.AgentName))
 		}
 	}
+
+	// Backlog: ▶ in flight, ⏸ waiting to be picked. Symbols rather than words
+	// because this binary ships to users of every supported language.
+	if r.isSegmentEnabled(SegmentBacklog) && data.Backlog.Available {
+		segs = append(segs, fmt.Sprintf("📋 ▶%d ⏸%d", data.Backlog.Picked, data.Backlog.Queued))
+	}
+
+	return r.joinSegments(segs)
+}
+
+func (r *Renderer) renderInfoLine(data *StatusData, withPrefix bool) string {
+	var segs []string
 
 	// Model
 	if r.isSegmentEnabled(SegmentModel) && data.Metrics.Available && data.Metrics.Model != "" {

--- a/internal/statusline/session_identity_test.go
+++ b/internal/statusline/session_identity_test.go
@@ -7,9 +7,10 @@ import (
 
 // The statusline is the only durable place a session's identity can be shown:
 // Claude Code drops its own prompt-bar name chip after /clear even though the
-// explicit name (--name / /rename) is retained. These tests pin that the name
-// and the agent identity reach the rendered L3 line, and that an unnamed
-// ordinary session renders exactly as it did before the segment existed.
+// explicit name (--name / /rename) is retained, and the directory segment shows
+// the worktree once a session enters one. These tests pin that the name and the
+// agent identity lead the info line, and that an unnamed ordinary session
+// renders exactly as it did before the segment existed.
 
 func TestBuildStatusData_CarriesSessionNameAndAgent(t *testing.T) {
 	t.Parallel()
@@ -51,11 +52,9 @@ func TestBuildStatusData_CarriesSessionNameAndAgent(t *testing.T) {
 			t.Parallel()
 
 			var data StatusData
-			if tt.input != nil {
-				data.SessionName = tt.input.SessionName
-				if tt.input.Agent != nil {
-					data.AgentName = tt.input.Agent.Name
-				}
+			data.SessionName = tt.input.SessionName
+			if tt.input.Agent != nil {
+				data.AgentName = tt.input.Agent.Name
 			}
 
 			if data.SessionName != tt.wantName {
@@ -68,16 +67,24 @@ func TestBuildStatusData_CarriesSessionNameAndAgent(t *testing.T) {
 	}
 }
 
-func TestRenderDirGitLine_SessionIdentityAtHead(t *testing.T) {
+// namedData builds a StatusData carrying both an identity and a model, so the
+// ordering assertions below have something to order against.
+func namedData() *StatusData {
+	d := &StatusData{
+		SessionName: "Team-A-Lead",
+		AgentName:   "manager-kanban",
+		Directory:   "statusline-session-name",
+	}
+	d.Metrics.Available = true
+	d.Metrics.Model = "Opus 5 (1M context)"
+	return d
+}
+
+func TestRenderInfoLine_SessionIdentityLeadsTheLine(t *testing.T) {
 	t.Parallel()
 
 	r := NewRenderer("default", true, nil)
-
-	got := r.renderDirGitLine(&StatusData{
-		SessionName: "Team-A-Lead",
-		AgentName:   "manager-kanban",
-		Directory:   "moai-adk-go",
-	})
+	got := r.renderInfoLine(namedData(), false)
 
 	if !strings.Contains(got, "🏷️ Team-A-Lead") {
 		t.Errorf("session name segment missing from %q", got)
@@ -86,47 +93,62 @@ func TestRenderDirGitLine_SessionIdentityAtHead(t *testing.T) {
 		t.Errorf("agent segment missing from %q", got)
 	}
 
-	// Order is load-bearing: the operator scans left-to-right for identity
-	// before location, and the user asked for the name at the head.
+	// Order is load-bearing: identity is what the operator scans for first when
+	// several sessions are open, so it precedes the model.
 	nameAt := strings.Index(got, "Team-A-Lead")
 	agentAt := strings.Index(got, "manager-kanban")
-	dirAt := strings.Index(got, "moai-adk-go")
-	if !(nameAt < agentAt && agentAt < dirAt) {
-		t.Errorf("want order name < agent < directory, got name=%d agent=%d dir=%d in %q",
-			nameAt, agentAt, dirAt, got)
+	modelAt := strings.Index(got, "Opus 5")
+	if !(nameAt < agentAt && agentAt < modelAt) {
+		t.Errorf("want order name < agent < model, got name=%d agent=%d model=%d in %q",
+			nameAt, agentAt, modelAt, got)
 	}
 }
 
-func TestRenderDirGitLine_OmitsEmptyIdentity(t *testing.T) {
+func TestRenderInfoLine_OmitsEmptyIdentity(t *testing.T) {
 	t.Parallel()
 
 	r := NewRenderer("default", true, nil)
+	d := namedData()
+	d.SessionName = ""
+	d.AgentName = ""
 
-	got := r.renderDirGitLine(&StatusData{Directory: "moai-adk-go"})
+	got := r.renderInfoLine(d, false)
 
 	if strings.Contains(got, "🏷️") || strings.Contains(got, "👤") {
 		t.Errorf("unnamed session must render no identity segment, got %q", got)
 	}
-	if !strings.Contains(got, "📁 moai-adk-go") {
-		t.Errorf("directory segment lost when identity absent: %q", got)
+	if !strings.Contains(got, "🤖 Opus 5 (1M context)") {
+		t.Errorf("model segment lost when identity absent: %q", got)
 	}
 }
 
-func TestRenderDirGitLine_SessionSegmentDisablable(t *testing.T) {
+func TestRenderInfoLine_SessionSegmentDisablable(t *testing.T) {
 	t.Parallel()
 
 	r := NewRenderer("default", true, map[string]bool{SegmentSession: false})
-
-	got := r.renderDirGitLine(&StatusData{
-		SessionName: "Team-A-Lead",
-		AgentName:   "manager-kanban",
-		Directory:   "moai-adk-go",
-	})
+	got := r.renderInfoLine(namedData(), false)
 
 	if strings.Contains(got, "Team-A-Lead") || strings.Contains(got, "manager-kanban") {
 		t.Errorf("disabled session segment still rendered: %q", got)
 	}
-	if !strings.Contains(got, "📁 moai-adk-go") {
-		t.Errorf("directory segment lost when session segment disabled: %q", got)
+	if !strings.Contains(got, "🤖 Opus 5 (1M context)") {
+		t.Errorf("model segment lost when session segment disabled: %q", got)
+	}
+}
+
+// The identity was moved from the directory line to the info line. Rendering it
+// in both places would double it on every status update, so pin its absence
+// here rather than trusting the move stayed clean.
+func TestRenderDirGitLine_CarriesNoSessionIdentity(t *testing.T) {
+	t.Parallel()
+
+	r := NewRenderer("default", true, nil)
+	got := r.renderDirGitLine(namedData())
+
+	if strings.Contains(got, "🏷️") || strings.Contains(got, "👤") {
+		t.Errorf("identity must live on the info line only, found it in %q", got)
+	}
+	if !strings.Contains(got, "📁 statusline-session-name") {
+		t.Errorf("directory segment lost: %q", got)
 	}
 }

--- a/internal/statusline/session_identity_test.go
+++ b/internal/statusline/session_identity_test.go
@@ -1,0 +1,132 @@
+package statusline
+
+import (
+	"strings"
+	"testing"
+)
+
+// The statusline is the only durable place a session's identity can be shown:
+// Claude Code drops its own prompt-bar name chip after /clear even though the
+// explicit name (--name / /rename) is retained. These tests pin that the name
+// and the agent identity reach the rendered L3 line, and that an unnamed
+// ordinary session renders exactly as it did before the segment existed.
+
+func TestBuildStatusData_CarriesSessionNameAndAgent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		input     *StdinData
+		wantName  string
+		wantAgent string
+	}{
+		{
+			name:      "name and agent both present",
+			input:     &StdinData{SessionName: "Team-A-Lead", Agent: &AgentInfo{Name: "manager-kanban"}},
+			wantName:  "Team-A-Lead",
+			wantAgent: "manager-kanban",
+		},
+		{
+			name:      "name only — ordinary named session",
+			input:     &StdinData{SessionName: "review-tjti6j"},
+			wantName:  "review-tjti6j",
+			wantAgent: "",
+		},
+		{
+			name:      "agent object present but empty name",
+			input:     &StdinData{SessionName: "worker-1", Agent: &AgentInfo{}},
+			wantName:  "worker-1",
+			wantAgent: "",
+		},
+		{
+			name:      "neither — unnamed session",
+			input:     &StdinData{},
+			wantName:  "",
+			wantAgent: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var data StatusData
+			if tt.input != nil {
+				data.SessionName = tt.input.SessionName
+				if tt.input.Agent != nil {
+					data.AgentName = tt.input.Agent.Name
+				}
+			}
+
+			if data.SessionName != tt.wantName {
+				t.Errorf("SessionName = %q, want %q", data.SessionName, tt.wantName)
+			}
+			if data.AgentName != tt.wantAgent {
+				t.Errorf("AgentName = %q, want %q", data.AgentName, tt.wantAgent)
+			}
+		})
+	}
+}
+
+func TestRenderDirGitLine_SessionIdentityAtHead(t *testing.T) {
+	t.Parallel()
+
+	r := NewRenderer("default", true, nil)
+
+	got := r.renderDirGitLine(&StatusData{
+		SessionName: "Team-A-Lead",
+		AgentName:   "manager-kanban",
+		Directory:   "moai-adk-go",
+	})
+
+	if !strings.Contains(got, "🏷️ Team-A-Lead") {
+		t.Errorf("session name segment missing from %q", got)
+	}
+	if !strings.Contains(got, "👤 manager-kanban") {
+		t.Errorf("agent segment missing from %q", got)
+	}
+
+	// Order is load-bearing: the operator scans left-to-right for identity
+	// before location, and the user asked for the name at the head.
+	nameAt := strings.Index(got, "Team-A-Lead")
+	agentAt := strings.Index(got, "manager-kanban")
+	dirAt := strings.Index(got, "moai-adk-go")
+	if !(nameAt < agentAt && agentAt < dirAt) {
+		t.Errorf("want order name < agent < directory, got name=%d agent=%d dir=%d in %q",
+			nameAt, agentAt, dirAt, got)
+	}
+}
+
+func TestRenderDirGitLine_OmitsEmptyIdentity(t *testing.T) {
+	t.Parallel()
+
+	r := NewRenderer("default", true, nil)
+
+	got := r.renderDirGitLine(&StatusData{Directory: "moai-adk-go"})
+
+	if strings.Contains(got, "🏷️") || strings.Contains(got, "👤") {
+		t.Errorf("unnamed session must render no identity segment, got %q", got)
+	}
+	if !strings.Contains(got, "📁 moai-adk-go") {
+		t.Errorf("directory segment lost when identity absent: %q", got)
+	}
+}
+
+func TestRenderDirGitLine_SessionSegmentDisablable(t *testing.T) {
+	t.Parallel()
+
+	r := NewRenderer("default", true, map[string]bool{SegmentSession: false})
+
+	got := r.renderDirGitLine(&StatusData{
+		SessionName: "Team-A-Lead",
+		AgentName:   "manager-kanban",
+		Directory:   "moai-adk-go",
+	})
+
+	if strings.Contains(got, "Team-A-Lead") || strings.Contains(got, "manager-kanban") {
+		t.Errorf("disabled session segment still rendered: %q", got)
+	}
+	if !strings.Contains(got, "📁 moai-adk-go") {
+		t.Errorf("directory segment lost when session segment disabled: %q", got)
+	}
+}

--- a/internal/statusline/session_identity_test.go
+++ b/internal/statusline/session_identity_test.go
@@ -1,6 +1,8 @@
 package statusline
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -8,147 +10,182 @@ import (
 // The statusline is the only durable place a session's identity can be shown:
 // Claude Code drops its own prompt-bar name chip after /clear even though the
 // explicit name (--name / /rename) is retained, and the directory segment shows
-// the worktree once a session enters one. These tests pin that the name and the
-// agent identity lead the info line, and that an unnamed ordinary session
-// renders exactly as it did before the segment existed.
+// the worktree once a session enters one. The session line carries identity and
+// board workload together; these tests pin what it renders and, just as
+// importantly, what it leaves out.
 
-func TestBuildStatusData_CarriesSessionNameAndAgent(t *testing.T) {
+func namedData() *StatusData {
+	return &StatusData{
+		SessionName: "Team-A-Lead",
+		AgentName:   "manager-kanban",
+		Directory:   "statusline-session-name",
+		Backlog:     BacklogCounts{Picked: 12, Queued: 26, Available: true},
+	}
+}
+
+func TestRenderSessionLine_OrdersIdentityThenWorkload(t *testing.T) {
+	t.Parallel()
+
+	got := NewRenderer("default", true, nil).renderSessionLine(namedData())
+
+	for _, want := range []string{"🏷️ Team-A-Lead", "👤 manager-kanban", "📋 ▶12 ⏸26"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in %q", want, got)
+		}
+	}
+
+	// Order is load-bearing: identity is what the operator scans for when
+	// several sessions are open, and the workload only means something once
+	// you know whose it is.
+	nameAt := strings.Index(got, "Team-A-Lead")
+	agentAt := strings.Index(got, "manager-kanban")
+	boardAt := strings.Index(got, "📋")
+	if !(nameAt < agentAt && agentAt < boardAt) {
+		t.Errorf("want name < agent < backlog, got %d/%d/%d in %q", nameAt, agentAt, boardAt, got)
+	}
+}
+
+func TestRenderSessionLine_EmptyWhenNothingToSay(t *testing.T) {
+	t.Parallel()
+
+	got := NewRenderer("default", true, nil).renderSessionLine(&StatusData{Directory: "moai-adk-go"})
+
+	if got != "" {
+		t.Errorf("a session with no identity and no backlog must render no line, got %q", got)
+	}
+}
+
+func TestRenderSessionLine_UnreadableBacklogRendersNoCounts(t *testing.T) {
+	t.Parallel()
+
+	d := namedData()
+	d.Backlog = BacklogCounts{} // Available=false — the fail-open outcome
+
+	got := NewRenderer("default", true, nil).renderSessionLine(d)
+
+	if strings.Contains(got, "📋") {
+		t.Errorf("unavailable backlog must render no counts, got %q", got)
+	}
+	if !strings.Contains(got, "🏷️ Team-A-Lead") {
+		t.Errorf("identity lost when backlog unavailable: %q", got)
+	}
+}
+
+func TestRenderSessionLine_SegmentsDisablable(t *testing.T) {
+	t.Parallel()
+
+	cfg := map[string]bool{SegmentSession: false}
+	got := NewRenderer("default", true, cfg).renderSessionLine(namedData())
+	if strings.Contains(got, "Team-A-Lead") || strings.Contains(got, "manager-kanban") {
+		t.Errorf("disabled session segment still rendered: %q", got)
+	}
+	if !strings.Contains(got, "📋") {
+		t.Errorf("backlog must survive disabling the identity segment: %q", got)
+	}
+
+	cfg = map[string]bool{SegmentBacklog: false}
+	got = NewRenderer("default", true, cfg).renderSessionLine(namedData())
+	if strings.Contains(got, "📋") {
+		t.Errorf("disabled backlog segment still rendered: %q", got)
+	}
+	if !strings.Contains(got, "🏷️ Team-A-Lead") {
+		t.Errorf("identity must survive disabling the backlog segment: %q", got)
+	}
+}
+
+// The identity previously lived on the directory line and then on the info
+// line. Leaving a copy behind would double it on every status update, so pin
+// its absence from both rather than trusting the moves stayed clean.
+func TestOtherLines_CarryNoSessionIdentity(t *testing.T) {
+	t.Parallel()
+
+	r := NewRenderer("default", true, nil)
+
+	dirLine := r.renderDirGitLine(namedData())
+	if strings.Contains(dirLine, "🏷️") || strings.Contains(dirLine, "👤") {
+		t.Errorf("identity leaked onto the directory line: %q", dirLine)
+	}
+	if !strings.Contains(dirLine, "📁 statusline-session-name") {
+		t.Errorf("directory segment lost: %q", dirLine)
+	}
+
+	infoLine := r.renderInfoLine(namedData(), false)
+	if strings.Contains(infoLine, "🏷️") || strings.Contains(infoLine, "👤") {
+		t.Errorf("identity leaked onto the info line: %q", infoLine)
+	}
+}
+
+func TestResolveBacklogCounts(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		input     *StdinData
-		wantName  string
-		wantAgent string
+		name       string
+		body       string // empty means: write no file at all
+		wantPicked int
+		wantQueued int
+		wantAvail  bool
 	}{
 		{
-			name:      "name and agent both present",
-			input:     &StdinData{SessionName: "Team-A-Lead", Agent: &AgentInfo{Name: "manager-kanban"}},
-			wantName:  "Team-A-Lead",
-			wantAgent: "manager-kanban",
+			name:       "counts picked and queued, ignores dropped",
+			body:       `{"items":[{"state":"picked"},{"state":"queued"},{"state":"queued"},{"state":"dropped"}]}`,
+			wantPicked: 1, wantQueued: 2, wantAvail: true,
 		},
 		{
-			name:      "name only — ordinary named session",
-			input:     &StdinData{SessionName: "review-tjti6j"},
-			wantName:  "review-tjti6j",
-			wantAgent: "",
+			name: "empty board is available but zero",
+			body: `{"items":[]}`, wantAvail: true,
 		},
 		{
-			name:      "agent object present but empty name",
-			input:     &StdinData{SessionName: "worker-1", Agent: &AgentInfo{}},
-			wantName:  "worker-1",
-			wantAgent: "",
+			name:       "unknown states are not counted",
+			body:       `{"items":[{"state":"archived"},{"state":"picked"}]}`,
+			wantPicked: 1, wantAvail: true,
 		},
-		{
-			name:      "neither — unnamed session",
-			input:     &StdinData{},
-			wantName:  "",
-			wantAgent: "",
-		},
+		{name: "corrupt json fails open", body: `{"items":`},
+		{name: "absent file fails open"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			var data StatusData
-			data.SessionName = tt.input.SessionName
-			if tt.input.Agent != nil {
-				data.AgentName = tt.input.Agent.Name
+			root := t.TempDir()
+			if tt.body != "" {
+				dir := filepath.Join(root, ".moai", "state", "kanban")
+				if err := os.MkdirAll(dir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(dir, "backlog.json"), []byte(tt.body), 0o600); err != nil {
+					t.Fatal(err)
+				}
 			}
 
-			if data.SessionName != tt.wantName {
-				t.Errorf("SessionName = %q, want %q", data.SessionName, tt.wantName)
+			got := resolveBacklogCounts(root)
+			if got.Available != tt.wantAvail {
+				t.Errorf("Available = %v, want %v", got.Available, tt.wantAvail)
 			}
-			if data.AgentName != tt.wantAgent {
-				t.Errorf("AgentName = %q, want %q", data.AgentName, tt.wantAgent)
+			if got.Picked != tt.wantPicked || got.Queued != tt.wantQueued {
+				t.Errorf("picked/queued = %d/%d, want %d/%d",
+					got.Picked, got.Queued, tt.wantPicked, tt.wantQueued)
 			}
 		})
 	}
 }
 
-// namedData builds a StatusData carrying both an identity and a model, so the
-// ordering assertions below have something to order against.
-func namedData() *StatusData {
-	d := &StatusData{
-		SessionName: "Team-A-Lead",
-		AgentName:   "manager-kanban",
-		Directory:   "statusline-session-name",
-	}
-	d.Metrics.Available = true
-	d.Metrics.Model = "Opus 5 (1M context)"
-	return d
-}
-
-func TestRenderInfoLine_SessionIdentityLeadsTheLine(t *testing.T) {
+// A worktree session must read the PRIMARY checkout's board: `.moai/state/` is
+// gitignored, so it does not exist in the worktree at all. Getting this wrong
+// shows an empty board to exactly the sessions doing the work.
+func TestResolveBoardRoot_PrefersPrimaryCheckoutOverWorktree(t *testing.T) {
 	t.Parallel()
 
-	r := NewRenderer("default", true, nil)
-	got := r.renderInfoLine(namedData(), false)
-
-	if !strings.Contains(got, "🏷️ Team-A-Lead") {
-		t.Errorf("session name segment missing from %q", got)
+	worktreeSession := &StdinData{
+		Workspace: &WorkspaceInfo{CurrentDir: "/repo/.claude/worktrees/card-x"},
+		Worktree:  &WorktreeInfo{Path: "/repo/.claude/worktrees/card-x", OriginalCwd: "/repo"},
 	}
-	if !strings.Contains(got, "👤 manager-kanban") {
-		t.Errorf("agent segment missing from %q", got)
+	if got := resolveBoardRoot(worktreeSession); got != "/repo" {
+		t.Errorf("worktree session board root = %q, want /repo", got)
 	}
 
-	// Order is load-bearing: identity is what the operator scans for first when
-	// several sessions are open, so it precedes the model.
-	nameAt := strings.Index(got, "Team-A-Lead")
-	agentAt := strings.Index(got, "manager-kanban")
-	modelAt := strings.Index(got, "Opus 5")
-	if !(nameAt < agentAt && agentAt < modelAt) {
-		t.Errorf("want order name < agent < model, got name=%d agent=%d model=%d in %q",
-			nameAt, agentAt, modelAt, got)
-	}
-}
-
-func TestRenderInfoLine_OmitsEmptyIdentity(t *testing.T) {
-	t.Parallel()
-
-	r := NewRenderer("default", true, nil)
-	d := namedData()
-	d.SessionName = ""
-	d.AgentName = ""
-
-	got := r.renderInfoLine(d, false)
-
-	if strings.Contains(got, "🏷️") || strings.Contains(got, "👤") {
-		t.Errorf("unnamed session must render no identity segment, got %q", got)
-	}
-	if !strings.Contains(got, "🤖 Opus 5 (1M context)") {
-		t.Errorf("model segment lost when identity absent: %q", got)
-	}
-}
-
-func TestRenderInfoLine_SessionSegmentDisablable(t *testing.T) {
-	t.Parallel()
-
-	r := NewRenderer("default", true, map[string]bool{SegmentSession: false})
-	got := r.renderInfoLine(namedData(), false)
-
-	if strings.Contains(got, "Team-A-Lead") || strings.Contains(got, "manager-kanban") {
-		t.Errorf("disabled session segment still rendered: %q", got)
-	}
-	if !strings.Contains(got, "🤖 Opus 5 (1M context)") {
-		t.Errorf("model segment lost when session segment disabled: %q", got)
-	}
-}
-
-// The identity was moved from the directory line to the info line. Rendering it
-// in both places would double it on every status update, so pin its absence
-// here rather than trusting the move stayed clean.
-func TestRenderDirGitLine_CarriesNoSessionIdentity(t *testing.T) {
-	t.Parallel()
-
-	r := NewRenderer("default", true, nil)
-	got := r.renderDirGitLine(namedData())
-
-	if strings.Contains(got, "🏷️") || strings.Contains(got, "👤") {
-		t.Errorf("identity must live on the info line only, found it in %q", got)
-	}
-	if !strings.Contains(got, "📁 statusline-session-name") {
-		t.Errorf("directory segment lost: %q", got)
+	primarySession := &StdinData{Workspace: &WorkspaceInfo{CurrentDir: "/repo"}}
+	if got := resolveBoardRoot(primarySession); got != "/repo" {
+		t.Errorf("primary session board root = %q, want /repo", got)
 	}
 }

--- a/internal/statusline/session_identity_test.go
+++ b/internal/statusline/session_identity_test.go
@@ -40,7 +40,7 @@ func TestRenderSessionLine_OrdersIdentityThenWorkload(t *testing.T) {
 	nameAt := strings.Index(got, "Team-A-Lead")
 	agentAt := strings.Index(got, "manager-kanban")
 	boardAt := strings.Index(got, "🔄 ")
-	if !(nameAt < agentAt && agentAt < boardAt) {
+	if nameAt >= agentAt || agentAt >= boardAt {
 		t.Errorf("want name < agent < backlog, got %d/%d/%d in %q", nameAt, agentAt, boardAt, got)
 	}
 }

--- a/internal/statusline/session_identity_test.go
+++ b/internal/statusline/session_identity_test.go
@@ -28,7 +28,7 @@ func TestRenderSessionLine_OrdersIdentityThenWorkload(t *testing.T) {
 
 	got := NewRenderer("default", true, nil).renderSessionLine(namedData())
 
-	for _, want := range []string{"🏷️ Team-A-Lead", "👤 manager-kanban", "📋 ▶12 ⏸26"} {
+	for _, want := range []string{"🏷️ Team-A-Lead", "👤 manager-kanban", "🔄 12 / ⤵️ 26"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("missing %q in %q", want, got)
 		}
@@ -39,7 +39,7 @@ func TestRenderSessionLine_OrdersIdentityThenWorkload(t *testing.T) {
 	// you know whose it is.
 	nameAt := strings.Index(got, "Team-A-Lead")
 	agentAt := strings.Index(got, "manager-kanban")
-	boardAt := strings.Index(got, "📋")
+	boardAt := strings.Index(got, "🔄 ")
 	if !(nameAt < agentAt && agentAt < boardAt) {
 		t.Errorf("want name < agent < backlog, got %d/%d/%d in %q", nameAt, agentAt, boardAt, got)
 	}
@@ -63,7 +63,7 @@ func TestRenderSessionLine_UnreadableBacklogRendersNoCounts(t *testing.T) {
 
 	got := NewRenderer("default", true, nil).renderSessionLine(d)
 
-	if strings.Contains(got, "📋") {
+	if strings.Contains(got, "🔄 ") {
 		t.Errorf("unavailable backlog must render no counts, got %q", got)
 	}
 	if !strings.Contains(got, "🏷️ Team-A-Lead") {
@@ -79,13 +79,13 @@ func TestRenderSessionLine_SegmentsDisablable(t *testing.T) {
 	if strings.Contains(got, "Team-A-Lead") || strings.Contains(got, "manager-kanban") {
 		t.Errorf("disabled session segment still rendered: %q", got)
 	}
-	if !strings.Contains(got, "📋") {
+	if !strings.Contains(got, "🔄 ") {
 		t.Errorf("backlog must survive disabling the identity segment: %q", got)
 	}
 
 	cfg = map[string]bool{SegmentBacklog: false}
 	got = NewRenderer("default", true, cfg).renderSessionLine(namedData())
-	if strings.Contains(got, "📋") {
+	if strings.Contains(got, "🔄 ") {
 		t.Errorf("disabled backlog segment still rendered: %q", got)
 	}
 	if !strings.Contains(got, "🏷️ Team-A-Lead") {

--- a/internal/statusline/types.go
+++ b/internal/statusline/types.go
@@ -71,7 +71,21 @@ type StdinData struct {
 	Version        string             `json:"version"`             // Claude Code version (e.g., "1.0.80")
 	PR             *PRInfo            `json:"pr,omitempty"`        // Claude Code v2.1.145+ active PR info (nil if no PR detected)
 	Agent          *AgentInfo         `json:"agent,omitempty"`     // Active agent identity when the session runs as one (claude --agent); nil otherwise
+	Worktree       *WorktreeInfo      `json:"worktree,omitempty"`  // Worktree session details; nil when the session is in the primary checkout
 	ExceedsLong    bool               `json:"exceeds_200k_tokens"` // long-context overflow boolean (false if absent)
+}
+
+// WorktreeInfo describes a worktree session, from the statusline stdin
+// `worktree` object. OriginalCwd is the load-bearing field: it names the
+// primary checkout, which is where gitignored project state such as the kanban
+// backlog actually lives. Without it a worktree session would have to shell out
+// to git to find that directory, on every render.
+type WorktreeInfo struct {
+	Name           string `json:"name"`
+	Path           string `json:"path"`
+	Branch         string `json:"branch"`
+	OriginalCwd    string `json:"original_cwd"`
+	OriginalBranch string `json:"original_branch"`
 }
 
 // AgentInfo carries the agent identity a session runs under, from the
@@ -235,6 +249,7 @@ type StatusData struct {
 	ClaudeCodeVersion string         // Claude Code version from JSON input (e.g., "1.0.80")
 	SessionName       string         // Explicit session name (e.g., "Team-A-Lead"); empty when unnamed
 	AgentName         string         // Agent identity the session runs as (e.g., "manager-kanban"); empty when none
+	Backlog           BacklogCounts  // Kanban backlog in-flight/waiting counts (Available=false when unreadable)
 	Directory         string         // Project directory name (e.g., "modu-saju")
 	OutputStyle       string         // Output style name (e.g., "Mr.Alfred", "R2-D2")
 	Task              TaskData       // Current active task (rendering enabled in Phase 4)
@@ -329,7 +344,8 @@ const (
 	SegmentClaudeVersion = "claude_version"
 	SegmentMoaiVersion   = "moai_version"
 	SegmentGitBranch     = "git_branch"
-	SegmentSession       = "session" // Session name + agent identity (L3 head)
+	SegmentSession       = "session" // Session name + agent identity (session line head)
+	SegmentBacklog       = "backlog" // Kanban backlog in-flight/waiting counts
 
 	// v3 new segment constants (REQ-V3-TIME-003, enabled in Phase 4)
 	SegmentSessionTime = "session_time" // Session duration

--- a/internal/statusline/types.go
+++ b/internal/statusline/types.go
@@ -57,6 +57,7 @@ func NormalizeMode(mode StatuslineMode) StatuslineMode {
 type StdinData struct {
 	HookEventName  string             `json:"hook_event_name"`
 	SessionID      string             `json:"session_id"`
+	SessionName    string             `json:"session_name"` // Explicit name from --name / /rename. Survives /clear; an AI-generated title does not, and is not reported here.
 	TranscriptPath string             `json:"transcript_path"`
 	CWD            string             `json:"cwd"` // Legacy field, prefer Workspace.CurrentDir
 	Model          *ModelInfo         `json:"model"`
@@ -69,7 +70,17 @@ type StdinData struct {
 	Thinking       *ThinkingInfo      `json:"thinking"`            // Claude Code v2.1.139+ thinking flag (nil if absent)
 	Version        string             `json:"version"`             // Claude Code version (e.g., "1.0.80")
 	PR             *PRInfo            `json:"pr,omitempty"`        // Claude Code v2.1.145+ active PR info (nil if no PR detected)
+	Agent          *AgentInfo         `json:"agent,omitempty"`     // Active agent identity when the session runs as one (claude --agent); nil otherwise
 	ExceedsLong    bool               `json:"exceeds_200k_tokens"` // long-context overflow boolean (false if absent)
+}
+
+// AgentInfo carries the agent identity a session runs under, from the
+// statusline stdin `agent` object. Present only when the session was launched
+// with `claude --agent <name>` or the `agent` setting; nil for an ordinary
+// session. Paired with StdinData.SessionName, it answers "which session is
+// this, and what is it acting as" without the operator having to remember.
+type AgentInfo struct {
+	Name string `json:"name"`
 }
 
 // PRInfo represents GitHub Pull Request metadata from Claude Code v2.1.145+
@@ -222,6 +233,8 @@ type StatusData struct {
 	Metrics           MetricsData
 	Version           VersionData    // MoAI-ADK version from config
 	ClaudeCodeVersion string         // Claude Code version from JSON input (e.g., "1.0.80")
+	SessionName       string         // Explicit session name (e.g., "Team-A-Lead"); empty when unnamed
+	AgentName         string         // Agent identity the session runs as (e.g., "manager-kanban"); empty when none
 	Directory         string         // Project directory name (e.g., "modu-saju")
 	OutputStyle       string         // Output style name (e.g., "Mr.Alfred", "R2-D2")
 	Task              TaskData       // Current active task (rendering enabled in Phase 4)
@@ -316,6 +329,7 @@ const (
 	SegmentClaudeVersion = "claude_version"
 	SegmentMoaiVersion   = "moai_version"
 	SegmentGitBranch     = "git_branch"
+	SegmentSession       = "session" // Session name + agent identity (L3 head)
 
 	// v3 new segment constants (REQ-V3-TIME-003, enabled in Phase 4)
 	SegmentSessionTime = "session_time" // Session duration

--- a/internal/statusline/types.go
+++ b/internal/statusline/types.go
@@ -250,6 +250,7 @@ type StatusData struct {
 	SessionName       string         // Explicit session name (e.g., "Team-A-Lead"); empty when unnamed
 	AgentName         string         // Agent identity the session runs as (e.g., "manager-kanban"); empty when none
 	Backlog           BacklogCounts  // Kanban backlog in-flight/waiting counts (Available=false when unreadable)
+	GitHub            GitHubCounts   // Cached open issue/PR counts (Available=false when never fetched)
 	Directory         string         // Project directory name (e.g., "modu-saju")
 	OutputStyle       string         // Output style name (e.g., "Mr.Alfred", "R2-D2")
 	Task              TaskData       // Current active task (rendering enabled in Phase 4)
@@ -346,6 +347,7 @@ const (
 	SegmentGitBranch     = "git_branch"
 	SegmentSession       = "session" // Session name + agent identity (session line head)
 	SegmentBacklog       = "backlog" // Kanban backlog in-flight/waiting counts
+	SegmentGitHub        = "github"  // Cached open issue / PR counts
 
 	// v3 new segment constants (REQ-V3-TIME-003, enabled in Phase 4)
 	SegmentSessionTime = "session_time" // Session duration

--- a/internal/template/templates/.moai/config/sections/statusline.yaml
+++ b/internal/template/templates/.moai/config/sections/statusline.yaml
@@ -2,6 +2,15 @@ statusline:
   # Theme — exactly 2 themes exist: catppuccin-mocha (seeded) | catppuccin-latte
   theme: "catppuccin-mocha"
 
+  # Which hosting service the `github` segment counts open work against.
+  # Leave unset to decide from the origin remote's host: github.com selects
+  # `gh`, gitlab.com selects `glab`. A self-hosted instance carries no signal
+  # in its name, so set this explicitly there.
+  #   github | gitlab | none
+  # An unrecognised value renders nothing rather than falling back to
+  # detection, so a typo shows as an absent segment instead of a wrong count.
+  # forge: gitlab
+
   # Individual segment toggles — the only runtime lever.
   # All 16 segments default-on; graceful no-output handles inactive states.
   segments:


### PR DESCRIPTION
## What

1. **Session identity** — the session name and agent identity are rendered at the head of the L3 info line, surviving Claude Code dropping its own name chip after `/clear`.
2. **Session line with board workload** — the session gets its own line carrying the kanban board workload (picked/queued, read from `.moai/state/kanban/backlog.json` under the board root resolved via `worktree.original_cwd`).
3. **Open forge counts** — a new segment shows the repo's open issue/PR counts (`🐛 N / 📥 N`).
4. **GitLab support** — GitLab is served by the same code via a `forgeSpec` table, remote-host detection, and a `statusline.forge` config override.

## Design invariants

- The render path never touches the network — it reads one small cache file (`.moai/state/github/counts.json`).
- A 10-minute TTL with stale-while-revalidate hands refreshing to a detached child (`moai statusline --refresh-github --board-root …`) that stamps a fresh timestamp before fetching (stampede guard), bounds itself with a 20s budget, and is gated by `isSelfInvocable` so a test binary can never re-invoke itself recursively.

## Local verification (2026-08-16, this machine)

- Cache backdated 1h with sentinel counts 111/222 → one render printed the stale sentinel and returned same-second.
- The detached child was observed alive via pgrep (PID + argv).
- The cache was stamped with sentinel counts preserved, then rewritten with real counts 2 issues / 3 PRs, matching direct `gh issue list` / `gh pr list` exactly.
- The child exited with no orphan processes; a fresh-cache render spawned nothing and left the timestamp unchanged.
- Earlier checks: `go test ./internal/statusline/...` and `./internal/template/...` pass; `GOOS=windows go vet ./...` exit 0.

## Known gaps

- The GitLab fetch path cannot be proven on a machine without `glab` (command assembly + host detection are unit-tested only).
- `internal/cli` full suite has a pre-existing unresolved failure at ~178s while `-run Statusline` and `-run Rollback` pass individually — provenance vs this branch unresolved, flagged for reviewers.

🗿 MoAI
