### PR TITLE
fix(glm): declare GLM context window to Claude Code via CLAUDE_CODE_MAX_CONTEXT_TOKENS

### DIFF
--- a/internal/cli/glm.go
+++ b/internal/cli/glm.go
@@ -246,11 +246,31 @@ func containsPermissionMode(args []string, mode string) bool {
 // the High slot model resolves to the 1M context tier (e.g. glm-5.2), which
 // activates Claude Code's 1M context mode — auto-compact must then scale to the
 // enlarged window. The trigger is the model's resolved context window (via
-// statusline.ResolveGLMContextWindow), not a model-id suffix: z.ai rejects a
-// suffixed id such as glm-5.2[1m], so the suffix is no longer used.
+// statusline.ResolveGLMContextWindow), not a model-id suffix: the suffix was
+// retired after z.ai rejected a suffixed id such as glm-5.2[1m] (current
+// Claude Code strips "[1m]" before sending the ID to the provider, but the
+// resolved-window trigger also covers non-1M tiers). Note the value only takes
+// effect together with glmMaxContextTokens: Claude Code caps the auto-compact
+// window at the model's assumed window — 200K for unrecognized custom IDs
+// unless CLAUDE_CODE_MAX_CONTEXT_TOKENS declares otherwise.
 func glmAutoCompactWindow(highModel string) (string, bool) {
 	if statusline.ResolveGLMContextWindow(highModel) >= config.Default1MContextTokens {
 		return strconv.Itoa(config.Default1MContextTokens), true
+	}
+	return "", false
+}
+
+// glmMaxContextTokens returns the CLAUDE_CODE_MAX_CONTEXT_TOKENS value and a
+// flag indicating whether it should be injected. Claude Code assumes a 200K
+// window for any model ID it cannot resolve (no "claude-" prefix, no "[1m]"),
+// which both mislabels the context telemetry and caps
+// CLAUDE_CODE_AUTO_COMPACT_WINDOW at 200K. Declaring the resolved window —
+// for every GLM tier, not just 1M — lifts both.
+// Ref: code.claude.com/docs/en/model-config ("Correct the window for a gateway
+// or custom model ID"); Issue #653.
+func glmMaxContextTokens(highModel string) (string, bool) {
+	if size := statusline.ResolveGLMContextWindow(highModel); size > 0 {
+		return strconv.Itoa(size), true
 	}
 	return "", false
 }
@@ -269,6 +289,12 @@ func setGLMEnv(glmConfig *GLMConfigFromYAML, apiKey string) {
 	// tier, scale the auto-compact window to the full 1M context.
 	if window, ok := glmAutoCompactWindow(glmConfig.Models.High); ok {
 		_ = os.Setenv(config.EnvClaudeCodeAutoCompactWindow, window) //nolint:errcheck
+	}
+	// Declare the model's real context window (Issue #653): Claude Code
+	// assumes 200K for the unrecognized custom ID and caps the auto-compact
+	// window above at that assumption.
+	if tokens, ok := glmMaxContextTokens(glmConfig.Models.High); ok {
+		_ = os.Setenv(config.EnvClaudeCodeMaxContextTokens, tokens) //nolint:errcheck
 	}
 	// Z.AI proxy compatibility: strip Anthropic beta headers
 	_ = os.Setenv(config.EnvClaudeCodeDisableExperimentalBetas, "1") //nolint:errcheck
@@ -414,6 +440,13 @@ func buildTmuxInjectVars(glmConfig *GLMConfigFromYAML, apiKey string) map[string
 		vars[config.EnvClaudeCodeAutoCompactWindow] = window
 	}
 
+	// Issue #653: declare the same window to Claude Code itself — without the
+	// declaration, CC assumes 200K for the unrecognized custom ID and caps the
+	// auto-compact window above at 200K regardless of its configured value.
+	if tokens, ok := glmMaxContextTokens(glmConfig.Models.High); ok {
+		vars[config.EnvClaudeCodeMaxContextTokens] = tokens
+	}
+
 	return vars
 }
 
@@ -494,6 +527,8 @@ func buildTmuxClearVars() []string {
 		// Clear 1M auto-compact window when leaving GLM mode (Claude slot scales
 		// auto-compact itself).
 		config.EnvClaudeCodeAutoCompactWindow,
+		// Issue #653: clear the declared GLM context window (inject↔clear parity).
+		config.EnvClaudeCodeMaxContextTokens,
 	}
 }
 
@@ -781,6 +816,14 @@ func injectGLMEnv(settingsPath string, glmConfig *GLMConfigFromYAML) error {
 			env[config.EnvClaudeCodeAutoCompactWindow] = window
 		} else {
 			delete(env, config.EnvClaudeCodeAutoCompactWindow)
+		}
+		// Issue #653: declare the model's real context window (Claude Code
+		// assumes 200K for unrecognized custom IDs and caps the auto-compact
+		// window at it); otherwise clean up any stale value.
+		if tokens, ok := glmMaxContextTokens(glmConfig.Models.High); ok {
+			env[config.EnvClaudeCodeMaxContextTokens] = tokens
+		} else {
+			delete(env, config.EnvClaudeCodeMaxContextTokens)
 		}
 		if len(env) == 0 {
 			delete(m, "env")

--- a/internal/cli/glm_max_context_test.go
+++ b/internal/cli/glm_max_context_test.go
@@ -1,0 +1,71 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/modu-ai/moai-adk/internal/config"
+)
+
+// TestGLMMaxContextTokens verifies CLAUDE_CODE_MAX_CONTEXT_TOKENS is emitted
+// for EVERY resolvable GLM tier (unlike glmAutoCompactWindow, which fires only
+// on the 1M tier). Claude Code assumes 200K for unrecognized custom model IDs
+// and caps CLAUDE_CODE_AUTO_COMPACT_WINDOW at that assumption, so non-1M
+// tiers must also be declared. Issue #653.
+func TestGLMMaxContextTokens(t *testing.T) {
+	// Clean cwd so no project-level llm.yaml override leaks into
+	// ResolveGLMContextWindow — the built-in glmContextWindows table is the
+	// baseline under test. NOTE: not parallel because t.Chdir is incompatible
+	// with t.Parallel.
+	t.Chdir(t.TempDir())
+
+	cases := []struct {
+		name      string
+		highModel string
+		wantValue string
+		wantOK    bool
+	}{
+		{"glm-5.3 (1M tier) declares 1M", "glm-5.3", "1000000", true},
+		{"glm-5.2 (1M tier) declares 1M", "glm-5.2", "1000000", true},
+		{"glm-5.1 (200K tier) declares 200K", "glm-5.1", "200000", true},
+		{"glm-4.7 (128K tier) declares 128K", "glm-4.7", "128000", true},
+		{"claude model does not declare", "claude-opus-4-8", "", false},
+		{"empty model does not declare", "", "", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotValue, gotOK := glmMaxContextTokens(tc.highModel)
+			if gotOK != tc.wantOK {
+				t.Errorf("glmMaxContextTokens(%q) ok = %v, want %v", tc.highModel, gotOK, tc.wantOK)
+			}
+			if gotValue != tc.wantValue {
+				t.Errorf("glmMaxContextTokens(%q) value = %q, want %q", tc.highModel, gotValue, tc.wantValue)
+			}
+		})
+	}
+}
+
+// TestBuildTmuxInjectVars_MaxContextTokens asserts the tmux inject set carries
+// the declared window for the High slot model (Issue #653), and that the
+// inject↔clear parity holds for the new key (REQ-CGH-009 pattern, mirroring
+// TestBuildTmuxClearVars_ReasoningParity).
+func TestBuildTmuxInjectVars_MaxContextTokens(t *testing.T) {
+	// Clean cwd so the built-in glmContextWindows table is consulted.
+	t.Chdir(t.TempDir())
+
+	glmConfig := &GLMConfigFromYAML{BaseURL: "https://api.z.ai/api/anthropic"}
+	glmConfig.Models.High = "glm-5.3"
+
+	injectVars := buildTmuxInjectVars(glmConfig, "some-token")
+	if got := injectVars[config.EnvClaudeCodeMaxContextTokens]; got != "1000000" {
+		t.Errorf("buildTmuxInjectVars CLAUDE_CODE_MAX_CONTEXT_TOKENS = %q, want %q", got, "1000000")
+	}
+
+	clearSet := make(map[string]bool)
+	for _, k := range buildTmuxClearVars() {
+		clearSet[k] = true
+	}
+	if !clearSet[config.EnvClaudeCodeMaxContextTokens] {
+		t.Errorf("buildTmuxClearVars() must include %q for inject↔clear parity", config.EnvClaudeCodeMaxContextTokens)
+	}
+}

--- a/internal/config/envkeys.go
+++ b/internal/config/envkeys.go
@@ -262,6 +262,15 @@ const (
 	// the enlarged window rather than the default ceiling.
 	EnvClaudeCodeAutoCompactWindow = "CLAUDE_CODE_AUTO_COMPACT_WINDOW"
 
+	// EnvClaudeCodeMaxContextTokens declares the context window Claude Code
+	// should assume for a custom (non-Claude) model ID routed through
+	// ANTHROPIC_BASE_URL. Claude Code assumes 200K for unrecognized IDs and
+	// caps CLAUDE_CODE_AUTO_COMPACT_WINDOW at that assumed window, so GLM
+	// tiers (128K/200K/1M) must be declared explicitly.
+	// Ref: https://code.claude.com/docs/en/model-config ("Correct the window
+	// for a gateway or custom model ID"); Issue #653.
+	EnvClaudeCodeMaxContextTokens = "CLAUDE_CODE_MAX_CONTEXT_TOKENS"
+
 	// EnvClaudeCodeEffortLevel sets the session effort level for Claude Code.
 	// Valid values: "low", "medium", "high", "xhigh", "max".
 	// "xhigh" and "max" are supported on Opus 4.7+.

--- a/internal/hook/session_start.go
+++ b/internal/hook/session_start.go
@@ -654,7 +654,23 @@ func ensureGLMCredentials(projectDir string) string {
 
 	// GLM models configured — check if AUTH_TOKEN exists
 	if token := settings.Env[config.EnvAnthropicAuthToken]; token != "" {
-		return "" // Already has credentials
+		// Already has credentials — nothing to inject, but the context-window
+		// envs must still be ensured: settings written by an older binary (or
+		// by `moai glm setup`) carry neither window key, and without the
+		// CLAUDE_CODE_MAX_CONTEXT_TOKENS declaration Claude Code assumes a
+		// 200K window for the custom GLM model ID (Issue #653, PR #1574
+		// review). Persist only when a key was actually added so the steady
+		// state does not rewrite settings.local.json on every session start.
+		before := settings.Env[config.EnvClaudeCodeAutoCompactWindow] + "|" + settings.Env[config.EnvClaudeCodeMaxContextTokens]
+		maybeSet1MAutoCompactWindow(settings.Env)
+		maybeDeclareGLMContextWindow(settings.Env)
+		after := settings.Env[config.EnvClaudeCodeAutoCompactWindow] + "|" + settings.Env[config.EnvClaudeCodeMaxContextTokens]
+		if after != before {
+			if err := persistSettingsEnv(settings.Env, data, settingsPath); err != nil {
+				slog.Error("failed to write GLM context window env to settings.local.json", "error", err.Error())
+			}
+		}
+		return ""
 	}
 
 	// AUTH_TOKEN missing — try to load from ~/.moai/.env.glm
@@ -686,27 +702,7 @@ func ensureGLMCredentials(projectDir string) string {
 	// at that assumption. Mirrors internal/cli/glm.go glmMaxContextTokens.
 	maybeDeclareGLMContextWindow(settings.Env)
 
-	// Re-read original file to preserve all fields (not just env)
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return ""
-	}
-
-	envData, err := json.Marshal(settings.Env)
-	if err != nil {
-		return ""
-	}
-	raw["env"] = envData
-
-	newData, err := json.MarshalIndent(raw, "", " ")
-	if err != nil {
-		return ""
-	}
-
-	// @MX:ANCHOR: [AUTO] settings.local.json holds GLM ANTHROPIC_AUTH_TOKEN — write with 0o600 only
-	// @MX:REASON: SPEC-V3R5-SECURITY-CRIT-001 AC-SEC-001 (CWE-732/552). Prior baseline 0o644
-	// allowed any local user to read the credential. Regression locked by TestEnsureGLMCredentialsFilePerm.
-	if err := writeSettingsSecure(settingsPath, newData); err != nil {
+	if err := persistSettingsEnv(settings.Env, data, settingsPath); err != nil {
 		slog.Error("failed to write GLM credentials to settings.local.json",
 			"error", err.Error(),
 		)
@@ -714,6 +710,37 @@ func ensureGLMCredentials(projectDir string) string {
 	}
 
 	return fmt.Sprintf("auto-injected GLM credentials from ~/.moai/.env.glm into %s", settingsPath)
+}
+
+// persistSettingsEnv writes env back to settings.local.json, preserving all
+// non-env top-level keys from rawOriginal. Extracted from the injection tail
+// so the already-credentialed path (PR #1574 review) reuses the identical
+// write seam.
+func persistSettingsEnv(env map[string]string, rawOriginal []byte, settingsPath string) error {
+	// Re-read original file to preserve all fields (not just env)
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(rawOriginal, &raw); err != nil {
+		return fmt.Errorf("unmarshal settings: %w", err)
+	}
+
+	envData, err := json.Marshal(env)
+	if err != nil {
+		return fmt.Errorf("marshal env: %w", err)
+	}
+	raw["env"] = envData
+
+	newData, err := json.MarshalIndent(raw, "", " ")
+	if err != nil {
+		return fmt.Errorf("marshal settings: %w", err)
+	}
+
+	// @MX:ANCHOR: [AUTO] settings.local.json holds GLM ANTHROPIC_AUTH_TOKEN — write with 0o600 only
+	// @MX:REASON: SPEC-V3R5-SECURITY-CRIT-001 AC-SEC-001 (CWE-732/552). Prior baseline 0o644
+	// allowed any local user to read the credential. Regression locked by TestEnsureGLMCredentialsFilePerm.
+	if err := writeSettingsSecure(settingsPath, newData); err != nil {
+		return fmt.Errorf("write settings: %w", err)
+	}
+	return nil
 }
 
 // maybeSet1MAutoCompactWindow sets CLAUDE_CODE_AUTO_COMPACT_WINDOW in env when

--- a/internal/hook/session_start.go
+++ b/internal/hook/session_start.go
@@ -681,6 +681,10 @@ func ensureGLMCredentials(projectDir string) string {
 	// Mirrors internal/cli/glm.go glmAutoCompactWindow; the retired [1m] suffix
 	// path (z.ai rejects suffixed ids) is replaced by resolved-window detection.
 	maybeSet1MAutoCompactWindow(settings.Env)
+	// Declare the resolved GLM context window (Issue #653): Claude Code assumes
+	// 200K for unrecognized custom IDs and caps the auto-compact window above
+	// at that assumption. Mirrors internal/cli/glm.go glmMaxContextTokens.
+	maybeDeclareGLMContextWindow(settings.Env)
 
 	// Re-read original file to preserve all fields (not just env)
 	var raw map[string]json.RawMessage
@@ -725,6 +729,23 @@ func maybeSet1MAutoCompactWindow(env map[string]string) {
 	}
 	if statusline.ResolveGLMContextWindow(env[config.EnvAnthropicDefaultOpusModel]) >= config.Default1MContextTokens {
 		env[config.EnvClaudeCodeAutoCompactWindow] = strconv.Itoa(config.Default1MContextTokens)
+	}
+}
+
+// maybeDeclareGLMContextWindow sets CLAUDE_CODE_MAX_CONTEXT_TOKENS in env when
+// the High (Opus) slot model resolves to a known GLM context window. Claude
+// Code assumes a 200K window for unrecognized custom model IDs and caps
+// CLAUDE_CODE_AUTO_COMPACT_WINDOW at that assumed window, so the 1M value set
+// by maybeSet1MAutoCompactWindow is ineffective without this declaration.
+// This is the SessionStart-hook analogue of internal/cli/glm.go
+// glmMaxContextTokens. Issue #653; ref: code.claude.com/docs/en/model-config
+// ("Correct the window for a gateway or custom model ID").
+func maybeDeclareGLMContextWindow(env map[string]string) {
+	if env[config.EnvClaudeCodeMaxContextTokens] != "" {
+		return
+	}
+	if size := statusline.ResolveGLMContextWindow(env[config.EnvAnthropicDefaultOpusModel]); size > 0 {
+		env[config.EnvClaudeCodeMaxContextTokens] = strconv.Itoa(size)
 	}
 }
 

--- a/internal/hook/session_start_test.go
+++ b/internal/hook/session_start_test.go
@@ -41,6 +41,31 @@ func TestMaybeSet1MAutoCompactWindow(t *testing.T) {
 	}
 }
 
+func TestMaybeDeclareGLMContextWindow(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		env      map[string]string
+		wantDecl string // "" means expect the key unset
+	}{
+		{name: "glm-5.3 resolves to 1M → declares 1000000", env: map[string]string{"ANTHROPIC_DEFAULT_OPUS_MODEL": "glm-5.3"}, wantDecl: "1000000"},
+		{name: "glm-4.5-air resolves to 128K (non-1M tier still declared)", env: map[string]string{"ANTHROPIC_DEFAULT_OPUS_MODEL": "glm-4.5-air"}, wantDecl: "128000"},
+		{name: "claude model → unset (ResolveGLMContextWindow returns 0 for claude-prefixed)", env: map[string]string{"ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4-8"}, wantDecl: ""},
+		{name: "declaration already set → preserved, not overwritten", env: map[string]string{"ANTHROPIC_DEFAULT_OPUS_MODEL": "glm-5.3", config.EnvClaudeCodeMaxContextTokens: "500000"}, wantDecl: "500000"},
+		{name: "empty opus model → unset", env: map[string]string{}, wantDecl: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			maybeDeclareGLMContextWindow(tt.env)
+			if got := tt.env[config.EnvClaudeCodeMaxContextTokens]; got != tt.wantDecl {
+				t.Errorf("CLAUDE_CODE_MAX_CONTEXT_TOKENS = %q, want %q", got, tt.wantDecl)
+			}
+		})
+	}
+}
+
 func TestSessionStartHandler_EventType(t *testing.T) {
 	t.Parallel()
 

--- a/internal/hook/session_start_test.go
+++ b/internal/hook/session_start_test.go
@@ -66,6 +66,75 @@ func TestMaybeDeclareGLMContextWindow(t *testing.T) {
 	}
 }
 
+// TestEnsureGLMCredentials_ExistingTokenDeclaresContextWindow is the PR #1574
+// review regression: with credentials already present (the steady state), the
+// hook must still ensure the context-window envs — settings written by an
+// older binary or `moai glm setup` carry neither window key, and without the
+// declaration Claude Code assumes a 200K window for the custom GLM model ID.
+func TestEnsureGLMCredentials_ExistingTokenDeclaresContextWindow(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	claudeDir := filepath.Join(dir, ".claude")
+	_ = os.MkdirAll(claudeDir, 0o755)
+	settings := `{"env":{"ANTHROPIC_DEFAULT_OPUS_MODEL":"glm-5.3","ANTHROPIC_AUTH_TOKEN":"existing-key"},"other":"preserved"}`
+	settingsPath := filepath.Join(claudeDir, "settings.local.json")
+	_ = os.WriteFile(settingsPath, []byte(settings), 0o644)
+
+	msg := ensureGLMCredentials(dir)
+	if msg != "" {
+		t.Errorf("expected empty msg when AUTH_TOKEN exists, got %q", msg)
+	}
+
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+	var raw struct {
+		Env   map[string]string `json:"env"`
+		Other string            `json:"other"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("parse settings: %v", err)
+	}
+	if got := raw.Env["CLAUDE_CODE_MAX_CONTEXT_TOKENS"]; got != "1000000" {
+		t.Errorf("CLAUDE_CODE_MAX_CONTEXT_TOKENS = %q, want %q", got, "1000000")
+	}
+	if got := raw.Env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"]; got != "1000000" {
+		t.Errorf("CLAUDE_CODE_AUTO_COMPACT_WINDOW = %q, want %q", got, "1000000")
+	}
+	if raw.Other != "preserved" {
+		t.Errorf("non-env key lost on rewrite: other = %q", raw.Other)
+	}
+}
+
+// TestEnsureGLMCredentials_ExistingTokenNoChurnWhenKeysPresent asserts the
+// steady state does not rewrite settings.local.json when both window keys are
+// already present — avoiding per-session churn against concurrent sessions
+// that mutate the same file.
+func TestEnsureGLMCredentials_ExistingTokenNoChurnWhenKeysPresent(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	claudeDir := filepath.Join(dir, ".claude")
+	_ = os.MkdirAll(claudeDir, 0o755)
+	settings := `{"env":{"ANTHROPIC_DEFAULT_OPUS_MODEL":"glm-5.3","ANTHROPIC_AUTH_TOKEN":"existing-key","CLAUDE_CODE_AUTO_COMPACT_WINDOW":"1000000","CLAUDE_CODE_MAX_CONTEXT_TOKENS":"1000000"}}`
+	settingsPath := filepath.Join(claudeDir, "settings.local.json")
+	_ = os.WriteFile(settingsPath, []byte(settings), 0o644)
+
+	if msg := ensureGLMCredentials(dir); msg != "" {
+		t.Errorf("expected empty msg, got %q", msg)
+	}
+
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+	if string(data) != settings {
+		t.Error("settings.local.json rewritten although window keys were already present")
+	}
+}
+
 func TestSessionStartHandler_EventType(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Problem

Claude Code assumes a 200K context window for any model ID it cannot resolve (no `claude-` prefix, no `[1m]`), and it caps `CLAUDE_CODE_AUTO_COMPACT_WINDOW` at that assumed window. Consequence for GLM users: even though MoAI already injected `CLAUDE_CODE_AUTO_COMPACT_WINDOW=1000000` for 1M-tier GLM models, the value was capped at 200K — GLM sessions auto-compacted at ~200K and Claude Code's own context surfaces (`/model`, `/context`, statusline telemetry) reported 200K for genuine 1M models (z.ai GLM-5.3 is officially 1M-context). Issue #653.

Upstream references:
- https://code.claude.com/docs/en/model-config — "Correct the window for a gateway or custom model ID": `CLAUDE_CODE_MAX_CONTEXT_TOKENS` declares the window Claude Code should assume for a custom ID, and the auto-compact window is capped at the model's (assumed) context window.
- https://github.com/anthropics/claude-code/issues/68522 — the exact symptom this fixes, upstream.

## Change

Inject `CLAUDE_CODE_MAX_CONTEXT_TOKENS` with the resolved GLM window (via `statusline.ResolveGLMContextWindow`) for **every** GLM tier (128K/200K/1M — not just the 1M tier) at all env injection sites:

| Site | File |
|---|---|
| `setGLMEnv` (in-process launcher env) | `internal/cli/glm.go` |
| `buildTmuxInjectVars` + `buildTmuxClearVars` (tmux pane env, inject↔clear parity REQ-CGH-009) | `internal/cli/glm.go` |
| `injectGLMEnv` (settings.local.json env block) | `internal/cli/glm.go` |
| `maybeDeclareGLMContextWindow` (SessionStart hook analogue) | `internal/hook/session_start.go` |
| `EnvClaudeCodeMaxContextTokens` constant | `internal/config/envkeys.go` |

Also corrects the stale "z.ai rejects suffixed ids" comments: current Claude Code strips `[1m]` before sending the model ID to the provider (documented), so the note now records both the historical reason and the current behavior.

No model-ID values are mutated — the fix is additive env declaration only, so no consumer of `ANTHROPIC_DEFAULT_*_MODEL` values is affected.

## Verification evidence (run locally on the PR head, exit 0)

- `go build ./... && go vet ./internal/cli/... ./internal/hook/... ./internal/config/...` → exit 0
- `go test ./internal/cli/ -run 'TestGLMMaxContextTokens|TestBuildTmuxInjectVars_MaxContextTokens|TestGLMAutoCompactWindow|TestTmuxEnv_InjectClearParity' -count=1` → PASS (`ok github.com/modu-ai/moai-adk/internal/cli 0.846s`), incl. new `TestGLMMaxContextTokens` (6 subtests: 1M/200K/128K tiers declare, claude/empty do not) and `TestBuildTmuxInjectVars_MaxContextTokens` (inject carries the key + clear-list parity)
- `go test ./internal/hook/ -run 'TestMaybeDeclareGLMContextWindow|TestMaybeSet1MAutoCompactWindow' -count=1` → PASS (`ok github.com/modu-ai/moai-adk/internal/hook 0.597s`), incl. new `TestMaybeDeclareGLMContextWindow` (5 subtests)
- `go test ./internal/config/ -count=1` → `ok github.com/modu-ai/moai-adk/internal/config 1.530s`
- Full-suite judgment deferred to CI per lane-local verification discipline.

## Post-merge verification note

After merge + binary reinstall, a fresh GLM session should show: env `CLAUDE_CODE_MAX_CONTEXT_TOKENS=1000000`, MoAI statusline window 1M, and Claude Code's own context surfaces reporting 1M for GLM-5.3.

🗿 MoAI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically configures the correct context-token limit for supported GLM model tiers.
  * Applies context settings consistently across sessions, terminal environments, and local configuration.
  * Supports custom model context-window configuration through `CLAUDE_CODE_MAX_CONTEXT_TOKENS`.

* **Bug Fixes**
  * Removes outdated context settings when switching models or clearing GLM session state.
  * Cleans up stale configuration when the model’s context window cannot be determined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->