### PR TITLE
fix(update): surface rate-limit headers and send auth token in release check

### DIFF
--- a/internal/config/envkeys.go
+++ b/internal/config/envkeys.go
@@ -327,3 +327,16 @@ const (
 	// down to the Anthropic namespace, and must never be read with os.Getenv.
 	EnvAnthropicPrefix = "ANTHROPIC_"
 )
+
+// GitHub API environment variables.
+const (
+	// EnvGitHubToken provides a GitHub API token for authenticated requests
+	// (the update checker's release lookups), lifting the shared-IP 60 req/h
+	// anonymous budget to 5,000 req/h. Standard GitHub Actions / gh-tooling
+	// variable — MoAI reads it but never sets it.
+	EnvGitHubToken = "GITHUB_TOKEN"
+
+	// EnvGHToken is the GitHub CLI's equivalent of GITHUB_TOKEN and takes
+	// precedence over it, matching gh's own resolution order.
+	EnvGHToken = "GH_TOKEN"
+)

--- a/internal/update/checker.go
+++ b/internal/update/checker.go
@@ -6,10 +6,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"runtime"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/modu-ai/moai-adk/internal/config"
 )
 
 const (
@@ -63,6 +66,12 @@ func (c *checker) CheckLatest(ctx context.Context) (*VersionInfo, error) {
 	}
 	req.Header.Set("Accept", "application/vnd.github.v3+json")
 	req.Header.Set("User-Agent", updateUserAgent)
+	// Authenticated requests draw from a 5,000 req/h budget instead of the
+	// 60 req/h anonymous pool shared per IP. The token, when present, is
+	// never logged or embedded in error messages.
+	if token := githubAuthToken(); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
 
 	resp, err := c.client.Do(req)
 	if err != nil {
@@ -74,7 +83,7 @@ func (c *checker) CheckLatest(ctx context.Context) (*VersionInfo, error) {
 		if resp.StatusCode == http.StatusNotFound {
 			return nil, fmt.Errorf("checker: release not found (status 404) - repository may not exist or have no releases")
 		}
-		return nil, fmt.Errorf("checker: unexpected status %d", resp.StatusCode)
+		return nil, fmt.Errorf("checker: unexpected status %d%s", resp.StatusCode, rateLimitContext(resp.Header))
 	}
 
 	// Check if the response is an array (releases list) or single object (latest release)
@@ -113,6 +122,51 @@ func (c *checker) CheckLatest(ctx context.Context) (*VersionInfo, error) {
 	}
 
 	return c.buildVersionInfo(release)
+}
+
+// githubAuthToken resolves the GitHub API bearer token from the environment.
+// GH_TOKEN takes precedence over GITHUB_TOKEN, matching the GitHub CLI's own
+// order between the two equivalent variables. Empty when neither is set: the
+// request then proceeds unauthenticated against the 60 req/h anonymous pool.
+func githubAuthToken() string {
+	if t := os.Getenv(config.EnvGHToken); t != "" {
+		return t
+	}
+	return os.Getenv(config.EnvGitHubToken)
+}
+
+// rateLimitContext renders GitHub's rate-limit response headers as an
+// error-message suffix, so a 403/429 explains itself (budget, reset time)
+// instead of surfacing as a bare "unexpected status 403". Returns "" when the
+// response carries none of the headers, keeping messages from non-GitHub
+// servers (and test stubs) byte-identical to the previous format.
+func rateLimitContext(h http.Header) string {
+	limit := h.Get("X-RateLimit-Limit")
+	remaining := h.Get("X-RateLimit-Remaining")
+	if limit == "" && remaining == "" {
+		if after := h.Get("Retry-After"); after != "" {
+			return fmt.Sprintf(" (rate limited, retry after %ss)", after)
+		}
+		return ""
+	}
+	var parts []string
+	switch {
+	case remaining != "" && limit != "":
+		parts = append(parts, fmt.Sprintf("%s/%s requests remaining", remaining, limit))
+	case remaining != "":
+		parts = append(parts, remaining+" requests remaining")
+	default:
+		parts = append(parts, "limit "+limit+" requests/h")
+	}
+	if reset := h.Get("X-RateLimit-Reset"); reset != "" {
+		if n, err := strconv.ParseInt(reset, 10, 64); err == nil {
+			parts = append(parts, "resets "+time.Unix(n, 0).Format(time.RFC3339))
+		}
+	}
+	if after := h.Get("Retry-After"); after != "" {
+		parts = append(parts, "retry after "+after+"s")
+	}
+	return " (api rate limit: " + strings.Join(parts, ", ") + ")"
 }
 
 // buildVersionInfo constructs a VersionInfo from a releaseResponse.

--- a/internal/update/checker_test.go
+++ b/internal/update/checker_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 )
@@ -655,5 +656,82 @@ func TestChecker_IsUpdateAvailable_Error(t *testing.T) {
 	}
 	if info != nil {
 		t.Error("expected nil info on error")
+	}
+}
+
+func TestChecker_CheckLatest_RateLimitContextInErrorMessage(t *testing.T) {
+	t.Parallel()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-RateLimit-Limit", "60")
+		w.Header().Set("X-RateLimit-Remaining", "0")
+		w.Header().Set("X-RateLimit-Reset", "1786889899")
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer ts.Close()
+
+	checker := NewChecker(ts.URL, http.DefaultClient)
+	_, err := checker.CheckLatest(context.Background())
+	if err == nil {
+		t.Fatal("expected error for 403 response")
+	}
+	msg := err.Error()
+	for _, want := range []string{"403", "0/60 requests remaining", "resets "} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error %q missing %q", msg, want)
+		}
+	}
+}
+
+func TestChecker_CheckLatest_ErrorWithoutRateLimitHeadersStaysPlain(t *testing.T) {
+	t.Parallel()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer ts.Close()
+
+	checker := NewChecker(ts.URL, http.DefaultClient)
+	_, err := checker.CheckLatest(context.Background())
+	if err == nil {
+		t.Fatal("expected error for 503 response")
+	}
+	if want := "checker: unexpected status 503"; err.Error() != want {
+		t.Errorf("error = %q, want exactly %q", err, want)
+	}
+}
+
+// TestChecker_CheckLatest_AuthorizationHeaderFromEnv pins the bearer-token
+// resolution order. Non-parallel on purpose: t.Setenv panics inside
+// t.Parallel tests and the environment is process-global.
+func TestChecker_CheckLatest_AuthorizationHeaderFromEnv(t *testing.T) {
+	tests := []struct {
+		name     string
+		ghToken  string
+		github   string
+		wantAuth string
+	}{
+		{"GH_TOKEN wins over GITHUB_TOKEN", "gh-token", "github-token", "Bearer gh-token"},
+		{"GITHUB_TOKEN when GH_TOKEN empty", "", "github-token", "Bearer github-token"},
+		{"no header when both empty", "", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("GH_TOKEN", tt.ghToken)
+			t.Setenv("GITHUB_TOKEN", tt.github)
+
+			var got string
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				got = r.Header.Get("Authorization")
+				w.WriteHeader(http.StatusServiceUnavailable)
+			}))
+			defer ts.Close()
+
+			checker := NewChecker(ts.URL, http.DefaultClient)
+			_, _ = checker.CheckLatest(context.Background())
+			if got != tt.wantAuth {
+				t.Errorf("Authorization = %q, want %q", got, tt.wantAuth)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- GitHub API 403s during the update check surfaced as a bare `unexpected status 403` — the `X-RateLimit-*` / `Retry-After` headers on the response were discarded. Non-200 errors now append rate-limit context (remaining/limit, reset time, retry-after) when present; servers that don't send the headers keep the previous byte-identical message.
- `CheckLatest` now sends `Authorization: Bearer <token>` resolved from `GH_TOKEN` / `GITHUB_TOKEN` (env-only; `GH_TOKEN` wins, matching gh's resolution order), lifting the anonymous 60 req/h shared-IP pool to 5,000 req/h when a token is set. The token is never logged or embedded in errors, and `checksums.txt` downloads stay unauthenticated (they hit `browser_download_url`, not the API).
- New `EnvGitHubToken` / `EnvGHToken` constants in `internal/config/envkeys.go` (CLAUDE.local.md §14 env-constant discipline).

## Evidence
- `go build ./internal/update/ ./internal/config/` — OK
- `go vet ./internal/update/ ./internal/config/` — OK
- `go test ./internal/update/ -count=1` — `ok github.com/modu-ai/moai-adk/internal/update 6.319s`
- 3 new tests: rate-limit message content on 403, plain-message stability without headers, bearer-token resolution order (incl. both-empty → no header)

🗿 MoAI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Update checks now support GitHub authentication through `GH_TOKEN` or `GITHUB_TOKEN`.
  * Requests include authorization when a valid token is available.
  * Error messages now provide rate-limit details, including retry and reset information, when supplied by GitHub.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->