### PR TITLE
docs(spec): SPEC-ALWAYS-LOADED-DIET-001 plan-phase artifacts

### DIFF
--- a/.moai/specs/SPEC-ALWAYS-LOADED-DIET-001/acceptance.md
+++ b/.moai/specs/SPEC-ALWAYS-LOADED-DIET-001/acceptance.md
@@ -1,0 +1,448 @@
+# Acceptance Criteria — SPEC-ALWAYS-LOADED-DIET-001
+
+## §A 판정 규율 (AC 실행 전 필독)
+
+이 SPEC의 AC는 전부 **명령의 출력이 판정한다**. 아래 5개 함정은 과거 SPEC에서 공허한 GREEN 또는 부당한 FAIL을 실제로 만들어냈다. AC를 돌리기 전에 읽는다.
+
+1. **명령을 표 셀에 넣지 않는다.** 마크다운 표 셀 안의 `\|` 는 `grep -E` 에서 리터럴 파이프로 해석돼 패턴이 조용히 아무 것도 매치하지 않는다. 이 문서의 모든 명령은 펜스 코드블록에 있다.
+2. **패턴 언어와 파일 언어를 맞춘다.** `.claude/rules/`, `.claude/agents/`, `.claude/skills/` 본문은 **영어 전용**이다. 이 SPEC 본문은 한국어지만, 규칙 파일을 겨냥한 grep 패턴은 반드시 영어여야 한다.
+3. **부재(absence) 판정은 양성 대조를 먼저 세운다.** "0건이면 통과" 형태의 AC는 패턴 자체가 고장나도 0건을 낸다. 부재 AC마다 같은 패턴이 분리 이전 파일에서는 매치되는지를 먼저 확인한다.
+4. **가드 정규식을 면제 목록 없이 재구현하지 않는다.** `go test ./internal/config/ -run TestAlwaysLoaded` 의 실행 결과가 권위다. §A의 `grep -rL '^paths:'` 스니펫은 델타 관측용 보조 계측이며, 둘이 어긋나면 **가드가 맞다**.
+5. **`--strict` 는 severity 문자열이 아니라 exit code 를 바꾼다.** spec-lint 판정은 exit code 로 한다.
+6. **부재 판정 앞에 존재 단언을 세운다.** `grep` 계열은 대상 파일이 없으면 에러를 stderr 로만 내고 stdout 에 아무 것도 출력하지 않는다. 그래서 "출력이 없으면 통과" 형태의 AC 는 **파일을 만들지 않은 것만으로** GREEN 이 되고, `grep -c` 는 `0` 이 아니라 **빈 문자열**을 내어 기계 판정을 미정의로 만든다. 파일을 다루는 AC 는 전부 `test -f` 를 먼저 통과시킨다.
+7. **줄 위치로 필드를 뽑지 않는다.** `sed -n '2p'` 같은 위치 기반 추출은 frontmatter 키 순서가 조금만 달라도 무너진다. 실측: 기존 컴패니언 4개는 **전부** 2행이 `description:` 이다. 키는 이름으로 뽑는다(아래 `fm()`).
+
+공통 전제: 모든 명령은 리포 루트에서 실행한다.
+
+```bash
+# frontmatter(첫 --- 블록)만 뽑는다. 본문에 나오는 --- 에 영향받지 않는다.
+fm() { awk '/^---$/{c++; if(c==2) exit; next} c==1' "$1"; }
+# 양성 대조(2026-08-16 실측): 기존 컴패니언 4개 전부 `fm "$f" | grep -c '^paths:'` = 1,
+#   always-loaded 파일(kanban-dispatch.md)은 0.
+
+# 이 문서 전반에서 쓰는 계측 함수
+headroom() {
+  tot=0
+  for f in $(grep -rL '^paths:' .claude/rules/moai --include='*.md'); do tot=$((tot+$(wc -c < "$f"))); done
+  for f in CLAUDE.md .claude/output-styles/moai/moai.md; do tot=$((tot+$(wc -c < "$f"))); done
+  [ -f MEMORY.md ] && tot=$((tot+$(head -200 MEMORY.md | head -c 25600 | wc -c)))
+  echo "files=$(grep -rL '^paths:' .claude/rules/moai --include='*.md' | wc -l) bytes=$tot tokens=$((tot/4)) headroom=$((75000 - tot/4))"
+}
+```
+
+Baseline (2026-08-16 실측): `files=14 bytes=295044 tokens=73761 headroom=1239`
+
+---
+
+## §B AC 매트릭스
+
+### AC-ALD-001 — 순감소 (구속 조건)
+
+**Given** baseline 여유가 1,239 토큰이고
+**When** M1~M4 완료 후 `headroom` 을 재실행하면
+**Then** 출력의 `headroom` 값이 **1,239보다 엄격히 커야** 한다.
+
+```bash
+headroom
+# PASS 조건: headroom > 1239
+```
+
+이 SPEC의 단일 종료 조건이다. M1(감소)과 M2(증가)를 개별 판정하지 않는다.
+
+### AC-ALD-002 — 가드 통과 + `internal/config` 불변
+
+**Given** always-loaded 표면이 변경된 상태에서
+**When** 권위 있는 가드를 실행하고 `internal/config` 의 상태를 함께 재면
+**Then** 가드는 exit 0 이고, 예산 상수는 75,000 그대로이며, Go 변경은 0건이어야 한다.
+
+```bash
+go test ./internal/config/ -run TestAlwaysLoaded; echo "exit=$?"
+# D4-1: 예산 상수 불변 — 이 SPEC 안에서 AlwaysLoadedTokenBudget 을 움직이지 않는다
+echo "budget_const=$(grep -c 'AlwaysLoadedTokenBudget = 75000' internal/config/token_budget_guard.go)"
+# D4-2: M3 는 문서 전용 — Go 무변경
+echo "go_changed=$(git diff --name-only origin/main...HEAD -- '*.go' | wc -l)"
+# PASS 조건: exit=0, budget_const=1, go_changed=0
+# baseline 관측(2026-08-16): ok github.com/modu-ai/moai-adk/internal/config, budget_const=1, go_changed=0
+```
+
+두 줄을 여기 접어 넣은 이유는 둘 다 `internal/config` 를 겨냥하고 있어 이 AC 의 판정 대상과 같기 때문이다. 별도 AC 로 세우면 17개가 되어 Tier M 상한(16)을 넘는다.
+
+`git diff` 의 `origin/main...HEAD` 앵커는 **생략 불가**다. 인자 없는 `git diff` 는 워킹 트리와 비교하므로 작업을 커밋하는 순간 항상 비어, 아무 것도 판정하지 못하는 공허한 검사로 바뀐다.
+
+`budget_const` 가 잡는 것: `AC-ALD-001` 의 `headroom` 함수는 셸 안에 `75000` 리터럴을 박고 있어 Go 상수가 바뀌어도 비교가 흔들리지 않는다. 뒤집으면 **상수 변경을 탐지하지도 못한다**는 뜻이고, 이 줄이 그 구멍을 막는다.
+
+### AC-ALD-003 — 스텁이 BINDING-EVERYWHERE 구간 7개를 보유
+
+**Given** `kanban-dispatch.md` 가 분리된 뒤
+**When** 스텁에서 BINDING 구간 제목을 세면
+**Then** 7개 제목이 모두 있어야 한다.
+
+```bash
+f=.claude/rules/moai/workflow/kanban-dispatch.md
+for h in '^# Kanban Dispatch Protocol' \
+         '^## Scope — when this rule is live' \
+         '^## Completion is read, never trusted' \
+         '^### CodeRabbit is not read from' \
+         '^## Isolation is entered, never provisioned' \
+         '^## Verification load is lane-local' \
+         '^### The env-isolated verification form' \
+         '^## Boundaries — what this protocol does not do' \
+         '^## Cross-references'; do
+  printf '%s => %s\n' "$h" "$(grep -c "$h" "$f")"
+done
+# PASS 조건: 9개 제목 전부 count=1 (7구간 + 하위 2개 제목)
+
+# (b) LEAD-ONLY 6개 제목의 **부재** — 이동이 아니라 복사로 구현한 경우를 여기서 잡는다
+for h in '^## The board' \
+         '^## Entry into the board is an operator act' \
+         '^## Card classes' \
+         '^## The dispatch cycle' \
+         '^## Review lens selection' \
+         '^## The `/clear` handoff between phases'; do
+  printf 'absent:%s => %s\n' "$h" "$(grep -c "$h" "$f")"
+done
+# PASS 조건: 6개 전부 count=0
+# 양성 대조(함정 3): 분리 이전 원본에 같은 패턴을 돌리면 6개 전부 1 이어야 한다 —
+#   2026-08-16 실측으로 확인함. 패턴이 살아있음을 본 뒤에야 0 을 근거로 삼는다.
+
+# (c) REQ-ALD-001 이 지정한 Class B 문단이 스텁에 있고 컴패니언에 없는지
+anchor='names that path in its completion report'
+comp=.claude/rules/moai/workflow/kanban-dispatch-detail.md
+echo "relocated_in_stub=$(grep -c "$anchor" "$f")"
+if [ -f "$comp" ]; then
+  echo "relocated_in_companion=$(grep -c "$anchor" "$comp")"
+else
+  echo "companion_MISSING=1"
+fi
+# PASS 조건: relocated_in_stub=1, relocated_in_companion=0, companion_MISSING 출력 없음
+# 가드가 필요한 이유는 §A 함정 6 과 같다 — 컴패니언이 없으면 grep -c 는 0 이 아니라 빈 문자열을 낸다.
+# 앵커 유일성(2026-08-16 실측): 이 문구는 .claude/rules/moai 전체에서 kanban-dispatch.md 에만, 1회 나온다.
+```
+
+**이 AC 는 보존 AC 다.** (a) 는 손대지 않은 트리에서도 통과하는 것이 정상이며 — 분리 이전 원본에 9개 제목이 다 있으므로 — 그 자체로는 진척 신호가 아니다. 진척은 `AC-ALD-005`(컴패니언 존재) · `AC-ALD-009`(바이트 합계) · `AC-ALD-001`(여유)이 판정한다. (b) 와 (c) 는 반대로 **분리 이전에는 반드시 실패**하므로, 이 AC 를 falsifiable 하게 만드는 쪽은 그 둘이다.
+
+### AC-ALD-004 — 스텁의 HARD 절 보존
+
+**Given** 분리 이전 원본이 `[HARD]` 9건을 갖고, 그중 6건이 STAY 구간·3건이 MOVE 구간에 있었으며
+**When** 분리 후 스텁과 컴패니언에서 각각 세면
+**Then** 스텁 6건 / 컴패니언 3건이어야 한다.
+
+```bash
+s=.claude/rules/moai/workflow/kanban-dispatch.md
+c=.claude/rules/moai/workflow/kanban-dispatch-detail.md
+for p in "$s" "$c"; do test -f "$p" || { echo "MISSING $p"; exit 1; }; done   # §A 함정 6
+echo "stub=$(grep -c '\[HARD\]' "$s")"
+echo "companion=$(grep -c '\[HARD\]' "$c")"
+# PASS 조건: stub=6 companion=3 (합 9 = 분리 이전 총계)
+```
+
+이 AC가 R2(안전 관련 HARD 절 유실)를 잡는다. 합이 9가 아니면 절이 사라졌거나 생겼다.
+
+### AC-ALD-005 — 컴패니언이 LEAD-ONLY 구간 6개를 보유
+
+**Given** LEAD-ONLY로 분류된 6구간이 이동한 뒤
+**When** 컴패니언에서 제목을 세면
+**Then** 6개 제목(+ 하위 1개)이 모두 있어야 한다.
+
+```bash
+f=.claude/rules/moai/workflow/kanban-dispatch-detail.md
+test -f "$f" || { echo "MISSING $f"; exit 1; }   # §A 함정 6
+for h in '^## The board' \
+         '^## Entry into the board is an operator act' \
+         '^## Card classes' \
+         '^## The dispatch cycle' \
+         '^### Dispatch language' \
+         '^## Review lens selection' \
+         '^## The `/clear` handoff between phases'; do
+  printf '%s => %s\n' "$h" "$(grep -c "$h" "$f")"
+done
+# PASS 조건: 7개 전부 count=1
+```
+
+### AC-ALD-006 — 내용 보존 (이동한 바이트가 사라지지 않음)
+
+**Given** 분리 이전 원본의 비어있지 않은 줄이 140개이고
+**When** 스텁과 컴패니언의 합집합과 대조하면
+**Then** 원본의 모든 비어있지 않은 줄이 둘 중 한쪽에 있어야 한다(포인터 줄·frontmatter 등 **추가된** 줄은 허용).
+
+```bash
+c=.claude/rules/moai/workflow/kanban-dispatch-detail.md
+test -f "$c" || { echo "MISSING $c"; exit 1; }   # §A 함정 6 — 가드가 없으면 분리 이전에도
+                                                  # missing_lines=0 으로 통과한다(감사 iter2 D2)
+git show HEAD:.claude/rules/moai/workflow/kanban-dispatch.md \
+  | grep -v '^[[:space:]]*$' | sort -u > /tmp/ald-orig.txt
+cat .claude/rules/moai/workflow/kanban-dispatch.md \
+    .claude/rules/moai/workflow/kanban-dispatch-detail.md \
+  | grep -v '^[[:space:]]*$' | sort -u > /tmp/ald-after.txt
+comm -23 /tmp/ald-orig.txt /tmp/ald-after.txt
+echo "missing_lines=$(comm -23 /tmp/ald-orig.txt /tmp/ald-after.txt | wc -l)"
+# PASS 조건: missing_lines=0
+# 양성 대조(함정 3): 위 comm 을 /dev/null 대상으로 돌리면 140에 가까운 값이 나와야 한다 —
+#   패턴이 살아있음을 확인한 뒤 0을 근거로 삼는다.
+```
+
+### AC-ALD-007 — 컴패니언이 domain-keyed
+
+**Given** self-keyed 컴패니언 3개와 domain-keyed 1개가 선례로 존재하고
+**When** 새 컴패니언의 `paths:` 를 읽으면
+**Then** 부모 규칙 파일 외에 실제 kanban 도메인 경로 2개를 함께 키로 가져야 한다.
+
+```bash
+c=.claude/rules/moai/workflow/kanban-dispatch-detail.md
+test -f "$c" || { echo "MISSING $c"; }
+p=$(fm "$c" | grep '^paths:')
+echo "$p"
+echo "manager-kanban_key=$(printf '%s' "$p" | grep -c 'manager-kanban.md')"
+echo "todo_key=$(printf '%s' "$p" | grep -c 'workflows/todo.md')"
+# PASS 조건: MISSING 출력 없음, 두 값 모두 1 (self-keyed 단독이면 둘 다 0 → FAIL)
+```
+
+**줄 위치로 뽑지 않는 이유**(실측된 거짓 실패): 종전 판정은 `sed -n '2p'` 로 2행이 `paths:` 라고 가정했는데, 리포의 컴패니언 **4개 전부** 2행이 `description:` 이다(`goal-directive-detail.md` / `session-handoff-examples.md` / `agent-common-protocol-reference.md` / `askuser-protocol-reference.md`). 그중 `goal-directive-detail.md` 는 plan.md D2 가 "유일한 domain-keyed 선례"로 지목하고 REQ-ALD-004 가 준수를 요구하는 바로 그 파일이다. 즉 종전 형태에서는 **선례를 정확히 따르면 이 AC 가 실패하고, 통과시키려면 선례를 어겨야 했다**. `fm()` 은 키를 이름으로 뽑으므로 순서에 무관하다.
+
+### AC-ALD-008 — 선례 3요소 (포인터 열거 / 소유 선언 / 버전 기록)
+
+**Given** `goal-directive.md` 선례가 세 요소를 확립했고
+**When** 스텁과 컴패니언을 읽으면
+**Then** 셋이 모두 있어야 한다.
+
+```bash
+stub=.claude/rules/moai/workflow/kanban-dispatch.md
+comp=.claude/rules/moai/workflow/kanban-dispatch-detail.md
+for p in "$stub" "$comp"; do test -f "$p" || { echo "MISSING $p"; exit 1; }; done   # §A 함정 6
+# (a) 스텁 포인터가 옮긴 구간을 이름으로 열거
+grep -n 'kanban-dispatch-detail.md' "$stub"
+for n in 'board' 'Card classes' 'dispatch cycle' 'Review lens' 'clear' 'operator act'; do
+  printf 'enumerated:%s => %s\n' "$n" "$(grep -c "$n" <(grep -A2 -B2 'kanban-dispatch-detail.md' "$stub"))"
+done
+# (b) 컴패니언이 자기 쪽에서 소유 경계 선언
+echo "ownership_decl=$(grep -ciE 'detail companion|companion (to|for) `?kanban-dispatch' "$comp")"
+# (c) 스텁 푸터 버전 줄에 분리 기록
+tail -5 "$stub"
+# PASS 조건: (a) 6개 구간명이 포인터 근방에 열거, (b) ownership_decl >= 1, (c) 푸터에 분리 문구 존재
+```
+
+**`owns` 를 대안에서 뺀 이유**(실측된 공허 GREEN): `owns` 는 분리 이전 원본 60행에 이미 들어 있다 — "The `run` session **owns** both the investigation and the fix."(`kanban-dispatch.md:60`). 종전 패턴 `'detail companion\|Detail Companion\|owns'` 를 원본에 돌리면 **1** 이 나오므로, 순수 이동만 해도 컴패니언이 자동으로 `owns` 를 얻어 소유 선언을 **한 글자도 쓰지 않고** 통과했다. REQ-ALD-004(b)가 요구하는 것을 전혀 검증하지 못한 셈이다.
+
+이 결함은 D5(그 60행을 STAY 로 재배치)와 맞물려 있어 함께 푼다. 재배치 후에는 `owns` 가 컴패니언이 아니라 스텁에 남으므로 종전 패턴은 이번엔 **거짓 실패** 쪽으로 뒤집힌다 — 어느 쪽이든 판별력이 없다는 뜻이며, 그래서 앵커 자체를 선언 문구로 바꿨다.
+
+양성 대조(함정 3, 2026-08-16 실측): 새 패턴을 선례 컴패니언 `goal-directive-detail.md` 에 `goal-directive` 앵커로 돌리면 **3**, 분리 이전 `kanban-dispatch.md` 에 `kanban-dispatch` 앵커로 돌리면 **0** 이다. 패턴이 살아 있고 이동만으로는 충족되지 않음을 둘이 함께 보인다.
+
+### AC-ALD-009 — 컴패니언이 적치장이 되지 않음
+
+**Given** 원본이 21,003 bytes 이고 오버헤드 추정이 600~900 bytes 이며
+**When** 분리 후 두 파일의 합계를 재면
+**Then** 21,003 이상 21,903 이하여야 한다.
+
+```bash
+s=.claude/rules/moai/workflow/kanban-dispatch.md
+c=.claude/rules/moai/workflow/kanban-dispatch-detail.md
+test -f "$s" || { echo "MISSING $s"; exit 1; }
+test -f "$c" || { echo "MISSING $c"; exit 1; }
+a=$(wc -c < "$s"); b=$(wc -c < "$c")
+echo "stub=$a companion=$b sum=$((a+b))"
+# PASS 조건: b >= 1 AND 21003 <= sum <= 21903
+# 반례 참고: session-handoff-examples.md 는 40,891 로 부모 23,251 보다 크다.
+#
+# 존재 가드가 없으면 이 AC 는 무작업 상태에서 통과한다(감사 iter2 D1, 실행으로 확인).
+# `wc -c` 가 없는 파일에 실패하면 b 가 빈 문자열이 되고 bash 산술이 이를 0 으로 읽어
+# sum 이 원본 크기 21,003 이 되는데, 그 값이 PASS 범위의 하한과 정확히 일치한다.
+# 경계의 우연이 아니라 구조적이므로 `b >= 1` 을 조건에 함께 건다. (§A 함정 6)
+```
+
+### AC-ALD-010 — G3~G7 다섯 규율이 인라인에 존재
+
+**Given** 다섯 갭 모두 현재 매치 0건으로 실측되었고
+**When** 편입 후 `cache-aware-execution.md` 를 읽으면
+**Then** 다섯 주제어가 각각 최소 1회 등장해야 한다.
+
+```bash
+f=.claude/rules/moai/workflow/cache-aware-execution.md
+printf 'G3_at_mention => %s\n' "$(grep -ci 'mention' "$f")"
+printf 'G3_context_audit => %s\n' "$(grep -c '`/context`' "$f")"
+printf 'G4_output_len => %s\n' "$(grep -c 'BASH_MAX_OUTPUT_LENGTH' "$f")"
+printf 'G5_quiet => %s\n' "$(grep -ci 'quiet' "$f")"
+printf 'G6_session_length => %s\n' "$(grep -ci 'session length\|one long session' "$f")"
+printf 'G7_thinking => %s\n' "$(grep -c 'MAX_THINKING_TOKENS' "$f")"
+# PASS 조건: 6개 값 전부 >= 1
+# 양성 대조(함정 3): 편입 전 같은 명령은 6개 전부 0 이어야 한다 — 2026-08-16 실측으로 확인함.
+#
+# G3 패턴이 백틱을 포함하는 이유(실측된 오탐): 맨몸 `grep -c '/context'` 는
+# 이 파일 27행의 cross-reference `workflow/context-window-management.md` 를 매치해
+# 편입 전에도 1을 낸다. 즉 규율이 없는데도 GREEN 이 되는 공허한 AC 가 된다.
+# 백틱 형태(`` `/context` ``)는 편입 전 이 파일 0건, `.claude/rules/moai` 전체 0건이다.
+```
+
+### AC-ALD-011 — 인라인 증가가 예산 안
+
+**Given** `cache-aware-execution.md` 가 4,497 bytes 였고
+**When** G3~G7 편입 후 재면
+**Then** 증가분이 1,000 이상 2,000 이하여야 한다.
+
+```bash
+n=$(wc -c < .claude/rules/moai/workflow/cache-aware-execution.md)
+echo "before=4497 after=$n delta=$((n-4497))"
+# PASS 조건: 1000 <= delta <= 2000
+```
+
+상한 2,000 은 순감소 보호에 필요하다 — M2 의 증가가 M1 의 절감을 갉아먹는 양을 묶는다.
+
+하한은 1,500 에서 **1,000 으로 낮췄다**. 종전 값의 목적은 "다섯 규율이 실제로 진술됐는지" 였는데, 그 판정은 이미 `AC-ALD-010` 의 6개 패턴이 하고 있어 중복이었고, 중복된 쪽이 하필 **순감소 방향(더 짧게 쓰기)을 벌하는** 형태였다. 진술 존재 판정은 `AC-ALD-010` 단독에 맡기고, 여기 하한은 "빈 껍데기 방지" 수준으로만 남긴다.
+
+**구현자에게 — 이 창은 현행 지시 1~5 를 복사하면 넘친다.** 실측(2026-08-16, `cache-aware-execution.md`):
+
+```
+directive 1: 508 B   directive 2: 614 B   directive 3: 490 B
+directive 4: 501 B   directive 5: 355 B   합계 2,468 B (평균 494 B)
+```
+
+같은 크기로 다섯 개를 더 쓰면 약 +2,470 B 로 **상한을 초과해 FAIL** 한다. 이는 창이 잘못됐다는 뜻이 아니라 `REQ-ALD-011` 이 요구하는 바 그대로다 — 새 지시는 **HARD 지시 본문만** 인라인이고 근거·수치·예시는 `cache-aware-execution-reference.md` 로 간다. 현행 1~5 는 근거를 문단 안에 품고 있어 494 B 인 것이고, 근거를 덜어낸 형태는 그보다 작아야 정상이다.
+
+역산한 문단 예산: 창 [1,000, 2,000] 에 지시 5개 + 구분 빈 줄이면 **문단당 약 200~400 B**. plan.md M2 step 1 의 "현행 지시 1~5와 같은 형태"는 **형태(번호 매김 + `[ZONE:Evolvable] [HARD]` 접두 + 한 문단)를 뜻하지 크기를 뜻하지 않는다.**
+
+### AC-ALD-012 — 신설 컴패니언 2개가 always-loaded 로 계상되지 않음
+
+**Given** 신설 파일이 `kanban-dispatch-detail.md` 와 `cache-aware-execution-reference.md` 2개이고
+**When** 가드가 세는 no-`paths:` 파일 수를 보면
+**Then** 여전히 14개여야 한다(신설 2개는 `paths:` 보유).
+
+```bash
+headroom
+for f in .claude/rules/moai/workflow/kanban-dispatch-detail.md \
+         .claude/rules/moai/workflow/cache-aware-execution-reference.md; do
+  if [ -f "$f" ]; then
+    printf '%s exists=1 paths_key=%s\n' "$f" "$(fm "$f" | grep -c '^paths:')"
+  else
+    printf '%s exists=0 paths_key=0\n' "$f"
+  fi
+done
+# PASS 조건: 2행 전부 exists=1 paths_key=1, 그리고 headroom 출력의 files=14
+```
+
+**`grep -L` 을 버린 이유**(실측된 공허 GREEN): `grep -L` 은 패턴이 없는 파일명을 내지만, **파일이 존재하지 않으면** 에러를 stderr 로만 내고 stdout 에는 아무 것도 내지 않는다. 종전 PASS 조건 "위 grep 이 아무 것도 출력하지 않음"은 그래서 **신설 파일 2개를 아예 만들지 않은 상태에서 충족**됐다. 2026-08-16 실측:
+
+```
+$ out=$(grep -L '^paths:' <존재하지 않는 파일 2개> 2>/dev/null); echo "len=${#out}"
+len=0
+```
+
+`files=14` 쪽도 손대지 않은 트리에서 이미 14라, 두 조건이 함께 무작업 GREEN 을 냈다. 새 형태는 존재 단언을 앞세우고 `paths:` 키를 frontmatter **안에서** 직접 센다(§A 함정 6·7). 무작업 상태에서는 `exists=0` 으로 정확히 FAIL 한다 — 실행해 확인했다.
+
+### AC-ALD-013 — 인용 수치가 인용으로 표기됨
+
+**Given** 캐시 배수와 TTL이 원문 인용이고 이번 세션에 재측정되지 않았으며
+**When** 신설 reference 컴패니언을 읽으면
+**Then** 해당 수치 근방에 인용 출처 표기가 있어야 한다.
+
+```bash
+f=.claude/rules/moai/workflow/cache-aware-execution-reference.md
+test -f "$f" || { echo "MISSING $f"; exit 1; }   # §A 함정 6
+grep -n -i 'quoted\|not re-measured\|source article' "$f"
+echo "labeled=$(grep -c -i 'quoted\|not re-measured\|source article' "$f")"
+# PASS 조건: labeled >= 1 이고, 0.1x / 5x / TTL 수치가 나오는 문단 안에 위치
+```
+
+### AC-ALD-014 — 재발 통제가 존재하고 비-호출 세션 비용을 다룸
+
+**Given** D1이 작성 규칙(확장안)을 선택했고 D4-3이 임계값을 1,000 bytes(단일 편집 기준)로 확정했으며
+**When** 신설 통제 파일을 읽으면
+**Then** `paths:` 스코프를 갖고, 신규 생성과 기존 파일 증가 **양쪽**을 다루며, 확정된 임계값을 적고, 비-호출 세션 비용을 명시해야 한다.
+
+```bash
+f=.claude/rules/moai/development/rule-authoring.md
+test -f "$f" && echo "exists=1" || echo "exists=0"
+sed -n '1,4p' "$f"
+printf 'scoped => %s\n' "$(sed -n '1,4p' "$f" | grep -c '^paths:')"
+printf 'new_rule_case => %s\n' "$(grep -ci 'new always-loaded' "$f")"
+printf 'growth_case => %s\n' "$(grep -ci 'grow\|increase' "$f")"
+printf 'threshold => %s\n' "$(grep -cE '1,000 bytes|1000 bytes' "$f")"
+printf 'non_invoking_cost => %s\n' "$(grep -ci 'never invoke\|does not invoke\|sessions that never' "$f")"
+# PASS 조건: exists=1, scoped=1, 나머지 4개 전부 >= 1
+```
+
+`threshold` 가 판정하는 것은 값이 문서에 **적혔는지**뿐이다. 임계값 자체는 측정에서 유도한 값이 아니라 선택한 값이며(spec.md §5), 실제 발화 빈도는 이 AC의 판정 대상이 아니다.
+
+### AC-ALD-015 — 템플릿 미러 패리티 + 빌드
+
+**Given** always-loaded 14개는 이번 세션에 미러 존재를 확인했고
+**When** 생성·수정된 파일 전부에 대해 미러를 대조하면
+**Then** 모든 대응 파일이 존재하고 `make build` 가 성공해야 한다.
+
+```bash
+for rel in \
+  .claude/rules/moai/workflow/kanban-dispatch.md \
+  .claude/rules/moai/workflow/kanban-dispatch-detail.md \
+  .claude/rules/moai/workflow/cache-aware-execution.md \
+  .claude/rules/moai/workflow/cache-aware-execution-reference.md \
+  .claude/rules/moai/development/rule-authoring.md ; do
+  m="internal/template/templates/$rel"
+  printf '%s => %s\n' "$rel" "$(test -f "$m" && echo MIRRORED || echo MISSING)"
+done
+make build; echo "build_exit=$?"
+# PASS 조건: 5개 전부 MIRRORED, build_exit=0
+```
+
+미러는 **byte-parity 가 아닐 수 있다**(sanitized-pair). 통째 `cp` 금지 — 존재와 중립성만 판정한다.
+
+### AC-ALD-016 — 미러 중립성
+
+**Given** 템플릿은 16개 언어 사용자에게 중립이어야 하고
+**When** 미러본에서 내부 전용 토큰을 찾으면
+**Then** 매치가 0건이어야 한다.
+
+```bash
+for rel in \
+  .claude/rules/moai/workflow/kanban-dispatch.md \
+  .claude/rules/moai/workflow/kanban-dispatch-detail.md \
+  .claude/rules/moai/workflow/cache-aware-execution.md \
+  .claude/rules/moai/workflow/cache-aware-execution-reference.md \
+  .claude/rules/moai/development/rule-authoring.md ; do
+  m="internal/template/templates/$rel"
+  test -f "$m" || { printf '%s MISSING\n' "$rel"; continue; }
+  printf '%s spec_id=%s req=%s sha=%s date=%s\n' "$rel" \
+    "$(grep -cE 'SPEC-[A-Z][A-Z0-9-]*-[0-9]{3}' "$m")" \
+    "$(grep -cE 'REQ-[A-Z]+-[0-9]{3}' "$m")" \
+    "$(grep -cE '\b[0-9a-f]{9,40}\b' "$m")" \
+    "$(grep -cE '20[0-9]{2}-[0-9]{2}-[0-9]{2}' "$m")"
+done
+MOAI_TEMPLATE_LEAK_STRICT=1 go test ./internal/template/ -run TestTemplateNoInternalContentLeak; echo "exit=$?"
+# PASS 조건: MISSING 0건, 5행 전부 네 값이 0, 그리고 leak 테스트 exit=0
+# 양성 대조(함정 3): 같은 패턴을 로컬 .moai/specs/ 파일에 돌리면 0이 아니어야 한다.
+# 오탐 없음 확인(2026-08-16): 편집 예정 미러 2개(kanban-dispatch.md, cache-aware-execution.md)에
+#   위 네 패턴을 돌려 전부 0 을 관측했다 — 이 AC 는 거짓 실패 기계가 아니다.
+```
+
+`test -f` 가드가 필요한 이유(실측): 5개 대상 중 **3개는 아직 미러가 없다**(`kanban-dispatch-detail.md` / `cache-aware-execution-reference.md` / `rule-authoring.md`). 존재하지 않는 파일에 `grep -cE` 를 걸면 stdout 이 비어 `printf` 가 `spec_id= req= sha= date=` 를 출력한다. 빈 값은 `0` 이 아니므로 눈으로는 잡히지만 기계 판정으로는 미정의다. `AC-ALD-015` 가 존재를 따로 확인하긴 해도 두 AC 사이에 기계적 의존이 없어, 016 만 단독 실행하면 조용히 넘어간다(§A 함정 6).
+
+---
+
+## §C 추적 매트릭스
+
+| REQ | AC |
+|---|---|
+| REQ-ALD-001 | AC-ALD-003, AC-ALD-004 |
+| REQ-ALD-002 | AC-ALD-005, AC-ALD-006 |
+| REQ-ALD-003 | AC-ALD-007 |
+| REQ-ALD-004 | AC-ALD-008 |
+| REQ-ALD-005 | AC-ALD-009 |
+| REQ-ALD-006 ~ REQ-ALD-010 | AC-ALD-010 |
+| REQ-ALD-011 | AC-ALD-011, AC-ALD-012 |
+| REQ-ALD-012 | AC-ALD-013 |
+| REQ-ALD-013 | AC-ALD-014, AC-ALD-002 (Go 무변경 하위절) |
+| REQ-ALD-014 | AC-ALD-014 |
+| REQ-ALD-015 | AC-ALD-001, AC-ALD-002 |
+| REQ-ALD-016 | AC-ALD-015, AC-ALD-016 |
+
+## §D Definition of Done
+
+- [ ] AC-ALD-001 ~ AC-ALD-016 전부 PASS, 각각 실행 출력을 근거로 인용
+- [ ] `moai spec lint .moai/specs/SPEC-ALWAYS-LOADED-DIET-001/spec.md` exit 0 (디렉터리 인자 불가 — 파일 경로로 호출)
+- [ ] 세 산출물에 미해결 표식 잔존 0건 — `grep -rc 'NEEDS CLARIFICATION' .moai/specs/SPEC-ALWAYS-LOADED-DIET-001/*.md` 를 돌려 `spec.md` 와 `plan.md` 가 0 이고, `acceptance.md` 는 이 항목이 문자열 자체를 언급하므로 1 이어야 한다(1을 넘으면 다른 곳에 표식이 남은 것)
+- [ ] 커밋 제목이 `feat(SPEC-ALWAYS-LOADED-DIET-001):` 접두를 사용
+- [ ] feature 브랜치 + PR 로 착지(리포 로컬 정책상 전 Tier PR 필수)
+- [ ] `.moai/specs/SPEC-ALWAYS-LOADED-DIET-001/progress.md` §E.2/§E.3 에 run-phase 근거 기록
+
+## §E 잔여 위험
+
+- `paths:` 부착은 Claude Code 런타임 소관이라 관측할 수 없다. AC-ALD-007/012는 **글롭 문자열의 형태**를 판정할 뿐 실제 부착을 판정하지 못한다. 최악의 실패 모드는 "컴패니언이 안 붙음"이고, 스텁이 모든 구속 절을 갖고 있으므로 안전 실패다.
+- 토큰 수치는 char/4 추정(±약 15%)이다. AC-ALD-001의 `headroom > 1239` 비교는 **같은 공식의 전후 비교**이므로 추정 오차가 상쇄되지만, 절대값을 실제 토큰 수로 읽어서는 안 된다.
+- AC-ALD-006의 `git show HEAD:` 는 분리 커밋 이전 HEAD 를 전제한다. 분리를 이미 커밋한 뒤라면 해당 SHA 를 명시해 다시 돌린다.

--- a/.moai/specs/SPEC-ALWAYS-LOADED-DIET-001/acceptance.md
+++ b/.moai/specs/SPEC-ALWAYS-LOADED-DIET-001/acceptance.md
@@ -348,18 +348,26 @@ len=0
 ```bash
 f=.claude/rules/moai/workflow/cache-aware-execution-reference.md
 test -f "$f" || { echo "MISSING $f"; exit 1; }   # §A 함정 6
-grep -n -i 'quoted\|not re-measured\|source article' "$f"   # 진단 출력
-echo "numeric_paragraphs=$(awk -v RS= 'tolower($0) ~ /(^|[^0-9a-z])(0\.1x|5x|ttl)([^0-9a-z]|$)/ { n++ } END { print n+0 }' "$f")"
+grep -n -iE '(^|[^a-zA-Z])quoted|not re-measured|source article' "$f"   # 진단 출력 — unquoted 를 quoted 로 오계상하지 않는다(3차)
+echo "numeric_paragraphs=$(awk -v RS= 'tolower($0) ~ /(^|[^0-9a-z._])(0\.1x|5x|ttl)([^0-9a-z_]|$)/ { n++ } END { print n+0 }' "$f")"
 awk -v RS= '
-  tolower($0) ~ /(^|[^0-9a-z])(0\.1x|5x|ttl)([^0-9a-z]|$)/ && tolower($0) !~ /quoted|not re-measured|source article/ {
+  tolower($0) ~ /(^|[^0-9a-z._])(0\.1x|5x|ttl)([^0-9a-z_]|$)/ && tolower($0) !~ /(^|[^a-z])quoted|not re-measured|source article/ {
     print "UNLABELED numeric paragraph:"; print; bad=1
   }
   END { exit bad ? 1 : 0 }
 ' "$f"; echo "citation_exit=$?"
-# PASS 조건: numeric_paragraphs >= 1 (양성 대조, 함정 3) 그리고 citation_exit=0 —
+printf 'growth was 15.5x this quarter\n\nthe cache_TTL setting is unquoted\n\ngain 5x is unquoted here\n\ncosts 0.1x (quoted, source article)\n\n' | awk -v RS= '
+  tolower($0) ~ /(^|[^0-9a-z._])(0\.1x|5x|ttl)([^0-9a-z_]|$)/ && tolower($0) !~ /(^|[^a-z])quoted|not re-measured|source article/ { n++ }
+  END { print "selftest_unlabeled=" n+0 }'
+# PASS 조건: numeric_paragraphs >= 1 (양성 대조, 함정 3), citation_exit=0, selftest_unlabeled=1 —
 #   0.1x / 5x / TTL 을 담은 문단 각각이 같은 문단(빈 줄로 구분된 블록) 안에 인용 표기를 동반
-#   경계 클래스 [^0-9a-z] 로 15x·settle 같은 부분 문자열은 세지 않는다(2차 리뷰)
+#   좌측 경계 [^0-9a-z._]: 점·밑줄은 토큰 경계가 아니므로 15.5x 의 5x·cache_TTL 의 TTL 을 세지 않는다(3차 리뷰)
+#   우측 경계 [^0-9a-z_]: 밑줄 연결(ttl_upper) 만 막고, 마침표는 문장 끝(0.1x.) 이므로 허용한다
+#   인용 표기 (^|[^a-z])quoted: unquoted 는 인용 표기로 치지 않는다(3차 리뷰)
+#   selftest_unlabeled=1 — 음성 대조(함정 3): 네 합성 문단 중 "gain 5x is unquoted" 만 UNLABELED 로 잡혀야 한다
 ```
+
+**경계 클래스가 좌우 비대칭인 이유**(3차 리뷰): `.` 를 양쪽 경계에서 모두 빼면 `15.5x` 는 막히지만 문장 끝의 `0.1x.` 까지 놓치고, 그 누락은 라벨 없는 수치 문단을 조용히 통과시키는 공허 GREEN 이 된다. 좌측에서만 `.` 와 `_` 를 빼면 유입은 차단되면서 문장 끝 마침표는 허용된다. 수정 전 패턴 실측(2026-08-17): `15.5x`·`cache_TTL` 문단 2개가 수치로 잘못 계상되고 `unquoted` 문단이 인용 표기 보유로 잘못 판정됐다 — 수정 후 각각 0건.
 
 ### AC-ALD-014 — 재발 통제가 존재하고 비-호출 세션 비용을 다룸
 

--- a/.moai/specs/SPEC-ALWAYS-LOADED-DIET-001/acceptance.md
+++ b/.moai/specs/SPEC-ALWAYS-LOADED-DIET-001/acceptance.md
@@ -172,7 +172,14 @@ done
 c=.claude/rules/moai/workflow/kanban-dispatch-detail.md
 test -f "$c" || { echo "MISSING $c"; exit 1; }   # §A 함정 6 — 가드가 없으면 분리 이전에도
                                                   # missing_lines=0 으로 통과한다(감사 iter2 D2)
-BASE_REF=be1958a4d   # 분리 이전(plan-phase) 커밋 — HEAD 는 구현 착지 후 post-split 상태다
+BASE_REF=be1958a4d374654998dd3b502111a3081d5dd03b   # 분리 이전(plan-phase) 커밋 — HEAD 는 구현 착지 후 post-split 상태다
+# fail-closed 가드(2차 리뷰): git show 가 실패해도 파이프라인은 sort 까지 status 0 으로
+#   끝나 빈 baseline 를 남기고 missing_lines=0 거짓 PASS 를 낸다 — 커밋과 baseline 경로를
+#   cat-file -e 로 먼저 확인하고, 하나라도 없으면 즉시 FAIL 한다
+git cat-file -e "${BASE_REF}^{commit}" \
+  || { echo "BAD_BASE_REF ${BASE_REF}"; exit 1; }
+git cat-file -e "${BASE_REF}:.claude/rules/moai/workflow/kanban-dispatch.md" \
+  || { echo "MISSING baseline path in ${BASE_REF}"; exit 1; }
 git show "${BASE_REF}:.claude/rules/moai/workflow/kanban-dispatch.md" \
   | grep -v '^[[:space:]]*$' | sort > /tmp/ald-orig.txt
 cat .claude/rules/moai/workflow/kanban-dispatch.md \
@@ -342,15 +349,16 @@ len=0
 f=.claude/rules/moai/workflow/cache-aware-execution-reference.md
 test -f "$f" || { echo "MISSING $f"; exit 1; }   # §A 함정 6
 grep -n -i 'quoted\|not re-measured\|source article' "$f"   # 진단 출력
-echo "numeric_paragraphs=$(awk -v RS= 'tolower($0) ~ /0\.1x|5x|ttl/ { n++ } END { print n+0 }' "$f")"
+echo "numeric_paragraphs=$(awk -v RS= 'tolower($0) ~ /(^|[^0-9a-z])(0\.1x|5x|ttl)([^0-9a-z]|$)/ { n++ } END { print n+0 }' "$f")"
 awk -v RS= '
-  tolower($0) ~ /0\.1x|5x|ttl/ && tolower($0) !~ /quoted|not re-measured|source article/ {
+  tolower($0) ~ /(^|[^0-9a-z])(0\.1x|5x|ttl)([^0-9a-z]|$)/ && tolower($0) !~ /quoted|not re-measured|source article/ {
     print "UNLABELED numeric paragraph:"; print; bad=1
   }
   END { exit bad ? 1 : 0 }
 ' "$f"; echo "citation_exit=$?"
 # PASS 조건: numeric_paragraphs >= 1 (양성 대조, 함정 3) 그리고 citation_exit=0 —
 #   0.1x / 5x / TTL 을 담은 문단 각각이 같은 문단(빈 줄로 구분된 블록) 안에 인용 표기를 동반
+#   경계 클래스 [^0-9a-z] 로 15x·settle 같은 부분 문자열은 세지 않는다(2차 리뷰)
 ```
 
 ### AC-ALD-014 — 재발 통제가 존재하고 비-호출 세션 비용을 다룸
@@ -364,8 +372,10 @@ f=.claude/rules/moai/development/rule-authoring.md
 test -f "$f" || { echo "MISSING $f"; exit 1; }   # §A 함정 6·7 — 존재 가드 + 줄 위치 추출 금지
 p=$(fm "$f" | grep '^paths:')
 echo "$p"
+# grep -F -- (2차 리뷰): 점을 와일드카드가 아닌 리터럴로 취급 — CLAUDEXmd 같은 오탈자 경로가
+#   CLAUDE.md 슬롯을 채우지 못한다. -- 는 frag 가 - 로 시작할 때 옵션으로 읽히는 것을 막는다
 for frag in 'rules' 'CLAUDE.md' 'output-styles' 'MEMORY.md'; do
-  printf 'slot_%s => %s\n' "$frag" "$(printf '%s' "$p" | grep -c "$frag")"
+  printf 'slot_%s => %s\n' "$frag" "$(printf '%s' "$p" | grep -F -c -- "$frag")"
 done
 printf 'new_rule_case => %s\n' "$(grep -ci 'new always-loaded' "$f")"
 printf 'growth_case => %s\n' "$(grep -ci 'grow\|increase' "$f")"

--- a/.moai/specs/SPEC-ALWAYS-LOADED-DIET-001/acceptance.md
+++ b/.moai/specs/SPEC-ALWAYS-LOADED-DIET-001/acceptance.md
@@ -7,7 +7,7 @@
 1. **명령을 표 셀에 넣지 않는다.** 마크다운 표 셀 안의 `\|` 는 `grep -E` 에서 리터럴 파이프로 해석돼 패턴이 조용히 아무 것도 매치하지 않는다. 이 문서의 모든 명령은 펜스 코드블록에 있다.
 2. **패턴 언어와 파일 언어를 맞춘다.** `.claude/rules/`, `.claude/agents/`, `.claude/skills/` 본문은 **영어 전용**이다. 이 SPEC 본문은 한국어지만, 규칙 파일을 겨냥한 grep 패턴은 반드시 영어여야 한다.
 3. **부재(absence) 판정은 양성 대조를 먼저 세운다.** "0건이면 통과" 형태의 AC는 패턴 자체가 고장나도 0건을 낸다. 부재 AC마다 같은 패턴이 분리 이전 파일에서는 매치되는지를 먼저 확인한다.
-4. **가드 정규식을 면제 목록 없이 재구현하지 않는다.** `go test ./internal/config/ -run TestAlwaysLoaded` 의 실행 결과가 권위다. §A의 `grep -rL '^paths:'` 스니펫은 델타 관측용 보조 계측이며, 둘이 어긋나면 **가드가 맞다**.
+4. **가드 정규식을 면제 목록 없이 재구현하지 않는다.** `go test ./internal/config/ -run TestAlwaysLoaded` 의 실행 결과가 권위다. §A의 `headroom` 스니펫은 `fm()` 을 통과시켜 `paths:` 판정을 frontmatter 블록에 한정한다(가드의 `alwaysLoadedSurface` 계약과 동일한 스코프). 종전의 `grep -rL '^paths:'` 형태는 본문 어디든 `paths:` 로 시작하는 줄이 있으면 scoped 로 잘못 빼서 가드와 어긋날 수 있었다(CodeRabbit #1576 Major 1). 그래도 이 스니펫은 보조 계측이며, 둘이 어긋나면 **가드가 맞다**.
 5. **`--strict` 는 severity 문자열이 아니라 exit code 를 바꾼다.** spec-lint 판정은 exit code 로 한다.
 6. **부재 판정 앞에 존재 단언을 세운다.** `grep` 계열은 대상 파일이 없으면 에러를 stderr 로만 내고 stdout 에 아무 것도 출력하지 않는다. 그래서 "출력이 없으면 통과" 형태의 AC 는 **파일을 만들지 않은 것만으로** GREEN 이 되고, `grep -c` 는 `0` 이 아니라 **빈 문자열**을 내어 기계 판정을 미정의로 만든다. 파일을 다루는 AC 는 전부 `test -f` 를 먼저 통과시킨다.
 7. **줄 위치로 필드를 뽑지 않는다.** `sed -n '2p'` 같은 위치 기반 추출은 frontmatter 키 순서가 조금만 달라도 무너진다. 실측: 기존 컴패니언 4개는 **전부** 2행이 `description:` 이다. 키는 이름으로 뽑는다(아래 `fm()`).
@@ -20,17 +20,20 @@ fm() { awk '/^---$/{c++; if(c==2) exit; next} c==1' "$1"; }
 # 양성 대조(2026-08-16 실측): 기존 컴패니언 4개 전부 `fm "$f" | grep -c '^paths:'` = 1,
 #   always-loaded 파일(kanban-dispatch.md)은 0.
 
-# 이 문서 전반에서 쓰는 계측 함수
+# 이 문서 전반에서 쓰는 계측 함수 — scoped 판정은 fm() 결과에서만 한다(가드 계약 준수)
 headroom() {
-  tot=0
-  for f in $(grep -rL '^paths:' .claude/rules/moai --include='*.md'); do tot=$((tot+$(wc -c < "$f"))); done
+  tot=0; n=0
+  for f in $(find .claude/rules/moai -type f -name '*.md' | sort); do
+    fm "$f" | grep -q '^paths:' && continue
+    tot=$((tot+$(wc -c < "$f"))); n=$((n+1))
+  done
   for f in CLAUDE.md .claude/output-styles/moai/moai.md; do tot=$((tot+$(wc -c < "$f"))); done
   [ -f MEMORY.md ] && tot=$((tot+$(head -200 MEMORY.md | head -c 25600 | wc -c)))
-  echo "files=$(grep -rL '^paths:' .claude/rules/moai --include='*.md' | wc -l) bytes=$tot tokens=$((tot/4)) headroom=$((75000 - tot/4))"
+  echo "files=$n bytes=$tot tokens=$((tot/4)) headroom=$((75000 - tot/4))"
 }
 ```
 
-Baseline (2026-08-16 실측): `files=14 bytes=295044 tokens=73761 headroom=1239`
+Baseline (2026-08-16 실측; 2026-08-17 에 frontmatter-aware 형태로 재실행해 동일 출력 확인): `files=14 bytes=295044 tokens=73761 headroom=1239`
 
 ---
 
@@ -169,11 +172,13 @@ done
 c=.claude/rules/moai/workflow/kanban-dispatch-detail.md
 test -f "$c" || { echo "MISSING $c"; exit 1; }   # §A 함정 6 — 가드가 없으면 분리 이전에도
                                                   # missing_lines=0 으로 통과한다(감사 iter2 D2)
-git show HEAD:.claude/rules/moai/workflow/kanban-dispatch.md \
-  | grep -v '^[[:space:]]*$' | sort -u > /tmp/ald-orig.txt
+BASE_REF=be1958a4d   # 분리 이전(plan-phase) 커밋 — HEAD 는 구현 착지 후 post-split 상태다
+git show "${BASE_REF}:.claude/rules/moai/workflow/kanban-dispatch.md" \
+  | grep -v '^[[:space:]]*$' | sort > /tmp/ald-orig.txt
 cat .claude/rules/moai/workflow/kanban-dispatch.md \
     .claude/rules/moai/workflow/kanban-dispatch-detail.md \
-  | grep -v '^[[:space:]]*$' | sort -u > /tmp/ald-after.txt
+  | grep -v '^[[:space:]]*$' | sort > /tmp/ald-after.txt
+#   sort 에 -u 를 붙이지 않는다 — 중복 줄도 보존해 대조한다(comm 은 정렬만 요구)
 comm -23 /tmp/ald-orig.txt /tmp/ald-after.txt
 echo "missing_lines=$(comm -23 /tmp/ald-orig.txt /tmp/ald-after.txt | wc -l)"
 # PASS 조건: missing_lines=0
@@ -336,9 +341,16 @@ len=0
 ```bash
 f=.claude/rules/moai/workflow/cache-aware-execution-reference.md
 test -f "$f" || { echo "MISSING $f"; exit 1; }   # §A 함정 6
-grep -n -i 'quoted\|not re-measured\|source article' "$f"
-echo "labeled=$(grep -c -i 'quoted\|not re-measured\|source article' "$f")"
-# PASS 조건: labeled >= 1 이고, 0.1x / 5x / TTL 수치가 나오는 문단 안에 위치
+grep -n -i 'quoted\|not re-measured\|source article' "$f"   # 진단 출력
+echo "numeric_paragraphs=$(awk -v RS= 'tolower($0) ~ /0\.1x|5x|ttl/ { n++ } END { print n+0 }' "$f")"
+awk -v RS= '
+  tolower($0) ~ /0\.1x|5x|ttl/ && tolower($0) !~ /quoted|not re-measured|source article/ {
+    print "UNLABELED numeric paragraph:"; print; bad=1
+  }
+  END { exit bad ? 1 : 0 }
+' "$f"; echo "citation_exit=$?"
+# PASS 조건: numeric_paragraphs >= 1 (양성 대조, 함정 3) 그리고 citation_exit=0 —
+#   0.1x / 5x / TTL 을 담은 문단 각각이 같은 문단(빈 줄로 구분된 블록) 안에 인용 표기를 동반
 ```
 
 ### AC-ALD-014 — 재발 통제가 존재하고 비-호출 세션 비용을 다룸
@@ -349,14 +361,18 @@ echo "labeled=$(grep -c -i 'quoted\|not re-measured\|source article' "$f")"
 
 ```bash
 f=.claude/rules/moai/development/rule-authoring.md
-test -f "$f" && echo "exists=1" || echo "exists=0"
-sed -n '1,4p' "$f"
-printf 'scoped => %s\n' "$(sed -n '1,4p' "$f" | grep -c '^paths:')"
+test -f "$f" || { echo "MISSING $f"; exit 1; }   # §A 함정 6·7 — 존재 가드 + 줄 위치 추출 금지
+p=$(fm "$f" | grep '^paths:')
+echo "$p"
+for frag in 'rules' 'CLAUDE.md' 'output-styles' 'MEMORY.md'; do
+  printf 'slot_%s => %s\n' "$frag" "$(printf '%s' "$p" | grep -c "$frag")"
+done
 printf 'new_rule_case => %s\n' "$(grep -ci 'new always-loaded' "$f")"
 printf 'growth_case => %s\n' "$(grep -ci 'grow\|increase' "$f")"
 printf 'threshold => %s\n' "$(grep -cE '1,000 bytes|1000 bytes' "$f")"
 printf 'non_invoking_cost => %s\n' "$(grep -ci 'never invoke\|does not invoke\|sessions that never' "$f")"
-# PASS 조건: exists=1, scoped=1, 나머지 4개 전부 >= 1
+# PASS 조건: MISSING 없음, slot_ 4개(rules / CLAUDE.md / output-styles / MEMORY.md) 전부 >= 1
+#   (REQ-ALD-013·plan.md D1 글롭의 가드 슬롯 4개 — rules-only 글롭이면 FAIL), 나머지 4개 전부 >= 1
 ```
 
 `threshold` 가 판정하는 것은 값이 문서에 **적혔는지**뿐이다. 임계값 자체는 측정에서 유도한 값이 아니라 선택한 값이며(spec.md §5), 실제 발화 빈도는 이 AC의 판정 대상이 아니다.
@@ -445,4 +461,4 @@ MOAI_TEMPLATE_LEAK_STRICT=1 go test ./internal/template/ -run TestTemplateNoInte
 
 - `paths:` 부착은 Claude Code 런타임 소관이라 관측할 수 없다. AC-ALD-007/012는 **글롭 문자열의 형태**를 판정할 뿐 실제 부착을 판정하지 못한다. 최악의 실패 모드는 "컴패니언이 안 붙음"이고, 스텁이 모든 구속 절을 갖고 있으므로 안전 실패다.
 - 토큰 수치는 char/4 추정(±약 15%)이다. AC-ALD-001의 `headroom > 1239` 비교는 **같은 공식의 전후 비교**이므로 추정 오차가 상쇄되지만, 절대값을 실제 토큰 수로 읽어서는 안 된다.
-- AC-ALD-006의 `git show HEAD:` 는 분리 커밋 이전 HEAD 를 전제한다. 분리를 이미 커밋한 뒤라면 해당 SHA 를 명시해 다시 돌린다.
+- AC-ALD-006의 원본 판독은 `BASE_REF=be1958a4d`(분리 이전 plan-phase 커밋)로 고정한다. 구현 착지 이후 어느 시점에 재실행해도 HEAD 가 아니라 이 SHA 를 읽으므로 pre-split 원본이 나온다.

--- a/.moai/specs/SPEC-ALWAYS-LOADED-DIET-001/acceptance.md
+++ b/.moai/specs/SPEC-ALWAYS-LOADED-DIET-001/acceptance.md
@@ -355,10 +355,13 @@ awk -v RS= '
     print "UNLABELED numeric paragraph:"; print; bad=1
   }
   END { exit bad ? 1 : 0 }
-' "$f"; echo "citation_exit=$?"
-printf 'growth was 15.5x this quarter\n\nthe cache_TTL setting is unquoted\n\ngain 5x is unquoted here\n\ncosts 0.1x (quoted, source article)\n\n' | awk -v RS= '
+' "$f" || { echo "citation_exit=1"; exit 1; }   # 4차 리뷰: 실패 exit 가 뒤따르는 echo 에 묻히지 않게 fail-closed
+echo "citation_exit=0"
+selftest_unlabeled=$(printf 'growth was 15.5x this quarter\n\nthe cache_TTL setting is unquoted\n\ngain 5x is unquoted here\n\ncosts 0.1x (quoted, source article)\n\n' | awk -v RS= '
   tolower($0) ~ /(^|[^0-9a-z._])(0\.1x|5x|ttl)([^0-9a-z_]|$)/ && tolower($0) !~ /(^|[^a-z])quoted|not re-measured|source article/ { n++ }
-  END { print "selftest_unlabeled=" n+0 }'
+  END { print n+0 }')
+printf 'selftest_unlabeled=%s\n' "$selftest_unlabeled"
+test "$selftest_unlabeled" -eq 1 || { echo "SELFTEST_UNLABELED_EXPECTED_1 got=$selftest_unlabeled"; exit 1; }   # 4차 리뷰: 음성 대조 단언(=1)을 exit 코드로 강제
 # PASS 조건: numeric_paragraphs >= 1 (양성 대조, 함정 3), citation_exit=0, selftest_unlabeled=1 —
 #   0.1x / 5x / TTL 을 담은 문단 각각이 같은 문단(빈 줄로 구분된 블록) 안에 인용 표기를 동반
 #   좌측 경계 [^0-9a-z._]: 점·밑줄은 토큰 경계가 아니므로 15.5x 의 5x·cache_TTL 의 TTL 을 세지 않는다(3차 리뷰)
@@ -367,7 +370,7 @@ printf 'growth was 15.5x this quarter\n\nthe cache_TTL setting is unquoted\n\nga
 #   selftest_unlabeled=1 — 음성 대조(함정 3): 네 합성 문단 중 "gain 5x is unquoted" 만 UNLABELED 로 잡혀야 한다
 ```
 
-**경계 클래스가 좌우 비대칭인 이유**(3차 리뷰): `.` 를 양쪽 경계에서 모두 빼면 `15.5x` 는 막히지만 문장 끝의 `0.1x.` 까지 놓치고, 그 누락은 라벨 없는 수치 문단을 조용히 통과시키는 공허 GREEN 이 된다. 좌측에서만 `.` 와 `_` 를 빼면 유입은 차단되면서 문장 끝 마침표는 허용된다. 수정 전 패턴 실측(2026-08-17): `15.5x`·`cache_TTL` 문단 2개가 수치로 잘못 계상되고 `unquoted` 문단이 인용 표기 보유로 잘못 판정됐다 — 수정 후 각각 0건.
+**경계 클래스가 좌우 비대칭인 이유**(3차 리뷰): `.` 를 양쪽 경계에서 모두 빼면 `15.5x` 는 막히지만 문장 끝의 `0.1x.` 까지 놓치고, 그 누락은 라벨 없는 수치 문단을 조용히 통과시키는 공허 GREEN 이 된다. 좌측에서만 `.` 와 `_` 를 빼면 유입은 차단되면서 문장 끝 마침표는 허용된다. 수정 전 패턴 실측(2026-08-16): `15.5x`·`cache_TTL` 문단 2개가 수치로 잘못 계상되고 `unquoted` 문단이 인용 표기 보유로 잘못 판정됐다 — 수정 후 각각 0건.
 
 ### AC-ALD-014 — 재발 통제가 존재하고 비-호출 세션 비용을 다룸
 

--- a/.moai/specs/SPEC-ALWAYS-LOADED-DIET-001/plan.md
+++ b/.moai/specs/SPEC-ALWAYS-LOADED-DIET-001/plan.md
@@ -1,0 +1,216 @@
+# Implementation Plan — SPEC-ALWAYS-LOADED-DIET-001
+
+> 순서 원칙: **되돌리기 어려운 결정이 먼저**. §B 결정 사항은 아직 확정되지 않았거나 사람의 판단이 필요한 순으로, §D 마일스톤은 기계적 작업이 뒤로 가도록 배치했다. 리뷰 시간은 §B에 쓰는 것이 맞다.
+
+## §A Context
+
+- 대상 리포: `/Users/goos/MoAI/moai-adk-go`, 브랜치 `main`
+- SPEC 산출물: `.moai/specs/SPEC-ALWAYS-LOADED-DIET-001/{spec,plan,acceptance,progress}.md` (Tier M = 3 산출물 + progress)
+- 근거: spec.md §1(실측 baseline), §2(재발 증거), §5(미검증 항목). **이 plan은 수치를 다시 유도하지 않고 인용한다.**
+- 편집 대상 파일 4개 + 미러 4개 + M3 신설 1개(+미러) = 최대 10개 파일
+
+주요 선례 2개를 작업 전에 통독한다.
+
+- `.claude/rules/moai/workflow/goal-directive.md` (6,531 B) — 스텁 쪽 선례
+- `.claude/rules/moai/workflow/goal-directive-detail.md` (17,334 B) — 컴패니언 쪽 선례
+
+선례가 확립한 분할선: **스텁**은 정의 + 메커니즘 + 위반이 안전 실패가 되는 HARD 불변식 + hard-precondition 목록 + 트리거를 한 줄로 압축한 형태 + cross-reference 를 갖는다. **컴패니언**은 표, 워크드 예시, 복붙 템플릿, 근거, 통합 열거를 가져간다.
+
+## §B 결정 사항 — 변경 가능성 높은 순
+
+### D1 (최상위 결정) — M3 재발 통제 메커니즘 선택
+
+후보 3개를 spec.md §2의 분해 수치에 대고 평가한다. 그 수치가 이 결정의 유일한 판별자다: **증가분의 45.3%는 기존 파일의 자체 성장이고 54.7%만 신규 유입**이다.
+
+| 후보 | 커버하는 성장 모드 | 비용 | 판정 |
+|---|---|---|---|
+| A. 작성 규칙 — 새 always-loaded 규칙은 자기 bytes와 비용 정당화를 진술해야 함 | 신규 유입만 (54.7%) | 문서만, Go 무변경 | **원안은 부족** |
+| B. `AlwaysLoadedTokenBudget` 하향 | 양쪽 (100%) | Go 상수 1줄 | 이 SPEC 밖 — 별도 백로그 카드 (D4-1) |
+| C. 가드가 pass/fail 대신 현재 여유를 보고 | 양쪽 (100%) | Go 테스트 메시지 | 미채택 — 실패 시점에만 보임 (D4-2) |
+
+**선택: A를 확장한 형태.** 작성 규칙을 두되, 신규 생성뿐 아니라 **기존 always-loaded 파일의 증가**에도 진술 의무를 건다. 근거 셋:
+
+1. A 원안 그대로면 측정된 성장의 절반을 놓친다 — 위 표의 판정이 그 이유다.
+2. 새 파일을 `.claude/rules/moai/development/rule-authoring.md` 로 두고 **가드 슬롯 전체를 키잉**하면, always-loaded 표면을 편집하려는 사람은 정의상 그 경로를 건드리고 있으므로 규칙이 정확히 그 순간 붙는다. 채택 글롭은 아래 세 경로다.
+
+   ```
+   paths: "**/.claude/rules/**,**/CLAUDE.md,**/.claude/output-styles/**,**/MEMORY.md"
+   ```
+
+   이 글롭의 도달 범위는 **295,044 bytes = 100%** 다. 종전 안이던 `**/.claude/rules/**` 단독은 규칙 파일 210,753 bytes 에만 닿아 **71.4%** 에 그친다 — 나머지 `CLAUDE.md`(19,040) + `.claude/output-styles/moai/moai.md`(65,251) = 84,291 bytes 가 **28.6%** 이고, `moai.md` 는 단일 파일로는 표면 최대 기여자다(규칙 1위 `agent-common-protocol.md` 39,455 의 1.65배). 규칙 파일만 키잉하는 안은 통제가 선언한 적용 범위(REQ-ALD-013: 신규 생성 + 기존 증가 양쪽)를 실제 도달 범위가 따라가지 못하는 상태였고, 그것이 이번에 교정된 지점이다. 확장해도 이 파일 자신은 `paths:` 를 갖고 있어 always-loaded 비용은 여전히 0 이다.
+
+   세 번째 글롭은 **슬롯보다 넓다.** `.claude/output-styles/moai/` 에는 `moai.md`(65,251) 외에 `moai-easy.md`(32,342)·`moai-learn.md`(31,395)도 있지만, 가드가 세는 것은 `moai.md` 하나뿐이다 — 위 295,044 에 나머지 둘은 들어 있지 않다. 넓은 쪽으로 틀린 것이라 해는 없다(슬롯이 아닌 output-style 을 편집할 때도 규칙이 붙을 뿐이고, 그 파일은 `paths:` 스코프라 always-loaded 비용이 0 이다). 좁은 글롭(`**/.claude/output-styles/moai/moai.md`)으로 정확히 맞출 수도 있으나, output-style 이 늘어날 때 슬롯 편입을 놓치는 쪽이 더 비싼 실수라 넓은 형태를 택했다.
+
+   부수 관찰(미검증) — `coding-standards.md:25` 는 `CLAUDE.md` 40,000자 한도를 "세션 시작 시 전량 로드되는 project-local instruction 파일"로 확장해 적고 있고, 그 기준에 `moai.md`(65,251)는 25,251 초과다. 다만 그 줄은 스스로를 "CI-**enforceable** heuristic"이라 부를 뿐이며 기계적 강제 여부는 확인하지 않았다. 이 관찰은 확장의 **동기**일 뿐 작동 중인 통제가 아니다(spec.md §5).
+3. B/C는 Go 변경을 수반해 리스크를 갖고, 이 SPEC의 순감소 판정을 흐린다.
+
+B는 기각이 아니라 **별도 백로그 카드로 분리한다** — 하향할 값은 M1/M2가 착지해야 알 수 있고, M4가 기록하는 여유가 그 카드의 입력이다. C는 이 SPEC 안에서 채택하지 않는다. 확정 내용과 근거는 아래 D4.
+
+### D2 — `kanban-dispatch-detail.md` 의 `paths:` 키
+
+실측한 컴패니언 4개의 키잉 형태:
+
+| 컴패니언 | `paths:` | 형태 |
+|---|---|---|
+| `agent-common-protocol-reference.md` | `**/agent-common-protocol.md` | self-keyed |
+| `askuser-protocol-reference.md` | `**/askuser-protocol.md` | self-keyed |
+| `session-handoff-examples.md` | `**/session-handoff.md` | self-keyed |
+| `goal-directive-detail.md` | `**/.moai/state/goal/**,**/.claude/skills/moai/workflows/goal.md,**/goal-directive.md,**/goal-directive-detail.md` | **domain-keyed** |
+
+self-keyed 3개는 부모 규칙 파일을 편집할 때만 붙는다 — 즉 실질적으로 문서 포인터다. domain-keyed 는 실제 그 도메인 작업 중에도 붙는다. lead 세션이 카드를 옮기는 동안 board/card-class/dispatch 구간이 필요하므로 **domain-keyed 를 채택**한다(REQ-ALD-003).
+
+채택 키 3개 — 모두 이번 세션에 존재를 확인했다:
+
+```
+paths: "**/kanban-dispatch*.md,**/.claude/agents/moai/manager-kanban.md,**/.claude/skills/moai/workflows/todo.md"
+```
+
+- `.claude/agents/moai/manager-kanban.md` — 존재(19,984 B), 미러 존재(19,989 B)
+- `.claude/skills/moai/workflows/todo.md` — 존재(5,099 B), 미러 존재(5,099 B)
+
+첫 키의 글롭이 스텁과 컴패니언을 함께 잡는 것은 의도다(`goal-directive-detail.md` 가 자기 자신을 키에 넣은 것과 같은 형태).
+
+### D3 — G7 의 겉보기 모순 해소 방식
+
+`agent-common-protocol.md` § Per-Spawn Model Injection 은 "스폰마다 모델을 명시하라"고 하고, `cache-aware-execution.md` 지시 5는 "세션 모델을 상속하라"고 한다. 읽는 사람에게 모순으로 보인다.
+
+해소: **두 축이 다르다.** 전자는 서브에이전트가 프로파일이 정한 모델로 도는지를 다루고(에이전트 정의 대부분이 `model: inherit` 이므로 미지정 스폰은 부모 모델로 조용히 떨어진다), 후자는 메인 세션이 쌓아온 캐시가 스폰 단위 오버라이드로 쪼개지는 비용을 다룬다. G7 지시문은 이 구분을 한 문장으로 명시하고 양쪽 SSOT를 cross-reference 한다. 어느 쪽도 개정하지 않는다.
+
+### D4 — 확정된 결정 (사용자 판단, 재논의 금지)
+
+이 SPEC에 미해결 항목은 없다. 종전에 이 자리에 있던 미해결 3건은 아래와 같이 확정됐다.
+
+**D4-1 — post-diet 예산 ratchet: 이 SPEC 범위 밖.** `AlwaysLoadedTokenBudget` 은 전 구간에서 75,000 을 유지한다. M4는 착지 후 여유를 **측정해 기록**하고, 그 기록값은 상수를 낮출지 판단하는 **별도 백로그 카드**의 입력이 된다. 근거: 종료 조건이 "완료 후 여유 > 완료 전 여유"인 SPEC 안에서 그 비교의 기준이 되는 예산 상수까지 함께 움직이면 AC가 무엇을 재는지가 흐려진다. baseline 은 75,000 상수 기준 1,239 토큰으로 고정한다. (D1 후보 B)
+
+**D4-2 — M3 재발 통제는 문서 전용, Go 변경 없음.** M3의 산출물은 `.claude/rules/moai/development/rule-authoring.md` 와 그 템플릿 미러가 전부다. 가드 출력은 지금 형태(초과분이 실패 시에만 보임)를 그대로 둔다. 가드가 여유를 함께 보고하도록 바꾸는 안(D1 후보 C)은 **채택하지 않는다**; 원한다면 별도 카드다. 근거: `internal/config` 를 건드리지 않으므로 순감소 판정이 문서 변경만을 재고, 새 CI 리스크가 들어오지 않는다.
+
+**D4-3 — 증가 진술 임계값은 1,000 bytes, 단일 편집 기준.** `rule-authoring.md` 의 진술 의무는 **한 번의 편집이 기존 always-loaded 규칙 파일을 1,000 bytes 넘게 늘릴 때** 발화한다. 그 아래면 발화하지 않는다. 누적 델타를 보는 2차 트리거는 두지 않는다. 기각한 두 값: 500 bytes(문단 하나에 발화하고, 너무 잦은 의무는 형식으로 전락한다), 2,000 bytes(800 bytes 급 추가가 반복돼도 걸리지 않는다). 교정 기준 — 오타 ~100 B와 한 줄 추가 ~200 B는 통과, 문단 ~800 B도 통과, 새 HARD 절 ~1,200 B는 발화, 새 `##` 절 ~2,500 B는 발화. spec.md §2의 측정된 성장(기존 5개 파일 합계 +71,347 bytes)에 대면 1,000 bytes 임계는 약 70회 발화에 해당한다.
+
+## §C 근거 재현 명령
+
+가드 공식 재현(이번 세션에서 실행해 baseline 과 정확히 일치함을 확인):
+
+```bash
+tot=0
+for f in $(grep -rL '^paths:' .claude/rules/moai --include='*.md'); do tot=$((tot+$(wc -c < "$f"))); done
+for f in CLAUDE.md .claude/output-styles/moai/moai.md; do tot=$((tot+$(wc -c < "$f"))); done
+[ -f MEMORY.md ] && tot=$((tot+$(head -200 MEMORY.md | head -c 25600 | wc -c)))
+echo "bytes=$tot tokens=$((tot/4)) headroom=$((75000 - tot/4))"
+# baseline 관측: bytes=295044 tokens=73761 headroom=1239
+```
+
+`grep -rL '^paths:'` 는 가드의 frontmatter-내부 판정보다 느슨한 근사다. 현 트리에서는 파일 14개 / 210,753 bytes 로 가드와 동일한 결과를 낸다. **권위 있는 판정은 언제나 `go test ./internal/config/ -run TestAlwaysLoaded`** 이며, 위 스니펫은 그 앞뒤 델타를 보기 위한 보조 계측이다.
+
+구간 바이트 재현(M1 분류의 근거):
+
+```bash
+f=.claude/rules/moai/workflow/kanban-dispatch.md
+stay=0; for r in 1,6 7,12 60,60 93,123 153,175 176,210 211,218 219,230; do stay=$((stay+$(sed -n "${r}p" "$f" | wc -c))); done
+move=0; for r in 13,31 32,43 44,59 61,65 66,92 124,138 139,152; do move=$((move+$(sed -n "${r}p" "$f" | wc -c))); done
+echo "stay=$stay move=$move sum=$((stay+move)) file=$(wc -c < "$f")"
+# 관측(2026-08-16 재실행): stay=12672 move=8331 sum=21003 file=21003
+```
+
+**구간 범위가 더 이상 깨끗한 절 경계와 일치하지 않는다** — REQ-ALD-001 이 지정한 Class B 문단(60행)이 LEAD-ONLY 절 한복판에서 STAY 로 넘어가기 때문이다. 처리 방식은 **스니펫을 다시 짜지 않고 범위만 재유도**하는 쪽을 택했다: STAY 에 `60,60` 을 추가하고, MOVE 의 `44,65` 를 `44,59` 와 `61,65` 로 쪼갰다. 12개였던 범위가 13개가 됐을 뿐 형태는 그대로다.
+
+그 이유는 이 스니펫이 재는 것이 절 구조가 아니라 **분할선의 바이트 귀속**이기 때문이다. 범위 목록은 여전히 1~230행을 빈틈·중복 없이 덮고, 그래서 `sum` 이 파일 총계와 정확히 일치하는 성질이 보존된다 — 이 성질이야말로 분류가 파일 전체를 실제로 덮는지를 판정하는 유일한 기계적 근거다. 절 단위 표현으로 바꾸면 읽기는 쉬워지지만 그 성질을 잃는다.
+
+종전 대비 델타: STAY +495, MOVE −495. 495 bytes 는 60행의 실측 크기다(`sed -n '60p' "$f" | wc -c`). 감사 보고서의 "약 450 B" 는 근사치였고, 아래 투영·코너 케이스는 전부 실측 495 를 쓴다.
+
+## §D 마일스톤
+
+우선순위 라벨만 쓴다(시간 추정 금지). 순서는 M1 → M2 → M3.
+
+### M1 (Priority High) — `kanban-dispatch.md` 분리
+
+1. `kanban-dispatch-detail.md` 생성. D2의 `paths:` + `description:` frontmatter, 그리고 자기 쪽 소유 경계 선언(`goal-directive-detail.md` 도입부 형태).
+2. LEAD-ONLY 6구간을 원본에서 **잘라내어** 컴패니언에 붙인다. 재작성이 아니라 이동이다(REQ-ALD-005).
+3. 단, `Card classes` 안의 Class B 문단(원본 60행)은 컴패니언이 아니라 **STAY 구간 `## Completion is read, never trusted` 로** 옮긴다(REQ-ALD-001). 줄을 쪼개지 말고 통째로 옮긴다 — 쪼개면 AC-ALD-006 이 거짓 실패한다. 옮긴 자리에서 앞뒤 빈 줄이 겹치면 하나로 정리하고(1 byte 수준, 오버헤드 허용 범위), `Card classes` 쪽에는 대체 문장을 **새로 쓰지 않는다**(REQ-ALD-005 — 컴패니언·스텁 어느 쪽도 원본에 없던 내용을 얻지 않는다).
+4. 스텁에 포인터 줄 삽입. 옮긴 6구간을 이름으로 열거하고 과업 형태 트리거를 진술한다("카드를 컬럼 간 이동시키거나 카드 클래스를 판정하거나 리뷰 렌즈를 고를 때 로드").
+5. 스텁 푸터의 `Classification:` 줄 아래 버전 줄에 분리 사실 기록.
+6. 계측: 위 §C 첫 스니펫 재실행 → 델타 확인.
+
+투영: 스텁 12,672 + 컴패니언 8,331 = 21,003 (정확히 원본과 같음). 절감 8,331 B (39.7%)에서 포인터 주석 + 컴패니언 frontmatter 오버헤드 600~900 B 가 되돌아온다 — **추정치이며 측정치가 아니다**(spec.md §5). 종전 투영(12,177 / 8,826 / 42.0%)은 Class B 문단 재배치 이전 값이며 더 이상 유효하지 않다.
+
+순감소 코너 케이스(오버헤드 300~900 B × M2 증가 1,000~2,000 B, 재배치 반영):
+
+| 스텁 오버헤드 | M2 증가 | bytes | tokens | headroom |
+|---|---|---|---|---|
+| +900 | +2,000 | 289,613 | 72,403 | **2,597** |
+| +900 | +1,000 | 288,613 | 72,153 | 2,847 |
+| +300 | +2,000 | 289,013 | 72,253 | 2,747 |
+| +300 | +1,000 | 288,013 | 72,003 | 2,997 |
+
+최악(오버헤드 900 + M2 상한 2,000)에서도 여유는 2,597 토큰으로 baseline 1,239 대비 1,358 토큰의 슬랙을 남긴다. 재배치로 절감이 495 B 줄어 최악값이 2,721 → 2,597 로 내려갔지만 순감소 판정(AC-ALD-001)은 모든 코너에서 성립한다.
+
+리스크: `session-handoff-examples.md` 는 40,891 B 로 부모(23,251)보다 크다. 분리가 축소를 보장하지 않는다는 증거이며, 2단계에서 "정리하면서 살 붙이기"를 하면 그대로 재현된다. 이동 후 스텁+컴패니언 합계가 21,003 ± 오버헤드 범위를 벗어나면 살이 붙은 것이다.
+
+### M2 (Priority High) — G3~G7 편입
+
+1. `cache-aware-execution.md` 에 지시 6~10을 추가. 각각 한 문단, `[ZONE:Evolvable] [HARD]` 접두, 현행 지시 1~5와 같은 **형태**.
+
+   "같은 형태"는 크기가 아니라 모양이다(번호 매김 + 접두 + 한 문단). 크기는 오히려 더 작아야 한다 — 실측하면 현행 1~5는 508/614/490/501/355 B, 합계 2,468 B(평균 494)이고, **그 크기로 다섯 개를 더 쓰면 AC-ALD-011 상한 2,000 B 를 넘겨 FAIL 한다.** 현행 지시가 494 B 인 이유는 근거를 문단 안에 품고 있기 때문이고, 새 지시는 `REQ-ALD-011` 에 따라 근거·수치·예시를 컴패니언으로 보내므로 그보다 작아야 정상이다. 역산한 예산은 **문단당 약 200~400 B**.
+2. `cache-aware-execution-reference.md` 생성. `paths: "**/cache-aware-execution.md"` 최소치에 더해 실제 캐시 관련 작업 경로를 함께 키잉할지는 D2와 같은 판단을 적용한다 — self-keyed 로 둔다(이 파일은 근거 보관용이며 도메인 작업 중 필요하지 않다).
+3. 인용 수치(read 0.1x / write 최대 2x / output ≈ input 5x / TTL 구독 1h·API 5m)는 컴패니언에 두고, **인용 출처값**임을 그 자리에서 명시(REQ-ALD-012).
+4. G7 문단에 D3 해소 문장 + 양쪽 SSOT cross-reference.
+5. 계측: `cache-aware-execution.md` 증가분이 +1,000~2,000 B 안에 드는지 확인(AC-ALD-011). 하한을 1,500 에서 낮춘 이유는 그쪽에 있다 — 다섯 규율을 현행 지시 1~5 형태로 간결하게 쓰면 1,200~1,400 B 로도 다 들어가며, 그때 종전 하한은 **잘 쓴 구현을 거짓 실패시킨다**. 진술 누락 탐지는 AC-ALD-010 의 6개 패턴이 단독으로 맡는다. 상한 2,000 은 순감소 보호에 필요하므로 유지한다.
+
+### M3 (Priority Medium) — 재발 통제
+
+1. `.claude/rules/moai/development/rule-authoring.md` 생성. `paths:` 는 가드 슬롯 전체를 덮는 확장 글롭이다(D1 근거 2).
+
+   ```
+   paths: "**/.claude/rules/**,**/CLAUDE.md,**/.claude/output-styles/**,**/MEMORY.md"
+   ```
+
+2. 내용: (a) 새 always-loaded 파일(= top-level `paths:` 없는 규칙, 그리고 `CLAUDE.md`·output-style 처럼 슬롯 자체인 파일) 생성 시 bytes 와 비용 정당화를 본문에 진술할 것, (b) **한 번의 편집**이 기존 always-loaded 파일을 **1,000 bytes 넘게** 늘릴 때 같은 진술을 할 것, (c) 진술은 **그 파일을 한 번도 필요로 하지 않는 세션이 지불하는 비용**을 다뤄야 함(REQ-ALD-014), (d) `paths:` 스코프로 옮길 수 있는지 먼저 물을 것. (a)~(d) 는 규칙 파일뿐 아니라 가드가 세는 슬롯 4개 전부에 건다 — 규칙 파일만 다루면 표면의 28.6%가 통제 밖에 남는다.
+3. (c)의 근거로 현행 실태를 인용: `session-handoff.md` 가 비용을 이름으로 부르는 가장 가까운 사례이고, `native-idiom-and-register.md` 의 "영어 세션에 부담 zero" 는 동작에 대해 참·컨텍스트 바이트에 대해 거짓이다.
+4. 임계값은 **1,000 bytes, 단일 편집 기준**으로 못박아 쓴다(D4-3). 규칙 본문이 이 값을 읽는 사람에게 납득시키도록 교정 기준을 함께 적는다 — 오타 ~100 B·한 줄 추가 ~200 B·문단 ~800 B는 통과, 새 HARD 절 ~1,200 B·새 `##` 절 ~2,500 B는 발화. 누적 델타를 보는 2차 트리거는 두지 않는다.
+5. M3는 **문서 전용**이다(D4-2). `internal/config` 의 가드 코드와 출력 형식은 손대지 않으며, 이 마일스톤이 만드는 Go 변경은 없다.
+
+### M4 (Priority Medium) — 미러 + 빌드 + 최종 계측
+
+1. 생성·수정 파일 전부를 `internal/template/templates/` 아래 대응 경로에 미러.
+2. `make build`.
+3. 미러본 중립성 확인 — SPEC ID / REQ 토큰 / 내부 날짜 / 커밋 SHA 부재.
+4. `go test ./internal/config/ -run TestAlwaysLoaded` + §C 스니펫 재실행 → **여유 > 1,239** 확인(REQ-ALD-015). 이때 관측된 여유 값을 progress.md 에 기록한다 — 예산 상수 하향을 판단할 별도 백로그 카드의 입력이 되는 값이다(D4-1). 이 SPEC 안에서 `AlwaysLoadedTokenBudget` 은 바꾸지 않는다.
+
+## §E 리스크
+
+| # | 리스크 | 완화 |
+|---|---|---|
+| R1 | 컴패니언이 적치장이 됨 | M1 이동 후 합계 바이트를 원본과 대조(AC-ALD-009) |
+| R2 | 스텁에서 안전 관련 HARD 절이 사라짐 | 이동 전후 HARD 절 grep 대조(AC-ALD-004) |
+| R3 | M2 증가가 M1 절감을 상쇄 | 순감소를 단일 종료 조건으로 고정(AC-ALD-001) |
+| R4 | 미러 누락으로 배포본 깨짐 | M4에서 파일별 대조 + `make build` |
+| R5 | `paths:` 부착이 예상과 다르게 동작 | 관측 불가(spec.md §5). 부착 실패 시 최악의 결과는 "컴패니언이 안 붙음"이며 스텁이 모든 구속 절을 갖고 있으므로 안전 실패다 — 이것이 REQ-ALD-001의 존재 이유 |
+| R6 | 병렬 세션이 같은 체크아웃에서 규칙 파일을 편집 | 워크트리 격리 + 명시 pathspec 스테이징(§F) |
+
+## §F 제약
+
+- **PR 필수**: 이 리포는 `main` 이 `enforce_admins: true` 로 보호돼 있어 Route A(main 직행)가 불가하다. Tier M이라도 feature 브랜치 + PR 로 간다(`.claude/rules/local/repo-local-pr-policy.md`).
+- **브랜치 상태 변경 금지**: primary 체크아웃에서 `git switch` / `git branch` / `git stash` 금지. 격리는 `moai cc -w <name>` 로 진입하고 `moai worktree done` 으로 폐기한다.
+- **스테이징은 명시 pathspec**: `git add -A` / `git add .` / `git commit -a` 금지.
+- **Template-First**: `.claude/` 하위 신규 파일은 템플릿 소스에 먼저 넣고 `make build` 후 로컬 동기화. 단 미러본은 중립화가 필요한 sanitized-pair 일 수 있으므로 **`cp` 로 통째 복사하지 않는다**.
+- **로컬 전체 스위트 금지**: `go test ./...` 대신 영향 패키지(`./internal/config/`)만 돌리고 전 패키지 판정은 CI에 맡긴다.
+- **plan-phase 커밋 제목은 `feat(` 접두**: `docs(` 를 쓰면 generic docs 로 오분류돼 `StatusGitConsistency` 경고가 상존한다.
+
+## §G Anti-patterns
+
+- **AP-1 — 분리를 축소로 착각.** 파일을 둘로 나누는 것 자체는 always-loaded 표면을 줄이지 않는다. 컴패니언에 `paths:` 가 붙어야 줄어든다. `session-handoff-examples.md` 가 반례다.
+- **AP-2 — "정리하는 김에" 문장 다듬기.** 이동은 이동이다. 살이 붙으면 R1이 현실화되고 AC-ALD-009가 실패한다.
+- **AP-3 — 공백 압축으로 바이트 줄이기.** 금지. 감축은 내용 이동으로만 얻는다.
+- **AP-4 — self-keyed 컴패니언을 domain-keyed 라 부르기.** 키 문자열이 부모 규칙 파일만 가리키면 실제 kanban 작업 중에는 붙지 않는다. D2 표가 이 구분의 근거다.
+- **AP-5 — 인용 수치를 실측치처럼 서술.** M2의 배수·TTL은 원문 인용이다(REQ-ALD-012).
+- **AP-6 — M3를 always-loaded 파일에 넣기.** 재발 통제가 스스로 재발 원인이 된다. `paths:` 스코프가 필수다.
+
+## §H Cross-references
+
+- `internal/config/token_budget_guard.go` / `token_budget_guard_test.go` — 가드 구현과 트립와이어
+- `.claude/rules/moai/workflow/goal-directive.md` + `goal-directive-detail.md` — 스텁/컴패니언 분리 선례
+- `.claude/rules/moai/workflow/kanban-dispatch.md` — M1 대상
+- `.claude/rules/moai/workflow/cache-aware-execution.md` — M2 대상
+- `.claude/rules/moai/core/agent-common-protocol.md` § Per-Spawn Model Injection — D3의 한쪽 축
+- `.claude/rules/moai/workflow/context-window-management.md` § Reduction Ladder — G6가 붙는 자리
+- `SPEC-V3R6-RULES-PATH-SCOPE-001` — 이전 다이어트(재발의 기준점)
+- `.claude/rules/local/repo-local-pr-policy.md` — 전 Tier PR 필수

--- a/.moai/specs/SPEC-ALWAYS-LOADED-DIET-001/progress.md
+++ b/.moai/specs/SPEC-ALWAYS-LOADED-DIET-001/progress.md
@@ -8,7 +8,7 @@
 - AC count: 16 / 16 (Tier M ceiling)
 - open items: none — the 3 former plan.md §D4 open questions are resolved by user decision (budget ratchet deferred to a separate backlog card; M3 control is documentation-only, no Go change; growth-statement threshold = 1,000 bytes per single edit). See plan.md §D4-1..D4-3.
 - baseline observed (2026-08-16): `files=14 bytes=295044 tokens=73761 headroom=1239`; `go test ./internal/config/ -run TestAlwaysLoaded` → ok
-- plan_complete_at: 2026-08-17
+- plan_complete_at: 2026-08-17 (산출물 커밋 be1958a4d, 2026-08-17 00:32 +0900 — 실제 실행일)
 - plan_audit: iter1 FAIL 0.73 (8 blocking) → iter2 **PASS 0.845** vs Tier M threshold 0.80 (Clarity 0.85 / Completeness 0.88 / Testability 0.75 / Traceability 0.92); re-audit ceiling (Tier M = 2) reached, no iter3
 - plan_audit reports: `.moai/reports/plan-audit/SPEC-ALWAYS-LOADED-DIET-001-review-{1,2}.md`
 - iter2 blocking 3 applied orchestrator-direct (auditor's own recommendation — local shell edits, ~15 lines):
@@ -16,7 +16,8 @@
   - D2 six AC touched files with no existence guard, breaching this document's own §A trap rule 6. `AC-ALD-006` actually PASSed (`missing_lines=0`). Guards added to AC-ALD-004/005/006/008/009/013; `AC-ALD-006` re-run → exit 1.
   - D3 `REQ-ALD-013` claimed all four guard slots while the glob covered three. `,**/MEMORY.md` added (13 chars, zero always-loaded cost) in spec.md §3.3 + plan.md D1/M3. Rationale: the guard counts that slot conditionally, so a future repo-root `MEMORY.md` would admit up to `memoryHeadByteCap` 25,600 B (~6,400 tokens) unstated — larger than the worst-corner headroom of 2,597 tokens.
 - post-fix verification (this tree): `moai spec lint …/spec.md` → `✓ No findings`, exit 0; REQ 16 / AC 16 unchanged
-- NOT committed: the SPEC directory is untracked. Committing is gated on the repo-local all-tier PR policy (`main` is protected with `enforce_admins: true`), so a branch + PR is required and branch creation is blocked in the primary checkout.
+- repository state (2026-08-17 갱신): 산출물 4개는 커밋됨 — 브랜치 `spec-always-loaded-diet-plan` 의 `be1958a4d`, PR #1576 에 포함. 리포 로컬 all-tier PR 정책은 브랜치+PR 로 충족했고 머지 대기.
+- revision (2026-08-17): PR #1576 CodeRabbit 인라인 리뷰의 🟠 Major 5건 반영 — acceptance.md(§A 규율 4 + `headroom` frontmatter 한정, AC-ALD-006 `BASE_REF` 고정 + `sort -u` 제거, AC-ALD-013 문단 스코프 인용 판정, AC-ALD-014 슬롯 4개 단언)과 progress.md 본 기록. 🟡 Minor 4건·🔵 Trivial 2건은 사용자 결정으로 이번 개정 범위 밖.
 - Implementation Kickoff Approval (plan→run) has NOT been requested or granted.
 
 ## §E.2 Run-phase Evidence

--- a/.moai/specs/SPEC-ALWAYS-LOADED-DIET-001/progress.md
+++ b/.moai/specs/SPEC-ALWAYS-LOADED-DIET-001/progress.md
@@ -1,0 +1,32 @@
+# Progress — SPEC-ALWAYS-LOADED-DIET-001
+
+## §E.1 Plan-phase Audit-Ready Signal
+
+- plan_status: audit-ready
+- tier: M (3 artifacts: spec.md + plan.md + acceptance.md)
+- REQ count: 16 / 16 (Tier M ceiling)
+- AC count: 16 / 16 (Tier M ceiling)
+- open items: none — the 3 former plan.md §D4 open questions are resolved by user decision (budget ratchet deferred to a separate backlog card; M3 control is documentation-only, no Go change; growth-statement threshold = 1,000 bytes per single edit). See plan.md §D4-1..D4-3.
+- baseline observed (2026-08-16): `files=14 bytes=295044 tokens=73761 headroom=1239`; `go test ./internal/config/ -run TestAlwaysLoaded` → ok
+- plan_complete_at: 2026-08-17
+- plan_audit: iter1 FAIL 0.73 (8 blocking) → iter2 **PASS 0.845** vs Tier M threshold 0.80 (Clarity 0.85 / Completeness 0.88 / Testability 0.75 / Traceability 0.92); re-audit ceiling (Tier M = 2) reached, no iter3
+- plan_audit reports: `.moai/reports/plan-audit/SPEC-ALWAYS-LOADED-DIET-001-review-{1,2}.md`
+- iter2 blocking 3 applied orchestrator-direct (auditor's own recommendation — local shell edits, ~15 lines):
+  - D1 `AC-ALD-009` passed with no companion (`wc -c` failure → empty → bash arithmetic 0 → `sum` equals the original 21,003, which is exactly the PASS lower bound). Fixed with `test -f` + `companion >= 1`. Re-run on the untouched tree → `MISSING …detail.md`, exit 1.
+  - D2 six AC touched files with no existence guard, breaching this document's own §A trap rule 6. `AC-ALD-006` actually PASSed (`missing_lines=0`). Guards added to AC-ALD-004/005/006/008/009/013; `AC-ALD-006` re-run → exit 1.
+  - D3 `REQ-ALD-013` claimed all four guard slots while the glob covered three. `,**/MEMORY.md` added (13 chars, zero always-loaded cost) in spec.md §3.3 + plan.md D1/M3. Rationale: the guard counts that slot conditionally, so a future repo-root `MEMORY.md` would admit up to `memoryHeadByteCap` 25,600 B (~6,400 tokens) unstated — larger than the worst-corner headroom of 2,597 tokens.
+- post-fix verification (this tree): `moai spec lint …/spec.md` → `✓ No findings`, exit 0; REQ 16 / AC 16 unchanged
+- NOT committed: the SPEC directory is untracked. Committing is gated on the repo-local all-tier PR policy (`main` is protected with `enforce_admins: true`), so a branch + PR is required and branch creation is blocked in the primary checkout.
+- Implementation Kickoff Approval (plan→run) has NOT been requested or granted.
+
+## §E.2 Run-phase Evidence
+
+_<pending run-phase>_
+
+## §E.3 Run-phase Audit-Ready Signal
+
+_<pending run-phase>_
+
+## §E.4 Sync-phase Audit-Ready Signal
+
+_<pending sync-phase>_

--- a/.moai/specs/SPEC-ALWAYS-LOADED-DIET-001/spec.md
+++ b/.moai/specs/SPEC-ALWAYS-LOADED-DIET-001/spec.md
@@ -1,0 +1,138 @@
+---
+id: SPEC-ALWAYS-LOADED-DIET-001
+title: "always-loaded 컨텍스트 표면 다이어트 + 캐시 규율 편입 + 재발 통제"
+version: "0.1.1"
+status: draft
+created: 2026-08-16
+updated: 2026-08-17
+author: manager-spec
+priority: P1
+phase: "v3.2.0 target"
+module: ".claude/rules/moai/workflow, internal/config, internal/template/templates/.claude/rules/moai"
+lifecycle: spec-anchored
+tags: "always-loaded, token-budget, context-diet, prompt-cache, rule-split, recurrence-control"
+tier: M
+era: V3R6
+related_specs: [SPEC-V3R6-RULES-PATH-SCOPE-001, SPEC-TOKEN-EFFICIENCY-001]
+---
+
+# SPEC: always-loaded 컨텍스트 표면 다이어트 + 캐시 규율 편입 + 재발 통제
+
+## 1. 문제 — 측정된 형태
+
+Claude Code는 매 턴 always-loaded 컨텍스트 표면을 다시 주입하고, `/clear` 이후에는 그 전량을 다시 지불한다. 이 표면에는 이미 기계적 가드가 걸려 있다.
+
+- `internal/config/token_budget_guard.go:26` — `const AlwaysLoadedTokenBudget = 75000`
+- `internal/config/token_budget_guard_test.go:53` — `TestAlwaysLoadedTokenBudget`. 표면이 예산을 넘으면 빌드가 깨진다.
+- 가드가 재는 슬롯은 4개다: `.claude/rules/moai/**` 중 top-level `paths:` frontmatter 키가 **없는** 규칙 파일 전체 + `CLAUDE.md` + `.claude/output-styles/moai/moai.md` + `MEMORY.md` head. 토큰 추정은 char/4.
+
+2026-08-16 실측(가드 자체의 공식을 그대로 재현):
+
+| 슬롯 | bytes |
+|---|---|
+| no-`paths:` 규칙 14개 | 210,753 |
+| `CLAUDE.md` | 19,040 |
+| `.claude/output-styles/moai/moai.md` | 65,251 |
+| `MEMORY.md` head (리포 루트에 부재) | 0 |
+| 합계 | 295,044 → 추정 73,761 토큰 |
+
+**남은 여유: 1,239 토큰 ≈ 4,956 bytes (1.65%).** `go test ./internal/config/ -run TestAlwaysLoaded` 는 이번 세션에서 실제로 실행해 `ok github.com/modu-ai/moai-adk/internal/config 0.422s` 를 확인했다 — 지금은 통과한다.
+
+문제는 여유의 폭이다. 가장 최근 always-loaded 규칙 추가 3건은 각각 6,200 bytes(`moai-mcp-tools.md`, 2026-08-13), 21,003 bytes(`kanban-dispatch.md`, 2026-08-14), 12,608 bytes(`cross-session-messaging.md`, 2026-08-15)였다. **셋 중 어느 것도 현재 여유 안에 들어가지 않는다.** 통상 크기의 규칙이 하나만 더 들어오면 빌드가 깨진다.
+
+## 2. 이것은 첫 청소가 아니라 재발이다
+
+`SPEC-V3R6-RULES-PATH-SCOPE-001`(status: implemented, created 2026-05-22)이 always-loaded 규칙을 9개에서 5개로 줄였다. 그 직후 커밋 `09d905bda57ed2537ac98aeefd22e2652719a482` 기준과 현재를 비교하면:
+
+- 당시: 5개 파일, 53,299 bytes
+- 현재: 14개 파일, 210,753 bytes — **3.95배, 약 3개월 만에 +157,454 bytes**
+- 분해: 기존 5개의 자체 증가 +71,347 (45.3%) / 신규 9개 유입 +86,107 (54.7%)
+
+원래 5개의 파일별 증가:
+
+| 파일 | 당시 | 현재 | 증가 |
+|---|---|---|---|
+| `agent-common-protocol.md` | 15,868 | 39,455 | +23,587 |
+| `askuser-protocol.md` | 11,603 | 30,154 | +18,551 |
+| `session-handoff.md` | 8,963 | 23,251 | +14,288 |
+| `context-window-management.md` | 4,328 | 13,009 | +8,681 |
+| `moai-constitution.md` | 12,537 | 18,777 | +6,240 |
+
+읽는 방식이 중요하다. 유입(54.7%)과 자체 증가(45.3%)가 거의 반반이므로, "새 파일을 막는" 통제만으로도 "기존 파일을 줄이는" 작업만으로도 재발을 못 막는다. 그리고 한 번의 정리는 그 자체로는 아무 것도 남기지 않는다 — 재발 통제 없는 다이어트는 위 표를 3개월 뒤에 다시 만들어낸다. 이 SPEC이 M3를 포함하는 이유다.
+
+## 3. 요구사항 (GEARS)
+
+각 요구사항 뒤 괄호는 GEARS 패턴을 가리킨다.
+
+### 3.1 M1 — `kanban-dispatch.md` 분리
+
+- **REQ-ALD-001** (Ubiquitous) — `kanban-dispatch.md` 스텁은 BINDING-EVERYWHERE로 분류된 7개 구간(제목+서문+Loading-scope, `Scope`, `Completion is read, never trusted`(하위 `CodeRabbit` 포함), `Isolation is entered, never provisioned`, `Verification load is lane-local`(하위 `env-isolated verification form` 포함), `Boundaries`, `Cross-references`+푸터)을 인라인으로 보유해야 한다. 분류 술어는 "이 구간이 kanban lead가 **아닌** 세션도 구속하는가"이며, 위 7개는 모두 참이다.
+  술어는 **구간 단위가 아니라 문단 단위로** 적용한다. 그렇게 적용하면 LEAD-ONLY 구간 안에서 반례가 정확히 1건 나온다 — `Card classes` 안의 Class B 문단(분리 이전 원본 60행, **495 bytes 실측**)은 주어가 `the run session` 이라 술어가 참이다("the evidence that established the cause ... is written into the card's progress record, and the run session names that path in its completion report"). 따라서 이 문단도 스텁이 보유해야 하며, 자리는 STAY 구간 `Completion is read, never trusted` 다(주제도 그쪽이 맞다 — 증거를 읽는 규율). 재배치는 **줄 단위 통째 이동**이며 문단을 쪼개지 않는다: 쪼개면 원본의 그 줄이 어느 파일에도 그대로 남지 않아 내용 보존 판정(AC-ALD-006, 비어있지 않은 줄 집합 대조)이 거짓 실패한다.
+- **REQ-ALD-002** (Ubiquitous) — 신설 `kanban-dispatch-detail.md` 는 LEAD-ONLY 6개 구간(`The board`, `Entry into the board is an operator act`, `Card classes`(단 REQ-ALD-001 이 지정한 Class B 문단 1줄 제외), `The dispatch cycle`(하위 `Dispatch language` 포함), `Review lens selection`, `The /clear handoff between phases`)을 받아야 하며, 스텁과 컴패니언의 합집합은 분리 이전 원본의 내용을 빠짐없이 덮어야 한다.
+- **REQ-ALD-003** (Ubiquitous) — `kanban-dispatch-detail.md` 의 frontmatter `paths:` 는 **domain-keyed** 형태여야 한다. 즉 부모 규칙 파일만 가리키는 self-keyed(`**/kanban-dispatch*.md` 단독)가 아니라, 실제 kanban 작업 중에도 붙는 도메인 경로를 함께 키로 가져야 한다. `goal-directive-detail.md` 가 유일한 domain-keyed 선례다.
+- **REQ-ALD-004** (Ubiquitous) — 분리는 `goal-directive.md` 선례의 3요소를 갖춰야 한다: (a) 스텁의 포인터 줄이 **옮겨진 구간을 이름으로 열거**하고 과업 형태의 로드 트리거를 진술한다, (b) 컴패니언이 자기 쪽에서 소유 경계를 선언한다, (c) 스텁 푸터의 버전 줄이 분리 사실을 기록한다.
+- **REQ-ALD-005** (unwanted) — 컴패니언은 분리 과정에서 원본에 없던 내용을 새로 획득해서는 안 된다(`shall not`). 근거: `session-handoff-examples.md` 는 40,891 bytes 로 부모 `session-handoff.md`(23,251)보다 **크다** — 분리는 축소와 같지 않으며, 컴패니언은 적치장이 되기 쉽다.
+
+### 3.2 M2 — G3~G7 규율을 `cache-aware-execution.md` 로 편입
+
+편입 대상은 `cache-aware-execution.md`(현재 4,497 bytes)다. 이미 prompt-cache와 실행 순서 지시를 소유하고 있어 주제가 맞고, **새 always-loaded 파일을 만들지 않는다**는 점이 결정적이다.
+
+- **REQ-ALD-006** (Ubiquitous) — 파일 내용을 프롬프트에 끌어올 때 파일명을 인용해 모델이 읽게 하는 대신 `@`-멘션으로 넘기는 규율, 그리고 `/context` 를 1회성 감사 수단으로 쓰는 규율을 HARD 지시로 보유해야 한다. (실측 갭: 두 규율 모두 `.claude/rules/` + `CLAUDE.md` 전체에서 매치 0개.)
+- **REQ-ALD-007** (Ubiquitous) — 일반 명령 출력 규율을 보유해야 한다. 현재 `agent-common-protocol.md` 의 file-redirect 계약(50줄 / 2KB)은 **검증 배치에만** 걸려 있고, `BASH_MAX_OUTPUT_LENGTH`(30,000자 임계)는 규칙 파일에 0회 등장한다.
+- **REQ-ALD-008** (Ubiquitous) — 상용 명령을 조용한 형태(quiet form)로 부르는 규율을 보유해야 한다. 실측 갭: 규칙 내 "quiet" 매치 2건은 모두 영어 형용사 용법("quiet and expensive", "the race is quiet")이며 규율이 아니다.
+- **REQ-ALD-009** (Ubiquitous) — 세션 길이를 비용 축으로 다루는 진술을 보유해야 한다. `context-window-management.md` 는 `/clear` 가 always-loaded 프리픽스를 다시 지불한다는 사실은 이미 적고 있으나(line 47), **긴 세션 하나가 짧은 세션 여럿보다 싸다**는 진술은 어디에도 없다(매치 0개).
+- **REQ-ALD-010** (Event-driven) — **When** 세션 도중 모델 또는 effort 를 바꾸려 할 때, 그 변경이 prompt cache 를 파기한다는 사실을 진술해야 한다(`MAX_THINKING_TOKENS` 는 규칙 파일에 0회 등장). 아울러 겉보기 충돌 2건을 같은 자리에서 해소해야 한다: `agent-common-protocol.md` § Per-Spawn Model Injection(스폰마다 모델을 명시하라)과 `cache-aware-execution.md` 지시 5(세션 모델을 상속하라)는 **서로 다른 축**이다 — 전자는 서브에이전트 컨텍스트, 후자는 메인 세션이다. 모순으로 읽히게 방치해서는 안 된다.
+- **REQ-ALD-011** (Ubiquitous) — HARD 지시 본문만 `cache-aware-execution.md` 에 압축해 인라인으로 두고, 근거·수치·예시는 신설 `cache-aware-execution-reference.md` 로 보내야 한다. 신설 파일은 `paths:` 를 가져 always-loaded 표면에 계상되지 않아야 한다.
+- **REQ-ALD-012** (Ubiquitous) — M2가 인용하는 캐시 배수·TTL(read 0.1x, write 최대 2x, output ≈ input 5x, TTL 구독 1시간 / API 키 5분)은 원문 인용이며 이번 세션에서 재측정하지 않았다. 문서에 **인용 출처값**임을 명시해야 하며 측정치로 서술해서는 안 된다.
+
+### 3.3 M3 — 재발 통제
+
+- **REQ-ALD-013** (Ubiquitous) — 다음 always-loaded 추가가 **자기 비용을 진술하도록** 강제하는 통제 장치 하나를 채택해 구현해야 한다. 채택된 통제는 **작성 규칙(문서 전용)** 이며, 신규 always-loaded 파일 생성과 기존 always-loaded 파일의 증가 **양쪽**에 진술 의무를 건다. 이 통제는 문서만으로 성립하고 Go 변경을 수반하지 않는다. 후보 3개(작성 규칙 / 예산 하향 / 여유 보고 가드)의 평가와 이 선택의 근거는 plan.md D1이 소유하며, 셋을 모두 구현하지는 않는다.
+  적용 범위는 **가드가 세는 슬롯 4개 전부**다. 통제의 `paths:` 글롭이 `.claude/rules/moai/**` 의 규칙 파일 + `CLAUDE.md` + `.claude/output-styles/**` + `MEMORY.md` 에 모두 붙어야 한다. 네 번째 슬롯을 "리포 루트에 파일이 없어 기여 0" 이라는 **현재 시제 사실**로 면제해서는 안 된다 — 통제는 미래 시제이고, 가드는 이 슬롯을 조건부로(`[ -f MEMORY.md ] && …`) 세므로 파일이 생기는 순간 최대 `memoryHeadByteCap` 25,600 bytes(약 6,400 토큰)가 진술 의무 없이 표면에 편입된다. 그 값은 이번 다이어트의 최악 코너 여유 2,597 토큰보다 크다(감사 iter2 D3). 글롭에 13자를 더하는 비용이 0 이므로 면제할 이유가 없다. 규칙 파일만 키잉하면 도달률이 **71.4%** 에 그친다: `CLAUDE.md`(19,040)와 `.claude/output-styles/moai/moai.md`(65,251)의 합계 84,291 bytes 가 295,044 중 **28.6%** 이고, `moai.md` 는 단일 파일로는 표면 최대 기여자다(규칙 1위 `agent-common-protocol.md` 39,455 의 1.65배). 통제 파일 자신이 `paths:` 를 갖기 때문에 이 확장의 always-loaded 비용은 0 이다.
+- **REQ-ALD-014** (Ubiquitous) — 그 통제는 "그 파일을 한 번도 필요로 하지 않는 세션이 지불하는 비용"을 명시적으로 다뤄야 한다. 진술 의무를 지는 대상은 규칙 파일에 한정되지 않고 REQ-ALD-013 이 열거한 가드 슬롯 4개 전부다. 근거: 현재 always-loaded 파일 중 어느 것의 정당화도 이 비용을 다루지 않는다. `session-handoff.md` 가 비용을 이름으로 부른다는 점에서 가장 가깝고, `native-idiom-and-register.md` 는 "영어 세션에 부담 zero"라고 적는데 이는 **동작에 대해서는 참이고 컨텍스트 바이트에 대해서는 거짓**이다.
+
+### 3.4 전 마일스톤 공통
+
+- **REQ-ALD-015** (Ubiquitous) — 이 SPEC의 구속 조건은 **순감소**다. M1은 표면을 줄이고 M2는 늘리므로, 종료 판정은 개별 마일스톤이 아니라 가드 여유의 전후 비교로 한다: 완료 후 여유가 baseline 1,239 토큰보다 **엄격히 커야** 한다.
+- **REQ-ALD-016** (Ubiquitous) — 생성·수정된 모든 규칙 파일은 `internal/template/templates/.claude/rules/moai/` 아래에 미러돼야 하고, `make build` 를 돌려야 하며, 미러본은 중립성을 유지해야 한다(SPEC ID, REQ 토큰, 내부 날짜, 커밋 SHA 금지). always-loaded 14개는 이번 세션에 미러 존재를 확인했다.
+
+### 3.5 Out of Scope
+
+#### Out of Scope — 다른 다이어트 후보
+
+- `agent-common-protocol.md`(39,455), `askuser-protocol.md`(30,154), `session-handoff.md`(23,251) 등 나머지 대형 always-loaded 파일의 분리. 사용자가 이번 범위를 `kanban-dispatch.md` 하나로 확정했다.
+- `CLAUDE.md`(19,040)와 `.claude/output-styles/moai/moai.md`(65,251) **축소**. 가드 슬롯이지만 규칙 파일이 아니며 별도 소관이다. 범위 밖인 것은 **이번에 바이트를 줄이는 작업**뿐이다 — M3 재발 통제는 이 두 슬롯에도 붙는다(REQ-ALD-013). 통제와 축소는 다른 일이고, 통제의 사각지대는 이번 다이어트가 끝난 뒤 성장이 그 두 슬롯으로 흘러들어도 아무 신호가 나지 않음을 뜻하기 때문이다.
+- `MEMORY.md` 정리. 리포 루트에 파일이 없어 현재 슬롯 기여가 0이다.
+
+#### Out of Scope — 가드 자체의 재설계
+
+- char/4 추정을 실제 tokenizer 로 교체하는 것. 가드는 상대 증가 감시용 트립와이어이며, 의존성 추가는 `token_budget_guard.go` 주석이 명시적으로 배제한다.
+- `paths:` 글롭 부착 동작의 검증. 이는 Claude Code 런타임 소관이며 이 리포에 구현이 없다.
+
+#### Out of Scope — 신규 always-loaded 파일
+
+- M2가 새 always-loaded 규칙 파일을 만드는 선택지. 편입 대상을 기존 `cache-aware-execution.md` 로 고정한 것은 사용자 확정 사항이다.
+
+#### Out of Scope — 이번에 내리지 않는 결정
+
+- `AlwaysLoadedTokenBudget`(현 75,000)의 하향. 상수는 전 구간에서 유지하고, M4는 착지 후 여유를 측정해 기록만 한다. 그 기록값을 입력으로 삼아 상수를 낮출지는 **별도 백로그 카드**가 판단한다. 순감소 AC("완료 후 여유 > 완료 전 여유")의 기준이 되는 상수를 같은 SPEC 안에서 함께 움직이지 않기 위한 확정 사항이다(plan.md D4-1).
+- M3 재발 통제의 Go 변경. 통제는 문서 전용이며 `internal/config` 의 가드 코드와 출력 형식은 손대지 않는다. 가드가 pass/fail 대신 현재 여유를 함께 보고하도록 바꾸는 안(plan.md D1 후보 C)은 채택하지 않는다(plan.md D4-2).
+
+## 4. 사용자 확정 결정 (재논의 금지)
+
+1. **하나의 SPEC, 세 마일스톤, 순감소를 구속 기준으로.** 두 방향(축소/증가)이 한 SPEC 안에서 상쇄되므로 AC는 "완료 후 여유 > 완료 전 여유"다.
+2. **다이어트 대상은 `kanban-dispatch.md` 하나.** 다른 후보는 이번에 손대지 않는다.
+3. **G3~G7은 `cache-aware-execution.md` 에 압축 HARD 지시로, 근거는 신설 `paths:`-스코프 컴패니언으로.** 새 always-loaded 파일은 만들지 않는다.
+
+## 5. 미검증 항목 (Gaps)
+
+이 SPEC의 근거 중 아래 항목은 **측정되지 않았거나 추정**이다. 덮지 않고 남긴다.
+
+- **토큰 수치는 char/4 추정이다.** 가드 자신의 공식이며 `token_budget_guard.go` 주석이 실제 tokenizer 대비 ±약 15% 오차를 문서화하고 있다. `/context` 는 한 번도 실행하지 않았다.
+- **`paths:` 글롭 부착 동작은 Claude Code 런타임 소관이며 이 리포에 구현이 없다.** self-keyed 대 domain-keyed 구분은 글롭 문자열을 읽고 **추론**한 것이지 실제 부착을 관측한 것이 아니다.
+- **분리 후 되돌아오는 오버헤드(600~900 bytes)는 `goal-directive.md` 선례에서 뽑은 추정치**이며 측정치가 아니다. 포인터 주석 + 컴패니언 frontmatter 분량을 가리킨다.
+- **M2의 캐시 배수와 TTL은 원문 인용이며 여기서 재현하지 않았다** (REQ-ALD-012가 이 사실의 문서 명기를 요구한다).
+- **기존 5개 파일의 2026-05-22 시점 크기는 커밋 `09d905bda57ed2537ac98aeefd22e2652719a482` 기준 1회 측정치**다. 그 사이 어떤 커밋이 어떤 몫을 더했는지는 분해하지 않았다.
+- **M3 진술 의무의 임계값 1,000 bytes 는 선택한 값이지 측정에서 유도한 값이 아니다.** 위 §2의 성장 수치(기존 5개 파일 합계 +71,347 bytes, 파일별 +6,240 ~ +23,587)에 대고 교정했을 뿐이며, 거기서 나온 "약 70회 발화"도 그 수치를 임계값으로 나눈 추정이다. 실제 발화 빈도는 앞으로의 편집 크기 분포에 달려 있어 관측되지 않았다.
+- **1,000 bytes 단일 편집 임계는 그 아래로 반복되는 증분 성장을 통제하지 못한다.** 측정된 +71,347 bytes 는 999 bytes 편집 71회로 **발화 0회** 재현이 가능하다(파일별 23/18/14/8/6회). 위 "약 70회 발화" 추정은 모든 편집이 1,000 bytes **이상**이라는 미관측 가정 위에서만 성립한다. 그리고 §2가 성장의 45.3%를 "기존 파일의 자체 증가"로 분해하는데, 자체 증가야말로 작은 증분으로 도착할 가능성이 가장 높은 모드다. 누적 델타를 보는 2차 트리거를 두지 않는 것은 확정 사항이며(plan.md D4-3), 이 사각지대는 **감수하는 잔여 위험**이다.
+- **`CLAUDE.md` 40,000자 규율이 기계적으로 강제되는지는 확인하지 않았다.** `.claude/rules/moai/development/coding-standards.md:25` 는 그 한도를 "any project-local instruction file that also loads in full at every session launch" 로 확장해 적고 있고, 그 기준을 그대로 대면 `moai.md`(65,251)는 25,251 초과다. 다만 같은 줄이 스스로를 "CI-**enforceable** heuristic"(강제 가능한 발견법)이라 부를 뿐 강제된다고 하지 않으며, `internal/config` 에서 40,000 리터럴은 무관한 `DefaultSyncTokens` 로만 나온다. 따라서 이는 **미검증 관찰**이지 작동 중인 통제가 아니다.


### PR DESCRIPTION
## Summary
- Lands the plan-phase artifacts of **SPEC-ALWAYS-LOADED-DIET-001** (always-loaded rule diet for session launch context) on main
- Adds exactly 4 SPEC documents: `spec.md`, `plan.md`, `acceptance.md`, `progress.md` (834 lines total, pure addition)

## What / Why
The always-loaded rule footprint has regrown from 5 to 14 files (3.95x over 3 months), leaving the always-loaded byte-budget guard with only 1,239 tokens (1.65%) of headroom at session launch. This SPEC plans the diet that reverses the growth.

## Audit Verdict
- Plan audit: **iter2 PASS, score 0.845** (independent plan-auditor; iter1 FAIL at 0.73 was addressed and re-audited)
- `acceptance.md` carries **13 D2 audit-guard preconditions**

## Scope Note
- 4 SPEC doc files only — docs-only change; the CI paths-filter skips the Go test suite by design for this path set
- No runtime state files included (stray `.moai/state/` subdirectory at the source location was excluded on purpose — out of scope)

## Checklist
- [x] Commit follows Conventional Commits format
- [x] No secrets committed
- [x] No code changes (docs-only)

SPEC: SPEC-ALWAYS-LOADED-DIET-001
Phase: PLAN

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a draft specification for reducing always-loaded context and improving prompt-cache and output-handling guidance.
  - Documented requirements for restructuring dispatch guidance, adding companion references, and controlling future documentation growth.
  - Added an implementation plan with milestones, measurements, risks, and repository constraints.
  - Added acceptance criteria covering budget reduction, content preservation, build validation, traceability, and recurrence controls.
  - Added progress tracking with baseline measurements, completed audits, verification results, and remaining work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->