### PR TITLE
feat(spec): SPEC-ALWAYS-LOADED-DIET-001 run-phase implementation (M1-M4)

### DIFF
--- a/.claude/rules/moai/development/rule-authoring.md
+++ b/.claude/rules/moai/development/rule-authoring.md
@@ -1,0 +1,55 @@
+---
+description: "Always-loaded surface recurrence control — statement duty on creating a new slot file and on any single edit growing one by more than 1,000 bytes"
+paths: "**/.claude/rules/**,**/CLAUDE.md,**/.claude/output-styles/**,**/MEMORY.md"
+---
+
+# Rule Authoring — Always-Loaded Cost Discipline
+
+> Loading scope: this rule keys the four guard slots themselves. Any edit that creates or grows an always-loaded file is the moment this discipline attaches — including edits to this repository's `CLAUDE.md`, its output styles, and `MEMORY.md`.
+
+## The surface and its four slots
+
+Claude Code re-injects the always-loaded surface on every turn, and `/clear` re-pays all of it at once. The surface is made of four slots:
+
+1. Rule files under `.claude/rules/` that lack a top-level `paths:` frontmatter key
+2. `CLAUDE.md`
+3. Output styles under `.claude/output-styles/`
+4. `MEMORY.md` (head)
+
+Rule files are not the whole surface. `CLAUDE.md` and the output styles together can outweigh every rule file, and the largest single contributor is an output style, not a rule. A duty that binds rule files only leaves the biggest share of the surface unwatched — every clause below therefore binds all four slots.
+
+## Why a cleanup is not enough
+
+A one-time diet does not stay done. In the repository this rule set ships from, the always-loaded rule surface grew roughly 4x in the three months after the previous reduction — and about half of that growth was existing files expanding in place, not new files arriving. Blocking new files alone blocks half the recurrence; the duty below covers both modes.
+
+## The statement duty
+
+[ZONE:Evolvable] [HARD] The duty has four parts, binding all four slots:
+
+- **(a) New file.** Creating a new always-loaded file — a rule file without top-level `paths:`, or a slot file such as `CLAUDE.md` or an output style — requires stating the file's byte size and a cost justification in the change description (commit body, or PR description where the change rides a PR).
+- **(b) Growth.** A single edit that grows an existing always-loaded file by more than 1,000 bytes requires the same statement, sized to the growth rather than the whole file.
+- **(c) Non-invoking cost.** Whatever statement (a) or (b) requires must address the cost paid by sessions that never need the file. Every session loads the surface; sessions that never invoke this feature pay for it anyway — every turn, and again after every `/clear`. No current always-loaded file's justification covers this cost: `session-handoff.md` is the closest precedent (it names the re-paid prefix as a cost), and `native-idiom-and-register.md`'s "zero burden for English sessions" is true for behavior and false for context bytes. A justification that does not name what the never-needing session pays is incomplete.
+- **(d) Scope first.** Before either duty fires, ask whether the content can live under a `paths:` scope instead — a reference companion keyed to the files that need it costs the surface nothing. Only content that genuinely must be always-loaded proceeds to the statement.
+
+## Threshold calibration
+
+The threshold is **1,000 bytes, single-edit basis**. Typical edit shapes:
+
+| Edit shape | Typical size | Duty fires |
+|---|---|---|
+| Typo fix | ~100 B | no |
+| One-line addition | ~200 B | no |
+| A paragraph | ~800 B | no |
+| A new HARD clause | ~1,200 B | yes |
+| A new `##` section | ~2,500 B | yes |
+
+There is deliberately **no cumulative-delta secondary trigger**: growth arriving as many sub-1,000-byte edits accumulates unwatched. That blind spot is an accepted residual risk, not an oversight to patch later — tracking per-file drift on every small edit would cost more attention than the growth it catches.
+
+## Self-compliance
+
+This rule carries a top-level `paths:` key, so it is excluded from the always-loaded surface it polices. The recurrence control must not itself be recurrence.
+
+---
+
+Version: 1.0.0
+Classification: Evolvable operational rule — binds edits to the four always-loaded slots; changes no gate semantics.

--- a/.claude/rules/moai/workflow/cache-aware-execution-reference.md
+++ b/.claude/rules/moai/workflow/cache-aware-execution-reference.md
@@ -9,17 +9,19 @@ paths: "**/cache-aware-execution.md"
 
 ## Cited cache numbers
 
-All figures in this section are **quoted source values** — quoted from the source article, **not re-measured** in the session that authored directives 6-10, and never to be restated as measurements of this project.
+All figures in this section are **quoted source values** — quoted from the source article, **not re-measured** in the session that authored directives 6-10, and never to be restated as measurements of this project. Date context: quoted from the source article as current on 2026-08-16 (the authoring date) and cross-checked against Anthropic's prompt-caching documentation during the 2026-08-16 PR review — performance figures the provider may change; re-quote before relying on one.
 
 | Quantity | Quoted value |
 |---|---|
 | Cache read | 0.1x the base input price |
 | Cache write (worst case) | up to 2x |
-| Output tokens | roughly 5x the input price |
-| Cache TTL (subscription) | 1 hour |
-| Cache TTL (API key) | 5 minutes |
+| Output tokens | roughly 5x the input price — output pricing is separate from input pricing and model-dependent; not a cache-cost figure |
+| Cache TTL (subscription auth, default) | 1 hour |
+| Cache TTL (API-key auth, default) | 5 minutes |
 
-The parent rule's intro quotes different figures for the write multiplier and TTL (reads ~0.1x, writes 1.25x, 5-minute TTL) — both sets are quoted from their respective source passages; neither was measured here, and the difference is a scope-of-quote artifact, not a contradiction this file resolves.
+Both TTL rows are authentication-mode defaults, not fixed properties: each cache hit refreshes the window (sliding TTL), and at the API level the 5-minute TTL is the default while the 1-hour TTL is an explicit `cache_control` override (`ttl: "1h"`). A Claude Code session selects neither — the runtime places cache breakpoints itself (parent rule, Non-goals).
+
+The parent rule's intro quotes different figures for the write multiplier and TTL (reads ~0.1x, writes 1.25x, 5-minute TTL) — both sets are quoted from their respective source passages; neither was measured here, and the difference is a scope-of-quote artifact, not a contradiction this file resolves. Neither figure is universal: the write multiplier ranges up to 2x and the TTL follows the authentication default (see above), so the parent's 1.25x / 5-minute pairing holds only for the API-key-default passage it was quoted from.
 
 ## Directive rationale
 
@@ -37,7 +39,7 @@ Routine commands in their default form emit progress spinners, banners, tables, 
 
 ### Directive 9 — session length as a cost axis
 
-Every fresh session re-pays the always-loaded prefix at write price; a continuing session reads it from cache. For the same body of work, N short sessions multiply the write; one long session pays it once. This is the same axis directive 4 weighs for `/clear` — the paste-ready resume exists precisely so a context reset buys something.
+Every fresh session re-pays the always-loaded prefix at write price; a continuing session reads it from cache — but only while that cache is warm. A gap longer than the idle TTL (a blocking user gate, an unattended wait) or a prefix invalidation (a session-loaded file edited mid-session — directive 3) reverts the next request to write price, collapsing the cheaper-continuation claim. For the same body of work, N short sessions multiply the write; one long session pays it once. This is the same axis directive 4 weighs for `/clear` — the paste-ready resume exists precisely so a context reset buys something.
 
 ### Directive 10 — mid-session model or effort switch
 

--- a/.claude/rules/moai/workflow/cache-aware-execution-reference.md
+++ b/.claude/rules/moai/workflow/cache-aware-execution-reference.md
@@ -1,0 +1,49 @@
+---
+description: "Reference companion for cache-aware-execution.md — cited cache-cost numbers, per-directive rationale, and worked examples for directives 6-10"
+paths: "**/cache-aware-execution.md"
+---
+
+# Cache-Aware Execution — Reference Companion
+
+> This is the reference companion of `cache-aware-execution.md`. The always-loaded rule owns the directive bodies (numbered 1-10) and nothing else from this file. This file owns the cited cache numbers, the per-directive rationale, and the worked examples behind directives 6-10. Load this file when authoring or reviewing one of those directives, or when a directive's grounding is challenged.
+
+## Cited cache numbers
+
+All figures in this section are **quoted source values** — quoted from the source article, **not re-measured** in the session that authored directives 6-10, and never to be restated as measurements of this project.
+
+| Quantity | Quoted value |
+|---|---|
+| Cache read | 0.1x the base input price |
+| Cache write (worst case) | up to 2x |
+| Output tokens | roughly 5x the input price |
+| Cache TTL (subscription) | 1 hour |
+| Cache TTL (API key) | 5 minutes |
+
+The parent rule's intro quotes different figures for the write multiplier and TTL (reads ~0.1x, writes 1.25x, 5-minute TTL) — both sets are quoted from their respective source passages; neither was measured here, and the difference is a scope-of-quote artifact, not a contradiction this file resolves.
+
+## Directive rationale
+
+### Directive 6 — `@`-mention, and `/context` as a one-shot audit
+
+Citing a filename in prose and relying on the model to fetch it spends a turn on the fetch and risks a miss or a stale read; an `@`-mention loads the file once, deterministically, at the point of need. `/context` re-renders the loaded-context summary on every invocation, which is an audit action (what is actually loaded, how close is the ceiling), not a routine status check.
+
+### Directive 7 — bounded command output
+
+Command output lands in the context and stays there for every later turn of the session; one verbose command is paid again on each subsequent request. The runtime truncates at `BASH_MAX_OUTPUT_LENGTH`, but the bound should be chosen by the caller — quiet flags, targeted queries, or redirect-to-file with the exit code and a bounded tail (the file-redirect contract of `agent-common-protocol.md` § Parallel Execution, generalized from verification batches to all commands).
+
+### Directive 8 — quiet forms of routine commands
+
+Routine commands in their default form emit progress spinners, banners, tables, and ANSI color — none of it decision-relevant. The quiet form returns the same decision bytes for a fraction of the context cost: `--no-progress`, `-q`/`--quiet`, machine-readable output (`--json`, `--porcelain`) piped through a targeted filter.
+
+### Directive 9 — session length as a cost axis
+
+Every fresh session re-pays the always-loaded prefix at write price; a continuing session reads it from cache. For the same body of work, N short sessions multiply the write; one long session pays it once. This is the same axis directive 4 weighs for `/clear` — the paste-ready resume exists precisely so a context reset buys something.
+
+### Directive 10 — mid-session model or effort switch
+
+Caches are model-scoped, and an effort or thinking-budget change (`MAX_THINKING_TOKENS`) keys a fresh cache as well: the request after the switch re-writes the prefix at full price. The apparent conflict with `agent-common-protocol.md` § Per-Spawn Model Injection is an axis difference, stated in the directive itself: Per-Spawn Model Injection governs which model a *subagent context* runs on (most agent definitions declare `model: inherit`, and an unspecified spawn silently falls back to the parent model); directives 5 and 10 govern the *main session's* accumulated cache. Neither SSOT revises the other.
+
+---
+
+Version: 1.0.0
+Classification: Reference companion — paths-scoped, never part of the always-loaded surface.

--- a/.claude/rules/moai/workflow/cache-aware-execution.md
+++ b/.claude/rules/moai/workflow/cache-aware-execution.md
@@ -22,7 +22,7 @@ Prompt-caching-aware ordering rules for orchestrator execution. Anthropic prompt
 
 8. **Prefer the quiet form of routine commands** [ZONE:Evolvable] [HARD] Call everyday commands in their quiet form — `--no-progress`, `-q`, machine-readable output with a targeted filter — not forms that emit spinners, banners, tables, or color noise: the same decision bytes, a fraction of the context cost.
 
-9. **Weigh session length as a cost axis** [ZONE:Evolvable] [HARD] One long session is cheaper than several short ones for the same work — every fresh session re-pays the always-loaded prefix at write price, a continuing one reads it from cache. Treat session splitting as directive 4 treats `/clear`: a cost to justify, not a default.
+9. **Weigh session length as a cost axis** [ZONE:Evolvable] [HARD] One long session is cheaper than several short ones for the same work — every fresh session re-pays the always-loaded prefix at write price, a continuing one reads it from cache — if it stays warm: a >5-min idle gap or prefix edit reverts it to write price. Treat session splitting as directive 4 treats `/clear`: a cost to justify, not a default.
 
 10. **A mid-session model or effort switch busts the cache** [ZONE:Evolvable] [HARD] Changing model or effort mid-session (thinking budget included — `MAX_THINKING_TOKENS`) discards the prompt cache; prefer a natural boundary for the switch. Directive 5 and this one govern the main session's cache; `agent-common-protocol.md` § Per-Spawn Model Injection governs which model a subagent runs on — different axes, not a contradiction.
 

--- a/.claude/rules/moai/workflow/cache-aware-execution.md
+++ b/.claude/rules/moai/workflow/cache-aware-execution.md
@@ -16,6 +16,16 @@ Prompt-caching-aware ordering rules for orchestrator execution. Anthropic prompt
 
 5. **Inherit the session model on spawns** [ZONE:Evolvable] Caches are model-scoped: a per-spawn model override splits the spawn off from every cache the session has built. Omit model overrides unless the task genuinely requires a different tier (already the default per agent-authoring guidance); this directive records the caching cost of violating it.
 
+6. **Pass files by `@`-mention, not by name** [ZONE:Evolvable] [HARD] When a prompt needs a file's content, pass it with an `@`-mention or a Read call rather than citing the filename for the model to fetch — one deterministic load beats a fetch-retry cycle. Use `/context` only as a one-shot audit of what is loaded, not a routine check.
+
+7. **Keep command output bounded** [ZONE:Evolvable] [HARD] Every command must bound what it returns: quiet flags, targeted queries, or redirect-to-file with the exit code and a bounded tail. `BASH_MAX_OUTPUT_LENGTH` is the runtime backstop, not the target; the file-redirect contract in `agent-common-protocol.md` § Parallel Execution applies to all commands.
+
+8. **Prefer the quiet form of routine commands** [ZONE:Evolvable] [HARD] Call everyday commands in their quiet form — `--no-progress`, `-q`, machine-readable output with a targeted filter — not forms that emit spinners, banners, tables, or color noise: the same decision bytes, a fraction of the context cost.
+
+9. **Weigh session length as a cost axis** [ZONE:Evolvable] [HARD] One long session is cheaper than several short ones for the same work — every fresh session re-pays the always-loaded prefix at write price, a continuing one reads it from cache. Treat session splitting as directive 4 treats `/clear`: a cost to justify, not a default.
+
+10. **A mid-session model or effort switch busts the cache** [ZONE:Evolvable] [HARD] Changing model or effort mid-session (thinking budget included — `MAX_THINKING_TOKENS`) discards the prompt cache; prefer a natural boundary for the switch. Directive 5 and this one govern the main session's cache; `agent-common-protocol.md` § Per-Spawn Model Injection governs which model a subagent runs on — different axes, not a contradiction.
+
 ## Non-goals
 
 - These directives NEVER justify skipping, weakening, or reordering an approval gate's *semantics* — Implementation Kickoff Approval and all HUMAN GATEs remain mandatory where defined. Only the *placement and batching* of questions is governed here.
@@ -27,8 +37,9 @@ Prompt-caching-aware ordering rules for orchestrator execution. Anthropic prompt
 - `.claude/rules/moai/workflow/context-window-management.md` — model-specific `/clear` thresholds (directive 4 is an additional, earlier trigger)
 - `.claude/rules/moai/core/agent-common-protocol.md` § Parallel Execution — single-turn verification batching (already cache-optimal: incremental append)
 - `.claude/rules/moai/core/askuser-protocol.md` — gate mechanics (unchanged by this rule)
+- `.claude/rules/moai/workflow/cache-aware-execution-reference.md` — cited cache numbers for directives 6-10
 
 ---
 
-Version: 1.0.0
+Version: 1.1.0
 Classification: Evolvable operational rule — execution ordering only; gate semantics unchanged.

--- a/.claude/rules/moai/workflow/kanban-dispatch-detail.md
+++ b/.claude/rules/moai/workflow/kanban-dispatch-detail.md
@@ -1,0 +1,116 @@
+---
+description: "Lead-only detail companion for kanban-dispatch.md — board, card classes, dispatch cycle, review lenses, /clear handoff"
+paths: "**/kanban-dispatch*.md,**/.claude/agents/moai/manager-kanban.md,**/.claude/skills/moai/workflows/todo.md"
+---
+
+# Kanban Dispatch — Detail Companion
+
+> Detail companion of `kanban-dispatch.md`, owning its lead-only sections; the always-loaded stub keeps every section that binds non-lead sessions. Load when moving a card between columns, classifying a card, or choosing review lenses.
+
+## The board
+
+Six columns, fixed and ordered:
+
+```
+backlog → plan → run → review → sync → done
+```
+
+`backlog` and `done` have no owning session. The four columns between them each map to exactly one companion role, which is what makes dispatch a lookup rather than a decision.
+
+| Column | Owning role | What happens there |
+|---|---|---|
+| `backlog` | *none* — a queue | Work waits. Entry is an operator act (see below). |
+| `plan` | `plan` | SPEC authored (`/moai plan`), then plan-audited. |
+| `run` | `run` | Implementation (`/moai run <SPEC-ID>`). |
+| `review` | `review` | Code review (`/moai review …`) with lenses chosen per card. |
+| `sync` | `sync` | Docs, CHANGELOG, PR (`/moai sync <SPEC-ID>`). |
+| `done` | *none* — terminal | Card closed. Nothing is dispatched here. |
+
+## Entry into the board is an operator act
+
+`backlog` has no owning session, so no completion report exists for the lead to react to, and a lead that admitted cards on its own initiative would be **generating** work rather than scheduling it. Entry is therefore always the operator's decision.
+
+The mechanism is `/moai todo`:
+
+- `/moai todo "<description>"` appends an item to the backlog queue.
+- `/moai todo` alone lists the queue.
+- After a `/clear`, the lead presents the queue through `AskUserQuestion` and the operator picks the next card. Only then does the lead dispatch to `plan`.
+
+The lead never picks for the operator, and never silently promotes a backlog item.
+
+## Card classes — not every card needs four columns
+
+Most of what accumulates in the backlog is chores: a one-line fix, a stale reference, a renamed flag. Sending those through `plan → run → review → sync` costs more in ceremony than the change is worth. The lead classifies each card as it leaves `backlog` and names the class in the dispatch.
+
+| Class | Shape | Path |
+|---|---|---|
+| A — direct close | The change is one file and one line, there is no design judgement in it, and CI catches the regression | One session carries the card through to a pull request; `plan` and `review` are skipped |
+| B — defect, cause unknown | Something is wrong and the cause has not been established | `run → review → sync`; `plan` is skipped, so no SPEC exists |
+| C — design change | The change contains a decision, or spans subsystems | All four columns |
+
+[HARD] **Class A is admitted on checked evidence, not on an assertion.** Two of its three properties are mechanically checkable, so they are checked and the check is cited: the diff is measured (`git diff --stat` against the base, showing the one file) and CI is observed green **on the head that will merge**. The third — no design judgement in it — is a judgement rather than a measurement, so it is stated in the dispatch where the operator can disagree with it. A card that cannot cite both measurements is not Class A, and it takes the `review` column.
+
+This is the same shape as the CodeRabbit section below. A class that skips review on a claim nobody checked is exactly the unobserved-claim hazard this rule forbids everywhere else; writing the justification down is not the same as verifying it.
+
+The justification is never "it is faster". Speed is the effect of skipping the columns, not the reason for it, and a card justified by speed alone is a Class C card being rushed.
+
+**Work in progress: one card per column, and only when each card occupies a different worktree.** Two cards sharing one worktree run serially whatever columns they sit in, because they share a working tree and a branch.
+
+For Class A this inverts where the parallelism comes from. Handing four sessions a whole card each puts four cards in flight; pipelining one card through four columns puts one. Pipelining repays its handoff cost only when each column does substantial work, which is the Class C case — and research fan-out during `plan` is reserved for Class C for the same reason.
+
+## The dispatch cycle
+
+Each arrow below is one dispatch from the lead to one companion session:
+
+```
+[operator picks a card]  →  plan  →  run  →  review  →  sync  →  [lead marks done]
+```
+
+Dispatch is addressed by session name. Companion sessions are named `<role>-<run-id>` at launch (for example `plan-a1b2c3`), and `ListAgents` reports the live set. Send with `SendMessage({to: "<name>", message: "…"})`; when a bare name is ambiguous, use the short reference the listing prints.
+
+Each instruction carries, at minimum: the card, the SPEC ID once one exists, the phase command to run, and the completion signal to write. Keep it a pointer, not a copy — the companion reads the SPEC artifacts itself rather than receiving them inline.
+
+**`sync → done` is the same act with the dispatch removed.** No session occupies `done`, so the lead reads the sync session's completion evidence and records the terminal transition itself.
+
+### Dispatch language
+
+[HARD] A dispatch is written in the operator's `conversation_language`. The operator watches it scroll past, which makes it user-facing output rather than internal agent traffic.
+
+This is a classification, not an exemption from the language rules, and it needs no change to either of them:
+
+- `agent-common-protocol.md` § Language Handling already opens with the opposite of an English default — agents receive and respond in the configured `conversation_language`. What it fixes to English is code, identifiers, and names. A dispatch is prose, so the rule was never against it; it simply did not name cross-session messages in its list.
+- `moai-constitution.md` § Response Language reserves English for internal agent communication, but the axis that clause sits on is stated one line above it: user-facing responses go in the operator's language. A message a human reads is user-facing by that rule's own criterion, so putting a dispatch in the operator's language applies the constitution rather than carving an exception out of it.
+
+The carve-out is narrow, and the boundary is **who reads it**. An `Agent()` subagent prompt reaches no human and stays English.
+
+What stays verbatim in every language: SPEC IDs, command names and their flags, file paths, session names, and technical identifiers. Those are addresses rather than prose, and a translated address does not resolve.
+
+## Review lens selection
+
+`review` is not one thing. The lead picks the lenses from what the card actually changed, and states the reason in the dispatch so the review session does not re-derive it:
+
+| Card touched | Lenses to instruct |
+|---|---|
+| Auth, session handling, input parsing, external calls, secrets, file/path handling | `--security` (add `--deep` when the surface is reachable by untrusted input) |
+| Non-trivial logic across several files | `--deep` (adversarially verified multi-phase scan) |
+| Whole-tree sweep rather than a diff | add `--repo` |
+| Suspected over-engineering | `--lean` (advisory only; applies no fixes) |
+| UI or design-system surface | `--design`, and `--critique` after the build |
+| Small, local, low-risk diff | no flag — the default 4-perspective pass is enough |
+
+`--deep --patch` is opt-in twice over: `--patch` drafts a fix and is absent unless the operator asked for it. Do not add it on the lead's own initiative.
+
+## The `/clear` handoff between phases
+
+[HARD] A companion session does not carry one card's context into the next card. When a phase completes and the lead has read its evidence, the lead **asks the operator to `/clear` that session** — `/clear` is a user-typed command and cannot be sent as an instruction.
+
+The lead's message to the operator states three things, in this order:
+
+1. **What closed** — the card, the phase, and the evidence that was read.
+2. **Which session to `/clear`** — by name, so the operator clears the right terminal.
+3. **What happens next** — the column the card moves to, and which session will be instructed once the clear is done.
+
+Where the next phase reuses a session that has just been cleared, the lead re-sends the full pointer instruction after the clear rather than assuming the session remembers the card.
+
+The lead's own session is cleared the same way, between cards rather than between phases: once a card reaches `done`, the lead asks the operator to `/clear` the lead session, and the next turn begins by presenting the backlog queue again.
+

--- a/.claude/rules/moai/workflow/kanban-dispatch.md
+++ b/.claude/rules/moai/workflow/kanban-dispatch.md
@@ -4,97 +4,21 @@ How the **lead** session of Kanban Mode moves a card across the board: what admi
 
 > **Loading scope**: Intentionally always-loaded. A session learns it is the kanban lead from the SessionStart context, not from a file path, so a `paths:`-restricted rule would never reach the session that needs it.
 
+> **Lead-only detail**: The board, Entry into the board is an operator act, Card classes, The dispatch cycle, Review lens selection, The `/clear` handoff between phases — moved to `kanban-dispatch-detail.md`; load when moving a card between columns, classifying a card, or choosing review lenses.
+
 ## Scope — when this rule is live
 
 This rule binds a session whose SessionStart context declares **Kanban Mode** with the `lead` role. In every other session it is inert: a companion session (`plan` / `run` / `review` / `sync`) receives instructions, it does not dispatch them, and a session outside Kanban Mode has no board to move.
 
 Kanban Mode is entered with `moai cc -k` (or `moai glm -k`), which elects one lead and prints one launch command per companion role. Companion sessions are launched **by hand, one per terminal** — a session cannot launch another session, and no mechanism to spawn a peer exists or is wanted.
 
-## The board
-
-Six columns, fixed and ordered:
-
-```
-backlog → plan → run → review → sync → done
-```
-
-`backlog` and `done` have no owning session. The four columns between them each map to exactly one companion role, which is what makes dispatch a lookup rather than a decision.
-
-| Column | Owning role | What happens there |
-|---|---|---|
-| `backlog` | *none* — a queue | Work waits. Entry is an operator act (see below). |
-| `plan` | `plan` | SPEC authored (`/moai plan`), then plan-audited. |
-| `run` | `run` | Implementation (`/moai run <SPEC-ID>`). |
-| `review` | `review` | Code review (`/moai review …`) with lenses chosen per card. |
-| `sync` | `sync` | Docs, CHANGELOG, PR (`/moai sync <SPEC-ID>`). |
-| `done` | *none* — terminal | Card closed. Nothing is dispatched here. |
-
-## Entry into the board is an operator act
-
-`backlog` has no owning session, so no completion report exists for the lead to react to, and a lead that admitted cards on its own initiative would be **generating** work rather than scheduling it. Entry is therefore always the operator's decision.
-
-The mechanism is `/moai todo`:
-
-- `/moai todo "<description>"` appends an item to the backlog queue.
-- `/moai todo` alone lists the queue.
-- After a `/clear`, the lead presents the queue through `AskUserQuestion` and the operator picks the next card. Only then does the lead dispatch to `plan`.
-
-The lead never picks for the operator, and never silently promotes a backlog item.
-
-## Card classes — not every card needs four columns
-
-Most of what accumulates in the backlog is chores: a one-line fix, a stale reference, a renamed flag. Sending those through `plan → run → review → sync` costs more in ceremony than the change is worth. The lead classifies each card as it leaves `backlog` and names the class in the dispatch.
-
-| Class | Shape | Path |
-|---|---|---|
-| A — direct close | The change is one file and one line, there is no design judgement in it, and CI catches the regression | One session carries the card through to a pull request; `plan` and `review` are skipped |
-| B — defect, cause unknown | Something is wrong and the cause has not been established | `run → review → sync`; `plan` is skipped, so no SPEC exists |
-| C — design change | The change contains a decision, or spans subsystems | All four columns |
-
-[HARD] **Class A is admitted on checked evidence, not on an assertion.** Two of its three properties are mechanically checkable, so they are checked and the check is cited: the diff is measured (`git diff --stat` against the base, showing the one file) and CI is observed green **on the head that will merge**. The third — no design judgement in it — is a judgement rather than a measurement, so it is stated in the dispatch where the operator can disagree with it. A card that cannot cite both measurements is not Class A, and it takes the `review` column.
-
-This is the same shape as the CodeRabbit section below. A class that skips review on a claim nobody checked is exactly the unobserved-claim hazard this rule forbids everywhere else; writing the justification down is not the same as verifying it.
-
-The justification is never "it is faster". Speed is the effect of skipping the columns, not the reason for it, and a card justified by speed alone is a Class C card being rushed.
-
-**Class B skips `plan`, not `review`** — an unestablished cause is precisely what review catches, so it is the last column to drop. The `run` session owns both the investigation and the fix. Before the card leaves `run`, the evidence that established the cause — the command that reproduced the defect and what it printed — is written into the card's progress record, and the run session names that path in its completion report so the lead reads the cause rather than taking it on trust.
-
-**Work in progress: one card per column, and only when each card occupies a different worktree.** Two cards sharing one worktree run serially whatever columns they sit in, because they share a working tree and a branch.
-
-For Class A this inverts where the parallelism comes from. Handing four sessions a whole card each puts four cards in flight; pipelining one card through four columns puts one. Pipelining repays its handoff cost only when each column does substantial work, which is the Class C case — and research fan-out during `plan` is reserved for Class C for the same reason.
-
-## The dispatch cycle
-
-Each arrow below is one dispatch from the lead to one companion session:
-
-```
-[operator picks a card]  →  plan  →  run  →  review  →  sync  →  [lead marks done]
-```
-
-Dispatch is addressed by session name. Companion sessions are named `<role>-<run-id>` at launch (for example `plan-a1b2c3`), and `ListAgents` reports the live set. Send with `SendMessage({to: "<name>", message: "…"})`; when a bare name is ambiguous, use the short reference the listing prints.
-
-Each instruction carries, at minimum: the card, the SPEC ID once one exists, the phase command to run, and the completion signal to write. Keep it a pointer, not a copy — the companion reads the SPEC artifacts itself rather than receiving them inline.
-
-**`sync → done` is the same act with the dispatch removed.** No session occupies `done`, so the lead reads the sync session's completion evidence and records the terminal transition itself.
-
-### Dispatch language
-
-[HARD] A dispatch is written in the operator's `conversation_language`. The operator watches it scroll past, which makes it user-facing output rather than internal agent traffic.
-
-This is a classification, not an exemption from the language rules, and it needs no change to either of them:
-
-- `agent-common-protocol.md` § Language Handling already opens with the opposite of an English default — agents receive and respond in the configured `conversation_language`. What it fixes to English is code, identifiers, and names. A dispatch is prose, so the rule was never against it; it simply did not name cross-session messages in its list.
-- `moai-constitution.md` § Response Language reserves English for internal agent communication, but the axis that clause sits on is stated one line above it: user-facing responses go in the operator's language. A message a human reads is user-facing by that rule's own criterion, so putting a dispatch in the operator's language applies the constitution rather than carving an exception out of it.
-
-The carve-out is narrow, and the boundary is **who reads it**. An `Agent()` subagent prompt reaches no human and stays English.
-
-What stays verbatim in every language: SPEC IDs, command names and their flags, file paths, session names, and technical identifiers. Those are addresses rather than prose, and a translated address does not resolve.
-
 ## Completion is read, never trusted
 
 [HARD] The lead advances a card on **evidence it read**, not on a companion's reply. Reply routing between sessions is not guaranteed to arrive, and a reply is a claim rather than an observation.
 
 Before moving a card out of a working column, the lead reads the card's `progress.md` (and, where the phase declares one, the verification evidence path it cites) and confirms the phase actually closed. A missing, unreadable, or stale evidence file is a **gap** — the card stays where it is and the lead reports why. Absence of a failure signal is not a pass.
+
+**Class B skips `plan`, not `review`** — an unestablished cause is precisely what review catches, so it is the last column to drop. The `run` session owns both the investigation and the fix. Before the card leaves `run`, the evidence that established the cause — the command that reproduced the defect and what it printed — is written into the card's progress record, and the run session names that path in its completion report so the lead reads the cause rather than taking it on trust.
 
 This applies equally to the operator: when the lead reports a column advanced, it names what it read.
 
@@ -120,35 +44,6 @@ A CodeRabbit row counts as evidence only when BOTH of these hold:
 Anything else is a gap, not a pass. `Review rate limited` in particular means the review never started, and a card carrying it does not leave `review` or `sync`.
 
 Branch protection is not the lever here. The status state is `success` in precisely the failing case, so adding CodeRabbit to the required contexts would admit the unreviewed pull request just as readily. The distinction lives in the description, and only a read of the description surfaces it — which is why an automated merge gate closing this hole does not close it on the path a human merges by hand.
-
-## Review lens selection
-
-`review` is not one thing. The lead picks the lenses from what the card actually changed, and states the reason in the dispatch so the review session does not re-derive it:
-
-| Card touched | Lenses to instruct |
-|---|---|
-| Auth, session handling, input parsing, external calls, secrets, file/path handling | `--security` (add `--deep` when the surface is reachable by untrusted input) |
-| Non-trivial logic across several files | `--deep` (adversarially verified multi-phase scan) |
-| Whole-tree sweep rather than a diff | add `--repo` |
-| Suspected over-engineering | `--lean` (advisory only; applies no fixes) |
-| UI or design-system surface | `--design`, and `--critique` after the build |
-| Small, local, low-risk diff | no flag — the default 4-perspective pass is enough |
-
-`--deep --patch` is opt-in twice over: `--patch` drafts a fix and is absent unless the operator asked for it. Do not add it on the lead's own initiative.
-
-## The `/clear` handoff between phases
-
-[HARD] A companion session does not carry one card's context into the next card. When a phase completes and the lead has read its evidence, the lead **asks the operator to `/clear` that session** — `/clear` is a user-typed command and cannot be sent as an instruction.
-
-The lead's message to the operator states three things, in this order:
-
-1. **What closed** — the card, the phase, and the evidence that was read.
-2. **Which session to `/clear`** — by name, so the operator clears the right terminal.
-3. **What happens next** — the column the card moves to, and which session will be instructed once the clear is done.
-
-Where the next phase reuses a session that has just been cleared, the lead re-sends the full pointer instruction after the clear rather than assuming the session remembers the card.
-
-The lead's own session is cleared the same way, between cards rather than between phases: once a card reaches `done`, the lead asks the operator to `/clear` the lead session, and the next turn begins by presenting the backlog queue again.
 
 ## Isolation is entered, never provisioned
 
@@ -228,3 +123,4 @@ Reading the script first does not restore them. A human read is not the guard ru
 ---
 
 Classification: Evolvable operational rule — applies to the lead session of Kanban Mode.
+Version: 1.1.0 — split into stub + detail companion

--- a/.moai/specs/SPEC-ALWAYS-LOADED-DIET-001/progress.md
+++ b/.moai/specs/SPEC-ALWAYS-LOADED-DIET-001/progress.md
@@ -114,6 +114,39 @@ exit=0
 
 **Other verification:** `go build ./...` → exit 0 (no output). Subagent boundary: `grep -rn 'AskUserQuestion'` on the two rule files → 1 match, pre-existing intro text (line 3, present in the pre-edit file; original census unchanged), 0 new occurrences; companion 0. golangci-lint: n/a — 0 Go files changed; markdown has no lint gate. RED-state evidence: n/a — documentation milestone, no test-first artifact (recorded as a gap, not fabricated; E8 docs-milestone gap).
 
+### M3 — 재발 통제 (2026-08-17)
+
+- Tree: worktree `feat/spec-always-loaded-diet`, pre-M3 HEAD `6d701d26c` (= the M2 commit; working tree clean at dispatch).
+- Construction: new `.claude/rules/moai/development/rule-authoring.md` (4,062 B). Frontmatter: `description:` + the plan D1 expanded glob, verbatim — `paths: "**/.claude/rules/**,**/CLAUDE.md,**/.claude/output-styles/**,**/MEMORY.md"` (keys all four guard slots; AP-6 satisfied — the control itself is `paths:`-scoped and excluded from the surface it polices). Body: four-slot surface definition (no-`paths:` rules / `CLAUDE.md` / output styles / `MEMORY.md` head) with the all-slots binding rationale; recurrence grounding (~4x growth in three months, ~half in-place expansion → both modes covered); the statement duty as one `[ZONE:Evolvable] [HARD]` clause with four lettered parts — (a) new always-loaded file → bytes + cost justification in the change description, (b) single edit growing an existing file by more than 1,000 bytes → same statement sized to the growth, (c) the statement must address the cost paid by sessions that never need the file (grounded per plan M3 step 3: `session-handoff.md` closest cost-naming precedent; `native-idiom-and-register.md` "zero burden for English sessions" true for behavior, false for context bytes), (d) `paths:`-scope-first question before the duty fires; threshold calibration table (typo ~100 B / one-line ~200 B / paragraph ~800 B pass; new HARD clause ~1,200 B / new `##` section ~2,500 B fire); explicit no-cumulative-delta-secondary-trigger clause (accepted residual risk per plan D4-3); self-compliance note. Size calibration vs development-category siblings: branch-origin-protocol.md 4,180 B, karpathy-quickref.md 2,068 B.
+- Zero Go changes (plan M3 step 5 / D4-2): one file added; `internal/` untouched.
+
+**Post-M3 instrumentation (acceptance §A `fm()`/`headroom` forms, this run, this tree, HEAD `6d701d26c` + working-tree rule-authoring.md):**
+
+```
+paths_key=1
+files=14 bytes=288975 tokens=72243 headroom=2757
+```
+
+Surface delta: **0 bytes** — rule-authoring.md carries top-level `paths:` so the guard excludes it; files stays 14, bytes/headroom byte-identical to post-M2 (288,975 / 2,757). AC-ALD-001 checkpoint holds: 2,757 > 1,239 (final gate is post-M4).
+
+**M3-decidable AC matrix (all PASS, commands run in this tree):**
+
+| AC | Command (form) | Observed | Verdict |
+|---|---|---|---|
+| AC-ALD-014 | acceptance §B verbatim form (`test -f` guard, `fm()` paths line, 4 slot fragments via `grep -F`, 4 body patterns) | paths line exact; slot_rules=1 slot_CLAUDE.md=1 slot_output-styles=1 slot_MEMORY.md=1; new_rule_case=1 growth_case=5 threshold=3 non_invoking_cost=1 | PASS |
+| AC-ALD-001 (checkpoint) | `headroom` | files=14 bytes=288975 tokens=72243 headroom=2757 (> 1,239) | PASS |
+| AC-ALD-002 (checkpoint) | guard + budget const + go diff | `ok  github.com/modu-ai/moai-adk/internal/config 0.457s` exit=0; budget_const=1; go_changed=0 | PASS |
+
+**Post-M3 guard re-run (verbatim):**
+
+```
+$ go test ./internal/config/ -run TestAlwaysLoaded -count=1; echo "exit=$?"
+ok  	github.com/modu-ai/moai-adk/internal/config	0.457s
+exit=0
+```
+
+**Other verification:** `go build ./...` → exit 0 (no output). `go test ./internal/config/ -count=1` (full package) → `ok  	github.com/modu-ai/moai-adk/internal/config	5.690s` exit=0. Subagent boundary: `grep -cn 'AskUserQuestion\|mcp__askuser'` on rule-authoring.md → 0. Neutrality pre-check (M4 mirrorability, local file): spec_id=0 req=0 sha=0 date=0 — no sanitization needed at mirror time. golangci-lint: n/a — 0 Go files changed; markdown has no lint gate. RED-state evidence: n/a — documentation milestone, no test-first artifact (recorded as a gap, not fabricated; E8 docs-milestone gap).
+
 ## §E.3 Run-phase Audit-Ready Signal
 
 _<pending run-phase>_

--- a/.moai/specs/SPEC-ALWAYS-LOADED-DIET-001/progress.md
+++ b/.moai/specs/SPEC-ALWAYS-LOADED-DIET-001/progress.md
@@ -69,6 +69,51 @@ Note (AC-ALD-008a form): acceptance.md's `<(grep -A2 -B2 …)` process-substitut
 
 **Residual (recorded, deliberately not fixed):** the companion line "This is the same shape as the CodeRabbit section below." now reads stale inside the companion (the CodeRabbit section stayed in the stub). Rewording it would break AC-ALD-006's line-set preservation and violate AP-2 — the line must stay verbatim; the referenced section exists in the stub.
 
+### M2 — G3~G7 규율 편입 (2026-08-17)
+
+- Tree: worktree `feat/spec-always-loaded-diet`, pre-M2 HEAD `a203a7c3a` (= the M1 commit; working tree clean at dispatch).
+- Construction: directives 6-10 appended to `cache-aware-execution.md` `## Directives` — same shape as 1-5 (numbered + bold title + zone prefix + one paragraph), prefix `[ZONE:Evolvable] [HARD]` per REQ-ALD-006..010. Per-directive bytes (wc-accurate): d6=339 / d7=360 / d8=313 / d9=337 / d10=437. Plus one Cross-references bullet for the companion (111 B) and footer version 1.0.0 → 1.1.0. Nothing else in the file touched — `git diff --stat`: 12 insertions, 1 deletion (the deletion is the old version line). New companion `cache-aware-execution-reference.md` (3,991 B): frontmatter `description:` + self-keyed `paths: "**/cache-aware-execution.md"` (plan M2 step 2 — rationale-store, no domain keying), ownership-declaration blockquote (goal-directive-detail.md shape), cited-numbers section, per-directive rationale for 6-10.
+- G7 / D3 resolution: directive 10 carries the one-sentence axis distinction (main-session cache vs `agent-common-protocol.md` § Per-Spawn Model Injection subagent model-resolution) and names both SSOTs inline; neither SSOT body was revised (per plan D3 — the cross-reference is textual from d10 only, so `agent-common-protocol.md` is untouched).
+
+**Baseline (pre-edit, attribution: M1 evidence measured at HEAD a203a7c3a, unchanged until this edit):**
+
+```
+headroom (fm() form, at a203a7c3a per §E.2 M1): files=14 bytes=287068 tokens=71767 headroom=3233
+cache-aware-execution.md = 4,497 B
+```
+
+**AC-ALD-010 positive contrast (pre-edit, this run, this tree, HEAD a203a7c3a):** all six patterns 0 — `G3_at_mention=0 G3_context_audit=0 G4_output_len=0 G5_quiet=0 G6_session_length=0 G7_thinking=0`.
+
+**Post-M2 (this run, this tree, working tree):**
+
+```
+files=14 bytes=288975 tokens=72243 headroom=2757    # acceptance §A fm() form
+n=$(wc -c < .claude/rules/moai/workflow/cache-aware-execution.md)
+before=4497 after=6404 delta=1907
+```
+
+Delta: +1,907 bytes (= 5 directive paragraphs 1,786 B + 5×2 separator newlines + companion cross-reference bullet 111 B) → headroom 3,233 → 2,757 (−476 tokens). Byte identity: 287,068 + 1,907 = 288,975 exactly. AC-ALD-001 checkpoint holds: 2,757 > 1,239 (final gate is post-M4).
+
+**M2-decidable AC matrix (all PASS, commands run in this tree):**
+
+| AC | Command (form) | Observed | Verdict |
+|---|---|---|---|
+| AC-ALD-010 | 6-pattern `grep` on post-edit file (positive contrast above: pre-edit 6×0) | G3_at_mention=1 G3_context_audit=1 G4_output_len=1 G5_quiet=2 G6_session_length=1 G7_thinking=1 — all >= 1 | PASS |
+| AC-ALD-011 | `wc -c` before/after | before=4497 after=6404 delta=1907; 1000 <= 1907 <= 2000 | PASS |
+| AC-ALD-012 | `headroom` files= + `fm()` paths_key on companion | files=14 (unchanged — companion excluded by `paths:`), exists=1 paths_key=1 | PASS |
+| AC-ALD-013 | unlabeled-numeric-paragraph awk + negative selftest | numeric_paragraphs=2 (table block + reconciliation paragraph, both labeled), citation_exit=0, selftest_unlabeled=1 | PASS |
+| AC-ALD-002 (checkpoint) | guard + budget const + go diff | `ok  github.com/modu-ai/moai-adk/internal/config 0.494s` exit=0; budget_const=1; go_changed=0 | PASS |
+
+**Post-M2 guard re-run (verbatim):**
+
+```
+$ go test ./internal/config/ -run TestAlwaysLoaded -count=1; echo "exit=$?"
+ok  	github.com/modu-ai/moai-adk/internal/config	0.494s
+exit=0
+```
+
+**Other verification:** `go build ./...` → exit 0 (no output). Subagent boundary: `grep -rn 'AskUserQuestion'` on the two rule files → 1 match, pre-existing intro text (line 3, present in the pre-edit file; original census unchanged), 0 new occurrences; companion 0. golangci-lint: n/a — 0 Go files changed; markdown has no lint gate. RED-state evidence: n/a — documentation milestone, no test-first artifact (recorded as a gap, not fabricated; E8 docs-milestone gap).
+
 ## §E.3 Run-phase Audit-Ready Signal
 
 _<pending run-phase>_

--- a/.moai/specs/SPEC-ALWAYS-LOADED-DIET-001/progress.md
+++ b/.moai/specs/SPEC-ALWAYS-LOADED-DIET-001/progress.md
@@ -147,9 +147,88 @@ exit=0
 
 **Other verification:** `go build ./...` → exit 0 (no output). `go test ./internal/config/ -count=1` (full package) → `ok  	github.com/modu-ai/moai-adk/internal/config	5.690s` exit=0. Subagent boundary: `grep -cn 'AskUserQuestion\|mcp__askuser'` on rule-authoring.md → 0. Neutrality pre-check (M4 mirrorability, local file): spec_id=0 req=0 sha=0 date=0 — no sanitization needed at mirror time. golangci-lint: n/a — 0 Go files changed; markdown has no lint gate. RED-state evidence: n/a — documentation milestone, no test-first artifact (recorded as a gap, not fabricated; E8 docs-milestone gap).
 
+### M4 — 미러 + 빌드 + 최종 계측 (2026-08-17)
+
+- Tree: worktree `feat/spec-always-loaded-diet`, pre-M4 HEAD `fcc07d1bc` (= the M3 commit; working tree clean at dispatch — verified `git status --short` empty).
+- Mirror scope: the 5 created/modified rule files, copied to `internal/template/templates/` at the corresponding paths. Pre-mirror baseline established: the two MODIFIED files' pre-edit dev versions (`a203a7c3a~1` kanban-dispatch.md, `6d701d26c~1` cache-aware-execution.md) are **byte-identical to the template copies** (`diff` exit 0, 0 lines) — the mirror applies to a clean baseline, no foreign template divergence to preserve.
+- Neutrality of the sources (pre-copy, this run, this tree): all 5 dev files scanned 0 across `SPEC-ALWAYS` / `REQ-ALD|AC-ALD` / generic `SPEC-…` / generic `REQ/AC-…-NNN` / `[0-9a-f]{40}` / `[0-9a-f]{7,8}+punct` / `2026-` / `/Users/goos` / `CLAUDE.local` / `Audit N Finding` — the rule bodies were authored neutral from M1 on (provenance lives in this file, not the rules). **Sanitization applied: none** — the byte-identical copy IS the sanitized form; plan §F's "no wholesale cp" guards against dirty sources, and the scan is the evidence this source is clean.
+- `make build`: exit 0. `catalog.yaml` regeneration ran (12407 bytes) with **zero hash change** (rule files are not catalog entries — `grep -c 'rules/moai' catalog.yaml` = 0), so no build artifacts enter the commit; `//go:embed all:templates` compiles the FS into the binary with no generated files. `git status` shows exactly the 5 mirror paths.
+
+**Post-M4 final measurement (acceptance §A `headroom` form + plan §C `grep -rL` form, this run, this tree, working tree with mirrors):**
+
+```
+files=14 bytes=288975 tokens=72243 headroom=2757    # acceptance §A fm() form
+bytes=288975 tokens=72243 headroom=2757              # plan §C grep -rL form (identical)
+```
+
+**Final gate: headroom 2,757 > 1,239 (strictly greater).** Byte-identical to post-M3 (288,975 / 2,757) — M4 touches only `internal/template/templates/`, which the guard does not measure; the measurement chain M1(3,233) → M2(2,757) → M3(2,757) → M4(2,757) is monotone above baseline at every checkpoint and lands above the plan's worst-corner projection (2,597). Observed headroom recorded for the budget-ratchet backlog card per plan D4-1: **2,757 tokens** (input to the separate card; `AlwaysLoadedTokenBudget` unchanged at 75,000 — D4-1).
+
+**M4-decidable AC matrix (all PASS, commands run in this tree):**
+
+| AC | Command (form) | Observed | Verdict |
+|---|---|---|---|
+| AC-ALD-001 (FINAL) | `headroom` | headroom=2757 > 1239 | PASS |
+| AC-ALD-015 | acceptance §B verbatim loop + `make build` | 5×MIRRORED, MISSING 0, build_exit=0 | PASS |
+| AC-ALD-016 | acceptance §B verbatim `test -f` + 4-pattern `grep -cE` + strict leak test | 5 rows `spec_id=0 req=0 sha=0 date=0`; `MOAI_TEMPLATE_LEAK_STRICT=1 go test … -run TestTemplateNoInternalContentLeak` → ok, exit=0; positive contrast live (same SPEC pattern on local spec.md = 3 matches — not a false-pass machine) | PASS |
+| AC-ALD-002 (final) | guard + budget const + go diff (`origin/main...HEAD`) | `ok … 0.281s` exit=0; budget_const=1; go_changed=0 | PASS |
+| AC-ALD-007 (mirror re-check) | `fm()` paths keys on mirrored companion | mirror carries the same domain-keyed `paths:` line (byte-identical copy) | PASS |
+
+**Other verification:** `go build ./...` → exit 0. `GOOS=windows go build ./...` → exit 0; `GOOS=linux go build ./...` → exit 0 (embed compiles cross-platform; markdown-only change). `MOAI_TEMPLATE_LEAK_STRICT=1 go test ./internal/template/ -count=1` (FULL package, includes `TestSanitizedPairParity` + `TestRuleTemplateMirrorDrift` + `TestTemplateNeutralityAudit`) → `ok … 37.769s` exit=0. The 3 CI `template-neutrality-check.yaml` targets run in isolation exactly as CI runs them: `TestTemplateNeutralityAudit` → PASS, `TestTemplateNoInternalContentLeak` (narrow) → PASS, strict tier → PASS (all exit 0). `go test ./internal/config/ -count=1` (full package) → `ok … 1.924s` exit=0. Subagent boundary: `grep -c 'AskUserQuestion\|mcp__askuser'` on the 5 mirrors → kanban stub 1 + kanban companion 1 + cache parent 1 + cache reference 0 + rule-authoring 0; sum 3 = original census sum 3 (kanban original 2 — 1 stayed in stub `Boundaries`, 1 moved verbatim to companion; cache original 1 — pre-existing intro line); 0 new occurrences, all doctrine-text mentions, none a subagent invocation. golangci-lint: n/a — 0 Go files changed (`git diff --name-only origin/main...HEAD -- '*.go'` = 0); markdown has no lint gate. RED-state evidence: n/a — documentation+mirror milestone, no test-first artifact (recorded as a gap, not fabricated; E8 docs-milestone gap).
+
+**Residual (recorded, deliberately not fixed):** the 5 mirrored files are enrolled in NO parity registry (`workflowOptMirroredPaths`, `sanitizedPairPaths`) — enrollment would be a Go test-file edit outside this SPEC's §F scope envelope (plan §A: "편집 대상 파일 4개 + 미러 4개 + M3 신설 1개(+미러) = 최대 10개 파일"). Consequence: a future single-tree edit to these 5 rules is not caught by `TestRuleTemplateMirrorDrift`; the byte-parity enrollment is a natural candidate for a follow-up card alongside the D4-1 budget ratchet.
+
 ## §E.3 Run-phase Audit-Ready Signal
 
-_<pending run-phase>_
+```yaml
+run_status: audit-ready
+run_complete_at: 2026-08-17
+spec_id: SPEC-ALWAYS-LOADED-DIET-001
+branch: feat/spec-always-loaded-diet
+worktree: /tmp/wt-run-ald
+base: 062a995d9   # origin/main at M1 dispatch; plan artifacts squash-merged via PR #1576 as be1958a4d
+run_phase_commits:
+  - a203a7c3a   # M1 kanban-dispatch.md split (stub + domain-keyed detail companion)
+  - 6d701d26c   # M2 cache-aware-execution.md directives 6-10 + self-keyed reference companion
+  - fcc07d1bc   # M3 rule-authoring.md recurrence control (paths-scoped, 4-slot)
+  - PENDING-M4-BACKFILL   # M4 template mirror (5 files) + rebuild + final measurement
+ac_pass_count: 16
+ac_fail_count: 0
+final_headroom_tokens: 2757   # observed post-M4, both measurement forms agree; baseline 1239; D4-1 budget-ratchet card input
+always_loaded_files: 14   # unchanged pre/post diet (files split, not removed)
+bytes_pre: 295044
+bytes_post: 288975   # net -6069 B (-1515 tokens); M1 -7976, M2 +1907, M3 0, M4 0
+preserve_list_post_run_count: 0   # no Go/config/hook surface touched; go_changed=0 across the run phase
+l44_pre_commit_fetch: true        # worktree branch only; primary checkout untouched; explicit-pathspec staging, no -A/-a
+l44_post_push_fetch: n/a          # not pushed — branch awaits orchestrator
+new_warnings_or_lints_introduced: 0   # 0 Go files changed; golangci-lint n/a; template package green incl. strict tier
+cross_platform_build:
+  darwin_arm64: pass   # go build ./... exit 0
+  windows_amd64: pass  # GOOS=windows go build ./... exit 0 (embed compiles)
+  linux_amd64: pass    # GOOS=linux go build ./... exit 0
+total_run_phase_files: 10   # 5 dev-surface files (M1-M3) + 5 template mirrors (M4); + progress.md evidence
+m1_to_mN_commit_strategy: one-commit-per-milestone (M1/M2/M3) + M4 commit + sha backfill commit
+mirror_status:
+  mirrored: 5
+  sanitization_applied: none   # sources authored neutral; byte-identical copy is the sanitized form (scan evidence in §E.2 M4)
+  parity_registries_enrolled: 0   # residual, recorded for follow-up card
+ci_neutrality_targets_local:
+  test_template_neutrality_audit: pass
+  test_template_no_internal_content_leak_narrow: pass
+  test_template_no_internal_content_leak_strict: pass
+```
+
+AC matrix summary for the run phase (detail per milestone in §E.2 above):
+
+| AC | Decided at | Verdict |
+|---|---|---|
+| AC-ALD-001 | M4 (final gate) | PASS — headroom 2757 > 1239 |
+| AC-ALD-002 | M1/M2/M3 checkpoints + M4 final | PASS — guard ok, budget_const=1, go_changed=0 |
+| AC-ALD-003 ~ AC-ALD-009 | M1 | PASS — see §E.2 M1 matrix |
+| AC-ALD-010 ~ AC-ALD-013 | M2/M3 | PASS — see §E.2 M2/M3 matrices |
+| AC-ALD-014 | M3 | PASS — see §E.2 M3 matrix |
+| AC-ALD-015, AC-ALD-016 | M4 | PASS — 5×MIRRORED, build exit 0; 4-token scan 5×0 + strict leak exit 0 |
+
+Gaps (E8): documentation/mirror milestone — no RED-state test-first artifact exists for any of M1-M4 (stated, not fabricated). Coverage: n/a — 0 Go files changed in the run phase; `internal/config` and `internal/template` packages both green (runs cited above).
 
 ## §E.4 Sync-phase Audit-Ready Signal
 

--- a/.moai/specs/SPEC-ALWAYS-LOADED-DIET-001/progress.md
+++ b/.moai/specs/SPEC-ALWAYS-LOADED-DIET-001/progress.md
@@ -22,7 +22,52 @@
 
 ## §E.2 Run-phase Evidence
 
-_<pending run-phase>_
+### M1 — `kanban-dispatch.md` 분리 (2026-08-17)
+
+- Phase 1 re-audit: **skipped as eligible** — plan-audit iter2 PASS 0.845 (Tier M threshold 0.80) + artifact content unchanged since the verdict (squash-merge of PR #1576 did not alter artifact bytes).
+- Implementation Kickoff Approval: granted orchestrator-side (run-phase M1 dispatch received 2026-08-17). The §E.1 "NOT been requested" line reflects plan-phase authoring time.
+- Tree: worktree `feat/spec-always-loaded-diet`, pre-M1 HEAD `062a995d9` (base origin/main).
+
+**Construction (verbatim move, no rewrite — REQ-ALD-005/AP-2):**
+
+- `kanban-dispatch-detail.md` = frontmatter + ownership declaration + `sed -n '13,59p;62,92p;124,152p'` of the original. Line 61 dropped as the collapsed duplicate blank at the Class-B lift-out point (plan M1 step 3's 1-byte cleanup).
+- Stub = stay lines `1,6 / 7,12 / 93,98 / 60 / 99,123 / 153,230` + pointer line (after the Loading-scope quote) + one separator blank + footer version line. The Class B paragraph (original line 60, 495 B) relocated **whole-line** into `## Completion is read, never trusted`, between "Before moving a card…" and "This applies equally…".
+
+**Baseline (pre-edit, this run, this tree, HEAD 062a995d9):**
+
+```
+files=14 bytes=295044 tokens=73761 headroom=1239   # acceptance §A fm() form
+bytes=295044 tokens=73761 headroom=1239             # plan §C grep -rL form (identical)
+```
+
+**Post-split (this run, this tree, working tree):**
+
+```
+files=14 bytes=287068 tokens=71767 headroom=3233    # fm() form
+bytes=287068 tokens=71767 headroom=3233              # grep -rL form
+```
+
+Delta: −7,976 bytes → headroom 1,239 → 3,233 (+1,994). AC-ALD-001 checkpoint (final gate is post-M4) already holds: 3,233 > 1,239.
+
+**M1-decidable AC matrix (all PASS, commands run in this tree):**
+
+| AC | Command (form) | Observed | Verdict |
+|---|---|---|---|
+| AC-ALD-003 | 9 BINDING headings `grep -c` in stub; 6 LEAD-ONLY `grep -c` in stub; anchor `names that path in its completion report` both files | 9×1; 6×0; relocated_in_stub=1 relocated_in_companion=0 | PASS |
+| AC-ALD-004 | `grep -c '\[HARD\]'` stub / companion | stub=6 companion=3 (sum 9 = original census 9) | PASS |
+| AC-ALD-005 | 7 headings `grep -c` in companion | 7×1 | PASS |
+| AC-ALD-006 | `comm -23` orig(BASE_REF=be1958a4d) vs stub+companion, non-empty sorted | missing_lines=0; positive contrast vs /dev/null=140 | PASS |
+| AC-ALD-007 | `fm()` paths keys | manager-kanban_key=1 todo_key=1 (domain-keyed, plan D2) | PASS |
+| AC-ALD-008 | (a) names within ±2 lines of the `kanban-dispatch-detail.md` mention (pipe form), (b) ownership_decl, (c) footer | (a) 6×1, (b) ownership_decl=3, (c) version line present | PASS |
+| AC-ALD-009 | `wc -c` both files | stub=13027 companion=8866 sum=21893 (range 21003..21903; overhead 890 B, within the 600–900 estimate) | PASS |
+| AC-ALD-012 | `headroom` files= + `fm()` paths_key | files=14, exists=1 paths_key=1 (cache-aware-execution-reference.md is M2 — AC completes at M2) | PASS (M1 scope) |
+| AC-ALD-002 | guard + budget const + go diff | `ok github.com/modu-ai/moai-adk/internal/config 0.607s` exit=0; budget_const=1; go_changed=0 | PASS |
+
+Note (AC-ALD-008a form): acceptance.md's `<(grep -A2 -B2 …)` process-substitution form yields empty `grep -c` output under this environment's zsh; the pipe form `grep -A2 -B2 … | grep -c` is semantically identical and was used. Bash (sync-audit) runs the acceptance form directly.
+
+**Other verification:** `go build ./...` → exit 0. `go test ./internal/config/` (full package) → `ok github.com/modu-ai/moai-adk/internal/config 2.551s`. Subagent boundary: `grep -rn 'AskUserQuestion'` on the two rule files → 2 matches, both pre-existing doctrine-text mentions (original census 2: 1 stayed in stub `Boundaries`, 1 moved verbatim to companion `Entry into the board`); no new occurrences. golangci-lint: n/a — 0 Go files changed; markdown has no lint gate. RED-state evidence: n/a — documentation milestone, no test-first artifact (recorded as a gap, not fabricated).
+
+**Residual (recorded, deliberately not fixed):** the companion line "This is the same shape as the CodeRabbit section below." now reads stale inside the companion (the CodeRabbit section stayed in the stub). Rewording it would break AC-ALD-006's line-set preservation and violate AP-2 — the line must stay verbatim; the referenced section exists in the stub.
 
 ## §E.3 Run-phase Audit-Ready Signal
 
@@ -31,3 +76,9 @@ _<pending run-phase>_
 ## §E.4 Sync-phase Audit-Ready Signal
 
 _<pending sync-phase>_
+
+## §F Phase 4 Mode Selection
+
+- decision: `sub-agent` (Mode 5 — sequential per milestone)
+- rationale: coding-heavy documentation surgery on one always-loaded rule file per milestone; single-writer discipline protects the AC-ALD-009 byte-sum attribution and the shared §C measurement chain (M1→M4 ordering is load-bearing: M2 adds back bytes M1 removed, M3 adds the recurrence control, M4 mirrors and takes the final measurement)
+- autonomous progression: goal armed orchestrator-side (ac_converge family); milestones delegated one at a time

--- a/.moai/specs/SPEC-ALWAYS-LOADED-DIET-001/progress.md
+++ b/.moai/specs/SPEC-ALWAYS-LOADED-DIET-001/progress.md
@@ -22,10 +22,10 @@
 
 ## §E.2 Run-phase Evidence
 
-### M1 — `kanban-dispatch.md` 분리 (2026-08-17)
+### M1 — `kanban-dispatch.md` 분리 (2026-08-16)
 
 - Phase 1 re-audit: **skipped as eligible** — plan-audit iter2 PASS 0.845 (Tier M threshold 0.80) + artifact content unchanged since the verdict (squash-merge of PR #1576 did not alter artifact bytes).
-- Implementation Kickoff Approval: granted orchestrator-side (run-phase M1 dispatch received 2026-08-17). The §E.1 "NOT been requested" line reflects plan-phase authoring time.
+- Implementation Kickoff Approval: granted orchestrator-side (run-phase M1 dispatch received 2026-08-16). The §E.1 "NOT been requested" line reflects plan-phase authoring time.
 - Tree: worktree `feat/spec-always-loaded-diet`, pre-M1 HEAD `062a995d9` (base origin/main).
 
 **Construction (verbatim move, no rewrite — REQ-ALD-005/AP-2):**
@@ -69,7 +69,7 @@ Note (AC-ALD-008a form): acceptance.md's `<(grep -A2 -B2 …)` process-substitut
 
 **Residual (recorded, deliberately not fixed):** the companion line "This is the same shape as the CodeRabbit section below." now reads stale inside the companion (the CodeRabbit section stayed in the stub). Rewording it would break AC-ALD-006's line-set preservation and violate AP-2 — the line must stay verbatim; the referenced section exists in the stub.
 
-### M2 — G3~G7 규율 편입 (2026-08-17)
+### M2 — G3~G7 규율 편입 (2026-08-16)
 
 - Tree: worktree `feat/spec-always-loaded-diet`, pre-M2 HEAD `a203a7c3a` (= the M1 commit; working tree clean at dispatch).
 - Construction: directives 6-10 appended to `cache-aware-execution.md` `## Directives` — same shape as 1-5 (numbered + bold title + zone prefix + one paragraph), prefix `[ZONE:Evolvable] [HARD]` per REQ-ALD-006..010. Per-directive bytes (wc-accurate): d6=339 / d7=360 / d8=313 / d9=337 / d10=437. Plus one Cross-references bullet for the companion (111 B) and footer version 1.0.0 → 1.1.0. Nothing else in the file touched — `git diff --stat`: 12 insertions, 1 deletion (the deletion is the old version line). New companion `cache-aware-execution-reference.md` (3,991 B): frontmatter `description:` + self-keyed `paths: "**/cache-aware-execution.md"` (plan M2 step 2 — rationale-store, no domain keying), ownership-declaration blockquote (goal-directive-detail.md shape), cited-numbers section, per-directive rationale for 6-10.
@@ -114,7 +114,7 @@ exit=0
 
 **Other verification:** `go build ./...` → exit 0 (no output). Subagent boundary: `grep -rn 'AskUserQuestion'` on the two rule files → 1 match, pre-existing intro text (line 3, present in the pre-edit file; original census unchanged), 0 new occurrences; companion 0. golangci-lint: n/a — 0 Go files changed; markdown has no lint gate. RED-state evidence: n/a — documentation milestone, no test-first artifact (recorded as a gap, not fabricated; E8 docs-milestone gap).
 
-### M3 — 재발 통제 (2026-08-17)
+### M3 — 재발 통제 (2026-08-16)
 
 - Tree: worktree `feat/spec-always-loaded-diet`, pre-M3 HEAD `6d701d26c` (= the M2 commit; working tree clean at dispatch).
 - Construction: new `.claude/rules/moai/development/rule-authoring.md` (4,062 B). Frontmatter: `description:` + the plan D1 expanded glob, verbatim — `paths: "**/.claude/rules/**,**/CLAUDE.md,**/.claude/output-styles/**,**/MEMORY.md"` (keys all four guard slots; AP-6 satisfied — the control itself is `paths:`-scoped and excluded from the surface it polices). Body: four-slot surface definition (no-`paths:` rules / `CLAUDE.md` / output styles / `MEMORY.md` head) with the all-slots binding rationale; recurrence grounding (~4x growth in three months, ~half in-place expansion → both modes covered); the statement duty as one `[ZONE:Evolvable] [HARD]` clause with four lettered parts — (a) new always-loaded file → bytes + cost justification in the change description, (b) single edit growing an existing file by more than 1,000 bytes → same statement sized to the growth, (c) the statement must address the cost paid by sessions that never need the file (grounded per plan M3 step 3: `session-handoff.md` closest cost-naming precedent; `native-idiom-and-register.md` "zero burden for English sessions" true for behavior, false for context bytes), (d) `paths:`-scope-first question before the duty fires; threshold calibration table (typo ~100 B / one-line ~200 B / paragraph ~800 B pass; new HARD clause ~1,200 B / new `##` section ~2,500 B fire); explicit no-cumulative-delta-secondary-trigger clause (accepted residual risk per plan D4-3); self-compliance note. Size calibration vs development-category siblings: branch-origin-protocol.md 4,180 B, karpathy-quickref.md 2,068 B.
@@ -147,7 +147,7 @@ exit=0
 
 **Other verification:** `go build ./...` → exit 0 (no output). `go test ./internal/config/ -count=1` (full package) → `ok  	github.com/modu-ai/moai-adk/internal/config	5.690s` exit=0. Subagent boundary: `grep -cn 'AskUserQuestion\|mcp__askuser'` on rule-authoring.md → 0. Neutrality pre-check (M4 mirrorability, local file): spec_id=0 req=0 sha=0 date=0 — no sanitization needed at mirror time. golangci-lint: n/a — 0 Go files changed; markdown has no lint gate. RED-state evidence: n/a — documentation milestone, no test-first artifact (recorded as a gap, not fabricated; E8 docs-milestone gap).
 
-### M4 — 미러 + 빌드 + 최종 계측 (2026-08-17)
+### M4 — 미러 + 빌드 + 최종 계측 (2026-08-16)
 
 - Tree: worktree `feat/spec-always-loaded-diet`, pre-M4 HEAD `fcc07d1bc` (= the M3 commit; working tree clean at dispatch — verified `git status --short` empty).
 - Mirror scope: the 5 created/modified rule files, copied to `internal/template/templates/` at the corresponding paths. Pre-mirror baseline established: the two MODIFIED files' pre-edit dev versions (`a203a7c3a~1` kanban-dispatch.md, `6d701d26c~1` cache-aware-execution.md) are **byte-identical to the template copies** (`diff` exit 0, 0 lines) — the mirror applies to a clean baseline, no foreign template divergence to preserve.
@@ -181,7 +181,7 @@ bytes=288975 tokens=72243 headroom=2757              # plan §C grep -rL form (i
 
 ```yaml
 run_status: audit-ready
-run_complete_at: 2026-08-17
+run_complete_at: 2026-08-16
 spec_id: SPEC-ALWAYS-LOADED-DIET-001
 branch: feat/spec-always-loaded-diet
 worktree: /tmp/wt-run-ald
@@ -196,7 +196,7 @@ ac_fail_count: 0
 final_headroom_tokens: 2757   # observed post-M4, both measurement forms agree; baseline 1239; D4-1 budget-ratchet card input
 always_loaded_files: 14   # unchanged pre/post diet (files split, not removed)
 bytes_pre: 295044
-bytes_post: 288975   # net -6069 B (-1515 tokens); M1 -7976, M2 +1907, M3 0, M4 0
+bytes_post: 288975   # net -6069 B (-1518 tokens); M1 -7976, M2 +1907, M3 0, M4 0
 preserve_list_post_run_count: 0   # no Go/config/hook surface touched; go_changed=0 across the run phase
 l44_pre_commit_fetch: true        # worktree branch only; primary checkout untouched; explicit-pathspec staging, no -A/-a
 l44_post_push_fetch: n/a          # not pushed — branch awaits orchestrator

--- a/.moai/specs/SPEC-ALWAYS-LOADED-DIET-001/progress.md
+++ b/.moai/specs/SPEC-ALWAYS-LOADED-DIET-001/progress.md
@@ -190,7 +190,7 @@ run_phase_commits:
   - a203a7c3a   # M1 kanban-dispatch.md split (stub + domain-keyed detail companion)
   - 6d701d26c   # M2 cache-aware-execution.md directives 6-10 + self-keyed reference companion
   - fcc07d1bc   # M3 rule-authoring.md recurrence control (paths-scoped, 4-slot)
-  - PENDING-M4-BACKFILL   # M4 template mirror (5 files) + rebuild + final measurement
+  - 9269a5e56   # M4 template mirror (5 files) + rebuild + final measurement
 ac_pass_count: 16
 ac_fail_count: 0
 final_headroom_tokens: 2757   # observed post-M4, both measurement forms agree; baseline 1239; D4-1 budget-ratchet card input

--- a/.moai/specs/SPEC-ALWAYS-LOADED-DIET-001/spec.md
+++ b/.moai/specs/SPEC-ALWAYS-LOADED-DIET-001/spec.md
@@ -2,7 +2,7 @@
 id: SPEC-ALWAYS-LOADED-DIET-001
 title: "always-loaded 컨텍스트 표면 다이어트 + 캐시 규율 편입 + 재발 통제"
 version: "0.1.1"
-status: draft
+status: in-progress
 created: 2026-08-16
 updated: 2026-08-17
 author: manager-spec

--- a/internal/template/templates/.claude/rules/moai/development/rule-authoring.md
+++ b/internal/template/templates/.claude/rules/moai/development/rule-authoring.md
@@ -1,0 +1,55 @@
+---
+description: "Always-loaded surface recurrence control — statement duty on creating a new slot file and on any single edit growing one by more than 1,000 bytes"
+paths: "**/.claude/rules/**,**/CLAUDE.md,**/.claude/output-styles/**,**/MEMORY.md"
+---
+
+# Rule Authoring — Always-Loaded Cost Discipline
+
+> Loading scope: this rule keys the four guard slots themselves. Any edit that creates or grows an always-loaded file is the moment this discipline attaches — including edits to this repository's `CLAUDE.md`, its output styles, and `MEMORY.md`.
+
+## The surface and its four slots
+
+Claude Code re-injects the always-loaded surface on every turn, and `/clear` re-pays all of it at once. The surface is made of four slots:
+
+1. Rule files under `.claude/rules/` that lack a top-level `paths:` frontmatter key
+2. `CLAUDE.md`
+3. Output styles under `.claude/output-styles/`
+4. `MEMORY.md` (head)
+
+Rule files are not the whole surface. `CLAUDE.md` and the output styles together can outweigh every rule file, and the largest single contributor is an output style, not a rule. A duty that binds rule files only leaves the biggest share of the surface unwatched — every clause below therefore binds all four slots.
+
+## Why a cleanup is not enough
+
+A one-time diet does not stay done. In the repository this rule set ships from, the always-loaded rule surface grew roughly 4x in the three months after the previous reduction — and about half of that growth was existing files expanding in place, not new files arriving. Blocking new files alone blocks half the recurrence; the duty below covers both modes.
+
+## The statement duty
+
+[ZONE:Evolvable] [HARD] The duty has four parts, binding all four slots:
+
+- **(a) New file.** Creating a new always-loaded file — a rule file without top-level `paths:`, or a slot file such as `CLAUDE.md` or an output style — requires stating the file's byte size and a cost justification in the change description (commit body, or PR description where the change rides a PR).
+- **(b) Growth.** A single edit that grows an existing always-loaded file by more than 1,000 bytes requires the same statement, sized to the growth rather than the whole file.
+- **(c) Non-invoking cost.** Whatever statement (a) or (b) requires must address the cost paid by sessions that never need the file. Every session loads the surface; sessions that never invoke this feature pay for it anyway — every turn, and again after every `/clear`. No current always-loaded file's justification covers this cost: `session-handoff.md` is the closest precedent (it names the re-paid prefix as a cost), and `native-idiom-and-register.md`'s "zero burden for English sessions" is true for behavior and false for context bytes. A justification that does not name what the never-needing session pays is incomplete.
+- **(d) Scope first.** Before either duty fires, ask whether the content can live under a `paths:` scope instead — a reference companion keyed to the files that need it costs the surface nothing. Only content that genuinely must be always-loaded proceeds to the statement.
+
+## Threshold calibration
+
+The threshold is **1,000 bytes, single-edit basis**. Typical edit shapes:
+
+| Edit shape | Typical size | Duty fires |
+|---|---|---|
+| Typo fix | ~100 B | no |
+| One-line addition | ~200 B | no |
+| A paragraph | ~800 B | no |
+| A new HARD clause | ~1,200 B | yes |
+| A new `##` section | ~2,500 B | yes |
+
+There is deliberately **no cumulative-delta secondary trigger**: growth arriving as many sub-1,000-byte edits accumulates unwatched. That blind spot is an accepted residual risk, not an oversight to patch later — tracking per-file drift on every small edit would cost more attention than the growth it catches.
+
+## Self-compliance
+
+This rule carries a top-level `paths:` key, so it is excluded from the always-loaded surface it polices. The recurrence control must not itself be recurrence.
+
+---
+
+Version: 1.0.0
+Classification: Evolvable operational rule — binds edits to the four always-loaded slots; changes no gate semantics.

--- a/internal/template/templates/.claude/rules/moai/workflow/cache-aware-execution-reference.md
+++ b/internal/template/templates/.claude/rules/moai/workflow/cache-aware-execution-reference.md
@@ -9,17 +9,19 @@ paths: "**/cache-aware-execution.md"
 
 ## Cited cache numbers
 
-All figures in this section are **quoted source values** — quoted from the source article, **not re-measured** in the session that authored directives 6-10, and never to be restated as measurements of this project.
+All figures in this section are **quoted source values** — quoted from the source article, **not re-measured** in the session that authored directives 6-10, and never to be restated as measurements of this project. Date context: quoted from the source article as current on 2026-08-16 (the authoring date) and cross-checked against Anthropic's prompt-caching documentation during the 2026-08-16 PR review — performance figures the provider may change; re-quote before relying on one.
 
 | Quantity | Quoted value |
 |---|---|
 | Cache read | 0.1x the base input price |
 | Cache write (worst case) | up to 2x |
-| Output tokens | roughly 5x the input price |
-| Cache TTL (subscription) | 1 hour |
-| Cache TTL (API key) | 5 minutes |
+| Output tokens | roughly 5x the input price — output pricing is separate from input pricing and model-dependent; not a cache-cost figure |
+| Cache TTL (subscription auth, default) | 1 hour |
+| Cache TTL (API-key auth, default) | 5 minutes |
 
-The parent rule's intro quotes different figures for the write multiplier and TTL (reads ~0.1x, writes 1.25x, 5-minute TTL) — both sets are quoted from their respective source passages; neither was measured here, and the difference is a scope-of-quote artifact, not a contradiction this file resolves.
+Both TTL rows are authentication-mode defaults, not fixed properties: each cache hit refreshes the window (sliding TTL), and at the API level the 5-minute TTL is the default while the 1-hour TTL is an explicit `cache_control` override (`ttl: "1h"`). A Claude Code session selects neither — the runtime places cache breakpoints itself (parent rule, Non-goals).
+
+The parent rule's intro quotes different figures for the write multiplier and TTL (reads ~0.1x, writes 1.25x, 5-minute TTL) — both sets are quoted from their respective source passages; neither was measured here, and the difference is a scope-of-quote artifact, not a contradiction this file resolves. Neither figure is universal: the write multiplier ranges up to 2x and the TTL follows the authentication default (see above), so the parent's 1.25x / 5-minute pairing holds only for the API-key-default passage it was quoted from.
 
 ## Directive rationale
 
@@ -37,7 +39,7 @@ Routine commands in their default form emit progress spinners, banners, tables, 
 
 ### Directive 9 — session length as a cost axis
 
-Every fresh session re-pays the always-loaded prefix at write price; a continuing session reads it from cache. For the same body of work, N short sessions multiply the write; one long session pays it once. This is the same axis directive 4 weighs for `/clear` — the paste-ready resume exists precisely so a context reset buys something.
+Every fresh session re-pays the always-loaded prefix at write price; a continuing session reads it from cache — but only while that cache is warm. A gap longer than the idle TTL (a blocking user gate, an unattended wait) or a prefix invalidation (a session-loaded file edited mid-session — directive 3) reverts the next request to write price, collapsing the cheaper-continuation claim. For the same body of work, N short sessions multiply the write; one long session pays it once. This is the same axis directive 4 weighs for `/clear` — the paste-ready resume exists precisely so a context reset buys something.
 
 ### Directive 10 — mid-session model or effort switch
 

--- a/internal/template/templates/.claude/rules/moai/workflow/cache-aware-execution-reference.md
+++ b/internal/template/templates/.claude/rules/moai/workflow/cache-aware-execution-reference.md
@@ -9,7 +9,7 @@ paths: "**/cache-aware-execution.md"
 
 ## Cited cache numbers
 
-All figures in this section are **quoted source values** — quoted from the source article, **not re-measured** in the session that authored directives 6-10, and never to be restated as measurements of this project. Date context: quoted from the source article as current on 2026-08-16 (the authoring date) and cross-checked against Anthropic's prompt-caching documentation during the 2026-08-16 PR review — performance figures the provider may change; re-quote before relying on one.
+All figures in this section are **quoted source values** — quoted from the source article, **not re-measured** in the session that authored directives 6-10, and never to be restated as measurements of this project. Date context: quoted from the source article as current at this file's authoring and cross-checked against Anthropic's prompt-caching documentation at the same time — performance figures the provider may change; re-quote before relying on one.
 
 | Quantity | Quoted value |
 |---|---|

--- a/internal/template/templates/.claude/rules/moai/workflow/cache-aware-execution-reference.md
+++ b/internal/template/templates/.claude/rules/moai/workflow/cache-aware-execution-reference.md
@@ -1,0 +1,49 @@
+---
+description: "Reference companion for cache-aware-execution.md — cited cache-cost numbers, per-directive rationale, and worked examples for directives 6-10"
+paths: "**/cache-aware-execution.md"
+---
+
+# Cache-Aware Execution — Reference Companion
+
+> This is the reference companion of `cache-aware-execution.md`. The always-loaded rule owns the directive bodies (numbered 1-10) and nothing else from this file. This file owns the cited cache numbers, the per-directive rationale, and the worked examples behind directives 6-10. Load this file when authoring or reviewing one of those directives, or when a directive's grounding is challenged.
+
+## Cited cache numbers
+
+All figures in this section are **quoted source values** — quoted from the source article, **not re-measured** in the session that authored directives 6-10, and never to be restated as measurements of this project.
+
+| Quantity | Quoted value |
+|---|---|
+| Cache read | 0.1x the base input price |
+| Cache write (worst case) | up to 2x |
+| Output tokens | roughly 5x the input price |
+| Cache TTL (subscription) | 1 hour |
+| Cache TTL (API key) | 5 minutes |
+
+The parent rule's intro quotes different figures for the write multiplier and TTL (reads ~0.1x, writes 1.25x, 5-minute TTL) — both sets are quoted from their respective source passages; neither was measured here, and the difference is a scope-of-quote artifact, not a contradiction this file resolves.
+
+## Directive rationale
+
+### Directive 6 — `@`-mention, and `/context` as a one-shot audit
+
+Citing a filename in prose and relying on the model to fetch it spends a turn on the fetch and risks a miss or a stale read; an `@`-mention loads the file once, deterministically, at the point of need. `/context` re-renders the loaded-context summary on every invocation, which is an audit action (what is actually loaded, how close is the ceiling), not a routine status check.
+
+### Directive 7 — bounded command output
+
+Command output lands in the context and stays there for every later turn of the session; one verbose command is paid again on each subsequent request. The runtime truncates at `BASH_MAX_OUTPUT_LENGTH`, but the bound should be chosen by the caller — quiet flags, targeted queries, or redirect-to-file with the exit code and a bounded tail (the file-redirect contract of `agent-common-protocol.md` § Parallel Execution, generalized from verification batches to all commands).
+
+### Directive 8 — quiet forms of routine commands
+
+Routine commands in their default form emit progress spinners, banners, tables, and ANSI color — none of it decision-relevant. The quiet form returns the same decision bytes for a fraction of the context cost: `--no-progress`, `-q`/`--quiet`, machine-readable output (`--json`, `--porcelain`) piped through a targeted filter.
+
+### Directive 9 — session length as a cost axis
+
+Every fresh session re-pays the always-loaded prefix at write price; a continuing session reads it from cache. For the same body of work, N short sessions multiply the write; one long session pays it once. This is the same axis directive 4 weighs for `/clear` — the paste-ready resume exists precisely so a context reset buys something.
+
+### Directive 10 — mid-session model or effort switch
+
+Caches are model-scoped, and an effort or thinking-budget change (`MAX_THINKING_TOKENS`) keys a fresh cache as well: the request after the switch re-writes the prefix at full price. The apparent conflict with `agent-common-protocol.md` § Per-Spawn Model Injection is an axis difference, stated in the directive itself: Per-Spawn Model Injection governs which model a *subagent context* runs on (most agent definitions declare `model: inherit`, and an unspecified spawn silently falls back to the parent model); directives 5 and 10 govern the *main session's* accumulated cache. Neither SSOT revises the other.
+
+---
+
+Version: 1.0.0
+Classification: Reference companion — paths-scoped, never part of the always-loaded surface.

--- a/internal/template/templates/.claude/rules/moai/workflow/cache-aware-execution.md
+++ b/internal/template/templates/.claude/rules/moai/workflow/cache-aware-execution.md
@@ -22,7 +22,7 @@ Prompt-caching-aware ordering rules for orchestrator execution. Anthropic prompt
 
 8. **Prefer the quiet form of routine commands** [ZONE:Evolvable] [HARD] Call everyday commands in their quiet form — `--no-progress`, `-q`, machine-readable output with a targeted filter — not forms that emit spinners, banners, tables, or color noise: the same decision bytes, a fraction of the context cost.
 
-9. **Weigh session length as a cost axis** [ZONE:Evolvable] [HARD] One long session is cheaper than several short ones for the same work — every fresh session re-pays the always-loaded prefix at write price, a continuing one reads it from cache. Treat session splitting as directive 4 treats `/clear`: a cost to justify, not a default.
+9. **Weigh session length as a cost axis** [ZONE:Evolvable] [HARD] One long session is cheaper than several short ones for the same work — every fresh session re-pays the always-loaded prefix at write price, a continuing one reads it from cache — if it stays warm: a >5-min idle gap or prefix edit reverts it to write price. Treat session splitting as directive 4 treats `/clear`: a cost to justify, not a default.
 
 10. **A mid-session model or effort switch busts the cache** [ZONE:Evolvable] [HARD] Changing model or effort mid-session (thinking budget included — `MAX_THINKING_TOKENS`) discards the prompt cache; prefer a natural boundary for the switch. Directive 5 and this one govern the main session's cache; `agent-common-protocol.md` § Per-Spawn Model Injection governs which model a subagent runs on — different axes, not a contradiction.
 

--- a/internal/template/templates/.claude/rules/moai/workflow/cache-aware-execution.md
+++ b/internal/template/templates/.claude/rules/moai/workflow/cache-aware-execution.md
@@ -16,6 +16,16 @@ Prompt-caching-aware ordering rules for orchestrator execution. Anthropic prompt
 
 5. **Inherit the session model on spawns** [ZONE:Evolvable] Caches are model-scoped: a per-spawn model override splits the spawn off from every cache the session has built. Omit model overrides unless the task genuinely requires a different tier (already the default per agent-authoring guidance); this directive records the caching cost of violating it.
 
+6. **Pass files by `@`-mention, not by name** [ZONE:Evolvable] [HARD] When a prompt needs a file's content, pass it with an `@`-mention or a Read call rather than citing the filename for the model to fetch — one deterministic load beats a fetch-retry cycle. Use `/context` only as a one-shot audit of what is loaded, not a routine check.
+
+7. **Keep command output bounded** [ZONE:Evolvable] [HARD] Every command must bound what it returns: quiet flags, targeted queries, or redirect-to-file with the exit code and a bounded tail. `BASH_MAX_OUTPUT_LENGTH` is the runtime backstop, not the target; the file-redirect contract in `agent-common-protocol.md` § Parallel Execution applies to all commands.
+
+8. **Prefer the quiet form of routine commands** [ZONE:Evolvable] [HARD] Call everyday commands in their quiet form — `--no-progress`, `-q`, machine-readable output with a targeted filter — not forms that emit spinners, banners, tables, or color noise: the same decision bytes, a fraction of the context cost.
+
+9. **Weigh session length as a cost axis** [ZONE:Evolvable] [HARD] One long session is cheaper than several short ones for the same work — every fresh session re-pays the always-loaded prefix at write price, a continuing one reads it from cache. Treat session splitting as directive 4 treats `/clear`: a cost to justify, not a default.
+
+10. **A mid-session model or effort switch busts the cache** [ZONE:Evolvable] [HARD] Changing model or effort mid-session (thinking budget included — `MAX_THINKING_TOKENS`) discards the prompt cache; prefer a natural boundary for the switch. Directive 5 and this one govern the main session's cache; `agent-common-protocol.md` § Per-Spawn Model Injection governs which model a subagent runs on — different axes, not a contradiction.
+
 ## Non-goals
 
 - These directives NEVER justify skipping, weakening, or reordering an approval gate's *semantics* — Implementation Kickoff Approval and all HUMAN GATEs remain mandatory where defined. Only the *placement and batching* of questions is governed here.
@@ -27,8 +37,9 @@ Prompt-caching-aware ordering rules for orchestrator execution. Anthropic prompt
 - `.claude/rules/moai/workflow/context-window-management.md` — model-specific `/clear` thresholds (directive 4 is an additional, earlier trigger)
 - `.claude/rules/moai/core/agent-common-protocol.md` § Parallel Execution — single-turn verification batching (already cache-optimal: incremental append)
 - `.claude/rules/moai/core/askuser-protocol.md` — gate mechanics (unchanged by this rule)
+- `.claude/rules/moai/workflow/cache-aware-execution-reference.md` — cited cache numbers for directives 6-10
 
 ---
 
-Version: 1.0.0
+Version: 1.1.0
 Classification: Evolvable operational rule — execution ordering only; gate semantics unchanged.

--- a/internal/template/templates/.claude/rules/moai/workflow/kanban-dispatch-detail.md
+++ b/internal/template/templates/.claude/rules/moai/workflow/kanban-dispatch-detail.md
@@ -1,0 +1,116 @@
+---
+description: "Lead-only detail companion for kanban-dispatch.md — board, card classes, dispatch cycle, review lenses, /clear handoff"
+paths: "**/kanban-dispatch*.md,**/.claude/agents/moai/manager-kanban.md,**/.claude/skills/moai/workflows/todo.md"
+---
+
+# Kanban Dispatch — Detail Companion
+
+> Detail companion of `kanban-dispatch.md`, owning its lead-only sections; the always-loaded stub keeps every section that binds non-lead sessions. Load when moving a card between columns, classifying a card, or choosing review lenses.
+
+## The board
+
+Six columns, fixed and ordered:
+
+```
+backlog → plan → run → review → sync → done
+```
+
+`backlog` and `done` have no owning session. The four columns between them each map to exactly one companion role, which is what makes dispatch a lookup rather than a decision.
+
+| Column | Owning role | What happens there |
+|---|---|---|
+| `backlog` | *none* — a queue | Work waits. Entry is an operator act (see below). |
+| `plan` | `plan` | SPEC authored (`/moai plan`), then plan-audited. |
+| `run` | `run` | Implementation (`/moai run <SPEC-ID>`). |
+| `review` | `review` | Code review (`/moai review …`) with lenses chosen per card. |
+| `sync` | `sync` | Docs, CHANGELOG, PR (`/moai sync <SPEC-ID>`). |
+| `done` | *none* — terminal | Card closed. Nothing is dispatched here. |
+
+## Entry into the board is an operator act
+
+`backlog` has no owning session, so no completion report exists for the lead to react to, and a lead that admitted cards on its own initiative would be **generating** work rather than scheduling it. Entry is therefore always the operator's decision.
+
+The mechanism is `/moai todo`:
+
+- `/moai todo "<description>"` appends an item to the backlog queue.
+- `/moai todo` alone lists the queue.
+- After a `/clear`, the lead presents the queue through `AskUserQuestion` and the operator picks the next card. Only then does the lead dispatch to `plan`.
+
+The lead never picks for the operator, and never silently promotes a backlog item.
+
+## Card classes — not every card needs four columns
+
+Most of what accumulates in the backlog is chores: a one-line fix, a stale reference, a renamed flag. Sending those through `plan → run → review → sync` costs more in ceremony than the change is worth. The lead classifies each card as it leaves `backlog` and names the class in the dispatch.
+
+| Class | Shape | Path |
+|---|---|---|
+| A — direct close | The change is one file and one line, there is no design judgement in it, and CI catches the regression | One session carries the card through to a pull request; `plan` and `review` are skipped |
+| B — defect, cause unknown | Something is wrong and the cause has not been established | `run → review → sync`; `plan` is skipped, so no SPEC exists |
+| C — design change | The change contains a decision, or spans subsystems | All four columns |
+
+[HARD] **Class A is admitted on checked evidence, not on an assertion.** Two of its three properties are mechanically checkable, so they are checked and the check is cited: the diff is measured (`git diff --stat` against the base, showing the one file) and CI is observed green **on the head that will merge**. The third — no design judgement in it — is a judgement rather than a measurement, so it is stated in the dispatch where the operator can disagree with it. A card that cannot cite both measurements is not Class A, and it takes the `review` column.
+
+This is the same shape as the CodeRabbit section below. A class that skips review on a claim nobody checked is exactly the unobserved-claim hazard this rule forbids everywhere else; writing the justification down is not the same as verifying it.
+
+The justification is never "it is faster". Speed is the effect of skipping the columns, not the reason for it, and a card justified by speed alone is a Class C card being rushed.
+
+**Work in progress: one card per column, and only when each card occupies a different worktree.** Two cards sharing one worktree run serially whatever columns they sit in, because they share a working tree and a branch.
+
+For Class A this inverts where the parallelism comes from. Handing four sessions a whole card each puts four cards in flight; pipelining one card through four columns puts one. Pipelining repays its handoff cost only when each column does substantial work, which is the Class C case — and research fan-out during `plan` is reserved for Class C for the same reason.
+
+## The dispatch cycle
+
+Each arrow below is one dispatch from the lead to one companion session:
+
+```
+[operator picks a card]  →  plan  →  run  →  review  →  sync  →  [lead marks done]
+```
+
+Dispatch is addressed by session name. Companion sessions are named `<role>-<run-id>` at launch (for example `plan-a1b2c3`), and `ListAgents` reports the live set. Send with `SendMessage({to: "<name>", message: "…"})`; when a bare name is ambiguous, use the short reference the listing prints.
+
+Each instruction carries, at minimum: the card, the SPEC ID once one exists, the phase command to run, and the completion signal to write. Keep it a pointer, not a copy — the companion reads the SPEC artifacts itself rather than receiving them inline.
+
+**`sync → done` is the same act with the dispatch removed.** No session occupies `done`, so the lead reads the sync session's completion evidence and records the terminal transition itself.
+
+### Dispatch language
+
+[HARD] A dispatch is written in the operator's `conversation_language`. The operator watches it scroll past, which makes it user-facing output rather than internal agent traffic.
+
+This is a classification, not an exemption from the language rules, and it needs no change to either of them:
+
+- `agent-common-protocol.md` § Language Handling already opens with the opposite of an English default — agents receive and respond in the configured `conversation_language`. What it fixes to English is code, identifiers, and names. A dispatch is prose, so the rule was never against it; it simply did not name cross-session messages in its list.
+- `moai-constitution.md` § Response Language reserves English for internal agent communication, but the axis that clause sits on is stated one line above it: user-facing responses go in the operator's language. A message a human reads is user-facing by that rule's own criterion, so putting a dispatch in the operator's language applies the constitution rather than carving an exception out of it.
+
+The carve-out is narrow, and the boundary is **who reads it**. An `Agent()` subagent prompt reaches no human and stays English.
+
+What stays verbatim in every language: SPEC IDs, command names and their flags, file paths, session names, and technical identifiers. Those are addresses rather than prose, and a translated address does not resolve.
+
+## Review lens selection
+
+`review` is not one thing. The lead picks the lenses from what the card actually changed, and states the reason in the dispatch so the review session does not re-derive it:
+
+| Card touched | Lenses to instruct |
+|---|---|
+| Auth, session handling, input parsing, external calls, secrets, file/path handling | `--security` (add `--deep` when the surface is reachable by untrusted input) |
+| Non-trivial logic across several files | `--deep` (adversarially verified multi-phase scan) |
+| Whole-tree sweep rather than a diff | add `--repo` |
+| Suspected over-engineering | `--lean` (advisory only; applies no fixes) |
+| UI or design-system surface | `--design`, and `--critique` after the build |
+| Small, local, low-risk diff | no flag — the default 4-perspective pass is enough |
+
+`--deep --patch` is opt-in twice over: `--patch` drafts a fix and is absent unless the operator asked for it. Do not add it on the lead's own initiative.
+
+## The `/clear` handoff between phases
+
+[HARD] A companion session does not carry one card's context into the next card. When a phase completes and the lead has read its evidence, the lead **asks the operator to `/clear` that session** — `/clear` is a user-typed command and cannot be sent as an instruction.
+
+The lead's message to the operator states three things, in this order:
+
+1. **What closed** — the card, the phase, and the evidence that was read.
+2. **Which session to `/clear`** — by name, so the operator clears the right terminal.
+3. **What happens next** — the column the card moves to, and which session will be instructed once the clear is done.
+
+Where the next phase reuses a session that has just been cleared, the lead re-sends the full pointer instruction after the clear rather than assuming the session remembers the card.
+
+The lead's own session is cleared the same way, between cards rather than between phases: once a card reaches `done`, the lead asks the operator to `/clear` the lead session, and the next turn begins by presenting the backlog queue again.
+

--- a/internal/template/templates/.claude/rules/moai/workflow/kanban-dispatch.md
+++ b/internal/template/templates/.claude/rules/moai/workflow/kanban-dispatch.md
@@ -4,97 +4,21 @@ How the **lead** session of Kanban Mode moves a card across the board: what admi
 
 > **Loading scope**: Intentionally always-loaded. A session learns it is the kanban lead from the SessionStart context, not from a file path, so a `paths:`-restricted rule would never reach the session that needs it.
 
+> **Lead-only detail**: The board, Entry into the board is an operator act, Card classes, The dispatch cycle, Review lens selection, The `/clear` handoff between phases — moved to `kanban-dispatch-detail.md`; load when moving a card between columns, classifying a card, or choosing review lenses.
+
 ## Scope — when this rule is live
 
 This rule binds a session whose SessionStart context declares **Kanban Mode** with the `lead` role. In every other session it is inert: a companion session (`plan` / `run` / `review` / `sync`) receives instructions, it does not dispatch them, and a session outside Kanban Mode has no board to move.
 
 Kanban Mode is entered with `moai cc -k` (or `moai glm -k`), which elects one lead and prints one launch command per companion role. Companion sessions are launched **by hand, one per terminal** — a session cannot launch another session, and no mechanism to spawn a peer exists or is wanted.
 
-## The board
-
-Six columns, fixed and ordered:
-
-```
-backlog → plan → run → review → sync → done
-```
-
-`backlog` and `done` have no owning session. The four columns between them each map to exactly one companion role, which is what makes dispatch a lookup rather than a decision.
-
-| Column | Owning role | What happens there |
-|---|---|---|
-| `backlog` | *none* — a queue | Work waits. Entry is an operator act (see below). |
-| `plan` | `plan` | SPEC authored (`/moai plan`), then plan-audited. |
-| `run` | `run` | Implementation (`/moai run <SPEC-ID>`). |
-| `review` | `review` | Code review (`/moai review …`) with lenses chosen per card. |
-| `sync` | `sync` | Docs, CHANGELOG, PR (`/moai sync <SPEC-ID>`). |
-| `done` | *none* — terminal | Card closed. Nothing is dispatched here. |
-
-## Entry into the board is an operator act
-
-`backlog` has no owning session, so no completion report exists for the lead to react to, and a lead that admitted cards on its own initiative would be **generating** work rather than scheduling it. Entry is therefore always the operator's decision.
-
-The mechanism is `/moai todo`:
-
-- `/moai todo "<description>"` appends an item to the backlog queue.
-- `/moai todo` alone lists the queue.
-- After a `/clear`, the lead presents the queue through `AskUserQuestion` and the operator picks the next card. Only then does the lead dispatch to `plan`.
-
-The lead never picks for the operator, and never silently promotes a backlog item.
-
-## Card classes — not every card needs four columns
-
-Most of what accumulates in the backlog is chores: a one-line fix, a stale reference, a renamed flag. Sending those through `plan → run → review → sync` costs more in ceremony than the change is worth. The lead classifies each card as it leaves `backlog` and names the class in the dispatch.
-
-| Class | Shape | Path |
-|---|---|---|
-| A — direct close | The change is one file and one line, there is no design judgement in it, and CI catches the regression | One session carries the card through to a pull request; `plan` and `review` are skipped |
-| B — defect, cause unknown | Something is wrong and the cause has not been established | `run → review → sync`; `plan` is skipped, so no SPEC exists |
-| C — design change | The change contains a decision, or spans subsystems | All four columns |
-
-[HARD] **Class A is admitted on checked evidence, not on an assertion.** Two of its three properties are mechanically checkable, so they are checked and the check is cited: the diff is measured (`git diff --stat` against the base, showing the one file) and CI is observed green **on the head that will merge**. The third — no design judgement in it — is a judgement rather than a measurement, so it is stated in the dispatch where the operator can disagree with it. A card that cannot cite both measurements is not Class A, and it takes the `review` column.
-
-This is the same shape as the CodeRabbit section below. A class that skips review on a claim nobody checked is exactly the unobserved-claim hazard this rule forbids everywhere else; writing the justification down is not the same as verifying it.
-
-The justification is never "it is faster". Speed is the effect of skipping the columns, not the reason for it, and a card justified by speed alone is a Class C card being rushed.
-
-**Class B skips `plan`, not `review`** — an unestablished cause is precisely what review catches, so it is the last column to drop. The `run` session owns both the investigation and the fix. Before the card leaves `run`, the evidence that established the cause — the command that reproduced the defect and what it printed — is written into the card's progress record, and the run session names that path in its completion report so the lead reads the cause rather than taking it on trust.
-
-**Work in progress: one card per column, and only when each card occupies a different worktree.** Two cards sharing one worktree run serially whatever columns they sit in, because they share a working tree and a branch.
-
-For Class A this inverts where the parallelism comes from. Handing four sessions a whole card each puts four cards in flight; pipelining one card through four columns puts one. Pipelining repays its handoff cost only when each column does substantial work, which is the Class C case — and research fan-out during `plan` is reserved for Class C for the same reason.
-
-## The dispatch cycle
-
-Each arrow below is one dispatch from the lead to one companion session:
-
-```
-[operator picks a card]  →  plan  →  run  →  review  →  sync  →  [lead marks done]
-```
-
-Dispatch is addressed by session name. Companion sessions are named `<role>-<run-id>` at launch (for example `plan-a1b2c3`), and `ListAgents` reports the live set. Send with `SendMessage({to: "<name>", message: "…"})`; when a bare name is ambiguous, use the short reference the listing prints.
-
-Each instruction carries, at minimum: the card, the SPEC ID once one exists, the phase command to run, and the completion signal to write. Keep it a pointer, not a copy — the companion reads the SPEC artifacts itself rather than receiving them inline.
-
-**`sync → done` is the same act with the dispatch removed.** No session occupies `done`, so the lead reads the sync session's completion evidence and records the terminal transition itself.
-
-### Dispatch language
-
-[HARD] A dispatch is written in the operator's `conversation_language`. The operator watches it scroll past, which makes it user-facing output rather than internal agent traffic.
-
-This is a classification, not an exemption from the language rules, and it needs no change to either of them:
-
-- `agent-common-protocol.md` § Language Handling already opens with the opposite of an English default — agents receive and respond in the configured `conversation_language`. What it fixes to English is code, identifiers, and names. A dispatch is prose, so the rule was never against it; it simply did not name cross-session messages in its list.
-- `moai-constitution.md` § Response Language reserves English for internal agent communication, but the axis that clause sits on is stated one line above it: user-facing responses go in the operator's language. A message a human reads is user-facing by that rule's own criterion, so putting a dispatch in the operator's language applies the constitution rather than carving an exception out of it.
-
-The carve-out is narrow, and the boundary is **who reads it**. An `Agent()` subagent prompt reaches no human and stays English.
-
-What stays verbatim in every language: SPEC IDs, command names and their flags, file paths, session names, and technical identifiers. Those are addresses rather than prose, and a translated address does not resolve.
-
 ## Completion is read, never trusted
 
 [HARD] The lead advances a card on **evidence it read**, not on a companion's reply. Reply routing between sessions is not guaranteed to arrive, and a reply is a claim rather than an observation.
 
 Before moving a card out of a working column, the lead reads the card's `progress.md` (and, where the phase declares one, the verification evidence path it cites) and confirms the phase actually closed. A missing, unreadable, or stale evidence file is a **gap** — the card stays where it is and the lead reports why. Absence of a failure signal is not a pass.
+
+**Class B skips `plan`, not `review`** — an unestablished cause is precisely what review catches, so it is the last column to drop. The `run` session owns both the investigation and the fix. Before the card leaves `run`, the evidence that established the cause — the command that reproduced the defect and what it printed — is written into the card's progress record, and the run session names that path in its completion report so the lead reads the cause rather than taking it on trust.
 
 This applies equally to the operator: when the lead reports a column advanced, it names what it read.
 
@@ -120,35 +44,6 @@ A CodeRabbit row counts as evidence only when BOTH of these hold:
 Anything else is a gap, not a pass. `Review rate limited` in particular means the review never started, and a card carrying it does not leave `review` or `sync`.
 
 Branch protection is not the lever here. The status state is `success` in precisely the failing case, so adding CodeRabbit to the required contexts would admit the unreviewed pull request just as readily. The distinction lives in the description, and only a read of the description surfaces it — which is why an automated merge gate closing this hole does not close it on the path a human merges by hand.
-
-## Review lens selection
-
-`review` is not one thing. The lead picks the lenses from what the card actually changed, and states the reason in the dispatch so the review session does not re-derive it:
-
-| Card touched | Lenses to instruct |
-|---|---|
-| Auth, session handling, input parsing, external calls, secrets, file/path handling | `--security` (add `--deep` when the surface is reachable by untrusted input) |
-| Non-trivial logic across several files | `--deep` (adversarially verified multi-phase scan) |
-| Whole-tree sweep rather than a diff | add `--repo` |
-| Suspected over-engineering | `--lean` (advisory only; applies no fixes) |
-| UI or design-system surface | `--design`, and `--critique` after the build |
-| Small, local, low-risk diff | no flag — the default 4-perspective pass is enough |
-
-`--deep --patch` is opt-in twice over: `--patch` drafts a fix and is absent unless the operator asked for it. Do not add it on the lead's own initiative.
-
-## The `/clear` handoff between phases
-
-[HARD] A companion session does not carry one card's context into the next card. When a phase completes and the lead has read its evidence, the lead **asks the operator to `/clear` that session** — `/clear` is a user-typed command and cannot be sent as an instruction.
-
-The lead's message to the operator states three things, in this order:
-
-1. **What closed** — the card, the phase, and the evidence that was read.
-2. **Which session to `/clear`** — by name, so the operator clears the right terminal.
-3. **What happens next** — the column the card moves to, and which session will be instructed once the clear is done.
-
-Where the next phase reuses a session that has just been cleared, the lead re-sends the full pointer instruction after the clear rather than assuming the session remembers the card.
-
-The lead's own session is cleared the same way, between cards rather than between phases: once a card reaches `done`, the lead asks the operator to `/clear` the lead session, and the next turn begins by presenting the backlog queue again.
 
 ## Isolation is entered, never provisioned
 
@@ -228,3 +123,4 @@ Reading the script first does not restore them. A human read is not the guard ru
 ---
 
 Classification: Evolvable operational rule — applies to the lead session of Kanban Mode.
+Version: 1.1.0 — split into stub + detail companion


### PR DESCRIPTION
## What

Always-loaded context diet for SPEC-ALWAYS-LOADED-DIET-001 — reduces the always-loaded rule surface and arms recurrence control.

- **M1** — `kanban-dispatch.md` split into a stub + paths-scoped companion: 21,003B file → 13,027B stub, 0 lines lost.
- **M2** — G3-G7 cache disciplines incorporated into `cache-aware-execution.md` (+1,907B) with a cited-numbers reference companion.
- **M3** — new `rule-authoring.md` recurrence control (paths-scoped loading, 4-slot coverage, 1,000B single-edit threshold).
- **M4** — all 5 files mirrored to `internal/template/templates/` (byte-identical, neutrality-scanned clean) + `make build`.

## Result

- Always-loaded surface: **295,044 → 288,975 bytes**
- Guard headroom: **1,239 → 2,757 tokens** (73,761 → 72,243 estimated tokens)
- **16/16 acceptance criteria PASS** — matrices in `.moai/specs/SPEC-ALWAYS-LOADED-DIET-001/progress.md` §E.2
- §E.3 run_status: **audit-ready**

## Evidence

- Guard `go test ./internal/config/ -run TestAlwaysLoaded` green at HEAD
- `MOAI_TEMPLATE_LEAK_STRICT=1` `./internal/template/` suite green
- Zero Go source changes (5 rule files local + 5 template mirrors + SPEC progress.md)

## Note

Parity-registry enrollment for the 5 mirrored files is deliberately deferred as a follow-up card (outside this SPEC's file-budget envelope).

SPEC: SPEC-ALWAYS-LOADED-DIET-001
Phase: RUN-*

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance for managing always-loaded instructions, including size thresholds and scoping considerations.
  - Expanded cache-aware execution guidance with cost, TTL, output, session, and model-switching recommendations.
  - Added detailed Kanban dispatch procedures covering workflow stages, card handling, evidence, reviews, and handoffs.
- **Templates**
  - Mirrored the updated guidance into project templates.
- **Project Tracking**
  - Recorded milestone verification, acceptance results, risks, and audit-ready completion status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->