### PR TITLE
fix(config): skip config-cache write in uninitialized directories so init validation passes

### DIFF
--- a/internal/config/cache.go
+++ b/internal/config/cache.go
@@ -122,6 +122,19 @@ func (l *Loader) LoadWithCache(configDir string) (*Config, error) {
 		return nil, err
 	}
 
+	// Skip the cache write when the config directory itself does not exist
+	// (issue #1568): writeCache's MkdirAll would materialize
+	// <root>/.moai/state/ as a side effect, and `moai init` then fails its
+	// "project already initialized" validation against the directory this
+	// very command just created. The project is not initialized here, so
+	// there is nothing worth caching; caching resumes once the directory
+	// exists (after init or update).
+	if _, statErr := os.Stat(configDir); statErr != nil {
+		slog.Debug("config cache: skipping write (config directory does not exist)",
+			"config_dir", configDir)
+		return cfg, nil
+	}
+
 	// Write cache (fail-open: a write failure is logged and ignored — the
 	// cache is an optimization, not a correctness dependency; C-EDGE-003).
 	if writeErr := writeCache(cachePath, cfg, currentFP); writeErr != nil {

--- a/internal/config/cache_test.go
+++ b/internal/config/cache_test.go
@@ -297,6 +297,33 @@ func TestCache_LocationUnderStateDir(t *testing.T) {
 	}
 }
 
+// TestCache_DoesNotCreateConfigDir (issue #1568) verifies that a cache-miss
+// write does not materialize the config directory as a side effect. Before
+// this guard, running any non-trivial moai command in a fresh directory
+// created <dir>/.moai/state/config-cache.json via writeCache's MkdirAll, and
+// `moai init` then failed its "project already initialized" validation
+// against the directory the very same command had just created.
+func TestCache_DoesNotCreateConfigDir(t *testing.T) {
+	requireCacheEnabled(t)
+	base := t.TempDir()
+	// The config directory of an uninitialized project: <root>/.moai, absent.
+	configDir := filepath.Join(base, "fresh-project", ".moai")
+
+	cfg, err := NewLoader().LoadWithCache(configDir)
+	if err != nil {
+		t.Fatalf("LoadWithCache on uninitialized dir: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("LoadWithCache returned nil config")
+	}
+
+	if _, statErr := os.Stat(configDir); statErr == nil {
+		t.Fatalf("LoadWithCache created %s as a side effect; the cache write must be skipped when the config directory does not exist", configDir)
+	} else if !os.IsNotExist(statErr) {
+		t.Fatalf("stat %s: %v", configDir, statErr)
+	}
+}
+
 // TestCache_SizeChangeInvalidates (AP-2 defense) verifies that a file whose
 // mtime did NOT change but whose size DID is treated as invalid.
 func TestCache_SizeChangeInvalidates(t *testing.T) {

--- a/internal/core/project/validator.go
+++ b/internal/core/project/validator.go
@@ -53,6 +53,43 @@ var requiredMoAIDirs = []string{
 	"logs",
 }
 
+// configCacheArtifactName is the fixed cache file name the config loader
+// writes under .moai/state/ (internal/config cache.go cacheFileName). It is
+// duplicated here as a local constant because the canonical one is unexported
+// and pulling the whole config package in would couple this validator to its
+// loader. Keep in sync with internal/config/cache.go.
+const configCacheArtifactName = "config-cache.json"
+
+// moaiDirIsOnlyCacheArtifact reports whether dir contains nothing but the
+// config cache artifact (.moai/state/config-cache.json) — the exact litter a
+// pre-fix moai command left in an uninitialized directory (issue #1568), and
+// therefore not evidence of an initialized project. Any other content
+// (config/, manifest.json, specs/, ...) marks a real project and MUST keep
+// failing validation as before.
+func moaiDirIsOnlyCacheArtifact(dir string) bool {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, entry := range entries {
+		if entry.Name() != "state" {
+			return false
+		}
+	}
+
+	stateEntries, err := os.ReadDir(filepath.Join(dir, "state"))
+	if err != nil {
+		// .moai/ without a readable state/ is not this hazard's shape.
+		return false
+	}
+	for _, entry := range stateEntries {
+		if entry.Name() != configCacheArtifactName {
+			return false
+		}
+	}
+	return true
+}
+
 // requiredClaudeDirs lists the directories that must exist under .claude/.
 // Post SPEC-V3R6-AGENT-FOLDER-SPLIT-001: agents are split into 4 domain subfolders.
 var requiredClaudeDirs = []string{
@@ -79,8 +116,16 @@ func (v *projectValidator) Validate(root string) (*ValidationResult, error) {
 	// Check if .moai/ already exists
 	moaiDir := filepath.Join(root, defs.MoAIDir)
 	if dirExists(moaiDir) {
-		result.Valid = false
-		result.Errors = append(result.Errors, "project already initialized: .moai/ directory exists. Use --force to reinitialize.")
+		if moaiDirIsOnlyCacheArtifact(moaiDir) {
+			// The directory holds nothing but the config cache artifact a
+			// pre-fix moai command left behind (issue #1568): tool litter,
+			// not an initialized project. Treat the project as
+			// uninitialized so init succeeds without manual cleanup.
+			result.Warnings = append(result.Warnings, ".moai/ contains only the config cache artifact; treating the directory as uninitialized.")
+		} else {
+			result.Valid = false
+			result.Errors = append(result.Errors, "project already initialized: .moai/ directory exists. Use --force to reinitialize.")
+		}
 	}
 
 	// Check if .claude/ already exists

--- a/internal/core/project/validator_test.go
+++ b/internal/core/project/validator_test.go
@@ -29,6 +29,39 @@ func TestValidate(t *testing.T) {
 			wantErrors: []string{"project already initialized"},
 		},
 		{
+			// Issue #1568: a pre-fix moai command left .moai/state/config-cache.json
+			// in an uninitialized directory; that litter must not block init.
+			name: "moai dir with only cache artifact is treated as uninitialized",
+			setup: func(t *testing.T, root string) {
+				t.Helper()
+				mkDir(t, root, ".moai/state")
+				writeFile(t, root, ".moai/state/config-cache.json", `{"schema_version":1}`)
+			},
+			wantValid:    true,
+			wantWarnings: []string{"treating the directory as uninitialized"},
+		},
+		{
+			name: "moai dir with cache artifact plus any real content stays invalid",
+			setup: func(t *testing.T, root string) {
+				t.Helper()
+				mkDir(t, root, ".moai/state")
+				writeFile(t, root, ".moai/state/config-cache.json", `{"schema_version":1}`)
+				writeFile(t, root, ".moai/manifest.json", `{"version":"1.0.0"}`)
+			},
+			wantValid:  false,
+			wantErrors: []string{"project already initialized"},
+		},
+		{
+			name: "moai dir with unexpected state content stays invalid",
+			setup: func(t *testing.T, root string) {
+				t.Helper()
+				mkDir(t, root, ".moai/state")
+				writeFile(t, root, ".moai/state/other.json", `{}`)
+			},
+			wantValid:  false,
+			wantErrors: []string{"project already initialized"},
+		},
+		{
 			name: "existing claude directory triggers warning",
 			setup: func(t *testing.T, root string) {
 				t.Helper()


### PR DESCRIPTION

### Summary

`moai init` in a brand-new empty directory failed with "project already
initialized" (issue #1568, a v3.1.0 regression). The cause is an ordering
side effect: every non-trivial command eagerly loads the project config
(`InitDependencies` → `ConfigManager.Load` → `Loader.LoadWithCache`), and on
a cache miss `writeCache` ran `os.MkdirAll(<root>/.moai/state/)`,
materializing `.moai/` in the uninitialized directory before init's
validator ran. The validator then flagged the tool's own artifact as an
existing project and aborted.

Two changes:

1. **Root cause** — `internal/config/cache.go`: `LoadWithCache` skips the
   cache write when the config directory itself does not exist. An
   uninitialized directory is left untouched (this also stops every other
   non-trivial moai command from leaving `.moai/state/config-cache.json`
   litter in arbitrary working directories). Caching resumes unchanged once
   the directory exists (after init/update).
2. **Poison healing** — `internal/core/project/validator.go`: a `.moai/`
   containing ONLY `state/config-cache.json` is treated as tool litter, not
   an initialized project, so directories already poisoned by a pre-fix
   binary initialize cleanly after upgrading — no manual cleanup, no
   `--force`. Any other content in `.moai/` still fails validation exactly
   as before.

### Root-cause archaeology

The cache layer landed with the config-perf work in the v3.1.0 cycle; the
eager `deps.Config.Load(cwd)` startup wiring is what puts it ahead of init's
`Validate` call. v3.0.1 had no disk-cache layer, hence no regression there.

### Test plan

- New regression test `TestCache_DoesNotCreateConfigDir`
  (`internal/config/cache_test.go`): asserts `LoadWithCache` on a
  nonexistent config dir creates nothing. Demonstrated FAILING on
  origin/main (fix reverted, test kept) and PASSING with the fix.
- New validator table cases (`internal/core/project/validator_test.go`):
  cache-artifact-only `.moai/` → valid (the poisoning case, fails on
  origin/main); artifact + any real content → still invalid; unexpected
  state content → still invalid (controls).
- Binary-level, both directions: origin/main build in a fresh empty dir →
  exit 1 "project already initialized" with `.moai/state/config-cache.json`
  (8,197 bytes) left behind (the reporter's exact symptom); fixed build in
  the same scenario → exit 0, project initialized. Fixed build also
  succeeds in a directory pre-poisoned with the artifact.
- `go test ./internal/config/ -run TestCache -count=1` → ok;
  `go test ./internal/core/project/ -count=1` → ok. The only failures in
  the full package runs (`TestShippedConfigKeysHaveReaders` in config) are
  pre-existing on pristine origin/main, verified on an untouched extraction.

Fixes #1568
