### PR TITLE
fix(hook): implement WorktreeCreate active-creator contract so isolation: worktree spawns succeed

### DIFF
--- a/internal/cli/hook.go
+++ b/internal/cli/hook.go
@@ -345,17 +345,26 @@ func runHookEvent(cmd *cobra.Command, event hook.EventType) error {
 // writeHookOutput dispatches stdout writing per event-specific contract.
 //
 // WorktreeCreate / WorktreeRemove (Claude Code v2.1.49+): the runtime parses
-// stdout as the worktree directory path (not JSON). The hook MUST echo the
-// directory path as plain text — emitting an empty JSON object yields
-// "WorktreeCreate hook returned a path that is not a directory: {}". We echo
-// input.WorktreePath unchanged, treating the hook as a passthrough observer.
-// When input.WorktreePath is absent the stdout is left empty (fail-safe).
+// stdout as the worktree directory path (not JSON), and an empty stdout on
+// WorktreeCreate ABORTS the agent spawn ("hook succeeded but returned no
+// worktree path" — issue #1570). For WorktreeCreate we echo the absolute path
+// the handler created (output.WorktreePath, set by the active-creator
+// worktree_create.go), falling back to input.WorktreePath when the handler
+// did not set one. For WorktreeRemove we echo input.WorktreePath (the event
+// carries the path; no output is required by the contract).
 //
 // All other events use the JSON HookOutput protocol via HookProtocol.WriteOutput.
 func writeHookOutput(event hook.EventType, input *hook.HookInput, output *hook.HookOutput) error {
 	if event == hook.EventWorktreeCreate || event == hook.EventWorktreeRemove {
-		if input != nil && input.WorktreePath != "" {
-			if _, writeErr := fmt.Fprintln(os.Stdout, input.WorktreePath); writeErr != nil {
+		if input == nil {
+			return nil
+		}
+		echoPath := input.WorktreePath
+		if event == hook.EventWorktreeCreate && output != nil && output.WorktreePath != "" {
+			echoPath = output.WorktreePath
+		}
+		if echoPath != "" {
+			if _, writeErr := fmt.Fprintln(os.Stdout, echoPath); writeErr != nil {
 				return fmt.Errorf("write worktree path: %w", writeErr)
 			}
 		}

--- a/internal/cli/hook_worktree_create_test.go
+++ b/internal/cli/hook_worktree_create_test.go
@@ -1,0 +1,188 @@
+// End-to-end wire-format regression test for the WorktreeCreate contract
+// (issue #1570).
+//
+// Claude Code's WorktreeCreate hook is an active creator: the payload carries
+// the suggested slug in the official `name` field, and the hook must create
+// the worktree itself and echo its absolute path to stdout as plain text —
+// empty stdout with exit 0 ABORTS the agent spawn. The passthrough
+// implementation that preceded this test always printed nothing (it waited
+// for a `worktree_path` input field this event never sends), so every
+// isolation: worktree spawn died. This test pins the full dispatcher path:
+// stdin JSON → handler → created worktree → path on stdout.
+package cli
+
+import (
+	"context"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/modu-ai/moai-adk/internal/hook"
+)
+
+// TestHookWorktreeCreate_EchoesCreatedPath runs the real `moai hook
+// worktree-create` subcommand wiring against a throwaway git repository and
+// asserts the contract: exit 0 with exactly one line on stdout — the absolute
+// path of a directory that now exists.
+func TestHookWorktreeCreate_EchoesCreatedPath(t *testing.T) {
+	repo, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("resolve symlinks: %v", err)
+	}
+	runTestGit(t, repo, "init", "-b", "main")
+	runTestGit(t, repo, "config", "user.email", "test@example.com")
+	runTestGit(t, repo, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("# Test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runTestGit(t, repo, "add", ".")
+	runTestGit(t, repo, "commit", "-m", "Initial commit")
+
+	origDeps := deps
+	t.Cleanup(func() { deps = origDeps })
+	InitDependencies()
+
+	payload := `{"hook_event_name":"WorktreeCreate","cwd":` + jsonQuote(repo) + `,"session_id":"sess-e2e","name":"e2e-probe"}`
+	swapStdinString(t, payload)
+
+	origStdout := os.Stdout
+	rOut, wOut, pipeErr := os.Pipe()
+	if pipeErr != nil {
+		t.Fatalf("os.Pipe: %v", pipeErr)
+	}
+	os.Stdout = wOut
+
+	var runErr error
+	found := false
+	for _, cmd := range hookCmd.Commands() {
+		if cmd.Name() == "worktree-create" {
+			found = true
+			cmd.SetContext(context.Background())
+			runErr = cmd.RunE(cmd, []string{})
+			break
+		}
+	}
+	_ = wOut.Close()
+	os.Stdout = origStdout
+
+	if !found {
+		t.Fatal("worktree-create subcommand not found")
+	}
+	if runErr != nil {
+		t.Fatalf("RunE returned error: %v", runErr)
+	}
+
+	out, err := io.ReadAll(rOut)
+	if err != nil {
+		t.Fatalf("read captured stdout: %v", err)
+	}
+
+	wantPath := filepath.Join(repo, ".claude", "worktrees", "e2e-probe")
+	if got := strings.TrimSpace(string(out)); got != wantPath {
+		t.Errorf("stdout = %q, want %q (empty stdout aborts the agent spawn)", got, wantPath)
+	}
+	if info, statErr := os.Stat(wantPath); statErr != nil {
+		t.Errorf("worktree not created at %s: %v", wantPath, statErr)
+	} else if !info.IsDir() {
+		t.Errorf("%s is not a directory", wantPath)
+	}
+}
+
+// TestWriteHookOutput_WorktreeCreatePrefersOutputPath pins the dispatcher's
+// echo rule directly: WorktreeCreate echoes the path the handler created
+// (output.WorktreePath) and falls back to input.WorktreePath when the
+// handler set none; WorktreeRemove keeps echoing the input path.
+//
+// Not parallel: swaps the process-global os.Stdout.
+func TestWriteHookOutput_WorktreeCreatePrefersOutputPath(t *testing.T) {
+	tests := []struct {
+		name       string
+		event      string
+		outputPath string
+		inputPath  string
+		wantStdout string
+	}{
+		{
+			name:       "create prefers handler-created path",
+			event:      "WorktreeCreate",
+			outputPath: "/repo/.claude/worktrees/agent-a",
+			inputPath:  "/ignored",
+			wantStdout: "/repo/.claude/worktrees/agent-a",
+		},
+		{
+			name:       "create falls back to input path",
+			event:      "WorktreeCreate",
+			outputPath: "",
+			inputPath:  "/repo/.claude/worktrees/agent-b",
+			wantStdout: "/repo/.claude/worktrees/agent-b",
+		},
+		{
+			name:       "remove echoes input path",
+			event:      "WorktreeRemove",
+			outputPath: "/ignored",
+			inputPath:  "/repo/.claude/worktrees/agent-c",
+			wantStdout: "/repo/.claude/worktrees/agent-c",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := captureWriteHookOutput(t, hook.EventType(tt.event),
+				&hook.HookInput{WorktreePath: tt.inputPath},
+				&hook.HookOutput{WorktreePath: tt.outputPath})
+			if out != tt.wantStdout {
+				t.Errorf("stdout = %q, want %q", out, tt.wantStdout)
+			}
+		})
+	}
+}
+
+// captureWriteHookOutput runs writeHookOutput with os.Stdout swapped for a
+// pipe and returns the captured text (trimmed). The worktree events never
+// reach the JSON protocol branch, so the global deps graph is not needed.
+func captureWriteHookOutput(t *testing.T, event hook.EventType, input *hook.HookInput, output *hook.HookOutput) string {
+	t.Helper()
+
+	origStdout := os.Stdout
+	rOut, wOut, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = wOut
+	defer func() { os.Stdout = origStdout }()
+
+	if err := writeHookOutput(event, input, output); err != nil {
+		t.Fatalf("writeHookOutput: %v", err)
+	}
+
+	_ = wOut.Close()
+	out, err := io.ReadAll(rOut)
+	if err != nil {
+		t.Fatalf("read captured stdout: %v", err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// runTestGit executes git in dir and fails the test on error.
+func runTestGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0", "LC_ALL=C")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v in %s: %s: %v", args, dir, string(out), err)
+	}
+}
+
+// jsonQuote renders s as a JSON string literal (the payloads built in this
+// file only need the escaping of backslashes and quotes).
+func jsonQuote(s string) string {
+	escaped := strings.ReplaceAll(s, `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+	return `"` + escaped + `"`
+}

--- a/internal/hook/misc_coverage_test.go
+++ b/internal/hook/misc_coverage_test.go
@@ -316,7 +316,10 @@ func TestIsCGMode_EmptyFile(t *testing.T) {
 
 // --- worktree_create.go: Handle ---
 
-// TestWorktreeCreateHandler_Handle_BasicPath verifies Handle returns output.
+// TestWorktreeCreateHandler_Handle_BasicPath verifies Handle without the
+// required `name` field aborts with an error (issue #1570: the active-creator
+// contract needs the suggested slug; the old passthrough returned an empty
+// success, which aborted the agent spawn with no diagnostics).
 func TestWorktreeCreateHandler_Handle_BasicPath(t *testing.T) {
 	t.Parallel()
 
@@ -330,12 +333,8 @@ func TestWorktreeCreateHandler_Handle_BasicPath(t *testing.T) {
 		ProjectDir: t.TempDir(),
 	}
 
-	out, err := h.Handle(context.Background(), input)
-	if err != nil {
-		t.Fatalf("Handle() error: %v", err)
-	}
-	if out == nil {
-		t.Fatal("Handle() returned nil output")
+	if _, err := h.Handle(context.Background(), input); err == nil {
+		t.Fatal("Handle() without name should return an error, got nil")
 	}
 }
 

--- a/internal/hook/registry.go
+++ b/internal/hook/registry.go
@@ -201,6 +201,14 @@ func mergeHandlerOutput(merged, output *HookOutput) {
 		merged.Retry = true
 	}
 
+	// WorktreePath (WorktreeCreate active creator, issue #1570): the path the
+	// handler created must survive the merge so the CLI dispatcher can echo
+	// it to stdout — an empty path aborts the agent spawn. Last-non-empty
+	// wins; only one WorktreeCreate handler exists in-tree.
+	if output.WorktreePath != "" {
+		merged.WorktreePath = output.WorktreePath
+	}
+
 	if output.HookSpecificOutput == nil {
 		return
 	}

--- a/internal/hook/registry_extra_coverage_test.go
+++ b/internal/hook/registry_extra_coverage_test.go
@@ -289,7 +289,13 @@ func TestGenerateSessionSummary_EmptyTraceDir(t *testing.T) {
 
 // --- WorktreeCreate / WorktreeRemove with CWD + WorktreePath set ---
 
-// TestWorktreeCreateHandler_Handle_WithWorktreePath exercises the registerWorktree branch.
+// TestWorktreeCreateHandler_Handle_WithWorktreePath verifies the payload
+// shape the OLD passthrough implementation assumed (worktree_path instead of
+// the official name field) now aborts with an error — per issue #1570 the
+// WorktreeCreate input carries the suggested slug in `name`, never a
+// worktree_path, so this input is malformed and must fail loudly rather than
+// return an empty success. Successful-creation registry coverage lives in
+// worktree_create_test.go (TestWorktreeCreateHandler_ActiveCreator).
 func TestWorktreeCreateHandler_Handle_WithWorktreePath(t *testing.T) {
 	t.Parallel()
 
@@ -302,12 +308,8 @@ func TestWorktreeCreateHandler_Handle_WithWorktreePath(t *testing.T) {
 		WorktreeBranch: "feature/test",
 		AgentName:      "test-agent",
 	}
-	out, err := h.Handle(context.Background(), input)
-	if err != nil {
-		t.Fatalf("Handle() error: %v", err)
-	}
-	if out == nil {
-		t.Fatal("Handle() returned nil output")
+	if _, err := h.Handle(context.Background(), input); err == nil {
+		t.Fatal("Handle() with worktree_path but no name should return an error, got nil")
 	}
 }
 

--- a/internal/hook/types.go
+++ b/internal/hook/types.go
@@ -278,7 +278,11 @@ type HookInput struct {
 	TaskDescription string `json:"task_description,omitempty"`
 
 	// WorktreeCreate and WorktreeRemove fields (v2.1.49+)
-	WorktreePath   string `json:"worktree_path,omitempty"`   // Absolute path to the worktree directory
+	// WorktreeCreate sends the official `name` field (the suggested worktree
+	// slug) and expects the hook to create the worktree itself; WorktreeRemove
+	// sends `worktree_path` (the absolute path of the worktree to remove).
+	WorktreeName   string `json:"name,omitempty"`            // WorktreeCreate: suggested worktree slug
+	WorktreePath   string `json:"worktree_path,omitempty"`   // WorktreeRemove: absolute path to the worktree directory
 	WorktreeBranch string `json:"worktree_branch,omitempty"` // Branch name for the worktree
 	AgentName      string `json:"agent_name,omitempty"`      // Name of the agent using the worktree
 
@@ -379,6 +383,12 @@ type HookOutput struct {
 	// ExitCode allows handlers to signal a specific process exit code.
 	// Not serialized to JSON. Used for exit code 2 protocol (TeammateIdle, TaskCompleted).
 	ExitCode int `json:"-"`
+
+	// WorktreePath carries the absolute path of the worktree the
+	// WorktreeCreate handler created. Not serialized to JSON — the CLI
+	// dispatcher echoes it to stdout as plain text per the WorktreeCreate
+	// contract (issue #1570).
+	WorktreePath string `json:"-"`
 
 	// Internal data (not serialized to JSON)
 	Data json.RawMessage `json:"-"`

--- a/internal/hook/worktree_create.go
+++ b/internal/hook/worktree_create.go
@@ -2,8 +2,16 @@
 package hook
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	gitcore "github.com/modu-ai/moai-adk/internal/core/git"
 )
 
 // worktreeCreateHandler processes WorktreeCreate events.
@@ -21,28 +29,138 @@ func (h *worktreeCreateHandler) EventType() EventType {
 	return EventWorktreeCreate
 }
 
-// Handle processes a WorktreeCreate event. It logs the worktree creation details
-// and persists the entry to the worktree registry for session tracking.
+// agentWorktreeBranchPrefix namespaces the branches this handler creates so
+// they never collide with user branches.
+const agentWorktreeBranchPrefix = "worktree-"
+
+// agentWorktreeParentDir is the directory, relative to the repository root,
+// under which hook-created worktrees live — mirroring Claude Code's native
+// agent-worktree layout (.claude/worktrees/<name>/).
+var agentWorktreeParentDir = filepath.Join(".claude", "worktrees")
+
+// Handle processes a WorktreeCreate event as an ACTIVE CREATOR (issue #1570).
 //
-// Stdout contract: Claude Code v2.1.49+ parses this hook's stdout as the
-// worktree directory path (plain text, not JSON). The CLI dispatcher
-// (cli/hook.go writeHookOutput) echoes input.WorktreePath back; emitting a
-// JSON HookOutput here would yield "is not a directory: {}". This handler
-// therefore returns an empty HookOutput and intentionally does NOT encode
-// payload data via the JSON protocol.
+// Per the Claude Code contract (v2.1.49+; verified against the embedded hook
+// schema of the 2.1.233 runtime), the stdin payload carries the suggested
+// worktree slug in the official `name` field — NOT a `worktree_path` — and the
+// hook MUST create the worktree directory itself and echo its absolute path
+// to stdout as plain text:
+//
+//	Input to command is JSON with name (suggested worktree slug).
+//	Stdout should contain the absolute path to the created worktree directory.
+//	Exit code 0 - worktree created successfully
+//	Other exit codes - worktree creation failed
+//
+// The previous passthrough-observer implementation echoed input.WorktreePath,
+// which never arrives on this event, so stdout stayed empty and Claude Code
+// aborted every isolation: worktree agent spawn with "hook succeeded but
+// returned no worktree path".
+//
+// Creation mirrors the native agent-worktree layout (.claude/worktrees/<name>,
+// branch worktree-<name>) with one deliberate simplification: the branch is
+// cut from the current HEAD rather than origin/HEAD, so the isolated agent
+// starts from the exact tree the spawning session sees.
+//
+// Failure contract: a non-nil error aborts creation (the CLI dispatcher
+// exits non-zero) — the honest "worktree creation failed" signal. An existing
+// directory at the target path is reused idempotently.
 func (h *worktreeCreateHandler) Handle(ctx context.Context, input *HookInput) (*HookOutput, error) {
+	slog.Info("worktree create requested for isolated agent",
+		"session_id", input.SessionID,
+		"agent_id", input.AgentID,
+		"agent_name", input.AgentName,
+		"worktree_name", input.WorktreeName,
+	)
+
+	if input.WorktreeName == "" {
+		return nil, fmt.Errorf("worktree create: missing required input field %q — Claude Code sends the suggested worktree slug in name", "name")
+	}
+
+	cwd := input.CWD
+	if cwd == "" {
+		wd, err := os.Getwd()
+		if err != nil {
+			return nil, fmt.Errorf("worktree create: resolve working directory: %w", err)
+		}
+		cwd = wd
+	}
+
+	repoRoot, err := resolveWorktreeRepoRoot(cwd)
+	if err != nil {
+		return nil, err
+	}
+
+	path := filepath.Join(repoRoot, agentWorktreeParentDir, input.WorktreeName)
+	branch := agentWorktreeBranchPrefix + sanitizeWorktreeBranchSuffix(input.WorktreeName)
+
+	// Idempotent reuse: an existing directory at the target path satisfies
+	// the contract without a second git invocation (Claude Code validates
+	// that the echoed path is a directory before handing it to the agent).
+	if info, statErr := os.Stat(path); statErr == nil {
+		if !info.IsDir() {
+			return nil, fmt.Errorf("worktree create: %s exists and is not a directory", path)
+		}
+		slog.Info("reusing existing worktree for isolated agent",
+			"worktree_path", path,
+			"worktree_branch", branch,
+		)
+		h.registerEntry(input, path, branch)
+		return &HookOutput{WorktreePath: path}, nil
+	}
+
+	// Add creates the branch when it does not exist and reuses it when it
+	// does (both cases must stay spawnable across repeated creations of the
+	// same slug).
+	if err := gitcore.NewWorktreeManager(repoRoot).Add(path, branch); err != nil {
+		return nil, fmt.Errorf("worktree create: %w", err)
+	}
+
 	slog.Info("worktree created for isolated agent",
 		"session_id", input.SessionID,
 		"agent_id", input.AgentID,
 		"agent_name", input.AgentName,
-		"worktree_path", input.WorktreePath,
-		"worktree_branch", input.WorktreeBranch,
+		"worktree_path", path,
+		"worktree_branch", branch,
 	)
 
-	// Persist the worktree entry so other sessions can inspect active worktrees.
-	if input.CWD != "" && input.WorktreePath != "" {
-		registerWorktree(input.CWD, input.WorktreePath, input.WorktreeBranch, input.AgentName)
-	}
+	h.registerEntry(input, path, branch)
 
-	return &HookOutput{}, nil
+	return &HookOutput{WorktreePath: path}, nil
+}
+
+// registerEntry persists the worktree to the registry so other sessions can
+// inspect active worktrees. Non-blocking on error (failures are logged).
+func (h *worktreeCreateHandler) registerEntry(input *HookInput, path, branch string) {
+	if input.CWD != "" {
+		registerWorktree(input.CWD, path, branch, input.AgentName)
+	}
+}
+
+// resolveWorktreeRepoRoot returns the absolute checkout root of the git
+// repository containing dir. The hook may run with cwd deep inside the tree,
+// so the root must be resolved rather than assumed.
+func resolveWorktreeRepoRoot(dir string) (string, error) {
+	full := []string{"-C", dir, "rev-parse", "--show-toplevel"}
+	cmd := exec.Command("git", full...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("worktree create: resolve repository root under %s: %w (%s)",
+			dir, err, strings.TrimSpace(stderr.String()))
+	}
+	root := strings.TrimSpace(stdout.String())
+	if root == "" || !filepath.IsAbs(root) {
+		return "", fmt.Errorf("worktree create: repository root %q under %s is not an absolute path", root, dir)
+	}
+	return root, nil
+}
+
+// sanitizeWorktreeBranchSuffix converts a worktree slug (letters, digits,
+// dots, underscores, dashes, and '/'-separated segments per Claude Code's
+// name validation) into a single git-branch-safe path segment. The
+// worktree- prefix added by the caller keeps the result from ever starting
+// with '-' or '.'.
+func sanitizeWorktreeBranchSuffix(name string) string {
+	return strings.ReplaceAll(name, "/", "-")
 }

--- a/internal/hook/worktree_create_test.go
+++ b/internal/hook/worktree_create_test.go
@@ -2,6 +2,10 @@ package hook
 
 import (
 	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -15,57 +19,188 @@ func TestWorktreeCreateHandler_EventType(t *testing.T) {
 	}
 }
 
-func TestWorktreeCreateHandler_Handle(t *testing.T) {
-	t.Parallel()
+// initWorktreeTestRepo creates a temporary git repository with one commit on
+// "main" (git worktree add requires an existing HEAD). The returned path has
+// symlinks resolved so it matches `git rev-parse --show-toplevel` output on
+// macOS (/var -> /private/var).
+func initWorktreeTestRepo(t *testing.T) string {
+	t.Helper()
 
-	tests := []struct {
-		name  string
-		input *HookInput
-	}{
-		{
-			name: "full worktree create payload",
-			input: &HookInput{
-				SessionID:      "sess-wt-1",
-				AgentID:        "agent-backend-dev",
-				AgentName:      "team-backend-dev",
-				WorktreePath:   "/repo/.claude/worktrees/backend-impl",
-				WorktreeBranch: "agent/backend-impl",
-				HookEventName:  "WorktreeCreate",
-			},
-		},
-		{
-			name: "minimal worktree create",
-			input: &HookInput{
-				SessionID:    "sess-wt-2",
-				WorktreePath: "/repo/.claude/worktrees/agent-xyz",
-			},
-		},
-		{
-			name: "empty input",
-			input: &HookInput{
-				SessionID: "sess-wt-3",
-			},
-		},
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("resolve symlinks: %v", err)
+	}
+	runWorktreeTestGit(t, dir, "init", "-b", "main")
+	runWorktreeTestGit(t, dir, "config", "user.email", "test@example.com")
+	runWorktreeTestGit(t, dir, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("# Test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runWorktreeTestGit(t, dir, "add", ".")
+	runWorktreeTestGit(t, dir, "commit", "-m", "Initial commit")
+	return dir
+}
+
+// runWorktreeTestGit executes git in dir and fails the test on error.
+func runWorktreeTestGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0", "LC_ALL=C")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v in %s: %s: %v", args, dir, string(out), err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// TestWorktreeCreateHandler_ActiveCreator (issue #1570) verifies the
+// active-creator contract: given the official `name` payload field, the
+// handler creates a real git worktree under .claude/worktrees/<name> and
+// returns its absolute path on the output for the CLI dispatcher to echo.
+// The passthrough-observer implementation this replaces always returned an
+// empty path, so Claude Code aborted every isolation: worktree spawn.
+func TestWorktreeCreateHandler_ActiveCreator(t *testing.T) {
+	repo := initWorktreeTestRepo(t)
+
+	h := NewWorktreeCreateHandler()
+	got, err := h.Handle(context.Background(), &HookInput{
+		SessionID:     "sess-wt-1",
+		AgentName:     "team-backend-dev",
+		WorktreeName:  "backend-impl",
+		CWD:           repo,
+		HookEventName: "WorktreeCreate",
+	})
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
 	}
 
+	wantPath := filepath.Join(repo, ".claude", "worktrees", "backend-impl")
+	if got.WorktreePath != wantPath {
+		t.Errorf("output.WorktreePath = %q, want %q", got.WorktreePath, wantPath)
+	}
+
+	info, err := os.Stat(wantPath)
+	if err != nil {
+		t.Fatalf("worktree directory not created: %v", err)
+	}
+	if !info.IsDir() {
+		t.Error("worktree path exists but is not a directory")
+	}
+
+	// The created directory must be a registered git worktree on the
+	// namespaced branch, not a plain directory.
+	listOut := runWorktreeTestGit(t, repo, "worktree", "list", "--porcelain")
+	if !strings.Contains(listOut, wantPath) {
+		t.Errorf("git worktree list does not contain %q:\n%s", wantPath, listOut)
+	}
+	branchOut := runWorktreeTestGit(t, repo, "branch", "--list", "worktree-backend-impl")
+	if branchOut == "" {
+		t.Error("expected branch worktree-backend-impl to exist")
+	}
+
+	// The registry entry must be persisted under the input CWD.
+	registryData, err := os.ReadFile(filepath.Join(repo, ".moai", "state", "worktrees.json"))
+	if err != nil {
+		t.Fatalf("worktree registry not written: %v", err)
+	}
+	if !strings.Contains(string(registryData), wantPath) {
+		t.Errorf("worktree registry does not reference %q:\n%s", wantPath, string(registryData))
+	}
+}
+
+// TestWorktreeCreateHandler_ReusesExistingDirectory verifies idempotency: an
+// existing directory at the target path is echoed back without a second git
+// worktree add (git would refuse the duplicate path).
+func TestWorktreeCreateHandler_ReusesExistingDirectory(t *testing.T) {
+	repo := initWorktreeTestRepo(t)
+
+	existing := filepath.Join(repo, ".claude", "worktrees", "leftover")
+	if err := os.MkdirAll(existing, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	h := NewWorktreeCreateHandler()
+	got, err := h.Handle(context.Background(), &HookInput{
+		SessionID:    "sess-wt-2",
+		WorktreeName: "leftover",
+		CWD:          repo,
+	})
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if got.WorktreePath != existing {
+		t.Errorf("output.WorktreePath = %q, want %q", got.WorktreePath, existing)
+	}
+
+	// A second run re-registers idempotently: one registry entry per path,
+	// not one per invocation.
+	if _, err := h.Handle(context.Background(), &HookInput{
+		SessionID:    "sess-wt-2b",
+		WorktreeName: "leftover",
+		CWD:          repo,
+	}); err != nil {
+		t.Fatalf("second Handle: %v", err)
+	}
+	registryData, err := os.ReadFile(filepath.Join(repo, ".moai", "state", "worktrees.json"))
+	if err != nil {
+		t.Fatalf("worktree registry not written: %v", err)
+	}
+	if got := strings.Count(string(registryData), existing); got != 1 {
+		t.Errorf("registry references %q %d times, want exactly 1:\n%s", existing, got, string(registryData))
+	}
+}
+
+// TestWorktreeCreateHandler_MissingNameAborts verifies the contract-honest
+// failure: the official payload carries the slug in `name`; without it the
+// hook cannot create anything and must fail (non-zero exit) rather than
+// return empty stdout + exit 0, which aborts the spawn with no diagnostics.
+func TestWorktreeCreateHandler_MissingNameAborts(t *testing.T) {
+	h := NewWorktreeCreateHandler()
+
+	_, err := h.Handle(context.Background(), &HookInput{
+		SessionID: "sess-wt-3",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing name field, got nil")
+	}
+	if !strings.Contains(err.Error(), "name") {
+		t.Errorf("error should name the missing field, got %q", err.Error())
+	}
+}
+
+// TestWorktreeCreateHandler_NotARepositoryAborts verifies the failure path in
+// a directory outside any git repository: creation is impossible, so the
+// handler errors (the CLI exits non-zero per "Other exit codes - worktree
+// creation failed") instead of printing an empty success.
+func TestWorktreeCreateHandler_NotARepositoryAborts(t *testing.T) {
+	dir := t.TempDir()
+
+	h := NewWorktreeCreateHandler()
+	_, err := h.Handle(context.Background(), &HookInput{
+		SessionID:    "sess-wt-4",
+		WorktreeName: "probe",
+		CWD:          dir,
+	})
+	if err == nil {
+		t.Fatal("expected error outside a git repository, got nil")
+	}
+}
+
+// TestSanitizeWorktreeBranchSuffix verifies slug-to-branch conversion for the
+// nested-segment names Claude Code's name validation permits.
+func TestSanitizeWorktreeBranchSuffix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct{ in, want string }{
+		{"backend-impl", "backend-impl"},
+		{"feat/auth", "feat-auth"},
+		{"a/b/c", "a-b-c"},
+	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			h := NewWorktreeCreateHandler()
-			ctx := context.Background()
-			got, err := h.Handle(ctx, tt.input)
-
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if got == nil {
-				t.Fatal("got nil output")
-			} else if got.HookSpecificOutput != nil {
-				t.Error("WorktreeCreate hook should not set hookSpecificOutput")
-			} else if got.Decision != "" {
-				t.Errorf("WorktreeCreate hook should not set decision, got %q", got.Decision)
-			}
-		})
+		if got := sanitizeWorktreeBranchSuffix(tt.in); got != tt.want {
+			t.Errorf("sanitizeWorktreeBranchSuffix(%q) = %q, want %q", tt.in, got, tt.want)
+		}
 	}
 }

--- a/internal/hook/worktree_registry.go
+++ b/internal/hook/worktree_registry.go
@@ -21,9 +21,11 @@ type WorktreeEntry struct {
 // @MX:REASON: global state mutation — concurrent hook handlers (WorktreeCreate/WorktreeRemove) share this lock; missing lock acquisition causes data races on the JSON state file
 var worktreeMu sync.Mutex
 
-// registerWorktree appends a new WorktreeEntry to the persistent state file.
-// If the state directory or file does not exist it is created.
-// Non-blocking on error: failures are logged as warnings.
+// registerWorktree records a WorktreeEntry in the persistent state file,
+// replacing any existing entry with the same path (idempotent — the
+// WorktreeCreate handler re-registers when it reuses an existing worktree
+// directory, issue #1570). If the state directory or file does not exist it
+// is created. Non-blocking on error: failures are logged as warnings.
 func registerWorktree(projectDir, path, branch, agentName string) {
 	worktreeMu.Lock()
 	defer worktreeMu.Unlock()
@@ -31,12 +33,27 @@ func registerWorktree(projectDir, path, branch, agentName string) {
 	stateFile := worktreeStateFile(projectDir)
 	entries := loadWorktreeEntries(stateFile)
 
-	entries = append(entries, WorktreeEntry{
-		Path:      path,
-		Branch:    branch,
-		AgentName: agentName,
-		CreatedAt: time.Now(),
-	})
+	replaced := false
+	for i := range entries {
+		if entries[i].Path == path {
+			entries[i] = WorktreeEntry{
+				Path:      path,
+				Branch:    branch,
+				AgentName: agentName,
+				CreatedAt: time.Now(),
+			}
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		entries = append(entries, WorktreeEntry{
+			Path:      path,
+			Branch:    branch,
+			AgentName: agentName,
+			CreatedAt: time.Now(),
+		})
+	}
 
 	saveWorktreeEntries(stateFile, entries)
 }


### PR DESCRIPTION

### Summary

`moai hook worktree-create` returned empty stdout with exit 0 for every
input, which per Claude Code's WorktreeCreate contract ABORTS worktree
creation — every agent whose frontmatter declares `isolation: worktree`
(including the template-distributed `manager-develop`) failed to spawn
(issue #1570).

The contract (verified against the hook schema embedded in the Claude Code
2.1.233 binary, and already documented correctly in the repo's own
`worktree-integration.md` § "WorktreeCreate and WorktreeRemove Hooks")
makes this hook an **active creator**:

```
Input to command is JSON with name (suggested worktree slug).
Stdout should contain the absolute path to the created worktree directory.
Exit code 0 - worktree created successfully
Other exit codes - worktree creation failed
```

The stdin payload carries the suggested slug in the official `name` field —
`worktree_path` belongs to WorktreeRemove and never arrives on this event.
The previous implementation was a passthrough observer echoing
`input.WorktreePath`, so stdout was always empty.

### Changes

- `internal/hook/worktree_create.go` — active-creator implementation:
  resolves the repo root from the payload `cwd`, creates the worktree at
  `<repoRoot>/.claude/worktrees/<name>` (branch `worktree-<name>`) via the
  existing `gitcore.WorktreeManager.Add` (reuses its branch-exists handling
  and CWE-88 argv hardening), reuses an existing directory at the target
  path idempotently, records the worktree in the
  `.moai/state/worktrees.json` registry, and returns the absolute path on
  the output. Missing `name` / non-git cwd abort with a clear error
  (contract-honest failure) instead of a silent empty success.
- `internal/hook/types.go` — add `HookInput.WorktreeName` (json `name`) and
  non-serialized `HookOutput.WorktreePath` (echoed by the CLI dispatcher;
  follows the existing `ExitCode int \`json:"-"\`` internal-field pattern).
- `internal/hook/registry.go` — `mergeHandlerOutput` propagates
  `WorktreePath`. Load-bearing: `Registry.Dispatch` returns a merged output
  and the created path was silently dropped without this — caught by the
  CLI e2e test, not the handler unit tests.
- `internal/cli/hook.go` — `writeHookOutput`: WorktreeCreate echoes the
  handler-created path with fallback to the input path; WorktreeRemove
  unchanged (still echoes `input.WorktreePath`).
- `internal/hook/worktree_registry.go` — `registerWorktree` is now
  idempotent per path (reuse no longer duplicates registry entries;
  `unregisterWorktree` already removes all entries for a path).
- Tests: rewritten `worktree_create_test.go` (creation, idempotent reuse,
  missing-name abort, non-repo abort, slug sanitization); new CLI e2e
  `hook_worktree_create_test.go` (real subcommand wiring: stdin JSON →
  worktree created → path on stdout; plus the dispatcher echo-rule table);
  the two coverage tests that pinned the old passthrough behavior updated
  to the abort contract.

Deliberately NOT done (scope): the hook is still not registered in the
template settings.json (per doctrine, Claude Code's native git path remains
the default); `.worktreeinclude` copying and `origin/HEAD` base selection
are follow-ups, noted in the issue.

### Registration-context (why users hit this at all)

The v3.x template does not register this hook (`settings_test.go` pins 20
events without it). Registration shipped in v2.10.0–v2.13.x (re-added
`daa720a4c`, removed `a3239d3de`), and `moai update` deploys settings.json
via JSON merge, which preserves existing hook entries — so projects
initialized in that window keep the registration and hit this abort on
v3.1.0 binaries. This fix makes the registered path functional for those
users.

### Test plan

- Binary, before (origin/main build) — the reporter's exact payloads, all
  rc=0 with empty stdout; with the official `name` field included the
  output is still empty (nothing in the old code reads `name`).
- Binary, after — `name` payload echoes
  `/…/.claude/worktrees/<name>` (rc=0), `git worktree list` shows the new
  worktree on `worktree-<name>`; second run on the same slug reuses the
  directory (single registry entry); payload without `name` exits 1 with
  the missing-field reason on stderr; `worktree-remove` path unchanged
  (echoes input path, clears the registry entry).
- Go tests: `go test ./internal/hook/ -run 'TestWorktreeCreate|TestSanitizeWorktreeBranchSuffix|TestWorktreeRemove' -count=1` → ok;
  `go test ./internal/cli/ -run 'TestHookWorktreeCreate|TestWriteHookOutput_Worktree' -count=1` → ok.
  The only failure in the full `internal/hook` package run
  (`TestPreTool_AstGrepSkipReasonSurfaces`) is pre-existing on pristine
  origin/main, verified on an untouched extraction.
- `go vet` on `internal/hook` + `internal/cli` clean; `gofmt -l` clean on
  all changed files.

Fixes #1570
