### PR TITLE
test(timing): stop the measuring tests from measuring each other

### DIFF
--- a/internal/timing/paired_test.go
+++ b/internal/timing/paired_test.go
@@ -9,7 +9,7 @@ import (
 // refUnit cannot offer: both sides of the ratio rest on the SAME number of
 // samples, so the denominator is no noisier than the numerator.
 func TestMeasurePairedEqualSampleCounts(t *testing.T) {
-	t.Parallel()
+	// Deliberately NOT parallel — measuring test; see the note on cpuUnit.
 	refSt, st := measurePaired(func() { cpuUnit(200_000) }, func() { cpuUnit(200_000) }, 20, 2)
 	if refSt.N != 20 || st.N != 20 {
 		t.Fatalf("sample counts = ref %d / measured %d; want 20 / 20", refSt.N, st.N)
@@ -55,7 +55,9 @@ func TestMeasurePairedAlternatesOrder(t *testing.T) {
 // TestAssertPairedHealthyEndToEnd runs the exported paired entry point on an
 // operation that costs one reference unit: every bound must pass.
 func TestAssertPairedHealthyEndToEnd(t *testing.T) {
-	t.Parallel()
+	// Deliberately NOT parallel: see the note on cpuUnit. This test measures,
+	// and the other measuring tests in this package are the load that moved
+	// its ratio.
 	AssertPaired(t, Bound{
 		Name:          "paired-cpu-1x",
 		Budget:        30 * time.Second,

--- a/internal/timing/timing_test.go
+++ b/internal/timing/timing_test.go
@@ -9,7 +9,23 @@ import (
 
 // cpuUnit is a deterministic CPU-bound unit: its duration scales linearly
 // with n and is independent of the filesystem or subprocess machinery, so
-// ratios between two cpuUnit calls are stable under machine load.
+// ratios between two cpuUnit calls are stable under *steady* machine load.
+//
+// [HARD] Every test that measures with cpuUnit runs WITHOUT t.Parallel().
+//
+// Steady is the load-bearing word, and the parallel runs in this package broke
+// it. Interleaving reference and measured samples (measurePaired) cancels a
+// load level that holds across both, but a sibling measuring test starting or
+// finishing mid-run is a step change, not a level: the two sides of the ratio
+// land on opposite sides of the step. With ref and fn byte-identical — the
+// ratio's ideal being 1.00x against a 2.00x bound — CI still observed 2.32x,
+// 2.72x, and 4.64x, and the reference unit itself moved 433µs to 1.687ms
+// between runs.
+//
+// So the harness reported a code regression on code that had not changed. The
+// non-parallel tests in a package run to completion before the parallel ones
+// resume, which is what keeps these five off each other's measuring window.
+// Adding t.Parallel() to a measuring test reopens this.
 func cpuUnit(n int) {
 	sum := 0
 	for i := 0; i < n; i++ {
@@ -113,7 +129,7 @@ func TestCheckSteadyAndBudgetArms(t *testing.T) {
 // denominator can inflate (or deflate) several-fold on its own, and the
 // resulting ratio says more about the runner than about the code.
 func TestMeasureCalibratedRatioHealthy(t *testing.T) {
-	t.Parallel()
+	// Deliberately NOT parallel — measuring test; see the note on cpuUnit.
 	unit := func() { cpuUnit(5_000_000) }
 	refSt, st := measurePaired(unit, unit, 30, 3)
 	b := Bound{Budget: 30 * time.Second, SteadyCeiling: 10 * time.Second, MaxUnits: 2.0, Name: "cpu-1x"}
@@ -134,7 +150,7 @@ func TestMeasureCalibratedRatioHealthy(t *testing.T) {
 // letting the growth through undetected. Interleaving the two units puts
 // both halves of the ratio under the same load.
 func TestMeasureCalibratedRatioTripsAt4x(t *testing.T) {
-	t.Parallel()
+	// Deliberately NOT parallel — measuring test; see the note on cpuUnit.
 	refSt, st := measurePaired(func() { cpuUnit(2_000_000) }, func() { cpuUnit(8_000_000) }, 30, 3)
 	b := Bound{Budget: time.Hour, SteadyCeiling: time.Hour, MaxUnits: 1.5, Name: "cpu-4x"}
 	errs := Check(b, refSt.Median, st)
@@ -183,7 +199,7 @@ func TestMedianRunsWarmupPlusSamples(t *testing.T) {
 }
 
 func TestAssertHealthyEndToEnd(t *testing.T) {
-	t.Parallel()
+	// Deliberately NOT parallel — measuring test; see the note on cpuUnit.
 	ref := Median(func() { cpuUnit(5_000_000) }, 2, 10)
 	// Generous bounds: this exercises the Assert wiring (measure + log +
 	// Check) on healthy code and must not fail.


### PR DESCRIPTION
## The symptom

`TestAssertPairedHealthyEndToEnd` prices two **byte-identical** functions:

```go
AssertPaired(t, Bound{MaxUnits: 2.0, Iterations: 20, Warmup: 2},
    func() { cpuUnit(2_000_000) },   // reference
    func() { cpuUnit(2_000_000) })   // measured
```

Its ideal ratio is `1.00x` against a `2.00x` bound. CI observed:

| run | platform | ratio | refUnit |
|---|---|---|---|
| PR #1589 | windows | 4.64x | 433µs |
| PR #1590 | ubuntu | 2.72x | 1.300ms |
| PR #1590 rerun | ubuntu | 2.32x | 1.687ms |

The harness reported "this is a code regression, not machine load" on code that had not changed — those PRs touch **zero** Go files. The reference unit itself moving 433µs to 1.687ms across runs is the tell.

## The cause

Seventeen of this package's twenty tests call `t.Parallel()`, and five of those are CPU-bound measuring tests:

- `TestAssertPairedHealthyEndToEnd`
- `TestMeasurePairedEqualSampleCounts`
- `TestMeasureCalibratedRatioHealthy`
- `TestMeasureCalibratedRatioTripsAt4x`
- `TestAssertHealthyEndToEnd`

They measured each other.

Interleaving reference and measured samples (`measurePaired`) cancels a load **level** that holds across both — that is exactly what the pairing was introduced for. But a sibling measuring test starting or finishing mid-run is a **step change**, not a level, and the two sides of the ratio land on opposite sides of the step. A four-fold move in the denominator between runs is that step, not the machine merely being busy.

## The fix

The five measuring tests drop `t.Parallel()`. Go runs a package's non-parallel tests to completion before the parallel ones resume, so the measuring tests no longer overlap each other or anything else burning CPU in this package. The twelve pure-logic tests stay parallel.

The `cpuUnit` doc comment carried the premise that broke — "ratios between two cpuUnit calls are stable under machine load" — and now records which word was load-bearing (*steady*), the observed figures, and the fact that adding `t.Parallel()` to a measuring test reopens it.

## Why this is the fourth attempt

Three prior commits worked this failure from the reference-pricing side, and each left the measuring tests parallel with one another:

```
4bd8136b6 test(timing): fix VM-runner false trips — mix-matched reference + tick-guaranteed self-test unit
7a531fe86 test(timing): interleave the calibration reference with the measured runs (t162)
1671abf87 test(timing): pair the calibrated-ratio references so both sides share one load window (t163)
```

Each made the pairing tighter. None removed the load the pairing was fighting.

## Verification

`go test ./internal/timing/ -count=5` passes locally and `go vet` is clean. Local passes are weak evidence for a load-sensitive test — a developer machine is not a two-core CI runner — so **CI on this PR is the real verdict**. The structural argument does not rest on the local run: non-parallel tests completing before parallel ones resume is a language guarantee, not a timing coincidence.

🗿 MoAI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated timing-related tests to run serially for more reliable measurement results.
  * Added documentation explaining why concurrent timing tests can produce inaccurate ratios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->