### PR TITLE
feat(gate): add a typecheck axis so a broken build cannot pass

### DIFF
--- a/.moai/config/sections/gate.yaml
+++ b/.moai/config/sections/gate.yaml
@@ -17,6 +17,30 @@ gate:
     vet: 30
     lint: 60
     test: 120
+    # A type-check over a large monorepo routinely outlasts the test budget,
+    # so it gets its own.
+    typecheck: 300
+  # The typecheck axis runs between vet and lint, so a type error surfaces
+  # before the slower style pass and a project whose linter config is absent
+  # still gets a correctness gate.
+  #
+  # Node resolves in three tiers: `command` below (any language), then
+  # package.json scripts.typecheck, then `npx --no-install tsc --noEmit` when a
+  # tsconfig.json is present. A solution-style tsconfig (files: [] plus
+  # references) is refused rather than run — it type-checks nothing and would
+  # pass vacuously.
+  #
+  # Every outcome is reported. A skip is not a failure, but it is never
+  # silent: a language with no default prints how to supply one.
+  typecheck:
+    enabled: true
+    # Overrides the language default and enables the axis for ANY language,
+    # e.g. "mypy --strict ." or "npm run typecheck".
+    #
+    # Split on whitespace and executed directly, so shell metacharacters are
+    # NOT interpreted — put a pipeline or a redirect in a script and name the
+    # script here.
+    command: ""
   ast_grep_gate:
     enabled: true
     # rules_dir is the single source of truth for where this checkout's

--- a/.moai/reports/t172/verdict.md
+++ b/.moai/reports/t172/verdict.md
@@ -93,8 +93,8 @@ FAIL	github.com/modu-ai/moai-adk/internal/hook/quality [build failed]
 ### 5.2 대조절 포함 테스트 14건
 
 차단(RED)만 있으면 "항상 실패하는 게이트"로도 만족된다. 그래서 **통과 대조절**을 같이 뒀다:
-`TestGateBlocksOnTypecheckFailure`(command `false` → 차단) ↔ `TestGatePassesWhenTypecheckSucceeds`
-(command `true` → 통과). 그 밖: 3티어 각각 · solution-style 차단 · 스크립트 우선 · 오버라이드
+`TestGateBlocksOnTypecheckFailure`(exit≠0 커맨드 → 차단) ↔ `TestGatePassesWhenTypecheckSucceeds`
+(exit 0 커맨드 → 통과). *§9.2 이후 두 커맨드는 `go` 기반 크로스플랫폼 형태다.* 그 밖: 3티어 각각 · solution-style 차단 · 스크립트 우선 · 오버라이드
 타언어 발화 · 사유 부착 · `disabled_steps` · `enabled:false` · 기본값 · Node 엔트리 배선.
 
 ### 5.3 실 바이너리 데모 (`make build` 산출물)

--- a/.moai/reports/t172/verdict.md
+++ b/.moai/reports/t172/verdict.md
@@ -1,0 +1,166 @@
+# t172 — `moai gate` typecheck axis
+
+베이스: `main` @ `4b2f203fe` · 브랜치 `WT-gate-typecheck` · 워크트리 `.claude/worktrees/t172`
+출처: mo.ai.kr 사고(10ab1872) 근본 수리 · 설계는 운영자 확정본(재조사 불요)
+
+---
+
+## 1. 카드 실측 좌표 검증 (착수 전 확인, 4/4 일치)
+
+카드가 "재조사 불요"라고 했으나 좌표만은 짚었다. **전부 맞았다.**
+
+| 좌표 | 확인 | 결과 |
+|---|---|---|
+| `gate.go:63-72` langToolchain 3축, typecheck 부재 | 62-73행 직접 읽음 | `vetSteps`/`lintSteps`/`testStep` 뿐 — **typecheck 없음** 확인 |
+| `:699-717` 무음 스킵 3경로 | 695-720행 직접 읽음 | optional 바이너리 부재 / configFiles 부재 / changedExts 불일치 — 전부 `return true, ""` |
+| `:289-304` passReason 인프라 | 285-305행 직접 읽음 | 존재. 다만 **덮어쓰기**였다(§3.2) |
+| `:622` readPackageJSONScripts | 618-622행 | 존재, 재사용 가능 |
+| 언어 엔트리 15개 | `toolchains` 블록 내 `markerFiles:` 정확 카운트 | **15** 일치 |
+
+> 주의 하나: 파일 전체 grep 은 18을 세는데, 그중 3건은 `var toolchains` 블록 밖이다. 블록 내부만
+> 세면 카드의 15가 맞다. 파일 전체 grep 으로 확인했다면 카드가 틀렸다고 오판했을 자리다.
+
+## 2. 구현 (9파일)
+
+| 파일 | 내용 |
+|---|---|
+| `internal/hook/quality/gate_typecheck.go` (신규) | 3티어 해석기 + solution-style 판별 + `appendReason` |
+| `internal/hook/quality/gate_typecheck_test.go` (신규) | 14 테스트 |
+| `internal/hook/quality/gate.go` | `typecheckStep` 필드 · Node 엔트리 배선 · GateConfig 3필드 · 기본값 · Run 순서 |
+| `internal/config/types.go` | `GateTypecheck` 구조체 · `Timeouts.Typecheck` · `TypecheckTimeoutDuration()` |
+| `internal/config/defaults.go` | `enabled: true` · `typecheck: 300` |
+| `internal/cli/gate.go` | config→quality 매핑 3필드 |
+| `.moai/config/sections/gate.yaml` + 템플릿 미러 | 신규 키 + 주석 |
+| `internal/config/testdata/shipped_key_inventory.yaml` | 신규 키 3건 triage 등록(§4) |
+
+실행 순서: **vet → typecheck → lint → ast-grep → test**. 타입 오류가 느린 스타일 패스보다 먼저
+드러나고, 린터 설정이 없는 프로젝트도 정합성 게이트는 받는다 — 사고의 정확한 형태가 후자였다.
+
+### 2.1 Node 3티어
+
+(a) `gate.typecheck.command` — **어느 언어든** 강제 발화 (b) `package.json` `scripts.typecheck` →
+`npm run typecheck` (c) `tsconfig.json` → `npx --no-install tsc --noEmit`.
+
+**티어 (b)가 tsconfig 형태 검사보다 우선**한다. turbo 에 위임하는 모노레포 루트가 solution-style
+tsconfig 를 가졌다는 이유로 벌받지 않게 하려는 것이고, 테스트로 고정했다
+(`TestSolutionStyleWithScriptStillRuns`).
+
+### 2.2 solution-style 차단
+
+`files: []` + `references` 만인 tsconfig 는 `tsc --noEmit` 이 **아무것도 검사하지 않고 exit 0** 한다.
+이걸 커버리지로 치면 이 카드가 닫으려는 사각을 그대로 다시 만든다. 그래서 실행하지 않고 사유와 함께
+스킵한다. 파싱 실패는 `false` — 읽을 수 없는 설정 때문에 검사를 거부하는 쪽이 더 나쁜 실패다.
+
+## 3. 스킵 의미론 — "스킵은 실패가 아니나 결코 무음이 아님"
+
+### 3.1 사유 부착
+
+축이 없는 언어는 `typecheck: skipped (no default for this language; set gate.typecheck.command to
+enable one)` 를 출력한다. 도구 가용성은 **fail-open 유지**하되 가시성은 항상 준다.
+
+### 3.2 발견 — passReason 은 누적이 아니라 덮어쓰기였다
+
+카드 범위를 넘지 않는 선에서 한 가지를 고쳐야 했다. 기존 `passReason = out` 은 **마지막 통지가 앞의
+것을 지웠다.** typecheck 와 ast-grep 이 둘 다 스킵하면 하나만 보고된다 — 이 카드가 만드는 통지가
+바로 그 자리에서 사라진다. `appendReason` 으로 누적하도록 바꿨고, vet/lint 스텝의 통지도 같이
+줍도록 했다(이전엔 버려졌다).
+
+실증(§5 데모 3): 한 실행에서 **두 통지가 함께** 출력된다.
+
+## 4. shipped-key 앤티로트 가드 (예상 밖 1건)
+
+`TestShippedConfigKeysHaveReaders` 가 신규 키 3건을 **미triage** 로 잡았다. 처음 출력이 잘려
+기존 실패(cacheStrategy·context_search·hook.*)만 보였고 **내 키가 안 보였다** — 필터를 다시 걸어
+확인하니 내 것이 맨 위에 있었다. 잘린 출력만 보고 "기존 baseline" 으로 넘겼으면 놓쳤을 자리다.
+
+`shipped_key_inventory.yaml` 에 3건을 등록했다. class **W**(wire) / evidence `reader` — 실제로
+`mapConfigGateToQuality` 가 읽는다. 헤더 카운트도 955→958 로 맞췄다.
+
+(기존 `gate.timeouts.*` 3건이 class R 로 등록돼 있는데 실제로는 읽힌다 — 스테일 triage 지만 내
+변경이 아니라 손대지 않았다.)
+
+## 5. 검증
+
+### 5.1 TDD RED 선행 (원문)
+
+```
+$ go test ./internal/hook/quality/          # gate_typecheck.go 존재 전
+internal/hook/quality/gate_typecheck_test.go:48:22: undefined: resolveTypecheckStep
+internal/hook/quality/gate_typecheck_test.go:48:43: undefined: nodeTypecheckStep
+FAIL	github.com/modu-ai/moai-adk/internal/hook/quality [build failed]
+```
+
+### 5.2 대조절 포함 테스트 14건
+
+차단(RED)만 있으면 "항상 실패하는 게이트"로도 만족된다. 그래서 **통과 대조절**을 같이 뒀다:
+`TestGateBlocksOnTypecheckFailure`(command `false` → 차단) ↔ `TestGatePassesWhenTypecheckSucceeds`
+(command `true` → 통과). 그 밖: 3티어 각각 · solution-style 차단 · 스크립트 우선 · 오버라이드
+타언어 발화 · 사유 부착 · `disabled_steps` · `enabled:false` · 기본값 · Node 엔트리 배선.
+
+### 5.3 실 바이너리 데모 (`make build` 산출물)
+
+`CLAUDE_PROJECT_DIR` 로 픽스처에 스코프. **cwd 도 픽스처 안이어야 한다** — §6 참조.
+
+| 픽스처 | 결과 |
+|---|---|
+| `broken`(typecheck exit 2) | `quality gate failed: typecheck` + **TS 오류 원문이 그대로 출력**. 게이트 차단 |
+| `fixed`(typecheck exit 0) | typecheck 통과 후 다음 스텝으로 진행 — 축이 통과함을 증명 |
+| `noconfig`(스크립트·tsconfig 둘 다 없음) | **게이트 통과(EXIT=0)** + `typecheck: skipped (…set gate.typecheck.command…)` 출력. ast-grep 통지와 **함께** 나옴(§3.2 실증) |
+
+### 5.4 명령과 관측
+
+```
+$ go test ./internal/hook/quality/ -count=1        -> ok 28.031s
+$ go test ./internal/config/... -count=1           -> ok (config / atomicfile / toolpolicy)
+$ go test ./internal/config/ -run TestStructYAMLSymmetry_Gate -> ok   (CONFIG_STRUCT_YAML_MISMATCH 통과)
+$ go test ./internal/config/ -run TestShippedConfigKeysHaveReaders -> ok
+$ golangci-lint run --timeout=3m <3 packages>      -> 0 issues.
+$ go build ./...                                   -> exit 0
+$ make build                                       -> 성공, catalog.yaml 변동 없음
+$ gofmt -l <변경 파일>                              -> 출력 없음
+```
+
+### 5.5 `internal/cli` 실패 3건 — 환경 오염, 내 변경 아님
+
+첫 실행에서 `TestCC_FactoryEntryThroughRunCC` / `TestGLM_FactoryWorkerEntry` /
+`TestHookCommandFlushesLastHandlerEntry` 3건이 붉었다. **이 세션이 팩토리 세션이라
+`MOAI_FACTORY_WORKERS` 등이 `go test` 까지 물린다**(기록된 실패 양식). env 스크럽 후 재실행:
+
+```
+$ unset MOAI_KANBAN … MOAI_FACTORY_WORKERS MOAI_FACTORY_WORKER && go test ./internal/cli/ -run '…'
+ok  	github.com/modu-ai/moai-adk/internal/cli	1.156s
+ok  	github.com/modu-ai/moai-adk/internal/cli	9.721s
+```
+
+3건 전부 초록. **내 변경과 무관한 로컬 환경 거짓 실패**로 판정한다.
+
+## 6. 알려진 한계 — cmd.Dir (카드 범위 밖, 그러나 실측으로 드러남)
+
+데모 1차에서 `fixed` 픽스처가 실패했다. 원인: 스텝 **해석**은 픽스처를 보는데 **실행**은 프로세스
+cwd 에서 일어나 `npm` 이 워크트리 루트의 없는 `package.json` 을 읽었다. 카드가 범위 밖으로 명시한
+`runStep` `cmd.Dir` 미지정과 같은 뿌리다.
+
+**소비자 영향은 없다** — 실제 사용은 저장소 루트에서 `moai gate` 를 부르므로 cwd == 프로젝트 디렉터리다
+(데모 2·3이 그 구성이고 전부 정상). 다만 **이 축이 그 결함을 상속한다**는 사실은 기록해 둔다:
+프로젝트 디렉터리와 cwd 가 갈리는 호출에서는 typecheck 도 엉뚱한 디렉터리에서 실행된다.
+
+## 7. 미검증 / 잔여 위험
+
+- **전체 스위트 로컬 미실행** — 부하 규율. 전 패키지 판정은 CI(PR) 몫이다.
+- **실제 `tsc` 를 돌려 본 적 없다.** 티어 (c)는 `npx --no-install tsc --noEmit` 커맨드를 **구성**하는
+  것까지만 테스트했고, tsc 가 실제로 그 인자로 기대대로 동작하는지는 관측하지 않았다. 데모는 전부
+  스크립트 티어(b)로 돌렸다.
+- **solution-style 판별은 `files: []` 명시만 결론으로 삼는다.** `files` 키 자체가 없고 `references`
+  만 있는 변형은 실무상 같은 공허 통과를 낳을 수 있으나 보수적으로 통과시킨다.
+- 소비자(mo.ai.kr) 자동 발화는 **추론**이다 — `scripts.typecheck` 보유 → 티어 (b) 발화로 예상되나,
+  ADK 릴리스 + `moai update` 이후 그쪽에서 실측해야 확정된다.
+- `pkill -x moai` 로 데모 잔여 프로세스를 정리하다 **`moai mcp-server` 도 함께 죽였다**(MCP 도구가
+  세션에서 끊김). 복구는 세션 재시작으로 되지만, 광범위 매칭 kill 을 쓴 내 실수다. PID 지정이 옳았다.
+
+## 8. 전달
+
+브랜치 `WT-gate-typecheck` → push → **PR 직접**(release 배치와 무관, 사고 근본 수리이므로).
+브랜치명은 규약상 `WT-` 접두(카드 스케치의 `feat/*` 대신); 의도는 PR 제목이 전달한다.
+
+금지된 untracked 4건(`ci-autofix-protocol.md`·`astgrep-rules/`·`t127/`·`diagram-design-absorption/`)은
+스테이징에 **포함되지 않았다** — `git status --short` 로 확인.

--- a/.moai/reports/t172/verdict.md
+++ b/.moai/reports/t172/verdict.md
@@ -164,3 +164,54 @@ cwd 에서 일어나 `npm` 이 워크트리 루트의 없는 `package.json` 을 
 
 금지된 untracked 4건(`ci-autofix-protocol.md`·`astgrep-rules/`·`t127/`·`diagram-design-absorption/`)은
 스테이징에 **포함되지 않았다** — `git status --short` 로 확인.
+
+
+---
+
+## 9. PR 리뷰 반영 (CodeRabbit, 5건 중 2건 수용 — 실측 후)
+
+리뷰 지적을 그대로 받지 않고 각각 재현했다. **둘은 진짜 결함이었고 내 코드였다.**
+
+### 9.1 tsconfig 는 JSONC 다 (수용, 커밋 `7d7f6cd4b`)
+
+재현: 주석 달린 tsconfig 에 `encoding/json` →
+`invalid character '/' looking for beginning of object key string`.
+
+이게 단순 파싱 실패로 끝나지 않는다. `isSolutionStyleTsconfig` 는 **파싱 실패 시 false** 를
+답하므로, 주석 하나가 solution-style 설정을 "tsc 실행" 경로로 보내고 **이 함수가 막으려던 공허
+통과를 그대로 되살린다.** 실무 tsconfig 는 주석과 후행 쉼표를 흔히 쓴다.
+
+조치: 주석·후행 쉼표를 걷어내고 파싱. 의존성 대신 작은 축약으로 했다 — 이 파일은 구조 질문 하나에
+답하려고 읽을 뿐이라 완전한 JSONC 파서는 질문값보다 비싸다. 문자열 상태와 백슬래시 이스케이프를
+추적해 URL 안의 `//` 가 살아남고 이스케이프된 따옴표가 문자열을 일찍 끝내지 않는다.
+
+**음성 대조 실행**: strip 을 되돌리면 새 회귀 테스트가
+`commented solution-style tsconfig accepted; it passes vacuously` 로 **FAIL** 한다. 되돌리기
+전/후를 모두 관측했다.
+
+### 9.2 `true`/`false` 는 크로스플랫폼이 아니다 (수용, 같은 커밋)
+
+Windows 는 두 유틸리티를 제공하지 않는다. 그리고 typecheck 스텝은 `optional: true` 라
+**LookPath 실패가 스텝을 실패시키는 게 아니라 스킵**한다 — Windows 실행에서는 게이트가 통과해
+차단 단언이 **엉뚱한 이유로** 실패했을 것이다. §5.4 의 `GOOS=windows go vet` 은 컴파일만 보므로
+이걸 잡지 못했고, CI 의 Test 매트릭스는 이 PR 에서 skipping 이었다.
+
+조치: `go version`(exit 0) / 잘못된 go 서브커맨드(exit≠0)로 교체. `go` 는 이 테스트가 도는 곳에
+반드시 있다.
+
+### 9.3 runStep cmd.Dir (미수용 — 범위 밖, 기록 유지)
+
+리뷰가 셋째로 지적한 `cmd.Dir` 미지정은 **실재하는 결함이 맞다**(§6 에서 내가 먼저 기록했다).
+다만 이 축보다 앞서 존재했고 카드가 [HARD] 로 범위 밖에 뒀으므로 손대지 않았다. §6 의 상속된
+한계 기록이 그대로 유효하다.
+
+### 9.4 재검증
+
+`go test ./internal/hook/quality/` ok 3.238s · `golangci-lint` **0 issues** ·
+`GOOS=windows go vet` OK · `go build ./...` OK.
+
+### 9.5 이 건에서 배운 것
+
+`GOOS=windows go vet` 통과를 크로스플랫폼 근거로 읽었는데, **vet 은 컴파일만 본다.** 런타임에
+외부 바이너리를 찾는 테스트는 vet 이 잡을 수 없고, 하필 그 스텝이 optional 이라 실패도 아닌
+스킵으로 조용히 갈렸을 것이다. 크로스플랫폼 주장에 vet 만 인용하면 안 된다.

--- a/internal/cli/gate.go
+++ b/internal/cli/gate.go
@@ -140,6 +140,10 @@ func mapConfigGateToQuality(g config.GateConfig) *quality.GateConfig {
 		VetTimeout:  g.VetTimeoutDuration(),
 		LintTimeout: g.LintTimeoutDuration(),
 		TestTimeout: g.TestTimeoutDuration(),
+
+		TypecheckEnabled: g.Typecheck.Enabled,
+		TypecheckCommand: g.Typecheck.Command,
+		TypecheckTimeout: g.TypecheckTimeoutDuration(),
 	}
 	// Map gate.disabled_steps through verbatim (issue #1265): the runner reads
 	// FALSE as "skip this step", so normalising values here would silently stop

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -493,9 +493,16 @@ func NewDefaultGateConfig() GateConfig {
 		Enabled:   true,
 		SkipTests: false,
 		Timeouts: GateTimeouts{
-			Vet:  30,
-			Lint: 60,
-			Test: 120,
+			Vet:       30,
+			Lint:      60,
+			Test:      120,
+			Typecheck: 300,
+		},
+		// The typecheck axis is ON by default. A project with no type-check
+		// surface reports the skip and passes, so enabling it costs nothing
+		// while closing the hole for every project that does have one.
+		Typecheck: GateTypecheck{
+			Enabled: true,
 		},
 		// The ast-grep sub-gate is ON by default in advisory mode (findings
 		// reported, commits never blocked); blocking is opt-in via gate.yaml.

--- a/internal/config/testdata/shipped_key_inventory.yaml
+++ b/internal/config/testdata/shipped_key_inventory.yaml
@@ -1,6 +1,6 @@
 # Shipped key inventory for SPEC-CONFIG-KEY-HONESTY-001 M1
 # Code baseline: ed70e4354
-# Total entries: 955
+# Total entries: 958
 # Classification: W=wire, P=prose-consumed, R=reserved, D=delete
 # Evidence: 'reader' = Go production reader; prose file path = P consumer; 'none' = R/D
 
@@ -386,9 +386,18 @@
 - path: "gate.timeouts.test"
   class: R
   evidence: none
+- path: "gate.timeouts.typecheck"
+  class: W
+  evidence: reader
 - path: "gate.timeouts.vet"
   class: R
   evidence: none
+- path: "gate.typecheck.command"
+  class: W
+  evidence: reader
+- path: "gate.typecheck.enabled"
+  class: W
+  evidence: reader
 - path: "git_convention.auto_detection.confidence_threshold"
   class: R
   evidence: none

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -738,6 +738,19 @@ type GateConfig struct {
 	// issue #1265 this field did not exist, so the runner's knob was documented
 	// but unreachable from any config file.
 	DisabledSteps map[string]bool `yaml:"disabled_steps"`
+	// Typecheck configures the type-check axis.
+	Typecheck GateTypecheck `yaml:"typecheck"`
+}
+
+// GateTypecheck configures the gate's type-check axis.
+type GateTypecheck struct {
+	// Enabled controls whether the typecheck axis runs. Default true.
+	Enabled bool `yaml:"enabled"`
+	// Command overrides the language default and enables the axis for ANY
+	// language. Split on whitespace and executed directly, so shell
+	// metacharacters are NOT interpreted — put a pipeline or a redirect in a
+	// script and name the script here.
+	Command string `yaml:"command"`
 }
 
 // AstGrepGateConfig holds configuration for ast-grep quality gate scanning.
@@ -754,9 +767,10 @@ type AstGrepGateConfig struct {
 
 // GateTimeouts holds per-step timeout configuration in seconds.
 type GateTimeouts struct {
-	Vet  int `yaml:"vet"`
-	Lint int `yaml:"lint"`
-	Test int `yaml:"test"`
+	Vet       int `yaml:"vet"`
+	Lint      int `yaml:"lint"`
+	Test      int `yaml:"test"`
+	Typecheck int `yaml:"typecheck"`
 }
 
 // VetTimeoutDuration converts the Vet timeout to time.Duration.
@@ -784,6 +798,16 @@ func (g *GateConfig) TestTimeoutDuration() time.Duration {
 		return 120 * time.Second
 	}
 	return time.Duration(g.Timeouts.Test) * time.Second
+}
+
+// TypecheckTimeoutDuration converts the Typecheck timeout to time.Duration.
+// Returns 300s when the value is zero or negative — a type-check over a large
+// monorepo routinely outlasts the test budget, so it gets its own.
+func (g *GateConfig) TypecheckTimeoutDuration() time.Duration {
+	if g.Timeouts.Typecheck <= 0 {
+		return 300 * time.Second
+	}
+	return time.Duration(g.Timeouts.Typecheck) * time.Second
 }
 
 // SunsetConfig defines the Build-to-Delete framework configuration.
@@ -1175,10 +1199,10 @@ type DesignEvaluator struct {
 
 // DesignEvolution holds evolution and self-learning settings.
 type DesignEvolution struct {
-	ArchiveAfterEvolve      bool                     `yaml:"archive_after_evolve"`
-	AutoEvolveThreshold     int                      `yaml:"auto_evolve_threshold"`
-	CooldownHours           int                      `yaml:"cooldown_hours"`
-	GraduationCriteria      DesignGraduationCriteria `yaml:"graduation_criteria"`
+	ArchiveAfterEvolve  bool                     `yaml:"archive_after_evolve"`
+	AutoEvolveThreshold int                      `yaml:"auto_evolve_threshold"`
+	CooldownHours       int                      `yaml:"cooldown_hours"`
+	GraduationCriteria  DesignGraduationCriteria `yaml:"graduation_criteria"`
 	// MaxActiveLearnings is declared but NOT read by any production code path.
 	// The actual ceiling on active learnings is enforced by two independent
 	// hardcoded constants: internal/evolution/types.go MaxActiveLearnings (= 50)
@@ -1186,9 +1210,9 @@ type DesignEvolution struct {
 	// Wiring this config field to those sites is out of scope (a refactor beyond
 	// SPEC-CONFIG-KEY-HONESTY-001). Treat this field as documentation of the
 	// intended value, not the lever.
-	MaxActiveLearnings      int                      `yaml:"max_active_learnings"`
-	MaxEvolutionRatePerWeek int                      `yaml:"max_evolution_rate_per_week"`
-	RequireApproval         bool                     `yaml:"require_approval"`
+	MaxActiveLearnings      int  `yaml:"max_active_learnings"`
+	MaxEvolutionRatePerWeek int  `yaml:"max_evolution_rate_per_week"`
+	RequireApproval         bool `yaml:"require_approval"`
 }
 
 // DesignGraduationCriteria holds graduation thresholds for learnings.

--- a/internal/hook/quality/gate.go
+++ b/internal/hook/quality/gate.go
@@ -45,6 +45,15 @@ type GateConfig struct {
 	// Keys are step names (e.g., "dotnet format"); a value of false skips that step.
 	// Example: map[string]bool{"dotnet format": false}
 	DisabledSteps map[string]bool
+	// TypecheckEnabled controls the typecheck axis. Default true.
+	TypecheckEnabled bool
+	// TypecheckCommand overrides the language default and enables the axis for
+	// any language. Split on whitespace (strings.Fields) and executed directly,
+	// so shell metacharacters are not interpreted — a pipeline or a redirect
+	// belongs in a script the command invokes.
+	TypecheckCommand string
+	// TypecheckTimeout is the maximum duration allowed for the typecheck step.
+	TypecheckTimeout time.Duration
 }
 
 // DefaultGateConfig returns a GateConfig with production-safe defaults.
@@ -56,6 +65,11 @@ func DefaultGateConfig() *GateConfig {
 		LintTimeout: 60 * time.Second,
 		TestTimeout: 120 * time.Second,
 		AstGrepGate: DefaultAstGrepGateConfig(),
+		// The axis ships on: a project with no type-check surface reports the
+		// skip and passes, so enabling it by default costs nothing while
+		// closing the hole for every project that does have one.
+		TypecheckEnabled: true,
+		TypecheckTimeout: 300 * time.Second,
 	}
 }
 
@@ -67,6 +81,11 @@ type langToolchain struct {
 	vetSteps []gateStep
 	// lintSteps are linter commands run in order. Each is optional.
 	lintSteps []gateStep
+	// typecheckStep is the type-check command, resolved against the project at
+	// run time by resolveTypecheckStep. Nil means the language has no default
+	// type-check axis — the gate then reports the absence rather than passing
+	// quietly, and gate.typecheck.command supplies one for any language.
+	typecheckStep *gateStep
 	// testStep is the test command. Nil means no test step available.
 	testStep *gateStep
 }
@@ -99,8 +118,16 @@ var toolchains = []langToolchain{
 		testStep: &gateStep{name: "go test", binary: "go", args: []string{"test", "./..."}},
 	},
 	// Node.js (TypeScript/JavaScript): package.json
+	//
+	// This entry has no vetSteps, which is what made Node the one type-unsafe
+	// blind spot: mypy sits on the lint axis, Dart analyze on the vet axis, go
+	// vet type-checks as it runs, and a compiled language's test step compiles
+	// first. Node had only lint and test, and a project whose linter config is
+	// absent (biome instead of eslint, say) skipped lint too — leaving a
+	// type-broken build to pass the gate. typecheckStep closes that hole.
 	{
-		markerFiles: []string{"package.json"},
+		markerFiles:   []string{"package.json"},
+		typecheckStep: nodeTypecheckStep(),
 		lintSteps: []gateStep{{
 			name: "eslint", binary: "npx", args: []string{"eslint", "."}, optional: true,
 			configFiles: []string{
@@ -273,23 +300,48 @@ func (g *QualityGate) Run(ctx context.Context) (bool, string) {
 	}
 
 	// Step 1: vet steps
+	var vetReason string
 	for _, step := range tc.vetSteps {
-		if ok, out := g.executeStep(ctx, step, g.config.VetTimeout); !ok {
+		ok, out := g.executeStep(ctx, step, g.config.VetTimeout)
+		if !ok {
 			return false, out
 		}
-	}
-
-	// Step 2: lint steps
-	for _, step := range tc.lintSteps {
-		if ok, out := g.executeStep(ctx, step, g.config.LintTimeout); !ok {
-			return false, out
-		}
+		vetReason = appendReason(vetReason, out)
 	}
 
 	// passReason carries a passing step's notice out to Run's caller. Dropping
 	// it here is what left an absent ast-grep scanner indistinguishable from a
 	// clean scan: the step reported the skip and this frame threw it away.
-	var passReason string
+	passReason := vetReason
+
+	// Step 1.5: typecheck axis.
+	//
+	// It runs after vet and before lint so a type error surfaces before the
+	// slower style pass, and so a project whose linter is absent still gets a
+	// correctness gate. Every outcome is reported: a skip is not a failure,
+	// but it is never silent — that silence is what let a broken build through.
+	if g.config.TypecheckEnabled {
+		step, reason, ok := resolveTypecheckStep(tc.typecheckStep, resolveQualityProjectDir(*g.config, "QualityGate.Run.typecheck"), g.config.TypecheckCommand)
+		switch {
+		case ok:
+			passed, out := g.executeStep(ctx, step, g.config.TypecheckTimeout)
+			if !passed {
+				return false, out
+			}
+			passReason = appendReason(passReason, out)
+		default:
+			passReason = appendReason(passReason, reason)
+		}
+	}
+
+	// Step 2: lint steps
+	for _, step := range tc.lintSteps {
+		ok, out := g.executeStep(ctx, step, g.config.LintTimeout)
+		if !ok {
+			return false, out
+		}
+		passReason = appendReason(passReason, out)
+	}
 
 	// Step 2.5: ast-grep domain rules
 	// ASTG-UPGRADE-001: switched to RunAstGrepGateV2 which uses the unified Scanner
@@ -300,7 +352,7 @@ func (g *QualityGate) Run(ctx context.Context) (bool, string) {
 		if !ok {
 			return false, out
 		}
-		passReason = out
+		passReason = appendReason(passReason, out)
 	}
 
 	// Step 3: test step (skippable)

--- a/internal/hook/quality/gate_typecheck.go
+++ b/internal/hook/quality/gate_typecheck.go
@@ -109,6 +109,12 @@ func resolveTypecheckStep(base *gateStep, dir, override string) (gateStep, strin
 // it as coverage would rebuild the very blind spot this axis closes. A parse
 // failure answers false: refusing to run on an unreadable config would be a
 // worse failure mode than attempting the check.
+//
+// tsconfig.json is JSONC, not JSON — TypeScript accepts comments and trailing
+// commas, and real configs use them. encoding/json rejects both, and because a
+// parse failure answers false, an unstripped comment would send a solution
+// config down the "run tsc" path and straight back into the vacuous pass this
+// function exists to prevent. Comments are stripped first.
 func isSolutionStyleTsconfig(path string) bool {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -120,7 +126,7 @@ func isSolutionStyleTsconfig(path string) bool {
 		Include    *[]string         `json:"include"`
 		References []json.RawMessage `json:"references"`
 	}
-	if err := json.Unmarshal(data, &cfg); err != nil {
+	if err := json.Unmarshal(stripJSONC(data), &cfg); err != nil {
 		return false
 	}
 

--- a/internal/hook/quality/gate_typecheck.go
+++ b/internal/hook/quality/gate_typecheck.go
@@ -1,0 +1,153 @@
+package quality
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// typecheckStepName is the axis name, deliberately language-independent: the
+// gate reports "typecheck" whether the underlying tool is tsc, mypy, or a
+// project's own script. It doubles as the disabled_steps key.
+const typecheckStepName = "typecheck"
+
+// nodeTypecheckScript is the package.json script the tier-(b) lookup honours.
+const nodeTypecheckScript = "typecheck"
+
+// nodeTypecheckStep is the Node placeholder resolved by resolveTypecheckStep.
+//
+// It carries no command of its own because which command is right depends on
+// the project: a script if the author declared one, otherwise tsc. Resolution
+// happens against the project directory at run time.
+func nodeTypecheckStep() *gateStep {
+	return &gateStep{name: typecheckStepName, binary: "", args: nil}
+}
+
+// resolveTypecheckStep decides what — if anything — to run for the typecheck
+// axis, in three tiers.
+//
+//	(a) override:  gate.typecheck.command, honoured for ANY language
+//	(b) script:    package.json scripts.typecheck  -> npm run typecheck
+//	(c) tsconfig:  tsconfig.json present           -> npx --no-install tsc --noEmit
+//
+// The third return reports whether a step was produced. When it is false the
+// second return explains why, and that explanation is surfaced rather than
+// dropped: a silent skip is the exact failure this axis repairs, where a
+// consumer repository's gate passed while its build was broken.
+//
+// A skip is not a failure. Tool availability stays fail-open — the point is
+// that the operator can always see which axes actually ran.
+func resolveTypecheckStep(base *gateStep, dir, override string) (gateStep, string, bool) {
+	// Tier (a): an explicit command outranks everything and works for any
+	// language, which is how a Python or Go project opts into the axis.
+	if cmd := strings.TrimSpace(override); cmd != "" {
+		fields := strings.Fields(cmd)
+		if len(fields) == 0 {
+			return gateStep{}, "typecheck: skipped (gate.typecheck.command is empty)", false
+		}
+		return gateStep{
+			name:     typecheckStepName,
+			binary:   fields[0],
+			args:     fields[1:],
+			optional: true,
+		}, "", true
+	}
+
+	if base == nil {
+		return gateStep{}, fmt.Sprintf(
+			"%s: skipped (no default for this language; set gate.typecheck.command to enable one)",
+			typecheckStepName), false
+	}
+
+	if dir == "" {
+		return gateStep{}, fmt.Sprintf("%s: skipped (project directory unknown)", typecheckStepName), false
+	}
+
+	// Tier (b): the project's own script. It outranks the tsconfig shape check
+	// below, so a monorepo root that delegates to turbo is not penalised for
+	// having a solution-style tsconfig.
+	if scripts, ok := readPackageJSONScripts(filepath.Join(dir, "package.json")); ok {
+		if strings.TrimSpace(scripts[nodeTypecheckScript]) != "" {
+			return gateStep{
+				name:     typecheckStepName,
+				binary:   "npm",
+				args:     []string{"run", nodeTypecheckScript},
+				optional: true,
+			}, "", true
+		}
+	}
+
+	// Tier (c): tsc against the project's tsconfig.
+	tsconfig := filepath.Join(dir, "tsconfig.json")
+	if _, err := os.Stat(tsconfig); err != nil {
+		return gateStep{}, fmt.Sprintf(
+			"%s: skipped (no scripts.typecheck and no tsconfig.json; set gate.typecheck.command to enable one)",
+			typecheckStepName), false
+	}
+
+	if isSolutionStyleTsconfig(tsconfig) {
+		return gateStep{}, fmt.Sprintf(
+			"%s: skipped (solution-style tsconfig type-checks nothing and would pass vacuously; "+
+				"add a scripts.typecheck that builds the referenced projects, or set gate.typecheck.command)",
+			typecheckStepName), false
+	}
+
+	return gateStep{
+		name:     typecheckStepName,
+		binary:   "npx",
+		args:     []string{"--no-install", "tsc", "--noEmit"},
+		optional: true,
+	}, "", true
+}
+
+// isSolutionStyleTsconfig reports whether the tsconfig is a solution file: an
+// empty files array plus project references, and nothing to compile itself.
+//
+// Running tsc --noEmit against one exits 0 having checked nothing, so treating
+// it as coverage would rebuild the very blind spot this axis closes. A parse
+// failure answers false: refusing to run on an unreadable config would be a
+// worse failure mode than attempting the check.
+func isSolutionStyleTsconfig(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+
+	var cfg struct {
+		Files      *[]string         `json:"files"`
+		Include    *[]string         `json:"include"`
+		References []json.RawMessage `json:"references"`
+	}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return false
+	}
+
+	if len(cfg.References) == 0 {
+		return false
+	}
+	// An include list means the config does compile something of its own.
+	if cfg.Include != nil && len(*cfg.Include) > 0 {
+		return false
+	}
+	// files: [] is the solution marker. An absent files key with references and
+	// no include also compiles nothing under the default exclusions in
+	// practice, but only the explicit empty array is treated as conclusive.
+	return cfg.Files != nil && len(*cfg.Files) == 0
+}
+
+// appendReason joins non-empty step notices with a newline.
+//
+// Notices accumulate rather than overwrite: before this, a later step's reason
+// replaced an earlier one, so a run that skipped two axes reported one.
+func appendReason(existing, add string) string {
+	add = strings.TrimSpace(add)
+	if add == "" {
+		return existing
+	}
+	if strings.TrimSpace(existing) == "" {
+		return add
+	}
+	return existing + "\n" + add
+}

--- a/internal/hook/quality/gate_typecheck_test.go
+++ b/internal/hook/quality/gate_typecheck_test.go
@@ -1,0 +1,291 @@
+package quality
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeFixture lays out a project directory and returns its path.
+func writeFixture(t *testing.T, files map[string]string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	for name, body := range files {
+		path := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir for %s: %v", name, err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	return dir
+}
+
+func typecheckConfig(dir string) *GateConfig {
+	cfg := DefaultGateConfig()
+	cfg.ProjectDir = dir
+	cfg.SkipTests = true
+	cfg.AstGrepGate = nil
+	return cfg
+}
+
+// --- Tier selection -------------------------------------------------------
+
+// TestTypecheckTierScriptWins — tier (b): package.json scripts.typecheck.
+func TestTypecheckTierScriptWins(t *testing.T) {
+	t.Parallel()
+
+	dir := writeFixture(t, map[string]string{
+		"package.json":  `{"scripts":{"typecheck":"turbo run typecheck"}}`,
+		"tsconfig.json": `{"compilerOptions":{"strict":true}}`,
+	})
+
+	step, reason, ok := resolveTypecheckStep(nodeTypecheckStep(), dir, "")
+	if !ok {
+		t.Fatalf("resolution skipped (%s); want the script tier to fire", reason)
+	}
+	if step.binary != "npm" {
+		t.Errorf("binary = %q, want npm", step.binary)
+	}
+	if got := strings.Join(step.args, " "); got != "run typecheck" {
+		t.Errorf("args = %q, want %q", got, "run typecheck")
+	}
+}
+
+// TestTypecheckTierTsconfigFallback — tier (c): tsconfig.json, no script.
+func TestTypecheckTierTsconfigFallback(t *testing.T) {
+	t.Parallel()
+
+	dir := writeFixture(t, map[string]string{
+		"package.json":  `{"scripts":{"build":"tsc"}}`,
+		"tsconfig.json": `{"compilerOptions":{"strict":true}}`,
+	})
+
+	step, reason, ok := resolveTypecheckStep(nodeTypecheckStep(), dir, "")
+	if !ok {
+		t.Fatalf("resolution skipped (%s); want the tsconfig tier to fire", reason)
+	}
+	if step.binary != "npx" {
+		t.Errorf("binary = %q, want npx", step.binary)
+	}
+	if got := strings.Join(step.args, " "); got != "--no-install tsc --noEmit" {
+		t.Errorf("args = %q, want %q", got, "--no-install tsc --noEmit")
+	}
+}
+
+// TestTypecheckSkipsWithoutTsconfigOrScript asserts the skip carries a reason.
+//
+// A silent skip here is exactly the shape of the incident this axis exists to
+// repair: a missing config made the gate pass while the build was broken.
+func TestTypecheckSkipsWithoutTsconfigOrScript(t *testing.T) {
+	t.Parallel()
+
+	dir := writeFixture(t, map[string]string{
+		"package.json": `{"scripts":{"build":"vite build"}}`,
+	})
+
+	_, reason, ok := resolveTypecheckStep(nodeTypecheckStep(), dir, "")
+	if ok {
+		t.Fatal("resolution fired with neither a typecheck script nor a tsconfig")
+	}
+	if strings.TrimSpace(reason) == "" {
+		t.Fatal("skip carried no reason")
+	}
+	if !strings.Contains(reason, "tsconfig") {
+		t.Errorf("reason %q does not say what was missing", reason)
+	}
+}
+
+// TestSolutionStyleTsconfigIsRefused — a solution-style tsconfig (files: [] plus
+// references only) type-checks nothing and exits 0, so accepting it would
+// reinstate the vacuous pass this card repairs.
+func TestSolutionStyleTsconfigIsRefused(t *testing.T) {
+	t.Parallel()
+
+	dir := writeFixture(t, map[string]string{
+		"package.json":  `{"scripts":{"build":"tsc -b"}}`,
+		"tsconfig.json": `{"files":[],"references":[{"path":"./packages/a"}]}`,
+	})
+
+	_, reason, ok := resolveTypecheckStep(nodeTypecheckStep(), dir, "")
+	if ok {
+		t.Fatal("solution-style tsconfig accepted; it passes vacuously")
+	}
+	if !strings.Contains(reason, "solution-style") {
+		t.Errorf("reason %q does not name the solution-style case", reason)
+	}
+}
+
+// TestSolutionStyleWithScriptStillRuns — the script tier outranks the tsconfig
+// shape, so a monorepo root delegating to turbo is not penalised.
+func TestSolutionStyleWithScriptStillRuns(t *testing.T) {
+	t.Parallel()
+
+	dir := writeFixture(t, map[string]string{
+		"package.json":  `{"scripts":{"typecheck":"turbo run typecheck"}}`,
+		"tsconfig.json": `{"files":[],"references":[{"path":"./packages/a"}]}`,
+	})
+
+	step, reason, ok := resolveTypecheckStep(nodeTypecheckStep(), dir, "")
+	if !ok {
+		t.Fatalf("skipped (%s); the script tier must outrank the tsconfig shape", reason)
+	}
+	if got := strings.Join(step.args, " "); got != "run typecheck" {
+		t.Errorf("args = %q, want the script tier", got)
+	}
+}
+
+// TestTypecheckOverrideForcesAnyLanguage — tier (a).
+func TestTypecheckOverrideForcesAnyLanguage(t *testing.T) {
+	t.Parallel()
+
+	dir := writeFixture(t, map[string]string{"go.mod": "module x\n"})
+
+	step, reason, ok := resolveTypecheckStep(nil, dir, "mypy --strict .")
+	if !ok {
+		t.Fatalf("override skipped (%s); it must fire for any language", reason)
+	}
+	if step.binary != "mypy" {
+		t.Errorf("binary = %q, want mypy", step.binary)
+	}
+	if got := strings.Join(step.args, " "); got != "--strict ." {
+		t.Errorf("args = %q, want %q", got, "--strict .")
+	}
+}
+
+// TestTypecheckAbsentForLanguageReportsReason — a language with no default
+// says so rather than passing quietly.
+func TestTypecheckAbsentForLanguageReportsReason(t *testing.T) {
+	t.Parallel()
+
+	dir := writeFixture(t, map[string]string{"go.mod": "module x\n"})
+
+	_, reason, ok := resolveTypecheckStep(nil, dir, "")
+	if ok {
+		t.Fatal("a language without a typecheck default produced a step")
+	}
+	if !strings.Contains(reason, "gate.typecheck.command") {
+		t.Errorf("reason %q does not tell the operator how to supply one", reason)
+	}
+}
+
+// --- Gate integration -----------------------------------------------------
+
+// TestGateBlocksOnTypecheckFailure is the headline RED: a failing typecheck
+// must stop the gate, which is precisely what did not happen in the incident.
+func TestGateBlocksOnTypecheckFailure(t *testing.T) {
+	t.Parallel()
+
+	dir := writeFixture(t, map[string]string{"go.mod": "module x\n"})
+	cfg := typecheckConfig(dir)
+	cfg.TypecheckCommand = "false" // exits 1
+	cfg.SkipTests = true
+
+	passed, out := NewQualityGate(cfg).Run(context.Background())
+	if passed {
+		t.Fatalf("gate passed with a failing typecheck; output = %q", out)
+	}
+	if !strings.Contains(strings.ToLower(out), "typecheck") {
+		t.Errorf("failure output %q does not name the typecheck step", out)
+	}
+}
+
+// TestGatePassesWhenTypecheckSucceeds is the GREEN counterpart — without it,
+// the block above could be satisfied by a gate that always fails.
+func TestGatePassesWhenTypecheckSucceeds(t *testing.T) {
+	t.Parallel()
+
+	dir := writeFixture(t, map[string]string{"go.mod": "module x\n"})
+	cfg := typecheckConfig(dir)
+	cfg.TypecheckCommand = "true" // exits 0
+
+	passed, out := NewQualityGate(cfg).Run(context.Background())
+	if !passed {
+		t.Fatalf("gate failed with a passing typecheck; output = %q", out)
+	}
+}
+
+// TestTypecheckDisabledByConfig — typecheck.enabled false.
+func TestTypecheckDisabledByConfig(t *testing.T) {
+	t.Parallel()
+
+	dir := writeFixture(t, map[string]string{"go.mod": "module x\n"})
+	cfg := typecheckConfig(dir)
+	cfg.TypecheckEnabled = false
+	cfg.TypecheckCommand = "false"
+
+	if passed, out := NewQualityGate(cfg).Run(context.Background()); !passed {
+		t.Fatalf("disabled typecheck still blocked the gate: %q", out)
+	}
+}
+
+// TestTypecheckDisabledByDisabledSteps — the step-name key already in use for
+// every other step works for this axis too.
+func TestTypecheckDisabledByDisabledSteps(t *testing.T) {
+	t.Parallel()
+
+	dir := writeFixture(t, map[string]string{"go.mod": "module x\n"})
+	cfg := typecheckConfig(dir)
+	cfg.TypecheckCommand = "false"
+	cfg.DisabledSteps = map[string]bool{typecheckStepName: false}
+
+	if passed, out := NewQualityGate(cfg).Run(context.Background()); !passed {
+		t.Fatalf("disabled_steps did not suppress the typecheck step: %q", out)
+	}
+}
+
+// TestTypecheckSkipIsReportedNotSilent — the axis's whole point.
+func TestTypecheckSkipIsReportedNotSilent(t *testing.T) {
+	t.Parallel()
+
+	dir := writeFixture(t, map[string]string{"go.mod": "module x\n"})
+	cfg := typecheckConfig(dir)
+
+	passed, out := NewQualityGate(cfg).Run(context.Background())
+	if !passed {
+		t.Fatalf("gate failed on a skipped typecheck; skipping is not failing: %q", out)
+	}
+	if !strings.Contains(out, typecheckStepName) {
+		t.Fatalf("output %q does not report the skip — a silent skip is the defect being repaired", out)
+	}
+}
+
+// TestTypecheckDefaultsAreProductionSafe pins the shipped defaults.
+func TestTypecheckDefaultsAreProductionSafe(t *testing.T) {
+	t.Parallel()
+
+	cfg := DefaultGateConfig()
+	if !cfg.TypecheckEnabled {
+		t.Error("TypecheckEnabled default = false, want true")
+	}
+	if cfg.TypecheckTimeout != 300*time.Second {
+		t.Errorf("TypecheckTimeout default = %s, want 300s", cfg.TypecheckTimeout)
+	}
+	if cfg.TypecheckCommand != "" {
+		t.Errorf("TypecheckCommand default = %q, want empty", cfg.TypecheckCommand)
+	}
+}
+
+// TestNodeToolchainCarriesTypecheckStep asserts the wiring exists where the
+// incident happened: the Node entry previously had no vet axis at all.
+func TestNodeToolchainCarriesTypecheckStep(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range toolchains {
+		for _, marker := range tc.markerFiles {
+			if marker != "package.json" {
+				continue
+			}
+			if tc.typecheckStep == nil {
+				t.Fatal("the Node toolchain has no typecheckStep; Node was the untyped hole")
+			}
+			return
+		}
+	}
+	t.Fatal("no Node toolchain entry found")
+}

--- a/internal/hook/quality/gate_typecheck_test.go
+++ b/internal/hook/quality/gate_typecheck_test.go
@@ -26,6 +26,17 @@ func writeFixture(t *testing.T, files map[string]string) string {
 	return dir
 }
 
+// Cross-platform stand-ins for the `true` / `false` utilities.
+//
+// Windows ships neither, and the typecheck step is optional, so a LookPath miss
+// SKIPS the step rather than failing it — a Windows run would have seen the gate
+// pass and failed the blocking assertion for the wrong reason. `go` is present
+// wherever these tests run, so its own exit codes carry the signal instead.
+const (
+	cmdExitZero    = "go version"
+	cmdExitNonZero = "go t172-not-a-subcommand"
+)
+
 func typecheckConfig(dir string) *GateConfig {
 	cfg := DefaultGateConfig()
 	cfg.ProjectDir = dir
@@ -183,7 +194,7 @@ func TestGateBlocksOnTypecheckFailure(t *testing.T) {
 
 	dir := writeFixture(t, map[string]string{"go.mod": "module x\n"})
 	cfg := typecheckConfig(dir)
-	cfg.TypecheckCommand = "false" // exits 1
+	cfg.TypecheckCommand = cmdExitNonZero
 	cfg.SkipTests = true
 
 	passed, out := NewQualityGate(cfg).Run(context.Background())
@@ -202,7 +213,7 @@ func TestGatePassesWhenTypecheckSucceeds(t *testing.T) {
 
 	dir := writeFixture(t, map[string]string{"go.mod": "module x\n"})
 	cfg := typecheckConfig(dir)
-	cfg.TypecheckCommand = "true" // exits 0
+	cfg.TypecheckCommand = cmdExitZero
 
 	passed, out := NewQualityGate(cfg).Run(context.Background())
 	if !passed {
@@ -217,7 +228,7 @@ func TestTypecheckDisabledByConfig(t *testing.T) {
 	dir := writeFixture(t, map[string]string{"go.mod": "module x\n"})
 	cfg := typecheckConfig(dir)
 	cfg.TypecheckEnabled = false
-	cfg.TypecheckCommand = "false"
+	cfg.TypecheckCommand = cmdExitNonZero
 
 	if passed, out := NewQualityGate(cfg).Run(context.Background()); !passed {
 		t.Fatalf("disabled typecheck still blocked the gate: %q", out)
@@ -231,7 +242,7 @@ func TestTypecheckDisabledByDisabledSteps(t *testing.T) {
 
 	dir := writeFixture(t, map[string]string{"go.mod": "module x\n"})
 	cfg := typecheckConfig(dir)
-	cfg.TypecheckCommand = "false"
+	cfg.TypecheckCommand = cmdExitNonZero
 	cfg.DisabledSteps = map[string]bool{typecheckStepName: false}
 
 	if passed, out := NewQualityGate(cfg).Run(context.Background()); !passed {

--- a/internal/hook/quality/jsonc.go
+++ b/internal/hook/quality/jsonc.go
@@ -1,0 +1,113 @@
+package quality
+
+// jsonc.go — the smallest JSONC-to-JSON reduction the typecheck axis needs.
+//
+// tsconfig.json is JSONC: TypeScript accepts // and /* */ comments and trailing
+// commas, and real configs use both. encoding/json rejects them, which matters
+// here because isSolutionStyleTsconfig answers false on a parse failure — an
+// unstripped comment would route a solution-style config to "run tsc" and
+// reinstate the vacuous pass the check exists to prevent.
+//
+// This is deliberately not a full JSONC parser. The file is read to answer one
+// structural question (files: [] plus references, nothing to compile), so a
+// dependency would be more than the question is worth.
+
+// stripJSONC removes comments and trailing commas, leaving valid JSON.
+//
+// String state is tracked so a "//" inside a value — a URL in a path mapping,
+// say — survives, and backslash escapes are honoured so an escaped quote does
+// not end a string early.
+func stripJSONC(data []byte) []byte {
+	out := make([]byte, 0, len(data))
+
+	var inString, escaped, inLine, inBlock bool
+	for i := 0; i < len(data); i++ {
+		c := data[i]
+
+		switch {
+		case inLine:
+			if c == '\n' {
+				inLine = false
+				out = append(out, c)
+			}
+			continue
+		case inBlock:
+			if c == '*' && i+1 < len(data) && data[i+1] == '/' {
+				inBlock = false
+				i++
+			}
+			continue
+		case inString:
+			out = append(out, c)
+			switch {
+			case escaped:
+				escaped = false
+			case c == '\\':
+				escaped = true
+			case c == '"':
+				inString = false
+			}
+			continue
+		}
+
+		if c == '/' && i+1 < len(data) {
+			if data[i+1] == '/' {
+				inLine = true
+				i++
+				continue
+			}
+			if data[i+1] == '*' {
+				inBlock = true
+				i++
+				continue
+			}
+		}
+		if c == '"' {
+			inString = true
+		}
+		out = append(out, c)
+	}
+
+	return stripTrailingCommas(out)
+}
+
+// stripTrailingCommas drops a comma followed only by whitespace and a closing
+// brace or bracket.
+func stripTrailingCommas(data []byte) []byte {
+	out := make([]byte, 0, len(data))
+
+	var inString, escaped bool
+	for i := 0; i < len(data); i++ {
+		c := data[i]
+
+		if inString {
+			out = append(out, c)
+			switch {
+			case escaped:
+				escaped = false
+			case c == '\\':
+				escaped = true
+			case c == '"':
+				inString = false
+			}
+			continue
+		}
+		if c == '"' {
+			inString = true
+			out = append(out, c)
+			continue
+		}
+		if c == ',' {
+			j := i + 1
+			for j < len(data) && (data[j] == ' ' || data[j] == '\t' || data[j] == '\n' || data[j] == '\r') {
+				j++
+			}
+			if j < len(data) && (data[j] == '}' || data[j] == ']') {
+				continue
+			}
+		}
+		out = append(out, c)
+	}
+
+	return out
+}

--- a/internal/hook/quality/jsonc_test.go
+++ b/internal/hook/quality/jsonc_test.go
@@ -1,0 +1,135 @@
+package quality
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestSolutionStyleTsconfigWithComments is the regression the review caught.
+//
+// tsconfig.json is JSONC and real configs carry comments. Before the strip,
+// encoding/json failed on them, isSolutionStyleTsconfig answered false, and the
+// config was routed to "run tsc" — a vacuous pass, which is the exact hole the
+// solution-style check exists to close.
+func TestSolutionStyleTsconfigWithComments(t *testing.T) {
+	t.Parallel()
+
+	dir := writeFixture(t, map[string]string{
+		"package.json": `{"scripts":{"build":"tsc -b"}}`,
+		"tsconfig.json": `{
+  // Solution file: compiles nothing itself, only references projects.
+  "files": [],
+  /* the workspaces this solution builds */
+  "references": [
+    { "path": "./packages/a" },
+    { "path": "./packages/b" },
+  ],
+}`,
+	})
+
+	_, reason, ok := resolveTypecheckStep(nodeTypecheckStep(), dir, "")
+	if ok {
+		t.Fatal("commented solution-style tsconfig accepted; it passes vacuously")
+	}
+	if !strings.Contains(reason, "solution-style") {
+		t.Errorf("reason %q does not name the solution-style case", reason)
+	}
+}
+
+// TestCommentedNonSolutionTsconfigStillRuns guards the other direction: comments
+// must not turn an ordinary config into a refusal.
+func TestCommentedNonSolutionTsconfigStillRuns(t *testing.T) {
+	t.Parallel()
+
+	dir := writeFixture(t, map[string]string{
+		"package.json": `{"scripts":{"build":"tsc"}}`,
+		"tsconfig.json": `{
+  // strict everywhere
+  "compilerOptions": { "strict": true },
+}`,
+	})
+
+	step, reason, ok := resolveTypecheckStep(nodeTypecheckStep(), dir, "")
+	if !ok {
+		t.Fatalf("skipped (%s); a commented ordinary tsconfig must still run", reason)
+	}
+	if step.binary != "npx" {
+		t.Errorf("binary = %q, want npx", step.binary)
+	}
+}
+
+func TestStripJSONC(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want map[string]any
+	}{
+		{
+			name: "line comment",
+			in:   "{\n // c\n \"a\": 1\n}",
+			want: map[string]any{"a": float64(1)},
+		},
+		{
+			name: "block comment",
+			in:   `{/* c */"a": 1}`,
+			want: map[string]any{"a": float64(1)},
+		},
+		{
+			name: "trailing comma in object",
+			in:   `{"a": 1,}`,
+			want: map[string]any{"a": float64(1)},
+		},
+		{
+			name: "trailing comma in array",
+			in:   `{"a": [1,2,]}`,
+			want: map[string]any{"a": []any{float64(1), float64(2)}},
+		},
+		{
+			// The load-bearing case: a // inside a string is data, not a comment.
+			name: "double slash inside a string survives",
+			in:   `{"url": "https://example.com/x"}`,
+			want: map[string]any{"url": "https://example.com/x"},
+		},
+		{
+			name: "escaped quote does not end the string early",
+			in:   `{"a": "say \"hi\" // not a comment"}`,
+			want: map[string]any{"a": `say "hi" // not a comment`},
+		},
+		{
+			name: "comma inside a string is not a trailing comma",
+			in:   `{"a": "x,"}`,
+			want: map[string]any{"a": "x,"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var got map[string]any
+			if err := json.Unmarshal(stripJSONC([]byte(tc.in)), &got); err != nil {
+				t.Fatalf("unmarshal after strip: %v (stripped: %s)", err, stripJSONC([]byte(tc.in)))
+			}
+
+			wantJSON, _ := json.Marshal(tc.want)
+			gotJSON, _ := json.Marshal(got)
+			if string(gotJSON) != string(wantJSON) {
+				t.Errorf("got %s, want %s", gotJSON, wantJSON)
+			}
+		})
+	}
+}
+
+// TestStripJSONCLeavesPlainJSONAlone asserts the strip is a no-op on input that
+// was already valid JSON — the common case, which must not be perturbed.
+func TestStripJSONCLeavesPlainJSONAlone(t *testing.T) {
+	t.Parallel()
+
+	const in = `{"compilerOptions":{"strict":true},"include":["src"]}`
+	if got := string(stripJSONC([]byte(in))); got != in {
+		t.Fatalf("plain JSON was altered:\n got %s\nwant %s", got, in)
+	}
+}

--- a/internal/template/templates/.moai/config/sections/gate.yaml
+++ b/internal/template/templates/.moai/config/sections/gate.yaml
@@ -21,6 +21,30 @@ gate:
     vet: 30
     lint: 60
     test: 120
+    # A type-check over a large monorepo routinely outlasts the test budget,
+    # so it gets its own.
+    typecheck: 300
+  # The typecheck axis runs between vet and lint, so a type error surfaces
+  # before the slower style pass and a project whose linter config is absent
+  # still gets a correctness gate.
+  #
+  # Node resolves in three tiers: `command` below (any language), then
+  # package.json scripts.typecheck, then `npx --no-install tsc --noEmit` when a
+  # tsconfig.json is present. A solution-style tsconfig (files: [] plus
+  # references) is refused rather than run — it type-checks nothing and would
+  # pass vacuously.
+  #
+  # Every outcome is reported. A skip is not a failure, but it is never
+  # silent: a language with no default prints how to supply one.
+  typecheck:
+    enabled: true
+    # Overrides the language default and enables the axis for ANY language,
+    # e.g. "mypy --strict ." or "npm run typecheck".
+    #
+    # Split on whitespace and executed directly, so shell metacharacters are
+    # NOT interpreted — put a pipeline or a redirect in a script and name the
+    # script here.
+    command: ""
   ast_grep_gate:
     enabled: true
     # Where this project's ast-grep rules live. This is the single source of


### PR DESCRIPTION
## Why

A consumer repository shipped a type error through a green `moai gate`.

The cause is a gap, not a bug: that repo uses **biome** rather than eslint, so the lint step skipped for want of an eslint config — and the Node toolchain entry has **no vet steps at all**, leaving only the test step, which never type-checks. Node was the one type-unsafe hole in the matrix:

| Language | Where type safety lives |
|---|---|
| Python | mypy, on the **lint** axis |
| Dart | analyze, on the **vet** axis |
| Go | `go vet` type-checks as it runs |
| Compiled languages | the test step compiles first |
| **Node** | **nowhere** |

A temporary workaround already landed on the consumer side. This is the root repair.

## What

A `typecheck` axis, running **between vet and lint** — a type error surfaces before the slower style pass, and a project whose linter config is absent still gets a correctness gate.

Node resolves in three tiers:

1. `gate.typecheck.command` — works for **any** language; how a Python or Go project opts in
2. `package.json` `scripts.typecheck` → `npm run typecheck`
3. `tsconfig.json` present → `npx --no-install tsc --noEmit`

**A solution-style tsconfig is refused rather than run.** `files: []` plus `references` type-checks nothing and exits 0, so accepting it would rebuild the very blind spot being closed. Tier 2 deliberately outranks that check, so a monorepo root delegating to turbo is not penalised for having one.

## Skipping is not failing, but it is never silent

The silence is what let the broken build through. A language with no default now says so, and says how to supply one:

```
typecheck: skipped (no scripts.typecheck and no tsconfig.json; set gate.typecheck.command to enable one)
```

Tool availability stays fail-open. Only the visibility changes.

### A second silence, found on the way

`passReason` **assigned** rather than accumulated, so the last notice erased the earlier ones — this axis's own notice would have vanished whenever ast-grep also had something to report. Vet and lint notices were dropped outright. They accumulate now.

## Config

```yaml
gate:
  timeouts:
    typecheck: 300   # a monorepo type-check routinely outlasts the test budget
  typecheck:
    enabled: true
    command: ""      # any language; split on whitespace, no shell metacharacters
```

Both `gate.yaml` files updated; the three keys are registered in the shipped-key triage inventory as wired, with the gate mapping as their reader. `CONFIG_STRUCT_YAML_MISMATCH` passes.

## Verification

TDD, RED first. 14 new tests, including a **pass counterpart** for the blocking test — a block-only assertion is satisfied by a gate that always fails.

Real-binary demo against three fixtures:

| Fixture | Result |
|---|---|
| failing typecheck | gate **blocks**, prints the type error verbatim |
| passing typecheck | gate proceeds past the axis |
| no script, no tsconfig | gate **passes**, reports the skip alongside ast-grep's |

`golangci-lint` 0 issues · `go build ./...` clean · `make build` clean, catalog unchanged.

## Known limitation (pre-existing, out of scope)

`runStep` does not set `cmd.Dir`, so a step **resolves** against the project dir but **executes** in the process cwd. Real use calls `moai gate` at the repo root, where the two match; this axis inherits the looseness rather than introducing it.

## Not verified

- Full suite is CI's call, not run locally.
- `tsc` itself was never executed — tier 3 is tested as far as constructing the command; the demos all ran tier 2.
- Consumer auto-firing is inferred from its `scripts.typecheck`, and needs measuring there after release.

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable typecheck step to the quality gate, enabled by default.
  * Supports custom commands, package scripts, and TypeScript fallback detection.
  * Typechecking runs between vet and lint with a 300-second default timeout.
  * Reports successful, skipped, and unavailable checks without silently ignoring them.
  * Skipped checks remain non-blocking, while failed typechecks block the gate.
* **Documentation**
  * Added configuration guidance for typecheck behavior, precedence, overrides, and TypeScript project handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->