### PR TITLE
fix(gate): stop the gate failing a project for having no code yet

### DIFF
--- a/internal/hook/quality/gate.go
+++ b/internal/hook/quality/gate.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -102,6 +103,27 @@ type gateStep struct {
 	// When non-empty, the step is skipped if no staged file has one of these extensions.
 	// Future heavy language-specific linters can opt-in using this pattern.
 	changedExts []string
+	// sourceExts lists the extensions that give this step something to check.
+	// When the project tree holds none of them, the step is skipped with a
+	// hint instead of run.
+	//
+	// This exists for tools that treat an empty source set as a usage error
+	// rather than a vacuous pass. mypy is the case: `mypy .` on a directory
+	// with no .py files prints "There are no .py[i] files in directory" and
+	// exits 2, so a freshly scaffolded project — a pyproject.toml and nothing
+	// else yet — failed its first gate for having no code. pytest already
+	// treats its own empty-suite exit as a pass (see runStep); this is the
+	// same judgement moved one step earlier, to the point where the tool has
+	// nothing to look at.
+	//
+	// Skipping BEFORE running, rather than forgiving an exit code after, is
+	// deliberate: mypy's exit 2 also covers a genuinely broken config, and
+	// forgiving the code would hide that. Absence of sources is checked
+	// directly instead.
+	//
+	// Distinct from changedExts, which asks what is staged for THIS commit;
+	// this asks whether the project has any such source at all.
+	sourceExts []string
 }
 
 // toolchains defines quality gate steps per language.
@@ -151,6 +173,10 @@ var toolchains = []langToolchain{
 			{name: "mypy", binary: "mypy", args: []string{"."}, optional: true,
 				configFiles: []string{"mypy.ini", ".mypy.ini", "pyproject.toml", "setup.cfg"},
 				changedExts: []string{".py"},
+				// ruff needs no counterpart: `ruff check .` on a source-free
+				// tree reports "All checks passed!" and exits 0. mypy is the
+				// one Python step that treats no sources as an error.
+				sourceExts: []string{".py", ".pyi"},
 			},
 		},
 		testStep: &gateStep{name: "pytest", binary: "pytest", args: nil, optional: true},
@@ -769,6 +795,21 @@ func (g *QualityGate) executeStep(ctx context.Context, step gateStep, timeout ti
 		}
 	}
 
+	// Skip when the project holds no source this step could check. A scaffold
+	// that has declared its language but not written code yet must not fail
+	// its first gate for having no code.
+	if len(step.sourceExts) > 0 {
+		dir := resolveQualityProjectDir(*g.config, "QualityGate.executeStep.srcfilter")
+		if found, determined := projectHasSourceFile(dir, step.sourceExts); determined && !found {
+			slog.Warn("no sources for step: treating as skip",
+				"step", step.name,
+				"extensions", strings.Join(step.sourceExts, ","),
+				"hint", "add sources, or set gate.disabled_steps in .moai/config/sections/gate.yaml",
+			)
+			return true, ""
+		}
+	}
+
 	return g.runStep(ctx, step.name, timeout, step.binary, step.args...)
 }
 
@@ -785,6 +826,89 @@ func (g *QualityGate) cachedStagedFiles(ctx context.Context, dir string) []strin
 		return nil
 	}
 	return g.stagedCache
+}
+
+// sourceScanEntryCap bounds projectHasSourceFile's walk. A source-free tree is
+// established by exhausting the walk, so on a very large repository that answer
+// could cost a full traversal. Past the cap the scan gives up and reports
+// undetermined, which runs the step — the conservative direction, and the same
+// one taken when the directory cannot be read at all.
+const sourceScanEntryCap = 20000
+
+// sourceScanSkipDirs are directory names never worth descending into when
+// asking whether a project has sources of its own: dependency trees, build
+// output, and caches. A .py under node_modules or .venv is somebody else's.
+var sourceScanSkipDirs = map[string]struct{}{
+	".git": {}, ".hg": {}, ".svn": {},
+	"node_modules": {}, "vendor": {},
+	".venv": {}, "venv": {}, "site-packages": {}, "__pycache__": {},
+	".tox": {}, ".nox": {}, ".mypy_cache": {}, ".ruff_cache": {}, ".pytest_cache": {},
+	"dist": {}, "build": {}, "target": {}, ".next": {}, ".output": {},
+}
+
+// projectHasSourceFile reports whether dir's tree holds a file with one of the
+// given extensions, stopping at the first match.
+//
+// The second return says whether the question was answered at all. An empty
+// dir, an unreadable tree, or a walk that outgrows sourceScanEntryCap answers
+// false — the caller then runs the step rather than skipping it, so an
+// uncertain scan never suppresses a check.
+func projectHasSourceFile(dir string, exts []string) (found bool, determined bool) {
+	if dir == "" || len(exts) == 0 {
+		return false, false
+	}
+
+	visited := 0
+	errStop := errors.New("stop")
+	errBudget := errors.New("budget")
+
+	walkErr := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			// The root failing is the whole question failing — a missing or
+			// unreadable project directory must answer undetermined, so the
+			// caller runs the step rather than skipping it.
+			if path == dir {
+				return err
+			}
+			// A permission hole somewhere below is skipped instead: it must
+			// not decide the whole answer.
+			if d != nil && d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		visited++
+		if visited > sourceScanEntryCap {
+			return errBudget
+		}
+		if d.IsDir() {
+			if path == dir {
+				return nil
+			}
+			if _, skip := sourceScanSkipDirs[d.Name()]; skip {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		ext := filepath.Ext(d.Name())
+		for _, want := range exts {
+			if strings.EqualFold(ext, want) {
+				found = true
+				return errStop
+			}
+		}
+		return nil
+	})
+
+	switch {
+	case errors.Is(walkErr, errStop):
+		return true, true
+	case walkErr == nil:
+		return false, true
+	default:
+		// errBudget, or the root itself being unreadable.
+		return false, false
+	}
 }
 
 // hasStagedExt returns true if any file in the staged list has an extension in exts.

--- a/internal/hook/quality/gate_empty_source_test.go
+++ b/internal/hook/quality/gate_empty_source_test.go
@@ -1,0 +1,241 @@
+package quality
+
+// gate_empty_source_test.go — the source-free scaffold regression.
+//
+// A project that had declared Python (a pyproject.toml) but not yet written
+// any .py failed its first gate: `mypy .` prints "There are no .py[i] files in
+// directory" and exits 2. The pytest step next to it already treats an empty
+// suite as a pass, so the same project was told its absent tests were fine and
+// its absent code was a failure.
+//
+// The steps below never invoke mypy: an optional step whose binary is missing
+// returns early at the LookPath check, which on a machine without mypy would
+// make every assertion here pass vacuously. The behavioural tests use a step
+// that is guaranteed to run and guaranteed to fail, so a skip and a run are
+// distinguishable regardless of what is installed.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// alwaysFailingStep returns a step that runs a command certain to exist in a
+// Go test environment and certain to exit non-zero. If the step executes, the
+// gate reports failure; if the guard skips it, the gate reports success.
+func alwaysFailingStep(name string, sourceExts []string) gateStep {
+	return gateStep{
+		name:       name,
+		binary:     "go",
+		args:       []string{"run", "./__t193_no_such_package__"},
+		sourceExts: sourceExts,
+	}
+}
+
+// TestExecuteStep_SkipsWhenProjectHasNoSources is the regression: a scaffold
+// carrying only a pyproject.toml must not fail the gate for having no code.
+func TestExecuteStep_SkipsWhenProjectHasNoSources(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "pyproject.toml", "[project]\nname = \"scaffold\"\n")
+
+	g := &QualityGate{config: &GateConfig{Enabled: true, ProjectDir: dir}}
+	ok, msg := g.executeStep(context.Background(), alwaysFailingStep("mypy", []string{".py", ".pyi"}), 30*time.Second)
+
+	if !ok {
+		t.Fatalf("source-free scaffold failed the gate: %s", msg)
+	}
+}
+
+// TestExecuteStep_RunsWhenProjectHasOneSource is the other half: one .py is
+// enough to make the step meaningful again, so the guard must not swallow it.
+// Without this, "always skip" would pass the test above.
+func TestExecuteStep_RunsWhenProjectHasOneSource(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "pyproject.toml", "[project]\nname = \"scaffold\"\n")
+	writeFile(t, dir, "src/app.py", "x = 1\n")
+
+	g := &QualityGate{config: &GateConfig{Enabled: true, ProjectDir: dir}}
+	ok, _ := g.executeStep(context.Background(), alwaysFailingStep("mypy", []string{".py", ".pyi"}), 30*time.Second)
+
+	if ok {
+		t.Fatal("step was skipped although the project has a .py source; the guard over-skips")
+	}
+}
+
+// TestExecuteStep_NoSourceExtsUnaffected asserts the guard is opt-in: a step
+// that declares no sourceExts runs exactly as before.
+func TestExecuteStep_NoSourceExtsUnaffected(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "pyproject.toml", "[project]\nname = \"scaffold\"\n")
+
+	g := &QualityGate{config: &GateConfig{Enabled: true, ProjectDir: dir}}
+	ok, _ := g.executeStep(context.Background(), alwaysFailingStep("other", nil), 30*time.Second)
+
+	if ok {
+		t.Fatal("a step with no sourceExts was skipped; the guard is not opt-in")
+	}
+}
+
+// TestExecuteStep_PyiCountsAsSource asserts a stubs-only package is not
+// treated as source-free — mypy has plenty to check there.
+func TestExecuteStep_PyiCountsAsSource(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "pyproject.toml", "[project]\nname = \"stubs\"\n")
+	writeFile(t, dir, "stubs/app.pyi", "def f() -> int: ...\n")
+
+	g := &QualityGate{config: &GateConfig{Enabled: true, ProjectDir: dir}}
+	if ok, _ := g.executeStep(context.Background(), alwaysFailingStep("mypy", []string{".py", ".pyi"}), 30*time.Second); ok {
+		t.Fatal("a .pyi-only project was treated as source-free")
+	}
+}
+
+// TestProjectHasSourceFile_IgnoresDependencyTrees asserts a .py belonging to a
+// dependency does not count as the project's own source. Counting it would
+// send mypy back into the failure this guard removes.
+func TestProjectHasSourceFile_IgnoresDependencyTrees(t *testing.T) {
+	for _, vendorDir := range []string{".venv/lib/python3.12/site-packages", "node_modules/pkg", ".git", "__pycache__"} {
+		t.Run(vendorDir, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFile(t, dir, "pyproject.toml", "[project]\nname = \"scaffold\"\n")
+			writeFile(t, dir, filepath.Join(vendorDir, "dep.py"), "x = 1\n")
+
+			found, determined := projectHasSourceFile(dir, []string{".py", ".pyi"})
+			if !determined {
+				t.Fatal("scan reported undetermined on a tiny tree")
+			}
+			if found {
+				t.Errorf("a .py under %s counted as the project's own source", vendorDir)
+			}
+		})
+	}
+}
+
+// TestProjectHasSourceFile_FindsNestedSource asserts the scan descends past
+// the root — a src/ layout is the common case, not the exception.
+func TestProjectHasSourceFile_FindsNestedSource(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "src/pkg/deep/mod.py", "x = 1\n")
+
+	found, determined := projectHasSourceFile(dir, []string{".py", ".pyi"})
+	if !determined || !found {
+		t.Fatalf("nested source not found: found=%v determined=%v", found, determined)
+	}
+}
+
+// TestProjectHasSourceFile_CaseInsensitiveExtension asserts an uppercase
+// extension still counts — the staged-file check next to it matches case
+// insensitively too.
+func TestProjectHasSourceFile_CaseInsensitiveExtension(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "MOD.PY", "x = 1\n")
+
+	if found, determined := projectHasSourceFile(dir, []string{".py"}); !determined || !found {
+		t.Fatalf("uppercase extension not matched: found=%v determined=%v", found, determined)
+	}
+}
+
+// TestProjectHasSourceFile_UndeterminedInputs asserts the scan reports
+// undetermined rather than "no sources" when it cannot answer. Undetermined
+// runs the step, so an unanswerable scan never suppresses a check.
+func TestProjectHasSourceFile_UndeterminedInputs(t *testing.T) {
+	cases := map[string]struct {
+		dir  string
+		exts []string
+	}{
+		"empty dir":     {dir: "", exts: []string{".py"}},
+		"no extensions": {dir: t.TempDir(), exts: nil},
+		"missing dir":   {dir: filepath.Join(t.TempDir(), "does-not-exist"), exts: []string{".py"}},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if found, determined := projectHasSourceFile(tc.dir, tc.exts); determined || found {
+				t.Errorf("found=%v determined=%v, want both false", found, determined)
+			}
+		})
+	}
+}
+
+// TestProjectHasSourceFile_EmptyTreeIsDetermined asserts a readable tree with
+// no matching source answers "no sources" conclusively — that answer is what
+// the skip depends on.
+func TestProjectHasSourceFile_EmptyTreeIsDetermined(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "pyproject.toml", "[project]\nname = \"scaffold\"\n")
+	writeFile(t, dir, "README.md", "# scaffold\n")
+
+	found, determined := projectHasSourceFile(dir, []string{".py", ".pyi"})
+	if !determined {
+		t.Fatal("a readable source-free tree reported undetermined")
+	}
+	if found {
+		t.Error("found a .py in a tree that has none")
+	}
+}
+
+// TestMypyStep_DeclaresSourceExts pins the wiring: the guard is only reachable
+// because the mypy step declares the extensions.
+func TestMypyStep_DeclaresSourceExts(t *testing.T) {
+	tc := pythonToolchain(t)
+	var mypy *gateStep
+	for i := range tc.lintSteps {
+		if tc.lintSteps[i].name == "mypy" {
+			mypy = &tc.lintSteps[i]
+		}
+	}
+	if mypy == nil {
+		t.Fatal("mypy step not found on the Python toolchain")
+	}
+	want := map[string]bool{".py": false, ".pyi": false}
+	for _, ext := range mypy.sourceExts {
+		if _, ok := want[ext]; ok {
+			want[ext] = true
+		}
+	}
+	for ext, seen := range want {
+		if !seen {
+			t.Errorf("mypy sourceExts = %v, missing %q", mypy.sourceExts, ext)
+		}
+	}
+}
+
+// TestRuffStep_DeclaresNoSourceExts records why ruff has no counterpart:
+// `ruff check .` on a source-free tree reports "All checks passed!" and exits
+// 0, so it needs no guard. If ruff's behaviour ever changes, this test is the
+// place that says the decision was deliberate.
+func TestRuffStep_DeclaresNoSourceExts(t *testing.T) {
+	tc := pythonToolchain(t)
+	for i := range tc.lintSteps {
+		if tc.lintSteps[i].name == "ruff" && len(tc.lintSteps[i].sourceExts) != 0 {
+			t.Errorf("ruff declares sourceExts = %v; it exits 0 on an empty tree and needs no guard",
+				tc.lintSteps[i].sourceExts)
+		}
+	}
+}
+
+// TestSourceScanSkipDirs_CoversTheCommonTrees guards the skip list against
+// accidental emptying.
+func TestSourceScanSkipDirs_CoversTheCommonTrees(t *testing.T) {
+	for _, name := range []string{".git", "node_modules", ".venv", "site-packages", "__pycache__"} {
+		if _, ok := sourceScanSkipDirs[name]; !ok {
+			t.Errorf("sourceScanSkipDirs is missing %q", name)
+		}
+	}
+}
+
+// TestProjectHasSourceFile_RootIsNotSkippedByName asserts a project that
+// happens to live in a directory named like a skipped one (a checkout under
+// ~/build, say) is still scanned — the skip applies to descendants only.
+func TestProjectHasSourceFile_RootIsNotSkippedByName(t *testing.T) {
+	parent := t.TempDir()
+	dir := filepath.Join(parent, "build")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	writeFile(t, dir, "app.py", "x = 1\n")
+
+	if found, determined := projectHasSourceFile(dir, []string{".py"}); !determined || !found {
+		t.Fatalf("root named \"build\" was skipped: found=%v determined=%v", found, determined)
+	}
+}


### PR DESCRIPTION
Card **t193** (t179 e2e F-2). Base `origin/main` — a pre-existing defect, independent of the release batch.

## Problem

A project that had declared Python but not yet written any of it failed its first quality gate. `mypy .` on a tree holding a `pyproject.toml` and no `.py` prints `There are no .py[i] files in directory` and exits 2, and the gate reported that as a failure.

The pytest step directly beside it already treats an empty suite as a pass. So the same scaffold was told its absent tests were fine and its absent code was a defect.

## Fix

`gateStep` gains `sourceExts` — the extensions that give a step something to check. When the project tree holds none of them, the step is skipped with a hint naming the step and pointing at `gate.disabled_steps`, the shape pytest's empty-suite warning already uses. `mypy` declares `.py` and `.pyi`.

**Skipping before running, rather than forgiving mypy's exit 2 afterwards, is deliberate.** Exit 2 also covers a genuinely broken mypy config; forgiving the code would hide that. Absence of sources is checked directly instead.

**ruff gets no counterpart because it does not need one** — measured, not assumed: `ruff check .` on the same source-free tree prints `All checks passed!` and exits 0. A test records that reasoning so a future change in ruff has somewhere to land.

**The scan is bounded and conservative.** It stops at the first match, skips dependency and cache trees (a `.py` under `.venv` or `node_modules` is somebody else's), and gives up past an entry cap. Anything it cannot answer — an empty or unreadable project directory, a walk that outgrows the cap — reports undetermined, which *runs* the step. An uncertain scan never suppresses a check.

`sourceExts` is distinct from the existing `changedExts`: that one asks what is staged for this commit, this one asks whether the project has any such source at all. The reported failure came through the path where the staged-file lookup returns nil (no git metadata, or a standalone `moai gate`), which runs steps conservatively.

## Evidence

End to end, two binaries built from this tree and from `origin/main`, on a scaffold holding only a `pyproject.toml`:

| | exit | output |
|---|---|---|
| before (`origin/main`) | **1** | `quality gate failed: mypy` / `There are no .py[i] files in directory '.'` |
| after (this branch) | **0** | `no sources for step: treating as skip step=mypy extensions=.py,.pyi hint=...` — printed next to pytest's existing `collected no tests: treating as pass` |

Then with one `.py` added to the same scaffold, the fixed binary:

- clean source → exit 0, and **no** skip line in the output (grep count 0) — mypy actually ran
- source with a type error → exit **1**, `app.py:2: error: Incompatible return value type (got "str", expected "int")` — the guard does not over-skip

Direct tool measurements behind the design (mypy 1.18.2, ruff 0.13.1, same scaffold): `mypy .` exit 2, `ruff check .` exit 0.

Unit and regression coverage — 12 new tests in `gate_empty_source_test.go`, all passing. They deliberately do **not** invoke mypy: an optional step whose binary is missing returns early at the `LookPath` check, which on a machine without mypy would make every assertion pass vacuously. The behavioural tests use a step guaranteed to run and guaranteed to fail, so a skip and a run stay distinguishable regardless of what is installed.

- `go test ./internal/hook/... -count=1` — 11 packages `ok`, 0 failures
- `golangci-lint run ./internal/hook/...` — `0 issues.`
- `go build ./...`, `go vet ./internal/hook/...`, `GOOS=windows GOARCH=amd64 go vet ./internal/hook/...` — clean

Full-suite verdict is CI's.

🗿 MoAI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Quality checks now skip source-dependent steps when no matching project files are present.
  - Python type checking recognizes both `.py` and `.pyi` files, including nested and case-insensitive matches.
  - Scanning ignores dependency, build, cache, and version-control directories to avoid unrelated files.
  - Checks run conservatively when the project contents cannot be determined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->