### PR TITLE
docs(t195): Claude cloud session setup — seed the moai binary via install.sh

### DIFF
--- a/.moai/reports/t195/verdict.md
+++ b/.moai/reports/t195/verdict.md
@@ -1,0 +1,97 @@
+# t195 — Claude Cloud 환경 moai 바이너리 시딩
+
+- 브랜치: `WT-cloud-seed` (worktree `.claude/worktrees/t195`), base `origin/main` (`76b2c4ece`)
+- 결론: **no-code 채택** — 문서(가이드 4로케일)만. 템플릿 setup 스크립트 불필요(§3).
+- 카드 지시 레시피는 **실측으로 반증됨** — `go install …@latest`는 동작하지 않는다(§2).
+
+## 1. 근거 (공식 문서 실측, code.claude.com/docs/en/cloud-environments)
+
+| 사실 | 인용 절 |
+|---|---|
+| 세션은 저장소를 새로 클론한 Ubuntu 24.04 x86_64 VM에서 시작, 커밋된 `.claude/**`·`.mcp.json`·`CLAUDE.md`는 전부 실림 | What carries over from your setup |
+| setup script는 bash·root·Claude Code 기동 **전** 1회, exit 0 필수, 약 5분 내 완료, 설치엔 네트워크 필요 | Setup scripts / Script requirements |
+| 완료 후 파일시스템 스냅샷 → 이후 세션은 setup script 생략. 스크립트/허용호스트 변경 또는 약 7일 만료 시 재실행 | Environment caching |
+| 기본 **Trusted** 허용 도메인에 `github.com`·`raw.githubusercontent.com`·`objects.githubusercontent.com`·`release-assets.githubusercontent.com`·`proxy.golang.org`·`sum.golang.org` 포함 | Default allowed domains |
+| **`adk.mo.ai.kr`은 허용 목록에 없음** | 같은 절 (부재로 확인) |
+| Go는 사전 설치되어 있으나 버전은 표에 없음("Go with module support") | Installed tools |
+
+## 2. `go install` 실측 — 카드 지시 레시피는 실패한다
+
+```
+$ go install github.com/modu-ai/moai-adk/cmd/moai@latest
+go: github.com/modu-ai/moai-adk/cmd/moai@latest: module github.com/modu-ai/moai-adk@latest
+    found (v1.14.5), but does not contain package github.com/modu-ai/moai-adk/cmd/moai
+
+$ go install github.com/modu-ai/moai-adk/cmd/moai@v3.1.2
+go: invalid version: module contains a go.mod file, so module path must match
+    major version ("github.com/modu-ai/moai-adk/v3")
+```
+
+원인: `go.mod`의 모듈 경로가 `github.com/modu-ai/moai-adk`로 `/v3` 접미사가 없다. Go의 시맨틱
+임포트 버저닝이 메이저 2 이상에 접미사를 요구하므로 `@latest`는 접미사 없는 경로가 가질 수 있는
+최신 태그(`v1.14.5`)로 해소되고, v3 태그는 지정해도 거부된다.
+
+`@main`은 동작한다(측정):
+
+| 경로 | 소요 | 산출물 | 판본 표시 |
+|---|---|---|---|
+| `go install …@main` | **1m42s** | 76,142,962 B | `moai-adk v3.1.2` (컴파일 기본값 — ldflags 없음, commit/date 없음) |
+| `install.sh --install-dir <dir>` | **2.4s** | 35,970,082 B | `3.1.2  4b2f203fe  built 2026-08-21T06:47:28Z` |
+
+`@main`을 권장하지 않는 이유 3: (a) 트리 전체 컴파일 (b) VM의 Go가 이 모듈 `go` 지시자
+(현재 `go 1.26.4`)를 만족해야 함 — VM Go 버전 미공개 (c) 판본 스탬프 부재로 사후 추적 불가.
+
+## 3. 채택 레시피와 그 근거
+
+```bash
+#!/bin/bash
+curl -fsSL https://raw.githubusercontent.com/modu-ai/moai-adk/main/install.sh \
+  | bash -s -- --install-dir /usr/local/bin || true
+moai --version || true
+```
+
+| 선택 | 근거 (실측) |
+|---|---|
+| `raw.githubusercontent.com` 경유 | `adk.mo.ai.kr`이 Trusted 목록에 없음. raw URL 응답 http=200 size=12636이고 저장소 루트 `install.sh`와 **바이트 동일**(`diff -q` 일치) |
+| `--install-dir` 플래그 (환경변수 아님) | `install.sh` main()이 `INSTALL_DIR=""`로 초기화(코드 확인) → env 값 무시. 기본값 경로는 `$GOPATH/bin` 또는 `~/.local/bin`이라 PATH 보장 없음 |
+| `\|\| true` | exit≠0이면 세션 시작 자체가 실패(Script requirements) |
+| 최신 릴리즈(비고정) | 캐시가 7일/스크립트 변경 시 재빌드되므로 재실행마다 현재 판본을 집음. 고정 필요 시 `--version 3.1.2` |
+
+**템플릿 setup 스크립트를 만들지 않은 이유**: setup script는 저장소 파일이 아니라
+claude.ai/code의 환경 설정 대화상자 필드에 입력한다. 저장소에 스크립트를 두어도 클라우드가
+자동으로 읽지 않으므로, 배포물이 아니라 붙여넣기 레시피가 맞는 형태다. (SessionStart 훅으로
+설치하는 대안은 공식 문서가 "프로젝트 의존성"용으로 구분하고 VM 프로비저닝은 setup script
+소관이라 명시 — Setup scripts vs. SessionStart hooks.)
+
+## 4. 산출물
+
+- `docs-site/content/{en,ko,ja,zh}/guides/claude-cloud.md` (신규 4파일)
+- `docs-site/content/{en,ko,ja,zh}/guides/_meta.yaml` — 네비 항목 추가
+- `docs-site/content/{en,ko,ja,zh}/guides/_index.md` — 가이드 목록 줄 추가
+
+## 5. 검증 (관측된 출력)
+
+| 명령 | 결과 |
+|---|---|
+| `bash scripts/docs-i18n-check.sh` | `Errors: 0 / Warnings: 0`, 4로케일 각 150 .md 파일 파리티 |
+| `hugo` (docs-site) | rc 0, WARN/ERROR 0건, KO 184 / EN·JA·ZH 182 페이지 |
+| 렌더 산출 | `public/{en,ko,ja,zh}/guides/claude-cloud/index.html` 4개 생성, mermaid 블록 렌더 확인 |
+| Mermaid 방향 | `flowchart LR/RL/BT` grep 0건 (TD-only 준수) |
+| URL | 사용 URL 3종 = `raw.githubusercontent.com/...`, `claude.ai/code`, `adk.mo.ai.kr/install.sh`(README 대비 설명용). 금지 URL(`docs.moai-ai.dev`·`adk.moai.com`·`adk.moai.kr`) 0건 |
+
+## 6. 미검증 (Gaps)
+
+- **실제 Claude Cloud VM에서 레시피를 실행해 보지 않았다.** 모든 근거는 (a) 공식 문서 인용과
+  (b) 로컬 macOS/arm64 실측이다. VM은 Ubuntu 24.04 x86_64이며 `install.sh`의 플랫폼 감지가
+  `linux_amd64`를 고르는 것은 코드로만 확인했다.
+- **클론과 setup script의 선후 관계**를 문서가 명시하지 않는다. 레시피는 저장소 파일에
+  의존하지 않으므로 어느 순서든 무해하지만, 저장소 스크립트를 호출하는 형태였다면 이 불확실성이
+  결정적이었을 것이다.
+- VM의 Go 버전 미공개 — `@main` 경로의 실패 가능성은 추정이지 실측이 아니다.
+- 세션 사용자가 root인지 여부 미확인. `/usr/local/bin`을 고른 것은 이 불확실성에 대한 방어다.
+
+## 7. 부수 관측 (카드 밖)
+
+`install.sh` 실행 로그 끝의 판본 줄은 **이미 설치돼 있던 `~/go/bin/moai`**(`v3.1.3-rc.0`)를
+PATH에서 찾아 출력한 것이었고, 새로 설치된 바이너리는 `3.1.2 4b2f203fe`로 정상이었다.
+릴리즈 자산 결함이 아니다 — 초기 오독을 정정해 기록해 둔다.

--- a/docs-site/content/en/guides/_index.md
+++ b/docs-site/content/en/guides/_index.md
@@ -19,3 +19,4 @@ parses issues with the `moai github` subcommand and links them to SPECs.
 
 - [Autonomous CI/CD](./ci-autonomy) — 8-Tier quality automation, from the pre-push hook to the auto-fix loop
 - [GitHub Integration](./github-integration) — parse issues with the `moai github` subcommand and link them to SPEC documents
+- [Claude Cloud Sessions](./claude-cloud) — the setup-script recipe that puts the `moai` binary on a cloud session's VM

--- a/docs-site/content/en/guides/_meta.yaml
+++ b/docs-site/content/en/guides/_meta.yaml
@@ -6,3 +6,5 @@ index:
   title: "GitHub Integration Guide"
 "mcp-server":
   title: "MCP Server"
+"claude-cloud":
+  title: "Claude Cloud Sessions"

--- a/docs-site/content/en/guides/claude-cloud.md
+++ b/docs-site/content/en/guides/claude-cloud.md
@@ -1,0 +1,132 @@
+---
+title: Claude Cloud Sessions
+weight: 40
+draft: false
+---
+
+A cloud session starts from a fresh clone of your repository on an Anthropic-managed VM. Everything
+MoAI-ADK keeps in the repository — `CLAUDE.md`, `.claude/settings.json` and its hooks,
+`.claude/rules/`, `.claude/skills/`, `.claude/agents/`, `.claude/commands/`, and `.mcp.json` — arrives
+with that clone. One thing does not: the `moai` binary, which lives on your own machine and was never
+part of the repo.
+
+That single gap is what this guide closes. Without the binary, the hooks wired in `.claude/settings.json`
+fail, `moai` commands are not found, and the MCP server declared in `.mcp.json` never starts. With it,
+a cloud session behaves like a local one.
+
+## The recipe
+
+Open the environment settings dialog at [claude.ai/code](https://claude.ai/code) and paste this into
+the **Setup script** field:
+
+```bash
+#!/bin/bash
+curl -fsSL https://raw.githubusercontent.com/modu-ai/moai-adk/main/install.sh \
+  | bash -s -- --install-dir /usr/local/bin || true
+moai --version || true
+```
+
+Three details in that snippet are load-bearing, and each one is there because the obvious form fails.
+
+**The installer is fetched from `raw.githubusercontent.com`, not from `adk.mo.ai.kr`.** The
+`curl -fsSL https://adk.mo.ai.kr/install.sh | bash` form documented in the README is the one to use on
+your own machine; in a cloud session the environment's default **Trusted** network level allows a fixed
+list of domains, and `adk.mo.ai.kr` is not on it. GitHub is: `github.com`, `raw.githubusercontent.com`,
+`objects.githubusercontent.com`, and `release-assets.githubusercontent.com` all resolve, which covers
+both the script and the release asset it downloads. The file served from `raw.githubusercontent.com` is
+the same `install.sh` that lives at the repository root.
+
+**`--install-dir` is passed as a flag, not as an environment variable.** The installer resets
+`INSTALL_DIR` when it parses its arguments, so `INSTALL_DIR=/usr/local/bin bash` is silently ignored and
+the binary lands somewhere else. Left to its own defaults on the VM it would choose `$GOPATH/bin` or
+`~/.local/bin`, neither of which is guaranteed to be on `PATH` for the session — `/usr/local/bin` is.
+
+**`|| true` guards the exit code.** A setup script that exits non-zero fails the whole session, so a
+transient network hiccup during install would stop you from starting a session at all rather than
+starting one without `moai`. The trailing `moai --version` is there to put the installed version in the
+setup log; it carries the same guard for the same reason.
+
+## Why not `go install`
+
+The obvious Go-native form does not work, and it fails in a way worth stating plainly so nobody spends
+an afternoon on it:
+
+```bash
+go install github.com/modu-ai/moai-adk/cmd/moai@latest
+# go: module github.com/modu-ai/moai-adk@latest found (v1.14.5),
+#     but does not contain package github.com/modu-ai/moai-adk/cmd/moai
+```
+
+The module path is `github.com/modu-ai/moai-adk` with no `/v3` suffix, and Go's semantic import
+versioning requires that suffix for any major version at or above 2. So `@latest` resolves to the
+newest tag the un-suffixed path can carry — `v1.14.5`, from long before `cmd/moai` existed. Asking for
+a v3 release by name is refused outright:
+
+```bash
+go install github.com/modu-ai/moai-adk/cmd/moai@v3.1.2
+# go: invalid version: module contains a go.mod file, so module path must match
+#     major version ("github.com/modu-ai/moai-adk/v3")
+```
+
+`@main` does build, because a pseudo-version from a branch sidesteps the major-version rule. It is not
+the recommended path for a cloud environment, for three reasons: it compiles the whole tree rather than
+downloading a binary (over a minute and a half on a warm local machine, against roughly two seconds for
+the installer), it depends on the VM's Go being new enough for this module's `go` directive, and the
+resulting binary carries no version stamp — `moai version` reports the compiled-in default rather than
+the release it was built from, which makes any later "which version is this?" question unanswerable.
+
+## What runs when
+
+```mermaid
+flowchart TD
+    A["Session starts on a fresh VM"] --> B["Repository cloned"]
+    B --> C{"Cached environment?"}
+    C -->|no| D["Setup script runs as root"]
+    C -->|yes| E["Snapshot restored, setup script skipped"]
+    D --> F["Filesystem snapshotted"]
+    F --> G["Claude Code launches"]
+    E --> G
+    G --> H["SessionStart hooks run"]
+    H --> I["moai available on PATH"]
+```
+
+The setup script runs once, before Claude Code launches. Anthropic then snapshots the filesystem and
+reuses it for later sessions, so the install cost is paid once rather than per session. The snapshot
+keeps what was written to disk — the binary included — and loses anything that was merely running.
+
+The script runs again when you change it, when you change the environment's allowed network hosts, and
+when the snapshot expires after roughly seven days. That cadence is why the recipe installs the latest
+release rather than a pinned one: each rebuild picks up the current version. If you would rather pin,
+add the flag:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/modu-ai/moai-adk/main/install.sh \
+  | bash -s -- --install-dir /usr/local/bin --version 3.1.2 || true
+```
+
+{{< callout type="info" >}}
+Setup scripts must finish within roughly five minutes for the cache to build. The installer downloads a
+prebuilt binary and completes in seconds, so it leaves the budget to whatever else your project needs.
+{{< /callout >}}
+
+## Verifying it
+
+Ask Claude to run these in the cloud session. They are ordinary shell commands, so Claude runs them for
+you:
+
+```bash
+which moai              # /usr/local/bin/moai
+moai --version          # the release the setup script installed
+moai doctor             # environment health, including MCP wiring
+```
+
+If `which moai` comes back empty, the setup script either did not run — a cached environment skips it —
+or failed while `|| true` swallowed the error. Change the script (any edit invalidates the cache),
+start a fresh session, and read the setup log.
+
+## What this does not cover
+
+The environment dialog holds the setup script and environment variables in plain text, readable by
+anyone who uses that environment, and there is no secrets store yet. Nothing in this recipe needs a
+credential, and nothing here should be extended to carry one. If your project needs `GH_TOKEN`, the
+session's GitHub proxy already authenticates `gh` without it.

--- a/docs-site/content/ja/guides/_index.md
+++ b/docs-site/content/ja/guides/_index.md
@@ -18,3 +18,4 @@ MoAI-ADK の運用に役立つガイドドキュメントを集めました。�
 
 - [自律 CI/CD](./ci-autonomy) — pre-push フックから auto-fix ループまで、8-Tier 品質自動化
 - [GitHub 連携](./github-integration) — `moai github` サブコマンドで Issue をパースし SPEC ドキュメントと連携
+- [Claude クラウドセッション](./claude-cloud) — クラウドセッションの VM に `moai` バイナリを載せる setup script レシピ

--- a/docs-site/content/ja/guides/_meta.yaml
+++ b/docs-site/content/ja/guides/_meta.yaml
@@ -6,3 +6,5 @@ index:
   title: "GitHub 連携ガイド"
 "mcp-server":
   title: "MCP サーバー"
+"claude-cloud":
+  title: "Claude クラウドセッション"

--- a/docs-site/content/ja/guides/claude-cloud.md
+++ b/docs-site/content/ja/guides/claude-cloud.md
@@ -1,0 +1,134 @@
+---
+title: Claude クラウドセッション
+weight: 40
+draft: false
+---
+
+クラウドセッションは、Anthropic が管理する VM 上でリポジトリを新しくクローンして始まります。
+MoAI-ADK がリポジトリに置くもの — `CLAUDE.md`、`.claude/settings.json` とそこに配線されたフック、
+`.claude/rules/`、`.claude/skills/`、`.claude/agents/`、`.claude/commands/`、`.mcp.json` — は
+そのクローンにすべて含まれます。含まれないものが一つだけあります。`moai` バイナリです。
+自分のマシンにしかなく、リポジトリに入ったことがないからです。
+
+この一つの欠落を埋めるのが本ガイドです。バイナリがなければ `.claude/settings.json` に配線された
+フックは失敗し、`moai` コマンドは見つからず、`.mcp.json` が宣言する MCP サーバーは起動しません。
+あれば、クラウドセッションはローカルセッションと同じように動きます。
+
+## レシピ
+
+[claude.ai/code](https://claude.ai/code) で環境設定ダイアログを開き、**Setup script** 欄に
+次を貼り付けます。
+
+```bash
+#!/bin/bash
+curl -fsSL https://raw.githubusercontent.com/modu-ai/moai-adk/main/install.sh \
+  | bash -s -- --install-dir /usr/local/bin || true
+moai --version || true
+```
+
+この短いスクリプトでは三つの点が要になります。いずれも「当然に見える書き方」が失敗するため
+そうなっています。
+
+**インストーラを `adk.mo.ai.kr` ではなく `raw.githubusercontent.com` から取得します。** README に
+ある `curl -fsSL https://adk.mo.ai.kr/install.sh | bash` は自分のマシン向けです。クラウドセッションの
+既定ネットワーク等級 **Trusted** は決められたドメインのみを許可し、`adk.mo.ai.kr` はその一覧に
+ありません。GitHub はあります — `github.com`、`raw.githubusercontent.com`、
+`objects.githubusercontent.com`、`release-assets.githubusercontent.com` がいずれも到達可能で、
+スクリプトとそれがダウンロードするリリース資産の両方をカバーします。
+`raw.githubusercontent.com` が返すファイルは、リポジトリ直下の `install.sh` と同一です。
+
+**`--install-dir` は環境変数ではなくフラグで渡します。** インストーラは引数を解析する際に
+`INSTALL_DIR` を空にするため、`INSTALL_DIR=/usr/local/bin bash` は黙って無視され、バイナリは
+別の場所に置かれます。既定に任せると VM では `$GOPATH/bin` か `~/.local/bin` が選ばれますが、
+どちらもセッションの `PATH` にある保証がありません。`/usr/local/bin` にはあります。
+
+**`|| true` が終了コードを守ります。** 終了コードが 0 でない setup script はセッションの起動
+そのものを失敗させます。つまりインストール中の一時的なネットワーク不調が、「moai のないセッション」
+ではなく「セッションを開けない状態」を生みます。後続の `moai --version` は導入された版を setup
+ログに残すためのもので、同じ理由で同じガードを付けます。
+
+## `go install` を使わない理由
+
+Go 利用者に最も自然な書き方は動きません。誰かが半日を費やさないよう、失敗の形をそのまま
+記しておきます。
+
+```bash
+go install github.com/modu-ai/moai-adk/cmd/moai@latest
+# go: module github.com/modu-ai/moai-adk@latest found (v1.14.5),
+#     but does not contain package github.com/modu-ai/moai-adk/cmd/moai
+```
+
+モジュールパスが `/v3` サフィックスのない `github.com/modu-ai/moai-adk` である一方、Go の
+セマンティックインポートバージョニングはメジャー 2 以上にそのサフィックスを要求します。
+そのため `@latest` は、サフィックスなしのパスが持ちうる最新タグ `v1.14.5` — `cmd/moai` が
+生まれるはるか前 — に解決されます。v3 リリースを名指ししても拒否されます。
+
+```bash
+go install github.com/modu-ai/moai-adk/cmd/moai@v3.1.2
+# go: invalid version: module contains a go.mod file, so module path must match
+#     major version ("github.com/modu-ai/moai-adk/v3")
+```
+
+`@main` はビルドできます。ブランチから作られる疑似バージョンはメジャーバージョン規則を
+回避するためです。ただしクラウド環境には推奨しません。理由は三つ — バイナリを取得する代わりに
+ツリー全体をコンパイルし（暖まったローカルマシンで 1 分 42 秒、インストーラは約 2 秒）、VM の Go が
+このモジュールの `go` ディレクティブを満たすほど新しい必要があり、生成されたバイナリには版の
+スタンプがないため `moai version` がリリースではなくコンパイル既定値を報告します。後から
+「これは何版か」に答えられなくなります。
+
+## 実行順序
+
+```mermaid
+flowchart TD
+    A["新しい VM でセッション開始"] --> B["リポジトリをクローン"]
+    B --> C{"キャッシュ済み環境があるか"}
+    C -->|なし| D["setup script が root で実行"]
+    C -->|あり| E["スナップショット復元、setup script は省略"]
+    D --> F["ファイルシステムをスナップショット"]
+    F --> G["Claude Code 起動"]
+    E --> G
+    G --> H["SessionStart フック実行"]
+    H --> I["PATH 上で moai が利用可能"]
+```
+
+setup script は Claude Code の起動前に一度だけ実行されます。その後 Anthropic がファイルシステムを
+スナップショットし、以降のセッションの出発点として再利用するため、インストール費用はセッション
+ごとではなく一度だけです。スナップショットはディスクに書かれたもの（バイナリを含む）を残し、
+単に動いていただけのものは失います。
+
+スクリプトを変更したとき、環境の許可ネットワークホストを変更したとき、そしてスナップショットが
+およそ 7 日で期限切れになったときに再実行されます。この周期のため、レシピは特定の版を固定せず
+最新リリースを導入します — 再構築のたびに現在の版を拾います。固定したい場合はフラグを足します。
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/modu-ai/moai-adk/main/install.sh \
+  | bash -s -- --install-dir /usr/local/bin --version 3.1.2 || true
+```
+
+{{< callout type="info" >}}
+setup script はキャッシュが構築されるよう、およそ 5 分以内に終える必要があります。インストーラは
+ビルド済みバイナリをダウンロードして数秒で完了するため、残りの予算はプロジェクトが必要とする
+他の作業に使えます。
+{{< /callout >}}
+
+## 確認
+
+クラウドセッションで Claude に次を実行してもらいます。普通のシェルコマンドなので、Claude が
+代わりに走らせます。
+
+```bash
+which moai              # /usr/local/bin/moai
+moai --version          # setup script が導入したリリース
+moai doctor             # MCP 配線を含む環境点検
+```
+
+`which moai` が空なら、setup script が実行されなかった（キャッシュ済み環境では省略されます）か、
+失敗したのに `|| true` がそのエラーを飲み込んだかのどちらかです。スクリプトを修正し（どの編集でも
+キャッシュは無効化されます）、新しいセッションを開始して setup ログを読んでください。
+
+## 本ガイドが扱わないこと
+
+環境ダイアログは setup script と環境変数を平文で保持し、その環境を使う人なら誰でも読めます。
+専用のシークレットストアはまだありません。このレシピは資格情報を必要とせず、資格情報を運ぶよう
+拡張すべきでもありません。プロジェクトが `GH_TOKEN` を必要とする場合、セッションの GitHub
+プロキシがトークンなしで `gh` を認証します。

--- a/docs-site/content/ko/guides/_index.md
+++ b/docs-site/content/ko/guides/_index.md
@@ -30,3 +30,4 @@ SPEC(요구사항 정의 문서)과 잇는 가벼운 워크플로우를 다룹�
 
 - [자율 CI/CD](./ci-autonomy) — pre-push 훅부터 auto-fix 루프까지, 8-Tier 품질 자동화
 - [GitHub 연동](./github-integration) — `moai github` 서브커맨드로 이슈를 파싱하고 SPEC 문서와 연결
+- [Claude 클라우드 세션](./claude-cloud) — 클라우드 세션 VM에 `moai` 바이너리를 얹는 setup script 레시피

--- a/docs-site/content/ko/guides/_meta.yaml
+++ b/docs-site/content/ko/guides/_meta.yaml
@@ -6,3 +6,5 @@ index:
   title: "GitHub 연동 가이드"
 "mcp-server":
   title: "MCP 서버"
+"claude-cloud":
+  title: "Claude 클라우드 세션"

--- a/docs-site/content/ko/guides/claude-cloud.md
+++ b/docs-site/content/ko/guides/claude-cloud.md
@@ -1,0 +1,132 @@
+---
+title: Claude 클라우드 세션
+weight: 40
+draft: false
+---
+
+클라우드 세션은 Anthropic이 관리하는 VM에서 저장소를 새로 클론하며 시작합니다. MoAI-ADK가
+저장소에 두는 것 — `CLAUDE.md`, `.claude/settings.json`과 거기에 걸린 훅, `.claude/rules/`,
+`.claude/skills/`, `.claude/agents/`, `.claude/commands/`, `.mcp.json` — 은 그 클론에 전부
+실려 옵니다. 하나만 오지 않습니다. `moai` 바이너리입니다. 내 컴퓨터에만 있고 저장소에
+들어간 적이 없기 때문입니다.
+
+이 빈칸 하나가 이 문서가 메우려는 것입니다. 바이너리가 없으면 `.claude/settings.json`에
+배선된 훅이 실패하고, `moai` 명령은 찾을 수 없다고 나오며, `.mcp.json`이 선언한 MCP 서버는
+아예 뜨지 않습니다. 있으면 클라우드 세션은 로컬 세션처럼 동작합니다.
+
+## 레시피
+
+[claude.ai/code](https://claude.ai/code)에서 환경 설정 대화상자를 열고 **Setup script** 칸에
+아래를 붙여 넣습니다.
+
+```bash
+#!/bin/bash
+curl -fsSL https://raw.githubusercontent.com/modu-ai/moai-adk/main/install.sh \
+  | bash -s -- --install-dir /usr/local/bin || true
+moai --version || true
+```
+
+이 짧은 스크립트에서 세 가지가 결정적입니다. 셋 다 "당연해 보이는 형태"가 실패하기 때문에
+그 자리에 있습니다.
+
+**설치 스크립트를 `adk.mo.ai.kr`이 아니라 `raw.githubusercontent.com`에서 받습니다.** README에
+적힌 `curl -fsSL https://adk.mo.ai.kr/install.sh | bash` 형태는 내 컴퓨터에서 쓰는 것입니다.
+클라우드 세션의 기본 네트워크 등급인 **Trusted**는 정해진 도메인 목록만 허용하는데,
+`adk.mo.ai.kr`은 그 목록에 없습니다. GitHub은 있습니다 — `github.com`,
+`raw.githubusercontent.com`, `objects.githubusercontent.com`,
+`release-assets.githubusercontent.com`이 모두 열려 있어 스크립트와 그것이 내려받는 릴리즈
+자산이 함께 해결됩니다. `raw.githubusercontent.com`이 주는 파일은 저장소 루트의 `install.sh`와
+동일한 파일입니다.
+
+**`--install-dir`는 환경변수가 아니라 플래그로 넘깁니다.** 설치 스크립트는 인자를 파싱할 때
+`INSTALL_DIR`를 비우므로 `INSTALL_DIR=/usr/local/bin bash`는 조용히 무시되고 바이너리가 다른
+곳에 떨어집니다. 기본값에 맡기면 VM에서는 `$GOPATH/bin`이나 `~/.local/bin`을 고르는데, 둘 다
+세션의 `PATH`에 있다는 보장이 없습니다. `/usr/local/bin`은 있습니다.
+
+**`|| true`가 종료 코드를 막아 줍니다.** 종료 코드가 0이 아닌 setup script는 세션 시작 자체를
+실패시킵니다. 즉 설치 중 일시적인 네트워크 문제가 "moai 없는 세션"이 아니라 "세션을 못 여는
+상태"를 만듭니다. 뒤따르는 `moai --version`은 설치된 판본을 setup 로그에 남기려는 것이고,
+같은 이유로 같은 가드를 답니다.
+
+## `go install`을 쓰지 않는 이유
+
+Go 사용자에게 가장 자연스러운 형태는 동작하지 않습니다. 누군가 반나절을 쓰지 않도록 실패
+형태를 그대로 적어 둡니다.
+
+```bash
+go install github.com/modu-ai/moai-adk/cmd/moai@latest
+# go: module github.com/modu-ai/moai-adk@latest found (v1.14.5),
+#     but does not contain package github.com/modu-ai/moai-adk/cmd/moai
+```
+
+모듈 경로가 `/v3` 접미사 없는 `github.com/modu-ai/moai-adk`인데, Go의 시맨틱 임포트 버저닝은
+메이저 2 이상에 그 접미사를 요구합니다. 그래서 `@latest`는 접미사 없는 경로가 가질 수 있는
+가장 최신 태그인 `v1.14.5` — `cmd/moai`가 생기기 한참 전 — 로 해소됩니다. v3 릴리즈를 이름으로
+지정하면 아예 거부됩니다.
+
+```bash
+go install github.com/modu-ai/moai-adk/cmd/moai@v3.1.2
+# go: invalid version: module contains a go.mod file, so module path must match
+#     major version ("github.com/modu-ai/moai-adk/v3")
+```
+
+`@main`은 빌드됩니다. 브랜치에서 만들어지는 유사 버전은 메이저 버전 규칙을 비껴가기 때문입니다.
+다만 클라우드 환경에 권장하지는 않습니다. 이유는 셋입니다 — 바이너리를 받는 대신 트리 전체를
+컴파일하고(따뜻한 로컬 머신에서 1분 42초, 설치 스크립트는 약 2초), VM의 Go가 이 모듈의 `go`
+지시자를 만족할 만큼 새로워야 하며, 만들어진 바이너리에 판본 스탬프가 없어 `moai version`이
+릴리즈가 아니라 컴파일 기본값을 보고합니다. 나중에 "이거 무슨 버전이지?"에 답할 수 없게 됩니다.
+
+## 실행 순서
+
+```mermaid
+flowchart TD
+    A["새 VM에서 세션 시작"] --> B["저장소 클론"]
+    B --> C{"캐시된 환경이 있는가"}
+    C -->|없음| D["setup script가 root로 실행"]
+    C -->|있음| E["스냅샷 복원, setup script 생략"]
+    D --> F["파일시스템 스냅샷"]
+    F --> G["Claude Code 기동"]
+    E --> G
+    G --> H["SessionStart 훅 실행"]
+    H --> I["PATH에서 moai 사용 가능"]
+```
+
+setup script는 Claude Code가 뜨기 전에 한 번 실행됩니다. 그 뒤 Anthropic이 파일시스템을
+스냅샷으로 떠서 이후 세션의 출발점으로 재사용하므로, 설치 비용은 세션마다가 아니라 한 번만
+듭니다. 스냅샷은 디스크에 쓰인 것(바이너리 포함)을 남기고, 그저 실행 중이던 것은 잃습니다.
+
+스크립트를 고쳤을 때, 환경의 허용 네트워크 호스트를 바꿨을 때, 그리고 스냅샷이 대략 7일 뒤
+만료됐을 때 다시 실행됩니다. 이 주기 때문에 레시피는 특정 판본을 고정하지 않고 최신 릴리즈를
+설치합니다 — 재생성될 때마다 현재 판본을 집습니다. 고정하고 싶다면 플래그를 더합니다.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/modu-ai/moai-adk/main/install.sh \
+  | bash -s -- --install-dir /usr/local/bin --version 3.1.2 || true
+```
+
+{{< callout type="info" >}}
+setup script는 캐시가 만들어지도록 대략 5분 안에 끝나야 합니다. 설치 스크립트는 미리 빌드된
+바이너리를 내려받아 수 초에 끝나므로, 남는 예산은 프로젝트가 필요로 하는 다른 일에 쓸 수 있습니다.
+{{< /callout >}}
+
+## 확인
+
+클라우드 세션에서 Claude에게 아래를 실행해 달라고 하면 됩니다. 평범한 셸 명령이라 Claude가
+대신 돌려 줍니다.
+
+```bash
+which moai              # /usr/local/bin/moai
+moai --version          # setup script가 설치한 릴리즈
+moai doctor             # MCP 배선을 포함한 환경 점검
+```
+
+`which moai`가 빈 값이면, setup script가 실행되지 않았거나(캐시된 환경은 건너뜁니다) 실패했는데
+`|| true`가 그 오류를 삼킨 것입니다. 스크립트를 수정해(어떤 편집이든 캐시를 무효화합니다) 새
+세션을 시작한 뒤 setup 로그를 읽으십시오.
+
+## 이 문서가 다루지 않는 것
+
+환경 대화상자는 setup script와 환경변수를 평문으로 보관하며, 그 환경을 쓰는 사람은 누구나 읽을
+수 있습니다. 아직 전용 비밀 저장소가 없습니다. 이 레시피는 자격 증명을 필요로 하지 않으며,
+자격 증명을 싣도록 확장해서도 안 됩니다. 프로젝트에 `GH_TOKEN`이 필요하다면, 세션의 GitHub
+프록시가 토큰 없이도 `gh`를 인증해 줍니다.

--- a/docs-site/content/zh/guides/_index.md
+++ b/docs-site/content/zh/guides/_index.md
@@ -18,3 +18,4 @@ draft: false
 
 - [自主 CI/CD](./ci-autonomy) —— 从 pre-push 钩子到 auto-fix 循环的 8-Tier 质量自动化
 - [GitHub 集成](./github-integration) —— 用 `moai github` 子命令解析 issue 并关联到 SPEC 文档
+- [Claude 云端会话](./claude-cloud) —— 把 `moai` 二进制文件装到云端会话 VM 上的 setup script 配方

--- a/docs-site/content/zh/guides/_meta.yaml
+++ b/docs-site/content/zh/guides/_meta.yaml
@@ -6,3 +6,5 @@ index:
   title: "GitHub 集成指南"
 "mcp-server":
   title: "MCP 服务器"
+"claude-cloud":
+  title: "Claude 云端会话"

--- a/docs-site/content/zh/guides/claude-cloud.md
+++ b/docs-site/content/zh/guides/claude-cloud.md
@@ -1,0 +1,121 @@
+---
+title: Claude 云端会话
+weight: 40
+draft: false
+---
+
+云端会话在 Anthropic 托管的 VM 上重新克隆仓库后启动。MoAI-ADK 放在仓库里的东西 ——
+`CLAUDE.md`、`.claude/settings.json` 及其挂载的钩子、`.claude/rules/`、`.claude/skills/`、
+`.claude/agents/`、`.claude/commands/`、`.mcp.json` —— 都随这次克隆一起到达。只有一样不会：
+`moai` 二进制文件。它只存在于你自己的机器上，从未进入仓库。
+
+本指南要补的就是这一处空缺。没有该二进制文件，`.claude/settings.json` 中配置的钩子会失败，
+`moai` 命令会提示找不到，`.mcp.json` 声明的 MCP 服务器根本不会启动。有了它，云端会话的表现
+与本地会话一致。
+
+## 配方
+
+在 [claude.ai/code](https://claude.ai/code) 打开环境设置对话框，把下面内容粘贴到
+**Setup script** 字段：
+
+```bash
+#!/bin/bash
+curl -fsSL https://raw.githubusercontent.com/modu-ai/moai-adk/main/install.sh \
+  | bash -s -- --install-dir /usr/local/bin || true
+moai --version || true
+```
+
+这段短脚本里有三处是关键，它们之所以这样写，是因为"看起来理所当然"的写法都会失败。
+
+**安装脚本从 `raw.githubusercontent.com` 获取，而不是 `adk.mo.ai.kr`。** README 里的
+`curl -fsSL https://adk.mo.ai.kr/install.sh | bash` 是给自己机器用的。云端会话默认的网络等级
+**Trusted** 只放行一份固定域名清单，`adk.mo.ai.kr` 不在其中。GitHub 在其中 —— `github.com`、
+`raw.githubusercontent.com`、`objects.githubusercontent.com`、
+`release-assets.githubusercontent.com` 均可访问，脚本本身和它下载的发布资产都被覆盖。
+`raw.githubusercontent.com` 提供的文件与仓库根目录的 `install.sh` 完全相同。
+
+**`--install-dir` 用命令行标志传入，而不是环境变量。** 安装脚本在解析参数时会清空
+`INSTALL_DIR`，所以 `INSTALL_DIR=/usr/local/bin bash` 会被静默忽略，二进制文件落到别处。
+若交给默认值，VM 上会选择 `$GOPATH/bin` 或 `~/.local/bin`，两者都不保证在会话的 `PATH` 中。
+`/usr/local/bin` 则在。
+
+**`|| true` 用来兜住退出码。** 退出码非 0 的 setup script 会让整个会话启动失败。也就是说安装
+过程中一次短暂的网络波动，带来的不是"没有 moai 的会话"，而是"打不开的会话"。随后的
+`moai --version` 用于把已安装版本写进 setup 日志，出于同样的理由加了同样的保护。
+
+## 为什么不用 `go install`
+
+对 Go 用户最自然的写法并不可行。为免有人为此耗掉半天，这里原样记下失败形态：
+
+```bash
+go install github.com/modu-ai/moai-adk/cmd/moai@latest
+# go: module github.com/modu-ai/moai-adk@latest found (v1.14.5),
+#     but does not contain package github.com/modu-ai/moai-adk/cmd/moai
+```
+
+模块路径是不带 `/v3` 后缀的 `github.com/modu-ai/moai-adk`，而 Go 的语义化导入版本要求主版本
+2 及以上必须带该后缀。于是 `@latest` 解析到不带后缀的路径所能承载的最新标签 `v1.14.5` ——
+远早于 `cmd/moai` 出现之前。直接点名 v3 发布版则会被拒绝：
+
+```bash
+go install github.com/modu-ai/moai-adk/cmd/moai@v3.1.2
+# go: invalid version: module contains a go.mod file, so module path must match
+#     major version ("github.com/modu-ai/moai-adk/v3")
+```
+
+`@main` 可以构建，因为来自分支的伪版本绕开了主版本规则。但不建议用于云端环境，原因有三 ——
+它不是下载二进制而是编译整棵树（在预热的本地机器上耗时 1 分 42 秒，安装脚本约 2 秒）；
+它要求 VM 的 Go 版本足以满足本模块的 `go` 指令；生成的二进制没有版本戳，`moai version`
+报告的是编译期默认值而非所构建的发布版，日后"这是哪个版本"将无从回答。
+
+## 执行顺序
+
+```mermaid
+flowchart TD
+    A["在全新 VM 上启动会话"] --> B["克隆仓库"]
+    B --> C{"是否存在缓存环境"}
+    C -->|否| D["setup script 以 root 运行"]
+    C -->|是| E["恢复快照，跳过 setup script"]
+    D --> F["对文件系统做快照"]
+    F --> G["Claude Code 启动"]
+    E --> G
+    G --> H["运行 SessionStart 钩子"]
+    H --> I["PATH 中可用 moai"]
+```
+
+setup script 在 Claude Code 启动之前只运行一次。随后 Anthropic 会对文件系统做快照，并把它作为
+后续会话的起点重用，因此安装成本只付一次，而不是每个会话都付。快照保留写入磁盘的内容
+（包括该二进制文件），丢弃仅仅处于运行状态的东西。
+
+当你修改脚本、修改环境的允许网络主机，以及快照在大约 7 天后过期时，脚本会重新运行。正因为
+这个周期，本配方不锁定特定版本而是安装最新发布版 —— 每次重建都会取到当前版本。若希望锁定，
+加上标志即可：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/modu-ai/moai-adk/main/install.sh \
+  | bash -s -- --install-dir /usr/local/bin --version 3.1.2 || true
+```
+
+{{< callout type="info" >}}
+setup script 需要在大约 5 分钟内完成，缓存才能建立。安装脚本下载的是预构建二进制，数秒即可完成，
+剩下的预算可以留给项目真正需要的其他工作。
+{{< /callout >}}
+
+## 验证
+
+在云端会话中请 Claude 执行下面几条。它们是普通 shell 命令，由 Claude 代为运行：
+
+```bash
+which moai              # /usr/local/bin/moai
+moai --version          # setup script 安装的发布版
+moai doctor             # 环境体检，包含 MCP 接线
+```
+
+如果 `which moai` 返回为空，说明 setup script 要么没有运行（缓存环境会跳过它），要么失败了而
+`|| true` 吞掉了错误。修改脚本（任何改动都会使缓存失效），开一个新会话，然后阅读 setup 日志。
+
+## 本指南不涉及的内容
+
+环境对话框以明文保存 setup script 和环境变量，使用该环境的任何人都能读取，目前还没有专用的
+密钥存储。本配方不需要任何凭据，也不应被扩展去携带凭据。如果项目需要 `GH_TOKEN`，会话的
+GitHub 代理无需令牌即可为 `gh` 完成认证。


### PR DESCRIPTION
## Summary

A cloud session clones the repository, so every MoAI-ADK file in it arrives — `CLAUDE.md`, the `.claude/settings.json` hooks, `.claude/rules/`, skills, agents, commands, `.mcp.json`. The `moai` binary does not, and without it the hooks fail, `moai` is not found, and the MCP server declared in `.mcp.json` never starts.

This adds a `guides/claude-cloud` page in all four locales with the setup-script recipe that closes that gap, plus the `_meta.yaml` and `_index.md` wiring.

## The card's recipe was measured and does not work

`go install github.com/modu-ai/moai-adk/cmd/moai@latest` fails: the module path has no `/v3` suffix, so `@latest` resolves `v1.14.5` — from before `cmd/moai` existed — and naming a v3 release is refused by the major-version rule. `@main` does build, but compiles the whole tree (1m42s against the installer's 2.4s), depends on the VM's Go satisfying this module's `go` directive (currently 1.26.4, VM version undocumented), and yields a binary whose `moai version` reports the compiled-in default instead of the release.

## The recipe that ships

```bash
#!/bin/bash
curl -fsSL https://raw.githubusercontent.com/modu-ai/moai-adk/main/install.sh \
  | bash -s -- --install-dir /usr/local/bin || true
moai --version || true
```

Three measured constraints shape it: `adk.mo.ai.kr` is **not** on the environment's default Trusted allowlist while the GitHub domains are (the raw file is byte-identical to the repo's `install.sh`); `install.sh` clears `INSTALL_DIR` when parsing arguments, so the flag form is required; and a non-zero setup script fails session start, so `|| true` guards it.

## No code

A setup script is entered in the environment dialog at claude.ai/code, not read from the repository, so a template script would never be consumed. Docs-only was the right shape.

## Verification

- `scripts/docs-i18n-check.sh` — 0 errors, 0 warnings, 150 `.md` per locale
- `hugo` — rc 0, no WARN or ERROR, all four `guides/claude-cloud/index.html` rendered
- Mermaid TD-only (`flowchart LR/RL/BT` grep: 0), no blacklisted URL

**Not verified**: the recipe has not been run on an actual cloud VM. Evidence is the official cloud-environments documentation plus local measurement on macOS/arm64; the VM is Ubuntu 24.04 x86_64 and `install.sh`'s platform detection was read, not executed there.

Card: t195 · evidence: `.moai/reports/t195/verdict.md`

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Claude Cloud Sessions guide explaining how to install and verify MoAI in cloud-based environments.
  * Documented setup-script installation, optional version pinning, caching behavior, troubleshooting, and environment limitations.
  * Added the guide to the English, Japanese, Korean, and Chinese documentation navigation.

* **Documentation**
  * Added multilingual instructions for handling installation failures, validating the installed version, and avoiding credential exposure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->