### PR TITLE
ci(windows): add temporary ancestor .moai diagnostics to the release matrix (t169)

### DIFF
--- a/.github/workflows/release-pr-multi-os.yml
+++ b/.github/workflows/release-pr-multi-os.yml
@@ -151,9 +151,69 @@ jobs:
       # run whose only other change was test-portability skips. The ceiling is
       # the job's own timeout-minutes; this value exists to stop a package from
       # being killed just under it.
+      # --- t169 diagnostic (windows only, temporary) ------------------------
+      # internal/hook and internal/cli tests have failed intermittently on the
+      # windows leg because a `.moai/state` directory exists in an ANCESTOR of
+      # the workspace, so the upward marker walk resolves outside the repo.
+      # These two steps establish WHO creates it: the pre step shows the state
+      # before any test runs, the post step (always()) shows it after. If the
+      # pre step already lists a `.moai` and the post step does not differ, the
+      # creator is the runner image or an earlier job step, not the test suite.
+      # Remove both steps once the creator is identified.
+      - name: 'Diagnose ancestor .moai (pre-test)'
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          function Show($label, $path) {
+            Write-Host "=== $label : $path"
+            if (Test-Path -LiteralPath $path) {
+              Get-ChildItem -LiteralPath $path -Force -Recurse -Depth 2 -ErrorAction SilentlyContinue |
+                Select-Object -First 60 |
+                ForEach-Object { Write-Host "    $($_.FullName)" }
+            } else {
+              Write-Host "    <absent>"
+            }
+          }
+          Show 'USERPROFILE' "$env:USERPROFILE\.moai"
+          Show 'TEMP'        "$env:TEMP\.moai"
+          # Workspace ancestors: the walk that actually escapes the repo.
+          $d = Get-Item -LiteralPath $PWD.Path
+          while ($null -ne $d) {
+            Show "ANCESTOR" (Join-Path $d.FullName '.moai')
+            $d = $d.Parent
+          }
+      # ---------------------------------------------------------------------
+
       - name: Run tests with race detector
         shell: bash
         run: go test -race -timeout 25m ./...
+
+      # --- t169 diagnostic (windows only, temporary) ------------------------
+      # always(): the failing run is the one worth reading, so this must not be
+      # skipped when the test step above fails.
+      - name: 'Diagnose ancestor .moai (post-test)'
+        if: always() && runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          function Show($label, $path) {
+            Write-Host "=== $label : $path"
+            if (Test-Path -LiteralPath $path) {
+              Get-ChildItem -LiteralPath $path -Force -Recurse -Depth 2 -ErrorAction SilentlyContinue |
+                Select-Object -First 60 |
+                ForEach-Object { Write-Host "    $($_.FullName)" }
+            } else {
+              Write-Host "    <absent>"
+            }
+          }
+          Show 'USERPROFILE' "$env:USERPROFILE\.moai"
+          Show 'TEMP'        "$env:TEMP\.moai"
+          $d = Get-Item -LiteralPath $PWD.Path
+          while ($null -ne $d) {
+            Show "ANCESTOR" (Join-Path $d.FullName '.moai')
+            $d = $d.Parent
+          }
+      # ---------------------------------------------------------------------
+
 
   # ---------------------------------------------------------------------------
   # Summary gate: ensures all OS legs passed (or were skipped for non-release


### PR DESCRIPTION
## What

Two windows-only diagnostic steps in `.github/workflows/release-pr-multi-os.yml`, one before and one after the race-test step. No test change, no other leg touched.

## Why

The windows leg has failed intermittently because a `.moai/state` directory exists in an **ancestor** of the workspace, so the upward marker walk resolves outside the repo (t164 plan-audit). t164's SPEC removes the symptom; it does not say who creates the directory. Nothing in the current logs answers that.

The pre step reads `%USERPROFILE%\.moai`, `%TEMP%\.moai`, and every workspace ancestor's `.moai` before any test runs; the post step (`always()`, so it survives a failing test step) reads the same set afterwards.

Reading the result:

- pre already lists a `.moai` → the runner image or an earlier step created it, not the suite
- pre absent, post present → a test created it, and the ancestor path in the listing names where

## Scope

Diagnostic infrastructure (Class B). Both steps come out once the creator is identified — **this PR is expected to be followed by an observation card** reading the next failing run.

## Verification

- `yaml.safe_load` on the workflow: parses; `full-matrix-test` has 9 steps, the two new ones carrying `runner.os == 'Windows'` and `always() && runner.os == 'Windows'`
- `git diff --stat`: 1 file, +60/-0
- Backslashes verified literal in the PowerShell double-quoted paths (`"$env:TEMP\.moai"`)

Card: t169

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added temporary Windows diagnostics to inspect relevant `.moai` directories before and after race tests.
  * Post-test diagnostics now run even if race tests fail, improving troubleshooting information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->