### PR TITLE
fix(hook): stop the registry walk at the home directory (t168)

### DIFF
--- a/internal/hook/cwd_changed_relocate.go
+++ b/internal/hook/cwd_changed_relocate.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/modu-ai/moai-adk/internal/paths"
 	"github.com/modu-ai/moai-adk/internal/session"
 )
 
@@ -65,9 +66,37 @@ func relocateSessionCwd(input *HookInput, newCwd string) {
 }
 
 // findRegistryUpward walks from dir toward the filesystem root and reports
-// the first <dir>/.moai/state/active-sessions.json that exists.
+// the first <dir>/.moai/state/active-sessions.json that exists, stopping at
+// the user's home directory.
+//
+// The home boundary is the one project.FindProjectRoot already enforces:
+// ~/.moai is global state, not a project. Without it a session working
+// outside any checkout climbs past $HOME and relocates its entry into the
+// global registry — a write to shared state on behalf of a project that was
+// never found.
 func findRegistryUpward(dir string) (string, bool) {
+	home, _ := paths.Home()
+	return findRegistryUpwardFrom(dir, home)
+}
+
+// findRegistryUpwardFrom is findRegistryUpward with the home boundary supplied
+// rather than read from the environment, so the walk can be exercised over a
+// directory tree the test fully owns. Both paths are symlink-resolved before
+// comparison (macOS /private/var, Windows 8.3 short paths), matching the
+// normalization project.FindProjectRoot performs.
+func findRegistryUpwardFrom(dir, homeDir string) (string, bool) {
+	if dir == "" {
+		return "", false
+	}
+	dir = resolveSymlinks(dir)
+	homeDir = resolveSymlinks(homeDir)
+
 	for {
+		// Stop at the home directory — ~/.moai/state is global state, never a
+		// project registry.
+		if homeDir != "" && dir == homeDir {
+			return "", false
+		}
 		candidate := filepath.Join(dir, session.DefaultRegistryPath)
 		if _, err := os.Stat(candidate); err == nil {
 			return candidate, true
@@ -78,4 +107,16 @@ func findRegistryUpward(dir string) (string, bool) {
 		}
 		dir = parent
 	}
+}
+
+// resolveSymlinks returns path with symlinks resolved, or path unchanged when
+// it cannot be resolved (a directory that does not exist, for instance).
+func resolveSymlinks(path string) string {
+	if path == "" {
+		return ""
+	}
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		return resolved
+	}
+	return path
 }

--- a/internal/hook/cwd_changed_relocate_test.go
+++ b/internal/hook/cwd_changed_relocate_test.go
@@ -106,6 +106,74 @@ func TestCwdChangedHandler_RelocateIsSymmetricOnExit(t *testing.T) {
 	}
 }
 
+// TestFindRegistryUpwardStopsAtHome pins the t168 boundary: the walk must
+// stop at the user's home directory rather than climb past it into
+// ~/.moai/state/active-sessions.json. Without the guard, a session whose
+// working directories sit under $HOME but outside any checkout relocates its
+// entry inside the GLOBAL registry — a write to shared state on behalf of a
+// project that was never found.
+//
+// The layout is home-shaped on purpose; every assertion compares paths inside
+// a directory the test owns, so it holds on every platform without reading
+// the machine's real $HOME.
+func TestFindRegistryUpwardStopsAtHome(t *testing.T) {
+	t.Run("a registry at the home directory is not claimed", func(t *testing.T) {
+		home := t.TempDir()
+		writeRelocateRegistry(t, home, "sess-t168-home", home)
+		start := mustMkdirAllHook(t, filepath.Join(home, "scratch", "nested"))
+
+		if got, ok := findRegistryUpwardFrom(start, home); ok {
+			t.Fatalf("walk claimed %q; it must stop at the home boundary %q", got, home)
+		}
+	})
+
+	t.Run("a registry above the home directory is not reached", func(t *testing.T) {
+		above := t.TempDir()
+		writeRelocateRegistry(t, above, "sess-t168-above", above)
+		home := mustMkdirAllHook(t, filepath.Join(above, "home", "user"))
+		start := mustMkdirAllHook(t, filepath.Join(home, "scratch"))
+
+		if got, ok := findRegistryUpwardFrom(start, home); ok {
+			t.Fatalf("walk climbed past home to %q", got)
+		}
+	})
+
+	t.Run("a registry below the home directory is still found", func(t *testing.T) {
+		home := t.TempDir()
+		checkout := mustMkdirAllHook(t, filepath.Join(home, "projects", "app"))
+		writeRelocateRegistry(t, checkout, "sess-t168-project", checkout)
+		start := mustMkdirAllHook(t, filepath.Join(checkout, "internal", "pkg"))
+
+		got, ok := findRegistryUpwardFrom(start, home)
+		if !ok {
+			t.Fatal("walk found no registry; the guard must not block descendants of home")
+		}
+		want := filepath.Join(resolveSymlinks(checkout), session.DefaultRegistryPath)
+		if got != want {
+			t.Fatalf("got %q, want the project registry %q", got, want)
+		}
+	})
+
+	t.Run("an unresolvable home boundary leaves the walk unbounded", func(t *testing.T) {
+		root := t.TempDir()
+		writeRelocateRegistry(t, root, "sess-t168-nohome", root)
+		start := mustMkdirAllHook(t, filepath.Join(root, "nested"))
+
+		if _, ok := findRegistryUpwardFrom(start, ""); !ok {
+			t.Fatal("walk found nothing with an empty home; the guard must be inert, not blocking")
+		}
+	})
+}
+
+// mustMkdirAllHook is a t.Fatal-on-error mkdir helper for the cases above.
+func mustMkdirAllHook(t *testing.T, dir string) string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	return dir
+}
+
 // TestCwdChangedHandler_RelocateNoRegistryNoOp: with no registry anywhere
 // up the candidate roots, the hook stays a silent no-op (fail-open).
 func TestCwdChangedHandler_RelocateNoRegistryNoOp(t *testing.T) {


### PR DESCRIPTION
## What

`findRegistryUpward` (`internal/hook/cwd_changed_relocate.go`) walked from the CwdChanged payload's working directories to the filesystem root with no boundary — the fourth such unbounded walk in the tree.

A session whose directories sit under `$HOME` but outside any checkout therefore reached `~/.moai/state/active-sessions.json` and relocated its entry inside the **global** registry: a write to shared state on behalf of a project that was never found.

## Change

The walk now stops at the home directory — the same boundary `project.FindProjectRoot` already enforces for `~/.moai` (global state, not a project root). Home resolves through `internal/paths` (HOME-first, the resolution SSOT), and both sides are symlink-resolved before comparison, matching that function's normalization.

The boundary is supplied as a parameter (`findRegistryUpwardFrom(dir, homeDir)`) rather than read from the environment, so the regression test exercises the walk over a directory tree it fully owns instead of the machine's real `$HOME` — the t164 `findStateDirFrom` seam. An empty home leaves the guard inert rather than blocking.

## Evidence

Baseline: with the guard neutered (`if false && …`), the two boundary subtests fail —

```
--- FAIL: TestFindRegistryUpwardStopsAtHome/a_registry_at_the_home_directory_is_not_claimed
    walk claimed ".../001/.moai/state/active-sessions.json"; it must stop at the home boundary ".../001"
--- FAIL: TestFindRegistryUpwardStopsAtHome/a_registry_above_the_home_directory_is_not_reached
    walk climbed past home to ".../001/.moai/state/active-sessions.json"
```

With the guard in place:

```
$ go test ./internal/hook/... -count=1
ok  github.com/modu-ai/moai-adk/internal/hook  33.165s   (+ 10 subpackages ok)

$ golangci-lint run ./internal/hook/...
0 issues.
```

Four subtests cover: registry at home not claimed, registry above home not reached, registry below home still found, empty home leaves the walk unbounded. The existing t74 relocate tests (enter / exit / no-registry no-op) are unchanged and pass.

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved registry discovery to avoid incorrectly selecting the global home-directory registry.
  - Registry searches now stop at the resolved home directory while continuing to find valid registries below it.
  - Added safer handling when home-directory resolution is unavailable, preserving existing discovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->