### PR TITLE
fix(constitution): let validate retire an entry instead of deleting it

### DIFF
--- a/.claude/rules/moai/core/zone-registry.md
+++ b/.claude/rules/moai/core/zone-registry.md
@@ -36,6 +36,25 @@ CanaryGate defaults (plan.md §7 OQ6 decision):
 - Frozen → `canary_gate: true`
 - Evolvable → `canary_gate: false`
 
+## Retiring an Entry
+
+A clause that is no longer in force is **retired, not deleted** — deleting it destroys the record that the clause once existed and was withdrawn.
+
+To retire an entry, prefix its `clause` with a `[SUPERSEDED …]` marker naming what replaced it:
+
+```yaml
+clause: "[SUPERSEDED by <replacement>] <the original clause text>"
+```
+
+`moai constitution validate` then counts the entry as retired and skips its drift, canary-gate, and source-file checks — the source text is gone by definition, so those checks could only ever fail. The entry still appears in `moai constitution list`, and the retired total is reported (`retired_count` in JSON output).
+
+Two boundaries:
+
+- The marker is a **prefix**, not a substring. A live clause that merely mentions `[SUPERSEDED …]` in its own text stays fully checked.
+- `canary_gate: false` is **not** a retirement marker — it is the documented default for every Evolvable entry. A retired Frozen entry may carry `canary_gate: false` because it is retired, not the other way round.
+
+`moai constitution validate --strict` ignores the marker and checks retired entries verbatim, for auditing what they still hold.
+
 ## Usage Guide
 
 ```bash

--- a/.claude/rules/moai/core/zone-registry.md
+++ b/.claude/rules/moai/core/zone-registry.md
@@ -42,9 +42,11 @@ A clause that is no longer in force is **retired, not deleted** — deleting it 
 
 To retire an entry, prefix its `clause` with a `[SUPERSEDED …]` marker naming what replaced it:
 
-```yaml
+```text
 clause: "[SUPERSEDED by <replacement>] <the original clause text>"
 ```
+
+(The fence above is deliberately tagged `text`, not `yaml`. The registry loader reads the **first** yaml-tagged fence in this file as the entry list, so a yaml-tagged example placed before `## Entries` would be parsed as the registry and fail to load — and so would that fence marker written out literally in prose.)
 
 `moai constitution validate` then counts the entry as retired and skips its drift, canary-gate, and source-file checks — the source text is gone by definition, so those checks could only ever fail. The entry still appears in `moai constitution list`, and the retired total is reported (`retired_count` in JSON output).
 

--- a/.moai/reports/t201/verdict.md
+++ b/.moai/reports/t201/verdict.md
@@ -1,0 +1,82 @@
+# t201 — constitution validate honours a retirement marker (#1595)
+
+Class B (defect, cause established during run). Branch `WT-constitution-retire`, base `28bde4022`.
+
+## Claim
+
+`moai constitution validate` now skips drift, canary-gate, and source-file checks for a registry entry whose `clause` begins with `[SUPERSEDED …]`, counts it as retired, and keeps it visible in the report. `--strict` restores verbatim checking.
+
+## Cause
+
+`internal/constitution/validator.go` `Validate` checked every entry's clause verbatim against its source file. A retired clause's text is gone from source by construction, so the DRIFT check could only ever fail — deleting the entry was the only escape, which is what destroyed the audit trail the issue describes.
+
+The issue's second symptom (`canary_gate: false`) was investigated and is **not** a second marker. The four entries named in the issue (`CONST-V3R2-021..024`) are `zone: Evolvable`, for which `canary_gate: false` is the documented default; measured, they raise DRIFT only, never `FROZEN_WITHOUT_CANARY`. Honouring `canary_gate: false` as a retirement marker would have disabled the drift check for most of the registry. Retirement is the `[SUPERSEDED …]` prefix alone; the canary invariant is relaxed for a retired Frozen entry as a *consequence* of retirement.
+
+The marker is a prefix rather than a substring for a measured reason: `CONST-V3R2-152`'s live clause instructs that superseded memory entries be marked `[SUPERSEDED by <new-file>]`, and a substring test would silently retire it.
+
+## Evidence
+
+Baseline reproduction, this tree, before the change (65 errors was the primary checkout at an older HEAD; this tree measures 67):
+
+```
+$ go run ./cmd/moai constitution validate 2>&1 | grep -E "CONST-V3R2-02[1-4]"
+  [DRIFT] CONST-V3R2-021 @ CLAUDE.md #14-parallel-execution-safeguards
+  [DRIFT] CONST-V3R2-022 @ CLAUDE.md #14-parallel-execution-safeguards
+  [DRIFT] CONST-V3R2-023 @ CLAUDE.md #14-parallel-execution-safeguards
+  [DRIFT] CONST-V3R2-024 @ CLAUDE.md #14-parallel-execution-safeguards
+```
+
+After, against the same registry:
+
+```
+$ go run ./cmd/moai constitution validate --format json | grep -E '"(drift|retired)_count"'
+  "drift_count": 63,
+  "retired_count": 4,
+
+$ go run ./cmd/moai constitution validate --strict --format json | grep -E '"(drift|retired)_count"'
+  "drift_count": 67,
+  "retired_count": 0,
+```
+
+63 + 4 = 67: the four skipped entries are exactly the retired ones, and `--strict` reproduces the pre-change count byte for byte. No other entry changed state.
+
+Regression tests (`internal/constitution/retirement_test.go`, fixture-based, written before the fix and observed failing to compile on `RetiredCount` / `IsRetiredClause`):
+
+- retired entry raises no DRIFT and reports `RetiredCount: 1`
+- retired Frozen entry with `canary_gate: false` raises no `FROZEN_WITHOUT_CANARY`
+- retired entry whose source file is deleted raises no fatal `SOURCE_FILE_MISSING`
+- `--strict` reports the retired entry as DRIFT
+- control: a non-retired absent clause still reports DRIFT
+- marker-boundary table, including the mid-clause mention that must NOT retire
+
+```
+$ go test ./internal/constitution/... ./internal/cli/ -count=1
+ok  github.com/modu-ai/moai-adk/internal/constitution  0.244s
+ok  github.com/modu-ai/moai-adk/internal/cli           406.930s
+
+$ MOAI_TEMPLATE_LEAK_STRICT=1 go test ./internal/template/... -count=1
+ok  github.com/modu-ai/moai-adk/internal/template            23.443s
+ok  github.com/modu-ai/moai-adk/internal/template/agentemit   0.473s
+
+$ golangci-lint run ./internal/constitution/... ./internal/cli/
+0 issues.
+
+$ go build ./...   # clean
+$ make build       # templates re-embedded; catalog.yaml unchanged
+```
+
+## Baseline attribution
+
+All figures measured in `.claude/worktrees/t201` at base `28bde4022`, this run. The 65-error figure quoted in the issue's repro is from the downstream mo.ai.kr checkout and is not this tree's baseline.
+
+## Gaps
+
+- Not measured: the downstream mo.ai.kr registry itself. The fix is verified against this repository's registry, which carries the same four entries verbatim.
+- Not run locally: the full `go test ./...` suite and the darwin/windows matrix — deferred to CI on the PR head, per the repository's local test policy.
+- Not addressed: the 63 remaining DRIFT entries in this repository's registry. Pre-existing, unrelated to retirement, out of this card's scope.
+- Not added: a way to retire an entry from the CLI (`moai constitution retire <id>`). The marker is hand-edited into the registry today.
+
+## Residual risk
+
+- An entry retired by mistake goes unchecked silently. Mitigated by the reported retired count and by `--strict`, but a maintainer who reads neither would not notice.
+- `[SUPERSEDED` is matched case-sensitively. A registry using `[Superseded` would not be recognised; no such entry exists in this repository.

--- a/.moai/reports/t201/verdict.md
+++ b/.moai/reports/t201/verdict.md
@@ -65,6 +65,28 @@ $ go build ./...   # clean
 $ make build       # templates re-embedded; catalog.yaml unchanged
 ```
 
+## Defect found in this card's own work (caught by CI, fixed)
+
+The first push broke `Constitution Check`. The documentation section added to `zone-registry.md` carried a yaml-tagged example fence, and the loader (`extractYAMLFence`) takes the **first** yaml-tagged fence in the document as the entry list — so the example became the registry:
+
+```
+Registry load error ".claude/rules/moai/core/zone-registry.md":
+  YAML parsing error: yaml: unmarshal errors: line 2: cannot unmarshal !!map into []constitution.rawEntry
+```
+
+Retagging the fence `text` was not sufficient: the explanatory sentence spelled the fence marker out literally in prose, and `strings.Index(content, "```yaml")` matched that too, producing a second, different parse error (`line 5: mapping values are not allowed in this context`). Both are now avoided by never writing the literal marker in this file.
+
+`TestShippedRegistriesLoad` (`internal/constitution/shipped_registry_test.go`) was added so this cannot recur silently: it loads both shipped registries — local and template mirror — and fails on a parse error. Nothing previously covered the real files; the CI job that noticed is `continue-on-error: true`, i.e. advisory, so a red run there does not block a merge.
+
+After the fix, both CI steps reproduce locally:
+
+```
+$ ./bin/moai constitution list --format json | ... len(entries)
+entries: 101          # identical to the base registry at 28bde4022
+$ ./bin/moai constitution list --zone frozen | tail -1
+Total 57 entries
+```
+
 ## Baseline attribution
 
 All figures measured in `.claude/worktrees/t201` at base `28bde4022`, this run. The 65-error figure quoted in the issue's repro is from the downstream mo.ai.kr checkout and is not this tree's baseline.

--- a/internal/cli/constitution.go
+++ b/internal/cli/constitution.go
@@ -243,7 +243,7 @@ func newConstitutionValidateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "validate",
 		Short: "Validate zone registry against source files for drift and invariant violations",
-		Long:  "Checks that every registry entry's clause exists in the source file, validates zone_class enum, canary_gate invariants, and reports drift. Exit codes: 0=ok, 1=drift/errors, 2=fatal (missing source file).",
+		Long:  "Checks that every registry entry's clause exists in the source file, validates zone_class enum, canary_gate invariants, and reports drift. Entries whose clause begins with a [SUPERSEDED …] retirement marker are counted and skipped, so a clause can be retired without deleting its audit record; --strict checks them verbatim like any other entry. Exit codes: 0=ok, 1=drift/errors, 2=fatal (missing source file).",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cwd, err := os.Getwd()
 			if err != nil {
@@ -257,7 +257,7 @@ func newConstitutionValidateCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVar(&strictFlag, "strict", false, "Strict mode (enforces all checks)")
+	cmd.Flags().BoolVar(&strictFlag, "strict", false, "Strict mode (enforces all checks, including on [SUPERSEDED …] retired entries)")
 	cmd.Flags().BoolVar(&failOnWarningFlag, "fail-on-warning", false, "Treat warnings as errors (implies --strict)")
 	cmd.Flags().StringVar(&formatFlag, "format", "text", "Output format (text|json)")
 
@@ -339,6 +339,7 @@ func renderValidateJSON(w io.Writer, result constitution.ValidationResult) error
 		DriftCount        int         `json:"drift_count"`
 		MissingCount      int         `json:"missing_count"`
 		UnregisteredCount int         `json:"unregistered_count"`
+		RetiredCount      int         `json:"retired_count"`
 		Entries           []jsonEntry `json:"entries"`
 		Warnings          []string    `json:"warnings,omitempty"`
 		Skipped           bool        `json:"skipped,omitempty"`
@@ -360,6 +361,7 @@ func renderValidateJSON(w io.Writer, result constitution.ValidationResult) error
 		DriftCount:        result.DriftCount,
 		MissingCount:      result.MissingCount,
 		UnregisteredCount: result.UnregisteredCount,
+		RetiredCount:      result.RetiredCount,
 		Entries:           entries,
 		Warnings:          result.Warnings,
 		Skipped:           result.Skipped,
@@ -382,6 +384,7 @@ func renderValidateText(w io.Writer, result constitution.ValidationResult) {
 
 	if result.Status == constitution.ValidateStatusOK {
 		_, _ = fmt.Fprintf(w, "constitution validate: OK — no drift or violations detected (%d entries checked)\n", 0)
+		renderRetiredNote(w, result)
 		return
 	}
 
@@ -392,6 +395,17 @@ func renderValidateText(w io.Writer, result constitution.ValidationResult) {
 			_, _ = fmt.Fprintf(w, "    detail: %s\n", e.Detail)
 		}
 	}
+	renderRetiredNote(w, result)
+}
+
+// renderRetiredNote reports entries skipped for carrying the [SUPERSEDED …]
+// retirement marker, so a retired clause stays visible instead of disappearing
+// from the report along with its check.
+func renderRetiredNote(w io.Writer, result constitution.ValidationResult) {
+	if result.RetiredCount == 0 {
+		return
+	}
+	_, _ = fmt.Fprintf(w, "\n  %d retired entry/entries skipped ([SUPERSEDED …] marker); re-check them with --strict\n", result.RetiredCount)
 }
 
 // renderConstitutionTable outputs entries in table format.

--- a/internal/constitution/marker_regression_check_test.go
+++ b/internal/constitution/marker_regression_check_test.go
@@ -1,0 +1,56 @@
+package constitution
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestIsRetiredClause_ShippedRegistryClassificationUnchanged pins the tightened
+// marker rule against the registry this repository actually ships.
+//
+// The rule was narrowed twice (a boundary character, then requiring the
+// marker's own bracket to close). Narrowing a classifier risks dropping a
+// genuine retirement, and a dropped retirement silently re-enables checks that
+// were deliberately switched off — so the safe direction has to be measured,
+// not asserted. Every clause carrying the marker in shipped form must still
+// classify as retired.
+func TestIsRetiredClause_ShippedRegistryClassificationUnchanged(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := filepath.Join("..", "..")
+	path := filepath.Join(repoRoot, ".claude", "rules", "moai", "core", "zone-registry.md")
+
+	data, err := os.ReadFile(path) //nolint:gosec // fixed in-repo path
+	if err != nil {
+		t.Fatalf("read registry %s: %v", path, err)
+	}
+
+	clauseRE := regexp.MustCompile(`(?m)^  clause: "(.*)"$`)
+	matches := clauseRE.FindAllStringSubmatch(string(data), -1)
+	if len(matches) == 0 {
+		t.Fatalf("no clause lines parsed from %s — the parser or the file shape changed", path)
+	}
+
+	retired := 0
+	for _, m := range matches {
+		clause := m[1]
+		// A clause that carries the marker in its shipped form — leading
+		// "[SUPERSEDED" with the bracket closed before any other opens — is a
+		// genuine retirement and must stay classified as one.
+		if !strings.HasPrefix(strings.TrimSpace(clause), "[SUPERSEDED") {
+			continue
+		}
+		retired++
+		if !IsRetiredClause(clause) {
+			t.Errorf("shipped retirement clause no longer classifies as retired: %.80q", clause)
+		}
+	}
+
+	if retired == 0 {
+		t.Fatal("no retirement-marked clauses found — this test would pass vacuously")
+	}
+	t.Logf("clauses parsed: %d, retirement-marked: %d", len(matches), retired)
+}

--- a/internal/constitution/retirement.go
+++ b/internal/constitution/retirement.go
@@ -1,0 +1,29 @@
+package constitution
+
+import "strings"
+
+// retirementMarkerPrefix is the marker that retires a registry entry.
+//
+// A clause beginning with this prefix records a clause that used to be in force
+// and has since been withdrawn. The entry stays in the registry as an audit
+// record ("this clause was retired") instead of being deleted, and validate
+// stops checking it against the source tree — the source text is gone by
+// definition, so a verbatim check can only ever fail.
+//
+// The marker is deliberately a PREFIX rather than a substring: a live clause may
+// legitimately mention the marker in its own text (the session-handoff clause
+// instructing that superseded memory entries be marked with it), and treating
+// that as retirement would silently disable a real check.
+//
+// canary_gate:false is NOT a retirement marker. It is the documented default for
+// every Evolvable entry, so honoring it as one would disable the drift check for
+// most of the registry. Retired entries carry the prefix; the canary invariant is
+// relaxed for them as a consequence of retirement, not as a second marker.
+const retirementMarkerPrefix = "[SUPERSEDED"
+
+// IsRetiredClause reports whether a registry clause carries the retirement
+// marker — a leading "[SUPERSEDED" (optionally followed by a reason, e.g.
+// "[SUPERSEDED by CONST-V3R6-001]"). Leading whitespace is ignored.
+func IsRetiredClause(clause string) bool {
+	return strings.HasPrefix(strings.TrimSpace(clause), retirementMarkerPrefix)
+}

--- a/internal/constitution/retirement.go
+++ b/internal/constitution/retirement.go
@@ -39,5 +39,9 @@ func IsRetiredClause(clause string) bool {
 	if rest == "" || (rest[0] != ']' && rest[0] != ' ') {
 		return false
 	}
-	return strings.Contains(rest, "]")
+	// The marker's OWN bracket has to close. A later bracket belonging to
+	// something else does not: "[SUPERSEDED live [HARD]" ends in ']', but that
+	// one closes "[HARD" and leaves the marker open.
+	closing := strings.IndexByte(rest, ']')
+	return closing >= 0 && !strings.Contains(rest[:closing], "[")
 }

--- a/internal/constitution/retirement.go
+++ b/internal/constitution/retirement.go
@@ -24,6 +24,20 @@ const retirementMarkerPrefix = "[SUPERSEDED"
 // IsRetiredClause reports whether a registry clause carries the retirement
 // marker — a leading "[SUPERSEDED" (optionally followed by a reason, e.g.
 // "[SUPERSEDED by CONST-V3R6-001]"). Leading whitespace is ignored.
+//
+// The marker must be a COMPLETE token: the prefix has to end at the bracket or
+// at a space, and the bracket has to close. A bare prefix match would classify
+// "[SUPERSEDEDLY] …" and an unterminated "[SUPERSEDED …" as retired, and a
+// retired entry skips drift, canary-gate, and source-file validation — so a
+// live or malformed clause would silently switch its own checks off.
 func IsRetiredClause(clause string) bool {
-	return strings.HasPrefix(strings.TrimSpace(clause), retirementMarkerPrefix)
+	trimmed := strings.TrimSpace(clause)
+	if !strings.HasPrefix(trimmed, retirementMarkerPrefix) {
+		return false
+	}
+	rest := trimmed[len(retirementMarkerPrefix):]
+	if rest == "" || (rest[0] != ']' && rest[0] != ' ') {
+		return false
+	}
+	return strings.Contains(rest, "]")
 }

--- a/internal/constitution/retirement_test.go
+++ b/internal/constitution/retirement_test.go
@@ -178,6 +178,8 @@ func TestIsRetiredClause(t *testing.T) {
 		{"lowercase is not a marker", "[superseded] text", false},
 		{"mid-clause mention is not a marker", "mark superseded entries with [SUPERSEDED by <file>] prefix", false},
 		{"unrelated bracket", "[HARD] text", false},
+		{"longer word starting with the marker is not a marker", "[SUPERSEDEDLY] text", false},
+		{"unterminated marker", "[SUPERSEDED text", false},
 		{"empty", "", false},
 	}
 	for _, tc := range cases {

--- a/internal/constitution/retirement_test.go
+++ b/internal/constitution/retirement_test.go
@@ -1,0 +1,191 @@
+package constitution_test
+
+import (
+	"testing"
+
+	"github.com/modu-ai/moai-adk/internal/constitution"
+)
+
+// retiredRegistryEntry is a registry entry whose clause carries the
+// [SUPERSEDED …] retirement marker and whose text no longer exists in source.
+const retiredRegistryEntry = `- id: CONST-V3R2-021
+  zone: Evolvable
+  zone_class: evolvable-experimental
+  file: CLAUDE.md
+  anchor: "#14-parallel-execution-safeguards"
+  clause: "[SUPERSEDED by worktree-opt-in policy] Implementation teammates MUST use isolation: worktree when spawned via Agent()"
+  canary_gate: false
+`
+
+// liveSource is a source file that does NOT contain the retired clause text.
+const liveSource = "# Rules\n\n[ZONE:Evolvable] [HARD] Worktree isolation is opt-in.\n"
+
+// TestValidateSkipsDriftForRetiredEntry verifies that a [SUPERSEDED …]-prefixed
+// clause is not reported as DRIFT, so an entry can be retired without deleting it.
+// Issue #1595.
+func TestValidateSkipsDriftForRetiredEntry(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeSourceInDir(t, dir, "CLAUDE.md", liveSource)
+	regPath := writeRegistryInDir(t, dir, retiredRegistryEntry)
+
+	result, err := constitution.Validate(constitution.ValidateOptions{
+		RegistryPath: regPath,
+		ProjectDir:   dir,
+	})
+	if err != nil {
+		t.Fatalf("Validate() unexpected error: %v", err)
+	}
+	if result.DriftCount != 0 {
+		t.Errorf("DriftCount = %d, want 0; entries: %v", result.DriftCount, result.Entries)
+	}
+	if result.Status != constitution.ValidateStatusOK {
+		t.Errorf("Status = %q, want %q; entries: %v", result.Status, constitution.ValidateStatusOK, result.Entries)
+	}
+	if result.RetiredCount != 1 {
+		t.Errorf("RetiredCount = %d, want 1", result.RetiredCount)
+	}
+}
+
+// TestValidateRetiredFrozenEntrySkipsCanaryCheck verifies that a retired Frozen
+// entry may carry canary_gate:false without a FROZEN_WITHOUT_CANARY error —
+// a retired clause is never amended, so shadow evaluation cannot apply.
+// Issue #1595.
+func TestValidateRetiredFrozenEntrySkipsCanaryCheck(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeSourceInDir(t, dir, "CLAUDE.md", liveSource)
+	regPath := writeRegistryInDir(t, dir, `- id: CONST-V3R2-030
+  zone: Frozen
+  zone_class: frozen-canonical
+  file: CLAUDE.md
+  anchor: "#rules"
+  clause: "[SUPERSEDED by CONST-V3R6-001] Some retired frozen clause."
+  canary_gate: false
+`)
+
+	result, err := constitution.Validate(constitution.ValidateOptions{
+		RegistryPath: regPath,
+		ProjectDir:   dir,
+	})
+	if err != nil {
+		t.Fatalf("Validate() unexpected error: %v", err)
+	}
+	if len(result.Entries) != 0 {
+		t.Errorf("Entries = %v, want none", result.Entries)
+	}
+}
+
+// TestValidateRetiredEntryToleratesMissingSource verifies that a retired entry
+// whose source file no longer exists does not raise the fatal
+// SOURCE_FILE_MISSING error — the entry survives purely as an audit record.
+// Issue #1595.
+func TestValidateRetiredEntryToleratesMissingSource(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	regPath := writeRegistryInDir(t, dir, `- id: CONST-V3R2-031
+  zone: Evolvable
+  zone_class: evolvable-tuning
+  file: deleted-rule.md
+  anchor: "#gone"
+  clause: "[SUPERSEDED by nothing] A clause whose source file was deleted."
+  canary_gate: false
+`)
+
+	result, err := constitution.Validate(constitution.ValidateOptions{
+		RegistryPath: regPath,
+		ProjectDir:   dir,
+	})
+	if err != nil {
+		t.Fatalf("Validate() unexpected error: %v", err)
+	}
+	if result.MissingCount != 0 {
+		t.Errorf("MissingCount = %d, want 0; entries: %v", result.MissingCount, result.Entries)
+	}
+}
+
+// TestValidateStrictEnforcesRetiredEntry verifies that --strict ignores the
+// retirement marker and checks the clause verbatim, so a maintainer can audit
+// what the retired entries would report.
+// Issue #1595.
+func TestValidateStrictEnforcesRetiredEntry(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeSourceInDir(t, dir, "CLAUDE.md", liveSource)
+	regPath := writeRegistryInDir(t, dir, retiredRegistryEntry)
+
+	result, err := constitution.Validate(constitution.ValidateOptions{
+		RegistryPath: regPath,
+		ProjectDir:   dir,
+		Strict:       true,
+	})
+	if err != nil {
+		t.Fatalf("Validate() unexpected error: %v", err)
+	}
+	if result.DriftCount != 1 {
+		t.Errorf("DriftCount = %d, want 1 under --strict; entries: %v", result.DriftCount, result.Entries)
+	}
+}
+
+// TestValidateNonRetiredEntryStillDrifts is the control: an ordinary entry whose
+// clause is absent from source is still reported, so the retirement skip does
+// not widen into a blanket bypass.
+func TestValidateNonRetiredEntryStillDrifts(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeSourceInDir(t, dir, "CLAUDE.md", liveSource)
+	regPath := writeRegistryInDir(t, dir, `- id: CONST-V3R2-032
+  zone: Evolvable
+  zone_class: evolvable-tuning
+  file: CLAUDE.md
+  anchor: "#rules"
+  clause: "A live clause that is absent from the source file."
+  canary_gate: false
+`)
+
+	result, err := constitution.Validate(constitution.ValidateOptions{
+		RegistryPath: regPath,
+		ProjectDir:   dir,
+	})
+	if err != nil {
+		t.Fatalf("Validate() unexpected error: %v", err)
+	}
+	if result.DriftCount != 1 {
+		t.Errorf("DriftCount = %d, want 1; entries: %v", result.DriftCount, result.Entries)
+	}
+	if result.RetiredCount != 0 {
+		t.Errorf("RetiredCount = %d, want 0", result.RetiredCount)
+	}
+}
+
+// TestIsRetiredClause pins the marker-detection boundary.
+func TestIsRetiredClause(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		clause string
+		want   bool
+	}{
+		{"bare marker", "[SUPERSEDED] text", true},
+		{"marker with reason", "[SUPERSEDED by X — see Y] text", true},
+		{"leading whitespace", "  [SUPERSEDED] text", true},
+		{"lowercase is not a marker", "[superseded] text", false},
+		{"mid-clause mention is not a marker", "mark superseded entries with [SUPERSEDED by <file>] prefix", false},
+		{"unrelated bracket", "[HARD] text", false},
+		{"empty", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := constitution.IsRetiredClause(tc.clause); got != tc.want {
+				t.Errorf("IsRetiredClause(%q) = %v, want %v", tc.clause, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/constitution/retirement_test.go
+++ b/internal/constitution/retirement_test.go
@@ -180,6 +180,7 @@ func TestIsRetiredClause(t *testing.T) {
 		{"unrelated bracket", "[HARD] text", false},
 		{"longer word starting with the marker is not a marker", "[SUPERSEDEDLY] text", false},
 		{"unterminated marker", "[SUPERSEDED text", false},
+		{"a later bracket does not close the marker", "[SUPERSEDED live [HARD]", false},
 		{"empty", "", false},
 	}
 	for _, tc := range cases {

--- a/internal/constitution/shipped_registry_test.go
+++ b/internal/constitution/shipped_registry_test.go
@@ -29,8 +29,11 @@ func TestShippedRegistriesLoad(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
+			// Fatal, not Skip: a deleted or renamed registry is exactly the
+			// failure this test claims to guard, and skipping would report
+			// green for it.
 			if _, err := os.Stat(path); err != nil {
-				t.Skipf("registry not present at %s: %v", path, err)
+				t.Fatalf("registry not present at %s: %v", path, err)
 			}
 
 			reg, err := constitution.LoadRegistry(path, repoRoot)

--- a/internal/constitution/shipped_registry_test.go
+++ b/internal/constitution/shipped_registry_test.go
@@ -1,0 +1,45 @@
+package constitution_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/modu-ai/moai-adk/internal/constitution"
+)
+
+// TestShippedRegistriesLoad guards the registry files this repository actually
+// ships against a parse break.
+//
+// The loader takes the FIRST yaml-tagged code fence in the document as the entry
+// list, so any yaml-tagged example added above "## Entries" — or that fence
+// marker written out literally in prose — silently becomes the registry and the
+// file stops loading. Prose edits to these documents are otherwise untested, and
+// the CI job that would notice is advisory (continue-on-error).
+func TestShippedRegistriesLoad(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := filepath.Join("..", "..")
+	paths := map[string]string{
+		"local":    filepath.Join(repoRoot, ".claude", "rules", "moai", "core", "zone-registry.md"),
+		"template": filepath.Join(repoRoot, "internal", "template", "templates", ".claude", "rules", "moai", "core", "zone-registry.md"),
+	}
+
+	for name, path := range paths {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if _, err := os.Stat(path); err != nil {
+				t.Skipf("registry not present at %s: %v", path, err)
+			}
+
+			reg, err := constitution.LoadRegistry(path, repoRoot)
+			if err != nil {
+				t.Fatalf("LoadRegistry(%s): %v", path, err)
+			}
+			if len(reg.Entries) == 0 {
+				t.Errorf("LoadRegistry(%s) returned 0 entries", path)
+			}
+		})
+	}
+}

--- a/internal/constitution/validator.go
+++ b/internal/constitution/validator.go
@@ -113,6 +113,11 @@ type ValidationResult struct {
 	// UnregisteredCount is the number of ZONE_UNREGISTERED entries.
 	UnregisteredCount int `json:"unregistered_count"`
 
+	// RetiredCount is the number of entries skipped because their clause carries
+	// the [SUPERSEDED …] retirement marker. Always 0 under --strict, which checks
+	// retired entries verbatim like any other.
+	RetiredCount int `json:"retired_count"`
+
 	// Entries is the list of error/warning items.
 	Entries []ValidationEntry `json:"entries"`
 
@@ -201,6 +206,13 @@ func Validate(opts ValidateOptions) (ValidationResult, error) {
 	sourceCache := make(map[string]string)
 
 	for _, entry := range reg.Entries {
+		// 0. Retirement marker — a [SUPERSEDED …] clause is an audit record of a
+		// withdrawn clause, not a live one. Its source text is gone by definition,
+		// so the drift, canary, and source-existence checks below cannot be
+		// satisfied and are skipped. --strict ignores the marker and checks the
+		// entry verbatim, so a maintainer can audit what the retired entries hold.
+		retired := !opts.Strict && IsRetiredClause(entry.Clause)
+
 		// 1. INVALID_ZONE_CLASS check
 		if entry.ZoneClass != "" && !validZoneClasses[entry.ZoneClass] {
 			result.Entries = append(result.Entries, ValidationEntry{
@@ -209,6 +221,11 @@ func Validate(opts ValidateOptions) (ValidationResult, error) {
 				SentinelKey: SentinelInvalidZoneClass,
 				Detail:      fmt.Sprintf("zone_class %q is not one of the 4 allowed values", entry.ZoneClass),
 			})
+		}
+
+		if retired {
+			result.RetiredCount++
+			continue
 		}
 
 		// 2. FROZEN_WITHOUT_CANARY check

--- a/internal/template/templates/.claude/rules/moai/core/zone-registry.md
+++ b/internal/template/templates/.claude/rules/moai/core/zone-registry.md
@@ -36,6 +36,25 @@ CanaryGate defaults (plan.md §7 OQ6 decision):
 - Frozen → `canary_gate: true`
 - Evolvable → `canary_gate: false`
 
+## Retiring an Entry
+
+A clause that is no longer in force is **retired, not deleted** — deleting it destroys the record that the clause once existed and was withdrawn.
+
+To retire an entry, prefix its `clause` with a `[SUPERSEDED …]` marker naming what replaced it:
+
+```yaml
+clause: "[SUPERSEDED by <replacement>] <the original clause text>"
+```
+
+`moai constitution validate` then counts the entry as retired and skips its drift, canary-gate, and source-file checks — the source text is gone by definition, so those checks could only ever fail. The entry still appears in `moai constitution list`, and the retired total is reported (`retired_count` in JSON output).
+
+Two boundaries:
+
+- The marker is a **prefix**, not a substring. A live clause that merely mentions `[SUPERSEDED …]` in its own text stays fully checked.
+- `canary_gate: false` is **not** a retirement marker — it is the documented default for every Evolvable entry. A retired Frozen entry may carry `canary_gate: false` because it is retired, not the other way round.
+
+`moai constitution validate --strict` ignores the marker and checks retired entries verbatim, for auditing what they still hold.
+
 ## Usage Guide
 
 ```bash

--- a/internal/template/templates/.claude/rules/moai/core/zone-registry.md
+++ b/internal/template/templates/.claude/rules/moai/core/zone-registry.md
@@ -42,9 +42,11 @@ A clause that is no longer in force is **retired, not deleted** — deleting it 
 
 To retire an entry, prefix its `clause` with a `[SUPERSEDED …]` marker naming what replaced it:
 
-```yaml
+```text
 clause: "[SUPERSEDED by <replacement>] <the original clause text>"
 ```
+
+(The fence above is deliberately tagged `text`, not `yaml`. The registry loader reads the **first** yaml-tagged fence in this file as the entry list, so a yaml-tagged example placed before `## Entries` would be parsed as the registry and fail to load — and so would that fence marker written out literally in prose.)
 
 `moai constitution validate` then counts the entry as retired and skips its drift, canary-gate, and source-file checks — the source text is gone by definition, so those checks could only ever fail. The entry still appears in `moai constitution list`, and the retired total is reported (`retired_count` in JSON output).
 


### PR DESCRIPTION
Fixes #1595 (card t201)

## The problem

A registry clause that has been withdrawn had nowhere to live. Its text is gone from the source tree by construction, so `moai constitution validate`'s verbatim drift check could only ever fail, and the single escape was to delete the entry — destroying the record that the clause once existed and was retired.

## The change

Validate recognises a `[SUPERSEDED …]` prefix on a clause as a retirement marker:

- drift, canary-gate, and source-file checks are skipped for that entry
- it is counted in a new `retired_count` (text report and JSON), so a retired clause stays visible rather than disappearing along with its check
- `moai constitution validate --strict` ignores the marker and checks retired entries verbatim
- the entry still appears in `moai constitution list`, unchanged

The retirement policy is documented in `zone-registry.md` (local + template mirror, `make build` run).

## Two decisions worth reviewing

**`canary_gate: false` is not a second marker.** The issue proposed it as one. It cannot be: `canary_gate: false` is the documented default for every Evolvable entry, so honouring it would disable the drift check across most of the registry. The four entries the issue names (`CONST-V3R2-021..024`) are `zone: Evolvable` and raise DRIFT only, never `FROZEN_WITHOUT_CANARY` — measured, not assumed. A retired Frozen entry may carry `canary_gate: false` as a *consequence* of retirement, which this change allows.

**The marker is a prefix, not a substring.** `CONST-V3R2-152`'s live clause instructs that superseded memory entries be marked `[SUPERSEDED by <new-file>]`. A substring test would silently retire a rule that is still in force.

## Evidence

Against this repository's own registry, at base `28bde4022`:

```
before (== --strict after):   drift_count 67, retired_count 0
after:                        drift_count 63, retired_count 4
```

63 + 4 = 67 — the four skipped entries are exactly the retired ones, and no other entry changed state. The four `CONST-V3R2-021..024` DRIFT rows the issue reports are gone.

Regression tests (`internal/constitution/retirement_test.go`) are fixture-based and were written before the fix, observed failing to compile on the not-yet-existing `RetiredCount` / `IsRetiredClause`: retired entry skipped and counted; retired Frozen with `canary_gate: false` clean; retired entry with a deleted source file not fatal; `--strict` still reports it; control case where a non-retired absent clause still drifts; and a marker-boundary table covering the mid-clause mention that must **not** retire.

```
go test ./internal/constitution/... ./internal/cli/ -count=1     ok
MOAI_TEMPLATE_LEAK_STRICT=1 go test ./internal/template/...      ok
golangci-lint run ./internal/constitution/... ./internal/cli/    0 issues
go build ./... && make build                                     clean (catalog.yaml unchanged)
```

Full 5-section record: `.moai/reports/t201/verdict.md`.

## Not in scope

The 63 remaining DRIFT entries in this repository's registry are pre-existing and unrelated to retirement. There is no `moai constitution retire <id>` verb — the marker is hand-edited today.

🗿 MoAI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for retiring constitution registry entries with a `[SUPERSEDED …]` marker.
  - Non-strict validation skips retired entries and reports their count.
  - JSON and text validation output include retired-entry details.
  - Strict mode continues to validate retired entries fully.
- **Documentation**
  - Added guidance on retirement markers, validation behavior, listing, and strict-mode handling.
- **Tests**
  - Added coverage for retirement behavior, marker boundaries, strict validation, and shipped registry loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->