### PR TITLE
fix(doctor): make the exit code and the constitution row tell the truth (t200)

### DIFF
--- a/docs-site/content/en/cli-reference/doctor.md
+++ b/docs-site/content/en/cli-reference/doctor.md
@@ -50,6 +50,17 @@ When the cleanable estimate exceeds the threshold (a compiled default of 500 MB)
 
 The estimate calls **the same scanner** `moai clean --home` uses, so the number doctor quotes and the list clean actually deletes cannot drift apart. Full detail: [Home Directory Hygiene](/en/advanced/home-hygiene).
 
+## Exit codes
+
+Scripts and CI wrappers calling `moai doctor` read the exit code, not the summary line.
+
+| Exit code | Meaning |
+|-----------|---------|
+| `0` | No failing check. Warnings are advisory and do not change the exit code |
+| `1` | One or more checks failed — the summary's `Fail N` carried through |
+
+The Constitution Registry check does more than confirm the registry parses: it runs the **same drift validation** as `moai constitution validate`. Doctor therefore cannot report ok on a checkout where validate fails. Bypassing with `MOAI_CONSTITUTION_SKIP_VALIDATE=1` returns doctor to its structural verdict.
+
 ## Examples
 
 ```bash

--- a/docs-site/content/ja/cli-reference/doctor.md
+++ b/docs-site/content/ja/cli-reference/doctor.md
@@ -50,6 +50,17 @@ moai doctor [OPTIONS]
 
 この推定値は `moai clean --home` が使うのと**同じスキャナ**を呼ぶので、doctor が言う数字と clean が実際に削除する一覧がずれることはありません。詳細は [ホームディレクトリ衛生](/ja/advanced/home-hygiene) にあります。
 
+## 終了コード
+
+スクリプトや CI ラッパーが `moai doctor` を呼ぶとき読むのは、要約の行ではなく終了コードです。
+
+| 終了コード | 意味 |
+|------------|------|
+| `0` | Fail 項目なし。Warn は勧告なので終了コードを変えません |
+| `1` | 一件以上が Fail。要約の `Fail N` がそのまま反映されます |
+
+Constitution Registry の項目は、レジストリが解析できるかを見るだけでなく、`moai constitution validate` と**同じドリフト検証**を実行します。したがって同じチェックアウトで doctor が ok と言い、validate が失敗する、ということは起こりません。`MOAI_CONSTITUTION_SKIP_VALIDATE=1` で迂回すると、doctor は構造検査の判定に戻ります。
+
 ## 例
 
 ```bash

--- a/docs-site/content/ko/cli-reference/doctor.md
+++ b/docs-site/content/ko/cli-reference/doctor.md
@@ -52,6 +52,17 @@ moai doctor [OPTIONS]
 
 이 추정치는 `moai clean --home`이 쓰는 것과 **같은 스캐너**를 호출하므로, doctor가 말하는 숫자와 clean이 실제로 지우는 목록이 어긋나지 않습니다. 자세한 내용은 [홈 디렉터리 위생](/ko/advanced/home-hygiene)에 있습니다.
 
+## 종료 코드
+
+스크립트나 CI 래퍼에서 `moai doctor` 를 부를 때는 요약 줄이 아니라 종료 코드를 읽습니다.
+
+| 종료 코드 | 의미 |
+|-----------|------|
+| `0` | Fail 항목 없음. Warn 은 권고라 종료 코드를 바꾸지 않습니다 |
+| `1` | 한 건 이상이 Fail. 요약의 `Fail N` 이 그대로 반영됩니다 |
+
+Constitution Registry 항목은 레지스트리가 파싱되는지만 보지 않고 `moai constitution validate` 와 **같은 드리프트 검사**를 돌립니다. 따라서 같은 체크아웃에서 doctor 가 ok 라고 하는데 validate 가 실패하는 일은 없습니다. `MOAI_CONSTITUTION_SKIP_VALIDATE=1` 로 우회하면 doctor 도 구조 검사 판정으로 돌아갑니다.
+
 ## 예시
 
 ```bash

--- a/docs-site/content/zh/cli-reference/doctor.md
+++ b/docs-site/content/zh/cli-reference/doctor.md
@@ -50,6 +50,17 @@ moai doctor [OPTIONS]
 
 这个估算调用的是与 `moai clean --home` **同一个扫描器**,所以 doctor 报出的数字和 clean 实际删除的清单不会脱节。详见 [主目录卫生](/zh/advanced/home-hygiene)。
 
+## 退出码
+
+脚本和 CI 包装器调用 `moai doctor` 时，读的是退出码，而不是摘要那一行。
+
+| 退出码 | 含义 |
+|--------|------|
+| `0` | 没有 Fail 项。Warn 属于劝告，不改变退出码 |
+| `1` | 有一项以上 Fail —— 摘要里的 `Fail N` 原样体现 |
+
+Constitution Registry 这一项不只确认注册表能否解析，它跑的是与 `moai constitution validate` **相同的漂移校验**。所以在同一个检出里，doctor 说 ok 而 validate 失败的情况不会出现。用 `MOAI_CONSTITUTION_SKIP_VALIDATE=1` 绕过时，doctor 回到它自己的结构检查判定。
+
 ## 示例
 
 ```bash

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -44,8 +44,9 @@ var doctorCmd = &cobra.Command{
 	Use:     "doctor",
 	Short:   "Run system diagnostics",
 	GroupID: "project",
-	Long:    "Run comprehensive system health checks including Claude Code configuration, dependency verification, and environment diagnostics.",
-	RunE:    runDoctor,
+	Long: "Run comprehensive system health checks including Claude Code configuration, dependency verification, and environment diagnostics.\n\n" +
+		"Exit codes: 0=no failing checks (warnings are advisory and do not fail the run), 1=one or more checks reported Fail.",
+	RunE: runDoctor,
 }
 
 func init() {
@@ -97,12 +98,7 @@ func runDoctor(cmd *cobra.Command, _ []string) error {
 	// Render per-section pass/fail tables + counts + summary (REQ-TUX4-002).
 	_, _ = fmt.Fprintln(out, renderDoctorGroups(out, groups, verbose, th))
 
-	failCount := 0
-	for _, c := range allChecks {
-		if c.Status == uikit.CheckFail {
-			failCount++
-		}
-	}
+	failCount := countFailedChecks(allChecks)
 
 	if fix && failCount > 0 {
 		var fixes []string
@@ -122,7 +118,33 @@ func runDoctor(cmd *cobra.Command, _ []string) error {
 		_, _ = fmt.Fprintf(out, "\nDiagnostics exported to %s\n", exportPath)
 	}
 
-	return nil
+	return doctorExitStatus(failCount)
+}
+
+// countFailedChecks counts the checks whose verdict is Fail — the same number
+// the rendered summary prints as `Fail N`.
+func countFailedChecks(checks []DiagnosticCheck) int {
+	n := 0
+	for _, c := range checks {
+		if c.Status == uikit.CheckFail {
+			n++
+		}
+	}
+	return n
+}
+
+// doctorExitStatus maps a doctor run's failing-check count onto the process
+// exit code (#1593). A run that printed `Fail N` (N > 0) MUST NOT exit 0 —
+// callers (scripts, hooks, CI wrappers) read the exit code, not the summary
+// line. Warn-only runs stay exit 0: a warning is advisory, not a failure.
+func doctorExitStatus(failCount int) error {
+	if failCount == 0 {
+		return nil
+	}
+	return &exitCodeError{
+		code: 1,
+		msg:  fmt.Sprintf("doctor: %d check(s) failed", failCount),
+	}
 }
 
 // checkStatusToTUI converts a uikit.CheckStatus to the tui.CheckLine status string.
@@ -605,11 +627,13 @@ func parseMCPJSON(path string) map[string]struct{} {
 const constitutionStrictEnvKey = "MOAI_CONSTITUTION_STRICT"
 
 // checkConstitution checks the zone registry status.
-// - registry file not found: Warn (optional feature)
-// - load error (duplicate ID, invalid YAML, etc.): Fail
-// - zero Frozen entries: Warn
-// - orphan warnings present + strictMode: Fail; otherwise Warn
-// - normal/OK: OK
+//   - registry file not found: Warn (optional feature)
+//   - load error (duplicate ID, invalid YAML, etc.): Fail
+//   - zero Frozen entries: Warn
+//   - orphan warnings present + strictMode: Fail; otherwise Warn
+//   - registry-vs-source validation errors (same check as `moai constitution
+//     validate`): Fail
+//   - normal/OK: OK
 func checkConstitution(projectDir, registryPath string, verbose, strictMode bool) DiagnosticCheck {
 	check := DiagnosticCheck{Name: "Constitution Registry"}
 
@@ -646,6 +670,15 @@ func checkConstitution(projectDir, registryPath string, verbose, strictMode bool
 		return check
 	}
 
+	// Registry-source drift check (#1594). Loading the registry proves it
+	// parses; it says nothing about whether the clauses still exist in their
+	// source files. Doctor runs the same constitution.Validate that
+	// `moai constitution validate` runs, so a check that a registry "is OK"
+	// cannot disagree with the dedicated command against the same checkout.
+	if vcheck, drifted := validateConstitutionRegistry(projectDir, registryPath, len(reg.Entries), verbose); drifted {
+		return vcheck
+	}
+
 	// Check Frozen entry count
 	frozen := reg.FilterByZone(constitution.ZoneFrozen)
 	if len(frozen) == 0 {
@@ -669,6 +702,48 @@ func checkConstitution(projectDir, registryPath string, verbose, strictMode bool
 	check.Message = fmt.Sprintf("registry OK — %d entries (%d Frozen, %d Evolvable)",
 		len(reg.Entries), len(frozen), len(reg.Entries)-len(frozen))
 	return check
+}
+
+// validateConstitutionRegistry runs the same drift validation as
+// `moai constitution validate` against the registry doctor just loaded.
+// It returns (check, true) when validation found errors — the caller surfaces
+// that check as the Constitution Registry verdict — and (zero, false) when the
+// registry validates clean or the validation was bypassed
+// (MOAI_CONSTITUTION_SKIP_VALIDATE=1), in which case doctor falls through to
+// its own structural verdict.
+func validateConstitutionRegistry(projectDir, registryPath string, entryCount int, verbose bool) (DiagnosticCheck, bool) {
+	check := DiagnosticCheck{Name: "Constitution Registry"}
+
+	result, err := constitution.Validate(constitution.ValidateOptions{
+		RegistryPath: registryPath,
+		ProjectDir:   projectDir,
+	})
+	if result.Skipped {
+		return DiagnosticCheck{}, false
+	}
+	if err == nil && result.Status != constitution.ValidateStatusDrift {
+		return DiagnosticCheck{}, false
+	}
+
+	check.Status = uikit.CheckFail
+	if len(result.Entries) == 0 {
+		// Validation could not complete (e.g. an unreadable source file).
+		// Report the error rather than a misleading error count of zero.
+		check.Message = fmt.Sprintf("registry validate error: %v", err)
+		return check, true
+	}
+
+	check.Message = fmt.Sprintf(
+		"registry loads (%d entries) but validate found %d error(s) — run `moai constitution validate`",
+		entryCount, len(result.Entries))
+	if verbose {
+		details := make([]string, 0, len(result.Entries))
+		for _, e := range result.Entries {
+			details = append(details, fmt.Sprintf("%s [%s] %s", e.ID, e.SentinelKey, e.Detail))
+		}
+		check.Detail = strings.Join(details, "\n")
+	}
+	return check, true
 }
 
 // checkHooksConfig verifies the Claude Code hooks configuration exists.

--- a/internal/cli/doctor_constitution_test.go
+++ b/internal/cli/doctor_constitution_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/modu-ai/moai-adk/internal/cli/uikit"
+	"github.com/modu-ai/moai-adk/internal/constitution"
 )
 
 // validConstitutionRegistryForDoctor is a registry content valid for doctor tests.
@@ -69,13 +70,19 @@ const emptyFrozenRegistryForDoctor = `# Test Registry
 ` + "```" + `
 `
 
+// claudeMDWithClauses carries both clauses referenced by
+// validConstitutionRegistryForDoctor, so the registry validates drift-free.
+// A CLAUDE.md missing them is the drift fixture (see
+// TestCheckConstitution_DriftFailsLikeValidate).
+const claudeMDWithClauses = "# Test\n\nSPEC+EARS format is the requirement form.\n\nTRUST 5 is the quality framework.\n"
+
 // TestCheckConstitution_ValidRegistry verifies that a valid registry returns OK.
 // Relates to AC-CON-001-001.
 func TestCheckConstitution_ValidRegistry(t *testing.T) {
 	dir := t.TempDir()
 
 	// Create CLAUDE.md (used for file-presence verification)
-	if err := os.WriteFile(filepath.Join(dir, "CLAUDE.md"), []byte("# Test"), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "CLAUDE.md"), []byte(claudeMDWithClauses), 0o600); err != nil {
 		t.Fatalf("CLAUDE.md 생성 오류: %v", err)
 	}
 
@@ -88,6 +95,72 @@ func TestCheckConstitution_ValidRegistry(t *testing.T) {
 
 	if check.Status != uikit.CheckOK {
 		t.Errorf("유효한 registry에서 Status = %q, want %q\n메시지: %s", check.Status, uikit.CheckOK, check.Message)
+	}
+}
+
+// TestCheckConstitution_DriftFailsLikeValidate verifies #1594: doctor must not
+// report a registry as OK on entry count alone while `moai constitution
+// validate` reports errors against the same checkout. The registry here loads
+// cleanly (structure is sound) but its clauses are absent from the source file,
+// which is exactly what validate flags as DRIFT.
+func TestCheckConstitution_DriftFailsLikeValidate(t *testing.T) {
+	dir := t.TempDir()
+
+	// CLAUDE.md exists (so the entries are not orphans) but carries neither
+	// clause — the drift condition.
+	if err := os.WriteFile(filepath.Join(dir, "CLAUDE.md"), []byte("# Test\n"), 0o600); err != nil {
+		t.Fatalf("CLAUDE.md 생성 오류: %v", err)
+	}
+
+	registryPath := filepath.Join(dir, "zone-registry.md")
+	if err := os.WriteFile(registryPath, []byte(validConstitutionRegistryForDoctor), 0o600); err != nil {
+		t.Fatalf("registry 파일 생성 오류: %v", err)
+	}
+
+	// Cross-check: the dedicated validate command sees the same drift.
+	result, err := constitution.Validate(constitution.ValidateOptions{
+		RegistryPath: registryPath,
+		ProjectDir:   dir,
+	})
+	if err != nil {
+		t.Fatalf("constitution.Validate 오류: %v", err)
+	}
+	if result.Status != constitution.ValidateStatusDrift {
+		t.Fatalf("fixture 전제 실패: validate Status = %q, want %q", result.Status, constitution.ValidateStatusDrift)
+	}
+
+	check := checkConstitution(dir, registryPath, true, false)
+
+	if check.Status != uikit.CheckFail {
+		t.Errorf("drift registry Status = %q, want %q\n메시지: %s", check.Status, uikit.CheckFail, check.Message)
+	}
+	if !strings.Contains(check.Message, "validate") {
+		t.Errorf("메시지가 validate를 가리켜야 한다: %s", check.Message)
+	}
+	if check.Detail == "" {
+		t.Error("verbose 모드에서 drift 항목 detail이 비어 있으면 안 된다")
+	}
+}
+
+// TestCheckConstitution_SkipValidateBypass verifies that
+// MOAI_CONSTITUTION_SKIP_VALIDATE=1 leaves doctor on its structural verdict
+// rather than turning the bypass into a Fail.
+func TestCheckConstitution_SkipValidateBypass(t *testing.T) {
+	t.Setenv("MOAI_CONSTITUTION_SKIP_VALIDATE", "1")
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "CLAUDE.md"), []byte("# Test\n"), 0o600); err != nil {
+		t.Fatalf("CLAUDE.md 생성 오류: %v", err)
+	}
+	registryPath := filepath.Join(dir, "zone-registry.md")
+	if err := os.WriteFile(registryPath, []byte(validConstitutionRegistryForDoctor), 0o600); err != nil {
+		t.Fatalf("registry 파일 생성 오류: %v", err)
+	}
+
+	check := checkConstitution(dir, registryPath, false, false)
+
+	if check.Status != uikit.CheckOK {
+		t.Errorf("skip-validate bypass Status = %q, want %q\n메시지: %s", check.Status, uikit.CheckOK, check.Message)
 	}
 }
 
@@ -135,6 +208,11 @@ func TestCheckConstitution_EmptyFrozen(t *testing.T) {
 	}
 
 	registryPath := filepath.Join(dir, "zone-registry.md")
+	// The clause must be present in the source so this fixture isolates the
+	// empty-Frozen condition rather than tripping the drift check.
+	if err := os.WriteFile(filepath.Join(dir, "CLAUDE.md"), []byte("# Test\n\nSome evolvable rule applies here.\n"), 0o600); err != nil {
+		t.Fatalf("CLAUDE.md 갱신 오류: %v", err)
+	}
 	if err := os.WriteFile(registryPath, []byte(emptyFrozenRegistryForDoctor), 0o600); err != nil {
 		t.Fatalf("registry 파일 생성 오류: %v", err)
 	}

--- a/internal/cli/exitcode_contract_test.go
+++ b/internal/cli/exitcode_contract_test.go
@@ -11,9 +11,36 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/modu-ai/moai-adk/internal/cli/uikit"
 	"github.com/modu-ai/moai-adk/internal/constitution"
 	"github.com/modu-ai/moai-adk/internal/spec"
 )
+
+// TestExitCodeContract_DoctorFailingChecks verifies #1593: a doctor run whose
+// summary prints `Fail N` (N > 0) exits 1 via the ExitCoder boundary, while a
+// run carrying only OK/Warn checks exits 0 (a warning is advisory).
+func TestExitCodeContract_DoctorFailingChecks(t *testing.T) {
+	clean := []DiagnosticCheck{
+		{Name: "A", Status: uikit.CheckOK},
+		{Name: "B", Status: uikit.CheckWarn},
+	}
+	if got := countFailedChecks(clean); got != 0 {
+		t.Fatalf("countFailedChecks(OK+Warn) = %d, want 0", got)
+	}
+	if err := doctorExitStatus(countFailedChecks(clean)); err != nil {
+		t.Fatalf("warn-only doctor run returned %v, want nil (exit 0)", err)
+	}
+
+	failing := append(clean, DiagnosticCheck{Name: "C", Status: uikit.CheckFail})
+	if got := countFailedChecks(failing); got != 1 {
+		t.Fatalf("countFailedChecks(with 1 Fail) = %d, want 1", got)
+	}
+	err := doctorExitStatus(countFailedChecks(failing))
+	assertExitCode(t, err, 1)
+	if !strings.Contains(err.Error(), "1 check(s) failed") {
+		t.Errorf("error message = %q, want it to name the failing-check count", err.Error())
+	}
+}
 
 // assertExitCode fails the test if err does not carry the expected exit code via
 // the ExitCoder boundary (cmd/moai/main.go errors.As mapping).


### PR DESCRIPTION
Card t200 (Class B). Closes two coupled defects on the same `internal/cli/doctor.go` surface.

## What was wrong

**#1593** — `moai doctor` printed `Fail 1` and exited 0. Callers (scripts, hooks, CI wrappers) read the exit code, not the summary line, so a failing run was indistinguishable from a clean one.

**#1594** — in the same run, the Constitution Registry row said `ok — registry OK — 101 entries` while `moai constitution validate` reported 67 errors against that identical checkout. The row counted entries; it never validated anything.

## What changed

- **Exit-code contract.** `runDoctor` returns exit 1 when one or more checks report Fail, through the existing `ExitCoder` boundary. Warn-only runs stay exit 0 — a warning is advisory. The decision is split into `countFailedChecks` / `doctorExitStatus` so the contract is testable without depending on the checkout's own health.
- **Constitution row validates.** `checkConstitution` now runs the same `constitution.Validate` that `moai constitution validate` runs. Drift surfaces as Fail, naming the error count and the command to run; `--verbose` lists the offending entries. `MOAI_CONSTITUTION_SKIP_VALIDATE=1` returns doctor to its structural verdict rather than turning a bypass into a failure.
- **Docs** — exit-code table + validate coupling added to `cli-reference/doctor` in all four locales.

## Fixture correction (no assertion weakened)

`TestCheckConstitution_ValidRegistry` and `_EmptyFrozen` asserted OK on registries whose clauses were absent from their `CLAUDE.md` — genuine drift under the new contract. The clauses were added to the source files so each test isolates the condition it names.

## Verification

| Command | Result |
|---|---|
| `go build ./...` | exit 0 |
| `go vet ./internal/cli/ ./internal/constitution/` | exit 0 |
| `GOOS=windows go vet ./internal/cli/` | exit 0 |
| `go test ./internal/cli/... -count=1` | all packages ok (`internal/cli` 427.3s) |
| `golangci-lint run ./internal/cli/...` | `0 issues.` |

End-to-end on this checkout, with the built binary:

```
fail  Constitution Registry  registry loads (101 entries) but validate found 67 error(s) — run `moai constitution validate`
fail  Harness 5-Layer        L1:FAIL … L6:FAIL
Pass 20    Warn 2    Fail 2
EXIT=1
```

## Residual risk

- **Interaction with #1595 (card t201).** `constitution validate` still flags retired `[SUPERSEDED]` entries as drift. Wiring doctor to validate propagates that false positive into a doctor Fail + exit 1 for downstream checkouts carrying retired entries. Closing #1595 resolves it on both surfaces.
- This repository genuinely carries 67 drift findings, so `moai doctor` here now exits 1 — the honest signal. No CI workflow, hook, or script invokes `moai doctor` (grep: 0 consumers), so no gate breaks.

Fixes #1593
Fixes #1594

🗿 MoAI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `moai doctor` now returns exit code `1` when one or more checks fail.
  * Warning-only results still return exit code `0`.
  * Constitution Registry checks now detect drift against source files and report validation details.
  * Set `MOAI_CONSTITUTION_SKIP_VALIDATE=1` to skip drift validation and use structural checks.

* **Documentation**
  * Updated CLI reference documentation with exit-code and Constitution Registry validation behavior in English, Japanese, Korean, and Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->