### PR TITLE
fix(kanban): register the lead session's own name as its title (t202)

### DIFF
--- a/.moai/reports/t202/verdict.md
+++ b/.moai/reports/t202/verdict.md
@@ -1,0 +1,101 @@
+# t202 — 칸반 리드 세션 이름의 런타임 등록 (Fixes #1596)
+
+- 카드: t202 (Class C — 설계 방향 리드 확정: (b) 기본 + (a) 병행, (c) 범위 외)
+- 브랜치: `WT-lead-name-register` (base `origin/main` = `28bde4022`)
+- 이슈: #1596
+
+## 1. Claim
+
+`moai cc -k` / `moai glm -k` (및 factory `-f`) 로 띄운 **리드 세션이 세션 목록에 자기 이름으로 표시**된다. 표시 이름은 그 세션이 실제로 띄워진 이름 — 운영자가 직접 준 이름이 있으면 그 이름, 없으면 bare 또는 bump된 역할명(`lead`, `lead-1`) — 과 항상 같은 문자열이다. 나중에 `/rename` 하면 그쪽이 이긴다.
+
+## 2. Evidence
+
+### 2.1 근본 원인 — 카드 전제의 정정
+
+카드와 이슈는 "선언만 하고 런타임에 등록 안 함"으로 적었으나, **`--name` 주입은 이미 존재했고 신고된 빌드에도 들어 있었다.**
+
+```
+$ git log --oneline -1 -S'func appendLeadName' -- internal/cli/kanban.go
+c326eb4e0 feat(kanban): name the lead session by its bare role, not lead-<run-id>
+
+$ git merge-base --is-ancestor c326eb4e0 4b2f203fe && echo "IN 3.1.2 (issue's build)"
+IN 3.1.2 (issue's build)
+```
+
+즉 이슈 본문의 "`/rename` 이 사실상 유일한 등록 수단"은 **이름(name)** 에는 해당하지 않는다. 이슈 본문이 스스로 적은 "메시징·위임 정상"이 그 증거다 — 메시징 주소는 정상 등록돼 있었다.
+
+실제 결함은 **이름과 제목이 서로 다른 두 개의 등록**이라는 데 있다. `--name` 은 메시징 주소만 등록하고, 세션 목록에 뜨는 **제목**은 별도 기록이다. 제목을 아무도 정하지 않으면 `UserPromptSubmit` 훅의 기존 정책이 그 자리를 채우는데, 그 정책의 2순위가 `detectActiveSpec` — 프로젝트에서 가장 최근 수정된 `spec.md` 의 제목이다.
+
+`internal/hook/user_prompt_submit.go` `buildSessionTitle` (수정 전 순서):
+
+1. first-wins 가드 (ai-title / custom-title 있으면 `""`)
+2. **활성 SPEC → `"SPEC-ID: heading"`**  ← 리드 세션이 여기 걸렸다
+3. 첫 사용자 프롬프트에서 파생
+4. `""`
+
+이슈가 관측한 `"SPEC-MIGRATE-002: — 뷰어 프런트엔드 이식"` 은 git 로그가 아니라 **이 2번 분기의 출력 형태**와 정확히 일치한다.
+
+### 2.2 수정
+
+| 파일 | 변경 |
+|---|---|
+| `internal/config/envkeys.go` | `EnvMoaiKanbanLeadName = "MOAI_KANBAN_LEAD_NAME"` 신설 — 리드의 **해소된** 세션 이름을 런처 → 훅으로 전달 |
+| `internal/cli/kanban.go` | `appendLeadName` 이 `([]string, string)` 반환 (argv + 해소된 이름). 운영자가 이름을 준 경우에도 그 이름을 **보고**한다. `exportLeadSessionName(name) func()` 추가 — 기존 `captureEnvState` + 복원 idiom 준수 |
+| `internal/cli/cc.go`, `internal/cli/glm.go` | 리드 분기 4곳(kanban×2, factory×2)에서 `defer exportLeadSessionName(leadName)()` |
+| `internal/hook/user_prompt_submit.go` | `buildSessionTitle` 에 리드 분기 추가 — **first-wins 가드 아래, SPEC 분기 위**. `leadSessionTitle()` 헬퍼가 env를 `TrimSpace` 해서 읽음 |
+| `internal/hook/session_start_kanban_i18n.go`, `session_start_factory_i18n.go` | (a) 안내문 갱신, 4-locale(en/ko/ja/zh) 전부 — 목록에도 같은 이름이 뜨고, 제목은 **첫 프롬프트에** 등록되며, `/rename` 이 우선한다는 사실 명시 |
+
+분기 위치가 설계의 핵심이다.
+
+- **SPEC 분기 위**: 리드가 SPEC 있는 프로젝트에 앉아 있는 상황이 곧 이 결함의 발생 조건이다.
+- **first-wins 가드 아래**: `/rename` 은 다른 모든 출처를 이기듯 이 분기도 이긴다. 매 턴 제목을 다시 쓰는 회귀(#1198)를 되살리지 않는다.
+
+역할명을 훅에서 다시 유추하지 않고 런처가 해소한 값을 그대로 실어 보내는 이유: bump된 리드(`lead-1`)에서 제목과 실제 주소가 갈리기 때문이다.
+
+### 2.3 검증
+
+```
+$ go build ./...                                     (무출력)
+$ gofmt -l <touched 9 files>                         (무출력)
+$ golangci-lint run ./internal/hook/... ./internal/cli/... ./internal/config/...
+0 issues.
+$ go test ./internal/hook/ ./internal/config/ -count=1
+ok  github.com/modu-ai/moai-adk/internal/hook    23.510s
+ok  github.com/modu-ai/moai-adk/internal/config   2.302s
+$ go test ./internal/cli/ -count=1 -timeout 600s
+ok  github.com/modu-ai/moai-adk/internal/cli    344.867s
+```
+
+신규 회귀 테스트 `TestBuildSessionTitle_LeadNameWinsOverSPEC` 5개 서브테스트 전부 PASS:
+
+```
+--- PASS: .../not_a_lead_->_SPEC_title_(unchanged_default)
+--- PASS: .../lead_->_the_session's_own_name,_not_the_SPEC
+--- PASS: .../bumped_lead_->_the_bumped_name
+--- PASS: .../existing_title_wins_over_the_lead_name
+--- PASS: .../whitespace-only_value_->_falls_through_to_the_SPEC_title
+```
+
+첫 서브테스트는 **음성 대조군**이다 — 변수가 없을 때 SPEC 제목이 그대로 나오는 것을 먼저 확인하지 않으면, 양성 케이스가 "모든 세션에 이름을 붙이는" 잘못된 구현으로도 통과한다.
+
+기존 `TestAppendLeadName_OperatorNameWins` 은 반환값 변경에 맞춰 갱신하고, 운영자 이름이 **보고되는지**를 추가로 단언한다.
+
+## 3. Baseline-attribution
+
+- 기준 트리: `WT-lead-name-register`, base `origin/main` = `28bde4022`
+- 모든 수치는 이 트리에서 이 라운드에 실행한 명령의 출력이다. 캐시 비활성(`-count=1`).
+
+## 4. Gaps (미검증)
+
+- **실제 세션에서 제목이 바뀌는지 육안 확인 안 함.** 검증은 `buildSessionTitle` 의 반환값까지다 — 훅이 반환한 `SessionTitle` 을 Claude Code가 실제로 세션 목록에 반영하는 구간은 런타임 소관이고, 이 트리에서 관측하지 않았다. 기존 SPEC 제목 기능이 같은 경로로 동작해 왔다는 것이 유일한 간접 근거다.
+- **동반 세션(plan/run/sync)과 factory lane의 제목은 고치지 않았다.** 동일한 결함이 그대로 남아 있다 — 이름은 `--name` 으로 등록되지만 목록 제목은 여전히 SPEC에서 온다. 카드 범위가 리드였고, `MOAI_KANBAN_LABEL` 이 이미 해소된 라벨을 들고 있어 분기 하나면 되지만 범위 밖이라 손대지 않았다. **후속 카드 후보.**
+- **(c) `moai doctor` 진단 항목은 범위 외** — 리드 지시.
+- 전체 스위트(`go test ./...`)는 로컬에서 돌리지 않았다(CLAUDE.local.md §4). 전 패키지 판정은 CI 몫.
+- Windows/Linux 매트릭스 미검증 — CI 몫. env 전달과 `TrimSpace` 뿐이라 플랫폼 의존은 없어 보이나 관측한 바 없다.
+
+## 5. Residual-risk
+
+- **제목은 첫 프롬프트에 등록된다, 런치 시점이 아니다.** `UserPromptSubmit` 훅이 그 지점이라 구조적이다. 운영자가 첫 프롬프트를 보내기 전에 세션 목록을 보면 여전히 이름이 없다. 안내문(a)에 이 사실을 명시한 이유다.
+- **훅이 꺼진 환경(`disableAllHooks`)에서는 제목이 등록되지 않는다.** 메시징 이름은 `--name` 이라 영향 없다.
+- `os.Setenv` 는 프로세스 전역이다. 신규 테스트는 그래서 병렬이 아니며, 런처 쪽은 기존 `captureEnvState` 복원 규율(`@MX:ANCHOR` on `enterKanbanMode`)을 그대로 따른다. 복원 누락은 같은 바이너리의 뒤따르는 테스트를 오염시킨다.
+- 운영자가 리드에 자기 이름을 준 경우 그 이름이 제목이 된다. 의도된 동작이지만, 종전에는 SPEC 제목이 나왔으므로 그 운영자에게는 **행동 변화**다.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reasoning directive z.ai prefixes the response with thinking content blocks whose payload lives
   in `thinking`, not `text` — the blind `Content[0]` read failed open to `inconclusive` while a
   complete review sat in the next block.
+- A Kanban or Factory **lead session now appears in the session list under its own name** rather than an unrelated SPEC heading ([#1596](https://github.com/modu-ai/moai-adk/issues/1596)). A session's name and its title are two separate registrations: `--name` (already injected) made the lead addressable, which is why messaging and delegation always worked, but nothing ever set a title — so the `UserPromptSubmit` title policy filled the slot from the most recently modified `spec.md`, and a lead was listed as `SPEC-…: <heading>`. The launcher now publishes the lead's resolved name — the operator's own when they supplied one, the bare or bumped role otherwise — and the hook titles the session with it, above the SPEC branch and below the first-wins guard, so a later `/rename` still wins. The title registers on the first prompt, not at launch, and the bootstrap notice says so in all four locales. Companion and lane sessions are unchanged.
 
 ## [3.1.3] - 2026-08-24
 

--- a/internal/cli/cc.go
+++ b/internal/cli/cc.go
@@ -159,7 +159,9 @@ func runCC(cmd *cobra.Command, args []string) error {
 		leadLabel, _ := parseLeadLabel(filteredArgs)
 		defer enterFactoryLeadMode(entry.FactoryWorkers, leadLabel)()
 		defer exportKanbanLaunchFacts(entry.Spec, kanban.BackendClaude)()
-		filteredArgs = appendLeadName(filteredArgs, launchProjectRoot(), cmd.ErrOrStderr())
+		var leadName string
+		filteredArgs, leadName = appendLeadName(filteredArgs, launchProjectRoot(), cmd.ErrOrStderr())
+		defer exportLeadSessionName(leadName)()
 		settingsFlag, settingsCleanup := prepareKanbanSettings(filteredArgs)
 		if len(settingsFlag) > 0 {
 			filteredArgs = append(filteredArgs, settingsFlag...)
@@ -192,7 +194,9 @@ func runCC(cmd *cobra.Command, args []string) error {
 			defer exportKanbanLaunchFacts(entry.Spec, kanban.BackendClaude)()
 			// A lead launched bare has only an AI-generated title, which claude
 			// discards on /clear; naming it explicitly is what survives.
-			filteredArgs = appendLeadName(filteredArgs, launchProjectRoot(), cmd.ErrOrStderr())
+			var leadName string
+			filteredArgs, leadName = appendLeadName(filteredArgs, launchProjectRoot(), cmd.ErrOrStderr())
+			defer exportLeadSessionName(leadName)()
 			settingsFlag, settingsCleanup := prepareKanbanSettings(filteredArgs)
 			if len(settingsFlag) > 0 {
 				filteredArgs = append(filteredArgs, settingsFlag...)

--- a/internal/cli/glm.go
+++ b/internal/cli/glm.go
@@ -222,7 +222,9 @@ func runGLM(cmd *cobra.Command, args []string) error {
 		leadLabel, _ := parseLeadLabel(filteredArgs)
 		defer enterFactoryLeadMode(entry.FactoryWorkers, leadLabel)()
 		defer exportKanbanLaunchFacts(entry.Spec, kanban.BackendGLM)()
-		filteredArgs = appendLeadName(filteredArgs, launchProjectRoot(), cmd.ErrOrStderr())
+		var leadName string
+		filteredArgs, leadName = appendLeadName(filteredArgs, launchProjectRoot(), cmd.ErrOrStderr())
+		defer exportLeadSessionName(leadName)()
 		settingsFlag, settingsCleanup := prepareKanbanSettings(filteredArgs)
 		if len(settingsFlag) > 0 {
 			filteredArgs = append(filteredArgs, settingsFlag...)
@@ -249,7 +251,9 @@ func runGLM(cmd *cobra.Command, args []string) error {
 			defer enterKanbanMode(entry.Spec, leadLabel)()
 			defer exportKanbanLaunchFacts(entry.Spec, kanban.BackendGLM)()
 			// See cc.go: glm mirrors the lead branch exactly.
-			filteredArgs = appendLeadName(filteredArgs, launchProjectRoot(), cmd.ErrOrStderr())
+			var leadName string
+			filteredArgs, leadName = appendLeadName(filteredArgs, launchProjectRoot(), cmd.ErrOrStderr())
+			defer exportLeadSessionName(leadName)()
 			settingsFlag, settingsCleanup := prepareKanbanSettings(filteredArgs)
 			if len(settingsFlag) > 0 {
 				filteredArgs = append(filteredArgs, settingsFlag...)

--- a/internal/cli/kanban.go
+++ b/internal/cli/kanban.go
@@ -648,13 +648,38 @@ func leadNameArgs(args []string) []string {
 // The bumped value must reach the backend argv: the session name is the address
 // the operator and the peers dispatch to, so a name resolved but not injected
 // leaves everyone addressing a session that answers to something else.
-func appendLeadName(args []string, root string, notes io.Writer) []string {
+func appendLeadName(args []string, root string, notes io.Writer) ([]string, string) {
 	nameArgs := leadNameArgs(args)
 	if len(nameArgs) == 0 {
-		return args
+		// The operator named the session themselves; that name is already in
+		// argv and is the one peers address. Report it so the title registered
+		// downstream is the name the session actually answers to, rather than
+		// the role moai would have chosen.
+		name, _ := parseNamedLabel(args, func(string) bool { return true })
+		return args, name
 	}
 	nameArgs[1] = resolveLeadName(root, nameArgs[1], notes)
-	return append(args, nameArgs...)
+	return append(args, nameArgs...), nameArgs[1]
+}
+
+// exportLeadSessionName publishes the lead's resolved session name to the child
+// session's environment and returns the restore func its callers defer.
+//
+// The name and the TITLE are two separate registrations in Claude Code: `--name`
+// makes the session addressable, and a title has to be set on its own or a
+// generated one takes the slot (issue #1596). Only the launcher knows the
+// resolved name and only a hook can set a title, so the value crosses that gap
+// through the environment the child already inherits.
+//
+// An empty name is a no-op that still returns a usable restore func, so a caller
+// can defer the result unconditionally.
+func exportLeadSessionName(name string) func() {
+	if name == "" {
+		return func() {}
+	}
+	restore := captureEnvState(config.EnvMoaiKanbanLeadName)
+	_ = os.Setenv(config.EnvMoaiKanbanLeadName, name)
+	return restore
 }
 
 // rejectKanbanOnCG returns the sentinel-bearing error when a kanban token

--- a/internal/cli/kanban_lead_name_test.go
+++ b/internal/cli/kanban_lead_name_test.go
@@ -307,8 +307,13 @@ func TestAppendLeadName_OperatorNameWins(t *testing.T) {
 	root := t.TempDir()
 
 	args := []string{"--name", "board-watch"}
-	got := appendLeadName(args, root, nil)
+	got, name := appendLeadName(args, root, nil)
 	if len(got) != len(args) {
 		t.Errorf("appendLeadName appended to an operator-named lead: %q", got)
+	}
+	// The operator's own name is still REPORTED, so the title registered
+	// downstream is the name the session actually answers to (issue #1596).
+	if name != "board-watch" {
+		t.Errorf("appendLeadName reported %q for an operator-named lead, want %q", name, "board-watch")
 	}
 }

--- a/internal/config/envkeys.go
+++ b/internal/config/envkeys.go
@@ -223,6 +223,23 @@ const (
 	// derivable value (REQ-KRS-005).
 	EnvMoaiKanbanCard = "MOAI_KANBAN_CARD"
 
+	// EnvMoaiKanbanLeadName carries the lead session's RESOLVED name — the value
+	// that actually reached the backend argv as `--name`, which is the operator's
+	// own name when they supplied one and the bare-or-bumped role otherwise.
+	//
+	// It exists because a session name and a session TITLE are two different
+	// registrations in Claude Code. `--name` registers the messaging address, and
+	// peers address the lead correctly by it; the title shown in the session list
+	// is a separate record, and a lead that never set one is given a generated
+	// title instead — which is how a lead came to be listed under an unrelated
+	// SPEC heading while messaging worked perfectly (issue #1596). The launcher is
+	// the only place that knows the resolved name, and the UserPromptSubmit hook
+	// is the only place that can register a title, so the value travels between
+	// them through the environment the child session already inherits.
+	//
+	// It is set on the LEAD only. A companion's title is not registered from here.
+	EnvMoaiKanbanLeadName = "MOAI_KANBAN_LEAD_NAME"
+
 	// EnvMoaiFactoryWorkers carries the Factory Mode signal and the run's
 	// worker count from the launcher entry point to the block-cap inject and
 	// the SessionStart hook. It is set on BOTH the factory lead and every

--- a/internal/hook/session_start_factory_i18n.go
+++ b/internal/hook/session_start_factory_i18n.go
@@ -57,7 +57,7 @@ type factoryMessages struct {
 var factoryLocales = map[string]factoryMessages{
 	langEnglish: {
 		leadHeader:   "Factory Mode: run %s, lead session.",
-		leadIdentity: "This session is named %s. It carries no run id: a second lead launched while this one is live takes the next free number instead, and peers address whichever name the session actually launched under.",
+		leadIdentity: "This session is named %s. It carries no run id: a second lead launched while this one is live takes the next free number instead, and peers address whichever name the session actually launched under. The session list shows that same name — the title is registered on your first prompt, and a later /rename still wins.",
 		leadManual: "This session dispatches cards to %d lanes over cross-session messages.\n" +
 			"The lanes below are launched by hand, one per new terminal, because a session cannot launch another session.\n" +
 			"Lanes are named lane-1..lane-%d; a number whose label is held by a live session is bumped to the next free number.",
@@ -85,7 +85,7 @@ var factoryLocales = map[string]factoryMessages{
 	},
 	"ko": {
 		leadHeader:   "팩토리 모드: run %s, 리더 세션.",
-		leadIdentity: "이 세션의 이름은 %s 입니다. 이름에 run id 는 들어가지 않습니다 — 이 세션이 살아 있는 동안 리드를 하나 더 띄우면 그쪽이 다음 번호를 받고, 다른 세션은 실제로 띄워진 이름으로 이 세션을 부릅니다.",
+		leadIdentity: "이 세션의 이름은 %s 입니다. 이름에 run id 는 들어가지 않습니다 — 이 세션이 살아 있는 동안 리드를 하나 더 띄우면 그쪽이 다음 번호를 받고, 다른 세션은 실제로 띄워진 이름으로 이 세션을 부릅니다. 세션 목록에도 같은 이름이 뜹니다 — 제목은 첫 프롬프트에서 등록되고, 나중에 /rename 을 하면 그쪽이 우선합니다.",
 		leadManual: "이 세션이 세션 간 메시지로 카드를 레인 %d개에 배분합니다.\n" +
 			"아래 레인은 터미널을 하나씩 새로 열어 직접 실행하세요 — 세션은 다른 세션을 띄울 수 없습니다.\n" +
 			"레인 이름은 lane-1..lane-%d 이며, 생존 세션이 이미 쓰고 있는 번호는 다음 빈 번호로 늘어납니다.",
@@ -110,7 +110,7 @@ var factoryLocales = map[string]factoryMessages{
 	},
 	"ja": {
 		leadHeader:   "ファクトリーモード: run %s、リーダーセッション。",
-		leadIdentity: "このセッションの名前は %s です。名前に run id は含まれません — このセッションが生きている間にもう一つリーダーを起動すると、そちらが次の番号を取り、他のセッションは実際に起動した名前でこのセッションを呼びます。",
+		leadIdentity: "このセッションの名前は %s です。名前に run id は含まれません — このセッションが生きている間にもう一つリーダーを起動すると、そちらが次の番号を取り、他のセッションは実際に起動した名前でこのセッションを呼びます。セッション一覧にも同じ名前が表示されます — タイトルは最初のプロンプトで登録され、後から /rename すればそちらが優先されます。",
 		leadManual: "このセッションが、セッション間メッセージでカードをレーン %d 本に割り振ります。\n" +
 			"以下のレーンは、ターミナルを 1 つずつ新規に開いて手動で起動してください — セッションが別のセッションを起動することはできません。\n" +
 			"レーン名は lane-1..lane-%d で、生存セッションが保持する番号は次の空き番号へ繰り上がります。",
@@ -135,7 +135,7 @@ var factoryLocales = map[string]factoryMessages{
 	},
 	"zh": {
 		leadHeader:   "工厂模式：run %s，主导会话。",
-		leadIdentity: "本会话的名称是 %s。名称中不含 run id —— 本会话存活期间再启动一个主导会话，后者会取下一个编号；其他会话按实际启动时的名称来称呼本会话。",
+		leadIdentity: "本会话的名称是 %s。名称中不含 run id —— 本会话存活期间再启动一个主导会话，后者会取下一个编号；其他会话按实际启动时的名称来称呼本会话。会话列表中也显示同一名称 —— 标题在首次提示时注册，之后 /rename 优先。",
 		leadManual: "本会话通过跨会话消息把卡片分发给 %d 条泳道。\n" +
 			"下面的泳道需要各自新开一个终端手动启动 —— 会话无法启动另一个会话。\n" +
 			"泳道命名为 lane-1..lane-%d；已被存活会话占用的编号会顺延到下一个空位。",

--- a/internal/hook/session_start_kanban_i18n.go
+++ b/internal/hook/session_start_kanban_i18n.go
@@ -59,7 +59,7 @@ type kanbanMessages struct {
 var kanbanLocales = map[string]kanbanMessages{
 	langEnglish: {
 		leadHeader:   "Kanban Mode: run %s, lead session.",
-		leadIdentity: "This session is named %s. It carries no run id: a second lead launched while this one is live takes the next free number instead, and peers address whichever name the session actually launched under.",
+		leadIdentity: "This session is named %s. It carries no run id: a second lead launched while this one is live takes the next free number instead, and peers address whichever name the session actually launched under. The session list shows that same name — the title is registered on your first prompt, and a later /rename still wins.",
 		leadManual: "This session drives the kanban chain.\n" +
 			"The three companions below are launched by hand, one per new terminal, " +
 			"because a session cannot launch another session.",
@@ -83,7 +83,7 @@ var kanbanLocales = map[string]kanbanMessages{
 	},
 	"ko": {
 		leadHeader:   "칸반 모드: run %s, 리더 세션.",
-		leadIdentity: "이 세션의 이름은 %s 입니다. 이름에 run id 는 들어가지 않습니다 — 이 세션이 살아 있는 동안 리드를 하나 더 띄우면 그쪽이 다음 번호를 받고, 다른 세션은 실제로 띄워진 이름으로 이 세션을 부릅니다.",
+		leadIdentity: "이 세션의 이름은 %s 입니다. 이름에 run id 는 들어가지 않습니다 — 이 세션이 살아 있는 동안 리드를 하나 더 띄우면 그쪽이 다음 번호를 받고, 다른 세션은 실제로 띄워진 이름으로 이 세션을 부릅니다. 세션 목록에도 같은 이름이 뜹니다 — 제목은 첫 프롬프트에서 등록되고, 나중에 /rename 을 하면 그쪽이 우선합니다.",
 		leadManual: "이 세션이 칸반 체인을 주도합니다.\n" +
 			"아래 세 개의 동반 세션은 터미널을 하나씩 새로 열어 직접 실행하세요 — 세션은 다른 세션을 띄울 수 없습니다.",
 		glmSubstitute: "진입점: `moai cc -k` 는 Claude 백엔드 공장장, `moai glm -k` 는 GLM 백엔드 공장장 — 런처가 백엔드를, `-k` 가 칸반 역할을 정합니다. " +
@@ -105,7 +105,7 @@ var kanbanLocales = map[string]kanbanMessages{
 	},
 	"ja": {
 		leadHeader:   "かんばんモード: run %s、リーダーセッション。",
-		leadIdentity: "このセッションの名前は %s です。名前に run id は含まれません — このセッションが生きている間にもう一つリーダーを起動すると、そちらが次の番号を取り、他のセッションは実際に起動した名前でこのセッションを呼びます。",
+		leadIdentity: "このセッションの名前は %s です。名前に run id は含まれません — このセッションが生きている間にもう一つリーダーを起動すると、そちらが次の番号を取り、他のセッションは実際に起動した名前でこのセッションを呼びます。セッション一覧にも同じ名前が表示されます — タイトルは最初のプロンプトで登録され、後から /rename すればそちらが優先されます。",
 		leadManual: "このセッションがかんばんチェーンを進行します。\n" +
 			"以下の 3 つの併走セッションは、ターミナルを 1 つずつ新規に開いて手動で起動してください — セッションが別のセッションを起動することはできません。",
 		glmSubstitute: "入口: `moai cc -k` は Claude バックエンドの親方、`moai glm -k` は GLM バックエンドの親方 — ランチャーがバックエンドを、`-k` がかんばんの役割を決めます。 " +
@@ -127,7 +127,7 @@ var kanbanLocales = map[string]kanbanMessages{
 	},
 	"zh": {
 		leadHeader:   "看板模式：run %s，主导会话。",
-		leadIdentity: "本会话的名称是 %s。名称中不含 run id —— 本会话存活期间再启动一个主导会话，后者会取下一个编号；其他会话按实际启动时的名称来称呼本会话。",
+		leadIdentity: "本会话的名称是 %s。名称中不含 run id —— 本会话存活期间再启动一个主导会话，后者会取下一个编号；其他会话按实际启动时的名称来称呼本会话。会话列表中也显示同一名称 —— 标题在首次提示时注册，之后 /rename 优先。",
 		leadManual: "本会话负责推进整条看板链路。\n" +
 			"下面三个协同会话需要各自新开一个终端手动启动 —— 会话无法启动另一个会话。",
 		glmSubstitute: "入口：`moai cc -k` 是 Claude 后端的工头，`moai glm -k` 是 GLM 后端的工头 —— 启动器决定后端，`-k` 决定看板角色。 " +

--- a/internal/hook/user_prompt_submit.go
+++ b/internal/hook/user_prompt_submit.go
@@ -15,6 +15,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"github.com/modu-ai/moai-adk/internal/config"
 	"github.com/modu-ai/moai-adk/internal/workflow"
 )
 
@@ -141,6 +142,17 @@ func (h *userPromptSubmitHandler) buildSessionTitle(ctx context.Context, cwd, tr
 		return ""
 	}
 
+	// No title yet, and this is a kanban or factory LEAD: the session's own name
+	// is the title, so the operator finds it in the session list under the name
+	// they and every peer already address it by (issue #1596). This branch sits
+	// ABOVE the SPEC branch deliberately — a lead session sitting in a project
+	// with SPECs is exactly the case that produced an unrelated SPEC heading as
+	// a lead's title. It sits BELOW the first-wins guard just as deliberately:
+	// a /rename still wins, as it does for every other source.
+	if name := leadSessionTitle(); name != "" {
+		return name
+	}
+
 	// No title yet. An active SPEC yields a content-bearing, stable title.
 	if cwd != "" {
 		if title := detectActiveSpec(cwd); title != "" {
@@ -161,6 +173,19 @@ func (h *userPromptSubmitHandler) buildSessionTitle(ctx context.Context, cwd, tr
 	// No SPEC and no usable first prompt: emit no title so the native ai-title
 	// generator has a clear field.
 	return ""
+}
+
+// leadSessionTitle returns the lead session's resolved name, or "" when this
+// session is not a kanban or factory lead.
+//
+// The value is published by the launcher (exportLeadSessionName) because the
+// launcher is the only actor that knows which name actually reached the backend
+// argv — the operator's own when they supplied one, the bare-or-bumped role
+// otherwise. Reading it here rather than re-deriving the role is what keeps the
+// title and the messaging address the same string; a title that guessed the role
+// would disagree with the session's real name on every bumped lead.
+func leadSessionTitle() string {
+	return strings.TrimSpace(os.Getenv(config.EnvMoaiKanbanLeadName))
 }
 
 // conversationLanguage returns the configured conversation_language, or "" when

--- a/internal/hook/user_prompt_submit_lead_title_test.go
+++ b/internal/hook/user_prompt_submit_lead_title_test.go
@@ -1,0 +1,99 @@
+package hook
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/modu-ai/moai-adk/internal/config"
+)
+
+// TestBuildSessionTitle_LeadNameWinsOverSPEC pins the repair for issue #1596: a
+// kanban or factory lead is titled by the name it actually launched under, even
+// when the project carries SPECs.
+//
+// The reported failure is exactly this shape — messaging worked (the `--name`
+// injection has shipped since c326eb4e0) while the session list showed an
+// unrelated SPEC heading, because a session name and a session TITLE are two
+// separate registrations and only the first one was ever made. Titling from the
+// SPEC is the correct default for every OTHER session, which is why this test
+// asserts the ordering rather than the absence of the SPEC branch.
+//
+// These subtests set a process-global environment variable, so they are
+// deliberately NOT parallel.
+func TestBuildSessionTitle_LeadNameWinsOverSPEC(t *testing.T) {
+	cwd := t.TempDir()
+	specDir := filepath.Join(cwd, ".moai", "specs", "SPEC-MIGRATE-002")
+	if err := os.MkdirAll(specDir, 0o755); err != nil {
+		t.Fatalf("failed to create spec directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(specDir, "spec.md"), []byte("# 뷰어 프런트엔드 이식\n"), 0o644); err != nil {
+		t.Fatalf("failed to create spec.md: %v", err)
+	}
+	specTitle := "SPEC-MIGRATE-002: 뷰어 프런트엔드 이식"
+
+	h := newHookHandler("ko")
+
+	// Negative control FIRST: with the variable unset, the SPEC title is what a
+	// session gets. Without this the positive case below could pass for the
+	// wrong reason — a leadSessionTitle that returned its argument on every
+	// session would look identical on the lead alone.
+	t.Run("not a lead -> SPEC title (unchanged default)", func(t *testing.T) {
+		// t.Setenv first so the prior value is restored on cleanup; the unset
+		// that follows is what the negative control actually needs, because
+		// presence — not emptiness — is the signal downstream readers use.
+		t.Setenv(config.EnvMoaiKanbanLeadName, "")
+		if err := os.Unsetenv(config.EnvMoaiKanbanLeadName); err != nil {
+			t.Fatalf("failed to unset %s: %v", config.EnvMoaiKanbanLeadName, err)
+		}
+
+		if got := h.buildSessionTitle(context.Background(), cwd, ""); got != specTitle {
+			t.Errorf("buildSessionTitle() = %q, want the SPEC title %q", got, specTitle)
+		}
+	})
+
+	t.Run("lead -> the session's own name, not the SPEC", func(t *testing.T) {
+		t.Setenv(config.EnvMoaiKanbanLeadName, "lead")
+
+		got := h.buildSessionTitle(context.Background(), cwd, "")
+		if got != "lead" {
+			t.Errorf("buildSessionTitle() = %q, want the lead's own name %q", got, "lead")
+		}
+		if got == specTitle {
+			t.Error("the lead was titled by an unrelated SPEC — issue #1596 regressed")
+		}
+	})
+
+	// A bumped lead (a second lead launched while the first is live) carries the
+	// bumped name in argv, so the title must carry it too — a title guessing the
+	// bare role would disagree with the address peers actually dispatch to.
+	t.Run("bumped lead -> the bumped name", func(t *testing.T) {
+		t.Setenv(config.EnvMoaiKanbanLeadName, "lead-1")
+
+		if got := h.buildSessionTitle(context.Background(), cwd, "lead-1"); got != "lead-1" {
+			t.Errorf("buildSessionTitle() = %q, want the bumped name %q", got, "lead-1")
+		}
+	})
+
+	// The first-wins guard is ABOVE this branch: a /rename (recorded as a
+	// custom-title) still wins, exactly as it does over the SPEC branch.
+	t.Run("existing title wins over the lead name", func(t *testing.T) {
+		t.Setenv(config.EnvMoaiKanbanLeadName, "lead")
+
+		path := writeTranscript(t, `{"type":"custom-title","customTitle":"운영자가 고른 이름","sessionId":"s1"}`)
+		if got := h.buildSessionTitle(context.Background(), cwd, path); got != "" {
+			t.Errorf("buildSessionTitle() = %q, want %q — a rename must not be clobbered", got, "")
+		}
+	})
+
+	// A whitespace-only value is not a name. Trimming to empty falls through to
+	// the SPEC branch rather than registering a blank title.
+	t.Run("whitespace-only value -> falls through to the SPEC title", func(t *testing.T) {
+		t.Setenv(config.EnvMoaiKanbanLeadName, "   ")
+
+		if got := h.buildSessionTitle(context.Background(), cwd, ""); got != specTitle {
+			t.Errorf("buildSessionTitle() = %q, want the SPEC title %q", got, specTitle)
+		}
+	})
+}


### PR DESCRIPTION
Fixes #1596

## What was actually wrong

The issue reads as "the name is declared but never registered". Measured, that premise is off by one registration: `--name` injection has shipped since `c326eb4e0`, and `git merge-base --is-ancestor c326eb4e0 4b2f203fe` confirms it was present in the reporter's own 3.1.2 build. The issue's own note that "messaging and delegation are fine" is the evidence — the messaging address was registered correctly all along.

A session's **name** and its **title** are two different registrations. Nothing ever set a title, so the existing `UserPromptSubmit` title policy filled the slot with its second-priority source: `detectActiveSpec`, the most recently modified `spec.md`. That is exactly the shape the reporter saw (`SPEC-MIGRATE-002: — 뷰어 프런트엔드 이식`).

## The change

- `EnvMoaiKanbanLeadName` (`MOAI_KANBAN_LEAD_NAME`) carries the lead's **resolved** name from the launcher to the hook — the operator's own when they supplied one, the bare or bumped role (`lead`, `lead-1`) otherwise.
- `appendLeadName` now returns `([]string, string)`; the four lead branches (kanban and factory, on `cc` and on `glm`) `defer exportLeadSessionName(leadName)()`, following the existing `captureEnvState` restore idiom.
- `buildSessionTitle` gains a lead branch **above** the SPEC branch (a lead sitting in a project with SPECs is the failing case) and **below** the first-wins guard (a `/rename` still wins; no per-turn re-emission, so #1198 does not regress).
- The bootstrap notice is updated in all four locales (en/ko/ja/zh) for both kanban and factory: the list shows the same name, the title registers on the **first prompt** rather than at launch, and `/rename` takes precedence.

Reading the resolved name rather than re-deriving the role is what keeps the title and the messaging address the same string — a guessed role would disagree on every bumped lead.

## Verification

```
go build ./...                                      (no output)
gofmt -l <9 touched files>                          (no output)
golangci-lint run ./internal/hook/... ./internal/cli/... ./internal/config/...
0 issues.
go test ./internal/hook/ ./internal/config/ -count=1     ok 23.510s / ok 2.302s
go test ./internal/cli/ -count=1 -timeout 600s           ok 344.867s
```

New regression test `TestBuildSessionTitle_LeadNameWinsOverSPEC` — 5 subtests, all PASS. The first is a **negative control** (variable unset → SPEC title unchanged); without it the positive case would also pass for an implementation that titled every session.

## Disclosed gaps

- The hook's return value is what is verified, not the rendered session list — whether Claude Code reflects `SessionTitle` in the picker is runtime behavior and was not observed in this tree.
- **Companion and lane sessions carry the identical defect and are deliberately out of scope** (the card scoped the lead). `MOAI_KANBAN_LABEL` already holds their resolved label, so it is one branch — follow-up card candidate.
- `moai doctor` diagnostic (option (c) in the issue) is out of scope per the lead's ruling.
- Full-suite and the cross-platform matrix are CI's verdict, not measured locally.

Evidence: `.moai/reports/t202/verdict.md`

🗿 MoAI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Kanban and Factory lead sessions displaying unrelated SPEC titles in the session list.
  - Lead sessions now use their resolved session names, including automatically adjusted names.
  - Existing custom titles set through `/rename` continue to take precedence.

- **Documentation**
  - Updated multilingual session messages to explain title registration and rename precedence.
  - Added a changelog entry describing the corrected lead-session titles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->