### PR TITLE
test(mcp): address the review on the project_root doc guard (t192 follow-up)

### DIFF
--- a/internal/cli/mcp_project_root_doc_test.go
+++ b/internal/cli/mcp_project_root_doc_test.go
@@ -1,8 +1,9 @@
 // mcp_project_root_doc_test.go — t192 (#e2e F-1): the rule file that tells
 // agents which MCP tools accept `project_root` drifted from the server, naming
 // five tools while six declare the input (`glm_audit` was missing). The
-// omission mattered: glm_audit is exactly where a GLM backend is told which
-// tree to read, so a reader learned no way to point it at a worktree.
+// omission mattered: glm_audit is where the server is told which tree to DIFF
+// before sending that diff to z.ai — GLM itself has no filesystem — so a
+// reader working in a worktree learned no way to have its tree reviewed.
 //
 // A doc claim about a machine-readable surface should be checked against that
 // surface rather than re-read by hand, which is what this test does — for the
@@ -11,7 +12,6 @@ package cli
 
 import (
 	"context"
-	"encoding/json"
 	"os"
 	"regexp"
 	"sort"
@@ -105,13 +105,12 @@ func toolsDeclaringProjectRoot(t *testing.T) []string {
 		t.Fatalf("ListTools: %v", err)
 	}
 
+	// The declaration is the properties key, not the text of the schema: a
+	// description mentioning project_root would otherwise read as a
+	// declaration and fail the doc for a tool that does not take the input.
 	var names []string
 	for _, tool := range res.Tools {
-		b, err := json.Marshal(tool.InputSchema)
-		if err != nil {
-			t.Fatalf("marshal %s schema: %v", tool.Name, err)
-		}
-		if strings.Contains(string(b), projectRootArg) {
+		if _, declared := tool.InputSchema.Properties[projectRootArg]; declared {
 			names = append(names, tool.Name)
 		}
 	}


### PR DESCRIPTION
Follow-up to #1615, which merged (`c298078b9`) before these review fixes could reach its head. Both findings came from that PR's CodeRabbit review; both were verified against the code before acting.

**1. The header described a contract the code does not have.** It said `glm_audit` tells GLM "which tree to read". The tool's own schema states GLM has no filesystem — `project_root` names the tree the **server** diffs before sending that diff to z.ai. Reworded: a test that documents a wrong runtime contract is worse than one with no comment. (The rule file itself was already correct: "the GLM path uses it to collect the diff it sends to z.ai".)

**2. Detection matched the serialized schema, not the schema.** `strings.Contains(json, "project_root")` treats any occurrence as a declaration, so a future tool *description* mentioning the parameter would read as one and fail the doc for a tool that does not take it. Now checks `InputSchema.Properties["project_root"]` directly — no false failure available.

The falsification probe still holds under the property-based check: restoring the stale `Five` in the rule turns the test red, correcting it turns it green.

| Command | Result |
|---|---|
| `go vet ./internal/cli/` | exit 0 |
| `go test ./internal/cli/ -run 'TestProjectRootDocMatchesServer\|TestCodexTools\|TestMCP' -count=1` | ok |
| `golangci-lint run ./internal/cli/...` | `0 issues.` |

Diff vs main is this one file.

🗿 MoAI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how project tree selection affects GLM audits, including support for reviewing worktrees.
  * Improved guidance for identifying tools that accept a project root.

* **Tests**
  * Updated validation to accurately detect supported project root inputs.
  * Prevented descriptive text from being mistaken for a declared input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->