### PR TITLE
fix(quality): run gate steps in the configured project dir, not the caller's cwd (t213)

### DIFF
--- a/.moai/reports/t213/verdict.md
+++ b/.moai/reports/t213/verdict.md
@@ -1,0 +1,150 @@
+# t213 — `go test` TMPDIR 누수 (Class B, 재현 우선)
+
+카드: t213 · 브랜치 `WT-gotest-tmp-leak` · base `origin/main f7d4b7824`
+
+## 1. Claim
+
+`$TMPDIR`에 쌓이던 세 갈래 누수 중 **두 갈래를 뿌리에서 닫았다.** 원인은 서로 다르고,
+둘 다 리드가 제시한 (a)/(b)/(c) 중 **(c) 하위 프로세스** 계열이다 — 다만 기전이 서로 다르다.
+
+| prefix | 개수(착수 시점) | 소유 패키지 | 근본 원인 | 이번 PR |
+|---|---|---|---|---|
+| `TestGateCmd_RunE_Behavior*` | 9,040 | `internal/hook/quality` | 게이트 스텝이 **자기 수트를 재귀 실행** | 닫음 |
+| `go-build*` | 9,171 | 위와 동일 | 죽은 재귀 `go test` 1건당 1개 | 닫음(동일 뿌리) |
+| `moai-cli-profiles-*` | 11,962 | `internal/cli` | 헬퍼 서브프로세스가 `os.Exit`로 TestMain 정리 우회 | 닫음 |
+
+기존 41만 건 청소는 범위 밖(지시대로). 쌓이던 것을 멈추는 것만 했다.
+
+## 2. Evidence
+
+### 2-A. `TestGateCmd` — 게이트가 자기 수트를 재귀 실행했다
+
+가설 검증은 **실행 중 프로세스 관측**으로 했다. 수정 전, 대상 테스트를 1회 돌리는 동안:
+
+```
+$ ps -o pid,etime,command -ax | grep cli.test
+62542  01:49  …/b001/cli.test -test.paniconexit0 -test.run=TestGateCmd_RunE_Behavior …   ← 내가 띄운 것
+65042  01:35  …/b001/cli.test -test.testlogfile=… -test.paniconexit0 -test.timeout=10m0s  ← 자식: -run 필터 없음 = 수트 전체
+77729  00:01  (cli.test)                                                                  ← 손자
+```
+
+자식의 `-test.timeout=10m0s`는 `runGate`의 `context.WithTimeout(10*time.Minute)`와 일치한다.
+`-test.run` 필터가 없다 = **`internal/cli` 수트 전체가 다시 돈다.** 손자까지 나온 시점에서 지수 증식.
+
+기전: `internal/hook/quality`의 `runStep`이 `exec.CommandContext`를 만들면서 **`cmd.Dir`를 지정하지
+않았다.** 모든 스텝의 인자가 cwd 상대(`vet ./...`, `run`, `test ./...`, 비-Go 15종도 동일)이므로,
+자식은 **호출 프로세스의 cwd**를 물려받는다. 프로덕션에선 `moai` 바이너리의 cwd가 대개 프로젝트
+루트라 잠복했다. `go test` 아래에서는 cwd가 시험 대상 패키지 디렉터리라, temp fixture를 가리킨
+게이트가 **실제 저장소를 검사**했고, 그 스텝이 `go test ./...`일 때 자기를 호출한 수트를 다시 돌렸다.
+
+누수는 그 결과다: 재귀 테스트 바이너리가 죽으면 `t.TempDir()` cleanup이 실행되지 않는다.
+**정리 코드가 없어서가 아니라, 정리에 도달하지 못해서다.**
+
+날짜 히스토그램이 이를 뒷받침한다 — 두 prefix가 거의 1:1로 겹친다(재귀 `go test` 1건 = go-build 임시
+작업 디렉터리 1개; 정상 종료 시 제거된다. 툴체인 캐시는 `~/Library/Caches/go-build`에 따로 있다):
+
+| 날짜 | `TestGateCmd*` | `go-build*` |
+|---|---|---|
+| 08-16 | 397 | 405 |
+| 08-17 | 5,493 | 5,529 |
+| 08-18 | 2,745 | 2,740 |
+| 08-19 | 152 | 169 |
+| 08-20 | 250 | 257 |
+
+→ **`go-build*`는 툴체인 소관이 아니라 우리 소관이었다.** 리드 배차의 "우리 것인지 먼저 확인" 지시에
+대한 답: 우리 것이다.
+
+**수정**: `runStep`이 `resolveQualityProjectDir`(같은 패키지가 이미 파일 존재 검사에 쓰던 SSOT)로
+`cmd.Dir`를 지정한다. 선행 SPEC(HOOK-CWD-LEAK-AUDIT)이 cwd 해석은 고쳤으나 **서브프로세스 실행부를
+놓쳤다.**
+
+**회귀 테스트** `TestRunStep_RunsInConfiguredProjectDir` — 문자열 grep이 아니라 실제 실행:
+fixture에 `go vet`이 반드시 잡는 printf 불일치 파일(`gate_cwd_probe.go`, 이름이 저장소에 유일)을
+심고, 스텝이 그 파일을 진단하는지 본다. cfg.ProjectDir를 지키면 실패하며 파일명을 뱉고, 다른 데서
+돌면 그 파일을 아예 못 본다.
+
+```
+수정 전:  --- FAIL … runStep passed on a fixture whose only package fails `go vet`
+수정 후:  --- PASS: TestRunStep_RunsInConfiguredProjectDir (0.51s)
+```
+
+**낙진 수정 1건**: `cmd.Dir`가 붙자 typecheck 테스트 5건이 깨졌다. fixture가 `go.mod`만 있고 `.go`
+파일이 없어 `go vet ./...`가 `matched no packages`로 non-zero 종료했기 때문이다. 이 5건은 **버그
+덕분에 통과하고 있었다**(실제 저장소를 검사해 초록). Go 스텝에 `sourceExts: [".go"]`를 붙여, 언어만
+선언하고 코드는 아직 없는 스캐폴드가 첫 게이트에서 막히지 않게 했다 — Python 스텝이 이미 갖고 있던
+정책과 동일하다.
+
+### 2-B. `moai-cli-profiles-*` — 헬퍼가 `os.Exit`로 정리를 우회했다
+
+리드가 전달한 t208 레인의 규명을 **재규명하지 않고 검증만** 했다. `internal/cli`의 5개 지점이
+`os.Args[0]`을 재실행하고(`exitcode_guard_test.go:31`, `todo_test.go:150/333/662`,
+`launch_session_pid_exec_posix_test.go:55`), 각 자식이 TestMain을 돌려 자기 샌드박스를 만든 뒤,
+헬퍼 본문이 `os.Exit`으로 끝난다 → `main_test.go`의 `restoreProfileBaseDir()`에 도달하지 못한다.
+
+**수정**: 자식이 자기 샌드박스를 만들지 않고 **부모 것을 물려받는다**(`MOAI_CLI_TEST_PROFILE_BASE`).
+5개 지점 전부 `append(os.Environ(), …)`로 자식 env를 만들므로 **호출 지점 수정이 0건**이고, 앞으로
+추가될 헬퍼도 자동으로 덮인다. 디렉터리 소유권은 그것을 만든 프로세스에 남는다.
+
+**회귀 테스트** `TestProfileSandbox_HelperSubprocessLeavesNoBaseDir` — 자식에게 **전용 TMPDIR**을
+주고 그 안만 검사한다. 전역 카운트를 쓰지 않으므로 다른 레인의 동시 실행이 결과를 흔들 수 없다.
+
+```
+수정 전:  --- FAIL … helper subprocess left 1 profile sandbox dir(s) behind in its TMPDIR
+수정 후:  --- PASS: TestProfileSandbox_HelperSubprocessLeavesNoBaseDir (0.06s)
+```
+
+> 함정 회피: Go의 `os.MkdirTemp`는 `$TMPDIR`을 지킨다. 리드가 경고한 "BSD `mktemp`은 `$TMPDIR`을
+> 무시한다"는 `mktemp` **바이너리** 이야기이며, 이 격리는 Go 런타임 경로라 무효화되지 않는다.
+
+### 2-C. 실제 실행 기반 누수 단언 (전역 baseline)
+
+```
+# TestGateCmd 계열
+before = 9,041
+$ go test ./internal/cli/ -run TestGateCmd_RunE_Behavior -count=1     → ok, 1.53s (수정 전: 120s 타임아웃)
+after  = 9,041                                                        → 신규 0
+
+# moai-cli-profiles 계열 (t208 레인이 baseline 보존용으로 남겨둔 11,962 + 내 RED 실행 3)
+before = 11,965
+$ go test ./internal/cli/ -run 'Todo|ExitCod|ExecHelper|LaunchSessionPID' -count=1  → ok, 19.5s
+after  = 11,965                                                       → 신규 0
+```
+
+부수 효과: `internal/hook/quality` 수트가 **22.1s → 6.9s**. fixture를 가리킨 게이트가 더 이상 실제
+저장소를 훑지 않는다.
+
+## 3. Baseline-attribution
+
+- 트리: `WT-gotest-tmp-leak`, base `origin/main f7d4b7824`(워크트리 생성 시 `cd0cee1b8`).
+- `$TMPDIR` = `/var/folders/kt/nq2q81cn4gx3y41r7x47ggmr0000gn/T` (`printenv TMPDIR`).
+- 계수는 전부 `timeout 300 find … -maxdepth 1 -name '<prefix>*'` + `find_rc=0` 확인.
+  `timeout 60`은 41만 엔트리 스캔 중에 죽어 `wc -l`이 **조용히 0을 보고**한다 — 한 번 겪고 상향했다.
+- 통과 기록: `go test ./internal/hook/quality/ -count=1` → `ok … 6.934s`.
+  `go vet ./internal/cli/... ./internal/hook/quality/...` → 무출력.
+  `gofmt -l` → 변경 4파일 모두 미출력(목록에 뜬 31개는 기존 미포맷 파일, 이번 변경과 무관).
+
+## 4. Gaps (미검증)
+
+- **`internal/cli` 전체 수트를 로컬에서 돌리지 않았다.** 착수 시점 load 29.10 — 여기서의 측정은
+  코드가 아니라 머신을 재는 것이고, CLAUDE.local.md §4가 금지한다. 전 패키지 판정은 CI 몫.
+- **darwin/windows 매트릭스 미검증.** `cmd.Dir` 지정은 플랫폼 중립이지만 실측은 darwin 1종뿐.
+- **비-Go 15개 툴체인의 스텝은 실행하지 않았다.** `cmd.Dir` 수정은 모든 스텝에 동일하게 적용되나,
+  실제 검증은 Go 스텝(vet)으로만 했다. `sourceExts` 추가는 Go 스텝에만 한정했다.
+- **기존 41만 엔트리는 그대로다.** 지시대로 청소하지 않았다.
+
+## 5. Residual-risk
+
+- **`cmd.Dir` 지정으로 동작이 바뀌는 곳이 더 있을 수 있다.** 지금까지 cwd == 프로젝트 루트를
+  암묵 전제하던 호출자가 있다면, 이제 `cfg.ProjectDir`(또는 `CLAUDE_PROJECT_DIR`)이 실제로
+  구속한다. `ProjectDir`이 비면 해석 결과가 종전과 같으므로(cwd 폴백) 영향은 `ProjectDir`을
+  설정한 경로에 한정된다. typecheck 테스트 5건이 바로 그 부류였고 — **버그에 기대 통과하던
+  테스트가 더 남아 있을 수 있다.** CI가 판정한다.
+- **`sourceExts` 스킵의 방향성**: `.go` 파일이 하나도 없는 모듈에서 vet/test가 스킵된다. 코드가
+  없으니 검사할 것도 없다는 판단이지만, "검사가 돌지 않았다"를 "통과했다"로 읽히게 하는 형태다.
+  기존 스킵과 마찬가지로 `slog.Warn`으로 보고된다.
+- **`MOAI_CLI_TEST_PROFILE_BASE` 상속 범위**: 테스트 프로세스가 `os.Setenv`로 심으므로, 그
+  프로세스가 띄우는 **모든** 자식이 값을 물려받는다. 테스트 전용 키이고 프로덕션 코드는 읽지
+  않지만, 자식이 임의 프로그램일 경우 env에 낯선 키가 하나 늘어난다.
+- **`moai-cli-profiles-*` 신규 누수 0**은 내가 돌린 테스트 집합에 한해 참이다. 아직 관측하지
+  못한 다른 재실행 지점이 `os.Environ()`을 쓰지 않는다면 그 지점은 여전히 샌드박스를 새로 만든다
+  (현재 5개 지점은 전부 `os.Environ()` 사용을 확인했다).

--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -148,7 +148,26 @@ func countCommandTree(c *cobra.Command) int {
 //
 // t.TempDir() is unavailable in TestMain (no *testing.T), so the directory is
 // created and removed manually.
+// profileBaseDirEnv carries the sandbox path from a test process to any test
+// binary it re-executes. Several tests in this package spawn os.Args[0] as a
+// helper subprocess (exitcode_guard_test.go, todo_test.go,
+// launch_session_pid_exec_posix_test.go), every one of them with
+// append(os.Environ(), …) — so the child picks this up with no per-call-site
+// wiring, and future helpers do too.
+const profileBaseDirEnv = "MOAI_CLI_TEST_PROFILE_BASE"
+
 func sandboxProfileBaseDir() func() {
+	// A re-executed child adopts the parent's sandbox and removes nothing: the
+	// helper bodies end in os.Exit, which returns through neither m.Run() nor
+	// the restore call after it, so anything a child created for itself would
+	// outlive every process that knew about it. Ownership stays with the
+	// process that minted the directory.
+	if inherited := os.Getenv(profileBaseDirEnv); inherited != "" {
+		orig := profile.BaseDirOverride
+		profile.BaseDirOverride = inherited
+		return func() { profile.BaseDirOverride = orig }
+	}
+
 	dir, err := os.MkdirTemp("", "moai-cli-profiles-")
 	if err != nil {
 		// Fall back to a path under the OS temp dir rather than silently
@@ -158,8 +177,10 @@ func sandboxProfileBaseDir() func() {
 	}
 	orig := profile.BaseDirOverride
 	profile.BaseDirOverride = dir
+	_ = os.Setenv(profileBaseDirEnv, dir)
 	return func() {
 		profile.BaseDirOverride = orig
+		_ = os.Unsetenv(profileBaseDirEnv)
 		_ = os.RemoveAll(dir)
 	}
 }

--- a/internal/cli/profile_sandbox_leak_test.go
+++ b/internal/cli/profile_sandbox_leak_test.go
@@ -1,0 +1,44 @@
+package cli
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// TestProfileSandbox_HelperSubprocessLeavesNoBaseDir pins the profile sandbox
+// against the one exit path that bypasses TestMain's cleanup.
+//
+// Several tests in this package re-execute the test binary to get a real
+// subprocess (exitcode_guard_test.go, todo_test.go, launch_session_pid_exec_posix_test.go).
+// Each child runs TestMain, so each child used to mint its own
+// "moai-cli-profiles-*" directory — and every one of those helper bodies ends
+// in os.Exit, which returns through neither m.Run() nor the
+// restoreProfileBaseDir() call that follows it. The directory was therefore
+// created by design and removed by nobody: tens of thousands accumulated in
+// TMPDIR, one per helper invocation, until a plain readdir of the temp
+// directory took seconds.
+//
+// The child is given its own TMPDIR so this assertion measures only what this
+// test caused — no global count, nothing another lane's concurrent run can
+// perturb.
+func TestProfileSandbox_HelperSubprocessLeavesNoBaseDir(t *testing.T) {
+	childTmp := t.TempDir()
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestHelperProcess$")
+	cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1", "TMPDIR="+childTmp)
+	// The helper exits 3 by design; a non-nil error here is the expected shape.
+	_ = cmd.Run()
+
+	leaked, err := filepath.Glob(filepath.Join(childTmp, "moai-cli-profiles-*"))
+	if err != nil {
+		t.Fatalf("glob child TMPDIR: %v", err)
+	}
+	if len(leaked) != 0 {
+		t.Fatalf("helper subprocess left %d profile sandbox dir(s) behind in its TMPDIR: %v\n"+
+			"the child minted its own sandbox and exited through os.Exit, so TestMain's "+
+			"restoreProfileBaseDir() never ran — children must inherit the parent's sandbox instead",
+			len(leaked), leaked)
+	}
+}

--- a/internal/hook/quality/gate.go
+++ b/internal/hook/quality/gate.go
@@ -132,12 +132,17 @@ var toolchains = []langToolchain{
 	// Go: go.mod
 	{
 		markerFiles: []string{"go.mod"},
-		vetSteps:    []gateStep{{name: "go vet", binary: "go", args: []string{"vet", "./..."}}},
+		// sourceExts: a module with a go.mod but not one .go file yet is a
+		// scaffold, and `go vet ./...` / `go test ./...` exit non-zero there
+		// ("matched no packages"). Skipping keeps a first commit from being
+		// blocked for having no code — the same policy the Python steps carry.
+		vetSteps: []gateStep{{name: "go vet", binary: "go", args: []string{"vet", "./..."}, sourceExts: []string{".go"}}},
 		lintSteps: []gateStep{{
 			name: "golangci-lint", binary: "golangci-lint", args: []string{"run"}, optional: true,
 			configFiles: []string{".golangci.yml", ".golangci.yaml", ".golangci.toml", ".golangci.json"},
+			sourceExts:  []string{".go"},
 		}},
-		testStep: &gateStep{name: "go test", binary: "go", args: []string{"test", "./..."}},
+		testStep: &gateStep{name: "go test", binary: "go", args: []string{"test", "./..."}, sourceExts: []string{".go"}},
 	},
 	// Node.js (TypeScript/JavaScript): package.json
 	//
@@ -983,6 +988,15 @@ func (g *QualityGate) runStep(ctx context.Context, stepName string, timeout time
 	defer cancel()
 
 	cmd := exec.CommandContext(stepCtx, name, args...)
+	// Every step's arguments are cwd-relative ("./...", ".", a bare "test").
+	// Without an explicit Dir the child inherits the calling process's cwd,
+	// which is the project root only by coincidence — so a gate configured for
+	// one directory would grade another. Under `go test` that coincidence
+	// breaks: the cwd is the package under test, so a "go test ./..." step
+	// re-executes the suite that invoked it.
+	if dir := resolveQualityProjectDir(*g.config, "QualityGate.runStep"); dir != "" {
+		cmd.Dir = dir
+	}
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/internal/hook/quality/gate_step_cwd_test.go
+++ b/internal/hook/quality/gate_step_cwd_test.go
@@ -1,0 +1,60 @@
+package quality
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestRunStep_RunsInConfiguredProjectDir pins the working directory of every
+// quality-gate subprocess to the configured project dir.
+//
+// runStep used to build its exec.Cmd without setting cmd.Dir, so each step
+// ("go vet ./...", "golangci-lint run", "go test ./...", and their non-Go
+// counterparts — every one of which takes a cwd-relative target) ran in
+// whatever directory the calling process happened to occupy, not in
+// cfg.ProjectDir. In production the moai binary's cwd usually equals the
+// project root, which kept the defect latent; under `go test` the cwd is the
+// package directory of the test being run, so a gate pointed at a temp fixture
+// silently graded the real repository instead — and, when the step was
+// "go test ./...", re-executed the very suite that had invoked it. That
+// recursion is what filled TMPDIR with thousands of orphaned t.TempDir()
+// fixtures: each recursive test binary was killed before its cleanups ran.
+//
+// The fixture below carries a printf verb/arg mismatch that `go vet` reliably
+// flags. A step honouring cfg.ProjectDir fails on it and names the fixture
+// path; a step running anywhere else never sees bad.go at all.
+func TestRunStep_RunsInConfiguredProjectDir(t *testing.T) {
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go not on PATH — the vet step cannot run")
+	}
+
+	repo := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repo, "go.mod"), []byte("module sample\n\ngo 1.21\n"), 0o644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	vetBad := "package sample\n\nimport \"fmt\"\n\n// VetBad triggers go vet's printf verb/arg check.\nfunc VetBad() { fmt.Printf(\"%d\", \"string-arg\") }\n"
+	if err := os.WriteFile(filepath.Join(repo, "gate_cwd_probe.go"), []byte(vetBad), 0o644); err != nil {
+		t.Fatalf("write gate_cwd_probe.go: %v", err)
+	}
+
+	cfg := DefaultGateConfig()
+	cfg.ProjectDir = repo
+	g := NewQualityGate(cfg)
+
+	ok, output := g.runStep(context.Background(), "go vet", 60*time.Second, "go", "vet", "./...")
+	if ok {
+		t.Fatalf("runStep passed on a fixture whose only package fails `go vet` — the step did not run in cfg.ProjectDir (%s) but in the calling process's cwd", repo)
+	}
+
+	// `go vet` reports diagnostics relative to its own cwd, so the fixture dir
+	// never appears in the output — the fixture's uniquely-named file does, and
+	// only if the step actually ran there.
+	if !strings.Contains(output, "gate_cwd_probe.go") {
+		t.Fatalf("vet diagnostics do not name the fixture file — the step failed for some other reason, not on the fixture (%s).\noutput:\n%s", repo, output)
+	}
+}


### PR DESCRIPTION
## The shipped defect: `moai gate` grades the wrong tree

This is not a test-hygiene patch. `runStep` — the function every quality-gate step goes through — built its `exec.Cmd` without setting `cmd.Dir`, so **a gate told to check directory X checked the caller's cwd instead.**

Both sibling call sites in the same package already set it, which is what makes this an omission rather than a design:

```
gate.go:936-937           cmd.Dir = dir   (git diff --cached)
tool_registry.go:143-144  cmd.Dir = cwd   (RunTool)
gate.go:985               exec.CommandContext(stepCtx, name, args...)   ← nothing
```

Every step's arguments are cwd-relative — `go vet ./...`, `golangci-lint run`, `go test ./...`, and the equivalents for the other toolchains — so all of them inherited the wrong directory together. It stayed latent because the `moai` binary's cwd is usually the project root; run the gate from a worktree or a subdirectory and it silently grades a different tree. A pre-commit gate that reports on code you are not committing is worse than no gate, because it reports green.

An earlier SPEC (`HOOK-CWD-LEAK-AUDIT`) introduced `resolveQualityProjectDir` and routed this package's file-existence checks through it, but not the subprocess execution path. This closes that gap using the same SSOT.

The `$TMPDIR` flood this card was opened for is a *symptom* of that defect, not a separate bug.

## The symptom that surfaced it

`$TMPDIR` held 418,427 entries. Three prefixes accounted for the bulk, from **two** distinct causes:

| prefix | count at start | owning package | cause |
|---|---|---|---|
| `TestGateCmd_RunE_Behavior*` | 9,040 | `internal/hook/quality` | the defect above — the gate step re-ran the suite that invoked it |
| `go-build*` | 9,171 | same | one per killed recursive `go test` |
| `moai-cli-profiles-*` | 11,962 | `internal/cli` | unrelated — helper subprocess exits via `os.Exit`, bypassing TestMain cleanup |

Cleaning the existing 418k entries is out of scope; this stops new ones.

## How the recursion happened

Under `go test` the cwd is the package under test, so a gate pointed at a temp fixture graded the real repository — and its `go test ./...` step re-executed the suite that had invoked it. Observed live during the repro:

```
62542  01:49  cli.test -test.run=TestGateCmd_RunE_Behavior …    ← the test
65042  01:35  cli.test -test.testlogfile=… -test.timeout=10m0s  ← child: no -run filter, gate's own 10m deadline
77729  00:01  (cli.test)                                        ← grandchild
```

The leak follows: each recursive binary was killed before its `t.TempDir()` cleanups ran. The cleanup code exists and is correct — nothing reached it. `go-build*` tracks the same burst within 1% day by day (5,529 vs 5,493 on the peak day), so it was ours, not the toolchain's; the toolchain's own cache lives in `~/Library/Caches/go-build`.

**Fallout, fixed here:** pinning `cmd.Dir` broke five typecheck tests that had been passing *because* of the bug — their fixtures carry a `go.mod` and no `.go` file, where `go vet ./...` exits non-zero on `matched no packages`. The Go steps now carry `sourceExts`, the same skip the Python steps already had, so a scaffold that has declared its language but written no code is not blocked on its first gate.

## The profile sandbox (separate cause)

Five tests in `internal/cli` re-execute `os.Args[0]`; each child runs `TestMain` and mints its own `moai-cli-profiles-*` sandbox; every helper body ends in `os.Exit`, which returns through neither `m.Run()` nor the `restoreProfileBaseDir()` after it.

Children now inherit the parent's sandbox through the environment and remove nothing — ownership stays with the process that minted the directory. All five spawn sites already build the child env with `append(os.Environ(), …)`, so there are no call-site changes and future helpers are covered.

## Verification

Both regression tests assert by execution, not by grep. The gate test plants a uniquely-named file that `go vet` reliably flags and checks the step diagnoses it. The sandbox test gives the child its own `TMPDIR`, so it measures only what it caused and no concurrent lane can perturb it. (Go's `os.MkdirTemp` honours `$TMPDIR`; the BSD `mktemp` binary's disregard for it does not apply on this path.)

```
TestGateCmd_RunE_Behavior            120s timeout → 1.53s ok
  TMPDIR entries                     9,041 → 9,041   (0 new)
internal/cli helper-spawning group   ok 19.5s
  moai-cli-profiles-*                11,965 → 11,965 (0 new)
internal/hook/quality suite          22.1s → 6.9s, ok
go vet ./internal/cli/... ./internal/hook/quality/...   clean
```

## Not verified

The full `internal/cli` suite was not run locally — load average was 29 at the time, where the measurement reads the machine rather than the code. CI judges the full matrix. darwin only; the non-Go toolchain steps were not executed, though the `cmd.Dir` change applies to all of them identically.

The main residual risk is the mirror of the fallout above: other tests may also have been passing because the gate graded the real repo instead of their fixture. With `ProjectDir` empty the resolution is unchanged, so the exposure is limited to callers that set it.

Evidence: `.moai/reports/t213/verdict.md`

🗿 MoAI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed quality checks running from the wrong project directory, improving results for projects using relative paths.
  - Prevented temporary profile directories from being left behind after helper processes complete.
  - Skipped Go quality checks for scaffolds without Go source files.

- **Tests**
  - Added regression coverage for project-directory execution and temporary-directory cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->