### PR TITLE
docs(kanban): pre-dispatch PR cross-check + card id in PR titles (t210)

### DIFF
--- a/.claude/rules/moai/workflow/kanban-dispatch-detail.md
+++ b/.claude/rules/moai/workflow/kanban-dispatch-detail.md
@@ -1,5 +1,5 @@
 ---
-description: "Detail companion for kanban-dispatch.md — terminology, board table, card classes, dispatch-cycle naming, sync-gate review-lens table, /clear message structure, isolation rationale, verification-load incident record, sub-agent-first design intent, manager-lead working mode, per-card fan-out, Factory in-lane 3-stage"
+description: "Detail companion for kanban-dispatch.md — terminology, board table, card classes, dispatch-cycle naming, sync-gate review-lens table, /clear message structure, isolation rationale, verification-load incident record, sub-agent-first design intent, manager-lead working mode, per-card fan-out, Factory in-lane 3-stage, pre-dispatch cross-check rationale, PR-title carrier measurements"
 paths: "**/kanban-dispatch*.md,**/.claude/agents/moai/manager-lead.md,**/.claude/skills/moai/workflows/todo.md"
 ---
 
@@ -202,3 +202,33 @@ Sessions share one machine as surely as they share one checkout, and verificatio
 The never-spawn-background-load rule (normative statement lives in the stub) comes from the same incident's second cause: a verification recipe started eight spin loops to test behaviour under CPU contention and placed its kill line *after* the long test command. The agent finished before reaching it, and twelve spinners ran orphaned for thirty-seven minutes.
 
 The same day supplied the reason contention and flakiness feed each other: a failing test left an unbounded spin-loop goroutine running, which burned a core for the remainder of that package's run and slowed every test after it. Load makes tests fail; failing tests can generate load.
+
+## The pre-dispatch cross-check
+
+The stub's two [HARD] clauses are the rule; this section is why each is worded the way it is.
+
+**The failure was not a misread — it was that nothing required looking.** Several cards sat `queued` while each already carried an open pull request, and one sat `queued` while its fix was already an ancestor of the integration branch. The second was discovered only after a lane had started work on it, which cost the whole lane — the only sub-case in the record with a quantified cost. A lead with perfect tooling available would still have dispatched blind, because reading was optional.
+
+**Why "reports, never vetoes" is a separate clause with its own criterion.** The obligation to look and the prohibition on acting are different rules, and the second is the fragile one. The operator has already picked the card; a lead that then withholds the dispatch because it found an open pull request has overridden an operator act rather than informing one — the same de-facto-authority hazard the read-only ruling on the queue tooling exists to prevent.
+
+The hazard is invisible after the fact. A clause requiring the lead to read and report, and a clause authorizing the lead to refuse, produce identical transcripts up to the moment the card does not move; nothing downstream distinguishes "the operator withdrew it" from "the lead declined to send it". No mechanical check can separate the two readings, so the wording is the only control there is — which is why the literal `confirms or withdraws` is pinned by its own acceptance criterion rather than folded into the obligation clause.
+
+**The tooling is a convenience, not the obligation.** `moai todo pr <id>` answers both halves in one read, but the clause is satisfiable by hand (`gh pr list`, then `git log` against the integration branch) and was written to be: the doctrine landed before the tooling, and the interval between them is a real operating condition rather than a paper one.
+
+## The PR-title carrier
+
+**Why the id leaves the branch name and lands on the PR title.** Neither name can serve both readers. The branch name is read by a human scanning `git branch` or a pull-request list, who learns nothing from an opaque card id and everything from a descriptive slug. The PR title is read by a resolver mapping pull requests back to cards, which needs a token it can match exactly. The branch-name rule and the title rule therefore assign different jobs to different names, and a reader meeting both [HARD] clauses cold will suspect a contradiction where there is none — which is why the stub states the non-contradiction outright instead of leaving it to be inferred.
+
+**The carrier measurements.** Scanning a set of open pull requests for card tokens, three carriers behave differently:
+
+| carrier | recall | precision | verdict |
+|---|---|---|---|
+| PR title | ~64% | every token present named the delivering card | precise, incomplete |
+| PR body | complete | poor — one pull request carried five tokens for one card | complete, noisy |
+| commit messages | high, and **wrong** on the worst case | worst of the three | unusable for attribution |
+
+The commit carrier deserves its own note, because it is the one the isolation rule already makes [HARD]. A branch that merges the integration branch inherits every other card's commits, so its token set scales with integration rather than with the card: in the measured worst case a pull request carried a dozen-plus card tokens and its own delivering card was **not among them**. Being mandated as a traceability carrier does not make it a usable attribution index.
+
+**The fix for ambiguous parsing is a naming convention, not a smarter parser.** The title carrier is already the precise one — where a token is present, it names the delivering card. It is incomplete only because nothing required it. Requiring it is what turns a resolver from a heuristic into a lookup, and no amount of parser sophistication substitutes for the missing token.
+
+**Why a token in a batch pull request's title would be worse than none.** A release or batch pull request delivers no single card. A card token in such a title would name a card the pull request does not deliver, and a resolver reading titles would attribute confidently and wrongly — a silent error, where the absent token merely leaves the card unresolved and visible as such. The scope restriction is therefore load-bearing, not politeness.

--- a/.claude/rules/moai/workflow/kanban-dispatch.md
+++ b/.claude/rules/moai/workflow/kanban-dispatch.md
@@ -30,11 +30,9 @@ Five columns, fixed and ordered: `backlog → plan → run → sync → done`. `
 
 [HARD] **The lead may attach a finding; it may not act on one.** Analysis runs automatically and records a relation between two cards — a near-duplicate the machine measured on `add` or `analyze`, or a `contains` / `absorbs` / `replaces` / `conflicts` the lead judged and wrote with `moai todo relate`. The record is evidence the operator reads, never a mandate: the lead never folds the related card away, never reorders the queue around it, and never drops or edits it. Analysis changes exactly one thing on its own authority — it refuses the admission of a card whose normalized text is identical to one already queued or picked, which creates no card and leaves the queue file byte-identical. Everything a finding suggests beyond that refusal is the operator's act.
 
-[HARD] **The pre-dispatch PR cross-check.** Before dispatching a card out of `backlog`, the lead reads that card's pull-request and landed state and reports what it read in the same turn — the open pull request that already carries the card, or the fact that its work is already in the integration branch. `moai todo pr <id>` answers both in one read; by hand it is a `gh pr list` plus a `git log` against the integration branch. What is reported is what was read, per § Completion is read, never trusted: an unchecked card is a gap, not a clean card.
+[HARD] **The pre-dispatch PR cross-check.** Before dispatching a card out of `backlog`, the lead reads that card's pull-request and landed state and reports what it read in the same turn. `moai todo pr <id>` answers both; by hand it is `gh pr list` plus a `git log` against the integration branch. An unchecked card is a gap, not a clean card (§ Completion is read, never trusted).
 
-[HARD] **The cross-check reports; it never vetoes.** Where a card turns out to carry an open pull request, or to be already landed, the lead surfaces that to the operator and the operator **confirms or withdraws** the card. The lead does not withhold the dispatch on its own authority. The operator has already picked this card, and promotion is the operator's act, always — a lead that refuses a picked card because it found something has overridden an operator act rather than informing one. Hand the decision back; the check produces evidence, never authority.
-
-The failure this closes was not a lead that looked and misread. It was that nothing required looking: cards sat queued while each already carried an open pull request, and one sat queued while its fix was already an ancestor of the integration branch — discovered only after a lane had started, which cost the whole lane.
+[HARD] **The cross-check reports; it never vetoes.** Where the card carries an open pull request or is already landed, the lead surfaces that and the operator **confirms or withdraws** it. The lead never withholds a picked card on its own authority — promotion is the operator's act, always. Why the wording is the only available control, and the incident it closes: `kanban-dispatch-detail.md` § The pre-dispatch cross-check.
 
 ## Report milestones ↔ queue cards
 
@@ -172,18 +170,9 @@ The **worktree directory keeps the card id** (`.claude/worktrees/<card-id>`). On
 
 A lane that reports a branch name without also reporting its card id has not reported the card. Merges reference the `WT-` name; the lead maps it back through the `card:` field it dispatched.
 
-[HARD] **A card-delivering pull request's PR title MUST carry the delivering card id — and this does not contradict the branch-name rule above.** The two clauses give different jobs to different names, so a reader meeting both cold should not suspect a conflict: the branch name is read by a human scanning `git branch`, and wants a descriptive slug; the PR title is read by a machine resolving cards to pull requests, and wants the id. Neither name can serve both readers, which is why the id leaves one and lands on the other.
+[HARD] **A card-delivering pull request's PR title MUST carry the delivering card id** — and this does not contradict the branch-name rule above: the branch name is read by a human scanning `git branch` and wants a slug; the PR title is read by a machine and wants the id. Traceability therefore rests on **four** carriers rather than the three above — the dispatch `card:` field, the commit message, the evidence path, and the PR title, the only machine-readable one.
 
-Traceability therefore rests on **four** carriers rather than the three above, and the PR title is the only machine-readable one:
-
-- the dispatch's `card:` field — the address the lead sent;
-- the card id in every commit message on the branch — `git log` recovers the card without the branch name;
-- the card id in the evidence path;
-- the card id in the **PR title** of the pull request that delivers the card.
-
-The obligation binds card-delivering pull requests only. A release pull request, a batch pull request rolling several cards up, and a maintenance pull request that delivers no card carry no card id and no obligation — a card token in such a title would name a card the pull request does not deliver, which is worse than no token. The clause binds pull requests opened after it lands; open and already-merged pull requests are not retitled.
-
-The fix for ambiguous card-to-pull-request parsing is a naming convention, not a smarter parser. The title carrier is the precise one — where a token is present it names the delivering card — and it is incomplete only because nothing required it. Requiring it is what makes the resolver a lookup rather than a heuristic.
+The obligation binds card-delivering pull requests only; a release, batch, or maintenance pull request delivers no card and carries none. It binds pull requests opened after it lands — nothing is retitled. Rationale and the carrier measurements: `kanban-dispatch-detail.md` § The PR-title carrier.
 
 The lead dispatches this rather than assuming it: each instruction names the worktree and says to drive it with `git -C <path>` rather than `cd` — a `cd` inside a compound command lasts for that invocation only, so the next command silently reads the wrong tree. A companion reporting it worked in the shared checkout is a fault to report, not a detail to tidy up (rationale: `kanban-dispatch-detail.md` § Isolation rationale).
 

--- a/.claude/rules/moai/workflow/kanban-dispatch.md
+++ b/.claude/rules/moai/workflow/kanban-dispatch.md
@@ -30,6 +30,12 @@ Five columns, fixed and ordered: `backlog → plan → run → sync → done`. `
 
 [HARD] **The lead may attach a finding; it may not act on one.** Analysis runs automatically and records a relation between two cards — a near-duplicate the machine measured on `add` or `analyze`, or a `contains` / `absorbs` / `replaces` / `conflicts` the lead judged and wrote with `moai todo relate`. The record is evidence the operator reads, never a mandate: the lead never folds the related card away, never reorders the queue around it, and never drops or edits it. Analysis changes exactly one thing on its own authority — it refuses the admission of a card whose normalized text is identical to one already queued or picked, which creates no card and leaves the queue file byte-identical. Everything a finding suggests beyond that refusal is the operator's act.
 
+[HARD] **The pre-dispatch PR cross-check.** Before dispatching a card out of `backlog`, the lead reads that card's pull-request and landed state and reports what it read in the same turn — the open pull request that already carries the card, or the fact that its work is already in the integration branch. `moai todo pr <id>` answers both in one read; by hand it is a `gh pr list` plus a `git log` against the integration branch. What is reported is what was read, per § Completion is read, never trusted: an unchecked card is a gap, not a clean card.
+
+[HARD] **The cross-check reports; it never vetoes.** Where a card turns out to carry an open pull request, or to be already landed, the lead surfaces that to the operator and the operator **confirms or withdraws** the card. The lead does not withhold the dispatch on its own authority. The operator has already picked this card, and promotion is the operator's act, always — a lead that refuses a picked card because it found something has overridden an operator act rather than informing one. Hand the decision back; the check produces evidence, never authority.
+
+The failure this closes was not a lead that looked and misread. It was that nothing required looking: cards sat queued while each already carried an open pull request, and one sat queued while its fix was already an ancestor of the integration branch — discovered only after a lane had started, which cost the whole lane.
+
 ## Report milestones ↔ queue cards
 
 [HARD] **A milestone-bearing report under `.moai/reports/` carries a `## Card Cross-Check` section** — one table row per milestone, a `card` column holding the delivering card id or an explicit new-card marker. A mapping claim is verified against the queue (`moai todo`), never remembered. Before the lead turns a report into card requests, the request message states the full comparison — `N milestones → N cards` — naming every milestone with no card in the live queue. Detail: `kanban-dispatch-detail.md` § Report milestones ↔ queue cards.
@@ -165,6 +171,19 @@ The **worktree directory keeps the card id** (`.claude/worktrees/<card-id>`). On
 - The evidence path keeps the card id (`.moai/reports/<card-id>/verdict.md`).
 
 A lane that reports a branch name without also reporting its card id has not reported the card. Merges reference the `WT-` name; the lead maps it back through the `card:` field it dispatched.
+
+[HARD] **A card-delivering pull request's PR title MUST carry the delivering card id — and this does not contradict the branch-name rule above.** The two clauses give different jobs to different names, so a reader meeting both cold should not suspect a conflict: the branch name is read by a human scanning `git branch`, and wants a descriptive slug; the PR title is read by a machine resolving cards to pull requests, and wants the id. Neither name can serve both readers, which is why the id leaves one and lands on the other.
+
+Traceability therefore rests on **four** carriers rather than the three above, and the PR title is the only machine-readable one:
+
+- the dispatch's `card:` field — the address the lead sent;
+- the card id in every commit message on the branch — `git log` recovers the card without the branch name;
+- the card id in the evidence path;
+- the card id in the **PR title** of the pull request that delivers the card.
+
+The obligation binds card-delivering pull requests only. A release pull request, a batch pull request rolling several cards up, and a maintenance pull request that delivers no card carry no card id and no obligation — a card token in such a title would name a card the pull request does not deliver, which is worse than no token. The clause binds pull requests opened after it lands; open and already-merged pull requests are not retitled.
+
+The fix for ambiguous card-to-pull-request parsing is a naming convention, not a smarter parser. The title carrier is the precise one — where a token is present it names the delivering card — and it is incomplete only because nothing required it. Requiring it is what makes the resolver a lookup rather than a heuristic.
 
 The lead dispatches this rather than assuming it: each instruction names the worktree and says to drive it with `git -C <path>` rather than `cd` — a `cd` inside a compound command lasts for that invocation only, so the next command silently reads the wrong tree. A companion reporting it worked in the shared checkout is a fault to report, not a detail to tidy up (rationale: `kanban-dispatch-detail.md` § Isolation rationale).
 

--- a/.claude/rules/moai/workflow/kanban-dispatch.md
+++ b/.claude/rules/moai/workflow/kanban-dispatch.md
@@ -170,7 +170,7 @@ The **worktree directory keeps the card id** (`.claude/worktrees/<card-id>`). On
 
 A lane that reports a branch name without also reporting its card id has not reported the card. Merges reference the `WT-` name; the lead maps it back through the `card:` field it dispatched.
 
-[HARD] **A card-delivering pull request's PR title MUST carry the delivering card id** — and this does not contradict the branch-name rule above: the branch name is read by a human scanning `git branch` and wants a slug; the PR title is read by a machine and wants the id. Traceability therefore rests on **four** carriers rather than the three above — the dispatch `card:` field, the commit message, the evidence path, and the PR title, the only machine-readable one.
+[HARD] **A card-delivering pull request's PR title MUST carry the delivering card id** — and this does not contradict the branch-name rule above: the branch name is read by a human scanning `git branch` and wants a slug; the PR title is read by a machine and wants the id. Traceability therefore rests on **four** carriers rather than the three above — the dispatch `card:` field, the commit message, the evidence path, and the PR title — the only one a resolver can read off the pull-request surface itself, where the dispatch `card:` field (also machine-readable) does not reach.
 
 The obligation binds card-delivering pull requests only; a release, batch, or maintenance pull request delivers no card and carries none. It binds pull requests opened after it lands — nothing is retitled. Rationale and the carrier measurements: `kanban-dispatch-detail.md` § The PR-title carrier.
 

--- a/.moai/reports/t210/measurement.md
+++ b/.moai/reports/t210/measurement.md
@@ -1,0 +1,110 @@
+# t210 — plan-phase measurement record
+
+Base: origin/main `cd0cee1b8` (dispatch named `f7d4b7824`; verified ancestor — the base is newer, not divergent).
+All commands below were run read-only from `.claude/worktrees/t210`.
+
+## M1 — the premise reproduces
+
+`CLAUDE_PROJECT_DIR=<primary> moai todo list` against the live queue, cross-read
+against `gh pr list --state open`:
+
+| card | queue state | open PR | verdict |
+|---|---|---|---|
+| t88  | picked | #1619 | in flight, queue agrees |
+| t200 | queued | #1612 | **divergent** |
+| t201 | queued | #1611 | **divergent** |
+| t202 | queued | #1613 | **divergent** |
+| t203 | queued | #1614 | **divergent** |
+| t205 | queued | #1617 | **divergent** |
+
+5 of the 6 named cards reproduce the lead's finding. t88 had already been picked
+by the time this lane measured, so the live divergence count is 5, not 6.
+
+## M2 — every open PR carries a card token, but no carrier is both complete and precise
+
+`gh pr list --state open` (11 PRs), scanning title / body / commit messages for `\bt[0-9]{1,4}\b`:
+
+| PR | title token | body tokens | commit-message tokens | delivering card |
+|---|---|---|---|---|
+| 1621 | t211 | t211 | t211 | t211 |
+| 1619 | — | t88 | t184,t187,t204,t83,t88 | t88 |
+| 1617 | t205 | t205 | t205 | t205 |
+| 1614 | t203 | t1,t151,t203,t69,t9 | t151,t203,t69 | t203 |
+| 1613 | t202 | t202 | t202 | t202 |
+| 1612 | t200 | t200,t201 | t200 | t200 |
+| 1611 | — | t201 | t201 | t201 |
+| 1606 | t187 | t187,t192 | t184,t187 | t187 |
+| 1605 | t194 | t181,t194 | t181,t194 | t194 |
+| 1601 | — | t188 | t188 | t188 |
+| 1600 | — | t184 | t127,t131,t142,t158,t159,t164,t165,t170,t171,t173,t81,t82,t83,t89,t91 | t184 |
+
+Carrier scorecard (n=11):
+
+- **PR title** — precision 7/7 (every token present is exactly the delivering
+  card), recall 7/11 (64%). Precise, incomplete.
+- **PR body** — recall 11/11 (100%), precision poor: 5 PRs carry extra tokens,
+  #1614 carries 5 tokens for 1 card. Complete, noisy.
+- **commit messages** — recall 10/11, and **wrong on #1600**, whose 15 tokens do
+  not include its delivering card t184. A branch that merges the release branch
+  inherits every other card's commits, so the noise scales with integration
+  rather than with the card. The worst carrier of the three, despite being the
+  one `kanban-dispatch.md` § Isolation already makes [HARD].
+
+Consequence for the design: a reverse index over the PR **body** finds every card
+but mislabels several; over the **title** it never mislabels but misses four.
+Neither is usable alone. This is a measurement, not a preference.
+
+## M3 — the queue already has a "record, never mutate" precedent
+
+`.claude/skills/moai/workflows/todo.md` § What the analyser may do carries a
+[HARD] clause: analysis "never folds one card into another, never reorders the
+queue, never drops a card, and never edits one... Acting on a record is the
+operator's act." The `findings[]` array in `backlog.json` holds observations
+ABOUT cards without touching them.
+
+That precedent settles the boundary question the dispatch raised: an observation
+surface already exists in this subsystem and is already fenced off from mutation.
+
+## M4 — no existing card↔PR machinery
+
+`grep -rn 'gh pr' internal/ --include=*.go` finds `gh` used for PR *state* checks
+(`session_worktree_prmerge.go`, `branch_protection.go`, `internal/github/gh.go`,
+`internal/statusline/forge.go`) but nothing mapping a card id to a PR. The index
+would be new.
+
+## Gaps (explicitly not measured)
+
+- Closed/merged PRs were not scanned — only `--state open`. A card whose PR has
+  already merged (the t199 case the dispatch names) is a different query, and its
+  carrier statistics are unmeasured.
+- `gh` latency was not measured. A per-render network call may be too slow for
+  `moai todo list`, which is documented as lock-free and cheap.
+- Whether a non-GitHub forge (the `glab` path `internal/statusline/forge.go`
+  contemplates) needs the same index is unexamined.
+
+## M5 — `gh` latency closes one of the gaps above
+
+    time gh pr list --state open --limit 40 --json number,title,body
+    → 0.878s total (0.14s user, 0.06s sys — the rest is network)
+
+Roughly nine-tenths of a second per query, all of it round-trip. `moai todo list`
+is documented as lock-free and cheap; making it pay ~0.9s of network on every
+render would change that character. This argues for a dedicated read verb or an
+opt-in flag rather than a default-on column, and it is a measurement rather than
+a preference.
+
+## M6 — the title convention is already emergent practice
+
+`gh pr list --state merged --limit 15`: 8 of 15 merged PR titles carry a card
+token. Of the 7 that do not, most deliver no card at all — `release: v3.1.3`,
+the v3.1.3 batch PR, and three `chore(release-update)` entries. Among merged PRs
+that do deliver a single card, the title token is close to universal.
+
+REQ-3(b) is therefore codification of a convention the repository already mostly
+follows, not a new burden imposed on contributors.
+
+## Remaining gaps after M5/M6
+
+- Merged-PR carrier statistics were sampled (M6) but not scored for precision the
+  way M2 scores the open set. The merged-side query stays out of scope.
+- Non-GitHub forge support remains unexamined.

--- a/.moai/reports/t210/verdict-2.md
+++ b/.moai/reports/t210/verdict-2.md
@@ -1,0 +1,371 @@
+# SPEC Review Report: t210 (two SPECs)
+
+Iteration: **2/2** (Tier M ceiling — final iteration)
+
+| SPEC | Tier | Threshold | Score | Verdict |
+|---|---|---|---|---|
+| `SPEC-KANBAN-QUEUE-PR-SYNC-001` | M | 0.80 | **0.801** | **PASS (marginal)** |
+| `SPEC-KANBAN-PR-CARD-TRACEABILITY-001` | S | 0.75 | **0.775** | **PASS (marginal)** |
+
+Reasoning context ignored per M1 Context Isolation. The dispatch's framing of what
+the author fixed was not treated as evidence; every disposition below rests on the
+pinned artifact files plus commands re-run in this worktree. Where the dispatch
+implied a defect (REQ-1.10 "a wish", AC-011 "vacuous"), I tested the implication
+and, on both, **found against it** — reasons in §3.
+
+**Both margins are thin — 0.001 and 0.025 — which is inside the resolution of my
+own scoring. Do not read either PASS as comfortable.** The verdict rests on the
+seven must-pass criteria (all pass on both SPECs) and on eighteen iteration-1
+findings being genuinely closed (§2). What the margins do not excuse is four
+blocking findings that survive (N1-N4). Each is a one-to-five-line edit; §8 says
+exactly what remains.
+
+---
+
+## 1. Pin verification
+
+Verified before the audit and again immediately before writing this verdict.
+
+```
+$ git status --short
+                                   (empty — no tracked drift, both times)
+$ git rev-parse HEAD
+22c3df39e5d2c514111720f494fbe5ac72d0f833
+$ git ls-tree -r HEAD .moai/specs/SPEC-KANBAN-QUEUE-PR-SYNC-001/ \
+                      .moai/specs/SPEC-KANBAN-PR-CARD-TRACEABILITY-001/
+06a2fc85f4a91e7962c437a01c37a17425ee215f  PR-CARD-TRACEABILITY-001/plan.md
+b8874230cdfcb6472c28eceddcfc9c32e11f3ed6  PR-CARD-TRACEABILITY-001/progress.md
+776bc491d19c2a6410f0d136053b93943c0d820f  PR-CARD-TRACEABILITY-001/spec.md
+4a81edacc7fe0c5de9a25012d6e40d3beb2f52a6  QUEUE-PR-SYNC-001/acceptance.md
+cea4c1075b9e98599ab2846064668e146ef5c8a6  QUEUE-PR-SYNC-001/plan.md
+5c8acfd18ca4bf71c6ee1d49ee4c87f90f0d8a7f  QUEUE-PR-SYNC-001/progress.md
+7ab347efd05e78fa44f8085c4ee51410caf18216  QUEUE-PR-SYNC-001/spec.md
+```
+
+All seven blobs match the dispatch's expected set, both times. The
+content-addressed freeze held; iteration 1's failure mode did not recur.
+
+---
+
+## 2. Iteration-1 finding disposition (D1-D18)
+
+Each verified independently. "The author says it is fixed" was not accepted as
+evidence for any row.
+
+| # | Disposition | Evidence |
+|---|---|---|
+| **D1** frontmatter `tags` | **closed** | `spec.md`:L13 `tags: "kanban, todo, github, observability, read-only"` (quoted string). `moai spec lint <spec.md> --json` → `[]` EXIT=0 on **both** SPECs — the file now parses, so the empty array is meaningful rather than suppressed. |
+| **D2** scope-motivation | **closed**, via option (c) | §A:L39-58 now records both failure shapes and the one-lane cost, and states why a merged-PR extension does not reach t199. §C.2 + REQ-1.9 adopt the landed carrier. §F:L311-320 narrows the exclusion to *merged-PR attribution* and says so. This is the fix that actually closes the incident, not the cheap one. |
+| **D3** veto vs re-decide | **closed** | Doctrine `spec.md`:L62-73 carries the prescribed wording verbatim — *"until the operator, so informed, confirms or withdraws it"* — plus the reasoning against line 29, plus the explicit note that no mechanical check can tell the readings apart. |
+| **D4** refuted fixtures | **closed**, re-verified live | I re-ran the fixture command today. `t188` → body of #1601 only, no title. `t201` → bodies of #1611 and #1612, no title. `t200` → title of #1612. All three assignments in AC-001/002/003 hold against current data. |
+| **D5** `--pr` MAY | **closed** | REQ-2.5:L272-273 *"No `--pr` flag on `moai todo list` is in scope"*; the option moved to §H (non-normative); AC-009:L175-177 records the whole-claim consequence. `grep -icE '\bmay\b\|\bshould\b'` over the 16 requirement lines → **0**. |
+| **D6** precedent omission | **closed** | §B.1:L81-91 cites the third [HARD] clause at line 31 verbatim and names it as REQ-2.1's wording source. |
+| **D7** AC-004 coverage | **closed** | AC-004 is now a recursive digest over `.moai/state/kanban/` with a path-set assertion (no sidecar, no lock), extended over the fail-open, ambiguous, and landed paths. |
+| **D8** REQ numbering | **open** (optional), now **aggravated** | Still `REQ-1.1`…`REQ-2.6`. The sibling authored in the same pass uses canonical `REQ-001`…`REQ-004`, so one card now ships two incompatible id schemes. `moai spec lint` tolerates both. See N9. |
+| **D9** `Where`→`While` | **closed** | REQ-1.2/1.3/1.4 all open with `**While**`. |
+| **D10** non-normative trailers | **closed** | REQ-2.1 *"and shall write no field, no `findings[]` entry, and no timestamp"*; REQ-2.4 *"and `moai todo list` shall remain lock-free, network-free…"* — both promoted to `shall`, neither dropped. |
+| **D11** AC-005 disjunction | **closed** | AC-005:L113-114 — *"renders **empty** for every card (not omitted — the column is present and blank)"*. |
+| **D12** grep tail untested | **closed in tooling; partially closed in doctrine** | AC-013 is split into a mechanical half and a labelled reviewer-judgement half. In the doctrine SPEC AC-001 and AC-002 are correctly split, **but AC-003's `**Mechanical.**` block still claims the four-carrier check with no command covering it** → N4. |
+| **D13** AC-006 count | **closed** | The "15 tokens" figure is gone; AC-006:L138-142 states only the load-bearing property. |
+| **D14** tier budget | **closed structurally, zero headroom** | 19 → 16 (measured) + a Tier S sibling at 4/8. But the split lost a requirement (N3) and the tooling SPEC sits at exactly 16/16, so the missing template-mirror requirement (N1) **cannot be added without breaching the ceiling**. The pressure D14 named is absorbed exactly, not relieved. |
+| **D15** mirror split | **closed** | AC-013 covers both `todo.md` copies; doctrine AC-004 covers both `kanban-dispatch.md` copies. Division is correct — tooling keeps `todo.md`, doctrine takes `kanban-dispatch.md`. |
+| **D16** REQ-1.5 over-general | **closed — genuinely, not relabelled** | See §3.1. |
+| **D17** `-E` boundary | **closed** | REQ-1.9 mandates `--perl-regexp` and names `-E` as forbidden with the reason. AC-011 carries three controls. `plan.md` §B:L32-35 and §G:L129-130 both name it. |
+| **D18** REQ-1.8 confirmed | **carried** | AC-008 unchanged and still sound. |
+
+**Regressions: none.** No previously-closed finding reopened.
+
+---
+
+## 3. The new material, attacked
+
+### 3.1 Does the Q1/Q2 split dissolve D16, or relabel it?
+
+**It dissolves it.** Three independent pieces of evidence, not one:
+
+1. REQ-1.5's prohibition is scoped in the requirement text itself — *"when
+   attributing an open pull request to a delivering card (question Q1)"* — not in
+   a footnote that an implementer can skip.
+2. REQ-1.9 **affirmatively mandates** the commit carrier for Q2. A relabelling
+   would narrow the ban and leave Q2 unspecified; this creates the counterpart
+   obligation.
+3. `plan.md` §G:L133-134 names *"Extending REQ-1.5's commit-message ban to the
+   landed check"* as an anti-pattern by name. The run phase is warned in the
+   direction the defect actually pointed.
+
+**Does any requirement silently apply Q1's reasoning to Q2?** I checked all 16.
+It does not. The one place the two touch is REQ-1.9's guard (*"While no open pull
+request carries the card id token in its title or body"*), which is a
+**sequencing** rule, not Q1 reasoning leaking. It has its own consequence — N7.
+
+### 3.2 Is REQ-1.10's boolean-only constraint enforceable, or a wish?
+
+**Enforceable, by construction. I find against the dispatch's framing here.**
+
+The prohibition is not a behavioural request that an implementation might quietly
+ignore — it is a constraint on the **shape of the returned type**, and AC-012
+asserts exactly that: *"the returned record contains no commit SHA, no commit
+subject, and no field naming a delivering commit."* A record type with no such
+field cannot report a delivering commit; there is nothing to report it with.
+`plan.md` M2 reinforces it at the implementation layer (*"returning a boolean and
+nothing else"*).
+
+Compare a genuinely unenforceable prohibition — "the resolver shall not mislead
+the operator" — which no test can observe. This one is observable by inspecting
+the type. The dispatch's worry ("an unenforceable prohibition reads as a
+guarantee") is the right worry applied to the wrong requirement.
+
+One real weakness survives, and it is smaller: AC-012's second clause — *"the
+public resolver API exposes no accessor that would return one"* — has no stated
+verb, and unlike AC-013 and the doctrine SPEC's ACs it is **not labelled a
+judgement**. It is mechanizable in Go (reflect over the exported fields), but the
+SPEC neither says so nor admits it is a judgement. → **N8**.
+
+### 3.3 Can AC-011's `-E` tripwire pass vacuously?
+
+**No.** I traced the logic rather than the intent, and the trap the dispatch
+describes is closed by the positive control, not by the tripwire.
+
+The criterion has three parts. Part A asserts the query string carries
+`--perl-regexp`. Part B pins the control's own assumption (`-E` returns empty for
+`t199`) — so if a future git made `\b` work under `-E`, the assumption breaks
+*loudly* rather than silently. Part C fails the test when the implementation's
+result matches the `-E` result on the positive control.
+
+Three broken implementations, each caught:
+
+| Broken implementation | What catches it |
+|---|---|
+| uses `-E` | result is empty; matches the `-E` result on the positive control → Part C fails. Also: the positive control itself requires `t199` → `landed` with a **non-empty** commit set. |
+| returns `landed` unconditionally | the negative control (`t205` → `no-link`, empty set) fails. |
+| returns `no-link` unconditionally | the positive control fails. |
+
+The dispatch's concern — "an assertion comparing against an empty result may
+itself be satisfiable by a broken implementation" — would hold if Part C were the
+*only* assertion. It is not: the positive control independently demands a
+non-empty result, so the comparison is a second line of defence rather than the
+first. I re-ran the baseline and it reproduces:
+
+```
+$ git log origin/main --perl-regexp --grep='\bt199\b' --oneline | wc -l   → 3
+$ git log origin/main -E           --grep='\bt199\b' --oneline | wc -l   → 0
+$ git log origin/main --perl-regexp --grep='\bt205\b' --oneline | wc -l   → 0
+```
+
+AC-011 is the best-constructed criterion in either SPEC. One ambiguity attaches
+to it → **N6**.
+
+### 3.4 The Tier S SPEC's four inline ACs
+
+**The grep-shaped halves do real work.** I confirmed all three zero baselines
+myself today, in this tree:
+
+```
+$ grep -c 'pre-dispatch PR cross-check'                .../kanban-dispatch.md   → 0
+$ grep -c 'confirms or withdraws'                      .../kanban-dispatch.md   → 0
+$ grep -c 'PR title MUST carry the delivering card id' .../kanban-dispatch.md   → 0
+```
+
+Zero on the pre-implementation tree is the project's admissibility bar, and all
+three clear it. These are not the "grep a word already in the prose" pattern.
+AC-001's second grep (`\[HARD\].*pre-dispatch PR cross-check`) is a genuine
+addition — it makes the marker observable rather than asserted — and `plan.md`
+§B:L27-29 warns that it is order-sensitive, which is the kind of self-aware
+detail that keeps a correct clause from failing its own criterion.
+
+**Are the judgement halves honestly labelled?** Two of three, yes — AC-001 and
+AC-002 both carry *"Reviewer judgement (recorded as such)"* and AC-001 adds *"No
+command verifies this, and this SPEC does not claim one does."* That is exactly
+what D12 asked for.
+
+**AC-003 is the exception and it is a D12-shape relapse.** Its `**Mechanical.**`
+block reads *"After M1 that grep returns at least 1, **and the same section names
+all four traceability carriers**"* — and the code block underneath carries one
+grep, which covers the first clause only. The four-carrier claim is a judgement
+sitting under a Mechanical heading. It is *also* stated correctly in the judgement
+half below, so no honesty is lost in substance — but the label is wrong, in the
+one SPEC that exists because mislabelled judgements were a blocking finding.
+→ **N4**.
+
+### 3.5 The 16/16 count and the REQ-2.6 consolidation
+
+**The consolidation is genuine, not a staple.** I expected to find otherwise.
+
+REQ-2.6 joins two clauses with a semicolon — render outcome+confidence in both
+forms; the JSON form carries these five fields. The test for a staple is whether
+the second clause is an independent obligation or an elaboration of the first.
+**The document's own precedent settles it**: REQ-1.1 already enumerates five
+fields of a returned record inside one requirement, and nobody counts that as five
+requirements. REQ-2.6 does the same thing for the render surface. Applying a
+stricter standard to REQ-2.6 than to REQ-1.1 would be inventing a rule to
+manufacture a finding.
+
+What I will not soften: **the budget fits exactly, with zero headroom, and that
+is load-bearing.** The tooling SPEC is at 16/16 requirements. N1 identifies a
+missing normative requirement (the template mirror). It cannot be added without
+tiering up or splitting again. So D14's pressure was absorbed to the last slot
+rather than relieved, and the run phase inherits a document that cannot take one
+more requirement.
+
+**Tier S is genuinely Tier S.** Two files changed, zero Go code, 4 requirements
+against a ceiling of 8, 4 criteria against 8, artifact set spec.md + plan.md with
+ACs inline — matches the S row of `spec-workflow.md` § SPEC Complexity Tier on
+every axis.
+
+### 3.6 Did the split drop anything?
+
+**Yes — one requirement, and it left an orphaned criterion behind.** Mapping the
+old REQ-3 block (blob `313a5c31a`) against the new SPEC:
+
+| old | new | status |
+|---|---|---|
+| REQ-3.1 (read + report before dispatch) | REQ-001 **+** REQ-002 | preserved and split, improved per D3 |
+| REQ-3.2 (PR title carries card id) | REQ-003 | preserved, scoped to card-delivering PRs |
+| REQ-3.3 (non-contradiction note) | REQ-004 | preserved, extended to name four carriers |
+| **REQ-3.4 (template mirror obligation)** | **— none —** | **dropped from the requirement layer** |
+
+The obligation survives as doctrine AC-004, `plan.md` §D, and milestone M3 — so
+nothing is unimplemented. But AC-004 now references no requirement, and the Tier S
+SPEC had **four unused requirement slots**, so no budget pressure explains the
+drop. → **N3**.
+
+Everything else divides correctly: the `todo.md` mirror stayed with the tooling
+SPEC (AC-013), the `kanban-dispatch.md` mirror went with the doctrine (AC-004),
+and cross-references resolve in both directions (4 refs each way in the spec
+bodies; both siblings `status: draft`, neither retired or superseded).
+
+### 3.7 The self-declared gaps
+
+**Pinned fixtures vs. a PR set that has grown to 12.** I judge the pinning
+**sound engineering, not rationalized staleness**, and the anti-pattern label is
+correct. The reason is that v0.1.1's fixtures were refuted by *misdescription*,
+not by drift: AC-002 asserted `inferred` for a token that already appeared in two
+bodies at the time it was written. Pinning does not reproduce that failure — it
+prevents a *different* one (non-determinism). And I confirmed the current
+fixtures survive the drift anyway: `t188`, `t201`, `t200` all still resolve as the
+ACs assert, against today's 12-PR set. What *will* drift is §C.1's carrier
+scorecard (7/11, 11/11), and that is motivation rather than test input.
+
+**Merged-PR attribution precision unscored.** Disclosed in §F and §H, with the
+narrowing argued rather than asserted. Honest.
+
+**Reviewer-judgement halves with no command.** Disclosed in `progress.md` §Gaps
+and labelled in the criteria themselves — except AC-003 (N4) and AC-012 (N8).
+
+---
+
+## 4. Must-Pass Results
+
+### `SPEC-KANBAN-QUEUE-PR-SYNC-001`
+
+- **[PASS] MP-1** — 16 leaf requirements, `REQ-1.1`…`REQ-1.10`, `REQ-2.1`…`REQ-2.6`, extracted in document order: sequential, no gaps, no duplicates. The hierarchical scheme is non-canonical (D8/N9) but MP-1's substance — sequence and uniqueness — holds.
+- **[PASS] MP-2 (requirement layer)** — all 16 checked individually. Ubiquitous: REQ-1.1, 1.7, 1.8, 2.2, 2.4, 2.5, 2.6. State-driven `While`: REQ-1.2, 1.3, 1.4, 1.9. Event-driven `When`: REQ-2.3. Unwanted `shall not`: REQ-1.5, 1.6, 1.10. Compound: REQ-2.1. `grep -icE '\bmay\b|\bshould\b'` over the requirement lines → **0**. Judged against `spec.md` REQ entries only; `acceptance.md`'s Given-When-Then is the verification layer and was graded under §5 Testability, not here.
+- **[PASS] MP-3** — all 12 canonical fields present with correct types (`version`/`title`/`phase`/`module`/`tags` quoted strings; `created`/`updated` ISO dates; `priority: P1`; `lifecycle: spec-anchored`), plus `tier: M`. No rejected snake_case alias. `moai spec lint --json` → `[]` EXIT=0.
+- **[N/A] MP-4** — single-language SPEC (Go tooling in this repo's own CLI). Auto-passes.
+- **[PASS] MP-5 (D7)** — the only SPEC references are the two siblings; both exist, both `status: draft`. No retired/superseded reference. No BLOCKING finding.
+- **[PASS] MP-6 (D8)** — `grep -c syscall` → 0 on spec.md and plan.md. Auto-pass.
+- **[PASS] MP-7** — `grep -rn '\[NEEDS CLARIFICATION'` over both SPEC directories → no match (exit 1).
+
+### `SPEC-KANBAN-PR-CARD-TRACEABILITY-001`
+
+- **[PASS] MP-1** — `REQ-001`…`REQ-004`, canonical flat zero-padded form, sequential, no duplicates.
+- **[PASS] MP-2** — REQ-001 event-driven `When`; REQ-002 state-driven `While`; REQ-003 ubiquitous with a non-system subject (GEARS permits any noun); REQ-004 ubiquitous.
+- **[PASS] MP-3** — 12 fields, correct types, `tier: S`. `moai spec lint --json` → `[]` EXIT=0.
+- **[N/A] MP-4** — doctrine SPEC, no language-specific tooling.
+- **[PASS] MP-5 / MP-6 / MP-7** — as above; no syscall, no clarification marker, sibling reference resolves and is `draft`.
+
+---
+
+## 5. Category Scores
+
+### `SPEC-KANBAN-QUEUE-PR-SYNC-001` — harmonic mean **0.801** (threshold 0.80)
+
+| Dimension | Score | Band | Evidence |
+|---|---|---|---|
+| Clarity | 0.85 | 0.75 (upper) | §C's two-question table (L119-122) and §C.2's measured both-directions block make the hardest design call legible. One genuine ambiguity survives (N6). N7 is a scope gap, not an ambiguity — REQ-1.9's guard is explicit. |
+| Completeness | 0.85 | 0.75-1.0 | Every required section present and substantive; five `### Out of Scope —` H3 sub-headings each with specific bullets (L296-339); frontmatter complete. Deductions: the template-mirror obligation has no normative requirement (N1/N3), and all four NFRs are AC-uncovered (`grep -n 'NFR-' acceptance.md` → **no match**) (N2). |
+| Testability | 0.80 | 0.75 (upper) | AC-004 is a recursive directory digest, not a "no error" check. AC-011 carries three controls. AC-012 is a structural type assertion. Weasel-word scan (`appropriate\|adequate\|reasonable\|proper\|as needed\|if necessary\|where possible`) → only the substring "property" in prose; **zero real hits**. Deductions: N2 (NFR-1's one-call bound — the sole basis for REQ-2.5 — is observed by nothing), N8. |
+| Traceability | 0.72 | 0.75 (lower) | D.2 covers all 16 requirements — the primary property is fully intact. But AC-013 maps to *"mirror parity (plan.md M4)"*, not to any REQ, and is **absent from the D.2 table** (`awk '/D.2 Traceability/,/D.3/' \| grep -c 'AC-013'` → **0**) while L295-296 asserts *"every criterion exercises at least one requirement"* — a false claim about the document's own contents (N1). Scored below the 0.75 anchor for the false claim, well above 0.50 since 1 of 13 criteria is affected. |
+
+`4 / (1/0.85 + 1/0.85 + 1/0.80 + 1/0.72) = 4 / 4.9918 = 0.8013`
+
+### `SPEC-KANBAN-PR-CARD-TRACEABILITY-001` — harmonic mean **0.775** (threshold 0.75)
+
+| Dimension | Score | Band | Evidence |
+|---|---|---|---|
+| Clarity | 0.90 | 1.0 (lower) | All four requirements single-interpretation. REQ-002's L66-73 note is the strongest passage in either document: it names the failure mode, argues against line 29, and states outright that *"No mechanical check can tell the two readings apart after the fact, so the wording is the only control."* |
+| Completeness | 0.85 | 0.75-1.0 | HISTORY, Context, Requirements, rationale, inline ACs, four `### Out of Scope —` H3s with bullets, cross-references — all present. Deductions: the mirror requirement dropped in the split (N3); no traceability matrix. |
+| Testability | 0.75 | 0.75 | Three grep criteria with independently-confirmed zero baselines (all three re-measured at 0 by me today). Deductions: AC-004 — the parity criterion — states *"every clause added by AC-001, AC-002, and AC-003 is present in the mirror"* with **no command**, in a SPEC whose own `plan.md` §B:L30-34 warns the mirror is deliberately not a verbatim copy. The three literal phrases contain no SPEC ID, path, date, or SHA, so they are neutrality-safe and could simply be grepped against the mirror; the criterion does not say so. Plus N4. |
+| Traceability | 0.65 | 0.50-0.75 | REQ-001→AC-001, REQ-002→AC-002, REQ-003+REQ-004→AC-003 all hold in substance. But there is no traceability matrix; AC-001 cites no REQ id; and **AC-004 references no requirement at all** (N3). Two of four criteria have no explicit REQ citation. |
+
+`4 / (1/0.90 + 1/0.85 + 1/0.75 + 1/0.65) = 4 / 5.1594 = 0.7753`
+
+---
+
+## 6. Defects Found
+
+**N1. AC-ORPHAN-FALSE-CLAIM — `acceptance.md`:L43 and L295-296 — AC-013 references no requirement, and the file asserts the opposite about itself — Severity: major — Class: blocking — Required fix:** the AC matrix row reads `| AC-013 | mirror parity (plan.md M4) | …`, and AC-013 is absent from the D.2 table (verified: 0 occurrences); yet L295-296 states *"every criterion exercises at least one requirement."* That is an unobserved claim about the document's own contents. Two routes, and the choice is not free: (a) add a normative template-mirror requirement — **but the SPEC is at exactly 16/16, so this breaches the Tier M ceiling and forces a tier-up**; or (b) restate L295-296 honestly, add an AC-013 row to D.2 mapping it to the Template-First constraint in `plan.md` §D, and record that the mirror obligation is carried by a plan constraint rather than a requirement. (b) is the cheap route and is what I recommend for run-phase entry; (a) is the structurally correct one and belongs in a follow-up.
+
+**N2. NFR-UNCOVERED — `spec.md`:L283-292 (§E) and `acceptance.md` (all) — none of the four NFRs has any acceptance criterion; NFR-1 is the sole justification for the SPEC's headline design ruling — Severity: major — Class: blocking — Required fix:** `grep -n 'NFR-' acceptance.md` returns **no match**. NFR-1 bounds the verb at *one* `gh pr list` with no per-card call, and REQ-2.5's dedicated-verb ruling rests entirely on the 0.878s figure that bound protects. An implementation issuing one `gh` query per card satisfies every one of the 13 criteria while costing ~0.9s × queue length. The fix is nearly free and reuses machinery AC-009 already requires: AC-009 injects a command executor that *records every subprocess invocation* — extend it (or add AC-014) to assert that `moai todo pr` spawns exactly one `gh` process regardless of queue length. NFR-2 (landed check does no network) rides the same assertion. NFR-3 and NFR-4 need no criterion.
+
+**N3. SPLIT-DROPPED-REQUIREMENT — `SPEC-KANBAN-PR-CARD-TRACEABILITY-001/spec.md` §B and §D AC-004 — old REQ-3.4 (the template-mirror obligation) did not survive the split into the requirement layer, leaving AC-004 orphaned — Severity: major — Class: blocking — Required fix:** verified against the iteration-1 blob `313a5c31a`:L211-213, which carried *"REQ-3.4 — The doctrine change shall be mirrored into `internal/template/templates/…/kanban-dispatch.md` per the Template-First rule, subject to the template neutrality catalogue."* No successor exists in §B. Unlike N1 there is **no budget obstacle** — the Tier S SPEC is at 4 requirements against a ceiling of 8. Restore it as REQ-005 and map AC-004 to it. Two lines.
+
+**N4. MECHANICAL-OVERCLAIM — `SPEC-KANBAN-PR-CARD-TRACEABILITY-001/spec.md`:L175-179 (AC-003) — a judgement sits inside the `**Mechanical.**` block, in the SPEC that exists partly because mislabelled judgements were a blocking finding — Severity: minor — Class: blocking — Required fix:** the block reads *"After M1 that grep returns at least 1, **and the same section names all four traceability carriers**"* and then shows a single grep covering only the first clause. The four-carrier claim is already stated correctly in the reviewer-judgement half below, so no substance is lost — only the label is wrong. Delete the eight words from the Mechanical block, or add a grep that observes the four carriers (e.g. a count over the carrier names). One line either way. Flagged blocking because it is a direct relapse of D12 inside D12's own remedy.
+
+**N5. FIXTURE-BLOCK-ELIDED — `acceptance.md`:L10-21 — a command's output is presented as a live measurement but is an unmarked excerpt — Severity: minor — Class: optional — Required fix:** the header says the fixtures *"were re-measured live in this worktree with"* the stated `gh … -q '.[] | …'` command. That jq emits **one line per open PR unconditionally** — I re-ran it today and got 12 lines for a 12-PR set. §C.1 states the measurement covered **11** open PRs, so the block should carry 11 lines; it carries 5. At least four token-bearing PRs from that set are absent (#1605 `t194`, #1606 `t187`, #1613 `t202`, #1617 `t205` — all present today with tokens). **No AC fixture is refuted** — I re-verified t188, t201, and t200 against current data and all three hold — and the 5-PR set is sufficient for every criterion, so this is a labelling defect, not a correctness one. Under this project's verbatim-output rule it is still a defect: add the omitted lines, or mark the block an excerpt and state the full set size.
+
+**N6. AC-011/AC-012-OBSERVABILITY-TENSION — `acceptance.md`:L201-207 vs L230-232 — two criteria impose opposite observability demands on the same value, and neither says how to satisfy both — Severity: minor — Class: optional — Required fix:** AC-011 requires that *"the underlying query returns a non-empty commit set"* be observed; AC-012 requires that *"the public resolver API exposes no accessor that would return one."* Both are correct and both are satisfiable — the test observes the git-query helper one layer below the resolver's public surface — but the SPEC never says that, and `plan.md` M2's *"returning a boolean and nothing else"* reads as closing the only door AC-011 needs. Add one sentence to AC-011 naming the layer its control observes. An implementer who resolves this the other way will either weaken AC-011 to a boolean check (losing the anti-vacuous property) or add the accessor AC-012 forbids.
+
+**N7. LANDED-MASKED-BY-OPEN-PR — `spec.md`:L227-234 (REQ-1.9) with L219-222 (REQ-1.7), and §F — a card that both carries an open PR and is already landed reports `linked` only, and nothing discloses it — Severity: minor — Class: optional — Required fix:** REQ-1.9 runs the landed query only *"While no open pull request carries the card id token in its title or body"*, and REQ-1.7 requires exactly one of four kinds. So an operator checking a card with a stale open PR whose work already merged via a batch is told `linked` and never told it landed — a near-neighbour of the t199 shape the SPEC exists to catch. This may well be the right design (one question, one answer), but it is a scope boundary and §F does not name it. Either add a bullet to §F stating that the landed check is not run when an open PR is found, or state in REQ-1.7 that the kinds are priority-ordered and why.
+
+**N8. AC-012-UNLABELLED-JUDGEMENT — `acceptance.md`:L232 — the API-surface half carries no verb and, unlike its siblings, is not recorded as a judgement — Severity: minor — Class: optional — Required fix:** *"the public resolver API exposes no accessor that would return one"* is mechanizable (reflection over the exported record's fields) but the criterion neither names that mechanism nor labels the clause a reviewer judgement. AC-013 and the doctrine SPEC's AC-001/AC-002 both handle this correctly; AC-012 should match one of those two patterns.
+
+**N9. TWO-ID-SCHEMES — `SPEC-KANBAN-QUEUE-PR-SYNC-001/spec.md` §D vs `SPEC-KANBAN-PR-CARD-TRACEABILITY-001/spec.md` §B — one card ships two incompatible requirement-id schemes — Severity: minor — Class: optional — Required fix:** iteration-1 D8 flagged `REQ-1.1`-style ids as cosmetic when only one SPEC existed. The sibling authored in the same pass uses canonical `REQ-001`. Grep-based tooling keying on `REQ-[0-9]{3}` matches one and not the other, and a reader moving between siblings meets two conventions. `moai spec lint` returns `[]` on both, so nothing mechanical breaks. Renumbering the tooling SPEC touches 16 requirement headings, 16 traceability rows, and every `plan.md` / `acceptance.md` back-reference — not free, and deferrable.
+
+---
+
+## 7. Regression Check (iteration 1 → 2)
+
+Score moved **0.60 → 0.801** on the tooling SPEC. No regression, so the LEAN
+STOP-on-regression clause does not fire. Of the eighteen iteration-1 findings,
+sixteen are closed, one (D12) is closed in the tooling SPEC and partially closed
+in the doctrine SPEC, and one (D8) stays open as an optional cosmetic item. No
+closed finding reopened. **No stagnation:** no defect appears unchanged across
+both iterations except D8, which was explicitly graded optional at iteration 1 and
+is graded optional again — that is a deliberate deferral, not an absence of
+progress.
+
+---
+
+## 8. Recommendation
+
+**Both SPECs are fit to enter run-phase, and I would not describe either margin as
+comfortable.**
+
+The eighteen iteration-1 findings were addressed substantively rather than
+cosmetically. Three repairs are better than the fixes I prescribed: the D2/D16
+landed-carrier adoption closes the incident where my own first-pass suggestion was
+refuted; the D3 wording carries the control clause *and* the argument for why
+wording is the only control available; and AC-011's three-way control set is more
+than the positive control D17 asked for. The Q1/Q2 split is a real design
+distinction, argued from measurement in both directions, not a relabelling.
+
+What remains, in the order I would fix it:
+
+1. **N4** — delete eight words from doctrine AC-003's Mechanical block. One line.
+2. **N3** — restore the template-mirror requirement as REQ-005 in the Tier S SPEC and map AC-004 to it. Two lines, four spare slots available.
+3. **N2** — extend AC-009's recording executor to assert exactly one `gh` spawn on `moai todo pr`. One assertion in a harness the SPEC already requires. **This is the one whose absence can send the run phase wrong**: without it, a per-card-query implementation passes every criterion while defeating the design ruling those criteria exist to protect.
+4. **N1** — restate `acceptance.md`:L295-296 honestly and add AC-013 to the D.2 table. Two lines. The structurally correct fix (a normative mirror requirement) is blocked by the 16/16 ceiling and belongs in a follow-up, not here.
+
+All four are cheap; none requires re-measurement, re-argument, or a design change.
+N5-N9 are optional and can ride into run-phase as recorded debt.
+
+**The one thing I would not let the run phase inherit silently is the zero budget
+headroom.** The tooling SPEC sits at exactly 16 requirements against a ceiling of
+16, and N1's structurally-correct fix cannot be made without breaching it. D14's
+pressure was absorbed to the last slot rather than relieved. If the run phase
+discovers it needs one more requirement — and N2 and N7 are both candidates for
+one — the answer is a tier-up or a further split, not a relaxed budget.
+
+Iteration ceiling reached (Tier M = 2). No iteration 3 is available under this
+contract.

--- a/.moai/reports/t210/verdict.md
+++ b/.moai/reports/t210/verdict.md
@@ -1,0 +1,597 @@
+# SPEC Review Report: SPEC-KANBAN-QUEUE-PR-SYNC-001
+
+Iteration: 1/2 (Tier M ceiling)
+Verdict: **FAIL**
+Overall Score: **0.60** (harmonic mean; Tier M PASS threshold 0.80)
+
+Reasoning context ignored per M1 Context Isolation. The dispatch's framing of the
+SPEC's own claims was not treated as evidence; every judgement below rests on the
+artifact files plus commands re-run in this worktree.
+
+## Pin verification and finding-attribution audit
+
+**Pin verified.** The lead re-pinned content-addressed after discovering the
+original freeze was defective:
+
+```
+$ git rev-parse HEAD
+06f4597aa471a79f7594e3bc913e74463c30513e
+$ git rev-parse HEAD:….../spec.md
+313a5c31af19e7dae963a9fd6478ecd566331f82
+$ git status --short
+?? .moai/reports/t210/verdict.md      # this report; no tracked drift
+```
+
+**Which findings were formed against superseded content: none of the graded
+ones.** Established mechanically rather than asserted. Blob ids of all four
+artifacts at the pin:
+
+```
+spec.md        313a5c31af19e7dae963a9fd6478ecd566331f82
+plan.md        90ca25ebf2d04ba381490c04a8f95f41d42a66df
+acceptance.md  67b243afa55fda9defda906712641a01b310a6c4
+progress.md    542d98ac0e9e1fd250800dbde223afda51164fda
+```
+
+The `git diff` I captured during the first pass recorded
+`spec.md index c985425d3..313a5c31a` and `plan.md index 61a5997f9..90ca25ebf` —
+the **after** sides are byte-identical to the pinned blobs, so my reads of both
+were post-edit, not mixed. `acceptance.md` never appeared in `git status` and is
+unmodified across both commits. `progress.md` is the file that changed under me
+mid-read; no graded finding depends on its content.
+
+Blob identity is necessary but not sufficient, so **every cited line was re-read
+at the pin** (`sed -n '13p;137p;146p;172p;189p;236p'` on spec.md;
+`'38p;50p;66p;76p;87p;140p;154p'` on acceptance.md; `'59p;87p'` on plan.md).
+All fifteen citations resolve to exactly the quoted text. **Every finding below
+survives re-verification at this pin.** One finding — D2 — is materially
+*strengthened*, and its recommended fix is partly **retracted** on new
+measurement; one new finding (D16) is added.
+
+**The process failure is worth recording, and it is the lead's, not the
+auditor's: a HEAD-pinned freeze cannot detect uncommitted working-tree drift.**
+HEAD never moved, so the check kept passing while three files changed underneath.
+Only a content hash — a blob id, or `git status --short` returning empty — closes
+that hole. Adopt the content-addressed form for every future audit dispatch.
+
+## Must-Pass Results
+
+- **[PASS] MP-1 REQ number consistency** — 19 leaf requirements, ids
+  `REQ-1.1..1.8`, `REQ-2.1..2.7`, `REQ-3.1..3.4`. Verified:
+  `grep -oE 'REQ-[0-9]+\.[0-9]+' spec.md | sort -u -V` → no gaps, no duplicates,
+  consistent hierarchical scheme. The scheme is `REQ-N.M` rather than the
+  canonical zero-padded flat `REQ-001`; it is internally consistent, so this is
+  recorded as a minor deviation (D8), not a failure.
+
+- **[PASS] MP-2 GEARS format compliance** — **judged against the requirement
+  layer (`spec.md` REQ-XXX entries) only.** All 19 leaves carry `shall` /
+  `shall not` and match a GEARS pattern: Ubiquitous (REQ-1.1, 1.8, 2.1, 2.2,
+  2.5, 2.6, 2.7, 3.2, 3.3, 3.4), Where (REQ-1.2), Where+While compound
+  (REQ-1.3, 1.4 — PASS-equivalent per the compound-clause rule), When (REQ-1.7,
+  2.3, 3.1), Unwanted `shall not` (REQ-1.5, 1.6, 2.4). The Given-When-Then
+  entries in `acceptance.md` are the correct verification-layer format and were
+  **not** graded here; they are graded under Group 4. Minor defects D9 and D10
+  are recorded but do not fail this criterion.
+
+- **[FAIL] MP-3 YAML frontmatter validity** — see D1. `spec.md:13` is
+  `tags: [kanban, todo, github, observability, read-only]`, a YAML **sequence**
+  where the canonical schema (`spec-frontmatter-schema.md` § Field Reference)
+  types `tags` as a comma-separated **string**. Verified with the domain tool,
+  not by inference:
+
+  ```
+  $ moai spec lint .moai/specs/SPEC-KANBAN-QUEUE-PR-SYNC-001/spec.md --json
+  [{"file":".moai/specs/SPEC-KANBAN-QUEUE-PR-SYNC-001/spec.md","line":1,
+    "severity":"error","code":"ParseFailure",
+    "message":"SPEC parsing failed: frontmatter parsing error: YAML parsing error:
+    yaml: unmarshal errors:\n  line 13: cannot unmarshal !!seq into string"}]
+  ```
+
+  This is worse than a single-field finding: the document **does not parse at
+  all**, so every other lint rule the linter advertises (EARS modality, REQ-ID
+  uniqueness, AC→REQ coverage, Out-of-Scope presence, dependency DAG, zone
+  cross-refs) is silently unevaluated on this SPEC. A green-looking absence of
+  further findings here is an absence of evaluation, not an absence of defects.
+
+  Corroboration that this is an isolated authoring slip rather than a schema
+  disagreement: both sibling SPECs use the string form —
+  `SPEC-KANBAN-TODO-CLI-001` → `tags: kanban, cli, backlog, concurrency`;
+  `SPEC-KANBAN-BOARD-001` → `tags: "kanban, board, column, …"`.
+
+- **[N/A — auto-pass] MP-4 language neutrality** — the SPEC is scoped to this
+  single-language project's own tooling (`gh`, `internal/github/gh.go`). The one
+  artifact it mirrors into the distributed template (a PR-title naming clause
+  plus a pre-dispatch cross-check) is language-neutral prose naming no
+  language-specific toolchain. No 16-language enumeration obligation arises.
+
+- **[PASS] MP-5 D7 cross-SPEC reconciliation** — `grep -oE
+  'SPEC-([A-Z][A-Z0-9]+-)+[0-9]+' spec.md | sort -u` returns exactly one id, the
+  SPEC's own. No external SPEC reference exists, so no retired/superseded
+  reconciliation obligation arises. No BLOCKING finding.
+
+- **[PASS] MP-6 D8 cross-platform discipline** — `grep -c 'syscall' spec.md` → 0.
+  D8-4 auto-PASS.
+
+- **[PASS] MP-7 clarification gate** — `grep -rn '\[NEEDS CLARIFICATION'` across
+  the SPEC directory → 0 matches. `research.md` correctly absent at Tier M.
+
+**MP-3 fails ⇒ Verdict FAIL regardless of the dimension scores.**
+
+## Category Scores (rubric-anchored)
+
+| Dimension | Score | Rubric Band | Evidence |
+|-----------|-------|-------------|----------|
+| Clarity | 0.60 | 0.50 band (multiple requirements need interpretation), credited upward for otherwise-unusual precision | D3 (`spec.md:189` REQ-3.1 "rather than dispatching"), D5 (`spec.md:172` REQ-2.5 MAY branch), D2 (`spec.md:137` REQ-1.7 merged-PR silence) |
+| Completeness | 0.60 | 0.50 band — every section present, but the evidence base does not cover the scope two requirements claim from it | 5 `### Out of Scope` H3s with bullets (verified, count 5); all 12 fields present but `tags` mis-typed (D1); **D16 (REQ-1.5 generalizes M2 past the question M2 measured)**; D2 (t199 absent from §A, and the merged extension is now measured not to fix it); D6 (same-file [HARD] precedent uncited) |
+| Testability | 0.50 | 0.50 band — several ACs are not binary-testable as written; **two must-severity ACs are unsatisfiable** | D4 (`acceptance.md:38-41` AC-002, `:45-53` AC-003 — both premises refuted by live re-measurement), D7 (`:66` AC-004 under-covers REQ-2.2), D11 (`:76` AC-005 disjunctive assertion), D12 (AC-011/AC-012 grep tails untested) |
+| Traceability | 0.75 | 0.75 band — mapping is nominally complete, two mappings non-functional | `acceptance.md:183-203` D.2 covers all 19 REQs; but AC-003 cannot exercise REQ-1.4/REQ-1.6 and AC-002 cannot exercise REQ-1.3 (D4); REQ-2.5's MAY branch uncovered (D5) |
+
+Harmonic mean: `4 / (1/0.60 + 1/0.60 + 1/0.50 + 1/0.75)` = **0.600**.
+
+(First pass scored Completeness 0.70 for an aggregate of 0.622. The re-audit's
+D16 — a requirement whose stated grounds do not support its scope — lowers
+Completeness to 0.60. The verdict was already FAIL on MP-3 and did not turn on
+this.)
+
+## Independent verification of the cited measurements
+
+The SPEC leans on M1..M6. Everything cheap to re-run was re-run in this worktree.
+
+**M1 — reproduces exactly.** `CLAUDE_PROJECT_DIR=<primary> moai todo list`
+cross-read against `gh pr list --state open`: t200 / t201 / t202 / t203 / t205
+are all still `queued` while carrying open PRs #1612 / #1611 / #1613 / #1614 /
+#1617; t88 is `picked` with #1619. The five-card divergence is real, not assumed.
+
+**M2 — the load-bearing claim is CONFIRMED.** The dispatch flagged the #1600
+commit-token claim as collapse-if-refuted for REQ-1.5. It survives:
+
+```
+$ gh pr view 1600 --json body -q .body   | grep -oE '\bt[0-9]{1,4}\b' | sort -u
+t184
+$ gh pr view 1600 --json commits -q '.commits[].messageHeadline' | grep -oE '\bt[0-9]{1,4}\b' | sort -u
+t127 t158 t159 t164 t165 t170 t171 t173 t81 t82 t83 t89
+$ gh pr view 1600 --json commits -q '.commits|length'
+100
+```
+
+t184 is in the body and **absent from every commit-message token**. REQ-1.5's
+grounds hold. (Count discrepancy: the record states 15 tokens; a headline-only
+scan yields 12 — the record evidently scanned full messages. This does not touch
+the claim, but it does touch AC-006, which pins the number 15 — see D13.)
+
+Title-carrier recall also re-verified at 7/11 on the record's PR set
+(1621, 1617, 1614, 1613, 1612, 1606, 1605 carry a title token; 1619, 1611, 1601,
+1600 do not). The open set has since grown to 13 PRs; the 11 in the record are
+unchanged.
+
+**Zero-baselines for AC-011 / AC-012 — independently confirmed.**
+
+```
+$ grep -c 'pre-dispatch PR cross-check' .claude/rules/moai/workflow/kanban-dispatch.md
+0
+$ grep -c 'PR title MUST carry the delivering card id' .claude/rules/moai/workflow/kanban-dispatch.md
+0
+```
+
+**Plan pre-flight targets all exist**: `internal/github/gh.go`,
+`internal/cli/todo.go`, `internal/cli/todo_why.go`,
+`internal/kanban/backlog_store.go`, and both template mirrors
+(`…/templates/.claude/rules/moai/workflow/kanban-dispatch.md`,
+`…/templates/.claude/skills/moai/workflows/todo.md`).
+
+## Ruling on the read-only design decision (spec.md §B)
+
+**The ruling is sound, not merely convenient.** I read both cited [HARD] clauses
+in full at `kanban-dispatch.md:27` and `:29`. "The lead is the queue's sole
+producer" governs *admission* ("nothing enters the queue the operator did not ask
+for"); "Promotion is the operator's act, always" governs *the pick*. A surface
+that computes a link and prints it does neither, and the SPEC's own §B.2 argument
+— that a state change nobody made destroys operator provenance and fails
+silently — is the correct reason, independent of convenience.
+
+The strongest counter the dispatch raised (does REQ-3.1 hand the tool de-facto
+promotion authority?) **partly lands**, but not against the read-only ruling —
+against REQ-3.1's wording. Recorded as D3.
+
+Two supporting notes:
+
+- The SPEC understates its own case. `kanban-dispatch.md` carries a **third**
+  [HARD] clause in the same section it proposes to edit — *"The lead may attach a
+  finding; it may not act on one… Analysis changes exactly one thing on its own
+  authority — it refuses the admission of a card whose normalized text is
+  identical to one already queued or picked, which creates no card and **leaves
+  the queue file byte-identical**."* That is the precedent, in the same file,
+  with the same byte-identity language REQ-2.1 adopts. §B cites the weaker
+  `todo.md` restatement instead and never mentions it (D6).
+- The rejected alternative (§B, auto-update on merge/close) is correctly rejected
+  and correctly named as weighed-not-overlooked. It is also option (b) of the
+  three the originating card itself proposed, so the record of consideration is
+  complete on that axis.
+
+## Defects Found
+
+**D1. MP3-FRONTMATTER — `.moai/specs/SPEC-KANBAN-QUEUE-PR-SYNC-001/spec.md`:L13 —
+`tags:` is a YAML sequence where the canonical schema types it as a
+comma-separated string; `moai spec lint` returns `ParseFailure` (error severity)
+and the document does not parse, silently suppressing every other lint rule —
+Severity: critical — Class: blocking — Required fix:** change L13 to
+`tags: "kanban, todo, github, observability, read-only"`, then re-run
+`moai spec lint <spec.md> --json` and record the verbatim output (an empty array)
+in `progress.md §E.1`. The zero-findings claim is only meaningful once the file
+parses.
+
+**D2. SCOPE-MOTIVATION — `spec.md`:L34-38 (§A) and L234-241 (Out of Scope —
+merged and closed) — the SPEC scopes out the half of its own motivating incident
+that had the highest measured cost, and does not disclose that it is doing so —
+Severity: major — Class: blocking — Required fix:** the originating card t210
+records two failure shapes, not one. §A presents only the five open-PR
+divergences. The card's own text records the second: *"같은 라운드에서 t199 도
+queued 였으나 수정 커밋 d9899f437 이 이미 origin/main 조상이었다 (레인 1개분
+낭비)"* — a card whose delivering commit was **already an ancestor of
+origin/main**, discovered only after a lane had started, costing one full lane.
+That is the merged case, and it is the only sub-case with a quantified waste
+figure.
+
+The consequence compounds with REQ-1.7. After this SPEC lands in full, a lead
+obeying the new [HARD] REQ-3.1 clause runs the read surface for t199, gets **no
+link** (open-only query), and REQ-1.7 requires that result to be distinguishable
+from `ambiguous` — but **not** from "already merged". The doctrine therefore
+returns a clean all-clear on precisely the case that produced the wasted lane. A
+[HARD] clause that reads as a green light on its own worst measured input is a
+worse outcome than no clause, because the lead now has a documented reason to
+trust it.
+
+**Re-audit addendum — the obvious fix is measured NOT to work, and I retract it.**
+My first pass offered "extend the resolver to `--state merged`" as fix option
+(a). I traced t199 and that option is refuted:
+
+```
+$ gh pr list --state all --search t199 --json number,title,state
+#1610 MERGED "release: v3.1.3"
+#1602 MERGED "release: v3.1.3 batch — … (22 cards)"
+#1606 OPEN   "feat(mcp): … card t187"
+$ gh pr view 1602 --json body -q .body | grep -oE '\bt199\b'      # → empty
+$ gh pr view 1602 --json body -q .body | grep -oE '\bt[0-9]{1,4}\b' | sort -u | wc -l
+26
+```
+
+**t199 has no PR of its own.** Its fix commit rode into `origin/main` inside the
+v3.1.3 batch PR #1602. #1602's *title* carries no card token, and its *body*
+carries 26 card tokens **not including t199** — the merged-side analogue of the
+#1600 finding M2 already recorded on the open side. So extending REQ-1 to
+`--state merged` would find t199 through neither the title carrier (REQ-1.2) nor
+the body carrier (REQ-1.3/1.4). The gap is not the query's `--state` filter; it
+is the carrier set. See D16.
+
+Revised fix (option (b) or (c); (a) is withdrawn):
+(b) keep the open-only PR scope but add a requirement that a no-link result
+renders as an explicit *"no OPEN pull request; merged and closed PRs and landed
+commits are not checked"*, and that the REQ-3.1 doctrine clause states the same
+limitation verbatim, so the lead is told what was not looked at; or
+(c) adopt the landed-commit query as a second, separate carrier for the distinct
+"is this card already in `origin/main`?" question — see D16, which is where that
+belongs.
+Option (b) is the cheapest and preserves the exclusion honestly; (c) is the one
+that actually closes the incident. Silence remains the one unacceptable outcome:
+the current text neither covers the case nor admits the gap.
+
+**D3. REQ-3.1-AMBIGUITY — `spec.md`:L185-189 — "the lead shall surface that fact
+to the operator rather than dispatching" is ambiguous between a lead-side veto
+and a report-and-re-decide, and the distinction is exactly the queue-authority
+boundary §B spends a page defending — Severity: major — Class: blocking —
+Required fix:** state which it is. Under `kanban-dispatch.md:29`, the operator has
+already picked the card; a lead that then withholds dispatch has overridden an
+operator act, which is the de-facto-authority hazard the read-only ruling exists
+to avoid. Under the reading the SPEC almost certainly intends — report the PR,
+let the operator re-decide — the ruling holds cleanly. Rewrite as: *"the lead
+shall report the open PR to the operator and shall not dispatch until the
+operator, so informed, confirms or withdraws the card"*, and mirror that wording
+into the doctrine clause. AC-011 cannot detect which reading was implemented, so
+the wording is the only control.
+
+**D4. AC-FIXTURE-REFUTED — `acceptance.md`:L36-41 (AC-002) and L45-53 (AC-003) —
+both ACs state a Given that is false against the M2 table they were transcribed
+from and against live re-measurement; between them REQ-1.3, REQ-1.4, and REQ-1.6
+end up with no working acceptance criterion — Severity: critical — Class:
+blocking — Required fix:** live measurement of every open PR body:
+
+```
+$ gh pr list --state open --limit 40 --json number,body \
+    -q '.[] | "\(.number): \([.body|scan("\\bt[0-9]{1,4}\\b")]|unique|join(" "))"'
+1614: t1 t151 t203 t69 t9
+1612: t200 t201
+1611: t201
+…
+```
+
+- **AC-002 is refuted.** Its Given asserts "PR #1611 (no title token, body token
+  `t201`) **and no other open PR whose body carries `t201`**". #1612's body
+  carries `t201` — as M2's own table row for 1612 already records
+  (`body tokens: t200,t201`). Under REQ-1.4, `t201` is therefore **`ambiguous`
+  across {1611, 1612}**, not `inferred`. AC-002 asserts the wrong label for its
+  own fixture.
+- **AC-003 is refuted in the opposite direction.** It resolves card `t151`
+  expecting `ambiguous` "which also appears in another PR body". `t151` appears
+  in exactly **one** body (#1614) and no title. Under REQ-1.3 it resolves
+  `inferred`. AC-003 cannot produce `ambiguous`, so REQ-1.4 and REQ-1.6 — the
+  no-best-guess rule, the single most consequential behavioural commitment in
+  REQ-1 — are untested.
+
+The repair is nearly free and improves the SPEC: **`t201` is the genuine
+ambiguous case in the measured set.** Rewrite AC-003 around `t201` /
+{#1611, #1612}, and rebuild AC-002 around a token that is genuinely
+single-bodied and title-absent — `t188` (#1601 only) or `t184` (#1600 only)
+both qualify against the live measurement above.
+
+**D5. REQ-2.5-MAY — `spec.md`:L172-174 — a `MAY`-scoped optional feature
+(`moai todo list --pr`) sits inside a normative requirement, has no acceptance
+criterion, and no decided disposition — Severity: major — Class: blocking —
+Required fix:** this violates RQ-5 (no `may` in normative text) and leaves an
+implementer free to build or skip a user-visible flag. Either promote it to its
+own requirement with an AC, or move it to a "possible follow-up" note outside
+§D. Note the interaction with AC-009, which asserts `moai todo list` spawns zero
+`gh` processes: if `--pr` ships, that assertion needs a companion asserting the
+flag is what gates the spawn, or AC-009 silently becomes a no-flag-only claim.
+
+**D6. PRECEDENT-OMISSION — `spec.md`:L59-68 (§B.1) — the closest and strongest
+precedent for the read-only ruling lives in the very file the SPEC proposes to
+edit and is never cited — Severity: minor — Class: optional — Required fix:** cite
+`kanban-dispatch.md` § Entry into the board is an operator act, third [HARD]
+clause ("The lead may attach a finding; it may not act on one… leaves the queue
+file byte-identical"). It is a stronger citation than the `todo.md` restatement
+currently used, it is in the file being amended, and its byte-identity language is
+the source of REQ-2.1's.
+
+**D7. AC-004-COVERAGE — `acceptance.md`:L55-69 — AC-004 is necessary but not
+sufficient to enforce the §B read-only ruling; REQ-2.2's "any queue-owned file"
+is not covered — Severity: major — Class: blocking — Required fix:** AC-004 is the
+best-constructed AC in the set (digest, not "no error"; extended over the
+fail-open and ambiguous paths). What it does **not** observe: a lock file taken
+and released around the read; a sidecar or cache written elsewhere under
+`.moai/state/`; a `findings[]` entry (byte-identity covers this only because
+`findings[]` lives inside `backlog.json` — it would not cover a `findings`
+sidecar); an mtime-only touch on a neighbouring queue-owned file. REQ-2.2
+explicitly forbids caching "into any queue-owned file", and no AC observes that
+wider surface. Strengthen AC-004 to assert a directory-level digest over
+`.moai/state/kanban/` — before/after, recursive — rather than a single file, and
+assert no new path appears. Declaring one AC "load-bearing" raises the bar for
+that AC rather than lowering it for its neighbours.
+
+**D8. REQ-NUMBERING — `spec.md`:L115-213 — hierarchical `REQ-N.M` ids instead of
+the canonical flat zero-padded `REQ-XXX` — Severity: minor — Class: optional —
+Required fix:** the scheme is internally consistent and traceable, so this is
+cosmetic. Flag only because downstream grep-based tooling that assumes
+`REQ-[0-9]{3}` will not match. Note that the linter could not report on this
+because the file does not parse (D1).
+
+**D9. GEARS-WHERE-SEMANTICS — `spec.md`:L120, L123, L126 — `Where` is used for a
+runtime data condition, where GEARS reserves it for a capability gate / feature
+flag / static config — Severity: minor — Class: optional — Required fix:** "Where
+the PR title contains the card id token" is a property of the input data
+evaluated per-resolution, i.e. a state or event, not a capability gate. The
+syntactic form matches a GEARS pattern (so MP-2 passes), but `While the PR title
+contains the card id token` is the semantically correct modality. Low priority.
+
+**D10. NON-NORMATIVE-TRAILERS — `spec.md`:L146-148 (REQ-2.1), L158-160 (REQ-2.4)
+— requirements carry trailing declarative sentences that restate rather than
+require — Severity: minor — Class: optional — Required fix:** "It writes no field,
+no `findings[]` entry, and no timestamp" and "`moai todo list` remains lock-free
+and network-free unless the operator opts in" are commentary inside a normative
+block. Either give them `shall` form or move them to prose. They are currently
+the only statement of the `findings[]` and lock-free constraints, so deleting
+them would lose content — promote, do not drop.
+
+**D11. AC-005-DISJUNCTION — `acceptance.md`:L76 — "the output renders the queue
+with the link column blank **or absent**" admits two different renderings, so the
+assertion cannot fail on rendering — Severity: minor — Class: optional — Required
+fix:** pick one. A test that passes on either branch observes only that the
+process did not crash, which AC-005's exit-code clause already covers.
+
+**D12. AC-GREP-TAIL-UNTESTED — `acceptance.md`:L134-147 (AC-011) and L149-162
+(AC-012) — the mechanical half proves a string was typed; the half that carries
+the meaning has no command — Severity: major — Class: blocking — Required fix:**
+on the dispatch's question of whether these are ceremony: **half.** The zero
+baselines are real (independently confirmed at 0 and 0 above), so the greps are
+not the vacuous "grep a word already in the prose" pattern this project has been
+burned by — they are genuine tripwires against the clause being dropped or
+reworded away. But each AC then appends an untested tail: *"**And** the
+surrounding clause is marked [HARD] and requires the lead to read and report the
+card's PR state before dispatching"* (AC-011) and *"**And** the same section
+explicitly states that this does not contradict the branch-name exclusion rule"*
+(AC-012). Those tails are the entire substance of REQ-3.1 and REQ-3.3, and they
+are human judgement with no verb attached. Fix: split each into a mechanical part
+(the grep, keeping the zero baseline) and an explicit reviewer-judgement part
+recorded as such, so the SPEC does not claim mechanical coverage it does not
+have. Do not delete the greps — keep them and stop over-claiming them. Add a
+mechanical assertion for the [HARD] marker itself: `grep -c '\[HARD\].*pre-dispatch
+PR cross-check'` is checkable where "requires the lead to read and report" is not.
+
+**D13. AC-006-FIXTURE-NUMBER — `acceptance.md`:L86-91 — AC-006 pins "15
+commit-message tokens" for #1600 and resolves card `t131`, neither of which
+reproduces from an independent scan — Severity: minor — Class: optional —
+Required fix:** a headline-only scan of #1600's 100 commits yields 12 distinct
+tokens and does **not** include `t131` (the record's 15 evidently came from full
+commit messages). `plan.md` §B correctly instructs pinning the fixture from the
+record rather than re-fetching, which mitigates this — but an AC that cites a
+number no stated command reproduces will confuse the implementer. Either name the
+exact scan (`--json commits -q '.commits[].messageBody'` vs `messageHeadline`) or
+drop the count and cite only the property that matters: t184 is absent from the
+commit tokens and present in the body.
+
+**D14. TIER-BUDGET — `spec.md` §D — 19 leaf requirements against the Tier M
+ceiling of 16 — Severity: major — Class: blocking — Required fix:** verified:
+`grep -cE '^\*\*REQ-[0-9]+\.[0-9]+\*\*' spec.md` → 19. `spec-workflow.md`
+§ SPEC Complexity Tier caps Tier M at 16 requirements and 16 acceptance criteria,
+applied independently; the AC count (13) is within budget, the REQ count is over
+by 3. Per that rule, over-budget is "a signal to tier up or to split the SPEC,
+not to relax the budget".
+
+On the dispatch's wider tier question — a Go resolver, a new CLI verb, two
+doctrine edits, and a template mirror — **Tier M is the right call on every other
+axis**: the file count is well under 15, the LOC estimate is plainly under 1000,
+and the 3-artifact set is correct. The clean split is to lift REQ-3 (the doctrine
+change, 4 requirements, no code) into its own Tier S SPEC. That also fixes a real
+ordering awkwardness: `plan.md` M1 ships a [HARD] behavioural rule binding every
+future card-delivering PR *before* the tooling that serves it exists, which is
+correct on reversibility grounds but means the doctrine is live and unserved for
+the whole of M2-M4. Two SPECs make that sequencing explicit instead of implicit.
+
+**D15. MILESTONE-MIRROR-SPLIT — `plan.md`:L58-60 (M1) and L87-88 (M4) — the
+Template-First mirror obligation is split across two milestones but only M1
+carries a parity AC — Severity: minor — Class: optional — Required fix:** M4
+mirrors `.claude/skills/moai/workflows/todo.md` into the template; AC-013 only
+covers the `kanban-dispatch.md` mirror. Extend AC-013 to both files, or give M4
+its own parity exit. Both mirror targets exist and were confirmed present.
+
+Milestone ordering is otherwise sound: M2 (pure resolver) → M3 (read surface
+consuming it) → M4 (wiring) is a genuine dependency chain, and M1's
+reversibility-first placement is argued rather than assumed.
+
+**D16. REQ-1.5-OVERGENERALIZED — `spec.md`:L130-132 (REQ-1.5) and L100-105 (§C) —
+M2 measured the commit carrier against one question and REQ-1.5 forbids it for
+all questions, including the one where it is the only carrier that works —
+Severity: major — Class: blocking — Required fix:** raised by the lead, tested
+independently, and **it holds.**
+
+M2 asked *"which cards does this PR deliver?"* — the attribution direction, where
+#1600's inherited tokens are genuinely ruinous. REQ-1.5 then bans the carrier
+outright: *"The resolver shall not consult commit messages as a linking carrier."*
+But the t199 incident poses a **different** question — *"is this card's work
+already in `origin/main`?"* — and in that direction inherited commits are not
+noise at all: a commit that rode in on another branch is still genuinely landed,
+so the property being tested is the very thing the query returns.
+
+Measured, both directions:
+
+```
+$ git log origin/main --perl-regexp --grep='\bt199\b' --oneline
+b4b8bdfbe docs: update CHANGELOG for v3.1.3
+711bfdbba merge(t199): internal/web 자기-SIGTERM TOCTOU …
+d9899f437 fix(web): register signal handling before binding the listener (t199)
+$ git merge-base --is-ancestor d9899f437 origin/main && echo ANCESTOR=yes
+ANCESTOR=yes
+
+# false-positive control — t205 is queued with an OPEN PR, i.e. NOT landed:
+$ git log origin/main --perl-regexp --grep='\bt205\b' --oneline     # → empty
+# positive controls — landed cards return their delivering commits:
+$ git log origin/main --perl-regexp --grep='\bt82\b'  --oneline | head -2
+32434bf9b docs(reports): record the t82 diet cross-reference sweep … (card t190)
+705f21f64 merge(t82): AGENTS.md canonical contract layer …
+$ git log origin/main --perl-regexp --grep='\bt165\b' --oneline | head -1
+b86fac07c Merge WT-svg-quality: SPEC-SVG-QUALITY-ABSORB-001 (card t165)
+```
+
+The landed-direction query returns the right answer on every sample: the delivering
+commit for landed cards, and **empty for a not-landed card**. It is not
+noise-free — t82's first hit is a different card's report commit that merely
+mentions t82 — but that noise does not produce a wrong answer to the landed
+question, because t82 *is* landed. Contrast the attribution direction, where the
+same carrier returns 15 tokens for #1600 and omits the one card it delivers.
+
+So the SPEC generalized a real measurement past the question that measurement
+addressed, and the over-generalization is load-bearing: combined with D2, the
+only carrier that finds t199 is the one REQ-1.5 categorically forbids, and the
+merged-PR extension that looks like the natural fix does not reach it either
+(measured above). **REQ-1 as written would not have prevented one of the two
+incidents in the card's own motivation.**
+
+Fix: scope REQ-1.5 to the question M2 actually measured — *"the resolver shall not
+consult commit messages **when attributing an open PR to a delivering card**"* —
+and either (i) add a separate landed-check requirement using
+`git log origin/main --perl-regexp --grep`, or (ii) state explicitly that the
+landed question is out of scope and that REQ-1.5's ban does not prejudge it. What
+must not survive is a blanket prohibition justified by a measurement of a
+narrower case.
+
+**D17. GREP-ERE-BOUNDARY — implementation hazard for any landed-check —
+Severity: major (conditional on D16 (i) being adopted) — Class: blocking if D16(i)
+is adopted, otherwise optional — Required fix:** `\b` is not POSIX ERE, and git's
+`--grep` fails **silently** rather than erroring:
+
+```
+$ git log origin/main --perl-regexp --grep='\bt199\b' --oneline | wc -l
+3
+$ git log origin/main -E --grep='\bt199\b' --oneline | wc -l
+0
+```
+
+The `-E` form returns empty, which is byte-indistinguishable from "this card is
+not landed" — a false negative that an AC would observe as a pass. This is the
+same vacuous-grep failure mode the project has been bitten by before. Any
+requirement or AC in this family MUST specify `--perl-regexp` explicitly and MUST
+carry a positive control (a known-landed card returning non-empty) so the
+regex-engine failure cannot masquerade as a clean result.
+
+**D18. REQ-1.8-CONFIRMED — `spec.md`:L141-142 — no defect; recording the positive
+verification — Severity: n/a — Class: n/a:** REQ-1.8's whole-token requirement is
+mechanically satisfiable and was verified against a tree containing t200, t205,
+and t206: `git log origin/main --perl-regexp --grep='\bt20\b' --oneline` returns
+zero hits. AC-008 is sound as written. Recorded so the run phase does not
+re-litigate it.
+
+## Recommendation
+
+FAIL. Fix in this order; 1-3 are cheap and 4 is the one that needs a decision.
+
+1. **D1** — one-line frontmatter fix, then re-run `moai spec lint` and paste the
+   verbatim output. Until the file parses, no other automated check on this SPEC
+   has actually run, and any "lint clean" claim is unattributed.
+2. **D4** — rebuild AC-002 and AC-003 against the live carrier data quoted above.
+   Use `t201`/{#1611,#1612} for ambiguous and `t188` or `t184` for inferred. This
+   is a transcription error, not a design error, and REQ-1.4/1.6 are untested
+   until it is fixed.
+3. **D3, D5, D7, D12** — wording and coverage repairs, each self-contained:
+   disambiguate REQ-3.1's "rather than dispatching"; resolve the REQ-2.5 `MAY`;
+   widen AC-004 to a directory digest; split AC-011/AC-012's mechanical and
+   judgement halves.
+4. **D2 + D16 + D14 — the ones that need an operator-level decision.**
+   - **D2 and D16 are one decision, not two.** t199 is unreachable by every
+     carrier REQ-1 specifies, and measurably still unreachable if the resolver is
+     extended to merged PRs. Either adopt the landed-commit carrier as a second,
+     separately-scoped question (D16 fix (i), with D17's `--perl-regexp` +
+     positive-control guard attached), or state the limitation in both the render
+     and the REQ-3.1 doctrine clause so the lead is told what was not checked
+     (D2 fix (b)). Shipping a [HARD] pre-dispatch clause that returns a silent
+     all-clear on the incident sub-case that already cost a full lane is the one
+     outcome to avoid.
+   - D14: decide whether to split REQ-3 into its own Tier S SPEC (which resolves
+     the budget overrun and the doctrine-before-tooling sequencing together) or
+     to tier up.
+
+Optional findings D6, D8, D9, D10, D11, D13, D15 are surfaced for the
+orchestrator's discretion and are **not** grounds for the FAIL. D18 is a
+confirmation, not a defect. The verdict rests on the MP-3 failure (D1), which is
+score-independent, and is corroborated by an aggregate of 0.60 against a Tier M
+threshold of 0.80.
+
+## On the lead's t199 evidence
+
+Accepted, and the direction is right. I re-ran every claim rather than taking
+them: t199 has no PR of its own (only release PRs #1602/#1610 surface it), the
+three `--perl-regexp` commits reproduce, `d9899f437` is an ancestor of
+`origin/main`, the `-E` form returns empty, and the `\bt20\b` control returns
+zero. Two additions the evidence did not include, both of which strengthen it:
+**#1602's body carries 26 card tokens and t199 is not among them**, which kills
+the merged-PR extension as a fix and forced me to retract my own recommendation;
+and the landed-direction query passes a false-positive control (`t205`, queued
+with an open PR, returns empty), which is what makes the direction argument
+sound rather than merely plausible.
+
+One qualification, so the run phase is not surprised: the landed direction is not
+noise-free. `t82`'s first hit is a different card's report commit that merely
+mentions it. The noise does not produce a wrong answer to the landed question —
+t82 is landed — but a naive implementation that reports the *first* matching
+commit as "the delivering commit" would attribute wrongly. Scope the landed check
+to the boolean it can answer ("does `origin/main` name this card?") and do not let
+it claim attribution, which is the exact distinction D16 turns on.
+
+A closing note in the SPEC's favour, since an adversarial report can leave a
+false impression: the design ruling in §B is correct and well argued, the
+measurement discipline is real (M1 and M2's load-bearing claim both survived
+independent re-measurement), the rejected alternative is honestly recorded, and
+AC-004 is the strongest single acceptance criterion I have audited in this
+project. The failures are an unparsed frontmatter line, two mis-transcribed
+fixtures, and a scoping decision that generalized a good measurement past the
+question it answered. Only the last is a reasoning failure, and it is the
+recoverable kind: the measurement was sound, the inference from it was drawn one
+step too wide.

--- a/.moai/specs/SPEC-KANBAN-PR-CARD-TRACEABILITY-001/plan.md
+++ b/.moai/specs/SPEC-KANBAN-PR-CARD-TRACEABILITY-001/plan.md
@@ -1,0 +1,128 @@
+# Implementation Plan — SPEC-KANBAN-PR-CARD-TRACEABILITY-001
+
+Tier S: 2 artifacts (spec.md + plan.md); acceptance criteria are inline in
+`spec.md` §D.
+
+## A. Context
+
+Doctrine-only SPEC, split out of `SPEC-KANBAN-QUEUE-PR-SYNC-001` per audit D14.
+Two files change and no Go code ships:
+
+- `.claude/rules/moai/workflow/kanban-dispatch.md`
+- `internal/template/templates/.claude/rules/moai/workflow/kanban-dispatch.md`
+
+Evidence base: `.moai/reports/t210/measurement.md` (M1, M2, M6) and
+`.moai/reports/t210/verdict.md` (D3, D12, D14, D15). Do not re-derive either.
+
+**Lands before the sibling.** `SPEC-KANBAN-QUEUE-PR-SYNC-001` ships the tooling;
+this SPEC ships the obligation and the naming convention that makes the tooling
+exact.
+
+## B. Known issues
+
+- **The AC greps are only non-vacuous against their zero baselines.** Both
+  baselines were confirmed at 0 during the t210 audit, but they must be re-run
+  and cited immediately before the edit — a baseline measured yesterday proves
+  nothing about the tree being edited today.
+- **The [HARD] marker grep is order-sensitive.** `grep -c '\[HARD\].*pre-dispatch
+  PR cross-check'` matches only when the marker precedes the phrase on the same
+  line. Write the clause that way, or the criterion fails on a correct clause.
+- **The mirror is not a verbatim copy.** `internal/template/templates/` is
+  deliberately neutralized — internal SPEC IDs, report paths, dates, and commit
+  SHAs are stripped per the template neutrality catalogue. Copying the local
+  file over the mirror will fail the neutrality guard. Write the mirror clause
+  in neutral prose that names no SPEC ID and no `.moai/reports/` path.
+
+## C. Pre-flight
+
+```bash
+# Zero baselines — cite these verbatim before editing.
+grep -c 'pre-dispatch PR cross-check' .claude/rules/moai/workflow/kanban-dispatch.md
+grep -c 'confirms or withdraws' .claude/rules/moai/workflow/kanban-dispatch.md
+grep -c 'PR title MUST carry the delivering card id' .claude/rules/moai/workflow/kanban-dispatch.md
+
+# Confirm both edit targets exist.
+ls .claude/rules/moai/workflow/kanban-dispatch.md
+ls internal/template/templates/.claude/rules/moai/workflow/kanban-dispatch.md
+
+# Read the section being amended, and the branch-naming rule REQ-004 reconciles.
+grep -n 'sole producer\|Promotion is the operator\|may attach a finding' .claude/rules/moai/workflow/kanban-dispatch.md
+grep -n 'WT-\|descriptive slug\|three other carriers' .claude/rules/moai/workflow/kanban-dispatch.md
+```
+
+## D. Constraints
+
+- **Doctrine only.** No Go file is touched. If the work appears to need code,
+  that is the sibling SPEC's scope — return a blocker rather than widening this
+  one.
+- **Do not weaken the three existing [HARD] clauses.** REQ-002's wording sits
+  next to *"Promotion is the operator's act, always"* and must read as
+  compatible with it, not as an exception to it.
+- **Template-First.** Local edit and mirror edit land in the same commit,
+  followed by `make build`.
+- **Template neutrality.** The mirrored clause names no SPEC ID, no
+  `.moai/reports/` path, no date, and no commit SHA.
+
+## E. Self-verification
+
+Each milestone's exit cites command output verbatim per
+`.claude/rules/moai/core/verification-claim-integrity.md`. The
+reviewer-judgement halves of AC-001, AC-002, and AC-003 are reported **as
+judgements** — recorded, attributed, and never presented as mechanical passes.
+
+## F. Milestones
+
+### M1 — The pre-dispatch cross-check clause (REQ-001, REQ-002)
+
+Least reversible of the two clauses: it changes what the lead must do on every
+dispatch, and its report-and-re-decide wording is the control against a
+de-facto-veto reading (audit D3).
+
+- Site the clause in `kanban-dispatch.md` § Entry into the board is an operator
+  act, after the three existing [HARD] clauses — that section already owns the
+  operator-authority boundary.
+- Write `[HARD]` before the phrase `pre-dispatch PR cross-check` on the same
+  line (see §B).
+- Include the literal `confirms or withdraws` (AC-002).
+- Exit: the three AC-001 / AC-002 greps return ≥ 1 against cited zero baselines.
+
+### M2 — The PR-title clause and the non-contradiction note (REQ-003, REQ-004)
+
+- Site it in § Isolation, next to the branch-naming rule it reconciles with.
+- Include the literal `PR title MUST carry the delivering card id`.
+- Scope it to card-delivering pull requests; name release, batch, and
+  release-update PRs as carrying no obligation.
+- Name all four traceability carriers — dispatch `card:` field, commit message,
+  evidence path, PR title — and state which is machine-readable.
+- Exit: AC-003 grep returns ≥ 1 against its cited zero baseline.
+
+### M3 — Template mirror
+
+- Mirror both clauses into
+  `internal/template/templates/.claude/rules/moai/workflow/kanban-dispatch.md`,
+  in neutral prose per §D.
+- `make build`.
+- Exit: AC-004 — `MOAI_TEMPLATE_LEAK_STRICT=1 go test ./internal/template/... -v`
+  passes; both clauses present in the mirror.
+
+## G. Anti-patterns to avoid
+
+- **Writing REQ-002 as a veto.** "The lead shall not dispatch a card carrying an
+  open PR" reads as lead-side authority over a picked card and contradicts line
+  29. The clause reports; the operator decides.
+- **Copying the local file over the template mirror.** Fails the neutrality
+  guard; the mirror is deliberately not a verbatim copy.
+- **Claiming the reviewer-judgement halves as mechanical passes.** The greps
+  prove a string was typed. That the clause *means* what REQ-001 through REQ-004
+  require is a judgement, and is recorded as one.
+- **Citing the t210 audit's zero baselines instead of re-measuring.** They were
+  true at audit time; re-run them against the tree being edited.
+- **Widening scope into tooling.** Any `gh`, `git`, or Go work belongs to
+  `SPEC-KANBAN-QUEUE-PR-SYNC-001`.
+
+## H. Cross-references
+
+- `spec.md` §B (the four requirements), §C (why they are cheap), §D (the inline
+  acceptance criteria)
+- `SPEC-KANBAN-QUEUE-PR-SYNC-001` — the sibling tooling SPEC; lands second
+- `.moai/reports/t210/measurement.md`, `.moai/reports/t210/verdict.md`

--- a/.moai/specs/SPEC-KANBAN-PR-CARD-TRACEABILITY-001/progress.md
+++ b/.moai/specs/SPEC-KANBAN-PR-CARD-TRACEABILITY-001/progress.md
@@ -1,0 +1,102 @@
+# Progress — SPEC-KANBAN-PR-CARD-TRACEABILITY-001
+
+## §E.1 Plan-phase Audit-Ready Signal
+
+### Artifacts
+
+Tier S set: `spec.md`, `plan.md`. Acceptance criteria are inline in `spec.md`
+§D per the Tier S contract. `progress.md` is emitted at every tier and is not
+counted in the Tier artifact total.
+
+### Provenance
+
+Split out of `SPEC-KANBAN-QUEUE-PR-SYNC-001` per audit finding D14
+(`.moai/reports/t210/verdict.md`, iteration 1): that SPEC carried 19 leaf
+requirements against a Tier M ceiling of 16, and its four doctrine requirements
+are code-free and land on a different schedule from the tooling.
+
+The split also makes an ordering explicit that was previously implicit inside a
+single milestone sequence: the [HARD] cross-check clause is live and satisfied
+by hand for the interval between this SPEC landing and the sibling shipping its
+tooling. That interval is stated in `spec.md` §A rather than left for a reader
+to discover.
+
+Audit findings carried into this SPEC: D3 (REQ-002's report-and-re-decide
+wording, which is the control against a de-facto-veto reading), D12 (each
+acceptance criterion split into a mechanical half and a reviewer-judgement
+half), D15 (mirror parity).
+
+### SPEC ID check
+
+```
+$ ID="SPEC-KANBAN-PR-CARD-TRACEABILITY-001"; [[ "$ID" =~ ^SPEC(-[A-Z][A-Z0-9]*)+-[0-9]{3}$ ]] && echo PASS || echo FAIL
+PASS
+```
+
+No collision in `.moai/specs/`.
+
+### Budget
+
+```
+$ grep -cE '^\*\*REQ-[0-9]{3}\*\*' .moai/specs/SPEC-KANBAN-PR-CARD-TRACEABILITY-001/spec.md
+4
+$ grep -cE '^### AC-[0-9]{3}' .moai/specs/SPEC-KANBAN-PR-CARD-TRACEABILITY-001/spec.md
+4
+```
+
+4 leaf requirements and 4 acceptance criteria against a Tier S ceiling of 8 each.
+
+### Lint — verbatim
+
+```
+$ moai spec lint .moai/specs/SPEC-KANBAN-PR-CARD-TRACEABILITY-001/spec.md --json
+[]
+EXIT=0
+```
+
+### Zero baselines observed in this worktree (not relayed)
+
+Each grep-shaped acceptance criterion is non-vacuous only against a zero
+baseline. All three confirm at 0:
+
+```
+$ grep -c 'pre-dispatch PR cross-check' .claude/rules/moai/workflow/kanban-dispatch.md
+0
+$ grep -c 'confirms or withdraws' .claude/rules/moai/workflow/kanban-dispatch.md
+0
+$ grep -c 'PR title MUST carry the delivering card id' .claude/rules/moai/workflow/kanban-dispatch.md
+0
+```
+
+The first and third were independently confirmed at 0 during the t210 audit;
+`plan.md` §B requires re-running all three against the tree being edited rather
+than citing these, because a baseline measured earlier proves nothing about the
+tree at edit time.
+
+### Gaps
+
+- The reviewer-judgement halves of AC-001, AC-002, and AC-003 have no command.
+  They are recorded as judgements and are not claimed as mechanical coverage.
+- No CI check enforces the PR-title convention (`spec.md` §E). The obligation is
+  doctrinal; mechanical enforcement is named as a plausible follow-up and is not
+  specified.
+- The `[HARD]`-marker grep in AC-001 is order-sensitive — it matches only when
+  the marker precedes the phrase on the same line. `plan.md` §B records this so
+  a correct clause is not failed by a grep that assumed the other order.
+
+### Signal
+
+`status: draft`. Awaiting audit, then Implementation Kickoff Approval. Lands
+**before** `SPEC-KANBAN-QUEUE-PR-SYNC-001`.
+
+## §E.2 Run-phase Evidence
+
+_<pending run-phase>_
+
+## §E.3 Run-phase Audit-Ready Signal
+
+_<pending run-phase>_
+
+## §E.4 Sync-phase Audit-Ready Signal
+
+_<pending sync-phase>_

--- a/.moai/specs/SPEC-KANBAN-PR-CARD-TRACEABILITY-001/progress.md
+++ b/.moai/specs/SPEC-KANBAN-PR-CARD-TRACEABILITY-001/progress.md
@@ -39,12 +39,30 @@ No collision in `.moai/specs/`.
 
 ```
 $ grep -cE '^\*\*REQ-[0-9]{3}\*\*' .moai/specs/SPEC-KANBAN-PR-CARD-TRACEABILITY-001/spec.md
-4
+5
 $ grep -cE '^### AC-[0-9]{3}' .moai/specs/SPEC-KANBAN-PR-CARD-TRACEABILITY-001/spec.md
 4
 ```
 
-4 leaf requirements and 4 acceptance criteria against a Tier S ceiling of 8 each.
+5 leaf requirements and 4 acceptance criteria against a Tier S ceiling of 8 each.
+
+### Audit iteration 2 — PASS (0.775 against the Tier S threshold of 0.75)
+
+`.moai/reports/t210/verdict-2.md`. Two blocking findings, both lead-verified
+rather than sent through a third round (the iteration ceiling is reached):
+
+- **N3 — the split dropped a requirement.** The pre-split SPEC's REQ-3.4 (the
+  template-mirror obligation) did not survive into this SPEC's requirement
+  layer, which left AC-004 exercising nothing. Restored as **REQ-005**, with
+  AC-004 mapped to it and a traceability table added. Tier S is at 5 of 8, so
+  there was no budget obstacle — unlike the sibling, where the structurally
+  correct fix for N1 would have breached 16/16.
+- **N4 — a judgement inside a `**Mechanical.**` block.** AC-003's mechanical
+  half asserted *"and the same section names all four traceability carriers"*
+  while showing a grep covering only the first clause. Removed; the claim was
+  already stated correctly in the judgement half, so nothing was lost. It was
+  flagged blocking because it is a relapse of the D12 defect inside D12's own
+  remedy — the reason this SPEC uses the split-AC pattern at all.
 
 ### Lint — verbatim
 

--- a/.moai/specs/SPEC-KANBAN-PR-CARD-TRACEABILITY-001/progress.md
+++ b/.moai/specs/SPEC-KANBAN-PR-CARD-TRACEABILITY-001/progress.md
@@ -109,11 +109,195 @@ tree at edit time.
 
 ## §E.2 Run-phase Evidence
 
-_<pending run-phase>_
+Card t210. Worktree `.claude/worktrees/t210`, branch `WT-queue-pr-sync`.
+Doctrine only — no Go file is touched, per `plan.md` §D. Two files change:
+
+| File | Milestone |
+|---|---|
+| `.claude/rules/moai/workflow/kanban-dispatch.md` | M1, M2 |
+| `internal/template/templates/.claude/rules/moai/workflow/kanban-dispatch.md` | M3 (mirror) |
+
+### Pre-flight — the zero baselines, re-measured against THIS tree
+
+`plan.md` §B is explicit that the audit-time baselines prove nothing about the
+tree being edited, so all three were re-run at HEAD `985343fad`, before any
+edit:
+
+```
+$ grep -c 'pre-dispatch PR cross-check' .claude/rules/moai/workflow/kanban-dispatch.md
+0
+$ grep -c 'confirms or withdraws' .claude/rules/moai/workflow/kanban-dispatch.md
+0
+$ grep -c 'PR title MUST carry the delivering card id' .claude/rules/moai/workflow/kanban-dispatch.md
+0
+```
+
+All zero. Both edit targets exist, and — measured rather than assumed — the
+live file and its mirror were **byte-identical** before the edit:
+
+```
+$ diff .claude/rules/moai/workflow/kanban-dispatch.md \
+       internal/template/templates/.claude/rules/moai/workflow/kanban-dispatch.md
+(no output)
+```
+
+That identity is what makes M3 a one-step mirror rather than a translation:
+the same neutral prose satisfies both copies, so it was written to both.
+
+### M1 — the pre-dispatch cross-check clause (REQ-001, REQ-002)
+
+Sited in § Entry into the board is an operator act, immediately after the third
+existing [HARD] clause ("The lead may attach a finding; it may not act on one")
+— that section already owns the operator-authority boundary, and the new clause
+sits inside it rather than beside it.
+
+Two [HARD] paragraphs, deliberately separate:
+
+- The first states the obligation: read the card's pull-request and landed
+  state before dispatching, and report what was read **in the same turn**. It
+  names `moai todo pr <id>` and the by-hand equivalent, so the clause is
+  satisfiable now and better satisfied once the sibling SPEC's tooling lands.
+- The second is the control against a de-facto veto (REQ-002). It carries the
+  literal `confirms or withdraws`, states that the lead does **not** withhold
+  the dispatch on its own authority, and grounds that in the existing
+  "promotion is the operator's act, always" clause it sits under.
+
+The `[HARD]` marker precedes the phrase `pre-dispatch PR cross-check` on the
+same line, per `plan.md` §B's order-sensitivity note.
+
+```
+$ grep -c 'pre-dispatch PR cross-check' .claude/rules/moai/workflow/kanban-dispatch.md
+1
+$ grep -c '\[HARD\].*pre-dispatch PR cross-check' .claude/rules/moai/workflow/kanban-dispatch.md
+1
+$ grep -c 'confirms or withdraws' .claude/rules/moai/workflow/kanban-dispatch.md
+1
+```
+
+### M2 — the PR-title clause and the non-contradiction note (REQ-003, REQ-004)
+
+Sited in § Isolation, immediately after the paragraph closing the branch-naming
+rule ("A lane that reports a branch name without also reporting its card id…"),
+so the reconciliation stands next to the rule it reconciles with rather than a
+section away.
+
+```
+$ grep -c 'PR title MUST carry the delivering card id' .claude/rules/moai/workflow/kanban-dispatch.md
+1
+```
+
+The clause states the non-contradiction outright — the branch name is read by a
+human scanning `git branch` and wants a slug; the PR title is read by a machine
+and wants the id — lists all **four** carriers with the PR title marked as the
+only machine-readable one, and scopes the obligation to card-delivering pull
+requests, naming release, batch, and maintenance pull requests as carrying
+none. It also states the forward-only binding: pull requests opened after the
+clause lands, no retitling.
+
+### M3 — the mirror
+
+```
+$ grep -c 'pre-dispatch PR cross-check' internal/template/templates/.claude/rules/moai/workflow/kanban-dispatch.md
+1
+$ grep -c '\[HARD\].*pre-dispatch PR cross-check' internal/template/templates/.claude/rules/moai/workflow/kanban-dispatch.md
+1
+$ grep -c 'confirms or withdraws' internal/template/templates/.claude/rules/moai/workflow/kanban-dispatch.md
+1
+$ grep -c 'PR title MUST carry the delivering card id' internal/template/templates/.claude/rules/moai/workflow/kanban-dispatch.md
+1
+$ MOAI_TEMPLATE_LEAK_STRICT=1 go test ./internal/template/... -count=1
+ok  	github.com/modu-ai/moai-adk/internal/template	25.962s
+ok  	github.com/modu-ai/moai-adk/internal/template/agentemit	0.950s
+?   	github.com/modu-ai/moai-adk/internal/template/scripts	[no test files]
+$ make build
+… catalog.yaml updated successfully (12899 bytes)
+go build -ldflags "…" -o bin/moai ./cmd/moai
+```
+
+**Neutrality was written in, not stripped afterwards.** `plan.md` §G's second
+anti-pattern is copying the live file over the mirror; here the clauses were
+authored neutral from the start — no SPEC ID, no `.moai/reports/` path, no
+date, no commit SHA — and "the integration branch" is named by role rather than
+by branch name. The measured incident counts ("five cards", "one card") were
+deliberately written as "cards sat queued" and "one sat queued", because a
+count is a fact about this repository's history and not about a user's project.
+
+### Always-loaded budget — measured, and worth the lead's attention
+
+`kanban-dispatch.md` is always-loaded, so the clauses cost every session.
+
+```
+$ go test ./internal/config/ -run TokenBudget -count=1 -v
+    token_budget_guard_test.go:69: always-loaded surface = 68091 tokens
+        (budget 76000, headroom 7909, 18 entries)
+--- PASS: TestAlwaysLoadedTokenBudget (0.02s)
+```
+
+The guard passes with 7,909 tokens of headroom. The file grew 27,777 → 30,943
+bytes (+3,166, 19 inserted lines), and the mirror grew identically.
+
+**Flag, not a blocker:** a separate card carries an always-loaded ratchet whose
+target is materially tighter than the live 76,000 budget. This card's +3,166
+bytes consume headroom that ratchet is counting on. Nothing here is over any
+enforced budget, and the two changes have not met in one tree — the lead owns
+the integration-order call.
 
 ## §E.3 Run-phase Audit-Ready Signal
 
-_<pending run-phase>_
+### Claim
+
+All four acceptance criteria are implemented. The mechanical half of each
+passes; the reviewer-judgement half of AC-001, AC-002, and AC-003 is recorded
+as an outstanding judgement and is **not** claimed as a mechanical pass.
+
+### Evidence
+
+| AC | Mechanical verification | Result |
+|---|---|---|
+| AC-001 | the two greps above, against a cited zero baseline | 0 → 1 on both |
+| AC-002 | `grep -c 'confirms or withdraws'`, against a cited zero baseline | 0 → 1 |
+| AC-003 | `grep -c 'PR title MUST carry the delivering card id'`, against a cited zero baseline | 0 → 1 |
+| AC-004 | the four mirror greps + `MOAI_TEMPLATE_LEAK_STRICT=1 go test ./internal/template/...` + `make build` | all present, suite green, build run |
+
+### Baseline-attribution
+
+Measured against HEAD `985343fad` in `.claude/worktrees/t210` on branch
+`WT-queue-pr-sync`. The three zero baselines were re-run on this tree at edit
+time rather than cited from the audit, per `plan.md` §G's fourth anti-pattern.
+The pre-edit byte-identity of the live file and its mirror was measured with
+`diff`, not assumed.
+
+### Gaps
+
+- **The reviewer-judgement halves are unverified.** No independent reviewer has
+  confirmed that the cross-check clause requires reading *and reporting*
+  (AC-001), that it cannot be read as authorizing a lead-side veto (AC-002), or
+  that the non-contradiction note reads correctly against the branch-name rule
+  (AC-003). The author's reading is that all three hold; that is a judgement,
+  and it is recorded as one rather than reported as a pass.
+- **Nothing mechanically enforces the PR-title convention.** No CI check, hook,
+  or lint rule was added — `spec.md` §E excludes it. Adherence is doctrinal.
+- **The doctrine-before-tooling interval is live.** Until the sibling SPEC
+  merges, the cross-check is satisfied by hand. `spec.md` §A accepts this cost
+  explicitly; it is named here because it is a real operating condition and not
+  a paper one.
+
+### Residual-risk
+
+- **The [HARD]-marker grep is order-sensitive** and matches only when `[HARD]`
+  precedes the phrase on one line. A future editor who rewraps the paragraph or
+  moves the marker fails AC-001 on a clause that is still correct. The
+  order-sensitivity is recorded in `plan.md` §B; the grep is not made smarter.
+- **The clause sits next to three existing [HARD] clauses about operator
+  authority.** It was written to be compatible with "promotion is the
+  operator's act, always" rather than as an exception to it, but the reading is
+  the thing under risk, and only the wording controls it — which is exactly why
+  AC-002 exists as a separate criterion with its own judgement half.
+- **Four carriers now, three named in the paragraph above the new clause.** The
+  pre-existing "three other carriers" sentence is left intact and the new
+  clause states the fourth explicitly; a reader who stops at the older sentence
+  sees three. Rewriting the older sentence was rejected as scope the card does
+  not carry.
 
 ## §E.4 Sync-phase Audit-Ready Signal
 

--- a/.moai/specs/SPEC-KANBAN-PR-CARD-TRACEABILITY-001/progress.md
+++ b/.moai/specs/SPEC-KANBAN-PR-CARD-TRACEABILITY-001/progress.md
@@ -222,25 +222,53 @@ by branch name. The measured incident counts ("five cards", "one card") were
 deliberately written as "cards sat queued" and "one sat queued", because a
 count is a fact about this repository's history and not about a user's project.
 
-### Always-loaded budget — measured, and worth the lead's attention
+### Always-loaded budget — measured, and the stub/companion split
 
-`kanban-dispatch.md` is always-loaded, so the clauses cost every session.
+`kanban-dispatch.md` is always-loaded, so every clause costs every session. The
+file is already a stub + lazy-companion pair, and the lead ruled that the new
+doctrine follow the same convention: the binding [HARD] clauses stay in the
+stub, the rationale moves to `kanban-dispatch-detail.md` (`paths:`-scoped, so it
+is NOT always-loaded).
+
+What stayed in the stub: the cross-check obligation, the report-never-veto
+clause with its literal `confirms or withdraws`, the PR-title requirement with
+its one-line non-contradiction, the four carriers, and the scope restriction.
+Every acceptance criterion still greps against the stub.
+
+What moved to the companion: the incident narrative, the reasoning for why the
+veto reading is invisible after the fact, the "neither name can serve both
+readers" argument, the carrier precision/recall table, the inherited-commit
+worst case, and why a card token in a batch pull-request title is worse than
+none.
+
+Measured before and after the split, on this tree:
 
 ```
 $ go test ./internal/config/ -run TokenBudget -count=1 -v
-    token_budget_guard_test.go:69: always-loaded surface = 68091 tokens
-        (budget 76000, headroom 7909, 18 entries)
---- PASS: TestAlwaysLoadedTokenBudget (0.02s)
+# before the trim
+    token_budget_guard_test.go:69: always-loaded surface = 68091 tokens (budget 76000, headroom 7909, 18 entries)
+# after the trim
+    token_budget_guard_test.go:69: always-loaded surface = 67698 tokens (budget 76000, headroom 8302, 18 entries)
 ```
 
-The guard passes with 7,909 tokens of headroom. The file grew 27,777 → 30,943
-bytes (+3,166, 19 inserted lines), and the mirror grew identically.
+| | bytes | tokens | delta vs `origin/main` |
+|---|---|---|---|
+| `origin/main` baseline | 27,777 | 67,300 (surface) | — |
+| first draft | 30,943 | 68,091 | +3,166 B / +791 tok |
+| after the stub/companion split | 29,368 | 67,698 | **+1,591 B / +398 tok** |
 
-**Flag, not a blocker:** a separate card carries an always-loaded ratchet whose
-target is materially tighter than the live 76,000 budget. This card's +3,166
-bytes consume headroom that ratchet is counting on. Nothing here is over any
-enforced budget, and the two changes have not met in one tree — the lead owns
-the integration-order call.
+The cost is halved and the rationale is preserved rather than deleted — the
+companion grew by the text the stub gave up, and the companion is not
+always-loaded.
+
+**Measurement provenance (the lead asked for the command, not the number).**
+The figure is `internal/config` `measureAlwaysLoaded`, whose surface is: every
+`.claude/rules/moai/**/*.md` whose frontmatter carries NO `paths:` key, sorted,
+plus four fixed slots (`CLAUDE.md`, `AGENTS.md`,
+`.claude/output-styles/moai/moai.md`, `MEMORY.md`); `MEMORY.md` is measured as
+its load head only (first 200 newlines or 25 KiB, whichever comes first) and is
+absent in this tree, so it contributes 0. Tokens are `len(bytes) / 4`. The
+enumeration is 18 entries; the per-file breakdown is in the completion report.
 
 ## §E.3 Run-phase Audit-Ready Signal
 

--- a/.moai/specs/SPEC-KANBAN-PR-CARD-TRACEABILITY-001/spec.md
+++ b/.moai/specs/SPEC-KANBAN-PR-CARD-TRACEABILITY-001/spec.md
@@ -2,7 +2,7 @@
 id: SPEC-KANBAN-PR-CARD-TRACEABILITY-001
 title: "Pre-dispatch PR cross-check and the PR-title card-id convention"
 version: "0.1.1"
-status: draft
+status: in-progress
 created: 2026-08-24
 updated: 2026-08-24
 author: manager-spec

--- a/.moai/specs/SPEC-KANBAN-PR-CARD-TRACEABILITY-001/spec.md
+++ b/.moai/specs/SPEC-KANBAN-PR-CARD-TRACEABILITY-001/spec.md
@@ -123,7 +123,10 @@ not a smarter parser.**
 carries a descriptive slug (`WT-branch-naming`, not `WT-t0`) so a reader of
 `git branch` learns what changed. That rule assigns traceability to three
 carriers: the dispatch `card:` field, the commit message, and the evidence path.
-REQ-003 adds a fourth — the PR title — and it is the only machine-readable one.
+REQ-003 adds a fourth — the PR title — and it is the only one a resolver can
+read off the pull-request surface itself. The dispatch `card:` field is
+machine-readable too, but it lives in a session message rather than on the
+pull request, so nothing reading a pull request can reach it.
 Branch names are for humans scanning a list; PR titles are for a resolver. There
 is no conflict, but a reader meeting both [HARD] clauses cold will suspect one,
 so the doctrine says so outright.

--- a/.moai/specs/SPEC-KANBAN-PR-CARD-TRACEABILITY-001/spec.md
+++ b/.moai/specs/SPEC-KANBAN-PR-CARD-TRACEABILITY-001/spec.md
@@ -1,0 +1,243 @@
+---
+id: SPEC-KANBAN-PR-CARD-TRACEABILITY-001
+title: "Pre-dispatch PR cross-check and the PR-title card-id convention"
+version: "0.1.0"
+status: draft
+created: 2026-08-24
+updated: 2026-08-24
+author: manager-spec
+priority: P1
+phase: "v3.2.0 target"
+module: ".claude/rules/moai/workflow"
+lifecycle: spec-anchored
+tags: "kanban, dispatch, doctrine, traceability, template-mirror"
+tier: S
+---
+
+## HISTORY
+
+- 2026-08-24 — v0.1.0 — plan-phase authoring. Split out of
+  `SPEC-KANBAN-QUEUE-PR-SYNC-001` per audit finding D14
+  (`.moai/reports/t210/verdict.md`): that SPEC carried 19 leaf requirements
+  against a Tier M ceiling of 16, and its four doctrine requirements are
+  code-free and land on a different schedule from the tooling.
+
+## A. Context
+
+A kanban lead dispatches a card out of `backlog` without any check on whether
+the work already exists. Two measured incidents follow from that, both recorded
+in `.moai/reports/t210/measurement.md` and re-verified during the t210 audit:
+
+1. Five cards (t200, t201, t202, t203, t205) sat `queued` while each carried an
+   open PR (**M1**).
+2. Card t199 sat `queued` while its fix commit was already an ancestor of
+   `origin/main` — discovered only after a lane had started, costing one full
+   lane.
+
+Neither is a tooling gap alone. The lead has no obligation to look, so a lead
+with perfect tooling available would still dispatch blind. That obligation is
+what this SPEC adds.
+
+This SPEC is **doctrine only — no code**. The tooling it relies on is
+`SPEC-KANBAN-QUEUE-PR-SYNC-001` (`moai todo pr`, the resolver, the landed
+check). The two are sequenced deliberately, and this one lands first: the
+PR-title convention in REQ-2 is what raises the title carrier's recall, and the
+resolver is materially more useful once titles are reliable.
+
+**Doctrine before tooling is a real, accepted cost.** Between this SPEC landing
+and the sibling shipping, the [HARD] cross-check clause is live and the operator
+satisfies it by hand (`gh pr list`, `git log`). That interval is why the split
+is honest rather than cosmetic: the previous single-SPEC plan left the same
+interval implicit inside one milestone sequence.
+
+## B. Requirements
+
+4 leaf requirements (Tier S ceiling: 8).
+
+**REQ-001** — **When** the lead is about to dispatch a card out of `backlog`,
+`.claude/rules/moai/workflow/kanban-dispatch.md` shall require the lead to read
+that card's pull-request and landed state first and to report what it read in
+the same turn.
+
+**REQ-002** — **While** a card carries an open pull request or is already landed
+on `origin/main`, the lead shall report that fact to the operator and shall not
+dispatch the card until the operator, so informed, confirms or withdraws it.
+
+The wording is deliberate and the distinction is load-bearing. Under
+`kanban-dispatch.md` line 29, *"Promotion is the operator's act, always"* — the
+operator has **already picked** this card. A lead that then withholds dispatch
+on its own authority has overridden an operator act, which is precisely the
+de-facto-authority hazard the sibling SPEC's read-only ruling exists to prevent.
+So the clause is **report-and-re-decide, never a lead-side veto**: the lead
+surfaces what it read and hands the decision back. No mechanical check can tell
+the two readings apart after the fact, so the wording is the only control.
+
+**REQ-003** — Every pull request delivering a card shall carry that card's id in
+its **title**.
+
+The clause binds only card-delivering pull requests. A release PR, a batch PR,
+or a `chore(release-update)` PR delivers no card and carries no obligation.
+
+**REQ-004** — The doctrine shall state explicitly that REQ-003 does not
+contradict the existing [HARD] rule that a card worktree's **branch** name must
+exclude the card id, and shall name the four traceability carriers so a reader
+sees the division rather than a conflict.
+
+## C. Why these two clauses, and why they are cheap
+
+**REQ-001/002 close the gap that cost the lane.** The measured failure was not
+that the lead looked and misread; it was that nothing required it to look.
+
+**REQ-003 is codification, not imposition.** Per **M6**, 8 of 15 merged PR titles
+already carry a card token, and most of the 7 that do not deliver no card at all
+(`release: v3.1.3`, the v3.1.3 batch PR, three `chore(release-update)` entries).
+Among merged PRs delivering a single card, the title token is close to
+universal. The rule names a convention contributors already mostly follow.
+
+**REQ-003 is also what makes the tooling exact.** Per **M2**, the title carrier
+has precision 7/7 but recall 7/11 (64%); the body carrier has recall 11/11 but
+carries up to 5 tokens for 1 card. Making the title mandatory takes the precise
+carrier to full recall, which converts the sibling SPEC's resolver from a
+heuristic into a lookup. **The fix for ambiguous parsing is a naming convention,
+not a smarter parser.**
+
+**REQ-004 forestalls a reading that looks like a contradiction.**
+`kanban-dispatch.md` already forbids the card id in the branch name — the branch
+carries a descriptive slug (`WT-branch-naming`, not `WT-t0`) so a reader of
+`git branch` learns what changed. That rule assigns traceability to three
+carriers: the dispatch `card:` field, the commit message, and the evidence path.
+REQ-003 adds a fourth — the PR title — and it is the only machine-readable one.
+Branch names are for humans scanning a list; PR titles are for a resolver. There
+is no conflict, but a reader meeting both [HARD] clauses cold will suspect one,
+so the doctrine says so outright.
+
+## D. Acceptance criteria (inline — Tier S)
+
+4 criteria (Tier S ceiling: 8). Each grep-shaped criterion records the
+zero-hit pre-implementation baseline that makes it non-vacuous, and each is
+split into a mechanical half and a reviewer-judgement half so the SPEC does not
+claim mechanical coverage of a human judgement (audit D12).
+
+### AC-001 — the pre-dispatch cross-check clause exists and is marked [HARD]
+
+**Pre-implementation baseline (required, confirmed independently during the
+t210 audit):**
+
+```
+$ grep -c 'pre-dispatch PR cross-check' .claude/rules/moai/workflow/kanban-dispatch.md
+0
+```
+
+**Mechanical.** **Given** the doctrine file after M1 **When** the following run
+**Then** both return at least 1:
+
+```
+grep -c 'pre-dispatch PR cross-check' .claude/rules/moai/workflow/kanban-dispatch.md
+grep -c '\[HARD\].*pre-dispatch PR cross-check' .claude/rules/moai/workflow/kanban-dispatch.md
+```
+
+The second grep is what makes the `[HARD]` marker mechanically observable rather
+than asserted.
+
+**Reviewer judgement (recorded as such).** A reviewer confirms the clause
+actually requires the lead to *read and report* the card's PR and landed state
+before dispatching. No command verifies this, and this SPEC does not claim one
+does.
+
+### AC-002 — the clause is report-and-re-decide, not a lead-side veto
+
+**Mechanical.** The clause contains the phrase `confirms or withdraws`:
+
+```
+grep -c 'confirms or withdraws' .claude/rules/moai/workflow/kanban-dispatch.md
+```
+
+Baseline 0 before M1; at least 1 after.
+
+**Reviewer judgement (recorded as such).** A reviewer confirms the clause reads
+as report-and-re-decide and cannot be read as authorizing the lead to refuse a
+picked card on its own authority (REQ-002).
+
+This criterion exists because the ambiguity it guards against is invisible to
+the AC-001 greps: a clause satisfying both of those could still be written as a
+veto.
+
+### AC-003 — the PR-title clause and its non-contradiction note exist
+
+**Pre-implementation baseline (required, confirmed independently during the
+t210 audit):**
+
+```
+$ grep -c 'PR title MUST carry the delivering card id' .claude/rules/moai/workflow/kanban-dispatch.md
+0
+```
+
+**Mechanical.** After M1 that grep returns at least 1, and the same section
+names all four traceability carriers:
+
+```
+grep -c 'PR title MUST carry the delivering card id' .claude/rules/moai/workflow/kanban-dispatch.md
+```
+
+**Reviewer judgement (recorded as such).** A reviewer confirms the section
+explicitly states the non-contradiction against the branch-name exclusion rule,
+names the branch slug and the three existing carriers, and scopes the obligation
+to card-delivering pull requests only (REQ-003, REQ-004).
+
+### AC-004 — template mirror parity
+
+**Given** the doctrine edits in `.claude/rules/moai/workflow/kanban-dispatch.md`
+**When** the mirror at
+`internal/template/templates/.claude/rules/moai/workflow/kanban-dispatch.md` is
+compared
+**Then** every clause added by AC-001, AC-002, and AC-003 is present in the
+mirror,
+**And** `MOAI_TEMPLATE_LEAK_STRICT=1 go test ./internal/template/... -v` passes,
+**And** `make build` has been run.
+
+Both mirror targets were confirmed present during the t210 audit.
+
+## E. Exclusions
+
+### Out of Scope — all tooling
+
+- No Go code, no CLI verb, no resolver, no `gh` or `git` invocation ships in
+  this SPEC. Every mechanical capability the doctrine references belongs to
+  `SPEC-KANBAN-QUEUE-PR-SYNC-001`.
+- The clause is satisfiable by hand in the interval before that SPEC lands
+  (§A), which is what makes the ordering safe.
+
+### Out of Scope — queue mutation
+
+- Nothing here writes to `.moai/state/kanban/backlog.json`. The lead's
+  obligation is to read and report; the operator still decides. The three [HARD]
+  clauses of `kanban-dispatch.md` § Entry into the board is an operator act are
+  unchanged.
+
+### Out of Scope — retroactive relabelling
+
+- Currently-open and already-merged pull requests are not retitled. REQ-003
+  binds pull requests opened after this SPEC lands.
+
+### Out of Scope — enforcement automation
+
+- No CI check, hook, or lint rule enforces the PR-title convention. The
+  obligation is doctrinal. Mechanical enforcement — a PR-title check in CI — is
+  a plausible follow-up once the convention has settled, and is not specified
+  here.
+
+## F. Cross-references
+
+- `SPEC-KANBAN-QUEUE-PR-SYNC-001` — the sibling Tier M SPEC carrying the
+  tooling; lands second.
+- `.moai/reports/t210/measurement.md` — M1 (the five divergent cards), M2 (the
+  carrier scorecard), M6 (the title convention already emergent).
+- `.moai/reports/t210/verdict.md` — audit iteration 1; D14 (the split), D3 (the
+  REQ-002 wording), D12 (the mechanical/judgement AC split), D15 (mirror
+  parity).
+- `.claude/rules/moai/workflow/kanban-dispatch.md` — the file being amended:
+  § Entry into the board is an operator act (three [HARD] clauses at lines 27 /
+  29 / 31), § Isolation (the branch-naming rule and the three carriers),
+  § Completion is read, never trusted.
+- `.claude/rules/moai/core/verification-claim-integrity.md` — the
+  read-don't-trust invariant REQ-001 operationalizes at the dispatch boundary.

--- a/.moai/specs/SPEC-KANBAN-PR-CARD-TRACEABILITY-001/spec.md
+++ b/.moai/specs/SPEC-KANBAN-PR-CARD-TRACEABILITY-001/spec.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-KANBAN-PR-CARD-TRACEABILITY-001
 title: "Pre-dispatch PR cross-check and the PR-title card-id convention"
-version: "0.1.0"
+version: "0.1.1"
 status: draft
 created: 2026-08-24
 updated: 2026-08-24
@@ -21,6 +21,13 @@ tier: S
   (`.moai/reports/t210/verdict.md`): that SPEC carried 19 leaf requirements
   against a Tier M ceiling of 16, and its four doctrine requirements are
   code-free and land on a different schedule from the tooling.
+- 2026-08-24 — v0.1.1 — audit iteration 2 PASS (0.775 against the Tier S
+  threshold of 0.75); `.moai/reports/t210/verdict-2.md`. Lead-verified repairs:
+  N3 (REQ-005 restored — the template-mirror obligation did not survive the
+  split into the requirement layer, leaving AC-004 orphaned) and N4 (a judgement
+  removed from AC-003's `**Mechanical.**` block, where it was a relapse of the
+  very defect the split-AC pattern exists to prevent). 5 requirements against a
+  Tier S ceiling of 8.
 
 ## A. Context
 
@@ -52,7 +59,7 @@ interval implicit inside one milestone sequence.
 
 ## B. Requirements
 
-4 leaf requirements (Tier S ceiling: 8).
+5 leaf requirements (Tier S ceiling: 8).
 
 **REQ-001** — **When** the lead is about to dispatch a card out of `backlog`,
 `.claude/rules/moai/workflow/kanban-dispatch.md` shall require the lead to read
@@ -82,6 +89,16 @@ or a `chore(release-update)` PR delivers no card and carries no obligation.
 contradict the existing [HARD] rule that a card worktree's **branch** name must
 exclude the card id, and shall name the four traceability carriers so a reader
 sees the division rather than a conflict.
+
+**REQ-005** — Every doctrine change this SPEC makes to
+`.claude/rules/moai/workflow/kanban-dispatch.md` shall be mirrored into
+`internal/template/templates/.claude/rules/moai/workflow/kanban-dispatch.md` per
+the Template-First rule, subject to the template neutrality catalogue.
+
+Restored per audit N3. This requirement existed in the pre-split SPEC (as
+REQ-3.4) and did not survive the split into the requirement layer, which left
+AC-004 exercising no requirement. Tier S is at 5 of a ceiling of 8, so unlike
+the sibling SPEC's N1 there is no budget obstacle to stating it normatively.
 
 ## C. Why these two clauses, and why they are cheap
 
@@ -172,19 +189,25 @@ $ grep -c 'PR title MUST carry the delivering card id' .claude/rules/moai/workfl
 0
 ```
 
-**Mechanical.** After M1 that grep returns at least 1, and the same section
-names all four traceability carriers:
+**Mechanical.** After M1 that grep returns at least 1:
 
 ```
 grep -c 'PR title MUST carry the delivering card id' .claude/rules/moai/workflow/kanban-dispatch.md
 ```
+
+> Per audit N4, the clause *"and the same section names all four traceability
+> carriers"* was removed from this Mechanical block. The shown grep covers only
+> the first clause, so the four-carrier claim was a judgement wearing a
+> mechanical label — a relapse of the exact defect this SPEC's split-AC pattern
+> exists to prevent. Nothing is lost: the claim is stated correctly in the
+> judgement half below.
 
 **Reviewer judgement (recorded as such).** A reviewer confirms the section
 explicitly states the non-contradiction against the branch-name exclusion rule,
 names the branch slug and the three existing carriers, and scopes the obligation
 to card-delivering pull requests only (REQ-003, REQ-004).
 
-### AC-004 — template mirror parity
+### AC-004 — template mirror parity (REQ-005)
 
 **Given** the doctrine edits in `.claude/rules/moai/workflow/kanban-dispatch.md`
 **When** the mirror at
@@ -196,6 +219,20 @@ mirror,
 **And** `make build` has been run.
 
 Both mirror targets were confirmed present during the t210 audit.
+
+### Traceability
+
+| REQ | AC |
+|---|---|
+| REQ-001 | AC-001 |
+| REQ-002 | AC-002 |
+| REQ-003 | AC-003 |
+| REQ-004 | AC-003 (judgement half) |
+| REQ-005 | AC-004 |
+
+Every requirement has a criterion and every criterion exercises a requirement.
+AC-004's mapping to REQ-005 is what audit N3 restored — before the restoration
+it exercised nothing.
 
 ## E. Exclusions
 

--- a/.moai/specs/SPEC-KANBAN-QUEUE-PR-SYNC-001/acceptance.md
+++ b/.moai/specs/SPEC-KANBAN-QUEUE-PR-SYNC-001/acceptance.md
@@ -1,0 +1,219 @@
+# Acceptance Criteria — SPEC-KANBAN-QUEUE-PR-SYNC-001
+
+Every AC below is verified by a command that observes something. Per this
+project's standing rule, a grep-based AC is admissible only when it returns
+**zero** hits on the pre-implementation tree; each grep AC below records its
+required pre-implementation baseline explicitly.
+
+## D. AC Matrix
+
+| AC | Requirement | Kind | Severity |
+|---|---|---|---|
+| AC-001 | REQ-1.2 | behavioural | must |
+| AC-002 | REQ-1.3 | behavioural | must |
+| AC-003 | REQ-1.4, REQ-1.6 | behavioural | must |
+| AC-004 | REQ-2.1 | behavioural (byte-identity) | **must — load-bearing** |
+| AC-005 | REQ-2.3 | behavioural | must |
+| AC-006 | REQ-1.5 | behavioural | must |
+| AC-007 | REQ-1.7 | behavioural | must |
+| AC-008 | REQ-1.8 | behavioural | must |
+| AC-009 | REQ-2.5, REQ-2.4 | behavioural | must |
+| AC-010 | REQ-2.6, REQ-2.7 | behavioural | must |
+| AC-011 | REQ-3.1 | grep (zero-baseline) | must |
+| AC-012 | REQ-3.2, REQ-3.3 | grep (zero-baseline) | must |
+| AC-013 | REQ-3.4 | mirror parity | must |
+
+---
+
+### AC-001 — an id in the PR title resolves `exact`
+
+**Given** a fixture PR set containing PR #1617 with title token `t205`
+**When** the resolver is run for card `t205`
+**Then** it returns exactly one link, PR number 1617, confidence `exact`.
+
+Verify: `go test ./internal/kanban/... -run TestResolveLink_ExactFromTitle -v`
+
+### AC-002 — no title token, exactly one body token resolves `inferred`
+
+**Given** the fixture set containing PR #1611 (no title token, body token `t201`)
+and no other open PR whose body carries `t201`
+**When** the resolver is run for card `t201`
+**Then** it returns one link, PR number 1611, confidence `inferred`.
+
+Verify: `go test ./internal/kanban/... -run TestResolveLink_InferredFromBody -v`
+
+### AC-003 — several body tokens resolve `ambiguous`, never a best guess
+
+**Given** the fixture set containing PR #1614 whose body carries the five tokens
+`t1, t151, t203, t69, t9` and no title token
+**When** the resolver is run for card `t151`, which also appears in another PR body
+**Then** the result is labelled `ambiguous`, enumerates every candidate PR number,
+**And** no single PR is returned as the resolved link.
+
+Verify: `go test ./internal/kanban/... -run TestResolveLink_AmbiguousNotCollapsed -v`
+
+### AC-004 — the queue file is byte-identical across a read-surface invocation
+
+**This is the load-bearing AC for the read-only ruling in spec.md §B.**
+
+**Given** a `backlog.json` fixture with a recorded SHA-256
+**When** `moai todo pr` and `moai todo pr --json` are each invoked against it
+**Then** the file's SHA-256 is unchanged after every invocation,
+**And** its modification time is unchanged,
+**And** this holds equally on the fail-open path (AC-005) and on the ambiguous
+path (AC-003).
+
+Verify: `go test ./internal/cli/... -run TestTodoPR_QueueFileByteIdentical -v`
+
+The test asserts the digest, not merely "no error" — an error-free run that
+rewrote the file with identical semantics but different bytes still fails.
+
+### AC-005 — fail-open when `gh` is unavailable
+
+**Given** a `PATH` from which `gh` is absent
+**When** `moai todo pr` is invoked
+**Then** the exit code is 0,
+**And** the output renders the queue with the link column blank or absent,
+**And** stderr carries a degradation note, not an error,
+**And** AC-004's byte-identity assertion still holds.
+
+Verify: `go test ./internal/cli/... -run TestTodoPR_FailOpenNoGh -v`
+
+Repeat for `gh` present but exiting non-zero (unauthenticated / offline
+simulation): `-run TestTodoPR_FailOpenGhNonZero`.
+
+### AC-006 — commit messages are not a carrier
+
+**Given** the fixture set containing PR #1600, whose 15 commit-message tokens do
+not include its delivering card `t184`, and whose body carries `t184`
+**When** the resolver is run for card `t131` (present in #1600's commit tokens,
+absent from its title and body)
+**Then** the resolver returns no link to #1600 for `t131`.
+
+Verify: `go test ./internal/kanban/... -run TestResolveLink_IgnoresCommitTokens -v`
+
+### AC-007 — no link is distinguishable from ambiguous
+
+**Given** a card id present in no open PR title or body
+**When** the resolver is run
+**Then** it returns a no-link result whose kind the caller can distinguish from
+an `ambiguous` result (distinct type or explicit field, not an empty candidate
+list on an ambiguous record).
+
+Verify: `go test ./internal/kanban/... -run TestResolveLink_NoLinkDistinctFromAmbiguous -v`
+
+### AC-008 — whole-token matching
+
+**Given** a fixture PR whose title carries `t200`
+**When** the resolver is run for card `t20`
+**Then** no link is returned.
+
+Verify: `go test ./internal/kanban/... -run TestResolveLink_WholeTokenOnly -v`
+
+### AC-009 — `moai todo list` stays network-free
+
+**Given** a `PATH` from which `gh` is absent and a network-denying environment
+**When** `moai todo list` is invoked with no flags
+**Then** it exits 0 and renders the queue,
+**And** no `gh` process is spawned (asserted via an injected executor recording
+zero invocations).
+
+Verify: `go test ./internal/cli/... -run TestTodoList_NoGhInvocation -v`
+
+### AC-010 — confidence is rendered, and the JSON form carries it
+
+**Given** a fixture producing one `exact`, one `inferred`, and one `ambiguous`
+result
+**When** `moai todo pr --json` is invoked
+**Then** each record carries `card_id`, `pr` (number or candidate list),
+`pr_state`, and `confidence`,
+**And** the human render displays the confidence label next to every link.
+
+Verify: `go test ./internal/cli/... -run TestTodoPR_RendersConfidence -v`
+
+### AC-011 — the pre-dispatch cross-check exists in the doctrine
+
+**Pre-implementation baseline (required):** the following returns **zero** hits
+on the tree before M1 lands. Confirm the zero baseline before accepting this AC.
+
+```
+grep -c 'pre-dispatch PR cross-check' .claude/rules/moai/workflow/kanban-dispatch.md
+```
+
+**Given** the doctrine file after M1
+**When** the grep is run
+**Then** it returns at least 1,
+**And** the surrounding clause is marked [HARD] and requires the lead to read
+and report the card's PR state before dispatching out of `backlog`.
+
+### AC-012 — the PR-title clause and its non-contradiction note exist
+
+**Pre-implementation baseline (required):** zero hits before M1.
+
+```
+grep -c 'PR title MUST carry the delivering card id' .claude/rules/moai/workflow/kanban-dispatch.md
+```
+
+**Given** the doctrine file after M1
+**When** the grep is run
+**Then** it returns at least 1,
+**And** the same section explicitly states that this does not contradict the
+branch-name exclusion rule, naming the branch slug and the three existing
+traceability carriers.
+
+### AC-013 — template mirror parity
+
+**Given** the doctrine edit in `.claude/rules/…/kanban-dispatch.md`
+**When** the mirror at
+`internal/template/templates/.claude/rules/moai/workflow/kanban-dispatch.md`
+is compared
+**Then** both clauses are present in the mirror,
+**And** the neutrality guard passes.
+
+Verify: `MOAI_TEMPLATE_LEAK_STRICT=1 go test ./internal/template/... -v`
+
+---
+
+## D.1 Severity
+
+All ACs above are `must`. There are no `should`-severity criteria in this SPEC.
+
+## D.2 Traceability
+
+| REQ | AC |
+|---|---|
+| REQ-1.1 | AC-001, AC-002, AC-003, AC-010 |
+| REQ-1.2 | AC-001 |
+| REQ-1.3 | AC-002 |
+| REQ-1.4 | AC-003 |
+| REQ-1.5 | AC-006 |
+| REQ-1.6 | AC-003 |
+| REQ-1.7 | AC-007 |
+| REQ-1.8 | AC-008 |
+| REQ-2.1 | AC-004 |
+| REQ-2.2 | AC-004 |
+| REQ-2.3 | AC-005 |
+| REQ-2.4 | AC-009 |
+| REQ-2.5 | AC-009 |
+| REQ-2.6 | AC-010 |
+| REQ-2.7 | AC-010 |
+| REQ-3.1 | AC-011 |
+| REQ-3.2 | AC-012 |
+| REQ-3.3 | AC-012 |
+| REQ-3.4 | AC-013 |
+
+## D.3 Quality gates
+
+- `go vet ./...` clean.
+- `golangci-lint run` clean on touched packages.
+- Affected-package tests green locally; full-suite verdict from CI on the PR head.
+- Coverage on the new resolver package ≥ 85%.
+
+## D.4 Definition of Done
+
+- All 13 ACs pass with cited command output.
+- AC-004's digest assertion is present in the committed test file, not merely
+  performed by hand.
+- AC-011 and AC-012 each recorded their zero-baseline grep result before the
+  doctrine edit landed.
+- Doctrine and template mirror committed together; `make build` run.

--- a/.moai/specs/SPEC-KANBAN-QUEUE-PR-SYNC-001/acceptance.md
+++ b/.moai/specs/SPEC-KANBAN-QUEUE-PR-SYNC-001/acceptance.md
@@ -1,6 +1,6 @@
 # Acceptance Criteria — SPEC-KANBAN-QUEUE-PR-SYNC-001
 
-13 acceptance criteria (Tier M ceiling: 16).
+14 acceptance criteria (Tier M ceiling: 16).
 
 Every criterion is verified by a command that observes something. Per this
 project's standing rule, a grep-based criterion is admissible only when it
@@ -40,7 +40,8 @@ values**, not re-fetched at test time — the live PR set changes.
 | AC-010 | REQ-2.6 | behavioural | must |
 | AC-011 | REQ-1.9 | behavioural (with controls) | **must — anti-vacuous** |
 | AC-012 | REQ-1.10 | behavioural | must |
-| AC-013 | mirror parity (plan.md M4) | mechanical grep + reviewer judgement | must |
+| AC-013 | `plan.md` §D Template-First constraint (no REQ — see D.2) | mechanical grep + reviewer judgement | must |
+| AC-014 | NFR-1, NFR-2 | behavioural (subprocess census) | **must — protects the design ruling** |
 
 ---
 
@@ -260,16 +261,48 @@ the SPEC does not claim it does.
 > `kanban-dispatch.md` mirror criterion moved with the doctrine changes to
 > `SPEC-KANBAN-PR-CARD-TRACEABILITY-001`.
 
+### AC-014 — exactly one `gh` process, regardless of queue length
+
+**This criterion protects REQ-2.5's design ruling. Without it, the ruling's own
+justification is unenforced.**
+
+**Given** a queue fixture containing **at least three** cards — the count must
+exceed one, or the assertion cannot distinguish a single batched query from a
+per-card loop
+**And** an injected command executor that records every subprocess invocation
+with its argv
+**When** `moai todo pr` is invoked over that queue
+**Then** exactly **one** `gh` process was spawned,
+**And** its argv is a single `gh pr list --state open …` (not a per-card
+`gh pr view`),
+**And** the count is one for a 3-card fixture and one for a 10-card fixture —
+asserted at two queue lengths, so the criterion observes invariance rather than
+a coincidence,
+**And** the landed check spawned only `git` processes, never `gh` (NFR-2 — the
+landed path is local and does not consume the network budget).
+
+Verify: `go test ./internal/cli/... -run TestTodoPR_ExactlyOneGhInvocation -v`
+
+> Added per audit N2. None of the four NFRs previously had a criterion, and
+> NFR-1 is the sole justification for the dedicated-verb ruling in REQ-2.5: an
+> implementation issuing one `gh` query per card satisfies all thirteen other
+> criteria while costing 0.878s × queue length — passing the SPEC while
+> defeating the thing the SPEC exists to protect. NFR-3 (no new dependency) and
+> NFR-4 (purity) need no criterion: the first is observable in `go.mod`, the
+> second is structurally implied by the fixture-driven tests in AC-001 through
+> AC-003.
+
 ---
 
 ## D.1 Severity
 
-All 13 criteria are `must`. There are no `should`-severity criteria.
+All 14 criteria are `must`. There are no `should`-severity criteria.
 
-Two are called out above as carrying extra weight, for different reasons:
-AC-004 is **load-bearing** (it is what enforces the §B read-only ruling), and
+Three are called out above as carrying extra weight, for different reasons:
+AC-004 is **load-bearing** (it is what enforces the §B read-only ruling),
 AC-011 is **anti-vacuous** (its failure mode is a silent empty result that would
-otherwise pass).
+otherwise pass), and AC-014 **protects the design ruling** (without it, REQ-2.5's
+justification is unenforced and a per-card implementation passes).
 
 ## D.2 Traceability
 
@@ -291,11 +324,30 @@ otherwise pass).
 | REQ-2.4 | AC-009 |
 | REQ-2.5 | AC-009 |
 | REQ-2.6 | AC-010 |
+| NFR-1 | AC-014 |
+| NFR-2 | AC-014 |
 
-Every one of the 16 leaf requirements has at least one criterion, and every
-criterion exercises at least one requirement. The two mappings the audit found
-non-functional (REQ-1.3 via AC-002, REQ-1.4 / REQ-1.6 via AC-003) are repaired
-by the D4 fixture rebuild above.
+Non-requirement obligations, mapped explicitly so no criterion is orphaned:
+
+| Obligation | Carried by | AC |
+|---|---|---|
+| Template-First mirror of `todo.md` | `plan.md` §D constraint + M4 exit | AC-013 |
+
+**Every one of the 16 leaf requirements has at least one criterion.** Thirteen
+of the fourteen criteria exercise a requirement or an NFR; **AC-013 exercises
+neither** — the `todo.md` mirror obligation is carried by the Template-First
+constraint in `plan.md` §D, not by any REQ in `spec.md` §D, and the row above
+records that rather than implying a requirement that does not exist.
+
+> Restated per audit N1. The prior sentence claimed "every criterion exercises
+> at least one requirement", which was false for AC-013 — an unobserved claim
+> the document made about its own contents. The structurally better fix is a
+> normative template-mirror requirement, but the SPEC sits at exactly 16/16 and
+> that route breaches the Tier M ceiling; it is recorded as a follow-up in
+> `spec.md` §H rather than taken here.
+
+The two mappings the audit found non-functional (REQ-1.3 via AC-002,
+REQ-1.4 / REQ-1.6 via AC-003) are repaired by the D4 fixture rebuild above.
 
 ## D.3 Quality gates
 
@@ -308,9 +360,12 @@ by the D4 fixture rebuild above.
 
 ## D.4 Definition of Done
 
-- All 13 criteria pass with cited command output.
+- All 14 criteria pass with cited command output.
 - AC-004's recursive-digest assertion is present in the committed test file, not
   performed by hand.
+- AC-014's subprocess census runs at two queue lengths (≥3 and 10); a
+  single-card fixture is rejected, because it cannot distinguish one batched
+  query from a per-card loop.
 - AC-011's positive control, negative control, and `-E` tripwire are all three
   present; a landed-check test suite without the positive control is rejected.
 - AC-013 recorded its zero-baseline grep result on both files before M4 landed,

--- a/.moai/specs/SPEC-KANBAN-QUEUE-PR-SYNC-001/acceptance.md
+++ b/.moai/specs/SPEC-KANBAN-QUEUE-PR-SYNC-001/acceptance.md
@@ -1,188 +1,281 @@
 # Acceptance Criteria — SPEC-KANBAN-QUEUE-PR-SYNC-001
 
-Every AC below is verified by a command that observes something. Per this
-project's standing rule, a grep-based AC is admissible only when it returns
-**zero** hits on the pre-implementation tree; each grep AC below records its
-required pre-implementation baseline explicitly.
+13 acceptance criteria (Tier M ceiling: 16).
+
+Every criterion is verified by a command that observes something. Per this
+project's standing rule, a grep-based criterion is admissible only when it
+returns **zero** hits on the pre-implementation tree; the one grep-shaped
+criterion here (AC-013) records its required baseline explicitly.
+
+**Fixture provenance.** The PR fixtures below were re-measured live in this
+worktree with:
+
+```
+$ gh pr list --state open --limit 40 --json number,title,body \
+    -q '.[] | "\(.number)|TITLE:\([.title|scan("\\bt[0-9]{1,4}\\b")]|join(" "))|BODY:\([.body//""|scan("\\bt[0-9]{1,4}\\b")]|unique|join(" "))"'
+1614|TITLE:t203|BODY:t1 t151 t203 t69 t9
+1612|TITLE:t200|BODY:t200 t201
+1611|TITLE:|BODY:t201
+1601|TITLE:|BODY:t188
+1600|TITLE:|BODY:t184
+```
+
+The v0.1.1 fixtures for AC-002 and AC-003 were refuted by this data (audit D4)
+and are rebuilt below. Per `plan.md` §B the fixture set is **pinned from these
+values**, not re-fetched at test time — the live PR set changes.
 
 ## D. AC Matrix
 
-| AC | Requirement | Kind | Severity |
+| AC | Requirement(s) | Kind | Severity |
 |---|---|---|---|
 | AC-001 | REQ-1.2 | behavioural | must |
 | AC-002 | REQ-1.3 | behavioural | must |
 | AC-003 | REQ-1.4, REQ-1.6 | behavioural | must |
-| AC-004 | REQ-2.1 | behavioural (byte-identity) | **must — load-bearing** |
+| AC-004 | REQ-2.1, REQ-2.2 | behavioural (directory digest) | **must — load-bearing** |
 | AC-005 | REQ-2.3 | behavioural | must |
 | AC-006 | REQ-1.5 | behavioural | must |
 | AC-007 | REQ-1.7 | behavioural | must |
 | AC-008 | REQ-1.8 | behavioural | must |
-| AC-009 | REQ-2.5, REQ-2.4 | behavioural | must |
-| AC-010 | REQ-2.6, REQ-2.7 | behavioural | must |
-| AC-011 | REQ-3.1 | grep (zero-baseline) | must |
-| AC-012 | REQ-3.2, REQ-3.3 | grep (zero-baseline) | must |
-| AC-013 | REQ-3.4 | mirror parity | must |
+| AC-009 | REQ-2.4, REQ-2.5 | behavioural | must |
+| AC-010 | REQ-2.6 | behavioural | must |
+| AC-011 | REQ-1.9 | behavioural (with controls) | **must — anti-vacuous** |
+| AC-012 | REQ-1.10 | behavioural | must |
+| AC-013 | mirror parity (plan.md M4) | mechanical grep + reviewer judgement | must |
 
 ---
 
 ### AC-001 — an id in the PR title resolves `exact`
 
-**Given** a fixture PR set containing PR #1617 with title token `t205`
-**When** the resolver is run for card `t205`
-**Then** it returns exactly one link, PR number 1617, confidence `exact`.
+**Given** the pinned fixture containing PR #1612 with title token `t200`
+**When** the resolver is run for card `t200`
+**Then** it returns a `linked` outcome, PR number 1612, confidence `exact`.
 
-Verify: `go test ./internal/kanban/... -run TestResolveLink_ExactFromTitle -v`
+Verify: `go test ./internal/kanban/... -run TestResolve_ExactFromTitle -v`
 
 ### AC-002 — no title token, exactly one body token resolves `inferred`
 
-**Given** the fixture set containing PR #1611 (no title token, body token `t201`)
-and no other open PR whose body carries `t201`
-**When** the resolver is run for card `t201`
-**Then** it returns one link, PR number 1611, confidence `inferred`.
+**Given** the pinned fixture, in which `t188` appears in no PR title and in
+exactly one PR body (#1601)
+**When** the resolver is run for card `t188`
+**Then** it returns a `linked` outcome, PR number 1601, confidence `inferred`.
 
-Verify: `go test ./internal/kanban/... -run TestResolveLink_InferredFromBody -v`
+Verify: `go test ./internal/kanban/... -run TestResolve_InferredFromSingleBody -v`
+
+> Rebuilt per audit D4. The prior fixture asserted `inferred` for `t201`, whose
+> token appears in **two** bodies (#1611 and #1612) — that is the ambiguous case,
+> and it now anchors AC-003 instead. `t188` is genuinely single-bodied and
+> title-absent.
 
 ### AC-003 — several body tokens resolve `ambiguous`, never a best guess
 
-**Given** the fixture set containing PR #1614 whose body carries the five tokens
-`t1, t151, t203, t69, t9` and no title token
-**When** the resolver is run for card `t151`, which also appears in another PR body
-**Then** the result is labelled `ambiguous`, enumerates every candidate PR number,
-**And** no single PR is returned as the resolved link.
+**Given** the pinned fixture, in which `t201` appears in no PR title and in
+**two** PR bodies — #1611 and #1612
+**When** the resolver is run for card `t201`
+**Then** the outcome kind is `ambiguous`,
+**And** the candidate list contains exactly {1611, 1612},
+**And** no single PR is returned as a resolved link.
 
-Verify: `go test ./internal/kanban/... -run TestResolveLink_AmbiguousNotCollapsed -v`
+Verify: `go test ./internal/kanban/... -run TestResolve_AmbiguousNotCollapsed -v`
 
-### AC-004 — the queue file is byte-identical across a read-surface invocation
+> Rebuilt per audit D4. The prior fixture used `t151`, which appears in exactly
+> one body (#1614) and therefore resolves `inferred` — it could never produce
+> `ambiguous`, leaving REQ-1.4 and REQ-1.6 untested. `t201` is the genuine
+> ambiguous case in the measured set.
 
-**This is the load-bearing AC for the read-only ruling in spec.md §B.**
+### AC-004 — nothing under the queue directory changes across an invocation
 
-**Given** a `backlog.json` fixture with a recorded SHA-256
+**This is the load-bearing criterion for the §B read-only ruling.**
+
+**Given** a `.moai/state/kanban/` fixture directory with a recorded recursive
+digest — every file's path plus its SHA-256, plus the set of paths present
 **When** `moai todo pr` and `moai todo pr --json` are each invoked against it
-**Then** the file's SHA-256 is unchanged after every invocation,
-**And** its modification time is unchanged,
-**And** this holds equally on the fail-open path (AC-005) and on the ambiguous
-path (AC-003).
+**Then** the recursive digest is unchanged after every invocation,
+**And** no path has been added or removed (no sidecar, no lock file, no cache),
+**And** `backlog.json`'s own SHA-256 and modification time are unchanged,
+**And** all of the above hold equally on the fail-open path (AC-005), the
+ambiguous path (AC-003), and the landed path (AC-011).
 
-Verify: `go test ./internal/cli/... -run TestTodoPR_QueueFileByteIdentical -v`
+Verify: `go test ./internal/cli/... -run TestTodoPR_QueueDirUnchanged -v`
 
-The test asserts the digest, not merely "no error" — an error-free run that
-rewrote the file with identical semantics but different bytes still fails.
+> Widened per audit D7. A single-file byte-identity assertion is necessary but
+> not sufficient for REQ-2.2, which forbids caching into *any* queue-owned file:
+> a `findings` sidecar, a lock taken and released, or an mtime touch on a
+> neighbouring file would all pass a `backlog.json`-only check. Declaring one
+> criterion load-bearing raises the bar for it rather than lowering it for its
+> neighbours.
 
 ### AC-005 — fail-open when `gh` is unavailable
 
 **Given** a `PATH` from which `gh` is absent
 **When** `moai todo pr` is invoked
 **Then** the exit code is 0,
-**And** the output renders the queue with the link column blank or absent,
-**And** stderr carries a degradation note, not an error,
-**And** AC-004's byte-identity assertion still holds.
+**And** the link column renders **empty** for every card (not omitted — the
+column is present and blank),
+**And** stderr carries a degradation note rather than an error,
+**And** the landed check still runs, so a landed card still reports `landed`,
+**And** AC-004's digest assertion still holds.
 
 Verify: `go test ./internal/cli/... -run TestTodoPR_FailOpenNoGh -v`
 
 Repeat for `gh` present but exiting non-zero (unauthenticated / offline
 simulation): `-run TestTodoPR_FailOpenGhNonZero`.
 
-### AC-006 — commit messages are not a carrier
+> Disjunction removed per audit D11. "Blank **or** absent" could not fail on
+> rendering, so the assertion observed only that the process did not crash —
+> which the exit-code clause already covers. The column is blank.
 
-**Given** the fixture set containing PR #1600, whose 15 commit-message tokens do
-not include its delivering card `t184`, and whose body carries `t184`
-**When** the resolver is run for card `t131` (present in #1600's commit tokens,
-absent from its title and body)
-**Then** the resolver returns no link to #1600 for `t131`.
+### AC-006 — commit tokens are not an attribution carrier
 
-Verify: `go test ./internal/kanban/... -run TestResolveLink_IgnoresCommitTokens -v`
+**Given** the pinned fixture for PR #1600, whose body carries `t184` and whose
+commit messages carry many other card tokens but **not** `t184`
+**When** the resolver is run for a card that appears in #1600's commit tokens
+but in neither its title nor its body
+**Then** the resolver returns no `linked` outcome pointing at #1600 for that
+card.
 
-### AC-007 — no link is distinguishable from ambiguous
+Verify: `go test ./internal/kanban/... -run TestResolve_IgnoresCommitTokensForAttribution -v`
 
-**Given** a card id present in no open PR title or body
-**When** the resolver is run
-**Then** it returns a no-link result whose kind the caller can distinguish from
-an `ambiguous` result (distinct type or explicit field, not an empty candidate
-list on an ambiguous record).
+> Per audit D13, the count is dropped. The prior text pinned "15 commit-message
+> tokens", which no stated command reproduces — a headline-only scan of #1600's
+> commits yields 12, and the record's 15 evidently came from full commit
+> messages. The load-bearing property is not the count: it is that #1600's
+> delivering card is present in the body and absent from the commit tokens.
 
-Verify: `go test ./internal/kanban/... -run TestResolveLink_NoLinkDistinctFromAmbiguous -v`
+### AC-007 — all four outcome kinds are mutually distinguishable
+
+**Given** a fixture producing one of each outcome kind — `linked`, `ambiguous`,
+`landed`, `no-link`
+**When** each is returned to a consumer
+**Then** the consumer can distinguish all four by kind alone,
+**And** in particular `landed` is distinguishable from `no-link` (an
+already-merged card is never reported as untouched work),
+**And** `no-link` is distinguishable from `ambiguous` by kind, not by an empty
+candidate list on an ambiguous record.
+
+Verify: `go test ./internal/kanban/... -run TestResolve_FourOutcomeKindsDistinct -v`
 
 ### AC-008 — whole-token matching
 
 **Given** a fixture PR whose title carries `t200`
 **When** the resolver is run for card `t20`
-**Then** no link is returned.
+**Then** no link is returned for `t20`.
 
-Verify: `go test ./internal/kanban/... -run TestResolveLink_WholeTokenOnly -v`
+Verify: `go test ./internal/kanban/... -run TestResolve_WholeTokenOnly -v`
 
-### AC-009 — `moai todo list` stays network-free
+### AC-009 — `moai todo list` stays network-free and git-free
 
-**Given** a `PATH` from which `gh` is absent and a network-denying environment
+**Given** an injected command executor that records every subprocess invocation
 **When** `moai todo list` is invoked with no flags
 **Then** it exits 0 and renders the queue,
-**And** no `gh` process is spawned (asserted via an injected executor recording
-zero invocations).
+**And** the recorded invocation count is **zero** — no `gh` process and no `git`
+process is spawned.
 
-Verify: `go test ./internal/cli/... -run TestTodoList_NoGhInvocation -v`
+Verify: `go test ./internal/cli/... -run TestTodoList_NoSubprocess -v`
 
-### AC-010 — confidence is rendered, and the JSON form carries it
+> This is a whole claim, not a no-flag-only one, because REQ-2.5 puts no `--pr`
+> flag in scope (audit D5). If a follow-up ever adds the flag (§H), this
+> criterion needs a companion asserting the flag is what gates the spawn.
 
-**Given** a fixture producing one `exact`, one `inferred`, and one `ambiguous`
-result
+### AC-010 — outcome and confidence are rendered, and the JSON form carries them
+
+**Given** a fixture producing one `exact`, one `inferred`, one `ambiguous`, and
+one `landed` outcome
 **When** `moai todo pr --json` is invoked
-**Then** each record carries `card_id`, `pr` (number or candidate list),
-`pr_state`, and `confidence`,
-**And** the human render displays the confidence label next to every link.
+**Then** each record carries `card_id` and `outcome`, carries `pr` and
+`pr_state` for the `linked` and `ambiguous` kinds, and carries `confidence` for
+the `linked` kind,
+**And** the human render displays the outcome kind for every card and the
+confidence label for every `linked` card.
 
-Verify: `go test ./internal/cli/... -run TestTodoPR_RendersConfidence -v`
+Verify: `go test ./internal/cli/... -run TestTodoPR_RendersOutcomeAndConfidence -v`
 
-### AC-011 — the pre-dispatch cross-check exists in the doctrine
+### AC-011 — the landed check works, and cannot pass vacuously
 
-**Pre-implementation baseline (required):** the following returns **zero** hits
-on the tree before M1 lands. Confirm the zero baseline before accepting this AC.
+**This criterion carries controls in both directions because its failure mode is
+a silent empty result (audit D17).**
+
+**Given** a repository fixture whose `origin/main` history contains commits
+naming card `t199` and no commit naming card `t205`
+**When** the landed check runs
+**Then** — **positive control** — `t199` returns `landed`, and the underlying
+query returns a non-empty commit set,
+**And** — **negative control** — `t205` returns `no-link` with an empty commit
+set,
+**And** — **regex-engine tripwire** — a test asserts that the implementation's
+query uses `--perl-regexp`; running the same query with `-E` returns empty for
+`t199`, and the test fails if the implementation's own result matches the `-E`
+result on the positive control.
+
+Verify: `go test ./internal/kanban/... -run TestLandedCheck_Controls -v`
+
+Baseline observed in this worktree at authoring time:
 
 ```
-grep -c 'pre-dispatch PR cross-check' .claude/rules/moai/workflow/kanban-dispatch.md
+$ git log origin/main --perl-regexp --grep='\bt199\b' --oneline | wc -l
+       3
+$ git log origin/main -E --grep='\bt199\b' --oneline | wc -l
+       0
+$ git log origin/main --perl-regexp --grep='\bt205\b' --oneline | wc -l
+       0
 ```
 
-**Given** the doctrine file after M1
-**When** the grep is run
-**Then** it returns at least 1,
-**And** the surrounding clause is marked [HARD] and requires the lead to read
-and report the card's PR state before dispatching out of `backlog`.
+Without the positive control, an `-E` regression makes every card report
+`no-link` and the criterion passes on a result that observed nothing.
 
-### AC-012 — the PR-title clause and its non-contradiction note exist
+### AC-012 — the landed answer is a boolean, and names no delivering commit
 
-**Pre-implementation baseline (required):** zero hits before M1.
+**Given** a repository fixture where a card's first matching commit is another
+card's report commit that merely mentions it
+**When** the landed check returns `landed` for that card
+**Then** the returned record contains no commit SHA, no commit subject, and no
+field naming a delivering commit,
+**And** the public resolver API exposes no accessor that would return one.
+
+Verify: `go test ./internal/kanban/... -run TestLandedCheck_BooleanOnly -v`
+
+### AC-013 — template mirror parity for the `todo.md` command table
+
+**Mechanical part.** The `moai todo pr` verb is documented in the command table
+of `.claude/skills/moai/workflows/todo.md` and mirrored into
+`internal/template/templates/.claude/skills/moai/workflows/todo.md`.
+
+**Pre-implementation baseline (required):** the following returns **zero** on
+both files before M4 lands. Confirm the zero baseline before accepting this
+criterion.
 
 ```
-grep -c 'PR title MUST carry the delivering card id' .claude/rules/moai/workflow/kanban-dispatch.md
+grep -c 'moai todo pr' .claude/skills/moai/workflows/todo.md
+grep -c 'moai todo pr' internal/template/templates/.claude/skills/moai/workflows/todo.md
 ```
 
-**Given** the doctrine file after M1
-**When** the grep is run
-**Then** it returns at least 1,
-**And** the same section explicitly states that this does not contradict the
-branch-name exclusion rule, naming the branch slug and the three existing
-traceability carriers.
+**Then** after M4 both return at least 1,
+**And** `MOAI_TEMPLATE_LEAK_STRICT=1 go test ./internal/template/... -v` passes.
 
-### AC-013 — template mirror parity
+**Reviewer-judgement part (recorded as such, not claimed as mechanical).** A
+reviewer confirms the mirrored table entry describes the verb's behaviour
+accurately and carries no internal-only content. No command verifies this, and
+the SPEC does not claim it does.
 
-**Given** the doctrine edit in `.claude/rules/…/kanban-dispatch.md`
-**When** the mirror at
-`internal/template/templates/.claude/rules/moai/workflow/kanban-dispatch.md`
-is compared
-**Then** both clauses are present in the mirror,
-**And** the neutrality guard passes.
-
-Verify: `MOAI_TEMPLATE_LEAK_STRICT=1 go test ./internal/template/... -v`
+> Split per audit D12, and extended to the `todo.md` mirror per D15. The
+> `kanban-dispatch.md` mirror criterion moved with the doctrine changes to
+> `SPEC-KANBAN-PR-CARD-TRACEABILITY-001`.
 
 ---
 
 ## D.1 Severity
 
-All ACs above are `must`. There are no `should`-severity criteria in this SPEC.
+All 13 criteria are `must`. There are no `should`-severity criteria.
+
+Two are called out above as carrying extra weight, for different reasons:
+AC-004 is **load-bearing** (it is what enforces the §B read-only ruling), and
+AC-011 is **anti-vacuous** (its failure mode is a silent empty result that would
+otherwise pass).
 
 ## D.2 Traceability
 
 | REQ | AC |
 |---|---|
-| REQ-1.1 | AC-001, AC-002, AC-003, AC-010 |
+| REQ-1.1 | AC-001, AC-002, AC-003, AC-007, AC-010 |
 | REQ-1.2 | AC-001 |
 | REQ-1.3 | AC-002 |
 | REQ-1.4 | AC-003 |
@@ -190,30 +283,37 @@ All ACs above are `must`. There are no `should`-severity criteria in this SPEC.
 | REQ-1.6 | AC-003 |
 | REQ-1.7 | AC-007 |
 | REQ-1.8 | AC-008 |
+| REQ-1.9 | AC-011 |
+| REQ-1.10 | AC-012 |
 | REQ-2.1 | AC-004 |
 | REQ-2.2 | AC-004 |
 | REQ-2.3 | AC-005 |
 | REQ-2.4 | AC-009 |
 | REQ-2.5 | AC-009 |
 | REQ-2.6 | AC-010 |
-| REQ-2.7 | AC-010 |
-| REQ-3.1 | AC-011 |
-| REQ-3.2 | AC-012 |
-| REQ-3.3 | AC-012 |
-| REQ-3.4 | AC-013 |
+
+Every one of the 16 leaf requirements has at least one criterion, and every
+criterion exercises at least one requirement. The two mappings the audit found
+non-functional (REQ-1.3 via AC-002, REQ-1.4 / REQ-1.6 via AC-003) are repaired
+by the D4 fixture rebuild above.
 
 ## D.3 Quality gates
 
 - `go vet ./...` clean.
 - `golangci-lint run` clean on touched packages.
-- Affected-package tests green locally; full-suite verdict from CI on the PR head.
+- Affected-package tests green locally; the full-suite verdict comes from CI on
+  the PR head.
 - Coverage on the new resolver package ≥ 85%.
+- `moai spec lint` on this SPEC returns an empty findings array.
 
 ## D.4 Definition of Done
 
-- All 13 ACs pass with cited command output.
-- AC-004's digest assertion is present in the committed test file, not merely
+- All 13 criteria pass with cited command output.
+- AC-004's recursive-digest assertion is present in the committed test file, not
   performed by hand.
-- AC-011 and AC-012 each recorded their zero-baseline grep result before the
-  doctrine edit landed.
-- Doctrine and template mirror committed together; `make build` run.
+- AC-011's positive control, negative control, and `-E` tripwire are all three
+  present; a landed-check test suite without the positive control is rejected.
+- AC-013 recorded its zero-baseline grep result on both files before M4 landed,
+  and its reviewer-judgement half is recorded as a judgement rather than
+  reported as a mechanical pass.
+- `make build` run after the template mirror.

--- a/.moai/specs/SPEC-KANBAN-QUEUE-PR-SYNC-001/plan.md
+++ b/.moai/specs/SPEC-KANBAN-QUEUE-PR-SYNC-001/plan.md
@@ -5,101 +5,144 @@ change come first, mechanical work last.
 
 ## A. Context
 
-Derived from `spec.md` §A. The measurement record `.moai/reports/t210/measurement.md`
-is the evidence base; do not re-derive its numbers during run-phase.
+Derived from `spec.md` §A. Two evidence bases, and neither is re-derived during
+run-phase:
+
+- `.moai/reports/t210/measurement.md` — M1..M6.
+- `.moai/reports/t210/verdict.md` — audit iteration 1 (FAIL), D1-D18.
+
+**Sequencing against the sibling SPEC.** `SPEC-KANBAN-PR-CARD-TRACEABILITY-001`
+carries the doctrine changes (pre-dispatch cross-check, [HARD] PR-title clause)
+and lands **first**. That ordering is deliberate: the title clause raises the
+Q1 title carrier from 64% recall toward 100%, which is what turns REQ-1.2's
+`exact` path from a minority case into the common one. This SPEC ships the
+tooling the doctrine relies on; the two are sequenced, not merged.
 
 ## B. Known issues in the current tree
 
 - No card↔PR mapping exists (**M4**). Every piece of REQ-1 is new code.
-- `gh` is invoked from four places today; none of them share a PR-listing
-  helper that returns title + body together. The run phase must check whether
-  `internal/github/gh.go` already exposes a suitable list call before adding one.
-- **M2**'s carrier statistics were computed against a live PR set that will have
-  changed by run-phase. The fixture set in the tests must be pinned from the
-  measurement record's table, not re-fetched.
+- `gh` is invoked from four places today; none of them share a PR-listing helper
+  that returns title and body together. Check whether `internal/github/gh.go`
+  already exposes a suitable list call before adding one.
+- **Fixture pinning is mandatory.** **M2**'s carrier statistics and the AC
+  fixtures were measured against a live PR set that changes continuously — the
+  open set has already grown since M2 was taken. Transcribe the fixtures from
+  `acceptance.md`'s pinned block; do **not** re-fetch at test time. A test that
+  queries live GitHub is not a test.
+- **The `-E` trap is a live hazard, not a hypothetical** (audit D17). `\b` is
+  not POSIX ERE and git fails silently. Any landed-check code path must pass
+  `--perl-regexp` explicitly, and the AC-011 positive control is what stops a
+  regression from passing as a clean result.
 
 ## C. Pre-flight
 
 - Confirm `internal/github/gh.go`'s existing surface: does it expose a PR list
-  with `title` and `body` fields, or only state?
-- Confirm the `moai todo` command registration point in `internal/cli/todo.go`
-  and how subverbs are added (`todo_why.go` is the smallest existing example).
-- Read `internal/kanban/backlog_store.go` to confirm a read path exists that
-  does not take the write lock.
+  carrying `title` and `body`, or only state?
+- Confirm the `moai todo` subverb registration point in `internal/cli/todo.go`.
+  `internal/cli/todo_why.go` is the smallest existing example of a read-only
+  subverb.
+- Confirm `internal/kanban/backlog_store.go` exposes a read path that does not
+  take the write lock — REQ-2.2 forbids taking one.
+- Confirm both mirror targets exist:
+  `internal/template/templates/.claude/skills/moai/workflows/todo.md` and
+  `internal/template/templates/.claude/rules/moai/workflow/kanban-dispatch.md`
+  (the latter belongs to the sibling SPEC).
+- Record the AC-013 zero baseline on both `todo.md` copies before M4.
 
 ## D. Constraints
 
-- [HARD] Zero writes to `backlog.json`. This is the load-bearing constraint;
-  see AC-004.
+- [HARD] Zero writes anywhere under `.moai/state/kanban/`. This is the
+  load-bearing constraint; AC-004 enforces it at directory granularity, not
+  file granularity.
 - Fail-open on every `gh` failure path. No new error exit.
-- Template-First: the doctrine edit lands in `internal/template/templates/…`
-  in the same commit, then `make build`.
+- The landed check is local git and must keep working when `gh` does not.
+- Template-First: the `todo.md` mirror lands in the same commit as the local
+  edit, then `make build`.
 - No new dependency.
 
 ## E. Self-verification
 
 Every milestone's exit is a command whose output is cited, per
-`.claude/rules/moai/core/verification-claim-integrity.md`.
+`.claude/rules/moai/core/verification-claim-integrity.md`. AC-011 additionally
+requires its controls to be cited, not merely asserted — a landed-check result
+with no positive control is a gap, not a pass.
 
 ## F. Milestones
 
-### M1 — The doctrine change (REQ-3)
+The former M1 (doctrine change) has moved to the sibling SPEC, so this plan
+starts at the resolver.
 
-Highest reversibility risk: it is a [HARD] behavioural rule on the lead and a
-naming obligation on every card-delivering PR. It goes first so the decision is
-reviewed before any code is written to serve it. Note when writing the clause
-that **M6** makes it codification rather than imposition — 8 of 15 merged PR
-titles already carry the token, and most of the remainder deliver no card.
+### M1 — The resolver, including the two-question split (REQ-1)
 
-- Add the pre-dispatch PR cross-check to `kanban-dispatch.md`, sited next to
-  § Entry into the board is an operator act.
-- Add the [HARD] PR-title card-id clause, with the explicit non-contradiction
-  note against the branch-naming rule (REQ-3.3).
-- Mirror both into `internal/template/templates/.claude/rules/moai/workflow/kanban-dispatch.md`,
-  neutrality-checked.
-- Exit: `go test ./internal/template/...` green; mirror parity check green.
+Most reversible remaining decision: the outcome taxonomy (`linked` / `ambiguous`
+/ `landed` / `no-link`) and the confidence labels are a user-visible contract,
+and the Q1/Q2 carrier split is the design ruling a reviewer is most likely to
+want to revisit.
 
-### M2 — The resolver (REQ-1)
+- New package function taking `(cardID, prs []PRRecord, landed LandedQuerier)`
+  and returning one outcome record.
+- Pure — no network, no filesystem, no repo. `LandedQuerier` is an interface so
+  the landed path is fixture-driven in tests.
+- Q1 (title → body) and Q2 (landed) are separate code paths with separate tests;
+  do not fold them into one scan.
+- Fixture set transcribed from `acceptance.md`'s pinned block, covering #1600,
+  #1601, #1611, #1612, #1614.
+- Exit: AC-001, AC-002, AC-003, AC-006, AC-007, AC-008, AC-012 green.
 
-Second-most reversible: the confidence taxonomy (`exact`/`inferred`/`ambiguous`)
-is a user-visible contract, and the no-commit-messages ruling is a decision a
-reviewer may want to revisit.
+### M2 — The landed check and its controls (REQ-1.9, REQ-1.10)
 
-- New package function taking `(cardIDs []string, prs []PRRecord) []Link`.
-- Pure — no network, no filesystem.
-- Fixture PR set transcribed from the measurement record's M2 table, so the
-  known-hard cases (#1600, #1614, #1611, #1612) are all covered.
-- Exit: table-driven tests asserting the confidence label for each fixture row.
+Separated from M1 because its failure mode is silent and its guard is the thing
+that catches it.
+
+- Implement the `LandedQuerier` against `git log origin/main --perl-regexp
+  --grep=…`, returning a boolean and nothing else.
+- Write the AC-011 controls **first** — the positive control, the negative
+  control, and the `-E` tripwire — then the implementation.
+- Exit: AC-011 green, with the positive control's non-empty result cited.
 
 ### M3 — The read surface (REQ-2)
 
 - New `moai todo pr [<id>]` verb with `--json`. The dedicated-verb choice is
-  settled by **M5** (0.878s per `gh pr list`), so do not reopen it as a
-  `todo list` column during implementation.
+  settled by **M5** (0.878s per `gh pr list`); do not reopen it as a
+  `todo list` column during implementation, and do not add a `--pr` flag —
+  §H records why it is out of scope.
 - Exactly one `gh pr list --state open --json number,title,body,state` call per
-  invocation; feed the resolver; render. No per-card query.
-- Fail-open wrapper around the `gh` call.
-- Exit: byte-identity assertion on `backlog.json` (AC-004); fail-open test with
-  `gh` forced absent via `PATH`.
+  invocation. No per-card network query.
+- Fail-open wrapper around the `gh` call; the landed path stays live when `gh`
+  is absent.
+- Exit: AC-004 (recursive directory digest), AC-005, AC-009, AC-010 green.
 
-### M4 — Mechanical wiring
+### M4 — Mechanical wiring and the mirror
 
-- Help text, `--json` schema doc in `.claude/skills/moai/workflows/todo.md`
-  command table, template mirror of that skill file.
-- Exit: `go vet ./...`, `golangci-lint run`, affected-package tests.
+- Help text; the `moai todo pr` row in the `.claude/skills/moai/workflows/todo.md`
+  command table; the template mirror of that file; `make build`.
+- Exit: AC-013 green (both mechanical greps, plus the reviewer-judgement half
+  recorded as a judgement); `go vet ./...`, `golangci-lint run`, and the
+  affected-package tests clean.
 
 ## G. Anti-patterns to avoid
 
-- Adding the PR column to `moai todo list` unconditionally — rejected in
-  REQ-2.5; it makes every queue read a network read.
-- "Helpfully" resolving an `ambiguous` link to the highest-numbered PR.
-- Writing the resolved link back into `findings[]` "because the array already
-  exists". The array exists for *pair relations between cards*, and writing to
-  it is still a write.
-- Scanning commit messages "as a tiebreaker". M2 rules the carrier out entirely.
+- **Re-fetching fixtures from live GitHub at test time.** The measured PR set
+  has already changed; a live query makes the suite non-deterministic and
+  silently invalidates the AC-002 / AC-003 fixtures the way the v0.1.1 draft was
+  invalidated.
+- **Using `-E` instead of `--perl-regexp`.** Returns empty, looks clean, reports
+  every card as not-landed.
+- **Returning the first matching commit as "the delivering commit."** REQ-1.10
+  forbids it; §C.2 records the mis-attribution it produces.
+- **Extending REQ-1.5's commit-message ban to the landed check.** That
+  over-generalization is the defect audit D16 found; the ban binds Q1 only.
+- **Adding the PR column to `moai todo list`, or adding a `--pr` flag.** Both
+  are out of scope; the first is rejected in REQ-2.5, the second in §H.
+- **Writing the resolved outcome into `findings[]` "because the array already
+  exists."** The array holds *pair relations between cards*, and writing to it is
+  still a write.
+- **Asserting only `backlog.json`'s bytes.** AC-004 is a directory digest for a
+  reason: a sidecar, a lock, or an mtime touch all pass a single-file check.
 
 ## H. Cross-references
 
-- `spec.md` §B (the read-only ruling), §C (the carrier problem)
-- `acceptance.md` (AC matrix)
-- `.moai/reports/t210/measurement.md`
+- `spec.md` §B (the read-only ruling), §C (the two questions and their carriers)
+- `acceptance.md` (the 13 criteria and the pinned fixture block)
+- `SPEC-KANBAN-PR-CARD-TRACEABILITY-001` (the sibling doctrine SPEC, lands first)
+- `.moai/reports/t210/measurement.md`, `.moai/reports/t210/verdict.md`

--- a/.moai/specs/SPEC-KANBAN-QUEUE-PR-SYNC-001/plan.md
+++ b/.moai/specs/SPEC-KANBAN-QUEUE-PR-SYNC-001/plan.md
@@ -46,8 +46,10 @@ Every milestone's exit is a command whose output is cited, per
 ### M1 — The doctrine change (REQ-3)
 
 Highest reversibility risk: it is a [HARD] behavioural rule on the lead and a
-new naming obligation on every PR. It goes first so the decision is reviewed
-before any code is written to serve it.
+naming obligation on every card-delivering PR. It goes first so the decision is
+reviewed before any code is written to serve it. Note when writing the clause
+that **M6** makes it codification rather than imposition — 8 of 15 merged PR
+titles already carry the token, and most of the remainder deliver no card.
 
 - Add the pre-dispatch PR cross-check to `kanban-dispatch.md`, sited next to
   § Entry into the board is an operator act.
@@ -71,9 +73,11 @@ reviewer may want to revisit.
 
 ### M3 — The read surface (REQ-2)
 
-- New `moai todo pr [<id>]` verb with `--json`.
-- One `gh pr list --state open --json number,title,body,state` call; feed the
-  resolver; render.
+- New `moai todo pr [<id>]` verb with `--json`. The dedicated-verb choice is
+  settled by **M5** (0.878s per `gh pr list`), so do not reopen it as a
+  `todo list` column during implementation.
+- Exactly one `gh pr list --state open --json number,title,body,state` call per
+  invocation; feed the resolver; render. No per-card query.
 - Fail-open wrapper around the `gh` call.
 - Exit: byte-identity assertion on `backlog.json` (AC-004); fail-open test with
   `gh` forced absent via `PATH`.

--- a/.moai/specs/SPEC-KANBAN-QUEUE-PR-SYNC-001/plan.md
+++ b/.moai/specs/SPEC-KANBAN-QUEUE-PR-SYNC-001/plan.md
@@ -49,6 +49,32 @@ tooling the doctrine relies on; the two are sequenced, not merged.
   (the latter belongs to the sibling SPEC).
 - Record the AC-013 zero baseline on both `todo.md` copies before M4.
 
+## C.1 Budget note for the run phase — READ THIS BEFORE ADDING A REQUIREMENT
+
+[HARD] **This SPEC sits at exactly 16 of 16 leaf requirements.** D14's pressure
+was absorbed to the last slot rather than relieved, and there is no headroom.
+
+**If run-phase discovers it needs one more requirement, the answer is a tier-up
+or a further split — never a relaxed budget.** `spec-workflow.md` § SPEC
+Complexity Tier is explicit that exceeding a ceiling "is a signal to tier up or
+to split the SPEC, not to relax the budget", and the same pressure has already
+been resolved once on this SPEC by splitting.
+
+This is a live risk, not a theoretical one. Two known candidates would each
+become that seventeenth requirement:
+
+- **A normative template-mirror requirement** (audit N1's structurally-correct
+  route). AC-013 currently maps to the Template-First constraint in §D below
+  rather than to a REQ, and `acceptance.md` §D.2 says so explicitly. Promoting
+  it to a requirement is the better structure and breaches the ceiling.
+- **A normative one-query bound** (audit N2). NFR-1 is currently a
+  non-functional constraint covered by AC-014; an implementer may reasonably
+  argue it belongs in §D as a requirement.
+
+Either promotion is legitimate on its merits. Neither may be made by quietly
+writing a seventeenth `**REQ-N.M**` heading. Return a blocker, and let the
+tier-up or split decision be made deliberately.
+
 ## D. Constraints
 
 - [HARD] Zero writes anywhere under `.moai/state/kanban/`. This is the

--- a/.moai/specs/SPEC-KANBAN-QUEUE-PR-SYNC-001/plan.md
+++ b/.moai/specs/SPEC-KANBAN-QUEUE-PR-SYNC-001/plan.md
@@ -1,0 +1,101 @@
+# Implementation Plan — SPEC-KANBAN-QUEUE-PR-SYNC-001
+
+Milestones are ordered by decision-reversibility: the decisions most likely to
+change come first, mechanical work last.
+
+## A. Context
+
+Derived from `spec.md` §A. The measurement record `.moai/reports/t210/measurement.md`
+is the evidence base; do not re-derive its numbers during run-phase.
+
+## B. Known issues in the current tree
+
+- No card↔PR mapping exists (**M4**). Every piece of REQ-1 is new code.
+- `gh` is invoked from four places today; none of them share a PR-listing
+  helper that returns title + body together. The run phase must check whether
+  `internal/github/gh.go` already exposes a suitable list call before adding one.
+- **M2**'s carrier statistics were computed against a live PR set that will have
+  changed by run-phase. The fixture set in the tests must be pinned from the
+  measurement record's table, not re-fetched.
+
+## C. Pre-flight
+
+- Confirm `internal/github/gh.go`'s existing surface: does it expose a PR list
+  with `title` and `body` fields, or only state?
+- Confirm the `moai todo` command registration point in `internal/cli/todo.go`
+  and how subverbs are added (`todo_why.go` is the smallest existing example).
+- Read `internal/kanban/backlog_store.go` to confirm a read path exists that
+  does not take the write lock.
+
+## D. Constraints
+
+- [HARD] Zero writes to `backlog.json`. This is the load-bearing constraint;
+  see AC-004.
+- Fail-open on every `gh` failure path. No new error exit.
+- Template-First: the doctrine edit lands in `internal/template/templates/…`
+  in the same commit, then `make build`.
+- No new dependency.
+
+## E. Self-verification
+
+Every milestone's exit is a command whose output is cited, per
+`.claude/rules/moai/core/verification-claim-integrity.md`.
+
+## F. Milestones
+
+### M1 — The doctrine change (REQ-3)
+
+Highest reversibility risk: it is a [HARD] behavioural rule on the lead and a
+new naming obligation on every PR. It goes first so the decision is reviewed
+before any code is written to serve it.
+
+- Add the pre-dispatch PR cross-check to `kanban-dispatch.md`, sited next to
+  § Entry into the board is an operator act.
+- Add the [HARD] PR-title card-id clause, with the explicit non-contradiction
+  note against the branch-naming rule (REQ-3.3).
+- Mirror both into `internal/template/templates/.claude/rules/moai/workflow/kanban-dispatch.md`,
+  neutrality-checked.
+- Exit: `go test ./internal/template/...` green; mirror parity check green.
+
+### M2 — The resolver (REQ-1)
+
+Second-most reversible: the confidence taxonomy (`exact`/`inferred`/`ambiguous`)
+is a user-visible contract, and the no-commit-messages ruling is a decision a
+reviewer may want to revisit.
+
+- New package function taking `(cardIDs []string, prs []PRRecord) []Link`.
+- Pure — no network, no filesystem.
+- Fixture PR set transcribed from the measurement record's M2 table, so the
+  known-hard cases (#1600, #1614, #1611, #1612) are all covered.
+- Exit: table-driven tests asserting the confidence label for each fixture row.
+
+### M3 — The read surface (REQ-2)
+
+- New `moai todo pr [<id>]` verb with `--json`.
+- One `gh pr list --state open --json number,title,body,state` call; feed the
+  resolver; render.
+- Fail-open wrapper around the `gh` call.
+- Exit: byte-identity assertion on `backlog.json` (AC-004); fail-open test with
+  `gh` forced absent via `PATH`.
+
+### M4 — Mechanical wiring
+
+- Help text, `--json` schema doc in `.claude/skills/moai/workflows/todo.md`
+  command table, template mirror of that skill file.
+- Exit: `go vet ./...`, `golangci-lint run`, affected-package tests.
+
+## G. Anti-patterns to avoid
+
+- Adding the PR column to `moai todo list` unconditionally — rejected in
+  REQ-2.5; it makes every queue read a network read.
+- "Helpfully" resolving an `ambiguous` link to the highest-numbered PR.
+- Writing the resolved link back into `findings[]` "because the array already
+  exists". The array exists for *pair relations between cards*, and writing to
+  it is still a write.
+- Scanning commit messages "as a tiebreaker". M2 rules the carrier out entirely.
+
+## H. Cross-references
+
+- `spec.md` §B (the read-only ruling), §C (the carrier problem)
+- `acceptance.md` (AC matrix)
+- `.moai/reports/t210/measurement.md`

--- a/.moai/specs/SPEC-KANBAN-QUEUE-PR-SYNC-001/progress.md
+++ b/.moai/specs/SPEC-KANBAN-QUEUE-PR-SYNC-001/progress.md
@@ -2,19 +2,111 @@
 
 ## §E.1 Plan-phase Audit-Ready Signal
 
-- Artifacts authored: `spec.md`, `plan.md`, `acceptance.md`, `progress.md`
-  (Tier M set).
-- SPEC ID regex check executed as Bash; verbatim output: `PASS`.
-- ID uniqueness confirmed against `.moai/specs/` — no existing
-  `SPEC-KANBAN-QUEUE-PR-SYNC-*` (existing kanban SPECs: BOARD-001,
-  BOOTSTRAP-001, RENAME-001, TODO-CLI-001, WORKTREE-001).
-- Requirements written in GEARS notation; exclusions section carries five
-  `### Out of Scope — <topic>` H3 sub-headings with `-` bullets.
-- Evidence base: `.moai/reports/t210/measurement.md` (M1..M6), cited by section
-  throughout `spec.md`. M5 (`gh` latency 0.878s) grounds REQ-2.5's surface
-  choice; M6 (8/15 merged titles already carry a card token) grounds REQ-3.2's
-  adoption-cost argument.
-- `status: draft`. Awaiting plan-audit and Implementation Kickoff Approval.
+### Artifacts
+
+Tier M set: `spec.md`, `plan.md`, `acceptance.md`, `progress.md`.
+
+### Audit iteration 1 — FAIL, and what was done about it
+
+`.moai/reports/t210/verdict.md` returned **FAIL** (0.60 harmonic, Tier M
+threshold 0.80) on must-pass MP-3. The score was never the binding part.
+
+| Finding | Disposition |
+|---|---|
+| D1 — `tags` was a YAML sequence; `moai spec lint` returned `ParseFailure` and **the document had never parsed** | Fixed. `tags` retyped to a comma-separated string. Every other lint rule had been silently unevaluated until this landed; the verbatim re-run is below. |
+| D4 — AC-002 and AC-003 fixtures refuted by the carrier data | Fixed. AC-002 rebuilt on `t188`/#1601 (single-bodied, title-absent); AC-003 rebuilt on `t201`/{#1611,#1612} (the genuine ambiguous case). REQ-1.3, REQ-1.4, REQ-1.6 now have working criteria. |
+| D2 + D16 + D17 — t199 unreachable by every specified carrier; REQ-1.5 over-generalized | Fixed per the lead's Decision A. §C now separates Q1 (attribution) from Q2 (landed); REQ-1.5 is scoped to Q1; REQ-1.9 adds the landed check with a mandated `--perl-regexp`; REQ-1.10 makes it boolean-only; REQ-1.7 is now four-valued. |
+| D14 — 19 leaf REQs against a Tier M ceiling of 16 | Fixed per the lead's Decision B. The former REQ-3 became `SPEC-KANBAN-PR-CARD-TRACEABILITY-001` (Tier S). |
+| D3 | Moved with the doctrine to the sibling SPEC, as REQ-002's report-and-re-decide wording. |
+| D5 | Decided: no `--pr` flag is in scope. Recorded in §H with the AC-009 interaction stated. |
+| D6 | Fixed. §B.1 now cites the third [HARD] clause of the same section (line 31), the same-file precedent whose byte-identity language REQ-2.1 adopts. |
+| D7 | Fixed. AC-004 is now a recursive directory digest over `.moai/state/kanban/` plus a path-set assertion, covering REQ-2.2's wider surface. |
+| D9, D10, D11, D12, D13, D15 | Fixed: `Where`→`While` on data conditions; trailers promoted to `shall` form; AC-005 disjunction resolved to "blank"; AC-013 split into mechanical and reviewer-judgement halves; AC-006's unreproducible count dropped; mirror parity extended to `todo.md`. |
+| D8 | Accepted as cosmetic. The `REQ-N.M` scheme is internally consistent; noted for grep-based tooling assuming `REQ-[0-9]{3}`. |
+| D18 | No action — a recorded positive verification of REQ-1.8. |
+
+### Budget
+
+```
+$ grep -cE '^\*\*REQ-[0-9]+\.[0-9]+\*\*' .moai/specs/SPEC-KANBAN-QUEUE-PR-SYNC-001/spec.md
+16
+$ grep -cE '^### AC-[0-9]{3}' .moai/specs/SPEC-KANBAN-QUEUE-PR-SYNC-001/acceptance.md
+13
+```
+
+Arithmetic: 19 − 4 (the doctrine requirements leaving for the sibling) = 15;
++2 for the landed carrier (REQ-1.9, REQ-1.10) = 17; −1 by consolidating the
+former REQ-2.6 (human render) and REQ-2.7 (JSON form) into a single REQ-2.6,
+since they are one requirement about one surface = **16**. At the Tier M
+ceiling, not over it, and reached by consolidating rather than relaxing.
+
+### Lint — verbatim (D1 closure)
+
+```
+$ moai spec lint .moai/specs/SPEC-KANBAN-QUEUE-PR-SYNC-001/spec.md --json
+[]
+EXIT=0
+```
+
+An empty array. This is the first run in which the file parsed, so it is also
+the first run in which any other lint rule was actually evaluated on this SPEC.
+
+### Measurements observed in this worktree (not relayed)
+
+Landed-check controls (REQ-1.9, AC-011):
+
+```
+$ git log origin/main --perl-regexp --grep='\bt199\b' --oneline
+b4b8bdfbe docs: update CHANGELOG for v3.1.3
+711bfdbba merge(t199): internal/web 자기-SIGTERM TOCTOU — 시그널 등록을 바인드 앞으로
+d9899f437 fix(web): register signal handling before binding the listener (t199)
+
+$ git log origin/main -E --grep='\bt199\b' --oneline
+                                                    (empty — the ERE trap)
+
+$ git log origin/main --perl-regexp --grep='\bt205\b' --oneline
+                                                    (empty — not landed)
+```
+
+Carrier data backing the rebuilt AC-002 / AC-003 fixtures:
+
+```
+$ gh pr list --state open --limit 40 --json number,title,body \
+    -q '.[] | "\(.number)|TITLE:…|BODY:…"'
+1614|TITLE:t203|BODY:t1 t151 t203 t69 t9
+1612|TITLE:t200|BODY:t200 t201
+1611|TITLE:|BODY:t201
+1601|TITLE:|BODY:t188
+1600|TITLE:|BODY:t184
+```
+
+`t201` appears in two bodies (ambiguous); `t188` in exactly one (inferred);
+`t151` in exactly one, which is why the prior AC-003 could never produce
+`ambiguous`.
+
+AC-013 zero baseline (recorded before implementation):
+
+```
+$ grep -c 'moai todo pr' .claude/skills/moai/workflows/todo.md
+0
+$ grep -c 'moai todo pr' internal/template/templates/.claude/skills/moai/workflows/todo.md
+0
+```
+
+### Gaps
+
+- The AC fixtures are pinned from a PR set that has already changed since M2 was
+  taken (the open set has grown to 12). `plan.md` §B makes pinning mandatory;
+  a run-phase that re-fetches would invalidate them again.
+- The reviewer-judgement half of AC-013 has no command, and is recorded as a
+  judgement rather than reported as a mechanical pass.
+- Merged-PR attribution precision remains unscored (§F). Only the landed
+  question is covered.
+
+### Signal
+
+`status: draft`. Awaiting audit iteration 2 of 2, then Implementation Kickoff
+Approval. Sequenced after `SPEC-KANBAN-PR-CARD-TRACEABILITY-001`.
 
 ## §E.2 Run-phase Evidence
 

--- a/.moai/specs/SPEC-KANBAN-QUEUE-PR-SYNC-001/progress.md
+++ b/.moai/specs/SPEC-KANBAN-QUEUE-PR-SYNC-001/progress.md
@@ -1,0 +1,27 @@
+# Progress — SPEC-KANBAN-QUEUE-PR-SYNC-001
+
+## §E.1 Plan-phase Audit-Ready Signal
+
+- Artifacts authored: `spec.md`, `plan.md`, `acceptance.md`, `progress.md`
+  (Tier M set).
+- SPEC ID regex check executed as Bash; verbatim output: `PASS`.
+- ID uniqueness confirmed against `.moai/specs/` — no existing
+  `SPEC-KANBAN-QUEUE-PR-SYNC-*` (existing kanban SPECs: BOARD-001,
+  BOOTSTRAP-001, RENAME-001, TODO-CLI-001, WORKTREE-001).
+- Requirements written in GEARS notation; exclusions section carries five
+  `### Out of Scope — <topic>` H3 sub-headings with `-` bullets.
+- Evidence base: `.moai/reports/t210/measurement.md` (M1..M4), cited by section
+  throughout `spec.md`.
+- `status: draft`. Awaiting plan-audit and Implementation Kickoff Approval.
+
+## §E.2 Run-phase Evidence
+
+_<pending run-phase>_
+
+## §E.3 Run-phase Audit-Ready Signal
+
+_<pending run-phase>_
+
+## §E.4 Sync-phase Audit-Ready Signal
+
+_<pending sync-phase>_

--- a/.moai/specs/SPEC-KANBAN-QUEUE-PR-SYNC-001/progress.md
+++ b/.moai/specs/SPEC-KANBAN-QUEUE-PR-SYNC-001/progress.md
@@ -10,8 +10,10 @@
   BOOTSTRAP-001, RENAME-001, TODO-CLI-001, WORKTREE-001).
 - Requirements written in GEARS notation; exclusions section carries five
   `### Out of Scope — <topic>` H3 sub-headings with `-` bullets.
-- Evidence base: `.moai/reports/t210/measurement.md` (M1..M4), cited by section
-  throughout `spec.md`.
+- Evidence base: `.moai/reports/t210/measurement.md` (M1..M6), cited by section
+  throughout `spec.md`. M5 (`gh` latency 0.878s) grounds REQ-2.5's surface
+  choice; M6 (8/15 merged titles already carry a card token) grounds REQ-3.2's
+  adoption-cost argument.
 - `status: draft`. Awaiting plan-audit and Implementation Kickoff Approval.
 
 ## §E.2 Run-phase Evidence

--- a/.moai/specs/SPEC-KANBAN-QUEUE-PR-SYNC-001/progress.md
+++ b/.moai/specs/SPEC-KANBAN-QUEUE-PR-SYNC-001/progress.md
@@ -31,7 +31,7 @@ threshold 0.80) on must-pass MP-3. The score was never the binding part.
 $ grep -cE '^\*\*REQ-[0-9]+\.[0-9]+\*\*' .moai/specs/SPEC-KANBAN-QUEUE-PR-SYNC-001/spec.md
 16
 $ grep -cE '^### AC-[0-9]{3}' .moai/specs/SPEC-KANBAN-QUEUE-PR-SYNC-001/acceptance.md
-13
+14
 ```
 
 Arithmetic: 19 − 4 (the doctrine requirements leaving for the sibling) = 15;
@@ -39,6 +39,11 @@ Arithmetic: 19 − 4 (the doctrine requirements leaving for the sibling) = 15;
 former REQ-2.6 (human render) and REQ-2.7 (JSON form) into a single REQ-2.6,
 since they are one requirement about one surface = **16**. At the Tier M
 ceiling, not over it, and reached by consolidating rather than relaxing.
+
+Iteration 2 added AC-014 (14 criteria, ceiling 16) and **changed no requirement
+count** — the SPEC remains at 16/16. `plan.md` §C.1 records that there is no
+headroom, and that a seventeenth requirement means a tier-up or a further split,
+never a relaxed budget.
 
 ### Lint — verbatim (D1 closure)
 
@@ -92,6 +97,55 @@ $ grep -c 'moai todo pr' .claude/skills/moai/workflows/todo.md
 $ grep -c 'moai todo pr' internal/template/templates/.claude/skills/moai/workflows/todo.md
 0
 ```
+
+### Audit iteration 2 — PASS, and the four lead-verified repairs
+
+`.moai/reports/t210/verdict-2.md` returned **PASS** on both SPECs: 0.801 against
+the Tier M threshold of 0.80 here, 0.775 against 0.75 on the sibling. Neither
+margin is comfortable and the Tier M iteration ceiling (2) is reached, so the
+four blocking findings were repaired and **verified by the lead** rather than
+sent through a third audit round.
+
+| Finding | Disposition |
+|---|---|
+| N2 — no NFR had any criterion; NFR-1 is the sole justification for REQ-2.5's dedicated-verb ruling | Fixed. **AC-014** added: exactly one `gh` process regardless of queue length, asserted at two queue lengths (≥3 and 10) so the census observes invariance rather than a coincidence. NFR-2 rides the same assertion (landed check spawns `git`, never `gh`). Without it, a per-card implementation passed all 13 other criteria while costing 0.878s × queue length — passing the SPEC while defeating what the SPEC protects. |
+| N1 — `acceptance.md` §D.2 claimed "every criterion exercises at least one requirement" while AC-013 appeared nowhere in the table | Fixed via route (b). The claim is restated honestly, AC-013 has a row mapping it to the Template-First constraint in `plan.md` §D, and the text records that the obligation is carried by a plan constraint rather than a requirement. Route (a) — a normative mirror requirement — is structurally better but breaches 16/16; it is logged as a follow-up in `spec.md` §H and in `plan.md` §C.1. |
+| N3 — the split dropped the template-mirror requirement, orphaning the sibling's AC-004 | Fixed in `SPEC-KANBAN-PR-CARD-TRACEABILITY-001`: REQ-005 restored, AC-004 mapped to it, and a traceability table added. Tier S is at 5 of 8, so no budget obstacle. |
+| N4 — a judgement sat inside AC-003's `**Mechanical.**` block in the doctrine SPEC | Fixed. The eight words were deleted; the four-carrier claim was already stated correctly in the judgement half, so nothing was lost. Flagged blocking because it was a relapse of D12 inside D12's own remedy. |
+
+### Run-phase debt (N5-N9 — recorded, not fixed)
+
+Carried forward deliberately. None is blocking; each is a real observation.
+
+- **N5 — the fixture block in `acceptance.md` is an unmarked excerpt.** The
+  header says the fixtures were re-measured with a `gh … -q` command that emits
+  one line per open PR unconditionally; the block carries 5 lines where the
+  12-PR set would give 12. No AC fixture is refuted — t188, t201, and t200 were
+  re-verified against current data — and 5 PRs suffice for every criterion, so
+  this is a labelling defect rather than a correctness one.
+- **N6 — AC-011 and AC-012 impose opposite observability demands on the same
+  value.** AC-011 needs the underlying query's non-empty commit set observed;
+  AC-012 forbids a public accessor returning one. Both are satisfiable — the
+  test observes the git-query helper one layer below the resolver's public
+  surface — but neither the SPEC nor `plan.md` M2 says so, and M2's "returning a
+  boolean and nothing else" reads as closing the door AC-011 needs. **Run-phase
+  should resolve this by testing the helper layer, not by weakening AC-011 to a
+  boolean check or adding the accessor AC-012 forbids.**
+- **N7 — a card that both carries an open PR and is already landed reports
+  `linked` only.** REQ-1.9 runs the landed query only while no open PR carries
+  the token, and REQ-1.7 permits exactly one outcome kind, so the landed fact is
+  masked. This may be the right design (one question, one answer), but §F does
+  not name it as a boundary. **This is one of the two candidates that would
+  become a seventeenth requirement — see `plan.md` §C.1.**
+- **N8 — AC-012's API-surface half carries no verb and is not labelled a
+  judgement.** It is mechanizable by reflection over the exported record's
+  fields; it should either name that mechanism or match the judgement-labelling
+  pattern AC-013 and the doctrine SPEC's AC-001/AC-002 use.
+- **N9 — two requirement-id schemes ship on one card.** This SPEC uses
+  `REQ-1.1`-style ids; the sibling uses canonical `REQ-001`. Grep tooling keying
+  on `REQ-[0-9]{3}` matches one and not the other. `moai spec lint` returns `[]`
+  on both, so nothing mechanical breaks. Renumbering touches 16 headings, 16
+  traceability rows, and every back-reference — deferrable, and deferred.
 
 ### Gaps
 

--- a/.moai/specs/SPEC-KANBAN-QUEUE-PR-SYNC-001/spec.md
+++ b/.moai/specs/SPEC-KANBAN-QUEUE-PR-SYNC-001/spec.md
@@ -1,44 +1,61 @@
 ---
 id: SPEC-KANBAN-QUEUE-PR-SYNC-001
-title: Read-only card-to-PR link surface for the kanban backlog queue
-version: 0.1.1
+title: "Read-only card-to-PR link surface for the kanban backlog queue"
+version: "0.2.0"
 status: draft
 created: 2026-08-24
 updated: 2026-08-24
 author: manager-spec
 priority: P1
 phase: "v3.2.0 target"
-module: kanban
+module: "internal/kanban"
 lifecycle: spec-anchored
-tags: [kanban, todo, github, observability, read-only]
+tags: "kanban, todo, github, observability, read-only"
 tier: M
 ---
 
 ## HISTORY
 
 - 2026-08-24 — v0.1.0 — plan-phase authoring. Grounded in the t210 measurement
-  record `.moai/reports/t210/measurement.md` (M1..M4). `status: draft`.
+  record `.moai/reports/t210/measurement.md` (M1..M4).
 - 2026-08-24 — v0.1.1 — M5 (`gh` latency 0.878s) and M6 (merged-title convention
-  already emergent) landed in the measurement record. REQ-2.5's surface choice
-  is now evidence-backed rather than judgement-backed; REQ-3.2 gains the
-  codification argument; the latency exclusion is rewritten from "unmeasured" to
-  "optimization out of scope".
+  already emergent) folded in.
+- 2026-08-24 — v0.2.0 — audit iteration 1 FAIL (0.60 harmonic, MP-3 fail);
+  `.moai/reports/t210/verdict.md`. Repairs: D1 (`tags` retyped to string — the
+  document had never parsed), D4 (AC-002 / AC-003 fixtures were refuted by the
+  carrier data and are rebuilt), D2+D16+D17 (landed-commit carrier adopted as a
+  second, separately-scoped question; REQ-1.5's over-generalized ban narrowed),
+  D14 (the former REQ-3 lifted into `SPEC-KANBAN-PR-CARD-TRACEABILITY-001`),
+  D3, D5, D6, D7, D9, D10, D11, D12, D13, D15.
 
 ## A. Context
 
 The kanban backlog queue (`.moai/state/kanban/backlog.json`, surfaced by
 `moai todo`) records exactly two things: what the operator admitted, and what
 the operator picked. It has no knowledge of work that has already been
-implemented and opened as a pull request.
+implemented — whether it is sitting in an open pull request or has already
+landed on `origin/main`.
 
-The consequence is measured, not assumed. Per **M1**, five live cards — t200,
-t201, t202, t203, t205 — sat in the queue as `queued` while each carried an
-open PR. The lead reads the queue, sees five cards awaiting dispatch, and
-dispatches work that is already in flight. A sixth card (t88) had been picked
-before the measurement ran, so the live divergence count is five.
+The originating card records **two** failure shapes, and both cost real work:
 
-The queue is not wrong; it is *uninformed*. Nothing in it is false. What is
-missing is a second fact — the PR state — that lives entirely outside the file.
+1. **The open-PR divergence.** Per **M1**, five live cards — t200, t201, t202,
+   t203, t205 — sat in the queue as `queued` while each carried an open PR. The
+   lead reads the queue, sees five cards awaiting dispatch, and dispatches work
+   already in flight. (A sixth, t88, had been picked before the measurement, so
+   the live divergence count is five.)
+
+2. **The already-landed card.** Card t199 was `queued` while its fix commit
+   `d9899f437` was *already an ancestor of `origin/main`*. It was discovered only
+   after a lane had started — **one full lane wasted**, the only sub-case in the
+   record with a quantified cost.
+
+The second shape is the harder one, and it is why this SPEC carries two
+independent questions rather than one. t199 has **no pull request of its own**:
+its fix rode into `origin/main` inside the v3.1.3 batch PR #1602, whose title
+carries no card token and whose body carries 26 card tokens *not including
+t199*. Extending a PR-based resolver to merged PRs therefore does not reach it —
+neither the title carrier nor the body carrier finds it. Only a query against
+landed commits does. §C.2 records that measurement.
 
 **M4** establishes that no card-to-PR mapping exists anywhere in the codebase
 today. `gh` is used for PR *state* (`internal/github/gh.go`,
@@ -53,19 +70,25 @@ requirement that follows.
 
 The dispatch flagged a [HARD] conflict against
 `.claude/rules/moai/workflow/kanban-dispatch.md` § Entry into the board is an
-operator act, which states *"The lead is the queue's sole producer"* and
-*"Promotion is the operator's act, always"*. Three grounds settle it:
+operator act, which states *"The lead is the queue's sole producer"* (line 27)
+and *"Promotion is the operator's act, always"* (line 29). Three grounds settle
+it:
 
 1. **Those clauses bind queue *mutation*, and an observation mutates nothing.**
-   A read surface that computes a link and prints it engages neither clause —
-   it produces no card, promotes no card, and leaves the file byte-identical.
-   Per **M3**, this subsystem has already drawn exactly this line once:
-   `.claude/skills/moai/workflows/todo.md` § What the analyser may do carries a
-   [HARD] clause that analysis *"never folds one card into another, never
-   reorders the queue, never drops a card, and never edits one… Acting on a
-   record is the operator's act"*, and `backlog.json` already carries a
-   `findings[]` array holding observations ABOUT cards without touching them.
-   The precedent is not an analogy; it is the same file and the same boundary.
+   The first governs *admission*; the second governs *the pick*. A surface that
+   computes a link and prints it does neither.
+
+   The strongest precedent is the **third [HARD] clause of that same section**
+   (line 31): *"The lead may attach a finding; it may not act on one… Analysis
+   changes exactly one thing on its own authority — it refuses the admission of
+   a card whose normalized text is identical to one already queued or picked,
+   which creates no card and **leaves the queue file byte-identical**."* That is
+   the boundary this SPEC proposes to sit inside, drawn in the very file it
+   proposes to amend, and its byte-identity language is where REQ-2.1's wording
+   comes from. `backlog.json`'s `findings[]` array is the storage form of the
+   same idea: observations held ABOUT cards without touching them
+   (`.claude/skills/moai/workflows/todo.md` § What the analyser may do restates
+   the clause).
 
 2. **Auto-updating card state would make the queue a derived artifact.** The
    queue's value is that every entry has visible operator provenance — someone
@@ -81,13 +104,24 @@ operator act, which states *"The lead is the queue's sole producer"* and
 ### Rejected alternative — auto-update card state on PR merge or close
 
 Considered and rejected: a hook or poll that flips a card to `done` when its
-PR merges, and to `dropped` when its PR closes unmerged. It was rejected on all
-three grounds above — it is precisely the queue mutation clause (1) forbids, it
-is precisely the derived-artifact failure (2) describes, and per (3) it would
-act on links that **M2** shows are not reliably precise. It is named here so a
-later reader sees the option was weighed rather than overlooked.
+PR merges, and to `dropped` when its PR closes unmerged. Rejected on all three
+grounds above — it is precisely the queue mutation clause (1) forbids, precisely
+the derived-artifact failure (2) describes, and per (3) it would act on links
+that **M2** shows are not reliably precise. Named here so a later reader sees the
+option was weighed rather than overlooked.
 
-## C. The carrier problem (M2)
+## C. Two questions, two carriers
+
+The SPEC answers two questions that look alike and behave differently.
+Conflating them is what produced the audit's D16 finding, so they are separated
+here before any requirement is stated.
+
+| | Question | Carrier | Cost |
+|---|---|---|---|
+| **Q1 — attribution** | "Which card does this open PR deliver?" | PR title, then PR body | one `gh pr list` (network) |
+| **Q2 — landed** | "Is this card's work already in `origin/main`?" | landed commit messages | local `git log` (no network) |
+
+### C.1 — Q1: no PR carrier is both complete and precise (M2)
 
 Across 11 open PRs, scanning for `\bt[0-9]{1,4}\b`:
 
@@ -95,72 +129,138 @@ Across 11 open PRs, scanning for `\bt[0-9]{1,4}\b`:
 |---|---|---|---|
 | PR title | 7/11 (64%) | 7/7 — every token present is the delivering card | precise, incomplete |
 | PR body | 11/11 (100%) | poor — 5 PRs carry extra tokens; #1614 carries 5 tokens for 1 card | complete, noisy |
-| commit messages | 10/11, and **wrong** on #1600 | worst of the three | unusable |
+| commit messages | 10/11, and **wrong** on #1600 | worst of the three | unusable **for Q1** |
 
 The commit-message carrier deserves its own note because it is the one
-`kanban-dispatch.md` § Isolation already makes [HARD]. PR #1600 carries 15
-commit tokens, and its own delivering card (t184) is not among them: a branch
-that merges the release branch inherits every other card's commits, so the
-noise scales with integration rather than with the card. Being mandated does
-not make it a usable index.
+`kanban-dispatch.md` § Isolation already makes [HARD]. PR #1600 carries commit
+tokens for a dozen-plus cards, and its own delivering card (t184) is not among
+them: a branch that merges the release branch inherits every other card's
+commits, so the noise scales with integration rather than with the card. Being
+mandated does not make it a usable attribution index.
 
-No single carrier is both complete and precise. That is a measurement, not a
-preference, and it is what forces both the confidence labelling in REQ-1 and
-the naming convention in REQ-3.
+No single carrier is both complete and precise **for Q1**. That is a
+measurement, not a preference, and it is what forces the confidence labelling in
+REQ-1.2 through REQ-1.4.
+
+### C.2 — Q2: the commit carrier is the only one that works, and it is sound here
+
+The noise that ruins the commit carrier for Q1 is **harmless for Q2**, because
+the two questions read the same data in opposite directions. Q1 asks the commit
+set to name a card exclusively; an inherited commit breaks that. Q2 asks only
+whether `origin/main` names the card at all — and a commit that rode in on
+another branch is still genuinely landed, so the "noise" *is* the property being
+tested.
+
+Measured in this worktree, both directions:
+
+```
+$ git log origin/main --perl-regexp --grep='\bt199\b' --oneline
+b4b8bdfbe docs: update CHANGELOG for v3.1.3
+711bfdbba merge(t199): internal/web 자기-SIGTERM TOCTOU — 시그널 등록을 바인드 앞으로
+d9899f437 fix(web): register signal handling before binding the listener (t199)
+
+$ git log origin/main --perl-regexp --grep='\bt205\b' --oneline
+                                        (empty — t205 is queued with an OPEN PR)
+```
+
+The query returns the landed card and stays empty for the not-landed one. It is
+not noise-free — a card's first hit can be another card's report commit merely
+mentioning it — which is exactly why REQ-1.10 makes the answer a boolean and
+forbids naming a delivering commit.
+
+**The regex-engine trap.** `\b` is not POSIX ERE, and git fails *silently*:
+
+```
+$ git log origin/main -E --grep='\bt199\b' --oneline
+                                        (empty — indistinguishable from "not landed")
+```
+
+An `-E` regression would render every card "not landed" and pass any acceptance
+criterion that only checks for a clean result. REQ-1.9 mandates `--perl-regexp`
+and AC-011 carries a positive control so the failure cannot masquerade as a
+clean run.
 
 ## D. Requirements
 
+16 leaf requirements (Tier M ceiling: 16). The doctrine changes that were
+formerly REQ-3 now live in `SPEC-KANBAN-PR-CARD-TRACEABILITY-001`.
+
 ### REQ-1 — Link resolver with honest confidence
 
-**REQ-1.1** — The resolver shall accept a card id and the open pull-request set
-and return at most one link record per card, carrying the PR number, the PR
-state, and a confidence label drawn from the closed set
-`exact | inferred | ambiguous`.
+**REQ-1.1** — The resolver shall accept a card id, the open pull-request set,
+and the landed-commit history, and shall return exactly one outcome record per
+card carrying the outcome kind, the PR number(s) where one applies, the PR
+state where one applies, and a confidence label drawn from the closed set
+`exact | inferred`.
 
-**REQ-1.2** — **Where** the PR title contains the card id token, the resolver
-shall label the link `exact`.
+**REQ-1.2** — **While** the PR title contains the card id token, the resolver
+shall return a `linked` outcome with confidence `exact`.
 
-**REQ-1.3** — **Where** no PR title contains the card id token **While** exactly
-one open PR body contains it, the resolver shall label the link `inferred`.
+**REQ-1.3** — **While** no PR title contains the card id token and exactly one
+open PR body contains it, the resolver shall return a `linked` outcome with
+confidence `inferred`.
 
-**REQ-1.4** — **Where** no PR title contains the card id token **While** more
-than one open PR body contains it, the resolver shall label the result
-`ambiguous` and shall enumerate every candidate PR number.
+**REQ-1.4** — **While** no PR title contains the card id token and more than one
+open PR body contains it, the resolver shall return an `ambiguous` outcome and
+shall enumerate every candidate PR number.
 
-**REQ-1.5** — The resolver shall not consult commit messages as a linking
-carrier. (Grounds: **M2** — the carrier is wrong on #1600, where the delivering
-card is absent from 15 inherited tokens.)
+**REQ-1.5** — The resolver shall not consult commit messages **when attributing
+an open pull request to a delivering card** (question Q1).
 
-**REQ-1.6** — The resolver shall not resolve an `ambiguous` result to a
-single best candidate. An ambiguous link is reported as ambiguous.
+This prohibition is scoped deliberately. **M2** measured the commit carrier
+against Q1 only, where #1600's inherited tokens are ruinous; §C.2 measures the
+same carrier against Q2 and finds it sound. A blanket ban would forbid the only
+carrier that answers Q2 — and would have left the t199 incident uncovered. The
+ban binds Q1 and does not prejudge Q2, which REQ-1.9 governs.
 
-**REQ-1.7** — **When** the card id token appears in no title and no body of any
-open PR, the resolver shall return no link for that card, distinguishable by
-the consumer from an ambiguous result.
+**REQ-1.6** — The resolver shall not collapse an `ambiguous` outcome to a single
+best candidate. An ambiguous outcome is reported as ambiguous.
 
-**REQ-1.8** — The token match shall be a whole-token match on the card id, so
-that `t20` never matches a `t200` token.
+**REQ-1.7** — The resolver shall return exactly one of four mutually
+distinguishable outcome kinds — `linked`, `ambiguous`, `landed`, `no-link` — so
+that a consumer can tell "already in `origin/main`" from "nobody has started
+this" from "several candidates" without inspecting any other field.
+
+**REQ-1.8** — The resolver shall match the card id as a whole token, so that
+`t20` never matches a `t200` token.
+
+**REQ-1.9** — **While** no open pull request carries the card id token in its
+title or body, the resolver shall query landed history with
+`git log origin/main --perl-regexp --grep='\b<card-id>\b'`, shall return a
+`landed` outcome when that query returns at least one commit, and shall return a
+`no-link` outcome when it returns none. The resolver shall use `--perl-regexp`
+and shall not use `-E` or any other POSIX-ERE mode, because `\b` is unsupported
+there and the resulting empty output is indistinguishable from a genuine
+`no-link`.
+
+**REQ-1.10** — The resolver shall not name, return, or otherwise claim which
+commit delivered a card. The `landed` outcome is a boolean fact about
+`origin/main` and nothing more. (Grounds: §C.2 — a card's first matching commit
+may be another card's report commit that merely mentions it, so any
+"first match is the delivering commit" reading attributes wrongly.)
 
 ### REQ-2 — A read surface that persists nothing
 
 **REQ-2.1** — [HARD] The read surface shall leave
-`.moai/state/kanban/backlog.json` byte-identical across an invocation. It writes
-no field, no `findings[]` entry, and no timestamp.
+`.moai/state/kanban/backlog.json` byte-identical across an invocation, and shall
+write no field, no `findings[]` entry, and no timestamp.
 
-**REQ-2.2** — The read surface shall compute the link set live at invocation
-time and shall not cache the result into any queue-owned file.
+**REQ-2.2** — The read surface shall compute every outcome live at invocation
+time and shall not cache any result into `backlog.json` or into any other
+queue-owned file, sidecar, lock, or index under `.moai/state/kanban/`.
 
 **REQ-2.3** — **When** the `gh` executable is absent, unauthenticated, offline,
-or exits non-zero, the read surface shall degrade fail-open: it renders the
-queue with the link column blank or absent, exits successfully, and reports the
-degradation as a note rather than an error.
+or exits non-zero, the read surface shall degrade fail-open: it shall render the
+queue with an empty link column, shall exit successfully, and shall report the
+degradation as a note rather than an error. The landed check (REQ-1.9) is local
+git and shall continue to run when `gh` is unavailable.
 
 **REQ-2.4** — The read surface shall not block, delay, or fail an ordinary queue
-read. `moai todo list` remains lock-free and network-free unless the operator
-opts in.
+read, and `moai todo list` shall remain lock-free, network-free, and free of any
+`git` or `gh` subprocess.
 
 **REQ-2.5** — [DESIGN DECISION] The link view shall be a **separate read-only
-verb** (`moai todo pr [<id>]`), not an always-on column on `moai todo list`.
+verb**, `moai todo pr [<id>]`, and shall not be a column on `moai todo list`.
 
 Rationale, and it is a measurement rather than a judgement: per **M5**,
 `gh pr list --state open --limit 40 --json number,title,body` costs **0.878s**,
@@ -169,58 +269,27 @@ of which 0.20s is user+sys and the rest is round-trip. `todo.md` documents
 glance and by the foreman loop; a default-on column would make every one of
 those callers pay ~0.9s of network to serve the one caller who wanted the link.
 A separate verb keeps the cheap path cheap and makes the network cost an
-explicit operator act. An opt-in `moai todo list --pr` flag MAY additionally
-render the column, and if provided it inherits REQ-2.1 through REQ-2.4
-unchanged.
+explicit operator act. **No `--pr` flag on `moai todo list` is in scope** —
+see §H.
 
-**REQ-2.6** — The read surface shall render the confidence label alongside every
-link, so an `inferred` or `ambiguous` link is never presented as an `exact` one.
-
-**REQ-2.7** — The read surface shall emit a structured form (`--json`) carrying
-card id, PR number(s), PR state, and confidence label, so the lead's
-pre-dispatch cross-check (REQ-3.1) can be mechanical.
-
-### REQ-3 — The doctrine change
-
-**REQ-3.1** — [HARD] `.claude/rules/moai/workflow/kanban-dispatch.md` shall
-require the lead, **before** dispatching a card out of `backlog`, to read that
-card's PR state and report it in the same turn. **When** the card carries an
-open PR, the lead shall surface that fact to the operator rather than
-dispatching. (This is the step whose absence produced the M1 incident.)
-
-**REQ-3.2** — [HARD] `kanban-dispatch.md` shall require every pull request
-delivering a card to carry that card's id in its **PR title**. This converts the
-M2 title carrier from 64% recall to 100%, which turns REQ-1's resolver from a
-heuristic into an exact lookup — the fix for ambiguous parsing is a naming
-convention, not a smarter parser.
-
-The clause is cheap to adopt because it **codifies existing practice rather than
-imposing a new burden**. Per **M6**, 8 of 15 merged PR titles already carry a
-card token, and most of the 7 that do not deliver no card at all — `release:
-v3.1.3`, the v3.1.3 batch PR, and three `chore(release-update)` entries. Among
-merged PRs that deliver a single card, the title token is close to universal.
-The rule therefore names a convention contributors already mostly follow.
-
-**REQ-3.3** — The doctrine shall state explicitly that REQ-3.2 does not
-contradict the existing [HARD] rule that a card worktree's **branch** name must
-exclude the card id. The branch carries a descriptive slug for human
-readability; `kanban-dispatch.md` already assigns traceability to three other
-carriers (the dispatch `card:` field, the commit message, the evidence path).
-This SPEC adds the PR title as the fourth, and the only machine-readable one.
-
-**REQ-3.4** — The doctrine change shall be mirrored into
-`internal/template/templates/.claude/rules/moai/workflow/kanban-dispatch.md`
-per the Template-First rule, subject to the template neutrality catalogue.
+**REQ-2.6** — The read surface shall render the outcome kind, and for a `linked`
+outcome its confidence label, in both its human form and its `--json` form; the
+`--json` form shall carry the card id, the outcome kind, the PR number(s) where
+applicable, the PR state where applicable, and the confidence label where
+applicable, so that a consumer's cross-check can be mechanical.
 
 ## E. Non-functional constraints
 
-- **NFR-1** — The separate verb's wall-time is bounded by **one** `gh pr list`
+- **NFR-1** — The verb's network wall-time is bounded by **one** `gh pr list`
   invocation — measured at 0.878s (**M5**) — with no per-card network call. A
   per-card query would multiply that figure by the queue length.
-- **NFR-2** — No new third-party dependency. The existing `gh` invocation path
+- **NFR-2** — The landed check (REQ-1.9) is a local `git log` against an
+  existing ref. It performs no network I/O and sits outside NFR-1's budget
+  entirely.
+- **NFR-3** — No new third-party dependency. The existing `gh` invocation path
   (`internal/github/gh.go`) is reused.
-- **NFR-3** — The resolver is a pure function of (card id set, PR record set),
-  so it is testable against a fixture PR set with no network.
+- **NFR-4** — The resolver is a pure function of (card id, PR record set, landed
+  commit set), so it is testable against fixtures with no network and no repo.
 
 ## F. Exclusions
 
@@ -228,31 +297,42 @@ per the Template-First rule, subject to the template neutrality catalogue.
 
 - No change to any card's state, text, queue position, or `spec_id`.
 - Zero writes to `.moai/state/kanban/backlog.json`, including its `findings[]`
-  array.
+  array, and zero writes anywhere under `.moai/state/kanban/`.
 - No automatic promotion, drop, or completion of a card on any PR event.
 
-### Out of Scope — merged and closed pull requests
+### Out of Scope — doctrine changes
 
-- Only `--state open` PRs are linked. **M2** scored the open set; **M6** sampled
-  15 merged PRs for the title-convention argument but did not score the merged
-  side for precision the way M2 scores the open side, and the measurement
-  record's remaining-gaps section says so explicitly. A card whose PR has
-  already merged (the t199 case) is a different query. Deferred to a follow-up
-  SPEC that first scores the closed set.
+- The pre-dispatch cross-check clause, the [HARD] PR-title naming clause, the
+  non-contradiction note against the branch-name rule, and their template
+  mirror are **not** in this SPEC. They are
+  `SPEC-KANBAN-PR-CARD-TRACEABILITY-001`, a sibling Tier S SPEC that lands
+  first. This SPEC ships the tooling that clause relies on.
+
+### Out of Scope — merged and closed pull requests as an attribution carrier
+
+- Q1 (REQ-1.2 through REQ-1.4) queries `--state open` only. **M2** scored the
+  open set; **M6** sampled 15 merged PRs for the title-convention argument but
+  did not score the merged side for precision the way M2 scores the open side.
+- This exclusion is narrower than it was in v0.1.1, and the narrowing is the
+  point: the t199 case is now covered by Q2 (REQ-1.9), which reaches it where a
+  merged-PR extension measurably does not (§A, §C.2). What remains excluded is
+  *attributing a merged PR to a delivering card* — scoring that carrier is
+  deferred to a follow-up SPEC.
 
 ### Out of Scope — non-GitHub forges
 
-- No GitLab or other forge support. The `glab` path contemplated by
-  `internal/statusline/forge.go` is unmeasured for card-token carriage.
+- No GitLab or other forge support for Q1. The `glab` path contemplated by
+  `internal/statusline/forge.go` is unmeasured for card-token carriage. Q2 is
+  forge-independent by construction — it reads git, not a forge API.
 
 ### Out of Scope — retroactive title relabelling
 
-- The 11 currently-open PRs are not retitled. REQ-3.2 binds pull requests opened
-  after the doctrine change lands.
+- The currently-open PRs are not retitled. The sibling SPEC's title clause binds
+  pull requests opened after it lands.
 
 ### Out of Scope — latency optimization
 
-- `gh` latency is now measured (**M5**: 0.878s, essentially all round-trip), and
+- `gh` latency is measured (**M5**: 0.878s, essentially all round-trip), and
   that measurement is what settles REQ-2.5. What stays out of scope is making
   that query *faster* — no caching layer, no background prefetch, no persisted
   link index. The cost is paid, visibly, only by the operator who invokes the
@@ -260,11 +340,30 @@ per the Template-First rule, subject to the template neutrality catalogue.
 
 ## G. Cross-references
 
-- `.moai/reports/t210/measurement.md` — M1..M4, the measurement record this SPEC
-  cites throughout.
+- `.moai/reports/t210/measurement.md` — M1..M6, the measurement record.
+- `.moai/reports/t210/verdict.md` — audit iteration 1 (FAIL), D1-D18.
+- `SPEC-KANBAN-PR-CARD-TRACEABILITY-001` — the sibling Tier S SPEC carrying the
+  doctrine changes this SPEC's tooling serves.
 - `.claude/rules/moai/workflow/kanban-dispatch.md` — § Entry into the board is an
-  operator act, § Isolation, § Completion is read, never trusted.
-- `.claude/skills/moai/workflows/todo.md` — § What the analyser may do (the
-  observe-never-mutate precedent), § Reading the records (`findings[]`).
-- `.claude/rules/moai/core/verification-claim-integrity.md` — the read-don't-trust
-  invariant REQ-3.1 operationalizes at the dispatch boundary.
+  operator act (three [HARD] clauses at lines 27 / 29 / 31), § Isolation,
+  § Completion is read, never trusted.
+- `.claude/skills/moai/workflows/todo.md` — § What the analyser may do,
+  § Reading the records (`findings[]`).
+- `.claude/rules/moai/core/verification-claim-integrity.md` — the
+  read-don't-trust invariant the sibling SPEC's pre-dispatch clause
+  operationalizes.
+
+## H. Possible follow-ups (non-normative — not requirements)
+
+Recorded so a later reader sees these were considered. Nothing here is in scope,
+and nothing here has an acceptance criterion.
+
+- **A `--pr` flag on `moai todo list`.** Deliberately not specified: it would put
+  a network path behind the queue's cheapest read, and it would turn AC-009's
+  zero-subprocess assertion into a no-flag-only claim. If it is ever wanted, it
+  needs its own requirement plus a companion acceptance criterion asserting that
+  the flag — and only the flag — gates the subprocess.
+- **Scoring the merged-PR attribution carrier**, which would close the remaining
+  half of the merged-PR exclusion above.
+- **Forge-independent Q1** via the `glab` path, once a carrier measurement
+  exists.

--- a/.moai/specs/SPEC-KANBAN-QUEUE-PR-SYNC-001/spec.md
+++ b/.moai/specs/SPEC-KANBAN-QUEUE-PR-SYNC-001/spec.md
@@ -1,0 +1,253 @@
+---
+id: SPEC-KANBAN-QUEUE-PR-SYNC-001
+title: Read-only card-to-PR link surface for the kanban backlog queue
+version: 0.1.0
+status: draft
+created: 2026-08-24
+updated: 2026-08-24
+author: manager-spec
+priority: P1
+phase: "v3.2.0 target"
+module: kanban
+lifecycle: spec-anchored
+tags: [kanban, todo, github, observability, read-only]
+tier: M
+---
+
+## HISTORY
+
+- 2026-08-24 — v0.1.0 — plan-phase authoring. Grounded in the t210 measurement
+  record `.moai/reports/t210/measurement.md` (M1..M4). `status: draft`.
+
+## A. Context
+
+The kanban backlog queue (`.moai/state/kanban/backlog.json`, surfaced by
+`moai todo`) records exactly two things: what the operator admitted, and what
+the operator picked. It has no knowledge of work that has already been
+implemented and opened as a pull request.
+
+The consequence is measured, not assumed. Per **M1**, five live cards — t200,
+t201, t202, t203, t205 — sat in the queue as `queued` while each carried an
+open PR. The lead reads the queue, sees five cards awaiting dispatch, and
+dispatches work that is already in flight. A sixth card (t88) had been picked
+before the measurement ran, so the live divergence count is five.
+
+The queue is not wrong; it is *uninformed*. Nothing in it is false. What is
+missing is a second fact — the PR state — that lives entirely outside the file.
+
+**M4** establishes that no card-to-PR mapping exists anywhere in the codebase
+today. `gh` is used for PR *state* (`internal/github/gh.go`,
+`internal/statusline/forge.go`, `session_worktree_prmerge.go`,
+`branch_protection.go`), never for card attribution. The index would be new.
+
+## B. The design ruling — the mechanism is strictly read-only
+
+[HARD] **The mechanism observes and reports. It never writes to
+`backlog.json`.** This ruling is stated first because it constrains every
+requirement that follows.
+
+The dispatch flagged a [HARD] conflict against
+`.claude/rules/moai/workflow/kanban-dispatch.md` § Entry into the board is an
+operator act, which states *"The lead is the queue's sole producer"* and
+*"Promotion is the operator's act, always"*. Three grounds settle it:
+
+1. **Those clauses bind queue *mutation*, and an observation mutates nothing.**
+   A read surface that computes a link and prints it engages neither clause —
+   it produces no card, promotes no card, and leaves the file byte-identical.
+   Per **M3**, this subsystem has already drawn exactly this line once:
+   `.claude/skills/moai/workflows/todo.md` § What the analyser may do carries a
+   [HARD] clause that analysis *"never folds one card into another, never
+   reorders the queue, never drops a card, and never edits one… Acting on a
+   record is the operator's act"*, and `backlog.json` already carries a
+   `findings[]` array holding observations ABOUT cards without touching them.
+   The precedent is not an analogy; it is the same file and the same boundary.
+
+2. **Auto-updating card state would make the queue a derived artifact.** The
+   queue's value is that every entry has visible operator provenance — someone
+   asked for this, someone picked it. A state change nobody made destroys that
+   property. It also fails asymmetrically: a wrong "this card is done" is
+   contradicted by no later signal, so the error is silent and permanent,
+   whereas a wrong read-only label is visible on the next render.
+
+3. **It would inherit the carrier ambiguity measured in M2.** A mislinked PR
+   under write mode silently mutates the wrong card. Read-only ambiguity is a
+   label the operator can disbelieve; write-mode ambiguity is corruption.
+
+### Rejected alternative — auto-update card state on PR merge or close
+
+Considered and rejected: a hook or poll that flips a card to `done` when its
+PR merges, and to `dropped` when its PR closes unmerged. It was rejected on all
+three grounds above — it is precisely the queue mutation clause (1) forbids, it
+is precisely the derived-artifact failure (2) describes, and per (3) it would
+act on links that **M2** shows are not reliably precise. It is named here so a
+later reader sees the option was weighed rather than overlooked.
+
+## C. The carrier problem (M2)
+
+Across 11 open PRs, scanning for `\bt[0-9]{1,4}\b`:
+
+| carrier | recall | precision | verdict |
+|---|---|---|---|
+| PR title | 7/11 (64%) | 7/7 — every token present is the delivering card | precise, incomplete |
+| PR body | 11/11 (100%) | poor — 5 PRs carry extra tokens; #1614 carries 5 tokens for 1 card | complete, noisy |
+| commit messages | 10/11, and **wrong** on #1600 | worst of the three | unusable |
+
+The commit-message carrier deserves its own note because it is the one
+`kanban-dispatch.md` § Isolation already makes [HARD]. PR #1600 carries 15
+commit tokens, and its own delivering card (t184) is not among them: a branch
+that merges the release branch inherits every other card's commits, so the
+noise scales with integration rather than with the card. Being mandated does
+not make it a usable index.
+
+No single carrier is both complete and precise. That is a measurement, not a
+preference, and it is what forces both the confidence labelling in REQ-1 and
+the naming convention in REQ-3.
+
+## D. Requirements
+
+### REQ-1 — Link resolver with honest confidence
+
+**REQ-1.1** — The resolver shall accept a card id and the open pull-request set
+and return at most one link record per card, carrying the PR number, the PR
+state, and a confidence label drawn from the closed set
+`exact | inferred | ambiguous`.
+
+**REQ-1.2** — **Where** the PR title contains the card id token, the resolver
+shall label the link `exact`.
+
+**REQ-1.3** — **Where** no PR title contains the card id token **While** exactly
+one open PR body contains it, the resolver shall label the link `inferred`.
+
+**REQ-1.4** — **Where** no PR title contains the card id token **While** more
+than one open PR body contains it, the resolver shall label the result
+`ambiguous` and shall enumerate every candidate PR number.
+
+**REQ-1.5** — The resolver shall not consult commit messages as a linking
+carrier. (Grounds: **M2** — the carrier is wrong on #1600, where the delivering
+card is absent from 15 inherited tokens.)
+
+**REQ-1.6** — The resolver shall not resolve an `ambiguous` result to a
+single best candidate. An ambiguous link is reported as ambiguous.
+
+**REQ-1.7** — **When** the card id token appears in no title and no body of any
+open PR, the resolver shall return no link for that card, distinguishable by
+the consumer from an ambiguous result.
+
+**REQ-1.8** — The token match shall be a whole-token match on the card id, so
+that `t20` never matches a `t200` token.
+
+### REQ-2 — A read surface that persists nothing
+
+**REQ-2.1** — [HARD] The read surface shall leave
+`.moai/state/kanban/backlog.json` byte-identical across an invocation. It writes
+no field, no `findings[]` entry, and no timestamp.
+
+**REQ-2.2** — The read surface shall compute the link set live at invocation
+time and shall not cache the result into any queue-owned file.
+
+**REQ-2.3** — **When** the `gh` executable is absent, unauthenticated, offline,
+or exits non-zero, the read surface shall degrade fail-open: it renders the
+queue with the link column blank or absent, exits successfully, and reports the
+degradation as a note rather than an error.
+
+**REQ-2.4** — The read surface shall not block, delay, or fail an ordinary queue
+read. `moai todo list` remains lock-free and network-free unless the operator
+opts in.
+
+**REQ-2.5** — [DESIGN DECISION] The link view shall be a **separate read-only
+verb** (`moai todo pr [<id>]`), not an always-on column on `moai todo list`.
+
+Rationale, and it is a measurement rather than a judgement: per **M5**,
+`gh pr list --state open --limit 40 --json number,title,body` costs **0.878s**,
+of which 0.20s is user+sys and the rest is round-trip. `todo.md` documents
+`moai todo list` as lock-free and cheap, and it is rendered on every operator
+glance and by the foreman loop; a default-on column would make every one of
+those callers pay ~0.9s of network to serve the one caller who wanted the link.
+A separate verb keeps the cheap path cheap and makes the network cost an
+explicit operator act. An opt-in `moai todo list --pr` flag MAY additionally
+render the column, and if provided it inherits REQ-2.1 through REQ-2.4
+unchanged.
+
+**REQ-2.6** — The read surface shall render the confidence label alongside every
+link, so an `inferred` or `ambiguous` link is never presented as an `exact` one.
+
+**REQ-2.7** — The read surface shall emit a structured form (`--json`) carrying
+card id, PR number(s), PR state, and confidence label, so the lead's
+pre-dispatch cross-check (REQ-3.1) can be mechanical.
+
+### REQ-3 — The doctrine change
+
+**REQ-3.1** — [HARD] `.claude/rules/moai/workflow/kanban-dispatch.md` shall
+require the lead, **before** dispatching a card out of `backlog`, to read that
+card's PR state and report it in the same turn. **When** the card carries an
+open PR, the lead shall surface that fact to the operator rather than
+dispatching. (This is the step whose absence produced the M1 incident.)
+
+**REQ-3.2** — [HARD] `kanban-dispatch.md` shall require every pull request
+delivering a card to carry that card's id in its **PR title**. This converts the
+M2 title carrier from 64% recall to 100%, which turns REQ-1's resolver from a
+heuristic into an exact lookup — the fix for ambiguous parsing is a naming
+convention, not a smarter parser.
+
+**REQ-3.3** — The doctrine shall state explicitly that REQ-3.2 does not
+contradict the existing [HARD] rule that a card worktree's **branch** name must
+exclude the card id. The branch carries a descriptive slug for human
+readability; `kanban-dispatch.md` already assigns traceability to three other
+carriers (the dispatch `card:` field, the commit message, the evidence path).
+This SPEC adds the PR title as the fourth, and the only machine-readable one.
+
+**REQ-3.4** — The doctrine change shall be mirrored into
+`internal/template/templates/.claude/rules/moai/workflow/kanban-dispatch.md`
+per the Template-First rule, subject to the template neutrality catalogue.
+
+## E. Non-functional constraints
+
+- **NFR-1** — The separate verb's wall-time is bounded by one `gh pr list`
+  invocation; no per-card network call.
+- **NFR-2** — No new third-party dependency. The existing `gh` invocation path
+  (`internal/github/gh.go`) is reused.
+- **NFR-3** — The resolver is a pure function of (card id set, PR record set),
+  so it is testable against a fixture PR set with no network.
+
+## F. Exclusions
+
+### Out of Scope — queue mutation
+
+- No change to any card's state, text, queue position, or `spec_id`.
+- Zero writes to `.moai/state/kanban/backlog.json`, including its `findings[]`
+  array.
+- No automatic promotion, drop, or completion of a card on any PR event.
+
+### Out of Scope — merged and closed pull requests
+
+- Only `--state open` PRs are linked. **M2** measured open PRs only; the
+  measurement record's gaps section states that a card whose PR has already
+  merged (the t199 case) is a different query whose carrier statistics are
+  unmeasured. Deferred to a follow-up SPEC that first measures the closed set.
+
+### Out of Scope — non-GitHub forges
+
+- No GitLab or other forge support. The `glab` path contemplated by
+  `internal/statusline/forge.go` is unmeasured for card-token carriage.
+
+### Out of Scope — retroactive title relabelling
+
+- The 11 currently-open PRs are not retitled. REQ-3.2 binds pull requests opened
+  after the doctrine change lands.
+
+### Out of Scope — latency budgeting
+
+- `gh` latency was not measured (measurement record, gaps). REQ-2.5's
+  separate-verb choice removes the need for a latency budget on the hot path;
+  no budget is specified here.
+
+## G. Cross-references
+
+- `.moai/reports/t210/measurement.md` — M1..M4, the measurement record this SPEC
+  cites throughout.
+- `.claude/rules/moai/workflow/kanban-dispatch.md` — § Entry into the board is an
+  operator act, § Isolation, § Completion is read, never trusted.
+- `.claude/skills/moai/workflows/todo.md` — § What the analyser may do (the
+  observe-never-mutate precedent), § Reading the records (`findings[]`).
+- `.claude/rules/moai/core/verification-claim-integrity.md` — the read-don't-trust
+  invariant REQ-3.1 operationalizes at the dispatch boundary.

--- a/.moai/specs/SPEC-KANBAN-QUEUE-PR-SYNC-001/spec.md
+++ b/.moai/specs/SPEC-KANBAN-QUEUE-PR-SYNC-001/spec.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-KANBAN-QUEUE-PR-SYNC-001
 title: Read-only card-to-PR link surface for the kanban backlog queue
-version: 0.1.0
+version: 0.1.1
 status: draft
 created: 2026-08-24
 updated: 2026-08-24
@@ -18,6 +18,11 @@ tier: M
 
 - 2026-08-24 — v0.1.0 — plan-phase authoring. Grounded in the t210 measurement
   record `.moai/reports/t210/measurement.md` (M1..M4). `status: draft`.
+- 2026-08-24 — v0.1.1 — M5 (`gh` latency 0.878s) and M6 (merged-title convention
+  already emergent) landed in the measurement record. REQ-2.5's surface choice
+  is now evidence-backed rather than judgement-backed; REQ-3.2 gains the
+  codification argument; the latency exclusion is rewritten from "unmeasured" to
+  "optimization out of scope".
 
 ## A. Context
 
@@ -189,6 +194,13 @@ M2 title carrier from 64% recall to 100%, which turns REQ-1's resolver from a
 heuristic into an exact lookup — the fix for ambiguous parsing is a naming
 convention, not a smarter parser.
 
+The clause is cheap to adopt because it **codifies existing practice rather than
+imposing a new burden**. Per **M6**, 8 of 15 merged PR titles already carry a
+card token, and most of the 7 that do not deliver no card at all — `release:
+v3.1.3`, the v3.1.3 batch PR, and three `chore(release-update)` entries. Among
+merged PRs that deliver a single card, the title token is close to universal.
+The rule therefore names a convention contributors already mostly follow.
+
 **REQ-3.3** — The doctrine shall state explicitly that REQ-3.2 does not
 contradict the existing [HARD] rule that a card worktree's **branch** name must
 exclude the card id. The branch carries a descriptive slug for human
@@ -202,8 +214,9 @@ per the Template-First rule, subject to the template neutrality catalogue.
 
 ## E. Non-functional constraints
 
-- **NFR-1** — The separate verb's wall-time is bounded by one `gh pr list`
-  invocation; no per-card network call.
+- **NFR-1** — The separate verb's wall-time is bounded by **one** `gh pr list`
+  invocation — measured at 0.878s (**M5**) — with no per-card network call. A
+  per-card query would multiply that figure by the queue length.
 - **NFR-2** — No new third-party dependency. The existing `gh` invocation path
   (`internal/github/gh.go`) is reused.
 - **NFR-3** — The resolver is a pure function of (card id set, PR record set),
@@ -220,10 +233,12 @@ per the Template-First rule, subject to the template neutrality catalogue.
 
 ### Out of Scope — merged and closed pull requests
 
-- Only `--state open` PRs are linked. **M2** measured open PRs only; the
-  measurement record's gaps section states that a card whose PR has already
-  merged (the t199 case) is a different query whose carrier statistics are
-  unmeasured. Deferred to a follow-up SPEC that first measures the closed set.
+- Only `--state open` PRs are linked. **M2** scored the open set; **M6** sampled
+  15 merged PRs for the title-convention argument but did not score the merged
+  side for precision the way M2 scores the open side, and the measurement
+  record's remaining-gaps section says so explicitly. A card whose PR has
+  already merged (the t199 case) is a different query. Deferred to a follow-up
+  SPEC that first scores the closed set.
 
 ### Out of Scope — non-GitHub forges
 
@@ -235,11 +250,13 @@ per the Template-First rule, subject to the template neutrality catalogue.
 - The 11 currently-open PRs are not retitled. REQ-3.2 binds pull requests opened
   after the doctrine change lands.
 
-### Out of Scope — latency budgeting
+### Out of Scope — latency optimization
 
-- `gh` latency was not measured (measurement record, gaps). REQ-2.5's
-  separate-verb choice removes the need for a latency budget on the hot path;
-  no budget is specified here.
+- `gh` latency is now measured (**M5**: 0.878s, essentially all round-trip), and
+  that measurement is what settles REQ-2.5. What stays out of scope is making
+  that query *faster* — no caching layer, no background prefetch, no persisted
+  link index. The cost is paid, visibly, only by the operator who invokes the
+  verb.
 
 ## G. Cross-references
 

--- a/.moai/specs/SPEC-KANBAN-QUEUE-PR-SYNC-001/spec.md
+++ b/.moai/specs/SPEC-KANBAN-QUEUE-PR-SYNC-001/spec.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-KANBAN-QUEUE-PR-SYNC-001
 title: "Read-only card-to-PR link surface for the kanban backlog queue"
-version: "0.2.0"
+version: "0.2.1"
 status: draft
 created: 2026-08-24
 updated: 2026-08-24
@@ -27,6 +27,14 @@ tier: M
   second, separately-scoped question; REQ-1.5's over-generalized ban narrowed),
   D14 (the former REQ-3 lifted into `SPEC-KANBAN-PR-CARD-TRACEABILITY-001`),
   D3, D5, D6, D7, D9, D10, D11, D12, D13, D15.
+- 2026-08-24 — v0.2.1 — audit iteration 2 PASS (0.801 against the Tier M
+  threshold of 0.80); `.moai/reports/t210/verdict-2.md`. Lead-verified repairs
+  applied without a further audit round (the Tier M iteration ceiling is
+  reached): N2 (AC-014 added — none of the four NFRs previously had a criterion,
+  and NFR-1 is the sole justification for REQ-2.5), N1 (`acceptance.md` §D.2's
+  self-claim restated honestly; AC-013 mapped to the `plan.md` §D Template-First
+  constraint). N5-N9 are recorded as run-phase debt in `progress.md`. Requirement
+  count unchanged at 16/16.
 
 ## A. Context
 

--- a/internal/template/templates/.claude/rules/moai/workflow/kanban-dispatch-detail.md
+++ b/internal/template/templates/.claude/rules/moai/workflow/kanban-dispatch-detail.md
@@ -1,5 +1,5 @@
 ---
-description: "Detail companion for kanban-dispatch.md — terminology, board table, card classes, dispatch-cycle naming, sync-gate review-lens table, /clear message structure, isolation rationale, verification-load incident record, sub-agent-first design intent, manager-lead working mode, per-card fan-out, Factory in-lane 3-stage"
+description: "Detail companion for kanban-dispatch.md — terminology, board table, card classes, dispatch-cycle naming, sync-gate review-lens table, /clear message structure, isolation rationale, verification-load incident record, sub-agent-first design intent, manager-lead working mode, per-card fan-out, Factory in-lane 3-stage, pre-dispatch cross-check rationale, PR-title carrier measurements"
 paths: "**/kanban-dispatch*.md,**/.claude/agents/moai/manager-lead.md,**/.claude/skills/moai/workflows/todo.md"
 ---
 
@@ -202,3 +202,33 @@ Sessions share one machine as surely as they share one checkout, and verificatio
 The never-spawn-background-load rule (normative statement lives in the stub) comes from the same incident's second cause: a verification recipe started eight spin loops to test behaviour under CPU contention and placed its kill line *after* the long test command. The agent finished before reaching it, and twelve spinners ran orphaned for thirty-seven minutes.
 
 The same day supplied the reason contention and flakiness feed each other: a failing test left an unbounded spin-loop goroutine running, which burned a core for the remainder of that package's run and slowed every test after it. Load makes tests fail; failing tests can generate load.
+
+## The pre-dispatch cross-check
+
+The stub's two [HARD] clauses are the rule; this section is why each is worded the way it is.
+
+**The failure was not a misread — it was that nothing required looking.** Several cards sat `queued` while each already carried an open pull request, and one sat `queued` while its fix was already an ancestor of the integration branch. The second was discovered only after a lane had started work on it, which cost the whole lane — the only sub-case in the record with a quantified cost. A lead with perfect tooling available would still have dispatched blind, because reading was optional.
+
+**Why "reports, never vetoes" is a separate clause with its own criterion.** The obligation to look and the prohibition on acting are different rules, and the second is the fragile one. The operator has already picked the card; a lead that then withholds the dispatch because it found an open pull request has overridden an operator act rather than informing one — the same de-facto-authority hazard the read-only ruling on the queue tooling exists to prevent.
+
+The hazard is invisible after the fact. A clause requiring the lead to read and report, and a clause authorizing the lead to refuse, produce identical transcripts up to the moment the card does not move; nothing downstream distinguishes "the operator withdrew it" from "the lead declined to send it". No mechanical check can separate the two readings, so the wording is the only control there is — which is why the literal `confirms or withdraws` is pinned by its own acceptance criterion rather than folded into the obligation clause.
+
+**The tooling is a convenience, not the obligation.** `moai todo pr <id>` answers both halves in one read, but the clause is satisfiable by hand (`gh pr list`, then `git log` against the integration branch) and was written to be: the doctrine landed before the tooling, and the interval between them is a real operating condition rather than a paper one.
+
+## The PR-title carrier
+
+**Why the id leaves the branch name and lands on the PR title.** Neither name can serve both readers. The branch name is read by a human scanning `git branch` or a pull-request list, who learns nothing from an opaque card id and everything from a descriptive slug. The PR title is read by a resolver mapping pull requests back to cards, which needs a token it can match exactly. The branch-name rule and the title rule therefore assign different jobs to different names, and a reader meeting both [HARD] clauses cold will suspect a contradiction where there is none — which is why the stub states the non-contradiction outright instead of leaving it to be inferred.
+
+**The carrier measurements.** Scanning a set of open pull requests for card tokens, three carriers behave differently:
+
+| carrier | recall | precision | verdict |
+|---|---|---|---|
+| PR title | ~64% | every token present named the delivering card | precise, incomplete |
+| PR body | complete | poor — one pull request carried five tokens for one card | complete, noisy |
+| commit messages | high, and **wrong** on the worst case | worst of the three | unusable for attribution |
+
+The commit carrier deserves its own note, because it is the one the isolation rule already makes [HARD]. A branch that merges the integration branch inherits every other card's commits, so its token set scales with integration rather than with the card: in the measured worst case a pull request carried a dozen-plus card tokens and its own delivering card was **not among them**. Being mandated as a traceability carrier does not make it a usable attribution index.
+
+**The fix for ambiguous parsing is a naming convention, not a smarter parser.** The title carrier is already the precise one — where a token is present, it names the delivering card. It is incomplete only because nothing required it. Requiring it is what turns a resolver from a heuristic into a lookup, and no amount of parser sophistication substitutes for the missing token.
+
+**Why a token in a batch pull request's title would be worse than none.** A release or batch pull request delivers no single card. A card token in such a title would name a card the pull request does not deliver, and a resolver reading titles would attribute confidently and wrongly — a silent error, where the absent token merely leaves the card unresolved and visible as such. The scope restriction is therefore load-bearing, not politeness.

--- a/internal/template/templates/.claude/rules/moai/workflow/kanban-dispatch.md
+++ b/internal/template/templates/.claude/rules/moai/workflow/kanban-dispatch.md
@@ -30,11 +30,9 @@ Five columns, fixed and ordered: `backlog → plan → run → sync → done`. `
 
 [HARD] **The lead may attach a finding; it may not act on one.** Analysis runs automatically and records a relation between two cards — a near-duplicate the machine measured on `add` or `analyze`, or a `contains` / `absorbs` / `replaces` / `conflicts` the lead judged and wrote with `moai todo relate`. The record is evidence the operator reads, never a mandate: the lead never folds the related card away, never reorders the queue around it, and never drops or edits it. Analysis changes exactly one thing on its own authority — it refuses the admission of a card whose normalized text is identical to one already queued or picked, which creates no card and leaves the queue file byte-identical. Everything a finding suggests beyond that refusal is the operator's act.
 
-[HARD] **The pre-dispatch PR cross-check.** Before dispatching a card out of `backlog`, the lead reads that card's pull-request and landed state and reports what it read in the same turn — the open pull request that already carries the card, or the fact that its work is already in the integration branch. `moai todo pr <id>` answers both in one read; by hand it is a `gh pr list` plus a `git log` against the integration branch. What is reported is what was read, per § Completion is read, never trusted: an unchecked card is a gap, not a clean card.
+[HARD] **The pre-dispatch PR cross-check.** Before dispatching a card out of `backlog`, the lead reads that card's pull-request and landed state and reports what it read in the same turn. `moai todo pr <id>` answers both; by hand it is `gh pr list` plus a `git log` against the integration branch. An unchecked card is a gap, not a clean card (§ Completion is read, never trusted).
 
-[HARD] **The cross-check reports; it never vetoes.** Where a card turns out to carry an open pull request, or to be already landed, the lead surfaces that to the operator and the operator **confirms or withdraws** the card. The lead does not withhold the dispatch on its own authority. The operator has already picked this card, and promotion is the operator's act, always — a lead that refuses a picked card because it found something has overridden an operator act rather than informing one. Hand the decision back; the check produces evidence, never authority.
-
-The failure this closes was not a lead that looked and misread. It was that nothing required looking: cards sat queued while each already carried an open pull request, and one sat queued while its fix was already an ancestor of the integration branch — discovered only after a lane had started, which cost the whole lane.
+[HARD] **The cross-check reports; it never vetoes.** Where the card carries an open pull request or is already landed, the lead surfaces that and the operator **confirms or withdraws** it. The lead never withholds a picked card on its own authority — promotion is the operator's act, always. Why the wording is the only available control, and the incident it closes: `kanban-dispatch-detail.md` § The pre-dispatch cross-check.
 
 ## Report milestones ↔ queue cards
 
@@ -172,18 +170,9 @@ The **worktree directory keeps the card id** (`.claude/worktrees/<card-id>`). On
 
 A lane that reports a branch name without also reporting its card id has not reported the card. Merges reference the `WT-` name; the lead maps it back through the `card:` field it dispatched.
 
-[HARD] **A card-delivering pull request's PR title MUST carry the delivering card id — and this does not contradict the branch-name rule above.** The two clauses give different jobs to different names, so a reader meeting both cold should not suspect a conflict: the branch name is read by a human scanning `git branch`, and wants a descriptive slug; the PR title is read by a machine resolving cards to pull requests, and wants the id. Neither name can serve both readers, which is why the id leaves one and lands on the other.
+[HARD] **A card-delivering pull request's PR title MUST carry the delivering card id** — and this does not contradict the branch-name rule above: the branch name is read by a human scanning `git branch` and wants a slug; the PR title is read by a machine and wants the id. Traceability therefore rests on **four** carriers rather than the three above — the dispatch `card:` field, the commit message, the evidence path, and the PR title, the only machine-readable one.
 
-Traceability therefore rests on **four** carriers rather than the three above, and the PR title is the only machine-readable one:
-
-- the dispatch's `card:` field — the address the lead sent;
-- the card id in every commit message on the branch — `git log` recovers the card without the branch name;
-- the card id in the evidence path;
-- the card id in the **PR title** of the pull request that delivers the card.
-
-The obligation binds card-delivering pull requests only. A release pull request, a batch pull request rolling several cards up, and a maintenance pull request that delivers no card carry no card id and no obligation — a card token in such a title would name a card the pull request does not deliver, which is worse than no token. The clause binds pull requests opened after it lands; open and already-merged pull requests are not retitled.
-
-The fix for ambiguous card-to-pull-request parsing is a naming convention, not a smarter parser. The title carrier is the precise one — where a token is present it names the delivering card — and it is incomplete only because nothing required it. Requiring it is what makes the resolver a lookup rather than a heuristic.
+The obligation binds card-delivering pull requests only; a release, batch, or maintenance pull request delivers no card and carries none. It binds pull requests opened after it lands — nothing is retitled. Rationale and the carrier measurements: `kanban-dispatch-detail.md` § The PR-title carrier.
 
 The lead dispatches this rather than assuming it: each instruction names the worktree and says to drive it with `git -C <path>` rather than `cd` — a `cd` inside a compound command lasts for that invocation only, so the next command silently reads the wrong tree. A companion reporting it worked in the shared checkout is a fault to report, not a detail to tidy up (rationale: `kanban-dispatch-detail.md` § Isolation rationale).
 

--- a/internal/template/templates/.claude/rules/moai/workflow/kanban-dispatch.md
+++ b/internal/template/templates/.claude/rules/moai/workflow/kanban-dispatch.md
@@ -30,6 +30,12 @@ Five columns, fixed and ordered: `backlog → plan → run → sync → done`. `
 
 [HARD] **The lead may attach a finding; it may not act on one.** Analysis runs automatically and records a relation between two cards — a near-duplicate the machine measured on `add` or `analyze`, or a `contains` / `absorbs` / `replaces` / `conflicts` the lead judged and wrote with `moai todo relate`. The record is evidence the operator reads, never a mandate: the lead never folds the related card away, never reorders the queue around it, and never drops or edits it. Analysis changes exactly one thing on its own authority — it refuses the admission of a card whose normalized text is identical to one already queued or picked, which creates no card and leaves the queue file byte-identical. Everything a finding suggests beyond that refusal is the operator's act.
 
+[HARD] **The pre-dispatch PR cross-check.** Before dispatching a card out of `backlog`, the lead reads that card's pull-request and landed state and reports what it read in the same turn — the open pull request that already carries the card, or the fact that its work is already in the integration branch. `moai todo pr <id>` answers both in one read; by hand it is a `gh pr list` plus a `git log` against the integration branch. What is reported is what was read, per § Completion is read, never trusted: an unchecked card is a gap, not a clean card.
+
+[HARD] **The cross-check reports; it never vetoes.** Where a card turns out to carry an open pull request, or to be already landed, the lead surfaces that to the operator and the operator **confirms or withdraws** the card. The lead does not withhold the dispatch on its own authority. The operator has already picked this card, and promotion is the operator's act, always — a lead that refuses a picked card because it found something has overridden an operator act rather than informing one. Hand the decision back; the check produces evidence, never authority.
+
+The failure this closes was not a lead that looked and misread. It was that nothing required looking: cards sat queued while each already carried an open pull request, and one sat queued while its fix was already an ancestor of the integration branch — discovered only after a lane had started, which cost the whole lane.
+
 ## Report milestones ↔ queue cards
 
 [HARD] **A milestone-bearing report under `.moai/reports/` carries a `## Card Cross-Check` section** — one table row per milestone, a `card` column holding the delivering card id or an explicit new-card marker. A mapping claim is verified against the queue (`moai todo`), never remembered. Before the lead turns a report into card requests, the request message states the full comparison — `N milestones → N cards` — naming every milestone with no card in the live queue. Detail: `kanban-dispatch-detail.md` § Report milestones ↔ queue cards.
@@ -165,6 +171,19 @@ The **worktree directory keeps the card id** (`.claude/worktrees/<card-id>`). On
 - The evidence path keeps the card id (`.moai/reports/<card-id>/verdict.md`).
 
 A lane that reports a branch name without also reporting its card id has not reported the card. Merges reference the `WT-` name; the lead maps it back through the `card:` field it dispatched.
+
+[HARD] **A card-delivering pull request's PR title MUST carry the delivering card id — and this does not contradict the branch-name rule above.** The two clauses give different jobs to different names, so a reader meeting both cold should not suspect a conflict: the branch name is read by a human scanning `git branch`, and wants a descriptive slug; the PR title is read by a machine resolving cards to pull requests, and wants the id. Neither name can serve both readers, which is why the id leaves one and lands on the other.
+
+Traceability therefore rests on **four** carriers rather than the three above, and the PR title is the only machine-readable one:
+
+- the dispatch's `card:` field — the address the lead sent;
+- the card id in every commit message on the branch — `git log` recovers the card without the branch name;
+- the card id in the evidence path;
+- the card id in the **PR title** of the pull request that delivers the card.
+
+The obligation binds card-delivering pull requests only. A release pull request, a batch pull request rolling several cards up, and a maintenance pull request that delivers no card carry no card id and no obligation — a card token in such a title would name a card the pull request does not deliver, which is worse than no token. The clause binds pull requests opened after it lands; open and already-merged pull requests are not retitled.
+
+The fix for ambiguous card-to-pull-request parsing is a naming convention, not a smarter parser. The title carrier is the precise one — where a token is present it names the delivering card — and it is incomplete only because nothing required it. Requiring it is what makes the resolver a lookup rather than a heuristic.
 
 The lead dispatches this rather than assuming it: each instruction names the worktree and says to drive it with `git -C <path>` rather than `cd` — a `cd` inside a compound command lasts for that invocation only, so the next command silently reads the wrong tree. A companion reporting it worked in the shared checkout is a fault to report, not a detail to tidy up (rationale: `kanban-dispatch-detail.md` § Isolation rationale).
 

--- a/internal/template/templates/.claude/rules/moai/workflow/kanban-dispatch.md
+++ b/internal/template/templates/.claude/rules/moai/workflow/kanban-dispatch.md
@@ -170,7 +170,7 @@ The **worktree directory keeps the card id** (`.claude/worktrees/<card-id>`). On
 
 A lane that reports a branch name without also reporting its card id has not reported the card. Merges reference the `WT-` name; the lead maps it back through the `card:` field it dispatched.
 
-[HARD] **A card-delivering pull request's PR title MUST carry the delivering card id** — and this does not contradict the branch-name rule above: the branch name is read by a human scanning `git branch` and wants a slug; the PR title is read by a machine and wants the id. Traceability therefore rests on **four** carriers rather than the three above — the dispatch `card:` field, the commit message, the evidence path, and the PR title, the only machine-readable one.
+[HARD] **A card-delivering pull request's PR title MUST carry the delivering card id** — and this does not contradict the branch-name rule above: the branch name is read by a human scanning `git branch` and wants a slug; the PR title is read by a machine and wants the id. Traceability therefore rests on **four** carriers rather than the three above — the dispatch `card:` field, the commit message, the evidence path, and the PR title — the only one a resolver can read off the pull-request surface itself, where the dispatch `card:` field (also machine-readable) does not reach.
 
 The obligation binds card-delivering pull requests only; a release, batch, or maintenance pull request delivers no card and carries none. It binds pull requests opened after it lands — nothing is retitled. Rationale and the carrier measurements: `kanban-dispatch-detail.md` § The PR-title carrier.
 


### PR DESCRIPTION
SPEC-KANBAN-PR-CARD-TRACEABILITY-001 (Tier S, doctrine only — no Go code).

Card: t210. Sibling: SPEC-KANBAN-QUEUE-PR-SYNC-001 (the tooling), which lands second.

## What this changes

Two [HARD] clauses in `.claude/rules/moai/workflow/kanban-dispatch.md`, mirrored into the distributed template.

**1. The pre-dispatch PR cross-check** (§ Entry into the board is an operator act). Before dispatching a card out of `backlog`, the lead reads that card's pull-request and landed state and reports what it read in the same turn.

The measured failure was not a lead that looked and misread — it was that nothing required looking. Five cards sat `queued` while each carried an open PR; one sat `queued` while its fix was already an ancestor of `origin/main`, discovered only after a lane had started. That cost a full lane, and it is the only sub-case in the record with a quantified cost.

**2. The clause reports; it never vetoes.** Where a card turns out to carry an open PR or to be already landed, the lead surfaces that and the operator **confirms or withdraws** it. This wording is the whole control: the operator has already picked the card, and "promotion is the operator's act, always" — a lead that refuses a picked card on its own authority has overridden an operator act rather than informing one. No mechanical check can tell the two readings apart after the fact, which is why it is a separate clause with its own acceptance criterion.

**3. A card-delivering PR title MUST carry the card id** (§ Isolation), stated next to the branch-naming rule it reconciles with. This does not contradict the [HARD] rule excluding the card id from branch names: the branch name is read by a human scanning `git branch` and wants a descriptive slug; the PR title is read by a machine and wants the id. Traceability now rests on four carriers rather than three — dispatch `card:` field, commit message, evidence path, and the PR title, the only machine-readable one. A reader meeting both [HARD] clauses cold will suspect a conflict, so the doctrine says outright there is none.

The obligation binds card-delivering PRs only; release, batch, and maintenance PRs carry no card id and no obligation. It binds PRs opened after it lands — nothing is retitled.

## Why doctrine lands before the tooling

The title convention is what raises the title carrier from 64% recall toward full coverage, which turns the sibling SPEC's resolver from a heuristic into a lookup. **The fix for ambiguous parsing is a naming convention, not a smarter parser.**

The interval between this landing and the tooling landing is a real, accepted cost: the cross-check is satisfiable by hand (`gh pr list` + `git log`) until then. That is what makes the ordering safe rather than merely convenient.

## Verification

All four acceptance criteria pass mechanically, each against a zero baseline **re-measured on this tree at edit time** rather than cited from the plan-phase audit:

| AC | Grep | Before | After |
|---|---|---|---|
| AC-001 | `pre-dispatch PR cross-check` | 0 | 1 |
| AC-001 | `\[HARD\].*pre-dispatch PR cross-check` | 0 | 1 |
| AC-002 | `confirms or withdraws` | 0 | 1 |
| AC-003 | `PR title MUST carry the delivering card id` | 0 | 1 |

Same four on the template mirror (AC-004), plus `MOAI_TEMPLATE_LEAK_STRICT=1 go test ./internal/template/...` green and `make build` run. The live file and mirror were byte-identical before the edit (measured with `diff`), and the same neutral prose was written to both.

Always-loaded budget after the addition: **68,091 / 76,000 tokens** (headroom 7,909). The file grew 3,166 bytes.

## Not claimed

The reviewer-judgement halves of AC-001, AC-002, and AC-003 have no command and are recorded as outstanding judgements, not reported as mechanical passes — that the clause *means* what the requirements ask is a human call, and the greps only prove a string was typed.

Nothing mechanically enforces the PR-title convention; a CI check is named as a plausible follow-up and is deliberately out of scope.

Evidence: `.moai/specs/SPEC-KANBAN-PR-CARD-TRACEABILITY-001/progress.md` §E.2 / §E.3.

🗿 MoAI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added documented Kanban checks for pull-request and integration status before dispatch.
  * Established a card-ID convention for pull-request titles, excluding release, batch, and maintenance changes.
  * Defined read-only status reporting for card-related pull requests and landed commits, with human-readable and JSON output.
* **Documentation**
  * Added implementation plans, acceptance criteria, progress tracking, measurements, and review findings for Kanban synchronization and traceability.
  * Mirrored the updated dispatch guidance in the internal template.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->