### PR TITLE
fix(hook): run the goal evaluator once per turn, not once per resolution tier (t220)

### DIFF
--- a/.claude/hooks/moai/handle-stop-goal.sh
+++ b/.claude/hooks/moai/handle-stop-goal.sh
@@ -58,22 +58,38 @@ if [ -z "$SESSION_ID" ] || [ ! -f "$STATE_FILE" ]; then
     exit 0
 fi
 
-# A goal IS armed — proceed to the 3-tier moai-binary resolution, replaying
-# the captured stdin so the evaluator sees the full Stop payload.
-# Try moai command in PATH
-if command -v moai &> /dev/null; then
-    printf '%s' "$INPUT" | exec moai hook stop-goal 2>>"$MOAI_HOOK_STDERR_LOG"
-fi
-
-# Try default ~/go/bin/moai
-if [ -f "$HOME/go/bin/moai" ]; then
-    printf '%s' "$INPUT" | exec "$HOME/go/bin/moai" hook stop-goal 2>>"$MOAI_HOOK_STDERR_LOG"
-fi
-
-# Try ~/.local/bin/moai (Linux install location)
-if [ -f "$HOME/.local/bin/moai" ]; then
-    printf '%s' "$INPUT" | exec "$HOME/.local/bin/moai" hook stop-goal 2>>"$MOAI_HOOK_STDERR_LOG"
+# A goal IS armed — resolve the moai binary across the same 3 tiers, then feed
+# it the captured stdin exactly ONCE.
+#
+# Resolution happens BEFORE the invocation rather than each tier ending in its
+# own `printf '%s' "$INPUT" | exec <bin> …`: on the right-hand side of a
+# pipeline, `exec` replaces the pipeline's SUBSHELL, not this wrapper. A
+# per-tier exec therefore left the wrapper alive to fall through to the next
+# `if`, firing the evaluator again for every tier whose binary existed — and
+# $HOME/go/bin/moai is the standard Go install location, so a second firing was
+# the norm. That double-emitted the Stop JSON from one hook entry, double-
+# incremented turns_used (exhausting the ceiling in half the intended turns),
+# and ran every mechanical condition twice. Guarded by
+# TestStopGoalWrapperFiresEvaluatorExactlyOnce (internal/hook).
+MOAI_BIN=""
+if command -v moai > /dev/null 2>&1; then
+    MOAI_BIN="$(command -v moai)"
+elif [ -f "$HOME/go/bin/moai" ]; then
+    # Default Go install location.
+    MOAI_BIN="$HOME/go/bin/moai"
+elif [ -f "$HOME/.local/bin/moai" ]; then
+    # Linux install location.
+    MOAI_BIN="$HOME/.local/bin/moai"
 fi
 
 # Not found - exit silently (Claude Code handles missing hooks gracefully)
+if [ -z "$MOAI_BIN" ]; then
+    exit 0
+fi
+
+printf '%s' "$INPUT" | "$MOAI_BIN" hook stop-goal 2>>"$MOAI_HOOK_STDERR_LOG"
+
+# Always exit 0: the block decision rides the JSON on stdout, which Claude Code
+# honors only on exit 0 (exit 2 discards stdout). The evaluator itself never
+# exits non-zero, so this preserves the wrapper's existing contract.
 exit 0

--- a/.moai/reports/t220/verdict.md
+++ b/.moai/reports/t220/verdict.md
@@ -1,0 +1,86 @@
+# t220 — handle-stop-goal.sh가 goal 평가기를 매 turn 여러 번 돌리던 문제
+
+card: t220 · branch: `WT-stop-goal-double-exec` · base: `origin/main@62eeda07e`
+
+## Claim
+
+1. 래퍼가 goal 평가기를 **매 turn 3번** 발화했다(리드 보고는 2번 — 3계층 전부 존재하면 3번이고, `$HOME/.local/bin/moai`까지 있는 환경이 그렇다).
+2. 원인은 `printf … | exec <bin>` — `exec`은 파이프라인 **우변 서브셸**을 대체할 뿐 래퍼를 대체하지 않아, 래퍼가 살아남아 다음 계층 `if`로 떨어진다.
+3. 배포된 3개 사본 전부 동일 패턴이었고, 3개 모두 고쳤다.
+4. 범위 내에 **제3의 `exec` 변종은 없다**.
+
+## Evidence
+
+### 재현 (수정 전 트리, RED)
+
+```
+$ go test ./internal/hook/ -run TestStopGoalWrapper -count=1
+--- FAIL: TestStopGoalWrapperFiresEvaluatorExactlyOnce/.claude/hooks/moai/handle-stop-goal.sh
+    invoked the goal evaluator 3 time(s) [tier1-PATH tier2-HOME-GO-BIN tier3-HOME-LOCAL-BIN]; want exactly 1
+--- FAIL: …/internal/template/templates/.claude/hooks/moai/handle-stop-goal.sh
+    invoked the goal evaluator 3 time(s) [tier1-PATH tier2-HOME-GO-BIN tier3-HOME-LOCAL-BIN]; want exactly 1
+--- FAIL: …/internal/template/templates/.claude/hooks/moai/handle-stop-goal.sh.tmpl
+    invoked the goal evaluator 3 time(s) [tier1-PATH tier2-HOME-GO-BIN tier3-HOME-LOCAL-BIN]; want exactly 1
+FAIL	github.com/modu-ai/moai-adk/internal/hook	10.945s
+```
+
+실행 기반 계수다 — 문자열 grep이 아니라 3개 계층에 각각 계수 스텁을 놓고 래퍼를 실제로 돌려 호출 라벨을 기록했다.
+
+**기존 테스트가 왜 못 잡았는가**: `TestAC001_GoalAbsentSkipsMoaiBinary`는 이미 "정확히 1"을 단언하지만 PATH 계층에만 스텁을 두고 `$HOME`는 빈 임시 디렉터리로 둔다 — 폴스루가 찾을 게 없어 관측되지 않았다. 계층을 **전부 채우는 것**이 이 결함을 관측 가능하게 만드는 조건이다.
+
+### 수정 후 (GREEN)
+
+```
+$ go test ./internal/hook/ -run 'TestStopGoal|TestAC001' -count=1
+ok  	github.com/modu-ai/moai-adk/internal/hook	3.102s
+
+$ go test ./internal/template/... -count=1
+ok  	github.com/modu-ai/moai-adk/internal/template	62.560s
+ok  	github.com/modu-ai/moai-adk/internal/template/agentemit	0.968s
+
+$ go vet ./internal/hook/ ./internal/template/   # 무출력
+$ bash -n .claude/hooks/moai/handle-stop-goal.sh # syntax ok
+$ go build ./...                                  # build ok
+```
+
+### 제3 변종 스윕
+
+```
+$ git grep -ln 'printf.*| *exec' -- '*.sh' '*.tmpl'
+.claude/hooks/moai/handle-stop-goal.sh
+internal/template/templates/.claude/hooks/moai/handle-stop-goal.sh
+internal/template/templates/.claude/hooks/moai/handle-stop-goal.sh.tmpl
+
+$ git grep -nE '\(\s*exec |exec [^|]*\|\||exec [^|]*&&|\| *exec ' -- '.claude/hooks' 'internal/template/templates/.claude/hooks'
+→ 위 3개 파일의 해당 라인 + sync-phase-quality-gate.sh의 `find … -exec`(셸 exec 아님) 뿐
+
+$ grep -rlE 'exec ' .claude/hooks/moai/ | xargs grep -lE '^\s*[a-z_]+\(\)'
+.claude/hooks/moai/sync-phase-quality-gate.sh    # 함수 내부 exec은 find -exec 뿐
+```
+
+나머지 래퍼 31개는 bare `exec moai hook <event>` — 셸을 통째로 대체하므로 폴스루가 불가능하다. stdin을 잡는 형제 래퍼들(`chain-event`, `handle-codex-review-gate`, `handle-multi-review-gate`)은 이미 `MOAI_BIN` 선해결 + 단일 파이프 형태였다 — 이번 수정이 그 하우스 스타일에 합류한 것이지 새 패턴을 만든 게 아니다.
+
+**즉, 제3의 변종은 없다.** 근거는 위 3개 명령의 출력이며, 훑은 범위는 `.claude/hooks/**` 와 `internal/template/templates/.claude/hooks/**` 다.
+
+## Baseline-attribution
+
+전부 이 트리(`.claude/worktrees/t220`), base `62eeda07e`, 이번 실행에서 측정. RED는 수정 **전**, GREEN은 수정 **후** 같은 트리.
+
+## 변경 내용
+
+- `.claude/hooks/moai/handle-stop-goal.sh` + 템플릿 `.sh` + 템플릿 `.sh.tmpl` (3개 사본, 바이트 동일 유지) — 3계층을 **먼저 해결**한 뒤 `printf '%s' "$INPUT" | "$MOAI_BIN" hook stop-goal` 한 번. 왜 계층별 `exec`이면 안 되는지 주석으로 고정.
+- `internal/template/renderer.go` — `$MOAI_BIN`을 `claudeCodePassthroughTokens`에 추가. 렌더러가 미확장 셸 변수를 차단하는데, 이 목록엔 이미 같은 부류(래퍼 셸 지역변수: `$INPUT`, `$SESSION_ID`, `$STATE_FILE`, `$PROJECT_ROOT`)가 등록돼 있다. 누락 시 `TestLLMPanelTemplate_Integration`이 `unexpanded dynamic token detected: found "$MOAI_BIN"`로 실패한다 — 실제로 한 번 걸렸고 그 게이트가 옳게 작동한 것이다.
+- `internal/hook/stop_goal_single_exec_test.go` (신규) — 계수 스텁 기반 단일 발화 단언 + 3개 사본 바이트 동일성 잠금(Template-First: 배포되는 건 `.tmpl`이라 한쪽만 고치면 다음 `moai update`가 되돌린다).
+
+동작 계약 보존: 계층 우선순위(PATH → `$HOME/go/bin` → `$HOME/.local/bin`), 미발견 시 조용한 `exit 0`, stderr 로그 리다이렉트, 항상 exit 0(차단 결정은 stdout JSON이 나른다 — 평가기 자체가 non-zero를 반환하지 않는다) 전부 그대로다.
+
+## Gaps
+
+- 실제 Claude Code 세션에서 `turns_used` 증가가 turn당 1로 돌아오는지는 **관측하지 않았다**. 기계적 근거는 래퍼 실행 계수(3→1)이고, `turns_used` 이중 증가는 그 계수로부터의 추론이다.
+- 리드가 보고한 지연 수치(76ms → 31ms)는 재측정하지 않았다.
+- 전체 스위트는 로컬에서 돌리지 않았다(레인 규율). 영향 패키지는 `internal/hook/...`, `internal/template/...`.
+
+## Residual-risk
+
+- `$MOAI_BIN` 패스스루 등록은 렌더러의 미확장 토큰 검사를 그 이름에 한해 완화한다. 같은 이름의 진짜 미확장 템플릿 변수가 생기면 잡히지 않는다 — 목록의 기존 7개 래퍼 지역변수와 동일한 성격의 위험이다.
+- 3개 사본 동일성은 새 테스트가 잠그지만, 네 번째 사본이 생기면 `stopGoalWrapperCopies()`에 손으로 추가해야 한다.

--- a/internal/hook/stop_goal_single_exec_test.go
+++ b/internal/hook/stop_goal_single_exec_test.go
@@ -1,0 +1,153 @@
+package hook
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// t220: handle-stop-goal.sh resolved the moai binary across three tiers with
+// three separate `if` blocks, each ending in
+//
+//	printf '%s' "$INPUT" | exec <bin> hook stop-goal
+//
+// `exec` on the right of a pipeline replaces the pipeline's SUBSHELL, not the
+// wrapper. The wrapper therefore survived the first tier and fell through to
+// the next `if`, firing the evaluator again for every tier whose binary
+// existed — and `$HOME/go/bin/moai` is the standard Go install location, so a
+// second firing was the norm, not an edge case. Consequences, worst first: the
+// Stop JSON is emitted twice from one hook entry (double block decision);
+// turns_used double-increments, exhausting the ceiling in half the intended
+// turns; every mechanical condition runs twice.
+//
+// TestAC001_GoalAbsentSkipsMoaiBinary already asserts "exactly 1" — it never
+// caught this because it stubs only the PATH tier, leaving $HOME/go/bin empty
+// so the fall-through had nothing to find. These tests populate EVERY tier,
+// which is what makes the count observable.
+
+// stopGoalWrapperCopies returns the repo-relative paths of the three shipped
+// copies of the wrapper. They are byte-identical by contract (CLAUDE.local.md
+// §2.3 — the .tmpl is the one that actually deploys, so a fix applied to only
+// one copy is reverted by the next `moai update`). Running all three is also
+// the parity lock.
+func stopGoalWrapperCopies() []string {
+	return []string{
+		".claude/hooks/moai/handle-stop-goal.sh",
+		"internal/template/templates/.claude/hooks/moai/handle-stop-goal.sh",
+		"internal/template/templates/.claude/hooks/moai/handle-stop-goal.sh.tmpl",
+	}
+}
+
+// writeLabeledStub writes a stub binary that appends its label to counterPath.
+// It drains stdin first so the wrapper's `printf | stub` pipeline never sees
+// EPIPE, which would otherwise perturb what is being measured.
+func writeLabeledStub(t *testing.T, path, label, counterPath string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "#!/bin/bash\ncat >/dev/null\necho \"" + label + "\" >> \"" + counterPath + "\"\nexit 0\n"
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatalf("write stub %s: %v", path, err)
+	}
+}
+
+// readCounterLabels returns the labels recorded by the stubs, in order.
+func readCounterLabels(t *testing.T, path string) []string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatalf("read counter %s: %v", path, err)
+	}
+	var labels []string
+	for _, ln := range strings.Split(string(b), "\n") {
+		if s := strings.TrimSpace(ln); s != "" {
+			labels = append(labels, s)
+		}
+	}
+	return labels
+}
+
+// TestStopGoalWrapperFiresEvaluatorExactlyOnce is execution-based, not a source
+// grep: every resolution tier gets a counting stub, an armed goal makes the
+// wrapper proceed past its precondition, and the counter must record exactly
+// one invocation — the first tier.
+func TestStopGoalWrapperFiresEvaluatorExactlyOnce(t *testing.T) {
+	requireBash(t)
+	requireGit(t)
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	repoRoot := filepath.Join(cwd, "..", "..")
+
+	for _, rel := range stopGoalWrapperCopies() {
+		t.Run(rel, func(t *testing.T) {
+			tmp := t.TempDir()
+			stubBin := filepath.Join(tmp, "bin")
+			homeDir := filepath.Join(tmp, "home")
+			counter := filepath.Join(tmp, "invocations.log")
+
+			// Every tier the wrapper knows about is populated, each with a
+			// label naming the tier that fired.
+			writeLabeledStub(t, filepath.Join(stubBin, "moai"), "tier1-PATH", counter)
+			writeLabeledStub(t, filepath.Join(homeDir, "go", "bin", "moai"), "tier2-HOME-GO-BIN", counter)
+			writeLabeledStub(t, filepath.Join(homeDir, ".local", "bin", "moai"), "tier3-HOME-LOCAL-BIN", counter)
+
+			// Arm a goal so the wrapper's shell precondition lets it through.
+			sessionID := "sess-t220-single-exec"
+			stateDir := filepath.Join(repoRoot, ".moai", "state", "goal")
+			if err := os.MkdirAll(stateDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			stateFile := filepath.Join(stateDir, sessionID+".json")
+			if err := os.WriteFile(stateFile, []byte(`{"armed":true}`), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = os.Remove(stateFile) })
+
+			stdin := `{"session_id":"` + sessionID + `","last_assistant_message":"done"}`
+			_ = runHookScript(t, rel, stdin, stubBin, homeDir, repoRoot)
+
+			labels := readCounterLabels(t, counter)
+			if len(labels) != 1 {
+				t.Fatalf("%s invoked the goal evaluator %d time(s) %v; want exactly 1 — a pipeline's `exec` replaces the subshell, not the wrapper, so the wrapper falls through to the next resolution tier",
+					rel, len(labels), labels)
+			}
+			if labels[0] != "tier1-PATH" {
+				t.Errorf("%s resolved to %q; want the first tier (PATH)", rel, labels[0])
+			}
+		})
+	}
+}
+
+// TestStopGoalWrapperCopiesStayIdentical locks the Template-First contract: the
+// deployed copy is the .tmpl, so a fix landing on only one copy is silently
+// reverted by the next `moai update`.
+func TestStopGoalWrapperCopiesStayIdentical(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	repoRoot := filepath.Join(cwd, "..", "..")
+
+	copies := stopGoalWrapperCopies()
+	first, err := os.ReadFile(filepath.Join(repoRoot, copies[0]))
+	if err != nil {
+		t.Fatalf("read %s: %v", copies[0], err)
+	}
+	for _, rel := range copies[1:] {
+		b, err := os.ReadFile(filepath.Join(repoRoot, rel))
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		if string(b) != string(first) {
+			t.Errorf("%s differs from %s — the three copies must stay byte-identical, or `moai update` reverts the deployed one", rel, copies[0])
+		}
+	}
+}

--- a/internal/template/renderer.go
+++ b/internal/template/renderer.go
@@ -57,6 +57,7 @@ var claudeCodePassthroughTokens = []string{
 	"$ACTION",
 	"$AUTONOMY_TIER_DORMANT",
 	"$INPUT",
+	"$MOAI_BIN",
 	"$PROJECT_ROOT",
 	"$SESSION_ID",
 	"$STATE_FILE",

--- a/internal/template/templates/.claude/hooks/moai/handle-stop-goal.sh
+++ b/internal/template/templates/.claude/hooks/moai/handle-stop-goal.sh
@@ -58,22 +58,38 @@ if [ -z "$SESSION_ID" ] || [ ! -f "$STATE_FILE" ]; then
     exit 0
 fi
 
-# A goal IS armed — proceed to the 3-tier moai-binary resolution, replaying
-# the captured stdin so the evaluator sees the full Stop payload.
-# Try moai command in PATH
-if command -v moai &> /dev/null; then
-    printf '%s' "$INPUT" | exec moai hook stop-goal 2>>"$MOAI_HOOK_STDERR_LOG"
-fi
-
-# Try default ~/go/bin/moai
-if [ -f "$HOME/go/bin/moai" ]; then
-    printf '%s' "$INPUT" | exec "$HOME/go/bin/moai" hook stop-goal 2>>"$MOAI_HOOK_STDERR_LOG"
-fi
-
-# Try ~/.local/bin/moai (Linux install location)
-if [ -f "$HOME/.local/bin/moai" ]; then
-    printf '%s' "$INPUT" | exec "$HOME/.local/bin/moai" hook stop-goal 2>>"$MOAI_HOOK_STDERR_LOG"
+# A goal IS armed — resolve the moai binary across the same 3 tiers, then feed
+# it the captured stdin exactly ONCE.
+#
+# Resolution happens BEFORE the invocation rather than each tier ending in its
+# own `printf '%s' "$INPUT" | exec <bin> …`: on the right-hand side of a
+# pipeline, `exec` replaces the pipeline's SUBSHELL, not this wrapper. A
+# per-tier exec therefore left the wrapper alive to fall through to the next
+# `if`, firing the evaluator again for every tier whose binary existed — and
+# $HOME/go/bin/moai is the standard Go install location, so a second firing was
+# the norm. That double-emitted the Stop JSON from one hook entry, double-
+# incremented turns_used (exhausting the ceiling in half the intended turns),
+# and ran every mechanical condition twice. Guarded by
+# TestStopGoalWrapperFiresEvaluatorExactlyOnce (internal/hook).
+MOAI_BIN=""
+if command -v moai > /dev/null 2>&1; then
+    MOAI_BIN="$(command -v moai)"
+elif [ -f "$HOME/go/bin/moai" ]; then
+    # Default Go install location.
+    MOAI_BIN="$HOME/go/bin/moai"
+elif [ -f "$HOME/.local/bin/moai" ]; then
+    # Linux install location.
+    MOAI_BIN="$HOME/.local/bin/moai"
 fi
 
 # Not found - exit silently (Claude Code handles missing hooks gracefully)
+if [ -z "$MOAI_BIN" ]; then
+    exit 0
+fi
+
+printf '%s' "$INPUT" | "$MOAI_BIN" hook stop-goal 2>>"$MOAI_HOOK_STDERR_LOG"
+
+# Always exit 0: the block decision rides the JSON on stdout, which Claude Code
+# honors only on exit 0 (exit 2 discards stdout). The evaluator itself never
+# exits non-zero, so this preserves the wrapper's existing contract.
 exit 0

--- a/internal/template/templates/.claude/hooks/moai/handle-stop-goal.sh.tmpl
+++ b/internal/template/templates/.claude/hooks/moai/handle-stop-goal.sh.tmpl
@@ -58,22 +58,38 @@ if [ -z "$SESSION_ID" ] || [ ! -f "$STATE_FILE" ]; then
     exit 0
 fi
 
-# A goal IS armed — proceed to the 3-tier moai-binary resolution, replaying
-# the captured stdin so the evaluator sees the full Stop payload.
-# Try moai command in PATH
-if command -v moai &> /dev/null; then
-    printf '%s' "$INPUT" | exec moai hook stop-goal 2>>"$MOAI_HOOK_STDERR_LOG"
-fi
-
-# Try default ~/go/bin/moai
-if [ -f "$HOME/go/bin/moai" ]; then
-    printf '%s' "$INPUT" | exec "$HOME/go/bin/moai" hook stop-goal 2>>"$MOAI_HOOK_STDERR_LOG"
-fi
-
-# Try ~/.local/bin/moai (Linux install location)
-if [ -f "$HOME/.local/bin/moai" ]; then
-    printf '%s' "$INPUT" | exec "$HOME/.local/bin/moai" hook stop-goal 2>>"$MOAI_HOOK_STDERR_LOG"
+# A goal IS armed — resolve the moai binary across the same 3 tiers, then feed
+# it the captured stdin exactly ONCE.
+#
+# Resolution happens BEFORE the invocation rather than each tier ending in its
+# own `printf '%s' "$INPUT" | exec <bin> …`: on the right-hand side of a
+# pipeline, `exec` replaces the pipeline's SUBSHELL, not this wrapper. A
+# per-tier exec therefore left the wrapper alive to fall through to the next
+# `if`, firing the evaluator again for every tier whose binary existed — and
+# $HOME/go/bin/moai is the standard Go install location, so a second firing was
+# the norm. That double-emitted the Stop JSON from one hook entry, double-
+# incremented turns_used (exhausting the ceiling in half the intended turns),
+# and ran every mechanical condition twice. Guarded by
+# TestStopGoalWrapperFiresEvaluatorExactlyOnce (internal/hook).
+MOAI_BIN=""
+if command -v moai > /dev/null 2>&1; then
+    MOAI_BIN="$(command -v moai)"
+elif [ -f "$HOME/go/bin/moai" ]; then
+    # Default Go install location.
+    MOAI_BIN="$HOME/go/bin/moai"
+elif [ -f "$HOME/.local/bin/moai" ]; then
+    # Linux install location.
+    MOAI_BIN="$HOME/.local/bin/moai"
 fi
 
 # Not found - exit silently (Claude Code handles missing hooks gracefully)
+if [ -z "$MOAI_BIN" ]; then
+    exit 0
+fi
+
+printf '%s' "$INPUT" | "$MOAI_BIN" hook stop-goal 2>>"$MOAI_HOOK_STDERR_LOG"
+
+# Always exit 0: the block decision rides the JSON on stdout, which Claude Code
+# honors only on exit 0 (exit 2 discards stdout). The evaluator itself never
+# exits non-zero, so this preserves the wrapper's existing contract.
 exit 0


### PR DESCRIPTION
## The defect

`handle-stop-goal.sh` resolved the moai binary across three tiers, each tier ending in its own

```bash
printf '%s' "$INPUT" | exec <bin> hook stop-goal
```

On the right-hand side of a pipeline, `exec` replaces the pipeline's **subshell**, not the wrapper. The wrapper survived and fell through to the next `if`, firing the evaluator again for every tier whose binary existed — and `$HOME/go/bin/moai` is the standard Go install location, so a second firing was the norm, not an edge case.

Worst first: the Stop JSON was emitted **twice from one hook entry** (double block decision); `turns_used` double-incremented, exhausting the ceiling in **half** the intended turns; every mechanical condition ran twice, doubling any network round-trip a condition performs.

## Reproduction — 3, not 2

With all three tiers populated the count is **3**, and it reproduces on all three shipped copies:

```
--- FAIL: TestStopGoalWrapperFiresEvaluatorExactlyOnce/.claude/hooks/moai/handle-stop-goal.sh
    invoked the goal evaluator 3 time(s) [tier1-PATH tier2-HOME-GO-BIN tier3-HOME-LOCAL-BIN]; want exactly 1
--- FAIL: …/templates/.claude/hooks/moai/handle-stop-goal.sh        (same)
--- FAIL: …/templates/.claude/hooks/moai/handle-stop-goal.sh.tmpl   (same)
```

**Why the existing test missed it**: `TestAC001_GoalAbsentSkipsMoaiBinary` already asserts "exactly 1", but it stubs only the PATH tier and leaves `$HOME` an empty temp dir — the fall-through had nothing to find. Populating *every* tier is what makes the count observable.

## The fix

Resolve the three tiers first, then feed the captured stdin to the winner exactly once. Tier order, the silent `exit 0` when no binary is found, the stderr redirect, and the always-exit-0 contract (the block decision rides stdout JSON) are unchanged. This is the form the sibling stdin-capturing wrappers — `chain-event`, `codex-review-gate`, `multi-review-gate` — already use.

All three copies are fixed together (Template-First: the `.tmpl` is what deploys, so a one-copy fix is reverted by the next `moai update`), and a test locks them byte-identical.

`$MOAI_BIN` joins `claudeCodePassthroughTokens` beside the wrapper locals already there (`$INPUT`, `$SESSION_ID`, `$STATE_FILE`, `$PROJECT_ROOT`). Without it the renderer refuses the template with `unexpanded dynamic token detected: found "$MOAI_BIN"` — that gate fired during this work and was working correctly.

## Third-variant sweep — none

```
$ git grep -ln 'printf.*| *exec' -- '*.sh' '*.tmpl'
→ only the three handle-stop-goal copies

$ git grep -nE '\(\s*exec |exec [^|]*\|\||exec [^|]*&&|\| *exec ' -- '.claude/hooks' 'internal/template/templates/.claude/hooks'
→ those lines, plus sync-phase-quality-gate.sh's `find … -exec` (not shell exec)
```

Every other wrapper uses bare `exec moai hook <event>`, which replaces the shell outright — fall-through is impossible. Scope swept: `.claude/hooks/**` and `internal/template/templates/.claude/hooks/**`.

## Verification

```
$ go test ./internal/hook/ -run 'TestStopGoal|TestAC001' -count=1
ok  	internal/hook	3.102s

$ go test ./internal/template/... -count=1
ok  	internal/template	62.560s
ok  	internal/template/agentemit	0.968s

$ go vet ./internal/hook/ ./internal/template/   # clean
$ bash -n .claude/hooks/moai/handle-stop-goal.sh # ok
$ go build ./...                                  # ok
```

Not observed: `turns_used` returning to one increment per turn in a live session (the mechanical evidence is the wrapper invocation count, 3 → 1), and the latency figures from the audit were not re-measured. Full gaps and residual risk: `.moai/reports/t220/verdict.md`

Independent of every other open PR.

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented the stop-goal evaluator from running multiple times when `moai` is available in multiple installation locations.
  - Preserved silent handling when the executable is unavailable and maintained successful hook completion.

- **Tests**
  - Added coverage verifying exactly one evaluator invocation.
  - Added checks ensuring shipped hook templates remain identical.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->