### PR TITLE
fix(hook): blame the budget that actually ran out on a gate timeout (t218)

### DIFF
--- a/internal/hook/quality/gate.go
+++ b/internal/hook/quality/gate.go
@@ -990,13 +990,17 @@ func (g *QualityGate) runStep(ctx context.Context, stepName string, timeout time
 	// misattribute the narrow case where the step deadline fires first and the
 	// parent deadline passes while the process is still shutting down — both
 	// contexts then read DeadlineExceeded.
+	// Both budgets are compared as absolute instants derived from one clock
+	// read: a duration comparison would drift by whatever elapses between the
+	// two reads, which is exactly the margin the comparison is deciding.
+	startedAt := time.Now()
+	stepDeadline := startedAt.Add(timeout)
 	parentBudget, parentBinds := time.Duration(0), false
-	if deadline, ok := ctx.Deadline(); ok {
-		parentBudget = time.Until(deadline)
-		parentBinds = parentBudget <= timeout
+	if deadline, ok := ctx.Deadline(); ok && !deadline.After(stepDeadline) {
+		parentBudget, parentBinds = deadline.Sub(startedAt), true
 	}
 
-	stepCtx, cancel := context.WithTimeout(ctx, timeout)
+	stepCtx, cancel := context.WithDeadline(ctx, stepDeadline)
 	defer cancel()
 
 	cmd := exec.CommandContext(stepCtx, name, args...)

--- a/internal/hook/quality/gate.go
+++ b/internal/hook/quality/gate.go
@@ -984,6 +984,14 @@ func (g *QualityGate) anyConfigFileExists(configFiles []string) bool {
 // runStep executes a single quality gate command with the given timeout.
 // Returns (true, "") on success, (false, errorMessage) on failure or timeout.
 func (g *QualityGate) runStep(ctx context.Context, stepName string, timeout time.Duration, name string, args ...string) (bool, string) {
+	// The caller's own deadline (the hook dispatcher's, when the gate runs from
+	// a hook) is recorded before the step starts, so a kill can be attributed to
+	// whichever budget actually ran out — see the DeadlineExceeded branch below.
+	parentBudget, parentBounded := time.Duration(0), false
+	if deadline, ok := ctx.Deadline(); ok {
+		parentBudget, parentBounded = time.Until(deadline), true
+	}
+
 	stepCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -1024,8 +1032,16 @@ func (g *QualityGate) runStep(ctx context.Context, stepName string, timeout time
 
 	// Distinguish timeout from other failures (REQ-GATE-009).
 	if stepCtx.Err() == context.DeadlineExceeded {
-		msg := fmt.Sprintf("quality gate timed out: %s exceeded %s", stepName, timeout)
-		return false, msg
+		// A parent cancellation propagates to stepCtx, so DeadlineExceeded here
+		// says nothing about WHICH budget ran out. Blaming the step's own budget
+		// unconditionally produced impossible reasons — a 30s dispatcher budget
+		// expiring mid-`go test` reported "go test exceeded 2m0s" (card t218).
+		if parentBounded && ctx.Err() == context.DeadlineExceeded {
+			return false, fmt.Sprintf(
+				"quality gate timed out: the overall gate budget ran out while running %s (%s of it remained when the step started; the step's own %s budget was not exceeded)",
+				stepName, parentBudget.Round(time.Millisecond), timeout)
+		}
+		return false, fmt.Sprintf("quality gate timed out: %s exceeded %s", stepName, timeout)
 	}
 
 	// Fix 2: when a NuGet restore failure (cross-platform TFM mismatch) is detected in the dotnet step,

--- a/internal/hook/quality/gate.go
+++ b/internal/hook/quality/gate.go
@@ -984,12 +984,16 @@ func (g *QualityGate) anyConfigFileExists(configFiles []string) bool {
 // runStep executes a single quality gate command with the given timeout.
 // Returns (true, "") on success, (false, errorMessage) on failure or timeout.
 func (g *QualityGate) runStep(ctx context.Context, stepName string, timeout time.Duration, name string, args ...string) (bool, string) {
-	// The caller's own deadline (the hook dispatcher's, when the gate runs from
-	// a hook) is recorded before the step starts, so a kill can be attributed to
-	// whichever budget actually ran out — see the DeadlineExceeded branch below.
-	parentBudget, parentBounded := time.Duration(0), false
+	// Which budget can kill this step is decided BEFORE it starts, by comparing
+	// the caller's remaining time (the hook dispatcher's, when the gate runs
+	// from a hook) with the step's own. Deciding afterwards from ctx.Err() would
+	// misattribute the narrow case where the step deadline fires first and the
+	// parent deadline passes while the process is still shutting down — both
+	// contexts then read DeadlineExceeded.
+	parentBudget, parentBinds := time.Duration(0), false
 	if deadline, ok := ctx.Deadline(); ok {
-		parentBudget, parentBounded = time.Until(deadline), true
+		parentBudget = time.Until(deadline)
+		parentBinds = parentBudget <= timeout
 	}
 
 	stepCtx, cancel := context.WithTimeout(ctx, timeout)
@@ -1036,7 +1040,7 @@ func (g *QualityGate) runStep(ctx context.Context, stepName string, timeout time
 		// says nothing about WHICH budget ran out. Blaming the step's own budget
 		// unconditionally produced impossible reasons — a 30s dispatcher budget
 		// expiring mid-`go test` reported "go test exceeded 2m0s" (card t218).
-		if parentBounded && ctx.Err() == context.DeadlineExceeded {
+		if parentBinds {
 			return false, fmt.Sprintf(
 				"quality gate timed out: the overall gate budget ran out while running %s (%s of it remained when the step started; the step's own %s budget was not exceeded)",
 				stepName, parentBudget.Round(time.Millisecond), timeout)

--- a/internal/hook/quality/gate_timeout_attribution_test.go
+++ b/internal/hook/quality/gate_timeout_attribution_test.go
@@ -2,11 +2,37 @@ package quality
 
 import (
 	"context"
-	"runtime"
+	"os"
 	"strings"
 	"testing"
 	"time"
 )
+
+// helperSleepEnv switches the test binary into "sleep and exit" mode so the
+// timeout tests below have a long-running child process on every platform,
+// without depending on a POSIX shell.
+const helperSleepEnv = "MOAI_TEST_HELPER_SLEEP"
+
+// TestHelperSleep is not a test: re-executed as a child by sleeperCommand, it
+// blocks past any deadline the parent sets. Without the env marker it returns
+// immediately, so a normal suite run does nothing.
+func TestHelperSleep(t *testing.T) {
+	if os.Getenv(helperSleepEnv) != "1" {
+		t.Skip("helper process only")
+	}
+	time.Sleep(30 * time.Second)
+}
+
+// sleeperCommand returns the argv of a process that outlives any timeout used
+// in this file: this same test binary, run with only the helper selected.
+func sleeperCommand() (string, []string) {
+	return os.Args[0], []string{"-test.run=^TestHelperSleep$", "-test.timeout=60s"}
+}
+
+func sleeperEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv(helperSleepEnv, "1")
+}
 
 // Card t218 — a step killed because the CALLER's deadline expired used to be
 // reported as if the step had blown its own budget.
@@ -16,9 +42,7 @@ import (
 // the parent, so a 30s dispatcher budget expiring mid-`go test` produced
 // "go test exceeded 2m0s" — 30 seconds elapsed, a 2-minute budget blamed.
 func TestRunStep_ParentDeadlineIsNotBlamedOnTheStep(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("uses a POSIX shell to sleep past the parent deadline")
-	}
+	sleeperEnv(t)
 	g := NewQualityGate(DefaultGateConfig())
 
 	// Parent budget far shorter than the step's own: whatever kills the step,
@@ -26,7 +50,8 @@ func TestRunStep_ParentDeadlineIsNotBlamedOnTheStep(t *testing.T) {
 	parent, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
-	ok, msg := g.runStep(parent, "go test", 2*time.Minute, "sh", "-c", "sleep 5")
+	name, args := sleeperCommand()
+	ok, msg := g.runStep(parent, "go test", 2*time.Minute, name, args...)
 	if ok {
 		t.Fatal("a step outliving the parent deadline must fail")
 	}
@@ -40,15 +65,14 @@ func TestRunStep_ParentDeadlineIsNotBlamedOnTheStep(t *testing.T) {
 
 // The step's own budget must still be named when the step really does exceed it.
 func TestRunStep_StepDeadlineStillBlamesTheStep(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("uses a POSIX shell to sleep past the step deadline")
-	}
+	sleeperEnv(t)
 	g := NewQualityGate(DefaultGateConfig())
 
 	parent, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	ok, msg := g.runStep(parent, "go test", 100*time.Millisecond, "sh", "-c", "sleep 5")
+	name, args := sleeperCommand()
+	ok, msg := g.runStep(parent, "go test", 100*time.Millisecond, name, args...)
 	if ok {
 		t.Fatal("a step exceeding its own budget must fail")
 	}

--- a/internal/hook/quality/gate_timeout_attribution_test.go
+++ b/internal/hook/quality/gate_timeout_attribution_test.go
@@ -1,0 +1,58 @@
+package quality
+
+import (
+	"context"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Card t218 — a step killed because the CALLER's deadline expired used to be
+// reported as if the step had blown its own budget.
+//
+// context propagates a parent's cancellation to every child, so stepCtx.Err()
+// reads DeadlineExceeded in both cases. The old reason string never looked at
+// the parent, so a 30s dispatcher budget expiring mid-`go test` produced
+// "go test exceeded 2m0s" — 30 seconds elapsed, a 2-minute budget blamed.
+func TestRunStep_ParentDeadlineIsNotBlamedOnTheStep(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses a POSIX shell to sleep past the parent deadline")
+	}
+	g := NewQualityGate(DefaultGateConfig())
+
+	// Parent budget far shorter than the step's own: whatever kills the step,
+	// it is not the step budget.
+	parent, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	ok, msg := g.runStep(parent, "go test", 2*time.Minute, "sh", "-c", "sleep 5")
+	if ok {
+		t.Fatal("a step outliving the parent deadline must fail")
+	}
+	if strings.Contains(msg, "go test exceeded 2m0s") {
+		t.Errorf("reason blames the step's own budget for a parent-deadline kill: %q", msg)
+	}
+	if !strings.Contains(msg, "overall") {
+		t.Errorf("reason must name the overall (caller) budget as the cause, got: %q", msg)
+	}
+}
+
+// The step's own budget must still be named when the step really does exceed it.
+func TestRunStep_StepDeadlineStillBlamesTheStep(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses a POSIX shell to sleep past the step deadline")
+	}
+	g := NewQualityGate(DefaultGateConfig())
+
+	parent, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	ok, msg := g.runStep(parent, "go test", 100*time.Millisecond, "sh", "-c", "sleep 5")
+	if ok {
+		t.Fatal("a step exceeding its own budget must fail")
+	}
+	if !strings.Contains(msg, "go test exceeded 100ms") {
+		t.Errorf("reason must name the step budget, got: %q", msg)
+	}
+}


### PR DESCRIPTION
Re-opened as #1633 was auto-closed by the branch rename (`gate-timeout-budget` → `WT-gate-timeout-budget`, naming convention reverted 2026-08-24). Same commits, same head `83d3d4f06`; #1633 was fully green (all builds, Race Test, Integration Tests on 3 OSes, CodeRabbit `Review completed`).

## What

`QualityGate.runStep` reported every `DeadlineExceeded` as the step blowing its own budget. Because a parent cancellation propagates to the derived step context, that reason was wrong whenever the caller's deadline expired first — the 30s hook-dispatcher budget (`config.DefaultHookDispatcherTimeout`, applied in `internal/cli/hook.go`) expiring mid-`go test` printed `go test exceeded 2m0s` after 30 seconds.

Observed in the t214 audit: 30,033 / 30,016 / 30,020 ms runs, all pinned to the parent budget, all blamed on a 2-minute step budget that was never exceeded. PR #1625 removed the gate from PreToolUse but left this message on the surviving `moai gate` path.

## How

Which budget can kill the step is decided before it starts: the caller's deadline and the step's own are compared as absolute instants derived from a single clock read, and the step context is built with `context.WithDeadline` on that same instant. When the caller's deadline is the binding one, the reason names the overall gate budget and states that the step's own budget was not exceeded. Step-budget timeouts read exactly as before.

## Verification

Execution-based regression tests, both directions, no source grepping and no POSIX-shell dependency (the sleeper is this test binary re-executed with only a helper test selected):

```
go test ./internal/hook/quality/ -count=1
ok  	github.com/modu-ai/moai-adk/internal/hook/quality	45.258s
```

`go vet ./internal/hook/...` clean. Full-suite verdict from CI.

Card: t218

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout reporting during quality checks.
  * Clearly distinguishes overall quality-gate timeouts from individual step timeouts.
  * Reports the applicable timeout budget for more accurate diagnostics.

* **Tests**
  * Added cross-platform coverage to verify timeout attribution in different deadline scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->