### PR TITLE
feat(cli): back up and disclose user-modified pre-push hooks (t257)

### DIFF
--- a/.moai/reports/t257/measurement.md
+++ b/.moai/reports/t257/measurement.md
@@ -1,0 +1,252 @@
+# t257 Measurement — `InstallPrePushHook` silent overwrite of user-modified hook
+
+- Card: t257 (Class B — defect, cause unknown)
+- Date: 2026-08-25
+- Predecessor: t230 / SPEC-PRECOMMIT-PRESERVE-001 (merged, PR #1647) — behavioral standard
+- Verdict: **REPRODUCED**
+
+## Claim
+
+`InstallPrePushHook` (`internal/cli/hook_install.go:125-155`) silently destroys a
+marker-bearing, user-modified `.git/hooks/pre-push` on reinstall. It gates only on the
+MoAI marker: marker present → unconditional `os.WriteFile` overwrite (lines 138-152);
+marker absent → `ErrUserHookExists`. There is no content comparison, no provenance
+record, no backup, and no disclosure — the exact defect shape t230 eliminated for the
+pre-commit installer. The wrapper (`installPrePushHookOptional`, lines 165-178) has a
+single output writer and no branch that could disclose a replacement.
+
+Discrete claims, each measured below:
+
+1. Reinstalling over a marker-bearing, user-modified pre-push hook loses the user's
+   edit with no backup (REPRODUCED — `TestInstallPrePushHook_UserModified_ReinstallBacksUp` RED).
+2. The wrapper reports the reinstall as an ordinary install — no disclosure
+   (REPRODUCED — `TestInstallPrePushHook_UserModified_ReplacementDisclosed` RED).
+3. The no-marker foreign-hook scenario already meets the t230 standard
+   (existing `TestInstallPrePushHook_PreservesUserHook` GREEN).
+4. The existing suite codifies the defect as expected behavior
+   (existing `TestInstallPrePushHook_OverwritesMoaiHook` GREEN on a silent overwrite
+   that t230 semantics classify as user-modified).
+
+## Evidence (verbatim test output)
+
+Command (scoped, this worktree):
+
+```
+go test ./internal/cli/ -run 'TestInstallPrePushHook_UserModified' -count=1 -v
+```
+
+Output (verbatim, exit 1):
+
+```
+=== RUN   TestInstallPrePushHook_UserModified_ReinstallBacksUp
+    hook_install_prepush_preserve_test.go:98: SILENT LOSS: reinstall of a marker-bearing user-modified pre-push hook took no backup — the user patch is unrecoverable
+--- FAIL: TestInstallPrePushHook_UserModified_ReinstallBacksUp (0.21s)
+=== RUN   TestInstallPrePushHook_UserModified_ReplacementDisclosed
+    hook_install_prepush_preserve_test.go:127: SILENT REPLACEMENT: wrapper output "  Pre-push hook installed (.git/hooks/pre-push)\n" does not disclose the replacement of the user-modified hook (t230 standard: notice naming the backup)
+--- FAIL: TestInstallPrePushHook_UserModified_ReplacementDisclosed (0.26s)
+FAIL
+FAIL	github.com/modu-ai/moai-adk/internal/cli	1.491s
+FAIL
+```
+
+Note on claim 1's failure shape: the test also asserts the hook WAS replaced with the
+canonical content after reinstall; that assertion produced no error — so the overwrite
+happened and returned nil while the user patch was destroyed. The failure is "silent
+loss", not "install failed".
+
+Command (existing pre-push suite coexistence):
+
+```
+go test ./internal/cli/ -run 'TestInstallPrePushHook' -count=1 -v
+```
+
+Output (tail, verbatim — the 4 pre-existing tests all PASS; only the two measurement
+tests FAIL):
+
+```
+=== RUN   TestInstallPrePushHook_FreshRepo
+--- PASS: TestInstallPrePushHook_FreshRepo (0.21s)
+=== RUN   TestInstallPrePushHook_SkipFlag
+--- PASS: TestInstallPrePushHook_SkipFlag (0.22s)
+=== RUN   TestInstallPrePushHook_PreservesUserHook
+--- PASS: TestInstallPrePushHook_PreservesUserHook (0.19s)
+=== RUN   TestInstallPrePushHook_OverwritesMoaiHook
+--- PASS: TestInstallPrePushHook_OverwritesMoaiHook (0.31s)
+FAIL
+FAIL	github.com/modu-ai/moai-adk/internal/cli	2.603s
+FAIL
+```
+
+Command (vet):
+
+```
+go vet ./internal/cli/
+```
+
+Output: none — exit 0.
+
+Reproduction procedure (mirrors the t230 pre-commit defect): isolated repo under
+`t.TempDir()` → `git init` → baseline `InstallPrePushHook(false)` → user patch appended
+to the installed body (marker lines in the first 3 lines untouched) → reinstall
+`InstallPrePushHook(false)` → assert the t230 standard (backup holding pre-run bytes +
+disclosed replacement). Both assertions fail on current code exactly as the hypothesis
+predicts; the RED run itself proves the tests can fail, so no mutation step was needed.
+
+Code-path anchors (read, this tree):
+
+- `internal/cli/hook_install.go:138-148` — existing-hook branch checks the marker only;
+  no read/classify/backup (contrast `internal/cli/hook_install_precommit.go:246-281`).
+- `internal/cli/hook_install.go:150-152` — unconditional `os.WriteFile` of
+  `prePushHookContent`.
+- `internal/cli/hook_install.go:165-178` — wrapper with a single `out io.Writer`; no
+  warning writer, no backup-notice branch (contrast
+  `internal/cli/hook_install_precommit.go:395-435`, the REQ-PCP-004 warn-writer wiring).
+
+## Baseline-attribution
+
+- Tree: `.claude/worktrees/t257`, branch `WT-prepush-overwrite`,
+  HEAD `539349c5b093d88fb6bf75a9c8a76e4fefbd138b` (re-read via
+  `git rev-parse HEAD` immediately before writing this report).
+- Working tree at measurement time: exactly one untracked file —
+  `internal/cli/hook_install_prepush_preserve_test.go` (the measurement test itself).
+  No production code modified, nothing committed, nothing pushed.
+- All commands above were run in this run, against this tree; outputs are the outputs
+  observed in this run, not carried over.
+
+## Code-path comparison — pre-commit (t230, fixed) vs pre-push (current)
+
+| Scenario | pre-commit (t230 fixed) | pre-push (current) | t230 standard met? |
+|---|---|---|---|
+| Fresh install | write hook + SHA-256 provenance sidecar; nil | write hook; nil — no record written | Partial: no record, so future attribution is impossible (latent, not lossy by itself) |
+| Marker-bearing, unchanged vs record | classify `unmodified` (record basis) → quiet overwrite, no backup | no comparison at all; blind overwrite | Observably equivalent in this narrow case (no harm done) |
+| Marker-bearing + user patch | classify `user-modified` (record mismatch, or no record + content diff → noisy `undecidable-legacy`) → backup pre-run bytes to `pre-commit.bak.<stamp>` BEFORE replace → warn-writer notice naming the backup | blind `os.WriteFile`; user patch destroyed; returns nil; no backup; no notice | **NO — the defect (REPRODUCED)** |
+| No marker (foreign hook) | `ErrUserHookExists`; bytes preserved; no backup | `ErrUserHookExists`; bytes preserved | YES (parity — existing test GREEN) |
+
+Existing-suite hazard for the fix: `TestInstallPrePushHook_OverwritesMoaiHook`
+(`internal/cli/hook_install_test.go:138-171`) plants a marker-bearing legacy hook with
+no provenance record — under t230 semantics the `undecidable-legacy` basis, i.e.
+user-modified — and asserts the silent overwrite as CORRECT behavior. A t230-style fix
+will turn that test red; it must be rewritten with the fix, not preserved.
+
+## Gaps
+
+- Only the marker+user-patch and no-marker scenarios were measured by new tests; fresh
+  install / unchanged reinstall / skip are covered by the existing suite, not
+  re-measured here.
+- The disclosure test asserts on the wrapper's single writer because no warning writer
+  exists on the pre-push surface. A t230-style fix will add a warn writer and change
+  the wrapper signature; this measurement test is then superseded by the fix SPEC's
+  own tests (it will not compile unchanged — expected for a measurement artifact).
+- Caller wiring (`init.go` / `update_template_sync.go` → `installPrePushHookOptional`)
+  was not audited in this run; the wrapper-level measurement stands, the end-to-end
+  `moai init` / `moai update` command output was not exercised.
+- Windows not exercised (macOS host only); the mechanism is pure file I/O, so
+  platform risk is low but unmeasured.
+
+## Residual-risk
+
+- The reproduction patches by appending to the canonical body. An in-place edit that
+  rewrites the first 3 marker lines would dodge the marker gate (→ `ErrUserHookExists`,
+  preservation) — not measured; the defect as measured is broader than the specific
+  patch shape tested (any body edit keeping the marker is silently lost).
+- A fix mirroring t230 requires a pre-push provenance sidecar that does not exist yet.
+  Until the first post-fix run stamps it, every legacy marker-bearing install is
+  `undecidable-legacy` and will be treated as user-modified (noisy first run) — the
+  deliberate t230 trade-off (REQ-PCP-005), to be carried into the fix SPEC rather
+  than re-litigated.
+
+## Artifacts
+
+- Measurement test (uncommitted): `internal/cli/hook_install_prepush_preserve_test.go`
+  - `TestInstallPrePushHook_UserModified_ReinstallBacksUp` (RED)
+  - `TestInstallPrePushHook_UserModified_ReplacementDisclosed` (RED)
+- This report: `.moai/reports/t257/measurement.md`
+
+---
+
+# Fix (t257 scope (2) — reuse the t230 discriminator)
+
+Executed by the orchestrator (lane-12) directly: the delegated specialist hit a
+provider usage limit (429, resets 08:36) after the measurement phase, and the
+operator directed continuation in-session.
+
+## Claim
+
+1. The tier-generic core of the t230 machinery — three-way classifier, provenance
+   sidecar, pre-replacement backup — was extracted to
+   `internal/cli/hook_install_shared.go` (single implementation, `hookTier`
+   parameterization); the pre-commit installer now delegates to it with
+   behaviour unchanged.
+2. `InstallPrePushHook` classifies a marker-bearing existing hook before
+   overwriting: user-modified (record mismatch, or undecidable-legacy differing)
+   → back up pre-run bytes to `pre-push.bak.<stamp>` BEFORE replacement, then
+   disclose; unmodified → quiet overwrite. `prePushHookContent` untouched
+   (byte-identical; the t255 same-release trap does not fire).
+3. `installPrePushHookOptional` gained a distinct warning writer (REQ-PCP-004
+   wiring); callers (`init.go`, `update_template_sync.go`) bind it to stderr.
+4. `TestInstallPrePushHook_OverwritesMoaiHook` — which codified the silent
+   overwrite as correct — is rewritten as
+   `TestInstallPrePushHook_OverwritesMoaiHookBacksUp` (backup + replace).
+5. New mirror test `TestInstallPrePushHook_UnchangedReinstall_Quiet` pins the
+   quiet direction (no backup, no warning on an unmodified reinstall).
+
+## Evidence (verbatim, this tree)
+
+```
+$ go test ./internal/cli/ -run 'PrePushHook' -count=1 -v
+=== RUN   TestInstallPrePushHook_UserModified_ReinstallBacksUp
+--- PASS: TestInstallPrePushHook_UserModified_ReinstallBacksUp (0.10s)
+=== RUN   TestInstallPrePushHook_UserModified_ReplacementDisclosed
+--- PASS: TestInstallPrePushHook_UserModified_ReplacementDisclosed (0.11s)
+=== RUN   TestInstallPrePushHook_UnchangedReinstall_Quiet
+--- PASS: TestInstallPrePushHook_UnchangedReinstall_Quiet (0.11s)
+=== RUN   TestInstallPrePushHook_FreshRepo
+--- PASS: TestInstallPrePushHook_FreshRepo (0.10s)
+=== RUN   TestPrePushHookConventionBlockPlacement
+--- PASS: TestPrePushHookConventionBlockPlacement (0.00s)
+=== RUN   TestInstallPrePushHook_SkipFlag
+--- PASS: TestInstallPrePushHook_SkipFlag (0.10s)
+=== RUN   TestInstallPrePushHook_PreservesUserHook
+--- PASS: TestInstallPrePushHook_PreservesUserHook (0.10s)
+=== RUN   TestInstallPrePushHook_OverwritesMoaiHookBacksUp
+--- PASS: TestInstallPrePushHook_OverwritesMoaiHookBacksUp (0.10s)
+PASS
+ok  	github.com/modu-ai/moai-adk/internal/cli	1.585s
+
+$ go test ./internal/cli/ -run 'PreCommit' -count=1
+ok  	github.com/modu-ai/moai-adk/internal/cli	12.587s
+
+$ go vet ./internal/cli/ && GOOS=windows GOARCH=amd64 go vet ./internal/cli/
+(exit 0, no output)
+
+$ golangci-lint run internal/cli/
+0 issues.
+```
+
+The two formerly-RED measurement tests PASS unchanged in assertion intent (the
+disclosure test moved its assertion to the new warning writer, per the fix
+design — the pre-fix single-writer form no longer exists).
+
+## Baseline-attribution
+
+- Tree: `.claude/worktrees/t257`, branch `WT-prepush-overwrite`, base
+  `539349c5b` (origin/main at fix start); all commands run in this run against
+  this tree.
+
+## Gaps
+
+- The end-to-end `moai init` / `moai update` command output (caller-level) was
+  not exercised; wrapper-level tests cover the disclosure, and both call sites
+  were compile-verified and bind warn to stderr mirroring the pre-commit line.
+- Full `internal/cli` package suite not run locally (repo discipline: scoped
+  runs locally, full suite in CI).
+
+## Residual-risk
+
+- First post-fix run over legacy marker-bearing pre-push installs (no sidecar)
+  with content differing from canonical will back up + warn — the deliberate
+  REQ-PCP-005 noisy-legacy trade-off, carried from t230 unchanged.
+- Backup accumulation over repeated user patches (one `pre-push.bak.<stamp>`
+  per loss-bearing reinstall) — same noisy-but-safe posture t230 shipped;
+  accumulation management remains out of scope (t230 residual-risk, unchanged).
+

--- a/internal/cli/hook_install.go
+++ b/internal/cli/hook_install.go
@@ -8,12 +8,27 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 // moaiPrePushMarker is the identifier written on line 2 of the hook file.
 // Its presence signals that the hook was installed by MoAI-ADK and can be
 // safely overwritten on subsequent installs.
 const moaiPrePushMarker = "# MoAI-ADK pre-push hook"
+
+// moaiPrePushProvenanceName is the pre-push provenance sidecar basename; see
+// hookTier.provenanceName (hook_install_shared.go) for the rationale.
+const moaiPrePushProvenanceName = ".moai-pre-push.sha256"
+
+// prePushBackupPrefix is the pre-push backup basename prefix; see
+// hookTier.backupPrefix (hook_install_shared.go) for the rationale.
+const prePushBackupPrefix = "pre-push.bak."
+
+// errPrePushBackupFailed wraps a pre-push backup-write failure so the optional
+// wrapper can turn it into a warning while leaving the hook untouched (the
+// REQ-PCP-010 sub-case (a) equivalent for the push tier, t257). It never
+// reaches the caller as a failure.
+var errPrePushBackupFailed = errors.New("pre-push backup failed")
 
 // ErrUserHookExists is returned when a pre-existing hook without the MoAI
 // marker is found. The caller should inform the user and skip installation.
@@ -104,25 +119,61 @@ fi
 exit 0
 `
 
-// PrePushInstaller installs the MoAI-ADK pre-push git hook.
+// PrePushInstaller installs the MoAI-ADK pre-push git hook. It shares the
+// hook-preservation machinery with the pre-commit installer
+// (hook_install_shared.go): an existing marker-bearing hook is classified by
+// provenance before any overwrite, and a user-modified hook is backed up and
+// disclosed rather than silently replaced (t257).
 type PrePushInstaller struct {
 	// repoRoot is the root of the git repository.
 	repoRoot string
+
+	// content is the hook body this installer writes — the "incoming" operand
+	// of the attribution. Defaults to prePushHookContent; overridden in tests
+	// to construct a version bump without editing the shipped constant.
+	content string
+
+	// lastAttribution is the classification of the most recent install run
+	// against an existing marker-bearing hook, or nil when the run classified
+	// nothing (no existing hook, a non-MoAI hook, or skip=true).
+	lastAttribution *hookAttribution
+
+	// lastProvenanceErr holds a provenance-write failure from the most recent
+	// run. The write happens after a hook write that already succeeded, so it
+	// must not fail the caller; it is recorded rather than discarded so the
+	// wrapper can warn about it.
+	lastProvenanceErr error
+
+	// lastBackupPath is the backup copy written for a user-modified hook in the
+	// most recent run, or "" when no backup was taken. The wrapper reads it to
+	// emit the disclosure notice.
+	lastBackupPath string
+
+	// now supplies the timestamp for backup names. A seam so tests can force
+	// the same stamp twice and construct the occupied-path case.
+	now func() time.Time
 }
 
 // NewPrePushInstaller creates a PrePushInstaller for the given repository root.
 func NewPrePushInstaller(repoRoot string) *PrePushInstaller {
-	return &PrePushInstaller{repoRoot: repoRoot}
+	return &PrePushInstaller{repoRoot: repoRoot, content: prePushHookContent, now: time.Now}
 }
 
 // InstallPrePushHook writes the pre-push hook to .git/hooks/pre-push with mode 0755.
 //
 // Behaviour:
 //   - skip=true: no-op, returns nil.
-//   - File does not exist: creates it.
-//   - File exists with MoAI-ADK marker (first 3 lines): overwrites safely.
+//   - File does not exist: creates it, plus its provenance record.
+//   - File exists with MoAI-ADK marker (first 3 lines): classified by the
+//     shared three-way attribution — an unmodified hook is replaced quietly;
+//     a user-modified (or undecidable-legacy, differing) hook is backed up to
+//     `pre-push.bak.<stamp>` BEFORE the replacement.
 //   - File exists WITHOUT marker: returns ErrUserHookExists without modifying the file.
 func (p *PrePushInstaller) InstallPrePushHook(skip bool) error {
+	p.lastAttribution = nil
+	p.lastProvenanceErr = nil
+	p.lastBackupPath = ""
+
 	if skip {
 		return nil
 	}
@@ -144,36 +195,91 @@ func (p *PrePushInstaller) InstallPrePushHook(skip bool) error {
 		if !hasMoaiMarker {
 			return ErrUserHookExists
 		}
-		// MoAI hook found — overwrite.
+		// MoAI hook found — classify it before overwriting, exactly as the
+		// pre-commit installer does: the verdict decides backup + disclosure.
+		installed, err := os.ReadFile(hookPath)
+		if err != nil {
+			return fmt.Errorf("read existing hook: %w", err)
+		}
+		attribution := classifyHook(installed, readHookProvenance(hookDir, prePushTier), []byte(p.content))
+		p.lastAttribution = &attribution
+
+		// A user-modified hook is copied aside BEFORE the replacement is
+		// written, so the patch is recoverable the moment the loss-bearing
+		// overwrite happens (REQ-PCP-003 equivalent for the push tier).
+		if attribution.Class == hookUserModified {
+			backupPath, err := backupHook(hookDir, installed, p.now(), prePushTier)
+			if err != nil {
+				// The backup sits before the hook write, so a failure here
+				// means the patch cannot be made recoverable — the hook is
+				// left untouched and the caller is not failed; the wrapper
+				// turns this into a warning. Overwriting anyway would destroy
+				// the patch with no recoverable copy.
+				return fmt.Errorf("%w: %w", errPrePushBackupFailed, err)
+			}
+			p.lastBackupPath = backupPath
+		}
 	}
 
-	if err := os.WriteFile(hookPath, []byte(prePushHookContent), 0o755); err != nil {
+	if err := os.WriteFile(hookPath, []byte(p.content), 0o755); err != nil {
 		return fmt.Errorf("write pre-push hook: %w", err)
 	}
+
+	// Record what was just written, so the next run can attribute a
+	// difference. A failure here follows a hook write that already succeeded,
+	// so it must not fail the caller: the missing record self-heals on the
+	// next run, which finds installed == incoming and re-stamps.
+	p.lastProvenanceErr = writeHookProvenance(hookDir, p.content, prePushTier)
 
 	return nil
 }
 
 // installPrePushHookOptional installs the pre-push hook into projectRoot's .git/hooks/
-// unless skip is true. Friendly, non-fatal: prints status to out, returns nothing.
-// Used by `moai init` and `moai update` to install the hook consistently
+// unless skip is true. Friendly, non-fatal: prints progress to out, warnings to
+// warn (a writer distinct from out — callers bind it to the command's stderr,
+// the REQ-PCP-004 wiring the pre-commit wrapper uses), returns nothing. Used by
+// `moai init` and `moai update` to install the hook consistently
 // (REQ-CIAUT-002).
 //
 // If a non-MoAI user hook is present, this function preserves it and prints a
 // note. Other errors are reported as warnings; project init/update is never
 // blocked by hook installation failures.
-func installPrePushHookOptional(projectRoot string, skip bool, out io.Writer) {
+func installPrePushHookOptional(projectRoot string, skip bool, out, warn io.Writer) {
 	installer := NewPrePushInstaller(projectRoot)
 	err := installer.InstallPrePushHook(skip)
 	switch {
 	case err == nil:
 		if !skip {
 			_, _ = fmt.Fprintln(out, "  Pre-push hook installed (.git/hooks/pre-push)")
+			if installer.lastBackupPath != "" {
+				// The notice carries exactly two elements — the backup path and
+				// the fact of the replacement — on the warning writer, never
+				// the progress writer (which `moai update` binds to stdout,
+				// where a redirected run swallows a data-loss notice whole).
+				_, _ = fmt.Fprintf(warn, "  Warning: user-modified pre-push hook was replaced; previous hook backed up at %s\n", installer.lastBackupPath)
+			}
+			if installer.lastProvenanceErr != nil {
+				// The hook write already succeeded, so the replacement stands;
+				// the missing record self-heals on the next run.
+				_, _ = fmt.Fprintf(warn, "  Warning: pre-push provenance record not written: %v\n", installer.lastProvenanceErr)
+			}
 		}
 	case errors.Is(err, ErrUserHookExists):
 		_, _ = fmt.Fprintln(out, "  Note: existing pre-push hook preserved (no MoAI-ADK marker found)")
+	case errors.Is(err, errPrePushBackupFailed):
+		// No backup could be written, so the hook was left exactly as found —
+		// nothing was installed and nothing was lost.
+		_, _ = fmt.Fprintf(warn, "  Warning: pre-push hook left unchanged (backup could not be written): %v\n", err)
 	default:
-		_, _ = fmt.Fprintf(out, "  Warning: pre-push hook install failed: %v\n", err)
+		if installer.lastBackupPath != "" {
+			// The backup succeeded but the replacement write failed, so no
+			// replacement notice (the hook was not replaced). Name the orphan
+			// backup so the artifact beside the unchanged hook is explained
+			// rather than mysterious.
+			_, _ = fmt.Fprintf(warn, "  Warning: pre-push hook install failed: %v (previous hook backed up at %s)\n", err, installer.lastBackupPath)
+		} else {
+			_, _ = fmt.Fprintf(out, "  Warning: pre-push hook install failed: %v\n", err)
+		}
 	}
 }
 

--- a/internal/cli/hook_install_precommit.go
+++ b/internal/cli/hook_install_precommit.go
@@ -1,15 +1,11 @@
 package cli
 
 import (
-	"bytes"
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 )
 
@@ -18,22 +14,12 @@ import (
 // can be safely overwritten on subsequent installs.
 const moaiPreCommitMarker = "# MoAI-ADK pre-commit hook"
 
-// moaiPreCommitProvenanceName is the sidecar recording the SHA-256 of the hook
-// content this tool last wrote. It lives beside the hook in .git/hooks/, so it
-// shares the hook's lifetime exactly: wiping .git/hooks/ takes both.
-//
-// The record is the third operand of the attribution in REQ-PCP-014. Without
-// it only "installed" and "incoming" exist, and those two cannot separate "the
-// user changed it" from "we changed it" — a routine version bump then reads as
-// a user patch for every user on every release.
+// moaiPreCommitProvenanceName is the pre-commit provenance sidecar basename;
+// see hookTier.provenanceName (hook_install_shared.go) for the rationale.
 const moaiPreCommitProvenanceName = ".moai-pre-commit.sha256"
 
-// preCommitBackupPrefix is the basename prefix of the backup copies taken
-// before a user-modified hook is replaced: `pre-commit.bak.<stamp>`, the
-// pattern REQ-PCP-003 names. The stamp is a colon-free UTC form
-// (20060102T150405Z) — RFC3339 proper contains `:`, which is illegal in a
-// Windows filename, and a backup the user cannot create/read on their own
-// platform is not a backup.
+// preCommitBackupPrefix is the pre-commit backup basename prefix; see
+// hookTier.backupPrefix (hook_install_shared.go) for the rationale.
 const preCommitBackupPrefix = "pre-commit.bak."
 
 // errPreCommitBackupFailed wraps a backup-write failure so the optional
@@ -126,56 +112,6 @@ fi
 exit 0
 `
 
-// preCommitClass is the attribution verdict for an existing marker-bearing hook.
-type preCommitClass int
-
-const (
-	// preCommitUnmodified: the hook is as MoAI last wrote it. Any difference
-	// against the incoming content is an upstream version bump, so the
-	// overwrite is quiet (REQ-PCP-002).
-	preCommitUnmodified preCommitClass = iota
-	// preCommitUserModified: the hook was edited after MoAI wrote it. This is
-	// the loss-bearing case; M2 hangs the backup and the notice off it.
-	preCommitUserModified
-)
-
-func (c preCommitClass) String() string {
-	if c == preCommitUserModified {
-		return "user-modified"
-	}
-	return "unmodified"
-}
-
-// preCommitBasis names which operands produced the verdict — the third label of
-// the spec's three-way classification, kept separate from the verdict because
-// "undecidable-legacy" describes how the answer was reached, not what it was.
-type preCommitBasis int
-
-const (
-	// preCommitBasisRecord: a usable provenance record existed, so the verdict
-	// comes from installed-vs-recorded — the three-way comparison.
-	preCommitBasisRecord preCommitBasis = iota
-	// preCommitBasisUndecidableLegacy: no usable record existed, so attribution
-	// was impossible and the verdict falls back to installed-vs-incoming, with
-	// any difference read as a user edit (REQ-PCP-005). Deliberately the noisy
-	// direction: a hand-patched legacy hook is the most likely thing to be
-	// found without a record.
-	preCommitBasisUndecidableLegacy
-)
-
-func (b preCommitBasis) String() string {
-	if b == preCommitBasisUndecidableLegacy {
-		return "undecidable-legacy"
-	}
-	return "record"
-}
-
-// preCommitAttribution is one classification of an existing marker-bearing hook.
-type preCommitAttribution struct {
-	Class preCommitClass
-	Basis preCommitBasis
-}
-
 // PreCommitInstaller installs the MoAI-ADK pre-commit git hook. It mirrors
 // PrePushInstaller's marker-based semantics for the commit tier.
 type PreCommitInstaller struct {
@@ -190,7 +126,7 @@ type PreCommitInstaller struct {
 	// lastAttribution is the classification of the most recent install run
 	// against an existing marker-bearing hook, or nil when the run classified
 	// nothing (no existing hook, a non-MoAI hook, or skip=true).
-	lastAttribution *preCommitAttribution
+	lastAttribution *hookAttribution
 
 	// lastProvenanceErr holds a provenance-write failure from the most recent
 	// run. The write happens after a hook write that already succeeded, so it
@@ -259,14 +195,14 @@ func (p *PreCommitInstaller) InstallPreCommitHook(skip bool) error {
 		if err != nil {
 			return fmt.Errorf("read existing hook: %w", err)
 		}
-		attribution := classifyPreCommitHook(installed, readPreCommitProvenance(hookDir), []byte(p.content))
+		attribution := classifyHook(installed, readHookProvenance(hookDir, preCommitTier), []byte(p.content))
 		p.lastAttribution = &attribution
 
 		// REQ-PCP-003: a user-modified hook is copied aside BEFORE the
 		// replacement is written, so the patch is recoverable the moment the
 		// loss-bearing overwrite happens.
-		if attribution.Class == preCommitUserModified {
-			backupPath, err := backupPreCommitHook(hookDir, installed, p.now())
+		if attribution.Class == hookUserModified {
+			backupPath, err := backupHook(hookDir, installed, p.now(), preCommitTier)
 			if err != nil {
 				// REQ-PCP-010 sub-case (a): the backup sits before the hook
 				// write, so a failure here means the patch cannot be made
@@ -289,98 +225,9 @@ func (p *PreCommitInstaller) InstallPreCommitHook(skip bool) error {
 	// succeeded, so it must not fail the caller (REQ-PCP-010): the missing
 	// record self-heals on the next run, which finds installed == incoming and
 	// re-stamps.
-	p.lastProvenanceErr = writePreCommitProvenance(hookDir, p.content)
+	p.lastProvenanceErr = writeHookProvenance(hookDir, p.content, preCommitTier)
 
 	return nil
-}
-
-// classifyPreCommitHook decides whether an existing marker-bearing hook was
-// edited by the user, from three operands: the installed bytes, the digest this
-// tool last recorded writing (empty when absent or unusable), and the incoming
-// bytes.
-//
-// A two-way comparison of installed against incoming cannot make this call: an
-// upstream version bump produces the same signal as a user patch, so a two-way
-// design warns every user on every release that touches the hook (REQ-PCP-014).
-func classifyPreCommitHook(installed []byte, recordedDigest string, incoming []byte) preCommitAttribution {
-	if recordedDigest == "" {
-		// No usable record: attribution is impossible, so fall back to
-		// installed-vs-incoming and read any difference as a user edit.
-		if bytes.Equal(installed, incoming) {
-			return preCommitAttribution{Class: preCommitUnmodified, Basis: preCommitBasisUndecidableLegacy}
-		}
-		return preCommitAttribution{Class: preCommitUserModified, Basis: preCommitBasisUndecidableLegacy}
-	}
-
-	if digestOfBytes(installed) == recordedDigest {
-		return preCommitAttribution{Class: preCommitUnmodified, Basis: preCommitBasisRecord}
-	}
-	return preCommitAttribution{Class: preCommitUserModified, Basis: preCommitBasisRecord}
-}
-
-// readPreCommitProvenance returns the recorded digest, or "" when no usable
-// record exists. A missing, unreadable or malformed record is treated as
-// absent, which routes the caller to the deliberately noisy legacy path
-// (REQ-PCP-005).
-func readPreCommitProvenance(hookDir string) string {
-	raw, err := os.ReadFile(filepath.Join(hookDir, moaiPreCommitProvenanceName))
-	if err != nil {
-		return ""
-	}
-	digest := strings.TrimSpace(string(raw))
-	if len(digest) != hex.EncodedLen(sha256.Size) {
-		return ""
-	}
-	if _, err := hex.DecodeString(digest); err != nil {
-		return ""
-	}
-	return digest
-}
-
-// writePreCommitProvenance records the digest of the content just written.
-func writePreCommitProvenance(hookDir, content string) error {
-	path := filepath.Join(hookDir, moaiPreCommitProvenanceName)
-	if err := os.WriteFile(path, []byte(digestOfBytes([]byte(content))+"\n"), 0o644); err != nil {
-		return fmt.Errorf("write pre-commit provenance record: %w", err)
-	}
-	return nil
-}
-
-func digestOfBytes(b []byte) string {
-	sum := sha256.Sum256(b)
-	return hex.EncodeToString(sum[:])
-}
-
-// backupPreCommitHook copies the pre-run hook bytes to a timestamped backup in
-// hookDir and returns the path chosen. The name is `pre-commit.bak.<UTC
-// colon-free stamp>`; when a candidate path is occupied a distinct sibling
-// suffix is chosen instead — an existing backup is never overwritten
-// (REQ-PCP-009). O_EXCL makes the never-clobber guarantee hold even if a file
-// appears between the choice and the write.
-func backupPreCommitHook(hookDir string, preRun []byte, now time.Time) (string, error) {
-	stamp := now.UTC().Format("20060102T150405Z")
-	for i := 0; ; i++ {
-		name := preCommitBackupPrefix + stamp
-		if i > 0 {
-			name = fmt.Sprintf("%s.%d", name, i)
-		}
-		path := filepath.Join(hookDir, name)
-		f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o755)
-		if err != nil {
-			if os.IsExist(err) {
-				continue // occupied: pick a distinct name, never clobber
-			}
-			return "", fmt.Errorf("back up user-modified pre-commit hook to %s: %w", path, err)
-		}
-		if _, err := f.Write(preRun); err != nil {
-			_ = f.Close()
-			return "", fmt.Errorf("back up user-modified pre-commit hook to %s: %w", path, err)
-		}
-		if err := f.Close(); err != nil {
-			return "", fmt.Errorf("back up user-modified pre-commit hook to %s: %w", path, err)
-		}
-		return path, nil
-	}
 }
 
 // installPreCommitHookOptional installs the pre-commit hook into projectRoot's

--- a/internal/cli/hook_install_precommit_attribution_test.go
+++ b/internal/cli/hook_install_precommit_attribution_test.go
@@ -112,7 +112,7 @@ func installWithContent(t *testing.T, root, incoming string) *PreCommitInstaller
 	return installer
 }
 
-func assertAttribution(t *testing.T, got *preCommitAttribution, wantClass preCommitClass, wantBasis preCommitBasis) {
+func assertAttribution(t *testing.T, got *hookAttribution, wantClass hookClass, wantBasis hookBasis) {
 	t.Helper()
 	if got == nil {
 		t.Fatalf("no attribution recorded: expected class=%v basis=%v", wantClass, wantBasis)
@@ -190,7 +190,7 @@ func TestPreCommitVersionBumpIsSilent(t *testing.T) {
 	root2 := newPreCommitTestRepo(t)
 	installWithContent(t, root2, previousPreCommitHookContent)
 	bump := installWithContent(t, root2, preCommitHookContent)
-	assertAttribution(t, bump.lastAttribution, preCommitUnmodified, preCommitBasisRecord)
+	assertAttribution(t, bump.lastAttribution, hookUnmodified, hookBasisRecord)
 }
 
 // TestPreCommitThreeWayAttribution — AC-PCP-014 (REQ-PCP-014).
@@ -208,7 +208,7 @@ func TestPreCommitThreeWayAttribution(t *testing.T) {
 
 		installer := installWithContent(t, root, incoming)
 
-		assertAttribution(t, installer.lastAttribution, preCommitUnmodified, preCommitBasisRecord)
+		assertAttribution(t, installer.lastAttribution, hookUnmodified, hookBasisRecord)
 		assertNoBackup(t, root)
 		if got := readHook(t, root); got != incoming {
 			t.Errorf("hook was not replaced with the incoming content")
@@ -222,7 +222,7 @@ func TestPreCommitThreeWayAttribution(t *testing.T) {
 
 		installer := installWithContent(t, root, incoming)
 
-		assertAttribution(t, installer.lastAttribution, preCommitUserModified, preCommitBasisRecord)
+		assertAttribution(t, installer.lastAttribution, hookUserModified, hookBasisRecord)
 	})
 }
 
@@ -239,7 +239,7 @@ func TestPreCommitLegacyNoRecord(t *testing.T) {
 
 		installer := installWithContent(t, root, preCommitHookContent)
 
-		assertAttribution(t, installer.lastAttribution, preCommitUserModified, preCommitBasisUndecidableLegacy)
+		assertAttribution(t, installer.lastAttribution, hookUserModified, hookBasisUndecidableLegacy)
 	})
 
 	t.Run("b_no_record_content_identical", func(t *testing.T) {
@@ -248,7 +248,7 @@ func TestPreCommitLegacyNoRecord(t *testing.T) {
 
 		installer := installWithContent(t, root, preCommitHookContent)
 
-		assertAttribution(t, installer.lastAttribution, preCommitUnmodified, preCommitBasisUndecidableLegacy)
+		assertAttribution(t, installer.lastAttribution, hookUnmodified, hookBasisUndecidableLegacy)
 		assertNoBackup(t, root)
 		if got, want := readRecord(t, root), digestOf(preCommitHookContent); got != want {
 			t.Errorf("record = %q, want %q", got, want)
@@ -262,7 +262,7 @@ func TestPreCommitLegacyNoRecord(t *testing.T) {
 
 		installer := installWithContent(t, root, preCommitHookContent)
 
-		assertAttribution(t, installer.lastAttribution, preCommitUnmodified, preCommitBasisUndecidableLegacy)
+		assertAttribution(t, installer.lastAttribution, hookUnmodified, hookBasisUndecidableLegacy)
 		assertNoBackup(t, root)
 		if got, want := readRecord(t, root), digestOf(preCommitHookContent); got != want {
 			t.Errorf("record = %q, want %q", got, want)

--- a/internal/cli/hook_install_prepush_preserve_test.go
+++ b/internal/cli/hook_install_prepush_preserve_test.go
@@ -1,0 +1,153 @@
+package cli
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// This file carries card t257's pre-push preservation tests, born as the
+// measurement that reproduced the defect (both UserModified tests RED against
+// the pre-t257 blind-overwrite installer) and retained as the regression guard
+// for the fix: a marker-bearing hook the user edited must be backed up before
+// replacement (REQ-PCP-003 equivalent) and the replacement must be disclosed on
+// the warning writer (REQ-PCP-004 equivalent) — never silently lost. The
+// unmodified-reinstall case must stay QUIET: no backup, no notice.
+
+// newPrePushTestRepo creates a git repository in a temp dir and returns its
+// root. git is required; its absence fails rather than skips, so an unrun
+// criterion cannot read as a pass (mirrors newPreCommitTestRepo).
+func newPrePushTestRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if out, err := exec.Command("git", "init", dir).CombinedOutput(); err != nil {
+		t.Fatalf("git init %s: %v\n%s", dir, err, out)
+	}
+	return dir
+}
+
+func prepushHookPath(root string) string {
+	return filepath.Join(root, ".git", "hooks", "pre-push")
+}
+
+// findPrePushBackups returns every pre-push.bak.* artifact in root's hooks
+// dir — the pre-push naming equivalent of the pre-commit backup pattern
+// (preCommitBackupPrefix, REQ-PCP-003).
+func findPrePushBackups(t *testing.T, root string) []string {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(root, ".git", "hooks", "pre-push.bak.*"))
+	if err != nil {
+		t.Fatalf("glob backups: %v", err)
+	}
+	return matches
+}
+
+// installPrePushAndPatch installs the hook once (baseline), then simulates a
+// user editing the installed body: a customization is appended while the MoAI
+// marker lines (first 3 lines) are untouched, so the marker gate still
+// recognises the hook as MoAI-installed. Returns the patched bytes.
+func installPrePushAndPatch(t *testing.T, root string) string {
+	t.Helper()
+	if err := NewPrePushInstaller(root).InstallPrePushHook(false); err != nil {
+		t.Fatalf("baseline InstallPrePushHook: %v", err)
+	}
+	if !strings.Contains(prePushHookContent, moaiPrePushMarker) {
+		t.Fatalf("fixture construction: prePushHookContent missing the marker %q", moaiPrePushMarker)
+	}
+	patched := prePushHookContent + "\n# USER PATCH: notify #ci on failure (added by the user)\n"
+	if patched == prePushHookContent {
+		t.Fatalf("fixture construction: user patch is vacuous")
+	}
+	if err := os.WriteFile(prepushHookPath(root), []byte(patched), 0o755); err != nil {
+		t.Fatalf("write user-patched hook: %v", err)
+	}
+	return patched
+}
+
+// TestInstallPrePushHook_UserModified_ReinstallBacksUp — t257 reproduction,
+// part one. Reinstalling over a marker-bearing, user-modified pre-push hook
+// must not silently lose the user's edit: the t230 standard (REQ-PCP-003
+// equivalent) requires a backup holding the pre-run bytes, taken before the
+// replacement.
+func TestInstallPrePushHook_UserModified_ReinstallBacksUp(t *testing.T) {
+	root := newPrePushTestRepo(t)
+	patched := installPrePushAndPatch(t, root)
+
+	// Reinstall over the user-modified hook.
+	if err := NewPrePushInstaller(root).InstallPrePushHook(false); err != nil {
+		t.Fatalf("reinstall InstallPrePushHook: %v", err)
+	}
+
+	// Confirm the replacement actually happened, so a missing backup reads as
+	// "silent loss" rather than "install failed".
+	if got, err := os.ReadFile(prepushHookPath(root)); err != nil {
+		t.Fatalf("read hook after reinstall: %v", err)
+	} else if string(got) != prePushHookContent {
+		t.Errorf("expected the canonical content after reinstall, got %d bytes", len(got))
+	}
+
+	// The t230 standard: the user's pre-run bytes must survive in a backup.
+	backups := findPrePushBackups(t, root)
+	if len(backups) == 0 {
+		t.Errorf("SILENT LOSS: reinstall of a marker-bearing user-modified pre-push hook took no backup — the user patch is unrecoverable")
+		return
+	}
+	if len(backups) != 1 {
+		t.Errorf("expected exactly one backup, found %d: %v", len(backups), backups)
+	}
+	got, err := os.ReadFile(backups[0])
+	if err != nil {
+		t.Fatalf("read backup %s: %v", backups[0], err)
+	}
+	if string(got) != patched {
+		t.Errorf("backup must hold the pre-run user-modified bytes: got %d bytes, want the %d-byte patched content", len(got), len(patched))
+	}
+}
+
+// TestInstallPrePushHook_UserModified_ReplacementDisclosed — t257, part two.
+// The replacement of a user-modified hook must be disclosed (REQ-PCP-004
+// equivalent): the warning writer names the backup, and the progress writer
+// must NOT carry the notice — `moai update` binds the progress writer to
+// stdout, where a redirected run would swallow a data-loss notice whole.
+func TestInstallPrePushHook_UserModified_ReplacementDisclosed(t *testing.T) {
+	root := newPrePushTestRepo(t)
+	installPrePushAndPatch(t, root)
+
+	var out, warn strings.Builder
+	installPrePushHookOptional(root, false, &out, &warn)
+
+	if !strings.Contains(warn.String(), "backed up") {
+		t.Errorf("SILENT REPLACEMENT: warning output %q does not disclose the replacement of the user-modified hook (standard: notice naming the backup)", warn.String())
+	}
+	if strings.Contains(out.String(), "backed up") {
+		t.Errorf("disclosure leaked to the progress writer %q — the notice belongs on the warning writer only", out.String())
+	}
+}
+
+// TestInstallPrePushHook_UnchangedReinstall_Quiet verifies the mirror of the
+// backup path: a reinstall over an UNMODIFIED hook (provenance record matches)
+// must be quiet — no backup file, no warning. Guards the noisy direction from
+// both ends so the classifier's unmodified verdict keeps routine reinstalls
+// silent.
+func TestInstallPrePushHook_UnchangedReinstall_Quiet(t *testing.T) {
+	root := newPrePushTestRepo(t)
+	// Baseline install writes the hook plus its provenance record.
+	if err := NewPrePushInstaller(root).InstallPrePushHook(false); err != nil {
+		t.Fatalf("baseline InstallPrePushHook: %v", err)
+	}
+
+	var out, warn strings.Builder
+	installPrePushHookOptional(root, false, &out, &warn)
+
+	if len(findPrePushBackups(t, root)) != 0 {
+		t.Errorf("unchanged reinstall must not take a backup, found: %v", findPrePushBackups(t, root))
+	}
+	if warn.String() != "" {
+		t.Errorf("unchanged reinstall must produce no warning output, got %q", warn.String())
+	}
+	if !strings.Contains(out.String(), "Pre-push hook installed") {
+		t.Errorf("unchanged reinstall should still report the install on the progress writer, got %q", out.String())
+	}
+}

--- a/internal/cli/hook_install_shared.go
+++ b/internal/cli/hook_install_shared.go
@@ -1,0 +1,199 @@
+package cli
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// This file carries the tier-generic core of the hook-preservation machinery
+// introduced by SPEC-PRECOMMIT-PRESERVE-001 (t230) for the pre-commit hook and
+// extended to the pre-push hook by card t257: the three-way attribution
+// classifier, the provenance sidecar, and the pre-replacement backup. Both
+// installers share this single implementation — a per-tier second copy is
+// forbidden (t257 card scope (2)); per-hook differences live in the hookTier
+// value each installer passes in.
+
+// hookTier names the per-hook constants of one install tier. Everything the
+// shared machinery needs to specialize its behaviour — messages, sidecar name,
+// backup prefix — is carried here so the algorithm itself is written once.
+type hookTier struct {
+	// label names the hook in human-facing error messages ("pre-commit",
+	// "pre-push").
+	label string
+
+	// provenanceName is the sidecar basename recording the SHA-256 of the hook
+	// content this tool last wrote. It lives beside the hook in .git/hooks/,
+	// so it shares the hook's lifetime exactly: wiping .git/hooks/ takes both.
+	//
+	// The record is the third operand of the attribution in REQ-PCP-014.
+	// Without it only "installed" and "incoming" exist, and those two cannot
+	// separate "the user changed it" from "we changed it" — a routine version
+	// bump then reads as a user patch for every user on every release.
+	provenanceName string
+
+	// backupPrefix is the basename prefix of the backup copies taken before a
+	// user-modified hook is replaced: `<hook>.bak.<stamp>`, the pattern
+	// REQ-PCP-003 names. The stamp is a colon-free UTC form (20060102T150405Z)
+	// — RFC3339 proper contains `:`, which is illegal in a Windows filename,
+	// and a backup the user cannot create/read on their own platform is not a
+	// backup.
+	backupPrefix string
+}
+
+// preCommitTier is the pre-commit specialization of the shared machinery.
+var preCommitTier = hookTier{
+	label:          "pre-commit",
+	provenanceName: moaiPreCommitProvenanceName,
+	backupPrefix:   preCommitBackupPrefix,
+}
+
+// prePushTier is the pre-push specialization of the shared machinery (t257).
+var prePushTier = hookTier{
+	label:          "pre-push",
+	provenanceName: moaiPrePushProvenanceName,
+	backupPrefix:   prePushBackupPrefix,
+}
+
+// hookClass is the attribution verdict for an existing marker-bearing hook.
+type hookClass int
+
+const (
+	// hookUnmodified: the hook is as MoAI last wrote it. Any difference
+	// against the incoming content is an upstream version bump, so the
+	// overwrite is quiet (REQ-PCP-002).
+	hookUnmodified hookClass = iota
+	// hookUserModified: the hook was edited after MoAI wrote it. This is the
+	// loss-bearing case; the backup and the notice hang off it.
+	hookUserModified
+)
+
+func (c hookClass) String() string {
+	if c == hookUserModified {
+		return "user-modified"
+	}
+	return "unmodified"
+}
+
+// hookBasis names which operands produced the verdict — the third label of the
+// three-way classification, kept separate from the verdict because
+// "undecidable-legacy" describes how the answer was reached, not what it was.
+type hookBasis int
+
+const (
+	// hookBasisRecord: a usable provenance record existed, so the verdict
+	// comes from installed-vs-recorded — the three-way comparison.
+	hookBasisRecord hookBasis = iota
+	// hookBasisUndecidableLegacy: no usable record existed, so attribution was
+	// impossible and the verdict falls back to installed-vs-incoming, with any
+	// difference read as a user edit (REQ-PCP-005). Deliberately the noisy
+	// direction: a hand-patched legacy hook is the most likely thing to be
+	// found without a record.
+	hookBasisUndecidableLegacy
+)
+
+func (b hookBasis) String() string {
+	if b == hookBasisUndecidableLegacy {
+		return "undecidable-legacy"
+	}
+	return "record"
+}
+
+// hookAttribution is one classification of an existing marker-bearing hook.
+type hookAttribution struct {
+	Class hookClass
+	Basis hookBasis
+}
+
+// classifyHook decides whether an existing marker-bearing hook was edited by
+// the user, from three operands: the installed bytes, the digest this tool
+// last recorded writing (empty when absent or unusable), and the incoming
+// bytes.
+//
+// A two-way comparison of installed against incoming cannot make this call: an
+// upstream version bump produces the same signal as a user patch, so a two-way
+// design warns every user on every release that touches the hook (REQ-PCP-014).
+func classifyHook(installed []byte, recordedDigest string, incoming []byte) hookAttribution {
+	if recordedDigest == "" {
+		// No usable record: attribution is impossible, so fall back to
+		// installed-vs-incoming and read any difference as a user edit.
+		if bytes.Equal(installed, incoming) {
+			return hookAttribution{Class: hookUnmodified, Basis: hookBasisUndecidableLegacy}
+		}
+		return hookAttribution{Class: hookUserModified, Basis: hookBasisUndecidableLegacy}
+	}
+
+	if digestOfBytes(installed) == recordedDigest {
+		return hookAttribution{Class: hookUnmodified, Basis: hookBasisRecord}
+	}
+	return hookAttribution{Class: hookUserModified, Basis: hookBasisRecord}
+}
+
+// readHookProvenance returns the recorded digest, or "" when no usable record
+// exists. A missing, unreadable or malformed record is treated as absent,
+// which routes the caller to the deliberately noisy legacy path (REQ-PCP-005).
+func readHookProvenance(hookDir string, tier hookTier) string {
+	raw, err := os.ReadFile(filepath.Join(hookDir, tier.provenanceName))
+	if err != nil {
+		return ""
+	}
+	digest := strings.TrimSpace(string(raw))
+	if len(digest) != hex.EncodedLen(sha256.Size) {
+		return ""
+	}
+	if _, err := hex.DecodeString(digest); err != nil {
+		return ""
+	}
+	return digest
+}
+
+// writeHookProvenance records the digest of the content just written.
+func writeHookProvenance(hookDir, content string, tier hookTier) error {
+	path := filepath.Join(hookDir, tier.provenanceName)
+	if err := os.WriteFile(path, []byte(digestOfBytes([]byte(content))+"\n"), 0o644); err != nil {
+		return fmt.Errorf("write %s provenance record: %w", tier.label, err)
+	}
+	return nil
+}
+
+func digestOfBytes(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// backupHook copies the pre-run hook bytes to a timestamped backup in hookDir
+// and returns the path chosen. The name is `<hook>.bak.<UTC colon-free
+// stamp>`; when a candidate path is occupied a distinct sibling suffix is
+// chosen instead — an existing backup is never overwritten (REQ-PCP-009).
+// O_EXCL makes the never-clobber guarantee hold even if a file appears between
+// the choice and the write.
+func backupHook(hookDir string, preRun []byte, now time.Time, tier hookTier) (string, error) {
+	stamp := now.UTC().Format("20060102T150405Z")
+	for i := 0; ; i++ {
+		name := tier.backupPrefix + stamp
+		if i > 0 {
+			name = fmt.Sprintf("%s.%d", name, i)
+		}
+		path := filepath.Join(hookDir, name)
+		f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o755)
+		if err != nil {
+			if os.IsExist(err) {
+				continue // occupied: pick a distinct name, never clobber
+			}
+			return "", fmt.Errorf("back up user-modified %s hook to %s: %w", tier.label, path, err)
+		}
+		if _, err := f.Write(preRun); err != nil {
+			_ = f.Close()
+			return "", fmt.Errorf("back up user-modified %s hook to %s: %w", tier.label, path, err)
+		}
+		if err := f.Close(); err != nil {
+			return "", fmt.Errorf("back up user-modified %s hook to %s: %w", tier.label, path, err)
+		}
+		return path, nil
+	}
+}

--- a/internal/cli/hook_install_test.go
+++ b/internal/cli/hook_install_test.go
@@ -133,9 +133,13 @@ func TestInstallPrePushHook_PreservesUserHook(t *testing.T) {
 	}
 }
 
-// TestInstallPrePushHook_OverwritesMoaiHook verifies that a pre-existing hook
-// WITH the MoAI marker is safely overwritten.
-func TestInstallPrePushHook_OverwritesMoaiHook(t *testing.T) {
+// TestInstallPrePushHook_OverwritesMoaiHookBacksUp verifies that a
+// pre-existing hook WITH the MoAI marker is replaced AND, because a planted
+// legacy hook carries no provenance record and differs from the incoming
+// content (the undecidable-legacy basis, read as user-modified), the pre-run
+// bytes are backed up first (t257). The pre-t257 version of this test asserted
+// the silent overwrite as correct behaviour; it is rewritten, not preserved.
+func TestInstallPrePushHook_OverwritesMoaiHookBacksUp(t *testing.T) {
 	dir := t.TempDir()
 	if err := exec.Command("git", "init", dir).Run(); err != nil {
 		t.Skipf("git init failed: %v", err)
@@ -167,5 +171,21 @@ func TestInstallPrePushHook_OverwritesMoaiHook(t *testing.T) {
 	}
 	if !strings.Contains(string(got), "ci-local") {
 		t.Error("new hook should contain ci-local")
+	}
+
+	// t257: the pre-run legacy bytes must survive in exactly one backup.
+	backups, err := filepath.Glob(filepath.Join(hooksDir, "pre-push.bak.*"))
+	if err != nil {
+		t.Fatalf("glob backups: %v", err)
+	}
+	if len(backups) != 1 {
+		t.Fatalf("expected exactly one pre-push backup, found %d: %v", len(backups), backups)
+	}
+	bak, err := os.ReadFile(backups[0])
+	if err != nil {
+		t.Fatalf("read backup %s: %v", backups[0], err)
+	}
+	if string(bak) != oldContent {
+		t.Errorf("backup must hold the pre-run bytes (%d bytes), got %d bytes", len(oldContent), len(bak))
 	}
 }

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -892,7 +892,7 @@ func runInit(cmd *cobra.Command, args []string) (err error) {
 
 	// Install pre-push hook (REQ-CIAUT-002). Non-fatal; --no-hooks opts out.
 	// Status/warning lines are human-facing -> stderr (REQ-CTX-016).
-	installPrePushHookOptional(opts.ProjectRoot, getBoolFlag(cmd, "no-hooks"), cmd.ErrOrStderr())
+	installPrePushHookOptional(opts.ProjectRoot, getBoolFlag(cmd, "no-hooks"), cmd.ErrOrStderr(), cmd.ErrOrStderr())
 
 	// Install pre-commit hook (REQ-PC-001). Fast-subset commit tier; --no-hooks opts out.
 	installPreCommitHookOptional(opts.ProjectRoot, getBoolFlag(cmd, "no-hooks"), cmd.ErrOrStderr(), cmd.ErrOrStderr())

--- a/internal/cli/update_template_sync.go
+++ b/internal/cli/update_template_sync.go
@@ -569,7 +569,7 @@ func runTemplateSyncWithReporter(cmd *cobra.Command, reporter project.ProgressRe
 	}
 
 	// Install pre-push hook (REQ-CIAUT-002). Non-fatal; --no-hooks opts out.
-	installPrePushHookOptional(projectRoot, getBoolFlag(cmd, "no-hooks"), out)
+	installPrePushHookOptional(projectRoot, getBoolFlag(cmd, "no-hooks"), out, errOut)
 
 	// Install pre-commit hook (REQ-PC-001). Fast-subset commit tier; --no-hooks opts out.
 	installPreCommitHookOptional(projectRoot, getBoolFlag(cmd, "no-hooks"), out, errOut)


### PR DESCRIPTION
## What

Card t257 (Class B). Closes the mirror of the t230 defect on the push tier: `InstallPrePushHook` silently overwrote a marker-bearing, user-modified `.git/hooks/pre-push` on reinstall — no content comparison, no backup, no disclosure (measured RED, then fixed GREEN; evidence in `.moai/reports/t257/measurement.md`).

The fix **reuses** the t230 discriminator (card scope (2) — no second implementation): the three-way classifier (installed / original-at-install / new incoming), provenance sidecar, and pre-replacement backup are extracted to `internal/cli/hook_install_shared.go` as a single tier-generic core both installers share.

- user-modified hook → backed up to `pre-push.bak.<stamp>` **before** replacement, disclosed on a distinct warning writer (callers bind it to stderr, REQ-PCP-004 wiring)
- unmodified hook → quiet overwrite (routine reinstalls stay silent — pinned by a mirror test)
- undecidable-legacy (no sidecar) differing content → treated as user-modified (the deliberate REQ-PCP-005 noisy-first-run trade-off, carried from t230 unchanged)
- `prePushHookContent` byte-identical — the t255 same-release alarm trap does not fire
- `TestInstallPrePushHook_OverwritesMoaiHook` (which codified the silent overwrite as correct) is rewritten as `...OverwritesMoaiHookBacksUp`

## Commits

1. `a2fd32cc0` refactor(cli): extract tier-generic hook-preservation core (t257)
2. `ff5e7d07c` feat(cli): back up and disclose user-modified pre-push hooks (t257)

## Verification (scoped, this worktree @ `539349c5b` base)

- `go test ./internal/cli/ -run 'PrePushHook' -count=1` — 8/8 PASS (incl. the two formerly-RED measurement tests and the rewritten backup test)
- `go test ./internal/cli/ -run 'PreCommit' -count=1` — ok (extraction caused no pre-commit regression)
- `go vet ./internal/cli/` + `GOOS=windows GOARCH=amd64 go vet ./internal/cli/` — clean
- `golangci-lint run internal/cli/` — 0 issues

Card: t257 · Predecessor: SPEC-PRECOMMIT-PRESERVE-001 (#1647)

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented silent overwriting of user-modified pre-commit and pre-push hooks.
  * Existing hooks are now backed up before replacement, with clear warnings when changes occur.
  * Backup failures leave the original hook unchanged and provide a non-fatal warning.
  * Reinstalling an unchanged hook no longer creates unnecessary backups or warnings.
* **Tests**
  * Added coverage for hook preservation, backup creation, warning output, and quiet reinstalls.
  * Updated existing tests to verify backup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->