### PR TITLE
t292: main stamp orphan repair — restamp provenance to reachable main tip

### DIFF
--- a/.moai/project/codemaps/provenance.json
+++ b/.moai/project/codemaps/provenance.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
-  "tree_root": "/Users/goos/MoAI/moai-adk-go/.claude/worktrees/t289",
-  "commit_sha": "a995e58fa69b40f3d76a76c0a5ca56d0594fb528",
+  "tree_root": "/Users/goos/MoAI/moai-adk-go/.claude/worktrees/t292",
+  "commit_sha": "3abde70530c4f1c8ebc5f1bc9c4b8f5912380271",
   "dirty": false,
   "described_roots": [
     "internal",
@@ -9,5 +9,5 @@
     "pkg"
   ],
   "generated_by": "codemaps-gen",
-  "generated_at": "2026-08-26T18:27:30Z"
+  "generated_at": "2026-08-26T19:20:39Z"
 }


### PR DESCRIPTION
## What
origin/main `codemaps/provenance.json` names `a995e58fa6` — a t289 lane commit orphaned by the #1668 squash merge (`26c5a7d54`); `git merge-base --is-ancestor a995e58fa6 origin/main` → rc 1. Every new branch cut from main inherited the unreachable anchor and went graph-freshness red. **Second recurrence of the F5 structural defect** (#1648 → `0d15864ae90b` was the first; independently confirmed by lane-1 + plan-auditor + lead).

## Repair
Re-anchor to main tip `3abde7053`. Fresh branch head = natural stamp anchor (no manual commit_sha edit needed).

Pipeline (t279 `52f7ba135` / t289 recipe): `mx scan --quiet` → `graph build` → `graph stamp codemaps` → `graph build` → `graph check`:
- codemaps described-source-diff **0**/40 fresh · mx-index 0/1 fresh · edges 0/0 fresh · exit 0

Provenance-only commit (1 file, +3/−3); `graph/` output untracked per t289 precedent. The anchor remains an **ancestor** after this PR's squash merge — the squash cannot re-orphan it.

## Related
- Structural fix (CI pre-merge reachability guard): t291 `SPEC-STAMP-REACHABILITY-001` — in flight on lane-1
- Card: t292 (queue-picked; operator-approved immediate repair 2026-08-27)

🗿 MoAI