### PR TITLE
fix(quality): detect toolchain markers below project top and bind module roots

### DIFF
--- a/internal/hook/quality/gate.go
+++ b/internal/hook/quality/gate.go
@@ -370,60 +370,33 @@ func (g *QualityGate) Run(ctx context.Context) (bool, string) {
 		return false, gfBlockReason
 	}
 
-	tc := g.detectToolchain()
-	if tc == nil {
+	tcs := g.detectToolchains()
+	if len(tcs) == 0 {
 		// No recognized language — pass, carrying the graph-freshness notice
 		// (the step ran before detection; dropping its notice here is the
 		// silence REQ-GF-005 forbids).
 		return true, gfNotice
 	}
 
-	// Step 1: vet steps
-	var vetReason string
-	for _, step := range tc.vetSteps {
-		ok, out := g.executeStep(ctx, step, g.config.VetTimeout)
-		if !ok {
-			return false, out
-		}
-		vetReason = appendReason(vetReason, out)
-	}
-
 	// passReason carries a passing step's notice out to Run's caller. Dropping
 	// it here is what left an absent ast-grep scanner indistinguishable from a
 	// clean scan: the step reported the skip and this frame threw it away.
 	// The graph-freshness notice (step 0) leads: it is the outermost wrap.
-	passReason := appendReason(gfNotice, vetReason)
+	passReason := gfNotice
 
-	// Step 1.5: typecheck axis.
-	//
-	// It runs after vet and before lint so a type error surfaces before the
-	// slower style pass, and so a project whose linter is absent still gets a
-	// correctness gate. Every outcome is reported: a skip is not a failure,
-	// but it is never silent — that silence is what let a broken build through.
-	if g.config.TypecheckEnabled {
-		step, reason, ok := resolveTypecheckStep(tc.typecheckStep, resolveQualityProjectDir(*g.config, "QualityGate.Run.typecheck"), g.config.TypecheckCommand)
-		switch {
-		case ok:
-			passed, out := g.executeStep(ctx, step, g.config.TypecheckTimeout)
-			if !passed {
-				return false, out
-			}
-			passReason = appendReason(passReason, out)
-		default:
-			passReason = appendReason(passReason, reason)
-		}
-	}
-
-	// Step 2: lint steps
-	for _, step := range tc.lintSteps {
-		ok, out := g.executeStep(ctx, step, g.config.LintTimeout)
+	// A monorepo can carry several language toolchains at once (package.json
+	// at the root plus go.mod under apps/id/, say); each detected entry runs
+	// its steps rooted at the directory whose marker matched it.
+	for i := range tcs {
+		out, ok := g.runToolchainStaticSteps(ctx, &tcs[i])
 		if !ok {
 			return false, out
 		}
 		passReason = appendReason(passReason, out)
 	}
 
-	// Step 2.5: ast-grep domain rules
+	// Step 2.5: ast-grep domain rules (project-level — runs once, not per
+	// toolchain; the rules are language-agnostic domain patterns)
 	// ASTG-UPGRADE-001: switched to RunAstGrepGateV2 which uses the unified Scanner
 	if g.config.AstGrepGate != nil && g.config.AstGrepGate.Enabled {
 		// REQ-HCWA-007: route cwd resolution through resolveQualityProjectDir.
@@ -435,47 +408,205 @@ func (g *QualityGate) Run(ctx context.Context) (bool, string) {
 		passReason = appendReason(passReason, out)
 	}
 
-	// Step 3: test step (skippable)
-	if !g.config.SkipTests && tc.testStep != nil {
-		// The Node test step is resolved to a self-terminating (run-form)
-		// command right before execution, reading the project's package.json
-		// scripts from the resolved project dir.
-		// Every other toolchain's step passes through unchanged.
-		// REQ-HCWA-007: route cwd resolution through resolveQualityProjectDir.
-		testStep := resolveNodeTestStep(*tc.testStep, resolveQualityProjectDir(*g.config, "QualityGate.Run.nodeTestStep"))
-		if ok, out := g.executeStep(ctx, testStep, g.config.TestTimeout); !ok {
+	// Step 3: test step per toolchain (skippable)
+	for i := range tcs {
+		out, ok := g.runToolchainTestStep(ctx, &tcs[i])
+		if !ok {
 			return false, out
 		}
+		passReason = appendReason(passReason, out)
 	}
 
 	return true, passReason
 }
 
+// runToolchainStaticSteps runs one detected toolchain's vet, typecheck, and
+// lint axes, rooted at the directory whose marker matched it. A nested
+// module's steps MUST execute at the module root: the project top is not
+// inside the nested module, so toolchain arguments like ./... only resolve
+// there (the pre-commit fast subset hit the same shape — issue #1679).
+func (g *QualityGate) runToolchainStaticSteps(ctx context.Context, dt *detectedToolchain) (string, bool) {
+	dir := dt.root
+	if dir == "" {
+		dir = resolveQualityProjectDir(*g.config, "QualityGate.runToolchainStaticSteps")
+	}
+
+	// Step 1: vet steps
+	var vetReason string
+	for _, step := range dt.tc.vetSteps {
+		ok, out := g.executeStep(ctx, step, dir, g.config.VetTimeout)
+		if !ok {
+			return out, false
+		}
+		vetReason = appendReason(vetReason, out)
+	}
+
+	// Step 1.5: typecheck axis.
+	//
+	// It runs after vet and before lint so a type error surfaces before the
+	// slower style pass, and so a project whose linter is absent still gets a
+	// correctness gate. Every outcome is reported: a skip is not a failure,
+	// but it is never silent — that silence is what let a broken build through.
+	var passReason string
+	if g.config.TypecheckEnabled {
+		step, reason, ok := resolveTypecheckStep(dt.tc.typecheckStep, dir, g.config.TypecheckCommand)
+		switch {
+		case ok:
+			passed, out := g.executeStep(ctx, step, dir, g.config.TypecheckTimeout)
+			if !passed {
+				return out, false
+			}
+			passReason = appendReason(passReason, out)
+		default:
+			passReason = appendReason(passReason, reason)
+		}
+	}
+
+	// Step 2: lint steps
+	for _, step := range dt.tc.lintSteps {
+		ok, out := g.executeStep(ctx, step, dir, g.config.LintTimeout)
+		if !ok {
+			return out, false
+		}
+		passReason = appendReason(passReason, out)
+	}
+
+	return appendReason(vetReason, passReason), true
+}
+
+// runToolchainTestStep runs one detected toolchain's test step, rooted at the
+// directory whose marker matched it.
+func (g *QualityGate) runToolchainTestStep(ctx context.Context, dt *detectedToolchain) (string, bool) {
+	if g.config.SkipTests || dt.tc.testStep == nil {
+		return "", true
+	}
+	dir := dt.root
+	if dir == "" {
+		dir = resolveQualityProjectDir(*g.config, "QualityGate.runToolchainTestStep")
+	}
+	// The Node test step is resolved to a self-terminating (run-form)
+	// command right before execution, reading the project's package.json
+	// scripts from the toolchain's own root.
+	// Every other toolchain's step passes through unchanged.
+	testStep := resolveNodeTestStep(*dt.tc.testStep, dir)
+	ok, out := g.executeStep(ctx, testStep, dir, g.config.TestTimeout)
+	return out, ok
+}
+
 // detectToolchain finds the matching toolchain by checking marker files in ProjectDir.
+// Kept as a thin wrapper over detectToolchains for callers that only want the
+// first match (root-level precedence, then the shallowest nested module).
 func (g *QualityGate) detectToolchain() *langToolchain {
+	tcs := g.detectToolchains()
+	if len(tcs) == 0 {
+		return nil
+	}
+	return tcs[0].tc
+}
+
+// detectedToolchain pairs a language toolchain with the directory whose
+// marker file matched it. A monorepo can carry several language toolchains
+// at once (package.json at the top plus go.mod under apps/id/, say); each
+// detected entry runs its steps rooted at its own directory.
+type detectedToolchain struct {
+	tc   *langToolchain
+	root string
+}
+
+// nestedScanDepthCap bounds how far detectToolchains descends below the
+// project dir looking for nested module markers. Deep enough for realistic
+// monorepo layouts (apps/<svc>/, packages/<pkg>/, services/<x>/), shallow
+// enough that a pathological tree cannot stall the gate.
+const nestedScanDepthCap = 6
+
+// detectToolchains finds every language toolchain applicable to the project:
+// the root-level first match (preserving detectToolchain's original
+// precedence) plus any additional toolchains whose markers live below the
+// project dir. The defect this closes: the marker scan previously tested
+// filepath.Join(projectDir, marker) only, so a go.mod (or pyproject.toml,
+// Cargo.toml, …) nested below the top was never seen and the heavy gate
+// contributed zero coverage for that language — silently, since a nil
+// detection passes. Each language is detected at most once; the shallowest
+// match wins. Dependency, build-output, and cache directories
+// (sourceScanSkipDirs) are never descended into, and neither is a directory
+// that matched a marker — what lives below a module root belongs to it.
+func (g *QualityGate) detectToolchains() []detectedToolchain {
 	// REQ-HCWA-007: route cwd resolution through resolveQualityProjectDir.
-	dir := resolveQualityProjectDir(*g.config, "QualityGate.detectToolchain")
+	dir := resolveQualityProjectDir(*g.config, "QualityGate.detectToolchains")
 	if dir == "" {
 		return nil
 	}
 
+	var found []detectedToolchain
+	detected := make(map[int]bool, len(toolchains))
+
+	// Root-level first match keeps the original precedence.
 	for i := range toolchains {
-		for _, marker := range toolchains[i].markerFiles {
-			if strings.Contains(marker, "*") {
-				// Glob pattern (e.g., "*.csproj")
-				matches, err := filepath.Glob(filepath.Join(dir, marker))
-				if err == nil && len(matches) > 0 {
-					return resolvePythonRunner(resolveGoBuildTags(resolveDartFlutter(&toolchains[i], dir), g.config.GoBuildTags), dir)
-				}
-			} else {
-				if fileExists(filepath.Join(dir, marker)) {
-					return resolvePythonRunner(resolveGoBuildTags(resolveDartFlutter(&toolchains[i], dir), g.config.GoBuildTags), dir)
-				}
-			}
+		if g.matchMarker(dir, &toolchains[i]) {
+			found = append(found, detectedToolchain{
+				tc:   g.resolveToolchain(&toolchains[i], dir),
+				root: dir,
+			})
+			detected[i] = true
+			break
 		}
 	}
 
-	return nil
+	// Nested modules: descend below the project dir for languages not yet
+	// detected.
+	_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil // unreadable subtree — skip it, never fail the gate
+		}
+		if !d.IsDir() || path == dir {
+			return nil
+		}
+		if _, skip := sourceScanSkipDirs[d.Name()]; skip {
+			return fs.SkipDir
+		}
+		if rel, relErr := filepath.Rel(dir, path); relErr != nil || strings.Count(rel, string(filepath.Separator)) >= nestedScanDepthCap {
+			return fs.SkipDir
+		}
+		for i := range toolchains {
+			if detected[i] {
+				continue
+			}
+			if g.matchMarker(path, &toolchains[i]) {
+				found = append(found, detectedToolchain{
+					tc:   g.resolveToolchain(&toolchains[i], path),
+					root: path,
+				})
+				detected[i] = true
+				return fs.SkipDir // what lives below a module root belongs to it
+			}
+		}
+		return nil
+	})
+
+	return found
+}
+
+// matchMarker reports whether any of the toolchain's marker files exist at dir.
+func (g *QualityGate) matchMarker(dir string, tc *langToolchain) bool {
+	for _, marker := range tc.markerFiles {
+		if strings.Contains(marker, "*") {
+			// Glob pattern (e.g., "*.csproj")
+			matches, err := filepath.Glob(filepath.Join(dir, marker))
+			if err == nil && len(matches) > 0 {
+				return true
+			}
+		} else if fileExists(filepath.Join(dir, marker)) {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveToolchain applies the per-toolchain variants (Flutter, Go build
+// tags, Python runner) rooted at dir, mirroring what detectToolchain applied
+// to its single hit.
+func (g *QualityGate) resolveToolchain(tc *langToolchain, dir string) *langToolchain {
+	return resolvePythonRunner(resolveGoBuildTags(resolveDartFlutter(tc, dir), g.config.GoBuildTags), dir)
 }
 
 // resolveDartFlutter returns a Flutter-specific toolchain variant when the
@@ -822,7 +953,14 @@ func nodeScriptWatchProne(script string) bool {
 // executeStep runs a single gate step. Optional steps skip silently when the binary is missing.
 // Steps with configFiles skip silently when none of the listed config files exist.
 // Steps with changedExts skip silently when no staged file matches any of the listed extensions.
-func (g *QualityGate) executeStep(ctx context.Context, step gateStep, timeout time.Duration) (bool, string) {
+// dir is the directory the step runs in — the detected toolchain's own root
+// (a nested module runs its checks from its module directory, not the
+// project top). Empty falls back to the resolved project dir.
+func (g *QualityGate) executeStep(ctx context.Context, step gateStep, dir string, timeout time.Duration) (bool, string) {
+	if dir == "" {
+		dir = resolveQualityProjectDir(*g.config, "QualityGate.executeStep")
+	}
+
 	// Fix 3: explicitly disable via DisabledSteps configuration
 	if disabled, ok := g.config.DisabledSteps[step.name]; ok && !disabled {
 		return true, ""
@@ -833,15 +971,15 @@ func (g *QualityGate) executeStep(ctx context.Context, step gateStep, timeout ti
 			return true, ""
 		}
 	}
-	if len(step.configFiles) > 0 && !g.anyConfigFileExists(step.configFiles) {
+	if len(step.configFiles) > 0 && !anyConfigFileExistsIn(dir, step.configFiles) {
 		return true, ""
 	}
 
 	// Fix 1: skip when no staged file matches changedExts.
 	// If stagedFiles lookup fails or we are outside a git repository, run the step conservatively.
+	// `git diff --cached` resolves the enclosing repository from any
+	// subdirectory, so the toolchain's own root yields the repo-wide staged set.
 	if len(step.changedExts) > 0 {
-		// REQ-HCWA-007: route cwd resolution through resolveQualityProjectDir.
-		dir := resolveQualityProjectDir(*g.config, "QualityGate.executeStep.extfilter")
 		staged := g.cachedStagedFiles(ctx, dir)
 		// If staged is nil, cannot determine — run step conservatively
 		if staged != nil && !hasStagedExt(staged, step.changedExts) {
@@ -851,9 +989,10 @@ func (g *QualityGate) executeStep(ctx context.Context, step gateStep, timeout ti
 
 	// Skip when the project holds no source this step could check. A scaffold
 	// that has declared its language but not written code yet must not fail
-	// its first gate for having no code.
+	// its first gate for having no code. The check is scoped to the toolchain's
+	// own root: a nested module is judged on its own sources, not the whole
+	// repository's.
 	if len(step.sourceExts) > 0 {
-		dir := resolveQualityProjectDir(*g.config, "QualityGate.executeStep.srcfilter")
 		if found, determined := projectHasSourceFile(dir, step.sourceExts); determined && !found {
 			slog.Warn("no sources for step: treating as skip",
 				"step", step.name,
@@ -864,7 +1003,7 @@ func (g *QualityGate) executeStep(ctx context.Context, step gateStep, timeout ti
 		}
 	}
 
-	return g.runStep(ctx, step.name, timeout, step.binary, step.args...)
+	return g.runStep(ctx, step.name, dir, timeout, step.binary, step.args...)
 }
 
 // cachedStagedFiles queries stagedFiles exactly once per Run call and caches the result.
@@ -1022,6 +1161,17 @@ func (g *QualityGate) anyConfigFileExists(configFiles []string) bool {
 	if dir == "" {
 		return false
 	}
+	return anyConfigFileExistsIn(dir, configFiles)
+}
+
+// anyConfigFileExistsIn reports whether at least one of the given config
+// files exists at dir — the toolchain's own root for a detected nested
+// module, whose linter configs live beside its marker file, not at the
+// project top.
+func anyConfigFileExistsIn(dir string, configFiles []string) bool {
+	if dir == "" {
+		return false
+	}
 	for _, cf := range configFiles {
 		if fileExists(filepath.Join(dir, cf)) {
 			return true
@@ -1032,7 +1182,7 @@ func (g *QualityGate) anyConfigFileExists(configFiles []string) bool {
 
 // runStep executes a single quality gate command with the given timeout.
 // Returns (true, "") on success, (false, errorMessage) on failure or timeout.
-func (g *QualityGate) runStep(ctx context.Context, stepName string, timeout time.Duration, name string, args ...string) (bool, string) {
+func (g *QualityGate) runStep(ctx context.Context, stepName string, dir string, timeout time.Duration, name string, args ...string) (bool, string) {
 	// Which budget can kill this step is decided BEFORE it starts, by comparing
 	// the caller's remaining time (the hook dispatcher's, when the gate runs
 	// from a hook) with the step's own. Deciding afterwards from ctx.Err() would
@@ -1058,8 +1208,13 @@ func (g *QualityGate) runStep(ctx context.Context, stepName string, timeout time
 	// which is the project root only by coincidence — so a gate configured for
 	// one directory would grade another. Under `go test` that coincidence
 	// breaks: the cwd is the package under test, so a "go test ./..." step
-	// re-executes the suite that invoked it.
-	if dir := resolveQualityProjectDir(*g.config, "QualityGate.runStep"); dir != "" {
+	// re-executes the suite that invoked it. An explicitly passed dir (the
+	// detected toolchain's own root) takes precedence; empty falls back to the
+	// resolved project dir.
+	if dir == "" {
+		dir = resolveQualityProjectDir(*g.config, "QualityGate.runStep")
+	}
+	if dir != "" {
 		cmd.Dir = dir
 	}
 	var stdout, stderr bytes.Buffer

--- a/internal/hook/quality/gate_empty_source_test.go
+++ b/internal/hook/quality/gate_empty_source_test.go
@@ -41,7 +41,7 @@ func TestExecuteStep_SkipsWhenProjectHasNoSources(t *testing.T) {
 	writeFile(t, dir, "pyproject.toml", "[project]\nname = \"scaffold\"\n")
 
 	g := &QualityGate{config: &GateConfig{Enabled: true, ProjectDir: dir}}
-	ok, msg := g.executeStep(context.Background(), alwaysFailingStep("mypy", []string{".py", ".pyi"}), 30*time.Second)
+	ok, msg := g.executeStep(context.Background(), alwaysFailingStep("mypy", []string{".py", ".pyi"}), dir, 30*time.Second)
 
 	if !ok {
 		t.Fatalf("source-free scaffold failed the gate: %s", msg)
@@ -57,7 +57,7 @@ func TestExecuteStep_RunsWhenProjectHasOneSource(t *testing.T) {
 	writeFile(t, dir, "src/app.py", "x = 1\n")
 
 	g := &QualityGate{config: &GateConfig{Enabled: true, ProjectDir: dir}}
-	ok, _ := g.executeStep(context.Background(), alwaysFailingStep("mypy", []string{".py", ".pyi"}), 30*time.Second)
+	ok, _ := g.executeStep(context.Background(), alwaysFailingStep("mypy", []string{".py", ".pyi"}), dir, 30*time.Second)
 
 	if ok {
 		t.Fatal("step was skipped although the project has a .py source; the guard over-skips")
@@ -71,7 +71,7 @@ func TestExecuteStep_NoSourceExtsUnaffected(t *testing.T) {
 	writeFile(t, dir, "pyproject.toml", "[project]\nname = \"scaffold\"\n")
 
 	g := &QualityGate{config: &GateConfig{Enabled: true, ProjectDir: dir}}
-	ok, _ := g.executeStep(context.Background(), alwaysFailingStep("other", nil), 30*time.Second)
+	ok, _ := g.executeStep(context.Background(), alwaysFailingStep("other", nil), dir, 30*time.Second)
 
 	if ok {
 		t.Fatal("a step with no sourceExts was skipped; the guard is not opt-in")
@@ -86,7 +86,7 @@ func TestExecuteStep_PyiCountsAsSource(t *testing.T) {
 	writeFile(t, dir, "stubs/app.pyi", "def f() -> int: ...\n")
 
 	g := &QualityGate{config: &GateConfig{Enabled: true, ProjectDir: dir}}
-	if ok, _ := g.executeStep(context.Background(), alwaysFailingStep("mypy", []string{".py", ".pyi"}), 30*time.Second); ok {
+	if ok, _ := g.executeStep(context.Background(), alwaysFailingStep("mypy", []string{".py", ".pyi"}), dir, 30*time.Second); ok {
 		t.Fatal("a .pyi-only project was treated as source-free")
 	}
 }

--- a/internal/hook/quality/gate_pytest_exit5_test.go
+++ b/internal/hook/quality/gate_pytest_exit5_test.go
@@ -21,7 +21,7 @@ func TestRunStep_PytestNoTestsCollectedPasses(t *testing.T) {
 		t.Skip("uses a POSIX shell to synthesise the exit code")
 	}
 	g := NewQualityGate(DefaultGateConfig())
-	ok, msg := g.runStep(context.Background(), "pytest", 10*time.Second, "sh", "-c", "exit 5")
+	ok, msg := g.runStep(context.Background(), "pytest", "", 10*time.Second, "sh", "-c", "exit 5")
 	if !ok {
 		t.Fatalf("pytest exit 5 (no tests collected) must pass the gate, got failure: %s", msg)
 	}
@@ -32,7 +32,7 @@ func TestRunStep_PytestRealFailureStillFails(t *testing.T) {
 		t.Skip("uses a POSIX shell to synthesise the exit code")
 	}
 	g := NewQualityGate(DefaultGateConfig())
-	ok, msg := g.runStep(context.Background(), "pytest", 10*time.Second, "sh", "-c", "echo boom >&2; exit 1")
+	ok, msg := g.runStep(context.Background(), "pytest", "", 10*time.Second, "sh", "-c", "echo boom >&2; exit 1")
 	if ok {
 		t.Fatal("pytest exit 1 is a real test failure and must still fail the gate")
 	}
@@ -46,7 +46,7 @@ func TestRunStep_NonPytestExit5StillFails(t *testing.T) {
 		t.Skip("uses a POSIX shell to synthesise the exit code")
 	}
 	g := NewQualityGate(DefaultGateConfig())
-	ok, _ := g.runStep(context.Background(), "go test", 10*time.Second, "sh", "-c", "exit 5")
+	ok, _ := g.runStep(context.Background(), "go test", "", 10*time.Second, "sh", "-c", "exit 5")
 	if ok {
 		t.Fatal("exit 5 is pytest-specific; other steps must still fail on it")
 	}

--- a/internal/hook/quality/gate_step_cwd_test.go
+++ b/internal/hook/quality/gate_step_cwd_test.go
@@ -46,7 +46,7 @@ func TestRunStep_RunsInConfiguredProjectDir(t *testing.T) {
 	cfg.ProjectDir = repo
 	g := NewQualityGate(cfg)
 
-	ok, output := g.runStep(context.Background(), "go vet", 60*time.Second, "go", "vet", "./...")
+	ok, output := g.runStep(context.Background(), "go vet", "", 60*time.Second, "go", "vet", "./...")
 	if ok {
 		t.Fatalf("runStep passed on a fixture whose only package fails `go vet` — the step did not run in cfg.ProjectDir (%s) but in the calling process's cwd", repo)
 	}

--- a/internal/hook/quality/gate_test.go
+++ b/internal/hook/quality/gate_test.go
@@ -162,7 +162,7 @@ func TestQualityGate_runStep_UnknownCommand(t *testing.T) {
 	cfg := DefaultGateConfig()
 	g := NewQualityGate(cfg)
 
-	passed, output := g.runStep(context.Background(), "test-step", 5*time.Second, "this-binary-does-not-exist-12345")
+	passed, output := g.runStep(context.Background(), "test-step", "", 5*time.Second, "this-binary-does-not-exist-12345")
 
 	if passed {
 		t.Error("runStep with missing binary should fail")
@@ -181,7 +181,7 @@ func TestQualityGate_runStep_TimeoutMessage(t *testing.T) {
 	g := NewQualityGate(cfg)
 
 	// sleep for a very long time but timeout after 10ms.
-	passed, output := g.runStep(context.Background(), "slow-step", 10*time.Millisecond, "sleep", "60")
+	passed, output := g.runStep(context.Background(), "slow-step", "", 10*time.Millisecond, "sleep", "60")
 
 	if passed {
 		t.Error("runStep should fail on timeout")
@@ -202,7 +202,7 @@ func TestQualityGate_runStep_Success(t *testing.T) {
 	cfg := DefaultGateConfig()
 	g := NewQualityGate(cfg)
 
-	passed, output := g.runStep(context.Background(), "noop", 5*time.Second, "true")
+	passed, output := g.runStep(context.Background(), "noop", "", 5*time.Second, "true")
 
 	if !passed {
 		t.Errorf("runStep with 'true' should pass, output: %q", output)
@@ -221,7 +221,7 @@ func TestQualityGate_executeStep_SkipsOptionalMissing(t *testing.T) {
 	g := NewQualityGate(cfg)
 
 	step := gateStep{name: "missing-tool", binary: "this-binary-does-not-exist-12345", optional: true}
-	passed, output := g.executeStep(context.Background(), step, 5*time.Second)
+	passed, output := g.executeStep(context.Background(), step, "", 5*time.Second)
 
 	if !passed {
 		t.Error("executeStep with missing optional binary should pass (skip)")
@@ -256,7 +256,7 @@ func TestQualityGate_executeStep_SkipsWhenConfigFileMissing(t *testing.T) {
 			".eslintrc.js", ".eslintrc.json",
 		},
 	}
-	passed, output := g.executeStep(context.Background(), step, 5*time.Second)
+	passed, output := g.executeStep(context.Background(), step, "", 5*time.Second)
 
 	if !passed {
 		t.Error("step with missing config files should skip (pass)")
@@ -288,7 +288,7 @@ func TestQualityGate_executeStep_RunsWhenConfigFileExists(t *testing.T) {
 		optional:    true,
 		configFiles: []string{"eslint.config.js", ".eslintrc.json"},
 	}
-	passed, output := g.executeStep(context.Background(), step, 5*time.Second)
+	passed, output := g.executeStep(context.Background(), step, "", 5*time.Second)
 
 	if !passed {
 		t.Errorf("step should run and pass when config file exists, output: %q", output)
@@ -657,7 +657,7 @@ func TestQualityGate_SkipsDotnetFormatWhenNoCSharpStaged(t *testing.T) {
 	})
 
 	// No .cs detected via stagedFiles → dotnet format skipped
-	passed, out := g.executeStep(context.Background(), step, 5*time.Second)
+	passed, out := g.executeStep(context.Background(), step, "", 5*time.Second)
 
 	if !passed {
 		t.Errorf("dotnet format must be skipped when no C# files are staged (expected passed=true), output: %q", out)
@@ -721,7 +721,7 @@ func TestQualityGate_RunsDotnetFormatWhenCSharpStaged(t *testing.T) {
 	})
 
 	// .cs file is staged → dotnet format must run → fake dotnet exits 0
-	passed, out := g.executeStep(context.Background(), step, 60*time.Second)
+	passed, out := g.executeStep(context.Background(), step, "", 60*time.Second)
 
 	if !passed {
 		t.Errorf("dotnet format must pass when .cs files are staged, output: %q", out)

--- a/internal/hook/quality/gate_timeout_attribution_test.go
+++ b/internal/hook/quality/gate_timeout_attribution_test.go
@@ -51,7 +51,7 @@ func TestRunStep_ParentDeadlineIsNotBlamedOnTheStep(t *testing.T) {
 	defer cancel()
 
 	name, args := sleeperCommand()
-	ok, msg := g.runStep(parent, "go test", 2*time.Minute, name, args...)
+	ok, msg := g.runStep(parent, "go test", "", 2*time.Minute, name, args...)
 	if ok {
 		t.Fatal("a step outliving the parent deadline must fail")
 	}
@@ -72,7 +72,7 @@ func TestRunStep_StepDeadlineStillBlamesTheStep(t *testing.T) {
 	defer cancel()
 
 	name, args := sleeperCommand()
-	ok, msg := g.runStep(parent, "go test", 100*time.Millisecond, name, args...)
+	ok, msg := g.runStep(parent, "go test", "", 100*time.Millisecond, name, args...)
 	if ok {
 		t.Fatal("a step exceeding its own budget must fail")
 	}


### PR DESCRIPTION
# fix(quality): detect toolchain markers below project top and bind module roots into step execution

> **PR draft — NOT SUBMITTED.** Submission is gated on operator approval (구스).
> Branch: `fix/heavy-gate-nested-toolchain` @ `70663c09b` (base `main` @ `48239c7dc`).

**Fixes #1680** · Companion context: #1679 (pre-commit fast-subset — different component, different repair surface; see "Boundary with #1679" below).

## Summary

The heavy gate (`moai gate`, `internal/hook/quality`) tests each language's marker files at exactly one path — the project top. A repository whose Go module (or any of the other 15 toolchains' markers) lives below the top takes the fail-open path: `detectToolchain()` returns `nil`, `Run()` returns `true, gfNotice`, and every commit passes with **zero** toolchain coverage — real defects included. Unlike #1679 (which failed loudly and forced workarounds), this defect passes quietly and skips the inspection the gate exists to perform.

The defect is three-layered, so the repair lands all three layers together:

1. **`detectToolchains()`** — keeps the root-level first match (existing precedence), then runs a bounded `filepath.WalkDir` below the project dir (skips `sourceScanSkipDirs` dependency/build/cache dirs, one entry per language, a matched dir is not descended into) collecting `(toolchain, root)` entries.
2. **`Run()`** — loops over all detected entries: vet/typecheck/lint per toolchain, then the project-level ast-grep step once, then each toolchain's test step.
3. **`executeStep()`/`runStep()`** — take the toolchain's own root as `cmd.Dir` (empty falls back to the project dir, preserving existing behavior for top-level projects); `configFiles` existence and `sourceExts` scans scope to that root too.

Why detection alone would make things *worse*: without (3), the newly-detected nested Go module would run `go vet ./...` from the project top → `cannot find main module` → every commit red. The three layers land together or the failure mode just flips direction from silent-pass to loud-fail.

## Reproduction (see #1680 for the full matrix)

Sandbox mirroring the triggering shape (root `package.json` + nested `apps/id/go.mod`, benign or defective `.go` staged), run with a PATH shim (`go` wrapper logging invocations, then exec'ing the real toolchain — the gate's green-path steps are silent, so absence-of-output alone would be a vacuous signal):

- **Pre-patch (shipped binary, v3.1.3-rc.5):** benign staged `.go` → exit 0, `go` invoked 0×; a real vet defect (`undefined: gateProbeBug`) → exit 0, `go` invoked 0× — the defect passes silently.
- **Level-is the-causal-variable control:** the same binary run from `apps/id/` (where the marker sits at the resolved level) detects Go and runs it green.

## Verification on current `main` (re-measured 2026-08-28, `main` @ `48239c7dc`)

Patches applied to a fresh clone of current `main` (clean apply, 0 conflicts, 6 files, +237/−82). Full A/B re-measurement on this exact tree — same source, only the binary differing:

| Cell | Staging | Binary | Result |
|---|---|---|---|
| T0-M | benign `.go` | unpatched `main` build | exit 0; `go` invoked 0× (shim log absent) ✔ reproduces |
| T1-M | real vet defect | unpatched `main` build | exit 0 — **silent pass reproduced on current main** ✔ |
| T0-P | benign `.go` | patched build | exit 0; shim log: `go vet ./...` + `go test ./...` **actually invoked** ✔ |
| T1-P | real vet defect | patched build | exit 1; verbatim `vet: ./probe.go:5:9: undefined: gateProbeBug` ✔ |

Direct-toolchain controls (proving the staged defects/toolchain are what they claim): positive cell `go vet ./...` + `go test ./...` exit 0; defect cell `go vet ./...` exit 1 with the same verbatim diagnostic.

Regression suite on the patched tree: `go test ./internal/hook/quality/` → `ok 6.662s`; consumers `go test ./internal/cli/` → `ok 241.807s`, `go test ./internal/hook/` → `ok 26.483s`; `go vet ./...` and `go build ./...` green. No dedicated CI guard in this repository touches these files (`manager_lead_depth_test.go` lives in the downstream mo.ai.kr harness, not upstream — checked, 0 hits).

## Boundary with #1679

#1679 owns the **pre-commit fast-subset** (shell template, staged-file reverse traversal). This PR owns the **heavy gate** (`internal/hook/quality`, Go source, project-scoped index-blind walk). Same root theme — "top-level-only placement assumptions" — different component, different repair surface, different verification matrix; hence a separate issue (#1680) and separate PR, cross-referenced both ways.

## Scope notes / known limits (prototype → production)

- One module per language (deepest-unreachable rule: first/shallowest marker wins, matched dirs are not descended into); multiple same-language modules are not enumerated.
- Walk depth is bounded (constant) — repositories with modules deeper than the cap are still invisible (fails open, same as today).
- The walk skips `sourceScanSkipDirs` to keep cost bounded on large trees.
- CI matrix verification (darwin/windows/linux) remains for upstream CI after submission.

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quality checks now detect and evaluate multiple language toolchains within a project, including nested modules.
  * Static analysis and tests run using each module’s own project directory and configuration.
  * Domain-rule scanning runs consistently across multi-toolchain projects.

* **Bug Fixes**
  * Improved quality-check accuracy for nested modules and their staged files.
  * Corrected working-directory handling so checks reference the appropriate source files and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->