### PR TITLE
feat(t629): docs-site ignoreCommand — 문서 입력 경로 변경 시에만 재빌드

### DIFF
--- a/docs-site/vercel.json
+++ b/docs-site/vercel.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "git rev-parse -q --verify \"${VERCEL_GIT_PREVIOUS_SHA}^{commit}\" >/dev/null 2>&1 && git diff --quiet \"$VERCEL_GIT_PREVIOUS_SHA\" HEAD -- ':(top)docs-site' || exit 1",
   "framework": "hugo",
   "buildCommand": "hugo --minify --gc",
   "outputDirectory": "public",


### PR DESCRIPTION
Closes #1688

## 요약
- moai-adk push 전량이 adk.mo.ai.kr 재빌드를 트리거(8/16~9/1 실측: 500건 배포·READY 499·하루 ~31건 — WT-* 레인 등 docs 무관 push 다수)
- docs-site/vercel.json에 ignoreCommand 1행 추가 — mo.ai.kr www·bo와 동일 패턴: ` 존재 검사 + git diff --quiet -- ':(top)docs-site' + || exit 1`
- Hugo mount·module import 부재 실측 — ':(top)docs-site' 단일 pathspec이 문서 입력 전부

## 검증
- 로컬 3케이스: 진행(20행 구간)=exit 1 / 스킵(0행 구간)=exit 0 / SHA 부재=exit 1(첫 배포 안전)
- 검사기 생존 입증(RED 대조): 스킵·진행이 pathspec 구간에 따라 갈림
- 커밋 push 시 dpl_2y9Qd3WnQ2 READY 실측 — 이 배포부터 ignoreCommand 활성

## 근거
- evidence: mo.ai.kr .moai/reports/t629/verdict.md (5절)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment efficiency by skipping documentation-site builds when no relevant changes are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->