### PR TITLE
feat(codex): expand default statusline fields

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,7 @@
+[mcp_servers.moai]
+command = "moai"
+args = ["mcp-server"]
+default_tools_approval_mode = "writes"
+
+[tui]
+status_line = ["model-with-reasoning", "context-remaining", "git-branch", "current-dir", "branch-changes", "five-hour-limit", "weekly-limit", "thread-title"]

--- a/internal/codexwiring/configtoml.go
+++ b/internal/codexwiring/configtoml.go
@@ -40,10 +40,11 @@ var StatusLineAllowlist = []string{
 }
 
 // defaultStatusLine is the fixed default configuration (operator directive
-// 2026-08-24): the 5 canonical tokens, a superset of Codex's own 3-token
-// default plus git-branch and thread-id.
+// 2026-09-10): the 8 canonical tokens covering model, context, repository,
+// rate-limit, and thread-title status.
 var defaultStatusLine = []string{
-	"model-with-reasoning", "context-remaining", "git-branch", "current-dir", "thread-id",
+	"model-with-reasoning", "context-remaining", "git-branch", "current-dir",
+	"branch-changes", "five-hour-limit", "weekly-limit", "thread-title",
 }
 
 // DefaultStatusLine returns a copy of the default status_line configuration.

--- a/internal/codexwiring/statusline_test.go
+++ b/internal/codexwiring/statusline_test.go
@@ -26,10 +26,13 @@ var parseOnlyStatusLineAliases = []string{
 	"context-usage", "session-id",
 }
 
-// TestStatusLineDefaultIsCanonicalFive verifies the default configuration is
-// exactly the 5 canonical tokens the operator directive fixed (AC-CW-013a).
-func TestStatusLineDefaultIsCanonicalFive(t *testing.T) {
-	want := []string{"model-with-reasoning", "context-remaining", "git-branch", "current-dir", "thread-id"}
+// TestStatusLineDefaultIsCanonicalEight verifies the operator-selected
+// 2026-09-10 default is exactly the 8 canonical tokens in the chosen order.
+func TestStatusLineDefaultIsCanonicalEight(t *testing.T) {
+	want := []string{
+		"model-with-reasoning", "context-remaining", "git-branch", "current-dir",
+		"branch-changes", "five-hour-limit", "weekly-limit", "thread-title",
+	}
 	got := DefaultStatusLine()
 	if len(got) != len(want) {
 		t.Fatalf("DefaultStatusLine() = %v (len %d), want %v (len %d)", got, len(got), want, len(want))


### PR DESCRIPTION
Rescue PR: this commit landed directly on local main (diverged ↑1 vs origin/main). Direct push is blocked by branch protection (5 required checks), so the original commit rides this PR unchanged — SHA preserved so local main fast-forwards cleanly after the merge commit.

- Touches: .codex/config.toml, internal/codexwiring/configtoml.go, internal/codexwiring/statusline_test.go (3 files, +18/−7)
- Merge method: **merge commit** (not squash) — ancestry of 93299267a must reach origin/main

🗿 MoAI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a default configuration for the MoAI MCP server with write-operation approval settings.
  - Expanded the status line to show model reasoning, remaining context, Git branch changes, five-hour usage limits, weekly usage limits, current directory, and thread title.
- **Changes**
  - Replaced the thread ID display with a more descriptive thread title.
  - Updated the default status line to include additional repository and usage information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->