### PR TITLE
fix(worktree): make clean --json the report its help promises

### DIFF
--- a/internal/cli/worktree/clean.go
+++ b/internal/cli/worktree/clean.go
@@ -57,17 +57,22 @@ func runClean(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("--stale and --merged-only are mutually exclusive")
 	}
 
+	// REQ-WR-013: the reporting path removes nothing, so --json IS the command
+	// whenever it is given. It used to be read inside the --stale branch
+	// alone: `clean --json` fell through to the default prune and printed a
+	// "Cleaned stale worktree references" banner where an inventory was
+	// promised, and `--merged-only --json` removed merged worktrees while
+	// printing human text (#1704). An inventory that mutates on a flag
+	// combination is not an inventory, so the report also overrides --yes
+	// rather than combining with it.
+	if asJSON, _ := cmd.Flags().GetBool("json"); asJSON {
+		base, _ := cmd.Flags().GetString("base")
+		return reportStaleWorktrees(cmd, base)
+	}
+
 	if stale {
 		base, _ := cmd.Flags().GetString("base")
 		apply, _ := cmd.Flags().GetBool("yes")
-		asJSON, _ := cmd.Flags().GetBool("json")
-		if asJSON {
-			// REQ-WR-013: the reporting path removes nothing. --json is a
-			// report, so it overrides --yes rather than combining with it —
-			// an inventory that could delete on a stray flag is not an
-			// inventory.
-			return reportStaleWorktrees(cmd, base)
-		}
 		return cleanStaleWorktrees(cmd, base, apply)
 	}
 
@@ -367,10 +372,13 @@ func isBaseBranch(branch, base string) bool {
 // removes nothing (REQ-WR-013). It covers EVERY non-protected registered
 // worktree — worktree-ness is a checkout property, not a branch-name one — so
 // the report reaches trees no branch-name glob would find.
+//
+// It does not prune. A prune drops administrative entries rather than
+// checkouts, but it is still a mutation, and this path is the one the help
+// calls inert (#1704). A worktree whose directory is already gone is reported
+// with undetermined state and a keep_reason naming what could not be read,
+// which tells the operator more than removing the entry silently did.
 func reportStaleWorktrees(cmd *cobra.Command, base string) error {
-	if err := WorktreeProvider.Prune(); err != nil {
-		return fmt.Errorf("prune worktrees: %w", err)
-	}
 	worktrees, err := WorktreeProvider.List()
 	if err != nil {
 		return fmt.Errorf("list worktrees: %w", err)

--- a/internal/cli/worktree/clean_json_no_mutation_test.go
+++ b/internal/cli/worktree/clean_json_no_mutation_test.go
@@ -11,6 +11,7 @@ package worktree
 
 import (
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
@@ -44,79 +45,119 @@ func decodeReport(t *testing.T, out string) []staleCandidate {
 	return got
 }
 
-// TestClean_JSONWithoutStaleReportsAndMutatesNothing is the reported case:
-// `moai worktree clean --json`, no other flag.
-func TestClean_JSONWithoutStaleReportsAndMutatesNothing(t *testing.T) {
+// TestClean_JSONModesReportAndMutateNothing walks the three ways --json can
+// be reached. They share one body on purpose: the property under test is the
+// same in all three, and a per-mode copy is how the --stale branch came to be
+// the only one that honoured the flag.
+func TestClean_JSONModesReportAndMutateNothing(t *testing.T) {
+	cases := []struct {
+		name      string
+		flags     map[string]string
+		worktrees []git.Worktree
+		merged    bool
+		wantCount int
+	}{
+		{
+			// The reported case: `moai worktree clean --json`, no other flag.
+			name:  "json alone",
+			flags: map[string]string{"json": "true"},
+			worktrees: []git.Worktree{
+				{Path: "/wt/slug", Branch: "worktree-reaper"},
+				{Path: "/wt/other", Branch: "docs-refresh"},
+			},
+			wantCount: 2,
+		},
+		{
+			// --merged-only removes merged worktrees, and --json was ignored
+			// there too, so the inventory flag used to delete.
+			name:      "json with merged-only",
+			flags:     map[string]string{"json": "true", "merged-only": "true"},
+			worktrees: []git.Worktree{{Path: "/wt/merged", Branch: "WT-merged-card"}},
+			merged:    true,
+			wantCount: 1,
+		},
+		{
+			// The property the --stale branch already had: a report cannot
+			// delete because another flag asked it to.
+			name:      "json overrides yes",
+			flags:     map[string]string{"json": "true", "stale": "true", "yes": "true"},
+			worktrees: []git.Worktree{{Path: "/wt/removable", Branch: "WT-removable-card"}},
+			merged:    true,
+			wantCount: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			removed, pruned := jsonModeEnv(t, tc.worktrees)
+			mockIsBranchMergedFunc = func(string, string) (bool, error) { return tc.merged, nil }
+
+			out, err := runStaleClean(t, tc.flags)
+			if err != nil {
+				t.Fatalf("runClean error: %v", err)
+			}
+
+			if *pruned != 0 {
+				t.Errorf("--json pruned %d time(s); the help calls this path inert", *pruned)
+			}
+			if len(*removed) != 0 {
+				t.Errorf("--json removed %v; it must remove nothing", *removed)
+			}
+			if strings.Contains(out, "Cleaned stale worktree references") {
+				t.Errorf("--json printed the human banner instead of an inventory:\n%s", out)
+			}
+			if got := decodeReport(t, out); len(got) != tc.wantCount {
+				t.Errorf("expected %d object(s) in the inventory, got %d:\n%s", tc.wantCount, len(got), out)
+			}
+		})
+	}
+}
+
+// TestClean_JSONReportsAnUnavailableWorktree is what dropping the prune buys:
+// a worktree whose directory is gone stays IN the inventory, with its state
+// undetermined and a keep_reason naming what could not be read. The prune used
+// to drop that entry before the report was built, so the operator saw nothing
+// where the interesting case was.
+func TestClean_JSONReportsAnUnavailableWorktree(t *testing.T) {
 	removed, pruned := jsonModeEnv(t, []git.Worktree{
-		{Path: "/wt/slug", Branch: "worktree-reaper"},
-		{Path: "/wt/other", Branch: "docs-refresh"},
+		{Path: "/wt/gone", Branch: "WT-vanished-card"},
+		{Path: "/wt/live", Branch: "docs-refresh"},
 	})
+	mockIsBranchMergedFunc = func(string, string) (bool, error) { return true, nil }
+	// The vanished tree's status call fails the way git does when the
+	// directory is no longer there; the live one answers normally.
+	gitWorktreeCmd = func(args ...string) (string, error) {
+		if len(args) >= 2 && args[0] == "-C" && args[1] == "/wt/gone" {
+			return "", errors.New("cannot chdir to '/wt/gone': No such file or directory")
+		}
+		return "", nil
+	}
 
 	out, err := runStaleClean(t, map[string]string{"json": "true"})
 	if err != nil {
 		t.Fatalf("runClean error: %v", err)
 	}
-
-	if *pruned != 0 {
-		t.Errorf("--json pruned %d time(s); the help calls this path inert", *pruned)
-	}
-	if len(*removed) != 0 {
-		t.Errorf("--json removed %v; it must remove nothing", *removed)
-	}
-	if strings.Contains(out, "Cleaned stale worktree references") {
-		t.Errorf("--json printed the human banner instead of an inventory:\n%s", out)
-	}
-	if got := decodeReport(t, out); len(got) != 2 {
-		t.Errorf("expected one object per registered worktree (2), got %d:\n%s", len(got), out)
-	}
-}
-
-// TestClean_JSONWithMergedOnlyReportsAndRemovesNothing covers the other
-// window: --merged-only removes merged worktrees, and --json was ignored there
-// too, so the inventory flag used to delete.
-func TestClean_JSONWithMergedOnlyReportsAndRemovesNothing(t *testing.T) {
-	removed, pruned := jsonModeEnv(t, []git.Worktree{
-		{Path: "/wt/merged", Branch: "WT-merged-card"},
-	})
-	mockIsBranchMergedFunc = func(string, string) (bool, error) { return true, nil }
-
-	out, err := runStaleClean(t, map[string]string{"json": "true", "merged-only": "true"})
-	if err != nil {
-		t.Fatalf("runClean error: %v", err)
+	if *pruned != 0 || len(*removed) != 0 {
+		t.Errorf("the report pruned %d time(s) and removed %v; it must do neither", *pruned, *removed)
 	}
 
-	if len(*removed) != 0 {
-		t.Errorf("--merged-only --json removed %v; --json removes nothing", *removed)
-	}
-	if *pruned != 0 {
-		t.Errorf("--merged-only --json pruned %d time(s)", *pruned)
-	}
-	if got := decodeReport(t, out); len(got) != 1 {
-		t.Errorf("expected the merged tree in the inventory, got %d objects:\n%s", len(got), out)
-	}
-}
-
-// TestClean_JSONOverridesYes keeps the property the --stale branch already
-// had: a report cannot delete because another flag asked it to.
-func TestClean_JSONOverridesYes(t *testing.T) {
-	removed, pruned := jsonModeEnv(t, []git.Worktree{
-		{Path: "/wt/removable", Branch: "WT-removable-card"},
-	})
-	mockIsBranchMergedFunc = func(string, string) (bool, error) { return true, nil }
-
-	out, err := runStaleClean(t, map[string]string{"json": "true", "stale": "true", "yes": "true"})
-	if err != nil {
-		t.Fatalf("runClean error: %v", err)
+	byPath := map[string]staleCandidate{}
+	for _, c := range decodeReport(t, out) {
+		byPath[c.Path] = c
 	}
 
-	if len(*removed) != 0 {
-		t.Errorf("--stale --yes --json removed %v; --json removes nothing", *removed)
+	gone, ok := byPath["/wt/gone"]
+	if !ok {
+		t.Fatalf("the unavailable worktree is missing from the inventory:\n%s", out)
 	}
-	if *pruned != 0 {
-		t.Errorf("--stale --yes --json pruned %d time(s)", *pruned)
+	if gone.Dirty != staleStateUndetermined {
+		t.Errorf("unavailable worktree reported dirty=%q, want %q", gone.Dirty, staleStateUndetermined)
 	}
-	if got := decodeReport(t, out); len(got) != 1 {
-		t.Errorf("expected one object, got %d:\n%s", len(got), out)
+	if gone.KeepReason == "" {
+		t.Error("unavailable worktree reported an empty keep_reason; the report must name what it could not read")
+	}
+	if _, ok := byPath["/wt/live"]; !ok {
+		t.Errorf("the reachable worktree vanished from the inventory:\n%s", out)
 	}
 }
 

--- a/internal/cli/worktree/clean_json_no_mutation_test.go
+++ b/internal/cli/worktree/clean_json_no_mutation_test.go
@@ -1,0 +1,139 @@
+package worktree
+
+// clean_json_no_mutation_test.go — `clean --json` is the whole command (#1704).
+//
+// The flag's help calls it a report that "removes nothing", but --json was read
+// inside the --stale branch alone. `moai worktree clean --json` therefore fell
+// through to the default prune and printed a box banner where an inventory was
+// promised, and `--merged-only --json` removed merged worktrees while printing
+// human text. REQ-WR-013 is the contract these cases pin: in --json mode the
+// command reports and mutates nothing, whatever else is on the command line.
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/modu-ai/moai-adk/internal/core/git"
+)
+
+// jsonModeEnv installs the stale test environment and additionally counts
+// Prune calls, which the default path makes and the report must not.
+func jsonModeEnv(t *testing.T, worktrees []git.Worktree) (removed *[]string, pruned *int) {
+	t.Helper()
+
+	removedPaths := staleTestEnv(t, worktrees, nil, map[string]bool{})
+	pruneCalls := 0
+	provider, ok := WorktreeProvider.(*mockWorktreeManager)
+	if !ok {
+		t.Fatalf("WorktreeProvider is %T, want the mock installed by staleTestEnv", WorktreeProvider)
+	}
+	provider.pruneFunc = func() error {
+		pruneCalls++
+		return nil
+	}
+	return removedPaths, &pruneCalls
+}
+
+func decodeReport(t *testing.T, out string) []staleCandidate {
+	t.Helper()
+	var got []staleCandidate
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("stdout must be a JSON inventory, got %d bytes: %v\n%s", len(out), err, out)
+	}
+	return got
+}
+
+// TestClean_JSONWithoutStaleReportsAndMutatesNothing is the reported case:
+// `moai worktree clean --json`, no other flag.
+func TestClean_JSONWithoutStaleReportsAndMutatesNothing(t *testing.T) {
+	removed, pruned := jsonModeEnv(t, []git.Worktree{
+		{Path: "/wt/slug", Branch: "worktree-reaper"},
+		{Path: "/wt/other", Branch: "docs-refresh"},
+	})
+
+	out, err := runStaleClean(t, map[string]string{"json": "true"})
+	if err != nil {
+		t.Fatalf("runClean error: %v", err)
+	}
+
+	if *pruned != 0 {
+		t.Errorf("--json pruned %d time(s); the help calls this path inert", *pruned)
+	}
+	if len(*removed) != 0 {
+		t.Errorf("--json removed %v; it must remove nothing", *removed)
+	}
+	if strings.Contains(out, "Cleaned stale worktree references") {
+		t.Errorf("--json printed the human banner instead of an inventory:\n%s", out)
+	}
+	if got := decodeReport(t, out); len(got) != 2 {
+		t.Errorf("expected one object per registered worktree (2), got %d:\n%s", len(got), out)
+	}
+}
+
+// TestClean_JSONWithMergedOnlyReportsAndRemovesNothing covers the other
+// window: --merged-only removes merged worktrees, and --json was ignored there
+// too, so the inventory flag used to delete.
+func TestClean_JSONWithMergedOnlyReportsAndRemovesNothing(t *testing.T) {
+	removed, pruned := jsonModeEnv(t, []git.Worktree{
+		{Path: "/wt/merged", Branch: "WT-merged-card"},
+	})
+	mockIsBranchMergedFunc = func(string, string) (bool, error) { return true, nil }
+
+	out, err := runStaleClean(t, map[string]string{"json": "true", "merged-only": "true"})
+	if err != nil {
+		t.Fatalf("runClean error: %v", err)
+	}
+
+	if len(*removed) != 0 {
+		t.Errorf("--merged-only --json removed %v; --json removes nothing", *removed)
+	}
+	if *pruned != 0 {
+		t.Errorf("--merged-only --json pruned %d time(s)", *pruned)
+	}
+	if got := decodeReport(t, out); len(got) != 1 {
+		t.Errorf("expected the merged tree in the inventory, got %d objects:\n%s", len(got), out)
+	}
+}
+
+// TestClean_JSONOverridesYes keeps the property the --stale branch already
+// had: a report cannot delete because another flag asked it to.
+func TestClean_JSONOverridesYes(t *testing.T) {
+	removed, pruned := jsonModeEnv(t, []git.Worktree{
+		{Path: "/wt/removable", Branch: "WT-removable-card"},
+	})
+	mockIsBranchMergedFunc = func(string, string) (bool, error) { return true, nil }
+
+	out, err := runStaleClean(t, map[string]string{"json": "true", "stale": "true", "yes": "true"})
+	if err != nil {
+		t.Fatalf("runClean error: %v", err)
+	}
+
+	if len(*removed) != 0 {
+		t.Errorf("--stale --yes --json removed %v; --json removes nothing", *removed)
+	}
+	if *pruned != 0 {
+		t.Errorf("--stale --yes --json pruned %d time(s)", *pruned)
+	}
+	if got := decodeReport(t, out); len(got) != 1 {
+		t.Errorf("expected one object, got %d:\n%s", len(got), out)
+	}
+}
+
+// TestClean_WithoutJSONStillPrunesAndReportsIt is the negative control: the
+// default path is the one that mutates, and it must keep doing so.
+func TestClean_WithoutJSONStillPrunesAndReportsIt(t *testing.T) {
+	_, pruned := jsonModeEnv(t, nil)
+
+	out, err := runStaleClean(t, map[string]string{})
+	if err != nil {
+		t.Fatalf("runClean error: %v", err)
+	}
+
+	if *pruned != 1 {
+		t.Errorf("the default path pruned %d time(s), want 1", *pruned)
+	}
+	if !strings.Contains(out, "Cleaned stale worktree references") {
+		t.Errorf("the default path must still say what it did:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Description

`moai worktree clean --json` is documented as a read-only reporter and behaved as neither: it printed the `✓ Cleaned stale worktree references` banner, emitted no JSON, and pruned. `--json` was read inside the `--stale` branch alone, so the default path and `--merged-only` ignored it entirely.

Fixes #1704.

## Changes

- `runClean` reads `--json` before the mode branches. In `--json` mode the command reports and does nothing else, whatever else is on the command line. That is REQ-WR-013, and it is the rule the `--stale` path already applied to `--yes`.
  - `clean --json` no longer prunes and no longer prints the banner; it emits the inventory.
  - `clean --merged-only --json` no longer removes merged worktrees; it emits the inventory.
- `reportStaleWorktrees` no longer prunes. A prune drops administrative entries rather than checkouts, but it is still the mutation the help denies. A worktree whose directory is already gone now appears in the report with undetermined state and a `keep_reason` naming what could not be read, which tells the operator more than removing the entry silently did.
- No help text changed: it was already correct, and this PR makes it true. That is option 1 of the two the issue offers.

## Testing

`internal/cli/worktree/clean_json_no_mutation_test.go`, four cases through the real `runClean` with the mock provider counting `Prune` and `Remove`:

| case | asserts |
|---|---|
| `clean --json` | valid JSON inventory with one object per registered worktree, zero prunes, zero removals, no banner |
| `clean --merged-only --json` | inventory, zero removals of a merged tree, zero prunes |
| `clean --stale --yes --json` | inventory, zero removals, zero prunes — the report still overrides `--yes` |
| `clean` | the default path still prunes exactly once and still says so |

The last case is the negative control for the change: the mutating path must keep mutating.

```
go test ./internal/cli/worktree/ -count=1          # ok
go test -race ./internal/cli/worktree/ -count=1    # ok
go test ./internal/cli/... -count=1                # ok
golangci-lint run ./internal/cli/worktree/...      # 0 issues
gofmt -l internal/cli/worktree/                    # clean
go build ./... && go vet ./internal/cli/worktree/  # clean
```

Reverting either half of the fix fails the new tests and nothing else: putting `--json` back inside the `--stale` branch fails three of the four, and restoring the prune inside the report fails the same three.

## Checklist

- [x] All tests pass
- [x] Linting passes
- [x] Code formatted
- [x] Race detection passes
- [ ] Documentation updated — none needed: the flag's help already described this behaviour, and no other doc describes the prune


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed JSON output for worktree cleanup so it consistently returns structured inventory data without human-readable banners.
  - Prevented JSON mode from deleting or pruning worktrees, even when combined with other cleanup options.
  - Worktrees whose directories are unavailable are now reported with an undetermined state and an explanation instead of being omitted.
  - Preserved the default cleanup behavior when JSON output is not requested.
  - Ensured JSON reports include all relevant worktrees, including those that cannot be inspected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->